### PR TITLE
Fix keeper required-tool runtime fallback

### DIFF
--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -516,6 +516,9 @@ let required_tool_rotation_candidate
     name
   =
   let normalized = normalized_runtime_id ~catalog_names name in
+  let is_declared_required_tool_runtime =
+    List.exists (String.equal normalized) (Runtime.get_required_tool_runtime_ids ())
+  in
   let routed_phase_buffer_is_distinct =
     not
       (String.equal
@@ -530,14 +533,25 @@ let required_tool_rotation_candidate
     ((routed_phase_buffer_is_distinct
       && String.equal normalized (Keeper_config.default_runtime_id ())))
   && (allow_phase_recovery
+      || is_declared_required_tool_runtime
       || not
            (String.equal normalized (Keeper_config.default_runtime_id ())))
   && not (String.equal normalized "")
 
-let tool_required_rotation_runtime_id () =
-  try
-    Runtime.get_default_runtime_id ()
-  with Failure _ -> (Keeper_config.default_runtime_id ())
+let runtime_catalog_names () =
+  match Runtime.get_runtime_ids () with
+  | [] -> [ Keeper_config.default_runtime_id () ]
+  | names -> names
+;;
+
+let tool_required_rotation_runtime_ids () =
+  let default_runtime_id =
+    try Runtime.get_default_runtime_id () with
+    | Failure _ -> Keeper_config.default_runtime_id ()
+  in
+  match Runtime.get_required_tool_runtime_ids () with
+  | [] -> [ default_runtime_id ]
+  | ids -> ids
 
 let default_degraded_rotation_candidates
     ~catalog_names
@@ -547,15 +561,16 @@ let default_degraded_rotation_candidates
   let default_runtime =
     normalized_runtime_id ~catalog_names (Keeper_config.default_runtime_id ())
   in
-  let tool_required_runtime =
-    normalized_runtime_id ~catalog_names (tool_required_rotation_runtime_id ())
+  let tool_required_runtimes =
+    tool_required_rotation_runtime_ids ()
+    |> List.map (normalized_runtime_id ~catalog_names)
   in
   let phase_recovery_runtime =
     normalized_runtime_id ~catalog_names
       (Runtime.get_default_runtime_id ())
   in
   match tool_requirement with
-  | Required -> [ normalized_base; tool_required_runtime ]
+  | Required -> normalized_base :: tool_required_runtimes
   | Optional | No_tools ->
     [ normalized_base; default_runtime; phase_recovery_runtime ]
 
@@ -623,7 +638,7 @@ let degraded_rotation_after_recoverable_error
       (* Load the live catalog once at the degraded-rotation boundary and pass
          the snapshot through normalization/filter helpers.  This preserves
          concrete profile names without adding per-candidate catalog I/O. *)
-      let catalog_names = [ Keeper_config.default_runtime_id () ] in
+      let catalog_names = runtime_catalog_names () in
       let attempted =
         attempted_runtimes
         |> List.map (normalized_runtime_id ~catalog_names)

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -74,15 +74,40 @@ let load_list ~(config_path : string) : (t list * t, string) result =
 (* ---- Lazy default runtime singleton ---- *)
 
 let default_runtime_ref : t option ref = ref None
+let runtimes_ref : t list ref = ref []
+
+let runtime_ids runtimes = List.map (fun (rt : t) -> rt.id) runtimes
+
+let runtime_supports_required_tools (rt : t) =
+  let provider_caps =
+    Option.value ~default:capabilities_default rt.provider.capabilities
+  in
+  let model_caps =
+    Option.value ~default:model_capabilities_default rt.model.capabilities
+  in
+  rt.model.tools_support
+  && model_caps.supports_tool_choice
+  && provider_caps.supports_runtime_mcp_tools
+;;
+
+let required_tool_runtime_ids runtimes =
+  runtimes
+  |> List.filter runtime_supports_required_tools
+  |> runtime_ids
+;;
 
 let init_default ~config_path =
   match load_list ~config_path with
-  | Ok (_, rt) ->
+  | Ok (runtimes, rt) ->
+    runtimes_ref := runtimes;
     default_runtime_ref := Some rt;
     Ok ()
   | Error _ as e -> e
 
 let get_default_runtime () = !default_runtime_ref
+let get_runtimes () = !runtimes_ref
+let get_runtime_ids () = runtime_ids !runtimes_ref
+let get_required_tool_runtime_ids () = required_tool_runtime_ids !runtimes_ref
 
 (* fail-fast: uninitialized = startup-ordering bug, NOT a recoverable
    condition. 이전 [| None -> "tool_strict"] 하드코딩 fallback 은 90 사이트에

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -18,6 +18,14 @@ type t =
 val id_of_binding : binding -> string
 val of_binding : config -> binding -> t option
 val load_list : config_path:string -> (t list * t, string) result
+val runtime_ids : t list -> string list
+
+val runtime_supports_required_tools : t -> bool
+(** [true] when a runtime can carry required keeper tool-use turns through
+    runtime MCP tooling and model-level tool-choice support. *)
+
+val required_tool_runtime_ids : t list -> string list
+(** Tool-capable runtime ids, preserving the TOML binding order. *)
 
 (** {1 Lazy default runtime singleton}
 
@@ -27,6 +35,9 @@ val load_list : config_path:string -> (t list * t, string) result
 
 val init_default : config_path:string -> (unit, string) result
 val get_default_runtime : unit -> t option
+val get_runtimes : unit -> t list
+val get_runtime_ids : unit -> string list
+val get_required_tool_runtime_ids : unit -> string list
 
 val get_default_runtime_id : unit -> string
 (** @raise Failure if {!init_default} has not run. No silent fallback

--- a/test/dune
+++ b/test/dune
@@ -181,6 +181,7 @@
   test_keeper_behavioral_regime
   test_keeper_toml
   test_keeper_runtime_toml
+  test_runtime_required_tool_fallback
   test_keeper_tool_policy_config
   test_keeper_tool_name_projection
   test_keeper_tool_resolution
@@ -442,6 +443,7 @@
   test_keeper_behavioral_regime
   test_keeper_toml
   test_keeper_runtime_toml
+  test_runtime_required_tool_fallback
   test_keeper_tool_policy_config
   test_keeper_tool_name_projection
   test_keeper_tool_resolution

--- a/test/test_runtime_required_tool_fallback.ml
+++ b/test/test_runtime_required_tool_fallback.ml
@@ -1,0 +1,178 @@
+module Runtime = Masc_mcp.Runtime
+module EC = Masc_mcp.Keeper_error_classify
+module Tool_surface = Masc_mcp.Keeper_agent_tool_surface
+module SdkE = Agent_sdk.Error
+
+let write_temp_runtime_config content =
+  let path = Filename.temp_file "masc_runtime_required_tool_fallback_" ".toml" in
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc content);
+  path
+;;
+
+let runtime_toml =
+  {|
+[runtime]
+default = "runpod_mtp.qwen"
+
+[providers.runpod_mtp]
+display-name = "RunPod"
+protocol = "provider_d-http"
+endpoint = "https://runpod.example/v1"
+
+[providers.runpod_mtp.capabilities]
+supports-runtime-mcp-tools = true
+supports-runtime-tool-events = true
+
+[providers.openai]
+display-name = "OpenAI"
+protocol = "provider_d-http"
+endpoint = "https://api.openai.example/v1"
+
+[providers.local_mtp]
+display-name = "Local MTP"
+protocol = "provider_d-http"
+endpoint = "http://127.0.0.1:8080"
+
+[providers.local_mtp.capabilities]
+supports-runtime-mcp-tools = true
+supports-runtime-tool-events = true
+
+[models.qwen]
+api-name = "qwen"
+max-context = 65536
+tools-support = true
+streaming = true
+
+[models.qwen.capabilities]
+supports-tool-choice = true
+
+[models.gpt]
+api-name = "gpt"
+max-context = 128000
+tools-support = true
+streaming = true
+
+[models.gpt.capabilities]
+supports-tool-choice = true
+
+[models.local-qwen]
+api-name = "qwen-local"
+max-context = 65536
+tools-support = true
+streaming = true
+
+[models.local-qwen.capabilities]
+supports-tool-choice = true
+
+[runpod_mtp.qwen]
+is-default = true
+max-concurrent = 4
+
+[openai.gpt]
+is-default = true
+max-concurrent = 1
+
+[local_mtp.local-qwen]
+is-default = true
+max-concurrent = 1
+|}
+;;
+
+let contract_violation =
+  SdkE.Agent
+    (SdkE.CompletionContractViolation
+       { contract = Agent_sdk.Completion_contract_id.Require_tool_use
+       ; reason = "model emitted text instead of keeper tool"
+       ; violation_detail = None
+       })
+;;
+
+let with_runtime_config f =
+  let path = write_temp_runtime_config runtime_toml in
+  Fun.protect
+    ~finally:(fun () -> try Sys.remove path with Sys_error _ -> ())
+    (fun () -> f path)
+;;
+
+let load_runtimes path =
+  match Runtime.load_list ~config_path:path with
+  | Ok (runtimes, _default_runtime) -> runtimes
+  | Error msg -> Alcotest.fail msg
+;;
+
+let init_runtime path =
+  match Runtime.init_default ~config_path:path with
+  | Ok () -> ()
+  | Error msg -> Alcotest.fail msg
+;;
+
+let test_required_tool_runtime_ids_preserve_configured_fallback () =
+  with_runtime_config (fun path ->
+    let runtimes = load_runtimes path in
+    Alcotest.(check (list string))
+      "runtime ids"
+      [ "runpod_mtp.qwen"; "local_mtp.local-qwen" ]
+      (Runtime.required_tool_runtime_ids runtimes))
+;;
+
+let test_required_tool_contract_violation_rotates_to_local_runtime () =
+  with_runtime_config (fun path ->
+    init_runtime path;
+    match
+      EC.degraded_rotation_after_recoverable_error
+        ~base_runtime:"runpod_mtp.qwen"
+        ~effective_runtime:"runpod_mtp.qwen"
+        ~tool_requirement:Tool_surface.Required
+        ~attempted_runtimes:[ "runpod_mtp.qwen" ]
+        contract_violation
+    with
+    | Some retry ->
+      Alcotest.(check string)
+        "next runtime"
+        "local_mtp.local-qwen"
+        retry.EC.next_runtime;
+      Alcotest.(check string)
+        "reason"
+        "required_tool_contract_violation"
+        (EC.degraded_retry_reason_to_string retry.EC.fallback_reason)
+    | None -> Alcotest.fail "expected local runtime fallback")
+;;
+
+let test_required_tool_contract_violation_rotates_back_to_default_runtime () =
+  with_runtime_config (fun path ->
+    init_runtime path;
+    match
+      EC.degraded_rotation_after_recoverable_error
+        ~base_runtime:"local_mtp.local-qwen"
+        ~effective_runtime:"local_mtp.local-qwen"
+        ~tool_requirement:Tool_surface.Required
+        ~attempted_runtimes:[ "local_mtp.local-qwen" ]
+        contract_violation
+    with
+    | Some retry ->
+      Alcotest.(check string) "next runtime" "runpod_mtp.qwen" retry.EC.next_runtime
+    | None -> Alcotest.fail "expected default runtime fallback")
+;;
+
+let () =
+  Alcotest.run
+    "runtime_required_tool_fallback"
+    [ ( "required-tool fallback"
+      , [ Alcotest.test_case
+            "runtime list exposes configured tool-capable fallback"
+            `Quick
+            test_required_tool_runtime_ids_preserve_configured_fallback
+        ; Alcotest.test_case
+            "contract violation rotates from default RunPod to local MTP"
+            `Quick
+            test_required_tool_contract_violation_rotates_to_local_runtime
+        ; Alcotest.test_case
+            "contract violation rotates from local MTP back to default RunPod"
+            `Quick
+            test_required_tool_contract_violation_rotates_back_to_default_runtime
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary
- retain the loaded runtime list after Runtime.init_default
- derive required-tool fallback candidates from tool-capable runtime bindings
- allow required-tool contract violations to rotate between RunPod and local MTP instead of ending after the default runtime

## Verification
- ocamlformat --check lib/runtime/runtime.ml lib/runtime/runtime.mli lib/keeper/keeper_error_classify.ml test/test_runtime_required_tool_fallback.ml
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_runtime_required_tool_fallback.exe
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh exec test/test_runtime_required_tool_fallback.exe
- pre-commit hook: dune build --root .
