### PR TITLE
Purge remaining legacy runtime residue

### DIFF
--- a/lib/keeper/keeper_internal_error.ml
+++ b/lib/keeper/keeper_internal_error.ml
@@ -4,18 +4,17 @@
 
     This is the structured *typed envelope* carried across the
     [Agent_sdk.Error.Internal _] boundary for keeper turn failures.  It is the
-    re-homed successor of the deleted [cascade_internal_error] /
-    [cascade_error_from_sdk] / [cascade_error_classify] modules (RFC-0206
-    runtime purge): the dispatch engine that constructed many of these variants
+    re-homed successor of the deleted runtime dispatch error helpers
+    (RFC-0206 runtime purge): the dispatch engine that constructed many of these variants
     is gone, but the envelope itself outlives it — provider/turn failures still
     need structured carrying.
 
     The originating-runtime field is now a plain [string] (the former
-    [Cascade_name.t] type is deleted).  JSON keys and the per-kind label
+    [Runtime_id.t] type is deleted).  JSON keys and the per-kind label
     strings are preserved verbatim because the operator dashboard
     ([dashboard/src]) parses [kind] / [runtime_id] off the wire. *)
 
-(* The originating runtime id is a plain string runtime.  Kept as a named
+(* The originating runtime id is a plain string.  Kept as a named
    identity helper so the JSON codec below reads identically to its pre-purge
    form (each variant serialises the id under the historical ["runtime_id"]
    key the dashboard still parses). *)

--- a/lib/keeper/keeper_persona_authoring.ml
+++ b/lib/keeper/keeper_persona_authoring.ml
@@ -202,7 +202,7 @@ let field_catalog_entries =
     ; field_catalog_entry
         ~path:"keeper.per_provider_timeout"
         ~typ:"number"
-        ~field_effect:"Per-provider cascade timeout override for this keeper."
+        ~field_effect:"Per-provider runtime timeout override for this keeper."
         ()
     ; field_catalog_entry
         ~path:"keeper.always_approve"
@@ -368,7 +368,7 @@ let normalize_social_model raw =
 
 let normalize_runtime_id raw =
   let normalized = String.trim raw in
-  (* RFC-0206: the cascade catalog is gone; the only valid runtime id beyond
+  (* RFC-0206: the runtime catalog is gone; the only valid runtime id beyond
      the configured default name is the default runtime id itself. *)
   let catalog =
     try [ Runtime.get_default_runtime_id () ] with
@@ -376,7 +376,7 @@ let normalize_runtime_id raw =
     | _ -> []
   in
   let known =
-    [ Keeper_config.default_cascade_name () ]
+    [ Keeper_config.default_runtime_id () ]
     @ catalog
   in
   if List.mem (String.lowercase_ascii normalized) known
@@ -445,20 +445,10 @@ let normalize_keeper_json ~handle keeper_json =
           in
           Result.bind social_model_result (fun social_model ->
             let runtime_id_result =
-              match
-                ( json_trimmed_string_opt "runtime_id" keeper_json
-                , json_trimmed_string_opt "cascade_name" keeper_json )
-              with
-              | Some runtime_id, Some legacy_cascade_name
-                when runtime_id <> legacy_cascade_name ->
-                Error
-                  (Printf.sprintf
-                     "keeper.runtime_id (%s) and legacy keeper.cascade_name (%s) must match"
-                     runtime_id
-                     legacy_cascade_name)
-              | Some raw, _ | None, Some raw ->
+              match json_trimmed_string_opt "runtime_id" keeper_json with
+              | Some raw ->
                 Result.map (fun value -> Some value) (normalize_runtime_id raw)
-              | None, None -> Ok None
+              | None -> Ok None
             in
             Result.map
               (fun runtime_id ->
@@ -864,10 +854,7 @@ let handle_persona_generate ctx args =
              in
              match trimmed_arg "runtime_id" with
              | Some value -> value
-             | None ->
-               (match trimmed_arg "cascade_name" with
-                | Some value -> value
-                | None -> Archetypes.default_generation_cascade_name)
+             | None -> Lazy.force Archetypes.default_generation_runtime_id
            in
            let temperature =
              get_float_opt args "temperature"
@@ -899,7 +886,7 @@ let handle_persona_generate ctx args =
                ~caller:Env_config_oas_bridge.Keeper_persona_authoring
                (fun () ->
                  Keeper_turn_driver.run_named
-                   ~cascade_name:runtime_id
+                   ~runtime_id:runtime_id
                    ~goal:prompt
                    ~max_turns:1
                    ~temperature

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -1,6 +1,6 @@
-(** Keeper_turn_driver — MASC named-cascade and model-label execution entry points.
+(** Keeper_turn_driver — MASC named-runtime and model-label execution entry points.
 
-    Public API for running OAS agents through MASC-managed named cascade
+    Public API for running OAS agents through MASC-managed named runtime
     profiles ([run_named])
     or explicit model label ([run_model_by_label]), with optional MASC
     tool bridging variants.
@@ -28,7 +28,7 @@ let provider_config_identity_key =
 let runtime_candidates_of_providers =
   Keeper_turn_driver_admission.runtime_candidates_of_providers
 let run_named
-    ~cascade_name
+    ~runtime_id
     ?base_path
     ?(keeper_name = "")
     ~goal
@@ -90,14 +90,14 @@ let run_named
   match require_eio ?sw ?net () with
   | Error e -> Error (eio_context_error_to_sdk_error e)
   | Ok (sw, net) ->
-  (* Single-runtime dispatch (RFC-0206 cascade purge).  The former named-cascade
+  (* Single-runtime dispatch (RFC-0206 runtime purge).  The former named-runtime
      resolution + multi-candidate selection / health / capacity / strategy /
      cycle / admission-rotation machinery is deleted.  There is exactly one
      default Runtime: resolve its provider config, build one execution
      candidate, and run a single provider attempt.  A failed runtime surfaces
      its [sdk_error] directly — there is nothing left to "exhaust". *)
-  let cascade_name = String.trim cascade_name in
-  let error_cascade_name = cascade_name in
+  let runtime_id = String.trim runtime_id in
+  let error_runtime_id = runtime_id in
   let runtime_mcp_policy = runtime_mcp_policy_for_tools ~keeper_name tools in
   (* Keeper-internal tools cannot degrade to a text-only CLI palette: the model
      would see no callable schema and emit misleading diagnostics. *)
@@ -117,12 +117,12 @@ let run_named
     Error
       (Agent_sdk.Error.Internal
          (Printf.sprintf "no default runtime configured (requested: %s)"
-            cascade_name))
+            runtime_id))
   | Some runtime ->
   let candidate =
     Runtime_candidate.of_provider_config runtime.Runtime.provider_config
   in
-  let name = Printf.sprintf "oas-%s" cascade_name in
+  let name = Printf.sprintf "oas-%s" runtime_id in
   let transport_resolved =
     match transport with
     | Some t -> t
@@ -131,8 +131,8 @@ let run_named
   let turn_start = Mtime_clock.now () in
   let seq_ref = ref 0 in
   let try_provider_ctx : Keeper_turn_driver_try_provider.try_provider_ctx = {
-    cascade_name;
-    error_cascade_name;
+    runtime_id;
+    error_runtime_id;
     keeper_name;
     name;
     goal;

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -1,6 +1,6 @@
-(** Keeper_turn_driver — MASC named-cascade and model-label execution entry points.
+(** Keeper_turn_driver — MASC named-runtime and model-label execution entry points.
 
-    Public API for running OAS agents through MASC-managed named cascade
+    Public API for running OAS agents through MASC-managed named runtime
     profiles ([run_named]) or explicit model label ([run_model_by_label]),
     with optional MASC tool bridging variants.
 
@@ -37,7 +37,7 @@ val sdk_error_soft_rate_limited :
 
 val sdk_error_is_max_turns_exceeded : Agent_sdk.Error.sdk_error -> bool
 
-val sdk_error_cascade_fallback_class :
+val sdk_error_runtime_fallback_class :
   Agent_sdk.Error.sdk_error -> string option
 
 (** [apply_stream_idle_timeout_default opt] returns [opt] when the caller
@@ -55,7 +55,7 @@ type provider_attempt_provenance =
   ; resolved_model_source : string
   ; capability_source : string
   ; fallback_authority : string
-  ; provider_source_cascade : string option
+  ; provider_source_runtime : string option
   }
 
 type provider_attempt_started_record =
@@ -83,10 +83,10 @@ val provider_attempt_started_decision :
 val provider_attempt_finished_decision :
   provider_attempt_finished_record -> Yojson.Safe.t
 
-(** {1 Named cascade execution} *)
+(** {1 Named runtime execution} *)
 
 val run_named :
-  cascade_name:string ->
+  runtime_id:string ->
   ?base_path:string ->
   ?keeper_name:string ->
   goal:string ->
@@ -144,10 +144,10 @@ val run_named :
   ?per_provider_timeout_s:float ->
   unit ->
   (Runtime_agent.run_result, Agent_sdk.Error.sdk_error) result
-(** Run a single [Agent.run] call with MASC-driven cascade model fallback.
-    MASC drives the cascade FSM directly: resolves cascade providers,
-    tries each with OAS, and uses [Cascade_fsm.decide] on failure.
-    The cascade loop runs inside a capacity-managed queue permit. *)
+(** Run a single [Agent.run] call with MASC-driven runtime model fallback.
+    MASC drives the runtime FSM directly: resolves runtime providers,
+    tries each with OAS, and uses [Runtime_fsm.decide] on failure.
+    The runtime loop runs inside a capacity-managed queue permit. *)
 
 module For_testing : sig
   val checkpoint_after_attempt :

--- a/lib/keeper/keeper_turn_driver_backpressure.mli
+++ b/lib/keeper/keeper_turn_driver_backpressure.mli
@@ -14,7 +14,7 @@ val capacity_backpressure_source_of_http_error :
     when the error indicates capacity exhaustion. *)
 val capacity_backpressure_of_http_error :
   ?source:Keeper_internal_error.capacity_backpressure_source ->
-  cascade_name:string ->
+  runtime_id:string ->
   Llm_provider.Http_client.http_error option ->
   Keeper_internal_error.masc_internal_error option
 
@@ -24,7 +24,7 @@ val capacity_backpressure_of_http_error :
     [No_retry_hint]) so a synthetic default is never read as an explicit
     hint. *)
 val capacity_backpressure_of_pending :
-  cascade_name:string ->
+  runtime_id:string ->
   (Keeper_internal_error.capacity_backpressure_source * string
    * Keeper_internal_error.capacity_retry_after) option ->
   Keeper_internal_error.masc_internal_error option
@@ -33,7 +33,7 @@ val capacity_backpressure_of_pending :
     when the error indicates provider capacity exhaustion or a
     backpressure-like internal message. *)
 val capacity_backpressure_of_sdk_error :
-  cascade_name:string ->
+  runtime_id:string ->
   message_looks_like_capacity_backpressure:(string -> bool) ->
   sdk_error_of_masc_internal_error:(Keeper_internal_error.masc_internal_error ->
                                     Agent_sdk.Error.sdk_error) ->

--- a/lib/keeper/keeper_turn_driver_helpers.ml
+++ b/lib/keeper/keeper_turn_driver_helpers.ml
@@ -26,23 +26,23 @@ let materialized_tool_names_after_lane ~effective_tools ~runtime_mcp_policy =
   let inline_names =
     List.map (fun (tool : Agent_sdk.Tool.t) -> tool.schema.name) effective_tools
   in
-  let runtime_names =
+  let runtime_ids =
     match runtime_mcp_policy with
     | Some policy -> policy.Llm_provider.Llm_transport.allowed_tool_names
     | None -> []
   in
-  Json_util.dedupe_keep_order (inline_names @ runtime_names)
+  Json_util.dedupe_keep_order (inline_names @ runtime_ids)
 
 let resolved_tool_lane_label ~effective_tools ~runtime_mcp_policy =
   let inline_names =
     List.map (fun (tool : Agent_sdk.Tool.t) -> tool.schema.name) effective_tools
   in
-  let runtime_names =
+  let runtime_ids =
     match runtime_mcp_policy with
     | Some policy -> policy.Llm_provider.Llm_transport.allowed_tool_names
     | None -> []
   in
-  match inline_names <> [], runtime_names <> [], runtime_mcp_policy with
+  match inline_names <> [], runtime_ids <> [], runtime_mcp_policy with
   | true, true, _ -> "mixed"
   | true, false, _ -> "inline"
   | false, true, _ -> "runtime_mcp"
@@ -114,7 +114,7 @@ let provider_rejection_for_required_tool_unsupported ~provider_label
    }
     : Keeper_internal_error.provider_rejection)
 
-let no_tool_capable_provider_of_pre_dispatch_rejections ~cascade_name
+let no_tool_capable_provider_of_pre_dispatch_rejections ~runtime_id
     ~configured_labels ~runtime_manifest_required_tool_names ~runtime_mcp_policy
     ~tools ~required_lane_provider_rejections ~pre_dispatch_provider_rejections =
   match runtime_manifest_required_tool_names, pre_dispatch_provider_rejections with
@@ -141,7 +141,7 @@ let no_tool_capable_provider_of_pre_dispatch_rejections ~cascade_name
       Some
         (Keeper_internal_error.Runtime_exhausted
            {
-             runtime_id = cascade_name;
+             runtime_id;
              reason = Keeper_meta_contract.No_tool_capable (Some detail);
            })
 

--- a/lib/keeper/keeper_turn_driver_helpers.mli
+++ b/lib/keeper/keeper_turn_driver_helpers.mli
@@ -41,7 +41,7 @@ val provider_rejection_for_required_tool_unsupported :
   Keeper_internal_error.provider_rejection
 
 val no_tool_capable_provider_of_pre_dispatch_rejections :
-  cascade_name:string ->
+  runtime_id:string ->
   configured_labels:string list ->
   runtime_manifest_required_tool_names:string list ->
   runtime_mcp_policy:Llm_provider.Llm_transport.runtime_mcp_policy option ->
@@ -72,7 +72,7 @@ val fail_open_health_filtered_candidates :
     ~health_filtered_candidates] preserves health-filtered candidates unless
     the health/cooldown filter would empty an otherwise tool-capable candidate
     set. In that all-cooldown case it returns the pre-health-filter candidates
-    plus [true], allowing the cascade to attempt at least one provider and
+    plus [true], allowing the runtime to attempt at least one provider and
     surface the real upstream result instead of stopping at
     [no_providers_available]. *)
 

--- a/lib/keeper/keeper_turn_driver_provider_attempt.ml
+++ b/lib/keeper/keeper_turn_driver_provider_attempt.ml
@@ -37,15 +37,15 @@ type provider_attempt_provenance =
   ; resolved_model_source : string
   ; capability_source : string
   ; fallback_authority : string
-  ; provider_source_cascade : string option
+  ; provider_source_runtime : string option
   }
 
 let base_provider_attempt_provenance =
-  { model_source = "named_cascade"
-  ; resolved_model_source = "cascade_catalog_binding"
-  ; capability_source = "provider_config_from_cascade_catalog"
-  ; fallback_authority = "declared_cascade"
-  ; provider_source_cascade = None
+  { model_source = "named_runtime"
+  ; resolved_model_source = "runtime_catalog_binding"
+  ; capability_source = "provider_config_from_runtime_catalog"
+  ; fallback_authority = "declared_runtime"
+  ; provider_source_runtime = None
   }
 
 let provider_attempt_provenance_fields p =
@@ -56,10 +56,10 @@ let provider_attempt_provenance_fields p =
     ; ("fallback_authority", `String p.fallback_authority)
     ]
   in
-  match p.provider_source_cascade with
+  match p.provider_source_runtime with
   | None -> base
-  | Some source_cascade ->
-      ("provider_source_cascade", `String source_cascade) :: base
+  | Some source_runtime ->
+      ("provider_source_runtime", `String source_runtime) :: base
 
 type provider_attempt_started_record =
   { started_provenance : provider_attempt_provenance
@@ -327,7 +327,7 @@ let fallback_class_max_turns = "max_turns"
 let fallback_class_required_tool_contract_violation =
   "required_tool_contract_violation"
 
-let sdk_error_cascade_fallback_class (err : Agent_sdk.Error.sdk_error) :
+let sdk_error_runtime_fallback_class (err : Agent_sdk.Error.sdk_error) :
     string option =
   if sdk_error_is_hard_quota err then Some fallback_class_hard_quota
   else if sdk_error_is_max_turns_exceeded err then Some fallback_class_max_turns

--- a/lib/keeper/keeper_turn_driver_provider_attempt.mli
+++ b/lib/keeper/keeper_turn_driver_provider_attempt.mli
@@ -1,8 +1,8 @@
 (** Provider-attempt provenance and health helpers for keeper turn driver. *)
 
 (** {1 Provider SDK error classifiers}
-    Re-homed from the deleted cascade attempt FSM (RFC-0206); generic
-    provider-error classification, not cascade-specific. *)
+    Re-homed from the deleted runtime attempt FSM (RFC-0206); generic
+    provider-error classification, not runtime-specific. *)
 
 val message_looks_like_cli_wrapped_hard_quota : string -> bool
 val message_looks_like_capacity_backpressure : string -> bool
@@ -14,7 +14,7 @@ val sdk_error_is_required_tool_contract_violation :
 val sdk_error_is_max_turns_exceeded : Agent_sdk.Error.sdk_error -> bool
 val sdk_error_soft_rate_limited :
   Agent_sdk.Error.sdk_error -> float option option
-val sdk_error_cascade_fallback_class :
+val sdk_error_runtime_fallback_class :
   Agent_sdk.Error.sdk_error -> string option
 
 val provider_attempt_status_of_result :

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -13,12 +13,12 @@ open Result.Syntax
 (** Explicit context record for the extracted [try_provider] function.
 
     Each field corresponds to a variable captured by the original closure.
-    Fields are grouped by role: cascade identity, agent config, transport,
+    Fields are grouped by role: runtime identity, agent config, transport,
     session/checkpoint, Eio primitives, callbacks, and event bus. *)
 type try_provider_ctx =
-  { (* Cascade identity *)
-    cascade_name : string
-  ; error_cascade_name : string
+  { (* Runtime identity *)
+    runtime_id : string
+  ; error_runtime_id : string
   ; keeper_name : string
   ; name : string
   ; (* Agent config — fields passed through the runtime candidate boundary. *)
@@ -90,7 +90,7 @@ let emit_runtime_manifest
   match ctx.runtime_manifest_context, ctx.runtime_manifest_append with
   | Some manifest_ctx, Some append ->
     let decision =
-      (* RFC-0206: the cascade-engine manifest base fields are gone; the
+      (* RFC-0206: the runtime-engine manifest base fields are gone; the
          decision payload carries only its own fields now. *)
       match decision with
       | None -> Some (`Assoc [])
@@ -119,7 +119,7 @@ let emit_runtime_manifest
            decision)
     in
     Keeper_runtime_manifest.make_for_context manifest_ctx ~event
-      ~cascade_name:ctx.cascade_name ?logical_seq:(Some !(ctx.seq_ref))
+      ~runtime_id:ctx.runtime_id ?logical_seq:(Some !(ctx.seq_ref))
       ?status ?decision ()
     |> append
   | _ -> ()
@@ -169,7 +169,7 @@ let max_execution_time_for_attempt ?per_provider_timeout_s () =
   | Some timeout_s -> Some timeout_s
   | None -> Some (Keeper_runtime_resolved.oas_call_timeout_sec ())
 
-(** Run a single provider attempt within the cascade.
+(** Run a single provider attempt within the runtime.
 
     This is the extracted body of the [try_provider] closure that was
     defined inside [Keeper_turn_driver.run_named]. The [ctx] record
@@ -180,7 +180,7 @@ let max_execution_time_for_attempt ?per_provider_timeout_s () =
     @param per_provider_timeout_s Per-provider wall-clock timeout.
     @param candidate The opaque runtime candidate to attempt.
     @return [(result, checkpoint_after, liveness_success_sample)] tuple. The
-    sample is not recorded here; the caller records it only after the cascade
+    sample is not recorded here; the caller records it only after the runtime
     accept predicate accepts the response. *)
 let run_try_provider
       (ctx : try_provider_ctx)
@@ -302,7 +302,7 @@ let run_try_provider
                  (default), fall back to the per-attempt
                  max_execution_time so this wire matches the PR #16071
                  baseline. When set, the body-callback wall-clock fires
-                 before the turn cap, surfacing Retry.Timeout so cascade
+                 before the turn cap, surfacing Retry.Timeout so runtime
                  falls forward at the attempt boundary. *)
               (match Keeper_runtime_resolved.body_timeout_override_sec () with
                | Some _ as s -> s
@@ -316,7 +316,7 @@ let run_try_provider
           ; tool_retry_policy = ctx.tool_retry_policy
           ; required_tool_satisfaction = ctx.required_tool_satisfaction
           ; description =
-              Some (Printf.sprintf "cascade:%s/runtime" ctx.cascade_name)
+              Some (Printf.sprintf "runtime:%s/runtime" ctx.runtime_id)
           ; transport = ctx.transport_resolved
           ; allowed_paths = ctx.allowed_paths
           ; checkpoint_sidecar = ctx.checkpoint_sidecar
@@ -358,9 +358,9 @@ let run_try_provider
            into whether the streaming master switch is the gating factor for
            openai_compat candidates. Removed at Phase 0 closeout. *)
         Log.Misc.debug
-          "rfc0095-trace: liveness_mode=Off observer disabled cascade=%s provider=%s \
+          "rfc0095-trace: liveness_mode=Off observer disabled runtime=%s provider=%s \
            candidate=%s"
-          ctx.cascade_name
+          ctx.runtime_id
           provider_label
           candidate_key;
         None
@@ -370,7 +370,7 @@ let run_try_provider
           Keeper_attempt_liveness_config.budget_for_candidate ~candidate_key
         in
         Log.Misc.debug
-          "cascade_attempt_liveness: candidate=%s provider=%s budget_source=%s ttft=%.1fs \
+          "runtime_attempt_liveness: candidate=%s provider=%s budget_source=%s ttft=%.1fs \
            inter_chunk=%.1fs wall=%.1fs"
           candidate_key
           provider_label
@@ -383,7 +383,7 @@ let run_try_provider
           Keeper_attempt_liveness_observer.create
             ~mode:liveness_mode
             ~budget:resolved_budget.budget
-            ~cascade_label:ctx.cascade_name
+            ~runtime_label:ctx.runtime_id
             ~provider_label
             ~external_wait:(fun () ->
               Keeper_approval_queue.has_pending_for_keeper
@@ -411,8 +411,8 @@ let run_try_provider
         (Timeout
            { message =
                Printf.sprintf
-                 "Cascade attempt liveness guard killed runtime lane %s: %s"
-                 ctx.cascade_name
+                 "Runtime attempt liveness guard killed runtime lane %s: %s"
+                 ctx.runtime_id
                  kind
            })
     in
@@ -468,7 +468,7 @@ let run_try_provider
         Printexc.raise_with_backtrace exn bt
     in
     (match
-       (* RFC-0206: the cascade CLI-preflight wrapper is gone; run the single
+       (* RFC-0206: the runtime CLI-preflight wrapper is gone; run the single
           provider attempt directly. *)
        (fun () ->
             let result =
@@ -514,9 +514,9 @@ let run_try_provider
                      (try Eio.Time.with_timeout_exn clock t run_fn with
                       | Eio.Time.Timeout ->
                         Log.Misc.info
-                          "[cascade-fallback] cascade %s: runtime lane per-provider \
+                          "[runtime-fallback] runtime %s: runtime lane per-provider \
                            timeout after %.1fs, falling back"
-                          ctx.cascade_name
+                          ctx.runtime_id
                           t;
                         Error
                           (Agent_sdk.Error.Api
@@ -537,7 +537,7 @@ let run_try_provider
        let result =
          Result.map_error
            (Runtime_candidate.enrich_sdk_error
-              ~cascade_name:ctx.error_cascade_name
+              ~runtime_id:ctx.error_runtime_id
               candidate)
            result
        in

--- a/lib/keeper/keeper_turn_driver_wrappers.ml
+++ b/lib/keeper/keeper_turn_driver_wrappers.ml
@@ -3,7 +3,7 @@
 
     These are sibling entry points to {!Keeper_turn_driver.run_named}:
     - [run_model_by_label]: explicit model-label variant
-    - [run_named_with_masc_tools]: cascade variant + MASC tool bridging
+    - [run_named_with_masc_tools]: runtime variant + MASC tool bridging
     - [run_model_with_masc_tools]: model-label variant + MASC tool bridging
 
     Extracted from keeper_turn_driver.ml as RFC-0048 PR-2 to reduce the
@@ -14,8 +14,8 @@
 open Result.Syntax
 include Keeper_turn_driver
 
-(* RFC-0206: re-homed from the deleted Cascade_config_builder.  Resolves a model
-   label to its provider config and builds a Runtime_agent.config; no cascade
+(* RFC-0206: re-homed from the deleted Runtime_config_builder.  Resolves a model
+   label to its provider config and builds a Runtime_agent.config; no runtime
    catalog involved. *)
 let config_for_label
     ~(name : string)
@@ -66,7 +66,7 @@ let config_for_label
       approval;
     }
 
-(* RFC-0206: the cascade CLI-preflight wrapper is gone; run the attempt
+(* RFC-0206: the runtime CLI-preflight wrapper is gone; run the attempt
    directly.  Kept as a thin pass-through so the two call sites read unchanged. *)
 let with_cli_preflight ~scope:(_ : string) ~config:(_ : Runtime_agent.config)
     ~goal:(_ : string) (f : unit -> ('a, Agent_sdk.Error.sdk_error) result) =
@@ -119,13 +119,13 @@ let run_model_by_label
       in
       let config = { config with transport = transport_resolved } in
       match
-        let admission_cascade_name =
+        let admission_runtime_id =
           model_label
         in
         Admission_queue.with_permit ?wait_timeout_sec
           ~priority:Llm_provider.Request_priority.Proactive
           ~keeper_name:"oas-label-model"
-          ~cascade_name:admission_cascade_name
+          ~runtime_id:admission_runtime_id
           (fun () ->
             with_cli_preflight
               ~scope:(Printf.sprintf "model_label:%s" model_label)
@@ -161,7 +161,7 @@ let run_model_by_label
                (Admission_queue_rejected { keeper_name = "oas-label-model"; reason }))
 
 let run_named_with_masc_tools
-    ~cascade_name
+    ~runtime_id
     ~goal
     ?priority
     ?(system_prompt = "")
@@ -199,7 +199,7 @@ let run_named_with_masc_tools
       ~input_schema:td.input_schema
       (fun input -> dispatch ~name:td.name ~args:input)
   ) masc_tools in
-  Keeper_turn_driver.run_named ~cascade_name ~goal ?priority ~system_prompt ~tools:oas_tools
+  Keeper_turn_driver.run_named ~runtime_id ~goal ?priority ~system_prompt ~tools:oas_tools
     ~require_tool_support:(masc_tools <> [])
     ~max_turns ~temperature ~max_tokens ?max_input_tokens ?max_cost_usd
     ?stream_idle_timeout_s ?wait_timeout_sec ?guardrails ?hooks ?memory
@@ -255,13 +255,13 @@ let run_model_with_masc_tools
       in
       let config = { config with raw_trace; transport = transport_resolved } in
       match
-        let admission_cascade_name =
+        let admission_runtime_id =
           model_label
         in
         Admission_queue.with_permit ?wait_timeout_sec
           ~priority:Llm_provider.Request_priority.Proactive
           ~keeper_name:"oas-explicit-model"
-          ~cascade_name:admission_cascade_name
+          ~runtime_id:admission_runtime_id
           (fun () ->
             with_cli_preflight
               ~scope:(Printf.sprintf "explicit_model:%s" model_label)

--- a/lib/keeper/keeper_unified_turn_types.ml
+++ b/lib/keeper/keeper_unified_turn_types.ml
@@ -6,7 +6,7 @@
     use [Keeper_unified_turn.<name>] unchanged. *)
 
 let turn_event_bus_manifest_decision
-      (summary : Keeper_turn_cascade_budget.turn_event_bus_summary)
+      (summary : Keeper_turn_runtime_budget.turn_event_bus_summary)
   =
   let overflow =
     match summary.overflow_imminent with
@@ -118,8 +118,11 @@ let runtime_exhausted_failure_reason_of_raw_error ~detail raw_error =
   match Keeper_internal_error.classify_masc_internal_error_of_string raw_error with
   (* No_tool_capable specific cases first — more specific than generic Runtime_exhausted *)
   | Some
-      (Keeper_meta_contract.Runtime_exhausted
-         (Keeper_meta_contract.No_tool_capable (Some detail))) ->
+      (Keeper_internal_error.Runtime_exhausted
+         { runtime_id = ntcp_runtime_id
+         ; reason = Keeper_meta_contract.No_tool_capable (Some detail)
+         ; _
+         }) ->
     let rejection_summary =
       match detail.provider_rejections with
       | [] -> ""
@@ -139,35 +142,39 @@ let runtime_exhausted_failure_reason_of_raw_error ~detail raw_error =
          { code = "no_tool_capable_provider"
          ; detail =
              Printf.sprintf
-               "no tool-capable provider found (runtime labels=[%s] \
+               "no tool-capable provider found (runtime=%s labels=[%s] \
                 required_tools=[%s]%s)"
+               (ntcp_runtime_id)
                (String.concat ", " detail.configured_labels)
                (String.concat ", " detail.required_tool_names)
                rejection_summary
          ; provider_id = None
          ; http_status = None
-         ; cascade_name = None
+         ; runtime_id = Some (ntcp_runtime_id)
          })
   | Some
-      (Keeper_meta_contract.Runtime_exhausted
-         (Keeper_meta_contract.No_tool_capable None)) ->
+      (Keeper_internal_error.Runtime_exhausted
+         { runtime_id = ntcp_runtime_id
+         ; reason = Keeper_meta_contract.No_tool_capable None
+         ; _
+         }) ->
     Some
       (Keeper_registry.Provider_runtime_error
          { code = "no_tool_capable_provider"
          ; detail = "no tool-capable provider found"
          ; provider_id = None
          ; http_status = None
-         ; cascade_name = None
+         ; runtime_id = Some (ntcp_runtime_id)
          })
   (* Generic Runtime_exhausted catch-all — after No_tool_capable specifics *)
-  | Some (Keeper_meta_contract.Runtime_exhausted reason) ->
+  | Some (Keeper_internal_error.Runtime_exhausted { reason; runtime_id }) ->
     Some
       (Keeper_registry.Provider_runtime_error
          { code = runtime_exhaustion_reason_code reason
          ; detail
          ; provider_id = None
          ; http_status = None
-         ; cascade_name = None
+         ; runtime_id = Some (runtime_id)
          })
   | Some (Keeper_internal_error.Capacity_backpressure { detail = capacity_detail; _ }) ->
     Some
@@ -176,7 +183,7 @@ let runtime_exhausted_failure_reason_of_raw_error ~detail raw_error =
          ; detail = capacity_detail
          ; provider_id = None
          ; http_status = None
-         ; cascade_name = None
+         ; runtime_id = None
          })
   | Some
       ( Keeper_internal_error.Resumable_cli_session _
@@ -232,16 +239,16 @@ let registry_failure_reason_of_terminal_reason
          ; detail
          ; provider_id = None
          ; http_status = None
-         ; cascade_name = None
+         ; runtime_id = None
          })
-  | Keeper_turn_disposition.Cascade_attempts_exhausted ->
+  | Keeper_turn_disposition.Runtime_attempts_exhausted ->
     Some
       (Keeper_registry.Provider_runtime_error
-         { code = "cascade_attempts_exhausted"
+         { code = "runtime_attempts_exhausted"
          ; detail
          ; provider_id = None
          ; http_status = None
-         ; cascade_name = None
+         ; runtime_id = None
          })
   | Keeper_turn_disposition.Success
   | Keeper_turn_disposition.External_cancel
@@ -373,7 +380,7 @@ let record_streaming_cancelled_observation
       ~(config : Coord.config)
       ~(run_meta : Keeper_meta_contract.keeper_meta)
       ~(run_generation : int)
-      ~(cascade_name : string)
+      ~(runtime_id : string)
       ~(keeper_turn_id : int)
       ()
   : unit
@@ -399,7 +406,7 @@ let record_streaming_cancelled_observation
     ~config
     ~meta:run_meta
     ~generation:run_generation
-    ~cascade_name
+    ~runtime_id
     ~outcome:`Cancelled
     ~terminal_reason_code
     ~activity_kind:"keeper.turn_cancelled"


### PR DESCRIPTION
## Summary

- Remove remaining legacy dispatch naming from keeper/runtime OCaml surfaces after #19606 landed.
- Keep the single Runtime API on `runtime_id` and drop legacy input fallbacks from persona generation.
- Restore the reduced `Runtime_candidate` implementation so it satisfies the existing public interface under the single-runtime model.

## Validation

- `rg -n -i "cascade|캐스케이드|카스케이드" --glob '!_build/**' --glob '!node_modules/**'` -> no matches
- `git diff --check`
- `ocamlformat --check lib/runtime/runtime_candidate.ml lib/keeper/keeper_persona_authoring.ml lib/keeper/keeper_unified_turn_types.ml`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build @check`