### PR TITLE
Rename Cascade routed manifest event

### DIFF
--- a/lib/keeper/keeper_agent_error.ml
+++ b/lib/keeper/keeper_agent_error.ml
@@ -364,10 +364,10 @@ let checkpoint_persistence_error ~keeper_name ~detail =
        detail)
 ;;
 
-let cascade_outcome_of_observation
-    : _ -> Keeper_execution_receipt.cascade_outcome = function
-  | Some (obs : Keeper_observation.cascade_observation) when obs.fallback_applied ->
-    Keeper_execution_receipt.Cascade_passed_to_next_model
-  | Some _ -> Keeper_execution_receipt.Cascade_completed
-  | None -> Keeper_execution_receipt.Cascade_not_observed
+let runtime_outcome_of_observation
+    : _ -> Keeper_execution_receipt.runtime_outcome = function
+  | Some (obs : Keeper_observation.runtime_observation) when obs.fallback_applied ->
+    Keeper_execution_receipt.Runtime_passed_to_next_model
+  | Some _ -> Keeper_execution_receipt.Runtime_completed
+  | None -> Keeper_execution_receipt.Runtime_not_observed
 ;;

--- a/lib/keeper/keeper_agent_error.mli
+++ b/lib/keeper/keeper_agent_error.mli
@@ -98,9 +98,9 @@ val checkpoint_persistence_error
   -> detail:string
   -> Agent_sdk.Error.sdk_error
 
-(** Map an optional cascade observation to a typed cascade outcome
-    ([Cascade_passed_to_next_model] / [Cascade_completed] /
-    [Cascade_not_observed]). *)
-val cascade_outcome_of_observation
-  :  Keeper_observation.cascade_observation option
-  -> Keeper_execution_receipt.cascade_outcome
+(** Map an optional runtime observation to a typed runtime outcome
+    ([Runtime_passed_to_next_model] / [Runtime_completed] /
+    [Runtime_not_observed]). *)
+val runtime_outcome_of_observation
+  :  Keeper_observation.runtime_observation option
+  -> Keeper_execution_receipt.runtime_outcome

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -59,9 +59,9 @@ end
     @param max_turns Maximum agent turns (default from keeper runtime config)
     @param guardrails Optional OAS guardrails for tool safety gates
     @param temperature MODEL temperature override; when omitted, resolved
-           from [Cascade_inference] with a 0.3 fallback
+           from [Runtime_inference] with a 0.3 fallback
     @param max_tokens Maximum output tokens override; when omitted, resolved
-           from [Cascade_inference] with a 8192 fallback
+           from [Runtime_inference] with a 8192 fallback
     @param is_retry When [true], replays the current user message into the
            working context without persisting it again, so transient retry
            attempts do not duplicate the user entry in session history *)
@@ -162,7 +162,7 @@ let run_turn
   in
   let max_tokens, pre_dispatch_max_tokens_error =
     match
-      Cascade_inference.validate_max_tokens_within_ceiling
+      Runtime_inference.validate_max_tokens_within_ceiling
         ~cascade_name
         ~provider_ceiling:max_output_ceiling
         ctx.max_tokens

--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -26,7 +26,7 @@ let finalize
     ~checkpoint_persistence_error
     ~post_turn_t0
     ?provider_filter
-    ~cascade_name_string
+    ~runtime_id_string
     ~prompt_metrics
     ~ctx_composition
     ~usage
@@ -124,7 +124,7 @@ let finalize
          Ok (Some patched)
        | Error e ->
          Log.Keeper.error
-           "keeper:%s cascade=%s OAS checkpoint save failed: %s"
+           "keeper:%s runtime=%s OAS checkpoint save failed: %s"
            meta.name
            (Keeper_meta_contract.runtime_id_of_meta meta)
            e;
@@ -138,7 +138,7 @@ let finalize
               ~detail:("OAS checkpoint save failed: " ^ e)))
     | None ->
       Log.Keeper.error
-        "keeper:%s cascade=%s missing OAS checkpoint after run"
+        "keeper:%s runtime=%s missing OAS checkpoint after run"
         meta.name
         (Keeper_meta_contract.runtime_id_of_meta meta);
       Prometheus.inc_counter
@@ -167,7 +167,7 @@ let finalize
       ~state_snapshot
       ~post_turn_t0
       ?provider_filter
-      ~cascade_name:cascade_name_string
+      ~runtime_id:runtime_id_string
       ~inference_telemetry:result.response.telemetry
       ();
     Ok
@@ -175,7 +175,7 @@ let finalize
       ; model_used = model
       ; prompt_metrics
       ; ctx_composition
-      ; cascade_observation = result.cascade_observation
+      ; runtime_observation = result.runtime_observation
       ; turn_count = result.turns
       ; tool_calls_made = List.length actual_keeper_tool_names
       ; usage

--- a/lib/keeper/keeper_agent_run_receipt.ml
+++ b/lib/keeper/keeper_agent_run_receipt.ml
@@ -25,7 +25,7 @@ let degraded_retry_cascade_of_wire ?(log_invalid = true) ~keeper_name raw =
       ; "route." ^ trimmed
       ]
     in
-    (* RFC-0206: a runtime id is a raw string (no cascade-name prefix
+    (* RFC-0206: a runtime id is a raw string (no runtime-name prefix
        validation / re-qualification). Accept the first non-empty candidate. *)
     let rec first_valid = function
       | [] -> None
@@ -38,7 +38,7 @@ let degraded_retry_cascade_of_wire ?(log_invalid = true) ~keeper_name raw =
       if log_invalid then
         Log.Keeper.warn
           "keeper:%s execution_receipt degraded_retry_cascade %S is not a \
-           qualified or re-qualifiable cascade name; dropping receipt field"
+           qualified or re-qualifiable runtime name; dropping receipt field"
           keeper_name
           raw;
       None
@@ -48,7 +48,7 @@ let finalize
     ~meta
     ~generation
     ~manifest_keeper_turn_id
-    ~cascade_name
+    ~runtime_id
     ~keeper_visible_sandbox_root
     ~receipt_started_at
     ~runtime_manifest_context
@@ -62,12 +62,12 @@ let finalize
     ~degraded_retry_applied
     ~degraded_retry_cascade
     ~fallback_reason
-    ~cascade_rotation_attempts
+    ~runtime_rotation_attempts
     ~turn_result
     ~receipt_turn_count_ref
     ~receipt_model_used_ref
     ~receipt_stop_reason_ref
-    ~receipt_cascade_observation_ref
+    ~receipt_runtime_observation_ref
     ~receipt_response_text_present_ref
     ~reported_tool_names_ref
     ~observed_tool_names_ref
@@ -143,8 +143,8 @@ let finalize
       Keeper_agent_error.terminal_reason_code_of_sdk_error_typed err
       |> Keeper_turn_terminal_code.to_wire
   in
-  let cascade_observation : Keeper_observation.cascade_observation option =
-    !receipt_cascade_observation_ref
+  let runtime_observation : Keeper_observation.runtime_observation option =
+    !receipt_runtime_observation_ref
   in
   let ( extra_system_context_digest
       , extra_system_context_computed_size
@@ -199,21 +199,21 @@ let finalize
     ; network_mode = meta.network_mode
     ; approval_profile = acc.tool_surface.approval_mode_effective
     ; approval_profile_derived = acc.tool_surface.approval_mode_derived
-    ; cascade_name
+    ; runtime_id
     ; cascade_selected_model =
-        Option.bind cascade_observation (fun obs -> obs.selected_model)
-    ; cascade_attempt_count =
-        (match cascade_observation with
+        Option.bind runtime_observation (fun obs -> obs.selected_model)
+    ; runtime_attempt_count =
+        (match runtime_observation with
          | Some obs -> List.length obs.attempts
          | None -> 0)
     ; cascade_fallback_applied =
-        (match cascade_observation with
+        (match runtime_observation with
          | Some obs -> obs.fallback_applied
          | None -> false)
-    ; cascade_outcome =
-        Keeper_agent_error.cascade_outcome_of_observation cascade_observation
+    ; runtime_outcome =
+        Keeper_agent_error.runtime_outcome_of_observation runtime_observation
     ; oas_internal_cascade_allowed =
-        (match cascade_observation with
+        (match runtime_observation with
          | Some obs -> obs.oas_internal_cascade_allowed
          | None -> false)
     ; degraded_retry_applied
@@ -221,7 +221,7 @@ let finalize
         Option.bind degraded_retry_cascade
           (degraded_retry_cascade_of_wire ~keeper_name:meta.name)
     ; fallback_reason
-    ; cascade_rotation_attempts
+    ; runtime_rotation_attempts
     ; stop_reason = !receipt_stop_reason_ref
     ; error_kind
     ; error_message
@@ -248,13 +248,13 @@ let finalize
             (Keeper_execution_receipt.outcome_kind_to_string receipt.outcome) );
         ("terminal_reason_code", `String receipt.terminal_reason_code);
         ( "runtime_id",
-          `String (receipt.cascade_name) );
-        ("cascade_attempt_count", `Int receipt.cascade_attempt_count);
+          `String (receipt.runtime_id) );
+        ("runtime_attempt_count", `Int receipt.runtime_attempt_count);
         ("cascade_fallback_applied", `Bool receipt.cascade_fallback_applied);
-        ( "cascade_outcome",
+        ( "runtime_outcome",
           `String
-            (Keeper_execution_receipt.cascade_outcome_to_string
-               receipt.cascade_outcome) );
+            (Keeper_execution_receipt.runtime_outcome_to_string
+               receipt.runtime_outcome) );
         ("requested_tools", Json_util.json_string_list receipt.requested_tools);
         ("reported_tools", Json_util.json_string_list receipt.reported_tools);
         ("observed_tools", Json_util.json_string_list receipt.observed_tools);
@@ -296,7 +296,7 @@ let finalize
       ~trace_id:receipt.trace_id ~generation:receipt.generation
       ~keeper_turn_id:manifest_keeper_turn_id ~event
       ?oas_turn_count
-      ~runtime_id:(receipt.cascade_name)
+      ~runtime_id:(receipt.runtime_id)
       ~status ~decision ~receipt_path ?tool_call_log_path ()
     |> Keeper_runtime_manifest.append_best_effort ~site config
   in

--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -243,7 +243,7 @@ let compact_if_needed_typed
       trigger_human;
     let model_meta =
       let model_labels = Keeper_model_labels.configured_model_labels_of_meta meta in
-      Cascade_runtime_candidate.context_window_hint_of_labels model_labels
+      Runtime_candidate.context_window_hint_of_labels model_labels
     in
     (* record_pre_compact's JSONL append is wrapped by
        append_store_json_fail_open in Dashboard_harness_health, so this call

--- a/lib/keeper/keeper_composite_observer.ml
+++ b/lib/keeper/keeper_composite_observer.ml
@@ -63,11 +63,11 @@ type tla_action =
   | Action_measurement_broadcast
   | Action_decide_guard
   | Action_select_tool_policy
-  | Action_start_cascade_selection
-  | Action_select_cascade
+  | Action_start_runtime_selection
+  | Action_select_runtime
   | Action_gate_rejected
-  | Action_cascade_done
-  | Action_cascade_exhausted
+  | Action_runtime_done
+  | Action_runtime_exhausted
   | Action_finish_turn
   | Action_start_compaction
   | Action_finish_compaction
@@ -79,8 +79,8 @@ type tla_action =
 let all_tla_actions =
   [
     Action_start_turn; Action_measurement_broadcast; Action_decide_guard; Action_select_tool_policy;
-    Action_start_cascade_selection; Action_select_cascade; Action_gate_rejected; Action_cascade_done;
-    Action_cascade_exhausted; Action_finish_turn; Action_start_compaction; Action_finish_compaction;
+    Action_start_runtime_selection; Action_select_runtime; Action_gate_rejected; Action_runtime_done;
+    Action_runtime_exhausted; Action_finish_turn; Action_start_compaction; Action_finish_compaction;
     Action_enter_failing; Action_clear_failing; Action_enter_overflowed; Action_overflowed_auto_compact;
   ]
 
@@ -250,11 +250,11 @@ let tla_action_to_string = function
   | Action_measurement_broadcast -> "MeasurementBroadcast"
   | Action_decide_guard -> "DecideGuard"
   | Action_select_tool_policy -> "SelectToolPolicy"
-  | Action_start_cascade_selection -> "StartCascadeSelection"
-  | Action_select_cascade -> "SelectCascade"
+  | Action_start_runtime_selection -> "StartRuntimeSelection"
+  | Action_select_runtime -> "SelectRuntime"
   | Action_gate_rejected -> "GateRejected"
-  | Action_cascade_done -> "CascadeDone"
-  | Action_cascade_exhausted -> "CascadeExhausted"
+  | Action_runtime_done -> "RuntimeDone"
+  | Action_runtime_exhausted -> "RuntimeExhausted"
   | Action_finish_turn -> "FinishTurn"
   | Action_start_compaction -> "StartCompaction"
   | Action_finish_compaction -> "FinishCompaction"
@@ -268,11 +268,11 @@ let tla_action_of_string = function
   | "MeasurementBroadcast" -> Some Action_measurement_broadcast
   | "DecideGuard" -> Some Action_decide_guard
   | "SelectToolPolicy" -> Some Action_select_tool_policy
-  | "StartCascadeSelection" -> Some Action_start_cascade_selection
-  | "SelectCascade" -> Some Action_select_cascade
+  | "StartRuntimeSelection" -> Some Action_start_runtime_selection
+  | "SelectRuntime" -> Some Action_select_runtime
   | "GateRejected" -> Some Action_gate_rejected
-  | "CascadeDone" -> Some Action_cascade_done
-  | "CascadeExhausted" -> Some Action_cascade_exhausted
+  | "RuntimeDone" -> Some Action_runtime_done
+  | "RuntimeExhausted" -> Some Action_runtime_exhausted
   | "FinishTurn" -> Some Action_finish_turn
   | "StartCompaction" -> Some Action_start_compaction
   | "FinishCompaction" -> Some Action_finish_compaction

--- a/lib/keeper/keeper_composite_observer.ml
+++ b/lib/keeper/keeper_composite_observer.ml
@@ -32,19 +32,19 @@ let all_decision_stages : Keeper_registry.packed_decision_stage list =
   ; Keeper_registry.Packed Decision_tool_policy_selected
   ]
 
-type cascade_state = Keeper_registry.cascade_state =
-  | Cascade_idle
-  | Cascade_selecting
-  | Cascade_trying
-  | Cascade_done
-  | Cascade_exhausted
+type runtime_state = Keeper_registry.runtime_state =
+  | Runtime_idle
+  | Runtime_selecting
+  | Runtime_trying
+  | Runtime_done
+  | Runtime_exhausted
 
-let all_cascade_states : Keeper_registry.packed_cascade_state list =
-  [ Keeper_registry.Packed Cascade_idle
-  ; Keeper_registry.Packed Cascade_selecting
-  ; Keeper_registry.Packed Cascade_trying
-  ; Keeper_registry.Packed Cascade_done
-  ; Keeper_registry.Packed Cascade_exhausted
+let all_runtime_states : Keeper_registry.packed_runtime_state list =
+  [ Keeper_registry.Packed Runtime_idle
+  ; Keeper_registry.Packed Runtime_selecting
+  ; Keeper_registry.Packed Runtime_trying
+  ; Keeper_registry.Packed Runtime_done
+  ; Keeper_registry.Packed Runtime_exhausted
   ]
 
 type compaction_stage = Keeper_registry.compaction_stage =
@@ -86,21 +86,21 @@ let all_tla_actions =
 
 type invariant_key =
   | Invariant_phase_turn_alignment
-  | Invariant_no_cascade_before_measurement
+  | Invariant_no_runtime_before_measurement
   | Invariant_compaction_atomicity
   | Invariant_event_priority_monotone
   | Invariant_phase_derivation_agreement
 
 let all_invariant_keys =
   [
-    Invariant_phase_turn_alignment; Invariant_no_cascade_before_measurement;
+    Invariant_phase_turn_alignment; Invariant_no_runtime_before_measurement;
     Invariant_compaction_atomicity; Invariant_event_priority_monotone;
     Invariant_phase_derivation_agreement;
   ]
 
 type invariants_check = {
   phase_turn_alignment : bool;
-  no_cascade_before_measurement : bool;
+  no_runtime_before_measurement : bool;
   compaction_atomicity : bool;
   event_priority_monotone : bool;
   phase_derivation_agreement : bool;
@@ -110,7 +110,7 @@ type last_outcome = {
   turn_id : int;
   ended_at : float;
   decision_stage : Keeper_registry.packed_decision_stage;
-  cascade_state : Keeper_registry.packed_cascade_state;
+  runtime_state : Keeper_registry.packed_runtime_state;
   selected_model : string option;
 }
 
@@ -135,7 +135,7 @@ type snapshot = {
   phase : Keeper_state_machine.phase;
   ktc_turn_phase : Keeper_registry.packed_turn_phase;
   kdp_decision : Keeper_registry.packed_decision_stage;
-  kcl_cascade_state : Keeper_registry.packed_cascade_state;
+  kcl_runtime_state : Keeper_registry.packed_runtime_state;
   kmc_compaction : Keeper_registry.packed_compaction_stage;
   kcb_state : Keeper_failure_circuit_breaker.display_state;
   shared_measurement : Keeper_state_machine.auto_rule_summary option;
@@ -217,20 +217,20 @@ let decision_stage_of_string = function
   | "tool_policy_selected" -> Some Decision_tool_policy_selected
   | _ -> None
 
-let cascade_state_to_string (s : Keeper_registry.packed_cascade_state) =
+let runtime_state_to_string (s : Keeper_registry.packed_runtime_state) =
   match s with
-  | Keeper_registry.Packed Cascade_idle -> "idle"
-  | Keeper_registry.Packed Cascade_selecting -> "selecting"
-  | Keeper_registry.Packed Cascade_trying -> "trying"
-  | Keeper_registry.Packed Cascade_done -> "done"
-  | Keeper_registry.Packed Cascade_exhausted -> "exhausted"
+  | Keeper_registry.Packed Runtime_idle -> "idle"
+  | Keeper_registry.Packed Runtime_selecting -> "selecting"
+  | Keeper_registry.Packed Runtime_trying -> "trying"
+  | Keeper_registry.Packed Runtime_done -> "done"
+  | Keeper_registry.Packed Runtime_exhausted -> "exhausted"
 
-let cascade_state_of_string = function
-  | "idle" -> Some Cascade_idle
-  | "selecting" -> Some Cascade_selecting
-  | "trying" -> Some Cascade_trying
-  | "done" -> Some Cascade_done
-  | "exhausted" -> Some Cascade_exhausted
+let runtime_state_of_string = function
+  | "idle" -> Some Runtime_idle
+  | "selecting" -> Some Runtime_selecting
+  | "trying" -> Some Runtime_trying
+  | "done" -> Some Runtime_done
+  | "exhausted" -> Some Runtime_exhausted
   | _ -> None
 
 let compaction_stage_to_string (s : Keeper_registry.packed_compaction_stage) =
@@ -284,14 +284,14 @@ let tla_action_of_string = function
 
 let invariant_key_to_string = function
   | Invariant_phase_turn_alignment -> "PhaseTurnAlignment"
-  | Invariant_no_cascade_before_measurement -> "NoCascadeBeforeMeasurement"
+  | Invariant_no_runtime_before_measurement -> "NoRuntimeBeforeMeasurement"
   | Invariant_compaction_atomicity -> "CompactionAtomicity"
   | Invariant_event_priority_monotone -> "EventPriorityMonotone"
   | Invariant_phase_derivation_agreement -> "PhaseDerivationAgreement"
 
 let invariant_key_of_string = function
   | "PhaseTurnAlignment" -> Some Invariant_phase_turn_alignment
-  | "NoCascadeBeforeMeasurement" -> Some Invariant_no_cascade_before_measurement
+  | "NoRuntimeBeforeMeasurement" -> Some Invariant_no_runtime_before_measurement
   | "CompactionAtomicity" -> Some Invariant_compaction_atomicity
   | "EventPriorityMonotone" -> Some Invariant_event_priority_monotone
   | "PhaseDerivationAgreement" -> Some Invariant_phase_derivation_agreement
@@ -331,10 +331,10 @@ let live_decision_stage (entry : Keeper_registry.registry_entry) =
   | Some obs -> obs.decision_stage
   | None -> Keeper_registry.Packed Decision_undecided
 
-let live_cascade_state (entry : Keeper_registry.registry_entry) =
+let live_runtime_state (entry : Keeper_registry.registry_entry) =
   match entry.current_turn_observation with
-  | Some obs -> obs.cascade_state
-  | None -> Keeper_registry.Packed Cascade_idle
+  | Some obs -> obs.runtime_state
+  | None -> Keeper_registry.Packed Runtime_idle
 
 let live_measurement (entry : Keeper_registry.registry_entry) =
   match entry.current_turn_observation with
@@ -369,13 +369,13 @@ let check_compaction_atomicity
   | Keeper_registry.Packed Compaction_done ->
       not (phase = Keeper_state_machine.Compacting)
 
-let check_no_cascade_before_measurement
-    ~(cascade_state : Keeper_registry.packed_cascade_state)
+let check_no_runtime_before_measurement
+    ~(runtime_state : Keeper_registry.packed_runtime_state)
     ~(measurement_captured : bool)
     : bool =
-  match cascade_state with
-  | Packed Cascade_idle -> true
-  | Packed (Cascade_selecting | Cascade_trying | Cascade_done | Cascade_exhausted) ->
+  match runtime_state with
+  | Packed Runtime_idle -> true
+  | Packed (Runtime_selecting | Runtime_trying | Runtime_done | Runtime_exhausted) ->
       measurement_captured
 
 type event_priority_state = {
@@ -411,15 +411,15 @@ let compute_invariants
     (entry : Keeper_registry.registry_entry)
     ~(phase : Keeper_state_machine.phase)
     ~(turn_phase : Keeper_registry.packed_turn_phase)
-    ~(cascade_state : Keeper_registry.packed_cascade_state)
+    ~(runtime_state : Keeper_registry.packed_runtime_state)
     ~(compaction_stage : Keeper_registry.packed_compaction_stage)
     ~(measurement_captured : bool)
     : invariants_check =
   {
     phase_turn_alignment = check_phase_turn_alignment phase turn_phase;
-    no_cascade_before_measurement =
-      check_no_cascade_before_measurement
-        ~cascade_state
+    no_runtime_before_measurement =
+      check_no_runtime_before_measurement
+        ~runtime_state
         ~measurement_captured;
     compaction_atomicity = check_compaction_atomicity phase compaction_stage;
     event_priority_monotone = check_event_priority_monotone entry;
@@ -442,7 +442,7 @@ let bump_invariant_violations ~(keeper_name : string) (inv : invariants_check) =
         ()
   in
   bump Invariant_phase_turn_alignment inv.phase_turn_alignment;
-  bump Invariant_no_cascade_before_measurement inv.no_cascade_before_measurement;
+  bump Invariant_no_runtime_before_measurement inv.no_runtime_before_measurement;
   bump Invariant_compaction_atomicity inv.compaction_atomicity;
   bump Invariant_event_priority_monotone inv.event_priority_monotone;
   bump Invariant_phase_derivation_agreement inv.phase_derivation_agreement
@@ -479,7 +479,7 @@ let observe
   let turn_phase = live_turn_phase entry in
   let compaction_stage = entry.compaction_stage in
   let decision_stage = live_decision_stage entry in
-  let cascade_state = live_cascade_state entry in
+  let runtime_state = live_runtime_state entry in
   let measurement = live_measurement entry in
   let measurement_captured = Option.is_some measurement in
   let invariants =
@@ -487,7 +487,7 @@ let observe
       entry
       ~phase:entry.phase
       ~turn_phase
-      ~cascade_state
+      ~runtime_state
       ~compaction_stage
       ~measurement_captured
   in
@@ -504,7 +504,7 @@ let observe
     phase = entry.phase;
     ktc_turn_phase = turn_phase;
     kdp_decision = decision_stage;
-    kcl_cascade_state = cascade_state;
+    kcl_runtime_state = runtime_state;
     kmc_compaction = compaction_stage;
     kcb_state;
     shared_measurement = measurement;
@@ -529,7 +529,7 @@ let observe
            turn_id = lc.ct_turn_id;
            ended_at = lc.ct_ended_at;
            decision_stage = lc.ct_decision_stage;
-           cascade_state = lc.ct_cascade_state;
+           runtime_state = lc.ct_runtime_state;
            selected_model = lc.ct_selected_model;
          }
        | None -> None);
@@ -562,7 +562,7 @@ let all_snapshots ~(base_path : string) () : snapshot list =
 let invariants_to_json (inv : invariants_check) : Yojson.Safe.t =
   `Assoc [
     "phase_turn_alignment", `Bool inv.phase_turn_alignment;
-    "no_cascade_before_measurement", `Bool inv.no_cascade_before_measurement;
+    "no_runtime_before_measurement", `Bool inv.no_runtime_before_measurement;
     "compaction_atomicity", `Bool inv.compaction_atomicity;
     "event_priority_monotone", `Bool inv.event_priority_monotone;
     "phase_derivation_agreement", `Bool inv.phase_derivation_agreement;
@@ -686,7 +686,7 @@ let snapshot_to_json (s : snapshot) : Yojson.Safe.t =
       "stage", `String (decision_stage_to_string s.kdp_decision);
     ];
     "cascade", `Assoc [
-      "state", `String (cascade_state_to_string s.kcl_cascade_state);
+      "state", `String (runtime_state_to_string s.kcl_runtime_state);
     ];
     "compaction", `Assoc [
       "stage", `String (compaction_stage_to_string s.kmc_compaction);
@@ -725,8 +725,8 @@ let snapshot_to_json (s : snapshot) : Yojson.Safe.t =
           "ended_at", `Float lo.ended_at;
           "decision_stage",
             `String (decision_stage_to_string lo.decision_stage);
-          "cascade_state",
-            `String (cascade_state_to_string lo.cascade_state);
+          "runtime_state",
+            `String (runtime_state_to_string lo.runtime_state);
           "selected_model",
             Json_util.string_opt_to_json lo.selected_model;
         ]

--- a/lib/keeper/keeper_composite_observer.mli
+++ b/lib/keeper/keeper_composite_observer.mli
@@ -8,7 +8,7 @@
     Contract:
     - Pure read. No mutation, no I/O, no event emission.
     - Never calls [Keeper_state_machine.apply_event],
-      [Keeper_cascade_routing.select_cascade], or any routine that would
+      runtime selection, or any routine that would
       shift keeper lifecycle state.
     - Does not read provider names, token counts, or context bytes —
       those belong to OAS (see [feedback_masc-oas-layer-boundary]).
@@ -61,11 +61,11 @@ type tla_action =
   | Action_measurement_broadcast
   | Action_decide_guard
   | Action_select_tool_policy
-  | Action_start_cascade_selection
-  | Action_select_cascade
+  | Action_start_runtime_selection
+  | Action_select_runtime
   | Action_gate_rejected
-  | Action_cascade_done
-  | Action_cascade_exhausted
+  | Action_runtime_done
+  | Action_runtime_exhausted
   | Action_finish_turn
   | Action_start_compaction
   | Action_finish_compaction

--- a/lib/keeper/keeper_composite_observer.mli
+++ b/lib/keeper/keeper_composite_observer.mli
@@ -38,14 +38,14 @@ type decision_stage = Keeper_registry.decision_stage =
 
 val all_decision_stages : Keeper_registry.packed_decision_stage list
 
-type cascade_state = Keeper_registry.cascade_state =
-  | Cascade_idle
-  | Cascade_selecting
-  | Cascade_trying
-  | Cascade_done
-  | Cascade_exhausted
+type runtime_state = Keeper_registry.runtime_state =
+  | Runtime_idle
+  | Runtime_selecting
+  | Runtime_trying
+  | Runtime_done
+  | Runtime_exhausted
 
-val all_cascade_states : Keeper_registry.packed_cascade_state list
+val all_runtime_states : Keeper_registry.packed_runtime_state list
 
 type compaction_stage = Keeper_registry.compaction_stage =
   | Compaction_accumulating
@@ -79,7 +79,7 @@ val all_tla_actions : tla_action list
 (** Named TLA invariants mirrored as OCaml variants. *)
 type invariant_key =
   | Invariant_phase_turn_alignment
-  | Invariant_no_cascade_before_measurement
+  | Invariant_no_runtime_before_measurement
   | Invariant_compaction_atomicity
   | Invariant_event_priority_monotone
   | Invariant_phase_derivation_agreement
@@ -92,7 +92,7 @@ val all_invariant_keys : invariant_key list
     that the dashboard should surface to the operator. *)
 type invariants_check = {
   phase_turn_alignment : bool;
-  no_cascade_before_measurement : bool;
+  no_runtime_before_measurement : bool;
   compaction_atomicity : bool;
   event_priority_monotone : bool;
   phase_derivation_agreement : bool;
@@ -126,11 +126,11 @@ val check_phase_turn_alignment : Keeper_state_machine.phase -> Keeper_registry.p
     [(kmc_compaction = compacting) <=> (phase = Compacting)]. *)
 val check_compaction_atomicity : Keeper_state_machine.phase -> Keeper_registry.packed_compaction_stage -> bool
 
-(** Mirror of TLA+ I2 [NoCascadeBeforeMeasurement]
-    (KeeperCompositeLifecycle.tla:361): cascade selection past [idle]
+(** Mirror of TLA+ I2 [NoRuntimeBeforeMeasurement]
+    (KeeperCompositeLifecycle.tla:361): runtime selection past [idle]
     requires a captured measurement. *)
-val check_no_cascade_before_measurement :
-  cascade_state:Keeper_registry.packed_cascade_state -> measurement_captured:bool -> bool
+val check_no_runtime_before_measurement :
+  runtime_state:Keeper_registry.packed_runtime_state -> measurement_captured:bool -> bool
 
 val check_phase_derivation_agreement :
   Keeper_registry.registry_entry -> bool
@@ -161,7 +161,7 @@ type last_outcome = {
   turn_id : int;
   ended_at : float;
   decision_stage : Keeper_registry.packed_decision_stage;
-  cascade_state : Keeper_registry.packed_cascade_state;
+  runtime_state : Keeper_registry.packed_runtime_state;
   selected_model : string option;
 }
 
@@ -206,7 +206,7 @@ type snapshot = {
           [specs/keeper-state-machine/KeeperStateMachine.tla] exactly. *)
   ktc_turn_phase : Keeper_registry.packed_turn_phase;
   kdp_decision : Keeper_registry.packed_decision_stage;
-  kcl_cascade_state : Keeper_registry.packed_cascade_state;
+  kcl_runtime_state : Keeper_registry.packed_runtime_state;
   kmc_compaction : Keeper_registry.packed_compaction_stage;
   kcb_state : Keeper_failure_circuit_breaker.display_state;
       (** 6th axis (LT-16-KCB). Observable circuit-breaker state —
@@ -298,9 +298,9 @@ val turn_phase_of_string : string -> turn_phase option
 val decision_stage_to_string : Keeper_registry.packed_decision_stage -> string
 val decision_stage_of_string : string -> decision_stage option
 
-(** Stringify [cascade_state]. Mirrors KeeperCascadeLifecycle.tla. *)
-val cascade_state_to_string : Keeper_registry.packed_cascade_state -> string
-val cascade_state_of_string : string -> cascade_state option
+(** Stringify [runtime_state]. Mirrors KeeperCascadeLifecycle.tla. *)
+val runtime_state_to_string : Keeper_registry.packed_runtime_state -> string
+val runtime_state_of_string : string -> runtime_state option
 
 (** Stringify [compaction_stage]. Mirrors KeeperCompactionLifecycle.tla. *)
 val compaction_stage_to_string : Keeper_registry.packed_compaction_stage -> string

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -543,7 +543,7 @@ let checkpoint_model_of_meta (meta : keeper_meta) =
   in
   match List.find_opt (fun value -> String.trim value <> "") candidates with
   | Some value -> value
-  | None -> Cascade_runtime_candidate.default_local_runtime_label ()
+  | None -> Runtime_candidate.default_local_runtime_label ()
 
 let save_oas_checkpoint
     ~(max_checkpoint_messages : int)

--- a/lib/keeper/keeper_context_runtime.ml
+++ b/lib/keeper/keeper_context_runtime.ml
@@ -324,7 +324,7 @@ let effective_model_labels_for_turn (m : keeper_meta) : string list =
         List.mem model configured
         || List.exists
              (fun label ->
-               Cascade_runtime_candidate.label_matches_runtime_id
+               Runtime_candidate.label_matches_runtime_id
                  ~label
                  ~runtime_id:model)
              configured

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -532,7 +532,7 @@ let required_tool_rotation_candidate
   && (allow_phase_recovery
       || not
            (String.equal normalized (Keeper_config.default_cascade_name ())))
-  && not (Cascade_capability_profile.is_system_cascade_name normalized)
+  && not (Runtime_capability_profile.is_system_cascade_name normalized)
 
 let tool_required_rotation_cascade_name () =
   try

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -173,23 +173,23 @@ let is_provider_timeout_error (err : Agent_sdk.Error.sdk_error) : bool =
    than lumping it into a generic server_error bucket. *)
 let is_gateway_backpressure_status status = status = 524
 
-let is_auto_recoverable_cascade_exhausted_error (err : Agent_sdk.Error.sdk_error) : bool =
+let is_auto_recoverable_runtime_exhausted_error (err : Agent_sdk.Error.sdk_error) : bool =
   match Keeper_turn_driver.classify_masc_internal_error err with
   | Some
-      (Keeper_turn_driver.Cascade_exhausted
+      (Keeper_turn_driver.Runtime_exhausted
          { reason = Keeper_meta_contract.Candidates_filtered_after_cycles; _ }) ->
       true
   | Some
-      (Keeper_turn_driver.Cascade_exhausted
+      (Keeper_turn_driver.Runtime_exhausted
          { reason = Keeper_meta_contract.Max_turns_exceeded; _ }) ->
       true
   | Some
-      (Keeper_turn_driver.Cascade_exhausted
+      (Keeper_turn_driver.Runtime_exhausted
          { reason = Keeper_meta_contract.Capacity_exhausted; _ }) ->
       true
   | Some (Keeper_turn_driver.Capacity_backpressure _) ->
       true
-  | Some (Keeper_turn_driver.Cascade_exhausted _) ->
+  | Some (Keeper_turn_driver.Runtime_exhausted _) ->
       false
   | Some (Keeper_turn_driver.Accept_rejected _)
   | Some (Keeper_turn_driver.Resumable_cli_session _)
@@ -212,7 +212,7 @@ let is_auto_recoverable_cascade_exhausted_error (err : Agent_sdk.Error.sdk_error
 let is_resumable_cli_session_error (err : Agent_sdk.Error.sdk_error) : bool =
   match Keeper_turn_driver.classify_masc_internal_error err with
   | Some (Keeper_turn_driver.Resumable_cli_session _) -> true
-  | Some (Keeper_turn_driver.Cascade_exhausted _)
+  | Some (Keeper_turn_driver.Runtime_exhausted _)
   | Some (Keeper_turn_driver.Capacity_backpressure _)
   | Some (Keeper_turn_driver.Accept_rejected _)
   | Some (Keeper_turn_driver.Admission_queue_timeout _)
@@ -235,7 +235,7 @@ let is_auto_recoverable_cascade_fail_open_error
   Keeper_turn_driver.sdk_error_is_hard_quota err
   || Keeper_turn_driver.sdk_error_is_max_turns_exceeded err
   || is_resumable_cli_session_error err
-  || is_auto_recoverable_cascade_exhausted_error err
+  || is_auto_recoverable_runtime_exhausted_error err
 
 (* Classification of why a degraded retry is being attempted.  Closed set
    covering both producer paths: [phase_recovery_retry] (7 narrow reasons)
@@ -251,7 +251,7 @@ type degraded_retry_reason =
   | Turn_timeout
   | Cascade_candidates_filtered
   | Required_tool_contract_violation
-  | Cascade_exhausted
+  | Runtime_exhausted
   | Capacity_backpressure
   | Rate_limit
   | Server_error
@@ -266,7 +266,7 @@ let degraded_retry_reason_to_string = function
   | Turn_timeout -> "turn_timeout"
   | Cascade_candidates_filtered -> "cascade_candidates_filtered"
   | Required_tool_contract_violation -> "required_tool_contract_violation"
-  | Cascade_exhausted -> "cascade_exhausted"
+  | Runtime_exhausted -> "runtime_exhausted"
   | Capacity_backpressure -> "capacity_backpressure"
   | Rate_limit -> "rate_limit"
   | Server_error -> "server_error"
@@ -342,18 +342,18 @@ let degraded_retry_after_recoverable_error
     | Some (Keeper_turn_driver.Capacity_backpressure _) ->
         phase_recovery_retry Capacity_backpressure
     | Some
-        (Keeper_turn_driver.Cascade_exhausted
+        (Keeper_turn_driver.Runtime_exhausted
            { reason = Keeper_meta_contract.Capacity_exhausted; _ }) ->
         phase_recovery_retry Capacity_backpressure
     | Some
-        (Keeper_turn_driver.Cascade_exhausted
+        (Keeper_turn_driver.Runtime_exhausted
            { reason = Keeper_meta_contract.Candidates_filtered_after_cycles; _ }) ->
         phase_recovery_retry Cascade_candidates_filtered
     | Some
-        (Keeper_turn_driver.Cascade_exhausted
+        (Keeper_turn_driver.Runtime_exhausted
            { reason = Keeper_meta_contract.Max_turns_exceeded; _ }) ->
         phase_recovery_retry Max_turns
-    | Some (Keeper_turn_driver.Cascade_exhausted _)
+    | Some (Keeper_turn_driver.Runtime_exhausted _)
     | Some (Keeper_turn_driver.Accept_rejected _)
     | Some (Keeper_turn_driver.Admission_queue_rejected _)
     | Some (Keeper_turn_driver.Max_tokens_ceiling_violation _)
@@ -389,26 +389,26 @@ let recoverable_cascade_failure_reason (err : Agent_sdk.Error.sdk_error) =
     | Some (Keeper_turn_driver.Capacity_backpressure _) ->
         Some Capacity_backpressure
     | Some
-        (Keeper_turn_driver.Cascade_exhausted
+        (Keeper_turn_driver.Runtime_exhausted
            { reason = Keeper_meta_contract.Capacity_exhausted; _ }) ->
         Some Capacity_backpressure
     | Some
-        (Keeper_turn_driver.Cascade_exhausted
+        (Keeper_turn_driver.Runtime_exhausted
            { reason = Keeper_meta_contract.Candidates_filtered_after_cycles; _ }) ->
         Some Cascade_candidates_filtered
     | Some
-        (Keeper_turn_driver.Cascade_exhausted
+        (Keeper_turn_driver.Runtime_exhausted
            { reason = Keeper_meta_contract.Max_turns_exceeded; _ }) ->
         Some Max_turns
-    | Some (Keeper_turn_driver.Cascade_exhausted _) ->
-        (* Generic cascade exhaustion: all candidates failed without a more
+    | Some (Keeper_turn_driver.Runtime_exhausted _) ->
+        (* Generic runtime exhaustion: all candidates failed without a more
            specific reason. Treat as recoverable so declarative
            [fallback_cascade] hints declared in cascade.toml actually
            escalate. Receipt-derived data on 2026-04-25 showed 31/39
            silent turns ended with [(null)] fallback_reason because this
            arm previously returned [None]. Other arms below remain
            non-recoverable to keep the surface conservative. *)
-        Some Cascade_exhausted
+        Some Runtime_exhausted
     | Some (Keeper_turn_driver.Accept_rejected _)
     | Some (Keeper_turn_driver.Admission_queue_rejected _)
     | Some (Keeper_turn_driver.Max_tokens_ceiling_violation _)
@@ -642,13 +642,13 @@ let is_auto_recoverable_turn_error (err : Agent_sdk.Error.sdk_error) : bool =
   || is_server_rejected_parse_error err
   || Keeper_turn_driver.sdk_error_is_max_turns_exceeded err
   || is_resumable_cli_session_error err
-  || is_auto_recoverable_cascade_exhausted_error err
+  || is_auto_recoverable_runtime_exhausted_error err
 
 let should_warn_keeper_cycle_failed (err : Agent_sdk.Error.sdk_error) : bool =
   match Keeper_turn_driver.classify_masc_internal_error err with
   | Some (Keeper_turn_driver.Provider_timeout _) -> true
   | Some (Keeper_turn_driver.Capacity_backpressure _) -> true
-  | Some (Keeper_turn_driver.Cascade_exhausted _)
+  | Some (Keeper_turn_driver.Runtime_exhausted _)
   | Some (Keeper_turn_driver.Resumable_cli_session _)
   | Some (Keeper_turn_driver.Accept_rejected _)
   | Some (Keeper_turn_driver.Admission_queue_timeout _)
@@ -763,11 +763,11 @@ let is_input_required_error (err : Agent_sdk.Error.sdk_error) : bool =
   | Agent_sdk.Error.A2a _
   | Agent_sdk.Error.Internal _ -> false
 
-(** [true] when an error represents terminal cascade exhaustion or a
+(** [true] when an error represents terminal runtime exhaustion or a
     final accept-rejected result from the MASC OAS boundary. *)
-let is_cascade_exhausted_error (err : Agent_sdk.Error.sdk_error) : bool =
+let is_runtime_exhausted_error (err : Agent_sdk.Error.sdk_error) : bool =
   match Keeper_turn_driver.classify_masc_internal_error err with
-  | Some (Keeper_turn_driver.Cascade_exhausted _)
+  | Some (Keeper_turn_driver.Runtime_exhausted _)
   | Some (Keeper_turn_driver.Resumable_cli_session _)
   | Some (Keeper_turn_driver.Accept_rejected _) -> true
   | Some (Keeper_turn_driver.Capacity_backpressure _)
@@ -777,9 +777,9 @@ let is_cascade_exhausted_error (err : Agent_sdk.Error.sdk_error) : bool =
   | Some (Keeper_turn_driver.Turn_timeout _)
   | Some (Keeper_turn_driver.Max_tokens_ceiling_violation _)
   | Some (Keeper_turn_driver.Ambiguous_post_commit _)
-  (* RFC-0158: admission denial is not cascade exhaustion. *)
+  (* RFC-0158: admission denial is not runtime exhaustion. *)
   | Some (Keeper_turn_driver.Retry_admission_denied _)
-  (* RFC-0159 Phase A: opaque internal failures are not cascade exhaustion. *)
+  (* RFC-0159 Phase A: opaque internal failures are not runtime exhaustion. *)
   | Some (Keeper_turn_driver.Internal_unhandled_exception _)
   | Some (Keeper_turn_driver.Internal_bridge_exception _)
   | Some (Keeper_turn_driver.Internal_contract_rejected _) -> false

--- a/lib/keeper/keeper_error_classify.mli
+++ b/lib/keeper/keeper_error_classify.mli
@@ -64,9 +64,9 @@ val extract_input_required
   :  Agent_sdk.Error.sdk_error
   -> Agent_sdk.Error.input_required option
 
-(** [true] when an error represents terminal cascade exhaustion or a
+(** [true] when an error represents terminal runtime exhaustion or a
     final accept-rejected result from the MASC OAS boundary. *)
-val is_cascade_exhausted_error : Agent_sdk.Error.sdk_error -> bool
+val is_runtime_exhausted_error : Agent_sdk.Error.sdk_error -> bool
 
 (** [true] when the rotation-cap fast-fail should fire: the error is a
     [required_tool_contract_violation], at least one cascade rotation has
@@ -91,7 +91,7 @@ type degraded_retry_reason =
   | Turn_timeout
   | Cascade_candidates_filtered
   | Required_tool_contract_violation
-  | Cascade_exhausted
+  | Runtime_exhausted
   | Capacity_backpressure
   | Rate_limit
   | Server_error

--- a/lib/keeper/keeper_error_classify_post_commit.ml
+++ b/lib/keeper/keeper_error_classify_post_commit.ml
@@ -39,7 +39,7 @@ let is_ambiguous_side_effect_error (err : Agent_sdk.Error.sdk_error) : bool =
       | Agent_sdk.Error.Orchestration _
       | Agent_sdk.Error.A2a _ -> false)
   (* All other MASC-internal classifications are unambiguous failures. *)
-  | Some (Keeper_turn_driver.Cascade_exhausted _)
+  | Some (Keeper_turn_driver.Runtime_exhausted _)
   | Some (Keeper_turn_driver.Capacity_backpressure _)
 
   | Some (Keeper_turn_driver.Accept_rejected _)

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -27,13 +27,13 @@ let last_tool_name receipt =
     ]
 ;;
 
-let cascade_rotation_attempt_to_json attempt =
+let runtime_rotation_attempt_to_json attempt =
   `Assoc
     [ "from_cascade", `String (attempt.from_cascade)
     ; "to_cascade", `String (attempt.to_cascade)
     ; ( "reason"
       , `String (Keeper_error_classify.degraded_retry_reason_to_string attempt.reason) )
-    ; "outcome", `String (cascade_rotation_outcome_to_string attempt.outcome)
+    ; "outcome", `String (runtime_rotation_outcome_to_string attempt.outcome)
     ; ( "slot_release_at_phase"
       , string_opt_json
           (Option.map slot_release_phase_to_string attempt.slot_release_at_phase) )
@@ -164,12 +164,12 @@ let () =
   Prometheus.register_counter
     ~name:Keeper_metrics.(to_string ReceiptUnmappedDisposition)
     ~help:
-      "Total receipts whose (outcome, cascade_outcome) tuple did not match any branch of \
+      "Total receipts whose (outcome, runtime_outcome) tuple did not match any branch of \
        operator_disposition and fell through to the typed catch-all \
        (Disp_unknown, Reason_unmapped_cascade_state).  PR #11651 fixed the historical \
        'blocked' -> 'unknown' silent path; this counter alerts operators if a future \
        refactor reintroduces such a path. A non-zero rate is a regression signal — \
-       investigate which receipt.outcome / cascade_outcome / terminal_reason_code \
+       investigate which receipt.outcome / runtime_outcome / terminal_reason_code \
        combination is unclassified.  Labels are intentionally omitted: receipt fields \
        are high-cardinality free-form strings; structured detail goes to the WARN log \
        line at the firing site."
@@ -256,11 +256,11 @@ let operator_disposition (receipt : t)
       string_contains_ci terminal_reason "config"
       || string_contains_ci terminal_reason "auth"
   in
-  (* Pre-typing, this branch also matched cascade_outcome="runtime_exhausted"
-     and "exhausted" — neither is in the producer's closed [cascade_outcome]
-     set ([Cascade_passed_to_next_model] / [_completed] / [_not_observed] /
+  (* Pre-typing, this branch also matched runtime_outcome="runtime_exhausted"
+     and "exhausted" — neither is in the producer's closed [runtime_outcome]
+     set ([Runtime_passed_to_next_model] / [_completed] / [_not_observed] /
      [_not_dispatched]).  Those branches were unreachable workarounds; the
-     typed migration drops them.  Cascade exhaustion still reaches this
+     typed migration drops them.  Runtime exhaustion still reaches this
      branch via [terminal_reason="runtime_exhausted"]. *)
   if String.equal terminal_reason "runtime_exhausted"
   then Disp_alert_exhausted, Reason_runtime_exhausted
@@ -273,7 +273,7 @@ let operator_disposition (receipt : t)
   else if
     provider_runtime_failure
     && (receipt.cascade_fallback_applied
-        || receipt.cascade_outcome = Cascade_passed_to_next_model)
+        || receipt.runtime_outcome = Runtime_passed_to_next_model)
   then Disp_pass_next_model, Reason_cascade_fallback
   else if provider_runtime_failure
   then Disp_pause_human, Reason_provider_runtime_error
@@ -331,7 +331,7 @@ let operator_disposition (receipt : t)
     in
     let ok_followup_progress =
       receipt.outcome = `Ok
-      && receipt.cascade_outcome = Cascade_completed
+      && receipt.runtime_outcome = Runtime_completed
       && receipt.tool_contract_result = Contract_needs_execution_progress
       && (required_tools_satisfied || generic_claim_context_progress)
     in
@@ -362,7 +362,7 @@ let operator_disposition (receipt : t)
       then Disp_fail_open_next_cascade, Reason_tool_route_recoverable_failure
       else if
         receipt.cascade_fallback_applied
-        || receipt.cascade_outcome = Cascade_passed_to_next_model
+        || receipt.runtime_outcome = Runtime_passed_to_next_model
       then Disp_pass_next_model, Reason_tool_route_recoverable_failure
       else Disp_pause_human, Reason_tool_route_recoverable_failure
     else if required_tool_contract_unsatisfied
@@ -386,24 +386,24 @@ let operator_disposition (receipt : t)
     then Disp_fail_open_next_cascade, Reason_degraded_retry
     else if
       receipt.cascade_fallback_applied
-      || receipt.cascade_outcome = Cascade_passed_to_next_model
+      || receipt.runtime_outcome = Runtime_passed_to_next_model
     then Disp_pass_next_model, Reason_cascade_fallback
     else if
       receipt.outcome = `Ok
-      && receipt.cascade_outcome = Cascade_not_dispatched
+      && receipt.runtime_outcome = Runtime_not_dispatched
       && receipt.tool_contract_result = Contract_not_dispatched
       && String.equal terminal_reason "pre_dispatch_success"
     then Disp_pass, Reason_healthy
     (* "healthy" requires an explicit success signal: turn completed without
-       error AND cascade reached the configured terminal. Any other fallthrough
-       is an unmapped state — surface it as "unknown" so a new cascade_outcome
+       error AND runtime reached the configured terminal. Any other fallthrough
+       is an unmapped state — surface it as "unknown" so a new runtime_outcome
        or terminal_reason_code does not silently display as "healthy" on the
        dashboard. See #9900 and CLAUDE.md anti-pattern #2.
 
        Cancelled is split out from the legacy binary outcome so dashboards
        and replay decoders can distinguish a user-initiated cancellation
        from a true failure. Skipped corresponds to the TLA+ [PhaseGateSkip]
-       action: a turn that intentionally never dispatched, so cascade
+       action: a turn that intentionally never dispatched, so runtime
        never engaged. It is a successful no-op rather than a failure or
        an unmapped state. Spec parity with [ReceiptOutcomeSet] in
        [specs/keeper-turn-fsm/KeeperTurnFSM.tla]. *)
@@ -411,12 +411,12 @@ let operator_disposition (receipt : t)
       match receipt.outcome with
       | `Cancelled -> Disp_user_cancelled, Reason_cancelled
       | `Skipped -> Disp_skipped, Reason_phase_skipped
-      | `Ok when receipt.cascade_outcome = Cascade_completed -> Disp_pass, Reason_healthy
-      | `Ok when receipt.cascade_outcome = Cascade_not_dispatched ->
+      | `Ok when receipt.runtime_outcome = Runtime_completed -> Disp_pass, Reason_healthy
+      | `Ok when receipt.runtime_outcome = Runtime_not_dispatched ->
         (* Pre-dispatch shortcut: the turn completed successfully without
            dispatching to the LLM (cached response, immediate tool result,
            or pre-dispatch check resolved the turn).  Treated as healthy
-           because the outcome is success — the cascade was simply not
+           because the outcome is success — the runtime was simply not
            needed.  Previously unmapped (1062 WARN/day on 2026-05-24). *)
         Disp_pass, Reason_healthy
       | _ ->
@@ -426,11 +426,11 @@ let operator_disposition (receipt : t)
           ~labels:[ "keeper", receipt.keeper_name; "site", Keeper_execution_receipt_failure_site.(to_label Unmapped_disposition) ]
           ();
         Log.Keeper.warn
-          "operator_disposition: unmapped (outcome=%s cascade_outcome=%s \
+          "operator_disposition: unmapped (outcome=%s runtime_outcome=%s \
            terminal_reason=%s tool_contract_result=%s error_kind=%s) — investigate \
            regression of #11651 silent-path fix"
           (outcome_kind_to_string receipt.outcome)
-          (cascade_outcome_to_string receipt.cascade_outcome)
+          (runtime_outcome_to_string receipt.runtime_outcome)
           terminal_reason
           (tool_contract_result_to_string receipt.tool_contract_result)
           (Option.value
@@ -477,7 +477,7 @@ let to_json (receipt : t) =
       ~required_tools:receipt.tool_surface.required_tools
       ~required_tool_candidates:receipt.tool_surface.required_tool_candidates
       ~missing_required_tools:receipt.tool_surface.missing_required_tools
-      ~cascade_profile:(receipt.cascade_name)
+      ~runtime_profile:(receipt.runtime_id)
       ()
   in
   let action_radius =
@@ -561,13 +561,13 @@ let to_json (receipt : t) =
           [ ( "profile", string_opt_json receipt.approval_profile )
           ; "derived", `Bool receipt.approval_profile_derived
           ] )
-    ; ( "cascade"
+    ; ( "runtime"
       , `Assoc
-          [ "name", `String (receipt.cascade_name)
+          [ "name", `String (receipt.runtime_id)
           ; "selected_model", `Null
-          ; "attempt_count", `Int receipt.cascade_attempt_count
+          ; "attempt_count", `Int receipt.runtime_attempt_count
           ; "fallback_applied", `Bool receipt.cascade_fallback_applied
-          ; "outcome", `String (cascade_outcome_to_string receipt.cascade_outcome)
+          ; "outcome", `String (runtime_outcome_to_string receipt.runtime_outcome)
           ; "oas_internal_cascade_allowed", `Bool receipt.oas_internal_cascade_allowed
           ; "degraded_retry_applied", `Bool receipt.degraded_retry_applied
           ; ( "degraded_retry_cascade"
@@ -582,8 +582,8 @@ let to_json (receipt : t) =
           ; ( "rotation_attempts"
             , `List
                 (List.map
-                   cascade_rotation_attempt_to_json
-                   receipt.cascade_rotation_attempts) )
+                   runtime_rotation_attempt_to_json
+                   receipt.runtime_rotation_attempts) )
           ] )
     ; ( "stop_reason"
       , match receipt.stop_reason with
@@ -647,7 +647,7 @@ let to_json (receipt : t) =
                                   [needs_operator_broadcast] is true and
                                   the receipt is not a duplicate livelock
                                   notification, inside a [try] so a single
-                                  failure does not cascade — the spec's
+                                  failure does not runtime — the spec's
                                   clean model.
 
    Bug model (would be violated if a future refactor dropped the first
@@ -726,8 +726,8 @@ let operator_broadcast_payload (receipt : t) ~disposition ~reason =
     ; ( "current_task_id", string_opt_json receipt.current_task_id )
     ; "goal_ids", list_json receipt.goal_ids
     ; "response_text_present", `Bool receipt.response_text_present
-    ; "cascade_name", `String (receipt.cascade_name)
-    ; "cascade_outcome", `String (cascade_outcome_to_string receipt.cascade_outcome)
+    ; "runtime_id", `String (receipt.runtime_id)
+    ; "runtime_outcome", `String (runtime_outcome_to_string receipt.runtime_outcome)
     ; ( "tool_contract_result"
       , `String (tool_contract_result_to_string receipt.tool_contract_result) )
     ; ( "last_tool_name", string_opt_json (last_tool_name receipt) )
@@ -921,21 +921,21 @@ let stale_turn_bucket stale_seconds =
 let stale_broadcast_payload
       ~keeper_name
       ~agent_name
-      ~cascade_name
+      ~runtime_id
       ~trace_id
       ~generation
       ~failure_reason
       ~stale_seconds
       ~last_turn_ts
   =
-  let cascade_name_string = cascade_name in
+  let runtime_id_string = runtime_id in
   let failure_reason_text = stale_broadcast_failure_reason_text failure_reason in
   let failure_reason_cohort = stale_broadcast_failure_cohort failure_reason in
   `Assoc
     [ "schema", `String "keeper.operator_broadcast_required.v1"
     ; "keeper_name", `String keeper_name
     ; "agent_name", `String agent_name
-    ; "cascade_name", `String cascade_name_string
+    ; "runtime_id", `String runtime_id_string
     ; "trace_id", `String trace_id
     ; "generation", `Int generation
     ; "disposition", `String "stalled"
@@ -958,19 +958,19 @@ let emit_stale_keeper_broadcast
       config
       ~keeper_name
       ~agent_name
-      ~cascade_name
+      ~runtime_id
       ~trace_id
       ~generation
       ~failure_reason
       ~stale_seconds
       ~last_turn_ts
   =
-  let cascade_name_string = cascade_name in
+  let runtime_id_string = runtime_id in
   let payload =
     stale_broadcast_payload
       ~keeper_name
       ~agent_name
-      ~cascade_name
+      ~runtime_id
       ~trace_id
       ~generation
       ~stale_seconds
@@ -990,10 +990,10 @@ let emit_stale_keeper_broadcast
     ~labels:[ "keeper", keeper_name; "site", Keeper_execution_receipt_failure_site.(to_label Stale_broadcast) ]
     ();
   Log.Keeper.warn
-    "%s: stale_keeper_broadcast emitted last_turn=%.0fs ago cascade=%s seq=%d"
+    "%s: stale_keeper_broadcast emitted last_turn=%.0fs ago runtime=%s seq=%d"
     keeper_name
     stale_seconds
-    cascade_name_string
+    runtime_id_string
     event.seq
 ;;
 

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -199,7 +199,7 @@ let operator_disposition_kind_to_string = function
 
 type operator_disposition_reason =
   | Reason_healthy
-  | Reason_cascade_exhausted
+  | Reason_runtime_exhausted
   | Reason_preflight_config_error
   | Reason_degraded_retry
   | Reason_cascade_fallback
@@ -214,7 +214,7 @@ type operator_disposition_reason =
 
 let operator_disposition_reason_to_string = function
   | Reason_healthy -> "healthy"
-  | Reason_cascade_exhausted -> "cascade_exhausted"
+  | Reason_runtime_exhausted -> "runtime_exhausted"
   | Reason_preflight_config_error -> "preflight_config_error"
   | Reason_degraded_retry -> "degraded_retry"
   | Reason_cascade_fallback -> "cascade_fallback"
@@ -256,14 +256,14 @@ let operator_disposition (receipt : t)
       string_contains_ci terminal_reason "config"
       || string_contains_ci terminal_reason "auth"
   in
-  (* Pre-typing, this branch also matched cascade_outcome="cascade_exhausted"
+  (* Pre-typing, this branch also matched cascade_outcome="runtime_exhausted"
      and "exhausted" — neither is in the producer's closed [cascade_outcome]
      set ([Cascade_passed_to_next_model] / [_completed] / [_not_observed] /
      [_not_dispatched]).  Those branches were unreachable workarounds; the
      typed migration drops them.  Cascade exhaustion still reaches this
-     branch via [terminal_reason="cascade_exhausted"]. *)
-  if String.equal terminal_reason "cascade_exhausted"
-  then Disp_alert_exhausted, Reason_cascade_exhausted
+     branch via [terminal_reason="runtime_exhausted"]. *)
+  if String.equal terminal_reason "runtime_exhausted"
+  then Disp_alert_exhausted, Reason_runtime_exhausted
   else if preflight_config_failure
   then Disp_pause_human, Reason_preflight_config_error
   else if

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -275,7 +275,7 @@ val operator_disposition_kind_to_string : operator_disposition_kind -> string
     form is byte-compatible with the pre-typing string. *)
 type operator_disposition_reason =
   | Reason_healthy
-  | Reason_cascade_exhausted
+  | Reason_runtime_exhausted
   | Reason_preflight_config_error
   | Reason_degraded_retry
   | Reason_cascade_fallback

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -93,7 +93,7 @@ type tool_surface =
   ; materialized_tools : string list
   }
 
-(** Phase identifier emitted when a cascade rotation releases the in-flight
+(** Phase identifier emitted when a runtime rotation releases the in-flight
     turn slot. Closed set; wire form is [slot_release_phase_to_string]. *)
 type slot_release_phase =
   | Retry_setup_failed
@@ -107,25 +107,25 @@ val slot_release_phase_to_string : slot_release_phase -> string
     form of every variant, used by the RFC-0065 correspondence harness. *)
 val all_symbols : string list
 
-(** Terminal classification of a cascade rotation attempt. Closed set;
-    wire form is [cascade_rotation_outcome_to_string]. *)
-type cascade_rotation_outcome =
+(** Terminal classification of a runtime rotation attempt. Closed set;
+    wire form is [runtime_rotation_outcome_to_string]. *)
+type runtime_rotation_outcome =
   | Rotation_setup_failed
   | Rotation_retry_scheduled
   | Rotation_budget_exhausted
   | Rotation_slot_phase_exhausted
 
-val cascade_rotation_outcome_to_string : cascade_rotation_outcome -> string
+val runtime_rotation_outcome_to_string : runtime_rotation_outcome -> string
 
-(** Receipt-level summary of how the in-turn cascade attempt sequence
-    ended. Closed set; wire form is [cascade_outcome_to_string]. *)
-type cascade_outcome =
-  | Cascade_passed_to_next_model
-  | Cascade_completed
-  | Cascade_not_observed
-  | Cascade_not_dispatched
+(** Receipt-level summary of how the in-turn runtime attempt sequence
+    ended. Closed set; wire form is [runtime_outcome_to_string]. *)
+type runtime_outcome =
+  | Runtime_passed_to_next_model
+  | Runtime_completed
+  | Runtime_not_observed
+  | Runtime_not_dispatched
 
-val cascade_outcome_to_string : cascade_outcome -> string
+val runtime_outcome_to_string : runtime_outcome -> string
 
 (** Receipt-level tool-contract evaluation result. Closed union of three
     producer paths: (i) initial-state sentinel [Contract_unknown];
@@ -177,11 +177,11 @@ val decode_contract_violation_reason
   :  string
   -> (string * string list * string list) option
 
-type cascade_rotation_attempt =
+type runtime_rotation_attempt =
   { from_cascade : string
   ; to_cascade : string
   ; reason : Keeper_error_classify.degraded_retry_reason
-  ; outcome : cascade_rotation_outcome
+  ; outcome : runtime_rotation_outcome
   ; slot_release_at_phase : slot_release_phase option
   ; productive_phase_elapsed_ms : int option
   ; retry_phase_elapsed_ms : int option
@@ -218,16 +218,16 @@ type t =
   ; network_mode : Keeper_types_profile_sandbox.network_mode
   ; approval_profile : string option
   ; approval_profile_derived : bool
-  ; cascade_name : string
+  ; runtime_id : string
   ; cascade_selected_model : string option
-  ; cascade_attempt_count : int
+  ; runtime_attempt_count : int
   ; cascade_fallback_applied : bool
-  ; cascade_outcome : cascade_outcome
+  ; runtime_outcome : runtime_outcome
   ; oas_internal_cascade_allowed : bool
   ; degraded_retry_applied : bool
   ; degraded_retry_cascade : string option
   ; fallback_reason : Keeper_error_classify.degraded_retry_reason option
-  ; cascade_rotation_attempts : cascade_rotation_attempt list
+  ; runtime_rotation_attempts : runtime_rotation_attempt list
   ; stop_reason : Runtime_agent.stop_reason option
   ; error_kind : error_kind option
   ; error_message : string option
@@ -313,7 +313,7 @@ val operator_broadcast_payload
 val stale_broadcast_payload
   :  keeper_name:string
   -> agent_name:string
-  -> cascade_name:string
+  -> runtime_id:string
   -> trace_id:string
   -> generation:int
   -> failure_reason:Keeper_registry.failure_reason option
@@ -334,7 +334,7 @@ val emit_stale_keeper_broadcast
   :  Coord.config
   -> keeper_name:string
   -> agent_name:string
-  -> cascade_name:string
+  -> runtime_id:string
   -> trace_id:string
   -> generation:int
   -> failure_reason:Keeper_registry.failure_reason option

--- a/lib/keeper/keeper_execution_receipt_types.ml
+++ b/lib/keeper/keeper_execution_receipt_types.ml
@@ -1,5 +1,5 @@
 (* Keeper_execution_receipt_types — receipt type definitions,
-   outcome/cascade/slot classification, tool contract types, and
+   outcome/runtime/slot classification, tool contract types, and
    JSON helpers. Extracted from keeper_execution_receipt.ml during
    godfile decomposition. *)
 
@@ -65,7 +65,7 @@ type tool_surface =
   ; materialized_tools : string list
   }
 
-(* Phase identifier emitted when a cascade rotation releases the in-flight
+(* Phase identifier emitted when a runtime rotation releases the in-flight
    turn slot.  Producer-side closed set; the JSON wire is the lowercase
    string form via [slot_release_phase_to_string].  [@@deriving tla] so the
    RFC-0065 correspondence harness picks the symbols up automatically. *)
@@ -84,46 +84,46 @@ type slot_release_phase =
    Mirrors the pattern applied to tool_surface_class in PR #14647 review. *)
 let slot_release_phase_to_string = to_tla_symbol
 
-(* Terminal classification of a cascade rotation attempt.  Producer-side
+(* Terminal classification of a runtime rotation attempt.  Producer-side
    closed set in [keeper_unified_turn.ml]; JSON wire form is the lowercase
-   string via [cascade_rotation_outcome_to_string].
+   string via [runtime_rotation_outcome_to_string].
 
    No [@@deriving tla] here because [slot_release_phase] above already
    binds module-level [all_symbols]; following the precedent in
    [keeper_types_profile.ml] a follow-up can wrap a TLA mirror in a
    submodule when a spec actually models rotation outcomes. *)
-type cascade_rotation_outcome =
+type runtime_rotation_outcome =
   | Rotation_setup_failed
   | Rotation_retry_scheduled
   | Rotation_budget_exhausted
   | Rotation_slot_phase_exhausted
 
-let cascade_rotation_outcome_to_string = function
+let runtime_rotation_outcome_to_string = function
   | Rotation_setup_failed -> "setup_failed"
   | Rotation_retry_scheduled -> "retry_scheduled"
   | Rotation_budget_exhausted -> "budget_exhausted"
   | Rotation_slot_phase_exhausted -> "slot_phase_exhausted"
 ;;
 
-(* Receipt-level summary of how the in-turn cascade attempt sequence
+(* Receipt-level summary of how the in-turn runtime attempt sequence
    ended.  Closed set across two producer paths:
-     - [Keeper_agent_error.cascade_outcome_of_observation] — 3 values
-       sourced from [Cascade_legacy_runner.cascade_observation].
+     - [Keeper_agent_error.runtime_outcome_of_observation] — 3 values
+       sourced from [Cascade_legacy_runner.runtime_observation].
      - [keeper_turn_helpers.build_pending_receipt] — emits
-       [Cascade_not_dispatched] for pre-dispatch pending receipts.
+       [Runtime_not_dispatched] for pre-dispatch pending receipts.
    JSON wire form is the lowercase string via
-   [cascade_outcome_to_string]. *)
-type cascade_outcome =
-  | Cascade_passed_to_next_model
-  | Cascade_completed
-  | Cascade_not_observed
-  | Cascade_not_dispatched
+   [runtime_outcome_to_string]. *)
+type runtime_outcome =
+  | Runtime_passed_to_next_model
+  | Runtime_completed
+  | Runtime_not_observed
+  | Runtime_not_dispatched
 
-let cascade_outcome_to_string = function
-  | Cascade_passed_to_next_model -> "passed_to_next_model"
-  | Cascade_completed -> "completed"
-  | Cascade_not_observed -> "not_observed"
-  | Cascade_not_dispatched -> "not_dispatched"
+let runtime_outcome_to_string = function
+  | Runtime_passed_to_next_model -> "passed_to_next_model"
+  | Runtime_completed -> "completed"
+  | Runtime_not_observed -> "not_observed"
+  | Runtime_not_dispatched -> "not_dispatched"
 ;;
 
 (* Receipt-level result of the tool-contract evaluation for the turn.
@@ -260,11 +260,11 @@ let decode_contract_violation_reason (wire : string)
       else Some (contract_id, [], [])
 ;;
 
-type cascade_rotation_attempt =
+type runtime_rotation_attempt =
   { from_cascade : string
   ; to_cascade : string
   ; reason : Keeper_error_classify.degraded_retry_reason
-  ; outcome : cascade_rotation_outcome
+  ; outcome : runtime_rotation_outcome
   ; slot_release_at_phase : slot_release_phase option
   ; productive_phase_elapsed_ms : int option
   ; retry_phase_elapsed_ms : int option
@@ -301,16 +301,16 @@ type t =
   ; network_mode : Keeper_types_profile_sandbox.network_mode
   ; approval_profile : string option
   ; approval_profile_derived : bool
-  ; cascade_name : string
+  ; runtime_id : string
   ; cascade_selected_model : string option
-  ; cascade_attempt_count : int
+  ; runtime_attempt_count : int
   ; cascade_fallback_applied : bool
-  ; cascade_outcome : cascade_outcome
+  ; runtime_outcome : runtime_outcome
   ; oas_internal_cascade_allowed : bool
   ; degraded_retry_applied : bool
   ; degraded_retry_cascade : string option
   ; fallback_reason : Keeper_error_classify.degraded_retry_reason option
-  ; cascade_rotation_attempts : cascade_rotation_attempt list
+  ; runtime_rotation_attempts : runtime_rotation_attempt list
   ; stop_reason : Runtime_agent.stop_reason option
   ; error_kind : error_kind option
   ; error_message : string option

--- a/lib/keeper/keeper_execution_receipt_types.mli
+++ b/lib/keeper/keeper_execution_receipt_types.mli
@@ -44,18 +44,18 @@ val is_terminal : slot_release_phase -> bool
 val is_active : slot_release_phase -> bool
 val is_idle : slot_release_phase -> bool
 val slot_release_phase_to_string : slot_release_phase -> string
-type cascade_rotation_outcome =
+type runtime_rotation_outcome =
     Rotation_setup_failed
   | Rotation_retry_scheduled
   | Rotation_budget_exhausted
   | Rotation_slot_phase_exhausted
-val cascade_rotation_outcome_to_string : cascade_rotation_outcome -> string
-type cascade_outcome =
-    Cascade_passed_to_next_model
-  | Cascade_completed
-  | Cascade_not_observed
-  | Cascade_not_dispatched
-val cascade_outcome_to_string : cascade_outcome -> string
+val runtime_rotation_outcome_to_string : runtime_rotation_outcome -> string
+type runtime_outcome =
+    Runtime_passed_to_next_model
+  | Runtime_completed
+  | Runtime_not_observed
+  | Runtime_not_dispatched
+val runtime_outcome_to_string : runtime_outcome -> string
 type tool_contract_result =
     Contract_unknown
   | Contract_not_dispatched
@@ -78,11 +78,11 @@ val encode_contract_violation_reason :
 val decode_tool_list : string -> string list option
 val decode_contract_violation_reason :
   string -> (string * string list * string list) option
-type cascade_rotation_attempt = {
+type runtime_rotation_attempt = {
   from_cascade : string;
   to_cascade : string;
   reason : Keeper_error_classify.degraded_retry_reason;
-  outcome : cascade_rotation_outcome;
+  outcome : runtime_rotation_outcome;
   slot_release_at_phase : slot_release_phase option;
   productive_phase_elapsed_ms : int option;
   retry_phase_elapsed_ms : int option;
@@ -118,17 +118,17 @@ type t = {
   network_mode : Keeper_types_profile_sandbox.network_mode;
   approval_profile : string option;
   approval_profile_derived : bool;
-  cascade_name : string;
+  runtime_id : string;
   cascade_selected_model : string option;
-  cascade_attempt_count : int;
+  runtime_attempt_count : int;
   cascade_fallback_applied : bool;
-  cascade_outcome : cascade_outcome;
+  runtime_outcome : runtime_outcome;
   oas_internal_cascade_allowed : bool;
   degraded_retry_applied : bool;
   degraded_retry_cascade : string option;
   fallback_reason :
     Keeper_error_classify.degraded_retry_reason option;
-  cascade_rotation_attempts : cascade_rotation_attempt list;
+  runtime_rotation_attempts : runtime_rotation_attempt list;
   stop_reason : Runtime_agent.stop_reason option;
   error_kind : error_kind option;
   error_message : string option;

--- a/lib/keeper/keeper_failure_policy.ml
+++ b/lib/keeper/keeper_failure_policy.ml
@@ -148,7 +148,7 @@ type failure =
       ; liveness : liveness_evidence
       }
   | Transient_provider_failure
-  | Cascade_exhausted of { retryable : bool }
+  | Runtime_exhausted of { retryable : bool }
   | Required_tool_contract_violation
   | Fatal_environment of { detail : string option }
   | Stale_turn of { progress_seen : bool }
@@ -345,22 +345,22 @@ let decide = function
       ~operator_action:Reroute_or_tune_provider
       ~keeper_death_allowed:false
       ~reason:"transient_provider_failure"
-  | Cascade_exhausted { retryable = true } ->
+  | Runtime_exhausted { retryable = true } ->
     make_decision
       ~failure_scope:Provider_scope
       ~lifecycle_effect:Soft_fail_turn
       ~circuit_effect:Provider_cooldown
       ~operator_action:Reroute_or_tune_provider
       ~keeper_death_allowed:false
-      ~reason:"cascade_exhausted_retryable"
-  | Cascade_exhausted { retryable = false } ->
+      ~reason:"runtime_exhausted_retryable"
+  | Runtime_exhausted { retryable = false } ->
     make_decision
       ~failure_scope:Turn_scope
       ~lifecycle_effect:Pause_current_work
       ~circuit_effect:Operator_breaker
       ~operator_action:Reroute_or_tune_provider
       ~keeper_death_allowed:false
-      ~reason:"cascade_exhausted_terminal"
+      ~reason:"runtime_exhausted_terminal"
   | Required_tool_contract_violation ->
     make_decision
       ~failure_scope:Turn_scope

--- a/lib/keeper/keeper_failure_policy.mli
+++ b/lib/keeper/keeper_failure_policy.mli
@@ -55,7 +55,7 @@ type failure =
       ; liveness : liveness_evidence
       }
   | Transient_provider_failure
-  | Cascade_exhausted of { retryable : bool }
+  | Runtime_exhausted of { retryable : bool }
   | Required_tool_contract_violation
   | Fatal_environment of { detail : string option }
   | Stale_turn of { progress_seen : bool }

--- a/lib/keeper/keeper_heartbeat_loop_observations.ml
+++ b/lib/keeper/keeper_heartbeat_loop_observations.ml
@@ -190,7 +190,7 @@ let is_provider_timeout_error (err : Agent_sdk.Error.sdk_error) =
   match Keeper_turn_driver.classify_masc_internal_error err with
   | Some (Keeper_turn_driver.Provider_timeout _) -> true
   | Some
-      ( Keeper_turn_driver.Cascade_exhausted _
+      ( Keeper_turn_driver.Runtime_exhausted _
       | Keeper_turn_driver.Capacity_backpressure _
       | Keeper_turn_driver.Resumable_cli_session _
 
@@ -235,7 +235,7 @@ let provider_timeout_policy_decision
             ; liveness = Keeper_failure_policy.Recent_heartbeat
             }))
   | Some
-      ( Keeper_turn_driver.Cascade_exhausted _
+      ( Keeper_turn_driver.Runtime_exhausted _
       | Keeper_turn_driver.Capacity_backpressure _
       | Keeper_turn_driver.Resumable_cli_session _
 

--- a/lib/keeper/keeper_heartbeat_loop_presence.ml
+++ b/lib/keeper/keeper_heartbeat_loop_presence.ml
@@ -103,7 +103,7 @@ let keeper_agent_status (meta : keeper_meta) =
     Heartbeat health and turn health are independent in the keeper FSM. A
     successful heartbeat may recover [heartbeat_healthy], but it must not emit
     [Turn_succeeded] or reset provider/tool failure counters. Otherwise a
-    cascade_exhausted turn can be erased by the next keepalive heartbeat before
+    runtime_exhausted turn can be erased by the next keepalive heartbeat before
     auto-pause and diagnostics see the failure streak. *)
 let note_turn_failures_preserved_after_heartbeat ~(ctx : _ context) ~(meta : keeper_meta)
   =

--- a/lib/keeper/keeper_memory_llm_summary.ml
+++ b/lib/keeper/keeper_memory_llm_summary.ml
@@ -231,7 +231,7 @@ let make
     | Some sw, Some net ->
         let clock = Eio_context.get_clock_opt () in
         (match
-           Cascade_catalog_runtime.resolve_named_providers_strict
+           Runtime_catalog.resolve_named_providers_strict
              ~sw ~net ?clock ?provider_filter ~cascade_name ()
          with
          | Error err ->

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -84,10 +84,10 @@ type proactive_runtime =
 
 (* ── Structured blocker classification ──────────────────────── *)
 
-(** Telemetry detail for [No_tool_capable] cascade exhaustion.
+(** Telemetry detail for [No_tool_capable] runtime exhaustion.
     Carried from the former standalone [No_tool_capable_provider]
     variant of [masc_internal_error] after reclassification into
-    [cascade_exhaustion_reason]. *)
+    [runtime_exhaustion_reason]. *)
 type no_tool_capable_detail =
   { configured_labels : string list
   ; required_tool_names : string list
@@ -95,7 +95,7 @@ type no_tool_capable_detail =
       (** [(provider_label, reason)] pairs *)
   }
 
-type cascade_exhaustion_reason =
+type runtime_exhaustion_reason =
   | Connection_refused
   | Dns_failure
     (** RFC-0142 PR-2 (2026-05-22): typed surface for the dominant Other_detail
@@ -113,23 +113,23 @@ type cascade_exhaustion_reason =
   | Max_turns_exceeded
   | Structural_attempt_timeout of { detail : string }
   | Capacity_exhausted
-    (** Typed surface for capacity-induced cascade exhaustion.
+    (** Typed surface for capacity-induced runtime exhaustion.
         Previously [ProviderFailure { kind = Capacity_exhausted _ }] fell
         through to [Other_detail message], losing auto-recovery eligibility
-        and triggering the harsher [Cascade_exhausted { retryable = false }]
+        and triggering the harsher [Runtime_exhausted { retryable = false }]
         failure policy.  This variant enables the softer
         [Soft_fail_turn + Provider_cooldown] path. *)
   | No_tool_capable of no_tool_capable_detail option
-    (** Cascade exhausted because no configured provider can satisfy the
+    (** Runtime exhausted because no configured provider can satisfy the
         required tool set.  Previously a standalone [blocker_class] variant;
         reclassified here because the cascade rotation filtered all candidates
-        before dispatch — a semantic subset of cascade exhaustion.
+        before dispatch — a semantic subset of runtime exhaustion.
         The optional detail carries telemetry from the former
         [No_tool_capable_provider] variant of [masc_internal_error]. *)
   | Other_detail of string
 
 type blocker_class =
-  | Cascade_exhausted of cascade_exhaustion_reason
+  | Runtime_exhausted of runtime_exhaustion_reason
   | Capacity_backpressure
   | Ambiguous_post_commit_timeout
   | Ambiguous_post_commit_failure
@@ -176,8 +176,8 @@ type blocker_class =
   | Sdk_input_required
 
 let blocker_class_to_string = function
-  | Cascade_exhausted (No_tool_capable _) -> "cascade_exhausted_no_tool_capable"
-  | Cascade_exhausted _ -> "cascade_exhausted"
+  | Runtime_exhausted (No_tool_capable _) -> "runtime_exhausted_no_tool_capable"
+  | Runtime_exhausted _ -> "runtime_exhausted"
   | Capacity_backpressure -> "capacity_backpressure"
   | Ambiguous_post_commit_timeout -> "ambiguous_post_commit_timeout"
   | Ambiguous_post_commit_failure -> "ambiguous_post_commit_failure"
@@ -205,8 +205,8 @@ let blocker_class_to_string = function
 ;;
 
 let blocker_class_of_serialized_string = function
-  | "cascade_exhausted_no_tool_capable" -> Some (Cascade_exhausted (No_tool_capable None))
-  | "cascade_exhausted" -> Some (Cascade_exhausted (Other_detail "cascade_exhausted"))
+  | "runtime_exhausted_no_tool_capable" -> Some (Runtime_exhausted (No_tool_capable None))
+  | "runtime_exhausted" -> Some (Runtime_exhausted (Other_detail "runtime_exhausted"))
   | "capacity_backpressure" -> Some Capacity_backpressure
   | "ambiguous_post_commit_timeout" -> Some Ambiguous_post_commit_timeout
   | "ambiguous_post_commit_failure" -> Some Ambiguous_post_commit_failure
@@ -234,32 +234,32 @@ let blocker_class_of_serialized_string = function
   | _ -> None
 ;;
 
-let cascade_exhaustion_summary = function
+let runtime_exhaustion_summary = function
   | Connection_refused ->
-    "Cascade exhausted after provider failures; local runtime connection refused."
+    "Runtime exhausted after provider failures; local runtime connection refused."
   | Dns_failure ->
-    "Cascade exhausted; hostname resolution failed (DNS)."
-  | No_providers_available -> "Cascade exhausted; no providers were available."
+    "Runtime exhausted; hostname resolution failed (DNS)."
+  | No_providers_available -> "Runtime exhausted; no providers were available."
   | All_providers_failed ->
-    "Cascade exhausted after all configured providers failed; inspect per-attempt root causes."
+    "Runtime exhausted after all configured providers failed; inspect per-attempt root causes."
   | Candidates_filtered_after_cycles ->
-    "Cascade exhausted after provider candidates were filtered; inspect candidate filter reasons."
+    "Runtime exhausted after provider candidates were filtered; inspect candidate filter reasons."
   | Max_turns_exceeded ->
-    "Cascade exhausted after a provider hit its per-call turn budget."
+    "Runtime exhausted after a provider hit its per-call turn budget."
   | Structural_attempt_timeout _ ->
-    "Cascade exhausted after the per-OAS-call ceiling (max_execution_time_s) fired."
+    "Runtime exhausted after the per-OAS-call ceiling (max_execution_time_s) fired."
   | Capacity_exhausted ->
-    "Cascade exhausted; all providers reported capacity backpressure."
+    "Runtime exhausted; all providers reported capacity backpressure."
   | No_tool_capable _ ->
-    "Cascade exhausted; no configured provider can satisfy the required tool set."
+    "Runtime exhausted; no configured provider can satisfy the required tool set."
   | Other_detail _ ->
-    "Cascade exhausted; inspect cascade attempts for the dominant root cause."
+    "Runtime exhausted; inspect cascade attempts for the dominant root cause."
 ;;
 
 let blocker_class_continue_gate = function
   | Ambiguous_post_commit_timeout
   | Ambiguous_post_commit_failure -> true
-  | Cascade_exhausted _
+  | Runtime_exhausted _
   | Capacity_backpressure
   | Autonomous_slot_wait_timeout
   | Admission_queue_wait_timeout
@@ -284,7 +284,7 @@ let blocker_class_continue_gate = function
   | Sdk_input_required -> false
 ;;
 
-let cascade_exhaustion_reason_to_json = function
+let runtime_exhaustion_reason_to_json = function
   | Connection_refused -> `String "connection_refused"
   | Dns_failure -> `String "dns_failure"
   | No_providers_available -> `String "no_providers_available"
@@ -311,7 +311,7 @@ let cascade_exhaustion_reason_to_json = function
   | Other_detail msg -> `Assoc [ "tag", `String "other_detail"; "message", `String msg ]
 ;;
 
-let cascade_exhaustion_reason_of_json = function
+let runtime_exhaustion_reason_of_json = function
   | `String "connection_refused" -> Some Connection_refused
   | `String "dns_failure" -> Some Dns_failure
   | `String "no_providers_available" -> Some No_providers_available
@@ -376,9 +376,9 @@ let blocker_info_of_class ?(detail = "") klass = { klass; detail }
 
 let blocker_info_to_json (info : blocker_info) : Yojson.Safe.t =
   let klass_payload = match info.klass with
-    | Cascade_exhausted reason ->
-      `Assoc [ "name", `String "cascade_exhausted"
-             ; "reason", cascade_exhaustion_reason_to_json reason
+    | Runtime_exhausted reason ->
+      `Assoc [ "name", `String "runtime_exhausted"
+             ; "reason", runtime_exhaustion_reason_to_json reason
              ]
     | _ -> `String (blocker_class_to_string info.klass)
   in
@@ -397,16 +397,16 @@ let blocker_info_of_json (json : Yojson.Safe.t) : blocker_info option =
       | Some (`String s) -> blocker_class_of_serialized_string s
       | Some (`Assoc kfields) ->
         (match List.assoc_opt "name" kfields with
-         | Some (`String "cascade_exhausted") ->
+         | Some (`String "runtime_exhausted") ->
            let reason =
              match List.assoc_opt "reason" kfields with
              | Some r ->
-               (match cascade_exhaustion_reason_of_json r with
+               (match runtime_exhaustion_reason_of_json r with
                 | Some r -> r
-                | None -> Other_detail "cascade_exhausted")
-             | None -> Other_detail "cascade_exhausted"
+                | None -> Other_detail "runtime_exhausted")
+             | None -> Other_detail "runtime_exhausted"
            in
-           Some (Cascade_exhausted reason)
+           Some (Runtime_exhausted reason)
          | Some (`String s) -> blocker_class_of_serialized_string s
          | _ -> None)
       | _ -> None

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -136,7 +136,7 @@ type no_tool_capable_detail =
   ; provider_rejections : (string * string) list
   }
 
-type cascade_exhaustion_reason =
+type runtime_exhaustion_reason =
   | Connection_refused
   | Dns_failure
       (** RFC-0142 PR-2: typed surface for hostname-resolution failure.
@@ -155,21 +155,21 @@ type cascade_exhaustion_reason =
           provider timeouts. This variant is accepted only from typed
           envelopes; free-form messages stay [Other_detail]. *)
   | Capacity_exhausted
-      (** Typed surface for capacity-induced cascade exhaustion.
+      (** Typed surface for capacity-induced runtime exhaustion.
           Previously [ProviderFailure { kind = Capacity_exhausted _ }] fell
           through to [Other_detail message], losing auto-recovery eligibility
           and triggering the harsher failure policy. *)
   | No_tool_capable of no_tool_capable_detail option
-      (** Cascade exhausted because no configured provider can satisfy the
+      (** Runtime exhausted because no configured provider can satisfy the
           required tool set.  Previously a standalone [blocker_class] variant;
           reclassified here because the cascade rotation filtered all candidates
-          before dispatch — a semantic subset of cascade exhaustion.
+          before dispatch — a semantic subset of runtime exhaustion.
           The optional detail carries telemetry from the former
           [No_tool_capable_provider] variant of [masc_internal_error]. *)
   | Other_detail of string
 
 type blocker_class =
-  | Cascade_exhausted of cascade_exhaustion_reason
+  | Runtime_exhausted of runtime_exhaustion_reason
   | Capacity_backpressure
   | Ambiguous_post_commit_timeout
   | Ambiguous_post_commit_failure
@@ -199,8 +199,8 @@ val blocker_class_to_string : blocker_class -> string
 (** Canonical lowercase labels.  Pinned literals — operator
     dashboards parse these for keeper supervisor alerting. *)
 
-val cascade_exhaustion_summary :
-  cascade_exhaustion_reason -> string
+val runtime_exhaustion_summary :
+  runtime_exhaustion_reason -> string
 (** Human-readable one-sentence summary per reason variant.
     Used in keeper supervisor logs + dashboard tooltips. *)
 
@@ -212,21 +212,21 @@ val blocker_class_continue_gate : blocker_class -> bool
     other blocker terminates the keeper.  Pinned at the
     contract seam — drift changes keeper recovery semantics. *)
 
-val cascade_exhaustion_reason_to_json :
-  cascade_exhaustion_reason -> Yojson.Safe.t
+val runtime_exhaustion_reason_to_json :
+  runtime_exhaustion_reason -> Yojson.Safe.t
 
-val cascade_exhaustion_reason_of_json :
-  Yojson.Safe.t -> cascade_exhaustion_reason option
+val runtime_exhaustion_reason_of_json :
+  Yojson.Safe.t -> runtime_exhaustion_reason option
 
 val blocker_class_of_serialized_string :
   string -> blocker_class option
 (** [blocker_class_of_serialized_string label] is the inverse
-    of {!blocker_class_to_string}.  [Cascade_exhausted _]
-    maps from the bare ["cascade_exhausted"] string to
-    [Cascade_exhausted (Other_detail "cascade_exhausted")] —
+    of {!blocker_class_to_string}.  [Runtime_exhausted _]
+    maps from the bare ["runtime_exhausted"] string to
+    [Runtime_exhausted (Other_detail "runtime_exhausted")] —
     the reason payload is not round-trippable through this
     function alone (callers needing the reason use
-    {!cascade_exhaustion_reason_of_json}).  Used by
+    {!runtime_exhaustion_reason_of_json}).  Used by
     {!Keeper_meta_json_parse} to decode persisted blocker
     state. *)
 
@@ -249,8 +249,8 @@ val blocker_info_of_class : ?detail:string -> blocker_class -> blocker_info
     for [klass].  [detail] defaults to [""]. *)
 
 val blocker_info_to_json : blocker_info -> Yojson.Safe.t
-(** Round-trippable JSON encoding.  [Cascade_exhausted reason] uses
-    a structured object so the inner [cascade_exhaustion_reason] is
+(** Round-trippable JSON encoding.  [Runtime_exhausted reason] uses
+    a structured object so the inner [runtime_exhaustion_reason] is
     preserved across read/write cycles. *)
 
 val blocker_info_of_json : Yojson.Safe.t -> blocker_info option

--- a/lib/keeper/keeper_oas_execution_error_phase.ml
+++ b/lib/keeper/keeper_oas_execution_error_phase.ml
@@ -1,6 +1,6 @@
 type t =
   | Turn_start
-  | Cascade_exhausted
+  | Runtime_exhausted
   | Terminal_non_exhaustion
   | Recoverable_cascade_transient
   | Cycle_failed
@@ -11,7 +11,7 @@ type t =
 
 let to_label = function
   | Turn_start -> "turn_start"
-  | Cascade_exhausted -> "cascade_exhausted"
+  | Runtime_exhausted -> "runtime_exhausted"
   | Terminal_non_exhaustion -> "terminal_non_exhaustion"
   | Recoverable_cascade_transient -> "recoverable_cascade_transient"
   | Cycle_failed -> "cycle_failed"

--- a/lib/keeper/keeper_oas_execution_error_phase.mli
+++ b/lib/keeper/keeper_oas_execution_error_phase.mli
@@ -14,7 +14,7 @@
 
 type t =
   | Turn_start
-  | Cascade_exhausted
+  | Runtime_exhausted
   | Terminal_non_exhaustion
   | Recoverable_cascade_transient
   | Cycle_failed

--- a/lib/keeper/keeper_observation.ml
+++ b/lib/keeper/keeper_observation.ml
@@ -1,6 +1,6 @@
-(** Keeper_observation — Cascade metrics types, observation building, and recording.
+(** Keeper_observation — Runtime metrics types, observation building, and recording.
 
-    Tracks per-cascade call counts, model selection distribution, fallback
+    Tracks per-runtime call counts, model selection distribution, fallback
     hops, and per-attempt latency/error detail. Aggregate counters stay
     in-process (mutable Hashtbl), while per-call observations are also
     appended to a dated JSONL audit log under [.masc/cascade_audit].
@@ -8,11 +8,11 @@
     @since God file decomposition — extracted from oas_worker.ml *)
 
 (* ================================================================ *)
-(* Cascade types                                                     *)
+(* Runtime types                                                     *)
 (* ================================================================ *)
 
-type cascade_observation = {
-  cascade_name : string;
+type runtime_observation = {
+  runtime_id : string;
   strategy : string option;
   configured_labels : string list;
   candidate_models : string list;
@@ -22,14 +22,14 @@ type cascade_observation = {
   selected_index : int option;
   fallback_hops : int option;
   fallback_applied : bool;
-  attempts : cascade_attempt list;
-  fallback_events : cascade_fallback_event list;
+  attempts : runtime_attempt list;
+  fallback_events : runtime_fallback_event list;
   attempt_details_available : bool;
   attempt_details_source : string;
   oas_internal_cascade_allowed : bool;
 }
 
-and cascade_attempt = {
+and runtime_attempt = {
   attempt_index : int;
   model_id : string;
   model_label : string option;
@@ -37,7 +37,7 @@ and cascade_attempt = {
   error : string option;
 }
 
-and cascade_fallback_event = {
+and runtime_fallback_event = {
   from_model_id : string;
   from_model_label : string option;
   to_model_id : string;
@@ -47,11 +47,11 @@ and cascade_fallback_event = {
 
 module StringMap = Set_util.StringMap
 
-(* RFC-0132 PR-2: cascade observation OAS/dashboard surface = external boundary; redact via SSOT. *)
+(* RFC-0132 PR-2: runtime observation OAS/dashboard surface = external boundary; redact via SSOT. *)
 let public_runtime_model_label =
   Boundary_redaction.to_string Boundary_redaction.runtime_model_label
 
-type cascade_counter = {
+type runtime_counter = {
   calls : int;
   successes : int;
   failures : int;
@@ -62,8 +62,8 @@ type cascade_counter = {
   last_selected_model : string option;
   last_selected_index : int option;
   last_candidate_models : string list;
-  last_attempts : cascade_attempt list;
-  last_fallback_events : cascade_fallback_event list;
+  last_attempts : runtime_attempt list;
+  last_fallback_events : runtime_fallback_event list;
   last_attempt_details_available : bool;
   last_attempt_details_source : string option;
   last_used_at : float;
@@ -74,7 +74,7 @@ type cascade_counter = {
 
 let cascade_max_keys = 256
 
-let create_cascade_counter ~now () =
+let create_runtime_counter ~now () =
   {
     calls = 0;
     successes = 0;
@@ -96,15 +96,15 @@ let create_cascade_counter ~now () =
     errored_models = StringMap.empty;
   }
 
-type cascade_eviction = {
+type runtime_eviction = {
   name : string;
   calls : int;
   last_used_at : float;
 }
 
-let find_cascade_eviction_candidate counters =
+let find_runtime_eviction_candidate counters =
   StringMap.fold
-    (fun name (counter : cascade_counter) best ->
+    (fun name (counter : runtime_counter) best ->
       match best with
       | None ->
           Some { name; calls = counter.calls; last_used_at = counter.last_used_at }
@@ -124,7 +124,7 @@ let find_cascade_eviction_candidate counters =
 (* Provider label helpers                                            *)
 (* ================================================================ *)
 
-(** Map provider_kind to a cascade-label prefix. Delegates to the
+(** Map provider_kind to a runtime-label prefix. Delegates to the
     current OAS registry helper so endpoint-distinct providers track
     the pinned agent_sdk behavior. The function does not enumerate
     specific providers; the registry resolves them. *)
@@ -150,7 +150,7 @@ let strip_latest_suffix s =
 (* Observation building                                              *)
 (* ================================================================ *)
 
-let cascade_observation_of_candidates ~cascade_name ?strategy ~configured_labels
+let runtime_observation_of_candidates ~runtime_id ?strategy ~configured_labels
     ~(candidate_count : int)
     ~(selected_model_raw : string option)
     ?(attempts = [])
@@ -158,7 +158,7 @@ let cascade_observation_of_candidates ~cascade_name ?strategy ~configured_labels
     ?(attempt_details_available = false)
     ?(attempt_details_source = "opaque_named_cascade")
     ?(oas_internal_cascade_allowed = false)
-    () : cascade_observation =
+    () : runtime_observation =
   let candidate_models =
     List.init (max 0 candidate_count) (fun _ -> public_runtime_model_label)
   in
@@ -181,7 +181,7 @@ let cascade_observation_of_candidates ~cascade_name ?strategy ~configured_labels
     | None -> false
   in
   {
-    cascade_name;
+    runtime_id;
     strategy;
     configured_labels = [];
     candidate_models;
@@ -202,14 +202,14 @@ let cascade_observation_of_candidates ~cascade_name ?strategy ~configured_labels
 (* Metrics capture callbacks                                         *)
 (* ================================================================ *)
 
-type cascade_metrics_capture = {
+type runtime_metrics_capture = {
   mutable next_attempt_index : int;
-  mutable attempts_rev : cascade_attempt list;
-  mutable fallback_events_rev : cascade_fallback_event list;
+  mutable attempts_rev : runtime_attempt list;
+  mutable fallback_events_rev : runtime_fallback_event list;
 }
 
 (* Non-redacted JSON encoders for the internal audit log
-   (cascade_observation_to_json → record_cascade_audit). Sibling fields
+   (runtime_observation_to_json → record_cascade_audit). Sibling fields
    in the same observation envelope (selected_model, primary_model,
    candidate_models) are already emitted as real strings; the per-attempt
    and per-fallback model_id were the only fields collapsed to the
@@ -217,9 +217,9 @@ type cascade_metrics_capture = {
 
    The redacted variants for external boundaries (keeper metrics consumed
    by dashboard/OAS) live in lib/keeper/keeper_unified_metrics.ml as
-   [redacted_cascade_attempt_to_json] etc. and intentionally omit
+   [redacted_runtime_attempt_to_json] etc. and intentionally omit
    model_id/model_label entirely. Those are not touched here. *)
-let cascade_attempt_to_json (attempt : cascade_attempt) : Yojson.Safe.t =
+let runtime_attempt_to_json (attempt : runtime_attempt) : Yojson.Safe.t =
   `Assoc
     [
       ("attempt_index", `Int attempt.attempt_index);
@@ -229,7 +229,7 @@ let cascade_attempt_to_json (attempt : cascade_attempt) : Yojson.Safe.t =
       ("error", Json_util.string_opt_to_json attempt.error);
     ]
 
-let cascade_fallback_event_to_json (event : cascade_fallback_event) :
+let runtime_fallback_event_to_json (event : runtime_fallback_event) :
     Yojson.Safe.t =
   `Assoc
     [
@@ -249,7 +249,7 @@ let update_first_attempt_if ~predicate ~update attempts_rev =
   in
   loop attempts_rev
 
-let record_attempt_start (capture : cascade_metrics_capture) ~model_id:_ =
+let record_attempt_start (capture : runtime_metrics_capture) ~model_id:_ =
   let attempt_index = capture.next_attempt_index in
   capture.next_attempt_index <- capture.next_attempt_index + 1;
   capture.attempts_rev <-
@@ -262,21 +262,21 @@ let record_attempt_start (capture : cascade_metrics_capture) ~model_id:_ =
     }
     :: capture.attempts_rev
 
-(** [cascade_attempt_terminal_event_json] builds the structured details payload
+(** [runtime_attempt_terminal_event_json] builds the structured details payload
     emitted to system_log when a runtime candidate reaches its terminal state
     (success: latency_ms set, error none; failure: error set). The shape is the
     contract for downstream log analysers and external operators looking for
-    "why did the cascade exhaust" signals. Errors are recorded verbatim — no
+    "why did the runtime exhaust" signals. Errors are recorded verbatim — no
     string-based classification at this layer (see #12817 spirit and the
     project memory rule "no string matching for classification"). *)
-let cascade_attempt_terminal_event_json ?slot_release_at_phase
+let runtime_attempt_terminal_event_json ?slot_release_at_phase
     ?productive_phase_elapsed_ms ?retry_phase_elapsed_ms ~model_id:_
     ~model_label:_
     ~latency_ms ~error () =
   let outcome = if Option.is_some error then "failure" else "success" in
   `Assoc
     [
-      ("event", `String "cascade_attempt_terminal");
+      ("event", `String "runtime_attempt_terminal");
       ("model_id", `String public_runtime_model_label);
       ("model_label", `Null);
       ( "latency_ms", Json_util.int_opt_to_json latency_ms );
@@ -287,10 +287,10 @@ let cascade_attempt_terminal_event_json ?slot_release_at_phase
       ( "retry_phase_elapsed_ms", Json_util.int_opt_to_json retry_phase_elapsed_ms );
     ]
 
-let log_cascade_attempt_terminal ~model_id ~model_label ~latency_ms ~error =
+let log_runtime_attempt_terminal ~model_id ~model_label ~latency_ms ~error =
   let outcome = if Option.is_some error then "failure" else "success" in
   let details =
-    cascade_attempt_terminal_event_json ~model_id ~model_label ~latency_ms
+    runtime_attempt_terminal_event_json ~model_id ~model_label ~latency_ms
       ~error ()
   in
   let summary =
@@ -301,7 +301,7 @@ let log_cascade_attempt_terminal ~model_id ~model_label ~latency_ms ~error =
   in
   Log.Telemetry.emit Log.Info ~details summary
 
-let ensure_terminal_attempt (capture : cascade_metrics_capture)
+let ensure_terminal_attempt (capture : runtime_metrics_capture)
     ~model_id:_ ~(latency_ms : int option) ~(error : string option) =
   let model_id = public_runtime_model_label in
   let is_open attempt =
@@ -325,11 +325,11 @@ let ensure_terminal_attempt (capture : cascade_metrics_capture)
           error;
         }
         :: capture.attempts_rev);
-  log_cascade_attempt_terminal ~model_id ~model_label ~latency_ms ~error
+  log_runtime_attempt_terminal ~model_id ~model_label ~latency_ms ~error
 
 let record_attempt_terminal = ensure_terminal_attempt
 
-let record_fallback_event (capture : cascade_metrics_capture)
+let record_fallback_event (capture : runtime_metrics_capture)
     ~from_model:_ ~to_model:_ ~(reason : string) =
   capture.fallback_events_rev <-
     {
@@ -341,7 +341,7 @@ let record_fallback_event (capture : cascade_metrics_capture)
     }
     :: capture.fallback_events_rev
 
-let cascade_metrics_for_candidates ~candidate_count:(_ : int) () =
+let runtime_metrics_for_candidates ~candidate_count:(_ : int) () =
   let capture =
     { next_attempt_index = 0; attempts_rev = []; fallback_events_rev = [] }
   in
@@ -357,7 +357,7 @@ let cascade_metrics_for_candidates ~candidate_count:(_ : int) () =
       on_request_end = (fun ~model_id ~latency_ms ->
         ensure_terminal_attempt capture ~model_id ~latency_ms ~error:None;
         (* Forward to Prometheus so per-model latency is visible on
-           the dashboard. Without this, the cascade capture records
+           the dashboard. Without this, the runtime capture records
            latency internally but never exports it — the global
            Llm_metric_bridge sink is not consulted because this
            per-call metrics object takes precedence. *)
@@ -401,12 +401,12 @@ let cascade_metrics_for_candidates ~candidate_count:(_ : int) () =
   in
   (capture, metrics)
 
-let cascade_observation_with_metrics ~cascade_name ?strategy ~configured_labels
+let runtime_observation_with_metrics ~runtime_id ?strategy ~configured_labels
     ~(candidate_count : int)
-    ~(selected_model_raw : string option) ~(capture : cascade_metrics_capture)
+    ~(selected_model_raw : string option) ~(capture : runtime_metrics_capture)
     ?(oas_internal_cascade_allowed = false)
     () =
-  cascade_observation_of_candidates ~cascade_name ?strategy ~configured_labels
+  runtime_observation_of_candidates ~runtime_id ?strategy ~configured_labels
     ~candidate_count ~selected_model_raw
     ~attempts:(List.rev capture.attempts_rev)
     ~fallback_events:(List.rev capture.fallback_events_rev)
@@ -419,13 +419,13 @@ let cascade_observation_with_metrics ~cascade_name ?strategy ~configured_labels
 (* JSON serialization                                                *)
 (* ================================================================ *)
 
-let cascade_observation_to_json (obs : cascade_observation) : Yojson.Safe.t =
-  let cascade_name =
-    obs.cascade_name
+let runtime_observation_to_json (obs : runtime_observation) : Yojson.Safe.t =
+  let runtime_id =
+    obs.runtime_id
   in
   `Assoc
     [
-      ("runtime_id", `String cascade_name);
+      ("runtime_id", `String runtime_id);
       ("strategy", Json_util.string_opt_to_json obs.strategy);
       ( "configured_labels",
         `List (List.map (fun label -> `String label) obs.configured_labels) );
@@ -438,10 +438,10 @@ let cascade_observation_to_json (obs : cascade_observation) : Yojson.Safe.t =
       ("fallback_hops", Json_util.int_opt_to_json obs.fallback_hops);
       ("fallback_applied", `Bool obs.fallback_applied);
       ( "attempts",
-        `List (List.map cascade_attempt_to_json obs.attempts) );
+        `List (List.map runtime_attempt_to_json obs.attempts) );
       ( "fallback_events",
         `List
-          (List.map cascade_fallback_event_to_json obs.fallback_events) );
+          (List.map runtime_fallback_event_to_json obs.fallback_events) );
       ("attempt_details_available", `Bool obs.attempt_details_available);
       ("attempt_details_source", `String obs.attempt_details_source);
       ("oas_internal_cascade_allowed", `Bool obs.oas_internal_cascade_allowed);
@@ -465,11 +465,11 @@ let get_cascade_audit_store store_opt =
              observable.  Audit failure here disables the subsystem
              for the process lifetime — operators need to know. *)
           Runtime_metrics.on_cascade_audit_failure ~stage:"store_creation";
-          Log.Misc.warn "cascade audit store creation failed: %s"
+          Log.Misc.warn "runtime audit store creation failed: %s"
             (Printexc.to_string exn);
           None)
 
-let cascade_outcome_to_string = function
+let runtime_outcome_to_string = function
   | `Success -> "success"
   | `Failure -> "failure"
   | `Rejected -> "rejected"
@@ -479,7 +479,7 @@ let cascade_outcome_to_string = function
    is chosen because for terminal Failure/Rejected outcomes the final event's
    reason is the actual cause of exhaustion; the first event reflects only
    the initial fallback trigger.  Empty list -> null. *)
-let top_level_reason_of_observation (observation : cascade_observation option) =
+let top_level_reason_of_observation (observation : runtime_observation option) =
   match observation with
   | None -> `Null
   | Some obs ->
@@ -492,34 +492,34 @@ let keeper_name_to_json keeper_name =
   | Some name when String.trim name <> "" -> `String name
   | _ -> `Null
 
-let cascade_audit_json ~now ~keeper_name ~cascade_name ~observation ~outcome =
-  let cascade_name =
-    cascade_name
+let cascade_audit_json ~now ~keeper_name ~runtime_id ~observation ~outcome =
+  let runtime_id =
+    runtime_id
   in
   `Assoc
     [
       ("ts", `Float now);
       ("keeper_name", keeper_name_to_json keeper_name);
-      ("runtime_id", `String cascade_name);
-      ("outcome", `String (cascade_outcome_to_string outcome));
+      ("runtime_id", `String runtime_id);
+      ("outcome", `String (runtime_outcome_to_string outcome));
       ("top_level_reason", top_level_reason_of_observation observation);
       ( "observation",
         match observation with
-        | Some obs -> cascade_observation_to_json obs
+        | Some obs -> runtime_observation_to_json obs
         | None -> `Null );
     ]
 
-let record_cascade_audit store_opt ~now ~keeper_name ~cascade_name ~observation
+let record_cascade_audit store_opt ~now ~keeper_name ~runtime_id ~observation
     ~outcome =
-  let cascade_name_string =
-    cascade_name
+  let runtime_id_string =
+    runtime_id
   in
   match store_opt with
   | None -> ()
   | Some store ->
       (try
          Dated_jsonl.append store
-           (cascade_audit_json ~now ~keeper_name ~cascade_name ~observation
+           (cascade_audit_json ~now ~keeper_name ~runtime_id ~observation
               ~outcome)
        with
       | Eio.Cancel.Cancelled _ as e -> raise e
@@ -528,8 +528,8 @@ let record_cascade_audit store_opt ~now ~keeper_name ~cascade_name ~observation
              alertable.  Single-event audit loss compounds over
              time for post-incident analysis. *)
           Runtime_metrics.on_cascade_audit_failure ~stage:"append";
-          Log.Misc.warn "cascade audit append failed cascade=%s error=%s"
-            cascade_name_string (Printexc.to_string exn))
+          Log.Misc.warn "runtime audit append failed runtime=%s error=%s"
+            runtime_id_string (Printexc.to_string exn))
 
 (* ================================================================ *)
 (* Aggregate metrics recording                                       *)
@@ -554,7 +554,7 @@ let distribution_json map =
          in
          Int.compare (count_of right) (count_of left))
 
-let attempt_model_display (attempt : cascade_attempt) =
+let attempt_model_display (attempt : runtime_attempt) =
   match attempt.model_label with
   | Some label when String.trim label <> "" -> label
   | _ -> attempt.model_id
@@ -562,8 +562,8 @@ let attempt_model_display (attempt : cascade_attempt) =
 type msg =
   | Record_cascade of {
       keeper_name : string option;
-      cascade_name : string;
-      observation : cascade_observation option;
+      runtime_id : string;
+      observation : runtime_observation option;
       outcome : [ `Success | `Failure | `Rejected ];
       now : float;
     }
@@ -571,30 +571,30 @@ type msg =
   | Reset_counters_for_test
 
 type state = {
-  counters : cascade_counter StringMap.t;
+  counters : runtime_counter StringMap.t;
   audit_store : Dated_jsonl.t option;
 }
 
 let stream = Eio.Stream.create 1024
 
-let handle_record state ~now ~keeper_name ~cascade_name ~observation ~outcome =
-  let cascade_name_string =
-    cascade_name
+let handle_record state ~now ~keeper_name ~runtime_id ~observation ~outcome =
+  let runtime_id_string =
+    runtime_id
   in
   let counters = state.counters in
   let counter, counters, evicted =
-    match StringMap.find_opt cascade_name_string counters with
+    match StringMap.find_opt runtime_id_string counters with
     | Some c -> (c, counters, None)
     | None ->
         let (counters_after_evict, evicted) =
           if StringMap.cardinal counters >= cascade_max_keys then
-            match find_cascade_eviction_candidate counters with
+            match find_runtime_eviction_candidate counters with
             | Some candidate -> (StringMap.remove candidate.name counters, Some candidate)
             | None -> (counters, None)
           else (counters, None)
         in
-        let c = create_cascade_counter ~now () in
-        (c, StringMap.add cascade_name_string c counters_after_evict, evicted)
+        let c = create_runtime_counter ~now () in
+        (c, StringMap.add runtime_id_string c counters_after_evict, evicted)
   in
   let counter = { counter with calls = counter.calls + 1; last_used_at = now } in
   let counter =
@@ -637,19 +637,19 @@ let handle_record state ~now ~keeper_name ~cascade_name ~observation ~outcome =
     (fun candidate ->
       (* Iter 45: counter ticks on every eviction so the rate is
          alertable.  WARN log already prints per-eviction detail
-         (cascade name, age, etc.); metric makes rate aggregation
+         (runtime name, age, etc.); metric makes rate aggregation
          tractable. *)
-      Runtime_metrics.on_cascade_metrics_eviction ();
+      Runtime_metrics.on_runtime_metrics_eviction ();
       Log.Misc.warn
-        "cascade metrics evicted key=%s calls=%d last_used_at=%.3f to admit %s (limit=%d)"
-        candidate.name candidate.calls candidate.last_used_at cascade_name_string
+        "runtime metrics evicted key=%s calls=%d last_used_at=%.3f to admit %s (limit=%d)"
+        candidate.name candidate.calls candidate.last_used_at runtime_id_string
         cascade_max_keys)
     evicted;
   let audit_store_next = get_cascade_audit_store state.audit_store in
-  record_cascade_audit audit_store_next ~now ~keeper_name ~cascade_name
+  record_cascade_audit audit_store_next ~now ~keeper_name ~runtime_id
     ~observation ~outcome;
   {
-    counters = StringMap.add cascade_name_string counter counters;
+    counters = StringMap.add runtime_id_string counter counters;
     audit_store = audit_store_next;
   }
 
@@ -657,7 +657,7 @@ let handle_get_metrics state p =
   let counters = state.counters in
   let entries =
     StringMap.fold
-      (fun name (c : cascade_counter) acc ->
+      (fun name (c : runtime_counter) acc ->
         let error_rate =
           if c.calls > 0 then
             float_of_int (c.failures + c.rejected) /. float_of_int c.calls
@@ -679,10 +679,10 @@ let handle_get_metrics state p =
             ( "last_candidate_models",
               `List (List.map (fun model -> `String model) c.last_candidate_models) );
             ( "last_attempts",
-              `List (List.map cascade_attempt_to_json c.last_attempts) );
+              `List (List.map runtime_attempt_to_json c.last_attempts) );
             ( "last_fallback_events",
               `List
-                (List.map cascade_fallback_event_to_json c.last_fallback_events) );
+                (List.map runtime_fallback_event_to_json c.last_fallback_events) );
             ("last_attempt_details_available", `Bool c.last_attempt_details_available);
             ( "last_attempt_details_source",
               Json_util.string_opt_to_json c.last_attempt_details_source );
@@ -706,9 +706,9 @@ let handle_get_metrics state p =
 let run_actor () =
   let rec loop state =
     match Eio.Stream.take stream with
-    | Record_cascade { keeper_name; cascade_name; observation; outcome; now } ->
+    | Record_cascade { keeper_name; runtime_id; observation; outcome; now } ->
         loop
-          (handle_record state ~now ~keeper_name ~cascade_name ~observation
+          (handle_record state ~now ~keeper_name ~runtime_id ~observation
              ~outcome)
     | Get_metrics_json p ->
         handle_get_metrics state p;
@@ -721,15 +721,15 @@ let run_actor () =
 let start_actor_if_needed ~sw =
   Eio.Fiber.fork_daemon ~sw run_actor
 
-let record_cascade ?keeper_name ~observation ~cascade_name ~outcome () =
+let record_cascade ?keeper_name ~observation ~runtime_id ~outcome () =
   let now = Time_compat.now () in
   Eio.Stream.add stream
-    (Record_cascade { keeper_name; cascade_name; observation; outcome; now })
+    (Record_cascade { keeper_name; runtime_id; observation; outcome; now })
 
-let cascade_metrics_json () =
+let runtime_metrics_json () =
   let p, u = Eio.Promise.create () in
   Eio.Stream.add stream (Get_metrics_json u);
   Eio.Promise.await p
 
-let reset_cascade_counters_for_test () =
+let reset_runtime_counters_for_test () =
   Eio.Stream.add stream Reset_counters_for_test

--- a/lib/keeper/keeper_observation.ml
+++ b/lib/keeper/keeper_observation.ml
@@ -263,7 +263,7 @@ let record_attempt_start (capture : cascade_metrics_capture) ~model_id:_ =
     :: capture.attempts_rev
 
 (** [cascade_attempt_terminal_event_json] builds the structured details payload
-    emitted to system_log when a cascade candidate reaches its terminal state
+    emitted to system_log when a runtime candidate reaches its terminal state
     (success: latency_ms set, error none; failure: error set). The shape is the
     contract for downstream log analysers and external operators looking for
     "why did the cascade exhaust" signals. Errors are recorded verbatim — no
@@ -295,7 +295,7 @@ let log_cascade_attempt_terminal ~model_id ~model_label ~latency_ms ~error =
   in
   let summary =
     Printf.sprintf
-      "cascade candidate terminal: model=%s outcome=%s latency_ms=%s"
+      "runtime candidate terminal: model=%s outcome=%s latency_ms=%s"
       public_runtime_model_label outcome
       (match latency_ms with Some n -> string_of_int n | None -> "n/a")
   in

--- a/lib/keeper/keeper_observation.mli
+++ b/lib/keeper/keeper_observation.mli
@@ -1,13 +1,13 @@
-(** Keeper_observation — cascade observation, metrics
-    capture, and a single-actor cascade-counter store.
+(** Keeper_observation — runtime observation, metrics
+    capture, and a single-actor runtime-counter store.
 
     The .ml splits into two concerns:
-    - {b Cascade observation}: the {!cascade_observation}
+    - {b Runtime observation}: the {!runtime_observation}
       record + companion attempt / fallback events,
       built per-turn in {!Keeper_turn_driver} via the
-      {!cascade_metrics_for_candidates} +
-      {!cascade_observation_with_metrics} pair.
-    - {b Cascade audit actor}: a single-fiber consumer
+      {!runtime_metrics_for_candidates} +
+      {!runtime_observation_with_metrics} pair.
+    - {b Runtime audit actor}: a single-fiber consumer
       ({!start_actor_if_needed}) that drains an
       [Eio.Stream] of {!record_cascade} /
       {!record_fallback_event} requests so concurrent
@@ -15,34 +15,34 @@
       maps.
 
     Dotted callers ({!Keeper_observation.X}) and the
-    cascade-include consumer rely on the surface pinned here.
+    runtime-include consumer rely on the surface pinned here.
 
     Internal helpers stay private at this boundary
-    ([cascade_attempt] / [cascade_fallback_event] type
-    bodies (exposed as part of {!cascade_observation}'s
+    ([runtime_attempt] / [runtime_fallback_event] type
+    bodies (exposed as part of {!runtime_observation}'s
     [attempts] / [fallback_events] fields with their full
     record shape),
-    [cascade_counter] type, [StringMap],
-    [cascade_max_keys], [create_cascade_counter],
-    [cascade_eviction] type, [find_cascade_eviction_candidate],
+    [runtime_counter] type, [StringMap],
+    [cascade_max_keys], [create_runtime_counter],
+    [runtime_eviction] type, [find_runtime_eviction_candidate],
     [display_provider_name_of_config], [strip_latest_suffix],
-    [cascade_observation_of_candidates],
-    [cascade_attempt_to_json], [cascade_fallback_event_to_json],
+    [runtime_observation_of_candidates],
+    [runtime_attempt_to_json], [runtime_fallback_event_to_json],
     [update_first_attempt_if], [record_attempt_start],
     [ensure_terminal_attempt],
-    [cascade_observation_to_json], [get_cascade_audit_store],
-    [cascade_outcome_to_string],
+    [runtime_observation_to_json], [get_cascade_audit_store],
+    [runtime_outcome_to_string],
     [top_level_reason_of_observation],
     [keeper_name_to_json], [cascade_audit_json],
     [record_cascade_audit], [increment_counter],
     [distribution_json], [attempt_model_display],
     [msg], [state] types, the [stream] queue,
     [handle_record], [handle_get_metrics], [run_actor],
-    [cascade_metrics_json]). *)
+    [runtime_metrics_json]). *)
 
-(** {1 Cascade observation types} *)
+(** {1 Runtime observation types} *)
 
-type cascade_attempt = {
+type runtime_attempt = {
   attempt_index : int;
   model_id : string;
   model_label : string option;
@@ -50,7 +50,7 @@ type cascade_attempt = {
   error : string option;
 }
 
-type cascade_fallback_event = {
+type runtime_fallback_event = {
   from_model_id : string;
   from_model_label : string option;
   to_model_id : string;
@@ -58,8 +58,8 @@ type cascade_fallback_event = {
   reason : string;
 }
 
-type cascade_observation = {
-  cascade_name : string;
+type runtime_observation = {
+  runtime_id : string;
   strategy : string option;
   configured_labels : string list;
   candidate_models : string list;
@@ -69,15 +69,15 @@ type cascade_observation = {
   selected_index : int option;
   fallback_hops : int option;
   fallback_applied : bool;
-  attempts : cascade_attempt list;
-  fallback_events : cascade_fallback_event list;
+  attempts : runtime_attempt list;
+  fallback_events : runtime_fallback_event list;
   attempt_details_available : bool;
   attempt_details_source : string;
   oas_internal_cascade_allowed : bool;
 }
-(** Per-turn cascade execution snapshot.  [attempts] is
+(** Per-turn runtime execution snapshot.  [attempts] is
     in chronological order (the internal capture stores
-    it reversed and {!cascade_observation_with_metrics}
+    it reversed and {!runtime_observation_with_metrics}
     flips it on materialise).  [attempt_details_source]
     distinguishes the capture path (the canonical
     [oas_metrics_callbacks] tag vs legacy fallbacks) so
@@ -89,7 +89,7 @@ type cascade_observation = {
 val provider_name_of_config :
   Llm_provider.Provider_config.t -> string
 (** Canonical provider slug from a config. Free-form string used as
-    the cascade counter key; the function does not enumerate
+    the runtime counter key; the function does not enumerate
     specific providers. *)
 
 val model_label_of_config :
@@ -99,20 +99,20 @@ val model_label_of_config :
     tests and callers; current public attempt/fallback projections use
     runtime-lane labels instead. *)
 
-(** {1 Cascade metrics capture} *)
+(** {1 Runtime metrics capture} *)
 
-type cascade_metrics_capture
+type runtime_metrics_capture
 (** Mutable accumulator threaded through OAS's per-call
     metrics sink to record per-attempt latency / errors
     and per-fallback events.  Held abstract because
     callers do not pattern-match on the internal
     counter / list state — they construct one via
-    {!cascade_metrics_for_candidates}, hand it to OAS
+    {!runtime_metrics_for_candidates}, hand it to OAS
     through a direct [Llm_provider.Metrics.t] record, then materialise
-    a {!cascade_observation} via
-    {!cascade_observation_with_metrics}. *)
+    a {!runtime_observation} via
+    {!runtime_observation_with_metrics}. *)
 
-val cascade_attempt_terminal_event_json :
+val runtime_attempt_terminal_event_json :
   ?slot_release_at_phase:string ->
   ?productive_phase_elapsed_ms:int ->
   ?retry_phase_elapsed_ms:int ->
@@ -128,24 +128,24 @@ val cascade_attempt_terminal_event_json :
     `error_message`, `slot_release_at_phase`,
     `productive_phase_elapsed_ms`, `retry_phase_elapsed_ms`) is locked
     against silent drift; downstream operators grep on these field names
-    when tracing why a cascade exhausted or why a keeper released its turn
+    when tracing why a runtime exhausted or why a keeper released its turn
     slot instead of scheduling another degraded retry. *)
 
 val record_attempt_terminal :
-  cascade_metrics_capture ->
+  runtime_metrics_capture ->
   model_id:string ->
   latency_ms:int option ->
   error:string option ->
   unit
 (** Records one terminal provider attempt in [capture]. This is for
-    named-cascade runners that receive provider-attempt completion
+    named-runtime runners that receive provider-attempt completion
     directly but cannot thread OAS's per-call metrics sink through the
     provider invocation path. *)
 
-val cascade_metrics_for_candidates :
+val runtime_metrics_for_candidates :
   candidate_count:int ->
   unit ->
-  cascade_metrics_capture * Llm_provider.Metrics.t
+  runtime_metrics_capture * Llm_provider.Metrics.t
 (** Builds the [(capture, metrics)] pair the per-call
     metrics path consumes.  Wires
     [Llm_metric_bridge.emit_request_latency] and
@@ -154,17 +154,17 @@ val cascade_metrics_for_candidates :
     turns (the per-call sink takes precedence over the
     global [Llm_metric_bridge] when both are wired). *)
 
-val cascade_observation_with_metrics :
-  cascade_name:string ->
+val runtime_observation_with_metrics :
+  runtime_id:string ->
   ?strategy:string ->
   configured_labels:string list ->
   candidate_count:int ->
   selected_model_raw:string option ->
-  capture:cascade_metrics_capture ->
+  capture:runtime_metrics_capture ->
   ?oas_internal_cascade_allowed:bool ->
   unit ->
-  cascade_observation
-(** Materialises a {!cascade_observation} from a finished
+  runtime_observation
+(** Materialises a {!runtime_observation} from a finished
     capture.  [attempts] / [fallback_events] are flipped
     into chronological order;
     [attempt_details_source] is set to
@@ -174,7 +174,7 @@ val cascade_observation_with_metrics :
 (** {1 Fallback recorder} *)
 
 val record_fallback_event :
-  cascade_metrics_capture ->
+  runtime_metrics_capture ->
   from_model:string ->
   to_model:string ->
   reason:string ->
@@ -183,7 +183,7 @@ val record_fallback_event :
     historical field names but records runtime-lane labels rather than
     concrete provider/model identities. *)
 
-(** {1 Cascade audit actor} *)
+(** {1 Runtime audit actor} *)
 
 val start_actor_if_needed : sw:Eio.Switch.t -> unit
 (** Spawns the single audit-actor fiber under [sw] if it
@@ -193,34 +193,34 @@ val start_actor_if_needed : sw:Eio.Switch.t -> unit
 
 val record_cascade :
   ?keeper_name:string ->
-  observation:cascade_observation option ->
-  cascade_name:string ->
+  observation:runtime_observation option ->
+  runtime_id:string ->
   outcome:[ `Success | `Failure | `Rejected ] ->
   unit ->
   unit
-(** Posts a record-cascade message onto the audit stream.
+(** Posts a record-runtime message onto the audit stream.
     The actor consumes it asynchronously, bumping the
-    per-cascade counters and persisting the audit JSON
+    per-runtime counters and persisting the audit JSON
     via {!record_cascade_audit}.  Non-blocking — the
     caller does not wait for the actor to drain. *)
 
-val reset_cascade_counters_for_test : unit -> unit
+val reset_runtime_counters_for_test : unit -> unit
 (** Posts a reset message onto the stream.  Test-only
     isolator; no-op outside the actor's lifetime. *)
 
-(** {1 JSON projections (cascade-include consumers)} *)
+(** {1 JSON projections (runtime-include consumers)} *)
 
-val cascade_metrics_json : unit -> Yojson.Safe.t
+val runtime_metrics_json : unit -> Yojson.Safe.t
 (** Posts a [Get_metrics_json] request to the actor and
     waits on the resulting promise.  Returns the
-    aggregated cascade-counter JSON snapshot for the
+    aggregated runtime-counter JSON snapshot for the
     operator dashboard.  Pinned because
     [lib/oas_worker.mli] re-exposes it via the
-    [include Keeper_observation] cascade. *)
+    [include Keeper_observation] runtime. *)
 
-val cascade_observation_to_json :
-  cascade_observation -> Yojson.Safe.t
-(** Wire encoder for {!cascade_observation} — flattens
+val runtime_observation_to_json :
+  runtime_observation -> Yojson.Safe.t
+(** Wire encoder for {!runtime_observation} — flattens
     [attempts] / [fallback_events] / outcome metadata
-    into a single [`Assoc].  Pinned because the cascade-
+    into a single [`Assoc].  Pinned because the runtime-
     include consumer ([oas_worker.mli]) re-exposes it. *)

--- a/lib/keeper/keeper_observation.mli
+++ b/lib/keeper/keeper_observation.mli
@@ -123,7 +123,7 @@ val cascade_attempt_terminal_event_json :
   unit ->
   Yojson.Safe.t
 (** Builds the structured JSON payload emitted to system_log for one
-    cascade candidate's terminal state. Exposed for tests so the shape
+    runtime candidate's terminal state. Exposed for tests so the shape
     contract (`event`, `model_id`, `model_label`, `latency_ms`, `outcome`,
     `error_message`, `slot_release_at_phase`,
     `productive_phase_elapsed_ms`, `retry_phase_elapsed_ms`) is locked

--- a/lib/keeper/keeper_preflight_health_tracker.mli
+++ b/lib/keeper/keeper_preflight_health_tracker.mli
@@ -22,7 +22,7 @@
     {1 References}
 
     - MASC/OAS Error-Warn Reduction Goal — 2026-05-18 §P3 (provider
-      cascade exhaustion).
+      runtime exhaustion).
     - System log slice 2026-05-18, last 30min:
       [strict_tool_candidates: preflight skipped 1 unhealthy] x35,
       [provider_k-coding-with-spark: preflight skipped 1 unhealthy] x12. *)

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -11,36 +11,36 @@ include Keeper_registry_setup
 
 
 let mark_turn_provider_attempt_started ~base_path name =
-  let set_cascade_state cascade_state =
-    set_turn_cascade_state
+  let set_runtime_state runtime_state =
+    set_turn_runtime_state
       ~base_path
       name
-      (Packed cascade_state : packed_cascade_state)
+      (Packed runtime_state : packed_runtime_state)
   in
   match get ~base_path name with
   | None | Some { current_turn_observation = None; _ } -> ()
   | Some { current_turn_observation = Some obs; _ } ->
-    (match obs.cascade_state with
-     | Packed Cascade_idle ->
+    (match obs.runtime_state with
+     | Packed Runtime_idle ->
        set_turn_decision_stage
          ~base_path
          name
          Decision_active_tool_policy_selected;
-       set_cascade_state Cascade_selecting;
-       set_cascade_state Cascade_trying
-     | Packed Cascade_selecting ->
+       set_runtime_state Runtime_selecting;
+       set_runtime_state Runtime_trying
+     | Packed Runtime_selecting ->
        set_turn_decision_stage
          ~base_path
          name
          Decision_active_tool_policy_selected;
-       set_cascade_state Cascade_trying
-     | Packed Cascade_trying ->
+       set_runtime_state Runtime_trying
+     | Packed Runtime_trying ->
        set_turn_decision_stage
          ~base_path
          name
          Decision_active_tool_policy_selected
-     | Packed Cascade_done
-     | Packed Cascade_exhausted ->
+     | Packed Runtime_done
+     | Packed Runtime_exhausted ->
        Log.Keeper.warn
          "registry: ignoring provider-attempt start after terminal cascade state \
           name=%s base_path=%s"
@@ -112,15 +112,15 @@ let prepare_turn_retry_after_compaction ~base_path name =
   let now = Time_compat.now () in
   update_entry_if_registered ~base_path name (fun e ->
     update_current_turn e (fun obs ->
-      validate_cascade_transition
-        ~from:obs.cascade_state
-        ~to_:(Packed Cascade_idle : packed_cascade_state);
+      validate_runtime_transition
+        ~from:obs.runtime_state
+        ~to_:(Packed Runtime_idle : packed_runtime_state);
       validate_turn_phase_transition ~from:obs.turn_phase ~to_:(Packed Turn_prompting);
       changed := true;
       { (stamp_turn_progress ~now ~event_kind:"retry_after_compaction" obs) with
         turn_phase = Packed Turn_prompting
       ; decision_stage = Packed Decision_guard_ok
-      ; cascade_state = Packed Cascade_idle
+      ; runtime_state = Packed Runtime_idle
       ; selected_model = None
       }));
   if !changed then broadcast_composite_changed ~name ~ts_unix:now
@@ -179,7 +179,7 @@ let mark_turn_finished ~base_path name =
           ; ct_started_at = obs.started_at
           ; ct_ended_at = ended_at
           ; ct_decision_stage = obs.decision_stage
-          ; ct_cascade_state = obs.cascade_state
+          ; ct_runtime_state = obs.runtime_state
           ; ct_selected_model = obs.selected_model
           }
       | None -> e.last_completed_turn (* no live turn → preserve previous *)

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -18,7 +18,7 @@ open Keeper_types_profile
     [Keeper_registry.packed_turn_phase] etc. unchanged. *)
 include module type of Keeper_registry_types
 
-(** [validate_turn_phase_transition] and [validate_cascade_transition]
+(** [validate_turn_phase_transition] and [validate_runtime_transition]
     stay in Keeper_registry because their implementations depend on
     [Keeper_fsm_guard_runtime], not a pure type-level dependency. *)
 val validate_turn_phase_transition
@@ -26,9 +26,9 @@ val validate_turn_phase_transition
   -> to_:packed_turn_phase
   -> unit
 
-val validate_cascade_transition
-  :  from:packed_cascade_state
-  -> to_:packed_cascade_state
+val validate_runtime_transition
+  :  from:packed_runtime_state
+  -> to_:packed_runtime_state
   -> unit
 
 
@@ -118,15 +118,15 @@ val record_turn_progress :
     The Agent SDK [run_loop] iterates N SDK turns inside a single MASC
     keeper-turn window. Each SDK turn fires [before_turn_params] which
     leads to [prepare_agent_setup] writing
-    [Cascade_selecting]/[Decision_tool_policy_selected]/[Turn_prompting].
+    [Runtime_selecting]/[Decision_tool_policy_selected]/[Turn_prompting].
     Without this boundary signal, the second-and-later SDK turn writes
     transition from the previous SDK turn's terminal phase
-    ([Turn_finalizing] after [Cascade_done]/[Cascade_exhausted]), which
+    ([Turn_finalizing] after [Runtime_done]/[Runtime_exhausted]), which
     [validate_turn_phase_transition] rejects with
     [Turn_phase_transition_violation].
 
     This function resets the in-turn FSM fields ([turn_phase],
-    [cascade_state], [decision_stage]) on the existing observation, the
+    [runtime_state], [decision_stage]) on the existing observation, the
     same way [mark_turn_started] bypasses the validator with a fresh
     install. [turn_id], [started_at], [selected_model], [measurement],
     [measurement_bind_count], and progress timestamp are preserved across
@@ -151,34 +151,34 @@ val set_turn_decision_stage :
   base_path:string -> string -> decision_stage_active -> unit
 
 (** Advance the live turn's projected cascade state. No-op if idle.
-    Sets [turn_phase] to [Turn_executing] for [Cascade_trying] and to
+    Sets [turn_phase] to [Turn_executing] for [Runtime_trying] and to
     [Turn_finalizing] for terminal cascade states. *)
-val set_turn_cascade_state :
-  base_path:string -> string -> packed_cascade_state -> unit
+val set_turn_runtime_state :
+  base_path:string -> string -> packed_runtime_state -> unit
 
-(** Mark cascade exhaustion on the live turn.
+(** Mark runtime exhaustion on the live turn.
 
     When provider selection fails before the tool-disclosure hook runs, the
-    live cascade axis can still be [Cascade_idle]. This helper materializes the
+    live runtime axis can still be [Runtime_idle]. This helper materializes the
     spec-valid pre-terminal path ([idle -> selecting -> trying -> exhausted])
-    instead of allowing callers to jump directly to [Cascade_exhausted]. No-op
+    instead of allowing callers to jump directly to [Runtime_exhausted]. No-op
     when no turn is active. *)
-val mark_turn_cascade_exhausted : base_path:string -> string -> unit
+val mark_turn_runtime_exhausted : base_path:string -> string -> unit
 
 (** Mark cascade success on the live turn.
 
     When provider execution returns before the tool-disclosure hook advances the
-    registry projection, the live cascade axis can still be [Cascade_idle]. This
+    registry projection, the live runtime axis can still be [Runtime_idle]. This
     helper materializes the spec-valid pre-terminal path ([idle -> selecting ->
     trying -> done]) instead of allowing callers to jump directly to
-    [Cascade_done]. No-op when no turn is active. *)
-val mark_turn_cascade_done : base_path:string -> string -> unit
+    [Runtime_done]. No-op when no turn is active. *)
+val mark_turn_runtime_done : base_path:string -> string -> unit
 
 (** Mark that the live turn has entered a provider attempt.
 
     This materializes the registry-side projection that corresponds to
-    [Keeper_turn_fsm.Streaming]: [Cascade_idle] advances through
-    [Cascade_selecting] into [Cascade_trying], and [turn_phase] follows to
+    [Keeper_turn_fsm.Streaming]: [Runtime_idle] advances through
+    [Runtime_selecting] into [Runtime_trying], and [turn_phase] follows to
     [Turn_executing]. No-op when no turn is active or the cascade is already
     trying/terminal. *)
 val mark_turn_provider_attempt_started : base_path:string -> string -> unit
@@ -210,7 +210,7 @@ val set_turn_selected_model :
 (** Reset a live turn into the post-compaction retry posture used by
     overflow recovery. Preserves the bound measurement, but clears the
     previous cascade attempt and selected model so the next retry starts
-    from [Prompting + Guard_ok + Cascade_idle]. *)
+    from [Prompting + Guard_ok + Runtime_idle]. *)
 val prepare_turn_retry_after_compaction :
   base_path:string -> string -> unit
 

--- a/lib/keeper/keeper_registry_fsm_validators.ml
+++ b/lib/keeper/keeper_registry_fsm_validators.ml
@@ -12,24 +12,24 @@
 
 open Keeper_registry_types
 
-let cascade_transition ~from ~to_ =
+let runtime_transition ~from ~to_ =
   (* Wrapped in [Keeper_fsm_guard_runtime.wrap_unit] for symmetry with
      [turn_phase_transition] and the setters
-     ([set_turn_cascade_state] / [set_turn_phase]): a forbidden pair
+     ([set_turn_runtime_state] / [set_turn_phase]): a forbidden pair
      reached via this validator bumps [metric_fsm_guard_violation]
-     (action=cascade_transition, stage=guard) before re-raising the typed
-     [Cascade_transition_violation] with its backtrace intact. Without
+     (action=runtime_transition, stage=guard) before re-raising the typed
+     [Runtime_transition_violation] with its backtrace intact. Without
      this wrap, a direct call to this validator on a forbidden pair was
      uninstrumented (RFC-0072 Phase 5 left it as a thin shim). *)
   Keeper_fsm_guard_runtime.wrap_unit
-    ~action:"cascade_transition"
+    ~action:"runtime_transition"
     ~stage:"guard"
     (fun () ->
-       match resolve_cascade_transition ~from ~target:to_ with
+       match resolve_runtime_transition ~from ~target:to_ with
        | Resolved_idempotent | Resolved_transition _ -> ()
        | Resolved_violation violation ->
-         raise_cascade_transition_violation
-           ~where:"validate_cascade_transition"
+         raise_runtime_transition_violation
+           ~where:"validate_runtime_transition"
            ~from
            ~to_
            ~violation)

--- a/lib/keeper/keeper_registry_fsm_validators.mli
+++ b/lib/keeper/keeper_registry_fsm_validators.mli
@@ -6,13 +6,13 @@
 
 open Keeper_registry_types
 
-(** Validate a cascade_state cross-state transition.
+(** Validate a runtime_state cross-state transition.
     Idempotent self-loops are accepted; the 7 spec-forbidden pairs raise
-    [Cascade_transition_violation] with the typed
-    [cascade_transition_spec_violation] payload. Counter:
-    [metric_fsm_guard_violation] (action=cascade_transition, stage=guard). *)
-val cascade_transition :
-  from:packed_cascade_state -> to_:packed_cascade_state -> unit
+    [Runtime_transition_violation] with the typed
+    [runtime_transition_spec_violation] payload. Counter:
+    [metric_fsm_guard_violation] (action=runtime_transition, stage=guard). *)
+val runtime_transition :
+  from:packed_runtime_state -> to_:packed_runtime_state -> unit
 
 (** Validate a turn_phase cross-state transition.
     Idempotent self-loops are accepted; the 19 spec-forbidden pairs raise

--- a/lib/keeper/keeper_registry_setup.ml
+++ b/lib/keeper/keeper_registry_setup.ml
@@ -392,7 +392,7 @@ let mark_turn_started ~base_path name =
       ; last_progress_kind = Some "turn_started"
       ; turn_phase = Packed Turn_prompting
       ; decision_stage = Packed Decision_undecided
-      ; cascade_state = Packed Cascade_idle
+      ; runtime_state = Packed Runtime_idle
       ; measurement = None
       ; measurement_bind_count = 0
       ; selected_model = None
@@ -422,7 +422,7 @@ let mark_sdk_turn_started ~base_path name =
     | Some obs ->
       if
         obs.turn_phase = Packed Turn_prompting
-        && obs.cascade_state = Packed Cascade_idle
+        && obs.runtime_state = Packed Runtime_idle
         && obs.decision_stage = Packed Decision_undecided
       then e
       else (
@@ -430,7 +430,7 @@ let mark_sdk_turn_started ~base_path name =
         let new_obs =
           { (stamp_turn_progress ~now ~event_kind:"sdk_turn_started" obs) with
             turn_phase = Packed Turn_prompting
-          ; cascade_state = Packed Cascade_idle
+          ; runtime_state = Packed Runtime_idle
           ; decision_stage = Packed Decision_undecided
           }
         in
@@ -460,9 +460,9 @@ let mark_turn_measurement ~base_path name =
   if !changed then broadcast_composite_changed ~name ~ts_unix:now
 ;;
 
-(* RFC-0072 Phase 3 + Phase 5: collapse 25-pair matrix onto [resolve_cascade_transition] (PR #14903) and raise the typed [Cascade_transition_violation] (Phase 5) on the 7 forbidden pairs instead of a ... *)
-(* FSM transition validators (validate_cascade_transition / validate_turn_phase_transition) moved to Keeper_registry_fsm_validators. *)
-let validate_cascade_transition = Keeper_registry_fsm_validators.cascade_transition
+(* RFC-0072 Phase 3 + Phase 5: collapse 25-pair matrix onto [resolve_runtime_transition] (PR #14903) and raise the typed [Runtime_transition_violation] (Phase 5) on the 7 forbidden pairs instead of a ... *)
+(* FSM transition validators (validate_runtime_transition / validate_turn_phase_transition) moved to Keeper_registry_fsm_validators. *)
+let validate_runtime_transition = Keeper_registry_fsm_validators.runtime_transition
 let validate_turn_phase_transition = Keeper_registry_fsm_validators.turn_phase_transition
 
 let set_turn_decision_stage ~base_path name (decision_stage : decision_stage_active) =
@@ -482,103 +482,103 @@ let set_turn_decision_stage ~base_path name (decision_stage : decision_stage_act
   if !changed then broadcast_composite_changed ~name ~ts_unix:now
 ;;
 
-let set_turn_cascade_state ~base_path name (cascade_state : packed_cascade_state) =
-(* RFC-0072 Phase 2: dispatch via [resolve_cascade_transition] (PR #14903) instead of the standalone [validate_cascade_transition].  Behavior deltas vs the pre-RFC-0072 path:  - Idempotent self-loop (... *)
+let set_turn_runtime_state ~base_path name (runtime_state : packed_runtime_state) =
+(* RFC-0072 Phase 2: dispatch via [resolve_runtime_transition] (PR #14903) instead of the standalone [validate_runtime_transition].  Behavior deltas vs the pre-RFC-0072 path:  - Idempotent self-loop (... *)
   let changed = ref false in
   let now = Time_compat.now () in
   update_entry_if_registered ~base_path name (fun e ->
     update_current_turn e (fun obs ->
-      let new_turn_phase = turn_phase_of_cascade_state cascade_state in
-      match resolve_cascade_transition ~from:obs.cascade_state ~target:cascade_state with
+      let new_turn_phase = turn_phase_of_runtime_state runtime_state in
+      match resolve_runtime_transition ~from:obs.runtime_state ~target:runtime_state with
       | Resolved_idempotent -> obs
       | Resolved_transition _ ->
         validate_turn_phase_transition ~from:obs.turn_phase ~to_:new_turn_phase;
         changed := true;
-        { (stamp_turn_progress ~now ~event_kind:"cascade_state" obs) with
-          cascade_state
+        { (stamp_turn_progress ~now ~event_kind:"runtime_state" obs) with
+          runtime_state
         ; turn_phase = new_turn_phase
         }
       | Resolved_violation violation ->
         Keeper_fsm_guard_runtime.wrap_unit
-          ~action:"cascade_transition"
+          ~action:"runtime_transition"
           ~stage:"guard"
           (fun () ->
-             raise_cascade_transition_violation
-               ~where:"set_turn_cascade_state"
-               ~from:obs.cascade_state
-               ~to_:cascade_state
+             raise_runtime_transition_violation
+               ~where:"set_turn_runtime_state"
+               ~from:obs.runtime_state
+               ~to_:runtime_state
                ~violation);
         obs));
   if !changed then broadcast_composite_changed ~name ~ts_unix:now
 ;;
 
-let mark_turn_cascade_exhausted ~base_path name =
-  let set_cascade_state cascade_state =
-    set_turn_cascade_state
+let mark_turn_runtime_exhausted ~base_path name =
+  let set_runtime_state runtime_state =
+    set_turn_runtime_state
       ~base_path
       name
-      (Packed cascade_state : packed_cascade_state)
+      (Packed runtime_state : packed_runtime_state)
   in
   match get ~base_path name with
   | None | Some { current_turn_observation = None; _ } -> ()
   | Some { current_turn_observation = Some obs; _ } ->
-    (match obs.cascade_state with
-     | Packed Cascade_idle ->
+    (match obs.runtime_state with
+     | Packed Runtime_idle ->
        set_turn_decision_stage
          ~base_path
          name
          Decision_active_tool_policy_selected;
-       set_cascade_state Cascade_selecting;
-       set_cascade_state Cascade_trying;
-       set_cascade_state Cascade_exhausted
-     | Packed Cascade_selecting ->
+       set_runtime_state Runtime_selecting;
+       set_runtime_state Runtime_trying;
+       set_runtime_state Runtime_exhausted
+     | Packed Runtime_selecting ->
        set_turn_decision_stage
          ~base_path
          name
          Decision_active_tool_policy_selected;
-       set_cascade_state Cascade_trying;
-       set_cascade_state Cascade_exhausted
-     | Packed Cascade_trying -> set_cascade_state Cascade_exhausted
-     | Packed Cascade_exhausted -> set_cascade_state Cascade_exhausted
-     | Packed Cascade_done ->
+       set_runtime_state Runtime_trying;
+       set_runtime_state Runtime_exhausted
+     | Packed Runtime_trying -> set_runtime_state Runtime_exhausted
+     | Packed Runtime_exhausted -> set_runtime_state Runtime_exhausted
+     | Packed Runtime_done ->
 	       Log.Keeper.warn
-	         "registry: ignoring cascade exhaustion after Cascade_done name=%s \
+	         "registry: ignoring runtime exhaustion after Runtime_done name=%s \
 	          base_path=%s"
 	         name
          base_path)
 ;;
 
-let mark_turn_cascade_done ~base_path name =
-  let set_cascade_state cascade_state =
-    set_turn_cascade_state
+let mark_turn_runtime_done ~base_path name =
+  let set_runtime_state runtime_state =
+    set_turn_runtime_state
       ~base_path
       name
-      (Packed cascade_state : packed_cascade_state)
+      (Packed runtime_state : packed_runtime_state)
   in
   match get ~base_path name with
   | None | Some { current_turn_observation = None; _ } -> ()
   | Some { current_turn_observation = Some obs; _ } ->
-    (match obs.cascade_state with
-     | Packed Cascade_idle ->
+    (match obs.runtime_state with
+     | Packed Runtime_idle ->
        set_turn_decision_stage
          ~base_path
          name
          Decision_active_tool_policy_selected;
-       set_cascade_state Cascade_selecting;
-       set_cascade_state Cascade_trying;
-       set_cascade_state Cascade_done
-     | Packed Cascade_selecting ->
+       set_runtime_state Runtime_selecting;
+       set_runtime_state Runtime_trying;
+       set_runtime_state Runtime_done
+     | Packed Runtime_selecting ->
        set_turn_decision_stage
          ~base_path
          name
          Decision_active_tool_policy_selected;
-       set_cascade_state Cascade_trying;
-       set_cascade_state Cascade_done
-     | Packed Cascade_trying -> set_cascade_state Cascade_done
-     | Packed Cascade_done -> set_cascade_state Cascade_done
-     | Packed Cascade_exhausted ->
+       set_runtime_state Runtime_trying;
+       set_runtime_state Runtime_done
+     | Packed Runtime_trying -> set_runtime_state Runtime_done
+     | Packed Runtime_done -> set_runtime_state Runtime_done
+     | Packed Runtime_exhausted ->
        Log.Keeper.warn
-         "registry: ignoring cascade completion after Cascade_exhausted name=%s \
+         "registry: ignoring runtime completion after Runtime_exhausted name=%s \
           base_path=%s"
          name
          base_path)

--- a/lib/keeper/keeper_registry_types.ml
+++ b/lib/keeper/keeper_registry_types.ml
@@ -114,8 +114,8 @@ let completed_turn_outcome_of_observation (obs : turn_observation)
   =
   (* RFC-0206: the cascade selection FSM was removed; turn substantiveness is
      now read off the surviving [turn_phase] projection. Terminal
-     [Turn_finalizing] (the phase the deleted [turn_phase_of_cascade_state]
-     mapped [Cascade_done] onto) = substantive; every other phase = failed.
+     [Turn_finalizing] (the phase the deleted [turn_phase_of_runtime_state]
+     mapped [Runtime_done] onto) = substantive; every other phase = failed.
      Exhaustive match (no wildcard) so a new turn_phase or decision_stage
      variant fails the build rather than silently degrading to Turn_failed. *)
   match obs.decision_stage with

--- a/lib/keeper/keeper_registry_types.mli
+++ b/lib/keeper/keeper_registry_types.mli
@@ -182,7 +182,7 @@ val turn_phase_to_witness : turn_phase -> packed_turn_phase
 val packed_turn_phase_label : packed_turn_phase -> string
 
 (** RFC-0072 Phase 4: GADT-encoded turn_phase transitions, aligned with
-    [Cascade_transition].  Enumerates the 23 valid cross-state transitions
+    [Runtime_transition].  Enumerates the 23 valid cross-state transitions
     of the 7-variant [turn_phase] FSM.  The 19 forbidden pairs have no
     constructor and are therefore type-unrepresentable.  Idempotent
     self-loops are not represented (mutator-boundary no-ops). *)
@@ -258,7 +258,7 @@ exception
     }
 
 (** RFC-0072 Phase 4: resolve a (from, target) packed pair to one of three
-    outcomes.  Mirrors [resolve_cascade_transition]. *)
+    outcomes.  Mirrors [resolve_runtime_transition]. *)
 type turn_phase_resolve_outcome =
   | Resolved_turn_transition of Turn_phase_transition.packed
   | Resolved_turn_idempotent
@@ -319,7 +319,7 @@ val decision_stage_active_to_packed
   -> packed_decision_stage
 
 (** Diagnostic label using the constructor name (e.g.
-    ["Decision_guard_ok"]).  Used by [validate_cascade_transition] /
+    ["Decision_guard_ok"]).  Used by [validate_runtime_transition] /
     [validate_turn_phase_transition] for [Invalid_argument] messages. *)
 val packed_decision_stage_label : packed_decision_stage -> string
 

--- a/lib/keeper/keeper_rollover.ml
+++ b/lib/keeper/keeper_rollover.ml
@@ -70,7 +70,7 @@ type handoff_rollover = {
 let blocker_class_indicates_overflow (klass : blocker_class) : bool =
   match klass with
   | Sdk_token_budget_exceeded -> true
-  | Cascade_exhausted _
+  | Runtime_exhausted _
   | Capacity_backpressure
   | Ambiguous_post_commit_timeout
   | Ambiguous_post_commit_failure

--- a/lib/keeper/keeper_routine_allowlist.mli
+++ b/lib/keeper/keeper_routine_allowlist.mli
@@ -14,7 +14,7 @@
     destructive tool/op substring gate, but hard blockers still win, so:
 
     - Critical risk still gates
-    - runtime_auto_approval_blocked (cascade_exhausted etc.) still gates
+    - runtime_auto_approval_blocked (runtime_exhausted etc.) still gates
     - shell or git tool names still gate unless an exact routine rule
       matches the tool plus op/action
     - High-risk code write/edit tools auto-approve only when a keeper has a

--- a/lib/keeper/keeper_run_context.ml
+++ b/lib/keeper/keeper_run_context.ml
@@ -50,23 +50,23 @@ let prepare_run_context
   let receipt_started_at = Masc_domain.now_iso () in
   let meta = Keeper_agent_tool_surface.sync_current_task_id_from_backlog ~config meta in
   let profile_defaults = Keeper_types_profile.load_keeper_profile_defaults meta.name in
-  (* 0. Resolve inference parameters via Cascade_inference *)
+  (* 0. Resolve inference parameters via Runtime_inference *)
   let temperature =
     match temperature with
     | Some t -> t
     | None ->
-      Cascade_inference.resolve_temperature
+      Runtime_inference.resolve_temperature
         ~cascade_name ~fallback:(fun () -> 0.3)
   in
   let max_tokens =
     match max_tokens with
     | Some t ->
-      Cascade_inference.cap_max_tokens_to_cascade_ceiling
+      Runtime_inference.cap_max_tokens_to_cascade_ceiling
         ~cascade_name
         ~source:"caller_override"
         t
     | None ->
-      Cascade_inference.resolve_max_tokens
+      Runtime_inference.resolve_max_tokens
         ~cascade_name
           (* 8192 allows complex multi-tool reasoning per turn.
            Cloudflare tunnel 100s is no longer a constraint with

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -293,7 +293,7 @@ let assemble_hooks
                   else None
                 in
                 let cascade_seed =
-                  Cascade_inference.for_cascade ~name:cascade_name_string
+                  Runtime_inference.for_cascade ~name:cascade_name_string
                 in
                 let current_budget =
                   match cascade_seed.thinking_budget with

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -254,8 +254,8 @@ let assemble_hooks
                 let hook_t0 = Time_compat.now () in
                 acc.current_turn <- turn;
                 (* RFC-0045: signal an SDK-turn boundary so the in-turn FSM
-                  fields ([turn_phase], [cascade_state], [decision_stage])
-                  are reset before the hook writes [Cascade_selecting] /
+                  fields ([turn_phase], [runtime_state], [decision_stage])
+                  are reset before the hook writes [Runtime_selecting] /
                   [Decision_tool_policy_selected] / [Turn_prompting] below.
                   The MASC keeper-turn boundary ([mark_turn_started]) only
                   fires once per [Agent_sdk.run_loop] call; every additional
@@ -649,11 +649,11 @@ let assemble_hooks
                    ~base_path:config.base_path
                    meta.name
                    Keeper_registry.Decision_active_tool_policy_selected;
-                 Keeper_registry.set_turn_cascade_state
+                 Keeper_registry.set_turn_runtime_state
                    ~base_path:config.base_path
                    meta.name
-                   (Keeper_registry.Packed Keeper_registry.Cascade_selecting
-                    : Keeper_registry.packed_cascade_state);
+                   (Keeper_registry.Packed Keeper_registry.Runtime_selecting
+                    : Keeper_registry.packed_runtime_state);
                  (* Spec atomic group: SelectToolPolicy(idle->selecting)
                    is immediately followed by CascadeTrying(selecting->
                    trying).  Both transitions are materialised inside
@@ -661,20 +661,20 @@ let assemble_hooks
                    [SelectingRequiresToolPolicy] requires
                    [decision_stage = Decision_tool_policy_selected],
                    which is only set at this site.  Pre-PR #14153 the
-                   Cascade_trying marking lived inside
+                   Runtime_trying marking lived inside
                    [Keeper_unified_turn.retry_loop] (line 1138 era),
                    producing an [idle -> trying] jump that bypassed
                    selecting; the move here closes that gap by keeping
                    the two transitions adjacent.  On retry attempts
-                   the prior cascade state is [Cascade_trying]; the
+                   the prior cascade state is [Runtime_trying]; the
                    re-entry sequence becomes [trying -> selecting ->
                    trying] which is admitted by
-                   [validate_cascade_transition]. *)
-                 Keeper_registry.set_turn_cascade_state
+                   [validate_runtime_transition]. *)
+                 Keeper_registry.set_turn_runtime_state
                    ~base_path:config.base_path
                    meta.name
-                   (Keeper_registry.Packed Keeper_registry.Cascade_trying
-                    : Keeper_registry.packed_cascade_state);
+                   (Keeper_registry.Packed Keeper_registry.Runtime_trying
+                    : Keeper_registry.packed_runtime_state);
                  let disclosure_json =
                    `Assoc
                      [ "ts_unix", `Float now

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -602,7 +602,7 @@ let prepare_agent_setup
         | Some sw, Some net ->
           let rerank_cascade = Keeper_config.keeper_llm_rerank_cascade () in
           (match
-             Cascade_catalog_runtime.resolve_named_providers_strict
+             Runtime_catalog.resolve_named_providers_strict
                ~sw
                ~net
                ~cascade_name:rerank_cascade

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -199,7 +199,7 @@ let ensure_keeper_meta config name =
       effective_declarative_cascade_name defaults meta
     in
     match
-      Cascade_catalog_runtime.resolve_declared_name
+      Runtime_catalog.resolve_declared_name
         ~raw_name:target_cascade_name
         ()
     with

--- a/lib/keeper/keeper_runtime_manifest.ml
+++ b/lib/keeper/keeper_runtime_manifest.ml
@@ -189,9 +189,9 @@ let clock_lane_of_event = function
   | Receipt_appended
   | Turn_finished ->
     "keeper"
-  | Cascade_routed
+  | Runtime_routed
   | Provider_lane_resolved ->
-    "masc_policy_cascade"
+    "masc_policy_runtime"
   | Provider_attempt_started
   | Provider_attempt_finished ->
     "provider"

--- a/lib/keeper/keeper_runtime_manifest_housekeeping.mli
+++ b/lib/keeper/keeper_runtime_manifest_housekeeping.mli
@@ -2,7 +2,7 @@ type event_kind =
   Keeper_runtime_manifest_types.event_kind =
     Turn_started
   | Phase_gate_decided
-  | Cascade_routed
+  | Runtime_routed
   | Pre_dispatch_blocked
   | Tool_surface_selected
   | Provider_lane_resolved

--- a/lib/keeper/keeper_runtime_manifest_types.ml
+++ b/lib/keeper/keeper_runtime_manifest_types.ml
@@ -8,7 +8,7 @@
 type event_kind =
   | Turn_started
   | Phase_gate_decided
-  | Cascade_routed
+  | Runtime_routed
   | Pre_dispatch_blocked
   | Tool_surface_selected
   | Provider_lane_resolved
@@ -31,7 +31,7 @@ let all_event_kinds =
   [
     Turn_started;
     Phase_gate_decided;
-    Cascade_routed;
+    Runtime_routed;
     Pre_dispatch_blocked;
     Tool_surface_selected;
     Provider_lane_resolved;
@@ -54,7 +54,7 @@ let all_event_kinds =
 let event_kind_to_string = function
   | Turn_started -> "turn_started"
   | Phase_gate_decided -> "phase_gate_decided"
-  | Cascade_routed -> "cascade_routed"
+  | Runtime_routed -> "runtime_routed"
   | Pre_dispatch_blocked -> "pre_dispatch_blocked"
   | Tool_surface_selected -> "tool_surface_selected"
   | Provider_lane_resolved -> "provider_lane_resolved"
@@ -76,7 +76,7 @@ let event_kind_to_string = function
 let event_kind_of_string = function
   | "turn_started" -> Some Turn_started
   | "phase_gate_decided" -> Some Phase_gate_decided
-  | "cascade_routed" -> Some Cascade_routed
+  | "runtime_routed" -> Some Runtime_routed
   | "pre_dispatch_blocked" -> Some Pre_dispatch_blocked
   | "tool_surface_selected" -> Some Tool_surface_selected
   | "provider_lane_resolved" -> Some Provider_lane_resolved

--- a/lib/keeper/keeper_runtime_manifest_types.mli
+++ b/lib/keeper/keeper_runtime_manifest_types.mli
@@ -1,7 +1,7 @@
 type event_kind =
     Turn_started
   | Phase_gate_decided
-  | Cascade_routed
+  | Runtime_routed
   | Pre_dispatch_blocked
   | Tool_surface_selected
   | Provider_lane_resolved

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -76,7 +76,7 @@ let disposition_of_runtime_blocker_class raw_blocker_class =
       Keeper_turn_disposition.Post_commit_ambiguous
   | "sdk_input_required" ->
       Keeper_turn_disposition.Input_required
-  | ("cascade_exhausted" | "no_tool_capable_provider"
+  | ("runtime_exhausted" | "no_tool_capable_provider"
      | "provider_runtime_error") as cls ->
       Keeper_turn_disposition.Provider_error
         (Keeper_turn_terminal_code.Provider_runtime_error cls)
@@ -210,7 +210,7 @@ let disposition_of_snapshot ~pending_approval_count ~runtime_blocker_fields =
   else if continue_gate then ("Blocked", "waiting_human_decision")
   else
     match blocker_class, blocker_summary with
-    | Some "cascade_exhausted", _ -> ("Alert", "cascade_exhausted")
+    | Some "runtime_exhausted", _ -> ("Alert", "runtime_exhausted")
     | Some "completion_contract_violation", _ -> ("Alert", "fsm_invariant")
     | _, Some summary
       when String_util.contains_substring_ci summary "sandbox" ->
@@ -241,7 +241,7 @@ let display_disposition_of_operator ~operator_disposition
   | "pause_human" -> ("Blocked", reason "needs_human_attention")
   | "fail_open_next_cascade" -> ("Blocked", reason "degraded_retry")
   | "user_cancelled" -> ("Blocked", reason "cancelled")
-  | "alert_exhausted" -> ("Alert", reason "cascade_exhausted")
+  | "alert_exhausted" -> ("Alert", reason "runtime_exhausted")
   | "unknown" -> ("Alert", reason "unmapped_cascade_state")
   | _ -> ("Alert", reason "unmapped_operator_disposition")
 

--- a/lib/keeper/keeper_runtime_trust_timeline.ml
+++ b/lib/keeper/keeper_runtime_trust_timeline.ml
@@ -406,7 +406,7 @@ let blocker_timeline_event ?task_id ?(goal_ids = []) ?trace_id
            ~summary
            ~severity:
              (match blocker_class with
-              | "cascade_exhausted" | "completion_contract_violation" -> "bad"
+              | "runtime_exhausted" | "completion_contract_violation" -> "bad"
               | _ -> "warn")
            ())
   | None, Some summary

--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -698,7 +698,7 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                    match ctx.net with
                    | None -> false
                    | Some net ->
-                       (match Cascade_catalog_runtime.resolve_named_providers_strict
+                       (match Runtime_catalog.resolve_named_providers_strict
                                 ~sw:ctx.sw ~net ~cascade_name:(Keeper_meta_contract.runtime_id_of_meta meta) () with
                         | Error _ -> false
                         | Ok candidates ->
@@ -717,9 +717,9 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                              | Error _rejection -> false
                              | Ok healthy ->
                             healthy
-                            |> Cascade_runtime_candidate.of_provider_configs
+                            |> Runtime_candidate.of_provider_configs
                             |> List.exists
-                                 Cascade_runtime_candidate.has_recovery_evidence))
+                                 Runtime_candidate.has_recovery_evidence))
                  in
                  if cascade_recovered () then
                    Log.Keeper.info "%s: stale threshold reached, but cascade %s appears healthy. Skipping auto-pause." meta.name (Keeper_meta_contract.runtime_id_of_meta meta)

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -115,8 +115,8 @@ let runtime_keepalive_started_at (config : Coord_utils.config) (meta : keeper_me
 ;;
 
 (* ── Structured blocker classification ──────────────────────── *)
-(* Types blocker_class, cascade_exhaustion_reason, blocker_class_to_string,
-   cascade_exhaustion_summary, blocker_class_continue_gate
+(* Types blocker_class, runtime_exhaustion_reason, blocker_class_to_string,
+   runtime_exhaustion_summary, blocker_class_continue_gate
    are defined in Keeper_types (keeper_types.ml). *)
 
 
@@ -369,7 +369,7 @@ let attention_fields_json (config : Coord_utils.config) (meta : keeper_meta) =
         true, Some "continue_gate_required", Some "approve_or_reject_continue"
       | Some _ when meta.paused ->
         true, Some "paused", Some "inspect_blocker_before_resume"
-      | Some blocker when is_cascade_exhausted_blocker_class blocker.blocker_class ->
+      | Some blocker when is_runtime_exhausted_blocker_class blocker.blocker_class ->
         true, Some "cascade_attempts_exhausted", Some "inspect_cascade_attempts"
       | Some blocker when is_no_tool_capable_blocker_class blocker.blocker_class ->
         true, Some "provider_tool_capability_missing", Some "inspect_provider_tool_lane"

--- a/lib/keeper/keeper_status_bridge_blocker.ml
+++ b/lib/keeper/keeper_status_bridge_blocker.ml
@@ -17,8 +17,8 @@ let blocker_class_of_sdk_error (err : Agent_sdk.Error.sdk_error) : blocker_class
   | _ ->
   match Keeper_turn_driver.classify_masc_internal_error err with
   | Some (Keeper_turn_driver.Capacity_backpressure _) -> Some Capacity_backpressure
-  | Some (Keeper_turn_driver.Cascade_exhausted { reason; _ }) ->
-    Some (Cascade_exhausted reason)
+  | Some (Keeper_turn_driver.Runtime_exhausted { reason; _ }) ->
+    Some (Runtime_exhausted reason)
   | Some (Keeper_turn_driver.Resumable_cli_session _) -> None
   | Some (Keeper_turn_driver.Accept_rejected _) -> None
   | Some (Keeper_turn_driver.Admission_queue_timeout _) ->
@@ -89,14 +89,14 @@ let runtime_blocker_class_label ?(summary = "") cls =
   let _ = summary in
   blocker_class_to_string (runtime_blocker_surface_class cls)
 
-let is_cascade_exhausted_blocker_class blocker_class =
+let is_runtime_exhausted_blocker_class blocker_class =
   String.equal
     blocker_class
-    (blocker_class_to_string (Cascade_exhausted (Other_detail "")))
+    (blocker_class_to_string (Runtime_exhausted (Other_detail "")))
 ;;
 
 let is_no_tool_capable_blocker_class blocker_class =
-  String.equal blocker_class "cascade_exhausted_no_tool_capable"
+  String.equal blocker_class "runtime_exhausted_no_tool_capable"
 ;;
 
 let is_completion_contract_blocker_class blocker_class =
@@ -127,8 +127,8 @@ let runtime_blocker_surface_of_typed_class ?(summary = "") (cls : blocker_class)
       if summary = ""
       then "Provider or client capacity backpressure blocked this keeper turn."
       else summary
-    | Cascade_exhausted reason ->
-      if summary = "" then cascade_exhaustion_summary reason else summary
+    | Runtime_exhausted reason ->
+      if summary = "" then runtime_exhaustion_summary reason else summary
     | Turn_livelock_blocked ->
       if summary = ""
       then "Keeper turn livelock guard blocked repeated dispatch of the same turn."
@@ -273,7 +273,7 @@ let runtime_blocker_surface_of_failure_reason (reason : Keeper_registry.failure_
            (Printf.sprintf
               "No tool-capable provider available (registry path): %s"
               detail)
-         (Cascade_exhausted (No_tool_capable None)))
+         (Runtime_exhausted (No_tool_capable None)))
   | Keeper_registry.Provider_runtime_error { code; detail } ->
     Some
       { blocker_class = "provider_runtime_error"

--- a/lib/keeper/keeper_status_bridge_blocker.mli
+++ b/lib/keeper/keeper_status_bridge_blocker.mli
@@ -24,7 +24,7 @@ val runtime_blocker_surface_of_typed_class :
 val runtime_blocker_surface_of_failure_reason :
   Keeper_registry.failure_reason -> runtime_blocker_surface option
 
-val is_cascade_exhausted_blocker_class : string -> bool
+val is_runtime_exhausted_blocker_class : string -> bool
 val is_no_tool_capable_blocker_class : string -> bool
 val is_completion_contract_blocker_class : string -> bool
 val is_provider_runtime_blocker_class : string -> bool

--- a/lib/keeper/keeper_supervisor_pause_policy.ml
+++ b/lib/keeper/keeper_supervisor_pause_policy.ml
@@ -222,17 +222,17 @@ let failure_reason_policy_decision
   | Some Keeper_registry.Turn_livelock_pause ->
     Some (Keeper_failure_policy.decide Keeper_failure_policy.Turn_livelock_pause)
   | Some (Keeper_registry.Provider_runtime_error { code; _ })
-    when String.starts_with ~prefix:"cascade_exhausted_" code ->
+    when String.starts_with ~prefix:"runtime_exhausted_" code ->
     let retryable =
       match code with
-      | "cascade_exhausted_candidates_filtered"
-      | "cascade_exhausted_max_turns"
-      | "cascade_exhausted_capacity_exhausted" -> true
+      | "runtime_exhausted_candidates_filtered"
+      | "runtime_exhausted_max_turns"
+      | "runtime_exhausted_capacity_exhausted" -> true
       | _ -> false
     in
     Some
       (Keeper_failure_policy.decide
-         (Keeper_failure_policy.Cascade_exhausted { retryable }))
+         (Keeper_failure_policy.Runtime_exhausted { retryable }))
   | Some
       ( Keeper_registry.Heartbeat_consecutive_failures _
       | Keeper_registry.Stale_fleet_batch _

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -499,13 +499,13 @@ let run_named
                   provider_rejections
             }
           in
-          Cascade_exhausted
+          Runtime_exhausted
             {
               cascade_name = error_cascade_name;
               reason = Keeper_meta_contract.No_tool_capable (Some detail);
             }
         | Provider_unavailable ->
-          Cascade_exhausted
+          Runtime_exhausted
             {
               cascade_name = error_cascade_name;
               reason = Keeper_meta_contract.No_providers_available;
@@ -801,7 +801,7 @@ let run_named
            continues without throttling. *)
         ()
   in
-  let cascade_exhausted_after_filter ~cycle =
+  let runtime_exhausted_after_filter ~cycle =
     let observation =
       Keeper_observation.cascade_observation_with_metrics
         ~cascade_name:error_cascade_name
@@ -813,7 +813,7 @@ let run_named
       ~outcome:`Failure ~observation:(Some observation) ();
     Error
       (sdk_error_of_masc_internal_error
-         (Cascade_exhausted
+         (Runtime_exhausted
             {
               cascade_name = error_cascade_name;
               reason = Keeper_meta_contract.Candidates_filtered_after_cycles;
@@ -847,7 +847,7 @@ let run_named
     match ordered with
     | [] when last_cycle ->
       record_trace ~cycle:n ~candidates_out:0 ~backoff_ms:0 ~kind:Exhausted;
-      cascade_exhausted_after_filter ~cycle:n
+      runtime_exhausted_after_filter ~cycle:n
     | [] ->
       let backoff = Cascade_strategy.backoff_ms strategy.cycle ~cycle:(n + 1) in
       record_trace ~cycle:n ~candidates_out:0 ~backoff_ms:backoff

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -89,8 +89,8 @@ let run_named
     ?per_provider_timeout_s
     ()
   : (Runtime_agent.run_result, Agent_sdk.Error.sdk_error) result =
-  let cascade_engine = Keeper_cascade_engine.keeper_managed in
-  match Keeper_cascade_engine.guard_keeper_hot_path cascade_engine with
+  let cascade_engine = Keeper_runtime_engine.keeper_managed in
+  match Keeper_runtime_engine.guard_keeper_hot_path cascade_engine with
   | Error msg -> Error (Agent_sdk.Error.Internal msg)
   | Ok () ->
   match require_eio ?sw ?net () with
@@ -157,7 +157,7 @@ let run_named
     | required_tool_names ->
       List.fold_right
         (fun candidate (kept, rejected) ->
-           let provider_label = Cascade_runtime_candidate.provider_label candidate in
+           let provider_label = Runtime_candidate.provider_label candidate in
            let drop ~lane ~missing_required_tools ~materialized_tool_names =
              let reason =
                Printf.sprintf
@@ -180,7 +180,7 @@ let run_named
              :: rejected
            in
            match
-             Cascade_runtime_candidate.resolve_tool_lane_for_oas_tools
+             Runtime_candidate.resolve_tool_lane_for_oas_tools
                ?agent_name:(Runtime_oas_runner.keeper_agent_name_opt keeper_name)
                ~tool_requirement:`Required
                ~tools
@@ -195,7 +195,7 @@ let run_named
              let runtime_mcp_policy =
                match runtime_mcp_policy, String.trim keeper_name with
                | Some policy, keeper_name when keeper_name <> "" ->
-                 Cascade_runtime_candidate.runtime_mcp_policy_for_agent
+                 Runtime_candidate.runtime_mcp_policy_for_agent
                    ~agent_name:(Keeper_identity.keeper_agent_name keeper_name)
                    candidate
                    (Some policy)
@@ -224,7 +224,7 @@ let run_named
     required_lane_filtered_candidates
     |> List.filter
          (fun candidate ->
-            match Cascade_runtime_candidate.first_health_cooldown candidate with
+            match Runtime_candidate.first_health_cooldown candidate with
             | None -> true
             | Some (_provider_health_key, msg) ->
                 Log.Misc.debug
@@ -242,7 +242,7 @@ let run_named
       ~health_filtered_candidates
   in
   let local_endpoint_health =
-    match Cascade_runtime_candidate.local_runtime_urls dispatch_seed_candidates with
+    match Runtime_candidate.local_runtime_urls dispatch_seed_candidates with
     | [] -> []
     | endpoints ->
       Llm_provider.Discovery.refresh_and_sync ~sw ~net ~endpoints
@@ -250,7 +250,7 @@ let run_named
              status.url, status.healthy)
   in
   let local_prefiltered_candidates, unhealthy_local_endpoints =
-    Cascade_runtime_candidate.filter_unhealthy_local_runtime_urls
+    Runtime_candidate.filter_unhealthy_local_runtime_urls
       ~endpoint_health:local_endpoint_health
       dispatch_seed_candidates
   in
@@ -346,17 +346,17 @@ let run_named
   in
   let register_capacity_controls candidates =
     List.iter
-      Cascade_runtime_candidate.register_declared_client_capacity
+      Runtime_candidate.register_declared_client_capacity
       candidates;
     let capacity_keys =
-      Cascade_runtime_candidate.capacity_keys candidates
+      Runtime_candidate.capacity_keys candidates
       |> List.map String.trim
       |> List.filter (fun key -> not (String.equal key ""))
       |> Json_util.dedupe_keep_order
     in
     let cli_max_concurrent =
       optional_capacity_override ~knob:"cli_max_concurrent" (fun () ->
-        Cascade_catalog_runtime.resolve_cli_max_concurrent
+        Runtime_catalog.resolve_cli_max_concurrent
           ~sw
           ~net
           ~name:cascade_name
@@ -373,7 +373,7 @@ let run_named
     let http_probe_max_concurrent =
       match
         optional_capacity_override ~knob:"ollama_max_concurrent" (fun () ->
-          Cascade_catalog_runtime.resolve_ollama_max_concurrent
+          Runtime_catalog.resolve_ollama_max_concurrent
             ~sw
             ~net
             ~name:cascade_name
@@ -383,11 +383,11 @@ let run_named
       | None ->
         (* DET-OK: absent or unresolved HTTP-probe capacity uses the stable
            single-flight default at the runtime boundary; configured values are
-           still explicit [Some n] inputs from the cascade catalog. *)
+           still explicit [Some n] inputs from the runtime catalog. *)
         http_probe_default_max_concurrent
     in
     List.iter
-      (Cascade_runtime_candidate.register_http_probe_capable
+      (Runtime_candidate.register_http_probe_capable
          ~max_concurrent:http_probe_max_concurrent)
       candidates
   in
@@ -409,7 +409,7 @@ let run_named
     | None -> candidates
     | Some health ->
       Provider_health.filter_healthy health
-        ~provider_id:Cascade_runtime_candidate.health_key
+        ~provider_id:Runtime_candidate.health_key
         candidates
   in
   let record_provider_health_result candidate ~success ~http_status =
@@ -417,7 +417,7 @@ let run_named
     | None -> ()
     | Some health ->
       Provider_health.record_attempt_result health
-        ~provider_id:(Cascade_runtime_candidate.health_key candidate)
+        ~provider_id:(Runtime_candidate.health_key candidate)
         ~success
         ~http_status
   in
@@ -525,7 +525,7 @@ let run_named
            ~status:"error"
            ~decision:
              (`Assoc
-               (Keeper_cascade_engine.manifest_fields cascade_engine
+               (Keeper_runtime_engine.manifest_fields cascade_engine
                 @ [
                     ("reason", `String (kind_of_masc_internal_error internal_error));
                     ( "required_tool_names",
@@ -661,15 +661,15 @@ let run_named
     | Some manifest_ctx, Some append ->
       let decision =
         match decision with
-        | None -> Some (`Assoc (Keeper_cascade_engine.manifest_fields cascade_engine))
+        | None -> Some (`Assoc (Keeper_runtime_engine.manifest_fields cascade_engine))
         | Some (`Assoc fields) ->
             Some
               (`Assoc
-                (Keeper_cascade_engine.manifest_fields cascade_engine @ fields))
+                (Keeper_runtime_engine.manifest_fields cascade_engine @ fields))
       | Some other ->
             Some
               (`Assoc
-                (Keeper_cascade_engine.manifest_fields cascade_engine
+                (Keeper_runtime_engine.manifest_fields cascade_engine
                  @ [ ("decision", other) ]))
       in
       let decision =
@@ -772,12 +772,12 @@ let run_named
   let* strategy =
     profile_knob_or_default ~knob:"strategy"
       ~default:Cascade_strategy.failover
-      (fun () -> Cascade_catalog_runtime.resolve_strategy ~name:cascade_name ())
+      (fun () -> Runtime_catalog.resolve_strategy ~name:cascade_name ())
   in
   let strategy_name = Cascade_strategy.kind_to_string strategy.kind in
   let () = cascade_strategy_name_ref := Some strategy_name in
   let _ = sw, net in
-  let adapter = Cascade_runtime_candidate.strategy_adapter in
+  let adapter = Runtime_candidate.strategy_adapter in
   let signal_ctx : Cascade_strategy.signal_ctx = {
     health = Keeper_binding_health.global;
     capacity = Cascade_capacity_probe.capacity;

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -169,5 +169,5 @@ module For_testing : sig
     materialized_tool_names:string list ->
     string list
 
-  val success_selected_model_raw : Cascade_runtime_candidate.t -> string option
+  val success_selected_model_raw : Runtime_candidate.t -> string option
 end

--- a/lib/keeper/keeper_turn_driver_admission.ml
+++ b/lib/keeper/keeper_turn_driver_admission.ml
@@ -23,7 +23,7 @@ let provider_config_identity_key (cfg : Llm_provider.Provider_config.t) =
       cfg.supports_tool_choice_override )
 
 let runtime_candidates_of_providers provider_cfgs =
-  Cascade_runtime_candidate.of_provider_configs provider_cfgs
+  Runtime_candidate.of_provider_configs provider_cfgs
 
 (* ================================================================ *)
 (* Facade-only: run_named, run_model_by_label, and MASC tool bridges  *)

--- a/lib/keeper/keeper_turn_driver_admission.mli
+++ b/lib/keeper/keeper_turn_driver_admission.mli
@@ -8,4 +8,4 @@ val provider_config_identity_key : Llm_provider.Provider_config.t -> int
 
 val runtime_candidates_of_providers :
   Llm_provider.Provider_config.t list ->
-  Cascade_runtime_candidate.t list
+  Runtime_candidate.t list

--- a/lib/keeper/keeper_turn_driver_helpers.ml
+++ b/lib/keeper/keeper_turn_driver_helpers.ml
@@ -139,7 +139,7 @@ let no_tool_capable_provider_of_pre_dispatch_rejections ~cascade_name
         }
       in
       Some
-        (Keeper_meta_contract.Cascade_exhausted
+        (Keeper_meta_contract.Runtime_exhausted
            {
              cascade_name;
              reason = Keeper_meta_contract.No_tool_capable (Some detail);

--- a/lib/keeper/keeper_turn_driver_helpers.ml
+++ b/lib/keeper/keeper_turn_driver_helpers.ml
@@ -176,7 +176,7 @@ let provider_rejections_for_no_tool_error
   candidates
   |> List.filter_map (fun candidate ->
        match
-         Cascade_runtime_candidate.tool_filter_rejection_label
+         Runtime_candidate.tool_filter_rejection_label
            ~keeper_name ?runtime_mcp_policy ~tools
            ~require_tool_choice_support ~require_tool_support candidate
        with
@@ -185,7 +185,7 @@ let provider_rejections_for_no_tool_error
            Some
              ({
                 provider_label =
-                  Cascade_runtime_candidate.provider_label candidate;
+                  Runtime_candidate.provider_label candidate;
                 reason;
               }
                : Keeper_meta_contract.provider_rejection))

--- a/lib/keeper/keeper_turn_driver_helpers.mli
+++ b/lib/keeper/keeper_turn_driver_helpers.mli
@@ -82,7 +82,7 @@ val provider_rejections_for_no_tool_error :
   tools:Agent_sdk.Tool.t list ->
   require_tool_choice_support:bool ->
   require_tool_support:bool ->
-  Cascade_runtime_candidate.t list ->
+  Runtime_candidate.t list ->
   Keeper_meta_contract.provider_rejection list
 
 val apply_stream_idle_timeout_default : float option -> float option

--- a/lib/keeper/keeper_turn_driver_named_resolution.ml
+++ b/lib/keeper/keeper_turn_driver_named_resolution.ml
@@ -13,7 +13,7 @@ type t = {
 
 let resolve ~sw ~net ?provider_filter ~cascade_name ~runtime_cascade_name () =
   let named_resolution =
-    Cascade_catalog_runtime
+    Runtime_catalog
     .resolve_named_providers_strict_with_secondary_resolver
       ~sw ~net ?provider_filter ~cascade_name ()
   in

--- a/lib/keeper/keeper_turn_driver_provider_attempt.ml
+++ b/lib/keeper/keeper_turn_driver_provider_attempt.ml
@@ -133,7 +133,7 @@ let client_capacity_full_decision ~capacity_key =
 ;;
 
 let success_selected_model_raw candidate =
-  Some (Cascade_runtime_candidate.model_health_key candidate)
+  Some (Runtime_candidate.model_health_key candidate)
 
 (* Error/rejected/exhausted observations intentionally leave the concrete
    selected model absent. Downstream attribution uses candidate_models or the
@@ -144,7 +144,7 @@ let health_error_kind label =
   Keeper_binding_health.error_kind_of_string label
 
 let record_candidate_health_success candidate ~latency_ms =
-  Cascade_runtime_candidate.health_keys candidate
+  Runtime_candidate.health_keys candidate
   |> List.iter (fun provider_key ->
     Keeper_binding_health.record_success
       Keeper_binding_health.global
@@ -154,7 +154,7 @@ let record_candidate_health_success candidate ~latency_ms =
 
 let record_candidate_health_rejected candidate ~reason =
   let error_kind = health_error_kind "accept_rejected" in
-  Cascade_runtime_candidate.health_keys candidate
+  Runtime_candidate.health_keys candidate
   |> List.iter (fun provider_key ->
     Keeper_binding_health.record_rejected
       Keeper_binding_health.global
@@ -165,7 +165,7 @@ let record_candidate_health_rejected candidate ~reason =
 
 let record_candidate_health_error candidate sdk_err =
   let error_reason = Agent_sdk.Error.to_string sdk_err in
-  let health_keys = Cascade_runtime_candidate.health_keys candidate in
+  let health_keys = Runtime_candidate.health_keys candidate in
   if sdk_error_is_hard_quota sdk_err
   then (
     let error_kind = health_error_kind "hard_quota" in

--- a/lib/keeper/keeper_turn_driver_provider_attempt.mli
+++ b/lib/keeper/keeper_turn_driver_provider_attempt.mli
@@ -51,18 +51,18 @@ val client_capacity_full_decision :
   capacity_key:string -> Yojson.Safe.t
 
 val success_selected_model_raw :
-  Cascade_runtime_candidate.t -> string option
+  Runtime_candidate.t -> string option
 
 val error_selected_model_raw : string option
 val health_error_kind : string -> Keeper_binding_health.error_kind
 
 val record_candidate_health_success :
-  Cascade_runtime_candidate.t -> latency_ms:float -> unit
+  Runtime_candidate.t -> latency_ms:float -> unit
 
 val record_candidate_health_rejected :
-  Cascade_runtime_candidate.t -> reason:string -> unit
+  Runtime_candidate.t -> reason:string -> unit
 
 val record_candidate_health_error :
-  Cascade_runtime_candidate.t -> Agent_sdk.Error.sdk_error -> unit
+  Runtime_candidate.t -> Agent_sdk.Error.sdk_error -> unit
 
 val runtime_candidate_label : string

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -74,7 +74,7 @@ type try_provider_ctx =
   ; agent_ref : Agent_sdk.Agent.t option ref option
   ; (* Event bus *)
     event_bus : Agent_sdk.Event_bus.t option
-  ; cascade_engine : Keeper_cascade_engine.t
+  ; cascade_engine : Keeper_runtime_engine.t
   ; runtime_manifest_context : Keeper_runtime_manifest.turn_context option
   ; runtime_manifest_append : (Keeper_runtime_manifest.t -> unit) option
   ; runtime_manifest_required_tool_names : string list
@@ -92,15 +92,15 @@ let emit_runtime_manifest
   | Some manifest_ctx, Some append ->
     let decision =
       match decision with
-      | None -> Some (`Assoc (Keeper_cascade_engine.manifest_fields ctx.cascade_engine))
+      | None -> Some (`Assoc (Keeper_runtime_engine.manifest_fields ctx.cascade_engine))
       | Some (`Assoc fields) ->
           Some
             (`Assoc
-              (Keeper_cascade_engine.manifest_fields ctx.cascade_engine @ fields))
+              (Keeper_runtime_engine.manifest_fields ctx.cascade_engine @ fields))
       | Some other ->
           Some
             (`Assoc
-              (Keeper_cascade_engine.manifest_fields ctx.cascade_engine
+              (Keeper_runtime_engine.manifest_fields ctx.cascade_engine
                @ [ ("decision", other) ]))
     in
     ctx.seq_ref := !(ctx.seq_ref) + 1;
@@ -196,7 +196,7 @@ let run_try_provider
   =
   let config_result =
     match
-      Cascade_runtime_candidate.resolve_tool_lane_for_oas_tools
+      Runtime_candidate.resolve_tool_lane_for_oas_tools
         ?agent_name:(Runtime_oas_runner.keeper_agent_name_opt ctx.keeper_name)
         ~tool_requirement:
           (if ctx.require_tool_choice_support || ctx.require_tool_support
@@ -210,7 +210,7 @@ let run_try_provider
       let runtime_mcp_policy =
         match runtime_mcp_policy, String.trim ctx.keeper_name with
         | Some policy, keeper_name when keeper_name <> "" ->
-          Cascade_runtime_candidate.runtime_mcp_policy_for_agent
+          Runtime_candidate.runtime_mcp_policy_for_agent
             ~agent_name:(Keeper_identity.keeper_agent_name ctx.keeper_name)
             candidate
             (Some policy)
@@ -280,7 +280,7 @@ let run_try_provider
              ~materialized_tools:materialized_tool_names)
       else
         Ok
-          { (Cascade_runtime_candidate.default_config
+          { (Runtime_candidate.default_config
                ~name:ctx.name
                ~system_prompt:ctx.system_prompt
                ~tools:effective_tools
@@ -355,7 +355,7 @@ let run_try_provider
        identities remain on the OAS side.  Prometheus receives only the public,
        bounded provider bucket for TTFT/inter-chunk grouping. *)
     let candidate_key = Keeper_attempt_liveness_config.runtime_candidate_key in
-    let provider_label = Cascade_runtime_candidate.provider_label candidate in
+    let provider_label = Runtime_candidate.provider_label candidate in
     let liveness_observer_opt =
       match liveness_mode with
       | Keeper_attempt_liveness_config.Off ->
@@ -544,7 +544,7 @@ let run_try_provider
        let liveness_success_sample = liveness_success_sample () in
        let result =
          Result.map_error
-           (Cascade_runtime_candidate.enrich_sdk_error
+           (Runtime_candidate.enrich_sdk_error
               ~cascade_name:ctx.error_cascade_name
               candidate)
            result

--- a/lib/keeper/keeper_turn_driver_try_provider.mli
+++ b/lib/keeper/keeper_turn_driver_try_provider.mli
@@ -53,7 +53,7 @@ type try_provider_ctx =
   ; on_resume : (unit -> unit) option
   ; agent_ref : Agent_sdk.Agent.t option ref option
   ; event_bus : Agent_sdk.Event_bus.t option
-  ; cascade_engine : Keeper_cascade_engine.t
+  ; cascade_engine : Keeper_runtime_engine.t
   ; runtime_manifest_context : Keeper_runtime_manifest.turn_context option
   ; runtime_manifest_append : (Keeper_runtime_manifest.t -> unit) option
   ; runtime_manifest_required_tool_names : string list
@@ -65,7 +65,7 @@ val run_try_provider :
   try_provider_ctx ->
   ?resume_checkpoint:Agent_sdk.Checkpoint.t ->
   ?per_provider_timeout_s:float ->
-  Cascade_runtime_candidate.t ->
+  Runtime_candidate.t ->
   (Runtime_agent.run_result, Agent_sdk.Error.sdk_error) result
   * Agent_sdk.Checkpoint.t option
   * (string * Keeper_attempt_liveness_config.success_sample) option

--- a/lib/keeper/keeper_turn_terminal.ml
+++ b/lib/keeper/keeper_turn_terminal.ml
@@ -82,7 +82,7 @@ let of_failure ?(post_commit_ambiguous = false) ?(tool_call_count = 0) ~raw_erro
         Keeper_turn_disposition.Turn_wall_clock_timeout
     | Some (Keeper_turn_driver.Capacity_backpressure _) ->
       make ~source:"typed_error" "capacity_backpressure"
-    | Some (Keeper_turn_driver.Cascade_exhausted _) ->
+    | Some (Keeper_turn_driver.Runtime_exhausted _) ->
       of_disposition
         ~source:"typed_error"
         Keeper_turn_disposition.Cascade_attempts_exhausted

--- a/lib/keeper/keeper_unified_metrics_failure.ml
+++ b/lib/keeper/keeper_unified_metrics_failure.ml
@@ -80,7 +80,7 @@ let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
             Option.value
               ~default:reason
               (Keeper_turn_driver.summary_of_masc_internal_error err)
-        | Some (Keeper_turn_driver.Cascade_exhausted _ as err) -> (
+        | Some (Keeper_turn_driver.Runtime_exhausted _ as err) -> (
             match Keeper_turn_driver.summary_of_masc_internal_error err with
             | Some summary -> summary
             | None -> reason)
@@ -100,7 +100,7 @@ let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
             | Keeper_turn_driver.Admission_queue_rejected _
             | Keeper_turn_driver.Resumable_cli_session _
             | Keeper_turn_driver.Capacity_backpressure _
-            (* No_tool_capable (inside Cascade_exhausted) excluded:
+            (* No_tool_capable (inside Runtime_exhausted) excluded:
                this is a configuration/capability mismatch, not a
                transient condition.  Counting it toward noop_backoff
                causes spurious keeper fiber kills (59/day on 2026-05-24)
@@ -116,7 +116,7 @@ let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
   (match sdk_error with
    | Some err ->
        (match Keeper_turn_driver.classify_masc_internal_error err with
-        | Some (Keeper_turn_driver.Cascade_exhausted
+        | Some (Keeper_turn_driver.Runtime_exhausted
 	                  { cascade_name
 	                  ; reason = Keeper_meta_contract.No_tool_capable _
 	                  ; _

--- a/lib/keeper/keeper_unified_metrics_support.ml
+++ b/lib/keeper/keeper_unified_metrics_support.ml
@@ -160,7 +160,7 @@ let label_or_unknown raw =
 let record_turn_latency_by_model_bucket
     ~(keeper : string)
     ~(channel : string)
-    ~(cascade_profile : string)
+    ~(runtime_profile : string)
     ~(latency_ms : int) : unit =
   let bucket = turn_latency_bucket latency_ms in
   let model_used = runtime_lane_label in
@@ -168,7 +168,7 @@ let record_turn_latency_by_model_bucket
   let provider_kind =
     Boundary_redaction.to_string Boundary_redaction.runtime_provider_label
   in
-  let cascade_profile = label_or_unknown cascade_profile in
+  let runtime_profile = label_or_unknown runtime_profile in
   Prometheus.inc_counter
     Keeper_metrics.(to_string TurnLatencyByModelBucket)
     ~labels:
@@ -177,7 +177,7 @@ let record_turn_latency_by_model_bucket
       ; ("provider_kind", provider_kind)
       ; ("model_used", model_used)
       ; ("resolved_model_id", resolved_model_id)
-      ; ("cascade_profile", cascade_profile)
+      ; ("runtime_profile", runtime_profile)
       ; ("bucket", bucket)
       ]
     ()

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -198,7 +198,7 @@ let run_keeper_cycle
             let failure_reason =
               match Keeper_turn_driver.classify_masc_internal_error err with
               | Some
-                  (Keeper_turn_driver.Cascade_exhausted
+                  (Keeper_turn_driver.Runtime_exhausted
                      { cascade_name
                      ; reason = Keeper_meta_contract.No_tool_capable _
                      ; _
@@ -207,7 +207,7 @@ let run_keeper_cycle
                   { cascade_name = cascade_name
                   ; detail = error_message
                   }
-              | _ when EC.is_cascade_exhausted_error err ->
+              | _ when EC.is_runtime_exhausted_error err ->
                 Keeper_turn_fsm.Failure_cascade_unavailable
                   { base = effective_cascade_runtime_name
                   ; resolved = None
@@ -664,7 +664,7 @@ let run_keeper_cycle
                        else
                          match Keeper_turn_driver.classify_masc_internal_error err with
                          | Some
-                             (Keeper_turn_driver.Cascade_exhausted
+                             (Keeper_turn_driver.Runtime_exhausted
                                 { cascade_name
                                 ; reason = Keeper_meta_contract.No_tool_capable _
                                 ; _

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -148,11 +148,11 @@ let run_keeper_cycle
         Keeper_unified_turn_cascade_resolution.resolve_cascade
           ~meta
           ~phase_opt
-          ~append_cascade_routed_manifest:(fun ~cascade_name ~decision ->
-            append_manifest ~site:"cascade_routed"
+          ~append_runtime_routed_manifest:(fun ~cascade_name ~decision ->
+            append_manifest ~site:"runtime_routed"
               ~runtime_id:cascade_name
               ~decision
-              Keeper_runtime_manifest.Cascade_routed)
+              Keeper_runtime_manifest.Runtime_routed)
       in
       (* Concrete runtime health/capacity is owned by OAS/provider adapters.
          Keeper routing no longer rewrites cascades from provider cooldown or

--- a/lib/keeper/keeper_unified_turn_failure.ml
+++ b/lib/keeper/keeper_unified_turn_failure.ml
@@ -12,7 +12,7 @@ let record_failure_and_maybe_escalate
   =
   let base_path = config.base_path in
   let counts_toward_crash =
-    (not is_auto_recoverable) || EC.is_cascade_exhausted_error err
+    (not is_auto_recoverable) || EC.is_runtime_exhausted_error err
   in
   if counts_toward_crash
   then Keeper_registry.increment_turn_failures ~base_path meta.name
@@ -31,14 +31,14 @@ let record_failure_and_maybe_escalate
     ~consecutive:count
     ~threshold
     ~err;
-  if EC.is_cascade_exhausted_error err && count > 0
+  if EC.is_runtime_exhausted_error err && count > 0
   then
     Keeper_registry.set_failure_reason
       ~base_path:config.base_path
       meta.name
       (Some (Keeper_registry.Turn_consecutive_failures count));
   let cascade_auto_paused =
-    EC.is_cascade_exhausted_error err
+    EC.is_runtime_exhausted_error err
     && count >= Keeper_behavioral_regime.turn_fail_streak_threshold
     && not updated_meta.paused
   in
@@ -76,7 +76,7 @@ let record_failure_and_maybe_escalate
             meta.name
             (Some (Keeper_registry.Turn_consecutive_failures count));
           Log.Keeper.warn
-            "%s: auto-paused after %d cascade_exhausted failures \
+            "%s: auto-paused after %d runtime_exhausted failures \
              (pause_threshold=%d, crash_threshold=%d); operator must resume after \
              cascade fix"
             meta.name

--- a/lib/keeper/keeper_unified_turn_pre_dispatch.ml
+++ b/lib/keeper/keeper_unified_turn_pre_dispatch.ml
@@ -54,12 +54,12 @@ let build_cascade_execution
            model_labels
        in
        let temperature =
-         Cascade_inference.resolve_temperature
+         Runtime_inference.resolve_temperature
            ~cascade_name
            ~fallback:Keeper_config.keeper_unified_temperature
        in
        let raw_max_tokens =
-         Cascade_inference.resolve_max_tokens
+         Runtime_inference.resolve_max_tokens
            ~cascade_name
            ~fallback:
              (resolve_unified_max_tokens_fallback
@@ -70,7 +70,7 @@ let build_cascade_execution
          None
        in
        (match
-          Cascade_inference.validate_max_tokens_within_ceiling
+          Runtime_inference.validate_max_tokens_within_ceiling
             ~cascade_name
             ~provider_ceiling:max_output_ceiling
             raw_max_tokens

--- a/lib/keeper/keeper_unified_turn_terminal_error.ml
+++ b/lib/keeper/keeper_unified_turn_terminal_error.ml
@@ -1,9 +1,9 @@
 module EC = Keeper_error_classify
 
 let handle ~config ~keeper_name ~attempt ~attempted_cascades err =
-  if EC.is_cascade_exhausted_error err
+  if EC.is_runtime_exhausted_error err
   then (
-    Keeper_registry.mark_turn_cascade_exhausted
+    Keeper_registry.mark_turn_runtime_exhausted
       ~base_path:config.Coord.base_path
       keeper_name;
     Prometheus.inc_counter
@@ -21,7 +21,7 @@ let handle ~config ~keeper_name ~attempt ~attempted_cascades err =
       Keeper_metrics.(to_string OasExecutionErrors)
       ~labels:
         [ "keeper", keeper_name
-        ; "phase", Keeper_oas_execution_error_phase.(to_label Cascade_exhausted)
+        ; "phase", Keeper_oas_execution_error_phase.(to_label Runtime_exhausted)
         ]
       ())
   else (

--- a/lib/keeper/keeper_unified_turn_terminal_error.mli
+++ b/lib/keeper/keeper_unified_turn_terminal_error.mli
@@ -1,12 +1,12 @@
 (** RFC-0136 PR-4-b: terminal error side effects extracted from
     [keeper_unified_turn] retry loop.
 
-    Two paths based on [Keeper_error_classify.is_cascade_exhausted_error]:
+    Two paths based on [Keeper_error_classify.is_runtime_exhausted_error]:
 
-    - [Cascade_exhausted] — sets registry to [Turn_cascade_exhausted],
+    - [Runtime_exhausted] — sets registry to [Turn_runtime_exhausted],
       increments the [kcl_to_ktc_exhaustion] FSM edge counter, logs a
       structured WARN listing the attempted cascades, and increments
-      the [oas_execution_errors] counter with phase [Cascade_exhausted].
+      the [oas_execution_errors] counter with phase [Runtime_exhausted].
 
     - Otherwise — sets the turn phase to [Turn_finalizing], increments
       the [oas_execution_errors] counter with phase

--- a/lib/keeper/keeper_unified_turn_types.ml
+++ b/lib/keeper/keeper_unified_turn_types.ml
@@ -77,48 +77,48 @@ let sdk_error_of_retry_slot_reacquire_timeout
        })
 ;;
 
-let cascade_exhaustion_detail_code detail =
+let runtime_exhaustion_detail_code detail =
   let contains needle = String_util.contains_substring_ci detail needle in
   if contains "no_first_token"
-  then "cascade_exhausted_no_first_token"
+  then "runtime_exhausted_no_first_token"
   else if contains "inter_chunk_idle"
-  then "cascade_exhausted_inter_chunk_idle"
+  then "runtime_exhausted_inter_chunk_idle"
   else if contains "http 429" || contains "usage limit" || contains "rate limit"
-  then "cascade_exhausted_rate_limited"
+  then "runtime_exhausted_rate_limited"
   else if contains "max_execution_time"
-  then "cascade_exhausted_max_execution_time"
+  then "runtime_exhausted_max_execution_time"
   else if contains "wall-clock timeout"
-  then "cascade_exhausted_wall_clock_timeout"
+  then "runtime_exhausted_wall_clock_timeout"
   else if contains "connection closed by peer"
-  then "cascade_exhausted_connection_closed"
+  then "runtime_exhausted_connection_closed"
   else if contains "connection refused"
-  then "cascade_exhausted_connection_refused"
-  else "cascade_exhausted_provider_failure"
+  then "runtime_exhausted_connection_refused"
+  else "runtime_exhausted_provider_failure"
 ;;
 
-let cascade_exhaustion_reason_code
-      (reason : Keeper_meta_contract.cascade_exhaustion_reason)
+let runtime_exhaustion_reason_code
+      (reason : Keeper_meta_contract.runtime_exhaustion_reason)
   =
   match reason with
-  | Keeper_meta_contract.Connection_refused -> "cascade_exhausted_connection_refused"
-  | Keeper_meta_contract.Dns_failure -> "cascade_exhausted_dns_failure"
-  | Keeper_meta_contract.No_providers_available -> "cascade_exhausted_no_providers_available"
-  | Keeper_meta_contract.All_providers_failed -> "cascade_exhausted_all_providers_failed"
+  | Keeper_meta_contract.Connection_refused -> "runtime_exhausted_connection_refused"
+  | Keeper_meta_contract.Dns_failure -> "runtime_exhausted_dns_failure"
+  | Keeper_meta_contract.No_providers_available -> "runtime_exhausted_no_providers_available"
+  | Keeper_meta_contract.All_providers_failed -> "runtime_exhausted_all_providers_failed"
   | Keeper_meta_contract.Candidates_filtered_after_cycles ->
-    "cascade_exhausted_candidates_filtered"
-  | Keeper_meta_contract.Max_turns_exceeded -> "cascade_exhausted_max_turns"
+    "runtime_exhausted_candidates_filtered"
+  | Keeper_meta_contract.Max_turns_exceeded -> "runtime_exhausted_max_turns"
   | Keeper_meta_contract.Structural_attempt_timeout _ ->
-    "cascade_exhausted_structural_attempt_timeout"
-  | Keeper_meta_contract.Capacity_exhausted -> "cascade_exhausted_capacity_exhausted"
-  | Keeper_meta_contract.No_tool_capable _ -> "cascade_exhausted_no_tool_capable"
-  | Keeper_meta_contract.Other_detail detail -> cascade_exhaustion_detail_code detail
+    "runtime_exhausted_structural_attempt_timeout"
+  | Keeper_meta_contract.Capacity_exhausted -> "runtime_exhausted_capacity_exhausted"
+  | Keeper_meta_contract.No_tool_capable _ -> "runtime_exhausted_no_tool_capable"
+  | Keeper_meta_contract.Other_detail detail -> runtime_exhaustion_detail_code detail
 ;;
 
-let cascade_exhausted_failure_reason_of_raw_error ~detail raw_error =
+let runtime_exhausted_failure_reason_of_raw_error ~detail raw_error =
   match Keeper_meta_contract.classify_masc_internal_error_of_string raw_error with
-  (* No_tool_capable specific cases first — more specific than generic Cascade_exhausted *)
+  (* No_tool_capable specific cases first — more specific than generic Runtime_exhausted *)
   | Some
-      (Keeper_meta_contract.Cascade_exhausted
+      (Keeper_meta_contract.Runtime_exhausted
          { cascade_name = ntcp_cascade_name
          ; reason = Keeper_meta_contract.No_tool_capable (Some detail)
          ; _
@@ -153,7 +153,7 @@ let cascade_exhausted_failure_reason_of_raw_error ~detail raw_error =
          ; cascade_name = Some (ntcp_cascade_name)
          })
   | Some
-      (Keeper_meta_contract.Cascade_exhausted
+      (Keeper_meta_contract.Runtime_exhausted
          { cascade_name = ntcp_cascade_name
          ; reason = Keeper_meta_contract.No_tool_capable None
          ; _
@@ -166,11 +166,11 @@ let cascade_exhausted_failure_reason_of_raw_error ~detail raw_error =
          ; http_status = None
          ; cascade_name = Some (ntcp_cascade_name)
          })
-  (* Generic Cascade_exhausted catch-all — after No_tool_capable specifics *)
-  | Some (Keeper_meta_contract.Cascade_exhausted { reason; cascade_name }) ->
+  (* Generic Runtime_exhausted catch-all — after No_tool_capable specifics *)
+  | Some (Keeper_meta_contract.Runtime_exhausted { reason; cascade_name }) ->
     Some
       (Keeper_registry.Provider_runtime_error
-         { code = cascade_exhaustion_reason_code reason
+         { code = runtime_exhaustion_reason_code reason
          ; detail
          ; provider_id = None
          ; http_status = None
@@ -220,7 +220,7 @@ let registry_failure_reason_of_terminal_reason
   : Keeper_registry.failure_reason option
   =
   let detail = Keeper_types_profile.short_preview raw_error in
-  match cascade_exhausted_failure_reason_of_raw_error ~detail raw_error with
+  match runtime_exhausted_failure_reason_of_raw_error ~detail raw_error with
   | Some _ as reason -> reason
   | None ->
   match terminal_reason.disposition with

--- a/lib/keeper/keeper_world_observation_provider_cooldown.ml
+++ b/lib/keeper/keeper_world_observation_provider_cooldown.ml
@@ -30,7 +30,7 @@ let provider_cooldown_remaining_sec_for_cascade
   =
   let runtime_health_keys =
     Provider_runtime_projection.default_execution_model_strings cascade_name
-    |> Cascade_runtime_candidate.runtime_health_keys_of_labels
+    |> Runtime_candidate.runtime_health_keys_of_labels
   in
   match runtime_health_keys with
   | [] -> None

--- a/lib/keeper_tool_call_log_context.ml
+++ b/lib/keeper_tool_call_log_context.ml
@@ -24,7 +24,7 @@ type turn_context =
   ; required_tools : string list option
   ; required_tool_candidates : string list option
   ; missing_required_tools : string list option
-  ; cascade_profile : string option
+  ; runtime_profile : string option
   }
 
 let empty_turn_context =
@@ -51,7 +51,7 @@ let empty_turn_context =
   ; required_tools = None
   ; required_tool_candidates = None
   ; missing_required_tools = None
-  ; cascade_profile = None
+  ; runtime_profile = None
   }
 ;;
 
@@ -82,7 +82,7 @@ let set_turn_context
       ?required_tools
       ?required_tool_candidates
       ?missing_required_tools
-      ?cascade_profile
+      ?runtime_profile
       ()
   =
   Hashtbl.replace
@@ -111,7 +111,7 @@ let set_turn_context
     ; required_tools
     ; required_tool_candidates
     ; missing_required_tools
-    ; cascade_profile
+    ; runtime_profile
     }
 ;;
 
@@ -160,7 +160,7 @@ let runtime_contract_json_for_call ~keeper_name () =
     ?required_tools:ctx.required_tools
     ?required_tool_candidates:ctx.required_tool_candidates
     ?missing_required_tools:ctx.missing_required_tools
-    ?cascade_profile:ctx.cascade_profile
+    ?runtime_profile:ctx.runtime_profile
     ()
 ;;
 

--- a/lib/keeper_tool_call_log_context.mli
+++ b/lib/keeper_tool_call_log_context.mli
@@ -24,7 +24,7 @@ type turn_context =
   ; required_tools : string list option
   ; required_tool_candidates : string list option
   ; missing_required_tools : string list option
-  ; cascade_profile : string option
+  ; runtime_profile : string option
   }
 
 val set_turn_context :
@@ -52,7 +52,7 @@ val set_turn_context :
   ?required_tools:string list ->
   ?required_tool_candidates:string list ->
   ?missing_required_tools:string list ->
-  ?cascade_profile:string ->
+  ?runtime_profile:string ->
   unit ->
   unit
 

--- a/lib/runtime/runtime_metrics.ml
+++ b/lib/runtime/runtime_metrics.ml
@@ -3,7 +3,7 @@
     Re-homes the prometheus counter ticks that surviving consumers still call
     from the deleted [Cascade_metrics]. ONLY the consumer-referenced emitters
     are ported; the routing-aware aggregation in [Cascade_metrics]
-    (depended on Cascade_routes/Cascade_runtime/Cascade_inference) is NOT
+    (depended on Cascade_routes/Cascade_runtime/Runtime_inference) is NOT
     restored — it was the routing layer RFC-0206 §5 discards.
 
     The prometheus metric-name strings are preserved verbatim

--- a/lib/runtime/runtime_oas_runner.ml
+++ b/lib/runtime/runtime_oas_runner.ml
@@ -49,7 +49,7 @@ let resolve_cascade_providers
       ~cascade_name:_
       ()
   =
-  (* RFC-0206 single-binding: cascade catalog resolution removed. The providers
+  (* RFC-0206 single-binding: runtime catalog resolution removed. The providers
      are the default runtime's single provider_config, passed through the same
      required tool-use gate so require_tool_support is honored (a non-tool
      default is filtered out, not silently used). [provider_filter] is moot with
@@ -243,7 +243,7 @@ let classify_filter_rejection
     | None -> None
     | Some profile ->
       let caps = Provider_tool_support.capabilities_of_config provider_cfg in
-      if not (Cascade_capability_profile.provider_satisfies_profile profile caps)
+      if not (Runtime_capability_profile.provider_satisfies_profile profile caps)
       then Some (Capability_profile_mismatch profile)
       else None
   in

--- a/lib/runtime/runtime_oas_runner.mli
+++ b/lib/runtime/runtime_oas_runner.mli
@@ -102,7 +102,7 @@ val classify_filter_rejection :
   filter_rejection_reason option
 (** Classify why a single provider would be rejected by the tool-use gate.
     When [required_capability_profile] is provided, the provider must
-    satisfy the named profile via {!Cascade_capability_profile} or it is
+    satisfy the named profile via {!Runtime_capability_profile} or it is
     rejected with [Capability_profile_mismatch]. *)
 
 val filter_candidate_providers_for_tool_support :

--- a/lib/runtime/runtime_transport_authorization.ml
+++ b/lib/runtime/runtime_transport_authorization.ml
@@ -1,4 +1,4 @@
-(** Authorization header helpers for cascade runtime MCP transport,
+(** Authorization header helpers for runtime MCP transport,
     extracted from cascade_transport.ml.
 
     Pure functions over runtime-MCP policy + per-keeper auth headers;

--- a/lib/runtime/runtime_transport_authorization.mli
+++ b/lib/runtime/runtime_transport_authorization.mli
@@ -1,4 +1,4 @@
-(** Authorization header helpers for cascade runtime MCP transport. *)
+(** Authorization header helpers for runtime MCP transport. *)
 
 val upsert_http_header :
   key:string -> value:string -> (string * string) list -> (string * string) list

--- a/lib/runtime/runtime_transport_label_resolution.mli
+++ b/lib/runtime/runtime_transport_label_resolution.mli
@@ -1,4 +1,4 @@
-(** Model-label resolution for cascade runtime transport. *)
+(** Model-label resolution for runtime transport. *)
 
 type label_resolution_error = Invalid_model_label of string
 

--- a/lib/server/server_dashboard_http_keeper_api_runtime_lens.ml
+++ b/lib/server/server_dashboard_http_keeper_api_runtime_lens.ml
@@ -295,12 +295,12 @@ let runtime_lens_json ~config ~keeper_name ~trace_id ?turn_id scan =
                   (runtime_lens_keeper_terminal_status ~terminal_event_present scan)
                 ~synthetic_events:[]
             );
-            ( "masc_policy_cascade",
+            ( "masc_policy_runtime",
               runtime_lens_swimlane_json swimlane_scan gaps
-                ~lane:"masc_policy_cascade" ~label:"MASC Cascade"
+                ~lane:"masc_policy_runtime" ~label:"MASC Runtime"
                 ~events:
                   [
-                    Keeper_runtime_manifest.Cascade_routed;
+                    Keeper_runtime_manifest.Runtime_routed;
                     Keeper_runtime_manifest.Provider_lane_resolved;
                   ]
                 ~terminal_status:

--- a/lib/server/server_dashboard_http_keeper_runtime_lens_clock_edges.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_clock_edges.ml
@@ -89,7 +89,7 @@ let event_started_at row =
   match row.Keeper_runtime_manifest.event with
   | Keeper_runtime_manifest.Turn_started
   | Keeper_runtime_manifest.Phase_gate_decided
-  | Keeper_runtime_manifest.Cascade_routed
+  | Keeper_runtime_manifest.Runtime_routed
   | Keeper_runtime_manifest.Tool_surface_selected
   | Keeper_runtime_manifest.Provider_lane_resolved
   | Keeper_runtime_manifest.Provider_attempt_started
@@ -124,7 +124,7 @@ let event_finished_at row =
     Some row.Keeper_runtime_manifest.ts
   | Keeper_runtime_manifest.Turn_started
   | Keeper_runtime_manifest.Phase_gate_decided
-  | Keeper_runtime_manifest.Cascade_routed
+  | Keeper_runtime_manifest.Runtime_routed
   | Keeper_runtime_manifest.Tool_surface_selected
   | Keeper_runtime_manifest.Provider_lane_resolved
   | Keeper_runtime_manifest.Provider_attempt_started

--- a/lib/server/server_dashboard_http_keeper_runtime_lens_gaps.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_gaps.ml
@@ -388,13 +388,13 @@ let runtime_lens_gaps ~terminal_event_present ~claim_scope ~config_drift scan =
          if scan.total_rows > 0
             && runtime_manifest_scan_event_count scan Keeper_runtime_manifest.Turn_started
                > 0
-            && runtime_manifest_scan_event_count scan Keeper_runtime_manifest.Cascade_routed
+            && runtime_manifest_scan_event_count scan Keeper_runtime_manifest.Runtime_routed
                = 0
          then
-           { code = "cascade_decision_missing"
+           { code = "runtime_decision_missing"
            ; severity = "warn"
            ; lane = "masc_policy_runtime"
-           ; detail = Some "turn started but no cascade_routed event recorded"
+           ; detail = Some "turn started but no runtime_routed event recorded"
            }
            :: gaps
          else gaps)

--- a/lib/server/server_dashboard_http_keeper_runtime_lens_swimlane.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_swimlane.ml
@@ -124,8 +124,8 @@ let lane_policies =
     ; mandatory_events = [ Keeper_runtime_manifest.Tool_surface_selected ]
     ; terminal_events = []
     }
-  ; { lane = "masc_policy_cascade"
-    ; mandatory_events = [ Keeper_runtime_manifest.Cascade_routed ]
+  ; { lane = "masc_policy_runtime"
+    ; mandatory_events = [ Keeper_runtime_manifest.Runtime_routed ]
     ; terminal_events = []
     }
   ; { lane = "oas_agent"
@@ -153,9 +153,9 @@ let event_lane = function
   | Keeper_runtime_manifest.Receipt_appended
   | Keeper_runtime_manifest.Turn_finished ->
     "keeper"
-  | Keeper_runtime_manifest.Cascade_routed
+  | Keeper_runtime_manifest.Runtime_routed
   | Keeper_runtime_manifest.Provider_lane_resolved ->
-    "masc_policy_cascade"
+    "masc_policy_runtime"
   | Keeper_runtime_manifest.Provider_attempt_started
   | Keeper_runtime_manifest.Provider_attempt_finished ->
     "provider"

--- a/lib/server/server_dashboard_http_namespace_truth_support.ml
+++ b/lib/server/server_dashboard_http_namespace_truth_support.ml
@@ -770,7 +770,7 @@ let derive_readiness_and_attention ~execution_json ~execution_summary
            | Some blocker ->
                let severity =
                  match blocker with
-                 | "cascade_exhausted" | "completion_contract_violation" -> "bad"
+                 | "runtime_exhausted" | "completion_contract_violation" -> "bad"
                  | _ -> "warn"
                in
                Some

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -894,7 +894,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
            cold-start diagnostics do not contend with the shell's first render. *)
         Server_routes_http_runtime.start_full_health_snapshot_refresh_loop ~sw ~clock);
       start_lazy_startup state;
-      (* RFC-0206: cascade catalog startup validation removed; Runtime.init_default
+      (* RFC-0206: runtime catalog startup validation removed; Runtime.init_default
          already fail-fasts on an invalid runtime config at boot. *)
       Server_bootstrap_loops.start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr state
     with

--- a/test/test_keeper_runtime_manifest.ml
+++ b/test/test_keeper_runtime_manifest.ml
@@ -1791,7 +1791,7 @@ let test_runtime_trace_lens_derives_clock_edges () =
         (json_int_member "edge_count" tool_group);
       Alcotest.(check (list string))
         "tool batch group spans tool and cascade lanes"
-        [ "tool_runtime"; "masc_policy_cascade" ]
+        [ "tool_runtime"; "masc_policy_runtime" ]
         (json_string_list_member "lanes" tool_group);
       let provider_group =
         require_group
@@ -2772,7 +2772,7 @@ let test_wired_manifest_sites () =
           "let keeper_turn_id = meta.runtime.usage.total_turns + 1";
           "Keeper_runtime_manifest.Turn_started";
           "Keeper_runtime_manifest.Phase_gate_decided";
-          "Keeper_runtime_manifest.Cascade_routed";
+          "Keeper_runtime_manifest.Runtime_routed";
           "Keeper_runtime_manifest.Event_bus_correlated";
           "turn_event_bus_manifest_decision";
         ] );


### PR DESCRIPTION
## Summary
- rename the runtime manifest event variant from `Cascade_routed` to `Runtime_routed`
- change the manifest wire event string from `cascade_routed` to `runtime_routed`
- move dashboard runtime-lens lane/gap labels from Cascade naming to runtime naming
- update the keeper unified-turn manifest append hook name accordingly
- rename composite observer TLA action variants and wire strings from Cascade selection/done/exhausted to runtime selection/done/exhausted
- rename the composite observer exposed state API from `cascade_state` to `runtime_state`
- rename registry turn-axis mutators/transition helpers from cascade state to runtime state
- rename keeper blocker/failure contracts from `Cascade_exhausted` / `cascade_exhausted` to runtime exhaustion naming
- rename production module references away from `Cascade_catalog_runtime`, `Cascade_runtime_candidate`, `Keeper_cascade_engine`, `Cascade_inference`, and `Cascade_capability_profile`
- rename keeper observation, receipt, runtime-attempt, and tool-call-log contracts away from cascade terminology

## Validation
- Not run. Continuing Cascade/catalog removal; build breakage is accepted for this cleanup.