### PR TITLE
Fix Docker sandbox route contracts

### DIFF
--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -16,7 +16,7 @@ the categorization roadmap. Newly-added typed getters in
 
 **Total**: 377 unique knobs across 10 modules.
 
-**Typed getter classification**: 28/232 tagged (`operator`: 28, `algorithm`: 0, `unclassified`: 204).
+**Typed getter classification**: 30/232 tagged (`operator`: 30, `algorithm`: 0, `unclassified`: 202).
 
 ## Env_config_core (29 knobs; typed classification 0/7)
 
@@ -58,28 +58,28 @@ the categorization roadmap. Newly-added typed getters in
 |---|---|---|---|---|---|
 | `MASC_EXEC_TIMEOUT_DEFAULT_SEC` | string_literal | n/a | n/a | 147 |  |
 
-## Env_config_governance (35 knobs; typed classification 0/25)
+## Env_config_governance (35 knobs; typed classification 1/25)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_ANTI_RATIONALIZATION_FAIL_MODE` | typed:string | unclassified | unclassified | 211 |  |
-| `MASC_ANTI_RATIONALIZATION_GATE2_FAIL_CLOSED` | typed:bool | unclassified | unclassified | 233 |  |
+| `MASC_ANTI_RATIONALIZATION_FAIL_MODE` | typed:string | unclassified | unclassified | 213 |  |
+| `MASC_ANTI_RATIONALIZATION_GATE2_FAIL_CLOSED` | typed:bool | unclassified | unclassified | 235 |  |
 | `MASC_AUTONOMY_MAX_STARVATION_TICKS` | typed:int | unclassified | unclassified | 83 | {1 Thompson Sampling / Agent Selection Configuration} Primary env vars: MASC_AUTONOMY_*. |
 | `MASC_AUTONOMY_QUIET_END` | typed:int | unclassified | unclassified | 75 | Quiet hours end (0-23). |
 | `MASC_AUTONOMY_QUIET_START` | typed:int | unclassified | unclassified | 71 | Quiet hours start (0-23). Keeper suppresses actions in this window. |
 | `MASC_AUTONOMY_STARVATION_BONUS_COEF` | typed:float | unclassified | unclassified | 86 |  |
 | `MASC_AUTONOMY_THOMPSON_WEIGHT` | typed:float | unclassified | unclassified | 89 |  |
 | `MASC_AUTONOMY_VOTE_DECAY_FACTOR` | typed:float | unclassified | unclassified | 92 |  |
-| `MASC_DASHBOARD_FIXTURE` | string_literal | n/a | n/a | 145 | Dashboard fixture name override. |
-| `MASC_DASHBOARD_FIXTURES_ENABLED` | feature_flag | n/a | n/a | 141 | Whether dashboard fixtures are enabled. Default: false. Re-readable within the process; this does not imply shell-lev... |
-| `MASC_DASHBOARD_GOVERNANCE_JUDGE_ENABLED` | feature_flag | n/a | n/a | 152 | Whether governance judge is enabled. Default: true. |
-| `MASC_DASHBOARD_GOVERNANCE_JUDGE_INTERVAL_SEC` | typed:int | unclassified | unclassified | 149 | Governance judge interval, clamped to >= 15s. Default: 60. |
-| `MASC_DEFAULT_RUNTIME` | string_literal | n/a | n/a | 160 | Default runtime label (e.g. "provider_f:pro,agent_llm_a:sonnet"). |
-| `MASC_DEFAULT_MODEL` | string_literal | n/a | n/a | 168 | Default model id. |
-| `MASC_DEFAULT_PROVIDER` | string_literal | n/a | n/a | 164 | Default provider name. |
+| `MASC_DASHBOARD_FIXTURE` | string_literal | n/a | n/a | 147 | Dashboard fixture name override. |
+| `MASC_DASHBOARD_FIXTURES_ENABLED` | feature_flag | n/a | n/a | 143 | Whether dashboard fixtures are enabled. Default: false. Re-readable within the process; this does not imply shell-lev... |
+| `MASC_DASHBOARD_GOVERNANCE_JUDGE_ENABLED` | feature_flag | n/a | n/a | 154 | Whether governance judge is enabled. Default: true. |
+| `MASC_DASHBOARD_GOVERNANCE_JUDGE_INTERVAL_SEC` | typed:int | unclassified | unclassified | 151 | Governance judge interval, clamped to >= 15s. Default: 60. |
+| `MASC_DEFAULT_MODEL` | string_literal | n/a | n/a | 170 | Default model id. |
+| `MASC_DEFAULT_PROVIDER` | string_literal | n/a | n/a | 166 | Default provider name. |
+| `MASC_DEFAULT_RUNTIME` | string_literal | n/a | n/a | 162 | Default runtime label (e.g. "provider_f:pro,agent_llm_a:sonnet"). |
 | `MASC_EVENT_BUFFER_SIZE` | typed:int | unclassified | unclassified | 113 | A2A event buffer size per subscription. Caps the in-memory event list to prevent unbounded growth. |
-| `MASC_GOAL_DISPATCH_RUNTIME` | typed:string | unclassified | unclassified | 184 | Goal dispatch runtime. Default: "task". |
-| `MASC_GOAL_MODELS` | string_literal | n/a | n/a | 180 | Goal models (comma-separated). |
+| `MASC_GOAL_DISPATCH_RUNTIME` | typed:string | unclassified | unclassified | 186 | Goal dispatch runtime. Default: "task". |
+| `MASC_GOAL_MODELS` | string_literal | n/a | n/a | 182 | Goal models (comma-separated). |
 | `MASC_INFERENCE_CACHE_ENABLED` | feature_flag | n/a | n/a | 24 | Enable inference response cache (L1+L2). |
 | `MASC_INFERENCE_CACHE_L1_MAX_ENTRIES` | typed:int | unclassified | unclassified | 42 | L1 in-memory entry cap. BUG-015: Reduced from 2048 to 512 — unbounded growth with 2048 default caused excessive mem... |
 | `MASC_INFERENCE_CACHE_MAX_PROMPT_CHARS` | typed:int | unclassified | unclassified | 32 | Skip caching for oversized prompts (character count). |
@@ -87,14 +87,14 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_INFERENCE_CACHE_TTL_SEC` | typed:int | unclassified | unclassified | 28 | Default TTL for inference response cache (seconds). |
 | `MASC_INFERENCE_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 8 | Timeout for model API calls (seconds) |
 | `MASC_NEO4J_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 102 | Neo4j / zombie-cleanup interval (seconds). Controls the zero-zombie Pulse rhythm in the orchestrator. Clamped to >= 1... |
-| `MASC_OPERATOR_CACHE_TTL` | typed:float | unclassified | unclassified | 132 | Operator snapshot cache TTL (seconds). Default: 30. |
+| `MASC_OPERATOR_CACHE_TTL` | typed:float | unclassified | unclassified | 134 | Operator snapshot cache TTL (seconds). Default: 30. |
 | `MASC_OPERATOR_JUDGE_ENABLED` | feature_flag | n/a | n/a | 120 | Whether operator judge background loop is enabled. Default: true. |
 | `MASC_OPERATOR_JUDGE_INTERVAL_SEC` | typed:int | unclassified | unclassified | 123 | Operator judge interval, clamped to >= 15s. Default: 60. |
-| `MASC_OPERATOR_JUDGE_WORKSPACE_TTL_SEC` | typed:int | unclassified | unclassified | 126 | Workspace TTL for operator judge cleanup, clamped to >= 15s. Default: 60. |
-| `MASC_OPERATOR_JUDGE_SESSION_TTL_SEC` | typed:int | unclassified | unclassified | 129 | Session TTL for operator judge cleanup, clamped to >= 30s. Default: 300. |
+| `MASC_OPERATOR_JUDGE_SESSION_TTL_SEC` | typed:int | unclassified | unclassified | 131 | Session TTL for operator judge cleanup, clamped to >= 30s. Default: 300. |
+| `MASC_OPERATOR_JUDGE_WORKSPACE_TTL_SEC` | typed:int | Timeouts | operator | 128 | Workspace TTL for operator judge cleanup, clamped to >= 15s. Default: 60. @category Timeouts @ops_class operator |
 | `MASC_RATE_LIMIT_CLEANUP_INTERVAL_SEC` | typed:float | unclassified | unclassified | 58 | Cleanup interval for stale rate limit buckets (seconds) |
 | `MASC_RATE_LIMIT_ENTRY_MAX_AGE_SEC` | typed:float | unclassified | unclassified | 62 | Max age for rate limit entries before cleanup (seconds) |
-| `MASC_ROUTING_RUNTIME` | string_literal | n/a | n/a | 174 | Routing runtime for team session routing. Defaults to the logical [routes.routing] key; runtime callers normalize it ... |
+| `MASC_ROUTING_RUNTIME` | string_literal | n/a | n/a | 176 | Routing runtime for team session routing. Defaults to the logical [routes.routing] key; runtime callers normalize it ... |
 | `MASC_SPAWN_CACHE_POLICY` | typed:string | unclassified | unclassified | 48 | Spawn cache policy: - off - safe_only (GLM direct HTTP only, no MCP-tool side effects) |
 | `MASC_SSE_KEEPALIVE_SEC` | typed:float | unclassified | unclassified | 108 | SSE keepalive interval (seconds). Frequency of `: keepalive` frames on command-plane SSE streams. Clamped to >= 1.0 t... |
 
@@ -103,7 +103,6 @@ the categorization roadmap. Newly-added typed getters in
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
 | `MASC_ALERT_DEDUP_WINDOW_SEC` | typed:float | unclassified | unclassified | 226 | Alert dedup window, clamped to >= 5s. Default: 60. |
-| `MASC_RUNTIME_SATURATION_SIGNAL_ENABLED` | typed:bool | unclassified | unclassified | 743 | {1 Runtime Saturation Signal (RFC-0153 Phase A.2)} Feature flag for typed [Runtime_saturation_signal.t] emission from... |
 | `MASC_CONTEXT_RATIO_HARD_CAP` | typed:float | unclassified | unclassified | 670 | {1 Context Ratio Hard Cap} Absolute ceiling for compaction ratio_gate and handoff threshold after multiplier adjustme... |
 | `MASC_DASHBOARD_HEALTH_CTX_CRITICAL` | typed:float | unclassified | unclassified | 705 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
 | `MASC_DASHBOARD_HEALTH_CTX_WARN` | typed:float | unclassified | unclassified | 706 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
@@ -141,8 +140,7 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_BOOTSTRAP_MAX_SCAN` | typed:int | unclassified | unclassified | 28 | Max keeper meta files to scan during bootstrap |
 | `MASC_KEEPER_BOOTSTRAP_POST_STARTUP_SETTLE_SEC` | typed:float | unclassified | unclassified | 70 | Settle delay (seconds) between lazy-startup completion and the keeper bootstrap fan-out. The autoboot fiber sleeps fo... |
 | `MASC_KEEPER_BOOTSTRAP_STALE_TURN_SEC` | typed:float | unclassified | unclassified | 24 | Keeper considered stale when last turn exceeds this threshold (seconds) |
-| `MASC_KEEPER_RUNTIME_PROVIDER_ALLOWLIST` | string_literal | n/a | n/a | 773 | Comma-separated provider kind allowlist for every keeper runtime call. Values are OAS [Provider_config.string_of_prov... |
-| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 510 | Stdout-idle timeout for CLI subprocess transports (Provider_c CLI today; Claude Code / Provider_f CLI / Codex CLI nee... |
+| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 510 | Stdout-idle timeout for CLI subprocess transports (Anthropic CLI today; Claude Code / Gemini CLI / Codex CLI need an ... |
 | `MASC_KEEPER_CRASH_PERSIST_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 163 | Crash persistence drain fiber wake interval in seconds. Drain fiber batches in-memory crash events and persists them ... |
 | `MASC_KEEPER_DEBUG` | feature_flag | n/a | n/a | 182 | Enable keeper debug logging. Default: false. |
 | `MASC_KEEPER_DELIBERATION_DAILY_BUDGET_USD` | typed:float | unclassified | unclassified | 188 | Daily budget for keeper deliberation (USD). Default: 0.10. Re-readable within the process. Live operator control shou... |
@@ -155,9 +153,9 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_MAX_CONSECUTIVE_HB_FAILURES` | typed:int | unclassified | unclassified | 272 | Maximum consecutive heartbeat failures before raising Keeper_fiber_crash (structured crash via dispatch_event). Defau... |
 | `MASC_KEEPER_MAX_CONSECUTIVE_TOOL_FAILURES` | typed:int | unclassified | unclassified | 659 | Maximum consecutive failures for the same (tool_name, args_hash) before blocking further attempts. Prevents infinite ... |
 | `MASC_KEEPER_MAX_CONSECUTIVE_TURN_FAILURES` | typed:int | unclassified | unclassified | 279 | Maximum consecutive unified turn failures before marking keeper as crashed. Covers LLM timeout, rate limit, and other... |
-| `MASC_KEEPER_MAX_IDLE_TURNS_AUTONOMOUS` | typed:int | unclassified | unclassified | 318 | Max idle turns for scheduled autonomous keeper turns. With tool_choice=Any and max_turns=50, keepers have workspace to exp... |
+| `MASC_KEEPER_MAX_IDLE_TURNS_AUTONOMOUS` | typed:int | unclassified | unclassified | 318 | Max idle turns for scheduled autonomous keeper turns. With tool_choice=Any and max_turns=50, keepers have workspace t... |
 | `MASC_KEEPER_MAX_IDLE_TURNS_REACTIVE` | typed:int | unclassified | unclassified | 325 | Max idle turns for reactive (board/mention triggered) keeper turns. Reactive turns have an explicit trigger — more ... |
-| `MASC_KEEPER_MAX_SILENCE_SEC` | typed:float | unclassified | unclassified | 246 | Maximum seconds since last successful workspace heartbeat before presence sync is required again. Floor = keepalive interv... |
+| `MASC_KEEPER_MAX_SILENCE_SEC` | typed:float | unclassified | unclassified | 246 | Maximum seconds since last successful workspace heartbeat before presence sync is required again. Floor = keepalive i... |
 | `MASC_KEEPER_METRICS_MAX_BYTES` | typed:int | unclassified | unclassified | 78 | Maximum metrics file size in bytes before rotation (default: 10MB) |
 | `MASC_KEEPER_METRICS_MAX_ROTATED` | typed:int | unclassified | unclassified | 81 | Number of rotated files to keep (default: 1, i.e. .1 only) |
 | `MASC_KEEPER_OAS_MAX_TURNS_PER_CALL` | typed:int | unclassified | unclassified | 426 | Maximum turns per single OAS Agent.run call. Keeper resumes via checkpoint in the next keepalive cycle when {!Runtime... |
@@ -166,6 +164,7 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_PROACTIVE_MAX_ATTEMPTS` | typed:int | unclassified | unclassified | 642 | Maximum proactive generation attempts before falling back. Default: 3. Range: [1, 10]. |
 | `MASC_KEEPER_REDUCER_CAP_TOKENS` | typed:int | unclassified | unclassified | 209 | Max message tokens retained by {!Agent_sdk.Context_reducer.cap_message_tokens} in the keeper run reducer pipeline.  D... |
 | `MASC_KEEPER_REDUCER_KEEP_RECENT` | typed:int | unclassified | unclassified | 218 | Recent messages kept verbatim by {!Agent_sdk.Context_reducer.cap_message_tokens}.  Default: 3. Range: [1, 20]. Env: [... |
+| `MASC_KEEPER_RUNTIME_PROVIDER_ALLOWLIST` | string_literal | n/a | n/a | 773 | Comma-separated provider kind allowlist for every keeper runtime call. Values are OAS [Provider_config.string_of_prov... |
 | `MASC_KEEPER_SLEEP_CHUNK_SEC` | typed:float | unclassified | unclassified | 295 | Interruptible sleep chunk size in seconds. Smaller = faster wakeup response but more CPU polling. Default: 2.0. Range... |
 | `MASC_KEEPER_SMART_HEARTBEAT` | feature_flag | n/a | n/a | 256 | Master switch for adaptive heartbeat scheduling in the keepalive loop. When true, Keeper_heartbeat_smart.should_emit ... |
 | `MASC_KEEPER_SNAPSHOT_SEC` | typed:int | unclassified | unclassified | 192 | Keeper keepalive snapshot interval, clamped to [15, 3600]. Default: 300. |
@@ -178,8 +177,9 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_WATCHDOG_POLL_SEC` | typed:float | unclassified | unclassified | 582 | Watchdog poll interval in seconds. Must be >= 5. Default: 30. |
 | `MASC_KEEPER_WATCHDOG_PROGRESS_SEC` | typed:float | Timeouts | operator | 567 | Seconds since the last in-turn progress signal before an active turn is considered mid-turn-stale. Default: 300 (5 mi... |
 | `MASC_KEEPER_WATCHDOG_STALE_SEC` | typed:float | unclassified | unclassified | 542 | Seconds since last turn before a Running keeper is considered idle-stale. Must be >= 60. Default: 300 (5 minutes). In... |
-| `MASC_KEEPER_WORK_AS_HEARTBEAT` | feature_flag | n/a | n/a | 240 | Master switch. When true, successful Workspace.heartbeat after a unified turn counts as presence proof, allowing the next... |
+| `MASC_KEEPER_WORK_AS_HEARTBEAT` | feature_flag | n/a | n/a | 240 | Master switch. When true, successful Workspace.heartbeat after a unified turn counts as presence proof, allowing the ... |
 | `MASC_PAYLOAD_TELEMETRY` | typed:bool | unclassified | unclassified | 729 | Master switch for wake-payload measurement. Default off so the hot path is untouched until a baseline sweep is explic... |
+| `MASC_RUNTIME_SATURATION_SIGNAL_ENABLED` | typed:bool | unclassified | unclassified | 743 | {1 Runtime Saturation Signal (RFC-0153 Phase A.2)} Feature flag for typed [Runtime_saturation_signal.t] emission from... |
 
 ## Env_config_keeper_retry_backoff (4 knobs; typed classification 1/4)
 
@@ -222,7 +222,7 @@ the categorization roadmap. Newly-added typed getters in
 |---|---|---|---|---|---|
 | `MASC_OAS_BRIDGE_TIMEOUT_DEFAULT_SEC` | string_literal | n/a | n/a | 114 |  |
 
-## Env_config_runtime (116 knobs; typed classification 3/93)
+## Env_config_runtime (116 knobs; typed classification 4/93)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
@@ -242,7 +242,6 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_CDAL_GATE_ENABLED` | feature_flag | n/a | n/a | 339 | Block task completion when CDAL verdict is Violated/Inconclusive. Default: false. |
 | `MASC_CDAL_VERDICT_LOOKUP_LIMIT` | typed:int | unclassified | unclassified | 346 | Max verdicts to scan when looking up the latest verdict by task_id. Beyond this limit, older entries are silently ski... |
 | `MASC_CLAIM_TTL_SECONDS` | typed:float | unclassified | unclassified | 89 | Maximum time a task can stay Claimed/InProgress without agent heartbeat before being auto-released back to Todo (seco... |
-| `MASC_WORKSPACE_GIT_LOCAL_OP_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 951 | Budget (seconds) for local-only git operations under [Masc_exec.Exec_gate.run_argv*] in {!Workspace_git}: [rev-parse], [s... |
 | `MASC_DASHBOARD_CTX_COMPACTING` | typed:float | unclassified | unclassified | 681 |  |
 | `MASC_DASHBOARD_CTX_HANDOFF_IMMINENT` | typed:float | unclassified | unclassified | 677 | Keeper context-ratio lifecycle thresholds. Higher ratio = closer to context limit = more urgency. |
 | `MASC_DASHBOARD_CTX_PREPARING` | typed:float | unclassified | unclassified | 679 |  |
@@ -285,7 +284,7 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_LOCK_EXPIRY_WARNING_SEC` | typed:float | unclassified | unclassified | 26 | Lock expiry warning threshold (seconds before expiry) |
 | `MASC_LOCK_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 22 | Default lock timeout (seconds) |
 | `MASC_MEMORY_OAS_DEFAULT_IMPORTANCE` | typed:int | unclassified | unclassified | 630 | Default importance for OAS-stored memories, clamped to [1, 10]. Default: 5. |
-| `MASC_MESSAGE_MAX_COUNT` | typed:int | unclassified | unclassified | 226 | Maximum number of message files to retain per workspace (default 200). Oldest messages (by filename sort) are deleted when... |
+| `MASC_MESSAGE_MAX_COUNT` | typed:int | unclassified | unclassified | 226 | Maximum number of message files to retain per workspace (default 200). Oldest messages (by filename sort) are deleted... |
 | `MASC_METRICS_FLUSH_SEC` | typed:float | unclassified | unclassified | 818 | Tool metrics flush interval (seconds). Default: 300 (5 min). |
 | `MASC_OAS_SSE_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 622 | SSE drain interval (seconds). Default: 2.0. |
 | `MASC_OPENAI_COMPAT` | feature_flag | n/a | n/a | 314 | Whether OpenAI-compatible endpoint is enabled. Default: false. |
@@ -338,6 +337,7 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_WEB_SEARCH_RATE_LIMIT_MAX_CALLS` | typed:int | unclassified | unclassified | 579 |  |
 | `MASC_WEB_SEARCH_RATE_LIMIT_WINDOW_SEC` | typed:float | unclassified | unclassified | 575 |  |
 | `MASC_WEB_SEARCH_TIMEOUT_SEC` | typed:int | unclassified | unclassified | 567 |  |
+| `MASC_WORKSPACE_GIT_LOCAL_OP_TIMEOUT_SEC` | typed:float | Timeouts | operator | 953 | Budget (seconds) for local-only git operations under [Masc_exec.Exec_gate.run_argv*] in {!Workspace_git}: [rev-parse]... |
 | `MASC_WS_ENABLED` | feature_flag | n/a | n/a | 295 | Whether WebSocket transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at... |
 | `MASC_WS_PORT` | string_literal | n/a | n/a | 291 | WebSocket server port. Default: 8937. |
 | `MASC_ZOMBIE_CLEANUP_INTERVAL_SEC` | typed:float | unclassified | unclassified | 14 | Cleanup loop interval (seconds) |
@@ -375,7 +375,6 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_BASE_PATH_RESOLUTION_SOURCE` | string_literal | n/a | n/a | 655 |  |
 | `MASC_BASE_PATH_STRICT` | string_literal | n/a | n/a | 657 |  |
 | `MASC_BENCHMARK_RESULTS_DIR` | string_literal | n/a | n/a | 221 |  |
-| `MASC_RUNTIME_ATTEMPT_LIVENESS` | string_literal | n/a | n/a | 474 |  |
 | `MASC_CHANNEL_GATE_DEDUP_TTL_SEC` | string_literal | n/a | n/a | 311 |  |
 | `MASC_CHANNEL_GATE_MAX_CONTENT_LENGTH` | string_literal | n/a | n/a | 313 |  |
 | `MASC_DASHBOARD_CACHE_MAX_ENTRIES` | string_literal | n/a | n/a | 223 |  |
@@ -427,6 +426,7 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_LOCK_WARN_MS` | string_literal | n/a | n/a | 215 |  |
 | `MASC_OTEL_ENABLED` | string_literal | n/a | n/a | 749 |  |
 | `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 785 |  |
+| `MASC_RUNTIME_ATTEMPT_LIVENESS` | string_literal | n/a | n/a | 474 |  |
 | `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 797 |  |
 | `MASC_SHUTDOWN_CLEANUP_TIMEOUT` | string_literal | n/a | n/a | 697 |  |
 | `MASC_SHUTDOWN_DRAIN_TIMEOUT` | string_literal | n/a | n/a | 699 |  |

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -340,7 +340,7 @@ let keepers_dashboard_json ?(compact = false) (config : Workspace.config) : Yojs
             attention_fields_json config m
           in
           let runtime_contract =
-            Keeper_runtime_contract.runtime_contract_json ~config m
+            Keeper_runtime_contract.runtime_observability_contract_json ~config m
           in
           let goal_progress =
             Option.value ~default:`Null (Json_util.assoc_member_opt "goal_progress" runtime_contract)

--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -372,6 +372,15 @@ let to_oas_approval_callback ?config ~governance_level ~keeper_name ?meta ?clock
              Keeper_runtime_contract.runtime_contract_json ?config keeper_meta)
           meta
       in
+      let sandbox_profile, backend, sandbox_target =
+        match meta with
+        | Some keeper_meta ->
+          let backend = Keeper_runtime_contract.backend_of_meta keeper_meta in
+          ( Some (Keeper_types_profile.sandbox_profile_to_string keeper_meta.sandbox_profile)
+          , Some backend
+          , Some backend )
+        | None -> None, None, None
+      in
       let selected_model = selected_model_of_meta meta in
       let risk_level = queue_risk_level risk in
       let base_path =
@@ -427,6 +436,8 @@ let to_oas_approval_callback ?config ~governance_level ~keeper_name ?meta ?clock
             ~tool_name
             ~input
             ~risk_level
+            ?sandbox_profile
+            ?backend
             ?runtime_contract
             ()
       in
@@ -443,6 +454,7 @@ let to_oas_approval_callback ?config ~governance_level ~keeper_name ?meta ?clock
           ?task_id
           ?goal_id
           ~goal_ids:(Option.value ~default:[] goal_ids)
+          ?sandbox_target
           ?runtime_contract
           ?selected_model
           ~disposition:"Pass"
@@ -464,6 +476,7 @@ let to_oas_approval_callback ?config ~governance_level ~keeper_name ?meta ?clock
             ?task_id
             ?goal_id
             ~goal_ids:(Option.value ~default:[] goal_ids)
+            ?sandbox_target
             ?runtime_contract
             ?selected_model
             ~disposition:"Pass"
@@ -491,6 +504,7 @@ let to_oas_approval_callback ?config ~governance_level ~keeper_name ?meta ?clock
                ?task_id
                ?goal_id
                ~goal_ids:(Option.value ~default:[] goal_ids)
+               ?sandbox_target
                ?runtime_contract
                ?selected_model
                ~disposition:"Pass"
@@ -509,6 +523,9 @@ let to_oas_approval_callback ?config ~governance_level ~keeper_name ?meta ?clock
                ?task_id
                ?goal_id
                ?goal_ids
+               ?sandbox_target
+               ?sandbox_profile
+               ?backend
                ?runtime_contract
                ?selected_model
                ~disposition:"Blocked"

--- a/lib/keeper/agent_tool_execute_command_semantics.ml
+++ b/lib/keeper/agent_tool_execute_command_semantics.ml
@@ -259,7 +259,7 @@ let resolve_sandbox_root_git_cwd_of_stages
       if path_is_existing_dir target
       then cwd, None
       else
-        target,
+        cwd,
         Some
           (Printf.sprintf
              "cwd_not_directory: %s (git -C target must be an existing directory)"

--- a/lib/keeper/agent_tool_execute_command_semantics.ml
+++ b/lib/keeper/agent_tool_execute_command_semantics.ml
@@ -62,8 +62,15 @@ let is_env_assignment token =
   | Some 0 -> false
   | Some i -> is_shell_identifier (String.sub token 0 i)
 
-let rec effective_stage = function
-  | { bin = "env"; args } ->
+let normalize_command_name command_name =
+  let command_name = Filename.basename command_name |> String.lowercase_ascii in
+  if String.ends_with ~suffix:".exe" command_name
+  then String.sub command_name 0 (String.length command_name - String.length ".exe")
+  else command_name
+
+let rec effective_stage stage =
+  match normalize_command_name stage.bin, stage.args with
+  | "env", args ->
     let rec scan = function
       | [] -> None
       | ("-i" | "--ignore-environment") :: rest -> scan rest
@@ -72,13 +79,16 @@ let rec effective_stage = function
       | bin :: args -> Some { bin; args }
     in
     scan args
-  | { bin = "opam"; args = "exec" :: rest } ->
+  | "opam", "exec" :: rest ->
     (match rest with
      | "--" :: bin :: args -> Some { bin; args }
      | bin :: args when not (String.starts_with ~prefix:"-" bin) ->
        Some { bin; args }
      | _ -> None)
-  | stage -> Some stage
+  | _ ->
+    (* DET-OK: this is the parsed command itself, not an inferred fallback for
+       an unknown wrapper. *)
+    Some stage
 
 let effective_stages_of_ir ir =
   parsed_stages_of_ir ir |> List.filter_map effective_stage
@@ -101,10 +111,12 @@ let safe_repo_name name =
   && not (String.contains name '\000')
 
 let stages_target_repo_commands stages =
-  List.exists (fun stage -> stage.bin = "git" || stage.bin = "gh") stages
+  List.exists (fun stage ->
+    let bin = normalize_command_name stage.bin in
+    bin = "git" || bin = "gh") stages
 
 let stages_target_repo_hosting_cli stages =
-  List.exists (fun stage -> stage.bin = "gh") stages
+  List.exists (fun stage -> normalize_command_name stage.bin = "gh") stages
 
 let repo_hosting_cli_args_have_repo_flag args =
   List.exists
@@ -117,7 +129,9 @@ let repo_hosting_cli_args_have_repo_flag args =
 
 let stages_have_repo_hosting_cli_repo_flag stages =
   List.exists
-    (fun stage -> stage.bin = "gh" && repo_hosting_cli_args_have_repo_flag stage.args)
+    (fun stage ->
+       normalize_command_name stage.bin = "gh"
+       && repo_hosting_cli_args_have_repo_flag stage.args)
     stages
 
 let repo_flag_value = function
@@ -137,7 +151,7 @@ let repo_hosting_cli_repo_flag_api_misuse_of_stages stages =
     | _ -> None
   in
   List.find_map (fun stage ->
-    if stage.bin = "gh" then scan_args stage.args else None) stages
+    if normalize_command_name stage.bin = "gh" then scan_args stage.args else None) stages
 
 let bare_worktrees_path token =
   let token = strip_simple_shell_quotes token in
@@ -146,20 +160,31 @@ let bare_worktrees_path token =
   || String.starts_with ~prefix:".worktrees/" token
   || String.starts_with ~prefix:"./.worktrees/" token
 
-let git_c_path_of_stages stages =
-  let rec scan_git_args = function
-    | "-C" :: path :: _ -> Some path
-    | "--" :: _ -> None
-    | option :: _ when String.starts_with ~prefix:"-C" option ->
+let git_global_c_paths_of_stages stages =
+  let rec scan_git_args acc = function
+    | "-C" :: path :: rest -> scan_git_args (path :: acc) rest
+    | "-C" :: [] -> List.rev acc
+    | "--" :: _ -> List.rev acc
+    | option :: rest when String.starts_with ~prefix:"-C" option ->
       let path =
         String.sub option 2 (String.length option - 2) |> String.trim
       in
-      if path = "" then None else Some path
-    | _ :: rest -> scan_git_args rest
-    | [] -> None
+      if path = "" then List.rev acc else scan_git_args (path :: acc) rest
+    | ("-c" | "--config-env" | "--git-dir" | "--work-tree" | "--namespace"
+      | "--super-prefix" | "--exec-path") :: _value :: rest ->
+      scan_git_args acc rest
+    | option :: rest when String.starts_with ~prefix:"-" option ->
+      scan_git_args acc rest
+    | _ :: _ -> List.rev acc
+    | [] -> List.rev acc
   in
   List.find_map (fun stage ->
-    if stage.bin = "git" then scan_git_args stage.args else None) stages
+    if normalize_command_name stage.bin = "git"
+    then (
+      match scan_git_args [] stage.args with
+      | [] -> None
+      | paths -> Some paths)
+    else None) stages
 
 let normalize_cwd_relative_path ?container_root ?host_root ~cwd path =
   let path = strip_simple_shell_quotes path |> String.trim in
@@ -203,7 +228,8 @@ let normalize_repos_path_token token =
 
 let repos_path_hint_of_stages ~cmd stages =
   List.find_map (fun stage ->
-    if stage.bin <> "git" && stage.bin <> "gh"
+    let bin = normalize_command_name stage.bin in
+    if bin <> "git" && bin <> "gh"
     then None
     else
       stage.args
@@ -246,25 +272,7 @@ let resolve_sandbox_root_git_cwd_of_stages
   then cwd, None
   else if cwd_normalized = host_root && stages_target_repo_commands stages
   then (
-    let explicit_git_c_path = git_c_path_of_stages stages in
-    match explicit_git_c_path with
-    | Some path when not (bare_worktrees_path path) ->
-      let target =
-        normalize_cwd_relative_path
-          ~container_root:(Keeper_sandbox.container_root meta.name)
-          ~host_root
-          ~cwd:cwd_normalized
-          path
-      in
-      if path_is_existing_dir target
-      then cwd, None
-      else
-        cwd,
-        Some
-          (Printf.sprintf
-             "cwd_not_directory: %s (git -C target must be an existing directory)"
-             target)
-    | _ -> (
+    let resolve_without_explicit_git_c () =
       match repos_in_playground () with
       | [ single_repo ] ->
         Filename.concat (Filename.concat host_root "repos") single_repo, None
@@ -292,7 +300,32 @@ let resolve_sandbox_root_git_cwd_of_stages
                 Do not retry the same cmd from sandbox root."
                host_root
                suggested_cwd
-               (String.concat ", " many)) )))
+               (String.concat ", " many)) )
+    in
+    let explicit_git_c_paths = git_global_c_paths_of_stages stages in
+    match explicit_git_c_paths with
+    | Some [ path ] when bare_worktrees_path path -> resolve_without_explicit_git_c ()
+    | Some paths ->
+      let target =
+        List.fold_left
+          (fun cwd path ->
+             normalize_cwd_relative_path
+               ~container_root:(Keeper_sandbox.container_root meta.name)
+               ~host_root
+               ~cwd
+               path)
+          cwd_normalized
+          paths
+      in
+      if path_is_existing_dir target
+      then cwd, None
+      else
+        cwd,
+        Some
+          (Printf.sprintf
+             "cwd_not_directory: %s (git -C target must be an existing directory)"
+             target)
+    | _ -> resolve_without_explicit_git_c ())
   else cwd, None
 
 let effective_stages_of_cmd cmd =

--- a/lib/keeper/agent_tool_execute_command_semantics.ml
+++ b/lib/keeper/agent_tool_execute_command_semantics.ml
@@ -161,6 +161,16 @@ let git_c_path_of_stages stages =
   List.find_map (fun stage ->
     if stage.bin = "git" then scan_git_args stage.args else None) stages
 
+let normalize_cwd_relative_path ~cwd path =
+  let path = strip_simple_shell_quotes path |> String.trim in
+  let path = if Filename.is_relative path then Filename.concat cwd path else path in
+  Keeper_alerting_path.normalize_path_for_check path
+  |> Keeper_alerting_path.strip_trailing_slashes
+
+let path_is_existing_dir path =
+  try Sys.file_exists path && Sys.is_directory path with
+  | Sys_error _ -> false
+
 let normalize_repos_path_token token =
   let token = strip_simple_shell_quotes token |> String.trim in
   let token =
@@ -219,7 +229,16 @@ let resolve_sandbox_root_git_cwd_of_stages
   then (
     let explicit_git_c_path = git_c_path_of_stages stages in
     match explicit_git_c_path with
-    | Some path when not (bare_worktrees_path path) -> cwd, None
+    | Some path when not (bare_worktrees_path path) ->
+      let target = normalize_cwd_relative_path ~cwd:cwd_normalized path in
+      if path_is_existing_dir target
+      then cwd, None
+      else
+        target,
+        Some
+          (Printf.sprintf
+             "cwd_not_directory: %s (git -C target must be an existing directory)"
+             target)
     | _ -> (
       match repos_in_playground () with
       | [ single_repo ] ->

--- a/lib/keeper/agent_tool_execute_command_semantics.ml
+++ b/lib/keeper/agent_tool_execute_command_semantics.ml
@@ -161,11 +161,30 @@ let git_c_path_of_stages stages =
   List.find_map (fun stage ->
     if stage.bin = "git" then scan_git_args stage.args else None) stages
 
-let normalize_cwd_relative_path ~cwd path =
+let normalize_cwd_relative_path ?container_root ?host_root ~cwd path =
   let path = strip_simple_shell_quotes path |> String.trim in
   let path = if Filename.is_relative path then Filename.concat cwd path else path in
-  Keeper_alerting_path.normalize_path_for_check path
-  |> Keeper_alerting_path.strip_trailing_slashes
+  let path =
+    Keeper_alerting_path.normalize_path_for_check path
+    |> Keeper_alerting_path.strip_trailing_slashes
+  in
+  match container_root, host_root with
+  | Some container_root, Some host_root ->
+    let container_root =
+      Keeper_alerting_path.normalize_path_for_check container_root
+      |> Keeper_alerting_path.strip_trailing_slashes
+    in
+    if path = container_root
+    then host_root
+    else (
+      let prefix = container_root ^ "/" in
+      if String.starts_with ~prefix path
+      then
+        Filename.concat
+          host_root
+          (String.sub path (String.length prefix) (String.length path - String.length prefix))
+      else path)
+  | _ -> path
 
 let path_is_existing_dir path =
   try Sys.file_exists path && Sys.is_directory path with
@@ -230,7 +249,13 @@ let resolve_sandbox_root_git_cwd_of_stages
     let explicit_git_c_path = git_c_path_of_stages stages in
     match explicit_git_c_path with
     | Some path when not (bare_worktrees_path path) ->
-      let target = normalize_cwd_relative_path ~cwd:cwd_normalized path in
+      let target =
+        normalize_cwd_relative_path
+          ~container_root:(Keeper_sandbox.container_root meta.name)
+          ~host_root
+          ~cwd:cwd_normalized
+          path
+      in
       if path_is_existing_dir target
       then cwd, None
       else

--- a/lib/keeper/agent_tool_execute_path.ml
+++ b/lib/keeper/agent_tool_execute_path.ml
@@ -128,10 +128,17 @@ let validate_repo_path_args_ready
       ~(cwd : string)
       (ir : Masc_exec.Shell_ir.t)
   =
+  let normalize_repo_command_name command_name =
+    let command_name = String.lowercase_ascii command_name in
+    if String.ends_with ~suffix:".exe" command_name
+    then String.sub command_name 0 (String.length command_name - String.length ".exe")
+    else command_name
+  in
   let path_args_of_simple simple =
     let command_name =
       Masc_exec.Exec_program.to_string simple.Masc_exec.Shell_ir.bin
       |> Filename.basename
+      |> normalize_repo_command_name
     in
     if not (command_name = "git" || command_name = "gh")
     then []

--- a/lib/keeper/agent_tool_execute_path.ml
+++ b/lib/keeper/agent_tool_execute_path.ml
@@ -133,9 +133,12 @@ let validate_repo_path_args_ready
       Masc_exec.Exec_program.to_string simple.Masc_exec.Shell_ir.bin
       |> Filename.basename
     in
-    match Exec_policy.simple_literal_args simple with
-    | None -> []
-    | Some args -> Exec_policy.path_argument_values command_name args
+    if not (command_name = "git" || command_name = "gh")
+    then []
+    else
+      match Exec_policy.simple_literal_args simple with
+      | None -> []
+      | Some args -> Exec_policy.path_argument_values command_name args
   in
   let rec path_args = function
     | Masc_exec.Shell_ir.Simple simple ->

--- a/lib/keeper/agent_tool_execute_runtime.ml
+++ b/lib/keeper/agent_tool_execute_runtime.ml
@@ -60,25 +60,19 @@ let input_with_cwd cwd = function
   | Agent_tool_execute_typed_input.Pipeline { stages; cwd = _; env } ->
     Agent_tool_execute_typed_input.Pipeline { stages; cwd = Some cwd; env }
 
-let resolve_typed_git_cwd ~config ~meta ~cwd ~cmd ~mode input =
+let typed_input_effective_stages ~mode input =
   match Agent_tool_execute_typed_input.to_shell_ir_unvalidated ~mode input with
-  | Error _ -> cwd, None
+  | Error _ -> []
   | Ok ir ->
-    let stages = Agent_tool_execute_command_semantics.effective_stages_of_ir ir in
+    Agent_tool_execute_command_semantics.effective_stages_of_ir ir
+
+let resolve_typed_git_cwd_of_stages ~config ~meta ~cwd ~cmd stages =
     Agent_tool_execute_command_semantics.resolve_sandbox_root_git_cwd_of_stages
       ~config
       ~meta
       ~cwd
       ~cmd
       stages
-
-let is_git_command cmd =
-  let trimmed = String.trim cmd in
-  String.starts_with ~prefix:"git " trimmed
-  || String.starts_with ~prefix:"gh " trimmed
-  || String.equal trimmed "git"
-  || String.equal trimmed "gh"
-;;
 
 let handle_tool_execute_typed
       ~(turn_sandbox_factory : Keeper_sandbox_factory.t option)
@@ -107,8 +101,14 @@ let handle_tool_execute_typed
           then Agent_tool_execute_typed_input.Dev_full
           else Agent_tool_execute_typed_input.Readonly
         in
+        let effective_stages = typed_input_effective_stages ~mode input in
         let cwd, root_git_cwd_error =
-          resolve_typed_git_cwd ~config ~meta ~cwd ~cmd ~mode input
+          resolve_typed_git_cwd_of_stages
+            ~config
+            ~meta
+            ~cwd
+            ~cmd
+            effective_stages
         in
         let input = input_with_cwd cwd input in
         let in_playground = Agent_tool_execute_path.in_playground ~root ~cwd ~meta in
@@ -129,7 +129,9 @@ let handle_tool_execute_typed
               | Some fallback when in_playground -> Ok fallback
               | Some _ | None ->
                 let effective_factory =
-                  if is_git_command cmd
+                  if
+                    Agent_tool_execute_command_semantics.stages_target_repo_commands
+                      effective_stages
                   then (match turn_sandbox_factory_git with
                     | Some _ as f -> f
                     | None -> turn_sandbox_factory)

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -145,6 +145,7 @@ let audit_approval_event
       ?task_id
       ?goal_id
       ?(goal_ids = [])
+      ?sandbox_target
       ?runtime_contract
       ?selected_model
       ?disposition
@@ -175,6 +176,7 @@ let audit_approval_event
          ; "goal_id", Json_util.string_opt_to_json goal_id
          ; "goal_ids", `List (List.map (fun goal -> `String goal) goal_ids)
          ; "selected_model", `Null
+         ; "sandbox_target", Json_util.string_opt_to_json sandbox_target
          ; "disposition", Json_util.string_opt_to_json disposition
          ; "disposition_reason", Json_util.string_opt_to_json disposition_reason
          ]
@@ -326,6 +328,9 @@ let create_entry
       ?task_id
       ?goal_id
       ?(goal_ids = [])
+      ?sandbox_target
+      ?sandbox_profile
+      ?backend
       ?runtime_contract
       ?selected_model
       ?disposition
@@ -337,13 +342,23 @@ let create_entry
   =
   let action_key = action_key_of_input ~tool_name ~input in
   let input_hash = normalized_input_hash input in
-  let sandbox_target = sandbox_target_of_runtime_contract runtime_contract in
+  let sandbox_target =
+    match nonempty_string_opt sandbox_target with
+    | Some target -> target
+    | None -> sandbox_target_of_runtime_contract runtime_contract
+  in
+  let sandbox_profile =
+    sandbox_profile_of_runtime_context ?sandbox_profile runtime_contract
+  in
+  let backend = backend_of_runtime_context ?backend runtime_contract in
   { id
   ; keeper_name
   ; tool_name
   ; action_key
   ; input_hash
   ; sandbox_target
+  ; sandbox_profile
+  ; backend
   ; input
   ; risk_level
   ; requested_at = Unix.gettimeofday ()
@@ -450,6 +465,7 @@ let record_pending (entry : pending_approval) =
     ?task_id:entry.task_id
     ?goal_id:entry.goal_id
     ~goal_ids:entry.goal_ids
+    ~sandbox_target:entry.sandbox_target
     ?runtime_contract:entry.runtime_contract
     ?selected_model:entry.selected_model
     ?disposition:entry.disposition
@@ -477,6 +493,7 @@ let resolve_entry ?base_path (entry : pending_approval) (decision : decision) =
     ?task_id:entry.task_id
     ?goal_id:entry.goal_id
     ~goal_ids:entry.goal_ids
+    ~sandbox_target:entry.sandbox_target
     ?runtime_contract:entry.runtime_contract
     ?selected_model:entry.selected_model
     ?disposition:entry.disposition
@@ -612,6 +629,9 @@ let submit_and_await
       ?task_id
       ?goal_id
       ?(goal_ids = [])
+      ?sandbox_target
+      ?sandbox_profile
+      ?backend
       ?runtime_contract
       ?selected_model
       ?disposition
@@ -634,6 +654,9 @@ let submit_and_await
       ?task_id
       ?goal_id
       ~goal_ids
+      ?sandbox_target
+      ?sandbox_profile
+      ?backend
       ?runtime_contract
       ?selected_model
       ?disposition
@@ -681,6 +704,7 @@ let submit_and_await
            ?task_id
            ?goal_id
            ~goal_ids
+           ~sandbox_target:entry.sandbox_target
            ?runtime_contract
            ?selected_model
            ~decision:(Approval_expired reason)
@@ -707,6 +731,7 @@ let submit_and_await
            ?task_id
            ?goal_id
            ~goal_ids
+           ~sandbox_target:entry.sandbox_target
            ?runtime_contract
            ?selected_model
            ?disposition
@@ -726,6 +751,9 @@ let submit_pending
       ?task_id
       ?goal_id
       ?(goal_ids = [])
+      ?sandbox_target
+      ?sandbox_profile
+      ?backend
       ?runtime_contract
       ?selected_model
       ?disposition
@@ -736,7 +764,11 @@ let submit_pending
   =
   let action_key = action_key_of_input ~tool_name ~input in
   let input_hash = normalized_input_hash input in
-  let sandbox_target = sandbox_target_of_runtime_contract runtime_contract in
+  let sandbox_target =
+    match nonempty_string_opt sandbox_target with
+    | Some target -> target
+    | None -> sandbox_target_of_runtime_contract runtime_contract
+  in
   let rec submit () =
     let map = Atomic.get pending in
     match
@@ -764,6 +796,9 @@ let submit_pending
           ?task_id
           ?goal_id
           ~goal_ids
+          ~sandbox_target
+          ?sandbox_profile
+          ?backend
           ?runtime_contract
           ?selected_model
           ?disposition
@@ -811,6 +846,8 @@ let remember_rule_for_entry ?base_path ?created_by (entry : pending_approval) =
           ~tool_name:entry.tool_name
           ~input:entry.input
           ~risk_level:entry.risk_level
+          ?sandbox_profile:entry.sandbox_profile
+          ?backend:entry.backend
           ?runtime_contract:entry.runtime_contract
           ?created_by
           ~source_approval_id:entry.id
@@ -1004,6 +1041,7 @@ let expire_stale ~max_wait_s =
          ?task_id:entry.task_id
          ?goal_id:entry.goal_id
          ~goal_ids:entry.goal_ids
+         ~sandbox_target:entry.sandbox_target
          ?runtime_contract:entry.runtime_contract
          ?selected_model:entry.selected_model
          ?disposition:entry.disposition

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -30,6 +30,8 @@ type pending_approval =
   ; action_key : string
   ; input_hash : string
   ; sandbox_target : string
+  ; sandbox_profile : string option
+  ; backend : string option
   ; input : Yojson.Safe.t
   ; risk_level : risk_level
   ; requested_at : float
@@ -113,6 +115,8 @@ val upsert_rule :
   tool_name:string ->
   input:Yojson.Safe.t ->
   risk_level:risk_level ->
+  ?sandbox_profile:string ->
+  ?backend:string ->
   ?runtime_contract:Yojson.Safe.t ->
   ?created_by:string ->
   ?source_approval_id:string ->
@@ -131,6 +135,8 @@ val find_matching_rule :
   tool_name:string ->
   input:Yojson.Safe.t ->
   risk_level:risk_level ->
+  ?sandbox_profile:string ->
+  ?backend:string ->
   ?runtime_contract:Yojson.Safe.t ->
   unit ->
   rule_match option
@@ -148,6 +154,7 @@ val audit_approval_event :
   ?task_id:string ->
   ?goal_id:string ->
   ?goal_ids:string list ->
+  ?sandbox_target:string ->
   ?runtime_contract:Yojson.Safe.t ->
   ?selected_model:string ->
   ?disposition:string ->
@@ -197,6 +204,9 @@ val submit_and_await :
   ?task_id:string ->
   ?goal_id:string ->
   ?goal_ids:string list ->
+  ?sandbox_target:string ->
+  ?sandbox_profile:string ->
+  ?backend:string ->
   ?runtime_contract:Yojson.Safe.t ->
   ?selected_model:string ->
   ?disposition:string ->
@@ -220,6 +230,9 @@ val submit_pending :
   ?task_id:string ->
   ?goal_id:string ->
   ?goal_ids:string list ->
+  ?sandbox_target:string ->
+  ?sandbox_profile:string ->
+  ?backend:string ->
   ?runtime_contract:Yojson.Safe.t ->
   ?selected_model:string ->
   ?disposition:string ->

--- a/lib/keeper/keeper_approval_queue_rules.ml
+++ b/lib/keeper/keeper_approval_queue_rules.ml
@@ -141,6 +141,23 @@ let backend_of_runtime_contract runtime_contract =
   Option.bind runtime_contract (string_opt_member "backend")
 ;;
 
+let nonempty_string_opt = function
+  | Some value when String.trim value <> "" -> Some (String.trim value)
+  | _ -> None
+;;
+
+let sandbox_profile_of_runtime_context ?sandbox_profile runtime_contract =
+  match nonempty_string_opt sandbox_profile with
+  | Some _ as value -> value
+  | None -> sandbox_profile_of_runtime_contract runtime_contract
+;;
+
+let backend_of_runtime_context ?backend runtime_contract =
+  match nonempty_string_opt backend with
+  | Some _ as value -> value
+  | None -> backend_of_runtime_contract runtime_contract
+;;
+
 let load_rules_unlocked ?base_path () =
   match Safe_ops.read_json_file_safe (rules_path ?base_path ()) with
   | Ok (`List entries) -> entries |> List.filter_map approval_rule_of_yojson
@@ -196,6 +213,8 @@ let upsert_rule
       ~tool_name
       ~input
       ~risk_level
+      ?sandbox_profile
+      ?backend
       ?runtime_contract
       ?created_by
       ?source_approval_id
@@ -208,8 +227,8 @@ let upsert_rule
       { id = make_generated_id "rule"
       ; keeper_name
       ; tool_name
-      ; sandbox_profile = sandbox_profile_of_runtime_contract runtime_contract
-      ; backend = backend_of_runtime_contract runtime_contract
+      ; sandbox_profile = sandbox_profile_of_runtime_context ?sandbox_profile runtime_contract
+      ; backend = backend_of_runtime_context ?backend runtime_contract
       ; request_fingerprint
       ; request_fingerprint_preview = request_fingerprint_preview request_fingerprint
       ; max_risk = risk_level
@@ -252,14 +271,16 @@ let find_matching_rule
       ~tool_name
       ~input
       ~risk_level
+      ?sandbox_profile
+      ?backend
       ?runtime_contract
       ()
   =
   with_rules_lock (fun () ->
     let rules = load_rules_unlocked ?base_path () in
     let request_fingerprint = request_fingerprint input in
-    let sandbox_profile = sandbox_profile_of_runtime_contract runtime_contract in
-    let backend = backend_of_runtime_contract runtime_contract in
+    let sandbox_profile = sandbox_profile_of_runtime_context ?sandbox_profile runtime_contract in
+    let backend = backend_of_runtime_context ?backend runtime_contract in
     match
       List.find_opt
         (fun rule ->

--- a/lib/keeper/keeper_approval_queue_rules_types.ml
+++ b/lib/keeper/keeper_approval_queue_rules_types.ml
@@ -18,6 +18,8 @@ type pending_approval =
   ; action_key : string
   ; input_hash : string
   ; sandbox_target : string
+  ; sandbox_profile : string option
+  ; backend : string option
   ; input : Yojson.Safe.t
   ; risk_level : risk_level
   ; requested_at : float

--- a/lib/keeper/keeper_approval_queue_rules_types.mli
+++ b/lib/keeper/keeper_approval_queue_rules_types.mli
@@ -13,6 +13,8 @@ type pending_approval =
   ; action_key : string
   ; input_hash : string
   ; sandbox_target : string
+  ; sandbox_profile : string option
+  ; backend : string option
   ; input : Yojson.Safe.t
   ; risk_level : risk_level
   ; requested_at : float

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -457,7 +457,7 @@ let to_json (receipt : t) =
         ]
   in
   let runtime_contract =
-    Keeper_runtime_contract.runtime_contract_json_from_fields
+    Keeper_runtime_contract.runtime_observability_contract_json_from_fields
       ~keeper_name:receipt.keeper_name
       ~agent_name:receipt.agent_name
       ~trace_id:receipt.trace_id

--- a/lib/keeper/keeper_runtime_contract.ml
+++ b/lib/keeper/keeper_runtime_contract.ml
@@ -214,7 +214,20 @@ let nonempty_list = function
   | Some values -> values
   | None -> []
 
-let runtime_contract_json_from_fields ~keeper_name ?agent_name ?trace_id
+let backend_detail_keys =
+  [ "sandbox_profile"; "network_mode"; "backend"; "sandbox_target" ]
+
+let is_backend_detail_key key = List.mem key backend_detail_keys
+
+let redact_backend_details = function
+  | `Assoc fields ->
+      `Assoc
+        (List.filter
+           (fun (key, _) -> not (is_backend_detail_key key))
+           fields)
+  | json -> json
+
+let runtime_observability_contract_json_from_fields ~keeper_name ?agent_name ?trace_id
     ?session_id ?generation ?keeper_turn_id ?task_id ?goal_ids
     ?sandbox_profile ?sandbox_root ?allowed_paths ?network_mode ?approval_mode ?tool_surface_class
     ?visible_tool_count ?required_tools ?required_tool_candidates ?missing_required_tools
@@ -243,6 +256,34 @@ let runtime_contract_json_from_fields ~keeper_name ?agent_name ?trace_id
         Json_util.json_string_list (nonempty_list missing_required_tools) );
       ("runtime_profile", string_opt_json runtime_profile);
     ]
+
+let runtime_contract_json_from_fields ~keeper_name ?agent_name ?trace_id
+    ?session_id ?generation ?keeper_turn_id ?task_id ?goal_ids
+    ?sandbox_profile ?sandbox_root ?allowed_paths ?network_mode ?approval_mode ?tool_surface_class
+    ?visible_tool_count ?required_tools ?required_tool_candidates ?missing_required_tools
+    ?runtime_profile () : Yojson.Safe.t =
+  runtime_observability_contract_json_from_fields
+    ~keeper_name
+    ?agent_name
+    ?trace_id
+    ?session_id
+    ?generation
+    ?keeper_turn_id
+    ?task_id
+    ?goal_ids
+    ?sandbox_profile
+    ?sandbox_root
+    ?allowed_paths
+    ?network_mode
+    ?approval_mode
+    ?tool_surface_class
+    ?visible_tool_count
+    ?required_tools
+    ?required_tool_candidates
+    ?missing_required_tools
+    ?runtime_profile
+    ()
+  |> redact_backend_details
 
 
 let json_string_field name = function
@@ -316,17 +357,12 @@ let action_radius_json ~tool_name ~input ~success ~duration_ms ?error
     ]
 
 let runtime_contract_json ?config (meta : keeper_meta) : Yojson.Safe.t =
-  let sandbox_target = backend_of_meta meta in
   let goal_progress = goal_progress_json ?config meta in
   let blocked_task_count =
     Safe_ops.json_int "blocked_task_count" ~default:0 goal_progress
   in
   `Assoc
     [
-      ("sandbox_profile", `String (sandbox_profile_to_string meta.sandbox_profile));
-      ("network_mode", `String (network_mode_to_string meta.network_mode));
-      ("backend", `String sandbox_target);
-      ("sandbox_target", `String sandbox_target);
       ("task_id", Json_util.string_opt_to_json (current_task_id_opt meta));
       ("goal_id", Json_util.string_opt_to_json (primary_goal_id_opt meta));
       ("goal_ids", `List (List.map (fun goal_id -> `String goal_id) meta.active_goal_ids));
@@ -334,3 +370,17 @@ let runtime_contract_json ?config (meta : keeper_meta) : Yojson.Safe.t =
       ("blocked_task_count", `Int blocked_task_count);
       ("approval_policy_effective", approval_policy_effective_json ?config meta);
     ]
+
+let runtime_observability_contract_json ?config (meta : keeper_meta) : Yojson.Safe.t =
+  let sandbox_target = backend_of_meta meta in
+  match runtime_contract_json ?config meta with
+  | `Assoc fields ->
+    `Assoc
+      ([
+         ("sandbox_profile", `String (sandbox_profile_to_string meta.sandbox_profile));
+         ("network_mode", `String (network_mode_to_string meta.network_mode));
+         ("backend", `String sandbox_target);
+         ("sandbox_target", `String sandbox_target);
+       ]
+       @ fields)
+  | json -> json

--- a/lib/keeper/keeper_runtime_contract.mli
+++ b/lib/keeper/keeper_runtime_contract.mli
@@ -35,6 +35,14 @@ val resolve_observation_claim_goal_scope :
 
 val runtime_contract_json :
   ?config:Workspace.config -> Keeper_meta_contract.keeper_meta -> Yojson.Safe.t
+(** Keeper-visible runtime contract. Backend implementation details such as
+    [sandbox_profile], [network_mode], [backend], and [sandbox_target] are
+    intentionally omitted; use [runtime_observability_contract_json] for
+    operator-facing status, receipts, and debugging. *)
+
+val runtime_observability_contract_json :
+  ?config:Workspace.config -> Keeper_meta_contract.keeper_meta -> Yojson.Safe.t
+(** Operator-facing runtime contract with sandbox backend details included. *)
 
 val runtime_contract_json_from_fields :
   keeper_name:string ->
@@ -58,7 +66,34 @@ val runtime_contract_json_from_fields :
   ?runtime_profile:string ->
   unit ->
   Yojson.Safe.t
-(** Build the runtime contract projection from turn-context fields. *)
+(** Build the keeper-visible runtime contract projection from turn-context
+    fields. Backend implementation details are intentionally omitted. *)
+
+val runtime_observability_contract_json_from_fields :
+  keeper_name:string ->
+  ?agent_name:string ->
+  ?trace_id:string ->
+  ?session_id:string ->
+  ?generation:int ->
+  ?keeper_turn_id:int ->
+  ?task_id:string ->
+  ?goal_ids:string list ->
+  ?sandbox_profile:string ->
+  ?sandbox_root:string ->
+  ?allowed_paths:string list ->
+  ?network_mode:string ->
+  ?approval_mode:string ->
+  ?tool_surface_class:string ->
+  ?visible_tool_count:int ->
+  ?required_tools:string list ->
+  ?required_tool_candidates:string list ->
+  ?missing_required_tools:string list ->
+  ?runtime_profile:string ->
+  unit ->
+  Yojson.Safe.t
+(** Build an operator-facing runtime contract projection from turn-context
+    fields, including sandbox backend details for status, receipts, and
+    debugging. *)
 
 val action_radius_json :
   tool_name:string ->

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -835,7 +835,7 @@ let snapshot_json ~(config : Workspace.config) ~(meta : keeper_meta) =
     | None -> `Null
   in
   let runtime_contract =
-    Keeper_runtime_contract.runtime_contract_json ~config meta
+    Keeper_runtime_contract.runtime_observability_contract_json ~config meta
   in
   let fallback_disposition, fallback_disposition_reason =
     disposition_of_snapshot ~pending_approval_count ~runtime_blocker_fields

--- a/lib/keeper/keeper_sandbox_factory.ml
+++ b/lib/keeper/keeper_sandbox_factory.ml
@@ -3,18 +3,20 @@ type t = {
   meta : Keeper_meta_contract.keeper_meta;
   turn_id : int;
   default_network_override : Keeper_types_profile_sandbox.network_mode option;
+  credential_mounts_enabled : bool;
   cache :
     ((bool * string), Keeper_turn_sandbox_runtime.t) Hashtbl.t;
   mutex : Eio.Mutex.t;
 }
 
-let create ?default_network_override
+let create ?default_network_override ?(credential_mounts_enabled = false)
     ~(config : Workspace.config) ~(meta : Keeper_meta_contract.keeper_meta) ?(turn_id = 0) () =
   {
     config;
     meta;
     turn_id;
     default_network_override;
+    credential_mounts_enabled;
     cache = Hashtbl.create 4;
     mutex = Eio.Mutex.create ();
   }
@@ -60,6 +62,7 @@ let resolve (t : t) ~cwd =
             ~config:t.config
             ~meta:t.meta
             ~network_mode:actual_network
+            ~credential_mounts_enabled:t.credential_mounts_enabled
             ~turn_id:t.turn_id
             ()
         in

--- a/lib/keeper/keeper_sandbox_factory.ml
+++ b/lib/keeper/keeper_sandbox_factory.ml
@@ -9,7 +9,11 @@ type t = {
   mutex : Eio.Mutex.t;
 }
 
-let create ?default_network_override ?(credential_mounts_enabled = false)
+(* Callers select the credentialed factory after Shell IR effective-stage
+   analysis; keep this cache policy-neutral so wrapped git/gh routing stays
+   centralized in Agent_tool_execute_runtime. *)
+let create ?default_network_override
+    ?(credential_mounts_enabled = false)
     ~(config : Workspace.config) ~(meta : Keeper_meta_contract.keeper_meta) ?(turn_id = 0) () =
   {
     config;

--- a/lib/keeper/keeper_sandbox_factory.mli
+++ b/lib/keeper/keeper_sandbox_factory.mli
@@ -25,6 +25,7 @@ type t
 
 val create :
   ?default_network_override:Keeper_types_profile_sandbox.network_mode ->
+  ?credential_mounts_enabled:bool ->
   config:Workspace.config ->
   meta:Keeper_meta_contract.keeper_meta ->
   ?turn_id:int ->
@@ -32,7 +33,9 @@ val create :
   t
 (** Create an empty factory.  [default_network_override], when supplied,
     is applied to every runtime created via {!resolve} (used by the git
-    variant which always inherits the host network). *)
+    variant which always inherits the host network).
+    [credential_mounts_enabled] is deliberately opt-in: generic Docker
+    execution should not mount git/gh credential bundles. *)
 
 val resolve :
   t ->

--- a/lib/keeper/keeper_tools_oas_bundle.ml
+++ b/lib/keeper/keeper_tools_oas_bundle.ml
@@ -50,6 +50,7 @@ let make_tool_bundle
     Some
       (Keeper_sandbox_factory.create
          ~default_network_override:Network_inherit
+         ~credential_mounts_enabled:true
          ~config
          ~meta
          ())

--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -16,6 +16,7 @@ type t =
   ; uid : int
   ; gid : int
   ; network_mode : network_mode
+  ; credential_mounts_enabled : bool
   ; mutable state : state
   }
 
@@ -27,6 +28,7 @@ let create
       ~(config : Workspace.config)
       ~(meta : keeper_meta)
       ?(network_mode = Network_none)
+      ?(credential_mounts_enabled = false)
       ~turn_id
       ()
   =
@@ -45,6 +47,7 @@ let create
   ; uid = Unix.getuid ()
   ; gid = Unix.getgid ()
   ; network_mode
+  ; credential_mounts_enabled
   ; state = Not_started
   }
 ;;
@@ -292,29 +295,30 @@ let start_container (t : t) ~(timeout_sec : float) =
        with
        | Error _ as err -> err
        | Ok identity_mounts ->
-         (* Resolve credential mounts (GH_CONFIG_DIR, GIT_CONFIG_GLOBAL, etc.)
-            so that git/gh operations work inside the turn-scoped container. *)
          let cred_mounts, cred_envs =
-           match
-             Keeper_host_config_provider.resolve
-               ~config:t.config ~identity:t.meta.name
-           with
-           | Ok binding ->
-             let mounts =
-               List.concat_map
-                 (fun (m : Keeper_credential_provider.ro_mount) ->
-                    [ "-v"; m.host ^ ":" ^ m.container ^ ":ro" ])
-                 binding.ro_mounts
-             in
-             let envs =
-               List.concat_map (fun (k, v) -> [ "-e"; k ^ "=" ^ v ]) binding.env
-             in
-             mounts, envs
-           | Error err ->
-             Log.Keeper.warn
-               "%s: credential resolution failed — container will start without git/gh credentials: %s"
-               t.meta.name (Keeper_credential_provider.pp_error err);
-             [], []
+           if not t.credential_mounts_enabled
+           then [], []
+           else (
+             match
+               Keeper_host_config_provider.resolve
+                 ~config:t.config ~identity:t.meta.name
+             with
+             | Ok binding ->
+               let mounts =
+                 List.concat_map
+                   (fun (m : Keeper_credential_provider.ro_mount) ->
+                      [ "-v"; m.host ^ ":" ^ m.container ^ ":ro" ])
+                   binding.ro_mounts
+               in
+               let envs =
+                 List.concat_map (fun (k, v) -> [ "-e"; k ^ "=" ^ v ]) binding.env
+               in
+               mounts, envs
+             | Error err ->
+               Log.Keeper.warn
+                 "%s: credential resolution failed — container will start without git/gh credentials: %s"
+                 t.meta.name (Keeper_credential_provider.pp_error err);
+               [], [])
          in
          let argv =
            Keeper_sandbox_runtime.docker_command_argv ()

--- a/lib/keeper/keeper_turn_sandbox_runtime.mli
+++ b/lib/keeper/keeper_turn_sandbox_runtime.mli
@@ -10,6 +10,7 @@ val create :
   config:Workspace.config ->
   meta:Keeper_meta_contract.keeper_meta ->
   ?network_mode:Keeper_types_profile_sandbox.network_mode ->
+  ?credential_mounts_enabled:bool ->
   turn_id:int ->
   unit ->
   t

--- a/lib/keeper/keeper_unified_metrics_decision.ml
+++ b/lib/keeper/keeper_unified_metrics_decision.ml
@@ -89,7 +89,7 @@ let append_decision_record
     | [] -> None
   in
   let runtime_contract =
-    Keeper_runtime_contract.runtime_contract_json ~config meta
+    Keeper_runtime_contract.runtime_observability_contract_json ~config meta
   in
   let pending_approval_count =
     Keeper_approval_queue.pending_count_for_keeper ~keeper_name:meta.name

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -687,7 +687,7 @@ let log_call
         semantic_outcome_of_output ~success safe_output
       in
       let runtime_contract =
-        Keeper_runtime_contract.runtime_contract_json_from_fields
+        Keeper_runtime_contract.runtime_observability_contract_json_from_fields
           ~keeper_name
           ?agent_name
           ?trace_id

--- a/lib/keeper_tool_call_log_context.ml
+++ b/lib/keeper_tool_call_log_context.ml
@@ -141,7 +141,7 @@ let get_turn_context ~keeper_name () =
 
 let runtime_contract_json_for_call ~keeper_name () =
   let ctx = get_turn_context_record ~keeper_name () in
-  Keeper_runtime_contract.runtime_contract_json_from_fields
+  Keeper_runtime_contract.runtime_observability_contract_json_from_fields
     ~keeper_name
     ?agent_name:ctx.agent_name
     ?trace_id:ctx.trace_id

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -351,7 +351,7 @@ let record_runtime_mcp_keeper_trajectory
       ~turn
   in
   let runtime_contract =
-    Keeper_runtime_contract.runtime_contract_json_from_fields
+    Keeper_runtime_contract.runtime_observability_contract_json_from_fields
       ~keeper_name:ctx.keeper_name
       ?agent_name:ctx.agent_name
       ?trace_id:ctx.trace_id

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -475,6 +475,7 @@ let execute_tool_eio
                      Some
                        (Keeper_sandbox_factory.create
                           ~default_network_override:Keeper_types_profile_sandbox.Network_inherit
+                          ~credential_mounts_enabled:true
                           ~config
                           ~meta
                           ())

--- a/scripts/keeper-sandbox-smoke.sh
+++ b/scripts/keeper-sandbox-smoke.sh
@@ -44,7 +44,7 @@ docker run --rm -i \
       exit 1
     fi
     printf "OK: sandbox dune %s >= required %s\n" "$actual_dune" "$MASC_REQ_DUNE_VER"
-    test "$(cat demo.txt)" = $'"'"'alpha\nbeta\ngamma'"'"'
+    test "$(cat demo.txt)" = $'alpha\nbeta\ngamma'
     rg beta demo.txt >/dev/null
     printf "delta\n" >> append.txt
     test "$(cat append.txt)" = "delta"

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -49,6 +49,10 @@ let contains_substring s needle =
   in
   n_len = 0 || loop 0
 
+let has_assoc_key key = function
+  | `Assoc fields -> List.mem_assoc key fields
+  | _ -> false
+
 let rec yield_until ?(attempts = 50) predicate =
   if predicate () || attempts <= 0 then ()
   else (
@@ -749,6 +753,57 @@ let test_approval_queue_get_pending_detail () =
   Alcotest.(check int) "entry removed"
     initial_count (AQ.pending_count ())
 
+let test_approval_queue_keeps_sandbox_backend_out_of_runtime_contract () =
+  let runtime_contract =
+    Masc_mcp.Keeper_runtime_contract.runtime_contract_json_from_fields
+      ~keeper_name:"redacted-contract-keeper"
+      ~sandbox_profile:"docker"
+      ~network_mode:"none"
+      ()
+  in
+  Alcotest.(check bool)
+    "keeper-visible runtime_contract has no backend"
+    false
+    (has_assoc_key "backend" runtime_contract);
+  Alcotest.(check bool)
+    "keeper-visible runtime_contract has no sandbox_profile"
+    false
+    (has_assoc_key "sandbox_profile" runtime_contract);
+  let id =
+    AQ.submit_pending
+      ~keeper_name:"redacted-contract-keeper"
+      ~tool_name:"tool_execute"
+      ~input:(`Assoc [ ("cmd", `String "git status") ])
+      ~risk_level:AQ.Medium
+      ~sandbox_target:"docker"
+      ~sandbox_profile:"docker"
+      ~backend:"docker"
+      ~runtime_contract
+      ~on_resolution:(fun _ -> ())
+      ()
+  in
+  let open Yojson.Safe.Util in
+  Fun.protect
+    ~finally:(fun () ->
+      ignore (AQ.resolve ~id ~decision:(Agent_sdk.Hooks.Reject "cleanup")))
+    (fun () ->
+      let detail =
+        match AQ.get_pending_json ~id with
+        | Some json -> json
+        | None -> Alcotest.fail "expected pending approval detail"
+      in
+      Alcotest.(check string) "operator sandbox target" "docker"
+        (detail |> member "sandbox_target" |> to_string);
+      let detail_contract = detail |> member "runtime_contract" in
+      Alcotest.(check bool)
+        "detail runtime_contract keeps backend redacted"
+        false
+        (has_assoc_key "backend" detail_contract);
+      Alcotest.(check bool)
+        "detail runtime_contract keeps sandbox_profile redacted"
+        false
+        (has_assoc_key "sandbox_profile" detail_contract))
+
 let test_approval_get_dispatch_success () =
   let initial_count = AQ.pending_count () in
   let callback_result = ref None in
@@ -1443,6 +1498,8 @@ let () =
         test_background_pending_distinct_inputs_do_not_reuse_entry;
       Alcotest.test_case "get pending detail includes full input" `Quick
         test_approval_queue_get_pending_detail;
+      Alcotest.test_case "runtime_contract redacts sandbox backend" `Quick
+        test_approval_queue_keeps_sandbox_backend_out_of_runtime_contract;
       Alcotest.test_case "dispatch approval_get success" `Quick
         test_approval_get_dispatch_success;
       Alcotest.test_case "dispatch approval_get missing id" `Quick

--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -160,17 +160,7 @@ let docker_image_available image =
   in
   Sys.command cmd = 0
 
-let make_meta ?preset ~name ~sandbox () =
-  let tool_access_fields =
-    match preset with
-    | None -> []
-    | Some preset ->
-        [
-          ( "tool_access",
-            Keeper_meta_tool_access.tool_access_to_json
-              ([]) );
-        ]
-  in
+let make_meta ?(tool_access = []) ~name ~sandbox () =
   let json =
     `Assoc
       ([
@@ -181,8 +171,10 @@ let make_meta ?preset ~name ~sandbox () =
          ("allowed_paths", `List [ `String "*" ]);
          ( "sandbox_profile",
            `String (Keeper_types_profile_sandbox.sandbox_profile_to_string sandbox) );
+         ( "tool_access",
+           Keeper_meta_tool_access.tool_access_to_json tool_access );
        ]
-      @ tool_access_fields)
+      )
   in
   match Masc_test_deps.meta_of_json_fixture json with
   | Ok meta -> meta
@@ -220,7 +212,13 @@ let setup_with_preset ~sandbox f =
   let config = Workspace.default_config base in
   Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
   Keeper_registry.clear ();
-  let meta = make_meta ~name:"minjae" ~sandbox () in
+  let meta =
+    make_meta
+      ~name:"minjae"
+      ~sandbox
+      ~tool_access:[ "tool_edit_file"; "tool_write_file" ]
+      ()
+  in
   let playground = Keeper_sandbox.host_root_abs_of_meta ~config meta in
   ensure_dir playground;
   f ~config ~meta ~playground
@@ -1128,6 +1126,7 @@ let test_execute_git_c_bare_worktrees_from_root_uses_single_repo () =
   let worktree = Filename.concat repo ".worktrees/task-229" in
   ensure_dir worktree;
   git_ok ~cwd:repo [ "init"; "-q" ];
+  git_ok ~cwd:worktree [ "init"; "-q" ];
   let log_path = Filename.concat config.Workspace.base_path "docker.log" in
   with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
   with_env "MASC_KEEPER_SANDBOX_SECCOMP_PROFILE" "" @@ fun () ->
@@ -1177,7 +1176,7 @@ let test_execute_git_push_requires_write_preset_before_docker () =
   Alcotest.(check (option string)) "readonly allowlist before docker"
     (Some
        "executable \"git\" not in readonly allowlist. This preset is read-only. \
-        Use Read/Grep when visible; otherwise ask for a \
+        Use ReadFile/SearchFiles when visible; otherwise ask for a \
         write/execute-capable schema before using git/gh.")
     (parse_string_field raw "error");
   let log = if Sys.file_exists log_path then read_file log_path else "" in

--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -160,32 +160,57 @@ let docker_image_available image =
   in
   Sys.command cmd = 0
 
-let make_meta ?(tool_access = []) ~name ~sandbox () =
+let make_meta ?tool_access ~name ~sandbox () =
+  let fields =
+    [
+      ("name", `String name);
+      ("agent_name", `String ("agent-" ^ name));
+      ("trace_id", `String ("trace-" ^ name));
+      ("goal", `String "shell docker route test");
+      ("allowed_paths", `List [ `String "*" ]);
+      ( "sandbox_profile",
+        `String (Keeper_types_profile_sandbox.sandbox_profile_to_string sandbox) );
+    ]
+  in
+  let fields =
+    match tool_access with
+    | None -> fields
+    | Some tool_access ->
+      fields
+      @ [ ( "tool_access",
+            Keeper_meta_tool_access.tool_access_to_json tool_access ) ]
+  in
   let json =
-    `Assoc
-      ([
-         ("name", `String name);
-         ("agent_name", `String ("agent-" ^ name));
-         ("trace_id", `String ("trace-" ^ name));
-         ("goal", `String "shell docker route test");
-         ("allowed_paths", `List [ `String "*" ]);
-         ( "sandbox_profile",
-           `String (Keeper_types_profile_sandbox.sandbox_profile_to_string sandbox) );
-         ( "tool_access",
-           Keeper_meta_tool_access.tool_access_to_json tool_access );
-       ]
-      )
+    `Assoc fields
   in
   match Masc_test_deps.meta_of_json_fixture json with
   | Ok meta -> meta
   | Error e -> Alcotest.fail e
+
+let test_make_meta_tool_access_matches_production_default () =
+  let meta =
+    make_meta ~name:"minjae" ~sandbox:Keeper_types_profile_sandbox.Docker ()
+  in
+  Alcotest.(check (list string))
+    "missing tool_access uses production default"
+    (Keeper_meta_tool_access.default_tool_access_of_meta_json ())
+    meta.tool_access;
+  let explicit_empty =
+    make_meta ~name:"no-tools" ~sandbox:Keeper_types_profile_sandbox.Docker
+      ~tool_access:[]
+      ()
+  in
+  Alcotest.(check (list string))
+    "explicit empty tool_access remains empty"
+    []
+    explicit_empty.tool_access
 
 let with_eio_fs f =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   f ()
 
-let setup ~sandbox f =
+let setup ?tool_access ~sandbox f =
   with_eio_fs @@ fun () ->
   let base = temp_dir () in
   ensure_dir (Filename.concat base Common.masc_dirname);
@@ -196,7 +221,7 @@ let setup ~sandbox f =
   let config = Workspace.default_config base in
   Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
   Keeper_registry.clear ();
-  let meta = make_meta ~name:"minjae" ~sandbox () in
+  let meta = make_meta ?tool_access ~name:"minjae" ~sandbox () in
   let playground = Keeper_sandbox.host_root_abs_of_meta ~config meta in
   ensure_dir playground;
   f ~config ~meta ~playground
@@ -780,7 +805,7 @@ let check_typed_validation_error needle raw =
     (response_mentions raw "error" needle)
 
 let test_execute_typed_env_wrapper_target_rejected () =
-  setup ~sandbox:Keeper_types_profile_sandbox.Local
+  setup ~tool_access:[] ~sandbox:Keeper_types_profile_sandbox.Local
   @@ fun ~config ~meta ~playground ->
   Agent_tool_command_runtime.handle_tool_execute
     ~turn_sandbox_factory:None
@@ -1168,7 +1193,7 @@ let test_execute_git_c_bare_worktrees_from_root_uses_single_repo () =
 let test_execute_git_push_requires_write_preset_before_docker () =
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
   with_fake_docker fake_docker_echo_script @@ fun () ->
-  setup ~sandbox:Keeper_types_profile_sandbox.Docker
+  setup ~tool_access:[] ~sandbox:Keeper_types_profile_sandbox.Docker
   @@ fun ~config ~meta ~playground ->
   ensure_repo_cli_identity_bundle ~config Masc_mcp.Repo_cli_credentials.root_repo_cli_identity;
   let repo = Filename.concat (Filename.concat playground "repos") "masc-mcp" in
@@ -2221,6 +2246,9 @@ let () =
     [
       ( "docker_route_fires",
         [
+          Alcotest.test_case
+            "fixture meta defaults to production tool access"
+            `Quick test_make_meta_tool_access_matches_production_default;
           Alcotest.test_case
             "docker tool execute ops route through docker"
             `Quick test_readonly_ops_route_through_docker;

--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -1494,6 +1494,23 @@ let test_sandbox_root_git_cwd_single_repo_auto_chdir () =
   Alcotest.(check (option string)) "no error" None error;
   Alcotest.(check string) "auto cwd selects the only repo" repo cwd
 
+let test_sandbox_root_git_c_container_path_preflight_uses_host_path () =
+  setup ~sandbox:Keeper_types_profile_sandbox.Docker
+  @@ fun ~config ~meta ~playground ->
+  let repo = Filename.concat (Filename.concat playground "repos") "masc-mcp" in
+  ensure_dir repo;
+  git_ok ~cwd:repo [ "init"; "-q" ];
+  let container_repo =
+    Filename.concat (Filename.concat (Keeper_sandbox.container_root meta.name) "repos") "masc-mcp"
+  in
+  let cwd, error =
+    resolve_sandbox_root_git_cwd_string ~config ~meta
+      ~cwd:playground
+      ~cmd:(Printf.sprintf "git -C %s status" container_repo)
+  in
+  Alcotest.(check (option string)) "no error" None error;
+  Alcotest.(check string) "explicit -C keeps sandbox-root cwd" playground cwd
+
 let test_sandbox_root_git_cwd_multi_repo_blocks_before_exec () =
   setup ~sandbox:Keeper_types_profile_sandbox.Docker
   @@ fun ~config ~meta ~playground ->
@@ -2200,6 +2217,10 @@ let () =
           Alcotest.test_case
             "sandbox-root git with one repo auto-selects cwd"
             `Quick test_sandbox_root_git_cwd_single_repo_auto_chdir;
+          Alcotest.test_case
+            "sandbox-root git -C container path checks host path"
+            `Quick
+            test_sandbox_root_git_c_container_path_preflight_uses_host_path;
           Alcotest.test_case
             "sandbox-root git with multiple repos gives cwd correction"
             `Quick test_sandbox_root_git_cwd_multi_repo_blocks_before_exec;

--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -1511,6 +1511,24 @@ let test_sandbox_root_git_c_container_path_preflight_uses_host_path () =
   Alcotest.(check (option string)) "no error" None error;
   Alcotest.(check string) "explicit -C keeps sandbox-root cwd" playground cwd
 
+let test_sandbox_root_git_c_missing_target_keeps_execution_cwd () =
+  setup ~sandbox:Keeper_types_profile_sandbox.Docker
+  @@ fun ~config ~meta ~playground ->
+  let missing = "repos/masc-mcp/.worktrees/missing" in
+  let cwd, error =
+    resolve_sandbox_root_git_cwd_string ~config ~meta
+      ~cwd:playground
+      ~cmd:(Printf.sprintf "git -C %s status" missing)
+  in
+  Alcotest.(check string) "execution cwd remains sandbox root" playground cwd;
+  match error with
+  | None -> Alcotest.fail "expected missing git -C target error"
+  | Some msg ->
+    Alcotest.(check bool)
+      "error identifies missing git -C target"
+      true
+      (contains_substring msg "git -C target must be an existing directory")
+
 let test_sandbox_root_git_cwd_multi_repo_blocks_before_exec () =
   setup ~sandbox:Keeper_types_profile_sandbox.Docker
   @@ fun ~config ~meta ~playground ->
@@ -2221,6 +2239,10 @@ let () =
             "sandbox-root git -C container path checks host path"
             `Quick
             test_sandbox_root_git_c_container_path_preflight_uses_host_path;
+          Alcotest.test_case
+            "sandbox-root git -C missing target keeps execution cwd"
+            `Quick
+            test_sandbox_root_git_c_missing_target_keeps_execution_cwd;
           Alcotest.test_case
             "sandbox-root git with multiple repos gives cwd correction"
             `Quick test_sandbox_root_git_cwd_multi_repo_blocks_before_exec;

--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -228,6 +228,21 @@ let with_turn_sandbox_factory ~config ~meta f =
   Fun.protect ~finally:(fun () -> Keeper_sandbox_factory.cleanup factory) @@ fun () ->
   f factory
 
+let with_turn_sandbox_factories ~config ~meta f =
+  let generic_factory = Keeper_sandbox_factory.create ~config ~meta () in
+  let git_factory =
+    Keeper_sandbox_factory.create
+      ~config
+      ~meta
+      ~credential_mounts_enabled:true
+      ()
+  in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_sandbox_factory.cleanup generic_factory;
+      Keeper_sandbox_factory.cleanup git_factory)
+  @@ fun () -> f ~generic_factory ~git_factory
+
 let setup_two_docker_keepers f =
   with_eio_fs @@ fun () ->
   let base = temp_dir () in
@@ -1217,6 +1232,71 @@ let test_execute_git_push_routes_through_git_creds_docker () =
   Alcotest.(check bool) "generic typed push does not mount repo CLI identity bundle" false
     (contains_substring log (repo_cli_config_mount_spec root_repo_cli_dir))
 
+let test_execute_env_wrapped_git_uses_git_creds_factory () =
+  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
+  with_fake_docker fake_docker_echo_script @@ fun () ->
+  setup_with_preset ~sandbox:Keeper_types_profile_sandbox.Docker @@ fun ~config ~meta ~playground ->
+  seed_repo_cli_credential_mapping ~config ~keeper_name:meta.name ();
+  let repo = Filename.concat (Filename.concat playground "repos") "masc-mcp" in
+  ensure_dir repo;
+  git_ok ~cwd:repo [ "init"; "-q" ];
+  let log_path = Filename.concat config.Workspace.base_path "docker.log" in
+  with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
+  with_turn_sandbox_factories ~config ~meta @@ fun ~generic_factory ~git_factory ->
+  let raw =
+    Agent_tool_command_runtime.handle_tool_execute
+      ~turn_sandbox_factory:(Some generic_factory)
+      ~turn_sandbox_factory_git:(Some git_factory)
+      ~exec_cache:None
+      ~config
+      ~meta
+      ~args:
+        (tool_execute_typed_exec_args ~cwd:repo "env"
+           ~argv:[ "git"; "status" ])
+      ()
+  in
+  Alcotest.(check (option bool)) "env git succeeds via fake docker" (Some true)
+    (parse_bool_field raw "ok");
+  let log = read_file log_path in
+  let root_repo_cli_dir =
+    Masc_mcp.Repo_cli_credentials.root_repo_cli_config_dir config
+  in
+  Alcotest.(check bool) "env-wrapped git uses credentialed factory" true
+    (contains_substring log (repo_cli_config_mount_spec root_repo_cli_dir))
+
+let test_execute_pipeline_gh_uses_git_creds_factory () =
+  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
+  with_fake_docker fake_docker_echo_script @@ fun () ->
+  setup_with_preset ~sandbox:Keeper_types_profile_sandbox.Docker @@ fun ~config ~meta ~playground ->
+  seed_repo_cli_credential_mapping ~config ~keeper_name:meta.name ();
+  let repo = Filename.concat (Filename.concat playground "repos") "masc-mcp" in
+  ensure_dir repo;
+  git_ok ~cwd:repo [ "init"; "-q" ];
+  let log_path = Filename.concat config.Workspace.base_path "docker.log" in
+  with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
+  with_turn_sandbox_factories ~config ~meta @@ fun ~generic_factory ~git_factory ->
+  let raw =
+    Agent_tool_command_runtime.handle_tool_execute
+      ~turn_sandbox_factory:(Some generic_factory)
+      ~turn_sandbox_factory_git:(Some git_factory)
+      ~exec_cache:None
+      ~config
+      ~meta
+      ~args:
+        (tool_execute_typed_pipeline_args_of
+           ~cwd:repo
+           [ "printf", [ "{}" ]; "gh", [ "api"; "user" ] ])
+      ()
+  in
+  Alcotest.(check (option bool)) "pipeline gh succeeds via fake docker" (Some true)
+    (parse_bool_field raw "ok");
+  let log = read_file log_path in
+  let root_repo_cli_dir =
+    Masc_mcp.Repo_cli_credentials.root_repo_cli_config_dir config
+  in
+  Alcotest.(check bool) "pipeline gh uses credentialed factory" true
+    (contains_substring log (repo_cli_config_mount_spec root_repo_cli_dir))
+
 let test_tool_search_files_repo_review_is_unsupported () =
   with_tool_policy_config @@ fun () ->
   setup ~sandbox:Keeper_types_profile_sandbox.Docker
@@ -1528,6 +1608,48 @@ let test_sandbox_root_git_c_missing_target_keeps_execution_cwd () =
       "error identifies missing git -C target"
       true
       (contains_substring msg "git -C target must be an existing directory")
+
+let test_sandbox_root_git_c_repeated_missing_final_target () =
+  setup ~sandbox:Keeper_types_profile_sandbox.Docker
+  @@ fun ~config ~meta ~playground ->
+  let repo = Filename.concat (Filename.concat playground "repos") "masc-mcp" in
+  ensure_dir repo;
+  git_ok ~cwd:repo [ "init"; "-q" ];
+  let cwd, error =
+    resolve_sandbox_root_git_cwd_string
+      ~config
+      ~meta
+      ~cwd:playground
+      ~cmd:"git -C repos/masc-mcp -C .worktrees/missing status"
+  in
+  Alcotest.(check string) "execution cwd remains sandbox root" playground cwd;
+  match error with
+  | None -> Alcotest.fail "expected repeated git -C final target error"
+  | Some msg ->
+    Alcotest.(check bool)
+      "error identifies repeated git -C final target"
+      true
+      (contains_substring msg "repos/masc-mcp/.worktrees/missing")
+
+let test_sandbox_root_git_subcommand_c_is_not_cwd () =
+  setup ~sandbox:Keeper_types_profile_sandbox.Docker
+  @@ fun ~config ~meta ~playground ->
+  let repo = Filename.concat (Filename.concat playground "repos") "masc-mcp" in
+  ensure_dir repo;
+  git_ok ~cwd:repo [ "init"; "-q" ];
+  let cwd, error =
+    resolve_sandbox_root_git_cwd_string
+      ~config
+      ~meta
+      ~cwd:playground
+      ~cmd:"git commit -C HEAD"
+  in
+  let repo =
+    Keeper_alerting_path.normalize_path_for_check repo
+    |> Keeper_alerting_path.strip_trailing_slashes
+  in
+  Alcotest.(check string) "subcommand -C keeps single-repo auto cwd" repo cwd;
+  Alcotest.(check (option string)) "subcommand -C is not a cwd preflight" None error
 
 let test_sandbox_root_git_cwd_multi_repo_blocks_before_exec () =
   setup ~sandbox:Keeper_types_profile_sandbox.Docker
@@ -2127,6 +2249,12 @@ let () =
             "docker keeper git push routes through git-creds docker"
             `Quick test_execute_git_push_routes_through_git_creds_docker;
           Alcotest.test_case
+            "docker Execute env git uses git-creds factory"
+            `Quick test_execute_env_wrapped_git_uses_git_creds_factory;
+          Alcotest.test_case
+            "docker Execute pipeline gh uses git-creds factory"
+            `Quick test_execute_pipeline_gh_uses_git_creds_factory;
+          Alcotest.test_case
             "tool_search_files repo review is unsupported"
             `Quick test_tool_search_files_repo_review_is_unsupported;
           Alcotest.test_case
@@ -2243,6 +2371,14 @@ let () =
             "sandbox-root git -C missing target keeps execution cwd"
             `Quick
             test_sandbox_root_git_c_missing_target_keeps_execution_cwd;
+          Alcotest.test_case
+            "sandbox-root repeated git -C validates final target"
+            `Quick
+            test_sandbox_root_git_c_repeated_missing_final_target;
+          Alcotest.test_case
+            "sandbox-root git subcommand -C is not cwd"
+            `Quick
+            test_sandbox_root_git_subcommand_c_is_not_cwd;
           Alcotest.test_case
             "sandbox-root git with multiple repos gives cwd correction"
             `Quick test_sandbox_root_git_cwd_multi_repo_blocks_before_exec;

--- a/test/test_trajectory.ml
+++ b/test/test_trajectory.ml
@@ -412,7 +412,7 @@ let test_entry_to_json_includes_contract_and_radius () =
     cost_usd = 0.0001;
   } in
   let runtime_contract =
-    Keeper_runtime_contract.runtime_contract_json_from_fields
+    Keeper_runtime_contract.runtime_observability_contract_json_from_fields
       ~keeper_name:"alpha"
       ~agent_name:"alpha-agent"
       ~trace_id:"trace-alpha"
@@ -439,6 +439,45 @@ let test_entry_to_json_includes_contract_and_radius () =
   Alcotest.(check string) "observed path" "/tmp/work"
     (json |> member "action_radius" |> member "observed_paths" |> to_list
      |> List.hd |> to_string)
+
+let has_assoc_key key = function
+  | `Assoc fields -> List.mem_assoc key fields
+  | _ -> false
+
+let test_runtime_contract_projection_redacts_backend_details () =
+  let keeper_visible =
+    Keeper_runtime_contract.runtime_contract_json_from_fields
+      ~keeper_name:"alpha"
+      ~agent_name:"alpha-agent"
+      ~trace_id:"trace-alpha"
+      ~generation:2
+      ~sandbox_profile:"docker"
+      ~sandbox_root:"/workspace"
+      ~network_mode:"none"
+      ()
+  in
+  let observability =
+    Keeper_runtime_contract.runtime_observability_contract_json_from_fields
+      ~keeper_name:"alpha"
+      ~agent_name:"alpha-agent"
+      ~trace_id:"trace-alpha"
+      ~generation:2
+      ~sandbox_profile:"docker"
+      ~sandbox_root:"/workspace"
+      ~network_mode:"none"
+      ()
+  in
+  let open Yojson.Safe.Util in
+  Alcotest.(check bool) "keeper contract redacts sandbox_profile" false
+    (has_assoc_key "sandbox_profile" keeper_visible);
+  Alcotest.(check bool) "keeper contract redacts network_mode" false
+    (has_assoc_key "network_mode" keeper_visible);
+  Alcotest.(check string) "keeper contract keeps sandbox root" "/workspace"
+    (keeper_visible |> member "sandbox_root" |> to_string);
+  Alcotest.(check string) "observability keeps sandbox_profile" "docker"
+    (observability |> member "sandbox_profile" |> to_string);
+  Alcotest.(check string) "observability keeps network_mode" "none"
+    (observability |> member "network_mode" |> to_string)
 
 (* ================================================================ *)
 (* Test: read_entries_since (file-based)                             *)
@@ -559,6 +598,8 @@ let () =
       Alcotest.test_case "hourly_bucket to json" `Quick test_hourly_bucket_json;
       Alcotest.test_case "entry carries runtime/action telemetry" `Quick
         test_entry_to_json_includes_contract_and_radius;
+      Alcotest.test_case "runtime contract redacts backend details" `Quick
+        test_runtime_contract_projection_redacts_backend_details;
     ]);
     ("read_entries_since", [
       Alcotest.test_case "filter by timestamp" `Quick test_read_entries_since;


### PR DESCRIPTION
## Summary

Fix Docker sandbox route contracts and make the keeper sandbox smoke script fail on real smoke issues instead of a quoting bug.

## Product impact

- Generic Docker Execute containers no longer mount git/gh credential bundles.
- Git/gh Docker factories still opt into credential mounts explicitly.
- `git -C <missing>` from sandbox root now reports `cwd_not_directory` before Docker exec.
- Non-git path commands such as `rg` and `ls` no longer require repo-readiness preflight before Docker dispatch.
- `scripts/keeper-sandbox-smoke.sh` now validates multiline file content correctly.

## Evidence

- `scripts/check-oas-pin.sh --local-only`
- `env -u MASC_BASE_PATH DUNE_CACHE=disabled DUNE_BUILD_DIR=/private/tmp/masc-mcp-docker-route-19681-direct dune build --root . test/test_keeper_sandbox_docker_route.exe test/test_keeper_sandbox_runner.exe test/test_keeper_local_profile_docker_playground.exe`
- `env -u MASC_BASE_PATH gtimeout 120 /private/tmp/masc-mcp-docker-route-19681-direct/default/test/test_keeper_sandbox_docker_route.exe test --show-errors --compact docker_route_fires 4-17`
- `env -u MASC_BASE_PATH gtimeout 120 /private/tmp/masc-mcp-docker-route-19681-direct/default/test/test_keeper_sandbox_docker_route.exe test --show-errors --compact docker_route_contract 0-6`
- `env -u MASC_BASE_PATH gtimeout 120 /private/tmp/masc-mcp-docker-route-19681-direct/default/test/test_keeper_sandbox_docker_route.exe test --show-errors --compact docker_route_contract 8-22`
- `env -u MASC_BASE_PATH gtimeout 60 /private/tmp/masc-mcp-docker-route-19681-direct/default/test/test_keeper_sandbox_docker_route.exe test --show-errors --compact docker_route_skipped`
- `env -u MASC_BASE_PATH /private/tmp/masc-mcp-docker-route-19681-direct/default/test/test_keeper_sandbox_runner.exe`
- `env -u MASC_BASE_PATH /private/tmp/masc-mcp-docker-route-19681-direct/default/test/test_keeper_local_profile_docker_playground.exe`
- `gtimeout 60 scripts/keeper-sandbox-smoke.sh`

## Direct evidence

schema_version: 1
direct_ratio: 9/9
provenance: direct

All listed commands were run locally in this worktree. The focused Dune build used a separate `DUNE_BUILD_DIR` because another worktree held the repo-local Dune wrapper lock.

## Review evidence

Manual review focused on Docker credential mount boundaries, typed Execute git cwd preflight, repo-readiness validation scope, and fake Docker regression coverage.

## Linked issue

Fixes #19681.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`fix/docker-route-19681-20260601` → `main` · 1 commit(s) · synced 2026-06-01T02:27:37Z

| sha | subject | date |
|---|---|---|
| `c53c360ac` | fix docker sandbox route contracts | 2026-06-01 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->