### PR TITLE
[codex] Purge legacy keeper cursor meta

### DIFF
--- a/dashboard/design-system/preview/scope-phase2.html
+++ b/dashboard/design-system/preview/scope-phase2.html
@@ -545,7 +545,7 @@
         <p class="data">
           <b>.masc/messages/*_broadcast.json</b> · 909 entries<br/>
           fields: <em>seq</em>, <em>room_id</em>, <em>mentions</em> (e.g. @nick0cave), <em>[STATE]…[/STATE]</em> blocks<br/>
-          keeper의 <em>last_seen_seq_by_room</em>로 미독 계산
+          keeper의 <em>last_seen_message_seq</em>로 미독 계산
         </p>
         <p class="lbl">Variants</p>
         <ul class="vars">

--- a/docs/design/oas-masc-state-boundary.md
+++ b/docs/design/oas-masc-state-boundary.md
@@ -54,7 +54,7 @@ State that describes the coordination domain — not how an agent thinks, but wh
 
 | Category | Data | Current Owner | Target Owner |
 |----------|------|---------------|--------------|
-| Room membership | `joined_room_ids`, `last_seen_seq_by_room`, agents.json | MASC | MASC (single-room canonical state) |
+| Message cursor | `last_seen_message_seq`, agents.json | MASC | MASC (single-feed canonical state) |
 | Task claims | task files, `assignee`, `status` | MASC | MASC (correct) |
 | Board posts | `board_posts`, `board_comments`, `board_votes` | MASC | MASC (correct) |
 | Governance | petitions, cases, rulings, execution orders | MASC (`governance_v2`) | MASC (correct) |
@@ -95,7 +95,7 @@ So the flattened operational surface is roughly 83 fields. Approximately 29-30 o
 
 **Domain state fields in keeper_meta (correct placement):**
 - `mention_targets`, `proactive_*` — operational coordination policy
-- `joined_room_ids`, `last_seen_seq_by_room` — room membership state under the single-room canonical model
+- `last_seen_message_seq` — single-feed read cursor
 - `autonomy_level`, `active_goal_ids` — coordination state
 
 **Impact**: Every keeper turn reads the full keeper record, updates agent-runtime fields, and writes it back. This couples domain persistence (MASC JSONL/PG) with agent-runtime state that OAS should own.

--- a/lib/keeper/keeper_meta_json_scrub.ml
+++ b/lib/keeper/keeper_meta_json_scrub.ml
@@ -58,6 +58,7 @@ let persisted_retired_keeper_meta_key_names =
   let retired_discovery_key suffix = "work_" ^ "discovery" ^ suffix in
   [
     "repo_cli_identity";
+    "last_seen_seq_by_room";
     "last_" ^ retired_discovery_key "_ts";
     retired_discovery_key "_count";
     retired_discovery_key "_enabled";

--- a/test/test_keeper_auto_pause_blocker_persist_12683.ml
+++ b/test/test_keeper_auto_pause_blocker_persist_12683.ml
@@ -11,6 +11,39 @@
     related test rows have been removed accordingly.) *)
 
 open Alcotest
+
+let write_file path content =
+  let oc = open_out path in
+  Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () ->
+    output_string oc content)
+
+let init_test_runtime () =
+  let path = Filename.temp_file "keeper-meta-runtime-" ".toml" in
+  Fun.protect
+    ~finally:(fun () -> try Sys.remove path with _ -> ())
+    (fun () ->
+       write_file path
+         {|[runtime]
+default = "test_provider.test_model"
+
+[providers.test_provider]
+protocol = "provider_d-http"
+endpoint = "http://127.0.0.1:9/v1"
+
+[models.test_model]
+api-name = "test-model"
+max-context = 1024
+tools-support = true
+
+[test_provider.test_model]
+max-concurrent = 1
+|};
+       match Masc_mcp.Runtime.init_default ~config_path:path with
+       | Ok () -> ()
+       | Error msg -> failwith ("test runtime init failed: " ^ msg))
+
+let () = init_test_runtime ()
+
 module KT = Masc_mcp.Keeper_types
 module Keeper_meta_contract = Masc_mcp.Keeper_meta_contract
 module Keeper_meta_json_parse = Masc_mcp.Keeper_meta_json_parse
@@ -147,7 +180,7 @@ let test_legacy_last_blocker_pair_rejected () =
   | Error msg ->
     check string
       "rejects legacy blocker class"
-      "legacy keeper meta fields are no longer supported: last_blocker_class"
+      "removed keeper meta fields are no longer supported: last_blocker_class"
       msg
 
 let test_legacy_last_blocker_string_rejected () =
@@ -163,7 +196,7 @@ let test_legacy_last_blocker_string_rejected () =
   | Error msg ->
     check string
       "rejects string last_blocker"
-      "legacy keeper meta field shape is no longer supported: \
+      "removed keeper meta field shape is no longer supported: \
        last_blocker:string. Use structured last_blocker object."
       msg
 
@@ -179,7 +212,7 @@ let test_repo_cli_identity_runtime_meta_rejected () =
   | Error msg ->
     check string
       "rejects repo_cli_identity"
-      "legacy keeper meta fields are no longer supported: repo_cli_identity"
+      "removed keeper meta fields are no longer supported: repo_cli_identity"
       msg
 
 let has_key key = function
@@ -192,6 +225,7 @@ let test_persisted_retired_runtime_meta_fields_scrubbed () =
   let retired_fields =
     [
       "repo_cli_identity", `String "anyang-keepers";
+      "last_seen_seq_by_room", `Assoc [ "default", `Int 5749 ];
       "last_" ^ retired_discovery_key "_ts", `String "2026-05-24T16:29:11Z";
       retired_discovery_key "_count", `Int 12;
       retired_discovery_key "_enabled", `Bool true;


### PR DESCRIPTION
## Summary
- scrub retired last_seen_seq_by_room from persisted keeper meta before unknown-key warnings
- update the meta scrub regression fixture and removed-field expectations
- replace stale docs/preview mentions with last_seen_message_seq

## Validation
- ocamlformat --check lib/keeper/keeper_meta_json_scrub.ml test/test_keeper_auto_pause_blocker_persist_12683.ml
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_auto_pause_blocker_persist_12683.exe
- ./_build/default/test/test_keeper_auto_pause_blocker_persist_12683.exe
- jq verified /Users/dancer/me/.masc/keepers/masc-improver.json has no last_seen_seq_by_room and preserves last_seen_message_seq=5749