### PR TITLE
Purge keeper room reply surface

### DIFF
--- a/config/prompts/keeper.deliberation.md
+++ b/config/prompts/keeper.deliberation.md
@@ -15,7 +15,6 @@ Detected triggers that require your attention:
 
 Available actions (pick exactly one):
 - noop: Do nothing. Use when triggers do not warrant action.
-- reply_in_room: Reply in the current namespace conversation. Requires room_id and content.
 - task_claim: Claim an unclaimed task. Requires task_id and reason.
 - broadcast: Send a broadcast message to all agents. Requires message.
 - board_post: Post to the community board. Requires content and optional hearth.
@@ -30,7 +29,6 @@ Respond with ONLY the tool input object for schema `keeper_deliberation_decision
 
 Examples:
 {"action":"noop","params":{"reason":"No urgent triggers"},"reasoning":"All triggers are low priority","confidence":0.9}
-{"action":"reply_in_room","params":{"room_id":"default","content":"I see a new task available."},"reasoning":"Direct mention in the namespace conversation needs a reply","confidence":0.8}
 {"action":"task_claim","params":{"task_id":"task-123","reason":"Matches my goal"},"reasoning":"Unclaimed task aligns with keeper goal","confidence":0.7}
 {"action":"broadcast","params":{"message":"Status update: monitoring active goals"},"reasoning":"Team needs coordination update","confidence":0.6}
 {"action":"board_post","params":{"content":"Noticed recurring pattern in board posts about memory search quality","hearth":"observation"},"reasoning":"Self-directed exploration found a pattern worth sharing","confidence":0.65}{{multi_step_example}}

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -170,7 +170,6 @@ type turn_affordance =
   | Board_curation
   | Board_post_or_comment
   | Message_sweep
-  | Reply_in_room
   | Task_claim
   | Task_audit
   | Task_verify
@@ -179,7 +178,6 @@ let turn_affordance_of_string = function
   | "board_curation" -> Some Board_curation
   | "board_post_or_comment" -> Some Board_post_or_comment
   | "message_sweep" -> Some Message_sweep
-  | "reply_in_room" -> Some Reply_in_room
   | "task_claim" -> Some Task_claim
   | "task_audit" -> Some Task_audit
   | "task_verify" -> Some Task_verify
@@ -189,7 +187,6 @@ let turn_affordance_to_string = function
   | Board_curation -> "board_curation"
   | Board_post_or_comment -> "board_post_or_comment"
   | Message_sweep -> "message_sweep"
-  | Reply_in_room -> "reply_in_room"
   | Task_claim -> "task_claim"
   | Task_audit -> "task_audit"
   | Task_verify -> "task_verify"
@@ -199,7 +196,6 @@ let should_tool_gate_affordance = function
   | Board_curation
   | Board_post_or_comment
   | Message_sweep
-  | Reply_in_room
   | Task_audit
   | Task_verify -> true
 
@@ -223,9 +219,6 @@ let tools_for_gated_affordance = function
   | Board_post_or_comment ->
     [ "keeper_board_post"; "keeper_board_comment"; "masc_broadcast" ]
   | Message_sweep -> [ "masc_messages"; "masc_keeper_msg" ]
-  | Reply_in_room ->
-    [ "keeper_board_post"; "keeper_board_comment";
-      "masc_keeper_msg"; "masc_broadcast" ]
   | Task_claim ->
     [ "keeper_task_claim"; "masc_claim_next" ]
   | Task_audit ->
@@ -264,9 +257,6 @@ let preferred_tool_names_for_turn_affordances turn_affordances =
          [ "keeper_board_comment"; "keeper_board_post" ]
        | Message_sweep ->
          [ "masc_keeper_msg"; "masc_broadcast" ]
-       | Reply_in_room ->
-         [ "keeper_board_comment"; "keeper_board_post";
-           "masc_keeper_msg"; "masc_broadcast" ]
        | Task_claim ->
          [ "keeper_task_claim"; "masc_claim_next" ]
        | Task_audit ->
@@ -443,12 +433,6 @@ let preferred_tool_choice_for_required_turn ~(has_current_task : bool)
           && List.exists
                progress_tool_available
                [ "keeper_board_comment"; "keeper_board_post"; "masc_broadcast" ]
-  then Agent_sdk.Types.Any
-  else if has_turn_affordance Reply_in_room turn_affordances
-          && List.exists
-               progress_tool_available
-               [ "keeper_board_comment"; "keeper_board_post"; "masc_keeper_msg";
-                 "masc_broadcast" ]
   then Agent_sdk.Types.Any
   else if has_turn_affordance Task_audit turn_affordances
           && progress_tool_available "keeper_tasks_audit"

--- a/lib/keeper/keeper_deliberation.ml
+++ b/lib/keeper/keeper_deliberation.ml
@@ -41,7 +41,6 @@ let deliberation_trigger_to_json trigger =
 
 type deliberation_action =
   | Noop of string
-  | ReplyInRoom of { room_id: string; content: string }
   | BoardPost of { content: string; hearth: string option }
   | BoardComment of { post_id: string; content: string }
   | BoardVote of { post_id: string; direction: string }
@@ -52,7 +51,6 @@ type deliberation_action =
 
 let rec deliberation_action_to_string = function
   | Noop reason -> "noop:" ^ reason
-  | ReplyInRoom _ -> "reply_in_room"
   | BoardPost _ -> "board_post"
   | BoardComment _ -> "board_comment"
   | BoardVote _ -> "board_vote"
@@ -67,7 +65,6 @@ let rec deliberation_action_to_string = function
 (** Map typed action to stable policy labels used by policy logging and reward models. *)
 let deliberation_action_to_policy_label = function
   | Noop _ -> "noop"
-  | ReplyInRoom _ -> "reply_in_room"
   | BoardPost _ -> "board_post"
   | BoardComment _ -> "board_comment"
   | BoardVote _ -> "board_vote"
@@ -79,13 +76,6 @@ let deliberation_action_to_policy_label = function
 let rec deliberation_action_to_json = function
   | Noop reason ->
       `Assoc [ ("type", `String "noop"); ("reason", `String reason) ]
-  | ReplyInRoom { room_id; content } ->
-      `Assoc
-        [
-          ("type", `String "reply_in_room");
-          ("room_id", `String room_id);
-          ("content", `String content);
-        ]
   | BoardPost { content; hearth } ->
       `Assoc
         [
@@ -288,11 +278,10 @@ let deliberation_meta_of_json (json : Yojson.Safe.t) : deliberation_meta =
 
 (* ---------- Baseline action: typed replacement for the 2-line heuristic ---------- *)
 
-(** Deterministic baseline using the typed action space.
-    Equivalent to the old [if direct_mention then "reply_in_room" else "noop"]. *)
+(** Deterministic baseline using the typed action space. *)
 let deterministic_baseline_action (obs : world_observation) : deliberation_action =
   if obs.direct_mention then
-    ReplyInRoom { room_id = ""; content = "" }
+    Noop "direct mention requires explicit board/task action"
   else
     Noop "no_trigger"
 
@@ -435,9 +424,6 @@ let is_self_directed (obs : world_observation) =
 
 let rec legality_error (obs : world_observation) = function
   | Noop _ -> None
-  | ReplyInRoom _ ->
-      if has_room_signal obs then None
-      else Some "reply_in_room requires direct mention or a question"
   | BoardPost _ ->
       if has_board_signal obs || obs.active_goal_count > 0
          || is_self_directed obs then None
@@ -572,11 +558,6 @@ let rec parse_action_from_json (json : Yojson.Safe.t)
   | "noop" ->
       let reason = Safe_ops.json_string ~default:"no reason" "reason" params in
       Ok (Noop reason)
-  | "reply_in_room" ->
-      let room_id = Safe_ops.json_string ~default:"default" "room_id" params in
-      let content = Safe_ops.json_string ~default:"" "content" params in
-      if content = "" then Error "reply_in_room requires non-empty content"
-      else Ok (ReplyInRoom { room_id; content })
   | "task_claim" ->
       let task_id = Safe_ops.json_string ~default:"" "task_id" params in
       let reason = Safe_ops.json_string ~default:"" "reason" params in
@@ -686,7 +667,7 @@ let structured_result_schema : structured_result Agent_sdk.Structured.schema =
       [
         {
           Agent_sdk.Types.name = "action";
-          description = "One of: noop, reply_in_room, task_claim, broadcast, board_post, board_comment, board_vote, propose_spawn, multi_step.";
+          description = "One of: noop, task_claim, broadcast, board_post, board_comment, board_vote, propose_spawn, multi_step.";
           param_type = Agent_sdk.Types.String;
           required = true;
         };

--- a/lib/keeper/keeper_deliberation.mli
+++ b/lib/keeper/keeper_deliberation.mli
@@ -24,7 +24,6 @@ val deliberation_trigger_to_json : deliberation_trigger -> Yojson.Safe.t
 
 type deliberation_action =
   | Noop of string
-  | ReplyInRoom of { room_id: string; content: string }
   | BoardPost of { content: string; hearth: string option }
   | BoardComment of { post_id: string; content: string }
   | BoardVote of { post_id: string; direction: string }
@@ -130,8 +129,7 @@ val deliberation_meta_of_json : Yojson.Safe.t -> deliberation_meta
 
 (** {1 Baseline action} *)
 
-(** Deterministic baseline using the typed action space.
-    Equivalent to the old [if direct_mention then "reply_in_room" else "noop"]. *)
+(** Deterministic baseline using the typed action space. *)
 val deterministic_baseline_action : world_observation -> deliberation_action
 
 (** {1 Phase 2: Deliberation Evaluation} *)

--- a/lib/keeper/keeper_unified_metrics_support.ml
+++ b/lib/keeper/keeper_unified_metrics_support.ml
@@ -440,7 +440,6 @@ let observed_affordances_of_observation
     (observation : Keeper_world_observation.world_observation) : string list =
   let affordances = ref [] in
   let add affordance = affordances := affordance :: !affordances in
-  if observation.pending_mentions <> [] then add "reply_in_room";
   if observation.pending_board_events <> [] then add "board_post_or_comment";
   let _ = meta in
   if List.length observation.pending_board_events >= 2 then add "board_curation";

--- a/test/test_keeper_deliberation.ml
+++ b/test/test_keeper_deliberation.ml
@@ -123,11 +123,6 @@ let test_action_to_policy_label_noop () =
   check string "noop policy label" "noop"
     (D.deliberation_action_to_policy_label (D.Noop "test"))
 
-let test_action_to_policy_label_reply () =
-  check string "reply policy label" "reply_in_room"
-    (D.deliberation_action_to_policy_label
-       (D.ReplyInRoom { room_id = "r1"; content = "hello" }))
-
 let test_action_to_policy_label_board_post () =
   check string "board_post policy label" "board_post"
     (D.deliberation_action_to_policy_label
@@ -139,12 +134,12 @@ let test_action_to_policy_label_task_claim () =
        (D.TaskClaim { task_id = "t-1"; reason = "needed" }))
 
 let test_action_to_json_roundtrip () =
-  let action = D.ReplyInRoom { room_id = "room-1"; content = "hello" } in
+  let action = D.BoardPost { content = "hello"; hearth = None } in
   let json = D.deliberation_action_to_json action in
   let typ =
     Yojson.Safe.Util.member "type" json |> Yojson.Safe.Util.to_string
   in
-  check string "json type field" "reply_in_room" typ
+  check string "json type field" "board_post" typ
 
 let test_action_to_json_noop () =
   let action = D.Noop "nothing to do" in
@@ -168,12 +163,12 @@ let test_action_multistep_to_string () =
 
 (* ---------- Baseline action tests ---------- *)
 
-let test_baseline_mention_returns_reply () =
+let test_baseline_mention_returns_noop () =
   let obs = { base_obs with direct_mention = true } in
   let action = D.deterministic_baseline_action obs in
   match action with
-  | D.ReplyInRoom _ -> ()
-  | _ -> fail "expected ReplyInRoom for direct mention"
+  | D.Noop _ -> ()
+  | _ -> fail "expected Noop for direct mention"
 
 let test_baseline_no_mention_returns_noop () =
   let obs = base_obs in
@@ -354,9 +349,6 @@ let test_prompt_contains_action_list () =
   check bool "mentions noop action" true
     (try ignore (Str.search_forward (Str.regexp_string "noop") prompt 0); true
      with Not_found -> false);
-  check bool "mentions reply_in_room action" true
-    (try ignore (Str.search_forward (Str.regexp_string "reply_in_room") prompt 0); true
-     with Not_found -> false);
   check bool "mentions task_claim action" true
     (try ignore (Str.search_forward (Str.regexp_string "task_claim") prompt 0); true
      with Not_found -> false);
@@ -379,19 +371,6 @@ let test_parse_valid_noop_json () =
        | _ -> fail "expected Noop action");
       check string "reasoning" "Nothing to do" reasoning;
       check (float 0.01) "confidence" 0.95 confidence
-
-let test_parse_valid_reply_json () =
-  let raw =
-    {|{"action":"reply_in_room","params":{"room_id":"room-42","content":"Hello team"},"reasoning":"Responding to mention","confidence":0.8}|}
-  in
-  match D.parse_deliberation_response raw with
-  | Error msg -> fail ("expected Ok, got Error: " ^ msg)
-  | Ok (action, _reasoning, _confidence) ->
-      match action with
-      | D.ReplyInRoom { room_id; content } ->
-          check string "room_id" "room-42" room_id;
-          check string "content" "Hello team" content
-      | _ -> fail "expected ReplyInRoom action"
 
 let test_parse_valid_task_claim_json () =
   let raw =
@@ -560,14 +539,6 @@ let test_parse_unknown_action_type () =
         (try ignore (Str.search_forward (Str.regexp_string "unknown action") msg 0); true
          with Not_found -> false)
   | Ok _ -> fail "expected Error for unknown action type"
-
-let test_parse_reply_empty_content_fails () =
-  let raw =
-    {|{"action":"reply_in_room","params":{"room_id":"r1","content":""},"reasoning":"test","confidence":0.5}|}
-  in
-  match D.parse_deliberation_response raw with
-  | Error _ -> ()
-  | Ok _ -> fail "expected Error for empty reply content"
 
 let test_parse_task_claim_empty_task_id_fails () =
   let raw =
@@ -804,12 +775,12 @@ let test_parse_multi_step_nested_rejected () =
 let test_parse_multi_step_invalid_substep_fails () =
   let raw =
     {|{"action":"multi_step","params":{"steps":[
-        {"action":"reply_in_room","params":{"room_id":"r1","content":""}},
+        {"action":"task_claim","params":{"task_id":"","reason":"missing task"}},
         {"action":"noop","params":{"reason":"ok"}}
       ]},"reasoning":"bad step","confidence":0.5}|}
   in
   match D.parse_deliberation_response raw with
-  | Error _ -> () (* expected: reply with empty content fails *)
+  | Error _ -> ()
   | Ok _ -> fail "expected Error for invalid substep in multi_step"
 
 (* ---------- multi_step is always included ---------- *)
@@ -1048,8 +1019,6 @@ let () =
         [
           test_case "noop to policy label" `Quick
             test_action_to_policy_label_noop;
-          test_case "reply to policy label" `Quick
-            test_action_to_policy_label_reply;
           test_case "board_post to policy label" `Quick
             test_action_to_policy_label_board_post;
           test_case "task_claim to policy label" `Quick
@@ -1063,8 +1032,8 @@ let () =
         ] );
       ( "baseline",
         [
-          test_case "mention returns ReplyInRoom" `Quick
-            test_baseline_mention_returns_reply;
+          test_case "mention returns Noop" `Quick
+            test_baseline_mention_returns_noop;
           test_case "no mention returns Noop" `Quick
             test_baseline_no_mention_returns_noop;
           test_case "baseline execution emits baseline source" `Quick
@@ -1127,8 +1096,6 @@ let () =
       ( "parse_deliberation_response",
         [
           test_case "parse valid noop" `Quick test_parse_valid_noop_json;
-          test_case "parse valid reply_in_room" `Quick
-            test_parse_valid_reply_json;
           test_case "parse valid task_claim" `Quick
             test_parse_valid_task_claim_json;
           test_case "parse valid broadcast" `Quick
@@ -1145,8 +1112,6 @@ let () =
             test_parse_missing_action_field;
           test_case "parse unknown action type" `Quick
             test_parse_unknown_action_type;
-          test_case "reply with empty content fails" `Quick
-            test_parse_reply_empty_content_fails;
           test_case "task_claim with empty task_id fails" `Quick
             test_parse_task_claim_empty_task_id_fails;
           test_case "confidence clamped to 1.0" `Quick

--- a/test/test_keeper_unified_required_tools.ml
+++ b/test/test_keeper_unified_required_tools.ml
@@ -189,15 +189,7 @@ let test_satisfying_tools_for_turn_computes_from_affordances () =
       ~allowed_tool_names:[ "masc_claim_next"; "masc_status" ]
   in
   check (list string) "task_claim returns only allowed subset" [ "masc_claim_next" ] partial;
-  let multi =
-    Surface.satisfying_tools_for_turn
-      ~turn_affordances:[ "reply_in_room"; "board_post_or_comment" ]
-      ~allowed_tool_names:
-        [ "keeper_board_post"; "keeper_board_comment"; "masc_broadcast"; "masc_keeper_msg" ]
-  in
-  List.iter
-    (fun t -> check bool ("tool in multi-affordance result: " ^ t) true (List.mem t multi))
-    [ "keeper_board_post"; "keeper_board_comment"; "masc_keeper_msg"; "masc_broadcast" ];
+  ()
   let empty =
     Surface.satisfying_tools_for_turn
       ~turn_affordances:[ "unknown_affordance" ]


### PR DESCRIPTION
## Summary
- remove the keeper deliberation ReplyInRoom action and reply_in_room parser/schema/prompt surface
- remove reply_in_room turn affordance routing from keeper tool selection and observed affordances
- delete tests that preserved reply_in_room behavior or examples

## Validation
- Not run: continuation of room concept purge; user accepted temporary build breakage.