### PR TITLE
Rename runtime config health APIs

### DIFF
--- a/lib/config_dir_resolver/config_dir_resolver.mli
+++ b/lib/config_dir_resolver/config_dir_resolver.mli
@@ -139,7 +139,8 @@ val keeper_repo_mappings_toml_path : base_path:string -> string
 
 val config_signature_exists : string -> bool
 (** [config_signature_exists dir] checks whether [dir] looks like a valid
-    MASC config directory (has keeper_runtime.toml, prompts/, keepers/, or personas/). *)
+    MASC config directory (has keeper_runtime.toml, tool_policy.toml, prompts/,
+    keepers/, or personas/). *)
 
 (** {1 Env introspection}
 

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -10,7 +10,7 @@ open Keeper_status_bridge
 
 include Dashboard_http_keeper_detail
 
-(** Health constants + compute_health_score + live_keeper_runtime_id moved
+(** Health constants + compute_health_score + live runtime-id resolver moved
     to Dashboard_http_keeper_types (intra-library file split, 2026-05-16). *)
 include Dashboard_http_keeper_types
 module Outcomes = Dashboard_http_keeper_outcomes

--- a/lib/dashboard/dashboard_http_keeper_snapshot.ml
+++ b/lib/dashboard/dashboard_http_keeper_snapshot.ml
@@ -248,7 +248,7 @@ let keeper_config_json (config : Coord.config) (name : string)
       (* RFC-0149 §3.3 — Result-returning resolver: on [Error] the
          canonical field surfaces as JSON [null] (parse-don't-validate
          honest signal) instead of the silent [Keeper_turn] rewrite the
-         legacy [live_keeper_runtime_id] would produce. *)
+         legacy live runtime-id facade would produce. *)
       let selected_runtime_canonical_json =
         match live_keeper_runtime_id_result runtime_id with
         | Ok runtime ->

--- a/lib/dashboard/dashboard_http_keeper_types.ml
+++ b/lib/dashboard/dashboard_http_keeper_types.ml
@@ -11,7 +11,7 @@ let runtime_warning_ctx_ratio =
   Env_config_keeper.DashboardHealth.runtime_warning_ctx_ratio
 
 (* RFC-0149 §3.3 — typed Result resolver for dashboard call sites.  The
-   legacy [live_keeper_runtime_id] facade + its silent-fallback carrier
+   legacy live runtime-id facade + its silent-fallback carrier
    ([Keeper_runtime_profile.resolve_live]) were removed in the §3.3
    sunset closeout. *)
 let live_keeper_runtime_id_result (raw : string) :

--- a/lib/dashboard/dashboard_http_keeper_types.mli
+++ b/lib/dashboard/dashboard_http_keeper_types.mli
@@ -17,7 +17,7 @@ val runtime_warning_ctx_ratio : float
 
 val live_keeper_runtime_id_result :
   string -> (string, [ `Unresolved of string ]) result
-(** Resolve a raw runtime name to its live (post-rotation) identifier.
+(** Resolve a raw runtime id to its live (post-rotation) identifier.
     Returns [Error (`Unresolved raw)] when the input cannot be resolved
     to any catalog member; the caller is expected to surface the
     unresolved input directly (e.g. as JSON [null] on the canonical

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -51,13 +51,13 @@ end
     @param meta Keeper metadata
     @param base_dir Session base directory for checkpoints
     @param max_context Maximum context window tokens
-    @param build_turn_prompt Callback: receives the base keeper system prompt
-           and checkpoint message history, returns the final turn system prompt
-    @param user_message The user's message to the keeper
-    @param runtime_id Runtime runtime profile name for model selection
-    @param generation Current generation counter
-    @param max_turns Maximum agent turns (default from keeper runtime config)
-    @param guardrails Optional OAS guardrails for tool safety gates
+     @param build_turn_prompt Callback: receives the base keeper system prompt
+            and checkpoint message history, returns the final turn system prompt
+     @param user_message The user's message to the keeper
+    @param runtime_id Runtime profile name for model selection
+     @param generation Current generation counter
+     @param max_turns Maximum agent turns (default from keeper runtime config)
+     @param guardrails Optional OAS guardrails for tool safety gates
     @param temperature MODEL temperature override; when omitted, resolved
            from [Runtime_inference] with a 0.3 fallback
     @param max_tokens Maximum output tokens override; when omitted, resolved

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -59,13 +59,13 @@ val per_provider_timeout_for_turn
     @param meta Keeper metadata
     @param base_dir Session base directory for checkpoints
     @param max_context Maximum context window tokens
-    @param build_turn_prompt Callback: receives the base keeper system prompt
-           and checkpoint message history, returns the final turn system prompt
-    @param user_message The user's message to the keeper
-    @param runtime_id Typed runtime runtime profile name for model selection
-    @param world_observation Structured keeper world snapshot used by
-           required-tool contract checks. When omitted, the contract gate
-           does not infer world state from prompt text.
+     @param build_turn_prompt Callback: receives the base keeper system prompt
+            and checkpoint message history, returns the final turn system prompt
+     @param user_message The user's message to the keeper
+    @param runtime_id Typed runtime profile name for model selection
+     @param world_observation Structured keeper world snapshot used by
+            required-tool contract checks. When omitted, the contract gate
+            does not infer world state from prompt text.
     @param provider_filter Optional provider restriction
     @param generation Current generation counter
     @param max_turns Maximum agent turns (default from env config)

--- a/lib/keeper/keeper_attempt_liveness_observer.ml
+++ b/lib/keeper/keeper_attempt_liveness_observer.ml
@@ -12,7 +12,7 @@ exception Liveness_kill of L.failure
 type t = {
   mode : Cfg.mode;
   budget : L.budget;
-  runtime_label : string;
+  runtime_id : string;
   provider_label : string;
   candidate_key : string option;
   external_wait : (unit -> bool) option;
@@ -70,7 +70,7 @@ let public_provider_label_of_raw raw =
 let create
       ~mode
       ~budget
-      ~runtime_label
+      ~runtime_id
       ?(provider_label = public_runtime_provider_label)
       ?external_wait
       ?candidate_key
@@ -81,7 +81,7 @@ let create
   {
     mode;
     budget;
-    runtime_label;
+    runtime_id;
     provider_label = public_provider_label_of_raw provider_label;
     candidate_key;
     external_wait;
@@ -103,16 +103,16 @@ let current_state_for_test (t : t) : L.state = !(t.state)
 (* -- Prometheus emission ------------------------------------------- *)
 
 let kill_labels (t : t) (failure : L.failure) =
-  [
-    ("mode", Cfg.mode_label t.mode);
-    ("kind", L.failure_kind_label failure);
-    ("runtime", t.runtime_label);
-    ("provider", t.provider_label);
-  ]
+    [
+      ("mode", Cfg.mode_label t.mode);
+      ("kind", L.failure_kind_label failure);
+    ("runtime_id", t.runtime_id);
+      ("provider", t.provider_label);
+    ]
 
 let observed_labels (t : t) ~outcome =
   [
-    ("runtime", t.runtime_label);
+    ("runtime_id", t.runtime_id);
     ("provider", t.provider_label);
     ("outcome", outcome);
   ]
@@ -188,7 +188,7 @@ let react_to_output (t : t) (output : L.output) : unit =
                Log.Misc.warn
                  "runtime_attempt_liveness: enforce mode but no switch \
                   registered (runtime=%s provider=%s); shadowing kill"
-                 t.runtime_label t.provider_label))
+                 t.runtime_id t.provider_label))
 
 (* -- on_event wrapper --------------------------------------------- *)
 
@@ -207,7 +207,7 @@ let observe_chunk_clock (t : t) ~(at : float) : unit =
   t.last_chunk_at := Some at
 
 let prometheus_recorder (t : t) : L.recorder =
-  let _labels = [ ("runtime", t.runtime_label); ("provider", t.provider_label) ] in
+  let _labels = [ ("runtime_id", t.runtime_id); ("provider", t.provider_label) ] in
   {
     L.record_ttft = (fun _seconds -> ());
     record_inter_chunk = (fun _seconds -> ());
@@ -250,10 +250,10 @@ let external_wait_active (t : t) : bool =
     (try f () with
      | Eio.Cancel.Cancelled _ as e -> raise e
      | exn ->
-       Log.Misc.warn
-         "runtime_attempt_liveness: external_wait predicate raised \
-          (runtime=%s provider=runtime): %s"
-         t.runtime_label
+      Log.Misc.warn
+        "runtime_attempt_liveness: external_wait predicate raised \
+         (runtime=%s provider=runtime): %s"
+         t.runtime_id
          (Printexc.to_string exn);
        false)
 
@@ -274,10 +274,10 @@ let wrap_on_event (t : t)
              try f evt with
              | Eio.Cancel.Cancelled _ as e -> raise e
              | exn ->
-                 Log.Misc.warn
-                   "runtime_attempt_liveness: original on_event raised \
-                    (runtime=%s provider=runtime): %s"
-                   t.runtime_label
+                Log.Misc.warn
+                  "runtime_attempt_liveness: original on_event raised \
+                   (runtime=%s provider=runtime): %s"
+                   t.runtime_id
                    (Printexc.to_string exn)));
         Eio_guard.check_if_ready ();
         try step_with_event t evt with
@@ -287,7 +287,7 @@ let wrap_on_event (t : t)
             Log.Misc.warn
               "runtime_attempt_liveness: step raised (runtime=%s \
                provider=runtime): %s"
-              t.runtime_label (Printexc.to_string exn)
+              t.runtime_id (Printexc.to_string exn)
       in
       Some wrapped
 
@@ -363,7 +363,7 @@ let start_tick_fiber (t : t) ~(sw : Eio.Switch.t)
               Log.Misc.warn
                 "runtime_attempt_liveness tick fiber crashed (runtime=%s \
                  provider=%s): %s"
-                t.runtime_label t.provider_label (Printexc.to_string exn))
+                t.runtime_id t.provider_label (Printexc.to_string exn))
 
 (* -- Finalize ----------------------------------------------------- *)
 

--- a/lib/keeper/keeper_attempt_liveness_observer.mli
+++ b/lib/keeper/keeper_attempt_liveness_observer.mli
@@ -48,7 +48,7 @@ type t
 val create :
   mode:Keeper_attempt_liveness_config.mode ->
   budget:Keeper_attempt_liveness.budget ->
-  runtime_label:string ->
+  runtime_id:string ->
   ?provider_label:string ->
   ?external_wait:(unit -> bool) ->
   ?candidate_key:string ->

--- a/lib/keeper/keeper_health_probe.ml
+++ b/lib/keeper/keeper_health_probe.ml
@@ -259,9 +259,9 @@ let scan_runtime_health ~base_path =
   let by_runtime = Hashtbl.create 8 in
   List.iter
     (fun (entry : Keeper_registry.registry_entry) ->
-       let runtime = Keeper_meta_contract.runtime_id_of_meta entry.meta in
+       let runtime_id = Keeper_meta_contract.runtime_id_of_meta entry.meta in
        let acc =
-         match Hashtbl.find_opt by_runtime runtime with
+         match Hashtbl.find_opt by_runtime runtime_id with
          | Some acc -> acc
          | None -> empty_runtime_scan_acc
        in
@@ -275,15 +275,15 @@ let scan_runtime_health ~base_path =
               else acc.failure_reasons)
          }
        in
-       Hashtbl.replace by_runtime runtime acc')
+       Hashtbl.replace by_runtime runtime_id acc')
     entries;
   Hashtbl.fold
-    (fun runtime acc rows ->
+    (fun runtime_id acc rows ->
        let healthy =
          if acc.total <= 0 then true
          else acc.failed <= max_failed_allowed_for_runtime ~total:acc.total
        in
-       (runtime, healthy, acc) :: rows)
+       (runtime_id, healthy, acc) :: rows)
     by_runtime
     []
 ;;
@@ -302,7 +302,7 @@ let scan_runtime_health ~base_path =
     turn. *)
 let check_runtime_health ~base_path =
   scan_runtime_health ~base_path
-  |> List.map (fun (runtime, healthy, _acc) -> runtime, healthy)
+  |> List.map (fun (runtime_id, healthy, _acc) -> runtime_id, healthy)
 ;;
 
 (* ------------------------------------------------------------------ *)
@@ -312,11 +312,11 @@ let check_runtime_health ~base_path =
 let run_once ~base_path =
   let results = scan_runtime_health ~base_path in
   List.iter
-    (fun (runtime, healthy, acc) ->
+    (fun (runtime_id, healthy, acc) ->
        let status =
          if healthy then Healthy else Unhealthy (runtime_failure_reason acc)
        in
-       set_runtime_status ~runtime_id:runtime status)
+       set_runtime_status ~runtime_id status)
     results
 ;;
 

--- a/lib/keeper/keeper_health_probe.mli
+++ b/lib/keeper/keeper_health_probe.mli
@@ -63,7 +63,7 @@ val is_terminal_unhealthy : Keeper_state_machine.phase -> bool
 (** {1 Runtime health scan} *)
 
 (** [max_failed_allowed_for_runtime ~total] returns the maximum number
-    of terminal-unhealthy keepers (Dead/Zombie/Crashed) a runtime of
+    of terminal-unhealthy keepers (Dead/Zombie/Crashed) a runtime group of
     size [total] can hold while still being treated as healthy.
     Formula: [max 1 (total / 10)] — one keeper down is always allowed,
     larger runtimes scale at 10%.  Exposed so tests and other callers

--- a/lib/keeper/keeper_runtime.mli
+++ b/lib/keeper/keeper_runtime.mli
@@ -87,7 +87,7 @@ val invalid_profile_defaults_error : keeper_name:string -> string -> string
 val effective_declarative_runtime_id :
   Keeper_types_profile.keeper_profile_defaults ->
   Keeper_meta_contract.keeper_meta -> string
-(** Resolve the runtime name for a keeper meta given its profile
+(** Resolve the runtime id for a keeper meta given its profile
     defaults; falls back to the profile default when the meta omits one. *)
 
 val resynced_tool_access :

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -593,7 +593,6 @@ let source_provenance_json config (meta : keeper_meta) =
      ; "config_resolution", Config_dir_resolver.to_json resolution
      ; "precedence", `List [ `String "live_meta"; `String "toml"; `String "persona" ]
      ]
-     @ runtime_catalog_source_fields resolution
      @ [ "has_live_override", `Bool (override_fields <> [])
        ; "override_fields", Json_util.json_string_list override_fields
        ; ( "override_field_sources"

--- a/lib/keeper/keeper_status_bridge_blocker.ml
+++ b/lib/keeper/keeper_status_bridge_blocker.ml
@@ -265,8 +265,8 @@ let runtime_blocker_surface_of_failure_reason (reason : Keeper_registry.failure_
                window; keeper was auto-paused before restart loop."
               distinct_count)
          Stale_fleet_batch)
-  | Keeper_registry.Provider_runtime_error { code; detail; runtime_id }
-    when code = "no_tool_capable_provider" ->
+  | Keeper_registry.Provider_runtime_error { code; detail; runtime_id = _ }
+     when code = "no_tool_capable_provider" ->
     Some
       (runtime_blocker_surface_of_typed_class
          ~summary:

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -383,7 +383,7 @@ let run_try_provider
           Keeper_attempt_liveness_observer.create
             ~mode:liveness_mode
             ~budget:resolved_budget.budget
-            ~runtime_label:ctx.runtime_id
+            ~runtime_id:ctx.runtime_id
             ~provider_label
             ~external_wait:(fun () ->
               Keeper_approval_queue.has_pending_for_keeper

--- a/lib/keeper/keeper_unified_metrics_failure.ml
+++ b/lib/keeper/keeper_unified_metrics_failure.ml
@@ -114,21 +114,18 @@ let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
   (* #10474: emit Prometheus counters for no_tool_provider and proactive
      cycle outcomes so Grafana can surface fleet-wide health ratios. *)
   (match sdk_error with
-   | Some err ->
-       (match Keeper_turn_driver.classify_masc_internal_error err with
-        | Some (Keeper_turn_driver.Runtime_exhausted
+     | Some err ->
+         (match Keeper_turn_driver.classify_masc_internal_error err with
+          | Some (Keeper_turn_driver.Runtime_exhausted
 	                  { runtime_id
 	                  ; reason = Keeper_meta_contract.No_tool_capable _
 	                  ; _
 	                  }) ->
-            let runtime_id =
-              runtime_id
-            in
             Prometheus.inc_counter
               Keeper_metrics.(to_string NoToolProvider)
               ~labels:
                 [ ("keeper", meta.name)
-                ; ("runtime", runtime_id)
+                ; ("runtime_id", runtime_id)
                 ]
               ()
         | _ -> ())

--- a/lib/keeper/keeper_unified_turn_pre_dispatch.ml
+++ b/lib/keeper/keeper_unified_turn_pre_dispatch.ml
@@ -68,8 +68,8 @@ let build_runtime_execution
          None
        in
        (match
-          Runtime_inference.validate_max_tokens_within_ceiling
-            ~runtime_id
+         Runtime_inference.validate_max_tokens_within_ceiling
+           ~runtime_id
             ~provider_ceiling:max_output_ceiling
             raw_max_tokens
         with

--- a/lib/keeper/keeper_unified_turn_pre_dispatch.mli
+++ b/lib/keeper/keeper_unified_turn_pre_dispatch.mli
@@ -19,7 +19,7 @@ val build_runtime_execution
   -> ( Keeper_turn_runtime_budget.runtime_execution
      , Agent_sdk.Error.sdk_error )
      result
-(** Build a [runtime_execution] for the given runtime name under
+(** Build a [runtime_execution] for the given [runtime_id] under
     [meta]'s context.
 
     Failure modes (returned as [Error]):

--- a/lib/otel/otel_genai.ml
+++ b/lib/otel/otel_genai.ml
@@ -37,7 +37,7 @@ module Attr_key = struct
   ;;
 
   let masc_gen_ai_runtime_id =
-    register Masc_extension "masc.gen_ai.runtime.name"
+    register Masc_extension "masc.gen_ai.runtime_id"
   ;;
 
   let keeper_name = register Legacy "keeper.name"

--- a/lib/runtime/runtime_oas_runner.ml
+++ b/lib/runtime/runtime_oas_runner.ml
@@ -148,7 +148,7 @@ let cli_tool_a_cannot_carry_keeper_bound_runtime_mcp
 
 (* #10681: per-provider rejection reason produced by the runtime filter.
    When the filter empties the runtime, operators previously saw only a
-   flat list of provider names; root-cause classification required
+    flat list of provider names; root-cause classification required
    re-running each predicate by hand. The reason is now attached to the
    provider in the WARN log so the next [no_tool_capable_provider] event
    pinpoints the failing check on the first read.
@@ -164,8 +164,8 @@ let cli_tool_a_cannot_carry_keeper_bound_runtime_mcp
       returned [Error], typically transport/auth/capability mismatch
       surfaced by [Runtime_agent].
    3. [Required_tool_use { reason }] — the inline-tool-choice / runtime
-      MCP capability gate from [Provider_tool_support]. Re-uses the
-      existing [rejection_reason] so dashboards stay consistent with
+       MCP capability gate from [Provider_tool_support]. Re-uses the
+       existing [rejection_reason] so dashboards stay consistent with
       [masc_runtime_filter_rejection_total]. *)
 type filter_rejection_reason =
   | Capability_profile_mismatch of string

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -1,4 +1,4 @@
-(** Declarative Runtime TOML parser (RFC-0206, runtime→Runtime rebirth).
+(** Declarative Runtime TOML parser.
 
     Re-homed from the deleted [Runtime_declarative_parser]. Parses RFC-0058
     layers 1-3 plus [[runtime].default] into a self-standing


### PR DESCRIPTION
## Summary
- rename LLM rerank config API from keeper_llm_rerank_cascade to keeper_llm_rerank_runtime
- rename health probe scan/check APIs from cascade health to runtime health
- rename recoverable failure classifier from cascade failure to runtime failure terms
- rename Keeper_agent_run.run_turn public label from cascade_name to runtime_id and update direct callsites
- rename Keeper_agent_run_turn_helpers manifest helper labels from cascade_name to runtime_id
- rename post-turn memory and memory LLM summary APIs/metrics from cascade_name/cascade to runtime_id/runtime terms
- align Keeper_agent_run finalize_response callsite with runtime_id_string label
- rename Keeper_run_context and tool-surface violation APIs/logs from cascade_name to runtime_id
- rename run tool hook and streaming-cancel APIs from cascade labels to runtime_id labels
- rename pre-dispatch runtime builder and terminal-observation APIs from cascade_name to runtime_id labels
- rename Keeper_run_tools.prepare_agent_setup public label from cascade_name to runtime_id
- rename Admission_queue/Admission_queue_metrics and Otel_genai public labels from cascade_name to runtime_id
- rename Dashboard_oas_bridge provider-error public labels and record field from cascade_name to runtime_id
- rename Keeper_status_detail_observability public label from current_cascade_name to current_runtime_id
- rename Admission_queue waiter snapshot field and docs from cascade_name/cascade-layer to runtime_id/runtime-layer
- rename Dashboard_http_keeper live resolver facade from cascade_name to runtime_id
- rename dashboard judge runtime wrapper callsites from cascade_name to runtime_id
- rename Keeper_turn_driver.run_named production callsites from cascade_name to runtime_id
- rename declarative runtime resolver APIs from effective_declarative_cascade_name to effective_declarative_runtime_id
- rename attempt-liveness observer constructor and labels from cascade_label/cascade to runtime_id
- align dashboard manifest row projection with Keeper_runtime_manifest.runtime_id
- rename Keeper_registry.Provider_runtime_error payload from cascade_name to runtime_id
- rename no-tool-capable failure and metrics labels from cascade to runtime_id
- rename OTel MASC GenAI runtime attribute key from cascade name to runtime_id
- remove Doctor naming from remaining runtime diagnostic code surfaces
- remove cascade catalog provenance payloads and rename cascade-empty runtime filter surfaces
- rename dashboard receipt, health, and persona generation defaults from cascade to runtime terms
- rename stale-watchdog/runtime-driver cascade log and rejected-input surfaces to runtime terms
- rename unified turn execution, observation audit, and runtime metrics surfaces from cascade to runtime terms
- remove Runtime_catalog callsites from keeper runtime paths and rename trace/log code surfaces to runtime terms
- rename Prometheus and LLM metric documentation/label surfaces from cascade to runtime terms
- rename config/env saturation and sync metric surfaces from cascade to runtime terms
- rename runtime status/trust/composite observer payloads from cascade to runtime terms
- purge remaining keeper/runtime/bin cascade, Doctor, and Runtime_catalog leftovers from code surfaces

## Validation
- Not run. Continuing Cascade/catalog removal; build breakage is accepted for this cleanup.
