### PR TITLE
[codex] Seed release evidence runtime config

### DIFF
--- a/scripts/release-evidence.sh
+++ b/scripts/release-evidence.sh
@@ -205,6 +205,25 @@ copy_install_smoke() {
   cp "$BINARY" "$installed_bin"
   chmod +x "$installed_bin"
   cp config/tool_policy.toml "$base_path/.masc/config/tool_policy.toml"
+  cat >"$base_path/.masc/config/keeper_runtime.toml" <<'EOF'
+[runtime]
+default = "release_evidence.smoke"
+
+[providers.release_evidence]
+display-name = "Release Evidence Smoke"
+protocol = "provider_d-http"
+endpoint = "http://127.0.0.1:9/v1"
+
+[models.smoke]
+api-name = "smoke"
+max-context = 32768
+tools-support = true
+streaming = true
+
+[release_evidence.smoke]
+is-default = true
+max-concurrent = 1
+EOF
 }
 
 capture_installed_version() {


### PR DESCRIPTION
## Summary
- seed an isolated minimal keeper_runtime.toml in scripts/release-evidence.sh
- keep the release-evidence smoke runtime self-contained so fresh base-path boot can initialize Runtime.default

## Why
main CI was failing in Generate main release evidence bundle because the smoke base path had tool_policy.toml but no keeper_runtime.toml, causing server boot to abort with: No runtime config path; cannot initialize default Runtime.

## Validation
- bash -n scripts/release-evidence.sh
- python3 TOML extraction check for the generated keeper_runtime.toml heredoc
- git diff --check origin/main...HEAD
- bash scripts/lint/tool-keeper-boundary-ratchet.sh --fail
- scoped rg keeper-owned tokens across generic tool surfaces: no matches

## Local caveat
- scripts/dune-local.sh build test/test_runtime_config_validity.exe was attempted but local opam/CMI drift still reports Agent_sdk inconsistent assumptions; GitHub CI is the authoritative build surface here.