### PR TITLE
Rename operator room projection to coord

### DIFF
--- a/lib/dashboard/briefing_sections.ml
+++ b/lib/dashboard/briefing_sections.ml
@@ -13,19 +13,19 @@ let section_label = function
   | Alignment -> "Alignment"
   | Watch -> "Watch Next"
 
-let has_operational_signal ~section ~room_health ~incident_count ~recommended_action_count =
-  let room_risky =
-    Dashboard_utils.is_health_at_risk (Dashboard_utils.health_level_of_string room_health)
+let has_operational_signal ~section ~coord_health ~incident_count ~recommended_action_count =
+  let coord_risky =
+    Dashboard_utils.is_health_at_risk (Dashboard_utils.health_level_of_string coord_health)
   in
   match section with
-  | Watch -> room_risky || incident_count > 0 || recommended_action_count > 0
-  | Communication | Alignment -> room_risky || incident_count > 0
+  | Watch -> coord_risky || incident_count > 0 || recommended_action_count > 0
+  | Communication | Alignment -> coord_risky || incident_count > 0
 
 let annotate_section ~section ~status ~summary ~evidence ~metadata_gaps
-    ~room_health ~incident_count ~recommended_action_count =
+    ~coord_health ~incident_count ~recommended_action_count =
   let gap_count = count_metadata_gaps_for_section ~section metadata_gaps in
   let operational =
-    has_operational_signal ~section ~room_health ~incident_count
+    has_operational_signal ~section ~coord_health ~incident_count
       ~recommended_action_count
   in
   let signal_class, evidence_quality =
@@ -75,7 +75,7 @@ let evidence_add_if cond text items =
   if cond && text <> "" then text :: items else items
 
 let build_communication_section ~sessions ~recent_messages ~metadata_gaps
-    ~room_health ~incident_count ~recommended_action_count =
+    ~coord_health ~incident_count ~recommended_action_count =
   let live_session_count = List.length sessions in
   let recent_message_count = List.length recent_messages in
   let broadcast_total = sum_int_field "broadcast_count" sessions in
@@ -122,7 +122,7 @@ let build_communication_section ~sessions ~recent_messages ~metadata_gaps
     ("unclear", "Communication metadata is incomplete and no positive activity signal is recorded.", evidence)
   else if known_mode_count = 0 then
     ("unclear", "Communication mode is not recorded for the live sessions.", evidence)
-  else if Dashboard_utils.is_health_at_risk (Dashboard_utils.health_level_of_string room_health)
+  else if Dashboard_utils.is_health_at_risk (Dashboard_utils.health_level_of_string coord_health)
           || incident_count > 0 || recommended_action_count > 0
   then
     ("watch", "Live sessions exist without recorded communication activity while the namespace still has open operator attention.", evidence)
@@ -176,15 +176,15 @@ let build_alignment_section ~sessions ~agents ~metadata_gaps =
   else
     ("watch", "Some active agents are present without a bound focus.", evidence)
 
-let build_watch_section ~room_health ~incident_count ~recommended_action_count
+let build_watch_section ~coord_health ~incident_count ~recommended_action_count
     ~top_attention_summary =
-  let room_health_level = Dashboard_utils.health_level_of_string room_health in
-  let risky_room =
-    Dashboard_utils.is_health_at_risk room_health_level
+  let coord_health_level = Dashboard_utils.health_level_of_string coord_health in
+  let risky_coord =
+    Dashboard_utils.is_health_at_risk coord_health_level
   in
   let evidence =
     []
-    |> evidence_add_if risky_room (Printf.sprintf "Namespace health is %s" room_health)
+    |> evidence_add_if risky_coord (Printf.sprintf "Namespace health is %s" coord_health)
     |> evidence_add_if (incident_count > 0)
          (Printf.sprintf "Incident count is %d" incident_count)
     |> evidence_add_if (recommended_action_count > 0)
@@ -194,11 +194,11 @@ let build_watch_section ~room_health ~incident_count ~recommended_action_count
          top_attention_summary
     |> take 2
   in
-  if risky_room then
+  if risky_coord then
     ( "risk",
       Printf.sprintf
         "Namespace health is %s with %d incidents and %d recommended actions."
-        room_health incident_count recommended_action_count,
+        coord_health incident_count recommended_action_count,
       evidence )
   else if incident_count > 0 || recommended_action_count > 0 then
     ( "watch",
@@ -211,7 +211,7 @@ let build_watch_section ~room_health ~incident_count ~recommended_action_count
 
 let build_briefing_sections ~briefing_summary_json ~sessions ~agents ~recent_messages
     ~metadata_gaps =
-  let room_health = briefing_summary_json |> string_field "room_health" in
+  let coord_health = briefing_summary_json |> string_field "coord_health" in
   let incident_count = Option.value ~default:0 (Json_util.assoc_int_opt "incident_count" briefing_summary_json) in
   let recommended_action_count =
     Option.value ~default:0 (Json_util.assoc_int_opt "recommended_action_count" briefing_summary_json)
@@ -221,24 +221,24 @@ let build_briefing_sections ~briefing_summary_json ~sessions ~agents ~recent_mes
   in
   let communication_status, communication_summary, communication_evidence =
     build_communication_section ~sessions ~recent_messages ~metadata_gaps
-      ~room_health ~incident_count ~recommended_action_count
+      ~coord_health ~incident_count ~recommended_action_count
   in
   let alignment_status, alignment_summary, alignment_evidence =
     build_alignment_section ~sessions ~agents ~metadata_gaps
   in
   let watch_status, watch_summary, watch_evidence =
-    build_watch_section ~room_health ~incident_count ~recommended_action_count
+    build_watch_section ~coord_health ~incident_count ~recommended_action_count
       ~top_attention_summary
   in
   ( watch_summary,
     [
       annotate_section ~section:Communication ~status:communication_status
         ~summary:communication_summary ~evidence:communication_evidence
-        ~metadata_gaps ~room_health ~incident_count ~recommended_action_count;
+        ~metadata_gaps ~coord_health ~incident_count ~recommended_action_count;
       annotate_section ~section:Alignment ~status:alignment_status
         ~summary:alignment_summary ~evidence:alignment_evidence ~metadata_gaps
-        ~room_health ~incident_count ~recommended_action_count;
+        ~coord_health ~incident_count ~recommended_action_count;
       annotate_section ~section:Watch ~status:watch_status
         ~summary:watch_summary ~evidence:watch_evidence ~metadata_gaps
-        ~room_health ~incident_count ~recommended_action_count;
+        ~coord_health ~incident_count ~recommended_action_count;
     ] )

--- a/lib/dashboard/dashboard_briefing.ml
+++ b/lib/dashboard/dashboard_briefing.ml
@@ -199,8 +199,8 @@ let rec evidence_preview_strings json =
       fields |> List.map snd |> List.concat_map evidence_preview_strings |> dedup_strings |> take 4
   | _ -> []
 
-(* Issue #8395: root-level attention uses [target_type="root"].  This
-   predicate previously compared only to the literal "room", so the
+(* Issue #8395: root-level attention uses [target_type="coord"].  This
+   predicate previously compared only to the literal "coord", so the
    canonical form fell through to the public queue.  Delegate to the
    shared canonical target check used by [Dashboard_briefing_assembly]. *)
 let is_internal_attention incident =
@@ -361,9 +361,9 @@ let build_projection ?actor ~config ~sw ~clock
               ])
   in
   let namespace_json =
-    match member_assoc "root" snapshot_json with
+    match member_assoc "coord" snapshot_json with
     | `Assoc _ as value -> value
-    | _ -> member_assoc "room" snapshot_json
+    | _ -> member_assoc "coord" snapshot_json
   in
   let incidents =
     list_field "attention_items" digest_json
@@ -408,7 +408,7 @@ let json ?actor ~config ~sw ~clock ~proc_mgr
   let summary_json =
     `Assoc
       [
-        ("room_health", `String (string_field ~default:"ok" "health" projection.digest_json));
+        ("coord_health", `String (string_field ~default:"ok" "health" projection.digest_json));
         ("cluster", Json_util.string_opt_to_json (Some (string_field "cluster" projection.namespace_json)));
         ("project", Json_util.string_opt_to_json (Some (string_field "project" projection.namespace_json)));
       ]

--- a/lib/dashboard/dashboard_briefing_agents.ml
+++ b/lib/dashboard/dashboard_briefing_agents.ml
@@ -143,7 +143,7 @@ let latest_message_to agent_name messages =
             if message.seq >= current.seq then Some message else best)
     None messages
 
-let read_recent_room_event_lines config ~limit =
+let read_recent_coord_event_lines config ~limit =
   let events_dir = Filename.concat (Coord.masc_dir config) "events" in
   if not (Sys.file_exists events_dir) then []
   else
@@ -225,7 +225,7 @@ let archived_agent_meta_map config agent_names =
         Hashtbl.add table agent_name row;
         row
   in
-  read_recent_room_event_lines config ~limit:2000
+  read_recent_coord_event_lines config ~limit:2000
   |> List.rev
   |> List.iter (fun line ->
          try
@@ -260,7 +260,7 @@ let keeper_alias_by_agent_name (keepers : Yojson.Safe.t list) =
     keepers;
   table
 
-let build_agent_briefs config sessions attention_queue _room_json (keepers : Yojson.Safe.t list) =
+let build_agent_briefs config sessions attention_queue _coord_json (keepers : Yojson.Safe.t list) =
   let now_ts = Time_compat.now () in
   let task_lookup = build_task_lookup config in
   let messages =
@@ -277,23 +277,23 @@ let build_agent_briefs config sessions attention_queue _room_json (keepers : Yoj
         | Some label -> Some label
         | None -> Some id)
   in
-  let room_agents =
+  let coord_agents =
     if Coord.is_initialized config then Coord.get_agents_raw config else []
   in
-  let room_agent_by_name =
-    room_agents
+  let coord_agent_by_name =
+    coord_agents
     |> List.map (fun (agent : Masc_domain.agent) -> (agent.name, agent))
   in
   let agent_names =
     dedup_strings
-      (List.map (fun (agent : Masc_domain.agent) -> agent.name) room_agents
+      (List.map (fun (agent : Masc_domain.agent) -> agent.name) coord_agents
       @ List.concat_map (fun (session : session_context) -> session.member_names) sessions)
   in
   let archived_meta_by_name = archived_agent_meta_map config agent_names in
   let keeper_aliases = keeper_alias_by_agent_name keepers in
   agent_names
   |> List.map (fun agent_name ->
-         let agent = List.assoc_opt agent_name room_agent_by_name in
+         let agent = List.assoc_opt agent_name coord_agent_by_name in
          let related_session =
            List.find_opt
              (fun (session : session_context) -> List.mem agent_name session.member_names)

--- a/lib/dashboard/dashboard_briefing_agents.mli
+++ b/lib/dashboard/dashboard_briefing_agents.mli
@@ -9,7 +9,7 @@
 
     Internal: 9 helpers (\[build_task_lookup\],
     \[latest_message_from\], \[latest_message_to\],
-    \[read_recent_room_event_lines\], \[is_session_concluded\],
+    \[read_recent_coord_event_lines\], \[is_session_concluded\],
     \[status_of_archived_session\], \[archived_reason_for_session\],
     \[archived_agent_meta_map\], \[keeper_alias_by_agent_name\])
     stay private — none are referenced bare in the runtime
@@ -119,11 +119,11 @@ val build_agent_briefs :
   Yojson.Safe.t ->
   Yojson.Safe.t list ->
   Yojson.Safe.t list
-(** [build_agent_briefs config sessions attention_queue room_json
+(** [build_agent_briefs config sessions attention_queue coord_json
       keepers] aggregates per-agent briefs from session contexts +
     attention queue + keeper list.
 
-    [room_json] is currently unused (placeholder for future room
+    [coord_json] is currently unused (placeholder for future coord
     metadata expansion) — kept in signature for forward compat.
 
     Returns a JSON list, one entry per active / archived agent,

--- a/lib/dashboard/dashboard_briefing_sections.ml
+++ b/lib/dashboard/dashboard_briefing_sections.ml
@@ -15,7 +15,7 @@ let briefing_sections_criteria =
     "no_model_status_inference";
     "communication_from_message_and_session_counts";
     "alignment_from_active_agents_and_focus_bindings";
-    "watch_from_room_health_and_incident_counts";
+    "watch_from_coord_health_and_incident_counts";
     "metadata_gaps_reported_separately";
   ]
 
@@ -129,16 +129,16 @@ let compute_briefing_json ~actor_name ~config ~sw ~clock ~proc_mgr () =
          dashboard surfaces. The briefing only needs session status/events;
          keeper metadata can come from briefing_json. Pulling keepers,
          command-plane, and message payloads here duplicates the heaviest
-         snapshot path and can spike memory on rooms with many keepers. *)
+         snapshot path and can spike memory on coords with many keepers. *)
       Operator_control.snapshot_json ~actor:actor_name ~view:"summary"
         ~include_messages:false ~include_keepers:false
         ~include_summary_fields:false
         ~lightweight_summary:true ctx
     in
     let scope_json =
-      match snapshot_json |> member_assoc "root" with
+      match snapshot_json |> member_assoc "coord" with
       | `Assoc _ as value -> value
-      | _ -> snapshot_json |> member_assoc "room"
+      | _ -> snapshot_json |> member_assoc "coord"
     in
     let current_namespace =
       match String_util.option_trim (Some (scope_json |> string_field "project")) with
@@ -202,7 +202,7 @@ let compute_briefing_json ~actor_name ~config ~sw ~clock ~proc_mgr () =
       let summary = member_assoc "summary" briefing_json in
       `Assoc
         [
-          ("room_health", member_assoc "room_health" summary);
+          ("coord_health", member_assoc "coord_health" summary);
           ("active_agents", member_assoc "active_agents" summary);
           ("keeper_pressure", member_assoc "keeper_pressure" summary);
           ("active_operations", member_assoc "active_operations" summary);

--- a/lib/dashboard/dashboard_cache.ml
+++ b/lib/dashboard/dashboard_cache.ml
@@ -203,7 +203,7 @@ let timeout_json ~key ~timeout_sec ~timeout_kind =
     invariant "watchdog >= largest caller budget" holds by construction.
     Previously hardcoded to 130.0, which silently drifted from caller
     config when env overrides were introduced.  Multiplier N = 8 gives
-    headroom so the watchdog is a *floor* protection — under normal
+    headcoord so the watchdog is a *floor* protection — under normal
     operation the structural cleanup ([release_on_cancel]) keeps slots
     from ever reaching this ceiling.  An SLO alert on
     [masc_cache_stuck_evictions_total] pages operators if it does fire,

--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -2,7 +2,7 @@ include Dashboard_execution_helpers
 include Dashboard_execution_fixture
 include Dashboard_execution_builders
 
-let room_status_json (config : Coord.config) : Yojson.Safe.t =
+let coord_status_json (config : Coord.config) : Yojson.Safe.t =
   let coord_state_opt =
     if Coord.is_initialized config then Some (Coord.read_state config) else None
   in
@@ -733,7 +733,7 @@ let json_render ~effective_actor ~light ~config ~sw ~clock ~proc_mgr () =
     let base_fields =
       let utf8_repair = Safe_ops.persistence_utf8_repair_stats () in
       [ "generated_at", `String (Masc_domain.now_iso ())
-      ; "status", room_status_json config
+      ; "status", coord_status_json config
       ; ( "projection_diagnostics"
         , `Assoc
             [ "surface", `String "execution"
@@ -842,6 +842,6 @@ let json ?actor ?fixture ?(light = true) ~config ~sw ~clock ~proc_mgr () =
          [ "generated_at", `String (Masc_domain.now_iso ())
          ; ( "error"
            , `String (Printf.sprintf "render timed out after %.0fs" render_timeout_s) )
-         ; "status", room_status_json config
+         ; "status", coord_status_json config
          ])
 ;;

--- a/lib/dashboard/dashboard_operator_judge.ml
+++ b/lib/dashboard/dashboard_operator_judge.ml
@@ -87,7 +87,7 @@ let enabled () = Env_config.Operator.judge_enabled
 
 let interval_sec () = Env_config.Operator.judge_interval_sec
 
-let room_ttl_sec () = Env_config.Operator.room_ttl_sec
+let coord_ttl_sec () = Env_config.Operator.coord_ttl_sec
 
 let session_ttl_sec () = Env_config.Operator.session_ttl_sec
 
@@ -177,7 +177,7 @@ let prompt_for_facts facts_json =
   | Ok value -> value
   | Error _ -> Prompt_registry.get_prompt prompt_dashboard_operator_judge
 
-let parse_room_judgment ~config ~generated_at ~generated_at_unix ~model_used:_ json =
+let parse_coord_judgment ~config ~generated_at ~generated_at_unix ~model_used:_ json =
   match json with
   | `Assoc _ ->
       let summary =
@@ -191,14 +191,14 @@ let parse_room_judgment ~config ~generated_at ~generated_at_unix ~model_used:_ j
           |> Option.value ~default:0.0
         in
         let fresh_until_unix =
-          generated_at_unix +. float_of_int (room_ttl_sec ())
+          generated_at_unix +. float_of_int (coord_ttl_sec ())
         in
         Some
           (Operator_judgment.record config ~surface:"command.namespace"
              ~target_type:Operator_judgment.Coord ~target_id:None ~summary
              ~confidence ?model_name:None
              ?recommended_action:
-               (build_recommended_action ~actor:keeper_name ~target_type:"root"
+               (build_recommended_action ~actor:keeper_name ~target_type:"coord"
                   ~target_id:None (Option.value ~default:`Null (Json_util.assoc_member_opt member_recommended_action json)))
              ~evidence_refs:(parse_string_list json "evidence_refs")
              ~disagreement_with_truth:
@@ -299,13 +299,13 @@ let refresh_once ~sw ~net
         let generated_at_unix = Unix.gettimeofday () in
         let generated_at = Masc_domain.iso8601_of_unix_seconds generated_at_unix in
         let expires_at =
-          Masc_domain.iso8601_of_unix_seconds (generated_at_unix +. float_of_int (room_ttl_sec ()))
+          Masc_domain.iso8601_of_unix_seconds (generated_at_unix +. float_of_int (coord_ttl_sec ()))
         in
-        let room_judgment =
-          parse_room_judgment ~config ~generated_at ~generated_at_unix
+        let coord_judgment =
+          parse_coord_judgment ~config ~generated_at ~generated_at_unix
             ~model_used result_json
         in
-        let has_any = Option.is_some room_judgment in
+        let has_any = Option.is_some coord_judgment in
         with_lock st (fun () ->
             st.refreshing <- false;
             st.judge_online <- has_any;

--- a/lib/dashboard/dashboard_operator_judge.mli
+++ b/lib/dashboard/dashboard_operator_judge.mli
@@ -1,8 +1,8 @@
-(** Dashboard_operator_judge — periodic LLM-driven room judgment loop.
+(** Dashboard_operator_judge — periodic LLM-driven coord judgment loop.
 
     Runs as an Eio daemon fiber per [base_path]: every
     [Env_config.Operator.judge_interval_sec], it asks an operator-judge
-    keeper to evaluate room health using freshly built facts, then
+    keeper to evaluate coord health using freshly built facts, then
     caches the verdict (and "is the judge online?" status) for HTTP
     consumption.
 

--- a/lib/dashboard/dashboard_workspace.ml
+++ b/lib/dashboard/dashboard_workspace.ml
@@ -1,6 +1,6 @@
 let clamp_limit limit = Server_utils.clamp ~min_v:1 ~max_v:200 limit
 let fetch_limit limit = Server_utils.clamp ~min_v:limit ~max_v:1000 (limit * 5)
-let workspace_id = "root"
+let workspace_id = "coord"
 let workspace_name = "Workspace timeline"
 
 let take = List.take

--- a/lib/operator/operator_control.ml
+++ b/lib/operator/operator_control.ml
@@ -76,45 +76,45 @@ let keeper_recovery_outcome after_diagnostic =
 
 (** {1 Domain-specific action handlers} *)
 
-let room_action_result request result =
+let coord_action_result request result =
   Ok (`Assoc [
     ("tool_name", `String (delegated_tool_for request.action_type));
     ("result", result);
   ])
 
-let execute_room_action (ctx : 'a context) (request : action_request) =
+let execute_coord_action (ctx : 'a context) (request : action_request) =
   match request.action_type with
   | "broadcast" ->
-      let* () = validate_target_type "root" request in
+      let* () = validate_target_type "coord" request in
       let* message =
         match get_string_opt request.payload "message" with
         | Some value -> Ok value
         | None -> Error "payload.message is required"
       in
       let result = Coord.broadcast ctx.config ~from_agent:request.actor ~content:message in
-      room_action_result request (`String result)
+      coord_action_result request (`String result)
   | "namespace_pause" ->
-      let* () = validate_target_type "root" request in
+      let* () = validate_target_type "coord" request in
       let reason =
         get_string request.payload "reason" "Paused by operator control plane"
       in
       Coord.pause ctx.config ~by:request.actor ~reason;
-      room_action_result request
+      coord_action_result request
         (`Assoc [ ("paused", `Bool true); ("reason", `String reason) ])
   | "namespace_resume" ->
-      let* () = validate_target_type "root" request in
+      let* () = validate_target_type "coord" request in
       let status =
         match Coord.resume ctx.config ~by:request.actor with
         | `Resumed -> "resumed"
         | `Already_running -> "already_running"
       in
-      room_action_result request (`Assoc [ ("status", `String status) ])
+      coord_action_result request (`Assoc [ ("status", `String status) ])
   | "social_sweep" ->
-      room_action_result request
+      coord_action_result request
         (`Assoc [("status", `String "removed");
                  ("reason", `String "Social runtime removed. Keepers discover board events via proactive turns.")])
   | "task_inject" ->
-      let* () = validate_target_type "root" request in
+      let* () = validate_target_type "coord" request in
       let* title =
         match get_string_opt request.payload "title" with
         | Some value -> Ok value
@@ -132,7 +132,7 @@ let execute_room_action (ctx : 'a context) (request : action_request) =
           ~reject_if:(Coord_task_capacity.rejection_for_add_task ?goal_id:None)
           ctx.config ~title ~priority ~description
       in
-      room_action_result request (`String result)
+      coord_action_result request (`String result)
   | _ -> Error (Printf.sprintf "not a namespace action: %s" request.action_type)
 
 (* Issue #8394: removed [execute_team_action] — team session execution
@@ -288,7 +288,7 @@ let execute_action (ctx : 'a context) (request : action_request) :
   match request.action_type with
   | "broadcast" | "namespace_pause" | "namespace_resume" | "social_sweep"
   | "task_inject" ->
-      execute_room_action ctx request
+      execute_coord_action ctx request
   | "keeper_probe" | "keeper_recover" | "keeper_message" ->
       execute_keeper_action ctx request
   | "" -> Error "action_type is required"

--- a/lib/operator/operator_control_action.ml
+++ b/lib/operator/operator_control_action.ml
@@ -16,7 +16,7 @@ let normalize_judgment_surface value =
 let normalize_judgment_target_type value =
   let normalized = String.trim value |> String.lowercase_ascii in
   if Operator_digest_types.is_root_target_type normalized then
-    Ok ("root", Operator_judgment.Coord)
+    Ok ("coord", Operator_judgment.Coord)
   else Error "target_type must be root"
 
 let default_fresh_ttl_sec surface =
@@ -107,7 +107,7 @@ let canonical_action_type action_type = action_type
 
 let normalize_action_target_type target_type =
   let normalized = String.trim target_type |> String.lowercase_ascii in
-  if Operator_digest_types.is_root_target_type normalized then Ok "root"
+  if Operator_digest_types.is_root_target_type normalized then Ok "coord"
   else match normalized with
   | "keeper" as value -> Ok value
   | "" -> Ok ""
@@ -116,7 +116,7 @@ let normalize_action_target_type target_type =
 let default_target_type_for action_type =
   match action_type with
   | "broadcast" | "namespace_pause" | "namespace_resume" | "task_inject" | "social_sweep"
-    -> "root"
+    -> "coord"
   | "keeper_message" | "keeper_probe" | "keeper_recover" -> "keeper"
   | _ -> ""
 

--- a/lib/operator/operator_control_action.mli
+++ b/lib/operator/operator_control_action.mli
@@ -29,7 +29,7 @@ val judgment_write_json :
     {!Operator_judgment} entry parsed from [args].  Required fields:
 
     - [surface]: ["command.namespace"] or ["intervene"].
-    - [target_type]: ["root"].
+    - [target_type]: ["coord"].
     - [summary] (non-empty after trim).
 
     Optional: [target_id], [fresh_ttl_sec] (default 60s for

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -626,7 +626,7 @@ let _snapshot_recent_completed_limit () =
 
 (* sessions_json removed — team session cleanup. Sessions always return []. *)
 
-let room_json = Operator_control_snapshot_room.room_json
+let coord_json = Operator_control_snapshot_coord.coord_json
 
 (* snapshot_view variant + parser extracted to
    [Operator_control_snapshot_view] (godfile decomp). *)
@@ -821,13 +821,13 @@ let snapshot_json
           | Summary | Full -> true
           | Sessions | Keepers | Messages -> false
         then (
-          let room_attention =
-            build_room_attention_items config |> List.sort compare_attention
+          let coord_attention =
+            build_coord_attention_items config |> List.sort compare_attention
           in
-          let room_recommendation_items = room_recommendations config in
-          [ "attention_summary", summary_of_attention_items room_attention
+          let coord_recommendation_items = coord_recommendations config in
+          [ "attention_summary", summary_of_attention_items coord_attention
           ; ( "recommendation_summary"
-            , summary_of_recommendations ~actor:actor_name room_recommendation_items )
+            , summary_of_recommendations ~actor:actor_name coord_recommendation_items )
           ])
         else [])
     in
@@ -847,7 +847,7 @@ let snapshot_json
          ; "judgment_owner", `String "fallback_read_model"
          ; "authoritative_judgment_available", `Bool false
          ; "admission_queue", Admission_queue.snapshot_json ()
-         ; "root", room_json config
+         ; "coord", coord_json config
          ]
          @ ((* Parallelize independent I/O: sessions, keepers, and persistent_agents. *)
             let empty_section = `Assoc [ "count", `Int 0; "items", `List [] ] in

--- a/lib/operator/operator_control_snapshot_coord.ml
+++ b/lib/operator/operator_control_snapshot_coord.ml
@@ -1,10 +1,10 @@
-(** Operator dashboard room descriptor, extracted from
+(** Operator dashboard coord descriptor, extracted from
     [operator_control_snapshot.ml] (godfile decomp).
 
-    [room_json config] produces a minimal room-state summary for the
+    [coord_json config] produces a minimal coord-state summary for the
     operator dashboard:
 
-    - When the room is not yet initialized via [Coord.init], returns
+    - When the coord is not yet initialized via [Coord.init], returns
       `{initialized=false, project=basename(base_path)}` so the
       dashboard can render a placeholder before any keeper has
       bootstrapped the coordination root.
@@ -15,7 +15,7 @@
 
     Pure helper move — local-only function with no .mli surface. *)
 
-let room_json config =
+let coord_json config =
   let initialized = Coord.is_initialized config in
   if not initialized
   then

--- a/lib/operator/operator_control_snapshot_coord.mli
+++ b/lib/operator/operator_control_snapshot_coord.mli
@@ -1,0 +1,4 @@
+(** Operator dashboard coord descriptor extracted from [Operator_control_snapshot]. *)
+
+val coord_json : Coord.config -> Yojson.Safe.t
+(** Return the current coord summary JSON for the operator dashboard. *)

--- a/lib/operator/operator_control_snapshot_room.mli
+++ b/lib/operator/operator_control_snapshot_room.mli
@@ -1,4 +1,0 @@
-(** Operator dashboard room descriptor extracted from [Operator_control_snapshot]. *)
-
-val room_json : Coord.config -> Yojson.Safe.t
-(** Return the current room summary JSON for the operator dashboard. *)

--- a/lib/operator/operator_control_snapshot_trust.ml
+++ b/lib/operator/operator_control_snapshot_trust.ml
@@ -15,7 +15,7 @@ let compact_runtime_trust_cache_ttl_sec = 1.0
 
    - Originally embedded [meta.updated_at] (ISO timestamp ticking on
      every meta refresh): 41/64 entries (65%) of the shared LRU
-     belonged to this prefix, evicting hot keys (branches/rooms/board).
+     belonged to this prefix, evicting hot keys (branches/coords/board).
      PR #19010 dropped [meta.updated_at].
    - PR #19010 retained [meta.runtime.usage.total_turns] in the key,
      reasoning that monotonic per-turn invalidation was useful.  On a

--- a/lib/operator/operator_digest.ml
+++ b/lib/operator/operator_digest.ml
@@ -5,7 +5,7 @@ include Operator_digest_types
 (* Operator_digest_session removed — team session cleanup *)
 open Operator_digest_guidance
 
-(* Retained from Operator_digest_session — used for room-level attention health *)
+(* Retained from Operator_digest_session — used for coord-level attention health *)
 let health_from_attention_items (items : attention_item list) =
   if
     List.exists
@@ -49,7 +49,7 @@ let recent_tool_host_failures ~now () =
                     severity =
                       operator_severity_of_failure_envelope envelope.severity;
                     summary = envelope.summary;
-                    target_type = "root";
+                    target_type = "coord";
                     target_id = None;
                     actor = None;
                     evidence =
@@ -67,7 +67,7 @@ let recent_tool_host_failures ~now () =
   Log.Ring.recent ~limit:12 ~module_filter:Failure_envelope.tool_host_log_module_name ()
   |> dedup [] []
 
-let build_room_attention_items config =
+let build_coord_attention_items config =
   let pending_confirms = read_pending_confirms config in
   let pending_items =
     if pending_confirms = [] then []
@@ -79,7 +79,7 @@ let build_room_attention_items config =
           summary =
             Printf.sprintf "%d pending confirmation(s) are waiting for operator input"
               (List.length pending_confirms);
-          target_type = "root";
+          target_type = "coord";
           target_id = None;
           actor = None;
           evidence = `Assoc [ ("count", `Int (List.length pending_confirms)) ];
@@ -197,7 +197,7 @@ let keeper_attention_projection_items config =
     | Ok (Some meta) -> keeper_attention_projection config meta
     | Ok None | Error _ -> None)
 
-let room_recommendations _config =
+let coord_recommendations _config =
   dedup_recommendations []
 
 let coord_state_json config =
@@ -229,7 +229,7 @@ let digest_json ?actor ?target_type ?target_id:_target_id ?include_workers:_incl
       (`Assoc
         [
           ("trace_id", `String (trace_id "opsd"));
-          ("target_type", `String "root");
+          ("target_type", `String "coord");
           ("target_id", `Null);
           ("health", `String "ok");
           ("judgment_owner", `String "fallback_read_model");
@@ -254,25 +254,25 @@ let digest_json ?actor ?target_type ?target_id:_target_id ?include_workers:_incl
     let* target_type = normalize_digest_target_type target_type in
     let coord_state_json = coord_state_json config in
     match target_type with
-    | "root" ->
+    | "coord" ->
         let confirm_scope = pending_confirm_scope ?actor config in
         let keeper_attention, keeper_recommendations =
           keeper_attention_projection_items config |> List.split
         in
         let attention_items =
-          build_room_attention_items config
+          build_coord_attention_items config
           @ keeper_attention
           |> List.sort compare_attention
         in
         let recommended_actions =
           dedup_recommendations
-            (room_recommendations config @ keeper_recommendations)
+            (coord_recommendations config @ keeper_recommendations)
         in
         let fallback_recommendation_summary =
           summary_of_recommendations ~actor:actor_name recommended_actions
         in
         let active_guidance =
-          active_guidance_fields ~config ~actor:actor_name ~target_type:"root"
+          active_guidance_fields ~config ~actor:actor_name ~target_type:"coord"
             ~target_id:None ~fallback_recommendations:recommended_actions
             ~fallback_summary:fallback_recommendation_summary
         in
@@ -283,7 +283,7 @@ let digest_json ?actor ?target_type ?target_id:_target_id ?include_workers:_incl
           (`Assoc
             ([
               ("trace_id", `String (trace_id "opsd"));
-              ("target_type", `String "root");
+              ("target_type", `String "coord");
               ("target_id", `Null);
               ("health", `String (health_from_attention_items attention_items));
               ("operator_judge_runtime", operator_judge_runtime_json config);
@@ -295,7 +295,7 @@ let digest_json ?actor ?target_type ?target_id:_target_id ?include_workers:_incl
                   (List.map (recommended_action_to_yojson ~actor:actor_name)
                      recommended_actions) );
               ("recommendation_summary", fallback_recommendation_summary);
-              ("root", coord_state_json);
+              ("coord", coord_state_json);
             ]
             @ [ ("recent_reviews", recent_reviews) ]
             @ active_guidance))

--- a/lib/operator/operator_digest.mli
+++ b/lib/operator/operator_digest.mli
@@ -38,9 +38,9 @@ val summary_of_recommendations : actor:string -> recommended_action list -> Yojs
 
 val health_from_attention_items : attention_item list -> string
 
-val build_room_attention_items : Coord.config -> attention_item list
+val build_coord_attention_items : Coord.config -> attention_item list
 
-val room_recommendations : Coord.config -> recommended_action list
+val coord_recommendations : Coord.config -> recommended_action list
 
 val normalize_digest_target_type :
   string option -> (string, string) result

--- a/lib/operator/operator_digest_types.ml
+++ b/lib/operator/operator_digest_types.ml
@@ -172,13 +172,13 @@ let summary_of_recommendations ~actor (items : recommended_action list) =
       ("authoritative", `Bool false);
     ]
 
-(** [is_root_target_type v] is true when [v] matches the canonical "root" target type. *)
-let is_root_target_type value = String.equal value "root"
+(** [is_root_target_type v] is true when [v] matches the canonical "coord" target type. *)
+let is_root_target_type value = String.equal value "coord"
 
 let normalize_digest_target_type value =
   match value with
   | Some raw ->
       let normalized = String.trim raw |> String.lowercase_ascii in
-      if is_root_target_type normalized then Ok "root"
+      if is_root_target_type normalized then Ok "coord"
       else Error "target_type must be root"
-  | None -> Ok "root"
+  | None -> Ok "coord"

--- a/lib/operator/operator_digest_types.mli
+++ b/lib/operator/operator_digest_types.mli
@@ -82,9 +82,9 @@ val summary_of_recommendations :
 
 (** {1 Target type normalisation} *)
 
-(** [true] for the canonical ["root"] target type. *)
+(** [true] for the canonical ["coord"] target type. *)
 val is_root_target_type : string -> bool
 
-(** Accepts [None] → [Ok "root"]; [Some raw] is trimmed + lowercased, then
+(** Accepts [None] → [Ok "coord"]; [Some raw] is trimmed + lowercased, then
     checked via {!is_root_target_type}. Otherwise [Error "target_type must be root"]. *)
 val normalize_digest_target_type : string option -> (string, string) result

--- a/lib/operator/operator_judgment.ml
+++ b/lib/operator/operator_judgment.ml
@@ -26,10 +26,10 @@ type record = {
 }
 
 let target_type_to_string = function
-  | Coord -> "root"
+  | Coord -> "coord"
 
 let target_type_of_string = function
-  | "root" -> Some Coord
+  | "coord" -> Some Coord
   | _ -> None
 
 
@@ -47,8 +47,8 @@ let key_of ~surface ~target_type ~target_id =
     match target_id with
     | Some value ->
         let trimmed = String.trim value in
-        if trimmed <> "" then trimmed else "__room__"
-    | None -> "__room__"
+        if trimmed <> "" then trimmed else "__coord__"
+    | None -> "__coord__"
   in
   String.concat ":" [ surface; target_type_to_string target_type; target ]
 

--- a/lib/operator/operator_judgment.mli
+++ b/lib/operator/operator_judgment.mli
@@ -51,11 +51,11 @@ type record = {
 (** {1 target_type codec} *)
 
 val target_type_to_string : target_type -> string
-(** [Coord -> "root"].  Pinned literal for the on-disk JSONL format. *)
+(** [Coord -> "coord"].  Pinned literal for the on-disk JSONL format. *)
 
 val target_type_of_string : string -> target_type option
-(** Accepts only the canonical [["root"]] target type for [Coord].
-    Historical [["room"]] / [["namespace"]] aliases are rejected at
+(** Accepts only the canonical [["coord"]] target type for [Coord].
+    Historical [["coord"]] / [["namespace"]] aliases are rejected at
     the parse boundary. *)
 
 (** {1 JSON codec} *)
@@ -106,7 +106,7 @@ val load_all : Coord.config -> record list
 
     Records are keyed by [(surface, target_type, target_id)]
     triple.  When [target_id] is [None] or empty/whitespace, the
-    composite key uses the literal [["__room__"]] sentinel —
+    composite key uses the literal [["__coord__"]] sentinel —
     pinned because it must remain stable across runs. *)
 
 val latest_active :

--- a/lib/operator/operator_pending_confirm.ml
+++ b/lib/operator/operator_pending_confirm.ml
@@ -237,19 +237,19 @@ let pending_confirms_json ?actor config =
 let available_actions : available_action list =
   [
     make_available_action ~action_type:"broadcast" ~tool_name:"masc_broadcast"
-      ~target_type:"root"
+      ~target_type:"coord"
       ~description:"Namespace-wide operator broadcast.";
     make_available_action ~action_type:"namespace_pause" ~tool_name:"masc_pause"
-      ~target_type:"root"
+      ~target_type:"coord"
       ~description:"Pause namespace automation and spawning.";
     make_available_action ~action_type:"namespace_resume" ~tool_name:"masc_resume"
-      ~target_type:"root"
+      ~target_type:"coord"
       ~description:"Resume a paused namespace.";
     make_available_action ~action_type:"social_sweep" ~tool_name:"social_sweep"
-      ~target_type:"root"
+      ~target_type:"coord"
       ~description:"Run one immediate social sweep across keepers.";
     make_available_action ~action_type:"task_inject" ~tool_name:"masc_add_task"
-      ~target_type:"root"
+      ~target_type:"coord"
       ~description:"Inject a backlog task into the namespace.";
     make_available_action ~action_type:"keeper_message" ~tool_name:"masc_keeper_msg"
       ~target_type:"keeper"

--- a/lib/server/fd_accountant.mli
+++ b/lib/server/fd_accountant.mli
@@ -15,7 +15,7 @@
 
     Layer B (shared): when [Keeper_fd_pressure.active ()] is true, ALL
     kinds serialize against a shared global mutex. Engaged
-    automatically; gives the cooldown room to drain.
+    automatically; gives the cooldown coord to drain.
 
     Callers wrap with [with_slot ~kind f]; [f] is invoked after a slot
     is acquired and FD-pressure (if active) is taken. *)

--- a/lib/server/server_activity_http.ml
+++ b/lib/server/server_activity_http.ml
@@ -28,7 +28,7 @@ let kind_filters deps request =
   in
   from_kinds @ from_kind |> List.sort_uniq String.compare
 
-(* room_filter removed — namespace retired (#unify-namespace). *)
+(* coord_filter removed — namespace retired (#unify-namespace). *)
 
 let last_event_id request =
   match Httpun.Headers.get request.Httpun.Request.headers "last-event-id" with

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -46,7 +46,7 @@ let http_auth_bind_is_loopback () =
 
 let strict_http_auth_error endpoint =
   Printf.sprintf
-    "%s requires room auth enabled with require_token=true when server is \
+    "%s requires coord auth enabled with require_token=true when server is \
      bound to a non-loopback host or MASC_HTTP_BASE_URL points to a public address."
     endpoint
 
@@ -232,7 +232,7 @@ let verify_operator_mcp_auth ~base_path request =
   let auth_config = Auth.load_auth_config base_path in
   if not auth_config.Masc_domain.enabled then
     Error
-      "/mcp/operator requires room auth enabled with require_token=true."
+      "/mcp/operator requires coord auth enabled with require_token=true."
   else if not auth_config.require_token then
     Error "/mcp/operator requires bearer token auth (require_token=true)."
   else
@@ -834,7 +834,7 @@ let authorize_token_bound_permission_request ~base_path ~permission request :
     Error
       (Masc_domain.Auth (Masc_domain.Auth_error.Unauthorized
          { reason = Missing_token
-         ; message = "HTTP mutation requires room auth enabled with require_token=true."
+         ; message = "HTTP mutation requires coord auth enabled with require_token=true."
          }))
   else if not auth_cfg.require_token then
     Error

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -470,7 +470,7 @@ let start_keeper_loops
         activity_kind
         (Printexc.to_string exn));
   (* Wire broadcast → keeper wakeup: any broadcast wakes keepers so they
-     can react to new tasks, mentions, or room activity immediately.
+     can react to new tasks, mentions, or coord activity immediately.
      SSOT: Coord_broadcast.on_broadcast_mention is the single ref wired here. *)
   let broadcast_mention_handler =
     fun mention ->
@@ -514,12 +514,12 @@ let start_keeper_loops
     let start_time = Time_compat.now () in
     let config = state.coord_config in
     let agent_name = actor in
-    let ctx_room : Tool_coord.context = { config; agent_name } in
+    let ctx_coord : Tool_coord.context = { config; agent_name } in
     let ctx_task : Tool_task.context = { config; agent_name; sw = Some sw } in
     let ctx_agent : Tool_agent.context = { config; agent_name } in
     match name with
     | "masc_status" ->
-      (match Tool_coord.dispatch ctx_room ~name ~args with
+      (match Tool_coord.dispatch ctx_coord ~name ~args with
        | Some result -> result
        | None ->
          (* RFC-0189: [Tool_*.dispatch] returning [None] when the

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -94,7 +94,7 @@ let mission_cache =
   create_cached_surface
     (`Assoc
         [ "generated_at", `String (Masc_domain.now_iso ())
-        ; "summary", `Assoc [ "room_health", `String "initializing" ]
+        ; "summary", `Assoc [ "coord_health", `String "initializing" ]
         ; "incidents", `List []
         ; "recommended_actions", `List []
         ; "command_focus", `Assoc []
@@ -314,7 +314,7 @@ let provider_capacity_json = Server_dashboard_http_core_entities.provider_capaci
    light is genuinely under-scoped or has accidentally taken on full's
    work. Splitting the budget makes that distinction visible: a light
    timeout means "light path is doing too much"; a full timeout means
-   "the full path needs more headroom or a real perf fix". *)
+   "the full path needs more headcoord or a real perf fix". *)
 let dashboard_shell_timeout_s = Env_config_runtime.Dashboard.shell_timeout_sec
 let dashboard_shell_light_timeout_s = Env_config_runtime.Dashboard.shell_light_timeout_sec
 
@@ -327,7 +327,7 @@ let dashboard_shell_timeout_for ~light =
 ;;
 
 (* Meta_cognition.summary_json does a full board_posts.jsonl scan +
-   belief/tension/desire rule evaluation. On a room with 450+ posts this
+   belief/tension/desire rule evaluation. On a coord with 450+ posts this
    regularly exceeds 8s, which was the previous shell timeout and caused
    repeat "cache compute timeout: shell:..." + "cache bg-revalidate failed"
    noise in the log. Give it its own cache with a longer TTL, and on a cold
@@ -483,7 +483,7 @@ let dashboard_shell_payload_json
         `Null)
   in
   match
-    (* Cold workspaces lazily materialize room/keeper state on first access.
+    (* Cold workspaces lazily materialize coord/keeper state on first access.
        Keep those stateful reads sequential so one failing init path does not
        cancel sibling fibers and poison shared Eio mutexes. Retain parallelism
        only for projection-style reads that are safe to drop to `Null`. *)
@@ -747,7 +747,7 @@ let dashboard_shell_http_json
        The payload compute runs status / agents / tasks / keepers /
        meta_cognition projections (the latter scans board_posts.jsonl and
        evaluates belief/tension/desire rules — frequently 8s+ on a hot
-       room).  Under cache miss this used to run inline on the calling
+       coord).  Under cache miss this used to run inline on the calling
        fiber's Eio main domain, blocking every other HTTP fiber for the
        duration — the same Eio cooperative scheduling violation that
        PRs #18991 / #18993 / #18994 / #19007 / #19015 / #19023 / #19024 /

--- a/lib/server/server_dashboard_http_core_batch.ml
+++ b/lib/server/server_dashboard_http_core_batch.ml
@@ -2,7 +2,7 @@
     [server_dashboard_http_core.ml] (godfile decomp).
 
     [dashboard_batch_json ?compact config] builds the operator
-    dashboard's all-in-one snapshot: room status, monitoring
+    dashboard's all-in-one snapshot: coord status, monitoring
     sub-feeds (board / governance / credentials / coord_state /
     executor / slots), alert thresholds, tasks list (filtered by
     [compact] flag — Done entries dropped when [compact=true]),

--- a/lib/server/server_dashboard_http_core_digest_refresh.ml
+++ b/lib/server/server_dashboard_http_core_digest_refresh.ml
@@ -6,7 +6,7 @@
     [operator_digest] surface into [Proactive_refresh.start] with the
     dashboard runtime's offloaded-readonly compute path. Each cycle
     invokes [Operator_control.digest_json ~actor:"dashboard"
-    ~target_type:"root"] under a fresh [Operator_control.context],
+    ~target_type:"coord"] under a fresh [Operator_control.context],
     decorates the result with [with_projection_diagnostics] /
     [with_operator_digest_metadata], and republishes via
     [!operator_digest_broadcast_ref].
@@ -64,7 +64,7 @@ let start_operator_digest_refresh_loop ~state ~sw ~clock =
              }
            in
            match
-             Operator_control.digest_json ~actor:"dashboard" ~target_type:"root" ctx
+             Operator_control.digest_json ~actor:"dashboard" ~target_type:"coord" ctx
            with
            | Ok json ->
              Core_cache.with_projection_diagnostics

--- a/lib/server/server_dashboard_http_core_operator.ml
+++ b/lib/server/server_dashboard_http_core_operator.ml
@@ -24,7 +24,7 @@ let operator_actor_hint request =
    every ~18s worst-case, which is acceptable for dashboard SSE polling. *)
 
 (* Late-bound broadcast refs — set by server_dashboard_http.ml after
-   Sse module is in scope.  Same pattern as _broadcast_room_truth_ref. *)
+   Sse module is in scope.  Same pattern as _broadcast_coord_truth_ref. *)
 let operator_snapshot_broadcast_ref : (Yojson.Safe.t -> unit) ref =
   ref (fun (_json : Yojson.Safe.t) -> ())
 ;;

--- a/lib/server/server_dashboard_http_core_operator_digest_http.ml
+++ b/lib/server/server_dashboard_http_core_operator_digest_http.ml
@@ -58,10 +58,10 @@ let operator_digest_http_json ~state ~sw ~clock request =
   let root_target_type value =
     match Option.map (fun raw -> String.lowercase_ascii (String.trim raw)) value with
     | None -> true
-    | Some "root" -> true
+    | Some "coord" -> true
     | Some _ -> false
   in
-  let effective_target_type = Option.value ~default:"root" target_type in
+  let effective_target_type = Option.value ~default:"coord" target_type in
   let default_namespace_request =
     actor = None
     && target_id = None

--- a/lib/server/server_dashboard_http_core_operator_query.ml
+++ b/lib/server/server_dashboard_http_core_operator_query.ml
@@ -140,6 +140,6 @@ let operator_digest_default_query () =
     ~target_type:None
     ~target_id:None
     ~include_workers:None
-    ~effective_target_type:"root"
+    ~effective_target_type:"coord"
     ~default_namespace_request:true
 ;;

--- a/lib/server/server_dashboard_http_execution_surfaces.ml
+++ b/lib/server/server_dashboard_http_execution_surfaces.ml
@@ -17,7 +17,7 @@ let transport_health_timeout_max_s = 30.0
 (* Routed through Env_config_runtime.Dashboard so operators can raise
    the ceiling on slow-disk deployments without a rebuild. The outer
    wrapper at [server_runtime_bootstrap.ml] uses the matching
-   [shell_prewarm_outer_timeout_sec] env to keep the 5s headroom. *)
+   [shell_prewarm_outer_timeout_sec] env to keep the 5s headcoord. *)
 let shell_prewarm_timeout_s = Env_config_runtime.Dashboard.shell_prewarm_inner_timeout_sec
 
 let warm_shell_cache (state : Mcp_server.server_state) =

--- a/lib/server/server_dashboard_http_execution_surfaces.mli
+++ b/lib/server/server_dashboard_http_execution_surfaces.mli
@@ -132,7 +132,7 @@ val start_execution_refresh_loop :
 (** Forks the per-process execution-cache refresh fiber.
     Idempotent.  Default refresh interval keeps timeout
     < interval (60 s) so [Proactive_refresh]'s clamp
-    leaves room for the first build window after boot. *)
+    leaves coord for the first build window after boot. *)
 
 val start_transport_health_refresh_loop :
   state:Mcp_server.server_state ->

--- a/lib/server/server_dashboard_http_namespace_truth_support.ml
+++ b/lib/server/server_dashboard_http_namespace_truth_support.ml
@@ -67,7 +67,7 @@ let dashboard_namespace_truth_focus_json ~initialized ~runtime_count
     let target_id = json_string_field_opt "target_id" top_item in
   let source, target_kind, suggested_tab, suggested_surface, suggested_params =
       match target_type with
-      | Some "room_meta_cognition" | Some "namespace_meta_cognition" ->
+      | Some "coord_meta_cognition" | Some "namespace_meta_cognition" ->
           ( "meta_cognition",
             "meta_cognition",
             "overview",
@@ -204,7 +204,7 @@ let severity_of_meta_salience = function
   | Meta_cognition.Operator_tension -> "bad"
   | Meta_cognition.Contested_belief
   | Meta_cognition.Operator_desire
-  | Meta_cognition.Stagnant_room -> "warn"
+  | Meta_cognition.Stagnant_coord -> "warn"
   | Meta_cognition.Stable -> "info"
 
 let derived_meta_attention_item ~meta_cognition_json
@@ -688,7 +688,7 @@ let derive_readiness_and_attention ~execution_json ~execution_summary
         ~key:"operational_clarity"
         ~label:"Operational Clarity"
         ~status:operational_clarity_status
-        ~ok_message:"The control room has recent audit anchors and no open attention backlog."
+        ~ok_message:"The control coord has recent audit anchors and no open attention backlog."
         ~reasons:operational_clarity_reasons
         ~metrics:
           [
@@ -902,7 +902,7 @@ let compose_namespace_truth_snapshot ~(config : Coord.config) ~initialized ~shel
     (namespace_truth_metadata_fields ~config ~generated_at
      @ [
          ("generated_at", `String generated_at);
-        ("root", namespace_block);
+        ("coord", namespace_block);
         ( "execution",
         `Assoc
           [

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -935,7 +935,7 @@ let runtime_resolution_json (config : Coord.config) =
   in
   let add_repair_warning acc =
     if repair_count > 0
-    then Printf.sprintf "Recent room-state repair events detected (%d)." repair_count :: acc
+    then Printf.sprintf "Recent coord-state repair events detected (%d)." repair_count :: acc
     else acc
   in
   let add_agent_issue_warning acc =

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -872,9 +872,9 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
           h2_respond_json_value h2_reqd json ~extra_headers:cors
 
       | `GET, "/api/v1/namespace/current"
-      | `GET, "/api/v1/room/current"
+      | `GET, "/api/v1/coord/current"
       | `POST, "/api/v1/namespace/current"
-      | `POST, "/api/v1/room/current" ->
+      | `POST, "/api/v1/coord/current" ->
           h2_respond_removed_surface h2_reqd ~surface:"namespace" ~extra_headers:cors
 
       | `POST, p when String.starts_with ~prefix:"/api/v1/command-plane" p ->

--- a/lib/server/server_mcp_transport_http_agui.ml
+++ b/lib/server/server_mcp_transport_http_agui.ml
@@ -49,7 +49,7 @@ let handle_ag_ui_events ~deps request reqd =
   let origin = deps.get_origin request in
   let session_id = Mcp_session.get_or_generate (get_session_id_any request) in
   let protocol_version = get_protocol_version_for_session ~session_id request in
-  (* room query param ignored — namespace retired *)
+  (* coord query param ignored — namespace retired *)
   let last_event_id =
     match Httpun.Headers.get (request : Httpun.Request.t).headers "last-event-id" with
     | Some id -> (int_of_string_opt (id))

--- a/lib/server/server_routes_http_common.ml
+++ b/lib/server/server_routes_http_common.ml
@@ -258,7 +258,7 @@ let handle_presence_events request reqd =
    Executor_pool ([Domain_pool_ref.submit_io_or_inline]). ~20 routes inline
    this 2-call nesting; ~28 dashboard GET routes still omit it and recompute
    uncached on the main HTTP domain per request. The uncached ones (e.g.
-   /branches spawning `git branch`, /rooms querying up to 1000 messages,
+   /branches spawning `git branch`, /coords querying up to 1000 messages,
    /status) head-of-line-block other requests when a dashboard page fires
    many calls in parallel — a 12-way parallel probe converged every endpoint
    (incl. ms-cached ones) to ~3.4s because the uncached handlers held the

--- a/lib/server/server_routes_http_dashboard_handlers.ml
+++ b/lib/server/server_routes_http_dashboard_handlers.ml
@@ -102,7 +102,7 @@ let handle_dashboard_workspace state req reqd =
      (uncached, ~4.7s measured solo; under a parallel dashboard burst it held
      the single Eio HTTP domain and dragged co-fired requests to ~3.4s). Cache
      + offload via respond_cached_read; cache_key carries limit + actor so
-     param variants stay distinct. Shared by /dashboard/workspace and /rooms. *)
+     param variants stay distinct. Shared by /dashboard/workspace and /coords. *)
   let cache_key =
     Printf.sprintf "workspace:%s:%d:%s"
       state.Mcp_server.coord_config.base_path limit

--- a/lib/server/server_routes_http_pages.ml
+++ b/lib/server/server_routes_http_pages.ml
@@ -113,7 +113,7 @@ let graphql_playground_html ~nonce =
       </svg>
       <div class="text">Loading <strong>GraphQL Playground</strong></div>
     </div>
-    <div id="root"></div>
+    <div id="coord"></div>
     <script nonce="|};
     nonce;
     {|">
@@ -122,7 +122,7 @@ let graphql_playground_html ~nonce =
         if (loading) {
           loading.classList.add("fadeOut");
         }
-        var root = document.getElementById("root");
+        var root = document.getElementById("coord");
         if (!root) {
           return;
         }
@@ -431,7 +431,7 @@ let keepers_summary_from_registry ~base_path
   K.{
     keepers;
     cycle;
-    room = Some (Filename.basename base_path);
+    coord = Some (Filename.basename base_path);
     generated_at = Masc_domain.now_iso ();
   }
 

--- a/test/test_dashboard_briefing.ml
+++ b/test/test_dashboard_briefing.ml
@@ -71,7 +71,7 @@ let write_pending_confirm config _session_id =
           ];
       ])
 
-let seed_room config session_id =
+let seed_coord config session_id =
   ignore (Lib.Coord.init config ~agent_name:(Some "fixture-root"));
   ignore (Lib.Coord.join config ~agent_name:"mission-local64-smoke"
             ~capabilities:[ "operator"; "fixture"; "local64" ] ());
@@ -90,7 +90,7 @@ let seed_room config session_id =
     (Lib.Coord.broadcast config ~from_agent:"llama-local-alpha"
        ~content:"Spawned worker recovered partial role coverage and runtime visibility.");
 
-  (* Team sessions are retired; mission fixtures now exercise room-level
+  (* Team sessions are retired; mission fixtures now exercise coord-level
      attention and worker/keeper signals without persisting session records. *)
   ignore session_id;
   write_pending_confirm config session_id
@@ -103,7 +103,7 @@ let test_dashboard_briefing_projection () =
       let session_id = "ts-mission-fixture-001" in
       with_test_env @@ fun ~clock ~sw ->
       let config = Coord_utils.default_config dir in
-      seed_room config session_id;
+      seed_coord config session_id;
       (* Simulate delta departing: remove agent file so Dashboard_briefing
          sees delta as departed. *)
       let delta_path =
@@ -163,15 +163,15 @@ let test_dashboard_briefing_projection () =
         (internal_signals
          |> List.exists (fun row ->
               contains (row |> member "summary" |> to_string) "pending confirmation"));
-      (* room broadcast actions require microarch signal tones "warn"/"bad",
+      (* coord broadcast actions require microarch signal tones "warn"/"bad",
          which need non-empty command-plane operations. In a clean test
-         fixture all 9 signals default to "ok", so room_recommendations
+         fixture all 9 signals default to "ok", so coord_recommendations
          returns []. Verify internal_signals carries the pending-confirm
-         incident instead — that is the reachable room-level signal. *)
-      check bool "internal signals are room-scoped" true
+         incident instead — that is the reachable coord-level signal. *)
+      check bool "internal signals are coord-scoped" true
         (internal_signals
          |> List.for_all (fun row ->
-              row |> member "target_type" |> to_string = "root")))
+              row |> member "target_type" |> to_string = "coord")))
 
 let test_dashboard_briefing_http_full_contract () =
   let dir = test_dir () in
@@ -181,7 +181,7 @@ let test_dashboard_briefing_http_full_contract () =
       let session_id = "ts-mission-http-fixture-001" in
       with_test_env @@ fun ~clock ~sw ->
       let config = Coord_utils.default_config dir in
-      seed_room config session_id;
+      seed_coord config session_id;
       (* Clear stale cache entries from prior tests to avoid cross-test pollution.
          Both dashboard-level and operator snapshot caches must be invalidated. *)
       Lib.Dashboard_cache.invalidate_all ();
@@ -210,7 +210,7 @@ let test_dashboard_briefing_http_default_bootstraps_first_success () =
       with_test_env @@ fun ~clock ~sw ->
       let config = Coord_utils.default_config dir in
       let session_id = "ts-mission-http-default-001" in
-      seed_room config session_id;
+      seed_coord config session_id;
       let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
       let json =
         Lib.Server_dashboard_http.dashboard_briefing_http_json
@@ -227,7 +227,7 @@ let test_dashboard_briefing_http_default_bootstraps_first_success () =
         (json |> member "projection_diagnostics" |> member "last_success_at"
          <> `Null);
       check bool "default mission leaves initializing placeholder" true
-        (json |> member "summary" |> member "room_health" |> to_string
+        (json |> member "summary" |> member "coord_health" |> to_string
          <> "initializing");
       check bool "mission summary namespace_id removed" true
         (json |> member "summary" |> member "namespace_id" = `Null);
@@ -242,7 +242,7 @@ let test_dashboard_briefing_keeper_tool_audit_fallback () =
       let session_id = "ts-mission-http-default-001" in
       with_test_env @@ fun ~clock ~sw ->
       let config = Coord_utils.default_config dir in
-      seed_room config session_id;
+      seed_coord config session_id;
       Lib.Dashboard_cache.invalidate_all ();
       Lib.Operator_control.invalidate_snapshot_cache ();
       let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
@@ -261,7 +261,7 @@ let test_dashboard_briefing_keeper_tool_audit_fallback () =
         (json |> member "projection_diagnostics" |> member "last_success_at"
          <> `Null);
       check bool "default mission leaves initializing placeholder" true
-        (json |> member "summary" |> member "room_health" |> to_string
+        (json |> member "summary" |> member "coord_health" |> to_string
          <> "initializing");
       check bool "mission summary namespace_id removed" true
         (json |> member "summary" |> member "namespace_id" = `Null);
@@ -282,8 +282,8 @@ let test_dashboard_briefing_http_cache_isolation () =
       with_test_env @@ fun ~clock ~sw ->
       let config_a = Coord_utils.default_config dir_a in
       let config_b = Coord_utils.default_config dir_b in
-      seed_room config_a session_a;
-      seed_room config_b session_b;
+      seed_coord config_a session_a;
+      seed_coord config_b session_b;
       let state_a =
         Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir_a ()
       in
@@ -308,9 +308,9 @@ let test_dashboard_briefing_http_cache_isolation () =
           request
       in
       let open Yojson.Safe.Util in
-      check bool "first room namespace_id removed" true
+      check bool "first coord namespace_id removed" true
         (json_a |> member "summary" |> member "namespace_id" = `Null);
-      check bool "second room namespace_id removed" true
+      check bool "second coord namespace_id removed" true
         (json_b |> member "summary" |> member "namespace_id" = `Null))
 
 let test_dashboard_briefing_keeper_tool_audit_prefers_heartbeat_task () =
@@ -485,7 +485,7 @@ let () =
             `Quick test_dashboard_briefing_http_default_bootstraps_first_success;
           Alcotest.test_case "keeper tool audit fallback" `Quick
             test_dashboard_briefing_keeper_tool_audit_fallback;
-          Alcotest.test_case "http mission cache stays room-scoped" `Quick
+          Alcotest.test_case "http mission cache stays coord-scoped" `Quick
             test_dashboard_briefing_http_cache_isolation;
           Alcotest.test_case "keeper brief prefers heartbeat task" `Quick
             test_dashboard_briefing_keeper_tool_audit_prefers_heartbeat_task;

--- a/test/test_dashboard_briefing_sections.ml
+++ b/test/test_dashboard_briefing_sections.ml
@@ -367,7 +367,7 @@ let test_build_briefing_sections_demotes_metadata_only_communication () =
   let briefing_summary_json =
     `Assoc
       [
-        ("room_health", `String "ok");
+        ("coord_health", `String "ok");
         ("incident_count", `Int 0);
         ("recommended_action_count", `Int 0);
         ("top_attention_summary", `String "");
@@ -401,7 +401,7 @@ let test_build_briefing_sections_keeps_metadata_evidence_visible () =
   let briefing_summary_json =
     `Assoc
       [
-        ("room_health", `String "ok");
+        ("coord_health", `String "ok");
         ("incident_count", `Int 0);
         ("recommended_action_count", `Int 0);
         ("top_attention_summary", `String "");
@@ -462,7 +462,7 @@ let test_build_briefing_sections_watch_evidence_uses_namespace_wording () =
   let briefing_summary_json =
     `Assoc
       [
-        ("room_health", `String "bad");
+        ("coord_health", `String "bad");
         ("incident_count", `Int 0);
         ("recommended_action_count", `Int 0);
         ("top_attention_summary", `String "");

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -355,7 +355,7 @@ let test_lightweight_snapshot_surfaces_paused_keeper_runtime_trust () =
       cleanup_dir base_dir)
     (fun () ->
       let config = Coord.default_config base_dir in
-      (* See: this fixture only needs an initialized room for digest reads. *)
+      (* See: this fixture only needs an initialized coord for digest reads. *)
       ignore (Coord.init config ~agent_name:(Some "operator"));
       let meta =
         match
@@ -483,7 +483,7 @@ let test_lightweight_snapshot_surfaces_paused_keeper_runtime_trust () =
       Alcotest.(check string) "full paused pipeline" "paused"
         (full_keeper |> member "pipeline_stage" |> to_string))
 
-let test_digest_room_includes_keeper_runtime_attention () =
+let test_digest_coord_includes_keeper_runtime_attention () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
   Eio.Switch.run @@ fun sw ->
@@ -689,7 +689,7 @@ let test_snapshot_has_expected_sections () =
       ignore (Coord.add_task config ~title:"operator backlog" ~priority:2 ~description:"");
       ignore (Coord.broadcast config ~from_agent:"owner" ~content:"operator snapshot seed");
       let json = Operator_control.snapshot_json (operator_ctx env sw config "owner") in
-      let root = Yojson.Safe.Util.member "root" json in
+      let root = Yojson.Safe.Util.member "coord" json in
       Alcotest.(check bool) "root block present" true
         (root <> `Null);
       Alcotest.(check bool) "root initialized" true
@@ -753,7 +753,7 @@ let test_snapshot_pending_confirm_summary_tracks_actor_scope () =
               [
                 ("actor", `String actor);
                 ("action_type", `String "namespace_pause");
-                ("target_type", `String "root");
+                ("target_type", `String "coord");
               ])
         with
         | Ok _ -> ()
@@ -1221,9 +1221,9 @@ let test_snapshot_waiter_returns_stale_inflight_result () =
       Alcotest.(check bool) "stale waiter does not replace owner" true
         still_computing)
 
-(* test_orchestra_room_core_shape removed (CP purge: Command_plane_orchestra deleted) *)
+(* test_orchestra_coord_core_shape removed (CP purge: Command_plane_orchestra deleted) *)
 
-let test_digest_room_exposes_pending_confirm_attention () =
+let test_digest_coord_exposes_pending_confirm_attention () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
   Eio.Switch.run @@ fun sw ->
@@ -1240,7 +1240,7 @@ let test_digest_room_exposes_pending_confirm_attention () =
             [
               ("actor", `String "operator");
                ("action_type", `String "namespace_pause");
-               ("target_type", `String "root");
+               ("target_type", `String "coord");
             ])
       in
       (match action_json with Ok _ -> () | Error err -> Alcotest.fail err);
@@ -1249,7 +1249,7 @@ let test_digest_room_exposes_pending_confirm_attention () =
         | Ok json -> json
         | Error err -> Alcotest.fail err
       in
-      Alcotest.(check string) "target_type" "root"
+      Alcotest.(check string) "target_type" "coord"
         Yojson.Safe.Util.(digest |> member "target_type" |> to_string);
       Alcotest.(check string) "health" "warn"
         Yojson.Safe.Util.(digest |> member "health" |> to_string);
@@ -1269,8 +1269,8 @@ let test_digest_room_exposes_pending_confirm_attention () =
                Yojson.Safe.Util.(item |> member "provenance" |> to_string))
            attention_items);
       (* command_* attention items only appear when microarch signals
-         are warn/bad; in a fresh room they are absent *)
-      Alcotest.(check bool) "no command attention in fresh room" true
+         are warn/bad; in a fresh coord they are absent *)
+      Alcotest.(check bool) "no command attention in fresh coord" true
         (not
            (List.exists
               (fun item ->
@@ -1279,7 +1279,7 @@ let test_digest_room_exposes_pending_confirm_attention () =
                   Yojson.Safe.Util.(item |> member "kind" |> to_string))
               attention_items)))
 
-let test_digest_room_includes_tool_host_failure_attention () =
+let test_digest_coord_includes_tool_host_failure_attention () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
   Eio.Switch.run @@ fun sw ->


### PR DESCRIPTION
## Summary
- rename Operator_control_snapshot_room module/file to Operator_control_snapshot_coord
- rename room_json to coord_json
- move operator snapshot payload key from root/room fallback to coord
- update dashboard briefing/operator digest consumers and tests to the coord target naming

## Validation
- residue scan: no Operator_control_snapshot_room/operator_control_snapshot_room/room_json/member_assoc room-root projection identifiers remain in operator/dashboard/server target scope
- build not run; build breakage accepted for this hard-cut cleanup slice