### PR TITLE
Fix persona tool_access default omission

### DIFF
--- a/lib/keeper/agent_tool_persona_runtime.ml
+++ b/lib/keeper/agent_tool_persona_runtime.ml
@@ -81,12 +81,9 @@ let resolved_keeper_args_to_json
     | None -> []
   in
   let tool_policy_field =
-    let tool_access =
-      match tool_access_opt with
-      | Some tool_access -> tool_access
-      | None -> []
-    in
-    [("tool_access", tool_access_to_json tool_access)]
+    match tool_access_opt with
+    | Some tool_access -> [("tool_access", tool_access_to_json tool_access)]
+    | None -> []
   in
   let shards_field =
     match shards with

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -890,7 +890,7 @@ runtime_id = "oas-coding_first"
          (Some "oas-coding_first")
          defaults.model)
 
-let test_persona_resolver_defaults_to_empty_tool_access () =
+let test_persona_resolver_omits_unspecified_tool_access () =
   with_personas_dir @@ fun personas_dir ->
   let persona_dir = Filename.concat personas_dir "probe" in
   mkdir_p persona_dir;
@@ -912,10 +912,8 @@ let test_persona_resolver_defaults_to_empty_tool_access () =
   | Ok (_, resolved) ->
       let tool_access = Yojson.Safe.Util.member "tool_access" resolved in
       (match tool_access with
-       | `List items ->
-           check int "persona default tool_access is empty" 0
-             (List.length items)
-       | _ -> fail "persona default tool_access should be a list")
+       | `Null -> ()
+       | _ -> fail "unspecified tool_access should be omitted")
 
 let test_persona_resolver_rejects_operator_todo_profile () =
   with_personas_dir @@ fun personas_dir ->
@@ -1925,8 +1923,8 @@ let () =
           test_case "with files" `Quick test_discover_with_files;
           test_case "nonexistent dir" `Quick test_discover_nonexistent_dir;
           test_case "skips bad files" `Quick test_discover_skips_bad_files;
-          test_case "persona resolver defaults to empty tool_access" `Quick
-            test_persona_resolver_defaults_to_empty_tool_access;
+          test_case "persona resolver omits unspecified tool_access" `Quick
+            test_persona_resolver_omits_unspecified_tool_access;
           test_case "persona resolver rejects OPERATOR_TODO profile" `Quick
             test_persona_resolver_rejects_operator_todo_profile;
           test_case "persona resolver reports placeholder defaults source" `Quick


### PR DESCRIPTION
## Summary
- Follow up on #19725 review: omit `tool_access` from resolved persona args when it was not explicitly provided.
- Preserve persona/downstream defaults instead of serializing `tool_access = []`.
- Update the keeper TOML regression test to assert omitted `tool_access`.

## Validation
- `ocamlformat --check lib/keeper/agent_tool_persona_runtime.ml test/test_keeper_toml.ml`
- `git diff --check HEAD~1..HEAD`
- `rg -n "<<<<<<<|>>>>>>>|^=======$|^\|\|\|\|\|\|\|" lib/keeper/agent_tool_persona_runtime.ml test/test_keeper_toml.ml` returned no matches
- Earlier same patch before main-based cherry-pick: `scripts/dune-local.sh build test/test_keeper_toml.exe` and `./_build/default/test/test_keeper_toml.exe` passed 96 tests

Note: re-running focused Dune in this new worktree was blocked by unrelated machine-wide bare Dune lock holders.