### PR TITLE
Remove keeper and gate legacy fallback surfaces

### DIFF
--- a/lib/gate/gate_protocol.mli
+++ b/lib/gate/gate_protocol.mli
@@ -28,7 +28,7 @@ type inbound_message = {
 (** Turn-level statistics from the keeper. *)
 type turn_stats = {
   model_used : string;
-      (** Legacy in-memory compatibility slot. Public JSON redacts this field;
+      (** Internal in-memory model slot. Public JSON redacts this field;
           callers should use duration/token metrics, not provider/model
           identity. *)
   duration_ms : int;

--- a/lib/keeper/agent_tool_persona_runtime.ml
+++ b/lib/keeper/agent_tool_persona_runtime.ml
@@ -329,7 +329,7 @@ let resolved_keeper_args_from_persona args :
   if not (validate_name persona_name) then
     Error "persona_name is required"
   else
-    match Keeper_meta_contract.reject_legacy_model_args ~tool_name:"masc_keeper_create_from_persona" args with
+    match Keeper_meta_contract.reject_removed_model_args ~tool_name:"masc_keeper_create_from_persona" args with
     | Error err -> Error err
     | Ok () ->
     match reject_removed_keeper_input_keys

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -160,7 +160,7 @@ type blocker_class =
         cohort during a fleet stall (observed: 6/14 keepers in
         cohort=stale_turn_timeout). *)
   | Stale_fleet_batch
-    (** Legacy blocker class for pre-existing fleet-batch state. Current
+    (** Retired blocker class for pre-existing fleet-batch state. Current
         fleet-batch detection is observation-only and should not stamp keeper
         meta; stale keepers use their per-keeper watchdog blocker instead. *)
   | Oas_agent_execution_timeout
@@ -442,7 +442,7 @@ let runtime_attempt_outcome_of_json = function
      | Some (`String "failure") ->
        (match List.assoc_opt "message" fields with
         | Some (`String message) -> Some (`Failure message)
-        (* DET-OK: legacy attempt rows encoded failure without a message;
+        (* DET-OK: retired attempt rows encoded failure without a message;
            keep the lossy historical record instead of dropping it. *)
         | _ -> Some (`Failure ""))
      | _ -> None)
@@ -720,11 +720,11 @@ let map_proactive_rt (f : proactive_runtime -> proactive_runtime) (m : keeper_me
   { m with runtime = { m.runtime with proactive_rt = f m.runtime.proactive_rt } }
 ;;
 
-let keeper_legacy_model_arg_names = [ "models"; "allowed_models"; "active_model" ]
+let removed_keeper_model_arg_names = [ "models"; "allowed_models"; "active_model" ]
 
-let reject_legacy_model_args ~tool_name (args : Yojson.Safe.t) =
+let reject_removed_model_args ~tool_name (args : Yojson.Safe.t) =
   let present =
-    keeper_legacy_model_arg_names
+    removed_keeper_model_arg_names
     |> List.filter (fun key ->
       match Json_util.assoc_member_opt key args with
       | Some `Null -> false
@@ -735,7 +735,7 @@ let reject_legacy_model_args ~tool_name (args : Yojson.Safe.t) =
   | fields ->
     Error
       (Printf.sprintf
-         "legacy keeper model args removed for %s: %s. Use runtime_id; concrete \
+         "removed keeper model args for %s: %s. Use runtime_id; concrete \
           provider/model identity is resolved from the default runtime."
          tool_name
          (String.concat ", " fields))

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -16,9 +16,7 @@
     only by JSON parsing), \[map_compaction_rt] /
     \[map_proactive_rt]
     (nested-record updaters that callers reach via the higher-level
-    {!map_runtime} / {!map_usage}), \[keeper_legacy_model_arg_names]
-    (data table consumed by the legacy-arg rejector in
-    {!Keeper_types}).  All consumed only via the include
+    {!map_runtime} / {!map_usage}).  All consumed only via the include
     runtime or the JSON pipeline. *)
 
 (** {1 Tool-access runtime re-export} *)
@@ -383,12 +381,6 @@ val runtime_id_of_meta : keeper_meta -> string
     Ignores [m] because keeper-level provider/model selection has been
     collapsed to the single default Runtime binding. *)
 
-(** {1 Legacy runtime compatibility} *)
-
-val runtime_id_of_meta : keeper_meta -> string
-(** Compatibility alias for {!runtime_id_of_meta}.
-    Kept while older JSON fields and call sites still use [runtime_id]. *)
-
 (** {1 Outcome <-> string} *)
 
 val proactive_cycle_outcome_to_string :
@@ -447,19 +439,19 @@ val map_proactive_rt :
   keeper_meta
 (** Nested update of [m.runtime.proactive_rt]. *)
 
-(** {1 Legacy model-arg sentinel list} *)
+(** {1 Removed model-arg sentinel list} *)
 
-val keeper_legacy_model_arg_names : string list
-(** Names of legacy keeper-creation tool arguments that have
+val removed_keeper_model_arg_names : string list
+(** Names of removed keeper-creation tool arguments that have
     been retired in favour of the [runtime_id] field
     (["models"], ["allowed_models"], ["active_model"]).
-    Consumed by {!reject_legacy_model_args} which
+    Consumed by {!reject_removed_model_args} which
     surfaces operator-readable rejection messages instead of
-    silently ignoring deprecated args.  Pinned data table —
-    drift would either re-accept retired args silently or
+    silently ignoring removed args.  Pinned data table —
+    drift would either re-accept removed args silently or
     reject newly added args by mistake. *)
 
-val reject_legacy_model_args :
+val reject_removed_model_args :
   tool_name:string -> Yojson.Safe.t -> (unit, string) result
 (** Reject retired keeper model-selection input fields at tool/API boundaries.
     Model and provider identity is resolved from the default Runtime binding,

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -119,28 +119,8 @@ let parse_keeper_identity (json : Yojson.Safe.t) : (parsed_keeper_identity, stri
     let pk_desires = personality.desires in
     let pk_instructions = personality.instructions in
     let pk_runtime_id_result =
-      (* RFC-0206: [runtime_id] is the canonical persisted/input name if a
-         pre-scrub JSON payload still carries model-selection state.
-         [runtime_id] is accepted only as a legacy alias for older files.
-         If both appear with different non-empty values, fail loud instead of
-         silently choosing one model-selection identity. *)
-      let runtime_id_opt =
-        Safe_ops.json_string_opt "runtime_id" json |> Option.map String.trim
-      in
-      let legacy_runtime_id_opt =
-        Safe_ops.json_string_opt "runtime_id" json |> Option.map String.trim
-      in
-      match runtime_id_opt, legacy_runtime_id_opt with
-      | Some runtime_id, Some legacy_runtime_id
-        when runtime_id <> "" && legacy_runtime_id <> ""
-             && runtime_id <> legacy_runtime_id ->
-        Error
-          (Printf.sprintf
-             "keeper meta parse error: runtime_id (%s) and legacy runtime_id (%s) \
-              disagree"
-             runtime_id legacy_runtime_id)
-      | Some runtime_id, _ when runtime_id <> "" -> Ok runtime_id
-      | _, Some legacy_runtime_id when legacy_runtime_id <> "" -> Ok legacy_runtime_id
+      match Safe_ops.json_string_opt "runtime_id" json |> Option.map String.trim with
+      | Some runtime_id when runtime_id <> "" -> Ok runtime_id
       | _ -> Ok (Keeper_config.default_runtime_id ())
     in
     (match pk_runtime_id_result with
@@ -560,13 +540,13 @@ let parse_keeper_state
   }
 ;;
 
-let reject_legacy_keeper_meta_shapes (json : Yojson.Safe.t) =
+let reject_removed_keeper_meta_shapes (json : Yojson.Safe.t) =
   match json with
   | `Assoc fields ->
     (match List.assoc_opt "last_blocker" fields with
      | Some (`String _) ->
        Error
-         "legacy keeper meta field shape is no longer supported: \
+         "removed keeper meta field shape is no longer supported: \
           last_blocker:string. Use structured last_blocker object."
      | Some _ | None -> Ok ())
   | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ -> Ok ()
@@ -577,10 +557,10 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
     match reject_removed_keeper_meta_fields json with
     | Error e -> Error e
     | Ok () ->
-      (match reject_legacy_keeper_meta_fields json with
+      (match reject_strict_keeper_meta_fields json with
        | Error e -> Error e
        | Ok () ->
-         (match reject_legacy_keeper_meta_shapes json with
+         (match reject_removed_keeper_meta_shapes json with
           | Error e -> Error e
           | Ok () ->
          (match parse_keeper_identity json with

--- a/lib/keeper/keeper_meta_json_scrub.ml
+++ b/lib/keeper/keeper_meta_json_scrub.ml
@@ -46,13 +46,13 @@ let reject_removed_keeper_meta_fields (json : Yojson.Safe.t) =
     Error (Printf.sprintf "removed keeper meta fields: %s" (String.concat ", " fields))
 ;;
 
-let legacy_keeper_meta_tool_policy_key_names =
+let rejected_keeper_meta_tool_policy_key_names =
   [ "tool_preset"; "tool_preset_source"; "tool_also_allow"; "tool_custom_allowlist"; "tool_allowlist" ]
 ;;
 
-let legacy_keeper_meta_key_names =
+let strict_rejected_keeper_meta_key_names =
   [ "allowed_providers"; "last_blocker_class"; "repo_cli_identity" ]
-  @ legacy_keeper_meta_tool_policy_key_names
+  @ rejected_keeper_meta_tool_policy_key_names
 ;;
 
 let persisted_retired_keeper_meta_key_names =
@@ -68,14 +68,14 @@ let persisted_retired_keeper_meta_key_names =
   ]
 ;;
 
-let reject_legacy_keeper_meta_fields (json : Yojson.Safe.t) =
-  let present = Keeper_config_text.present_json_keys legacy_keeper_meta_key_names json in
+let reject_strict_keeper_meta_fields (json : Yojson.Safe.t) =
+  let present = Keeper_config_text.present_json_keys strict_rejected_keeper_meta_key_names json in
   match present with
   | [] -> Ok ()
   | fields ->
     Error
       (Printf.sprintf
-         "legacy keeper meta fields are no longer supported: %s"
+         "removed keeper meta fields are no longer supported: %s"
          (String.concat ", " fields))
 ;;
 
@@ -95,7 +95,7 @@ let scrub_persisted_keeper_meta_json ~path (json : Yojson.Safe.t) : Yojson.Safe.
     let removed_to_scrub =
       removed_present
       |> List.filter (fun key ->
-        (not (List.mem key legacy_keeper_meta_key_names))
+        (not (List.mem key strict_rejected_keeper_meta_key_names))
         || List.mem key persisted_retired_keeper_meta_key_names)
     in
     if removed_to_scrub = []
@@ -119,7 +119,7 @@ let scrub_persisted_keeper_meta_json ~path (json : Yojson.Safe.t) : Yojson.Safe.
       (try
          Fs_compat.save_file path content;
          Log.Keeper.info
-           "scrubbed legacy keeper meta fields for %s: %s%s"
+           "scrubbed removed keeper meta fields for %s: %s%s"
            path
            (String.concat ", " removed_to_scrub)
            (if migrate_legacy_disabled_keepalive

--- a/lib/keeper/keeper_meta_json_scrub.mli
+++ b/lib/keeper/keeper_meta_json_scrub.mli
@@ -18,23 +18,23 @@ val drop_assoc_keys : string list -> Yojson.Safe.t -> Yojson.Safe.t
 val reject_removed_keeper_meta_fields :
   Yojson.Safe.t -> (unit, string) result
 
-(** Legacy tool-policy keys that are no longer supported. *)
-val legacy_keeper_meta_tool_policy_key_names : string list
+(** Removed tool-policy keys that are no longer supported. *)
+val rejected_keeper_meta_tool_policy_key_names : string list
 
-(** Combined legacy key names that remain rejected by strict runtime
+(** Combined removed key names that remain rejected by strict runtime
     meta decoding. *)
-val legacy_keeper_meta_key_names : string list
+val strict_rejected_keeper_meta_key_names : string list
 
-(** Returns [Error msg] if any legacy key is present. *)
-val reject_legacy_keeper_meta_fields :
+(** Returns [Error msg] if any strictly rejected key is present. *)
+val reject_strict_keeper_meta_fields :
   Yojson.Safe.t -> (unit, string) result
 
 (** [scrub_persisted_keeper_meta_json ~path json] migrates persisted
     keeper meta to the current schema for removed non-tool fields and
     stale persisted-only runtime fields (including
     presence_keepalive=false→paused=true) and writes the scrubbed
-    content back to [path] when changes were needed. Legacy tool policy
-    fields and other strict legacy fields are intentionally not
+    content back to [path] when changes were needed. Removed tool policy
+    fields and other strict removed fields are intentionally not
     rewritten. Returns the scrubbed JSON and a [bool] indicating whether
     the file was rewritten. *)
 val scrub_persisted_keeper_meta_json :

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -129,7 +129,7 @@ let preflight_keeper_msg ctx args : (unit, string) result =
     match keeper_msg_timeout_override args with
     | Error e -> Error e
     | Ok _ ->
-    (match Keeper_meta_contract.reject_legacy_model_args ~tool_name:"masc_keeper_msg" args with
+    (match Keeper_meta_contract.reject_removed_model_args ~tool_name:"masc_keeper_msg" args with
     | Error e -> Error e
     | Ok () ->
     (match reject_removed_keeper_input_keys ~tool_name:"masc_keeper_msg" args with
@@ -192,7 +192,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
     (match keeper_msg_timeout_override args with
     | Error e -> tool_result_error e
     | Ok keeper_msg_oas_timeout_s ->
-    (match Keeper_meta_contract.reject_legacy_model_args ~tool_name:"masc_keeper_msg" args with
+    (match Keeper_meta_contract.reject_removed_model_args ~tool_name:"masc_keeper_msg" args with
     | Error e -> tool_result_error ("" ^ e)
     | Ok () ->
     (match reject_removed_keeper_input_keys ~tool_name:"masc_keeper_msg" args with

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -128,30 +128,18 @@ let parse_runtime_id_field_opt args key =
             Error (Printf.sprintf "invalid %s '%s': %s" key raw detail)
 
 let parse_runtime_id_opt args =
-  match
-    parse_runtime_id_field_opt args "runtime_id",
-    parse_runtime_id_field_opt args "runtime_id"
-  with
-  | Error msg, _ | _, Error msg -> Error msg
-  | Ok (Some runtime_id), Ok (Some legacy_runtime_id)
-    when runtime_id <> legacy_runtime_id ->
-      Error
-        (Printf.sprintf
-           "runtime_id (%s) and legacy runtime_id (%s) must match"
-           runtime_id legacy_runtime_id)
-  | Ok (Some runtime_id), _ -> Ok (Some runtime_id)
-  | Ok None, Ok legacy_runtime_id_opt -> Ok legacy_runtime_id_opt
+  parse_runtime_id_field_opt args "runtime_id"
 
 let resolve_tool_name_list ~preferred ~fallback =
   Dashboard_utils.first_some preferred fallback
   |> Option.value ~default:[]
   |> normalize_tool_name_list
 
-let reject_legacy_tool_access_kind access_json =
+let reject_removed_tool_access_kind access_json =
   match Json_util.assoc_member_opt "kind" access_json with
   | Some (`String ("restricted" | "unrestricted")) ->
       Error
-        "tool_access.kind must be \"preset\" or \"custom\"; legacy kinds \"restricted\" and \"unrestricted\" are not supported for this endpoint"
+        "tool_access.kind must be \"preset\" or \"custom\"; removed kinds \"restricted\" and \"unrestricted\" are not supported for this endpoint"
   | _ -> Ok ()
 
 let parse_tool_access_input (args : Yojson.Safe.t) :
@@ -169,7 +157,7 @@ let parse_tool_access_input (args : Yojson.Safe.t) :
   else
     match Json_util.assoc_member_opt "tool_access" args with
     | Some ((`Assoc _) as access_json) -> (
-        match reject_legacy_tool_access_kind access_json with
+        match reject_removed_tool_access_kind access_json with
         | Error msg -> Error msg
         | Ok () -> (
             match tool_access_of_meta_json (`Assoc [ ("tool_access", access_json) ]) with
@@ -187,7 +175,7 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) 
   if not (validate_name name) then
     Error (tool_result_error "invalid keeper name (allowed: [A-Za-z0-9._-])")
   else
-    match Keeper_meta_contract.reject_legacy_model_args ~tool_name:"masc_keeper_up" args with
+    match Keeper_meta_contract.reject_removed_model_args ~tool_name:"masc_keeper_up" args with
     | Error e -> Error (tool_result_error e)
     | Ok () ->
     match reject_removed_keeper_input_keys ~tool_name:"masc_keeper_up" args with

--- a/lib/keeper/keeper_turn_up_args.mli
+++ b/lib/keeper/keeper_turn_up_args.mli
@@ -78,14 +78,14 @@ val parse_enum_string_opt :
 val resolve_tool_name_list :
   preferred:string list option -> fallback:string list option -> string list
 
-(** Reject legacy [tool_access.kind = "restricted" | "unrestricted"]
+(** Reject removed [tool_access.kind = "restricted" | "unrestricted"]
     payloads — the dashboard endpoint only accepts [preset] or
     [custom]. *)
-val reject_legacy_tool_access_kind :
+val reject_removed_tool_access_kind :
   Yojson.Safe.t -> (unit, string) result
 
 (** Parse the canonical [tool_access] field.
-    Legacy top-level tool-policy args are rejected. *)
+    Removed top-level tool-policy args are rejected. *)
 val parse_tool_access_input :
   Yojson.Safe.t ->
   (string list option, string) result

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -148,7 +148,7 @@ let parse_keeper_chat_stream_request body_str =
           "channel, channel_user_id, and channel_room_id are required when connector context is supplied"
       else
         match
-          Keeper_meta_contract.reject_legacy_model_args ~tool_name:"masc_keeper_msg" json
+          Keeper_meta_contract.reject_removed_model_args ~tool_name:"masc_keeper_msg" json
         with
         | Error err -> Error err
         | Ok () -> (

--- a/sidecars/shared/gate_shared/gate_response.py
+++ b/sidecars/shared/gate_shared/gate_response.py
@@ -33,12 +33,7 @@ class GateResponse:
             if isinstance(raw_structured, dict)
             else None
         )
-        # Read priority for the routing identifier: prefer destination_id
-        # (introduced in B2 Phase 2) and fall back to the legacy keeper_name
-        # key so sidecars handle both old and new gate emit shapes. Pairs
-        # with gate_protocol.outbound_to_json which currently emits both.
-        destination = str(data.get("destination_id", ""))
-        keeper_name = destination if destination else str(data.get("keeper_name", ""))
+        keeper_name = str(data.get("destination_id", ""))
         return GateResponse(
             ok=bool(data.get("ok", False)),
             keeper_name=keeper_name,

--- a/sidecars/shared/tests/test_gate_response.py
+++ b/sidecars/shared/tests/test_gate_response.py
@@ -11,7 +11,7 @@ class TestFromJson:
     def test_parses_full_response(self) -> None:
         data = {
             "ok": True,
-            "keeper_name": "sangsu",
+            "destination_id": "sangsu",
             "reply": "hello world",
             "turn_stats": {
                 "model_used": "qwen3.5:35b",
@@ -31,7 +31,7 @@ class TestFromJson:
         assert resp.error == ""
 
     def test_handles_missing_turn_stats(self) -> None:
-        data = {"ok": True, "keeper_name": "test", "reply": "hi"}
+        data = {"ok": True, "destination_id": "test", "reply": "hi"}
         resp = GateResponse.from_json(data)
         assert resp.ok is True
         assert resp.model_used == ""
@@ -55,15 +55,15 @@ class TestFromJson:
         assert resp.reply == ""
         assert resp.error == ""
 
-    def test_prefers_destination_id_when_present(self) -> None:
-        data = {"ok": True, "destination_id": "new-key", "keeper_name": "legacy", "reply": "hi"}
+    def test_uses_destination_id_when_present(self) -> None:
+        data = {"ok": True, "destination_id": "new-key", "keeper_name": "old-key", "reply": "hi"}
         resp = GateResponse.from_json(data)
         assert resp.keeper_name == "new-key"
 
-    def test_falls_back_to_keeper_name_when_destination_id_missing(self) -> None:
-        data = {"ok": True, "keeper_name": "legacy-only", "reply": "hi"}
+    def test_ignores_keeper_name_when_destination_id_missing(self) -> None:
+        data = {"ok": True, "keeper_name": "old-only", "reply": "hi"}
         resp = GateResponse.from_json(data)
-        assert resp.keeper_name == "legacy-only"
+        assert resp.keeper_name == ""
 
     def test_accepts_destination_id_without_keeper_name(self) -> None:
         data = {"ok": True, "destination_id": "future-only", "reply": "hi"}

--- a/test/test_gate_protocol.ml
+++ b/test/test_gate_protocol.ml
@@ -136,7 +136,7 @@ let test_inbound_of_json_accepts_destination_id () =
   | Ok msg -> check string "destination_id maps to keeper_name" "luna" msg.keeper_name
   | Error e -> fail e
 
-let test_inbound_of_json_ignores_legacy_keeper_name_when_destination_id_present () =
+let test_inbound_of_json_ignores_noncanonical_keeper_name_when_destination_id_present () =
   let json =
     `Assoc [
       ("channel", `String "discord");
@@ -144,7 +144,7 @@ let test_inbound_of_json_ignores_legacy_keeper_name_when_destination_id_present 
       ("channel_user_name", `String "alice");
       ("channel_room_id", `String "r1");
       ("destination_id", `String "new-name");
-      ("keeper_name", `String "legacy-name");
+      ("keeper_name", `String "old-name");
       ("content", `String "hi");
       ("idempotency_key", `String "k-both");
     ]
@@ -154,26 +154,26 @@ let test_inbound_of_json_ignores_legacy_keeper_name_when_destination_id_present 
       check string "destination_id is canonical" "new-name" msg.keeper_name
   | Error e -> fail e
 
-let test_inbound_of_json_rejects_legacy_keeper_name_only () =
+let test_inbound_of_json_rejects_keeper_name_only () =
   let json =
     `Assoc [
       ("channel", `String "discord");
       ("channel_user_id", `String "u1");
       ("channel_user_name", `String "alice");
       ("channel_room_id", `String "r1");
-      ("keeper_name", `String "legacy-only");
+      ("keeper_name", `String "old-only");
       ("content", `String "hi");
-      ("idempotency_key", `String "k-legacy");
+      ("idempotency_key", `String "k-old");
     ]
   in
   match Gate_protocol.inbound_of_json json with
   | Ok msg ->
-      check string "legacy keeper_name is not a destination" "" msg.keeper_name;
+      check string "keeper_name is not a destination" "" msg.keeper_name;
       (match
          Gate_protocol.validate ~max_content_length:4000 ~dedup_check:no_dedup msg
        with
        | Error Gate_protocol.Empty_keeper_name -> ()
-       | Ok () -> fail "legacy keeper_name-only payload should not validate"
+       | Ok () -> fail "keeper_name-only payload should not validate"
        | Error _ -> fail "expected Empty_keeper_name")
   | Error e -> fail e
 
@@ -187,7 +187,7 @@ let test_outbound_emits_destination_id () =
   let json = Gate_protocol.outbound_to_json out in
   let open Yojson.Safe.Util in
   check string "destination_id present" "luna" (json |> member "destination_id" |> to_string);
-  (* B2 Phase 3 — legacy keeper_name key is no longer emitted. *)
+  (* B2 Phase 3 — noncanonical keeper_name key is no longer emitted. *)
   (match json |> member "keeper_name" with
    | `Null -> ()
    | _ -> fail "keeper_name should no longer be emitted")
@@ -253,10 +253,10 @@ let () =
           test_case "inbound with metadata" `Quick test_inbound_of_json_with_metadata;
           test_case "inbound invalid" `Quick test_inbound_of_json_invalid;
           test_case "inbound accepts destination_id" `Quick test_inbound_of_json_accepts_destination_id;
-          test_case "destination_id ignores legacy keeper_name" `Quick
-            test_inbound_of_json_ignores_legacy_keeper_name_when_destination_id_present;
-          test_case "inbound rejects legacy keeper_name only" `Quick
-            test_inbound_of_json_rejects_legacy_keeper_name_only;
+          test_case "destination_id ignores noncanonical keeper_name" `Quick
+            test_inbound_of_json_ignores_noncanonical_keeper_name_when_destination_id_present;
+          test_case "inbound rejects keeper_name only" `Quick
+            test_inbound_of_json_rejects_keeper_name_only;
           test_case "outbound emits destination_id" `Quick test_outbound_emits_destination_id;
           test_case "outbound roundtrip" `Quick test_outbound_to_json_roundtrip;
           test_case "error_json" `Quick test_error_json;


### PR DESCRIPTION
## Summary
- stop Channel Gate sidecars from falling back from `destination_id` to the old response `keeper_name` key
- rename keeper removed-argument rejectors away from `legacy_*` surfaces while preserving fail-closed rejection for removed model/tool-policy inputs
- simplify keeper runtime-id parsing to the canonical `runtime_id` field only
- remove remaining Gate protocol test/comment wording that still described noncanonical `keeper_name` as legacy

## Evidence
- `rg -n "reject_legacy|keeper_legacy|legacy_keeper|legacy runtime_id|legacy kinds|legacy keeper meta|legacy keeper model|legacy key|legacy field|legacy keeper_name|falls back to.*keeper_name|fall back to.*keeper_name|\blegacy\b|\bLegacy\b" sidecars/shared/gate_shared/gate_response.py sidecars/shared/tests/test_gate_response.py lib/keeper/keeper_meta_contract.ml lib/keeper/keeper_meta_contract.mli lib/keeper/keeper_turn_up_args.ml lib/keeper/keeper_turn_up_args.mli lib/keeper/keeper_turn.ml lib/server/server_routes_http_keeper_stream.ml lib/keeper/agent_tool_persona_runtime.ml lib/keeper/keeper_meta_json_scrub.ml lib/keeper/keeper_meta_json_scrub.mli lib/keeper/keeper_meta_json_parse.ml` returned no matches.
- `rg -n "\blegacy\b|\bLegacy\b" lib/gate/gate_protocol.ml lib/gate/gate_protocol.mli test/test_gate_protocol.ml sidecars/shared/gate_shared/gate_response.py sidecars/shared/tests/test_gate_response.py lib/keeper/keeper_meta_contract.ml lib/keeper/keeper_meta_contract.mli lib/keeper/keeper_turn_up_args.ml lib/keeper/keeper_turn_up_args.mli lib/keeper/keeper_turn.ml lib/server/server_routes_http_keeper_stream.ml lib/keeper/agent_tool_persona_runtime.ml lib/keeper/keeper_meta_json_scrub.ml lib/keeper/keeper_meta_json_scrub.mli lib/keeper/keeper_meta_json_parse.ml` returned no matches.

## Validation
- Not run: user requested aggressive legacy removal and accepts build breakage.
