### PR TITLE
[codex] Treat telemetry coverage gaps as active-only

### DIFF
--- a/docs/KEEPER-SANDBOX-BOUNDARY-POLICY.md
+++ b/docs/KEEPER-SANDBOX-BOUNDARY-POLICY.md
@@ -72,6 +72,12 @@ failure just because a keeper uses the Docker backend.
   back from decision telemetry to the latest receipt model. Public dashboards
   may keep provider/model lanes redacted, but keeper operator surfaces must show
   either observed attribution or a typed runtime/provider blocker.
+- Telemetry coverage gaps are historical evidence, not permanent health
+  latches. Dashboard source health may report `coverage_gap` only for active
+  gaps: a gap is active until the same source has a durable row with a timestamp
+  equal to or newer than the gap timestamp. Summary payloads must keep
+  historical `coverage_gap_count` visible and expose
+  `active_coverage_gap_count` for current health decisions.
 - Command semantics may only interpret commands accepted by the typed
   bash subset parser. Unsupported shell constructs fail closed and must
   not be reinterpreted with space splitting or fallback token scans.
@@ -84,6 +90,8 @@ Focused behavioral tests verify path and command behavior:
 - `test_keeper_effective_meta_overlay`
 - `test_keeper_runtime_trust_snapshot`
 - `test_runtime_provider_auth_headers`
+- `test_telemetry_unified` recovered coverage-gap summary test
+- `test_keeper_tool_call_log` recovered tool-call coverage-gap aggregate test
 - `test_keeper_sandbox_docker_route`
 
 Source-level boundary tests prevent regressions in layer ownership:
@@ -123,3 +131,5 @@ The boundary test intentionally fails if:
 - completed or partial-completed runtime turns stop producing terminal runtime
   observation for receipts, or runtime-trust status stops surfacing receipt
   `runtime.selected_model` when decision telemetry is absent.
+- recovered historical telemetry coverage gaps force source health to remain
+  `coverage_gap` after a newer durable row exists for that source.

--- a/docs/audit/2026-06-01-keeper-boundary-runtime-report.html
+++ b/docs/audit/2026-06-01-keeper-boundary-runtime-report.html
@@ -164,7 +164,7 @@
         <div class="card">
           <h3>Tool Surface</h3>
           <p><span class="badge warn">PARTIAL</span></p>
-          <p>Keeper는 도구를 실제로 보고 실행한다. Echo/Analyst 모두 allowed tools 39개, 최근 receipt는 `satisfied_execution`이다. 하지만 `tool_usage`, `tool_call_io`, `trajectory`, `execution_receipt` telemetry에는 coverage gap이 남아 있다.</p>
+          <p>Keeper는 도구를 실제로 보고 실행한다. Echo/Analyst 모두 allowed tools 39개, 최근 receipt는 `satisfied_execution`이다. Historical coverage gap이 현재 health를 계속 붙잡는 판정 버그는 active-gap 기준으로 패치됐다. live runtime 반영 후 `tool_call_io`, `trajectory_tool_call`, `execution_receipt`는 최신 성공 row가 과거 gap보다 새로우면 `ok`로 회복되어야 한다.</p>
         </div>
         <div class="card">
           <h3>Model Runtime</h3>
@@ -214,8 +214,8 @@
           </tr>
           <tr>
             <td>`/api/v1/dashboard/telemetry/summary`</td>
-            <td>`tool_call_io`, `trajectory_tool_call`, `tool_usage`, `execution_receipt` show coverage gaps; `oas_event` is ok.</td>
-            <td>Runtime/tool evidence is being produced in places, but durable dashboard observability is incomplete.</td>
+            <td>Before this slice, `tool_call_io`, `trajectory_tool_call`, `tool_usage`, `execution_receipt` showed coverage gaps even when newer successful rows existed; `oas_event` was ok.</td>
+            <td>Dashboard summary now separates historical `coverage_gap_count` from `active_coverage_gap_count`; only active gaps can force source health to `coverage_gap`.</td>
           </tr>
           <tr>
             <td>`masc_keeper_persona_audit(include_ok=false)`</td>
@@ -318,8 +318,8 @@
       <div class="finding good">
         <strong>Finding T1:</strong> Tools are not simply missing. Echo and Analyst can see and execute tools; recent receipts show `satisfied_execution` and descriptor route evidence.
       </div>
-      <div class="finding critical">
-        <strong>Finding T2:</strong> Tool observability is not green. `tool_usage_append_failed`, `tool_call_io_append_failed`, `trajectory_append_failed`, and `execution_receipt_append_failed` mean dashboard-level proof is incomplete.
+      <div class="finding warn">
+        <strong>Finding T2:</strong> Tool observability had stale red health. `tool_usage_append_failed`, `tool_call_io_append_failed`, `trajectory_append_failed`, and `execution_receipt_append_failed` remain retained as historical evidence, but dashboard health now treats them as active only until a newer durable source row proves recovery.
       </div>
 
       <h3>3. Model-Provider Runtime Path</h3>
@@ -422,7 +422,7 @@
         <li><strong>Stabilize commit truth.</strong> Bring root checkout to current `origin/main`, rebuild/restart once, and require `/health?full=1` to report the same commit as `git rev-parse origin/main`. Do not evaluate Keeper behavior while runtime is warming or flapping.</li>
         <li><strong>Repair fleet boot first.</strong> After restart, wait one startup window. If `keeper_fibers=0`, inspect supervisor startup logs and meta decode errors. Acceptance: `keeper_fleet_safety.status` is `ok` or a bounded degraded state with named keepers, not `no_executable_keeper_fibers`.</li>
         <li><strong>Converge sandbox truth.</strong> Make `masc_keeper_sandbox_status`, `masc_keeper_status.policy`, `runtime_trust.runtime_contract`, and receipt sandbox summary read the same overlay source. Acceptance: Analyst TOML docker yields status docker and receipt docker, or an explicit local override is shown with source.</li>
-        <li><strong>Lock tool surface evidence.</strong> Treat descriptor route evidence as canonical and fix coverage gap appenders. Acceptance: `tool_usage`, `tool_call_io`, `trajectory_tool_call`, and `execution_receipt` are `ok` or carry a fresh, actionable error with one failing source.</li>
+        <li><strong>Lock tool surface evidence.</strong> Treat descriptor route evidence as canonical and make coverage gap health active-only. Acceptance: `tool_usage`, `tool_call_io`, `trajectory_tool_call`, and `execution_receipt` are `ok` or carry `active_coverage_gap_count &gt; 0` with a fresh, actionable error for the failing source.</li>
         <li><strong>Make runtime identity observable.</strong> Add internal-safe provider/model attribution to runtime observation and receipt. Public dashboards may keep redacted runtime lanes, but Keeper status must say either `verified=true` with source or a concrete provider blocker. Acceptance: one controlled turn produces non-null runtime observation or a named failure class.</li>
         <li><strong>Clean persona/fleet drift.</strong> Remove stale active goal IDs, restore missing registry entries, decide whether `tech_glutton` should stay paused, and create or remove missing `base` runtime meta. Acceptance: `masc_keeper_persona_audit(include_ok=false)` returns only intentional issues.</li>
         <li><strong>Clean docs/routes.</strong> Update stale capacity/dashboard route docs after the live route sweep. Acceptance: docs do not point operators to 404/410 endpoints for runtime capacity or dashboard batch state.</li>
@@ -468,9 +468,9 @@
 	          </tr>
 	          <tr>
 	            <td>Telemetry append gaps</td>
-	            <td><span class="badge warn">remaining</span></td>
-	            <td>No telemetry appender repair in this slice.</td>
-	            <td>`tool_usage`, `tool_call_io`, `trajectory_tool_call`, and `execution_receipt` need fresh ok status or a single actionable append error.</td>
+	            <td><span class="badge good">patched</span></td>
+	            <td>`Telemetry_unified.summary_json`, `Dashboard_tool_source_freshness`, and `Tool_usage_log.source_metadata_json` now keep historical `coverage_gaps` visible while filtering health through active gaps only. A source row whose timestamp is equal to or newer than the gap timestamp proves recovery; source summaries expose `coverage_gap_count` and `active_coverage_gap_count`. Regression tests cover recovered `tool_call_io` summary and tool-quality aggregate behavior.</td>
+	            <td>After rebuild/restart, `/api/v1/dashboard/telemetry/summary` should report `active_coverage_gap_count=0` for recovered lanes. If a lane still reports `coverage_gap`, the gap must be newer than the latest durable source row and include the single actionable append error.</td>
 	          </tr>
 	        </tbody>
 	      </table>
@@ -484,7 +484,7 @@ curl -fsS 'http://127.0.0.1:8935/health?full=1' | jq '{build, keeper_fibers, kee
 masc_keeper_sandbox_status(name="analyst", include_preflight=true)
 masc_keeper_status(name="analyst", fast=true)
 masc_keeper_status(name="echo", fast=true)
-curl -fsS 'http://127.0.0.1:8935/api/v1/dashboard/telemetry/summary' | jq '.sources[] | {source, health, stale_reason, latest_ts_iso}'
+curl -fsS 'http://127.0.0.1:8935/api/v1/dashboard/telemetry/summary' | jq '.sources[] | {source, health, stale_reason, latest_ts_iso, coverage_gap_count, active_coverage_gap_count}'
 curl -fsS 'http://127.0.0.1:8935/api/v1/models/metrics' | jq '{total_entries,total_error_entries,models}'
 masc_keeper_persona_audit(include_ok=false)</pre>
       <p>Pass condition: source commit truth stable, keeper fibers executable, sandbox surfaces converged, tool telemetry gap closed or sharply explained, runtime model observation verified or explicitly blocked.</p>

--- a/lib/dashboard_tool_source_freshness.ml
+++ b/lib/dashboard_tool_source_freshness.ml
@@ -67,6 +67,16 @@ let freshness_fields ~now latest_ts =
       ("latest_age_s", `Null);
     ]
 
+let coverage_gap_recovered ~latest_ts gap =
+  match latest_ts, latest_ts_of_record gap with
+  | Some source_ts, Some gap_ts when Stdlib.Float.compare source_ts gap_ts >= 0
+    ->
+    true
+  | _ -> false
+
+let active_coverage_gaps ~latest_ts gaps =
+  List.filter (fun gap -> not (coverage_gap_recovered ~latest_ts gap)) gaps
+
 let health_fields ~now ~exists ~entry_count ~latest_ts ~freshness_slo_s
     ?coverage_gap () =
   let health, stale_reason =
@@ -111,7 +121,10 @@ let metadata_fields ~source_name ~source_producer ~dashboard_surface
     if exists then Option.bind latest_record latest_ts_of_record else None
   in
   let coverage_gaps = coverage_gaps_for_store ~source_name ~durable_store in
-  let coverage_gap = List.rev coverage_gaps |> List.find_opt (fun _ -> true) in
+  let active_coverage_gaps = active_coverage_gaps ~latest_ts coverage_gaps in
+  let coverage_gap =
+    List.rev active_coverage_gaps |> List.find_opt (fun _ -> true)
+  in
   [
     ("source", `String source_name);
     ("producer", `String source_producer);
@@ -122,6 +135,7 @@ let metadata_fields ~source_name ~source_producer ~dashboard_surface
     ("exists", `Bool exists);
     ("coverage_gaps", `List coverage_gaps);
     ("coverage_gap_count", `Int (List.length coverage_gaps));
+    ("active_coverage_gap_count", `Int (List.length active_coverage_gaps));
   ]
   @ freshness_fields ~now latest_ts
   @ health_fields ~now ~exists ~entry_count ~latest_ts ~freshness_slo_s

--- a/lib/dashboard_tool_source_freshness.mli
+++ b/lib/dashboard_tool_source_freshness.mli
@@ -67,6 +67,18 @@ val health_fields :
     The empty-string [stale_reason] for healthy sources renders
     as [`Null] (Null-vs-missing pattern preserved per cycle 69). *)
 
+val coverage_gap_recovered : latest_ts:float option -> Yojson.Safe.t -> bool
+(** [coverage_gap_recovered ~latest_ts gap] is [true] when the
+    source has a durable row whose timestamp is equal to or newer
+    than the coverage-gap timestamp. Recovered historical gaps stay
+    visible in [coverage_gaps] but no longer force source health to
+    ["coverage_gap"]. *)
+
+val active_coverage_gaps :
+  latest_ts:float option -> Yojson.Safe.t list -> Yojson.Safe.t list
+(** Filter coverage gaps down to the entries still active for the
+    current source timestamp. *)
+
 val coverage_gaps_for_store :
   source_name:string ->
   durable_store:string ->
@@ -90,8 +102,8 @@ val metadata_fields :
     9 identity / count fields ([source] / [producer] /
     [durable_store] / [dashboard_surface] / [freshness_slo_s] /
     [entry_count] / [exists] / [coverage_gaps] /
-    [coverage_gap_count]), then the {!freshness_fields} triplet,
-    then the {!health_fields} pair.
+    [coverage_gap_count] / [active_coverage_gap_count]), then the
+    {!freshness_fields} triplet, then the {!health_fields} pair.
 
     [now] is captured once at the start of the call so the
     freshness and health computations use the same reference

--- a/lib/telemetry_unified.ml
+++ b/lib/telemetry_unified.ml
@@ -193,14 +193,32 @@ let source_optional_when_missing = function
   | Keeper_metric | Agent_event | Tool_call_io | Trajectory_tool_call
   | Tool_usage | Oas_event | Execution_receipt | Tool_metric -> false
 
-let latest_coverage_gap_for_source gaps source =
+let coverage_gap_recovered ~latest_ts gap =
+  match latest_ts, extract_ts gap with
+  | Some source_ts, gap_ts
+    when gap_ts > 0.0 && Float.compare source_ts gap_ts >= 0 ->
+      true
+  | _ -> false
+
+let coverage_gaps_for_source gaps source =
   let source_name = source_to_string source in
   gaps
-  |> List.rev
-  |> List.find_opt (fun gap ->
+  |> List.filter (fun gap ->
        String.equal
          (Safe_ops.json_string ~default:"" "source" gap)
          source_name)
+
+let active_coverage_gaps ~latest_ts gaps =
+  List.filter (fun gap -> not (coverage_gap_recovered ~latest_ts gap)) gaps
+
+let coverage_gap_status_fields gaps source ~latest_ts =
+  let source_gaps = coverage_gaps_for_source gaps source in
+  let active_gaps = active_coverage_gaps ~latest_ts source_gaps in
+  ( [
+      ("coverage_gap_count", `Int (List.length source_gaps));
+      ("active_coverage_gap_count", `Int (List.length active_gaps));
+    ],
+    List.rev active_gaps |> List.find_opt (fun _ -> true) )
 
 (* ── Semantic duplicate suppression ───────────────── *)
 
@@ -786,7 +804,6 @@ let summary_json ~base_path ~masc_root () : Yojson.Safe.t =
   let source_json_and_count source =
     let freshness_slo_s = source_freshness_slo_s source in
     let metadata_fields = source_metadata_fields ~base_path ~masc_root source in
-    let coverage_gap = latest_coverage_gap_for_source coverage_gaps source in
     let keeper_dir_fields dirs =
       [
         ( "keepers",
@@ -801,6 +818,10 @@ let summary_json ~base_path ~masc_root () : Yojson.Safe.t =
     match source with
     | Keeper_metric ->
       let exists = keeper_dirs <> [] in
+      let coverage_gap_fields, coverage_gap =
+        coverage_gap_status_fields coverage_gaps source
+          ~latest_ts:keeper_latest_ts
+      in
       ( `Assoc
           ([
              ("source", `String (source_to_string source));
@@ -812,8 +833,9 @@ let summary_json ~base_path ~masc_root () : Yojson.Safe.t =
                     keeper_dirs) );
              ("keeper_count", `Int (List.length keeper_dirs));
              ("entry_count", `Int keeper_total);
-           ]
+          ]
           @ metadata_fields
+          @ coverage_gap_fields
           @ freshness_fields ~now keeper_latest_ts
           @ source_health_fields ~now ~exists ~entry_count:keeper_total
               ~latest_ts:keeper_latest_ts ~freshness_slo_s
@@ -844,15 +866,19 @@ let summary_json ~base_path ~masc_root () : Yojson.Safe.t =
         if dir_state = Store_directory then trajectory_tool_call_summary_stats ~masc_root
         else (0, None)
       in
+      let coverage_gap_fields, coverage_gap =
+        coverage_gap_status_fields coverage_gaps source ~latest_ts
+      in
       ( `Assoc
           ([
              ("source", `String (source_to_string source));
              ("path", `String trajectories_root);
              ("exists", `Bool exists);
              ("entry_count", `Int count);
-           ]
+          ]
           @ keeper_dir_fields dirs
           @ metadata_fields
+          @ coverage_gap_fields
           @ freshness_fields ~now latest_ts
           @ source_health_fields ~now ~exists ~entry_count:count ~latest_ts
               ~freshness_slo_s
@@ -878,15 +904,19 @@ let summary_json ~base_path ~masc_root () : Yojson.Safe.t =
         if dir_state = Store_directory then execution_receipt_summary_stats ~masc_root
         else (0, None)
       in
+      let coverage_gap_fields, coverage_gap =
+        coverage_gap_status_fields coverage_gaps source ~latest_ts
+      in
       ( `Assoc
           ([
              ("source", `String (source_to_string source));
              ("path", `String (Filename.concat keepers_root "*/execution-receipts"));
              ("exists", `Bool exists);
              ("entry_count", `Int count);
-           ]
+          ]
           @ keeper_dir_fields dirs
           @ metadata_fields
+          @ coverage_gap_fields
           @ freshness_fields ~now latest_ts
           @ source_health_fields ~now ~exists ~entry_count:count ~latest_ts
               ~freshness_slo_s
@@ -900,14 +930,18 @@ let summary_json ~base_path ~masc_root () : Yojson.Safe.t =
         if exists then goal_event_summary_stats ~masc_root
         else (0, None)
       in
+      let coverage_gap_fields, coverage_gap =
+        coverage_gap_status_fields coverage_gaps source ~latest_ts
+      in
       ( `Assoc
           ([
              ("source", `String (source_to_string source));
              ("path", `String path);
              ("exists", `Bool exists);
              ("entry_count", `Int count);
-           ]
+          ]
           @ metadata_fields
+          @ coverage_gap_fields
           @ freshness_fields ~now latest_ts
           @ source_health_fields ~now ~exists ~entry_count:count ~latest_ts
               ~freshness_slo_s
@@ -939,14 +973,18 @@ let summary_json ~base_path ~masc_root () : Yojson.Safe.t =
           latest_store_ts source dir (source_to_string source)
         else None
       in
+      let coverage_gap_fields, coverage_gap =
+        coverage_gap_status_fields coverage_gaps source ~latest_ts
+      in
       ( `Assoc
           ([
              ("source", `String (source_to_string source));
              ("path", `String dir);
              ("exists", `Bool exists);
              ("entry_count", `Int count);
-           ]
+          ]
           @ metadata_fields
+          @ coverage_gap_fields
           @ freshness_fields ~now latest_ts
           @ source_health_fields ~now ~exists ~entry_count:count ~latest_ts
               ~freshness_slo_s

--- a/lib/tool_usage_log.ml
+++ b/lib/tool_usage_log.ml
@@ -147,6 +147,15 @@ let coverage_gaps masc_root =
 let latest_coverage_gap gaps =
   List.rev gaps |> List.find_opt (fun _ -> true)
 
+let coverage_gap_recovered ~latest_ts gap =
+  match latest_ts, ts_of_record gap with
+  | Some source_ts, Some gap_ts when Float.compare source_ts gap_ts >= 0 ->
+    true
+  | _ -> false
+
+let active_coverage_gaps ~latest_ts gaps =
+  List.filter (fun gap -> not (coverage_gap_recovered ~latest_ts gap)) gaps
+
 let synthetic_store_gap ~durable_store ~stale_reason ~error =
   let now = Time_compat.now () in
   `Assoc
@@ -353,7 +362,8 @@ let source_metadata_json ~masc_root =
     else
       gaps
   in
-  let coverage_gap = latest_coverage_gap coverage_gaps in
+  let active_coverage_gaps = active_coverage_gaps ~latest_ts coverage_gaps in
+  let coverage_gap = latest_coverage_gap active_coverage_gaps in
   `Assoc
     ([
        ("source", `String source_name);
@@ -365,6 +375,7 @@ let source_metadata_json ~masc_root =
        ("exists", `Bool exists);
        ("coverage_gaps", `List coverage_gaps);
        ("coverage_gap_count", `Int (List.length coverage_gaps));
+       ("active_coverage_gap_count", `Int (List.length active_coverage_gaps));
      ]
     @ freshness_fields ~now latest_ts
     @ source_health_fields

--- a/test/test_keeper_tool_call_log.ml
+++ b/test/test_keeper_tool_call_log.ml
@@ -852,6 +852,36 @@ let test_dashboard_aggregate_surfaces_coverage_gap () =
     Alcotest.(check int) "coverage gap count" 1
       (Safe_ops.json_int ~default:0 "coverage_gap_count" summary))
 
+let test_dashboard_aggregate_ignores_recovered_coverage_gap () =
+  with_tmp_log_dir (fun dir ->
+    let masc_root = Filename.concat dir ".masc" in
+    Telemetry_coverage_gap.record
+      ~masc_root
+      ~source:"tool_call_io"
+      ~producer:"keeper_hooks_oas"
+      ~durable_store:(Filename.concat masc_root "tool_calls")
+      ~dashboard_surface:"/api/v1/keepers/:name/tool-calls"
+      ~stale_reason:"tool_call_io_append_failed"
+      ~keeper_name:"k"
+      ~trace_id:"trace-gap"
+      ();
+    Keeper_tool_call_log.log_call
+      ~keeper_name:"k" ~tool_name:"masc_status"
+      ~input:(`Assoc []) ~output_text:"ok"
+      ~success:true ~duration_ms:2.0
+      ~trace_id:"trace-recovered" ();
+    let summary = Dashboard_http_tool_quality.aggregate ~n:10 () in
+    Alcotest.(check (option string)) "recovered gap health"
+      (Some "ok")
+      (Safe_ops.json_string_opt "health" summary);
+    Alcotest.(check (option string)) "recovered gap stale reason cleared"
+      None
+      (Safe_ops.json_string_opt "stale_reason" summary);
+    Alcotest.(check int) "historical gap count" 1
+      (Safe_ops.json_int ~default:0 "coverage_gap_count" summary);
+    Alcotest.(check int) "active gap count" 0
+      (Safe_ops.json_int ~default:(-1) "active_coverage_gap_count" summary))
+
 (* ── UTF-8 sanitization ────────────────────────────── *)
 
 (* Regression guard: tool output may contain invalid UTF-8 bytes from
@@ -1084,6 +1114,8 @@ let () =
             test_append_failure_records_coverage_gap
         ; eio_test "dashboard aggregate surfaces coverage gap"
             test_dashboard_aggregate_surfaces_coverage_gap
+        ; eio_test "dashboard aggregate ignores recovered coverage gap"
+            test_dashboard_aggregate_ignores_recovered_coverage_gap
         ] )
     ; ( "utf8_sanitize",
         [ eio_test "invalid UTF-8 bytes scrubbed before persist"

--- a/test/test_telemetry_unified.ml
+++ b/test/test_telemetry_unified.ml
@@ -1069,6 +1069,52 @@ let test_summary_surfaces_coverage_gaps () =
       (json_string_field "stale_reason" source_summary)
   | _ -> Alcotest.fail "expected Assoc"
 
+let test_summary_ignores_recovered_coverage_gap () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = tmpdir "telem_summary_recovered_gap" in
+  let root = masc_root dir in
+  Telemetry_coverage_gap.record
+    ~masc_root:root
+    ~source:"tool_call_io"
+    ~producer:"keeper_hooks_oas"
+    ~durable_store:(Filename.concat root "tool_calls")
+    ~dashboard_surface:"/api/v1/keepers/:name/tool-calls"
+    ~stale_reason:"tool_call_io_append_failed"
+    ~error:"old fd pressure"
+    ();
+  let recovered_ts = Unix.gettimeofday () +. 10.0 in
+  write_jsonl
+    (Filename.concat root "tool_calls")
+    [
+      `Assoc
+        [
+          ("ts", `Float recovered_ts);
+          ("keeper", `String "alice");
+          ("tool", `String "masc_status");
+          ("success", `Bool true);
+        ];
+    ];
+  let json = Telemetry_unified.summary_json ~base_path:dir ~masc_root:root () in
+  let tool_summary = source_summary "tool_call_io" json in
+  Alcotest.(check string) "recovered gap health" "ok"
+    (json_string_field "health" tool_summary);
+  Alcotest.(check string) "recovered gap stale reason cleared" ""
+    (json_string_field "stale_reason" tool_summary);
+  Alcotest.(check int) "historical gap count" 1
+    (json_int_field "coverage_gap_count" tool_summary);
+  Alcotest.(check int) "active gap count" 0
+    (json_int_field "active_coverage_gap_count" tool_summary);
+  match json with
+  | `Assoc fields ->
+    let gaps =
+      match List.assoc_opt "coverage_gaps" fields with
+      | Some (`List values) -> values
+      | _ -> Alcotest.fail "expected coverage_gaps"
+    in
+    Alcotest.(check int) "historical gap retained" 1 (List.length gaps)
+  | _ -> Alcotest.fail "expected Assoc"
+
 let test_summary_counts_all_entries_beyond_recent_cap () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -1231,6 +1277,8 @@ let () =
             test_summary_includes_trajectory_and_execution_receipt_sources;
           Alcotest.test_case "surfaces coverage gaps" `Quick
             test_summary_surfaces_coverage_gaps;
+          Alcotest.test_case "ignores recovered coverage gaps" `Quick
+            test_summary_ignores_recovered_coverage_gap;
           Alcotest.test_case "goal_event missing reports not_yet" `Quick
             test_goal_event_missing_reports_not_yet;
           Alcotest.test_case "tool_call_io missing stays missing" `Quick


### PR DESCRIPTION
## Summary

- Treat telemetry coverage gaps as active only until the same source records a durable row with an equal or newer timestamp.
- Keep historical coverage-gap evidence visible while adding `active_coverage_gap_count` to source metadata surfaces.
- Update the keeper boundary/runtime audit and sandbox boundary policy with the active-gap health rule.

## Why

The live dashboard was keeping `tool_call_io`, `trajectory_tool_call`, `tool_usage`, and `execution_receipt` red because old May coverage-gap rows were still present, even though several sources had newer successful durable rows. Historical gap rows should remain audit evidence, but they should not permanently latch current source health.

## Validation

- `git diff --check origin/main..HEAD`
- `ocamlformat --check lib/dashboard_tool_source_freshness.ml lib/dashboard_tool_source_freshness.mli lib/tool_usage_log.ml lib/telemetry_unified.ml test/test_telemetry_unified.ml test/test_keeper_tool_call_log.ml`

Focused Dune compile was attempted with `scripts/dune-local.sh build test/test_telemetry_unified.exe test/test_keeper_tool_call_log.exe`, but local verification was blocked by existing bare/long-running Dune processes and the machine-wide Dune lock. The branch is draft for CI validation.