### PR TITLE
Purge runtime coord residue

### DIFF
--- a/dashboard_bonsai/src/keepers_types.ml
+++ b/dashboard_bonsai/src/keepers_types.ml
@@ -48,7 +48,7 @@ type keeper =
 type response =
   { keepers : keeper list
   ; cycle : int
-  ; room : string option
+  ; coord : string option
   ; generated_at : string        (* ISO-8601 UTC *)
   ; fetch_status : fetch_status
   }
@@ -126,7 +126,7 @@ let keeper_of_yojson json =
 let response_of_yojson json =
   { keepers = list_field keeper_of_yojson json "keepers"
   ; cycle = int_field json "cycle"
-  ; room = string_opt_field json "room"
+  ; coord = string_opt_field json "coord"
   ; generated_at = string_field json "generated_at"
   ; fetch_status = Fetch_fresh
   }
@@ -151,7 +151,7 @@ let fetch_status_reason = function
 let fixture : response =
   { keepers = []
   ; cycle = 0
-  ; room = None
+  ; coord = None
   ; generated_at = ""
   ; fetch_status = Fetch_pending
   }

--- a/dashboard_bonsai/src/logs_view.ml
+++ b/dashboard_bonsai/src/logs_view.ml
@@ -1709,7 +1709,7 @@ let render_response
       (response : Logs_types.response)
     : Node.t =
   let runtime_name =
-    match keepers.room with
+    match keepers.coord with
     | Some name when String.length name > 0 -> name
     | _ -> "local"
   in

--- a/docs/design/keeper-continuity-diagnosis-rfc.md
+++ b/docs/design/keeper-continuity-diagnosis-rfc.md
@@ -3,7 +3,7 @@
 **Status**: Draft v3 (post-review, 7 rounds)
 **Date**: 2026-03-29
 **Scope**: MASC Keeper Checkpoint Continuity / GC / Naming
-**Issues**: #3626 (zombie GC), #3627 (perpetual naming), #3630 (memory dead code)
+**Issues**: #3626 (zombie GC), #3627 (runtime directory naming), #3630 (memory dead code)
 **One sentence**: keeper가 이전 대화를 기억 못하는 원인을 OAS checkpoint 경로 진단으로 확정하고, 진단 중 발견된 filesystem 부채(dead code, naming, GC)를 정리한다.
 
 ## Related Documents
@@ -155,12 +155,11 @@ Source files (functional 변경): 9 files, 19 occurrences + TUI.
 
 Documentation: 13 files, 26 occurrences.
 
-### Directory Rename
+### Canonical Runtime Directories
 
 ```
-.masc/perpetual/          → .masc/traces/
-.masc/keepers/  → .masc/keepers/
-.masc/resident-keepers/   → .masc/keepers/ (병합 후 삭제)
+.masc/traces/
+.masc/keepers/
 ```
 
 ### Migration: 재귀 merge + file-level quarantine

--- a/docs/spec/05-keeper-agent.md
+++ b/docs/spec/05-keeper-agent.md
@@ -16,13 +16,13 @@ code_refs:
 | Modules | 67 (.ml) + 5 (.mli-only) |
 | LOC | ~17.8K |
 | MCP Tools | `tool_keeper` |
-| External Deps | `Agent_sdk` (OAS), `Llm_provider`, `Room`, `Runtime_inference`, `Verifier_oas` |
+| External Deps | `Agent_sdk` (OAS), `Llm_provider`, `Coord`, `Runtime_inference`, `Verifier_oas` |
 
 ---
 
 ## 1. Purpose
 
-Keeper는 MASC의 자율 에이전트 하네스(harness)다. OAS `Agent.run` 위에서 동작하며, 장기 실행(perpetual) 루프, 컨텍스트 관리, 메모리 계층, 심의(deliberation), 승계(succession), 검증(verification)을 담당한다.
+Keeper는 MASC의 자율 에이전트 하네스(harness)다. OAS `Agent.run` 위에서 동작하며, 장기 실행 루프, 컨텍스트 관리, 메모리 계층, 심의(deliberation), 승계(succession), 검증(verification)을 담당한다.
 
 Keeper 하나는 다음을 소유한다:
 - **identity**: `keeper_meta` 레코드 (이름, 목표, will/needs/desires)

--- a/lib/audit_log.ml
+++ b/lib/audit_log.ml
@@ -489,12 +489,12 @@ let log_broadcast config ~agent_id ~message_preview ?cost_estimate ?token_count 
     ~details:(`Assoc [("preview", `String preview)])
     ?cost_estimate ?token_count ~outcome:Success ()
 
-let log_suspend config ~agent_id ~target_agent ~reason ~rooms_affected ?cost_estimate ?token_count () =
+let log_suspend config ~agent_id ~target_agent ~reason ~coords_affected ?cost_estimate ?token_count () =
   log_action config ~agent_id ~action:Suspend
     ~details:(`Assoc [
       ("target_agent", `String target_agent);
       ("reason", `String reason);
-      ("rooms_affected", `Int rooms_affected);
+      ("coords_affected", `Int coords_affected);
     ])
     ?cost_estimate ?token_count ~outcome:Success ()
 

--- a/lib/audit_log.mli
+++ b/lib/audit_log.mli
@@ -182,7 +182,7 @@ val log_suspend :
   agent_id:string ->
   target_agent:string ->
   reason:string ->
-  rooms_affected:int ->
+  coords_affected:int ->
   ?cost_estimate:float ->
   ?token_count:int ->
   unit -> unit

--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -526,10 +526,10 @@ let authorize_tool_v2 config ~agent_name ~token ~tool_name : (unit, masc_error) 
 ;;
 
 (* ============================================ *)
-(* Coord secret (for room-level auth)            *)
+(* Coord secret                                  *)
 (* ============================================ *)
 
-(** Initialize room secret *)
+(** Initialize coord secret *)
 let init_coord_secret config : string =
   ensure_auth_dirs config;
   let secret = generate_token () in
@@ -541,7 +541,7 @@ let init_coord_secret config : string =
   secret (* Return raw secret to show user once *)
 ;;
 
-(** Verify room secret *)
+(** Verify coord secret *)
 let verify_coord_secret config secret : bool =
   let hash = sha256_hash secret in
   let file = coord_secret_file config in
@@ -556,7 +556,7 @@ let verify_coord_secret config secret : bool =
 (* High-level auth operations                   *)
 (* ============================================ *)
 
-(** Enable authentication for a room.
+(** Enable authentication for a coord.
     Creates a bootstrap admin token for the enabling agent to prevent
     circular permission deadlock (BUG-025). *)
 let enable_auth config ~require_token ~agent_name : string * string option =

--- a/lib/auth.mli
+++ b/lib/auth.mli
@@ -284,10 +284,10 @@ val authorize_tool_v2 :
   string -> agent_name:string -> token:string option ->
   tool_name:string -> (unit, masc_error) result
 
-(** {1 Room Secret} *)
+(** {1 Coord Secret} *)
 
 val init_coord_secret : string -> string
-(** [init_coord_secret config] generates and persists a room secret.
+(** [init_coord_secret config] generates and persists a coord secret.
     Returns the raw secret (shown once). *)
 
 val verify_coord_secret : string -> string -> bool

--- a/lib/briefing_compactors/briefing_compactors.ml
+++ b/lib/briefing_compactors/briefing_compactors.ml
@@ -25,7 +25,7 @@ let session_recent_enough ~now_ts session_json =
   | [] -> false
 
 let relevant_sessions_for_briefing ~current_namespace ~now_ts sessions =
-  let room_matches session_json =
+  let coord_matches session_json =
     match String_util.option_trim (Some current_namespace) with
     | None -> true
     | Some project ->
@@ -42,7 +42,7 @@ let relevant_sessions_for_briefing ~current_namespace ~now_ts sessions =
   in
   sessions
   |> List.filter (fun session_json ->
-         room_matches session_json
+         coord_matches session_json
          &&
          let status_detail = member_assoc "status" session_json in
          let status =

--- a/lib/briefing_compactors/briefing_compactors.mli
+++ b/lib/briefing_compactors/briefing_compactors.mli
@@ -6,7 +6,7 @@
 
 (** [relevant_sessions_for_briefing ~current_namespace ~now_ts
     sessions] keeps sessions that either match [current_namespace]
-    (project/room id) and are in a live status, or have a
+    (project/coord id) and are in a live status, or have a
     [recent_events] entry within the last hour of [now_ts]. *)
 val relevant_sessions_for_briefing :
   current_namespace:string ->

--- a/lib/cdal/adversarial_eval.ml
+++ b/lib/cdal/adversarial_eval.ml
@@ -121,14 +121,14 @@ let classify_path path =
   let has_room_history =
     has_history_artifact_extension lower
     && List.exists (String_util.contains_substring normalized)
-         [ "room_history"; "room-history"; "roomtaskhistory"; "room_task_history";
-           "room-task-history" ]
+         [ "coord_history"; "coord-history"; "coordhistory"; "coord_task_history";
+           "coord-task-history" ]
   in
   let has_task_history =
     has_history_artifact_extension lower
     && List.exists (String_util.contains_substring normalized)
-         [ "task_history"; "task-history"; "taskhistory"; "room/task_history";
-           "room/task-history" ]
+         [ "task_history"; "task-history"; "taskhistory"; "coord/task_history";
+           "coord/task-history" ]
   in
   let has_governance_history =
     (List.mem "governance" basename_tokens

--- a/lib/cdal/adversarial_eval.mli
+++ b/lib/cdal/adversarial_eval.mli
@@ -7,7 +7,7 @@
     Output is advisory only — not a gate.
 
     Red line: this evaluator never sees README, design docs,
-    room/task history, or governance history. *)
+    coord/task history, or governance history. *)
 
 (** Allowed input types — anything not in this type is banned. *)
 type allowed_input =

--- a/lib/dashboard_api_types/keepers.ml
+++ b/lib/dashboard_api_types/keepers.ml
@@ -57,7 +57,7 @@ type keeper = {
 type response = {
   keepers : keeper list;
   cycle : int;                  (* current cycle number *)
-  room : string option;          [@default None]
+  coord : string option;         [@default None]
   generated_at : string;        (* ISO-8601 UTC *)
 }
 [@@deriving yojson { strict = false }]

--- a/lib/dashboard_api_types/keepers.mli
+++ b/lib/dashboard_api_types/keepers.mli
@@ -57,7 +57,7 @@ val keeper_to_yojson : keeper -> Yojson.Safe.t
 type response = {
   keepers : keeper list;
   cycle : int;                 (** current cycle number *)
-  room : string option;
+  coord : string option;
   generated_at : string;       (** ISO-8601 UTC *)
 }
 

--- a/lib/mcp_server_eio_caller_identity.ml
+++ b/lib/mcp_server_eio_caller_identity.ml
@@ -130,14 +130,14 @@ let resolve_auth_fallback_agent_name
           agent_name)
   | _ -> agent_name
 
-let resolve_explicit_bound_alias ~config ~room_initialized ~log_mcp_exn
+let resolve_explicit_bound_alias ~config ~coord_initialized ~log_mcp_exn
     ~has_explicit_agent_name agent_name =
   if has_explicit_agent_name && not (Nickname.is_generated_nickname agent_name)
   then (
     let resolved = Coord.resolve_agent_name config agent_name in
     if resolved <> agent_name then (
       try
-        if room_initialized () then (
+        if coord_initialized () then (
           try
             if Coord.is_agent_session_bound config ~agent_name:resolved then
               resolved
@@ -161,7 +161,7 @@ let resolve_explicit_bound_alias ~config ~room_initialized ~log_mcp_exn
     agent_name
 
 let resolve ~(config : Coord_utils_backend_setup.config) ~tool_name ~arguments ~identity
-    ~cached_resolved_agent ~auth_token ~internal_keeper_runtime ~room_initialized
+    ~cached_resolved_agent ~auth_token ~internal_keeper_runtime ~coord_initialized
     ~log_mcp_exn =
   let explicit_agent_name = caller_agent_name_from_arguments arguments in
   let has_explicit_agent_name = Option.is_some explicit_agent_name in
@@ -206,7 +206,7 @@ let resolve ~(config : Coord_utils_backend_setup.config) ~tool_name ~arguments ~
       agent_name
   in
   let agent_name =
-    resolve_explicit_bound_alias ~config ~room_initialized ~log_mcp_exn
+    resolve_explicit_bound_alias ~config ~coord_initialized ~log_mcp_exn
       ~has_explicit_agent_name agent_name
   in
   {

--- a/lib/mcp_server_eio_caller_identity.mli
+++ b/lib/mcp_server_eio_caller_identity.mli
@@ -20,6 +20,6 @@ val resolve :
   cached_resolved_agent:string option ->
   auth_token:string option ->
   internal_keeper_runtime:bool ->
-  room_initialized:(unit -> bool) ->
+  coord_initialized:(unit -> bool) ->
   log_mcp_exn:(label:string -> exn -> unit) ->
   t

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -62,9 +62,9 @@ let execute_tool_eio
   Prometheus.record_request ();
   let config = state.Mcp_server.coord_config in
   let registry = state.Mcp_server.session_registry in
-  (* Fix 3: Cache room_initialized to avoid repeated stat syscalls.
+  (* Fix 3: Cache coord_initialized to avoid repeated stat syscalls.
      Updated after auto-init succeeds. *)
-  let room_init_cached = ref (Coord.is_initialized config) in
+  let coord_init_cached = ref (Coord.is_initialized config) in
   (* Fix 4: Check resolved-name cache for fast identity resolution.
      On 2nd+ call in the same MCP session, the cached name preserves the
      nickname selected by the prior session binding without relying on sidecar files. *)
@@ -81,7 +81,7 @@ let execute_tool_eio
   let caller_identity =
     Mcp_server_eio_caller_identity.resolve ~config ~tool_name:name ~arguments
       ~identity ~cached_resolved_agent ~auth_token ~internal_keeper_runtime
-      ~room_initialized:(fun () -> !room_init_cached)
+      ~coord_initialized:(fun () -> !coord_init_cached)
       ~log_mcp_exn
   in
   let agent_name = caller_identity.agent_name in
@@ -212,7 +212,7 @@ let execute_tool_eio
           in
           (match owner_keeper_identity with
            | Some (keeper_name, keeper_id)
-             when agent_name <> "unknown" && !room_init_cached ->
+             when agent_name <> "unknown" && !coord_init_cached ->
              (try
                 Coord_task.update_local_agent_state config ~agent_name (fun agent ->
                   let meta =
@@ -260,7 +260,7 @@ let execute_tool_eio
               | Tool_catalog.Real | Tool_catalog.Adapter | Tool_catalog.Placeholder ->
                 false
             in
-            if (not skip_heartbeat) && !room_init_cached
+            if (not skip_heartbeat) && !coord_init_cached
             then (
               try
                 let (_ : string) = Coord.heartbeat config ~agent_name in

--- a/lib/mention_inbox.mli
+++ b/lib/mention_inbox.mli
@@ -11,7 +11,7 @@ type mention_record = {
   id: string;              (** Unique ID: "m-" prefix + timestamp + random *)
   target_agent: string;    (** Who was mentioned *)
   source_agent: string;    (** Who mentioned them *)
-  source_kind: string;     (** "room_message" | "board_post" | "board_comment" *)
+  source_kind: string;     (** "coord_message" | "board_post" | "board_comment" *)
   source_id: string;       (** coord_id or post_id *)
   content_preview: string; (** First ~200 chars of the content *)
   created_at: float;       (** Unix timestamp *)

--- a/lib/tool_broadcast_typed.ml
+++ b/lib/tool_broadcast_typed.ml
@@ -32,14 +32,14 @@ let broadcast_schema = Sg.one message_field
 
 type broadcast_output = {
   delivered : bool;
-  room_message : string;
+  coord_message : string;
   mention : string option;
 }
 
 let encode_broadcast (output : broadcast_output) : Yojson.Safe.t =
   `Assoc ([
     ("delivered", `Bool output.delivered);
-    ("room_message", `String output.room_message);
+    ("coord_message", `String output.coord_message);
   ] @ match output.mention with
     | Some m -> [("mention", `String m)]
     | None -> [])
@@ -50,7 +50,7 @@ let handle_broadcast (message : string)
   if String.equal trimmed "" then Error "Broadcast message cannot be empty"
   else
     let mention = Mention.extract trimmed in
-    Ok { delivered = true; room_message = trimmed; mention }
+    Ok { delivered = true; coord_message = trimmed; mention }
 
 let parse_broadcast (json : Yojson.Safe.t) =
   match Sg.parse broadcast_schema json with

--- a/lib/tool_broadcast_typed.mli
+++ b/lib/tool_broadcast_typed.mli
@@ -6,7 +6,7 @@
 
 type broadcast_output = {
   delivered : bool;
-  room_message : string;
+  coord_message : string;
   mention : string option;
 }
 

--- a/lib/tool_control.ml
+++ b/lib/tool_control.ml
@@ -102,7 +102,7 @@ let handle_pause_status ~tool_name ~start_time ctx _args : Tool_result.result =
             ("paused_by", Json_util.string_opt_to_json by);
             ("pause_reason", Json_util.string_opt_to_json reason);
             ("paused_at", Json_util.string_opt_to_json at);
-            ("pause_scope", `String "coord_room");
+            ("pause_scope", `String "coord");
             ("any_pause_active", `Bool true);
             ("keeper_pause", keeper_pause);
             ("message", `String "Server is paused");
@@ -117,7 +117,7 @@ let handle_pause_status ~tool_name ~start_time ctx _args : Tool_result.result =
             ("paused_by", `Null);
             ("pause_reason", `Null);
             ("paused_at", `Null);
-            ("pause_scope", `String "coord_room");
+            ("pause_scope", `String "coord");
             ("any_pause_active", `Bool keeper_paused);
             ("keeper_pause", keeper_pause);
             ( "message",
@@ -136,7 +136,7 @@ let handle_pause_status ~tool_name ~start_time ctx _args : Tool_result.result =
             ("paused_by", `Null);
             ("pause_reason", `Null);
             ("paused_at", `Null);
-            ("pause_scope", `String "coord_room");
+            ("pause_scope", `String "coord");
             ("any_pause_active", `Null);
             ("keeper_pause", keeper_pause);
             ( "message",

--- a/lib/tool_coord.mli
+++ b/lib/tool_coord.mli
@@ -47,8 +47,6 @@ type context = Coord_types.context =
     {!Coord_assertions} (the SSOT) and propagates here
     automatically. *)
 type assertion_kind = Coord_assertions.assertion_kind =
-  | Room_set
-  | Joined
   | Task_claimed
   | Current_task_set
 

--- a/lib/tool_deep_review.ml
+++ b/lib/tool_deep_review.ml
@@ -46,7 +46,7 @@ let validate_target_files target_files =
         match kind with
         | Adversarial_eval.Readme -> "README"
         | Adversarial_eval.Design_doc -> "design_doc"
-        | Adversarial_eval.Coord_history -> "room_history"
+        | Adversarial_eval.Coord_history -> "coord_history"
         | Adversarial_eval.Task_history -> "task_history"
         | Adversarial_eval.Governance_history -> "governance_history"
       in

--- a/lib/transport.ml
+++ b/lib/transport.ml
@@ -174,7 +174,7 @@ module Rest = struct
     | Public ->
         "No bearer token is required for this route."
     | Conditional_bearer ->
-        "Bearer token auth is required when room auth/token enforcement is active; loopback-local development may allow access without a bearer."
+        "Bearer token auth is required when coord auth/token enforcement is active; loopback-local development may allow access without a bearer."
     | Same_origin_or_bearer ->
         "Loopback browser requests may use same-origin checks; non-browser clients should use Authorization: Bearer <token>."
     | Bearer_required ->
@@ -651,7 +651,7 @@ module Rest = struct
                           ("bearerFormat", `String "opaque-token");
                           ( "description",
                             `String
-                              "MASC room bearer token. Some loopback-local routes may additionally permit same-origin browser access." );
+                              "MASC coord bearer token. Some loopback-local routes may additionally permit same-origin browser access." );
                         ] );
                   ] );
             ] );

--- a/test/test_adversarial_eval.ml
+++ b/test/test_adversarial_eval.ml
@@ -39,9 +39,9 @@ let test_classify_history () =
     (Option.is_some (Adversarial_eval.classify_path "session_log.jsonl"));
   Alcotest.(check bool) "retrospective.json is banned" true
     (Option.is_some (Adversarial_eval.classify_path "retrospective.json"));
-  Alcotest.(check bool) "room-task-history path is banned" true
+  Alcotest.(check bool) "coord-task-history path is banned" true
     (Option.is_some
-       (Adversarial_eval.classify_path "memory/room-task-history.jsonl"))
+       (Adversarial_eval.classify_path "memory/coord-task-history.jsonl"))
 
 let test_classify_allowed () =
   Alcotest.(check bool) "module.ml is allowed" true
@@ -54,8 +54,8 @@ let test_classify_allowed () =
     (Option.is_none (Adversarial_eval.classify_path "lib/spec_decoder.ml"));
   Alcotest.(check bool) "governance source file is allowed" true
     (Option.is_none (Adversarial_eval.classify_path "lib/governance_pipeline.ml"));
-  Alcotest.(check bool) "room history source file is allowed" true
-    (Option.is_none (Adversarial_eval.classify_path "lib/room_history_parser.ml"))
+  Alcotest.(check bool) "coord history source file is allowed" true
+    (Option.is_none (Adversarial_eval.classify_path "lib/coord_history_parser.ml"))
 
 let test_validate_clean_inputs () =
   let inputs =
@@ -96,17 +96,17 @@ let test_validate_rejects_design_doc () =
   | Error (_, _) -> Alcotest.fail "wrong rejection kind"
   | Ok _ -> Alcotest.fail "should reject design doc"
 
-let test_validate_rejects_room_history_path () =
+let test_validate_rejects_coord_history_path () =
   let inputs =
     Adversarial_eval.[
       Changed_file
-        { path = "memory/room-task-history.jsonl"; content = "{}\n" };
+        { path = "memory/coord-task-history.jsonl"; content = "{}\n" };
     ]
   in
   match Adversarial_eval.validate_inputs inputs with
   | Error (_, Adversarial_eval.Coord_history) -> ()
   | Error (_, _) -> Alcotest.fail "wrong rejection kind"
-  | Ok _ -> Alcotest.fail "should reject room history"
+  | Ok _ -> Alcotest.fail "should reject coord history"
 
 (* --- Structural check tests --- *)
 
@@ -222,8 +222,8 @@ let () =
           Alcotest.test_case "validate clean" `Quick test_validate_clean_inputs;
           Alcotest.test_case "reject readme" `Quick test_validate_rejects_readme;
           Alcotest.test_case "reject design doc" `Quick test_validate_rejects_design_doc;
-          Alcotest.test_case "reject room history path" `Quick
-            test_validate_rejects_room_history_path;
+          Alcotest.test_case "reject coord history path" `Quick
+            test_validate_rejects_coord_history_path;
         ] );
       ( "structural_checks",
         [

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -215,7 +215,7 @@ let test_coord_secret_saved_private () =
     ~finally:(fun () -> cleanup_test_room dir)
     (fun () ->
       ignore (Auth.init_coord_secret dir);
-      check int "room secret mode 0600" 0o600
+      check int "coord secret mode 0600" 0o600
         (permission_bits (Auth.coord_secret_file dir)))
 
 let test_verify_token () =
@@ -1533,6 +1533,6 @@ let () =
     ];
     "enable_disable", [
       test_case "enable/disable auth" `Quick test_enable_disable_auth;
-      test_case "room secret saved private" `Quick test_coord_secret_saved_private;
+      test_case "coord secret saved private" `Quick test_coord_secret_saved_private;
     ];
   ]

--- a/test/test_briefing_compactors.ml
+++ b/test/test_briefing_compactors.ml
@@ -162,8 +162,8 @@ let int_of j = match j with `Int n -> n | _ -> -1
 
 let test_relevant_empty_namespace_matches_all () =
   (* When current_namespace is "" (or whitespace), trim_to_option
-     returns None, and room_matches always returns true. *)
-  let s = session_fixture ~project:"any-room" () in
+     returns None, and coord_matches always returns true. *)
+  let s = session_fixture ~project:"any-coord" () in
   let result =
     C.relevant_sessions_for_briefing ~current_namespace:""
       ~now_ts:0.0 [ s ]
@@ -171,18 +171,18 @@ let test_relevant_empty_namespace_matches_all () =
   assert (List.length result = 1)
 
 let test_relevant_namespace_matching_keeps () =
-  let s = session_fixture ~project:"room-X" ~status:"active"
+  let s = session_fixture ~project:"coord-X" ~status:"active"
               ~summary_status:"active" () in
   let result =
-    C.relevant_sessions_for_briefing ~current_namespace:"room-X"
+    C.relevant_sessions_for_briefing ~current_namespace:"coord-X"
       ~now_ts:0.0 [ s ]
   in
   assert (List.length result = 1)
 
 let test_relevant_namespace_mismatch_drops () =
-  let s = session_fixture ~project:"room-X" ~status:"active" () in
+  let s = session_fixture ~project:"coord-X" ~status:"active" () in
   let result =
-    C.relevant_sessions_for_briefing ~current_namespace:"room-Y"
+    C.relevant_sessions_for_briefing ~current_namespace:"coord-Y"
       ~now_ts:0.0 [ s ]
   in
   assert (result = [])

--- a/test/test_briefing_sections.ml
+++ b/test/test_briefing_sections.ml
@@ -14,7 +14,7 @@
     1. {b Output shape} — returns [(watch_summary, [c; a; w])]
        where the list always has length 3 with section ids
        [communication / alignment / watch] in that order.
-    2. {b Watch branches} — risky room → "risk"; incidents or
+    2. {b Watch branches} — risky coord → "risk"; incidents or
        recommended actions → "watch"; otherwise "ok".
     3. {b Communication branches} — positive signal vs
        metadata gaps vs live-session-count vs known mode count.
@@ -30,11 +30,11 @@ module S = Masc_mcp.Briefing_sections
 
 let s_str s = `String s
 
-let briefing_summary ?(room_health = "ok") ?(incidents = 0)
+let briefing_summary ?(coord_health = "ok") ?(incidents = 0)
     ?(recommended = 0) ?(top_attention = "") () : Yojson.Safe.t =
   `Assoc
     [
-      ("room_health", s_str room_health);
+      ("coord_health", s_str coord_health);
       ("incident_count", `Int incidents);
       ("recommended_action_count", `Int recommended);
       ("top_attention_summary", s_str top_attention);
@@ -168,10 +168,10 @@ let test_watch_summary_matches_watch_section () =
 
 (* ── (2) Watch section branches ────────────────────────────── *)
 
-let test_watch_risky_room () =
+let test_watch_risky_coord () =
   let _ws, sections =
     S.build_briefing_sections
-      ~briefing_summary_json:(briefing_summary ~room_health:"critical" ())
+      ~briefing_summary_json:(briefing_summary ~coord_health:"critical" ())
       ~sessions:[] ~agents:[] ~recent_messages:[]
       ~metadata_gaps:[]
   in
@@ -366,7 +366,7 @@ let () =
   test_output_shape_section_attribute_keys ();
   test_provenance_and_authoritative_pinned ();
   test_watch_summary_matches_watch_section ();
-  test_watch_risky_room ();
+  test_watch_risky_coord ();
   test_watch_incidents_only ();
   test_watch_recommended_actions_only ();
   test_watch_clean_state_ok ();

--- a/test/test_join_required_guard_counter.ml
+++ b/test/test_join_required_guard_counter.ml
@@ -25,10 +25,10 @@ let test_metric_name_stable () =
     "masc_tool_join_required_guard_total"
     Masc_mcp.Prometheus.metric_tool_join_required_guard
 
-let test_increments_room_uninitialized () =
+let test_increments_coord_uninitialized () =
   let tool = "masc_claim_next" in
   let agent_name = "san-test-9770" in
-  let reason = "room_uninitialized" in
+  let reason = "coord_uninitialized" in
   let before = counter_for ~tool ~agent_name ~reason in
   Masc_mcp.Prometheus.inc_counter
     Masc_mcp.Prometheus.metric_tool_join_required_guard
@@ -37,7 +37,7 @@ let test_increments_room_uninitialized () =
               ("reason", reason) ]
     ();
   Alcotest.(check (float 0.0001))
-    "room_uninitialized +1"
+    "coord_uninitialized +1"
     (before +. 1.0)
     (counter_for ~tool ~agent_name ~reason)
 
@@ -63,8 +63,8 @@ let test_label_isolation_across_reasons () =
      failure modes in operator dashboards. *)
   let tool = "masc_status" in
   let agent_name = "isolation-test-9770" in
-  let before_room =
-    counter_for ~tool ~agent_name ~reason:"room_uninitialized"
+  let before_coord =
+    counter_for ~tool ~agent_name ~reason:"coord_uninitialized"
   in
   Masc_mcp.Prometheus.inc_counter
     Masc_mcp.Prometheus.metric_tool_join_required_guard
@@ -73,9 +73,9 @@ let test_label_isolation_across_reasons () =
               ("reason", "agent_not_joined") ]
     ();
   Alcotest.(check (float 0.0001))
-    "room_uninitialized counter unchanged when agent_not_joined fires"
-    before_room
-    (counter_for ~tool ~agent_name ~reason:"room_uninitialized")
+    "coord_uninitialized counter unchanged when agent_not_joined fires"
+    before_coord
+    (counter_for ~tool ~agent_name ~reason:"coord_uninitialized")
 
 let test_label_isolation_across_agents () =
   let tool = "masc_claim_next" in
@@ -101,8 +101,8 @@ let () =
         test_metric_name_stable;
     ];
     "counter", [
-      Alcotest.test_case "room_uninitialized increments" `Quick
-        test_increments_room_uninitialized;
+      Alcotest.test_case "coord_uninitialized increments" `Quick
+        test_increments_coord_uninitialized;
       Alcotest.test_case "agent_not_joined increments" `Quick
         test_increments_agent_not_joined;
     ];

--- a/test/test_mcp_server_eio_join_state.ml
+++ b/test/test_mcp_server_eio_join_state.ml
@@ -2,7 +2,7 @@ let test_resolve_join_state_skips_read_only_lookup () =
   let called = ref false in
   let joined =
     Masc_mcp.Mcp_server_eio_execute.resolve_join_state
-      ~room_initialized:true
+      ~coord_initialized:true
       ~join_required:false
       ~agent_name:"agent_code"
       ~check_join:(fun _candidate ->
@@ -16,7 +16,7 @@ let test_resolve_join_state_checks_join_required_tools () =
   let called = ref false in
   let joined =
     Masc_mcp.Mcp_server_eio_execute.resolve_join_state
-      ~room_initialized:true
+      ~coord_initialized:true
       ~join_required:true
       ~agent_name:"agent_code"
       ~check_join:(fun _candidate ->
@@ -30,7 +30,7 @@ let test_resolve_join_state_skips_unknown_agent () =
   let called = ref false in
   let joined =
     Masc_mcp.Mcp_server_eio_execute.resolve_join_state
-      ~room_initialized:true
+      ~coord_initialized:true
       ~join_required:true
       ~agent_name:"unknown"
       ~check_join:(fun _candidate ->
@@ -44,7 +44,7 @@ let test_resolve_join_state_alias_does_not_probe_canonical () =
   let candidates = ref [] in
   let joined =
     Masc_mcp.Mcp_server_eio_execute.resolve_join_state
-      ~room_initialized:true
+      ~coord_initialized:true
       ~join_required:true
       ~agent_name:"agent_code-rotated"
       ~check_join:(fun candidate ->
@@ -61,7 +61,7 @@ let test_resolve_join_state_alias_does_not_probe_canonical () =
 let test_resolve_join_state_unknown_alias_stays_false () =
   let joined =
     Masc_mcp.Mcp_server_eio_execute.resolve_join_state
-      ~room_initialized:true
+      ~coord_initialized:true
       ~join_required:true
       ~agent_name:"a-b"
       ~check_join:(fun _candidate -> false)

--- a/test/test_operator_control_actions.ml
+++ b/test/test_operator_control_actions.ml
@@ -87,8 +87,6 @@ let test_operator_action_rejects_legacy_action_aliases () =
     [
       "autonomy_tick";
       "keeper_msg";
-      "room_pause";
-      "room_resume";
       "team_note";
       "team_broadcast";
       "team_task_inject";

--- a/test/test_operator_mcp_e2e.ml
+++ b/test/test_operator_mcp_e2e.ml
@@ -478,7 +478,7 @@ let test_mcp_requires_auth_when_bound_non_loopback () =
   let result = call_until_ready 40 in
   Alcotest.(check (option int)) "returns unauthorized" (Some 401) result.status;
   check bool "strict auth message" true
-    (contains_substr "requires room auth enabled with require_token=true"
+    (contains_substr "requires coord auth enabled with require_token=true"
        result.body)
 
 let test_agent_json_route_served_on_canonical_path () =

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -857,7 +857,7 @@ let test_keeper_tool_call_log_uses_cluster_root () =
                 1
                 (List.length (Keeper_tool_call_log.read_recent ~n:10 ())))))
 
-let test_room_init_bootstraps_keeper_runtime_dirs () =
+let test_coord_init_bootstraps_keeper_runtime_dirs () =
   with_temp_dir "startup-keeper-dirs" (fun dir ->
       let config = Coord.default_config dir in
       ignore (Coord.init config ~agent_name:None);
@@ -867,9 +867,7 @@ let test_room_init_bootstraps_keeper_runtime_dirs () =
       Alcotest.(check bool) "keeper dir exists" true
         (Sys.file_exists keeper_dir && Sys.is_directory keeper_dir);
       Alcotest.(check bool) "traces dir exists" true
-        (Sys.file_exists traces_dir && Sys.is_directory traces_dir);
-      Alcotest.(check bool) "perpetual dir not recreated" false
-        (Sys.file_exists (Filename.concat root_dir "perpetual")))
+        (Sys.file_exists traces_dir && Sys.is_directory traces_dir))
 
 let test_otel_exporter_setup_failure_is_soft () =
   Otel_spans.shutdown ~enabled:true ();
@@ -2686,8 +2684,8 @@ let () =
             test_tool_usage_log_uses_cluster_root;
           Alcotest.test_case "keeper tool call log uses cluster root" `Quick
             test_keeper_tool_call_log_uses_cluster_root;
-          Alcotest.test_case "room init bootstraps keeper runtime dirs" `Quick
-            test_room_init_bootstraps_keeper_runtime_dirs;
+          Alcotest.test_case "coord init bootstraps keeper runtime dirs" `Quick
+            test_coord_init_bootstraps_keeper_runtime_dirs;
           Alcotest.test_case "otel exporter setup failure is soft" `Quick
             test_otel_exporter_setup_failure_is_soft;
           Alcotest.test_case "lazy startup plan parallelizes independent tasks"

--- a/test/test_tool_control_coverage.ml
+++ b/test/test_tool_control_coverage.ml
@@ -131,7 +131,7 @@ let () =
       | None -> failwith "dispatch returned None")
 
 let () =
-  test "dispatch_pause_status_surfaces_keeper_pause_when_room_running" (fun () ->
+  test "dispatch_pause_status_surfaces_keeper_pause_when_coord_running" (fun () ->
       with_ctx @@ fun ctx ->
       seed_keeper_meta ctx "paused-keeper" ~paused:true;
       match Tool_control.dispatch ctx ~name:"masc_pause_status" ~args:(`Assoc []) with
@@ -156,7 +156,7 @@ let () =
       with_ctx @@ fun ctx ->
       match
         Tool_control.dispatch ctx ~name:"masc_pause_status"
-          ~args:(`Assoc [ ("namespace_id", `String "focus-room") ])
+          ~args:(`Assoc [ ("namespace_id", `String "focus-coord") ])
       with
       | Some result ->
           assert (Tool_result.is_success result);
@@ -167,7 +167,7 @@ let () =
       | None -> failwith "dispatch returned None")
 
 let () =
-  test "dispatch_pause_status_uninitialized_room_is_safe" (fun () ->
+  test "dispatch_pause_status_uninitialized_coord_is_safe" (fun () ->
       with_ctx ~initialize:false @@ fun ctx ->
       match Tool_control.dispatch ctx ~name:"masc_pause_status" ~args:(`Assoc []) with
       | Some result ->

--- a/test/test_tool_coord_coverage.ml
+++ b/test/test_tool_coord_coverage.ml
@@ -791,24 +791,6 @@ let () =
     | None -> failwith "dispatch returned None")
 ;;
 
-let () =
-  test "dispatch_check_coord_set" (fun () ->
-    let ctx = make_test_ctx () in
-    let _ = Coord.init ctx.config ~agent_name:(Some "test-agent") in
-    match
-      Tool_coord.dispatch
-        ctx
-        ~name:"masc_check"
-        ~args:(`Assoc [ "assertions", `List [ `String "coord_set" ] ])
-    with
-    | Some result ->
-      assert (Tool_result.is_success result);
-      let message = (Tool_result.message result) in
-      let json = Yojson.Safe.from_string message in
-      assert (Yojson.Safe.Util.member "all_passed" json = `Bool true)
-    | None -> failwith "dispatch returned None")
-;;
-
 (* Test helper functions *)
 let () =
   test "get_string_present" (fun () ->

--- a/test/test_tool_deep_review.ml
+++ b/test/test_tool_deep_review.ml
@@ -95,13 +95,13 @@ let test_build_prompt_rejects_rfc_docs_outside_docs_dir () =
             (String.length msg > 0)
       | Ok _ -> fail "expected RFC doc to be rejected")
 
-let test_build_prompt_rejects_room_task_history_paths () =
+let test_build_prompt_rejects_coord_task_history_paths () =
   with_temp_dir (fun base ->
-      let file = Filename.concat base "memory/room-task-history.jsonl" in
+      let file = Filename.concat base "memory/coord-task-history.jsonl" in
       write_file file "{}\n";
       match
         TDR.build_prompt
-          ~target_files:[ "memory/room-task-history.jsonl" ]
+          ~target_files:[ "memory/coord-task-history.jsonl" ]
           ~question:"Find issues"
           ~base_path:base
       with
@@ -122,7 +122,7 @@ let () =
             test_build_prompt_rejects_design_docs_by_full_path;
           test_case "reject rfc docs outside docs dir" `Quick
             test_build_prompt_rejects_rfc_docs_outside_docs_dir;
-          test_case "reject room/task history" `Quick
-            test_build_prompt_rejects_room_task_history_paths;
+          test_case "reject coord/task history" `Quick
+            test_build_prompt_rejects_coord_task_history_paths;
         ] );
     ]

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -313,10 +313,6 @@ let test_remote_operator_action_schema_is_strict () =
                   (List.mem (`String "task_inject") enums);
                 Alcotest.(check bool) (label ^ " excludes keeper_msg") false
                   (List.mem (`String "keeper_msg") enums);
-                Alcotest.(check bool) (label ^ " excludes room_pause") false
-                  (List.mem (`String "room_pause") enums);
-                Alcotest.(check bool) (label ^ " excludes room_resume") false
-                  (List.mem (`String "room_resume") enums);
                 Alcotest.(check bool) (label ^ " excludes team_note") false
                   (List.mem (`String "team_note") enums);
                 Alcotest.(check bool) (label ^ " excludes team_broadcast") false

--- a/test/test_typed_tool_masc.ml
+++ b/test/test_typed_tool_masc.ml
@@ -49,7 +49,7 @@ let test_handler_success () =
   match Tool_broadcast_typed.handle_broadcast "hello @agent_llm_a" with
   | Ok output ->
     Alcotest.(check bool) "delivered" true output.delivered;
-    Alcotest.(check string) "message" "hello @agent_llm_a" output.room_message;
+    Alcotest.(check string) "message" "hello @agent_llm_a" output.coord_message;
     Alcotest.(check (option string)) "mention" (Some "agent_llm_a") output.mention
   | Error e -> Alcotest.fail ("handler failed: " ^ e)
 
@@ -60,19 +60,19 @@ let test_handler_empty () =
 
 let test_handler_trim () =
   match Tool_broadcast_typed.handle_broadcast "  trimmed  " with
-  | Ok output -> Alcotest.(check string) "trimmed" "trimmed" output.room_message
+  | Ok output -> Alcotest.(check string) "trimmed" "trimmed" output.coord_message
   | Error e -> Alcotest.fail e
 
 let test_encode_mention () =
   let output : Tool_broadcast_typed.broadcast_output =
-    { delivered = true; room_message = "hi"; mention = Some "alice" } in
+    { delivered = true; coord_message = "hi"; mention = Some "alice" } in
   let json = Tool_broadcast_typed.encode_broadcast output in
   let open Yojson.Safe.Util in
   Alcotest.(check string) "mention" "alice" (json |> member "mention" |> to_string)
 
 let test_encode_no_mention () =
   let output : Tool_broadcast_typed.broadcast_output =
-    { delivered = true; room_message = "hi"; mention = None } in
+    { delivered = true; coord_message = "hi"; mention = None } in
   let json = Tool_broadcast_typed.encode_broadcast output in
   let open Yojson.Safe.Util in
   Alcotest.(check bool) "delivered" true (json |> member "delivered" |> to_bool)
@@ -100,8 +100,8 @@ let test_e2e_coerced_input () =
     let result = Yojson.Safe.from_string content in
     let open Yojson.Safe.Util in
     Alcotest.(check bool) "delivered" true (result |> member "delivered" |> to_bool);
-    Alcotest.(check string) "room_message" "99"
-      (result |> member "room_message" |> to_string)
+    Alcotest.(check string) "coord_message" "99"
+      (result |> member "coord_message" |> to_string)
   | Error e -> Alcotest.fail ("expected coercion success: " ^ e.message)
 
 let test_e2e_handler_error () =


### PR DESCRIPTION
## Summary
- replace typed broadcast output room_message with coord_message
- rename briefing coord matching residue and coord bootstrap test naming
- remove remaining perpetual/resident keeper directory concept from active bootstrap test/docs

## Validation
- not run per request