### PR TITLE
Rename runtime preflight health tracker

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -74,7 +74,7 @@ let heartbeat_event_intake = Stimulus_intake.heartbeat_event_intake
 type runtime_backpressure_decision = Observations.runtime_backpressure_decision =
   | Runtime_admitted
   | Runtime_backpressured of {
-      cascade_name : string;
+      runtime_id : string;
       reason : string;
     }
 
@@ -233,15 +233,15 @@ let run_keepalive_unified_turn
              ~base_path:ctx.config.base_path
              meta_after_triage.name
              ~reasons:admission_reason_strs
-         | Runtime_backpressured { cascade_name; reason } ->
+         | Runtime_backpressured { runtime_id; reason } ->
            record_runtime_backpressure_observation
              ~base_path:ctx.config.base_path
              ~keeper_name:meta_after_triage.name
              ~reason;
            Log.Keeper.info
-             "keepalive turn backpressured for %s: cascade=%s reason=%s requested=[%s]"
+             "keepalive turn backpressured for %s: runtime=%s reason=%s requested=[%s]"
              meta_after_triage.name
-             cascade_name
+             runtime_id
              reason
              (String.concat "," verdict_strs));
         let paused_info =

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -74,7 +74,7 @@ val record_semaphore_wait_observation :
 type runtime_backpressure_decision =
   | Runtime_admitted
   | Runtime_backpressured of {
-      cascade_name : string;
+      runtime_id : string;
       reason : string;
     }
 
@@ -101,8 +101,8 @@ type keepalive_scheduling_decision = {
 
 val decide_keepalive_scheduling :
   ?runtime_resilience_of_name:(string -> Keeper_runtime_resilience.runtime_resilience) ->
-  ?cascade_status_of_name:
-    (cascade_name:string -> Keeper_health_probe.health_status) ->
+  ?runtime_status_of_name:
+    (runtime_id:string -> Keeper_health_probe.health_status) ->
   stop:bool Atomic.t ->
   meta:keeper_meta ->
   Keeper_world_observation.world_observation ->
@@ -111,8 +111,8 @@ val decide_keepalive_scheduling :
 val runtime_backpressure_decision :
   runtime_resilience:Keeper_runtime_resilience.runtime_resilience option ->
   should_run_turn:bool ->
-  cascade_name:string ->
-  cascade_status:Keeper_health_probe.health_status ->
+  runtime_id:string ->
+  runtime_status:Keeper_health_probe.health_status ->
   runtime_backpressure_decision
 
 val runtime_backpressure_observation_reasons : reason:string -> string list
@@ -124,7 +124,7 @@ val semaphore_wait_timeout_blocker_class :
   Keeper_turn_slot.semaphore_wait_timeout -> blocker_class
 
 val semaphore_wait_timeout_diagnostics :
-  cascade_name:string -> Keeper_turn_slot.semaphore_wait_timeout -> string * string
+  runtime_id:string -> Keeper_turn_slot.semaphore_wait_timeout -> string * string
 
 val provider_timeout_observation_reasons : string list
 

--- a/lib/keeper/keeper_heartbeat_loop_observations.ml
+++ b/lib/keeper/keeper_heartbeat_loop_observations.ml
@@ -69,7 +69,7 @@ let record_semaphore_wait_observation
 type runtime_backpressure_decision =
   | Runtime_admitted
   | Runtime_backpressured of {
-      cascade_name : string;
+      runtime_id : string;
       reason : string;
     }
 
@@ -101,7 +101,7 @@ let runtime_backpressure_observation_reasons ~reason =
   let category =
     if String.starts_with ~prefix:"runtime_resilience_" reason
     then "runtime_resilience"
-    else "cascade_unhealthy"
+    else "runtime_unhealthy"
   in
   let base = [ "runtime_backpressure"; category ] in
   let class_reasons =
@@ -123,18 +123,18 @@ let runtime_resilience_backpressure_reason
 let runtime_backpressure_decision
       ~runtime_resilience
       ~should_run_turn
-      ~cascade_name
-      ~cascade_status
+      ~runtime_id
+      ~runtime_status
   =
   let resilience_reason =
     match runtime_resilience with
     | None -> None
     | Some resilience -> runtime_resilience_backpressure_reason resilience
   in
-  match should_run_turn, cascade_status, resilience_reason with
+  match should_run_turn, runtime_status, resilience_reason with
   | true, Keeper_health_probe.Unhealthy reason, _ ->
-    Runtime_backpressured { cascade_name; reason }
-  | true, _, Some reason -> Runtime_backpressured { cascade_name; reason }
+    Runtime_backpressured { runtime_id; reason }
+  | true, _, Some reason -> Runtime_backpressured { runtime_id; reason }
   | false, _, _
   | true, Keeper_health_probe.Unknown, None
   | true, Keeper_health_probe.Healthy, None -> Runtime_admitted

--- a/lib/keeper/keeper_heartbeat_loop_observations.mli
+++ b/lib/keeper/keeper_heartbeat_loop_observations.mli
@@ -23,7 +23,7 @@ val record_semaphore_wait_observation
 type runtime_backpressure_decision =
   | Runtime_admitted
   | Runtime_backpressured of {
-      cascade_name : string;
+      runtime_id : string;
       reason : string;
     }
 
@@ -32,8 +32,8 @@ val runtime_backpressure_observation_reasons : reason:string -> string list
 val runtime_backpressure_decision
   :  runtime_resilience:Keeper_runtime_resilience.runtime_resilience option
   -> should_run_turn:bool
-  -> cascade_name:string
-  -> cascade_status:Keeper_health_probe.health_status
+  -> runtime_id:string
+  -> runtime_status:Keeper_health_probe.health_status
   -> runtime_backpressure_decision
 
 val record_runtime_backpressure_observation

--- a/lib/keeper/keeper_heartbeat_loop_scheduling.ml
+++ b/lib/keeper/keeper_heartbeat_loop_scheduling.ml
@@ -1,7 +1,7 @@
 (** Keepalive scheduling decision for the heartbeat loop, extracted from
     [keeper_heartbeat_loop.ml]. Holds the record type returned by
     [decide_keepalive_scheduling] and the pure decision function that
-    combines the turn verdict with cascade backpressure admission. *)
+    combines the turn verdict with runtime backpressure admission. *)
 
 open Keeper_types
 open Keeper_meta_contract

--- a/lib/keeper/keeper_heartbeat_loop_semaphore_timeout.ml
+++ b/lib/keeper/keeper_heartbeat_loop_semaphore_timeout.ml
@@ -27,7 +27,7 @@ let semaphore_wait_timeout_blocker_class
 ;;
 
 let semaphore_wait_timeout_diagnostics
-      ~cascade_name
+      ~runtime_id
       (timeout : Keeper_turn_slot.semaphore_wait_timeout)
   =
   let phase_label =
@@ -44,11 +44,11 @@ let semaphore_wait_timeout_diagnostics
   in
   let persisted_blocker =
     Printf.sprintf
-      "skipped: semaphore wait > %.0fs phase=%s (cascade=%s%s queue_depth=%d \
+      "skipped: semaphore wait > %.0fs phase=%s (runtime=%s%s queue_depth=%d \
        autonomous_available=%d reactive_available=%d turn_available=%d)"
       timeout.timeout_wait_sec
       phase_label
-      cascade_name
+      runtime_id
       queue_ahead_text
       timeout.timeout_queue_depth
       timeout.timeout_autonomous_available
@@ -103,7 +103,7 @@ let handle_semaphore_wait_timeout
     ();
   let persisted_blocker, log_diagnostic =
     semaphore_wait_timeout_diagnostics
-      ~cascade_name:(runtime_id_of_meta meta_after_triage)
+      ~runtime_id:(runtime_id_of_meta meta_after_triage)
       timeout
   in
   let blocker_class = semaphore_wait_timeout_blocker_class timeout in
@@ -126,4 +126,3 @@ let handle_semaphore_wait_timeout
        })
     meta_after_triage
 ;;
-

--- a/lib/keeper/keeper_heartbeat_loop_semaphore_timeout.mli
+++ b/lib/keeper/keeper_heartbeat_loop_semaphore_timeout.mli
@@ -19,7 +19,7 @@ val semaphore_wait_timeout_blocker_class
   -> Keeper_meta_contract.blocker_class
 
 val semaphore_wait_timeout_diagnostics
-  :  cascade_name:string
+  :  runtime_id:string
   -> Keeper_turn_slot.semaphore_wait_timeout
   -> string * string
 

--- a/lib/keeper/keeper_preflight_health_tracker.ml
+++ b/lib/keeper/keeper_preflight_health_tracker.ml
@@ -9,7 +9,7 @@ type reason =
   | Rate_limited_long_window
 
 type fingerprint = {
-  cascade_name : string;
+  runtime_id : string;
   provider : string;
   reason : reason;
 }
@@ -37,31 +37,31 @@ let reason_slug = function
   | Rate_limited_long_window -> "rate-limited-long-window"
 ;;
 
-(* Owned metric names. Following the cascade_metrics.ml RFC-0043 pattern
+(* Owned metric names. Following the runtime_metrics.ml RFC-0043 pattern
    (module owns its constants; [Prometheus.ml]'s register_all() may mirror
    for /metrics endpoint registration later). *)
 let metric_preflight_unhealthy_skip =
-  "masc_cascade_preflight_unhealthy_skip_total"
+  "masc_runtime_preflight_unhealthy_skip_total"
 ;;
 
-let metric_provider_disabled = "masc_cascade_provider_disabled_total"
-let metric_provider_re_enabled = "masc_cascade_provider_re_enabled_total"
+let metric_provider_disabled = "masc_runtime_provider_disabled_total"
+let metric_provider_re_enabled = "masc_runtime_provider_re_enabled_total"
 
 (* ── State ──────────────────────────────────────────────────────── *)
 
 (* [Hashtbl] keyed by an opaque triple to avoid string interpolation
-   collisions when cascade_name or provider contain separators. *)
+   collisions when runtime_id or provider contain separators. *)
 module Key = struct
   type t = fingerprint
 
   let equal (a : t) (b : t) =
-    String.equal a.cascade_name b.cascade_name
+    String.equal a.runtime_id b.runtime_id
     && String.equal a.provider b.provider
     && a.reason = b.reason
   ;;
 
   let hash (k : t) =
-    Hashtbl.hash (k.cascade_name, k.provider, reason_slug k.reason)
+    Hashtbl.hash (k.runtime_id, k.provider, reason_slug k.reason)
   ;;
 end
 
@@ -79,7 +79,7 @@ end)
 type t = {
   counts : int FpTbl.t;
   disabled : (float * string) StrTbl.t;
-      (** Maps provider → (disabled_at_timestamp, cascade_name).
+      (** Maps provider → (disabled_at_timestamp, runtime_id).
           The timestamp enables TTL-based auto-expiry so providers
           don't stay disabled forever (GitHub #18502). *)
   mu : Stdlib.Mutex.t;
@@ -107,14 +107,14 @@ let with_lock t f =
 
 (* ── Public API ─────────────────────────────────────────────────── *)
 
-let record ?(clock = Time_compat.now) t ~cascade_name ~provider ~reason : record_outcome =
-  let fp = { cascade_name; provider; reason } in
+let record ?(clock = Time_compat.now) t ~runtime_id ~provider ~reason : record_outcome =
+  let fp = { runtime_id; provider; reason } in
   with_lock t (fun () ->
     (* Always tick the per-call counter so dashboards see absolute
        skip volume (independent of disable transitions). *)
     Prometheus.inc_counter metric_preflight_unhealthy_skip
       ~labels:
-        [ ("cascade", cascade_name)
+        [ ("runtime_id", runtime_id)
         ; ("provider", provider)
         ; ("reason", reason_slug reason)
         ]
@@ -129,10 +129,10 @@ let record ?(clock = Time_compat.now) t ~cascade_name ~provider ~reason : record
       then `First
       else if next >= t.threshold
       then (
-        StrTbl.replace t.disabled provider (clock (), cascade_name);
+        StrTbl.replace t.disabled provider (clock (), runtime_id);
         Prometheus.inc_counter metric_provider_disabled
           ~labels:
-            [ ("cascade", cascade_name)
+            [ ("runtime_id", runtime_id)
             ; ("provider", provider)
             ; ("reason", reason_slug reason)
             ]
@@ -145,7 +145,7 @@ let is_disabled ?(clock = Time_compat.now) t ~provider =
   with_lock t (fun () ->
     match StrTbl.find_opt t.disabled provider with
     | None -> false
-    | Some (disabled_at, _cascade_name) ->
+    | Some (disabled_at, _runtime_id) ->
       let age = clock () -. disabled_at in
       if age >= disabled_ttl_seconds
       then (

--- a/lib/keeper/keeper_preflight_health_tracker.mli
+++ b/lib/keeper/keeper_preflight_health_tracker.mli
@@ -1,7 +1,7 @@
-(** Cascade preflight unhealthy-skip escalation state.
+(** Runtime preflight unhealthy-skip escalation state.
 
     Tracks repeated [preflight skipped N unhealthy ...] events per
-    (cascade_name, provider, reason) fingerprint. After [threshold_disable]
+    (runtime_id, provider, reason) fingerprint. After [threshold_disable]
     consecutive skips of the same fingerprint, the provider is registered
     in an in-memory disabled list and a single ERROR-class escalation is
     emitted (instead of a WARN per skip).
@@ -15,7 +15,7 @@
     - Routing semantics are preserved: the disabled list is advisory.
       Callers may still attempt the provider; this module only changes
       the {e log-level cadence}, not routing.
-    - State is in-memory only (per-process). Survives across cascade
+    - State is in-memory only (per-process). Survives across runtime
       attempts in one keeper-server lifetime; rebuilt at restart.
     - Closed sum types only, no catch-all match.
 
@@ -46,7 +46,7 @@ type reason =
 
 (** Fingerprint of a single skip event. *)
 type fingerprint = {
-  cascade_name : string;  (** Cascade name (e.g. ["strict_tool_candidates"]). *)
+  runtime_id : string;  (** Runtime id (e.g. ["strict_tool_candidates"]). *)
   provider : string;  (** Provider key or endpoint URL. *)
   reason : reason;
 }
@@ -90,12 +90,12 @@ val global : t
 (** Record one preflight unhealthy-skip event. Returns the outcome,
     which the caller uses to decide log level and disable-list
     registration. Increments
-    [masc_cascade_preflight_unhealthy_skip_total] (always) and
-    [masc_cascade_provider_disabled_total] (on the [`Threshold_disable]
+    [masc_runtime_preflight_unhealthy_skip_total] (always) and
+    [masc_runtime_provider_disabled_total] (on the [`Threshold_disable]
     transition). *)
 val record :
   ?clock:(unit -> float) ->
-  t -> cascade_name:string -> provider:string -> reason:reason -> record_outcome
+  t -> runtime_id:string -> provider:string -> reason:reason -> record_outcome
 
 (** True iff the provider is currently in the disabled list (i.e. some
     fingerprint crossed threshold and recovery has not happened yet).

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -260,7 +260,7 @@ let run_named
   (* RFC: MASC/OAS Error-Warn Reduction Goal — 2026-05-18 §P3.
      For each unhealthy endpoint, record the preflight-skip event in
      [Keeper_preflight_health_tracker.global]. After N consecutive skips of
-     the same (cascade, endpoint, reason) fingerprint we escalate to
+     the same (runtime_id, endpoint, reason) fingerprint we escalate to
      ERROR once and register the endpoint in the in-process disabled
      list — subsequent identical skips return [`Already_disabled] and
      are dropped to DEBUG, so the log volume drops from ~35-50/30min
@@ -281,7 +281,7 @@ let run_named
       match outcome with
       | `First ->
         Log.Misc.warn
-          "cascade %s: preflight skipped 1 unhealthy local endpoint(s) before \
+          "runtime %s: preflight skipped 1 unhealthy local endpoint(s) before \
            provider dispatch: [%s] (reason=%s, first occurrence)"
           runtime_id
           endpoint
@@ -289,7 +289,7 @@ let run_named
              Keeper_preflight_health_tracker.Health_check_failed_repeatedly)
       | `Repeated n ->
         Log.Misc.warn
-          "cascade %s: preflight skipped 1 unhealthy local endpoint(s) before \
+          "runtime %s: preflight skipped 1 unhealthy local endpoint(s) before \
            provider dispatch: [%s] (reason=%s, consecutive=%d)"
           runtime_id
           endpoint
@@ -298,7 +298,7 @@ let run_named
           n
       | `Threshold_disable n ->
         Log.Misc.error
-          "cascade %s: provider [%s] disabled after %d consecutive preflight \
+          "runtime %s: provider [%s] disabled after %d consecutive preflight \
            unhealthy skips (reason=%s); subsequent skips silenced via \
            disabled-list. Recovery requires successful health probe."
           runtime_id
@@ -310,7 +310,7 @@ let run_named
         (* Drop noise: this endpoint is in the disabled list and has
            already emitted its ERROR escalation. *)
         Log.Misc.debug
-          "cascade %s: preflight skipped already-disabled endpoint [%s]"
+          "runtime %s: preflight skipped already-disabled endpoint [%s]"
           runtime_id endpoint)
     unhealthy_local_endpoints;
   (* Recovery: for any endpoint that probed healthy this cycle, clear
@@ -328,7 +328,7 @@ let run_named
         if recovered
         then
           Log.Misc.info
-            "cascade %s: provider [%s] re-enabled after successful health \
+            "runtime %s: provider [%s] re-enabled after successful health \
              probe; removed from disabled-list."
             runtime_id url)
     local_endpoint_health;

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -755,53 +755,14 @@ let run_named
       ?last_capacity_backpressure
       try_cascade_ctx remaining last_err
   in
-  (* Pluggable strategy + cycle/backoff wrapper (since 0.9.6).
-
-     When no [<name>_strategy] is configured in cascade.toml,
-     [Cascade_config.resolve_strategy] returns [Cascade_strategy.failover]
-     with [max_cycles = 1].  In that case [cycle_loop] invokes
-     [try_cascade] exactly once on the original [candidate_cfgs] —
-     bit-identical to the pre-strategy behaviour (linear failover). *)
-  let profile_knob_or_default ~knob ~default resolve =
-    match resolve () with
-    | Ok value -> Ok value
-    | Error detail ->
-        Log.Misc.error "cascade %s: %s" runtime_id detail;
-        Error (runtime_catalog_error_to_sdk_error detail)
-  in
-  let* strategy =
-    profile_knob_or_default ~knob:"strategy"
-      ~default:Cascade_strategy.failover
-      (fun () -> Runtime_catalog.resolve_strategy ~name:runtime_id ())
-  in
-  let strategy_name = Cascade_strategy.kind_to_string strategy.kind in
-  let () = cascade_strategy_name_ref := Some strategy_name in
+  (* Runtime dispatch no longer resolves a cascade strategy catalog.
+     Candidate ordering is produced by the runtime candidate resolution layer;
+     this driver only applies the health fail-open filter and executes the
+     provider attempts in that order. *)
+  let runtime_strategy_name = "linear_failover" in
+  let () = cascade_strategy_name_ref := Some runtime_strategy_name in
   let _ = sw, net in
-  let adapter = Runtime_candidate.strategy_adapter in
-  let signal_ctx : Cascade_strategy.signal_ctx = {
-    health = Keeper_binding_health.global;
-    capacity = Cascade_capacity_probe.capacity;
-    now = Unix.gettimeofday ();
-    rand_int = Random.int;
-    keeper_name;
-    runtime_id = error_runtime_id;
-  } in
-  let cycle_clock = Eio_context.get_clock_opt () in
-  let do_backoff cycle =
-    let ms = Cascade_strategy.backoff_ms strategy.cycle ~cycle in
-    if ms <= 0 then ()
-    else
-      let secs = float_of_int ms /. 1000. in
-      match cycle_clock with
-      | Some clock -> Eio.Time.sleep clock secs
-      | None ->
-        (* No Eio clock available — skip backoff rather than block the
-           thread.  Reachable only outside an Eio.Switch, which is not a
-           supported entry path for this worker; the cycle simply
-           continues without throttling. *)
-        ()
-  in
-  let runtime_exhausted_after_filter ~cycle =
+  let runtime_exhausted_after_filter () =
     let observation =
       Keeper_observation.runtime_observation_with_metrics
         ~runtime_id:error_runtime_id
@@ -819,66 +780,22 @@ let run_named
               reason = Keeper_meta_contract.Candidates_filtered_after_cycles;
             }))
   in
-  let record_trace ~cycle ~candidates_out ~backoff_ms ~kind =
-    Cascade_strategy_trace.record {
-      ts = Unix.gettimeofday ();
-      runtime_id = runtime_id;
-      strategy = strategy_name;
-      cycle;
-      candidates_in = List.length candidates;
-      candidates_out;
-      backoff_ms;
-      kind;
-      (* trace_id is left [None] until the keeper_turn_id wired by
-         Step 0a is threaded into [try_cascade]; downstream consumers
-         (dashboard_cascade, bin/masc_trace) already render [None] as
-         a JSON [null] so producers can adopt incrementally. *)
-      trace_id = None;
-      confidence_score = None;
-    }
-  in
-  let rec cycle_loop n =
+  let cycle_loop () =
     let ordered =
-      Cascade_strategy.order_candidates strategy
-        ~adapter ~ctx:signal_ctx ~cycle:n candidates
+      candidates
       |> filter_provider_health_fail_open
     in
-    let last_cycle = n + 1 >= strategy.cycle.max_cycles in
     match ordered with
-    | [] when last_cycle ->
-      record_trace ~cycle:n ~candidates_out:0 ~backoff_ms:0 ~kind:Exhausted;
-      runtime_exhausted_after_filter ~cycle:n
-    | [] ->
-      let backoff = Cascade_strategy.backoff_ms strategy.cycle ~cycle:(n + 1) in
-      record_trace ~cycle:n ~candidates_out:0 ~backoff_ms:backoff
-        ~kind:Filtered_empty;
-      Log.Misc.info
-        "cascade %s: cycle %d (%s) filtered all candidates, retrying"
-        runtime_id n strategy_name;
-      do_backoff (n + 1);
-      cycle_loop (n + 1)
+    | [] -> runtime_exhausted_after_filter ()
     | _ ->
-      record_trace ~cycle:n ~candidates_out:(List.length ordered)
-        ~backoff_ms:0 ~kind:Ordered;
-      let on_success ~provider_key =
-        Cascade_strategy.record_choice strategy ~ctx:signal_ctx ~provider_key
-      in
-      (match try_cascade ~on_success ?per_provider_timeout_s ordered None with
-       | Ok _ as ok -> ok
-       | Error _ as err when last_cycle -> err
-       | Error _ ->
-         Log.Misc.info
-           "cascade %s: cycle %d exhausted, backoff before retry (strategy=%s)"
-           runtime_id n strategy_name;
-         do_backoff (n + 1);
-         cycle_loop (n + 1))
+      try_cascade ?per_provider_timeout_s ordered None
   in
   let admission_runtime_id =
     runtime_id
   in
   match Admission_queue.with_permit ?wait_timeout_sec
     ~priority:queue_priority ~keeper_name:name ~runtime_id:admission_runtime_id
-    (fun () -> cycle_loop 0) with
+    cycle_loop with
   | Ok result -> result
   | Error (`Host_resource_saturated reason) ->
       Error

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -12,10 +12,9 @@
 
 (** {1 MASC/OAS structured errors}
 
-    Re-exported from {!Runtime_error_classify} (which itself includes
-    {!Cascade_internal_error}). Using [include module type of] instead of a
-    manual type copy so the interface stays structurally identical to the
-    implementation's [include Runtime_error_classify]. *)
+    Re-exported from {!Runtime_error_classify}. Using [include module type of]
+    instead of a manual type copy so the interface stays structurally identical
+    to the implementation's [include Runtime_error_classify]. *)
 
 include module type of Runtime_error_classify
 

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -1,6 +1,6 @@
-(** Keeper_turn_driver — MASC named-cascade and model-label execution entry points.
+(** Keeper_turn_driver — MASC named-runtime and model-label execution entry points.
 
-    Public API for running OAS agents through MASC-managed named cascade
+    Public API for running OAS agents through MASC-managed named runtime
     profiles ([run_named]) or explicit model label ([run_model_by_label]),
     with optional MASC tool bridging variants.
 
@@ -19,7 +19,7 @@
 
 include module type of Runtime_error_classify
 
-(** {1 Cascade error helpers} *)
+(** {1 Runtime error helpers} *)
 
 val sdk_error_to_runtime_id_outcome :
   Agent_sdk.Error.sdk_error -> Runtime_fsm.provider_outcome option

--- a/lib/keeper/keeper_turn_driver_backpressure.ml
+++ b/lib/keeper/keeper_turn_driver_backpressure.ml
@@ -5,7 +5,7 @@
 
     @since God file decomposition *)
 
-open Cascade_internal_error
+open Keeper_meta_contract
 open Runtime_name
 
 (* Synthetic backoff default for paths where the upstream provides no
@@ -30,7 +30,7 @@ let capacity_backpressure_source_of_http_error = function
   | Llm_provider.Http_client.ProviderFailure _ ->
     None
 
-let capacity_backpressure_of_http_error ?source ~cascade_name last_err =
+let capacity_backpressure_of_http_error ?source ~runtime_id last_err =
   match last_err with
   | Some
       (Llm_provider.Http_client.ProviderFailure
@@ -43,7 +43,7 @@ let capacity_backpressure_of_http_error ?source ~cascade_name last_err =
     Some
       (Capacity_backpressure
          {
-           cascade_name;
+           cascade_name = runtime_id;
            source =
              Option.value source ~default:Provider_capacity;
            detail = message;
@@ -61,7 +61,7 @@ let capacity_backpressure_of_http_error ?source ~cascade_name last_err =
     Some
       (Capacity_backpressure
          {
-           cascade_name;
+           cascade_name = runtime_id;
            source = Option.value source ~default:Cascade_slot;
            detail = message;
            retry_after = Synthetic_default synthetic_retry_after_sec;
@@ -76,12 +76,12 @@ let capacity_backpressure_of_http_error ?source ~cascade_name last_err =
   | None ->
     None
 
-let capacity_backpressure_of_pending ~cascade_name = function
+let capacity_backpressure_of_pending ~runtime_id = function
   | Some (source, detail, retry_after) ->
     Some
       (Capacity_backpressure
          {
-           cascade_name;
+           cascade_name = runtime_id;
            source;
            detail;
            retry_after;
@@ -89,7 +89,7 @@ let capacity_backpressure_of_pending ~cascade_name = function
   | None -> None
 
 let capacity_backpressure_of_sdk_error
-    ~cascade_name
+    ~runtime_id
     ~message_looks_like_capacity_backpressure
     ~sdk_error_of_masc_internal_error
     sdk_err =
@@ -100,7 +100,7 @@ let capacity_backpressure_of_sdk_error
       (sdk_error_of_masc_internal_error
          (Capacity_backpressure
             {
-              cascade_name;
+              cascade_name = runtime_id;
               source = Provider_capacity;
               detail;
               retry_after =
@@ -114,7 +114,7 @@ let capacity_backpressure_of_sdk_error
       (sdk_error_of_masc_internal_error
          (Capacity_backpressure
             {
-              cascade_name;
+              cascade_name = runtime_id;
               source = Provider_capacity;
               detail = msg;
               retry_after = Synthetic_default synthetic_retry_after_sec;

--- a/lib/keeper/keeper_turn_driver_backpressure.mli
+++ b/lib/keeper/keeper_turn_driver_backpressure.mli
@@ -14,7 +14,7 @@ val capacity_backpressure_source_of_http_error :
     when the error indicates capacity exhaustion. *)
 val capacity_backpressure_of_http_error :
   ?source:Keeper_meta_contract.capacity_backpressure_source ->
-  cascade_name:string ->
+  runtime_id:string ->
   Llm_provider.Http_client.http_error option ->
   Keeper_meta_contract.masc_internal_error option
 
@@ -24,7 +24,7 @@ val capacity_backpressure_of_http_error :
     [No_retry_hint]) so a synthetic default is never read as an explicit
     hint. *)
 val capacity_backpressure_of_pending :
-  cascade_name:string ->
+  runtime_id:string ->
   (Keeper_meta_contract.capacity_backpressure_source * string
    * Keeper_meta_contract.capacity_retry_after) option ->
   Keeper_meta_contract.masc_internal_error option
@@ -33,7 +33,7 @@ val capacity_backpressure_of_pending :
     when the error indicates provider capacity exhaustion or a
     backpressure-like internal message. *)
 val capacity_backpressure_of_sdk_error :
-  cascade_name:string ->
+  runtime_id:string ->
   message_looks_like_capacity_backpressure:(string -> bool) ->
   sdk_error_of_masc_internal_error:(Keeper_meta_contract.masc_internal_error ->
                                     Agent_sdk.Error.sdk_error) ->

--- a/lib/keeper/keeper_turn_fsm.ml
+++ b/lib/keeper/keeper_turn_fsm.ml
@@ -11,7 +11,7 @@ type failure_reason =
       resolved : string option;
     }
   | Failure_no_tool_capable_provider of {
-      cascade_name : string;
+      runtime_id : string;
       detail : string;
     }
   | Failure_provider_error of { kind : string; detail : string }
@@ -109,9 +109,9 @@ let pp_failure_reason fmt = function
       Format.fprintf fmt "runtime_unavailable(base=%s,resolved=%s)"
         base
         (Option.value resolved ~default:"-")
-  | Failure_no_tool_capable_provider { cascade_name; detail } ->
-      Format.fprintf fmt "no_tool_capable_provider(cascade=%s,detail=%s)"
-        cascade_name detail
+  | Failure_no_tool_capable_provider { runtime_id; detail } ->
+      Format.fprintf fmt "no_tool_capable_provider(runtime=%s,detail=%s)"
+        runtime_id detail
   | Failure_provider_error { kind; detail } ->
       Format.fprintf fmt "provider_error(kind=%s,detail=%s)" kind detail
   | Failure_tool_contract_violation { reason_code } ->

--- a/lib/keeper/keeper_turn_fsm.mli
+++ b/lib/keeper/keeper_turn_fsm.mli
@@ -26,7 +26,7 @@ type failure_reason =
       resolved : string option;
     }
   | Failure_no_tool_capable_provider of {
-      cascade_name : string;
+      runtime_id : string;
       detail : string;
     }
   | Failure_provider_error of { kind : string; detail : string }

--- a/test/test_keeper_error_classify_recoverable.ml
+++ b/test/test_keeper_error_classify_recoverable.ml
@@ -41,7 +41,7 @@ let make_capacity_backpressure ?(source = Owne.Client_capacity)
          cascade_name = test_cascade;
          source;
          detail;
-         retry_after = Masc_mcp.Cascade_internal_error.No_retry_hint;
+         retry_after = Masc_mcp.Keeper_meta_contract.No_retry_hint;
        })
 
 let make_no_tool_capable () =

--- a/test/test_keeper_semaphore_wait_counter.ml
+++ b/test/test_keeper_semaphore_wait_counter.ml
@@ -249,87 +249,87 @@ let test_cascade_backpressure_decision () =
     }
   in
   let unhealthy =
-    KHL.cascade_backpressure_decision
-      ~cascade_resilience:None
+    KHL.runtime_backpressure_decision
+      ~runtime_resilience:None
       ~should_run_turn:true
-      ~cascade_name:"primary"
-      ~cascade_status:(Masc_mcp.Keeper_health_probe.Unhealthy "failure_ratio")
+      ~runtime_id:"primary"
+      ~runtime_status:(Masc_mcp.Keeper_health_probe.Unhealthy "failure_ratio")
   in
   (match unhealthy with
-   | KHL.Cascade_backpressured { cascade_name; reason } ->
-     Alcotest.(check string) "cascade name" "primary" cascade_name;
+   | KHL.Runtime_backpressured { runtime_id; reason } ->
+     Alcotest.(check string) "runtime id" "primary" runtime_id;
      Alcotest.(check string) "reason" "failure_ratio" reason
-   | KHL.Cascade_admitted -> Alcotest.fail "unhealthy cascade was admitted");
+   | KHL.Runtime_admitted -> Alcotest.fail "unhealthy runtime was admitted");
   (match
-     KHL.cascade_backpressure_decision
-       ~cascade_resilience:None
+     KHL.runtime_backpressure_decision
+       ~runtime_resilience:None
        ~should_run_turn:true
-       ~cascade_name:"primary"
-       ~cascade_status:Masc_mcp.Keeper_health_probe.Healthy
+       ~runtime_id:"primary"
+       ~runtime_status:Masc_mcp.Keeper_health_probe.Healthy
    with
-   | KHL.Cascade_admitted -> ()
-   | KHL.Cascade_backpressured _ -> Alcotest.fail "healthy cascade was blocked");
+   | KHL.Runtime_admitted -> ()
+   | KHL.Runtime_backpressured _ -> Alcotest.fail "healthy runtime was blocked");
   (match
-     KHL.cascade_backpressure_decision
-       ~cascade_resilience:None
+     KHL.runtime_backpressure_decision
+       ~runtime_resilience:None
        ~should_run_turn:true
-       ~cascade_name:"primary"
-       ~cascade_status:Masc_mcp.Keeper_health_probe.Unknown
+       ~runtime_id:"primary"
+       ~runtime_status:Masc_mcp.Keeper_health_probe.Unknown
    with
-   | KHL.Cascade_admitted -> ()
-   | KHL.Cascade_backpressured _ -> Alcotest.fail "unknown cascade was blocked");
+   | KHL.Runtime_admitted -> ()
+   | KHL.Runtime_backpressured _ -> Alcotest.fail "unknown runtime was blocked");
   (match
-     KHL.cascade_backpressure_decision
-       ~cascade_resilience:(Some blocked_resilience)
+     KHL.runtime_backpressure_decision
+       ~runtime_resilience:(Some blocked_resilience)
        ~should_run_turn:true
-       ~cascade_name:"cascade.provider_k-coding-with-spark"
-       ~cascade_status:Masc_mcp.Keeper_health_probe.Healthy
+       ~runtime_id:"cascade.provider_k-coding-with-spark"
+       ~runtime_status:Masc_mcp.Keeper_health_probe.Healthy
    with
-   | KHL.Cascade_backpressured { cascade_name; reason } ->
+   | KHL.Runtime_backpressured { runtime_id; reason } ->
      Alcotest.(check string)
-       "resilience cascade name"
+       "resilience runtime id"
        "cascade.provider_k-coding-with-spark"
-       cascade_name;
+       runtime_id;
      Alcotest.(check string)
        "resilience reason"
-       "cascade_resilience_pure_local_single_provider_no_fallback"
+       "runtime_resilience_pure_local_single_provider_no_fallback"
        reason
-   | KHL.Cascade_admitted -> Alcotest.fail "bad cascade resilience was admitted");
+   | KHL.Runtime_admitted -> Alcotest.fail "bad runtime resilience was admitted");
   match
-    KHL.cascade_backpressure_decision
-      ~cascade_resilience:(Some blocked_resilience)
+    KHL.runtime_backpressure_decision
+      ~runtime_resilience:(Some blocked_resilience)
       ~should_run_turn:false
-      ~cascade_name:"primary"
-      ~cascade_status:(Masc_mcp.Keeper_health_probe.Unhealthy "failure_ratio")
+      ~runtime_id:"primary"
+      ~runtime_status:(Masc_mcp.Keeper_health_probe.Unhealthy "failure_ratio")
   with
-  | KHL.Cascade_admitted -> ()
-  | KHL.Cascade_backpressured _ ->
+  | KHL.Runtime_admitted -> ()
+  | KHL.Runtime_backpressured _ ->
     Alcotest.fail "already-skipped turn was reclassified"
 
 let test_cascade_backpressure_reason_labels () =
   Alcotest.(check (list string))
-    "cascade backpressure reasons"
-    [ "cascade_backpressure"; "cascade_unhealthy"; "reason_failure_ratio_" ]
-    (KHL.cascade_backpressure_observation_reasons ~reason:"Failure Ratio!");
+    "runtime backpressure reasons"
+    [ "runtime_backpressure"; "runtime_unhealthy"; "reason_failure_ratio_" ]
+    (KHL.runtime_backpressure_observation_reasons ~reason:"Failure Ratio!");
   Alcotest.(check (list string))
-    "provider dns cascade backpressure reasons"
+    "provider dns runtime backpressure reasons"
     [
-      "cascade_backpressure";
-      "cascade_unhealthy";
+      "runtime_backpressure";
+      "runtime_unhealthy";
       "class_provider_dns_failure";
       "reason_failure_ratio_provider_dns_failure";
     ]
-    (KHL.cascade_backpressure_observation_reasons
+    (KHL.runtime_backpressure_observation_reasons
        ~reason:"failure_ratio:provider_dns_failure");
   Alcotest.(check (list string))
-    "cascade resilience backpressure reasons"
+    "runtime resilience backpressure reasons"
     [
-      "cascade_backpressure";
-      "cascade_resilience";
-      "reason_cascade_resilience_pure_local_single_provider_no_fallback";
+      "runtime_backpressure";
+      "runtime_resilience";
+      "reason_runtime_resilience_pure_local_single_provider_no_fallback";
     ]
-    (KHL.cascade_backpressure_observation_reasons
-       ~reason:"cascade_resilience_pure_local_single_provider_no_fallback")
+    (KHL.runtime_backpressure_observation_reasons
+       ~reason:"runtime_resilience_pure_local_single_provider_no_fallback")
 
 let test_cascade_backpressure_updates_registry () =
   let base_path =
@@ -349,7 +349,7 @@ let test_cascade_backpressure_updates_registry () =
          | Some entry -> entry.meta.runtime.usage.last_turn_ts
          | None -> Alcotest.fail "registered keeper missing before observation"
        in
-       KHL.record_cascade_backpressure_observation
+       KHL.record_runtime_backpressure_observation
          ~base_path
          ~keeper_name:keeper
          ~reason:"failure_ratio";
@@ -361,7 +361,7 @@ let test_cascade_backpressure_updates_registry () =
            } ->
          Alcotest.(check (list string))
            "backpressure stamped for watchdog routing"
-           [ "cascade_backpressure"; "cascade_unhealthy"; "reason_failure_ratio" ]
+           [ "runtime_backpressure"; "runtime_unhealthy"; "reason_failure_ratio" ]
            reasons;
          Alcotest.(check bool)
            "last_turn_ts touched"
@@ -378,7 +378,7 @@ let test_queue_head_timeout_diagnostic_names_fifo_blocker () =
     "admission_queue_wait_timeout"
     (Keeper_meta_contract.blocker_class_to_string blocker_class);
   let persisted, log_diagnostic =
-    KHL.semaphore_wait_timeout_diagnostics ~cascade_name:"queue-cascade" timeout
+    KHL.semaphore_wait_timeout_diagnostics ~runtime_id:"queue-runtime" timeout
   in
   Alcotest.(check bool)
     "persisted detail names fifo blocker"
@@ -410,7 +410,7 @@ let test_autonomous_slot_timeout_keeps_holder_diagnostic () =
     "autonomous_slot_wait_timeout"
     (Keeper_meta_contract.blocker_class_to_string blocker_class);
   let _persisted, log_diagnostic =
-    KHL.semaphore_wait_timeout_diagnostics ~cascade_name:"slot-cascade" timeout
+    KHL.semaphore_wait_timeout_diagnostics ~runtime_id:"slot-runtime" timeout
   in
   Alcotest.(check bool)
     "slot diagnostic still names holders"

--- a/test/test_keeper_status_runtime.ml
+++ b/test/test_keeper_status_runtime.ml
@@ -522,13 +522,13 @@ let test_runtime_surface_derives_runtime_exhausted_from_meta () =
   KR.clear ();
   let base = make_meta ~name:"runtime-cascade-exhausted-test" () in
   let reason =
-    (* The canonical envelope written by [masc_internal_error_to_json] in
-       lib/cascade/cascade_internal_error.ml uses a typed [reason] field
+    (* The canonical envelope written by [masc_internal_error_to_json] uses
+       a typed [reason] field
        (variant serialization), not a free-form ["detail"] string.  Use
        the typed value here so the runtime_blocker_summary classifier
        (keeper_status_bridge.ml:298) can recover the variant and
        synthesize the canonical English summary. *)
-    "Internal error: [masc_oas_error] {\"kind\":\"runtime_exhausted\",\"cascade_name\":\"primary\",\"reason\":\"connection_refused\"}"
+    "Internal error: [masc_oas_error] {\"kind\":\"runtime_exhausted\",\"runtime_id\":\"primary\",\"reason\":\"connection_refused\"}"
   in
   let meta =
     {

--- a/test/test_keeper_status_runtime.ml
+++ b/test/test_keeper_status_runtime.ml
@@ -739,7 +739,7 @@ let test_status_bridge_classifies_oas_agent_execution_timeout () =
 let test_runtime_blocker_summary_is_not_reparsed_from_masc_error_payload () =
   let summary =
     "Internal error: [masc_oas_error] \
-     {\"kind\":\"capacity_backpressure\",\"cascade_name\":\"primary\",\"source\":\"client_capacity\",\"detail\":\"slot full\",\"retry_after_sec\":null}"
+     {\"kind\":\"capacity_backpressure\",\"runtime_id\":\"primary\",\"source\":\"client_capacity\",\"detail\":\"slot full\",\"retry_after_sec\":null}"
   in
   let cascade_surface =
     KSB.runtime_blocker_surface_of_typed_class

--- a/test/test_keeper_typed_labels.ml
+++ b/test/test_keeper_typed_labels.ml
@@ -60,7 +60,7 @@ let test_cancel_reason_labels_unique () =
 let all_failure_reasons : Keeper_turn_fsm.failure_reason list =
   [
     Failure_cascade_unavailable { base = "x"; resolved = None };
-    Failure_no_tool_capable_provider { cascade_name = "x"; detail = "d" };
+    Failure_no_tool_capable_provider { runtime_id = "x"; detail = "d" };
     Failure_provider_error { kind = "k"; detail = "d" };
     Failure_tool_contract_violation { reason_code = "rc" };
     Failure_receipt_lost { primary_error = "e"; fallback_path = None };

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1418,8 +1418,8 @@ let test_keepalive_scheduling_seam_preserves_reactive_run () =
   let obs = { base_observation with pending_mentions = [ "operator", "@keeper wake" ] } in
   let decision =
     KHL.decide_keepalive_scheduling
-      ~cascade_resilience_of_name:healthy_cascade_resilience
-      ~cascade_status_of_name:healthy_cascade_status
+      ~runtime_resilience_of_name:healthy_cascade_resilience
+      ~runtime_status_of_name:healthy_cascade_status
       ~stop:(Atomic.make false)
       ~meta
       obs
@@ -1441,25 +1441,25 @@ let test_keepalive_scheduling_seam_records_backpressure_reasons () =
   let obs = { base_observation with pending_mentions = [ "operator", "@keeper wake" ] } in
   let decision =
     KHL.decide_keepalive_scheduling
-      ~cascade_resilience_of_name:blocked_cascade_resilience
-      ~cascade_status_of_name:healthy_cascade_status
+      ~runtime_resilience_of_name:blocked_cascade_resilience
+      ~runtime_status_of_name:healthy_cascade_status
       ~stop:(Atomic.make false)
       ~meta
       obs
   in
   check bool "raw requested run stays visible" true decision.requested_should_run_turn;
   check bool "backpressure blocks admitted run" false decision.should_run_turn;
-  begin match decision.cascade_backpressure with
-  | KHL.Cascade_backpressured { reason; _ } ->
-    check string "backpressure reason" "cascade_resilience_test_blocker" reason
-  | KHL.Cascade_admitted -> fail "expected cascade backpressure"
+  begin match decision.runtime_backpressure with
+  | KHL.Runtime_backpressured { reason; _ } ->
+    check string "backpressure reason" "runtime_resilience_test_blocker" reason
+  | KHL.Runtime_admitted -> fail "expected runtime backpressure"
   end;
   check
     (list string)
     "admission reasons explain backpressure"
-    [ "cascade_backpressure"
-    ; "cascade_resilience"
-    ; "reason_cascade_resilience_test_blocker"
+    [ "runtime_backpressure"
+    ; "runtime_resilience"
+    ; "reason_runtime_resilience_test_blocker"
     ]
     decision.admission_reasons
 ;;
@@ -1469,8 +1469,8 @@ let test_keepalive_scheduling_seam_gates_requested_run_on_stop () =
   let obs = { base_observation with pending_mentions = [ "operator", "@keeper wake" ] } in
   let decision =
     KHL.decide_keepalive_scheduling
-      ~cascade_resilience_of_name:healthy_cascade_resilience
-      ~cascade_status_of_name:healthy_cascade_status
+      ~runtime_resilience_of_name:healthy_cascade_resilience
+      ~runtime_status_of_name:healthy_cascade_status
       ~stop:(Atomic.make true)
       ~meta
       obs

--- a/test/test_oas_error_kind_counter.ml
+++ b/test/test_oas_error_kind_counter.ml
@@ -89,7 +89,7 @@ let test_capacity_backpressure_kind () =
            cascade_name = typed_cascade_name cascade_name;
            source = OWN.Client_capacity;
            detail = "client capacity key provider_k is full";
-           retry_after = Masc_mcp.Cascade_internal_error.No_retry_hint;
+           retry_after = Masc_mcp.Keeper_meta_contract.No_retry_hint;
          })
   in
   Alcotest.(check (float 0.0001))


### PR DESCRIPTION
## Summary
- rename preflight health tracker fingerprints from cascade_name to runtime_id
- rename preflight health tracker metrics from masc_cascade_* to masc_runtime_*
- update preflight unhealthy local endpoint log text from cascade to runtime terminology
- rename heartbeat runtime backpressure observation/scheduling APIs from cascade_* to runtime_* terms
- rename semaphore wait timeout diagnostics from cascade label/detail to runtime id/detail
- rename capacity backpressure helper APIs and runtime blocker payload expectations from cascade_name to runtime_id terms
- remove Cascade_internal_error references in keeper error facade/tests in favor of Keeper_meta_contract runtime error terms
- rename turn FSM no-tool-capable failure payload from cascade_name to runtime_id
- remove cascade strategy catalog resolution/backoff loop from keeper turn dispatch

## Validation
- Not run. Continuing Cascade/catalog removal; build breakage is accepted for this cleanup.