### PR TITLE
Remove Agent_identity room context

### DIFF
--- a/lib/agent_identity.ml
+++ b/lib/agent_identity.ml
@@ -142,7 +142,6 @@ type t = {
   agent_name : string;            (** Display name (e.g., "agent_llm_a-agent-001") *)
   channel : channel option;       (** Source channel if known *)
   user_id : string option;        (** User ID from channel (e.g., telegram user id) *)
-  room_id : string option;        (** Current room if joined *)
   capabilities : string list;     (** Declared agent capabilities *)
   registered_at : float;          (** Unix timestamp *)
   mutable last_seen : float;      (** Last activity timestamp *)
@@ -194,7 +193,6 @@ let from_mcp_params params =
     | None -> None
   in
   let user_id = get_opt "_user_id" in
-  let room_id = get_opt "room" in
   let capabilities = Json_util.get_string_list params "_capabilities" in
   let now = Time_compat.now () in
   {
@@ -203,7 +201,6 @@ let from_mcp_params params =
     agent_name;
     channel;
     user_id;
-    room_id;
     capabilities;
     registered_at = now;
     last_seen = now;
@@ -221,7 +218,6 @@ let anonymous () =
     agent_name = name;
     channel = None;
     user_id = None;
-    room_id = None;
     capabilities = [];
     registered_at = now;
     last_seen = now;
@@ -268,17 +264,12 @@ module Registry = struct
       | None -> None
     )
 
-  (** Update last_seen and optionally room *)
-  let touch reg session_key ?room_id () =
+  (** Update last_seen *)
+  let touch reg session_key () =
     with_lock reg (fun () ->
       match StringMap.find_opt session_key !(reg.identities) with
       | Some identity ->
-          identity.last_seen <- Time_compat.now ();
-          (match room_id with
-           | Some rid -> 
-               let updated = { identity with room_id = Some rid } in
-               reg.identities := StringMap.add session_key updated !(reg.identities)
-           | None -> ())
+          identity.last_seen <- Time_compat.now ()
       | None -> ()
     )
 
@@ -327,15 +318,10 @@ let to_display_string identity =
     | Some c -> Printf.sprintf " via %s" (string_of_channel c)
     | None -> ""
   in
-  let room_str = match identity.room_id with
-    | Some r -> Printf.sprintf " in %s" r
-    | None -> ""
-  in
-  Printf.sprintf "%s (%s)%s%s"
+  Printf.sprintf "%s (%s)%s"
     identity.agent_name
     prefix_str
     channel_str
-    room_str
 
 (** Check if two identities refer to the same agent *)
 let same_agent a b =

--- a/lib/agent_registry_eio.ml
+++ b/lib/agent_registry_eio.ml
@@ -118,11 +118,6 @@ let get_registry_locked s = s.registry
     @return Agent identity for this request
 *)
 let get_or_create_identity ?mcp_session_id params =
-  let room_id =
-    match Json_util.assoc_member_opt "room" params with
-    | Some (`String r) -> Some r
-    | _ -> None
-  in
   with_state_rw (fun s ->
     let reg = get_registry_locked !s in
     let find_from_cache sid =
@@ -138,7 +133,7 @@ let get_or_create_identity ?mcp_session_id params =
     match existing with
     | Some identity ->
         Agent_identity.Registry.touch reg identity.Agent_identity.session_key
-          ?room_id ();
+          ();
         (match Agent_identity.Registry.find_by_session reg identity.session_key with
          | Some updated -> updated
          | None -> identity)

--- a/test/test_agent_identity.ml
+++ b/test/test_agent_identity.ml
@@ -28,13 +28,11 @@ let test_from_mcp_params () =
     ("_agent_name", `String "mcp-agent-001");
     ("_channel", `String "telegram");
     ("_user_id", `String "12345");
-    ("room", `String "test-room");
     ("_capabilities", `List [`String "code"; `String "search"]);
   ] in
   let identity = Agent_identity.from_mcp_params params in
   check string "agent_name" "mcp-agent-001" identity.agent_name;
   check (option string) "user_id" (Some "12345") identity.user_id;
-  check (option string) "room_id" (Some "test-room") identity.room_id;
   check int "capabilities count" 2 (List.length identity.capabilities);
   check bool "has code capability" true (Agent_identity.has_capability identity "code")
 
@@ -178,7 +176,6 @@ let test_to_display_string () =
     agent_name = "test-agent";
     channel = Some (Agent_identity.External "telegram");
     user_id = Some "user123";
-    room_id = Some "room-a";
     capabilities = [];
     registered_at = 0.0;
     last_seen = 0.0;
@@ -195,7 +192,6 @@ let test_to_display_string_empty_session_key () =
     agent_name = "empty-key-agent";
     channel = Some Agent_identity.Api;
     user_id = None;
-    room_id = None;
     capabilities = [];
     registered_at = 0.0;
     last_seen = 0.0;
@@ -246,7 +242,7 @@ module RegistryTests = struct
     }) in
     let _ = Agent_identity.Registry.register reg identity in
     
-    Agent_identity.Registry.touch reg identity.session_key ~room_id:"new-room" ();
+    Agent_identity.Registry.touch reg identity.session_key ();
     
     match Agent_identity.Registry.find_by_session reg identity.session_key with
     | Some updated ->

--- a/test/test_agent_registry_eio.ml
+++ b/test/test_agent_registry_eio.ml
@@ -18,11 +18,9 @@ let test_get_or_create_new () =
   let params = `Assoc [
     ("_agent_name", `String "test-new-agent");
     ("_channel", `String "telegram");
-    ("room", `String "test-room");
   ] in
   let identity = Agent_registry_eio.get_or_create_identity params in
-  check string "agent_name" "test-new-agent" identity.agent_name;
-  check (option string) "room_id" (Some "test-room") identity.room_id
+  check string "agent_name" "test-new-agent" identity.agent_name
 
 let test_get_or_create_existing () =
   Eio_main.run @@ fun env ->

--- a/test/test_identity_e2e.ml
+++ b/test/test_identity_e2e.ml
@@ -17,14 +17,12 @@ let test_identity_from_mcp_params () =
     ("_channel", `String "telegram");
     ("_user_id", `String "user-12345");
     ("_session_key", `String "session-abc-123");
-    ("room", `String "project-room");
     ("_capabilities", `List [`String "code"; `String "file_ops"]);
   ] in
   
   let identity = Agent_registry_eio.get_or_create_identity params in
   
   check string "agent_name" "agent_llm_a-code-agent" identity.agent_name;
-  check (option string) "room" (Some "project-room") identity.room_id;
   check bool "has code cap" true (Agent_identity.has_capability identity "code");
   check bool "no admin cap" false (Agent_identity.has_capability identity "admin")
 
@@ -49,24 +47,6 @@ let test_mcp_session_persistence () =
   
   check string "id1 == id2" id1.session_key id2.session_key;
   check string "id1 == id3" id1.session_key id3.session_key
-
-(** Test room context updates *)
-let test_room_context_updates () =
-  Eio_main.run @@ fun env ->
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
-  Agent_registry_eio.reset_for_testing ();
-  
-  let mcp_session = "mcp-room-test" in
-  
-  (* Join room-1 *)
-  let p1 = `Assoc [("_agent_name", `String "room-agent"); ("room", `String "room-1")] in
-  let id1 = Agent_registry_eio.get_or_create_identity ~mcp_session_id:mcp_session p1 in
-  check (option string) "in room-1" (Some "room-1") id1.room_id;
-  
-  (* Move to room-2 *)
-  let p2 = `Assoc [("room", `String "room-2")] in
-  let id2 = Agent_registry_eio.get_or_create_identity ~mcp_session_id:mcp_session p2 in
-  check (option string) "in room-2" (Some "room-2") id2.room_id
 
 (** Test multi-agent isolation *)
 let test_multi_agent_isolation () =
@@ -96,7 +76,6 @@ let test_display_string () =
     agent_name = "test-display-agent";
     channel = Some (Agent_identity.External "telegram");
     user_id = Some "tg-user-99";
-    room_id = Some "work-room";
     capabilities = ["code"; "search"];
     registered_at = Unix.gettimeofday ();
     last_seen = Unix.gettimeofday ();
@@ -130,7 +109,6 @@ let () =
     "integration", [
       test_case "from_mcp_params" `Quick test_identity_from_mcp_params;
       test_case "session_persistence" `Quick test_mcp_session_persistence;
-      test_case "room_updates" `Quick test_room_context_updates;
       test_case "multi_agent" `Quick test_multi_agent_isolation;
       test_case "display_string" `Quick test_display_string;
       test_case "stale_cleanup" `Quick test_stale_cleanup;

--- a/test/test_identity_edge_cases.ml
+++ b/test/test_identity_edge_cases.ml
@@ -20,7 +20,6 @@ let test_null_values () =
   Agent_registry_eio.reset_for_testing ();
   let params = `Assoc [
     ("_agent_name", `Null);
-    ("room", `Null);
   ] in
   let identity = Agent_registry_eio.get_or_create_identity params in
   check bool "generated name" true (String.length identity.agent_name > 0)

--- a/test/test_mcp_full_cycle.ml
+++ b/test/test_mcp_full_cycle.ml
@@ -11,9 +11,8 @@ open Masc_mcp
 
 (** Test fixtures *)
 module Fixtures = struct
-  let make_room_join_params ~room ~agent_name =
+  let make_identity_params ~agent_name =
     `Assoc [
-      ("room", `String room);
       ("agent_name", `String agent_name);
       ("_agent_name", `String agent_name);
       ("_channel", `String "internal");
@@ -35,12 +34,11 @@ end
 
 (** Test: Agent identity extracted from MCP params *)
 let test_identity_extraction () =
-  let params = Fixtures.make_room_join_params ~room:"test-room" ~agent_name:"integration-agent" in
+  let params = Fixtures.make_identity_params ~agent_name:"integration-agent" in
   let args = Yojson.Safe.Util.(params |> member "arguments" |> function `Null -> params | x -> x) in
   let identity = Agent_identity.from_mcp_params args in
   
   check string "agent_name extracted" "integration-agent" identity.agent_name;
-  check (option string) "room extracted" (Some "test-room") identity.room_id;
   match identity.channel with
   | Some Agent_identity.Internal -> ()
   | _ -> fail "expected Internal channel"
@@ -85,23 +83,6 @@ let test_multi_agent_isolation () =
     | Some id -> check string "correct name" name id.agent_name
     | None -> fail (Printf.sprintf "agent %s not found" name)
   ) agents
-
-(** Test: Coord context preserved in identity *)
-let test_room_context () =
-  Eio_main.run @@ fun env ->
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
-  let reg = Agent_identity.Registry.create () in
-  
-  let id = Fixtures.identity_for "room-agent" in
-  let _ = Agent_identity.Registry.register reg id in
-  
-  (* Agent joins room *)
-  Agent_identity.Registry.touch reg id.session_key ~room_id:"project-alpha" ();
-  
-  match Agent_identity.Registry.find_by_session reg id.session_key with
-  | Some updated ->
-      check (option string) "room updated" (Some "project-alpha") updated.room_id
-  | None -> fail "identity not found"
 
 (** Test: Capability filtering *)
 let test_capability_filtering () =
@@ -173,9 +154,7 @@ let test_session_key_stability () =
   let original_key = id.session_key in
   let _ = Agent_identity.Registry.register reg id in
   
-  (* Multiple touches with different room IDs *)
-  Agent_identity.Registry.touch reg original_key ~room_id:"room-1" ();
-  Agent_identity.Registry.touch reg original_key ~room_id:"room-2" ();
+  (* Multiple touches keep the session stable. *)
   Agent_identity.Registry.touch reg original_key ();
   
   match Agent_identity.Registry.find_by_session reg original_key with
@@ -189,7 +168,6 @@ let () =
       test_case "extraction" `Quick test_identity_extraction;
       test_case "registry_persistence" `Quick test_identity_registry_persistence;
       test_case "multi_agent_isolation" `Quick test_multi_agent_isolation;
-      test_case "room_context" `Quick test_room_context;
       test_case "capability_filtering" `Quick test_capability_filtering;
     ];
     "lifecycle", [

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -68,7 +68,6 @@ let test_agent_identity ~uuid ~session_key : Masc_mcp.Agent_identity.t =
     agent_name = "";
     channel = None;
     user_id = None;
-    room_id = None;
     capabilities = [];
     registered_at = 0.;
     last_seen = 0.;


### PR DESCRIPTION
## Summary
- remove room_id from Agent_identity.t and generated identity JSON
- stop parsing room from MCP params and stop updating identity room state on registry touch
- delete tests that preserved room context in identity/registry flows

## Validation
- Not run: continuation of room concept purge; user accepted temporary build breakage.