### PR TITLE
fix: expose keeper parse rejection split

### DIFF
--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -82,46 +82,33 @@ let is_transient_network_error (err : Agent_sdk.Error.sdk_error) : bool =
     eligible for same-turn retry.  They ARE eligible for auto-recovery
     when all committed tools are reconcile-safe (idempotent/board-like):
     the keeper's next heartbeat cycle will build a fresh prompt. *)
-let is_server_rejected_parse_error (err : Agent_sdk.Error.sdk_error) : bool =
+let server_parse_rejection_message_matches message =
+  let lower = String.lowercase_ascii message in
+  (* Compound patterns to avoid false positives on generic messages
+     like "Service closing" or "Can't find the specified tool".
+     Each pattern targets a specific JSON parser error family. *)
+  (string_contains_substring ~needle:"can't find closing" lower
+   || string_contains_substring ~needle:"find end of" lower)
+  || string_contains_substring ~needle:"unexpected character in json" lower
+  || string_contains_substring ~needle:"unterminated" lower
+  || string_contains_substring ~needle:"parse error" lower
+
+let is_provider_rejected_parse_error (err : Agent_sdk.Error.sdk_error) : bool =
   match err with
   | Agent_sdk.Error.Provider (Llm_provider.Error.ParseError _) -> true
-  | Agent_sdk.Error.Api (InvalidRequest { message }) ->
-      let lower = String.lowercase_ascii message in
-      (* Compound patterns to avoid false positives on generic messages
-         like "Service closing" or "Can't find the specified tool".
-         Each pattern targets a specific JSON parser error family. *)
-      (string_contains_substring ~needle:"can't find closing" lower
-       || string_contains_substring ~needle:"find end of" lower)
-      || string_contains_substring ~needle:"unexpected character in json" lower
-      || string_contains_substring ~needle:"unterminated" lower
-      || string_contains_substring ~needle:"parse error" lower
   | Agent_sdk.Error.Provider
       (Llm_provider.Error.InvalidRequest { reason; _ }) ->
-      let lower = String.lowercase_ascii reason in
-      (string_contains_substring ~needle:"can't find closing" lower
-       || string_contains_substring ~needle:"find end of" lower)
-      || string_contains_substring ~needle:"unexpected character in json" lower
-      || string_contains_substring ~needle:"unterminated" lower
-      || string_contains_substring ~needle:"parse error" lower
-  (* All other API error variants do not represent server-side parse failures. *)
-  | Agent_sdk.Error.Api (RateLimited _)
-  | Agent_sdk.Error.Api (Overloaded _)
-  | Agent_sdk.Error.Api (ServerError _)
-  | Agent_sdk.Error.Api (AuthError _)
-  | Agent_sdk.Error.Api (NotFound _)
-  | Agent_sdk.Error.Api (ContextOverflow _)
-  | Agent_sdk.Error.Api (NetworkError _)
-  | Agent_sdk.Error.Api (Timeout _) -> false
-  (* Non-API error families. *)
-  | Agent_sdk.Error.Provider _
-  | Agent_sdk.Error.Agent _
-  | Agent_sdk.Error.Mcp _
-  | Agent_sdk.Error.Config _
-  | Agent_sdk.Error.Serialization _
-  | Agent_sdk.Error.Io _
-  | Agent_sdk.Error.Orchestration _
-  | Agent_sdk.Error.A2a _
-  | Agent_sdk.Error.Internal _ -> false
+      server_parse_rejection_message_matches reason
+  | _ -> false
+
+let is_model_rejected_parse_error (err : Agent_sdk.Error.sdk_error) : bool =
+  match err with
+  | Agent_sdk.Error.Api (InvalidRequest { message }) ->
+      server_parse_rejection_message_matches message
+  | _ -> false
+
+let is_server_rejected_parse_error (err : Agent_sdk.Error.sdk_error) : bool =
+  is_provider_rejected_parse_error err || is_model_rejected_parse_error err
 
 let is_required_tool_contract_violation (err : Agent_sdk.Error.sdk_error) : bool =
   match err with

--- a/lib/keeper/keeper_error_classify.mli
+++ b/lib/keeper/keeper_error_classify.mli
@@ -13,15 +13,14 @@ val is_transient_network_error : Agent_sdk.Error.sdk_error -> bool
     not a transport-level timeout. *)
 val is_structural_oas_timeout_message : string -> bool
 
-(** Detect server-side request body parse errors (e.g. Ollama yyjson
-    rejecting a malformed request body).  The LLM never
-    processed the request, so committed tool results are not at risk
-    of duplication.  Used to auto-recover reconcile-safe tools instead
-    of requiring manual reconcile. *)
+(** Detect request body parse errors from either the provider or the API
+    (e.g. Ollama yyjson rejecting a malformed request body or the API
+    rejecting invalid JSON).  The LLM never processed the request, so
+    committed tool results are not at risk of duplication.  Used to
+    auto-recover reconcile-safe tools instead of requiring manual reconcile. *)
 val is_server_rejected_parse_error : Agent_sdk.Error.sdk_error -> bool
 
-(** [true] for provider/client-side request serialization or provider
-    request-body parse rejections. *)
+(** [true] for provider-side request-body parse rejections. *)
 val is_provider_rejected_parse_error : Agent_sdk.Error.sdk_error -> bool
 
 (** [true] for model/API-side request-body parse rejections reported as

--- a/lib/keeper/keeper_error_classify.mli
+++ b/lib/keeper/keeper_error_classify.mli
@@ -20,6 +20,14 @@ val is_structural_oas_timeout_message : string -> bool
     of requiring manual reconcile. *)
 val is_server_rejected_parse_error : Agent_sdk.Error.sdk_error -> bool
 
+(** [true] for provider/client-side request serialization or provider
+    request-body parse rejections. *)
+val is_provider_rejected_parse_error : Agent_sdk.Error.sdk_error -> bool
+
+(** [true] for model/API-side request-body parse rejections reported as
+    [InvalidRequest]. *)
+val is_model_rejected_parse_error : Agent_sdk.Error.sdk_error -> bool
+
 (** [true] when the provider/tooling violated a required tool-use contract
     by returning text/no-op where a ToolUse block was required. *)
 val is_required_tool_contract_violation : Agent_sdk.Error.sdk_error -> bool

--- a/test/test_keeper_sdk_error_typed_bridge.ml
+++ b/test/test_keeper_sdk_error_typed_bridge.ml
@@ -16,6 +16,7 @@
 
 module AE = Masc_mcp.Keeper_agent_error
 module Code = Masc_mcp.Keeper_turn_terminal_code
+module EC = Masc_mcp.Keeper_error_classify
 module SdkE = Agent_sdk.Error
 module Retry = Agent_sdk.Retry
 module Http = Llm_provider.Http_client
@@ -111,6 +112,44 @@ let test_sdk_typed_wire () =
     sdk_cases
 ;;
 
+let check_parse_split label err ~provider ~model_ ~server =
+  Alcotest.(check bool)
+    (label ^ "/provider")
+    provider
+    (EC.is_provider_rejected_parse_error err);
+  Alcotest.(check bool) (label ^ "/model") model_ (EC.is_model_rejected_parse_error err);
+  Alcotest.(check bool) (label ^ "/server") server (EC.is_server_rejected_parse_error err)
+;;
+
+let test_server_parse_rejection_split () =
+  check_parse_split
+    "provider_parse_error"
+    (SdkE.Provider (Llm_provider.Error.ParseError { detail = "yyjson rejected body" }))
+    ~provider:true
+    ~model_:false
+    ~server:true;
+  check_parse_split
+    "provider_invalid_request_parse_error"
+    (SdkE.Provider
+       (Llm_provider.Error.InvalidRequest
+          { provider = "agent_llm_a"; reason = "unexpected character in JSON at byte 9" }))
+    ~provider:true
+    ~model_:false
+    ~server:true;
+  check_parse_split
+    "api_invalid_request_parse_error"
+    (SdkE.Api (Retry.InvalidRequest { message = "unexpected character in JSON at byte 9" }))
+    ~provider:false
+    ~model_:true
+    ~server:true;
+  check_parse_split
+    "api_invalid_request_generic"
+    (SdkE.Api (Retry.InvalidRequest { message = "missing required field: model" }))
+    ~provider:false
+    ~model_:false
+    ~server:false
+;;
+
 let () =
   Alcotest.run
     "keeper_sdk_error_typed_bridge"
@@ -125,6 +164,12 @@ let () =
             "all sdk_error cases produce expected wire"
             `Quick
             test_sdk_typed_wire
+        ] )
+    ; ( "server parse rejection split"
+      , [ Alcotest.test_case
+            "provider and model parse rejections remain distinguishable"
+            `Quick
+            test_server_parse_rejection_split
         ] )
     ]
 ;;


### PR DESCRIPTION
Post-merge follow-up for #19726 review feedback.\n\nChanges:\n- expose provider/model parse rejection helpers on Keeper_error_classify\n- keep combined server parse rejection behavior for provider OR model errors\n- add regression coverage in test_keeper_sdk_error_typed_bridge\n\nValidation:\n- git diff --check HEAD~1..HEAD\n- ocamlformat --check lib/keeper/keeper_error_classify.ml lib/keeper/keeper_error_classify.mli test/test_keeper_sdk_error_typed_bridge.ml\n- scripts/check-oas-pin.sh --local-only\n- scripts/dune-local.sh build test/test_keeper_sdk_error_typed_bridge.exe: blocked by shared /tmp/me-dune-local.lock