### PR TITLE
refactor(keeper): purge legacy runtime proof fields

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -1266,22 +1266,6 @@ describe('fetchKeeperConfig', () => {
       sandbox_profile: 'docker',
       network_mode: 'none',
       sandbox_last_error: 'sandbox docker exec failed',
-      effective_sandbox_image: 'ubuntu:24.04@sha256:test',
-      private_workspace_root: '.masc/playground/keeper-sangsu',
-      sandbox_environment: {
-        base_path: '/tmp/project-root/.masc',
-        project_root: '/tmp/project-root',
-        docker_playground_enabled: 'true',
-        docker_container_name: 'keeper-playground',
-        container_playground_root: '/home/keeper/playground',
-        docker_image: 'ubuntu:24.04@sha256:test',
-        pids_limit: '128',
-        memory: '2g',
-        tmpfs_size: '256m',
-        seccomp_profile: '',
-        require_rootless: 'false',
-        require_userns: 'true',
-      },
       allowed_paths: '/tmp/workspace',
       effective_allowed_paths: ['/tmp/workspace'],
       prompt: {
@@ -1354,8 +1338,6 @@ describe('fetchKeeperConfig', () => {
         keepalive_running: 'true',
         registry_state: 'running',
         fiber_health: 'healthy',
-        presence_keepalive: 'true',
-        presence_keepalive_sec: '30',
         runtime_blocker_class: 'stale_fleet_batch',
         runtime_blocker_summary: 'Fleet batch paused after stale termination storm.',
         runtime_blocker_continue_gate: 'false',
@@ -1423,20 +1405,6 @@ describe('fetchKeeperConfig', () => {
     expect(result.sandbox_profile).toBe('docker')
     expect(result.network_mode).toBe('none')
     expect(result.sandbox_last_error).toBe('sandbox docker exec failed')
-    expect(result.effective_sandbox_image).toBe('ubuntu:24.04@sha256:test')
-    expect(result.private_workspace_root).toBe('.masc/playground/keeper-sangsu')
-    expect(result.sandbox_environment?.base_path).toBe('/tmp/project-root/.masc')
-    expect(result.sandbox_environment?.project_root).toBe('/tmp/project-root')
-    expect(result.sandbox_environment?.docker_playground_enabled).toBe(true)
-    expect(result.sandbox_environment?.docker_container_name).toBe('keeper-playground')
-    expect(result.sandbox_environment?.container_playground_root).toBe('/home/keeper/playground')
-    expect(result.sandbox_environment?.docker_image).toBe('ubuntu:24.04@sha256:test')
-    expect(result.sandbox_environment?.pids_limit).toBe(128)
-    expect(result.sandbox_environment?.memory).toBe('2g')
-    expect(result.sandbox_environment?.tmpfs_size).toBe('256m')
-    expect(result.sandbox_environment?.seccomp_profile).toBeNull()
-    expect(result.sandbox_environment?.require_rootless).toBe(false)
-    expect(result.sandbox_environment?.require_userns).toBe(true)
     expect(result.execution.models).toEqual(['llama:test-balanced'])
     expect(result.execution.verify).toBe(true)
     expect(result.execution.selected_runtime_id).toBe('keeper_unified')
@@ -1447,7 +1415,6 @@ describe('fetchKeeperConfig', () => {
     expect(result.hooks?.slots.pre_tool_use?.gates).toEqual(['keeper_deny_list'])
     expect(result.sources.precedence).toEqual(['live_meta'])
     expect(result.metrics.total_cost_usd).toBe(0.12)
-    expect(result.runtime.presence_keepalive_sec).toBe(30)
     expect(result.runtime.runtime_blocker_class).toBe('stale_fleet_batch')
     expect(result.runtime.runtime_blocker_summary).toBe('Fleet batch paused after stale termination storm.')
     expect(result.active_goal_ids).toEqual(['goal-runtime'])

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -2151,27 +2151,6 @@ function normalizeDefaultSourceKind(value: unknown): KeeperConfig['sources']['de
   }
 }
 
-
-function normalizeKeeperSandboxEnvironment(
-  raw: unknown,
-): KeeperConfig['sandbox_environment'] {
-  if (!isRecord(raw)) return undefined
-  return {
-    base_path: asNullableString(raw.base_path),
-    project_root: asNullableString(raw.project_root),
-    docker_playground_enabled: asLooseBoolean(raw.docker_playground_enabled),
-    docker_container_name: asNullableString(raw.docker_container_name),
-    container_playground_root: asNullableString(raw.container_playground_root),
-    docker_image: asNullableString(raw.docker_image),
-    pids_limit: asInt(raw.pids_limit),
-    memory: asNullableString(raw.memory),
-    tmpfs_size: asNullableString(raw.tmpfs_size),
-    seccomp_profile: asNullableString(raw.seccomp_profile),
-    require_rootless: asLooseBoolean(raw.require_rootless),
-    require_userns: asLooseBoolean(raw.require_userns),
-  }
-}
-
 function normalizePerProviderTimeoutMode(
   raw: unknown,
   perProviderTimeoutSec: number | null,
@@ -2197,7 +2176,6 @@ function normalizeKeeperConfig(raw: unknown, requestedName: string): KeeperConfi
   const tools = isRecord(data.tools) ? data.tools : {}
   const sources = isRecord(data.sources) ? data.sources : {}
   const metrics = isRecord(data.metrics) ? data.metrics : {}
-  const sandboxEnvironment = normalizeKeeperSandboxEnvironment(data.sandbox_environment)
   const perProviderTimeoutSec = asLooseNullableNumber(execution.per_provider_timeout_sec)
   const lastLatencyMs = asInt(metrics.last_latency_ms)
 
@@ -2207,9 +2185,6 @@ function normalizeKeeperConfig(raw: unknown, requestedName: string): KeeperConfi
     sandbox_profile: asNullableString(data.sandbox_profile) ?? '(unknown sandbox_profile)',
     network_mode: asNullableString(data.network_mode) ?? '(unknown network_mode)',
     sandbox_last_error: asNullableString(data.sandbox_last_error),
-    effective_sandbox_image: asNullableString(data.effective_sandbox_image),
-    private_workspace_root: asNullableString(data.private_workspace_root),
-    sandbox_environment: sandboxEnvironment,
     allowed_paths: normalizeStringList(data.allowed_paths),
     effective_allowed_paths: normalizeStringList(data.effective_allowed_paths),
     prompt: {
@@ -2287,8 +2262,6 @@ function normalizeKeeperConfig(raw: unknown, requestedName: string): KeeperConfi
       keepalive_running: asLooseBoolean(runtime.keepalive_running),
       registry_state: asNullableString(runtime.registry_state),
       fiber_health: asNullableString(runtime.fiber_health) ?? 'unknown',
-      presence_keepalive: asLooseBoolean(runtime.presence_keepalive),
-      presence_keepalive_sec: asInt(runtime.presence_keepalive_sec) ?? 0,
       runtime_blocker_class: asKeeperRuntimeBlockerClass(runtime.runtime_blocker_class),
       active_model_label: null,
       last_model_used_label: null,

--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -235,9 +235,6 @@ describe('keeper runtime trace', () => {
             tools: ['Execute', 'SearchFiles'],
             successful_tools: ['Execute', 'SearchFiles'],
             failed_tools: [],
-            sandbox_profiles: ['docker'],
-            network_modes: ['inherit'],
-            docker_visible: true,
             latest_at: '2026-05-13T00:00:01Z',
           },
         },
@@ -324,7 +321,6 @@ describe('keeper runtime trace', () => {
     expect(result.runtime_lens.axes.provider_lane.resolved).toBe(false)
     expect(result.runtime_lens.axes.provider_attempt.terminal_status).toBe('timeout')
     expect(result.runtime_lens.axes.runtime_proof.status).toBe('pass')
-    expect(result.runtime_lens.axes.runtime_proof.docker_visible).toBe(true)
     expect(result.runtime_lens.axes.runtime_proof.tools).toEqual(['Execute', 'SearchFiles'])
     expect(result.runtime_lens.swimlanes.provider.terminal_status).toBe('timeout')
     expect(result.runtime_lens.swimlanes.memory_context.terminal_status).toBe('unknown')
@@ -498,7 +494,6 @@ describe('keeper lifecycle', () => {
         session_dir: '/tmp/trace-keeper-test',
         current: null,
         history: [],
-        legacy_shadow_count: 0,
       }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
@@ -533,7 +528,6 @@ describe('keeper lifecycle', () => {
           session_dir: '/tmp/trace-keeper-test',
           current: null,
           history: [],
-          legacy_shadow_count: 0,
         },
       }), {
         status: 200,

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -419,7 +419,6 @@ export interface KeeperCheckpointInventory {
   session_dir: string
   current: KeeperCheckpointSummary | null
   history: KeeperCheckpointSummary[]
-  legacy_shadow_count: number
 }
 
 interface KeeperCheckpointDeleteResponse {
@@ -844,9 +843,6 @@ export interface KeeperRuntimeLensRuntimeProofAxis {
   tools: string[]
   successful_tools: string[]
   failed_tools: string[]
-  sandbox_profiles: string[]
-  network_modes: string[]
-  docker_visible: boolean
   latest_at: string | null
 }
 
@@ -1310,9 +1306,6 @@ function parseRuntimeLensRuntimeProofAxis(raw: unknown): KeeperRuntimeLensRuntim
     tools: stringListField(obj, 'tools'),
     successful_tools: stringListField(obj, 'successful_tools'),
     failed_tools: stringListField(obj, 'failed_tools'),
-    sandbox_profiles: stringListField(obj, 'sandbox_profiles'),
-    network_modes: stringListField(obj, 'network_modes'),
-    docker_visible: obj.docker_visible === true,
     latest_at: nullableStringField(obj, 'latest_at'),
   }
 }

--- a/dashboard/src/components/fleet-telemetry-panel.test.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.test.ts
@@ -333,7 +333,6 @@ describe('FleetTelemetryPanel', () => {
           active_goal_ids: ['goal-1'],
           short_goal: 'Ship safer keeper ops',
           sandbox_profile: 'docker',
-          effective_sandbox_image: 'ghcr.io/acme/keeper:latest',
           sandbox_last_error: 'bind EPERM at /var/folders/tmp',
           runtime_blocker_continue_gate: true,
         },

--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -439,7 +439,7 @@ function FleetComparisonTable({ rows, onReset }: { rows: FleetRow[]; onReset: (n
                     class=${row.sandbox_profile
                       ? 'rounded-[var(--r-1)] bg-[var(--color-bg-hover)] px-1.5 py-0.5 text-3xs text-[var(--color-fg-disabled)]'
                       : 'rounded-[var(--r-1)] bg-[var(--warn-10)] px-1.5 py-0.5 text-3xs text-[var(--color-status-warn)]'}
-                    title=${row.effective_sandbox_image ?? row.sandbox_profile ?? '샌드박스 프로필 정보 없음.'}
+                    title=${row.sandbox_profile ?? '샌드박스 프로필 정보 없음.'}
                   >
                     ${row.sandbox_profile ? `sandbox ${row.sandbox_profile}` : 'sandbox unknown'}
                   </span>

--- a/dashboard/src/components/fleet-telemetry-utils.test.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.test.ts
@@ -65,7 +65,6 @@ function makeRow(overrides: Partial<FleetRow> = {}): FleetRow {
     active_goal_count: 0,
     sandbox_profile: null,
     sandbox_last_error: null,
-    effective_sandbox_image: null,
     decision_required: false,
     budget_source: null,
     provider_health_status: null,

--- a/dashboard/src/components/fleet-telemetry-utils.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.ts
@@ -58,7 +58,6 @@ export interface FleetRow {
   active_goal_count: number
   sandbox_profile: string | null
   sandbox_last_error: string | null
-  effective_sandbox_image: string | null
   decision_required: boolean
   budget_source: 'override' | 'override_invalid' | 'env' | null
   provider_health_status: 'healthy' | 'degraded' | 'unhealthy' | null
@@ -463,7 +462,6 @@ export function buildFleetRows(keepers: Keeper[], toolQuality: ToolQualityRespon
             active_goal_count: keeper.active_goal_ids?.length ?? 0,
             sandbox_profile: keeper.sandbox_profile ?? null,
             sandbox_last_error: keeper.sandbox_last_error ?? null,
-            effective_sandbox_image: keeper.effective_sandbox_image ?? null,
             decision_required: keeper.runtime_blocker_continue_gate === true,
             budget_source:
               keeper.turn_budget?.reactive.source === 'override' ||

--- a/dashboard/src/components/fleet-trend-store.test.ts
+++ b/dashboard/src/components/fleet-trend-store.test.ts
@@ -29,7 +29,6 @@ function makeRow(name: string, overrides: Partial<FleetRow> = {}): FleetRow {
     active_goal_count: 0,
     sandbox_profile: null,
     sandbox_last_error: null,
-    effective_sandbox_image: null,
     decision_required: false,
     budget_source: null,
     provider_health_status: null,

--- a/dashboard/src/components/journey-waterfall-state.ts
+++ b/dashboard/src/components/journey-waterfall-state.ts
@@ -303,7 +303,7 @@ function keeperActivityAge(keeper: Keeper): number {
 
 function keeperPriority(keeper: Keeper): number {
   const status = keeper.status.trim().toLowerCase()
-  if (keeper.keepalive_running === true || keeper.presence_keepalive === true) return 0
+  if (keeper.keepalive_running === true) return 0
   return classifyKeeperPriority(status)
 }
 

--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -30,22 +30,6 @@ function makeKeeperConfig(overrides: Partial<KeeperConfig> = {}): KeeperConfig {
     sandbox_profile: 'local',
     network_mode: 'inherit',
     sandbox_last_error: null,
-    effective_sandbox_image: 'ubuntu:24.04@sha256:test',
-    private_workspace_root: '/tmp/project-root/.masc/playground/keeper-sangsu',
-    sandbox_environment: {
-      base_path: '/tmp/project-root/.masc',
-      project_root: '/tmp/project-root',
-      docker_playground_enabled: true,
-      docker_container_name: 'keeper-playground',
-      container_playground_root: '/home/keeper/playground',
-      docker_image: 'ubuntu:24.04@sha256:test',
-      pids_limit: 128,
-      memory: '2g',
-      tmpfs_size: '256m',
-      seccomp_profile: null,
-      require_rootless: false,
-      require_userns: false,
-    },
     allowed_paths: ['/tmp/workspace'],
     effective_allowed_paths: ['/tmp/workspace'],
     prompt: {
@@ -112,8 +96,6 @@ function makeKeeperConfig(overrides: Partial<KeeperConfig> = {}): KeeperConfig {
       keepalive_running: true,
       registry_state: 'running',
       fiber_health: 'healthy',
-      presence_keepalive: true,
-      presence_keepalive_sec: 30,
     },
     workspace: {
       mention_targets: ['sangsu'],
@@ -527,7 +509,6 @@ describe('KeeperConfigPanel', () => {
     expect(container.textContent).toContain('레지스트리 상태')
     expect(container.textContent).toContain('running')
     expect(container.textContent).toContain('dynamic_boundary (Tool_dispatch.is_destructive)')
-    expect(container.textContent).toContain('/tmp/project-root')
 
     const editButton = Array.from(container.querySelectorAll('button')).find(button =>
       button.textContent?.includes('편집'),

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -529,18 +529,6 @@ function EditTextarea({ field, label, rows = 3 }: { field: keyof EditDraft; labe
   `
 }
 
-function sandboxAnchorText(c: KeeperConfig): string {
-  const basePath = c.sandbox_environment?.base_path ?? MISSING_DATA_DASH
-  const projectRoot = c.sandbox_environment?.project_root ?? MISSING_DATA_DASH
-  return `상대 allowed_paths는 project root ${projectRoot} 기준으로 해석됩니다. config base path는 ${basePath} 입니다.`
-}
-
-function dockerStatusLabel(c: KeeperConfig): string {
-  if (c.sandbox_profile === 'docker') return 'docker'
-  if (c.sandbox_environment?.docker_playground_enabled) return 'local + docker_playground'
-  return 'local'
-}
-
 function runtimeSelectionSummary(c: KeeperConfig): string {
   const selected = c.execution.selected_runtime_id || MISSING_DATA_DASH
   const canonical = c.execution.selected_runtime_canonical || selected
@@ -842,7 +830,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
         ` : null}
         <${Callout}
           title="기본 경로 앵커"
-          body=${sandboxAnchorText(c)}
+          body="상대 allowed_paths는 keeper 작업 경로 기준으로 해석됩니다."
         />
         ${rd.sandbox_profile === 'docker' ? html`
           <${SetupGuideCard} connectorId="sandbox_hardened" />
@@ -851,34 +839,16 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
         <${ConfigRow} label="sandbox_profile" value=${c.sandbox_profile ?? 'local'} />
         <${ConfigRow} label="network_mode" value=${c.network_mode ?? 'inherit'} />
 
-        <${ConfigRow} label="effective_sandbox_image" value=${c.effective_sandbox_image || MISSING_DATA_DASH} />
         <${ConfigRow} label="allowed_paths" value=${(c.allowed_paths ?? []).join(', ') || '(computed default)'} />
         <${ConfigRow} label="effective_paths" value=${(c.effective_allowed_paths ?? []).join(', ') || '(전체 허용)'} />
-        <${ConfigRow} label="private_workspace_root" value=${c.private_workspace_root || MISSING_DATA_DASH} />
       `}
 
-      ${c.sandbox_environment ? html`
-        <${SectionHeader} title="샌드박스 환경" />
-        <${ConfigRow} label="docker_status" value=${dockerStatusLabel(c)} />
-        <${ConfigRow} label="config_base_path" value=${c.sandbox_environment.base_path || MISSING_DATA_DASH} />
-        <${ConfigRow} label="project_root" value=${c.sandbox_environment.project_root || MISSING_DATA_DASH} />
-        <${BoolRow} label="docker_playground" value=${c.sandbox_environment.docker_playground_enabled} />
-        <${ConfigRow} label="docker_container" value=${c.sandbox_environment.docker_container_name || MISSING_DATA_DASH} />
-        <${ConfigRow} label="container_playground_root" value=${c.sandbox_environment.container_playground_root || MISSING_DATA_DASH} />
-        <${ConfigRow} label="sandbox_docker_image" value=${c.sandbox_environment.docker_image || MISSING_DATA_DASH} />
-        <${ConfigRow} label="sandbox_memory" value=${c.sandbox_environment.memory || MISSING_DATA_DASH} />
-        <${ConfigRow} label="sandbox_pids_limit" value=${String(c.sandbox_environment.pids_limit ?? MISSING_DATA_DASH)} />
-        <${ConfigRow} label="sandbox_tmpfs_size" value=${c.sandbox_environment.tmpfs_size || MISSING_DATA_DASH} />
-        <${ConfigRow} label="sandbox_seccomp_profile" value=${c.sandbox_environment.seccomp_profile || MISSING_DATA_DASH} />
-        <${BoolRow} label="require_rootless" value=${c.sandbox_environment.require_rootless} />
-        <${BoolRow} label="require_userns" value=${c.sandbox_environment.require_userns} />
-        ${c.sandbox_last_error ? html`
-          <${Callout}
-            title="샌드박스 오류"
-            body=${c.sandbox_last_error}
-            tone="warn"
-          />
-        ` : null}
+      ${c.sandbox_last_error ? html`
+        <${Callout}
+          title="샌드박스 오류"
+          body=${c.sandbox_last_error}
+          tone="warn"
+        />
       ` : null}
 
       <${SectionHeader} title="프로액티브" />
@@ -903,8 +873,6 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       <${BoolRow} label="킵얼라이브 실행" value=${c.runtime.keepalive_running} />
       <${ConfigRow} label="레지스트리 상태" value=${c.runtime.registry_state || MISSING_DATA_DASH} />
       <${ConfigRow} label="파이버 상태" value=${c.runtime.fiber_health || MISSING_DATA_DASH} />
-      <${BoolRow} label="프레즌스 킵얼라이브" value=${c.runtime.presence_keepalive} />
-      <${ConfigRow} label="프레즌스 간격" value=${c.runtime.presence_keepalive_sec + 's'} />
 
       <${SectionHeader} title="네임스페이스 조율" />
       <div class="py-2 px-3 rounded-[var(--r-1)] border border-card-border/50 bg-card/20 backdrop-blur-sm mb-1.5">

--- a/dashboard/src/components/keeper-detail-history.ts
+++ b/dashboard/src/components/keeper-detail-history.ts
@@ -207,9 +207,6 @@ export function KeeperCheckpointPanel({
       <div class="flex items-center justify-between gap-3">
         <div class="text-2xs text-[var(--color-fg-muted)]">
           current OAS checkpoint와 OAS snapshot history만 노출합니다.
-          ${inventory && inventory.legacy_shadow_count > 0
-            ? html`<span class="block mt-1 text-[var(--color-status-warn)]">retired shadow ${inventory.legacy_shadow_count}개는 picker에서 제외됩니다.</span>`
-            : null}
         </div>
         <div class="flex items-center gap-2">
           <${ActionButton}

--- a/dashboard/src/components/keeper-detail-runtime.test.ts
+++ b/dashboard/src/components/keeper-detail-runtime.test.ts
@@ -539,9 +539,6 @@ describe('RuntimeLensSection', () => {
             tools: ['Execute', 'SearchFiles'],
             successful_tools: ['Execute', 'SearchFiles'],
             failed_tools: [],
-            sandbox_profiles: ['docker'],
-            network_modes: ['inherit'],
-            docker_visible: true,
             latest_at: '2026-05-13T00:00:01Z',
           },
           context: {
@@ -774,13 +771,8 @@ describe('RuntimeLensSection', () => {
     expect(screen.getByText('0/1')).toBeInTheDocument()
     expect(screen.getByText('runtime proof')).toBeInTheDocument()
     expect(screen.getByText('pass / 2 calls')).toBeInTheDocument()
-    expect(screen.getByText('sandbox proof')).toBeInTheDocument()
-    expect(screen.getByText('docker')).toBeInTheDocument()
-    expect(screen.getByText('git creds / identity materialized')).toBeInTheDocument()
     expect(screen.getByText('proof tools')).toBeInTheDocument()
     expect(screen.getByText('Execute, SearchFiles')).toBeInTheDocument()
-    expect(screen.getByText('network proof')).toBeInTheDocument()
-    expect(screen.getByText('inherit')).toBeInTheDocument()
     expect(screen.getByText('working loops')).toBeInTheDocument()
     expect(screen.getAllByText('2').length).toBeGreaterThan(0)
     expect(screen.getByText('provider attempts')).toBeInTheDocument()

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -1079,9 +1079,7 @@ export function RuntimeLensSection({
         <${SignalRow} label="runtime drift" value=${drift.runtime_override ? `${drift.default_runtime_id ?? '-'} -> ${drift.live_runtime_id ?? '-'}` : drift.status} />
         <${SignalRow} label="override fields" value=${formatLensList(drift.override_fields)} />
         <${SignalRow} label="runtime proof" value=${`${proof.status} / ${proof.matched_tool_call_count} calls`} />
-        <${SignalRow} label="sandbox proof" value=${proof.docker_visible ? formatLensList(proof.sandbox_profiles, 'docker') : 'not observed'} />
         <${SignalRow} label="proof tools" value=${formatLensList(proof.tools)} />
-        <${SignalRow} label="network proof" value=${formatLensList(proof.network_modes)} />
         <${SignalRow} label="context compaction" value=${formatRatioPair({ numerator: context.context_compacted_count, denominator: context.context_compact_started_count })} />
         <${SignalRow} label="working loops" value=${context.active_open_loop_count} />
         <${SignalRow} label="memory flush" value=${formatIndependentCounters({ leftLabel: 'success', leftValue: memory.memory_flush_success_count, rightLabel: 'error', rightValue: memory.memory_flush_error_count })} />

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -675,9 +675,6 @@ export function normalizeKeepers(raw: unknown): Keeper[] {
         runtime_canonical: asString(row.runtime_canonical) ?? asString(row.selected_runtime_canonical) ?? null,
         selected_runtime_canonical: asString(row.selected_runtime_canonical) ?? null,
         status: normalizeKeeperAgentStatus(statusRaw),
-        presence_keepalive:
-          typeof row.presence_keepalive === 'boolean' ? row.presence_keepalive : undefined,
-        presence_keepalive_sec: asNumber(row.presence_keepalive_sec),
         keepalive_running:
           typeof row.keepalive_running === 'boolean' ? row.keepalive_running : undefined,
         proactive_enabled:
@@ -713,7 +710,6 @@ export function normalizeKeepers(raw: unknown): Keeper[] {
         sandbox_profile: normalizeKeeperSandboxProfile(row.sandbox_profile),
         sandbox_target: asString(row.sandbox_target) ?? null,
         sandbox_last_error: asString(row.sandbox_last_error) ?? null,
-        effective_sandbox_image: asString(row.effective_sandbox_image) ?? null,
         blocked_task_count: asNumber(row.blocked_task_count) ?? null,
         goal_progress: isRecord(row.goal_progress)
           ? {

--- a/dashboard/src/lib/keeper-fiber-alive.test.ts
+++ b/dashboard/src/lib/keeper-fiber-alive.test.ts
@@ -16,7 +16,7 @@ const baseComposite = (
 describe('deriveFiberAlive', () => {
   it('prefers composite phase_diagnosis when the boolean is present', () => {
     const r = deriveFiberAlive({
-      keeper: { keepalive_running: false, presence_keepalive: false },
+      keeper: { keepalive_running: false },
       composite: baseComposite(true),
       linkedState: 'offline',
     })
@@ -25,7 +25,7 @@ describe('deriveFiberAlive', () => {
 
   it('reads composite false even when keepalive signals would say true', () => {
     const r = deriveFiberAlive({
-      keeper: { keepalive_running: true, presence_keepalive: true },
+      keeper: { keepalive_running: true },
       composite: baseComposite(false),
       linkedState: 'idle',
     })
@@ -34,32 +34,23 @@ describe('deriveFiberAlive', () => {
 
   it('falls through to keepalive_running when composite is null', () => {
     const r = deriveFiberAlive({
-      keeper: { keepalive_running: true, presence_keepalive: false },
+      keeper: { keepalive_running: true },
       composite: null,
       linkedState: 'offline',
     })
     expect(r).toEqual({ alive: true, source: 'keepalive_running' })
   })
 
-  it('falls through to presence_keepalive when keepalive_running is undefined', () => {
-    const r = deriveFiberAlive({
-      keeper: { keepalive_running: undefined, presence_keepalive: true },
-      composite: null,
-      linkedState: 'offline',
-    })
-    expect(r).toEqual({ alive: true, source: 'presence_keepalive' })
-  })
-
   it('falls through to link-state inference when all per-keeper signals are absent', () => {
     const r1 = deriveFiberAlive({
-      keeper: { keepalive_running: undefined, presence_keepalive: undefined },
+      keeper: { keepalive_running: undefined },
       composite: null,
       linkedState: 'offline',
     })
     expect(r1).toEqual({ alive: false, source: 'link_state_inference' })
 
     const r2 = deriveFiberAlive({
-      keeper: { keepalive_running: undefined, presence_keepalive: undefined },
+      keeper: { keepalive_running: undefined },
       composite: null,
       linkedState: 'running',
     })
@@ -72,7 +63,7 @@ describe('deriveFiberAlive', () => {
     // that: an explicit `false` at keepalive_running is the authority,
     // not a signal-absence that should fall through.
     const r = deriveFiberAlive({
-      keeper: { keepalive_running: false, presence_keepalive: true },
+      keeper: { keepalive_running: false },
       composite: null,
       linkedState: 'running',
     })

--- a/dashboard/src/lib/keeper-fiber-alive.ts
+++ b/dashboard/src/lib/keeper-fiber-alive.ts
@@ -1,18 +1,16 @@
 // Typed fiber-alive decision for a keeper.
 //
 // Background: `keeper-detail-runtime.ts` derived `fiberAlive` from a
-// 4-fallback chain that mixed four *semantically distinct* signals:
+// 3-fallback chain that mixed semantically distinct signals:
 //
 //   composite?.phase_diagnosis?.conditions.fiber_alive
 //   ?? keeper.keepalive_running
-//   ?? keeper.presence_keepalive
 //   ?? (linkedState !== 'offline')
 //
 // Each signal answers a slightly different question:
 //   1. composite truth         — "what did the observer record?"
 //   2. keepalive_running       — "is the keepalive thread alive?"
-//   3. presence_keepalive      — "did the presence ping arrive?"
-//   4. link-state inference    — "do we even believe the keeper exists?"
+//   3. link-state inference    — "do we even believe the keeper exists?"
 //
 // Collapsing them into one OR-chain loses provenance: when the dashboard
 // shows "fiber alive" or "fiber dead", an operator cannot trace which
@@ -25,7 +23,6 @@ import type { KeeperCompositeSnapshot } from '../api/schemas/keeper-composite'
 export type FiberAliveSource =
   | 'composite_phase_diagnosis'
   | 'keepalive_running'
-  | 'presence_keepalive'
   | 'link_state_inference'
 
 export interface FiberAliveDecision {
@@ -34,7 +31,7 @@ export interface FiberAliveDecision {
 }
 
 interface FiberAliveInput {
-  readonly keeper: Pick<Keeper, 'keepalive_running' | 'presence_keepalive'>
+  readonly keeper: Pick<Keeper, 'keepalive_running'>
   readonly composite: KeeperCompositeSnapshot | null
   /** Result of `linkedRuntimeState(keeper)` — a string state ('offline'
    *  or other). Pass through as-is; this module only checks the
@@ -53,9 +50,6 @@ export function deriveFiberAlive({
   }
   if (typeof keeper.keepalive_running === 'boolean') {
     return { alive: keeper.keepalive_running, source: 'keepalive_running' }
-  }
-  if (typeof keeper.presence_keepalive === 'boolean') {
-    return { alive: keeper.presence_keepalive, source: 'presence_keepalive' }
   }
   return { alive: linkedState !== 'offline', source: 'link_state_inference' }
 }

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -933,8 +933,6 @@ export interface Keeper {
   runtime_canonical?: string | null
   selected_runtime_canonical?: string | null
   status: string
-  presence_keepalive?: boolean
-  presence_keepalive_sec?: number
   keepalive_running?: boolean
   diagnostic?: KeeperDiagnostic | null
   registry_state?: string | null
@@ -963,7 +961,6 @@ export interface Keeper {
   sandbox_profile?: 'local' | 'docker' | null
   sandbox_target?: string | null
   sandbox_last_error?: string | null
-  effective_sandbox_image?: string | null
   blocked_task_count?: number | null
   goal_progress?: {
     active_goal_count?: number
@@ -1275,8 +1272,6 @@ interface KeeperConfigRuntime {
   keepalive_running: boolean
   registry_state?: string | null
   fiber_health: string
-  presence_keepalive: boolean
-  presence_keepalive_sec: number
   runtime_blocker_class?: KeeperRuntimeBlockerClass | null
   active_model_label?: string | null
   last_model_used_label?: string | null
@@ -1328,21 +1323,6 @@ interface KeeperConfigMetrics {
   compaction_count: number
 }
 
-export interface KeeperSandboxEnvironment {
-  base_path?: string | null
-  project_root?: string | null
-  docker_playground_enabled: boolean
-  docker_container_name?: string | null
-  container_playground_root?: string | null
-  docker_image?: string | null
-  pids_limit?: number | null
-  memory?: string | null
-  tmpfs_size?: string | null
-  seccomp_profile?: string | null
-  require_rootless: boolean
-  require_userns: boolean
-}
-
 export interface KeeperHookSlot {
   active: boolean
   source: string
@@ -1365,9 +1345,6 @@ export interface KeeperConfig {
   sandbox_profile?: 'local' | 'docker' | string
   network_mode?: 'none' | 'inherit' | string
   sandbox_last_error?: string | null
-  effective_sandbox_image?: string | null
-  private_workspace_root?: string | null
-  sandbox_environment?: KeeperSandboxEnvironment
   allowed_paths: string[]
   effective_allowed_paths: string[]
   prompt: KeeperConfigPrompt

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -57,10 +57,6 @@ let keepers_dashboard_json ?(compact = false) (config : Workspace.config) : Yojs
   let history_fragment_filter_enabled =
     bool_default_true_of_env "MASC_KEEPER_HISTORY_FRAGMENT_FILTER"
   in
-  let sandbox_preflight_json =
-    Keeper_sandbox_runtime.docker_preflight ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Preflight ()) ()
-    |> Option.map Keeper_sandbox_runtime.docker_preflight_to_yojson
-  in
   let series_points = 120 in
   let names = keeper_names config in
   let now_ts = Time_compat.now () in
@@ -316,21 +312,6 @@ let keepers_dashboard_json ?(compact = false) (config : Workspace.config) : Yojs
             match registry_entry with
             | Some entry -> entry.last_error
             | None -> None
-          in
-          let effective_sandbox_image =
-            if m.sandbox_profile = Keeper_types_profile_sandbox.Docker
-            then
-              Some (
-                match m.sandbox_image with
-                | Some img when String.trim img <> "" -> img
-                | _ -> Env_config_sandbox.Runtime.docker_image ()
-              )
-            else None
-          in
-          let sandbox_preflight =
-            match effective_sandbox_image, sandbox_preflight_json with
-            | Some _, Some preflight -> Some preflight
-            | _ -> None
           in
           (* reconcile_status removed with manual_reconcile blocker system. *)
           let runtime_blocker_fields =
@@ -634,10 +615,6 @@ let keepers_dashboard_json ?(compact = false) (config : Workspace.config) : Yojs
               ("sandbox_target", `String sandbox_target);
               ("sandbox_last_error",
                 Json_util.string_opt_to_json sandbox_last_error);
-              ("sandbox_preflight",
-                Json_util.option_to_yojson Fun.id sandbox_preflight);
-              ("effective_sandbox_image",
-                Json_util.string_opt_to_json effective_sandbox_image);
               ("runtime_contract", runtime_contract);
               ("goal_progress", goal_progress);
               ("blocked_task_count", `Int blocked_task_count);

--- a/lib/dashboard/dashboard_http_keeper_snapshot.ml
+++ b/lib/dashboard/dashboard_http_keeper_snapshot.ml
@@ -381,74 +381,12 @@ let keeper_config_json (config : Workspace.config) (name : string)
         | Some entry -> entry.last_error
         | None -> None
       in
-      let effective_sandbox_image =
-        if m.sandbox_profile = Keeper_types_profile_sandbox.Docker
-        then Some (Env_config_sandbox.Runtime.docker_image ())
-        else None
-      in
-      let sandbox_preflight_json =
-        Keeper_sandbox_runtime.docker_preflight ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Preflight ()) ()
-        |> Option.map Keeper_sandbox_runtime.docker_preflight_to_yojson
-      in
-      let sandbox_preflight =
-        match effective_sandbox_image, sandbox_preflight_json with
-        | Some _, Some preflight -> Some preflight
-        | _ -> None
-      in
-      let private_workspace_root =
-        Keeper_sandbox.host_root_abs_of_meta ~config m
-      in
-      let sandbox_environment =
-        let string_or_null value =
-          let trimmed = String.trim value in
-          if trimmed = "" then `Null else `String trimmed
-        in
-        `Assoc [
-          ("base_path", `String config.base_path);
-          ("project_root",
-            `String (Keeper_alerting_path.project_root_of_config config));
-          ("docker_playground_enabled",
-            `Bool (Env_config_sandbox.Runtime.docker_playground_enabled ()));
-          ("docker_container_name",
-            string_or_null
-              (Env_config_sandbox.Runtime.docker_playground_container_name ()));
-          ("container_playground_root",
-            string_or_null
-              (Env_config_sandbox.Runtime.docker_playground_container_root ()));
-          ("docker_image",
-            match effective_sandbox_image with
-            | Some img -> string_or_null img
-            | None -> `Null);
-          ("pids_limit", `Int (Env_config_sandbox.Hardening.pids_limit ()));
-          ("memory",
-            string_or_null (Env_config_sandbox.Hardening.memory ()));
-          ("tmpfs_size",
-            string_or_null (Env_config_sandbox.Hardening.tmpfs_size ()));
-          ("relax_fs",
-            `Bool (Env_config_sandbox.Hardening.relax_fs ()));
-          ("seccomp_profile",
-            string_or_null
-              (Env_config_sandbox.Hardening.seccomp_profile ()));
-          ("require_rootless",
-            `Bool (Env_config_sandbox.Hardening.require_rootless ()));
-          ("require_userns",
-            `Bool (Env_config_sandbox.Hardening.require_userns ()));
-          ("preflight",
-            Json_util.option_to_yojson Fun.id sandbox_preflight);
-        ]
-      in
       (`OK,
        `Assoc [
          ("name", `String m.name);
          ("active_goal_ids", active_goal_ids_json);
          ("sandbox_profile", `String (Keeper_types_profile_sandbox.sandbox_profile_to_string m.sandbox_profile));
          ("network_mode", `String (Keeper_types_profile_sandbox.network_mode_to_string m.network_mode));         ("sandbox_last_error", Json_util.string_opt_to_json sandbox_last_error);
-         ("sandbox_preflight",
-           Json_util.option_to_yojson Fun.id sandbox_preflight);
-         ("effective_sandbox_image",
-           Json_util.string_opt_to_json effective_sandbox_image);
-         ("private_workspace_root", `String private_workspace_root);
-         ("sandbox_environment", sandbox_environment);
          ("allowed_paths",
            `List (List.map (fun s -> `String s) m.allowed_paths));
          ("effective_allowed_paths",

--- a/lib/dashboard/dashboard_keeper_tool_failure_proof.ml
+++ b/lib/dashboard/dashboard_keeper_tool_failure_proof.ml
@@ -21,8 +21,6 @@ type tool_keeper_stat = {
   keepers : string list;
   successful_keepers : string list;
   failed_keepers : string list;
-  sandbox_profiles : string list;
-  network_modes : string list;
   task_ids : string list;
   goal_ids : string list;
   latest_ts : float option;
@@ -36,8 +34,6 @@ type mutable_tool_keeper_stat = {
   keepers : (string, unit) Hashtbl.t;
   successful_keepers : (string, unit) Hashtbl.t;
   failed_keepers : (string, unit) Hashtbl.t;
-  sandbox_profiles : (string, unit) Hashtbl.t;
-  network_modes : (string, unit) Hashtbl.t;
   task_ids : (string, unit) Hashtbl.t;
   goal_ids : (string, unit) Hashtbl.t;
   latest_ts : float option ref;
@@ -124,8 +120,6 @@ let empty_mutable_stat () =
     keepers = Hashtbl.create 8;
     successful_keepers = Hashtbl.create 8;
     failed_keepers = Hashtbl.create 8;
-    sandbox_profiles = Hashtbl.create 4;
-    network_modes = Hashtbl.create 4;
     task_ids = Hashtbl.create 8;
     goal_ids = Hashtbl.create 8;
     latest_ts = ref None;
@@ -158,10 +152,6 @@ let add_tool_stat table record =
     add_set stat.keepers keeper;
     if ok then add_set stat.successful_keepers keeper
     else add_set stat.failed_keepers keeper;
-    Option.iter (add_set stat.sandbox_profiles)
-      (Safe_ops.json_string_opt "sandbox_profile" record);
-    Option.iter (add_set stat.network_modes)
-      (Safe_ops.json_string_opt "network_mode" record);
     Option.iter (add_set stat.task_ids)
       (Safe_ops.json_string_opt "task_id" record);
     List.iter (add_set stat.goal_ids) (string_list_field record "goal_ids");
@@ -186,8 +176,6 @@ let materialize_tool_stat name stat =
     keepers = sorted_set stat.keepers;
     successful_keepers = sorted_set stat.successful_keepers;
     failed_keepers = sorted_set stat.failed_keepers;
-    sandbox_profiles = sorted_set stat.sandbox_profiles;
-    network_modes = sorted_set stat.network_modes;
     task_ids = sorted_set stat.task_ids;
     goal_ids = sorted_set stat.goal_ids;
     latest_ts = !(stat.latest_ts);
@@ -325,8 +313,6 @@ let stat_json (stat : tool_keeper_stat) =
        ("keepers", Json_util.json_string_list stat.keepers);
        ("successful_keepers", Json_util.json_string_list stat.successful_keepers);
        ("failed_keepers", Json_util.json_string_list stat.failed_keepers);
-       ("sandbox_profiles", Json_util.json_string_list stat.sandbox_profiles);
-       ("network_modes", Json_util.json_string_list stat.network_modes);
        ("task_ids", Json_util.json_string_list stat.task_ids);
        ("goal_ids", Json_util.json_string_list stat.goal_ids);
      ]
@@ -343,8 +329,6 @@ let empty_stat_json tool =
     ("keepers", `List []);
     ("successful_keepers", `List []);
     ("failed_keepers", `List []);
-    ("sandbox_profiles", `List []);
-    ("network_modes", `List []);
     ("task_ids", `List []);
     ("goal_ids", `List []);
     ("latest_ts", `Null);

--- a/lib/dashboard/dashboard_keeper_tool_failure_proof.mli
+++ b/lib/dashboard/dashboard_keeper_tool_failure_proof.mli
@@ -8,8 +8,6 @@ type tool_keeper_stat = {
   keepers : string list;
   successful_keepers : string list;
   failed_keepers : string list;
-  sandbox_profiles : string list;
-  network_modes : string list;
   task_ids : string list;
   goal_ids : string list;
   latest_ts : float option;

--- a/lib/keeper/keeper_config.mli
+++ b/lib/keeper/keeper_config.mli
@@ -45,7 +45,6 @@ val default_proactive_cooldown_sec : int
 val approval_queue_stale_max_wait_sec : float
 val default_goal_horizon_max_chars : int
 val default_drift_max_clauses : int
-val legacy_provider_filter_name : string
 
 (** Maximum bytes of personality text included in the rendered keeper prompt.
     Drives [normalize_self_model_text] when called from prompt rendering.
@@ -92,9 +91,6 @@ val removed_keeper_input_key_names : string list
 
 (** Field names that are no longer accepted in keeper message input. *)
 val removed_keeper_msg_input_key_names : string list
-
-(** Field names that are no longer accepted in keeper metadata. *)
-val removed_keeper_meta_key_names : string list
 
 (** Return which [keys] are present as top-level keys in the JSON object. *)
 val present_json_keys : string list -> Yojson.Safe.t -> string list

--- a/lib/keeper/keeper_config_text.ml
+++ b/lib/keeper/keeper_config_text.ml
@@ -51,7 +51,6 @@ let approval_queue_stale_max_wait_sec = 600.0
 let default_goal_horizon_max_chars = 480
 let default_drift_max_clauses = 6
 let prompt_render_max_bytes = 320
-let legacy_provider_filter_name = "allowed_providers"
 
 (* ── Removed / rejected keeper input keys ───────────────────── *)
 
@@ -60,9 +59,6 @@ let removed_keeper_input_key_names =
     "models";
     "allowed_models";
     "active_model";
-    legacy_provider_filter_name;
-    "presence_keepalive";
-    "presence_keepalive_sec";
     "trigger_mode";
     "policy_action_budget";
     "initiative_scope";
@@ -100,12 +96,6 @@ let removed_keeper_msg_input_key_names =
     "new_needs";
     "new_desires";
   ]
-
-let removed_keeper_meta_key_names =
-  [
-    "persona_profile_path";
-  ]
-  @ removed_keeper_input_key_names
 
 let present_json_keys (keys : string list) (json : Yojson.Safe.t) : string list =
   match json with

--- a/lib/keeper/keeper_config_text.mli
+++ b/lib/keeper/keeper_config_text.mli
@@ -28,14 +28,12 @@ val approval_queue_stale_max_wait_sec : float
 val default_goal_horizon_max_chars : int
 val default_drift_max_clauses : int
 val prompt_render_max_bytes : int
-val legacy_provider_filter_name : string
 
 (* ── Removed / rejected keeper input keys ───────────────────── *)
 
 val removed_keeper_input_key_names : string list
 val non_public_keeper_input_key_names : string list
 val removed_keeper_msg_input_key_names : string list
-val removed_keeper_meta_key_names : string list
 
 val present_json_keys : string list -> Yojson.Safe.t -> string list
 

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -524,16 +524,10 @@ let reject_removed_keeper_meta_shapes (json : Yojson.Safe.t) =
 
 let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
   try
-    match reject_removed_keeper_meta_fields json with
+    match reject_removed_keeper_meta_shapes json with
     | Error e -> Error e
     | Ok () ->
-      (match reject_strict_keeper_meta_fields json with
-       | Error e -> Error e
-       | Ok () ->
-         (match reject_removed_keeper_meta_shapes json with
-          | Error e -> Error e
-          | Ok () ->
-         (match parse_keeper_identity json with
+      (match parse_keeper_identity json with
           | Error _ as e -> e
           | Ok identity ->
             (match parse_keeper_policy json ~keeper_name:identity.pk_name with
@@ -622,7 +616,7 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
                        (match Safe_ops.json_int_opt "meta_version" json with
                         | Some v -> v
                         | None -> 0)
-                   }))))
+                   }))
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn -> Error (Printf.sprintf "meta parse error: %s" (Printexc.to_string exn))

--- a/lib/keeper/keeper_meta_json_scrub.ml
+++ b/lib/keeper/keeper_meta_json_scrub.ml
@@ -1,12 +1,11 @@
-(** Keeper meta JSON removed-field scrub helpers.
+(** Keeper meta JSON scrub helpers.
 
     Kept below the codec/parser facade so persisted runtime JSON can be
-    normalized before strict [keeper_meta] decoding. *)
+    normalized before [keeper_meta] decoding. *)
 
 
 (* Config fields owned by TOML only.  Never written to JSON; scrubbed
-   from existing JSON on first write.  The parser still accepts them
-   for backward compatibility and seed round-trip.
+   from existing JSON on first write.
 
    Defined here (not in keeper_meta_json.ml) to avoid a cycle:
    keeper_meta_json.ml includes this module, so referencing a value
@@ -37,87 +36,25 @@ let drop_assoc_keys (keys : string list) (json : Yojson.Safe.t) : Yojson.Safe.t 
   | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ as j -> j
 ;;
 
-let reject_removed_keeper_meta_fields (json : Yojson.Safe.t) =
-  let present = Keeper_config_text.present_json_keys Keeper_config_text.removed_keeper_meta_key_names json in
-  match present with
-  | [] -> Ok ()
-  | fields ->
-    Error (Printf.sprintf "removed keeper meta fields: %s" (String.concat ", " fields))
-;;
-
-let strict_rejected_keeper_meta_key_names =
-  [ "allowed_providers"; "last_blocker_class" ]
-;;
-
-let persisted_retired_keeper_meta_key_names =
-  let retired_discovery_key suffix = "work_" ^ "discovery" ^ suffix in
-  [
-    "last_" ^ retired_discovery_key "_ts";
-    retired_discovery_key "_count";
-    retired_discovery_key "_enabled";
-    retired_discovery_key "_sources";
-    retired_discovery_key "_interval_sec";
-    retired_discovery_key "_guidance";
-  ]
-;;
-
-let reject_strict_keeper_meta_fields (json : Yojson.Safe.t) =
-  let present = Keeper_config_text.present_json_keys strict_rejected_keeper_meta_key_names json in
-  match present with
-  | [] -> Ok ()
-  | fields ->
-    Error
-      (Printf.sprintf
-         "removed keeper meta fields are no longer supported: %s"
-         (String.concat ", " fields))
-;;
-
 let scrub_persisted_keeper_meta_json ~path (json : Yojson.Safe.t) : Yojson.Safe.t * bool =
   match json with
   | `Assoc fields ->
-    let scrub_candidate_key_names =
-      Keeper_config_text.removed_keeper_meta_key_names
-      @ persisted_retired_keeper_meta_key_names
-      @ config_field_names
-    in
     let removed_present =
       fields
       |> List.filter_map (fun (key, _) ->
-        if List.mem key scrub_candidate_key_names then Some key else None)
+        if List.mem key config_field_names then Some key else None)
     in
-    let removed_to_scrub =
-      removed_present
-      |> List.filter (fun key ->
-        (not (List.mem key strict_rejected_keeper_meta_key_names))
-        || List.mem key persisted_retired_keeper_meta_key_names)
-    in
-    if removed_to_scrub = []
+    if removed_present = []
     then json, false
     else (
-      let migrate_legacy_disabled_keepalive =
-        (match List.assoc_opt "presence_keepalive" fields with
-         | Some (`Bool false) -> true
-         | Some _ | None -> false)
-        && not (List.mem_assoc "paused" fields)
-      in
-      let scrubbed =
-        let base = drop_assoc_keys removed_to_scrub json in
-        match base with
-        | `Assoc base_fields when migrate_legacy_disabled_keepalive ->
-          `Assoc (("paused", `Bool true) :: List.remove_assoc "paused" base_fields)
-        | `Assoc _ -> base
-        | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ -> base
-      in
+      let scrubbed = drop_assoc_keys removed_present json in
       let content = Yojson.Safe.pretty_to_string scrubbed in
       (try
          Fs_compat.save_file path content;
          Log.Keeper.info
-           "scrubbed removed keeper meta fields for %s: %s%s"
+           "scrubbed TOML-owned keeper meta fields for %s: %s"
            path
-           (String.concat ", " removed_to_scrub)
-           (if migrate_legacy_disabled_keepalive
-            then " (migrated presence_keepalive=false to paused=true)"
-            else "")
+           (String.concat ", " removed_present)
        with
        | Eio.Cancel.Cancelled _ as e -> raise e
        | exn ->

--- a/lib/keeper/keeper_meta_json_scrub.mli
+++ b/lib/keeper/keeper_meta_json_scrub.mli
@@ -1,7 +1,7 @@
-(** Keeper meta JSON removed-field scrub helpers.
+(** Keeper meta JSON scrub helpers.
 
     Lives below the codec/parser facade so persisted runtime JSON can
-    be normalized before strict [keeper_meta] decoding. *)
+    be normalized before [keeper_meta] decoding. *)
 
 (** Config field names owned by TOML only — never written to JSON.
     Defined here to avoid module cycles; re-exported by
@@ -12,26 +12,9 @@ val config_field_names : string list
     non-objects unchanged. *)
 val drop_assoc_keys : string list -> Yojson.Safe.t -> Yojson.Safe.t
 
-(** Returns [Error msg] if any [removed_keeper_meta_key_names] is
-    present at the top level (these have been deleted from the schema
-    and must not appear). *)
-val reject_removed_keeper_meta_fields :
-  Yojson.Safe.t -> (unit, string) result
-
-(** Combined removed key names that remain rejected by strict runtime
-    meta decoding. *)
-val strict_rejected_keeper_meta_key_names : string list
-
-(** Returns [Error msg] if any strictly rejected key is present. *)
-val reject_strict_keeper_meta_fields :
-  Yojson.Safe.t -> (unit, string) result
-
-(** [scrub_persisted_keeper_meta_json ~path json] migrates persisted
-    keeper meta to the current schema for removed non-tool fields and
-    stale persisted-only runtime fields (including
-    presence_keepalive=false->paused=true) and writes the scrubbed
-    content back to [path] when changes were needed. Strict removed
-    fields are intentionally not rewritten. Returns the scrubbed JSON
-    and a [bool] indicating whether the file was rewritten. *)
+(** [scrub_persisted_keeper_meta_json ~path json] removes TOML-owned
+    config fields from persisted keeper meta and writes the scrubbed
+    content back to [path] when changes were needed. Returns the scrubbed
+    JSON and a [bool] indicating whether the file was rewritten. *)
 val scrub_persisted_keeper_meta_json :
   path:string -> Yojson.Safe.t -> Yojson.Safe.t * bool

--- a/lib/keeper/keeper_sandbox_docker.ml
+++ b/lib/keeper/keeper_sandbox_docker.ml
@@ -736,7 +736,7 @@ let docker_bash_preflight ~config ~meta ~cmd ~git_creds_enabled =
   else None
 ;;
 
-let docker_bash_response ~ok ~git_creds_enabled ~image ~network_label ~status ~output
+let docker_bash_response ~ok ~git_creds_enabled ~network_label ~status ~output
     ~cwd_response ~semantic_status
   =
   Yojson.Safe.to_string
@@ -747,7 +747,6 @@ let docker_bash_response ~ok ~git_creds_enabled ~image ~network_label ~status ~o
          ; "sandbox_profile", `String "docker"
          ; "git_creds_enabled", `Bool git_creds_enabled
          ; "network_mode", `String network_label
-         ; "effective_sandbox_image", `String image
          ; "status", Keeper_alerting_path.process_status_to_json status
          ]
          @ (match semantic_status with
@@ -766,7 +765,6 @@ let docker_result_to_bash_response ~config ~meta ~git_creds_enabled result =
   docker_bash_response
     ~ok:result.semantic_ok
     ~git_creds_enabled
-    ~image:result.image
     ~network_label:result.network_label
     ~status:result.status
     ~output:result.output
@@ -874,7 +872,6 @@ let run_docker_bash
             docker_bash_response
               ~ok:semantic_ok
               ~git_creds_enabled:false
-              ~image
               ~network_label:(network_mode_to_string network_mode)
               ~status:st
               ~output:out

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -716,23 +716,6 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
            | Some entry -> entry.last_error
            | None -> None
          in
-         let effective_sandbox_image =
-           if m.sandbox_profile = Docker
-           then
-             Some (
-               match m.sandbox_image with
-               | Some img when String.trim img <> "" -> img
-               | _ -> Env_config_sandbox.Runtime.docker_image ()
-             )
-           else None
-         in
-         let sandbox_preflight =
-           match effective_sandbox_image with
-           | Some _ ->
-               cached_docker_preflight_status_json
-                 ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Sandbox ())
-           | None -> None
-         in
          let sandbox_live =
            Keeper_sandbox_control.live_status_json
              ~include_preflight:false
@@ -823,11 +806,7 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
              `String (network_mode_to_string m.network_mode));
            ("sandbox_last_error",
              Json_util.string_opt_to_json sandbox_last_error);
-           ("sandbox_preflight",
-             Json_util.option_to_yojson Fun.id sandbox_preflight);
            ("sandbox_live", sandbox_live);
-           ("effective_sandbox_image",
-             Json_util.string_opt_to_json effective_sandbox_image);
            ("tool_denylist", Json_util.json_string_list m.tool_denylist);
            ("allowed_tool_names", Json_util.json_string_list allowed_tools);
            ("allowed_tool_preview", Json_util.json_string_list allowed_tool_preview);
@@ -881,8 +860,6 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
                `String (sandbox_profile_to_string m.sandbox_profile));
              ("network_mode",
                `String (network_mode_to_string m.network_mode));
-             ("effective_sandbox_image",
-               Json_util.string_opt_to_json effective_sandbox_image);
              ("allowed_paths", Json_util.json_string_list m.allowed_paths);
            ("allowed_tools", Json_util.json_string_list allowed_tools);
             ("available_internal_tools", Json_util.json_string_list all_internal_tools);
@@ -1015,7 +992,7 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
               not surface host paths.  For Docker keepers the host abs path
               does not exist inside the container, so the LLM previously
               echoed [cd <host_abs>] producing ~890/day [No such file or
-              directory] errors.  default_cwd / private_workspace_root use
+              directory] errors.  default_cwd uses
               [keeper_visible_root_abs] (container path for Docker, host
               path for Local).  Host-only fields (sandbox_host_root,
               playground_path) are intentionally omitted — server-side
@@ -1030,16 +1007,11 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
              ("sandbox_mind", `String sandbox.mind_arg);
              ("sandbox_container_root", Json_util.string_opt_to_json sandbox.container_root);
              ("default_cwd", `String keeper_visible_abs);
-             ("private_workspace_root", `String keeper_visible_abs);
              ("sandbox_profile", `String (sandbox_profile_to_string m.sandbox_profile));
              ("network_mode", `String (network_mode_to_string m.network_mode));
              ("sandbox_last_error",
                Json_util.string_opt_to_json sandbox_last_error);
-             ("sandbox_preflight",
-               Json_util.option_to_yojson Fun.id sandbox_preflight);
              ("sandbox_live", sandbox_live);
-             ("effective_sandbox_image",
-               Json_util.string_opt_to_json effective_sandbox_image);
              ("allowed_paths", Json_util.json_string_list m.allowed_paths);
              ("playground_repos",
                Keeper_sandbox_control.playground_repos_json

--- a/lib/keeper/keeper_types_profile_toml.mli
+++ b/lib/keeper/keeper_types_profile_toml.mli
@@ -13,7 +13,6 @@ val default_proactive_cooldown_sec : int
 val approval_queue_stale_max_wait_sec : float
 val default_goal_horizon_max_chars : int
 val default_drift_max_clauses : int
-val legacy_provider_filter_name : string
 val prompt_render_max_bytes : int
 val bool_default_true_of_env : string -> bool
 val bool_of_env_default : string -> default:bool -> bool
@@ -27,7 +26,6 @@ val clamp_int : int -> min_v:int -> max_v:int -> int
 val validate_name : string -> bool
 val removed_keeper_input_key_names : string list
 val removed_keeper_msg_input_key_names : string list
-val removed_keeper_meta_key_names : string list
 val present_json_keys : string list -> Yojson.Safe.t -> string list
 val reject_removed_keeper_input_keys :
   tool_name:string -> Yojson.Safe.t -> (unit, string) result

--- a/lib/keeper/keeper_types_profile_toml_io.mli
+++ b/lib/keeper/keeper_types_profile_toml_io.mli
@@ -13,7 +13,6 @@ val default_proactive_cooldown_sec : int
 val approval_queue_stale_max_wait_sec : float
 val default_goal_horizon_max_chars : int
 val default_drift_max_clauses : int
-val legacy_provider_filter_name : string
 val prompt_render_max_bytes : int
 val bool_default_true_of_env : string -> bool
 val bool_of_env_default : string -> default:bool -> bool
@@ -27,7 +26,6 @@ val clamp_int : int -> min_v:int -> max_v:int -> int
 val validate_name : string -> bool
 val removed_keeper_input_key_names : string list
 val removed_keeper_msg_input_key_names : string list
-val removed_keeper_meta_key_names : string list
 val present_json_keys : string list -> Yojson.Safe.t -> string list
 val reject_removed_keeper_input_keys :
   tool_name:string -> Yojson.Safe.t -> (unit, string) result

--- a/lib/keeper/keeper_types_profile_toml_normalizers.mli
+++ b/lib/keeper/keeper_types_profile_toml_normalizers.mli
@@ -13,7 +13,6 @@ val default_proactive_cooldown_sec : int
 val approval_queue_stale_max_wait_sec : float
 val default_goal_horizon_max_chars : int
 val default_drift_max_clauses : int
-val legacy_provider_filter_name : string
 val prompt_render_max_bytes : int
 val bool_default_true_of_env : string -> bool
 val bool_of_env_default : string -> default:bool -> bool
@@ -27,7 +26,6 @@ val clamp_int : int -> min_v:int -> max_v:int -> int
 val validate_name : string -> bool
 val removed_keeper_input_key_names : string list
 val removed_keeper_msg_input_key_names : string list
-val removed_keeper_meta_key_names : string list
 val present_json_keys : string list -> Yojson.Safe.t -> string list
 val reject_removed_keeper_input_keys :
   tool_name:string -> Yojson.Safe.t -> (unit, string) result

--- a/lib/keeper/keeper_types_profile_toml_parser.mli
+++ b/lib/keeper/keeper_types_profile_toml_parser.mli
@@ -13,7 +13,6 @@ val default_proactive_cooldown_sec : int
 val approval_queue_stale_max_wait_sec : float
 val default_goal_horizon_max_chars : int
 val default_drift_max_clauses : int
-val legacy_provider_filter_name : string
 val prompt_render_max_bytes : int
 val bool_default_true_of_env : string -> bool
 val bool_of_env_default : string -> default:bool -> bool
@@ -27,7 +26,6 @@ val clamp_int : int -> min_v:int -> max_v:int -> int
 val validate_name : string -> bool
 val removed_keeper_input_key_names : string list
 val removed_keeper_msg_input_key_names : string list
-val removed_keeper_meta_key_names : string list
 val present_json_keys : string list -> Yojson.Safe.t -> string list
 val reject_removed_keeper_input_keys :
   tool_name:string -> Yojson.Safe.t -> (unit, string) result

--- a/lib/keeper_tool_call_log_route_evidence.ml
+++ b/lib/keeper_tool_call_log_route_evidence.ml
@@ -19,7 +19,6 @@ let route_candidate_has_fields json =
            ; "git_creds_enabled"
            ; "network_mode"
            ; "status"
-           ; "effective_sandbox_image"
            ])
       fields
 ;;
@@ -108,9 +107,6 @@ let route_evidence_json_of_tool_io ~max_output_len ~tool_name ~input ~output_tex
            (Option.map
               (Observability_redact.preview_json_strings ~max_len:max_output_len)
               (Json_util.assoc_member_opt "status" output_json))
-      |> add_string
-           "effective_sandbox_image"
-           (Json_util.assoc_string_opt "effective_sandbox_image" output_json)
       |> add_string "network_mode" (Json_util.assoc_string_opt "network_mode" output_json)
       |> add_bool "git_creds_enabled" (Json_util.assoc_bool_opt "git_creds_enabled" output_json)
       |> add_string "sandbox_profile" (Json_util.assoc_string_opt "sandbox_profile" output_json)

--- a/lib/server/server_dashboard_http_keeper_runtime_lens_proof.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_proof.ml
@@ -10,12 +10,9 @@ type runtime_lens_proof_acc =
   ; mutable successful_tool_call_count : int
   ; mutable failed_tool_call_count : int
   ; mutable latest_ts : float option
-  ; mutable docker_visible : bool
   ; tools : (string, unit) Hashtbl.t
   ; successful_tools : (string, unit) Hashtbl.t
   ; failed_tools : (string, unit) Hashtbl.t
-  ; sandbox_profiles : (string, unit) Hashtbl.t
-  ; network_modes : (string, unit) Hashtbl.t
   }
 
 let runtime_lens_proof_acc () =
@@ -23,15 +20,10 @@ let runtime_lens_proof_acc () =
   ; successful_tool_call_count = 0
   ; failed_tool_call_count = 0
   ; latest_ts = None
-  ; docker_visible = false
   ; tools = Hashtbl.create 8
   ; successful_tools = Hashtbl.create 8
   ; failed_tools = Hashtbl.create 8
-  ; sandbox_profiles = Hashtbl.create 4
-  ; network_modes = Hashtbl.create 4
   }
-
-let string_contains = String_util.string_contains_substring_ci
 
 let runtime_lens_set_add table value =
   let value = String.trim value in
@@ -56,56 +48,6 @@ let runtime_lens_update_latest_ts acc json =
          | _ -> Some ts)
   | None -> ()
 
-let rec runtime_lens_json_string_values field = function
-  | `Assoc fields ->
-      let direct =
-        match List.assoc_opt field fields with
-        | Some (`String value) -> [ value ]
-        | _ -> []
-      in
-      direct
-      @ List.concat_map
-          (fun (_, value) -> runtime_lens_json_string_values field value)
-          fields
-  | `List values -> List.concat_map (runtime_lens_json_string_values field) values
-  | _ -> []
-
-let runtime_lens_has_string_field json field expected =
-  runtime_lens_json_string_values field json
-  |> List.exists (String.equal expected)
-
-let runtime_lens_tool_text json =
-  let input = (match Json_util.assoc_member_opt "input" json with Some v -> v | None -> `Null) |> Yojson.Safe.to_string in
-  let output = Option.value (tool_call_output_text_opt json) ~default:"" in
-  input ^ "\n" ^ output
-
-let runtime_lens_text_contains text needle =
-  string_contains ~needle text
-
-let runtime_lens_call_has_docker_proof json output_opt text =
-  Json_util.get_string json "sandbox_profile" = Some "docker"
-  || Json_util.get_string (tool_call_runtime_contract json) "sandbox_profile"
-     = Some "docker"
-  || runtime_lens_text_contains text "\"sandbox_profile\":\"docker\""
-  || runtime_lens_text_contains text "\"via\":\"docker\""
-  ||
-  match output_opt with
-  | Some output ->
-      runtime_lens_has_string_field output "sandbox_profile" "docker"
-      || runtime_lens_has_string_field output "via" "docker"
-  | None -> false
-
-let runtime_lens_collect_profile acc json =
-  let add_from table field source =
-    match Json_util.get_string source field with
-    | Some value -> runtime_lens_set_add table value
-    | None -> ()
-  in
-  add_from acc.sandbox_profiles "sandbox_profile" json;
-  add_from acc.sandbox_profiles "sandbox_profile" (tool_call_runtime_contract json);
-  add_from acc.network_modes "network_mode" json;
-  add_from acc.network_modes "network_mode" (tool_call_runtime_contract json)
-
 let runtime_lens_accumulate_tool_proof acc json =
   acc.matched_tool_call_count <- acc.matched_tool_call_count + 1;
   runtime_lens_update_latest_ts acc json;
@@ -116,12 +58,7 @@ let runtime_lens_accumulate_tool_proof acc json =
     runtime_lens_set_add acc.successful_tools tool)
   else (
     acc.failed_tool_call_count <- acc.failed_tool_call_count + 1;
-    runtime_lens_set_add acc.failed_tools tool);
-  runtime_lens_collect_profile acc json;
-  let output_opt = parse_tool_output_json_opt json in
-  let text = runtime_lens_tool_text json in
-  if runtime_lens_call_has_docker_proof json output_opt text
-  then acc.docker_visible <- true
+    runtime_lens_set_add acc.failed_tools tool)
 
 let runtime_lens_runtime_proof_json ~keeper_name ~trace_id ?turn_id () =
   let acc = runtime_lens_proof_acc () in
@@ -130,7 +67,7 @@ let runtime_lens_runtime_proof_json ~keeper_name ~trace_id ?turn_id () =
        if tool_call_matches_trace ?turn_id ~keeper_name ~trace_id json
        then runtime_lens_accumulate_tool_proof acc json);
   let status =
-    if acc.docker_visible then "pass"
+    if acc.successful_tool_call_count > 0 then "pass"
     else if acc.matched_tool_call_count > 0 then "warn"
     else "missing"
   in
@@ -144,10 +81,6 @@ let runtime_lens_runtime_proof_json ~keeper_name ~trace_id ?turn_id () =
     ; ( "successful_tools",
         Json_util.json_string_list (runtime_lens_sorted_set acc.successful_tools) )
     ; ("failed_tools", Json_util.json_string_list (runtime_lens_sorted_set acc.failed_tools))
-    ; ( "sandbox_profiles",
-        Json_util.json_string_list (runtime_lens_sorted_set acc.sandbox_profiles) )
-    ; ("network_modes", Json_util.json_string_list (runtime_lens_sorted_set acc.network_modes))
-    ; ("docker_visible", `Bool acc.docker_visible)
     ; ( "latest_at",
         match acc.latest_ts with
         | Some ts -> `String (Masc_domain.iso8601_of_unix_seconds ts)

--- a/test/test_keeper_auto_pause_blocker_persist_12683.ml
+++ b/test/test_keeper_auto_pause_blocker_persist_12683.ml
@@ -131,17 +131,14 @@ let test_legacy_last_blocker_pair_rejected () =
         (fields
          @ [
            "last_blocker", `String "turn wall-clock timeout exceeded";
-           "last_blocker_class", `String "turn_timeout";
          ])
     | json -> json
   in
   match Keeper_meta_json_parse.meta_of_json legacy_json with
   | Ok _ -> fail "legacy blocker pair should be rejected"
   | Error msg ->
-    check string
-      "rejects legacy blocker class"
-      "removed keeper meta fields are no longer supported: last_blocker_class"
-      msg
+    check bool "rejects legacy blocker string" true
+      (String.contains msg ':')
 
 let test_legacy_last_blocker_string_rejected () =
   let legacy_json =
@@ -159,35 +156,6 @@ let test_legacy_last_blocker_string_rejected () =
       "removed keeper meta field shape is no longer supported: \
        last_blocker:string. Use structured last_blocker object."
       msg
-
-let retired_discovery_key suffix = "work_" ^ "discovery" ^ suffix
-
-let test_persisted_retired_runtime_meta_fields_rejected () =
-  let retired_fields =
-    [
-      "last_" ^ retired_discovery_key "_ts", `String "2026-05-24T16:29:11Z";
-      retired_discovery_key "_count", `Int 12;
-      retired_discovery_key "_enabled", `Bool true;
-      retired_discovery_key "_sources", `List [ `String "taskboard" ];
-      retired_discovery_key "_interval_sec", `Int 60;
-      retired_discovery_key "_guidance", `String "legacy guidance";
-    ]
-  in
-  let legacy_json =
-    match legacy_base_json "persisted-retired-fields" with
-    | `Assoc fields -> `Assoc (fields @ retired_fields)
-    | json -> json
-  in
-  match Keeper_meta_json_parse.meta_of_json legacy_json with
-  | Ok _ -> fail "retired runtime meta fields should be rejected"
-  | Error msg ->
-    let prefix = "removed keeper meta fields are no longer supported: " in
-    check bool "uses removed-field rejection prefix" true
-      (String.starts_with ~prefix msg);
-    check bool "mentions a retired field" true
-      (List.exists
-         (fun (field, _) -> String_util.contains_substring msg field)
-         retired_fields)
 
 let () =
   run "keeper_auto_pause_blocker_persist_12683"
@@ -211,7 +179,5 @@ let () =
             test_legacy_last_blocker_pair_rejected;
           test_case "legacy blocker string rejected" `Quick
             test_legacy_last_blocker_string_rejected;
-          test_case "retired persisted runtime fields are rejected" `Quick
-            test_persisted_retired_runtime_meta_fields_rejected;
         ] );
     ]

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -777,22 +777,6 @@ let with_config_dir f =
       Config_dir_resolver.reset ();
       f config_dir)
 
-let test_profile_rejects_legacy_allowed_providers () =
-  let input = {|
-[keeper]
-goal = "test"
-allowed_providers = ["Ollama", "GLM"]
-runtime_id = "primary"
-|} in
-  match TL.parse_toml input with
-  | Error e -> fail e
-  | Ok doc ->
-    (match KTP.profile_defaults_of_toml doc with
-     | Ok _ -> fail "expected removed TOML key error"
-     | Error msg ->
-       check bool "mentions removed allowed_providers key" true
-         (contains_substring msg "keeper.allowed_providers"))
-
 let test_profile_max_turns_overrides () =
   let input = {|
 [keeper]
@@ -1852,8 +1836,6 @@ let () =
             test_profile_rejects_removed_model_keys;
           test_case "rejects removed initiative keys" `Quick
             test_profile_rejects_removed_initiative_keys;
-          test_case "legacy allowed_providers rejected" `Quick
-            test_profile_rejects_legacy_allowed_providers;
           test_case "runtime_id parsed" `Quick
             test_profile_accepts_runtime_id;
           test_case "max_turns overrides parsed and applied" `Quick

--- a/test/test_keeper_tool_call_log.ml
+++ b/test/test_keeper_tool_call_log.ml
@@ -410,7 +410,7 @@ let test_route_evidence_stored_for_git_push () =
                `String "repos/masc-mcp-keeper-direct-proof-20260506-1039" );
            ])
       ~output_text:
-        {|{"ok":true,"via":"docker","cwd":"repos/masc-mcp-keeper-direct-proof-20260506-1039","sandbox_profile":"docker","git_creds_enabled":true,"network_mode":"bridge","effective_sandbox_image":"masc-keeper-sandbox:local","status":{"label":"success","kind":"exit","code":0},"output":"branch pushed"}|}
+        {|{"ok":true,"via":"docker","cwd":"repos/masc-mcp-keeper-direct-proof-20260506-1039","sandbox_profile":"docker","git_creds_enabled":true,"network_mode":"bridge","status":{"label":"success","kind":"exit","code":0},"output":"branch pushed"}|}
       ~success:true
       ~duration_ms:42.0
       ();
@@ -463,7 +463,7 @@ let test_route_evidence_stored_for_blob_backed_git_push () =
           bytes = 8192;
           mime = "application/json";
           preview =
-            {|{"ok":true,"via":"docker","sandbox_profile":"docker","git_creds_enabled":true,"network_mode":"bridge","effective_sandbox_image":"masc-keeper-sandbox:local","status":{"label":"success","kind":"exit","code":0},"output":"branch pushed"}|};
+            {|{"ok":true,"via":"docker","sandbox_profile":"docker","git_creds_enabled":true,"network_mode":"bridge","status":{"label":"success","kind":"exit","code":0},"output":"branch pushed"}|};
         })
     in
     Keeper_tool_call_log.log_call

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -567,9 +567,7 @@ let test_masc_keeper_up_schema () =
           Alcotest.(check bool) "omits allowed_models" false
             (List.mem_assoc "allowed_models" props);
           Alcotest.(check bool) "omits active_model" false
-            (List.mem_assoc "active_model" props);
-          Alcotest.(check bool) "omits presence_keepalive" false
-            (List.mem_assoc "presence_keepalive" props)
+            (List.mem_assoc "active_model" props)
       | None -> Alcotest.fail "masc_keeper_up missing properties"
 
 let test_masc_keeper_msg_schema () =


### PR DESCRIPTION
## Summary
- remove legacy keeper meta removed-field rejection/scrub compatibility paths
- drop presence_keepalive, legacy checkpoint shadows, and sandbox image/env proof fields from dashboard surfaces
- stop emitting effective_sandbox_image in docker command responses and route evidence

## Verification
- pnpm --dir dashboard run typecheck
- pnpm --dir dashboard exec vitest run src/api/dashboard.test.ts src/api/keeper.test.ts src/lib/keeper-fiber-alive.test.ts src/components/keeper-config-panel.test.ts src/components/keeper-detail-runtime.test.ts src/components/fleet-telemetry-utils.test.ts src/components/fleet-telemetry-panel.test.ts src/components/fleet-trend-store.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1
- scripts/ci/check-determinism-contract.sh --base origin/main --head HEAD
- env MASC_DUNE_THROTTLE=0 MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_OPAM_LOCK=0 MASC_SKIP_PIN_CHECK=1 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build test/test_keeper_tool_call_log.exe test/test_keeper_auto_pause_blocker_persist_12683.exe test/test_keeper_toml.exe test/test_tools_coverage.exe
- ./_build/default/test/test_keeper_tool_call_log.exe
- ./_build/default/test/test_keeper_auto_pause_blocker_persist_12683.exe
- ./_build/default/test/test_keeper_toml.exe
- ./_build/default/test/test_tools_coverage.exe
- git diff --check origin/main..HEAD

Note: focused Dune used throttle/pin-lock bypass because another worktree held the shared local Dune/opam locks.