### PR TITLE
[codex] Support explicit cwd for keeper Read

### DIFF
--- a/lib/keeper/agent_tool_descriptor.ml
+++ b/lib/keeper/agent_tool_descriptor.ml
@@ -193,9 +193,16 @@ let read_file_schema =
     [ property
         "file_path"
         "string"
-        "Existing file path to read. Read has no implicit cwd and does not inherit \
-         Execute cwd; use an absolute path, a sandbox-relative path, or a path returned \
-         by Grep/Execute listing."
+        "Existing file path to read. Relative paths resolve against cwd when cwd is \
+         provided, otherwise against the keeper sandbox. Read does not inherit Execute \
+         cwd implicitly; pass cwd explicitly or use a sandbox-relative repos/<repo>/... \
+         path."
+    ; property
+        "cwd"
+        "string"
+        "Optional sandbox-relative directory to resolve file_path from, e.g. \
+         repos/masc-mcp. This is explicit only; Read never inherits the previous \
+         Execute cwd."
     ; property
         "limit"
         "integer"
@@ -439,8 +446,8 @@ let public_descriptors =
       ~public_name:"Read"
       ~internal_name:"tool_read_file"
       ~description:
-        "Read one existing file from the keeper sandbox or an allowed path. Read has no \
-         implicit cwd; list or search first when the exact path is unclear."
+        "Read one existing file from the keeper sandbox or an allowed path. Pass cwd \
+         explicitly for repo-relative reads; Read never inherits Execute cwd."
       ~input_schema:read_file_schema
       ~policy:
         (policy

--- a/lib/keeper/agent_tool_filesystem_runtime.ml
+++ b/lib/keeper/agent_tool_filesystem_runtime.ml
@@ -47,6 +47,119 @@ let read_file_default_max_bytes = Tool_shard_limits.read_file_default_max_bytes
 let read_file_min_max_bytes = 512
 let read_file_max_max_bytes = 200_000
 
+type read_file_resolution_error =
+  | Missing_file of
+      { target : string
+      ; error : string
+      }
+  | Read_path_error of string
+
+let string_opt_nonempty name json =
+  match Safe_ops.json_string_opt name json with
+  | None -> None
+  | Some raw ->
+    let trimmed = String.trim raw in
+    if trimmed = "" then None else Some trimmed
+;;
+
+let relative_path_has_segment_prefix prefix raw =
+  String.equal raw prefix || String.starts_with ~prefix:(prefix ^ "/") raw
+;;
+
+let sandbox_rooted_relative_path raw =
+  Filename.is_relative raw
+  && List.exists
+       (fun prefix -> relative_path_has_segment_prefix prefix raw)
+       [ "repos"; "mind"; Common.masc_dirname; "playground" ]
+;;
+
+let resolve_read_file_cwd ~(config : Workspace.config) ~(meta : keeper_meta) ~cwd =
+  match cwd with
+  | None -> Ok (keeper_default_read_root ~config ~meta)
+  | Some raw_cwd ->
+    (match resolve_keeper_read_path ~config ~meta ~raw_path:raw_cwd with
+     | Error e -> Error e
+     | Ok cwd when safe_is_dir cwd -> Ok cwd
+     | Ok cwd when safe_file_exists cwd ->
+       Error (Printf.sprintf "cwd_not_directory: %s (path_is_file_not_directory)" cwd)
+     | Ok cwd ->
+       Error
+         (Printf.sprintf
+            "cwd_not_directory: %s (directory does not exist; Read will not create cwd)"
+            cwd))
+;;
+
+let read_file_path_relative_to_project_root ~(config : Workspace.config) path =
+  match project_relative_host_path ~config path with
+  | Some relative -> relative
+  | None -> path
+;;
+
+let read_file_resolver_input ~(config : Workspace.config) ~cwd ~(raw_path : string) =
+  let raw_path = String.trim raw_path in
+  if
+    raw_path = ""
+    || (not (Filename.is_relative raw_path))
+    || sandbox_rooted_relative_path raw_path
+  then raw_path
+  else Filename.concat cwd raw_path |> read_file_path_relative_to_project_root ~config
+;;
+
+let resolve_read_file_target
+      ~(config : Workspace.config)
+      ~(meta : keeper_meta)
+      ~(args : Yojson.Safe.t)
+      ~(raw_path : string)
+  =
+  let cwd = string_opt_nonempty "cwd" args in
+  let raw_path = String.trim raw_path in
+  if raw_path = ""
+  then
+    Error
+      (Read_path_error
+         (Keeper_alerting_path.rejection_to_user_message Keeper_alerting_path.Path_required))
+  else match resolve_read_file_cwd ~config ~meta ~cwd with
+  | Error e -> Error (Read_path_error e)
+  | Ok cwd_abs ->
+    let resolver_input = read_file_resolver_input ~config ~cwd:cwd_abs ~raw_path in
+    let resolve_once candidate =
+      match playground_relative_unless_allowed_root ~config ~meta candidate with
+      | Error e -> Error (Read_path_error e)
+      | Ok normalized ->
+        (match
+           Keeper_alerting_path.resolve_keeper_read_path
+             ~config
+             ~allowed_paths:(keeper_effective_allowed_paths ~meta)
+             ~raw_path:normalized
+         with
+         | Ok target -> Ok target
+         | Error (Not_found_relative { raw }) ->
+           let root = Keeper_alerting_path.project_root_of_config config in
+           let target =
+             if Filename.is_relative normalized then Filename.concat root normalized else normalized
+           in
+           Error
+             (Missing_file
+                { target
+                ; error =
+                    Keeper_alerting_path.rejection_to_user_message
+                      (Not_found_relative { raw })
+                })
+         | Error rej ->
+           Error
+             (Read_path_error (Keeper_alerting_path.rejection_to_user_message rej)))
+    in
+    (match resolve_once resolver_input with
+     | Ok _ as ok -> ok
+     | Error original ->
+       (match Agent_tool_execute_path.auto_correct_path ~meta resolver_input with
+        | Some corrected ->
+          (match resolve_once corrected with
+           | Ok _ as ok -> ok
+           | Error _ -> Error original)
+        | None -> Error original))
+;;
+
 let handle_read_file
       ~(turn_sandbox_factory : Keeper_sandbox_factory.t option)
       ~(config : Workspace.config)
@@ -61,30 +174,19 @@ let handle_read_file
     |> fun n -> max read_file_min_max_bytes (min read_file_max_max_bytes n)
   in
   let fallback_dir = keeper_default_read_root ~config ~meta in
-  match playground_relative_unless_allowed_root ~config ~meta path with
-  | Error e -> error_json e
-  | Ok normalized ->
-    (match
-       Keeper_alerting_path.resolve_keeper_read_path
-         ~config
-         ~allowed_paths:(keeper_effective_allowed_paths ~meta)
-         ~raw_path:normalized
-     with
-     | Error (Not_found_relative { raw }) ->
-       (* Path within root but doesn't exist — use structured error with suggestions *)
-       let root = Keeper_alerting_path.project_root_of_config config in
-       let target =
-         if Filename.is_relative path then Filename.concat root path else path
-       in
-       missing_file_error_json
-         ~config
-         ~meta
-         ~target
-         ~fallback_dir
-         ~error:
-           (Keeper_alerting_path.rejection_to_user_message (Not_found_relative { raw }))
-     | Error rej -> error_json (Keeper_alerting_path.rejection_to_user_message rej)
-     | Ok target ->
+  let cwd = string_opt_nonempty "cwd" args in
+  match resolve_read_file_target ~config ~meta ~args ~raw_path:path with
+  | Error (Read_path_error e) -> error_json e
+  | Error (Missing_file { target; error }) ->
+    missing_file_error_json
+      ~cwd
+      ~raw_path:(Some path)
+      ~config
+      ~meta
+      ~target
+      ~fallback_dir
+      ~error
+  | Ok target ->
        (* RFC-0006 Phase B-1: Docker keepers are always contained to their
        playground bundle on the host before any read-side I/O proceeds.
        The resolver-level allowed_paths check is augmented by this
@@ -135,25 +237,32 @@ let handle_read_file
                        ; "content", `String body
                        ; "via", `String Keeper_sandbox_read_runner.backend_via
                        ]))
-             else (
-               match Safe_ops.read_file_safe target with
-               | Error e when String.starts_with ~prefix:file_not_found_prefix e ->
-                 missing_file_error_json ~config ~meta ~target ~fallback_dir ~error:e
-               | Error e -> error_json ~fields:[ "path", `String target ] e
-               | Ok content ->
-                 let total = String.length content in
+              else (
+                match Safe_ops.read_file_safe target with
+                | Error e when String.starts_with ~prefix:file_not_found_prefix e ->
+                 missing_file_error_json
+                   ~cwd
+                   ~raw_path:(Some path)
+                   ~config
+                   ~meta
+                   ~target
+                   ~fallback_dir
+                   ~error:e
+                | Error e -> error_json ~fields:[ "path", `String target ] e
+                | Ok content ->
+                  let total = String.length content in
                  let truncated = total > max_bytes in
                  let body =
                    if truncated then String.sub content 0 max_bytes else content
                  in
                  Yojson.Safe.to_string
                    (`Assoc
-                       [ "ok", `Bool true
-                       ; "path", `String target
-                       ; "bytes", `Int total
-                       ; "truncated", `Bool truncated
-                       ; "content", `String body
-                       ])))))
+                        [ "ok", `Bool true
+                        ; "path", `String target
+                        ; "bytes", `Int total
+                        ; "truncated", `Bool truncated
+                        ; "content", `String body
+                        ]))))
 ;;
 
 (* RFC-0006 Phase A.4: replace [old] with [new] in [text]. When

--- a/lib/keeper/agent_tool_shared_runtime.ml
+++ b/lib/keeper/agent_tool_shared_runtime.ml
@@ -115,6 +115,8 @@ let actionable_path_error
 let file_not_found_prefix = "File not found:"
 
 let missing_file_error_json
+      ~(raw_path : string option)
+      ~(cwd : string option)
       ~(config : Workspace.config)
       ~(meta : keeper_meta)
       ~(target : string)
@@ -134,17 +136,22 @@ let missing_file_error_json
         ; "error", `String error
         ; "path", `String target
         ; "your_playground", `String playground
+        ; "input_file_path", Json_util.string_opt_to_json raw_path
         ; ( "path_resolution"
           , `Assoc
               [ "implicit_cwd", `Bool false
+              ; "explicit_cwd_supported", `Bool true
+              ; "cwd", Json_util.string_opt_to_json cwd
               ; ( "basis"
                 , `String
-                    "Read resolves file_path against the keeper sandbox or explicit \
-                     allowed_paths; it does not inherit Execute cwd." )
+                    "Read resolves file_path against explicit cwd when cwd is provided; \
+                     otherwise it resolves against the keeper sandbox or explicit \
+                     allowed_paths. It does not inherit Execute cwd implicitly." )
               ; ( "next_action"
                 , `String
-                    "Use Grep or Execute ls to discover the exact file path, then pass \
-                     that path to Read." )
+                    "For repo-relative files, pass cwd=\"repos/<repo>\" with \
+                     file_path=\"lib/...\", or pass file_path=\"repos/<repo>/lib/...\". \
+                     Use Grep or Execute ls first when the exact path is unclear." )
               ] )
         ])
 ;;

--- a/lib/keeper/agent_tool_shared_runtime.mli
+++ b/lib/keeper/agent_tool_shared_runtime.mli
@@ -43,7 +43,9 @@ val file_not_found_prefix : string
     #10349: directory entries are intentionally excluded to prevent
     sandbox oracle leaks when keeper identity drifts. *)
 val missing_file_error_json
-  :  config:Workspace.config
+  :  raw_path:string option
+  -> cwd:string option
+  -> config:Workspace.config
   -> meta:Keeper_meta_contract.keeper_meta
   -> target:string
   -> fallback_dir:string

--- a/lib/keeper/keeper_runtime_contract.ml
+++ b/lib/keeper/keeper_runtime_contract.ml
@@ -230,13 +230,17 @@ let redact_backend_details = function
 let path_resolution_contract_json =
   `Assoc
     [ "read_implicit_cwd", `Bool false
+    ; "read_explicit_cwd_supported", `Bool true
     ; ( "read_basis"
       , `String
-          "Read file_path is absolute or relative to the keeper sandbox/allowed_paths; \
-           it does not inherit Execute cwd." )
+          "Read file_path resolves against explicit cwd when cwd is provided; otherwise \
+           it is relative to the keeper sandbox/allowed_paths. It does not inherit \
+           Execute cwd implicitly." )
     ; ( "discover_before_read"
       , `String
-          "When unsure, use Grep or Execute ls to discover concrete paths before Read."
+          "When unsure, use Grep or Execute ls to discover concrete paths before Read. \
+           For repo files, use cwd=\"repos/<repo>\" plus file_path=\"lib/...\", or use \
+           file_path=\"repos/<repo>/lib/...\"."
       )
     ]
 

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -173,6 +173,10 @@ let read_path meta path = Filename.concat (read_repo_dir meta) path
 
 let read_args meta path = `Assoc [ "file_path", `String (read_path meta path) ]
 
+let read_args_with_cwd ~cwd path =
+  `Assoc [ "file_path", `String path; "cwd", `String cwd ]
+;;
+
 let ensure_read_repo_dir config meta =
   let root = Keeper_alerting_path.project_root_of_config config in
   Fs_compat.mkdir_p (Filename.concat root (read_repo_dir meta))
@@ -770,6 +774,78 @@ let test_missing_file_error_redacts_directory_suggestions () =
             | `Null | `List [] -> true
             | _ -> false)
        | Ok _ -> fail "missing file should be surfaced as tool error")
+;;
+
+let test_read_file_resolves_relative_path_against_explicit_cwd () =
+  let meta =
+    match
+      Masc_test_deps.meta_of_json_fixture
+        (`Assoc
+            [ "name", `String "test-keeper-read-cwd"
+            ; "agent_name", `String "test-keeper-read-cwd"
+            ; "trace_id", `String "test-trace-read-cwd"
+            ; ( "tool_access"
+              , Keeper_meta_tool_access.tool_access_to_json
+                  (Keeper_meta_tool_access.default_tool_access_of_meta_json ()) )
+            ])
+    with
+    | Ok meta -> { meta with allowed_paths = [ "repos" ] }
+    | Error e -> failwith (Printf.sprintf "make_read_cwd_meta failed: %s" e)
+  in
+  let ctx_snapshot = make_test_ctx () in
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "test_keeper_tools_read_cwd_%d" (Random.int 100000))
+  in
+  (try Unix.mkdir dir 0o755 with
+   | Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  Fun.protect
+    ~finally:(fun () -> rm_rf dir)
+    (fun () ->
+       Eio_main.run
+       @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       let config = Workspace.default_config dir in
+       let read_dir =
+         Filename.concat (Keeper_alerting_path.project_root_of_config config)
+           (read_repo_dir meta)
+       in
+       Fs_compat.mkdir_p read_dir;
+       let existing = Filename.concat read_dir "known.txt" in
+       Out_channel.with_open_text existing (fun oc ->
+         Out_channel.output_string oc "known via cwd");
+       let tools = make_registered_tools ~config ~meta ~ctx_snapshot () in
+       let tool = find_read_tool tools in
+       let check_known_read ~case args =
+         match Tool.execute tool args with
+         | Ok { Agent_sdk.Types.content; _ } ->
+           let json = Yojson.Safe.from_string content in
+           let result = Yojson.Safe.Util.member "result" json in
+           check string
+             (case ^ " content")
+             "known via cwd"
+             (Yojson.Safe.Util.member "content" result |> Yojson.Safe.Util.to_string);
+           check string
+             (case ^ " resolved path")
+             existing
+             (Yojson.Safe.Util.member "path" result |> Yojson.Safe.Util.to_string)
+         | Error { Agent_sdk.Types.message; _ } ->
+           fail (case ^ " should succeed: " ^ message)
+       in
+       check_known_read ~case:"explicit cwd"
+         (read_args_with_cwd ~cwd:(read_repo_dir meta) "known.txt");
+       check_known_read
+         ~case:"sandbox-rooted file_path is not doubled under cwd"
+         (read_args_with_cwd ~cwd:(read_repo_dir meta) (read_path meta "known.txt"));
+       (match Tool.execute tool (read_args_with_cwd ~cwd:(read_repo_dir meta) "") with
+        | Error { Agent_sdk.Types.message; _ } ->
+          check string "empty file_path still rejected" "path_required" message
+        | Ok _ -> fail "empty file_path should be rejected");
+       (match Tool.execute tool (read_args_with_cwd ~cwd:(read_repo_dir meta) "   ") with
+        | Error { Agent_sdk.Types.message; _ } ->
+          check string "blank file_path still rejected" "path_required" message
+        | Ok _ -> fail "blank file_path should be rejected"))
 ;;
 
 let test_repeated_error_results_are_blocked () =
@@ -1841,6 +1917,10 @@ let () =
             "missing file error redacts suggestions"
             `Quick
             test_missing_file_error_redacts_directory_suggestions
+        ; test_case
+            "Read resolves file_path against explicit cwd"
+            `Quick
+            test_read_file_resolves_relative_path_against_explicit_cwd
         ; test_case
             "repeated errors are blocked"
             `Quick


### PR DESCRIPTION
## Summary

- add explicit `cwd` support to Keeper `Read`
- keep `Read` from implicitly inheriting `Execute` cwd
- include clearer missing-file path-resolution guidance
- add focused coverage for repo-relative reads and sandbox-rooted paths

## Root Cause

`Read` only accepted `file_path`, while `Execute` already had `cwd`. Agents that had just run commands in a repo could reasonably try repo-relative `Read` paths, but the runtime resolved those paths against the keeper sandbox/default path model instead.

## Validation

- `ocamlformat --check lib/keeper/agent_tool_descriptor.ml lib/keeper/agent_tool_shared_runtime.ml lib/keeper/agent_tool_shared_runtime.mli lib/keeper/agent_tool_filesystem_runtime.ml lib/keeper/keeper_runtime_contract.ml test/test_keeper_tools_oas.ml`
- `git diff --check origin/main..HEAD`
- `bash scripts/ci/check-determinism-contract.sh --base origin/main --head HEAD`

`scripts/check-oas-pin.sh --local-only` passed after `scripts/opam-pin-external-deps.sh --install`, but the shared local opam switch later moved `agent_sdk` back to `eb9424f...` while this branch expects `10a5024e...`.

`scripts/dune-local.sh build test/test_keeper_tools_oas.exe` was attempted but refused to start because unrelated bare Dune processes were already running outside `scripts/dune-local.sh`.
