### PR TITLE
Fix keeper playground contract build

### DIFF
--- a/lib/keeper/agent_tool_execute_typed_input.ml
+++ b/lib/keeper/agent_tool_execute_typed_input.ml
@@ -568,6 +568,22 @@ let executable_not_allowlisted_hint ~name ~mode =
       Some
         "Shell interpreters are intentionally unavailable. Use typed \
          executable/argv, or explicit pipeline stages, without shell syntax."
+    | _, "mkdir" ->
+      Some
+        "Directory materialization is handled by structured file/write or \
+         worktree workflows, not by Execute. Use tool_write_file/tool_edit_file \
+         for file changes, or a git/worktree workflow when a repo checkout is \
+         needed."
+    | _, "touch" ->
+      Some
+        "Empty placeholder creation is not an Execute capability. Use \
+         tool_write_file with the intended content, or skip the placeholder \
+         when no content is needed."
+    | _, "test" ->
+      Some
+        "Shell conditionals are not standalone Execute programs. Use stat, ls, \
+         git status, or the visible structured task/file tools for existence \
+         checks."
     | _, "rm" | _, "chmod" | _, "chown" | _, "sudo" ->
       Some
         "This executable is privileged/destructive. Use a dedicated structured \

--- a/lib/keeper/agent_tool_execute_typed_input.ml
+++ b/lib/keeper/agent_tool_execute_typed_input.ml
@@ -571,14 +571,13 @@ let executable_not_allowlisted_hint ~name ~mode =
     | _, "mkdir" ->
       Some
         "Directory materialization is handled by structured file/write or \
-         worktree workflows, not by Execute. Use tool_write_file/tool_edit_file \
-         for file changes, or a git/worktree workflow when a repo checkout is \
-         needed."
+         worktree workflows, not by Execute. Use Write/Edit when visible for \
+         file changes, or a git/worktree workflow when a repo checkout is needed."
     | _, "touch" ->
       Some
         "Empty placeholder creation is not an Execute capability. Use \
-         tool_write_file with the intended content, or skip the placeholder \
-         when no content is needed."
+         Write with the intended content, or skip the placeholder when no \
+         content is needed."
     | _, "test" ->
       Some
         "Shell conditionals are not standalone Execute programs. Use stat, ls, \

--- a/lib/keeper/keeper_agent_error.ml
+++ b/lib/keeper/keeper_agent_error.ml
@@ -84,8 +84,6 @@ let sdk_termination_semantics = function
   | Agent_sdk.Error.Agent (Agent_sdk.Error.AgentExecutionTimeout _)
   | Agent_sdk.Error.Agent (Agent_sdk.Error.AgentExecutionIdleTimeout _) ->
     Oas_agent_execution_timeout
-  | Agent_sdk.Error.Agent (Agent_sdk.Error.AgentExecutionIdleTimeout _) ->
-    Oas_agent_execution_timeout
   | Agent_sdk.Error.Agent (Agent_sdk.Error.MaxTurnsExceeded _) ->
     Oas_turn_budget_exhausted
   | Agent_sdk.Error.Agent (Agent_sdk.Error.IdleDetected _) ->

--- a/lib/keeper/keeper_status_bridge_blocker.ml
+++ b/lib/keeper/keeper_status_bridge_blocker.ml
@@ -52,8 +52,6 @@ let blocker_class_of_sdk_error (err : Agent_sdk.Error.sdk_error) : blocker_class
      | Agent_sdk.Error.Agent (Agent_sdk.Error.AgentExecutionTimeout _)
      | Agent_sdk.Error.Agent (Agent_sdk.Error.AgentExecutionIdleTimeout _) ->
        Some Oas_agent_execution_timeout
-     | Agent_sdk.Error.Agent (Agent_sdk.Error.AgentExecutionIdleTimeout _) ->
-       Some Oas_agent_execution_timeout
      | Agent_sdk.Error.Agent (MaxTurnsExceeded _) -> Some Sdk_max_turns_exceeded
      | Agent_sdk.Error.Agent (TokenBudgetExceeded _) -> Some Sdk_token_budget_exceeded
      | Agent_sdk.Error.Agent (CostBudgetExceeded _) -> Some Sdk_cost_budget_exceeded

--- a/test/test_agent_tool_execute_typed_input.ml
+++ b/test/test_agent_tool_execute_typed_input.ml
@@ -333,7 +333,7 @@ let test_not_allowlisted_hints_self_correction () =
   check_not_allowlisted_hint
     ~name:"touch"
     ~mode:Execute_input.Dev_full
-    ~needle:"tool_write_file"
+    ~needle:"Write"
     ();
   check_not_allowlisted_hint
     ~name:"test"

--- a/test/test_agent_tool_execute_typed_input.ml
+++ b/test/test_agent_tool_execute_typed_input.ml
@@ -326,6 +326,21 @@ let test_not_allowlisted_hints_self_correction () =
     ~needle:"Shell interpreters"
     ();
   check_not_allowlisted_hint
+    ~name:"mkdir"
+    ~mode:Execute_input.Dev_full
+    ~needle:"structured file/write"
+    ();
+  check_not_allowlisted_hint
+    ~name:"touch"
+    ~mode:Execute_input.Dev_full
+    ~needle:"tool_write_file"
+    ();
+  check_not_allowlisted_hint
+    ~name:"test"
+    ~mode:Execute_input.Dev_full
+    ~needle:"Shell conditionals"
+    ();
+  check_not_allowlisted_hint
     ~name:"chmod"
     ~mode:Execute_input.Dev_full
     ~needle:"privileged/destructive"

--- a/test/test_keeper_sandbox_runner.ml
+++ b/test/test_keeper_sandbox_runner.ml
@@ -1,6 +1,8 @@
 open Alcotest
 open Masc_mcp
 
+external unsetenv : string -> unit = "masc_test_unsetenv"
+
 let temp_dir prefix =
   let dir = Filename.temp_file prefix "" in
   Unix.unlink dir;
@@ -19,6 +21,11 @@ let cleanup_dir path =
     | exception Unix.Unix_error _ -> ()
   in
   rm path
+
+let string_starts_with ~prefix value =
+  let prefix_len = String.length prefix in
+  String.length value >= prefix_len
+  && String.sub value 0 prefix_len = prefix
 
 let make_meta ~sandbox : Keeper_meta_contract.keeper_meta =
   let json =
@@ -162,6 +169,30 @@ let test_uses_backend_respects_profile () =
          (Keeper_sandbox_runner.route_via
             ~config ~meta:local_meta ~cwd:local_cwd))
 
+let test_playground_root_uses_config_base_path () =
+  let config_base = temp_dir "keeper_sandbox_config_base_" in
+  let env_base = temp_dir "keeper_sandbox_env_base_" in
+  let previous_masc_base = Sys.getenv_opt "MASC_BASE_PATH" in
+  Fun.protect
+    ~finally:(fun () ->
+      (match previous_masc_base with
+       | Some value -> Unix.putenv "MASC_BASE_PATH" value
+       | None -> unsetenv "MASC_BASE_PATH");
+      cleanup_dir config_base;
+      cleanup_dir env_base)
+    (fun () ->
+       Unix.putenv "MASC_BASE_PATH" env_base;
+       let config = Workspace.default_config config_base in
+       let meta = make_meta ~sandbox:Keeper_types_profile_sandbox.Local in
+       let host_root = Keeper_sandbox.host_root_abs_of_meta ~config meta in
+       check bool "host root under config base_path" true
+         (string_starts_with ~prefix:(config_base ^ "/") host_root);
+       check bool "host root ignores ambient MASC_BASE_PATH" false
+         (string_starts_with ~prefix:(env_base ^ "/") host_root);
+       check string "host root suffix"
+         (Filename.concat config_base ".masc/playground/runner-test")
+         (Keeper_alerting_path.strip_trailing_slashes host_root))
+
 let test_local_route_does_not_force_backend_cwd () =
   let base = temp_dir "keeper_sandbox_runner_lazy_cwd_" in
   Fun.protect
@@ -202,6 +233,10 @@ let () =
         ] )
     ; ( "routing",
         [ test_case "profile selects backend" `Quick test_uses_backend_respects_profile
+        ; test_case
+            "playground root uses config base_path"
+            `Quick
+            test_playground_root_uses_config_base_path
         ; test_case
             "local route does not force backend cwd"
             `Quick


### PR DESCRIPTION
Summary:
- remove duplicate AgentExecutionIdleTimeout match arms that broke -warn-error builds
- keep mkdir/touch/test out of Execute allowlist and add self-correction hints instead
- add regression coverage that keeper playground roots come from Workspace.config.base_path, not ambient MASC_BASE_PATH

Live ops:
- updated ~/.masc/config/keepers/*.toml to remove stale retired tool names from active keeper instructions
- cleaned broken ~/.masc/playground/*/repos/*/.worktrees entries; preserved valid git worktrees

Verification:
- ocamlformat --check lib/keeper/agent_tool_execute_typed_input.ml lib/keeper/keeper_status_bridge_blocker.ml lib/keeper/keeper_agent_error.ml test/test_agent_tool_execute_typed_input.ml test/test_keeper_sandbox_runner.ml
- git diff --check
- scripts/dune-local.sh build test/test_agent_tool_execute_typed_input.exe test/test_keeper_sandbox_runner.exe
- _build/default/test/test_agent_tool_execute_typed_input.exe
- _build/default/test/test_keeper_sandbox_runner.exe
- scripts/dune-local.sh build .