### PR TITLE
fix(keeper): expose CompactionCallbackRecoveries in keeper_metrics interface (main build green)

### DIFF
--- a/lib/keeper/keeper_metrics.mli
+++ b/lib/keeper/keeper_metrics.mli
@@ -168,6 +168,7 @@ type t =
   | TurnPhaseDuration
   | LifecycleTransitions
   | LifecycleCallbackFailures
+  | CompactionCallbackRecoveries
   | BriefingSessionLastEventSource
   | EventBusDrain
   | SupervisorCleanupFailures


### PR DESCRIPTION
## 목적

main의 `Build and Test`(whole-program 컴파일) 게이트가 깨져 있던 것을 복구합니다. `keeper_metrics.ml`(구현)과 `keeper_metrics.mli`(인터페이스)의 `type t` variant 집합이 어긋나 시그니처 불일치가 발생했습니다.

## 원인

PR #19712 (`337dfd745f`, "compaction/handoff callback hardening")가 다음을 추가했습니다:
- `keeper_metrics.ml`: `type t`에 `| CompactionCallbackRecoveries` + Prometheus 이름 매핑(`masc_keeper_compaction_callback_recoveries_total`)
- `keeper_context_runtime.ml`: 해당 카운터 증가(consumer)

그러나 `keeper_metrics.mli`에는 생성자를 노출하지 않아 인터페이스 `type t`가 구현과 불일치했습니다. 결과로 두 가지 컴파일 에러:
1. `The implementation lib/keeper/keeper_metrics.pp.ml does not match the interface ...: An extra constructor, CompactionCallbackRecoveries, is provided in the first declaration.`
2. consumer(`keeper_context_runtime.ml`)에서 `There is no constructor CompactionCallbackRecoveries within type t`

이 break는 #19712 이후 #19711·#19700·#19714·#19717 등 4개 이상 커밋이 그 위에 머지될 동안 방치되었습니다(`Build and Test`가 required merge gate가 아니라 silent하게 누적).

## 변경

`keeper_metrics.mli`의 `type t`에 `| CompactionCallbackRecoveries` 한 줄 추가(구현 순서와 동일하게 `LifecycleCallbackFailures`와 `BriefingSessionLastEventSource` 사이). companion `val` 시그니처 변경 불필요.

워크어라운드 아님: closed sum type에 생성자를 **노출**하는 정합성 복원입니다(분류기/텔레메트리/N-of-M/cap-cooldown 시그니처 해당 없음).

## 검증

- `.ml`/`.mli`의 `type t` 생성자 집합 set-equality: 223 = 223, diff 없음(인터페이스 enum 정합성의 결정론적 증명, opam switch 독립).
- 로컬 `dune build @check`에서 `keeper_metrics`/`CompactionCallbackRecoveries` 에러 0건(완전 해소 확인).
- 잔여 로컬 `@check` 에러는 전부 `Agent_sdk.Error.AgentExecutionIdleTimeout` Unbound뿐인데, 이는 로컬 opam switch가 OAS pin(`10a5024e`)보다 한 리비전 뒤(`eb9424fb`, 둘 다 version `0.200.7`라 version-keyed 캐시 미갱신)인 환경 아티팩트입니다. CI(per-branch isolated env, `10a5024e`)에서는 컴파일됩니다 — 근거: 그 생성자를 추가한 #19714가 머지되었고, 그 머지 커밋의 Build-and-Test 실패는 `keeper_metrics` 2건뿐(`AgentExecutionIdleTimeout` 에러 0건)이었습니다.

## 범위

이 PR은 `Build and Test`의 **컴파일 break**만 복구합니다. main의 다른 빨간 잡(`Lint`/`Health` 등)이 독립적으로 존재할 수 있으며 이 변경으로 해소되지 않습니다.

RFC-WAIVED: keeper_metrics 인터페이스 정합성 복원(credential/identity/operator/sandbox subsystem 해당 없음, 동작 변경 없음).
