### PR TITLE
Reduce keeper meta drift log noise

### DIFF
--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -181,10 +181,6 @@ let ensure_keeper_meta config name =
     let target_social_model =
       apply_default defaults.social_model meta.social_model
       |> Keeper_social_model.normalize_social_model in
-    let target_runtime_id =
-      effective_declarative_runtime_id defaults meta
-    in
-    let resolved_target_runtime_id = target_runtime_id in
     (* --- Personality --- *)
     let target_goal = apply_default defaults.goal meta.goal in
     let target_short_goal = apply_default defaults.short_goal meta.short_goal in
@@ -277,125 +273,8 @@ let ensure_keeper_meta config name =
       | [] -> meta.oas_env
       | env -> env
     in
-    (* --- Change detection by category --- *)
-    let proactive_changed =
-      meta.proactive.enabled <> target_proactive
-      || meta.proactive.idle_sec <> target_idle_sec
-      || meta.proactive.cooldown_sec <> target_cooldown_sec in
-    let denylist_changed = meta.tool_denylist <> target_denylist in
-    let social_model_changed = meta.social_model <> target_social_model in
-    (* [meta runtime id] may be a raw TOML/JSON value while
-       [resolved_target_runtime_id] is the validated runtime catalog
-       name. Normalize the meta side only so alias cleanup does not
-       register as a semantic change. *)
-    let runtime_changed =
-      String.trim (runtime_id_of_meta meta)
-      <> resolved_target_runtime_id
-    in
-    (* #10061: persisted state vs TOML source can differ by a single
-       trailing newline when OCaml string literals round-trip through
-       the TOML writer (heredoc [""" … """] closing sequence drops the
-       final newline) or through an older binary that wrote the field
-       with extra whitespace. The semantic content of these prose
-       fields does not care about trailing whitespace, yet a byte-
-       level [<>] compare marks every 30 s hot-reload tick as a
-       personality change, producing a re-sync storm (2880 redundant
-       writes/day on nick0cave alone; other 13 keepers: 0 events).
-       Normalise both sides with [String.trim] so only meaningful
-       content drives resync. *)
-    (* #10269: name the diverging fields so the re-sync log carries
-       the diagnostic upstream (length and first-diff offset) instead
-       of the opaque [personality] category. *)
-    let personality_diff_entries =
-      personality_diff_summary
-        [
-          ("goal", meta.goal, target_goal);
-          ("short_goal", meta.short_goal, target_short_goal);
-          ("mid_goal", meta.mid_goal, target_mid_goal);
-          ("long_goal", meta.long_goal, target_long_goal);
-          ("will", meta.will, target_will);
-          ("needs", meta.needs, target_needs);
-          ("desires", meta.desires, target_desires);
-          ("instructions", meta.instructions, target_instructions);
-        ]
-    in
-    let personality_changed = personality_diff_entries <> [] in
-    let policy_changed =
-      meta.autoboot_enabled <> target_autoboot_enabled
-      || meta.mention_targets <> target_mention_targets
-      || meta.active_goal_ids <> target_active_goal_ids
-      || meta.tool_access <> target_tool_access
-      || meta.sandbox_profile <> target_sandbox_profile
-      || meta.network_mode <> target_network_mode
-      || meta.allowed_paths <> target_allowed_paths
-      || meta.always_approve <> target_always_approve in
-    let telemetry_changed =
-      meta.telemetry_feedback_enabled <> target_tf_enabled
-      || meta.telemetry_feedback_window_hours <> target_tf_window in
-    let timeout_policy_changed =
-      meta.per_provider_timeout_s <> target_per_provider_timeout in
-    let oas_env_changed = meta.oas_env <> target_oas_env in
-    let any_changed =
-      proactive_changed || denylist_changed
-      || social_model_changed
-      || runtime_changed
-      || personality_changed || policy_changed
-      || telemetry_changed || timeout_policy_changed || oas_env_changed in
-
-    if any_changed then begin
-      let cats = List.filter_map Fun.id [
-        (if proactive_changed then Some "proactive" else None);
-        (if denylist_changed then Some "denylist" else None);
-        (if social_model_changed then Some "social_model" else None);
-        (if runtime_changed then Some "runtime" else None);
-        (if personality_changed then
-           Some
-             (Printf.sprintf "personality:%s"
-                (String.concat "+" personality_diff_entries))
-        else None);
-        (if policy_changed then Some "policy" else None);
-        (if telemetry_changed then Some "telemetry" else None);
-        (if timeout_policy_changed then Some "timeout_policy" else None);
-        (if oas_env_changed then Some "oas_env" else None);
-      ] in
-      Log.Keeper.info
-        "ensure_keeper_meta: re-syncing [%s] for %s"
-        (String.concat "," cats)
-        meta.name;
-      (* #10269: nick0cave alone re-syncs [personality] on every reconcile
-         tick (~371 events / 3000 logs).  When personality is in [cats],
-         emit a follow-up info line listing the specific fields that
-         differ along with their raw lengths and trim-normalised
-         previews so root cause (TOML triple-quote, JSON encoding drift,
-         persona overlay) is visible without code-reading. *)
-      if personality_changed then begin
-        let diffs =
-          List.filter_map Fun.id
-            [
-              personality_field_diff_summary ~field:"goal"
-                ~current:meta.goal ~target:target_goal;
-              personality_field_diff_summary ~field:"short_goal"
-                ~current:meta.short_goal ~target:target_short_goal;
-              personality_field_diff_summary ~field:"mid_goal"
-                ~current:meta.mid_goal ~target:target_mid_goal;
-              personality_field_diff_summary ~field:"long_goal"
-                ~current:meta.long_goal ~target:target_long_goal;
-              personality_field_diff_summary ~field:"will"
-                ~current:meta.will ~target:target_will;
-              personality_field_diff_summary ~field:"needs"
-                ~current:meta.needs ~target:target_needs;
-              personality_field_diff_summary ~field:"desires"
-                ~current:meta.desires ~target:target_desires;
-              personality_field_diff_summary ~field:"instructions"
-                ~current:meta.instructions ~target:target_instructions;
-            ]
-        in
-        Log.Keeper.info
-          "ensure_keeper_meta: personality drift fields for %s: %s"
-          meta.name
-          (String.concat "; " diffs)
-      end;
-      let updated = { meta with
+    let overlayed =
+      { meta with
         proactive = {
           enabled = target_proactive;
           idle_sec = target_idle_sec;
@@ -424,19 +303,47 @@ let ensure_keeper_meta config name =
         per_provider_timeout_s = target_per_provider_timeout;
         always_approve = target_always_approve;
         oas_env = target_oas_env;
-        updated_at = now_iso ();
-      } in
+      }
+    in
+    (* Runtime JSON intentionally omits TOML-owned config/personality
+       fields.  They must be overlaid into the returned meta for the
+       live registry, but comparing those omitted fields against TOML
+       would classify every reconcile tick as a write-worthy drift.
+       Only fields serialized by [meta_to_json] should drive a disk
+       write here. *)
+    let active_goal_ids_changed =
+      meta.active_goal_ids <> target_active_goal_ids
+    in
+    let oas_env_changed = meta.oas_env <> target_oas_env in
+    let persistent_changed = active_goal_ids_changed || oas_env_changed in
+    let overlay_without_persistent_changes =
+      { overlayed with
+        active_goal_ids = meta.active_goal_ids;
+        oas_env = meta.oas_env;
+      }
+    in
+
+    if persistent_changed then begin
+      let cats = List.filter_map Fun.id [
+        (if active_goal_ids_changed then Some "active_goal_ids" else None);
+        (if oas_env_changed then Some "oas_env" else None);
+      ] in
+      Log.Keeper.info
+        "ensure_keeper_meta: re-syncing [%s] for %s"
+        (String.concat "," cats)
+        meta.name;
+      let updated = { overlayed with updated_at = now_iso () } in
       match write_meta config updated with
-      | Ok () -> Ok updated
+      | Ok () -> Ok { updated with meta_version = updated.meta_version + 1 }
       | Error e ->
         Prometheus.inc_counter
           Keeper_metrics.(to_string WriteMetaFailures)
           ~labels:[("keeper", updated.name); ("phase", "ensure_meta_resync")]
           ();
         Log.Keeper.warn "ensure_keeper_meta: write_meta re-sync failed: %s" e;
-        Ok meta
+        Ok overlay_without_persistent_changes
     end
-    else Ok meta))
+    else Ok overlayed))
   | Ok None ->
     Log.Keeper.warn
       "ensure_keeper_meta: no persistent meta for %s — run keeper_up to initialize" name;

--- a/lib/keeper/keeper_runtime_personality_diff.ml
+++ b/lib/keeper/keeper_runtime_personality_diff.ml
@@ -53,24 +53,66 @@ let personality_diff_summary fields =
       personality_field_diff_entry name current target)
     fields
 
+let utf8_char_width s i =
+  let byte = Char.code s.[i] in
+  if byte land 0x80 = 0 then 1
+  else if byte land 0xE0 = 0xC0 then 2
+  else if byte land 0xF0 = 0xE0 then 3
+  else if byte land 0xF8 = 0xF0 then 4
+  else 1
+
+let truncate_utf8_prefix ~max_bytes s =
+  let len = String.length s in
+  if len <= max_bytes then s, false
+  else
+    let rec loop i =
+      if i >= len then i
+      else
+        let next = i + utf8_char_width s i in
+        if next > max_bytes then i else loop next
+    in
+    String.sub s 0 (loop 0), true
+
+let quote_log_preview s =
+  let buf = Buffer.create (String.length s + 2) in
+  Buffer.add_char buf '"';
+  String.iter
+    (fun c ->
+       match c with
+       | '"' -> Buffer.add_string buf "\\\""
+       | '\\' -> Buffer.add_string buf "\\\\"
+       | '\n' -> Buffer.add_string buf "\\n"
+       | '\r' -> Buffer.add_string buf "\\r"
+       | '\t' -> Buffer.add_string buf "\\t"
+       | c ->
+         let code = Char.code c in
+         if code < 0x20 || code = 0x7F
+         then Buffer.add_string buf (Printf.sprintf "\\x%02x" code)
+         else Buffer.add_char buf c)
+    s;
+  Buffer.add_char buf '"';
+  Buffer.contents buf
+
 (** Per-call helper used at runtime re-sync sites.  Different output
     shape from [personality_field_diff_entry]:
     [field(raw_meta_len=N raw_target_len=N trim_meta=S trim_target=S)]
     so dashboards can distinguish raw-length drift from trimmed-content
     drift.  Returns [None] when the two trim-equal so steady-state
     keepers stay quiet.  Trimmed previews truncated to 32 bytes each
-    to keep a wide [instructions] field log-friendly. *)
+    to keep a wide [instructions] field log-friendly.  UTF-8 bytes are
+    preserved for operator readability; only quotes, backslashes, and
+    control characters are escaped. *)
 let personality_field_diff_summary ~field ~current ~target =
   if personality_text_equal current target then None
   else
     let preview s =
       let trimmed = String.trim s in
-      if String.length trimmed <= 32 then trimmed
-      else String.sub trimmed 0 32 ^ "..."
+      let prefix, truncated = truncate_utf8_prefix ~max_bytes:32 trimmed in
+      quote_log_preview (if truncated then prefix ^ "..." else prefix)
     in
     Some
       (Printf.sprintf
-         "%s(raw_meta_len=%d raw_target_len=%d trim_meta=%S trim_target=%S)"
+         "%s(raw_meta_len=%d raw_target_len=%d trim_meta=%s trim_target=%s)"
          field
          (String.length current) (String.length target)
          (preview current) (preview target))

--- a/test/test_keeper_runtime_denylist.ml
+++ b/test/test_keeper_runtime_denylist.ml
@@ -21,6 +21,36 @@ let write_file path content =
   output_string oc content;
   close_out oc
 
+let runtime_toml =
+  {|[runtime]
+default = "test.local"
+
+[providers.test]
+display-name = "Test"
+protocol = "provider_d-http"
+endpoint = "http://127.0.0.1:1"
+
+[models.local]
+api-name = "local"
+max-context = 4096
+tools-support = true
+streaming = true
+
+[test.local]
+is-default = true
+max-concurrent = 1
+|}
+
+let with_runtime_default f =
+  let path = Filename.temp_file "keeper-runtime-denylist-runtime" ".toml" in
+  write_file path runtime_toml;
+  Fun.protect
+    ~finally:(fun () -> try Sys.remove path with Sys_error _ -> ())
+    (fun () ->
+      match Runtime.init_default ~config_path:path with
+      | Ok () -> f ()
+      | Error e -> fail ("Runtime.init_default failed: " ^ e))
+
 let with_config_dir f =
   with_temp_dir "keeper-runtime-denylist-config" @@ fun config_dir ->
   let original = Sys.getenv_opt "MASC_CONFIG_DIR" in
@@ -38,15 +68,18 @@ let with_config_dir f =
       Config_dir_resolver.reset ();
       f config_dir)
 
-(** Regression test: ensure_keeper_meta must overwrite a stale persisted
-    tool_denylist with the value from config/keepers/<name>.toml on bootstrap.
+(** Regression test: ensure_keeper_meta must overlay a TOML-owned
+    tool_denylist at runtime without trying to persist it back into the
+    runtime-only JSON file on every reconcile tick.
 
     Steps:
     1. Write a keeper TOML declaring tool_denylist = ["toml-tool-x", "toml-tool-y"]
     2. Write keeper meta with a different stale denylist = ["old-stale-tool"]
     3. Call ensure_keeper_meta
-    4. Assert the returned (and persisted) denylist matches the TOML *)
-let test_ensure_keeper_meta_resyncs_denylist_from_toml () =
+    4. Assert the returned meta has the TOML denylist while persisted JSON
+       remains runtime-only. *)
+let test_ensure_keeper_meta_overlays_denylist_from_toml () =
+  with_runtime_default @@ fun () ->
   with_temp_dir "keeper-runtime-denylist-workspace" @@ fun workspace_dir ->
   with_config_dir @@ fun config_dir ->
   Fs_compat.clear_fs ();
@@ -60,6 +93,7 @@ let test_ensure_keeper_meta_resyncs_denylist_from_toml () =
     (Filename.concat keepers_toml_dir (keeper_name ^ ".toml"))
     {|[keeper]
 goal = "Test denylist resync"
+sandbox_profile = "local"
 tool_denylist = ["toml-tool-x", "toml-tool-y"]
 |};
   (* 2. Write keeper meta with a stale denylist *)
@@ -82,26 +116,84 @@ tool_denylist = ["toml-tool-x", "toml-tool-y"]
   (match Keeper_meta_store.write_meta ~force:true config initial_meta with
   | Error e -> fail ("write_meta failed: " ^ e)
   | Ok () -> ());
-  (* 3. Call ensure_keeper_meta — should resync denylist from TOML *)
+  (* 3. Call ensure_keeper_meta — should overlay denylist from TOML *)
   (match Keeper_runtime.ensure_keeper_meta config keeper_name with
   | Error e -> fail ("ensure_keeper_meta failed: " ^ e)
   | Ok updated ->
       (* 4a. Returned meta has TOML denylist *)
       check
         (list string)
-        "returned meta denylist resynced from TOML"
+        "returned meta denylist overlaid from TOML"
         [ "toml-tool-x"; "toml-tool-y" ]
         updated.Keeper_meta_contract.tool_denylist;
-      (* 4b. Persisted meta also has TOML denylist *)
+      (* 4b. Persisted meta remains runtime-only, so TOML-owned denylist
+         does not cause a reconcile write loop. *)
       (match Keeper_meta_store.read_meta config keeper_name with
       | Error e -> fail ("read_meta failed: " ^ e)
       | Ok None -> fail "meta should exist after ensure_keeper_meta"
       | Ok (Some persisted) ->
           check
             (list string)
-            "persisted meta denylist resynced from TOML"
-            [ "toml-tool-x"; "toml-tool-y" ]
-            persisted.Keeper_meta_contract.tool_denylist))
+            "persisted meta does not store TOML denylist"
+            []
+            persisted.Keeper_meta_contract.tool_denylist;
+          check int "no TOML-only write bump" (initial_meta.meta_version + 1)
+            persisted.Keeper_meta_contract.meta_version))
+
+let test_ensure_keeper_meta_persists_active_goal_ids () =
+  with_runtime_default @@ fun () ->
+  with_temp_dir "keeper-runtime-active-goal-workspace" @@ fun workspace_dir ->
+  with_config_dir @@ fun config_dir ->
+  Fs_compat.clear_fs ();
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let keeper_name = "active-goal-resync-test" in
+  let keepers_toml_dir = Filename.concat config_dir "keepers" in
+  Unix.mkdir keepers_toml_dir 0o755;
+  write_file
+    (Filename.concat keepers_toml_dir (keeper_name ^ ".toml"))
+    {|[keeper]
+goal = "Test active goal resync"
+sandbox_profile = "local"
+active_goal_ids = ["goal-runtime"]
+|};
+  let config = Workspace.default_config workspace_dir in
+  let initial_meta =
+    match
+      Masc_test_deps.meta_of_json_fixture
+        (`Assoc
+          [
+            ("name", `String keeper_name);
+            ("agent_name", `String keeper_name);
+            ("trace_id", `String "trace-active-goal-resync");
+          ])
+    with
+    | Ok meta -> meta
+    | Error e -> fail ("meta_of_json failed: " ^ e)
+  in
+  (match Keeper_meta_store.write_meta ~force:true config initial_meta with
+  | Error e -> fail ("write_meta failed: " ^ e)
+  | Ok () -> ());
+  (match Keeper_runtime.ensure_keeper_meta config keeper_name with
+  | Error e -> fail ("ensure_keeper_meta failed: " ^ e)
+  | Ok updated ->
+      check
+        (list string)
+        "returned meta active_goal_ids overlaid from TOML"
+        [ "goal-runtime" ]
+        updated.Keeper_meta_contract.active_goal_ids;
+      (match Keeper_meta_store.read_meta config keeper_name with
+      | Error e -> fail ("read_meta failed: " ^ e)
+      | Ok None -> fail "meta should exist after ensure_keeper_meta"
+      | Ok (Some persisted) ->
+          check
+            (list string)
+            "persisted meta keeps active_goal_ids"
+            [ "goal-runtime" ]
+            persisted.Keeper_meta_contract.active_goal_ids;
+          check int "persisted write bumps meta_version"
+            (initial_meta.meta_version + 2)
+            persisted.Keeper_meta_contract.meta_version))
 
 let () =
   run "Keeper_runtime denylist resync"
@@ -109,8 +201,12 @@ let () =
       ( "ensure_keeper_meta",
         [
           test_case
-            "resyncs stale persisted denylist from TOML on bootstrap"
+            "overlays TOML denylist without persisting config fields"
             `Quick
-            test_ensure_keeper_meta_resyncs_denylist_from_toml;
+            test_ensure_keeper_meta_overlays_denylist_from_toml;
+          test_case
+            "persists active_goal_ids from TOML on bootstrap"
+            `Quick
+            test_ensure_keeper_meta_persists_active_goal_ids;
         ] );
     ]

--- a/test/test_personality_field_diff_10269.ml
+++ b/test/test_personality_field_diff_10269.ml
@@ -66,6 +66,30 @@ let test_long_field_truncates_preview () =
       check bool "untruncated preview must not appear" false
         (Astring.String.is_infix ~affix:long_a s)
 
+let test_utf8_preview_stays_readable () =
+  match
+    Kr.personality_field_diff_summary
+      ~field:"goal" ~current:"" ~target:"masc-mcp의 Telemetry와 Logging"
+  with
+  | None -> fail "expected Some summary for missing UTF-8 target"
+  | Some s ->
+      check bool "Korean UTF-8 is preserved" true
+        (Astring.String.is_infix ~affix:"masc-mcp의" s);
+      check bool "Korean bytes are not octal-escaped" false
+        (Astring.String.is_infix ~affix:"\\236" s)
+
+let test_control_chars_still_escape () =
+  match
+    Kr.personality_field_diff_summary
+      ~field:"instructions" ~current:"alpha" ~target:"line1\n\"line2\""
+  with
+  | None -> fail "expected Some summary for escaped-control target"
+  | Some s ->
+      check bool "newline escaped" true
+        (Astring.String.is_infix ~affix:"line1\\n" s);
+      check bool "quote escaped" true
+        (Astring.String.is_infix ~affix:"\\\"line2\\\"" s)
+
 let () =
   run "personality_field_diff_10269" [
     ("diff_summary", [
@@ -77,5 +101,9 @@ let () =
           test_length_drift_returns_summary;
         test_case "long preview is truncated" `Quick
           test_long_field_truncates_preview;
+        test_case "UTF-8 preview stays readable" `Quick
+          test_utf8_preview_stays_readable;
+        test_case "control chars still escape" `Quick
+          test_control_chars_still_escape;
       ]);
   ]


### PR DESCRIPTION
## Summary

- Stop treating TOML-only keeper config/personality overlays as write-worthy `ensure_keeper_meta` drift.
- Preserve UTF-8 in personality diff previews while still escaping control characters.
- Add focused regression coverage for TOML overlay behavior and readable UTF-8 previews.

## Product impact

Reduces keeper startup/reconcile log noise such as repeated `raw_meta_len=0` personality drift lines and escaped Korean byte sequences.

## Evidence

- `scripts/dune-local.sh build test/test_keeper_runtime_denylist.exe test/test_personality_field_diff_10269.exe`
- `_build/default/test/test_personality_field_diff_10269.exe`
- `_build/default/test/test_keeper_runtime_denylist.exe`
- `git diff --check`

## Direct evidence

schema_version: 1
direct_ratio: 4/4
provenance: direct

Focused local commands above were run in the PR worktree. The first build had to wait behind unrelated live Dune processes; the final focused build and both test executables passed.

## Review evidence

- Verified TOML-only `tool_denylist` overlays into returned meta without bumping persisted JSON `meta_version`.
- Verified persisted `active_goal_ids` still writes through and bumps `meta_version`.
- Verified Korean UTF-8 preview text remains readable and no longer appears as OCaml octal escapes.
- Verified newline and quote characters remain escaped in preview output.

## Linked issue

N/A

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`codex/keeper-drift-log-readable` → `main` · 1 commit(s) · synced 2026-06-01T04:31:25Z

| sha | subject | date |
|---|---|---|
| `41874a0c8` | Reduce keeper meta drift log noise | 2026-06-01 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->