### PR TITLE
fix(runtime): drop auth credential from headers (duplicate Authorization → qwen cloudflare 400)

### DIFF
--- a/lib/runtime/runtime_adapter.ml
+++ b/lib/runtime/runtime_adapter.ml
@@ -30,16 +30,24 @@ let normalize_provider_id provider_id =
   |> String.map (fun c -> if c = '-' then '_' else c)
 ;;
 
+(* Returns the non-credential request headers only. The auth credential
+   (Authorization / x-api-key) is intentionally NOT emitted here: the OAS
+   transport derives it from [~api_key] at request time, and its contract is
+   that the header list "never carries sensitive tokens" (oas api.ml auth_hdrs).
+   Emitting the credential here too produced a DUPLICATE Authorization header
+   that RunPod's cloudflare edge rejected with an opaque 400 before the origin
+   (diagnosed 2026-06-01 via the http_client_4xx_request_header_profile log:
+   2 x Authorization, 74 B each). The token still travels to OAS via [~api_key];
+   only Content-Type (OAS does not set it) and the non-credential Anthropic
+   version header belong here. *)
 let headers_with_auth ~(kind : Llm_provider.Provider_config.provider_kind) ~api_key =
   let base = [ ("Content-Type", "application/json") ] in
   if api_key = ""
   then base
   else (
     match kind with
-    | Anthropic ->
-      ("x-api-key", api_key) :: ("provider_a-version", "2023-06-01") :: base
-    | OpenAI_compat | Ollama | Gemini | Glm | Kimi | DashScope ->
-      ("Authorization", "Bearer " ^ api_key) :: base)
+    | Anthropic -> ("provider_a-version", "2023-06-01") :: base
+    | OpenAI_compat | Ollama | Gemini | Glm | Kimi | DashScope -> base)
 ;;
 
 let trim_trailing_slash path =

--- a/lib/runtime/runtime_provider_binding.ml
+++ b/lib/runtime/runtime_provider_binding.ml
@@ -107,16 +107,24 @@ let display_provider_name provider_name =
 
 (* Build headers list with Authorization when api_key is present.
    Anthropic/Anthropic use x-api-key; OpenAI-compat (including GLM) uses Bearer. *)
+(* Returns the non-credential request headers only. The auth credential
+   (Authorization / x-api-key) is intentionally NOT emitted here: the OAS
+   transport derives it from [~api_key] at request time, and its contract is
+   that the header list "never carries sensitive tokens" (oas api.ml auth_hdrs).
+   Emitting the credential here too produced a DUPLICATE Authorization header
+   that RunPod's cloudflare edge rejected with an opaque 400 before the origin
+   (diagnosed 2026-06-01 via the http_client_4xx_request_header_profile log:
+   2 x Authorization). The token still travels to OAS via [~api_key]; only
+   Content-Type (OAS does not set it) and the non-credential Anthropic version
+   header belong here. Mirror of [Runtime_adapter.headers_with_auth] — keep in
+   sync (tracked for de-duplication). *)
 let headers_with_auth ~(kind : Llm_provider.Provider_config.provider_kind) ~api_key =
   let base = [("Content-Type", "application/json")] in
   if api_key = "" then base
     else match kind with
     | Anthropic ->
-        ("x-api-key", api_key)
-        :: ("provider_a-version", "2023-06-01")
-        :: base
-    | OpenAI_compat | Ollama | Gemini | Glm | Kimi | DashScope ->
-        ("Authorization", "Bearer " ^ api_key) :: base
+        ("provider_a-version", "2023-06-01") :: base
+    | OpenAI_compat | Ollama | Gemini | Glm | Kimi | DashScope -> base
 
 let trim_trailing_slash path =
   if String.length path > 1 && String.ends_with ~suffix:"/" path then


### PR DESCRIPTION
## 증상 (production-blocking)

keeper/governance 턴이 qwen runtime(`runpod_mtp.qwen36-35b-a3b-mtp`)으로 갈 때마다 `~0.076s`에 `400 Bad Request cloudflare`로 FAILED. albini 등 keeper cycle 전멸.

## 근본 원인 — 중복 `Authorization` 헤더

oas #1820 프로파일러가 첫 재발에 정전했습니다:
```json
{"event":"http_client_4xx_request_header_profile","status":400,"response_server":"cloudflare",
 "max_single_header_bytes":74,"total_request_header_bytes":222,
 "header_sizes":[{"name":"Authorization","bytes":74},{"name":"Authorization","bytes":74},
                 {"name":"Content-Type"},...]}
```
크기(74B, 8192 한참 아래)도 malformed 값도 아닌 **Authorization ×2**. RunPod `*.proxy.runpod.net` cloudflare edge가 중복 Authorization을 ambiguous로 보고 origin 도달 전 400.

출처: masc가 `headers_with_auth`에서 `Authorization`을 만들어 `~headers`에 넣고, `~api_key`도 함께 넘김 → oas transport가 `~api_key`로 **또** Authorization 파생(`api.ml` `header_list @ auth_hdrs`). oas 계약은 *"header list never carries sensitive tokens"*인데 masc가 위반.

## 변경

`headers_with_auth`(runtime_adapter.ml + runtime_provider_binding.ml, **동일 복제본 2개**)가 credential(Authorization/x-api-key)을 **더 이상 emit하지 않음**. Content-Type(oas가 안 붙임)과 비-credential Anthropic version 헤더만 반환. 토큰은 `~api_key`로 전달되어 oas가 **단일** Authorization을 붙임. → oas의 header_list 계약에 다시 부합.

## 검증

- `dune build @check` (whole-program) **exit 0**.
- 3중 입증: 프로파일러 진단(중복 정전) + oas 문서화된 계약 + @check.
- **라이브 검증**: 재배포 후 다음 governance 턴에서 프로파일러가 Authorization **1개**를 보이거나 턴 성공.

## 미검증 / follow-up

- 회귀 unit 테스트: lib에 inline_tests 미사용 + test/dune 배선 friction → production fix 최소화를 위해 fast-follow로 분리.
- `headers_with_auth` 복제본 2개 de-duplication (DRY) follow-up.

## RFC

새 credential 아키텍처 아님 — oas의 기존 `header_list` 계약 위반을 바로잡는 버그 fix. RFC-0008(credential-provider)이 credential 컨텍스트. RFC 불필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)