### PR TITLE
Fix stale doc truth refs after cascade purge

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,13 +236,12 @@ Reload 계약 ([docs/TOML-RELOAD-MATRIX.md](docs/TOML-RELOAD-MATRIX.md)):
 
 ## Model Runtime
 
-- 작성 매뉴얼: [docs/RUNTIME-TOML.md](docs/RUNTIME-TOML.md)
+- 작성 매뉴얼: [docs/spec/14-configuration.md](docs/spec/14-configuration.md)
 - live SSOT: `config/keeper_runtime.toml` (`config/runtime.json` 은 retired, 더 이상 생성/소비되지 않음)
 - 스키마 / parsing / 선택 정책 은 MASC 소유. OAS 에는 *해결된 단일 provider/model* 만 넘어갑니다.
 - keeper TOML 안의 `runtime_id` 으로 per-keeper override 가능.
 - 시드에서 keeper 가 정상 선택할 수 있는 프로필은 `primary` 뿐. `default`, `local_only`, `local_recovery`, `scoring` 은 시스템 전용 plumbing.
 - 체크인 runtime 의 provider 는 현재 pin 된 OAS 런타임이 *실제로* 실행할 수 있는 provider 로만 채워야 합니다.
-- 복붙용 로컬/개인 예시: [docs/RUNTIME-COOKBOOK.md](docs/RUNTIME-COOKBOOK.md)
 - 경계 문서: [docs/OAS-MASC-BOUNDARY.md](docs/OAS-MASC-BOUNDARY.md), [docs/spec/13-oas-integration.md](docs/spec/13-oas-integration.md), [docs/spec/14-configuration.md](docs/spec/14-configuration.md)
 
 ## Safe Starting Paths
@@ -386,8 +385,7 @@ raw `opam exec -- dune ...` 은 의도적인 CI-parity 점검 때만. 평소 개
 | [docs/QUICK-START.md](docs/QUICK-START.md) | 설치, health, 첫 워크플로 |
 | [docs/BOOT-ENV-STATE-INVENTORY.md](docs/BOOT-ENV-STATE-INVENTORY.md) | boot / path / state / active config inventory |
 | [docs/MCP-TEMPLATE.md](docs/MCP-TEMPLATE.md) | HTTP / stdio MCP 클라이언트 템플릿 |
-| [docs/RUNTIME-TOML.md](docs/RUNTIME-TOML.md) | keeper_runtime.toml 작성 매뉴얼 |
-| [docs/RUNTIME-COOKBOOK.md](docs/RUNTIME-COOKBOOK.md) | 복붙용 로컬 / 개인 예시 |
+| [docs/spec/14-configuration.md](docs/spec/14-configuration.md) | keeper_runtime.toml 작성 매뉴얼 |
 | [docs/OAS-MASC-BOUNDARY.md](docs/OAS-MASC-BOUNDARY.md) | OAS / MASC 소유 경계 |
 | [docs/KEEPER-USER-MANUAL.md](docs/KEEPER-USER-MANUAL.md) | keeper 라이프사이클, sandbox profile, Docker one-shot/managed 실행, 트러블슈팅 |
 | [docs/SUPERVISOR-MODE.md](docs/SUPERVISOR-MODE.md) | supervisor / operator 워크플로 |

--- a/docs/EXECUTE-RUNBOOK.md
+++ b/docs/EXECUTE-RUNBOOK.md
@@ -5,7 +5,6 @@ code_refs:
   - lib/exec/exec_semantic.ml
   - lib/exec/exec_buffer.ml
   - lib/exec_core.ml
-  - lib/cdal/cdal_judge.ml
   - lib/exec/command_gate/shell_command_gate.ml
   - lib/worker_dev_tools.ml
   - lib/keeper/agent_tool_command_runtime.ml

--- a/docs/design/adaptive-heartbeat-scheduling-rfc.md
+++ b/docs/design/adaptive-heartbeat-scheduling-rfc.md
@@ -4,7 +4,6 @@ last_verified: 2026-04-17
 code_refs:
   - lib/keeper/keeper_state_machine.ml
   - lib/keeper/keeper_config.ml
-  - lib/keeper/keeper_runtime_routing.ml
 ---
 
 # Adaptive Heartbeat and Runtime Scheduling RFC

--- a/docs/design/cdal-contract-kernel-and-advisory-split.md
+++ b/docs/design/cdal-contract-kernel-and-advisory-split.md
@@ -3,7 +3,6 @@ status: reference
 last_verified: 2026-04-17
 code_refs:
   - lib/cdal/
-  - lib/keeper/keeper_cdal_contract.ml
   - lib/keeper/keeper_accountability.ml
 ---
 

--- a/docs/design/cross-run-loader-and-window-spec.md
+++ b/docs/design/cross-run-loader-and-window-spec.md
@@ -3,7 +3,6 @@ status: reference
 last_verified: 2026-05-12
 code_refs:
   - lib/cdal/
-  - lib/cdal/proof_artifact_reader.ml
   - lib/keeper/keeper_agent_run.ml
 ---
 

--- a/docs/design/external-agent-framework-patterns-rfc.md
+++ b/docs/design/external-agent-framework-patterns-rfc.md
@@ -4,7 +4,6 @@ last_verified: 2026-05-12
 code_refs:
   - lib/keeper/
   - lib/keeper/keeper_agent_run.ml
-  - lib/cdal/proof_artifact_reader.ml
 ---
 
 # External Agent Framework Patterns RFC

--- a/docs/qa/OAS-OBSERVABILITY-TRUTH-AUDIT-2026-04-15.md
+++ b/docs/qa/OAS-OBSERVABILITY-TRUTH-AUDIT-2026-04-15.md
@@ -2,8 +2,8 @@
 status: runbook
 last_verified: 2026-05-12
 code_refs:
-  - lib/runtime/runtime_events.ml
-  - lib/runtime/runtime_event_bridge.ml
+  - lib/core/masc_runtime_events.ml
+  - lib/keeper/keeper_event_bridge.ml
   - lib/telemetry_unified.ml
 ---
 

--- a/docs/rfc/RFC-0041-runtime-routing-group-item-hierarchy.md
+++ b/docs/rfc/RFC-0041-runtime-routing-group-item-hierarchy.md
@@ -2,7 +2,7 @@
 status: Draft
 last_verified: 2026-05-08
 code_refs:
-  - lib/keeper/keeper_runtime_profile.ml
+  - lib/keeper/keeper_runtime.ml
   - lib/keeper/keeper_health_probe.ml
   - lib/keeper/keeper_supervisor.ml
   - lib/keeper/keeper_unified_turn.ml

--- a/docs/spec/A-existing-doc-index.md
+++ b/docs/spec/A-existing-doc-index.md
@@ -3,7 +3,6 @@ status: reference
 last_verified: 2026-05-12
 code_refs:
   - docs/
-  - docs/audit/2026-04-17-doc-classification.md
 ---
 
 # Appendix A: Existing Documentation Index


### PR DESCRIPTION
## Summary
- remove stale README links to deleted runtime docs
- update/remove stale frontmatter code_refs that pointed at deleted runtime/CDAL files

## Verification
- bash scripts/check-doc-truth.sh
- scripts/sync-oas-pin-docs.sh --check
- scripts/audit-keeper-tool-boundary-matrix.sh
- git grep -n -i -E 'cascade|캐스케이드|카스케이드' -- .
- git diff --cached --check