### PR TITLE
Purge Agent_stress room id field

### DIFF
--- a/lib/agent_stress.ml
+++ b/lib/agent_stress.ml
@@ -50,7 +50,6 @@ and turn_failure = {
 
 type event = {
   agent_name : string;
-  room_id : string;
   kind : stress_kind;
   timestamp : float;
 }
@@ -94,7 +93,6 @@ let stress_kind_to_json = function
 let event_to_json (e : event) : Yojson.Safe.t =
   `Assoc [
     ("agent_name", `String e.agent_name);
-    ("room_id", `String e.room_id);
     ("kind", stress_kind_to_json e.kind);
     ("timestamp", `Float e.timestamp);
   ]

--- a/lib/agent_stress.mli
+++ b/lib/agent_stress.mli
@@ -59,7 +59,6 @@ and turn_failure = {
 (** A single stress observation. *)
 type event = {
   agent_name : string;
-  room_id : string;
   kind : stress_kind;
   timestamp : float;
 }

--- a/lib/keeper/keeper_agent_memory_episode.ml
+++ b/lib/keeper/keeper_agent_memory_episode.ml
@@ -190,7 +190,6 @@ let record_failure
          Agent_stress.record
            {
              agent_name = keeper_name;
-             room_id = "";
              kind;
              timestamp = Unix.gettimeofday ();
            });

--- a/lib/keeper/keeper_heartbeat_loop_presence.ml
+++ b/lib/keeper/keeper_heartbeat_loop_presence.ml
@@ -153,7 +153,6 @@ let sync_keeper_presence
         (* RFC-0001 Gate A: record failure streak *)
         Agent_stress.record
           { agent_name = meta_current.name
-          ; room_id = ""
           ; kind = Failure_streak !consecutive_failures
           ; timestamp = Unix.gettimeofday ()
           };

--- a/lib/keeper/keeper_turn_runtime_budget_routing.ml
+++ b/lib/keeper/keeper_turn_runtime_budget_routing.ml
@@ -41,10 +41,8 @@ let record_turn_failure_stress
       ~(err : Agent_sdk.Error.sdk_error)
   : unit
   =
-  let room_id = "" in
   Agent_stress.record
     { agent_name = meta.name
-    ; room_id
     ; kind =
         Turn_failure
           { consecutive

--- a/lib/memory_oas_bridge.ml
+++ b/lib/memory_oas_bridge.ml
@@ -452,7 +452,6 @@ let emit_stress_for_failure ~keeper_name ~error_kind =
       Agent_stress.record
         {
           agent_name = keeper_name;
-          room_id = "";
           kind = stress_kind;
           timestamp = Unix.gettimeofday ();
         }

--- a/test/test_agent_stress.ml
+++ b/test/test_agent_stress.ml
@@ -13,7 +13,6 @@ let test_turn_failure_json_contract () =
   let event : Stress.event =
     {
       agent_name = "sangsu";
-      room_id = "default";
       kind =
         Stress.Turn_failure {
           consecutive = 2;
@@ -73,7 +72,6 @@ let test_turn_failure_omits_absent_error_kind () =
   let event : Stress.event =
     {
       agent_name = "janitor";
-      room_id = "";
       kind =
         Stress.Turn_failure {
           consecutive = 0;


### PR DESCRIPTION
## Summary
- remove room_id from Agent_stress.event and serialized stress events
- stop stress event producers from writing empty room ids
- update Agent_stress tests to construct agent-only stress events
- remove unused keeper room sequence JSON helpers from Keeper_types_profile

## Validation
- Not run: continuation of room concept purge; user accepted temporary build breakage.