### PR TITLE
fix(keeper): harden typed execute input contract

### DIFF
--- a/lib/keeper/agent_tool_execute_typed_input.ml
+++ b/lib/keeper/agent_tool_execute_typed_input.ml
@@ -200,12 +200,6 @@ let optional_redirect_target ~path fields key =
       (json_type_name value)
 ;;
 
-let normalize_argv_for_executable ~executable argv =
-  match argv with
-  | first :: rest when String.equal (String.trim first) (String.trim executable) -> rest
-  | _ -> argv
-;;
-
 let parse_stage ~path_prefix ~index (value : Yojson.Safe.t) =
   let ( let* ) = Result.bind in
   let path = Printf.sprintf "%s[%d]" path_prefix index in
@@ -213,7 +207,6 @@ let parse_stage ~path_prefix ~index (value : Yojson.Safe.t) =
   let* () = reject_unknown_fields ~path ~allowed:[ "executable"; "argv" ] fields in
   let* executable = required_string ~path fields "executable" in
   let* argv = optional_string_list ~path fields "argv" in
-  let argv = normalize_argv_for_executable ~executable argv in
   Ok { executable; argv }
 ;;
 
@@ -262,12 +255,6 @@ let of_json (json : Yojson.Safe.t) =
   let executable_present = Option.is_some (member fields "executable") in
   let pipeline_value =
     match member fields "pipeline" with
-    | Some (`List []) when executable_present ->
-      (* Some providers/middleware include an empty pipeline array while using
-         the single-process form. Treat only the empty value as absent; a
-         populated pipeline is still mutually exclusive with executable. *)
-      None
-    | Some `Null when executable_present -> None
     | Some value -> Some ("$.pipeline", value)
     | None -> None
   in
@@ -284,7 +271,6 @@ let of_json (json : Yojson.Safe.t) =
   | true, None ->
     let* executable = required_string ~path:"$" fields "executable" in
     let* argv = optional_string_list ~path:"$" fields "argv" in
-    let argv = normalize_argv_for_executable ~executable argv in
     let* stdin = optional_redirect_target ~path:"$" fields "stdin" in
     let* stdout = optional_redirect_target ~path:"$" fields "stdout" in
     let* stderr = optional_redirect_target ~path:"$" fields "stderr" in
@@ -292,16 +278,7 @@ let of_json (json : Yojson.Safe.t) =
   | false, Some (path, value) ->
     let* stages = parse_pipeline ~path value in
     Ok (Pipeline { stages; cwd; env })
-  | false, None -> (
-    let* argv = optional_string_list ~path:"$" fields "argv" in
-    match argv with
-    | executable :: argv ->
-      let argv = normalize_argv_for_executable ~executable argv in
-      let* stdin = optional_redirect_target ~path:"$" fields "stdin" in
-      let* stdout = optional_redirect_target ~path:"$" fields "stdout" in
-      let* stderr = optional_redirect_target ~path:"$" fields "stderr" in
-      Ok (Exec { executable; argv; cwd; env; stdin; stdout; stderr })
-    | [] -> Error "$.executable or $.pipeline is required")
+  | false, None -> Error "$.executable or $.pipeline is required"
 ;;
 
 (* Execve-style: argv tokens pass verbatim to the child process, so

--- a/test/test_agent_tool_execute_typed_input.ml
+++ b/test/test_agent_tool_execute_typed_input.ml
@@ -356,25 +356,22 @@ let test_of_json_exec () =
   | Execute_input.Pipeline _ -> Alcotest.fail "expected Exec"
 ;;
 
-let test_of_json_promotes_argv0_when_executable_missing () =
-  let input =
-    parse_json_exn
+let test_of_json_rejects_argv_without_executable () =
+  let msg =
+    parse_json_error
       (`Assoc
           [ "argv", `List [ `String "git"; `String "status"; `String "--short" ]
           ; "cwd", `String "/tmp"
           ; "env", `Assoc [ "LC_ALL", `String "C" ]
           ])
   in
-  match input with
-  | Execute_input.Exec { executable; argv; cwd; env; _ } ->
-    Alcotest.(check string) "argv0 promoted to executable" "git" executable;
-    Alcotest.(check (list string)) "remaining argv" [ "status"; "--short" ] argv;
-    Alcotest.(check (option string)) "cwd" (Some "/tmp") cwd;
-    Alcotest.(check (list (pair string string))) "env" [ "LC_ALL", "C" ] env
-  | Execute_input.Pipeline _ -> Alcotest.fail "expected Exec"
+  Alcotest.(check bool)
+    "error requires explicit command form"
+    true
+    (String_util.contains_substring_ci msg "$.executable or $.pipeline is required")
 ;;
 
-let test_of_json_drops_duplicate_executable_argv0 () =
+let test_of_json_preserves_duplicate_executable_argv0 () =
   let input =
     parse_json_exn
       (`Assoc
@@ -385,7 +382,10 @@ let test_of_json_drops_duplicate_executable_argv0 () =
   match input with
   | Execute_input.Exec { executable; argv; _ } ->
     Alcotest.(check string) "executable" "cat" executable;
-    Alcotest.(check (list string)) "argv" [ "repos/masc-mcp/README.md" ] argv
+    Alcotest.(check (list string))
+      "argv remains caller-authored"
+      [ "cat"; "repos/masc-mcp/README.md" ]
+      argv
   | Execute_input.Pipeline _ -> Alcotest.fail "expected Exec"
 ;;
 
@@ -399,20 +399,19 @@ let test_of_json_rejects_empty_argv_without_executable () =
     (String_util.contains_substring_ci msg "$.executable or $.pipeline is required")
 ;;
 
-let test_of_json_ignores_empty_pipeline_with_executable () =
-  let input =
-    parse_json_exn
+let test_of_json_rejects_empty_pipeline_with_executable () =
+  let msg =
+    parse_json_error
       (`Assoc
           [ "executable", `String "echo"
           ; "argv", `List [ `String "hello" ]
           ; "pipeline", `List []
           ])
   in
-  match input with
-  | Execute_input.Exec { executable; argv; _ } ->
-    Alcotest.(check string) "executable" "echo" executable;
-    Alcotest.(check (list string)) "argv" [ "hello" ] argv
-  | Execute_input.Pipeline _ -> Alcotest.fail "expected Exec"
+  Alcotest.(check bool)
+    "error rejects mutually exclusive fields"
+    true
+    (String_util.contains_substring_ci msg "mutually exclusive")
 ;;
 
 let test_of_json_keeps_empty_exec_for_validation () =
@@ -469,7 +468,7 @@ let test_of_json_pipeline () =
   | Execute_input.Exec _ -> Alcotest.fail "expected Pipeline"
 ;;
 
-let test_of_json_pipeline_drops_duplicate_stage_argv0 () =
+let test_of_json_pipeline_preserves_duplicate_stage_argv0 () =
   let input =
     parse_json_exn
       (`Assoc
@@ -490,8 +489,14 @@ let test_of_json_pipeline_drops_duplicate_stage_argv0 () =
   | Execute_input.Pipeline { stages; _ } ->
     (match stages with
      | [ first; second ] ->
-       Alcotest.(check (list string)) "first argv" [ "hello" ] first.argv;
-       Alcotest.(check (list string)) "second argv" [ "-c" ] second.argv
+       Alcotest.(check (list string))
+         "first argv remains caller-authored"
+         [ "printf"; "hello" ]
+         first.argv;
+       Alcotest.(check (list string))
+         "second argv remains caller-authored"
+         [ "wc"; "-c" ]
+         second.argv
      | _ -> Alcotest.fail "expected exactly two stages")
   | Execute_input.Exec _ -> Alcotest.fail "expected Pipeline"
 ;;
@@ -1135,21 +1140,21 @@ let suite =
           test_not_allowlisted_hints_self_correction
       ; Alcotest.test_case "of_json_exec" `Quick test_of_json_exec
       ; Alcotest.test_case
-          "of_json_promotes_argv0_when_executable_missing"
+          "of_json_rejects_argv_without_executable"
           `Quick
-          test_of_json_promotes_argv0_when_executable_missing
+          test_of_json_rejects_argv_without_executable
       ; Alcotest.test_case
-          "of_json_drops_duplicate_executable_argv0"
+          "of_json_preserves_duplicate_executable_argv0"
           `Quick
-          test_of_json_drops_duplicate_executable_argv0
+          test_of_json_preserves_duplicate_executable_argv0
       ; Alcotest.test_case
           "of_json_rejects_empty_argv_without_executable"
           `Quick
           test_of_json_rejects_empty_argv_without_executable
       ; Alcotest.test_case
-          "of_json_ignores_empty_pipeline_with_executable"
+          "of_json_rejects_empty_pipeline_with_executable"
           `Quick
-          test_of_json_ignores_empty_pipeline_with_executable
+          test_of_json_rejects_empty_pipeline_with_executable
       ; Alcotest.test_case
           "of_json_keeps_empty_exec_for_validation"
           `Quick
@@ -1160,9 +1165,9 @@ let suite =
           `Quick
           test_of_json_keeps_empty_pipeline_stage_for_validation
       ; Alcotest.test_case
-          "of_json_pipeline_drops_duplicate_stage_argv0"
+          "of_json_pipeline_preserves_duplicate_stage_argv0"
           `Quick
-          test_of_json_pipeline_drops_duplicate_stage_argv0
+          test_of_json_pipeline_preserves_duplicate_stage_argv0
       ; Alcotest.test_case
           "of_json_rejects_cmd_string_only"
           `Quick


### PR DESCRIPTION
## Summary

- Remove typed Execute parser compatibility that promoted top-level `argv[0]` into `executable`.
- Stop stripping duplicated executable tokens from `Exec` and `Pipeline` argv.
- Reject `executable` + `pipeline` consistently, including empty pipeline arrays.

## Product impact

Malformed tool execution payloads now fail at the typed JSON boundary instead of being silently rewritten before Shell IR lowering. The runtime parser now matches the public `tool_execute` schema: callers must choose explicit `executable`/`argv` or explicit `pipeline`.

## Evidence

- `ocamlformat --check lib/keeper/agent_tool_execute_typed_input.ml test/test_agent_tool_execute_typed_input.ml`
- `git diff --check origin/main..HEAD`
- `scripts/audit-shell-ir-consumption.sh --baseline scripts/shell-ir-consumption-baseline.json`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_BUILD_DIR=_build_shell_ir_tools_next dune build --root . ./test/test_agent_tool_execute_typed_input.exe`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_BUILD_DIR=_build_shell_ir_tools_next dune exec --root . ./test/test_agent_tool_execute_typed_input.exe` (49 tests)

## Direct evidence

schema_version: 1
direct_ratio: 5/5
provenance: direct

The commands in Evidence were run locally after rebasing onto `origin/main`; all passed.

## Review evidence

Self-reviewed the parser contract against `lib/tool_shard_types_schemas_execute.ml` and `lib/keeper/agent_tool_execute_typed_input.mli`. The removed behavior was compatibility normalization below the advertised schema boundary.

## Linked issue

n/a

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`shell-ir-tools-next-20260601` → `main` · 1 commit(s) · synced 2026-06-01T04:28:54Z

| sha | subject | date |
|---|---|---|
| `0671517f3` | fix(keeper): harden typed execute input contract | 2026-06-01 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->