### PR TITLE
Avoid defaulted runtime header parsing

### DIFF
--- a/lib/runtime/runtime_adapter.ml
+++ b/lib/runtime/runtime_adapter.ml
@@ -265,9 +265,10 @@ let provider_config_from_declared_provider (provider : Runtime_schema.provider)
        let api_key = api_key_of_credential ?registry_entry provider.credentials in
        let default_headers = default_headers_for_kind kind in
        let custom_headers =
-         provider.headers
-         |> Option.value ~default:[]
-         |> List.filter (fun (key, _) -> not (is_auth_header_key key))
+         match provider.headers with
+         | None -> []
+         | Some headers ->
+           List.filter (fun (key, _) -> not (is_auth_header_key key)) headers
        in
        (* TOML-declared custom headers override generated non-auth headers by
           key. Auth is carried only by [api_key] and is merged by OAS at HTTP


### PR DESCRIPTION
## Summary
- Replace the runtime provider custom-header default pipe with an explicit option match.
- Keep TOML auth-header filtering behavior from #19677 while satisfying the determinism boundary gate.

## Why
#19677 merged the auth-header filtering fix, but the Meta determinism gate still flagged the `Option.value ~default:[]` shape on `provider.headers`. This follow-up preserves behavior and removes that ratchet violation.

## Checks
- `ocamlformat --check lib/runtime/runtime_adapter.ml`
- `bash scripts/ci/check-determinism-contract.sh`
- `git diff --check`
- `scripts/dune-local.sh build --cache=disabled @test/runtest-test_runtime_provider_auth_headers`