### PR TITLE
Rename runtime health status API

### DIFF
--- a/lib/keeper/keeper_health_probe.ml
+++ b/lib/keeper/keeper_health_probe.ml
@@ -52,7 +52,7 @@ let runtime_pressure_class_of_label label =
   | _ -> None
 ;;
 
-let provider_runtime_pressure_class ~code ~detail ~http_status ~cascade_name =
+let provider_runtime_pressure_class ~code ~detail ~http_status ~runtime_id =
   let contains needle =
     String_util.contains_substring_ci code needle
     || String_util.contains_substring_ci detail needle
@@ -70,7 +70,7 @@ let provider_runtime_pressure_class ~code ~detail ~http_status ~cascade_name =
   else if
     contains "admission_capacity"
     || contains "inflight_capacity_full"
-    || Option.is_some cascade_name
+    || Option.is_some runtime_id
     || contains "admission="
   then Cascade_admission_full
   else if
@@ -103,8 +103,8 @@ let provider_runtime_pressure_class ~code ~detail ~http_status ~cascade_name =
 
 let runtime_pressure_class_of_failure_reason = function
   | Some (Keeper_registry.Provider_timeout_loop _) -> Some Provider_timeout
-  | Some (Keeper_registry.Provider_runtime_error { code; detail; http_status; cascade_name }) ->
-    Some (provider_runtime_pressure_class ~code ~detail ~http_status ~cascade_name)
+  | Some (Keeper_registry.Provider_runtime_error { code; detail; http_status; runtime_id }) ->
+    Some (provider_runtime_pressure_class ~code ~detail ~http_status ~runtime_id)
   | Some (Keeper_registry.Stale_turn_timeout _) -> Some Turn_stale_timeout
   | Some
       ( Keeper_registry.Heartbeat_consecutive_failures _
@@ -157,21 +157,21 @@ let record_item_result ~keeper_name ~item_id ~success =
   set_item_health ~keeper_name ~item_id status
 ;;
 
-let set_cascade_status ~cascade_name status =
+let set_runtime_status ~runtime_id status =
   Eio.Mutex.use_rw ~protect:true health_cache_mu (fun () ->
-    Hashtbl.replace health_cache (cascade_name, "") (status, Time_compat.now ()))
+    Hashtbl.replace health_cache (runtime_id, "") (status, Time_compat.now ()))
 ;;
 
-(** [get_cascade_status ~cascade_name] reads the cascade-level entry
+(** [get_runtime_status ~runtime_id] reads the runtime-level entry
     written by [run_once].  Three-valued:
       - [Healthy]    : last probe saw the cascade at < threshold ratio.
       - [Unhealthy r]: last probe saw the cascade at >= threshold ratio.
       - [Unknown]    : probe never wrote this cascade (e.g. boot before
                        first sweep, or no running keepers in the cascade
                        at the time of the last scan). *)
-let get_cascade_status ~cascade_name =
+let get_runtime_status ~runtime_id =
   Eio.Mutex.use_ro health_cache_mu (fun () ->
-    match Hashtbl.find_opt health_cache (cascade_name, "") with
+    match Hashtbl.find_opt health_cache (runtime_id, "") with
     | Some (status, _) -> status
     | None -> Unknown)
 ;;
@@ -205,7 +205,7 @@ let is_terminal_unhealthy (phase : Keeper_state_machine.phase) =
     keeper in a 3-member cascade became a permanent admission block in
     [keeper_supervisor.ml]'s auto-resume path. The floor restores the obvious
     invariant ("one keeper down out of N is recoverable") at every N. *)
-let max_failed_allowed_for_cascade ~total =
+let max_failed_allowed_for_runtime ~total =
   max 1 (total / 10)
 ;;
 
@@ -281,7 +281,7 @@ let scan_cascade_health ~base_path =
     (fun cascade acc rows ->
        let healthy =
          if acc.total <= 0 then true
-         else acc.failed <= max_failed_allowed_for_cascade ~total:acc.total
+         else acc.failed <= max_failed_allowed_for_runtime ~total:acc.total
        in
        (cascade, healthy, acc) :: rows)
     by_cascade
@@ -289,7 +289,7 @@ let scan_cascade_health ~base_path =
 ;;
 
 (** Compute health per cascade from registry entries.
-    Returns (cascade_name, is_healthy).
+    Returns (runtime_id, is_healthy).
 
     A keeper is counted as "failed" only when its phase is a terminal
     unhealthy state (Dead, Zombie, or Crashed).  Past restarts
@@ -316,14 +316,14 @@ let run_once ~base_path =
        let status =
          if healthy then Healthy else Unhealthy (cascade_failure_reason acc)
        in
-       set_cascade_status ~cascade_name:cascade status)
+       set_runtime_status ~runtime_id:runtime status)
     results
 ;;
 
 let rec probe_loop ~base_path ~interval_sec ~clock () =
   (* Cancel-aware: Safe_ops.protect re-raises Eio.Cancel.Cancelled and swallows
      other exceptions so a transient registry I/O failure cannot kill the fiber
-     and leave cascade status stale forever. *)
+     and leave runtime status stale forever. *)
   Safe_ops.protect ~default:() (fun () -> run_once ~base_path);
   Eio.Time.sleep clock interval_sec;
   probe_loop ~base_path ~interval_sec ~clock ()

--- a/lib/keeper/keeper_health_probe.mli
+++ b/lib/keeper/keeper_health_probe.mli
@@ -62,27 +62,27 @@ val is_terminal_unhealthy : Keeper_state_machine.phase -> bool
 
 (** {1 Cascade health scan} *)
 
-(** [max_failed_allowed_for_cascade ~total] returns the maximum number
+(** [max_failed_allowed_for_runtime ~total] returns the maximum number
     of terminal-unhealthy keepers (Dead/Zombie/Crashed) a cascade of
     size [total] can hold while still being treated as healthy.
     Formula: [max 1 (total / 10)] — one keeper down is always allowed,
     larger cascades scale at 10%.  Exposed so tests and other callers
     can derive the same admission threshold without duplicating the
     arithmetic. *)
-val max_failed_allowed_for_cascade : total:int -> int
+val max_failed_allowed_for_runtime : total:int -> int
 
 (** [check_cascade_health ~base_path] scans the registry and computes
     the health status of each active cascade.  Returns a list of
-    (cascade_name, is_healthy) pairs.  A keeper is counted as failed
+    (runtime_id, is_healthy) pairs.  A keeper is counted as failed
     only when its phase is Dead, Zombie, or Crashed — not based on
     restart_count, which is monotonic and would cause permanent
     cascade pollution.  Healthy iff
-    [failed <= max_failed_allowed_for_cascade ~total].  This function
+    [failed <= max_failed_allowed_for_runtime ~total].  This function
     performs I/O and should be called from the probe fiber, not the
     supervisor sweep. *)
 val check_cascade_health : base_path:string -> (string * bool) list
 
-(** [get_cascade_status ~cascade_name] returns the cached cascade-level
+(** [get_runtime_status ~runtime_id] returns the cached runtime-level
     [health_status] written by [run_once].  This preserves the [Unknown]
     case so the supervisor's auto-resume guard can distinguish
     "no probe data yet" from
@@ -93,7 +93,7 @@ val check_cascade_health : base_path:string -> (string * bool) list
     Phase 3.5 guard collapsed [Unknown] and [Unhealthy] to the same
     boolean result — turning the boot-time cold-cache window into a
     permanent auto-resume lockout for every cascade. *)
-val get_cascade_status : cascade_name:string -> health_status
+val get_runtime_status : runtime_id:string -> health_status
 
 (** [run_once ~base_path] runs [check_cascade_health] and writes the
     results into the cascade cache.  Idempotent and bounded (registry

--- a/lib/keeper/keeper_heartbeat_loop_scheduling.ml
+++ b/lib/keeper/keeper_heartbeat_loop_scheduling.ml
@@ -13,7 +13,7 @@ module Observations = Keeper_heartbeat_loop_observations
 type runtime_backpressure_decision = Observations.runtime_backpressure_decision =
   | Runtime_admitted
   | Runtime_backpressured of {
-      cascade_name : string;
+      runtime_id : string;
       reason : string;
     }
 
@@ -36,8 +36,8 @@ type keepalive_scheduling_decision = {
 let decide_keepalive_scheduling
       ?(runtime_resilience_of_name =
         Keeper_runtime_resilience.runtime_resilience_of_name)
-      ?(cascade_status_of_name =
-        fun ~cascade_name -> Keeper_health_probe.get_cascade_status ~cascade_name)
+      ?(runtime_status_of_name =
+        fun ~runtime_id -> Keeper_health_probe.get_runtime_status ~runtime_id)
       ~stop
       ~meta
       obs
@@ -46,14 +46,14 @@ let decide_keepalive_scheduling
   let requested_should_run_turn =
     (not (Atomic.get stop)) && turn_decision.should_run
   in
-  let cascade_name = runtime_id_of_meta meta in
-  let runtime_resilience = runtime_resilience_of_name cascade_name in
+  let runtime_id = runtime_id_of_meta meta in
+  let runtime_resilience = runtime_resilience_of_name runtime_id in
   let runtime_backpressure =
     runtime_backpressure_decision
       ~runtime_resilience:(Some runtime_resilience)
       ~should_run_turn:requested_should_run_turn
-      ~cascade_name
-      ~cascade_status:(cascade_status_of_name ~cascade_name)
+      ~runtime_id
+      ~runtime_status:(runtime_status_of_name ~runtime_id)
   in
   let should_run_turn =
     match runtime_backpressure with

--- a/lib/keeper/keeper_heartbeat_loop_scheduling.mli
+++ b/lib/keeper/keeper_heartbeat_loop_scheduling.mli
@@ -4,7 +4,7 @@ type runtime_backpressure_decision =
   Keeper_heartbeat_loop_observations.runtime_backpressure_decision =
   | Runtime_admitted
   | Runtime_backpressured of {
-      cascade_name : string;
+      runtime_id : string;
       reason : string;
     }
 
@@ -20,8 +20,8 @@ type keepalive_scheduling_decision = {
 
 val decide_keepalive_scheduling :
   ?runtime_resilience_of_name:(string -> Keeper_runtime_resilience.runtime_resilience) ->
-  ?cascade_status_of_name:
-    (cascade_name:string -> Keeper_health_probe.health_status) ->
+  ?runtime_status_of_name:
+    (runtime_id:string -> Keeper_health_probe.health_status) ->
   stop:bool Atomic.t ->
   meta:Keeper_meta_contract.keeper_meta ->
   Keeper_world_observation.world_observation ->

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -537,8 +537,8 @@ let sweep_and_recover (ctx : _ context) =
         when Keeper_supervisor_types.paused_meta_auto_resume_due ~now meta
              && not (Keeper_approval_queue.has_pending_for_keeper ~keeper_name:meta.name)
         ->
-        let cascade_name = Keeper_meta_contract.runtime_id_of_meta meta in
-        let cascade_status = Keeper_health_probe.get_cascade_status ~cascade_name in
+        let runtime_id = Keeper_meta_contract.runtime_id_of_meta meta in
+        let runtime_status = Keeper_health_probe.get_runtime_status ~runtime_id in
         (* Three-valued admission:
                     Unhealthy   — block, the probe saw restart pressure.
                     Healthy     — proceed with timer check.
@@ -551,16 +551,16 @@ let sweep_and_recover (ctx : _ context) =
                                   permanent lockout.  See instructions/
                                   software-development.md anti-pattern
                                   "Unknown -> Permissive Default". *)
-        (match cascade_status with
+        (match runtime_status with
          | Keeper_health_probe.Unhealthy reason ->
            Log.Keeper.info
              "%s: auto-resume blocked; cascade %s is unhealthy (%s)"
              name
-             cascade_name
+             runtime_id
              reason;
            Prometheus.inc_counter
              Keeper_metrics.(to_string AutoResumeBlockedTotal)
-             ~labels:[ "keeper", name; "cascade", cascade_name ]
+             ~labels:[ "keeper", name; "runtime_id", runtime_id ]
              ()
          | Keeper_health_probe.Unknown | Keeper_health_probe.Healthy ->
            let resume_after_sec =

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -625,7 +625,7 @@ let should_inject_entropic_oscillation ~since_last_scheduled_autonomous ~draw_pe
 ;;
 
 let keeper_cycle_decision
-      ?(provider_cooldown_remaining_sec = provider_cooldown_remaining_sec_for_cascade)
+      ?(provider_cooldown_remaining_sec = provider_cooldown_remaining_sec_for_runtime)
       ~(meta : keeper_meta)
       (observation : world_observation)
   =
@@ -763,20 +763,20 @@ let keeper_cycle_decision
                   || backlog_elapsed
                   || (idle_gate_elapsed && cooldown_elapsed)))
         in
-        let cascade_name = runtime_id_of_meta meta in
+        let runtime_id = runtime_id_of_meta meta in
         let provider_cooldown_remaining_sec =
           if should_run
           then
             provider_cooldown_remaining_sec
-              ~cascade_name:(cascade_name)
+              ~runtime_id:(runtime_id)
           else None
         in
         let provider_cooldown_fail_open =
           match provider_cooldown_remaining_sec with
           | Some _ ->
             fallback_cascade_for_provider_cooldown
-              ~base_runtime_id:cascade_name
-              ~effective_runtime_id:cascade_name
+              ~base_runtime_id:runtime_id
+              ~effective_runtime_id:runtime_id
           | None -> None
         in
         let verdict =

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -270,12 +270,12 @@ val effective_scheduled_autonomous_cooldown :
   base_cooldown:int -> since_last:int ->
   ?consecutive_noop_count:int -> unit -> int
 
-val provider_cooldown_remaining_sec_for_cascade :
-  cascade_name:string -> int option
+val provider_cooldown_remaining_sec_for_runtime :
+  runtime_id:string -> int option
 
 val provider_capacity_blocked_task_count :
   ?provider_cooldown_remaining_sec:
-    (cascade_name:string -> int option) ->
+    (runtime_id:string -> int option) ->
   meta:Keeper_meta_contract.keeper_meta ->
   claimable_task_count:int ->
   unit ->
@@ -294,12 +294,12 @@ val should_inject_entropic_oscillation :
 
 val keeper_cycle_decision :
   ?provider_cooldown_remaining_sec:
-    (cascade_name:string -> int option) ->
+    (runtime_id:string -> int option) ->
   meta:Keeper_meta_contract.keeper_meta -> world_observation -> keeper_cycle_decision
 
 val unified_turn_decision :
   ?provider_cooldown_remaining_sec:
-    (cascade_name:string -> int option) ->
+    (runtime_id:string -> int option) ->
   meta:Keeper_meta_contract.keeper_meta -> world_observation -> keeper_cycle_decision
 
 val should_run_keeper_cycle :

--- a/lib/keeper/keeper_world_observation_provider_cooldown.ml
+++ b/lib/keeper/keeper_world_observation_provider_cooldown.ml
@@ -24,12 +24,12 @@ let fallback_cascade_for_provider_cooldown
   then None
   else Some (Keeper_config.default_runtime_id ())
 
-let provider_cooldown_remaining_sec_for_cascade
-      ~(cascade_name : string)
+let provider_cooldown_remaining_sec_for_runtime
+      ~(runtime_id : string)
   : int option
   =
   let runtime_health_keys =
-    Provider_runtime_projection.default_execution_model_strings cascade_name
+    Provider_runtime_projection.default_execution_model_strings runtime_id
     |> Runtime_candidate.runtime_health_keys_of_labels
   in
   match runtime_health_keys with
@@ -64,7 +64,7 @@ let provider_cooldown_remaining_sec_for_cascade
         | first :: rest -> Some (List.fold_left min first rest)))
 
 let provider_capacity_blocked_task_count
-      ?(provider_cooldown_remaining_sec = provider_cooldown_remaining_sec_for_cascade)
+      ?(provider_cooldown_remaining_sec = provider_cooldown_remaining_sec_for_runtime)
       ~(meta : keeper_meta)
       ~(claimable_task_count : int)
       ()
@@ -72,15 +72,15 @@ let provider_capacity_blocked_task_count
   if claimable_task_count <= 0
   then 0
   else (
-    let cascade_name = runtime_id_of_meta meta in
+    let runtime_id = runtime_id_of_meta meta in
     match
       provider_cooldown_remaining_sec
-        ~cascade_name:(cascade_name)
+        ~runtime_id:(runtime_id)
     with
     | Some _
       when Option.is_none
              (fallback_cascade_for_provider_cooldown
-                ~base_runtime_id:cascade_name
-                ~effective_runtime_id:cascade_name) ->
+                ~base_runtime_id:runtime_id
+                ~effective_runtime_id:runtime_id) ->
       claimable_task_count
     | Some _ | None -> 0)

--- a/lib/keeper/keeper_world_observation_provider_cooldown.mli
+++ b/lib/keeper/keeper_world_observation_provider_cooldown.mli
@@ -3,11 +3,11 @@ val fallback_cascade_for_provider_cooldown :
   effective_runtime_id:string ->
   string option
 
-val provider_cooldown_remaining_sec_for_cascade :
-  cascade_name:string -> int option
+val provider_cooldown_remaining_sec_for_runtime :
+  runtime_id:string -> int option
 
 val provider_capacity_blocked_task_count :
-  ?provider_cooldown_remaining_sec:(cascade_name:string -> int option) ->
+  ?provider_cooldown_remaining_sec:(runtime_id:string -> int option) ->
   meta:Keeper_meta_contract.keeper_meta ->
   claimable_task_count:int ->
   unit ->

--- a/test/test_keeper_health_probe.ml
+++ b/test/test_keeper_health_probe.ml
@@ -1,6 +1,6 @@
 (* Tests for keeper_health_probe.  Pure synchronous tests for the
    cache and cascade ratio logic; the supervisor wiring (run_once
-   call site, get_cascade_status branch) is covered by integration
+   call site, get_runtime_status branch) is covered by integration
    tests in test_keeper_supervisor.ml. *)
 
 module H = Masc_mcp.Keeper_health_probe
@@ -25,7 +25,7 @@ let status_eq a b =
 
 let status_t = Alcotest.testable pp_status status_eq
 
-let make_meta ?cascade_name name =
+let make_meta ?runtime_id name =
   let fields =
     [
       ("name", `String name);
@@ -34,8 +34,8 @@ let make_meta ?cascade_name name =
     ]
   in
   let fields =
-    match cascade_name with
-    | Some cascade_name -> ("runtime_id", `String cascade_name) :: fields
+    match runtime_id with
+    | Some runtime_id -> ("runtime_id", `String runtime_id) :: fields
     | None -> fields
   in
   match Masc_test_deps.meta_of_json_fixture (`Assoc fields) with
@@ -49,12 +49,12 @@ let pressure_label_of_failure_reason reason =
     (H.runtime_pressure_class_of_failure_reason (Some reason))
 ;;
 
-let test_get_cascade_status_default_unknown () =
+let test_get_runtime_status_default_unknown () =
   Alcotest.check
     status_t
     "cold cascade cache = Unknown"
     H.Unknown
-    (H.get_cascade_status ~cascade_name:"never-written-cascade-xyz")
+    (H.get_runtime_status ~runtime_id:"never-written-cascade-xyz")
 ;;
 
 let test_check_cascade_health_all_healthy () =
@@ -75,7 +75,7 @@ let test_runtime_pressure_classifier () =
           ; detail = "source=client_capacity; all client slots full"
           ; provider_id = None
           ; http_status = None
-          ; cascade_name = None
+          ; runtime_id = None
           }));
   Alcotest.check
     pressure_label_t
@@ -87,7 +87,7 @@ let test_runtime_pressure_classifier () =
           ; detail = "inflight_capacity_full admission_key=strict_tool_candidates"
           ; provider_id = None
           ; http_status = None
-          ; cascade_name = None
+          ; runtime_id = None
           }));
   Alcotest.check
     pressure_label_t
@@ -99,7 +99,7 @@ let test_runtime_pressure_classifier () =
           ; detail = "rate limit"
           ; provider_id = Some "provider_d"
           ; http_status = Some 429
-          ; cascade_name = None
+          ; runtime_id = None
           }));
   Alcotest.check
     pressure_label_t
@@ -111,7 +111,7 @@ let test_runtime_pressure_classifier () =
           ; detail = "getaddrinfo ENOTFOUND api.z.ai"
           ; provider_id = Some "zai"
           ; http_status = None
-          ; cascade_name = None
+          ; runtime_id = None
           }));
   Alcotest.check
     pressure_label_t
@@ -123,7 +123,7 @@ let test_runtime_pressure_classifier () =
           ; detail = "inter_chunk_idle timeout"
           ; provider_id = None
           ; http_status = Some 504
-          ; cascade_name = None
+          ; runtime_id = None
           }));
   Alcotest.check
     pressure_label_t
@@ -135,7 +135,7 @@ let test_runtime_pressure_classifier () =
           ; detail = "unexpected provider failure"
           ; provider_id = None
           ; http_status = Some 500
-          ; cascade_name = None
+          ; runtime_id = None
           }));
   Alcotest.check
     pressure_label_t
@@ -158,11 +158,11 @@ let test_run_once_records_specific_failure_ratio_reason () =
   R.clear ();
   let base_dir = Filename.temp_file "probe-pressure-" "" in
   Sys.remove base_dir;
-  let cascade_name =
+  let runtime_id =
     Printf.sprintf "probe-provider-dns-%d" (Unix.getpid ())
   in
   let register_crashed name reason =
-    let meta = make_meta ~cascade_name name in
+    let meta = make_meta ~runtime_id name in
     (* See: fixture setup only needs the registry side effect. *)
     ignore (R.register ~base_path:base_dir name meta);
     R.set_failure_reason ~base_path:base_dir name (Some reason);
@@ -184,7 +184,7 @@ let test_run_once_records_specific_failure_ratio_reason () =
             ; detail = "getaddrinfo ENOTFOUND api.z.ai"
             ; provider_id = Some "zai"
             ; http_status = None
-            ; cascade_name = None
+            ; runtime_id = None
             });
        register_crashed
          "provider-dns-b"
@@ -193,14 +193,14 @@ let test_run_once_records_specific_failure_ratio_reason () =
             ; detail = "getaddrinfo ENOTFOUND api.z.ai"
             ; provider_id = Some "zai"
             ; http_status = None
-            ; cascade_name = None
+            ; runtime_id = None
             });
        H.run_once ~base_path:base_dir;
        Alcotest.check
          status_t
          "unhealthy reason carries dominant runtime pressure"
          (H.Unhealthy "failure_ratio:provider_dns_failure")
-         (H.get_cascade_status ~cascade_name))
+         (H.get_runtime_status ~runtime_id))
 ;;
 
 (* ------------------------------------------------------------------ *)
@@ -254,7 +254,7 @@ let check_max_failed name ~total ~expected =
   Alcotest.(check int)
     (Printf.sprintf "max_failed_allowed N=%d %s" total name)
     expected
-    (H.max_failed_allowed_for_cascade ~total)
+    (H.max_failed_allowed_for_runtime ~total)
 ;;
 
 let test_max_failed_small_cascade_floor () =
@@ -283,7 +283,7 @@ let test_max_failed_monotone_nondecreasing () =
   let rec loop prev n =
     if n > 50 then ()
     else
-      let cur = H.max_failed_allowed_for_cascade ~total:n in
+      let cur = H.max_failed_allowed_for_runtime ~total:n in
       Alcotest.(check bool)
         (Printf.sprintf "max_failed N=%d >= N=%d" n (n - 1))
         true
@@ -300,7 +300,7 @@ let () =
       , [ Alcotest.test_case
             "default_status_is_unknown"
             `Quick
-            test_get_cascade_status_default_unknown
+            test_get_runtime_status_default_unknown
         ] )
     ; ( "cascade"
       , [ Alcotest.test_case

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -30,23 +30,23 @@ module Keeper_types = Masc_mcp.Keeper_types
 module Keeper_types_support = Masc_mcp.Keeper_types_support
 
 (* #19327 cascade purge: Cascade_name is a plain string alias. *)
-let oas_error_cascade_name raw =
+let oas_error_runtime_id raw =
   Masc_mcp.Keeper_runtime_profile.normalize_declared_name raw
   |> Cascade_name.of_string_exn
 ;;
 
 let phase_recovery_runtime_id () =
-  Masc_mcp.Keeper_runtime_profile.cascade_name_for_use
+  Masc_mcp.Keeper_runtime_profile.runtime_id_for_use
     Masc_mcp.Keeper_runtime_profile.Phase_recovery
 ;;
 
-let tool_required_cascade_name () =
-  Masc_mcp.Keeper_runtime_profile.cascade_name_for_use
+let tool_required_runtime_id () =
+  Masc_mcp.Keeper_runtime_profile.runtime_id_for_use
     Masc_mcp.Keeper_runtime_profile.Tool_required
 ;;
 
-let keeper_turn_cascade_name () =
-  Masc_mcp.Keeper_runtime_profile.cascade_name_for_use
+let keeper_turn_runtime_id () =
+  Masc_mcp.Keeper_runtime_profile.runtime_id_for_use
     Masc_mcp.Keeper_runtime_profile.Keeper_turn
 ;;
 
@@ -59,7 +59,7 @@ let normalize_keeper_runtime_declared_name raw =
    resolve to the Keeper_turn route, not pass the dead name through to capability
    resolution (which crash-loops the keeper with no_tool_capable_provider). *)
 let test_keeper_runtime_declared_name_substitutes_unresolvable_with_keeper_turn () =
-  let expected = keeper_turn_cascade_name () in
+  let expected = keeper_turn_runtime_id () in
   check
     string
     "legacy tier-group.* declared name resolves to keeper_turn route"
@@ -83,16 +83,16 @@ let test_keeper_runtime_declared_name_preserves_logical_use_route () =
   check
     string
     "logical-use keeper_turn resolves to the keeper_turn route target"
-    (keeper_turn_cascade_name ())
+    (keeper_turn_runtime_id ())
     (normalize_keeper_runtime_declared_name "keeper_turn");
   check
     string
     "logical-use tool_required resolves to the tool_required route target"
-    (tool_required_cascade_name ())
+    (tool_required_runtime_id ())
     (normalize_keeper_runtime_declared_name "tool_required")
 ;;
 
-let safe_lane_cascade_name = Masc_mcp.Cascade_capability_profile.safe_lane_cascade_name
+let safe_lane_runtime_id = Masc_mcp.Cascade_capability_profile.safe_lane_runtime_id
 
 let has_prompt_root path =
   Sys.file_exists (Filename.concat path "config/prompts/keeper.unified.system.md")
@@ -1179,7 +1179,7 @@ let test_scheduled_turn_uses_cooldown_only () =
     "cooldown opens scheduled turn for current task"
     true
     (WO.keeper_cycle_decision
-       ~provider_cooldown_remaining_sec:(fun ~cascade_name:_ -> None)
+       ~provider_cooldown_remaining_sec:(fun ~runtime_id:_ -> None)
        ~meta
        obs)
       .should_run
@@ -1292,7 +1292,7 @@ let test_provider_cooldown_blocks_scheduled_turn_when_work_is_ready () =
   in
   let decision =
     WO.keeper_cycle_decision
-      ~provider_cooldown_remaining_sec:(fun ~cascade_name:_ -> Some 3599)
+      ~provider_cooldown_remaining_sec:(fun ~runtime_id:_ -> Some 3599)
       ~meta
       base_observation
   in
@@ -1320,15 +1320,15 @@ let test_provider_capacity_blocked_backlog_count_requires_non_fail_open_cooldown
   let default_meta = minimal_meta in
   let blocked =
     WO.provider_capacity_blocked_task_count
-      ~provider_cooldown_remaining_sec:(fun ~cascade_name:_ -> Some 3599)
+      ~provider_cooldown_remaining_sec:(fun ~runtime_id:_ -> Some 3599)
       ~meta:default_meta
       ~claimable_task_count:3
       ()
   in
-  check int "default cascade cooldown blocks claimable backlog" 3 blocked;
+  check int "default runtime cooldown blocks claimable backlog" 3 blocked;
   let healthy =
     WO.provider_capacity_blocked_task_count
-      ~provider_cooldown_remaining_sec:(fun ~cascade_name:_ -> None)
+      ~provider_cooldown_remaining_sec:(fun ~runtime_id:_ -> None)
       ~meta:default_meta
       ~claimable_task_count:3
       ()
@@ -1339,7 +1339,7 @@ let test_provider_capacity_blocked_backlog_count_requires_non_fail_open_cooldown
   in
   let fail_open_blocked =
     WO.provider_capacity_blocked_task_count
-      ~provider_cooldown_remaining_sec:(fun ~cascade_name:_ -> Some 3599)
+      ~provider_cooldown_remaining_sec:(fun ~runtime_id:_ -> Some 3599)
       ~meta:fail_open_meta
       ~claimable_task_count:3
       ()
@@ -1366,7 +1366,7 @@ let test_provider_cooldown_keeps_scheduled_turn_open_when_fail_open_exists () =
   in
   let decision =
     WO.keeper_cycle_decision
-      ~provider_cooldown_remaining_sec:(fun ~cascade_name:_ -> Some 3599)
+      ~provider_cooldown_remaining_sec:(fun ~runtime_id:_ -> Some 3599)
       ~meta
       base_observation
   in
@@ -1389,11 +1389,11 @@ let test_provider_cooldown_keeps_scheduled_turn_open_when_fail_open_exists () =
      | WO.Run _ -> false)
 ;;
 
-let healthy_cascade_resilience cascade_name
+let healthy_cascade_resilience runtime_id
   : Masc_mcp.Keeper_cascade_resilience.cascade_resilience
   =
   { ok = true
-  ; cascade_name
+  ; runtime_id
   ; model_labels = []
   ; pure_local = false
   ; fallback_cascade = None
@@ -1403,15 +1403,15 @@ let healthy_cascade_resilience cascade_name
   }
 ;;
 
-let blocked_cascade_resilience cascade_name =
-  { (healthy_cascade_resilience cascade_name) with
+let blocked_cascade_resilience runtime_id =
+  { (healthy_cascade_resilience runtime_id) with
     ok = false
   ; blocker = Some "test_blocker"
   ; error = Some "blocked"
   }
 ;;
 
-let healthy_cascade_status ~cascade_name:_ = Masc_mcp.Keeper_health_probe.Healthy
+let healthy_cascade_status ~runtime_id:_ = Masc_mcp.Keeper_health_probe.Healthy
 
 let test_keepalive_scheduling_seam_preserves_reactive_run () =
   let meta = make_meta "heartbeat-scheduling-reactive" in
@@ -1511,7 +1511,7 @@ let test_idle_decay_triggers_turn () =
     "idle decay triggers turn before base cooldown"
     true
     (WO.keeper_cycle_decision
-       ~provider_cooldown_remaining_sec:(fun ~cascade_name:_ -> None)
+       ~provider_cooldown_remaining_sec:(fun ~runtime_id:_ -> None)
        ~meta
        base_observation)
       .should_run
@@ -1533,7 +1533,7 @@ let test_scheduled_turn_decision_uses_backlog_acceleration () =
   let obs = { base_observation with idle_seconds = 120; failed_task_count = 2 } in
   let decision =
     WO.keeper_cycle_decision
-      ~provider_cooldown_remaining_sec:(fun ~cascade_name:_ -> None)
+      ~provider_cooldown_remaining_sec:(fun ~runtime_id:_ -> None)
       ~meta
       obs
   in
@@ -1583,7 +1583,7 @@ let test_scheduled_turn_ignores_unclaimable_backlog () =
   in
   let decision =
     WO.keeper_cycle_decision
-      ~provider_cooldown_remaining_sec:(fun ~cascade_name:_ -> None)
+      ~provider_cooldown_remaining_sec:(fun ~runtime_id:_ -> None)
       ~meta
       obs
   in
@@ -1717,7 +1717,7 @@ let test_task_reactive_cooldown_floor_never_hits_zero () =
     let obs = { base_observation with idle_seconds = 120; failed_task_count = 1 } in
     let decision =
       WO.keeper_cycle_decision
-        ~provider_cooldown_remaining_sec:(fun ~cascade_name:_ -> None)
+        ~provider_cooldown_remaining_sec:(fun ~runtime_id:_ -> None)
         ~meta
         obs
     in
@@ -1752,7 +1752,7 @@ let test_task_backlog_cooldown_applies_noop_backoff_once () =
     in
     let decision =
       WO.keeper_cycle_decision
-        ~provider_cooldown_remaining_sec:(fun ~cascade_name:_ -> None)
+        ~provider_cooldown_remaining_sec:(fun ~runtime_id:_ -> None)
         ~meta
         obs
     in
@@ -1789,7 +1789,7 @@ let test_scheduled_turn_decision_runs_immediately_on_fresh_backlog_update () =
   in
   let decision =
     WO.keeper_cycle_decision
-      ~provider_cooldown_remaining_sec:(fun ~cascade_name:_ -> None)
+      ~provider_cooldown_remaining_sec:(fun ~runtime_id:_ -> None)
       ~meta
       obs
   in
@@ -1822,7 +1822,7 @@ let test_bootstrap_turn_fires_when_never_started () =
   let obs = { base_observation with idle_seconds = 0 } in
   let decision =
     WO.keeper_cycle_decision
-      ~provider_cooldown_remaining_sec:(fun ~cascade_name:_ -> None)
+      ~provider_cooldown_remaining_sec:(fun ~runtime_id:_ -> None)
       ~meta
       obs
   in
@@ -1854,7 +1854,7 @@ let test_bootstrap_turn_emits_scheduled_autonomous_channel () =
   let obs = { base_observation with idle_seconds = 0 } in
   let decision =
     WO.keeper_cycle_decision
-      ~provider_cooldown_remaining_sec:(fun ~cascade_name:_ -> None)
+      ~provider_cooldown_remaining_sec:(fun ~runtime_id:_ -> None)
       ~meta
       obs
   in
@@ -1878,7 +1878,7 @@ let test_provider_cooldown_blocks_bootstrap_turn () =
   let obs = { base_observation with idle_seconds = 0 } in
   let decision =
     WO.keeper_cycle_decision
-      ~provider_cooldown_remaining_sec:(fun ~cascade_name:_ -> Some 3599)
+      ~provider_cooldown_remaining_sec:(fun ~runtime_id:_ -> Some 3599)
       ~meta
       obs
   in
@@ -1920,7 +1920,7 @@ let test_min_interval_fires_without_work_signal () =
     let obs = { base_observation with idle_seconds = 0 } in
     let decision =
       WO.keeper_cycle_decision
-        ~provider_cooldown_remaining_sec:(fun ~cascade_name:_ -> None)
+        ~provider_cooldown_remaining_sec:(fun ~runtime_id:_ -> None)
         ~meta
         obs
     in
@@ -1955,7 +1955,7 @@ let test_min_interval_turn_is_not_tagged_entropic () =
     let obs = { base_observation with idle_seconds = 0 } in
     let decision =
       WO.keeper_cycle_decision
-        ~provider_cooldown_remaining_sec:(fun ~cascade_name:_ -> None)
+        ~provider_cooldown_remaining_sec:(fun ~runtime_id:_ -> None)
         ~meta
         obs
     in
@@ -1998,7 +1998,7 @@ let test_min_interval_does_not_fire_before_elapsed () =
     let obs = { base_observation with idle_seconds = 0 } in
     let decision =
       WO.keeper_cycle_decision
-        ~provider_cooldown_remaining_sec:(fun ~cascade_name:_ -> None)
+        ~provider_cooldown_remaining_sec:(fun ~runtime_id:_ -> None)
         ~meta
         obs
     in
@@ -2034,7 +2034,7 @@ let test_min_interval_never_fires_for_bootstrap () =
     let obs = { base_observation with idle_seconds = 0 } in
     let decision =
       WO.keeper_cycle_decision
-        ~provider_cooldown_remaining_sec:(fun ~cascade_name:_ -> None)
+        ~provider_cooldown_remaining_sec:(fun ~runtime_id:_ -> None)
         ~meta
         obs
     in
@@ -2072,7 +2072,7 @@ let test_provider_cooldown_blocks_min_interval_turn () =
     let obs = { base_observation with idle_seconds = 0 } in
     let decision =
       WO.keeper_cycle_decision
-        ~provider_cooldown_remaining_sec:(fun ~cascade_name:_ -> Some 3599)
+        ~provider_cooldown_remaining_sec:(fun ~runtime_id:_ -> Some 3599)
         ~meta
         obs
     in
@@ -3635,8 +3635,8 @@ let test_metrics_surface_model_prefers_successful_cascade_label () =
       ~input_tok:100
       ~output_tok:50
       ~cascade_observation:
-        { Masc_mcp.Cascade_observation.cascade_name =
-            oas_error_cascade_name Masc_mcp.(Keeper_config.default_runtime_id ())
+        { Masc_mcp.Cascade_observation.runtime_id =
+            oas_error_runtime_id Masc_mcp.(Keeper_config.default_runtime_id ())
         ; strategy = Some "round_robin"
         ; configured_labels = [ "llama:auto" ]
         ; candidate_models = [ "llama:qwen3.5-35b-a3b-ud-q8-xl"; selected_label ]
@@ -4287,8 +4287,8 @@ let test_append_metrics_snapshot_includes_cascade_observation () =
          ; run_validation = Some validation
          ; cascade_observation =
              Some
-               { Masc_mcp.Cascade_observation.cascade_name =
-                   oas_error_cascade_name Masc_mcp.(Keeper_config.default_runtime_id ())
+               { Masc_mcp.Cascade_observation.runtime_id =
+                   oas_error_runtime_id Masc_mcp.(Keeper_config.default_runtime_id ())
                ; strategy = Some "round_robin"
                ; configured_labels = [ "llama:auto" ]
                ; candidate_models =
@@ -4398,7 +4398,7 @@ let test_append_metrics_snapshot_includes_cascade_observation () =
          string
          "cascade name persisted"
          Masc_mcp.(Keeper_config.default_runtime_id ())
-         Yojson.Safe.Util.(json |> member "cascade" |> member "cascade_name" |> to_string);
+         Yojson.Safe.Util.(json |> member "cascade" |> member "runtime_id" |> to_string);
        check
          bool
          "fallback applied persisted"
@@ -5725,8 +5725,8 @@ let test_streaming_cancel_records_supervisor_stop_when_fiber_stop_set () =
          ~config
          ~run_meta:meta
          ~run_generation:meta.runtime.generation
-         ~cascade_name:
-           (oas_error_cascade_name (Masc_mcp.Keeper_meta_contract.cascade_name_of_meta meta))
+         ~runtime_id:
+           (oas_error_runtime_id (Masc_mcp.Keeper_meta_contract.runtime_id_of_meta meta))
          ~keeper_turn_id:meta.runtime.usage.total_turns
          ();
        let supervisor_request_after =
@@ -6178,8 +6178,8 @@ let wrapped_claude_max_turns_error () =
 let structured_cascade_max_turns_error () =
   Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
     (Masc_mcp.Keeper_turn_driver.Cascade_exhausted
-       { cascade_name =
-           oas_error_cascade_name Masc_mcp.(Keeper_config.default_runtime_id ())
+       { runtime_id =
+           oas_error_runtime_id Masc_mcp.(Keeper_config.default_runtime_id ())
        ; reason = Keeper_meta_contract.Max_turns_exceeded
        })
 ;;
@@ -6229,7 +6229,7 @@ let test_degraded_retry_after_recoverable_error_uses_local_recovery_for_resumabl
       ~tool_requirement:Masc_mcp.Keeper_agent_tool_surface.Optional
       (Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
          (Masc_mcp.Keeper_turn_driver.Resumable_cli_session
-            { cascade_name = oas_error_cascade_name "cli_tool_c_keeper"
+            { runtime_id = oas_error_runtime_id "cli_tool_c_keeper"
             ; detail =
                 "cli-tool exited with code 75: \n\
                  To resume this session: cli-tool -r ff37febe-2adb-4ac6-9dc6-cae23e672fbc"
@@ -6251,7 +6251,7 @@ let test_degraded_retry_after_recoverable_error_includes_admission_queue_timeout
       (Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
          (Masc_mcp.Keeper_turn_driver.Admission_queue_timeout
             { keeper_name = "nick0cave"
-            ; cascade_name = oas_error_cascade_name "primary"
+            ; runtime_id = oas_error_runtime_id "primary"
             ; wait_sec = 90.0
             }))
   in
@@ -6385,7 +6385,7 @@ let test_next_fail_open_cascade_for_turn_returns_untried_default_cascade () =
   in
   expect_degraded_retry
     "next degraded retry uses configured fallback"
-    safe_lane_cascade_name
+    safe_lane_runtime_id
     "hard_quota"
     degraded_retry
 ;;
@@ -6401,7 +6401,7 @@ let test_next_fail_open_cascade_for_turn_continues_to_local_recovery () =
   in
   expect_degraded_retry
     "configured fallback remains after default"
-    safe_lane_cascade_name
+    safe_lane_runtime_id
     "hard_quota"
     degraded_retry
 ;;
@@ -6416,7 +6416,7 @@ let test_next_fail_open_cascade_for_turn_suppresses_exhausted_rotation_group () 
         [ "scoring"
         ; KC.default_runtime_id ()
         ; (KC.default_runtime_id ())
-        ; safe_lane_cascade_name
+        ; safe_lane_runtime_id
         ]
       (wrapped_claude_limit_error ())
   in
@@ -6434,7 +6434,7 @@ let test_next_fail_open_cascade_for_required_tool_uses_tool_required_route () =
   in
   expect_degraded_retry
     "required tool degraded retry uses configured tool-required route"
-    (tool_required_cascade_name ())
+    (tool_required_runtime_id ())
     "hard_quota"
     degraded_retry
 ;;
@@ -6483,7 +6483,7 @@ let test_next_fail_open_cascade_for_turn_uses_catalog_rotation_profile () =
   in
   expect_degraded_retry
     "catalog degraded retry uses configured fallback first"
-    safe_lane_cascade_name
+    safe_lane_runtime_id
     "hard_quota"
     degraded_retry
 ;;
@@ -6499,7 +6499,7 @@ let test_next_fail_open_cascade_for_turn_does_not_inject_default_when_catalog_om
   in
   expect_degraded_retry
     "catalog-only degraded retry uses configured fallback first"
-    safe_lane_cascade_name
+    safe_lane_runtime_id
     "hard_quota"
     degraded_retry
 ;;
@@ -6531,7 +6531,7 @@ let test_next_fail_open_cascade_for_required_tool_rejects_local_recovery_only_ca
   in
   expect_degraded_retry
     "required catalog tool-required-backed recovery"
-    (tool_required_cascade_name ())
+    (tool_required_runtime_id ())
     "required_tool_contract_violation"
     degraded_retry
 ;;
@@ -6544,7 +6544,7 @@ let test_next_fail_open_cascade_for_required_tool_does_not_fall_through_to_manua
       ~base_runtime_id:"strict_exec"
       ~effective_runtime_id:"strict_exec"
       ~tool_requirement:Masc_mcp.Keeper_agent_tool_surface.Required
-      ~attempted_runtime_ids:[ "strict_exec"; tool_required_cascade_name () ]
+      ~attempted_runtime_ids:[ "strict_exec"; tool_required_runtime_id () ]
       (required_tool_contract_violation_error ())
   in
   check bool
@@ -6819,7 +6819,7 @@ let test_metrics_failure_response_redacts_resumable_cli_session_payload () =
   let sdk_error =
     Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
       (Masc_mcp.Keeper_turn_driver.Resumable_cli_session
-         { cascade_name = oas_error_cascade_name "cli_tool_c_keeper"
+         { runtime_id = oas_error_runtime_id "cli_tool_c_keeper"
          ; detail = canonical_detail
          ; exit_code = Some 75
          })
@@ -7641,8 +7641,8 @@ let test_runtime_exhausted_error_detected_from_structured_internal_error () =
   let err =
     Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
       (Masc_mcp.Keeper_turn_driver.Cascade_exhausted
-         { cascade_name =
-             oas_error_cascade_name Masc_mcp.(Keeper_config.default_runtime_id ())
+         { runtime_id =
+             oas_error_runtime_id Masc_mcp.(Keeper_config.default_runtime_id ())
          ; reason = Masc_mcp.Keeper_meta_contract.All_providers_failed
          })
   in
@@ -7700,8 +7700,8 @@ let test_auto_recoverable_turn_error_includes_filtered_candidates_cascade_exhaus
   let err =
     Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
       (Masc_mcp.Keeper_turn_driver.Cascade_exhausted
-         { cascade_name =
-             oas_error_cascade_name Masc_mcp.(Keeper_config.default_runtime_id ())
+         { runtime_id =
+             oas_error_runtime_id Masc_mcp.(Keeper_config.default_runtime_id ())
          ; reason = Keeper_meta_contract.Candidates_filtered_after_cycles
          })
   in
@@ -7716,7 +7716,7 @@ let test_auto_recoverable_turn_error_includes_resumable_cli_session_error () =
   let err =
     Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
       (Masc_mcp.Keeper_turn_driver.Resumable_cli_session
-         { cascade_name = oas_error_cascade_name "cli_tool_c_keeper"
+         { runtime_id = oas_error_runtime_id "cli_tool_c_keeper"
          ; detail =
              Masc_mcp.Cascade_transport.Json_stream_cli_transport_local.resumable_session_detail
          ; exit_code = Some 75
@@ -7733,7 +7733,7 @@ let test_runtime_exhausted_error_includes_resumable_cli_session_error () =
   let err =
     Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
       (Masc_mcp.Keeper_turn_driver.Resumable_cli_session
-         { cascade_name = oas_error_cascade_name "cli_tool_c_keeper"
+         { runtime_id = oas_error_runtime_id "cli_tool_c_keeper"
          ; detail =
              Masc_mcp.Cascade_transport.Json_stream_cli_transport_local.resumable_session_detail
          ; exit_code = Some 75
@@ -9426,7 +9426,7 @@ let test_social_model_bdi_failure_state_rewrites_claim_retry_loop () =
       ~sdk_error:None
       ~reason:
         "Internal error: [masc_oas_error] \
-         {\"kind\":\"runtime_exhausted\",\"cascade_name\":\"tool_use_strict\"}"
+         {\"kind\":\"runtime_exhausted\",\"runtime_id\":\"tool_use_strict\"}"
   in
   check
     string


### PR DESCRIPTION
## Summary
- rename Keeper health probe APIs from cascade status to runtime status terms
- update heartbeat scheduling and supervisor callsites to use runtime_id/runtime_status naming
- update health probe tests from get_cascade_status/max_failed_allowed_for_cascade to runtime equivalents
- rename world-observation provider cooldown APIs/callback params from cascade_name to runtime_id terms

## Validation
- Not run. Continuing Cascade/catalog removal; build breakage is accepted for this cleanup.