### PR TITLE
[codex] Fix keeper metrics callback recovery interface

### DIFF
--- a/lib/keeper/keeper_metrics.mli
+++ b/lib/keeper/keeper_metrics.mli
@@ -168,6 +168,7 @@ type t =
   | TurnPhaseDuration
   | LifecycleTransitions
   | LifecycleCallbackFailures
+  | CompactionCallbackRecoveries
   | BriefingSessionLastEventSource
   | EventBusDrain
   | SupervisorCleanupFailures


### PR DESCRIPTION
## Summary
- add the missing CompactionCallbackRecoveries constructor to keeper_metrics.mli
- restore the .ml/.mli interface match for keeper_context_runtime compile paths

## Verification
- git diff --check
- ocamlformat --check lib/keeper/keeper_metrics.mli
- scripts/check-oas-pin.sh --local-only
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build lib/.masc_mcp.objs/byte/masc_mcp__Keeper_context_runtime.cmo

Note: the normal commit hook was interrupted after unrelated shared local agent_sdk drift errors; the focused target above passed before the hook hit the drifted full-build path.