### PR TITLE
[codex] Expose internal MCP auth health

### DIFF
--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -144,10 +144,56 @@ let health_uptime_secs = Server_routes_http_runtime_health_helpers.health_uptime
 let health_uptime_string = Server_routes_http_runtime_health_helpers.health_uptime_string
 let protocol_json = Server_routes_http_runtime_health_helpers.protocol_json
 let quick_gc_json = Server_routes_http_runtime_health_helpers.quick_gc_json
+
+let internal_mcp_auth_json ~base_path =
+  let env_key = Auth.internal_keeper_token_env_key in
+  let env_token =
+    match Sys.getenv_opt env_key with
+    | Some raw ->
+      let trimmed = String.trim raw in
+      if String.equal trimmed "" then None else Some trimmed
+    | None -> None
+  in
+  let env_token_present = Option.is_some env_token in
+  let token_hash_file_present =
+    Sys.file_exists (Auth.internal_keeper_token_hash_file base_path)
+  in
+  let env_token_verifies =
+    match env_token with
+    | Some token -> Auth.verify_internal_keeper_token base_path ~token
+    | None -> false
+  in
+  let ready = env_token_present && token_hash_file_present && env_token_verifies in
+  let missing =
+    [ (not env_token_present, "env_token")
+    ; (not token_hash_file_present, "token_hash_file")
+    ; (env_token_present && token_hash_file_present && not env_token_verifies, "token_hash_match")
+    ]
+    |> List.filter_map (fun (missing, name) -> if missing then Some name else None)
+  in
+  let status = if ready then "ok" else "degraded" in
+  let next_action =
+    if ready then "none" else "sync_internal_keeper_token_and_restart_runtime"
+  in
+  `Assoc
+    [ "schema", `String "masc.internal_mcp_auth.v1"
+    ; "status", `String status
+    ; "source", `String "running_process_env_and_auth_hash"
+    ; "env_key", `String env_key
+    ; "env_token_present", `Bool env_token_present
+    ; "token_hash_file_present", `Bool token_hash_file_present
+    ; "env_token_verifies", `Bool env_token_verifies
+    ; "keeper_internal_runtime_mcp_ready", `Bool ready
+    ; "missing", `List (List.map (fun name -> `String name) missing)
+    ; "operator_action_required", `Bool (not ready)
+    ; "next_action", `String next_action
+    ]
+
 let make_health_probe_fields ?(listener = "http/1.1") ?full_health_url
     ?(health_detail = "probe") request =
   let uptime_secs = health_uptime_secs () in
   let build = Build_identity.current () in
+  let path_diagnostics = health_path_diagnostics () in
   let full_health_url_fields =
     match full_health_url with
     | Some url -> [ ("full_health_url", `String url) ]
@@ -165,7 +211,9 @@ let make_health_probe_fields ?(listener = "http/1.1") ?full_health_url
       ("protocol", protocol_json ~listener);
       ("transport", transport_json request);
       ("http_listener", Transport_metrics.http_listener_json ());
-      ("paths", Server_base_path_diagnostics.to_yojson (health_path_diagnostics ()));
+      ("paths", Server_base_path_diagnostics.to_yojson path_diagnostics);
+      ( "internal_mcp_auth"
+      , internal_mcp_auth_json ~base_path:path_diagnostics.effective_base_path );
       ("uptime", `String (health_uptime_string uptime_secs));
       ("sse_clients", `Int (Sse.client_count ()));
       ("startup", Server_startup_state.to_yojson ());
@@ -323,6 +371,8 @@ let make_health_json ?(listener = "http/1.1") ?section_timings_ref request =
     ("transport", transport_json request);
     ("http_listener", Transport_metrics.http_listener_json ());
     ("paths", Server_base_path_diagnostics.to_yojson path_diagnostics);
+    ( "internal_mcp_auth"
+    , internal_mcp_auth_json ~base_path:path_diagnostics.effective_base_path );
     ( "runtime_truth"
     , runtime_truth_json ~build ~path_diagnostics ~keeper_fibers
         ~fd_accountant:fd_accountant_json );

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -145,6 +145,18 @@ let health_uptime_string = Server_routes_http_runtime_health_helpers.health_upti
 let protocol_json = Server_routes_http_runtime_health_helpers.protocol_json
 let quick_gc_json = Server_routes_http_runtime_health_helpers.quick_gc_json
 
+let internal_keeper_token_hash_opt ~base_path =
+  let hash_file = Auth.internal_keeper_token_hash_file base_path in
+  if Sys.file_exists hash_file then
+    try
+      let hash =
+        In_channel.with_open_bin hash_file In_channel.input_all |> String.trim
+      in
+      if String.equal hash "" then None else Some hash
+    with Sys_error _ -> None
+  else
+    None
+
 let internal_mcp_auth_json ~base_path =
   let env_key = Auth.internal_keeper_token_env_key in
   let env_token =
@@ -155,24 +167,24 @@ let internal_mcp_auth_json ~base_path =
     | None -> None
   in
   let env_token_present = Option.is_some env_token in
-  let token_hash_file_present =
-    Sys.file_exists (Auth.internal_keeper_token_hash_file base_path)
-  in
+  let token_hash = internal_keeper_token_hash_opt ~base_path in
+  let token_hash_file_present = Option.is_some token_hash in
   let env_token_verifies =
-    match env_token with
-    | Some token -> Auth.verify_internal_keeper_token base_path ~token
-    | None -> false
+    match env_token, token_hash with
+    | Some token, Some hash -> String.equal hash (Auth.sha256_hash token)
+    | _ -> false
   in
   let ready = env_token_present && token_hash_file_present && env_token_verifies in
   let missing =
     [ (not env_token_present, "env_token")
     ; (not token_hash_file_present, "token_hash_file")
-    ; (env_token_present && token_hash_file_present && not env_token_verifies, "token_hash_match")
+    ; ( env_token_present && token_hash_file_present && not env_token_verifies
+      , "token_hash_mismatch" )
     ]
     |> List.filter_map (fun (missing, name) -> if missing then Some name else None)
   in
   let status = if ready then "ok" else "degraded" in
-  let next_action =
+  let operator_next_action =
     if ready then "none" else "sync_internal_keeper_token_and_restart_runtime"
   in
   `Assoc
@@ -186,7 +198,7 @@ let internal_mcp_auth_json ~base_path =
     ; "keeper_internal_runtime_mcp_ready", `Bool ready
     ; "missing", `List (List.map (fun name -> `String name) missing)
     ; "operator_action_required", `Bool (not ready)
-    ; "next_action", `String next_action
+    ; "operator_next_action", `String operator_next_action
     ]
 
 let make_health_probe_fields ?(listener = "http/1.1") ?full_health_url

--- a/lib/server/server_routes_http_runtime.mli
+++ b/lib/server/server_routes_http_runtime.mli
@@ -121,8 +121,8 @@ val make_health_json :
 
     [status] / [server] / [version] / [release_version] /
     [build] / [protocol] (default + listener + supported list) /
-    [transport] / [paths] / [uptime] / [sse_clients] /
-    [startup] / [subsystems] / [feature_flags] / [gc] /
+    [transport] / [paths] / [internal_mcp_auth] / [uptime] /
+    [sse_clients] / [startup] / [subsystems] / [feature_flags] / [gc] /
     [keeper_fibers] / [keeper_fd_pressure] / [fd_accountant] /
     [keeper_fleet_safety] / [keeper_reaction_ledger] / [paused_keepers] /
     [keeper_config_parse_error_count] / [keeper_config_parse_errors] /

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1377,6 +1377,47 @@ let test_health_json_surfaces_log_ring_summary () =
     (latest |> member "details" = `Null);
   ignore (logs |> member "file_sink" |> member "enabled" |> to_bool)
 
+let test_health_json_surfaces_internal_mcp_auth_diagnostics () =
+  with_temp_dir "health-internal-mcp-auth" @@ fun dir ->
+  with_env Auth.internal_keeper_token_env_key None @@ fun () ->
+  with_cwd dir @@ fun () ->
+  Server_runtime_bootstrap.bootstrap_base_path_config_root ~base_path:dir;
+  let request = Httpun.Request.create `GET "/health" in
+  let open Yojson.Safe.Util in
+  let degraded =
+    Server_routes_http_runtime.make_health_json request
+    |> member "internal_mcp_auth"
+  in
+  Alcotest.(check string) "auth schema" "masc.internal_mcp_auth.v1"
+    (degraded |> member "schema" |> to_string);
+  Alcotest.(check string) "missing token degrades" "degraded"
+    (degraded |> member "status" |> to_string);
+  Alcotest.(check bool) "env token absent" false
+    (degraded |> member "env_token_present" |> to_bool);
+  Alcotest.(check bool) "hash file absent" false
+    (degraded |> member "token_hash_file_present" |> to_bool);
+  Alcotest.(check bool) "not ready" false
+    (degraded |> member "keeper_internal_runtime_mcp_ready" |> to_bool);
+  let raw_token = Auth.ensure_internal_keeper_token dir in
+  let ready =
+    Server_routes_http_runtime.make_health_json request
+    |> member "internal_mcp_auth"
+  in
+  Alcotest.(check string) "verified token is ok" "ok"
+    (ready |> member "status" |> to_string);
+  Alcotest.(check bool) "env token present" true
+    (ready |> member "env_token_present" |> to_bool);
+  Alcotest.(check bool) "hash file present" true
+    (ready |> member "token_hash_file_present" |> to_bool);
+  Alcotest.(check bool) "env token verifies" true
+    (ready |> member "env_token_verifies" |> to_bool);
+  Alcotest.(check bool) "ready" true
+    (ready |> member "keeper_internal_runtime_mcp_ready" |> to_bool);
+  Alcotest.(check bool) "no operator action when ready" false
+    (ready |> member "operator_action_required" |> to_bool);
+  Alcotest.(check bool) "raw token not exposed" false
+    (contains_substring (Yojson.Safe.to_string ready) raw_token)
+
 let test_health_response_default_is_light_probe () =
   let request = Httpun.Request.create `GET "/health" in
   let json = Server_routes_http_runtime.make_health_response_json request in
@@ -1389,6 +1430,8 @@ let test_health_response_default_is_light_probe () =
     (match json |> member "startup" with `Assoc _ -> true | _ -> false);
   Alcotest.(check bool) "paths stay on default health" true
     (match json |> member "paths" with `Assoc _ -> true | _ -> false);
+  Alcotest.(check bool) "internal mcp auth stays on default health" true
+    (match json |> member "internal_mcp_auth" with `Assoc _ -> true | _ -> false);
   Alcotest.(check bool) "default health skips reaction ledger" true
     (json |> member "keeper_reaction_ledger" = `Null);
   Alcotest.(check bool) "default health skips cdal snapshot" true
@@ -2715,6 +2758,10 @@ let () =
             `Quick test_health_json_reaction_ledger_cursor_sweep_clears_pending;
           Alcotest.test_case "health json surfaces log ring summary" `Quick
             test_health_json_surfaces_log_ring_summary;
+          Alcotest.test_case
+            "health json surfaces internal mcp auth diagnostics"
+            `Quick
+            test_health_json_surfaces_internal_mcp_auth_diagnostics;
           Alcotest.test_case "default health response is light probe" `Quick
             test_health_response_default_is_light_probe;
           Alcotest.test_case "full health query uses snapshot cache" `Quick

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1388,10 +1388,16 @@ let test_health_json_surfaces_internal_mcp_auth_diagnostics () =
     Server_routes_http_runtime.make_health_json request
     |> member "internal_mcp_auth"
   in
+  let missing_names json =
+    json |> member "missing" |> to_list |> List.map to_string
+  in
   Alcotest.(check string) "auth schema" "masc.internal_mcp_auth.v1"
     (degraded |> member "schema" |> to_string);
   Alcotest.(check string) "missing token degrades" "degraded"
     (degraded |> member "status" |> to_string);
+  Alcotest.(check (list string)) "missing token reasons"
+    [ "env_token"; "token_hash_file" ]
+    (missing_names degraded);
   Alcotest.(check bool) "env token absent" false
     (degraded |> member "env_token_present" |> to_bool);
   Alcotest.(check bool) "hash file absent" false
@@ -1415,8 +1421,31 @@ let test_health_json_surfaces_internal_mcp_auth_diagnostics () =
     (ready |> member "keeper_internal_runtime_mcp_ready" |> to_bool);
   Alcotest.(check bool) "no operator action when ready" false
     (ready |> member "operator_action_required" |> to_bool);
+  Alcotest.(check string) "ready operator next action" "none"
+    (ready |> member "operator_next_action" |> to_string);
   Alcotest.(check bool) "raw token not exposed" false
-    (contains_substring (Yojson.Safe.to_string ready) raw_token)
+    (contains_substring (Yojson.Safe.to_string ready) raw_token);
+  let hash_file = Auth.internal_keeper_token_hash_file dir in
+  write_file hash_file " \n";
+  let empty_hash =
+    Server_routes_http_runtime.make_health_json request
+    |> member "internal_mcp_auth"
+  in
+  Alcotest.(check bool) "empty hash is absent" false
+    (empty_hash |> member "token_hash_file_present" |> to_bool);
+  Alcotest.(check bool) "empty hash asks for hash file" true
+    (List.mem "token_hash_file" (missing_names empty_hash));
+  Alcotest.(check bool) "empty hash is not mismatch" false
+    (List.mem "token_hash_mismatch" (missing_names empty_hash));
+  write_file hash_file (Auth.sha256_hash (raw_token ^ "-stale"));
+  let mismatch =
+    Server_routes_http_runtime.make_health_json request
+    |> member "internal_mcp_auth"
+  in
+  Alcotest.(check bool) "mismatch keeps hash present" true
+    (mismatch |> member "token_hash_file_present" |> to_bool);
+  Alcotest.(check bool) "mismatch reason is explicit" true
+    (List.mem "token_hash_mismatch" (missing_names mismatch))
 
 let test_health_response_default_is_light_probe () =
   let request = Httpun.Request.create `GET "/health" in


### PR DESCRIPTION
## Summary

- Add `internal_mcp_auth` to `/health` and full health JSON.
- Surface whether `MASC_INTERNAL_MCP_TOKEN` exists, whether the internal token hash exists, whether the env token verifies, and the operator next action.
- Keep the raw token out of health output and cover both degraded and ready states in tests.

## Product impact

Operators can now see the exact reason Keeper internal MCP auth is not ready instead of inferring it from missing process env or auth hash state. This is the first scoped fix from the Keeper Env/Sandbox audit.

## Evidence

- `ocamlformat -i lib/server/server_routes_http_runtime.ml lib/server/server_routes_http_runtime.mli test/test_server_runtime_bootstrap.ml`
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=.codex_build_internal_mcp dune build --root . lib/server test/test_server_runtime_bootstrap.exe`
- `./.codex_build_internal_mcp/default/test/test_server_runtime_bootstrap.exe test --color=never --show-errors bootstrap 28,29`
- `git commit` pre-commit hook completed `dune build --root .`

## Direct evidence

schema_version: 1
direct_ratio: 4/4
provenance: direct

- Focused compile completed successfully.
- Focused Alcotest cases 28 and 29 completed successfully.
- Full pre-commit Dune build completed successfully before commit `734130ae74`.
- The focused test asserts the raw internal token string is not present in health JSON.

## Review evidence

- Reviewed the health JSON diff for token leakage: only booleans, env key name, readiness, missing reason names, and next action are emitted.
- Tried `scripts/dune-local.sh build lib/server test/test_server_runtime_bootstrap.exe`, but it only queued behind another worktree's global Dune lock; no compile started in that run.

## Linked issue

- Part of #19689

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`codex/internal-mcp-token-health-20260601` → `main` · 1 commit(s) · synced 2026-06-01T05:02:18Z

| sha | subject | date |
|---|---|---|
| `734130ae7` | Expose internal MCP auth health | 2026-06-01 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->