### PR TITLE
Hard-cut keeper credential and sandbox heuristics

### DIFF
--- a/config/keepers/base.toml
+++ b/config/keepers/base.toml
@@ -12,8 +12,6 @@ autoboot_enabled = false
 runtime_id = "runpod_mtp.qwen-runpod"
 sandbox_profile = "docker"
 network_mode = "inherit"
-repo_cli_identity = "anyang-keepers"
-git_identity_mode = "repo_cli_identity"
 
 instructions = """
 MASC 기본 소양 — 모든 keeper의 공통 행동 기반. persona instructions는 이 위에 stack.

--- a/config/keepers/verifier.toml
+++ b/config/keepers/verifier.toml
@@ -25,8 +25,6 @@ tool_denylist = [
   "masc_transition:submit_for_verification",
   "masc_transition:submit_pr_evidence",
 ]
-repo_cli_identity = "reviewer-keepers-nonoperator-0506b"
-git_identity_mode = "repo_cli_identity"
 
 instructions = """
 너는 task completion 검증자다. AwaitingVerification 상태의 task를 발견하면 다음 절차를 따른다.

--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -238,8 +238,6 @@ describe('keeper runtime trace', () => {
             sandbox_profiles: ['docker'],
             network_modes: ['inherit'],
             docker_visible: true,
-            git_credentials_enabled: true,
-            repo_cli_identity_materialized: true,
             latest_at: '2026-05-13T00:00:01Z',
           },
         },
@@ -327,7 +325,6 @@ describe('keeper runtime trace', () => {
     expect(result.runtime_lens.axes.provider_attempt.terminal_status).toBe('timeout')
     expect(result.runtime_lens.axes.runtime_proof.status).toBe('pass')
     expect(result.runtime_lens.axes.runtime_proof.docker_visible).toBe(true)
-    expect(result.runtime_lens.axes.runtime_proof.repo_cli_identity_materialized).toBe(true)
     expect(result.runtime_lens.axes.runtime_proof.tools).toEqual(['Execute', 'SearchFiles'])
     expect(result.runtime_lens.swimlanes.provider.terminal_status).toBe('timeout')
     expect(result.runtime_lens.swimlanes.memory_context.terminal_status).toBe('unknown')

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -847,8 +847,6 @@ export interface KeeperRuntimeLensRuntimeProofAxis {
   sandbox_profiles: string[]
   network_modes: string[]
   docker_visible: boolean
-  git_credentials_enabled: boolean
-  repo_cli_identity_materialized: boolean
   latest_at: string | null
 }
 
@@ -1315,8 +1313,6 @@ function parseRuntimeLensRuntimeProofAxis(raw: unknown): KeeperRuntimeLensRuntim
     sandbox_profiles: stringListField(obj, 'sandbox_profiles'),
     network_modes: stringListField(obj, 'network_modes'),
     docker_visible: obj.docker_visible === true,
-    git_credentials_enabled: obj.git_credentials_enabled === true,
-    repo_cli_identity_materialized: obj.repo_cli_identity_materialized === true,
     latest_at: nullableStringField(obj, 'latest_at'),
   }
 }

--- a/dashboard/src/components/keeper-detail-runtime.test.ts
+++ b/dashboard/src/components/keeper-detail-runtime.test.ts
@@ -542,8 +542,6 @@ describe('RuntimeLensSection', () => {
             sandbox_profiles: ['docker'],
             network_modes: ['inherit'],
             docker_visible: true,
-            git_credentials_enabled: true,
-            repo_cli_identity_materialized: true,
             latest_at: '2026-05-13T00:00:01Z',
           },
           context: {
@@ -778,7 +776,6 @@ describe('RuntimeLensSection', () => {
     expect(screen.getByText('pass / 2 calls')).toBeInTheDocument()
     expect(screen.getByText('sandbox proof')).toBeInTheDocument()
     expect(screen.getByText('docker')).toBeInTheDocument()
-    expect(screen.getByText('repo CLI proof')).toBeInTheDocument()
     expect(screen.getByText('git creds / identity materialized')).toBeInTheDocument()
     expect(screen.getByText('proof tools')).toBeInTheDocument()
     expect(screen.getByText('Execute, SearchFiles')).toBeInTheDocument()

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -1080,10 +1080,6 @@ export function RuntimeLensSection({
         <${SignalRow} label="override fields" value=${formatLensList(drift.override_fields)} />
         <${SignalRow} label="runtime proof" value=${`${proof.status} / ${proof.matched_tool_call_count} calls`} />
         <${SignalRow} label="sandbox proof" value=${proof.docker_visible ? formatLensList(proof.sandbox_profiles, 'docker') : 'not observed'} />
-        <${SignalRow}
-          label="repo CLI proof"
-          value=${`${proof.git_credentials_enabled ? 'git creds' : 'no git creds'} / ${proof.repo_cli_identity_materialized ? 'identity materialized' : 'identity missing'}`}
-        />
         <${SignalRow} label="proof tools" value=${formatLensList(proof.tools)} />
         <${SignalRow} label="network proof" value=${formatLensList(proof.network_modes)} />
         <${SignalRow} label="context compaction" value=${formatRatioPair({ numerator: context.context_compacted_count, denominator: context.context_compact_started_count })} />

--- a/lib/dashboard/dashboard_http_keeper_snapshot.ml
+++ b/lib/dashboard/dashboard_http_keeper_snapshot.ml
@@ -415,13 +415,6 @@ let keeper_config_json (config : Workspace.config) (name : string)
           ("container_playground_root",
             string_or_null
               (Env_config_sandbox.Runtime.docker_playground_container_root ()));
-          ("git_egress",
-            `String
-              (if Env_config_sandbox.Runtime.git_dispatch () then
-                 "repo_cli_identity_dispatch"
-               else
-                 "container_network_policy"));
-          ("credential_fallbacks_disabled", `Bool false);
           ("docker_image",
             match effective_sandbox_image with
             | Some img -> string_or_null img

--- a/lib/keeper/keeper_credential_provider.mli
+++ b/lib/keeper/keeper_credential_provider.mli
@@ -44,8 +44,7 @@ type binding = {
       (** argv executed inside the container after start ([None] for
           host-mounted bundles). *)
   metadata : (string * string) list;
-      (** Audit pairs: [source], [git_identity_mode], optional
-          [repo_cli_identity], [effective_repo_cli_identity],
+      (** Audit pairs such as [source], [credential_identity],
           [credential_scope], and [bundle_root]. *)
 }
 

--- a/lib/keeper/keeper_host_config_provider.ml
+++ b/lib/keeper/keeper_host_config_provider.ml
@@ -157,26 +157,17 @@ let compose_ro_mounts_result ?keeper_name
                 ~container:(Filename.concat cred_root ".ssh")))
 
 let resolve_git_identity (kb : Repo_cli_credentials.keeper_binding) ~keeper_name =
-  match kb.configured_repo_cli_identity, kb.git_identity_mode with
-  | Some id, "repo_cli_identity" ->
-      id, id ^ "@users.noreply.github.com"
-  | _ ->
-      Keeper_identity.keeper_git_author ~keeper_name,
-      Keeper_identity.keeper_git_email ~keeper_name
+  ignore keeper_name;
+  ( kb.credential_identity,
+    kb.credential_identity ^ "@users.noreply.github.com" )
 
 let metadata_of_binding (kb : Repo_cli_credentials.keeper_binding) =
-  let base =
-    [ "source", "host_config";
-      "git_identity_mode", kb.git_identity_mode;
-      "effective_repo_cli_identity", kb.effective_repo_cli_identity;
-      "credential_scope",
-      Repo_cli_credentials.credential_scope_to_string kb.credential_scope;
-      "bundle_root", kb.bundle_root;
-    ]
-  in
-  match kb.configured_repo_cli_identity with
-  | Some id -> base @ [ "repo_cli_identity", id ]
-  | None -> base
+  [ "source", "host_config";
+    "credential_identity", kb.credential_identity;
+    "credential_scope",
+    Repo_cli_credentials.credential_scope_to_string kb.credential_scope;
+    "bundle_root", kb.bundle_root;
+  ]
 
 (* RFC-0019 bridge to the multi-repo credential store.  A keeper must have a
    [Keeper_repo_mapping] entry that resolves to exactly one
@@ -237,7 +228,7 @@ let bind_from_keeper_binding ?ssh_key_path ~keeper_name
          Ok
            Keeper_credential_provider.
              {
-               identity = kb.effective_repo_cli_identity;
+               identity = kb.credential_identity;
                env;
                ro_mounts;
                bootstrap = None;
@@ -286,10 +277,8 @@ let binding_of_credential (cred : Repo_manager_types.credential)
       Ok
         Repo_cli_credentials.
           {
-            configured_repo_cli_identity = Some cred.username;
-            effective_repo_cli_identity = cred.username;
+            credential_identity = cred.username;
             credential_scope = Keeper_identity;
-            git_identity_mode = "repo_cli_identity";
             bundle_root = synth_bundle_root;
             gh_config_dir;
           }
@@ -301,14 +290,6 @@ let bind_from_credential ~keeper_name (cred : Repo_manager_types.credential) =
         (Keeper_credential_provider.Missing_bundle
            { identity = keeper_name; path = reason })
   | Ok kb ->
-      let kb =
-        match
-          (Keeper_types_profile.load_keeper_profile_defaults keeper_name)
-            .git_identity_mode
-        with
-        | Some "keeper_alias" -> { kb with git_identity_mode = "keeper_alias" }
-        | _ -> kb
-      in
       let ssh_key_path =
         match cred.ssh_key_path with
         | Some path ->
@@ -345,51 +326,6 @@ let bind_from_credential ~keeper_name (cred : Repo_manager_types.credential) =
               match ssh_key_path with
               | None -> []
               | Some path -> [ ("ssh_key_path", path) ]))
-
-let repo_cli_config_dir_matches_identity ~expected gh_config_dir =
-  String.equal (Filename.basename gh_config_dir) "gh"
-  && String.equal (Filename.basename (Filename.dirname gh_config_dir)) expected
-
-let credential_matches_explicit_repo_cli_identity ~expected
-    (cred : Repo_manager_types.credential) =
-  let expected = String.trim expected in
-  expected <> ""
-  && (String.equal cred.id expected
-      || String.equal cred.username expected
-      ||
-      match cred.gh_config_dir with
-      | Some gh_config_dir ->
-          repo_cli_config_dir_matches_identity ~expected (String.trim gh_config_dir)
-      | None -> false)
-
-let explicit_repo_cli_identity_conflict ~keeper_name
-    (cred : Repo_manager_types.credential) =
-  let defaults = Keeper_types_profile.load_keeper_profile_defaults keeper_name in
-  match defaults.repo_cli_identity, defaults.git_identity_mode with
-  | Some expected, Some "repo_cli_identity"
-    when not (credential_matches_explicit_repo_cli_identity ~expected cred) ->
-      Some expected
-  | _ -> None
-
-let bind_from_credential_checked ~keeper_name cred =
-  match explicit_repo_cli_identity_conflict ~keeper_name cred with
-  | Some expected ->
-      let gh_config_dir =
-        Option.value ~default:"<none>" cred.Repo_manager_types.gh_config_dir
-      in
-      Error
-        (Keeper_credential_provider.Missing_bundle
-           { identity = keeper_name
-           ; path =
-               Printf.sprintf
-                 "keeper %s declares repo_cli_identity %s but credential \
-                  mapping selected credential_id=%s username=%s \
-                  gh_config_dir=%s. Update keeper_repo_mappings.toml to \
-                  select the declared identity bundle or remove the \
-                  conflicting mapping."
-                 keeper_name expected cred.id cred.username gh_config_dir
-           })
-  | None -> bind_from_credential ~keeper_name cred
 
 let resolve ~config ~identity:keeper_name =
   match
@@ -428,7 +364,7 @@ let resolve ~config ~identity:keeper_name =
   | Ok [cred] ->
       count_resolve_outcome ~keeper_name ~source:"credential_store"
         ~reason:"single_mapping";
-      bind_from_credential_checked ~keeper_name cred
+      bind_from_credential ~keeper_name cred
   | Ok many ->
       count_resolve_outcome ~keeper_name ~source:"ambiguous"
         ~reason:"multi_mapping";

--- a/lib/keeper/keeper_host_config_provider.mli
+++ b/lib/keeper/keeper_host_config_provider.mli
@@ -1,9 +1,8 @@
 (** Keeper repo CLI credential provider.
 
     Resolves a keeper through [keeper_repo_mappings.toml] and the credential
-    store.  Missing or unreadable mappings fail closed; legacy inference from
-    keeper profile [repo_cli_identity] or the MASC-owned [root] bundle is no
-    longer a runtime fallback.  It mounts only files from the selected
+    store.  Missing or unreadable mappings fail closed; keeper TOML no longer
+    participates in repo credential selection.  It mounts only files from the selected
     credential bundle read-only into the dispatch container and composes
     container-local forge/Git environment variables.  Operator ambient credentials
     ([GH_TOKEN], [GITHUB_TOKEN], [~/.config/gh], [~/.ssh], keychain probes) are

--- a/lib/keeper/keeper_meta_json_scrub.ml
+++ b/lib/keeper/keeper_meta_json_scrub.ml
@@ -46,13 +46,12 @@ let reject_removed_keeper_meta_fields (json : Yojson.Safe.t) =
 ;;
 
 let strict_rejected_keeper_meta_key_names =
-  [ "allowed_providers"; "last_blocker_class"; "repo_cli_identity" ]
+  [ "allowed_providers"; "last_blocker_class" ]
 ;;
 
 let persisted_retired_keeper_meta_key_names =
   let retired_discovery_key suffix = "work_" ^ "discovery" ^ suffix in
   [
-    "repo_cli_identity";
     "last_" ^ retired_discovery_key "_ts";
     retired_discovery_key "_count";
     retired_discovery_key "_enabled";

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -154,7 +154,7 @@ let effective_declarative_runtime_id
 let resynced_tool_access
     (defaults : Keeper_types_profile.keeper_profile_defaults)
     (meta : keeper_meta) =
-  match defaults.tool_custom_list with
+  match defaults.tool_access with
   | Some tools -> normalize_tool_names tools
   | None -> meta.tool_access
 

--- a/lib/keeper/keeper_sandbox_runtime.ml
+++ b/lib/keeper/keeper_sandbox_runtime.ml
@@ -625,8 +625,6 @@ let docker_preflight_to_yojson (preflight : docker_preflight) =
     [ "backend", `String "docker"
     ; "status", `String (if preflight.ok then "ok" else "error")
     ; "ok", `Bool preflight.ok
-    ; "credential_fallbacks_disabled", `Bool preflight.credential_fallbacks_disabled
-    ; "git_egress", `String preflight.git_egress
     ; "image", `String preflight.image
     ; "docker_runtime_ok", `Bool preflight.docker_runtime_ok
     ; Json_util.string_opt_field "docker_runtime_error" preflight.docker_runtime_error
@@ -804,11 +802,6 @@ let docker_preflight ~timeout_sec () =
           && image_present
           && command_error = None
           && missing_commands = []
-      ; credential_fallbacks_disabled = false
-      ; git_egress =
-          (if Env_config_sandbox.Runtime.git_dispatch ()
-           then "repo_cli_identity_dispatch"
-           else "container_network_policy")
       ; image
       ; docker_runtime_ok
       ; docker_runtime_error

--- a/lib/keeper/keeper_sandbox_runtime.mli
+++ b/lib/keeper/keeper_sandbox_runtime.mli
@@ -16,8 +16,6 @@ type required_command_check =
 
 type docker_preflight =
   { ok : bool
-  ; credential_fallbacks_disabled : bool
-  ; git_egress : string
   ; image : string
   ; docker_runtime_ok : bool
   ; docker_runtime_error : string option

--- a/lib/keeper/keeper_sandbox_runtime_setup.ml
+++ b/lib/keeper/keeper_sandbox_runtime_setup.ml
@@ -132,8 +132,6 @@ type required_command_check =
 
 type docker_preflight =
   { ok : bool
-  ; credential_fallbacks_disabled : bool
-  ; git_egress : string
   ; image : string
   ; docker_runtime_ok : bool
   ; docker_runtime_error : string option

--- a/lib/keeper/keeper_sandbox_runtime_setup.mli
+++ b/lib/keeper/keeper_sandbox_runtime_setup.mli
@@ -25,8 +25,6 @@ val docker_info_security_options :
 type required_command_check = { command : string; available : bool; }
 type docker_preflight = {
   ok : bool;
-  credential_fallbacks_disabled : bool;
-  git_egress : string;
   image : string;
   docker_runtime_ok : bool;
   docker_runtime_error : string option;

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -304,21 +304,9 @@ let resolve_sandbox_profile ~preferred ~fallback =
   Dashboard_utils.first_some preferred fallback
   |> Option.value ~default:default_sandbox_profile
 
-let resolve_network_mode ~sandbox_profile ~preferred ~fallback =
+let resolve_network_mode ~preferred ~fallback =
   Dashboard_utils.first_some preferred fallback
-  |> Option.value ~default:(default_network_mode_for_profile sandbox_profile)
-
-
-let private_workspace_root_rel ~sandbox_profile keeper_name =
-  Keeper_sandbox.host_root_rel_of_profile sandbox_profile keeper_name
-  |> Keeper_alerting_path.strip_trailing_slashes
-
-let private_workspace_root_abs ~(config : Workspace.config) ~sandbox_profile keeper_name =
-  Filename.concat
-    (Keeper_alerting_path.project_root_of_config config)
-    (private_workspace_root_rel ~sandbox_profile keeper_name)
-  |> Keeper_alerting_path.normalize_path_for_check
-  |> Keeper_alerting_path.strip_trailing_slashes
+  |> Option.value ~default:Network_inherit
 
 let sandbox_allowed_path_has_forbidden_segments path =
   let has_glob =
@@ -334,65 +322,17 @@ let sandbox_allowed_path_has_forbidden_segments path =
            | "." | ".." -> true
            | _ -> false))
 
-let sandbox_allowed_path_within_private_root
-    ~(config : Workspace.config)
-    ~keeper_name
-    ~sandbox_profile
-    path =
-  let trimmed = String.trim path in
-  if trimmed = "" then false
-  else if sandbox_allowed_path_has_forbidden_segments trimmed then
-    false
-  else
-    let private_root =
-      private_workspace_root_abs ~config ~sandbox_profile keeper_name
-    in
-    let candidate =
-      (if Filename.is_relative trimmed then
-         Filename.concat
-           (Keeper_alerting_path.project_root_of_config config)
-           trimmed
-       else
-         trimmed)
-      |> Keeper_alerting_path.normalize_path_for_check
-      |> Keeper_alerting_path.strip_trailing_slashes
-    in
-    candidate = private_root
-    || String.starts_with ~prefix:(private_root ^ "/") candidate
-
-let validate_sandbox_settings
-    ~(config : Workspace.config)
-    ~keeper_name
-    ~repo_cli_identity
-    ~sandbox_profile
-    ~network_mode
-    ~allowed_paths =
+let validate_sandbox_settings ~allowed_paths =
   if allowed_paths = [ "*" ] then
     Error "allowed_paths=[\"*\"] is not supported; enumerate explicit paths instead"
   else
-  match sandbox_profile with
-  | Local -> (
-      match network_mode with
-      | Network_inherit -> Ok ()
-      | Network_none ->
-          Error
-            "network_mode=none requires sandbox_profile=docker")
-  | Docker ->
-      let profile_label = sandbox_profile_to_string sandbox_profile in
-      let escaping =
-        List.filter
-          (fun path ->
-            not
-              (sandbox_allowed_path_within_private_root
-                 ~config ~keeper_name ~sandbox_profile path))
-          allowed_paths
-      in
-      match escaping with
-      | [] -> Ok ()
-      | _ ->
-          Error
-            (Printf.sprintf
-               "%s allowed_paths must stay under %s (rejected: %s)"
-               profile_label
-               (private_workspace_root_rel ~sandbox_profile keeper_name)
-               (String.concat ", " escaping))
+    match
+      List.filter sandbox_allowed_path_has_forbidden_segments allowed_paths
+    with
+    | [] -> Ok ()
+    | rejected ->
+        Error
+          (Printf.sprintf
+             "allowed_paths entries may not contain globs or traversal segments \
+              (rejected: %s)"
+             (String.concat ", " rejected))

--- a/lib/keeper/keeper_turn_up_args.mli
+++ b/lib/keeper/keeper_turn_up_args.mli
@@ -104,43 +104,15 @@ val resolve_sandbox_profile :
   sandbox_profile
 
 val resolve_network_mode :
-  sandbox_profile:sandbox_profile ->
   preferred:network_mode option ->
   fallback:network_mode option ->
   network_mode
-
-(** Private workspace root path (relative to project root). *)
-val private_workspace_root_rel :
-  sandbox_profile:sandbox_profile -> string -> string
-
-(** Private workspace root path (absolute, normalized). *)
-val private_workspace_root_abs :
-  config:Workspace.config ->
-  sandbox_profile:sandbox_profile ->
-  string ->
-  string
 
 (** Reject globs ([*?\[\]]) and traversal segments ([./..]) in
     sandbox allowed-path entries. *)
 val sandbox_allowed_path_has_forbidden_segments : string -> bool
 
-(** [true] iff [path] resolves to a location within the keeper's
-    private workspace root (after normalization + traversal check). *)
-val sandbox_allowed_path_within_private_root :
-  config:Workspace.config ->
-  keeper_name:string ->
-  sandbox_profile:sandbox_profile ->
-  string ->
-  bool
-
-(** Validate sandbox + network + allowed_paths against the
-    [Local | Docker] profile constraints. Returns [Error msg] with
-    a remediation hint when settings are inconsistent. *)
+(** Validate allowed_paths without changing behavior by sandbox backend. *)
 val validate_sandbox_settings :
-  config:Workspace.config ->
-  keeper_name:string ->
-  repo_cli_identity:'a option ->
-  sandbox_profile:sandbox_profile ->
-  network_mode:network_mode ->
   allowed_paths:string list ->
   (unit, string) result

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -79,7 +79,6 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
   in
   let network_mode =
     resolve_network_mode
-      ~sandbox_profile
       ~preferred:p.network_mode_opt
       ~fallback:p.profile_defaults.network_mode
   in
@@ -97,13 +96,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
   | Some msg -> tool_result_error msg
   | None ->
     match
-      validate_sandbox_settings
-        ~config:ctx.config
-        ~keeper_name:p.name
-        ~repo_cli_identity:p.profile_defaults.repo_cli_identity
-        ~sandbox_profile
-        ~network_mode
-        ~allowed_paths
+      validate_sandbox_settings ~allowed_paths
     with
     | Error err ->
         Prometheus.inc_counter
@@ -186,7 +179,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
                 match p.tool_access_opt with
                 | Some access -> access
                 | None ->
-                    (match p.profile_defaults.tool_custom_list with
+                    (match p.profile_defaults.tool_access with
                      | Some tools -> normalize_tool_names tools
                      | None -> default_tool_access_of_meta_json ())
               in

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -90,17 +90,7 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
     Option.value ~default:old.sandbox_profile p.sandbox_profile_opt
   in
   let network_mode =
-    match p.network_mode_opt with
-    | Some mode -> mode
-    | None ->
-        if Option.is_some p.sandbox_profile_opt
-           && sandbox_profile <> old.sandbox_profile
-        then
-          (* Recompute the profile default on sandbox posture changes so
-             legacy egress does not silently carry into hardened mode. *)
-          default_network_mode_for_profile sandbox_profile
-        else
-          old.network_mode
+    Option.value ~default:old.network_mode p.network_mode_opt
   in
   let autoboot_enabled =
     match p.autoboot_enabled_opt, p.profile_defaults.autoboot_enabled with
@@ -131,7 +121,7 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
     match p.tool_access_opt with
     | Some access -> access
     | None ->
-        (match p.profile_defaults.tool_custom_list with
+        (match p.profile_defaults.tool_access with
          | Some tools -> normalize_tool_names tools
          | None -> old.tool_access)
   in
@@ -310,13 +300,7 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
     updated_at = now_iso ();
   } in
   match
-    validate_sandbox_settings
-      ~config:ctx.config
-      ~keeper_name:p.name
-      ~repo_cli_identity:p.profile_defaults.repo_cli_identity
-      ~sandbox_profile
-      ~network_mode
-      ~allowed_paths
+    validate_sandbox_settings ~allowed_paths
   with
   | Error err ->
       Prometheus.inc_counter

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -212,9 +212,7 @@ let load_keeper_profile_defaults_from_persona name : keeper_profile_defaults =
                 sandbox_profile = None;
                 sandbox_image = None;
                 network_mode = None;
-                repo_cli_identity = None;
-                git_identity_mode = None;
-                tool_custom_list = None;
+                tool_access = None;
                 tool_denylist =
                   normalize_name_list_opt
                     (Safe_ops.json_string_list "tool_denylist" keeper_json);

--- a/lib/keeper/keeper_types_profile.mli
+++ b/lib/keeper/keeper_types_profile.mli
@@ -31,7 +31,6 @@ val ensure_dir : string -> string
 val dedupe_keep_order : 'a list -> 'a list
 val normalize_name_list : string list -> string list
 val normalize_name_list_opt : string list -> string list option
-val normalize_git_identity_mode_opt : string option -> string option
 val normalize_social_model_opt : string option -> string option
 val valid_social_model_strings : string list
 val lower_string_list_opt : string list -> string list option

--- a/lib/keeper/keeper_types_profile_defaults.ml
+++ b/lib/keeper/keeper_types_profile_defaults.ml
@@ -25,9 +25,7 @@ type keeper_profile_defaults = {
   sandbox_profile : Keeper_types_profile_sandbox.sandbox_profile option;
   sandbox_image : string option;
   network_mode : Keeper_types_profile_sandbox.network_mode option;
-  repo_cli_identity : string option;
-  git_identity_mode : string option;
-  tool_custom_list : string list option;
+  tool_access : string list option;
   tool_denylist : string list option;
   active_goal_ids : string list option;
   (* Telemetry Feedback — inject behavioral stats into keeper context *)
@@ -83,9 +81,7 @@ let empty_keeper_profile_defaults =
     sandbox_profile = None;
     sandbox_image = None;
     network_mode = None;
-    repo_cli_identity = None;
-    git_identity_mode = None;
-    tool_custom_list = None;
+    tool_access = None;
     tool_denylist = None;
     active_goal_ids = None;
     telemetry_feedback_enabled = None;

--- a/lib/keeper/keeper_types_profile_defaults.mli
+++ b/lib/keeper/keeper_types_profile_defaults.mli
@@ -27,9 +27,7 @@ type keeper_profile_defaults = {
   sandbox_profile : Keeper_types_profile_sandbox.sandbox_profile option;
   sandbox_image : string option;
   network_mode : Keeper_types_profile_sandbox.network_mode option;
-  repo_cli_identity : string option;
-  git_identity_mode : string option;
-  tool_custom_list : string list option;
+  tool_access : string list option;
   tool_denylist : string list option;
   active_goal_ids : string list option;
   telemetry_feedback_enabled : bool option;

--- a/lib/keeper/keeper_types_profile_toml.mli
+++ b/lib/keeper/keeper_types_profile_toml.mli
@@ -166,9 +166,7 @@ type keeper_profile_defaults =
     Keeper_types_profile_sandbox.sandbox_profile option;
   sandbox_image : string option;
   network_mode : Keeper_types_profile_sandbox.network_mode option;
-  repo_cli_identity : string option;
-  git_identity_mode : string option;
-  tool_custom_list : string list option;
+  tool_access : string list option;
   tool_denylist : string list option;
   active_goal_ids : string list option;
   telemetry_feedback_enabled : bool option;
@@ -200,7 +198,6 @@ val keeper_oas_context_of_defaults :
 val dedupe_keep_order : 'a list -> 'a list
 val normalize_name_list : string list -> string list
 val normalize_name_list_opt : string list -> string list option
-val normalize_git_identity_mode_opt : string option -> string option
 val normalize_social_model_opt : string option -> string option
 val valid_social_model_strings : string list
 val lower_string_list_opt : string list -> string list option

--- a/lib/keeper/keeper_types_profile_toml_io.mli
+++ b/lib/keeper/keeper_types_profile_toml_io.mli
@@ -166,9 +166,7 @@ type keeper_profile_defaults =
     Keeper_types_profile_sandbox.sandbox_profile option;
   sandbox_image : string option;
   network_mode : Keeper_types_profile_sandbox.network_mode option;
-  repo_cli_identity : string option;
-  git_identity_mode : string option;
-  tool_custom_list : string list option;
+  tool_access : string list option;
   tool_denylist : string list option;
   active_goal_ids : string list option;
   telemetry_feedback_enabled : bool option;
@@ -200,7 +198,6 @@ val keeper_oas_context_of_defaults :
 val dedupe_keep_order : 'a list -> 'a list
 val normalize_name_list : string list -> string list
 val normalize_name_list_opt : string list -> string list option
-val normalize_git_identity_mode_opt : string option -> string option
 val normalize_social_model_opt : string option -> string option
 val valid_social_model_strings : string list
 val lower_string_list_opt : string list -> string list option

--- a/lib/keeper/keeper_types_profile_toml_normalizers.ml
+++ b/lib/keeper/keeper_types_profile_toml_normalizers.ml
@@ -24,14 +24,6 @@ let normalize_name_list_opt items =
   | [] -> None
   | xs -> Some xs
 
-let normalize_git_identity_mode_opt = function
-  | None -> None
-  | Some raw -> (
-      match String.trim (String.lowercase_ascii raw) with
-      | "keeper_alias" -> Some "keeper_alias"
-      | "repo_cli_identity" -> Some "repo_cli_identity"
-      | _ -> None)
-
 let normalize_social_model_opt = function
   | None -> None
   | Some raw -> (

--- a/lib/keeper/keeper_types_profile_toml_normalizers.mli
+++ b/lib/keeper/keeper_types_profile_toml_normalizers.mli
@@ -166,9 +166,7 @@ type keeper_profile_defaults =
     Keeper_types_profile_sandbox.sandbox_profile option;
   sandbox_image : string option;
   network_mode : Keeper_types_profile_sandbox.network_mode option;
-  repo_cli_identity : string option;
-  git_identity_mode : string option;
-  tool_custom_list : string list option;
+  tool_access : string list option;
   tool_denylist : string list option;
   active_goal_ids : string list option;
   telemetry_feedback_enabled : bool option;
@@ -200,7 +198,6 @@ val keeper_oas_context_of_defaults :
 val dedupe_keep_order : 'a list -> 'a list
 val normalize_name_list : string list -> string list
 val normalize_name_list_opt : string list -> string list option
-val normalize_git_identity_mode_opt : string option -> string option
 val normalize_social_model_opt : string option -> string option
 val valid_social_model_strings : string list
 val lower_string_list_opt : string list -> string list option

--- a/lib/keeper/keeper_types_profile_toml_parser.ml
+++ b/lib/keeper/keeper_types_profile_toml_parser.ml
@@ -49,26 +49,6 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
   in
   let result =
     Result.bind result (fun () ->
-        match str "repo_cli_identity" with
-        | Some raw when not (validate_name raw) ->
-            Error (Printf.sprintf "invalid repo_cli_identity '%s'" raw)
-        | _ -> Ok ())
-  in
-  let result =
-    Result.bind result (fun () ->
-        match str "git_identity_mode" with
-        | Some raw -> (
-            match normalize_git_identity_mode_opt (Some raw) with
-            | Some _ -> Ok ()
-            | None ->
-                Error
-                  (Printf.sprintf
-                     "invalid git_identity_mode '%s' (allowed: keeper_alias, repo_cli_identity)"
-                     raw))
-        | None -> Ok ())
-  in
-  let result =
-    Result.bind result (fun () ->
         match str "social_model" with
         | Some raw -> (
             match normalize_social_model_opt (Some raw) with
@@ -137,11 +117,11 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
     Result.bind result (fun () -> tool_access_defaults_result)
   in
   let result =
-    Result.bind result (fun tool_custom_list ->
-      Result.map (fun runtime_id_opt -> tool_custom_list, runtime_id_opt) runtime_id_result)
+    Result.bind result (fun tool_access ->
+      Result.map (fun runtime_id_opt -> tool_access, runtime_id_opt) runtime_id_result)
   in
   Result.map
-    (fun (tool_custom_list, runtime_id_opt) ->
+    (fun (tool_access, runtime_id_opt) ->
       {
         id = None;
         manifest_path = None;
@@ -177,10 +157,7 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
         sandbox_image = str "sandbox_image";
         network_mode =
           Option.bind (str "network_mode") network_mode_of_string;
-        repo_cli_identity = str "repo_cli_identity";
-        git_identity_mode =
-          normalize_git_identity_mode_opt (str "git_identity_mode");
-        tool_custom_list;
+        tool_access;
         tool_denylist = normalize_name_list_opt (strs "tool_denylist");
         active_goal_ids =
           if has "active_goal_ids" then
@@ -226,8 +203,6 @@ let parsed_field_key_names =
   ; "sandbox_profile"
   ; "sandbox_image"
   ; "network_mode"
-  ; "repo_cli_identity"
-  ; "git_identity_mode"
   ; "tool_access"
   ; "tool_denylist"
   ; "active_goal_ids"
@@ -271,8 +246,6 @@ let canonical_keeper_toml_key_names =
   ; "sandbox_profile"
   ; "sandbox_image"
   ; "network_mode"
-  ; "repo_cli_identity"
-  ; "git_identity_mode"
   ; "tool_access"
   ; "tool_denylist"
   ; "active_goal_ids"
@@ -410,10 +383,7 @@ let merge_keeper_profile_defaults
     sandbox_profile = prefer overlay.sandbox_profile base.sandbox_profile;
     sandbox_image = prefer overlay.sandbox_image base.sandbox_image;
     network_mode = prefer overlay.network_mode base.network_mode;
-    repo_cli_identity = prefer overlay.repo_cli_identity base.repo_cli_identity;
-    git_identity_mode =
-      prefer overlay.git_identity_mode base.git_identity_mode;
-    tool_custom_list = prefer overlay.tool_custom_list base.tool_custom_list;
+    tool_access = prefer overlay.tool_access base.tool_access;
     tool_denylist = prefer overlay.tool_denylist base.tool_denylist;
     active_goal_ids = prefer overlay.active_goal_ids base.active_goal_ids;
     telemetry_feedback_enabled =

--- a/lib/keeper/keeper_types_profile_toml_parser.mli
+++ b/lib/keeper/keeper_types_profile_toml_parser.mli
@@ -166,9 +166,7 @@ type keeper_profile_defaults =
     Keeper_types_profile_sandbox.sandbox_profile option;
   sandbox_image : string option;
   network_mode : Keeper_types_profile_sandbox.network_mode option;
-  repo_cli_identity : string option;
-  git_identity_mode : string option;
-  tool_custom_list : string list option;
+  tool_access : string list option;
   tool_denylist : string list option;
   active_goal_ids : string list option;
   telemetry_feedback_enabled : bool option;
@@ -200,7 +198,6 @@ val keeper_oas_context_of_defaults :
 val dedupe_keep_order : 'a list -> 'a list
 val normalize_name_list : string list -> string list
 val normalize_name_list_opt : string list -> string list option
-val normalize_git_identity_mode_opt : string option -> string option
 val normalize_social_model_opt : string option -> string option
 val valid_social_model_strings : string list
 val lower_string_list_opt : string list -> string list option

--- a/lib/keeper/repo_cli_credentials.ml
+++ b/lib/keeper/repo_cli_credentials.ml
@@ -14,28 +14,26 @@ type credential_scope =
   | Keeper_identity
   | Root_fallback
 
-let root_repo_cli_identity = "root"
+let root_credential_identity = "root"
 
 let credential_scope_to_string = function
   | Keeper_identity -> "keeper_identity"
   | Root_fallback -> "root_fallback"
 
 type keeper_binding = {
-  configured_repo_cli_identity : string option;
-  effective_repo_cli_identity : string;
+  credential_identity : string;
   credential_scope : credential_scope;
-  git_identity_mode : string;
   bundle_root : string;
   gh_config_dir : string;
 }
 
-let bundle_root (config : Workspace.config) ~(repo_cli_identity : string) =
+let bundle_root (config : Workspace.config) ~(credential_identity : string) =
   Filename.concat
     (Filename.concat (Workspace.masc_dir config) "repo-cli-identities")
-    repo_cli_identity
+    credential_identity
 
 let root_bundle_root config =
-  bundle_root config ~repo_cli_identity:root_repo_cli_identity
+  bundle_root config ~credential_identity:root_credential_identity
 
 let repo_cli_config_dir_of_bundle bundle_root =
   Filename.concat bundle_root "gh"
@@ -79,87 +77,48 @@ let config_dir (config : Workspace.config) : string option =
   let dir = root_repo_cli_config_dir config in
   if repo_cli_config_dir_exists dir then Some dir else None
 
-let binding_of_repo_cli_identity
-    ~(configured_repo_cli_identity : string option)
-    ~(effective_repo_cli_identity : string)
+let binding_of_credential_identity
+    ~(credential_identity : string)
     ~(credential_scope : credential_scope)
-    ~(git_identity_mode : string)
     ~(bundle_root : string)
     ~(gh_config_dir : string) =
   {
-    configured_repo_cli_identity;
-    effective_repo_cli_identity;
+    credential_identity;
     credential_scope;
-    git_identity_mode;
     bundle_root;
     gh_config_dir;
   }
 
-let repo_cli_config_dir_matches_identity ~expected gh_config_dir =
-  String.equal (Filename.basename gh_config_dir) "gh"
-  && String.equal (Filename.basename (Filename.dirname gh_config_dir)) expected
-
-let credential_matches_explicit_repo_cli_identity ~expected
-    (cred : Repo_manager_types.credential) =
-  let expected = String.trim expected in
-  expected <> ""
-  && (String.equal cred.id expected
-      || String.equal cred.username expected
-      ||
-      match cred.gh_config_dir with
-      | Some gh_config_dir ->
-          repo_cli_config_dir_matches_identity ~expected (String.trim gh_config_dir)
-      | None -> false)
-
 let binding_of_mapped_credential
     ~(keeper_name : string)
-    ~(defaults : Keeper_types_profile.keeper_profile_defaults)
     (cred : Repo_manager_types.credential) =
-  match defaults.repo_cli_identity, defaults.git_identity_mode with
-  | Some expected, Some "repo_cli_identity"
-    when not (credential_matches_explicit_repo_cli_identity ~expected cred) ->
-      let gh_config_dir =
-        Option.value ~default:"<none>" cred.Repo_manager_types.gh_config_dir
-      in
+  match cred.gh_config_dir with
+  | None ->
       Error
         (Printf.sprintf
-           "keeper %s declares repo_cli_identity %s but credential mapping selected credential_id=%s username=%s gh_config_dir=%s. Update keeper_repo_mappings.toml or the keeper TOML so both credential SSOTs agree."
-           keeper_name expected cred.id cred.username gh_config_dir)
-  | _ -> (
-      match cred.gh_config_dir with
-      | None ->
-          Error
-            (Printf.sprintf
-               "credential %s selected for keeper %s has no gh_config_dir"
-               cred.id keeper_name)
-      | Some raw_gh_config_dir ->
-          let gh_config_dir = String.trim raw_gh_config_dir in
-          if gh_config_dir = "" then
-            Error
-              (Printf.sprintf
-                 "credential %s selected for keeper %s has empty gh_config_dir"
-                 cred.id keeper_name)
-          else if not (repo_cli_config_dir_exists gh_config_dir) then
-            Error
-              (Printf.sprintf
-                 "credential %s selected for keeper %s points at missing GH config dir %s"
-                 cred.id keeper_name gh_config_dir)
-          else
-            let git_identity_mode =
-              match defaults.git_identity_mode with
-              | Some "keeper_alias" -> "keeper_alias"
-              | _ -> "repo_cli_identity"
-            in
-            Ok
-              (binding_of_repo_cli_identity
-                 ~configured_repo_cli_identity:(Some cred.username)
-                 ~effective_repo_cli_identity:cred.username
-                 ~credential_scope:Keeper_identity
-                 ~git_identity_mode
-                 ~bundle_root:(Filename.dirname gh_config_dir)
-                 ~gh_config_dir))
+           "credential %s selected for keeper %s has no gh_config_dir"
+           cred.id keeper_name)
+  | Some raw_gh_config_dir ->
+      let gh_config_dir = String.trim raw_gh_config_dir in
+      if gh_config_dir = "" then
+        Error
+          (Printf.sprintf
+             "credential %s selected for keeper %s has empty gh_config_dir"
+             cred.id keeper_name)
+      else if not (repo_cli_config_dir_exists gh_config_dir) then
+        Error
+          (Printf.sprintf
+             "credential %s selected for keeper %s points at missing GH config dir %s"
+             cred.id keeper_name gh_config_dir)
+      else
+        Ok
+          (binding_of_credential_identity
+             ~credential_identity:cred.username
+             ~credential_scope:Keeper_identity
+             ~bundle_root:(Filename.dirname gh_config_dir)
+             ~gh_config_dir)
 
-let mapped_keeper_binding ~(config : Workspace.config) ~keeper_name ~defaults =
+let mapped_keeper_binding ~(config : Workspace.config) ~keeper_name =
   match
     Keeper_repo_mapping.credentials_for_keeper
       ~base_path:config.Workspace.base_path ~keeper_id:keeper_name
@@ -180,7 +139,7 @@ let mapped_keeper_binding ~(config : Workspace.config) ~keeper_name ~defaults =
               ~base_path:config.Workspace.base_path)
            keeper_name)
   | Ok [ credential ] ->
-      binding_of_mapped_credential ~keeper_name ~defaults credential
+      binding_of_mapped_credential ~keeper_name credential
   | Ok credentials ->
       Error
         (Printf.sprintf
@@ -189,9 +148,7 @@ let mapped_keeper_binding ~(config : Workspace.config) ~keeper_name ~defaults =
 
 let keeper_binding (config : Workspace.config) ~(keeper_name : string) :
     (keeper_binding, string) result =
-  match Keeper_types_profile.load_keeper_profile_defaults_result keeper_name with
-  | Error reason -> Error reason
-  | Ok defaults -> mapped_keeper_binding ~config ~keeper_name ~defaults
+  mapped_keeper_binding ~config ~keeper_name
 
 let keeper_config_dir (config : Workspace.config) ~(keeper_name : string) :
     (string, string) result =

--- a/lib/keeper/repo_cli_credentials.mli
+++ b/lib/keeper/repo_cli_credentials.mli
@@ -9,27 +9,24 @@ type credential_scope =
   | Root_fallback
 
 type keeper_binding = {
-  configured_repo_cli_identity : string option;
-      (** Keeper-configured repo CLI identity, if one was declared. *)
-  effective_repo_cli_identity : string;
+  credential_identity : string;
       (** Identity whose bundle will actually be used. *)
   credential_scope : credential_scope;
-  git_identity_mode : string;
   bundle_root : string;
   gh_config_dir : string;
 }
 
 (** Reserved root fallback identity. *)
-val root_repo_cli_identity : string
+val root_credential_identity : string
 
 val credential_scope_to_string : credential_scope -> string
 
 (** Resolve the root fallback repo CLI config dir when it exists. *)
 val config_dir : Workspace.config -> string option
 
-(** [bundle_root config ~repo_cli_identity] is the on-disk root of the repo CLI
+(** [bundle_root config ~credential_identity] is the on-disk root of the repo CLI
     identity bundle: [$base_path/.masc/repo-cli-identities/<id>]. *)
-val bundle_root : Workspace.config -> repo_cli_identity:string -> string
+val bundle_root : Workspace.config -> credential_identity:string -> string
 
 val root_bundle_root : Workspace.config -> string
 
@@ -45,9 +42,9 @@ val git_config_env_pairs : (string * string) list
 
 val root_repo_cli_config_dir_exists : Workspace.config -> bool
 
-(** Resolve the keeper's repo CLI identity binding, or an error string
-    explaining why the binding cannot be established (missing identity
-    in profile defaults, missing GH config dir on disk, etc.). *)
+(** Resolve the keeper's repo CLI credential binding from
+    [keeper_repo_mappings.toml], or return an error string explaining
+    why the binding cannot be established. *)
 val keeper_binding :
   Workspace.config -> keeper_name:string -> (keeper_binding, string) result
 
@@ -69,12 +66,12 @@ val with_env : Workspace.config -> string -> string
     canonical lists. *)
 val compose_base_with_repo_cli_config : dir:string -> string array
 
-(** [process_env config] returns the composed env for the root repo CLI
-    identity path. It never uses the operator's ambient GH config. *)
+(** [process_env config] returns the composed env for the root credential
+    path. It never uses the operator's ambient GH config. *)
 val process_env : Workspace.config -> string array option
 
 (** [keeper_process_env config ~keeper_name] returns the composed env
-    for a specific keeper's repo CLI identity, or an error if the binding
-    cannot be resolved. *)
+    for a specific keeper credential, or an error if the binding cannot
+    be resolved. *)
 val keeper_process_env :
   Workspace.config -> keeper_name:string -> (string array option, string) result

--- a/lib/server/server_dashboard_http_keeper_runtime_lens_proof.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_proof.ml
@@ -11,8 +11,6 @@ type runtime_lens_proof_acc =
   ; mutable failed_tool_call_count : int
   ; mutable latest_ts : float option
   ; mutable docker_visible : bool
-  ; mutable git_credentials_enabled : bool
-  ; mutable repo_cli_identity_materialized : bool
   ; tools : (string, unit) Hashtbl.t
   ; successful_tools : (string, unit) Hashtbl.t
   ; failed_tools : (string, unit) Hashtbl.t
@@ -26,8 +24,6 @@ let runtime_lens_proof_acc () =
   ; failed_tool_call_count = 0
   ; latest_ts = None
   ; docker_visible = false
-  ; git_credentials_enabled = false
-  ; repo_cli_identity_materialized = false
   ; tools = Hashtbl.create 8
   ; successful_tools = Hashtbl.create 8
   ; failed_tools = Hashtbl.create 8
@@ -74,26 +70,9 @@ let rec runtime_lens_json_string_values field = function
   | `List values -> List.concat_map (runtime_lens_json_string_values field) values
   | _ -> []
 
-let rec runtime_lens_json_bool_values field = function
-  | `Assoc fields ->
-      let direct =
-        match List.assoc_opt field fields with
-        | Some (`Bool value) -> [ value ]
-        | _ -> []
-      in
-      direct
-      @ List.concat_map
-          (fun (_, value) -> runtime_lens_json_bool_values field value)
-          fields
-  | `List values -> List.concat_map (runtime_lens_json_bool_values field) values
-  | _ -> []
-
 let runtime_lens_has_string_field json field expected =
   runtime_lens_json_string_values field json
   |> List.exists (String.equal expected)
-
-let runtime_lens_has_true_field json field =
-  runtime_lens_json_bool_values field json |> List.exists Fun.id
 
 let runtime_lens_tool_text json =
   let input = (match Json_util.assoc_member_opt "input" json with Some v -> v | None -> `Null) |> Yojson.Safe.to_string in
@@ -115,31 +94,6 @@ let runtime_lens_call_has_docker_proof json output_opt text =
       runtime_lens_has_string_field output "sandbox_profile" "docker"
       || runtime_lens_has_string_field output "via" "docker"
   | None -> false
-
-let runtime_lens_call_has_git_credentials output_opt text =
-  runtime_lens_text_contains text "\"git_creds_enabled\":true"
-  ||
-  match output_opt with
-  | Some output -> runtime_lens_has_true_field output "git_creds_enabled"
-  | None -> false
-
-let runtime_lens_call_has_repo_cli_identity output_opt text =
-  let structured =
-    match output_opt with
-    | Some output ->
-        runtime_lens_has_string_field output "credential_scope" "keeper_identity"
-        &&
-        (runtime_lens_has_string_field output "git_identity_mode" "repo_cli_identity"
-         || runtime_lens_has_string_field output "state" "materialized")
-    | None -> false
-  in
-  structured
-  ||
-   (runtime_lens_text_contains text "\"credential_scope\":\"keeper_identity\""
-    &&
-   (runtime_lens_text_contains text "\"git_identity_mode\":\"repo_cli_identity\""
-    || runtime_lens_text_contains text
-         "\"credential_state\":{\"state\":\"materialized\""))
 
 let runtime_lens_collect_profile acc json =
   let add_from table field source =
@@ -167,11 +121,7 @@ let runtime_lens_accumulate_tool_proof acc json =
   let output_opt = parse_tool_output_json_opt json in
   let text = runtime_lens_tool_text json in
   if runtime_lens_call_has_docker_proof json output_opt text
-  then acc.docker_visible <- true;
-  if runtime_lens_call_has_git_credentials output_opt text
-  then acc.git_credentials_enabled <- true;
-  if runtime_lens_call_has_repo_cli_identity output_opt text
-  then acc.repo_cli_identity_materialized <- true
+  then acc.docker_visible <- true
 
 let runtime_lens_runtime_proof_json ~keeper_name ~trace_id ?turn_id () =
   let acc = runtime_lens_proof_acc () in
@@ -180,16 +130,8 @@ let runtime_lens_runtime_proof_json ~keeper_name ~trace_id ?turn_id () =
        if tool_call_matches_trace ?turn_id ~keeper_name ~trace_id json
        then runtime_lens_accumulate_tool_proof acc json);
   let status =
-    if
-      acc.docker_visible
-      && (acc.git_credentials_enabled || acc.repo_cli_identity_materialized)
-    then "pass"
-    else if
-      acc.matched_tool_call_count > 0
-      && (acc.docker_visible
-          || acc.git_credentials_enabled
-          || acc.repo_cli_identity_materialized)
-    then "warn"
+    if acc.docker_visible then "pass"
+    else if acc.matched_tool_call_count > 0 then "warn"
     else "missing"
   in
   `Assoc
@@ -206,8 +148,6 @@ let runtime_lens_runtime_proof_json ~keeper_name ~trace_id ?turn_id () =
         Json_util.json_string_list (runtime_lens_sorted_set acc.sandbox_profiles) )
     ; ("network_modes", Json_util.json_string_list (runtime_lens_sorted_set acc.network_modes))
     ; ("docker_visible", `Bool acc.docker_visible)
-    ; ("git_credentials_enabled", `Bool acc.git_credentials_enabled)
-    ; ("repo_cli_identity_materialized", `Bool acc.repo_cli_identity_materialized)
     ; ( "latest_at",
         match acc.latest_ts with
         | Some ts -> `String (Masc_domain.iso8601_of_unix_seconds ts)

--- a/test/test_credential_provider.ml
+++ b/test/test_credential_provider.ml
@@ -87,18 +87,6 @@ let with_config_dir_env config_dir f =
       Config_dir_resolver.reset ())
     f
 
-let write_repo_cli_identity_toml ~base_path ~keeper_name ~repo_cli_identity =
-  let keepers_dir = Filename.concat base_path ".masc/config/keepers" in
-  mkdir_p keepers_dir;
-  let path = Filename.concat keepers_dir (keeper_name ^ ".toml") in
-  let oc = open_out path in
-  Fun.protect
-    ~finally:(fun () -> close_out_noerr oc)
-    (fun () ->
-      Printf.fprintf oc
-        "[keeper]\nname = %S\nrepo_cli_identity = %S\ngit_identity_mode = \"repo_cli_identity\"\n"
-        keeper_name repo_cli_identity)
-
 let seed_credential ~base_path cred =
   match Credential_store.add ~base_path cred with
   | Ok _ -> ()
@@ -140,10 +128,8 @@ let make_repo ~id ~credential_id : repository =
 
 let make_keeper_binding ~bundle_root ~gh_config_dir : KRC.keeper_binding =
   {
-    KRC.configured_repo_cli_identity = Some "test-gh";
-    effective_repo_cli_identity = "test-gh";
+    KRC.credential_identity = "test-gh";
     credential_scope = KRC.Keeper_identity;
-    git_identity_mode = "repo_cli_identity";
     bundle_root;
     gh_config_dir;
   }
@@ -455,52 +441,6 @@ let test_resolve_credential_store_mounts_explicit_ssh_key () =
                binding.ro_mounts)
       | Error err -> failf "expected credential binding, got %s" (CP.pp_error err))
 
-let test_credential_store_mapping_conflicting_repo_cli_identity_fails_closed
-    () =
-  with_temp_base_path (fun base_path ->
-      let config = Masc_mcp.Workspace.default_config base_path in
-      let config_dir = Filename.concat base_path ".masc/config" in
-      let keeper_name = "keeper-conflict" in
-      let declared_identity = "declared-reviewer" in
-      write_repo_cli_identity_toml ~base_path ~keeper_name
-        ~repo_cli_identity:declared_identity;
-      with_config_dir_env config_dir (fun () ->
-          let gh_config_dir =
-            Filename.concat base_path ".masc/repo-cli-identities/other/gh"
-          in
-          seed_credential ~base_path
-            (make_credential ~id:"other-credential" ~username:"other-user"
-               ~gh_config_dir ());
-          seed_repo ~base_path
-            (make_repo ~id:"repo-conflict"
-               ~credential_id:"other-credential");
-          write_mapping base_path keeper_name [ "repo-conflict" ];
-          match HCP.resolve ~config ~identity:keeper_name with
-          | Error (CP.Missing_bundle { identity; path }) ->
-              check string "identity" keeper_name identity;
-              check bool "mentions declared identity" true
-                (try
-                   ignore
-                     (Str.search_forward
-                        (Str.regexp_string declared_identity)
-                        path 0);
-                   true
-                 with Not_found -> false);
-              check bool "mentions mapped credential" true
-                (try
-                   ignore
-                     (Str.search_forward
-                        (Str.regexp_string "other-credential")
-                        path 0);
-                   true
-                 with Not_found -> false)
-          | Ok _ ->
-              fail
-                "conflicting credential-store mapping should fail closed \
-                 before materializing Docker credentials"
-          | Error other ->
-              failf "expected Missing_bundle, got %s" (CP.pp_error other)))
-
 (* --- 4. finalize / tear_down noop semantics --- *)
 
 let dummy_binding () : CP.binding =
@@ -699,8 +639,6 @@ let () =
             test_resolve_without_mapping_fails_closed;
           test_case "explicit ssh key is mounted" `Quick
             test_resolve_credential_store_mounts_explicit_ssh_key;
-          test_case "conflicting keeper repo_cli_identity fails closed" `Quick
-            test_credential_store_mapping_conflicting_repo_cli_identity_fails_closed;
         ] );
       ( "lifecycle (PR-1 noop)",
         [

--- a/test/test_keeper_allowed_paths.ml
+++ b/test/test_keeper_allowed_paths.ml
@@ -2,9 +2,8 @@ open Alcotest
 
 module KAP = Masc_mcp.Keeper_alerting_path
 module Keeper_meta_json_parse = Masc_mcp.Keeper_meta_json_parse
-module Keeper_types_profile_sandbox = Masc_mcp.Keeper_types_profile_sandbox
-module KT = Masc_mcp.Keeper_types
 module KTU = Masc_mcp.Keeper_turn_up_args
+
 let make_meta ?(allowed_paths = []) ~name () =
   let json =
     `Assoc
@@ -24,49 +23,6 @@ let make_meta ?(allowed_paths = []) ~name () =
 
 let sandbox_roots meta =
   [ KAP.sandbox_path_of_meta ~meta ]
-
-let with_temp_dir prefix f =
-  let path = Filename.temp_file prefix "" in
-  Sys.remove path;
-  Unix.mkdir path 0o755;
-  Fun.protect
-    ~finally:(fun () ->
-      let rec rm dir =
-        if Sys.file_exists dir then
-          if Sys.is_directory dir then begin
-            Sys.readdir dir |> Array.iter (fun name -> rm (Filename.concat dir name));
-            Unix.rmdir dir
-          end else
-            Sys.remove dir
-      in
-      rm path)
-    (fun () -> f path)
-
-let with_env key value f =
-  let prior = Sys.getenv_opt key in
-  Unix.putenv key value;
-  Fun.protect
-    ~finally:(fun () ->
-      match prior with
-      | Some v -> Unix.putenv key v
-      | None -> Unix.putenv key "")
-    f
-
-let with_temp_config f =
-  with_temp_dir "keeper_allowed_paths_" (fun dir ->
-    Eio_main.run @@ fun env ->
-    Fs_compat.set_fs (Eio.Stdenv.fs env);
-    f (Masc_mcp.Workspace.default_config dir))
-
-let ensure_dir path =
-  let rec loop p =
-    if p = "" || p = "." || p = "/" then ()
-    else if Sys.file_exists p then ()
-    else (
-      loop (Filename.dirname p);
-      Unix.mkdir p 0o755)
-  in
-  loop path
 
 let contains_substring s needle =
   let s_len = String.length s in
@@ -100,74 +56,32 @@ let test_playground_path_sanitizes_name () =
     ".masc/playground/my_keeper_.._.._etc/" path
 
 let test_validate_rejects_star_wildcard () =
-  with_temp_config (fun config ->
-    match
-      KTU.validate_sandbox_settings
-        ~config
-        ~keeper_name:"keeper"
-        ~repo_cli_identity:None
-        ~sandbox_profile:Keeper_types_profile_sandbox.Local
-        ~network_mode:Keeper_types_profile_sandbox.Network_inherit
-        ~allowed_paths:["*"]
-    with
-    | Ok () -> fail "expected wildcard rejection"
-    | Error err ->
-        check string "explicit rejection message"
-          "allowed_paths=[\"*\"] is not supported; enumerate explicit paths instead"
-          err)
+  match KTU.validate_sandbox_settings ~allowed_paths:[ "*" ] with
+  | Ok () -> fail "expected wildcard rejection"
+  | Error err ->
+      check string "explicit rejection message"
+        "allowed_paths=[\"*\"] is not supported; enumerate explicit paths instead"
+        err
 
-let test_validate_local_rejects_network_none () =
-  with_temp_config (fun config ->
-    match
-      KTU.validate_sandbox_settings
-        ~config
-        ~keeper_name:"keeper"
-        ~repo_cli_identity:None
-        ~sandbox_profile:Keeper_types_profile_sandbox.Local
-        ~network_mode:Keeper_types_profile_sandbox.Network_none
-        ~allowed_paths:[]
-    with
-    | Ok () -> fail "expected local network_mode rejection"
-    | Error err ->
-        check string "local requires inherit"
-          "network_mode=none requires sandbox_profile=docker"
-          err)
+let test_validate_rejects_globs_and_traversal () =
+  match
+    KTU.validate_sandbox_settings
+      ~allowed_paths:[ "workspace/../outside"; "logs/*.txt" ]
+  with
+  | Ok () -> fail "expected path-shape rejection"
+  | Error err ->
+      check bool "error mentions rejected path" true
+        (contains_substring err "workspace/../outside");
+      check bool "error mentions glob" true
+        (contains_substring err "logs/*.txt")
 
-let test_validate_docker_allows_private_root_paths () =
-  with_temp_config (fun config ->
-    let allowed =
-      [
-        Masc_mcp.Keeper_turn_up_args.private_workspace_root_rel ~sandbox_profile:Keeper_types_profile_sandbox.Docker
-          "keeper";
-      ]
-    in
-    match
-      KTU.validate_sandbox_settings
-        ~config
-        ~keeper_name:"keeper"
-        ~repo_cli_identity:None
-        ~sandbox_profile:Keeper_types_profile_sandbox.Docker
-        ~network_mode:Keeper_types_profile_sandbox.Network_none
-        ~allowed_paths:allowed
-    with
-    | Ok () -> ()
-    | Error err -> fail ("expected docker private root to validate: " ^ err))
-
-let test_validate_docker_rejects_paths_outside_private_root () =
-  with_temp_config (fun config ->
-    match
-      KTU.validate_sandbox_settings
-        ~config
-        ~keeper_name:"keeper"
-        ~repo_cli_identity:None
-        ~sandbox_profile:Keeper_types_profile_sandbox.Docker
-        ~network_mode:Keeper_types_profile_sandbox.Network_inherit
-        ~allowed_paths:["workspace/outside"]
-    with
-    | Ok () -> fail "expected docker path rejection"
-    | Error err ->
-        check bool "error mentions rejected path" true
-          (String.contains err 'w'))
+let test_validate_accepts_plain_paths () =
+  match
+    KTU.validate_sandbox_settings
+      ~allowed_paths:[ "workspace/outside"; ".masc/playground/keeper/" ]
+  with
+  | Ok () -> ()
+  | Error err -> fail ("expected plain paths to validate: " ^ err)
 
 
 let () =
@@ -186,11 +100,9 @@ let () =
         [
           test_case "rejects wildcard full access" `Quick
             test_validate_rejects_star_wildcard;
-          test_case "local rejects network none" `Quick
-            test_validate_local_rejects_network_none;
-          test_case "docker allows private root paths" `Quick
-            test_validate_docker_allows_private_root_paths;
-          test_case "docker rejects paths outside private root" `Quick
-            test_validate_docker_rejects_paths_outside_private_root;
+          test_case "rejects globs and traversal" `Quick
+            test_validate_rejects_globs_and_traversal;
+          test_case "accepts plain paths" `Quick
+            test_validate_accepts_plain_paths;
         ] );
     ]

--- a/test/test_keeper_auto_pause_blocker_persist_12683.ml
+++ b/test/test_keeper_auto_pause_blocker_persist_12683.ml
@@ -160,27 +160,11 @@ let test_legacy_last_blocker_string_rejected () =
        last_blocker:string. Use structured last_blocker object."
       msg
 
-let test_repo_cli_identity_runtime_meta_rejected () =
-  let legacy_json =
-    match legacy_base_json "legacy-github-identity" with
-    | `Assoc fields ->
-      `Assoc (fields @ [ "repo_cli_identity", `String "anyang-keepers" ])
-    | json -> json
-  in
-  match Keeper_meta_json_parse.meta_of_json legacy_json with
-  | Ok _ -> fail "runtime meta repo_cli_identity field should be rejected"
-  | Error msg ->
-    check string
-      "rejects repo_cli_identity"
-      "removed keeper meta fields are no longer supported: repo_cli_identity"
-      msg
-
 let retired_discovery_key suffix = "work_" ^ "discovery" ^ suffix
 
 let test_persisted_retired_runtime_meta_fields_rejected () =
   let retired_fields =
     [
-      "repo_cli_identity", `String "anyang-keepers";
       "last_" ^ retired_discovery_key "_ts", `String "2026-05-24T16:29:11Z";
       retired_discovery_key "_count", `Int 12;
       retired_discovery_key "_enabled", `Bool true;
@@ -227,8 +211,6 @@ let () =
             test_legacy_last_blocker_pair_rejected;
           test_case "legacy blocker string rejected" `Quick
             test_legacy_last_blocker_string_rejected;
-          test_case "repo_cli_identity stays out of runtime meta" `Quick
-            test_repo_cli_identity_runtime_meta_rejected;
           test_case "retired persisted runtime fields are rejected" `Quick
             test_persisted_retired_runtime_meta_fields_rejected;
         ] );

--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -321,60 +321,39 @@ let write_fake_github_hosts repo_cli_dir =
     \    oauth_token: ghp_fake_test_token_for_docker_route\n\
     \    user: test-user\n"
 
-let with_repo_cli_identity_toml ~config ~keeper_name ~repo_cli_identity
-    ~git_identity_mode f =
-  let masc_dir = Filename.concat config.Workspace.base_path Common.masc_dirname in
-  let config_dir = Filename.concat masc_dir "config" in
-  let keepers_dir = Filename.concat config_dir "keepers" in
-  let repo_cli_dir =
-    Filename.concat
-      (Filename.concat
-         (Filename.concat masc_dir "repo-cli-identities")
-         repo_cli_identity)
-      "gh"
-  in
-  ensure_dir keepers_dir;
-  write_fake_github_hosts repo_cli_dir;
-  write_file
-    (Filename.concat keepers_dir (keeper_name ^ ".toml"))
-    (Printf.sprintf
-       "[keeper]\nrepo_cli_identity = %S\ngit_identity_mode = %S\n"
-       repo_cli_identity git_identity_mode);
-  with_config_dir config_dir f
-
-let ensure_repo_cli_identity_bundle ~config repo_cli_identity =
+let ensure_credential_identity_bundle ~config credential_identity =
   let masc_dir = Filename.concat config.Workspace.base_path Common.masc_dirname in
   let repo_cli_dir =
     Filename.concat
       (Filename.concat
          (Filename.concat masc_dir "repo-cli-identities")
-         repo_cli_identity)
+         credential_identity)
       "gh"
   in
   write_fake_github_hosts repo_cli_dir
 
-let repo_cli_config_dir_for_identity ~config repo_cli_identity =
+let repo_cli_config_dir_for_credential ~config credential_identity =
   let masc_dir = Filename.concat config.Workspace.base_path Common.masc_dirname in
   Filename.concat
     (Filename.concat
        (Filename.concat masc_dir "repo-cli-identities")
-       repo_cli_identity)
+       credential_identity)
     "gh"
 
 let seed_repo_cli_credential_mapping
-    ?(repo_cli_identity = Masc_mcp.Repo_cli_credentials.root_repo_cli_identity)
+    ?(credential_identity = Masc_mcp.Repo_cli_credentials.root_credential_identity)
     ?(repository_ids = [])
     ~config
     ~keeper_name
     () =
-  let gh_config_dir = repo_cli_config_dir_for_identity ~config repo_cli_identity in
+  let gh_config_dir = repo_cli_config_dir_for_credential ~config credential_identity in
   write_fake_github_hosts gh_config_dir;
-  let credential_id = "cred-" ^ keeper_name ^ "-" ^ repo_cli_identity in
+  let credential_id = "cred-" ^ keeper_name ^ "-" ^ credential_identity in
   let credential : Repo_manager_types.credential =
     {
       id = credential_id;
       cred_type = Repo_manager_types.Github;
-      username = repo_cli_identity;
+      username = credential_identity;
       gh_config_dir = Some gh_config_dir;
       ssh_key_path = None;
       gpg_key_id = None;
@@ -1179,7 +1158,7 @@ let test_execute_git_push_requires_write_tool_access_before_docker () =
   with_fake_docker fake_docker_echo_script @@ fun () ->
   setup ~tool_access:[] ~sandbox:Keeper_types_profile_sandbox.Docker
   @@ fun ~config ~meta ~playground ->
-  ensure_repo_cli_identity_bundle ~config Masc_mcp.Repo_cli_credentials.root_repo_cli_identity;
+  ensure_credential_identity_bundle ~config Masc_mcp.Repo_cli_credentials.root_credential_identity;
   let repo = Filename.concat (Filename.concat playground "repos") "masc-mcp" in
   ensure_dir repo;
   git_ok ~cwd:repo [ "init"; "-q" ];
@@ -1867,40 +1846,19 @@ let test_git_creds_mounts_numeric_user_identity () =
     (contains_substring (read_file group_path)
        (Printf.sprintf "keeper:x:%d:" (Unix.getgid ())))
 
-let test_git_creds_respects_keeper_alias_identity_mode () =
+let test_git_creds_uses_mapped_credential_identity () =
   with_fake_docker fake_docker_echo_script @@ fun () ->
   setup ~sandbox:Keeper_types_profile_sandbox.Docker
   @@ fun ~config ~meta ~playground ->
-  with_repo_cli_identity_toml ~config ~keeper_name:meta.name
-    ~repo_cli_identity:"anyang-keepers" ~git_identity_mode:"keeper_alias"
-  @@ fun () ->
   seed_repo_cli_credential_mapping ~config ~keeper_name:meta.name
-    ~repo_cli_identity:"anyang-keepers" ();
+    ~credential_identity:"anyang-keepers" ();
   let log_path = Filename.concat config.Workspace.base_path "docker.log" in
   let line =
     run_git_creds_docker_shell ~config ~meta ~playground ~log_path
   in
-  Alcotest.(check bool) "keeper_alias keeps keeper author" true
-    (contains_substring line "GIT_AUTHOR_NAME=minjae (MASC Keeper)");
-  Alcotest.(check bool) "keeper_alias does not force repo CLI identity author" false
-    (contains_substring line "GIT_AUTHOR_NAME=anyang-keepers")
-
-let test_git_creds_uses_configured_identity_mode () =
-  with_fake_docker fake_docker_echo_script @@ fun () ->
-  setup ~sandbox:Keeper_types_profile_sandbox.Docker
-  @@ fun ~config ~meta ~playground ->
-  with_repo_cli_identity_toml ~config ~keeper_name:meta.name
-    ~repo_cli_identity:"anyang-keepers" ~git_identity_mode:"repo_cli_identity"
-  @@ fun () ->
-  seed_repo_cli_credential_mapping ~config ~keeper_name:meta.name
-    ~repo_cli_identity:"anyang-keepers" ();
-  let log_path = Filename.concat config.Workspace.base_path "docker.log" in
-  let line =
-    run_git_creds_docker_shell ~config ~meta ~playground ~log_path
-  in
-  Alcotest.(check bool) "repo_cli_identity mode uses forge author" true
+  Alcotest.(check bool) "mapped credential uses forge author" true
     (contains_substring line "GIT_AUTHOR_NAME=anyang-keepers");
-  Alcotest.(check bool) "repo_cli_identity mode uses noreply email" true
+  Alcotest.(check bool) "mapped credential uses noreply email" true
     (contains_substring line
        "GIT_AUTHOR_EMAIL=anyang-keepers@users.noreply.github.com")
 
@@ -1910,46 +1868,43 @@ let test_git_creds_mounts_only_selected_keeper_identity () =
   @@ fun ~config ~meta_a ~playground_a ~meta_b ~playground_b ->
   let identity_a = "keeper-a-gh" in
   let identity_b = "keeper-b-gh" in
-  ensure_repo_cli_identity_bundle ~config
-    Masc_mcp.Repo_cli_credentials.root_repo_cli_identity;
-  ensure_repo_cli_identity_bundle ~config identity_a;
-  ensure_repo_cli_identity_bundle ~config identity_b;
+  ensure_credential_identity_bundle ~config
+    Masc_mcp.Repo_cli_credentials.root_credential_identity;
+  ensure_credential_identity_bundle ~config identity_a;
+  ensure_credential_identity_bundle ~config identity_b;
   let root_repo_cli_dir = Masc_mcp.Repo_cli_credentials.root_repo_cli_config_dir config in
   let repo_cli_dir id =
     Masc_mcp.Repo_cli_credentials.repo_cli_config_dir_of_bundle
-      (Masc_mcp.Repo_cli_credentials.bundle_root config ~repo_cli_identity:id)
+      (Masc_mcp.Repo_cli_credentials.bundle_root config ~credential_identity:id)
   in
-  let run_for ~(meta : Keeper_meta_contract.keeper_meta) ~playground ~repo_cli_identity
+  let run_for ~(meta : Keeper_meta_contract.keeper_meta) ~playground ~credential_identity
       ~other_identity ~log_name =
-    with_repo_cli_identity_toml ~config ~keeper_name:meta.name
-      ~repo_cli_identity ~git_identity_mode:"repo_cli_identity"
-    @@ fun () ->
     seed_repo_cli_credential_mapping ~config ~keeper_name:meta.name
-      ~repo_cli_identity ();
+      ~credential_identity ();
     let log_path = Filename.concat config.Workspace.base_path log_name in
     let line =
       run_git_creds_docker_shell ~config ~meta ~playground ~log_path
     in
-    let selected_repo_cli = repo_cli_dir repo_cli_identity in
+    let selected_repo_cli = repo_cli_dir credential_identity in
     let other_repo_cli = repo_cli_dir other_identity in
     let mounted_playground =
       Keeper_alerting_path.normalize_path_for_check playground
       |> Keeper_alerting_path.strip_trailing_slashes
     in
     check_line_contains
-      (repo_cli_identity ^ " selected repo CLI bundle mounted read-only")
+      (credential_identity ^ " selected repo CLI bundle mounted read-only")
       line
       (repo_cli_config_mount_spec selected_repo_cli);
     Alcotest.(check bool)
-      (repo_cli_identity ^ " root fallback bundle not mounted")
+      (credential_identity ^ " root fallback bundle not mounted")
       false
       (contains_substring line (repo_cli_config_mount_spec root_repo_cli_dir));
     Alcotest.(check bool)
-      (repo_cli_identity ^ " sibling keeper bundle not mounted")
+      (credential_identity ^ " sibling keeper bundle not mounted")
       false
       (contains_substring line (repo_cli_config_mount_spec other_repo_cli));
     Alcotest.(check bool)
-      (repo_cli_identity ^ " own playground mounted")
+      (credential_identity ^ " own playground mounted")
       true
       (contains_substring line
          (mounted_playground ^ ":"
@@ -1967,12 +1922,12 @@ let test_git_creds_mounts_only_selected_keeper_identity () =
   in
   let line_a =
     run_for ~meta:meta_a ~playground:playground_a
-      ~repo_cli_identity:identity_a ~other_identity:identity_b
+      ~credential_identity:identity_a ~other_identity:identity_b
       ~log_name:"docker-a.log"
   in
   let line_b =
     run_for ~meta:meta_b ~playground:playground_b
-      ~repo_cli_identity:identity_b ~other_identity:identity_a
+      ~credential_identity:identity_b ~other_identity:identity_a
       ~log_name:"docker-b.log"
   in
   Alcotest.(check bool) "keeper A docker run does not mount keeper B playground"
@@ -2402,11 +2357,8 @@ let () =
             "git-creds mounts passwd entry for numeric uid"
             `Quick test_git_creds_mounts_numeric_user_identity;
           Alcotest.test_case
-            "git-creds respects keeper_alias git identity mode"
-            `Quick test_git_creds_respects_keeper_alias_identity_mode;
-          Alcotest.test_case
-            "git-creds uses forge author only in repo_cli_identity mode"
-            `Quick test_git_creds_uses_configured_identity_mode;
+            "git-creds uses mapped credential identity"
+            `Quick test_git_creds_uses_mapped_credential_identity;
           Alcotest.test_case
             "git-creds mounts only the selected keeper identity"
             `Quick test_git_creds_mounts_only_selected_keeper_identity;

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -453,8 +453,6 @@ proactive_enabled = true
 proactive_idle_sec = 300
 proactive_cooldown_sec = 60
 autoboot_enabled = false
-repo_cli_identity = "anyang-keepers"
-git_identity_mode = "keeper_alias"
 active_goal_ids = ["goal-runtime", "goal-masc-mcp"]
 |} in
   match TL.parse_toml input with
@@ -471,10 +469,6 @@ active_goal_ids = ["goal-runtime", "goal-masc-mcp"]
       check int "mention_targets" 2 (List.length d.mention_targets);
       check (option bool) "proactive" (Some true) d.proactive_enabled;
       check (option bool) "autoboot_enabled" (Some false) d.autoboot_enabled;
-      check (option string) "repo_cli_identity" (Some "anyang-keepers")
-        d.repo_cli_identity;
-      check (option string) "git_identity_mode" (Some "keeper_alias")
-        d.git_identity_mode;
       check (option (list string)) "active_goal_ids"
         (Some [ "goal-runtime"; "goal-masc-mcp" ])
         d.active_goal_ids
@@ -494,21 +488,6 @@ proactive_idle_sec = 120
        | Error msg ->
            check bool "mentions missing cooldown" true
              (contains_substring msg "proactive_cooldown_sec is missing"))
-
-let test_profile_rejects_invalid_git_identity_mode () =
-  let input = {|
-[keeper]
-goal = "test"
-git_identity_mode = "hot_switch"
-|} in
-  match TL.parse_toml input with
-  | Error e -> fail e
-  | Ok doc ->
-      (match KTP.profile_defaults_of_toml doc with
-       | Ok _ -> fail "expected invalid git_identity_mode error"
-       | Error msg ->
-           check bool "mentions invalid git_identity_mode" true
-             (contains_substring msg "invalid git_identity_mode"))
 
 let test_profile_rejects_invalid_social_model () =
   let input = {|
@@ -649,8 +628,6 @@ let test_load_keeper_toml_inherits_base_defaults () =
 runtime_id = "route.keeper_turn"
 sandbox_profile = "docker"
 network_mode = "inherit"
-repo_cli_identity = "anyang-keepers"
-git_identity_mode = "repo_cli_identity"
 |};
       write_file child_path {|
 [keeper]
@@ -669,10 +646,6 @@ persona_name = "sangsu"
             (Option.map KTP.sandbox_profile_to_string defaults.sandbox_profile);
           check (option string) "base network" (Some "inherit")
             (Option.map KTP.network_mode_to_string defaults.network_mode);
-          check (option string) "base github identity"
-            (Some "anyang-keepers") defaults.repo_cli_identity;
-          check (option string) "base git identity mode"
-            (Some "repo_cli_identity") defaults.git_identity_mode;
           ())
 
 (* ================================================================ *)
@@ -1193,7 +1166,7 @@ let test_persona_resolver_renders_durable_keeper_toml () =
               check (option (list string)) "allowed_paths"
                 (Some [ "/tmp/probe" ]) defaults.allowed_paths;
               check (option (list string)) "tool_access"
-                (Some [ "masc_status" ]) defaults.tool_custom_list;
+                (Some [ "masc_status" ]) defaults.tool_access;
               check (option (list string)) "tool_denylist"
                 (Some [ "masc_keeper_reset" ]) defaults.tool_denylist))
 
@@ -1411,8 +1384,6 @@ goal = "canonical"
 mention_targets = ["a", "b"]
 autoboot_enabled = false
 runtime_id = "primary"
-repo_cli_identity = "anyang-keepers"
-git_identity_mode = "keeper_alias"
 active_goal_ids = ["goal-runtime"]
 |} in
   match TL.parse_toml input with
@@ -1879,8 +1850,6 @@ let () =
             test_profile_rejects_partial_proactive_interval_pair;
           test_case "rejects invalid social_model" `Quick
             test_profile_rejects_invalid_social_model;
-          test_case "rejects invalid git_identity_mode" `Quick
-            test_profile_rejects_invalid_git_identity_mode;
           test_case "rejects removed model keys" `Quick
             test_profile_rejects_removed_model_keys;
           test_case "rejects removed initiative keys" `Quick

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -784,13 +784,6 @@ let test_snapshot_pending_confirm_summary_tracks_actor_scope () =
            (fun row ->
              Yojson.Safe.Util.(row |> member "action_type" |> to_string) = "namespace_pause")
            confirm_required_actions);
-      let retired_identity_login_prepare = "repo_cli_identity_" ^ "login_prepare" in
-      Alcotest.(check bool) "root repo CLI identity login prepare removed" false
-        (List.exists
-           (fun row ->
-             Yojson.Safe.Util.(row |> member "action_type" |> to_string)
-             = retired_identity_login_prepare)
-           confirm_required_actions);
       Alcotest.(check bool) "keeper recover listed" true
         (List.exists
            (fun row ->

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -335,17 +335,7 @@ let test_remote_operator_action_schema_is_strict () =
                   (List.mem (`String "keeper_recover") enums);
                 Alcotest.(check bool) (label ^ " includes keeper_message") true
                   (List.mem (`String "keeper_message") enums);
-                let retired_identity_login_prepare =
-                  "repo_cli_identity_" ^ "login_prepare"
-                in
-                let retired_identity_status = "repo_cli_identity_" ^ "status" in
-                Alcotest.(check bool)
-                  (label ^ " excludes retired repo CLI identity login prepare")
-                  false
-                  (List.mem (`String retired_identity_login_prepare) enums);
-                Alcotest.(check bool)
-                  (label ^ " excludes retired repo CLI identity status") false
-                  (List.mem (`String retired_identity_status) enums)
+                ()
             | _ -> Alcotest.failf "%s action_type missing enum" label)
        | _ -> Alcotest.failf "%s action_type missing" label)
   | None -> Alcotest.failf "%s masc_operator_action missing properties" label


### PR DESCRIPTION
## Summary
- remove keeper profile `repo_cli_identity` / `git_identity_mode` and `tool_custom_list` remnants
- make keeper repo credential binding depend only on repo mapping / credential store data
- remove sandbox-dependent keeper turn-up defaulting and validation paths
- remove dashboard/runtime JSON proof fields for git credential enablement, identity materialization, credential fallback disablement, and git egress labels

## Verification
- `rg -n "repo_cli_identity|git_identity_mode|configured_repo_cli_identity|tool_custom_list|root_repo_cli_identity|effective_repo_cli_identity|git_credentials_enabled|credential_fallbacks_disabled|git_egress|repo_cli_identity_materialized|credential_identity_materialized|tool_access\\.kind|tool_access: \\{ kind|tool_preset|tool_also_allow|tool_custom_allowlist" lib test config dashboard/src scripts --glob '!dashboard/design-system/**' --glob '!dashboard/pnpm-lock.yaml'` (clean)
- `git diff --check origin/main..HEAD`
- `python3 -m py_compile scripts/audit-keeper-fleet-readiness.py test/test_audit_keeper_fleet_readiness.py`
- `python3 test/test_audit_keeper_fleet_readiness.py`
- `ruff check scripts/audit-keeper-fleet-readiness.py test/test_audit_keeper_fleet_readiness.py`
- `pyright --outputjson scripts/audit-keeper-fleet-readiness.py test/test_audit_keeper_fleet_readiness.py`

## Local caveats
- Dashboard vitest was not run because this worktree does not have `dashboard/node_modules/.bin/vitest`.
- Local Dune hook/build hit stale `_build/default` / `agent_sdk` CMI inconsistency from shared machine state after the focused source edits; no changed-file OCaml syntax error was observed after the metrics interface fix that is already on main.
