### PR TITLE
fix(keeper): upgrade bare try/with to Cancel_safe.observe for FSM callbacks

### DIFF
--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -505,17 +505,20 @@ let resolve_entry ?base_path (entry : pending_approval) (decision : decision) =
    | None -> ());
   (match entry.on_resolution with
    | Some f ->
-     (try f decision with
-      | Eio.Cancel.Cancelled _ as e -> raise e
-      | exn ->
-        Prometheus.inc_counter
-          Keeper_metrics.(to_string ApprovalQueueFailures)
-          ~labels:[ "keeper", entry.keeper_name; "site", Keeper_approval_queue_failure_site.(to_label Resolution_callback) ]
-          ();
-        Log.Keeper.warn
-          "approval_queue: resolution callback failed id=%s err=%s"
-          entry.id
-          (Printexc.to_string exn))
+     Cancel_safe.observe
+       ~on_exn:(fun exn ->
+         Prometheus.inc_counter Keeper_metrics.(to_string LifecycleCallbackFailures)
+           ~labels:[ ("keeper", entry.keeper_name); ("callback", "on_resolution") ]
+           ();
+         Prometheus.inc_counter
+           Keeper_metrics.(to_string ApprovalQueueFailures)
+           ~labels:[ "keeper", entry.keeper_name; "site", Keeper_approval_queue_failure_site.(to_label Resolution_callback) ]
+           ();
+         Log.Keeper.warn
+           "approval_queue: resolution callback failed id=%s err=%s"
+           entry.id
+           (Printexc.to_string exn))
+       (fun () -> f decision)
    | None -> ());
   try
     Sse.broadcast
@@ -1053,17 +1056,20 @@ let expire_stale ~max_wait_s =
         | None -> ());
        match entry.on_resolution with
        | Some f ->
-         (try f (Agent_sdk.Hooks.Reject reason) with
-          | Eio.Cancel.Cancelled _ as e -> raise e
-          | exn ->
-            Prometheus.inc_counter
-              Keeper_metrics.(to_string ApprovalQueueFailures)
-              ~labels:[ "keeper", entry.keeper_name; "site", Keeper_approval_queue_failure_site.(to_label Expire_callback) ]
-              ();
-            Log.Keeper.warn
-              "approval_queue: expire callback failed id=%s err=%s"
-              id
-              (Printexc.to_string exn))
+         Cancel_safe.observe
+           ~on_exn:(fun exn ->
+             Prometheus.inc_counter Keeper_metrics.(to_string LifecycleCallbackFailures)
+               ~labels:[ ("keeper", entry.keeper_name); ("callback", "on_approval_expire") ]
+               ();
+             Prometheus.inc_counter
+               Keeper_metrics.(to_string ApprovalQueueFailures)
+               ~labels:[ "keeper", entry.keeper_name; "site", Keeper_approval_queue_failure_site.(to_label Expire_callback) ]
+               ();
+             Log.Keeper.warn
+               "approval_queue: expire callback failed id=%s err=%s"
+               id
+               (Printexc.to_string exn))
+           (fun () -> f (Agent_sdk.Hooks.Reject reason))
        | None -> ())
     stale
 ;;

--- a/lib/keeper/keeper_guards.ml
+++ b/lib/keeper/keeper_guards.ml
@@ -281,6 +281,12 @@ let notify_gate_decision on_gate_decision (event : gate_decision_event) =
      propagates without per-site discipline drift. *)
   Cancel_safe.observe
     ~on_exn:(fun exn ->
+      (* Keep existing GuardsFailures metric for backward compatibility
+         (test_keeper_guards.ml asserts this counter). *)
+      Prometheus.inc_counter
+        Keeper_metrics.(to_string GuardsFailures)
+        ~labels:[("keeper", event.keeper_name); ("site", "gate_observer")]
+        ();
       Prometheus.inc_counter
         Keeper_metrics.(to_string LifecycleCallbackFailures)
         ~labels:[("keeper", event.keeper_name); ("callback", "on_gate_decision")]

--- a/lib/keeper/keeper_guards.ml
+++ b/lib/keeper/keeper_guards.ml
@@ -277,17 +277,18 @@ type gate_decision_event = {
 let ignore_gate_decision (_ : gate_decision_event) = ()
 
 let notify_gate_decision on_gate_decision (event : gate_decision_event) =
-  try on_gate_decision event
-  with
-  | Eio.Cancel.Cancelled _ as e -> raise e
-  | exn ->
+  (* RFC-0106 P0 canary: use Cancel_safe.observe so Cancelled
+     propagates without per-site discipline drift. *)
+  Cancel_safe.observe
+    ~on_exn:(fun exn ->
       Prometheus.inc_counter
-        Keeper_metrics.(to_string GuardsFailures)
-        ~labels:[("keeper", event.keeper_name); ("site", "gate_observer")]
+        Keeper_metrics.(to_string LifecycleCallbackFailures)
+        ~labels:[("keeper", event.keeper_name); ("callback", "on_gate_decision")]
         ();
       Log.Keeper.warn
         "keeper_guards: gate observer failed keeper=%s stage=%s tool=%s err=%s"
-        event.keeper_name event.stage event.tool_name (Printexc.to_string exn)
+        event.keeper_name event.stage event.tool_name (Printexc.to_string exn))
+    (fun () -> on_gate_decision event)
 
 (** Emit a [masc:keeper_gate] Event_bus Custom event.
 


### PR DESCRIPTION
## Summary

Upgrade remaining bare `try/with` blocks wrapping FSM-critical callbacks to `Cancel_safe.observe` + `LifecycleCallbackFailures` counter, completing the fleet-wide callback hardening.

## Changes

### keeper_guards.ml: `on_gate_decision`
Replace bare `try/with` with `Cancel_safe.observe`. Add `LifecycleCallbackFailures` counter with `callback=on_gate_decision` label.

### keeper_approval_queue.ml: 2 sites
- **resolve_entry** (`on_resolution`): bare `try/with` → `Cancel_safe.observe` + counter `callback=on_resolution`
- **expire_stale** (`on_approval_expire`): bare `try/with` → `Cancel_safe.observe` + counter `callback=on_approval_expire`

Existing `ApprovalQueueFailures` counters and warn logs preserved at both sites.

### Audit results (no change needed)
- `keeper_turn.ml`: callbacks handled by callees (`keeper_post_turn.ml`, `keeper_rollover.ml`) — already safe
- `keeper_turn_runtime_budget.ml`: synchronous dispatch, no yield risk
- `keeper_context_runtime.ml`: dispatches already in `dispatch_keeper_phase_event` which logs errors
- `keeper_supervisor.ml`: supervisor-level, crash visibility is appropriate

## Verification
- `dune build lib/keeper/keeper_guards.ml --root .` EXIT=0
- `dune build lib/keeper/keeper_approval_queue.ml --root .` EXIT=0

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
