### PR TITLE
[codex] Fix dashboard Agent_stress fixture after room id purge

### DIFF
--- a/test/test_dashboard_o5_feeds.ml
+++ b/test/test_dashboard_o5_feeds.ml
@@ -76,7 +76,6 @@ let test_agent_stress_feed_exposes_board_rows () =
   let event =
     Agent_stress.event_to_json
       { agent_name = "sangsu"
-      ; room_id = "default"
       ; kind =
           Agent_stress.Turn_failure
             { consecutive = 2


### PR DESCRIPTION
## Summary
- Remove the stale `room_id` field from the dashboard O5 Agent_stress fixture.

## Root Cause
PR #19644 removed `room_id` from `Agent_stress.event`, but `test/test_dashboard_o5_feeds.ml` still constructed the old record shape. That is the next compile failure after the keeper runtime build fix in #19648.

## Validation
- `ocamlformat --check test/test_dashboard_o5_feeds.ml`
- `git diff --check origin/main..HEAD`
- `env DUNE_BUILD_DIR=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-main-keeper-runtime-build-20260601/_build-direct dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-main-keeper-runtime-build-20260601 test/test_dashboard_o5_feeds.exe`