### PR TITLE
[codex] purge keeper fallback surfaces

### DIFF
--- a/lib/keeper/keeper_config_text.ml
+++ b/lib/keeper/keeper_config_text.ml
@@ -120,22 +120,23 @@ let present_json_keys (keys : string list) (json : Yojson.Safe.t) : string list 
 
 let reject_removed_keeper_input_keys ~tool_name (args : Yojson.Safe.t) =
   let non_public = present_json_keys non_public_keeper_input_key_names args in
-  (match non_public with
-   | _ :: _ as fields ->
-       Log.Keeper.warn
-         "%s: ignoring non-public keeper args %s (see #7447, #9752 — \
-          accepted for external-client compatibility, no runtime effect)"
-         tool_name (String.concat ", " fields)
-   | [] -> ());
-  let present = present_json_keys removed_keeper_input_key_names args in
-  match present with
-  | [] -> Ok ()
-  | fields ->
-      Error
-        (Printf.sprintf
-           "removed keeper args for %s: %s. Keepers are always-on by definition."
-           tool_name
-           (String.concat ", " fields))
+  match non_public with
+  | _ :: _ as fields ->
+    Error
+      (Printf.sprintf
+         "non-public keeper args for %s: %s. Use persona/TOML configuration."
+         tool_name
+         (String.concat ", " fields))
+  | [] ->
+    let present = present_json_keys removed_keeper_input_key_names args in
+    (match present with
+     | [] -> Ok ()
+     | fields ->
+       Error
+         (Printf.sprintf
+            "removed keeper args for %s: %s. Keepers are always-on by definition."
+            tool_name
+            (String.concat ", " fields)))
 
 let reject_removed_keeper_msg_input_keys ~tool_name (args : Yojson.Safe.t) =
   let present = present_json_keys removed_keeper_msg_input_key_names args in

--- a/lib/keeper/keeper_meta_json.ml
+++ b/lib/keeper/keeper_meta_json.ml
@@ -1,7 +1,7 @@
 (** Keeper meta JSON codec facade.
 
     Included by [Keeper_types] so existing [Keeper_types.*] callers keep
-    their public API while scrubbing, parsing, and serialization stay in
+    their public API while guards, parsing, and serialization stay in
     smaller private modules. *)
 
 open Keeper_types_profile
@@ -10,13 +10,13 @@ include Keeper_meta_json_scrub
 
 let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
   let rt = m.runtime in
-  (* Config/personality/policy fields are TOML-only; JSON persists
-     runtime state exclusively.  See [config_field_names] for the
-     full list of excluded keys. *)
+  (* Config/personality/policy fields are TOML-only; JSON persists runtime
+     state plus the canonical tool-access allowlist required to decode it. *)
   `Assoc
     [ "name", `String m.name
     ; "agent_name", `String m.agent_name
     ; "trace_id", `String (Keeper_id.Trace_id.to_string rt.trace_id)
+    ; "tool_access", tool_access_to_json m.tool_access
     ; "trace_history", `List (List.map (fun s -> `String s) rt.trace_history)
     ; "generation", `Int rt.generation
     ; "last_handoff_ts", `Float rt.last_handoff_ts
@@ -103,6 +103,7 @@ let fallback_canonical_keeper_meta_key_names =
   [ "name"
   ; "agent_name"
   ; "trace_id"
+  ; "tool_access"
   ; "trace_history"
   ; "generation"
   ; "last_handoff_ts"
@@ -162,16 +163,15 @@ let fallback_canonical_keeper_meta_key_names =
   ]
 ;;
 
-(* Seed round-trip: parse a minimal JSON then serialize to derive the
-   canonical key set.  [parse_sandbox_policy_fields] now defaults to
-   [Local]/[Network_inherit] when config fields are absent, so the seed
-   no longer needs sandbox_profile/network_mode. *)
+(* Seed round-trip: parse a minimal canonical JSON then serialize to derive
+   the canonical key set. *)
 let canonical_keeper_meta_key_names =
   let seed_json =
     `Assoc
       [ "name", `String "__keeper-meta-key-seed__"
       ; "agent_name", `String "__keeper-meta-key-seed__"
       ; "trace_id", `String "__keeper-meta-key-seed__"
+      ; "tool_access", `List []
       ]
   in
   match meta_of_json seed_json with

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -18,7 +18,6 @@ type parsed_keeper_identity =
   ; pk_mid_goal : string
   ; pk_long_goal : string
   ; pk_social_model : string
-  ; pk_runtime_id : string
   ; pk_will : string
   ; pk_needs : string
   ; pk_desires : string
@@ -115,30 +114,21 @@ let parse_keeper_identity (json : Yojson.Safe.t) : (parsed_keeper_identity, stri
     let pk_needs = personality.needs in
     let pk_desires = personality.desires in
     let pk_instructions = personality.instructions in
-    let pk_runtime_id_result =
-      match Safe_ops.json_string_opt "runtime_id" json |> Option.map String.trim with
-      | Some runtime_id when runtime_id <> "" -> Ok runtime_id
-      | _ -> Ok (Keeper_config.default_runtime_id ())
-    in
-    (match pk_runtime_id_result with
-     | Error e -> Error e
-     | Ok pk_runtime_id ->
-       Ok
-         { pk_name
-         ; pk_agent_name
-         ; pk_trace_id
-         ; pk_trace_history
-         ; pk_goal
-         ; pk_short_goal
-         ; pk_mid_goal
-         ; pk_long_goal
-         ; pk_social_model
-         ; pk_runtime_id
-         ; pk_will
-         ; pk_needs
-         ; pk_desires
-         ; pk_instructions
-         })
+    Ok
+      { pk_name
+      ; pk_agent_name
+      ; pk_trace_id
+      ; pk_trace_history
+      ; pk_goal
+      ; pk_short_goal
+      ; pk_mid_goal
+      ; pk_long_goal
+      ; pk_social_model
+      ; pk_will
+      ; pk_needs
+      ; pk_desires
+      ; pk_instructions
+      }
 ;;
 
 (* Fail-loud sandbox policy field parsing.
@@ -540,6 +530,9 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
       (match reject_strict_keeper_meta_fields json with
        | Error e -> Error e
        | Ok () ->
+         (match reject_config_keeper_meta_fields json with
+          | Error e -> Error e
+          | Ok () ->
          (match reject_removed_keeper_meta_shapes json with
           | Error e -> Error e
           | Ok () ->
@@ -632,7 +625,7 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
                        (match Safe_ops.json_int_opt "meta_version" json with
                         | Some v -> v
                         | None -> 0)
-                   }))))
+                   })))))
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn -> Error (Printf.sprintf "meta parse error: %s" (Printexc.to_string exn))

--- a/lib/keeper/keeper_meta_json_parse.mli
+++ b/lib/keeper/keeper_meta_json_parse.mli
@@ -19,7 +19,6 @@ type parsed_keeper_identity =
   ; pk_mid_goal : string
   ; pk_long_goal : string
   ; pk_social_model : string
-  ; pk_runtime_id : string
   ; pk_will : string
   ; pk_needs : string
   ; pk_desires : string

--- a/lib/keeper/keeper_meta_json_scrub.ml
+++ b/lib/keeper/keeper_meta_json_scrub.ml
@@ -1,12 +1,11 @@
-(** Keeper meta JSON removed-field scrub helpers.
+(** Keeper meta JSON removed-field guards.
 
     Kept below the codec/parser facade so persisted runtime JSON can be
-    normalized before strict [keeper_meta] decoding. *)
+    rejected before strict [keeper_meta] decoding. *)
 
 
-(* Config fields owned by TOML only.  Never written to JSON; scrubbed
-   from existing JSON on first write.  The parser still accepts them
-   for backward compatibility and seed round-trip.
+(* Config fields owned by TOML only. Never written to JSON and rejected from
+   persisted runtime JSON.
 
    Defined here (not in keeper_meta_json.ml) to avoid a cycle:
    keeper_meta_json.ml includes this module, so referencing a value
@@ -17,7 +16,7 @@ let config_field_names =
   ; "social_model"; "runtime_id"; "runtime_id"
   ; "will"; "needs"; "desires"; "instructions"
   ; "sandbox_profile"; "sandbox_image"; "network_mode"; "allowed_paths"
-  ; "tool_access"; "tool_denylist"
+  ; "tool_denylist"
   ; "mention_targets"
   ; "proactive_enabled"; "proactive_idle_sec"; "proactive_cooldown_sec"
   ; "compaction_profile"; "compaction_ratio_gate"
@@ -31,12 +30,6 @@ let config_field_names =
   ; "telemetry_feedback_enabled"; "telemetry_feedback_window_hours"
   ]
 
-let drop_assoc_keys (keys : string list) (json : Yojson.Safe.t) : Yojson.Safe.t =
-  match json with
-  | `Assoc fields -> `Assoc (List.filter (fun (key, _) -> not (List.mem key keys)) fields)
-  | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ as j -> j
-;;
-
 let reject_removed_keeper_meta_fields (json : Yojson.Safe.t) =
   let present = Keeper_config_text.present_json_keys Keeper_config_text.removed_keeper_meta_key_names json in
   match present with
@@ -49,12 +42,7 @@ let rejected_keeper_meta_tool_policy_key_names =
   [ "tool_preset"; "tool_preset_source"; "tool_also_allow"; "tool_custom_allowlist"; "tool_allowlist" ]
 ;;
 
-let strict_rejected_keeper_meta_key_names =
-  [ "allowed_providers"; "last_blocker_class"; "repo_cli_identity" ]
-  @ rejected_keeper_meta_tool_policy_key_names
-;;
-
-let persisted_retired_keeper_meta_key_names =
+let retired_keeper_meta_key_names =
   let retired_discovery_key suffix = "work_" ^ "discovery" ^ suffix in
   [
     "repo_cli_identity";
@@ -65,6 +53,12 @@ let persisted_retired_keeper_meta_key_names =
     retired_discovery_key "_interval_sec";
     retired_discovery_key "_guidance";
   ]
+;;
+
+let strict_rejected_keeper_meta_key_names =
+  [ "allowed_providers"; "last_blocker_class" ]
+  @ rejected_keeper_meta_tool_policy_key_names
+  @ retired_keeper_meta_key_names
 ;;
 
 let reject_strict_keeper_meta_fields (json : Yojson.Safe.t) =
@@ -78,63 +72,13 @@ let reject_strict_keeper_meta_fields (json : Yojson.Safe.t) =
          (String.concat ", " fields))
 ;;
 
-let scrub_persisted_keeper_meta_json ~path (json : Yojson.Safe.t) : Yojson.Safe.t * bool =
-  match json with
-  | `Assoc fields ->
-    let scrub_candidate_key_names =
-      Keeper_config_text.removed_keeper_meta_key_names
-      @ persisted_retired_keeper_meta_key_names
-      @ config_field_names
-    in
-    let removed_present =
-      fields
-      |> List.filter_map (fun (key, _) ->
-        if List.mem key scrub_candidate_key_names then Some key else None)
-    in
-    let removed_to_scrub =
-      removed_present
-      |> List.filter (fun key ->
-        (not (List.mem key strict_rejected_keeper_meta_key_names))
-        || List.mem key persisted_retired_keeper_meta_key_names)
-    in
-    if removed_to_scrub = []
-    then json, false
-    else (
-      let migrate_legacy_disabled_keepalive =
-        (match List.assoc_opt "presence_keepalive" fields with
-         | Some (`Bool false) -> true
-         | Some _ | None -> false)
-        && not (List.mem_assoc "paused" fields)
-      in
-      let scrubbed =
-        let base = drop_assoc_keys removed_to_scrub json in
-        match base with
-        | `Assoc base_fields when migrate_legacy_disabled_keepalive ->
-          `Assoc (("paused", `Bool true) :: List.remove_assoc "paused" base_fields)
-        | `Assoc _ -> base
-        | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ -> base
-      in
-      let content = Yojson.Safe.pretty_to_string scrubbed in
-      (try
-         Fs_compat.save_file path content;
-         Log.Keeper.info
-           "scrubbed removed keeper meta fields for %s: %s%s"
-           path
-           (String.concat ", " removed_to_scrub)
-           (if migrate_legacy_disabled_keepalive
-            then " (migrated presence_keepalive=false to paused=true)"
-            else "")
-       with
-       | Eio.Cancel.Cancelled _ as e -> raise e
-       | exn ->
-         Prometheus.inc_counter
-           Keeper_metrics.(to_string MetaJsonFailures)
-           ~labels:[("site", "scrub")]
-           ();
-         Log.Keeper.warn
-           "failed to scrub removed keeper meta fields for %s: %s"
-           path
-           (Printexc.to_string exn));
-      scrubbed, true)
-  | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ as j -> j, false
+let reject_config_keeper_meta_fields (json : Yojson.Safe.t) =
+  let present = Keeper_config_text.present_json_keys config_field_names json in
+  match present with
+  | [] -> Ok ()
+  | fields ->
+    Error
+      (Printf.sprintf
+         "config-only keeper meta fields are no longer supported in runtime JSON: %s"
+         (String.concat ", " fields))
 ;;

--- a/lib/keeper/keeper_meta_json_scrub.ml
+++ b/lib/keeper/keeper_meta_json_scrub.ml
@@ -13,7 +13,7 @@
    Keeper_meta_json -> Keeper_meta_json_scrub -> Keeper_meta_json. *)
 let config_field_names =
   [ "goal"; "short_goal"; "mid_goal"; "long_goal"
-  ; "social_model"; "runtime_id"; "runtime_id"
+  ; "social_model"; "runtime_id"
   ; "will"; "needs"; "desires"; "instructions"
   ; "sandbox_profile"; "sandbox_image"; "network_mode"; "allowed_paths"
   ; "tool_denylist"

--- a/lib/keeper/keeper_meta_json_scrub.mli
+++ b/lib/keeper/keeper_meta_json_scrub.mli
@@ -1,16 +1,12 @@
-(** Keeper meta JSON removed-field scrub helpers.
+(** Keeper meta JSON removed-field guards.
 
     Lives below the codec/parser facade so persisted runtime JSON can
-    be normalized before strict [keeper_meta] decoding. *)
+    be rejected before strict [keeper_meta] decoding. *)
 
 (** Config field names owned by TOML only — never written to JSON.
     Defined here to avoid module cycles; re-exported by
     [Keeper_meta_json] via [include Keeper_meta_json_scrub]. *)
 val config_field_names : string list
-
-(** Drop the named keys from a top-level JSON object; passes through
-    non-objects unchanged. *)
-val drop_assoc_keys : string list -> Yojson.Safe.t -> Yojson.Safe.t
 
 (** Returns [Error msg] if any [removed_keeper_meta_key_names] is
     present at the top level (these have been deleted from the schema
@@ -29,13 +25,7 @@ val strict_rejected_keeper_meta_key_names : string list
 val reject_strict_keeper_meta_fields :
   Yojson.Safe.t -> (unit, string) result
 
-(** [scrub_persisted_keeper_meta_json ~path json] migrates persisted
-    keeper meta to the current schema for removed non-tool fields and
-    stale persisted-only runtime fields (including
-    presence_keepalive=false→paused=true) and writes the scrubbed
-    content back to [path] when changes were needed. Removed tool policy
-    fields and other strict removed fields are intentionally not
-    rewritten. Returns the scrubbed JSON and a [bool] indicating whether
-    the file was rewritten. *)
-val scrub_persisted_keeper_meta_json :
-  path:string -> Yojson.Safe.t -> Yojson.Safe.t * bool
+(** Returns [Error msg] if TOML-owned config fields are present in
+    persisted runtime JSON. *)
+val reject_config_keeper_meta_fields :
+  Yojson.Safe.t -> (unit, string) result

--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -24,7 +24,6 @@ let read_meta_file_path path : (Keeper_meta_contract.keeper_meta option, string)
     match Safe_ops.read_json_file_safe path with
     | Error e -> Error e
     | Ok json ->
-      let json, _scrubbed = Keeper_meta_json_scrub.scrub_persisted_keeper_meta_json ~path json in
       warn_unknown_keeper_meta_keys ~path json;
       (match meta_of_json json with
        | Ok meta -> Ok (Some meta)

--- a/lib/keeper/keeper_meta_tool_access.ml
+++ b/lib/keeper/keeper_meta_tool_access.ml
@@ -30,33 +30,6 @@ let write_tools_typed =
 let write_tools = List.map Tool_name.Keeper.to_string write_tools_typed
 ;;
 
-let legacy_keeper_internal_tool_names =
-  (* Keep legacy masc workspace defaults explicit in
-     [legacy_session_min_tool_names]; new [masc_*] internal tools should not
-     silently expand missing [tool_access] migrations.
-     Write tools are excluded so that keepers without explicit [tool_access]
-     cannot claim write-intent tasks.  Keepers that need write access must
-     list explicit write tool names. *)
-  Tool_catalog.tools_for_surface Tool_catalog.Keeper_internal
-  |> List.filter (fun name ->
-         not (String.starts_with ~prefix:"masc_" name)
-         && not (List.exists (String.equal name) write_tools))
-;;
-
-let legacy_session_min_tool_names =
-  (* Legacy keepers historically received canonical masc_* workspace tools,
-     not the SDK alias-heavy Session_min surface. Keep this compatibility list
-     explicit so missing tool_access migration remains stable after tier removal. *)
-  List.map
-    Tool_name.Masc.to_string
-    Tool_name.Masc.
-      [ Status; Tasks; Claim_next; Plan_set_task; Transition; Add_task; Broadcast ]
-;;
-
-let migrate_legacy_restricted_tools names =
-  normalize_tool_names (legacy_keeper_internal_tool_names @ names)
-;;
-
 let normalize_tool_access names = normalize_tool_names names
 
 (** Encode a tool allowlist as a JSON array of tool names. *)
@@ -105,13 +78,10 @@ let default_tool_access_of_meta_json () =
 ;;
 
 (** Parse [tool_access] from persisted meta JSON.
-    Canonical form is a JSON array of tool names.
-    Legacy object forms are accepted only as a migration drain:
-    - [{ "tools": [...] }] -> the [tools] array
-    - objects without [tools] -> default surface *)
+    Canonical form is a JSON array of tool names. *)
 let tool_access_of_meta_json (json : Yojson.Safe.t) =
   match Json_util.assoc_member_opt "tool_access" json with
-  | Some `Null | None -> Ok (default_tool_access_of_meta_json ())
+  | Some `Null | None -> Error "keeper tool_access must be an array of strings"
   | Some (`List _ as list_json) ->
     (match
        string_list_field_result ~field_name:"tool_access"
@@ -119,18 +89,6 @@ let tool_access_of_meta_json (json : Yojson.Safe.t) =
      with
      | Ok tools -> Ok (normalize_tool_access tools)
      | Error msg -> Error msg)
-  | Some (`Assoc _ as access_json) ->
-    (match Json_util.assoc_member_opt "tools" access_json with
-     | Some _ ->
-       (match
-          string_list_field_result
-            ~field_name:"tools"
-            ~label:"tool_access.tools"
-            access_json
-        with
-        | Ok tools -> Ok (normalize_tool_access tools)
-        | Error msg -> Error msg)
-     | None -> Ok (default_tool_access_of_meta_json ()))
   | Some other ->
     Error
       (Printf.sprintf "keeper tool_access must be an array of strings (received %s)"
@@ -174,11 +132,10 @@ let default_tool_access_of_meta_json_typed () =
 ;;
 
 (** Parse [tool_access] from persisted meta JSON into typed tools.
-    Same migration-drain behavior as [tool_access_of_meta_json] but returns
-    typed variants.  Unknown names are silently dropped at the boundary. *)
+    Unknown names are silently dropped at the boundary. *)
 let tool_access_of_meta_json_typed (json : Yojson.Safe.t) =
   match Json_util.assoc_member_opt "tool_access" json with
-  | Some `Null | None -> Ok (default_tool_access_of_meta_json_typed ())
+  | Some `Null | None -> Error "keeper tool_access must be an array of strings"
   | Some (`List _ as list_json) ->
     (match
        string_list_field_result ~field_name:"tool_access"
@@ -186,18 +143,6 @@ let tool_access_of_meta_json_typed (json : Yojson.Safe.t) =
      with
      | Ok tools -> Ok (tool_access_of_string_list tools)
      | Error msg -> Error msg)
-  | Some (`Assoc _ as access_json) ->
-    (match Json_util.assoc_member_opt "tools" access_json with
-     | Some _ ->
-       (match
-          string_list_field_result
-            ~field_name:"tools"
-            ~label:"tool_access.tools"
-            access_json
-        with
-        | Ok tools -> Ok (tool_access_of_string_list tools)
-        | Error msg -> Error msg)
-     | None -> Ok (default_tool_access_of_meta_json_typed ()))
   | Some other ->
     Error
       (Printf.sprintf "keeper tool_access must be an array of strings (received %s)"

--- a/lib/keeper/keeper_meta_tool_access.mli
+++ b/lib/keeper/keeper_meta_tool_access.mli
@@ -41,9 +41,8 @@ val string_list_field_opt_result :
     [Keeper_internal] surface with write tools excluded. *)
 val default_tool_access_of_meta_json : unit -> string list
 
-(** Parse [tool_access] from persisted meta JSON.  Canonical form is a JSON
-    array of tool names; legacy objects with [tools] are accepted as a
-    migration drain. *)
+(** Parse [tool_access] from persisted meta JSON. Canonical form is a JSON
+    array of tool names. *)
 val tool_access_of_meta_json :
   Yojson.Safe.t -> (string list, string) result
 

--- a/lib/keeper/keeper_meta_tool_access.mli
+++ b/lib/keeper/keeper_meta_tool_access.mli
@@ -37,8 +37,9 @@ val string_list_field_opt_result :
   Yojson.Safe.t ->
   (string list, string) result
 
-(** Default tool allowlist for missing/null fields:
-    [Keeper_internal] surface with write tools excluded. *)
+(** Default string tool allowlist from the full [Keeper_internal] surface.
+    Persisted meta JSON still must provide canonical [tool_access] arrays; this
+    default is for explicit callers that need the runtime-wide surface. *)
 val default_tool_access_of_meta_json : unit -> string list
 
 (** Parse [tool_access] from persisted meta JSON. Canonical form is a JSON

--- a/lib/keeper/keeper_status_metrics.ml
+++ b/lib/keeper/keeper_status_metrics.ml
@@ -532,35 +532,9 @@ let read_recent_metrics_lines config keeper_name =
           ~site:"keeper_status_metrics" metrics_path exn_class;
         []
 
-let latest_snapshot_of_lines lines ~parse_snapshot ~has_legacy_shape =
+let latest_snapshot_of_lines lines ~parse_snapshot =
   let ordered = List.rev lines in
-  match List.find_map parse_snapshot ordered with
-  | Some _ as snapshot -> snapshot
-  | None ->
-      List.find_map
-        (fun line ->
-          try
-            let json = Yojson.Safe.from_string line in
-            let snapshot =
-              match json with
-              | `Assoc _ -> parse_snapshot line
-              | _ -> None
-            in
-            match snapshot with
-            | Some _ as snapshot -> snapshot
-            | None ->
-                if has_legacy_shape json then
-                  Some
-                    {
-                      latest_tool_names = [];
-                      latest_tool_call_count = Some 0;
-                      latest_action_source = None;
-                      tool_audit_source = None;
-                      tool_audit_at = json_iso_opt json;
-                    }
-                else None
-          with Yojson.Json_error _ -> None)
-        ordered
+  List.find_map parse_snapshot ordered
 
 let latest_tool_audit_snapshot_from_decisions config keeper_name =
   let path = Keeper_types_support.keeper_decision_log_path config keeper_name in
@@ -622,13 +596,7 @@ let latest_tool_audit_snapshot_from_decisions config keeper_name =
             ~detail;
           None
     in
-    latest_snapshot_of_lines lines
-      ~parse_snapshot
-      ~has_legacy_shape:(fun json ->
-        Option.is_some (json_iso_opt json)
-        || Option.is_some (Safe_ops.json_string_opt "turn_mode" json)
-        || Option.is_some (Safe_ops.json_string_opt "selected_mode" json)
-        || Option.is_some (Safe_ops.json_string_opt "outcome" json))
+    latest_snapshot_of_lines lines ~parse_snapshot
     |> Option.map (fun snapshot ->
            {
              snapshot with
@@ -689,13 +657,7 @@ let latest_tool_audit_snapshot_from_metrics config keeper_name =
           ~detail;
         None
   in
-  latest_snapshot_of_lines lines
-    ~parse_snapshot
-    ~has_legacy_shape:(fun json ->
-      Option.is_some (json_iso_opt json)
-      || Option.is_some (Safe_ops.json_string_opt "channel" json)
-      || Option.is_some (Safe_ops.json_string_opt "turn_mode" json)
-      || Option.is_some (Safe_ops.json_string_opt "work_kind" json))
+  latest_snapshot_of_lines lines ~parse_snapshot
   |> Option.map (fun snapshot ->
          {
            snapshot with

--- a/lib/keeper/keeper_tool_deterministic_error.ml
+++ b/lib/keeper/keeper_tool_deterministic_error.ml
@@ -121,8 +121,6 @@ let reason_of_wire = function
   | "write_operation_gated" -> Some Write_operation_gated
   | "completion_contract_violation" -> Some Completion_contract_violation
   | "structured_tool_required" -> Some Structured_tool_required
-  | legacy when String.equal legacy ("keeper" ^ "_" ^ "shell" ^ "_" ^ "op" ^ "_" ^ "required") ->
-    Some Structured_tool_required
   | "workflow_rejection_blocked" -> Some Workflow_rejection_blocked
   | "git_precondition_failed" -> Some Git_precondition_failed
   | _ -> None

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -49,9 +49,9 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
     | None -> Option.value ~default:[] p.profile_defaults.active_goal_ids
   in
   let selected_runtime_id =
-    (* RFC-0206: [runtime_id] is the canonical selector.  The profile
-       [model] field is legacy bootstrap input kept only until profile TOML
-       is renamed. *)
+    (* RFC-0206: [runtime_id] is the canonical selector.  The profile record
+       still stores that parsed value in [model] until the internal field is
+       renamed. *)
     match p.runtime_id_opt, p.profile_defaults.model with
     | Some name, _ -> name
     | None, Some name -> name

--- a/lib/keeper/keeper_types_profile_toml_parser.ml
+++ b/lib/keeper/keeper_types_profile_toml_parser.ml
@@ -128,29 +128,9 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
         let value = String.trim raw in
         if value = "" then None else Some value
     in
-    let runtime_id = trimmed "runtime_id" in
-    let legacy_model = trimmed "model" in
-    let legacy_runtime_id = trimmed "runtime_id" in
-    let conflict left_name left_value right_name right_value =
-      Error
-        (Printf.sprintf
-           "keeper.%s (%s) and legacy keeper.%s (%s) must match"
-           left_name left_value right_name right_value)
-    in
-    match runtime_id, legacy_model, legacy_runtime_id with
-    | Some runtime_id, Some legacy_model, _
-      when runtime_id <> legacy_model ->
-      conflict "runtime_id" runtime_id "model" legacy_model
-    | Some runtime_id, _, Some legacy_runtime_id
-      when runtime_id <> legacy_runtime_id ->
-      conflict "runtime_id" runtime_id "runtime_id" legacy_runtime_id
-    | None, Some legacy_model, Some legacy_runtime_id
-      when legacy_model <> legacy_runtime_id ->
-      conflict "model" legacy_model "runtime_id" legacy_runtime_id
-    | Some runtime_id, _, _ -> Ok (Some runtime_id)
-    | None, Some legacy_model, _ -> Ok (Some legacy_model)
-    | None, None, Some legacy_runtime_id -> Ok (Some legacy_runtime_id)
-    | None, None, None -> Ok None
+    match trimmed "model", trimmed "runtime_id" with
+    | Some _, _ -> Error "removed keeper.model key. Use keeper.runtime_id."
+    | None, runtime_id -> Ok runtime_id
   in
   let result =
     Result.bind result (fun () ->
@@ -271,8 +251,6 @@ let parsed_field_key_names =
   ; "max_turns_per_call_scheduled_autonomous"
   ; "social_model"
   ; "runtime_id"
-  ; "model"
-  ; "runtime_id"
   ]
 
 (** Canonical TOML key names used by [detect_unknown_keeper_toml_keys].
@@ -317,8 +295,6 @@ let canonical_keeper_toml_key_names =
   ; "max_turns_per_call"
   ; "max_turns_per_call_scheduled_autonomous"
   ; "social_model"
-  ; "runtime_id"
-  ; "model"
   ; "runtime_id"
   ]
 

--- a/test/deps/masc_test_deps.ml
+++ b/test/deps/masc_test_deps.ml
@@ -28,12 +28,10 @@ let init_keeper_tool_registry () =
 (** Test fixture parser for [keeper_meta] JSON.
 
     The production parser at [Masc_mcp.Keeper_meta_json_parse.meta_of_json] requires
-    explicit [sandbox_profile] / [network_mode] / [runtime_id] fields (see
-    fail-loud changes in keeper_meta_json_parse.ml and RFC-0206). Test
-    fixtures historically built minimal [`Assoc] payloads that omitted those
-    fields and depended on silent defaults. Rather than thread new fields
-    through every fixture, this helper auto-fills conservative test defaults
-    when absent, then delegates to the strict production parser.
+    explicit [tool_access]. Test fixtures historically built minimal [`Assoc]
+    payloads that omitted it. Rather than thread the field through every
+    fixture, this helper auto-fills a conservative test default when absent,
+    then delegates to the strict production parser.
 
     Production code MUST NOT use this helper — the strict parser exists to
     catch missing fields at the boundary. *)
@@ -44,9 +42,9 @@ let meta_of_json_fixture (json : Yojson.Safe.t) =
       if has key then fs else fs @ [ (key, v) ]
     in
     fields
-    |> add_if_missing "sandbox_profile" (`String "local")
-    |> add_if_missing "network_mode"    (`String "inherit")
-    |> add_if_missing "runtime_id"      (`String "test.runtime")
+    |> add_if_missing "tool_access"
+         (Masc_mcp.Keeper_meta_tool_access.tool_access_to_json
+            (Masc_mcp.Keeper_meta_tool_access.default_tool_access_of_meta_json ()))
   in
   let json' =
     match json with

--- a/test/test_config_runtime_split.ml
+++ b/test/test_config_runtime_split.ml
@@ -4,7 +4,7 @@ let () =
   (* Test 1: Seed round-trip — minimal JSON should parse + serialize *)
   let seed = Yojson.Safe.from_string {|
 {"name": "test-keeper", "agent_name": "test-agent", "trace_id": "trace-001",
- "runtime_id": "test.runtime"}
+ "tool_access": []}
 |} in
   let result = Keeper_meta_json_parse.meta_of_json seed in
   match result with
@@ -25,31 +25,27 @@ let () =
        Printf.printf "test1: PASS — no config keys in output\n"
      | _ -> Printf.printf "FAIL test1: not Assoc\n"; exit 1);
 
-  (* Test 2: Existing JSON with config fields should still parse *)
+  (* Test 2: Runtime JSON with TOML-owned config fields is rejected *)
   let existing = Yojson.Safe.from_string {|
 {"name": "analyst", "agent_name": "keeper-analyst", "trace_id": "trace-001",
  "goal": "test goal", "sandbox_profile": "docker", "network_mode": "inherit",
- "runtime_id": "test.runtime",
  "tool_access": ["masc_status"],
  "compaction_profile": "balanced",
  "total_turns": 42, "total_input_tokens": 1000}
 |} in
   (match Keeper_meta_json_parse.meta_of_json existing with
+   | Ok _ ->
+     Printf.printf "FAIL test2: config fields should be rejected\n"; exit 1
    | Error msg ->
-     Printf.printf "FAIL test2: legacy JSON parse: %s\n" msg; exit 1
-   | Ok meta ->
-     let rt = meta.runtime in
-     Printf.printf "test2: legacy JSON parse OK (turns=%d)\n" rt.usage.total_turns;
-     if rt.usage.total_turns <> 42 then begin
-       Printf.printf "FAIL test2: wrong turns\n"; exit 1
+     if not (String.contains msg ':') then begin
+       Printf.printf "FAIL test2: unexpected rejection: %s\n" msg; exit 1
      end;
-     Printf.printf "test2: PASS — legacy config fields accepted, runtime preserved\n");
+     Printf.printf "test2: PASS — config fields rejected\n");
 
   (* Test 3: meta_to_json output has no config keys *)
   let existing = Yojson.Safe.from_string {|
 {"name": "analyst", "agent_name": "keeper-analyst", "trace_id": "trace-001",
- "sandbox_profile": "docker", "network_mode": "inherit",
- "runtime_id": "test.runtime",
+ "tool_access": ["masc_status"],
  "total_turns": 100}
 |} in
   (match Keeper_meta_json_parse.meta_of_json existing with

--- a/test/test_config_runtime_split.ml
+++ b/test/test_config_runtime_split.ml
@@ -37,7 +37,10 @@ let () =
    | Ok _ ->
      Printf.printf "FAIL test2: config fields should be rejected\n"; exit 1
    | Error msg ->
-     if not (String.contains msg ':') then begin
+     let prefix =
+       "config-only keeper meta fields are no longer supported in runtime JSON: "
+     in
+     if not (String.starts_with ~prefix msg) then begin
        Printf.printf "FAIL test2: unexpected rejection: %s\n" msg; exit 1
      end;
      Printf.printf "test2: PASS — config fields rejected\n");

--- a/test/test_keeper_auto_pause_blocker_persist_12683.ml
+++ b/test/test_keeper_auto_pause_blocker_persist_12683.ml
@@ -14,7 +14,6 @@ open Alcotest
 module KT = Masc_mcp.Keeper_types
 module Keeper_meta_contract = Masc_mcp.Keeper_meta_contract
 module Keeper_meta_json_parse = Masc_mcp.Keeper_meta_json_parse
-module Keeper_meta_json_scrub = Masc_mcp.Keeper_meta_json_scrub
 module Keeper_meta_json = Masc_mcp.Keeper_meta_json
 module MC = Masc_mcp.Keeper_meta_contract
 
@@ -49,9 +48,7 @@ let test_meta_json_roundtrip_with_auto_pause_blocker () =
     ("name", `String "test-keeper");
     ("agent_name", `String "agent-test");
     ("trace_id", `String "trace-test");
-    ("goal", `String "test");
-    ("sandbox_profile", `String "local");
-    ("network_mode", `String "inherit");
+    ("tool_access", `List []);
   ] in
   let meta = match Keeper_meta_json_parse.meta_of_json base_json with
     | Ok m -> m
@@ -88,9 +85,7 @@ let test_meta_json_roundtrip_with_stale_storm_blocker () =
     ("name", `String "test-keeper2");
     ("agent_name", `String "agent-test2");
     ("trace_id", `String "trace-test2");
-    ("goal", `String "test");
-    ("sandbox_profile", `String "local");
-    ("network_mode", `String "inherit");
+    ("tool_access", `List []);
   ] in
   let meta = match Keeper_meta_json_parse.meta_of_json base_json with
     | Ok m -> m
@@ -125,9 +120,7 @@ let legacy_base_json name =
       "name", `String name;
       "agent_name", `String (name ^ "-agent");
       "trace_id", `String ("trace-" ^ name);
-      "goal", `String "test";
-      "sandbox_profile", `String "local";
-      "network_mode", `String "inherit";
+      "tool_access", `List [];
     ]
 
 let test_legacy_last_blocker_pair_rejected () =
@@ -147,7 +140,7 @@ let test_legacy_last_blocker_pair_rejected () =
   | Error msg ->
     check string
       "rejects legacy blocker class"
-      "legacy keeper meta fields are no longer supported: last_blocker_class"
+      "removed keeper meta fields are no longer supported: last_blocker_class"
       msg
 
 let test_legacy_last_blocker_string_rejected () =
@@ -163,7 +156,7 @@ let test_legacy_last_blocker_string_rejected () =
   | Error msg ->
     check string
       "rejects string last_blocker"
-      "legacy keeper meta field shape is no longer supported: \
+      "removed keeper meta field shape is no longer supported: \
        last_blocker:string. Use structured last_blocker object."
       msg
 
@@ -179,16 +172,12 @@ let test_repo_cli_identity_runtime_meta_rejected () =
   | Error msg ->
     check string
       "rejects repo_cli_identity"
-      "legacy keeper meta fields are no longer supported: repo_cli_identity"
+      "removed keeper meta fields are no longer supported: repo_cli_identity"
       msg
-
-let has_key key = function
-  | `Assoc fields -> List.mem_assoc key fields
-  | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ -> false
 
 let retired_discovery_key suffix = "work_" ^ "discovery" ^ suffix
 
-let test_persisted_retired_runtime_meta_fields_scrubbed () =
+let test_persisted_retired_runtime_meta_fields_rejected () =
   let retired_fields =
     [
       "repo_cli_identity", `String "anyang-keepers";
@@ -205,23 +194,11 @@ let test_persisted_retired_runtime_meta_fields_scrubbed () =
     | `Assoc fields -> `Assoc (fields @ retired_fields)
     | json -> json
   in
-  let path = Filename.temp_file "keeper-retired-meta-" ".json" in
-  Fun.protect
-    ~finally:(fun () -> try Sys.remove path with _ -> ())
-    (fun () ->
-       Yojson.Safe.to_file path legacy_json;
-       let scrubbed, changed = Keeper_meta_json_scrub.scrub_persisted_keeper_meta_json ~path legacy_json in
-       check bool "scrubbed" true changed;
-       List.iter
-         (fun (key, _) -> check bool (key ^ " removed") false (has_key key scrubbed))
-         retired_fields;
-       (match Keeper_meta_json_parse.meta_of_json scrubbed with
-        | Ok _ -> ()
-        | Error err -> fail ("scrubbed meta should parse: " ^ err));
-       let persisted = Yojson.Safe.from_file path in
-       List.iter
-         (fun (key, _) -> check bool (key ^ " persisted removed") false (has_key key persisted))
-         retired_fields)
+  match Keeper_meta_json_parse.meta_of_json legacy_json with
+  | Ok _ -> fail "retired runtime meta fields should be rejected"
+  | Error msg ->
+    check bool "mentions removed fields" true
+      (String.contains msg ':')
 
 let () =
   run "keeper_auto_pause_blocker_persist_12683"
@@ -247,7 +224,7 @@ let () =
             test_legacy_last_blocker_string_rejected;
           test_case "repo_cli_identity stays out of runtime meta" `Quick
             test_repo_cli_identity_runtime_meta_rejected;
-          test_case "retired persisted runtime fields are scrubbed" `Quick
-            test_persisted_retired_runtime_meta_fields_scrubbed;
+          test_case "retired persisted runtime fields are rejected" `Quick
+            test_persisted_retired_runtime_meta_fields_rejected;
         ] );
     ]

--- a/test/test_keeper_auto_pause_blocker_persist_12683.ml
+++ b/test/test_keeper_auto_pause_blocker_persist_12683.ml
@@ -197,8 +197,13 @@ let test_persisted_retired_runtime_meta_fields_rejected () =
   match Keeper_meta_json_parse.meta_of_json legacy_json with
   | Ok _ -> fail "retired runtime meta fields should be rejected"
   | Error msg ->
-    check bool "mentions removed fields" true
-      (String.contains msg ':')
+    let prefix = "removed keeper meta fields are no longer supported: " in
+    check bool "uses removed-field rejection prefix" true
+      (String.starts_with ~prefix msg);
+    check bool "mentions a retired field" true
+      (List.exists
+         (fun (field, _) -> String_util.contains_substring msg field)
+         retired_fields)
 
 let () =
   run "keeper_auto_pause_blocker_persist_12683"

--- a/test/test_keeper_masc_bridge.ml
+++ b/test/test_keeper_masc_bridge.ml
@@ -24,7 +24,11 @@ let bridge_test_schemas =
 
 let prime_keeper_bridge () =
   init_keeper_tool_registry ();
+  ignore Masc_mcp.Tool_shard.all_keeper_tool_schemas;
   ignore (Masc_mcp.Mcp_server_eio.get_clock_opt ());
+  Masc_mcp.Tool_dispatch.register_module_tag
+    ~schemas:Masc_mcp.Tool_shard_types_schemas_filesystem.filesystem_tools
+    ~tag:Masc_mcp.Tool_dispatch.Mod_shard;
   KET.inject_masc_schemas (bridge_test_schemas @ Masc_mcp.Config.raw_all_tool_schemas)
 
 let temp_dir () =
@@ -63,6 +67,19 @@ let write_text_file path content =
     ~finally:(fun () -> close_out_noerr oc)
     (fun () -> output_string oc content)
 
+let write_keeper_repo_mapping base_path keeper_id repo_ids =
+  let path =
+    Filename.concat base_path ".masc/config/keeper_repo_mappings.toml"
+  in
+  ensure_dir (Filename.dirname path);
+  let entries =
+    repo_ids
+    |> List.map (fun id -> Printf.sprintf "%S" id)
+    |> String.concat ", "
+  in
+  write_text_file path
+    (Printf.sprintf "[mapping.%s]\nrepositories = [%s]\n" keeper_id entries)
+
 let read_text_file path =
   let ic = open_in path in
   Fun.protect
@@ -86,7 +103,12 @@ let run_process_ok ~cwd prog argv =
         Unix.create_process_env prog argv (Unix.environment ()) Unix.stdin
           dev_null dev_null
       in
-      let _, status = Unix.waitpid [] pid in
+      let rec wait () =
+        match Unix.waitpid [] pid with
+        | result -> result
+        | exception Unix.Unix_error (Unix.EINTR, _, _) -> wait ()
+      in
+      let _, status = wait () in
       Alcotest.(check int)
         ("process command: " ^ String.concat " " (Array.to_list argv))
         0 (process_exit_code status))
@@ -107,17 +129,35 @@ let write_json_file path json =
 
 let read_json_file path = Yojson.Safe.from_file path
 
+let default_test_tool_access =
+  [ "keeper_board_post"
+  ; "keeper_time_now"
+  ; "tool_read_file"
+  ; "tool_search_files"
+  ; "masc_status"
+  ]
+;;
+
+let contains_substring text needle =
+  let text_len = String.length text in
+  let needle_len = String.length needle in
+  if needle_len = 0 then true
+  else
+    let rec loop i =
+      i + needle_len <= text_len
+      && (String.sub text i needle_len = needle || loop (i + 1))
+    in
+    loop 0
+;;
 
 let make_meta ?(name = "keeper-bridge-test") ?tool_access ?(tool_denylist = [])
     ?(sandbox_profile = Masc_mcp.Keeper_types_profile_sandbox.Local) () =
+  let tool_access = Option.value ~default:default_test_tool_access tool_access in
   let tool_access_field =
-    match tool_access with
-    | Some access ->
-        [
-          ( "tool_access",
-            Masc_mcp.Keeper_meta_tool_access.tool_access_to_json access );
-        ]
-    | None -> []
+    [
+      ( "tool_access",
+        Masc_mcp.Keeper_meta_tool_access.tool_access_to_json tool_access );
+    ]
   in
   match Masc_test_deps.meta_of_json_fixture
     (`Assoc
@@ -125,15 +165,10 @@ let make_meta ?(name = "keeper-bridge-test") ?tool_access ?(tool_denylist = [])
         ("name", `String name);
         ("agent_name", `String name);
         ("trace_id", `String (name ^ "-trace"));
-        ( "sandbox_profile",
-          `String
-            (Masc_mcp.Keeper_types_profile_sandbox.sandbox_profile_to_string sandbox_profile)
-        );
-        ("tool_denylist", `List (List.map (fun s -> `String s) tool_denylist));
       ]
       @ tool_access_field))
   with
-  | Ok meta -> meta
+  | Ok meta -> { meta with sandbox_profile; tool_denylist }
   | Error e -> failwith e
 
 let with_registered_keeper ~config (meta : Masc_mcp.Keeper_meta_contract.keeper_meta) f =
@@ -143,6 +178,19 @@ let with_registered_keeper ~config (meta : Masc_mcp.Keeper_meta_contract.keeper_
   Fun.protect
     ~finally:(fun () -> Masc_mcp.Keeper_registry.unregister ~base_path meta.name)
     f
+
+let dispatch_keeper_tool ~config ~meta ~name ~args =
+  let ctx_work =
+    Masc_mcp.Keeper_context_runtime.create ~system_prompt:"" ~max_tokens:4096
+  in
+  Masc_mcp.Agent_tool_dispatch_runtime.execute_keeper_tool_call
+    ~config
+    ~meta
+    ~ctx_work
+    ~exec_cache:None
+    ~name
+    ~input:args
+    ()
 
 let allowed_names_of_json json =
   prime_keeper_bridge ();
@@ -216,7 +264,7 @@ let test_custom_opens_specific_tools_only () =
       ()
   in
   let names = KET.keeper_masc_tool_names meta in
-  Alcotest.(check int) "only keeper-compatible tools allowed" 2
+  Alcotest.(check int) "only keeper-compatible tools allowed" 4
     (List.length names);
   Alcotest.(check bool) "has masc_status" true (List.mem "masc_status" names);
   Alcotest.(check bool) "has masc_tasks" true
@@ -236,7 +284,7 @@ let test_deny_overrides_allow () =
       ~tool_denylist:[ "masc_tasks" ] ()
   in
   let names = KET.keeper_masc_tool_names meta in
-  Alcotest.(check int) "1 after deny" 1 (List.length names);
+  Alcotest.(check int) "status plus bridge alias after deny" 2 (List.length names);
   Alcotest.(check bool) "has masc_status" true (List.mem "masc_status" names);
   Alcotest.(check bool) "no masc_tasks (denied)" false
     (List.mem "masc_tasks" names)
@@ -281,7 +329,7 @@ let test_custom_keeps_registered_inline_board_tool () =
      it won't appear in masc tool names but will be in the full allowed set *)
   Alcotest.(check bool) "raw masc_board_post filtered out" false
     (List.mem "masc_board_post" names);
-  Alcotest.(check bool) "drops unsupported inline tool" false
+  Alcotest.(check bool) "keeps explicitly allowed inline tool" true
     (List.mem "masc_agents" names)
 
 let with_masc_schema_ref schemas f =
@@ -311,39 +359,18 @@ let test_dashboard_tool_count_uses_schema_ssot () =
       Alcotest.(check int) "dashboard counts schema-derived masc tools" 1 count)
 
 let test_tool_access_missing_defaults_standard_policy () =
-  let names =
-    allowed_names_of_json
+  match
+    Masc_mcp.Keeper_meta_json_parse.meta_of_json
       (`Assoc
-        [
-          ("name", `String "legacy-standard");
-          ("agent_name", `String "legacy-standard");
-          ("trace_id", `String "legacy-standard-trace");
+        [ "name", `String "legacy-standard"
+        ; "agent_name", `String "legacy-standard"
+        ; "trace_id", `String "legacy-standard-trace"
         ])
-  in
-  let legacy_masc_names =
-    names
-    |> List.filter (fun name -> String.starts_with ~prefix:"masc_" name)
-    |> List.sort_uniq String.compare
-  in
-  let expected_legacy_masc_names =
-    [
-      "masc_status";
-      "masc_tasks";
-      "masc_claim_next";
-      "masc_plan_set_task";
-      "masc_transition";
-      "masc_add_task";
-    ]
-    |> List.sort_uniq String.compare
-  in
-  Alcotest.(check bool) "keeps keeper internal tool" true
-    (List.mem "keeper_time_now" names);
-  Alcotest.(check bool) "keeps legacy standard masc tool" true
-    (List.mem "masc_status" names);
-  Alcotest.(check (list string)) "default keeps expected masc set"
-    expected_legacy_masc_names legacy_masc_names;
-  Alcotest.(check bool) "default exposes full read surface" true
-    (List.mem "tool_read_file" names)
+  with
+  | Ok _ -> Alcotest.fail "expected missing tool_access rejection"
+  | Error e ->
+    Alcotest.(check bool) "mentions tool_access" true
+      (contains_substring e "tool_access must be an array")
 
 let test_read_meta_file_rejects_legacy_tool_keys () =
   let dir = temp_dir () in
@@ -373,7 +400,7 @@ let test_read_meta_file_rejects_legacy_tool_keys () =
             (Yojson.Safe.Util.member "tool_preset" persisted
              |> Yojson.Safe.Util.to_string))
 
-let test_read_meta_file_defaults_legacy_tool_access_object_without_tools () =
+let test_read_meta_file_rejects_tool_access_object_without_tools () =
   let dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir dir)
@@ -385,18 +412,15 @@ let test_read_meta_file_defaults_legacy_tool_access_object_without_tools () =
             ("name", `String "legacy-object");
             ("agent_name", `String "legacy-object");
             ("trace_id", `String "legacy-object-trace");
-            ("runtime_id", `String "test.runtime");
             ("tool_access", `Assoc [ ("preset", `String "full") ]);
           ]);
       match Masc_mcp.Keeper_meta_store.read_meta_file_path path with
-      | Error e -> Alcotest.fail e
-      | Ok None -> Alcotest.fail "expected keeper meta"
-      | Ok (Some meta) ->
-          let names = KET.keeper_allowed_tool_names meta in
-          Alcotest.(check bool) "default keeps keeper internal tool" true
-            (List.mem "keeper_time_now" names))
+      | Ok _ -> Alcotest.fail "expected tool_access object rejection"
+      | Error e ->
+          Alcotest.(check bool) "mentions array" true
+            (contains_substring e "tool_access must be an array"))
 
-let test_read_meta_file_defaults_missing_tool_access_without_rewrite () =
+let test_read_meta_file_rejects_missing_tool_access () =
   let dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir dir)
@@ -408,20 +432,12 @@ let test_read_meta_file_defaults_missing_tool_access_without_rewrite () =
             ("name", `String "legacy-standard");
             ("agent_name", `String "legacy-standard");
             ("trace_id", `String "legacy-standard-trace");
-            ("runtime_id", `String "test.runtime");
-            ("sandbox_profile", `String "local");
-            ("network_mode", `String "inherit");
           ]);
       match Masc_mcp.Keeper_meta_store.read_meta_file_path path with
-      | Error e -> Alcotest.fail e
-      | Ok None -> Alcotest.fail "expected keeper meta"
-      | Ok (Some meta) ->
-          let names = KET.keeper_allowed_tool_names meta in
-          Alcotest.(check bool) "default keeps keeper internal tool" true
-            (List.mem "keeper_time_now" names);
-          let persisted = read_json_file path in
-          Alcotest.(check bool) "missing tool_access not rewritten" true
-            (Yojson.Safe.Util.member "tool_access" persisted = `Null))
+      | Ok _ -> Alcotest.fail "expected missing tool_access rejection"
+      | Error e ->
+          Alcotest.(check bool) "mentions tool_access" true
+            (contains_substring e "tool_access must be an array"))
 
 let test_meta_of_json_rejects_legacy_tool_policy_keys () =
   match Masc_test_deps.meta_of_json_fixture
@@ -440,26 +456,21 @@ let test_meta_of_json_rejects_legacy_tool_policy_keys () =
         "removed keeper meta fields: tool_preset"
         e
 
-let test_tool_access_legacy_object_empty_tools_preserved () =
-  let meta =
-    match Masc_test_deps.meta_of_json_fixture
+let test_tool_access_object_empty_tools_rejected () =
+  match
+    Masc_test_deps.meta_of_json_fixture
       (`Assoc
-        [
-          ("name", `String "preset-json");
-          ("agent_name", `String "preset-json");
-          ("trace_id", `String "preset-json-trace");
-          ( "tool_access",
-            `Assoc
-              [
-                ("tools", `List []);
-              ] );
-        ])
-    with
-    | Ok meta -> meta
-    | Error e -> failwith e
-  in
-  let names = meta.Masc_mcp.Keeper_meta_contract.tool_access in
-  Alcotest.(check int) "legacy object empty tools preserved" 0 (List.length names)
+         [
+           ("name", `String "preset-json");
+           ("agent_name", `String "preset-json");
+           ("trace_id", `String "preset-json-trace");
+           ("tool_access", `Assoc [ ("tools", `List []) ]);
+         ])
+  with
+  | Ok _ -> Alcotest.fail "expected object tool_access rejection"
+  | Error e ->
+      Alcotest.(check bool) "mentions array" true
+        (contains_substring e "tool_access must be an array")
 
 let test_tool_access_array_empty_json_preserved () =
   let meta =
@@ -478,7 +489,7 @@ let test_tool_access_array_empty_json_preserved () =
   let names = meta.Masc_mcp.Keeper_meta_contract.tool_access in
   Alcotest.(check int) "custom empty preserved" 0 (List.length names)
 
-let test_tool_access_legacy_object_with_tools_preserved () =
+let test_tool_access_object_with_tools_rejected () =
   match Masc_test_deps.meta_of_json_fixture
     (`Assoc
       [
@@ -488,12 +499,12 @@ let test_tool_access_legacy_object_with_tools_preserved () =
         ("tool_access", `Assoc [ ("tools", `List [ `String "masc_status" ]) ]);
       ])
   with
-  | Error e -> Alcotest.fail e
-  | Ok meta ->
-      let names = meta.Masc_mcp.Keeper_meta_contract.tool_access in
-      Alcotest.(check (list string)) "legacy tools preserved" [ "masc_status" ] names
+  | Ok _ -> Alcotest.fail "expected object tool_access rejection"
+  | Error e ->
+      Alcotest.(check bool) "mentions array" true
+        (contains_substring e "tool_access must be an array")
 
-let test_tool_access_legacy_object_without_tools_defaults () =
+let test_tool_access_object_without_tools_rejected () =
   match Masc_test_deps.meta_of_json_fixture
     (`Assoc
       [
@@ -503,12 +514,10 @@ let test_tool_access_legacy_object_without_tools_defaults () =
         ("tool_access", `Assoc [ ("preset", `String "full") ]);
       ])
   with
+  | Ok _ -> Alcotest.fail "expected object tool_access rejection"
   | Error e ->
-      Alcotest.fail e
-  | Ok meta ->
-      let names = meta.Masc_mcp.Keeper_meta_contract.tool_access in
-      Alcotest.(check bool) "legacy object defaults" true
-        (List.mem "keeper_time_now" names)
+      Alcotest.(check bool) "mentions array" true
+        (contains_substring e "tool_access must be an array")
 
 let test_tool_access_invalid_tool_member_rejected () =
   match Masc_test_deps.meta_of_json_fixture
@@ -517,18 +526,14 @@ let test_tool_access_invalid_tool_member_rejected () =
         ("name", `String "invalid-tool-member");
         ("agent_name", `String "invalid-tool-member");
         ("trace_id", `String "invalid-tool-member-trace");
-        ( "tool_access",
-          `Assoc
-            [
-              ("tools", `List [ `String "masc_status"; `Int 1 ]);
-            ] );
+        ("tool_access", `List [ `String "masc_status"; `Int 1 ]);
       ])
   with
   | Ok _ -> Alcotest.fail "expected invalid tool member to fail"
   | Error e ->
       Alcotest.(check string)
         "invalid tool member error"
-        "meta parse error: keeper tool_access.tools[1] must be a string (received int)"
+        "meta parse error: keeper tool_access[1] must be a string (received int)"
         e
 
 let test_allowlist_gates_shard_tools () =
@@ -581,14 +586,16 @@ let test_approval_pending_bridge_uses_keeper_safe_inline_dispatch () =
               raw))
 
 let test_read_only_preflight_accepts_sandbox_relative_repo_path () =
+  prime_keeper_bridge ();
   let dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
       git_ok ~cwd:dir [ "init"; "--quiet" ];
+      write_keeper_repo_mapping dir "masc-improver" [ "masc-mcp" ];
       let file_path =
         Filename.concat dir
-          ".masc/playground/docker/masc-improver/repos/masc-mcp/lib/thompson_sampling.ml"
+          ".masc/playground/masc-improver/repos/masc-mcp/lib/thompson_sampling.ml"
       in
       ensure_dir (Filename.dirname file_path);
       write_text_file file_path "let alpha = 0.1\nlet beta = 0.2\n";
@@ -598,15 +605,15 @@ let test_read_only_preflight_accepts_sandbox_relative_repo_path () =
         let meta =
           make_meta
             ~name:"masc-improver"
-            ~sandbox_profile:Masc_mcp.Keeper_types_profile_sandbox.Docker
+            ~sandbox_profile:Masc_mcp.Keeper_types_profile_sandbox.Local
             ~tool_access:([ "tool_read_file" ])
             ()
         in
         with_registered_keeper ~config meta (fun () ->
             let raw =
-              Masc_mcp.Agent_tool_remote_mcp_runtime.handle_masc_tool
+              dispatch_keeper_tool
                 ~config
-                ~keeper_name:meta.name
+                ~meta
                 ~name:"tool_read_file"
                 ~args:
                   (`Assoc
@@ -618,20 +625,14 @@ let test_read_only_preflight_accepts_sandbox_relative_repo_path () =
                     ])
             in
             let json = Yojson.Safe.from_string raw in
-            let path =
-              Yojson.Safe.Util.member "path" json |> Yojson.Safe.Util.to_string
-            in
-            let lines =
-              Yojson.Safe.Util.member "lines" json
-              |> Yojson.Safe.Util.to_list
-              |> List.map Yojson.Safe.Util.to_string
-            in
-            Alcotest.(check string) "path preserved"
-              "repos/masc-mcp/lib/thompson_sampling.ml"
-              path;
-            Alcotest.(check (list string)) "reads expected lines"
-              [ "let alpha = 0.1"; "let beta = 0.2" ]
-              lines)))
+            match Yojson.Safe.Util.member "error" json with
+            | `Null -> ()
+            | `String err ->
+              Alcotest.failf "tool_read_file should pass read preflight, got: %s" err
+            | other ->
+              Alcotest.failf
+                "unexpected error shape: %s"
+                (Yojson.Safe.to_string other))))
 
 let test_write_preflight_accepts_docker_container_repo_path () =
   let dir = temp_dir () in
@@ -644,6 +645,7 @@ let test_write_preflight_accepts_docker_container_repo_path () =
       in
       ensure_dir (Filename.dirname keeper_toml);
       write_text_file keeper_toml "[keeper]\nsandbox_profile = \"docker\"\n";
+      write_keeper_repo_mapping dir "sangsu" [ "masc-mcp" ];
       let file_path =
         Filename.concat dir
           ".masc/playground/docker/sangsu/repos/masc-mcp/.worktrees/keeper-sangsu-agent-task-210/lib/workspace/workspace_orphan_daemon.ml"
@@ -663,9 +665,9 @@ let test_write_preflight_accepts_docker_container_repo_path () =
         in
         with_registered_keeper ~config meta (fun () ->
           let raw =
-            Masc_mcp.Agent_tool_remote_mcp_runtime.handle_masc_tool
+            dispatch_keeper_tool
               ~config
-              ~keeper_name:meta.name
+              ~meta
               ~name:"tool_edit_file"
               ~args:
                 (`Assoc
@@ -674,21 +676,22 @@ let test_write_preflight_accepts_docker_container_repo_path () =
                       `String
                         "/home/keeper/playground/sangsu/repos/masc-mcp/.worktrees/keeper-sangsu-agent-task-210/lib/workspace/workspace_orphan_daemon.ml"
                     );
+                    ("mode", `String "patch");
                     ("old_string", `String "let before = 1");
                     ("new_string", `String "let before = 2");
                     ("replace_all", `Bool false);
                   ])
           in
           let json = Yojson.Safe.from_string raw in
-          let status =
-            Yojson.Safe.Util.member "status" json |> Yojson.Safe.Util.to_string
+          let ok =
+            Yojson.Safe.Util.member "ok" json |> Yojson.Safe.Util.to_bool
           in
-          let replacements =
-            Yojson.Safe.Util.member "replacements" json
+          let occurrences =
+            Yojson.Safe.Util.member "occurrences" json
             |> Yojson.Safe.Util.to_int
           in
-          Alcotest.(check string) "edit status" "ok" status;
-          Alcotest.(check int) "single replacement" 1 replacements;
+          Alcotest.(check bool) "edit ok" true ok;
+          Alcotest.(check int) "single replacement" 1 occurrences;
           Alcotest.(check string)
             "file edited through host playground"
             "let before = 2\n"
@@ -717,6 +720,7 @@ let test_write_preflight_accepts_sandbox_relative_repo_path () =
       in
       ensure_dir (Filename.dirname keeper_config);
       write_text_file keeper_config "[keeper]\nsandbox_profile = \"docker\"\n";
+      write_keeper_repo_mapping dir keeper_name [ "masc-mcp" ];
       ensure_dir (Filename.dirname file_path);
       write_text_file file_path "let x = 1\n";
       run_with_fs (fun () ->
@@ -730,13 +734,14 @@ let test_write_preflight_accepts_sandbox_relative_repo_path () =
         in
         ignore (Masc_mcp.Keeper_registry.register ~base_path:dir keeper_name meta);
         let raw =
-          Masc_mcp.Agent_tool_remote_mcp_runtime.handle_masc_tool
+          dispatch_keeper_tool
             ~config
-            ~keeper_name
+            ~meta
             ~name:"tool_edit_file"
             ~args:
               (`Assoc
                 [ "path", `String rel_path
+                ; "mode", `String "patch"
                 ; "old_string", `String "let x = 1"
                 ; "new_string", `String "let x = 2"
                 ; "replace_all", `Bool false
@@ -853,24 +858,24 @@ let () =
         ] );
       ( "meta_json",
         [
-          Alcotest.test_case "missing tool_access defaults standard policy" `Quick
+          Alcotest.test_case "missing tool_access rejected" `Quick
             test_tool_access_missing_defaults_standard_policy;
           Alcotest.test_case "read_meta rejects legacy tool keys" `Quick
             test_read_meta_file_rejects_legacy_tool_keys;
-          Alcotest.test_case "read_meta drains legacy tool_access object" `Quick
-            test_read_meta_file_defaults_legacy_tool_access_object_without_tools;
-          Alcotest.test_case "read_meta defaults missing tool_access without rewrite" `Quick
-            test_read_meta_file_defaults_missing_tool_access_without_rewrite;
+          Alcotest.test_case "read_meta rejects tool_access object" `Quick
+            test_read_meta_file_rejects_tool_access_object_without_tools;
+          Alcotest.test_case "read_meta rejects missing tool_access" `Quick
+            test_read_meta_file_rejects_missing_tool_access;
           Alcotest.test_case "direct meta_of_json rejects legacy tool keys" `Quick
             test_meta_of_json_rejects_legacy_tool_policy_keys;
-          Alcotest.test_case "legacy object empty tools preserved" `Quick
-            test_tool_access_legacy_object_empty_tools_preserved;
+          Alcotest.test_case "tool_access object empty tools rejected" `Quick
+            test_tool_access_object_empty_tools_rejected;
           Alcotest.test_case "array empty json preserved" `Quick
             test_tool_access_array_empty_json_preserved;
-          Alcotest.test_case "legacy object tools preserved" `Quick
-            test_tool_access_legacy_object_with_tools_preserved;
-          Alcotest.test_case "legacy object without tools defaults" `Quick
-            test_tool_access_legacy_object_without_tools_defaults;
+          Alcotest.test_case "tool_access object tools rejected" `Quick
+            test_tool_access_object_with_tools_rejected;
+          Alcotest.test_case "tool_access object without tools rejected" `Quick
+            test_tool_access_object_without_tools_rejected;
           Alcotest.test_case "invalid tool member rejected" `Quick
             test_tool_access_invalid_tool_member_rejected;
         ] );

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -921,7 +921,7 @@ max_turns_per_call_scheduled_autonomous = 0
        check int "zero autonomous falls back" 10
          (KTP.effective_max_turns_per_call_scheduled_autonomous d))
 
-let test_profile_accepts_legacy_runtime_id_alias () =
+let test_profile_accepts_runtime_id () =
   let input = {|
 [keeper]
 goal = "test"
@@ -934,7 +934,7 @@ runtime_id = "oas-coding_first"
      | Error e -> fail e
      | Ok defaults ->
        check (option string)
-         "legacy runtime_id aliases runtime id"
+         "runtime_id"
          (Some "oas-coding_first")
          defaults.model)
 
@@ -1071,7 +1071,7 @@ tool_denylist = ["OPERATOR_TODO: remove before spawn"]
       check bool "reports resolved payload field" true
         (contains_substring e "$.tool_denylist[0]")
 
-let test_persona_resolver_ignores_non_public_social_model_arg () =
+let test_persona_resolver_rejects_non_public_social_model_arg () =
   with_personas_dir @@ fun personas_dir ->
   let persona_dir = Filename.concat personas_dir "probe" in
   mkdir_p persona_dir;
@@ -1093,12 +1093,10 @@ let test_persona_resolver_ignores_non_public_social_model_arg () =
           ("social_model", `String "magentic_ledger_v1");
         ])
   with
-  | Error e -> fail ("resolver failed: " ^ e)
-  | Ok (_, resolved) ->
-      check bool "social_model omitted from resolved args" false
-        (match Yojson.Safe.Util.member "social_model" resolved with
-         | `String _ -> true
-         | _ -> false)
+  | Ok _ -> fail "expected social_model arg rejection"
+  | Error e ->
+      check bool "reports non-public arg" true
+        (contains_substring e "non-public keeper args")
 
 let test_persona_resolver_preserves_autoboot_enabled_arg () =
   with_personas_dir @@ fun personas_dir ->
@@ -1927,8 +1925,8 @@ let () =
             test_profile_rejects_removed_initiative_keys;
           test_case "legacy allowed_providers rejected" `Quick
             test_profile_rejects_legacy_allowed_providers;
-          test_case "legacy runtime_id aliases runtime id" `Quick
-            test_profile_accepts_legacy_runtime_id_alias;
+          test_case "runtime_id parsed" `Quick
+            test_profile_accepts_runtime_id;
           test_case "max_turns overrides parsed and applied" `Quick
             test_profile_max_turns_overrides;
           test_case "max_turns defaults when absent" `Quick
@@ -2006,8 +2004,8 @@ let () =
             test_persona_resolver_reports_placeholder_defaults_source;
           test_case "persona resolver rejects placeholder in resolved payload" `Quick
             test_persona_resolver_rejects_placeholder_in_resolved_payload;
-          test_case "persona resolver ignores non-public social_model arg" `Quick
-            test_persona_resolver_ignores_non_public_social_model_arg;
+          test_case "persona resolver rejects non-public social_model arg" `Quick
+            test_persona_resolver_rejects_non_public_social_model_arg;
           test_case "persona resolver preserves autoboot_enabled arg" `Quick
             test_persona_resolver_preserves_autoboot_enabled_arg;
           test_case "persona resolver preserves canonical tool_access and allowed_paths" `Quick


### PR DESCRIPTION
## Summary
- Strictly reject retired keeper config/meta fallback fields instead of migrating or scrubbing them.
- Require canonical `tool_access` arrays and `runtime_id`, rejecting old `model` and tool-policy object forms.
- Update bridge/status/TOML/meta tests and fix filesystem preflight dispatch fixture coverage.

## Breaking changes
- Missing/object/null `tool_access` in persisted keeper meta is rejected.
- TOML `keeper.model`, non-public keeper args, and retired runtime/config fields are rejected.
- Legacy wire reason `keeper_shell_op_required` and legacy snapshot synthesis are removed.

## OAS pin
- Not bumped in this PR because `scripts/check-oas-pin.sh` requires an OAS SHA reachable from OAS `main`; bump after the OAS PR merges.

## Validation
- `env DUNE_BUILD_DIR=/tmp/masc-fallback-purge-20260601-pr-build ./scripts/dune-local.sh build test/test_keeper_toml.exe test/test_keeper_masc_bridge.exe test/test_config_runtime_split.exe test/test_keeper_auto_pause_blocker_persist_12683.exe`
- `/tmp/masc-fallback-purge-20260601-pr-build/default/test/test_keeper_toml.exe`
- `/tmp/masc-fallback-purge-20260601-pr-build/default/test/test_keeper_masc_bridge.exe`
- `/tmp/masc-fallback-purge-20260601-pr-build/default/test/test_config_runtime_split.exe`
- `/tmp/masc-fallback-purge-20260601-pr-build/default/test/test_keeper_auto_pause_blocker_persist_12683.exe`
- `./scripts/check-oas-pin.sh --local-only`
- `git diff --check`
