### PR TITLE
Fix main build fallout after lifecycle collapse

### DIFF
--- a/docs/spec/02-types-and-invariants.md
+++ b/docs/spec/02-types-and-invariants.md
@@ -527,20 +527,19 @@ type agent_role = Worker | Admin
 
 ```ocaml
 type permission =
-  | CanInit | CanReset | CanJoin | CanLeave
+  | CanInit | CanReset
   | CanReadState | CanAddTask | CanClaimTask | CanCompleteTask
   | CanBroadcast
-  | CanOpenPortal | CanSendPortal
-  | CanVote | CanInterrupt | CanApprove
+  | CanOpenPortal | CanSendPortal | CanVote
   | CanAdmin
 ```
 
-17개 variant. 각 `agent_role`에 허용된 permission 목록:
+11개 variant. 각 `agent_role`에 허용된 permission 목록:
 
 | Role | Permissions |
 |------|------------|
-| Worker | `CanReadState`, `CanJoin`, `CanLeave`, `CanAddTask`, `CanClaimTask`, `CanCompleteTask`, `CanBroadcast`, `CanOpenPortal`, `CanSendPortal`, `CanVote` |
-| Admin | Worker + `CanInit`, `CanReset`, `CanInterrupt`, `CanApprove`, `CanAdmin` (전체) |
+| Worker | `CanReadState`, `CanAddTask`, `CanClaimTask`, `CanCompleteTask`, `CanBroadcast`, `CanOpenPortal`, `CanSendPortal`, `CanVote` |
+| Admin | Worker + `CanInit`, `CanReset`, `CanAdmin` (전체) |
 
 ### 9.3 Agent Credential
 

--- a/lib/coord/coord_init.ml
+++ b/lib/coord/coord_init.ml
@@ -12,6 +12,7 @@ open Coord_backlog
 
 (** Initialize MASC room *)
 let init config ~agent_name =
+  invalidate_initialized_cache ();
   (* Ensure root .masc structure exists even when initializing a non-default room. *)
   let root_dir = masc_root_dir config in
   let root_agents_dir = Filename.concat root_dir "agents" in
@@ -89,6 +90,7 @@ let init config ~agent_name =
       }
     in
     write_state config state;
+    invalidate_initialized_cache ();
     (* Preserve a migrated backlog when blocking bootstrap has already
        promoted legacy room state into the flattened root namespace. *)
     if not (path_exists config (backlog_path config))
@@ -160,5 +162,6 @@ let reset config =
       else Sys.remove path
     in
     rm_rf (masc_dir config);
+    invalidate_initialized_cache ();
     Printf.sprintf "MASC room reset! (.masc/ deleted at %s)" config.base_path)
 ;;

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -589,7 +589,7 @@ let execute_tool_eio
                       ~agent_name
                       (runtime_error_result
                          ~tool_name:name
-                         (Printf.sprintf "Unknown tool: %s (registry inconsistency)" name)))))))
+                         (Printf.sprintf "Unknown tool: %s (registry inconsistency)" name)))))
 ;;
 
 (* RFC-0182 §3.1 — register Tool_coord.dispatch with the dependency

--- a/lib/prometheus_builtin_metrics_part1.ml
+++ b/lib/prometheus_builtin_metrics_part1.ml
@@ -216,6 +216,7 @@ let register
     "Wall-clock unixtime of the most recent successful supervisor sweep beat (labels: \
      base_path).  Stale (> 2 × interval) means the sweep stalled."
     `Gauge;
+  add
     metric_tool_metrics_persist_dropped
     "Total JSONL records dropped by tool_metrics_persist because the bounded \
      write queue is full. No labels."

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -292,7 +292,7 @@ let explicit_metadata : (string * metadata) list =
         broadcast_tool );
     (* Catalog-owned permissions for split/lazily registered tool modules. *)
     ("masc_reset", reset_tool);
-    ("masc_start", join_tool);
+    ("masc_start", broadcast_tool);
     ("masc_task_history", read_state_tool);
     ("masc_add_task", add_task_tool);
     ("masc_batch_add_tasks", add_task_tool);

--- a/lib/tool_coord.ml
+++ b/lib/tool_coord.ml
@@ -576,7 +576,7 @@ let status_summary_string (ctx : context) =
   in
   Coord_status_rendering.status_summary_string
     ~ctx
-    ~session_bound
+    ~joined:session_bound
     ~actual_name
     ~credential_state
     ~credential_blocked

--- a/lib/tool_coord.mli
+++ b/lib/tool_coord.mli
@@ -47,8 +47,6 @@ type context = Coord_types.context =
     {!Coord_assertions} (the SSOT) and propagates here
     automatically. *)
 type assertion_kind = Coord_assertions.assertion_kind =
-  | Room_set
-  | Joined
   | Task_claimed
   | Current_task_set
 

--- a/lib/tool_schemas/tool_schemas_inline.ml
+++ b/lib/tool_schemas/tool_schemas_inline.ml
@@ -1,8 +1,8 @@
 (** MCP tool schemas for inline-dispatched tools.
     Split into sub-modules by functional group. *)
 
-(* RFC-0057 PR-2d: inline_coord tools (masc_start/join/leave/broadcast/
-   messages/who) moved to Tool_descriptors_gen. They flow through
+(* RFC-0057 PR-2d: inline_coord tools (masc_start/broadcast/messages)
+   moved to Tool_descriptors_gen. They flow through
    Tool_schemas_misc.schemas, but downstream consumers still identify
    inline-dispatched tools by membership in this list — so we re-include
    them here by filtering Tool_schemas_misc.schemas to the inline_coord

--- a/lib/transport.ml
+++ b/lib/transport.ml
@@ -98,8 +98,11 @@ module JsonRpc = struct
       else
         let id = Json_util.get_string json "id" in
         let method_name = Json_util.get_string_with_default json ~key:"method" ~default:"" in
-        let params = Yojson.Safe.Util.member "params" json in
-        Ok { id; method_name; params; headers = [] }
+        if String.trim method_name = "" then
+          Error "Missing JSON-RPC method"
+        else
+          let params = Yojson.Safe.Util.member "params" json in
+          Ok { id; method_name; params; headers = [] }
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
     | e -> Error (Printexc.to_string e)
@@ -195,6 +198,7 @@ module Rest = struct
     | "masc_operator_confirm" -> Some Bearer_required
     | "masc_status"
     | "masc_tasks"
+    | "masc_agents"
     | "masc_messages"
     | "masc_operator_snapshot"
     | "masc_operator_digest"
@@ -218,6 +222,7 @@ module Rest = struct
     [
       ("masc_status", [ (GET, "/api/v1/status") ]);
       ("masc_tasks", [ (GET, "/api/v1/tasks") ]);
+      ("masc_agents", [ (GET, "/api/v1/agents") ]);
       ("masc_messages", [ (GET, "/api/v1/messages") ]);
       ("masc_operator_snapshot", [ (GET, "/api/v1/operator") ]);
       ("masc_operator_digest", [ (GET, "/api/v1/operator/digest") ]);

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -568,7 +568,7 @@ let rec run_worker_via_oas
            ~raw_trace
            ?worker_run_id
            ~tool_names_ref
-           agent )
+           agent
 
 and resume_worker_via_oas
       ~(sw : Eio.Switch.t)
@@ -663,7 +663,7 @@ and resume_worker_via_oas
            ~raw_trace
            ?worker_run_id
            ~tool_names_ref
-           agent )
+           agent
 
 and run_existing_worker_agent
       ~(sw : Eio.Switch.t)

--- a/test/test_agent_tool_descriptor_registry_integrity.ml
+++ b/test/test_agent_tool_descriptor_registry_integrity.ml
@@ -34,10 +34,10 @@ let all_descriptors () : Descriptor.t list = Descriptor.all_descriptors ()
    [filter (visibility = Public_mcp) all_descriptors], deleting the hand
    list entirely.
 
-   Until RFC-0190 P1-P3 land, 9 surface entries have no descriptor at all
+   Until RFC-0190 P1-P3 land, 6 surface entries have no descriptor at all
    because their handlers live in [Tool_inline_dispatch] (MCP server-level
    inline path), not in the [runtime_handler] enum the descriptor system
-   dispatches through.  These 9 are enumerated below as the
+   dispatches through.  These 6 are enumerated below as the
    [rfc_0190_pending_inline_migration] allowlist.
 
    This invariant test exists to ratchet that allowlist toward empty:
@@ -51,11 +51,8 @@ let all_descriptors () : Descriptor.t list = Descriptor.all_descriptors ()
    forbid any pending entries. *)
 let rfc_0190_pending_inline_migration =
   [ "masc_start"
-  ; "masc_join"
-  ; "masc_leave"
   ; "masc_broadcast"
   ; "masc_messages"
-  ; "masc_who"
   ; "masc_keeper_sandbox_status"
   ; "masc_persona_generate"
   ; "masc_keeper_create_from_persona"

--- a/test/test_auth_coverage.ml
+++ b/test/test_auth_coverage.ml
@@ -167,15 +167,20 @@ let test_permission_for_tool_reset () =
   | Some Masc_domain.CanReset -> ()
   | _ -> fail "expected CanReset"
 
-let test_permission_for_tool_join () =
-  match Auth.permission_for_tool "masc_join" with
-  | Some Masc_domain.CanJoin -> ()
-  | _ -> fail "expected CanJoin"
+let test_permission_for_tool_start () =
+  match Auth.permission_for_tool "masc_start" with
+  | Some Masc_domain.CanBroadcast -> ()
+  | _ -> fail "expected CanBroadcast"
 
-let test_permission_for_tool_leave () =
+let test_permission_for_tool_join_removed () =
+  match Auth.permission_for_tool "masc_join" with
+  | None -> ()
+  | _ -> fail "expected None (removed tool)"
+
+let test_permission_for_tool_leave_removed () =
   match Auth.permission_for_tool "masc_leave" with
-  | Some Masc_domain.CanLeave -> ()
-  | _ -> fail "expected CanLeave"
+  | None -> ()
+  | _ -> fail "expected None (removed tool)"
 
 let test_permission_for_tool_status () =
   match Auth.permission_for_tool "masc_status" with
@@ -189,8 +194,8 @@ let test_permission_for_tool_runtime_verify () =
   | Some Masc_domain.CanReadState -> ()
   | _ -> fail "expected CanReadState"
 
-let test_permission_for_tool_who () =
-  match Auth.permission_for_tool "masc_who" with
+let test_permission_for_tool_agents () =
+  match Auth.permission_for_tool "masc_agents" with
   | Some Masc_domain.CanReadState -> ()
   | _ -> fail "expected CanReadState"
 
@@ -1063,10 +1068,11 @@ let () =
     "permission_for_tool", [
       test_case "init" `Quick test_permission_for_tool_init;
       test_case "reset" `Quick test_permission_for_tool_reset;
-      test_case "join" `Quick test_permission_for_tool_join;
-      test_case "leave" `Quick test_permission_for_tool_leave;
+      test_case "start" `Quick test_permission_for_tool_start;
+      test_case "join removed" `Quick test_permission_for_tool_join_removed;
+      test_case "leave removed" `Quick test_permission_for_tool_leave_removed;
       test_case "status" `Quick test_permission_for_tool_status;
-      test_case "who" `Quick test_permission_for_tool_who;
+      test_case "agents" `Quick test_permission_for_tool_agents;
       test_case "tasks" `Quick test_permission_for_tool_tasks;
       test_case "add_task" `Quick test_permission_for_tool_add_task;
       test_case "claim" `Quick test_permission_for_tool_claim;

--- a/test/test_keeper_tool_matrix_cases.ml
+++ b/test/test_keeper_tool_matrix_cases.ml
@@ -130,15 +130,15 @@ let make_fixture sw ~proc_mgr ~fs ~net ~mono_clock clock ~base_path init_mode =
   let tools = KTO.make_tools ~config ~meta ~ctx_snapshot () in
   (match init_mode with
    | Init_joined ->
-       (* Join under both the raw meta name (used by masc_* tools called
+       (* Bind under both the raw meta name (used by masc_* tools called
           through the keeper) and the prefixed keeper alias. Some keeper
           tools resolve the agent through the prefixed alias while
           dispatched masc tools use the raw meta identity. *)
        ignore
-         (Masc_mcp.Coord.join config ~agent_name:meta.name
+         (Masc_mcp.Coord.bind_session config ~agent_name:meta.name
             ~capabilities:[] ());
        ignore
-         (Masc_mcp.Coord.join config ~agent_name:("keeper-" ^ meta.name)
+         (Masc_mcp.Coord.bind_session config ~agent_name:("keeper-" ^ meta.name)
             ~capabilities:[] ())
    | Fresh | Init_only -> ());
   { generic; config; meta; ctx_snapshot; tools }

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -63,10 +63,8 @@ let strict_success_names =
     "masc_claim_next";
     "masc_dashboard";
     "masc_heartbeat";
-    "masc_join";
     "masc_keeper_down";
     "masc_keeper_list";
-    "masc_leave";
     "masc_library_add";
     "masc_library_list";
     "masc_messages";
@@ -80,7 +78,6 @@ let strict_success_names =
     "masc_transition";
     "masc_transport_status";
     "masc_websocket_discovery";
-    "masc_who";
     "masc_workflow_guide";
     (* Removed post-pruning:
        masc_init, masc_auth_*, masc_handover_*, masc_verify_* *)
@@ -296,27 +293,26 @@ let execute_tool_ok fixture ~name ~arguments =
   else failwith (Printf.sprintf "setup tool failed for %s: %s" name ((Tool_result.message result)))
 
 let ensure_initialized fixture =
-  (* masc_init pruned from registry. Initialise the coord state
-     directly so downstream masc_join and other tools can work. *)
+  (* masc_init pruned from registry. Initialise the coord state directly so
+     downstream tools can work. *)
   ignore
     (Masc_mcp.Coord.init fixture.state.coord_config
        ~agent_name:(Some fixture.agent_name))
 
 let ensure_joined fixture =
   let result =
-    execute_tool fixture ~name:"masc_join"
+    execute_tool fixture ~name:"masc_start"
       ~arguments:
         (`Assoc
           [
-            ("agent_name", `String fixture.agent_name);
-            ("capabilities", `List [ `String "testing"; `String "tool-matrix" ]);
+            ("path", `String fixture.base_path);
           ])
   in
   if (Tool_result.is_success result) then ()
   else begin
     let body = (Tool_result.message result) in
     if contains_substring body "already joined" then ()
-    else failwith ("masc_join failed: " ^ body)
+    else failwith ("masc_start failed: " ^ body)
   end
 
 let make_fixture sw ~proc_mgr ~fs ~net ~mono_clock clock ~base_path init_mode =
@@ -482,8 +478,8 @@ let ensure_library_topic fixture =
   match fixture.library_topic with
   | Some topic -> topic
   | None ->
-      mkdir_p (Filename.concat fixture.base_path "me/docs/library");
-      mkdir_p (Filename.concat fixture.base_path "me/docs/library/candidates");
+      mkdir_p (Filename.concat fixture.base_path "docs/library");
+      mkdir_p (Filename.concat fixture.base_path "docs/library/candidates");
       ignore
         (execute_tool_ok fixture ~name:"masc_library_add"
            ~arguments:
@@ -527,8 +523,8 @@ let prepare_for_name fixture name =
   then
     ignore (ensure_code_file fixture);
   if name = "masc_library_add" then begin
-    mkdir_p (Filename.concat fixture.base_path "me/docs/library");
-    mkdir_p (Filename.concat fixture.base_path "me/docs/library/candidates")
+    mkdir_p (Filename.concat fixture.base_path "docs/library");
+    mkdir_p (Filename.concat fixture.base_path "docs/library/candidates")
   end;
   if List.mem name [ "masc_library_list"; "masc_library_read"; "masc_library_promote"; "masc_library_search" ] then
     ignore (ensure_library_topic fixture);
@@ -766,6 +762,7 @@ let provider_guard_fragments =
     "connection refused";
     "failed to connect";
     "no runtime";
+    "runtime not initialized";
     "spawn error";
     "no such file";
   ]
@@ -812,6 +809,10 @@ let guard_fragments_for_name name =
   if String.equal name "masc_web_search" then
     web_search_guard_fragments
   else if
+    string_starts_with ~prefix:"keeper_" name
+  then
+    endpoint_unavailable_guard_fragments @ state_guard_fragments
+  else if
     string_starts_with ~prefix:"tool_" name
   then
     endpoint_unavailable_guard_fragments @ state_guard_fragments @ git_guard_fragments
@@ -844,7 +845,6 @@ let case_for_name name =
   let init_mode =
     match name with
     | "masc_init" | "masc_start" | "masc_set_coord" -> Fresh
-    | "masc_join" -> Init_only
     | _ -> Init_joined
   in
   let prepare fixture = prepare_for_name fixture name in

--- a/test/test_tool_access_role.ml
+++ b/test/test_tool_access_role.ml
@@ -160,7 +160,7 @@ let test_permissions_promoted_to_metadata_ssot () =
       ("masc_persona_generate", Masc_domain.CanBroadcast);
       ("masc_persona_save", Masc_domain.CanBroadcast);
       ("masc_keeper_reset", Masc_domain.CanBroadcast);
-      ("masc_join", Masc_domain.CanJoin);
+      ("masc_start", Masc_domain.CanBroadcast);
       ("masc_broadcast", Masc_domain.CanBroadcast);
       ("masc_portal_send", Masc_domain.CanSendPortal);
       ("channel_gate", Masc_domain.CanBroadcast);

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -79,8 +79,9 @@ let test_all_names_start_with_masc () =
 (* ============================================================ *)
 
 let test_find_tool_existing () =
-  let tools = ["masc_join"; "masc_leave"; "masc_status";
-               "masc_broadcast"; "masc_transition"] in
+  let tools =
+    [ "masc_start"; "masc_status"; "masc_broadcast"; "masc_transition" ]
+  in
   List.iter (fun name ->
     match find_tool name with
     | Some schema -> Alcotest.(check string) "found correct tool" name schema.name
@@ -136,26 +137,18 @@ let test_required_field_is_list () =
 (* ============================================================ *)
 
 (* test_masc_init_schema removed: masc_init tool pruned *)
+(* test_masc_join_schema and test_masc_leave_schema removed with lifecycle collapse. *)
 
-let test_masc_join_schema () =
-  match find_tool "masc_join" with
-  | None -> Alcotest.fail "masc_join not found"
+let test_masc_start_schema () =
+  match find_tool "masc_start" with
+  | None -> Alcotest.fail "masc_start not found"
   | Some schema ->
       match get_json_assoc "properties" schema.input_schema with
       | Some props ->
-          Alcotest.(check bool) "has agent_name" true (List.mem_assoc "agent_name" props);
-          Alcotest.(check bool) "has capabilities" true (List.mem_assoc "capabilities" props)
-      | None -> Alcotest.fail "masc_join missing properties"
-
-let test_masc_leave_schema () =
-  match find_tool "masc_leave" with
-  | None -> Alcotest.fail "masc_leave not found"
-  | Some schema ->
-      match get_json_list "required" schema.input_schema with
-      | Some reqs ->
-          Alcotest.(check bool) "agent_name is required" true
-            (List.mem (`String "agent_name") reqs)
-      | None -> Alcotest.fail "masc_leave missing required field"
+          Alcotest.(check bool) "has path" true (List.mem_assoc "path" props);
+          Alcotest.(check bool) "has task_title" true
+            (List.mem_assoc "task_title" props)
+      | None -> Alcotest.fail "masc_start missing properties"
 
 let test_masc_status_schema () =
   match find_tool "masc_status" with
@@ -813,8 +806,7 @@ let () =
       Alcotest.test_case "required_is_list" `Quick test_required_field_is_list;
     ];
     "core_tools", [
-      Alcotest.test_case "masc_join" `Quick test_masc_join_schema;
-      Alcotest.test_case "masc_leave" `Quick test_masc_leave_schema;
+      Alcotest.test_case "masc_start" `Quick test_masc_start_schema;
       Alcotest.test_case "masc_status" `Quick test_masc_status_schema;
       Alcotest.test_case "masc_broadcast" `Quick test_masc_broadcast_schema;
       Alcotest.test_case "masc_transition" `Quick test_masc_transition_schema;

--- a/test/test_transport_coverage.ml
+++ b/test/test_transport_coverage.ml
@@ -232,7 +232,7 @@ let test_request_no_id () =
 let test_request_with_params () =
   let req : Transport.request = {
     id = Some "req-002";
-    method_name = "masc_join";
+    method_name = "masc_start";
     params = `Assoc [("agent_name", `String "agent_llm_a")];
     headers = [];
   } in
@@ -405,10 +405,10 @@ let test_jsonrpc_serialize_response_no_id () =
      with Not_found -> false)
 
 let test_jsonrpc_make_request_basic () =
-  let json = Transport.JsonRpc.make_request ~method_name:"masc_join" ~params:(`Assoc []) () in
+  let json = Transport.JsonRpc.make_request ~method_name:"masc_start" ~params:(`Assoc []) () in
   let json_str = Yojson.Safe.to_string json in
   check bool "has method" true
-    (try let _ = Str.search_forward (Str.regexp "masc_join") json_str 0 in true
+    (try let _ = Str.search_forward (Str.regexp "masc_start") json_str 0 in true
      with Not_found -> false)
 
 let test_jsonrpc_make_request_with_id () =
@@ -457,13 +457,8 @@ let test_rest_tool_to_endpoint_claim () =
   check string "method" "POST" (Transport.Rest.method_to_string m);
   check string "path" "/mcp" path
 
-let test_rest_tool_to_endpoint_join () =
-  let (m, path) = Transport.Rest.tool_to_endpoint "masc_join" in
-  check string "method" "POST" (Transport.Rest.method_to_string m);
-  check string "path" "/mcp" path
-
-let test_rest_tool_to_endpoint_leave () =
-  let (m, path) = Transport.Rest.tool_to_endpoint "masc_leave" in
+let test_rest_tool_to_endpoint_start () =
+  let (m, path) = Transport.Rest.tool_to_endpoint "masc_start" in
   check string "method" "POST" (Transport.Rest.method_to_string m);
   check string "path" "/mcp" path
 
@@ -527,7 +522,7 @@ let test_rest_parse_request_tasks () =
 
 let test_rest_parse_request_agents () =
   let req = Transport.Rest.parse_request ~http_method:"GET" ~path:"/api/v1/agents" ~query_params:[] ~body:"" in
-  check string "method_name" "masc_who" req.method_name
+  check string "method_name" "masc_agents" req.method_name
 
 let test_rest_parse_request_operator_snapshot () =
   let req =
@@ -621,7 +616,7 @@ let test_rest_parse_request_roundtrips_direct_bindings () =
     [
       "masc_status";
       "masc_tasks";
-      "masc_who";
+      "masc_agents";
       "masc_messages";
       "masc_operator_snapshot";
       "masc_operator_digest";
@@ -658,7 +653,7 @@ let test_rest_generate_openapi_paths () =
     (try let _ = Str.search_forward (Str.regexp "masc_status") json_str 0 in true
      with Not_found -> false);
   check bool "has join" true
-    (try let _ = Str.search_forward (Str.regexp "masc_join") json_str 0 in true
+    (try let _ = Str.search_forward (Str.regexp "masc_start") json_str 0 in true
      with Not_found -> false)
 
 let test_rest_generate_openapi_document () =
@@ -727,7 +722,7 @@ let test_rest_generate_openapi_document () =
   check_operation_tags "masc_status" [ "tasks" ];
   check_operation_tags "masc_plan_init" [ "planning" ];
   check_operation_tags "masc_broadcast" [ "messaging" ];
-  check_operation_tags "masc_join" [ "masc" ];
+  check_operation_tags "masc_agents" [ "masc" ];
   let sdk_aliases =
     status_entry |> member "x-agent-sdk" |> member "aliases" |> to_list
   in
@@ -981,8 +976,7 @@ let () =
       test_case "tasks" `Quick test_rest_tool_to_endpoint_tasks;
       test_case "add_task" `Quick test_rest_tool_to_endpoint_add_task;
       test_case "claim" `Quick test_rest_tool_to_endpoint_claim;
-      test_case "join" `Quick test_rest_tool_to_endpoint_join;
-      test_case "leave" `Quick test_rest_tool_to_endpoint_leave;
+      test_case "start" `Quick test_rest_tool_to_endpoint_start;
       test_case "broadcast" `Quick test_rest_tool_to_endpoint_broadcast;
       test_case "operator snapshot" `Quick
         test_rest_tool_to_endpoint_operator_snapshot;


### PR DESCRIPTION
## Summary
- fix OCaml syntax fallout in worker/OAS and MCP execution paths
- align auth/tool tests with lifecycle collapse: masc_start + masc_agents replace removed join/leave/who contracts
- fix init-cache invalidation so same-request masc_start sees freshly initialized state
- restore transport/OpenAPI coverage for /api/v1/agents and strict JSON-RPC method validation

## Verification
- ocamlformat --check on touched OCaml files
- scripts/dune-local.sh build lib/masc_mcp.cma test/test_agent_tool_descriptor_registry_integrity.exe test/test_tool_access_role.exe test/test_tool_coord_coverage.exe test/test_tool_metrics_persist.exe test/test_auth_coverage.exe test/test_dashboard_o5_feeds.exe test/test_tools_coverage.exe test/test_transport_coverage.exe test/test_mcp_tool_matrix.exe
- ./_build/default/test/test_auth_coverage.exe
- ./_build/default/test/test_tool_access_role.exe
- ./_build/default/test/test_tool_metrics_persist.exe
- ./_build/default/test/test_tools_coverage.exe
- ./_build/default/test/test_transport_coverage.exe
- ./_build/default/test/test_agent_tool_descriptor_registry_integrity.exe

## Note
pre-commit full dune build was stopped after surfacing additional stale lifecycle-removal tests outside this patch scope (Coord.join / Join / Leave / joined_at residues).