### PR TITLE
fix(keeper): make default_evaluator_runtime a function to fix startup crash (RFC-0206 §2.1)

### DIFF
--- a/lib/anti_rationalization.ml
+++ b/lib/anti_rationalization.ml
@@ -495,7 +495,10 @@ let parse_verdict (text : string) : (verdict, string) result =
     Cross-model evaluation is more effective than same-model different-role
     because different model architectures have different blindspots.
     See: Anthropic "Harness Design" blog analysis. *)
-let default_evaluator_runtime =
+(* Function, not a module-level value: [Runtime.get_default_runtime_id] fail-fasts
+   until [Runtime.init_default] runs at startup (RFC-0206 §2.1). A module-level
+   binding evaluates at load time and crashes boot; defer to call time. *)
+let default_evaluator_runtime () =
   Runtime.get_default_runtime_id ()
 ;;
 
@@ -529,7 +532,7 @@ let check_contract ~(notes : string) ~(contract : string list) : string list =
 ;;
 
 let review
-      ?(evaluator_runtime = default_evaluator_runtime)
+      ?(evaluator_runtime = default_evaluator_runtime ())
       ?generator_runtime
       ?(completion_contract : string list option)
       ?(on_verdict : (review_result -> unit) option)


### PR DESCRIPTION
## 목적

또 다른 모듈-레벨 eager runtime 평가로 인한 startup crash 수정. #19607/#19608이 persona/schema 경로를 고쳤지만, `anti_rationalization.ml`의 `default_evaluator_runtime`이 **모듈-레벨 값**으로 `Runtime.get_default_runtime_id`를 eager 평가해 `Runtime.init_default` 전에 crash합니다.

## 증상 (#19608 머지 후)

```
Fatal error: Failure("Runtime.get_default_runtime_id: default runtime not initialized; ... RFC-0206 §2.1")
Called from Masc_mcp__Anti_rationalization.default_evaluator_runtime in lib/anti_rationalization.ml:499
```

## 수정

모듈-레벨 값 → 함수:

```ocaml
let default_evaluator_runtime () = Runtime.get_default_runtime_id ()
```

consumer(`review`의 `?(evaluator_runtime = default_evaluator_runtime ())`)는 OCaml optional-arg 규칙상 호출 시 평가되므로 `init_default` 이후에 해석됩니다. 동작 동일.

## 전수 검증

`get_default_runtime_id` 호출처 전수 스캔(col-0 모듈-레벨 바인딩):
- 모듈-레벨 eager는 **이게 마지막**입니다 — `keeper_persona_authoring_contract`는 lazy(#19607), 나머지 13개 호출처는 전부 함수 안(런타임).
- `dune build @check` = 0 에러 green.

## 근본 (sweep 패턴 경고)

이 crash 연쇄(#19607 persona → #19608 schema → 본 PR anti)는 cascade 적출 sweep이 `cascade_name`(정적 문자열) → `runtime_id`(`Runtime.get_default_runtime_id`, init-의존)로 바꾸며 **모듈-레벨 바인딩을 그대로 남긴** 데서 옵니다. 향후 모듈-레벨 runtime_id 바인딩은 §2.1 fail-fast로 boot crash하므로, sweep 쪽에 "runtime id는 모듈-레벨에서 평가 금지(함수/lazy 강제)" 규칙을 두는 것이 재발 방지에 필요합니다.

RFC-0206

🤖 Generated with [Claude Code](https://claude.com/claude-code)
