### PR TITLE
fix(telemetry): backward-compatible codec for renamed event variants

### DIFF
--- a/lib/telemetry_eio.ml
+++ b/lib/telemetry_eio.ml
@@ -176,10 +176,40 @@ let report_telemetry_drop ~reason ~path ~detail =
     ~on_drop:(fun () -> observe_telemetry_drop ~reason)
     ~surface:telemetry_eio_surface ~reason ~path ~detail
 
+(** Schema migration: map legacy variant names to current ones.
+
+    The [event] type underwent renames ([Agent_joined] → [Agent_session_bound],
+    [Agent_left] → [Agent_unbound]) but stored JSONL records retain the old
+    names in the wire format.  This normalizes the raw JSON so the
+    auto-generated yojson codec can deserialize it.
+
+    Payload fields are identical — this is a pure rename, no field migration. *)
+let legacy_variant_aliases : (string * string) list = [
+  ("Agent_joined", "Agent_session_bound");
+  ("Agent_left", "Agent_unbound");
+]
+
+let migrate_legacy_event_variant (json : Yojson.Safe.t) =
+  match json with
+  | `Assoc fields ->
+    let migrate_field (key, value) =
+      if key <> "event" then (key, value)
+      else
+        match value with
+        | `List [`String variant; payload] ->
+          (match List.assoc_opt variant legacy_variant_aliases with
+           | Some new_name -> (key, `List [`String new_name; payload])
+           | None -> (key, value))
+        | _ -> (key, value)
+    in
+    `Assoc (List.map migrate_field fields)
+  | _ -> json
+
 let parse_event_records (jsons : Yojson.Safe.t list) : event_record list =
   List.filter_map
     (fun json ->
-      match event_record_of_yojson json with
+      let migrated = migrate_legacy_event_variant json in
+      match event_record_of_yojson migrated with
       | Ok record -> Some record
       | Error msg ->
           report_telemetry_drop
@@ -196,7 +226,8 @@ let read_all_events_from_path (file : string) : event_record list =
     |> List.filter (fun line -> String.trim line <> "")
     |> List.filter_map (fun line ->
            try
-             match event_record_of_yojson (Yojson.Safe.from_string line) with
+             let json = migrate_legacy_event_variant (Yojson.Safe.from_string line) in
+             match event_record_of_yojson json with
              | Ok record -> Some record
              | Error msg ->
                  report_telemetry_drop

--- a/test/test_telemetry_eio_coverage.ml
+++ b/test/test_telemetry_eio_coverage.ml
@@ -347,6 +347,48 @@ let test_event_json_roundtrip () =
        | _ -> fail "wrong event type")
   | Error e -> fail ("json decode failed: " ^ e)
 
+(* Legacy variant migration: Agent_joined → Agent_session_bound.
+   Records written before the rename must still deserialize. *)
+let test_legacy_agent_joined_migration () =
+  let legacy_json =
+    `Assoc [
+      ("timestamp", `Float 1000.0);
+      ("event", `List [
+        `String "Agent_joined";
+        `Assoc [("agent_id", `String "keeper-test"); ("capabilities", `List [])]
+      ]);
+    ]
+  in
+  let parsed = Telemetry_eio.parse_event_records [ legacy_json ] in
+  check int "legacy Agent_joined produces 1 record" 1 (List.length parsed);
+  let record = List.hd parsed in
+  check bool "event is Agent_session_bound" true
+    (match record.event with
+     | Telemetry_eio.Agent_session_bound r ->
+       String.equal r.agent_id "keeper-test" &&
+       List.length r.capabilities = 0
+     | _ -> false)
+
+let test_legacy_agent_left_migration () =
+  let legacy_json =
+    `Assoc [
+      ("timestamp", `Float 1000.0);
+      ("event", `List [
+        `String "Agent_left";
+        `Assoc [("agent_id", `String "keeper-test"); ("reason", `String "leave")]
+      ]);
+    ]
+  in
+  let parsed = Telemetry_eio.parse_event_records [ legacy_json ] in
+  check int "legacy Agent_left produces 1 record" 1 (List.length parsed);
+  let record = List.hd parsed in
+  check bool "event is Agent_unbound" true
+    (match record.event with
+     | Telemetry_eio.Agent_unbound r ->
+       String.equal r.agent_id "keeper-test" &&
+       String.equal r.reason "leave"
+     | _ -> false)
+
 (* Drop observability: malformed payload increments
    masc_persistence_read_drops_total{surface=telemetry_eio,reason=invalid_payload}.
    Pairs with WARN log via Safe_ops.report_persistence_read_drop. *)
@@ -653,6 +695,10 @@ let () =
       test_case "metrics" `Quick test_metrics_json_roundtrip;
       test_case "drop increments persistence_read_drops counter" `Quick
         test_parse_event_records_drop_increments_counter;
+      test_case "legacy Agent_joined migrates to Agent_session_bound" `Quick
+        test_legacy_agent_joined_migration;
+      test_case "legacy Agent_left migrates to Agent_unbound" `Quick
+        test_legacy_agent_left_migration;
     ];
     "event_to_json", [
       test_case "agent_session_bounded" `Quick test_event_to_json_agent_session_bounded;


### PR DESCRIPTION
## Problem

`[WARN] [Misc] [telemetry_eio] persistence read drop (invalid_payload) path=<in-memory>: Telemetry_eio.event` 가 매 이벤트 읽기 사이클마다 1,385건 반복 발생.

## Root Cause

`event` 타입 변형 리네임 시 스키마 마이그레이션 누락:

| JSONL 저장 이름 | 현재 타입 이름 | 영향 |
|---|---|---|
| `Agent_joined` (1,384건) | `Agent_session_bound` | 역직렬화 실패 |
| `Agent_left` (1건) | `Agent_unbound` | 역직렬화 실패 |

`@@deriving yojson` 자동 생성 codec이 옛 변형 이름을 인식하지 못해 `Error` 반환 → `invalid_payload` drop.

## Fix

`migrate_legacy_event_variant`: Yojson AST 레벨에서 옛 변형 이름을 새 이름으로 정규화 후 typed codec에 전달. 두 읽기 경로 모두 적용:
- `parse_event_records` (Dated_jsonl in-memory path)
- `read_all_events_from_path` (legacy single-file path)

## Verification

- `dune build @check` EXIT 0
- `test_telemetry_eio_coverage.exe` 전체 통과 (legacy migration 2케이스 포함)

## Files

- `lib/telemetry_eio.ml`: +35/-2 (migration 함수 + 두 호출점 적용)
- `test/test_telemetry_eio_coverage.ml`: +46 (legacy round-trip 테스트 2개)
