### PR TITLE
Fix runtime capability boundary ratchet

### DIFF
--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -80,10 +80,14 @@ let runtime_ids runtimes = List.map (fun (rt : t) -> rt.id) runtimes
 
 let runtime_supports_required_tools (rt : t) =
   let provider_caps =
-    Option.value ~default:capabilities_default rt.provider.capabilities
+    match rt.provider.capabilities with
+    | Some capabilities -> capabilities
+    | None -> capabilities_default
   in
   let model_caps =
-    Option.value ~default:model_capabilities_default rt.model.capabilities
+    match rt.model.capabilities with
+    | Some capabilities -> capabilities
+    | None -> model_capabilities_default
   in
   rt.model.tools_support
   && model_caps.supports_tool_choice


### PR DESCRIPTION
## Summary
- Replace optional runtime capability defaulting with explicit matches in `Runtime.runtime_supports_required_tools`.
- Fix the gRPC descriptor drift check to use `masc_workspace.proto` and refresh the embedded workspace descriptor.
- Clears the deterministic-boundary and descriptor lint failures left after #19679 was merged.

## Validation
- `ocamlformat --check lib/runtime/runtime.ml lib/grpc/masc_grpc_server.ml`
- `git diff --check`
- `scripts/ci/check-determinism-contract.sh --base origin/main --head HEAD`
- `scripts/gen-grpc-descriptors.sh --check`

Note: local Dune build was not rerun after this follow-up because the local temp volume hit ENOSPC during an isolated build attempt. GitHub CI should be the source of truth for full build here.
