### PR TITLE
Rename sidecar doctor surfaces to diagnostics

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -518,7 +518,7 @@ let base_path =
   let doc = "Base path for MASC data (.masc folder location)" in
   Arg.(value & opt string (default_base_path ()) & info ["base-path"] ~docv:"PATH" ~doc)
 
-let doctor_json =
+let login_json =
   let doc = "Emit machine-readable JSON instead of text output" in
   Arg.(value & flag & info ["json"] ~doc)
 
@@ -915,7 +915,7 @@ let login_cmd =
   Cmd.v info
     Term.(
       const login_cmd_exit $ base_path $ host $ port $ login_agent
-      $ login_role $ login_client_env $ login_no_expiry $ doctor_json
+      $ login_role $ login_client_env $ login_no_expiry $ login_json
       $ login_shell)
 
 let init_force =

--- a/dashboard/docs/consolidation/route-inventory.md
+++ b/dashboard/docs/consolidation/route-inventory.md
@@ -26,7 +26,7 @@
 |---------|----------|
 | `cockpit` | none; hidden surface |
 | `overview` | none |
-| `monitoring` | `runtime`, `runtime-config`, `agents`, `fleet-health`, `doctor`, `transport-health`, `feature-health`, `observatory`, `cognition`; hidden diagnostics: `journey` |
+| `monitoring` | `runtime`, `runtime-config`, `agents`, `fleet-health`, `diagnostics`, `transport-health`, `feature-health`, `observatory`, `cognition`; hidden diagnostics: `journey` |
 | `command` | `operations` |
 | `connectors` | `connector-status` |
 | `workspace` | `board`, `sub-boards`, `moderation`, `planning`, `repositories`, `verification` |

--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -74,7 +74,7 @@ let archive_credential_file config ~agent_name ~reason =
                       that starvation killed every short-form caller.
      PR-#10440        ensure_credential_alias re-creates a bare-form
                       redirect stub on every boot so short-form
-                      load_credential callers (auth_doctor, etc.)
+                      load_credential callers (auth diagnostics, etc.)
                       resolve directly.
 
    PR-3b2 and PR-#10440 contradict: the alias writer puts a stub back

--- a/lib/config/env_config_core.ml
+++ b/lib/config/env_config_core.ml
@@ -277,7 +277,7 @@ let get_port ~default name =
 
 (** Env var names exposed as SSOT constants so out-of-process callers
     that read/write the variable by name (docker worker putenv, sidecar
-    lookup, config doctor diagnostics, runtime-bootstrap putenv) can
+    lookup, config auth diagnostics, runtime-bootstrap putenv) can
     reference the same literal. Issue 8352. *)
 let base_path_env_key = "MASC_BASE_PATH"
 let base_path_input_env_key = "MASC_BASE_PATH_INPUT"

--- a/lib/config/env_config_sandbox.ml
+++ b/lib/config/env_config_sandbox.ml
@@ -222,7 +222,7 @@ module Shell_timeout = struct
 end
 
 (* --------------------------------------------------------------- *)
-(* Doctor / observability surface                                  *)
+(* Diagnostics / observability surface                                  *)
 (* --------------------------------------------------------------- *)
 
 (* Helper: does an env var currently exist (non-empty after trim)? *)

--- a/lib/config/env_config_sandbox.mli
+++ b/lib/config/env_config_sandbox.mli
@@ -119,7 +119,7 @@ end
 (** {1 Preflight — runtime feasibility check} *)
 module Preflight : sig
   val enabled : unit -> bool
-  (** Master switch for keeper_up / doctor preflight.
+  (** Master switch for keeper_up / diagnostics preflight.
       Env: [MASC_KEEPER_SANDBOX_PREFLIGHT_ENABLED].  Default: [true]. *)
 
   val min_timeout_sec : unit -> float
@@ -140,8 +140,8 @@ module Preflight : sig
       python3; node; npm; make; opam; dune; ssh]).
 
       INTENTIONALLY NOT env-overridable: an operator who removes
-      [gh] from the list would make doctor falsely report green
-      while runtime fails opaquely.  Exposed read-only so doctor
+      [gh] from the list would make diagnostics falsely report green
+      while runtime fails opaquely.  Exposed read-only so diagnostics
       and tests can iterate the canonical list. *)
 end
 
@@ -209,7 +209,7 @@ module Shell_timeout : sig
       5. {!global_default_sec}. *)
 end
 
-(** {1 Doctor / observability surface} *)
+(** {1 Diagnostics / observability surface} *)
 
 val effective_config_json : unit -> Yojson.Safe.t
 (** Returns a snapshot of every sandbox setting under two top-level

--- a/lib/host_config/host_config.mli
+++ b/lib/host_config/host_config.mli
@@ -71,7 +71,7 @@ type t =
   ; base_path_raw : string option
         (** [MASC_BASE_PATH] value as read from the environment, with
             whitespace trimmed but no path normalisation.  Used by
-            routes / dashboard / config_doctor inputs that surface
+            routes / dashboard / config diagnostics inputs that surface
             the operator's literal input.  RFC-0085 PR-9 replaces
             [Env_config_core.base_path_raw_opt]. *)
   ; config_dir : string option

--- a/lib/server/server_bootstrap_loops.mli
+++ b/lib/server/server_bootstrap_loops.mli
@@ -38,6 +38,6 @@ val start_background_maintenance :
   Mcp_server.server_state -> string * string
 (** Spawn the periodic maintenance fibers (institution episode capping,
     cost ledger flush, dashboard cache warmer, etc.) under [sw].
-    Returns a [(summary, doctor_hint)] pair printed at boot so an
+    Returns a [(summary, diagnostics_hint)] pair printed at boot so an
     operator can see what schedules are active and where to look when
     one stops. *)

--- a/lib/types/types_auth.ml
+++ b/lib/types/types_auth.ml
@@ -192,7 +192,7 @@ let permissions_for_role = function
 
 (* Direct (role, permission) variant match — O(1), no per-call list
    allocation.  Hot path: [Auth.check_permission] runs this on every
-   protected operation; [Auth_doctor] runs it 10+ times per snapshot.
+   protected operation; [auth diagnostics] runs it 10+ times per snapshot.
    The previous [List.mem permission (permissions_for_role role)] form
    built a fresh 12-element (Worker) / 15-element (Admin) list each
    call.

--- a/mk/build.mk
+++ b/mk/build.mk
@@ -4,7 +4,7 @@
 all: build-all
 
 # Build OCaml + dashboard (dashboard rebuilds only when sources changed)
-build: doctor-oas-pin
+build: diagnostics-oas-pin
 	scripts/dune-local.sh build
 	@scripts/build-dashboard-if-needed.sh
 

--- a/mk/quality.mk
+++ b/mk/quality.mk
@@ -1,11 +1,11 @@
-.PHONY: doctor-oas-pin doctor-disk-hygiene fix-disk-hygiene fix-disk-hygiene-hard doctor-oas-drift dashboard-drift-check dashboard-drift-regen fmt fmt-check health ocaml-health check-memory-leak check-silent check-ssot check-variants ci
+.PHONY: diagnostics-oas-pin diagnostics-disk-hygiene fix-disk-hygiene fix-disk-hygiene-hard diagnostics-oas-drift dashboard-drift-check dashboard-drift-regen fmt fmt-check health ocaml-health check-memory-leak check-silent check-ssot check-variants ci
 
-# Fast local-only doctor for OAS/agent_sdk pin drift in the current switch.
-doctor-oas-pin:
+# Fast local-only diagnostics for OAS/agent_sdk pin drift in the current switch.
+diagnostics-oas-pin:
 	bash scripts/check-oas-pin.sh --local-only
 
 # Disk hygiene snapshot for TLC artefacts, Dune cache drift, isolated builds, worktree fan-out.
-doctor-disk-hygiene:
+diagnostics-disk-hygiene:
 	bash scripts/disk-hygiene.sh
 
 # Safe fixes only: TLC artefact cleanup + Dune cache trim.
@@ -20,7 +20,7 @@ fix-disk-hygiene-hard:
 # against scripts/oas-api-surface.json fingerprint. Catches upstream variant/field
 # additions before they surface as scattered non-exhaustive warnings in consumer
 # modules. Regenerate with: bash scripts/oas-drift-check.sh --regenerate
-doctor-oas-drift:
+diagnostics-oas-drift:
 	bash scripts/oas-drift-check.sh
 
 # Dashboard styling-drift ratchet gate — fail if forbidden Tailwind patterns

--- a/mk/test.mk
+++ b/mk/test.mk
@@ -4,7 +4,7 @@
 test: test-unit
 
 # Unit tests only (no server required)
-test-unit: doctor-oas-pin
+test-unit: diagnostics-oas-pin
 	scripts/ci-run-tests.sh "scripts/dune-local.sh test"
 
 # Contract harness (self-bootstrapping, hermetic local server)

--- a/scripts/check-oas-pin.sh
+++ b/scripts/check-oas-pin.sh
@@ -43,7 +43,7 @@ min_version_re="${OAS_AGENT_SDK_MIN_VERSION//./\\.}"
 default_pin_source="${OAS_AGENT_SDK_URL}#${OAS_AGENT_SDK_SHA}"
 pin_source="${AGENT_SDK_PIN_URL:-${default_pin_source}}"
 expected_opam_pin_source="git+${OAS_AGENT_SDK_URL}#${OAS_AGENT_SDK_SHA}"
-# Ambient local checkouts are not authoritative for doctor runs.
+# Ambient local checkouts are not authoritative for diagnostics runs.
 # Only validate a local OAS checkout when the caller explicitly opts in.
 local_oas_checkout="${AGENT_SDK_LOCAL_REPO:-}"
 
@@ -304,9 +304,9 @@ else
 fi
 
 # API surface summary (non-fatal). A full drift diff with repair
-# guidance is available via `make doctor-oas-drift` or
+# guidance is available via `make diagnostics-oas-drift` or
 # `bash scripts/oas-drift-check.sh`. Here we emit one line so that
-# every doctor-oas-pin run surfaces surface-level drift without
+# every diagnostics-oas-pin run surfaces surface-level drift without
 # requiring the operator to remember a second command.
 #
 # Skip the surface check entirely under --local-only: oas-drift-check.sh
@@ -324,7 +324,7 @@ if [[ "${LOCAL_ONLY}" -eq 0 && -x "${SCRIPT_DIR}/oas-drift-check.sh" ]]; then
       metadata_n="$(printf '%s\n' "${drift_output}" | grep -c '^      ~ ' || true)"
       added_n="$(printf '%s\n' "${drift_output}" | grep -c '^      + ' || true)"
       removed_n="$(printf '%s\n' "${drift_output}" | grep -c '^      - ' || true)"
-      echo "OAS API surface: ⚠ drift (metadata ${metadata_n}, added ${added_n}, removed ${removed_n}) — run 'make doctor-oas-drift' for detail"
+      echo "OAS API surface: ⚠ drift (metadata ${metadata_n}, added ${added_n}, removed ${removed_n}) — run 'make diagnostics-oas-drift' for detail"
     else
       echo "OAS API surface: (could not compute — ${drift_exit}; run 'bash scripts/oas-drift-check.sh' for detail)"
     fi

--- a/scripts/ide/export-symbol-graph
+++ b/scripts/ide/export-symbol-graph
@@ -273,7 +273,7 @@ def live_lsp_prereq_report(data: dict[str, Any], *, artifact: pathlib.Path) -> d
         "commands": commands,
         "ready": ready,
         "note": (
-            "This doctor checks local executable prerequisites only. It does not "
+            "This diagnostics command checks local executable prerequisites only. It does not "
             "call /api/v1/ide/lsp, open a WebSocket, spawn LSP servers, or mutate "
             "the checked-in artifact."
         ),
@@ -372,7 +372,7 @@ def main() -> int:
     parser.add_argument("--emit", action="store_true", help="validate and print canonical JSON to stdout")
     parser.add_argument("--write", action="store_true", help="validate and rewrite the artifact canonically")
     parser.add_argument(
-        "--doctor-live-lsp",
+        "--diagnostics-live-lsp",
         "--live-lsp-prereq-report",
         action="store_true",
         help="print a non-mutating JSON report for live LSP executable prerequisites",
@@ -401,7 +401,7 @@ def main() -> int:
     if args.generated_at:
         data["generated_at"] = args.generated_at
 
-    if args.doctor_live_lsp:
+    if args.diagnostics_live_lsp:
         sys.stdout.write(dump_canonical(live_lsp_prereq_report(data, artifact=artifact)))
         return 0
 

--- a/scripts/init-codex-mcp-config.sh
+++ b/scripts/init-codex-mcp-config.sh
@@ -29,7 +29,7 @@ Usage:
   scripts/init-codex-mcp-config.sh [--base-path PATH] [--host HOST] [--port PORT] [--dry-run]
 
 This script generates the correct [mcp_servers.masc] Codex config entry that
-the MASC auth doctor (doctor auth) expects:
+the MASC auth diagnostics (diagnostics) expects:
   - bearer_token_env_var = "MASC_MCP_TOKEN"   (no hardcoded Authorization header)
   - http_headers with Accept and X-MASC-Agent  (no Authorization header)
 
@@ -43,7 +43,7 @@ Security notes:
   - Never write the raw bearer token into ~/.codex/config.toml.
   - Use bearer_token_env_var so Codex reads the token from the environment
     at runtime; this avoids persisting the literal token in the config file.
-  - Run `masc-mcp doctor auth` to verify the config is correct.
+  - Run `masc-mcp login --json` to verify the config is correct.
 
 Env:
   MASC_BASE_PATH         Base path for the MASC data root (default: MASC_BASE_PATH, then repo root)
@@ -67,7 +67,7 @@ MCP_URL="http://${HOST}:${PORT}/mcp"
 
 # The canonical [mcp_servers.masc] stanza.
 # bearer_token_env_var is used instead of a hardcoded Authorization header.
-# This is what `masc-mcp doctor auth` checks for in codex_mcp.config.stages.
+# This is what `masc-mcp login --json` checks for in codex_mcp.config.stages.
 MASC_STANZA=$(cat <<EOF
 [mcp_servers.masc]
 url = "${MCP_URL}"
@@ -90,7 +90,7 @@ if [ "$DRY_RUN" = "1" ]; then
   echo "  3. Add or replace the stanza with the output above."
   echo "  4. Mint a codex-mcp-client token and export it:"
   echo "     eval \"\$(masc-mcp login --base-path '${BASE_PATH}' --agent codex-mcp-client --role worker --shell)\""
-  echo "  5. Run: masc-mcp doctor auth --base-path '${BASE_PATH}'"
+  echo "  5. Run: MASC_SYNC_CODEX_MCP_CONFIG=1 masc-mcp --base-path '${BASE_PATH}'"
   exit 0
 fi
 
@@ -105,7 +105,7 @@ elif grep -qE '^\[mcp_servers\.masc\]' "$CODEX_CONFIG_PATH" 2>/dev/null; then
   # Stanza already present.
   echo "==> [mcp_servers.masc] already present in ${CODEX_CONFIG_PATH}." >&2
   echo "    Run: MASC_SYNC_CODEX_MCP_CONFIG=1 masc-mcp --base-path '${BASE_PATH}'" >&2
-  echo "    Or:  masc-mcp doctor auth --base-path '${BASE_PATH}'" >&2
+  echo "    Or:  MASC_SYNC_CODEX_MCP_CONFIG=1 masc-mcp --base-path '${BASE_PATH}'" >&2
   echo "    to check and repair bearer_token_env_var / Authorization drift." >&2
 else
   # Append the stanza to the existing config.
@@ -123,5 +123,5 @@ echo "==> Mint / verify codex-mcp-client bearer token:" >&2
 echo "    eval \"\$(masc-mcp login --base-path '${BASE_PATH}' --agent codex-mcp-client --role worker --shell)\"" >&2
 echo "    export MASC_MCP_TOKEN" >&2
 echo "" >&2
-echo "==> Verify config with auth doctor:" >&2
-echo "    masc-mcp doctor auth --base-path '${BASE_PATH}'" >&2
+echo "==> Verify config with auth diagnostics:" >&2
+echo "    MASC_SYNC_CODEX_MCP_CONFIG=1 masc-mcp --base-path '${BASE_PATH}'" >&2

--- a/scripts/lint/exhaustive-guard.allowlist
+++ b/scripts/lint/exhaustive-guard.allowlist
@@ -35,8 +35,6 @@ lib/attempt_state.ml:129
 lib/audit_log.ml:351
 lib/audit_log.ml:384
 lib/audit_log.ml:393
-lib/auth_doctor.ml:374
-lib/auth_doctor.ml:499
 lib/auth_error_kind.ml:43
 lib/auth_login.ml:36
 lib/auth.ml:271
@@ -157,9 +155,6 @@ lib/chronicle_ingest.ml:42
 lib/chronicle_ingest.ml:224
 lib/chronicle_ingest.ml:230
 lib/chronicle_validate.ml:44
-lib/codex_mcp_config_doctor.ml:69
-lib/codex_mcp_config_doctor.ml:86
-lib/codex_mcp_config_doctor.ml:91
 lib/config/env_config_runtime.ml:343
 lib/coord_assertions.ml:58
 lib/coord_goals.ml:220
@@ -287,7 +282,6 @@ lib/dashboard/dashboard_worktree_status.ml:109
 lib/dashboard/dashboard_worktree_status.ml:132
 lib/dashboard/dashboard_worktree_status.ml:218
 lib/dashboard/judge_json_recovery.ml:36
-lib/doctor_dispatch.ml:9
 lib/drift_guard.ml:50
 lib/drift_guard.ml:108
 lib/eval_calibration.ml:31

--- a/sidecars/cli-connector/src/__main__.py
+++ b/sidecars/cli-connector/src/__main__.py
@@ -1,10 +1,10 @@
-"""Entry point: python -m src [keeper_name | doctor].
+"""Entry point: python -m src [keeper_name | diagnostics].
 
     python -m src                # 기본 keeper (CLI_DEFAULT_KEEPER 또는 sangsu) 로 연결
     python -m src <keeper>       # 지정 keeper 로 연결
-    python -m src doctor         # 기동 전 건강 점검
-    python -m src doctor --json  # 점검 결과 JSON
-    python -m src doctor --fix   # 가능한 auto-fix 후 재점검 (현재 없음 — placeholder)
+    python -m src diagnostics         # 기동 전 건강 점검
+    python -m src diagnostics --json  # 점검 결과 JSON
+    python -m src diagnostics --fix   # 가능한 auto-fix 후 재점검 (현재 없음 — placeholder)
 """
 from __future__ import annotations
 
@@ -25,34 +25,34 @@ from gate_shared import (  # noqa: E402
 )
 
 
-def _run_doctor(argv: list[str]) -> int:
-    # Lazy import — doctor must still run when runtime deps are missing.
-    from .doctor import run_doctor  # noqa: PLC0415
+def _run_diagnostics(argv: list[str]) -> int:
+    # Lazy import — diagnostics must still run when runtime deps are missing.
+    from .diagnostics import run_diagnostics  # noqa: PLC0415
 
     as_json = "--json" in argv
     auto_fix = "--fix" in argv
 
     async def run() -> int:
-        doctor = await run_doctor()
-        checks = await doctor.run()
+        diagnostics = await run_diagnostics()
+        checks = await diagnostics.run()
         outcomes: list[FixOutcome] = []
         if auto_fix:
-            checks, outcomes = await doctor.run_auto_fixes(checks)
+            checks, outcomes = await diagnostics.run_auto_fixes(checks)
         if as_json:
-            sys.stdout.write(render_json(doctor.title, checks))
+            sys.stdout.write(render_json(diagnostics.title, checks))
         else:
             fix_block = render_fix_outcomes(outcomes)
             if fix_block:
                 sys.stdout.write(fix_block + "\n")
-            sys.stdout.write(render_pretty(doctor.title, checks))
+            sys.stdout.write(render_pretty(diagnostics.title, checks))
         sys.stdout.write("\n")
         return exit_code_for(checks)
 
     return asyncio.run(run())
 
 
-if len(sys.argv) > 1 and sys.argv[1] == "doctor":
-    raise SystemExit(_run_doctor(sys.argv[2:]))
+if len(sys.argv) > 1 and sys.argv[1] == "diagnostics":
+    raise SystemExit(_run_diagnostics(sys.argv[2:]))
 
 from .bot import main  # noqa: E402
 

--- a/sidecars/cli-connector/src/diagnostics.py
+++ b/sidecars/cli-connector/src/diagnostics.py
@@ -1,7 +1,7 @@
-"""CLI connector Doctor — 대화형 모드 사전 점검.
+"""CLI connector Diagnostics — 대화형 모드 사전 점검.
 
 CLI connector 는 다른 sidecar 와 달리 **stateless** 다. 바인딩도, 상태 파일도,
-토큰도 없다. 따라서 doctor 는 짧다. 대신 다른 sidecar 가 가정하는 "지속적
+토큰도 없다. 따라서 diagnostics 는 짧다. 대신 다른 sidecar 가 가정하는 "지속적
 서비스" 대신 "**사람이 즉시 쓰는 터미널 도구**" 의 관점에서 본다:
 
 - stdin 이 TTY 인가? (파이프 환경에서 interactive loop 는 헛돈다)
@@ -10,8 +10,8 @@ CLI connector 는 다른 sidecar 와 달리 **stateless** 다. 바인딩도, 상
 
 사용법::
 
-    python -m src doctor          # 사람용 출력
-    python -m src doctor --json   # 자동화용 JSON
+    python -m src diagnostics          # 사람용 출력
+    python -m src diagnostics --json   # 자동화용 JSON
 """
 
 from __future__ import annotations
@@ -27,8 +27,8 @@ if str(_shared_root) not in sys.path:
 
 import httpx  # noqa: E402
 
-from gate_shared import AutoFix, Check, Doctor, Severity  # noqa: E402
-from gate_shared.doctor import (  # noqa: E402
+from gate_shared import AutoFix, Check, Diagnostics, Severity  # noqa: E402
+from gate_shared.diagnostics import (  # noqa: E402
     NETWORK_TIMEOUT_SEC,
     check_dependencies_installed,
 )
@@ -36,8 +36,8 @@ from gate_shared.doctor import (  # noqa: E402
 _REQUIRED_PACKAGES = ("httpx",)
 
 
-async def run_doctor() -> Doctor:
-    doc = Doctor("CLI Connector Doctor")
+async def run_diagnostics() -> Diagnostics:
+    doc = Diagnostics("CLI Connector Diagnostics")
     doc.register(check_python_version)
     doc.register(check_dependencies_installed(_REQUIRED_PACKAGES))
     doc.register(check_httpx_installed)

--- a/sidecars/imessage-bot/run.sh
+++ b/sidecars/imessage-bot/run.sh
@@ -12,9 +12,9 @@
 #   ./run.sh              start the bot (foreground, tees to today's log)
 #   ./run.sh tail         tail -F today's log file
 #   ./run.sh status       pretty-print the current status.json
-#   ./run.sh doctor       run health checks without starting the bot
-#   ./run.sh doctor --json   machine-readable check output
-#   ./run.sh doctor --fix    run available auto-fixes then recheck
+#   ./run.sh diagnostics       run health checks without starting the bot
+#   ./run.sh diagnostics --json   machine-readable check output
+#   ./run.sh diagnostics --fix    run available auto-fixes then recheck
 
 set -euo pipefail
 
@@ -73,10 +73,10 @@ case "$cmd" in
       cat "$STATUS_FILE"
     fi
     ;;
-  doctor)
+  diagnostics)
     cd "$(script_dir)"
     shift || true
-    python -m src doctor "$@"
+    python -m src diagnostics "$@"
     ;;
   stop)
     # Match by absolute script_dir path so we never hit another sidecar.
@@ -88,7 +88,7 @@ case "$cmd" in
     fi
     ;;
   *)
-    echo "Usage: $0 [start|stop|tail|status|doctor]" >&2
+    echo "Usage: $0 [start|stop|tail|status|diagnostics]" >&2
     exit 2
     ;;
 esac

--- a/sidecars/imessage-bot/src/__main__.py
+++ b/sidecars/imessage-bot/src/__main__.py
@@ -1,11 +1,11 @@
 """Entry point: python -m src.
 
-기본은 봇 기동. ``doctor`` subcommand 로 건강 점검만 실행.
+기본은 봇 기동. ``diagnostics`` subcommand 로 건강 점검만 실행.
 
     python -m src                # 봇 기동
-    python -m src doctor         # 점검
-    python -m src doctor --json  # 점검 결과 JSON
-    python -m src doctor --fix   # 가능한 auto-fix 후 재점검
+    python -m src diagnostics         # 점검
+    python -m src diagnostics --json  # 점검 결과 JSON
+    python -m src diagnostics --fix   # 가능한 auto-fix 후 재점검
 """
 from __future__ import annotations
 
@@ -26,26 +26,26 @@ from gate_shared import (  # noqa: E402
 )
 
 
-def _run_doctor(argv: list[str]) -> int:
-    # Lazy import — doctor must still run when runtime deps are missing.
-    from .doctor import run_doctor  # noqa: PLC0415
+def _run_diagnostics(argv: list[str]) -> int:
+    # Lazy import — diagnostics must still run when runtime deps are missing.
+    from .diagnostics import run_diagnostics  # noqa: PLC0415
 
     as_json = "--json" in argv
     auto_fix = "--fix" in argv
 
     async def run() -> int:
-        doctor = await run_doctor()
-        checks = await doctor.run()
+        diagnostics = await run_diagnostics()
+        checks = await diagnostics.run()
         outcomes: list[FixOutcome] = []
         if auto_fix:
-            checks, outcomes = await doctor.run_auto_fixes(checks)
+            checks, outcomes = await diagnostics.run_auto_fixes(checks)
         if as_json:
-            sys.stdout.write(render_json(doctor.title, checks))
+            sys.stdout.write(render_json(diagnostics.title, checks))
         else:
             fix_block = render_fix_outcomes(outcomes)
             if fix_block:
                 sys.stdout.write(fix_block + "\n")
-            sys.stdout.write(render_pretty(doctor.title, checks))
+            sys.stdout.write(render_pretty(diagnostics.title, checks))
         sys.stdout.write("\n")
         return exit_code_for(checks)
 
@@ -53,8 +53,8 @@ def _run_doctor(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    if len(sys.argv) > 1 and sys.argv[1] == "doctor":
-        raise SystemExit(_run_doctor(sys.argv[2:]))
+    if len(sys.argv) > 1 and sys.argv[1] == "diagnostics":
+        raise SystemExit(_run_diagnostics(sys.argv[2:]))
     from .bot import main  # noqa: PLC0415
 
     asyncio.run(main())

--- a/sidecars/imessage-bot/src/diagnostics.py
+++ b/sidecars/imessage-bot/src/diagnostics.py
@@ -1,19 +1,19 @@
-"""iMessage Sidecar Doctor — 기동 전 건강 점검 (macOS 전용).
+"""iMessage Sidecar Diagnostics — 기동 전 건강 점검 (macOS 전용).
 
 iMessage 커넥터는 토큰을 쓰지 않는다. 대신 macOS 의 두 가지 권한에 의존한다:
 
 1. **Full Disk Access (FDA)** — `~/Library/Messages/chat.db` 읽기
 2. **Automation (Messages.app)** — `osascript` 로 메시지 전송
 
-Doctor 는 이 두 권한이 실제로 살아있는지까지 한 번에 검증한다.
+Diagnostics 는 이 두 권한이 실제로 살아있는지까지 한 번에 검증한다.
 단순 존재 확인이 아니라 SQLite 열기 시도 / osascript 실행 시도로
 "설정돼 있는 것처럼 보이지만 실제로 안 되는" 케이스를 잡아낸다.
 
 사용법::
 
-    python -m src doctor           # 사람용 출력
-    python -m src doctor --json    # 자동화용 JSON
-    python -m src doctor --fix     # 가능한 auto-fix 후 재점검
+    python -m src diagnostics           # 사람용 출력
+    python -m src diagnostics --json    # 자동화용 JSON
+    python -m src diagnostics --fix     # 가능한 auto-fix 후 재점검
 """
 
 from __future__ import annotations
@@ -31,13 +31,13 @@ _shared_root = Path(__file__).resolve().parent.parent.parent / "shared"
 if str(_shared_root) not in sys.path:
     sys.path.insert(0, str(_shared_root))
 
-# httpx is required for the doctor itself. pydantic_settings is NOT
-# imported at module top so the doctor can still run and report it
+# httpx is required for the diagnostics itself. pydantic_settings is NOT
+# imported at module top so the diagnostics can still run and report it
 # as missing instead of crashing before any check executes.
 import httpx  # noqa: E402
 
-from gate_shared import AutoFix, Check, Doctor, Severity  # noqa: E402
-from gate_shared.doctor import (  # noqa: E402
+from gate_shared import AutoFix, Check, Diagnostics, Severity  # noqa: E402
+from gate_shared.diagnostics import (  # noqa: E402
     NETWORK_TIMEOUT_SEC,
     check_dependencies_installed,
 )
@@ -67,8 +67,8 @@ def _config_or_none() -> BotConfig | None:
         return None
 
 
-async def run_doctor() -> Doctor:
-    doc = Doctor("iMessage Sidecar Doctor")
+async def run_diagnostics() -> Diagnostics:
+    doc = Diagnostics("iMessage Sidecar Diagnostics")
     doc.register(check_python_version)
     doc.register(check_dependencies_installed(_REQUIRED_PACKAGES))
     doc.register(check_macos_platform)
@@ -408,7 +408,7 @@ async def check_binding_paths_writable() -> Check:
             try:
                 p.chmod(0o755)
             except OSError as exc:
-                print(f"[doctor] chmod 0755 {p} failed: {exc.strerror or exc}", file=sys.stderr)
+                print(f"[diagnostics] chmod 0755 {p} failed: {exc.strerror or exc}", file=sys.stderr)
 
     return Check(
         name="binding paths writable",

--- a/sidecars/shared/gate_shared/__init__.py
+++ b/sidecars/shared/gate_shared/__init__.py
@@ -1,11 +1,11 @@
 """Shared connector components for MASC Channel Gate sidecars."""
 
-from .doctor import (
+from .diagnostics import (
     NETWORK_TIMEOUT_SEC,
     AutoFix,
     Check,
     CheckFn,
-    Doctor,
+    Diagnostics,
     FixOutcome,
     Severity,
     check_dependencies_installed,
@@ -22,7 +22,7 @@ __all__ = [
     "BreakerSnapshot",
     "Check",
     "CheckFn",
-    "Doctor",
+    "Diagnostics",
     "FixOutcome",
     "GateClientBase",
     "GateResponse",

--- a/sidecars/shared/gate_shared/diagnostics.py
+++ b/sidecars/shared/gate_shared/diagnostics.py
@@ -1,9 +1,9 @@
-"""Doctor framework for MASC connector sidecars.
+"""Diagnostics framework for MASC connector sidecars.
 
 진단(Diagnose) → 보고(Report) → 힌트(Hint) → 자가치유(Fix) 의 네 단계를 표준화한다.
-각 커넥터는 ``Check`` 들을 등록하고 ``Doctor.run()`` 으로 실행한다.
+각 커넥터는 ``Check`` 들을 등록하고 ``Diagnostics.run()`` 으로 실행한다.
 
-외모는 ``flutter doctor`` / ``brew doctor`` / ``rustup check`` 를 참고한다:
+외모는 ``flutter diagnostics`` / ``brew diagnostics`` / ``rustup check`` 를 참고한다:
 
     [✓] gate reachable (http://localhost:8935)
     [!] DISCORD_ADMIN_ROLE_ID not set
@@ -11,7 +11,7 @@
           fix: export DISCORD_ADMIN_ROLE_ID=<role_id>
     [✗] binding store path not writable
         ↳ .gate/runtime/discord/bindings.json 을 만들 수 없습니다.
-          auto-fix 가능: doctor --fix
+          auto-fix 가능: diagnostics --fix
 """
 
 from __future__ import annotations
@@ -32,7 +32,7 @@ __all__ = [
     "AutoFix",
     "Check",
     "CheckFn",
-    "Doctor",
+    "Diagnostics",
     "FixOutcome",
     "NETWORK_TIMEOUT_SEC",
     "Severity",
@@ -117,7 +117,7 @@ def _colorize(text: str, sev: Severity, *, use_color: bool) -> str:
 
 
 def _banner(counts: dict[Severity, int], *, use_color: bool) -> str:
-    """검사 결과를 한 줄로 요약한 상단 배너. ``flutter doctor`` 헤드라인 풍.
+    """검사 결과를 한 줄로 요약한 상단 배너. ``flutter diagnostics`` 헤드라인 풍.
 
     error > warn > (모두 skip) > ok 순으로 우선 판정한다. skip 만 있을 때
     "통과" 로 표시하면 전제가 깨진 상태를 정상처럼 오해하게 된다.
@@ -176,7 +176,7 @@ def _action_items(checks: Sequence[Check]) -> list[str]:
             if c.auto_fix.command:
                 items.append(f"       $ {c.auto_fix.command}")
             if c.auto_fix.callback is not None:
-                items.append("       # doctor --fix 로 실행")
+                items.append("       # diagnostics --fix 로 실행")
     return items
 
 
@@ -203,15 +203,15 @@ def render_pretty(
 ) -> str:
     """사람이 읽기 좋은 출력.
 
-    레이아웃은 ``flutter doctor`` / ``brew doctor`` 외형을 참고:
+    레이아웃은 ``flutter diagnostics`` / ``brew diagnostics`` 외형을 참고:
 
-    1. 제목 (전통적 underline 스타일 — ``Discord Sidecar Doctor`` + ``====``)
+    1. 제목 (전통적 underline 스타일 — ``Discord Sidecar Diagnostics`` + ``====``)
     2. 배너 — 전체 상태 한 줄 요약
     3. 검사 목록 — 등록 순서 유지 (검진 흐름이 곧 읽는 순서)
     4. 조치 항목 — warn/error 에서 나온 hint + auto-fix 를 번호 목록으로
     5. 합계 — 한글 카운트
 
-    Note: `masc-mcp doctor all` 이 섹션마다 ``====`` divider 를 넣으므로,
+    Note: `masc-mcp diagnostics all` 이 섹션마다 ``====`` divider 를 넣으므로,
     사이드카 제목도 동일한 underline 을 써서 단독/통합 실행 양쪽에서
     시각적으로 자연스럽게 이어지도록 한다 (이전의 markdown ``#`` 접두 제거).
     """
@@ -244,7 +244,7 @@ def render_pretty(
             if c.auto_fix.command:
                 lines.append(f"        $ {c.auto_fix.command}")
             if c.auto_fix.callback is not None:
-                lines.append("        auto-fix 가능: doctor --fix")
+                lines.append("        auto-fix 가능: diagnostics --fix")
     actions = _action_items(checks)
     if actions:
         lines.append("")
@@ -328,7 +328,7 @@ def exit_code_for(checks: Sequence[Check]) -> int:
     return 0
 
 
-class Doctor:
+class Diagnostics:
     def __init__(self, title: str) -> None:
         self._title = title
         self._checks: list[CheckFn] = []
@@ -411,7 +411,7 @@ def check_dependencies_installed(packages: Sequence[str]) -> CheckFn:
     dependencies — critical for diagnosing "nothing is installed yet"
     states where importing the sidecar's own config module would crash.
 
-    Register this first in a Doctor so the operator sees a single clear
+    Register this first in a Diagnostics so the operator sees a single clear
     'missing deps' check instead of a raw ImportError traceback.
     """
 

--- a/sidecars/shared/tests/test_diagnostics.py
+++ b/sidecars/shared/tests/test_diagnostics.py
@@ -1,4 +1,4 @@
-"""Doctor framework 단위 테스트.
+"""Diagnostics framework 단위 테스트.
 
 실제 네트워크/파일시스템 의존 없이 Check 조립 / 렌더링 / exit code / auto-fix
 콜백 동작만 검증한다.
@@ -10,10 +10,10 @@ import json
 
 import pytest
 
-from gate_shared.doctor import (
+from gate_shared.diagnostics import (
     AutoFix,
     Check,
-    Doctor,
+    Diagnostics,
     Severity,
     check_dependencies_installed,
     exit_code_for,
@@ -40,18 +40,18 @@ def test_severity_symbols_render_prefix() -> None:
 def test_title_uses_underline_style_not_markdown_heading() -> None:
     """제목은 전통적 underline 스타일 (`Title\\n=====`) 로 렌더돼야 한다.
 
-    `masc-mcp doctor all` 섹션 divider (``====``) 와 일관된 외형 유지,
+    `masc-mcp diagnostics all` 섹션 divider (``====``) 와 일관된 외형 유지,
     그리고 pretty 출력에서 markdown 기호(`# `) 가 보이지 않도록.
     """
 
     text = render_pretty(
-        "Discord Sidecar Doctor",
+        "Discord Sidecar Diagnostics",
         [Check(name="a", severity=Severity.ok, message="")],
         use_color=False,
     )
     lines = text.splitlines()
-    assert lines[0] == "Discord Sidecar Doctor"
-    assert lines[1] == "=" * len("Discord Sidecar Doctor")
+    assert lines[0] == "Discord Sidecar Diagnostics"
+    assert lines[1] == "=" * len("Discord Sidecar Diagnostics")
     # markdown heading 기호는 제거됐어야 한다
     assert not text.startswith("# ")
     assert "\n# Discord" not in text
@@ -137,7 +137,7 @@ def test_action_item_marks_auto_fix_callback_available() -> None:
     ]
     text = render_pretty("T", checks, use_color=False)
     assert "[자동 치유] 재시작" in text
-    assert "# doctor --fix 로 실행" in text
+    assert "# diagnostics --fix 로 실행" in text
 
 
 def test_summary_line_in_korean() -> None:
@@ -196,7 +196,7 @@ def test_severity_needs_action() -> None:
 
 
 @pytest.mark.asyncio
-async def test_doctor_runs_all_checks_even_when_one_raises() -> None:
+async def test_diagnostics_runs_all_checks_even_when_one_raises() -> None:
     async def good() -> Check:
         return Check(name="good", severity=Severity.ok, message="")
 
@@ -206,7 +206,7 @@ async def test_doctor_runs_all_checks_even_when_one_raises() -> None:
     async def other() -> Check:
         return Check(name="other", severity=Severity.warn, message="skip-me")
 
-    d = Doctor("unit")
+    d = Diagnostics("unit")
     d.register_many([good, bad, other])
     results = await d.run()
     names = [c.name for c in results]
@@ -245,7 +245,7 @@ async def test_auto_fix_callback_invoked_only_for_warn_or_error() -> None:
     async def emit_bad() -> Check:
         return bad_check
 
-    d = Doctor("unit")
+    d = Diagnostics("unit")
     d.register_many([emit_ok, emit_bad])
     initial = await d.run()
     rerun, outcomes = await d.run_auto_fixes(initial)
@@ -288,7 +288,7 @@ async def test_run_auto_fixes_captures_failure_and_continues() -> None:
     async def emit_c2() -> Check:
         return c2
 
-    d = Doctor("unit")
+    d = Diagnostics("unit")
     d.register_many([emit_c1, emit_c2])
     initial = await d.run()
     _, outcomes = await d.run_auto_fixes(initial)
@@ -299,13 +299,13 @@ async def test_run_auto_fixes_captures_failure_and_continues() -> None:
 
 
 def test_render_fix_outcomes_empty_returns_empty_string() -> None:
-    from gate_shared.doctor import render_fix_outcomes  # noqa: PLC0415
+    from gate_shared.diagnostics import render_fix_outcomes  # noqa: PLC0415
 
     assert render_fix_outcomes([], use_color=False) == ""
 
 
 def test_render_fix_outcomes_shows_success_and_failure() -> None:
-    from gate_shared.doctor import FixOutcome, render_fix_outcomes  # noqa: PLC0415
+    from gate_shared.diagnostics import FixOutcome, render_fix_outcomes  # noqa: PLC0415
 
     outcomes = [
         FixOutcome(

--- a/sidecars/slack-bot/run.sh
+++ b/sidecars/slack-bot/run.sh
@@ -9,9 +9,9 @@
 #   ./run.sh              start the bot (foreground, tees to today's log)
 #   ./run.sh tail         tail -F today's log file
 #   ./run.sh status       pretty-print the current status.json
-#   ./run.sh doctor       run health checks without starting the bot
-#   ./run.sh doctor --json   machine-readable check output
-#   ./run.sh doctor --fix    run available auto-fixes then recheck
+#   ./run.sh diagnostics       run health checks without starting the bot
+#   ./run.sh diagnostics --json   machine-readable check output
+#   ./run.sh diagnostics --fix    run available auto-fixes then recheck
 
 set -euo pipefail
 
@@ -65,10 +65,10 @@ case "$cmd" in
       cat "$STATUS_FILE"
     fi
     ;;
-  doctor)
+  diagnostics)
     cd "$(script_dir)"
     shift || true
-    python -m src doctor "$@"
+    python -m src diagnostics "$@"
     ;;
   stop)
     # Match by absolute script_dir path so we never hit another sidecar.
@@ -80,7 +80,7 @@ case "$cmd" in
     fi
     ;;
   *)
-    echo "Usage: $0 [start|stop|tail|status|doctor]" >&2
+    echo "Usage: $0 [start|stop|tail|status|diagnostics]" >&2
     exit 2
     ;;
 esac

--- a/sidecars/slack-bot/src/__main__.py
+++ b/sidecars/slack-bot/src/__main__.py
@@ -1,11 +1,11 @@
 """Entry point: python -m src.
 
-기본은 봇 기동. ``doctor`` subcommand 로 건강 점검만 실행.
+기본은 봇 기동. ``diagnostics`` subcommand 로 건강 점검만 실행.
 
     python -m src                # 봇 기동
-    python -m src doctor         # 점검
-    python -m src doctor --json  # 점검 결과 JSON
-    python -m src doctor --fix   # 가능한 auto-fix 후 재점검
+    python -m src diagnostics         # 점검
+    python -m src diagnostics --json  # 점검 결과 JSON
+    python -m src diagnostics --fix   # 가능한 auto-fix 후 재점검
 """
 from __future__ import annotations
 
@@ -26,34 +26,34 @@ from gate_shared import (  # noqa: E402
 )
 
 
-def _run_doctor(argv: list[str]) -> int:
-    # Lazy import — doctor must still run when runtime deps are missing.
-    from .doctor import run_doctor  # noqa: PLC0415
+def _run_diagnostics(argv: list[str]) -> int:
+    # Lazy import — diagnostics must still run when runtime deps are missing.
+    from .diagnostics import run_diagnostics  # noqa: PLC0415
 
     as_json = "--json" in argv
     auto_fix = "--fix" in argv
 
     async def run() -> int:
-        doctor = await run_doctor()
-        checks = await doctor.run()
+        diagnostics = await run_diagnostics()
+        checks = await diagnostics.run()
         outcomes: list[FixOutcome] = []
         if auto_fix:
-            checks, outcomes = await doctor.run_auto_fixes(checks)
+            checks, outcomes = await diagnostics.run_auto_fixes(checks)
         if as_json:
-            sys.stdout.write(render_json(doctor.title, checks))
+            sys.stdout.write(render_json(diagnostics.title, checks))
         else:
             fix_block = render_fix_outcomes(outcomes)
             if fix_block:
                 sys.stdout.write(fix_block + "\n")
-            sys.stdout.write(render_pretty(doctor.title, checks))
+            sys.stdout.write(render_pretty(diagnostics.title, checks))
         sys.stdout.write("\n")
         return exit_code_for(checks)
 
     return asyncio.run(run())
 
 
-if len(sys.argv) > 1 and sys.argv[1] == "doctor":
-    raise SystemExit(_run_doctor(sys.argv[2:]))
+if len(sys.argv) > 1 and sys.argv[1] == "diagnostics":
+    raise SystemExit(_run_diagnostics(sys.argv[2:]))
 
 from .bot import main  # noqa: E402
 

--- a/sidecars/slack-bot/src/diagnostics.py
+++ b/sidecars/slack-bot/src/diagnostics.py
@@ -1,19 +1,18 @@
-"""Telegram Sidecar Doctor — 기동 전 건강 점검.
+"""Slack Sidecar Diagnostics — 기동 전 건강 점검.
 
 사용법::
 
-    python -m src doctor           # 사람용 출력
-    python -m src doctor --json    # 자동화용 JSON
-    python -m src doctor --fix     # 가능한 auto-fix 수행 후 재점검
+    python -m src diagnostics           # 사람용 출력
+    python -m src diagnostics --json    # 자동화용 JSON
+    python -m src diagnostics --fix     # 가능한 auto-fix 수행 후 재점검
 
-체크 목록은 ``run_doctor`` 의 ``register`` 호출이 SSOT.
+체크 목록은 ``run_diagnostics`` 의 ``register`` 호출이 SSOT.
 """
 
 from __future__ import annotations
 
 import importlib.metadata
 import os
-import re
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -22,13 +21,13 @@ _shared_root = Path(__file__).resolve().parent.parent.parent / "shared"
 if str(_shared_root) not in sys.path:
     sys.path.insert(0, str(_shared_root))
 
-# httpx is required for the doctor itself. pydantic_settings and
-# python-telegram-bot are NOT imported at module top so the doctor can
-# still run and report them as missing instead of crashing.
+# httpx is required for the diagnostics itself. pydantic_settings / slack_bolt
+# are NOT imported at module top so the diagnostics can still run and report
+# them as missing instead of crashing before any check executes.
 import httpx  # noqa: E402
 
-from gate_shared import AutoFix, Check, Doctor, Severity  # noqa: E402
-from gate_shared.doctor import (  # noqa: E402
+from gate_shared import AutoFix, Check, Diagnostics, Severity  # noqa: E402
+from gate_shared.diagnostics import (  # noqa: E402
     NETWORK_TIMEOUT_SEC,
     check_dependencies_installed,
 )
@@ -36,11 +35,10 @@ from gate_shared.doctor import (  # noqa: E402
 if TYPE_CHECKING:
     from .config import BotConfig
 
-# Telegram 봇 토큰은 `<digits>:<base64url-ish>` 규약. BotFather 가 발급하는 포맷.
-_TG_TOKEN_RE = re.compile(r"^\d{6,}:[A-Za-z0-9_-]{30,}$")
 
 _REQUIRED_PACKAGES = (
-    "python-telegram-bot",
+    "slack-bolt",
+    "slack-sdk",
     "pydantic",
     "pydantic-settings",
     "httpx",
@@ -48,31 +46,17 @@ _REQUIRED_PACKAGES = (
 )
 
 
-def _config_or_none() -> BotConfig | None:
-    try:
-        from pydantic import ValidationError  # noqa: PLC0415
-
-        from .config import get_config  # noqa: PLC0415
-    except ImportError:
-        return None
-    try:
-        return get_config()
-    except (ValidationError, OSError):
-        return None
-
-
-async def run_doctor() -> Doctor:
-    doc = Doctor("Telegram Sidecar Doctor")
+async def run_diagnostics() -> Diagnostics:
+    doc = Diagnostics("Slack Sidecar Diagnostics")
     doc.register(check_python_version)
     doc.register(check_dependencies_installed(_REQUIRED_PACKAGES))
-    doc.register(check_telegram_lib_version)
+    doc.register(check_slack_bolt_version)
     doc.register(check_bot_token)
+    doc.register(check_app_token)
     doc.register(check_env_gate_url)
     doc.register(check_env_api_token)
-    doc.register(check_admin_user_ids)
     doc.register(check_default_keeper_exists)
     doc.register(check_gate_reachable)
-    doc.register(check_telegram_api_reachable)
     doc.register(check_binding_paths_writable)
     doc.register(check_legacy_binding_path)
     return doc
@@ -95,19 +79,32 @@ async def check_python_version() -> Check:
     return Check(name="python >= 3.11", severity=Severity.ok, detail=ver, message="")
 
 
-async def check_telegram_lib_version() -> Check:
-    for pkg in ("python-telegram-bot", "telegram"):
-        try:
-            ver = importlib.metadata.version(pkg)
-            return Check(name=f"{pkg} installed", severity=Severity.ok, detail=ver, message="")
-        except importlib.metadata.PackageNotFoundError:
-            continue
-    return Check(
-        name="python-telegram-bot installed",
-        severity=Severity.error,
-        message="python-telegram-bot 미설치.",
-        hint="pip install -r requirements.txt",
-    )
+async def check_slack_bolt_version() -> Check:
+    try:
+        ver = importlib.metadata.version("slack-bolt")
+    except importlib.metadata.PackageNotFoundError:
+        return Check(
+            name="slack-bolt installed",
+            severity=Severity.error,
+            message="slack-bolt 미설치.",
+            hint="pip install -r requirements.txt",
+        )
+    return Check(name="slack-bolt installed", severity=Severity.ok, detail=ver, message="")
+
+
+def _config_or_none() -> BotConfig | None:
+    """Lazy config load — survives missing pydantic_settings."""
+
+    try:
+        from pydantic import ValidationError  # noqa: PLC0415
+
+        from .config import get_config  # noqa: PLC0415
+    except ImportError:
+        return None
+    try:
+        return get_config()
+    except (ValidationError, OSError):
+        return None
 
 
 def _mask(raw: str) -> str:
@@ -118,26 +115,44 @@ def _mask(raw: str) -> str:
 
 
 async def check_bot_token() -> Check:
-    raw = os.getenv("TELEGRAM_BOT_TOKEN", "").strip()
+    raw = os.getenv("SLACK_BOT_TOKEN", "").strip()
     if not raw:
         return Check(
-            name="TELEGRAM_BOT_TOKEN",
+            name="SLACK_BOT_TOKEN",
             severity=Severity.error,
-            message="Telegram Bot Token 이 설정되지 않았습니다.",
-            hint="Telegram @BotFather 에서 /newbot 또는 /token 으로 발급",
+            message="Slack Bot Token 이 설정되지 않았습니다.",
+            hint="Slack App → Install App → Bot User OAuth Token 복사 (xoxb- 로 시작)",
         )
-    if not _TG_TOKEN_RE.match(raw):
+    if not raw.startswith("xoxb-"):
         return Check(
-            name="TELEGRAM_BOT_TOKEN",
+            name="SLACK_BOT_TOKEN",
             severity=Severity.warn,
             detail=_mask(raw),
-            message="토큰 형식이 '<digits>:<alphanumeric>' 규약과 다릅니다.",
-            hint="BotFather 가 발급한 원본 토큰을 그대로 복사했는지 확인",
+            message="토큰이 xoxb- 로 시작하지 않습니다. Bot Token 이 맞는지 확인하세요.",
         )
-    return Check(name="TELEGRAM_BOT_TOKEN", severity=Severity.ok, detail=_mask(raw), message="")
+    return Check(name="SLACK_BOT_TOKEN", severity=Severity.ok, detail=_mask(raw), message="")
 
 
-# --- gate + env --------------------------------------------------------------
+async def check_app_token() -> Check:
+    raw = os.getenv("SLACK_APP_TOKEN", "").strip()
+    if not raw:
+        return Check(
+            name="SLACK_APP_TOKEN",
+            severity=Severity.error,
+            message="Socket Mode 에 필요한 App-Level Token 이 없습니다.",
+            hint="Slack App → Basic Info → App-Level Tokens → Generate (scope: connections:write, xapp- 로 시작)",
+        )
+    if not raw.startswith("xapp-"):
+        return Check(
+            name="SLACK_APP_TOKEN",
+            severity=Severity.warn,
+            detail=_mask(raw),
+            message="토큰이 xapp- 로 시작하지 않습니다. App-Level Token 이 맞는지 확인하세요.",
+        )
+    return Check(name="SLACK_APP_TOKEN", severity=Severity.ok, detail=_mask(raw), message="")
+
+
+# --- gate --------------------------------------------------------------------
 
 
 async def check_env_gate_url() -> Check:
@@ -170,43 +185,9 @@ async def check_env_api_token() -> Check:
     )
 
 
-async def check_admin_user_ids() -> Check:
-    cfg = _config_or_none()
-    if cfg is None:
-        return Check(
-            name="TELEGRAM_ADMIN_USER_IDS",
-            severity=Severity.skip,
-            message="config 로드 실패로 건너뜀",
-        )
-    ids = cfg.admin_ids()
-    raw = cfg.admin_user_ids.strip()
-    if not raw:
-        return Check(
-            name="TELEGRAM_ADMIN_USER_IDS",
-            severity=Severity.warn,
-            message="admin 이 비어 있어 바인딩 명령 권한이 누구에게나 열립니다.",
-            hint="Telegram 에서 @userinfobot 으로 본인 user ID 확인 후 쉼표로 구분해 기록",
-        )
-    # 파싱 손실 감지 — CSV 에 숫자 아닌 토큰이 섞인 경우
-    tokens = [t.strip() for t in raw.split(",") if t.strip()]
-    parsed_count = len(ids)
-    if parsed_count < len(tokens):
-        return Check(
-            name="TELEGRAM_ADMIN_USER_IDS",
-            severity=Severity.warn,
-            detail=f"{parsed_count}/{len(tokens)} parsed",
-            message="일부 항목이 숫자가 아니라 무시되었습니다.",
-            hint="Telegram user ID 는 양의 정수. 공백과 쉼표 이외의 문자를 제거",
-        )
-    return Check(
-        name="TELEGRAM_ADMIN_USER_IDS",
-        severity=Severity.ok,
-        detail=f"{parsed_count} admin(s)",
-        message="",
-    )
-
-
 async def _gate_get(path: str) -> tuple[str, httpx.Response | str]:
+    """Returns (url, response_or_error_string)."""
+
     cfg = _config_or_none()
     if cfg is None:
         return ("", "config load failed")
@@ -249,68 +230,6 @@ async def check_gate_reachable() -> Check:
     return Check(name="gate reachable", severity=Severity.ok, detail=f"{url} → {res.status_code}", message="")
 
 
-async def check_telegram_api_reachable() -> Check:
-    """Telegram 은 자체 API 로 토큰 유효성을 getMe 로 확인할 수 있다."""
-
-    raw = os.getenv("TELEGRAM_BOT_TOKEN", "").strip()
-    if not raw or not _TG_TOKEN_RE.match(raw):
-        return Check(
-            name="Telegram API getMe",
-            severity=Severity.skip,
-            message="토큰이 없거나 형식 오류로 API 호출 생략",
-        )
-    url = f"https://api.telegram.org/bot{raw}/getMe"
-    try:
-        async with httpx.AsyncClient(timeout=NETWORK_TIMEOUT_SEC) as client:
-            res = await client.get(url)
-    except httpx.HTTPError as exc:
-        return Check(
-            name="Telegram API getMe",
-            severity=Severity.warn,
-            detail="api.telegram.org",
-            message=f"연결 실패: {exc}",
-            hint="네트워크 / 방화벽 / VPN 상태 확인",
-        )
-    if res.status_code == 401:
-        return Check(
-            name="Telegram API getMe",
-            severity=Severity.error,
-            detail="401",
-            message="Telegram 이 토큰을 거절했습니다. 만료/재발급/오타 의심.",
-            hint="BotFather /revoke 후 새 토큰 발급",
-        )
-    if res.status_code >= 400:
-        return Check(
-            name="Telegram API getMe",
-            severity=Severity.warn,
-            detail=str(res.status_code),
-            message="Telegram API 가 비정상 응답을 반환했습니다.",
-        )
-    try:
-        body = res.json()
-    except ValueError:
-        return Check(
-            name="Telegram API getMe",
-            severity=Severity.warn,
-            message="getMe 응답을 파싱할 수 없습니다.",
-        )
-    if not isinstance(body, dict) or not body.get("ok"):
-        return Check(
-            name="Telegram API getMe",
-            severity=Severity.warn,
-            message="getMe ok=false",
-            detail=str(body),
-        )
-    result = body.get("result") if isinstance(body, dict) else None
-    username = result.get("username") if isinstance(result, dict) else None
-    return Check(
-        name="Telegram API getMe",
-        severity=Severity.ok,
-        detail=f"@{username}" if username else "ok",
-        message="",
-    )
-
-
 async def check_default_keeper_exists() -> Check:
     cfg = _config_or_none()
     if cfg is None:
@@ -327,7 +246,7 @@ async def check_default_keeper_exists() -> Check:
         return Check(
             name="default_keeper exists",
             severity=Severity.warn,
-            detail=str(res.status_code),
+            detail=f"{res.status_code}",
             message="keepers 엔드포인트 오류 응답. 토큰/권한 확인.",
         )
     try:
@@ -344,7 +263,7 @@ async def check_default_keeper_exists() -> Check:
             name="default_keeper exists",
             severity=Severity.error,
             detail=cfg.default_keeper,
-            message=f"TELEGRAM_DEFAULT_KEEPER='{cfg.default_keeper}' 가 서버에 등록돼 있지 않습니다.",
+            message=f"SLACK_DEFAULT_KEEPER='{cfg.default_keeper}' 가 서버에 등록돼 있지 않습니다.",
             hint="config/keepers/*.toml 또는 runtime 등록 확인",
         )
     return Check(
@@ -418,7 +337,7 @@ async def check_binding_paths_writable() -> Check:
             try:
                 p.chmod(0o755)
             except OSError as exc:
-                print(f"[doctor] chmod 0755 {p} failed: {exc.strerror or exc}", file=sys.stderr)
+                print(f"[diagnostics] chmod 0755 {p} failed: {exc.strerror or exc}", file=sys.stderr)
 
     return Check(
         name="binding paths writable",

--- a/sidecars/telegram-bot/run.sh
+++ b/sidecars/telegram-bot/run.sh
@@ -7,9 +7,9 @@
 #   ./run.sh              start the bot (foreground, tees to today's log)
 #   ./run.sh tail         tail -F today's log file
 #   ./run.sh status       pretty-print the current status.json
-#   ./run.sh doctor       run health checks without starting the bot
-#   ./run.sh doctor --json   machine-readable check output
-#   ./run.sh doctor --fix    run available auto-fixes then recheck
+#   ./run.sh diagnostics       run health checks without starting the bot
+#   ./run.sh diagnostics --json   machine-readable check output
+#   ./run.sh diagnostics --fix    run available auto-fixes then recheck
 
 set -euo pipefail
 
@@ -63,10 +63,10 @@ case "$cmd" in
       cat "$STATUS_FILE"
     fi
     ;;
-  doctor)
+  diagnostics)
     cd "$(script_dir)"
     shift || true
-    python -m src doctor "$@"
+    python -m src diagnostics "$@"
     ;;
   stop)
     # Match by absolute script_dir path so we never hit another sidecar.
@@ -78,7 +78,7 @@ case "$cmd" in
     fi
     ;;
   *)
-    echo "Usage: $0 [start|stop|tail|status|doctor]" >&2
+    echo "Usage: $0 [start|stop|tail|status|diagnostics]" >&2
     exit 2
     ;;
 esac

--- a/sidecars/telegram-bot/src/__main__.py
+++ b/sidecars/telegram-bot/src/__main__.py
@@ -1,11 +1,11 @@
 """Entry point: python -m src.
 
-기본은 봇 기동. ``doctor`` subcommand 로 건강 점검만 실행.
+기본은 봇 기동. ``diagnostics`` subcommand 로 건강 점검만 실행.
 
     python -m src                # 봇 기동
-    python -m src doctor         # 점검
-    python -m src doctor --json  # 점검 결과 JSON
-    python -m src doctor --fix   # 가능한 auto-fix 후 재점검
+    python -m src diagnostics         # 점검
+    python -m src diagnostics --json  # 점검 결과 JSON
+    python -m src diagnostics --fix   # 가능한 auto-fix 후 재점검
 """
 from __future__ import annotations
 
@@ -26,34 +26,34 @@ from gate_shared import (  # noqa: E402
 )
 
 
-def _run_doctor(argv: list[str]) -> int:
-    # Lazy import — doctor must still run when runtime deps are missing.
-    from .doctor import run_doctor  # noqa: PLC0415
+def _run_diagnostics(argv: list[str]) -> int:
+    # Lazy import — diagnostics must still run when runtime deps are missing.
+    from .diagnostics import run_diagnostics  # noqa: PLC0415
 
     as_json = "--json" in argv
     auto_fix = "--fix" in argv
 
     async def run() -> int:
-        doctor = await run_doctor()
-        checks = await doctor.run()
+        diagnostics = await run_diagnostics()
+        checks = await diagnostics.run()
         outcomes: list[FixOutcome] = []
         if auto_fix:
-            checks, outcomes = await doctor.run_auto_fixes(checks)
+            checks, outcomes = await diagnostics.run_auto_fixes(checks)
         if as_json:
-            sys.stdout.write(render_json(doctor.title, checks))
+            sys.stdout.write(render_json(diagnostics.title, checks))
         else:
             fix_block = render_fix_outcomes(outcomes)
             if fix_block:
                 sys.stdout.write(fix_block + "\n")
-            sys.stdout.write(render_pretty(doctor.title, checks))
+            sys.stdout.write(render_pretty(diagnostics.title, checks))
         sys.stdout.write("\n")
         return exit_code_for(checks)
 
     return asyncio.run(run())
 
 
-if len(sys.argv) > 1 and sys.argv[1] == "doctor":
-    raise SystemExit(_run_doctor(sys.argv[2:]))
+if len(sys.argv) > 1 and sys.argv[1] == "diagnostics":
+    raise SystemExit(_run_diagnostics(sys.argv[2:]))
 
 from .bot import main  # noqa: E402
 

--- a/sidecars/telegram-bot/src/diagnostics.py
+++ b/sidecars/telegram-bot/src/diagnostics.py
@@ -1,18 +1,19 @@
-"""Slack Sidecar Doctor — 기동 전 건강 점검.
+"""Telegram Sidecar Diagnostics — 기동 전 건강 점검.
 
 사용법::
 
-    python -m src doctor           # 사람용 출력
-    python -m src doctor --json    # 자동화용 JSON
-    python -m src doctor --fix     # 가능한 auto-fix 수행 후 재점검
+    python -m src diagnostics           # 사람용 출력
+    python -m src diagnostics --json    # 자동화용 JSON
+    python -m src diagnostics --fix     # 가능한 auto-fix 수행 후 재점검
 
-체크 목록은 ``run_doctor`` 의 ``register`` 호출이 SSOT.
+체크 목록은 ``run_diagnostics`` 의 ``register`` 호출이 SSOT.
 """
 
 from __future__ import annotations
 
 import importlib.metadata
 import os
+import re
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -21,13 +22,13 @@ _shared_root = Path(__file__).resolve().parent.parent.parent / "shared"
 if str(_shared_root) not in sys.path:
     sys.path.insert(0, str(_shared_root))
 
-# httpx is required for the doctor itself. pydantic_settings / slack_bolt
-# are NOT imported at module top so the doctor can still run and report
-# them as missing instead of crashing before any check executes.
+# httpx is required for the diagnostics itself. pydantic_settings and
+# python-telegram-bot are NOT imported at module top so the diagnostics can
+# still run and report them as missing instead of crashing.
 import httpx  # noqa: E402
 
-from gate_shared import AutoFix, Check, Doctor, Severity  # noqa: E402
-from gate_shared.doctor import (  # noqa: E402
+from gate_shared import AutoFix, Check, Diagnostics, Severity  # noqa: E402
+from gate_shared.diagnostics import (  # noqa: E402
     NETWORK_TIMEOUT_SEC,
     check_dependencies_installed,
 )
@@ -35,10 +36,11 @@ from gate_shared.doctor import (  # noqa: E402
 if TYPE_CHECKING:
     from .config import BotConfig
 
+# Telegram 봇 토큰은 `<digits>:<base64url-ish>` 규약. BotFather 가 발급하는 포맷.
+_TG_TOKEN_RE = re.compile(r"^\d{6,}:[A-Za-z0-9_-]{30,}$")
 
 _REQUIRED_PACKAGES = (
-    "slack-bolt",
-    "slack-sdk",
+    "python-telegram-bot",
     "pydantic",
     "pydantic-settings",
     "httpx",
@@ -46,17 +48,31 @@ _REQUIRED_PACKAGES = (
 )
 
 
-async def run_doctor() -> Doctor:
-    doc = Doctor("Slack Sidecar Doctor")
+def _config_or_none() -> BotConfig | None:
+    try:
+        from pydantic import ValidationError  # noqa: PLC0415
+
+        from .config import get_config  # noqa: PLC0415
+    except ImportError:
+        return None
+    try:
+        return get_config()
+    except (ValidationError, OSError):
+        return None
+
+
+async def run_diagnostics() -> Diagnostics:
+    doc = Diagnostics("Telegram Sidecar Diagnostics")
     doc.register(check_python_version)
     doc.register(check_dependencies_installed(_REQUIRED_PACKAGES))
-    doc.register(check_slack_bolt_version)
+    doc.register(check_telegram_lib_version)
     doc.register(check_bot_token)
-    doc.register(check_app_token)
     doc.register(check_env_gate_url)
     doc.register(check_env_api_token)
+    doc.register(check_admin_user_ids)
     doc.register(check_default_keeper_exists)
     doc.register(check_gate_reachable)
+    doc.register(check_telegram_api_reachable)
     doc.register(check_binding_paths_writable)
     doc.register(check_legacy_binding_path)
     return doc
@@ -79,32 +95,19 @@ async def check_python_version() -> Check:
     return Check(name="python >= 3.11", severity=Severity.ok, detail=ver, message="")
 
 
-async def check_slack_bolt_version() -> Check:
-    try:
-        ver = importlib.metadata.version("slack-bolt")
-    except importlib.metadata.PackageNotFoundError:
-        return Check(
-            name="slack-bolt installed",
-            severity=Severity.error,
-            message="slack-bolt 미설치.",
-            hint="pip install -r requirements.txt",
-        )
-    return Check(name="slack-bolt installed", severity=Severity.ok, detail=ver, message="")
-
-
-def _config_or_none() -> BotConfig | None:
-    """Lazy config load — survives missing pydantic_settings."""
-
-    try:
-        from pydantic import ValidationError  # noqa: PLC0415
-
-        from .config import get_config  # noqa: PLC0415
-    except ImportError:
-        return None
-    try:
-        return get_config()
-    except (ValidationError, OSError):
-        return None
+async def check_telegram_lib_version() -> Check:
+    for pkg in ("python-telegram-bot", "telegram"):
+        try:
+            ver = importlib.metadata.version(pkg)
+            return Check(name=f"{pkg} installed", severity=Severity.ok, detail=ver, message="")
+        except importlib.metadata.PackageNotFoundError:
+            continue
+    return Check(
+        name="python-telegram-bot installed",
+        severity=Severity.error,
+        message="python-telegram-bot 미설치.",
+        hint="pip install -r requirements.txt",
+    )
 
 
 def _mask(raw: str) -> str:
@@ -115,44 +118,26 @@ def _mask(raw: str) -> str:
 
 
 async def check_bot_token() -> Check:
-    raw = os.getenv("SLACK_BOT_TOKEN", "").strip()
+    raw = os.getenv("TELEGRAM_BOT_TOKEN", "").strip()
     if not raw:
         return Check(
-            name="SLACK_BOT_TOKEN",
+            name="TELEGRAM_BOT_TOKEN",
             severity=Severity.error,
-            message="Slack Bot Token 이 설정되지 않았습니다.",
-            hint="Slack App → Install App → Bot User OAuth Token 복사 (xoxb- 로 시작)",
+            message="Telegram Bot Token 이 설정되지 않았습니다.",
+            hint="Telegram @BotFather 에서 /newbot 또는 /token 으로 발급",
         )
-    if not raw.startswith("xoxb-"):
+    if not _TG_TOKEN_RE.match(raw):
         return Check(
-            name="SLACK_BOT_TOKEN",
+            name="TELEGRAM_BOT_TOKEN",
             severity=Severity.warn,
             detail=_mask(raw),
-            message="토큰이 xoxb- 로 시작하지 않습니다. Bot Token 이 맞는지 확인하세요.",
+            message="토큰 형식이 '<digits>:<alphanumeric>' 규약과 다릅니다.",
+            hint="BotFather 가 발급한 원본 토큰을 그대로 복사했는지 확인",
         )
-    return Check(name="SLACK_BOT_TOKEN", severity=Severity.ok, detail=_mask(raw), message="")
+    return Check(name="TELEGRAM_BOT_TOKEN", severity=Severity.ok, detail=_mask(raw), message="")
 
 
-async def check_app_token() -> Check:
-    raw = os.getenv("SLACK_APP_TOKEN", "").strip()
-    if not raw:
-        return Check(
-            name="SLACK_APP_TOKEN",
-            severity=Severity.error,
-            message="Socket Mode 에 필요한 App-Level Token 이 없습니다.",
-            hint="Slack App → Basic Info → App-Level Tokens → Generate (scope: connections:write, xapp- 로 시작)",
-        )
-    if not raw.startswith("xapp-"):
-        return Check(
-            name="SLACK_APP_TOKEN",
-            severity=Severity.warn,
-            detail=_mask(raw),
-            message="토큰이 xapp- 로 시작하지 않습니다. App-Level Token 이 맞는지 확인하세요.",
-        )
-    return Check(name="SLACK_APP_TOKEN", severity=Severity.ok, detail=_mask(raw), message="")
-
-
-# --- gate --------------------------------------------------------------------
+# --- gate + env --------------------------------------------------------------
 
 
 async def check_env_gate_url() -> Check:
@@ -185,9 +170,43 @@ async def check_env_api_token() -> Check:
     )
 
 
-async def _gate_get(path: str) -> tuple[str, httpx.Response | str]:
-    """Returns (url, response_or_error_string)."""
+async def check_admin_user_ids() -> Check:
+    cfg = _config_or_none()
+    if cfg is None:
+        return Check(
+            name="TELEGRAM_ADMIN_USER_IDS",
+            severity=Severity.skip,
+            message="config 로드 실패로 건너뜀",
+        )
+    ids = cfg.admin_ids()
+    raw = cfg.admin_user_ids.strip()
+    if not raw:
+        return Check(
+            name="TELEGRAM_ADMIN_USER_IDS",
+            severity=Severity.warn,
+            message="admin 이 비어 있어 바인딩 명령 권한이 누구에게나 열립니다.",
+            hint="Telegram 에서 @userinfobot 으로 본인 user ID 확인 후 쉼표로 구분해 기록",
+        )
+    # 파싱 손실 감지 — CSV 에 숫자 아닌 토큰이 섞인 경우
+    tokens = [t.strip() for t in raw.split(",") if t.strip()]
+    parsed_count = len(ids)
+    if parsed_count < len(tokens):
+        return Check(
+            name="TELEGRAM_ADMIN_USER_IDS",
+            severity=Severity.warn,
+            detail=f"{parsed_count}/{len(tokens)} parsed",
+            message="일부 항목이 숫자가 아니라 무시되었습니다.",
+            hint="Telegram user ID 는 양의 정수. 공백과 쉼표 이외의 문자를 제거",
+        )
+    return Check(
+        name="TELEGRAM_ADMIN_USER_IDS",
+        severity=Severity.ok,
+        detail=f"{parsed_count} admin(s)",
+        message="",
+    )
 
+
+async def _gate_get(path: str) -> tuple[str, httpx.Response | str]:
     cfg = _config_or_none()
     if cfg is None:
         return ("", "config load failed")
@@ -230,6 +249,68 @@ async def check_gate_reachable() -> Check:
     return Check(name="gate reachable", severity=Severity.ok, detail=f"{url} → {res.status_code}", message="")
 
 
+async def check_telegram_api_reachable() -> Check:
+    """Telegram 은 자체 API 로 토큰 유효성을 getMe 로 확인할 수 있다."""
+
+    raw = os.getenv("TELEGRAM_BOT_TOKEN", "").strip()
+    if not raw or not _TG_TOKEN_RE.match(raw):
+        return Check(
+            name="Telegram API getMe",
+            severity=Severity.skip,
+            message="토큰이 없거나 형식 오류로 API 호출 생략",
+        )
+    url = f"https://api.telegram.org/bot{raw}/getMe"
+    try:
+        async with httpx.AsyncClient(timeout=NETWORK_TIMEOUT_SEC) as client:
+            res = await client.get(url)
+    except httpx.HTTPError as exc:
+        return Check(
+            name="Telegram API getMe",
+            severity=Severity.warn,
+            detail="api.telegram.org",
+            message=f"연결 실패: {exc}",
+            hint="네트워크 / 방화벽 / VPN 상태 확인",
+        )
+    if res.status_code == 401:
+        return Check(
+            name="Telegram API getMe",
+            severity=Severity.error,
+            detail="401",
+            message="Telegram 이 토큰을 거절했습니다. 만료/재발급/오타 의심.",
+            hint="BotFather /revoke 후 새 토큰 발급",
+        )
+    if res.status_code >= 400:
+        return Check(
+            name="Telegram API getMe",
+            severity=Severity.warn,
+            detail=str(res.status_code),
+            message="Telegram API 가 비정상 응답을 반환했습니다.",
+        )
+    try:
+        body = res.json()
+    except ValueError:
+        return Check(
+            name="Telegram API getMe",
+            severity=Severity.warn,
+            message="getMe 응답을 파싱할 수 없습니다.",
+        )
+    if not isinstance(body, dict) or not body.get("ok"):
+        return Check(
+            name="Telegram API getMe",
+            severity=Severity.warn,
+            message="getMe ok=false",
+            detail=str(body),
+        )
+    result = body.get("result") if isinstance(body, dict) else None
+    username = result.get("username") if isinstance(result, dict) else None
+    return Check(
+        name="Telegram API getMe",
+        severity=Severity.ok,
+        detail=f"@{username}" if username else "ok",
+        message="",
+    )
+
+
 async def check_default_keeper_exists() -> Check:
     cfg = _config_or_none()
     if cfg is None:
@@ -246,7 +327,7 @@ async def check_default_keeper_exists() -> Check:
         return Check(
             name="default_keeper exists",
             severity=Severity.warn,
-            detail=f"{res.status_code}",
+            detail=str(res.status_code),
             message="keepers 엔드포인트 오류 응답. 토큰/권한 확인.",
         )
     try:
@@ -263,7 +344,7 @@ async def check_default_keeper_exists() -> Check:
             name="default_keeper exists",
             severity=Severity.error,
             detail=cfg.default_keeper,
-            message=f"SLACK_DEFAULT_KEEPER='{cfg.default_keeper}' 가 서버에 등록돼 있지 않습니다.",
+            message=f"TELEGRAM_DEFAULT_KEEPER='{cfg.default_keeper}' 가 서버에 등록돼 있지 않습니다.",
             hint="config/keepers/*.toml 또는 runtime 등록 확인",
         )
     return Check(
@@ -337,7 +418,7 @@ async def check_binding_paths_writable() -> Check:
             try:
                 p.chmod(0o755)
             except OSError as exc:
-                print(f"[doctor] chmod 0755 {p} failed: {exc.strerror or exc}", file=sys.stderr)
+                print(f"[diagnostics] chmod 0755 {p} failed: {exc.strerror or exc}", file=sys.stderr)
 
     return Check(
         name="binding paths writable",

--- a/test/test_disk_hygiene_script.ml
+++ b/test/test_disk_hygiene_script.ml
@@ -330,8 +330,8 @@ let read_makefile_surface () =
 
 let test_makefile_exposes_disk_hygiene_targets () =
   let makefile = read_makefile_surface () in
-  check bool "doctor target exists" true
-    (contains_substring makefile "doctor-disk-hygiene:");
+  check bool "diagnostics target exists" true
+    (contains_substring makefile "diagnostics-disk-hygiene:");
   check bool "safe fix target exists" true
     (contains_substring makefile "fix-disk-hygiene:");
   check bool "hard fix target exists" true


### PR DESCRIPTION
## Summary
- rename sidecar doctor modules/classes/subcommands to diagnostics
- rename Make targets and script references from doctor-* to diagnostics-*
- remove stale doctor allowlist/comment/config wording from core code and scripts

## Evidence
- rg scan for Runtime_catalog, Cascade_catalog_runtime, cascade.toml, Log.Cascade, module Cascade, cascade_name, masc_cascade, cascade, Cascade, doctor, Doctor across lib/bin/test/scripts/mk/Makefile/sidecars/dashboard returned no matches in code scope.
- find scan for *cascade*, *Cascade*, *doctor*, *Doctor* under lib/bin/test/scripts/mk/sidecars/dashboard returned no matches.

## Validation
- Attempted: scripts/dune-local.sh build
- Blocked: wrapper refused because unrelated bare Dune processes are running: dune build --root ., dune build @check --root .
