### PR TITLE
Rename joined agent state surfaces

### DIFF
--- a/lib/activity_graph/activity_graph.ml
+++ b/lib/activity_graph/activity_graph.ml
@@ -628,7 +628,7 @@ let graph_json config ?(kinds = []) ?(limit = 500)
 (* Span start events paired with their matching end events *)
 let span_start_kind = function
   | "task.claimed" | "task.started" -> Some "task"
-  | "agent.joined" -> Some "presence"
+  | "agent.session_bound" -> Some "presence"
   | "operation.started" -> Some "operation"
   | "keeper.autonomy_started" -> Some "autonomy"
   | _ -> None

--- a/lib/activity_graph/activity_graph_reducer.ml
+++ b/lib/activity_graph/activity_graph_reducer.ml
@@ -51,7 +51,7 @@ let semantic_multiplier = function
   | "board.commented" | "decision.voted" -> 1.0
   | "operation.started" | "operation.resumed" -> 1.0
   | "policy.approved" | "policy.denied" -> 2.0
-  | "agent.joined" | "agent.left" -> 0.5
+  | "agent.session_bound" | "agent.left" -> 0.5
   | "agent.retired" | "agent.compacted" -> 0.5
   | "keeper.compaction" | "keeper.guardrail" -> 0.5
   | "keeper.autonomy_started" | "keeper.autonomy_completed" -> 1.5
@@ -168,7 +168,7 @@ let reduce_event ~nodes ~edges (value : event) =
     | None -> ()
   in
   (match value.kind with
-  | "agent.joined" -> set_subject_status Active
+  | "agent.session_bound" -> set_subject_status Active
   | "agent.left" -> set_subject_status Offline
   | "agent.spawned" -> set_subject_status Spawned
   | "agent.retired" -> set_subject_status Retired

--- a/lib/ag_ui/ag_ui.ml
+++ b/lib/ag_ui/ag_ui.ml
@@ -129,11 +129,11 @@ let event_to_sse (e : event) : string =
 (** Default thread ID for the single-namespace AG-UI bridge. *)
 let default_thread_id = "default"
 
-(** Map MASC agent_joined to AG-UI RUN_STARTED *)
-let of_agent_joined ~agent_name : event =
+(** Map MASC agent_session_bound to AG-UI RUN_STARTED *)
+let of_agent_session_bound ~agent_name : event =
   make_event ~thread_id:default_thread_id
     ~run_id:(Some agent_name)
-    ~custom_name:(Some "AGENT_JOINED")
+    ~custom_name:(Some "AGENT_SESSION_BOUND")
     ~custom_value:(Some (`Assoc [("agent", `String agent_name)]))
     Run_started
 

--- a/lib/ag_ui/ag_ui.mli
+++ b/lib/ag_ui/ag_ui.mli
@@ -87,8 +87,8 @@ val event_to_sse : event -> string
 val default_thread_id : string
 (** Thread ID used by the single-namespace MASC bridge (["default"]). *)
 
-val of_agent_joined : agent_name:string -> event
-(** [agent_joined] → [Run_started] with [custom_name="AGENT_JOINED"]. *)
+val of_agent_session_bound : agent_name:string -> event
+(** [agent_session_bound] → [Run_started] with [custom_name="AGENT_SESSION_BOUND"]. *)
 
 val of_agent_left : agent_name:string -> event
 (** [agent_left] → [Run_finished] with [custom_name="AGENT_LEFT"]. *)

--- a/lib/briefing_compactors/briefing_compactors.ml
+++ b/lib/briefing_compactors/briefing_compactors.ml
@@ -176,7 +176,7 @@ let compact_agent_json (agent : Masc_domain.agent) =
       ("assignment_status", `String (if current_focus = "unassigned" then "unassigned" else "assigned"));
       ("current_focus", `String current_focus);
       ("goal_hint", `String current_focus);
-      ("joined_at", `String agent.joined_at);
+      ("session_bound_at", `String agent.session_bound_at);
       ("last_seen", `String agent.last_seen);
       ("capabilities", `List (List.map (fun item -> `String item) (take 2 agent.capabilities)));
     ]

--- a/lib/coord.ml
+++ b/lib/coord.ml
@@ -205,7 +205,7 @@ let observe_agent_lifecycle
       match event with
       | Session_ended -> Telemetry_eio.track_agent_left config ~agent_id ~reason:"session_ended"
       | Session_bound | Session_rebound ->
-        Telemetry_eio.track_agent_joined config ~agent_id ())
+        Telemetry_eio.track_agent_session_bound config ~agent_id ())
   with
   | Stdlib.Effect.Unhandled _ as exn ->
     let lifecycle_kind : Coord_telemetry_drop_event.lifecycle_kind =

--- a/lib/coord/coord_init.mli
+++ b/lib/coord/coord_init.mli
@@ -9,7 +9,7 @@ open Coord_utils
 open Coord_state
 open Coord_broadcast
 
-(** Initialise room state; auto-joins [agent_name] when given. *)
+(** Initialise room state; session-binds [agent_name] when given. *)
 val init :
   Coord_utils_backend_setup.config -> agent_name:'a option -> string
 

--- a/lib/coord/coord_lifecycle.ml
+++ b/lib/coord/coord_lifecycle.ml
@@ -159,7 +159,7 @@ let bind_session config ~agent_name ?(agent_type_override=None) ~capabilities
     status = Active;
     capabilities;
     current_task = None;
-    joined_at = now_iso ();
+    session_bound_at = now_iso ();
     last_seen = now_iso ();
     meta = Some meta;
   } in

--- a/lib/coord/coord_query.ml
+++ b/lib/coord/coord_query.ml
@@ -1,7 +1,7 @@
 (** Coord_query -- Task/agent/message query and listing functions.
 
     Read-only operations on room state: raw list retrieval, orphan auditing,
-    message collection, agent-joined checks, and formatted listing. *)
+    message collection, agent-session-bound checks, and formatted listing. *)
 
 open Masc_domain
 include Coord_utils
@@ -118,7 +118,7 @@ let get_all_agents config =
 let audit_orphan_tasks config : (Masc_domain.task * string) list =
   if not (is_initialized config) then []
   else
-    (* Read agent files from the same path that cleanup_zombies and join use *)
+    (* Read agent files from the same path that cleanup_zombies and session binding use *)
     let agents_path = agents_dir config in
     let active_names =
       load_agents_from_dir config agents_path ~include_inactive:false
@@ -151,8 +151,8 @@ let is_agent_active_at_path config path =
        | Ok agent -> agent.status <> Inactive
        | Error _ -> false)
 
-(** Check if an agent has joined the room *)
-let is_agent_joined config ~agent_name =
+(** Check if an agent has session-bound *)
+let is_agent_session_bound config ~agent_name =
   if not (root_is_initialized config) then false
   else
     let actual_name = resolve_agent_name config agent_name in

--- a/lib/coord/coord_query.mli
+++ b/lib/coord/coord_query.mli
@@ -1,7 +1,7 @@
 (** Coord_query -- Task/agent/message query and listing functions.
 
     Read-only operations on room state: raw list retrieval, orphan
-    auditing, message collection, agent-joined checks, and formatted
+    auditing, message collection, agent-session-bound checks, and formatted
     listing.
 
     Inherits types and helpers from {!Coord_utils} and {!Coord_state}. *)
@@ -42,8 +42,8 @@ val audit_orphan_tasks : config -> (Masc_domain.task * string) list
 
 (** {1 Agent Membership} *)
 
-(** Check if an agent has joined the current room. *)
-val is_agent_joined : config -> agent_name:string -> bool
+(** Check if an agent has an active session the current room. *)
+val is_agent_session_bound : config -> agent_name:string -> bool
 
 (** {1 Messages} *)
 

--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -544,7 +544,7 @@ let agent_json ~(model_map : (string, string) Hashtbl.t) (agent : Masc_domain.ag
     ; "agent_type", `String agent.agent_type
     ; "status", `String (Masc_domain.string_of_agent_status agent.status)
     ; ( "current_task", Json_util.string_opt_to_json agent.current_task )
-    ; "joined_at", `String agent.joined_at
+    ; "session_bound_at", `String agent.session_bound_at
     ; "last_seen", `String agent.last_seen
     ; "capabilities", `List (List.map (fun value -> `String value) agent.capabilities)
     ; "emoji", `String profile.emoji

--- a/lib/dashboard/dashboard_execution_fixture.ml
+++ b/lib/dashboard/dashboard_execution_fixture.ml
@@ -313,7 +313,7 @@ let execution_smoke_fixture_json () =
                 ("agent_type", `String "llama");
                 ("status", `String "busy");
                 ("current_task", `String "Validate local64 swarm role coverage");
-                ("joined_at", `String generated_at);
+                ("session_bound_at", `String generated_at);
                 ("last_seen", `String generated_at);
                 ("capabilities", `List [ `String "manager"; `String "local64" ]);
                 ("emoji", `String "🤖");
@@ -325,7 +325,7 @@ let execution_smoke_fixture_json () =
                 ("agent_type", `String "llama");
                 ("status", `String "active");
                 ("current_task", `String "Inspect secondary runtime health");
-                ("joined_at", `String generated_at);
+                ("session_bound_at", `String generated_at);
                 ("last_seen", `String "2026-03-11T09:15:00Z");
                 ("capabilities", `List [ `String "metacog"; `String "local64" ]);
                 ("emoji", `String "🤖");
@@ -337,7 +337,7 @@ let execution_smoke_fixture_json () =
                 ("agent_type", `String "llama");
                 ("status", `String "idle");
                 ("current_task", `Null);
-                ("joined_at", `String generated_at);
+                ("session_bound_at", `String generated_at);
                 ("last_seen", `String generated_at);
                 ("capabilities", `List [ `String "executor"; `String "local64" ]);
                 ("emoji", `String "🤖");
@@ -349,7 +349,7 @@ let execution_smoke_fixture_json () =
                 ("agent_type", `String "llama");
                 ("status", `String "inactive");
                 ("current_task", `Null);
-                ("joined_at", `String generated_at);
+                ("session_bound_at", `String generated_at);
                 ("last_seen", `String "2026-03-11T08:55:00Z");
                 ("capabilities", `List [ `String "observer"; `String "local64" ]);
                 ("emoji", `String "🤖");

--- a/lib/dashboard/dashboard_http_monitoring.ml
+++ b/lib/dashboard/dashboard_http_monitoring.ml
@@ -276,7 +276,7 @@ let executor_outcomes_json (config : Coord.config) : Yojson.Safe.t =
         incr total;
         if success then incr successes
       | Telemetry_eio.Tool_called _ -> ()
-      | Agent_joined _ | Agent_left _ | Task_started _ | Task_completed _
+      | Agent_session_bound _ | Agent_left _ | Task_started _ | Task_completed _
       | Handoff_triggered _ | Error_occurred _ | Tool_assigned _ -> ()
     ) events;
     `Assoc [

--- a/lib/graphql_api.ml
+++ b/lib/graphql_api.ml
@@ -301,10 +301,10 @@ let agent_typ =
         ~typ:Schema.string
         ~args:Arg.[]
         ~resolve:(fun _ (agent : Masc_domain.agent) -> agent.current_task);
-      Schema.field "joinedAt"
+      Schema.field "sessionBoundAt"
         ~typ:(Schema.non_null Schema.string)
         ~args:Arg.[]
-        ~resolve:(fun _ (agent : Masc_domain.agent) -> agent.joined_at);
+        ~resolve:(fun _ (agent : Masc_domain.agent) -> agent.session_bound_at);
       Schema.field "lastSeen"
         ~typ:(Schema.non_null Schema.string)
         ~args:Arg.[]

--- a/lib/grpc/masc_grpc_service.ml
+++ b/lib/grpc/masc_grpc_service.ml
@@ -133,7 +133,7 @@ let handle_get_status (room_config : Coord_utils_backend_setup.config) (_bytes :
                ; status = status_str
                ; capabilities = agent.capabilities
                ; last_heartbeat_ms = now_ms ()
-               ; joined_at_ms = now_ms ()
+               ; session_bound_at_ms = now_ms ()
                ; current_task_id = Option.value ~default:"" agent.current_task
                }
                : T.agent_info)

--- a/lib/grpc/masc_grpc_types.ml
+++ b/lib/grpc/masc_grpc_types.ml
@@ -49,7 +49,7 @@ type agent_info =
   ; status : string
   ; capabilities : string list
   ; last_heartbeat_ms : int64
-  ; joined_at_ms : int64
+  ; session_bound_at_ms : int64
   ; current_task_id : string
   }
 
@@ -67,7 +67,7 @@ let agent_info_to_proto (a : agent_info) : P.AgentInfo.t =
   ; status = a.status
   ; capabilities = a.capabilities
   ; last_heartbeat_ms = a.last_heartbeat_ms
-  ; joined_at_ms = a.joined_at_ms
+  ; session_bound_at_ms = a.session_bound_at_ms
   ; current_task_id = a.current_task_id
   }
 ;;
@@ -77,7 +77,7 @@ let agent_info_of_proto (p : P.AgentInfo.t) : agent_info =
   ; status = p.status
   ; capabilities = p.capabilities
   ; last_heartbeat_ms = p.last_heartbeat_ms
-  ; joined_at_ms = p.joined_at_ms
+  ; session_bound_at_ms = p.session_bound_at_ms
   ; current_task_id = p.current_task_id
   }
 ;;

--- a/lib/grpc/masc_grpc_types.mli
+++ b/lib/grpc/masc_grpc_types.mli
@@ -14,7 +14,7 @@ type agent_info =
   ; status : string
   ; capabilities : string list
   ; last_heartbeat_ms : int64
-  ; joined_at_ms : int64
+  ; session_bound_at_ms : int64
   ; current_task_id : string
   }
 

--- a/lib/keeper/keeper_deliberation.ml
+++ b/lib/keeper/keeper_deliberation.ml
@@ -14,7 +14,7 @@ type deliberation_trigger =
   | DirectMention
   | NewUnclaimedTask
   | FailedTask
-  | AgentJoinedOrLeft
+  | AgentSessionBoundOrLeft
   | GoalDeadline
   | BoardActivity of string
   | IdleTimeout
@@ -26,7 +26,7 @@ let deliberation_trigger_to_string = function
   | DirectMention -> "direct_mention"
   | NewUnclaimedTask -> "new_unclaimed_task"
   | FailedTask -> "failed_task"
-  | AgentJoinedOrLeft -> "agent_joined_or_left"
+  | AgentSessionBoundOrLeft -> "agent_session_bound_or_left"
   | GoalDeadline -> "goal_deadline"
   | BoardActivity detail -> "board_activity:" ^ detail
   | IdleTimeout -> "idle_timeout"
@@ -203,7 +203,7 @@ let triage (obs : world_observation) : triage_result =
   if obs.direct_mention then add DirectMention;
   if obs.unclaimed_task_count > 0 then add NewUnclaimedTask;
   if obs.failed_task_count > 0 then add FailedTask;
-  if obs.agent_count_changed then add AgentJoinedOrLeft;
+  if obs.agent_count_changed then add AgentSessionBoundOrLeft;
 
   (* L2 Proactive triggers — goal-directed *)
   if obs.board_mention_count > 0 then

--- a/lib/keeper/keeper_deliberation.mli
+++ b/lib/keeper/keeper_deliberation.mli
@@ -9,7 +9,7 @@ type deliberation_trigger =
   | DirectMention
   | NewUnclaimedTask
   | FailedTask
-  | AgentJoinedOrLeft
+  | AgentSessionBoundOrLeft
   | GoalDeadline
   | BoardActivity of string
   | IdleTimeout

--- a/lib/keeper/keeper_status_runtime.ml
+++ b/lib/keeper/keeper_status_runtime.ml
@@ -85,15 +85,15 @@ let parse_agent_status (config : Coord.config) ~(agent_name : string) : Yojson.S
             `Assoc [ ("exists", `Bool true); ("error", `String "failed_to_parse") ]
         | Ok (agent : Masc_domain.agent) ->
             let now_ts = Time_compat.now () in
-            let joined_ts =
-              Coord_resilience.Time.parse_iso8601_opt agent.joined_at
+            let session_bound_ts =
+              Coord_resilience.Time.parse_iso8601_opt agent.session_bound_at
               |> Option.value ~default:0.0
             in
             let last_seen_ts =
               Coord_resilience.Time.parse_iso8601_opt agent.last_seen
               |> Option.value ~default:0.0
             in
-            let age_s = if joined_ts <= 0.0 then 0.0 else now_ts -. joined_ts in
+            let age_s = if session_bound_ts <= 0.0 then 0.0 else now_ts -. session_bound_ts in
             let last_seen_ago_s =
               if last_seen_ts <= 0.0 then 0.0 else now_ts -. last_seen_ts
             in
@@ -106,7 +106,7 @@ let parse_agent_status (config : Coord.config) ~(agent_name : string) : Yojson.S
                 ( "capabilities",
                   `List (List.map (fun s -> `String s) agent.capabilities) );
                 ( "current_task", Json_util.string_opt_to_json agent.current_task );
-                ("joined_at", `String agent.joined_at);
+                ("session_bound_at", `String agent.session_bound_at);
                 ("last_seen", `String agent.last_seen);
                 ("age_s", `Float age_s);
                 ("last_seen_ago_s", `Float last_seen_ago_s);

--- a/lib/mcp_server.ml
+++ b/lib/mcp_server.ml
@@ -508,7 +508,7 @@ let create_state ~base_path =
     net = None;
   } in
   Tool_board.set_agent_lookup (fun name ->
-    try Coord.is_agent_joined state.room_config ~agent_name:name
+    try Coord.is_agent_session_bound state.room_config ~agent_name:name
     with Sys_error _ | Not_found | Invalid_argument _ -> false);
   state
 
@@ -554,7 +554,7 @@ let create_state_eio ~sw ~proc_mgr ~fs ~clock ~mono_clock ~net ~base_path =
   (* Board post kind auto-classification: reads state.room_config so
      room changes via set_room are reflected automatically. *)
   Tool_board.set_agent_lookup (fun name ->
-    try Coord.is_agent_joined state.room_config ~agent_name:name
+    try Coord.is_agent_session_bound state.room_config ~agent_name:name
     with Sys_error _ | Not_found | Invalid_argument _ -> false);
   state
 

--- a/lib/mcp_server_eio_caller_identity.ml
+++ b/lib/mcp_server_eio_caller_identity.ml
@@ -130,7 +130,7 @@ let resolve_auth_fallback_agent_name
           agent_name)
   | _ -> agent_name
 
-let resolve_explicit_joined_alias ~config ~room_initialized ~log_mcp_exn
+let resolve_explicit_bound_alias ~config ~room_initialized ~log_mcp_exn
     ~has_explicit_agent_name agent_name =
   if has_explicit_agent_name && not (Nickname.is_generated_nickname agent_name)
   then (
@@ -139,21 +139,21 @@ let resolve_explicit_joined_alias ~config ~room_initialized ~log_mcp_exn
       try
         if room_initialized () then (
           try
-            if Coord.is_agent_joined config ~agent_name:resolved then
+            if Coord.is_agent_session_bound config ~agent_name:resolved then
               resolved
             else
               agent_name
           with
           | Eio.Cancel.Cancelled _ as e -> raise e
           | exn ->
-              log_mcp_exn ~label:"is_agent_joined" exn;
+              log_mcp_exn ~label:"is_agent_session_bound" exn;
               agent_name)
         else
           agent_name
       with
       | Eio.Cancel.Cancelled _ as e -> raise e
       | exn ->
-          log_mcp_exn ~label:"resolve_explicit_joined_alias" exn;
+          log_mcp_exn ~label:"resolve_explicit_bound_alias" exn;
           agent_name)
     else
       agent_name)
@@ -206,7 +206,7 @@ let resolve ~(config : Coord_utils_backend_setup.config) ~tool_name ~arguments ~
       agent_name
   in
   let agent_name =
-    resolve_explicit_joined_alias ~config ~room_initialized ~log_mcp_exn
+    resolve_explicit_bound_alias ~config ~room_initialized ~log_mcp_exn
       ~has_explicit_agent_name agent_name
   in
   {

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -2,7 +2,7 @@
 
     Extracted from mcp_server_eio.ml.
     Contains the main tool dispatch function that resolves agent identity,
-    checks authorization, auto-joins, and delegates to tool modules.
+    checks authorization, session-binds, and delegates to tool modules.
 *)
 
 let log_mcp_exn = Mcp_server_eio_helpers.log_mcp_exn

--- a/lib/server/server_dashboard_http_core_entities.ml
+++ b/lib/server/server_dashboard_http_core_entities.ml
@@ -61,7 +61,7 @@ let dashboard_agent_json (agent : Masc_domain.agent) =
     ; "keeper_id", Json_util.string_opt_to_json (Option.bind meta (fun m -> m.keeper_id))
     ; "status", `String (Masc_domain.string_of_agent_status agent.status)
     ; "current_task", Json_util.string_opt_to_json agent.current_task
-    ; "joined_at", `String agent.joined_at
+    ; "session_bound_at", `String agent.session_bound_at
     ; "last_seen", `String agent.last_seen
     ; "capabilities", `List (List.map (fun item -> `String item) agent.capabilities)
     ; "emoji", `String profile.emoji

--- a/lib/telemetry_eio.ml
+++ b/lib/telemetry_eio.ml
@@ -25,7 +25,7 @@ let show_error_kind = error_kind_to_string
 
 (** Telemetry event types *)
 type event =
-  | Agent_joined of { agent_id: string; capabilities: string list }
+  | Agent_session_bound of { agent_id: string; capabilities: string list }
   | Agent_left of { agent_id: string; reason: string }
   | Task_started of { task_id: string; agent_id: string }
   | Task_completed of { task_id: string; duration_ms: int; success: bool }
@@ -281,7 +281,7 @@ let summarize_tool_usage ?fs config : tool_usage_summary =
             incr total_calls;
             update_tool_usage stats_by_tool ~tool_name ~success
               ~timestamp:record.timestamp
-        | Agent_joined _ | Agent_left _ | Task_started _ | Task_completed _
+        | Agent_session_bound _ | Agent_left _ | Task_started _ | Task_completed _
         | Handoff_triggered _ | Error_occurred _ | Tool_assigned _ -> ()
       ) records;
       let summary = {
@@ -326,7 +326,7 @@ let summarize_agent_activity ?fs config ~since : agent_activity list =
               last_seen = max current.last_seen record.timestamp;
             }
       | Tool_called { agent_id = None; _ } -> ()
-      | Agent_joined { agent_id; _ } ->
+      | Agent_session_bound { agent_id; _ } ->
           if not (Hashtbl.mem by_agent agent_id) then
             Hashtbl.replace by_agent agent_id
               { agent_id; tool_calls = 0; success_count = 0; failure_count = 0;
@@ -361,20 +361,20 @@ let read_events_since ?fs config ~since : event_record list =
 
 (** Metrics calculation functions (pure) *)
 
-(* [count_active_agents] = joined \ left,
+(* [count_active_agents] = session_bound \ left,
    [count_tasks_in_progress] = started \ completed.
    Kernel lives in [Set_util.count_difference] (lib/core/set_util.ml). *)
 let count_active_agents events =
   Set_util.count_difference events
     ~present:(fun r ->
       match r.event with
-      | Agent_joined { agent_id; _ } -> Some agent_id
+      | Agent_session_bound { agent_id; _ } -> Some agent_id
       | Agent_left _ | Task_started _ | Task_completed _ | Handoff_triggered _
       | Error_occurred _ | Tool_called _ | Tool_assigned _ -> None)
     ~absent:(fun r ->
       match r.event with
       | Agent_left { agent_id; _ } -> Some agent_id
-      | Agent_joined _ | Task_started _ | Task_completed _ | Handoff_triggered _
+      | Agent_session_bound _ | Task_started _ | Task_completed _ | Handoff_triggered _
       | Error_occurred _ | Tool_called _ | Tool_assigned _ -> None)
 
 let count_tasks_in_progress events =
@@ -382,19 +382,19 @@ let count_tasks_in_progress events =
     ~present:(fun r ->
       match r.event with
       | Task_started { task_id; _ } -> Some task_id
-      | Agent_joined _ | Agent_left _ | Task_completed _ | Handoff_triggered _
+      | Agent_session_bound _ | Agent_left _ | Task_completed _ | Handoff_triggered _
       | Error_occurred _ | Tool_called _ | Tool_assigned _ -> None)
     ~absent:(fun r ->
       match r.event with
       | Task_completed { task_id; _ } -> Some task_id
-      | Agent_joined _ | Agent_left _ | Task_started _ | Handoff_triggered _
+      | Agent_session_bound _ | Agent_left _ | Task_started _ | Handoff_triggered _
       | Error_occurred _ | Tool_called _ | Tool_assigned _ -> None)
 
 let count_completed_tasks events =
   List_util.count_if (fun r ->
     match r.event with
     | Task_completed _ -> true
-    | Agent_joined _ | Agent_left _ | Task_started _ | Handoff_triggered _
+    | Agent_session_bound _ | Agent_left _ | Task_started _ | Handoff_triggered _
     | Error_occurred _ | Tool_called _ | Tool_assigned _ -> false
   ) events
 
@@ -402,7 +402,7 @@ let avg_duration events =
   let durations = List.filter_map (fun r ->
     match r.event with
     | Task_completed { duration_ms; _ } -> Some (float_of_int duration_ms)
-    | Agent_joined _ | Agent_left _ | Task_started _ | Handoff_triggered _
+    | Agent_session_bound _ | Agent_left _ | Task_started _ | Handoff_triggered _
     | Error_occurred _ | Tool_called _ | Tool_assigned _ -> None
   ) events in
   match durations with
@@ -415,13 +415,13 @@ let calculate_handoff_rate events =
   let handoffs = List_util.count_if (fun r ->
     match r.event with
     | Handoff_triggered _ -> true
-    | Agent_joined _ | Agent_left _ | Task_started _ | Task_completed _
+    | Agent_session_bound _ | Agent_left _ | Task_started _ | Task_completed _
     | Error_occurred _ | Tool_called _ | Tool_assigned _ -> false
   ) events in
   let task_events = List_util.count_if (fun r ->
     match r.event with
     | Task_started _ | Task_completed _ -> true
-    | Agent_joined _ | Agent_left _ | Handoff_triggered _ | Error_occurred _
+    | Agent_session_bound _ | Agent_left _ | Handoff_triggered _ | Error_occurred _
     | Tool_called _ | Tool_assigned _ -> false
   ) events in
   if task_events = 0 then 0.0
@@ -431,7 +431,7 @@ let calculate_error_rate events =
   let errors = List_util.count_if (fun r ->
     match r.event with
     | Error_occurred _ -> true
-    | Agent_joined _ | Agent_left _ | Task_started _ | Task_completed _
+    | Agent_session_bound _ | Agent_left _ | Task_started _ | Task_completed _
     | Handoff_triggered _ | Tool_called _ | Tool_assigned _ -> false
   ) events in
   let total = List.length events in
@@ -453,8 +453,8 @@ let get_metrics ?fs config : metrics =
   }
 
 (** Convenience tracking functions *)
-let track_agent_joined ?fs config ~agent_id ?(capabilities=[]) () =
-  track ?fs config (Agent_joined { agent_id; capabilities })
+let track_agent_session_bound ?fs config ~agent_id ?(capabilities=[]) () =
+  track ?fs config (Agent_session_bound { agent_id; capabilities })
 
 let track_agent_left ?fs config ~agent_id ~reason =
   track ?fs config (Agent_left { agent_id; reason })

--- a/lib/telemetry_eio.mli
+++ b/lib/telemetry_eio.mli
@@ -34,7 +34,7 @@ val error_kind_of_string : string -> error_kind
 val error_kind_to_string : error_kind -> string
 
 type event =
-  | Agent_joined of { agent_id : string; capabilities : string list }
+  | Agent_session_bound of { agent_id : string; capabilities : string list }
   | Agent_left of { agent_id : string; reason : string }
   | Task_started of { task_id : string; agent_id : string }
   | Task_completed of {
@@ -153,7 +153,7 @@ val calculate_error_rate : event_record list -> float
 
 (** {1 Convenience emitters} *)
 
-val track_agent_joined :
+val track_agent_session_bound :
   ?fs:'a ->
   config ->
   agent_id:string ->

--- a/lib/tool_agent_timeline.ml
+++ b/lib/tool_agent_timeline.ml
@@ -21,7 +21,7 @@ module Float = Stdlib.Float
     a single chronological timeline for a given agent.
 
     Data sources:
-    - Agent join status (Coord.get_agents_raw)
+    - Agent session status (Coord.get_agents_raw)
     - Task state transitions (Coord.get_tasks_raw)
     - Broadcast messages (Coord.get_messages_raw)
 *)
@@ -106,20 +106,20 @@ let event_to_json (e : timeline_event) : Yojson.Safe.t =
       ("detail", e.detail);
     ]
 
-(* Collect agent join/status events *)
+(* Collect agent session/status events *)
 let agent_events (config : Coord.config) ~agent_name :
     timeline_event list =
   let agents = Coord.get_active_agents config in
   agents
   |> List.filter (fun (a : Masc_domain.agent) -> String.equal a.name agent_name)
   |> List.filter_map (fun (a : Masc_domain.agent) ->
-         match parse_iso_timestamp a.joined_at with
+         match parse_iso_timestamp a.session_bound_at with
          | Some ts ->
              Some
                {
                  ts;
-                 ts_iso = a.joined_at;
-                 event_type = "joined";
+                 ts_iso = a.session_bound_at;
+                 event_type = "session_bound";
                  detail =
                    `Assoc
                      [

--- a/lib/tool_board.mli
+++ b/lib/tool_board.mli
@@ -5,7 +5,7 @@
     - the {b agent-lookup callback} ({!set_agent_lookup} /
       {!set_agent_lookup_none} / {!is_agent}) wired at
       server bootstrap so post-kind classification can ask
-      whether a name is currently joined to the room,
+      whether a name is currently bound to the namespace,
     - the {b post / comment / vote handlers} routed
       through {!handle_tool} (one entry per
       [masc_board_*] tool name),
@@ -109,7 +109,7 @@ val visibility_of_string : string -> Board.visibility option
 (** {1 Agent lookup callback} *)
 
 val set_agent_lookup : (string -> bool) -> unit
-(** Wires the [is_agent_joined] check used by the
+(** Wires the [is_agent_session_bound] check used by the
     auto-classifier to decide whether a [system_*] author
     name resolves to a live agent.  Installed once at
     server bootstrap from [server_state.room_config]. *)

--- a/lib/tool_board_handlers.ml
+++ b/lib/tool_board_handlers.ml
@@ -30,7 +30,7 @@ open Tool_args
 
 (** {1 Agent lookup callback} *)
 
-(** Set once at server startup with the real [Coord.is_agent_joined]
+(** Set once at server startup with the real [Coord.is_agent_session_bound]
     check so that board posts are auto-classified without requiring
     callers to pass config or post_kind. *)
 let agent_lookup_hook : (string -> bool) option Atomic.t = Atomic.make None
@@ -39,7 +39,7 @@ let set_agent_lookup f = Atomic.set agent_lookup_hook (Some f)
 let set_agent_lookup_none () = Atomic.set agent_lookup_hook None
 
 (** Check whether [name] is a registered agent. Uses the registry
-    lookup ([Coord.is_agent_joined]) when available via
+    lookup ([Coord.is_agent_session_bound]) when available via
     [agent_lookup_hook]; returns [false] when no hook is installed. *)
 let is_agent name =
   match Atomic.get agent_lookup_hook with

--- a/lib/tool_coord.ml
+++ b/lib/tool_coord.ml
@@ -17,7 +17,7 @@ module Float = Stdlib.Float
 
 (** Tool_coord - Coord management operations
     Handles: status, reset, init, check
-    Note: join, leave, set_room, who require state/registry and remain in mcp_server_eio.ml
+    Note: stateful coord helpers remain in server dispatch modules
 *)
 
 open Coord_types
@@ -32,8 +32,6 @@ type context = Coord_types.context =
   }
 
 type assertion_kind = Coord_assertions.assertion_kind =
-  | Room_set
-  | Joined
   | Task_claimed
   | Current_task_set
 
@@ -161,8 +159,8 @@ let credential_state (ctx : context) ~actual_name =
    share the single-warn-arm shape; [Eio.Cancel.Cancelled] is re-raised
    explicitly so cancellation propagation is preserved across all of
    them. *)
-let safe_resolve_agent_name (ctx : context) ~joined =
-  if not joined
+let safe_resolve_agent_name (ctx : context) ~session_bound =
+  if not session_bound
   then ctx.agent_name
   else (
     try Coord.resolve_agent_name ctx.config ctx.agent_name with
@@ -175,8 +173,8 @@ let safe_resolve_agent_name (ctx : context) ~joined =
       ctx.agent_name)
 ;;
 
-let safe_current_task (ctx : context) ~joined =
-  if not joined
+let safe_current_task (ctx : context) ~session_bound =
+  if not session_bound
   then None
   else (
     try Planning_eio.get_current_task ctx.config with
@@ -319,28 +317,28 @@ let status_summary_string (ctx : context) =
   Coord.ensure_initialized ctx.config;
   let state = Coord.read_state ctx.config in
   let backlog = safe_read_backlog ctx in
-  let joined =
+  let session_bound =
     (* status_summary_string is read-only on the coord file; a missing
-       or malformed file is treated as "not joined" because that's the
+       or malformed file is treated as "session not bound" because that's the
        most useful default for status rendering. But the silent path
-       hid an operationally meaningful failure (file missing post-join,
+       hid an operationally meaningful failure (file missing after session bind,
        config corrupted) — surface it via warn while keeping the
        [false] default. *)
-    try Coord.is_agent_joined ctx.config ~agent_name:ctx.agent_name with
+    try Coord.is_agent_session_bound ctx.config ~agent_name:ctx.agent_name with
     | Eio.Cancel.Cancelled _ as e -> raise e
     | exn ->
       Log.Coord.warn
-        "is_agent_joined failed for %s: %s"
+        "is_agent_session_bound failed for %s: %s"
         ctx.agent_name
         (Stdlib.Printexc.to_string exn);
       false
   in
-  let actual_name = safe_resolve_agent_name ctx ~joined in
+  let actual_name = safe_resolve_agent_name ctx ~session_bound in
   let credential_state = credential_state ctx ~actual_name in
   let credential_blocked =
     credential_state.credential_required && not credential_state.credential_available
   in
-  let current_task = safe_current_task ctx ~joined in
+  let current_task = safe_current_task ctx ~session_bound in
   let effective_cluster_name = effective_cluster_name ctx.config in
   let active_task_assignees = Coord.active_task_assignees_by_task_id backlog in
   let agents =
@@ -481,8 +479,8 @@ let status_summary_string (ctx : context) =
   let attention_items =
     let items = [] in
     let items =
-      if not joined
-      then items @ [ "You are not joined in the project namespace. Call masc_start." ]
+      if not session_bound
+      then items @ [ "Your agent session is not bound. Call masc_start." ]
       else items
     in
     let items =
@@ -578,7 +576,7 @@ let status_summary_string (ctx : context) =
   in
   Coord_status_rendering.status_summary_string
     ~ctx
-    ~joined
+    ~session_bound
     ~actual_name
     ~credential_state
     ~credential_blocked
@@ -638,7 +636,7 @@ type agent_state =
 
 let inspect_state ctx =
   let binding =
-    let actual_name = safe_resolve_agent_name ctx ~joined:true in
+    let actual_name = safe_resolve_agent_name ctx ~session_bound:true in
     let matches_you assignee =
       String.equal assignee ctx.agent_name || String.equal assignee actual_name
     in
@@ -648,7 +646,7 @@ let inspect_state ctx =
     in
     resolve_current_binding
       ~assigned_task_ids
-      ~planning_current:(safe_current_task ctx ~joined:true)
+      ~planning_current:(safe_current_task ctx ~session_bound:true)
   in
   let task_claimed = Stdlib.List.length binding.assigned_task_ids > 0 in
   let current_task_set = binding.current_task_set in
@@ -686,7 +684,7 @@ let handle_heartbeat ~tool_name ~start_time ctx _args =
   else
     (* RFC-0189: heartbeat failure stems from agent-state issues
        ("agent not found", "invalid file") that the caller can
-       resolve (join the room, refresh credentials).
+       resolve (bind the session, refresh credentials).
        [Workflow_rejection]. *)
     Tool_result.error
       ~failure_class:(Some Tool_result.Workflow_rejection)

--- a/lib/tool_task_handlers.ml
+++ b/lib/tool_task_handlers.ml
@@ -329,8 +329,8 @@ let handle_batch_add_tasks ~tool_name ~start_time ctx args =
       ~created_by:ctx.agent_name ctx.config tasks)
 
 let handle_claim ?agent_tool_names ~tool_name ~start_time ctx args =
-  (* #18965 — removed [is_agent_joined] hard gate.  Keeper-internal tag
-     dispatch path bypasses MCP entry auto-join, so this gate produced
+  (* #18965 — removed [is_agent_session_bound] hard gate.  Keeper-internal tag
+     dispatch path bypasses MCP entry session binding, so this gate produced
      false-negative rejects for every keeper turn (fleet evidence:
      ~/.masc/agents/ empty while keepers run normally; only
      masc_claim/masc_claim_next failed).  Coord.claim_task_r works on
@@ -432,7 +432,7 @@ let format_no_eligible
         diagnostics
 
 let handle_claim_next ?agent_tool_names ~tool_name ~start_time ctx _args =
-  (* #18965 — removed [is_agent_joined] hard gate (same rationale as
+  (* #18965 — removed [is_agent_session_bound] hard gate (same rationale as
      [handle_claim] above).  Coord.claim_next_r operates on
      [~agent_name] alone; backlog read does not require an entry under
      agents_dir. *)

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -125,7 +125,7 @@ type agent = {
   status: agent_status;
   capabilities: string list;
   current_task: string option; [@default None]
-  joined_at: string;
+  session_bound_at: string;
   last_seen: string;
   meta: agent_meta option; [@default None] (* session metadata *)
 } [@@deriving yojson { strict = false }, show]
@@ -138,13 +138,13 @@ let iso8601_of_unix_seconds ts =
     (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday
     tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
 
-let normalize_agent_last_seen ~joined_at = function
+let normalize_agent_last_seen ~session_bound_at = function
   | `String _ as value -> Some value
   | `Int seconds ->
       Some (`String (iso8601_of_unix_seconds (float_of_int seconds)))
   | `Float seconds ->
       Some (`String (iso8601_of_unix_seconds seconds))
-  | `Null -> joined_at  (* bootstrap from joined_at — see #7947 *)
+  | `Null -> session_bound_at  (* bootstrap from session_bound_at — see #7947 *)
   | _ -> None
 
 let short_json_repr = function
@@ -167,8 +167,8 @@ let agent_of_yojson json =
   | Error original_error -> (
       match json with
       | `Assoc fields ->
-          let joined_at_value =
-            match List.assoc_opt "joined_at" fields with
+          let session_bound_at_value =
+            match List.assoc_opt "session_bound_at" fields with
             | Some (`String _ as v) -> Some v
             | _ -> None
           in
@@ -187,15 +187,15 @@ let agent_of_yojson json =
           let normalized_last_seen =
             match last_seen_raw with
             | Some value ->
-                normalize_agent_last_seen ~joined_at:joined_at_value value
+                normalize_agent_last_seen ~session_bound_at:session_bound_at_value value
             | None ->
-                (* Missing last_seen → bootstrap from joined_at when
+                (* Missing last_seen → bootstrap from session_bound_at when
                    present, otherwise fall back to the current wall-clock
                    time (#9751).  [last_seen] is a liveness marker, not
                    identity-critical; a recent-but-approximate timestamp
                    is strictly better than failing the whole record
                    deserialisation for an optional field. *)
-                (match joined_at_value with
+                (match session_bound_at_value with
                  | Some _ as v -> v
                  | None -> Some (now_iso ()))
           in
@@ -205,17 +205,17 @@ let agent_of_yojson json =
                 ("last_seen", normalized_last_seen)
                 :: List.remove_assoc "last_seen" fields
               in
-              (* If joined_at is also unusable, inject a now() value so
+              (* If session_bound_at is also unusable, inject a now() value so
                  the generated deserialiser's required-field check passes.
                  The agent record can always be rebuilt from a heartbeat;
                  losing the whole entry because of a missing timestamp is
                  strictly worse (#9751). *)
               let normalized_fields =
-                match joined_at_value with
+                match session_bound_at_value with
                 | Some _ -> fields_without_last_seen
                 | None ->
-                    ("joined_at", now_iso ())
-                    :: List.remove_assoc "joined_at" fields_without_last_seen
+                    ("session_bound_at", now_iso ())
+                    :: List.remove_assoc "session_bound_at" fields_without_last_seen
               in
               (match agent_of_yojson_generated (`Assoc normalized_fields) with
                | Ok _ as ok -> ok

--- a/lib/types/types_core.mli
+++ b/lib/types/types_core.mli
@@ -43,7 +43,7 @@ type agent =
   ; status : agent_status
   ; capabilities : string list
   ; current_task : string option [@default None]
-  ; joined_at : string
+  ; session_bound_at : string
   ; last_seen : string
   ; meta : agent_meta option [@default None]
   }
@@ -52,7 +52,7 @@ type agent =
 val agent_to_yojson : agent -> Yojson.Safe.t
 val agent_of_yojson : Yojson.Safe.t -> (agent, string) result
 val iso8601_of_unix_seconds : float -> string
-val normalize_agent_last_seen : joined_at:Yojson.Safe.t option -> Yojson.Safe.t -> Yojson.Safe.t option
+val normalize_agent_last_seen : session_bound_at:Yojson.Safe.t option -> Yojson.Safe.t -> Yojson.Safe.t option
 val short_json_repr : Yojson.Safe.t -> string
 
 type task_action =

--- a/proto/masc.proto
+++ b/proto/masc.proto
@@ -18,7 +18,7 @@ message Agent {
   string status = 2;  // "active", "idle", "zombie"
   repeated string capabilities = 3;
   string last_heartbeat = 4;
-  string joined_at = 5;
+  string session_bound_at = 5;
 }
 
 message Task {
@@ -70,24 +70,6 @@ message StatusResponse {
   int32 message_count = 3;
   string room_path = 4;
   string project_name = 5;
-}
-
-// Agent Operations
-message JoinRequest {
-  string agent_name = 1;
-  repeated string capabilities = 2;
-}
-message JoinResponse {
-  bool success = 1;
-  string message = 2;
-}
-
-message LeaveRequest {
-  string agent_name = 1;
-}
-message LeaveResponse {
-  bool success = 1;
-  string message = 2;
 }
 
 // Task Operations
@@ -221,10 +203,6 @@ message StreamMessagesRequest {
 service MASCService {
   // Status
   rpc GetStatus(StatusRequest) returns (StatusResponse);
-
-  // Agent lifecycle
-  rpc Join(JoinRequest) returns (JoinResponse);
-  rpc Leave(LeaveRequest) returns (LeaveResponse);
 
   // Task management
   rpc AddTask(AddTaskRequest) returns (AddTaskResponse);

--- a/proto/masc_coordination.proto
+++ b/proto/masc_coordination.proto
@@ -12,18 +12,12 @@ package masc.coordination.v1;
 
 // Agent lifecycle and coordination service.
 service MascCoordination {
-  // Agent joins the coordination room.
-  rpc Join(JoinRequest) returns (JoinResponse);
-
-  // Agent leaves the coordination room.
-  rpc Leave(LeaveRequest) returns (LeaveResponse);
-
   // Bidirectional heartbeat stream.
   // Agent sends periodic pings; server responds with acks containing room state.
   rpc Heartbeat(stream HeartbeatPing) returns (stream HeartbeatAck);
 
   // Server-streaming event subscription (replaces SSE for agents).
-  // Returns a stream of room events: broadcasts, task changes, agent joins/leaves.
+  // Returns a stream of room events: broadcasts, task changes, agent session changes.
   rpc Subscribe(SubscribeRequest) returns (stream Event);
 
   // Unary tool call (replaces POST /mcp tools/call).
@@ -41,33 +35,6 @@ service MascCoordination {
   // obtain hover, codeLens, inlayHint, and diagnostic results over the
   // gRPC-web transport instead of a separate WebSocket.
   rpc LspCall(LspRequest) returns (LspResponse);
-}
-
-// ===== Agent Lifecycle =====
-
-message JoinRequest {
-  string agent_name = 1;
-  repeated string capabilities = 2;
-  // Optional metadata: model name, version, etc.
-  map<string, string> metadata = 3;
-}
-
-message JoinResponse {
-  bool success = 1;
-  string message = 2;
-  string session_id = 3;
-  // Current agents already in the room.
-  repeated AgentInfo active_agents = 4;
-}
-
-message LeaveRequest {
-  string agent_name = 1;
-  string session_id = 2;
-}
-
-message LeaveResponse {
-  bool success = 1;
-  string message = 2;
 }
 
 // ===== Heartbeat =====
@@ -160,7 +127,7 @@ message AgentInfo {
   string status = 2;
   repeated string capabilities = 3;
   int64 last_heartbeat_ms = 4;
-  int64 joined_at_ms = 5;
+  int64 session_bound_at_ms = 5;
   string current_task_id = 6;
 }
 


### PR DESCRIPTION
## Summary
- rename agent membership checks to session-bound terminology
- rename telemetry/AG-UI/activity event surfaces from agent_joined to agent_session_bound
- rename agent timestamp fields from joined_at to session_bound_at and remove Join/Leave RPCs from proto contracts

## Validation
- targeted residue scan for removed join/joined identifiers only
- build not run (deletion-first cleanup; build may break)