### PR TITLE
[codex] Fix keeper runtime build after room signal purge

### DIFF
--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -345,7 +345,6 @@ let ensure_keeper_meta config name =
     if any_changed then begin
       let cats = List.filter_map Fun.id [
         (if proactive_changed then Some "proactive" else None);
-        (if signal_changed then Some "signal" else None);
         (if denylist_changed then Some "denylist" else None);
         (if social_model_changed then Some "social_model" else None);
         (if runtime_changed then Some "runtime" else None);

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -118,7 +118,6 @@ type board_signal_match = Board_signal.match_result =
 module Message_scope = Keeper_world_observation_message_scope
 module Inputs = Keeper_world_observation_inputs
 
-let scope_message_feed_enabled = Message_scope.scope_message_feed_enabled
 let self_identity_tokens = Message_scope.self_identity_tokens
 let is_self_author = Message_scope.is_self_author
 let collect_message_scope = Message_scope.collect_message_scope
@@ -228,7 +227,6 @@ let collect_board_events_with_cursor_policy
   : pending_board_event list * int * int
   =
   try
-    let broad_scope = scope_message_feed_enabled meta in
     let cursor_ts, cursor_post_id =
       Keeper_registry.get_board_cursor ~base_path meta.name
     in
@@ -288,11 +286,11 @@ let collect_board_events_with_cursor_policy
              }
            in
            let matched = board_signal_match ~continuity_summary ~meta ~signal in
-           if not (matched.explicit_mention || broad_scope)
+           if not matched.explicit_mention
            then (
              Log.Keeper.debug
-               "board dedup: skipping post_id=%s (no mention and no prior keeper \
-                participation)"
+               "board dedup: skipping post_id=%s (no explicit mention and no prior \
+                keeper participation)"
                post_id;
              consume_posts remaining (Some next_cursor) acc rest)
            else if remaining <= 0

--- a/lib/keeper/keeper_world_observation_board_signal.ml
+++ b/lib/keeper/keeper_world_observation_board_signal.ml
@@ -217,8 +217,6 @@ let wake_reason
   let matched = match_signal ~continuity_summary ~meta ~signal in
   if matched.explicit_mention
   then Some "explicit_mention"
-  else if Message_scope.scope_message_feed_enabled meta
-  then Some "board_activity"
   else (
     let stigmergy = stigmergy_match ~meta ~signal in
     if stigmergy.overall_score > 0

--- a/lib/keeper/keeper_world_observation_message_scope.mli
+++ b/lib/keeper/keeper_world_observation_message_scope.mli
@@ -1,10 +1,8 @@
 (** Message-scope helpers for keeper world observation. *)
 
-open Keeper_types
 open Keeper_meta_contract
 open Keeper_types_profile
 
-val scope_message_feed_enabled : keeper_meta -> bool
 val message_feed_targets : keeper_meta -> string list
 val self_identity_tokens : keeper_meta -> string list
 val is_self_author : self_tokens:string list -> string -> bool


### PR DESCRIPTION
## Summary
- Remove the stale `scope_message_feed_enabled` interface/export and its remaining broad-scope board branches after the room signal prompt purge.
- Remove the stale `signal_changed` re-sync log category reference from keeper runtime.

## Root Cause
PR #19642 removed `room_signal_prompt_enabled` and its implementation-side change detection, but left the public message-scope declaration and a keeper runtime log category referencing the deleted value.

## Validation
- `ocamlformat --check lib/keeper/keeper_runtime.ml lib/keeper/keeper_world_observation.ml lib/keeper/keeper_world_observation_board_signal.ml lib/keeper/keeper_world_observation_message_scope.mli`
- `git diff --check origin/main..HEAD`
- `env DUNE_BUILD_DIR=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-main-keeper-runtime-build-20260601/_build-direct dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-main-keeper-runtime-build-20260601 lib/masc_mcp.cma`