### PR TITLE
Fix main compile drift after room state cleanup

### DIFF
--- a/lib/agent_identity.mli
+++ b/lib/agent_identity.mli
@@ -35,7 +35,6 @@ type t = {
   agent_name : string;
   channel : channel option;
   user_id : string option;
-  room_id : string option;
   capabilities : string list;
   registered_at : float;
   mutable last_seen : float;
@@ -63,7 +62,7 @@ module Registry : sig
   val register : registry -> t -> t
   val find_by_session : registry -> string -> t option
   val find_by_name : registry -> string -> t option
-  val touch : registry -> string -> ?room_id:string -> unit -> unit
+  val touch : registry -> string -> unit -> unit
   val unregister : registry -> string -> unit
   val list_active : registry -> within_seconds:float -> t list
   val count : registry -> int

--- a/lib/keeper/keeper_context_runtime.ml
+++ b/lib/keeper/keeper_context_runtime.ml
@@ -400,7 +400,7 @@ let ensure_keeper_room_presence config (meta : keeper_meta)
     Log.Keeper.error "workspace_presence_failed keeper=%s exn=%s" meta.name exn_msg;
     meta, [ { room_id = ""; exn_msg } ]
 
-let exact_direct_mention_presentlet exact_direct_mention_present ~(targets : string list) (content : string) :
+let exact_direct_mention_present ~(targets : string list) (content : string) :
     bool =
   Mention.any_mentioned ~targets content
 

--- a/lib/keeper/keeper_execution.ml
+++ b/lib/keeper/keeper_execution.ml
@@ -18,6 +18,4 @@ let compaction_policy_of_keeper = Keeper_context_runtime.compaction_policy_of_ke
 let generate_trace_id = Keeper_context_runtime.generate_trace_id
 let effective_model_labels_for_turn = Keeper_context_runtime.effective_model_labels_for_turn
 let ensure_keeper_room_presence = Keeper_coordination.ensure_keeper_room_presence
-let room_cursor_for = Keeper_coordination.room_cursor_for
-let set_room_cursor = Keeper_coordination.set_room_cursor
 let memory_check_default_json = Keeper_context_runtime.memory_check_default_json

--- a/lib/keeper/keeper_execution.mli
+++ b/lib/keeper/keeper_execution.mli
@@ -52,14 +52,6 @@ val generate_trace_id : ?now:float -> unit -> string
 (** Resolve effective model labels for a turn. *)
 val effective_model_labels_for_turn : keeper_meta -> string list
 
-(** {1 Coord Cursor} *)
-
-(** Get last-seen sequence number for a room. *)
-val room_cursor_for : keeper_meta -> string -> int
-
-(** Set last-seen sequence number for a room. *)
-val set_room_cursor : keeper_meta -> string -> int -> keeper_meta
-
 (** {1 Mention Detection} *)
 
 (** Check if any target mention is directly present in content. *)

--- a/lib/keeper/keeper_memory_policy.ml
+++ b/lib/keeper/keeper_memory_policy.ml
@@ -79,7 +79,7 @@ let keeper_policy_observation_of_room_message
     message_chars = String.length msg.content;
     total_turns = meta.runtime.usage.total_turns;
     active_goal_count = List.length meta.active_goal_ids;
-    joined_room_count = List.length meta.joined_room_ids;
+    joined_room_count = 0;
     last_turn_ago_s;
   }
 

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -193,7 +193,6 @@ let parse_keeper_policy (json : Yojson.Safe.t) ~(keeper_name : string)
         json
     in
     let proactive_enabled =
-    let proactive_enabled =
       Safe_ops.json_bool ~default:default_proactive_enabled "proactive_enabled" json
     in
     let proactive_idle_sec =
@@ -257,8 +256,6 @@ let parse_keeper_policy (json : Yojson.Safe.t) ~(keeper_name : string)
       ; pp_tool_denylist
       ; pp_mention_targets
       ; pp_room_signal_prompt_enabled
-      ; pp_joined_room_ids
-      ; pp_last_seen_seq_by_room
       ; pp_proactive =
           { enabled = proactive_enabled
           ; idle_sec = proactive_idle_sec

--- a/lib/keeper/keeper_turn_runtime_budget_routing.ml
+++ b/lib/keeper/keeper_turn_runtime_budget_routing.ml
@@ -43,7 +43,6 @@ let record_turn_failure_stress
   =
   let room_id = "" in
   Agent_stress.record
-  Agent_stress.record
     { agent_name = meta.name
     ; room_id
     ; kind =

--- a/lib/keeper/keeper_world_observation_message_scope.ml
+++ b/lib/keeper/keeper_world_observation_message_scope.ml
@@ -51,91 +51,13 @@ let is_keeper_authored_message author =
 let collect_message_scope ~(config : Coord.config) ~(meta : keeper_meta)
   : (string * string) list * (string * string) list * (string * int) list
   =
-  let targets = message_feed_targets meta in
-  let broad_scope = scope_message_feed_enabled meta in
-  let self_tokens = self_identity_tokens meta in
-  let batch_limit = Keeper_config.keeper_batch_limit () in
-  let rec consume_room_messages remaining last_processed mentions scope_messages
-    = function
-    | [] -> `Done, remaining, last_processed, List.rev mentions, List.rev scope_messages
-    | (msg : Masc_domain.message) :: rest ->
-      let author = String.trim msg.from_agent in
-      if author = "" || is_self_author ~self_tokens author
-      then consume_room_messages remaining msg.seq mentions scope_messages rest
-      else if
-        Coord_task_cache_invariant.stale_active_task_signal_present
-          ~config
-          ~from_agent:author
-          ~module_name:"keeper_world_observation"
-          ~content:msg.content
-      then consume_room_messages remaining msg.seq mentions scope_messages rest
-      else if exact_direct_mention_present ~targets msg.content
-      then
-        if remaining <= 0
-        then
-          ( `Saturated
-          , remaining
-          , last_processed
-          , List.rev mentions
-          , List.rev scope_messages )
-        else
-          consume_room_messages
-            (remaining - 1)
-            msg.seq
-            ((msg.from_agent, msg.content) :: mentions)
-            scope_messages
-            rest
-      else if broad_scope
-      then
-        (* Broad room scope is for operator/human context; direct mentions
-           above still allow explicit keeper-to-keeper handoff. *)
-        if is_keeper_authored_message author
-        then consume_room_messages remaining msg.seq mentions scope_messages rest
-        else if remaining <= 0
-        then
-          ( `Saturated
-          , remaining
-          , last_processed
-          , List.rev mentions
-          , List.rev scope_messages )
-        else
-          consume_room_messages
-            (remaining - 1)
-            msg.seq
-            mentions
-            ((msg.from_agent, msg.content) :: scope_messages)
-            rest
-      else consume_room_messages remaining msg.seq mentions scope_messages rest
-  in
-  let rec consume_rooms remaining mentions_acc scope_acc cursor_acc = function
-    | [] -> mentions_acc, scope_acc, List.rev cursor_acc
-    | _ when remaining <= 0 -> mentions_acc, scope_acc, List.rev cursor_acc
-    | room_id :: rest ->
-      let since_seq = room_cursor_for meta room_id in
-      let messages =
-        try Coord.get_all_messages_raw config ~since_seq with
-        | Eio.Cancel.Cancelled _ as e -> raise e
-        | _ -> []
-      in
-      let status, remaining, last_processed, room_mentions, scoped_messages =
-        consume_room_messages remaining since_seq [] [] messages
-      in
-      let cursor_acc =
-        if last_processed > since_seq
-        then (room_id, last_processed) :: cursor_acc
-        else cursor_acc
-      in
-      let mentions_acc = mentions_acc @ room_mentions in
-      let scope_acc = scope_acc @ scoped_messages in
-      (match status with
-       | `Done -> consume_rooms remaining mentions_acc scope_acc cursor_acc rest
-       | `Saturated -> mentions_acc, scope_acc, List.rev cursor_acc)
-  in
-  consume_rooms batch_limit [] [] [] meta.joined_room_ids
+  let _ = config, meta in
+  [], [], []
 ;;
 
 let apply_message_cursor_updates (meta : keeper_meta) (updates : (string * int) list)
   : keeper_meta
   =
-  List.fold_left (fun acc (room_id, seq) -> set_room_cursor acc room_id seq) meta updates
+  let _ = updates in
+  meta
 ;;

--- a/lib/types/types_core.mli
+++ b/lib/types/types_core.mli
@@ -56,7 +56,6 @@ val normalize_agent_last_seen : joined_at:Yojson.Safe.t option -> Yojson.Safe.t 
 val short_json_repr : Yojson.Safe.t -> string
 
 type task_action =
-type task_action =
   | Claim
   | Start
   | Done_action


### PR DESCRIPTION
## Summary
- Remove leftover room-state fields from `Agent_identity` and keeper meta parsing interfaces after the room presence meta cleanup.
- Drop stale room cursor exports/usages and no-op message cursor persistence where the backing meta state no longer exists.
- Remove merge-artifact duplicate declarations/calls that were still breaking focused Dune builds on current main.

## Verification
- `ocamlformat --check lib/agent_identity.mli lib/keeper/keeper_meta_json_parse.ml lib/keeper/keeper_memory_policy.ml lib/keeper/keeper_context_runtime.ml lib/keeper/keeper_turn_runtime_budget_routing.ml lib/keeper/keeper_execution.ml lib/keeper/keeper_execution.mli lib/keeper/keeper_world_observation_message_scope.ml`
- `git diff --check`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_mcp_protocol_coverage.exe test/test_http_negotiation.exe test/test_mcp_h1_h2_admission_parity.exe test/test_mcp_server_eio.exe`
- `_build/default/test/test_mcp_protocol_coverage.exe` passed: 37 tests.
- `_build/default/test/test_http_negotiation.exe` passed: 15 tests.
- `_build/default/test/test_mcp_h1_h2_admission_parity.exe` passed: 6 tests.
- `_build/default/test/test_mcp_server_eio.exe test eio 2,4` passed: 2 tests.
- `_build/default/test/test_mcp_server_eio.exe test eio 14` passed: 1 test.

## Notes
- I attempted an additional targeted keeper-side build (`test_agent_identity`, `test_mcp_full_cycle`, `test_keeper_unified_idle_cooldown`, `test_keeper_unified_verification_surface`) but stopped it while it was waiting behind another active wrapper-owned full `dune build .` lock in `.worktrees/fix-main-build-20260601-codex`.