### PR TITLE
fix(keeper): callback hardening + test fix + policy doc

### DIFF
--- a/lib/cancel_safe/cancel_safe.ml
+++ b/lib/cancel_safe/cancel_safe.ml
@@ -1,3 +1,27 @@
+(** Cancel_safe — exception-safe callback wrapper for Eio fibers.
+
+    [observe] runs [f ()] and catches all exceptions except
+    [Eio.Cancel.Cancelled] (which must propagate to honor cooperative
+    cancellation).  All other exceptions are routed to [on_exn] instead
+    of propagating to the caller.
+
+    **FSM-critical callback policy**: when wrapping a lifecycle callback
+    that dispatches FSM state transitions (e.g. [on_compaction_started],
+    [on_handoff_started]), the [on_exn] handler MUST:
+
+    1. Increment a Prometheus counter (e.g.
+       [masc_keeper_lifecycle_callback_failures_total{callback=...}])
+       so the failure is observable in Grafana.
+    2. Record the failure via [Keeper_callback_failure.record] for
+       durable audit.
+    3. Track callback success in the lifecycle record (e.g.
+       [started_dispatched : bool] on [compaction_event]) so downstream
+       dispatch sites know the FSM state and can recover the correct
+       transition path.
+
+    See [keeper_post_turn.ml] (compaction) and [keeper_rollover.ml]
+    (handoff) for reference implementations of this policy. *)
+
 let protect ~on_exn f =
   try f ()
   with

--- a/lib/keeper/keeper_context_runtime.ml
+++ b/lib/keeper/keeper_context_runtime.ml
@@ -263,11 +263,20 @@ let dispatch_post_turn_lifecycle_events
          and we must dispatch Compaction_started first.  The Started
          dispatch is idempotent from compacting, so this is safe in
          both cases. *)
-      if not lifecycle.compaction.started_dispatched then
+      if not lifecycle.compaction.started_dispatched then begin
+        Prometheus.inc_counter Keeper_metrics.(to_string CompactionCallbackRecoveries)
+          ~labels:[ ("keeper", keeper_name) ] ();
+        Log.Keeper.warn
+          "%s: on_compaction_started callback did not fire — \
+           dispatching Compaction_started before Completed to recover \
+           FSM path.  If this repeats, investigate registry contention \
+           or keeper registration timing."
+          keeper_name;
         dispatch_keeper_phase_event ~config
           ~origin:Keeper_registry.Post_turn_lifecycle
           ~keeper_name
-          Keeper_state_machine.Compaction_started;
+          Keeper_state_machine.Compaction_started
+      end;
       dispatch_compaction_completed
         ~config
         ~origin:Keeper_registry.Post_turn_lifecycle

--- a/lib/keeper/keeper_metrics.ml
+++ b/lib/keeper/keeper_metrics.ml
@@ -177,6 +177,7 @@ type t =
   | TurnPhaseDuration
   | LifecycleTransitions
   | LifecycleCallbackFailures
+  | CompactionCallbackRecoveries
   | BriefingSessionLastEventSource
   | EventBusDrain
   | SupervisorCleanupFailures
@@ -417,6 +418,8 @@ let to_string = function
   | TurnPhaseDuration -> "masc_keeper_turn_phase_duration_seconds"
   | LifecycleTransitions -> "masc_keeper_lifecycle_transitions_total"
   | LifecycleCallbackFailures -> "masc_keeper_lifecycle_callback_failures_total"
+  | CompactionCallbackRecoveries ->
+    "masc_keeper_compaction_callback_recoveries_total"
   | BriefingSessionLastEventSource ->
     "masc_briefing_session_last_event_source_total"
   | EventBusDrain -> "masc_keeper_event_bus_drain_total"

--- a/lib/keeper/keeper_rollover.ml
+++ b/lib/keeper/keeper_rollover.ml
@@ -250,11 +250,15 @@ let maybe_rollover_oas_handoff
            single fleet-wide invariant: any lifecycle callback that
            can't reach the registry must surface as a counter+warn and
            durable telemetry gap, never silently abort the rollover. *)
-        (try on_started ()
-         with
-         | exn ->
-             Keeper_callback_failure.record ~base_dir ~meta:base_meta
-               ~callback:"on_handoff_started" exn);
+        let () =
+          Cancel_safe.observe
+            ~on_exn:(fun exn ->
+              Prometheus.inc_counter Keeper_metrics.(to_string LifecycleCallbackFailures)
+                ~labels:[ ("keeper", base_meta.name); ("callback", "on_handoff_started") ] ();
+              Keeper_callback_failure.record ~base_dir ~meta:base_meta
+                ~callback:"on_handoff_started" exn)
+            on_started
+        in
         (try
           let new_session =
             create_session ~session_id:new_trace_id ~base_dir

--- a/test/test_keeper_lifecycle_registry_dispatch.ml
+++ b/test/test_keeper_lifecycle_registry_dispatch.ml
@@ -102,10 +102,8 @@ let make_keeper_meta ?(name = "keeper-lifecycle-test")
           ("name", `String name);
           ("agent_name", `String name);
           ("trace_id", `String trace_id);
-          ("runtime_id", `String (Masc_mcp.Keeper_config.default_runtime_id ()));
           ("last_model_used", `String "llama:auto");
-          ("sandbox_profile", `String "local");
-          ("network_mode", `String "inherit");
+          ("tool_access", `List []);
         ])
   with
   | Ok meta -> meta


### PR DESCRIPTION
## Summary

Follow-up to #19710. Four items: test fix, observability, handoff consistency, policy documentation.

## Changes

### 1. Test fixture fix (9/9 → green)
Remove config-only fields (`runtime_id`, `sandbox_profile`, `network_mode`) from `test_keeper_lifecycle_registry_dispatch.ml` JSON fixture and add required `tool_access` field. Tests were 2/9 passing on main, now 9/9.

### 2. Compaction callback recovery observability
Add `CompactionCallbackRecoveries` Prometheus counter (`masc_keeper_compaction_callback_recoveries_total{keeper}`) that fires when `started_dispatched=false` at the dispatch site, plus a warn log. Rising rate = registry contention or registration timing issue.

### 3. Handoff callback consistency
Replace bare `try/with` in `on_handoff_started` (`keeper_rollover.ml`) with `Cancel_safe.observe` + `LifecycleCallbackFailures` counter increment. Now matches the compaction callback pattern exactly.

### 4. FSM callback policy documentation
Add module-level doc comment to `Cancel_safe` documenting the 3-rule policy for FSM-critical callbacks:
1. Prometheus counter for observability
2. `Keeper_callback_failure.record` for durable audit
3. Lifecycle record tracking (`started_dispatched`) for downstream boundary

Reference implementations cross-linked to `keeper_post_turn.ml` and `keeper_rollover.ml`.

## Verification

- `dune build lib/keeper/keeper_context_runtime.ml --root .` EXIT=0
- `dune build lib/keeper/keeper_rollover.ml --root .` EXIT=0
- `dune runtest test/test_keeper_lifecycle_registry_dispatch.ml` 9/9 OK

## Files changed

- `lib/cancel_safe/cancel_safe.ml` (+24): FSM callback policy doc comment
- `lib/keeper/keeper_context_runtime.ml` (+11/-2): recovery counter + warn log
- `lib/keeper/keeper_metrics.ml` (+3): `CompactionCallbackRecoveries` metric
- `lib/keeper/keeper_rollover.ml` (+10/-5): `Cancel_safe.observe` for handoff
- `test/test_keeper_lifecycle_registry_dispatch.ml` (+2/-3): fixture fix

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
