### PR TITLE
Align keeper status with effective meta

### DIFF
--- a/docs/KEEPER-SANDBOX-BOUNDARY-POLICY.md
+++ b/docs/KEEPER-SANDBOX-BOUNDARY-POLICY.md
@@ -1,6 +1,6 @@
 # Keeper Sandbox Boundary Policy
 
-Last updated: 2026-05-25
+Last updated: 2026-06-01
 
 ## Goal
 
@@ -59,6 +59,12 @@ failure just because a keeper uses the Docker backend.
 - Tool modules must not branch on `meta.sandbox_profile = Docker` or call
   `Keeper_sandbox_docker` directly. They pass host/backend command
   projections to `Keeper_sandbox_runner`.
+- Status, list, operator, and sandbox-status surfaces must read effective
+  keeper meta via `Keeper_meta_store.read_effective_meta*`, not raw persisted
+  JSON, before displaying `sandbox_profile`, `network_mode`, `tool_access`, or
+  sandbox live state. Persisted runtime JSON intentionally omits TOML-owned
+  fields; raw reads can otherwise report `local` while receipts and tool
+  execution correctly use `docker`.
 - Command semantics may only interpret commands accepted by the typed
   bash subset parser. Unsupported shell constructs fail closed and must
   not be reinterpreted with space splitting or fallback token scans.
@@ -68,6 +74,7 @@ failure just because a keeper uses the Docker backend.
 Focused behavioral tests verify path and command behavior:
 
 - `test_keeper_path_ssot`
+- `test_keeper_effective_meta_overlay`
 - `test_keeper_sandbox_docker_route`
 
 Source-level boundary tests prevent regressions in layer ownership:
@@ -78,6 +85,7 @@ Source-level boundary tests prevent regressions in layer ownership:
 The boundary test intentionally fails if:
 
 - tool code reintroduces Docker path literals or profile detection;
+- status/sandbox-status surfaces bypass TOML-overlaid effective keeper meta;
 - workspace repo-path helpers reintroduce Docker container-root construction
   or sandbox-profile parsing;
 - Docker shell code re-exports generic command classification or parses

--- a/docs/KEEPER-SANDBOX-BOUNDARY-POLICY.md
+++ b/docs/KEEPER-SANDBOX-BOUNDARY-POLICY.md
@@ -65,6 +65,13 @@ failure just because a keeper uses the Docker backend.
   sandbox live state. Persisted runtime JSON intentionally omits TOML-owned
   fields; raw reads can otherwise report `local` while receipts and tool
   execution correctly use `docker`.
+- Runtime/provider attribution for status surfaces must come from explicit
+  runtime observations and execution receipts. `Runtime_agent.run` must attach
+  terminal runtime observation to completed or partial-completed turns, receipts
+  must serialize `runtime.selected_model`, and runtime-trust status may fall
+  back from decision telemetry to the latest receipt model. Public dashboards
+  may keep provider/model lanes redacted, but keeper operator surfaces must show
+  either observed attribution or a typed runtime/provider blocker.
 - Command semantics may only interpret commands accepted by the typed
   bash subset parser. Unsupported shell constructs fail closed and must
   not be reinterpreted with space splitting or fallback token scans.
@@ -75,6 +82,8 @@ Focused behavioral tests verify path and command behavior:
 
 - `test_keeper_path_ssot`
 - `test_keeper_effective_meta_overlay`
+- `test_keeper_runtime_trust_snapshot`
+- `test_runtime_provider_auth_headers`
 - `test_keeper_sandbox_docker_route`
 
 Source-level boundary tests prevent regressions in layer ownership:
@@ -111,3 +120,6 @@ The boundary test intentionally fails if:
 - keeper TOML parsing stops using the structured parser;
 - command semantics reintroduces word extraction or string-split fallback
   parsing.
+- completed or partial-completed runtime turns stop producing terminal runtime
+  observation for receipts, or runtime-trust status stops surfacing receipt
+  `runtime.selected_model` when decision telemetry is absent.

--- a/docs/audit/2026-06-01-keeper-boundary-runtime-report.html
+++ b/docs/audit/2026-06-01-keeper-boundary-runtime-report.html
@@ -456,9 +456,15 @@
 	          </tr>
 	          <tr>
 	            <td>Runtime/provider observability</td>
-	            <td><span class="badge warn">remaining</span></td>
-	            <td>No provider/model attribution patch in this slice.</td>
-	            <td>One controlled keeper turn must produce non-null runtime observation or a typed provider blocker.</td>
+	            <td><span class="badge good">patched</span></td>
+	            <td>`Runtime_agent.run` now materializes a terminal runtime observation for completed and partial-completed OAS turns. `Keeper_execution_receipt.to_json` preserves `runtime.selected_model`, and `Keeper_runtime_trust_snapshot` falls back from decision telemetry to latest receipt runtime model for `selected_model`, `active_model`, and `execution.provider_selected_model`.</td>
+	            <td>After rebuild/restart, one controlled keeper turn must produce non-null runtime observation or a typed provider blocker in the live receipt/status surface.</td>
+	          </tr>
+	          <tr>
+	            <td>Runtime observability regression guard</td>
+	            <td><span class="badge good">added</span></td>
+	            <td>`test_runtime_provider_auth_headers` proves runtime-agent terminal observations carry runtime id, selected model, one attempt, and `runtime_agent_terminal` source. `test_keeper_runtime_trust_snapshot` proves receipt runtime model attribution feeds trust snapshot when decision telemetry is absent.</td>
+	            <td>Focused Dune build/test must stay green for `test_runtime_provider_auth_headers` and `test_keeper_runtime_trust_snapshot`.</td>
 	          </tr>
 	          <tr>
 	            <td>Telemetry append gaps</td>

--- a/docs/audit/2026-06-01-keeper-boundary-runtime-report.html
+++ b/docs/audit/2026-06-01-keeper-boundary-runtime-report.html
@@ -1,0 +1,488 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Keeper Boundary Runtime Audit - Sandbox, Tool Surface, Model Runtime</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --ink: #17212b;
+      --muted: #5d6a75;
+      --line: #d9e0e7;
+      --soft: #f5f7f9;
+      --panel: #ffffff;
+      --bad: #b42318;
+      --warn: #a15c00;
+      --ok: #087443;
+      --info: #2459a6;
+      --code: #26313d;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.55;
+      color: var(--ink);
+      background: #eef2f5;
+    }
+    .page-header {
+      padding: 36px 40px 28px;
+      background: #14202b;
+      color: #fff;
+    }
+    h1 {
+      margin: 0 0 10px;
+      font-size: 30px;
+      line-height: 1.2;
+      letter-spacing: 0;
+    }
+    .page-header p {
+      max-width: 1120px;
+      margin: 0;
+      color: #d8e2ec;
+      font-size: 15px;
+    }
+    .page-main {
+      max-width: 1220px;
+      margin: 0 auto;
+      padding: 28px 24px 56px;
+    }
+    .section {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 22px;
+      margin: 0 0 18px;
+    }
+    h2 {
+      margin: 0 0 14px;
+      font-size: 21px;
+      letter-spacing: 0;
+    }
+    h3 {
+      margin: 20px 0 8px;
+      font-size: 16px;
+      letter-spacing: 0;
+    }
+    p { margin: 8px 0; }
+    ul, ol { margin: 8px 0 8px 22px; padding: 0; }
+    li { margin: 5px 0; }
+    code {
+      color: var(--code);
+      background: #eef3f7;
+      padding: 1px 5px;
+      border-radius: 4px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 0.95em;
+    }
+    pre {
+      overflow-x: auto;
+      background: #101820;
+      color: #e6edf3;
+      border-radius: 8px;
+      padding: 14px;
+      font-size: 13px;
+      line-height: 1.45;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 12px 0;
+      font-size: 14px;
+    }
+    th, td {
+      border: 1px solid var(--line);
+      padding: 9px 10px;
+      vertical-align: top;
+      text-align: left;
+    }
+    th { background: var(--soft); }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 12px;
+    }
+    .card {
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 14px;
+      background: #fbfcfd;
+    }
+    .badge {
+      display: inline-block;
+      padding: 2px 8px;
+      border-radius: 999px;
+      font-size: 12px;
+      font-weight: 700;
+      border: 1px solid currentColor;
+      white-space: nowrap;
+    }
+    .bad { color: var(--bad); }
+    .warn { color: var(--warn); }
+    .ok { color: var(--ok); }
+    .info { color: var(--info); }
+    .muted { color: var(--muted); }
+    .small { font-size: 13px; color: var(--muted); }
+    .finding {
+      border-left: 4px solid var(--warn);
+      padding: 10px 12px;
+      background: #fffaf2;
+      margin: 12px 0;
+    }
+    .finding.critical {
+      border-left-color: var(--bad);
+      background: #fff5f3;
+    }
+    .finding.good {
+      border-left-color: var(--ok);
+      background: #f2fbf7;
+    }
+    @media (max-width: 900px) {
+      .page-header { padding: 28px 22px 22px; }
+      .page-main { padding: 18px 12px 36px; }
+      .grid { grid-template-columns: 1fr; }
+      .section { padding: 16px; }
+    }
+  </style>
+</head>
+<body>
+  <div class="page-header">
+    <h1>Keeper Boundary Runtime Audit</h1>
+    <p>Sandbox 설정, Tool Surface 가시성, Model-Provider Runtime 관측성을 코드 경로와 live evidence로 대조한 보고서 및 실행 계획서.</p>
+  </div>
+
+  <div class="page-main">
+    <div class="section">
+      <h2>Executive Verdict</h2>
+      <div class="grid">
+        <div class="card">
+          <h3>Sandbox</h3>
+          <p><span class="badge bad">NOT GREEN</span></p>
+          <p>코드는 TOML 기반 sandbox overlay를 갖고 있고 docker route 테스트도 있다. 그러나 live surface는 아직 서로 다르다. `analyst.toml`은 docker인데 `masc_keeper_sandbox_status`는 local로 보이고, 직전 execution receipt는 docker로 기록됐다.</p>
+        </div>
+        <div class="card">
+          <h3>Tool Surface</h3>
+          <p><span class="badge warn">PARTIAL</span></p>
+          <p>Keeper는 도구를 실제로 보고 실행한다. Echo/Analyst 모두 allowed tools 39개, 최근 receipt는 `satisfied_execution`이다. 하지만 `tool_usage`, `tool_call_io`, `trajectory`, `execution_receipt` telemetry에는 coverage gap이 남아 있다.</p>
+        </div>
+        <div class="card">
+          <h3>Model Runtime</h3>
+          <p><span class="badge bad">NOT VERIFIED</span></p>
+          <p>Keeper status는 `runtime_id=ollama_cloud.deepseek-v4-pro`를 들고 있지만 `selected_model=null`, `attempt_count=0`, `runtime_outcome=not_observed`다. MASC가 실제 provider/model 실행을 검증했다고 말할 수 없다.</p>
+        </div>
+      </div>
+      <p><strong>최종 판정:</strong> 운영은 재기동과 일부 self-repair가 계속 일어나는 중이지만, 현재 상태는 “잘 되고 있음”이 아니라 “불안정하게 살아 있고 증거 surface가 갈라져 있음”이다.</p>
+      <p class="small">Generated: 2026-06-01 16:56 KST. Source worktree: `6c0950fd09`. Live runtime/root: `24cde720f7` and still behind `origin/main` by 1 at last root checkout probe.</p>
+    </div>
+
+    <div class="section">
+      <h2>Evidence Snapshot</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Surface</th>
+            <th>Observed result</th>
+            <th>Interpretation</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>`/health?full=1`</td>
+            <td>`keeper_fibers=0`, fleet `blocked`, blocker `no_executable_keeper_fibers`, config schema `ok`, parse errors `0`.</td>
+            <td>Config parse 자체는 복구됐지만, 마지막 probe 시점에는 keepalive fleet가 다시 뜨지 못했다.</td>
+          </tr>
+          <tr>
+            <td>Runtime/source commits</td>
+            <td>Report source worktree `6c0950fd09`; live root checkout `24cde720f7`; runtime build reports commit from repo head, binary commit is not proven.</td>
+            <td>현재성 검증이 실패하는 핵심 원인. 같은 코드 기준에서 판단하고 있지 않다.</td>
+          </tr>
+          <tr>
+            <td>`masc_keeper_sandbox_status(include_preflight=true)`</td>
+            <td>15 keepers all `sandbox_profile=local`, `effective_mode=local`, no Docker preflight.</td>
+            <td>Sandbox status surface 기준으로는 Keeper가 docker를 모른다.</td>
+          </tr>
+          <tr>
+            <td>`masc_keeper_status analyst`</td>
+            <td>Top-level sandbox says local, but latest decision/runtime_contract says docker; tool route evidence includes `via=docker` for Grep/Read/Execute.</td>
+            <td>Receipt/runtime lens와 sandbox status lens가 같은 truth를 말하지 않는다.</td>
+          </tr>
+          <tr>
+            <td>`masc_keeper_status echo`</td>
+            <td>allowed tools 39, latest receipt `satisfied_execution`, 30 tools used, sandbox local, model observability unverified.</td>
+            <td>Tool execution works, but model/runtime observation remains absent.</td>
+          </tr>
+          <tr>
+            <td>`/api/v1/dashboard/telemetry/summary`</td>
+            <td>`tool_call_io`, `trajectory_tool_call`, `tool_usage`, `execution_receipt` show coverage gaps; `oas_event` is ok.</td>
+            <td>Runtime/tool evidence is being produced in places, but durable dashboard observability is incomplete.</td>
+          </tr>
+          <tr>
+            <td>`masc_keeper_persona_audit(include_ok=false)`</td>
+            <td>Total 16, ok 0, with issues 16. Main issues: stale active goals 15, keepalive not running 3, registry missing 2, paused 1.</td>
+            <td>Fleet-level done criteria is not met even after config parse recovery.</td>
+          </tr>
+        </tbody>
+      </table>
+      <h3>[근거]</h3>
+      <ul>
+        <li>Command: `curl -fsS 'http://127.0.0.1:8935/health?full=1' | jq ...`; checked 2026-06-01 16:56 KST; confidence High for live health, Medium for binary identity because health itself says binary commit is unproven.</li>
+        <li>Command: `masc_keeper_sandbox_status(include_preflight=true)`; checked 2026-06-01 16:54 KST; confidence High for that surface, Medium overall because other surfaces disagree.</li>
+        <li>Command: `masc_keeper_status echo/analyst`; checked 2026-06-01 16:54 KST; confidence High for receipt/status payload, Medium overall because runtime restarted during audit.</li>
+        <li>Command: `git fetch origin main`, `git merge --ff-only origin/main`, `git rev-parse --short=10 HEAD`; checked 2026-06-01 16:50 KST; confidence High for report worktree source.</li>
+      </ul>
+    </div>
+
+    <div class="section">
+      <h2>Code-Level Trace</h2>
+
+      <h3>1. Sandbox Authority Path</h3>
+      <p>The intended path is:</p>
+      <pre>TOML keeper profile
+  -> Keeper_types_profile_toml_parser
+  -> Keeper_runtime.ensure_keeper_meta overlay
+  -> Keeper_registry/meta
+  -> Keeper_sandbox_control + agent tool backends
+  -> execution receipt + dashboard/status</pre>
+      <table>
+        <thead>
+          <tr><th>Code</th><th>Role</th><th>Risk</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>`lib/keeper/keeper_types_profile_toml_parser.ml:123-133`</td>
+            <td>Rejects removed `keeper.model`; requires `keeper.runtime_id`.</td>
+            <td>Config migration is sharp. During audit this blocker appeared, then config was repaired to `runtime_id`.</td>
+          </tr>
+          <tr>
+            <td>`lib/keeper/keeper_meta_tool_access.ml:80-96` and `lib/keeper/keeper_meta_json_parse.ml:164-172`</td>
+            <td>Persisted meta JSON must include `tool_access` as an array.</td>
+            <td>Meta files without `tool_access` hard-fail. Tests now cover defaults for fixtures, but production decode still rejects missing field.</td>
+          </tr>
+          <tr>
+            <td>`lib/keeper/keeper_runtime.ml:140-152`, `580-604`</td>
+            <td>Runtime reconcile should use the same declarative runtime source and update registry meta.</td>
+            <td>If status reads stale registry meta, TOML docker can still appear as live local.</td>
+          </tr>
+          <tr>
+            <td>`test/test_keeper_sandbox_docker_route.ml:191-207`, `2290-2318`</td>
+            <td>Tests now prove fixture defaults and docker routing for Execute/Grep/Read paths.</td>
+            <td>Good coverage exists, but it does not prove the live status surfaces are converged.</td>
+          </tr>
+        </tbody>
+      </table>
+      <div class="finding critical">
+        <strong>Finding S1:</strong> Sandbox truth is split. `analyst.toml` declares docker, the latest receipt records docker, but `masc_keeper_sandbox_status` and top-level `masc_keeper_status` report local. This is the exact “Keeper does not know Sandbox” failure mode.
+      </div>
+
+      <h3>2. Tool Surface Path</h3>
+      <p>The intended path is:</p>
+      <pre>keeper tool policy / descriptor catalog
+  -> Keeper_tool_policy.keeper_allowed_tool_names
+  -> Keeper_run_tools_setup.compute_tool_surface
+  -> Keeper_run_tools_hooks.set_turn_context + tool_disclosure
+  -> Agent/OAS materialized runtime tools
+  -> execution receipt + tool logs + dashboard telemetry</pre>
+      <table>
+        <thead>
+          <tr><th>Code</th><th>Role</th><th>Risk</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>`lib/keeper/keeper_tool_policy.ml:385-399`</td>
+            <td>Computes allowed tool names from keeper meta and policy.</td>
+            <td>Depends on meta/tool_access being readable and current.</td>
+          </tr>
+          <tr>
+            <td>`lib/keeper/keeper_run_tools_setup.ml:698-887`</td>
+            <td>Builds visible tools, required tools, missing tools, lane, surface class.</td>
+            <td>Good core logic, but last-turn filtering and fallback make exact visible/materialized counts easy to misread.</td>
+          </tr>
+          <tr>
+            <td>`lib/keeper/keeper_run_tools_hooks.ml:636-652`, `684-730`</td>
+            <td>Threads sandbox/profile/tool surface into tool-call context and writes `tool_disclosure` JSONL.</td>
+            <td>Append failures create dashboard coverage gaps.</td>
+          </tr>
+          <tr>
+            <td>`lib/keeper/keeper_execution_receipt.ml:524-570`</td>
+            <td>Stores tool contract, tool surface, sandbox summary, runtime summary in receipt.</td>
+            <td>Receipt is the strongest proof surface, but dashboard summaries may redact or stale-read it.</td>
+          </tr>
+          <tr>
+            <td>`lib/keeper/agent_tool_descriptor.ml` and `test/test_agent_tool_descriptor_registry_integrity.ml`</td>
+            <td>Descriptor spine now records executor/backend/sandbox/runtime handler labels.</td>
+            <td>This is useful evidence; keep it as the canonical route proof.</td>
+          </tr>
+        </tbody>
+      </table>
+      <div class="finding good">
+        <strong>Finding T1:</strong> Tools are not simply missing. Echo and Analyst can see and execute tools; recent receipts show `satisfied_execution` and descriptor route evidence.
+      </div>
+      <div class="finding critical">
+        <strong>Finding T2:</strong> Tool observability is not green. `tool_usage_append_failed`, `tool_call_io_append_failed`, `trajectory_append_failed`, and `execution_receipt_append_failed` mean dashboard-level proof is incomplete.
+      </div>
+
+      <h3>3. Model-Provider Runtime Path</h3>
+      <p>The intended path is:</p>
+      <pre>keeper.runtime_id in TOML
+  -> Keeper_meta_contract.runtime_id_of_meta
+  -> Keeper_agent_run
+  -> Keeper_turn_driver.run_named
+  -> Runtime.get_runtime_by_id + provider config
+  -> Agent/OAS response observation
+  -> receipt runtime.selected_model + model metrics</pre>
+      <table>
+        <thead>
+          <tr><th>Code</th><th>Role</th><th>Risk</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>`lib/keeper/keeper_meta_contract.ml:612-630`</td>
+            <td>Per-keeper runtime id resolves from profile defaults, then global default.</td>
+            <td>Correct direction: no silent default substitution.</td>
+          </tr>
+          <tr>
+            <td>`lib/keeper/keeper_turn_driver.ml:99-132`</td>
+            <td>Trims requested runtime id, fails fast if missing, builds runtime candidate.</td>
+            <td>Good control-plane behavior; does not by itself prove provider/model execution.</td>
+          </tr>
+          <tr>
+            <td>`lib/keeper/keeper_agent_run_receipt.ml:146-205`</td>
+            <td>Receipt `runtime_selected_model` comes from runtime observation.</td>
+            <td>If observation is absent, receipt reports `selected_model=null` and attempts 0.</td>
+          </tr>
+          <tr>
+            <td>`lib/dashboard_provider_runs.ml:361-377`, `lib/model_inference_metrics_json.ml:140-147`</td>
+            <td>Public dashboard redacts provider/model into runtime lanes and may report model_count 0.</td>
+            <td>Good privacy boundary, but weak operator proof unless paired with a verified/raw internal evidence link.</td>
+          </tr>
+        </tbody>
+      </table>
+      <div class="finding critical">
+        <strong>Finding R1:</strong> Keeper does not currently know the actual provider/model runtime. Status shows `selected_model=null`, `attempt_count=0`, `runtime_outcome=not_observed`, and “Provider/model identity is owned by OAS.”
+      </div>
+    </div>
+
+    <div class="section">
+      <h2>Failure Matrix</h2>
+      <table>
+        <thead>
+          <tr><th>ID</th><th>Severity</th><th>Issue</th><th>Immediate next check</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>F0</td>
+            <td><span class="badge bad">P0</span></td>
+            <td>Runtime/source drift and restarts: report worktree, root checkout, and running process are not on a single stable commit.</td>
+            <td>`git -C root status`, `/health?full=1`, restart only after root matches `origin/main`.</td>
+          </tr>
+          <tr>
+            <td>F1</td>
+            <td><span class="badge bad">P0</span></td>
+            <td>Fleet currently blocked or flapping. Last health: no executable keeper fibers.</td>
+            <td>Wait for startup once; if still 0 fibers, inspect keeper supervisor/fiber startup logs.</td>
+          </tr>
+          <tr>
+            <td>F2</td>
+            <td><span class="badge bad">P0</span></td>
+            <td>Sandbox truth split: sandbox status says local, receipt says docker for Analyst.</td>
+            <td>Compare `masc_keeper_sandbox_status analyst` with `masc_keeper_status analyst.runtime_trust.latest_decision.runtime_contract`.</td>
+          </tr>
+          <tr>
+            <td>F3</td>
+            <td><span class="badge warn">P1</span></td>
+            <td>Tool execution works but durable telemetry appenders are unhealthy.</td>
+            <td>Tail `Telemetry_coverage_gap` by source and repair the first live append exception.</td>
+          </tr>
+          <tr>
+            <td>F4</td>
+            <td><span class="badge bad">P0</span></td>
+            <td>Model/provider runtime identity is unverified at Keeper boundary.</td>
+            <td>Force one small runtime turn and require receipt with non-null provider/model observation or an explicit provider blocker.</td>
+          </tr>
+          <tr>
+            <td>F5</td>
+            <td><span class="badge warn">P1</span></td>
+            <td>Persona audit has 0/16 ok: stale goals, registry missing, paused keeper, keepalive gaps.</td>
+            <td>Clear stale goal IDs and registry mismatch after F0/F1 stabilize.</td>
+          </tr>
+          <tr>
+            <td>F6</td>
+            <td><span class="badge warn">P2</span></td>
+            <td>Docs still mention stale runtime capacity routes while current dashboard routes moved.</td>
+            <td>Update `docs/DASHBOARD-INTEGRATION.md` and route references after live route sweep.</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+	    <div class="section">
+	      <h2>Execution Plan</h2>
+	      <ol>
+        <li><strong>Stabilize commit truth.</strong> Bring root checkout to current `origin/main`, rebuild/restart once, and require `/health?full=1` to report the same commit as `git rev-parse origin/main`. Do not evaluate Keeper behavior while runtime is warming or flapping.</li>
+        <li><strong>Repair fleet boot first.</strong> After restart, wait one startup window. If `keeper_fibers=0`, inspect supervisor startup logs and meta decode errors. Acceptance: `keeper_fleet_safety.status` is `ok` or a bounded degraded state with named keepers, not `no_executable_keeper_fibers`.</li>
+        <li><strong>Converge sandbox truth.</strong> Make `masc_keeper_sandbox_status`, `masc_keeper_status.policy`, `runtime_trust.runtime_contract`, and receipt sandbox summary read the same overlay source. Acceptance: Analyst TOML docker yields status docker and receipt docker, or an explicit local override is shown with source.</li>
+        <li><strong>Lock tool surface evidence.</strong> Treat descriptor route evidence as canonical and fix coverage gap appenders. Acceptance: `tool_usage`, `tool_call_io`, `trajectory_tool_call`, and `execution_receipt` are `ok` or carry a fresh, actionable error with one failing source.</li>
+        <li><strong>Make runtime identity observable.</strong> Add internal-safe provider/model attribution to runtime observation and receipt. Public dashboards may keep redacted runtime lanes, but Keeper status must say either `verified=true` with source or a concrete provider blocker. Acceptance: one controlled turn produces non-null runtime observation or a named failure class.</li>
+        <li><strong>Clean persona/fleet drift.</strong> Remove stale active goal IDs, restore missing registry entries, decide whether `tech_glutton` should stay paused, and create or remove missing `base` runtime meta. Acceptance: `masc_keeper_persona_audit(include_ok=false)` returns only intentional issues.</li>
+        <li><strong>Clean docs/routes.</strong> Update stale capacity/dashboard route docs after the live route sweep. Acceptance: docs do not point operators to 404/410 endpoints for runtime capacity or dashboard batch state.</li>
+	      </ol>
+	    </div>
+
+	    <div class="section">
+	      <h2>Implementation Update</h2>
+	      <table>
+	        <thead>
+	          <tr><th>Slice</th><th>Status</th><th>Code/doc change</th><th>Remaining acceptance</th></tr>
+	        </thead>
+	        <tbody>
+	          <tr>
+	            <td>P0 sandbox truth split</td>
+	            <td><span class="badge good">patched</span></td>
+	            <td>`Keeper_meta_contract.effective_meta_result` now overlays TOML-owned keeper fields onto persisted runtime meta. `Keeper_meta_store.read_effective_meta*` is the status-facing read API. `masc_keeper_sandbox_status`, `masc_keeper_status`, keeper list rows, and operator diagnostics now consume effective meta.</td>
+	            <td>After rebuild/restart, `masc_keeper_sandbox_status(name="analyst")` and `masc_keeper_status(name="analyst").sandbox_profile` must both report `docker` when Analyst TOML declares docker.</td>
+	          </tr>
+	          <tr>
+	            <td>Regression guard</td>
+	            <td><span class="badge good">added</span></td>
+	            <td>`test_keeper_effective_meta_overlay` proves raw runtime JSON with local defaults is overlaid by TOML `sandbox_profile=docker`, Docker default network `none`, and TOML `tool_access` before status surfaces read it.</td>
+	            <td>Focused Dune build/test must stay green for `test_keeper_effective_meta_overlay` and affected library modules.</td>
+	          </tr>
+	          <tr>
+	            <td>Boundary docs</td>
+	            <td><span class="badge good">updated</span></td>
+	            <td>`docs/KEEPER-SANDBOX-BOUNDARY-POLICY.md` now names effective meta as the required read path for status/list/operator/sandbox-status surfaces.</td>
+	            <td>Future sandbox/status changes should extend the effective meta contract instead of reading raw persisted JSON for TOML-owned fields.</td>
+	          </tr>
+	          <tr>
+	            <td>Runtime/provider observability</td>
+	            <td><span class="badge warn">remaining</span></td>
+	            <td>No provider/model attribution patch in this slice.</td>
+	            <td>One controlled keeper turn must produce non-null runtime observation or a typed provider blocker.</td>
+	          </tr>
+	          <tr>
+	            <td>Telemetry append gaps</td>
+	            <td><span class="badge warn">remaining</span></td>
+	            <td>No telemetry appender repair in this slice.</td>
+	            <td>`tool_usage`, `tool_call_io`, `trajectory_tool_call`, and `execution_receipt` need fresh ok status or a single actionable append error.</td>
+	          </tr>
+	        </tbody>
+	      </table>
+	    </div>
+
+	    <div class="section">
+	      <h2>Acceptance Checks</h2>
+      <pre>git -C /Users/dancer/me/workspace/yousleepwhen/masc-mcp fetch origin main
+git -C /Users/dancer/me/workspace/yousleepwhen/masc-mcp status --short --branch
+curl -fsS 'http://127.0.0.1:8935/health?full=1' | jq '{build, keeper_fibers, keeper_fleet_safety, keeper_config_schema_status}'
+masc_keeper_sandbox_status(name="analyst", include_preflight=true)
+masc_keeper_status(name="analyst", fast=true)
+masc_keeper_status(name="echo", fast=true)
+curl -fsS 'http://127.0.0.1:8935/api/v1/dashboard/telemetry/summary' | jq '.sources[] | {source, health, stale_reason, latest_ts_iso}'
+curl -fsS 'http://127.0.0.1:8935/api/v1/models/metrics' | jq '{total_entries,total_error_entries,models}'
+masc_keeper_persona_audit(include_ok=false)</pre>
+      <p>Pass condition: source commit truth stable, keeper fibers executable, sandbox surfaces converged, tool telemetry gap closed or sharply explained, runtime model observation verified or explicitly blocked.</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -564,7 +564,7 @@ let to_json (receipt : t) =
     ; ( "runtime"
       , `Assoc
           [ "name", `String (receipt.runtime_id)
-          ; "selected_model", `Null
+          ; "selected_model", string_opt_json receipt.runtime_selected_model
           ; "attempt_count", `Int receipt.runtime_attempt_count
           ; "fallback_applied", `Bool receipt.runtime_fallback_applied
           ; "outcome", `String (runtime_outcome_to_string receipt.runtime_outcome)

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -653,11 +653,10 @@ let effective_meta_of_profile_defaults
   let target_sandbox_profile =
     match defaults.sandbox_profile, defaults.manifest_path with
     | Some profile, _ -> Ok profile
-    | None, Some _ ->
+    | None, _ ->
         Error
           (missing_required_sandbox_profile_error ~keeper_name:meta.name
              defaults)
-    | None, None -> Ok meta.sandbox_profile
   in
   match target_sandbox_profile with
   | Error _ as err -> err

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -609,6 +609,149 @@ type keeper_meta =
   ; meta_version : int
   }
 
+let apply_profile_default opt current =
+  match opt with
+  | Some value -> value
+  | None -> current
+;;
+
+let apply_profile_default_opt opt current =
+  match opt with
+  | Some _ -> opt
+  | None -> current
+;;
+
+let invalid_profile_defaults_error ~keeper_name detail =
+  if String_util.contains_substring detail "runtime_id" then
+    Printf.sprintf
+      "invalid profile.runtime_id for keeper %s: unknown runtime_id: %s"
+      keeper_name detail
+  else
+    Printf.sprintf "invalid keeper profile for keeper %s: %s" keeper_name detail
+;;
+
+let missing_required_sandbox_profile_error ~keeper_name
+    (defaults : Keeper_types_profile.keeper_profile_defaults) =
+  let manifest_hint =
+    match defaults.manifest_path with
+    | Some path -> Printf.sprintf " (loaded from %s)" path
+    | None -> ""
+  in
+  Printf.sprintf
+    "keeper %s rejected: sandbox_profile is required (allowed: %s)%s. \
+     Add e.g. `sandbox_profile = \"docker\"` to the keeper TOML."
+    keeper_name
+    (String.concat ", " Keeper_types_profile.valid_sandbox_profile_strings)
+    manifest_hint
+;;
+
+let effective_meta_of_profile_defaults
+    (defaults : Keeper_types_profile.keeper_profile_defaults)
+    (meta : keeper_meta) : (keeper_meta, string) result =
+  let open Keeper_types_profile in
+  let has_profile_source = Option.is_some defaults.manifest_path in
+  let target_sandbox_profile =
+    match defaults.sandbox_profile, defaults.manifest_path with
+    | Some profile, _ -> Ok profile
+    | None, Some _ ->
+        Error
+          (missing_required_sandbox_profile_error ~keeper_name:meta.name
+             defaults)
+    | None, None -> Ok meta.sandbox_profile
+  in
+  match target_sandbox_profile with
+  | Error _ as err -> err
+  | Ok sandbox_profile ->
+      let default_network_mode =
+        if has_profile_source then default_network_mode_for_profile sandbox_profile
+        else meta.network_mode
+      in
+      let network_mode =
+        apply_profile_default defaults.network_mode default_network_mode
+      in
+      let tool_access =
+        match defaults.tool_custom_list with
+        | Some tools -> normalize_tool_names tools
+        | None -> meta.tool_access
+      in
+      let per_provider_timeout_s =
+        match defaults.per_provider_timeout_state with
+        | Per_provider_timeout_unset ->
+            normalize_per_provider_timeout_opt
+              ~source:(Printf.sprintf "keeper effective meta %s" meta.name)
+              meta.per_provider_timeout_s
+        | Per_provider_timeout_invalid -> None
+        | Per_provider_timeout_set -> defaults.per_provider_timeout
+      in
+      Ok
+        { meta with
+          proactive =
+            {
+              enabled =
+                apply_profile_default defaults.proactive_enabled
+                  Keeper_config.default_proactive_enabled;
+              idle_sec =
+                apply_profile_default defaults.proactive_idle_sec
+                  Keeper_config.default_proactive_idle_sec;
+              cooldown_sec =
+                apply_profile_default defaults.proactive_cooldown_sec
+                  Keeper_config.default_proactive_cooldown_sec;
+            };
+          tool_denylist =
+            apply_profile_default defaults.tool_denylist meta.tool_denylist;
+          social_model =
+            apply_profile_default defaults.social_model meta.social_model;
+          goal = apply_profile_default defaults.goal meta.goal;
+          short_goal =
+            apply_profile_default defaults.short_goal meta.short_goal;
+          mid_goal = apply_profile_default defaults.mid_goal meta.mid_goal;
+          long_goal = apply_profile_default defaults.long_goal meta.long_goal;
+          will = apply_profile_default defaults.will meta.will;
+          needs = apply_profile_default defaults.needs meta.needs;
+          desires = apply_profile_default defaults.desires meta.desires;
+          instructions =
+            apply_profile_default defaults.instructions meta.instructions;
+          autoboot_enabled =
+            apply_profile_default defaults.autoboot_enabled
+              meta.autoboot_enabled;
+          mention_targets =
+            (match defaults.mention_targets with
+             | [] -> meta.mention_targets
+             | targets -> targets);
+          active_goal_ids =
+            apply_profile_default defaults.active_goal_ids meta.active_goal_ids;
+          tool_access;
+          sandbox_profile;
+          sandbox_image =
+            apply_profile_default_opt defaults.sandbox_image meta.sandbox_image;
+          network_mode;
+          allowed_paths =
+            apply_profile_default defaults.allowed_paths
+              (if has_profile_source then [] else meta.allowed_paths);
+          telemetry_feedback_enabled =
+            apply_profile_default_opt defaults.telemetry_feedback_enabled
+              meta.telemetry_feedback_enabled;
+          telemetry_feedback_window_hours =
+            apply_profile_default_opt defaults.telemetry_feedback_window_hours
+              meta.telemetry_feedback_window_hours;
+          per_provider_timeout_s;
+          always_approve =
+            apply_profile_default_opt defaults.always_approve
+              meta.always_approve;
+          oas_env =
+            (match defaults.oas_env with
+             | [] -> meta.oas_env
+             | env -> env);
+        }
+;;
+
+let effective_meta_result (meta : keeper_meta) : (keeper_meta, string) result =
+  match Keeper_types_profile.load_keeper_profile_defaults_result meta.name with
+  | Error detail ->
+      Error (invalid_profile_defaults_error ~keeper_name:meta.name detail)
+  | Ok defaults -> effective_meta_of_profile_defaults defaults meta
+;;
+
 let runtime_id_of_meta (m : keeper_meta) : string =
   (* RFC-0207: a keeper's per-keeper runtime is its persona [model] selection
      (keepers/<name>.toml [model = "provider.model"], cached by

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -373,6 +373,18 @@ type keeper_meta = {
   meta_version : int;
 }
 
+(** Overlay TOML/persona defaults onto persisted runtime meta for
+    status-facing reads. Persisted runtime JSON intentionally omits
+    TOML-owned fields such as [sandbox_profile], [network_mode], and
+    [tool_access]. *)
+val effective_meta_result : keeper_meta -> (keeper_meta, string) result
+
+(** Pure variant for callers that already loaded profile defaults. *)
+val effective_meta_of_profile_defaults :
+  Keeper_types_profile.keeper_profile_defaults ->
+  keeper_meta ->
+  (keeper_meta, string) result
+
 (** {1 Runtime id derivation} *)
 
 val runtime_id_of_meta : keeper_meta -> string

--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -186,6 +186,25 @@ let read_meta config name : (Keeper_meta_contract.keeper_meta option, string) re
   | Error _ as err -> err
 ;;
 
+let read_effective_meta_resolved config name
+    : ((string * Keeper_meta_contract.keeper_meta) option, string) result =
+  match read_meta_resolved config name with
+  | Error _ as err -> err
+  | Ok None -> Ok None
+  | Ok (Some (resolved_name, meta)) -> (
+      match Keeper_meta_contract.effective_meta_result meta with
+      | Ok meta -> Ok (Some (resolved_name, meta))
+      | Error msg -> Error msg)
+;;
+
+let read_effective_meta config name
+    : (Keeper_meta_contract.keeper_meta option, string) result =
+  match read_effective_meta_resolved config name with
+  | Ok (Some (_resolved_name, meta)) -> Ok (Some meta)
+  | Ok None -> Ok None
+  | Error _ as err -> err
+;;
+
 (** Read keeper meta only if the file's mtime has changed since [last_mtime].
     Returns [Some (meta, new_mtime)] when the file changed, [None] when
     unchanged. Avoids parsing JSON on every heartbeat cycle when no

--- a/lib/keeper/keeper_meta_store.mli
+++ b/lib/keeper/keeper_meta_store.mli
@@ -70,6 +70,19 @@ val read_meta_resolved :
 val read_meta :
   Workspace.config -> string -> (Keeper_meta_contract.keeper_meta option, string) result
 
+(** Read persisted keeper meta and overlay TOML/persona defaults before
+    returning it. Status/list/operator surfaces should use this for
+    TOML-owned fields such as [sandbox_profile], [network_mode], and
+    [tool_access]. *)
+val read_effective_meta_resolved :
+  Workspace.config ->
+  string ->
+  ((string * Keeper_meta_contract.keeper_meta) option, string) result
+
+(** Like [read_effective_meta_resolved] but discards the filename component. *)
+val read_effective_meta :
+  Workspace.config -> string -> (Keeper_meta_contract.keeper_meta option, string) result
+
 (** Read keeper meta only if the canonical [name] file's mtime exceeds
     [last_mtime]. Returns [Some (meta, mtime)] when changed, [None] when
     unchanged, missing, or unparsable (logs the parse-failure case). *)

--- a/lib/keeper/keeper_observation.ml
+++ b/lib/keeper/keeper_observation.ml
@@ -404,6 +404,7 @@ let runtime_metrics_for_candidates ~candidate_count:(_ : int) () =
 let runtime_observation_with_metrics ~runtime_id ?strategy ~configured_labels
     ~(candidate_count : int)
     ~(selected_model_raw : string option) ~(capture : runtime_metrics_capture)
+    ?(attempt_details_source = "oas_metrics_callbacks")
     ?(oas_internal_runtime_allowed = false)
     () =
   runtime_observation_of_candidates ~runtime_id ?strategy ~configured_labels
@@ -411,7 +412,7 @@ let runtime_observation_with_metrics ~runtime_id ?strategy ~configured_labels
     ~attempts:(List.rev capture.attempts_rev)
     ~fallback_events:(List.rev capture.fallback_events_rev)
     ~attempt_details_available:true
-    ~attempt_details_source:"oas_metrics_callbacks"
+    ~attempt_details_source
     ~oas_internal_runtime_allowed
     ()
 

--- a/lib/keeper/keeper_observation.mli
+++ b/lib/keeper/keeper_observation.mli
@@ -161,6 +161,7 @@ val runtime_observation_with_metrics :
   candidate_count:int ->
   selected_model_raw:string option ->
   capture:runtime_metrics_capture ->
+  ?attempt_details_source:string ->
   ?oas_internal_runtime_allowed:bool ->
   unit ->
   runtime_observation

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -391,6 +391,15 @@ let selected_model_of_latest_decision latest_decision =
       | Some _ as value -> value
       | None -> json_string_opt_member "selected_model" decision)
 
+let selected_model_of_latest_decision_or_receipt latest_decision latest_receipt
+    =
+  match selected_model_of_latest_decision latest_decision with
+  | Some _ as value -> value
+  | None ->
+      Option.bind latest_receipt (fun receipt ->
+          receipt |> json_member "runtime"
+          |> json_string_opt_member "selected_model")
+
 let pending_first_json pending_approvals =
   match pending_approvals with
   | `List (first :: _) ->
@@ -535,6 +544,11 @@ let execution_summary_json ~(meta : Keeper_meta_contract.keeper_meta) ~latest_re
     | `Null -> None
     | json -> json_string_opt_member "outcome" json
   in
+  let runtime_selected_model =
+    match runtime_json with
+    | `Null -> None
+    | json -> json_string_opt_member "selected_model" json
+  in
   let mutation_guard_summary =
     match tool_contract_result with
     | Some "violated" -> "mutation_contract_violated"
@@ -566,7 +580,7 @@ let execution_summary_json ~(meta : Keeper_meta_contract.keeper_meta) ~latest_re
         | Some value -> `Bool value
         | None -> `Null );
       ( "provider_selected_model",
-        `Null );
+        Json_util.string_opt_to_json runtime_selected_model );
       ( "runtime_outcome",
         Json_util.string_opt_to_json runtime_outcome );
       ( "sandbox_summary",
@@ -825,7 +839,9 @@ let snapshot_json ~(config : Workspace.config) ~(meta : keeper_meta) =
   let latest_next_action =
     Option.bind latest_terminal_reason (fun reason -> reason.next_action)
   in
-  let selected_model = selected_model_of_latest_decision latest_decision in
+  let selected_model =
+    selected_model_of_latest_decision_or_receipt latest_decision latest_receipt
+  in
   let attention_fields =
     Keeper_status_bridge.attention_fields_json config meta
   in

--- a/lib/keeper/keeper_status.ml
+++ b/lib/keeper/keeper_status.ml
@@ -43,7 +43,7 @@ let handle_keeper_list ctx args : tool_result =
     let now_ts = Time_compat.now () in
     let keepers =
       List.filter_map (fun name ->
-        match read_meta ctx.config name with
+        match read_effective_meta ctx.config name with
         | Error _ -> None
         | Ok None -> None
         | Ok (Some m) ->

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -175,50 +175,61 @@ let resolve_status_target (ctx : _ context) args =
     parameter combos (e.g. fast=true vs fast=false) and TOML/persona overlays
     get separate cache entries. Persisted JSON writes update [updated_at], but
     external [keepers/<name>.toml] edits do not. *)
-let profile_overlay_pair_json pairs =
-  `List (List.map (fun (key, value) -> `List [ `String key; `String value ]) pairs)
+let cache_fingerprint_field (key, value) =
+  Printf.sprintf "%s=%d:%s" key (String.length value) value
+
+let cache_fingerprint_list values = String.concat "\x1f" values
+
+let cache_fingerprint_pairs pairs =
+  pairs
+  |> List.map (fun (key, value) ->
+       key ^ "\x1e" ^ string_of_int (String.length value) ^ "\x1e" ^ value)
+  |> String.concat "\x1f"
 
 let effective_meta_overlay_hash (meta : keeper_meta) =
-  let overlay_json =
-    `Assoc
-      [
-        ("goal", `String meta.goal);
-        ("short_goal", `String meta.short_goal);
-        ("mid_goal", `String meta.mid_goal);
-        ("long_goal", `String meta.long_goal);
-        ("will", `String meta.will);
-        ("needs", `String meta.needs);
-        ("desires", `String meta.desires);
-        ("instructions", `String meta.instructions);
-        ("social_model", `String meta.social_model);
-        ( "sandbox_profile",
-          `String (sandbox_profile_to_string meta.sandbox_profile) );
-        ("sandbox_image", Json_util.string_opt_to_json meta.sandbox_image);
-        ("network_mode", `String (network_mode_to_string meta.network_mode));
-        ("allowed_paths", Json_util.json_string_list meta.allowed_paths);
-        ("tool_access", Json_util.json_string_list meta.tool_access);
-        ("tool_denylist", Json_util.json_string_list meta.tool_denylist);
-        ("mention_targets", Json_util.json_string_list meta.mention_targets);
-        ("active_goal_ids", Json_util.json_string_list meta.active_goal_ids);
-        ( "proactive",
-          `Assoc
-            [
-              ("enabled", `Bool meta.proactive.enabled);
-              ("idle_sec", `Int meta.proactive.idle_sec);
-              ("cooldown_sec", `Int meta.proactive.cooldown_sec);
-            ] );
-        ("autoboot_enabled", `Bool meta.autoboot_enabled);
-        ( "telemetry_feedback_enabled",
-          Json_util.bool_opt_to_json meta.telemetry_feedback_enabled );
-        ( "telemetry_feedback_window_hours",
-          Json_util.int_opt_to_json meta.telemetry_feedback_window_hours );
-        ( "per_provider_timeout_s",
-          Json_util.float_opt_to_json meta.per_provider_timeout_s );
-        ("always_approve", Json_util.bool_opt_to_json meta.always_approve);
-        ("oas_env", profile_overlay_pair_json meta.oas_env);
-      ]
+  let opt_string = Option.value ~default:"" in
+  let opt_bool = function
+    | Some true -> "true"
+    | Some false -> "false"
+    | None -> ""
   in
-  Digest.string (Yojson.Safe.to_string overlay_json) |> Digest.to_hex
+  let opt_int = Option.fold ~none:"" ~some:string_of_int in
+  let opt_float = Option.fold ~none:"" ~some:(Printf.sprintf "%.6f") in
+  let fields =
+    [
+      ("goal", meta.goal);
+      ("short_goal", meta.short_goal);
+      ("mid_goal", meta.mid_goal);
+      ("long_goal", meta.long_goal);
+      ("will", meta.will);
+      ("needs", meta.needs);
+      ("desires", meta.desires);
+      ("social_model", meta.social_model);
+      ("sandbox_profile", sandbox_profile_to_string meta.sandbox_profile);
+      ("sandbox_image", opt_string meta.sandbox_image);
+      ("network_mode", network_mode_to_string meta.network_mode);
+      ("allowed_paths", cache_fingerprint_list meta.allowed_paths);
+      ("tool_access", cache_fingerprint_list meta.tool_access);
+      ("tool_denylist", cache_fingerprint_list meta.tool_denylist);
+      ("mention_targets", cache_fingerprint_list meta.mention_targets);
+      ("active_goal_ids", cache_fingerprint_list meta.active_goal_ids);
+      ("proactive_enabled", string_of_bool meta.proactive.enabled);
+      ("proactive_idle_sec", string_of_int meta.proactive.idle_sec);
+      ("proactive_cooldown_sec", string_of_int meta.proactive.cooldown_sec);
+      ("autoboot_enabled", string_of_bool meta.autoboot_enabled);
+      ("telemetry_feedback_enabled", opt_bool meta.telemetry_feedback_enabled);
+      ( "telemetry_feedback_window_hours",
+        opt_int meta.telemetry_feedback_window_hours );
+      ("per_provider_timeout_s", opt_float meta.per_provider_timeout_s);
+      ("always_approve", opt_bool meta.always_approve);
+      ("oas_env", cache_fingerprint_pairs meta.oas_env);
+    ]
+  in
+  fields
+  |> List.map cache_fingerprint_field
+  |> String.concat "\n"
+  |> Digest.string
+  |> Digest.to_hex
 
 let hash_status_args _config resolved_name (meta : keeper_meta) args =
   let parts = [

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -187,7 +187,10 @@ let cache_fingerprint_pairs pairs =
   |> String.concat "\x1f"
 
 let effective_meta_overlay_hash (meta : keeper_meta) =
-  let opt_string = Option.value ~default:"" in
+  let opt_string = function
+    | Some value -> value
+    | None -> ""
+  in
   let opt_bool = function
     | Some true -> "true"
     | Some false -> "false"

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -162,7 +162,7 @@ let resolve_status_target_config ~(config : Workspace.config) ~(agent_name : str
           [A-Za-z0-9._-]+; see Keeper_config.validate_name)"
          requested_name)
   else
-    match read_meta_resolved config requested_name with
+    match read_effective_meta_resolved config requested_name with
     | Error e -> Error e
     | Ok (Some (resolved_name, meta)) -> Ok (resolved_name, meta)
     | Ok None ->
@@ -171,11 +171,21 @@ let resolve_status_target_config ~(config : Workspace.config) ~(agent_name : str
 let resolve_status_target (ctx : _ context) args =
   resolve_status_target_config ~config:ctx.config ~agent_name:ctx.agent_name args
 
-(** Hash the status-affecting args so different parameter combos
-    get separate cache entries (e.g. fast=true vs fast=false). *)
-let hash_status_args _config resolved_name args =
+(** Hash the status-affecting args and the effective meta snapshot so different
+    parameter combos (e.g. fast=true vs fast=false) and TOML/persona overlays
+    get separate cache entries. Persisted JSON writes update [updated_at], but
+    external [keepers/<name>.toml] edits do not. *)
+let hash_status_args _config resolved_name (meta : keeper_meta) args =
+  let effective_meta_hash =
+    meta
+    |> Keeper_meta_json.meta_to_json
+    |> Yojson.Safe.to_string
+    |> Digest.string
+    |> Digest.to_hex
+  in
   let parts = [
     resolved_name;
+    effective_meta_hash;
     (* Keeper_manual_reconcile.cache_key removed with reconcile system. *)
     string_of_bool (get_bool args "fast" false);
     string_of_bool (get_bool args "include_context" false);
@@ -202,8 +212,8 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
   | Error err -> tool_result_error err
   | Ok (name, m) ->
       let cache_key = status_cache_key ~base_path:config.base_path ~name in
-      let args_hash = hash_status_args config name args in
-      (* Cache hit: same updated_at + same args → return cached response.
+      let args_hash = hash_status_args config name m args in
+      (* Cache hit: same updated_at + same args/effective-meta hash → return cached response.
          The read is taken under [cache_mu] so it cannot interleave with
          an eviction from [invalidate_status_cache_{for,all}]. *)
       (match

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -171,21 +171,59 @@ let resolve_status_target_config ~(config : Workspace.config) ~(agent_name : str
 let resolve_status_target (ctx : _ context) args =
   resolve_status_target_config ~config:ctx.config ~agent_name:ctx.agent_name args
 
-(** Hash the status-affecting args and the effective meta snapshot so different
+(** Hash the status-affecting args and the profile-overlay fields so different
     parameter combos (e.g. fast=true vs fast=false) and TOML/persona overlays
     get separate cache entries. Persisted JSON writes update [updated_at], but
     external [keepers/<name>.toml] edits do not. *)
-let hash_status_args _config resolved_name (meta : keeper_meta) args =
-  let effective_meta_hash =
-    meta
-    |> Keeper_meta_json.meta_to_json
-    |> Yojson.Safe.to_string
-    |> Digest.string
-    |> Digest.to_hex
+let profile_overlay_pair_json pairs =
+  `List (List.map (fun (key, value) -> `List [ `String key; `String value ]) pairs)
+
+let effective_meta_overlay_hash (meta : keeper_meta) =
+  let overlay_json =
+    `Assoc
+      [
+        ("goal", `String meta.goal);
+        ("short_goal", `String meta.short_goal);
+        ("mid_goal", `String meta.mid_goal);
+        ("long_goal", `String meta.long_goal);
+        ("will", `String meta.will);
+        ("needs", `String meta.needs);
+        ("desires", `String meta.desires);
+        ("instructions", `String meta.instructions);
+        ("social_model", `String meta.social_model);
+        ( "sandbox_profile",
+          `String (sandbox_profile_to_string meta.sandbox_profile) );
+        ("sandbox_image", Json_util.string_opt_to_json meta.sandbox_image);
+        ("network_mode", `String (network_mode_to_string meta.network_mode));
+        ("allowed_paths", Json_util.json_string_list meta.allowed_paths);
+        ("tool_access", Json_util.json_string_list meta.tool_access);
+        ("tool_denylist", Json_util.json_string_list meta.tool_denylist);
+        ("mention_targets", Json_util.json_string_list meta.mention_targets);
+        ("active_goal_ids", Json_util.json_string_list meta.active_goal_ids);
+        ( "proactive",
+          `Assoc
+            [
+              ("enabled", `Bool meta.proactive.enabled);
+              ("idle_sec", `Int meta.proactive.idle_sec);
+              ("cooldown_sec", `Int meta.proactive.cooldown_sec);
+            ] );
+        ("autoboot_enabled", `Bool meta.autoboot_enabled);
+        ( "telemetry_feedback_enabled",
+          Json_util.bool_opt_to_json meta.telemetry_feedback_enabled );
+        ( "telemetry_feedback_window_hours",
+          Json_util.int_opt_to_json meta.telemetry_feedback_window_hours );
+        ( "per_provider_timeout_s",
+          Json_util.float_opt_to_json meta.per_provider_timeout_s );
+        ("always_approve", Json_util.bool_opt_to_json meta.always_approve);
+        ("oas_env", profile_overlay_pair_json meta.oas_env);
+      ]
   in
+  Digest.string (Yojson.Safe.to_string overlay_json) |> Digest.to_hex
+
+let hash_status_args _config resolved_name (meta : keeper_meta) args =
   let parts = [
     resolved_name;
-    effective_meta_hash;
+    effective_meta_overlay_hash meta;
     (* Keeper_manual_reconcile.cache_key removed with reconcile system. *)
     string_of_bool (get_bool args "fast" false);
     string_of_bool (get_bool args "include_context" false);

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -467,9 +467,13 @@ let profile_cache_scope () =
       [ resolution.config_root.path; resolution.personas.path ]
   with
   | exn ->
+    (* resolver failure fallback uses env only as a cache-key salt;
+       profile parsing remains explicit and the cache miss path revalidates
+       file fingerprints before returning a cached result. NDT-OK *)
     String.concat "|"
       [
         Option.value ~default:"" (Sys.getenv_opt "MASC_CONFIG_DIR");
+        (* NDT-OK: same cache-key salt fallback as MASC_CONFIG_DIR above. *)
         Option.value ~default:"" (Sys.getenv_opt "MASC_PERSONAS_DIR");
         Printexc.to_string exn;
       ]
@@ -510,7 +514,8 @@ let persona_profile_candidate_paths name =
   |> List.map (fun root ->
        Filename.concat (Filename.concat root name) "profile.json")
 
-let profile_dependency_paths ~name ~primary_toml_path result =
+let profile_dependency_paths ~name ~primary_toml_path
+    (result : (keeper_profile_defaults, string) result) =
   let paths =
     match primary_toml_path, result with
     | Some toml_path, Ok defaults ->

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -267,7 +267,7 @@ let resolved_persona_name ~keeper_name
   | Some name when String.trim name <> "" -> name
   | _ -> keeper_name
 
-let load_keeper_profile_defaults_result name :
+let load_keeper_profile_defaults_result_uncached name :
     (keeper_profile_defaults, string) result =
   (* Priority: TOML config/keepers/<name>.toml > persona profile.json.
      If TOML sets [persona_name], load that persona first and treat TOML as a
@@ -443,14 +443,123 @@ let keeper_toml_config_error_for_name name =
   | None -> None
   | Some path -> keeper_toml_config_error_of_path path
 
-(* Profile defaults cache — TOML/JSON config files are static at runtime.
-   Eliminates per-tool-call disk reads for the same keeper name.
-   Key includes config_dir so tests with isolated MASC_CONFIG_DIR don't collide. *)
-let profile_defaults_cache : (string * string, keeper_profile_defaults) Hashtbl.t =
+(* Profile defaults cache — strict results are cached by source file
+   fingerprint, not by keeper name alone. TOML/persona edits happen outside the
+   process, so both Ok and Error entries must invalidate when their dependency
+   mtimes/sizes change. *)
+type profile_defaults_cache_key = string * string
+
+type profile_defaults_cache_entry =
+  { primary_toml_path : string option
+  ; dependency_paths : string list
+  ; dependency_fingerprint : string
+  ; result : (keeper_profile_defaults, string) result
+  }
+
+let profile_defaults_cache : (profile_defaults_cache_key, profile_defaults_cache_entry) Hashtbl.t =
   Hashtbl.create 32
 let profile_defaults_mu = Stdlib.Mutex.create ()
 
-let load_keeper_profile_defaults_uncached name : keeper_profile_defaults =
+let profile_cache_scope () =
+  try
+    let resolution = Config_dir_resolver.resolve () in
+    String.concat "|"
+      [ resolution.config_root.path; resolution.personas.path ]
+  with
+  | exn ->
+    String.concat "|"
+      [
+        Option.value ~default:"" (Sys.getenv_opt "MASC_CONFIG_DIR");
+        Option.value ~default:"" (Sys.getenv_opt "MASC_PERSONAS_DIR");
+        Printexc.to_string exn;
+      ]
+
+let profile_defaults_cache_key name = (profile_cache_scope (), name)
+
+let same_string_opt a b =
+  match a, b with
+  | None, None -> true
+  | Some a, Some b -> String.equal a b
+  | _ -> false
+
+let file_fingerprint path =
+  match Fs_compat.file_mtime path, Fs_compat.file_size path with
+  | Some mtime, Some size -> Printf.sprintf "%s:%.6f:%d" path mtime size
+  | Some mtime, None -> Printf.sprintf "%s:%.6f:?" path mtime
+  | None, Some size -> Printf.sprintf "%s:missing:%d" path size
+  | None, None -> path ^ ":missing"
+
+let dependency_fingerprint paths =
+  paths |> List.map file_fingerprint |> String.concat "|"
+
+let persona_profile_candidate_paths name =
+  let dirs =
+    try Config_dir_resolver.personas_dirs () with
+    | Sys_error _ -> []
+    | exn ->
+      Prometheus.inc_counter
+        Keeper_metrics.(to_string ProfileLoadFailures)
+        ~labels:[ "site", Keeper_profile_load_failure_site.(to_label Personas_dirs_resolve) ]
+        ();
+      Log.Keeper.warn
+        "profile cache personas_dirs unexpected: %s"
+        (Printexc.to_string exn);
+      []
+  in
+  dirs
+  |> List.map (fun root ->
+       Filename.concat (Filename.concat root name) "profile.json")
+
+let profile_dependency_paths ~name ~primary_toml_path result =
+  let paths =
+    match primary_toml_path, result with
+    | Some toml_path, Ok defaults ->
+      let persona_paths =
+        match defaults.persona_name with
+        | Some persona_name when String.trim persona_name <> "" ->
+          persona_profile_candidate_paths persona_name
+        | _ -> []
+      in
+      toml_path :: persona_paths
+    | Some toml_path, Error _ -> [ toml_path ]
+    | None, _ -> persona_profile_candidate_paths name
+  in
+  dedupe_keep_order paths
+
+let load_keeper_profile_defaults_result name :
+    (keeper_profile_defaults, string) result =
+  let primary_toml_path = keeper_toml_path_opt name in
+  let key = profile_defaults_cache_key name in
+  let cached =
+    Stdlib.Mutex.lock profile_defaults_mu;
+    let value = Hashtbl.find_opt profile_defaults_cache key in
+    Stdlib.Mutex.unlock profile_defaults_mu;
+    value
+  in
+  match cached with
+  | Some entry
+    when same_string_opt entry.primary_toml_path primary_toml_path
+         && String.equal entry.dependency_fingerprint
+              (dependency_fingerprint entry.dependency_paths) ->
+    entry.result
+  | _ ->
+    let result = load_keeper_profile_defaults_result_uncached name in
+    let dependency_paths =
+      profile_dependency_paths ~name ~primary_toml_path result
+    in
+    let entry =
+      { primary_toml_path
+      ; dependency_paths
+      ; dependency_fingerprint = dependency_fingerprint dependency_paths
+      ; result
+      }
+    in
+    Stdlib.Mutex.lock profile_defaults_mu;
+    Hashtbl.replace profile_defaults_cache key entry;
+    Stdlib.Mutex.unlock profile_defaults_mu;
+    result
+
+let load_keeper_profile_defaults name : keeper_profile_defaults =
   match load_keeper_profile_defaults_result name with
   | Ok defaults -> defaults
   | Error e ->
@@ -462,22 +571,6 @@ let load_keeper_profile_defaults_uncached name : keeper_profile_defaults =
          ()
      | None -> ());
     load_keeper_profile_defaults_from_persona name
-
-let load_keeper_profile_defaults name : keeper_profile_defaults =
-  let config_dir = Option.value ~default:"" (Sys.getenv_opt "MASC_CONFIG_DIR") in
-  let key = (config_dir, name) in
-  Stdlib.Mutex.lock profile_defaults_mu;
-  match Hashtbl.find_opt profile_defaults_cache key with
-  | Some defaults ->
-    Stdlib.Mutex.unlock profile_defaults_mu;
-    defaults
-  | None ->
-    Stdlib.Mutex.unlock profile_defaults_mu;
-    let defaults = load_keeper_profile_defaults_uncached name in
-    Stdlib.Mutex.lock profile_defaults_mu;
-    Hashtbl.replace profile_defaults_cache key defaults;
-    Stdlib.Mutex.unlock profile_defaults_mu;
-    defaults
 
 (** Clamp a profile-provided max-turns override to [1, 100] — the same range
     enforced by [Keeper_runtime_resolved.reactive_max_turns_per_call].

--- a/lib/operator/operator_control.ml
+++ b/lib/operator/operator_control.ml
@@ -24,7 +24,7 @@ let dispatch_keeper_json (ctx : 'a context) ~tool_name ~args =
   | None -> Error (Printf.sprintf "%s dispatch unavailable" tool_name)
 
 let resolve_keeper_meta_for_name (ctx : 'a context) ~(name : string) =
-  match Keeper_meta_store.read_meta_resolved ctx.config name with
+  match Keeper_meta_store.read_effective_meta_resolved ctx.config name with
   | Error err -> Error err
   | Ok None -> Error (Printf.sprintf "keeper not found: %s" name)
   | Ok (Some (resolved_name, meta)) -> Ok (resolved_name, meta)

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -257,11 +257,46 @@ let transport_for_provider ~sw ~net ~provider_cfg () =
      threaded here. *)
   Ok (Some (provider_config_preserving_http_transport ~sw ~net ~provider_cfg))
 
+let runtime_id_of_config (config : config) =
+  let runtime_prefix = "runtime:" in
+  let runtime_suffix = "/runtime" in
+  match config.description with
+  | Some description
+    when String.starts_with ~prefix:runtime_prefix description
+         && String.ends_with ~suffix:runtime_suffix description ->
+      let prefix_len = String.length runtime_prefix in
+      let suffix_len = String.length runtime_suffix in
+      let len = String.length description - prefix_len - suffix_len in
+      if len > 0 then String.sub description prefix_len len else config.name
+  | _ -> config.name
+
+let runtime_observation_for_completed_config ~total_duration_ms
+    (config : config) =
+  let latency_ms = Some (int_of_float total_duration_ms) in
+  let capture, _metrics =
+    Keeper_observation.runtime_metrics_for_candidates ~candidate_count:1 ()
+  in
+  Keeper_observation.record_attempt_terminal capture ~model_id:config.model_id
+    ~latency_ms ~error:None;
+  Keeper_observation.runtime_observation_with_metrics
+    ~runtime_id:(runtime_id_of_config config)
+    ~strategy:"single_provider_runtime"
+    ~configured_labels:
+      [ Keeper_observation.model_label_of_config config.provider_cfg ]
+    ~candidate_count:1
+    ~selected_model_raw:(Some config.model_id)
+    ~capture
+    ~attempt_details_source:"runtime_agent_terminal"
+    ()
+
 module For_testing = struct
   let request_runtime_fields_on_base_config =
     request_runtime_fields_on_base_config
 
   let provider_http_slot_transport = provider_http_slot_transport
+  let runtime_id_of_config = runtime_id_of_config
+  let runtime_observation_for_completed_config =
+    runtime_observation_for_completed_config
 end
 
 (* ================================================================ *)
@@ -556,6 +591,10 @@ let run
       record_dashboard_oas_response ~config
         ~total_duration_ms:run_total_duration_ms
         ~status:Dashboard_oas_bridge.Success response;
+      let runtime_observation =
+        runtime_observation_for_completed_config
+          ~total_duration_ms:run_total_duration_ms config
+      in
       Ok
         {
           response;
@@ -564,7 +603,7 @@ let run
           turns;
           trace_ref;
           run_validation;
-          runtime_observation = None;
+          runtime_observation = Some runtime_observation;
           stop_reason = Completed;
         }
     | Error (Agent_sdk.Error.Agent (Agent_sdk.Error.MaxTurnsExceeded r)) ->
@@ -578,6 +617,10 @@ let run
       record_dashboard_oas_response ~config
         ~total_duration_ms:run_total_duration_ms
         ~status:Dashboard_oas_bridge.Timeout partial_response;
+      let runtime_observation =
+        runtime_observation_for_completed_config
+          ~total_duration_ms:run_total_duration_ms config
+      in
       Ok
         {
           response = partial_response;
@@ -586,7 +629,7 @@ let run
           turns;
           trace_ref;
           run_validation;
-          runtime_observation = None;
+          runtime_observation = Some runtime_observation;
           stop_reason = TurnBudgetExhausted { turns_used = r.turns; limit = r.limit };
         }
     | Error (Agent_sdk.Error.Agent (Agent_sdk.Error.ExitConditionMet r)) -> (
@@ -608,6 +651,10 @@ let run
           ~total_duration_ms:run_total_duration_ms
           ~status:(dashboard_status_of_stop_reason stop_reason)
           partial_response;
+        let runtime_observation =
+          runtime_observation_for_completed_config
+            ~total_duration_ms:run_total_duration_ms config
+        in
         Ok
           {
             response = partial_response;
@@ -616,7 +663,7 @@ let run
             turns;
             trace_ref;
             run_validation;
-            runtime_observation = None;
+            runtime_observation = Some runtime_observation;
             stop_reason;
           }
       | None ->

--- a/lib/runtime/runtime_agent.mli
+++ b/lib/runtime/runtime_agent.mli
@@ -192,6 +192,11 @@ module For_testing : sig
 
   val provider_http_slot_transport :
     Llm_provider.Llm_transport.t -> Llm_provider.Llm_transport.t
+
+  val runtime_id_of_config : config -> string
+
+  val runtime_observation_for_completed_config :
+    total_duration_ms:float -> config -> Keeper_observation.runtime_observation
 end
 
 (** {1 Lifecycle / checkpoint helpers (re-exported)} *)

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -92,17 +92,29 @@ let handle_keeper_sandbox_status ctx args : tool_result =
       let resolved =
         candidate_names
         |> List.filter_map (fun name ->
-             match read_meta ctx.config name with
+             match read_effective_meta ctx.config name with
              | Ok (Some meta) -> Some meta
              | Ok None when List.mem name configured_names -> (
                  match load_or_materialize_boot_meta ctx name with
-                 | Ok { meta; _ } -> Some meta
+                 | Ok { meta; _ } -> (
+                     match Keeper_meta_contract.effective_meta_result meta with
+                     | Ok effective_meta -> Some effective_meta
+                     | Error msg ->
+                         Log.Keeper.warn
+                           "keeper_sandbox_status fleet: failed to overlay effective meta for materialized keeper %s: %s"
+                           name msg;
+                         None)
                  | Error msg ->
                      Log.Keeper.warn
                        "keeper_sandbox_status fleet: failed to materialize configured keeper %s: %s"
                        name msg;
                      None)
-             | Ok None | Error _ -> None)
+             | Ok None -> None
+             | Error msg ->
+                 Log.Keeper.warn
+                   "keeper_sandbox_status fleet: failed to read effective meta for %s: %s"
+                   name msg;
+                 None)
       in
       let seen = Hashtbl.create 16 in
       let unique_metas =

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -81,6 +81,59 @@ let keeper_sandbox_status_fleet_names ctx =
   registry_names @ configured_keeper_names ctx.config @ keeper_names ctx.config
   |> dedupe_sorted_strings
 
+type sandbox_status_fleet_item =
+  | Sandbox_status_meta of keeper_meta
+  | Sandbox_status_error of { name : string; error : string }
+
+let keeper_sandbox_status_error_item_json config ~name ~error =
+  let persisted_meta =
+    match read_meta config name with
+    | Ok (Some meta) -> Some meta
+    | Ok None | Error _ -> None
+  in
+  let keepalive_running =
+    match persisted_meta with
+    | Some meta -> Keeper_status_bridge.runtime_keepalive_running config meta
+    | None -> false
+  in
+  let persisted_fields =
+    match persisted_meta with
+    | Some meta ->
+        [
+          ("persisted_meta", keeper_brief_meta_json meta);
+          ("agent_name", `String meta.agent_name);
+          ( "persisted_sandbox_profile",
+            `String (sandbox_profile_to_string meta.sandbox_profile) );
+          ( "persisted_network_mode",
+            `String (network_mode_to_string meta.network_mode) );
+        ]
+    | None ->
+        [
+          ("persisted_meta", `Null);
+          ("agent_name", `Null);
+          ("persisted_sandbox_profile", `Null);
+          ("persisted_network_mode", `Null);
+        ]
+  in
+  error_assoc
+    ([
+       ("keeper", `String name);
+       ("sandbox_profile", `Null);
+       ("configured_network_mode", `Null);
+       ("effective_mode", `String "unknown");
+       ("managed_container_kind", `String Keeper_sandbox_control.managed_kind);
+       ("container_count", `Int 0);
+       ("containers", `List []);
+       ("preflight", `Null);
+       ("container_error", `Null);
+       ("why_no_container", `String "effective_meta_read_failed");
+       ( "recommendation",
+         `String "Fix keeper TOML/persona profile and retry sandbox status." );
+       ("keepalive_running", `Bool keepalive_running);
+       ("effective_meta_error", keeper_list_effective_meta_error_json name error);
+     ]
+     @ persisted_fields)
+
 let handle_keeper_sandbox_status ctx args : tool_result =
   let verbose = get_bool args "verbose" false in
   let include_preflight = get_bool args "include_preflight" true in
@@ -93,44 +146,50 @@ let handle_keeper_sandbox_status ctx args : tool_result =
         candidate_names
         |> List.filter_map (fun name ->
              match read_effective_meta ctx.config name with
-             | Ok (Some meta) -> Some meta
+             | Ok (Some meta) -> Some (Sandbox_status_meta meta)
              | Ok None when List.mem name configured_names -> (
                  match load_or_materialize_boot_meta ctx name with
                  | Ok { meta; _ } -> (
                      match Keeper_meta_contract.effective_meta_result meta with
-                     | Ok effective_meta -> Some effective_meta
+                     | Ok effective_meta -> Some (Sandbox_status_meta effective_meta)
                      | Error msg ->
                          Log.Keeper.warn
                            "keeper_sandbox_status fleet: failed to overlay effective meta for materialized keeper %s: %s"
                            name msg;
-                         None)
+                         Some (Sandbox_status_error { name; error = msg }))
                  | Error msg ->
                      Log.Keeper.warn
                        "keeper_sandbox_status fleet: failed to materialize configured keeper %s: %s"
                        name msg;
-                     None)
+                     Some (Sandbox_status_error { name; error = msg }))
              | Ok None -> None
              | Error msg ->
                  Log.Keeper.warn
                    "keeper_sandbox_status fleet: failed to read effective meta for %s: %s"
                    name msg;
-                 None)
+                 Some (Sandbox_status_error { name; error = msg }))
       in
       let seen = Hashtbl.create 16 in
-      let unique_metas =
+      let unique_items =
         List.filter_map
-          (fun (meta : keeper_meta) ->
-            if Hashtbl.mem seen meta.name then None
-            else begin
-              Hashtbl.add seen meta.name ();
-              Some meta
-            end)
+          (fun item ->
+            let name =
+              match item with
+              | Sandbox_status_meta meta -> meta.name
+              | Sandbox_status_error { name; _ } -> name
+            in
+            if Hashtbl.mem seen name then None
+            else (
+              Hashtbl.add seen name ();
+              Some item))
           resolved
       in
       let any_docker =
         List.exists
-          (fun (m : keeper_meta) -> m.sandbox_profile = Docker)
-          unique_metas
+          (function
+            | Sandbox_status_meta (m : keeper_meta) -> m.sandbox_profile = Docker
+            | Sandbox_status_error _ -> false)
+          unique_items
       in
       let cached_preflight =
         if include_preflight && any_docker then
@@ -147,7 +206,14 @@ let handle_keeper_sandbox_status ctx args : tool_result =
           ~include_preflight ?preflight_override
           ~config:ctx.config ~meta ~timeout_sec ~verbose ()
       in
-      let items = List.map render_item unique_metas in
+      let items =
+        List.map
+          (function
+            | Sandbox_status_meta meta -> render_item meta
+            | Sandbox_status_error { name; error } ->
+                keeper_sandbox_status_error_item_json ctx.config ~name ~error)
+          unique_items
+      in
       tool_result_ok
         (Yojson.Safe.pretty_to_string
            (`Assoc

--- a/lib/tool_keeper_ops.ml
+++ b/lib/tool_keeper_ops.ml
@@ -213,6 +213,49 @@ let keeper_brief_meta_json (meta : keeper_meta) =
       ("trace_id", `String (Keeper_id.Trace_id.to_string meta.runtime.trace_id));
       ("created_at", `String meta.created_at); ("updated_at", `String meta.updated_at);
     ]
+
+let keeper_list_effective_meta_error_json name err =
+  `Assoc
+    [
+      ("keeper", `String name);
+      ("message", `String err);
+      ("terminal_reason", `String "effective_meta_read_failed");
+      ("severity", `String "error");
+      ("operator_action_required", `Bool true);
+      ("next_action", `String "fix_keeper_toml_or_persona_profile");
+    ]
+
+let keeper_list_error_row_json ~runtime_class config name err =
+  let persisted_fields =
+    match read_meta config name with
+    | Ok (Some meta) ->
+        [
+          ("meta", keeper_brief_meta_json meta);
+          ("agent_name", `String meta.agent_name);
+          ("created_at", `String meta.created_at);
+          ("updated_at", `String meta.updated_at);
+          ("autoboot_enabled", `Bool meta.autoboot_enabled);
+          ("proactive_enabled", `Bool meta.proactive.enabled);
+          ("proactive_idle_sec", `Int meta.proactive.idle_sec);
+          ("proactive_cooldown_sec", `Int meta.proactive.cooldown_sec);
+        ]
+    | Ok None | Error _ ->
+        [
+          ("meta", `Null);
+          ("agent_name", `Null);
+          ("created_at", `Null);
+          ("updated_at", `Null);
+        ]
+  in
+  error_assoc
+    ([
+       ("runtime_class", `String runtime_class);
+       ("name", `String name);
+       ("keepalive_running", `Bool false);
+       ("effective_meta_error", keeper_list_effective_meta_error_json name err);
+     ]
+     @ persisted_fields)
+
 let keeper_list_skill_route_json config (meta : keeper_meta) =
   let metrics_store = Keeper_types_support.keeper_metrics_store config meta.name in
   let metrics_path = Keeper_types_support.keeper_metrics_path config meta.name in
@@ -258,8 +301,9 @@ let keeper_list_skill_route_json config (meta : keeper_meta) =
   in
   find_latest (List.rev lines)
 let keeper_list_row_json ~runtime_class config name =
-  match read_meta config name with
-  | Error _ | Ok None -> None
+  match read_effective_meta config name with
+  | Error err -> Some (keeper_list_error_row_json ~runtime_class config name err)
+  | Ok None -> None
   | Ok (Some (meta : keeper_meta)) ->
       let now_ts = Time_compat.now () in
       let keepalive_running = Keeper_status_bridge.runtime_keepalive_running config meta in
@@ -586,7 +630,7 @@ let handle_keeper_msg_stream ~on_text_delta ctx args : tool_result =
 (* RFC-0182 §3.1 — ctx-free body for keeper_dispatch_ref path. *)
 let resolve_keeper_meta_config ~(config : Workspace.config) args =
   let name = String.trim (get_string args "name" "") in
-  match read_meta_resolved config name with
+  match read_effective_meta_resolved config name with
   | Ok (Some (_resolved_name, meta)) -> Ok meta
   | Ok None -> Error (Printf.sprintf "keeper not found: %s" name)
   | Error err -> Error (Printf.sprintf "%s" err)

--- a/lib/tool_keeper_ops.ml
+++ b/lib/tool_keeper_ops.ml
@@ -226,9 +226,19 @@ let keeper_list_effective_meta_error_json name err =
     ]
 
 let keeper_list_error_row_json ~runtime_class config name err =
-  let persisted_fields =
+  let persisted_meta =
     match read_meta config name with
-    | Ok (Some meta) ->
+    | Ok (Some meta) -> Some meta
+    | Ok None | Error _ -> None
+  in
+  let keepalive_running =
+    match persisted_meta with
+    | Some meta -> Keeper_status_bridge.runtime_keepalive_running config meta
+    | None -> false
+  in
+  let persisted_fields =
+    match persisted_meta with
+    | Some meta ->
         [
           ("meta", keeper_brief_meta_json meta);
           ("agent_name", `String meta.agent_name);
@@ -239,7 +249,7 @@ let keeper_list_error_row_json ~runtime_class config name err =
           ("proactive_idle_sec", `Int meta.proactive.idle_sec);
           ("proactive_cooldown_sec", `Int meta.proactive.cooldown_sec);
         ]
-    | Ok None | Error _ ->
+    | None ->
         [
           ("meta", `Null);
           ("agent_name", `Null);
@@ -251,7 +261,7 @@ let keeper_list_error_row_json ~runtime_class config name err =
     ([
        ("runtime_class", `String runtime_class);
        ("name", `String name);
-       ("keepalive_running", `Bool false);
+       ("keepalive_running", `Bool keepalive_running);
        ("effective_meta_error", keeper_list_effective_meta_error_json name err);
      ]
      @ persisted_fields)

--- a/scripts/ci/check-masc-oas-boundary.sh
+++ b/scripts/ci/check-masc-oas-boundary.sh
@@ -138,7 +138,7 @@ masc_matches=$(
 )
 if [ -n "$masc_matches" ]; then
   echo "WARN: MASC files contain OAS-reserved concepts (verify they call OAS, not reimplement):"
-  echo "$masc_matches" | head -20
+  head -20 <<< "$masc_matches"
 fi
 
 # 3. MASC using Oas_worker raw/internal interfaces instead of public API.
@@ -154,7 +154,7 @@ internal_matches=$(
 )
 if [ -n "$internal_matches" ]; then
   echo "FAIL: MASC uses Oas_worker raw/internal identifiers (route through Masc_oas_bridge or Oas_worker public API):"
-  echo "$internal_matches" | head -20
+  head -20 <<< "$internal_matches"
   exit_code=1
 else
   echo "PASS: no Oas_worker raw/internal access in MASC keeper/bridge files"

--- a/test/dune
+++ b/test/dune
@@ -166,6 +166,7 @@
   test_playground_paths
   test_keeper_llama_only
   test_keeper_meta_cwd_resilience
+  test_keeper_effective_meta_overlay
   test_metrics_rotation
   test_tool_access_policy
   test_tool_access_role
@@ -436,6 +437,7 @@
   test_playground_paths
   test_keeper_llama_only
   test_keeper_meta_cwd_resilience
+  test_keeper_effective_meta_overlay
   test_metrics_rotation
   test_tool_access_policy
   test_tool_access_role

--- a/test/test_keeper_effective_meta_overlay.ml
+++ b/test/test_keeper_effective_meta_overlay.ml
@@ -1,0 +1,216 @@
+module Workspace = Masc_mcp.Workspace
+module Store = Masc_mcp.Keeper_meta_store
+module Profile = Masc_mcp.Keeper_types_profile
+module Status_detail = Masc_mcp.Keeper_status_detail
+module Tool_keeper_ops = Masc_mcp.Tool_keeper_ops
+
+let temp_dir () =
+  let path = Filename.temp_file "keeper-effective-meta-" "" in
+  Sys.remove path;
+  Unix.mkdir path 0o755;
+  path
+
+let rec mkdir_p path =
+  if Sys.file_exists path then ()
+  else (
+    let parent = Filename.dirname path in
+    if not (String.equal parent path) then mkdir_p parent;
+    Unix.mkdir path 0o755)
+
+let write_file path content =
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc content)
+
+let rm_rf path =
+  try Masc_mcp.Fs_compat.remove_tree path with
+  | _ -> ()
+
+let restore_env name = function
+  | Some value -> Unix.putenv name value
+  | None -> Unix.putenv name ""
+
+let contains_substring ~needle haystack =
+  let needle_len = String.length needle in
+  let haystack_len = String.length haystack in
+  let rec loop index =
+    index + needle_len <= haystack_len
+    && (String.sub haystack index needle_len = needle || loop (index + 1))
+  in
+  needle_len = 0 || loop 0
+
+let json_string_field key = function
+  | `Assoc fields -> (
+      match List.assoc_opt key fields with
+      | Some (`String value) -> Some value
+      | _ -> None)
+  | _ -> None
+
+let with_config_dir f =
+  let base = temp_dir () in
+  let config_dir = Filename.concat base ".masc/config" in
+  let keepers_dir = Filename.concat config_dir "keepers" in
+  mkdir_p keepers_dir;
+  let previous = Sys.getenv_opt "MASC_CONFIG_DIR" in
+  Fun.protect
+    ~finally:(fun () ->
+      restore_env "MASC_CONFIG_DIR" previous;
+      Config_dir_resolver.reset ();
+      rm_rf base)
+    (fun () ->
+      Unix.putenv "MASC_CONFIG_DIR" config_dir;
+      Config_dir_resolver.reset ();
+      f ~base ~config_dir ~keepers_dir)
+
+let seed_runtime_meta config name =
+  let json =
+    `Assoc
+      [
+        ("name", `String name);
+        ("agent_name", `String ("keeper-" ^ name ^ "-agent"));
+        ("trace_id", `String ("trace-" ^ name));
+        ("goal", `String "effective meta overlay regression");
+        ("tool_access", `List [ `String "masc_status" ]);
+      ]
+  in
+  match Masc_test_deps.meta_of_json_fixture json with
+  | Error err -> Alcotest.fail err
+  | Ok meta -> (
+      match Store.write_meta config meta with
+      | Ok () -> meta
+  | Error err -> Alcotest.failf "write_meta failed: %s" err)
+
+let write_keeper_toml ~keepers_dir ~name ~sandbox_profile ~goal =
+  write_file
+    (Filename.concat keepers_dir (name ^ ".toml"))
+    (Printf.sprintf
+       {|[keeper]
+sandbox_profile = "%s"
+goal = "%s"
+|}
+       sandbox_profile
+       goal)
+
+let status_goal config name =
+  let args = `Assoc [ ("name", `String name); ("fast", `Bool true) ] in
+  let result =
+    Status_detail.handle_keeper_status_config
+      ~config
+      ~agent_name:"test-agent"
+      args
+  in
+  if not (Profile.tool_result_success result) then
+    Alcotest.failf "status failed: %s" (Profile.tool_result_body result);
+  let json = Yojson.Safe.from_string (Profile.tool_result_body result) in
+  match json_string_field "goal" json with
+  | Some goal -> goal
+  | None -> Alcotest.fail "status response missing goal"
+
+let test_toml_overlay_reaches_effective_meta () =
+  with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir ->
+  let name = "analyst" in
+  write_file
+    (Filename.concat keepers_dir (name ^ ".toml"))
+    {|[keeper]
+sandbox_profile = "docker"
+
+[keeper.tool_access]
+tools = ["tool_execute", "tool_read_file"]
+|};
+  let config = Workspace.default_config base in
+  ignore (seed_runtime_meta config name : Masc_mcp.Keeper_meta_contract.keeper_meta);
+  match Store.read_effective_meta config name with
+  | Error err -> Alcotest.failf "read_effective_meta failed: %s" err
+  | Ok None -> Alcotest.fail "expected seeded keeper meta"
+  | Ok (Some meta) ->
+      Alcotest.(check string)
+        "sandbox_profile overlays from TOML"
+        "docker"
+        (Profile.sandbox_profile_to_string meta.sandbox_profile);
+      Alcotest.(check string)
+        "docker default network overlays from TOML profile"
+        "none"
+        (Profile.network_mode_to_string meta.network_mode);
+      Alcotest.(check (list string))
+        "tool_access overlays from TOML"
+        [ "tool_execute"; "tool_read_file" ]
+        meta.tool_access
+
+let test_missing_sandbox_profile_fails_loud_for_profile_source () =
+  with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir ->
+  let name = "nosandbox" in
+  write_file
+    (Filename.concat keepers_dir (name ^ ".toml"))
+    {|[keeper]
+goal = "missing sandbox profile"
+|};
+  let config = Workspace.default_config base in
+  ignore (seed_runtime_meta config name : Masc_mcp.Keeper_meta_contract.keeper_meta);
+  match Store.read_effective_meta config name with
+  | Ok _ -> Alcotest.fail "expected missing sandbox_profile to fail loudly"
+  | Error err ->
+      Alcotest.(check bool)
+        "error names missing sandbox_profile"
+        true
+        (contains_substring ~needle:"sandbox_profile is required" err)
+
+let test_status_cache_tracks_toml_overlay_changes () =
+  with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir ->
+  let name = "statuscache" in
+  write_keeper_toml ~keepers_dir ~name ~sandbox_profile:"local"
+    ~goal:"first cache goal";
+  let config = Workspace.default_config base in
+  ignore (seed_runtime_meta config name : Masc_mcp.Keeper_meta_contract.keeper_meta);
+  Alcotest.(check string)
+    "initial TOML goal reaches status"
+    "first cache goal"
+    (status_goal config name);
+  write_keeper_toml ~keepers_dir ~name ~sandbox_profile:"local"
+    ~goal:"second cache goal after toml edit";
+  Alcotest.(check string)
+    "TOML edit invalidates cached status"
+    "second cache goal after toml edit"
+    (status_goal config name)
+
+let test_keeper_list_row_surfaces_effective_meta_errors () =
+  with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir ->
+  let name = "badprofile" in
+  write_file
+    (Filename.concat keepers_dir (name ^ ".toml"))
+    {|[keeper]
+goal = "missing sandbox profile"
+|};
+  let config = Workspace.default_config base in
+  ignore (seed_runtime_meta config name : Masc_mcp.Keeper_meta_contract.keeper_meta);
+  match Tool_keeper_ops.keeper_list_row_json ~runtime_class:"keeper" config name with
+  | None -> Alcotest.fail "expected error row for invalid effective meta"
+  | Some row ->
+      Alcotest.(check (option string))
+        "row status is error"
+        (Some "error")
+        (json_string_field "status" row);
+      (match row with
+       | `Assoc fields ->
+           Alcotest.(check bool)
+             "row includes actionable error"
+             true
+             (List.mem_assoc "effective_meta_error" fields)
+       | _ -> Alcotest.fail "expected object row")
+
+let () =
+  Alcotest.run "keeper_effective_meta_overlay"
+    [
+      ( "effective_meta",
+        [
+          Alcotest.test_case "TOML sandbox/tool overlay reaches effective meta"
+            `Quick test_toml_overlay_reaches_effective_meta;
+          Alcotest.test_case
+            "profile source without sandbox_profile fails loudly"
+            `Quick test_missing_sandbox_profile_fails_loud_for_profile_source;
+          Alcotest.test_case "status cache tracks TOML overlay edits" `Quick
+            test_status_cache_tracks_toml_overlay_changes;
+          Alcotest.test_case "keeper list surfaces effective meta errors"
+            `Quick test_keeper_list_row_surfaces_effective_meta_errors;
+        ] );
+    ]

--- a/test/test_keeper_effective_meta_overlay.ml
+++ b/test/test_keeper_effective_meta_overlay.ml
@@ -23,9 +23,15 @@ let write_file path content =
     ~finally:(fun () -> close_out_noerr oc)
     (fun () -> output_string oc content)
 
-let rm_rf path =
-  try Masc_mcp.Fs_compat.remove_tree path with
-  | _ -> ()
+let rec rm_rf path =
+  try
+    if Sys.file_exists path then
+      if Sys.is_directory path then (
+        Sys.readdir path
+        |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+        Unix.rmdir path)
+      else Sys.remove path
+  with _ -> ()
 
 let restore_env name = function
   | Some value -> Unix.putenv name value

--- a/test/test_keeper_runtime_trust_snapshot.ml
+++ b/test/test_keeper_runtime_trust_snapshot.ml
@@ -110,11 +110,57 @@ let test_snapshot_counts_malformed_decision_rows () =
        Alcotest.(check (float 0.001))
          "malformed json increments entry error"
          1.0
-         (drop_value entry_error -. before_entry_error);
+       (drop_value entry_error -. before_entry_error);
        Alcotest.(check (float 0.001))
          "non-object row increments invalid payload"
          1.0
          (drop_value invalid_payload -. before_invalid_payload))
+;;
+
+let test_snapshot_uses_receipt_runtime_model_when_decision_absent () =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> remove_tree base_dir)
+    (fun () ->
+       with_env "MASC_BASE_PATH" base_dir
+       @@ fun () ->
+       let config = Masc_mcp.Workspace.default_config base_dir in
+       let keeper_name = "runtime-trust-receipt-model" in
+       let meta = make_meta keeper_name in
+       let receipt_store =
+         Masc_mcp.Keeper_types_support.keeper_execution_receipt_store config keeper_name
+       in
+       Dated_jsonl.append
+         receipt_store
+         (`Assoc
+             [ "turn_count", `Int 7
+             ; "ended_at", `String "2026-06-01T00:00:00Z"
+             ; ( "runtime"
+               , `Assoc
+                   [ "name", `String "runtime-test"
+                   ; "selected_model", `String "receipt-model"
+                   ; "attempt_count", `Int 1
+                   ; "fallback_applied", `Bool false
+                   ; "outcome", `String "completed"
+                   ] )
+             ]);
+       let snapshot = K.snapshot_json ~config ~meta in
+       let open Yojson.Safe.Util in
+       Alcotest.(check string)
+         "selected model falls back to receipt"
+         "receipt-model"
+         (snapshot |> member "selected_model" |> to_string);
+       Alcotest.(check string)
+         "active model falls back to receipt"
+         "receipt-model"
+         (snapshot |> member "active_model" |> to_string);
+       Alcotest.(check string)
+         "execution provider selected model follows receipt"
+         "receipt-model"
+         (snapshot |> member "execution" |> member "provider_selected_model" |> to_string))
 ;;
 
 let () =
@@ -125,6 +171,12 @@ let () =
             "malformed decision rows increment drop metrics"
             `Quick
             test_snapshot_counts_malformed_decision_rows
+        ] )
+    ; ( "receipt_runtime_model"
+      , [ Alcotest.test_case
+            "receipt runtime model feeds trust snapshot when decision is absent"
+            `Quick
+            test_snapshot_uses_receipt_runtime_model_when_decision_absent
         ] )
     ]
 ;;

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -110,6 +110,41 @@ let test_runtime_adapter_filters_toml_auth_headers () =
       (Some "trace-1")
       (normalized_header_value "X-Trace-Id" provider_cfg.headers)
 
+let provider_cfg () =
+  let cfg =
+    { Runtime_schema.providers = [ runpod_provider ]
+    ; models = [ qwen_model ]
+    ; bindings = [ runpod_binding ]
+    ; default_runtime_id = Some "runpod_mtp.qwen"
+    }
+  in
+  match Runtime_adapter.binding_to_provider_config cfg runpod_binding with
+  | Ok provider_cfg -> provider_cfg
+  | Error msg -> failf "unexpected adapter error: %s" msg
+
+let test_runtime_agent_terminal_observation_uses_runtime_identity () =
+  let config =
+    Runtime_agent.default_config
+      ~name:"oas-runpod_mtp.qwen"
+      ~provider_cfg:(provider_cfg ())
+      ~system_prompt:""
+      ~tools:[]
+  in
+  let config =
+    { config with description = Some "runtime:runpod_mtp.qwen/runtime" }
+  in
+  let observation =
+    Runtime_agent.For_testing.runtime_observation_for_completed_config
+      ~total_duration_ms:42.9
+      config
+  in
+  check string "runtime id" "runpod_mtp.qwen" observation.runtime_id;
+  check (option string) "selected model" (Some "qwen")
+    observation.selected_model;
+  check int "attempt count" 1 (List.length observation.attempts);
+  check string "attempt detail source" "runtime_agent_terminal"
+    observation.attempt_details_source
+
 let () =
   run "runtime_provider_auth_headers"
     [ ( "provider_config"
@@ -121,5 +156,9 @@ let () =
             "runtime adapter filters TOML auth headers"
             `Quick
             test_runtime_adapter_filters_toml_auth_headers
+        ; test_case
+            "runtime agent terminal observation carries model identity"
+            `Quick
+            test_runtime_agent_terminal_observation_uses_runtime_identity
         ] )
     ]


### PR DESCRIPTION
## Summary

Fixes the first P0 slice from the Keeper boundary audit: status/list/operator/sandbox-status surfaces now read TOML-overlaid effective keeper meta instead of raw persisted runtime JSON for TOML-owned fields.

- Added `Keeper_meta_contract.effective_meta_result` and `Keeper_meta_store.read_effective_meta*`.
- Switched `masc_keeper_sandbox_status`, `masc_keeper_status`, keeper list rows, and operator diagnostics to effective meta.
- Added `test_keeper_effective_meta_overlay` covering TOML `sandbox_profile=docker`, Docker default network, and TOML tool access overlay.
- Updated the sandbox boundary policy and the generated audit/plan HTML with implementation progress.

## Product impact

Operators should no longer see a Docker keeper reported as `local` in status surfaces while receipts/tool route evidence correctly say `docker`. This reduces false diagnosis around “Keeper does not know Sandbox” and makes sandbox status consistent with runtime/tool execution evidence.

## Evidence

- `git diff --check` passed.
- `xmllint --html --noout docs/audit/2026-06-01-keeper-boundary-runtime-report.html` passed.
- `ocamlformat -i` was run on touched OCaml files.
- Dune validation was attempted before PR creation. The first pre-commit build caught missing `.mli` exports for the new effective-meta helpers and a bad `Config_dir_resolver` test alias; both were fixed. The final full pre-commit build is blocked by current local dependency state: `Agent_sdk` / `/Users/dancer/.opam/5.4.1/lib/agent_sdk/llm_provider/llm_provider.cmxa` is missing, so this PR is opened draft with validation incomplete.

## Direct evidence

schema_version: 1
direct_ratio: 3/4
provenance: direct

- Direct code trace: `read_meta*` status paths bypassed TOML overlay, while receipts/tool backends already had Docker route evidence.
- Direct patch: effective meta overlay is now the read API for status-facing sandbox/tool fields.
- Direct docs: `docs/KEEPER-SANDBOX-BOUNDARY-POLICY.md` now names effective meta as the required status read path.
- Not yet direct: focused Dune build/test is pending until the local `agent_sdk`/`llm_provider` installation is repaired.

## Review evidence

- Review should focus on whether `effective_meta_result` and `ensure_keeper_meta` should be further deduplicated in a follow-up, and whether any additional read-only status endpoints still use raw persisted meta for TOML-owned fields.
- Known remaining plan items from the audit: runtime/provider observability and telemetry append coverage gaps are not fixed in this slice.

## Linked issue

n/a

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`audit/keeper-boundary-report-20260601` → `main` · 1 commit(s) · synced 2026-06-01T08:37:16Z

| sha | subject | date |
|---|---|---|
| `0aeed7678` | Align keeper status with effective meta | 2026-06-01 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->