### PR TITLE
Purge room lifecycle tool surface

### DIFF
--- a/bin/gen_tool_descriptors.ml
+++ b/bin/gen_tool_descriptors.ml
@@ -367,7 +367,7 @@ let masc_plan_set_task_spec : tool_spec =
   ; description =
       "Set the current task for your session so you can omit task_id in subsequent \
        planning calls. Use when starting work on a task after claiming it. After \
-       masc_claim_next; auto-cleared on masc_leave."
+       masc_claim_next; auto-cleared on session end."
   ; parameters =
       [ { p_name = "task_id"
         ; p_type = T_string { enum = None; default = None }
@@ -385,7 +385,7 @@ let masc_plan_get_task_spec : tool_spec =
   ; description =
       "Get the task_id you're currently working on (session-scoped). Use when resuming \
        work after a context switch or verifying your current assignment. Set via \
-       masc_plan_set_task. Auto-cleared on masc_leave."
+       masc_plan_set_task. Auto-cleared on session end."
   ; parameters = []
   ; additional_properties = false
   ; behavior_contract = []
@@ -397,8 +397,7 @@ let masc_plan_clear_task_spec : tool_spec =
   ; description =
       "Clear your current task assignment without completing it (does not change task \
        status). Use when switching to a different task, abandoning work, or resetting \
-       session state. Use masc_transition to change task status separately. Auto-called \
-       on masc_leave."
+       session state. Use masc_transition to change task status separately."
   ; parameters = []
   ; additional_properties = false
   ; behavior_contract = []
@@ -516,52 +515,6 @@ let masc_start_spec : tool_spec =
   }
 ;;
 
-let masc_join_spec : tool_spec =
-  { name = "masc_join"
-  ; description =
-      "Join the active MASC project as agent_name to collaborate with other AI agents. \
-       Call at session start or to re-register presence. Other agents can @mention \
-       you. Check masc_status after joining to see active agents and available tasks."
-  ; parameters =
-      [ { p_name = "agent_name"
-        ; p_type = T_string { enum = None; default = None }
-        ; p_description =
-            "Your identity — any string you choose. Conventionally matches \
-             your MCP client name (so other agents can @mention you), but the \
-             server holds no closed list."
-        ; p_required = true
-        }
-      ; { p_name = "capabilities"
-        ; p_type = T_string_array { default = None }
-        ; p_description =
-            "Your strengths (e.g., ['typescript', 'code-review', 'testing'])"
-        ; p_required = false
-        }
-      ]
-  ; additional_properties = false
-  ; behavior_contract = []
-  }
-;;
-
-let masc_leave_spec : tool_spec =
-  { name = "masc_leave"
-  ; description =
-      "Leave the active MASC project and mark yourself as offline. Call when: (1) \
-       session ends, (2) switching projects, (3) work complete. Side effects: releases \
-       all your locks, sets presence to offline. Other agents will see you've left via \
-       SSE. Example: masc_leave({agent_name: 'worker-1'})"
-  ; parameters =
-      [ { p_name = "agent_name"
-        ; p_type = T_string { enum = None; default = None }
-        ; p_description = "Your agent name"
-        ; p_required = true
-        }
-      ]
-  ; additional_properties = false
-  ; behavior_contract = []
-  }
-;;
-
 let masc_broadcast_spec : tool_spec =
   { name = "masc_broadcast"
   ; description =
@@ -612,20 +565,6 @@ let masc_messages_spec : tool_spec =
   }
 ;;
 
-let masc_who_spec : tool_spec =
-  { name = "masc_who"
-  ; description =
-      "List all agents currently in the active project with their capabilities. \
-       Shows: agent name, join time, capabilities (e.g., ['typescript', 'testing']). \
-       Use to: find who can help, check if specific agent is online, see team \
-       composition. Agents appear after masc_join, disappear after masc_leave. Tip: \
-       Use capabilities to find the right agent for @mentions."
-  ; parameters = []
-  ; additional_properties = false
-  ; behavior_contract = []
-  }
-;;
-
 let phase6_specs : tool_spec list =
   [ masc_config_spec
   ; masc_tool_help_spec
@@ -654,11 +593,8 @@ let phase6_specs : tool_spec list =
   ; masc_approval_get_spec
     (* PR-2d: inline_coord group *)
   ; masc_start_spec
-  ; masc_join_spec
-  ; masc_leave_spec
   ; masc_broadcast_spec
   ; masc_messages_spec
-  ; masc_who_spec
   ]
 ;;
 

--- a/config/prompts/keeper.tool_unknown_guard.md
+++ b/config/prompts/keeper.tool_unknown_guard.md
@@ -3,4 +3,4 @@ description: keeper guard against calling tool names absent from the active runt
 category: keeper
 ---
 
-Do not call tool names that are absent from the active runtime schema list. Heartbeat is server-managed; public lifecycle/status tools such as `masc_join`, `masc_who`, and `masc_heartbeat` are not keeper action tools unless they are explicitly shown to you. Copy active schema names exactly; do not substitute public `masc_*` aliases such as `masc_board_list` for keeper-scoped tools.
+Do not call tool names that are absent from the active runtime schema list. Heartbeat is server-managed; public status tools such as `masc_heartbeat` are not keeper action tools unless they are explicitly shown to you. Copy active schema names exactly; do not substitute public `masc_*` aliases such as `masc_board_list` for keeper-scoped tools.

--- a/config/tool_policy.toml
+++ b/config/tool_policy.toml
@@ -113,7 +113,7 @@ tools = [
   "masc_batch_add_tasks", "masc_agents", "masc_dashboard",
   "masc_agent_card", "masc_tool_help",
   "masc_task_history", "masc_plan_get", "masc_plan_get_task",
-  "masc_join", "masc_leave", "masc_who", "masc_heartbeat",
+  "masc_heartbeat",
   "masc_messages", "masc_broadcast",
 ]
 

--- a/lib/auto_responder.ml
+++ b/lib/auto_responder.ml
@@ -185,23 +185,6 @@ let masc_call ~sw:_ ~tool_name ~(args : Yojson.Safe.t) : (string, string) result
         Log.Misc.warn "auto_responder: MCP response parse failed: %s" (Printexc.to_string exn);
         Ok body_str
 
-let extract_nickname (response_text : string) : string option =
-  let prefix = "Nickname:" in
-  let lines = String.split_on_char '\n' response_text in
-  let rec find = function
-    | [] -> None
-    | line :: rest ->
-        let trimmed = String.trim line in
-        if String.starts_with trimmed ~prefix
-        then
-          Some
-            (String.trim
-               (String.sub trimmed (String.length prefix)
-                  (String.length trimmed - String.length prefix)))
-        else find rest
-  in
-  find lines
-
 let call_model_and_broadcast ~sw ~agent_type ~prompt ~mention =
   let response = call_model_direct_sync ~agent_type ~prompt in
   debug_log (Printf.sprintf "MODEL_RESPONSE: %s"
@@ -209,50 +192,19 @@ let call_model_and_broadcast ~sw ~agent_type ~prompt ~mention =
   if response = "" || response = "no response" then
     Log.AutoResponder.info "MODEL returned empty response"
   else begin
-    let join_args =
-      `Assoc [
-        ("agent_name", `String agent_type);
-        ("capabilities", `List [`String "model-auto-responder"]);
-      ]
-    in
-    match
-      masc_call ~sw
-        ~tool_name:(Tool_name.Masc.to_string Tool_name.Masc.Join)
-        ~args:join_args
-    with
-    | Error e ->
-        debug_log (Printf.sprintf "MASC_JOIN_FAILED: %s" e);
-        Log.AutoResponder.error "Failed to join MASC (%s)" e
-    | Ok join_resp -> (
-        debug_log (Printf.sprintf "MASC_JOIN: %s"
-          (String_util.utf8_safe ~max_bytes:203 ~suffix:"..." join_resp |> String_util.to_string));
-        match extract_nickname join_resp with
-        | None ->
-            debug_log "MASC_JOIN_FAILED: Could not extract nickname";
-            Log.AutoResponder.error "Failed to join MASC (no nickname)"
-        | Some nickname ->
-            let msg = Printf.sprintf "@%s %s" mention response in
-            let broadcast_args = `Assoc [("agent_name", `String nickname); ("message", `String msg)] in
-            (try
-               ignore
-                 (masc_call ~sw
-                    ~tool_name:(Tool_name.Masc.to_string Tool_name.Masc.Broadcast)
-                    ~args:broadcast_args)
-             with
-             | Eio.Cancel.Cancelled _ as e -> raise e
-             | exn -> Log.AutoResponder.error "broadcast failed: %s" (Printexc.to_string exn));
-            let leave_args = `Assoc [("agent_name", `String nickname)] in
-            (try
-               ignore
-                 (masc_call ~sw
-                    ~tool_name:(Tool_name.Masc.to_string Tool_name.Masc.Leave)
-                    ~args:leave_args)
-             with
-             | Eio.Cancel.Cancelled _ as e -> raise e
-             | exn -> Log.AutoResponder.error "leave failed: %s" (Printexc.to_string exn));
-            let short_resp = String_util.utf8_safe ~max_bytes:53 ~suffix:"..." response |> String_util.to_string in
-            Log.AutoResponder.info "%s: %s" nickname short_resp
-      )
+    let nickname = agent_type in
+    let msg = Printf.sprintf "@%s %s" mention response in
+    let broadcast_args = `Assoc [("agent_name", `String nickname); ("message", `String msg)] in
+    (try
+       ignore
+         (masc_call ~sw
+            ~tool_name:(Tool_name.Masc.to_string Tool_name.Masc.Broadcast)
+            ~args:broadcast_args)
+     with
+     | Eio.Cancel.Cancelled _ as e -> raise e
+     | exn -> Log.AutoResponder.error "broadcast failed: %s" (Printexc.to_string exn));
+    let short_resp = String_util.utf8_safe ~max_bytes:53 ~suffix:"..." response |> String_util.to_string in
+    Log.AutoResponder.info "%s: %s" nickname short_resp
   end
 
 (* --- Public API --- *)

--- a/lib/auto_responder.mli
+++ b/lib/auto_responder.mli
@@ -5,7 +5,6 @@ type mode = Disabled | Model
 val get_mode : unit -> mode
 val is_enabled : unit -> bool
 val activity_log_file : unit -> string
-val extract_nickname : string -> string option
 val chain_limit : int
 val chain_window_sec : float
 

--- a/lib/board_types/board_types.ml
+++ b/lib/board_types/board_types.ml
@@ -87,7 +87,7 @@ end = struct
 
   (* Issue #8633: pattern was [^[a-zA-Z0-9._-]+$] which rejected the
      [keeper:foo] colon-namespacing supported by the canonical
-     [Validation.Agent_id] (used by masc_join / masc_claim_next).
+     [Validation.Agent_id] (used by session-bound task coordination).
      Real callers exist (server_routes_http_keeper_stream:413,
      server_openai_compat:153). Pattern is now a strict superset of
      both: optional single colon namespace + previously-allowed dots.

--- a/lib/coord/coord_agent.ml
+++ b/lib/coord/coord_agent.ml
@@ -83,7 +83,7 @@ let register_capabilities config ~agent_name ~capabilities =
           Printf.sprintf "Invalid agent file for %s" actual_name
     )
   end else
-    Printf.sprintf "Agent %s not found. Join first!" agent_name
+    Printf.sprintf "Agent %s not found. Bind the session first." agent_name
 
 (** Update agent metadata (status/capabilities).
     Since #4638 agent metadata always lives under the root agents_dir. *)

--- a/lib/coord/coord_lifecycle.ml
+++ b/lib/coord/coord_lifecycle.ml
@@ -30,7 +30,7 @@ let agent_parse_error_snapshot ~agent_name ~agent_file =
       if raw_head = "" then `Null else `String raw_head);
   ]
 
-(** Join room - with auto-generated nickname and metadata *)
+(** Bind agent session - with auto-generated nickname and metadata *)
 let join config ~agent_name ?(agent_type_override=None) ~capabilities
     ?(pid=None) ?(hostname=None) ?(tty=None)
     ?(parent_task=None) ?(keeper_name=None) ?(keeper_id=None) () =
@@ -207,7 +207,7 @@ let join config ~agent_name ?(agent_type_override=None) ~capabilities
 (* join_in_room removed — namespace concept retired (#unify-namespace).
    Use [join] directly. *)
 
-(** Leave room *)
+(** End agent session *)
 let leave ?(stop_heartbeats = true) config ~agent_name =
   ensure_initialized config;
 

--- a/lib/coord/coord_status.ml
+++ b/lib/coord/coord_status.ml
@@ -94,7 +94,7 @@ let status config =
     if total_agents > max_agents_display then
       Buffer.add_string buf
         (Printf.sprintf
-           "  … and %d more agents (use masc_who for full list)\n"
+           "  … and %d more agents\n"
            (total_agents - max_agents_display))
   end;
 

--- a/lib/coord_assertions.ml
+++ b/lib/coord_assertions.ml
@@ -54,7 +54,7 @@ let assertion_kind_of_string_lenient = function
 
 let assertion_fix_hint = function
   | Room_set -> "Call masc_start with your project root path."
-  | Joined -> "Call masc_join to register your agent in the project namespace"
+  | Joined -> "Call masc_start to bind your agent session"
   | Task_claimed -> "Claim a task with masc_transition(action=claim) or masc_claim_next"
   | Current_task_set ->
     "Call masc_plan_set_task to choose or re-sync the active task when current_task is \

--- a/lib/coord_status_rendering.ml
+++ b/lib/coord_status_rendering.ml
@@ -269,7 +269,7 @@ let status_summary_string
       if agent_count > max_agents_display then
         Buffer.add_string buf
           (Printf.sprintf
-             "  … and %d more agents (use masc_who for full list)\n"
+             "  … and %d more agents\n"
              (agent_count - max_agents_display)));
   Buffer.add_string buf "\nQuest Board:\n";
   List.iter

--- a/lib/governance_pipeline_risk.ml
+++ b/lib/governance_pipeline_risk.ml
@@ -171,10 +171,10 @@ let risk_of_masc (m : Tool_name.Masc.t) : risk_level =
   | Heartbeat | Messages | Note_add | Operator_action | Operator_digest
   | Operator_snapshot | Plan_clear_task | Plan_get | Plan_get_task | Plan_init
   | Plan_set_task | Status | Task_history | Tasks | Tool_grant | Tool_help
-  | Tool_list | Tool_revoke | Transition | Web_fetch | Web_search | Who
+  | Tool_list | Tool_revoke | Transition | Web_fetch | Web_search
   | Approval_pending | Approval_get | Config | Gc | Get_metrics | Mcp_session
   | Tool_admin_snapshot | Tool_stats -> Low
-  | Claim_next | Goal_upsert | Goal_verify | Join | Leave | Operator_confirm
+  | Claim_next | Goal_upsert | Goal_verify | Operator_confirm
   | Pause | Resume | Start -> Medium
   | Agent_update | Board_sub_board_create | Board_sub_board_update | Plan_update
   | Update_priority | Tool_admin_update -> High

--- a/lib/grpc/masc_grpc_client.ml
+++ b/lib/grpc/masc_grpc_client.ml
@@ -50,18 +50,6 @@ let call_unary_safe t ~sw ~env ~method_ ~request ~decode =
 
 (** {1 Unary RPCs} *)
 
-let join t ~sw ~env ~agent_name ~capabilities ~metadata =
-  let request = T.JoinRequest.to_bytes
-    { agent_name; capabilities; metadata } in
-  call_unary_safe t ~sw ~env ~method_:"Join" ~request
-    ~decode:T.JoinResponse.of_bytes
-
-let leave t ~sw ~env ~agent_name ~session_id =
-  let request = T.LeaveRequest.to_bytes
-    { agent_name; session_id } in
-  call_unary_safe t ~sw ~env ~method_:"Leave" ~request
-    ~decode:T.LeaveResponse.of_bytes
-
 let get_status t ~sw ~env =
   (* StatusRequest is an empty protobuf message: 0 bytes on the wire. *)
   let request = "" in

--- a/lib/grpc/masc_grpc_client.mli
+++ b/lib/grpc/masc_grpc_client.mli
@@ -4,7 +4,7 @@
     Mirrors the server RPCs defined in [Masc_grpc_service].
 
     Each function maps to one gRPC RPC:
-    - [join], [leave], [get_status], [tool_call], [broadcast] are unary.
+    - [get_status], [tool_call], [broadcast] are unary.
     - [subscribe] is server-streaming (returns an event stream).
     - [heartbeat_stream] is bidirectional streaming.
 
@@ -41,25 +41,6 @@ val create_from_env :
 val close : t -> unit
 
 (** {1 Unary RPCs} *)
-
-(** Join the coordination room. *)
-val join :
-  t ->
-  sw:Eio.Switch.t ->
-  env:Eio_unix.Stdenv.base ->
-  agent_name:string ->
-  capabilities:string list ->
-  metadata:(string * string) list ->
-  (Masc_grpc_types.JoinResponse.t, string) result
-
-(** Leave the coordination room. *)
-val leave :
-  t ->
-  sw:Eio.Switch.t ->
-  env:Eio_unix.Stdenv.base ->
-  agent_name:string ->
-  session_id:string ->
-  (Masc_grpc_types.LeaveResponse.t, string) result
 
 (** Get current room status. *)
 val get_status :

--- a/lib/grpc/masc_grpc_server.ml
+++ b/lib/grpc/masc_grpc_server.ml
@@ -471,7 +471,7 @@ let start
         Log.Server.info "  service: %s" Masc_grpc_service.service_name;
         Log.Server.info "  health: %s/Check" health_service_name;
         Log.Server.info
-          "  methods: Join, Leave, Broadcast, GetStatus, ToolCall, Subscribe, Heartbeat";
+          "  methods: Broadcast, GetStatus, ToolCall, Subscribe, Heartbeat";
         Transport_metrics.set_grpc_runtime_listening true;
         Transport_metrics.set_grpc_listen_status "listening";
         (* Safe: finally is Atomic.set — no I/O, no exception risk *)

--- a/lib/grpc/masc_grpc_service.ml
+++ b/lib/grpc/masc_grpc_service.ml
@@ -78,93 +78,6 @@ let task_info_of_task (task : Masc_domain.task) : T.task_info =
 
 (** {1 Unary Handlers} *)
 
-(** Join handler: agent joins the coordination room. *)
-let handle_join (room_config : Coord_utils_backend_setup.config) (bytes : string) : string
-  =
-  let req = decode_request_or_raise ~rpc:"Join" T.JoinRequest.of_bytes_result bytes in
-  let result =
-    try
-      let msg =
-        Coord.join
-          room_config
-          ~agent_name:req.agent_name
-          ~capabilities:req.capabilities
-          ()
-      in
-      (* Read current agents for the response *)
-      let agents_dir =
-        Filename.concat
-          (Common.masc_dir_from_base_path ~base_path:room_config.base_path)
-          "agents"
-      in
-      let active_agents =
-        if Sys.file_exists agents_dir && Sys.is_directory agents_dir
-        then
-          Sys.readdir agents_dir
-          |> Array.to_list
-          |> List.filter (fun f -> Filename.check_suffix f ".json")
-          |> List.filter_map (fun f ->
-            let path = Filename.concat agents_dir f in
-            try
-              let json = Yojson.Safe.from_string (read_file_safe path) in
-              match Masc_domain.agent_of_yojson json with
-              | Ok agent when agent.Masc_domain.status = Masc_domain.Active ->
-                Some
-                  ({ T.name = agent.name
-                   ; status = "active"
-                   ; capabilities = agent.capabilities
-                   ; last_heartbeat_ms = now_ms ()
-                   ; joined_at_ms = now_ms ()
-                   ; current_task_id = Option.value ~default:"" agent.current_task
-                   }
-                   : T.agent_info)
-              | _ -> None
-            with
-            | Eio.Cancel.Cancelled _ as e -> raise e
-            | exn ->
-              Log.Transport.debug "agent parse skip: %s" (Printexc.to_string exn);
-              None)
-        else []
-      in
-      T.JoinResponse.
-        { success = true
-        ; message = msg
-        ; session_id = Printf.sprintf "grpc-%s-%Ld" req.agent_name (now_ms ())
-        ; active_agents
-        }
-    with
-    | Eio.Cancel.Cancelled _ as e -> raise e
-    | exn ->
-      T.JoinResponse.
-        { success = false
-        ; message = Printf.sprintf "Join failed: %s" (Printexc.to_string exn)
-        ; session_id = ""
-        ; active_agents = []
-        }
-  in
-  T.JoinResponse.to_bytes result
-;;
-
-(** Leave handler: agent leaves the coordination room. *)
-let handle_leave (room_config : Coord_utils_backend_setup.config) (bytes : string)
-  : string
-  =
-  let req = decode_request_or_raise ~rpc:"Leave" T.LeaveRequest.of_bytes_result bytes in
-  let result =
-    try
-      let msg = Coord.leave room_config ~agent_name:req.agent_name in
-      T.LeaveResponse.{ success = true; message = msg }
-    with
-    | Eio.Cancel.Cancelled _ as e -> raise e
-    | exn ->
-      T.LeaveResponse.
-        { success = false
-        ; message = Printf.sprintf "Leave failed: %s" (Printexc.to_string exn)
-        }
-  in
-  T.LeaveResponse.to_bytes result
-;;
-
 (** Broadcast handler: send a message to all agents. *)
 let handle_broadcast (room_config : Coord_utils_backend_setup.config) (bytes : string)
   : string
@@ -631,8 +544,6 @@ let create_service
   : Grpc_eio.Service.t
   =
   Grpc_eio.Service.create service_name
-  |> Grpc_eio.Service.add_unary "Join" (handle_join room_config)
-  |> Grpc_eio.Service.add_unary "Leave" (handle_leave room_config)
   |> Grpc_eio.Service.add_unary "Broadcast" (handle_broadcast room_config)
   |> Grpc_eio.Service.add_unary "GetStatus" (handle_get_status room_config)
   |> Grpc_eio.Service.add_unary "ToolCall" (handle_tool_call tool_dispatcher)

--- a/lib/grpc/masc_grpc_types.ml
+++ b/lib/grpc/masc_grpc_types.ml
@@ -18,7 +18,7 @@ let encode to_proto msg = Ocaml_protoc_plugin.Writer.contents (to_proto msg)
 (** Deserialize a protobuf message from a binary string.
 
     [type_name] identifies the protobuf message type being decoded
-    (e.g. "JoinRequest", "ToolCallResponse"). It is embedded in the
+    (e.g. "ToolCallResponse"). It is embedded in the
     error message so operators see which message type failed instead
     of a context-free "protobuf decode error: ..." line. *)
 let decode_result ~type_name from_proto bytes =
@@ -100,109 +100,6 @@ let task_info_of_proto (p : P.TaskInfo.t) : task_info =
   ; priority = p.priority
   }
 ;;
-
-(** {1 Agent Lifecycle} *)
-
-module JoinRequest = struct
-  type t =
-    { agent_name : string
-    ; capabilities : string list
-    ; metadata : (string * string) list
-    }
-
-  let of_bytes_result bytes =
-    match decode_result ~type_name:"JoinRequest" P.JoinRequest.from_proto bytes with
-    | Ok p ->
-      Ok
-        ({ agent_name = p.agent_name
-         ; capabilities = p.capabilities
-         ; metadata = p.metadata
-         }
-         : t)
-    | Error _ as err -> err
-  ;;
-
-  let of_bytes bytes =
-    match of_bytes_result bytes with
-    | Ok req -> req
-    | Error msg -> invalid_arg msg
-  ;;
-
-  let to_bytes (t : t) =
-    encode
-      P.JoinRequest.to_proto
-      { agent_name = t.agent_name; capabilities = t.capabilities; metadata = t.metadata }
-  ;;
-end
-
-module JoinResponse = struct
-  type t =
-    { success : bool
-    ; message : string
-    ; session_id : string
-    ; active_agents : agent_info list
-    }
-
-  let of_bytes bytes =
-    let p = decode ~type_name:"JoinResponse" P.JoinResponse.from_proto bytes in
-    { success = p.success
-    ; message = p.message
-    ; session_id = p.session_id
-    ; active_agents = List.map agent_info_of_proto p.active_agents
-    }
-  ;;
-
-  let to_bytes (t : t) =
-    encode
-      P.JoinResponse.to_proto
-      { success = t.success
-      ; message = t.message
-      ; session_id = t.session_id
-      ; active_agents = List.map agent_info_to_proto t.active_agents
-      }
-  ;;
-end
-
-module LeaveRequest = struct
-  type t =
-    { agent_name : string
-    ; session_id : string
-    }
-
-  let of_bytes_result bytes =
-    match decode_result ~type_name:"LeaveRequest" P.LeaveRequest.from_proto bytes with
-    | Ok p -> Ok ({ agent_name = p.agent_name; session_id = p.session_id } : t)
-    | Error _ as err -> err
-  ;;
-
-  let of_bytes bytes =
-    match of_bytes_result bytes with
-    | Ok req -> req
-    | Error msg -> invalid_arg msg
-  ;;
-
-  let to_bytes (t : t) =
-    encode
-      P.LeaveRequest.to_proto
-      { agent_name = t.agent_name; session_id = t.session_id }
-  ;;
-end
-
-module LeaveResponse = struct
-  type t =
-    { success : bool
-    ; message : string
-    }
-
-  let of_bytes bytes =
-    let p = decode ~type_name:"LeaveResponse" P.LeaveResponse.from_proto bytes in
-    { success = p.success; message = p.message }
-  ;;
-
-  let to_bytes (t : t) =
-    encode P.LeaveResponse.to_proto { success = t.success; message = t.message }
-  ;;
-end
 
 (** {1 Heartbeat} *)
 

--- a/lib/grpc/masc_grpc_types.mli
+++ b/lib/grpc/masc_grpc_types.mli
@@ -26,53 +26,6 @@ type task_info =
   ; priority : int
   }
 
-(** {1 Agent Lifecycle} *)
-
-module JoinRequest : sig
-  type t =
-    { agent_name : string
-    ; capabilities : string list
-    ; metadata : (string * string) list
-    }
-
-  val of_bytes_result : string -> (t, string) result
-  val of_bytes : string -> t
-  val to_bytes : t -> string
-end
-
-module JoinResponse : sig
-  type t =
-    { success : bool
-    ; message : string
-    ; session_id : string
-    ; active_agents : agent_info list
-    }
-
-  val of_bytes : string -> t
-  val to_bytes : t -> string
-end
-
-module LeaveRequest : sig
-  type t =
-    { agent_name : string
-    ; session_id : string
-    }
-
-  val of_bytes_result : string -> (t, string) result
-  val of_bytes : string -> t
-  val to_bytes : t -> string
-end
-
-module LeaveResponse : sig
-  type t =
-    { success : bool
-    ; message : string
-    }
-
-  val of_bytes : string -> t
-  val to_bytes : t -> string
-end
-
 (** {1 Heartbeat} *)
 
 module HeartbeatPing : sig

--- a/lib/institution_eio.ml
+++ b/lib/institution_eio.ml
@@ -687,7 +687,7 @@ let load_and_format_for_spawn ~fs (config : config) : string =
   | None -> ""
 ;;
 
-(** Short welcome format for masc_join response.
+(** Short welcome format for agent startup response.
     Concise cultural inheritance - mission + values + one tip.
     @param inst The institution to format
     @return Formatted string for join welcome

--- a/lib/keeper/keeper_tool_guidance.ml
+++ b/lib/keeper/keeper_tool_guidance.ml
@@ -123,8 +123,8 @@ let fallback_prose key =
   then
     Some
       "Do not call tool names that are absent from the active runtime schema \
-       list. Heartbeat is server-managed; public lifecycle/status tools such \
-       as `masc_join`, `masc_who`, and `masc_heartbeat` are not keeper action \
+       list. Heartbeat is server-managed; public status tools such \
+       as `masc_heartbeat` are not keeper action \
        tools unless they are explicitly shown to you. Copy active schema names \
        exactly; do not substitute public `masc_*` aliases such as \
        `masc_board_list` for keeper-scoped tools."

--- a/lib/local/worker_container_types.ml
+++ b/lib/local/worker_container_types.ml
@@ -549,26 +549,6 @@ let local_worker_max_tokens () = Env_config.Worker.local_worker_max_tokens
 
 let local_worker_heartbeat_interval_sec () = Env_config.Worker.local_worker_heartbeat_sec
 
-let join_worker ~sw ~(auth_token : string option) ~session_id ~worker_name =
-  let args =
-    `Assoc
-      [
-        ("agent_name", `String worker_name);
-        ( "capabilities",
-          `List
-            [
-              `String "llama";
-              `String "mcp-worker";
-              `String "local-tool-loop";
-            ] );
-      ]
-  in
-  call_masc_tool ~sw ~auth_token ~session_id ~tool_name:"masc_join" ~args
-
-let leave_worker ~sw ~(auth_token : string option) ~session_id ~worker_name =
-  let args = `Assoc [ ("agent_name", `String worker_name) ] in
-  call_masc_tool ~sw ~auth_token ~session_id ~tool_name:"masc_leave" ~args
-
 let default_system_prompt ~worker_name ~model_id ?role
     ?selection_note () =
   let role_line =

--- a/lib/local/worker_container_types.mli
+++ b/lib/local/worker_container_types.mli
@@ -6,7 +6,7 @@
       types: the values flowing between {!Worker_runtime},
       {!Worker_oas}, and {!Worker_runtime_helper_protocol}.
     - The MCP transport bridge ({!call_masc_tool},
-      {!join_worker}, {!leave_worker}, {!mcp_endpoint_url}):
+      {!mcp_endpoint_url}):
       a JSON-RPC client that lets a local worker call MASC
       tools without going through the HTTP server's auth
       machinery.
@@ -169,28 +169,6 @@ val call_masc_tool :
     extracted text and [isError] flag, or an error string on
     transport / parse / RPC failure.  Re-raises
     [Eio.Cancel.Cancelled]. *)
-
-val join_worker :
-  sw:Eio.Switch.t ->
-  auth_token:string option ->
-  session_id:string ->
-  worker_name:string ->
-  (tool_exec_result, string) result
-(** Convenience wrapper around {!call_masc_tool} for the
-    [masc_join] tool.  Passes the canonical capability set
-    ([llama], [mcp-worker], [local-tool-loop]) so the room
-    routing knows this is a local worker, not a coordinating
-    keeper. *)
-
-val leave_worker :
-  sw:Eio.Switch.t ->
-  auth_token:string option ->
-  session_id:string ->
-  worker_name:string ->
-  (tool_exec_result, string) result
-(** Convenience wrapper around {!call_masc_tool} for the
-    [masc_leave] tool.  Pairs with {!join_worker} on worker
-    shutdown to retire the agent registration. *)
 
 (** {1 Default system prompt} *)
 

--- a/lib/masc_error_recovery.ml
+++ b/lib/masc_error_recovery.ml
@@ -36,7 +36,7 @@ let recovery_hint (message : string) : string option =
   if contains msg "not initialized" || contains msg "no .masc/" then
     Some "Run masc_init to initialize, or use masc_start(path=...) for one-step setup."
   else if contains msg "not joined" || contains msg "join the room" then
-    Some "Call masc_join first, or use masc_start for one-step setup."
+    Some "Call masc_start for one-step setup."
   else if contains msg "task not found" || contains msg "not found" && contains msg "task" then
     Some "Call masc_status to see available tasks."
   else if contains msg "already claimed" then

--- a/lib/masc_error_recovery.mli
+++ b/lib/masc_error_recovery.mli
@@ -26,8 +26,7 @@ val recovery_hint : string -> string option
 
     - "not initialized" / "no .masc/" → [masc_init] /
       [masc_start(path=…)]
-    - "not joined" / "join the room" → [masc_join] /
-      [masc_start]
+    - "not joined" / "join the room" → [masc_start]
     - "task not found" / ("not found" ∧ "task") → [masc_status]
     - "already claimed" → [masc_status] / [masc_claim_next]
     - "no unclaimed tasks" → [masc_add_task]

--- a/lib/mcp_server.ml
+++ b/lib/mcp_server.ml
@@ -230,7 +230,7 @@ let resources : mcp_resource list = [
     ~mime_type:"application/json" ();
   make_resource ~uri:"masc://who" ~name:"Active Agents"
     ~title:"Online Agents"
-    ~description:"In-memory agent/session status (same as masc_who)"
+    ~description:"In-memory agent/session status"
     ~mime_type:"text/markdown" ();
   make_resource ~uri:"masc://who.json" ~name:"Active Agents (JSON)"
     ~title:"Online Agents (JSON)"

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -213,7 +213,7 @@ let execute_tool_eio
        let caller_tool_names =
          Some (dedupe_string_list (profile_tool_names @ keeper_tool_names))
        in
-       let extract_nickname_from_join_result ~fallback result =
+       let extract_nickname_from_session_binding_result ~fallback result =
          try
            let prefix = "  Nickname: " in
            let start_idx =
@@ -235,9 +235,9 @@ let execute_tool_eio
          with
          | Invalid_argument _ -> fallback
        in
-       (* Auto-init/auto-join for better UX.
+       (* Auto-init/auto-bind for better UX.
      - Auto-init only when auth is disabled (avoid side effects in secured rooms).
-     - Auto-join when allowed by auth (and safe for token-based auth). *)
+     - Auto-bind when allowed by auth (and safe for token-based auth). *)
        let join_required =
          Agent_tool_descriptor_resolution.capability_has
            Tool_capability.Requires_join
@@ -272,14 +272,14 @@ let execute_tool_eio
             then false
             else if Option.is_none mcp_session_id
             then
-              (* Sessionless requests (no Mcp-Session-Id header) should not auto-join.
+              (* Sessionless requests (no Mcp-Session-Id header) should not auto-bind.
          Without a session, each request gets a new ephemeral agent name,
          causing orphan agent proliferation in the room. *)
               false
             else if not auth_enabled
             then true
             else (
-              (* If per-agent tokens are required, only auto-join when agent_name already
+              (* If per-agent tokens are required, only auto-bind when agent_name already
          looks like a stable nickname. Otherwise Coord.join would generate a new
          nickname, breaking token verification for subsequent calls. *)
               let auth_cfg = Auth.load_auth_config config.base_path in
@@ -291,7 +291,7 @@ let execute_tool_eio
                     config.base_path
                     ~agent_name
                     ~token
-                    ~tool_name:"masc_join"
+                    ~tool_name:"masc_start"
                 with
                 | Ok () -> true
                 | Error _ -> false))
@@ -323,7 +323,7 @@ let execute_tool_eio
               if is_joined
               then agent_name
               else (
-                let join_result =
+                let session_binding_result =
                   Coord.join
                     config
                     ~agent_name
@@ -333,9 +333,11 @@ let execute_tool_eio
                     ()
                 in
                 let nickname =
-                  extract_nickname_from_join_result ~fallback:agent_name join_result
+                  extract_nickname_from_session_binding_result
+                    ~fallback:agent_name
+                    session_binding_result
                 in
-                Log.Mcp.info "Auto-joined for %s: %s -> %s" name agent_name nickname;
+                Log.Mcp.info "Auto-bound session for %s: %s -> %s" name agent_name nickname;
                 (* Remember nickname so subsequent calls in this MCP session can use it. *)
                 record_mcp_session_agent nickname;
                 let (_ : Session.session) =
@@ -429,7 +431,7 @@ let execute_tool_eio
           then (
             (* #9770: surface guard fires as a fleet-wide metric so
        operators can see which (tool, agent) pairs repeatedly skip
-       masc_join without log-scraping. *)
+       session binding without log-scraping. *)
             Prometheus.inc_counter
               Prometheus.metric_tool_join_required_guard
               ~labels:
@@ -442,7 +444,7 @@ let execute_tool_eio
                     "MASC room not initialized.\n\n\
                      Fastest: masc_start(path=\"<project>\") — one-step init+join, then \
                      call %s.\n\
-                     Alternative: masc_init → masc_join → masc_status → %s\n\
+                     Alternative: masc_init → masc_start → masc_status → %s\n\
                      📚 See: @~/me/instructions/masc-workflow.md\n\
                      [DEBUG] agent_name=%s room_initialized=%b"
                     name
@@ -460,10 +462,9 @@ let execute_tool_eio
               ~agent_name
               (runtime_error_result
                  (Printf.sprintf
-                    "Join required before using %s.\n\n\
-                     Fastest: masc_start(path=\"<project>\") — one-step join with room \
-                     scope.\n\
-                     Alternative: masc_join → masc_status → %s\n\
+                    "Session binding required before using %s.\n\n\
+                     Fastest: masc_start(path=\"<project>\") — one-step session binding.\n\
+                     Alternative: masc_start → masc_status → %s\n\
                      📚 See: @~/me/instructions/masc-workflow.md\n\
                      [DEBUG] agent_name=%s is_joined=%b"
                     name

--- a/lib/mcp_server_eio_execute.mli
+++ b/lib/mcp_server_eio_execute.mli
@@ -27,7 +27,7 @@
     (audit wrappers, tool dispatchers, error formatters)
     that are local to its lexical scope. *)
 
-(** {1 Join state resolution} *)
+(** {1 Session binding state resolution} *)
 
 val resolve_join_state :
   room_initialized:bool ->

--- a/lib/mcp_server_eio_protocol.ml
+++ b/lib/mcp_server_eio_protocol.ml
@@ -126,8 +126,6 @@ let affected_resource_ids_for_tool = function
   | "masc_update_priority"
   | "masc_plan_set_task"
   | "masc_plan_clear_task" -> task_resource_ids
-  | "masc_join"
-  | "masc_leave"
   | "masc_heartbeat" -> agent_resource_ids
   | "masc_broadcast" | "masc_portal_open" | "masc_portal_send" | "masc_portal_close" ->
     message_resource_ids

--- a/lib/mcp_server_eio_tool_profile.ml
+++ b/lib/mcp_server_eio_tool_profile.ml
@@ -228,11 +228,8 @@ let label_words_from_identifier ident =
     Falls back to auto-generated Title Case when absent. *)
 let custom_tool_titles : (string * string) list = [
   (* Coord lifecycle *)
-  ("masc_join", "Join Project");
-  ("masc_leave", "Leave Project");
   ("masc_status", "Project Status");
   ("masc_reset", "Reset Project");
-  ("masc_who", "List Online Agents");
   ("masc_check", "Check Preconditions");
   (* Task management *)
   ("masc_tasks", "List Tasks");

--- a/lib/prometheus_builtin_metrics_part4.ml
+++ b/lib/prometheus_builtin_metrics_part4.ml
@@ -383,7 +383,7 @@ let register
     "Total Coord.join identity normalizations by Keeper_identity.normalize_all_names \
      (RFC P3-a). Labels: outcome (ok | empty_input | persona_not_found | \
      credential_missing | name_ambiguous | ephemeral_suffix_rejected). Non-ok outcomes \
-     reject masc_join at the fail-closed identity gate; pair with \
+     reject agent session binding at the fail-closed identity gate; pair with \
      masc_silent_auth_token_resolve_error_total for auth/name drift diagnosis."
     `Counter;
   add

--- a/lib/prometheus_metric_names.ml
+++ b/lib/prometheus_metric_names.ml
@@ -153,7 +153,7 @@ let metric_backend_mutex_held_sec = "masc_backend_mutex_held_sec"
 
 (* #9770: counter for the [join_required] guard firing in
    [Mcp_server_eio_execute].  Production observed agents calling
-   [masc_claim_next] (and similar) without [masc_join] first; the
+   [masc_claim_next] (and similar) before session binding; the
    guard returns a polite error message but no fleet-wide signal
    exists for "how often does this happen, and which agent / tool
    pair is most affected".  Labels:

--- a/lib/sdk_tool_contract.ml
+++ b/lib/sdk_tool_contract.ml
@@ -117,9 +117,6 @@ let core_remote_operation_names =
     (List.map (fun binding -> binding.canonical_operation) sdk_bindings
     @ [
         "masc_status";
-        "masc_join";
-        "masc_leave";
-        "masc_who";
         "masc_agents";
         "masc_agent_update";
         "masc_messages";

--- a/lib/sdk_tool_contract.mli
+++ b/lib/sdk_tool_contract.mli
@@ -50,7 +50,7 @@ val sdk_aliases_for_operation :
 val core_remote_operation_names : string list
 (** Deduplicated union of [canonical_operation] values from
     {!sdk_bindings} plus the hand-written core operation list
-    (masc_join / masc_operator_action / etc.). Used by the dashboard
+    (masc_operator_action / etc.). Used by the dashboard
     capability inventory and the discovery wiring. *)
 
 val sdk_tool_schemas : Masc_domain.tool_schema list

--- a/lib/server/server_mcp_streaming_tools.ml
+++ b/lib/server/server_mcp_streaming_tools.ml
@@ -26,7 +26,6 @@ let streaming_capable_tools =
        holds the public contract while non-listed tools default to chunked
        JSON under RFC-0100 PR-3. *)
     "masc_status"
-  ; "masc_join"
   ]
 
 let set =

--- a/lib/tool_access_role.ml
+++ b/lib/tool_access_role.ml
@@ -21,7 +21,7 @@ module Float = Stdlib.Float
     reads Tool_catalog-declared required_permission metadata.
 
     Each tool's required permission determines which role tier it belongs to:
-    - Worker tier: CanReadState, CanJoin, CanLeave, CanAddTask, CanClaimTask,
+    - Worker tier: CanReadState, CanAddTask, CanClaimTask,
                    CanCompleteTask, CanBroadcast,
                    CanOpenPortal, CanSendPortal
     - Admin tier:  CanInit, CanReset, CanAdmin
@@ -38,8 +38,7 @@ let all_surface_tools () =
 
 let required_role_of_permission = function
   | Masc_domain.CanInit | Masc_domain.CanReset | Masc_domain.CanAdmin -> Admin_role
-  | Masc_domain.CanReadState | Masc_domain.CanJoin | Masc_domain.CanLeave
-  | Masc_domain.CanAddTask
+  | Masc_domain.CanReadState | Masc_domain.CanAddTask
   | Masc_domain.CanClaimTask
   | Masc_domain.CanCompleteTask
   | Masc_domain.CanBroadcast

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -205,12 +205,6 @@ let claim_task_tool =
 let complete_task_tool =
   with_required_permission Masc_domain.CanCompleteTask actor_bound_masc_coordination_tool
 
-let join_tool =
-  with_required_permission Masc_domain.CanJoin actor_bound_masc_coordination_tool
-
-let leave_tool =
-  with_required_permission Masc_domain.CanLeave actor_bound_masc_coordination_tool
-
 let admin_tool =
   with_required_permission Masc_domain.CanAdmin destructive_tool
 
@@ -221,15 +215,12 @@ let reset_tool =
   with_required_permission Masc_domain.CanReset destructive_tool
 
 let static_requires_join_tool_names =
-  [ "masc_broadcast"; "masc_leave" ]
+  [ "masc_broadcast" ]
 
 let static_mcp_context_required_tool_names =
   [ "masc_start"
-  ; "masc_join"
-  ; "masc_leave"
   ; "masc_broadcast"
   ; "masc_messages"
-  ; "masc_who"
   ; "masc_approval_get"
   ; "masc_mcp_session"
   ]
@@ -261,7 +252,6 @@ let explicit_metadata : (string * metadata) list =
     ("masc_status", read_state_tool);
     ("masc_tasks", read_state_tool);
     ("masc_messages", read_state_tool);
-    ("masc_who", read_state_tool);
     ("masc_agents", read_state_tool);
     ("masc_agent_card", read_state_tool);
     ("masc_dashboard", read_state_tool);
@@ -275,8 +265,6 @@ let explicit_metadata : (string * metadata) list =
     ("masc_keeper_status", read_state_tool);
     ("masc_keeper_persona_audit", read_state_tool);
     ("masc_plan_get", read_state_tool);
-    ("masc_join", join_tool);
-    ("masc_leave", leave_tool);
     ("masc_claim_next", claim_task_tool);
     ("masc_transition", complete_task_tool);
     ("masc_plan_set_task", actor_broadcast_tool);

--- a/lib/tool_catalog_inference.ml
+++ b/lib/tool_catalog_inference.ml
@@ -137,7 +137,6 @@ let inferred_effect_domain_of_typed_tool_name = function
   | TN.Masc TM.Tool_stats
   | TN.Masc TM.Web_fetch
   | TN.Masc TM.Web_search
-  | TN.Masc TM.Who
   | TN.Masc TM.Board_sub_board_get
   | TN.Masc TM.Board_sub_board_list
   | TN.Masc TM.Approval_pending
@@ -165,8 +164,6 @@ let inferred_effect_domain_of_typed_tool_name = function
   | TN.Masc TM.Goal_upsert
   | TN.Masc TM.Goal_verify
   | TN.Masc TM.Heartbeat
-  | TN.Masc TM.Join
-  | TN.Masc TM.Leave
   | TN.Masc TM.Note_add
   | TN.Masc TM.Operator_confirm
   | TN.Masc TM.Pause
@@ -307,8 +304,6 @@ let tool_group_of_typed_tool_name = function
       | TM.Goal_upsert
       | TM.Goal_verify
       | TM.Heartbeat
-      | TM.Join
-      | TM.Leave
       | TM.Mcp_session
       | TM.Messages
       | TM.Note_add
@@ -333,8 +328,7 @@ let tool_group_of_typed_tool_name = function
       | TM.Transition
       | TM.Update_priority
       | TM.Web_fetch
-      | TM.Web_search
-      | TM.Who ) ->
+      | TM.Web_search ) ->
       Some Masc_core
 
 let tool_group name =

--- a/lib/tool_catalog_surfaces/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces/tool_catalog_surfaces.ml
@@ -133,13 +133,10 @@ type surface =
 let public_mcp_surface_tools =
   [ (* Coord lifecycle *)
     "masc_start"
-  ; "masc_join"
-  ; "masc_leave"
   ; "masc_status"
   ; (* Messaging *)
     "masc_broadcast"
   ; "masc_messages"
-  ; "masc_who"
   ; (* Task coordination *)
     "masc_add_task"
   ; "masc_batch_add_tasks"
@@ -214,9 +211,6 @@ let spawned_agent_surface_tools =
   ; "masc_transition"
   ; "masc_task_history"
   ; "masc_broadcast"
-  ; "masc_join"
-  ; "masc_leave"
-  ; "masc_who"
   ; "masc_agent_update"
   ; "masc_add_task"
   ; "masc_heartbeat"
@@ -393,9 +387,6 @@ let coordination_role_tools : string list =
   ; "masc_tasks"
   ; "masc_add_task"
   ; "masc_broadcast"
-  ; "masc_join"
-  ; "masc_leave"
-  ; "masc_who"
   ; "masc_heartbeat"
   ; "masc_messages"
   ; "masc_board_list"

--- a/lib/tool_coord.ml
+++ b/lib/tool_coord.ml
@@ -482,7 +482,7 @@ let status_summary_string (ctx : context) =
     let items = [] in
     let items =
       if not joined
-      then items @ [ "You are not joined in the project namespace. Call masc_join." ]
+      then items @ [ "You are not joined in the project namespace. Call masc_start." ]
       else items
     in
     let items =

--- a/lib/tool_dispatch.ml
+++ b/lib/tool_dispatch.ml
@@ -274,12 +274,10 @@ let static_tag_of_tool_name (tool : Tool_name.t) : module_tag option =
     | Approval_get
     | Approval_pending
     | Broadcast
-    | Join
-    | Leave
     | Mcp_session
     | Messages
     | Start
-    | Who -> Some Mod_inline
+    -> Some Mod_inline
     | Check
     | Goal_list
     | Goal_transition

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -19,8 +19,8 @@ module Float = Stdlib.Float
 (** Tool_inline_dispatch — thin dispatch router for inline tool handlers.
 
     Delegates to sub-modules:
-    - Tool_inline_dispatch_coord: masc_start, masc_join, masc_leave
-    - Tool_inline_dispatch_comm: masc_broadcast, masc_messages, masc_who
+    - Tool_inline_dispatch_coord: masc_start
+    - Tool_inline_dispatch_comm: masc_broadcast, masc_messages
     - Tool_inline_dispatch_extra: remaining tools (board, etc.)
 
     Keeps inline: mcp_session, approval, spawn, discover_tools.
@@ -187,18 +187,12 @@ let dispatch (ctx : context) ~(name : string) : Tool_result.result option =
   (* ── Coord lifecycle (delegated) ─────────────────────────────── *)
   | "masc_start" ->
       Tool_inline_dispatch_coord.handle_start ~tool_name:name ~start_time:start ctx
-  | "masc_join" ->
-      Tool_inline_dispatch_coord.handle_join ~tool_name:name ~start_time:start ctx
-  | "masc_leave" ->
-      Tool_inline_dispatch_coord.handle_leave ~tool_name:name ~start_time:start ctx
 
   (* ── Communication (delegated) ──────────────────────────────── *)
   | "masc_broadcast" ->
       Tool_inline_dispatch_comm.handle_broadcast ~tool_name:name ~start_time:start ctx
   | "masc_messages" ->
       Tool_inline_dispatch_comm.handle_messages ~tool_name:name ~start_time:start ctx
-  | "masc_who" ->
-      Tool_inline_dispatch_comm.handle_who ~tool_name:name ~start_time:start ctx
 
   (* ── Approval queue (#5907) ─────────────────────────────────── *)
   | "masc_approval_pending" ->
@@ -344,13 +338,11 @@ let dispatch (ctx : context) ~(name : string) : Tool_result.result option =
      (lib/tool_shard.ml:348). Audit row was a false positive. *)
 
 let inline_register_targets =
-  [ "masc_join"; "masc_leave"; "masc_broadcast"; "masc_messages"
+  [ "masc_broadcast"; "masc_messages"
   ; "masc_approval_get"; "masc_approval_pending" ]
 
 let inline_tool_required_permission name : Masc_domain.permission option =
   match name with
-  | "masc_join" -> Some Masc_domain.CanJoin
-  | "masc_leave" -> Some Masc_domain.CanLeave
   | "masc_broadcast" -> Some Masc_domain.CanBroadcast
   | "masc_messages" -> Some Masc_domain.CanReadState
   | "masc_approval_get" -> Some Masc_domain.CanAdmin
@@ -360,12 +352,12 @@ let inline_tool_required_permission name : Masc_domain.permission option =
 let inline_tool_read_only =
   [ "masc_messages"; "masc_approval_get"; "masc_approval_pending" ]
 
-let inline_tool_requires_join = [ "masc_leave"; "masc_broadcast" ]
+let inline_tool_requires_join = [ "masc_broadcast" ]
 
-let inline_tool_requires_actor_binding = [ "masc_join"; "masc_leave" ]
+let inline_tool_requires_actor_binding = []
 
 let inline_tool_mcp_context_required =
-  [ "masc_join"; "masc_leave"; "masc_broadcast"; "masc_messages"; "masc_approval_get" ]
+  [ "masc_broadcast"; "masc_messages"; "masc_approval_get" ]
 
 let inline_tool_effect_domain name : Tool_catalog.effect_domain =
   if List.mem name inline_tool_read_only then Tool_catalog.Read_only

--- a/lib/tool_inline_dispatch_comm.ml
+++ b/lib/tool_inline_dispatch_comm.ml
@@ -17,7 +17,7 @@ module Float = Stdlib.Float
 
 (** Tool_inline_dispatch_comm — communication tool handlers.
 
-    Handles: masc_broadcast, masc_messages, masc_who.
+    Handles: masc_broadcast, masc_messages.
 
     Extracted from tool_inline_dispatch.ml to reduce file size. *)
 
@@ -111,8 +111,3 @@ let handle_messages ~tool_name ~start_time (ctx : context) : tool_result option 
   let since_seq = arg_get_int ctx "since_seq" 0 in
   let limit = arg_get_int ctx "limit" 10 in
   Some (Tool_result.ok ~tool_name ~start_time (Coord.get_messages config ~since_seq ~limit))
-
-(** masc_who — list agents currently in the room *)
-let handle_who ~tool_name ~start_time (ctx : context) : tool_result option =
-  let registry = ctx.registry in
-  Some (Tool_result.ok ~tool_name ~start_time (Session.status_string registry))

--- a/lib/tool_inline_dispatch_comm.mli
+++ b/lib/tool_inline_dispatch_comm.mli
@@ -1,6 +1,6 @@
 (** Tool_inline_dispatch_comm — communication tool handlers.
 
-    Handles: masc_broadcast, masc_messages, masc_who.
+    Handles: masc_broadcast, masc_messages.
 
     RFC-0062 Phase 4c-2: handlers now accept [~tool_name ~start_time]
     and return structured [Tool_result.result] instead of [(bool * string)].
@@ -13,4 +13,3 @@ type context = Tool_inline_dispatch_types.context
 
 val handle_broadcast : tool_name:string -> start_time:float -> context -> Tool_result.result option
 val handle_messages : tool_name:string -> start_time:float -> context -> Tool_result.result option
-val handle_who : tool_name:string -> start_time:float -> context -> Tool_result.result option

--- a/lib/tool_inline_dispatch_coord.ml
+++ b/lib/tool_inline_dispatch_coord.ml
@@ -15,9 +15,9 @@ module Char = Stdlib.Char
 module Int = Stdlib.Int
 module Float = Stdlib.Float
 
-(** Tool_inline_dispatch_coord — room lifecycle tool handlers.
+(** Tool_inline_dispatch_coord — project startup tool handler.
 
-    Handles: masc_start, masc_join, masc_leave.
+    Handles: masc_start.
 
     Extracted from tool_inline_dispatch.ml to reduce file size. *)
 
@@ -126,7 +126,7 @@ let handle_start ~tool_name ~start_time (ctx : context) : Tool_result.result opt
       (* join exception caught from [Coord.join] — internal failure. *)
       Some
         (inline_err_runtime ~tool_name ~start_time
-           (Printf.sprintf "masc_start failed at join: %s\nHint: try masc_join separately." e))
+           (Printf.sprintf "masc_start failed while binding agent session: %s" e))
     | Ok () ->
       (* Step 3: add_task + claim + plan_set_task (if task_title provided) *)
       if String.equal task_title "" then
@@ -182,148 +182,3 @@ let handle_start ~tool_name ~start_time (ctx : context) : Tool_result.result opt
                       agent_name task_id))
         end
       end
-
-(** masc_join — join the active MASC project *)
-let handle_join ~tool_name ~start_time (ctx : context) : Tool_result.result option =
-  let config = ctx.config in
-  let agent_name = ctx.agent_name in
-  let registry = ctx.registry in
-  let state = ctx.state in
-  let mcp_session_id = ctx.mcp_session_id in
-  let sid = Option.value ~default:"-" mcp_session_id in
-  let caps = arg_get_string_list ctx "capabilities" in
-  let proceed_with_join resolved_name =
-    let result =
-      Coord.join config ~agent_name:resolved_name ~capabilities:caps ()
-    in
-    (* GC: reap zombie agents on join. Best-effort.
-       Typed outcome mirrors sibling [Orchestrator] zombie consumer
-       (PR #15510): each Coord.cleanup_zombie_result constructor and
-       exception class is mapped to a distinct severity, so a future
-       variant addition fails compile rather than slipping through a
-       silent catch-all.  [Eio.Cancel.Cancelled] re-raised unchanged. *)
-    let module Join_gc_outcome = struct
-      type t =
-        | Reaped of { count : int; names : string list }
-        | No_op
-        | Misconfigured
-        | Failed of { benign : bool; reason : string }
-    end in
-    let join_gc_outcome : Join_gc_outcome.t =
-      try
-        match Coord.cleanup_zombies config with
-        | Coord.Cleaned { count = 0; _ } -> Join_gc_outcome.No_op
-        | Coord.Cleaned { count; names; _ } ->
-            Join_gc_outcome.Reaped { count; names }
-        | Coord.No_zombies -> Join_gc_outcome.No_op
-        | Coord.No_agents_dir -> Join_gc_outcome.Misconfigured
-      with
-      | Eio.Cancel.Cancelled _ as e -> raise e
-      | exn ->
-          Join_gc_outcome.Failed
-            { benign = Coord_resilience.ZeroZombie.is_benign_error exn
-            ; reason = Stdlib.Printexc.to_string exn
-            }
-    in
-    (match join_gc_outcome with
-     | Join_gc_outcome.Reaped { count; names } ->
-         Log.Gc.info "[sid=%s] join GC reaped %d zombie(s): %s"
-           sid count (String.concat ", " names)
-     | Join_gc_outcome.No_op -> ()
-     | Join_gc_outcome.Misconfigured ->
-         Log.Gc.warn "[sid=%s] join GC: agents dir missing (misconfig)" sid
-     | Join_gc_outcome.Failed { benign = true; reason } ->
-         Log.Gc.debug "[sid=%s] join GC benign failure: %s" sid reason
-     | Join_gc_outcome.Failed { benign = false; reason } ->
-         Log.Gc.error "[sid=%s] join GC failed: %s" sid reason);
-    (* Extract nickname from join result (format: "  Nickname: xxx\n...") *)
-    let nickname =
-      try
-        let prefix = "  Nickname: " in
-        let start_idx =
-          let idx = ref 0 in
-          while !idx < String.length result - String.length prefix &&
-                not (String.equal (Stdlib.String.sub result !idx (String.length prefix)) prefix) do
-            Stdlib.incr idx
-          done;
-          !idx + String.length prefix
-        in
-        let end_idx = match String.index_from_opt result start_idx '\n' with
-          | Some idx -> idx
-          | None -> String.length result
-        in
-        String.sub result start_idx (end_idx - start_idx)
-      with Invalid_argument _ -> agent_name
-    in
-    let _ = Session.register registry ~agent_name:nickname in
-    ctx.record_mcp_session_agent nickname;
-    Log.Misc.debug
-      "[sid=%s] masc_join: recorded nickname=%s for MCP session (original=%s)"
-      sid nickname agent_name;
-    let institution_welcome = match state.Mcp_server.fs with
-      | Some fs ->
-          (try Institution_eio.load_and_format_for_welcome ~fs config
-           with
-           | Eio.Io _ | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> ""
-           | Eio.Cancel.Cancelled _ as exn -> raise exn
-           | exn ->
-               Log.Institution.warn "[sid=%s] Unexpected institution error: %s" sid (Stdlib.Printexc.to_string exn); "")
-      | None -> ""
-    in
-    let final_result = if String.equal institution_welcome "" then result
-      else result ^ institution_welcome in
-    let join_event = `Assoc [
-      ("type", `String "masc/agent_joined");
-      ("agent_name", `String nickname);
-      ("timestamp", `Float (Time_compat.now ()));
-    ] in
-    let _pushed = Session.push_notification_to_active_agents registry ~event:join_event in
-    Mcp_server.sse_broadcast state join_event;
-    Some (inline_ok ~tool_name ~start_time final_result)
-  in
-  (* RFC P3-a — fail-closed identity gate. The identity backend validates
-     the agent identity against persona + credential filesystem checks.
-     When validation fails, the join is rejected rather than silently
-     accepted. Previously, normalize errors were logged and the join
-     proceeded with the original agent_name (fail-open), causing persona
-     drift and downstream credential resolution failures. *)
-  match
-    Coord_identity_backend.validate_join_identity
-      ~agent_name
-      ~base_path:config.base_path
-  with
-  | Ok keeper_name ->
-      Prometheus.inc_counter Prometheus.metric_coord_join_normalize_outcome
-        ~labels:[ ("outcome", "ok") ] ();
-      proceed_with_join keeper_name
-  | Error err ->
-      Prometheus.inc_counter Prometheus.metric_coord_join_normalize_outcome
-        ~labels:[ ("outcome", err.Coord_identity_backend.outcome) ] ();
-      Log.Misc.warn
-        "[sid=%s] [fail-closed:coord_join_normalize] agent=%s outcome=%s \
-         detail=%s - join rejected"
-        sid agent_name err.Coord_identity_backend.outcome err.detail;
-      (* Caller-provided identity / persona / credential files invalid. *)
-      Some
-        (inline_err_workflow ~tool_name ~start_time
-           (Printf.sprintf
-              "masc_join rejected: identity validation failed for '%s' — %s. \
-               Ensure the persona and credential files exist for this agent."
-              agent_name err.detail))
-
-(** masc_leave — leave a MASC room *)
-let handle_leave ~tool_name ~start_time (ctx : context) : Tool_result.result option =
-  let config = ctx.config in
-  let agent_name = ctx.agent_name in
-  let registry = ctx.registry in
-  let state = ctx.state in
-  let leave_event = `Assoc [
-    ("type", `String "masc/agent_left");
-    ("agent_name", `String agent_name);
-    ("timestamp", `Float (Time_compat.now ()));
-  ] in
-  let _pushed = Session.push_notification_to_active_agents registry ~event:leave_event in
-  Mcp_server.sse_broadcast state leave_event;
-  let result = Coord.leave config ~agent_name in
-  Session.unregister registry ~agent_name;
-  Some (inline_ok ~tool_name ~start_time result)

--- a/lib/tool_inline_dispatch_coord.mli
+++ b/lib/tool_inline_dispatch_coord.mli
@@ -1,12 +1,9 @@
-(** Tool_inline_dispatch_coord — room lifecycle tool handlers.
+(** Tool_inline_dispatch_coord — project startup tool handler.
 
-    Three [masc_*] handlers covering the agent room lifecycle:
-    {!handle_start} (project root + join + optional task),
-    {!handle_join} (idempotent re-join), {!handle_leave}
-    (graceful exit).
+    Handles project root setup and optional task bootstrapping.
 
     Extracted from {!Tool_inline_dispatch} to keep the dispatch
-    table file under the lint cap.  All three return
+    table file under the lint cap.  The handler returns
     [Tool_result.result option] — [Some] when the tool name matches,
     [None] when the dispatcher should fall through to a default handler.
 
@@ -39,9 +36,8 @@ val handle_start :
     1. **Set project root**: validates the directory exists,
        initialises {!Coord} when not already initialised, and
        atomically swaps [state.room_config].
-    2. **Join**: idempotent — re-join is a no-op when already
-       in the room.  Failure surfaces with hint
-       [["Hint: try masc_join separately."]].
+    2. **Bind agent session**: idempotent when already bound.
+       Failure surfaces as a startup error.
     3. **Optional task creation**: when [task_title] non-empty,
        runs [Coord_task.add_task] + extracts the task id from
        the [["Added task-NNN: title"]] response prefix.
@@ -55,24 +51,8 @@ val handle_start :
     - Step 1 failure:
       ["masc_start failed while setting project scope: <e>"]
     - Step 2 failure:
-      ["masc_start failed at join: <e>\nHint: try masc_join separately."]
+      ["masc_start failed while binding agent session: <e>"]
 
     Operator runbooks grep on these prefixes; pinning at the
     contract seam so a future "let's rephrase the errors" PR
     must touch this. *)
-
-val handle_join :
-  tool_name:string -> start_time:float ->
-  Tool_inline_dispatch_types.context ->
-  Tool_result.result option
-(** [handle_join ~tool_name ~start_time ctx] handles [masc_join] —
-    register the agent in the project namespace.  Idempotent:
-    re-joining is a no-op success.  Reads [path] / [room] /
-    [agent] / [capabilities] (string list) from [ctx.arguments]. *)
-
-val handle_leave :
-  tool_name:string -> start_time:float ->
-  Tool_inline_dispatch_types.context ->
-  Tool_result.result option
-(** [handle_leave ~tool_name ~start_time ctx] handles [masc_leave] —
-    graceful agent exit. *)

--- a/lib/tool_name.ml
+++ b/lib/tool_name.ml
@@ -246,8 +246,6 @@ module Masc = struct
     | Goal_upsert
     | Goal_verify
     | Heartbeat
-    | Join
-    | Leave
     | Messages
     | Note_add
     | Operator_action
@@ -272,7 +270,6 @@ module Masc = struct
     | Update_priority
     | Web_fetch
     | Web_search
-    | Who
     | Approval_pending
     | Approval_get
     | Config
@@ -324,8 +321,6 @@ module Masc = struct
     | Goal_upsert -> "masc_goal_upsert"
     | Goal_verify -> "masc_goal_verify"
     | Heartbeat -> "masc_heartbeat"
-    | Join -> "masc_join"
-    | Leave -> "masc_leave"
     | Messages -> "masc_messages"
     | Note_add -> "masc_note_add"
     | Operator_action -> "masc_operator_action"
@@ -350,7 +345,6 @@ module Masc = struct
     | Update_priority -> "masc_update_priority"
     | Web_fetch -> "masc_web_fetch"
     | Web_search -> "masc_web_search"
-    | Who -> "masc_who"
     | Approval_pending -> "masc_approval_pending"
     | Approval_get -> "masc_approval_get"
     | Config -> "masc_config"
@@ -403,8 +397,6 @@ module Masc = struct
     | "masc_goal_upsert" -> Some Goal_upsert
     | "masc_goal_verify" -> Some Goal_verify
     | "masc_heartbeat" -> Some Heartbeat
-    | "masc_join" -> Some Join
-    | "masc_leave" -> Some Leave
     | "masc_messages" -> Some Messages
     | "masc_note_add" -> Some Note_add
     | "masc_operator_action" -> Some Operator_action
@@ -429,7 +421,6 @@ module Masc = struct
     | "masc_update_priority" -> Some Update_priority
     | "masc_web_fetch" -> Some Web_fetch
     | "masc_web_search" -> Some Web_search
-    | "masc_who" -> Some Who
     | "masc_approval_pending" -> Some Approval_pending
     | "masc_approval_get" -> Some Approval_get
     | "masc_config" -> Some Config

--- a/lib/tool_name.mli
+++ b/lib/tool_name.mli
@@ -101,8 +101,6 @@ module Masc : sig
     | Goal_upsert
     | Goal_verify
     | Heartbeat
-    | Join
-    | Leave
     | Messages
     | Note_add
     | Operator_action
@@ -127,7 +125,6 @@ module Masc : sig
     | Update_priority
     | Web_fetch
     | Web_search
-    | Who
     | Approval_pending
     | Approval_get
     | Config

--- a/lib/tool_prefilter.ml
+++ b/lib/tool_prefilter.ml
@@ -48,7 +48,6 @@ let synonyms : (string * string list) list =
       ; "take task"
       ] )
   ; "masc_add_task", [ "create task"; "new task"; "make task"; "register task" ]
-  ; "masc_leave", [ "disconnect"; "go offline"; "exit room"; "sign off"; "leave room" ]
   ; "masc_messages", [ "chat"; "conversation"; "history"; "log"; "what was said" ]
   ; "masc_agents", [ "who is working"; "team members"; "workers"; "collaborators" ]
   ; "masc_status", [ "how are things"; "state"; "health"; "situation" ]

--- a/lib/tool_resource_axis.ml
+++ b/lib/tool_resource_axis.ml
@@ -198,8 +198,6 @@ let classify_masc_tool (tool : Tool_name.Masc.t) =
   | Goal_upsert
   | Goal_verify
   | Heartbeat
-  | Join
-  | Leave
   | Note_add
   | Plan_clear_task
   | Plan_init
@@ -251,8 +249,7 @@ let classify_masc_tool (tool : Tool_name.Masc.t) =
   | Tool_admin_snapshot
   | Tool_help
   | Tool_list
-  | Tool_stats
-  | Who -> Ungated
+  | Tool_stats -> Ungated
 ;;
 
 let classify_masc_keeper_tool (tool : Tool_name.Masc_keeper.t) =

--- a/lib/tool_schemas/tool_schemas_coord_core.ml
+++ b/lib/tool_schemas/tool_schemas_coord_core.ml
@@ -22,7 +22,7 @@ let schemas : tool_schema list = [
     name = "masc_status";
     description = "Get current project status: active agents, task queue, recent broadcasts, and cluster info. \
 Use when you need a snapshot of who is online and what tasks are available. \
-Call after masc_join to orient yourself. Pair with masc_tasks for detailed backlog.";
+Call after masc_start to orient yourself. Pair with masc_tasks for detailed backlog.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);

--- a/lib/tool_schemas/tool_schemas_inline.ml
+++ b/lib/tool_schemas/tool_schemas_inline.ml
@@ -5,15 +5,12 @@
    messages/who) moved to Tool_descriptors_gen. They flow through
    Tool_schemas_misc.schemas, but downstream consumers still identify
    inline-dispatched tools by membership in this list — so we re-include
-   them here by filtering Tool_schemas_misc.schemas to the six inline_coord
+   them here by filtering Tool_schemas_misc.schemas to the inline_coord
    names. *)
 let inline_coord_codegen_names =
   [ "masc_start"
-  ; "masc_join"
-  ; "masc_leave"
   ; "masc_broadcast"
   ; "masc_messages"
-  ; "masc_who"
   ]
 
 let inline_coord_from_codegen =

--- a/lib/transport.ml
+++ b/lib/transport.ml
@@ -195,7 +195,6 @@ module Rest = struct
     | "masc_operator_confirm" -> Some Bearer_required
     | "masc_status"
     | "masc_tasks"
-    | "masc_who"
     | "masc_messages"
     | "masc_operator_snapshot"
     | "masc_operator_digest"
@@ -219,7 +218,6 @@ module Rest = struct
     [
       ("masc_status", [ (GET, "/api/v1/status") ]);
       ("masc_tasks", [ (GET, "/api/v1/tasks") ]);
-      ("masc_who", [ (GET, "/api/v1/agents") ]);
       ("masc_messages", [ (GET, "/api/v1/messages") ]);
       ("masc_operator_snapshot", [ (GET, "/api/v1/operator") ]);
       ("masc_operator_digest", [ (GET, "/api/v1/operator/digest") ]);

--- a/lib/types/masc_error.ml
+++ b/lib/types/masc_error.ml
@@ -119,7 +119,7 @@ module Agent_error = struct
   let to_string = function
     | NotFound name -> Printf.sprintf "[AgentError] Agent not found: %s" name
     | NotJoined name ->
-        Printf.sprintf "[AgentError] Agent not joined: %s. Use masc_join first." name
+        Printf.sprintf "[AgentError] Agent not joined: %s. Use masc_start first." name
     | AlreadyJoined name -> Printf.sprintf "[AgentError] Agent already joined: %s" name
     | InvalidName reason -> Printf.sprintf "[AgentError] Invalid agent name: %s" reason
 end

--- a/lib/types/types_auth.ml
+++ b/lib/types/types_auth.ml
@@ -137,8 +137,6 @@ let auth_config_of_yojson json =
 type permission =
   | CanInit
   | CanReset
-  | CanJoin
-  | CanLeave
   | CanReadState
   | CanAddTask
   | CanClaimTask
@@ -160,8 +158,6 @@ type permission =
 let permission_to_string = function
   | CanInit -> "CanInit"
   | CanReset -> "CanReset"
-  | CanJoin -> "CanJoin"
-  | CanLeave -> "CanLeave"
   | CanReadState -> "CanReadState"
   | CanAddTask -> "CanAddTask"
   | CanClaimTask -> "CanClaimTask"
@@ -175,7 +171,7 @@ let permission_to_string = function
 (** Get permissions for a role *)
 let permissions_for_role = function
   | Worker -> [
-      CanReadState; CanJoin; CanLeave;
+      CanReadState;
       CanAddTask; CanClaimTask; CanCompleteTask;
       CanBroadcast;
       CanOpenPortal; CanSendPortal;
@@ -183,7 +179,7 @@ let permissions_for_role = function
     ]
   | Admin -> [
       CanInit; CanReset;
-      CanReadState; CanJoin; CanLeave;
+      CanReadState;
       CanAddTask; CanClaimTask; CanCompleteTask;
       CanBroadcast;
       CanOpenPortal; CanSendPortal;
@@ -205,8 +201,7 @@ let has_permission role permission =
   match role, permission with
   | Admin, _ -> true
   | Worker, (CanInit | CanReset | CanAdmin) -> false
-  | Worker, ( CanJoin | CanLeave | CanReadState | CanAddTask
-            | CanClaimTask | CanCompleteTask | CanBroadcast
+  | Worker, ( CanReadState | CanAddTask | CanClaimTask | CanCompleteTask | CanBroadcast
             | CanOpenPortal | CanSendPortal | CanVote ) -> true
 
 (* ============================================ *)

--- a/lib/types/types_auth.mli
+++ b/lib/types/types_auth.mli
@@ -116,8 +116,6 @@ val auth_config_of_yojson : Yojson.Safe.t -> (auth_config, string) result
 type permission =
   | CanInit
   | CanReset
-  | CanJoin
-  | CanLeave
   | CanReadState
   | CanAddTask
   | CanClaimTask

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -2,7 +2,7 @@
 
     Converts MASC worker metadata into OAS Agent configuration, using the
     OAS Builder pattern for agent construction. Wraps Agent.run with MASC
-    worker lifecycle hooks (heartbeat, join/leave, board posting).
+    worker lifecycle hooks (heartbeat, board posting).
 
     Key mappings:
     - worker_container_meta fields -> OAS agent_config + Builder options
@@ -554,17 +554,7 @@ let rec run_worker_via_oas
       ()
   in
   let* () = Worker_container.save_worker_meta ~base_path ~worker_name meta in
-  Eio_guard.protect
-    ~finally:(fun () ->
-      ignore
-        (Worker_container_types.leave_worker ~sw ~auth_token ~session_id ~worker_name))
-    (fun () ->
-       match
-         Worker_container_types.join_worker ~sw ~auth_token ~session_id ~worker_name
-       with
-       | Error e -> Error ("worker join failed: " ^ e)
-       | Ok _ ->
-         let workspace_path =
+  let workspace_path =
            if String.trim meta.workspace_path <> ""
            then meta.workspace_path
            else base_path
@@ -649,17 +639,7 @@ and resume_worker_via_oas
       approval = Some approval
     }
   in
-  Eio_guard.protect
-    ~finally:(fun () ->
-      ignore
-        (Worker_container_types.leave_worker ~sw ~auth_token ~session_id ~worker_name))
-    (fun () ->
-       match
-         Worker_container_types.join_worker ~sw ~auth_token ~session_id ~worker_name
-       with
-       | Error e -> Error ("worker join failed: " ^ e)
-       | Ok _ ->
-         let agent =
+  let agent =
            Agent_sdk.Agent.resume
              ~net
              ~checkpoint


### PR DESCRIPTION
## Summary
- remove masc_join/masc_leave/masc_who from public/catalog/inline dispatch surfaces
- remove room lifecycle descriptors, transport mappings, streaming/gRPC wrappers, SDK contract entries, and auth permissions
- stop auto-responder/local-worker paths from calling join/leave tool wrappers

## Validation
- not run (user requested deletion-first; build may break)