### PR TITLE
Fix cascade purge guard fallout

### DIFF
--- a/lib/keeper/keeper_internal_error.mli
+++ b/lib/keeper/keeper_internal_error.mli
@@ -1,0 +1,127 @@
+(** Structured keeper-internal error envelopes carried through
+    [Agent_sdk.Error.Internal]. *)
+
+type provider_rejection = {
+  provider_label : string;
+  reason : string;
+}
+
+type capacity_backpressure_source =
+  | Provider_capacity
+  | Client_capacity
+  | Runtime_slot
+
+val capacity_backpressure_source_to_string :
+  capacity_backpressure_source -> string
+
+val capacity_backpressure_source_of_string :
+  string -> capacity_backpressure_source option
+
+type retry_admission_denial =
+  | Retry_budget_below_min of {
+      projected_usable_budget_s : float;
+      min_required_s : float;
+      remaining_turn_budget_s : float;
+      adaptive_timeout_s : float;
+      allow_wall_clock_retry_budget : bool;
+    }
+  | First_attempt_budget_below_min of {
+      projected_usable_budget_s : float;
+      min_required_s : float;
+      remaining_turn_budget_s : float;
+    }
+
+val retry_admission_denial_to_yojson :
+  retry_admission_denial -> Yojson.Safe.t
+
+type capacity_retry_after =
+  | Explicit of float
+  | Synthetic_default of float
+  | No_retry_hint
+
+type masc_internal_error =
+  | Runtime_exhausted of {
+      runtime_id : string;
+      reason : Keeper_meta_contract.runtime_exhaustion_reason;
+    }
+  | Capacity_backpressure of {
+      runtime_id : string;
+      source : capacity_backpressure_source;
+      detail : string;
+      retry_after : capacity_retry_after;
+    }
+  | Resumable_cli_session of {
+      runtime_id : string;
+      detail : string;
+      exit_code : int option;
+    }
+  | Accept_rejected of {
+      scope : string;
+      model : string option;
+      reason : string;
+    }
+  | Admission_queue_timeout of {
+      keeper_name : string;
+      runtime_id : string;
+      wait_sec : float;
+    }
+  | Admission_queue_rejected of {
+      keeper_name : string;
+      reason : string;
+    }
+  | Turn_timeout of { elapsed_sec : float }
+  | Provider_timeout of {
+      budget_sec : float;
+      keeper_turn_timeout_sec : float;
+      estimated_input_tokens : int;
+      source : string;
+      remaining_turn_budget_sec : float option;
+      min_required_sec : float;
+      phase : string;
+    }
+  | Max_tokens_ceiling_violation of {
+      runtime_id : string;
+      requested_max_tokens : int;
+      provider_ceiling : int;
+      reason : string;
+    }
+  | Ambiguous_post_commit of {
+      is_timeout : bool;
+      tools : string list;
+      original_error : string;
+    }
+  | Retry_admission_denied of {
+      denial_reason : retry_admission_denial;
+      is_retry : bool;
+    }
+  | Internal_unhandled_exception of {
+      site : string;
+      exn_repr : string;
+    }
+  | Internal_bridge_exception of {
+      caller : string;
+      exn_repr : string;
+    }
+  | Internal_contract_rejected of { reason : string }
+
+val masc_internal_error_prefix : string
+
+val masc_internal_error_to_json : masc_internal_error -> Yojson.Safe.t
+
+val summary_of_masc_internal_error : masc_internal_error -> string option
+
+val kind_of_masc_internal_error : masc_internal_error -> string
+
+val runtime_id_of_masc_internal_error : masc_internal_error -> string
+
+val sdk_error_of_masc_internal_error :
+  masc_internal_error -> Agent_sdk.Error.sdk_error
+
+val parse_masc_internal_error_json :
+  Yojson.Safe.t -> masc_internal_error option
+
+val classify_masc_internal_error_of_string :
+  string -> masc_internal_error option
+
+val classify_masc_internal_error :
+  Agent_sdk.Error.sdk_error -> masc_internal_error option

--- a/lib/runtime/runtime_attempt_fsm.mli
+++ b/lib/runtime/runtime_attempt_fsm.mli
@@ -1,0 +1,43 @@
+(** Pure decision logic for trying provider candidates in order. *)
+
+type provider_outcome =
+  | Call_ok of Llm_provider.Types.api_response
+  | Call_err of Llm_provider.Http_client.http_error
+  | Accept_rejected of {
+      response : Llm_provider.Types.api_response;
+      reason : string;
+    }
+
+type decision =
+  | Accept of Llm_provider.Types.api_response
+  | Accept_on_exhaustion of {
+      response : Llm_provider.Types.api_response;
+      reason : string;
+    }
+  | Try_next of { last_err : Llm_provider.Http_client.http_error option }
+  | Exhausted of { last_err : Llm_provider.Http_client.http_error option }
+
+val should_try_next : Llm_provider.Http_client.http_error -> bool
+
+val decide :
+  accept_on_exhaustion:bool ->
+  is_last:bool ->
+  provider_outcome ->
+  decision
+
+val decide_and_record :
+  runtime_id:string ->
+  accept_on_exhaustion:bool ->
+  is_last:bool ->
+  provider_outcome ->
+  decision
+
+val to_user_message : Llm_provider.Http_client.http_error option -> string
+
+val format_exhausted_error :
+  Llm_provider.Http_client.http_error option ->
+  Llm_provider.Http_client.http_error
+
+val provider_outcome_to_string : provider_outcome -> string
+
+val provider_outcome_option_to_string : provider_outcome option -> string

--- a/specs/keeper-state-machine/KeeperCoreTriad.tla
+++ b/specs/keeper-state-machine/KeeperCoreTriad.tla
@@ -18,8 +18,8 @@
 \* Bug model: BugSelectRuntime removes phase-aware routing, reproducing
 \* the Groq max_tokens ceiling violation (masc-mcp#6686).
 \*
-\* Mirrors: lib/keeper/keeper_runtime_routing.ml (SelectRuntime action)
-\*          lib/runtime_inference.ml (CapabilityGate action)
+\* Mirrors: lib/keeper/keeper_turn_driver_try_runtime.ml (SelectRuntime action)
+\*          lib/runtime/runtime_inference.ml (CapabilityGate action)
 \*          lib/keeper/keeper_unified_turn.ml (turn lifecycle)
 \*
 \* OCaml mapping:
@@ -34,7 +34,7 @@
 \*                          Comment A for the canonical 13->7 mapping
 \*                          (referred to as "Terminal" shorthand earlier in
 \*                          some prose; the projection symbol is "Stable").)
-\*   effective_runtime  <-> Keeper_runtime_routing.select_runtime result
+\*   effective_runtime  <-> Keeper_turn_driver_try_runtime.run selected candidate
 \*   provider_ceiling   <-> Oas_model_resolve.resolve_max_runtime_context
 \*   requested_max_tokens <-> Runtime_inference.resolve_max_tokens
 \*
@@ -229,8 +229,8 @@ OverflowedBecomeCompacting ==
                    retry_count, turn_outcome>>
 
 \* ── Turn Lifecycle: Select Runtime ───────────────────────
-\* Mirrors: Keeper_runtime_routing.select_runtime
-\* Pure function: phase -> effective runtime profile.
+\* Mirrors: Keeper_turn_driver_try_runtime.run candidate selection
+\* Pure abstraction: phase -> effective runtime role.
 
 SelectRuntime ==
     /\ turn_status = "idle"
@@ -383,36 +383,22 @@ Spec == Init /\ [][Next]_vars /\ WF_vars(Next)
 \* The string literals "none", "local_recovery", and "local_only" used below
 \* are SPEC-LEVEL CANONICAL ROLE NAMES, not literal OCaml return values.
 \*
-\* On the OCaml side (`lib/keeper/keeper_runtime_routing.ml` +
-\* `lib/runtime/runtime_routes.ml`), runtime names are resolved through a
-\* typed `logical_use` enum (`Phase_recovery`, `Phase_buffer`) and a
-\* prioritised resolution chain in `runtime_id_for_use`:
-\*   (a) operator-supplied `routes.<key>` binding, if its target exists
-\*       in the live catalog;
-\*   (b) first catalog entry name (the boot-time default profile);
-\*   (c) `route_spec.aliases` first element, or the route key — *only*
-\*       when the catalog is empty (a state boot validation rejects).
-\* The literal string produced at runtime depends on operator catalog and
-\* routes (RFC-0058 declarative route mapping); only the *default empty
-\* catalog* boot path produces the literal strings written below.
-\*
-\* The invariants below are written as TLA+ string equalities, but those
-\* literals should be read as canonical *role identifiers* — they stand
-\* in for the typed `logical_use` role that production resolves through
-\* the chain above:
+\* On the OCaml side, runtime ids are already resolved before
+\* `Keeper_turn_driver_try_runtime.run` walks the candidate list.  The
+\* literal strings below are therefore canonical *role identifiers* for
+\* the spec, not production return values:
 \*   - "none"           ↔ "no runtime is active for this turn"
-\*   - "local_recovery" ↔ `Phase_recovery` role
-\*   - "local_only"     ↔ `Phase_buffer` role
-\* TLC still compares strings; the *semantic* claim is role identity.
+\*   - "local_recovery" ↔ recovery runtime role
+\*   - "local_only"     ↔ buffer-operation runtime role
+\* TLC still compares strings; the semantic claim is role identity.
 \* See `docs/tla-audit/kct-c3-terminal-runtime-contract-gap-2026-05-12.md`
 \* and `docs/tla-audit/kct-s2s3-failing-buffer-runtime-alignment-2026-05-12.md`
 \* (the latter lands via PR #14787) for the production indirection
 \* analysis.
 
 \* S1: Terminal phase never has an active runtime.
-\* OCaml note: `select_runtime` returns `base_runtime` for terminal phases
-\* (paper contract gap — caller graph upstream-gates the call so the value
-\* is unreachable in production).  See C-3 audit memo above.
+\* OCaml note: runtime attempts are upstream-gated for terminal phases, so
+\* the spec-level empty role has no literal production counterpart.
 NoTerminalRuntime ==
     phase = "Terminal" => effective_runtime = "none"
 
@@ -420,18 +406,14 @@ NoTerminalRuntime ==
 \* Note: if a keeper transitions to Failing MID-TURN, the already-selected
 \* runtime remains — runtime is chosen at turn start, not re-evaluated.
 \* This invariant checks the selection action, not the runtime state.
-\* OCaml: `Failing -> Keeper_config.local_recovery_runtime_id`, which
-\* resolves through `Phase_recovery` route — string match only in the
-\* default catalog.  See S2/S3 audit memo above.
+\* OCaml: failing-turn recovery uses the resolved recovery runtime id.
 FailingUsesRecovery ==
     (phase = "Failing" /\ turn_status = "selecting"
      /\ effective_runtime /= "none") =>
         effective_runtime = "local_recovery"
 
 \* S3 (buffer): Runtime selection in buffer-operation phases must yield
-\* the Phase_buffer role.  OCaml:
-\* `Compacting | HandingOff -> Keeper_config.local_only_runtime_id`,
-\* which resolves through `Phase_buffer` route.  See S2/S3 audit memo.
+\* the buffer-operation role.
 BufferOpsUseLocalOnly ==
     (phase \in {"Compacting", "HandingOff"} /\ turn_status = "selecting"
      /\ effective_runtime /= "none") =>
@@ -454,15 +436,13 @@ SideEffectContainment ==
 \* Runtime-name abstraction: `"none"` here is the SPEC-LEVEL EMPTY-ROLE
 \* SENTINEL — it asserts "no runtime is selected", not a literal string
 \* match against an OCaml return value.  The OCaml side has no literal
-\* "none" — `select_runtime` always returns a real runtime name (even for
-\* terminal phases — see `docs/tla-audit/kct-c3-terminal-runtime-contract
-\* -gap-2026-05-12.md`); the empty-role assertion is preserved
-\* STRUCTURALLY by the caller graph upstream gating the call for non-
-\* active turn_status values.
+\* "none"; the empty-role assertion is preserved structurally by the
+\* caller graph upstream gating runtime attempts for non-active
+\* turn_status values.
 \*
-\* The invariant therefore captures a structural property: the dispatch
-\* table in `lib/keeper/keeper_runtime_routing.ml` returns a non-empty
-\* runtime name for all phases that can co-occur with
+\* The invariant therefore captures a structural property: candidate
+\* selection in `lib/keeper/keeper_turn_driver_try_runtime.ml` uses a
+\* non-empty runtime id for all phases that can co-occur with
 \* turn_status in {selecting, executing, retrying}, namely
 \* {Running, Failing, Compacting, HandingOff}.
 PhaseDecisionConsistency ==


### PR DESCRIPTION
## Summary
- add missing OCaml interfaces for keeper internal errors and runtime attempt FSM
- update KeeperCoreTriad Mirrors annotations away from deleted runtime routing paths
- keep repo-wide cascade string grep at zero

## Validation
- `scripts/ocaml-structure-ratchet.sh`
- `bash scripts/check-spec-truth.sh`
- `ocamlformat --check lib/keeper/keeper_internal_error.mli lib/runtime/runtime_attempt_fsm.mli`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build @check`
- `rg -n -i "cascade|캐스케이드|카스케이드" --glob '!_build/**' --glob '!node_modules/**'` (no matches)