### PR TITLE
Rename agent session binding internals

### DIFF
--- a/lib/audit_log.ml
+++ b/lib/audit_log.ml
@@ -30,8 +30,6 @@ type governance_audit_decision =
 [@@deriving tla]
 
 type action =
-  | Join [@tla.symbol "join"]
-  | Leave [@tla.symbol "leave"]
   | ClaimTask [@tla.symbol "claim_task"]
   | StartTask [@tla.symbol "start_task"]
   | DoneTask [@tla.symbol "done_task"]
@@ -89,8 +87,6 @@ let governance_audit_decision_of_string = function
   | value -> Governance_other value
 
 let action_to_string = function
-  | Join -> "join"
-  | Leave -> "leave"
   | ClaimTask -> "claim_task"
   | StartTask -> "start_task"
   | DoneTask -> "done_task"
@@ -109,8 +105,6 @@ let action_to_string = function
   | Custom name -> "custom:" ^ name
 
 let string_to_action = function
-  | "join" -> Join
-  | "leave" -> Leave
   | "claim_task" -> ClaimTask
   | "start_task" -> StartTask
   | "done_task" -> DoneTask
@@ -469,14 +463,6 @@ let log_action
     ~summary ~severity ?payload:payload_opt ()
 
 (** Convenience functions for common events *)
-
-let log_join config ~agent_id ?cost_estimate ?token_count () =
-  log_action config ~agent_id ~action:Join
-    ?cost_estimate ?token_count ~outcome:Success ()
-
-let log_leave config ~agent_id ?cost_estimate ?token_count () =
-  log_action config ~agent_id ~action:Leave
-    ?cost_estimate ?token_count ~outcome:Success ()
 
 let log_claim_task config ~agent_id ~task_id ?cost_estimate ?token_count () =
   log_action config ~agent_id ~action:ClaimTask

--- a/lib/audit_log.mli
+++ b/lib/audit_log.mli
@@ -42,8 +42,6 @@ type governance_audit_decision =
 [@@deriving tla]
 
 type action =
-  | Join
-  | Leave
   | ClaimTask
   | StartTask
   | DoneTask
@@ -144,20 +142,6 @@ val log_action :
     delegate to this. *)
 
 (** {1 Logging — per-action helpers} *)
-
-val log_join :
-  config ->
-  agent_id:string ->
-  ?cost_estimate:float ->
-  ?token_count:int ->
-  unit -> unit
-
-val log_leave :
-  config ->
-  agent_id:string ->
-  ?cost_estimate:float ->
-  ?token_count:int ->
-  unit -> unit
 
 val log_claim_task :
   config ->

--- a/lib/auth_credential_base.ml
+++ b/lib/auth_credential_base.ml
@@ -258,7 +258,7 @@ let load_credential_from_path config agent_name path : agent_credential option =
     cover every dynamically generated nickname in that family
     (e.g. [adversary-fair-tapir]).
 
-    Without this fallback, Coord.join's nickname output caused a
+    Without this fallback, Coord.bind_session's nickname output caused a
     chronic "No credential found for <type>-<adj>-<animal>" noise band
     at ~0.3/min on the live fleet (2026-04-20). *)
 let load_credential_from_path_raw config agent_name path : agent_credential option =

--- a/lib/coord.ml
+++ b/lib/coord.ml
@@ -16,21 +16,21 @@ include Coord_task_id
 include Coord_backlog
 include Coord_broadcast
 
-(* Agent join/leave lifecycle *)
+(* Agent session binding lifecycle *)
 include Coord_lifecycle
 
-(* Coord initialization, reset, pause, resume (without auto-join) *)
+(* Coord initialization, reset, pause, resume *)
 include Coord_init
 
-(** Initialize MASC room with optional auto-join.
-    Wraps [Coord_init.init] and calls [join] when [agent_name] is provided. *)
+(** Initialize MASC room with optional session binding.
+    Wraps [Coord_init.init] and calls [bind_session] when [agent_name] is provided. *)
 let init config ~agent_name =
   let result = Coord_init.init config ~agent_name in
   if result = "MASC already initialized."
   then result
   else (
     match agent_name with
-    | Some name -> result ^ "\n" ^ join config ~agent_name:name ~capabilities:[] ()
+    | Some name -> result ^ "\n" ^ bind_session config ~agent_name:name ~capabilities:[] ()
     | None -> result)
 ;;
 
@@ -145,10 +145,10 @@ let task_action_of_transition : Masc_domain.task_action -> Audit_log.action = fu
 
 (* #8605 family: replaced four parallel string switches on [event_kind]
    with a single [agent_lifecycle_event] variant. The compiler now
-   forces every dispatch to cover Lifecycle_join / Lifecycle_rejoin /
-   Lifecycle_leave explicitly, so a future event variant cannot silently
-   coalesce into the catch-all "join" branch. JSON wire format is
-   preserved via [agent_lifecycle_event_to_string]. *)
+   forces every dispatch to cover each session-binding event explicitly,
+   so a future event variant cannot silently coalesce into a catch-all
+   branch. JSON wire format is centralised via
+   [agent_lifecycle_event_to_string]. *)
 let observe_agent_lifecycle
       config
       ~agent_id
@@ -166,28 +166,28 @@ let observe_agent_lifecycle
   in
   let level =
     match event with
-    | Lifecycle_join | Lifecycle_rejoin | Lifecycle_leave -> Log.Info
+    | Session_bound | Session_rebound | Session_ended -> Log.Info
   in
   let message =
     match event with
-    | Lifecycle_join -> Printf.sprintf "agent joined: %s" agent_id
-    | Lifecycle_rejoin -> Printf.sprintf "agent rejoined: %s" agent_id
-    | Lifecycle_leave -> Printf.sprintf "agent left: %s" agent_id
+    | Session_bound -> Printf.sprintf "agent session bound: %s" agent_id
+    | Session_rebound -> Printf.sprintf "agent session rebound: %s" agent_id
+    | Session_ended -> Printf.sprintf "agent session ended: %s" agent_id
   in
   Log.emit level ~module_name:"Coord" ~details message;
   (match event with
-   | Lifecycle_leave -> Prometheus.dec_gauge Prometheus.metric_active_agents ()
-   | Lifecycle_join | Lifecycle_rejoin ->
+   | Session_ended -> Prometheus.dec_gauge Prometheus.metric_active_agents ()
+   | Session_bound | Session_rebound ->
      Prometheus.inc_gauge Prometheus.metric_active_agents ());
   let audit_details =
     match event with
-    | Lifecycle_rejoin -> merge_detail_fields [ "rejoin", `Bool true ] details
-    | Lifecycle_join | Lifecycle_leave -> details
+    | Session_rebound -> merge_detail_fields [ "session_rebound", `Bool true ] details
+    | Session_bound | Session_ended -> details
   in
   let action =
     match event with
-    | Lifecycle_leave -> Audit_log.Leave
-    | Lifecycle_join | Lifecycle_rejoin -> Audit_log.Join
+    | Session_ended -> Audit_log.Custom "agent_session_ended"
+    | Session_bound | Session_rebound -> Audit_log.Custom "agent_session_bound"
   in
   (* Audit and telemetry require Eio context (Eio.Mutex).
      Skip when running outside an Eio scheduler, but emit a warn log
@@ -203,16 +203,16 @@ let observe_agent_lifecycle
     if telemetry_enabled ()
     then (
       match event with
-      | Lifecycle_leave -> Telemetry_eio.track_agent_left config ~agent_id ~reason:"leave"
-      | Lifecycle_join | Lifecycle_rejoin ->
+      | Session_ended -> Telemetry_eio.track_agent_left config ~agent_id ~reason:"session_ended"
+      | Session_bound | Session_rebound ->
         Telemetry_eio.track_agent_joined config ~agent_id ())
   with
   | Stdlib.Effect.Unhandled _ as exn ->
     let lifecycle_kind : Coord_telemetry_drop_event.lifecycle_kind =
       match event with
-      | Coord_hooks.Lifecycle_join -> Lifecycle_join
-      | Coord_hooks.Lifecycle_rejoin -> Lifecycle_rejoin
-      | Coord_hooks.Lifecycle_leave -> Lifecycle_leave
+      | Coord_hooks.Session_bound -> Session_bound
+      | Coord_hooks.Session_rebound -> Session_rebound
+      | Coord_hooks.Session_ended -> Session_ended
     in
     warn_telemetry_drop ~event:(Agent_lifecycle lifecycle_kind) exn
 ;;
@@ -653,7 +653,7 @@ let () =
     | Error msg -> Log.Misc.error "task earn failed: %s" msg)
 ;;
 
-(* Relation materializer — agent leave *)
+(* Relation materializer — agent session end *)
 let () = Atomic.set Coord_hooks.relation_on_leave_fn Relation_materializer.on_agent_leave
 
 (* Relation materializer — task done *)
@@ -754,7 +754,7 @@ let () =
          0)
 ;;
 
-(* Subscription auto-subscribe on join — wraps Subscriptions for room_eio *)
+(* Subscription auto-subscribe on session binding — wraps Subscriptions for room_eio *)
 let () =
   Atomic.set Coord_hooks.subscribe_messages_fn (fun ~subscriber ->
     let _ =

--- a/lib/coord.mli
+++ b/lib/coord.mli
@@ -26,8 +26,8 @@ include module type of Coord_gc
 include module type of Coord_agent
 (** {1 Coord lifecycle (overrides)} *)
 
-(** Initialize MASC room with optional auto-join.
-    Wraps [Coord_init.init] and calls [join] when [agent_name] is provided. *)
+(** Initialize MASC room with optional session binding.
+    Wraps [Coord_init.init] and calls [bind_session] when [agent_name] is provided. *)
 val init : config -> agent_name:string option -> string
 
 (** {1 Test hooks} *)

--- a/lib/coord/coord_hooks.ml
+++ b/lib/coord/coord_hooks.ml
@@ -55,7 +55,7 @@ let stop_keeper_fn
   : (string -> unit) Atomic.t
   = Atomic.make (fun _name -> ())
 
-(** Relation materializer: agent leave — wraps Relation_materializer.on_agent_leave. *)
+(** Relation materializer: agent session end — wraps Relation_materializer.on_agent_leave. *)
 let relation_on_leave_fn
   : (leaving_agent:string -> active_agents:string list -> unit) Atomic.t
   = Atomic.make (fun ~leaving_agent:_ ~active_agents:_ -> ())
@@ -77,23 +77,22 @@ let hebbian_on_task_cancelled_fn
      agent_name:string -> active_agents:string list -> unit) Atomic.t
   = Atomic.make (fun _config ~agent_name:_ ~active_agents:_ -> ())
 
-(** Closed enum for the agent lifecycle hook. Replaces the previous
+(** Closed enum for the agent session hook. Replaces the previous
     [event_kind:string] surface (#8605 family): the variant lets the
     compiler enforce exhaustive dispatch on every consumer, and the
     string<->variant mapping is centralised in the helpers below so the
-    JSON wire format ("join" / "rejoin" / "leave") stays exactly the
-    same. *)
+    JSON wire format is owned by this module. *)
 type agent_lifecycle_event =
-  | Lifecycle_join
-  | Lifecycle_rejoin
-  | Lifecycle_leave
+  | Session_bound
+  | Session_rebound
+  | Session_ended
 
 let agent_lifecycle_event_to_string = function
-  | Lifecycle_join -> "join"
-  | Lifecycle_rejoin -> "rejoin"
-  | Lifecycle_leave -> "leave"
+  | Session_bound -> "session_bound"
+  | Session_rebound -> "session_rebound"
+  | Session_ended -> "session_ended"
 
-(** Shared observability hook for join/rejoin/leave events.
+(** Shared observability hook for agent session binding events.
     Upper layers can mirror state transitions to audit, telemetry, and logs
     without introducing circular dependencies into room sub-modules. *)
 let observe_agent_lifecycle_fn
@@ -136,7 +135,7 @@ let on_task_mutation_fn
   = Atomic.make (fun () -> ())
 
 
-(** Auto-subscribe agent to messages on join — wraps Subscriptions.SubscriptionStore. *)
+(** Auto-subscribe agent to messages on session binding — wraps Subscriptions.SubscriptionStore. *)
 let subscribe_messages_fn
   : (subscriber:string -> unit) Atomic.t
   = Atomic.make (fun ~subscriber:_ -> ())

--- a/lib/coord/coord_hooks.mli
+++ b/lib/coord/coord_hooks.mli
@@ -10,9 +10,9 @@ open Masc_domain
 
 type activity_entity = { kind: string; id: string }
 type agent_lifecycle_event =
-  | Lifecycle_join
-  | Lifecycle_rejoin
-  | Lifecycle_leave
+  | Session_bound
+  | Session_rebound
+  | Session_ended
 
 val force_release_task_fn : (Coord_utils_backend_setup.config ->
             agent_name:string ->

--- a/lib/coord/coord_lifecycle.ml
+++ b/lib/coord/coord_lifecycle.ml
@@ -1,4 +1,4 @@
-(** Coord Lifecycle - Agent join/leave operations.
+(** Coord Lifecycle - Agent session binding operations.
 
     Extracted from Coord module. Handles agent entry, re-entry, and departure
     including nickname resolution, dedup, metadata, and relation materialization. *)
@@ -31,12 +31,12 @@ let agent_parse_error_snapshot ~agent_name ~agent_file =
   ]
 
 (** Bind agent session - with auto-generated nickname and metadata *)
-let join config ~agent_name ?(agent_type_override=None) ~capabilities
+let bind_session config ~agent_name ?(agent_type_override=None) ~capabilities
     ?(pid=None) ?(hostname=None) ?(tty=None)
     ?(parent_task=None) ?(keeper_name=None) ?(keeper_id=None) () =
   ensure_initialized config;
 
-  (* Determine if this is a legacy call (agent_name = type) or new style *)
+  (* Determine whether [agent_name] is a stable nickname or an agent type. *)
   let agent_type = match agent_type_override with
     | Some t -> t
     | None ->
@@ -47,9 +47,9 @@ let join config ~agent_name ?(agent_type_override=None) ~capabilities
           agent_name  (* Legacy: agent_name is the type *)
   in
 
-  (* Reuse existing nickname for same agent_type if already joined,
+  (* Reuse existing nickname for same agent_type if already bound,
      otherwise generate a new one. This prevents identity drift when
-     the same agent_name joins multiple times within a session. *)
+     the same agent_name binds multiple times within a session. *)
   let nickname =
     if Nickname.is_generated_nickname agent_name then
       agent_name  (* Already a nickname, use as-is *)
@@ -72,7 +72,7 @@ let join config ~agent_name ?(agent_type_override=None) ~capabilities
     end
   in
 
-  (* Dedup: if agent already joined, update last_seen and return early *)
+  (* Dedup: if agent already has a session, update last_seen and return early *)
   let agent_file_dedup = Filename.concat (agents_dir config) (safe_filename nickname ^ ".json") in
   let already_joined = Sys.file_exists agent_file_dedup in
   if already_joined then begin
@@ -100,32 +100,32 @@ let join config ~agent_name ?(agent_type_override=None) ~capabilities
        } in
        write_json config agent_file_dedup (agent_to_yojson updated);
        if is_inactive then begin
-         (* Restore to active_agents on rejoin *)
+         (* Restore to active_agents on session rebound *)
          let _state = update_state config (fun s ->
            let agents = nickname :: List.filter ((<>) nickname) s.active_agents in
            { s with active_agents = agents }
          ) in
          let _ =
            broadcast config ~from_agent:nickname
-             ~msg_type:"lifecycle_rejoin"
-             ~content:(Printf.sprintf "👋 %s rejoined the namespace" nickname)
+             ~msg_type:"session_rebound"
+             ~content:(Printf.sprintf "%s rebound the namespace session" nickname)
          in
          log_event config (`Assoc [
-           ("type", `String "agent_join");
+           ("type", `String "agent_session_bound");
            ("agent", `String nickname);
            ("agent_type", `String agent_type);
            ("session_id", `String new_session_id);
-           ("rejoin", `Bool true);
+           ("session_rebound", `Bool true);
            ("ts", `String (now_iso ()));
          ]);
          (Atomic.get Coord_hooks.observe_agent_lifecycle_fn) config ~agent_id:nickname
-           ~event:Coord_hooks.Lifecycle_rejoin
+           ~event:Coord_hooks.Session_rebound
            ~details:
              (`Assoc
                [
                  ("agent_type", `String agent_type);
                  ("session_id", `String new_session_id);
-                 ("rejoin", `Bool true);
+                 ("session_rebound", `Bool true);
                ]);
        end
      | Error e ->
@@ -134,9 +134,9 @@ let join config ~agent_name ?(agent_type_override=None) ~capabilities
              ~agent_file:agent_file_dedup
          in
          Log.Coord.warn
-           "agent rejoin: invalid agent JSON for %s: %s | snapshot=%s"
+           "agent session rebound: invalid agent JSON for %s: %s | snapshot=%s"
            nickname e (Yojson.Safe.to_string snapshot));
-    Printf.sprintf "%s already in the namespace (last_seen updated)" nickname
+    Printf.sprintf "%s already bound in the namespace (last_seen updated)" nickname
   end else begin
     (* Collect metadata *)
   let session_id = generate_session_id () in
@@ -173,16 +173,16 @@ let join config ~agent_name ?(agent_type_override=None) ~capabilities
     { s with active_agents = agents }
   ) in
 
-  (* Broadcast join *)
+  (* Broadcast session binding *)
   let _ =
     broadcast config ~from_agent:nickname
-      ~msg_type:"lifecycle_join"
-      ~content:(Printf.sprintf "👋 %s joined the namespace" nickname)
+      ~msg_type:"session_bound"
+      ~content:(Printf.sprintf "%s bound the namespace session" nickname)
   in
 
   (* Log event with metadata *)
   log_event config (`Assoc [
-    ("type", `String "agent_join");
+    ("type", `String "agent_session_bound");
     ("agent", `String nickname);
     ("agent_type", `String agent_type);
     ("session_id", `String session_id);
@@ -190,7 +190,7 @@ let join config ~agent_name ?(agent_type_override=None) ~capabilities
     ("ts", `String (now_iso ()));
   ]);
   (Atomic.get Coord_hooks.observe_agent_lifecycle_fn) config ~agent_id:nickname
-    ~event:Coord_hooks.Lifecycle_join
+    ~event:Coord_hooks.Session_bound
     ~details:
       (`Assoc
         [
@@ -200,15 +200,12 @@ let join config ~agent_name ?(agent_type_override=None) ~capabilities
             `List (List.map (fun s -> `String s) capabilities) );
         ]);
 
-  Printf.sprintf "%s joined\n  Nickname: %s\n  Type: %s\n  Session: %s"
+  Printf.sprintf "%s session bound\n  Nickname: %s\n  Type: %s\n  Session: %s"
     nickname nickname agent_type session_id
   end
 
-(* join_in_room removed — namespace concept retired (#unify-namespace).
-   Use [join] directly. *)
-
 (** End agent session *)
-let leave ?(stop_heartbeats = true) config ~agent_name =
+let end_session ?(stop_heartbeats = true) config ~agent_name =
   ensure_initialized config;
 
   (* Support both exact nickname match and agent_type prefix match *)
@@ -222,8 +219,8 @@ let leave ?(stop_heartbeats = true) config ~agent_name =
   let agent_file = Filename.concat (agents_dir config) (safe_filename actual_name ^ ".json") in
   let in_fs = Sys.file_exists agent_file in
   if in_fs then begin
-    (* Mark agent as Inactive instead of deleting, so re-join can restore identity.
-       This prevents orphan state when the same agent_type re-joins later. *)
+    (* Mark agent as Inactive instead of deleting, so a future session can restore
+       identity without orphan state. *)
     (match read_agent_with_repair config agent_file with
      | Ok existing_agent ->
        let updated = { existing_agent with status = Inactive; last_seen = now_iso () } in
@@ -233,7 +230,7 @@ let leave ?(stop_heartbeats = true) config ~agent_name =
            agent_parse_error_snapshot ~agent_name:actual_name ~agent_file
          in
          Log.Coord.warn
-           "agent leave: invalid agent JSON for %s: %s | snapshot=%s"
+           "agent session end: invalid agent JSON for %s: %s | snapshot=%s"
            actual_name e (Yojson.Safe.to_string snapshot));
 
     (* Capture active agents before removal for relationship materialization *)
@@ -245,25 +242,25 @@ let leave ?(stop_heartbeats = true) config ~agent_name =
 
     let _ =
       broadcast config ~from_agent:"system"
-        ~msg_type:"lifecycle_leave"
-        ~content:(Printf.sprintf "👋 %s left the namespace" actual_name)
+        ~msg_type:"session_ended"
+        ~content:(Printf.sprintf "%s ended the namespace session" actual_name)
     in
 
     (* Log event *)
     log_event config (`Assoc [
-      ("type", `String "agent_leave");
+      ("type", `String "agent_session_ended");
       ("agent", `String actual_name);
       ("ts", `String (now_iso ()));
     ]);
     (Atomic.get Coord_hooks.observe_agent_lifecycle_fn) config ~agent_id:actual_name
-      ~event:Coord_hooks.Lifecycle_leave
+      ~event:Coord_hooks.Session_ended
       ~details:`Null;
 
     (* Record co-presence relationships via hook (async, non-blocking) *)
     (try (Atomic.get Coord_hooks.relation_on_leave_fn)
            ~leaving_agent:actual_name ~active_agents:peers_before_leave
      with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-       Log.Coord.error "relation-materializer leave hook error: %s"
+       Log.Coord.error "relation-materializer session-end hook error: %s"
          (Printexc.to_string exn));
 
     Printf.sprintf "%s left the namespace" actual_name

--- a/lib/coord/coord_lifecycle.mli
+++ b/lib/coord/coord_lifecycle.mli
@@ -1,4 +1,4 @@
-(** Coord lifecycle — agent join / leave and registry parse-error
+(** Coord lifecycle — agent session binding and registry parse-error
     diagnostics. *)
 
 open Masc_domain
@@ -6,7 +6,7 @@ open Coord_utils
 open Coord_state
 open Coord_broadcast
 
-val join :
+val bind_session :
   Coord_utils_backend_setup.config ->
   agent_name:string ->
   ?agent_type_override:string option ->
@@ -20,7 +20,7 @@ val join :
   unit ->
   string
 
-val leave :
+val end_session :
   ?stop_heartbeats:bool ->
   Coord_utils_backend_setup.config ->
   agent_name:string ->

--- a/lib/coord/coord_telemetry_drop_event.ml
+++ b/lib/coord/coord_telemetry_drop_event.ml
@@ -2,16 +2,16 @@
    telemetry drop counter [Prometheus.metric_coord_telemetry_drop].
 
    See [.mli] for the public contract. The wire strings are chosen to be
-   byte-for-byte compatible with the legacy free-string call sites in
-   [lib/coord.ml] (lifecycle: "agent_lifecycle/{join,rejoin,leave}",
+   explicit names owned by the typed call sites in
+   [lib/coord.ml] (lifecycle: "agent_lifecycle/{session_bound,session_rebound,session_ended}",
    task transition: "task_transition/<task_action>", accountability:
    "accountability/<task_action>") so the Grafana / alerting rules
    filtering on the existing label values keep matching. *)
 
 type lifecycle_kind =
-  | Lifecycle_join
-  | Lifecycle_rejoin
-  | Lifecycle_leave
+  | Session_bound
+  | Session_rebound
+  | Session_ended
 
 type t =
   | Agent_lifecycle of lifecycle_kind
@@ -25,9 +25,9 @@ let family_to_wire = function
 ;;
 
 let lifecycle_kind_to_wire = function
-  | Lifecycle_join -> "join"
-  | Lifecycle_rejoin -> "rejoin"
-  | Lifecycle_leave -> "leave"
+  | Session_bound -> "session_bound"
+  | Session_rebound -> "session_rebound"
+  | Session_ended -> "session_ended"
 ;;
 
 let kind_to_wire = function

--- a/lib/coord/coord_telemetry_drop_event.mli
+++ b/lib/coord/coord_telemetry_drop_event.mli
@@ -32,9 +32,9 @@
     lifecycle variant in [Coord_hooks] does not silently widen the drop
     counter label set without a deliberate change here. *)
 type lifecycle_kind =
-  | Lifecycle_join
-  | Lifecycle_rejoin
-  | Lifecycle_leave
+  | Session_bound
+  | Session_rebound
+  | Session_ended
 
 (** Drop event identifies which Coord sub-path raised
     [Stdlib.Effect.Unhandled]. *)
@@ -62,7 +62,8 @@ type t =
 val family_to_wire : t -> string
 
 (** Wire label for the [event_kind] Prometheus label. For
-    [Agent_lifecycle] this is one of ["join" / "rejoin" / "leave"]
+    [Agent_lifecycle] this is one of ["session_bound" / "session_rebound" /
+    "session_ended"]
     (matching {!Coord_hooks.agent_lifecycle_event_to_string}). For
     [Task_transition] / [Accountability] it is
     {!Masc_domain.task_action_to_string} of the carried action

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -75,7 +75,7 @@ let execute_tool_eio
   let room_init_cached = ref (Coord.is_initialized config) in
   (* Fix 4: Check resolved-name cache for fast identity resolution.
      On 2nd+ call in the same MCP session, the cached name preserves the
-     nickname selected by the prior join without relying on sidecar files. *)
+     nickname selected by the prior session binding without relying on sidecar files. *)
   let cached_resolved_agent =
     Option.bind mcp_session_id Agent_registry_eio.get_resolved_name
   in
@@ -280,7 +280,7 @@ let execute_tool_eio
             then true
             else (
               (* If per-agent tokens are required, only auto-bind when agent_name already
-         looks like a stable nickname. Otherwise Coord.join would generate a new
+         looks like a stable nickname. Otherwise Coord.bind_session would generate a new
          nickname, breaking token verification for subsequent calls. *)
               let auth_cfg = Auth.load_auth_config config.base_path in
               if auth_cfg.require_token && not (Nickname.is_generated_nickname agent_name)
@@ -303,9 +303,9 @@ let execute_tool_eio
               let is_joined =
                 if !room_init_cached
                 then (
-                  (* Auto-join gate hides the failure mode that distinguishes
-                     "agent really isn't joined yet" from "we can't read the
-                     join state". Invalid_argument is kept because
+                  (* Auto-bind gate hides the failure mode that distinguishes
+                     "agent really isn't bound yet" from "we can't read the
+                     binding state". Invalid_argument is kept because
                      [Coord.is_agent_joined] surface formerly raised it on
                      malformed agent_name input; dropping it changes scope. *)
                   try Coord.is_agent_joined config ~agent_name with
@@ -314,7 +314,7 @@ let execute_tool_eio
                     ->
                     Log.Mcp.warn
                       "[is_agent_joined gate] read failed for %s: %s; \
-                       treating as not-joined"
+                       treating as not-bound"
                       agent_name
                       (Printexc.to_string exn);
                     false)
@@ -324,7 +324,7 @@ let execute_tool_eio
               then agent_name
               else (
                 let session_binding_result =
-                  Coord.join
+                  Coord.bind_session
                     config
                     ~agent_name
                     ~capabilities:[]
@@ -409,7 +409,7 @@ let execute_tool_eio
                   agent_name
                   name
                   (Printexc.to_string exn)));
-          (* Check if agent must join first — Fix 3: use cached value *)
+          (* Check if agent must be session-bound first — Fix 3: use cached value *)
           let room_initialized = !room_init_cached in
           let is_joined =
             resolve_join_state
@@ -419,7 +419,7 @@ let execute_tool_eio
               ~check_join:(fun candidate ->
                 Coord.is_agent_joined config ~agent_name:candidate)
           in
-          (* Debug: log join check *)
+          (* Debug: log session binding check *)
           Log.Misc.debug
             "tool=%s agent_name=%s join_required=%b room_initialized=%b is_joined=%b"
             name
@@ -442,7 +442,7 @@ let execute_tool_eio
               (runtime_error_result
                  (Printf.sprintf
                     "MASC room not initialized.\n\n\
-                     Fastest: masc_start(path=\"<project>\") — one-step init+join, then \
+                     Fastest: masc_start(path=\"<project>\") — one-step init+session binding, then \
                      call %s.\n\
                      Alternative: masc_init → masc_start → masc_status → %s\n\
                      📚 See: @~/me/instructions/masc-workflow.md\n\

--- a/lib/prometheus_builtin_metrics_part4.ml
+++ b/lib/prometheus_builtin_metrics_part4.ml
@@ -311,7 +311,7 @@ let register
     "Total times a Coord lifecycle/transition hook dropped its Audit_log + Telemetry \
      emit because the dispatch happened outside an Eio scheduler. Labels: event_family \
      (one of agent_lifecycle | task_transition | accountability) and event_kind (the \
-     variant). event_kind values: agent_lifecycle uses join | rejoin | leave (3 values); \
+     variant). event_kind values: agent_lifecycle uses session_bound | session_rebound | session_ended (3 values); \
      task_transition and accountability both use the 8 task_action variants claim | \
      start | done | cancel | release | submit_for_verification | approve | reject. \
      Cardinality bound: 19 series (3 + 8 + 8). Non-zero rate means a production path is \
@@ -380,7 +380,7 @@ let register
     `Counter;
   add
     metric_coord_join_normalize_outcome
-    "Total Coord.join identity normalizations by Keeper_identity.normalize_all_names \
+    "Total Coord.bind_session identity normalizations by Keeper_identity.normalize_all_names \
      (RFC P3-a). Labels: outcome (ok | empty_input | persona_not_found | \
      credential_missing | name_ambiguous | ephemeral_suffix_rejected). Non-ok outcomes \
      reject agent session binding at the fail-closed identity gate; pair with \

--- a/lib/server/server_dashboard_http_delete_actions.ml
+++ b/lib/server/server_dashboard_http_delete_actions.ml
@@ -237,7 +237,7 @@ let purge_agent_filesystem_artifacts config agent_names =
        in
        let heartbeats_stopped = Heartbeat.stop_by_agent ~agent_name in
        let coord_leave_result =
-         Coord.leave ~stop_heartbeats:false config ~agent_name
+         Coord.end_session ~stop_heartbeats:false config ~agent_name
        in
        let aliases_label = String.concat "," aliases in
        Log.Misc.info

--- a/lib/tool_inline_dispatch_coord.ml
+++ b/lib/tool_inline_dispatch_coord.ml
@@ -60,7 +60,7 @@ let arg_get_string ctx key default =
 let arg_get_string_list ctx key =
   Safe_ops.json_string_list key ctx.arguments
 
-(** masc_start — compound onboarding (set project root + join + optional task) *)
+(** masc_start — compound onboarding (set project root + bind session + optional task) *)
 let handle_start ~tool_name ~start_time (ctx : context) : Tool_result.result option =
   let config = ctx.config in
   let agent_name = ctx.agent_name in
@@ -112,18 +112,18 @@ let handle_start ~tool_name ~start_time (ctx : context) : Tool_result.result opt
         (inline_err_workflow ~tool_name ~start_time
            (Printf.sprintf "masc_start failed while setting project scope: %s" e))
   | Ok active_config ->
-    (* Step 2: join (idempotent — skip if already joined) *)
-    let join_result =
+    (* Step 2: bind session (idempotent) *)
+    let session_binding_result =
       try
-        let _msg = Coord.join active_config ~agent_name ~capabilities:[] () in
+        let _msg = Coord.bind_session active_config ~agent_name ~capabilities:[] () in
         Ok ()
       with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
         let msg = Tool_error.to_string (Tool_error.of_exn exn) in
-        if String.length msg > 0 then Error msg else Error "join failed"
+        if String.length msg > 0 then Error msg else Error "session binding failed"
     in
-    match join_result with
+    match session_binding_result with
     | Error e ->
-      (* join exception caught from [Coord.join] — internal failure. *)
+      (* Session binding exception caught from [Coord.bind_session] — internal failure. *)
       Some
         (inline_err_runtime ~tool_name ~start_time
            (Printf.sprintf "masc_start failed while binding agent session: %s" e))
@@ -133,7 +133,7 @@ let handle_start ~tool_name ~start_time (ctx : context) : Tool_result.result opt
         Some
           (inline_ok ~tool_name ~start_time
              (Printf.sprintf
-                "masc_start complete (project scope set + joined as %s). No task created — use %s to create one."
+                "masc_start complete (project scope set + session bound as %s). No task created — use %s to create one."
                 agent_name
                 masc_add_task_name))
       else begin
@@ -166,7 +166,7 @@ let handle_start ~tool_name ~start_time (ctx : context) : Tool_result.result opt
           Some
             (inline_ok ~tool_name ~start_time
                (Printf.sprintf
-                  "masc_start partial: joined as %s, but task creation failed: %s"
+                  "masc_start partial: session bound as %s, but task creation failed: %s"
                   agent_name add_result))
         else begin
           let _claim_msg = Coord_task.claim_task active_config ~agent_name ~task_id in
@@ -178,7 +178,7 @@ let handle_start ~tool_name ~start_time (ctx : context) : Tool_result.result opt
               Some
                 (inline_ok ~tool_name ~start_time
                    (Printf.sprintf
-                      "masc_start complete: project scope set, joined as %s, task %s created+claimed+set as current."
+                      "masc_start complete: project scope set, session bound as %s, task %s created+claimed+set as current."
                       agent_name task_id))
         end
       end


### PR DESCRIPTION
## Summary
- rename Coord join/leave API to bind_session/end_session
- replace lifecycle hook variants with session_bound/session_rebound/session_ended
- remove dedicated audit Join/Leave actions and log helpers in favor of custom session audit events

## Validation
- targeted residue scan for removed tool/API identifiers only
- build not run (deletion-first cleanup; build may break)