### PR TITLE
docs: close out Shell IR and tool evidence

### DIFF
--- a/docs/audit/2026-05-31-tool-keeper-boundary-severance.md
+++ b/docs/audit/2026-05-31-tool-keeper-boundary-severance.md
@@ -17,23 +17,21 @@ false-positive classes — (a) `Tool_name.Keeper` / `Keeper.` name-namespace con
 (b) `Keeper_internal` / `Keeper_denied` which are `Tool_catalog_surfaces.surface`
 constructors, not keeper modules — and after stripping nested comments + string literals,
 the measured severance set started at **12 tool-surface files that called a
-`Keeper_<module>`**. Current ratchet debt is **10** after the
-2026-06-01 `tool_emission` severance:
+`Keeper_<module>`**.
 
-| File | Keeper module(s) called | Bucket | Severance |
-|------|-------------------------|--------|-----------|
-| `lib/tool_usage_log.ml` | `Keeper_fd_pressure`, `Keeper_disk_pressure` | infra-leak | **DONE** — `~on_io_failure` injected at install boundary |
-| `lib/multimodal/tool_emission.ml` | `Keeper_emitter` (+`Multimodal_keeper_bridge`) | infra-leak | **DONE** — injected emitter port; keeper hook supplies `Keeper_emitter.emit` |
-| `lib/tool_unified.ml` | `Keeper_observation.runtime_metrics_json` | infra-leak | Runtime-demolition zone — re-eval after main green (field may be deleted) |
-| `lib/tool_task_payloads.ml` | `Keeper_tools_oas_workflow.workflow_rejection_*` | infra-leak | relocate pure payload builders to neutral module (RFC-0195 territory) |
-| `lib/tool_resource_axis.ml` | `Keeper_tool_alias.*` | misplaced | relocate `keeper_tool_alias` → `tool_alias` (surface concern). ⚠️ collides with #19290 |
-| `lib/tool_registration_check.ml` | `Keeper_tool_policy`, `Keeper_tool_policy_config` | infra-leak | ⚠️ collides with #19290/#19282; sequence after they land |
-| `lib/tool_control.ml` | `Keeper_meta_store`, `Keeper_registry`, `Keeper_types_profile_toml_normalizers` | domain-handler | invert via injected reader interface |
-| `lib/tool_coord.ml` | `Keeper_identity`, `Keeper_runtime` | domain-handler | invert: identity-resolver interface keeper registers into |
-| `lib/tool_deep_review.ml` | `Keeper_turn_driver.run_named` | domain-handler | inject turn-runner capability |
-| `lib/tool_inline_dispatch.ml` | `Keeper_approval_queue.*` | domain-handler | inject approval-queue port |
-| `lib/tool_inline_dispatch_coord.ml` | `Keeper_identity.*` | domain-handler | shared identity-resolver port (with tool_coord) |
-| `lib/tool_task_handlers.ml` | `Keeper_config`, `Keeper_registry`, `Keeper_identity`, `Keeper_current_task_reconcile`, `Keeper_tool_policy`, `Keeper_meta_store` | domain-handler | largest; multiple injected ports |
+Current main status, 2026-06-01 (`origin/main` at `1096d319ba`): the severance
+set is empty. `bash scripts/lint/tool-keeper-boundary-ratchet.sh --print`
+reports `tool_keeper_callers current=0 baseline=0`, and
+`bash scripts/audit-keeper-tool-boundary-matrix.sh` reports all 168 scoped
+keeper files covered by `docs/design/keeper-tool-boundary-matrix.md`.
+
+Historical drain:
+
+- 12 initial tool-surface files called `Keeper_<module>`.
+- `tool_usage_log` severed fd/disk pressure through injected failure handling.
+- `tool_emission` severed keeper emission through an injected emitter port.
+- #19632 (`Decouple tool surfaces from keeper internals`) drained the remaining
+  reverse-dependency set and regenerated the ratchet baseline to zero.
 
 `tool_keeper*.ml` (keeper-purpose handlers — keeper IS their domain) are out of scope for
 this gate. The dispatch path (`tool_dispatch.ml`) is already keeper-clean (RFC-0084).
@@ -53,40 +51,28 @@ direction is compiler-enforced; the lint holds the line until then.
 ## 3. This is not a workaround
 
 The ratchet is an invariant-enforcement gate (the compiler can't express the direction in a
-flat library), not a "counter-as-fix": severance PRs have already reduced the baseline
-12→11 (`tool_usage_log`) and 11→10 (`tool_emission`), proving the ratchet drives toward zero.
-Removal target: empty baseline / sub-library split.
+flat library), not a "counter-as-fix": severance PRs reduced the baseline
+12 -> 11 (`tool_usage_log`), 11 -> 10 (`tool_emission`), and finally 10 -> 0
+(#19632). The removal target is now achieved at the ratchet level; the remaining
+root fix is a future sub-library split so the compiler enforces the direction.
 
-## 4. Sequencing (in-flight PR collisions)
+## 4. Sequencing (closed at ratchet level)
 
-- Clear runway (no in-flight PR): `tool_usage_log` (done), `tool_emission` (done), `tool_inline_dispatch*`,
-  `tool_control`, `tool_coord`, `tool_deep_review`, `tool_task_handlers`, `tool_task_payloads`.
-- Contended — sequence AFTER they land: `tool_registration_check`, `tool_resource_axis`
-  (#19290 / #19282 typed-predicate pair touches these + `keeper_tool_policy`).
-- Hold: `tool_unified` (Runtime demolition in-flight; `runtime_metrics_json` may be removed).
+No per-file Tool -> Keeper severance remains on current main. The only
+structural follow-up is the compiler-enforced split described in §2. Older
+in-flight typed-tool PRs may still conflict with the files touched by #19632,
+but they are rebase problems, not live Tool -> Keeper debt.
 
 ## 5. Status
 
-main is currently red from the in-flight Runtime demolition (25 `Runtime_*`
-unbound-module errors, identical set on pristine main — this PR adds none). Verification is
-asymmetric because a flat library stops typechecking at the first broken module:
+2026-06-01 current-main verification:
 
-- `tool_usage_log.{ml,mli}` severance: **compile-verified** (`_build` `.cmt` regenerated
-  after the edit; reached and typechecked).
-- `server_bootstrap_maintenance.ml` injection: **reasoned-correct, not compile-verified**
-  (downstream of the broken keeper modules; only its `.cmti` was produced, the `.ml` was
-  never reached). The DI type logic is sound (`~site` punning matches the original
-  `?site` call) but reachability is unproven until main greens.
-- `scripts/lint/tool-keeper-boundary-ratchet.sh`: **fully verified** (compile-independent;
-  tested for pass, drift-up fail, stale-baseline fail, and comment/string false-positives).
-
-Full `dune build @check` + `@runtest` and Ready transition are gated on main returning to green.
-
-2026-06-01 progress update:
-
-- `tool_emission` no longer calls `Keeper_emitter` directly; `Keeper_tool_emission_hook`
-  now injects the keeper emitter port at the keeper boundary.
-- `scripts/lint/tool-keeper-boundary-ratchet.callers` regenerated to 10 entries.
+- `scripts/lint/tool-keeper-boundary-ratchet.sh --print`: current=0,
+  baseline=0.
+- `scripts/lint/no-tool-substrate-adapter-surface.sh --fail`: 0 forbidden
+  active substrate/micro-tool hits and 0 stale allowlist entries.
+- `scripts/audit-keeper-tool-boundary-matrix.sh`: OK, 168 scoped keeper files
+  covered by `docs/design/keeper-tool-boundary-matrix.md`.
 
 ## 6. Open decision — RFC ownership
 

--- a/docs/design/tool-execution-substrate-plan.html
+++ b/docs/design/tool-execution-substrate-plan.html
@@ -647,10 +647,10 @@
             <td>Receipt tests plus dashboard projection tests.</td>
           </tr>
           <tr>
-            <td><span class="status risk">PR-E</span> Shell IR audit maintenance</td>
-            <td>Resolve the live <code>G3</code> metric mismatch.</td>
-            <td>Either restore meaningful direct coverage or replace the old grep heuristic with facade-aware coverage.</td>
-            <td><code>scripts/audit-shell-ir-consumption.sh --json</code> and focused Shell IR tests.</td>
+            <td><span class="status done">PR-E</span> Shell IR audit closeout</td>
+            <td>Prove the Shell IR substrate is still inside the RFC-0160 targets.</td>
+            <td>Current main reports <code>G3=5</code>, <code>G7=0</code>, and <code>G8=110/110</code>; the baseline ratchet returns OK.</td>
+            <td><code>scripts/audit-shell-ir-consumption.sh --json</code> and <code>scripts/audit-shell-ir-consumption.sh --baseline scripts/shell-ir-consumption-baseline.json</code>.</td>
           </tr>
           <tr>
             <td><span class="status next">PR-F</span> GitHub workflow cleanup</td>
@@ -874,7 +874,7 @@
         <thead>
           <tr>
             <th>Evidence</th>
-            <th>2026-05-27 observation</th>
+            <th>2026-06-01 observation</th>
           </tr>
         </thead>
         <tbody>
@@ -884,11 +884,11 @@
           </tr>
           <tr>
             <td>Shell IR audit</td>
-            <td><code>G1=3</code>, <code>G2 string=0/IR=2</code>, <code>G3=2</code>, <code>G4 phantom=18</code>, <code>G5=4</code>, <code>G6=1</code>, <code>G7=0</code>.</td>
+            <td><code>G1=3</code>, <code>G2 string=0/IR=2</code>, <code>G3=5</code>, <code>G4 phantom=18</code>, <code>G5=4</code>, <code>G6=1</code>, <code>G7=0</code>, <code>G8=110/110</code>; baseline ratchet OK.</td>
           </tr>
           <tr>
             <td>Active micro-tool scan</td>
-            <td>Enforced by <code>scripts/lint/no-tool-substrate-adapter-surface.sh</code> and source-guard case 28: no active-surface hits for dedicated repository mutation wrappers, gh-specific wrappers, or retired repository wrapper prefixes in descriptor/prompt/policy/matrix surfaces.</td>
+            <td><code>scripts/lint/no-tool-substrate-adapter-surface.sh --fail</code> reports 0 forbidden active-surface hits, 0 allowlist entries, and 0 stale allowlist entries for dedicated repository mutation wrappers, gh-specific wrappers, or retired repository wrapper prefixes.</td>
           </tr>
           <tr>
             <td>Keeper prompt web aliases</td>

--- a/docs/design/tool-execution-substrate-plan.md
+++ b/docs/design/tool-execution-substrate-plan.md
@@ -53,13 +53,12 @@ Current main already points in the right direction.
   dispatches via the decided IR path.
 - The keeper capability matrix already states that GitHub PR and issue work
   uses `Execute` with `executable = "gh"` and typed `argv`.
-- A 2026-05-27 live `scripts/audit-shell-ir-consumption.sh --json` run shows
-  the Shell IR substrate remains mostly in target range. One metric needs audit
-  maintenance: `g3_gate_typed_refs_in_keeper = 2`, while RFC-0160's historical
-  target was `>= 4`. This appears to be a measurement drift caused by routing
-  through the centralized `Agent_tool_execute_shell_ir` facade rather than
-  direct `gate_typed` calls in many keeper files. PR-E must prove this or fix
-  a real coverage regression before closing.
+- A 2026-06-01 live `scripts/audit-shell-ir-consumption.sh --json` run on
+  `origin/main` (`1096d319ba`) shows the Shell IR substrate inside the RFC-0160
+  targets: G1=3 files / 3 refs, G2 string=0 / IR=2, G3=5, G4 phantom=18 with
+  6 decided-dispatch consumers, G5=4, G6=1, G7=0, and G8=110/110 with the
+  single allowed generic arm. The baseline ratchet also passes with no
+  G1/G7/G8 regression and no unclassified parse sites.
 
 The remaining risk is not missing a `Gh_cli` executor. The risk is letting
 micro-tools re-enter through convenience pressure.
@@ -331,6 +330,14 @@ Expected state:
   if all `Shell_ir` executor paths still route through
   `Agent_tool_execute_shell_ir.dispatch` or `dispatch_classified`.
 
+Current status, 2026-06-01: verified on `origin/main` at `1096d319ba`.
+`scripts/audit-shell-ir-consumption.sh --json` reports G3=5 and G7=0, and
+`scripts/audit-shell-ir-consumption.sh --baseline
+scripts/shell-ir-consumption-baseline.json` returns OK. PR-E is no longer an
+open measurement gap; it is a closeout evidence point. The remaining Shell IR
+cleanup is optional hardening: the three allowed non-test `Bash.parse_string`
+callers are still the canonical string-to-IR entrypoints.
+
 ### PR-F: GitHub Workflow Guidance Cleanup
 
 Delete or rewrite any docs, prompts, or hints that imply dedicated GitHub tools
@@ -378,12 +385,14 @@ If answers 1 or 2 are yes, do not add a tool.
 IR, classifies the IR, gates destructive/write behavior, and dispatches the
 classified IR.
 
-[evidence] 2026-05-27, confidence High: local repo
+[evidence] 2026-06-01, confidence High: local repo command output on
+`origin/main` at `1096d319ba`
 `docs/rfc/RFC-0160-shell-ir-first-class.md` records Shell IR first-class status
-as implemented. A live audit on 2026-05-27 returned G1=3, G2 string=0/IR=2,
-G4 phantom=18, G5=4, G6=1, and G7=0. It also returned G3=2, which requires
-metric follow-up because the current facade structure may make the old direct
-`gate_typed` grep heuristic stale.
+as implemented. A live `scripts/audit-shell-ir-consumption.sh --json` run
+returned G1=3 files / 3 refs, G2 string=0/IR=2, G3=5, G4 phantom=18 with
+6 decided-dispatch consumers, G5=4, G6=1, G7=0, and G8=110/110 with one
+allowed generic arm. The matching baseline run returned `OK (RFC-0160 ratchet:
+no G1/G7/G8 regression, no unclassified sites)`.
 
 [evidence] 2026-05-27, confidence High: local repo
 `docs/KEEPER-CAPABILITY-MATRIX.md` records GitHub PR/issue work as `Execute`


### PR DESCRIPTION
## Summary
- refresh Shell IR substrate plan with current 2026-06-01 audit numbers on origin/main
- mark PR-E as closeout evidence instead of an open G3 measurement gap
- refresh Tool -> Keeper boundary severance audit after the ratchet reached 0/0
- sync the HTML companion evidence table

## Verification
- bash scripts/audit-shell-ir-consumption.sh --baseline scripts/shell-ir-consumption-baseline.json
- bash scripts/lint/no-tool-substrate-adapter-surface.sh --fail
- bash scripts/lint/tool-keeper-boundary-ratchet.sh --fail
- bash scripts/audit-keeper-tool-boundary-matrix.sh
- bash scripts/check-doc-truth.sh
- bash scripts/lint/no-legacy-tool-surface-name.sh --fail
- git diff --check