### PR TITLE
Purge join-required execution guard

### DIFF
--- a/lib/coord/coord_task_claim.ml
+++ b/lib/coord/coord_task_claim.ml
@@ -116,14 +116,6 @@ let claim_task_r config ~agent_name ~task_id ?agent_tool_names ()
     | _, Error e -> Error e
     | Ok _, Ok _ -> Ok ()
   in
-  (* BUG-005: Verify agent has joined before allowing claim. *)
-  let actual_name = resolve_agent_name config agent_name in
-  let filename = safe_filename actual_name ^ ".json" in
-  let agent_path = Filename.concat (agents_dir config) filename in
-  let agent_joined = path_exists config agent_path in
-  let* () =
-    if not agent_joined then Error (Masc_domain.Agent (Masc_domain.Agent_error.NotJoined actual_name)) else Ok ()
-  in
   let backlog_path = Filename.concat (tasks_dir config) ".backlog" in
   with_file_lock config backlog_path (fun () ->
     match read_backlog_r config with

--- a/lib/coord_assertions.ml
+++ b/lib/coord_assertions.ml
@@ -21,40 +21,30 @@ open Masc_domain
 open Coord_types
 
 type agent_state =
-  { room_set : bool
-  ; joined : bool
-  ; task_claimed : bool
+  { task_claimed : bool
   ; current_task_set : bool
   }
 
 type assertion_kind =
-  | Room_set
-  | Joined
   | Task_claimed
   | Current_task_set
 
 let assertion_kind_to_string = function
-  | Room_set -> "room_set"
-  | Joined -> "joined"
   | Task_claimed -> "task_claimed"
   | Current_task_set -> "current_task_set"
 ;;
 
-let all_assertion_kinds = [ Room_set; Joined; Task_claimed; Current_task_set ]
+let all_assertion_kinds = [ Task_claimed; Current_task_set ]
 
 let valid_assertion_strings = List.map assertion_kind_to_string all_assertion_kinds
 
 let assertion_kind_of_string_lenient = function
-  | "room_set" -> Some Room_set
-  | "joined" -> Some Joined
   | "task_claimed" -> Some Task_claimed
   | "current_task_set" -> Some Current_task_set
   | _ -> None
 ;;
 
 let assertion_fix_hint = function
-  | Room_set -> "Call masc_start with your project root path."
-  | Joined -> "Call masc_start to bind your agent session"
   | Task_claimed -> "Claim a task with masc_transition(action=claim) or masc_claim_next"
   | Current_task_set ->
     "Call masc_plan_set_task to choose or re-sync the active task when current_task is \
@@ -62,8 +52,6 @@ let assertion_fix_hint = function
 ;;
 
 let assertion_passes st = function
-  | Room_set -> st.room_set
-  | Joined -> st.joined
   | Task_claimed -> st.task_claimed
   | Current_task_set -> st.current_task_set
 ;;
@@ -93,9 +81,7 @@ let check_assertion st assertion =
 
 let state_to_json st =
   `Assoc
-    [ "room_set", `Bool st.room_set
-    ; "joined", `Bool st.joined
-    ; "task_claimed", `Bool st.task_claimed
+    [ "task_claimed", `Bool st.task_claimed
     ; "current_task_set", `Bool st.current_task_set
     ; "session_active", `Bool false
     ]
@@ -104,7 +90,7 @@ let state_to_json st =
 let handle_check ~(inspect_state : context -> agent_state) ~tool_name ~start_time ctx args
   =
   let st = inspect_state ctx in
-  let default_assertions = [ "room_set"; "joined"; "task_claimed"; "current_task_set" ] in
+  let default_assertions = [ "task_claimed"; "current_task_set" ] in
   let assertions =
     match Json_util.assoc_member_opt "assertions" args with
     | Some (`List items) ->

--- a/lib/coord_assertions.mli
+++ b/lib/coord_assertions.mli
@@ -22,37 +22,26 @@
 (** {1 State snapshot} *)
 
 (** Concrete record because {!Tool_coord} field-constructs it
-    when projecting an inspected context to the assertion engine
-    ([Coord_assertions.room_set = s.room_set]).  Hiding would
-    break the type seam. *)
+    when projecting an inspected context to the assertion engine. *)
 type agent_state =
-  { room_set : bool
-  ; joined : bool
-  ; task_claimed : bool
+  { task_claimed : bool
   ; current_task_set : bool
   }
 
 (** {1 Assertion taxonomy} *)
 
-(** Closed variant — every match site must update on extension.
-    [Tool_coord] type-aliases this exact shape with the same four
-    constructors, so the cross-module re-export is structurally
-    pinned. *)
+(** Closed variant — every match site must update on extension. *)
 type assertion_kind =
-  | Room_set
-  (** Project root configured. *)
-  | Joined (** Agent has joined the project namespace. *)
   | Task_claimed (** Agent owns at least one claimed task. *)
   | Current_task_set (** [current_task] is set, fresh, and unambiguous. *)
 
 (** [assertion_kind_to_string k] returns the canonical snake_case
-    tag (e.g. [Room_set -> "room_set"]).  This is the operator-
+    tag.  This is the operator-
     visible name in JSON output — runbook commands grep on these
     literals. *)
 val assertion_kind_to_string : assertion_kind -> string
 
-(** Canonical declaration order: [Room_set; Joined; Task_claimed;
-    Current_task_set].  Used by
+(** Canonical declaration order: [Task_claimed; Current_task_set].  Used by
     {!handle_check}'s default-list fallback when callers omit the
     [assertions] argument. *)
 val all_assertion_kinds : assertion_kind list
@@ -85,9 +74,8 @@ val assertion_kind_of_string_lenient : string -> assertion_kind option
       context.
     - [args] is the raw JSON-RPC params.  Recognises an optional
       [assertions: [<string>...]] array; missing or non-list values
-      fall back to the canonical defaults (the four
-      [room_set / joined / task_claimed / current_task_set]
-      strings.  An empty list also falls back to
+      fall back to the canonical defaults ([task_claimed] /
+      [current_task_set]).  An empty list also falls back to
       defaults so callers cannot accidentally pass nothing.
 
     {2 Return value}

--- a/lib/dispatch_outcome.mli
+++ b/lib/dispatch_outcome.mli
@@ -11,7 +11,7 @@ type t =
   | Rejected_by_capability of { missing : string list }
       (** Capability gate rejected the dispatch.  [missing] enumerates
           the capability kinds the caller lacked (e.g.
-          ["destructive"; "requires_join"]).  PR-10 introduces the
+          ["destructive"]).  PR-10 introduces the
           variant; PR-7 still treats capability as advisory.  PR-12+
           may wire enforcement on top of this variant. *)
   | Rejected_by_pre_hook of { reason : string }

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -8,14 +8,6 @@
 let log_mcp_exn = Mcp_server_eio_helpers.log_mcp_exn
 let wait_for_message_eio = Mcp_server_eio_helpers.wait_for_message_eio
 
-let resolve_join_state ~room_initialized ~join_required ~agent_name ~check_join =
-  if not (room_initialized && join_required)
-  then false
-  else if agent_name = "unknown"
-  then false
-  else check_join agent_name
-;;
-
 let caller_agent_name_from_arguments arguments =
   Mcp_server_eio_caller_identity.caller_agent_name_from_arguments arguments
 ;;
@@ -213,138 +205,10 @@ let execute_tool_eio
        let caller_tool_names =
          Some (dedupe_string_list (profile_tool_names @ keeper_tool_names))
        in
-       let extract_nickname_from_session_binding_result ~fallback result =
-         try
-           let prefix = "  Nickname: " in
-           let start_idx =
-             let idx = ref 0 in
-             while
-               !idx < String.length result - String.length prefix
-               && String.sub result !idx (String.length prefix) <> prefix
-             do
-               incr idx
-             done;
-             !idx + String.length prefix
-           in
-           let end_idx =
-             match String.index_from_opt result start_idx '\n' with
-             | Some idx -> idx
-             | None -> String.length result
-           in
-           String.sub result start_idx (end_idx - start_idx)
-         with
-         | Invalid_argument _ -> fallback
-       in
-       (* Auto-init/auto-bind for better UX.
-     - Auto-init only when auth is disabled (avoid side effects in secured rooms).
-     - Auto-bind when allowed by auth (and safe for token-based auth). *)
-       let join_required =
-         Agent_tool_descriptor_resolution.capability_has
-           Tool_capability.Requires_join
-           name
-       in
-       let init_error =
-         if (not auth_enabled) && join_required && not !room_init_cached
-         then (
-           try
-             let (_init_msg : string) = Coord.init config ~agent_name:None in
-             room_init_cached := true;
-             (* Fix 3: update cache after successful init *)
-             None
-           with
-           | Invalid_argument msg -> Some msg
-           | Sys_error msg -> Some msg
-           | Yojson.Json_error msg -> Some msg
-           | Eio.Cancel.Cancelled _ as exn -> raise exn
-           | exn -> Some (Printexc.to_string exn))
-         else None
-       in
-       (match init_error with
-        | Some msg -> with_system_internal_audit ~agent_name (runtime_error_result msg)
-        | None ->
           let is_read_only =
             Agent_tool_descriptor_resolution.capability_has
               Tool_capability.Read_only
               name
-          in
-          let can_auto_join =
-            if (not join_required) || agent_name = "unknown"
-            then false
-            else if Option.is_none mcp_session_id
-            then
-              (* Sessionless requests (no Mcp-Session-Id header) should not auto-bind.
-         Without a session, each request gets a new ephemeral agent name,
-         causing orphan agent proliferation in the room. *)
-              false
-            else if not auth_enabled
-            then true
-            else (
-              (* If per-agent tokens are required, only auto-bind when agent_name already
-         looks like a stable nickname. Otherwise Coord.bind_session would generate a new
-         nickname, breaking token verification for subsequent calls. *)
-              let auth_cfg = Auth.load_auth_config config.base_path in
-              if auth_cfg.require_token && not (Nickname.is_generated_nickname agent_name)
-              then false
-              else (
-                match
-                  Auth.authorize_tool_v2
-                    config.base_path
-                    ~agent_name
-                    ~token
-                    ~tool_name:"masc_start"
-                with
-                | Ok () -> true
-                | Error _ -> false))
-          in
-          let agent_name =
-            if can_auto_join
-            then (
-              (* Fix 3: use cached room_initialized *)
-              let is_joined =
-                if !room_init_cached
-                then (
-                  (* Auto-bind gate hides the failure mode that distinguishes
-                     "agent really isn't bound yet" from "we can't read the
-                     binding state". Invalid_argument is kept because
-                     [Coord.is_agent_joined] surface formerly raised it on
-                     malformed agent_name input; dropping it changes scope. *)
-                  try Coord.is_agent_joined config ~agent_name with
-                  | Eio.Cancel.Cancelled _ as e -> raise e
-                  | (Sys_error _ | Yojson.Json_error _ | Invalid_argument _) as exn
-                    ->
-                    Log.Mcp.warn
-                      "[is_agent_joined gate] read failed for %s: %s; \
-                       treating as not-bound"
-                      agent_name
-                      (Printexc.to_string exn);
-                    false)
-                else false
-              in
-              if is_joined
-              then agent_name
-              else (
-                let session_binding_result =
-                  Coord.bind_session
-                    config
-                    ~agent_name
-                    ~capabilities:[]
-                    ~keeper_name:(Option.map fst owner_keeper_identity)
-                    ~keeper_id:(Option.bind owner_keeper_identity snd)
-                    ()
-                in
-                let nickname =
-                  extract_nickname_from_session_binding_result
-                    ~fallback:agent_name
-                    session_binding_result
-                in
-                Log.Mcp.info "Auto-bound session for %s: %s -> %s" name agent_name nickname;
-                (* Remember nickname so subsequent calls in this MCP session can use it. *)
-                record_mcp_session_agent nickname;
-                let (_ : Session.session) =
-                  Session.register registry ~agent_name:nickname
-                in
-                nickname))
-            else agent_name
           in
           (match owner_keeper_identity with
            | Some (keeper_name, keeper_id)
@@ -409,70 +273,7 @@ let execute_tool_eio
                   agent_name
                   name
                   (Printexc.to_string exn)));
-          (* Check if agent must be session-bound first — Fix 3: use cached value *)
-          let room_initialized = !room_init_cached in
-          let is_joined =
-            resolve_join_state
-              ~room_initialized
-              ~join_required
-              ~agent_name
-              ~check_join:(fun candidate ->
-                Coord.is_agent_joined config ~agent_name:candidate)
-          in
-          (* Debug: log session binding check *)
-          Log.Misc.debug
-            "tool=%s agent_name=%s join_required=%b room_initialized=%b is_joined=%b"
-            name
-            agent_name
-            join_required
-            room_initialized
-            is_joined;
-          if join_required && not room_initialized
-          then (
-            (* #9770: surface guard fires as a fleet-wide metric so
-       operators can see which (tool, agent) pairs repeatedly skip
-       session binding without log-scraping. *)
-            Prometheus.inc_counter
-              Prometheus.metric_tool_join_required_guard
-              ~labels:
-                [ "tool", name; "agent_name", agent_name; "reason", "room_uninitialized" ]
-              ();
-            with_system_internal_audit
-              ~agent_name
-              (runtime_error_result
-                 (Printf.sprintf
-                    "MASC room not initialized.\n\n\
-                     Fastest: masc_start(path=\"<project>\") — one-step init+session binding, then \
-                     call %s.\n\
-                     Alternative: masc_init → masc_start → masc_status → %s\n\
-                     📚 See: @~/me/instructions/masc-workflow.md\n\
-                     [DEBUG] agent_name=%s room_initialized=%b"
-                    name
-                    name
-                    agent_name
-                    room_initialized)))
-          else if join_required && not is_joined
-          then (
-            Prometheus.inc_counter
-              Prometheus.metric_tool_join_required_guard
-              ~labels:
-                [ "tool", name; "agent_name", agent_name; "reason", "agent_not_joined" ]
-              ();
-            with_system_internal_audit
-              ~agent_name
-              (runtime_error_result
-                 (Printf.sprintf
-                    "Session binding required before using %s.\n\n\
-                     Fastest: masc_start(path=\"<project>\") — one-step session binding.\n\
-                     Alternative: masc_start → masc_status → %s\n\
-                     📚 See: @~/me/instructions/masc-workflow.md\n\
-                     [DEBUG] agent_name=%s is_joined=%b"
-                    name
-                    name
-                    agent_name
-                    is_joined)))
-          else (
-            (* === Fix 1: Tag-based lazy context dispatch ===
+          (* === Fix 1: Tag-based lazy context dispatch ===
      O(1) tag lookup determines which module handles this tool.
      Only the matched module's context is created (1 out of 45+).
      Eliminates per-call 40+ context creation and ~210 Hashtbl.replace. *)

--- a/lib/mcp_server_eio_execute.mli
+++ b/lib/mcp_server_eio_execute.mli
@@ -1,11 +1,6 @@
-(** Mcp_server_eio_execute — inner [tools/call] dispatcher
-    plus the join-state resolver shared with the keeper
-    onboarding path.
+(** Mcp_server_eio_execute — inner [tools/call] dispatcher.
 
     Only a small set of entries reach callers:
-    - {!resolve_join_state} —
-      [test/test_mcp_server_eio.ml] exercises the join-required
-      decisions to keep alias handling consistent across refactors.
     - {!caller_agent_name_from_arguments} — isolates the
       HTTP [_agent_name] caller identity contract without running
       the full dispatcher.
@@ -26,26 +21,6 @@
     body itself contains many internal sub-helpers
     (audit wrappers, tool dispatchers, error formatters)
     that are local to its lexical scope. *)
-
-(** {1 Session binding state resolution} *)
-
-val resolve_join_state :
-  room_initialized:bool ->
-  join_required:bool ->
-  agent_name:string ->
-  check_join:(string -> bool) ->
-  bool
-(** Returns [true] iff the request should be treated as a
-    joined-agent call.
-
-    The decision is short-circuited:
-    - [room_initialized = false] or [join_required = false]
-      → [false] (no join check needed).
-    - [agent_name = "unknown"] → [false] (sentinel name).
-    - Otherwise probes only [check_join agent_name].
-
-    [check_join] is injected so tests can drive the
-    resolver against a deterministic registry. *)
 
 val caller_agent_name_from_arguments : Yojson.Safe.t -> string option
 (** Returns the explicit caller identity carried in [tools/call]

--- a/lib/prometheus_builtin_metrics_part1.ml
+++ b/lib/prometheus_builtin_metrics_part1.ml
@@ -216,12 +216,6 @@ let register
     "Wall-clock unixtime of the most recent successful supervisor sweep beat (labels: \
      base_path).  Stale (> 2 × interval) means the sweep stalled."
     `Gauge;
-  add
-    metric_tool_join_required_guard
-    "Total join-required guard rejections before tool execution (labels: tool, \
-     agent_name, reason=room_uninitialized|agent_not_joined)"
-    `Counter;
-  add
     metric_tool_metrics_persist_dropped
     "Total JSONL records dropped by tool_metrics_persist because the bounded \
      write queue is full. No labels."

--- a/lib/prometheus_metric_names.ml
+++ b/lib/prometheus_metric_names.ml
@@ -151,20 +151,6 @@ let metric_backend_mutex_held_sec = "masc_backend_mutex_held_sec"
      [time() - masc_keeper_supervisor_last_sweep_unixtime > 90]
      means the sweep is stalled (default sweep interval is 30s). *)
 
-(* #9770: counter for the [join_required] guard firing in
-   [Mcp_server_eio_execute].  Production observed agents calling
-   [masc_claim_next] (and similar) before session binding; the
-   guard returns a polite error message but no fleet-wide signal
-   exists for "how often does this happen, and which agent / tool
-   pair is most affected".  Labels:
-     [tool]: tool name that hit the guard (bounded by tool surface
-       size, ~50).
-     [agent_name]: agent that called the tool (bounded by fleet
-       size, ~10).
-     [reason]: ["room_uninitialized" | "agent_not_joined"].
-   Cardinality: ~50 × ~10 × 2 = ~1000 series, safe for Prometheus. *)
-let metric_tool_join_required_guard = "masc_tool_join_required_guard_total"
-
 (* tool_metrics_persist write queue overflow.
    Counts JSONL records dropped because the bounded write queue is full.
    No labels (single source). Existing in-memory [dropped_full_queue]

--- a/lib/prometheus_metric_names.mli
+++ b/lib/prometheus_metric_names.mli
@@ -124,12 +124,6 @@ val metric_backend_mutex_held_sec : string
     for the rationale.  Counter increments on each Pulse start;
     gauge advances on every successful beat. *)
 
-(** #9770: count fires of the [join_required] guard in
-    [Mcp_server_eio_execute].  Labels:
-    [tool, agent_name, reason] with reason
-    [room_uninitialized | agent_not_joined]. *)
-val metric_tool_join_required_guard : string
-
 (** Counter for [tool_metrics_persist] write-queue overflow drops. No labels. *)
 val metric_tool_metrics_persist_dropped : string
 

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -558,10 +558,7 @@ let http_status_of_auth_error = function
       | Masc_domain.Task_error.NotClaimed _
       | Masc_domain.Task_error.InvalidState _
       | Masc_domain.Task_error.InvalidId _) -> `Bad_request
-  | Masc_domain.Agent
-      (Masc_domain.Agent_error.NotJoined _
-      | Masc_domain.Agent_error.AlreadyJoined _
-      | Masc_domain.Agent_error.InvalidName _) -> `Bad_request
+  | Masc_domain.Agent (Masc_domain.Agent_error.InvalidName _) -> `Bad_request
   | Masc_domain.Portal _ -> `Bad_request
   | Masc_domain.System _ -> `Bad_request
   | Masc_domain.RateLimitExceeded _ -> `Too_many_requests

--- a/lib/tool_agent.ml
+++ b/lib/tool_agent.ml
@@ -417,8 +417,6 @@ let schemas = Tool_schemas_agent.schemas
 
 let tool_spec_read_only =
   [ "masc_agents"; "masc_agent_card" ]
-let tool_spec_requires_join = []
-
 let tool_required_permission = function
   | "masc_agents" | "masc_agent_fitness" | "masc_agent_card"
   | "masc_get_metrics" ->
@@ -438,7 +436,6 @@ let () =
            ~handler_binding:Tag_dispatch
            ~is_read_only:(List.mem s.name tool_spec_read_only)
            ~is_idempotent:(List.mem s.name tool_spec_read_only)
-           ~requires_join:(List.mem s.name tool_spec_requires_join)
            ?required_permission:(tool_required_permission s.name)
            ()))
     schemas

--- a/lib/tool_broadcast_typed.ml
+++ b/lib/tool_broadcast_typed.ml
@@ -68,5 +68,4 @@ let tool = Typed_tool_masc.create
   ~parse:parse_broadcast
   ~handler:handle_broadcast
   ~encode:encode_broadcast
-  ~requires_join:true
   ()

--- a/lib/tool_capability.ml
+++ b/lib/tool_capability.ml
@@ -3,14 +3,12 @@
 
 type kind =
   | Read_only
-  | Requires_join
   | Mcp_context_required
   | Destructive
   | Idempotent
 
 let to_string = function
   | Read_only -> "read_only"
-  | Requires_join -> "requires_join"
   | Mcp_context_required -> "mcp_context_required"
   | Destructive -> "destructive"
   | Idempotent -> "idempotent"
@@ -18,7 +16,6 @@ let to_string = function
 
 let of_string = function
   | "read_only" -> Some Read_only
-  | "requires_join" -> Some Requires_join
   | "mcp_context_required" -> Some Mcp_context_required
   | "destructive" -> Some Destructive
   | "idempotent" -> Some Idempotent
@@ -26,7 +23,7 @@ let of_string = function
 ;;
 
 let all_kinds =
-  [ Read_only; Requires_join; Mcp_context_required; Destructive; Idempotent ]
+  [ Read_only; Mcp_context_required; Destructive; Idempotent ]
 ;;
 
 module Set = Stdlib.Set.Make (struct
@@ -45,10 +42,6 @@ let rec has kind tool_name =
     (match metadata.readonly, metadata.effect_domain with
      | Some true, _ | _, Some Tool_catalog.Read_only -> true
      | Some false, _ | None, _ -> false)
-  | Requires_join ->
-    (match metadata.requires_join with
-     | Some true -> true
-     | Some false | None -> false)
   | Mcp_context_required ->
     (match metadata.mcp_context_required with
      | Some true -> true

--- a/lib/tool_capability.mli
+++ b/lib/tool_capability.mli
@@ -12,7 +12,6 @@
 
 type kind =
   | Read_only
-  | Requires_join
   | Mcp_context_required
   | Destructive
   | Idempotent

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -82,7 +82,6 @@ type metadata = {
   reason : string option;
   allow_direct_call_when_hidden : bool;
   readonly : bool option;
-  requires_join : bool option;
   mcp_context_required : bool option;
   destructive : bool option;
   idempotent : bool option;
@@ -105,7 +104,6 @@ let default_metadata =
     reason = None;
     allow_direct_call_when_hidden = false;
     readonly = None;
-    requires_join = None;
     mcp_context_required = None;
     destructive = None;
     idempotent = None;
@@ -134,7 +132,6 @@ let hidden_active ?canonical_name ?replacement ?(allow_direct_call_when_hidden =
     reason = Some reason;
     allow_direct_call_when_hidden;
     readonly = None;
-    requires_join = None;
     mcp_context_required = None;
     destructive = None;
     idempotent = None;
@@ -143,16 +140,12 @@ let hidden_active ?canonical_name ?replacement ?(allow_direct_call_when_hidden =
     requires_actor_binding = None;
   }
 
-let with_semantic_flags ?readonly ?requires_join ?mcp_context_required
+let with_semantic_flags ?readonly ?mcp_context_required
     ?destructive ?idempotent ?effect_domain ?requires_actor_binding meta =
   {
     meta with
     readonly =
       (match readonly with Some value -> Some value | None -> meta.readonly);
-    requires_join =
-      (match requires_join with
-      | Some value -> Some value
-      | None -> meta.requires_join);
     mcp_context_required =
       (match mcp_context_required with
       | Some value -> Some value
@@ -213,9 +206,6 @@ let admin_read_tool =
 
 let reset_tool =
   with_required_permission Masc_domain.CanReset destructive_tool
-
-let static_requires_join_tool_names =
-  [ "masc_broadcast" ]
 
 let static_mcp_context_required_tool_names =
   [ "masc_start"
@@ -481,8 +471,6 @@ let attach_inferred_effect_domain name (meta : metadata) =
 let attach_static_capabilities name (meta : metadata) =
   {
     meta with
-    requires_join =
-      force_true_if_member name static_requires_join_tool_names meta.requires_join;
     mcp_context_required =
       force_true_if_member
         name
@@ -626,15 +614,10 @@ let metadata_to_fields name =
         ("toolGroup", `String (tool_group_to_string group)) :: with_effect_domain
     | None -> with_effect_domain
   in
-  let with_requires_join =
-    match meta.requires_join with
-    | Some value -> ("requiresJoin", `Bool value) :: with_tool_group
-    | None -> with_tool_group
-  in
   let with_mcp_context_required =
     match meta.mcp_context_required with
-    | Some value -> ("mcpContextRequired", `Bool value) :: with_requires_join
-    | None -> with_requires_join
+    | Some value -> ("mcpContextRequired", `Bool value) :: with_tool_group
+    | None -> with_tool_group
   in
   let with_actor_binding =
     match meta.requires_actor_binding with
@@ -667,15 +650,10 @@ let public_contract_fields name =
     | Some value -> ("requiresActorBinding", `Bool value) :: with_effect_domain
     | None -> with_effect_domain
   in
-  let with_requires_join =
-    match meta.requires_join with
-    | Some value -> ("requiresJoin", `Bool value) :: with_actor_binding
-    | None -> with_actor_binding
-  in
   let with_mcp_context_required =
     match meta.mcp_context_required with
-    | Some value -> ("mcpContextRequired", `Bool value) :: with_requires_join
-    | None -> with_requires_join
+    | Some value -> ("mcpContextRequired", `Bool value) :: with_actor_binding
+    | None -> with_actor_binding
   in
   match meta.canonical_name with
   | Some canonical_name -> ("canonicalName", `String canonical_name) :: with_mcp_context_required

--- a/lib/tool_catalog.mli
+++ b/lib/tool_catalog.mli
@@ -43,7 +43,6 @@ type metadata = {
   reason : string option;
   allow_direct_call_when_hidden : bool;
   readonly : bool option;
-  requires_join : bool option;
   mcp_context_required : bool option;
   destructive : bool option;
   idempotent : bool option;

--- a/lib/tool_coord.ml
+++ b/lib/tool_coord.ml
@@ -632,47 +632,32 @@ let handle_reset ~tool_name ~start_time ctx args =
 (* ── State inspection (shared by status and check) ──────── *)
 
 type agent_state =
-  { room_set : bool
-  ; joined : bool
-  ; task_claimed : bool
+  { task_claimed : bool
   ; current_task_set : bool
   }
 
 let inspect_state ctx =
-  let room_set = Coord.is_initialized ctx.config in
-  let joined =
-    if room_set
-    then (
-      try Coord.is_agent_joined ctx.config ~agent_name:ctx.agent_name with
-      | Sys_error _ | Yojson.Json_error _ -> false)
-    else false
-  in
   let binding =
-    if joined
-    then (
-      let actual_name = safe_resolve_agent_name ctx ~joined in
-      let matches_you assignee =
-        String.equal assignee ctx.agent_name || String.equal assignee actual_name
-      in
-      let assigned_task_ids =
-        Coord.get_tasks_raw ctx.config
-        |> Coord_status_rendering.assigned_task_ids ~matches_you
-      in
-      resolve_current_binding
-        ~assigned_task_ids
-        ~planning_current:(safe_current_task ctx ~joined))
-    else resolve_current_binding ~assigned_task_ids:[] ~planning_current:None
+    let actual_name = safe_resolve_agent_name ctx ~joined:true in
+    let matches_you assignee =
+      String.equal assignee ctx.agent_name || String.equal assignee actual_name
+    in
+    let assigned_task_ids =
+      Coord.get_tasks_raw ctx.config
+      |> Coord_status_rendering.assigned_task_ids ~matches_you
+    in
+    resolve_current_binding
+      ~assigned_task_ids
+      ~planning_current:(safe_current_task ctx ~joined:true)
   in
   let task_claimed = Stdlib.List.length binding.assigned_task_ids > 0 in
   let current_task_set = binding.current_task_set in
-  { room_set; joined; task_claimed; current_task_set }
+  { task_claimed; current_task_set }
 ;;
 
 let state_to_json st =
   `Assoc
-    [ "room_set", `Bool st.room_set
-    ; "joined", `Bool st.joined
-    ; "task_claimed", `Bool st.task_claimed
+    [ "task_claimed", `Bool st.task_claimed
     ; "current_task_set", `Bool st.current_task_set
     ; "session_active", `Bool false
     ]
@@ -730,9 +715,7 @@ let dispatch ctx ~name ~args : Tool_result.result option =
   | "masc_check" ->
     let inspect ctx =
       let s = inspect_state ctx in
-      { Coord_assertions.room_set = s.room_set
-      ; joined = s.joined
-      ; task_claimed = s.task_claimed
+      { Coord_assertions.task_claimed = s.task_claimed
       ; current_task_set = s.current_task_set
       }
     in
@@ -755,8 +738,6 @@ let schemas = Tool_schemas_coord.schemas
 let tool_spec_read_only = [ "masc_status"; "masc_goal_list" ];;
 
 let tool_spec_system_internal = [ "masc_reset" ]
-let tool_spec_requires_join = [ "masc_heartbeat" ]
-
 let tool_required_permission = function
   | "masc_status"
   | "masc_check"
@@ -779,7 +760,6 @@ let () =
             ~module_tag:Tool_dispatch.Mod_room
             ~input_schema:s.input_schema
             ~handler_binding:Tag_dispatch
-            ~requires_join:(List.mem s.name tool_spec_requires_join)
             ~is_read_only:(List.mem s.name tool_spec_read_only)
             ~is_idempotent:(List.mem s.name tool_spec_read_only)
             ~visibility:(if is_system then Tool_catalog.Hidden else Tool_catalog.Default)

--- a/lib/tool_coord.mli
+++ b/lib/tool_coord.mli
@@ -70,12 +70,8 @@ val all_assertion_kinds : assertion_kind list
     constructor automatically updates this list. *)
 val valid_assertion_strings : string list
 
-(** [assertion_kind_of_string_lenient s] parses a permissive
-    label form (case-insensitive, allows variants like
-    ["room_set"] / ["roomSet"] / ["room"]).  Returns [None] on
-    unknown.  Lenient parsing is intentional for human-typed
-    governance commands; drift to strict matching would break
-    operator UX. *)
+(** [assertion_kind_of_string_lenient s] parses a canonical assertion label.
+    Returns [None] on unknown. *)
 val assertion_kind_of_string_lenient : string -> assertion_kind option
 
 (** {1 Dispatch} *)

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -352,8 +352,6 @@ let inline_tool_required_permission name : Masc_domain.permission option =
 let inline_tool_read_only =
   [ "masc_messages"; "masc_approval_get"; "masc_approval_pending" ]
 
-let inline_tool_requires_join = [ "masc_broadcast" ]
-
 let inline_tool_requires_actor_binding = []
 
 let inline_tool_mcp_context_required =
@@ -383,7 +381,6 @@ let () =
            ~handler_binding:Tag_dispatch
            ~is_read_only
            ~is_idempotent:is_read_only
-           ~requires_join:(List.mem name inline_tool_requires_join)
            ~mcp_context_required:(List.mem name inline_tool_mcp_context_required)
            ~requires_actor_binding:(List.mem name inline_tool_requires_actor_binding)
            ~effect_domain:(inline_tool_effect_domain name)

--- a/lib/tool_operator.ml
+++ b/lib/tool_operator.ml
@@ -354,8 +354,6 @@ let remote_tool_names : string list =
 (* ================================================================ *)
 
 let tool_spec_read_only = [ "masc_operator_snapshot"; "masc_operator_digest"; "masc_surface_audit" ]
-let tool_spec_requires_join = [ "masc_operator_action"; "masc_operator_confirm" ]
-
 (* Tools with explicit catalog metadata that must be preserved. *)
 let tool_spec_hidden = [ "masc_operator_judgment_write"; "masc_surface_audit" ]
 let tool_spec_hidden_destructive = [ "masc_operator_action" ]
@@ -383,7 +381,6 @@ let () =
            ~handler_binding:Tag_dispatch
            ~is_read_only:(List.mem s.name tool_spec_read_only)
            ~is_idempotent:(List.mem s.name tool_spec_read_only)
-           ~requires_join:(List.mem s.name tool_spec_requires_join)
            ~visibility:(if is_hidden then Tool_catalog.Hidden else Tool_catalog.Default)
            ~is_destructive
            ~allow_direct_call_when_hidden:is_hidden

--- a/lib/tool_plan.ml
+++ b/lib/tool_plan.ml
@@ -228,8 +228,6 @@ let dispatch ctx ~name ~args : Tool_result.result option =
 (* ================================================================ *)
 
 let tool_spec_read_only = [ "masc_plan_get" ]
-let tool_spec_requires_join = [ "masc_plan_set_task"; "masc_plan_clear_task" ]
-
 let tool_required_permission = function
   | "masc_plan_get" | "masc_plan_get_task" ->
       Some Masc_domain.CanReadState
@@ -266,7 +264,6 @@ let () =
              ~handler_binding:Tag_dispatch
              ~is_read_only:(List.mem s.name tool_spec_read_only)
              ~is_idempotent:(List.mem s.name tool_spec_read_only)
-             ~requires_join:(List.mem s.name tool_spec_requires_join)
              ?required_permission:(tool_required_permission s.name)
              ()))
     Tool_schemas_misc.schemas

--- a/lib/tool_schemas/tool_schemas_coord_core.ml
+++ b/lib/tool_schemas/tool_schemas_coord_core.ml
@@ -15,7 +15,7 @@ open Masc_domain
     compilation in [assertion_kind_to_string] AND fails the test here,
     instead of silently dropping from the JSON Schema. *)
 let assertion_kind_enum_strings =
-  [ "room_set"; "joined"; "task_claimed"; "current_task_set" ]
+  [ "task_claimed"; "current_task_set" ]
 
 let schemas : tool_schema list = [
   {
@@ -49,7 +49,7 @@ Requires confirm=true to execute. Example: masc_reset({confirm: true})";
   };
   {
     name = "masc_check";
-    description = "Assert preconditions on your agent state (joined, task claimed, current task set, etc). \
+    description = "Assert task preconditions on your agent state (task claimed, current task set, etc). \
 Call when you want to confirm prerequisites before starting work; returns pass/fail with fix hints.";
     input_schema = `Assoc [
       ("type", `String "object");
@@ -62,7 +62,7 @@ Call when you want to confirm prerequisites before starting work; returns pass/f
              `List
                (List.map (fun s -> `String s) assertion_kind_enum_strings));
           ]);
-          ("description", `String "List of state assertions to check. Each returns true/false with a fix hint if false. Canonical readiness key is 'room_set'.");
+          ("description", `String "List of task-state assertions to check. Each returns true/false with a fix hint if false.");
         ]);
       ]);
       ("required", `List [`String "assertions"]);

--- a/lib/tool_spec.ml
+++ b/lib/tool_spec.ml
@@ -33,7 +33,6 @@ type t = {
   module_tag : Tool_dispatch.module_tag;
   handler_binding : handler_binding;
   is_read_only : bool;
-  requires_join : bool;
   mcp_context_required : bool;
   is_destructive : bool;
   is_idempotent : bool;
@@ -60,7 +59,6 @@ let create
     ~input_schema
     ~handler_binding
     ?(is_read_only = false)
-    ?(requires_join = false)
     ?(mcp_context_required = false)
     ?(is_destructive = false)
     ?(is_idempotent = false)
@@ -76,7 +74,7 @@ let create
     ?requires_actor_binding
     () =
   { name; description; module_tag; input_schema; handler_binding;
-    is_read_only; requires_join; mcp_context_required; is_destructive; is_idempotent;
+    is_read_only; mcp_context_required; is_destructive; is_idempotent;
     visibility; implementation_status;
     canonical_name; replacement; reason;
     allow_direct_call_when_hidden; title; required_permission; effect_domain;
@@ -126,7 +124,6 @@ let register (spec : t) =
   let requires_actor_binding =
     match spec.requires_actor_binding with
     | Some _ as value -> value
-    | None when spec.requires_join -> Some true
     | None ->
         Option.bind existing (fun (meta : Tool_catalog.metadata) ->
           meta.requires_actor_binding)
@@ -147,7 +144,6 @@ let register (spec : t) =
       reason = spec.reason;
       allow_direct_call_when_hidden = effective_allow_direct;
       readonly = Some spec.is_read_only;
-      requires_join = Some spec.requires_join;
       mcp_context_required = Some spec.mcp_context_required;
       destructive = Some spec.is_destructive;
       idempotent = Some spec.is_idempotent;

--- a/lib/tool_spec.mli
+++ b/lib/tool_spec.mli
@@ -36,7 +36,6 @@ type t = {
   module_tag : Tool_dispatch.module_tag;
   handler_binding : handler_binding;
   is_read_only : bool;
-  requires_join : bool;
   mcp_context_required : bool;
   is_destructive : bool;
   is_idempotent : bool;
@@ -61,7 +60,6 @@ val create :
   input_schema:Yojson.Safe.t ->
   handler_binding:handler_binding ->
   ?is_read_only:bool ->
-  ?requires_join:bool ->
   ?mcp_context_required:bool ->
   ?is_destructive:bool ->
   ?is_idempotent:bool ->

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -702,8 +702,6 @@ let dispatch ?agent_tool_names ctx ~name ~args : Tool_result.result option =
 (* ================================================================ *)
 
 let tool_spec_read_only = [ "masc_task_history"; "masc_tasks" ]
-let tool_spec_requires_join = [ "masc_claim_next"; "masc_transition" ]
-
 let tool_required_permission = function
   | "masc_tasks" | "masc_task_history" ->
       Some Masc_domain.CanReadState
@@ -727,7 +725,6 @@ let () =
            ~handler_binding:Tag_dispatch
            ~is_read_only:(List.mem s.name tool_spec_read_only)
            ~is_idempotent:(List.mem s.name tool_spec_read_only)
-           ~requires_join:(List.mem s.name tool_spec_requires_join)
            ?required_permission:(tool_required_permission s.name)
            ()))
     schemas

--- a/lib/tool_unified.ml
+++ b/lib/tool_unified.ml
@@ -21,7 +21,7 @@ module Float = Stdlib.Float
     - Tool_catalog: visibility, lifecycle, metadata
     - Tool_registry: call statistics (count, success, failure, duration)
     - Tool_dispatch: registration status
-    - Tool_capability: read_only, join_required
+    - Tool_capability: read_only
 *)
 
 type tool_info = {
@@ -30,7 +30,6 @@ type tool_info = {
   lifecycle : Tool_catalog.lifecycle;
   is_registered : bool;
   is_read_only : bool;
-  is_join_required : bool;
   call_stats : Tool_registry.call_stats option;
 }
 
@@ -46,7 +45,6 @@ let tool_info name : tool_info =
     lifecycle = meta.lifecycle;
     is_registered = Tool_dispatch.is_registered name;
     is_read_only = Tool_capability.has Tool_capability.Read_only name;
-    is_join_required = Tool_capability.has Tool_capability.Requires_join name;
     call_stats = stats;
   }
 
@@ -72,7 +70,6 @@ let tool_info_to_json (info : tool_info) : Yojson.Safe.t =
     ("lifecycle", `String (Tool_catalog.lifecycle_to_string info.lifecycle));
     ("is_registered", `Bool info.is_registered);
     ("is_read_only", `Bool info.is_read_only);
-    ("is_join_required", `Bool info.is_join_required);
     ("call_stats", stats_json);
   ]
 

--- a/lib/tool_unified.mli
+++ b/lib/tool_unified.mli
@@ -5,7 +5,7 @@
     Combines:
     - {!Tool_catalog}: visibility, lifecycle, metadata
     - {!Tool_registry}: call statistics (count, success, failure, duration)
-    - {!Tool_dispatch}: registration status, read-only, join-required *)
+    - {!Tool_dispatch}: registration status, read-only *)
 
 (** {1 Types} *)
 
@@ -15,7 +15,6 @@ type tool_info = {
   lifecycle : Tool_catalog.lifecycle;
   is_registered : bool;
   is_read_only : bool;
-  is_join_required : bool;
   call_stats : Tool_registry.call_stats option;
 }
 

--- a/lib/typed_tool_masc.ml
+++ b/lib/typed_tool_masc.ml
@@ -9,18 +9,17 @@ type ('input, 'output) t = {
   is_destructive : bool;
   is_idempotent : bool;
   visibility : Tool_catalog.visibility;
-  requires_join : bool;
   effect_domain : Tool_catalog.effect_domain option;
 }
 
 let create ~name ~description ~module_tag ~params ~parse ~handler ~encode
     ?(is_read_only = false) ?(is_destructive = false) ?(is_idempotent = false)
-    ?(visibility = Tool_catalog.Default) ?(requires_join = false)
+    ?(visibility = Tool_catalog.Default)
     ?effect_domain () =
   let oas_tool = Agent_sdk.Typed_tool.create
     ~name ~description ~params ~parse ~handler ~encode () in
   { oas_tool; module_tag; is_read_only; is_destructive;
-    is_idempotent; visibility; requires_join; effect_domain }
+    is_idempotent; visibility; effect_domain }
 
 (** Build a dispatch handler for the typed tool.
     The handler is registered via [Tool_spec.Direct] for a specific tool name,
@@ -77,7 +76,6 @@ let to_spec tool =
     ~is_destructive:tool.is_destructive
     ~is_idempotent:tool.is_idempotent
     ~visibility:tool.visibility
-    ~requires_join:tool.requires_join
     ?effect_domain:tool.effect_domain
     ()
 

--- a/lib/typed_tool_masc.mli
+++ b/lib/typed_tool_masc.mli
@@ -26,7 +26,6 @@ val create :
   ?is_destructive:bool ->
   ?is_idempotent:bool ->
   ?visibility:Tool_catalog.visibility ->
-  ?requires_join:bool ->
   ?effect_domain:Tool_catalog.effect_domain ->
   unit ->
   ('input, 'output) t

--- a/lib/types/masc_error.ml
+++ b/lib/types/masc_error.ml
@@ -112,15 +112,10 @@ end
 module Agent_error = struct
   type t =
     | NotFound of string
-    | NotJoined of string
-    | AlreadyJoined of string
     | InvalidName of string
 
   let to_string = function
     | NotFound name -> Printf.sprintf "[AgentError] Agent not found: %s" name
-    | NotJoined name ->
-        Printf.sprintf "[AgentError] Agent not joined: %s. Use masc_start first." name
-    | AlreadyJoined name -> Printf.sprintf "[AgentError] Agent already joined: %s" name
     | InvalidName reason -> Printf.sprintf "[AgentError] Invalid agent name: %s" reason
 end
 
@@ -241,9 +236,7 @@ let code = function
          | Task_error.NotClaimed _
          | Task_error.InvalidState _
          | Task_error.InvalidId _) -> 400
-  | Agent (Agent_error.NotJoined _
-          | Agent_error.AlreadyJoined _
-          | Agent_error.InvalidName _) -> 400
+  | Agent (Agent_error.InvalidName _) -> 400
   | Portal (Portal_error.NotOpen _
            | Portal_error.AlreadyOpen _
            | Portal_error.Closed _) -> 400

--- a/lib/types/masc_error.mli
+++ b/lib/types/masc_error.mli
@@ -28,8 +28,6 @@ end
 module Agent_error : sig
   type t =
     | NotFound of string
-    | NotJoined of string
-    | AlreadyJoined of string
     | InvalidName of string
   val to_string : t -> string
 end


### PR DESCRIPTION
## Summary
- remove requires_join capability/metadata plumbing and public contract fields
- remove join-required execute-time guard, auto-bind path, and related metric
- remove room_set/joined assertions and NotJoined/AlreadyJoined agent errors

## Validation
- targeted residue scan for removed guard/tool identifiers only
- build not run (deletion-first cleanup; build may break)