### PR TITLE
Fix agent stress dashboard test fixture

### DIFF
--- a/test/test_dashboard_o5_feeds.ml
+++ b/test/test_dashboard_o5_feeds.ml
@@ -76,7 +76,6 @@ let test_agent_stress_feed_exposes_board_rows () =
   let event =
     Agent_stress.event_to_json
       { agent_name = "sangsu"
-      ; room_id = "default"
       ; kind =
           Agent_stress.Turn_failure
             { consecutive = 2


### PR DESCRIPTION
## Summary
- Remove stale room_id field from the Agent_stress.event fixture in dashboard O5 feed test

## Verification
- scripts/dune-local.sh build test/test_dashboard_o5_feeds.exe
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_dashboard_o5_feeds.exe