### PR TITLE
Rename runtime try dispatch boundary

### DIFF
--- a/lib/keeper/keeper_composite_observer.ml
+++ b/lib/keeper/keeper_composite_observer.ml
@@ -429,8 +429,7 @@ let compute_invariants
 (* Prometheus bump — one counter tick per violated invariant per snapshot.
    Called from [observe]. PromQL rate/increase distinguishes transient
    from steady-state violations. Labels bounded: keeper × invariant (5)
-   ≤ ~250 series on a 50-keeper host. Mirrors the naming pattern in
-   [Cascade_strategy_trace.bump_prometheus_counter]. *)
+   ≤ ~250 series on a 50-keeper host. *)
 let bump_invariant_violations ~(keeper_name : string) (inv : invariants_check) =
   let bump key satisfied =
     if not satisfied then

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -583,7 +583,7 @@ let run_named
   let capture, _metrics =
     Keeper_observation.runtime_metrics_for_candidates ~candidate_count ()
   in
-  let cascade_strategy_name_ref = ref None in
+  let runtime_strategy_name_ref = ref None in
   let name = Printf.sprintf "oas-%s" runtime_id in
   let transport_resolved = match transport with
     | Some t -> t
@@ -710,7 +710,7 @@ let run_named
         Some (Runtime_deadline.of_seconds_from_now ~clock turn_budget)
     | None -> None
   in
-  let try_cascade_ctx : Keeper_turn_driver_try_cascade.try_cascade_ctx = {
+  let try_runtime_ctx : Keeper_turn_driver_try_runtime.try_runtime_ctx = {
     runtime_id;
     error_runtime_id;
     keeper_name;
@@ -719,7 +719,7 @@ let run_named
     configured_labels;
     error_selected_model_raw;
     capture;
-    cascade_strategy_name_ref;
+    runtime_strategy_name_ref;
     try_provider_ctx;
     runtime_manifest_required_tool_names;
     runtime_mcp_policy;
@@ -743,30 +743,30 @@ let run_named
     wait_timeout_sec;
     turn_deadline;
   } in
-  let try_cascade
+  let try_runtime
         ?(on_success = fun ~provider_key:_ -> ())
         ?(pre_dispatch_required_tool_rejections_rev = [])
         ?resume_checkpoint ?per_provider_timeout_s ?last_capacity_source
         ?last_capacity_backpressure remaining last_err =
-    Keeper_turn_driver_try_cascade.run
+    Keeper_turn_driver_try_runtime.run
       ~on_success
       ~pre_dispatch_required_tool_rejections_rev
       ?resume_checkpoint ?per_provider_timeout_s ?last_capacity_source
       ?last_capacity_backpressure
-      try_cascade_ctx remaining last_err
+      try_runtime_ctx remaining last_err
   in
   (* Runtime dispatch no longer resolves a cascade strategy catalog.
      Candidate ordering is produced by the runtime candidate resolution layer;
      this driver only applies the health fail-open filter and executes the
      provider attempts in that order. *)
   let runtime_strategy_name = "linear_failover" in
-  let () = cascade_strategy_name_ref := Some runtime_strategy_name in
+  let () = runtime_strategy_name_ref := Some runtime_strategy_name in
   let _ = sw, net in
   let runtime_exhausted_after_filter () =
     let observation =
       Keeper_observation.runtime_observation_with_metrics
         ~runtime_id:error_runtime_id
-        ?strategy:!cascade_strategy_name_ref ~configured_labels
+        ?strategy:!runtime_strategy_name_ref ~configured_labels
         ~candidate_count ~selected_model_raw:error_selected_model_raw ~capture ()
     in
     Keeper_observation.record_cascade ~keeper_name
@@ -788,7 +788,7 @@ let run_named
     match ordered with
     | [] -> runtime_exhausted_after_filter ()
     | _ ->
-      try_cascade ?per_provider_timeout_s ordered None
+      try_runtime ?per_provider_timeout_s ordered None
   in
   let admission_runtime_id =
     runtime_id

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -774,7 +774,7 @@ let keeper_cycle_decision
         let provider_cooldown_fail_open =
           match provider_cooldown_remaining_sec with
           | Some _ ->
-            fallback_cascade_for_provider_cooldown
+            fallback_runtime_for_provider_cooldown
               ~base_runtime_id:runtime_id
               ~effective_runtime_id:runtime_id
           | None -> None

--- a/lib/keeper/keeper_world_observation_provider_cooldown.ml
+++ b/lib/keeper/keeper_world_observation_provider_cooldown.ml
@@ -9,7 +9,7 @@ open Keeper_types
 open Keeper_meta_contract
 open Keeper_types_profile
 
-let fallback_cascade_for_provider_cooldown
+let fallback_runtime_for_provider_cooldown
       ~(base_runtime_id : string)
       ~(effective_runtime_id : string)
   : string option
@@ -79,7 +79,7 @@ let provider_capacity_blocked_task_count
     with
     | Some _
       when Option.is_none
-             (fallback_cascade_for_provider_cooldown
+             (fallback_runtime_for_provider_cooldown
                 ~base_runtime_id:runtime_id
                 ~effective_runtime_id:runtime_id) ->
       claimable_task_count

--- a/lib/keeper/keeper_world_observation_provider_cooldown.mli
+++ b/lib/keeper/keeper_world_observation_provider_cooldown.mli
@@ -1,4 +1,4 @@
-val fallback_cascade_for_provider_cooldown :
+val fallback_runtime_for_provider_cooldown :
   base_runtime_id:string ->
   effective_runtime_id:string ->
   string option

--- a/lib/runtime/runtime_adapter.mli
+++ b/lib/runtime/runtime_adapter.mli
@@ -2,7 +2,7 @@
 
     Re-homed from the deleted [Cascade_declarative_adapter], keeping only the
     binding materialization path. Routing layers — aliases, routes,
-    system_targets, capability profiles, [Cascade_strategy] mapping, the
+    system_targets, capability profiles, strategy mapping, the
     [adapted_catalog] aggregate, and the typed [adapter_error] list — are
     intentionally dropped (a Runtime is one pre-selected binding, not a
     routed catalog). Types are owned by {!Runtime_schema}.

--- a/test/test_tla_literal_parity.ml
+++ b/test/test_tla_literal_parity.ml
@@ -86,12 +86,6 @@ let test_autonomous_transitions () =
     ~expected
     ~actual:Autonomous.Autonomous_phase.Transition.all_symbols
 
-let test_cascade_strategy () =
-  assert_set ~label:"CascadeStrategy.StrategyKindSet"
-    ~expected:
-      (set "specs/boundary/CascadeStrategy.tla" "StrategyKindSet")
-    ~actual:Masc_mcp.Cascade_strategy.all_symbols
-
 let test_sandbox_dispatch_profile () =
   assert_set ~label:"SandboxDispatch.ProfileSet"
     ~expected:(set "specs/boundary/SandboxDispatch.tla" "ProfileSet")
@@ -103,6 +97,5 @@ let () =
   test_resilience_degradation ();
   test_autonomous_phase ();
   test_autonomous_transitions ();
-  test_cascade_strategy ();
   test_sandbox_dispatch_profile ();
   print_endline "test_tla_literal_parity: OK"

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -783,55 +783,6 @@ let () =
           (Option.map Masc_mcp.Dashboard.scope_to_string
              (Masc_mcp.Dashboard.scope_of_string_opt "recent")));
     ];
-    "cascade_strategy_kind_ssot", [
-      (* Issue #8603: parse_kind's Error message used to hard-code the
-         7 wire-format names; an 8th constructor would silently produce
-         a stale operator-visible error. The fix exposes [all_kinds]
-         and [valid_kind_strings] derived from kind_to_string and
-         routes the error message through them. These tests pin the
-         witness exhaustiveness, the count, and that the error message
-         is derived (not hard-coded). *)
-      Alcotest.test_case "all_kinds round-trips through kind_to_string" `Quick (fun () ->
-        let module C = Masc_mcp.Cascade_strategy in
-        List.iter (fun k ->
-          let actual = C.kind_to_string k in
-          if not (List.mem actual C.valid_kind_strings) then
-            Alcotest.failf "kind_to_string %S not in valid_kind_strings" actual)
-          C.all_kinds;
-        Alcotest.(check int) "count" 1 (List.length C.all_kinds);
-        Alcotest.(check int) "strings count" 1
-          (List.length C.valid_kind_strings));
-      Alcotest.test_case "valid_kind_strings pinned to wire format" `Quick (fun () ->
-        Alcotest.(check (list string)) "wire-format names"
-          [ "failover" ]
-          Masc_mcp.Cascade_strategy.valid_kind_strings);
-      Alcotest.test_case "parse_kind error mentions every valid kind" `Quick (fun () ->
-        let module C = Masc_mcp.Cascade_strategy in
-        match C.parse_kind "fabricated_strategy" with
-        | Ok _ -> Alcotest.fail "expected Error for unknown kind"
-        | Error msg ->
-          List.iter (fun k ->
-            let needle = k in
-            let len = String.length needle in
-            let mlen = String.length msg in
-            let rec contains i =
-              if i + len > mlen then false
-              else if String.sub msg i len = needle then true
-              else contains (i + 1)
-            in
-            Alcotest.(check bool)
-              (Printf.sprintf "error message lists %S" k) true (contains 0))
-            C.valid_kind_strings);
-      Alcotest.test_case "parse_kind round-trips every valid string" `Quick (fun () ->
-        let module C = Masc_mcp.Cascade_strategy in
-        List.iter (fun s ->
-          match C.parse_kind s with
-          | Error e -> Alcotest.failf "parse_kind %S returned Error: %s" s e
-          | Ok k ->
-            let back = C.kind_to_string k in
-            Alcotest.(check string) (Printf.sprintf "round-trip %S" s) s back)
-          C.valid_kind_strings);
-    ];
     "library_source_ssot", [
       (* Issue #8601: 3-way drift — module docstring claimed 3 sources,
          handler valid_sources had 4, schema enum had 4. The fix


### PR DESCRIPTION
## Summary
- rename keeper turn driver try-cascade boundary references to try-runtime terms
- rename cascade strategy ref plumbing to runtime strategy ref plumbing
- remove Cascade_strategy wording from runtime adapter docs
- remove Cascade_strategy contract/TLA parity tests and stale observer reference
- rename provider cooldown fallback API from fallback_cascade to fallback_runtime terms

## Validation
- Not run. Continuing Cascade/catalog removal; build breakage is accepted for this cleanup.