### PR TITLE
fix(keeper): lazy default_generation_runtime_id to survive pre-init module load (RFC-0206 §2.1)

### DIFF
--- a/lib/keeper/keeper_persona_authoring.ml
+++ b/lib/keeper/keeper_persona_authoring.ml
@@ -855,7 +855,7 @@ let handle_persona_generate ctx args =
              | None ->
                (match trimmed_arg "runtime_id" with
                 | Some value -> value
-                | None -> Archetypes.default_generation_runtime_id)
+                | None -> Lazy.force Archetypes.default_generation_runtime_id)
            in
            let temperature =
              get_float_opt args "temperature"

--- a/lib/keeper/keeper_persona_authoring_contract.ml
+++ b/lib/keeper/keeper_persona_authoring_contract.ml
@@ -20,8 +20,11 @@ type archetype_axis =
   }
 
 let default_generation_language = "ko"
+(* Lazy: [Runtime.get_default_runtime_id] fail-fasts until [Runtime.init_default]
+   runs at startup (RFC-0206 §2.1). A module-level eager binding evaluates before
+   that, crashing boot; defer to first use so it resolves post-init. *)
 let default_generation_runtime_id =
-  Runtime.get_default_runtime_id ()
+  lazy (Runtime.get_default_runtime_id ())
 let default_temperature = 0.7
 let default_max_tokens = 2500
 let default_generation_proactive_enabled = false

--- a/lib/keeper/keeper_persona_authoring_contract.mli
+++ b/lib/keeper/keeper_persona_authoring_contract.mli
@@ -22,7 +22,9 @@ type archetype_axis =
 (** {1 Generation defaults} *)
 
 val default_generation_language : string
-val default_generation_runtime_id : string
+val default_generation_runtime_id : string Lazy.t
+(** Lazy: resolves the default runtime id on first force, after
+    [Runtime.init_default] has run at startup. *)
 val default_temperature : float
 val default_max_tokens : int
 val default_generation_proactive_enabled : bool

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -119,7 +119,7 @@ let keeper_schemas : tool_schema list = [
         ]);
         ("runtime_id", `Assoc [
           ("type", `String "string");
-          ("default", `String Persona_contract.default_generation_runtime_id);
+          ("default", `String (Lazy.force Persona_contract.default_generation_runtime_id));
           ("description", `String "Runtime id used to draft the persona.");
         ]);
         ("temperature", `Assoc [

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -521,7 +521,7 @@ let test_masc_persona_authoring_schemas () =
           Alcotest.(check string) "language default follows contract"
             Contract.default_generation_language (default_string "language");
           Alcotest.(check string) "runtime default follows contract"
-            Contract.default_generation_runtime_id (default_string "runtime_id");
+            (Lazy.force Contract.default_generation_runtime_id) (default_string "runtime_id");
           Alcotest.(check bool) "proactive default follows contract"
             Contract.default_generation_proactive_enabled (default_bool "proactive_enabled")
       | None -> Alcotest.fail "masc_persona_generate missing properties"));


### PR DESCRIPTION
## 목적

서버 startup crash 수정. `Runtime.get_default_runtime_id`는 `Runtime.init_default`가 startup에 실행되기 전에는 fail-fast(RFC-0206 §2.1, no silent fallback)하는데, `keeper_persona_authoring_contract.ml`의 `default_generation_runtime_id`가 **모듈-레벨 eager 바인딩**이라 init보다 먼저 평가되어 boot이 죽습니다.

## 증상

`./start-masc-mcp.sh` 실행 시:

```
Fatal error: exception Failure("Runtime.get_default_runtime_id: default runtime not initialized; Runtime.init_default must run at startup (no silent fallback — RFC-0206 §2.1)")
Called from Masc_mcp__Keeper_persona_authoring_contract.default_generation_runtime_id in lib/keeper/keeper_persona_authoring_contract.ml:24
```

## 수정

eager → lazy:

```ocaml
let default_generation_runtime_id = lazy (Runtime.get_default_runtime_id ())
```

첫 `Lazy.force`(persona generate 요청 시점 = `Runtime.init_default` 이후)에 평가됩니다. consumer 3곳(`keeper_persona_authoring`/`keeper_schema`/`test_tools_coverage`)을 `Lazy.force`로 갱신. .mli 타입은 `string Lazy.t`.

이건 cascade 적출과 **독립적인 init-순서 버그 fix**입니다 — cascade를 되살리는 게 아니라, #19600(cascade concept 제거)이 `cascade_name`→`runtime_id`로 개명하며 그대로 남긴 eager 모듈-레벨 바인딩을 lazy화하는 것입니다.

WORKAROUND-WAIVED: lazy 평가는 fail-fast 계약(RFC-0206 §2.1)을 우회하는 게 아니라 *준수*합니다 — eager 평가를 init 이후로 미뤄 계약이 의도한 시점에 호출되게 합니다. 근본 fix이며 대체 RFC 불필요.

## 검증

`dune build @check` = 0 에러 (origin/main #19600 위 green).

RFC-0206

🤖 Generated with [Claude Code](https://claude.com/claude-code)
