### PR TITLE
fix(lint): refresh RFC-0132 preapproved runtime-literal lines after #19604 collapse

### DIFF
--- a/scripts/lint/no-runtime-literal-outside-boundary-redaction.sh
+++ b/scripts/lint/no-runtime-literal-outside-boundary-redaction.sh
@@ -77,8 +77,13 @@ SCAN_FILES=(
 PREAPPROVED=(
   # Debug format string inside Printf.sprintf — internal observability
   # (real provider identity, not boundary redaction). The model field
-  # above it is already routed via Boundary_redaction.
-  "lib/keeper/keeper_turn_driver_wrappers.ml:94"
+  # above it is already routed via Boundary_redaction. Line moved by the
+  # RFC-0206 run_named single-dispatch collapse (#19604).
+  "lib/keeper/keeper_turn_driver_wrappers.ml:152"
+  # Redacted manifest decision reason for the Runtime_routed event —
+  # internal observability; concrete runtime identity is owned by the
+  # OAS/provider adapters, not this boundary surface.
+  "lib/keeper/keeper_unified_turn.ml:142"
 )
 
 violations_tmp="$(mktemp -t rfc0132-pr3.violations.XXXXXX)"


### PR DESCRIPTION
RFC-0132 Boundary-redaction SSOT lint (`Fundamental Check`) is red on main.

The RFC-0206 `run_named` single-dispatch collapse (#19604) shifted the
internal-observability `"runtime"` debug literal in
`keeper_turn_driver_wrappers.ml` from line 94 → 152 (leaving the `PREAPPROVED`
entry stale), and `keeper_unified_turn.ml:142` (the redacted `Runtime_routed`
manifest decision reason) was not in the list.

Both are internal-observability redaction placeholders, not boundary-surface
labels — concrete runtime identity is owned by the OAS/provider adapters. This
refreshes the `PREAPPROVED` list to the current line numbers.

Verify:
```
bash scripts/lint/no-runtime-literal-outside-boundary-redaction.sh --fail
# rfc0132_pr3_violations 0 / rfc0132_pr3_stale_preapproved 0 / OK / exit 0
```

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
