### PR TITLE
[codex] Clarify IDE orphan partition fallback

### DIFF
--- a/lib/server/server_ide_http.ml
+++ b/lib/server/server_ide_http.ml
@@ -38,13 +38,13 @@ let resolve_workspace_base ~state ~uri =
 
    Priority:
      1. [?canonical_url=...] explicit override (still re-normalised so a
-        misspelt query falls back to Legacy rather than silently
+        misspelt query falls back to Orphan rather than silently
         creating a new bucket).
      2. [?repo_id=...] → lookup repo.url in [Repo_store] → normalise.
-     3. Default → [Legacy] so traffic that has not been updated to use
-        either parameter keeps reading the historical flat store.
+     3. Default → [Orphan] so traffic that has not been updated to use
+        either parameter is preserved in the unresolved partition.
 
-   PR-1d removes the [Legacy] fallback once the data migration runs. *)
+   PR-1d removed the old [Legacy] constructor in favor of [Orphan]. *)
 let resolve_partition_for_query ~state ~uri =
   let project_base = base_path_of_state state in
   let from_canonical =


### PR DESCRIPTION
## Summary

After rebasing onto current `main`, the main build syntax fixes and the legacy model-arg regression test removal are already present in the base branch. This PR now only keeps the remaining documentation cleanup in `server_ide_http`:

- Replace stale `Legacy` wording with `Orphan` in the IDE partition fallback comment.
- Keep the comment aligned with the current `Ide_paths.partition` API, where the old `Legacy` constructor has been removed.

## Conflict Resolution

- Rebased `fix/main-build-syntax-20260601` onto `origin/main`.
- PR #19643 is now `MERGEABLE` according to `gh pr view`.
- The legacy test file/stanza are absent from `origin/main`, so they no longer appear in this PR diff.

## Validation

- `ocamlformat --check lib/server/server_ide_http.ml`
- `git diff --check origin/main..HEAD`

Earlier, before the rebase collapsed the build-fix diff into base, this worktree also passed `scripts/dune-local.sh build .`.