### PR TITLE
[codex] Clarify Execute argv examples

### DIFF
--- a/lib/keeper/agent_tool_descriptor.ml
+++ b/lib/keeper/agent_tool_descriptor.ml
@@ -399,7 +399,10 @@ let public_descriptors =
       ~internal_name:"tool_execute"
       ~description:
         "Execute one typed command through deterministic execution gates. Provide \
-         executable/argv or pipeline; use cwd for repo-scoped git/gh commands."
+         executable plus argv arguments after the executable, or pipeline. Do not \
+         repeat executable as argv[0]. Examples: executable='git' argv=['status', \
+         '--short']; executable='grep' argv=['-rn', 'pattern', 'lib']. Use cwd for \
+         repo-scoped git/gh commands."
       ~input_schema:execute_schema
       ~policy:
         (policy

--- a/lib/tool_shard_types_schemas_execute.ml
+++ b/lib/tool_shard_types_schemas_execute.ml
@@ -24,8 +24,11 @@ let tool_execute_exec_stage_schema =
                 ; "items", `Assoc [ "type", `String "string" ]
                 ; ( "description"
                   , `String
-                      "Arguments passed verbatim to executable. Shell metacharacters \
-                       are data; use pipeline for multi-stage execution." )
+                      "Arguments after executable, passed verbatim. Do not repeat \
+                       executable as argv[0]. Example: executable='grep', argv=['-rn', \
+                       'pattern', 'lib']; not argv=['grep', ...]. Shell \
+                       metacharacters are data; use pipeline for multi-stage \
+                       execution." )
                 ] )
           ] )
     ; "required", `List [ `String "executable" ]
@@ -53,8 +56,10 @@ let tool_execute_argv_field =
       ; "items", `Assoc [ "type", `String "string" ]
       ; ( "description"
         , `String
-            "Typed argv form: arguments passed verbatim to executable. A literal '|' \
-             token is data, not a pipe." )
+            "Typed argv form: arguments after executable, passed verbatim. Do not \
+             repeat executable as argv[0]. Example: executable='git', argv=['status', \
+             '--short']; example: executable='grep', argv=['-rn', 'pattern', 'lib']. \
+             A literal '|' token is data, not a pipe." )
       ] )
 ;;
 

--- a/test/test_agent_tool_descriptor_registry_integrity.ml
+++ b/test/test_agent_tool_descriptor_registry_integrity.ml
@@ -179,6 +179,34 @@ let test_read_descriptor_spells_out_path_basis () =
     (string_contains ~sub:"does not inherit Execute cwd" file_path_description)
 ;;
 
+let test_execute_descriptor_spells_out_argv_basis () =
+  let descriptor = required_public_descriptor "Execute" in
+  let argv_description =
+    schema_property_description descriptor.input_schema "argv"
+    |> Option.value ~default:""
+  in
+  Alcotest.(check bool)
+    "Execute description says argv follows executable"
+    true
+    (string_contains ~sub:"argv arguments after the executable" descriptor.description);
+  Alcotest.(check bool)
+    "Execute description forbids duplicate argv0"
+    true
+    (string_contains ~sub:"Do not repeat executable as argv[0]" descriptor.description);
+  Alcotest.(check bool)
+    "Execute description includes git example"
+    true
+    (string_contains ~sub:"executable='git' argv=['status', '--short']" descriptor.description);
+  Alcotest.(check bool)
+    "Execute argv schema repeats argv0 warning"
+    true
+    (string_contains ~sub:"Do not repeat executable as argv[0]" argv_description);
+  Alcotest.(check bool)
+    "Execute argv schema includes grep example"
+    true
+    (string_contains ~sub:"executable='grep', argv=['-rn', 'pattern', 'lib']" argv_description)
+;;
+
 let test_masc_board_registry_has_descriptor_projection () =
   List.iter
     (fun (schema : Masc_domain.tool_schema) ->
@@ -481,6 +509,10 @@ let () =
             "Read path basis is explicit"
             `Quick
             test_read_descriptor_spells_out_path_basis
+        ; test_case
+            "Execute argv basis is explicit"
+            `Quick
+            test_execute_descriptor_spells_out_argv_basis
         ] )
     ; ( "masc-board"
       , [ test_case


### PR DESCRIPTION
## Summary
- Clarify the public Execute descriptor so `argv` means arguments after `executable`, not a POSIX-style vector containing argv[0].
- Add git/grep examples and explicitly warn not to repeat `executable` as `argv[0]`.
- Add a descriptor registry test that pins the Execute argv wording and examples.

## Why
A keeper recently called Execute with `executable="grep"` and `argv=["grep", ...]`, which caused grep to search for the literal word `grep` and report a usage-style error. The existing runtime treated duplicate executable tokens as caller errors, but the model-facing descriptor did not state the contract plainly enough.

## Validation
- `ocamlformat --check lib/tool_shard_types_schemas_execute.ml lib/keeper/agent_tool_descriptor.ml test/test_agent_tool_descriptor_registry_integrity.ml`
- `git diff --check origin/main...HEAD`

## Not run
- `scripts/dune-local.sh build test/test_agent_tool_descriptor_registry_integrity.exe` (blocked by existing bare Dune processes outside `scripts/dune-local.sh`; a later commit-hook full-build path also hit stale `Agent_sdk_base__Types` CMI assumptions unrelated to this descriptor-only change)