### PR TITLE
[codex] Follow up tool access review comments

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -1376,8 +1376,8 @@ describe('fetchKeeperConfig', () => {
         missing_active_goal_ids: [],
       },
       tools: {
-        tool_access: ['keeper_fs_read'],
-        resolved_allowlist: 'keeper_fs_read',
+        tool_access: ['tool_read_file'],
+        resolved_allowlist: 'tool_read_file',
         tool_denylist: 'Execute',
         active_masc_tool_count: '1',
         active_keeper_tool_count: '2',

--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -134,8 +134,8 @@ function makeKeeperConfig(overrides: Partial<KeeperConfig> = {}): KeeperConfig {
       override_fields: ['goal', 'instructions'],
     },
     tools: {
-      tool_access: ['keeper_fs_read'],
-      resolved_allowlist: ['keeper_fs_read'],
+      tool_access: ['tool_read_file'],
+      resolved_allowlist: ['tool_read_file'],
       tool_denylist: ['Execute'],
       active_masc_tool_count: 1,
       active_keeper_tool_count: 2,

--- a/lib/keeper/keeper_metrics.mli
+++ b/lib/keeper/keeper_metrics.mli
@@ -168,6 +168,7 @@ type t =
   | TurnPhaseDuration
   | LifecycleTransitions
   | LifecycleCallbackFailures
+  | CompactionCallbackRecoveries
   | BriefingSessionLastEventSource
   | EventBusDrain
   | SupervisorCleanupFailures

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -241,19 +241,9 @@ include Prometheus_identity_metric_names
    agent_tool_execute_runtime.ml, keeper_sandbox_docker.ml,
    keeper_heartbeat_snapshot.ml, keeper_stay_silent_loop_detector.ml,
    keeper_unified_metrics.ml. *)
-(* #13xxx: keeper dispatch layer denied a tool call because the
-   tool is not in the keeper's allowlist (tool_access drift, deny-list,
-   or unknown tool name).  Distinct from [Keeper_metrics.(to_string ToolUseFailure)]
-   (post-execution hook failure) and
-   [Keeper_metrics.(to_string TurnGateRejectedTerminal)] (pre_tool_use guard
-   hard-reject).  Labels:
-   - [keeper] — keeper name (fleet-bounded)
-   - [tool]   — tool name attempted (registry-bounded, ~100 tools)
-   - [reason] — vocabulary:
-       "not_in_candidate_set" (unknown / not available to this tool_access list)
-       "denied_by_policy"     (explicit deny-list entry)
-       "not_in_allow_set"     (tool exists but tool_access omits it)
-   Cardinality: ~16 keepers × ~100 tools × 3 reasons = ~4800 series. *)
+(* OAS after-turn response metadata was accepted but omitted its response model
+   field. This is provider response-shape telemetry, not keeper policy
+   telemetry. *)
 let metric_after_turn_response_model_empty = "masc_after_turn_response_model_empty_total"
 let metric_after_turn_response_model_alias = "masc_after_turn_response_model_alias_total"
 let metric_pricing_catalog_miss = "masc_pricing_catalog_miss_total"

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -269,8 +269,8 @@ include module type of Prometheus_transport_metric_names
 
 (** #13xxx: counter incremented every time the keeper dispatch layer
     denies a tool call because the tool is not in the keeper's allowlist.
-    Surfaces tool_access drift (e.g. [board_core] group omitted from the
-    keeper's [tool_groups]) and deny-list collisions as a Prometheus
+    Surfaces tool_access drift (e.g. a required board tool omitted from the
+    keeper's [tool_access] list) and deny-list collisions as a Prometheus
     alert rather than requiring operators to grep
     [keepers/*.decisions.jsonl] after the fact.
     Labels:

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -267,21 +267,9 @@ include module type of Prometheus_transport_metric_names
     Labels: runtime, provider, source. *)
 (* Centralized metric constants for inline string replacement. *)
 
-(** #13xxx: counter incremented every time the keeper dispatch layer
-    denies a tool call because the tool is not in the keeper's allowlist.
-    Surfaces tool_access drift (e.g. a required board tool omitted from the
-    keeper's [tool_access] list) and deny-list collisions as a Prometheus
-    alert rather than requiring operators to grep
-    [keepers/*.decisions.jsonl] after the fact.
-    Labels:
-    - [keeper] — keeper name
-    - [tool]   — tool name attempted (bounded by tool registry, ~100)
-    - [reason] — [not_in_candidate_set | denied_by_policy |
-                  not_in_allow_set]
-    Operator alert: [rate(masc_keeper_tool_not_allowed_total[5m]) > 0]
-    on any [(keeper, tool)] pair means that keeper is looping without
-    making progress — its BDI is requesting a tool that its tool_access
-    does not permit. *)
+(** Counter incremented when an OAS after-turn response is accepted but
+    its response model field is empty. This tracks malformed or partial
+    provider response metadata, not keeper tool_access policy decisions. *)
 val metric_after_turn_response_model_empty : string
 
 val metric_after_turn_response_model_alias : string

--- a/lib/prometheus_builtin_metric_names.ml
+++ b/lib/prometheus_builtin_metric_names.ml
@@ -183,19 +183,9 @@ include Prometheus_identity_metric_names
    agent_tool_execute_runtime.ml, keeper_sandbox_docker.ml,
    keeper_heartbeat_snapshot.ml, keeper_stay_silent_loop_detector.ml,
    keeper_unified_metrics.ml. *)
-(* #13xxx: keeper dispatch layer denied a tool call because the
-   tool is not in the keeper's allowlist (tool_access drift, deny-list,
-   or unknown tool name).  Distinct from [Keeper_metrics.(to_string ToolUseFailure)]
-   (post-execution hook failure) and
-   [Keeper_metrics.(to_string TurnGateRejectedTerminal)] (pre_tool_use guard
-   hard-reject).  Labels:
-   - [keeper] — keeper name (fleet-bounded)
-   - [tool]   — tool name attempted (registry-bounded, ~100 tools)
-   - [reason] — vocabulary:
-       "not_in_candidate_set" (unknown / not available to this tool_access list)
-       "denied_by_policy"     (explicit deny-list entry)
-       "not_in_allow_set"     (tool exists but tool_access omits it)
-   Cardinality: ~16 keepers × ~100 tools × 3 reasons = ~4800 series. *)
+(* OAS after-turn response metadata was accepted but omitted its response model
+   field. This is provider response-shape telemetry, not keeper policy
+   telemetry. *)
 let metric_after_turn_response_model_empty = "masc_after_turn_response_model_empty_total"
 let metric_after_turn_response_model_alias = "masc_after_turn_response_model_alias_total"
 let metric_pricing_catalog_miss = "masc_pricing_catalog_miss_total"

--- a/lib/prometheus_builtin_metric_names.mli
+++ b/lib/prometheus_builtin_metric_names.mli
@@ -225,8 +225,8 @@ include module type of Prometheus_transport_metric_names
 
 (** #13xxx: counter incremented every time the keeper dispatch layer
     denies a tool call because the tool is not in the keeper's allowlist.
-    Surfaces tool_access drift (e.g. [board_core] group omitted from the
-    keeper's [tool_groups]) and deny-list collisions as a Prometheus
+    Surfaces tool_access drift (e.g. a required board tool omitted from the
+    keeper's [tool_access] list) and deny-list collisions as a Prometheus
     alert rather than requiring operators to grep
     [keepers/*.decisions.jsonl] after the fact.
     Labels:

--- a/lib/prometheus_builtin_metric_names.mli
+++ b/lib/prometheus_builtin_metric_names.mli
@@ -223,21 +223,9 @@ include module type of Prometheus_transport_metric_names
     Labels: runtime, provider, source. *)
 (* Centralized metric constants for inline string replacement. *)
 
-(** #13xxx: counter incremented every time the keeper dispatch layer
-    denies a tool call because the tool is not in the keeper's allowlist.
-    Surfaces tool_access drift (e.g. a required board tool omitted from the
-    keeper's [tool_access] list) and deny-list collisions as a Prometheus
-    alert rather than requiring operators to grep
-    [keepers/*.decisions.jsonl] after the fact.
-    Labels:
-    - [keeper] — keeper name
-    - [tool]   — tool name attempted (bounded by tool registry, ~100)
-    - [reason] — [not_in_candidate_set | denied_by_policy |
-                  not_in_allow_set]
-    Operator alert: [rate(masc_keeper_tool_not_allowed_total[5m]) > 0]
-    on any [(keeper, tool)] pair means that keeper is looping without
-    making progress — its BDI is requesting a tool that its tool_access
-    does not permit. *)
+(** Counter incremented when an OAS after-turn response is accepted but
+    its response model field is empty. This tracks malformed or partial
+    provider response metadata, not keeper tool_access policy decisions. *)
 val metric_after_turn_response_model_empty : string
 
 val metric_after_turn_response_model_alias : string

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -57,41 +57,6 @@ let ensure_test_runtime =
            if not (Atomic.get initialized) then initialize_once ()))
 ;;
 
-let write_text_file path content =
-  let oc = open_out path in
-  Fun.protect
-    ~finally:(fun () -> close_out_noerr oc)
-    (fun () -> output_string oc content)
-
-let runtime_toml =
-  {|
-[runtime]
-default = "test_provider.test_model"
-
-[providers.test_provider]
-display-name = "Test Provider"
-protocol = "provider_d-http"
-endpoint = "http://127.0.0.1:1"
-
-[models.test_model]
-api-name = "test-model"
-max-context = 8192
-tools-support = true
-streaming = true
-
-[test_provider.test_model]
-is-default = true
-max-concurrent = 1
-|}
-;;
-
-let init_runtime_default_for_tests () =
-  let path = Filename.temp_file "tool_task_runtime_" ".toml" in
-  write_text_file path runtime_toml;
-  match Runtime.init_default ~config_path:path with
-  | Ok () -> ()
-  | Error e -> Alcotest.failf "Runtime.init_default failed: %s" e
-
 let with_env name value_opt f =
   let original = Sys.getenv_opt name in
   let restore () =
@@ -2468,7 +2433,7 @@ let () = test "rfc_0034_v2_capacity_check_returns_some_at_limit" (fun () ->
        failwith "expected capacity_error at the per-goal limit"))
 
 let () =
-  init_runtime_default_for_tests ();
+  ensure_test_runtime ();
   Alcotest.run "Tool_task"
     [
       ( "coverage",


### PR DESCRIPTION
## Summary
- replace stale dashboard fixture tool names with canonical tool_read_file
- update tool_access drift metric docs to remove tool_groups wording
- reuse ensure_test_runtime in Tool_task tests and remove duplicated runtime TOML init
- expose CompactionCallbackRecoveries in Keeper_metrics.mli so main builds with the existing implementation constructor

## Verification
- pnpm typecheck
- pnpm exec vitest run --config vitest.config.ts src/api/dashboard.test.ts src/components/keeper-config-panel.test.ts --no-file-parallelism --maxWorkers=1
- scripts/check-oas-pin.sh --local-only
- MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_tool_task_coverage.exe