### PR TITLE
fix(lint): green RFC-0132 redaction gate after RFC-0206 collapse

### DIFF
--- a/lib/keeper/keeper_turn_driver_wrappers.ml
+++ b/lib/keeper/keeper_turn_driver_wrappers.ml
@@ -149,6 +149,7 @@ let run_model_by_label
                               reason =
                                 Printf.sprintf
                                   "response rejected by accept (runtime=%s)"
+                                  (* RFC-0132-EXEMPT: internal observability — rejection reason label, not a redacted public surface *)
                                   "runtime";
                             }))
                 | Error e -> Error e))

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -139,6 +139,7 @@ let run_keeper_cycle
       append_manifest
         ~site:"runtime_routed"
         ~runtime_id:effective_runtime_id
+        (* RFC-0132-EXEMPT: internal observability — manifest decision reason label, not a redacted public surface *)
         ~decision:(`Assoc [ "reason", `String "runtime" ])
         Keeper_runtime_manifest.Runtime_routed;
       (* Concrete runtime health/capacity is owned by OAS/provider adapters.

--- a/scripts/lint/no-runtime-literal-outside-boundary-redaction.sh
+++ b/scripts/lint/no-runtime-literal-outside-boundary-redaction.sh
@@ -75,10 +75,10 @@ SCAN_FILES=(
 # Drift (line move) makes the entry stale and must be cleaned in the
 # same PR. The runtime check accepts any of the listed lines.
 PREAPPROVED=(
-  # Debug format string inside Printf.sprintf — internal observability
-  # (real provider identity, not boundary redaction). The model field
-  # above it is already routed via Boundary_redaction.
-  "lib/keeper/keeper_turn_driver_wrappers.ml:94"
+  # Empty: internal-observability "runtime" literals now carry inline
+  # `(* RFC-0132-EXEMPT: ... *)` pragmas instead of file:line entries, which
+  # go stale on every line shift (the RFC-0206 dispatch collapse moved the
+  # former keeper_turn_driver_wrappers.ml:94 site and broke this gate).
 )
 
 violations_tmp="$(mktemp -t rfc0132-pr3.violations.XXXXXX)"
@@ -88,7 +88,8 @@ trap 'rm -f "$violations_tmp" "$stale_tmp"' EXIT
 is_preapproved() {
   local key="$1"
   local entry
-  for entry in "${PREAPPROVED[@]}"; do
+  # `${arr[@]+...}` guard: expands to nothing on an empty array under `set -u`.
+  for entry in "${PREAPPROVED[@]+"${PREAPPROVED[@]}"}"; do
     [[ "$key" == "$entry" ]] && return 0
   done
   return 1
@@ -141,7 +142,7 @@ for f in "${SCAN_FILES[@]}"; do
 done
 
 # Detect stale preapproved entries: line no longer carries `"runtime"`.
-for entry in "${PREAPPROVED[@]}"; do
+for entry in "${PREAPPROVED[@]+"${PREAPPROVED[@]}"}"; do
   path="${entry%%:*}"
   line="${entry#*:}"
   [[ -f "$path" ]] || { echo "$entry (file missing)" >>"$stale_tmp"; continue; }


### PR DESCRIPTION
## 목표

머지된 RFC-0206 dispatch collapse(#19604)가 `keeper_turn_driver_wrappers.ml`을 재구성하면서 `"runtime"` 리터럴이 line 94→152로 이동 → RFC-0132 boundary-redaction lint의 `PREAPPROVED` file:line 항목이 stale → **main Fundamental Check (Boundary redaction SSOT) FAILURE**. 짝이 되는 baseline 갱신이 collapse PR에서 누락된 전형적 사례.

## 변경

- `scripts/lint/no-runtime-literal-outside-boundary-redaction.sh`: stale `keeper_turn_driver_wrappers.ml:94` 항목 제거, `PREAPPROVED`를 비움. **line-number 기반 항목은 라인 이동마다 stale**해지므로(이 실패의 원인), lint이 권장하는 robust 메커니즘인 inline `(* RFC-0132-EXEMPT: ... *)` 주석으로 전환. 빈 배열이 `set -u`에서 깨지던 `"${PREAPPROVED[@]}"` 두 곳을 `${arr[@]+...}` 가드로 수정.
- `keeper_turn_driver_wrappers.ml:152` / `keeper_unified_turn.ml:142`: 두 내부-observability `"runtime"` 리터럴(rejection reason / manifest decision 레이블 — redact 대상 공개 surface 아님)에 `RFC-0132-EXEMPT` 주석 추가.

## 검증

- `scripts/lint/no-runtime-literal-outside-boundary-redaction.sh --fail`: PASS (preapproved 0, violations 0, stale 0).
- 두 OCaml 파일 parse OK (주석 삽입은 whitespace이므로 의미 불변).
- `bash -n` lint 스크립트 syntax OK.

RFC-WAIVED: lint allowlist + 2개 내부-observability 주석 추가. credential/identity/operator/sandbox 로직 변경 없음. RFC-0132(boundary redaction) 메커니즘의 sanctioned exemption, RFC-0206 collapse fallout 복구.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
