### PR TITLE
Fix dashboard shell cross-domain FD snapshot

### DIFF
--- a/lib/server/fd_accountant.ml
+++ b/lib/server/fd_accountant.ml
@@ -62,12 +62,7 @@ let state_of kind = List.assoc kind _state_for_kind
 let note_acquire state = Atomic.incr state.in_flight
 
 let note_release state =
-  let rec loop () =
-    let current = Atomic.get state.in_flight in
-    let next = max 0 (current - 1) in
-    if not (Atomic.compare_and_set state.in_flight current next) then loop ()
-  in
-  loop ()
+  Lockfree_atomic.update state.in_flight (fun current -> max 0 (current - 1))
 
 (* Shared FD-pressure gate — when Keeper_fd_pressure.active () is true,
    all top-level kinds serialize through one global slot. Nested cross-kind

--- a/lib/server/fd_accountant.ml
+++ b/lib/server/fd_accountant.ml
@@ -44,16 +44,30 @@ let read_cap kind =
 (* Per-kind state: configured cap + semaphore (lazily realised; first
    acquire is during startup which is sequential, so a Lazy.force race
    is harmless). *)
-type slot_state = { cap : int ; sem : Eio.Semaphore.t }
+type slot_state =
+  { cap : int
+  ; sem : Eio.Semaphore.t
+  ; in_flight : int Atomic.t
+  }
 
 let _state_for_kind : (kind * slot_state) list =
   List.map
     (fun kind ->
       let cap = read_cap kind in
-      (kind, { cap ; sem = Eio.Semaphore.make cap }))
+      (kind, { cap ; sem = Eio.Semaphore.make cap ; in_flight = Atomic.make 0 }))
     all_kinds
 
 let state_of kind = List.assoc kind _state_for_kind
+
+let note_acquire state = Atomic.incr state.in_flight
+
+let note_release state =
+  let rec loop () =
+    let current = Atomic.get state.in_flight in
+    let next = max 0 (current - 1) in
+    if not (Atomic.compare_and_set state.in_flight current next) then loop ()
+  in
+  loop ()
 
 (* Shared FD-pressure gate — when Keeper_fd_pressure.active () is true,
    all top-level kinds serialize through one global slot. Nested cross-kind
@@ -101,11 +115,14 @@ let with_slot ~kind f =
     f ()
   else
     let release_pressure = acquire_pressure_gate_if_needed () in
-    let { sem ; _ } = state_of kind in
+    let ({ sem ; _ } as state) = state_of kind in
     Eio.Switch.run @@ fun sw ->
     Eio.Switch.on_release sw release_pressure ;
     Eio.Semaphore.acquire sem ;
-    Eio.Switch.on_release sw (fun () -> Eio.Semaphore.release sem) ;
+    note_acquire state ;
+    Eio.Switch.on_release sw (fun () ->
+        note_release state ;
+        Eio.Semaphore.release sem) ;
     let held = { kind ; active = Atomic.make true } in
     Fun.protect
       ~finally:(fun () -> Atomic.set held.active false)
@@ -113,14 +130,16 @@ let with_slot ~kind f =
 
 let acquire_lifetime_slot ~kind () =
   let release_pressure = acquire_pressure_gate_if_needed () in
-  let { sem ; _ } = state_of kind in
+  let ({ sem ; _ } as state) = state_of kind in
   (try Eio.Semaphore.acquire sem with
    | exn ->
      release_pressure ();
      raise exn);
+  note_acquire state;
   let released = Atomic.make false in
   fun () ->
     if Atomic.compare_and_set released false true then (
+      note_release state;
       Eio.Semaphore.release sem;
       release_pressure ())
 
@@ -184,13 +203,13 @@ let () =
   install_autonomy_exec_sandbox_exec_guard ();
   install_bg_sandbox_exec_guard ()
 
-(* In-flight count = configured cap minus current semaphore credits.
-   Eio.Semaphore exposes [get_value] which returns the available credit
-   count; in-flight = cap − available. *)
+(* Use explicit atomic counters instead of reading semaphore credits here.
+   Dashboard projections run on worker domains, while the semaphores are used
+   by the main Eio domain; observing them through [get_value] can cross Eio
+   domain ownership boundaries. *)
 let in_flight kind =
-  let { cap ; sem } = state_of kind in
-  let available = Eio.Semaphore.get_value sem in
-  max 0 (cap - available)
+  let { in_flight ; _ } = state_of kind in
+  max 0 (Atomic.get in_flight)
 
 (* Best-effort FD-open count using /dev/fd (macOS) or /proc/self/fd
    (Linux). Returns -1 on other platforms. *)

--- a/lib/server/fd_accountant.mli
+++ b/lib/server/fd_accountant.mli
@@ -113,7 +113,8 @@ val install_bg_sandbox_exec_guard : unit -> unit
 
 type snapshot = {
   per_kind : (kind * int) list ;
-      (** in-flight count per class (cap − available semaphore slots). *)
+      (** in-flight count per class. Maintained separately from Eio semaphore
+          credits so snapshots remain safe from dashboard worker domains. *)
   fd_open : int ;
       (** Best-effort observation of process-wide open FDs.
           On macOS / Linux uses [/dev/fd] / [/proc/self/fd] counting;

--- a/test/test_fd_accountant.ml
+++ b/test/test_fd_accountant.ml
@@ -11,6 +11,7 @@
 open Alcotest
 module FA = Masc_mcp.Fd_accountant
 module DST = Masc_mcp.Docker_spawn_throttle
+module DP = Domain_pool
 
 let tmpdir prefix =
   Filename.concat
@@ -125,6 +126,19 @@ let test_snapshot_shape () =
   let expected = Masc_mcp.Keeper_fd_pressure.active () in
   check bool "pressure_active mirrors Keeper_fd_pressure" expected
     s.pressure_active
+
+let test_snapshot_safe_from_worker_domain () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let pool = DP.create ~sw ~domain_count:1 (Eio.Stdenv.domain_mgr env) in
+  let caller_domain = (Domain.self () :> int) in
+  let worker_domain, snapshot =
+    DP.submit_io pool (fun () -> ((Domain.self () :> int), FA.fd_snapshot ()))
+  in
+  check bool "snapshot ran off caller domain" true
+    (worker_domain <> caller_domain);
+  check int "worker snapshot covers all kinds" (List.length FA.all_kinds)
+    (List.length snapshot.per_kind)
 
 let log_writer_in_flight () =
   let snapshot = FA.fd_snapshot () in
@@ -496,7 +510,11 @@ let () =
             test_docker_delegation_consistent ;
         ] ) ;
       ( "snapshot",
-        [ test_case "shape" `Quick test_snapshot_shape ] ) ;
+        [
+          test_case "shape" `Quick test_snapshot_shape ;
+          test_case "safe from worker domain" `Quick
+            test_snapshot_safe_from_worker_domain ;
+        ] ) ;
       ( "log writer",
         [
           test_case "Dated_jsonl append uses slot" `Quick


### PR DESCRIPTION
## Summary

- Keep FD accountant in-flight telemetry in atomic counters instead of reading Eio semaphore credits.
- Add a regression test proving `Fd_accountant.fd_snapshot` is safe from a `Domain_pool` worker domain.
- Preserve the existing semaphore gating behavior for slot admission and release.

## Product impact

- Prevents dashboard light-shell `runtime_resolution` from dropping to `null` with `Invalid_argument("Switch accessed from wrong domain!")` when shell computation is offloaded.
- Keeps `/api/v1/dashboard/shell?light=true` aligned with runtime health without touching keeper scheduling policy.

## Evidence

- `ocamlformat --check lib/server/fd_accountant.ml lib/server/fd_accountant.mli test/test_fd_accountant.ml`
- `git diff --check origin/main..HEAD`
- `env DUNE_BUILD_DIR=_build_fd_direct DUNE_CACHE=disabled dune build --root ... test/test_fd_accountant.exe test/test_dashboard_http_core.exe`
- `_build_fd_direct/default/test/test_fd_accountant.exe test snapshot 1`
- `_build_fd_direct/default/test/test_dashboard_http_core.exe test executor_pool 26`

## Direct evidence

schema_version: 1
direct_ratio: 5/5
provenance: direct

- Direct code change: `Fd_accountant.fd_snapshot` no longer observes Eio semaphore state.
- Direct regression: worker-domain snapshot test passed.
- Direct dashboard coverage: light shell runtime health SSOT test passed.

## Review evidence

- Not reviewed yet; draft PR for CI and review.
- Full `test_fd_accountant` direct executable run was not used as final evidence because existing BgTask tests fail outside dune's normal test harness environment; the targeted regression passed.

## Linked issue

- None. Runtime warning was observed in live logs after restart.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`fix-dashboard-shell-domain-20260601` → `main` · 1 commit(s) · synced 2026-06-01T04:13:30Z

| sha | subject | date |
|---|---|---|
| `babd1229d` | Fix FD snapshot cross-domain reads | 2026-06-01 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->