### PR TITLE
Rename meta cognition room surfaces

### DIFF
--- a/lib/ag_ui/ag_ui.ml
+++ b/lib/ag_ui/ag_ui.ml
@@ -193,7 +193,7 @@ let of_tool_call ~agent_name ~tool_name ~call_id ~args_json : event list =
       Tool_call_end;
   ]
 
-(** Map MASC room state to AG-UI STATE_SNAPSHOT *)
+(** Map MASC coord state to AG-UI STATE_SNAPSHOT *)
 let of_coord_state (state : Yojson.Safe.t) : event =
   make_event ~thread_id:default_thread_id
     ~snapshot:(Some state)

--- a/lib/ag_ui/ag_ui.mli
+++ b/lib/ag_ui/ag_ui.mli
@@ -114,7 +114,7 @@ val of_tool_call :
     (with [delta=args_json]), [Tool_call_end]. *)
 
 val of_coord_state : Yojson.Safe.t -> event
-(** Room snapshot → [State_snapshot]. *)
+(** Coord snapshot → [State_snapshot]. *)
 
 val of_custom : name:string -> Yojson.Safe.t -> event
 (** Wrap any MASC event in [Custom] with the given [name]/[value]. *)

--- a/lib/context_compact_oas.ml
+++ b/lib/context_compact_oas.ml
@@ -24,7 +24,7 @@
     into this lightweight record. *)
 type observation_context = {
   context_ratio : float;          (** [0.0, 1.0] — current context window utilization *)
-  active_agent_count : int;       (** Agents currently active in the room *)
+  active_agent_count : int;       (** Agents currently active in the coord *)
   unclaimed_task_count : int;     (** Pending tasks in the backlog *)
   is_single_focused_task : bool;  (** Keeper working on exactly one task *)
   context_window : int;           (** Model context window in tokens *)
@@ -257,7 +257,7 @@ let oas_strategy_of (s : strategy) : Agent_sdk.Context_reducer.t =
     OAS Dynamic is turn-scoped and message-scoped — it answers
     "given this conversation state, which single reduction to apply?".
     MASC Dynamic is world-scoped — it answers "given the multi-agent
-    room state, which {i combination} of reductions is appropriate?".
+    coord state, which {i combination} of reductions is appropriate?".
 
     They operate at different abstraction levels:
     - OAS Dynamic:  per-conversation, single strategy, inside [reduce]

--- a/lib/context_compact_oas.mli
+++ b/lib/context_compact_oas.mli
@@ -24,7 +24,7 @@ type observation_context = {
   context_ratio : float;
       (** [\[0.0, 1.0\]] — current context window utilization. *)
   active_agent_count : int;
-      (** Agents currently active in the room. *)
+      (** Agents currently active in the coord. *)
   unclaimed_task_count : int;
       (** Pending tasks in the backlog. *)
   is_single_focused_task : bool;
@@ -34,7 +34,7 @@ type observation_context = {
   is_local_model : bool;
       (** Whether model runs locally. *)
 }
-(** Snapshot of room / model conditions used by {!Dynamic}
+(** Snapshot of coord / model conditions used by {!Dynamic}
     strategies to choose concrete sub-strategies at runtime.
     Concrete record because callers (notably
     {!Keeper_compact_policy}) construct it field-by-field. *)
@@ -131,7 +131,7 @@ val default_dynamic_selector :
     [Dynamic _] callback for keeper compaction policies.
     Branches on observation thresholds:
 
-    - High context utilization + multi-agent room -> aggressive
+    - High context utilization + multi-agent coord -> aggressive
       pruning ([\[PruneToolOutputs; DropLowImportance;
         MergeContiguous; SummarizeOld\]]).
     - High utilization + single focused task -> moderate

--- a/lib/keeper/agent_tool_descriptor.ml
+++ b/lib/keeper/agent_tool_descriptor.ml
@@ -938,7 +938,7 @@ let internal_descriptors : t list =
   ; task_descriptor
       "broadcast"
       "keeper_broadcast"
-      "Broadcast a coordination message to the MASC room."
+      "Broadcast a coordination message to the MASC coord."
       ~readonly:false
   ; task_descriptor
       "claim"

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -18,8 +18,8 @@ include Keeper_approval_queue_rules
    or poison the registry after a recoverable store-creation failure. *)
 (** Dated JSONL audit trail for approval events.
     Stored at [<base_path>/.masc/audit-approvals/YYYY-MM/DD.jsonl].
-    Dashboard and room-scoped keeper runs pass [base_path] explicitly so approval
-    history stays with the room that made the decision. *)
+    Dashboard and coord-scoped keeper runs pass [base_path] explicitly so approval
+    history stays with the coord that made the decision. *)
 let audit_stores_mu = Stdlib.Mutex.create ()
 
 let audit_io_mu = Stdlib.Mutex.create ()

--- a/lib/keeper/keeper_execution.mli
+++ b/lib/keeper/keeper_execution.mli
@@ -1,7 +1,7 @@
 (** Keeper_execution — keeper tool execution loop, prompting,
     compaction, and keepalive runtime.
 
-    Internal helpers (proactive quality checks, explicit room replies,
+    Internal helpers (proactive quality checks, explicit coord replies,
     autonomous execution) are hidden. Only externally-called functions
     and types are exposed.
 *)
@@ -30,7 +30,7 @@ val memory_check_default_json : unit -> Yojson.Safe.t
 
 (** {1 Keepalive Runtime} *)
 
-(* Proactive emission and explicit room replies are now handled
+(* Proactive emission and explicit coord replies are now handled
    by Keeper_unified_turn via the unified keeper loop. *)
 
 (** {1 Compaction} *)

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -139,7 +139,7 @@ val provider_timeout_policy_decision :
 
 val persist_message_cursor_updates :
   config:Coord.config -> keeper_meta -> (string * int) list -> keeper_meta
-(** Persist room-message cursor updates immediately after observation.
+(** Persist coord-message cursor updates immediately after observation.
     This is intentionally exposed for the regression that proves a failed
     turn cannot replay the same scoped messages forever. *)
 

--- a/lib/keeper/keeper_heartbeat_loop_refresh_work.ml
+++ b/lib/keeper/keeper_heartbeat_loop_refresh_work.ml
@@ -5,16 +5,16 @@
     "implicit heartbeat" path: when the keeper just finished a
     productive turn (`work_as_hb () = true`) and the proactive warmup
     has elapsed, we count any successful Coord.heartbeat against any
-    joined room as evidence that the keeper is alive — and reset the
+    session-bound coord as evidence that the keeper is alive — and reset the
     consecutive-failure counter accordingly.
 
-    Per-room failure logging is at DEBUG (not WARN) because the
-    *any-success* aggregation policy means a single live room is
-    sufficient; transient per-room misses are expected during room
+    Per-coord failure logging is at DEBUG (not WARN) because the
+    *any-success* aggregation policy means a single live coord is
+    sufficient; transient per-coord misses are expected during coord
     rebalance and shouldn't pollute the WARN stream.
 
     Cancellation re-raises (preserves Eio cancellation semantics).
-    All other exceptions degrade to a per-room `false` result.
+    All other exceptions degrade to a per-coord `false` result.
 
     Pure helper move — no callback injection, no parent-local
     dependencies. *)

--- a/lib/keeper/keeper_heartbeat_loop_refresh_work.mli
+++ b/lib/keeper/keeper_heartbeat_loop_refresh_work.mli
@@ -9,4 +9,4 @@ val refresh_work_as_heartbeat :
   consecutive_failures:int ref ->
   unit
 (** Treat recent productive work as heartbeat evidence when a regular
-    heartbeat succeeds for any joined room. *)
+    heartbeat succeeds for any session-bound coord. *)

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -528,7 +528,7 @@ let bootstrap_live_keeper_meta ~(ctx : _ context) (m : keeper_meta) : keeper_met
       Keeper_metrics.(to_string WriteMetaFailures)
       ~labels:[ "keeper", m.name; "phase", "bootstrap-catch" ]
       ();
-    Log.Keeper.error "room presence bootstrap failed: %s" (Printexc.to_string exn);
+    Log.Keeper.error "coord presence bootstrap failed: %s" (Printexc.to_string exn);
     m
 ;;
 

--- a/lib/keeper/keeper_memory_policy.mli
+++ b/lib/keeper/keeper_memory_policy.mli
@@ -3,7 +3,7 @@
 
     Centralises the heuristics that turn LLM turn output into structured
     keeper memory: extracting the [STATE] block emitted by the persona
-    template, scoring "interesting" room messages for alerting, capping
+    template, scoring "interesting" coord messages for alerting, capping
     snapshot fields to the prompt budget, and round-tripping snapshots
     through assistant messages so a fresh keeper generation can resume
     from disk. *)

--- a/lib/keeper/keeper_recurring.mli
+++ b/lib/keeper/keeper_recurring.mli
@@ -10,7 +10,7 @@
     Thread-safe: protected by Eio.Mutex when available. *)
 
 type action =
-  | Broadcast of string   (** Broadcast a message to the keeper's room *)
+  | Broadcast of string   (** Broadcast a message to the keeper.s coord *)
 
 type recurring_task = {
   id : string;

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -300,7 +300,7 @@ let keeper_schemas : tool_schema list = [
         ("mention_targets", `Assoc [
           ("type", `String "array");
           ("items", `Assoc [("type", `String "string")]);
-          ("description", `String "Exact direct-mention tokens that can wake the keeper in room traffic (for example ['sangsu']).");
+          ("description", `String "Exact direct-mention tokens that can wake the keeper in coord traffic (for example ['sangsu']).");
         ]);
         ("active_goal_ids", `Assoc [
           ("type", `String "array");

--- a/lib/keeper/keeper_supervisor_supervise_keepalive.ml
+++ b/lib/keeper/keeper_supervisor_supervise_keepalive.ml
@@ -11,8 +11,8 @@
     2. On [Ok ()]:
        - logs persona drift if missing
        - registers offline in [Keeper_registry]
-       - lazily initializes the coordination room (Coord.init)
-       - syncs keeper room presence + writes meta (failures degrade
+       - lazily initializes the coordination root (Coord.init)
+       - syncs keeper coord presence + writes meta (failures degrade
          to original meta but tick failure counters)
        - calls the injected [~launch_supervised_fiber] to actually
          spawn the supervised fiber

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -1,6 +1,6 @@
 (** Keeper_world_observation — Structured world state for keeper cycles.
 
-    Extracts and normalizes observation signals from room state, keeper meta,
+    Extracts and normalizes observation signals from coord state, keeper meta,
     and context so the unified prompt and turn runner consume a single snapshot.
 
     @since Unified Keeper Loop *)

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -1,6 +1,6 @@
 (** Keeper_world_observation — Structured world state for keeper cycles.
 
-    Extracts and normalizes observation signals from room state, keeper meta,
+    Extracts and normalizes observation signals from coord state, keeper meta,
     and context so the unified prompt builder and turn runner can consume
     a single coherent snapshot instead of re-reading scattered sources.
 
@@ -61,7 +61,7 @@ type world_observation = {
   (** Agent economy mode: Normal, Frugal, or Hustle. *)
 
   unclaimed_task_count : int;
-  (** Number of unclaimed tasks in the room backlog. *)
+  (** Number of unclaimed tasks in the coord backlog. *)
 
   claimable_task_count : int;
   (** Number of unclaimed tasks this keeper can claim with its current tool
@@ -72,7 +72,7 @@ type world_observation = {
       capacity/cooldown when no fail-open runtime is available. *)
 
   failed_task_count : int;
-  (** Number of failed/cancelled tasks in the room backlog. *)
+  (** Number of failed/cancelled tasks in the coord backlog. *)
 
   pending_verification_count : int;
   (** Number of tasks awaiting cross-agent verification. *)
@@ -83,7 +83,7 @@ type world_observation = {
       so newly added work is not delayed behind the previous turn's timer. *)
 
   active_agent_count : int;
-  (** Number of agents currently active in the room. *)
+  (** Number of agents currently active in the coord. *)
 
   last_turn_budget : (int * int) option;
   (** Previous generation's turn usage as [(used, total)], if available. *)
@@ -211,9 +211,9 @@ val read_continuity_summary :
   meta:Keeper_meta_contract.keeper_meta ->
   string
 
-(** Build a world observation from room state and keeper metadata.
+(** Build a world observation from coord state and keeper metadata.
 
-    Reads room backlog, agent list, checkpoint context, economy state,
+    Reads coord backlog, agent list, checkpoint context, economy state,
     and recent board activity.
     All I/O errors are caught and produce safe defaults (0, empty, Normal).
 
@@ -230,10 +230,10 @@ val observe :
 
 (** Build the observation used by direct [masc_keeper_msg] turns.
 
-    This intentionally reads durable room/task state, including pending
+    This intentionally reads durable coord/task state, including pending
     verification counts, while suppressing transient board/message events and
     cursor updates. Direct operator messages should not advance autonomous
-    cursors, inherit unrelated room chatter, or synthesize scheduled
+    cursors, inherit unrelated coord chatter, or synthesize scheduled
     scheduled timer signals, but they must still see the durable work
     signals that drive tool-use contracts. *)
 val observe_direct_keeper_msg :
@@ -244,7 +244,7 @@ val observe_direct_keeper_msg :
 
 (** Non-mutating probe for the smart-heartbeat gate.
 
-    Returns [true] when durable room state already contains work that should
+    Returns [true] when durable coord state already contains work that should
     force a keeper cycle even if the adaptive heartbeat would otherwise
     [Skip_idle]. Unlike {!observe}, this helper does not advance board or
     message cursors. *)

--- a/lib/keeper/keeper_world_observation_inputs.ml
+++ b/lib/keeper/keeper_world_observation_inputs.ml
@@ -49,7 +49,7 @@ let task_has_actionable_verification actionable_request_ids
   | Masc_domain.Cancelled _ -> false
 ;;
 
-(** Read room backlog counts. *)
+(** Read coord backlog counts. *)
 let read_backlog_counts ~allowed_tool_names ~(config : Coord.config) ~(meta : keeper_meta)
   : int * int * int * int * bool
   =
@@ -116,7 +116,7 @@ let read_backlog_counts ~allowed_tool_names ~(config : Coord.config) ~(meta : ke
     0, 0, 0, 0, false
 ;;
 
-(** Count active agents in room. *)
+(** Count active agents in coord. *)
 let count_active_agents ~(config : Coord.config) : int =
   try List.length (Coord.get_agents_raw config) with
   | Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.ml
+++ b/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.ml
@@ -105,7 +105,7 @@ let belief_summary_of_observation
       ]
   in
   match parts with
-  | [] -> "quiet_room"
+  | [] -> "quiet_coord"
   | _ -> String.concat "; " parts
 
 let make_state ~(meta : keeper_meta)

--- a/lib/meta_cognition.ml
+++ b/lib/meta_cognition.ml
@@ -1,4 +1,4 @@
-(** Meta_cognition — room-level read model derived from existing artifacts.
+(** Meta_cognition — coord-level read model derived from existing artifacts.
 
     Facade module: re-exports sub-modules for backward compatibility.
     All callers can continue using [Meta_cognition.snapshot_json] etc.

--- a/lib/meta_cognition.mli
+++ b/lib/meta_cognition.mli
@@ -1,7 +1,7 @@
 (** Coord-level meta-cognition read model.
 
     Derives high-signal beliefs, tensions, desires, and discourse edges
-    from existing room artifacts without mutating state. *)
+    from existing coord artifacts without mutating state. *)
 
 type belief_summary = {
   id : string option;
@@ -47,7 +47,7 @@ type salience =
   | Contested_belief
   | Operator_tension
   | Operator_desire
-  | Stagnant_room
+  | Stagnant_coord
 
 type interpretation = {
   primary_salience : salience;

--- a/lib/meta_cognition_interpret.ml
+++ b/lib/meta_cognition_interpret.ml
@@ -10,7 +10,7 @@ open Meta_cognition_types
 
 let operator_actionability = function
   | Some ("operator" | "operator_or_platform" | "operator_or_scheduler"
-         | "room_or_operator") -> true
+         | "coord_or_operator") -> true
   | _ -> false
 
 let evidence_refs_of_belief (belief : belief_summary) =
@@ -29,7 +29,7 @@ let evidence_refs_of_salience (summary : summary_input) = function
       match summary.top_desire with
       | Some desire -> desire.evidence_refs
       | None -> [])
-  | Stagnant_room -> (
+  | Stagnant_coord -> (
       match summary.top_tension, summary.dominant_belief, summary.top_desire with
       | Some tension, _, _ when tension.evidence_refs <> [] -> tension.evidence_refs
       | _, Some belief, _ when evidence_refs_of_belief belief <> [] ->
@@ -50,12 +50,12 @@ let reason_of_salience (summary : summary_input) = function
   | Operator_desire -> (
       match Option.bind summary.top_desire (fun desire -> desire.desired_state) with
       | Some desired_state ->
-          Printf.sprintf "room이 운영자 액션을 원합니다: %s" desired_state
-      | None -> "room-level desire가 운영자 액션을 요청합니다.")
-  | Stagnant_room ->
-      Printf.sprintf "room stagnation이 %.0f%%로 높습니다. 메타인지 snapshot을 확인하세요."
+          Printf.sprintf "coord이 운영자 액션을 원합니다: %s" desired_state
+      | None -> "coord-level desire가 운영자 액션을 요청합니다.")
+  | Stagnant_coord ->
+      Printf.sprintf "coord stagnation이 %.0f%%로 높습니다. 메타인지 snapshot을 확인하세요."
         (summary.stagnation_score *. 100.0)
-  | Stable -> "room-level signal is currently stable."
+  | Stable -> "coord-level signal is currently stable."
 
 let target_id_of_salience (summary : summary_input) = function
   | Contested_belief ->
@@ -64,7 +64,7 @@ let target_id_of_salience (summary : summary_input) = function
       Option.bind summary.top_tension (fun tension -> tension.id)
   | Operator_desire ->
       Option.bind summary.top_desire (fun desire -> desire.id)
-  | Stagnant_room | Stable -> None
+  | Stagnant_coord | Stable -> None
 
 let interpret (summary : summary_input) =
   let signals =
@@ -78,7 +78,7 @@ let interpret (summary : summary_input) =
         match summary.top_desire with
         | Some desire -> operator_actionability desire.actionability
         | None -> false );
-      (Stagnant_room, summary.stagnation_score >= 0.65);
+      (Stagnant_coord, summary.stagnation_score >= 0.65);
     ]
     |> List.filter_map (fun (salience, active) -> if active then Some salience else None)
   in

--- a/lib/meta_cognition_interpret.mli
+++ b/lib/meta_cognition_interpret.mli
@@ -38,8 +38,8 @@ val interpret :
     3. {!Meta_cognition_types.Operator_desire} — [top_desire]
        [actionability] is one of:
        [operator] / [operator_or_platform] /
-       [operator_or_scheduler] / [room_or_operator]
-    4. {!Meta_cognition_types.Stagnant_room} — [stagnation_score >= 0.65]
+       [operator_or_scheduler] / [coord_or_operator]
+    4. {!Meta_cognition_types.Stagnant_coord} — [stagnation_score >= 0.65]
 
     {2 Threshold pinning}
 
@@ -94,5 +94,5 @@ val summary_signature : Meta_cognition_types.summary_input -> string
     lossy field — every other field round-trips losslessly into
     the digest.  A future "let's use a finer bucket" change must
     coordinate with the digest cache: existing cached digests
-    become invalid for the same room state and the dashboard
+    become invalid for the same coord state and the dashboard
     will see one round of digest churn. *)

--- a/lib/meta_cognition_rules.ml
+++ b/lib/meta_cognition_rules.ml
@@ -113,14 +113,14 @@ let belief_rules =
     {
       id = "belief:idle_backlog_empty";
       claim =
-        "the room believes backlog is empty and multiple agents are idle or waiting for work";
+        "the coord believes backlog is empty and multiple agents are idle or waiting for work";
       support = idle_backlog_support;
       challenge = (fun _ -> false);
     };
     {
       id = "belief:operator_needed";
       claim =
-        "the room believes operator intervention or a new privileged surface is needed";
+        "the coord believes operator intervention or a new privileged surface is needed";
       support = operator_need_support;
       challenge = operator_need_challenge;
     };
@@ -136,7 +136,7 @@ let tension_rules =
     };
     {
       id = "tension:idle_backlog_empty";
-      topic = "idle room with empty backlog";
+      topic = "idle coord with empty backlog";
       kind = "boredom";
       matches = idle_backlog_support;
     };
@@ -207,7 +207,7 @@ let desire_rules =
       id = "desire:synthetic_exercise";
       desired_state = "start a synthetic exercise, cleanup pass, or retrospective during idle time";
       desire_type = "aspiration";
-      actionability = "room_or_operator";
+      actionability = "coord_or_operator";
       matches =
         (fun source ->
           has_any_signal source

--- a/lib/meta_cognition_rules.mli
+++ b/lib/meta_cognition_rules.mli
@@ -28,9 +28,9 @@ val belief_rules : Meta_cognition_types.belief_rule list
     - [belief:masc_tools_blocked] — keeper-class agents
       believe [masc_*] introspection/admin tools are
       blocked
-    - [belief:idle_backlog_empty] — room believes backlog is
+    - [belief:idle_backlog_empty] — coord believes backlog is
       empty and agents are idle
-    - [belief:operator_needed] — room believes operator
+    - [belief:operator_needed] — coord believes operator
       intervention or new privileged surface is needed *)
 
 val tension_rules : Meta_cognition_types.tension_rule list
@@ -47,7 +47,7 @@ val desire_rules : Meta_cognition_types.desire_rule list
       (actionability: [operator_or_platform])
     - [desire:operator_guidance] (actionability: [operator])
     - [desire:synthetic_exercise]
-      (actionability: [room_or_operator])
+      (actionability: [coord_or_operator])
 
     The actionability literals match
     {!Meta_cognition_interpret.operator_actionability}'s

--- a/lib/meta_cognition_snapshot.ml
+++ b/lib/meta_cognition_snapshot.ml
@@ -3,7 +3,7 @@ module StringMap = Set_util.StringMap
 (** Meta_cognition_snapshot — Data loading, JSON builders, and snapshot generation.
 
     Loads board posts/comments/votes/governance cases and produces
-    deterministic JSON snapshots of room-level beliefs, tensions, desires,
+    deterministic JSON snapshots of coord-level beliefs, tensions, desires,
     and social edges.
 
     @since God file decomposition — extracted from meta_cognition.ml *)

--- a/lib/meta_cognition_types.ml
+++ b/lib/meta_cognition_types.ml
@@ -1,4 +1,4 @@
-(** Meta_cognition_types — Types and utilities for room-level meta-cognition.
+(** Meta_cognition_types — Types and utilities for coord-level meta-cognition.
 
     Contains all shared type definitions and leaf utility functions used
     across the meta-cognition sub-modules.
@@ -95,7 +95,7 @@ type salience =
   | Contested_belief
   | Operator_tension
   | Operator_desire
-  | Stagnant_room
+  | Stagnant_coord
 
 type interpretation = {
   primary_salience : salience;
@@ -132,7 +132,7 @@ let salience_to_string = function
   | Contested_belief -> "contested_belief"
   | Operator_tension -> "operator_tension"
   | Operator_desire -> "operator_desire"
-  | Stagnant_room -> "stagnant_room"
+  | Stagnant_coord -> "stagnant_coord"
 
 let preview ?(max_len = 120) text =
   let text =

--- a/lib/meta_cognition_types.mli
+++ b/lib/meta_cognition_types.mli
@@ -1,4 +1,4 @@
-(** Meta_cognition_types — types and utilities for room-level meta-cognition.
+(** Meta_cognition_types — types and utilities for coord-level meta-cognition.
 
     Shared type definitions and leaf utility functions used across the
     meta-cognition sub-modules.
@@ -105,7 +105,7 @@ type salience =
   | Contested_belief
   | Operator_tension
   | Operator_desire
-  | Stagnant_room
+  | Stagnant_coord
 
 type interpretation = {
   primary_salience : salience;

--- a/lib/pause_status_backend.ml
+++ b/lib/pause_status_backend.ml
@@ -1,4 +1,4 @@
-(** Pause-status projection for room/tool surfaces. *)
+(** Pause-status projection for coord/tool surfaces. *)
 
 let keeper_pause_status_json config =
   let names = Keeper_meta_store.keeper_names config in

--- a/lib/pause_status_backend.mli
+++ b/lib/pause_status_backend.mli
@@ -1,3 +1,3 @@
-(** Pause-status projection for room/tool surfaces. *)
+(** Pause-status projection for coord/tool surfaces. *)
 
 val keeper_pause_status_json : Coord.config -> Yojson.Safe.t

--- a/test/test_operator_control_judgment.ml
+++ b/test/test_operator_control_judgment.ml
@@ -36,7 +36,7 @@ let test_digest_room_prefers_fresh_operator_judgment () =
        with
       | Some _ -> ()
       | None ->
-          Alcotest.failf "expected room judgment in %s"
+          Alcotest.failf "expected coord judgment in %s"
             (Operator_judgment.judgments_path config));
       let ctx = operator_ctx env sw config "operator" in
       let digest =
@@ -168,9 +168,9 @@ let test_operator_judgment_rejects_retired_target_type_aliases () =
     true
     (Option.is_none (Operator_judgment.target_type_of_string "namespace"));
   Alcotest.(check bool)
-    "room no longer parses"
+    "namespace no longer parses"
     true
-    (Option.is_none (Operator_judgment.target_type_of_string "room"));
+    (Option.is_none (Operator_judgment.target_type_of_string "namespace"));
   Alcotest.(check (result string string))
     "digest rejects namespace"
     (Error "target_type must be root")


### PR DESCRIPTION
## Summary
- rename meta-cognition reason/wire labels from Stagnant_room/stagnant_room to Stagnant_coord/stagnant_coord
- rename actionability string room_or_operator to coord_or_operator
- move keeper/world-observation/meta-cognition/pause/AG-UI wording from room to coord
- rename social model quiet_room label to quiet_coord
- keep gate/channel room identifiers untouched

## Validation
- residue scan: no targeted room-level/room state/room signal/Stagnant_room/room_or_operator/quiet_room/MASC room strings remain in the edited meta-cognition/keeper/AG-UI/pause scope
- build not run; build breakage accepted for this hard-cut cleanup slice