### PR TITLE
[codex] Purge tool access legacy drains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1446,9 +1446,9 @@ Aggregate of 185 commits since v0.14.0 (26 feat / 93 fix / 30 perf-refactor-obs-
   `evidence/effects.json` rows are treated as advisory effect-decision evidence
   instead of mode violations.
 - **Keeper TOML key drift assertion restored.** The TOML unknown-key allowlist no
-  longer whitelists `tool_access.kind` / `tool_access.preset` unless the TOML
-  profile parser actually consumes those nested keys, unblocking keeper test
-  executable startup after the canonical/parsed key lists diverged.
+  longer whitelists retired nested tool-access fields unless the TOML profile
+  parser actually consumes them, unblocking keeper test executable startup after
+  the canonical/parsed key lists diverged.
 - **OAS pin bump → `main@8b5bf30a` (`v0.170.4`).**
   `scripts/oas-agent-sdk-pin.sh` now tracks the merged OAS Kimi CLI session
   reuse fix on upstream `main`, and the dependency floor in `dune-project` /

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -1376,7 +1376,7 @@ describe('fetchKeeperConfig', () => {
         missing_active_goal_ids: [],
       },
       tools: {
-        tool_access: { kind: 'preset', preset: 'delivery' },
+        tool_access: ['keeper_fs_read'],
         resolved_allowlist: 'keeper_fs_read',
         tool_denylist: 'Execute',
         active_masc_tool_count: '1',

--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -134,7 +134,7 @@ function makeKeeperConfig(overrides: Partial<KeeperConfig> = {}): KeeperConfig {
       override_fields: ['goal', 'instructions'],
     },
     tools: {
-      tool_access: { kind: 'preset', preset: 'delivery' },
+      tool_access: ['keeper_fs_read'],
       resolved_allowlist: ['keeper_fs_read'],
       tool_denylist: ['Execute'],
       active_masc_tool_count: 1,

--- a/docs/KEEPER-FILE-MODEL.md
+++ b/docs/KEEPER-FILE-MODEL.md
@@ -92,7 +92,7 @@ These are the identity fields that should live in persona by default.
 | `desires` | Optional | Keeper self-model: desires | Identity field. |
 | `instructions` | Optional | Persona-specific instructions | Identity field. |
 | `mention_targets` | Optional | Default mention aliases | If omitted, create-from-persona falls back to `[persona_name]`. |
-| `tool_access` | Optional | Default tool allowlist | String array of callable tool names. |
+| `tool_access` | Optional | Default tool allowlist | String array of callable tool names; omitted means `[]`. |
 | `tool_denylist` | Optional | Tools to remove from the allowlist | Optional policy refinement. |
 | `policy_voice_enabled` | Optional | Whether voice tools should be surfaced | Policy default, not runtime state. |
 | `shards` | Optional | Default tool shards | Optional specialization hook. |

--- a/docs/audit-responses/2026-05-05-integrated-improvement-design.md
+++ b/docs/audit-responses/2026-05-05-integrated-improvement-design.md
@@ -214,7 +214,7 @@ candidate (RFC-0029)**.
 | `keeper.base` | 죽음 (unknown key 경고) | sangsu.toml line 2가 실제 사용 — base.toml inheritance 선언 | **D — false** |
 | `work_discovery_sources` | 죽음, `work.source`로 대체 | sangsu.toml line 4가 실제 사용. 코드 caller 확인 필요 | TBD |
 | `git_identity_mode` | 죽음, 항상 `"repo_cli_identity"` | active cleanup 후보 | **C** |
-| `tool_access.preset` | 중복 with `tools.preset` | sangsu.toml line 8 실제 사용. `tools.preset`은 audit의 가정 키 | **D — false** |
+| retired nested tool-access preset field | 중복 with `tools.preset` | sangsu.toml line 8 실제 사용. `tools.preset`은 audit의 가정 키 | **D — false** |
 | `sandbox_profile` | 기본값이라 advanced로 | 5 TOML 모두 미선언 — 이미 default | **D** |
 | `network_mode` | 기본값이라 advanced로 | 5 TOML 모두 미선언 — 이미 default | **D** |
 | `repo_cli_identity` | persona에서 파생 | 검증 필요 | TBD |

--- a/lib/keeper/agent_tool_persona_runtime.ml
+++ b/lib/keeper/agent_tool_persona_runtime.ml
@@ -184,11 +184,7 @@ let tool_access_toml_section json =
   | Some (`List _ as tool_access) -> (
       match tool_access_of_meta_json (`Assoc [ ("tool_access", tool_access) ]) with
       | Ok tools ->
-          Ok
-            [
-              "[keeper.tool_access]";
-              Printf.sprintf "tools = %s" (toml_string_array tools);
-            ]
+          Ok [ Printf.sprintf "tool_access = %s" (toml_string_array tools) ]
       | Error msg -> Error msg)
   | Some _ -> Error "tool_access must be an array of strings for durable TOML"
   | None -> Ok []

--- a/lib/keeper/keeper_meta_tool_access.ml
+++ b/lib/keeper/keeper_meta_tool_access.ml
@@ -23,40 +23,6 @@ let normalize_tool_names names =
   |> dedupe_keep_order
 ;;
 
-let write_tools_typed =
-  [ Tool_name.Keeper.Fs_edit; Tool_name.Keeper.Fs_write; Tool_name.Keeper.Execute ]
-;;
-
-let write_tools = List.map Tool_name.Keeper.to_string write_tools_typed
-;;
-
-let legacy_keeper_internal_tool_names =
-  (* Keep legacy masc workspace defaults explicit in
-     [legacy_session_min_tool_names]; new [masc_*] internal tools should not
-     silently expand missing [tool_access] migrations.
-     Write tools are excluded so that keepers without explicit [tool_access]
-     cannot claim write-intent tasks.  Keepers that need write access must
-     list explicit write tool names. *)
-  Tool_catalog.tools_for_surface Tool_catalog.Keeper_internal
-  |> List.filter (fun name ->
-         not (String.starts_with ~prefix:"masc_" name)
-         && not (List.exists (String.equal name) write_tools))
-;;
-
-let legacy_session_min_tool_names =
-  (* Legacy keepers historically received canonical masc_* workspace tools,
-     not the SDK alias-heavy Session_min surface. Keep this compatibility list
-     explicit so missing tool_access migration remains stable after tier removal. *)
-  List.map
-    Tool_name.Masc.to_string
-    Tool_name.Masc.
-      [ Status; Tasks; Claim_next; Plan_set_task; Transition; Add_task; Broadcast ]
-;;
-
-let migrate_legacy_restricted_tools names =
-  normalize_tool_names (legacy_keeper_internal_tool_names @ names)
-;;
-
 let normalize_tool_access names = normalize_tool_names names
 
 (** Encode a tool allowlist as a JSON array of tool names. *)
@@ -94,21 +60,10 @@ let string_list_field_opt_result ?label ~field_name (json : Yojson.Safe.t) =
   | _ -> string_list_field_result ?label ~field_name json
 ;;
 
-let default_tool_access_of_meta_json () =
-  (* Full Keeper_internal surface: keepers without explicit tool_access get the
-     complete tool set so runtime filtering can find providers with required tools
-     like masc_transition. Write-intent restrictions are handled by task contract
-     gating, not by default tool access exclusion.
-     See fleet deadlock Layer 2 analysis (2026-05-30) + runtime provider
-     gap analysis (2026-05-30). *)
-  normalize_tool_names (Tool_catalog.tools_for_surface Tool_catalog.Keeper_internal)
-;;
+let default_tool_access_of_meta_json () = []
 
 (** Parse [tool_access] from persisted meta JSON.
-    Canonical form is a JSON array of tool names.
-    Legacy object forms are accepted only as a migration drain:
-    - [{ "tools": [...] }] -> the [tools] array
-    - objects without [tools] -> default surface *)
+    Canonical form is a JSON array of tool names. *)
 let tool_access_of_meta_json (json : Yojson.Safe.t) =
   match Json_util.assoc_member_opt "tool_access" json with
   | Some `Null | None -> Ok (default_tool_access_of_meta_json ())
@@ -119,18 +74,6 @@ let tool_access_of_meta_json (json : Yojson.Safe.t) =
      with
      | Ok tools -> Ok (normalize_tool_access tools)
      | Error msg -> Error msg)
-  | Some (`Assoc _ as access_json) ->
-    (match Json_util.assoc_member_opt "tools" access_json with
-     | Some _ ->
-       (match
-          string_list_field_result
-            ~field_name:"tools"
-            ~label:"tool_access.tools"
-            access_json
-        with
-        | Ok tools -> Ok (normalize_tool_access tools)
-        | Error msg -> Error msg)
-     | None -> Ok (default_tool_access_of_meta_json ()))
   | Some other ->
     Error
       (Printf.sprintf "keeper tool_access must be an array of strings (received %s)"
@@ -165,17 +108,10 @@ let tool_access_to_json_typed tools =
   `List (List.map (fun t -> `String (Tool_name.Keeper.to_string t)) tools)
 ;;
 
-(** Default typed tool allowlist: [Keeper_internal] surface with write tools
-    excluded, parsed through the typed boundary. *)
-let default_tool_access_of_meta_json_typed () =
-  Tool_catalog.tools_for_surface Tool_catalog.Keeper_internal
-  |> tool_access_of_string_list
-  |> List.filter (fun tool -> not (List.mem tool write_tools_typed))
-;;
+let default_tool_access_of_meta_json_typed () = []
 
 (** Parse [tool_access] from persisted meta JSON into typed tools.
-    Same migration-drain behavior as [tool_access_of_meta_json] but returns
-    typed variants.  Unknown names are silently dropped at the boundary. *)
+    Unknown names are silently dropped at the boundary. *)
 let tool_access_of_meta_json_typed (json : Yojson.Safe.t) =
   match Json_util.assoc_member_opt "tool_access" json with
   | Some `Null | None -> Ok (default_tool_access_of_meta_json_typed ())
@@ -186,18 +122,6 @@ let tool_access_of_meta_json_typed (json : Yojson.Safe.t) =
      with
      | Ok tools -> Ok (tool_access_of_string_list tools)
      | Error msg -> Error msg)
-  | Some (`Assoc _ as access_json) ->
-    (match Json_util.assoc_member_opt "tools" access_json with
-     | Some _ ->
-       (match
-          string_list_field_result
-            ~field_name:"tools"
-            ~label:"tool_access.tools"
-            access_json
-        with
-        | Ok tools -> Ok (tool_access_of_string_list tools)
-        | Error msg -> Error msg)
-     | None -> Ok (default_tool_access_of_meta_json_typed ()))
   | Some other ->
     Error
       (Printf.sprintf "keeper tool_access must be an array of strings (received %s)"

--- a/lib/keeper/keeper_meta_tool_access.mli
+++ b/lib/keeper/keeper_meta_tool_access.mli
@@ -37,13 +37,11 @@ val string_list_field_opt_result :
   Yojson.Safe.t ->
   (string list, string) result
 
-(** Default tool allowlist for missing/null fields:
-    [Keeper_internal] surface with write tools excluded. *)
+(** Default tool allowlist for missing/null fields. *)
 val default_tool_access_of_meta_json : unit -> string list
 
 (** Parse [tool_access] from persisted meta JSON.  Canonical form is a JSON
-    array of tool names; legacy objects with [tools] are accepted as a
-    migration drain. *)
+    array of tool names. *)
 val tool_access_of_meta_json :
   Yojson.Safe.t -> (string list, string) result
 
@@ -70,7 +68,7 @@ val tool_access_to_json_typed : Tool_name.Keeper.t list -> Yojson.Safe.t
 (** Encode a typed tool allowlist as JSON. *)
 
 val default_tool_access_of_meta_json_typed : unit -> Tool_name.Keeper.t list
-(** Default typed tool allowlist from [Keeper_internal] surface. *)
+(** Default typed tool allowlist. *)
 
 val tool_access_of_meta_json_typed :
   Yojson.Safe.t -> (Tool_name.Keeper.t list, string) result

--- a/lib/keeper/keeper_types_profile_toml_parser.ml
+++ b/lib/keeper/keeper_types_profile_toml_parser.ml
@@ -13,24 +13,12 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
   let strs key = Keeper_toml_loader.toml_string_list doc (k key) in
   let has key = List.mem_assoc (k key) doc in
   let has_raw key = List.mem_assoc key doc in
-  let tool_access_key key = k ("tool_access." ^ key) in
   let tool_access_defaults_result =
-    let tools_key = tool_access_key "tools" in
-    let removed_keys =
-      [ "kind"; "preset"; "also_allow" ]
-      |> List.map tool_access_key
-      |> List.filter has_raw
-    in
-    match removed_keys with
-    | _ :: _ ->
-        Error
-          (Printf.sprintf
-             "removed keeper.tool_access keys: %s. Use [keeper.tool_access] tools = [...]"
-             (String.concat ", " removed_keys))
-    | [] when has_raw tools_key ->
-        let tools = Keeper_toml_loader.toml_string_list doc tools_key in
-        Ok (Some (normalize_name_list tools))
-    | [] -> Ok None
+    let key = k "tool_access" in
+    if has_raw key then
+      let tools = Keeper_toml_loader.toml_string_list doc key in
+      Ok (Some (normalize_name_list tools))
+    else Ok None
   in
   let per_provider_timeout_state, per_provider_timeout =
     per_provider_timeout_of_toml
@@ -260,7 +248,7 @@ let parsed_field_key_names =
   ; "network_mode"
   ; "repo_cli_identity"
   ; "git_identity_mode"
-  ; "tool_access.tools"
+  ; "tool_access"
   ; "tool_denylist"
   ; "active_goal_ids"
   ; "telemetry_feedback_enabled"
@@ -307,7 +295,7 @@ let canonical_keeper_toml_key_names =
   ; "network_mode"
   ; "repo_cli_identity"
   ; "git_identity_mode"
-  ; "tool_access.tools"
+  ; "tool_access"
   ; "tool_denylist"
   ; "active_goal_ids"
   ; "telemetry_feedback_enabled"

--- a/scripts/audit-keeper-fleet-readiness.py
+++ b/scripts/audit-keeper-fleet-readiness.py
@@ -2,9 +2,9 @@
 """Audit live keeper fleet readiness from on-disk MASC runtime state.
 
 This is intentionally read-only. It separates configuration readiness
-(Docker, repo CLI identity, repo-mutation-capable preset) from durable evidence
-(recent turns, board actions, persisted PR references) so operators do not
-mistake a configured capability for proof that every keeper already used it.
+(Docker, repo CLI identity, repo-mutation-capable tool access) from durable
+evidence (recent turns, board actions, persisted PR references) so operators do
+not mistake a configured capability for proof that every keeper already used it.
 """
 
 from __future__ import annotations
@@ -25,7 +25,8 @@ from typing import Any
 import tomllib
 
 
-PR_CAPABLE_PRESETS = {"research", "delivery", "full"}
+REPO_MUTATION_TOOLS = {"tool_execute", "tool_edit_file", "tool_write_file"}
+REMOVED_TOOL_POLICY_KEYS = {"tool_preset", "tool_also_allow", "tool_custom_allowlist"}
 BOARD_TOOLS = {
     "keeper_board_post",
     "keeper_board_comment",
@@ -79,7 +80,8 @@ class KeeperAudit:
     runtime_path: str | None
     sandbox_profile: str | None
     network_mode: str | None
-    tool_preset: str | None
+    tool_access: list[str] | None
+    repo_mutation_tools: list[str]
     repo_cli_identity: str | None
     github_account_login: str | None
     git_identity_mode: str | None
@@ -289,23 +291,54 @@ def jsonl_has_object(path: Path) -> bool:
     return False
 
 
-def tool_preset_from_config(config: dict[str, Any]) -> str | None:
-    tool_access = config.get("tool_access")
-    if isinstance(tool_access, dict):
-        preset = tool_access.get("preset")
-        if isinstance(preset, str) and preset:
-            return preset
-    preset = config.get("tool_preset")
-    return preset if isinstance(preset, str) and preset else None
+def string_list_value(value: Any) -> list[str] | None:
+    if not isinstance(value, list):
+        return None
+    tools: list[str] = []
+    for item in value:
+        if not isinstance(item, str):
+            return None
+        item = item.strip()
+        if item:
+            tools.append(item)
+    return tools
 
 
-def tool_preset_from_runtime(runtime: dict[str, Any]) -> str | None:
-    tool_access = runtime.get("tool_access")
-    if isinstance(tool_access, dict):
-        preset = tool_access.get("preset")
-        if isinstance(preset, str) and preset:
-            return preset
-    return string_field(runtime, "tool_preset")
+def tool_access_from_config(
+    config: dict[str, Any],
+) -> tuple[list[str] | None, list[str]]:
+    raw = config.get("tool_access")
+    if raw is None:
+        return None, []
+    tools = string_list_value(raw)
+    if tools is None:
+        return None, ["tool_access_config_invalid"]
+    return tools, []
+
+
+def tool_access_from_runtime(
+    runtime: dict[str, Any],
+) -> tuple[list[str] | None, list[str]]:
+    raw = runtime.get("tool_access")
+    if raw is None:
+        return None, []
+    tools = string_list_value(raw)
+    if tools is None:
+        return None, ["tool_access_runtime_invalid"]
+    return tools, []
+
+
+def repo_mutation_tools(tool_access: list[str] | None) -> list[str]:
+    if tool_access is None:
+        return []
+    return sorted(REPO_MUTATION_TOOLS.intersection(tool_access))
+
+
+def removed_tool_policy_failures(data: dict[str, Any], source: str) -> list[str]:
+    present = sorted(key for key in REMOVED_TOOL_POLICY_KEYS if key in data)
+    if not present:
+        return []
+    return [source + "_removed_tool_policy_keys_" + "_".join(present)]
 
 
 def tools_from_decision(row: dict[str, Any]) -> list[str]:
@@ -1079,7 +1112,14 @@ def audit_keeper(
     network_mode = string_field(runtime, "network_mode") or string_field(
         config, "network_mode"
     )
-    tool_preset = tool_preset_from_runtime(runtime) or tool_preset_from_config(config)
+    config_tool_access, config_tool_access_failures = tool_access_from_config(config)
+    runtime_tool_access, runtime_tool_access_failures = tool_access_from_runtime(
+        runtime
+    )
+    tool_access = (
+        runtime_tool_access if runtime_tool_access is not None else config_tool_access
+    )
+    mutation_tools = repo_mutation_tools(tool_access)
     repo_cli_identity = string_field(runtime, "repo_cli_identity") or string_field(
         config, "repo_cli_identity"
     )
@@ -1091,11 +1131,18 @@ def audit_keeper(
         failures.append("sandbox_not_docker")
     if network_mode != "inherit":
         failures.append("network_not_inherit")
-    if tool_preset not in PR_CAPABLE_PRESETS:
-        failures.append("preset_not_pr_capable")
+    failures.extend(removed_tool_policy_failures(config, "config"))
+    failures.extend(removed_tool_policy_failures(runtime, "runtime"))
+    failures.extend(config_tool_access_failures)
+    failures.extend(runtime_tool_access_failures)
+    if not mutation_tools:
+        failures.append("repo_mutation_tools_missing")
     if not repo_cli_identity:
         failures.append("repo_cli_identity_missing")
-    elif forbidden_repo_cli_identities and repo_cli_identity in forbidden_repo_cli_identities:
+    elif (
+        forbidden_repo_cli_identities
+        and repo_cli_identity in forbidden_repo_cli_identities
+    ):
         failures.append(f"repo_cli_identity_forbidden_{repo_cli_identity}")
     if git_identity_mode != "repo_cli_identity":
         failures.append("git_identity_mode_not_repo_cli_identity")
@@ -1209,7 +1256,8 @@ def audit_keeper(
         runtime_path=str(runtime_path) if runtime_path.exists() else None,
         sandbox_profile=sandbox_profile,
         network_mode=network_mode,
-        tool_preset=tool_preset,
+        tool_access=tool_access,
+        repo_mutation_tools=mutation_tools,
         repo_cli_identity=repo_cli_identity,
         github_account_login=github_account_login,
         git_identity_mode=git_identity_mode,
@@ -1350,8 +1398,15 @@ def print_text(report: dict[str, Any]) -> None:
         marker = "OK" if not failures else "FAIL"
         age = keeper["last_turn_age_hours"]
         age_label = "unknown" if age is None else f"{age:.2f}h"
+        tool_access_label = (
+            "default"
+            if keeper["tool_access"] is None
+            else str(len(keeper["tool_access"]))
+        )
+        repo_tools_label = ",".join(keeper["repo_mutation_tools"]) or "none"
         print(
-            "- {name}: {marker} preset={preset} sandbox={sandbox}/{network} "
+            "- {name}: {marker} tool_access={tool_access} repo_tools={repo_tools} "
+            "sandbox={sandbox}/{network} "
             "gh={github} recent={recent} age={age} board={board} "
             "web_search={web_search} "
             "gh_account={github_account} "
@@ -1361,7 +1416,8 @@ def print_text(report: dict[str, Any]) -> None:
             "history={history} tool_call_log={tool_call_log}".format(
                 name=keeper["name"],
                 marker=marker,
-                preset=keeper["tool_preset"],
+                tool_access=tool_access_label,
+                repo_tools=repo_tools_label,
                 sandbox=keeper["sandbox_profile"],
                 network=keeper["network_mode"],
                 github=keeper["repo_cli_identity"],
@@ -1413,7 +1469,9 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     )
     parser.add_argument("--max-silence-hours", type=float, default=2400.0)
     parser.add_argument(
+        "--forbid-repo-cli-identity",
         "--forbid-github-identity",
+        dest="forbid_repo_cli_identity",
         action="append",
         default=[],
         metavar="IDENTITY",

--- a/test/test_audit_keeper_fleet_readiness.py
+++ b/test/test_audit_keeper_fleet_readiness.py
@@ -99,9 +99,14 @@ def write_ready_keeper(
                 "[keeper]",
                 'sandbox_profile = "docker"',
                 'network_mode = "inherit"',
-                'tool_preset = "delivery"',
                 f'repo_cli_identity = "{repo_cli_identity}"',
                 'git_identity_mode = "repo_cli_identity"',
+                "tool_access = ["
+                '"tool_execute", '
+                '"tool_edit_file", '
+                '"tool_write_file", '
+                '"keeper_board_post"'
+                "]",
                 "",
             ]
         ),
@@ -112,7 +117,12 @@ def write_ready_keeper(
             {
                 "sandbox_profile": "docker",
                 "network_mode": "inherit",
-                "tool_preset": "delivery",
+                "tool_access": [
+                    "tool_execute",
+                    "tool_edit_file",
+                    "tool_write_file",
+                    "keeper_board_post",
+                ],
                 "repo_cli_identity": repo_cli_identity,
                 "git_identity_mode": "repo_cli_identity",
                 "last_turn_ts": time.time(),
@@ -268,6 +278,11 @@ class AuditKeeperFleetReadinessTest(unittest.TestCase):
         args = audit.parse_args([])
 
         self.assertEqual(args.expected_keepers, 18)
+
+    def test_parse_args_accepts_forbid_github_identity_alias(self):
+        args = audit.parse_args(["--forbid-github-identity", "operator"])
+
+        self.assertEqual(args.forbid_repo_cli_identity, ["operator"])
 
     def test_iter_jsonl_streams_rows(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -531,6 +546,70 @@ class AuditKeeperFleetReadinessTest(unittest.TestCase):
         self.assertEqual(
             report["fleet_failures"], ["minimum_2_configured_keepers_got_1"]
         )
+
+    def test_explicit_tool_access_must_include_repo_mutation_tool(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_ready_keeper(root, "alpha")
+            runtime_path = root / ".masc" / "keepers" / "alpha.json"
+            runtime = json.loads(runtime_path.read_text(encoding="utf-8"))
+            runtime["tool_access"] = ["keeper_board_post"]
+            runtime_path.write_text(json.dumps(runtime), encoding="utf-8")
+
+            report = audit.build_report(audit_args(root, expected_keepers=1))
+
+        self.assertFalse(report["ok"])
+        keeper = report["keepers"][0]
+        self.assertEqual(keeper["repo_mutation_tools"], [])
+        self.assertIn("repo_mutation_tools_missing", keeper["failures"])
+
+    def test_removed_tool_policy_keys_fail_readiness(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_ready_keeper(root, "alpha")
+            runtime_path = root / ".masc" / "keepers" / "alpha.json"
+            runtime = json.loads(runtime_path.read_text(encoding="utf-8"))
+            runtime["tool_preset"] = "delivery"
+            runtime_path.write_text(json.dumps(runtime), encoding="utf-8")
+
+            report = audit.build_report(audit_args(root, expected_keepers=1))
+
+        self.assertFalse(report["ok"])
+        self.assertIn(
+            "runtime_removed_tool_policy_keys_tool_preset",
+            report["keepers"][0]["failures"],
+        )
+
+    def test_missing_tool_access_has_no_repo_mutation_surface(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_ready_keeper(root, "alpha")
+            runtime_path = root / ".masc" / "keepers" / "alpha.json"
+            runtime = json.loads(runtime_path.read_text(encoding="utf-8"))
+            runtime.pop("tool_access")
+            runtime_path.write_text(json.dumps(runtime), encoding="utf-8")
+            config_path = root / ".masc" / "config" / "keepers" / "alpha.toml"
+            config_path.write_text(
+                "\n".join(
+                    [
+                        "[keeper]",
+                        'sandbox_profile = "docker"',
+                        'network_mode = "inherit"',
+                        'repo_cli_identity = "anyang-keepers"',
+                        'git_identity_mode = "repo_cli_identity"',
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            report = audit.build_report(audit_args(root, expected_keepers=1))
+
+        self.assertFalse(report["ok"])
+        keeper = report["keepers"][0]
+        self.assertIsNone(keeper["tool_access"])
+        self.assertEqual(keeper["repo_mutation_tools"], [])
+        self.assertIn("repo_mutation_tools_missing", keeper["failures"])
 
     def test_require_persistent_work_evidence_fails_without_runtime_artifacts(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/test/test_keeper_masc_bridge.ml
+++ b/test/test_keeper_masc_bridge.ml
@@ -181,20 +181,19 @@ let test_inject_stores_filtered_masc () =
   Alcotest.(check bool) "no keeper_time_now" false
     (List.mem "keeper_time_now" names)
 
-let test_default_tool_access_exposes_masc () =
+let test_missing_tool_access_exposes_no_masc_tools () =
   prime_keeper_bridge ();
   let meta = make_meta () in
   let names = KET.keeper_masc_tool_names meta in
-  Alcotest.(check bool) "has masc_status" true (List.mem "masc_status" names);
-  (* Governance tools are no longer in raw_all_tool_schemas *)
-  Alcotest.(check bool) "no masc_governance_status" false
-    (List.mem "masc_governance_status" names);
-  Alcotest.(check bool) "filters unsupported inline tool" false
-    (List.mem "masc_agents" names)
+  Alcotest.(check (list string)) "missing allowlist is empty" [] names
 
-let test_messaging_preset_exposes_board () =
+let test_explicit_tool_access_exposes_board () =
   prime_keeper_bridge ();
-  let meta = make_meta () in
+  let meta =
+    make_meta
+      ~tool_access:([ "keeper_board_post"; "tool_search_files"; "tool_read_file" ])
+      ()
+  in
   let names = KET.keeper_allowed_tool_names meta in
   Alcotest.(check bool) "has keeper_board_post" true
     (List.mem "keeper_board_post" names);
@@ -273,7 +272,7 @@ let test_custom_keeps_registered_inline_board_tool () =
     make_meta
       ~tool_access:
         (
-           [ "keeper_board_post"; "masc_agents" ])
+           [ "keeper_board_post"; "masc_broadcast" ])
       ()
   in
   let names = KET.keeper_masc_tool_names meta in
@@ -282,7 +281,7 @@ let test_custom_keeps_registered_inline_board_tool () =
   Alcotest.(check bool) "raw masc_board_post filtered out" false
     (List.mem "masc_board_post" names);
   Alcotest.(check bool) "drops unsupported inline tool" false
-    (List.mem "masc_agents" names)
+    (List.mem "masc_broadcast" names)
 
 let with_masc_schema_ref schemas f =
   KET.with_masc_schemas_for_test schemas f
@@ -310,7 +309,7 @@ let test_dashboard_tool_count_uses_schema_ssot () =
       in
       Alcotest.(check int) "dashboard counts schema-derived masc tools" 1 count)
 
-let test_tool_access_missing_defaults_standard_policy () =
+let test_tool_access_missing_defaults_empty_allowlist () =
   let names =
     allowed_names_of_json
       (`Assoc
@@ -320,30 +319,28 @@ let test_tool_access_missing_defaults_standard_policy () =
           ("trace_id", `String "legacy-standard-trace");
         ])
   in
-  let legacy_masc_names =
-    names
-    |> List.filter (fun name -> String.starts_with ~prefix:"masc_" name)
-    |> List.sort_uniq String.compare
+  Alcotest.(check (list string)) "missing allowlist is empty" [] names
+
+let test_typed_and_string_tool_access_defaults_match () =
+  let module Access = Masc_mcp.Keeper_meta_contract in
+  let check_default label json =
+    let string_default =
+      match Access.tool_access_of_meta_json json with
+      | Ok tools -> tools
+      | Error e -> Alcotest.failf "string parser failed for %s: %s" label e
+    in
+    let typed_default =
+      match Access.tool_access_of_meta_json_typed json with
+      | Ok tools -> Access.tool_access_to_string_list tools
+      | Error e -> Alcotest.failf "typed parser failed for %s: %s" label e
+    in
+    Alcotest.(check (list string))
+      (label ^ " typed/string defaults")
+      string_default
+      typed_default
   in
-  let expected_legacy_masc_names =
-    [
-      "masc_status";
-      "masc_tasks";
-      "masc_claim_next";
-      "masc_plan_set_task";
-      "masc_transition";
-      "masc_add_task";
-    ]
-    |> List.sort_uniq String.compare
-  in
-  Alcotest.(check bool) "keeps keeper internal tool" true
-    (List.mem "keeper_time_now" names);
-  Alcotest.(check bool) "keeps legacy standard masc tool" true
-    (List.mem "masc_status" names);
-  Alcotest.(check (list string)) "default keeps expected masc set"
-    expected_legacy_masc_names legacy_masc_names;
-  Alcotest.(check bool) "default exposes full read surface" true
-    (List.mem "tool_read_file" names)
+  check_default "missing" (`Assoc []);
+  check_default "null" (`Assoc [ "tool_access", `Null ])
 
 let test_read_meta_file_rejects_legacy_tool_keys () =
   let dir = temp_dir () in
@@ -373,29 +370,6 @@ let test_read_meta_file_rejects_legacy_tool_keys () =
             (Yojson.Safe.Util.member "tool_preset" persisted
              |> Yojson.Safe.Util.to_string))
 
-let test_read_meta_file_defaults_legacy_tool_access_object_without_tools () =
-  let dir = temp_dir () in
-  Fun.protect
-    ~finally:(fun () -> cleanup_dir dir)
-    (fun () ->
-      let path = Filename.concat dir "legacy-object.json" in
-      write_json_file path
-        (`Assoc
-          [
-            ("name", `String "legacy-object");
-            ("agent_name", `String "legacy-object");
-            ("trace_id", `String "legacy-object-trace");
-            ("runtime_id", `String "test.runtime");
-            ("tool_access", `Assoc [ ("preset", `String "full") ]);
-          ]);
-      match Masc_mcp.Keeper_meta_store.read_meta_file_path path with
-      | Error e -> Alcotest.fail e
-      | Ok None -> Alcotest.fail "expected keeper meta"
-      | Ok (Some meta) ->
-          let names = KET.keeper_allowed_tool_names meta in
-          Alcotest.(check bool) "default keeps keeper internal tool" true
-            (List.mem "keeper_time_now" names))
-
 let test_read_meta_file_defaults_missing_tool_access_without_rewrite () =
   let dir = temp_dir () in
   Fun.protect
@@ -417,8 +391,7 @@ let test_read_meta_file_defaults_missing_tool_access_without_rewrite () =
       | Ok None -> Alcotest.fail "expected keeper meta"
       | Ok (Some meta) ->
           let names = KET.keeper_allowed_tool_names meta in
-          Alcotest.(check bool) "default keeps keeper internal tool" true
-            (List.mem "keeper_time_now" names);
+          Alcotest.(check (list string)) "missing allowlist is empty" [] names;
           let persisted = read_json_file path in
           Alcotest.(check bool) "missing tool_access not rewritten" true
             (Yojson.Safe.Util.member "tool_access" persisted = `Null))
@@ -440,27 +413,6 @@ let test_meta_of_json_rejects_legacy_tool_policy_keys () =
         "removed keeper meta fields: tool_preset"
         e
 
-let test_tool_access_legacy_object_empty_tools_preserved () =
-  let meta =
-    match Masc_test_deps.meta_of_json_fixture
-      (`Assoc
-        [
-          ("name", `String "preset-json");
-          ("agent_name", `String "preset-json");
-          ("trace_id", `String "preset-json-trace");
-          ( "tool_access",
-            `Assoc
-              [
-                ("tools", `List []);
-              ] );
-        ])
-    with
-    | Ok meta -> meta
-    | Error e -> failwith e
-  in
-  let names = meta.Masc_mcp.Keeper_meta_contract.tool_access in
-  Alcotest.(check int) "legacy object empty tools preserved" 0 (List.length names)
-
 let test_tool_access_array_empty_json_preserved () =
   let meta =
     match Masc_test_deps.meta_of_json_fixture
@@ -478,7 +430,7 @@ let test_tool_access_array_empty_json_preserved () =
   let names = meta.Masc_mcp.Keeper_meta_contract.tool_access in
   Alcotest.(check int) "custom empty preserved" 0 (List.length names)
 
-let test_tool_access_legacy_object_with_tools_preserved () =
+let test_tool_access_object_with_tools_rejected () =
   match Masc_test_deps.meta_of_json_fixture
     (`Assoc
       [
@@ -488,27 +440,29 @@ let test_tool_access_legacy_object_with_tools_preserved () =
         ("tool_access", `Assoc [ ("tools", `List [ `String "masc_status" ]) ]);
       ])
   with
-  | Error e -> Alcotest.fail e
-  | Ok meta ->
-      let names = meta.Masc_mcp.Keeper_meta_contract.tool_access in
-      Alcotest.(check (list string)) "legacy tools preserved" [ "masc_status" ] names
+  | Ok _ -> Alcotest.fail "expected legacy tool_access object rejection"
+  | Error e ->
+      Alcotest.(check string)
+        "legacy object with tools rejected"
+        "meta parse error: keeper tool_access must be an array of strings (received object)"
+        e
 
-let test_tool_access_legacy_object_without_tools_defaults () =
+let test_tool_access_object_without_tools_rejected () =
   match Masc_test_deps.meta_of_json_fixture
     (`Assoc
       [
         ("name", `String "legacy-no-tools");
         ("agent_name", `String "legacy-no-tools");
         ("trace_id", `String "legacy-no-tools-trace");
-        ("tool_access", `Assoc [ ("preset", `String "full") ]);
+        ("tool_access", `Assoc [ ("unexpected", `String "object") ]);
       ])
   with
+  | Ok _ -> Alcotest.fail "expected legacy tool_access object rejection"
   | Error e ->
-      Alcotest.fail e
-  | Ok meta ->
-      let names = meta.Masc_mcp.Keeper_meta_contract.tool_access in
-      Alcotest.(check bool) "legacy object defaults" true
-        (List.mem "keeper_time_now" names)
+      Alcotest.(check string)
+        "legacy object without tools rejected"
+        "meta parse error: keeper tool_access must be an array of strings (received object)"
+        e
 
 let test_tool_access_invalid_tool_member_rejected () =
   match Masc_test_deps.meta_of_json_fixture
@@ -517,18 +471,14 @@ let test_tool_access_invalid_tool_member_rejected () =
         ("name", `String "invalid-tool-member");
         ("agent_name", `String "invalid-tool-member");
         ("trace_id", `String "invalid-tool-member-trace");
-        ( "tool_access",
-          `Assoc
-            [
-              ("tools", `List [ `String "masc_status"; `Int 1 ]);
-            ] );
+        ("tool_access", `List [ `String "masc_status"; `Int 1 ]);
       ])
   with
   | Ok _ -> Alcotest.fail "expected invalid tool member to fail"
   | Error e ->
       Alcotest.(check string)
         "invalid tool member error"
-        "meta parse error: keeper tool_access.tools[1] must be a string (received int)"
+        "meta parse error: keeper tool_access[1] must be a string (received int)"
         e
 
 let test_allowlist_gates_shard_tools () =
@@ -829,10 +779,10 @@ let () =
         ] );
       ( "preset_policy",
         [
-          Alcotest.test_case "default tool_access exposes masc tools" `Quick
-            test_default_tool_access_exposes_masc;
-          Alcotest.test_case "default tool_access exposes board" `Quick
-            test_messaging_preset_exposes_board;
+          Alcotest.test_case "missing tool_access exposes no masc tools" `Quick
+            test_missing_tool_access_exposes_no_masc_tools;
+          Alcotest.test_case "explicit tool_access exposes board" `Quick
+            test_explicit_tool_access_exposes_board;
           Alcotest.test_case "explicit allowlist opens extra tool" `Quick
             test_explicit_allowlist_opens_extra_tool;
           Alcotest.test_case "custom filters board tools with keeper wrappers" `Quick
@@ -853,24 +803,22 @@ let () =
         ] );
       ( "meta_json",
         [
-          Alcotest.test_case "missing tool_access defaults standard policy" `Quick
-            test_tool_access_missing_defaults_standard_policy;
+          Alcotest.test_case "missing tool_access defaults empty allowlist" `Quick
+            test_tool_access_missing_defaults_empty_allowlist;
+          Alcotest.test_case "typed/string defaults match" `Quick
+            test_typed_and_string_tool_access_defaults_match;
           Alcotest.test_case "read_meta rejects legacy tool keys" `Quick
             test_read_meta_file_rejects_legacy_tool_keys;
-          Alcotest.test_case "read_meta drains legacy tool_access object" `Quick
-            test_read_meta_file_defaults_legacy_tool_access_object_without_tools;
           Alcotest.test_case "read_meta defaults missing tool_access without rewrite" `Quick
             test_read_meta_file_defaults_missing_tool_access_without_rewrite;
           Alcotest.test_case "direct meta_of_json rejects legacy tool keys" `Quick
             test_meta_of_json_rejects_legacy_tool_policy_keys;
-          Alcotest.test_case "legacy object empty tools preserved" `Quick
-            test_tool_access_legacy_object_empty_tools_preserved;
           Alcotest.test_case "array empty json preserved" `Quick
             test_tool_access_array_empty_json_preserved;
-          Alcotest.test_case "legacy object tools preserved" `Quick
-            test_tool_access_legacy_object_with_tools_preserved;
-          Alcotest.test_case "legacy object without tools defaults" `Quick
-            test_tool_access_legacy_object_without_tools_defaults;
+          Alcotest.test_case "legacy object with tools rejected" `Quick
+            test_tool_access_object_with_tools_rejected;
+          Alcotest.test_case "legacy object without tools rejected" `Quick
+            test_tool_access_object_without_tools_rejected;
           Alcotest.test_case "invalid tool member rejected" `Quick
             test_tool_access_invalid_tool_member_rejected;
         ] );

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -938,7 +938,7 @@ runtime_id = "oas-coding_first"
          (Some "oas-coding_first")
          defaults.model)
 
-let test_persona_resolver_defaults_to_research_tool_access () =
+let test_persona_resolver_defaults_to_empty_tool_access () =
   with_personas_dir @@ fun personas_dir ->
   let persona_dir = Filename.concat personas_dir "probe" in
   mkdir_p persona_dir;
@@ -961,8 +961,8 @@ let test_persona_resolver_defaults_to_research_tool_access () =
       let tool_access = Yojson.Safe.Util.member "tool_access" resolved in
       (match tool_access with
        | `List items ->
-           check bool "persona default tool_access is non-empty list" true
-             (List.length items > 0)
+           check int "persona default tool_access is empty" 0
+             (List.length items)
        | _ -> fail "persona default tool_access should be a list")
 
 let test_persona_resolver_rejects_operator_todo_profile () =
@@ -1235,8 +1235,8 @@ let test_persona_resolver_renders_tool_access_array_durable_toml () =
   match KEP.render_keeper_toml_from_resolved_args resolved with
   | Error e -> fail ("render failed: " ^ e)
   | Ok toml ->
-      check bool "renders tools array" true
-        (contains_substring toml "tools = [\"masc_status\"]")
+      check bool "renders tool_access array" true
+        (contains_substring toml "tool_access = [\"masc_status\"]")
 
 let authoring_minimal_profile =
   `Assoc
@@ -1459,19 +1459,17 @@ mention_targets = ["a"]
     check (list string) "surfaces dead config"
       ["keeper.legacy_scope"; "keeper.scope_kind"] unknown
 
-let test_detect_unknown_keys_accepts_tool_access_table () =
+let test_detect_unknown_keys_accepts_tool_access_array () =
   let input = {|
 [keeper]
 goal = "g"
-
-[keeper.tool_access]
-tools = ["masc_status"]
+tool_access = ["masc_status"]
 |} in
   match TL.parse_toml input with
   | Error e -> fail e
   | Ok doc ->
     let unknown = KTP.detect_unknown_keeper_toml_keys doc in
-    check (list string) "tool_access TOML table is canonical" [] unknown
+    check (list string) "tool_access TOML array is canonical" [] unknown
 
 let test_detect_unknown_keys_accepts_loader_base () =
   let input = {|
@@ -1944,8 +1942,8 @@ let () =
             test_detect_unknown_keys_empty_when_all_canonical;
           test_case "flags legacy dead config" `Quick
             test_detect_unknown_keys_flags_legacy_dead_config;
-          test_case "accepts tool_access table" `Quick
-            test_detect_unknown_keys_accepts_tool_access_table;
+          test_case "accepts tool_access array" `Quick
+            test_detect_unknown_keys_accepts_tool_access_array;
           test_case "accepts loader base include" `Quick
             test_detect_unknown_keys_accepts_loader_base;
           test_case "also_allow alias flagged" `Quick
@@ -1998,8 +1996,8 @@ let () =
           test_case "with files" `Quick test_discover_with_files;
           test_case "nonexistent dir" `Quick test_discover_nonexistent_dir;
           test_case "skips bad files" `Quick test_discover_skips_bad_files;
-          test_case "persona resolver defaults to research tool_access" `Quick
-            test_persona_resolver_defaults_to_research_tool_access;
+          test_case "persona resolver defaults to empty tool_access" `Quick
+            test_persona_resolver_defaults_to_empty_tool_access;
           test_case "persona resolver rejects OPERATOR_TODO profile" `Quick
             test_persona_resolver_rejects_operator_todo_profile;
           test_case "persona resolver reports placeholder defaults source" `Quick


### PR DESCRIPTION
## Summary
- make keeper tool access an allowed-tools string array only: JSON `tool_access: []`, TOML `tool_access = []`
- remove nested `tool_access` object/table handling and the old implicit default expansion; missing/null now resolves to an empty allowlist
- update fleet readiness audit and fixtures so missing tool access has no repo-mutation surface unless explicitly allowed

## Validation
- python3 test/test_audit_keeper_fleet_readiness.py
- ruff check scripts/audit-keeper-fleet-readiness.py test/test_audit_keeper_fleet_readiness.py
- ruff format --check scripts/audit-keeper-fleet-readiness.py test/test_audit_keeper_fleet_readiness.py
- ocamlformat --check lib/keeper/keeper_meta_tool_access.ml lib/keeper/keeper_meta_tool_access.mli lib/keeper/keeper_types_profile_toml_parser.ml lib/keeper/agent_tool_persona_runtime.ml test/test_keeper_masc_bridge.ml test/test_keeper_toml.ml
- env DUNE_LOCAL_LOCK=/tmp/codex-tool-access-dune-local.lock MASC_OPAM_LOCK_HELD=1 MASC_SKIP_DEPS_CHECK=1 MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_BUILD_DIR=_build-codex-tool-access scripts/dune-local.sh build test/test_keeper_masc_bridge.exe test/test_keeper_toml.exe
- ./_build-codex-tool-access/default/test/test_keeper_masc_bridge.exe test preset_policy --show-errors
- ./_build-codex-tool-access/default/test/test_keeper_masc_bridge.exe test meta_json 0-2 --show-errors
- ./_build-codex-tool-access/default/test/test_keeper_masc_bridge.exe test meta_json 5-8 --show-errors
- ./_build-codex-tool-access/default/test/test_keeper_toml.exe test unknown_keys --show-errors
- ./_build-codex-tool-access/default/test/test_keeper_toml.exe test discovery --show-errors
- rg -n `tool_access\.kind|tool_access\.preset|removed_tool_access_keys|removed keeper\.tool_access|"kind"; "preset"|\[keeper\.tool_access\]|tool_access\.tools` lib test scripts dashboard/src docs CHANGELOG.md (no matches)