### PR TITLE
Hard-purge tool access preset/kind residue

### DIFF
--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -884,7 +884,7 @@ materialize될 수 있지만, 정식 edit surface는 `profile.json`과 `keeper.t
 - **Canonical minimal**: `[keeper]` 테이블에 `persona_name`만. 나머지는 persona 기본값에서 해석.
 - **Overlay fields**: `goal`, `tool_access`, `runtime_id`, `sandbox_profile`, `network_mode`, `repo_cli_identity`, `git_identity_mode`, `active_goal_ids` 등 배치별 override 전용.
 - **Allowed value sets**: `tool_access`는 tool name string 배열, `sandbox_profile ∈ {local, docker}`, `network_mode ∈ {none, inherit}`, `git_identity_mode ∈ {keeper_alias, repo_cli_identity}`, `social_model ∈ {bdi_speech_v1, magentic_ledger_v1}`, `runtime_id`는 `keeper_runtime.toml`에 `<name>_models` 키로 존재해야 함.
-- **Removed / hard-rejected**: `models`, `allowed_models`, `active_model`, `presence_keepalive*`, `trigger_mode`, `initiative_*`, `policy_mode`, `policy_shell_mode`, `tool_preset`, `tool_also_allow`, `tool_custom_allowlist`, `also_allow`. 로드 시 에러로 실패한다.
+- **Removed / hard-rejected**: `models`, `allowed_models`, `active_model`, `presence_keepalive*`, `trigger_mode`, `initiative_*`, `policy_mode`, `policy_shell_mode`. 로드 시 에러로 실패한다.
 - **Unknown keys**: canonical/removed 둘 다 아닌 key는 **boot 시 warning** 후 무시된다 (`keeper TOML <path> has unknown keys: ...`). 과거에 `legacy_scope`/`scope_kind` 같은 dead config가 축적된 적이 있으므로 warning을 발견하면 정리한다.
 
 Definitive source는 코드의 `canonical_keeper_toml_key_names` (`lib/keeper/keeper_types_profile.ml`)와 `removed_keeper_input_key_names` (`lib/keeper/keeper_config.ml`)다.

--- a/docs/NORTH-STAR-OCAML.md
+++ b/docs/NORTH-STAR-OCAML.md
@@ -383,10 +383,11 @@ type keeper_stats = {
 
 ```ocaml
 (* Before — config array that never mutates *)
-let tool_presets = [| "minimal"; "social"; "messaging"; "research"; "delivery"; "full" |]
+let tool_access_profiles = [| "read"; "write"; "execute" |]
 
 (* After — OCaml 5.4 *)
-let tool_presets : string Iarray.t = Iarray.of_array [| "minimal"; "social"; "messaging"; "research"; "delivery"; "full" |]
+let tool_access_profiles : string Iarray.t =
+  Iarray.of_array [| "read"; "write"; "execute" |]
 ```
 
-적용: config 상수, tool preset, priority level 등 초기화 후 변경 없는 배열. `Array.copy` 방어 코드 제거 가능.
+적용: config 상수, priority level 등 초기화 후 변경 없는 배열. `Array.copy` 방어 코드 제거 가능.

--- a/docs/rfc/RFC-0074-sandbox-credential-auto-provision.md
+++ b/docs/rfc/RFC-0074-sandbox-credential-auto-provision.md
@@ -21,10 +21,10 @@ RFC-0073 이 *gap 을 진단*한다면 이 RFC 는 *gap 을 닫는다*.
 
 ## 2. Problem
 
-- preset (coding/research/social/...) 은 *어떤 자원이 필요한지* 를 implicit 하게만 안다 (`preset_allowlist` 의 tool 목록).
+- keeper `tool_access` 는 *어떤 자원이 필요한지* 를 명시하지만 sandbox/credential 부착까지 직접 표현하지 않는다.
 - sandbox/credential 부착은 caller 측 책임 — `register_keeper` 호출자가 각자 ad-hoc 으로 결정.
-- 결과: dashboard 상 "허용 54" 와 실제 호출 가능한 도구 사이 항구적 gap.
-- credential 부착은 *security surface* — 모든 keeper 에 자동 주입은 부적절. preset-aware 가 필요.
+- 결과: dashboard 상 허용 도구와 실제 호출 가능한 도구 사이 항구적 gap.
+- credential 부착은 *security surface* — 모든 keeper 에 자동 주입은 부적절하다.
 
 AGENT-LLM-A.md §워크어라운드 거부 기준 시그니처 #3 (N-of-M abstraction admission) 의 회피 대상.
 

--- a/docs/rfc/RFC-0191-descriptor-policy-ssot.md
+++ b/docs/rfc/RFC-0191-descriptor-policy-ssot.md
@@ -40,14 +40,14 @@ Yet `lib/keeper/keeper_tool_policy.ml` is **670 LoC, 63 definitions**, and the o
 | Writable path prefix list | `keeper_writable_prefixes` (3 entries, hardcoded) | none — should be derived per descriptor (`cwd_scope` + tool-specific) |
 | Path normalization | `normalize_path`, `is_masc_write_allowed` | none |
 | Denied-set | `keeper_denied_set` Hashtbl | `visibility = Keeper_denied` |
-| Tool preset enum | `Minimal/Social/Messaging/Dispatch/Research/Delivery/Full` (7) + `preset_allows_privileged_operations`, `allows_workflow_for_preset`, `allows_shell_write_for_preset` | none — preset is an agent attribute, but the *per-tool* preset gate is missing as a descriptor field |
+| Tool-access tier rules | hand-maintained per-agent access checks | should be expressed as descriptor policy + `tool_access` grants |
 | Per-tool inline safety | `keeper_safe_inline_tools` list (handmade) | descriptor `executor = In_process` already captures it |
 | Maintenance gates | `keeper_maintenance_only_tools` list | none — should be `approval = Human_required` + new `audience` field |
 | Last-turn safety | `last_turn_safe_tool_names` list | none — should be a derived property (`readonly_hint = Some true` + `effect_domain = None`) |
-| Allowlist by preset | `preset_allowlist` | should be a descriptor-driven projection |
+| Allowlist by tool access | tool-access keyed lists | should be a descriptor-driven projection |
 | Universe filter | `tool_access_lookup_of_meta`, `filter_by_universe`, `filter_by_access` | should be a descriptor capability check |
 
-Net result: two SSOTs, the smaller (`policy` record) defines structure, the larger (`keeper_tool_policy.ml`) defines truth. Any preset change requires editing the larger one, and the descriptor never gets consulted.
+Net result: two SSOTs, the smaller (`policy` record) defines structure, the larger (`keeper_tool_policy.ml`) defines truth. Any access-rule change requires editing the larger one, and the descriptor never gets consulted.
 
 ## 1. Why this is dangerous
 
@@ -87,8 +87,8 @@ type policy =
   ; credential_profile   : string option
   ; (* NEW *)
     audience             : audience_class
-    (* Minimum agent preset required to be granted this tool. *)
-  ; minimum_preset       : tool_preset
+    (* Tool-access grant required to expose this tool. *)
+  ; required_tool_access : string option
     (* Whether this tool may execute on the final turn before turn cap.
        Currently a hand-curated list; will be derived from
        (readonly_hint = Some true && effect_domain = None). *)
@@ -107,7 +107,7 @@ and audience_class =
   | Audience_admin_only
 ```
 
-`audience_class` and `minimum_preset` are *new* descriptor fields, not derived. The other three (`last_turn_safe`, `inline_safe`, `maintenance_only`) are bridges: introduced as explicit fields in P1, then narrowed in P3 to be *derived* from other fields where possible.
+`audience_class` and `required_tool_access` are *new* descriptor fields, not derived. The other three (`last_turn_safe`, `inline_safe`, `maintenance_only`) are bridges: introduced as explicit fields in P1, then narrowed in P3 to be *derived* from other fields where possible.
 
 ## 5. Implementation phases
 
@@ -116,8 +116,8 @@ and audience_class =
 | **P1** | Extend `policy` record with 4 new fields. Every existing descriptor literal gets explicit values matching current `keeper_tool_policy.ml` decisions. No callers migrate yet. | Build green. `Agent_tool_descriptor.all_descriptors ()` answers every per-tool policy question. Cross-check test: for each descriptor, assert agreement with `keeper_tool_policy.<predicate>`. Cross-check pass is the migration safety gate. |
 | **P2** | Migrate `is_keeper_denied`, `is_keeper_safe_inline_tool`, `is_keeper_maintenance_only_tool` to descriptor-driven projections. Drop the corresponding string lists/Hashtbls. | `keeper_tool_policy.ml` LoC down by ~60. Test from P1 still passes (no semantic change). |
 | **P3** | Migrate `last_turn_safe_tool_names` to a derivation rule (`readonly_hint = Some true && effect_domain = None`). Drop the hand list. Audit any descriptor whose old-vs-new disagrees — the disagreement *is* the latent bug, fix by descriptor edit. | Last hand list of per-tool policy classification removed. |
-| **P4** | Migrate `preset_allowlist` to read `descriptor.policy.minimum_preset`. Drop preset-keyed string list construction. | `tool_access_lookup_of_meta` becomes a descriptor filter. |
-| **P5** | Drop everything in `keeper_tool_policy.ml` that has no agent-level role. Target: < 250 LoC, only `tool_preset` enum + agent-side state + path normalization + descriptor projections. | LoC reduction ~420. |
+| **P4** | Migrate tool-access allowlists to descriptor policy data. Drop preset-keyed string list construction. | `tool_access_lookup_of_meta` becomes a descriptor filter. |
+| **P5** | Drop everything in `keeper_tool_policy.ml` that has no agent-level role. Target: < 250 LoC, only agent-side state + path normalization + descriptor projections. | LoC reduction ~420. |
 | **P6** (follow-up RFC) | Re-evaluate whether `Keeper_tool_policy_config` (TOML loader) can be regenerated from descriptors instead of edited by operators. Likely no — operators tune presets, not per-tool policy. | Out of scope. |
 
 P1's cross-check test is the central safety device. The test compares every descriptor's projected predicate against the existing `keeper_tool_policy` answer; **the migration is only permitted to advance if all descriptors agree**. Disagreements found in P1 are P1's job to resolve (by descriptor edit, never by changing the predicate to be more permissive).
@@ -134,8 +134,7 @@ This RFC does *not* trigger workaround signatures:
 
 1. **`audience_class` enum granularity.** Today the de facto audience is binary (operator-facing on `public_mcp_surface_tools` vs. keeper-facing on `keeper_internal_tools`), but `Tool_catalog_surfaces.keeper_internal_replacement` already encodes a 1:1 mapping for tools with both surfaces. Audience may want a fifth variant `Audience_both_with_distinct_handler` — open for discussion in P1.
 2. **Maintenance gate consolidation.** `maintenance_only` overlaps `approval = Human_required`. The distinction today: maintenance can be operator-bypassed for a single tool call, approval is a per-call queue event. Keep both fields in P1; reconsider in P5.
-3. **Preset bypass for `tool_preset = Full`.** `Full` preset agents currently skip all preset checks. Keep this behavior — encode as `minimum_preset` defaulting to `Minimal` and a single bypass at the preset evaluator, not as descriptor-level fields.
-4. **`Keeper_tool_policy_config` TOML.** Operators edit it. If a descriptor's static `minimum_preset = Dispatch` is overridden by TOML to `Research`, the TOML wins (operator > source). Document precedence in P4.
+3. **Tool-access override precedence.** Operators edit `Keeper_tool_policy_config` TOML. If descriptor policy and TOML disagree, the TOML wins (operator > source). Document precedence in P4.
 
 ## 8. Rejected alternatives
 
@@ -149,5 +148,5 @@ This RFC does *not* trigger workaround signatures:
 - P1's cross-check test exists and passes on every descriptor for every migrated predicate.
 - P2–P5 PRs all merged.
 - `keeper_tool_policy.ml` is < 250 LoC.
-- `is_keeper_denied`, `is_keeper_safe_inline_tool`, `is_keeper_maintenance_only_tool`, `last_turn_safe_tool_names`, `preset_allowlist` all read from `Agent_tool_descriptor.{public,internal}_descriptors`.
-- No string list of tool names remains in `keeper_tool_policy.ml` outside of preset enum semantics.
+- `is_keeper_denied`, `is_keeper_safe_inline_tool`, `is_keeper_maintenance_only_tool`, `last_turn_safe_tool_names`, and tool-access projections all read from `Agent_tool_descriptor.{public,internal}_descriptors`.
+- No string list of tool names remains in `keeper_tool_policy.ml` outside descriptor projections.

--- a/docs/rfc/withdrawn/RFC-0030-masc-create-cli.md
+++ b/docs/rfc/withdrawn/RFC-0030-masc-create-cli.md
@@ -183,7 +183,7 @@ runs:
 
 - TOML parse (delegate to existing `keeper_meta_json_parse` /
   `runtime_toml_materializer`).
-- Cross-reference checks (persona's tool preset exists; runtime's
+- Cross-reference checks (persona's tool access exists; runtime's
   fallback profile exists; keeper's persona exists).
 - Capability checks (persona's `git_identity_mode` is one of the two
   enum variants; tier exists in runtime).

--- a/docs/spec/06-command-plane.md
+++ b/docs/spec/06-command-plane.md
@@ -76,7 +76,7 @@ Cp_types -> Cp_paths -> Cp_serde -> Cp_io
 type policy_envelope = {
   policy_class : string;       (* strategic | tactical | execution | worker *)
   approval_class : string;     (* strict | guarded *)
-  tool_allowlist : string list;
+  tool_access : string list;
   model_allowlist : string list;
   requires_human_for : string list;
   autonomy_level : string;     (* L2..L5 *)

--- a/lib/keeper/agent_tool_persona_runtime.ml
+++ b/lib/keeper/agent_tool_persona_runtime.ml
@@ -405,8 +405,7 @@ let resolved_keeper_args_from_persona args :
             in
             let autoboot_enabled = get_bool_opt args "autoboot_enabled" in
             (match
-               Keeper_turn_up_args.parse_tool_access_input
-                 ~tool_name:"masc_keeper_create_from_persona" args,
+               Keeper_turn_up_args.parse_tool_access_input args,
                Keeper_turn_up_args.parse_present_string_list_opt args "allowed_paths"
              with
             | Error err, _ | _, Error err -> Error err

--- a/lib/keeper/agent_tool_persona_runtime.ml
+++ b/lib/keeper/agent_tool_persona_runtime.ml
@@ -84,7 +84,7 @@ let resolved_keeper_args_to_json
     let tool_access =
       match tool_access_opt with
       | Some tool_access -> tool_access
-      | None -> default_tool_access_of_meta_json ()
+      | None -> []
     in
     [("tool_access", tool_access_to_json tool_access)]
   in

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -135,23 +135,20 @@ let resolve_tool_name_list ~preferred ~fallback =
   |> Option.value ~default:[]
   |> normalize_tool_name_list
 
-let parse_tool_access_input ?(tool_name = "keeper input") (args : Yojson.Safe.t) :
+let parse_tool_access_input (args : Yojson.Safe.t) :
     (string list option, string) result =
-  match reject_removed_keeper_input_keys ~tool_name args with
-  | Error msg -> Error msg
-  | Ok () -> (
-      match Json_util.assoc_member_opt "tool_access" args with
-      | Some (`List _ as access_json) -> (
-          match tool_access_of_meta_json (`Assoc [ ("tool_access", access_json) ]) with
-          | Ok access -> Ok (Some access)
-          | Error msg -> Error msg)
-      | Some `Null -> Ok None
-      | Some other ->
-          Error
-            (Printf.sprintf
-               "tool_access must be an array of strings (received %s)"
-               (Json_util.kind_name other))
-      | None -> Ok None)
+  match Json_util.assoc_member_opt "tool_access" args with
+  | Some (`List _ as access_json) -> (
+      match tool_access_of_meta_json (`Assoc [ ("tool_access", access_json) ]) with
+      | Ok access -> Ok (Some access)
+      | Error msg -> Error msg)
+  | Some `Null -> Ok None
+  | Some other ->
+      Error
+        (Printf.sprintf
+           "tool_access must be an array of strings (received %s)"
+           (Json_util.kind_name other))
+  | None -> Ok None
 
 let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) result =
   let name = get_string args "name" "" in
@@ -167,9 +164,7 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) 
     let compaction_profile_opt_res =
       parse_compaction_profile_opt args "compaction_profile"
     in
-    let tool_access_input_res =
-      parse_tool_access_input ~tool_name:"masc_keeper_up" args
-    in
+    let tool_access_input_res = parse_tool_access_input args in
     let allowed_paths_opt_res = parse_present_string_list_opt args "allowed_paths" in
     let active_goal_ids_opt_res = parse_present_string_list_opt args "active_goal_ids" in
     let sandbox_profile_opt_res =

--- a/lib/keeper/keeper_turn_up_args.mli
+++ b/lib/keeper/keeper_turn_up_args.mli
@@ -78,10 +78,8 @@ val parse_enum_string_opt :
 val resolve_tool_name_list :
   preferred:string list option -> fallback:string list option -> string list
 
-(** Parse the canonical [tool_access] field.
-    Removed top-level tool-policy args are rejected. *)
+(** Parse the canonical [tool_access] field. *)
 val parse_tool_access_input :
-  ?tool_name:string ->
   Yojson.Safe.t ->
   (string list option, string) result
 

--- a/test/test_keeper_masc_bridge.ml
+++ b/test/test_keeper_masc_bridge.ml
@@ -72,6 +72,8 @@ let read_text_file path =
     ~finally:(fun () -> close_in_noerr ic)
     (fun () -> Stdlib.really_input_string ic (in_channel_length ic))
 
+let contains_substring = String_util.contains_substring
+
 let process_exit_code = function
   | Unix.WEXITED code -> code
   | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> 255
@@ -383,7 +385,7 @@ let test_dashboard_tool_count_uses_schema_ssot () =
       in
       Alcotest.(check int) "dashboard counts schema-derived masc tools" 1 count)
 
-let test_tool_access_missing_defaults_empty_allowlist () =
+let test_tool_access_missing_defaults_standard_policy () =
   let names =
     allowed_names_of_json
       (`Assoc
@@ -393,30 +395,29 @@ let test_tool_access_missing_defaults_empty_allowlist () =
           ("trace_id", `String "legacy-standard-trace");
         ])
   in
-  Alcotest.(check (list string)) "missing allowlist is empty" [] names
+  Alcotest.(check bool) "missing allowlist uses default keeper surface" true
+    (List.mem "keeper_time_now" names)
 
-let test_typed_and_string_tool_access_defaults_match () =
+let test_typed_and_string_tool_access_rejections_match () =
   let module Access = Masc_mcp.Keeper_meta_contract in
-  let check_default label json =
-    let string_default =
+  let check_rejection label json =
+    let string_error =
       match Access.tool_access_of_meta_json json with
-      | Ok tools -> tools
-      | Error e -> Alcotest.failf "string parser failed for %s: %s" label e
+      | Ok _ -> Alcotest.failf "string parser accepted %s" label
+      | Error e -> e
     in
-    let typed_default =
+    let typed_error =
       match Access.tool_access_of_meta_json_typed json with
-      | Ok tools -> Access.tool_access_to_string_list tools
-      | Error e -> Alcotest.failf "typed parser failed for %s: %s" label e
+      | Ok _ -> Alcotest.failf "typed parser accepted %s" label
+      | Error e -> e
     in
-    Alcotest.(check (list string))
-      (label ^ " typed/string defaults")
-      string_default
-      typed_default
+    Alcotest.(check string) (label ^ " typed/string rejection") string_error
+      typed_error
   in
-  check_default "missing" (`Assoc []);
-  check_default "null" (`Assoc [ "tool_access", `Null ])
+  check_rejection "missing" (`Assoc []);
+  check_rejection "null" (`Assoc [ "tool_access", `Null ])
 
-let test_read_meta_file_defaults_missing_tool_access_without_rewrite () =
+let test_read_meta_file_rejects_missing_tool_access () =
   let dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir dir)
@@ -433,14 +434,46 @@ let test_read_meta_file_defaults_missing_tool_access_without_rewrite () =
             ("network_mode", `String "inherit");
           ]);
       match Masc_mcp.Keeper_meta_store.read_meta_file_path path with
-      | Error e -> Alcotest.fail e
-      | Ok None -> Alcotest.fail "expected keeper meta"
-      | Ok (Some meta) ->
-          let names = KET.keeper_allowed_tool_names meta in
-          Alcotest.(check (list string)) "missing allowlist is empty" [] names;
-          let persisted = read_json_file path in
-          Alcotest.(check bool) "missing tool_access not rewritten" true
-            (Yojson.Safe.Util.member "tool_access" persisted = `Null))
+      | Ok _ -> Alcotest.fail "expected missing tool_access rejection"
+      | Error e ->
+          Alcotest.(check bool) "mentions tool_access" true
+            (contains_substring e "tool_access must be an array"))
+
+let test_read_meta_file_rejects_tool_access_object () =
+  let dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      let path = Filename.concat dir "object-tool-access.json" in
+      write_json_file path
+        (`Assoc
+          [
+            ("name", `String "object-tool-access");
+            ("agent_name", `String "object-tool-access");
+            ("trace_id", `String "object-tool-access-trace");
+            ("tool_access", `Assoc [ ("value", `String "full") ]);
+          ]);
+      match Masc_mcp.Keeper_meta_store.read_meta_file_path path with
+      | Ok _ -> Alcotest.fail "expected tool_access object rejection"
+      | Error e ->
+          Alcotest.(check bool) "mentions array" true
+            (contains_substring e "tool_access must be an array"))
+
+let test_tool_access_object_empty_value_rejected () =
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+         [
+           ("name", `String "object-json");
+           ("agent_name", `String "object-json");
+           ("trace_id", `String "object-json-trace");
+           ("tool_access", `Assoc [ ("value", `List []) ]);
+         ])
+  with
+  | Ok _ -> Alcotest.fail "expected object tool_access rejection"
+  | Error e ->
+      Alcotest.(check bool) "mentions array" true
+        (contains_substring e "tool_access must be an array")
 
 let test_tool_access_array_empty_json_preserved () =
   let meta =
@@ -475,6 +508,36 @@ let test_tool_access_non_array_rejected () =
         "non-array tool_access rejected"
         "meta parse error: keeper tool_access must be an array of strings (received string)"
         e
+
+let test_tool_access_object_array_value_rejected () =
+  match Masc_test_deps.meta_of_json_fixture
+    (`Assoc
+      [
+        ("name", `String "object-tools");
+        ("agent_name", `String "object-tools");
+        ("trace_id", `String "object-tools-trace");
+        ("tool_access", `Assoc [ ("value", `List [ `String "masc_status" ]) ]);
+      ])
+  with
+  | Ok _ -> Alcotest.fail "expected object tool_access rejection"
+  | Error e ->
+      Alcotest.(check bool) "mentions array" true
+        (contains_substring e "tool_access must be an array")
+
+let test_tool_access_object_scalar_value_rejected () =
+  match Masc_test_deps.meta_of_json_fixture
+    (`Assoc
+      [
+        ("name", `String "object-no-array");
+        ("agent_name", `String "object-no-array");
+        ("trace_id", `String "object-no-array-trace");
+        ("tool_access", `Assoc [ ("value", `String "full") ]);
+      ])
+  with
+  | Ok _ -> Alcotest.fail "expected object tool_access rejection"
+  | Error e ->
+      Alcotest.(check bool) "mentions array" true
+        (contains_substring e "tool_access must be an array")
 
 let test_tool_access_invalid_tool_member_rejected () =
   match Masc_test_deps.meta_of_json_fixture
@@ -834,16 +897,24 @@ let () =
         ] );
       ( "meta_json",
         [
-          Alcotest.test_case "missing tool_access defaults empty allowlist" `Quick
-            test_tool_access_missing_defaults_empty_allowlist;
-          Alcotest.test_case "typed/string defaults match" `Quick
-            test_typed_and_string_tool_access_defaults_match;
-          Alcotest.test_case "read_meta defaults missing tool_access without rewrite" `Quick
-            test_read_meta_file_defaults_missing_tool_access_without_rewrite;
+          Alcotest.test_case "missing tool_access uses standard policy" `Quick
+            test_tool_access_missing_defaults_standard_policy;
+          Alcotest.test_case "typed/string rejections match" `Quick
+            test_typed_and_string_tool_access_rejections_match;
+          Alcotest.test_case "read_meta rejects missing tool_access" `Quick
+            test_read_meta_file_rejects_missing_tool_access;
+          Alcotest.test_case "read_meta rejects tool_access object" `Quick
+            test_read_meta_file_rejects_tool_access_object;
+          Alcotest.test_case "tool_access object empty value rejected" `Quick
+            test_tool_access_object_empty_value_rejected;
           Alcotest.test_case "array empty json preserved" `Quick
             test_tool_access_array_empty_json_preserved;
           Alcotest.test_case "non-array tool_access rejected" `Quick
             test_tool_access_non_array_rejected;
+          Alcotest.test_case "tool_access object array value rejected" `Quick
+            test_tool_access_object_array_value_rejected;
+          Alcotest.test_case "tool_access object scalar value rejected" `Quick
+            test_tool_access_object_scalar_value_rejected;
           Alcotest.test_case "invalid tool member rejected" `Quick
             test_tool_access_invalid_tool_member_rejected;
         ] );


### PR DESCRIPTION
## Summary
- #19700 merged before the final hard-purge push, so this follow-up carries the remaining cleanup on top of current main.
- Remove remaining tool preset/kind/allowlist vocabulary from code, tests, and docs.
- Keep only canonical tool_access parsing, with generic object-shaped rejection coverage instead of legacy preset compatibility tests.

## Verification
- rg residue sweep for tool_preset/tool_allowlist/tool_access.kind/tool_access.preset/[keeper.tool_access]/minimum_preset/preset_allowlist/tool preset: no matches
- git diff --check origin/main..HEAD
- ocamlformat --check touched OCaml files
- scripts/check-oas-pin.sh --local-only
- scripts/dune-local.sh build test/test_keeper_masc_bridge.exe test/test_keeper_toml.exe
- test/test_keeper_masc_bridge.exe: 30 tests
- test/test_keeper_toml.exe: 96 tests