### PR TITLE
fix(runtime): justify RFC-0207 budget fallback

### DIFF
--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -212,7 +212,9 @@ implementation_prs: []             # [14181, 14550] 형식 (정수). RFC body �
 | 0204 | Dashboard Read Serving Isolation from Fleet Compute | Draft | a7296801a7 2026-06-01 | - |
 | 0205 | Keeper Module Consolidation — Eliminate Facade Anti-Pattern | Draft | a7296801a7 2026-06-01 | - |
 | 0206 | Runtime 개념 — runtime→Runtime 재탄생 | Draft | a7296801a7 2026-06-01 | - |
-| 0207 | Per-keeper LLM runtime routing | Draft | c98bcf0088 2026-06-01 | - |
+| 0207 | Per-keeper LLM runtime routing | Draft | 86aee8bb04 2026-06-01 | - |
+
+
 
 
 

--- a/lib/keeper/keeper_context_runtime.ml
+++ b/lib/keeper/keeper_context_runtime.ml
@@ -375,11 +375,13 @@ let resolve_max_context_resolution ~requested_override (labels : string list)
            String.trim label
            |> Runtime.max_context_of_runtime_id
            |> Option.map clamp)
+    (* Labels are an ordered runtime-budget preference list. If none resolve,
+       the precomputed default runtime budget preserves config-less tests.
+       DET-OK: dispatch still fail-fast validates the selected runtime id before
+       provider execution. *)
     |> Option.value ~default:default_budget
   in
-  (* RFC-0207: budget against the same per-keeper runtime id that dispatch uses.
-     If no label resolves yet (for config-less tests), retain the default
-     runtime/fallback budget. *)
+  (* RFC-0207: budget against the same per-keeper runtime id that dispatch uses. *)
   let primary_budget = runtime_budget in
   let turn_budget =
     match requested_override with


### PR DESCRIPTION
## Summary

- Add a nearby DET-OK rationale for the RFC-0207 runtime budget default.
- Regenerate the RFC index entry for RFC-0207 after #19704 squash-merged.

## Product impact

- User-visible change: none. This is a CI guard/documentation metadata cleanup for RFC-0207 runtime routing.

## Evidence

- `ocamlformat --check lib/keeper/keeper_context_runtime.ml`
- `git diff --check`
- `python3 scripts/rfc-generate-index.py --check`
- `scripts/ci/check-determinism-contract.sh`
- `scripts/dune-local.sh build test/test_runtime_per_keeper_routing.exe` was attempted but blocked because another worktree has a live bare `dune build` outside `scripts/dune-local.sh`.

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 0/0
provenance: n/a
stages: []
```

## GOAL LOOP ACT checklist

- [x] Observe — #19704's merged head left the deterministic-boundary guard debt in `lib/keeper/keeper_context_runtime.ml`.
- [x] Orient — the debt is the `Option.value ~default:default_budget` budget boundary introduced by RFC-0207 routing.
- [x] Decide — keep the behavior and add the required local DET-OK rationale because the selected runtime id is still fail-fast validated before provider execution.
- [x] Act — scoped to the guard rationale plus RFC index regeneration.
- [x] Verify — local format, RFC index, diff, and determinism guard commands pass; focused dune build is blocked by an unrelated live bare dune process.
- [x] Loop — no additional follow-up identified for this slice.

## Review evidence

- Operator review only; no cross-model review was run for this narrow guard-comment follow-up.

## Linked issue

- Closes #
- Relates #19704

## Variant addition checklist

- [ ] **OCaml** — N/A, no variant changes.
- [ ] **TypeScript** — N/A, no TypeScript union changes.
- [ ] **TLA+ spec** — N/A, no TLA+ domain changes.
- [ ] **Event / JSON schema** — N/A, no event or schema enum changes.
- [ ] **`make check-variants` passes** — N/A, no variant surface changed.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`codex/rfc-0207-det-budget-followup-20260601` → `main` · 1 commit(s) · synced 2026-06-01T07:46:04Z

| sha | subject | date |
|---|---|---|
| `5c764d36e` | fix(runtime): justify default budget fallback | 2026-06-01 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->