### PR TITLE
Purge core room state naming

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -261,7 +261,7 @@ let dispatch_route ~router ~request ~path reqd =
              ~status:"server_error" ~message:"Server not initialized" ())
           reqd
       | Some state ->
-        let config = state.Mcp_server.room_config in
+        let config = state.Mcp_server.coord_config in
         (match state.Mcp_server.sw, state.Mcp_server.clock with
         | Some sw, Some clock ->
             let (status, resp_body) =
@@ -426,7 +426,7 @@ let dispatch_route ~router ~request ~path reqd =
       let format = Option.value ~default:"nested" (query_param request "format") in
       let voter = board_voter_query request in
       let config =
-        Option.map (fun state -> state.Mcp_server.room_config) !server_state
+        Option.map (fun state -> state.Mcp_server.coord_config) !server_state
       in
       let (status, body) =
         board_post_detail_json ~include_moderation:false ~blind_votes:false

--- a/bin/masc_worker_run.ml
+++ b/bin/masc_worker_run.ml
@@ -65,7 +65,7 @@ let main_result () =
                 match
                   Lib.Worker_runtime.run_worker_oas ~sw
                     ~net:(Eio.Stdenv.net env)
-                    ~room_config:None spec ()
+                    ~coord_config:None spec ()
                 with
                 | Ok run_result ->
                     ( Lib.Worker_runtime_helper_protocol.success_json run_result,

--- a/config/prompts/dashboard.governance_judge.md
+++ b/config/prompts/dashboard.governance_judge.md
@@ -28,7 +28,7 @@ Output strict JSON only with this shape:
 {
   "items": [
     {
-      "kind": "case|agent_health|room_state",
+      "kind": "case|agent_health|coord_state",
       "id": string,
       "summary": string,
       "confidence": number,

--- a/lib/ag_ui/ag_ui.ml
+++ b/lib/ag_ui/ag_ui.ml
@@ -194,7 +194,7 @@ let of_tool_call ~agent_name ~tool_name ~call_id ~args_json : event list =
   ]
 
 (** Map MASC room state to AG-UI STATE_SNAPSHOT *)
-let of_room_state (state : Yojson.Safe.t) : event =
+let of_coord_state (state : Yojson.Safe.t) : event =
   make_event ~thread_id:default_thread_id
     ~snapshot:(Some state)
     State_snapshot

--- a/lib/ag_ui/ag_ui.mli
+++ b/lib/ag_ui/ag_ui.mli
@@ -113,7 +113,7 @@ val of_tool_call :
 (** Tool call → 3 events: [Tool_call_start], [Tool_call_args]
     (with [delta=args_json]), [Tool_call_end]. *)
 
-val of_room_state : Yojson.Safe.t -> event
+val of_coord_state : Yojson.Safe.t -> event
 (** Room snapshot → [State_snapshot]. *)
 
 val of_custom : name:string -> Yojson.Safe.t -> event

--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -530,21 +530,21 @@ let authorize_tool_v2 config ~agent_name ~token ~tool_name : (unit, masc_error) 
 (* ============================================ *)
 
 (** Initialize room secret *)
-let init_room_secret config : string =
+let init_coord_secret config : string =
   ensure_auth_dirs config;
   let secret = generate_token () in
   let hash = sha256_hash secret in
-  save_private_text_file (room_secret_file config) hash;
+  save_private_text_file (coord_secret_file config) hash;
   (* Update auth config with hash *)
   let cfg = load_auth_config config in
-  save_auth_config config { cfg with room_secret_hash = Some hash };
+  save_auth_config config { cfg with coord_secret_hash = Some hash };
   secret (* Return raw secret to show user once *)
 ;;
 
 (** Verify room secret *)
-let verify_room_secret config secret : bool =
+let verify_coord_secret config secret : bool =
   let hash = sha256_hash secret in
-  let file = room_secret_file config in
+  let file = coord_secret_file config in
   if Sys.file_exists file
   then (
     let stored_hash = String.trim (In_channel.with_open_text file In_channel.input_all) in
@@ -560,7 +560,7 @@ let verify_room_secret config secret : bool =
     Creates a bootstrap admin token for the enabling agent to prevent
     circular permission deadlock (BUG-025). *)
 let enable_auth config ~require_token ~agent_name : string * string option =
-  let secret = init_room_secret config in
+  let secret = init_coord_secret config in
   let cfg = load_auth_config config in
   save_auth_config config { cfg with enabled = true; require_token };
   let bootstrap_token =

--- a/lib/auth.mli
+++ b/lib/auth.mli
@@ -24,7 +24,7 @@ val save_private_text_file : string -> string -> unit
 
 val auth_dir : string -> string
 val agents_dir : string -> string
-val room_secret_file : string -> string
+val coord_secret_file : string -> string
 val auth_config_file : string -> string
 val credential_file : string -> string -> string
 val internal_keeper_token_hash_file : string -> string
@@ -286,11 +286,11 @@ val authorize_tool_v2 :
 
 (** {1 Room Secret} *)
 
-val init_room_secret : string -> string
-(** [init_room_secret config] generates and persists a room secret.
+val init_coord_secret : string -> string
+(** [init_coord_secret config] generates and persists a room secret.
     Returns the raw secret (shown once). *)
 
-val verify_room_secret : string -> string -> bool
+val verify_coord_secret : string -> string -> bool
 
 (** {1 Auth Toggle} *)
 
@@ -298,7 +298,7 @@ val enable_auth :
   string -> require_token:bool -> agent_name:string ->
   string * string option
 (** [enable_auth config ~require_token ~agent_name] returns
-    [(room_secret, bootstrap_token)]. *)
+    [(coord_secret, bootstrap_token)]. *)
 
 val disable_auth : string -> unit
 

--- a/lib/auth_credential_base.ml
+++ b/lib/auth_credential_base.ml
@@ -23,7 +23,7 @@ let sha256_hash input = Digestif.SHA256.(digest_string input |> to_hex)
 
 let auth_dir config = Common.auth_dir_from_base_path ~base_path:config
 let agents_dir config = Common.agents_dir_from_base_path ~base_path:config
-let room_secret_file config = Filename.concat (auth_dir config) "room_secret.hash"
+let coord_secret_file config = Filename.concat (auth_dir config) "coord_secret.hash"
 let auth_config_file config = Filename.concat (auth_dir config) "config.json"
 let initial_admin_file config = Filename.concat (auth_dir config) "initial_admin"
 

--- a/lib/auth_login.ml
+++ b/lib/auth_login.ml
@@ -66,7 +66,7 @@ let ensure_required_bearer_auth ~base_path ~agent_name =
   if cfg.enabled && cfg.require_token then
     Ok Auth_already_required
   else if not cfg.enabled then
-    let _room_secret, _bootstrap_token =
+    let _coord_secret, _bootstrap_token =
       Auth.enable_auth base_path ~require_token:true ~agent_name
     in
     Ok Auth_enabled

--- a/lib/auto_recall.ml
+++ b/lib/auto_recall.ml
@@ -83,14 +83,14 @@ let estimate_tokens = Inference_utils.estimate_tokens
 (** Fetch from MASC cache *)
 (* Issue #8597 #2: dropped [~query] — cache filtering is by tag
    (config.cache_tags), not by query string. *)
-let fetch_from_cache (room_config : Coord_utils.config) ~(config : recall_config) =
+let fetch_from_cache (coord_config : Coord_utils.config) ~(config : recall_config) =
   let entries =
     match config.cache_tags with
-    | [] -> Cache_eio.list room_config ()
+    | [] -> Cache_eio.list coord_config ()
     | tags ->
         (* Fetch entries matching any of the specified tags *)
         List.concat_map (fun tag ->
-          Cache_eio.list room_config ~tag ()
+          Cache_eio.list coord_config ~tag ()
         ) tags
         |> List.sort_uniq (fun a b -> compare a.Cache_eio.key b.Cache_eio.key)
   in
@@ -110,8 +110,8 @@ let fetch_from_cache (room_config : Coord_utils.config) ~(config : recall_config
 (** Fetch recent broadcasts *)
 (* Issue #8597 #2: dropped [~query] — broadcast fetch is limit-based
    (config.max_broadcasts), not query-ranked. *)
-let fetch_from_broadcasts (room_config : Coord_utils.config) ~(config : recall_config) =
-  let messages = Coord.get_messages_raw room_config
+let fetch_from_broadcasts (coord_config : Coord_utils.config) ~(config : recall_config) =
+  let messages = Coord.get_messages_raw coord_config
     ~since_seq:0
     ~limit:config.max_broadcasts
   in
@@ -136,8 +136,8 @@ let fetch_from_broadcasts (room_config : Coord_utils.config) ~(config : recall_c
    maps to file scanning (max_files=10 / max_preview_bytes=500 are
    hard-coded; cache_tags / max_broadcasts / max_tokens belong to other
    sources). The arg was structurally received, semantically ignored. *)
-let fetch_from_file_context (room_config : Coord_utils.config) ~query =
-  let masc_dir = Coord_utils.masc_dir room_config in
+let fetch_from_file_context (coord_config : Coord_utils.config) ~query =
+  let masc_dir = Coord_utils.masc_dir coord_config in
   let work_dir = Filename.dirname masc_dir in (* Parent of .masc *)
   
   (* Get recently modified files without shelling out (no find/xargs). *)
@@ -247,23 +247,23 @@ let fetch_from_file_context (room_config : Coord_utils.config) ~query =
     Each leaf consumes only the args it needs (#8597 #2):
     - [Masc_cache] / [Recent_broadcasts] use [config] (tags / limit)
     - [File_context] uses [query] for relevance ranking *)
-let fetch_source room_config ~config ~query = function
-  | Masc_cache -> fetch_from_cache room_config ~config
-  | Recent_broadcasts -> fetch_from_broadcasts room_config ~config
-  | File_context -> fetch_from_file_context room_config ~query
+let fetch_source coord_config ~config ~query = function
+  | Masc_cache -> fetch_from_cache coord_config ~config
+  | Recent_broadcasts -> fetch_from_broadcasts coord_config ~config
+  | File_context -> fetch_from_file_context coord_config ~query
 
 (** {1 Main API} *)
 
 (** Fetch context from configured sources
 
-    @param room_config MASC room configuration
+    @param coord_config MASC room configuration
     @param config Recall configuration
     @param query Optional query string for relevance ranking
 
     @return Recall result with items sorted by relevance, truncated to token budget
 *)
 let fetch_context
-    (room_config : Coord_utils.config)
+    (coord_config : Coord_utils.config)
     ~(config : recall_config)
     ?(query : string = "")
     ()
@@ -272,7 +272,7 @@ let fetch_context
     { items = []; total_tokens = 0; truncated = false }
   else
     (* Fetch from all configured sources *)
-    let all_items = List.concat_map (fetch_source room_config ~config ~query) config.sources in
+    let all_items = List.concat_map (fetch_source coord_config ~config ~query) config.sources in
 
     (* Sort by relevance (highest first) *)
     let sorted = List.sort (fun a b -> compare b.relevance a.relevance) all_items in
@@ -296,7 +296,7 @@ let fetch_context
     @param sw Eio switch
     @param env Eio environment with network access
     @param clock Eio clock
-    @param room_config MASC room configuration
+    @param coord_config MASC room configuration
     @param config Recall configuration
     @param query Query string for relevance
 
@@ -304,12 +304,12 @@ let fetch_context
 *)
 let fetch_context_eio
     ~sw:_ ~env:_ ~clock:_
-    (room_config : Coord_utils.config)
+    (coord_config : Coord_utils.config)
     ~(config : recall_config)
     ?(query : string = "")
     ()
     : recall_result =
-  fetch_context room_config ~config ~query ()
+  fetch_context coord_config ~config ~query ()
 
 (** {1 Formatting} *)
 

--- a/lib/auto_recall.mli
+++ b/lib/auto_recall.mli
@@ -12,7 +12,7 @@
         () in
 
       (* With Eio runtime context *)
-      let result = Auto_recall.fetch_context_eio ~sw ~env room_config ~config ~query:"error handling" () in
+      let result = Auto_recall.fetch_context_eio ~sw ~env coord_config ~config ~query:"error handling" () in
       let injection = Auto_recall.format_for_injection result in
       (* Use injection as system prompt prefix *)
     ]}
@@ -75,7 +75,7 @@ val estimate_tokens : string -> int
 (** Fetch context from configured sources.
     Results are sorted by relevance and truncated to token budget.
 
-    @param room_config MASC room configuration
+    @param coord_config MASC room configuration
     @param config Recall configuration
     @param query Optional query for relevance ranking
     @return Recall result with items and metadata
@@ -92,7 +92,7 @@ val fetch_context :
 
     @param sw Eio switch
     @param env Eio environment with network access
-    @param room_config MASC room configuration
+    @param coord_config MASC room configuration
     @param config Recall configuration
     @param query Query string for semantic search
     @return Recall result from configured sources

--- a/lib/coord.ml
+++ b/lib/coord.ml
@@ -654,7 +654,7 @@ let () =
 ;;
 
 (* Relation materializer — agent session end *)
-let () = Atomic.set Coord_hooks.relation_on_leave_fn Relation_materializer.on_agent_leave
+let () = Atomic.set Coord_hooks.relation_on_leave_fn Relation_materializer.on_agent_session_ended
 
 (* Relation materializer — task done *)
 let () =

--- a/lib/coord/coord_backlog.ml
+++ b/lib/coord/coord_backlog.ml
@@ -1,6 +1,6 @@
 (** Coord Backlog - Backlog I/O.
 
-    Extracted from room_state.ml. *)
+    Extracted from coord_state.ml. *)
 
 open Masc_domain
 open Coord_utils

--- a/lib/coord/coord_bootstrap.ml
+++ b/lib/coord/coord_bootstrap.ml
@@ -1,12 +1,12 @@
 (** Coord Bootstrap - Directory initialization and default state.
 
-    Extracted from room_state.ml to isolate the "init or not"
+    Extracted from coord_state.ml to isolate the "init or not"
     responsibility from runtime state I/O. *)
 
 open Masc_domain
 open Coord_utils
 
-let default_room_state config = {
+let default_coord_state config = {
   protocol_version = "0.1.0";
   project = Filename.basename config.base_path;
   started_at = now_iso ();
@@ -21,7 +21,7 @@ let default_room_state config = {
   speculation_budget = None;
 }
 
-let ensure_room_bootstrap config =
+let ensure_coord_bootstrap config =
   let root_dir = masc_root_dir config in
   let root_agents_dir = Filename.concat root_dir "agents" in
   let root_keepers_dir = Filename.concat root_dir "keepers" in
@@ -39,7 +39,7 @@ let ensure_room_bootstrap config =
     ];
   if not (path_exists_root config (root_state_path config)) then
     write_json_root config (root_state_path config)
-      (room_state_to_yojson (default_room_state config));
+      (coord_state_to_yojson (default_coord_state config));
   if not (path_exists_root config root_backlog_path) then
     write_json_root config root_backlog_path
       (backlog_to_yojson { tasks = []; last_updated = now_iso (); version = 1 });
@@ -51,7 +51,7 @@ let ensure_room_bootstrap config =
   let scoped_backlog = backlog_path config in
   List.iter mkdir_p [ masc_dir config; scoped_agents; scoped_tasks; scoped_messages ];
   if not (path_exists config scoped_state) then
-    write_json config scoped_state (room_state_to_yojson (default_room_state config));
+    write_json config scoped_state (coord_state_to_yojson (default_coord_state config));
   if not (path_exists config scoped_backlog) then
     write_json config scoped_backlog
       (backlog_to_yojson { tasks = []; last_updated = now_iso (); version = 1 })

--- a/lib/coord/coord_bootstrap.mli
+++ b/lib/coord/coord_bootstrap.mli
@@ -1,8 +1,8 @@
-(** Coord room bootstrap — initialize the default room state on
+(** Coord coord bootstrap — initialize the default room state on
     first boot. *)
 
 open Masc_domain
 open Coord_utils
 
-val default_room_state : Coord_utils_backend_setup.config -> Masc_domain.room_state
-val ensure_room_bootstrap : Coord_utils_backend_setup.config -> unit
+val default_coord_state : Coord_utils_backend_setup.config -> Masc_domain.coord_state
+val ensure_coord_bootstrap : Coord_utils_backend_setup.config -> unit

--- a/lib/coord/coord_broadcast.ml
+++ b/lib/coord/coord_broadcast.ml
@@ -1,6 +1,6 @@
 (** Coord Broadcast - Message broadcasting and activity emission.
 
-    Extracted from room_state.ml. Depends on Coord_state for
+    Extracted from coord_state.ml. Depends on Coord_state for
     next_seq and normalized_string_list. *)
 
 open Masc_domain

--- a/lib/coord/coord_eio.ml
+++ b/lib/coord/coord_eio.ml
@@ -30,7 +30,7 @@ type agent_state = {
 }
 
 (** Coord state *)
-type room_state = {
+type coord_state = {
   protocol_version: string;
   started_at: float;
   last_updated: float;
@@ -126,15 +126,15 @@ let event_key seq = Printf.sprintf "%s:%06d" events_key seq
 
 (** Event types for audit logging *)
 type event_type =
-  | AgentJoin
-  | AgentLeave
+  | AgentSessionBound
+  | AgentSessionEnded
   | Broadcast
   | LockAcquire
   | LockRelease
 
 let event_type_to_string = function
-  | AgentJoin -> "agent_join"
-  | AgentLeave -> "agent_leave"
+  | AgentSessionBound -> "agent_session_bound"
+  | AgentSessionEnded -> "agent_session_ended"
   | Broadcast -> "broadcast"
   | LockAcquire -> "lock_acquire"
   | LockRelease -> "lock_release"
@@ -219,7 +219,7 @@ let get_recent_events config ~limit =
 
 (** {1 State Management} *)
 
-let default_room_state () = {
+let default_coord_state () = {
   protocol_version = "1.0.0";
   started_at = Time_compat.now ();
   last_updated = Time_compat.now ();
@@ -233,7 +233,7 @@ let default_room_state () = {
   pause_reason = None;
 }
 
-let room_state_to_json state =
+let coord_state_to_json state =
   `Assoc [
     ("protocol_version", `String state.protocol_version);
     ("started_at", `Float state.started_at);
@@ -248,7 +248,7 @@ let room_state_to_json state =
     ("pause_reason", Json_util.string_opt_to_json state.pause_reason);
   ]
 
-let room_state_of_json json =
+let coord_state_of_json json =
   let m key = Option.value ~default:`Null (Json_util.assoc_member_opt key json) in
   try
     Ok {
@@ -275,10 +275,10 @@ let read_state config =
   | Ok json_str ->
       (try
         let json = Yojson.Safe.from_string json_str in
-        room_state_of_json json
+        coord_state_of_json json
       with Eio.Cancel.Cancelled _ as e -> raise e | e -> Error (Printexc.to_string e))
   | Error (Backend.NotFound _) ->
-      Ok (default_room_state ())
+      Ok (default_coord_state ())
   | Error (Backend.IOError msg) -> Error msg
   | Error (Backend.AlreadyExists k) -> Error ("Already exists: " ^ k)
   | Error (Backend.InvalidKey k) -> Error ("Invalid key: " ^ k)
@@ -288,7 +288,7 @@ let read_state config =
 (** Write room state *)
 let write_state config state =
   let state = { state with last_updated = Time_compat.now () } in
-  let json_str = Yojson.Safe.to_string (room_state_to_json state) in
+  let json_str = Yojson.Safe.to_string (coord_state_to_json state) in
   Backend.FileSystem.set config.backend state_key json_str
 
 (** Atomically update room state with a transform function.
@@ -301,26 +301,26 @@ let atomic_update_state config ~f =
   let transform json_opt =
     let current_state =
       match json_opt with
-      | None -> default_room_state ()
+      | None -> default_coord_state ()
       | Some json_str ->
           (try
             let json = Yojson.Safe.from_string json_str in
-            match room_state_of_json json with
+            match coord_state_of_json json with
             | Ok s -> s
             | Error e ->
                 Log.Coord.warn "update_state: state deserialization failed, resetting: %s" e;
-                default_room_state ()
-          with Eio.Io _ | Yojson.Json_error _ -> default_room_state ())
+                default_coord_state ()
+          with Eio.Io _ | Yojson.Json_error _ -> default_coord_state ())
     in
     let new_state = f current_state in
     let new_state = { new_state with last_updated = Time_compat.now () } in
-    Yojson.Safe.to_string (room_state_to_json new_state)
+    Yojson.Safe.to_string (coord_state_to_json new_state)
   in
   match Backend.FileSystem.atomic_update config.backend state_key ~f:transform with
   | Ok json_str ->
       (try
         let json = Yojson.Safe.from_string json_str in
-        room_state_of_json json
+        coord_state_of_json json
       with Eio.Cancel.Cancelled _ as e -> raise e | e -> Error (Printexc.to_string e))
   | Error e ->
       Atomic.incr state_update_failures;
@@ -359,7 +359,7 @@ let agent_state_of_json json =
 
     Automatically subscribes to Messages for A2A communication.
     This ensures all agents can receive broadcasts immediately after joining.
-    If the agent is already active, updates heartbeat without emitting AgentJoin.
+    If the agent is already active, updates heartbeat without emitting AgentSessionBound.
 *)
 let register_agent config ~name ?(capabilities=[]) () =
   let already_active =
@@ -393,7 +393,7 @@ let register_agent config ~name ?(capabilities=[]) () =
       (* Log join event only for new agents, skip for re-joins *)
       if not already_active then begin
         let _event = log_event config
-          ~event_type:AgentJoin
+          ~event_type:AgentSessionBound
           ~agent:name
           ~payload:(`Assoc [
             ("capabilities", `List (List.map (fun c -> `String c) capabilities))
@@ -436,7 +436,7 @@ let remove_agent config ~name =
 
       (* Log leave event *)
       let _event = log_event config
-        ~event_type:AgentLeave
+        ~event_type:AgentSessionEnded
         ~agent:name
         ~payload:`Null in
 

--- a/lib/coord/coord_eio.mli
+++ b/lib/coord/coord_eio.mli
@@ -25,7 +25,7 @@ type agent_state = {
 }
 
 (** Coord-level state (protocol version, active agents, pause, etc.). *)
-type room_state = {
+type coord_state = {
   protocol_version: string;
   started_at: float;
   last_updated: float;
@@ -41,8 +41,8 @@ type room_state = {
 
 (** Event types for the persistent audit log. *)
 type event_type =
-  | AgentJoin
-  | AgentLeave
+  | AgentSessionBound
+  | AgentSessionEnded
   | Broadcast
   | LockAcquire
   | LockRelease
@@ -122,25 +122,25 @@ val event_key : int -> string
 (** {1 State Management} *)
 
 (** Return a fresh default room state. *)
-val default_room_state : unit -> room_state
+val default_coord_state : unit -> coord_state
 
 (** Serialize room state to JSON. *)
-val room_state_to_json : room_state -> Yojson.Safe.t
+val coord_state_to_json : coord_state -> Yojson.Safe.t
 
 (** Deserialize room state from JSON. *)
-val room_state_of_json : Yojson.Safe.t -> (room_state, string) result
+val coord_state_of_json : Yojson.Safe.t -> (coord_state, string) result
 
 (** Read room state from the backend (defaults if absent). *)
-val read_state : config -> (room_state, string) result
+val read_state : config -> (coord_state, string) result
 
 (** Write room state to the backend. *)
-val write_state : config -> room_state ->
+val write_state : config -> coord_state ->
   (unit, Backend.error) result
 
 (** Atomically read-modify-write room state.
     [f] receives the current state and returns the new state. *)
 val atomic_update_state :
-  config -> f:(room_state -> room_state) -> (room_state, string) result
+  config -> f:(coord_state -> coord_state) -> (coord_state, string) result
 
 (** {1 Agent Operations} *)
 

--- a/lib/coord/coord_hooks.ml
+++ b/lib/coord/coord_hooks.ml
@@ -55,7 +55,7 @@ let stop_keeper_fn
   : (string -> unit) Atomic.t
   = Atomic.make (fun _name -> ())
 
-(** Relation materializer: agent session end — wraps Relation_materializer.on_agent_leave. *)
+(** Relation materializer: agent session end — wraps Relation_materializer.on_agent_session_ended. *)
 let relation_on_leave_fn
   : (leaving_agent:string -> active_agents:string list -> unit) Atomic.t
   = Atomic.make (fun ~leaving_agent:_ ~active_agents:_ -> ())

--- a/lib/coord/coord_identity.ml
+++ b/lib/coord/coord_identity.ml
@@ -1,6 +1,6 @@
 (** Coord Identity - Session and agent identity helpers.
 
-    Extracted from room_state.ml. *)
+    Extracted from coord_state.ml. *)
 
 open Coord_utils
 

--- a/lib/coord/coord_init.ml
+++ b/lib/coord/coord_init.ml
@@ -45,7 +45,7 @@ let init config ~agent_name =
       ; speculation_budget = None
       }
     in
-    write_json_root config (root_state_path config) (room_state_to_yojson root_state))
+    write_json_root config (root_state_path config) (coord_state_to_yojson root_state))
   else (
     (* Sync PG state to local file on startup so filesystem fallback has fresh data *)
     let root_json = read_json_root config (root_state_path config) in

--- a/lib/coord/coord_state.ml
+++ b/lib/coord/coord_state.ml
@@ -4,11 +4,11 @@
     - State read/write/update with file locking
     - Sequence counter (next_seq)
     - Pause state (is_paused, pause_info)
-    - State recovery (recover_room_state)
+    - State recovery (recover_coord_state)
     - Shared string utilities (String_util.option_trim, normalized_string_list)
 
     Extracted owner modules:
-    - Coord_bootstrap: default_room_state, ensure_room_bootstrap
+    - Coord_bootstrap: default_coord_state, ensure_coord_bootstrap
     - Coord_identity: generate_session_id, get_hostname, get_tty, resolve_agent_name
     - Coord_task_id: task_id_to_int, archive management, next_task_number
     - Coord_backlog: read_backlog, write_backlog
@@ -40,8 +40,8 @@ let recover_active_agent_name = function
   | `String name -> String_util.option_trim (Some name)
   | _ -> None
 
-let recover_room_state config json =
-  let defaults = Coord_bootstrap.default_room_state config in
+let recover_coord_state config json =
+  let defaults = Coord_bootstrap.default_coord_state config in
   let active_agents =
     match Safe_ops.json_list_opt "active_agents" json with
     | Some agents -> List.filter_map recover_active_agent_name agents
@@ -85,15 +85,15 @@ let recover_room_state config json =
 (* ============================================ *)
 
 let write_state config state =
-  let json = room_state_to_yojson state in
+  let json = coord_state_to_yojson state in
   write_json config (state_path config) json
 
 let read_state config =
   let json = read_json config (state_path config) in
-  match room_state_of_yojson json with
+  match coord_state_of_yojson json with
   | Ok state -> state
   | Error msg ->
-      let repaired = recover_room_state config json in
+      let repaired = recover_coord_state config json in
       let raw_snippet =
         let s = Yojson.Safe.to_string json in
         if String.length s <= 500 then s
@@ -143,7 +143,7 @@ let pause_info config =
 
 (* Broadcast moved to Coord_broadcast (exported via Coord aggregator).
    Cannot re-export here — broadcast depends on next_seq, which would
-   create a circular dep room_state <-> room_broadcast. *)
+   create a circular dep coord_state <-> room_broadcast. *)
 
 (* ============================================ *)
 (* Re-exports: Zombie Detection (Resilience)    *)

--- a/lib/coord/coord_state.mli
+++ b/lib/coord/coord_state.mli
@@ -10,19 +10,19 @@ val normalized_string_list : string list -> string list
     entries; object-shaped historical entries are ignored during repair. *)
 val recover_active_agent_name : Yojson.Safe.t -> string option
 
-val recover_room_state :
+val recover_coord_state :
   Coord_utils_backend_setup.config ->
-  Yojson.Safe.t -> Masc_domain.room_state
+  Yojson.Safe.t -> Masc_domain.coord_state
 
 val write_state :
-  Coord_utils_backend_setup.config -> Masc_domain.room_state -> unit
+  Coord_utils_backend_setup.config -> Masc_domain.coord_state -> unit
 
-val read_state : Coord_utils_backend_setup.config -> Masc_domain.room_state
+val read_state : Coord_utils_backend_setup.config -> Masc_domain.coord_state
 
 val update_state :
   Coord_utils_backend_setup.config ->
-  (Masc_domain.room_state -> Masc_domain.room_state) ->
-  Masc_domain.room_state
+  (Masc_domain.coord_state -> Masc_domain.coord_state) ->
+  Masc_domain.coord_state
 
 val next_seq : Coord_utils_backend_setup.config -> int
 val is_paused : Coord_utils_backend_setup.config -> bool

--- a/lib/coord/coord_task_id.ml
+++ b/lib/coord/coord_task_id.ml
@@ -1,6 +1,6 @@
 (** Coord Task ID - Task ID parsing and archive management.
 
-    Extracted from room_state.ml. *)
+    Extracted from coord_state.ml. *)
 
 open Masc_domain
 open Coord_utils

--- a/lib/coord_protocol.ml
+++ b/lib/coord_protocol.ml
@@ -6,13 +6,13 @@ type status = {
 }
 
 let status config =
-  let room_state = Coord.read_state config in
+  let coord_state = Coord.read_state config in
   let tempo = Tempo.get_tempo config in
   {
     cluster = Env_config_core.cluster_name ();
-    project = room_state.project;
+    project = coord_state.project;
     tempo_interval_s = tempo.current_interval_s;
-    paused = room_state.paused;
+    paused = coord_state.paused;
   }
 
 let task_status_matches status_filter (task : Masc_domain.task) =

--- a/lib/coord_protocol.mli
+++ b/lib/coord_protocol.mli
@@ -1,4 +1,4 @@
-(** Room_protocol exposes the read-side room boundary used by HTTP routes.
+(** Coord_protocol exposes the read-side room boundary used by HTTP routes.
 
     It keeps route modules from depending directly on the Coord implementation
     hub while preserving the existing response shape. *)

--- a/lib/coord_status_rendering.ml
+++ b/lib/coord_status_rendering.ml
@@ -172,7 +172,7 @@ let status_summary_string
     ~(planning_state : planning_context_state)
     ~(suggested_next : string list)
     ~(attention_items : string list)
-    ~(state : Masc_domain.room_state)
+    ~(state : Masc_domain.coord_state)
     ~(backlog : Masc_domain.backlog) =
   
   let max_agents_display = 40 in

--- a/lib/coord_status_rendering.mli
+++ b/lib/coord_status_rendering.mli
@@ -85,7 +85,7 @@ val status_summary_string :
   planning_state:Coord_types.planning_context_state ->
   suggested_next:string list ->
   attention_items:string list ->
-  state:Masc_domain.room_state ->
+  state:Masc_domain.coord_state ->
   backlog:Masc_domain.backlog ->
   string
 (** [status_summary_string] renders the full [masc_status]

--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -3,17 +3,17 @@ include Dashboard_execution_fixture
 include Dashboard_execution_builders
 
 let room_status_json (config : Coord.config) : Yojson.Safe.t =
-  let room_state_opt =
+  let coord_state_opt =
     if Coord.is_initialized config then Some (Coord.read_state config) else None
   in
   let project =
-    match room_state_opt with
-    | Some room_state -> room_state.project
+    match coord_state_opt with
+    | Some coord_state -> coord_state.project
     | None -> "default"
   in
   let paused =
-    match room_state_opt with
-    | Some room_state -> room_state.paused
+    match coord_state_opt with
+    | Some coord_state -> coord_state.paused
     | None -> false
   in
   let tempo = Tempo.get_tempo config in

--- a/lib/dashboard/dashboard_execution_helpers.mli
+++ b/lib/dashboard/dashboard_execution_helpers.mli
@@ -12,7 +12,7 @@
     every dashboard execution consumer.  Plus dotted
     callers ({!get_agent_profile} from
     [server_dashboard_http_core] +
-    [server_routes_http_routes_room]).
+    [server_routes_http_routes_coord]).
 
     External surface (38 entries — 8 records + 30
     helpers).

--- a/lib/dune
+++ b/lib/dune
@@ -120,7 +120,7 @@
  server_routes_http_keeper_stream
  server_routes_http_sidecar_paths
  server_routes_http_routes_frontend
- server_routes_http_routes_room
+ server_routes_http_routes_coord
  server_routes_http_dashboard_provider_logs
  server_routes_http_routes_dashboard
  server_routes_http_routes_activity

--- a/lib/goal/goal_janitor.ml
+++ b/lib/goal/goal_janitor.ml
@@ -127,7 +127,7 @@ let audit_unclaimed_goal_orphan_tasks ?(now = Unix.gettimeofday ())
         Some (task, age_seconds)
     | _ -> None)
 
-let emit_orphan_task_escalation room_config ~threshold_seconds orphan_tasks =
+let emit_orphan_task_escalation coord_config ~threshold_seconds orphan_tasks =
   match orphan_tasks with
   | [] -> ()
   | _ ->
@@ -148,7 +148,7 @@ let emit_orphan_task_escalation room_config ~threshold_seconds orphan_tasks =
                ])
           orphan_tasks
       in
-      Coord.log_event room_config
+      Coord.log_event coord_config
         (`Assoc
            [ ("type", `String "goal_orphan_task_escalation")
            ; ("subsystem", `String "goal_janitor")
@@ -179,33 +179,33 @@ let prune_active_goal_ids ~(valid_goal_ids : string list)
 
 (** Run a full sweep: goals + keeper active_goal_ids.
     Writes updated state to disk. *)
-let run ?(config = default_config) (room_config : Coord.config) : sweep_result =
-  let st = Goal_store.read_state room_config in
+let run ?(config = default_config) (coord_config : Coord.config) : sweep_result =
+  let st = Goal_store.read_state coord_config in
   let goals', partial = sweep_goals ~config st.goals in
   let valid_ids = List.map (fun (g : Goal_store.goal) -> g.id) goals' in
   (* Write updated goal state — use update_state so the file lock protects
      the read-modify-write cycle. Prevents truncation races (#17229). *)
   if partial.purged > 0 || partial.stagnated > 0 then
-    ignore (Goal_store.update_state room_config (fun _state ->
+    ignore (Goal_store.update_state coord_config (fun _state ->
       { goals = goals'; version = st.version + 1; updated_at = Masc_domain.now_iso () }));
   (* Prune active_goal_ids from all keeper metas *)
   let total_orphans = ref 0 in
   let keeper_dir =
-    Filename.concat (Coord.masc_dir room_config) "keepers"
+    Filename.concat (Coord.masc_dir coord_config) "keepers"
   in
   if Sys.file_exists keeper_dir && Sys.is_directory keeper_dir then
     Sys.readdir keeper_dir
     |> Array.iter (fun entry ->
       if Filename.check_suffix entry ".json" then begin
         let name = Filename.chop_suffix entry ".json" in
-        match Keeper_meta_store.read_meta room_config name with
+        match Keeper_meta_store.read_meta coord_config name with
         | Ok (Some meta) when meta.active_goal_ids <> [] ->
           let pruned_ids, removed =
             prune_active_goal_ids ~valid_goal_ids:valid_ids meta.active_goal_ids
           in
           if removed > 0 then begin
             let updated = { meta with active_goal_ids = pruned_ids } in
-            match Keeper_meta_store.write_meta room_config updated with
+            match Keeper_meta_store.write_meta coord_config updated with
             | Ok () ->
                 total_orphans := !total_orphans + removed
             | Error e ->
@@ -217,11 +217,11 @@ let run ?(config = default_config) (room_config : Coord.config) : sweep_result =
         | Ok None | Ok (Some _) | Error _ -> ()
       end);
   let orphan_task_rows =
-    Coord.get_tasks_safe room_config
+    Coord.get_tasks_safe coord_config
     |> audit_unclaimed_goal_orphan_tasks ~valid_goal_ids:valid_ids
          ~min_age_seconds:config.orphan_task_escalation_age_seconds
   in
-  emit_orphan_task_escalation room_config
+  emit_orphan_task_escalation coord_config
     ~threshold_seconds:config.orphan_task_escalation_age_seconds
     orphan_task_rows;
   let result = { partial with orphans = !total_orphans;

--- a/lib/graphql_api.ml
+++ b/lib/graphql_api.ml
@@ -6,7 +6,7 @@ module Types = Masc_domain
 open Masc_domain
 
 type ctx = {
-  room_config: Coord_utils.config;
+  coord_config: Coord_utils.config;
 }
 
 type response_status = [ `OK | `Bad_request ]
@@ -356,45 +356,45 @@ let message_typ =
         ~resolve:(fun _ (message : Masc_domain.message) -> message.relevance);
     ]
 
-let room_state_typ =
-  Schema.obj "RoomState"
+let coord_state_typ =
+  Schema.obj "CoordState"
     ~fields:[
       Schema.field "protocolVersion"
         ~typ:(Schema.non_null Schema.string)
         ~args:Arg.[]
-        ~resolve:(fun _ (state : Masc_domain.room_state) -> state.protocol_version);
+        ~resolve:(fun _ (state : Masc_domain.coord_state) -> state.protocol_version);
       Schema.field "project"
         ~typ:(Schema.non_null Schema.string)
         ~args:Arg.[]
-        ~resolve:(fun _ (state : Masc_domain.room_state) -> state.project);
+        ~resolve:(fun _ (state : Masc_domain.coord_state) -> state.project);
       Schema.field "startedAt"
         ~typ:(Schema.non_null Schema.string)
         ~args:Arg.[]
-        ~resolve:(fun _ (state : Masc_domain.room_state) -> state.started_at);
+        ~resolve:(fun _ (state : Masc_domain.coord_state) -> state.started_at);
       Schema.field "messageSeq"
         ~typ:(Schema.non_null Schema.int)
         ~args:Arg.[]
-        ~resolve:(fun _ (state : Masc_domain.room_state) -> state.message_seq);
+        ~resolve:(fun _ (state : Masc_domain.coord_state) -> state.message_seq);
       Schema.field "activeAgents"
         ~typ:(Schema.non_null (Schema.list (Schema.non_null Schema.string)))
         ~args:Arg.[]
-        ~resolve:(fun _ (state : Masc_domain.room_state) -> state.active_agents);
+        ~resolve:(fun _ (state : Masc_domain.coord_state) -> state.active_agents);
       Schema.field "paused"
         ~typ:(Schema.non_null Schema.bool)
         ~args:Arg.[]
-        ~resolve:(fun _ (state : Masc_domain.room_state) -> state.paused);
+        ~resolve:(fun _ (state : Masc_domain.coord_state) -> state.paused);
       Schema.field "pauseReason"
         ~typ:Schema.string
         ~args:Arg.[]
-        ~resolve:(fun _ (state : Masc_domain.room_state) -> state.pause_reason);
+        ~resolve:(fun _ (state : Masc_domain.coord_state) -> state.pause_reason);
       Schema.field "pausedBy"
         ~typ:Schema.string
         ~args:Arg.[]
-        ~resolve:(fun _ (state : Masc_domain.room_state) -> state.paused_by);
+        ~resolve:(fun _ (state : Masc_domain.coord_state) -> state.paused_by);
       Schema.field "pausedAt"
         ~typ:Schema.string
         ~args:Arg.[]
-        ~resolve:(fun _ (state : Masc_domain.room_state) -> state.paused_at);
+        ~resolve:(fun _ (state : Masc_domain.coord_state) -> state.paused_at);
     ]
 
 let task_edge_typ =
@@ -628,9 +628,9 @@ let messages_connection config first after =
 let schema =
   Schema.schema [
     Schema.field "status"
-      ~typ:(Schema.non_null room_state_typ)
+      ~typ:(Schema.non_null coord_state_typ)
       ~args:Arg.[]
-      ~resolve:(fun info () -> Coord.read_state info.ctx.room_config);
+      ~resolve:(fun info () -> Coord.read_state info.ctx.coord_config);
     Schema.field "tasks"
       ~typ:(Schema.non_null task_connection_typ)
       ~args:Arg.[
@@ -638,7 +638,7 @@ let schema =
         Arg.arg "after" ~typ:Arg.string;
       ]
       ~resolve:(fun info () first after ->
-        tasks_connection info.ctx.room_config first after);
+        tasks_connection info.ctx.coord_config first after);
     Schema.field "agents"
       ~typ:(Schema.non_null agent_connection_typ)
       ~args:Arg.[
@@ -646,7 +646,7 @@ let schema =
         Arg.arg "after" ~typ:Arg.string;
       ]
       ~resolve:(fun info () first after ->
-        agents_connection info.ctx.room_config first after);
+        agents_connection info.ctx.coord_config first after);
     Schema.field "messages"
       ~typ:(Schema.non_null message_connection_typ)
       ~args:Arg.[
@@ -654,7 +654,7 @@ let schema =
         Arg.arg "after" ~typ:Arg.string;
       ]
       ~resolve:(fun info () first after ->
-        messages_connection info.ctx.room_config first after);
+        messages_connection info.ctx.coord_config first after);
   ]
 
 let handle_request ~config body_str =
@@ -679,7 +679,7 @@ let handle_request ~config body_str =
                { status = `Bad_request; body = graphql_error err }
            | Ok doc ->
                let variables = variables_of_yojson variables_json in
-               let ctx = { room_config = config } in
+               let ctx = { coord_config = config } in
                let result =
                  if variables = [] then
                    Schema.execute schema ctx ?operation_name doc

--- a/lib/graphql_api.mli
+++ b/lib/graphql_api.mli
@@ -18,13 +18,13 @@
 
     Internal: ~25+ helpers + 5 internal types stay private —
     \[ctx] (the per-request GraphQL execution context, carrying
-    [room_config]), \[page_info] / [\'a edge] / [\'a connection]
+    [coord_config]), \[page_info] / [\'a edge] / [\'a connection]
     (internal Connection-spec records used by the schema
     builders), \[task_status_info] type +
     \[task_status_info_of_task] projector, the schema typ
     definitions ([page_info_typ],
     [task_status_typ], [task_typ], [agent_meta_typ],
-    [agent_typ], [message_typ], [room_state_typ],
+    [agent_typ], [message_typ], [coord_state_typ],
     [task_edge_typ], [agent_edge_typ], etc.), and
     \[drop_after_id] (cursor-based pagination cursor
     consumption helper).  All consumed only inside the schema

--- a/lib/grpc/masc_grpc_server.ml
+++ b/lib/grpc/masc_grpc_server.ml
@@ -395,11 +395,11 @@ end
 
 let create_server
       ~(port : int)
-      ~(room_config : Coord_utils_backend_setup.config)
+      ~(coord_config : Coord_utils_backend_setup.config)
       ~(tool_dispatcher : string -> string -> (string, string) result)
   : Grpc_eio.Server.t
   =
-  let service = Masc_grpc_service.create_service ~room_config ~tool_dispatcher in
+  let service = Masc_grpc_service.create_service ~coord_config ~tool_dispatcher in
   let health = Grpc_eio.Health.create ~default_status:Grpc_eio.Health.Serving () in
   Grpc_eio.Health.register_service health ~service:Masc_grpc_service.service_name;
   Grpc_eio.Health.set_status
@@ -446,12 +446,12 @@ let create_server
 
     @param sw Eio switch for structured concurrency.
     @param env Eio environment (for network access).
-    @param room_config The MASC room configuration.
+    @param coord_config The MASC room configuration.
     @param tool_dispatcher Function that dispatches tool calls. *)
 let start
       ~(sw : Eio.Switch.t)
       ~(env : Eio_unix.Stdenv.base)
-      ~(room_config : Coord_utils_backend_setup.config)
+      ~(coord_config : Coord_utils_backend_setup.config)
       ~(tool_dispatcher : string -> string -> (string, string) result)
   : unit
   =
@@ -464,7 +464,7 @@ let start
     let port = configured_port () in
     Eio.Fiber.fork ~sw (fun () ->
       try
-        let server = create_server ~port ~room_config ~tool_dispatcher in
+        let server = create_server ~port ~coord_config ~tool_dispatcher in
         Log.Server.info
           "gRPC coordination server starting on port %d (health + reflection enabled)"
           port;

--- a/lib/grpc/masc_grpc_server.mli
+++ b/lib/grpc/masc_grpc_server.mli
@@ -19,7 +19,7 @@ val is_enabled : unit -> bool
     services. Exposed for tests and local transport wiring checks. *)
 val create_server :
   port:int ->
-  room_config:Coord_utils_backend_setup.config ->
+  coord_config:Coord_utils_backend_setup.config ->
   tool_dispatcher:(string -> string -> (string, string) result) ->
   Grpc_eio.Server.t
 
@@ -29,11 +29,11 @@ val create_server :
 
     @param sw Eio switch for structured concurrency.
     @param env Eio environment.
-    @param room_config The MASC room configuration.
+    @param coord_config The MASC room configuration.
     @param tool_dispatcher Function that dispatches tool calls. *)
 val start :
   sw:Eio.Switch.t ->
   env:Eio_unix.Stdenv.base ->
-  room_config:Coord_utils_backend_setup.config ->
+  coord_config:Coord_utils_backend_setup.config ->
   tool_dispatcher:(string -> string -> (string, string) result) ->
   unit

--- a/lib/grpc/masc_grpc_service.ml
+++ b/lib/grpc/masc_grpc_service.ml
@@ -79,7 +79,7 @@ let task_info_of_task (task : Masc_domain.task) : T.task_info =
 (** {1 Unary Handlers} *)
 
 (** Broadcast handler: send a message to all agents. *)
-let handle_broadcast (room_config : Coord_utils_backend_setup.config) (bytes : string)
+let handle_broadcast (coord_config : Coord_utils_backend_setup.config) (bytes : string)
   : string
   =
   let req =
@@ -96,7 +96,7 @@ let handle_broadcast (room_config : Coord_utils_backend_setup.config) (bytes : s
           in
           mention_prefix ^ " " ^ req.message)
       in
-      let _msg = Coord.broadcast room_config ~from_agent:req.agent_name ~content in
+      let _msg = Coord.broadcast coord_config ~from_agent:req.agent_name ~content in
       T.BroadcastResponse.{ success = true; seq = now_ms () }
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
@@ -108,10 +108,10 @@ let handle_broadcast (room_config : Coord_utils_backend_setup.config) (bytes : s
 ;;
 
 (** GetStatus handler: return current room state. *)
-let handle_get_status (room_config : Coord_utils_backend_setup.config) (_bytes : string)
+let handle_get_status (coord_config : Coord_utils_backend_setup.config) (_bytes : string)
   : string
   =
-  let masc_dir = Common.masc_dir_from_base_path ~base_path:room_config.base_path in
+  let masc_dir = Common.masc_dir_from_base_path ~base_path:coord_config.base_path in
   let agents_dir = Filename.concat masc_dir "agents" in
   let agents =
     if Sys.file_exists agents_dir && Sys.is_directory agents_dir
@@ -145,9 +145,9 @@ let handle_get_status (room_config : Coord_utils_backend_setup.config) (_bytes :
           None)
     else []
   in
-  let tasks = Coord.get_tasks_safe room_config |> List.map task_info_of_task in
+  let tasks = Coord.get_tasks_safe coord_config |> List.map task_info_of_task in
   T.StatusResponse.(
-    to_bytes { agents; tasks; message_count = 0; room_path = room_config.base_path })
+    to_bytes { agents; tasks; message_count = 0; workspace_path = coord_config.base_path })
 ;;
 
 (** ToolCall handler: dispatch an MCP tool call via gRPC. *)
@@ -208,11 +208,11 @@ let active_subscribe_streams = Atomic.make 0
     Returns a list of string directives to include in HeartbeatAck.
     Reads agent paused state and unclaimed tasks from the filesystem. *)
 let compute_directives
-      ~(room_config : Coord_utils_backend_setup.config)
+      ~(coord_config : Coord_utils_backend_setup.config)
       ~(agent_name : string)
   : string list
   =
-  let masc_dir = Common.masc_dir_from_base_path ~base_path:room_config.base_path in
+  let masc_dir = Common.masc_dir_from_base_path ~base_path:coord_config.base_path in
   let directives = ref [] in
   (* 1. Pause directive: check if agent is marked paused *)
   let agent_file =
@@ -236,10 +236,10 @@ let compute_directives
         agent_file
         (Printexc.to_string exn));
   (* 2. Task assignment: find first unclaimed task for idle agent *)
-  if Coord.root_is_initialized room_config
+  if Coord.root_is_initialized coord_config
   then (
     let unclaimed =
-      Coord.get_tasks_safe room_config
+      Coord.get_tasks_safe coord_config
       |> List.filter_map (fun (task : Masc_domain.task) ->
         match task.task_status with
         | Masc_domain.Todo -> Some task.id
@@ -257,7 +257,7 @@ let compute_directives
 
 (** Heartbeat bidi handler: receive pings, respond with acks. *)
 let handle_heartbeat
-      (room_config : Coord_utils_backend_setup.config)
+      (coord_config : Coord_utils_backend_setup.config)
       ~(sw : Eio.Switch.t)
       (request_stream : string Grpc_eio.Stream.t)
   : string Grpc_eio.Stream.t
@@ -294,7 +294,7 @@ let handle_heartbeat
                  let agent_file =
                    Filename.concat
                      (Filename.concat
-                        (Common.masc_dir_from_base_path ~base_path:room_config.base_path)
+                        (Common.masc_dir_from_base_path ~base_path:coord_config.base_path)
                         "agents")
                      (safe_filename ping.agent_name ^ ".json")
                  in
@@ -325,7 +325,7 @@ let handle_heartbeat
                    (Printexc.to_string exn));
               (* Count active agents and pending tasks *)
               let masc_dir =
-                Common.masc_dir_from_base_path ~base_path:room_config.base_path
+                Common.masc_dir_from_base_path ~base_path:coord_config.base_path
               in
               let agents_dir = Filename.concat masc_dir "agents" in
               let agent_count =
@@ -344,7 +344,7 @@ let handle_heartbeat
                 else 0
               in
               let directives =
-                compute_directives ~room_config ~agent_name:ping.agent_name
+                compute_directives ~coord_config ~agent_name:ping.agent_name
               in
               let ack =
                 T.HeartbeatAck.
@@ -382,7 +382,7 @@ let handle_heartbeat
 ;;
 
 (** Subscribe server-streaming handler: push room events to the agent. *)
-let handle_subscribe (room_config : Coord_utils_backend_setup.config) (bytes : string)
+let handle_subscribe (coord_config : Coord_utils_backend_setup.config) (bytes : string)
   : string Grpc_eio.Stream.t
   =
   let req =
@@ -428,7 +428,7 @@ let handle_subscribe (room_config : Coord_utils_backend_setup.config) (bytes : s
   (* Read recent messages and push as events *)
   let backlog_file =
     Filename.concat
-      (Common.masc_dir_from_base_path ~base_path:room_config.base_path)
+      (Common.masc_dir_from_base_path ~base_path:coord_config.base_path)
       "backlog.jsonl"
   in
   if Sys.file_exists backlog_file
@@ -535,19 +535,19 @@ let handle_subscribe (room_config : Coord_utils_backend_setup.config) (bytes : s
 
 (** Create the gRPC service with all handlers wired to the given room config.
 
-    @param room_config The MASC room configuration.
+    @param coord_config The MASC room configuration.
     @param tool_dispatcher Function that dispatches tool calls:
       [tool_name -> arguments_json -> (result_json, error_message) result]. *)
 let create_service
-      ~(room_config : Coord_utils_backend_setup.config)
+      ~(coord_config : Coord_utils_backend_setup.config)
       ~(tool_dispatcher : string -> string -> (string, string) result)
   : Grpc_eio.Service.t
   =
   Grpc_eio.Service.create service_name
-  |> Grpc_eio.Service.add_unary "Broadcast" (handle_broadcast room_config)
-  |> Grpc_eio.Service.add_unary "GetStatus" (handle_get_status room_config)
+  |> Grpc_eio.Service.add_unary "Broadcast" (handle_broadcast coord_config)
+  |> Grpc_eio.Service.add_unary "GetStatus" (handle_get_status coord_config)
   |> Grpc_eio.Service.add_unary "ToolCall" (handle_tool_call tool_dispatcher)
   |> Grpc_eio.Service.add_unary "LspCall" handle_lsp_call
-  |> Grpc_eio.Service.add_server_streaming "Subscribe" (handle_subscribe room_config)
-  |> Grpc_eio.Service.add_bidi_streaming "Heartbeat" (handle_heartbeat room_config)
+  |> Grpc_eio.Service.add_server_streaming "Subscribe" (handle_subscribe coord_config)
+  |> Grpc_eio.Service.add_bidi_streaming "Heartbeat" (handle_heartbeat coord_config)
 ;;

--- a/lib/grpc/masc_grpc_service.mli
+++ b/lib/grpc/masc_grpc_service.mli
@@ -16,10 +16,10 @@ val stream_max_buffer : unit -> int
 
 (** Create the gRPC service with all handlers wired to the given room config.
 
-    @param room_config The MASC room configuration.
+    @param coord_config The MASC room configuration.
     @param tool_dispatcher Function that dispatches tool calls:
       [tool_name -> arguments_json -> (result_json, error_message) result]. *)
 val create_service :
-  room_config:Coord_utils_backend_setup.config ->
+  coord_config:Coord_utils_backend_setup.config ->
   tool_dispatcher:(string -> string -> (string, string) result) ->
   Grpc_eio.Service.t

--- a/lib/grpc/masc_grpc_types.ml
+++ b/lib/grpc/masc_grpc_types.ml
@@ -362,7 +362,7 @@ module StatusResponse = struct
     { agents : agent_info list
     ; tasks : task_info list
     ; message_count : int
-    ; room_path : string
+    ; workspace_path : string
     }
 
   let of_bytes bytes =
@@ -370,7 +370,7 @@ module StatusResponse = struct
     { agents = List.map agent_info_of_proto p.agents
     ; tasks = List.map task_info_of_proto p.tasks
     ; message_count = p.message_count
-    ; room_path = p.room_path
+    ; workspace_path = p.workspace_path
     }
   ;;
 
@@ -380,7 +380,7 @@ module StatusResponse = struct
       { agents = List.map agent_info_to_proto t.agents
       ; tasks = List.map task_info_to_proto t.tasks
       ; message_count = t.message_count
-      ; room_path = t.room_path
+      ; workspace_path = t.workspace_path
       }
   ;;
 end

--- a/lib/grpc/masc_grpc_types.mli
+++ b/lib/grpc/masc_grpc_types.mli
@@ -143,7 +143,7 @@ module StatusResponse : sig
     { agents : agent_info list
     ; tasks : task_info list
     ; message_count : int
-    ; room_path : string
+    ; workspace_path : string
     }
 
   val of_bytes : string -> t

--- a/lib/institution_eio.ml
+++ b/lib/institution_eio.ml
@@ -436,13 +436,13 @@ module Pure = struct
     { inst with memory = { inst.memory with procedural } }
   ;;
 
-  let agent_join inst ~agent_id =
+  let agent_session_bound inst ~agent_id =
     if List.mem agent_id inst.current_agents
     then inst
     else { inst with current_agents = agent_id :: inst.current_agents }
   ;;
 
-  let agent_leave inst ~agent_id =
+  let agent_session_ended inst ~agent_id =
     if List.mem agent_id inst.current_agents
     then
       { inst with
@@ -577,13 +577,13 @@ let codify_pattern ~fs config inst ~name ~description ~trigger ~steps =
 ;;
 
 let join ~fs config inst ~agent_id =
-  let inst' = Pure.agent_join inst ~agent_id in
+  let inst' = Pure.agent_session_bound inst ~agent_id in
   save_institution ~fs config inst';
   inst'
 ;;
 
 let leave ~fs config inst ~agent_id =
-  let inst' = Pure.agent_leave inst ~agent_id in
+  let inst' = Pure.agent_session_ended inst ~agent_id in
   save_institution ~fs config inst';
   inst'
 ;;

--- a/lib/keeper/keeper_sandbox_docker.ml
+++ b/lib/keeper/keeper_sandbox_docker.ml
@@ -389,7 +389,7 @@ let docker_run_argv
   @ Keeper_sandbox_runtime.docker_config_mount_args
       ~base_path:config.base_path
       ~container_root
-  @ Keeper_sandbox_runtime.docker_room_state_mount_args
+  @ Keeper_sandbox_runtime.docker_coord_state_mount_args
       ~base_path:config.base_path
       ~container_root
   @ network_args

--- a/lib/keeper/keeper_sandbox_read_backend.ml
+++ b/lib/keeper/keeper_sandbox_read_backend.ml
@@ -90,7 +90,7 @@ let build_docker_argv ~image ~container_name ~base_path ~host_root ~croot
   @ Keeper_sandbox_runtime.docker_config_mount_args
       ~base_path
       ~container_root:croot
-  @ Keeper_sandbox_runtime.docker_room_state_mount_args
+  @ Keeper_sandbox_runtime.docker_coord_state_mount_args
       ~base_path
       ~container_root:croot
   @ [

--- a/lib/keeper/keeper_sandbox_runtime.mli
+++ b/lib/keeper/keeper_sandbox_runtime.mli
@@ -224,13 +224,13 @@ val docker_config_mount_args
     outside [<container_root>] because that path is itself a bind-mounted
     playground; host-absolute [.masc] targets must never be used as Docker
     mount destinations. *)
-val docker_room_state_mount_specs
+val docker_coord_state_mount_specs
   :  base_path:string
   -> container_root:string
   -> string list
 
-(** Docker [-v ...] argv fragment for {!docker_room_state_mount_specs}. *)
-val docker_room_state_mount_args
+(** Docker [-v ...] argv fragment for {!docker_coord_state_mount_specs}. *)
+val docker_coord_state_mount_args
   :  base_path:string
   -> container_root:string
   -> string list

--- a/lib/keeper/keeper_sandbox_runtime_setup.ml
+++ b/lib/keeper/keeper_sandbox_runtime_setup.ml
@@ -347,11 +347,11 @@ let docker_config_mount_args ~base_path ~container_root =
     ]
 ;;
 
-type room_state_mount_kind =
+type coord_state_mount_kind =
   | Room_state_file
   | Room_state_dir
 
-let docker_room_state_mounts =
+let docker_coord_state_mounts =
   [ Room_state_dir, "tasks"
   ; Room_state_file, "tasks.json"
   ; Room_state_file, "backlog.json"
@@ -366,7 +366,7 @@ let docker_room_state_mounts =
   ]
 ;;
 
-let room_state_path_available kind path =
+let coord_state_path_available kind path =
   try
     match kind with
     | Room_state_file -> Sys.file_exists path && not (Sys.is_directory path)
@@ -386,16 +386,16 @@ let unique_preserving_order values =
   loop [] [] values
 ;;
 
-let docker_room_state_mount_specs ~base_path ~container_root =
+let docker_coord_state_mount_specs ~base_path ~container_root =
   let host_masc_root = Common.masc_dir_from_base_path ~base_path in
   (* [container_root] is itself a bind-mounted playground. Mounting room-state
      files inside it creates nested bind targets that Docker Desktop can resolve
      through /run/host_virtiofs and reject as outside the container rootfs. *)
   let container_masc_root = container_masc_dir ~container_root in
-  docker_room_state_mounts
+  docker_coord_state_mounts
   |> List.concat_map (fun (kind, rel_path) ->
     let host_path = Filename.concat host_masc_root rel_path in
-    if not (room_state_path_available kind host_path)
+    if not (coord_state_path_available kind host_path)
     then []
     else
       [ Printf.sprintf "%s:%s:ro" host_path (Filename.concat container_masc_root rel_path)
@@ -403,8 +403,8 @@ let docker_room_state_mount_specs ~base_path ~container_root =
   |> unique_preserving_order
 ;;
 
-let docker_room_state_mount_args ~base_path ~container_root =
-  docker_room_state_mount_specs ~base_path ~container_root
+let docker_coord_state_mount_args ~base_path ~container_root =
+  docker_coord_state_mount_specs ~base_path ~container_root
   |> List.concat_map (fun spec -> [ "-v"; spec ])
 ;;
 

--- a/lib/keeper/keeper_sandbox_runtime_setup.mli
+++ b/lib/keeper/keeper_sandbox_runtime_setup.mli
@@ -110,13 +110,13 @@ val docker_config_container_root : container_root:'a -> string
 val docker_config_available : string -> bool
 val docker_config_mount_args :
   base_path:string -> container_root:'a -> string list
-type room_state_mount_kind = Room_state_file | Room_state_dir
-val docker_room_state_mounts : (room_state_mount_kind * string) list
-val room_state_path_available : room_state_mount_kind -> string -> bool
+type coord_state_mount_kind = Room_state_file | Room_state_dir
+val docker_coord_state_mounts : (coord_state_mount_kind * string) list
+val coord_state_path_available : coord_state_mount_kind -> string -> bool
 val unique_preserving_order : 'a list -> 'a list
-val docker_room_state_mount_specs :
+val docker_coord_state_mount_specs :
   base_path:string -> container_root:'a -> string list
-val docker_room_state_mount_args :
+val docker_coord_state_mount_args :
   base_path:string -> container_root:'a -> string list
 val docker_config_env_args :
   base_path:string -> container_root:'a -> string list

--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -352,7 +352,7 @@ let start_container (t : t) ~(timeout_sec : float) =
            @ Keeper_sandbox_runtime.docker_config_mount_args
                ~base_path:t.config.base_path
                ~container_root:t.container_root
-           @ Keeper_sandbox_runtime.docker_room_state_mount_args
+           @ Keeper_sandbox_runtime.docker_coord_state_mount_args
                ~base_path:t.config.base_path
                ~container_root:t.container_root
            @ cred_mounts

--- a/lib/local/worker_container.ml
+++ b/lib/local/worker_container.ml
@@ -337,7 +337,7 @@ let local_worker_failure_class_of_error_kind = function
   | Worker_dev_tools.Shell_error ->
     Tool_result.Runtime_failure
 
-let build_local_shell_tools ~room_config ~worker_name ~workdir =
+let build_local_shell_tools ~coord_config ~worker_name ~workdir =
   match Process_eio.get_proc_mgr (), Process_eio.get_clock () with
   | Ok proc_mgr, Ok clock -> (
       (* #10358: forward error_kind / error_message from Worker_dev_tools
@@ -346,7 +346,7 @@ let build_local_shell_tools ~room_config ~worker_name ~workdir =
          worker tool path. *)
       let on_exec ~tool_name ~success ~duration_ms
           ?error_kind ?error_message () =
-        (match room_config, Fs_compat.get_fs_opt () with
+        (match coord_config, Fs_compat.get_fs_opt () with
         | Some config, Some fs -> (
             try
               let kind =

--- a/lib/local/worker_container.mli
+++ b/lib/local/worker_container.mli
@@ -155,14 +155,14 @@ val build_oas_mcp_tools :
     errors into [Agent_sdk.Types.tool_result]. *)
 
 val build_local_shell_tools :
-  room_config:Coord.config option ->
+  coord_config:Coord.config option ->
   worker_name:string ->
   workdir:string ->
   (Agent_sdk.Tool.t list, string) result
 (** Builds the local-shell tool subset (process exec /
     file IO).  Errors when {!Process_eio.get_proc_mgr} or
     {!Process_eio.get_clock} are unavailable.  Hooks
-    telemetry through [room_config] when an Eio fs is
+    telemetry through [coord_config] when an Eio fs is
     present; missing either drops telemetry silently. *)
 
 (** {1 Provider resolution} *)

--- a/lib/local/worker_container_runners.ml
+++ b/lib/local/worker_container_runners.ml
@@ -72,7 +72,7 @@ let create_raw_trace ~base_path ~worker_name =
       (Printf.sprintf "failed to create worker raw trace for %s: %s"
          worker_name msg)
 
-let run_worker_oas ~sw ?net ~room_config
+let run_worker_oas ~sw ?net ~coord_config
     (spec : Worker_execution_spec.t) : unit -> (run_result, string) result =
   fun () ->
     let* net = resolve_net ?net () in
@@ -107,7 +107,7 @@ let run_worker_oas ~sw ?net ~room_config
         ~worker_name
     in
     let* shell_tools =
-      build_local_shell_tools ~room_config ~worker_name ~workdir:workspace_path
+      build_local_shell_tools ~coord_config ~worker_name ~workdir:workspace_path
     in
     let tools = dedupe_tools_by_name (masc_tools @ shell_tools) in
     let* raw_trace = create_raw_trace ~base_path ~worker_name in

--- a/lib/local/worker_container_runners.mli
+++ b/lib/local/worker_container_runners.mli
@@ -26,11 +26,11 @@ end
 val run_worker_oas :
   sw:Eio.Switch.t ->
   ?net:Eio_context.eio_net ->
-  room_config:Coord.config option ->
+  coord_config:Coord.config option ->
   Worker_execution_spec.t ->
   unit ->
   (run_result, string) result
-(** [run_worker_oas ~sw ?net ~room_config spec] returns a thunk
+(** [run_worker_oas ~sw ?net ~coord_config spec] returns a thunk
     that runs (or resumes) the worker via OAS:
 
     - Resolve net (from [?net] or {!Eio_context}).

--- a/lib/mcp_sdk_adapter_masc.ml
+++ b/lib/mcp_sdk_adapter_masc.ml
@@ -269,7 +269,7 @@ let create_handler
                  (List.map (fun (key, value) -> (key, `String value)) arguments)
              in
              match
-               Mcp_prompt_surface.get_json ~config:state.Mcp_server.room_config
+               Mcp_prompt_surface.get_json ~config:state.Mcp_server.coord_config
                  ~name:prompt.name ~arguments:args_json
                  Config.raw_all_tool_schemas
              with

--- a/lib/mcp_server.ml
+++ b/lib/mcp_server.ml
@@ -478,7 +478,7 @@ let schema_markdown =
 
 (** MCP Server state *)
 type server_state = {
-  mutable room_config: Coord.config;
+  mutable coord_config: Coord.config;
   session_registry: Session.registry;
   on_sse_broadcast: (Yojson.Safe.t -> unit) option Atomic.t;  (* SSE push callback, Atomic for cross-fiber visibility *)
   sw: Eio.Switch.t option; (* Request/runtime fibers for HTTP/MCP handlers *)
@@ -497,7 +497,7 @@ let create_state ~base_path =
     Session.push_notification_to_active_agents registry ~event
   );
   let state = {
-    room_config = config;
+    coord_config = config;
     session_registry = registry;
     on_sse_broadcast = Atomic.make None;
     sw = None;
@@ -508,7 +508,7 @@ let create_state ~base_path =
     net = None;
   } in
   Tool_board.set_agent_lookup (fun name ->
-    try Coord.is_agent_session_bound state.room_config ~agent_name:name
+    try Coord.is_agent_session_bound state.coord_config ~agent_name:name
     with Sys_error _ | Not_found | Invalid_argument _ -> false);
   state
 
@@ -541,7 +541,7 @@ let create_state_eio ~sw ~proc_mgr ~fs ~clock ~mono_clock ~net ~base_path =
     Session.push_notification_to_active_agents registry ~event
   );
   let state = {
-    room_config = config;
+    coord_config = config;
     session_registry = registry;
     on_sse_broadcast = Atomic.make None;
     sw = Some sw;
@@ -551,10 +551,10 @@ let create_state_eio ~sw ~proc_mgr ~fs ~clock ~mono_clock ~net ~base_path =
     mono_clock = Some mono_clock;
     net = Some net;
   } in
-  (* Board post kind auto-classification: reads state.room_config so
+  (* Board post kind auto-classification: reads state.coord_config so
      room changes via set_room are reflected automatically. *)
   Tool_board.set_agent_lookup (fun name ->
-    try Coord.is_agent_session_bound state.room_config ~agent_name:name
+    try Coord.is_agent_session_bound state.coord_config ~agent_name:name
     with Sys_error _ | Not_found | Invalid_argument _ -> false);
   state
 

--- a/lib/mcp_server.mli
+++ b/lib/mcp_server.mli
@@ -173,7 +173,7 @@ val schema_markdown : string
 (** {1 Server state} *)
 
 type server_state = {
-  mutable room_config : Coord.config;
+  mutable coord_config : Coord.config;
   session_registry : Session.registry;
   on_sse_broadcast :
     (Yojson.Safe.t -> unit) option Atomic.t;
@@ -185,7 +185,7 @@ type server_state = {
   net : Eio_context.eio_net option;
 }
 (** Runtime state threaded through every request handler.
-    [room_config] is mutable so room-switch tools can swap
+    [coord_config] is mutable so room-switch tools can swap
     backends mid-flight.  Eio handles are [option] because
     the legacy non-Eio bootstrap ({!create_state}) still
     needs to construct a state without an active switch. *)

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -688,7 +688,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
               (if !timeout_hit then 1 else 0) duration_ms truncated)
   in
   let otel_trace_id = Otel_spans.current_trace_id () in
-  Audit_log.log_tool_call state.Mcp_server.room_config
+  Audit_log.log_tool_call state.Mcp_server.coord_config
     ~agent_id:agent_name ~tool_name:name ~success ~error_msg:error_detail
     ?trace_id:otel_trace_id ();
   if not success then (
@@ -758,7 +758,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
   if telemetry_enabled then
     (match state.Mcp_server.fs with
      | Some fs ->
-         (try Telemetry_eio.track_tool_called ~fs state.Mcp_server.room_config
+         (try Telemetry_eio.track_tool_called ~fs state.Mcp_server.coord_config
                 ~tool_name:name ~agent_id:agent_name ~success ~duration_ms
                 ~source:(Tool_registry.string_of_source source)
                 ?session_id:telemetry_session_id
@@ -834,7 +834,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
 
   (* Emit activity graph event for tool call — enables real-time dashboard tracking *)
   (try
-    ignore (Activity_graph.emit state.Mcp_server.room_config
+    ignore (Activity_graph.emit state.Mcp_server.coord_config
       ~actor:(Activity_graph.entity ~kind:"agent" agent_name)
       ~subject:(Activity_graph.entity ~kind:"tool" name)
       ~kind:"tool.called"

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -60,7 +60,7 @@ let execute_tool_eio
   Eio_context.set_clock clock;
   (* Prometheus: count every inbound tool call *)
   Prometheus.record_request ();
-  let config = state.Mcp_server.room_config in
+  let config = state.Mcp_server.coord_config in
   let registry = state.Mcp_server.session_registry in
   (* Fix 3: Cache room_initialized to avoid repeated stat syscalls.
      Updated after auto-init succeeds. *)

--- a/lib/mcp_server_eio_protocol.ml
+++ b/lib/mcp_server_eio_protocol.ml
@@ -237,7 +237,7 @@ let handle_list_tools_eio
       Some
         (Telemetry_eio.summarize_tool_usage
            ?fs:state.Mcp_server.fs
-           state.Mcp_server.room_config)
+           state.Mcp_server.coord_config)
     else None
   in
   let tools =
@@ -397,7 +397,7 @@ let handle_get_prompt_eio state id params =
        in
        (match
           Mcp_prompt_surface.get_json
-            ~config:state.Mcp_server.room_config
+            ~config:state.Mcp_server.coord_config
             ~name
             ~arguments
             Config.raw_all_tool_schemas
@@ -466,7 +466,7 @@ let handle_dashboard_hello_eio state id ?mcp_session_id params =
   | Some session_id, Some (`Assoc fields) ->
     let token = optional_string_member "token" fields in
     Server_mcp_transport_ws.dashboard_hello
-      ~base_path:state.Mcp_server.room_config.base_path
+      ~base_path:state.Mcp_server.coord_config.base_path
       ~session_id
       ?token
       ()
@@ -848,7 +848,7 @@ let run_stdio ~handle_request ~sw ~env state =
   let stdout = Eio.Stdenv.stdout env in
   let clock = Eio.Stdenv.clock env in
   Log.Mcp.info "MASC MCP Server (Eio stdio mode)";
-  Log.Mcp.info "Default room: %s" Mcp_server.(state.room_config.Coord.base_path);
+  Log.Mcp.info "Default room: %s" Mcp_server.(state.coord_config.Coord.base_path);
   let buf = Eio.Buf_read.of_flow stdin ~max_size:(16 * 1024 * 1024) in
   let read_framed_message_after_first_line first_line =
     let rec read_headers acc =

--- a/lib/mcp_server_eio_resource.ml
+++ b/lib/mcp_server_eio_resource.ml
@@ -31,7 +31,7 @@ let handle_read_resource_eio state id params =
         make_error_typed ~id Mcp_error_code.Invalid_params "Missing uri"
       else begin
         let resource_id, uri = Mcp_server.parse_masc_resource_uri uri_str in
-        let config = state.Mcp_server.room_config in
+        let config = state.Mcp_server.coord_config in
         let registry = state.Mcp_server.session_registry in
 
         let read_messages_json ~since_seq ~limit =
@@ -108,7 +108,7 @@ let handle_read_resource_eio state id params =
               ("text/markdown", text_opt)
           | "status" -> ("text/markdown", Some (Coord.status config))
           | "status.json" ->
-              let state_json = Masc_domain.room_state_to_yojson (Coord.read_state config) in
+              let state_json = Masc_domain.coord_state_to_yojson (Coord.read_state config) in
               let backlog_json = Masc_domain.backlog_to_yojson (Coord.read_backlog config) in
               let connected_agents = Session.get_agent_statuses registry in
               let json = `Assoc [

--- a/lib/meta_cognition_snapshot.ml
+++ b/lib/meta_cognition_snapshot.ml
@@ -521,7 +521,7 @@ let snapshot_json ?hearth ~limit config =
   `Assoc
     [
       ("generated_at", `String (Masc_domain.now_iso ()));
-      ( "room_state",
+      ( "coord_state",
         `Assoc
           [
             ("active_agent_count", `Int (List.length agents));

--- a/lib/operator/operator_digest.ml
+++ b/lib/operator/operator_digest.ml
@@ -200,7 +200,7 @@ let keeper_attention_projection_items config =
 let room_recommendations _config =
   dedup_recommendations []
 
-let room_state_json config =
+let coord_state_json config =
   if not (Coord.is_initialized config) then
     `Assoc
       [
@@ -252,7 +252,7 @@ let digest_json ?actor ?target_type ?target_id:_target_id ?include_workers:_incl
   else
     let actor_name = normalized_actor ~context_actor:ctx.agent_name actor in
     let* target_type = normalize_digest_target_type target_type in
-    let room_state_json = room_state_json config in
+    let coord_state_json = coord_state_json config in
     match target_type with
     | "root" ->
         let confirm_scope = pending_confirm_scope ?actor config in
@@ -295,7 +295,7 @@ let digest_json ?actor ?target_type ?target_id:_target_id ?include_workers:_incl
                   (List.map (recommended_action_to_yojson ~actor:actor_name)
                      recommended_actions) );
               ("recommendation_summary", fallback_recommendation_summary);
-              ("root", room_state_json);
+              ("root", coord_state_json);
             ]
             @ [ ("recent_reviews", recent_reviews) ]
             @ active_guidance))

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -29,13 +29,13 @@ let load_config () =
 let default_config = load_config ()
 
 (** Check if orchestration is needed *)
-let should_orchestrate ~min_priority room_config =
+let should_orchestrate ~min_priority coord_config =
   (* Check if room is paused first *)
-  if Coord.is_paused room_config then begin
+  if Coord.is_paused coord_config then begin
     Log.Orchestrator.debug "room is paused, skipping";
     false
   end else begin
-  match Coord.read_backlog_r room_config with
+  match Coord.read_backlog_r coord_config with
   | Error msg ->
       Log.Orchestrator.error
         "backlog unavailable, skipping orchestration check: %s" msg;
@@ -47,7 +47,7 @@ let should_orchestrate ~min_priority room_config =
       ) backlog.tasks in
 
       (* Get active (non-zombie) agents *)
-      let agents = Coord.get_agents_raw room_config in
+      let agents = Coord.get_agents_raw coord_config in
       let active_agents = List.filter (fun (agent: Masc_domain.agent) ->
         not (Coord_resilience.Zombie.is_zombie agent.last_seen)
       ) agents in
@@ -125,14 +125,14 @@ let with_pulse_ro f = Eio_guard.with_mutex_ro pulse_mu f
 
 (** Build the orchestrator check consumer.
     Checks if orchestration is needed and spawns coordinator if so. *)
-let make_orchestrator_check_consumer ~sw ~proc_mgr ?domain_mgr ~config ~room_config ()
+let make_orchestrator_check_consumer ~sw ~proc_mgr ?domain_mgr ~config ~coord_config ()
     : (module Pulse.Consumer) =
   (module struct
     let name = "orchestrator-check"
     let should_act _beat = config.enabled
     let on_beat _beat =
       try
-        if should_orchestrate ~min_priority:config.min_priority room_config then
+        if should_orchestrate ~min_priority:config.min_priority coord_config then
           Log.Orchestrator.info "orchestration needed but vendor-specific spawn removed";
         Ok ()
       with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
@@ -143,7 +143,7 @@ let make_orchestrator_check_consumer ~sw ~proc_mgr ?domain_mgr ~config ~room_con
 
 (** Build the zero-zombie cleanup consumer.
     Runs Coord.cleanup_zombies and logs if zombies were found. *)
-let make_zero_zombie_consumer ~sw ~room_config
+let make_zero_zombie_consumer ~sw ~coord_config
     : (module Pulse.Consumer) =
   let cleanup_running = Atomic.make false in
   (module struct
@@ -175,7 +175,7 @@ let make_zero_zombie_consumer ~sw ~room_config
       let release_stale_claims_typed () : Stale_claim_outcome.t =
         let ttl = Env_config_runtime.Claim.ttl_seconds in
         match
-          Coord_task_schedule.release_stale_claims room_config ~ttl_seconds:ttl
+          Coord_task_schedule.release_stale_claims coord_config ~ttl_seconds:ttl
         with
         | exception (Eio.Cancel.Cancelled _ as e) -> raise e
         | exception exn ->
@@ -194,7 +194,7 @@ let make_zero_zombie_consumer ~sw ~room_config
             ~finally:(fun () -> Atomic.set cleanup_running false)
             (fun () ->
               try
-                let zombie_result = Coord.cleanup_zombies room_config in
+                let zombie_result = Coord.cleanup_zombies coord_config in
                 (* Explicit variant match — no catch-all.  Adding a new
                    [cleanup_zombie_result] constructor must surface as a
                    compile error here, not a silent debug. *)
@@ -243,13 +243,13 @@ let make_zero_zombie_consumer ~sw ~room_config
 
 (** Start the orchestrator background services using Pulse.
     Returns a cancel function to gracefully stop both Pulse engines. *)
-let start ~sw ~proc_mgr ~clock ?domain_mgr room_config =
+let start ~sw ~proc_mgr ~clock ?domain_mgr coord_config =
   let config = load_config () in
 
   (* Zero-Zombie cleanup: always enabled, configurable interval *)
   let neo4j_interval = Env_config_governance.Timeouts.neo4j_timeout_sec in
   Log.Orchestrator.debug "zero-zombie cleanup enabled (interval: %.0fs)" neo4j_interval;
-  let zombie_consumer = make_zero_zombie_consumer ~sw ~room_config in
+  let zombie_consumer = make_zero_zombie_consumer ~sw ~coord_config in
   let dedup_consumer = Channel_gate.make_dedup_cleanup_consumer () in
   let zp = Pulse.create ~clock ~rhythm:(fixed_rhythm neo4j_interval) ~lifecycle:Always_on ~consumers:[zombie_consumer; dedup_consumer] in
   with_pulse_rw (fun () -> zombie_pulse := Some zp);
@@ -268,7 +268,7 @@ let start ~sw ~proc_mgr ~clock ?domain_mgr room_config =
   else
     Log.Orchestrator.debug "loop disabled (set MASC_ORCHESTRATOR_ENABLED=1 to enable)";
 
-  let orch_consumer = make_orchestrator_check_consumer ~sw ~proc_mgr ?domain_mgr ~config ~room_config () in
+  let orch_consumer = make_orchestrator_check_consumer ~sw ~proc_mgr ?domain_mgr ~config ~coord_config () in
   let op = Pulse.create ~clock ~rhythm:(fixed_rhythm config.check_interval_s) ~lifecycle:Always_on ~consumers:[orch_consumer] in
   with_pulse_rw (fun () -> orchestrator_pulse := Some op);
   Eio.Fiber.fork ~sw (fun () ->

--- a/lib/relation_materializer.ml
+++ b/lib/relation_materializer.ml
@@ -63,7 +63,7 @@ let record_collaborations_async ~tag ~context ~agent ~peers =
     between the departing agent and every other active agent.
     Runs asynchronously — returns immediately.
     20 peers = 1 HTTP request (alias batching). *)
-let on_agent_leave ~leaving_agent ~active_agents =
+let on_agent_session_ended ~leaving_agent ~active_agents =
   let peers = List.filter (fun name -> name <> leaving_agent) active_agents in
   if peers <> [] then
     record_collaborations_async

--- a/lib/relation_materializer.mli
+++ b/lib/relation_materializer.mli
@@ -14,7 +14,7 @@
 
     @since 2.112.0 *)
 
-val on_agent_leave :
+val on_agent_session_ended :
   leaving_agent:string ->
   active_agents:string list ->
   unit

--- a/lib/server/server_activity_http.ml
+++ b/lib/server/server_activity_http.ml
@@ -113,7 +113,7 @@ let events_http_json ~deps ~state request =
        Offload via Domain_pool_ref still protects the HTTP main
        domain from JSONL-scan stall. *)
     Domain_pool_ref.submit_io_or_inline (fun () ->
-      Activity_graph.json_response state.Mcp_server.room_config ~kinds
+      Activity_graph.json_response state.Mcp_server.coord_config ~kinds
         ~after_seq ~limit ())
 
 let parse_since_ms (raw : string) : int option =
@@ -172,7 +172,7 @@ let graph_http_json ~deps ~state request =
             Some (now_ms - delta_ms)
         | None -> None
       in
-      Activity_graph.graph_json state.Mcp_server.room_config ~kinds ~limit
+      Activity_graph.graph_json state.Mcp_server.coord_config ~kinds ~limit
         ~timeline_limit ?since_ms ())
 
 let swimlane_http_json ~deps ~state request =
@@ -207,7 +207,7 @@ let swimlane_http_json ~deps ~state request =
             Some (now_ms - delta_ms)
         | None -> None
       in
-      Activity_graph.agent_spans_json state.Mcp_server.room_config ~limit
+      Activity_graph.agent_spans_json state.Mcp_server.coord_config ~limit
         ?since_ms ())
 
 let stream_headers ~deps origin =
@@ -300,7 +300,7 @@ let handle_stream ~deps ~state request reqd =
        (Printf.sprintf ": activity-stream after=%d\nretry: 3000\n\n"
           after_seq));
   let replay =
-    Activity_graph.list_events state.Mcp_server.room_config ~kinds
+    Activity_graph.list_events state.Mcp_server.coord_config ~kinds
       ~after_seq ~limit:replay_limit ()
   in
   List.iter (fun value -> ignore (send_raw info (Activity_graph.format_sse_event value))) replay;

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -887,7 +887,7 @@ and with_read_auth handler request reqd =
   match !server_state with
   | None -> Http_server_eio.Response.json {|{"error":"not initialized"}|} reqd
   | Some state ->
-      let base_path = state.Mcp_server.room_config.base_path in
+      let base_path = state.Mcp_server.coord_config.base_path in
       (match authorize_read_request ~base_path request with
       | Ok () ->
           (match check_agent_rate_limit request reqd with
@@ -899,7 +899,7 @@ and with_permission_auth ~permission handler request reqd =
   match !server_state with
   | None -> Http_server_eio.Response.json {|{"error":"not initialized"}|} reqd
   | Some state ->
-      let base_path = state.Mcp_server.room_config.base_path in
+      let base_path = state.Mcp_server.coord_config.base_path in
       (match authorize_permission_request ~base_path ~permission request with
       | Ok () ->
           (match check_agent_rate_limit request reqd with
@@ -911,7 +911,7 @@ and with_tool_auth ~tool_name handler request reqd =
   match !server_state with
   | None -> Http_server_eio.Response.json {|{"error":"not initialized"}|} reqd
   | Some state ->
-      let base_path = state.Mcp_server.room_config.base_path in
+      let base_path = state.Mcp_server.coord_config.base_path in
       (match authorize_tool_request ~base_path ~tool_name request with
       | Ok () ->
           (match check_agent_rate_limit request reqd with
@@ -923,7 +923,7 @@ and with_token_permission_auth ~permission handler request reqd =
   match !server_state with
   | None -> Http_server_eio.Response.json {|{"error":"not initialized"}|} reqd
   | Some state ->
-      let base_path = state.Mcp_server.room_config.base_path in
+      let base_path = state.Mcp_server.coord_config.base_path in
       (match authorize_token_bound_permission_request ~base_path ~permission request with
       | Ok agent_name ->
           (match check_agent_rate_limit request reqd with

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -4,7 +4,7 @@
     subsystem-spawning functions into a focused module. *)
 
 let install_tooling ~governance_level (state : Mcp_server.server_state) =
-  Governance_pipeline.install ~config:state.room_config ~governance_level
+  Governance_pipeline.install ~config:state.coord_config ~governance_level
 ;;
 
 (* Stable djb2-style hash for the autoboot warmup jitter.
@@ -270,8 +270,8 @@ let start_keeper_loops
   in
   Masc_event_bus.set masc_event_bus;
   (* Event_bus → SSE bridge: relay both OAS and MASC buses to dashboard *)
-  Keeper_event_bridge.start ~sw ~clock ~config:state.room_config ~bus:event_bus;
-  Keeper_event_bridge.start ~sw ~clock ~config:state.room_config ~bus:masc_event_bus;
+  Keeper_event_bridge.start ~sw ~clock ~config:state.coord_config ~bus:event_bus;
+  Keeper_event_bridge.start ~sw ~clock ~config:state.coord_config ~bus:masc_event_bus;
   (* Compaction audit: subscribe to ContextCompactStarted/ContextCompacted and
      persist paired rows to [base_path/data/harness-compact/YYYY-MM/DD.jsonl]
      with rolling 14-day retention (override via
@@ -364,7 +364,7 @@ let start_keeper_loops
   Keeper_keepalive.set_bus event_bus;
   Board_dispatch.set_keeper_board_signal_hook (fun signal ->
     Keeper_keepalive.wakeup_relevant_keeper_for_board_signal
-      ~config:state.room_config
+      ~config:state.coord_config
       signal);
   Board_dispatch.set_board_sse_hook (fun event ->
     let params = board_sse_event_params event in
@@ -455,7 +455,7 @@ let start_keeper_loops
     try
       ignore
         (Activity_graph.emit
-           state.room_config
+           state.coord_config
            ~actor:activity_actor
            ?subject:activity_subject
            ~kind:activity_kind
@@ -476,17 +476,17 @@ let start_keeper_loops
     fun mention ->
     match mention with
     | Some target ->
-      Keeper_keepalive.wakeup_keeper ~base_path:state.room_config.base_path target;
+      Keeper_keepalive.wakeup_keeper ~base_path:state.coord_config.base_path target;
       Log.Keeper.info "broadcast mention → wakeup keeper %s" target
     | None ->
-      Keeper_keepalive.wakeup_all_keepers ~base_path:state.room_config.base_path ();
+      Keeper_keepalive.wakeup_all_keepers ~base_path:state.coord_config.base_path ();
       Log.Keeper.info "broadcast → wakeup all keepers (reactive push)"
   in
   Coord_broadcast.on_broadcast_mention := broadcast_mention_handler;
   (* Orchestrator needs synchronous registration for shutdown hook *)
   (try
      let cancel_orchestrator =
-       Orchestrator.start ~sw ~proc_mgr ~clock ~domain_mgr state.room_config
+       Orchestrator.start ~sw ~proc_mgr ~clock ~domain_mgr state.coord_config
      in
      Shutdown_hooks.register_cancel_orchestrator cancel_orchestrator
    with
@@ -512,7 +512,7 @@ let start_keeper_loops
   in
   let make_judge_dispatch ~actor ~(name : string) ~(args : Yojson.Safe.t) : Tool_result.result =
     let start_time = Time_compat.now () in
-    let config = state.room_config in
+    let config = state.coord_config in
     let agent_name = actor in
     let ctx_room : Tool_coord.context = { config; agent_name } in
     let ctx_task : Tool_task.context = { config; agent_name; sw = Some sw } in
@@ -562,7 +562,7 @@ let start_keeper_loops
       ~sw
       ~clock
       ~net
-      ~base_path:state.room_config.base_path
+      ~base_path:state.coord_config.base_path
       ~masc_tools:judge_masc_tools
       ~dispatch:governance_judge_dispatch
       ~build_facts:(fun () ->
@@ -573,12 +573,12 @@ let start_keeper_loops
             ; "activity", `List []
             ]
         in
-        let agents = Coord.get_agents_status state.room_config in
+        let agents = Coord.get_agents_status state.coord_config in
         Operator_control_snapshot.merge_json_objects base (`Assoc [ "agents", agents ]))
       ());
   fork_subsystem "operator_judge" (fun () ->
     let operator_judge_ctx : _ Operator_control.context =
-      { config = state.room_config
+      { config = state.coord_config
       ; agent_name = "operator-judge"
       ; sw
       ; clock
@@ -591,7 +591,7 @@ let start_keeper_loops
       ~sw
       ~clock
       ~net
-      ~config:state.room_config
+      ~config:state.coord_config
       ~masc_tools:judge_masc_tools
       ~dispatch:operator_judge_dispatch
       ~build_facts:(fun () ->
@@ -608,7 +608,7 @@ let start_keeper_loops
     let interval = Env_config_runtime.Verification.timeout_check_interval_seconds in
     let rec loop () =
       Eio.Time.sleep clock interval;
-      Verification_protocol.check_timeouts ~config:state.room_config;
+      Verification_protocol.check_timeouts ~config:state.coord_config;
       loop ()
     in
     loop ());
@@ -629,7 +629,7 @@ let start_keeper_loops
         Eio.Time.sleep clock interval;
         (try
            let config = Goal_janitor.runtime_config () in
-           let _result = Goal_janitor.run ~config state.room_config in
+           let _result = Goal_janitor.run ~config state.coord_config in
            ()
          with
          | Eio.Cancel.Cancelled _ as e -> raise e
@@ -688,7 +688,7 @@ let start_keeper_loops
       Log.Keeper.info "autoboot: lazy startup complete; keeper bootstrap will start last";
       (* Brief delay so other subsystems (SSE, board, orchestrator) settle first. *)
       Eio.Time.sleep clock Env_config_keeper.KeeperBootstrap.post_startup_settle_sec;
-      let config = state.room_config in
+      let config = state.coord_config in
       let masc_root = Coord.masc_root_dir config in
       let keeper_dir = Keeper_fs.keeper_dir config in
       let all_names = Keeper_meta_store.keeper_names config in

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -38,7 +38,7 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
       Tool_metrics.record r;
       Tool_metrics_persist.enqueue r
     | _ -> ());
-  Tool_metrics_persist.start_flush_fiber ~sw ~clock ~base_path:state.room_config.base_path;
+  Tool_metrics_persist.start_flush_fiber ~sw ~clock ~base_path:state.coord_config.base_path;
   (* Bare-alias audit fiber (PR #15112 surface refresh): re-run the
      classifier every minute so the [masc_auth_bare_alias] gauges
      reflect mid-run regressions, not only the boot snapshot. The
@@ -47,9 +47,9 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
   Auth.start_bare_alias_audit_fiber
     ~sw
     ~clock
-    ~base_path:state.room_config.base_path
+    ~base_path:state.coord_config.base_path
     ~canonical_names_fn:(fun () ->
-      Keeper_runtime.bootable_keeper_names state.room_config
+      Keeper_runtime.bootable_keeper_names state.coord_config
       |> List.map Keeper_identity.keeper_agent_name);
   (* #9876: Hebbian consolidation fiber. Prior to this, the graph was
      write-only — strengthen/weaken populated synapses but decay +
@@ -58,8 +58,8 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
      production. *)
   (* System_internal tool usage log: durable JSONL for pruning evidence (#5120) *)
   Tool_usage_log.init
-    ~base_path:state.room_config.base_path
-    ~cluster_name:state.room_config.backend_config.Backend_types.cluster_name
+    ~base_path:state.coord_config.base_path
+    ~cluster_name:state.coord_config.backend_config.Backend_types.cluster_name
     ();
   (* Inject keeper FD/disk pressure handling at the boundary so the generic
      Tool_usage_log surface does not reference the keeper subsystem directly
@@ -70,8 +70,8 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
     Keeper_disk_pressure.note_exception ~site exn);
   (* Keeper tool call I/O log: full input/output for dashboard inspector *)
   Keeper_tool_call_log.init
-    ~base_path:state.room_config.base_path
-    ~cluster_name:state.room_config.backend_config.Backend_types.cluster_name
+    ~base_path:state.coord_config.base_path
+    ~cluster_name:state.coord_config.backend_config.Backend_types.cluster_name
     ();
   Keeper_tool_call_log.start_flush_fiber ~sw ~clock;
   Otel_dispatch_hook.install ();
@@ -102,7 +102,7 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
            (* SSE replay-buffer eviction is periodic housekeeping; failed
                sends and stale connection reaping remain visible elsewhere. *)
            Log.Server.routine "Evicted %d expired SSE buffer events" evicted_events;
-         let evicted = Cache_eio.evict_expired state.room_config in
+         let evicted = Cache_eio.evict_expired state.coord_config in
          if evicted > 0 then Log.Server.info "Cache: evicted %d expired entries" evicted;
          let sse_guards_reaped = Server_mcp_transport_http_sse.reap_stale_guards () in
          let http_guards_reaped = Server_mcp_transport_http.reap_stale_guards () in
@@ -157,7 +157,7 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
              ticks faster but the helper short-circuits when called too soon. *)
          (match
             Keeper_sandbox_runtime.maybe_cleanup_stale_containers
-              ~base_path:state.room_config.base_path
+              ~base_path:state.coord_config.base_path
               ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Startup ())
               ()
           with
@@ -182,7 +182,7 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
              let days =
                Safe_ops.get_env_int_logged "MASC_JSONL_RETENTION_DAYS" ~default:30
              in
-             let masc = Coord.masc_dir state.room_config in
+             let masc = Coord.masc_dir state.coord_config in
              let prune_dir dir =
                if Sys.file_exists dir
                then Dated_jsonl.prune (Dated_jsonl.create ~base_dir:dir ()) ~days
@@ -227,7 +227,7 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
     let sync_once () =
       try
         let now = Int64.of_float (Eio.Time.now clock) in
-        match Repo_sync.sync_all ~base_path:state.room_config.base_path ~now with
+        match Repo_sync.sync_all ~base_path:state.coord_config.base_path ~now with
         | Ok repos ->
           if repos <> []
           then Log.Server.info "repo_sync: synced %d repositories" (List.length repos)
@@ -263,9 +263,9 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
          of the request fiber for the canonical project-snapshot
          response (Step 4 retires the env knobs themselves). *)
       Dashboard_snapshot.refresh_loop
-        ~sw ~clock ~config:state.room_config ~state
+        ~sw ~clock ~config:state.coord_config ~state
         ~interval_sec:2.0 ());
-  let resolved_base = state.room_config.base_path in
-  let masc_dir = Coord.masc_root_dir state.room_config in
+  let resolved_base = state.coord_config.base_path in
+  let masc_dir = Coord.masc_root_dir state.coord_config in
   resolved_base, masc_dir
 ;;

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -548,11 +548,11 @@ let dashboard_goal_detail_http_json ~(config : Coord.config) ~goal_id : Yojson.S
 let operator_action_http_json ~state ~sw ~clock request ~args =
   let actor =
     Server_auth.dashboard_actor_for_request
-      ~base_path:state.Mcp_server.room_config.base_path
+      ~base_path:state.Mcp_server.coord_config.base_path
       request
   in
   let ctx : _ Operator_control.context =
-    { config = state.Mcp_server.room_config
+    { config = state.Mcp_server.coord_config
     ; agent_name = Option.value ~default:"dashboard" actor
     ; sw
     ; clock
@@ -567,11 +567,11 @@ let operator_action_http_json ~state ~sw ~clock request ~args =
 let operator_confirm_http_json ~state ~sw ~clock request ~args =
   let actor =
     Server_auth.dashboard_actor_for_request
-      ~base_path:state.Mcp_server.room_config.base_path
+      ~base_path:state.Mcp_server.coord_config.base_path
       request
   in
   let ctx : _ Operator_control.context =
-    { config = state.Mcp_server.room_config
+    { config = state.Mcp_server.coord_config
     ; agent_name = Option.value ~default:"dashboard" actor
     ; sw
     ; clock
@@ -631,7 +631,7 @@ let dashboard_bootstrap_http_json
         ?clock:state.Mcp_server.clock
         ~request
         ~light:true
-        state.Mcp_server.room_config)
+        state.Mcp_server.coord_config)
   in
   let execution =
     slice "execution" (fun () -> dashboard_execution_http_json ~state ~sw ~clock request)
@@ -643,12 +643,12 @@ let dashboard_bootstrap_http_json
        bypassing Dashboard_cache and re-reading goals/backlog on every load. *)
     slice "planning" (fun () ->
       let cache_key =
-        Printf.sprintf "planning:%s" state.Mcp_server.room_config.base_path
+        Printf.sprintf "planning:%s" state.Mcp_server.coord_config.base_path
       in
       Dashboard_cache.get_or_compute cache_key
         ~ttl:Server_dashboard_http_core_cache.standard_cache_ttl_s (fun () ->
           Domain_pool_ref.submit_io_or_inline (fun () ->
-            dashboard_planning_http_json ~config:state.Mcp_server.room_config)))
+            dashboard_planning_http_json ~config:state.Mcp_server.coord_config)))
   in
   let namespace_truth =
     slice "namespace_truth" (fun () ->
@@ -665,16 +665,16 @@ let dashboard_bootstrap_http_json
     (* Share the standalone /api/v1/dashboard/goals cache (same key + ttl). *)
     slice "goals" (fun () ->
       let cache_key =
-        Printf.sprintf "goals_tree:%s" state.Mcp_server.room_config.base_path
+        Printf.sprintf "goals_tree:%s" state.Mcp_server.coord_config.base_path
       in
       Dashboard_cache.get_or_compute cache_key
         ~ttl:Server_dashboard_http_core_cache.standard_cache_ttl_s (fun () ->
           Domain_pool_ref.submit_io_or_inline (fun () ->
-            dashboard_goals_tree_http_json ~config:state.Mcp_server.room_config)))
+            dashboard_goals_tree_http_json ~config:state.Mcp_server.coord_config)))
   in
   let goal_loop_status =
     slice "goal_loop_status" (fun () ->
-      Dashboard_goal_loop.status_json ~base_path:state.Mcp_server.room_config.base_path ())
+      Dashboard_goal_loop.status_json ~base_path:state.Mcp_server.coord_config.base_path ())
   in
   `Assoc
     [ "served_at", `String (Masc_domain.now_iso ())

--- a/lib/server/server_dashboard_http_agent_api.ml
+++ b/lib/server/server_dashboard_http_agent_api.ml
@@ -20,7 +20,7 @@ let add_agent_api_routes router =
          in
          let since = Time_compat.now () -. (hours *. Masc_time_constants.hour) in
          let activities =
-           Telemetry_eio.summarize_agent_activity state.Mcp_server.room_config ~since
+           Telemetry_eio.summarize_agent_activity state.Mcp_server.coord_config ~since
          in
          let json = `Assoc [
            ("hours", `Float hours);
@@ -79,7 +79,7 @@ let add_agent_api_routes router =
            in
            let json =
              Tool_agent_timeline.build_timeline
-               state.Mcp_server.room_config
+               state.Mcp_server.coord_config
                ~agent_name ~since_hours ~limit
                ~include_tasks:true ~include_board:false
                ~include_tool_calls:true

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -109,7 +109,7 @@ let mission_cache =
 let _mission_cache = mission_cache
 
 let start_mission_refresh_loop ~state ~sw ~clock =
-  let room_config = state.Mcp_server.room_config in
+  let coord_config = state.Mcp_server.coord_config in
   let proc_mgr = state.Mcp_server.proc_mgr in
   let net, mono_clock = state_dashboard_runtime_caps state in
   let mission_refresh_timeout_s = 60.0 in
@@ -123,7 +123,7 @@ let start_mission_refresh_loop ~state ~sw ~clock =
         ?mono_clock
         ~sw
         ~clock
-        ~config:room_config
+        ~config:coord_config
       |> fun run_compute ->
       let result =
         run_compute (fun ~config ~sw ->
@@ -154,7 +154,7 @@ let start_mission_refresh_loop ~state ~sw ~clock =
 let dashboard_briefing_http_json ~state ~sw ~clock request =
   let net, mono_clock = state_dashboard_runtime_caps state in
   let actor =
-    dashboard_actor_for_request ~base_path:state.Mcp_server.room_config.base_path request
+    dashboard_actor_for_request ~base_path:state.Mcp_server.coord_config.base_path request
   in
   let compute ?actor () =
     let started_at = Unix.gettimeofday () in
@@ -164,7 +164,7 @@ let dashboard_briefing_http_json ~state ~sw ~clock request =
       ?mono_clock
       ~sw
       ~clock
-      ~config:state.Mcp_server.room_config
+      ~config:state.Mcp_server.coord_config
       (fun ~config ~sw ->
          Dashboard_briefing.json
            ?actor
@@ -193,7 +193,7 @@ let dashboard_briefing_http_json ~state ~sw ~clock request =
       (* Actor-parameterized: on-demand with SWR cache. *)
       let cache_key =
         dashboard_cache_key
-          state.Mcp_server.room_config
+          state.Mcp_server.coord_config
           "mission"
           (Option.value ~default:"" actor)
       in
@@ -215,10 +215,10 @@ let dashboard_session_http_json ~state ~sw ~clock request =
        Dashboard_briefing.session_json
          ?actor:
            (dashboard_actor_for_request
-              ~base_path:state.Mcp_server.room_config.base_path
+              ~base_path:state.Mcp_server.coord_config.base_path
               request)
          ~session_id:trimmed_id
-         ~config:state.Mcp_server.room_config
+         ~config:state.Mcp_server.coord_config
          ~sw
          ~clock
          ~proc_mgr:state.Mcp_server.proc_mgr
@@ -249,14 +249,14 @@ let dashboard_session_http_json ~state ~sw ~clock request =
 
 let dashboard_briefing_sections_http_json ~state ~sw ~clock request =
   let actor =
-    dashboard_actor_for_request ~base_path:state.Mcp_server.room_config.base_path request
+    dashboard_actor_for_request ~base_path:state.Mcp_server.coord_config.base_path request
   in
   let force = bool_query_param request "force" ~default:false in
   let compute () =
     Dashboard_briefing_sections.json
       ?actor
       ~force
-      ~config:state.Mcp_server.room_config
+      ~config:state.Mcp_server.coord_config
       ~sw
       ~clock
       ~proc_mgr:state.Mcp_server.proc_mgr
@@ -267,7 +267,7 @@ let dashboard_briefing_sections_http_json ~state ~sw ~clock request =
   else (
     let cache_key =
       dashboard_cache_key
-        state.Mcp_server.room_config
+        state.Mcp_server.coord_config
         "mission_briefing"
         (Option.value ~default:"" actor)
     in

--- a/lib/server/server_dashboard_http_core_batch.ml
+++ b/lib/server/server_dashboard_http_core_batch.ml
@@ -3,7 +3,7 @@
 
     [dashboard_batch_json ?compact config] builds the operator
     dashboard's all-in-one snapshot: room status, monitoring
-    sub-feeds (board / governance / credentials / room_state /
+    sub-feeds (board / governance / credentials / coord_state /
     executor / slots), alert thresholds, tasks list (filtered by
     [compact] flag — Done entries dropped when [compact=true]),
     agents list (with profile enrichment from
@@ -31,7 +31,7 @@ let proactive_similarity_bad = 0.97
 let alert_toast_cooldown_sec = 300
 
 let dashboard_batch_json ?(compact = false) (config : Coord.config) : Yojson.Safe.t =
-  let room_state = Coord.read_state config in
+  let coord_state = Coord.read_state config in
   let tempo = Tempo.get_tempo config in
   (* M-17 fix: single-namespace, queries scoped by basepath *)
   let tasks = Coord.get_tasks_safe config in
@@ -51,9 +51,9 @@ let dashboard_batch_json ?(compact = false) (config : Coord.config) : Yojson.Saf
       ; "workspace_path", `String config.workspace_path
       ; "workspace_differs", `Bool (config.workspace_path <> config.base_path)
       ; "cluster", `String (Env_config_core.cluster_name ())
-      ; "project", `String room_state.project
+      ; "project", `String coord_state.project
       ; "tempo_interval_s", `Float tempo.current_interval_s
-      ; "paused", `Bool room_state.paused
+      ; "paused", `Bool coord_state.paused
       ; "tool_call_health", tool_call_health_json config
       ; ( "alert_thresholds"
         , `Assoc
@@ -70,7 +70,7 @@ let dashboard_batch_json ?(compact = false) (config : Coord.config) : Yojson.Saf
             [ "board", board_monitor_json
             ; "governance", governance_monitor_json
             ; "credentials", credential_monitoring_json ()
-            ; "room_state", Coord_eio.state_health_counters ()
+            ; "coord_state", Coord_eio.state_health_counters ()
             ; "executor", executor_outcomes_json config
             ; "slots", slot_monitoring_json ()
             ] )

--- a/lib/server/server_dashboard_http_core_digest_refresh.ml
+++ b/lib/server/server_dashboard_http_core_digest_refresh.ml
@@ -38,7 +38,7 @@ module Core_operator = Server_dashboard_http_core_operator
 module Core_operator_query = Server_dashboard_http_core_operator_query
 
 let start_operator_digest_refresh_loop ~state ~sw ~clock =
-  let config = state.Mcp_server.room_config in
+  let config = state.Mcp_server.coord_config in
   let proc_mgr = state.Mcp_server.proc_mgr in
   let net, mono_clock = Core_runtime.state_dashboard_runtime_caps state in
   let compute () =

--- a/lib/server/server_dashboard_http_core_entities.ml
+++ b/lib/server/server_dashboard_http_core_entities.ml
@@ -1,5 +1,5 @@
 let dashboard_shell_status_json (config : Coord.config) : Yojson.Safe.t =
-  let room_state = Coord.read_state config in
+  let coord_state = Coord.read_state config in
   let cluster = Env_config_core.cluster_name () in
   let tempo = Tempo.get_tempo config in
   let build = Build_identity.current () in
@@ -9,9 +9,9 @@ let dashboard_shell_status_json (config : Coord.config) : Yojson.Safe.t =
     ; "coordination_root", `String config.base_path
     ; "workspace_path", `String config.workspace_path
     ; "workspace_differs", `Bool (config.workspace_path <> config.base_path)
-    ; "project", `String room_state.project
+    ; "project", `String coord_state.project
     ; "tempo_interval_s", `Float tempo.current_interval_s
-    ; "paused", `Bool room_state.paused
+    ; "paused", `Bool coord_state.paused
     ; "version", `String build.release_version
     ; "build", Build_identity.to_yojson build
     ]

--- a/lib/server/server_dashboard_http_core_operator_digest_http.ml
+++ b/lib/server/server_dashboard_http_core_operator_digest_http.ml
@@ -42,7 +42,7 @@ module Core_operator_query = Server_dashboard_http_core_operator_query
 open Server_dashboard_http_runtime_support
 
 let operator_digest_http_json ~state ~sw ~clock request =
-  let config = state.Mcp_server.room_config in
+  let config = state.Mcp_server.coord_config in
   let net, mono_clock = Core_runtime.state_dashboard_runtime_caps state in
   let actor =
     dashboard_actor_for_request ~base_path:config.base_path request

--- a/lib/server/server_dashboard_http_core_operator_snapshot_http.ml
+++ b/lib/server/server_dashboard_http_core_operator_snapshot_http.ml
@@ -44,7 +44,7 @@ module Core_operator_query = Server_dashboard_http_core_operator_query
 open Server_dashboard_http_runtime_support
 
 let operator_snapshot_http_json ~state ~sw ~clock request =
-  let config = state.Mcp_server.room_config in
+  let config = state.Mcp_server.coord_config in
   let proc_mgr = state.Mcp_server.proc_mgr in
   let net, mono_clock = Core_runtime.state_dashboard_runtime_caps state in
   let actor =

--- a/lib/server/server_dashboard_http_core_snapshot_refresh.ml
+++ b/lib/server/server_dashboard_http_core_snapshot_refresh.ml
@@ -28,7 +28,7 @@ module Core_operator = Server_dashboard_http_core_operator
 module Core_operator_query = Server_dashboard_http_core_operator_query
 
 let start_operator_snapshot_refresh_loop ~state ~sw ~clock =
-  let config = state.Mcp_server.room_config in
+  let config = state.Mcp_server.coord_config in
   let proc_mgr = state.Mcp_server.proc_mgr in
   let net, mono_clock = Core_runtime.state_dashboard_runtime_caps state in
   let compute () =

--- a/lib/server/server_dashboard_http_delete_actions.ml
+++ b/lib/server/server_dashboard_http_delete_actions.ml
@@ -337,7 +337,7 @@ let add_delete_action_routes router =
              | None ->
                  respond_error ~request:req reqd (invalid_request "task_id")
              | Some task_id ->
-             let config = state.Mcp_server.room_config in
+             let config = state.Mcp_server.coord_config in
              match Task_dispatch.delete_task config ~task_id with
              | Ok () -> respond_ok ~request:req reqd
              | Error err ->
@@ -359,7 +359,7 @@ let add_delete_action_routes router =
              | None ->
                  respond_error ~request:req reqd (invalid_request "goal_id")
              | Some goal_id ->
-             let config = state.Mcp_server.room_config in
+             let config = state.Mcp_server.coord_config in
              match Goal_store.delete_goal config ~goal_id with
              | Ok () -> respond_ok ~request:req reqd
              | Error msg ->
@@ -379,7 +379,7 @@ let add_delete_action_routes router =
              | None ->
                respond_error ~request:req reqd (invalid_request "agent_name")
              | Some requested_name ->
-               let config = state.Mcp_server.room_config in
+               let config = state.Mcp_server.coord_config in
                (match resolve_keeper_purge_target config requested_name with
                 | Some keeper_target ->
                   let toml_deleted = Option.is_some keeper_target.toml_path in
@@ -432,7 +432,7 @@ let add_delete_action_routes router =
   |> Http.Router.post "/api/v1/dashboard/goals/sweep" (fun request reqd ->
        with_token_permission_auth ~permission:Masc_domain.CanAdmin
          (fun state _agent_name _req reqd ->
-         let config = state.Mcp_server.room_config in
+         let config = state.Mcp_server.coord_config in
          let sweep_config = Goal_janitor.runtime_config () in
          let result = Goal_janitor.run ~config:sweep_config config in
          Http.Response.json_value ~compress:true ~request

--- a/lib/server/server_dashboard_http_execution_surfaces.ml
+++ b/lib/server/server_dashboard_http_execution_surfaces.ml
@@ -28,10 +28,10 @@ let warm_shell_cache (state : Mcp_server.server_state) =
        let t0 = Time_compat.now () in
        let cache_shell_payload ~light =
          let cache_key =
-           dashboard_shell_cache_key ~light state.Mcp_server.room_config
+           dashboard_shell_cache_key ~light state.Mcp_server.coord_config
          in
          let compute () =
-           dashboard_shell_payload_json ~light state.Mcp_server.room_config
+           dashboard_shell_payload_json ~light state.Mcp_server.coord_config
          in
          match state.Mcp_server.clock with
          | Some clock ->
@@ -589,7 +589,7 @@ let broadcast_namespace_truth_ref : (Mcp_server.server_state -> unit) ref =
     available, each refresh runs in a pool domain with a domain-local Caqti
     pool. Falls back to in-domain compute. *)
 let start_execution_refresh_loop ~state ~sw ~clock ~net ~mono_clock =
-  let room_config = state.Mcp_server.room_config in
+  let coord_config = state.Mcp_server.coord_config in
   let proc_mgr = state.Mcp_server.proc_mgr in
   (* Default keeps timeout < interval (60s) so Proactive_refresh's clamp
      at start does not fire every boot. Env var override can still push
@@ -611,7 +611,7 @@ let start_execution_refresh_loop ~state ~sw ~clock ~net ~mono_clock =
         ~clock
         ~net
         ~mono_clock
-        ~config:room_config
+        ~config:coord_config
         (fun ~config ~sw ->
            Dashboard_execution.json ~light:true ~config ~sw ~clock ~proc_mgr ()
            |> patch_surface_json_for_running_keepers config
@@ -644,7 +644,7 @@ let start_execution_refresh_loop ~state ~sw ~clock ~net ~mono_clock =
         ~event_type:"execution_snapshot"
         (cached_surface_json execution_cache
          |> with_execution_metadata
-              ~config:room_config
+              ~config:coord_config
               ~query:
                 (execution_query_json
                    ~actor:None
@@ -665,7 +665,7 @@ let start_transport_health_refresh_loop ~state ~sw ~clock =
   in
   let compute () =
     mark_cached_surface_attempt transport_health_cache;
-    try Transport_metrics.transport_health_json ~config:state.Mcp_server.room_config with
+    try Transport_metrics.transport_health_json ~config:state.Mcp_server.coord_config with
     | Eio.Cancel.Cancelled _ as e -> raise e
     | exn ->
       mark_cached_surface_error transport_health_cache exn;
@@ -688,12 +688,12 @@ let start_transport_health_refresh_loop ~state ~sw ~clock =
         ~event_type:"transport_health_snapshot"
         (cached_surface_json transport_health_cache
          |> with_transport_health_metadata
-              ~config:state.Mcp_server.room_config
+              ~config:state.Mcp_server.coord_config
               ~timeout_s))
 ;;
 
 let dashboard_execution_http_json ~state ~sw ~clock request =
-  let config = state.Mcp_server.room_config in
+  let config = state.Mcp_server.coord_config in
   let net = state.Mcp_server.net in
   let mono_clock = state.Mcp_server.mono_clock in
   let fixture = query_param request "fixture" in
@@ -789,7 +789,7 @@ let dashboard_execution_trust_http_json ~state ~sw ~clock _request =
       ?mono_clock:state.Mcp_server.mono_clock
       ~sw
       ~clock
-      ~config:state.Mcp_server.room_config
+      ~config:state.Mcp_server.coord_config
       (fun ~config ~sw:_ ->
          Dashboard_http_keeper.execution_trust_dashboard_json config
          |> with_projection_diagnostics ~surface:"execution_trust" ~started_at ~extra:[])
@@ -828,6 +828,6 @@ let dashboard_transport_health_http_json ~state =
     json
     (("source", `String "cached_surface") :: transport_health_cache_diagnostics ())
   |> with_transport_health_metadata
-       ~config:state.Mcp_server.room_config
+       ~config:state.Mcp_server.coord_config
        ~timeout_s
 ;;

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -31,7 +31,7 @@ let handle_keeper_get_subroutes state req request reqd =
       Server_auth.respond_json_value_with_cors ~status:`Bad_request request reqd
         (error_json "missing keeper name")
     else
-      let base_dir = state.Mcp_server.room_config.base_path in
+      let base_dir = state.Mcp_server.coord_config.base_path in
       let messages =
         Keeper_chat_store.load ~base_dir ~keeper_name:name
       in
@@ -42,7 +42,7 @@ let handle_keeper_get_subroutes state req request reqd =
     if String.length name = 0 then
       respond_error reqd "keeper name is required"
     else
-      let (st, json) = keeper_checkpoint_inventory_json state.Mcp_server.room_config name in
+      let (st, json) = keeper_checkpoint_inventory_json state.Mcp_server.coord_config name in
       let status : Httpun.Status.t =
         match st with `OK -> `OK | `Not_found -> `Not_found
       in
@@ -63,7 +63,7 @@ let handle_keeper_get_subroutes state req request reqd =
         |> max 1 |> min trajectory_max_limit
       in
       let st, json =
-        keeper_runtime_trace_json state.Mcp_server.room_config name
+        keeper_runtime_trace_json state.Mcp_server.coord_config name
           ?trace_id ?turn_id ~limit ()
       in
       let status : Httpun.Status.t =
@@ -75,7 +75,7 @@ let handle_keeper_get_subroutes state req request reqd =
     if String.length name = 0 then
       respond_error reqd "keeper name is required"
     else
-      let config = state.Mcp_server.room_config in
+      let config = state.Mcp_server.coord_config in
       let (st, json) =
         Dashboard_http_keeper.keeper_config_json config name
       in
@@ -88,7 +88,7 @@ let handle_keeper_get_subroutes state req request reqd =
     if String.length name = 0 then
       respond_error reqd "keeper name is required"
     else
-      let config = state.Mcp_server.room_config in
+      let config = state.Mcp_server.coord_config in
       let (st, json) =
         Dashboard_http_keeper.keeper_bdi_snapshot_json config name
       in
@@ -106,7 +106,7 @@ let handle_keeper_get_subroutes state req request reqd =
            [("error", `String (Printf.sprintf "invalid keeper name: %s" name))])
         reqd
     else
-      let config = state.Mcp_server.room_config in
+      let config = state.Mcp_server.coord_config in
       let masc_root = Coord.masc_root_dir config in
       let window_hours =
         Server_utils.int_query_param req "window_hours"
@@ -226,7 +226,7 @@ let handle_keeper_get_subroutes state req request reqd =
       let entries =
         Keeper_tool_call_log.read_recent ~keeper_name:name ~n:limit ()
       in
-      let config = state.Mcp_server.room_config in
+      let config = state.Mcp_server.coord_config in
       let masc_root = Coord.masc_root_dir config in
       let latest_ts =
         List.fold_left
@@ -301,7 +301,7 @@ let handle_keeper_get_subroutes state req request reqd =
            [("error", `String (Printf.sprintf "invalid keeper name: %s" name))])
         reqd
     else
-      let config = state.Mcp_server.room_config in
+      let config = state.Mcp_server.coord_config in
       (match Keeper_meta_store.read_meta config name with
        | Error e ->
          respond_error ~status:`Internal_server_error reqd e
@@ -379,7 +379,7 @@ let handle_keeper_get_subroutes state req request reqd =
         Server_utils.int_query_param req "limit" ~default:20
         |> max 1 |> min 50
       in
-      let base_path = state.Mcp_server.room_config.base_path in
+      let base_path = state.Mcp_server.coord_config.base_path in
       let phase = Keeper_registry.get_phase ~base_path name in
       let phase_str = match phase with
         | Some p -> `String (Keeper_state_machine.phase_to_string p)
@@ -420,14 +420,14 @@ let handle_keeper_get_subroutes state req request reqd =
     if String.length name = 0 then
       respond_error reqd "keeper name is required"
     else
-      let base_path = state.Mcp_server.room_config.base_path in
+      let base_path = state.Mcp_server.coord_config.base_path in
       let limit =
         Server_utils.int_query_param req "limit" ~default:10
         |> max 1 |> min 100
       in
       (* Use keeper name as agent_name for eval lookup.
          Keepers may also have a separate agent_name — look up both. *)
-      let config = state.Mcp_server.room_config in
+      let config = state.Mcp_server.coord_config in
       let agent_name_opt =
         match Keeper_meta_store.read_meta config name with
         | Ok (Some m) when m.agent_name <> name -> Some m.agent_name
@@ -467,14 +467,14 @@ let handle_keeper_get_subroutes state req request reqd =
     if String.length name = 0 then
       respond_error reqd "keeper name is required"
     else
-      let base_path = state.Mcp_server.room_config.base_path in
+      let base_path = state.Mcp_server.coord_config.base_path in
       let phase = Keeper_registry.get_phase ~base_path name in
       let current = match phase with Some p -> p | None -> Keeper_state_machine.Offline in
       let mermaid = Keeper_state_machine_mermaid.phase_to_mermaid ~current in
       let phase_str = Keeper_state_machine.phase_to_string current in
       let stats = Thompson_sampling.get_stats name in
       let meta = Keeper_meta_store.read_meta
-          state.Mcp_server.room_config name in
+          state.Mcp_server.coord_config name in
       let tool_count = match meta with
         | Ok (Some m) ->
           List.length (Agent_tool_dispatch_runtime.keeper_allowed_tool_names m)
@@ -484,7 +484,7 @@ let handle_keeper_get_subroutes state req request reqd =
         List.length (Keeper_tool_policy.failing_minimum_tool_names ())
       in
       let turn_outcome : [`Ok | `Failed] option =
-        match Keeper_registry.get ~base_path:state.Mcp_server.room_config.base_path name with
+        match Keeper_registry.get ~base_path:state.Mcp_server.coord_config.base_path name with
         | Some entry when entry.turn_consecutive_failures > 0 ->
           Some `Failed
         | Some _ -> Some `Ok
@@ -544,7 +544,7 @@ let handle_keeper_get_subroutes state req request reqd =
         | Ok (Some _) ->
           (match
              Keeper_memory.read_keeper_memory_summary_result
-               state.Mcp_server.room_config
+               state.Mcp_server.coord_config
                ~name ~max_bytes:120_000 ~max_lines:200 ~recent_limit:0
            with
            | Ok summary ->
@@ -620,7 +620,7 @@ let handle_keeper_get_subroutes state req request reqd =
        (LT-16b, upcoming). *)
     let json =
       Server_dashboard_http.dashboard_fleet_composite_json
-        ~config:state.Mcp_server.room_config ()
+        ~config:state.Mcp_server.coord_config ()
     in
     Http.Response.json_value ~compress:true ~request:req json reqd
   else if ends_with "/composite" then
@@ -631,7 +631,7 @@ let handle_keeper_get_subroutes state req request reqd =
     if String.length name = 0 then
       respond_error reqd "keeper name is required"
     else
-      let base_path = state.Mcp_server.room_config.base_path in
+      let base_path = state.Mcp_server.coord_config.base_path in
       (match Keeper_registry.get ~base_path name with
        | None ->
          respond_error ~status:`Not_found reqd
@@ -639,14 +639,14 @@ let handle_keeper_get_subroutes state req request reqd =
        | Some entry ->
          let json =
            Server_dashboard_http.dashboard_keeper_composite_json
-             ~config:state.Mcp_server.room_config entry
+             ~config:state.Mcp_server.coord_config entry
          in
          Http.Response.json_value ~compress:true ~request:req json reqd)
   else if req_path = prefix ^ "regime" then
     (* 7th FSM axis MVP: fleet-wide behavioral-regime snapshot. Same
        purity contract as the composite route above, uses the
        [Keeper_behavioral_regime_observer] pure projection. *)
-    let base_path = state.Mcp_server.room_config.base_path in
+    let base_path = state.Mcp_server.coord_config.base_path in
     let snapshots =
       Keeper_behavioral_regime_observer.all_snapshots ~base_path ()
     in
@@ -668,7 +668,7 @@ let handle_keeper_get_subroutes state req request reqd =
     if String.length name = 0 then
       respond_error reqd "keeper name is required"
     else
-      let base_path = state.Mcp_server.room_config.base_path in
+      let base_path = state.Mcp_server.coord_config.base_path in
       (match Keeper_registry.get ~base_path name with
        | None ->
          respond_error ~status:`Not_found reqd

--- a/lib/server/server_dashboard_http_keeper_api_lifecycle_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_lifecycle_post.ml
@@ -58,7 +58,7 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
   if String.length name = 0 then
     respond_error reqd "keeper name is required"
   else
-    let config = state.Mcp_server.room_config in
+    let config = state.Mcp_server.coord_config in
     let resolve_keeper_agent_name () =
       match Keeper_registry_lookup.find_by_name name with
       | Some entry -> Some entry.meta.agent_name

--- a/lib/server/server_dashboard_http_keeper_api_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_post.ml
@@ -61,7 +61,7 @@ let handle_keeper_tools_post state req reqd =
     if String.length name = 0 then
       respond_error reqd "keeper name required"
     else
-      let config = state.Mcp_server.room_config in
+      let config = state.Mcp_server.coord_config in
       match Keeper_meta_store.read_meta config name with
       | Error msg -> respond_error ~status:`Not_found reqd msg
       | Ok None -> respond_error ~status:`Not_found reqd (Printf.sprintf "keeper %S not found" name)
@@ -285,7 +285,7 @@ let handle_keeper_checkpoints_post state req reqd body_str =
   if String.length name = 0 then
     respond_error ~ok:false reqd "keeper name is required"
   else
-    let config = state.Mcp_server.room_config in
+    let config = state.Mcp_server.coord_config in
     try
       let args = Yojson.Safe.from_string body_str in
       let action = Safe_ops.json_string ~default:"" "action" args in
@@ -350,7 +350,7 @@ let handle_keeper_config_post ~sw ~clock state agent_name req reqd body_str =
   if String.length name = 0 then
     respond_error reqd "keeper name is required"
   else
-    let config = state.Mcp_server.room_config in
+    let config = state.Mcp_server.coord_config in
     match Keeper_meta_store.read_meta config name with
     | Error msg -> respond_error ~status:`Not_found reqd msg
     | Ok None ->
@@ -440,7 +440,7 @@ let handle_keeper_directive_post state _agent_name req reqd body_str =
   | Error msg ->
       respond_error ~ok:false reqd msg
     | Ok directive ->
-        let config = state.Mcp_server.room_config in
+        let config = state.Mcp_server.coord_config in
         let action_str =
           match directive with
           | `Pause -> "pause"
@@ -613,7 +613,7 @@ let handle_keeper_bulk_directive_post state _agent_name req reqd body_str =
         (`Assoc [ ("ok", `Bool false); ("error", `String msg) ])
         reqd
   | Ok (names, directive) ->
-      let config = state.Mcp_server.room_config in
+      let config = state.Mcp_server.coord_config in
       let action_str =
         match directive with
         | `Pause -> "pause"

--- a/lib/server/server_dashboard_http_namespace_truth.ml
+++ b/lib/server/server_dashboard_http_namespace_truth.ml
@@ -100,7 +100,7 @@ let schedule_namespace_truth_shell_refresh ~sw ~clock config =
                    (Printexc.to_string exn))))
 
 let dashboard_namespace_truth_http_json ~state ~sw ~clock _request =
-  let config = state.Mcp_server.room_config in
+  let config = state.Mcp_server.coord_config in
   (* Fast-path: if the proactive execution refresh hasn't produced a result
      yet, return "initializing" immediately instead of blocking for 15-20s
      on cold-start on-demand compute. The frontend retries every 3s via
@@ -243,7 +243,7 @@ let namespace_truth_snapshot_from_caches (state : Mcp_server.server_state) :
   if not (cached_surface_has_success Server_dashboard_http_execution_surfaces.execution_cache) then
     None
   else
-    let config = state.Mcp_server.room_config in
+    let config = state.Mcp_server.coord_config in
     let shell_json = cached_shell_json_for_namespace ~config in
     let execution_json =
       cached_surface_json Server_dashboard_http_execution_surfaces.execution_cache

--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -127,7 +127,7 @@ let start ~sw ~env ~clock ~state =
         ~sw ~clock
         ~proc_mgr:state.Mcp_server.proc_mgr
         ~net:state.Mcp_server.net
-        ~config:state.Mcp_server.room_config
+        ~config:state.Mcp_server.coord_config
     in
     let policy_label =
       match policy with

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -116,7 +116,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
         with_initialized_state (fun state ->
           match
             authorize_read_request
-              ~base_path:state.Mcp_server.room_config.base_path
+              ~base_path:state.Mcp_server.coord_config.base_path
               httpun_request
           with
           | Ok () ->
@@ -130,7 +130,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
       with_server_state h2_reqd (fun state ->
         match
           authorize_token_bound_permission_request
-            ~base_path:state.Mcp_server.room_config.base_path
+            ~base_path:state.Mcp_server.coord_config.base_path
             ~permission
             httpun_request
         with
@@ -164,7 +164,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
 
     let _h2_authorize_tool state ~tool_name =
       authorize_tool_request
-        ~base_path:state.Mcp_server.room_config.base_path
+        ~base_path:state.Mcp_server.coord_config.base_path
         ~tool_name httpun_request
     in
 
@@ -228,7 +228,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
             with_server_state h2_reqd (fun state ->
               match
                 authorize_permission_request
-                  ~base_path:state.Mcp_server.room_config.base_path
+                  ~base_path:state.Mcp_server.coord_config.base_path
                   ~permission:Masc_domain.CanBroadcast
                   httpun_request
               with
@@ -258,7 +258,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
             with_server_state h2_reqd (fun state ->
               match
                 authorize_permission_request
-                  ~base_path:state.Mcp_server.room_config.base_path
+                  ~base_path:state.Mcp_server.coord_config.base_path
                   ~permission:Masc_domain.CanBroadcast
                   httpun_request
               with
@@ -321,7 +321,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
           in
           (* HTTP-level auth check for MCP endpoints *)
           let base_path = match !server_state with
-            | Some s -> s.Mcp_server.room_config.base_path
+            | Some s -> s.Mcp_server.coord_config.base_path
             | None -> default_base_path ()
           in
           let context =
@@ -460,7 +460,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
             else Server_mcp_transport_http.Full
           in
           let base_path = match !server_state with
-            | Some s -> s.Mcp_server.room_config.base_path
+            | Some s -> s.Mcp_server.coord_config.base_path
             | None -> default_base_path ()
           in
           let auth_result =
@@ -540,7 +540,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
       | `POST, "/graphql" ->
           h2_read_body h2_reqd (fun body_str ->
             with_server_state h2_reqd (fun state ->
-              let response = Graphql_api.handle_request ~config:state.room_config body_str in
+              let response = Graphql_api.handle_request ~config:state.coord_config body_str in
               let status = match response.status with `OK -> `OK | `Bad_request -> `Bad_request in
               h2_respond_json h2_reqd response.body ~status ~extra_headers:cors))
 
@@ -567,14 +567,14 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
             let json =
               dashboard_shell_http_json ?clock:state.Mcp_server.clock
                 ~request:httpun_request ~light
-                state.Mcp_server.room_config
+                state.Mcp_server.coord_config
             in
             h2_respond_json_value h2_reqd json ~extra_headers:cors)
 
       | `GET, "/api/v1/dashboard/branches" ->
           with_server_state h2_reqd (fun state ->
             let json =
-              Dashboard_branches.json ~config:state.Mcp_server.room_config
+              Dashboard_branches.json ~config:state.Mcp_server.coord_config
             in
             h2_respond_json_value h2_reqd json ~extra_headers:cors)
 
@@ -586,7 +586,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
             in
             let json =
               Dashboard_operator_nudges.json
-                ~config:state.Mcp_server.room_config ~limit ()
+                ~config:state.Mcp_server.coord_config ~limit ()
             in
             h2_respond_json_value h2_reqd json
               ~extra_headers:cors)
@@ -603,7 +603,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
               | None -> trimmed_query_param httpun_request "agent"
             in
             let json =
-              Dashboard_workspace.json ~config:state.Mcp_server.room_config ?me
+              Dashboard_workspace.json ~config:state.Mcp_server.coord_config ?me
                 ~limit ()
             in
             h2_respond_json_value h2_reqd json
@@ -632,7 +632,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
           with_server_state h2_reqd (fun state ->
             let json =
               Server_routes_http_routes_provider_runs.dashboard_stress_json
-                ~config:state.Mcp_server.room_config httpun_request
+                ~config:state.Mcp_server.coord_config httpun_request
             in
             h2_respond_json_value h2_reqd json
               ~extra_headers:cors)
@@ -724,7 +724,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
           with_h2_public_read h2_reqd (fun state ->
             let json =
               dashboard_governance_http_json httpun_request
-                ~base_path:state.Mcp_server.room_config.base_path
+                ~base_path:state.Mcp_server.coord_config.base_path
             in
             h2_respond_json_value h2_reqd json ~extra_headers:cors)
 
@@ -732,7 +732,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
           with_h2_public_read h2_reqd (fun state ->
             let json =
               dashboard_proof_http_json
-                ~config:state.Mcp_server.room_config httpun_request
+                ~config:state.Mcp_server.coord_config httpun_request
             in
             h2_respond_json_value h2_reqd json ~extra_headers:cors)
 
@@ -740,7 +740,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
           with_h2_public_read h2_reqd (fun state ->
             let json =
               dashboard_planning_http_json
-                ~config:state.Mcp_server.room_config
+                ~config:state.Mcp_server.coord_config
             in
             h2_respond_json_value h2_reqd json ~extra_headers:cors)
 
@@ -758,7 +758,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
           with_h2_public_read h2_reqd (fun state ->
             let json =
               dashboard_goals_tree_http_json
-                ~config:state.Mcp_server.room_config
+                ~config:state.Mcp_server.coord_config
             in
             h2_respond_json_value h2_reqd json ~extra_headers:cors)
 
@@ -780,7 +780,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
             else
               let json =
                 dashboard_goal_detail_http_json
-                  ~config:state.Mcp_server.room_config ~goal_id
+                  ~config:state.Mcp_server.coord_config ~goal_id
               in
               h2_respond_json_value h2_reqd json
                 ~extra_headers:cors)
@@ -802,7 +802,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
                 |> Server_utils.clamp ~min_v:1 ~max_v:200
               in
               let json =
-                Tool_task.task_history_events_json state.Mcp_server.room_config
+                Tool_task.task_history_events_json state.Mcp_server.coord_config
                   ~task_id ~limit
               in
               h2_respond_json_value h2_reqd json
@@ -833,7 +833,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
 
       | `GET, "/api/v1/dashboard/perf" ->
           with_h2_public_read h2_reqd (fun state ->
-            let json = dashboard_perf_http_json state.Mcp_server.room_config in
+            let json = dashboard_perf_http_json state.Mcp_server.coord_config in
             h2_respond_json_value h2_reqd json ~extra_headers:cors)
 
       | `GET, "/api/v1/dashboard/oas/telemetry/recent" ->
@@ -857,14 +857,14 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
 
       | `GET, "/api/v1/status" ->
           with_server_state h2_reqd (fun state ->
-            let config = state.Mcp_server.room_config in
-            let room_state = Coord.read_state config in
+            let config = state.Mcp_server.coord_config in
+            let coord_state = Coord.read_state config in
             let tempo = Tempo.get_tempo config in
             let json = `Assoc [
               ("cluster", `String (Env_config_core.cluster_name ()));
-              ("project", `String room_state.project);
+              ("project", `String coord_state.project);
               ("tempo_interval_s", `Float tempo.current_interval_s);
-              ("paused", `Bool room_state.paused);
+              ("paused", `Bool coord_state.paused);
             ] in
             h2_respond_json_value h2_reqd json ~extra_headers:cors)
 
@@ -898,7 +898,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
                ~cors ~path
                ~config:
                  (Option.map
-                    (fun state -> state.Mcp_server.room_config)
+                    (fun state -> state.Mcp_server.coord_config)
                     !server_state)
                httpun_meth ->
           ()

--- a/lib/server/server_ide_http.ml
+++ b/lib/server/server_ide_http.ml
@@ -8,12 +8,12 @@ open Server_auth
 open Server_utils
 module Http = Http_server_eio
 
-let base_path_of_state state = state.Mcp_server.room_config.base_path
+let base_path_of_state state = state.Mcp_server.coord_config.base_path
 let extract_path_param = Server_utils.extract_path_param
 
 let resolve_workspace_base ~state ~uri =
   let project_base = base_path_of_state state in
-  let config = state.Mcp_server.room_config in
+  let config = state.Mcp_server.coord_config in
   let lookup_repository repo_id =
     match Repo_store.find ~base_path:project_base repo_id with
     | Ok repo -> Some (Repo_store.local_path ~base_path:project_base repo)

--- a/lib/server/server_ide_lsp_proxy.ml
+++ b/lib/server/server_ide_lsp_proxy.ml
@@ -65,7 +65,7 @@ type conn_state =
   ; disconnected : bool Atomic.t
   }
 
-let base_path_of_state state = state.Mcp_server.room_config.base_path
+let base_path_of_state state = state.Mcp_server.coord_config.base_path
 
 (** Signal connection end — resolves the disconnect promise so
     [Eio.Switch.run] exits and cleans up all associated resources. *)

--- a/lib/server/server_routes_http.ml
+++ b/lib/server/server_routes_http.ml
@@ -18,7 +18,7 @@ let make_routes ~port ~host ~sw ~clock =
     Multimodal.Workspace_holder.get;
   Http.Router.create ()
   |> Server_routes_http_routes_frontend.add_routes ~port ~host
-  |> Server_routes_http_routes_room.add_routes
+  |> Server_routes_http_routes_coord.add_routes
   |> Server_routes_http_routes_dashboard.add_routes ~sw ~clock
   |> Server_routes_http_routes_provider_runs.add_routes ~sw
   |> Server_routes_http_routes_verification.add_routes

--- a/lib/server/server_routes_http_common.ml
+++ b/lib/server/server_routes_http_common.ml
@@ -176,7 +176,7 @@ let mcp_transport_http_deps () : Server_mcp_transport_http.deps =
             | Some sw, Some clock ->
                 Ok
                   {
-                    base_path = state.Mcp_server.room_config.base_path;
+                    base_path = state.Mcp_server.coord_config.base_path;
                     sw;
                     clock;
                     handle_request =
@@ -197,7 +197,7 @@ let mcp_transport_http_deps () : Server_mcp_transport_http.deps =
     get_base_path =
       (fun () ->
         match current_server_state_opt () with
-        | Some state -> state.Mcp_server.room_config.base_path
+        | Some state -> state.Mcp_server.coord_config.base_path
         | None -> Server_mcp_transport_http.default_base_path ());
     verify_mcp_auth =
       (fun ~base_path request ->

--- a/lib/server/server_routes_http_dashboard_handlers.ml
+++ b/lib/server/server_routes_http_dashboard_handlers.ml
@@ -29,7 +29,7 @@ let handle_broadcast state agent_name reqd body_str =
     let json = Yojson.Safe.from_string body_str in
     match Json_util.assoc_member_opt "message" json with
     | Some (`String message) ->
-        let config = state.Mcp_server.room_config in
+        let config = state.Mcp_server.coord_config in
         let _ = Coord.broadcast config ~from_agent:agent_name ~content:message in
         reply true None
     | Some `Null -> reply false (Some "missing required field: message")
@@ -78,12 +78,12 @@ let handle_dashboard_task_history state req reqd =
     in
     let cache_key =
       Printf.sprintf "task_history:%s:%s:%d"
-        state.Mcp_server.room_config.base_path task_id limit
+        state.Mcp_server.coord_config.base_path task_id limit
     in
     let json =
       Dashboard_cache.get_or_compute cache_key ~ttl:standard_cache_ttl_s (fun () ->
         Domain_pool_ref.submit_io_or_inline (fun () ->
-          Tool_task.task_history_events_json state.Mcp_server.room_config
+          Tool_task.task_history_events_json state.Mcp_server.coord_config
             ~task_id ~limit))
     in
     Http.Response.json_value ~compress:true ~request:req json reqd
@@ -105,9 +105,9 @@ let handle_dashboard_workspace state req reqd =
      param variants stay distinct. Shared by /dashboard/workspace and /rooms. *)
   let cache_key =
     Printf.sprintf "workspace:%s:%d:%s"
-      state.Mcp_server.room_config.base_path limit
+      state.Mcp_server.coord_config.base_path limit
       (Option.value ~default:"" me)
   in
   Server_routes_http_common.respond_cached_read ~request:req ~reqd ~cache_key
     ~ttl:Server_dashboard_http_core_cache.realtime_cache_ttl_s (fun () ->
-      Dashboard_workspace.json ~config:state.Mcp_server.room_config ?me ~limit ())
+      Dashboard_workspace.json ~config:state.Mcp_server.coord_config ?me ~limit ())

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -31,7 +31,7 @@ let execute_keeper_stream_tool ~sw ~clock ?auth_token:_ state ~agent_name ~argum
     try
       let keeper_ctx : _ Tool_keeper.context =
         {
-          config = state.Mcp_server.room_config;
+          config = state.Mcp_server.coord_config;
           agent_name;
           sw;
           clock;
@@ -57,7 +57,7 @@ let execute_keeper_stream_tool ~sw ~clock ?auth_token:_ state ~agent_name ~argum
     if success then None
     else Some (Printf.sprintf "duration_ms=%d" duration_ms)
   in
-  Audit_log.log_tool_call state.Mcp_server.room_config
+  Audit_log.log_tool_call state.Mcp_server.coord_config
     ~agent_id:agent_name ~tool_name:"masc_keeper_msg" ~success ~error_msg ();
   if not success then
     Log.emit Log.Error ~module_name:"Keeper"
@@ -80,7 +80,7 @@ let execute_keeper_stream_tool ~sw ~clock ?auth_token:_ state ~agent_name ~argum
              if success then None
              else Some (Telemetry_eio.error_kind_of_string "tool_failure")
            in
-           Telemetry_eio.track_tool_called ~fs state.Mcp_server.room_config
+           Telemetry_eio.track_tool_called ~fs state.Mcp_server.coord_config
              ~tool_name:"masc_keeper_msg" ~agent_id:agent_name ~success ~duration_ms
              ~source:(Tool_registry.string_of_source Keeper_internal)
              ?error_kind:telemetry_error_kind ?error_message:error_msg ()
@@ -253,7 +253,7 @@ let execute_keeper_stream_tool_streaming ~sw ~clock ?auth_token:_ state
     try
       let keeper_ctx : _ Tool_keeper.context =
         {
-          config = state.Mcp_server.room_config;
+          config = state.Mcp_server.coord_config;
           agent_name;
           sw;
           clock;
@@ -282,7 +282,7 @@ let execute_keeper_stream_tool_streaming ~sw ~clock ?auth_token:_ state
     if success then None
     else Some (Printf.sprintf "duration_ms=%d" duration_ms)
   in
-  Audit_log.log_tool_call state.Mcp_server.room_config ~agent_id:agent_name
+  Audit_log.log_tool_call state.Mcp_server.coord_config ~agent_id:agent_name
     ~tool_name:"masc_keeper_msg" ~success ~error_msg ();
   if not success then
     Log.emit Log.Error ~module_name:"Keeper"
@@ -305,7 +305,7 @@ let execute_keeper_stream_tool_streaming ~sw ~clock ?auth_token:_ state
              if success then None
              else Some (Telemetry_eio.error_kind_of_string "tool_failure")
            in
-           Telemetry_eio.track_tool_called ~fs state.Mcp_server.room_config
+           Telemetry_eio.track_tool_called ~fs state.Mcp_server.coord_config
              ~tool_name:"masc_keeper_msg" ~agent_id:agent_name ~success
              ~duration_ms ~source:(Tool_registry.string_of_source Keeper_internal)
              ?error_kind:telemetry_error_kind ?error_message:error_msg ()
@@ -525,7 +525,7 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
                  | None -> ());
                 (* Persist user + assistant messages in a single write *)
                 Keeper_chat_store.append_pair
-                  ~base_dir:state.Mcp_server.room_config.base_path
+                  ~base_dir:state.Mcp_server.coord_config.base_path
                   ~keeper_name:payload.name
                   ~user_content:payload.message
                   ~assistant_content:visible_reply;

--- a/lib/server/server_routes_http_pages.ml
+++ b/lib/server/server_routes_http_pages.ml
@@ -445,7 +445,7 @@ let bonsai_api_keepers_summary request reqd =
         (`Assoc [ ("error", `String "server state not initialized") ])
   | Some state ->
       let resp =
-        keepers_summary_from_registry ~base_path:state.room_config.base_path
+        keepers_summary_from_registry ~base_path:state.coord_config.base_path
       in
       respond_public_read_json_value request reqd
         (Masc_dashboard_api_types.Keepers.response_to_yojson resp)
@@ -516,7 +516,7 @@ let handle_post_graphql request reqd =
         respond_json_with_cors ~status:`Internal_server_error request reqd
           (server_state_error_json message)
     | Ok state ->
-        let response = Graphql_api.handle_request ~config:state.room_config body_str in
+        let response = Graphql_api.handle_request ~config:state.coord_config body_str in
         let status = http_status_of_graphql response.status in
         let headers = Httpun.Headers.of_list (
           ("content-length", string_of_int (String.length response.body))

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -206,7 +206,7 @@ let add_routes ~sw ~clock router =
 
   |> Http.Router.get "/api/v1/governance/params/audit" (fun request reqd ->
        with_public_read (fun state req reqd ->
-         let base_path = state.Mcp_server.room_config.base_path in
+         let base_path = state.Mcp_server.coord_config.base_path in
          let limit = int_query_param req "limit" ~default:50 |> clamp ~min_v:1 ~max_v:200 in
          let entries = Runtime_params.recent_audit ~base_path limit in
          let json = `Assoc [
@@ -218,7 +218,7 @@ let add_routes ~sw ~clock router =
 
   |> Http.Router.get "/api/v1/audit" (fun request reqd ->
        with_public_read (fun state req reqd ->
-         let config = state.Mcp_server.room_config in
+         let config = state.Mcp_server.coord_config in
          let limit  = int_query_param req "limit"  ~default:100 |> clamp ~min_v:1 ~max_v:500 in
          let actor_filter    = query_param req "actor" in
          let kind_filter     = query_param req "kind" in
@@ -266,7 +266,7 @@ let add_routes ~sw ~clock router =
          let blind_votes = bool_query_param req "blind_votes" ~default:false in
          let include_moderation =
            include_moderation_projection
-             ~base_path:state.Mcp_server.room_config.base_path
+             ~base_path:state.Mcp_server.coord_config.base_path
              req
          in
          let posts =
@@ -290,7 +290,7 @@ let add_routes ~sw ~clock router =
          let reactions_for = board_reactions_lookup reaction_rows in
          let contributor_quality_for =
            board_contributor_quality_lookup
-             ~config:state.Mcp_server.room_config ()
+             ~config:state.Mcp_server.coord_config ()
          in
          let posts_json =
            List.map
@@ -476,12 +476,12 @@ let add_routes ~sw ~clock router =
               in
               let include_moderation =
                 include_moderation_projection
-                  ~base_path:state.Mcp_server.room_config.base_path
+                  ~base_path:state.Mcp_server.coord_config.base_path
                   req
               in
               let (status, body) =
                 board_post_detail_json ~include_moderation ~blind_votes ~voter
-                  ~config:(Some state.Mcp_server.room_config)
+                  ~config:(Some state.Mcp_server.coord_config)
                   ~response_format:format ~post_id
               in
               respond_json_with_cors ~status request reqd body)
@@ -631,11 +631,11 @@ let add_routes ~sw ~clock router =
           | Some agent_name ->
               let limit = standard_limit request in
               let mentions =
-                Mention_inbox.read_mentions state.Mcp_server.room_config
+                Mention_inbox.read_mentions state.Mcp_server.coord_config
                   ~target_agent:agent_name ~limit
               in
               let unread =
-                Mention_inbox.unread_count state.Mcp_server.room_config
+                Mention_inbox.unread_count state.Mcp_server.coord_config
                   ~target_agent:agent_name
               in
               let json = `Assoc [
@@ -658,7 +658,7 @@ let add_routes ~sw ~clock router =
           | Some agent_name ->
               let rep =
                 Agent_reputation.compute_reputation
-                  state.Mcp_server.room_config ~agent_name
+                  state.Mcp_server.coord_config ~agent_name
               in
               Http.Response.json_value
                 (Agent_reputation.reputation_to_json rep) reqd)
@@ -670,7 +670,7 @@ let add_routes ~sw ~clock router =
          let agent_name = query_param req "agent" in
          let limit = int_query_param req "limit" ~default:50 |> clamp ~min_v:1 ~max_v:200 in
          let items =
-           Activity_feed.recent_activity state.Mcp_server.room_config
+           Activity_feed.recent_activity state.Mcp_server.coord_config
              ?agent_name ~limit ()
          in
          let json = `Assoc [
@@ -706,7 +706,7 @@ let add_routes ~sw ~clock router =
                  | "clear" ->
                    Prompt_registry.clear_prompt_override key;
                    (try Prompt_registry.persist_overrides
-                          state.Mcp_server.room_config.base_path
+                          state.Mcp_server.coord_config.base_path
                     with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
                       Log.Pages.warn "prompt override persist (clear) failed: %s"
                         (Printexc.to_string exn));
@@ -717,7 +717,7 @@ let add_routes ~sw ~clock router =
                    match Prompt_registry.set_override key value with
                    | Ok () ->
                      (try Prompt_registry.persist_overrides
-                            state.Mcp_server.room_config.base_path
+                            state.Mcp_server.coord_config.base_path
                       with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
                         Log.Pages.warn "prompt override persist (set) failed: %s"
                           (Printexc.to_string exn));
@@ -756,7 +756,7 @@ let add_routes ~sw ~clock router =
          Http.Request.read_body_async reqd (fun body_str ->
            try
              let args = Yojson.Safe.from_string body_str in
-             let base_path = state.Mcp_server.room_config.base_path in
+             let base_path = state.Mcp_server.coord_config.base_path in
              let actor =
                sanitized_dashboard_actor_for_request ~base_path request
                |> Option.value ~default:"dashboard"
@@ -833,7 +833,7 @@ let add_routes ~sw ~clock router =
              let args = Yojson.Safe.from_string body_str in
              let param_key = Json_util.get_string args "param_key"
                |> Option.value ~default:"" in
-             let base_path = state.Mcp_server.room_config.base_path in
+             let base_path = state.Mcp_server.coord_config.base_path in
              let actor =
                sanitized_dashboard_actor_for_request ~base_path request
                |> Option.value ~default:"dashboard"

--- a/lib/server/server_routes_http_routes_channel_gate.ml
+++ b/lib/server/server_routes_http_routes_channel_gate.ml
@@ -122,7 +122,7 @@ let handle_gate_message ~sw ~clock state request reqd =
         ~sw ~clock
         ~proc_mgr:state.Mcp_server.proc_mgr
         ~net:state.Mcp_server.net
-        ~config:state.Mcp_server.room_config
+        ~config:state.Mcp_server.coord_config
     in
     let result =
       try
@@ -256,7 +256,7 @@ let handle_gate_connector_status _state request reqd =
 
 let gate_keeper_ctx ~sw ~clock state =
   {
-    Tool_keeper.config = state.Mcp_server.room_config;
+    Tool_keeper.config = state.Mcp_server.coord_config;
     agent_name = "gate:connector";
     sw;
     clock;
@@ -377,7 +377,7 @@ let handle_bind_for_connector ~sw ~clock state request reqd
         | Ok true -> (
             let actor_name =
               sanitized_dashboard_actor_for_request
-                ~base_path:state.Mcp_server.room_config.base_path request
+                ~base_path:state.Mcp_server.coord_config.base_path request
               |> Option.value ~default:"dashboard"
               |> String.trim
             in
@@ -411,7 +411,7 @@ let handle_unbind_for_connector state request reqd
       else
         let actor_name =
           sanitized_dashboard_actor_for_request
-            ~base_path:state.Mcp_server.room_config.base_path request
+            ~base_path:state.Mcp_server.coord_config.base_path request
           |> Option.value ~default:"dashboard"
           |> String.trim
         in

--- a/lib/server/server_routes_http_routes_coord.ml
+++ b/lib/server/server_routes_http_routes_coord.ml
@@ -15,8 +15,8 @@ module Keeper_stream = Server_routes_http_keeper_stream
   router
   |> Http.Router.get "/api/v1/status" (fun request reqd ->
        with_read_auth (fun state _req reqd ->
-         let config = state.Mcp_server.room_config in
-         let status = Room_protocol.status config in
+         let config = state.Mcp_server.coord_config in
+         let status = Coord_protocol.status config in
          let json = `Assoc [
            ("cluster", `String status.cluster);
            ("project", `String status.project);
@@ -27,14 +27,14 @@ module Keeper_stream = Server_routes_http_keeper_stream
        ) request reqd)
   |> Http.Router.get "/api/v1/tasks" (fun request reqd ->
        with_read_auth (fun state req reqd ->
-         let config = state.Mcp_server.room_config in
+         let config = state.Mcp_server.coord_config in
          let status_filter = query_param req "status" in
          let include_done = bool_query_param req "include_done" ~default:false in
          let include_cancelled = bool_query_param req "include_cancelled" ~default:false in
          let limit = int_query_param req "limit" ~default:50 |> clamp ~min_v:1 ~max_v:200 in
          let offset = int_query_param req "offset" ~default:0 |> clamp ~min_v:0 ~max_v:5000 in
          let filtered =
-           Room_protocol.tasks ?status_filter ~include_done
+           Coord_protocol.tasks ?status_filter ~include_done
              ~include_cancelled config
          in
          let total = List.length filtered in
@@ -52,7 +52,7 @@ module Keeper_stream = Server_routes_http_keeper_stream
                ("priority", `Int t.priority);
                ( "assignee",
                  Json_util.string_opt_to_json
-                   (Room_protocol.task_assignee t) );
+                   (Coord_protocol.task_assignee t) );
                ("created_at", `String t.created_at);
              ]
            in
@@ -73,12 +73,12 @@ module Keeper_stream = Server_routes_http_keeper_stream
        ) request reqd)
   |> Http.Router.get "/api/v1/agents" (fun request reqd ->
        with_read_auth (fun state req reqd ->
-         let config = state.Mcp_server.room_config in
+         let config = state.Mcp_server.coord_config in
          let status_filter = query_param req "status" in
          let limit = int_query_param req "limit" ~default:50 |> clamp ~min_v:1 ~max_v:200 in
          let offset = int_query_param req "offset" ~default:0 |> clamp ~min_v:0 ~max_v:5000 in
          let agents =
-           Room_protocol.agents ?status_filter config
+           Coord_protocol.agents ?status_filter config
          in
          let total = List.length agents in
          let page =
@@ -108,12 +108,12 @@ module Keeper_stream = Server_routes_http_keeper_stream
        ) request reqd)
   |> Http.Router.get "/api/v1/messages" (fun request reqd ->
        with_read_auth (fun state req reqd ->
-         let config = state.Mcp_server.room_config in
+         let config = state.Mcp_server.coord_config in
          let since_seq = int_query_param req "since_seq" ~default:0 in
          let limit = int_query_param req "limit" ~default:20 in
          let agent_filter = query_param req "agent" in
          let filtered =
-           Room_protocol.messages ?agent_filter ~since_seq ~limit:500 config
+           Coord_protocol.messages ?agent_filter ~since_seq ~limit:500 config
          in
          let total = List.length filtered in
          let page = filtered |> List.filteri (fun idx _ -> idx < limit) in

--- a/lib/server/server_routes_http_routes_coord.mli
+++ b/lib/server/server_routes_http_routes_coord.mli
@@ -1,4 +1,4 @@
-(** Server_routes_http_routes_room — Read-only HTTP routes for
+(** Server_routes_http_routes_coord — Read-only HTTP routes for
     project/room state.
 
     Registers [GET /api/v1/status], [/api/v1/tasks], [/api/v1/agents],

--- a/lib/server/server_routes_http_routes_credentials.ml
+++ b/lib/server/server_routes_http_routes_credentials.ml
@@ -145,7 +145,7 @@ let add_routes router =
   router
   |> Http.Router.get "/api/v1/credentials" (fun request reqd ->
        with_public_read (fun state req reqd ->
-         let base_path = state.Mcp_server.room_config.base_path in
+         let base_path = state.Mcp_server.coord_config.base_path in
          match Credential_store.load_all ~base_path with
          | Error msg ->
              Http.Response.json_value ~status:`Internal_server_error
@@ -172,7 +172,7 @@ let add_routes router =
        ) request reqd)
   |> Http.Router.prefix_get "/api/v1/credentials/" (fun request reqd ->
        with_public_read (fun state req reqd ->
-         let base_path = state.Mcp_server.room_config.base_path in
+         let base_path = state.Mcp_server.coord_config.base_path in
          let path = Http.Request.path request in
          match extract_path_param ~prefix:"/api/v1/credentials/" path with
          | None | Some "" ->
@@ -228,7 +228,7 @@ let add_routes router =
                  match credential_of_json json with
                  | Error msg -> response `Bad_request msg
                  | Ok credential ->
-                     let base_path = state.Mcp_server.room_config.base_path in
+                     let base_path = state.Mcp_server.coord_config.base_path in
                      (* Sanity-check the credential id so it can be
                         embedded in a path safely (used both for
                         server-derived gh_config_dir and for any
@@ -356,7 +356,7 @@ let add_routes router =
   |> Http.Router.prefix_delete "/api/v1/credentials/" (fun request reqd ->
          with_token_permission_auth ~permission:Masc_domain.CanAdmin
            (fun state _agent_name req reqd ->
-             let base_path = state.Mcp_server.room_config.base_path in
+             let base_path = state.Mcp_server.coord_config.base_path in
              let path = Http.Request.path request in
              match extract_path_param ~prefix:"/api/v1/credentials/" path with
              | None | Some "" ->

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -78,7 +78,7 @@ let add_routes ~sw ~clock router =
          let json =
            Server_dashboard_snapshot_select.select_shell_json
              ?clock:state.Mcp_server.clock ~request:req
-             ~timing ~light state.Mcp_server.room_config
+             ~timing ~light state.Mcp_server.coord_config
          in
          Http.Response.json_value ~compress:true ~request:req ~extra_headers:(Server_timing.extra_header timing) json reqd
        ) request reqd)
@@ -90,13 +90,13 @@ let add_routes ~sw ~clock router =
          in
          let cache_key =
            Printf.sprintf "nudges:%s:%d"
-             state.Mcp_server.room_config.base_path limit
+             state.Mcp_server.coord_config.base_path limit
          in
          let json =
            Dashboard_cache.get_or_compute cache_key ~ttl:realtime_cache_ttl_s (fun () ->
              Domain_pool_ref.submit_io_or_inline (fun () ->
                Dashboard_operator_nudges.json
-                 ~config:state.Mcp_server.room_config ~limit ()))
+                 ~config:state.Mcp_server.coord_config ~limit ()))
          in
          Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
@@ -104,7 +104,7 @@ let add_routes ~sw ~clock router =
        with_public_read (fun state req reqd ->
          let json =
            Dashboard_goal_loop.status_json
-             ~base_path:state.Mcp_server.room_config.base_path ()
+             ~base_path:state.Mcp_server.coord_config.base_path ()
          in
          Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
@@ -116,11 +116,11 @@ let add_routes ~sw ~clock router =
             an Executor_pool domain instead of blocking the main HTTP domain. *)
          let cache_key =
            Printf.sprintf "branches:%s"
-             state.Mcp_server.room_config.base_path
+             state.Mcp_server.coord_config.base_path
          in
          respond_cached_read ~request:req ~reqd ~cache_key
            ~ttl:realtime_cache_ttl_s (fun () ->
-             Dashboard_branches.json ~config:state.Mcp_server.room_config)
+             Dashboard_branches.json ~config:state.Mcp_server.coord_config)
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/workspace" (fun request reqd ->
        with_public_read handle_dashboard_workspace request reqd)
@@ -136,7 +136,7 @@ let add_routes ~sw ~clock router =
            "dev-token endpoint disabled (non-loopback bind or strict auth)"
        else
          with_public_read (fun state req reqd ->
-           let base_path = state.Mcp_server.room_config.base_path in
+           let base_path = state.Mcp_server.coord_config.base_path in
            let raw_result = ensure_dashboard_dev_token base_path in
            begin
              match raw_result with
@@ -202,7 +202,7 @@ let add_routes ~sw ~clock router =
              Log.Ring.recent ~limit ~min_level ~module_filter ?since_seq ()
            in
            let json =
-             dashboard_logs_json ~config:state.Mcp_server.room_config ~limit
+             dashboard_logs_json ~config:state.Mcp_server.coord_config ~limit
                ~level_filter ~applied_level ~min_level ~module_filter ~since_seq entries
            in
            Http.Response.json_value ~compress:true ~request:req json reqd
@@ -227,7 +227,7 @@ let add_routes ~sw ~clock router =
          Http.Request.read_body_async reqd (fun body_str ->
            let fallback_agent =
              dashboard_actor_for_request
-               ~base_path:state.Mcp_server.room_config.base_path request
+               ~base_path:state.Mcp_server.coord_config.base_path request
            in
            let report_result =
              try
@@ -239,7 +239,7 @@ let add_routes ~sw ~clock router =
            match report_result with
            | Ok report ->
                Dashboard_tool_host_events.record ?fs:state.Mcp_server.fs
-                 state.Mcp_server.room_config
+                 state.Mcp_server.coord_config
                  report;
                respond_dashboard_ok ~request:req reqd
            | Error message ->
@@ -361,7 +361,7 @@ let add_routes ~sw ~clock router =
   |> Http.Router.get "/api/v1/dashboard/board" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let json =
-           dashboard_memory_http_json ~config:state.Mcp_server.room_config req
+           dashboard_memory_http_json ~config:state.Mcp_server.coord_config req
          in
          Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
@@ -376,7 +376,7 @@ let add_routes ~sw ~clock router =
          dashboard_memory_subsystems_include_entries request
        in
        let handler state req reqd =
-         let config = state.Mcp_server.room_config in
+         let config = state.Mcp_server.coord_config in
          let cache_key =
            Printf.sprintf "memory_subsystems:%s:%b"
              config.base_path include_memory_entries
@@ -396,7 +396,7 @@ let add_routes ~sw ~clock router =
        else with_public_read handler request reqd)
   |> Http.Router.get "/api/v1/dashboard/governance" (fun request reqd ->
        with_public_read (fun state req reqd ->
-         let base_path = state.Mcp_server.room_config.base_path in
+         let base_path = state.Mcp_server.coord_config.base_path in
          let json = dashboard_governance_http_json req ~base_path in
          Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
@@ -408,7 +408,7 @@ let add_routes ~sw ~clock router =
   |> Http.Router.get "/api/v1/dashboard/proof" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let json =
-           dashboard_proof_http_json ~config:state.Mcp_server.room_config req
+           dashboard_proof_http_json ~config:state.Mcp_server.coord_config req
          in
          Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
@@ -417,7 +417,7 @@ let add_routes ~sw ~clock router =
          Http.Request.read_body_async reqd (fun body_str ->
            try
              let args = Yojson.Safe.from_string body_str in
-             let base_path = state.Mcp_server.room_config.base_path in
+             let base_path = state.Mcp_server.coord_config.base_path in
              match dashboard_governance_approval_resolve_http_json ~base_path ~args with
              | Ok json ->
                  respond_json_value_with_cors request reqd json
@@ -434,7 +434,7 @@ let add_routes ~sw ~clock router =
          Http.Request.read_body_async reqd (fun body_str ->
            try
              let args = Yojson.Safe.from_string body_str in
-             let base_path = state.Mcp_server.room_config.base_path in
+             let base_path = state.Mcp_server.coord_config.base_path in
              match
                dashboard_governance_approval_rule_delete_http_json ~base_path ~args
              with
@@ -456,7 +456,7 @@ let add_routes ~sw ~clock router =
        with_public_read (fun state req reqd ->
          let cache_key =
            Printf.sprintf "operator_snapshot:%s"
-             state.Mcp_server.room_config.base_path
+             state.Mcp_server.coord_config.base_path
          in
          let json =
            Dashboard_cache.get_or_compute cache_key ~ttl:realtime_cache_ttl_s (fun () ->
@@ -506,12 +506,12 @@ let add_routes ~sw ~clock router =
        with_public_read (fun state req reqd ->
          let cache_key =
            Printf.sprintf "planning:%s"
-             state.Mcp_server.room_config.base_path
+             state.Mcp_server.coord_config.base_path
          in
          let json =
            Dashboard_cache.get_or_compute cache_key ~ttl:standard_cache_ttl_s (fun () ->
              Domain_pool_ref.submit_io_or_inline (fun () ->
-               dashboard_planning_http_json ~config:state.Mcp_server.room_config))
+               dashboard_planning_http_json ~config:state.Mcp_server.coord_config))
          in
          Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
@@ -530,12 +530,12 @@ let add_routes ~sw ~clock router =
        with_public_read (fun state req reqd ->
          let cache_key =
            Printf.sprintf "goals_tree:%s"
-             state.Mcp_server.room_config.base_path
+             state.Mcp_server.coord_config.base_path
          in
          let json =
            Dashboard_cache.get_or_compute cache_key ~ttl:standard_cache_ttl_s (fun () ->
              Domain_pool_ref.submit_io_or_inline (fun () ->
-               dashboard_goals_tree_http_json ~config:state.Mcp_server.room_config))
+               dashboard_goals_tree_http_json ~config:state.Mcp_server.coord_config))
          in
          Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
@@ -552,13 +552,13 @@ let add_routes ~sw ~clock router =
          else
            let cache_key =
              Printf.sprintf "goal_detail:%s:%s"
-               state.Mcp_server.room_config.base_path goal_id
+               state.Mcp_server.coord_config.base_path goal_id
            in
            let json =
              Dashboard_cache.get_or_compute cache_key ~ttl:standard_cache_ttl_s (fun () ->
                Domain_pool_ref.submit_io_or_inline (fun () ->
                  dashboard_goal_detail_http_json
-                   ~config:state.Mcp_server.room_config ~goal_id))
+                   ~config:state.Mcp_server.coord_config ~goal_id))
            in
            Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
@@ -569,7 +569,7 @@ let add_routes ~sw ~clock router =
   |> Http.Router.get "/api/v1/dashboard/briefing" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let cache_key =
-           Printf.sprintf "briefing:%s" state.Mcp_server.room_config.base_path
+           Printf.sprintf "briefing:%s" state.Mcp_server.coord_config.base_path
          in
          let json =
            Dashboard_cache.get_or_compute cache_key ~ttl:live_cache_ttl_s (fun () ->
@@ -581,7 +581,7 @@ let add_routes ~sw ~clock router =
   |> Http.Router.get "/api/v1/dashboard/session" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let cache_key =
-           Printf.sprintf "session:%s" state.Mcp_server.room_config.base_path
+           Printf.sprintf "session:%s" state.Mcp_server.coord_config.base_path
          in
          let json =
            Dashboard_cache.get_or_compute cache_key ~ttl:live_cache_ttl_s (fun () ->
@@ -603,8 +603,8 @@ let add_routes ~sw ~clock router =
                ~timing
                ?actor:
                  (dashboard_actor_for_request
-                    ~base_path:state.Mcp_server.room_config.base_path request)
-               state.Mcp_server.room_config
+                    ~base_path:state.Mcp_server.coord_config.base_path request)
+               state.Mcp_server.coord_config
            in
          Http.Response.json_value ~compress:true ~request:req ~extra_headers:(Server_timing.extra_header timing) json reqd
        ) request reqd)
@@ -612,7 +612,7 @@ let add_routes ~sw ~clock router =
        with_public_read (fun state req reqd ->
          let cache_key =
            Printf.sprintf "mission_briefing:%s"
-             state.Mcp_server.room_config.base_path
+             state.Mcp_server.coord_config.base_path
          in
          let json =
            Dashboard_cache.get_or_compute cache_key ~ttl:live_cache_ttl_s (fun () ->
@@ -697,7 +697,7 @@ let add_routes ~sw ~clock router =
               | Some _ | None -> None)
            | None -> None
          in
-         let config = state.Mcp_server.room_config in
+         let config = state.Mcp_server.coord_config in
          let cache_key =
            Printf.sprintf "keeper_feature_proof:%s:%d:%s:%s"
              config.base_path n
@@ -728,7 +728,7 @@ let add_routes ~sw ~clock router =
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/perf" (fun request reqd ->
        with_public_read (fun state req reqd ->
-         let json = dashboard_perf_http_json state.Mcp_server.room_config in
+         let json = dashboard_perf_http_json state.Mcp_server.coord_config in
          Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/harness-health" (fun _request reqd ->
@@ -737,14 +737,14 @@ let add_routes ~sw ~clock router =
          let until = Server_utils.query_param req "until" in
          let cache_key =
            Printf.sprintf "harness_health:%s:%s:%s"
-             state.Mcp_server.room_config.base_path
+             state.Mcp_server.coord_config.base_path
              (Option.value ~default:"-" since)
              (Option.value ~default:"-" until)
          in
          let json =
            Dashboard_cache.get_or_compute cache_key ~ttl:standard_cache_ttl_s (fun () ->
              Domain_pool_ref.submit_io_or_inline (fun () ->
-               Dashboard_harness_health.json ~config:state.Mcp_server.room_config
+               Dashboard_harness_health.json ~config:state.Mcp_server.coord_config
                  ?since ?until ()))
          in
          Http.Response.json_value ~compress:true ~request:req json reqd
@@ -766,7 +766,7 @@ let add_routes ~sw ~clock router =
   (* ── Eval feed (RFC-MASC-005 Phase 2) ── *)
   |> Http.Router.get "/api/v1/dashboard/eval-feed" (fun request reqd ->
        with_public_read (fun state req reqd ->
-         let base_path = state.Mcp_server.room_config.base_path in
+         let base_path = state.Mcp_server.coord_config.base_path in
          let agent_name = Server_utils.query_param req "agent_name" in
          let limit =
            Server_utils.int_query_param req "limit" ~default:10
@@ -833,7 +833,7 @@ let add_routes ~sw ~clock router =
             for cold start. *)
          let json =
            Server_dashboard_snapshot_select.select_telemetry_summary_json
-             ~timing state.Mcp_server.room_config
+             ~timing state.Mcp_server.coord_config
          in
          Http.Response.json_value ~compress:true ~request:req ~extra_headers:(Server_timing.extra_header timing) json reqd
        ) request reqd)

--- a/lib/server/server_routes_http_routes_dashboard_setup.ml
+++ b/lib/server/server_routes_http_routes_dashboard_setup.ml
@@ -58,7 +58,7 @@ let handle_dashboard_workspace = Server_routes_http_dashboard_handlers.handle_da
    as part of godfile near-threshold split. *)
 let handle_telemetry request reqd =
   with_public_read (fun state req reqd ->
-    let config = state.Mcp_server.room_config in
+    let config = state.Mcp_server.coord_config in
     let base_path = config.base_path in
     let masc_root = Coord.masc_root_dir config in
     let float_query_param req key =

--- a/lib/server/server_routes_http_routes_keeper_repos.ml
+++ b/lib/server/server_routes_http_routes_keeper_repos.ml
@@ -78,7 +78,7 @@ let mapping_of_json keeper_id (json : Yojson.Safe.t) :
   | _ -> Error "expected JSON object body"
 
 let handle_list_mappings state req reqd =
-  let base_path = state.Mcp_server.room_config.base_path in
+  let base_path = state.Mcp_server.coord_config.base_path in
   match Keeper_repo_mapping.load_all ~base_path with
   | Error msg ->
       Http.Response.json_value ~status:`Internal_server_error ~request:req
@@ -94,7 +94,7 @@ let handle_list_mappings state req reqd =
         reqd
 
 let handle_get_mapping state keeper_id req reqd =
-  let base_path = state.Mcp_server.room_config.base_path in
+  let base_path = state.Mcp_server.coord_config.base_path in
   match Keeper_repo_mapping.load_all ~base_path with
   | Error msg ->
       Http.Response.json_value ~status:`Internal_server_error ~request:req
@@ -146,7 +146,7 @@ let validate_mapping_credential ~base_path
                  credential_id (credential_type_label credential.cred_type)))
 
 let handle_save_mapping state keeper_id req reqd =
-  let base_path = state.Mcp_server.room_config.base_path in
+  let base_path = state.Mcp_server.coord_config.base_path in
   Http.Request.read_body_async reqd (fun body_str ->
       let response status message =
         Http.Response.json_value ~status ~request:req

--- a/lib/server/server_routes_http_routes_provider_runs.ml
+++ b/lib/server/server_routes_http_routes_provider_runs.ml
@@ -186,7 +186,7 @@ let respond_dashboard_heuristics_coverage request reqd =
 
 let respond_dashboard_stress request reqd =
   with_public_read (fun state req reqd ->
-    let config = state.Mcp_server.room_config in
+    let config = state.Mcp_server.coord_config in
     let json = dashboard_stress_json ~config req in
     Http.Response.json_value ~compress:true ~request:req json reqd
   ) request reqd
@@ -202,7 +202,7 @@ let add_routes ~sw router =
        with_public_read (fun state req reqd ->
          let window = int_query_param req "window" ~default:30 in
          let bucket_min = int_query_param req "bucket_min" ~default:0 in
-         let base_path = state.Mcp_server.room_config.base_path in
+         let base_path = state.Mcp_server.coord_config.base_path in
          let key =
            cache_key
              [ base_path; string_of_int window; string_of_int bucket_min ]
@@ -276,7 +276,7 @@ let add_routes ~sw router =
   |> Http.Router.get "/api/v1/dashboard/keeper-costs" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let window = int_query_param req "window" ~default:1440 in
-         let config = state.Mcp_server.room_config in
+         let config = state.Mcp_server.coord_config in
          let keeper_names = Keeper_meta_store.keeper_names config in
          let keepers =
            List.filter_map (fun name ->
@@ -294,7 +294,7 @@ let add_routes ~sw router =
   |> Http.Router.get "/api/v1/dashboard/cost-latency" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let window = int_query_param req "window" ~default:1440 in
-         let base_path = state.Mcp_server.room_config.base_path in
+         let base_path = state.Mcp_server.coord_config.base_path in
          let json =
            cached_dashboard_json ~sw ~cache:dashboard_cost_latency_cache
              ~key:(cache_key [ base_path; string_of_int window ])
@@ -308,7 +308,7 @@ let add_routes ~sw router =
   |> Http.Router.get "/api/v1/dashboard/keeper-decisions" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let limit = dashboard_feed_limit req in
-         let config = state.Mcp_server.room_config in
+         let config = state.Mcp_server.coord_config in
          let keeper_names = Keeper_meta_store.keeper_names config in
          let keepers =
            List.filter_map (fun name ->
@@ -326,7 +326,7 @@ let add_routes ~sw router =
   |> Http.Router.get "/api/v1/dashboard/keeper-decisions-log" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let limit = dashboard_feed_limit req in
-         let config = state.Mcp_server.room_config in
+         let config = state.Mcp_server.coord_config in
          let keeper_names = Keeper_meta_store.keeper_names config in
          let keepers =
            List.filter_map (fun name ->
@@ -344,7 +344,7 @@ let add_routes ~sw router =
   |> Http.Router.get "/api/v1/dashboard/keeper-memory-log" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let limit = dashboard_feed_limit req in
-         let config = state.Mcp_server.room_config in
+         let config = state.Mcp_server.coord_config in
          let keeper_names = Keeper_meta_store.keeper_names config in
          let keepers =
            List.filter_map (fun name ->

--- a/lib/server/server_routes_http_routes_repositories.ml
+++ b/lib/server/server_routes_http_routes_repositories.ml
@@ -3,7 +3,7 @@ open Server_utils
 
 module Http = Http_server_eio
 
-let base_path_of_state state = state.Mcp_server.room_config.base_path
+let base_path_of_state state = state.Mcp_server.coord_config.base_path
 
 let json_error message =
   `Assoc [("ok", `Bool false); ("error", `String message)]

--- a/lib/server/server_routes_http_routes_verification.ml
+++ b/lib/server/server_routes_http_routes_verification.ml
@@ -52,7 +52,7 @@ let add_routes router =
            | Some s -> int_of_string_opt s
            | None -> None
          in
-         let base_path = state.Mcp_server.room_config.base_path in
+         let base_path = state.Mcp_server.coord_config.base_path in
          let json =
            Dashboard_verification.requests_json ~base_path ?task_id ?limit ()
          in
@@ -65,7 +65,7 @@ let add_routes router =
            | Some s -> int_of_string_opt s
            | None -> None
          in
-         let base_path = state.Mcp_server.room_config.base_path in
+         let base_path = state.Mcp_server.coord_config.base_path in
          let json = Dashboard_verification.summary_json ~base_path ?recent () in
          Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
@@ -85,7 +85,7 @@ let add_routes router =
            Http.Request.read_body_async reqd (fun body_str ->
              try
                let args = Yojson.Safe.from_string body_str in
-               let config = state.Mcp_server.room_config in
+               let config = state.Mcp_server.coord_config in
                let verifier = verifier_of_request ~base_path:config.base_path req in
                match
                  Server_dashboard_http.dashboard_verification_resolve_http_json

--- a/lib/server/server_routes_http_routes_workspace.ml
+++ b/lib/server/server_routes_http_routes_workspace.ml
@@ -4,7 +4,7 @@ open Server_routes_http_pages
 
 module Http = Http_server_eio
 
-let base_path_of_state state = state.Mcp_server.room_config.base_path
+let base_path_of_state state = state.Mcp_server.coord_config.base_path
 
 let sanitize_log_value ?(max_bytes = 240) s =
   let without_controls =
@@ -98,7 +98,7 @@ let classify_workspace_query
 
 let resolve_workspace_base ~state ~uri =
   let project_base = base_path_of_state state in
-  let config = state.Mcp_server.room_config in
+  let config = state.Mcp_server.coord_config in
   let lookup_repository repo_id =
     match Repo_store.find ~base_path:project_base repo_id with
     | Ok repo -> Some (Repo_store.local_path ~base_path:project_base repo)

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -279,7 +279,7 @@ let make_health_json ?(listener = "http/1.1") ?section_timings_ref request =
   let fleet_meta_scan =
     match current_server_state_opt () with
     | Some state ->
-      Some (keeper_fleet_meta_scan state.Mcp_server.room_config)
+      Some (keeper_fleet_meta_scan state.Mcp_server.coord_config)
     | None -> None
   in
   let paused_keepers_json =

--- a/lib/server/server_routes_http_runtime.mli
+++ b/lib/server/server_routes_http_runtime.mli
@@ -105,7 +105,7 @@ val health_path_diagnostics :
 (** [health_path_diagnostics ()] resolves the base-path
     diagnostics for the [/health] response.  When the runtime
     state is initialised, reads from
-    [state.room_config.base_path]; otherwise falls back to the
+    [state.coord_config.base_path]; otherwise falls back to the
     default base path computed from env. *)
 
 val make_health_json :

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -161,7 +161,7 @@ let paused_keepers_health_json () =
   let running_names = running_paused_keeper_names () in
   let durable_scan =
     match current_server_state_opt () with
-    | Some state -> durable_paused_keeper_scan state.Mcp_server.room_config
+    | Some state -> durable_paused_keeper_scan state.Mcp_server.coord_config
     | None -> empty_paused_keeper_scan
   in
   paused_keepers_health_json_of_scan ~running_names durable_scan
@@ -388,8 +388,8 @@ let keeper_fleet_safety_health_json
       match current_server_state_opt () with
       | Some state ->
         (try
-           ( Keeper_runtime.bootable_keeper_names state.Mcp_server.room_config
-           , autoboot_enabled_keeper_scan state.Mcp_server.room_config )
+           ( Keeper_runtime.bootable_keeper_names state.Mcp_server.coord_config
+           , autoboot_enabled_keeper_scan state.Mcp_server.coord_config )
          with
          | Eio.Cancel.Cancelled _ as exn -> raise exn
          | exn ->

--- a/lib/server/server_routes_http_runtime_health_fleet.ml
+++ b/lib/server/server_routes_http_runtime_health_fleet.ml
@@ -30,7 +30,7 @@ let keeper_reaction_ledger_health_json () =
       ; "keepers", `List []
       ]
   | Some state ->
-    let config = state.Mcp_server.room_config in
+    let config = state.Mcp_server.coord_config in
     let keeper_names =
       try Keeper_meta_store.keeper_names config |> sorted_unique_strings |> take 64 with
       | Eio.Cancel.Cancelled _ as exn -> raise exn
@@ -65,10 +65,10 @@ let bool_field name = function
 (* Scope keeper counts to the active workspace's base_path so a running
    keeper from another workspace cannot mask a local outage in fleet
    safety. `bootable_keeper_count` is already derived from
-   `state.room_config`, so the running count must use the same scope. *)
+   `state.coord_config`, so the running count must use the same scope. *)
 let runtime_base_path_opt () =
   match current_server_state_opt () with
-  | Some state -> Some state.Mcp_server.room_config.base_path
+  | Some state -> Some state.Mcp_server.coord_config.base_path
   | None -> None
 
 let keeper_fleet_runtime_resolution_base_fields
@@ -175,7 +175,7 @@ let keeper_fleet_runtime_resolution_light_fields () =
       Some
         (keeper_fleet_meta_scan
            ~include_paused_details:false
-           state.Mcp_server.room_config)
+           state.Mcp_server.coord_config)
     | None -> None
   in
   keeper_fleet_runtime_resolution_base_fields

--- a/lib/server/server_routes_http_runtime_health_helpers.ml
+++ b/lib/server/server_routes_http_runtime_health_helpers.ml
@@ -31,8 +31,8 @@ let health_path_diagnostics () =
       Server_base_path_diagnostics.detect
         ?input_base_path:((Host_config.from_env ()).base_path_raw)
         ?env_masc_base_path:((Host_config.from_env ()).base_path_raw)
-        ~effective_base_path:state.room_config.base_path
-        ~effective_masc_root:(Coord.masc_root_dir state.room_config)
+        ~effective_base_path:state.coord_config.base_path
+        ~effective_masc_root:(Coord.masc_root_dir state.coord_config)
         ()
   | None ->
       let effective_base_path = default_base_path () in

--- a/lib/server/server_routes_http_sidecar_paths.ml
+++ b/lib/server/server_routes_http_sidecar_paths.ml
@@ -27,7 +27,7 @@ let runtime_base_path ?base_path () =
      | _ -> Sys.getcwd ())
 ;;
 
-let request_base_path state = state.Mcp_server.room_config.base_path
+let request_base_path state = state.Mcp_server.coord_config.base_path
 let dir_exists path = Sys.file_exists path && Sys.is_directory path
 
 let project_root_from_executable () =

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -146,8 +146,8 @@ let create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
     Server_base_path_diagnostics.detect
       ?input_base_path
       ?env_masc_base_path:((Host_config.from_env ()).base_path_raw)
-      ~effective_base_path:state.room_config.base_path
-      ~effective_masc_root:(Coord.masc_root_dir state.room_config)
+      ~effective_base_path:state.coord_config.base_path
+      ~effective_masc_root:(Coord.masc_root_dir state.coord_config)
       ()
     |> Server_base_path_diagnostics.to_yojson
   in
@@ -165,16 +165,16 @@ let runtime_path_diagnostics ?input_base_path (state : Mcp_server.server_state) 
   Server_base_path_diagnostics.detect
     ?input_base_path
     ?env_masc_base_path:((Host_config.from_env ()).base_path_raw)
-    ~effective_base_path:state.room_config.base_path
-    ~effective_masc_root:(Coord.masc_root_dir state.room_config)
+    ~effective_base_path:state.coord_config.base_path
+    ~effective_masc_root:(Coord.masc_root_dir state.coord_config)
     ()
 
 let restore_persisted_sessions (state : Mcp_server.server_state) =
   Session.restore_from_disk state.session_registry
-    ~agents_path:(Coord.agents_dir state.room_config)
+    ~agents_path:(Coord.agents_dir state.coord_config)
 
 let reconcile_active_agents_gauge (state : Mcp_server.server_state) =
-  Prometheus.reconcile_active_agents_gauge (Coord.masc_dir state.room_config)
+  Prometheus.reconcile_active_agents_gauge (Coord.masc_dir state.coord_config)
 
 
 (* Startup maintenance extracted to
@@ -190,7 +190,7 @@ let bootstrap_server_state_blocking (state : Mcp_server.server_state) =
      direct state constructors used by tests and execute contexts can leave a
      stale process-global config resolution in place. *)
   Config_dir_resolver.reset ();
-  let (_init_msg : string) = Coord.init state.room_config ~agent_name:None in
+  let (_init_msg : string) = Coord.init state.coord_config ~agent_name:None in
   audit_keeper_egress_policies state;
   Mcp_server.set_sse_callback state Sse.broadcast
 
@@ -251,8 +251,8 @@ let bootstrap_prompt_state (state : Mcp_server.server_state) =
   (* Initialize prompt registry with defaults and restore saved overrides *)
   let prompt_markdown_dir =
     Prompt_defaults.bootstrap_runtime
-      ~workspace_path:state.room_config.workspace_path
-      ~base_path:state.room_config.base_path
+      ~workspace_path:state.coord_config.workspace_path
+      ~base_path:state.coord_config.base_path
   in
   let expected_prompt_dir = Config_dir_resolver.prompts_dir () in
   if prompt_markdown_dir <> expected_prompt_dir then
@@ -281,7 +281,7 @@ let bootstrap_prompt_state (state : Mcp_server.server_state) =
 let warm_tool_registry_from_telemetry (state : Mcp_server.server_state) =
   (try
      let summary =
-       Telemetry_eio.summarize_tool_usage state.room_config
+       Telemetry_eio.summarize_tool_usage state.coord_config
      in
      if summary.telemetry_available then
        let n = Tool_registry.warm_up summary in
@@ -296,7 +296,7 @@ let warm_tool_registry_from_telemetry (state : Mcp_server.server_state) =
 let restore_tool_metrics_from_disk (state : Mcp_server.server_state) =
   (try
      let n = Tool_metrics_persist.restore
-       ~base_path:state.room_config.base_path in
+       ~base_path:state.coord_config.base_path in
      if n > 0 then
        Log.Misc.info "tool metrics: restored %d records from disk" n
    with
@@ -618,7 +618,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
         Log.Server.info "lazy_task_group: finished %s" group.group_name
       in
       Server_startup_state.activate_lazy
-        ~backend_mode:(Coord.backend_name state.room_config)
+        ~backend_mode:(Coord.backend_name state.coord_config)
         ~tasks:task_names;
       Eio.Fiber.fork ~sw (fun () -> List.iter run_lazy_task_group task_groups)
     in
@@ -629,7 +629,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
       in
       server_state := Some state;
       Server_startup_state.mark_state_ready
-        ~backend_mode:(Coord.backend_name state.room_config);
+        ~backend_mode:(Coord.backend_name state.coord_config);
       let resolved_base, masc_dir =
         Server_bootstrap_loops.start_background_maintenance ~sw ~clock ~env state
       in
@@ -676,7 +676,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
             tool_name (String.length result_str);
         if success then Ok result_str else Error result_str
       in
-      Masc_grpc_server.start ~sw ~env ~room_config:state.room_config
+      Masc_grpc_server.start ~sw ~env ~coord_config:state.coord_config
         ~tool_dispatcher;
       (* Initialize gRPC client for keeper heartbeat when transport is gRPC *)
       (match Masc_grpc_transport.from_env () with
@@ -693,7 +693,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
         | "shell" ->
             Some
               (Server_dashboard_http.dashboard_shell_payload_json ~light:true
-                 state.Mcp_server.room_config)
+                 state.Mcp_server.coord_config)
         | "execution" ->
             Some (Server_dashboard_http.dashboard_execution_snapshot_json ())
         | "operator" ->
@@ -714,7 +714,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
         | "composite" ->
             Some
               (Server_dashboard_http.dashboard_fleet_composite_json
-                 ~config:state.Mcp_server.room_config ())
+                 ~config:state.Mcp_server.coord_config ())
         | "board" ->
             Some
               (Server_dashboard_http.dashboard_board_json
@@ -723,7 +723,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
         | "goals" ->
             Some
               (Server_dashboard_http.dashboard_goals_snapshot_json
-                 ~config:state.Mcp_server.room_config)
+                 ~config:state.Mcp_server.coord_config)
         | _ ->
             None);
       (* Standalone WebSocket transport (enabled by default, opt-out via MASC_WS_ENABLED=0) *)

--- a/lib/server/server_runtime_startup_credentials.ml
+++ b/lib/server/server_runtime_startup_credentials.ml
@@ -20,7 +20,7 @@ let audit_keeper_egress_policies (state : Mcp_server.server_state) =
      opt-in seed PR (PR-Eg4).  The audit is fail-soft: any unexpected
      exception is logged and swallowed so a misbehaving keepers/ tree
      can't keep the server from starting. *)
-  let config = state.Mcp_server.room_config in
+  let config = state.Mcp_server.coord_config in
   let keepers_dir = Filename.concat (Coord.masc_root_dir config) "keepers" in
   let metas =
     if not (Sys.file_exists keepers_dir) then []
@@ -87,7 +87,7 @@ let audit_keeper_egress_policies (state : Mcp_server.server_state) =
   end
 
 let sync_admin_token_env (state : Mcp_server.server_state) =
-  let base_path = state.Mcp_server.room_config.base_path in
+  let base_path = state.Mcp_server.coord_config.base_path in
   let admin_agent_name =
     match Auth.read_initial_admin base_path with
     | Some name ->
@@ -136,19 +136,19 @@ let sync_admin_token_env (state : Mcp_server.server_state) =
              (Masc_domain.masc_error_to_string err))
 
 let sync_internal_keeper_token_env (state : Mcp_server.server_state) =
-  let base_path = state.Mcp_server.room_config.base_path in
+  let base_path = state.Mcp_server.coord_config.base_path in
   let raw_token = Auth.ensure_internal_keeper_token base_path in
   Unix.putenv "MASC_INTERNAL_MCP_TOKEN" raw_token;
   Log.Server.info
     "startup internal keeper MCP token synced via MASC_INTERNAL_MCP_TOKEN"
 
 let sync_bootable_keeper_credentials (state : Mcp_server.server_state) =
-  let base_path = state.Mcp_server.room_config.base_path in
+  let base_path = state.Mcp_server.coord_config.base_path in
   let keeper_names =
-    Keeper_runtime.bootable_keeper_names state.Mcp_server.room_config
+    Keeper_runtime.bootable_keeper_names state.Mcp_server.coord_config
   in
   let excluded_keepers =
-    Keeper_runtime.autoboot_excluded_keeper_reasons state.Mcp_server.room_config
+    Keeper_runtime.autoboot_excluded_keeper_reasons state.Mcp_server.coord_config
   in
   let keeper_agent_names =
     List.map Keeper_identity.keeper_agent_name keeper_names

--- a/lib/server/server_runtime_startup_maintenance.ml
+++ b/lib/server/server_runtime_startup_maintenance.ml
@@ -9,14 +9,14 @@ let startup_prune_jsonl (state : Mcp_server.server_state) =
      let days =
        Safe_ops.get_env_int_logged "MASC_JSONL_RETENTION_DAYS" ~default:30
      in
-     let masc = Coord.masc_dir state.room_config in
+     let masc = Coord.masc_dir state.coord_config in
      let prune_dir dir =
        if Sys.file_exists dir then
          Dated_jsonl.prune (Dated_jsonl.create ~base_dir:dir ()) ~days
        else 0
      in
      let tool_metrics_dir =
-       Filename.concat state.room_config.base_path "data/tool-metrics"
+       Filename.concat state.coord_config.base_path "data/tool-metrics"
      in
      let total =
        prune_dir (Filename.concat masc "audit")
@@ -57,7 +57,7 @@ let startup_prune_auth_archive (state : Mcp_server.server_state) =
      in
      let kept, pruned =
        Auth.prune_archive
-         ~base_path:state.room_config.base_path
+         ~base_path:state.coord_config.base_path
          ~retention_days:days
          ~min_keep
      in
@@ -82,7 +82,7 @@ let startup_prune_auth_archive (state : Mcp_server.server_state) =
 let startup_migrate_keeper_histories (state : Mcp_server.server_state) =
   (try
      let traces_dir =
-       Filename.concat (Coord.masc_root_dir state.room_config) "traces"
+       Filename.concat (Coord.masc_root_dir state.coord_config) "traces"
      in
      if Sys.file_exists traces_dir then begin
        let moved_total = ref 0 in

--- a/lib/tool_board.mli
+++ b/lib/tool_board.mli
@@ -112,7 +112,7 @@ val set_agent_lookup : (string -> bool) -> unit
 (** Wires the [is_agent_session_bound] check used by the
     auto-classifier to decide whether a [system_*] author
     name resolves to a live agent.  Installed once at
-    server bootstrap from [server_state.room_config]. *)
+    server bootstrap from [server_state.coord_config]. *)
 
 val set_agent_lookup_none : unit -> unit
 (** Clears the previously-installed callback.  Used by

--- a/lib/tool_inline_dispatch_coord.ml
+++ b/lib/tool_inline_dispatch_coord.ml
@@ -73,7 +73,7 @@ let handle_start ~tool_name ~start_time (ctx : context) : Tool_result.result opt
   (* Step 1: set project root *)
   let room_result =
     if String.equal path "" then begin
-      if Coord.is_initialized state.Mcp_server.room_config then
+      if Coord.is_initialized state.Mcp_server.coord_config then
         Ok config
       else
         Error "path is required when no project scope is set. Provide the project directory path."
@@ -94,11 +94,11 @@ let handle_start ~tool_name ~start_time (ctx : context) : Tool_result.result opt
       else begin
         let cfg = Coord.default_config expanded in
         if Coord.is_initialized cfg then begin
-          state.Mcp_server.room_config <- cfg;
+          state.Mcp_server.coord_config <- cfg;
           Ok cfg
         end else begin
           let _msg = Coord.init cfg ~agent_name:None in
-          state.Mcp_server.room_config <- cfg;
+          state.Mcp_server.coord_config <- cfg;
           Ok cfg
         end
       end

--- a/lib/tool_inline_dispatch_coord.mli
+++ b/lib/tool_inline_dispatch_coord.mli
@@ -35,7 +35,7 @@ val handle_start :
 
     1. **Set project root**: validates the directory exists,
        initialises {!Coord} when not already initialised, and
-       atomically swaps [state.room_config].
+       atomically swaps [state.coord_config].
     2. **Bind agent session**: idempotent when already bound.
        Failure surfaces as a startup error.
     3. **Optional task creation**: when [task_title] non-empty,

--- a/lib/tool_metrics_persist.mli
+++ b/lib/tool_metrics_persist.mli
@@ -19,7 +19,7 @@ val start_flush_fiber : sw:Eio.Switch.t -> clock:_ Eio.Time.clock -> base_path:s
 (** [start_flush_fiber ~sw ~clock ~base_path] spawns a background fiber that
     drains buffered records to JSONL every 5 minutes.  Also registers a
     shutdown hook to flush remaining records.
-    [base_path] is the workspace root (e.g. [state.room_config.base_path]). *)
+    [base_path] is the workspace root (e.g. [state.coord_config.base_path]). *)
 
 val restore : base_path:string -> int
 (** [restore ~base_path] reads all existing JSONL day-files under

--- a/lib/tool_misc_admin.ml
+++ b/lib/tool_misc_admin.ml
@@ -235,7 +235,7 @@ let handle_tool_admin_update ~tool_name ~start_time ctx args : tool_result =
       (match expiry_hours with
       | Error err -> error_workflow ~tool_name ~start_time err
       | Ok token_expiry_hours ->
-          let room_secret =
+          let coord_secret =
             match enabled_opt with
             | Some true when not current.enabled ->
                 let (secret, _bootstrap) =
@@ -261,7 +261,7 @@ let handle_tool_admin_update ~tool_name ~start_time ctx args : tool_result =
           ok_result_typed ~tool_name ~start_time
             [
               ("section", `String "auth");
-              ("room_secret", Json_util.string_opt_to_json_trimmed room_secret);
+              ("coord_secret", Json_util.string_opt_to_json_trimmed coord_secret);
               ("result", auth_snapshot_json ctx);
             ])
   | _ ->

--- a/lib/types/types_auth.ml
+++ b/lib/types/types_auth.ml
@@ -104,14 +104,14 @@ let agent_credential_of_yojson json =
 (** Auth configuration *)
 type auth_config = {
   enabled: bool;
-  room_secret_hash: string option; [@default None]
+  coord_secret_hash: string option; [@default None]
   require_token: bool; [@default false]
   token_expiry_hours: int; [@default 24]
 } [@@deriving show]
 
 let default_auth_config = {
   enabled = true;
-  room_secret_hash = None;
+  coord_secret_hash = None;
   require_token = true;
   token_expiry_hours = 24;
 }
@@ -119,7 +119,7 @@ let default_auth_config = {
 let auth_config_to_yojson c =
   `Assoc [
     ("enabled", `Bool c.enabled);
-    ("room_secret_hash", Json_util.string_opt_to_json c.room_secret_hash);
+    ("coord_secret_hash", Json_util.string_opt_to_json c.coord_secret_hash);
     ("require_token", `Bool c.require_token);
     ("token_expiry_hours", `Int c.token_expiry_hours);
   ]
@@ -127,10 +127,10 @@ let auth_config_to_yojson c =
 let auth_config_of_yojson json =
   try
     let enabled = Json_util.get_bool json "enabled" |> Option.value ~default:true in
-    let room_secret_hash = Json_util.get_string json "room_secret_hash" in
+    let coord_secret_hash = Json_util.get_string json "coord_secret_hash" in
     let require_token = Json_util.get_bool json "require_token" |> Option.value ~default:false in
     let token_expiry_hours = Json_util.get_int json "token_expiry_hours" |> Option.value ~default:24 in
-    Ok { enabled; room_secret_hash; require_token; token_expiry_hours }
+    Ok { enabled; coord_secret_hash; require_token; token_expiry_hours }
   with e -> Error (Printexc.to_string e)
 
 (** Permission matrix - what each role can do *)

--- a/lib/types/types_auth.mli
+++ b/lib/types/types_auth.mli
@@ -96,14 +96,14 @@ val agent_credential_of_yojson :
 
 type auth_config = {
   enabled : bool;
-  room_secret_hash : string option;  [@default None]
+  coord_secret_hash : string option;  [@default None]
   require_token : bool;  [@default false]
   token_expiry_hours : int;  [@default 24]
 }
 [@@deriving show]
 
 val default_auth_config : auth_config
-(** [enabled = true; room_secret_hash = None; require_token = true;
+(** [enabled = true; coord_secret_hash = None; require_token = true;
        token_expiry_hours = 24]. *)
 
 val auth_config_to_yojson : auth_config -> Yojson.Safe.t

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -733,7 +733,7 @@ type message = {
 } [@@deriving yojson { strict = false }, show]
 
 (** Coord state *)
-type room_state = {
+type coord_state = {
   protocol_version: string;
   project: string;
   started_at: string;

--- a/lib/types/types_core.mli
+++ b/lib/types/types_core.mli
@@ -214,7 +214,7 @@ type message =
   }
 [@@deriving yojson { strict = false }, show]
 
-type room_state =
+type coord_state =
   { protocol_version : string
   ; project : string
   ; started_at : string

--- a/proto/masc.proto
+++ b/proto/masc.proto
@@ -68,7 +68,7 @@ message StatusResponse {
   repeated Agent agents = 1;
   repeated Task tasks = 2;
   int32 message_count = 3;
-  string room_path = 4;
+  string workspace_path = 4;
   string project_name = 5;
 }
 

--- a/proto/masc_coordination.proto
+++ b/proto/masc_coordination.proto
@@ -117,7 +117,7 @@ message StatusResponse {
   repeated AgentInfo agents = 1;
   repeated TaskInfo tasks = 2;
   int32 message_count = 3;
-  string room_path = 4;
+  string workspace_path = 4;
 }
 
 // ===== Shared Types =====

--- a/test/dune
+++ b/test/dune
@@ -39,7 +39,7 @@
   test_dashboard_oas_bridge
   test_masc_runtime_events
   test_room
-  test_room_state_recovery
+  test_coord_state_recovery
   test_exec_tap
   test_auth
   test_auth_credential_index_cache
@@ -310,7 +310,7 @@
   test_dashboard_oas_bridge
   test_masc_runtime_events
   test_room
-  test_room_state_recovery
+  test_coord_state_recovery
   test_exec_tap
   test_auth
   test_auth_credential_index_cache

--- a/test/test_ag_ui_coverage.ml
+++ b/test/test_ag_ui_coverage.ml
@@ -87,8 +87,8 @@ let test_event_to_sse_format () =
 
 (* ---------- MASC → AG-UI Mapping Tests ---------- *)
 
-let test_of_agent_joined () =
-  let e = of_agent_joined ~agent_name:"agent_llm_a" in
+let test_of_agent_session_bounded () =
+  let e = of_agent_session_bounded ~agent_name:"agent_llm_a" in
   assert (e.event_type = Run_started);
   assert (e.thread_id = "default");
   assert (e.run_id = Some "agent_llm_a");
@@ -139,9 +139,9 @@ let test_of_tool_call () =
   let e2 = List.nth events 2 in
   assert (e2.event_type = Tool_call_end)
 
-let test_of_room_state () =
+let test_of_coord_state () =
   let state = `Assoc [("agents", `Int 3); ("tasks", `Int 5)] in
-  let e = of_room_state state in
+  let e = of_coord_state state in
   assert (e.event_type = State_snapshot);
   assert (e.snapshot = Some state)
 
@@ -197,13 +197,13 @@ let () =
     ("event_to_json_optional_fields", test_event_to_json_with_optional_fields);
     ("event_to_json_custom", test_event_to_json_custom);
     ("event_to_sse_format", test_event_to_sse_format);
-    ("of_agent_joined", test_of_agent_joined);
+    ("of_agent_session_bounded", test_of_agent_session_bounded);
     ("of_agent_left", test_of_agent_left);
     ("of_broadcast", test_of_broadcast);
     ("of_task_claimed", test_of_task_claimed);
     ("of_task_done", test_of_task_done);
     ("of_tool_call", test_of_tool_call);
-    ("of_room_state", test_of_room_state);
+    ("of_coord_state", test_of_coord_state);
     ("of_custom", test_of_custom);
     ("of_task_update_claimed", test_of_task_update_claimed);
     ("of_task_update_done", test_of_task_update_done);

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -209,14 +209,14 @@ let test_credential_saved_private () =
             (Printf.sprintf "create_token should succeed: %s"
                (Masc_domain.masc_error_to_string e)))
 
-let test_room_secret_saved_private () =
+let test_coord_secret_saved_private () =
   let dir = setup_test_room () in
   Fun.protect
     ~finally:(fun () -> cleanup_test_room dir)
     (fun () ->
-      ignore (Auth.init_room_secret dir);
+      ignore (Auth.init_coord_secret dir);
       check int "room secret mode 0600" 0o600
-        (permission_bits (Auth.room_secret_file dir)))
+        (permission_bits (Auth.coord_secret_file dir)))
 
 let test_verify_token () =
   let dir = setup_test_room () in
@@ -1533,6 +1533,6 @@ let () =
     ];
     "enable_disable", [
       test_case "enable/disable auth" `Quick test_enable_disable_auth;
-      test_case "room secret saved private" `Quick test_room_secret_saved_private;
+      test_case "room secret saved private" `Quick test_coord_secret_saved_private;
     ];
   ]

--- a/test/test_auth_coverage.ml
+++ b/test/test_auth_coverage.ml
@@ -3,7 +3,7 @@
     Tests for MASC Authentication & Authorization:
     - generate_token: random token generation
     - sha256_hash: cryptographic hashing
-    - auth_dir, agents_dir, room_secret_file, auth_config_file: path helpers
+    - auth_dir, agents_dir, coord_secret_file, auth_config_file: path helpers
 *)
 
 (* Initialize RNG for crypto operations *)
@@ -131,12 +131,12 @@ let test_agents_dir_contains_agents () =
        true
      with Not_found -> false)
 
-let test_room_secret_file_nonempty () =
-  let path = Auth.room_secret_file "/tmp/test" in
+let test_coord_secret_file_nonempty () =
+  let path = Auth.coord_secret_file "/tmp/test" in
   check bool "nonempty" true (String.length path > 0)
 
-let test_room_secret_file_contains_hash () =
-  let path = Auth.room_secret_file "/tmp/test" in
+let test_coord_secret_file_contains_hash () =
+  let path = Auth.coord_secret_file "/tmp/test" in
   check bool "contains .hash" true
     (try
        let _ = Str.search_forward (Str.regexp "\\.hash") path 0 in
@@ -1052,9 +1052,9 @@ let () =
       test_case "nonempty" `Quick test_agents_dir_nonempty;
       test_case "contains agents" `Quick test_agents_dir_contains_agents;
     ];
-    "room_secret_file", [
-      test_case "nonempty" `Quick test_room_secret_file_nonempty;
-      test_case "contains hash" `Quick test_room_secret_file_contains_hash;
+    "coord_secret_file", [
+      test_case "nonempty" `Quick test_coord_secret_file_nonempty;
+      test_case "contains hash" `Quick test_coord_secret_file_contains_hash;
     ];
     "auth_config_file", [
       test_case "nonempty" `Quick test_auth_config_file_nonempty;

--- a/test/test_coord_bootstrap.ml
+++ b/test/test_coord_bootstrap.ml
@@ -8,21 +8,21 @@ module Types = Masc_domain
 
     The module has two exposed functions:
 
-    - [default_room_state config] — pure (modulo [now_iso ()] for
-      [started_at]) constructor for [Masc_domain.room_state].
-    - [ensure_room_bootstrap config] — idempotent FS bootstrap
-      that creates [.masc/<dirs>] and seed [room_state.json] /
+    - [default_coord_state config] — pure (modulo [now_iso ()] for
+      [started_at]) constructor for [Masc_domain.coord_state].
+    - [ensure_coord_bootstrap config] — idempotent FS bootstrap
+      that creates [.masc/<dirs>] and seed [coord_state.json] /
       [backlog.json] under both root and scoped layouts.
 
     Properties pinned:
 
-    1. {b default_room_state constants} — every field except
+    1. {b default_coord_state constants} — every field except
        [started_at] and [project] is a fixed default; [project]
        derives from [Filename.basename config.base_path].
-    2. {b ensure_room_bootstrap idempotency} — running it twice
+    2. {b ensure_coord_bootstrap idempotency} — running it twice
        on the same tmpdir leaves the seed files unchanged
        (mtime-stable) and produces no extra directories.
-    3. {b ensure_room_bootstrap creates expected dirs} — after
+    3. {b ensure_coord_bootstrap creates expected dirs} — after
        a single call, [.masc/agents/], [.masc/tasks/],
        [.masc/messages/] exist plus the root mirrors. *)
 
@@ -59,12 +59,12 @@ let with_tmp f =
     ~finally:(fun () -> try rm_rf dir with _ -> ())
     (fun () -> f dir)
 
-(* ── (1) default_room_state ─────────────────────────────── *)
+(* ── (1) default_coord_state ─────────────────────────────── *)
 
-let test_default_room_state_constants () =
+let test_default_coord_state_constants () =
   with_tmp (fun dir ->
       let config = Coord.default_config dir in
-      let st = B.default_room_state config in
+      let st = B.default_coord_state config in
       assert (st.protocol_version = "0.1.0");
       assert (st.message_seq = 0);
       assert (st.active_agents = []);
@@ -78,17 +78,17 @@ let test_default_room_state_constants () =
       (* started_at is non-empty (now_iso ()). *)
       assert (st.started_at <> ""))
 
-let test_default_room_state_project_from_base_path () =
+let test_default_coord_state_project_from_base_path () =
   (* project = Filename.basename config.base_path *)
   with_tmp (fun dir ->
       let config = Coord.default_config dir in
-      let st = B.default_room_state config in
+      let st = B.default_coord_state config in
       assert (st.project = Filename.basename dir))
 
-let test_default_room_state_started_at_iso_format () =
+let test_default_coord_state_started_at_iso_format () =
   with_tmp (fun dir ->
       let config = Coord.default_config dir in
-      let st = B.default_room_state config in
+      let st = B.default_coord_state config in
       (* ISO 8601: starts with 4-digit year + "-". *)
       let s = st.started_at in
       assert (String.length s >= 19);
@@ -98,12 +98,12 @@ let test_default_room_state_started_at_iso_format () =
       assert (s.[7] = '-');
       assert (s.[10] = 'T'))
 
-(* ── (2) ensure_room_bootstrap creates dirs ──────────────── *)
+(* ── (2) ensure_coord_bootstrap creates dirs ──────────────── *)
 
-let test_ensure_room_bootstrap_creates_scoped_dirs () =
+let test_ensure_coord_bootstrap_creates_scoped_dirs () =
   with_tmp (fun dir ->
       let config = Coord.default_config dir in
-      B.ensure_room_bootstrap config;
+      B.ensure_coord_bootstrap config;
       let masc = Filename.concat dir ".masc" in
       assert (Sys.file_exists masc);
       assert (Sys.is_directory masc);
@@ -114,12 +114,12 @@ let test_ensure_room_bootstrap_creates_scoped_dirs () =
           assert (Sys.is_directory p))
         [ "agents"; "tasks"; "messages" ])
 
-let test_ensure_room_bootstrap_creates_root_dirs () =
+let test_ensure_coord_bootstrap_creates_root_dirs () =
   (* The root layout (under [.masc/] sibling) — agents / keepers /
      traces / tasks / messages — should also exist after bootstrap. *)
   with_tmp (fun dir ->
       let config = Coord.default_config dir in
-      B.ensure_room_bootstrap config;
+      B.ensure_coord_bootstrap config;
       let root_dir =
         Coord_utils.masc_root_dir config
       in
@@ -130,11 +130,11 @@ let test_ensure_room_bootstrap_creates_root_dirs () =
           assert (Sys.is_directory p))
         [ "agents"; "keepers"; "traces"; "tasks"; "messages" ])
 
-let test_ensure_room_bootstrap_seeds_state_json () =
+let test_ensure_coord_bootstrap_seeds_state_json () =
   (* The scoped state JSON file should be created. *)
   with_tmp (fun dir ->
       let config = Coord.default_config dir in
-      B.ensure_room_bootstrap config;
+      B.ensure_coord_bootstrap config;
       let state_path = Coord_utils.state_path config in
       assert (Sys.file_exists state_path);
       let backlog_path =
@@ -144,35 +144,35 @@ let test_ensure_room_bootstrap_seeds_state_json () =
 
 (* ── (3) idempotency ──────────────────────────────────────── *)
 
-let test_ensure_room_bootstrap_idempotent () =
+let test_ensure_coord_bootstrap_idempotent () =
   (* Running twice must not corrupt or duplicate — file presence
      after the second call equals after the first. *)
   with_tmp (fun dir ->
       let config = Coord.default_config dir in
-      B.ensure_room_bootstrap config;
+      B.ensure_coord_bootstrap config;
       let state_path = Coord_utils.state_path config in
       let mtime1 = (Unix.stat state_path).st_mtime in
       (* Second invocation must NOT rewrite the seed file (the
          impl skips when path_exists). *)
-      B.ensure_room_bootstrap config;
+      B.ensure_coord_bootstrap config;
       let mtime2 = (Unix.stat state_path).st_mtime in
       assert (mtime1 = mtime2);
       (* Seeded files still exist. *)
       assert (Sys.file_exists state_path))
 
-let test_ensure_room_bootstrap_does_not_clobber_existing_state () =
+let test_ensure_coord_bootstrap_does_not_clobber_existing_state () =
   (* If a state file already exists with custom content, bootstrap
      must NOT overwrite it. *)
   with_tmp (fun dir ->
       let config = Coord.default_config dir in
-      B.ensure_room_bootstrap config;
+      B.ensure_coord_bootstrap config;
       let state_path = Coord_utils.state_path config in
       (* Replace the seeded state with a sentinel JSON. *)
       let oc = open_out state_path in
       output_string oc "{\"sentinel\":\"do not clobber\"}";
       close_out oc;
       (* Re-bootstrap. *)
-      B.ensure_room_bootstrap config;
+      B.ensure_coord_bootstrap config;
       let ic = open_in state_path in
       let body = input_line ic in
       close_in ic;
@@ -187,12 +187,12 @@ let test_ensure_room_bootstrap_does_not_clobber_existing_state () =
 (* ── runner ───────────────────────────────────────────────── *)
 
 let () =
-  test_default_room_state_constants ();
-  test_default_room_state_project_from_base_path ();
-  test_default_room_state_started_at_iso_format ();
-  test_ensure_room_bootstrap_creates_scoped_dirs ();
-  test_ensure_room_bootstrap_creates_root_dirs ();
-  test_ensure_room_bootstrap_seeds_state_json ();
-  test_ensure_room_bootstrap_idempotent ();
-  test_ensure_room_bootstrap_does_not_clobber_existing_state ();
+  test_default_coord_state_constants ();
+  test_default_coord_state_project_from_base_path ();
+  test_default_coord_state_started_at_iso_format ();
+  test_ensure_coord_bootstrap_creates_scoped_dirs ();
+  test_ensure_coord_bootstrap_creates_root_dirs ();
+  test_ensure_coord_bootstrap_seeds_state_json ();
+  test_ensure_coord_bootstrap_idempotent ();
+  test_ensure_coord_bootstrap_does_not_clobber_existing_state ();
   print_endline "test_coord_bootstrap: all assertions passed"

--- a/test/test_coord_eio_pure.ml
+++ b/test/test_coord_eio_pure.ml
@@ -2,7 +2,7 @@
 
     Covers the deterministic helpers that don't touch Eio fibers, the
     filesystem backend, or any Eio context: key formatters, the
-    [event_type] string mapping, and the [room_state] JSON round-trip. *)
+    [event_type] string mapping, and the [coord_state] JSON round-trip. *)
 
 open Masc_mcp
 module CE = Coord_eio
@@ -43,18 +43,18 @@ let test_event_key_zero_pads () =
 (* ── event_type_to_string ────────────────────────────────────────────── *)
 
 let test_event_type_strings () =
-  check_string "AgentJoin"   "agent_join"   (CE.event_type_to_string CE.AgentJoin);
-  check_string "AgentLeave"  "agent_leave"  (CE.event_type_to_string CE.AgentLeave);
+  check_string "AgentSessionBound"   "agent_session_bound"   (CE.event_type_to_string CE.AgentSessionBound);
+  check_string "AgentSessionEnded"  "agent_session_ended"  (CE.event_type_to_string CE.AgentSessionEnded);
   check_string "Broadcast"   "broadcast"    (CE.event_type_to_string CE.Broadcast);
   check_string "LockAcquire" "lock_acquire" (CE.event_type_to_string CE.LockAcquire);
   check_string "LockRelease" "lock_release" (CE.event_type_to_string CE.LockRelease)
 
-(* ── room_state JSON round-trip ──────────────────────────────────────── *)
+(* ── coord_state JSON round-trip ──────────────────────────────────────── *)
 
-let test_default_room_state_round_trip () =
-  let state = CE.default_room_state () in
-  let json = CE.room_state_to_json state in
-  match CE.room_state_of_json json with
+let test_default_coord_state_round_trip () =
+  let state = CE.default_coord_state () in
+  let json = CE.coord_state_to_json state in
+  match CE.coord_state_of_json json with
   | Error msg -> Alcotest.fail ("default round-trip failed: " ^ msg)
   | Ok decoded ->
     check_string "protocol_version preserved"
@@ -70,8 +70,8 @@ let test_default_room_state_round_trip () =
     check_bool "paused preserved"
       state.paused decoded.paused
 
-let test_paused_room_state_round_trip () =
-  let base = CE.default_room_state () in
+let test_paused_coord_state_round_trip () =
+  let base = CE.default_coord_state () in
   let state =
     { base with
       paused = true;
@@ -83,8 +83,8 @@ let test_paused_room_state_round_trip () =
       event_seq = 7;
     }
   in
-  let json = CE.room_state_to_json state in
-  match CE.room_state_of_json json with
+  let json = CE.coord_state_to_json state in
+  match CE.coord_state_of_json json with
   | Error msg -> Alcotest.fail ("paused round-trip failed: " ^ msg)
   | Ok decoded ->
     check_bool "paused=true preserved" true decoded.paused;
@@ -97,10 +97,10 @@ let test_paused_room_state_round_trip () =
     check_int "message_seq=42 preserved" 42 decoded.message_seq;
     check_int "event_seq=7 preserved" 7 decoded.event_seq
 
-let test_room_state_of_json_missing_event_seq () =
+let test_coord_state_of_json_missing_event_seq () =
   (* Backward-compat path: old state files without event_seq must default
      to 0 instead of failing — explicitly handled by Safe_ops.json_int in
-     room_state_of_json. *)
+     coord_state_of_json. *)
   let json =
     `Assoc
       [
@@ -117,14 +117,14 @@ let test_room_state_of_json_missing_event_seq () =
         ("pause_reason", `Null);
       ]
   in
-  match CE.room_state_of_json json with
+  match CE.coord_state_of_json json with
   | Error msg -> Alcotest.fail ("missing event_seq should default to 0: " ^ msg)
   | Ok decoded -> check_int "event_seq defaults to 0" 0 decoded.event_seq
 
-let test_room_state_of_json_malformed () =
+let test_coord_state_of_json_malformed () =
   let json = `String "not an object" in
-  match CE.room_state_of_json json with
-  | Ok _ -> Alcotest.fail "malformed json should not parse to room_state"
+  match CE.coord_state_of_json json with
+  | Ok _ -> Alcotest.fail "malformed json should not parse to coord_state"
   | Error _ -> ()
 
 (* ── runner ──────────────────────────────────────────────────────────── *)
@@ -144,15 +144,15 @@ let () =
         [
           Alcotest.test_case "all variants" `Quick test_event_type_strings;
         ] );
-      ( "room_state_round_trip",
+      ( "coord_state_round_trip",
         [
           Alcotest.test_case "default state"               `Quick
-            test_default_room_state_round_trip;
+            test_default_coord_state_round_trip;
           Alcotest.test_case "paused state with all opts"  `Quick
-            test_paused_room_state_round_trip;
+            test_paused_coord_state_round_trip;
           Alcotest.test_case "missing event_seq defaults"  `Quick
-            test_room_state_of_json_missing_event_seq;
+            test_coord_state_of_json_missing_event_seq;
           Alcotest.test_case "malformed json fails cleanly" `Quick
-            test_room_state_of_json_malformed;
+            test_coord_state_of_json_malformed;
         ] );
     ]

--- a/test/test_dashboard_namespace_truth.ml
+++ b/test/test_dashboard_namespace_truth.ml
@@ -262,7 +262,7 @@ let test_dashboard_namespace_truth_keeper_only_room_not_reported_empty () =
       Fs_compat.set_fs (Eio.Stdenv.fs env);
       let module Mcp_server = Lib.Mcp_server in
       let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
-      let config = state.Mcp_server.room_config in
+      let config = state.Mcp_server.coord_config in
       ignore (Lib.Coord.init config ~agent_name:None);
       ignore
         (Lib.Coord.join config
@@ -304,7 +304,7 @@ let test_dashboard_namespace_truth_mixed_runtime_counts () =
       Fs_compat.set_fs (Eio.Stdenv.fs env);
       let module Mcp_server = Lib.Mcp_server in
       let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
-      let config = state.Mcp_server.room_config in
+      let config = state.Mcp_server.coord_config in
       ignore (Lib.Coord.init config ~agent_name:None);
       ignore
         (Lib.Coord.join config
@@ -378,7 +378,7 @@ let test_dashboard_namespace_truth_promotes_meta_cognition_focus () =
       Fs_compat.set_fs (Eio.Stdenv.fs env);
       let module Mcp_server = Lib.Mcp_server in
       let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
-      let config = state.Mcp_server.room_config in
+      let config = state.Mcp_server.coord_config in
       ignore (Lib.Coord.init config ~agent_name:None);
       let masc_dir = Lib.Coord.masc_dir config in
       save_jsonl
@@ -443,7 +443,7 @@ let test_dashboard_namespace_truth_does_not_auto_post_meta_digest () =
       Fs_compat.set_fs (Eio.Stdenv.fs env);
       let module Mcp_server = Lib.Mcp_server in
       let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
-      let config = state.Mcp_server.room_config in
+      let config = state.Mcp_server.coord_config in
       ignore (Lib.Coord.init config ~agent_name:None);
       let masc_dir = Lib.Coord.masc_dir config in
       save_jsonl
@@ -522,7 +522,7 @@ let test_dashboard_namespace_truth_warm_request_uses_stale_shell () =
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
       let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
-      let config = state.Lib.Mcp_server.room_config in
+      let config = state.Lib.Mcp_server.coord_config in
       warm_execution_cache ();
       let cached_shell =
         `Assoc
@@ -615,7 +615,7 @@ let test_last_good_shell_fallback_preserves_counts () =
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
       let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
-      ignore (Lib.Coord.init state.Lib.Mcp_server.room_config ~agent_name:None);
+      ignore (Lib.Coord.init state.Lib.Mcp_server.coord_config ~agent_name:None);
       warm_execution_cache ();
       (* Warm the shell cache so last_good_shell gets populated. *)
       Lib.Server_dashboard_http.warm_shell_cache state;

--- a/test/test_grpc_client.ml
+++ b/test/test_grpc_client.ml
@@ -139,14 +139,14 @@ let test_status_response_roundtrip () =
       assigned_to = "agent_llm_a"; priority = 2;
     }];
     message_count = 10;
-    room_path = "/tmp/test-room";
+    workspace_path = "/tmp/test-room";
   } in
   let bytes = T.StatusResponse.to_bytes resp in
   let decoded = T.StatusResponse.of_bytes bytes in
   Alcotest.(check int) "agents" 1 (List.length decoded.agents);
   Alcotest.(check int) "tasks" 1 (List.length decoded.tasks);
   Alcotest.(check int) "msg_count" 10 decoded.message_count;
-  Alcotest.(check string) "room_path" "/tmp/test-room" decoded.room_path;
+  Alcotest.(check string) "workspace_path" "/tmp/test-room" decoded.workspace_path;
   let task = List.hd decoded.tasks in
   Alcotest.(check string) "task_id" "T-1" task.T.id;
   Alcotest.(check int) "priority" 2 task.T.priority

--- a/test/test_grpc_coordination.ml
+++ b/test/test_grpc_coordination.ml
@@ -242,13 +242,13 @@ let test_status_response_roundtrip () =
             }
           ]
       ; message_count = 10
-      ; room_path = "/tmp/test"
+      ; workspace_path = "/tmp/test"
       }
   in
   let bytes = T.StatusResponse.to_bytes resp in
   let decoded = T.StatusResponse.of_bytes bytes in
   Alcotest.(check int) "message_count" 10 decoded.message_count;
-  Alcotest.(check string) "room_path" "/tmp/test" decoded.room_path;
+  Alcotest.(check string) "workspace_path" "/tmp/test" decoded.workspace_path;
   Alcotest.(check int) "agents count" 1 (List.length decoded.agents);
   Alcotest.(check int) "tasks count" 1 (List.length decoded.tasks);
   let task = List.hd decoded.tasks in
@@ -341,11 +341,11 @@ let test_grpc_server_registers_health_service () =
        @@ fun env ->
        Fs_compat.set_fs (Eio.Stdenv.fs env);
        with_temp_dir "masc-grpc-health" (fun dir ->
-         let room_config = Coord_utils.default_config dir in
+         let coord_config = Coord_utils.default_config dir in
          let server =
            Masc_mcp.Masc_grpc_server.create_server
              ~port:Masc_mcp.Masc_grpc_server.default_port
-             ~room_config
+             ~coord_config
              ~tool_dispatcher:(fun _tool _payload -> Ok "{}")
          in
          let services = Grpc_eio.Server.list_services server in
@@ -372,18 +372,18 @@ let test_get_status_projects_backlog_tasks () =
   @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   with_temp_dir "masc-grpc-status" (fun dir ->
-    let room_config = Coord_utils.default_config dir in
-    ignore (Masc_mcp.Coord.init room_config ~agent_name:(Some "alpha"));
+    let coord_config = Coord_utils.default_config dir in
+    ignore (Masc_mcp.Coord.init coord_config ~agent_name:(Some "alpha"));
     ignore
       (Masc_mcp.Coord.add_task
-         room_config
+         coord_config
          ~title:"Fix stale projection"
          ~priority:1
          ~description:"Use backlog SSOT for gRPC status");
-    ignore (Masc_mcp.Coord.claim_next room_config ~agent_name:"alpha");
+    ignore (Masc_mcp.Coord.claim_next coord_config ~agent_name:"alpha");
     let service =
       Masc_mcp.Masc_grpc_service.create_service
-        ~room_config
+        ~coord_config
         ~tool_dispatcher:(fun _tool _payload -> Ok "{}")
     in
     match Grpc_eio.Service.get_method service "GetStatus" with
@@ -485,10 +485,10 @@ let test_join_handler_invalid_bytes_raise_grpc_status () =
   @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   with_temp_dir "masc-grpc-invalid-join" (fun dir ->
-    let room_config = Coord_utils.default_config dir in
+    let coord_config = Coord_utils.default_config dir in
     let service =
       Masc_mcp.Masc_grpc_service.create_service
-        ~room_config
+        ~coord_config
         ~tool_dispatcher:(fun _tool _payload -> Ok "{}")
     in
     match Grpc_eio.Service.get_method service "Join" with
@@ -507,10 +507,10 @@ let test_join_handler_invalid_bytes_raise_grpc_status () =
 
 let test_subscribe_handler_invalid_bytes_raise_grpc_status () =
   with_temp_dir "masc-grpc-invalid-subscribe" (fun dir ->
-    let room_config = Coord_utils.default_config dir in
+    let coord_config = Coord_utils.default_config dir in
     let service =
       Masc_mcp.Masc_grpc_service.create_service
-        ~room_config
+        ~coord_config
         ~tool_dispatcher:(fun _tool _payload -> Ok "{}")
     in
     match Grpc_eio.Service.get_method service "Subscribe" with
@@ -532,10 +532,10 @@ let test_heartbeat_handler_invalid_bytes_warns_and_continues () =
   @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   with_temp_dir "masc-grpc-invalid-heartbeat" (fun dir ->
-    let room_config = Coord_utils.default_config dir in
+    let coord_config = Coord_utils.default_config dir in
     let service =
       Masc_mcp.Masc_grpc_service.create_service
-        ~room_config
+        ~coord_config
         ~tool_dispatcher:(fun _tool _payload -> Ok "{}")
     in
     match Grpc_eio.Service.get_method service "Heartbeat" with

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -170,7 +170,7 @@ let with_test_config f =
     ~finally:(fun () -> cleanup_dir base_path)
     (fun () ->
       let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
-      f state.room_config)
+      f state.coord_config)
 
 let with_eio_base_path f =
   Eio_main.run @@ fun env ->
@@ -1016,7 +1016,7 @@ let test_callback_production_tool_edit_file_requires_approval () =
     ~finally:(fun () -> cleanup_dir base_path)
     (fun () ->
   let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
-  let config = state.room_config in
+  let config = state.coord_config in
   Eio.Fiber.fork ~sw (fun () ->
     let cb =
       GP.to_oas_approval_callback
@@ -1282,7 +1282,7 @@ let test_callback_always_approve_respects_forbidden () =
     ~finally:(fun () -> cleanup_dir base_path)
     (fun () ->
       let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
-      let config = state.room_config in
+      let config = state.coord_config in
       let meta =
         meta_from_json
           (`Assoc [

--- a/test/test_keeper_deliberation.ml
+++ b/test/test_keeper_deliberation.ml
@@ -70,8 +70,8 @@ let test_triage_agent_change () =
   match D.triage obs with
   | D.Skip _ -> fail "expected Triggered for agent change"
   | D.Triggered triggers ->
-      check bool "contains AgentJoinedOrLeft" true
-        (List.mem D.AgentJoinedOrLeft triggers)
+      check bool "contains AgentSessionBoundedOrLeft" true
+        (List.mem D.AgentSessionBoundedOrLeft triggers)
 
 let test_triage_board_mention () =
   let obs = { base_obs with board_mention_count = 2 } in

--- a/test/test_keeper_sandbox_read_backend.ml
+++ b/test/test_keeper_sandbox_read_backend.ml
@@ -725,7 +725,7 @@ let test_docker_config_mount_and_env_args () =
        ~base_path:base
        ~container_root)
 
-let test_docker_room_state_mount_args_expose_safe_subset () =
+let test_docker_coord_state_mount_args_expose_safe_subset () =
   let base = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
   let masc_root = Filename.concat base ".masc" in
@@ -736,7 +736,7 @@ let test_docker_room_state_mount_args_expose_safe_subset () =
   write_file (Filename.concat (Filename.concat masc_root "auth") "keeper.token") "secret";
   let container_root = "/home/keeper/playground/minjae" in
   let specs =
-    Keeper_sandbox_runtime.docker_room_state_mount_specs
+    Keeper_sandbox_runtime.docker_coord_state_mount_specs
       ~base_path:base
       ~container_root
   in
@@ -1276,7 +1276,7 @@ let run_tests ~clock () =
           Alcotest.test_case "docker config mount and env args" `Quick
             test_docker_config_mount_and_env_args;
           Alcotest.test_case "docker room state mount exposes safe subset" `Quick
-            test_docker_room_state_mount_args_expose_safe_subset;
+            test_docker_coord_state_mount_args_expose_safe_subset;
           Alcotest.test_case "managed label args include ttl" `Quick
             test_sandbox_container_label_args_include_managed_ttl;
           Alcotest.test_case "sandbox label args include owner scope" `Quick

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -326,7 +326,7 @@ let test_create_state () =
   let base_path = temp_dir () in
   let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
   Alcotest.(check string) "base_path preserved"
-    base_path state.room_config.base_path;
+    base_path state.coord_config.base_path;
   cleanup_dir base_path
 
 let test_type_compatibility () =
@@ -335,7 +335,7 @@ let test_type_compatibility () =
   let state : Mcp_eio.server_state = Mcp_eio.create_state ~test_mode:true ~base_path () in
   let state2 : Mcp.server_state = state in  (* Type unification at compile time *)
   (* Verify the unified type preserves field access *)
-  Alcotest.(check string) "base_path via unified type" base_path state2.room_config.base_path;
+  Alcotest.(check string) "base_path via unified type" base_path state2.coord_config.base_path;
   cleanup_dir base_path
 
 let test_eio_context_delegation () =
@@ -948,12 +948,12 @@ let test_handle_request_tools_call_managed_profile_rejects_hidden_claim_alias ()
   (* masc_init and setup join are not under test here; initialise the room
      fixture directly so downstream managed-profile assertions are isolated. *)
   Alcotest.(check bool) "init returns failure (tool pruned)" false (Tool_result.is_success init_result);
-  let _ = Masc_mcp.Coord.init state.room_config ~agent_name:None in
+  let _ = Masc_mcp.Coord.init state.coord_config ~agent_name:None in
   let _joined =
-    Masc_mcp.Coord.join state.room_config ~agent_name:"agent_code" ~capabilities:[] ()
+    Masc_mcp.Coord.join state.coord_config ~agent_name:"agent_code" ~capabilities:[] ()
   in
   let _added =
-    Masc_mcp.Coord.add_task state.room_config ~title:"managed-claim"
+    Masc_mcp.Coord.add_task state.coord_config ~title:"managed-claim"
       ~priority:2 ~description:""
   in
   let request = Yojson.Safe.to_string (`Assoc [
@@ -993,12 +993,12 @@ let test_handle_request_tools_call_transition_claim_guidance () =
   (* masc_init and setup join are not under test here; initialise the room
      fixture directly so transition guidance assertions are isolated. *)
   Alcotest.(check bool) "init returns failure (tool pruned)" false (Tool_result.is_success init_result);
-  let _ = Masc_mcp.Coord.init state.room_config ~agent_name:None in
+  let _ = Masc_mcp.Coord.init state.coord_config ~agent_name:None in
   let _joined =
-    Masc_mcp.Coord.join state.room_config ~agent_name:"agent_code" ~capabilities:[] ()
+    Masc_mcp.Coord.join state.coord_config ~agent_name:"agent_code" ~capabilities:[] ()
   in
   ignore
-    (Masc_mcp.Coord.add_task state.room_config ~title:"transition-claim"
+    (Masc_mcp.Coord.add_task state.coord_config ~title:"transition-claim"
        ~priority:2 ~description:"");
   let request =
     Yojson.Safe.to_string
@@ -1025,7 +1025,7 @@ let test_handle_request_tools_call_transition_claim_guidance () =
   in
   let steps = workflow_next_step_names response in
   Alcotest.(check (option string)) "claim binds current_task" (Some "task-001")
-    (Masc_mcp.Planning_eio.get_current_task state.room_config);
+    (Masc_mcp.Planning_eio.get_current_task state.coord_config);
   Alcotest.(check bool) "claim guidance omits plan_set_task" false
     (List.mem "masc_plan_set_task" steps);
   cleanup_dir base_path
@@ -1048,12 +1048,12 @@ let test_handle_request_tools_call_transition_done_guidance () =
   (* masc_init and setup join are not under test here; initialise the room
      fixture directly so transition guidance assertions are isolated. *)
   Alcotest.(check bool) "init returns failure (tool pruned)" false (Tool_result.is_success init_result);
-  let _ = Masc_mcp.Coord.init state.room_config ~agent_name:None in
+  let _ = Masc_mcp.Coord.init state.coord_config ~agent_name:None in
   let _joined =
-    Masc_mcp.Coord.join state.room_config ~agent_name:"agent_code" ~capabilities:[] ()
+    Masc_mcp.Coord.join state.coord_config ~agent_name:"agent_code" ~capabilities:[] ()
   in
   ignore
-    (Masc_mcp.Coord.add_task state.room_config ~title:"transition-done"
+    (Masc_mcp.Coord.add_task state.coord_config ~title:"transition-done"
        ~priority:2 ~description:"");
   let claim_result =
     Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state
@@ -1115,12 +1115,12 @@ let test_handle_request_tools_call_transition_claim_requires_action () =
   (* masc_init and setup join are not under test here; initialise the room
      fixture directly so transition guidance assertions are isolated. *)
   Alcotest.(check bool) "init returns failure (tool pruned)" false (Tool_result.is_success init_result);
-  let _ = Masc_mcp.Coord.init state.room_config ~agent_name:None in
+  let _ = Masc_mcp.Coord.init state.coord_config ~agent_name:None in
   let _joined =
-    Masc_mcp.Coord.join state.room_config ~agent_name:"agent_code" ~capabilities:[] ()
+    Masc_mcp.Coord.join state.coord_config ~agent_name:"agent_code" ~capabilities:[] ()
   in
   ignore
-    (Masc_mcp.Coord.add_task state.room_config ~title:"deprecated-claim"
+    (Masc_mcp.Coord.add_task state.coord_config ~title:"deprecated-claim"
        ~priority:2 ~description:"");
   let request =
     Yojson.Safe.to_string
@@ -1460,16 +1460,16 @@ let test_execute_tool_explicit_generated_alias_claim_next_not_rewritten_by_token
 
   let base_path = temp_dir () in
   let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
-  ignore (Masc_mcp.Coord.init state.room_config ~agent_name:None);
+  ignore (Masc_mcp.Coord.init state.coord_config ~agent_name:None);
   ignore (Masc_mcp.Auth.enable_auth base_path ~require_token:true ~agent_name:"bootstrap-admin");
   let raw_token =
     match Masc_mcp.Auth.create_token base_path ~agent_name:"stable-admin" ~role:Masc_domain.Admin with
     | Ok (token, _cred) -> token
     | Error e -> Alcotest.fail (Masc_domain.masc_error_to_string e)
   in
-  ignore (Masc_mcp.Coord.join state.room_config ~agent_name:"stable-admin" ~capabilities:[] ());
+  ignore (Masc_mcp.Coord.join state.coord_config ~agent_name:"stable-admin" ~capabilities:[] ());
   ignore
-    (Masc_mcp.Coord.add_task state.room_config ~title:"explicit-alias-claim-next"
+    (Masc_mcp.Coord.add_task state.coord_config ~title:"explicit-alias-claim-next"
        ~priority:2 ~description:"");
   let result =
     Mcp_eio.execute_tool_eio ~sw ~clock ~auth_token:raw_token state
@@ -1478,7 +1478,7 @@ let test_execute_tool_explicit_generated_alias_claim_next_not_rewritten_by_token
   in
   check_auth_preflight_result ~tool_name:"masc_claim_next"
     (Tool_result.is_success result) ((Tool_result.message result));
-  check_task_still_todo state.room_config "task-001";
+  check_task_still_todo state.coord_config "task-001";
   cleanup_dir base_path
 
 let test_execute_tool_explicit_generated_alias_transition_not_rewritten_by_token () =
@@ -1491,16 +1491,16 @@ let test_execute_tool_explicit_generated_alias_transition_not_rewritten_by_token
 
   let base_path = temp_dir () in
   let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
-  ignore (Masc_mcp.Coord.init state.room_config ~agent_name:None);
+  ignore (Masc_mcp.Coord.init state.coord_config ~agent_name:None);
   ignore (Masc_mcp.Auth.enable_auth base_path ~require_token:true ~agent_name:"bootstrap-admin");
   let raw_token =
     match Masc_mcp.Auth.create_token base_path ~agent_name:"stable-admin" ~role:Masc_domain.Admin with
     | Ok (token, _cred) -> token
     | Error e -> Alcotest.fail (Masc_domain.masc_error_to_string e)
   in
-  ignore (Masc_mcp.Coord.join state.room_config ~agent_name:"stable-admin" ~capabilities:[] ());
+  ignore (Masc_mcp.Coord.join state.coord_config ~agent_name:"stable-admin" ~capabilities:[] ());
   ignore
-    (Masc_mcp.Coord.add_task state.room_config ~title:"explicit-alias-transition"
+    (Masc_mcp.Coord.add_task state.coord_config ~title:"explicit-alias-transition"
        ~priority:2 ~description:"");
   let result =
     Mcp_eio.execute_tool_eio ~sw ~clock ~auth_token:raw_token state
@@ -1515,7 +1515,7 @@ let test_execute_tool_explicit_generated_alias_transition_not_rewritten_by_token
   in
   check_auth_preflight_result ~tool_name:"masc_transition"
     (Tool_result.is_success result) ((Tool_result.message result));
-  check_task_still_todo state.room_config "task-001";
+  check_task_still_todo state.coord_config "task-001";
   cleanup_dir base_path
 
 let test_execute_tool_hyphenated_generated_alias_claim_next_reuses_base_token () =
@@ -1528,7 +1528,7 @@ let test_execute_tool_hyphenated_generated_alias_claim_next_reuses_base_token ()
 
   let base_path = temp_dir () in
   let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
-  ignore (Masc_mcp.Coord.init state.room_config ~agent_name:None);
+  ignore (Masc_mcp.Coord.init state.coord_config ~agent_name:None);
   ignore (Masc_mcp.Auth.enable_auth base_path ~require_token:true ~agent_name:"bootstrap-admin");
   let raw_token =
     match Masc_mcp.Auth.create_token base_path ~agent_name:"qa-king" ~role:Masc_domain.Admin with
@@ -1536,7 +1536,7 @@ let test_execute_tool_hyphenated_generated_alias_claim_next_reuses_base_token ()
     | Error e -> Alcotest.fail (Masc_domain.masc_error_to_string e)
   in
   ignore
-    (Masc_mcp.Coord.add_task state.room_config ~title:"hyphenated-generated-alias-claim-next"
+    (Masc_mcp.Coord.add_task state.coord_config ~title:"hyphenated-generated-alias-claim-next"
        ~priority:2 ~description:"");
   let result =
     Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:"sid-hyphenated-generated-alias"
@@ -1550,9 +1550,9 @@ let test_execute_tool_hyphenated_generated_alias_claim_next_reuses_base_token ()
     (contains_substring ((Tool_result.message result)) "task-001");
   Alcotest.(check (option string)) "current task set after claim_next"
     (Some "task-001")
-    (Masc_mcp.Planning_eio.get_current_task state.room_config);
+    (Masc_mcp.Planning_eio.get_current_task state.coord_config);
   Alcotest.(check bool) "explicit alias joined" true
-    (Masc_mcp.Coord.is_agent_joined state.room_config
+    (Masc_mcp.Coord.is_agent_session_bounded state.coord_config
        ~agent_name:"qa-king-warm-heron");
   cleanup_dir base_path
 
@@ -1566,11 +1566,11 @@ let test_execute_tool_claim_next_requires_auth_before_mutation () =
 
   let base_path = temp_dir () in
   let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
-  ignore (Masc_mcp.Coord.init state.room_config ~agent_name:None);
+  ignore (Masc_mcp.Coord.init state.coord_config ~agent_name:None);
   ignore (Masc_mcp.Auth.enable_auth base_path ~require_token:true ~agent_name:"bootstrap-admin");
-  ignore (Masc_mcp.Coord.join state.room_config ~agent_name:"uncredentialed-agent" ~capabilities:[] ());
+  ignore (Masc_mcp.Coord.join state.coord_config ~agent_name:"uncredentialed-agent" ~capabilities:[] ());
   ignore
-    (Masc_mcp.Coord.add_task state.room_config ~title:"claim-next-auth-preflight"
+    (Masc_mcp.Coord.add_task state.coord_config ~title:"claim-next-auth-preflight"
        ~priority:2 ~description:"");
   let result =
     Mcp_eio.execute_tool_eio ~sw ~clock state
@@ -1579,9 +1579,9 @@ let test_execute_tool_claim_next_requires_auth_before_mutation () =
   in
   check_auth_preflight_result ~tool_name:"masc_claim_next"
     (Tool_result.is_success result) ((Tool_result.message result));
-  check_task_still_todo state.room_config "task-001";
+  check_task_still_todo state.coord_config "task-001";
   Alcotest.(check (option string)) "no current task after rejected claim_next" None
-    (Masc_mcp.Planning_eio.get_current_task state.room_config);
+    (Masc_mcp.Planning_eio.get_current_task state.coord_config);
   cleanup_dir base_path
 
 let test_execute_tool_transition_requires_auth_before_mutation () =
@@ -1594,11 +1594,11 @@ let test_execute_tool_transition_requires_auth_before_mutation () =
 
   let base_path = temp_dir () in
   let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
-  ignore (Masc_mcp.Coord.init state.room_config ~agent_name:None);
+  ignore (Masc_mcp.Coord.init state.coord_config ~agent_name:None);
   ignore (Masc_mcp.Auth.enable_auth base_path ~require_token:true ~agent_name:"bootstrap-admin");
-  ignore (Masc_mcp.Coord.join state.room_config ~agent_name:"uncredentialed-agent" ~capabilities:[] ());
+  ignore (Masc_mcp.Coord.join state.coord_config ~agent_name:"uncredentialed-agent" ~capabilities:[] ());
   ignore
-    (Masc_mcp.Coord.add_task state.room_config ~title:"transition-auth-preflight"
+    (Masc_mcp.Coord.add_task state.coord_config ~title:"transition-auth-preflight"
        ~priority:2 ~description:"");
   let result =
     Mcp_eio.execute_tool_eio ~sw ~clock state
@@ -1613,9 +1613,9 @@ let test_execute_tool_transition_requires_auth_before_mutation () =
   in
   check_auth_preflight_result ~tool_name:"masc_transition"
     (Tool_result.is_success result) ((Tool_result.message result));
-  check_task_still_todo state.room_config "task-001";
+  check_task_still_todo state.coord_config "task-001";
   Alcotest.(check (option string)) "no current task after rejected transition" None
-    (Masc_mcp.Planning_eio.get_current_task state.room_config);
+    (Masc_mcp.Planning_eio.get_current_task state.coord_config);
   cleanup_dir base_path
 
 let test_execute_tool_add_task_with_admin_token_without_join () =
@@ -1628,7 +1628,7 @@ let test_execute_tool_add_task_with_admin_token_without_join () =
 
   let base_path = temp_dir () in
   let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
-  ignore (Masc_mcp.Coord.init state.room_config ~agent_name:None);
+  ignore (Masc_mcp.Coord.init state.coord_config ~agent_name:None);
   ignore (Masc_mcp.Auth.enable_auth base_path ~require_token:true ~agent_name:"bootstrap-admin");
   let raw_token =
     match Masc_mcp.Auth.create_token base_path ~agent_name:"stable-admin" ~role:Masc_domain.Admin with
@@ -1650,7 +1650,7 @@ let test_execute_tool_add_task_with_admin_token_without_join () =
   Alcotest.(check bool) "response mentions added task" true
     (contains_substring ((Tool_result.message result)) "Added task-001");
   let task =
-    match Masc_mcp.Coord.get_tasks_raw state.room_config with
+    match Masc_mcp.Coord.get_tasks_raw state.coord_config with
     | [ task ] -> task
     | tasks ->
         Alcotest.failf "expected exactly one task, found %d" (List.length tasks)
@@ -1765,7 +1765,7 @@ let test_handle_request_tools_call_board_post_structured_content () =
 
   let base_path = temp_dir () in
   let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
-  ignore (Masc_mcp.Coord.init state.room_config ~agent_name:None);
+  ignore (Masc_mcp.Coord.init state.coord_config ~agent_name:None);
   let request = Yojson.Safe.to_string (`Assoc [
     ("jsonrpc", `String "2.0");
     ("id", `Int 117);
@@ -1800,7 +1800,7 @@ let test_handle_request_tools_call_logs_structured_mcp_details () =
     ~finally:(fun () -> cleanup_dir base_path)
     (fun () ->
       let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
-      ignore (Masc_mcp.Coord.init state.room_config ~agent_name:None);
+      ignore (Masc_mcp.Coord.init state.coord_config ~agent_name:None);
       let request =
         Yojson.Safe.to_string
           (`Assoc
@@ -1875,7 +1875,7 @@ let test_handle_request_tools_call_records_keeper_usage_for_public_mcp () =
         (Keeper_registry.register ~base_path keeper_name
            (make_keeper_meta ~agent_name:keeper_agent_name keeper_name));
       let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
-      ignore (Masc_mcp.Coord.init state.room_config ~agent_name:None);
+      ignore (Masc_mcp.Coord.init state.coord_config ~agent_name:None);
       let request =
         Yojson.Safe.to_string
           (`Assoc
@@ -2522,7 +2522,7 @@ let test_handle_request_resources_read_matrix () =
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
   let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
-  ignore (Masc_mcp.Coord.init state.room_config ~agent_name:(Some "fixture-root"));
+  ignore (Masc_mcp.Coord.init state.coord_config ~agent_name:(Some "fixture-root"));
   let ensure_dir path =
     if not (Sys.file_exists path) then Unix.mkdir path 0o755
   in

--- a/test/test_mcp_server_eio_tool_dispatch.ml
+++ b/test/test_mcp_server_eio_tool_dispatch.ml
@@ -94,7 +94,7 @@ let test_execute_tool_tag_dispatch_respects_pre_hooks () =
           else Tool_dispatch.Pass);
       let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
       let raw_token = create_admin_token base_path in
-      let _room_path = Masc_mcp.Coord.masc_dir state.room_config in
+      let _workspace_path = Masc_mcp.Coord.masc_dir state.coord_config in
       let hook_result =
         Mcp_eio.execute_tool_eio ~sw ~clock ~auth_token:raw_token state
           ~name:"masc_tool_help"

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -299,7 +299,7 @@ let ensure_initialized fixture =
   (* masc_init pruned from registry. Initialise the room state
      directly so downstream masc_join and other tools can work. *)
   ignore
-    (Masc_mcp.Coord.init fixture.state.room_config
+    (Masc_mcp.Coord.init fixture.state.coord_config
        ~agent_name:(Some fixture.agent_name))
 
 let ensure_joined fixture =
@@ -379,7 +379,7 @@ let ensure_goal fixture =
   | None ->
       let goal =
         match
-          Goal_store.upsert_goal fixture.state.room_config
+          Goal_store.upsert_goal fixture.state.coord_config
             ~title:"Tool Matrix Goal" ()
         with
         | Ok (goal, _status) -> goal
@@ -456,7 +456,7 @@ let ensure_verification_request fixture =
   | Some req_id -> req_id
   | None ->
       let base_path =
-        Masc_mcp.Coord.masc_dir fixture.state.room_config
+        Masc_mcp.Coord.masc_dir fixture.state.coord_config
       in
       let req =
         match

--- a/test/test_meta_cognition_snapshot.ml
+++ b/test/test_meta_cognition_snapshot.ml
@@ -283,7 +283,7 @@ let test_snapshot_governance_cases_skip_bad_entries_with_metric () =
   let json = Meta_cognition.snapshot_json ~limit:5 ctx.config in
   let open Yojson.Safe.Util in
   Alcotest.(check int) "valid governance case still counted" 1
-    (json |> member "room_state" |> member "governance_case_count" |> to_int);
+    (json |> member "coord_state" |> member "governance_case_count" |> to_int);
   Alcotest.(check (float 0.1)) "broken file increments entry_load_error" 1.0
     (persistence_counter Safe_ops.persistence_read_drop_reason_entry_load_error
      -. before_entry);

--- a/test/test_multi_room.ml
+++ b/test/test_multi_room.ml
@@ -92,7 +92,7 @@ let test_join_uses_default_namespace () =
             |> Yojson.Safe.Util.member "type"
             |> Yojson.Safe.Util.to_string
           in
-          check string "event type is agent_join" "agent_join" event_type))
+          check string "event type is agent_session_bound" "agent_session_bound" event_type))
 
 let () =
   run "flat_namespace"

--- a/test/test_room.ml
+++ b/test/test_room.ml
@@ -69,7 +69,7 @@ let contains_error = contains_problem_result
 let backlog_recovery_path config =
   Coord.backlog_path config ^ ".last-good"
 
-let room_config tmp_dir =
+let coord_config tmp_dir =
   Unix.putenv "MASC_BASE_PATH" tmp_dir;
   Coord.default_config tmp_dir
 
@@ -80,7 +80,7 @@ let test_init_creates_folder () =
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
 
-  let config = room_config tmp_dir in
+  let config = coord_config tmp_dir in
 
   (* Initially not initialized *)
   Alcotest.(check bool) "not init" false (Coord.is_initialized config);
@@ -103,7 +103,7 @@ let test_join_creates_agent () =
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
 
-  let config = room_config tmp_dir in
+  let config = coord_config tmp_dir in
   let _ = Coord.init config ~agent_name:None in
 
   (* Join - now returns auto-generated nickname like "test_agent-swift-fox" *)
@@ -128,7 +128,7 @@ let test_add_and_claim_task () =
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
 
-  let config = room_config tmp_dir in
+  let config = coord_config tmp_dir in
   let _ = Coord.init config ~agent_name:(Some "agent_llm_a") in
 
   (* Add task *)
@@ -154,7 +154,7 @@ let test_add_task_uses_archive_max_id () =
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
 
-  let config = room_config tmp_dir in
+  let config = coord_config tmp_dir in
   let _ = Coord.init config ~agent_name:None in
 
   let archive_path = Filename.concat (Filename.concat tmp_dir Common.masc_dirname) "tasks-archive.json" in
@@ -181,7 +181,7 @@ let test_broadcast_message () =
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
 
-  let config = room_config tmp_dir in
+  let config = coord_config tmp_dir in
   let _ = Coord.init config ~agent_name:(Some "agent_llm_a") in
 
   (* Broadcast *)
@@ -209,7 +209,7 @@ let test_broadcast_replaces_terminal_task_cache_desync () =
   in
   Unix.mkdir tmp_dir 0o755;
 
-  let config = room_config tmp_dir in
+  let config = coord_config tmp_dir in
   let current_task_for agent_name =
     let agent_opt =
       Coord.get_agents_raw config
@@ -303,7 +303,7 @@ let test_event_log () =
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
 
-  let config = room_config tmp_dir in
+  let config = coord_config tmp_dir in
   let _ = Coord.init config ~agent_name:None in
 
   (* Broadcast should create event log *)
@@ -339,7 +339,7 @@ let with_test_env f =
   let tmp_dir = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
-  let config = room_config tmp_dir in
+  let config = coord_config tmp_dir in
   let _ = Coord.init config ~agent_name:(Some "agent_llm_a") in
   try
     f config;
@@ -636,7 +636,7 @@ let test_event_log_on_join () =
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
 
-  let config = room_config tmp_dir in
+  let config = coord_config tmp_dir in
   let _ = Coord.init config ~agent_name:None in
   let _ = Coord.join config ~agent_name:"test_agent" ~capabilities:["ocaml"] () in
 
@@ -657,7 +657,7 @@ let test_event_log_on_claim_done () =
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
 
-  let config = room_config tmp_dir in
+  let config = coord_config tmp_dir in
   let _ = Coord.init config ~agent_name:(Some "agent_llm_a") in
   let _ = Coord.add_task config ~title:"Test" ~priority:1 ~description:"" in
   let _ = Coord.claim_task config ~agent_name:"agent_llm_a" ~task_id:"task-001" in
@@ -690,7 +690,7 @@ let test_heartbeat_updates_lastseen () =
     Alcotest.(check bool) "heartbeat success" true (contains_heartbeat result)
   )
 
-let test_is_agent_joined_after_default_join () =
+let test_is_agent_session_bounded_after_default_join () =
   with_test_env (fun config ->
     let _ = Coord.join config ~agent_name:"provider_f" ~capabilities:[] () in
     let agents : Masc_domain.agent list = Coord.get_agents_raw config in
@@ -702,12 +702,12 @@ let test_is_agent_joined_after_default_join () =
       | None -> failwith "expected provider_f agent"
     in
     Alcotest.(check bool) "joined agent detected" true
-      (Coord.is_agent_joined config ~agent_name:gemini_name)
+      (Coord.is_agent_session_bounded config ~agent_name:gemini_name)
   )
 
 let test_room_bootstrap_preserves_backend_state () =
   with_memory_test_env (fun config ->
-    Coord.ensure_room_bootstrap config;
+    Coord.ensure_coord_bootstrap config;
     let _ =
       Coord.update_state config (fun state ->
         { state with message_seq = 41 })
@@ -722,7 +722,7 @@ let test_room_bootstrap_preserves_backend_state () =
     Coord_utils.write_json config (Coord.backlog_path config)
       (Masc_domain.backlog_to_yojson backlog);
 
-    Coord.ensure_room_bootstrap config;
+    Coord.ensure_coord_bootstrap config;
 
     let state = Coord.read_state config in
     let saved_backlog = Coord.read_backlog config in
@@ -732,7 +732,7 @@ let test_room_bootstrap_preserves_backend_state () =
 
 let test_room_bootstrap_ignores_invalid_room_id_in_flat_mode () =
   with_memory_test_env (fun config ->
-    Coord.ensure_room_bootstrap config;
+    Coord.ensure_coord_bootstrap config;
     Alcotest.(check bool) "root state initialized" true
       (Coord.is_initialized config)
   )
@@ -1154,7 +1154,7 @@ let test_reset_clears_all_state () =
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
 
-  let config = room_config tmp_dir in
+  let config = coord_config tmp_dir in
   let _ = Coord.init config ~agent_name:(Some "agent_llm_a") in
   let _ = Coord.add_task config ~title:"Task" ~priority:1 ~description:"" in
   let _ = Coord.broadcast config ~from_agent:"agent_llm_a" ~content:"Hello" in
@@ -1174,7 +1174,7 @@ let test_reinit_after_reset () =
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
 
-  let config = room_config tmp_dir in
+  let config = coord_config tmp_dir in
   let _ = Coord.init config ~agent_name:(Some "agent_llm_a") in
   let _ = Coord.reset config in
   (* Reinit should work *)
@@ -1564,7 +1564,7 @@ let test_rejoin_event_log () =
     (* Read event log and check for rejoin entry *)
     let events = read_event_log config in
     let has_rejoin = List.exists (fun line ->
-      str_contains line "\"rejoin\":true" && str_contains line "agent_join"
+      str_contains line "\"rejoin\":true" && str_contains line "agent_session_bound"
     ) events in
     Alcotest.(check bool) "rejoin event logged" true has_rejoin
   )
@@ -1816,7 +1816,7 @@ let () =
     (* === Heartbeat & Zombie Detection Tests === *)
     "heartbeat", [
       Alcotest.test_case "updates last_seen" `Quick test_heartbeat_updates_lastseen;
-      Alcotest.test_case "default join keeps joined status" `Quick test_is_agent_joined_after_default_join;
+      Alcotest.test_case "default join keeps joined status" `Quick test_is_agent_session_bounded_after_default_join;
       Alcotest.test_case "nonexistent agent" `Quick test_heartbeat_nonexistent_agent;
       Alcotest.test_case "get agents status" `Quick test_get_agents_status;
       Alcotest.test_case "backend bootstrap preserves room state" `Quick test_room_bootstrap_preserves_backend_state;

--- a/test/test_room_coverage.ml
+++ b/test/test_room_coverage.ml
@@ -1622,7 +1622,7 @@ let test_get_messages_raw () =
     Alcotest.(check bool) "has messages" true (List.length msgs >= 2))
 ;;
 
-let test_is_agent_joined () =
+let test_is_agent_session_bounded () =
   with_test_env (fun config ->
     (* agent_llm_a is joined from init *)
     (* Note: agent names are auto-generated with nicknames, so we check by type prefix *)
@@ -1997,7 +1997,7 @@ let () =
         ; Alcotest.test_case "get tasks raw empty" `Quick test_get_tasks_raw_empty
         ; Alcotest.test_case "get agents raw" `Quick test_get_agents_raw
         ; Alcotest.test_case "get messages raw" `Quick test_get_messages_raw
-        ; Alcotest.test_case "is agent joined" `Quick test_is_agent_joined
+        ; Alcotest.test_case "is agent joined" `Quick test_is_agent_session_bounded
         ] )
     ; (* === Result Variants === *)
       ( "result_variants"

--- a/test/test_room_eio.ml
+++ b/test/test_room_eio.ml
@@ -148,7 +148,7 @@ let test_get_message () =
 
 (** {1 State Tests} *)
 
-let test_room_state () =
+let test_coord_state () =
   with_eio_env @@ fun config ->
   (* Register some agents *)
   let _ = Coord_eio.register_agent config ~name:"agent_llm_a" () in
@@ -197,7 +197,7 @@ let () =
       Alcotest.test_case "get message" `Quick test_get_message;
     ];
     "state", [
-      Alcotest.test_case "room state" `Quick test_room_state;
+      Alcotest.test_case "room state" `Quick test_coord_state;
       Alcotest.test_case "room status" `Quick test_room_status;
     ];
     "health", [

--- a/test/test_room_state_recovery.ml
+++ b/test/test_room_state_recovery.ml
@@ -4,7 +4,7 @@ open Alcotest
 open Masc_mcp
 
 let temp_dir () =
-  let dir = Filename.temp_file "test_room_state_recovery_" "" in
+  let dir = Filename.temp_file "test_coord_state_recovery_" "" in
   Unix.unlink dir;
   Unix.mkdir dir 0o755;
   dir
@@ -315,7 +315,7 @@ let test_heartbeat_repairs_legacy_agent_last_seen () =
 let () =
   run "Coord_state_recovery"
     [
-      ( "room_state",
+      ( "coord_state",
         [
           test_case "repairs empty object" `Quick
             test_read_state_repairs_empty_object;

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -777,7 +777,7 @@ let test_constructor_is_pure () =
 let test_restore_persisted_sessions_uses_flat_agents_dir () =
   with_temp_dir "startup-scope" (fun dir ->
       let state = Mcp_server.create_state ~base_path:dir in
-      let agents = Coord.agents_dir state.Mcp_server.room_config in
+      let agents = Coord.agents_dir state.Mcp_server.coord_config in
       Fs_compat.mkdir_p agents;
       write_file (Filename.concat agents "test-agent.json") "{}";
       Server_runtime_bootstrap.restore_persisted_sessions state;
@@ -980,7 +980,7 @@ let test_health_json_surfaces_durable_paused_keepers () =
         (fun () ->
           let state = Mcp_server.create_state ~base_path:dir in
           Server_auth.server_state := Some state;
-          let config = state.Mcp_server.room_config in
+          let config = state.Mcp_server.coord_config in
           write_keeper_meta_exn config
             (make_keeper_meta ~name:"durable-paused" ~trace_id:"trace-paused"
                ~paused:true ());
@@ -1146,7 +1146,7 @@ let test_health_json_keeps_timeout_pause_without_policy_manual () =
       (fun () ->
         let state = Mcp_server.create_state ~base_path:dir in
         Server_auth.server_state := Some state;
-        let config = state.Mcp_server.room_config in
+        let config = state.Mcp_server.coord_config in
         let timeout_paused =
           { (make_keeper_meta
                ~name:"timeout-without-policy"
@@ -1203,7 +1203,7 @@ let test_health_json_degrades_when_reaction_capacity_below_target () =
       (fun () ->
         let state = Mcp_server.create_state ~base_path:dir in
         Server_auth.server_state := Some state;
-        let config = state.Mcp_server.room_config in
+        let config = state.Mcp_server.coord_config in
         let paused =
           make_keeper_meta ~name:"capacity-paused" ~trace_id:"trace-capacity-paused"
             ~paused:true ()
@@ -1265,7 +1265,7 @@ let test_health_json_distinguishes_failing_executable_keepers () =
       (fun () ->
         let state = Mcp_server.create_state ~base_path:dir in
         Server_auth.server_state := Some state;
-        let config = state.Mcp_server.room_config in
+        let config = state.Mcp_server.coord_config in
         let paused =
           make_keeper_meta ~name:"capacity-paused" ~trace_id:"trace-capacity-paused"
             ~paused:true ()
@@ -1310,7 +1310,7 @@ let test_health_json_reaction_ledger_cursor_sweep_clears_pending () =
         Config_dir_resolver.reset ();
         let state = Mcp_server.create_state ~base_path:dir in
         Server_auth.server_state := Some state;
-        let config = state.Mcp_server.room_config in
+        let config = state.Mcp_server.coord_config in
         write_keeper_meta_exn config
           (make_keeper_meta ~name:"cursor-swept" ~trace_id:"trace-cursor" ());
         let stimulus post_id updated_at : Keeper_event_queue.stimulus =

--- a/test/test_telemetry_eio_coverage.ml
+++ b/test/test_telemetry_eio_coverage.ml
@@ -73,7 +73,7 @@ let write_dated_file dir month day lines =
    event Type Tests
    ============================================================ *)
 
-let test_event_agent_joined () =
+let test_event_agent_session_bounded () =
   let e = Telemetry_eio.Agent_joined {
     agent_id = "agent_llm_a-001";
     capabilities = ["code"; "review"];
@@ -392,7 +392,7 @@ let test_metrics_json_roundtrip () =
    event_to_json Tests
    ============================================================ *)
 
-let test_event_to_json_agent_joined () =
+let test_event_to_json_agent_session_bounded () =
   let e = Telemetry_eio.Agent_joined {
     agent_id = "test";
     capabilities = ["a"; "b"];
@@ -589,7 +589,7 @@ let test_track_applies_default_retention_days () =
           Filename.concat (Filename.concat telemetry_dir "2020-01") "01.jsonl"
         in
         write_dated_file telemetry_dir "2020-01" "01" [ {|{"old":true}|} ];
-        Telemetry_eio.track_agent_joined config ~agent_id:"retention-test" ();
+        Telemetry_eio.track_agent_session_bounded config ~agent_id:"retention-test" ();
         check bool "old telemetry file pruned by default retention" false
           (Sys.file_exists old_file))))
 
@@ -611,7 +611,7 @@ let test_track_applies_telemetry_max_bytes () =
           [ Printf.sprintf {|{"payload":"%s"}|} (String.make 80 'a') ];
         write_dated_file telemetry_dir "2020-01" "02"
           [ Printf.sprintf {|{"payload":"%s"}|} (String.make 80 'b') ];
-        Telemetry_eio.track_agent_joined config ~agent_id:"max-bytes-test" ();
+        Telemetry_eio.track_agent_session_bounded config ~agent_id:"max-bytes-test" ();
         check bool "old telemetry file 1 pruned by max bytes" false
           (Sys.file_exists old_file_1);
         check bool "old telemetry file 2 pruned by max bytes" false
@@ -626,7 +626,7 @@ let test_track_applies_telemetry_max_bytes () =
 let () =
   run "Telemetry Eio Coverage" [
     "event", [
-      test_case "agent_joined" `Quick test_event_agent_joined;
+      test_case "agent_session_bounded" `Quick test_event_agent_session_bounded;
       test_case "agent_left" `Quick test_event_agent_left;
       test_case "task_started" `Quick test_event_task_started;
       test_case "task_completed" `Quick test_event_task_completed;
@@ -655,7 +655,7 @@ let () =
         test_parse_event_records_drop_increments_counter;
     ];
     "event_to_json", [
-      test_case "agent_joined" `Quick test_event_to_json_agent_joined;
+      test_case "agent_session_bounded" `Quick test_event_to_json_agent_session_bounded;
       test_case "task_completed" `Quick test_event_to_json_task_completed;
     ];
     "count_active_agents", [

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -1124,7 +1124,7 @@ let test_board_curation_submit_roundtrips_to_read () =
 
 let inline_board_dispatch ~sw ~clock name args =
   let state = Mcp_server.create_state ~base_path:_test_base_path in
-  Tool_inline_dispatch_extra.dispatch ~config:state.Mcp_server.room_config
+  Tool_inline_dispatch_extra.dispatch ~config:state.Mcp_server.coord_config
     ~agent_name:"inline-curator" ~arguments:args ~state ~sw ~clock ~name
     ~start_time:(Unix.gettimeofday ())
 

--- a/test/test_tool_misc_coverage.ml
+++ b/test/test_tool_misc_coverage.ml
@@ -77,7 +77,7 @@ let () = test "dispatch_unknown_tool" (fun () ->
 let () = test "dispatch_dashboard" (fun () ->
   let ctx = make_test_ctx () in
   ignore (Coord.add_task ctx.config ~title:"default task" ~priority:2 ~description:"");
-  Coord.ensure_room_bootstrap ctx.config;
+  Coord.ensure_coord_bootstrap ctx.config;
   let second_room = ctx.config in
   ignore (Coord.add_task second_room ~title:"second task" ~priority:1 ~description:"");
   let args = `Assoc [] in
@@ -108,7 +108,7 @@ let () = test "dispatch_dashboard_compact" (fun () ->
 
 let () = test "dispatch_dashboard_current_scope" (fun () ->
   let ctx = make_test_ctx () in
-  Coord.ensure_room_bootstrap ctx.config;
+  Coord.ensure_coord_bootstrap ctx.config;
   let focused = ctx.config in
   ignore (Coord.add_task focused ~title:"focus task" ~priority:2 ~description:"");
   let args = `Assoc [("scope", `String "current")] in

--- a/test/test_types_coverage.ml
+++ b/test/test_types_coverage.ml
@@ -914,7 +914,7 @@ let test_auth_config_to_yojson () =
 let test_auth_config_of_yojson_ok () =
   let json = `Assoc [
     ("enabled", `Bool true);
-    ("room_secret_hash", `Null);
+    ("coord_secret_hash", `Null);
     ("require_token", `Bool false);
     ("token_expiry_hours", `Int 48);
   ] in

--- a/test/test_types_utils_coverage.ml
+++ b/test/test_types_utils_coverage.ml
@@ -581,7 +581,7 @@ let test_default_auth_config () =
 let test_auth_config_roundtrip () =
   let cfg = Masc_domain.{
     enabled = true;
-    room_secret_hash = Some "sha256:secret";
+    coord_secret_hash = Some "sha256:secret";
     require_token = true;
     token_expiry_hours = 48;
   } in
@@ -683,8 +683,8 @@ let test_contains_substring_empty () =
 (* ============================================================ *)
 
 let test_room_eio_event_type_to_string () =
-  check string "AgentJoin" "agent_join" (Coord_eio.event_type_to_string Coord_eio.AgentJoin);
-  check string "AgentLeave" "agent_leave" (Coord_eio.event_type_to_string Coord_eio.AgentLeave);
+  check string "AgentSessionBound" "agent_session_bound" (Coord_eio.event_type_to_string Coord_eio.AgentSessionBound);
+  check string "AgentSessionEnded" "agent_session_ended" (Coord_eio.event_type_to_string Coord_eio.AgentSessionEnded);
   check string "Broadcast" "broadcast" (Coord_eio.event_type_to_string Coord_eio.Broadcast);
   check string "LockAcquire" "lock_acquire" (Coord_eio.event_type_to_string Coord_eio.LockAcquire);
   check string "LockRelease" "lock_release" (Coord_eio.event_type_to_string Coord_eio.LockRelease)
@@ -701,16 +701,16 @@ let test_room_eio_now_iso () =
   check bool "has ms" true (String.contains ts '.')
 
 (* ============================================================ *)
-(* Coord_eio.room_state JSON Tests                                *)
+(* Coord_eio.coord_state JSON Tests                                *)
 (* ============================================================ *)
 
-let test_room_eio_default_room_state () =
-  let state = Coord_eio.default_room_state () in
+let test_room_eio_default_coord_state () =
+  let state = Coord_eio.default_coord_state () in
   check string "protocol_version" "1.0.0" state.protocol_version;
   check bool "not paused" false state.paused;
   check (list string) "no active agents" [] state.active_agents
 
-let test_room_eio_room_state_roundtrip () =
+let test_room_eio_coord_state_roundtrip () =
   let state = Coord_eio.{
     protocol_version = "1.0.0";
     started_at = 1704067200.0;
@@ -724,8 +724,8 @@ let test_room_eio_room_state_roundtrip () =
     paused_at = Some 1704070000.0;
     pause_reason = Some "Maintenance";
   } in
-  let json = Coord_eio.room_state_to_json state in
-  let result = Coord_eio.room_state_of_json json in
+  let json = Coord_eio.coord_state_to_json state in
+  let result = Coord_eio.coord_state_of_json json in
   check bool "roundtrip ok" true (is_ok result)
 
 (* ============================================================ *)
@@ -946,8 +946,8 @@ let room_eio_time_tests = [
 ]
 
 let room_eio_state_tests = [
-  "default_room_state", `Quick, test_room_eio_default_room_state;
-  "room_state roundtrip", `Quick, test_room_eio_room_state_roundtrip;
+  "default_coord_state", `Quick, test_room_eio_default_coord_state;
+  "coord_state roundtrip", `Quick, test_room_eio_coord_state_roundtrip;
 ]
 
 let room_eio_agent_tests = [

--- a/test/test_worker_container_coverage.ml
+++ b/test/test_worker_container_coverage.ml
@@ -119,7 +119,7 @@ let test_local_shell_failure_class_reaches_tool_called () =
       let tools =
         match
           Worker_container.build_local_shell_tools
-            ~room_config:(Some config)
+            ~coord_config:(Some config)
             ~worker_name:"local-worker-test"
             ~workdir:base_dir
         with

--- a/test/test_worker_runtime.ml
+++ b/test/test_worker_runtime.ml
@@ -188,7 +188,7 @@ let test_run_worker_oas_rejects_invalid_explicit_model_label () =
       match
         Lib.Worker_runtime.run_worker_oas ~sw
           ~net:(Eio.Stdenv.net env)
-          ~room_config:None spec ()
+          ~coord_config:None spec ()
       with
       | Ok _ ->
           fail "expected invalid explicit model label to fail before execution"


### PR DESCRIPTION
## Summary
- rename core server state from room_config to coord_config
- rename domain/coord state APIs from room_state to coord_state
- rename Room_protocol and room route module internals to Coord_protocol/coord route naming
- rename gRPC status path/auth secret surfaces away from room_* naming

## Validation
- not run; build breakage accepted for this hard-cut cleanup slice