### PR TITLE
[codex] fix keeper idle timeout duplicate arms

### DIFF
--- a/lib/keeper/keeper_agent_error.ml
+++ b/lib/keeper/keeper_agent_error.ml
@@ -84,8 +84,6 @@ let sdk_termination_semantics = function
   | Agent_sdk.Error.Agent (Agent_sdk.Error.AgentExecutionTimeout _)
   | Agent_sdk.Error.Agent (Agent_sdk.Error.AgentExecutionIdleTimeout _) ->
     Oas_agent_execution_timeout
-  | Agent_sdk.Error.Agent (Agent_sdk.Error.AgentExecutionIdleTimeout _) ->
-    Oas_agent_execution_timeout
   | Agent_sdk.Error.Agent (Agent_sdk.Error.MaxTurnsExceeded _) ->
     Oas_turn_budget_exhausted
   | Agent_sdk.Error.Agent (Agent_sdk.Error.IdleDetected _) ->

--- a/lib/keeper/keeper_status_bridge_blocker.ml
+++ b/lib/keeper/keeper_status_bridge_blocker.ml
@@ -52,8 +52,6 @@ let blocker_class_of_sdk_error (err : Agent_sdk.Error.sdk_error) : blocker_class
      | Agent_sdk.Error.Agent (Agent_sdk.Error.AgentExecutionTimeout _)
      | Agent_sdk.Error.Agent (Agent_sdk.Error.AgentExecutionIdleTimeout _) ->
        Some Oas_agent_execution_timeout
-     | Agent_sdk.Error.Agent (Agent_sdk.Error.AgentExecutionIdleTimeout _) ->
-       Some Oas_agent_execution_timeout
      | Agent_sdk.Error.Agent (MaxTurnsExceeded _) -> Some Sdk_max_turns_exceeded
      | Agent_sdk.Error.Agent (TokenBudgetExceeded _) -> Some Sdk_token_budget_exceeded
      | Agent_sdk.Error.Agent (CostBudgetExceeded _) -> Some Sdk_cost_budget_exceeded


### PR DESCRIPTION
## Summary
- remove duplicate AgentExecutionIdleTimeout match arms in keeper SDK error classification
- keep timeout and idle-timeout semantics mapped to Oas_agent_execution_timeout

## Root cause
A duplicated AgentExecutionIdleTimeout arm became unreachable after the timeout cases were grouped, and OCaml warning 11 is treated as an error.

## Validation
- scripts/check-oas-pin.sh --local-only: passed, OAS main@10a5024e0b1d5b4bb9d272eccb5051dead5421c4 / v0.200.7
- ocamlformat --check lib/keeper/keeper_status_bridge_blocker.ml lib/keeper/keeper_agent_error.ml: passed
- scripts/dune-local.sh build .: running locally; PR opened draft while it completes