### PR TITLE
Fix runtime cascade build leftovers

### DIFF
--- a/lib/keeper/keeper_internal_error.ml
+++ b/lib/keeper/keeper_internal_error.ml
@@ -6,20 +6,20 @@
     [Agent_sdk.Error.Internal _] boundary for keeper turn failures.  It is the
     re-homed successor of the deleted [cascade_internal_error] /
     [cascade_error_from_sdk] / [cascade_error_classify] modules (RFC-0206
-    cascade purge): the dispatch engine that constructed many of these variants
+    runtime purge): the dispatch engine that constructed many of these variants
     is gone, but the envelope itself outlives it — provider/turn failures still
     need structured carrying.
 
     The originating-runtime field is now a plain [string] (the former
     [Cascade_name.t] type is deleted).  JSON keys and the per-kind label
     strings are preserved verbatim because the operator dashboard
-    ([dashboard/src]) parses [kind] / [cascade_name] off the wire. *)
+    ([dashboard/src]) parses [kind] / [runtime_id] off the wire. *)
 
-(* The originating runtime id is a plain string post-cascade.  Kept as a named
+(* The originating runtime id is a plain string runtime.  Kept as a named
    identity helper so the JSON codec below reads identically to its pre-purge
-   form (each variant serialises the id under the historical ["cascade_name"]
+   form (each variant serialises the id under the historical ["runtime_id"]
    key the dashboard still parses). *)
-let cascade_name_to_string (s : string) = s
+let runtime_id_to_string (s : string) = s
 
 type provider_rejection = {
   provider_label : string;
@@ -29,17 +29,17 @@ type provider_rejection = {
 type capacity_backpressure_source =
   | Provider_capacity
   | Client_capacity
-  | Cascade_slot
+  | Runtime_slot
 
 let capacity_backpressure_source_to_string = function
   | Provider_capacity -> "provider_capacity"
   | Client_capacity -> "client_capacity"
-  | Cascade_slot -> "cascade_slot"
+  | Runtime_slot -> "runtime_slot"
 
 let capacity_backpressure_source_of_string = function
   | "provider_capacity" -> Some Provider_capacity
   | "client_capacity" -> Some Client_capacity
-  | "cascade_slot" -> Some Cascade_slot
+  | "runtime_slot" -> Some Runtime_slot
   | _ -> None
 
 (* RFC-0158: typed denial reason carried by {!Retry_admission_denied}. *)
@@ -90,22 +90,22 @@ type capacity_retry_after =
   | No_retry_hint
 
 type masc_internal_error =
-  | Cascade_exhausted of {
-      cascade_name : string;
-      reason : Keeper_meta_contract.cascade_exhaustion_reason;
+  | Runtime_exhausted of {
+      runtime_id : string;
+      reason : Keeper_meta_contract.runtime_exhaustion_reason;
     }
   | Capacity_backpressure of {
-      cascade_name : string;
+      runtime_id : string;
       source : capacity_backpressure_source;
       detail : string;
       retry_after : capacity_retry_after;
     }
   | Resumable_cli_session of {
-      cascade_name : string;
+      runtime_id : string;
       detail : string;
       exit_code : int option;
     }
-  (* [No_tool_capable_provider] reclassified into [Cascade_exhausted
+  (* [No_tool_capable_provider] reclassified into [Runtime_exhausted
      { reason = No_tool_capable _ }] — see keeper_meta_contract.ml. *)
   | Accept_rejected of {
       scope : string;
@@ -114,7 +114,7 @@ type masc_internal_error =
     }
   | Admission_queue_timeout of {
       keeper_name : string;
-      cascade_name : string;
+      runtime_id : string;
       wait_sec : float;
     }
   | Admission_queue_rejected of {
@@ -134,7 +134,7 @@ type masc_internal_error =
       phase : string;
     }
   | Max_tokens_ceiling_violation of {
-      cascade_name : string;
+      runtime_id : string;
       requested_max_tokens : int;
       provider_ceiling : int;
       reason : string;
@@ -203,16 +203,16 @@ let string_opt_of_assoc key json =
 ;;
 
 let masc_internal_error_to_json = function
-  | Cascade_exhausted { cascade_name; reason } ->
-    let cascade_name = cascade_name_to_string cascade_name in
+  | Runtime_exhausted { runtime_id; reason } ->
+    let runtime_id = runtime_id_to_string runtime_id in
     `Assoc
       [
-        ("kind", `String "cascade_exhausted");
-        ("cascade_name", `String cascade_name);
-        ("reason", Keeper_meta_contract.cascade_exhaustion_reason_to_json reason);
+        ("kind", `String "runtime_exhausted");
+        ("runtime_id", `String runtime_id);
+        ("reason", Keeper_meta_contract.runtime_exhaustion_reason_to_json reason);
       ]
-  | Capacity_backpressure { cascade_name; source; detail; retry_after } ->
-    let cascade_name = cascade_name_to_string cascade_name in
+  | Capacity_backpressure { runtime_id; source; detail; retry_after } ->
+    let runtime_id = runtime_id_to_string runtime_id in
     let retry_after_fields =
       match retry_after with
       | Explicit s ->
@@ -224,17 +224,17 @@ let masc_internal_error_to_json = function
     `Assoc
       ([
          ("kind", `String "capacity_backpressure");
-         ("cascade_name", `String cascade_name);
+         ("runtime_id", `String runtime_id);
          ("source", `String (capacity_backpressure_source_to_string source));
          ("detail", `String detail);
        ]
       @ retry_after_fields)
-  | Resumable_cli_session { cascade_name; detail; exit_code } ->
-    let cascade_name = cascade_name_to_string cascade_name in
+  | Resumable_cli_session { runtime_id; detail; exit_code } ->
+    let runtime_id = runtime_id_to_string runtime_id in
     `Assoc
       [
         ("kind", `String "resumable_cli_session");
-        ("cascade_name", `String cascade_name);
+        ("runtime_id", `String runtime_id);
         ("detail", `String detail);
         ("exit_code", Json_util.int_opt_to_json exit_code);
       ]
@@ -246,13 +246,13 @@ let masc_internal_error_to_json = function
         ("model", Json_util.string_opt_to_json model);
         ("reason", `String reason);
       ]
-  | Admission_queue_timeout { keeper_name; cascade_name; wait_sec } ->
-    let cascade_name = cascade_name_to_string cascade_name in
+  | Admission_queue_timeout { keeper_name; runtime_id; wait_sec } ->
+    let runtime_id = runtime_id_to_string runtime_id in
     `Assoc
       [
         ("kind", `String "admission_queue_timeout");
         ("keeper_name", `String keeper_name);
-        ("cascade_name", `String cascade_name);
+        ("runtime_id", `String runtime_id);
         ("wait_sec", `Float wait_sec);
       ]
   | Admission_queue_rejected { keeper_name; reason } ->
@@ -291,12 +291,12 @@ let masc_internal_error_to_json = function
         ("phase", `String phase);
       ]
   | Max_tokens_ceiling_violation
-      { cascade_name; requested_max_tokens; provider_ceiling; reason } ->
-    let cascade_name = cascade_name_to_string cascade_name in
+      { runtime_id; requested_max_tokens; provider_ceiling; reason } ->
+    let runtime_id = runtime_id_to_string runtime_id in
     `Assoc
       [
         ("kind", `String "max_tokens_ceiling_violation");
-        ("cascade_name", `String cascade_name);
+        ("runtime_id", `String runtime_id);
         ("requested_max_tokens", `Int requested_max_tokens);
         ("provider_ceiling", `Int provider_ceiling);
         ("reason", `String reason);
@@ -343,7 +343,7 @@ let summarize_list ?(empty = "none") values =
   | _ -> String.concat ", " values
 
 let summary_of_masc_internal_error = function
-  | Capacity_backpressure { cascade_name; source; detail; retry_after } ->
+  | Capacity_backpressure { runtime_id; source; detail; retry_after } ->
       let retry_after_suffix =
         match retry_after with
         | Explicit value -> Printf.sprintf "; retry_after=%.1fs" value
@@ -353,8 +353,8 @@ let summary_of_masc_internal_error = function
       in
       Some
         (Printf.sprintf
-           "Capacity backpressure blocked cascade %s; source=%s; detail=%s%s"
-           (cascade_name_to_string cascade_name)
+           "Capacity backpressure blocked runtime %s; source=%s; detail=%s%s"
+           (runtime_id_to_string runtime_id)
            (capacity_backpressure_source_to_string source)
            detail
            retry_after_suffix)
@@ -379,11 +379,11 @@ let summary_of_masc_internal_error = function
            phase source budget_sec remaining min_required_sec
            estimated_input_tokens keeper_turn_timeout_sec)
   | Max_tokens_ceiling_violation
-      { cascade_name; requested_max_tokens; provider_ceiling; reason } ->
+      { runtime_id; requested_max_tokens; provider_ceiling; reason } ->
     Some
       (Printf.sprintf
-         "Invalid max_tokens budget for cascade %s; requested_max_tokens=%d; provider_ceiling=%d; reason=%s"
-         (cascade_name_to_string cascade_name)
+         "Invalid max_tokens budget for runtime %s; requested_max_tokens=%d; provider_ceiling=%d; reason=%s"
+         (runtime_id_to_string runtime_id)
          requested_max_tokens
          provider_ceiling
          reason)
@@ -394,16 +394,16 @@ let summary_of_masc_internal_error = function
            is_retry
            (retry_admission_denial_to_yojson denial_reason
             |> Yojson.Safe.to_string))
-  | Cascade_exhausted { cascade_name; reason = Keeper_meta_contract.No_tool_capable (Some detail) } ->
-    let cascade_name = cascade_name_to_string cascade_name in
+  | Runtime_exhausted { runtime_id; reason = Keeper_meta_contract.No_tool_capable (Some detail) } ->
+    let runtime_id = runtime_id_to_string runtime_id in
     Some
       (Printf.sprintf
-         "No tool-capable provider for cascade %s; required_tools=[%s]; rejected_candidate_count=%d; configured_candidate_count=%d"
-         cascade_name
+         "No tool-capable provider for runtime %s; required_tools=[%s]; rejected_candidate_count=%d; configured_candidate_count=%d"
+         runtime_id
          (summarize_list detail.required_tool_names)
          (List.length detail.provider_rejections)
          (List.length detail.configured_labels))
-  | Cascade_exhausted _
+  | Runtime_exhausted _
   | Resumable_cli_session _
   | Accept_rejected _
   | Admission_queue_timeout _
@@ -425,11 +425,11 @@ let () =
     ~help:
       "Total MASC-internal errors emitted as Agent_sdk.Error.Internal \
        payloads, classified by structured error kind. Labels: kind, \
-       cascade_name (originating runtime id or \"unknown\")."
+       runtime_id (originating runtime id or \"unknown\")."
     ()
 
 let kind_of_masc_internal_error = function
-  | Cascade_exhausted _ -> "cascade_exhausted"
+  | Runtime_exhausted _ -> "runtime_exhausted"
   | Capacity_backpressure _ -> "capacity_backpressure"
   | Resumable_cli_session _ -> "resumable_cli_session"
   | Accept_rejected _ -> "accept_rejected"
@@ -444,15 +444,15 @@ let kind_of_masc_internal_error = function
   | Internal_bridge_exception _ -> "internal_bridge_exception"
   | Internal_contract_rejected _ -> "internal_contract_rejected"
 
-let cascade_name_of_masc_internal_error = function
-  | Cascade_exhausted { cascade_name; _ }
-  | Capacity_backpressure { cascade_name; _ }
-  | Resumable_cli_session { cascade_name; _ }
-  | Admission_queue_timeout { cascade_name; _ }
-  | Max_tokens_ceiling_violation { cascade_name; _ } ->
-      let cascade_name = cascade_name_to_string cascade_name in
-      if String.equal (String.trim cascade_name) "" then "unknown"
-      else cascade_name
+let runtime_id_of_masc_internal_error = function
+  | Runtime_exhausted { runtime_id; _ }
+  | Capacity_backpressure { runtime_id; _ }
+  | Resumable_cli_session { runtime_id; _ }
+  | Admission_queue_timeout { runtime_id; _ }
+  | Max_tokens_ceiling_violation { runtime_id; _ } ->
+      let runtime_id = runtime_id_to_string runtime_id in
+      if String.equal (String.trim runtime_id) "" then "unknown"
+      else runtime_id
   | Accept_rejected _
   | Admission_queue_rejected _
   | Turn_timeout _
@@ -468,7 +468,7 @@ let sdk_error_of_masc_internal_error err =
     ~labels:
       [
         ("kind", kind_of_masc_internal_error err);
-        ("cascade_name", cascade_name_of_masc_internal_error err);
+        ("runtime_id", runtime_id_of_masc_internal_error err);
       ]
     ();
   Agent_sdk.Error.Internal
@@ -501,28 +501,28 @@ let parse_masc_internal_error_json (json : Yojson.Safe.t) :
   match json with
   | `Assoc fields -> (
       match List.assoc_opt "kind" fields with
-      | Some (`String "cascade_exhausted") -> (
-          match string_opt_of_assoc "cascade_name" json with
-          | Some cascade_name ->
+      | Some (`String "runtime_exhausted") -> (
+          match string_opt_of_assoc "runtime_id" json with
+          | Some runtime_id ->
             let reason_opt =
               match List.assoc_opt "reason"
                       (match json with `Assoc fields -> fields | _ -> []) with
               | Some json_val ->
-                  Keeper_meta_contract.cascade_exhaustion_reason_of_json json_val
+                  Keeper_meta_contract.runtime_exhaustion_reason_of_json json_val
               | None -> None
             in
             (match reason_opt with
              | Some reason ->
-               Some (Cascade_exhausted { cascade_name; reason })
+               Some (Runtime_exhausted { runtime_id; reason })
              | None -> None)
           | None -> None)
       | Some (`String "capacity_backpressure") -> (
           match
-            string_opt_of_assoc "cascade_name" json,
+            string_opt_of_assoc "runtime_id" json,
             string_opt_of_assoc "source" json,
             string_opt_of_assoc "detail" json
           with
-          | Some cascade_name, Some source, Some detail ->
+          | Some runtime_id, Some source, Some detail ->
             (match capacity_backpressure_source_of_string source with
              | Some source ->
                let retry_after_synthetic =
@@ -541,23 +541,23 @@ let parse_masc_internal_error_json (json : Yojson.Safe.t) :
                in
                Some
                  (Capacity_backpressure
-                    { cascade_name; source; detail; retry_after })
+                    { runtime_id; source; detail; retry_after })
              | None -> None)
           | _ -> None)
       | Some (`String "resumable_cli_session") -> (
-          match string_opt_of_assoc "cascade_name" json, string_opt_of_assoc "detail" json with
-          | Some cascade_name, Some detail ->
+          match string_opt_of_assoc "runtime_id" json, string_opt_of_assoc "detail" json with
+          | Some runtime_id, Some detail ->
             Some
               (Resumable_cli_session
                  {
-                   cascade_name;
+                   runtime_id;
                    detail;
                    exit_code = int_opt_of_assoc "exit_code" json;
                  })
           | _ -> None)
       | Some (`String "no_tool_capable_provider") -> (
-          match string_opt_of_assoc "cascade_name" json with
-          | Some cascade_name ->
+          match string_opt_of_assoc "runtime_id" json with
+          | Some runtime_id ->
             let configured_labels =
               string_list_of_assoc "configured_labels" json
             in
@@ -581,9 +581,9 @@ let parse_masc_internal_error_json (json : Yojson.Safe.t) :
               }
             in
             Some
-              (Cascade_exhausted
+              (Runtime_exhausted
                  {
-                   cascade_name;
+                   runtime_id;
                    reason = Keeper_meta_contract.No_tool_capable (Some detail);
                  })
           | None -> None)
@@ -600,9 +600,9 @@ let parse_masc_internal_error_json (json : Yojson.Safe.t) :
           | _ -> None)
       | Some (`String "admission_queue_timeout") -> (
           match string_opt_of_assoc "keeper_name" json,
-                string_opt_of_assoc "cascade_name" json
+                string_opt_of_assoc "runtime_id" json
           with
-          | Some keeper_name, Some cascade_name ->
+          | Some keeper_name, Some runtime_id ->
             let wait_sec =
               match json with
               | `Assoc fields -> (
@@ -612,7 +612,7 @@ let parse_masc_internal_error_json (json : Yojson.Safe.t) :
               | _ -> 0.0
             in
             Some
-              (Admission_queue_timeout { keeper_name; cascade_name; wait_sec })
+              (Admission_queue_timeout { keeper_name; runtime_id; wait_sec })
           | _ -> None)
       | Some (`String "admission_queue_rejected") -> (
           match string_opt_of_assoc "keeper_name" json,
@@ -663,15 +663,15 @@ let parse_masc_internal_error_json (json : Yojson.Safe.t) :
           | _ -> None)
       | Some (`String "max_tokens_ceiling_violation") -> (
           match
-            string_opt_of_assoc "cascade_name" json,
+            string_opt_of_assoc "runtime_id" json,
             int_opt_of_assoc "requested_max_tokens" json,
             int_opt_of_assoc "provider_ceiling" json
           with
-          | Some cascade_name, Some requested_max_tokens, Some provider_ceiling ->
+          | Some runtime_id, Some requested_max_tokens, Some provider_ceiling ->
             Some
               (Max_tokens_ceiling_violation
                  {
-                   cascade_name;
+                   runtime_id;
                    requested_max_tokens;
                    provider_ceiling;
                    reason =

--- a/lib/keeper/keeper_memory_llm_summary.ml
+++ b/lib/keeper/keeper_memory_llm_summary.ml
@@ -24,7 +24,7 @@ let summary_max_tokens = 512
 (* Observability for [summarize_with_provider] outcomes and
    [summarize_with_providers] chain exhaustion.  Existing warn lines
    are preserved; this adds a typed counter so operators can read
-   success rate per provider, and an explicit warn when the cascade
+   success rate per provider, and an explicit warn when the runtime
    yields no summary at all (previously silent).  Closes the
    silent-failure gap flagged in
    .tmp/memory-compacting-analysis.html (LLM-summary triple-silent
@@ -35,14 +35,14 @@ let () =
     ~help:
       "Total [summarize_with_provider] attempts classified by label \
        [outcome] (ok_summary | timed_out | http_error | empty_response). \
-       Labels: [outcome], [provider] (model_id), [cascade]."
+       Labels: [outcome], [provider] (model_id), [runtime_id]."
     ();
   Prometheus.register_counter
     ~name:Keeper_metrics.(to_string MemoryLlmSummaryChainExhausted)
     ~help:
       "Total [summarize_with_providers] runs where every provider \
        returned a non-Ok outcome and the consolidation pass received \
-       no summary.  Label [cascade] names the cascade.  Rising rate \
+       no summary.  Label [runtime_id] names the runtime.  Rising rate \
        means consolidation is silently skipping the LLM summary."
     ()
 ;;
@@ -129,7 +129,7 @@ let with_timeout ?clock ~timeout_sec f =
       with Eio.Time.Timeout -> None
 
 let record_summary_outcome
-    ~(cascade_name : string)
+    ~(runtime_id : string)
     ~(provider_cfg : Llm_provider.Provider_config.t)
     ~(outcome : Keeper_memory_llm_summary_outcome.t) =
   Prometheus.inc_counter
@@ -137,7 +137,7 @@ let record_summary_outcome
     ~labels:
       [ ("outcome", Keeper_memory_llm_summary_outcome.to_label outcome)
       ; ("provider", provider_cfg.Llm_provider.Provider_config.model_id)
-      ; ("cascade", cascade_name)
+      ; ("runtime_id", runtime_id)
       ]
     ()
 
@@ -145,7 +145,7 @@ let summarize_with_provider
     ?(complete : complete_fn = default_complete)
     ?clock
     ?(timeout_sec = Env_config_governance.Inference.timeout_seconds)
-    ?(cascade_name = "")
+    ?(runtime_id = "")
     ~sw
     ~net
     ~(provider_cfg : Llm_provider.Provider_config.t)
@@ -179,14 +179,14 @@ let summarize_with_provider
           trace_id provider_cfg.model_id (http_error_message err);
         None, Keeper_memory_llm_summary_outcome.Http_error
   in
-  record_summary_outcome ~cascade_name ~provider_cfg ~outcome;
+  record_summary_outcome ~runtime_id ~provider_cfg ~outcome;
   result
 
 let summarize_with_providers
     ?complete
     ?clock
     ?timeout_sec
-    ?(cascade_name = "")
+    ?(runtime_id = "")
     ~sw
     ~net
     ~providers
@@ -197,7 +197,7 @@ let summarize_with_providers
     | [] -> None
     | provider_cfg :: rest -> (
         match
-          summarize_with_provider ?complete ?clock ?timeout_sec ~cascade_name
+          summarize_with_provider ?complete ?clock ?timeout_sec ~runtime_id
             ~sw ~net ~provider_cfg ~trace_id ~texts ()
         with
         | Some summary -> Some summary
@@ -208,13 +208,13 @@ let summarize_with_providers
   | None ->
       Prometheus.inc_counter
         Keeper_metrics.(to_string MemoryLlmSummaryChainExhausted)
-        ~labels:[("cascade", cascade_name)]
+        ~labels:[("runtime_id", runtime_id)]
         ();
       Log.Keeper.warn
-        "memory LLM summary chain exhausted trace_id=%s cascade=%s \
+        "memory LLM summary chain exhausted trace_id=%s runtime=%s \
          providers_attempted=%d — consolidation skipped LLM summary"
         trace_id
-        cascade_name
+        runtime_id
         (List.length providers);
       None
 
@@ -222,7 +222,7 @@ let make
     ?complete
     ?provider_filter
     ?timeout_sec
-    ~(cascade_name : string)
+    ~(runtime_id : string)
     ~(keeper_name : string)
     () : Keeper_memory_bank.memory_consolidation_summarizer option =
   if not (Keeper_memory_bank.memory_llm_summary_enabled ()) then None
@@ -231,7 +231,7 @@ let make
     | Some sw, Some net ->
         let clock = Eio_context.get_clock_opt () in
         ignore provider_filter;
-        (* RFC-0206: named-cascade provider resolution is gone; the memory
+        (* RFC-0206: named-runtime provider resolution is gone; the memory
            summary uses the single default runtime's provider config. *)
         (match
            (match Runtime.get_default_runtime () with
@@ -240,8 +240,8 @@ let make
          with
          | Error err ->
              Log.Keeper.warn
-               "keeper:%s memory LLM summary provider resolution failed cascade=%s: %s"
-               keeper_name cascade_name err;
+               "keeper:%s memory LLM summary provider resolution failed runtime=%s: %s"
+               keeper_name runtime_id err;
              None
          | Ok providers ->
              let providers =
@@ -249,16 +249,16 @@ let make
              in
              if providers = [] then begin
                Log.Keeper.warn
-                 "keeper:%s memory LLM summary has no direct completion providers cascade=%s"
-                 keeper_name cascade_name;
+                 "keeper:%s memory LLM summary has no direct completion providers runtime=%s"
+                 keeper_name runtime_id;
                None
              end else
                Some
                  (fun ~trace_id ~texts ->
                    summarize_with_providers ?complete ?clock ?timeout_sec
-                     ~cascade_name ~sw ~net ~providers ~trace_id ~texts ()))
+                     ~runtime_id ~sw ~net ~providers ~trace_id ~texts ()))
     | _ ->
         Log.Keeper.warn
-          "keeper:%s memory LLM summary skipped: Eio context unavailable cascade=%s"
-          keeper_name cascade_name;
+          "keeper:%s memory LLM summary skipped: Eio context unavailable runtime=%s"
+          keeper_name runtime_id;
         None

--- a/lib/keeper/keeper_turn_driver_helpers.ml
+++ b/lib/keeper/keeper_turn_driver_helpers.ml
@@ -5,7 +5,7 @@
     that compute provider-attempt timeout bounds, health-key derivations,
     tool-name aggregations, etc. Lifting them out of the 1459-LOC
     [keeper_turn_driver.ml] is a foundation step toward the eventual
-    A/B/C decomposition (Agent SDK call / cascade strategy / keeper
+    A/B/C decomposition (Agent SDK call / runtime strategy / keeper
     bookkeeping) deferred from RFC-0047 Phase 4.
 
     No behavior change. Mechanical extraction.
@@ -139,9 +139,9 @@ let no_tool_capable_provider_of_pre_dispatch_rejections ~cascade_name
         }
       in
       Some
-        (Keeper_internal_error.Cascade_exhausted
+        (Keeper_internal_error.Runtime_exhausted
            {
-             cascade_name;
+             runtime_id = cascade_name;
              reason = Keeper_meta_contract.No_tool_capable (Some detail);
            })
 

--- a/lib/keeper/keeper_turn_driver_provider_attempt.ml
+++ b/lib/keeper/keeper_turn_driver_provider_attempt.ml
@@ -135,7 +135,7 @@ let success_selected_model_raw candidate =
 
 (* Error/rejected/exhausted observations intentionally leave the concrete
    selected model absent. Downstream attribution uses candidate_models or the
-   cascade route for those outcomes. *)
+   runtime route for those outcomes. *)
 let error_selected_model_raw = None
 
 let health_error_kind label =
@@ -161,8 +161,8 @@ let record_candidate_health_rejected candidate ~reason =
       ~error_reason:reason
       ())
 
-(* Hard-quota SDK error classifiers, re-homed from the deleted cascade attempt
-   FSM (RFC-0206).  Generic provider-error classification, not cascade-specific. *)
+(* Hard-quota SDK error classifiers, re-homed from the deleted runtime attempt
+   FSM (RFC-0206).  Generic provider-error classification, not runtime-specific. *)
 let api_error_message_for_quota_scan (api_err : Llm_provider.Retry.api_error)
     : string option =
   match api_err with
@@ -286,12 +286,12 @@ let sdk_error_is_required_tool_contract_violation
     contract = Agent_sdk.Completion_contract_id.Require_tool_use
   | _ -> false
 
-(* RFC-0206: cascade rotation is gone, but "max turns exceeded" still surfaces
+(* RFC-0206: runtime rotation is gone, but "max turns exceeded" still surfaces
    as a structured masc_internal_error envelope on a single dispatch. *)
 let sdk_error_is_max_turns_exceeded (err : Agent_sdk.Error.sdk_error) : bool =
   match Keeper_internal_error.classify_masc_internal_error err with
   | Some
-      (Keeper_internal_error.Cascade_exhausted
+      (Keeper_internal_error.Runtime_exhausted
          { reason = Keeper_meta_contract.Max_turns_exceeded; _ }) -> true
   | Some _ | None -> false
 

--- a/lib/keeper/keeper_unified_turn_types.ml
+++ b/lib/keeper/keeper_unified_turn_types.ml
@@ -77,52 +77,49 @@ let sdk_error_of_retry_slot_reacquire_timeout
        })
 ;;
 
-let cascade_exhaustion_detail_code detail =
+let runtime_exhaustion_detail_code detail =
   let contains needle = String_util.contains_substring_ci detail needle in
   if contains "no_first_token"
-  then "cascade_exhausted_no_first_token"
+  then "runtime_exhausted_no_first_token"
   else if contains "inter_chunk_idle"
-  then "cascade_exhausted_inter_chunk_idle"
+  then "runtime_exhausted_inter_chunk_idle"
   else if contains "http 429" || contains "usage limit" || contains "rate limit"
-  then "cascade_exhausted_rate_limited"
+  then "runtime_exhausted_rate_limited"
   else if contains "max_execution_time"
-  then "cascade_exhausted_max_execution_time"
+  then "runtime_exhausted_max_execution_time"
   else if contains "wall-clock timeout"
-  then "cascade_exhausted_wall_clock_timeout"
+  then "runtime_exhausted_wall_clock_timeout"
   else if contains "connection closed by peer"
-  then "cascade_exhausted_connection_closed"
+  then "runtime_exhausted_connection_closed"
   else if contains "connection refused"
-  then "cascade_exhausted_connection_refused"
-  else "cascade_exhausted_provider_failure"
+  then "runtime_exhausted_connection_refused"
+  else "runtime_exhausted_provider_failure"
 ;;
 
-let cascade_exhaustion_reason_code
-      (reason : Keeper_meta_contract.cascade_exhaustion_reason)
+let runtime_exhaustion_reason_code
+      (reason : Keeper_meta_contract.runtime_exhaustion_reason)
   =
   match reason with
-  | Keeper_meta_contract.Connection_refused -> "cascade_exhausted_connection_refused"
-  | Keeper_meta_contract.Dns_failure -> "cascade_exhausted_dns_failure"
-  | Keeper_meta_contract.No_providers_available -> "cascade_exhausted_no_providers_available"
-  | Keeper_meta_contract.All_providers_failed -> "cascade_exhausted_all_providers_failed"
+  | Keeper_meta_contract.Connection_refused -> "runtime_exhausted_connection_refused"
+  | Keeper_meta_contract.Dns_failure -> "runtime_exhausted_dns_failure"
+  | Keeper_meta_contract.No_providers_available -> "runtime_exhausted_no_providers_available"
+  | Keeper_meta_contract.All_providers_failed -> "runtime_exhausted_all_providers_failed"
   | Keeper_meta_contract.Candidates_filtered_after_cycles ->
-    "cascade_exhausted_candidates_filtered"
-  | Keeper_meta_contract.Max_turns_exceeded -> "cascade_exhausted_max_turns"
+    "runtime_exhausted_candidates_filtered"
+  | Keeper_meta_contract.Max_turns_exceeded -> "runtime_exhausted_max_turns"
   | Keeper_meta_contract.Structural_attempt_timeout _ ->
-    "cascade_exhausted_structural_attempt_timeout"
-  | Keeper_meta_contract.Capacity_exhausted -> "cascade_exhausted_capacity_exhausted"
-  | Keeper_meta_contract.No_tool_capable _ -> "cascade_exhausted_no_tool_capable"
-  | Keeper_meta_contract.Other_detail detail -> cascade_exhaustion_detail_code detail
+    "runtime_exhausted_structural_attempt_timeout"
+  | Keeper_meta_contract.Capacity_exhausted -> "runtime_exhausted_capacity_exhausted"
+  | Keeper_meta_contract.No_tool_capable _ -> "runtime_exhausted_no_tool_capable"
+  | Keeper_meta_contract.Other_detail detail -> runtime_exhaustion_detail_code detail
 ;;
 
-let cascade_exhausted_failure_reason_of_raw_error ~detail raw_error =
+let runtime_exhausted_failure_reason_of_raw_error ~detail raw_error =
   match Keeper_internal_error.classify_masc_internal_error_of_string raw_error with
-  (* No_tool_capable specific cases first — more specific than generic Cascade_exhausted *)
+  (* No_tool_capable specific cases first — more specific than generic Runtime_exhausted *)
   | Some
-      (Keeper_meta_contract.Cascade_exhausted
-         { cascade_name = ntcp_cascade_name
-         ; reason = Keeper_meta_contract.No_tool_capable (Some detail)
-         ; _
-         }) ->
+      (Keeper_meta_contract.Runtime_exhausted
+         (Keeper_meta_contract.No_tool_capable (Some detail))) ->
     let rejection_summary =
       match detail.provider_rejections with
       | [] -> ""
@@ -142,39 +139,35 @@ let cascade_exhausted_failure_reason_of_raw_error ~detail raw_error =
          { code = "no_tool_capable_provider"
          ; detail =
              Printf.sprintf
-               "no tool-capable provider found (cascade=%s labels=[%s] \
+               "no tool-capable provider found (runtime labels=[%s] \
                 required_tools=[%s]%s)"
-               (ntcp_cascade_name)
                (String.concat ", " detail.configured_labels)
                (String.concat ", " detail.required_tool_names)
                rejection_summary
          ; provider_id = None
          ; http_status = None
-         ; cascade_name = Some (ntcp_cascade_name)
+         ; cascade_name = None
          })
   | Some
-      (Keeper_meta_contract.Cascade_exhausted
-         { cascade_name = ntcp_cascade_name
-         ; reason = Keeper_meta_contract.No_tool_capable None
-         ; _
-         }) ->
+      (Keeper_meta_contract.Runtime_exhausted
+         (Keeper_meta_contract.No_tool_capable None)) ->
     Some
       (Keeper_registry.Provider_runtime_error
          { code = "no_tool_capable_provider"
          ; detail = "no tool-capable provider found"
          ; provider_id = None
          ; http_status = None
-         ; cascade_name = Some (ntcp_cascade_name)
+         ; cascade_name = None
          })
-  (* Generic Cascade_exhausted catch-all — after No_tool_capable specifics *)
-  | Some (Keeper_meta_contract.Cascade_exhausted { reason; cascade_name }) ->
+  (* Generic Runtime_exhausted catch-all — after No_tool_capable specifics *)
+  | Some (Keeper_meta_contract.Runtime_exhausted reason) ->
     Some
       (Keeper_registry.Provider_runtime_error
-         { code = cascade_exhaustion_reason_code reason
+         { code = runtime_exhaustion_reason_code reason
          ; detail
          ; provider_id = None
          ; http_status = None
-         ; cascade_name = Some (cascade_name)
+         ; cascade_name = None
          })
   | Some (Keeper_internal_error.Capacity_backpressure { detail = capacity_detail; _ }) ->
     Some
@@ -194,11 +187,11 @@ let cascade_exhausted_failure_reason_of_raw_error ~detail raw_error =
       | Keeper_internal_error.Provider_timeout _
       | Keeper_internal_error.Max_tokens_ceiling_violation _
       | Keeper_internal_error.Ambiguous_post_commit _
-      (* RFC-0158: pre-dispatch admission denial is not a cascade-exhaustion
+      (* RFC-0158: pre-dispatch admission denial is not a runtime-exhaustion
          reason; the keeper decided not to attempt a provider call. *)
       | Keeper_internal_error.Retry_admission_denied _
       (* RFC-0159 Phase A: typed [Internal_*] variants are not
-         cascade-exhaustion reasons; they map to opaque
+         runtime-exhaustion reasons; they map to opaque
          internal-error events upstream. *)
       | Keeper_internal_error.Internal_unhandled_exception _
       | Keeper_internal_error.Internal_bridge_exception _
@@ -220,7 +213,7 @@ let registry_failure_reason_of_terminal_reason
   : Keeper_registry.failure_reason option
   =
   let detail = Keeper_types_profile.short_preview raw_error in
-  match cascade_exhausted_failure_reason_of_raw_error ~detail raw_error with
+  match runtime_exhausted_failure_reason_of_raw_error ~detail raw_error with
   | Some _ as reason -> reason
   | None ->
   match terminal_reason.disposition with

--- a/lib/runtime/runtime_candidate.ml
+++ b/lib/runtime/runtime_candidate.ml
@@ -1,6 +1,6 @@
 (** Runtime_candidate — single-dispatch execution candidate (RFC-0206).
 
-    cascade->Runtime annihilation: the deleted [Cascade_runtime_candidate]
+    Runtime dispatch
     wrapped a [Provider_config.t] with health / capacity / probe keys to feed
     the multi-candidate selection FSM. With single-binding dispatch there is
     exactly one Runtime, so the candidate collapses to its provider config and
@@ -38,8 +38,8 @@ let default_config ~name ~system_prompt ~tools (t : t) =
   Runtime_agent.default_config ~name ~provider_cfg:t ~system_prompt ~tools
 
 (* Error decoration collapsed to identity: the deleted version added provider
-   auth-env / not-found hints via the annihilated cascade attempt-fsm helpers. *)
-let enrich_sdk_error ~cascade_name:(_ : string) (_ : t)
+   auth-env / not-found hints via the annihilated runtime attempt-fsm helpers. *)
+let enrich_sdk_error ~runtime_id:(_ : string) (_ : t)
     (err : Agent_sdk.Error.sdk_error) =
   err
 
@@ -95,6 +95,11 @@ type context_window_hint =
   ; is_local_model : bool
   }
 
+type attempt_timeout_resolution =
+  { timeout_s : float option
+  ; source : string
+  }
+
 (* Collapsed: the deleted version was already a no-op stub (tier-based local
    classification removed); context window comes from the Runtime model spec. *)
 let context_window_hint_of_labels labels =
@@ -125,3 +130,107 @@ let strip_latest_suffix runtime_id =
 
 let normalize_runtime_name_for_bucket label =
   runtime_id_of_label_or_raw label |> strip_latest_suffix
+
+let nonempty_string_opt s =
+  let s = String.trim s in
+  if String.equal s "" then None else Some s
+
+let runtime_url_of_label label =
+  match Provider_kind_resolver.resolve label with
+  | Provider_kind_resolver.Registered { provider_name; _ } ->
+    nonempty_string_opt (registry_default_base_url provider_name)
+  | Provider_kind_resolver.Custom_url { base_url; _ } ->
+    nonempty_string_opt base_url
+  | Provider_kind_resolver.Unknown _ -> None
+
+let label_matches_runtime_id ~label ~runtime_id =
+  let label_id = normalize_runtime_name_for_bucket label in
+  let runtime_id = String.trim runtime_id |> strip_latest_suffix in
+  (not (String.equal runtime_id "")) && String.equal label_id runtime_id
+
+let has_resolvable_runtime_label labels =
+  List.exists (fun label -> Option.is_some (runtime_id_of_label label)) labels
+
+let labels_require_runtime_mcp_header_sync labels =
+  let _ = labels in
+  false
+
+let unknown_runtime_label = "unknown"
+
+let provider_label_of_runtime_label ?provider_kind label =
+  let _ = provider_kind in
+  match nonempty_string_opt label with
+  | Some label -> label
+  | None -> unknown_runtime_label
+
+let is_structurally_unmetered_runtime_provider label =
+  let _ = label in
+  false
+
+let runtime_label_for_active_id ~configured_labels ~active =
+  let active = String.trim active in
+  match
+    List.find_opt
+      (fun label -> label_matches_runtime_id ~label ~runtime_id:active)
+      configured_labels
+  with
+  | Some label -> label
+  | None ->
+    if String.equal active "" then unknown_runtime_label else active
+
+let resolve_reported_runtime_id ~labels ~reported_runtime_id =
+  runtime_label_for_active_id ~configured_labels:labels ~active:reported_runtime_id
+  |> normalize_runtime_name_for_bucket
+
+let threshold_multipliers_of_runtime_id runtime_id =
+  let _ = runtime_id in
+  (1.0, 1.0)
+
+let first_health_cooldown (_ : t) = None
+let has_recovery_evidence (_ : t) = false
+
+let effective_attempt_timeout_resolution ~is_last ~configured_timeout_s (_ : t) =
+  let _ = is_last in
+  match configured_timeout_s with
+  | Some timeout_s -> { timeout_s = Some timeout_s; source = "configured" }
+  | None -> { timeout_s = None; source = "runtime_default" }
+
+let effective_attempt_timeout_s ~is_last ~configured_timeout_s t =
+  (effective_attempt_timeout_resolution ~is_last ~configured_timeout_s t).timeout_s
+
+let tool_filter_rejection_label ~keeper_name ?runtime_mcp_policy ~tools
+    ~require_tool_choice_support ~require_tool_support (t : t) =
+  let _ =
+    ( keeper_name,
+      runtime_mcp_policy,
+      tools,
+      require_tool_choice_support,
+      require_tool_support,
+      t )
+  in
+  None
+
+let capacity_key (t : t) = health_key t
+
+let capacity_keys candidates =
+  candidates |> List.map capacity_key |> List.sort_uniq String.compare
+
+let declared_client_capacity (_ : t) = None
+let register_declared_client_capacity (_ : t) = ()
+
+let runtime_urls candidates =
+  candidates
+  |> List.filter_map (fun (cfg : t) -> nonempty_string_opt cfg.base_url)
+  |> List.sort_uniq String.compare
+
+let local_runtime_urls candidates = runtime_urls candidates
+
+let filter_unhealthy_local_runtime_urls ~endpoint_health candidates =
+  let _ = endpoint_health in
+  (candidates, [])
+
+let http_probe_urls candidates = runtime_urls candidates
+
+let register_http_probe_capable ~max_concurrent (_ : t) =
+  let _ = max_concurrent in
+  ()


### PR DESCRIPTION
## Summary
- fill Runtime_candidate implementation entries required by the runtime interface
- rename keeper memory LLM summary public argument from cascade_name to runtime_id
- switch internal exhaustion envelope to runtime_id / Runtime_exhausted / runtime_exhaustion_reason

## Validation
- Not run: user provided the failing dune build output; this patch was applied without rerunning build.