### PR TITLE
fix(keeper): reject_legacy_model_args counted absent keys as present

### DIFF
--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -726,9 +726,15 @@ let reject_legacy_model_args ~tool_name (args : Yojson.Safe.t) =
   let present =
     keeper_legacy_model_arg_names
     |> List.filter (fun key ->
+      (* A legacy arg counts as "present" only when supplied with a real value.
+         [assoc_member_opt] returns [None] for an absent key; the prior
+         [| _ -> true] arm classified that [None] as present, so a request
+         that simply omitted all three keys (e.g. the [{name}] used by base
+         autoboot materialization) was rejected as if it had passed them.
+         Absent ([None]) and explicit-null are both "not supplied". *)
       match Json_util.assoc_member_opt key args with
-      | Some `Null -> false
-      | _ -> true)
+      | None | Some `Null -> false
+      | Some _ -> true)
   in
   match present with
   | [] -> Ok ()

--- a/test/dune
+++ b/test/dune
@@ -1470,6 +1470,8 @@
 
 (include stanzas/test_keeper_meta_unknown_keys_warn.inc)
 
+(include stanzas/test_keeper_legacy_model_args_reject.inc)
+
 (include stanzas/test_keeper_semaphore_wait_queue_head_clock.inc)
 
 (include stanzas/test_keeper_meta_heartbeat_retain_9733.inc)

--- a/test/stanzas/test_keeper_legacy_model_args_reject.inc
+++ b/test/stanzas/test_keeper_legacy_model_args_reject.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_legacy_model_args_reject)
+ (modules test_keeper_legacy_model_args_reject)
+ (libraries masc_mcp alcotest))

--- a/test/test_keeper_legacy_model_args_reject.ml
+++ b/test/test_keeper_legacy_model_args_reject.ml
@@ -1,0 +1,71 @@
+(** Regression: [reject_legacy_model_args] inverted-presence bug.
+
+    [Json_util.assoc_member_opt] returns [None] for an absent key. The prior
+    [| _ -> true] arm classified that [None] as "present", so a request that
+    omitted all three legacy keys — e.g. the bare [{ "name" : ... }] that base
+    autoboot materialization passes through [masc_keeper_up] — was rejected
+    with "legacy keeper model args removed for masc_keeper_up: models,
+    allowed_models, active_model", blocking [base] from booting (observed live
+    2026-06-01 ~01:05 KST).
+
+    Behaviour contract this test pins:
+      absent OR explicit-null  -> Ok ()    (not supplied)
+      present with a value     -> Error    (legacy arg, rejected) *)
+
+open Masc_mcp
+
+let is_ok = function Ok () -> true | Error _ -> false
+
+let reject args =
+  Keeper_meta_contract.reject_legacy_model_args ~tool_name:"masc_keeper_up" args
+
+(* The exact shape keeper_runtime autoboot passes to handle_keeper_up. *)
+let test_bare_name_accepted () =
+  Alcotest.(check bool)
+    "bare {name} (no legacy model key) must be accepted — regression: base \
+     autoboot was rejected"
+    true
+    (is_ok (reject (`Assoc [ ("name", `String "base") ])))
+
+let test_empty_args_accepted () =
+  Alcotest.(check bool)
+    "empty object must be accepted"
+    true
+    (is_ok (reject (`Assoc [])))
+
+let test_explicit_null_accepted () =
+  Alcotest.(check bool)
+    "legacy keys present but explicitly null must be accepted"
+    true
+    (is_ok
+       (reject
+          (`Assoc
+            [ ("name", `String "k")
+            ; ("models", `Null)
+            ; ("allowed_models", `Null)
+            ; ("active_model", `Null)
+            ])))
+
+let test_real_value_rejected () =
+  Alcotest.(check bool)
+    "a legacy key supplied with a real value must still be rejected"
+    false
+    (is_ok (reject (`Assoc [ ("name", `String "k"); ("active_model", `String "gpt-x") ])))
+
+let test_real_list_value_rejected () =
+  Alcotest.(check bool)
+    "models supplied as a non-empty list must still be rejected"
+    false
+    (is_ok
+       (reject (`Assoc [ ("models", `List [ `String "a"; `String "b" ]) ])))
+
+let () =
+  Alcotest.run "keeper_legacy_model_args_reject"
+    [ ( "reject_legacy_model_args"
+      , [ Alcotest.test_case "bare {name} accepted" `Quick test_bare_name_accepted
+        ; Alcotest.test_case "empty args accepted" `Quick test_empty_args_accepted
+        ; Alcotest.test_case "explicit null accepted" `Quick test_explicit_null_accepted
+        ; Alcotest.test_case "real string value rejected" `Quick test_real_value_rejected
+        ; Alcotest.test_case "real list value rejected" `Quick test_real_list_value_rejected
+        ] )
+    ]


### PR DESCRIPTION
## 증상

`base` keeper가 autoboot 무한 retry 루프에 빠져 부팅 실패. 라이브 로그 (2026-06-01 ~01:05 KST):

```
[ERROR] [Keeper] autoboot: failed to load meta for base: failed to materialize
declarative keeper base from .../base.toml: legacy keeper model args removed for
masc_keeper_up: models, allowed_models, active_model. Use runtime_id; ...
```

## 근본 원인

`Keeper_meta_contract.reject_legacy_model_args`의 로직 반전 버그.

```ocaml
| Some `Null -> false
| _ -> true          (* assoc_member_opt 의 None(키 부재)도 여기 걸림 *)
```

`Json_util.assoc_member_opt`는 키 부재 시 `None`을 반환한다 (`List.assoc_opt`). 위 `| _ -> true` arm이 그 `None`을 "present"로 분류하므로, **legacy 키 3개를 모두 생략한** 요청이 거부된다. base autoboot은 `keeper_runtime.ml`의 materialize에서 bare `{ "name": "base" }`를 `masc_keeper_up`으로 넘기므로 세 키가 전부 부재 → 셋 다 "present"로 잡혀 에러 메시지가 셋을 나열한다 (로그와 정확히 일치).

다른 keeper는 persisted meta로 부팅해 `keeper_up`을 우회하고, proactive/MCP 호출자는 키를 명시적 null로 넘겨 버그 체크를 통과하므로 영향이 없었다. base의 내부 bare-args만 트립한다.

## 수정

```ocaml
| None | Some `Null -> false   (* 부재 또는 명시적 null = 미제공 *)
| Some _ -> true                (* 실제 값 보유 = legacy arg, 거부 *)
```

부재(`None`)와 명시적 null을 모두 "미제공"으로 처리. 실제 값을 가진 legacy 키만 거부. null-passing / real-value 호출자의 동작은 불변.

## Behavioral delta (안전성)

이 수정이 출력을 바꾸는 유일한 입력은 "세 키가 모두 부재"인 args뿐이다 (거부 → 수용). null로 넘기거나 실제 값을 넘기는 5개 호출처 전부 before/after 동일.

## 검증

- `dune build .` (whole-program, default target) EXIT=0
- 회귀 테스트 `test_keeper_legacy_model_args_reject` 5/5 통과 (bare `{name}` 수용 / empty 수용 / 명시적 null 수용 / 실제 string 거부 / 실제 list 거부)

## 참고

동일 hunk가 정체된 ~100파일 리팩토링 #19289 (catch-all 제거)에도 부수적으로 포함되어 있으나, 그 PR은 삭제된 `lib/cascade/*` 트리와 충돌해 landing 불가 상태다. 본 PR은 live-breaking 버그에 대한 focused 수정이다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
