### PR TITLE
feat(keeper): restore @mention feed without rooms (single global cursor)

### DIFF
--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -542,6 +542,13 @@ type agent_runtime_state =
   ; last_runtime_attempt : runtime_attempt_record option
   ; last_need : string
   ; last_turn_tool_calls : tool_call_summary list
+  ; last_seen_message_seq : int
+    (** Global message-feed cursor: the highest [Coord] message seq this keeper
+        has already scanned for direct mentions.  Replaces the per-room
+        [last_seen_seq_by_room] map removed in the room-state purge; with rooms
+        gone, [Coord.get_all_messages_raw ~since_seq] is a single global stream,
+        so one cursor suffices.  Persisted across heartbeats so mentions are not
+        re-surfaced. *)
   }
 
 type keeper_meta =

--- a/lib/keeper/keeper_meta_json.ml
+++ b/lib/keeper/keeper_meta_json.ml
@@ -61,6 +61,7 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
     ; "board_reactive_turn_count", `Int rt.board_reactive_turn_count
     ; "mention_reactive_turn_count", `Int rt.mention_reactive_turn_count
     ; "noop_turn_count", `Int rt.noop_turn_count
+    ; "last_seen_message_seq", `Int rt.last_seen_message_seq
     ; "last_speech_act", `String rt.last_speech_act
     ; "last_social_transition_reason", `String rt.last_social_transition_reason
     ; "last_active_desire", `String rt.last_active_desire
@@ -143,6 +144,7 @@ let fallback_canonical_keeper_meta_key_names =
   ; "board_reactive_turn_count"
   ; "mention_reactive_turn_count"
   ; "noop_turn_count"
+  ; "last_seen_message_seq"
   ; "last_speech_act"
   ; "last_social_transition_reason"
   ; "last_active_desire"

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -411,6 +411,7 @@ let parse_keeper_state
     Safe_ops.json_int ~default:0 "mention_reactive_turn_count" json
   in
   let noop_turn_count = Safe_ops.json_int ~default:0 "noop_turn_count" json in
+  let last_seen_message_seq = Safe_ops.json_int ~default:0 "last_seen_message_seq" json in
   let last_speech_act = Safe_ops.json_string ~default:"" "last_speech_act" json in
   let last_social_transition_reason =
     Safe_ops.json_string ~default:"" "last_social_transition_reason" json
@@ -506,6 +507,7 @@ let parse_keeper_state
       ; board_reactive_turn_count
       ; mention_reactive_turn_count
       ; noop_turn_count
+      ; last_seen_message_seq
       ; last_speech_act
       ; last_social_transition_reason
       ; last_active_desire

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -503,6 +503,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
           board_reactive_turn_count = 0;
           mention_reactive_turn_count = 0;
           noop_turn_count = 0;
+          last_seen_message_seq = 0;
           last_speech_act = "";
           last_social_transition_reason = "";
 	          last_active_desire = "";

--- a/lib/keeper/keeper_world_observation_message_scope.ml
+++ b/lib/keeper/keeper_world_observation_message_scope.ml
@@ -44,17 +44,70 @@ let is_keeper_authored_message author =
   Option.is_some (Keeper_identity.canonical_keeper_name_from_agent_name author)
 ;;
 
+(* Room-less message feed.  The room-state purge removed the per-room cursor
+   [last_seen_seq_by_room] and the [joined_room_ids] iteration this scan used to
+   walk.  [Coord.get_all_messages_raw ~since_seq] was already a single global
+   stream (the per-room loop just called it once per room), so the feed
+   collapses to one scan since the global [meta.runtime.last_seen_message_seq]
+   cursor.  Direct @mention detection (the feed's contract) is preserved; the
+   former broad-scope branch was gated on the now-purged
+   [room_signal_prompt_enabled] setting, so scope_messages is always empty. *)
 let collect_message_scope ~(config : Coord.config) ~(meta : keeper_meta)
   : (string * string) list * (string * string) list * (string * int) list
   =
-  let _ = config in
-  let _ = meta in
-  [], [], []
+  let targets = message_feed_targets meta in
+  let self_tokens = self_identity_tokens meta in
+  let batch_limit = Keeper_config.keeper_batch_limit () in
+  let since_seq = meta.runtime.last_seen_message_seq in
+  let rec consume remaining last_processed mentions = function
+    | [] -> last_processed, List.rev mentions
+    | (msg : Masc_domain.message) :: rest ->
+      let author = String.trim msg.from_agent in
+      if author = "" || is_self_author ~self_tokens author
+      then consume remaining msg.seq mentions rest
+      else if
+        Coord_task_cache_invariant.stale_active_task_signal_present
+          ~config
+          ~from_agent:author
+          ~module_name:"keeper_world_observation"
+          ~content:msg.content
+      then consume remaining msg.seq mentions rest
+      else if exact_direct_mention_present ~targets msg.content
+      then
+        (* Saturation: stop without advancing past this mention so it is
+           re-surfaced next cycle (mirrors the former [`Saturated] path). *)
+        if remaining <= 0
+        then last_processed, List.rev mentions
+        else
+          consume
+            (remaining - 1)
+            msg.seq
+            ((msg.from_agent, msg.content) :: mentions)
+            rest
+      else consume remaining msg.seq mentions rest
+  in
+  let messages =
+    try Coord.get_all_messages_raw config ~since_seq with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | _ -> []
+  in
+  let last_processed, mentions = consume batch_limit since_seq [] messages in
+  let cursor_updates =
+    if last_processed > since_seq then [ meta.name, last_processed ] else []
+  in
+  mentions, [], cursor_updates
 ;;
 
+(* The cursor-update list is room-less now (at most one entry); fold the highest
+   seq into the single global cursor. *)
 let apply_message_cursor_updates (meta : keeper_meta) (updates : (string * int) list)
   : keeper_meta
   =
-  let _ = updates in
-  meta
+  let max_seq =
+    List.fold_left
+      (fun acc (_key, seq) -> if seq > acc then seq else acc)
+      meta.runtime.last_seen_message_seq
+      updates
+  in
+  { meta with runtime = { meta.runtime with last_seen_message_seq = max_seq } }
 ;;


### PR DESCRIPTION
## 목적

room-state purge가 죽인 keeper **@mention feed를 room 없이 복원**한다.

## 배경

room purge(#19634 등)가 `last_seen_seq_by_room`/`joined_room_ids`를 제거했고, 후속 빌드-fix가 `collect_message_scope`를 `[], [], []` **stub으로 만들어 feed를 조용히 무력화**했다(keeper가 @mention을 더 이상 인지 못 함). 사용자 요구: "room 없어도 동작하게, feed는 필요해."

## 구현 (단일 global cursor)

`Coord.get_all_messages_raw ~since_seq`는 **이미 global 스트림**이다(옛 per-room 루프는 room마다 같은 호출을 반복했을 뿐). 따라서 per-room cursor를 **단일 global cursor `agent_runtime_state.last_seen_message_seq`**로 collapse:

- `collect_message_scope`: cursor 이후 메시지를 한 번 스캔 → `exact_direct_mention_present`로 direct @mention surface. self/keeper-authored/stale-task-signal 필터는 유지. batch_limit saturation은 cursor를 mention 앞에서 멈춰 다음 cycle 재출현(옛 `Saturated` 동작 미러).
- broad-scope 분기는 purge된 `room_signal_prompt_enabled`에 묶여 있었으므로 제거 → `scope_messages = []`. **direct @mention이 feed의 본질 계약이고 그건 보존**.
- `apply_message_cursor_updates`: 업데이트 중 최대 seq를 단일 cursor에 fold.

## 직렬화 / 생성

- `last_seen_message_seq : int`를 `agent_runtime_state`에 추가, `keeper_meta_json[_parse]`에서 `noop_turn_count` 패턴 그대로 (de)serialize (default 0).
- 신규 keeper는 0 초기화(`keeper_turn_up_create`). `keeper_unified_metrics_result`는 functional update(`{rt with}`)라 cursor를 **carry-through**(리셋 안 함) — 매 metrics 갱신마다 0으로 덮으면 mention 무한 재출현하므로 의도적으로 미설정.

## 검증 상태 (중요)

**`dune build .` 미검증**: origin/main이 purge-fleet의 무관한 에러들로 RED 상태라 whole-program 빌드 불가. 로직·직렬화는 **읽기 + grep 완전성**으로 검수(`last_seen_message_seq` 9개 참조 정합 확인, 모든 full-construction 사이트 커버, functional-update 제외 확인). fleet이 main을 green으로 만든 뒤 **rebase + `dune build .` 확인 필요**.

**Draft 유지** — fleet green + rebase + 빌드 통과 전까지 Ready 전환 안 함.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
