### PR TITLE
ci: harden ocamlformat dependency fetch

### DIFF
--- a/.github/workflows/ocamlformat.yml
+++ b/.github/workflows/ocamlformat.yml
@@ -108,7 +108,7 @@ jobs:
             done
             opam install -y "${fmt_pkgs[@]}"
           }
-          install_from_opam_archives || install_from_git_tags
+          if ! install_from_opam_archives; then install_from_git_tags; fi
 
       - name: Check formatting (changed files only)
         if: steps.changed.outputs.no_files != 'true'

--- a/.github/workflows/ocamlformat.yml
+++ b/.github/workflows/ocamlformat.yml
@@ -87,17 +87,28 @@ jobs:
         run: |
           # Formatter-only CI. Install with checksum verification first so the
           # whole formatter toolchain (ocamlformat included) is integrity-checked
-          # in the normal path. GitLab-generated archives for the fix/menhir date
-          # tags can drift from opam-repository checksums; only when that drift
-          # actually fails the verified install do we retry without checksums,
-          # scoping the no-checksum window to these pinned packages.
+          # in the normal path. GitLab-generated archives for the fix/menhir
+          # date tags can drift or be served as a non-archive by GitLab; only
+          # when that actually fails do we pin those exact tags via git and
+          # retry, leaving ocamlformat itself checksum-verified from opam.
           fmt_pkgs=(
             "fix.20250428"
             "menhir.20250912"
             "ocamlformat.${{ steps.pin.outputs.ocamlformat_version }}"
           )
-          opam install -y "${fmt_pkgs[@]}" \
-            || opam install -y --no-checksums "${fmt_pkgs[@]}"
+          install_from_opam_archives() {
+            opam install -y "${fmt_pkgs[@]}"
+          }
+          install_from_git_tags() {
+            opam pin add -n -y fix.20250428 \
+              "git+https://gitlab.inria.fr/fpottier/fix.git#20250428"
+            for pkg in menhir menhirCST menhirLib menhirSdk; do
+              opam pin add -n -y "${pkg}.20250912" \
+                "git+https://gitlab.inria.fr/fpottier/menhir.git#20250912"
+            done
+            opam install -y "${fmt_pkgs[@]}"
+          }
+          install_from_opam_archives || install_from_git_tags
 
       - name: Check formatting (changed files only)
         if: steps.changed.outputs.no_files != 'true'


### PR DESCRIPTION
Summary:
- retry fix/menhir formatter dependencies via exact git tags when GitLab generated archives fail
- keep ocamlformat itself checksum-verified from opam

Validation:
- git diff --check origin/main..HEAD
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ocamlformat.yml')"