### PR TITLE
Send runtime provider auth once

### DIFF
--- a/lib/runtime/runtime_adapter.ml
+++ b/lib/runtime/runtime_adapter.ml
@@ -11,7 +11,7 @@
     Runtime is one pre-selected binding. Errors are surfaced as
     [(_, string) result] so the caller fails fast (no silent fallback).
 
-    The three identity helpers ([normalize_provider_id], [headers_with_auth],
+    The identity helpers ([normalize_provider_id], [default_headers_for_kind],
     [normalize_openai_compat_request_path]) lived only in the deleted
     [Runtime_config_provider_binding] and are inlined here so this module has
     no [Runtime_*] dependency.
@@ -40,14 +40,11 @@ let normalize_provider_id provider_id =
    2 x Authorization, 74 B each). The token still travels to OAS via [~api_key];
    only Content-Type (OAS does not set it) and the non-credential Anthropic
    version header belong here. *)
-let headers_with_auth ~(kind : Llm_provider.Provider_config.provider_kind) ~api_key =
+let default_headers_for_kind (kind : Llm_provider.Provider_config.provider_kind) =
   let base = [ ("Content-Type", "application/json") ] in
-  if api_key = ""
-  then base
-  else (
-    match kind with
-    | Anthropic -> ("provider_a-version", "2023-06-01") :: base
-    | OpenAI_compat | Ollama | Gemini | Glm | Kimi | DashScope -> base)
+  match kind with
+  | Anthropic -> ("provider_a-version", "2023-06-01") :: base
+  | OpenAI_compat | Ollama | Gemini | Glm | Kimi | DashScope -> base
 ;;
 
 let trim_trailing_slash path =
@@ -258,15 +255,15 @@ let provider_config_from_declared_provider (provider : Runtime_schema.provider)
          request_path_for_http_provider ~provider ~registry_entry ~kind ~base_url
        in
        let api_key = api_key_of_credential ?registry_entry provider.credentials in
-       let auth_headers = headers_with_auth ~kind ~api_key in
+       let default_headers = default_headers_for_kind kind in
        let custom_headers = Option.value ~default:[] provider.headers in
-       (* TOML-declared custom headers override generated auth headers by key.
-          This allows operators to set provider-specific headers (e.g.
-          provider_a-version) while preserving auth and Content-Type. *)
+       (* TOML-declared custom headers override generated non-auth headers by
+          key. Auth is carried only by [api_key] and is merged by OAS at HTTP
+          request time, so [Provider_config.headers] does not duplicate secrets. *)
        let custom_keys = List.map fst custom_headers in
        let headers =
          custom_headers
-         @ List.filter (fun (k, _) -> not (List.mem k custom_keys)) auth_headers
+         @ List.filter (fun (k, _) -> not (List.mem k custom_keys)) default_headers
        in
        Some
          (Llm_provider.Provider_config.make

--- a/lib/runtime/runtime_adapter.ml
+++ b/lib/runtime/runtime_adapter.ml
@@ -47,6 +47,14 @@ let default_headers_for_kind (kind : Llm_provider.Provider_config.provider_kind)
   | OpenAI_compat | Ollama | Gemini | Glm | Kimi | DashScope -> base
 ;;
 
+let normalize_header_key key = String.lowercase_ascii (String.trim key)
+
+let is_auth_header_key key =
+  match normalize_header_key key with
+  | "authorization" | "x-api-key" -> true
+  | _ -> false
+;;
+
 let trim_trailing_slash path =
   if String.length path > 1 && String.ends_with ~suffix:"/" path
   then String.sub path 0 (String.length path - 1)
@@ -256,14 +264,20 @@ let provider_config_from_declared_provider (provider : Runtime_schema.provider)
        in
        let api_key = api_key_of_credential ?registry_entry provider.credentials in
        let default_headers = default_headers_for_kind kind in
-       let custom_headers = Option.value ~default:[] provider.headers in
+       let custom_headers =
+         provider.headers
+         |> Option.value ~default:[]
+         |> List.filter (fun (key, _) -> not (is_auth_header_key key))
+       in
        (* TOML-declared custom headers override generated non-auth headers by
           key. Auth is carried only by [api_key] and is merged by OAS at HTTP
           request time, so [Provider_config.headers] does not duplicate secrets. *)
-       let custom_keys = List.map fst custom_headers in
+       let custom_keys = List.map (fun (key, _) -> normalize_header_key key) custom_headers in
        let headers =
          custom_headers
-         @ List.filter (fun (k, _) -> not (List.mem k custom_keys)) default_headers
+         @ List.filter
+             (fun (key, _) -> not (List.mem (normalize_header_key key) custom_keys))
+             default_headers
        in
        Some
          (Llm_provider.Provider_config.make

--- a/lib/runtime/runtime_model_string.ml
+++ b/lib/runtime/runtime_model_string.ml
@@ -105,7 +105,7 @@ let make_registry_config
     then ""
     else Sys.getenv_opt effective_api_key_env |> Option.value ~default:""
   in
-  let headers = Binding.headers_with_auth ~kind:defaults.kind ~api_key in
+  let headers = Binding.default_headers_for_kind defaults.kind in
   let discover =
     if Binding.provider_name_matches_kind_default provider_name Ollama
     then

--- a/lib/runtime/runtime_provider_binding.ml
+++ b/lib/runtime/runtime_provider_binding.ml
@@ -105,6 +105,13 @@ let display_provider_name provider_name =
   | None -> String.trim provider_name
 ;;
 
+let default_headers_for_kind (kind : Llm_provider.Provider_config.provider_kind) =
+  let base = [("Content-Type", "application/json")] in
+  match kind with
+  | Anthropic -> ("provider_a-version", "2023-06-01") :: base
+  | OpenAI_compat | Ollama | Gemini | Glm | Kimi | DashScope -> base
+;;
+
 (* Build headers list with Authorization when api_key is present.
    Anthropic/Anthropic use x-api-key; OpenAI-compat (including GLM) uses Bearer. *)
 (* Returns the non-credential request headers only. The auth credential

--- a/lib/runtime/runtime_provider_binding.mli
+++ b/lib/runtime/runtime_provider_binding.mli
@@ -47,6 +47,9 @@ val provider_name_matches_kind_default :
 
 val display_provider_name : string -> string
 
+val default_headers_for_kind :
+  Llm_provider.Provider_config.provider_kind -> (string * string) list
+
 val headers_with_auth :
   kind:Llm_provider.Provider_config.provider_kind ->
   api_key:string ->

--- a/lib/runtime/runtime_wire_overlay.ml
+++ b/lib/runtime/runtime_wire_overlay.ml
@@ -14,19 +14,8 @@ let api_key_from_env name =
      | None -> "")
 ;;
 
-let auth_headers_for_provider_cfg
-      ~(api_key : string)
-      (provider_cfg : Llm_provider.Provider_config.t)
-  =
-  let headers = provider_cfg.headers in
-  if String.trim api_key = ""
-  then headers
-  else (
-    match provider_cfg.kind with
-    | Anthropic -> ("x-api-key", api_key) :: headers
-    | Gemini -> headers
-    | OpenAI_compat | Ollama | Glm | Kimi | DashScope ->
-      ("Authorization", "Bearer " ^ api_key) :: headers)
+let headers_for_provider_cfg (provider_cfg : Llm_provider.Provider_config.t) =
+  provider_cfg.headers
 ;;
 
 let request_kind_of_provider_cfg (provider_cfg : Llm_provider.Provider_config.t) =
@@ -111,7 +100,7 @@ let register_capability_overlay_provider
            Ok
              ( provider_cfg.base_url
              , api_key
-             , auth_headers_for_provider_cfg ~api_key provider_cfg ))
+             , headers_for_provider_cfg provider_cfg ))
     }
 ;;
 

--- a/test/dune
+++ b/test/dune
@@ -181,6 +181,7 @@
   test_keeper_behavioral_regime
   test_keeper_toml
   test_keeper_runtime_toml
+  test_runtime_provider_auth_headers
   test_keeper_tool_policy_config
   test_keeper_tool_name_projection
   test_keeper_tool_resolution
@@ -442,6 +443,7 @@
   test_keeper_behavioral_regime
   test_keeper_toml
   test_keeper_runtime_toml
+  test_runtime_provider_auth_headers
   test_keeper_tool_policy_config
   test_keeper_tool_name_projection
   test_keeper_tool_resolution

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -6,6 +6,18 @@ let header_count name headers =
   |> List.filter (fun (k, _) -> String.equal k name)
   |> List.length
 
+let normalized_header_count name headers =
+  let name = String.lowercase_ascii name in
+  headers
+  |> List.filter (fun (k, _) -> String.equal name (String.lowercase_ascii k))
+  |> List.length
+
+let normalized_header_value name headers =
+  let name = String.lowercase_ascii name in
+  headers
+  |> List.find_map (fun (k, v) ->
+    if String.equal name (String.lowercase_ascii k) then Some v else None)
+
 let runpod_provider =
   { Runtime_schema.id = "runpod_mtp"
   ; display_name = "RunPod"
@@ -58,6 +70,46 @@ let test_runtime_adapter_keeps_auth_out_of_headers () =
     check int "Content-Type header count" 1
       (header_count "Content-Type" provider_cfg.headers)
 
+let test_runtime_adapter_filters_toml_auth_headers () =
+  let provider =
+    { runpod_provider with
+      headers =
+        Some
+          [ "Authorization", "Bearer from-toml"
+          ; "X-API-Key", "from-toml"
+          ; "Content-Type", "application/custom+json"
+          ; "X-Trace-Id", "trace-1"
+          ]
+    }
+  in
+  let cfg =
+    { Runtime_schema.providers = [ provider ]
+    ; models = [ qwen_model ]
+    ; bindings = [ runpod_binding ]
+    ; default_runtime_id = Some "runpod_mtp.qwen"
+    }
+  in
+  match Runtime_adapter.binding_to_provider_config cfg runpod_binding with
+  | Error msg -> failf "unexpected adapter error: %s" msg
+  | Ok provider_cfg ->
+    check string "api key" "rp-test-token" provider_cfg.api_key;
+    check int "Authorization header count" 0
+      (normalized_header_count "Authorization" provider_cfg.headers);
+    check int "x-api-key header count" 0
+      (normalized_header_count "x-api-key" provider_cfg.headers);
+    check int "Content-Type header count" 1
+      (normalized_header_count "Content-Type" provider_cfg.headers);
+    check
+      (option string)
+      "Content-Type override"
+      (Some "application/custom+json")
+      (normalized_header_value "Content-Type" provider_cfg.headers);
+    check
+      (option string)
+      "non-auth custom header"
+      (Some "trace-1")
+      (normalized_header_value "X-Trace-Id" provider_cfg.headers)
+
 let () =
   run "runtime_provider_auth_headers"
     [ ( "provider_config"
@@ -65,5 +117,9 @@ let () =
             "runtime adapter carries auth in api_key only"
             `Quick
             test_runtime_adapter_keeps_auth_out_of_headers
+        ; test_case
+            "runtime adapter filters TOML auth headers"
+            `Quick
+            test_runtime_adapter_filters_toml_auth_headers
         ] )
     ]

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -1,0 +1,69 @@
+open Alcotest
+open Masc_mcp
+
+let header_count name headers =
+  headers
+  |> List.filter (fun (k, _) -> String.equal k name)
+  |> List.length
+
+let runpod_provider =
+  { Runtime_schema.id = "runpod_mtp"
+  ; display_name = "RunPod"
+  ; protocol = "provider_d-http"
+  ; api_format = Chat_completions_api
+  ; transport = Http "https://example-runpod.proxy.runpod.net/v1"
+  ; is_non_interactive = true
+  ; credentials = Some (Inline "rp-test-token")
+  ; capabilities = None
+  ; headers = None
+  }
+
+let qwen_model =
+  { Runtime_schema.id = "qwen"
+  ; api_name = "qwen"
+  ; tools_support = true
+  ; max_context = 160000
+  ; thinking_support = true
+  ; max_thinking_budget = None
+  ; streaming = true
+  ; capabilities = None
+  ; match_prefixes = []
+  }
+
+let runpod_binding =
+  { Runtime_schema.provider_id = "runpod_mtp"
+  ; model_id = "qwen"
+  ; is_default = true
+  ; max_concurrent = 4
+  ; price_input = None
+  ; price_output = None
+  ; keep_alive = None
+  ; num_ctx = None
+  }
+
+let test_runtime_adapter_keeps_auth_out_of_headers () =
+  let cfg =
+    { Runtime_schema.providers = [ runpod_provider ]
+    ; models = [ qwen_model ]
+    ; bindings = [ runpod_binding ]
+    ; default_runtime_id = Some "runpod_mtp.qwen"
+    }
+  in
+  match Runtime_adapter.binding_to_provider_config cfg runpod_binding with
+  | Error msg -> failf "unexpected adapter error: %s" msg
+  | Ok provider_cfg ->
+    check string "api key" "rp-test-token" provider_cfg.api_key;
+    check int "Authorization header count" 0
+      (header_count "Authorization" provider_cfg.headers);
+    check int "Content-Type header count" 1
+      (header_count "Content-Type" provider_cfg.headers)
+
+let () =
+  run "runtime_provider_auth_headers"
+    [ ( "provider_config"
+      , [ test_case
+            "runtime adapter carries auth in api_key only"
+            `Quick
+            test_runtime_adapter_keeps_auth_out_of_headers
+        ] )
+    ]


### PR DESCRIPTION
Summary:
- keep runtime Provider_config.headers non-auth-only so OAS adds Authorization once from api_key
- apply the same contract to runtime model labels and capability overlay providers
- add regression coverage for RunPod-style runtime bindings

Validation:
- scripts/dune-local.sh build test/test_runtime_provider_auth_headers.exe
- scripts/dune-local.sh exec test/test_runtime_provider_auth_headers.exe
- git diff --cached --check