### PR TITLE
Remove retired masc_leave from benchmarks

### DIFF
--- a/benchmarks/benchmark.sh
+++ b/benchmarks/benchmark.sh
@@ -185,12 +185,6 @@ bench_bootstrap_agent() {
   bench_call_tool "masc_start" "$(jq -cn --arg path "$BENCH_ROOM_PATH" '{path:$path}')" >/dev/null
 }
 
-bench_leave_agent() {
-  if [[ -n "$MCP_SESSION_ID" ]]; then
-    bench_call_tool "masc_leave" "$(jq -cn --arg agent "$MASC_AGENT" '{agent_name:$agent}')" >/dev/null 2>&1 || true
-  fi
-}
-
 stats_csv() {
   python3 - "$@" <<'PY'
 import math, sys
@@ -497,7 +491,6 @@ log "Session warmup iterations: $BENCH_SESSION_WARMUP_ITERATIONS"
 log "Results: $RESULT_FILE"
 
 printf 'benchmark,avg_ms,p50_ms,p95_ms,max_ms,notes\n' >"$RESULT_FILE"
-trap bench_leave_agent EXIT
 
 run_pattern
 COMPARE_BASELINE_FILE="$(find_compare_baseline || true)"

--- a/benchmarks/quick-bench.sh
+++ b/benchmarks/quick-bench.sh
@@ -166,12 +166,6 @@ bench_bootstrap_agent() {
   bench_call_tool "masc_start" "$(jq -cn --arg path "$BENCH_ROOM_PATH" '{path:$path}')" >/dev/null
 }
 
-bench_leave_agent() {
-  if [[ -n "$MCP_SESSION_ID" ]]; then
-    bench_call_tool "masc_leave" "$(jq -cn --arg agent "$MASC_AGENT" '{agent_name:$agent}')" >/dev/null 2>&1 || true
-  fi
-}
-
 measure_avg() {
   local label="$1"
   local tool_name="$2"
@@ -205,7 +199,6 @@ echo "Warmup iterations: $BENCH_WARMUP_ITERATIONS"
 echo ""
 
 bench_initialize_session
-trap bench_leave_agent EXIT
 
 echo "Operation                     Latency"
 echo "──────────────────────────────────────────────"


### PR DESCRIPTION
## Summary
- Remove the stale EXIT cleanup calls to retired `masc_leave` from both benchmark scripts.
- Keep benchmark startup on `masc_start`, which is the current bootstrap path.

## Verification
- `bash -n benchmarks/quick-bench.sh && bash -n benchmarks/benchmark.sh`
- `git diff --check origin/main..HEAD`
- `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/_build/default/test/test_tool_registration_consistency.exe test linter 4`
