### PR TITLE
Fix dashboard workspace syntax after #19668

### DIFF
--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -438,7 +438,7 @@ function bootstrapInitializingPayload(path: string): unknown | null {
           done: 0,
           cancelled: 0,
         },
-        workspace collaboration_fsm: {
+        workspace_fsm: {
           schema_version: 1,
           mode: 'advisory',
           summary: {

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -1288,7 +1288,7 @@ describe('fetchKeeperConfig', () => {
         goal: 'Ship stable keeper ops',
         short_goal: 'Diagnose agent liveness',
         mid_goal: 'Reduce restart confusion',
-        long_goal: 'Keep workspace collaboration stable',
+        long_goal: 'Keep workspace stable',
         will: 'Stay on call',
         needs: 'Accurate runtime state',
         desires: 'Clear operator feedback',
@@ -1365,7 +1365,7 @@ describe('fetchKeeperConfig', () => {
         disposition_reason: 'healthy',
         needs_attention: false,
       },
-      workspace collaboration: {
+      workspace: {
         mention_targets: 'sangsu',
         bound_workspace_ids: 'default',
         active_goal_ids: ['goal-runtime'],
@@ -1451,8 +1451,8 @@ describe('fetchKeeperConfig', () => {
     expect(result.runtime.runtime_blocker_class).toBe('stale_fleet_batch')
     expect(result.runtime.runtime_blocker_summary).toBe('Fleet batch paused after stale termination storm.')
     expect(result.active_goal_ids).toEqual(['goal-runtime'])
-    expect(result.workspace collaboration.active_goal_ids).toEqual(['goal-runtime'])
-    expect(result.workspace collaboration.active_goals[0]?.title).toBe('Ship runtime clarity')
+    expect(result.workspace.active_goal_ids).toEqual(['goal-runtime'])
+    expect(result.workspace.active_goals[0]?.title).toBe('Ship runtime clarity')
     expect(result.runtime_trust?.disposition).toBe('Pass')
   })
 

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -2113,7 +2113,7 @@ function normalizeKeeperHookSlots(raw: unknown): Record<string, KeeperHookSlot> 
   return slots
 }
 
-function normalizeKeeperConfigActiveGoals(raw: unknown): KeeperConfig['workspace collaboration']['active_goals'] {
+function normalizeKeeperConfigActiveGoals(raw: unknown): KeeperConfig['workspace']['active_goals'] {
   return asRecordArray(raw)
     .map((item) => {
       const id = asNullableString(item.id)
@@ -2122,7 +2122,7 @@ function normalizeKeeperConfigActiveGoals(raw: unknown): KeeperConfig['workspace
       if (!id || !title || !horizon) return null
       return { id, title, horizon }
     })
-    .filter((item): item is KeeperConfig['workspace collaboration']['active_goals'][number] => item !== null)
+    .filter((item): item is KeeperConfig['workspace']['active_goals'][number] => item !== null)
 }
 
 function normalizePromptBlock(raw: unknown, fallbackKey: string): { key: string; source: string; text: string } {
@@ -2193,7 +2193,7 @@ function normalizeKeeperConfig(raw: unknown, requestedName: string): KeeperConfi
   const hooks = isRecord(data.hooks) ? data.hooks : null
   const runtime = isRecord(data.runtime) ? data.runtime : {}
   const runtimeTrust = isRecord(data.runtime_trust) ? data.runtime_trust : null
-  const workspace collaboration = isRecord(data.workspace collaboration) ? data.workspace collaboration : {}
+  const workspace = isRecord(data.workspace) ? data.workspace : {}
   const tools = isRecord(data.tools) ? data.tools : {}
   const sources = isRecord(data.sources) ? data.sources : {}
   const metrics = isRecord(data.metrics) ? data.metrics : {}
@@ -2296,13 +2296,13 @@ function normalizeKeeperConfig(raw: unknown, requestedName: string): KeeperConfi
       runtime_blocker_continue_gate: asLooseNullableBoolean(runtime.runtime_blocker_continue_gate),
     },
     runtime_trust: runtimeTrust,
-    workspace collaboration: {
-      mention_targets: normalizeStringList(workspace collaboration.mention_targets),
-      bound_workspace_ids: normalizeStringList(workspace collaboration.bound_workspace_ids),
-      active_goal_ids: normalizeStringList(workspace collaboration.active_goal_ids),
-      active_goals: normalizeKeeperConfigActiveGoals(workspace collaboration.active_goals),
-      active_goal_count: asInt(workspace collaboration.active_goal_count) ?? 0,
-      missing_active_goal_ids: normalizeStringList(workspace collaboration.missing_active_goal_ids),
+    workspace: {
+      mention_targets: normalizeStringList(workspace.mention_targets),
+      bound_workspace_ids: normalizeStringList(workspace.bound_workspace_ids),
+      active_goal_ids: normalizeStringList(workspace.active_goal_ids),
+      active_goals: normalizeKeeperConfigActiveGoals(workspace.active_goals),
+      active_goal_count: asInt(workspace.active_goal_count) ?? 0,
+      missing_active_goal_ids: normalizeStringList(workspace.missing_active_goal_ids),
     },
     tools: {
       tool_access: tools.tool_access ?? {},

--- a/dashboard/src/api/schemas/logs.test.ts
+++ b/dashboard/src/api/schemas/logs.test.ts
@@ -41,7 +41,7 @@ describe('parseLogsResponse', () => {
       source: 'masc_log_ring',
       retention: {
         scope: 'dashboard_logs',
-        workspace collaboration_root: '/Users/dancer/me/.masc',
+        workspace_root: '/Users/dancer/me/.masc',
         buffer: 'Log.Ring',
         capacity: 50000,
         durable_store: '/Users/dancer/me/.masc/logs/system_log_2026-05-15.jsonl',

--- a/dashboard/src/api/schemas/logs.ts
+++ b/dashboard/src/api/schemas/logs.ts
@@ -58,7 +58,7 @@ const LogsResponseSchema = object({
 
 export interface LogsRetention {
   scope?: string
-  workspace collaboration_root?: string
+  workspace_root?: string
   buffer?: string
   capacity?: number
   durable_store?: string

--- a/dashboard/src/cockpit-entrypoints.ts
+++ b/dashboard/src/cockpit-entrypoints.ts
@@ -127,6 +127,12 @@ export const COCKPIT_ENTRYPOINTS: CockpitEntrypoint[] = [
   },
   {
     mode: 'observe',
+    aliases: ['runtime'],
+    target: { tab: 'monitoring', params: { section: 'runtime' } },
+    coverage: 'covered',
+  },
+  {
+    mode: 'observe',
     aliases: ['audit'],
     target: { tab: 'monitoring', params: { section: 'runtime', view: 'audit' } },
     coverage: 'covered',

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -17,6 +17,7 @@ import {
 import { FilterChips } from './common/filter-chips'
 import { TextInput } from './common/input'
 import { EmptyState } from './common/feedback-state'
+import { ringFocusClasses } from './common/ring'
 import { RouteLink } from './common/route-link'
 import { TimeAgo } from './common/time-ago'
 import {
@@ -1010,7 +1011,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                   aria-pressed=${selected}
                   onClick=${() => setSelectedKey(row.key)}
                   onKeyDown=${handleRowKey}
-                  class="grid w-full cursor-pointer grid-cols-1 gap-2 px-4 py-3 text-left transition-colors hover:bg-[var(--color-bg-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent-fg)] lg:grid-cols-[minmax(180px,1.35fr)_minmax(80px,0.5fr)_minmax(170px,1.1fr)_minmax(110px,0.65fr)_minmax(160px,0.9fr)] lg:items-center lg:gap-3 ${selected ? 'bg-[var(--color-bg-surface)]' : 'bg-transparent'}"
+                  class="grid w-full cursor-pointer grid-cols-1 gap-2 px-4 py-3 text-left transition-colors hover:bg-[var(--color-bg-hover)] ${ringFocusClasses({ tone: 'accent-fg', width: 2 })} lg:grid-cols-[minmax(180px,1.35fr)_minmax(80px,0.5fr)_minmax(170px,1.1fr)_minmax(110px,0.65fr)_minmax(160px,0.9fr)] lg:items-center lg:gap-3 ${selected ? 'bg-[var(--color-bg-surface)]' : 'bg-transparent'}"
                 >
                   <span class="flex min-w-0 items-center gap-3">
                     <span class="shrink-0">

--- a/dashboard/src/components/composite-fsm-flowchart.ts
+++ b/dashboard/src/components/composite-fsm-flowchart.ts
@@ -29,7 +29,6 @@ export const COMPOSITE_FSM_TLA_SPEC_PATHS = [
   'specs/keeper-state-machine/KeeperStateMachine.tla',
   'specs/keeper-state-machine/KeeperTurnCycle.tla',
   'specs/keeper-state-machine/KeeperDecisionPipeline.tla',
-  'specs/keeper-state-machine/KeeperRuntimeLifecycle.tla',
   'specs/keeper-state-machine/KeeperCompactionLifecycle.tla',
   'specs/keeper-state-machine/KeeperCircuitBreaker.tla',
 ] as const

--- a/dashboard/src/components/fsm-hub-invariant-analysis.ts
+++ b/dashboard/src/components/fsm-hub-invariant-analysis.ts
@@ -179,7 +179,7 @@ export function deriveOperationalInsight(
     return {
       tone: 'info',
       headline: 'Compaction 가 현재 턴 소유',
-      detail: 'parent lifecycle 과 memory lane 모두 post-turn compaction 이 active workspace collaboration point 임을 가리킴.',
+      detail: 'parent lifecycle 과 memory lane 모두 post-turn compaction 이 active workspace point 임을 가리킴.',
       nextStep: nextExpectedStep(snapshot),
       evidence: [
         `KSM ${snapshot.phase}`,

--- a/dashboard/src/components/fsm-hub-timeline-panels.ts
+++ b/dashboard/src/components/fsm-hub-timeline-panels.ts
@@ -3,6 +3,7 @@ import { useSignal } from '@preact/signals'
 import { useEffect, useMemo, useRef } from 'preact/hooks'
 import { DashedNotice } from './common/dashed-notice'
 import { TextInput } from './common/input'
+import { ringFocusClasses } from './common/ring'
 import { nowSecondsSignal, useNowSecondsTicker } from '../lib/now-signal'
 import { unixSecondsToDate } from '../lib/format-time'
 
@@ -236,7 +237,7 @@ export function SwimlaneTimeline({
                       data-lane-key=${lane.key}
                       data-lane-index=${laneIndex}
                       data-seg-index=${segIndex}
-                      class=${`${swimlaneSegmentColor(seg.value)} h-full transition-[filter,opacity,box-shadow] duration-[var(--t-med)] border-r border-[var(--color-border-default)] last:border-r-0 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent-fg)] focus-visible:ring-inset ${isHovered ? 'ring-1 ring-[var(--color-accent-fg)] brightness-125' : ''} ${dimmed ? 'opacity-40' : ''}`}
+                      class=${`${swimlaneSegmentColor(seg.value)} h-full transition-[filter,opacity,box-shadow] duration-[var(--t-med)] border-r border-[var(--color-border-default)] last:border-r-0 cursor-pointer ${ringFocusClasses({ tone: 'accent-fg', width: 2, inset: true })} ${isHovered ? 'ring-1 ring-[var(--color-accent-fg)] brightness-125' : ''} ${dimmed ? 'opacity-40' : ''}`}
                       style=${`width: ${pct.toFixed(2)}%`}
                       title=${`${lane.label} (${lane.short}) · ${displayState(seg.value)} (${seg.value})\n${fmtAbs(seg.from)} → ${fmtAbs(seg.to)} · ${holdFor}`}
                       aria-label=${ariaLabel}

--- a/dashboard/src/components/fsm-hub-types.ts
+++ b/dashboard/src/components/fsm-hub-types.ts
@@ -695,7 +695,7 @@ export type SwimlaneSegment = {
   value: string
 }
 
-/** Cross-panel hover workspace collaboration payload. When a swimlane segment is
+/** Cross-panel hover workspace payload. When a swimlane segment is
     under the cursor, the SwimlaneTimeline publishes which lane, value,
     and time window it covers, and downstream panels (TransitionTrail,
     PipelineStep) highlight rows that overlap. */

--- a/dashboard/src/components/goals/goal-tree.test.ts
+++ b/dashboard/src/components/goals/goal-tree.test.ts
@@ -20,7 +20,7 @@ const mocks = vi.hoisted(() => ({
       postId: null,
     },
   },
-  workspace collaborationFsmSnapshot: { value: null },
+  workspaceFsmSnapshot: { value: null },
 }))
 
 vi.mock('../../api/dashboard', () => ({
@@ -41,7 +41,7 @@ vi.mock('../../router', () => ({
 }))
 
 vi.mock('../../store', () => ({
-  workspace collaborationFsmSnapshot: mocks.workspace collaborationFsmSnapshot,
+  workspaceFsmSnapshot: mocks.workspaceFsmSnapshot,
 }))
 
 vi.mock('../task-manage/task-create-form', () => ({
@@ -149,7 +149,7 @@ describe('GoalTree', () => {
       params: { section: 'planning' },
       postId: null,
     }
-    mocks.workspace collaborationFsmSnapshot.value = null
+    mocks.workspaceFsmSnapshot.value = null
     hydrateGoalTreeSnapshot({ tree: [], summary: emptySummary() })
   })
 

--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -15,7 +15,7 @@ import {
   goalTreeLoading as treeLoading,
   hydrateGoalTreeSnapshot,
 } from '../../goal-tree-state'
-import { workspace collaborationFsmSnapshot } from '../../store'
+import { workspaceFsmSnapshot } from '../../store'
 import { EmptyState, ErrorState, LoadingState } from '../common/feedback-state'
 import { ActionButton } from '../common/button'
 import { FilterChips } from '../common/filter-chips'
@@ -692,8 +692,8 @@ function GoalBadges({ badges }: { badges: string[] }) {
   `
 }
 
-function workspace collaborationViolationsForGoal(goalId: string): DashboardWorkspaceFsmViolation[] {
-  const violations = workspace collaborationFsmSnapshot.value?.violations ?? []
+function workspaceViolationsForGoal(goalId: string): DashboardWorkspaceFsmViolation[] {
+  const violations = workspaceFsmSnapshot.value?.violations ?? []
   return violations.filter(violation => violation.refs?.goal_id === goalId)
 }
 
@@ -950,8 +950,8 @@ function TreeNode({ node, depth }: { node: GoalTreeNode; depth: number }) {
   const hasContent = node.children.length > 0 || node.tasks.length > 0
   const isSelected = selectedGoalId.value === node.id
   const verificationSummary = node.verification_summary ?? EMPTY_GOAL_VERIFICATION_SUMMARY
-  const workspace collaborationViolations = workspace collaborationViolationsForGoal(node.id)
-  const workspace collaborationHasError = workspace collaborationViolations.some(v => v.severity === 'error')
+  const workspaceViolations = workspaceViolationsForGoal(node.id)
+  const workspaceHasError = workspaceViolations.some(v => v.severity === 'error')
   const indent = depth * 20
   const headerBase = isSelected
     ? TREE_NODE_CARD_ACTIVE
@@ -1030,12 +1030,12 @@ function TreeNode({ node, depth }: { node: GoalTreeNode; depth: number }) {
                 approval ${node.pending_approval_count}
               </span>
             ` : null}
-            ${workspace collaborationViolations.length > 0 ? html`
+            ${workspaceViolations.length > 0 ? html`
               <span
-                class="rounded-[var(--r-1)] border px-2 py-0.5 text-3xs font-medium ${workspace collaborationHasError ? 'border-bad/30 bg-bad/10 text-bad' : 'border-warn/30 bg-warn/10 text-warn'}"
+                class="rounded-[var(--r-1)] border px-2 py-0.5 text-3xs font-medium ${workspaceHasError ? 'border-bad/30 bg-bad/10 text-bad' : 'border-warn/30 bg-warn/10 text-warn'}"
                 title="Goal x Task x Board x Reward"
               >
-                FSM ${workspace collaborationViolations.length}
+                FSM ${workspaceViolations.length}
               </span>
             ` : null}
             ${node.blocking_source !== 'none' ? html`

--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -52,7 +52,7 @@ function makeKeeperConfig(overrides: Partial<KeeperConfig> = {}): KeeperConfig {
       goal: 'Ship stable keeper ops',
       short_goal: 'Diagnose agent liveness',
       mid_goal: 'Reduce restart confusion',
-      long_goal: 'Keep workspace collaboration stable',
+      long_goal: 'Keep workspace stable',
       will: 'Stay on call',
       needs: 'Accurate runtime state',
       desires: 'Clear operator feedback',
@@ -115,7 +115,7 @@ function makeKeeperConfig(overrides: Partial<KeeperConfig> = {}): KeeperConfig {
       presence_keepalive: true,
       presence_keepalive_sec: 30,
     },
-    workspace collaboration: {
+    workspace: {
       mention_targets: ['sangsu'],
       bound_workspace_ids: ['default'],
       active_goal_ids: ['goal-runtime'],
@@ -277,7 +277,7 @@ function makeKeeperConfigForSandbox(overrides: Partial<KeeperConfig> = {}): Keep
       cooldown_sec: 0,
     } as KeeperConfig['handoff'],
     runtime: {} as KeeperConfig['runtime'],
-    workspace collaboration: {
+    workspace: {
       mention_targets: [],
       bound_workspace_ids: [],
       active_goal_ids: [],
@@ -375,7 +375,7 @@ describe('buildRuntimePayload — sandbox diffing', () => {
   it('emits active_goal_ids when goal bindings change', () => {
     const c = makeKeeperConfigForSandbox({
       active_goal_ids: ['goal-a'],
-      workspace collaboration: {
+      workspace: {
         mention_targets: [],
         bound_workspace_ids: [],
         active_goal_ids: ['goal-a'],
@@ -513,12 +513,11 @@ describe('KeeperConfigPanel', () => {
 
     expect(mocks.fetchKeeperConfig).toHaveBeenCalledTimes(1)
     expect(mocks.fetchDashboardGoalsTree).toHaveBeenCalledTimes(1)
-    expect(mocks.fetchRuntimeProfiles).toHaveBeenCalledTimes(1)
+    expect(mocks.fetchRuntimeProfiles).not.toHaveBeenCalled()
     expect(container.textContent).toContain('편집 가능 범위')
-    expect(container.textContent).toContain('keeper TOML의 runtime_id')
+    expect(container.textContent).toContain('keeper_runtime.toml')
     expect(container.textContent).toContain('Runtime 선택')
     expect(container.textContent).toContain('tier-group.keeper_unified')
-    expect(container.textContent).toContain('broken_profile')
     expect(container.textContent).toContain('/tmp/config/keepers/default.toml')
     expect(container.textContent).toContain('런타임 설정')
     expect(container.textContent).toContain('active_goal_ids')
@@ -541,41 +540,20 @@ describe('KeeperConfigPanel', () => {
     expect(textareas[0]?.value).toContain('Ship stable keeper ops')
   })
 
-  it('exposes runtime selection controls directly in the config panel', async () => {
+  it('renders runtime selection as read-only resolved config state', async () => {
     render(html`<${KeeperConfigPanel} keeperName="keeper-sangsu" />`, container)
     await flush()
     await flush()
 
     const runtimeSelect = Array.from(container.querySelectorAll('select')).find(
       (select) => !select.getAttribute('aria-label'),
-    ) as HTMLSelectElement | undefined
-    expect(runtimeSelect).toBeDefined()
-    expect(runtimeSelect?.value).toBe('tier-group.keeper_unified')
-
-    mocks.fetchKeeperConfig.mockResolvedValueOnce(
-      makeKeeperConfig({
-        execution: {
-          models: ['llama:test-balanced'],
-          active_model: 'llama:test-balanced',
-          per_provider_timeout_sec: null,
-          per_provider_timeout_mode: 'turn_budget_heuristic',
-          verify: true,
-          selected_runtime_id: 'tier.resilient_breaker',
-          selected_runtime_canonical: 'tier.resilient_breaker',
-        },
-      }),
     )
-
-    runtimeSelect!.value = 'tier.resilient_breaker'
-    runtimeSelect!.dispatchEvent(new Event('change', { bubbles: true }))
-    await flush()
-    await flush()
-
-    expect(mocks.updateKeeperRuntime).toHaveBeenCalledWith(
-      'keeper-sangsu',
-      'tier.resilient_breaker',
-    )
-    expect(mocks.fetchKeeperConfig).toHaveBeenCalledTimes(2)
+    expect(runtimeSelect).toBeUndefined()
+    expect(container.textContent).toContain('선택 runtime')
+    expect(container.textContent).toContain('tier-group.keeper_unified')
+    expect(container.textContent).toContain('선택은 /tmp/config/keepers/default.toml 에서 관리됩니다.')
+    expect(mocks.updateKeeperRuntime).not.toHaveBeenCalled()
+    expect(mocks.fetchKeeperConfig).toHaveBeenCalledTimes(1)
   })
 
   it('patches sandbox runtime controls from the dashboard panel', async () => {

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -151,8 +151,8 @@ export function coerceSharedMemoryScope(raw: string | undefined): SharedMemorySc
 export function initRuntimeDraftFromConfig(c: KeeperConfig): RuntimeDraft {
   return {
     sandbox_profile: coerceSandboxProfile(c.sandbox_profile),
-    active_goal_ids: c.workspace collaboration.active_goal_ids.length > 0
-      ? c.workspace collaboration.active_goal_ids
+    active_goal_ids: c.workspace.active_goal_ids.length > 0
+      ? c.workspace.active_goal_ids
       : c.active_goal_ids,
     network_mode: coerceNetworkMode(c.network_mode),
     allowed_paths_text: (c.allowed_paths ?? []).join('\n'),
@@ -173,8 +173,8 @@ export function buildRuntimePayload(draft: RuntimeDraft, orig: KeeperConfig): Ke
   const payload: KeeperConfigUpdatePayload = {}
   const newPaths = draft.allowed_paths_text.split('\n').map(s => s.trim()).filter(Boolean)
   const origPaths = orig.allowed_paths ?? []
-  const origActiveGoalIds = orig.workspace collaboration.active_goal_ids.length > 0
-    ? orig.workspace collaboration.active_goal_ids
+  const origActiveGoalIds = orig.workspace.active_goal_ids.length > 0
+    ? orig.workspace.active_goal_ids
     : orig.active_goal_ids
   if (!sameStringArray(draft.active_goal_ids, origActiveGoalIds)) payload.active_goal_ids = draft.active_goal_ids
   if (JSON.stringify(newPaths) !== JSON.stringify(origPaths)) payload.allowed_paths = newPaths
@@ -718,7 +718,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
   const goalOptions: GoalTreeNode[] = goalOptionsLoaded ? goalState.data : []
   const selectedActiveGoalIds = rd
     ? rd.active_goal_ids
-    : (c.workspace collaboration.active_goal_ids.length > 0 ? c.workspace collaboration.active_goal_ids : c.active_goal_ids)
+    : (c.workspace.active_goal_ids.length > 0 ? c.workspace.active_goal_ids : c.active_goal_ids)
   const knownGoalIds = new Set(goalOptions.map((goal) => goal.id))
   const unknownSelectedGoalIds = goalOptionsLoaded
     ? selectedActiveGoalIds.filter((goalId) => !knownGoalIds.has(goalId))
@@ -947,21 +947,21 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
           </div>
         ` : null}
       </div>
-      ${isVerifierRoleKeeper(c.workspace collaboration.mention_targets) ? html`
+      ${isVerifierRoleKeeper(c.workspace.mention_targets) ? html`
       <div class="mb-2 flex items-center gap-2 rounded-[var(--r-1)] border border-[var(--accent-30)] bg-[var(--accent-10)] px-3 py-2">
         <span class="rounded-[var(--r-1)] border border-[var(--accent-40)] bg-[var(--accent-5)] px-2 py-0.5 text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-accent-fg">검증자</span>
         <span class="text-2xs text-text-body">이 keeper는 task completion_contract를 독립 실측하는 검증자 역할입니다.</span>
       </div>
       ` : null}
-      ${c.workspace collaboration.mention_targets.length > 0 ? html`
+      ${c.workspace.mention_targets.length > 0 ? html`
       <div class="mt-1.5">
         <${SectionHeader} size="xs" class="mb-1">멘션 대상</${SectionHeader}>
-        <${ModelList} models=${c.workspace collaboration.mention_targets} />
+        <${ModelList} models=${c.workspace.mention_targets} />
       </div>
       ` : null}
       <div class="mt-1.5">
         <${SectionHeader} size="xs" class="mb-1">참여 네임스페이스</${SectionHeader}>
-        <${ModelList} models=${c.workspace collaboration.bound_workspace_ids} />
+        <${ModelList} models=${c.workspace.bound_workspace_ids} />
       </div>
 
       <${SectionHeader} title="핸드오프" />

--- a/dashboard/src/components/keeper-tool-access.test.ts
+++ b/dashboard/src/components/keeper-tool-access.test.ts
@@ -12,7 +12,7 @@ function makeConfig(overrides: Partial<KeeperConfig> = {}): KeeperConfig {
     network_mode: 'inherit',
     handoff: { auto: true, threshold: 0.8 },
     proactive: { enabled: true, idle_sec: 300 },
-    workspace collaboration: { mention_targets: ['alpha', 'beta'] },
+    workspace: { mention_targets: ['alpha', 'beta'] },
     tools: { resolved_allowlist: ['tool1', 'tool2'], tool_denylist: ['bad1'] },
     ...overrides,
   } as KeeperConfig
@@ -55,7 +55,7 @@ describe('KeeperToolAccessSummary', () => {
 
   it('shows em dash for empty mention targets', () => {
     const container = document.createElement('div')
-    render(h(KeeperToolAccessSummary, { config: makeConfig({ workspace collaboration: { mention_targets: [] } }) }), container)
+    render(h(KeeperToolAccessSummary, { config: makeConfig({ workspace: { mention_targets: [] } }) }), container)
     const dds = container.querySelectorAll('dd')
     expect(dds[5]!.textContent).toBe('—')
   })

--- a/dashboard/src/components/keeper-tool-access.ts
+++ b/dashboard/src/components/keeper-tool-access.ts
@@ -41,7 +41,7 @@ export function KeeperToolAccessSummary({ config }: { config: KeeperConfig }) {
   const network = config.network_mode ?? '(unknown network_mode)'
   const handoff = `${config.handoff.auto ? 'on' : 'off'} · threshold ${config.handoff.threshold}`
   const idle = `${config.proactive.idle_sec}s${config.proactive.enabled ? '' : ' (disabled)'}`
-  const mentions = mentionsLabel(config.workspace collaboration.mention_targets)
+  const mentions = mentionsLabel(config.workspace.mention_targets)
   const allowlistCount = config.tools.resolved_allowlist.length
   const denylistCount = config.tools.tool_denylist.length
 

--- a/dashboard/src/components/planning-panel.test.ts
+++ b/dashboard/src/components/planning-panel.test.ts
@@ -21,12 +21,12 @@ vi.mock('../router', () => ({
   }),
 }))
 
-const workspace collaborationSignal = signal<unknown>(null)
+const workspaceSignal = signal<unknown>(null)
 const tasksSignal = signal<unknown[]>([])
 const goalsSignal = signal<unknown[]>([])
 
 vi.mock('../store', () => ({
-  get workspace collaborationFsmSnapshot() { return workspace collaborationSignal },
+  get workspaceFsmSnapshot() { return workspaceSignal },
   get tasks() { return tasksSignal },
   get goals() { return goalsSignal },
 }))
@@ -56,7 +56,7 @@ function setRoute(view?: string, focus?: string) {
 describe('PlanningPanel', () => {
   beforeEach(() => {
     setRoute()
-    workspace collaborationSignal.value = null
+    workspaceSignal.value = null
     tasksSignal.value = []
     goalsSignal.value = []
     openTaskDetailMock.mockReset()
@@ -97,8 +97,8 @@ describe('PlanningPanel', () => {
     expect(screen.getByTestId('goal-tree')).toBeTruthy()
   })
 
-  it('renders workspace collaboration health violations', () => {
-    workspace collaborationSignal.value = {
+  it('renders workspace health violations', () => {
+    workspaceSignal.value = {
       mode: 'advisory',
       summary: {
         products: 1,

--- a/dashboard/src/components/planning-panel.ts
+++ b/dashboard/src/components/planning-panel.ts
@@ -7,7 +7,7 @@ import { html } from 'htm/preact'
 import { computed } from '@preact/signals'
 import { useEffect } from 'preact/hooks'
 import { replaceRoute, route } from '../router'
-import { workspace collaborationFsmSnapshot, goals, tasks } from '../store'
+import { workspaceFsmSnapshot, goals, tasks } from '../store'
 import { FilterChips } from './common/filter-chips'
 import { Planning } from './goals/planning'
 import { GoalTree } from './goals/goal-tree'
@@ -50,7 +50,7 @@ function updateViewParam(view: PlanningView): void {
   replaceRoute('workspace', params)
 }
 
-function workspace collaborationCount(
+function workspaceCount(
   snapshot: DashboardWorkspaceFsmSnapshot | null,
   key: 'products' | 'violations' | 'evidence' | 'warn' | 'error',
 ): number {
@@ -188,7 +188,7 @@ function WorkspaceViolationRow({ violation }: { violation: DashboardWorkspaceFsm
         <span class="font-mono text-2xs text-text-strong">${violation.code ?? violation.axis ?? '(unknown violation)'}</span>
         ${violation.axis ? html`<span class="text-3xs text-text-dim">${violation.axis}</span>` : null}
       </div>
-      <div class="mt-1 text-xs leading-relaxed text-text-body">${violation.message ?? 'workspace collaboration invariant 검토 필요.'}</div>
+      <div class="mt-1 text-xs leading-relaxed text-text-body">${violation.message ?? 'workspace invariant 검토 필요.'}</div>
       <div class="mt-1 truncate text-3xs text-text-dim" title=${refsLabel(violation.refs)}>${refsLabel(violation.refs)}</div>
       ${evidence.length > 0 ? html`
         <ul class="mt-2 grid gap-1">
@@ -202,14 +202,14 @@ function WorkspaceViolationRow({ violation }: { violation: DashboardWorkspaceFsm
 }
 
 function WorkspaceHealthPanel() {
-  const snapshot = workspace collaborationFsmSnapshot.value
+  const snapshot = workspaceFsmSnapshot.value
   if (!snapshot) return null
   const violations = snapshot.violations ?? []
   const topViolations = violations.slice(0, 5)
   const topEvidence = (snapshot.evidence ?? []).slice(0, 5)
-  const errorCount = workspace collaborationCount(snapshot, 'error')
-  const warnCount = workspace collaborationCount(snapshot, 'warn')
-  const evidenceCount = workspace collaborationCount(snapshot, 'evidence')
+  const errorCount = workspaceCount(snapshot, 'error')
+  const warnCount = workspaceCount(snapshot, 'warn')
+  const evidenceCount = workspaceCount(snapshot, 'evidence')
   return html`
     <section class="rounded-[var(--r-1)] border border-card-border/70 bg-[var(--color-bg-surface)] p-3" aria-label="협력 상태">
       <div class="flex flex-wrap items-center justify-between gap-3">
@@ -218,10 +218,10 @@ function WorkspaceHealthPanel() {
         </div>
         <div class="flex flex-wrap items-center gap-2 text-3xs font-medium">
           <span class="rounded-[var(--r-1)] border border-card-border/60 bg-[var(--color-bg-elevated)] px-2 py-1 text-text-body">
-            products ${workspace collaborationCount(snapshot, 'products')}
+            products ${workspaceCount(snapshot, 'products')}
           </span>
           <span class="rounded-[var(--r-1)] border border-card-border/60 bg-[var(--color-bg-elevated)] px-2 py-1 text-text-body">
-            violations ${workspace collaborationCount(snapshot, 'violations')}
+            violations ${workspaceCount(snapshot, 'violations')}
           </span>
           <span class="rounded-[var(--r-1)] border border-card-border/60 bg-[var(--color-bg-elevated)] px-2 py-1 text-text-body">
             evidence ${evidenceCount}
@@ -244,7 +244,7 @@ function WorkspaceHealthPanel() {
       ` : html`
         <ul class="mt-2 grid gap-2">
           ${topViolations.map((violation, index) => html`
-            <${WorkspaceViolationRow} key=${`${violation.code ?? violation.axis ?? 'workspace collaboration'}-${index}`} violation=${violation} />
+            <${WorkspaceViolationRow} key=${`${violation.code ?? violation.axis ?? 'workspace'}-${index}`} violation=${violation} />
           `)}
         </ul>
       `}

--- a/dashboard/src/components/tool-call-shared.test.ts
+++ b/dashboard/src/components/tool-call-shared.test.ts
@@ -60,7 +60,7 @@ describe('toolCategory', () => {
     expect(result.label).toBe('voice')
   })
 
-  it('matches workspace collaboration category', () => {
+  it('matches workspace category', () => {
     const result = toolCategory('task_claim')
     expect(result.label).toBe('workspace')
   })

--- a/dashboard/src/components/tools/config-resolution-panel.test.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.test.ts
@@ -178,7 +178,6 @@ describe('ConfigResolutionPanel', () => {
     )
 
     const cards = Array.from(container.querySelectorAll('[title]'))
-    expect(cards.map(card => card.getAttribute('title'))).toContain('/tmp/root-config/keeper_runtime.toml')
     expect(cards.map(card => card.getAttribute('title'))).toContain('/tmp/root-config')
     expect(container.textContent?.match(/env override/g)?.length ?? 0).toBe(1)
     expect(container.textContent).toContain('cwd fallback')
@@ -218,8 +217,8 @@ describe('ConfigResolutionPanel', () => {
       container,
     )
 
-    expect(container.textContent).toContain('same as config root')
-    expect(container.textContent).toContain('.')
+    expect(container.textContent).toContain('under config root')
+    expect(container.textContent).toContain('prompts')
   })
 
   it('treats slash root as a valid root-relative prefix', () => {

--- a/dashboard/src/components/transport-health.test.ts
+++ b/dashboard/src/components/transport-health.test.ts
@@ -431,7 +431,7 @@ describe('filterHotSessions', () => {
   })
 
   it('matches substring of kind', () => {
-    const result = filterHotSessions(sessions, 'workspace')
+    const result = filterHotSessions(sessions, 'agent')
     expect(result).toHaveLength(1)
     expect(result[0]!.kind).toBe('agent_stream')
   })

--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -199,10 +199,10 @@ describe('monitoring navigation labels', () => {
     const labels = sections.map(item => item.label)
     const uniq = new Set(labels)
     expect(uniq.size).toBe(labels.length)
-    // Regression guard: the word "Runtime" must not appear in sidebar
-    // labels after the runtime-to-runtime renaming.
+    // Regression guard: the Runtime label must not be overloaded across
+    // multiple sidebar items.
     const runtimeOccurrences = labels.filter(l => l.includes('Runtime')).length
-    expect(runtimeOccurrences).toBe(0)
+    expect(runtimeOccurrences).toBe(1)
   })
 })
 

--- a/dashboard/src/grpc/masc_workspace_pb.ts
+++ b/dashboard/src/grpc/masc_workspace_pb.ts
@@ -1,4 +1,4 @@
-/** Hand-written TypeScript types derived from proto/masc_workspace collaboration.proto.
+/** Hand-written TypeScript types derived from proto/masc_workspace.proto.
  *
  * These are used by the grpc-web transport until protoc codegen is wired.
  */

--- a/dashboard/src/namespace-truth-normalizers.test.ts
+++ b/dashboard/src/namespace-truth-normalizers.test.ts
@@ -52,7 +52,7 @@ describe('normalizeNamespaceTruth', () => {
       source: 'namespace_truth_read_model',
       retention: {
         scope: 'dashboard_namespace_truth',
-        workspace collaboration_root: '/Users/dancer/me',
+        workspace_root: '/Users/dancer/me',
         workspace_path: '/Users/dancer/me',
         shell_input: '/api/v1/dashboard/shell',
         execution_input: '/api/v1/dashboard/execution',
@@ -75,7 +75,7 @@ describe('normalizeNamespaceTruth', () => {
     const result = normalizeNamespaceTruth({
       root: {
         status: {
-          workspace collaboration_root: '/path/to/root',
+          workspace_root: '/path/to/root',
           workspace_path: '/path/to/ws',
           workspace_differs: true,
           cluster: 'local',
@@ -89,7 +89,7 @@ describe('normalizeNamespaceTruth', () => {
     })
     const status = result.root.status
     expect(status).not.toBeNull()
-    expect(status!.workspace collaboration_root).toBe('/path/to/root')
+    expect(status!.workspace_root).toBe('/path/to/root')
     expect(status!.workspace_differs).toBe(true)
     expect(status!.paused).toBe(false)
     expect(status!.version).toBe('1.0.0')
@@ -99,7 +99,7 @@ describe('normalizeNamespaceTruth', () => {
     const result = normalizeNamespaceTruth({
       root: {
         status: {
-          workspace collaboration_root: '/path/to/root',
+          workspace_root: '/path/to/root',
           workspace_path: '/path/to/ws',
           version: '1.0.0',
           generated_at: '2026-04-17T10:00:00Z',
@@ -549,7 +549,7 @@ describe('normalizeNamespaceTruth', () => {
     const result = normalizeNamespaceTruth({
       generated_at: '2026-04-17T12:00:00Z',
       root: {
-        status: { workspace collaboration_root: '/root', workspace_path: '/ws' },
+        status: { workspace_root: '/root', workspace_path: '/ws' },
         counts: { agents: 3, tasks: 5, keepers: 2, total_runtimes: 3 },
         configured_keepers: 4,
         provenance: 'fs',

--- a/dashboard/src/namespace-truth-normalizers.ts
+++ b/dashboard/src/namespace-truth-normalizers.ts
@@ -195,7 +195,7 @@ export function normalizeNamespaceTruth(raw: unknown): DashboardNamespaceTruthRe
     retention: retentionBlock
       ? {
           scope: asString(retentionBlock.scope),
-          workspace collaboration_root: asString(retentionBlock.workspace collaboration_root),
+          workspace_root: asString(retentionBlock.workspace_root),
           workspace_path: asString(retentionBlock.workspace_path),
           shell_input: asString(retentionBlock.shell_input),
           execution_input: asString(retentionBlock.execution_input),

--- a/dashboard/src/store-dashboard-bootstrap.test.ts
+++ b/dashboard/src/store-dashboard-bootstrap.test.ts
@@ -67,7 +67,7 @@ describe('refreshDashboard bootstrap', () => {
         generated_at: '2026-05-14T06:00:01Z',
         goals: [],
         rollup: {},
-        workspace collaboration_fsm: null,
+        workspace_fsm: null,
       },
       namespace_truth: {
         generated_at: '2026-05-14T06:00:02Z',

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -214,7 +214,7 @@ export function removeBoardPost(postId: string | undefined): void {
 
 export const goals = signal<Goal[]>([])
 export const goalsLoading = signal(false)
-export const workspace collaborationFsmSnapshot = signal<DashboardWorkspaceFsmSnapshot | null>(null)
+export const workspaceFsmSnapshot = signal<DashboardWorkspaceFsmSnapshot | null>(null)
 
 // --- OAS monitoring state ---
 
@@ -765,7 +765,7 @@ function normalizeWorkspaceFsmSnapshot(raw: unknown): DashboardWorkspaceFsmSnaps
 }
 
 function applyPlanningEnvelope(data: DashboardPlanningResponse): void {
-  workspace collaborationFsmSnapshot.value = normalizeWorkspaceFsmSnapshot(data.workspace collaboration_fsm)
+  workspaceFsmSnapshot.value = normalizeWorkspaceFsmSnapshot(data.workspace_fsm)
   goals.value = (Array.isArray(data.goals) ? data.goals : [])
     .map((row): Goal | null => {
       if (!isRecord(row)) return null

--- a/dashboard/src/transports/grpc-transport.ts
+++ b/dashboard/src/transports/grpc-transport.ts
@@ -4,8 +4,8 @@
  * for the JSON flavour).  Uses fetch + ReadableStream for binary frame
  * parsing.
  *
- * Proto: proto/masc_workspace collaboration.proto
- * Service: masc.workspace collaboration.v1.MascWorkspace
+ * Proto: proto/masc_workspace.proto
+ * Service: masc.workspace.v1.MascWorkspace
  */
 
 import type { Transport, TransportEvent, TransportOptions } from './transport'
@@ -24,7 +24,7 @@ import type {
   StatusResponse,
   LspRequest,
   LspResponse,
-} from '../grpc/masc_workspace collaboration_pb'
+} from '../grpc/masc_workspace_pb'
 
 import { TRANSPORT_RETRY_BASE_MS, TRANSPORT_RETRY_MAX_MS } from '../config/constants'
 
@@ -230,7 +230,7 @@ export function createGrpcTransport(
   opts: TransportOptions = {},
 ): GrpcTransport {
   const state = createState()
-  const service = 'masc.workspace collaboration.v1.MascWorkspace'
+  const service = 'masc.workspace.v1.MascWorkspace'
 
   const connect = () => {
     state.connected = true

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -1379,7 +1379,7 @@ export interface KeeperConfig {
   hooks?: KeeperHookIntrospection
   runtime: KeeperConfigRuntime
   runtime_trust?: KeeperConfigRuntimeTrust | null
-  workspace collaboration: KeeperConfigWorkspace
+  workspace: KeeperConfigWorkspace
   tools: KeeperConfigTools
   sources: KeeperConfigSources
   metrics: KeeperConfigMetrics

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -395,7 +395,7 @@ export interface DashboardAttentionEvent {
 
 export interface DashboardNamespaceTruthRetention {
   scope?: string
-  workspace collaboration_root?: string
+  workspace_root?: string
   workspace_path?: string
   shell_input?: string
   execution_input?: string
@@ -673,7 +673,7 @@ export interface DashboardPlanningResponse {
     done?: number
     cancelled?: number
   }
-  workspace collaboration_fsm?: DashboardWorkspaceFsmSnapshot | null
+  workspace_fsm?: DashboardWorkspaceFsmSnapshot | null
 }
 
 export interface DashboardWorkspaceFsmRefs {
@@ -1028,7 +1028,7 @@ export interface DashboardGoalDetailResponse {
 
 
 export interface ServerStatus {
-  workspace collaboration_root?: string
+  workspace_root?: string
   workspace_path?: string
   workspace_differs?: boolean
   cluster?: string

--- a/scripts/lint-ignore-without-comment.sh
+++ b/scripts/lint-ignore-without-comment.sh
@@ -71,7 +71,7 @@ rg -nP --with-filename '^\s*ignore \(' "$TARGET" 2>/dev/null > "$tmp_all"
 
 # Drop test files unless asked
 if [[ "$INCLUDE_TESTS" -eq 0 ]]; then
-  grep -v '/test/' "$tmp_all" > "$tmp_all.notest" || true
+  grep -Ev '(^|/)test/' "$tmp_all" > "$tmp_all.notest" || true
   mv "$tmp_all.notest" "$tmp_all"
 fi
 


### PR DESCRIPTION
## Summary
- fix invalid dashboard TypeScript identifiers left as `workspace collaboration` after #19668
- restore cockpit/runtime route expectations and read-only runtime config tests
- keep dashboard focus-ring drift and ignore() guard clean

## Verification
- pnpm run typecheck
- scripts/dashboard-drift-check.sh
- bash scripts/ci/check-ignore-without-comment-diff.sh --base origin/main --head HEAD
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build .
- TMPDIR=/private/tmp/masc-vitest-main-followup-19668 pnpm test