### PR TITLE
fix(test): remove dangling room_id from Agent_stress event literal (#19644 follow-up)

### DIFF
--- a/test/test_dashboard_o5_feeds.ml
+++ b/test/test_dashboard_o5_feeds.ml
@@ -76,7 +76,6 @@ let test_agent_stress_feed_exposes_board_rows () =
   let event =
     Agent_stress.event_to_json
       { agent_name = "sangsu"
-      ; room_id = "default"
       ; kind =
           Agent_stress.Turn_failure
             { consecutive = 2


### PR DESCRIPTION
Follow-up to #19644 which removed `room_id` from `Agent_stress.event` but missed this test record literal.

- `dune build --root .` EXIT=0

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
