### PR TITLE
Rename internal room id contracts

### DIFF
--- a/lib/activity_graph/activity_graph.ml
+++ b/lib/activity_graph/activity_graph.ml
@@ -57,7 +57,7 @@ let sanitize_event (value : event) =
   {
     value with
     ts_iso = Safe_ops.sanitize_text_utf8 value.ts_iso;
-    room_id = Safe_ops.sanitize_text_utf8 value.room_id;
+    coord_id = Safe_ops.sanitize_text_utf8 value.coord_id;
     kind = Safe_ops.sanitize_text_utf8 value.kind;
     actor = Option.map sanitize_entity_ref value.actor;
     subject = Option.map sanitize_entity_ref value.subject;
@@ -94,7 +94,7 @@ let sanitize_event_traced (value : event) : event =
      List.map always allocates a new list, so tags are compared element-wise. *)
   let changed =
     not (sanitized.ts_iso == value.ts_iso)
-    || not (sanitized.room_id == value.room_id)
+    || not (sanitized.coord_id == value.coord_id)
     || not (sanitized.kind == value.kind)
     || entity_ref_changed sanitized.actor value.actor
     || entity_ref_changed sanitized.subject value.subject
@@ -347,7 +347,7 @@ let emit config ?actor ?subject ?(tags = []) ~kind ~payload () =
             seq;
             ts_ms = now_ts_ms ();
             ts_iso = Masc_domain.now_iso ();
-            room_id = "default";  (* retained for JSONL backward compat *)
+            coord_id = "default";  (* retained for JSONL backward compat *)
             kind;
             actor;
             subject;
@@ -423,7 +423,7 @@ let json_response config ?(kinds = []) ~after_seq ~limit () =
       ("after_seq", `Int after_seq);
       ("next_after_seq", `Int next_after_seq);
       ("limit", `Int limit);
-      ("room_id", `String "default");  (* backward compat *)
+      ("coord_id", `String "default");  (* backward compat *)
       ("kinds", `List (List.map (fun value -> `String value) kinds));
       ("latest_seq", `Int latest_store_seq);
       ("latest_matching_seq", `Int latest_matching_seq);
@@ -598,7 +598,7 @@ let graph_json config ?(kinds = []) ?(limit = 500)
           ~events_shown:(List.length events)
           ~events_store_total
           ~extra:[
-            ("room_id", `String "default");
+            ("coord_id", `String "default");
             ("kinds", `List (List.map (fun value -> `String value) kinds));
           ] () );
       ( "stats",

--- a/lib/activity_graph/activity_graph.mli
+++ b/lib/activity_graph/activity_graph.mli
@@ -106,7 +106,7 @@ val json_response :
 (** Polling-friendly JSON envelope: [generated_at_iso],
     [dashboard_surface], [source], [retention], [query],
     [events], [count], [total_matching_events], [after_seq],
-    [next_after_seq], [limit], [room_id] (kept as ["default"]
+    [next_after_seq], [limit], [coord_id] (kept as ["default"]
     for backward-compat), [kinds], [latest_seq], and
     [latest_matching_seq].  [next_after_seq] is the seq of the
     last returned event so the caller can resume cleanly on the

--- a/lib/activity_graph/activity_graph_reducer.ml
+++ b/lib/activity_graph/activity_graph_reducer.ml
@@ -124,8 +124,8 @@ let ensure_edge (edges : (string, edge_acc) Hashtbl.t) ~source ~target ~kind
 
 let reduce_event ~nodes ~edges (value : event) =
   let sw = semantic_multiplier value.kind in
-  let room_node_id = "room:" ^ value.room_id in
-  ensure_node nodes ~id:room_node_id ~kind:"room" ~label:value.room_id
+  let coord_node_id = "coord:" ^ value.coord_id in
+  ensure_node nodes ~id:coord_node_id ~kind:"coord" ~label:value.coord_id
     ~status:Coord ~ts_iso:value.ts_iso ~meta:default_meta ~sw_delta:sw;
   let actor_id =
     match value.actor with
@@ -134,7 +134,7 @@ let reduce_event ~nodes ~edges (value : event) =
           ensure_entity_node nodes actor ~fallback_status:Active
             ~ts_iso:value.ts_iso ~meta:value.payload ~sw_delta:sw
         in
-        ensure_edge edges ~source:id ~target:room_node_id ~kind:"belongs_to"
+        ensure_edge edges ~source:id ~target:coord_node_id ~kind:"belongs_to"
           ~active:true ~ts_iso:value.ts_iso ~meta:default_meta;
         Some id
     | None -> None
@@ -146,7 +146,7 @@ let reduce_event ~nodes ~edges (value : event) =
           ensure_entity_node nodes subject ~fallback_status:Observed
             ~ts_iso:value.ts_iso ~meta:value.payload ~sw_delta:sw
         in
-        ensure_edge edges ~source:id ~target:room_node_id ~kind:"belongs_to"
+        ensure_edge edges ~source:id ~target:coord_node_id ~kind:"belongs_to"
           ~active:true ~ts_iso:value.ts_iso ~meta:default_meta;
         Some id
     | None -> None
@@ -226,7 +226,7 @@ let reduce_event ~nodes ~edges (value : event) =
   | "message.broadcast" ->
       (match actor_id with
       | Some source ->
-          ensure_edge edges ~source ~target:room_node_id ~kind:"broadcasts"
+          ensure_edge edges ~source ~target:coord_node_id ~kind:"broadcasts"
             ~active:false ~ts_iso:value.ts_iso ~meta:value.payload
       | None -> ())
   | "message.mentioned" ->

--- a/lib/activity_graph/activity_graph_reducer.mli
+++ b/lib/activity_graph/activity_graph_reducer.mli
@@ -54,7 +54,7 @@ val reduce_event :
 (** [reduce_event ~nodes ~edges value] folds [value] into the
     accumulators in place.  Effects (in order):
 
-    + Ensure a [room:<room_id>] node exists with status [Coord]
+    + Ensure a [coord:<coord_id>] node exists with status [Coord]
       and the event's [ts_iso].
     + If [value.actor = Some actor], ensure the entity node with
       fallback status [Active] and add a [belongs_to] edge to the

--- a/lib/activity_graph/activity_graph_types.ml
+++ b/lib/activity_graph/activity_graph_types.ml
@@ -31,7 +31,7 @@ let node_status_to_string = function
   | Approved -> "approved" | Denied -> "denied"
   | Running -> "running" | Paused -> "paused"
   | Stopped -> "stopped" | Finalized -> "finalized"
-  | Observed -> "observed" | Coord -> "room" | Unset -> ""
+  | Observed -> "observed" | Coord -> "coord" | Unset -> ""
 
 (** Span status: separate from node_status (different lifecycle).
     @since 7182 *)
@@ -69,7 +69,7 @@ type event = {
   seq : int;
   ts_ms : int;
   ts_iso : string;
-  room_id : string;
+  coord_id : string;
   kind : string;
   actor : entity_ref option;
   subject : entity_ref option;
@@ -284,7 +284,7 @@ let event_to_yojson (value : event) =
       ("seq", `Int value.seq);
       ("ts_ms", `Int value.ts_ms);
       ("ts_iso", `String value.ts_iso);
-      ("room_id", `String value.room_id);
+      ("coord_id", `String value.coord_id);
       ("kind", `String value.kind);
       ( "actor",
         match value.actor with
@@ -306,14 +306,14 @@ let event_of_yojson (json : Yojson.Safe.t) : event option =
   match Safe_ops.json_int_opt "seq" json,
         Safe_ops.json_int_opt "ts_ms" json,
         Safe_ops.json_string_opt "ts_iso" json,
-        Safe_ops.json_string_opt "room_id" json,
+        Safe_ops.json_string_opt "coord_id" json,
         Safe_ops.json_string_opt "kind" json with
-  | Some seq, Some ts_ms, Some ts_iso, Some room_id, Some kind ->
+  | Some seq, Some ts_ms, Some ts_iso, Some coord_id, Some kind ->
     let actor = Option.bind (Safe_ops.json_member_opt "actor" json) entity_of_yojson in
     let subject = Option.bind (Safe_ops.json_member_opt "subject" json) entity_of_yojson in
     let payload = Safe_ops.json_member_opt "payload" json |> Option.value ~default:(`Assoc []) in
     let tags = Safe_ops.json_string_list "tags" json in
-    Some { seq; ts_ms; ts_iso; room_id; kind; actor; subject; payload; tags }
+    Some { seq; ts_ms; ts_iso; coord_id; kind; actor; subject; payload; tags }
   | _ -> None
 
 let graph_node_to_yojson (value : graph_node) =

--- a/lib/activity_graph/activity_graph_types.mli
+++ b/lib/activity_graph/activity_graph_types.mli
@@ -52,7 +52,7 @@ type event = {
   seq : int;
   ts_ms : int;
   ts_iso : string;
-  room_id : string;
+  coord_id : string;
   kind : string;
   actor : entity_ref option;
   subject : entity_ref option;

--- a/lib/audit_log.ml
+++ b/lib/audit_log.ml
@@ -51,7 +51,7 @@ type audit_entry = {
   timestamp: float;
   agent_id: string;
   action: action;
-  room_id: string option;
+  coord_id: string option;
   details: Yojson.Safe.t;
   outcome: outcome;
   cost_estimate: float option;
@@ -138,7 +138,7 @@ let entry_to_json (e : audit_entry) : Yojson.Safe.t =
     ("timestamp", `Float e.timestamp);
     ("agent_id", `String e.agent_id);
     ("action", `String (action_to_string e.action));
-    ("room_id", Json_util.string_opt_to_json e.room_id);
+    ("coord_id", Json_util.string_opt_to_json e.coord_id);
     ("details", e.details);
     ("outcome", outcome_to_json e.outcome);
   ] in
@@ -163,7 +163,7 @@ let entry_of_json_r (json : Yojson.Safe.t) : (audit_entry, string) result =
     let timestamp = Json_util.get_float json "timestamp" in
     let agent_id = Json_util.get_string json "agent_id" in
     let action_raw = Json_util.get_string json "action" in
-    let room_id = Json_util.get_string json "room_id" in
+    let coord_id = Json_util.get_string json "coord_id" in
     let details =
       match Safe_ops.json_member_opt "details" json with
       | Some v -> v
@@ -185,7 +185,7 @@ let entry_of_json_r (json : Yojson.Safe.t) : (audit_entry, string) result =
     match timestamp, agent_id, action_raw with
     | Some timestamp, Some agent_id, Some action_raw ->
       let action = string_to_action action_raw in
-      Ok { timestamp; agent_id; action; room_id; details; outcome; cost_estimate; token_count; trace_id }
+      Ok { timestamp; agent_id; action; coord_id; details; outcome; cost_estimate; token_count; trace_id }
     | _ -> Error "missing required fields (timestamp, agent_id, action)"
   with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     (* Redact details field to prevent sensitive content leaking into logs *)
@@ -432,7 +432,7 @@ let log_action
     (config : config)
     ~agent_id
     ~action
-    ?(room_id : string option)
+    ?(coord_id : string option)
     ?(details : Yojson.Safe.t = `Null)
     ?(cost_estimate : float option)
     ?(token_count : int option)
@@ -443,7 +443,7 @@ let log_action
     timestamp = Time_compat.now ();
     agent_id;
     action;
-    room_id;
+    coord_id;
     details;
     outcome;
     cost_estimate;

--- a/lib/audit_log.mli
+++ b/lib/audit_log.mli
@@ -63,7 +63,7 @@ type audit_entry = {
   timestamp : float;
   agent_id : string;
   action : action;
-  room_id : string option;
+  coord_id : string option;
   details : Yojson.Safe.t;
   outcome : outcome;
   cost_estimate : float option;
@@ -129,7 +129,7 @@ val log_action :
   config ->
   agent_id:string ->
   action:action ->
-  ?room_id:string ->
+  ?coord_id:string ->
   ?details:Yojson.Safe.t ->
   ?cost_estimate:float ->
   ?token_count:int ->

--- a/lib/board_votes.mli
+++ b/lib/board_votes.mli
@@ -271,7 +271,7 @@ type voter_kind =
 
 val classify_voter_target : string -> voter_kind
 (** [classify_voter_target target] derives the typed {!voter_kind}
-    from a vote-log target key ([room:agent] tuple or bare agent
+    from a vote-log target key ([coord:agent] tuple or bare agent
     name).  Extracts the voter segment after the rightmost [':']
     then dispatches on the [hot-voter-] / [synthetic-voter-] /
     [test-voter-] prefixes (matching the legacy

--- a/lib/briefing_compactors/briefing_compactors.ml
+++ b/lib/briefing_compactors/briefing_compactors.ml
@@ -35,7 +35,7 @@ let relevant_sessions_for_briefing ~current_namespace ~now_ts sessions =
           match String_util.option_trim (Some (string_field "project" session_json)) with
           | Some value -> value
           | None ->
-              String_util.option_trim (Some (string_field "room_id" session_json))
+              String_util.option_trim (Some (string_field "coord_id" session_json))
               |> Option.value ~default:""
         in
         String.equal project session_project
@@ -122,7 +122,7 @@ let compact_session_json session_json =
       ("goal", string_json ~default:"unassigned" ~max_len:160 (member_assoc "goal" session));
       ( "project",
         match member_assoc "project" session with
-        | `Null -> string_json ~default:"default" (member_assoc "room_id" session)
+        | `Null -> string_json ~default:"default" (member_assoc "coord_id" session)
         | value -> string_json ~default:"default" value );
       ("status", string_json ~default:"unknown" (member_assoc "status" session));
       ("agent_names", string_list_json (member_assoc "agent_names" session));

--- a/lib/coord/coord_lifecycle.ml
+++ b/lib/coord/coord_lifecycle.ml
@@ -10,7 +10,7 @@ open Coord_identity
 open Coord_broadcast
 open Coord_identity
 
-(* Single-namespace: room_id/namespace_id concepts retired (#unify-namespace).
+(* Single-namespace: coord_id/namespace_id concepts retired (#unify-namespace).
    All coordination scoped by cluster basepath only. *)
 
 (** Bounded snapshot of a corrupt agent JSON file for error diagnostics.

--- a/lib/coord/coord_task_classify.ml
+++ b/lib/coord/coord_task_classify.ml
@@ -14,7 +14,7 @@ include Coord_broadcast
 open Coord_backlog
 open Coord_identity
 
-(* activity_room_id removed — namespace retired (#unify-namespace). *)
+(* activity_coord_id removed — namespace retired (#unify-namespace). *)
 
 (* #9795: FSM drift observability. [masc_coord] sits below the
    [masc_mcp] library in the dep graph, so it cannot call

--- a/lib/dashboard/dashboard_execution_sessions.ml
+++ b/lib/dashboard/dashboard_execution_sessions.ml
@@ -154,7 +154,7 @@ let build_session_seed session_json _cards =
         namespace =
           (match String_util.trim_to_option (string_field "project" meta) with
           | Some _ as value -> value
-          | None -> String_util.trim_to_option (string_field "room_id" meta));
+          | None -> String_util.trim_to_option (string_field "coord_id" meta));
         status = session_status_string session_json;
         health =
           (match session_card with

--- a/lib/keeper/keeper_meta_merge.mli
+++ b/lib/keeper/keeper_meta_merge.mli
@@ -1,6 +1,6 @@
 (** Field-ownership merges for keeper_meta on CAS retry.
 
-    Room presence/cursor fields were removed; CAS retries now only need
+    Coord presence/cursor fields were removed; CAS retries now only need
     to carry the disk meta_version forward. *)
 
 type t = latest:Keeper_meta_contract.keeper_meta -> caller:Keeper_meta_contract.keeper_meta -> Keeper_meta_contract.keeper_meta
@@ -11,4 +11,4 @@ val caller_wins : t
 
 val heartbeat_fields_from_disk : t
 (** Transitional name for existing heartbeat retry call sites. With
-    room-owned fields removed, this is equivalent to {!caller_wins}. *)
+    coord-owned fields removed, this is equivalent to {!caller_wins}. *)

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -80,20 +80,20 @@ include Keeper_types_profile_toml
 (* ── JSON room-seq helpers ───────────────────────────────────────── *)
 
 let room_seq_map_to_json (items : (string * int) list) : Yojson.Safe.t =
-  `Assoc (List.map (fun (room_id, seq) -> (room_id, `Int seq)) items)
+  `Assoc (List.map (fun (coord_id, seq) -> (coord_id, `Int seq)) items)
 
 let room_seq_map_of_json (json : Yojson.Safe.t) : (string * int) list =
   match json with
   | `Assoc fields ->
       fields
-      |> List.filter_map (fun (room_id, value) ->
-             if not (validate_name room_id) then
+      |> List.filter_map (fun (coord_id, value) ->
+             if not (validate_name coord_id) then
                None
              else
                match value with
-               | `Int seq -> Some (room_id, seq)
+               | `Int seq -> Some (coord_id, seq)
                | `Intlit raw ->
-                   Some (room_id, Safe_ops.int_of_string_with_default ~default:0 raw)
+                   Some (coord_id, Safe_ops.int_of_string_with_default ~default:0 raw)
                | _ -> None)
   | _ -> []
 

--- a/lib/mcp_server_eio_protocol.ml
+++ b/lib/mcp_server_eio_protocol.ml
@@ -848,7 +848,7 @@ let run_stdio ~handle_request ~sw ~env state =
   let stdout = Eio.Stdenv.stdout env in
   let clock = Eio.Stdenv.clock env in
   Log.Mcp.info "MASC MCP Server (Eio stdio mode)";
-  Log.Mcp.info "Default room: %s" Mcp_server.(state.coord_config.Coord.base_path);
+  Log.Mcp.info "Default coord: %s" Mcp_server.(state.coord_config.Coord.base_path);
   let buf = Eio.Buf_read.of_flow stdin ~max_size:(16 * 1024 * 1024) in
   let read_framed_message_after_first_line first_line =
     let rec read_headers acc =

--- a/lib/mention_inbox.mli
+++ b/lib/mention_inbox.mli
@@ -12,7 +12,7 @@ type mention_record = {
   target_agent: string;    (** Who was mentioned *)
   source_agent: string;    (** Who mentioned them *)
   source_kind: string;     (** "room_message" | "board_post" | "board_comment" *)
-  source_id: string;       (** room_id or post_id *)
+  source_id: string;       (** coord_id or post_id *)
   content_preview: string; (** First ~200 chars of the content *)
   created_at: float;       (** Unix timestamp *)
   read_at: float;          (** 0.0 = unread, otherwise Unix timestamp when read *)

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -287,7 +287,7 @@ let dashboard_task_json = Server_dashboard_http_core_entities.dashboard_task_jso
 let dashboard_agent_json = Server_dashboard_http_core_entities.dashboard_agent_json
 let dashboard_message_json = Server_dashboard_http_core_entities.dashboard_message_json
 
-(* dashboard_current_room_id removed — namespace retired (#unify-namespace). *)
+(* dashboard_current_coord_id removed — namespace retired (#unify-namespace). *)
 
 let dashboard_tasks_safe = Server_dashboard_http_core_entities.dashboard_tasks_safe
 let dashboard_agents_safe = Server_dashboard_http_core_entities.dashboard_agents_safe

--- a/lib/server/server_dashboard_http_core.mli
+++ b/lib/server/server_dashboard_http_core.mli
@@ -147,7 +147,7 @@ val dashboard_shell_status_json : Coord.config -> Yojson.Safe.t
 val dashboard_task_json : Coord.config -> Masc_domain.task -> Yojson.Safe.t
 val dashboard_agent_json : Masc_domain.agent -> Yojson.Safe.t
 val dashboard_message_json : Masc_domain.message -> Yojson.Safe.t
-(* dashboard_current_room_id removed — namespace retired (#unify-namespace). *)
+(* dashboard_current_coord_id removed — namespace retired (#unify-namespace). *)
 val dashboard_tasks_safe : Coord.config -> Masc_domain.task list
 val dashboard_agents_safe : Coord.config -> Masc_domain.agent list
 val dashboard_messages_safe :

--- a/lib/transport_metrics.ml
+++ b/lib/transport_metrics.ml
@@ -397,7 +397,7 @@ let int_field key json =
   | _ -> 0
 ;;
 
-let room_id_from_config (_config : Coord.config) = "default"
+let coord_id_from_config (_config : Coord.config) = "default"
 
 let cluster_summary_json (_config : Coord.config) =
   (* Transport health should stay metrics-only and avoid command-plane/Coord I/O. *)
@@ -573,7 +573,7 @@ let transport_health_json ~config =
   let webrtc_channels = Server_webrtc_transport.connected_channel_count () in
   let listener_mode = http_listener_mode () in
   let topology_summary = cluster_summary_json config in
-  let room_id = room_id_from_config config in
+  let coord_id = coord_id_from_config config in
   let cluster_name = Env_config_core.cluster_name () in
   (* Keep transport-health free of Coord/PG reads so proactive refresh does not
      contend with dashboard and MCP writes on the shared backend. *)
@@ -727,7 +727,7 @@ let transport_health_json ~config =
     ; ( "cluster"
       , `Assoc
           [ "cluster", `String cluster_name
-          ; "room_id", `String room_id
+          ; "coord_id", `String coord_id
           ; "topology_available", `Bool topology_available
           ; "topology_source", `String degraded_source
           ; "total_units", Json_util.int_opt_to_json (int_field_opt "total_units" topology_summary)

--- a/lib/transport_metrics.mli
+++ b/lib/transport_metrics.mli
@@ -17,7 +17,7 @@
     [grpc_port] / [ws_port] (env-derived), [set_agent_heartbeat_age]
     / [inc_agent_stale] (per-agent labels, internal-only), the
     JSON helpers (\[assoc_field], [int_field], [int_field_opt],
-    [int_option_json], [room_id_from_config], [cluster_summary_json]),
+    [int_option_json], [coord_id_from_config], [cluster_summary_json]),
     [http_listener_mode], [primary_path], [queue_pressure],
     [tcp_port_reachable], [hot_session_json], the
     [ws_delivery_metric_names] data table + its type.  All

--- a/test/test_activity_graph.ml
+++ b/test/test_activity_graph.ml
@@ -317,7 +317,7 @@ let test_read_self_heals_historic_invalid_utf8_event_file () =
       let event_path = Filename.concat month_dir "01.jsonl" in
       let raw_line =
         "{\"seq\":1,\"ts_ms\":1,\"ts_iso\":\"2000-01-01T00:00:00Z\",\
-         \"room_id\":\"default\",\"kind\":\"message.broadcast\",\
+         \"coord_id\":\"default\",\"kind\":\"message.broadcast\",\
          \"payload\":{\"content\":\"bad\xffpayload\"},\"tags\":[]}\n"
       in
       Fs_compat.save_file event_path raw_line;

--- a/test/test_audit_log.ml
+++ b/test/test_audit_log.ml
@@ -61,7 +61,7 @@ let entry ~timestamp ~agent_id ~action ~outcome =
     Audit_log.timestamp;
     agent_id;
     action;
-    room_id = None;
+    coord_id = None;
     details = `Null;
     outcome;
     cost_estimate = None;

--- a/test/test_briefing_compactors.ml
+++ b/test/test_briefing_compactors.ml
@@ -9,7 +9,7 @@
 
     1. {b relevant_sessions_for_briefing filtering}
        - Empty namespace → match all rooms.
-       - Project / room_id matching with live-status allow-list
+       - Project / coord_id matching with live-status allow-list
          {running, active, paused, starting, stopping, waiting},
          case-insensitive + whitespace-trimmed.
        - Recent-event window: keep if any recent_events ts_iso is
@@ -49,7 +49,7 @@ let assoc_keys_sorted j =
 (* Session JSON helper — minimal shape that the compactor
    navigates through. *)
 let session_fixture ?(session_id = "s-1") ?(project = "room-A")
-    ?(room_id = "room-A") ?(goal = "ship feature") ?(status = "active")
+    ?(coord_id = "room-A") ?(goal = "ship feature") ?(status = "active")
     ?(summary_status = "active") ?(comm_mode = "async")
     ?(broadcast = 3) ?(portal = 5) ?(recent = []) () =
   `Assoc
@@ -62,7 +62,7 @@ let session_fixture ?(session_id = "s-1") ?(project = "room-A")
               `Assoc
                 [
                   ("project", json_string project);
-                  ("room_id", json_string room_id);
+                  ("coord_id", json_string coord_id);
                   ("goal", json_string goal);
                   ("status", json_string status);
                   ("agent_names", `List [ json_string "a1" ]);
@@ -187,10 +187,10 @@ let test_relevant_namespace_mismatch_drops () =
   in
   assert (result = [])
 
-let test_relevant_room_id_fallback_when_project_blank () =
-  (* If project is blank, fall back to room_id for matching. *)
+let test_relevant_coord_id_fallback_when_project_blank () =
+  (* If project is blank, fall back to coord_id for matching. *)
   let s =
-    session_fixture ~project:"" ~room_id:"room-Z"
+    session_fixture ~project:"" ~coord_id:"room-Z"
       ~status:"active" ~summary_status:"active" ()
   in
   let result =
@@ -564,7 +564,7 @@ let () =
   test_relevant_empty_namespace_matches_all ();
   test_relevant_namespace_matching_keeps ();
   test_relevant_namespace_mismatch_drops ();
-  test_relevant_room_id_fallback_when_project_blank ();
+  test_relevant_coord_id_fallback_when_project_blank ();
   test_relevant_dead_status_drops ();
   test_relevant_live_status_case_insensitive_trim ();
   test_relevant_recent_event_within_hour_keeps_dead_session ();

--- a/test/test_governance_anomaly.ml
+++ b/test/test_governance_anomaly.ml
@@ -62,7 +62,7 @@ let gen_entries ~end_ts ~spacing_sec ~count ~tool_names ~outcomes ~token_counts 
       Audit_log.timestamp;
       agent_id;
       action = Audit_log.ToolCall tool_name;
-      room_id = None;
+      coord_id = None;
       details = `Null;
       outcome;
       cost_estimate = None;

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -688,7 +688,7 @@ let field_value fixture ~tool_name field_name schema =
   | "search" -> `String "tool matrix"
   | "prompt" -> `String "tool matrix"
   | "topic_id" -> `String "topic-001"
-  | "room_id" -> `String "default"
+  | "coord_id" -> `String "default"
   | "checkpoint_ref" -> `String "checkpoint-001"
   | "intent_id" -> `String "intent-001"
   | "operation_id" -> `String "operation-001"

--- a/test/test_room.ml
+++ b/test/test_room.ml
@@ -730,7 +730,7 @@ let test_room_bootstrap_preserves_backend_state () =
     Alcotest.(check int) "backlog preserved" 7 saved_backlog.version
   )
 
-let test_room_bootstrap_ignores_invalid_room_id_in_flat_mode () =
+let test_room_bootstrap_ignores_invalid_coord_id_in_flat_mode () =
   with_memory_test_env (fun config ->
     Coord.ensure_coord_bootstrap config;
     Alcotest.(check bool) "root state initialized" true
@@ -1820,7 +1820,7 @@ let () =
       Alcotest.test_case "nonexistent agent" `Quick test_heartbeat_nonexistent_agent;
       Alcotest.test_case "get agents status" `Quick test_get_agents_status;
       Alcotest.test_case "backend bootstrap preserves room state" `Quick test_room_bootstrap_preserves_backend_state;
-      Alcotest.test_case "bootstrap ignores invalid room id in flat mode" `Quick test_room_bootstrap_ignores_invalid_room_id_in_flat_mode;
+      Alcotest.test_case "bootstrap ignores invalid room id in flat mode" `Quick test_room_bootstrap_ignores_invalid_coord_id_in_flat_mode;
       Alcotest.test_case "read_backlog_r recovers from last good snapshot" `Quick
         test_read_backlog_r_recovers_from_last_good_snapshot;
       Alcotest.test_case "read_backlog_r reports parse error when recovery also invalid" `Quick

--- a/test/test_transport_metrics.ml
+++ b/test/test_transport_metrics.ml
@@ -438,7 +438,7 @@ let test_transport_health_json () =
   check bool "webrtc signaling_mode field exists" true
     (match webrtc_json |> U.member "signaling_mode" with `String _ -> true | _ -> false);
   check string "room id" "default"
-    (cluster_json |> U.member "room_id" |> U.to_string);
+    (cluster_json |> U.member "coord_id" |> U.to_string);
   check bool "summary primary path exists" true
     (String.length (summary_json |> U.member "primary_path" |> U.to_string) > 0);
   check string "summary queue pressure reflects relay drops" "high"


### PR DESCRIPTION
## Summary
- rename internal audit/activity/transport/briefing room_id contracts to coord_id
- update activity graph coord node prefix/kind away from room
- update related tests and comments
- leave external channel_room_id/gate connector identifiers untouched

## Validation
- residue scan: no internal room_id/room_node/room: identifiers remain outside gate/channel connector exclusions
- build not run; build breakage accepted for this hard-cut cleanup slice