### PR TITLE
Remove cascade heredoc marker

### DIFF
--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Create Railway LLM runtime config
         run: |
           mkdir -p config
-          cat > config/llm_runtime.json << 'CASCADEJSON'
+          cat > config/llm_runtime.json << 'LLM_RUNTIME_JSON'
           {
             "governance_judge_models": ["glm:glm-4.7-flash"],
             "operator_judge_models": ["glm:glm-4.7-flash"],
@@ -67,7 +67,7 @@ jobs:
             "classification_models": ["glm:glm-4.7-flash"],
             "verifier_models": ["glm:glm-4.7-flash"]
           }
-          CASCADEJSON
+          LLM_RUNTIME_JSON
 
       - name: Build deployment image
         run: docker build -t masc-mcp-railway-smoke .


### PR DESCRIPTION
## Summary
- rename the Railway workflow heredoc delimiter from CASCADEJSON to LLM_RUNTIME_JSON
- keep the generated llm_runtime.json content unchanged

## Verification
- git grep -n -i -E 'cascade|캐스케이드|카스케이드' -- .
- bash scripts/lint/yaml-syntax.sh
- git diff --check