### PR TITLE
[codex] Purge lobby viewer naming

### DIFF
--- a/dashboard/design-system/preview/scope-phase2.html
+++ b/dashboard/design-system/preview/scope-phase2.html
@@ -545,7 +545,7 @@
         <p class="data">
           <b>.masc/messages/*_broadcast.json</b> · 909 entries<br/>
           fields: <em>seq</em>, <em>room_id</em>, <em>mentions</em> (e.g. @nick0cave), <em>[STATE]…[/STATE]</em> blocks<br/>
-          keeper의 <em>last_seen_seq_by_room</em>로 미독 계산
+          keeper의 <em>last_seen_message_seq</em>로 미독 계산
         </p>
         <p class="lbl">Variants</p>
         <ul class="vars">

--- a/docs/design/oas-masc-state-boundary.md
+++ b/docs/design/oas-masc-state-boundary.md
@@ -54,7 +54,7 @@ State that describes the coordination domain — not how an agent thinks, but wh
 
 | Category | Data | Current Owner | Target Owner |
 |----------|------|---------------|--------------|
-| Room membership | `joined_room_ids`, `last_seen_seq_by_room`, agents.json | MASC | MASC (single-room canonical state) |
+| Message cursor | `last_seen_message_seq`, agents.json | MASC | MASC (single-feed canonical state) |
 | Task claims | task files, `assignee`, `status` | MASC | MASC (correct) |
 | Board posts | `board_posts`, `board_comments`, `board_votes` | MASC | MASC (correct) |
 | Governance | petitions, cases, rulings, execution orders | MASC (`governance_v2`) | MASC (correct) |
@@ -95,7 +95,7 @@ So the flattened operational surface is roughly 83 fields. Approximately 29-30 o
 
 **Domain state fields in keeper_meta (correct placement):**
 - `mention_targets`, `proactive_*` — operational coordination policy
-- `joined_room_ids`, `last_seen_seq_by_room` — room membership state under the single-room canonical model
+- `last_seen_message_seq` — single-feed read cursor
 - `autonomy_level`, `active_goal_ids` — coordination state
 
 **Impact**: Every keeper turn reads the full keeper record, updates agent-runtime fields, and writes it back. This couples domain persistence (MASC JSONL/PG) with agent-runtime state that OAS should own.

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -7,13 +7,13 @@
     <link data-trunk rel="css" href="style.css" />
     <link data-trunk rel="copy-dir" href="assets" />
 </head>
-<body class="mode-lobby">
+<body class="mode-home">
 
-    <!-- ═══ Lobby Screen (Mode Selector) ═══ -->
-    <div id="lobby-screen">
-        <div class="lobby-header">
-            <h1 class="lobby-title">MASC Viewer</h1>
-            <p class="lobby-subtitle">Multi-Agent Streaming Coordination</p>
+    <!-- ═══ Home Screen (Mode Selector) ═══ -->
+    <div id="home-screen">
+        <div class="home-header">
+            <h1 class="home-title">MASC Viewer</h1>
+            <p class="home-subtitle">Multi-Agent Streaming Coordination</p>
         </div>
 
         <div id="mode-cards" class="mode-grid">
@@ -42,7 +42,7 @@
             </button>
         </div>
 
-        <div class="lobby-footer">
+        <div class="home-footer">
             <span class="theme-label">Theme</span>
             <select id="theme-selector">
                 <option value="dark-fantasy" selected>Dark Fantasy</option>
@@ -64,7 +64,7 @@
         <div class="mode-panel-header">
             <h2>System Monitor</h2>
             <div id="monitor-status" class="mode-status status-disconnected">연결 대기 중</div>
-            <button class="back-btn" data-back="lobby">◂ Back</button>
+            <button class="back-btn" data-back="home">◂ Back</button>
         </div>
         <div class="mode-panel-content">
             <div class="monitor-grid">
@@ -94,7 +94,7 @@
     <div id="social-panel" class="mode-panel" style="display: none;">
         <div class="mode-panel-header">
             <h2>Social Board</h2>
-            <button class="back-btn" data-back="lobby">◂ Back</button>
+            <button class="back-btn" data-back="home">◂ Back</button>
         </div>
         <div class="mode-panel-content">
             <div class="panel-header">
@@ -111,7 +111,7 @@
     <div id="experiment-panel" class="mode-panel" style="display: none;">
         <div class="mode-panel-header">
             <h2>Experiments</h2>
-            <button class="back-btn" data-back="lobby">◂ Back</button>
+            <button class="back-btn" data-back="home">◂ Back</button>
         </div>
         <div class="mode-panel-content">
             <div class="panel-header">
@@ -128,7 +128,7 @@
     <div id="dashboard" style="display: none;" data-auto-round="0">
         <!-- Top Bar -->
         <header id="top-bar">
-            <button id="back-to-lobby" class="icon-btn" title="Back to Lobby">◂</button>
+            <button id="back-to-home" class="icon-btn" title="Back to Home">◂</button>
             <span id="mode-title">—</span>
             <div class="top-bar-right">
                 <div class="room-switch-inline">
@@ -297,7 +297,7 @@
         </section>
 
         <section id="trpg-surface-nav" class="trpg-surface-nav" style="display: none;" aria-label="TRPG 운영 콘솔">
-            <button class="trpg-surface-tab" type="button" data-trpg-surface="lobby" aria-pressed="false">Lobby</button>
+            <button class="trpg-surface-tab" type="button" data-trpg-surface="idle" aria-pressed="false">Idle</button>
             <button class="trpg-surface-tab" type="button" data-trpg-surface="overview" aria-pressed="true">Overview</button>
             <button class="trpg-surface-tab" type="button" data-trpg-surface="timeline" aria-pressed="false">Timeline</button>
             <button class="trpg-surface-tab" type="button" data-trpg-surface="control" aria-pressed="false">Control</button>
@@ -472,13 +472,13 @@
                     <div id="state-legend" class="state-legend runtime-advanced">
                         <span class="state-chip state-running">RUNNING: 라운드 순환 중</span>
                         <span class="state-chip state-stopped">STOPPED: 일시 정지/재개 대기</span>
-                        <span class="state-chip state-lobby">LOBBY: 세션 시작 전</span>
+                        <span class="state-chip state-idle">IDLE: 세션 시작 전</span>
                         <span class="state-chip state-ended">ENDED: 세션 종료</span>
                         <span class="state-chip state-unavailable">UNAVAILABLE: 연결/키퍼 오류</span>
                     </div>
                     <div id="lifecycle-diagram" class="lifecycle-diagram runtime-advanced" aria-label="TRPG 상태 전이 다이어그램">
                         <div class="lifecycle-track">
-                            <span class="lifecycle-node" data-state="lobby">LOBBY</span>
+                            <span class="lifecycle-node" data-state="idle">IDLE</span>
                             <span class="lifecycle-edge">→</span>
                             <span class="lifecycle-node" data-state="running">RUNNING</span>
                             <span class="lifecycle-edge">↔</span>
@@ -700,7 +700,7 @@
         const body = document.body;
         let booted = false;
 
-        function hideLoading(forceLobby, message) {
+        function hideLoading(forceHome, message) {
             if (!loading) return;
             loading.classList.add('hidden');
             loading.style.opacity = '0';
@@ -708,8 +708,8 @@
             if (message && loadingText) {
                 loadingText.textContent = message;
             }
-            if (forceLobby && body) {
-                body.classList.add('mode-lobby');
+            if (forceHome && body) {
+                body.classList.add('mode-home');
             }
         }
 

--- a/viewer/src/config.rs
+++ b/viewer/src/config.rs
@@ -374,7 +374,7 @@ pub fn apply_auth_headers(headers: &web_sys::Headers) -> Result<(), wasm_bindgen
 
 // ─── Room ID Management ─────────────────────
 
-/// Get current room ID from DOM attribute (set by dashboard/lobby) or URL param.
+/// Get current room ID from DOM attribute (set by dashboard/home) or URL param.
 pub fn current_room_id() -> String {
     #[cfg(target_arch = "wasm32")]
     {
@@ -422,7 +422,7 @@ pub fn set_current_room_id(room_id: &str) {
                     .search()
                     .ok()
                     .and_then(|search| parse_query_param(&search, "mode"))
-                    .filter(|mode| !mode.trim().is_empty() && mode != "lobby");
+                    .filter(|mode| !mode.trim().is_empty() && mode != "home");
                 let url = match mode_param {
                     Some(mode) => format!("?mode={}&room={}", mode, room_id),
                     None => format!("?room={}", room_id),
@@ -509,7 +509,7 @@ pub fn sse_endpoint(mode: &ViewerMode) -> Option<String> {
         ViewerMode::Monitor => Some(build_masc_url("sse?room=monitor")),
         ViewerMode::Experiment => Some(build_masc_url("sse?room=experiment")),
         ViewerMode::Social => Some(build_masc_url("sse?room=social")),
-        ViewerMode::Lobby => None,
+        ViewerMode::Home => None,
     }
 }
 

--- a/viewer/src/dom/session_history.rs
+++ b/viewer/src/dom/session_history.rs
@@ -87,7 +87,7 @@ fn normalize_room_status(raw: &str) -> String {
             "active"
         }
         "paused" | "pause" | "stopped" | "on_hold" | "on-hold" => "paused",
-        "idle" | "lobby" | "created" | "ready" => "unknown",
+        "idle" | "created" | "ready" => "unknown",
         "ended" | "finished" | "completed" | "closed" | "done" | "archived" | "terminated" => {
             "ended"
         }

--- a/viewer/src/dom/turn_controls.rs
+++ b/viewer/src/dom/turn_controls.rs
@@ -231,13 +231,11 @@ fn derive_trpg_ui_state(
     // Only honour round_running when the session is actually active.
     // Stale DOM attributes (data-round-runner-active) can persist after a
     // session ends abnormally, locking the UI in RoundRunning even though
-    // the lifecycle has returned to Lobby/Ended.
+    // the lifecycle has returned to Idle/Ended.
     if round_running
         && !matches!(
             lifecycle,
-            TrpgLifecycleState::Lobby
-                | TrpgLifecycleState::Ended
-                | TrpgLifecycleState::Unknown
+            TrpgLifecycleState::Idle | TrpgLifecycleState::Ended | TrpgLifecycleState::Unknown
         )
     {
         return TrpgUiState::RoundRunning;
@@ -249,11 +247,11 @@ fn derive_trpg_ui_state(
         TrpgLifecycleState::Running => TrpgUiState::SessionRunning,
         TrpgLifecycleState::Stopped => TrpgUiState::Paused,
         TrpgLifecycleState::Ended => TrpgUiState::Ended,
-        TrpgLifecycleState::Lobby | TrpgLifecycleState::Unknown => {
+        TrpgLifecycleState::Idle | TrpgLifecycleState::Unknown => {
             if preflight_ok && wizard_ready {
                 TrpgUiState::ConfigReady
             } else {
-                TrpgUiState::Lobby
+                TrpgUiState::Idle
             }
         }
         TrpgLifecycleState::Loading => TrpgUiState::SessionStarting,
@@ -422,13 +420,13 @@ pub fn sync_turn_controls_visibility(
         let lock_owner = current_round_flight_owner(&doc);
 
         // ── Stale DOM cleanup ──────────────────────────────────────────
-        // When the lifecycle has returned to a terminal state (Lobby or
+        // When the lifecycle has returned to a terminal state (Idle or
         // Ended), any lingering round-runner / flight-owner DOM flags are
         // stale leftovers from a previous session that ended abnormally.
         // Force-clear them so the UI is not permanently locked.
         if matches!(
             lifecycle,
-            TrpgLifecycleState::Lobby | TrpgLifecycleState::Ended
+            TrpgLifecycleState::Idle | TrpgLifecycleState::Ended
         ) {
             if let Some(dashboard) = doc.get_element_by_id("dashboard") {
                 let _ = dashboard.set_attribute("data-round-runner-active", "0");
@@ -1954,7 +1952,7 @@ mod tests {
     #[test]
     fn derive_round_control_state_requires_running_or_stopped() {
         let (can_run, reason, css) =
-            derive_round_control_state(TrpgLifecycleState::Lobby, true, None);
+            derive_round_control_state(TrpgLifecycleState::Idle, true, None);
         assert!(!can_run);
         assert!(reason.contains("실행 대기"));
         assert_eq!(css, "status-info");
@@ -2021,7 +2019,7 @@ mod tests {
     fn round_readiness_rows_report_missing_requirements() {
         let rows = derive_round_readiness_rows(
             false,
-            TrpgLifecycleState::Lobby,
+            TrpgLifecycleState::Idle,
             false,
             0,
             Some("자동 라운드 실행 중"),
@@ -2045,18 +2043,16 @@ mod tests {
 
     #[test]
     fn derive_trpg_ui_state_requires_preflight_before_ready() {
-        let state =
-            derive_trpg_ui_state(TrpgLifecycleState::Lobby, true, false, false, true, false);
-        assert_eq!(state, TrpgUiState::Lobby);
+        let state = derive_trpg_ui_state(TrpgLifecycleState::Idle, true, false, false, true, false);
+        assert_eq!(state, TrpgUiState::Idle);
     }
 
     /// Stale `data-round-runner-active` DOM attribute must NOT lock the UI
-    /// when lifecycle has returned to Lobby (e.g. after abnormal session end).
+    /// when lifecycle has returned to Idle (e.g. after abnormal session end).
     #[test]
-    fn derive_trpg_ui_state_ignores_stale_round_running_in_lobby() {
-        // round_running=true but lifecycle=Lobby → should NOT be RoundRunning
-        let state =
-            derive_trpg_ui_state(TrpgLifecycleState::Lobby, true, false, true, true, true);
+    fn derive_trpg_ui_state_ignores_stale_round_running_in_idle() {
+        // round_running=true but lifecycle=Idle → should NOT be RoundRunning
+        let state = derive_trpg_ui_state(TrpgLifecycleState::Idle, true, false, true, true, true);
         assert_ne!(state, TrpgUiState::RoundRunning);
         // With preflight+wizard ready, it should be ConfigReady
         assert_eq!(state, TrpgUiState::ConfigReady);
@@ -2065,8 +2061,7 @@ mod tests {
     /// Same stale-state protection for Ended lifecycle.
     #[test]
     fn derive_trpg_ui_state_ignores_stale_round_running_in_ended() {
-        let state =
-            derive_trpg_ui_state(TrpgLifecycleState::Ended, true, false, true, true, true);
+        let state = derive_trpg_ui_state(TrpgLifecycleState::Ended, true, false, true, true, true);
         assert_ne!(state, TrpgUiState::RoundRunning);
         assert_eq!(state, TrpgUiState::Ended);
     }
@@ -2077,7 +2072,7 @@ mod tests {
         let state =
             derive_trpg_ui_state(TrpgLifecycleState::Unknown, true, false, false, false, true);
         assert_ne!(state, TrpgUiState::RoundRunning);
-        assert_eq!(state, TrpgUiState::Lobby);
+        assert_eq!(state, TrpgUiState::Idle);
     }
 
     /// round_running in Running lifecycle should still be honoured.

--- a/viewer/src/dom/turn_runtime.rs
+++ b/viewer/src/dom/turn_runtime.rs
@@ -40,7 +40,7 @@ fn room_status_class(state: TrpgLifecycleState) -> &'static str {
         TrpgLifecycleState::Ended => "status-ended",
         TrpgLifecycleState::Unavailable => "status-unavailable",
         TrpgLifecycleState::Loading => "status-loading",
-        TrpgLifecycleState::Lobby | TrpgLifecycleState::Unknown => "status-idle",
+        TrpgLifecycleState::Idle | TrpgLifecycleState::Unknown => "status-idle",
     }
 }
 
@@ -610,7 +610,7 @@ fn build_next_action_hint(
             TrpgLifecycleState::Unavailable => {
                 "엔진/키퍼 연결을 복구한 뒤 다시 시도하세요.".to_string()
             }
-            TrpgLifecycleState::Lobby => "세션을 시작한 뒤 라운드 실행을 누르세요.".to_string(),
+            TrpgLifecycleState::Idle => "세션을 시작한 뒤 라운드 실행을 누르세요.".to_string(),
             TrpgLifecycleState::Unknown => "상태 확인 후 라운드 실행을 다시 누르세요.".to_string(),
             TrpgLifecycleState::Running => "진행 상태를 확인하세요.".to_string(),
         };
@@ -673,8 +673,8 @@ fn build_flow_banner(
                 "is-waiting",
                 "초기화/동기화 중입니다. 완료 후 라운드를 실행하세요.".to_string(),
             ),
-            TrpgLifecycleState::Lobby | TrpgLifecycleState::Unknown => (
-                "로비",
+            TrpgLifecycleState::Idle | TrpgLifecycleState::Unknown => (
+                "대기",
                 "is-idle",
                 "새 게임을 시작하거나 실행 가능한 방으로 이동하세요.".to_string(),
             ),
@@ -736,7 +736,7 @@ fn build_flow_action_signature(
     let mut parts = Vec::new();
     if matches!(
         lifecycle,
-        TrpgLifecycleState::Lobby
+        TrpgLifecycleState::Idle
             | TrpgLifecycleState::Loading
             | TrpgLifecycleState::Ended
             | TrpgLifecycleState::Unavailable
@@ -852,7 +852,7 @@ fn collect_flow_banner_actions(
 
     if matches!(
         lifecycle,
-        TrpgLifecycleState::Lobby
+        TrpgLifecycleState::Idle
             | TrpgLifecycleState::Loading
             | TrpgLifecycleState::Ended
             | TrpgLifecycleState::Unavailable
@@ -1109,7 +1109,7 @@ fn set_ops_hud_value(document: &web_sys::Document, id: &str, text: &str, status_
 fn runtime_compact_lifecycle(lifecycle: TrpgLifecycleState) -> bool {
     matches!(
         lifecycle,
-        TrpgLifecycleState::Lobby
+        TrpgLifecycleState::Idle
             | TrpgLifecycleState::Loading
             | TrpgLifecycleState::Ended
             | TrpgLifecycleState::Unavailable
@@ -1164,7 +1164,7 @@ fn sync_runtime_advanced_toggle_ui(document: &web_sys::Document) {
         let text = if show_advanced {
             "상태 전이, 라운드 진단, DM 음성 설정"
         } else if is_compact {
-            "기본 정보만 표시 중 (로비/종료 단순 모드)"
+            "기본 정보만 표시 중 (대기/종료 단순 모드)"
         } else {
             "핵심 정보만 표시 중"
         };
@@ -1192,7 +1192,8 @@ fn ensure_runtime_advanced_toggle_binding(document: &web_sys::Document) {
             .get_attribute("data-show-advanced")
             .map(|raw| raw == "1")
             .unwrap_or(false);
-        let _ = dashboard.set_attribute("data-show-advanced", if show_advanced { "0" } else { "1" });
+        let _ =
+            dashboard.set_attribute("data-show-advanced", if show_advanced { "0" } else { "1" });
         sync_runtime_advanced_toggle_ui(&document);
     }) as Box<dyn FnMut(_)>);
     let _ = toggle.add_event_listener_with_callback("click", cb.as_ref().unchecked_ref());

--- a/viewer/src/game/http.rs
+++ b/viewer/src/game/http.rs
@@ -163,8 +163,7 @@ fn normalize_room_status(raw: &str) -> String {
 fn room_requires_new_game(raw_status: &str) -> bool {
     matches!(
         normalize_room_status(raw_status).as_str(),
-        "" | "idle" | "lobby" | "ended" | "completed" | "done" | "retired" | "closed"
-            | "unavailable"
+        "" | "idle" | "ended" | "completed" | "done" | "retired" | "closed" | "unavailable"
     )
 }
 
@@ -579,7 +578,9 @@ fn merge_state_fallback(primary: &mut GameStateResponse, fallback: &GameStateRes
             {
                 primary_room.current_scenario = fallback_room.current_scenario.clone();
             }
-            if primary_room.current_node.trim().is_empty() && !fallback_room.current_node.trim().is_empty() {
+            if primary_room.current_node.trim().is_empty()
+                && !fallback_room.current_node.trim().is_empty()
+            {
                 primary_room.current_node = fallback_room.current_node.clone();
             }
         }
@@ -1589,14 +1590,16 @@ mod tests {
     }
 
     #[test]
-    fn initial_progress_event_is_hidden_for_idle_and_lobby() {
-        assert_eq!(initial_progress_event_type("lobby", false), None);
+    fn initial_progress_event_is_hidden_for_idle() {
         assert_eq!(initial_progress_event_type("idle", false), None);
     }
 
     #[test]
     fn initial_progress_event_marks_ended_room_as_ended_event() {
-        assert_eq!(initial_progress_event_type("ended", false), Some("room.ended"));
+        assert_eq!(
+            initial_progress_event_type("ended", false),
+            Some("room.ended")
+        );
     }
 
     #[test]

--- a/viewer/src/game/lifecycle.rs
+++ b/viewer/src/game/lifecycle.rs
@@ -1,6 +1,6 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TrpgLifecycleState {
-    Lobby,
+    Idle,
     Loading,
     Running,
     Stopped,
@@ -12,7 +12,7 @@ pub enum TrpgLifecycleState {
 #[cfg(any(target_arch = "wasm32", test))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TrpgUiState {
-    Lobby,
+    Idle,
     ConfigReady,
     SessionStarting,
     SessionRunning,
@@ -40,10 +40,10 @@ impl TrpgLifecycleState {
             | "outcome_narration" | "state_update" | "transition" => Self::Running,
             "paused" | "stopped" | "suspended" | "halted" => Self::Stopped,
             "ended" | "completed" | "done" | "retired" | "closed" | "archived" => Self::Ended,
-            "loading" | "bootstrapping" | "bootstrap" | "syncing" | "starting"
-            | "initializing" | "creating" => Self::Loading,
+            "loading" | "bootstrapping" | "bootstrap" | "syncing" | "starting" | "initializing"
+            | "creating" => Self::Loading,
             "unavailable" | "error" | "failed" => Self::Unavailable,
-            "idle" | "lobby" | "created" | "ready" => Self::Lobby,
+            "idle" | "created" | "ready" => Self::Idle,
             "unknown" => Self::Unknown,
             _ => Self::Unknown,
         }
@@ -58,12 +58,12 @@ impl TrpgLifecycleState {
 
         let progress = Self::from_status(progress_raw);
 
-        // Progress status is more granular when valid, but stale "loading/unknown/lobby"
+        // Progress status is more granular when valid, but stale "loading/unknown/idle"
         // should not mask a stronger room lifecycle from runtime state.
         match progress {
-            Self::Loading if !matches!(room, Self::Unknown | Self::Lobby | Self::Loading) => room,
+            Self::Loading if !matches!(room, Self::Unknown | Self::Idle | Self::Loading) => room,
             Self::Unknown if !matches!(room, Self::Unknown) => room,
-            Self::Lobby if !matches!(room, Self::Unknown | Self::Lobby | Self::Loading) => room,
+            Self::Idle if !matches!(room, Self::Unknown | Self::Idle | Self::Loading) => room,
             _ => progress,
         }
     }
@@ -75,14 +75,14 @@ impl TrpgLifecycleState {
             Self::Stopped => "stopped",
             Self::Ended => "ended",
             Self::Unavailable => "unavailable",
-            Self::Lobby | Self::Loading | Self::Unknown => "lobby",
+            Self::Idle | Self::Loading | Self::Unknown => "idle",
         }
     }
 
     #[cfg(target_arch = "wasm32")]
     pub fn css_class(self) -> &'static str {
         match self {
-            Self::Lobby => "state-lobby",
+            Self::Idle => "state-idle",
             Self::Loading => "state-loading",
             Self::Running => "state-running",
             Self::Stopped => "state-stopped",
@@ -95,7 +95,7 @@ impl TrpgLifecycleState {
     #[cfg(target_arch = "wasm32")]
     pub fn label(self) -> &'static str {
         match self {
-            Self::Lobby => "LOBBY",
+            Self::Idle => "IDLE",
             Self::Loading => "LOADING",
             Self::Running => "RUNNING",
             Self::Stopped => "STOPPED",
@@ -107,7 +107,7 @@ impl TrpgLifecycleState {
 
     pub fn label_ko(self) -> &'static str {
         match self {
-            Self::Lobby => "로비",
+            Self::Idle => "대기",
             Self::Loading => "로딩",
             Self::Running => "진행 중",
             Self::Stopped => "멈춤",
@@ -120,7 +120,7 @@ impl TrpgLifecycleState {
     #[cfg(any(target_arch = "wasm32", test))]
     pub fn help_text(self) -> &'static str {
         match self {
-            Self::Lobby => "세션 미시작 또는 초기 대기 상태",
+            Self::Idle => "세션 미시작 또는 초기 대기 상태",
             Self::Loading => "상태 동기화/초기화 진행 중",
             Self::Running => "라운드가 순환 중이며 입력/결과가 반영되는 상태",
             Self::Stopped => "의도적으로 멈춘 상태(재개 가능)",
@@ -144,7 +144,7 @@ impl TrpgLifecycleState {
 impl TrpgUiState {
     pub fn code(self) -> &'static str {
         match self {
-            Self::Lobby => "lobby",
+            Self::Idle => "idle",
             Self::ConfigReady => "config_ready",
             Self::SessionStarting => "session_starting",
             Self::SessionRunning => "session_running",
@@ -164,13 +164,13 @@ impl TrpgUiState {
             "paused" => Self::Paused,
             "ended" => Self::Ended,
             "error" => Self::Error,
-            _ => Self::Lobby,
+            _ => Self::Idle,
         }
     }
 
     pub fn label_ko(self) -> &'static str {
         match self {
-            Self::Lobby => "로비",
+            Self::Idle => "대기",
             Self::ConfigReady => "설정 완료",
             Self::SessionStarting => "세션 시작 중",
             Self::SessionRunning => "세션 진행 중",
@@ -183,7 +183,7 @@ impl TrpgUiState {
 
     pub fn help_text(self) -> &'static str {
         match self {
-            Self::Lobby => "새 세션 시작 전 대기 상태",
+            Self::Idle => "새 세션 시작 전 대기 상태",
             Self::ConfigReady => "사전 점검과 keeper 할당이 완료되어 시작 가능한 상태",
             Self::SessionStarting => "세션 생성/부트스트랩이 진행 중인 상태",
             Self::SessionRunning => "세션이 실행 중이며 라운드 실행 가능 상태",
@@ -199,7 +199,7 @@ impl TrpgUiState {
             Self::ConfigReady | Self::SessionRunning => "status-active",
             Self::SessionStarting | Self::RoundRunning => "status-info",
             Self::Paused => "status-warn",
-            Self::Ended | Self::Lobby => "status-idle",
+            Self::Ended | Self::Idle => "status-idle",
             Self::Error => "status-error",
         }
     }
@@ -212,7 +212,7 @@ mod tests {
     #[test]
     fn trpg_ui_state_code_roundtrip() {
         let cases = [
-            TrpgUiState::Lobby,
+            TrpgUiState::Idle,
             TrpgUiState::ConfigReady,
             TrpgUiState::SessionStarting,
             TrpgUiState::SessionRunning,
@@ -225,13 +225,13 @@ mod tests {
         for state in cases {
             assert_eq!(TrpgUiState::from_code(state.code()), state);
         }
-        assert_eq!(TrpgUiState::from_code("unknown-state"), TrpgUiState::Lobby);
+        assert_eq!(TrpgUiState::from_code("unknown-state"), TrpgUiState::Idle);
     }
 
     #[test]
     fn trpg_ui_state_labels_and_classes_are_defined() {
         let cases = [
-            TrpgUiState::Lobby,
+            TrpgUiState::Idle,
             TrpgUiState::ConfigReady,
             TrpgUiState::SessionStarting,
             TrpgUiState::SessionRunning,

--- a/viewer/src/mode/mod.rs
+++ b/viewer/src/mode/mod.rs
@@ -62,7 +62,7 @@ impl Default for ViewLayoutPrefs {
 pub enum ViewerMode {
     /// Mode selection screen. No SSE connection, no game state.
     #[default]
-    Lobby,
+    Home,
 
     /// D&D 5e game session viewer (그림란드 연대기).
     /// Data source:
@@ -89,7 +89,7 @@ impl ViewerMode {
     /// Used by `poll_mode_transition` (wasm32 only).
     pub fn display_name(&self) -> &'static str {
         match self {
-            Self::Lobby => "MASC Viewer",
+            Self::Home => "MASC Viewer",
             Self::Trpg => "그림란드 연대기",
             Self::Experiment => "Experiment Lab",
             Self::Monitor => "System Monitor",
@@ -98,7 +98,7 @@ impl ViewerMode {
     }
 
     /// DOM panel element ID for MASC mode panels.
-    /// Returns `None` for Lobby and Trpg (they use different layout).
+    /// Returns `None` for Home and Trpg (they use different layout).
     pub fn panel_id(&self) -> Option<&'static str> {
         match self {
             Self::Monitor => Some("monitor-panel"),
@@ -122,7 +122,7 @@ impl ViewerMode {
     /// Used by `poll_mode_transition` (wasm32 only).
     pub fn css_class(&self) -> &'static str {
         match self {
-            Self::Lobby => "mode-lobby",
+            Self::Home => "mode-home",
             Self::Trpg => "mode-trpg",
             Self::Experiment => "mode-experiment",
             Self::Monitor => "mode-monitor",
@@ -146,7 +146,7 @@ impl ViewerMode {
 #[cfg(target_arch = "wasm32")]
 fn mode_storage_value(mode: ViewerMode) -> &'static str {
     match mode {
-        ViewerMode::Lobby => "lobby",
+        ViewerMode::Home => "home",
         ViewerMode::Trpg => "trpg",
         ViewerMode::Experiment => "experiment",
         ViewerMode::Monitor => "monitor",
@@ -157,7 +157,7 @@ fn mode_storage_value(mode: ViewerMode) -> &'static str {
 #[cfg(target_arch = "wasm32")]
 fn parse_mode_storage_value(raw: &str) -> Option<ViewerMode> {
     match raw.trim().to_ascii_lowercase().as_str() {
-        "lobby" => Some(ViewerMode::Lobby),
+        "home" => Some(ViewerMode::Home),
         "trpg" => Some(ViewerMode::Trpg),
         "experiment" => Some(ViewerMode::Experiment),
         "monitor" => Some(ViewerMode::Monitor),
@@ -211,7 +211,7 @@ fn initial_mode_from_url_or_storage() -> Option<ViewerMode> {
     mode_from_query()
         .or_else(load_last_mode)
         .and_then(|mode| match mode {
-            ViewerMode::Lobby => None,
+            ViewerMode::Home => None,
             other => Some(other),
         })
 }
@@ -293,8 +293,8 @@ impl Plugin for ModePlugin {
     fn build(&self, app: &mut App) {
         app.init_state::<ViewerMode>()
             .init_resource::<ModeTransitionBuffer>()
-            .add_systems(OnEnter(ViewerMode::Lobby), on_enter_lobby)
-            .add_systems(OnExit(ViewerMode::Lobby), on_exit_lobby)
+            .add_systems(OnEnter(ViewerMode::Home), on_enter_home)
+            .add_systems(OnExit(ViewerMode::Home), on_exit_home)
             .add_systems(OnEnter(ViewerMode::Trpg), enter_trpg)
             .add_systems(OnExit(ViewerMode::Trpg), exit_trpg)
             .add_systems(OnEnter(ViewerMode::Monitor), enter_masc_panel)
@@ -312,10 +312,10 @@ impl Plugin for ModePlugin {
     }
 }
 
-// ─── Lobby Enter/Exit ────────────────────────
+// ─── Home Enter/Exit ────────────────────────
 
-/// Startup logic when entering Lobby mode: show lobby UI, bind click listeners.
-fn on_enter_lobby(buffer: Res<ModeTransitionBuffer>) {
+/// Startup logic when entering Home mode: show home UI, bind click listeners.
+fn on_enter_home(buffer: Res<ModeTransitionBuffer>) {
     #[cfg(target_arch = "wasm32")]
     {
         let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
@@ -323,19 +323,17 @@ fn on_enter_lobby(buffer: Res<ModeTransitionBuffer>) {
         };
 
         clear_trpg_dom(&doc);
-        let lobby_room = crate::config::current_room_id();
-        crate::config::set_current_room_id(&lobby_room);
-        // Show lobby UI, hide dashboard
+        // Show home UI, hide dashboard
         if let Some(body) = doc.body() {
-            body.set_class_name("mode-lobby");
+            body.set_class_name("mode-home");
         }
-        set_element_display(&doc, "lobby-screen", "flex");
+        set_element_display(&doc, "home-screen", "flex");
         set_element_display(&doc, "dashboard", "none");
 
         // Bind mode card clicks
         bind_mode_cards(&doc, &buffer.pending);
 
-        // Bind back-to-lobby button
+        // Bind back-to-home button
         bind_back_button(&doc, &buffer.pending);
         bind_debug_controls(&doc);
         bind_new_game_controls(&doc);
@@ -349,7 +347,7 @@ fn on_enter_lobby(buffer: Res<ModeTransitionBuffer>) {
         }
 
         // Restore the last active mode once at startup so refresh returns to
-        // the game view instead of forcing lobby re-entry.
+        // the game view instead of forcing home re-entry.
         if let Some(body) = doc.body() {
             let restored_once = body
                 .get_attribute("data-mode-restored")
@@ -370,15 +368,15 @@ fn on_enter_lobby(buffer: Res<ModeTransitionBuffer>) {
     let _ = &buffer;
 }
 
-/// Cleanup when leaving Lobby mode (entering a visualization mode).
-fn on_exit_lobby() {
+/// Cleanup when leaving Home mode (entering a visualization mode).
+fn on_exit_home() {
     #[cfg(target_arch = "wasm32")]
     {
         let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
             return;
         };
 
-        set_element_display(&doc, "lobby-screen", "none");
+        set_element_display(&doc, "home-screen", "none");
         set_element_display(&doc, "dashboard", "grid");
     }
 }
@@ -391,7 +389,7 @@ fn enter_trpg() {
         };
 
         set_element_display(&doc, "dashboard", "grid");
-        set_element_display(&doc, "lobby-screen", "none");
+        set_element_display(&doc, "home-screen", "none");
         set_element_display(&doc, "new-game-panel", "none");
         clear_trpg_dom(&doc);
         bind_debug_controls(&doc);
@@ -841,11 +839,11 @@ fn sync_session_pause_buttons(doc: &web_sys::Document, room_status: &str) {
             "세션 진행 중입니다.",
             "status-ok",
         ),
-        TrpgLifecycleState::Lobby => (
+        TrpgLifecycleState::Idle => (
             false,
             true,
-            "세션이 로비 상태입니다. 필요 시 멈춤 가능합니다.",
-            "세션 시작 전 로비 상태입니다. 새 게임에서 시작하세요.",
+            "세션이 대기 상태입니다. 필요 시 멈춤 가능합니다.",
+            "세션 시작 전 대기 상태입니다. 새 게임에서 시작하세요.",
             "status-info",
         ),
         TrpgLifecycleState::Stopped => (
@@ -1011,7 +1009,7 @@ fn poll_mode_transition(
 /// Each click writes the target ViewerMode into the shared buffer.
 #[cfg(target_arch = "wasm32")]
 fn bind_mode_cards(doc: &web_sys::Document, pending: &Arc<Mutex<Option<ViewerMode>>>) {
-    // Guard: only bind once to prevent closure accumulation on repeated lobby entries
+    // Guard: only bind once to prevent closure accumulation on repeated home entries
     if let Some(container) = doc.get_element_by_id("mode-cards") {
         if container.get_attribute("data-bound").as_deref() == Some("1") {
             return;
@@ -1050,10 +1048,10 @@ fn bind_mode_cards(doc: &web_sys::Document, pending: &Arc<Mutex<Option<ViewerMod
     }
 }
 
-/// Binds the `#back-to-lobby` button to transition back to Lobby.
+/// Binds the `#back-to-home` button to transition back to Home.
 #[cfg(target_arch = "wasm32")]
 fn bind_back_button(doc: &web_sys::Document, pending: &Arc<Mutex<Option<ViewerMode>>>) {
-    let Some(btn) = doc.get_element_by_id("back-to-lobby") else {
+    let Some(btn) = doc.get_element_by_id("back-to-home") else {
         return;
     };
     // Guard: only bind once
@@ -1065,7 +1063,7 @@ fn bind_back_button(doc: &web_sys::Document, pending: &Arc<Mutex<Option<ViewerMo
     let buf = pending.clone();
     let cb = Closure::wrap(Box::new(move || {
         if let Ok(mut guard) = buf.lock() {
-            *guard = Some(ViewerMode::Lobby);
+            *guard = Some(ViewerMode::Home);
         }
     }) as Box<dyn FnMut()>);
 
@@ -1403,10 +1401,7 @@ pub(super) fn set_new_game_preflight_status(doc: &web_sys::Document, message: &s
 }
 
 #[cfg(target_arch = "wasm32")]
-fn set_new_game_preflight_rows(
-    doc: &web_sys::Document,
-    rows: &[transport_classify::PreflightRow],
-) {
+fn set_new_game_preflight_rows(doc: &web_sys::Document, rows: &[transport_classify::PreflightRow]) {
     if let Some(el) = doc.get_element_by_id("new-game-preflight") {
         let html = rows
             .iter()
@@ -1489,10 +1484,14 @@ pub(super) fn clear_trpg_dom(doc: &web_sys::Document) {
         el.set_inner_html("<div class=\"trpg-summary-empty\">허용된 액션을 계산 중입니다.</div>");
     }
     if let Some(el) = doc.get_element_by_id("trpg-timeline-summary") {
-        el.set_inner_html("<div class=\"trpg-summary-empty\">타임라인 요약을 불러오는 중입니다.</div>");
+        el.set_inner_html(
+            "<div class=\"trpg-summary-empty\">타임라인 요약을 불러오는 중입니다.</div>",
+        );
     }
     if let Some(el) = doc.get_element_by_id("trpg-timeline-events") {
-        el.set_inner_html("<div class=\"trpg-summary-empty\">최근 이벤트를 불러오는 중입니다.</div>");
+        el.set_inner_html(
+            "<div class=\"trpg-summary-empty\">최근 이벤트를 불러오는 중입니다.</div>",
+        );
     }
     if let Some(el) = doc.get_element_by_id("turn-num") {
         el.set_text_content(Some("1"));
@@ -1760,8 +1759,8 @@ use room_hub::{
 mod trpg_controls;
 #[cfg(target_arch = "wasm32")]
 use trpg_controls::{
-    actor_admin_room_id, actor_admin_set_status, bind_new_game_controls,
-    refresh_actor_admin_list, refresh_trpg_ops_snapshots,
+    actor_admin_room_id, actor_admin_set_status, bind_new_game_controls, refresh_actor_admin_list,
+    refresh_trpg_ops_snapshots,
 };
 
 /// Refresh TRPG widget status counters (narrative, party, history, dedup).
@@ -1873,8 +1872,7 @@ async fn seed_monitor_snapshot(doc: web_sys::Document) -> Result<(), String> {
         "monitor-events",
         &format!(
             "[snapshot] current room {} / tracked rooms {}개 / keeper {}명 초기 상태 로드",
-            current_room,
-            room_count, keeper_count
+            current_room, room_count, keeper_count
         ),
         &["Waiting for events...", "No events yet"],
         50,
@@ -2021,7 +2019,7 @@ fn sync_masc_panel_connection_status(
 // ─── Generic MASC Panel Enter/Exit ───────────
 
 /// Generic enter handler for MASC mode panels (Monitor, Social, Experiment).
-/// Shows the mode's panel, hides lobby and dashboard, binds back navigation.
+/// Shows the mode's panel, hides home and dashboard, binds back navigation.
 fn enter_masc_panel(mode: Res<State<ViewerMode>>, buffer: Res<ModeTransitionBuffer>) {
     #[cfg(target_arch = "wasm32")]
     {
@@ -2034,7 +2032,7 @@ fn enter_masc_panel(mode: Res<State<ViewerMode>>, buffer: Res<ModeTransitionBuff
         };
 
         set_panel_active(&doc, panel_id, true);
-        set_element_display(&doc, "lobby-screen", "none");
+        set_element_display(&doc, "home-screen", "none");
         set_element_display(&doc, "dashboard", "none");
 
         bind_back_buttons(&doc, &buffer.pending);
@@ -2061,7 +2059,7 @@ fn exit_masc_panel() {
 // ─── DOM Helpers ─────────────────────────────
 
 /// Helper to set display style on a DOM element by ID.
-/// Used for lobby-screen (flex) and dashboard (grid/none) which don't use CSS transitions.
+/// Used for home-screen (flex) and dashboard (grid/none) which don't use CSS transitions.
 #[cfg(target_arch = "wasm32")]
 pub(super) fn set_element_display(doc: &web_sys::Document, id: &str, display: &str) {
     if let Some(el) = doc.get_element_by_id(id) {
@@ -2093,7 +2091,7 @@ fn set_panel_active(doc: &web_sys::Document, id: &str, active: bool) {
     }
 }
 
-/// Binds all `.back-btn[data-back]` buttons to transition back to Lobby.
+/// Binds all `.back-btn[data-back]` buttons to transition back to Home.
 #[cfg(target_arch = "wasm32")]
 fn bind_back_buttons(doc: &web_sys::Document, pending: &Arc<Mutex<Option<ViewerMode>>>) {
     let Ok(buttons) = doc.query_selector_all("[data-back]") else {
@@ -2114,7 +2112,7 @@ fn bind_back_buttons(doc: &web_sys::Document, pending: &Arc<Mutex<Option<ViewerM
         let buf = pending.clone();
         let cb = Closure::wrap(Box::new(move |_: web_sys::Event| {
             if let Ok(mut guard) = buf.lock() {
-                *guard = Some(ViewerMode::Lobby);
+                *guard = Some(ViewerMode::Home);
             }
         }) as Box<dyn FnMut(web_sys::Event)>);
 
@@ -2138,7 +2136,7 @@ mod tests {
 
     #[test]
     fn panel_id_returns_none_for_non_panel_modes() {
-        assert_eq!(ViewerMode::Lobby.panel_id(), None);
+        assert_eq!(ViewerMode::Home.panel_id(), None);
         assert_eq!(ViewerMode::Trpg.panel_id(), None);
     }
 

--- a/viewer/src/mode/room_hub.rs
+++ b/viewer/src/mode/room_hub.rs
@@ -22,7 +22,7 @@ pub(super) const ROOM_HUB_RUNNING_ONLY_STORAGE_KEY: &str = "masc_viewer_room_hub
 const INLINE_SELECTOR_MAX_OPTIONS: usize = 5;
 const ROOM_AUTO_FOCUS_DEFAULT_ROOM_ONLY: bool = true;
 const ROOM_AUTO_FOCUS_SCORE_RUNNING: u8 = 4;
-const ROOM_AUTO_FOCUS_SCORE_LOBBY: u8 = 3;
+const ROOM_AUTO_FOCUS_SCORE_IDLE: u8 = 3;
 const ROOM_AUTO_FOCUS_SCORE_STOPPED: u8 = 2;
 const ROOM_AUTO_FOCUS_SCORE_LOADING: u8 = 1;
 
@@ -83,7 +83,7 @@ fn room_display_label(room_id: &str) -> String {
 fn auto_focus_score(status: &str) -> Option<u8> {
     match TrpgLifecycleState::from_status(status) {
         TrpgLifecycleState::Running => Some(ROOM_AUTO_FOCUS_SCORE_RUNNING),
-        TrpgLifecycleState::Lobby => Some(ROOM_AUTO_FOCUS_SCORE_LOBBY),
+        TrpgLifecycleState::Idle => Some(ROOM_AUTO_FOCUS_SCORE_IDLE),
         TrpgLifecycleState::Stopped => Some(ROOM_AUTO_FOCUS_SCORE_STOPPED),
         TrpgLifecycleState::Loading => Some(ROOM_AUTO_FOCUS_SCORE_LOADING),
         _ => None,
@@ -132,10 +132,10 @@ mod tests {
     }
 
     #[test]
-    fn ended_default_prefers_running_over_lobby() {
+    fn ended_default_prefers_running_over_idle() {
         let rooms = vec![
             snapshot("default", "ended", 11),
-            snapshot("lobby-room", "lobby", 99),
+            snapshot("idle-room", "idle", 99),
             snapshot("running-room", "running", 1),
         ];
         assert_eq!(
@@ -211,7 +211,14 @@ mod tests {
             "default".to_string(),
         ];
         let rooms = inline_selector_rooms("beta-room", &known);
-        assert_eq!(rooms, vec!["beta-room".to_string(), "default".to_string(), "alpha-room".to_string()]);
+        assert_eq!(
+            rooms,
+            vec![
+                "beta-room".to_string(),
+                "default".to_string(),
+                "alpha-room".to_string()
+            ]
+        );
     }
 
     #[test]
@@ -255,7 +262,7 @@ fn render_room_hub(doc: &web_sys::Document, rooms: &[RoomSnapshot], selected_roo
     let mut current = Vec::new();
     let mut running = Vec::new();
     let mut stopped = Vec::new();
-    let mut lobby = Vec::new();
+    let mut idle = Vec::new();
     let mut unavailable = Vec::new();
     let mut ended_hidden_count = 0usize;
 
@@ -301,7 +308,7 @@ fn render_room_hub(doc: &web_sys::Document, rooms: &[RoomSnapshot], selected_roo
             "stopped" => stopped.push(card),
             "unavailable" => unavailable.push(card),
             "ended" => ended_hidden_count += 1,
-            _ => lobby.push(card),
+            _ => idle.push(card),
         }
     }
 
@@ -319,7 +326,7 @@ fn render_room_hub(doc: &web_sys::Document, rooms: &[RoomSnapshot], selected_roo
         )
     };
 
-    let previous_count = running.len() + stopped.len() + lobby.len() + unavailable.len();
+    let previous_count = running.len() + stopped.len() + idle.len() + unavailable.len();
     let hidden_ended_note = if ended_hidden_count > 0 {
         format!(" · 종료 {}개 숨김", ended_hidden_count)
     } else {
@@ -337,7 +344,7 @@ fn render_room_hub(doc: &web_sys::Document, rooms: &[RoomSnapshot], selected_roo
             lane_html("현재 게임", current, "current"),
             lane_html("진행 중", running, "running"),
             lane_html("멈춤", stopped, "stopped"),
-            lane_html("로비", lobby, "lobby"),
+            lane_html("대기", idle, "idle"),
             lane_html("오류", unavailable, "unavailable")
         )
     };
@@ -597,7 +604,10 @@ fn save_room_hub_running_only(enabled: bool) {
 fn sync_room_hub_top_offset(doc: &web_sys::Document) {
     let top_px = doc
         .get_element_by_id("top-bar")
-        .and_then(|el| el.dyn_ref::<web_sys::HtmlElement>().map(|bar| bar.offset_height()))
+        .and_then(|el| {
+            el.dyn_ref::<web_sys::HtmlElement>()
+                .map(|bar| bar.offset_height())
+        })
         .map(|height| height.max(84))
         .unwrap_or(84);
     if let Some(hub) = doc
@@ -773,7 +783,7 @@ fn apply_room_switch_from_ui(doc: &web_sys::Document, raw_room: &str, manual_inp
                 "현재 게임: {} · 빈 방(세션 없음, 새 게임 필요)",
                 room_label
             )));
-            let _ = pill.set_attribute("data-lifecycle", TrpgLifecycleState::Lobby.css_class());
+            let _ = pill.set_attribute("data-lifecycle", TrpgLifecycleState::Idle.css_class());
             let _ = pill.set_attribute(
                 "title",
                 "해당 방에 세션이 없을 수 있습니다. 새 게임에서 시작할 수 있습니다.",
@@ -878,7 +888,7 @@ pub(super) async fn refresh_rooms_from_server(
         .unwrap_or("idle");
 
     // Auto-round is a gameplay convenience for active rounds only.
-    // Keep it off in lobby/ended/unavailable to avoid confusing "auto running"
+    // Keep it off in idle/ended/unavailable to avoid confusing "auto running"
     // signals when the room cannot actually advance.
     if TrpgLifecycleState::from_status(current_status) != TrpgLifecycleState::Running {
         if let Some(dashboard) = doc.get_element_by_id("dashboard") {

--- a/viewer/src/theme.rs
+++ b/viewer/src/theme.rs
@@ -165,7 +165,7 @@ fn bind_theme_selectors(buffer: Res<ThemeTransitionBuffer>) {
             return;
         };
 
-        // Bind both theme selectors (lobby + inline dashboard)
+        // Bind both theme selectors (home + inline dashboard)
         for selector_id in &["theme-selector", "theme-selector-inline"] {
             bind_single_theme_selector(&doc, selector_id, &buffer.pending);
         }

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -30,7 +30,7 @@
     --panel-radius: 2px;
     --panel-shadow: 0 2px 12px rgba(0, 0, 0, 0.6);
     --card-radius: 4px;
-    --lobby-bg: radial-gradient(ellipse at 50% 30%, #1a1a2e 0%, #0a0a12 70%);
+    --home-bg: radial-gradient(ellipse at 50% 30%, #1a1a2e 0%, #0a0a12 70%);
     --mode-card-border: 1px solid #2a1f1a;
     --mode-card-hover-border: 1px solid #c4a265;
     --mode-card-hover-shadow: 0 0 20px rgba(196, 162, 101, 0.15);
@@ -65,7 +65,7 @@
     --panel-radius: 0;
     --panel-shadow: 0 0 16px rgba(106, 47, 214, 0.3);
     --card-radius: 0;
-    --lobby-bg: radial-gradient(ellipse at 50% 60%, #1a1235 0%, #05000f 70%);
+    --home-bg: radial-gradient(ellipse at 50% 60%, #1a1235 0%, #05000f 70%);
     --mode-card-border: 1px solid #2a1a4a;
     --mode-card-hover-border: 1px solid #00ffcc;
     --mode-card-hover-shadow: 0 0 24px rgba(0, 255, 204, 0.2), 0 0 48px rgba(0, 255, 204, 0.05);
@@ -100,7 +100,7 @@
     --panel-radius: 0;
     --panel-shadow: 0 0 8px rgba(0, 255, 0, 0.1);
     --card-radius: 0;
-    --lobby-bg: #000800;
+    --home-bg: #000800;
     --mode-card-border: 1px solid #0a3a0a;
     --mode-card-hover-border: 1px solid #00ff00;
     --mode-card-hover-shadow: 0 0 16px rgba(0, 255, 0, 0.15);
@@ -135,7 +135,7 @@
     --panel-radius: 3px;
     --panel-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
     --card-radius: 6px;
-    --lobby-bg: radial-gradient(ellipse at 50% 40%, #2e2820 0%, #1a1610 70%);
+    --home-bg: radial-gradient(ellipse at 50% 40%, #2e2820 0%, #1a1610 70%);
     --mode-card-border: 1px solid #4a3f30;
     --mode-card-hover-border: 1px solid #c4a050;
     --mode-card-hover-shadow: 0 4px 16px rgba(0, 0, 0, 0.5);
@@ -210,35 +210,35 @@ body {
 }
 
 /* ═══════════════════════════════════════════
-   LOBBY SCREEN
+   HOME SCREEN
    ═══════════════════════════════════════════ */
 
-#lobby-screen {
+#home-screen {
     display: none;
     flex-direction: column;
     align-items: center;
     justify-content: center;
     height: 100vh;
-    background: var(--lobby-bg);
+    background: var(--home-bg);
     padding: 40px 24px;
     gap: 48px;
 }
 
-body.mode-lobby #lobby-screen {
+body.mode-home #home-screen {
     display: flex;
 }
 
-body.mode-lobby #dashboard {
+body.mode-home #dashboard {
     display: none;
 }
 
-/* ─── Lobby Header ─────────────────────── */
+/* ─── Home Header ─────────────────────── */
 
-.lobby-header {
+.home-header {
     text-align: center;
 }
 
-.lobby-title {
+.home-title {
     font-family: var(--font-display);
     font-size: 42px;
     color: var(--accent-primary);
@@ -248,7 +248,7 @@ body.mode-lobby #dashboard {
     text-shadow: 0 0 40px var(--accent-glow);
 }
 
-.lobby-subtitle {
+.home-subtitle {
     font-family: var(--font-ui);
     font-size: 13px;
     color: var(--text-dim);
@@ -320,9 +320,9 @@ body.mode-lobby #dashboard {
     line-height: 1.5;
 }
 
-/* ─── Lobby Footer ─────────────────────── */
+/* ─── Home Footer ─────────────────────── */
 
-.lobby-footer {
+.home-footer {
     display: flex;
     align-items: center;
     gap: 12px;
@@ -488,7 +488,7 @@ body:not(.mode-trpg) #ops-hud {
     border-bottom: 1px solid var(--border-main);
 }
 
-#back-to-lobby {
+#back-to-home {
     background: none;
     border: none;
     color: var(--text-dim);
@@ -500,7 +500,7 @@ body:not(.mode-trpg) #ops-hud {
     font-family: inherit;
 }
 
-#back-to-lobby:hover {
+#back-to-home:hover {
     color: var(--accent-primary);
 }
 
@@ -2537,8 +2537,8 @@ body.wasm-dom-fallback #bevy-canvas {
     border-color: rgba(177, 116, 116, 0.32);
 }
 
-.turn-runtime-item .v.state-lobby,
-.room-chip-state.state-lobby,
+.turn-runtime-item .v.state-idle,
+.room-chip-state.state-idle,
 .turn-runtime-item .v.state-unknown,
 .room-chip-state.state-unknown {
     color: var(--text-dim);
@@ -3685,7 +3685,7 @@ body.wasm-dom-fallback #bevy-canvas {
     overflow-y: auto;
 }
 
-#dashboard[data-trpg-surface="lobby"] #new-game-panel {
+#dashboard[data-trpg-surface="idle"] #new-game-panel {
     display: flex;
 }
 
@@ -4173,7 +4173,7 @@ body.wasm-dom-fallback #bevy-canvas {
     text-shadow: -1px 0 #ff2266, 1px 0 #00ffcc;
 }
 
-[data-theme="cyberpunk"] .lobby-title {
+[data-theme="cyberpunk"] .home-title {
     animation: glitch-subtle 3s infinite;
 }
 


### PR DESCRIPTION
## Summary
- replace the viewer top-level Lobby mode with Home
- collapse TRPG Lobby lifecycle/UI state into Idle
- remove stale last_seen_seq_by_room docs and preview text

## Validation
- cargo check in viewer
- cargo test in viewer: 146 passed
- rg lobby/Lobby/LOBBY residue search: no matches
- git diff --check origin/main..HEAD

## Notes
- plain cargo fmt is blocked by the pre-existing missing archive module path in viewer/src/mode/mod.rs; touched Rust files were formatted with rustfmt --config skip_children=true.