### PR TITLE
Purge keeper max tools per turn residue

### DIFF
--- a/docs/BOOT-ENV-STATE-INVENTORY.md
+++ b/docs/BOOT-ENV-STATE-INVENTORY.md
@@ -159,7 +159,6 @@ max_active_keepers = 12
 [turn]
 stream_idle_timeout_sec = 120
 tool_cost_max_usd = 1.25
-max_tools_per_turn = 64
 llm_rerank = true
 
 [watchdog]

--- a/lib/keeper/keeper_tool_selection.ml
+++ b/lib/keeper/keeper_tool_selection.ml
@@ -91,12 +91,11 @@ let merge_tool_selection_boundary
   : string list
   =
   let sorted_discovered = List.sort String.compare discovered in
-  (* BM25-relevant tools first: when downstream truncation caps at
-     max_tools, the tail is dropped.  Placing deterministic_prefilter
-     and discovered before core ensures context-relevant tools survive
-     while generic core tools are truncated first.
-     Core tools that also appear in deterministic_prefilter are deduped
-     (first occurrence wins), so they naturally keep their BM25 rank. *)
+  (* Keep deterministic BM25 hits and explicit discoveries ahead of generic
+     core tools. This ordering preserves relevance signals without imposing a
+     global visible-tool count limit. Core tools that also appear in
+     deterministic_prefilter are deduped (first occurrence wins), so they
+     naturally keep their BM25 rank. *)
   let deterministic_floor =
     Keeper_types_profile_toml_normalizers.dedupe_keep_order (deterministic_prefilter @ sorted_discovered @ core)
   in

--- a/test/test_keeper_runtime_toml.ml
+++ b/test/test_keeper_runtime_toml.ml
@@ -184,13 +184,10 @@ let test_applies_turn_execution_overrides () =
   let count, overrides =
     Keeper_runtime_config.resolve_overrides ~env_lookup:empty_env doc
   in
-  check int "applied 7" 7 count;
+  check int "applied 6" 6 count;
   check (option string) "tool cost ceiling"
     (Some "1.25")
     (List.assoc_opt "MASC_KEEPER_TOOL_COST_MAX_USD" overrides);
-  check (option string) "max tools per turn"
-    (Some "64")
-    (List.assoc_opt "MASC_KEEPER_MAX_TOOLS_PER_TURN" overrides);
   check (option string) "llm rerank"
     (Some "true")
     (List.assoc_opt "MASC_KEEPER_LLM_RERANK" overrides);

--- a/test/test_keeper_topk_llm.ml
+++ b/test/test_keeper_topk_llm.ml
@@ -551,11 +551,7 @@ let test_tool_surface_selection_preserves_order () =
 let test_keeper_config_defaults () =
   (* Default: LLM rerank disabled *)
   Alcotest.(check bool) "llm_rerank disabled by default"
-    false (Keeper_config.keeper_llm_rerank_enabled ());
-  (* Default runtime name *)
-  let runtime = Keeper_config.keeper_llm_rerank_runtime () in
-  Alcotest.(check string) "default runtime name"
-    "route.llm_rerank" runtime
+    false (Keeper_config.keeper_llm_rerank_enabled ())
 
 (* ── Suite ───────────────────────────────────────────────── *)
 
@@ -610,7 +606,7 @@ let () =
         test_tool_search_partition_projects_allowed_internal_to_public_alias;
       Alcotest.test_case "tool_search filters denied core hits" `Quick
         test_tool_search_partition_filters_policy_denied_core_hits;
-      Alcotest.test_case "tool surface truncation dedupes essential tools" `Quick
+      Alcotest.test_case "tool surface selection preserves order" `Quick
         test_tool_surface_selection_preserves_order;
     ];
     "keeper_config", [


### PR DESCRIPTION
## Summary

- Remove the stale `max_tools_per_turn` TOML example and `MASC_KEEPER_MAX_TOOLS_PER_TURN` test expectation.
- Rewrite tool-selection comments/test labels so they describe ordering without implying a visible-tool cap.
- Drop a config-less test assertion that called `keeper_llm_rerank_runtime()` before `Runtime.init_default`.

## Product impact

- User-visible change: none. This removes stale config/test/docs residue for a rejected global visible-tool cap.

## Evidence

- `scripts/check-oas-pin.sh --local-only`
- `ocamlformat --check lib/keeper/keeper_tool_selection.ml test/test_keeper_runtime_toml.ml test/test_keeper_topk_llm.ml`
- `git diff --check`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_runtime_toml.exe test/test_keeper_topk_llm.exe`
- `_build/default/test/test_keeper_runtime_toml.exe`
- `_build/default/test/test_keeper_topk_llm.exe`
- `rg "MASC_KEEPER_MAX_TOOLS_PER_TURN|keeper\\.turn\\.max_tools_per_turn|max_tools_per_turn|tool surface truncation|downstream truncation" lib test docs` returned no matches.

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 0/7
provenance: operator_proxy
stages:
  - name: oas_pin
    command: scripts/check-oas-pin.sh --local-only
    result: pass
  - name: formatting
    command: ocamlformat --check lib/keeper/keeper_tool_selection.ml test/test_keeper_runtime_toml.ml test/test_keeper_topk_llm.ml
    result: pass
  - name: whitespace
    command: git diff --check
    result: pass
  - name: focused_build
    command: env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_runtime_toml.exe test/test_keeper_topk_llm.exe
    result: pass
  - name: runtime_toml_tests
    command: _build/default/test/test_keeper_runtime_toml.exe
    result: pass
  - name: topk_llm_tests
    command: _build/default/test/test_keeper_topk_llm.exe
    result: pass
  - name: residue_scan
    command: rg MASC_KEEPER_MAX_TOOLS_PER_TURN|keeper\\.turn\\.max_tools_per_turn|max_tools_per_turn|tool surface truncation|downstream truncation lib test docs
    result: pass
```

## GOAL LOOP ACT checklist

- [x] Observe — stale max-tools residue remained in docs/tests/comments after the visible cap PR was rejected.
- [x] Orient — the residue implied a global visible-tool cap that should not exist.
- [x] Decide — purge only the residue; do not introduce ranking, truncation, env, runtime param, or governance entries.
- [x] Act — docs, comments, and tests updated in the smallest bounded scope.
- [x] Verify — focused build/tests and residue scan passed.
- [x] Loop — no follow-up for max-tools cap; future tool-surface size issues should be measured as search/relevance work.

## Review evidence

- Cross-model review: not run; cleanup is a narrow residue purge with local focused verification.

## Linked issue

- Closes #N/A
- Relates #19696

## Variant addition checklist

- [ ] **OCaml** — N/A; no variants changed.
- [ ] **TypeScript** — N/A; no TypeScript unions changed.
- [ ] **TLA+ spec** — N/A; no TLA+ domain literals changed.
- [ ] **Event / JSON schema** — N/A; no event strings, schema enums, or keeper TOML key registry entries added.
- [ ] **`make check-variants` passes** — N/A; no variant/schema surface changed.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`purge/keeper-max-tools-per-turn-20260601` → `main` · 1 commit(s) · synced 2026-06-01T05:57:02Z

| sha | subject | date |
|---|---|---|
| `a852a724a` | purge keeper max tools per turn residue | 2026-06-01 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->