### PR TITLE
Add MCP 2026 stateless compatibility

### DIFF
--- a/lib/mcp_server_eio_protocol.ml
+++ b/lib/mcp_server_eio_protocol.ml
@@ -194,7 +194,33 @@ let handle_initialize_eio ?(profile = Full) id params =
              ]))
 ;;
 
+let profile_instructions = function
+  | Full -> TP.default_instructions
+  | Managed_agent -> TP.managed_agent_instructions
+  | Operator_remote -> TP.operator_remote_instructions
+;;
+
+let handle_server_discover_eio ?(profile = Full) id =
+  make_response
+    ~id
+    (`Assoc
+        [ "resultType", `String "complete"
+        ; ( "supportedVersions"
+          , `List
+              (List.map
+                 (fun version -> `String version)
+                 Mcp_transport_protocol.supported_protocol_versions) )
+        ; "capabilities", Mcp_server.capabilities
+        ; "serverInfo", Mcp_server.server_info
+        ; "instructions", `String (profile_instructions profile)
+        ])
+;;
+
 let public_tool_help_schemas () = Config.visible_tool_schemas ()
+
+let cache_hint_fields ~scope ~ttl_ms =
+  [ "ttlMs", `Int ttl_ms; "cacheScope", `String scope ]
+;;
 
 let handle_list_tools_eio
       ?(profile = Full)
@@ -265,6 +291,7 @@ let handle_list_tools_eio
       @ TP.maybe_assoc_field
           "nextCursor"
           (Option.map (fun value -> `String value) next_cursor)
+      @ cache_hint_fields ~scope:"private" ~ttl_ms:5000
       @ [ ( "_meta"
           , `Assoc
               [ "totalCount", `Int total_count; "pageSize", `Int (TP.list_page_size ()) ]
@@ -312,6 +339,7 @@ let handle_list_resources_eio id cursor =
       @ TP.maybe_assoc_field
           "nextCursor"
           (Option.map (fun value -> `String value) next_cursor)
+      @ cache_hint_fields ~scope:"private" ~ttl_ms:5000
     in
     make_response ~id (`Assoc result_fields)
 ;;
@@ -331,6 +359,7 @@ let handle_list_resource_templates_eio id cursor =
       @ TP.maybe_assoc_field
           "nextCursor"
           (Option.map (fun value -> `String value) next_cursor)
+      @ cache_hint_fields ~scope:"public" ~ttl_ms:30000
     in
     make_response ~id (`Assoc result_fields)
 ;;
@@ -351,6 +380,7 @@ let handle_list_prompts_eio id cursor =
       @ TP.maybe_assoc_field
           "nextCursor"
           (Option.map (fun value -> `String value) next_cursor)
+      @ cache_hint_fields ~scope:"public" ~ttl_ms:30000
     in
     make_response ~id (`Assoc result_fields)
 ;;
@@ -620,6 +650,7 @@ let handle_request
           else (
             try
               match req.method_ with
+              | "server/discover" -> handle_server_discover_eio ~profile id
               | "initialize" -> handle_initialize_eio ~profile id req.params
               | "initialized" | "notifications/initialized" -> make_response ~id `Null
               | "resources/list" ->

--- a/lib/mcp_server_eio_protocol.mli
+++ b/lib/mcp_server_eio_protocol.mli
@@ -128,10 +128,10 @@ val handle_request :
     ?mcp_session_id ?auth_token ?internal_keeper_runtime
     state request_str] parses [request_str] as JSON-RPC,
     routes the [method] to the matching internal handler
-    (initialize / tools/list / tools/call / resources/list
-    / resources/read / resources/subscribe / unsubscribe
-    / list_resource_templates / prompts/list / prompts/get
-    / dashboard/* family), and returns the response
+    (server/discover / initialize / tools/list / tools/call
+    / resources/list / resources/read / resources/subscribe /
+    unsubscribe / list_resource_templates / prompts/list /
+    prompts/get / dashboard/* family), and returns the response
     envelope.
 
     Parse failures return a [-32700] Parse error envelope

--- a/lib/mcp_server_eio_resource.ml
+++ b/lib/mcp_server_eio_resource.ml
@@ -19,6 +19,9 @@ let make_error_typed ?data ~id (code : Mcp_error_code.t) message =
 let public_tool_help_schemas () =
   Config.visible_tool_schemas ()
 
+let cache_hint_fields ~scope ~ttl_ms =
+  [ ("ttlMs", `Int ttl_ms); ("cacheScope", `String scope) ]
+
 let handle_read_resource_eio state id params =
   match params with
   | None -> make_error_typed ~id Mcp_error_code.Invalid_params "Missing params"
@@ -362,7 +365,10 @@ let handle_read_resource_eio state id params =
                 ("text", `String text);
               ]
             ] in
-            make_response ~id (`Assoc [("contents", contents)])
+            make_response ~id
+              (`Assoc
+                ([ ("contents", contents) ]
+                @ cache_hint_fields ~scope:"private" ~ttl_ms:5000))
       end
   | Some _ ->
       make_error_typed ~id Mcp_error_code.Invalid_params "Invalid params"

--- a/lib/mcp_transport_protocol/mcp_transport_protocol.ml
+++ b/lib/mcp_transport_protocol/mcp_transport_protocol.ml
@@ -159,12 +159,26 @@ module Http_negotiation = struct
     else Rejected
 end
 
-let supported_protocol_versions = Mcp_protocol.Version.supported_versions
+let protocol_version_2026_07_28 = "2026-07-28"
+let protocol_version_draft_2026_v1 = "DRAFT-2026-v1"
+
+let supported_protocol_versions =
+  let rec add acc version =
+    if List.mem version acc then acc else acc @ [ version ]
+  in
+  List.fold_left add []
+    (protocol_version_2026_07_28
+     :: protocol_version_draft_2026_v1
+     :: Mcp_protocol.Version.supported_versions)
 
 let default_protocol_version = Mcp_protocol.Version.latest
 
 let is_supported_protocol_version version =
-  Mcp_protocol.Version.is_supported version
+  List.mem version supported_protocol_versions
+
+let is_stateless_protocol_version version =
+  String.equal version protocol_version_2026_07_28
+  || String.equal version protocol_version_draft_2026_v1
 
 let validate_protocol_version version =
   if is_supported_protocol_version version then
@@ -185,6 +199,30 @@ let protocol_version_from_params = function
       | Some (`String version) -> version
       | _ -> default_protocol_version)
   | _ -> default_protocol_version
+
+let protocol_version_meta_key = "io.modelcontextprotocol/protocolVersion"
+
+let protocol_version_from_request_meta_json = function
+  | `Assoc fields -> (
+      match List.assoc_opt "params" fields with
+      | Some (`Assoc params) -> (
+          match List.assoc_opt "_meta" params with
+          | Some (`Assoc meta) -> (
+              match List.assoc_opt protocol_version_meta_key meta with
+              | Some (`String version) -> Some version
+              | _ -> None)
+          | _ -> None)
+      | _ -> None)
+  | _ -> None
+
+let protocol_version_from_request_meta_body body_str =
+  try Yojson.Safe.from_string body_str |> protocol_version_from_request_meta_json
+  with Yojson.Json_error _ -> None
+
+let body_uses_stateless_protocol body_str =
+  match protocol_version_from_request_meta_body body_str with
+  | Some version -> is_stateless_protocol_version version
+  | None -> false
 
 let protocol_version_from_initialize_request_json = function
   | `Assoc fields -> (

--- a/lib/mcp_transport_protocol/mcp_transport_protocol.mli
+++ b/lib/mcp_transport_protocol/mcp_transport_protocol.mli
@@ -112,13 +112,19 @@ end
 
 val supported_protocol_versions : string list
 (** Versions accepted by this server (delegates to
-    {!Mcp_protocol.Version.supported_versions}). *)
+    {!Mcp_protocol.Version.supported_versions}, with the 2026-07-28
+    stateless revision overlaid while the vendored SDK catches up). *)
 
 val default_protocol_version : string
 (** Latest version (delegates to {!Mcp_protocol.Version.latest}). *)
 
 val is_supported_protocol_version : string -> bool
 (** Membership test against {!supported_protocol_versions}. *)
+
+val is_stateless_protocol_version : string -> bool
+(** [true] for protocol revisions that do not use the initialize
+    handshake or [Mcp-Session-Id] as protocol state. Accepts both
+    the release-candidate date label and the current draft alias. *)
 
 val validate_protocol_version : string -> (string, string) result
 (** [Ok v] if supported, otherwise [Error msg] listing the supported set. *)
@@ -129,6 +135,24 @@ val normalize_protocol_version : string -> string
 val protocol_version_from_params : Yojson.Safe.t option -> string
 (** Extract [protocolVersion] from a JSON-RPC [params] object,
     falling back to {!default_protocol_version}. *)
+
+val protocol_version_meta_key : string
+(** Fully qualified per-request [_meta] key used by the 2026-07-28
+    stateless protocol: ["io.modelcontextprotocol/protocolVersion"]. *)
+
+val protocol_version_from_request_meta_json : Yojson.Safe.t -> string option
+(** Extract the per-request protocol version from
+    [params._meta.io.modelcontextprotocol/protocolVersion]. Returns
+    [None] for legacy initialize-only messages or malformed shapes. *)
+
+val protocol_version_from_request_meta_body : string -> string option
+(** Parses a JSON-RPC body and delegates to
+    {!protocol_version_from_request_meta_json}. Returns [None] on
+    malformed JSON. *)
+
+val body_uses_stateless_protocol : string -> bool
+(** [true] iff the JSON-RPC body declares a stateless protocol version
+    in per-request [_meta]. *)
 
 val protocol_version_from_initialize_request_json :
   Yojson.Safe.t -> string option

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -397,6 +397,16 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
                                  let body = json_rpc_error Mcp_error_code.Invalid_request msg in
                                  h2_respond_json h2_reqd body ~status:`Bad_request
                                    ~extra_headers:(cors @ mcp_headers session_id protocol_version)
+                             | Error
+                                 (Server_mcp_request_context.Header_mismatch msg)
+                               ->
+                                 let body =
+                                   Printf.sprintf
+                                     {|{"jsonrpc":"2.0","error":{"code":-32001,"message":"%s"},"id":null}|}
+                                     (String.escaped msg)
+                                 in
+                                 h2_respond_json h2_reqd body ~status:`Bad_request
+                                   ~extra_headers:(cors @ mcp_headers session_id protocol_version)
                              | Ok post_context ->
                                  with_server_state h2_reqd (fun state ->
                                    let profile =

--- a/lib/server/server_mcp_request_context.ml
+++ b/lib/server/server_mcp_request_context.ml
@@ -24,27 +24,44 @@ type post_body_rejection =
   | Session_required of string
   | Unknown_session of string
   | Invalid_accept of string
+  | Header_mismatch of string
 
 let invalid_accept_message =
   "Invalid Accept header: must include application/json and text/event-stream."
 
 let decide_post_body ~request ~context ~session_is_known body_str =
-  match
-    Server_mcp_transport_http_protocol.validate_session_requirement
-      ~session_was_provided:context.session_was_provided body_str
-  with
+  let stateless_request =
+    Server_mcp_transport_http_protocol.request_uses_stateless_protocol request
+      body_str
+  in
+  let session_gate =
+    if stateless_request then Ok ()
+    else
+      Server_mcp_transport_http_protocol.validate_session_requirement
+        ~session_was_provided:context.session_was_provided body_str
+  in
+  match session_gate with
   | Error msg -> Error (Session_required msg)
   | Ok () -> (
       let is_known = context.session_was_provided && session_is_known in
-      match
-        Server_mcp_transport_http_protocol.validate_session_known
-          ~session_was_provided:context.session_was_provided ~is_known body_str
-      with
+      let known_gate =
+        if stateless_request then Ok ()
+        else
+          Server_mcp_transport_http_protocol.validate_session_known
+            ~session_was_provided:context.session_was_provided ~is_known body_str
+      in
+      match known_gate with
       | Error msg -> Error (Unknown_session msg)
       | Ok () -> (
           match
-            Server_mcp_transport_http_headers.classify_mcp_accept request
+            Server_mcp_transport_http_protocol.validate_2026_request_headers
+              request body_str
           with
-          | Mcp_transport_protocol.Http_negotiation.Rejected ->
-              Error (Invalid_accept invalid_accept_message)
-          | accept_mode -> Ok { body_str; accept_mode }))
+          | Error msg -> Error (Header_mismatch msg)
+          | Ok () -> (
+              match
+                Server_mcp_transport_http_headers.classify_mcp_accept request
+              with
+              | Mcp_transport_protocol.Http_negotiation.Rejected ->
+                  Error (Invalid_accept invalid_accept_message)
+              | accept_mode -> Ok { body_str; accept_mode })))

--- a/lib/server/server_mcp_request_context.mli
+++ b/lib/server/server_mcp_request_context.mli
@@ -25,6 +25,7 @@ type post_body_rejection =
   | Session_required of string
   | Unknown_session of string
   | Invalid_accept of string
+  | Header_mismatch of string
 
 val invalid_accept_message : string
 

--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -111,6 +111,8 @@ let body_tools_call_name body_str =
 
 let session_cookie_header = Server_mcp_transport_http_headers.session_cookie_header
 
+let session_cookie_headers = Server_mcp_transport_http_headers.session_cookie_headers
+
 let sse_headers = Server_mcp_transport_http_headers.sse_headers
 
 let sse_stream_headers = Server_mcp_transport_http_headers.sse_stream_headers
@@ -122,8 +124,8 @@ let stream_post_sse_headers ~deps ~origin ~session_id ~protocol_version =
         ("cache-control", "no-cache");
         ("connection", "close");
         ("x-accel-buffering", "no");
-        session_cookie_header session_id;
       ]
+      @ session_cookie_headers protocol_version session_id
       @ mcp_headers session_id protocol_version
       @ deps.cors_headers origin)
 
@@ -320,6 +322,29 @@ let handle_post_mcp ~deps ?(profile = Full) request reqd =
                           ("code", `Int (Mcp_error_code.to_wire_code Invalid_request));
                           ("message", `String msg);
                         ] );
+                  ])
+            in
+            let headers =
+              Httpun.Headers.of_list
+                (("content-length", string_of_int (String.length body))
+                :: json_headers ~deps session_id protocol_version origin)
+            in
+            let response = Httpun.Response.create ~headers `Bad_request in
+            safe_respond_with_string reqd response body;
+            Error ()
+        | Error (Server_mcp_request_context.Header_mismatch msg) ->
+            let body =
+              Yojson.Safe.to_string
+                (`Assoc
+                  [
+                    ("jsonrpc", `String "2.0");
+                    ( "error",
+                      `Assoc
+                        [
+                          ("code", `Int (-32001));
+                          ("message", `String msg);
+                        ] );
+                    ("id", `Null);
                   ])
             in
             let headers =

--- a/lib/server/server_mcp_transport_http.mli
+++ b/lib/server/server_mcp_transport_http.mli
@@ -79,6 +79,9 @@ val get_protocol_version_for_session :
 val request_force_json_response : Httpun.Request.t -> bool
 val classify_mcp_accept :
   Httpun.Request.t -> Mcp_transport_protocol.Http_negotiation.accept_mode
+val request_uses_stateless_protocol : Httpun.Request.t -> string -> bool
+val validate_2026_request_headers :
+  Httpun.Request.t -> string -> (unit, string) result
 val should_use_sse_for_body :
   Httpun.Request.t ->
   string ->

--- a/lib/server/server_mcp_transport_http_headers.ml
+++ b/lib/server/server_mcp_transport_http_headers.ml
@@ -69,7 +69,111 @@ let body_jsonrpc_method body_str =
     | _ -> None
   with Yojson.Json_error _ -> None
 
+let body_jsonrpc_method_only body_str =
+  match body_jsonrpc_method body_str with
+  | Some (method_, _) -> Some method_
+  | None -> None
+
 let is_initialize_method method_ = String.equal method_ "initialize"
+
+let request_protocol_version_header (request : Httpun.Request.t) =
+  Server_mcp_transport_http_session.get_header_any_case request.headers
+    "mcp-protocol-version"
+
+let request_method_header (request : Httpun.Request.t) =
+  Server_mcp_transport_http_session.get_header_any_case request.headers
+    "mcp-method"
+
+let request_name_header (request : Httpun.Request.t) =
+  Server_mcp_transport_http_session.get_header_any_case request.headers
+    "mcp-name"
+
+let request_uses_stateless_protocol request body_str =
+  match request_protocol_version_header request with
+  | Some version when Mcp_transport_protocol.is_stateless_protocol_version version ->
+      true
+  | _ -> Mcp_transport_protocol.body_uses_stateless_protocol body_str
+
+let body_required_name_for_method body_str method_ =
+  let field_name =
+    match method_ with
+    | "tools/call" | "prompts/get" -> Some "name"
+    | "resources/read" -> Some "uri"
+    | _ -> None
+  in
+  match field_name with
+  | None -> None
+  | Some key -> (
+      try
+        match Yojson.Safe.from_string body_str with
+        | `Assoc fields -> (
+            match List.assoc_opt "params" fields with
+            | Some (`Assoc params) -> (
+                match List.assoc_opt key params with
+                | Some (`String value) -> Some value
+                | _ -> None)
+            | _ -> None)
+        | _ -> None
+      with Yojson.Json_error _ -> None)
+
+let header_mismatch msg = Error ("HeaderMismatch: " ^ msg)
+
+let validate_2026_request_headers request body_str =
+  if not (request_uses_stateless_protocol request body_str) then Ok ()
+  else
+    match
+      ( request_protocol_version_header request,
+        Mcp_transport_protocol.protocol_version_from_request_meta_body body_str )
+    with
+    | None, _ ->
+        header_mismatch "missing MCP-Protocol-Version header"
+    | Some _, None ->
+        header_mismatch
+          ("missing params._meta."
+         ^ Mcp_transport_protocol.protocol_version_meta_key)
+    | Some header_version, Some body_version
+      when not (String.equal header_version body_version) ->
+        header_mismatch
+          (Printf.sprintf
+             "MCP-Protocol-Version header value %S does not match body _meta \
+              value %S"
+             header_version body_version)
+    | Some version, Some _ when not (Mcp_transport_protocol.is_supported_protocol_version version) ->
+        Error
+          (Printf.sprintf "Unsupported protocol version %S (supported: %s)"
+             version
+             (String.concat ", "
+                Mcp_transport_protocol.supported_protocol_versions))
+    | Some _version, Some _ -> (
+        match body_jsonrpc_method_only body_str with
+        | None -> Ok ()
+        | Some method_ -> (
+            match request_method_header request with
+            | None -> header_mismatch "missing Mcp-Method header"
+            | Some header_method when not (String.equal header_method method_) ->
+                header_mismatch
+                  (Printf.sprintf
+                     "Mcp-Method header value %S does not match body method %S"
+                     header_method method_)
+            | Some _ -> (
+                match body_required_name_for_method body_str method_ with
+                | None when
+                    String.equal method_ "tools/call"
+                    || String.equal method_ "resources/read"
+                    || String.equal method_ "prompts/get" ->
+                    header_mismatch
+                      "missing body params.name or params.uri for required Mcp-Name"
+                | None -> Ok ()
+                | Some body_name -> (
+                    match request_name_header request with
+                    | None -> header_mismatch "missing Mcp-Name header"
+                    | Some header_name when not (String.equal header_name body_name) ->
+                        header_mismatch
+                          (Printf.sprintf
+                             "Mcp-Name header value %S does not match body \
+                              value %S"
+                             header_name body_name)
+                    | Some _ -> Ok ()))))
 
 let should_use_sse_for_body (request : Httpun.Request.t) body_str accept_mode =
   match body_jsonrpc_method body_str with
@@ -97,18 +201,23 @@ let get_last_event_id (request : Httpun.Request.t) =
   | None -> None
 
 let mcp_headers session_id protocol_version =
-  [ ("mcp-session-id", session_id); ("mcp-protocol-version", protocol_version) ]
+  if Mcp_transport_protocol.is_stateless_protocol_version protocol_version then
+    [ ("mcp-protocol-version", protocol_version) ]
+  else
+    [ ("mcp-session-id", session_id); ("mcp-protocol-version", protocol_version) ]
 
 let session_cookie_header session_id =
   ( "set-cookie",
     Printf.sprintf "mcp-session-id=%s; Path=/; Max-Age=%d; SameSite=Lax"
       session_id Masc_time_constants.day_int )
 
+let session_cookie_headers protocol_version session_id =
+  if Mcp_transport_protocol.is_stateless_protocol_version protocol_version then []
+  else [ session_cookie_header session_id ]
+
 let sse_headers ~(deps : deps) session_id protocol_version origin =
-  [
-    ("content-type", Http_negotiation.sse_content_type);
-    session_cookie_header session_id;
-  ]
+  [ ("content-type", Http_negotiation.sse_content_type) ]
+  @ session_cookie_headers protocol_version session_id
   @ mcp_headers session_id protocol_version
   @ deps.cors_headers origin
 
@@ -117,8 +226,8 @@ let sse_stream_headers ~(deps : deps) session_id protocol_version origin =
     ("content-type", Http_negotiation.sse_content_type);
     ("cache-control", "no-cache");
     ("connection", "keep-alive");
-    session_cookie_header session_id;
   ]
+  @ session_cookie_headers protocol_version session_id
   @ mcp_headers session_id protocol_version
   @ deps.cors_headers origin
 

--- a/lib/server/server_mcp_transport_http_headers.mli
+++ b/lib/server/server_mcp_transport_http_headers.mli
@@ -33,6 +33,27 @@ val body_jsonrpc_method : string -> (string * bool) option
     non-object body).  [has_id] reports whether the [id] field is
     present (used to distinguish notifications from requests). *)
 
+val request_protocol_version_header : Httpun.Request.t -> string option
+(** Case-insensitive lookup of [MCP-Protocol-Version]. *)
+
+val request_method_header : Httpun.Request.t -> string option
+(** Case-insensitive lookup of [Mcp-Method]. *)
+
+val request_name_header : Httpun.Request.t -> string option
+(** Case-insensitive lookup of [Mcp-Name]. *)
+
+val request_uses_stateless_protocol : Httpun.Request.t -> string -> bool
+(** [true] iff either the HTTP protocol-version header or body
+    per-request [_meta] declares a stateless MCP revision. *)
+
+val validate_2026_request_headers :
+  Httpun.Request.t -> string -> (unit, string) result
+(** Enforces the 2026-07-28 mirrored-header contract when a request
+    opts into a stateless MCP revision. Legacy requests return [Ok ()].
+    Modern requests require [MCP-Protocol-Version], matching body
+    [_meta], [Mcp-Method], and, for [tools/call], [resources/read],
+    and [prompts/get], matching [Mcp-Name]. *)
+
 val is_initialize_method : string -> bool
 (** [is_initialize_method m] tests whether [m] equals the literal
     [["initialize"]].  The initialize handshake must always go over
@@ -78,9 +99,10 @@ val force_json_response : bool
 (** {1 Header builders} *)
 
 val mcp_headers : string -> string -> (string * string) list
-(** [mcp_headers session_id protocol_version] returns the two MCP
-    envelope headers ([mcp-session-id], [mcp-protocol-version]) in
-    fixed order for grep stability in operator dumps. *)
+(** [mcp_headers session_id protocol_version] returns MCP envelope
+    headers. Legacy protocol revisions include [mcp-session-id] and
+    [mcp-protocol-version]; stateless revisions include only
+    [mcp-protocol-version]. *)
 
 val session_cookie_header : string -> string * string
 (** [session_cookie_header session_id] returns
@@ -89,13 +111,18 @@ val session_cookie_header : string -> string * string
     operators relying on shorter sessions must reset cookies via
     a separate path. *)
 
+val session_cookie_headers : string -> string -> (string * string) list
+(** [session_cookie_headers protocol_version session_id] returns no
+    cookie headers for stateless protocol revisions, otherwise the
+    legacy {!session_cookie_header}. *)
+
 val sse_headers :
   deps:deps -> string -> string -> string -> (string * string) list
 (** [sse_headers ~deps session_id protocol_version origin] returns
     SSE response headers: [content-type] (from
-    {!Http_negotiation.sse_content_type}), {!session_cookie_header},
-    {!mcp_headers} pair, plus [deps.cors_headers origin].  Used by
-    the one-shot SSE response path. *)
+    {!Http_negotiation.sse_content_type}), optional legacy session
+    cookie, {!mcp_headers}, plus [deps.cors_headers origin].  Used
+    by the one-shot SSE response path. *)
 
 val sse_stream_headers :
   deps:deps -> string -> string -> string -> (string * string) list
@@ -107,7 +134,7 @@ val sse_stream_headers :
 val json_headers :
   deps:deps -> string -> string -> string -> (string * string) list
 (** [json_headers ~deps session_id protocol_version origin] returns
-    [content-type: application/json] + {!mcp_headers} pair +
+    [content-type: application/json] + {!mcp_headers} +
     [deps.cors_headers origin].  The canonical "JSON response"
     builder used by every JSON-bodied response in the transport. *)
 

--- a/lib/server/server_mcp_transport_http_protocol.ml
+++ b/lib/server/server_mcp_transport_http_protocol.ml
@@ -38,9 +38,11 @@ let method_from_body body_str =
 
 let validate_session_requirement ~session_was_provided body_str =
   if session_was_provided then Ok ()
+  else if Mcp_transport_protocol.body_uses_stateless_protocol body_str then Ok ()
   else
     match method_from_body body_str with
-    | Some "initialize" | Some "notifications/initialized" | Some "ping" ->
+    | Some "initialize" | Some "notifications/initialized" | Some "ping"
+    | Some "server/discover" ->
         Ok ()
     | Some _ | None ->
         Error
@@ -60,9 +62,11 @@ let validate_session_requirement ~session_was_provided body_str =
 let validate_session_known ~session_was_provided ~is_known body_str =
   if not session_was_provided then Ok ()
   else if is_known then Ok ()
+  else if Mcp_transport_protocol.body_uses_stateless_protocol body_str then Ok ()
   else
     match method_from_body body_str with
-    | Some "initialize" | Some "notifications/initialized" | Some "ping" ->
+    | Some "initialize" | Some "notifications/initialized" | Some "ping"
+    | Some "server/discover" ->
         Ok ()
     | Some _ | None ->
         Error
@@ -79,6 +83,12 @@ let request_force_json_response =
   Server_mcp_transport_http_headers.request_force_json_response
 
 let classify_mcp_accept = Server_mcp_transport_http_headers.classify_mcp_accept
+
+let request_uses_stateless_protocol =
+  Server_mcp_transport_http_headers.request_uses_stateless_protocol
+
+let validate_2026_request_headers =
+  Server_mcp_transport_http_headers.validate_2026_request_headers
 
 let should_use_sse_for_body =
   Server_mcp_transport_http_headers.should_use_sse_for_body

--- a/lib/server/server_mcp_transport_http_protocol.mli
+++ b/lib/server/server_mcp_transport_http_protocol.mli
@@ -69,10 +69,12 @@ val validate_session_requirement :
 
     - Returns [Ok ()] when [session_was_provided = true] (session
       header / cookie / query-param resolved).
-    - When [session_was_provided = false], inspects the JSON-RPC
-      method via {!method_from_body}.  Permits the bootstrap
-      methods [initialize] / [notifications/initialized] / [ping]
-      to proceed without a session id; everything else rejects:
+    - When [session_was_provided = false], stateless 2026-07-28
+      bodies are admitted without a session.
+    - Otherwise inspects the JSON-RPC method via {!method_from_body}.
+      Permits the bootstrap methods [initialize] /
+      [notifications/initialized] / [ping] / [server/discover] to
+      proceed without a session id; everything else rejects:
 
       [Error "Mcp-Session-Id header required. Call initialize first
       to obtain a session."] *)
@@ -86,10 +88,11 @@ val validate_session_known :
     echoes an [Mcp-Session-Id] the server has no state for. Returns
     [Ok ()] when [session_was_provided = false] (a missing header is
     handled by {!validate_session_requirement}), when [is_known = true],
-    or when the JSON-RPC method is one of the handshake set
-    ([initialize] / [notifications/initialized] / [ping]). Otherwise
-    returns [Error] with a message suitable for a [404 Not Found]
-    response body. *)
+    when the body declares a stateless 2026-07-28 protocol version, or
+    when the JSON-RPC method is one of the bootstrap/probe set
+    ([initialize] / [notifications/initialized] / [ping] /
+    [server/discover]). Otherwise returns [Error] with a message
+    suitable for a [404 Not Found] response body. *)
 
 (** {1 Re-exports} *)
 
@@ -116,6 +119,15 @@ val classify_mcp_accept :
   Httpun.Request.t -> Mcp_transport_protocol.Http_negotiation.accept_mode
 (** Re-export of
     {!Server_mcp_transport_http_headers.classify_mcp_accept}. *)
+
+val request_uses_stateless_protocol : Httpun.Request.t -> string -> bool
+(** Re-export of
+    {!Server_mcp_transport_http_headers.request_uses_stateless_protocol}. *)
+
+val validate_2026_request_headers :
+  Httpun.Request.t -> string -> (unit, string) result
+(** Re-export of
+    {!Server_mcp_transport_http_headers.validate_2026_request_headers}. *)
 
 val should_use_sse_for_body :
   Httpun.Request.t ->

--- a/test/test_http_negotiation.ml
+++ b/test/test_http_negotiation.ml
@@ -151,6 +151,95 @@ let test_initialize_never_uses_sse () =
     (Transport.should_use_sse_for_body request body
        Mcp_transport_protocol.Http_negotiation.Streamable)
 
+let stateless_body ?(method_ = "tools/list") ?name () =
+  let params_fields =
+    [ ( "_meta",
+        `Assoc
+          [
+            ( Mcp_transport_protocol.protocol_version_meta_key,
+              `String "2026-07-28" );
+            ( "io.modelcontextprotocol/clientInfo",
+              `Assoc
+                [ ("name", `String "http-test"); ("version", `String "0.1") ]
+            );
+            ("io.modelcontextprotocol/clientCapabilities", `Assoc []);
+          ] )
+    ]
+    @
+    match name with
+    | None -> []
+    | Some value -> [ ("name", `String value) ]
+  in
+  `Assoc
+    [
+      ("jsonrpc", `String "2.0");
+      ("id", `Int 1);
+      ("method", `String method_);
+      ("params", `Assoc params_fields);
+    ]
+  |> Yojson.Safe.to_string
+
+let test_validate_2026_request_headers () =
+  let module Transport = Masc_mcp.Server_mcp_transport_http in
+  let ok_request =
+    Httpun.Request.create
+      ~headers:
+        (Httpun.Headers.of_list
+           [
+             ("accept", "application/json, text/event-stream");
+             ("mcp-protocol-version", "2026-07-28");
+             ("mcp-method", "tools/list");
+           ])
+      `POST "/mcp"
+  in
+  (match Transport.validate_2026_request_headers ok_request (stateless_body ()) with
+  | Ok () -> ()
+  | Error msg -> failf "expected valid 2026 headers, got %s" msg);
+  let tool_call_request =
+    Httpun.Request.create
+      ~headers:
+        (Httpun.Headers.of_list
+           [
+             ("accept", "application/json, text/event-stream");
+             ("mcp-protocol-version", "2026-07-28");
+             ("mcp-method", "tools/call");
+             ("mcp-name", "masc_status");
+           ])
+      `POST "/mcp"
+  in
+  (match
+     Transport.validate_2026_request_headers tool_call_request
+       (stateless_body ~method_:"tools/call" ~name:"masc_status" ())
+   with
+  | Ok () -> ()
+  | Error msg -> failf "expected valid Mcp-Name headers, got %s" msg);
+  let mismatch_request =
+    Httpun.Request.create
+      ~headers:
+        (Httpun.Headers.of_list
+           [
+             ("accept", "application/json, text/event-stream");
+             ("mcp-protocol-version", "2026-07-28");
+             ("mcp-method", "resources/list");
+           ])
+      `POST "/mcp"
+  in
+  match Transport.validate_2026_request_headers mismatch_request (stateless_body ()) with
+  | Ok () -> fail "expected mismatched Mcp-Method to reject"
+  | Error msg ->
+      check bool "mentions header mismatch" true
+        (String_util.contains_substring msg "HeaderMismatch")
+
+let test_stateless_headers_do_not_emit_session_id () =
+  let module Transport = Masc_mcp.Server_mcp_transport_http in
+  let headers = Transport.mcp_headers "session-x" "2026-07-28" in
+  check (option string) "no mcp-session-id"
+    None
+    (List.assoc_opt "mcp-session-id" headers);
+  check (option string) "keeps protocol version"
+    (Some "2026-07-28")
+    (List.assoc_opt "mcp-protocol-version" headers)
+
 let test_sse_guard_registry_is_shared_with_cleanup_loop () =
   let module Transport = Masc_mcp.Server_mcp_transport_http in
   let module Cleanup_view = Masc_mcp.Server_mcp_transport_http_sse in
@@ -213,6 +302,10 @@ let () =
         test_case "initialize json-only is rejected" `Quick test_initialize_json_only_accepted;
         test_case "no accept header rejected" `Quick test_no_accept_header_rejected;
         test_case "initialize disables sse" `Quick test_initialize_never_uses_sse;
+        test_case "2026 headers are validated" `Quick
+          test_validate_2026_request_headers;
+        test_case "2026 headers omit session id" `Quick
+          test_stateless_headers_do_not_emit_session_id;
         test_case "sse guard registry is shared" `Quick
           test_sse_guard_registry_is_shared_with_cleanup_loop;
         test_case "preserve guard keeps cooldown" `Quick

--- a/test/test_mcp_h1_h2_admission_parity.ml
+++ b/test/test_mcp_h1_h2_admission_parity.ml
@@ -26,6 +26,34 @@ let request ?(headers = []) ?(meth = `POST) target =
 let body method_ =
   Printf.sprintf {|{"jsonrpc":"2.0","id":1,"method":"%s","params":{}}|} method_
 
+let stateless_body ?(method_ = "tools/list") ?name () =
+  let params_fields =
+    [ ("_meta",
+       `Assoc
+         [
+           ( Mcp_transport_protocol.protocol_version_meta_key,
+             `String "2026-07-28" );
+           ( "io.modelcontextprotocol/clientInfo",
+             `Assoc
+               [ ("name", `String "parity-test"); ("version", `String "0.1") ]
+           );
+           ("io.modelcontextprotocol/clientCapabilities", `Assoc []);
+         ] )
+    ]
+    @
+    match name with
+    | None -> []
+    | Some value -> [ ("name", `String value) ]
+  in
+  `Assoc
+    [
+      ("jsonrpc", `String "2.0");
+      ("id", `Int 1);
+      ("method", `String method_);
+      ("params", `Assoc params_fields);
+    ]
+  |> Yojson.Safe.to_string
+
 let initialize_body =
   {|{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"parity-test","version":"0.1"}}}|}
 
@@ -78,6 +106,26 @@ let test_request_context_decides_post_body () =
   let streamable_request =
     request ~headers:[ ("accept", "application/json, text/event-stream") ] "/mcp"
   in
+  let stateless_request =
+    request
+      ~headers:
+        [
+          ("accept", "application/json, text/event-stream");
+          ("mcp-protocol-version", "2026-07-28");
+          ("mcp-method", "tools/list");
+        ]
+      "/mcp"
+  in
+  let stateless_bad_method_request =
+    request
+      ~headers:
+        [
+          ("accept", "application/json, text/event-stream");
+          ("mcp-protocol-version", "2026-07-28");
+          ("mcp-method", "tools/call");
+        ]
+      "/mcp"
+  in
   let json_only_request =
     request ~headers:[ ("accept", "application/json") ] "/mcp"
   in
@@ -120,7 +168,26 @@ let test_request_context_decides_post_body () =
        ~context:(context ()) ~session_is_known:false initialize_body
    with
   | Ok _ -> ()
-  | Error _ -> fail "unknown session should still permit initialize")
+  | Error _ -> fail "unknown session should still permit initialize");
+  (match
+     Request_context.decide_post_body ~request:stateless_request
+       ~context:(context ~session_was_provided:false ()) ~session_is_known:false
+       (stateless_body ())
+   with
+  | Ok decision ->
+      assert_accept_mode "stateless decision" Negotiation.Streamable
+        decision.accept_mode
+  | Error _ -> fail "stateless 2026 request should not require a session");
+  (match
+     Request_context.decide_post_body ~request:stateless_bad_method_request
+       ~context:(context ~session_was_provided:false ()) ~session_is_known:false
+       (stateless_body ())
+   with
+  | Error (Request_context.Header_mismatch msg) ->
+      check bool "header mismatch mentions Mcp-Method" true
+        (contains ~needle:"Mcp-Method" msg)
+  | Ok _ -> fail "mismatched stateless headers should reject"
+  | Error _ -> fail "mismatched stateless headers should use Header_mismatch")
 
 let test_shared_post_admission_matrix () =
   assert_result_ok "initialize may mint a fresh session"
@@ -129,12 +196,18 @@ let test_shared_post_admission_matrix () =
   assert_result_error "tools/call requires a session id"
     (Transport.validate_session_requirement ~session_was_provided:false
        (body "tools/call"));
+  assert_result_ok "2026 stateless request does not require a session id"
+    (Transport.validate_session_requirement ~session_was_provided:false
+       (stateless_body ()));
   assert_result_ok "known session passes Q3"
     (Transport.validate_session_known ~session_was_provided:true ~is_known:true
        (body "tools/call"));
   assert_result_error "unknown session blocks tools/call"
     (Transport.validate_session_known ~session_was_provided:true ~is_known:false
        (body "tools/call"));
+  assert_result_ok "unknown supplied session is ignored for 2026 stateless"
+    (Transport.validate_session_known ~session_was_provided:true ~is_known:false
+       (stateless_body ()));
   assert_result_ok "unknown session still permits initialize"
     (Transport.validate_session_known ~session_was_provided:true ~is_known:false
        initialize_body);

--- a/test/test_mcp_protocol_coverage.ml
+++ b/test/test_mcp_protocol_coverage.ml
@@ -26,6 +26,18 @@ let test_supported_protocol_versions () =
   check bool "current version included" true
     (List.mem "2025-11-25" Mcp_transport_protocol.supported_protocol_versions)
 
+let test_supported_protocol_versions_includes_2026_stateless () =
+  check bool "2026 stateless version included" true
+    (List.mem "2026-07-28"
+       Mcp_transport_protocol.supported_protocol_versions);
+  check bool "draft alias included" true
+    (List.mem "DRAFT-2026-v1"
+       Mcp_transport_protocol.supported_protocol_versions);
+  check bool "2026 is stateless" true
+    (Mcp_transport_protocol.is_stateless_protocol_version "2026-07-28");
+  check bool "draft alias is stateless" true
+    (Mcp_transport_protocol.is_stateless_protocol_version "DRAFT-2026-v1")
+
 let test_protocol_version_from_params_none () =
   check string "none falls back to default" "2025-11-25"
     (Mcp_transport_protocol.protocol_version_from_params None)
@@ -55,6 +67,14 @@ let test_protocol_version_from_body_missing_jsonrpc () =
   check (option string) "missing jsonrpc rejected" None
     (Mcp_transport_protocol.protocol_version_from_body
        {|{"method":"initialize","params":{"protocolVersion":"2025-06-18"}}|})
+
+let test_protocol_version_from_request_meta_body () =
+  check (option string) "request meta version" (Some "2026-07-28")
+    (Mcp_transport_protocol.protocol_version_from_request_meta_body
+       {|{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28"}}}|});
+  check bool "body uses stateless protocol" true
+    (Mcp_transport_protocol.body_uses_stateless_protocol
+       {|{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28"}}}|})
 
 (* ============================================================
    accepts_json Tests (new: delegates to SDK with wildcard support)
@@ -196,6 +216,8 @@ let () =
       test_case "json_content_type" `Quick test_json_content_type;
       test_case "default_protocol_version" `Quick test_default_protocol_version;
       test_case "supported_protocol_versions" `Quick test_supported_protocol_versions;
+      test_case "supported_protocol_versions includes 2026 stateless" `Quick
+        test_supported_protocol_versions_includes_2026_stateless;
     ];
     "protocol_versions", [
       test_case "from_params none" `Quick test_protocol_version_from_params_none;
@@ -207,6 +229,8 @@ let () =
         test_protocol_version_from_body_non_initialize;
       test_case "from_body missing jsonrpc" `Quick
         test_protocol_version_from_body_missing_jsonrpc;
+      test_case "from_request_meta_body" `Quick
+        test_protocol_version_from_request_meta_body;
     ];
     "accepts_json", [
       test_case "none" `Quick test_accepts_json_none;

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -558,6 +558,64 @@ let test_handle_request_initialize_rejects_unsupported_protocol_version () =
 
   cleanup_dir base_path
 
+let test_handle_request_server_discover_2026 () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+  let base_path = temp_dir () in
+  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let request =
+    Yojson.Safe.to_string
+      (`Assoc
+        [
+          ("jsonrpc", `String "2.0");
+          ("id", `String "discover-1");
+          ("method", `String "server/discover");
+          ( "params",
+            `Assoc
+              [
+                ( "_meta",
+                  `Assoc
+                    [
+                      ( Mcp_transport_protocol.protocol_version_meta_key,
+                        `String "2026-07-28" );
+                      ( "io.modelcontextprotocol/clientInfo",
+                        `Assoc
+                          [ ("name", `String "test"); ("version", `String "0.1") ]
+                      );
+                      ("io.modelcontextprotocol/clientCapabilities", `Assoc []);
+                    ] );
+              ] );
+        ])
+  in
+  let response = Mcp_eio.handle_request ~clock ~sw state request in
+  let result = result_fields_exn response in
+  Alcotest.(check (option string)) "complete result"
+    (Some "complete")
+    (match List.assoc_opt "resultType" result with
+     | Some (`String value) -> Some value
+     | _ -> None);
+  (match List.assoc_opt "supportedVersions" result with
+   | Some (`List versions) ->
+       let versions =
+         List.filter_map
+           (function
+             | `String value -> Some value
+             | _ -> None)
+           versions
+       in
+       Alcotest.(check bool) "advertises 2026-07-28" true
+         (List.mem "2026-07-28" versions);
+       Alcotest.(check bool) "keeps 2025-11-25 compatibility" true
+         (List.mem "2025-11-25" versions)
+   | _ -> Alcotest.fail "supportedVersions not a list");
+  Alcotest.(check bool) "has serverInfo" true
+    (List.mem_assoc "serverInfo" result);
+  Alcotest.(check bool) "has capabilities" true
+    (List.mem_assoc "capabilities" result);
+  cleanup_dir base_path
+
 let test_handle_request_tools_list () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -626,6 +684,17 @@ let test_handle_request_tools_list () =
   let meta = tools_list_meta_exn first_page in
   let total_count = int_field_exn "tools/list _meta" meta "totalCount" in
   let page_size = int_field_exn "tools/list _meta" meta "pageSize" in
+  let result_fields = result_fields_exn first_page in
+  Alcotest.(check (option int)) "tools/list ttlMs"
+    (Some 5000)
+    (match List.assoc_opt "ttlMs" result_fields with
+     | Some (`Int value) -> Some value
+     | _ -> None);
+  Alcotest.(check (option string)) "tools/list cacheScope"
+    (Some "private")
+    (match List.assoc_opt "cacheScope" result_fields with
+     | Some (`String value) -> Some value
+     | _ -> None);
   Alcotest.(check bool) "next cursor matches totalCount/pageSize"
     (total_count > page_size)
     (Option.is_some (next_cursor_of_response first_page));
@@ -2692,6 +2761,8 @@ let eio_tests = [
   "handle initialize", `Quick, test_handle_request_initialize;
   "handle initialize rejects unsupported protocol version", `Quick,
     test_handle_request_initialize_rejects_unsupported_protocol_version;
+  "handle server/discover advertises 2026", `Quick,
+    test_handle_request_server_discover_2026;
   "handle initialize operator profile", `Quick,
     test_handle_request_initialize_operator_profile;
   "handle tools/list", `Quick, test_handle_request_tools_list;


### PR DESCRIPTION
## Summary
- Accept the upcoming MCP stateless revision via both `2026-07-28` and the current `DRAFT-2026-v1` alias while preserving the existing default `2025-11-25` path.
- Add `server/discover`, per-request `_meta` protocol extraction, mirrored-header checks for `MCP-Protocol-Version` / `Mcp-Method` / `Mcp-Name`, and stateless session admission that omits `Mcp-Session-Id` response headers for 2026 requests.
- Add cache hints (`ttlMs`, `cacheScope`) to MCP list/read responses and cover the new transport/protocol behavior with focused tests.

## Verification
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_mcp_protocol_coverage.exe test/test_http_negotiation.exe test/test_mcp_h1_h2_admission_parity.exe test/test_mcp_server_eio.exe` passed before rebasing to latest `origin/main`.
- `_build/default/test/test_mcp_protocol_coverage.exe` passed: 37 tests.
- `_build/default/test/test_http_negotiation.exe` passed: 15 tests.
- `_build/default/test/test_mcp_h1_h2_admission_parity.exe` passed: 6 tests.
- `_build/default/test/test_mcp_server_eio.exe test eio 2,4` passed: new `server/discover` + touched `tools/list` case.
- `_build/default/test/test_mcp_server_eio.exe test eio 14` passed: resource read smoke.
- `ocamlformat --check ...changed OCaml files...` passed locally with 0.29.0.
- `git diff --check` passed.

## Known Blocker
- After rebasing onto latest `origin/main` (`1096d319ba`), focused Dune build is blocked by unrelated mainline syntax errors in `lib/types/types_core.mli` and `lib/keeper/keeper_meta_json_parse.ml`. Recorded as #19636.
- Full `test_mcp_server_eio.exe` still has existing environment-dependent failures after `eio.015` (`MASC not initialized`); the new/touched cases above pass when selected directly.