### PR TITLE
fix(keeper): compaction FSM accumulating->done transition violation

### DIFF
--- a/lib/keeper/keeper_context_runtime.ml
+++ b/lib/keeper/keeper_context_runtime.ml
@@ -253,13 +253,27 @@ let dispatch_post_turn_lifecycle_events
     ~keeper_name
     (lifecycle : post_turn_lifecycle) =
   if lifecycle.compaction.attempted then
-    if lifecycle.compaction.applied then
+    if lifecycle.compaction.applied then begin
+      (* The on_compaction_started callback in apply_post_turn_lifecycle
+         dispatches Compaction_started, but is wrapped in Cancel_safe.observe
+         which swallows exceptions.  If the dispatch fails (registry
+         contention, stale entry), the compaction stage stays at
+         accumulating while the save succeeds (applied = true).
+         Without this guard, Compaction_completed would attempt the
+         forbidden accumulating -> done transition.
+         Compaction_started is idempotent from compacting state, so
+         dispatching it here is safe even if the callback succeeded. *)
+      dispatch_keeper_phase_event ~config
+        ~origin:Keeper_registry.Post_turn_lifecycle
+        ~keeper_name
+        Keeper_state_machine.Compaction_started;
       dispatch_compaction_completed
         ~config
         ~origin:Keeper_registry.Post_turn_lifecycle
         ~keeper_name
         ~before_tokens:lifecycle.compaction.before_tokens
         ~after_tokens:lifecycle.compaction.after_tokens
+    end
     else
       dispatch_keeper_phase_event
         ~config


### PR DESCRIPTION
## Problem

`Compaction_transition_violation` raised at runtime:

```
validate_compaction_transition: invalid compaction transition
Compaction_accumulating -> Compaction_done (spec_violation=accumulating->done)
```

**Root cause**: The `on_compaction_started` callback in `apply_post_turn_lifecycle` dispatches `Compaction_started` to transition the FSM from `accumulating` to `compacting`. However, it is wrapped in `Cancel_safe.observe` which swallows exceptions. When the dispatch fails (registry contention, stale entry), the compaction stage remains at `accumulating` while the checkpoint save succeeds (`applied = true`). The subsequent `Compaction_completed` dispatch then attempts the forbidden `accumulating -> done` transition.

## Fix

Dispatch `Compaction_started` right before `Compaction_completed` in `dispatch_post_turn_lifecycle_events`. This ensures the FSM path is always `accumulating -> compacting -> done`. The `Compaction_started` dispatch is idempotent from `compacting` state, so a duplicate is harmless when the callback already succeeded.

## Verification

- `dune build @check --root .` EXIT=0
- `dune build . --root .` EXIT=0

## Files changed

- `lib/keeper/keeper_context_runtime.ml` (+14/-1): guard `Compaction_completed` with preceding `Compaction_started` dispatch

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
