### PR TITLE
[codex] Fix keeper base runtime id config

### DIFF
--- a/config/keepers/base.toml
+++ b/config/keepers/base.toml
@@ -9,7 +9,7 @@
 # disabling autoboot for this file. discover_keepers_toml still loads it
 # as a profile-defaults source for downstream keepers.
 autoboot_enabled = false
-model = "runpod_mtp.qwen-runpod"
+runtime_id = "runpod_mtp.qwen-runpod"
 sandbox_profile = "docker"
 network_mode = "inherit"
 repo_cli_identity = "anyang-keepers"


### PR DESCRIPTION
## Summary

- Replace the retired keeper `model` key in `config/keepers/base.toml` with canonical `runtime_id`.
- Keep the base keeper template non-autobooting while making it compatible with the current TOML parser.

## Why

Live keeper config cleanup showed the current parser rejects removed `keeper.model` keys. The checked-in base template still used the retired key, so fresh config seeds could reintroduce the same drift.

## Validation

- `rg -n '^model = ' config/keepers -g '*.toml'` returns no matches.
- `git diff --check`
- Local commit hook/focused Dune validation hit an unrelated existing warning in `lib/server/openai_compat_error_map.ml` for non-exhaustive `AgentExecutionIdleTimeout _`; this PR only changes TOML config.
