### PR TITLE
Purge keeper room signal prompt setting

### DIFF
--- a/lib/agent_identity.mli
+++ b/lib/agent_identity.mli
@@ -35,7 +35,6 @@ type t = {
   agent_name : string;
   channel : channel option;
   user_id : string option;
-  room_id : string option;
   capabilities : string list;
   registered_at : float;
   mutable last_seen : float;
@@ -63,7 +62,7 @@ module Registry : sig
   val register : registry -> t -> t
   val find_by_session : registry -> string -> t option
   val find_by_name : registry -> string -> t option
-  val touch : registry -> string -> ?room_id:string -> unit -> unit
+  val touch : registry -> string -> unit -> unit
   val unregister : registry -> string -> unit
   val list_active : registry -> within_seconds:float -> t list
   val count : registry -> int

--- a/lib/keeper/keeper_agent_tool_surface.mli
+++ b/lib/keeper/keeper_agent_tool_surface.mli
@@ -135,7 +135,6 @@ type turn_affordance =
   | Board_curation
   | Board_post_or_comment
   | Message_sweep
-  | Reply_in_room
   | Task_claim
   | Task_audit
   | Task_verify

--- a/lib/keeper/keeper_config.mli
+++ b/lib/keeper/keeper_config.mli
@@ -43,7 +43,6 @@ val default_proactive_enabled : bool
 val default_proactive_idle_sec : int
 val default_proactive_cooldown_sec : int
 val approval_queue_stale_max_wait_sec : float
-val default_room_signal_prompt_enabled : bool
 val default_goal_horizon_max_chars : int
 val default_drift_max_clauses : int
 val legacy_provider_filter_name : string
@@ -267,9 +266,6 @@ val keeper_adaptive_thinking_mode : unit -> bool
 (** {1 Runtime Param Handles}
 
     Exposed for test use only (e.g. [Runtime_params.clear]). *)
-
-(** Coord signal prompt enabled override from env var. *)
-val keeper_room_signal_prompt_enabled_override : unit -> bool option
 
 (** Force module initialization to guarantee all runtime params are registered
     before [Runtime_params.restore].  Call from server bootstrap. *)

--- a/lib/keeper/keeper_config_text.ml
+++ b/lib/keeper/keeper_config_text.ml
@@ -48,14 +48,10 @@ let default_proactive_enabled = true
 let default_proactive_idle_sec = 120
 let default_proactive_cooldown_sec = 300
 let approval_queue_stale_max_wait_sec = 600.0
-let default_room_signal_prompt_enabled = false
 let default_goal_horizon_max_chars = 480
 let default_drift_max_clauses = 6
 let prompt_render_max_bytes = 320
 let legacy_provider_filter_name = "allowed_providers"
-
-let keeper_room_signal_prompt_enabled_override () =
-  bool_of_env_opt "MASC_KEEPER_ROOM_SIGNAL_PROMPT_ENABLED"
 
 (* ── Removed / rejected keeper input keys ───────────────────── *)
 

--- a/lib/keeper/keeper_config_text.mli
+++ b/lib/keeper/keeper_config_text.mli
@@ -25,13 +25,10 @@ val default_proactive_enabled : bool
 val default_proactive_idle_sec : int
 val default_proactive_cooldown_sec : int
 val approval_queue_stale_max_wait_sec : float
-val default_room_signal_prompt_enabled : bool
 val default_goal_horizon_max_chars : int
 val default_drift_max_clauses : int
 val prompt_render_max_bytes : int
 val legacy_provider_filter_name : string
-
-val keeper_room_signal_prompt_enabled_override : unit -> bool option
 
 (* ── Removed / rejected keeper input keys ───────────────────── *)
 

--- a/lib/keeper/keeper_context_runtime.ml
+++ b/lib/keeper/keeper_context_runtime.ml
@@ -360,47 +360,7 @@ let resolve_max_context_resolution_of_meta (m : keeper_meta)
   resolve_max_context_resolution
     ~requested_override:m.max_context_override labels
 
-let keeper_room_capabilities (_meta : keeper_meta) =
-  [ "keeper" ]
-
-let keeper_room_capabilities_need_sync config (meta : keeper_meta) capabilities =
-  let agent_file =
-    Filename.concat (Coord.agents_dir config)
-      (Coord.safe_filename meta.agent_name ^ ".json")
-  in
-  (* Use backend-aware read_json_opt instead of Sys.file_exists which
-     returns false for non-filesystem backends (PG, Memory). *)
-  match Coord.read_json_opt config agent_file with
-  | None -> true
-  | Some json -> (
-      match Masc_domain.agent_of_yojson json with
-      | Ok agent -> agent.capabilities <> capabilities
-      | Error _ -> true)
-
-type room_presence_error = {
-  room_id : string;
-  exn_msg : string;
-}
-
-let ensure_keeper_room_presence config (meta : keeper_meta)
-  : keeper_meta * room_presence_error list =
-  let capabilities = keeper_room_capabilities meta in
-  try
-    let joined = Coord.is_agent_joined config ~agent_name:meta.agent_name in
-    if not joined then begin
-      Coord.ensure_room_bootstrap config;
-      ignore (Coord.join config ~agent_name:meta.agent_name ~capabilities ())
-    end;
-    if joined && keeper_room_capabilities_need_sync config meta capabilities then
-      ignore (Coord.update_agent_r config ~agent_name:meta.agent_name ~capabilities ());
-    ignore (Coord.heartbeat config ~agent_name:meta.agent_name);
-    meta, []
-  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-    let exn_msg = Printexc.to_string exn in
-    Log.Keeper.error "workspace_presence_failed keeper=%s exn=%s" meta.name exn_msg;
-    meta, [ { room_id = ""; exn_msg } ]
-
-let exact_direct_mention_presentlet exact_direct_mention_present ~(targets : string list) (content : string) :
+let exact_direct_mention_present ~(targets : string list) (content : string) :
     bool =
   Mention.any_mentioned ~targets content
 

--- a/lib/keeper/keeper_context_runtime.mli
+++ b/lib/keeper/keeper_context_runtime.mli
@@ -1,5 +1,5 @@
 (** Keeper_context_runtime — shared keeper context utilities: working context,
-    checkpoint management, compaction, room presence, system prompts,
+    checkpoint management, compaction, system prompts,
     text processing, proactive prompt helpers, and proactive generation.
 
     Working context types live in {!Keeper_types}.
@@ -285,16 +285,6 @@ val resolve_max_context_resolution
   -> max_context_resolution
 
 val resolve_max_context_resolution_of_meta : keeper_meta -> max_context_resolution
-type room_presence_error = {
-  room_id : string;
-  exn_msg : string;
-}
-
-val ensure_keeper_room_presence
-  :  Coord.config
-  -> keeper_meta
-  -> keeper_meta * room_presence_error list
-
 (** {1 Mention Detection} *)
 (** {1 Mention Detection} *)
 

--- a/lib/keeper/keeper_coordination.ml
+++ b/lib/keeper/keeper_coordination.ml
@@ -1,6 +1,0 @@
-(** Keeper_coordination — Coord presence bootstrap. *)
-
-open Keeper_types
-open Keeper_meta_contract
-
-let ensure_keeper_room_presence = Keeper_context_runtime.ensure_keeper_room_presence

--- a/lib/keeper/keeper_coordination.mli
+++ b/lib/keeper/keeper_coordination.mli
@@ -1,9 +1,0 @@
-(** Keeper_coordination — Coord presence bootstrap. *)
-
-open Keeper_types
-open Keeper_meta_contract
-
-val ensure_keeper_room_presence
-  :  Coord.config
-  -> keeper_meta
-  -> keeper_meta * Keeper_context_runtime.room_presence_error list

--- a/lib/keeper/keeper_execution.ml
+++ b/lib/keeper/keeper_execution.ml
@@ -3,7 +3,6 @@
 
     Delegates to sub-modules:
     - Keeper_context_runtime: checkpoint, compaction, model labels
-    - Keeper_coordination: room presence
     - Keeper_prompt: system prompts, mention detection, text processing
 
     Proactive emission and autonomous goal turns are now handled by
@@ -17,7 +16,4 @@ let load_context_from_checkpoint = Keeper_context_runtime.load_context_from_chec
 let compaction_policy_of_keeper = Keeper_context_runtime.compaction_policy_of_keeper
 let generate_trace_id = Keeper_context_runtime.generate_trace_id
 let effective_model_labels_for_turn = Keeper_context_runtime.effective_model_labels_for_turn
-let ensure_keeper_room_presence = Keeper_coordination.ensure_keeper_room_presence
-let room_cursor_for = Keeper_coordination.room_cursor_for
-let set_room_cursor = Keeper_coordination.set_room_cursor
 let memory_check_default_json = Keeper_context_runtime.memory_check_default_json

--- a/lib/keeper/keeper_execution.mli
+++ b/lib/keeper/keeper_execution.mli
@@ -25,12 +25,6 @@ val load_context_from_checkpoint :
   base_dir:string ->
   Keeper_context_runtime.session_context * Keeper_context_runtime.working_context option
 
-(** Ensure keeper is joined to all configured rooms. *)
-val ensure_keeper_room_presence
-  :  Coord.config
-  -> keeper_meta
-  -> keeper_meta * Keeper_context_runtime.room_presence_error list
-
 (** Default JSON for memory check tool. *)
 val memory_check_default_json : unit -> Yojson.Safe.t
 
@@ -51,14 +45,6 @@ val generate_trace_id : ?now:float -> unit -> string
 
 (** Resolve effective model labels for a turn. *)
 val effective_model_labels_for_turn : keeper_meta -> string list
-
-(** {1 Coord Cursor} *)
-
-(** Get last-seen sequence number for a room. *)
-val room_cursor_for : keeper_meta -> string -> int
-
-(** Set last-seen sequence number for a room. *)
-val set_room_cursor : keeper_meta -> string -> int -> keeper_meta
 
 (** {1 Mention Detection} *)
 

--- a/lib/keeper/keeper_heartbeat_loop_presence.ml
+++ b/lib/keeper/keeper_heartbeat_loop_presence.ml
@@ -145,12 +145,8 @@ let sync_keeper_presence
     meta_current)
   else (
     try
-      let (synced, presence_errors) = ensure_keeper_room_presence ctx.config meta_current in
-      List.iter
-        (fun (e : Keeper_context_runtime.room_presence_error) ->
-          Log.Keeper.warn "room_presence_error keeper=%s room=%s exn=%s"
-            meta_current.name e.room_id e.exn_msg)
-        presence_errors;
+      let synced = meta_current in
+      let presence_errors = [] in
       if presence_errors <> []
       then (
         incr consecutive_failures;

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -482,12 +482,7 @@ let bootstrap_live_keeper_meta ~(ctx : _ context) (m : keeper_meta) : keeper_met
       | Some repaired -> repaired
       | None -> m
     in
-    let (synced, presence_errors) = ensure_keeper_room_presence ctx.config m in
-    List.iter
-      (fun (e : Keeper_context_runtime.room_presence_error) ->
-        Log.Keeper.warn "keepalive_room_presence_error keeper=%s room=%s exn=%s"
-          m.name e.room_id e.exn_msg)
-      presence_errors;
+    let synced = m in
     (* Reset stale timestamp from previous server lifecycle.
 
        Use [Time_compat.now ()] (not [0.0]). The original intent was to

--- a/lib/keeper/keeper_keepalive_signal.ml
+++ b/lib/keeper/keeper_keepalive_signal.ml
@@ -339,8 +339,7 @@ let wakeup_relevant_keeper_for_board_signal
              reply after a self-comment. Without this counter, operators
              cannot distinguish between a board post that legitimately
              had no addressee and one that was silently dropped by a
-             keeper whose [room_signal_prompt_enabled] / mention_targets
-             configuration is too narrow. *)
+             keeper whose mention_targets configuration is too narrow. *)
           (match wake_reason, entry.phase with
            | None, Keeper_state_machine.Running ->
              Prometheus.inc_counter

--- a/lib/keeper/keeper_memory_bank.mli
+++ b/lib/keeper/keeper_memory_bank.mli
@@ -16,26 +16,6 @@
 val state_start_re : Re.re
 val state_end_re : Re.re
 
-type keeper_policy_observation =
-  Keeper_memory_policy.keeper_policy_observation = {
-  source_kind : string;
-  room_id : string option;
-  from_agent : string;
-  message : string;
-  direct_mention : bool;
-  has_question : bool;
-  message_chars : int;
-  total_turns : int;
-  active_goal_count : int;
-  last_turn_ago_s : float;
-}
-(** @see [Keeper_memory_policy.keeper_policy_observation] *)
-
-val observation_has_question : string -> bool
-val keeper_policy_observation_of_room_message :
-  meta:Keeper_meta_contract.keeper_meta ->
-  room_id:string -> Masc_domain.message -> keeper_policy_observation
-
 type alert_channel_result =
   Keeper_memory_policy.alert_channel_result = {
   channel : string;

--- a/lib/keeper/keeper_memory_bank.mli
+++ b/lib/keeper/keeper_memory_bank.mli
@@ -27,7 +27,6 @@ type keeper_policy_observation =
   message_chars : int;
   total_turns : int;
   active_goal_count : int;
-  joined_room_count : int;
   last_turn_ago_s : float;
 }
 (** @see [Keeper_memory_policy.keeper_policy_observation] *)

--- a/lib/keeper/keeper_memory_bank_selection.mli
+++ b/lib/keeper/keeper_memory_bank_selection.mli
@@ -1,22 +1,5 @@
 val state_start_re : Re.re
 val state_end_re : Re.re
-type keeper_policy_observation =
-  Keeper_memory_policy.keeper_policy_observation = {
-  source_kind : string;
-  room_id : string option;
-  from_agent : string;
-  message : string;
-  direct_mention : bool;
-  has_question : bool;
-  message_chars : int;
-  total_turns : int;
-  active_goal_count : int;
-  last_turn_ago_s : float;
-}
-val observation_has_question : string -> bool
-val keeper_policy_observation_of_room_message :
-  meta:Keeper_meta_contract.keeper_meta ->
-  room_id:string -> Masc_domain.message -> keeper_policy_observation
 type alert_channel_result =
   Keeper_memory_policy.alert_channel_result = {
   channel : string;

--- a/lib/keeper/keeper_memory_bank_selection.mli
+++ b/lib/keeper/keeper_memory_bank_selection.mli
@@ -11,7 +11,6 @@ type keeper_policy_observation =
   message_chars : int;
   total_turns : int;
   active_goal_count : int;
-  joined_room_count : int;
   last_turn_ago_s : float;
 }
 val observation_has_question : string -> bool

--- a/lib/keeper/keeper_memory_policy.ml
+++ b/lib/keeper/keeper_memory_policy.ml
@@ -41,46 +41,6 @@ open Keeper_meta_contract
 let state_start_re = Re.str "[STATE]" |> Re.compile
 let state_end_re = Re.str "[/STATE]" |> Re.compile
 
-type keeper_policy_observation = {
-  source_kind: string;
-  room_id: string option;
-  from_agent: string;
-  message: string;
-  direct_mention: bool;
-  has_question: bool;
-  message_chars: int;
-  total_turns: int;
-  active_goal_count: int;
-  last_turn_ago_s: float;
-}
-
-let observation_has_question (message : string) =
-  String.contains message '?'
-
-let keeper_policy_observation_of_room_message
-    ~(meta : keeper_meta)
-    ~(room_id : string)
-    (msg : Masc_domain.message) : keeper_policy_observation =
-  let now_ts = Time_compat.now () in
-  let mention_targets =
-    if meta.mention_targets <> [] then meta.mention_targets else [ meta.name ]
-  in
-  let last_turn_ago_s =
-    if meta.runtime.usage.last_turn_ts <= 0.0 then 0.0 else max 0.0 (now_ts -. meta.runtime.usage.last_turn_ts)
-  in
-  {
-    source_kind = "room_message";
-    room_id = Some room_id;
-    from_agent = msg.from_agent;
-    message = msg.content;
-    direct_mention = Mention.any_mentioned ~targets:mention_targets msg.content;
-    has_question = observation_has_question msg.content;
-    message_chars = String.length msg.content;
-    total_turns = meta.runtime.usage.total_turns;
-    active_goal_count = List.length meta.active_goal_ids;
-    last_turn_ago_s;
-  }
-
 type alert_channel_result = {
   channel: string;
   attempted: bool;

--- a/lib/keeper/keeper_memory_policy.ml
+++ b/lib/keeper/keeper_memory_policy.ml
@@ -51,7 +51,6 @@ type keeper_policy_observation = {
   message_chars: int;
   total_turns: int;
   active_goal_count: int;
-  joined_room_count: int;
   last_turn_ago_s: float;
 }
 
@@ -79,7 +78,6 @@ let keeper_policy_observation_of_room_message
     message_chars = String.length msg.content;
     total_turns = meta.runtime.usage.total_turns;
     active_goal_count = List.length meta.active_goal_ids;
-    joined_room_count = List.length meta.joined_room_ids;
     last_turn_ago_s;
   }
 

--- a/lib/keeper/keeper_memory_policy.mli
+++ b/lib/keeper/keeper_memory_policy.mli
@@ -31,7 +31,6 @@ type keeper_policy_observation = {
   message_chars : int;
   total_turns : int;
   active_goal_count : int;
-  joined_room_count : int;
   last_turn_ago_s : float;
 }
 (** Structured view of a single room message used by the alerting

--- a/lib/keeper/keeper_memory_policy.mli
+++ b/lib/keeper/keeper_memory_policy.mli
@@ -19,32 +19,6 @@ val state_start_re : Re.re
 val state_end_re : Re.re
 (** Closing fence of the [STATE]…[/STATE] block. *)
 
-(** {1 Room observation} *)
-
-type keeper_policy_observation = {
-  source_kind : string;
-  room_id : string option;
-  from_agent : string;
-  message : string;
-  direct_mention : bool;
-  has_question : bool;
-  message_chars : int;
-  total_turns : int;
-  active_goal_count : int;
-  last_turn_ago_s : float;
-}
-(** Structured view of a single room message used by the alerting
-    scorer.  Populated from a [Masc_domain.message] plus keeper meta context. *)
-
-val observation_has_question : string -> bool
-(** Heuristic: does [text] contain a question that warrants attention? *)
-
-val keeper_policy_observation_of_room_message :
-  meta:Keeper_meta_contract.keeper_meta ->
-  room_id:string -> Masc_domain.message -> keeper_policy_observation
-(** Build a [keeper_policy_observation] from a room message in [meta]'s
-    context. *)
-
 (** {1 Interesting-message alerting} *)
 
 type alert_channel_result = {

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -567,7 +567,6 @@ type keeper_meta =
   ; tool_access : string list
   ; tool_denylist : string list
   ; mention_targets : string list
-  ; room_signal_prompt_enabled : bool
   ; proactive : proactive_policy
   ; compaction : compaction_policy
   ; auto_handoff : bool

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -335,7 +335,6 @@ type keeper_meta = {
   tool_access : string list;
   tool_denylist : string list;
   mention_targets : string list;
-  room_signal_prompt_enabled : bool;
   proactive : proactive_policy;
   compaction : compaction_policy;
   auto_handoff : bool;

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -186,7 +186,6 @@ let parse_keeper_policy (json : Yojson.Safe.t) ~(keeper_name : string)
       Safe_ops.json_string_list "mention_targets" json |> dedupe_keep_order
     in
     let proactive_enabled =
-    let proactive_enabled =
       Safe_ops.json_bool ~default:default_proactive_enabled "proactive_enabled" json
     in
     let proactive_idle_sec =
@@ -249,8 +248,6 @@ let parse_keeper_policy (json : Yojson.Safe.t) ~(keeper_name : string)
       ; pp_tool_access
       ; pp_tool_denylist
       ; pp_mention_targets
-      ; pp_joined_room_ids
-      ; pp_last_seen_seq_by_room
       ; pp_proactive =
           { enabled = proactive_enabled
           ; idle_sec = proactive_idle_sec

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -33,7 +33,6 @@ type parsed_keeper_policy =
   ; pp_tool_access : string list
   ; pp_tool_denylist : string list
   ; pp_mention_targets : string list
-  ; pp_room_signal_prompt_enabled : bool
   ; pp_proactive : proactive_policy
   ; pp_compaction : compaction_policy
   ; pp_auto_handoff : bool
@@ -186,12 +185,6 @@ let parse_keeper_policy (json : Yojson.Safe.t) ~(keeper_name : string)
     let pp_mention_targets =
       Safe_ops.json_string_list "mention_targets" json |> dedupe_keep_order
     in
-    let pp_room_signal_prompt_enabled =
-      Safe_ops.json_bool
-        ~default:default_room_signal_prompt_enabled
-        "room_signal_prompt_enabled"
-        json
-    in
     let proactive_enabled =
     let proactive_enabled =
       Safe_ops.json_bool ~default:default_proactive_enabled "proactive_enabled" json
@@ -256,7 +249,6 @@ let parse_keeper_policy (json : Yojson.Safe.t) ~(keeper_name : string)
       ; pp_tool_access
       ; pp_tool_denylist
       ; pp_mention_targets
-      ; pp_room_signal_prompt_enabled
       ; pp_joined_room_ids
       ; pp_last_seen_seq_by_room
       ; pp_proactive =
@@ -594,7 +586,6 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
                    ; tool_access = policy.pp_tool_access
                    ; tool_denylist = policy.pp_tool_denylist
                    ; mention_targets = policy.pp_mention_targets
-                   ; room_signal_prompt_enabled = policy.pp_room_signal_prompt_enabled
                    ; proactive = policy.pp_proactive
                    ; compaction = policy.pp_compaction
                    ; auto_handoff = policy.pp_auto_handoff

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -33,7 +33,6 @@ type parsed_keeper_policy =
   ; pp_tool_access : string list
   ; pp_tool_denylist : string list
   ; pp_mention_targets : string list
-  ; pp_room_signal_prompt_enabled : bool
   ; pp_proactive : proactive_policy
   ; pp_compaction : compaction_policy
   ; pp_auto_handoff : bool
@@ -186,12 +185,6 @@ let parse_keeper_policy (json : Yojson.Safe.t) ~(keeper_name : string)
     let pp_mention_targets =
       Safe_ops.json_string_list "mention_targets" json |> dedupe_keep_order
     in
-    let pp_room_signal_prompt_enabled =
-      Safe_ops.json_bool
-        ~default:default_room_signal_prompt_enabled
-        "room_signal_prompt_enabled"
-        json
-    in
     let proactive_enabled =
       Safe_ops.json_bool ~default:default_proactive_enabled "proactive_enabled" json
     in
@@ -255,7 +248,6 @@ let parse_keeper_policy (json : Yojson.Safe.t) ~(keeper_name : string)
       ; pp_tool_access
       ; pp_tool_denylist
       ; pp_mention_targets
-      ; pp_room_signal_prompt_enabled
       ; pp_proactive =
           { enabled = proactive_enabled
           ; idle_sec = proactive_idle_sec
@@ -591,7 +583,6 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
                    ; tool_access = policy.pp_tool_access
                    ; tool_denylist = policy.pp_tool_denylist
                    ; mention_targets = policy.pp_mention_targets
-                   ; room_signal_prompt_enabled = policy.pp_room_signal_prompt_enabled
                    ; proactive = policy.pp_proactive
                    ; compaction = policy.pp_compaction
                    ; auto_handoff = policy.pp_auto_handoff

--- a/lib/keeper/keeper_meta_json_parse.mli
+++ b/lib/keeper/keeper_meta_json_parse.mli
@@ -35,7 +35,6 @@ type parsed_keeper_policy =
   ; pp_tool_access : string list
   ; pp_tool_denylist : string list
   ; pp_mention_targets : string list
-  ; pp_room_signal_prompt_enabled : bool
   ; pp_proactive : proactive_policy
   ; pp_compaction : compaction_policy
   ; pp_auto_handoff : bool

--- a/lib/keeper/keeper_meta_json_scrub.ml
+++ b/lib/keeper/keeper_meta_json_scrub.ml
@@ -18,7 +18,7 @@ let config_field_names =
   ; "will"; "needs"; "desires"; "instructions"
   ; "sandbox_profile"; "sandbox_image"; "network_mode"; "allowed_paths"
   ; "tool_access"; "tool_denylist"
-  ; "mention_targets"; "room_signal_prompt_enabled"
+  ; "mention_targets"
   ; "proactive_enabled"; "proactive_idle_sec"; "proactive_cooldown_sec"
   ; "compaction_profile"; "compaction_ratio_gate"
   ; "compaction_message_gate"; "compaction_token_gate"

--- a/lib/keeper/keeper_meta_tool_access.ml
+++ b/lib/keeper/keeper_meta_tool_access.ml
@@ -16,12 +16,6 @@ let tool_names_include_board name_list =
     name_list
 ;;
 
-(** Keep [room_signal_prompt] on when [default] is set or the allowlist
-    contains any board tool. *)
-let tool_access_default_room_signal_prompt_enabled ~default tool_names =
-  default || tool_names_include_board tool_names
-;;
-
 let normalize_tool_names names =
   names
   |> List.map String.trim
@@ -171,11 +165,6 @@ let tool_access_to_string_list tools =
 (** Typed variant of [tool_names_include_board]. *)
 let tool_names_include_board_typed tools =
   List.exists Tool_name.Keeper.is_board tools
-;;
-
-(** Typed variant of [tool_access_default_room_signal_prompt_enabled]. *)
-let tool_access_default_room_signal_prompt_enabled_typed ~default tools =
-  default || tool_names_include_board_typed tools
 ;;
 
 (** Deduplicate a typed tool list preserving first-seen order. *)

--- a/lib/keeper/keeper_meta_tool_access.mli
+++ b/lib/keeper/keeper_meta_tool_access.mli
@@ -8,11 +8,6 @@
     tool. Used to detect implicit board surface. *)
 val tool_names_include_board : string list -> bool
 
-(** Keep [room_signal_prompt] on when [default] is set or the allowlist
-    contains any board tool. *)
-val tool_access_default_room_signal_prompt_enabled :
-  default:bool -> string list -> bool
-
 (** Trim, drop blanks, dedupe (preserve first-seen order). *)
 val normalize_tool_names : string list -> string list
 
@@ -67,10 +62,6 @@ val tool_access_to_string_list : Tool_name.Keeper.t list -> string list
 
 val tool_names_include_board_typed : Tool_name.Keeper.t list -> bool
 (** Typed variant: true if any tool in the list is a board tool. *)
-
-val tool_access_default_room_signal_prompt_enabled_typed :
-  default:bool -> Tool_name.Keeper.t list -> bool
-(** Typed variant of [tool_access_default_room_signal_prompt_enabled]. *)
 
 val normalize_tool_access_typed : Tool_name.Keeper.t list -> Tool_name.Keeper.t list
 (** Deduplicate a typed tool list preserving first-seen order. *)

--- a/lib/keeper/keeper_persona_authoring.ml
+++ b/lib/keeper/keeper_persona_authoring.ml
@@ -180,11 +180,6 @@ let field_catalog_entries =
         ~field_effect:"Cooldown between proactive turns."
         ()
     ; field_catalog_entry
-        ~path:"keeper.room_signal_prompt_enabled"
-        ~typ:"boolean"
-        ~field_effect:"Whether room signal context is injected into keeper prompts."
-        ()
-    ; field_catalog_entry
         ~path:"keeper.shards"
         ~typ:"string[]"
         ~field_effect:"Persona-specific prompt shards applied after keeper creation."
@@ -481,8 +476,7 @@ let normalize_keeper_json ~handle keeper_json =
                         fields
                  in
                  let fields =
-                   [ "room_signal_prompt_enabled"
-                   ; "telemetry_feedback_enabled"
+                   [ "telemetry_feedback_enabled"
                    ; "always_approve"
                    ]
                    |> List.fold_left

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -177,17 +177,6 @@ let ensure_keeper_meta config name =
     let target_cooldown_sec =
       apply_default defaults.proactive_cooldown_sec Keeper_config.default_proactive_cooldown_sec in
     let target_tool_access = resynced_tool_access defaults meta in
-    let target_room_signal_prompt_enabled =
-      match Keeper_config.keeper_room_signal_prompt_enabled_override () with
-      | Some override -> override
-      | None ->
-          Option.value
-            ~default:
-              (tool_access_default_room_signal_prompt_enabled
-                 ~default:Keeper_config.default_room_signal_prompt_enabled
-                 target_tool_access)
-            defaults.room_signal_prompt_enabled
-    in
     let target_denylist = apply_default defaults.tool_denylist meta.tool_denylist in
     let target_social_model =
       apply_default defaults.social_model meta.social_model
@@ -293,8 +282,6 @@ let ensure_keeper_meta config name =
       meta.proactive.enabled <> target_proactive
       || meta.proactive.idle_sec <> target_idle_sec
       || meta.proactive.cooldown_sec <> target_cooldown_sec in
-    let signal_changed =
-      meta.room_signal_prompt_enabled <> target_room_signal_prompt_enabled in
     let denylist_changed = meta.tool_denylist <> target_denylist in
     let social_model_changed = meta.social_model <> target_social_model in
     (* [meta runtime id] may be a raw TOML/JSON value while
@@ -349,7 +336,7 @@ let ensure_keeper_meta config name =
       meta.per_provider_timeout_s <> target_per_provider_timeout in
     let oas_env_changed = meta.oas_env <> target_oas_env in
     let any_changed =
-      proactive_changed || signal_changed || denylist_changed
+      proactive_changed || denylist_changed
       || social_model_changed
       || runtime_changed
       || personality_changed || policy_changed
@@ -415,7 +402,6 @@ let ensure_keeper_meta config name =
           idle_sec = target_idle_sec;
           cooldown_sec = target_cooldown_sec;
         };
-        room_signal_prompt_enabled = target_room_signal_prompt_enabled;
         tool_denylist = target_denylist;
         social_model = target_social_model;
         goal = target_goal;

--- a/lib/keeper/keeper_supervisor_resume_reconcile_gate.ml
+++ b/lib/keeper/keeper_supervisor_resume_reconcile_gate.ml
@@ -34,9 +34,8 @@ let resume_keeper_after_reconcile_gate
   (* #9733: same race shape as keeper_msg/overflow-pause/sync paths
      already migrated by #10135 / #10145.  The supervisor reconcile
      fiber clears [paused] and [runtime.last_blocker] (cycle-owned
-     fields); a heartbeat fiber bumping [joined_room_ids] /
-     [last_seen_seq_by_room] in parallel can still steal the CAS
-     write and silently leave the keeper paused while
+     fields); a heartbeat fiber bumping heartbeat-owned metadata in
+     parallel can still steal the CAS write and silently leave the keeper paused while
      [Keeper_registry.update_meta] applies the resume in-memory —
      a registry/disk split that hides the failure. *)
   (match

--- a/lib/keeper/keeper_supervisor_supervise_keepalive.ml
+++ b/lib/keeper/keeper_supervisor_supervise_keepalive.ml
@@ -84,12 +84,7 @@ let supervise_keepalive
        Log.Keeper.error "supervisor room init failed: %s" (Printexc.to_string exn));
     let live_meta =
       try
-        let (synced, presence_errors) = ensure_keeper_room_presence ctx.config meta in
-        List.iter
-          (fun (e : Keeper_context_runtime.room_presence_error) ->
-            Log.Keeper.warn "supervisor_room_presence_error keeper=%s room=%s exn=%s"
-              meta.name e.room_id e.exn_msg)
-          presence_errors;
+        let synced = meta in
         (match write_meta ctx.config synced with
          | Ok () -> ()
          | Error msg ->

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -550,7 +550,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
               in
               (* #9733: keeper_msg turn-completion is the same race shape
                  as the unified-turn failure path — heartbeat updates
-                 [last_seen]/[joined_room_ids] in parallel and bumps
+                 [last_seen] in parallel and bumps
                  [meta_version], so a bare [write_meta] loses the CAS
                  race and silently drops the turn payload (usage tokens,
                  trace_history, generation).  Use the same merged-CAS

--- a/lib/keeper/keeper_turn_runtime_budget_routing.ml
+++ b/lib/keeper/keeper_turn_runtime_budget_routing.ml
@@ -43,7 +43,6 @@ let record_turn_failure_stress
   =
   let room_id = "" in
   Agent_stress.record
-  Agent_stress.record
     { agent_name = meta.name
     ; room_id
     ; kind =

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -190,17 +190,6 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
                      | Some tools -> normalize_tool_names tools
                      | None -> default_tool_access_of_meta_json ())
               in
-              let room_signal_prompt_enabled =
-                match keeper_room_signal_prompt_enabled_override () with
-                | Some value -> value
-                | None ->
-                    Option.value
-                      ~default:
-                        (tool_access_default_room_signal_prompt_enabled
-                           ~default:default_room_signal_prompt_enabled
-                           tool_access)
-                      p.profile_defaults.room_signal_prompt_enabled
-              in
               let tool_denylist =
                 resolve_tool_name_list
                   ~preferred:p.tool_denylist_opt
@@ -427,7 +416,6 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
         tool_access;
         tool_denylist;
         mention_targets;
-        room_signal_prompt_enabled;
         proactive = {
           enabled = proactive_enabled;
           idle_sec = proactive_idle_sec;

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -135,17 +135,6 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
          | Some tools -> normalize_tool_names tools
          | None -> old.tool_access)
   in
-  let room_signal_prompt_enabled =
-    match keeper_room_signal_prompt_enabled_override () with
-    | Some value -> value
-    | None ->
-        Option.value
-          ~default:
-            (tool_access_default_room_signal_prompt_enabled
-               ~default:default_room_signal_prompt_enabled
-               tool_access)
-          p.profile_defaults.room_signal_prompt_enabled
-  in
   let tool_denylist =
     let profile_or_old =
       match p.profile_defaults.tool_denylist with
@@ -264,7 +253,6 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
          }
        else old.runtime);
     mention_targets;
-    room_signal_prompt_enabled;
     telemetry_feedback_enabled =
       Dashboard_utils.first_some p.profile_defaults.telemetry_feedback_enabled
         old.telemetry_feedback_enabled;

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -202,8 +202,6 @@ let load_keeper_profile_defaults_from_persona name : keeper_profile_defaults =
                 proactive_enabled = Safe_ops.json_bool_opt "proactive_enabled" keeper_json;
                 proactive_idle_sec = Safe_ops.json_int_opt "proactive_idle_sec" keeper_json;
                 proactive_cooldown_sec = Safe_ops.json_int_opt "proactive_cooldown_sec" keeper_json;
-                room_signal_prompt_enabled =
-                  Safe_ops.json_bool_opt "room_signal_prompt_enabled" keeper_json;
                 shards =
                   (match Safe_ops.json_string_list "shards" keeper_json with
                    | [] -> None

--- a/lib/keeper/keeper_types_profile_defaults.ml
+++ b/lib/keeper/keeper_types_profile_defaults.ml
@@ -20,7 +20,6 @@ type keeper_profile_defaults = {
   proactive_enabled : bool option;
   proactive_idle_sec : int option;
   proactive_cooldown_sec : int option;
-  room_signal_prompt_enabled : bool option;
   shards : string list option;
   allowed_paths : string list option;
   sandbox_profile : Keeper_types_profile_sandbox.sandbox_profile option;
@@ -79,7 +78,6 @@ let empty_keeper_profile_defaults =
     proactive_enabled = None;
     proactive_idle_sec = None;
     proactive_cooldown_sec = None;
-    room_signal_prompt_enabled = None;
     shards = None;
     allowed_paths = None;
     sandbox_profile = None;

--- a/lib/keeper/keeper_types_profile_defaults.mli
+++ b/lib/keeper/keeper_types_profile_defaults.mli
@@ -22,7 +22,6 @@ type keeper_profile_defaults = {
   proactive_enabled : bool option;
   proactive_idle_sec : int option;
   proactive_cooldown_sec : int option;
-  room_signal_prompt_enabled : bool option;
   shards : string list option;
   allowed_paths : string list option;
   sandbox_profile : Keeper_types_profile_sandbox.sandbox_profile option;

--- a/lib/keeper/keeper_types_profile_toml.mli
+++ b/lib/keeper/keeper_types_profile_toml.mli
@@ -11,7 +11,6 @@ val default_proactive_enabled : bool
 val default_proactive_idle_sec : int
 val default_proactive_cooldown_sec : int
 val approval_queue_stale_max_wait_sec : float
-val default_room_signal_prompt_enabled : bool
 val default_goal_horizon_max_chars : int
 val default_drift_max_clauses : int
 val legacy_provider_filter_name : string
@@ -110,7 +109,6 @@ val keeper_slot_id : string -> int option
 val keeper_enable_thinking : unit -> bool
 val keeper_adaptive_thinking_enabled : unit -> bool
 val keeper_adaptive_thinking_mode : unit -> bool
-val keeper_room_signal_prompt_enabled_override : unit -> bool option
 val ensure_runtime_params_init : unit -> unit
 type sandbox_profile =
   Keeper_types_profile_sandbox.sandbox_profile =
@@ -164,7 +162,6 @@ type keeper_profile_defaults =
   proactive_enabled : bool option;
   proactive_idle_sec : int option;
   proactive_cooldown_sec : int option;
-  room_signal_prompt_enabled : bool option;
   shards : string list option;
   allowed_paths : string list option;
   sandbox_profile :

--- a/lib/keeper/keeper_types_profile_toml_io.mli
+++ b/lib/keeper/keeper_types_profile_toml_io.mli
@@ -11,7 +11,6 @@ val default_proactive_enabled : bool
 val default_proactive_idle_sec : int
 val default_proactive_cooldown_sec : int
 val approval_queue_stale_max_wait_sec : float
-val default_room_signal_prompt_enabled : bool
 val default_goal_horizon_max_chars : int
 val default_drift_max_clauses : int
 val legacy_provider_filter_name : string
@@ -110,7 +109,6 @@ val keeper_slot_id : string -> int option
 val keeper_enable_thinking : unit -> bool
 val keeper_adaptive_thinking_enabled : unit -> bool
 val keeper_adaptive_thinking_mode : unit -> bool
-val keeper_room_signal_prompt_enabled_override : unit -> bool option
 val ensure_runtime_params_init : unit -> unit
 type sandbox_profile =
   Keeper_types_profile_sandbox.sandbox_profile =
@@ -164,7 +162,6 @@ type keeper_profile_defaults =
   proactive_enabled : bool option;
   proactive_idle_sec : int option;
   proactive_cooldown_sec : int option;
-  room_signal_prompt_enabled : bool option;
   shards : string list option;
   allowed_paths : string list option;
   sandbox_profile :

--- a/lib/keeper/keeper_types_profile_toml_normalizers.mli
+++ b/lib/keeper/keeper_types_profile_toml_normalizers.mli
@@ -11,7 +11,6 @@ val default_proactive_enabled : bool
 val default_proactive_idle_sec : int
 val default_proactive_cooldown_sec : int
 val approval_queue_stale_max_wait_sec : float
-val default_room_signal_prompt_enabled : bool
 val default_goal_horizon_max_chars : int
 val default_drift_max_clauses : int
 val legacy_provider_filter_name : string
@@ -110,7 +109,6 @@ val keeper_slot_id : string -> int option
 val keeper_enable_thinking : unit -> bool
 val keeper_adaptive_thinking_enabled : unit -> bool
 val keeper_adaptive_thinking_mode : unit -> bool
-val keeper_room_signal_prompt_enabled_override : unit -> bool option
 val ensure_runtime_params_init : unit -> unit
 type sandbox_profile =
   Keeper_types_profile_sandbox.sandbox_profile =
@@ -164,7 +162,6 @@ type keeper_profile_defaults =
   proactive_enabled : bool option;
   proactive_idle_sec : int option;
   proactive_cooldown_sec : int option;
-  room_signal_prompt_enabled : bool option;
   shards : string list option;
   allowed_paths : string list option;
   sandbox_profile :

--- a/lib/keeper/keeper_types_profile_toml_parser.ml
+++ b/lib/keeper/keeper_types_profile_toml_parser.ml
@@ -203,7 +203,6 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
         proactive_enabled = bool_ "proactive_enabled";
         proactive_idle_sec = int_ "proactive_idle_sec";
         proactive_cooldown_sec = int_ "proactive_cooldown_sec";
-        room_signal_prompt_enabled = bool_ "room_signal_prompt_enabled";
         shards =
           (match strs "shards" with
            | [] -> None
@@ -260,7 +259,6 @@ let parsed_field_key_names =
   ; "proactive_enabled"
   ; "proactive_idle_sec"
   ; "proactive_cooldown_sec"
-  ; "room_signal_prompt_enabled"
   ; "shards"
   ; "allowed_paths"
   ; "sandbox_profile"
@@ -309,7 +307,6 @@ let canonical_keeper_toml_key_names =
   ; "proactive_enabled"
   ; "proactive_idle_sec"
   ; "proactive_cooldown_sec"
-  ; "room_signal_prompt_enabled"
   ; "shards"
   ; "allowed_paths"
   ; "sandbox_profile"
@@ -452,8 +449,6 @@ let merge_keeper_profile_defaults
     proactive_idle_sec = prefer overlay.proactive_idle_sec base.proactive_idle_sec;
     proactive_cooldown_sec =
       prefer overlay.proactive_cooldown_sec base.proactive_cooldown_sec;
-    room_signal_prompt_enabled =
-      prefer overlay.room_signal_prompt_enabled base.room_signal_prompt_enabled;
     shards = prefer overlay.shards base.shards;
     allowed_paths = prefer overlay.allowed_paths base.allowed_paths;
     sandbox_profile = prefer overlay.sandbox_profile base.sandbox_profile;

--- a/lib/keeper/keeper_types_profile_toml_parser.mli
+++ b/lib/keeper/keeper_types_profile_toml_parser.mli
@@ -11,7 +11,6 @@ val default_proactive_enabled : bool
 val default_proactive_idle_sec : int
 val default_proactive_cooldown_sec : int
 val approval_queue_stale_max_wait_sec : float
-val default_room_signal_prompt_enabled : bool
 val default_goal_horizon_max_chars : int
 val default_drift_max_clauses : int
 val legacy_provider_filter_name : string
@@ -110,7 +109,6 @@ val keeper_slot_id : string -> int option
 val keeper_enable_thinking : unit -> bool
 val keeper_adaptive_thinking_enabled : unit -> bool
 val keeper_adaptive_thinking_mode : unit -> bool
-val keeper_room_signal_prompt_enabled_override : unit -> bool option
 val ensure_runtime_params_init : unit -> unit
 type sandbox_profile =
   Keeper_types_profile_sandbox.sandbox_profile =
@@ -164,7 +162,6 @@ type keeper_profile_defaults =
   proactive_enabled : bool option;
   proactive_idle_sec : int option;
   proactive_cooldown_sec : int option;
-  room_signal_prompt_enabled : bool option;
   shards : string list option;
   allowed_paths : string list option;
   sandbox_profile :

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -841,9 +841,8 @@ let run_keeper_cycle
                     ~terminal_reason
                     ();
                   (* #9769 root fix: heartbeat-field-merge prevents the
-             turn-failure retry from clobbering heartbeat-owned fields
-             (joined_room_ids, last_seen_seq_by_room), which was the
-             dominant source of the observed CAS race exhaustion after
+             turn-failure retry from clobbering heartbeat-owned fields metadata fields, which was the
+dominant source of the observed CAS race exhaustion after
              keeper OAS timeout. *)
                   (match
                      write_meta_with_merge

--- a/lib/keeper/keeper_world_observation_message_scope.ml
+++ b/lib/keeper/keeper_world_observation_message_scope.ml
@@ -47,91 +47,14 @@ let is_keeper_authored_message author =
 let collect_message_scope ~(config : Coord.config) ~(meta : keeper_meta)
   : (string * string) list * (string * string) list * (string * int) list
   =
-  let targets = message_feed_targets meta in
-  let broad_scope = scope_message_feed_enabled meta in
-  let self_tokens = self_identity_tokens meta in
-  let batch_limit = Keeper_config.keeper_batch_limit () in
-  let rec consume_room_messages remaining last_processed mentions scope_messages
-    = function
-    | [] -> `Done, remaining, last_processed, List.rev mentions, List.rev scope_messages
-    | (msg : Masc_domain.message) :: rest ->
-      let author = String.trim msg.from_agent in
-      if author = "" || is_self_author ~self_tokens author
-      then consume_room_messages remaining msg.seq mentions scope_messages rest
-      else if
-        Coord_task_cache_invariant.stale_active_task_signal_present
-          ~config
-          ~from_agent:author
-          ~module_name:"keeper_world_observation"
-          ~content:msg.content
-      then consume_room_messages remaining msg.seq mentions scope_messages rest
-      else if exact_direct_mention_present ~targets msg.content
-      then
-        if remaining <= 0
-        then
-          ( `Saturated
-          , remaining
-          , last_processed
-          , List.rev mentions
-          , List.rev scope_messages )
-        else
-          consume_room_messages
-            (remaining - 1)
-            msg.seq
-            ((msg.from_agent, msg.content) :: mentions)
-            scope_messages
-            rest
-      else if broad_scope
-      then
-        (* Broad room scope is for operator/human context; direct mentions
-           above still allow explicit keeper-to-keeper handoff. *)
-        if is_keeper_authored_message author
-        then consume_room_messages remaining msg.seq mentions scope_messages rest
-        else if remaining <= 0
-        then
-          ( `Saturated
-          , remaining
-          , last_processed
-          , List.rev mentions
-          , List.rev scope_messages )
-        else
-          consume_room_messages
-            (remaining - 1)
-            msg.seq
-            mentions
-            ((msg.from_agent, msg.content) :: scope_messages)
-            rest
-      else consume_room_messages remaining msg.seq mentions scope_messages rest
-  in
-  let rec consume_rooms remaining mentions_acc scope_acc cursor_acc = function
-    | [] -> mentions_acc, scope_acc, List.rev cursor_acc
-    | _ when remaining <= 0 -> mentions_acc, scope_acc, List.rev cursor_acc
-    | room_id :: rest ->
-      let since_seq = room_cursor_for meta room_id in
-      let messages =
-        try Coord.get_all_messages_raw config ~since_seq with
-        | Eio.Cancel.Cancelled _ as e -> raise e
-        | _ -> []
-      in
-      let status, remaining, last_processed, room_mentions, scoped_messages =
-        consume_room_messages remaining since_seq [] [] messages
-      in
-      let cursor_acc =
-        if last_processed > since_seq
-        then (room_id, last_processed) :: cursor_acc
-        else cursor_acc
-      in
-      let mentions_acc = mentions_acc @ room_mentions in
-      let scope_acc = scope_acc @ scoped_messages in
-      (match status with
-       | `Done -> consume_rooms remaining mentions_acc scope_acc cursor_acc rest
-       | `Saturated -> mentions_acc, scope_acc, List.rev cursor_acc)
-  in
-  consume_rooms batch_limit [] [] [] meta.joined_room_ids
+  let _ = config in
+  let _ = meta in
+  [], [], []
 ;;
 
 let apply_message_cursor_updates (meta : keeper_meta) (updates : (string * int) list)
   : keeper_meta
   =
-  List.fold_left (fun acc (room_id, seq) -> set_room_cursor acc room_id seq) meta updates
+  let _ = updates in
+  meta
 ;;

--- a/lib/keeper/keeper_world_observation_message_scope.ml
+++ b/lib/keeper/keeper_world_observation_message_scope.ml
@@ -6,10 +6,6 @@ open Keeper_types_profile
 open Keeper_memory
 open Keeper_context_runtime
 
-let scope_message_feed_enabled (meta : keeper_meta) : bool =
-  meta.room_signal_prompt_enabled
-;;
-
 let message_feed_targets (meta : keeper_meta) =
   if meta.mention_targets <> [] then meta.mention_targets else [ meta.name ]
 ;;

--- a/lib/prometheus_builtin_metrics_part2.ml
+++ b/lib/prometheus_builtin_metrics_part2.ml
@@ -188,9 +188,8 @@ let register
      [Keeper_world_observation.board_signal_wake_reason] returns [None] — i.e. no \
      explicit_mention, scope feed disabled, and (for comments) no external reply after a \
      self-comment. Operators alert on this counter when keepers should be reacting to a \
-     known board signal: a high rate identifies keepers whose \
-     [room_signal_prompt_enabled] / mention-target configuration drops legitimate \
-     signals. Labels: keeper, kind=post_created|comment_added."
+     known board signal: a high rate identifies keepers whose mention-target \
+     configuration drops legitimate signals. Labels: keeper, kind=post_created|comment_added."
     `Counter;
   add
     Keeper_metrics.(to_string MetaJsonFailures)

--- a/lib/prometheus_metric_names.mli
+++ b/lib/prometheus_metric_names.mli
@@ -229,10 +229,8 @@ val metric_write_meta_cas_retry_total : string
     [Keeper_world_observation.board_signal_wake_reason] returns
     [None] — no explicit_mention, scope feed disabled, and no
     external reply after a self-comment. Discoverability for the
-    REPO_WAKE_UP audit finding: keepers with
-    [room_signal_prompt_enabled = false] (Minimal preset default)
-    silently drop board posts. Labels: keeper,
-    kind=post_created|comment_added. *)
+    REPO_WAKE_UP audit finding: keepers with narrow mention targets
+    can silently drop board posts. Labels: keeper, kind=post_created|comment_added. *)
 
 (** Total keeper OAS hook tool-output JSON parse failures. Labels:
     [surface] is the parser-owned hook surface. *)

--- a/test/test_agent_identity.ml
+++ b/test/test_agent_identity.ml
@@ -246,8 +246,7 @@ module RegistryTests = struct
     
     match Agent_identity.Registry.find_by_session reg identity.session_key with
     | Some updated ->
-        check bool "last_seen updated" true (updated.last_seen > old_time);
-        check (option string) "room_id updated" (Some "new-room") updated.room_id
+        check bool "last_seen updated" true (updated.last_seen > old_time)
     | None -> fail "identity not found after touch"
 
   let test_list_active () =

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -452,7 +452,6 @@ mention_targets = ["sherlock", "log-analyzer"]
 proactive_enabled = true
 proactive_idle_sec = 300
 proactive_cooldown_sec = 60
-room_signal_prompt_enabled = true
 autoboot_enabled = false
 repo_cli_identity = "anyang-keepers"
 git_identity_mode = "keeper_alias"
@@ -471,8 +470,6 @@ active_goal_ids = ["goal-runtime", "goal-masc-mcp"]
       check (option string) "will" (Some "detect issues") d.will;
       check int "mention_targets" 2 (List.length d.mention_targets);
       check (option bool) "proactive" (Some true) d.proactive_enabled;
-      check (option bool) "room signal prompt" (Some true)
-        d.room_signal_prompt_enabled;
       check (option bool) "autoboot_enabled" (Some false) d.autoboot_enabled;
       check (option string) "repo_cli_identity" (Some "anyang-keepers")
         d.repo_cli_identity;

--- a/test/test_keeper_unified_required_tools.ml
+++ b/test/test_keeper_unified_required_tools.ml
@@ -189,7 +189,6 @@ let test_satisfying_tools_for_turn_computes_from_affordances () =
       ~allowed_tool_names:[ "masc_claim_next"; "masc_status" ]
   in
   check (list string) "task_claim returns only allowed subset" [ "masc_claim_next" ] partial;
-  ()
   let empty =
     Surface.satisfying_tools_for_turn
       ~turn_affordances:[ "unknown_affordance" ]


### PR DESCRIPTION
## Summary
- remove room_signal_prompt_enabled from keeper meta, JSON parsing/scrubbing, and TOML profile defaults
- remove the room signal env override/default/tool-access helper plumbing
- stop create/update/runtime resync from calculating or persisting room signal prompt state
- remove keeper room presence/cursor layer and delete Keeper_coordination
- stop keepalive/supervisor/heartbeat paths from syncing room presence
- remove keeper memory room-observation API from memory policy/bank interfaces

## Validation
- Not run: continuation of room concept purge; user accepted temporary build breakage.