### PR TITLE
[codex] Clarify keeper Read path context

### DIFF
--- a/lib/keeper/agent_tool_descriptor.ml
+++ b/lib/keeper/agent_tool_descriptor.ml
@@ -190,7 +190,12 @@ let execute_schema = Tool_shard_types_schemas_execute.tool_execute_schema.input_
 let read_file_schema =
   object_schema
     ~required:[ "file_path" ]
-    [ property "file_path" "string" "Absolute or sandbox-relative file path to read."
+    [ property
+        "file_path"
+        "string"
+        "Existing file path to read. Read has no implicit cwd and does not inherit \
+         Execute cwd; use an absolute path, a sandbox-relative path, or a path returned \
+         by Grep/Execute listing."
     ; property
         "limit"
         "integer"
@@ -433,7 +438,9 @@ let public_descriptors =
       ~id:"agent.read_file"
       ~public_name:"Read"
       ~internal_name:"tool_read_file"
-      ~description:"Read one file from the keeper sandbox or an allowed path."
+      ~description:
+        "Read one existing file from the keeper sandbox or an allowed path. Read has no \
+         implicit cwd; list or search first when the exact path is unclear."
       ~input_schema:read_file_schema
       ~policy:
         (policy

--- a/lib/keeper/agent_tool_filesystem_runtime.ml
+++ b/lib/keeper/agent_tool_filesystem_runtime.ml
@@ -78,6 +78,7 @@ let handle_read_file
        in
        missing_file_error_json
          ~config
+         ~meta
          ~target
          ~fallback_dir
          ~error:
@@ -137,7 +138,7 @@ let handle_read_file
              else (
                match Safe_ops.read_file_safe target with
                | Error e when String.starts_with ~prefix:file_not_found_prefix e ->
-                 missing_file_error_json ~config ~target ~fallback_dir ~error:e
+                 missing_file_error_json ~config ~meta ~target ~fallback_dir ~error:e
                | Error e -> error_json ~fields:[ "path", `String target ] e
                | Ok content ->
                  let total = String.length content in

--- a/lib/keeper/agent_tool_shared_runtime.ml
+++ b/lib/keeper/agent_tool_shared_runtime.ml
@@ -116,6 +116,7 @@ let file_not_found_prefix = "File not found:"
 
 let missing_file_error_json
       ~(config : Workspace.config)
+      ~(meta : keeper_meta)
       ~(target : string)
       ~(fallback_dir : string)
       ~(error : string)
@@ -126,8 +127,26 @@ let missing_file_error_json
      and listing its contents leaks its directory layout (oracle leak).
      The generic error string already contains the path that was tried,
      which is sufficient for the LLM to self-correct. *)
+  let playground = Keeper_sandbox.allowed_root_rel_of_meta ~meta in
   Yojson.Safe.to_string
-    (`Assoc [ "ok", `Bool false; "error", `String error; "path", `String target ])
+    (`Assoc
+        [ "ok", `Bool false
+        ; "error", `String error
+        ; "path", `String target
+        ; "your_playground", `String playground
+        ; ( "path_resolution"
+          , `Assoc
+              [ "implicit_cwd", `Bool false
+              ; ( "basis"
+                , `String
+                    "Read resolves file_path against the keeper sandbox or explicit \
+                     allowed_paths; it does not inherit Execute cwd." )
+              ; ( "next_action"
+                , `String
+                    "Use Grep or Execute ls to discover the exact file path, then pass \
+                     that path to Read." )
+              ] )
+        ])
 ;;
 
 let find_registry_meta ~(keeper_name : string) ~(source_layer : string)

--- a/lib/keeper/agent_tool_shared_runtime.mli
+++ b/lib/keeper/agent_tool_shared_runtime.mli
@@ -38,11 +38,13 @@ val actionable_path_error
 
 val file_not_found_prefix : string
 
-(** Render a missing-file JSON envelope with the error and path.
+(** Render a missing-file JSON envelope with the error, path, and
+    path-resolution guidance.
     #10349: directory entries are intentionally excluded to prevent
     sandbox oracle leaks when keeper identity drifts. *)
 val missing_file_error_json
   :  config:Workspace.config
+  -> meta:Keeper_meta_contract.keeper_meta
   -> target:string
   -> fallback_dir:string
   -> error:string

--- a/lib/keeper/keeper_runtime_contract.ml
+++ b/lib/keeper/keeper_runtime_contract.ml
@@ -227,6 +227,19 @@ let redact_backend_details = function
            fields)
   | json -> json
 
+let path_resolution_contract_json =
+  `Assoc
+    [ "read_implicit_cwd", `Bool false
+    ; ( "read_basis"
+      , `String
+          "Read file_path is absolute or relative to the keeper sandbox/allowed_paths; \
+           it does not inherit Execute cwd." )
+    ; ( "discover_before_read"
+      , `String
+          "When unsure, use Grep or Execute ls to discover concrete paths before Read."
+      )
+    ]
+
 let runtime_observability_contract_json_from_fields ~keeper_name ?agent_name ?trace_id
     ?session_id ?generation ?keeper_turn_id ?task_id ?goal_ids
     ?sandbox_profile ?sandbox_root ?allowed_paths ?network_mode ?approval_mode ?tool_surface_class
@@ -245,6 +258,7 @@ let runtime_observability_contract_json_from_fields ~keeper_name ?agent_name ?tr
       ("sandbox_profile", string_opt_json sandbox_profile);
       ("sandbox_root", string_opt_json sandbox_root);
       ("allowed_paths", Json_util.json_string_list (nonempty_list allowed_paths));
+      ("path_resolution", path_resolution_contract_json);
       ("network_mode", string_opt_json network_mode);
       ("approval_mode", string_opt_json approval_mode);
       ("tool_surface_class", string_opt_json tool_surface_class);

--- a/test/test_agent_tool_descriptor_registry_integrity.ml
+++ b/test/test_agent_tool_descriptor_registry_integrity.ml
@@ -100,6 +100,19 @@ let test_internal_name_uniqueness () =
 
 let is_blank s = String.trim s = ""
 
+let string_contains ~sub text =
+  let text_len = String.length text in
+  let sub_len = String.length sub in
+  let rec loop idx =
+    if idx + sub_len > text_len
+    then false
+    else if String.sub text idx sub_len = sub
+    then true
+    else loop (idx + 1)
+  in
+  sub_len = 0 || loop 0
+;;
+
 let test_no_blank_names () =
   List.iter
     (fun d ->
@@ -137,6 +150,34 @@ let test_internal_name_snake_case () =
 let test_registry_not_empty () =
   if all_descriptors () = []
   then Alcotest.failf "Agent_tool_descriptor.all_descriptors () returned []"
+
+let required_public_descriptor name =
+  match Descriptor.find_public name with
+  | Some descriptor -> descriptor
+  | None -> Alcotest.failf "missing public descriptor: %s" name
+;;
+
+let schema_property_description schema name =
+  let open Yojson.Safe.Util in
+  schema |> member "properties" |> member name |> member "description"
+  |> to_string_option
+;;
+
+let test_read_descriptor_spells_out_path_basis () =
+  let descriptor = required_public_descriptor "Read" in
+  let file_path_description =
+    schema_property_description descriptor.input_schema "file_path"
+    |> Option.value ~default:""
+  in
+  Alcotest.(check bool)
+    "Read description says it has no implicit cwd"
+    true
+    (string_contains ~sub:"no implicit cwd" descriptor.description);
+  Alcotest.(check bool)
+    "Read file_path schema says it does not inherit Execute cwd"
+    true
+    (string_contains ~sub:"does not inherit Execute cwd" file_path_description)
+;;
 
 let test_masc_board_registry_has_descriptor_projection () =
   List.iter
@@ -434,6 +475,12 @@ let () =
     ; ( "format"
       , [ test_case "no blank name fields" `Quick test_no_blank_names
         ; test_case "internal_name is snake_case" `Quick test_internal_name_snake_case
+        ] )
+    ; ( "agent-contract"
+      , [ test_case
+            "Read path basis is explicit"
+            `Quick
+            test_read_descriptor_spells_out_path_basis
         ] )
     ; ( "masc-board"
       , [ test_case

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -743,6 +743,25 @@ let test_missing_file_error_redacts_directory_suggestions () =
            "detail preserves path"
            true
            (Option.is_some (Safe_ops.json_string_opt "path" detail));
+         check string
+           "detail names keeper playground"
+           (Keeper_sandbox.allowed_root_rel_of_meta ~meta)
+           (Yojson.Safe.Util.member "your_playground" detail
+            |> Yojson.Safe.Util.to_string);
+         let path_resolution =
+           Yojson.Safe.Util.member "path_resolution" detail
+         in
+         check bool
+           "detail says Read has no implicit cwd"
+           false
+           (Yojson.Safe.Util.member "implicit_cwd" path_resolution
+            |> Yojson.Safe.Util.to_bool);
+         check bool
+           "detail says Read does not inherit Execute cwd"
+           true
+           (Yojson.Safe.Util.member "basis" path_resolution
+            |> Yojson.Safe.Util.to_string
+            |> string_contains ~sub:"does not inherit Execute cwd");
          check
            bool
            "directory entries are not leaked"

--- a/test/test_trajectory.ml
+++ b/test/test_trajectory.ml
@@ -474,6 +474,9 @@ let test_runtime_contract_projection_redacts_backend_details () =
     (has_assoc_key "network_mode" keeper_visible);
   Alcotest.(check string) "keeper contract keeps sandbox root" "/workspace"
     (keeper_visible |> member "sandbox_root" |> to_string);
+  Alcotest.(check bool) "keeper contract says Read has no implicit cwd" false
+    (keeper_visible |> member "path_resolution" |> member "read_implicit_cwd"
+     |> to_bool);
   Alcotest.(check string) "observability keeps sandbox_profile" "docker"
     (observability |> member "sandbox_profile" |> to_string);
   Alcotest.(check string) "observability keeps network_mode" "none"


### PR DESCRIPTION
## Summary

- Clarify that keeper `Read` has no implicit cwd and does not inherit `Execute` cwd.
- Add missing-file response guidance with `your_playground` and path-resolution next actions without leaking directory entries.
- Surface the same path-resolution rule in the keeper runtime contract.

## Product impact

Keeper agents get a clearer path model before and after failed reads, reducing guessed `.ml/.mli` paths that resolve against an unexpected base.

## Evidence

- `ocamlformat --check lib/keeper/agent_tool_descriptor.ml lib/keeper/agent_tool_filesystem_runtime.ml lib/keeper/agent_tool_shared_runtime.ml lib/keeper/agent_tool_shared_runtime.mli lib/keeper/keeper_runtime_contract.ml test/test_agent_tool_descriptor_registry_integrity.ml test/test_keeper_tools_oas.ml test/test_trajectory.ml`
- `git diff --check`
- `scripts/check-oas-pin.sh --local-only`
- Focused Dune build was attempted, but local Dune validation was blocked by machine-wide Dune lock / bare-Dune contention from other worktrees before push.

## Direct evidence

schema_version: 1
direct_ratio: 3/4
provenance: direct

- Direct: descriptor text now says `Read` has no implicit cwd.
- Direct: missing-file JSON includes `path_resolution.implicit_cwd=false`.
- Direct: runtime contract includes `path_resolution.read_implicit_cwd=false`.
- Not direct: focused Dune build result is pending due unrelated local lock contention.

## Review evidence

- Added descriptor regression coverage for `Read` path-basis wording.
- Extended missing-file OAS wrapper coverage to preserve path guidance while keeping directory suggestions redacted.
- Extended trajectory/runtime contract coverage for the keeper-visible path-resolution rule.

## Linked issue

None.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`fix/read-path-context-20260601` → `main` · 1 commit(s) · synced 2026-06-01T07:34:44Z

| sha | subject | date |
|---|---|---|
| `5ae836ca8` | Clarify keeper Read path context | 2026-06-01 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->