### PR TITLE
Fix Docker route review follow-up

### DIFF
--- a/lib/keeper/agent_tool_execute_command_semantics.ml
+++ b/lib/keeper/agent_tool_execute_command_semantics.ml
@@ -160,7 +160,7 @@ let bare_worktrees_path token =
   || String.starts_with ~prefix:".worktrees/" token
   || String.starts_with ~prefix:"./.worktrees/" token
 
-let git_global_c_paths_of_stages stages =
+let git_global_c_path_groups_of_stages stages =
   let rec scan_git_args acc = function
     | "-C" :: path :: rest -> scan_git_args (path :: acc) rest
     | "-C" :: [] -> List.rev acc
@@ -178,7 +178,7 @@ let git_global_c_paths_of_stages stages =
     | _ :: _ -> List.rev acc
     | [] -> List.rev acc
   in
-  List.find_map (fun stage ->
+  List.filter_map (fun stage ->
     if normalize_command_name stage.bin = "git"
     then (
       match scan_git_args [] stage.args with
@@ -302,30 +302,56 @@ let resolve_sandbox_root_git_cwd_of_stages
                suggested_cwd
                (String.concat ", " many)) )
     in
-    let explicit_git_c_paths = git_global_c_paths_of_stages stages in
-    match explicit_git_c_paths with
-    | Some [ path ] when bare_worktrees_path path -> resolve_without_explicit_git_c ()
-    | Some paths ->
+    let explicit_git_c_path_groups = git_global_c_path_groups_of_stages stages in
+    let base_for_git_c_paths = function
+      | first :: _ when bare_worktrees_path first ->
+        (match repos_in_playground () with
+         | [ single_repo ] ->
+           Some (Filename.concat (Filename.concat host_root "repos") single_repo)
+         | _ -> None)
+      | _ -> Some cwd_normalized
+    in
+    let git_c_target_from_paths ~base paths =
+      List.fold_left
+        (fun cwd path ->
+           normalize_cwd_relative_path
+             ~container_root:(Keeper_sandbox.container_root meta.name)
+             ~host_root
+             ~cwd
+             path)
+        base
+        paths
+    in
+    let validate_git_c_paths paths =
+      match base_for_git_c_paths paths with
+      | None -> Ok ()
+      | Some base ->
       let target =
-        List.fold_left
-          (fun cwd path ->
-             normalize_cwd_relative_path
-               ~container_root:(Keeper_sandbox.container_root meta.name)
-               ~host_root
-               ~cwd
-               path)
-          cwd_normalized
-          paths
+        git_c_target_from_paths ~base paths
       in
       if path_is_existing_dir target
-      then cwd, None
+      then Ok ()
       else
-        cwd,
-        Some
+        Error
           (Printf.sprintf
              "cwd_not_directory: %s (git -C target must be an existing directory)"
              target)
-    | _ -> resolve_without_explicit_git_c ())
+    in
+    match explicit_git_c_path_groups with
+    | [] -> resolve_without_explicit_git_c ()
+    | groups ->
+      (match List.find_map
+               (fun paths ->
+                  match validate_git_c_paths paths with
+                  | Ok () -> None
+                  | Error msg -> Some msg)
+               groups
+       with
+       | Some msg -> cwd, Some msg
+       | None ->
+         if List.exists (List.exists bare_worktrees_path) groups
+         then resolve_without_explicit_git_c ()
+         else cwd, None))
   else cwd, None
 
 let effective_stages_of_cmd cmd =

--- a/lib/keeper/agent_tool_execute_path.ml
+++ b/lib/keeper/agent_tool_execute_path.ml
@@ -61,14 +61,14 @@ let repo_path_context ~(config : Workspace.config) ~(meta : keeper_meta) cwd =
         Some (repo_name, repo_root, repo_root, [ repo_root ])
       | _ -> None
 
-let repo_cwd_not_ready_error ~repo_name ~repo_root ~git_toplevel =
+let repo_cwd_not_ready_error ~repo_name ~path_root ~git_toplevel =
   Printf.sprintf
     "sandbox_repo_not_ready: sandbox path is under repos/%s, but %s is not an \
      independent git checkout (git_toplevel=%s). Repair or reclone the sandbox \
      repo under repos/%s, then retry with cwd=\"repos/%s\" or \
      cwd=\"repos/%s/.worktrees/<task>\"."
     repo_name
-    repo_root
+    path_root
     (Option.value ~default:"<none>" git_toplevel)
     repo_name
     repo_name
@@ -82,11 +82,11 @@ let validate_repo_path_ready
   =
   match repo_path_context ~config ~meta cwd with
   | None -> Ok ()
-  | Some (repo_name, repo_root, _path_root, accepted_toplevels) ->
+  | Some (repo_name, _repo_root, path_root, accepted_toplevels) ->
     let check_probe () =
       if not (safe_is_dir probe_path) then
         Error
-          (repo_cwd_not_ready_error ~repo_name ~repo_root ~git_toplevel:None)
+          (repo_cwd_not_ready_error ~repo_name ~path_root ~git_toplevel:None)
       else
         let top =
           Keeper_repo_readiness.run_git
@@ -107,7 +107,7 @@ let validate_repo_path_ready
         if top_matches then Ok ()
         else
           Error
-            (repo_cwd_not_ready_error ~repo_name ~repo_root ~git_toplevel:top_opt)
+            (repo_cwd_not_ready_error ~repo_name ~path_root ~git_toplevel:top_opt)
     in
     match check_probe () with
     | Ok () -> Ok ()
@@ -134,24 +134,44 @@ let validate_repo_path_args_ready
     then String.sub command_name 0 (String.length command_name - String.length ".exe")
     else command_name
   in
+  let command_has_repo_path_args command_name =
+    command_name = "git"
+    || command_name = "gh"
+    || Exec_policy_path_arg_descriptor.command_materializes_path_arg command_name
+  in
   let path_args_of_simple simple =
     let command_name =
       Masc_exec.Exec_program.to_string simple.Masc_exec.Shell_ir.bin
       |> Filename.basename
       |> normalize_repo_command_name
     in
-    if not (command_name = "git" || command_name = "gh")
+    if not (command_has_repo_path_args command_name)
     then []
-    else
+    else (
       match Exec_policy.simple_literal_args simple with
       | None -> []
-      | Some args -> Exec_policy.path_argument_values command_name args
+      | Some args -> Exec_policy.path_argument_values command_name args)
+  in
+  let path_args_of_effective_stage
+      (stage : Agent_tool_execute_command_semantics.parsed_stage)
+    =
+    let command_name =
+      stage.bin |> Filename.basename |> normalize_repo_command_name
+    in
+    if command_has_repo_path_args command_name
+    then Exec_policy.path_argument_values command_name stage.args
+    else []
   in
   let rec path_args = function
     | Masc_exec.Shell_ir.Simple simple ->
       path_args_of_simple simple
     | Masc_exec.Shell_ir.Pipeline stages ->
       List.concat_map path_args stages
+  in
+  let all_path_args =
+    path_args ir
+    @ (Agent_tool_execute_command_semantics.effective_stages_of_ir ir
+       |> List.concat_map path_args_of_effective_stage)
   in
   let validate_target seen raw =
     let trimmed = String.trim raw in
@@ -162,7 +182,7 @@ let validate_repo_path_args_ready
       in
       match repo_path_context ~config ~meta target with
       | None -> Ok seen
-      | Some (_repo_name, repo_root, path_root, _accepted_toplevels) ->
+      | Some (_repo_name, _repo_root, path_root, _accepted_toplevels) ->
         let key = normalize_repo_cwd_path path_root in
         if List.mem key seen then Ok seen
         else (
@@ -187,7 +207,7 @@ let validate_repo_path_args_ready
         Ok (true, seen)
       | None -> Result.map (fun seen -> false, seen) (validate_target seen trimmed))
   in
-  path_args ir
+  all_path_args
   |> List.fold_left
        (fun acc raw ->
           match acc with

--- a/test/test_agent_tool_execute_safety.ml
+++ b/test/test_agent_tool_execute_safety.ml
@@ -14,6 +14,7 @@ module Keeper_registry = Masc_mcp.Keeper_registry
 module Keeper_sandbox = Masc_mcp.Keeper_sandbox
 module Keeper_sandbox_docker = Masc_mcp.Keeper_sandbox_docker
 module Keeper_types = Masc_mcp.Keeper_types
+module Keeper_types_profile_sandbox = Masc_mcp.Keeper_types_profile_sandbox
 module Dev_exec_allowlist = Masc_mcp.Dev_exec_allowlist
 module Exec_program = Masc_exec.Exec_program
 module Json = Yojson.Safe.Util
@@ -278,37 +279,34 @@ let make_config () =
   ensure_dir (Filename.concat tmp Common.masc_dirname);
   (tmp, Workspace.default_config tmp)
 
-let make_docker_meta name =
+let make_base_meta ~context name =
   let json =
     `Assoc
       [
         ("name", `String name);
         ("agent_name", `String ("agent-" ^ name));
         ("trace_id", `String ("trace-" ^ name));
-        ("goal", `String "sandbox test");
-        ("sandbox_profile", `String "docker");
-        ("network_mode", `String "none");
       ]
   in
   match Masc_test_deps.meta_of_json_fixture json with
   | Ok meta -> meta
-  | Error err -> Alcotest.fail ("make_docker_meta failed: " ^ err)
+  | Error err -> Alcotest.fail (context ^ " failed: " ^ err)
+
+let make_docker_meta name =
+  let meta = make_base_meta ~context:"make_docker_meta" name in
+  { meta with
+    goal = "sandbox test"
+  ; sandbox_profile = Keeper_types_profile_sandbox.Docker
+  ; network_mode = Keeper_types_profile_sandbox.Network_none
+  }
 
 let make_local_meta name =
-  let json =
-    `Assoc
-      [
-        ("name", `String name);
-        ("agent_name", `String ("agent-" ^ name));
-        ("trace_id", `String ("trace-" ^ name));
-        ("goal", `String "sandbox test");
-        ("sandbox_profile", `String "local");
-        ("network_mode", `String "inherit");
-      ]
-  in
-  match Masc_test_deps.meta_of_json_fixture json with
-  | Ok meta -> meta
-  | Error err -> Alcotest.fail ("make_local_meta failed: " ^ err)
+  let meta = make_base_meta ~context:"make_local_meta" name in
+  { meta with
+    goal = "sandbox test"
+  ; sandbox_profile = Keeper_types_profile_sandbox.Local
+  ; network_mode = Keeper_types_profile_sandbox.Network_inherit
+  }
 
 let with_eio_fs f =
   Eio_main.run @@ fun env ->
@@ -335,7 +333,11 @@ let run_process ~cwd prog argv =
         Unix.create_process prog (Array.of_list (prog :: argv)) Unix.stdin out_fd
           err_fd)
   in
-  let _, status = Unix.waitpid [] pid in
+  let rec wait () =
+    try Unix.waitpid [] pid with
+    | Unix.Unix_error (Unix.EINTR, _, _) -> wait ()
+  in
+  let _, status = wait () in
   let stdout = read_file out in
   let stderr = read_file err in
   Sys.remove out;
@@ -420,6 +422,46 @@ let test_tool_execute_rejects_parent_git_repo_path_arg () =
       (String_util.contains_substring err "No such file or directory")
   | None -> Alcotest.fail ("expected error json, got: " ^ raw)
 
+let test_tool_execute_rejects_wrapped_git_repo_path_arg () =
+  with_eio_fs @@ fun () ->
+  let base = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  run_process_ok ~cwd:base "git" [ "init"; "-q"; "--initial-branch=main" ];
+  let config = Workspace.default_config base in
+  let meta = make_local_meta "sangsu" in
+  let playground = Filename.concat base (playground_path_of meta.name) in
+  let repo_dir = Filename.concat playground "repos/masc-mcp" in
+  ensure_dir repo_dir;
+  let raw =
+    Agent_tool_command_runtime.handle_tool_execute
+      ~turn_sandbox_factory:None
+      ~turn_sandbox_factory_git:None
+      ~exec_cache:None
+      ~config
+      ~meta
+      ~args:
+        (`Assoc
+           [ "executable", `String "env"
+           ; ( "argv"
+             , `List
+                 [ `String "git"
+                 ; `String "-C"
+                 ; `String "./repos/masc-mcp"
+                 ; `String "status"
+                 ] )
+           ; "cwd", `String playground
+           ])
+      ()
+  in
+  match parse_error_field raw with
+  | Some err ->
+    if
+      not
+        (String_util.contains_substring err "sandbox_repo_not_ready"
+         || String_util.contains_substring err "no sandbox git clones exist")
+    then Alcotest.failf "expected repo readiness/root git guard, got: %s" err
+  | None -> Alcotest.fail ("expected error json, got: " ^ raw)
+
 let test_tool_execute_rg_pattern_under_repos_is_not_repo_path () =
   with_eio_fs @@ fun () ->
   let base = temp_dir () in
@@ -480,9 +522,11 @@ let test_tool_execute_rejects_inline_git_work_tree_path_arg () =
   in
   match parse_error_field raw with
   | Some err ->
-    Alcotest.(check bool) "sandbox_repo_not_ready"
-      true
-      (String_util.contains_substring err "sandbox_repo_not_ready")
+    if
+      not
+        (String_util.contains_substring err "sandbox_repo_not_ready"
+         || String_util.contains_substring err "no sandbox git clones exist")
+    then Alcotest.failf "expected repo readiness/root git guard, got: %s" err
   | None -> Alcotest.fail ("expected error json, got: " ^ raw)
 
 let test_tool_execute_rejects_stale_worktree_path_arg () =
@@ -516,9 +560,8 @@ let test_tool_execute_rejects_stale_worktree_path_arg () =
     Alcotest.(check bool) "sandbox_repo_not_ready"
       true
       (String_util.contains_substring err "sandbox_repo_not_ready");
-    Alcotest.(check bool) "stale worktree root is surfaced"
-      true
-      (String_util.contains_substring err ".worktrees/task")
+    if not (String_util.contains_substring err ".worktrees/task")
+    then Alcotest.failf "expected stale worktree root, got: %s" err
   | None -> Alcotest.fail ("expected error json, got: " ^ raw)
 
 let test_tool_execute_elapsed_duration_preserves_positive_sub_ms () =
@@ -721,18 +764,8 @@ let test_playground_guard_traversal () =
 (* ── tool_search_files readonly hints teach the model about alternatives ───── *)
 
 let make_readonly_meta name =
-  let json =
-    `Assoc
-      [
-        ("name", `String name);
-        ("agent_name", `String ("agent-" ^ name));
-        ("trace_id", `String ("trace-" ^ name));
-        ("goal", `String "readonly hint test");
-      ]
-  in
-  match Masc_test_deps.meta_of_json_fixture json with
-  | Ok meta -> meta
-  | Error err -> Alcotest.fail ("make_readonly_meta failed: " ^ err)
+  let meta = make_base_meta ~context:"make_readonly_meta" name in
+  { meta with goal = "readonly hint test" }
 
 let make_write_enabled_meta name =
   let json =
@@ -741,14 +774,13 @@ let make_write_enabled_meta name =
         ("name", `String name);
         ("agent_name", `String ("agent-" ^ name));
         ("trace_id", `String ("trace-" ^ name));
-        ("goal", `String "write-enabled Execute test");
         ( "tool_access",
           Keeper_meta_tool_access.tool_access_to_json
             (["tool_edit_file"; "tool_write_file"]) );
       ]
   in
   match Masc_test_deps.meta_of_json_fixture json with
-  | Ok meta -> meta
+  | Ok meta -> { meta with goal = "write-enabled Execute test" }
   | Error err -> Alcotest.fail ("make_write_enabled_meta failed: " ^ err)
 
 let parse_hint raw =
@@ -1304,6 +1336,10 @@ let () =
             "repo path arg rejects parent git checkout"
             `Quick
             test_tool_execute_rejects_parent_git_repo_path_arg
+        ; Alcotest.test_case
+            "wrapped git repo path arg rejects parent git checkout"
+            `Quick
+            test_tool_execute_rejects_wrapped_git_repo_path_arg
         ; Alcotest.test_case
             "rg pattern under repos is not a repo path"
             `Quick

--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -166,10 +166,6 @@ let make_meta ?tool_access ~name ~sandbox () =
       ("name", `String name);
       ("agent_name", `String ("agent-" ^ name));
       ("trace_id", `String ("trace-" ^ name));
-      ("goal", `String "shell docker route test");
-      ("allowed_paths", `List [ `String "*" ]);
-      ( "sandbox_profile",
-        `String (Keeper_types_profile_sandbox.sandbox_profile_to_string sandbox) );
     ]
   in
   let fields =
@@ -184,7 +180,12 @@ let make_meta ?tool_access ~name ~sandbox () =
     `Assoc fields
   in
   match Masc_test_deps.meta_of_json_fixture json with
-  | Ok meta -> meta
+  | Ok meta ->
+    { meta with
+      goal = "shell docker route test"
+    ; allowed_paths = ["*"]
+    ; sandbox_profile = sandbox
+    }
   | Error e -> Alcotest.fail e
 
 let test_make_meta_tool_access_matches_production_default () =
@@ -1656,6 +1657,50 @@ let test_sandbox_root_git_c_repeated_missing_final_target () =
       true
       (contains_substring msg "repos/masc-mcp/.worktrees/missing")
 
+let test_sandbox_root_git_c_pipeline_missing_later_target () =
+  setup ~sandbox:Keeper_types_profile_sandbox.Docker
+  @@ fun ~config ~meta ~playground ->
+  let repo = Filename.concat (Filename.concat playground "repos") "masc-mcp" in
+  ensure_dir repo;
+  git_ok ~cwd:repo [ "init"; "-q" ];
+  let cwd, error =
+    resolve_sandbox_root_git_cwd_string
+      ~config
+      ~meta
+      ~cwd:playground
+      ~cmd:"git -C repos/masc-mcp status | git -C repos/missing status"
+  in
+  Alcotest.(check string) "execution cwd remains sandbox root" playground cwd;
+  match error with
+  | None -> Alcotest.fail "expected later git stage -C target error"
+  | Some msg ->
+    Alcotest.(check bool)
+      "error identifies later git stage missing target"
+      true
+      (contains_substring msg "repos/missing")
+
+let test_sandbox_root_git_c_bare_worktree_missing_target () =
+  setup ~sandbox:Keeper_types_profile_sandbox.Docker
+  @@ fun ~config ~meta ~playground ->
+  let repo = Filename.concat (Filename.concat playground "repos") "masc-mcp" in
+  ensure_dir repo;
+  git_ok ~cwd:repo [ "init"; "-q" ];
+  let cwd, error =
+    resolve_sandbox_root_git_cwd_string
+      ~config
+      ~meta
+      ~cwd:playground
+      ~cmd:"git -C .worktrees/missing status"
+  in
+  Alcotest.(check string) "execution cwd remains sandbox root" playground cwd;
+  match error with
+  | None -> Alcotest.fail "expected bare worktree git -C target error"
+  | Some msg ->
+    Alcotest.(check bool)
+      "error identifies bare worktree under sole repo"
+      true
+      (contains_substring msg "repos/masc-mcp/.worktrees/missing")
+
 let test_sandbox_root_git_subcommand_c_is_not_cwd () =
   setup ~sandbox:Keeper_types_profile_sandbox.Docker
   @@ fun ~config ~meta ~playground ->
@@ -2403,6 +2448,14 @@ let () =
             "sandbox-root repeated git -C validates final target"
             `Quick
             test_sandbox_root_git_c_repeated_missing_final_target;
+          Alcotest.test_case
+            "sandbox-root git pipeline validates every -C target"
+            `Quick
+            test_sandbox_root_git_c_pipeline_missing_later_target;
+          Alcotest.test_case
+            "sandbox-root bare worktree git -C validates target"
+            `Quick
+            test_sandbox_root_git_c_bare_worktree_missing_target;
           Alcotest.test_case
             "sandbox-root git subcommand -C is not cwd"
             `Quick


### PR DESCRIPTION
Follow-up for merged #19684 review threads.\n\nChanges:\n- validate repo path readiness for effective wrapped stages such as env git\n- validate every git -C group across pipeline stages\n- keep non-git materialized repo path readiness checks for cat/rg/etc\n- validate bare .worktrees git -C targets before sandbox-root auto-cwd\n- update fixtures for the hard-cut runtime/config JSON split on latest main\n\nValidation:\n- ocamlformat --check lib/keeper/agent_tool_execute_path.ml lib/keeper/agent_tool_execute_command_semantics.ml test/test_agent_tool_execute_safety.ml test/test_keeper_sandbox_docker_route.ml\n- env -u MASC_BASE_PATH DUNE_CACHE=disabled DUNE_BUILD_DIR=/private/tmp/masc-mcp-pr19684-followup-rebased3 dune build --root . test/test_keeper_sandbox_docker_route.exe test/test_agent_tool_execute_safety.exe\n- /private/tmp/masc-mcp-pr19684-followup-rebased3/default/test/test_keeper_sandbox_docker_route.exe test --color=never --show-errors docker_route_contract 23-26\n- /private/tmp/masc-mcp-pr19684-followup-rebased3/default/test/test_agent_tool_execute_safety.exe test --color=never --show-errors playground_guard