### PR TITLE
[codex] Guard keeper repo worktree cwd readiness

### DIFF
--- a/lib/keeper/agent_tool_execute_path.ml
+++ b/lib/keeper/agent_tool_execute_path.ml
@@ -3,31 +3,6 @@ open Keeper_meta_contract
 open Keeper_types_profile
 open Agent_tool_shared_runtime
 
-let resolve_tool_read_cwd
-      ~(config : Workspace.config)
-      ~(meta : keeper_meta)
-      ~(args : Yojson.Safe.t)
-  =
-  let raw_cwd = Safe_ops.json_string ~default:"" "cwd" args |> String.trim in
-  let resolved =
-    if raw_cwd = ""
-    then Ok (keeper_default_read_root ~config ~meta)
-    else resolve_keeper_read_path ~config ~meta ~raw_path:raw_cwd
-  in
-  match resolved with
-  | Error _ as err -> err
-  | Ok cwd when Fs_compat.file_exists cwd && Sys.is_directory cwd -> Ok cwd
-  | Ok cwd ->
-    if not (Fs_compat.file_exists cwd) then begin
-      (* Auto-create missing CWD under the sandbox.  The path has already
-         passed [resolve_keeper_read_path] sandbox containment, so creating
-         it is safe.  This handles stale worktree references and first-run
-         repo directories that the LLM targets before clone. *)
-      ignore (Keeper_fs.ensure_dir cwd);
-      Ok cwd
-    end else
-      Error (Printf.sprintf "cwd_not_directory: %s (path_is_file_not_directory)" cwd)
-
 let normalize_repo_cwd_path path =
   Keeper_alerting_path.normalize_path_for_check path
   |> Keeper_alerting_path.strip_trailing_slashes
@@ -121,6 +96,40 @@ let validate_repo_path_ready
 
 let validate_repo_cwd_ready ~(config : Workspace.config) ~(meta : keeper_meta) cwd =
   validate_repo_path_ready ~config ~meta ~probe_path:cwd cwd
+
+let resolve_missing_cwd
+      ~(config : Workspace.config)
+      ~(meta : keeper_meta)
+      cwd
+  =
+  match repo_path_context ~config ~meta cwd with
+  | Some _ ->
+    (match validate_repo_cwd_ready ~config ~meta cwd with
+     | Ok () -> Ok cwd
+     | Error _ as err -> err)
+  | None ->
+    let _created_path = Keeper_fs.ensure_dir cwd in
+    Ok cwd
+
+let resolve_tool_read_cwd
+      ~(config : Workspace.config)
+      ~(meta : keeper_meta)
+      ~(args : Yojson.Safe.t)
+  =
+  let raw_cwd = Safe_ops.json_string ~default:"" "cwd" args |> String.trim in
+  let resolved =
+    if raw_cwd = ""
+    then Ok (keeper_default_read_root ~config ~meta)
+    else resolve_keeper_read_path ~config ~meta ~raw_path:raw_cwd
+  in
+  match resolved with
+  | Error _ as err -> err
+  | Ok cwd when Fs_compat.file_exists cwd && Sys.is_directory cwd -> Ok cwd
+  | Ok cwd ->
+    if not (Fs_compat.file_exists cwd) then
+      resolve_missing_cwd ~config ~meta cwd
+    else
+      Error (Printf.sprintf "cwd_not_directory: %s (path_is_file_not_directory)" cwd)
 
 let validate_repo_path_args_ready
       ~(config : Workspace.config)
@@ -234,12 +243,9 @@ let resolve_tool_write_cwd
      | Ok () -> Ok cwd
      | Error _ as err -> err)
   | Ok cwd ->
-    if not (Fs_compat.file_exists cwd) then begin
-      ignore (Keeper_fs.ensure_dir cwd);
-      match validate_repo_cwd_ready ~config ~meta cwd with
-      | Ok () -> Ok cwd
-      | Error _ as err -> err
-    end else
+    if not (Fs_compat.file_exists cwd) then
+      resolve_missing_cwd ~config ~meta cwd
+    else
       Error (Printf.sprintf "cwd_not_directory: %s (path_is_file_not_directory)" cwd)
 
 (* Docker playground path mapping: host → container.

--- a/test/test_agent_tool_execute_safety.ml
+++ b/test/test_agent_tool_execute_safety.ml
@@ -564,6 +564,42 @@ let test_tool_execute_rejects_stale_worktree_path_arg () =
     then Alcotest.failf "expected stale worktree root, got: %s" err
   | None -> Alcotest.fail ("expected error json, got: " ^ raw)
 
+let test_tool_execute_missing_worktree_cwd_does_not_create_directory () =
+  with_eio_fs @@ fun () ->
+  let base = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  let config = Workspace.default_config base in
+  let meta = make_local_meta "sangsu" in
+  let playground = Filename.concat base (playground_path_of meta.name) in
+  let repo_dir = Filename.concat playground "repos/masc-mcp" in
+  let missing_worktree = Filename.concat repo_dir ".worktrees/task-missing" in
+  ensure_dir repo_dir;
+  run_process_ok ~cwd:repo_dir "git" [ "init"; "-q"; "--initial-branch=main" ];
+  let raw =
+    Agent_tool_command_runtime.handle_tool_execute
+      ~turn_sandbox_factory:None
+      ~turn_sandbox_factory_git:None
+      ~exec_cache:None
+      ~config
+      ~meta
+      ~args:
+        (`Assoc
+           [ "executable", `String "ls"
+           ; "argv", `List []
+           ; "cwd", `String "repos/masc-mcp/.worktrees/task-missing"
+           ])
+      ()
+  in
+  match parse_error_field raw with
+  | Some err ->
+    Alcotest.(check bool) "sandbox_repo_not_ready"
+      true
+      (String_util.contains_substring err "sandbox_repo_not_ready");
+    Alcotest.(check bool) "missing worktree was not materialized"
+      false
+      (Sys.file_exists missing_worktree)
+  | None -> Alcotest.fail ("expected error json, got: " ^ raw)
+
 let test_tool_execute_elapsed_duration_preserves_positive_sub_ms () =
   let elapsed = Agent_tool_command_runtime.For_testing.elapsed_duration_ms in
   Alcotest.(check int) "sub-ms positive duration rounds up to 1" 1
@@ -1352,6 +1388,10 @@ let () =
             "stale worktree path arg rejects parent clone"
             `Quick
             test_tool_execute_rejects_stale_worktree_path_arg
+        ; Alcotest.test_case
+            "missing worktree cwd rejects without mkdir"
+            `Quick
+            test_tool_execute_missing_worktree_cwd_does_not_create_directory
         ] )
     ; ( "edge"
       , [ Alcotest.test_case


### PR DESCRIPTION
Summary
- stop missing repos/<repo>/.worktrees/<task> cwd values from being auto-created as plain directories
- route missing repo/worktree cwd through repo readiness validation so Execute returns sandbox_repo_not_ready instead of materializing a bad path
- add regression coverage that a missing worktree cwd is rejected without creating the directory

Validation
- git diff --check
- ocamlformat --check lib/keeper/agent_tool_execute_path.ml test/test_agent_tool_execute_safety.ml
- scripts/check-oas-pin.sh --local-only currently blocked by global opam switch pin contention: another concurrent worktree reverted agent_sdk from expected 10a5024e0b1d5b4bb9d272eccb5051dead5421c4 to eb9424fb0a6641c53dcdc0dfef4fd1d9b7af689b after this worktree pinned successfully
- scripts/dune-local.sh build test/test_agent_tool_execute_safety.exe attempted after clean, but local verification is not reliable under the same global opam switch contention; CI should validate in a clean pin state

Live evidence
- all live keeper repos/masc-mcp roots currently resolve to their own git toplevel
- stale plain directories remain under multiple repos/masc-mcp/.worktrees entries; this PR prevents Execute from creating more of that residue