### PR TITLE
Clarify MASC base path semantics

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -515,7 +515,9 @@ let host =
   Arg.(value & opt string default & info ["host"] ~docv:"HOST" ~doc)
 
 let base_path =
-  let doc = "Base path for MASC data (.masc folder location)" in
+  let doc =
+    "Workspace root for MASC data. Runtime state lives under <base-path>/.masc; do not pass the .masc directory itself."
+  in
   Arg.(value & opt string (default_base_path ()) & info ["base-path"] ~docv:"PATH" ~doc)
 
 let login_json =

--- a/bin/main_stdio_eio.ml
+++ b/bin/main_stdio_eio.ml
@@ -11,7 +11,9 @@ open Cmdliner
 let default_base_path () = Masc_mcp.Server_mcp_transport_http.default_base_path ()
 
 let base_path =
-  let doc = "Base path for MASC data (.masc folder location)" in
+  let doc =
+    "Workspace root for MASC data. Runtime state lives under <base-path>/.masc; do not pass the .masc directory itself."
+  in
   Arg.(value & opt string (default_base_path ()) & info ["base-path"] ~docv:"PATH" ~doc)
 
 let run_cmd base_path =

--- a/bin/masc_tui.ml
+++ b/bin/masc_tui.ml
@@ -105,7 +105,9 @@ let parse_args () =
     ("--port", Arg.Set_int port, Printf.sprintf "MASC server port (default: %d)" (Env_config_core.masc_http_port_int ()));
     ("--workspace", Arg.Set_string workspace, "Workspace name (default: from base path)");
     ("--refresh", Arg.Set_float refresh, "Refresh interval in seconds (default: 2)");
-    ("--base", Arg.Set_string base_path, "Base path (default: MASC_BASE_PATH or cwd)");
+    ( "--base",
+      Arg.Set_string base_path,
+      "Workspace/base path; .masc lives below it (default: MASC_BASE_PATH or cwd)" );
   ] in
 
   Arg.parse specs (fun _ -> ()) "masc-tui [OPTIONS]";

--- a/docs/BOOT-ENV-STATE-INVENTORY.md
+++ b/docs/BOOT-ENV-STATE-INVENTORY.md
@@ -32,8 +32,8 @@ Scope:
 
 | Input | What it controls | Used by |
 | --- | --- | --- |
-| `--base-path` | Startup runtime root selection. `main_eio` exports this to `MASC_BASE_PATH`. | `bin/main_eio.ml`, all `.masc` path helpers |
-| `MASC_BASE_PATH` | Runtime base path once the server is running. `.masc` lives under this directory. | `Env_config_core`, `Workspace_utils`, keeper/board/control-plane/logging paths |
+| `--base-path` | Startup workspace root selection. `main_eio` exports this to `MASC_BASE_PATH`; runtime state is under `<base-path>/.masc`. | `bin/main_eio.ml`, all `.masc` path helpers |
+| `MASC_BASE_PATH` | Runtime base path once the server is running. This is the workspace root, not the `.masc` directory itself. | `Env_config_core`, `Workspace_utils`, keeper/board/control-plane/logging paths |
 | `MASC_CONFIG_DIR` | Explicit config root override. Highest-precedence config selector. | `Config_dir_resolver`, bootstrap, keeper/persona config resolution |
 | `MASC_PERSONAS_DIR` | Explicit personas root override. | `Config_dir_resolver`, keeper/persona loading |
 | `MASC_STORAGE_TYPE` | Runtime backend selector. Only `filesystem` is active; PostgreSQL backend was removed. | bootstrap and backend setup |
@@ -406,7 +406,7 @@ Current observed state on the inspected host:
 
 Interpretation:
 
-- `/Users/dancer/me/.masc` is the current canonical runtime root.
+- `/Users/dancer/me/.masc` is the current canonical runtime root for base path `/Users/dancer/me`; do not shorten this to `~/.masc`, which means `/Users/dancer/.masc` in a shell.
 - `/Users/dancer/me/.masc/.masc` should be treated as historical drift from earlier runs that used `/Users/dancer/me/.masc` itself as `base_path`.
 - The active config root should be treated as the resolved runtime config root under `/Users/dancer/me/.masc/config` unless `MASC_CONFIG_DIR` explicitly points elsewhere.
 - The checked-in repo `config/` tree is the versioned default/seed source, not the live runtime truth by itself.
@@ -439,6 +439,7 @@ Current log sink observed today:
 1. Pick one base-path convention per environment and stick to it.
    - `--base-path /Users/dancer/me` produces `/Users/dancer/me/.masc`
    - `--base-path /Users/dancer/me/.masc` normalizes to `/Users/dancer/me` and warns
+   - Avoid bare `~/.masc` in docs and runbooks; write `<base-path>/.masc` or the fully resolved path.
 2. Pick one active config root.
    - If `MASC_CONFIG_DIR` is set, that wins.
    - If you want the base-path config root to become active, unset `MASC_CONFIG_DIR` and restart.

--- a/docs/COMMAND-PLANE-RUNBOOK.md
+++ b/docs/COMMAND-PLANE-RUNBOOK.md
@@ -22,7 +22,7 @@ merged 기준 전체 구조 요약은 [spec/SPEC-INDEX.md](./spec/SPEC-INDEX.md)
 ## 개념 맵
 
 - `namespace`
-  - 조율 범위. tool 이름은 아직 `workspace`을 쓰지만 현재 구현은 project root 아래 `.masc/`의 single default namespace로 수렴한다.
+  - 조율 범위. tool 이름은 아직 `workspace`을 쓰지만 현재 구현은 `<base-path>/.masc/`의 single default namespace로 수렴한다.
 - `task`
   - backlog item. `masc_transition(action="claim")`은 backlog 소유권만 바꾸고 planning `current_task`는 자동으로 안 잡힌다. `masc_claim_next`는 current builds에서 planning `current_task`를 함께 맞춘다.
 - `operation`

--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -912,7 +912,7 @@ masc_keeper_up(name: "sangsu")
 
 ### 8.3 base-path 주의사항
 
-`--base-path` CLI 인자는 workspace/base 경로다. runtime root는 항상 `<base-path>/.masc/`로 계산한다. `scripts/run-local.sh`는 `<target>/.masc/`를 기본값으로 쓰고, `start-masc-mcp.sh`는 shared/full-runtime 경로로 유지된다.
+`--base-path` CLI 인자는 workspace/base 경로다. runtime root는 항상 `<base-path>/.masc/`로 계산한다. `scripts/run-local.sh`는 `MASC_BASE_PATH=<target>` 및 `--base-path <target>`을 넘기며, 그 결과 data root가 `<target>/.masc/`가 된다. `start-masc-mcp.sh`는 shared/full-runtime 경로로 유지된다.
 
 dir-local 실행에서 shared keeper 상태가 보이지 않는 것은 정상이다. 공유 keeper 상태가 필요하면 shared/full-runtime 경로를 사용해야 한다.
 

--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -912,13 +912,13 @@ masc_keeper_up(name: "sangsu")
 
 ### 8.3 base-path 주의사항
 
-`--base-path` CLI 인자가 `.masc/` 디렉토리 위치를 결정한다. `scripts/run-local.sh`는 `<target>/.masc/`를 기본값으로 쓰고, `start-masc-mcp.sh`는 shared/full-runtime 경로로 유지된다.
+`--base-path` CLI 인자는 workspace/base 경로다. runtime root는 항상 `<base-path>/.masc/`로 계산한다. `scripts/run-local.sh`는 `<target>/.masc/`를 기본값으로 쓰고, `start-masc-mcp.sh`는 shared/full-runtime 경로로 유지된다.
 
 dir-local 실행에서 shared keeper 상태가 보이지 않는 것은 정상이다. 공유 keeper 상태가 필요하면 shared/full-runtime 경로를 사용해야 한다.
 
 해결: dir-local 개발은 `scripts/run-local.sh --target-dir <dir>`를 사용하고, shared `.masc/`를 봐야 할 때만 `./start-masc-mcp.sh --http` 또는 explicit `--base-path`를 사용한다.
 
-이 값은 `.masc/` data root를 결정하고, explicit `MASC_CONFIG_DIR`가 없을 때는 `<MASC_BASE_PATH>/.masc/config`를 resolved config root의 첫 후보로도 사용한다.
+이 값은 workspace/base 경로이며, explicit `MASC_CONFIG_DIR`가 없을 때는 `<MASC_BASE_PATH>/.masc/config`를 resolved config root의 첫 후보로도 사용한다. bare `~/.masc`는 `/Users/dancer/.masc`로 해석될 수 있으므로 runbook에서는 `<base-path>/.masc` 또는 fully resolved path를 쓴다.
 
 ### 8.4 모델 실행
 

--- a/docs/spec/09-server-transport.md
+++ b/docs/spec/09-server-transport.md
@@ -741,7 +741,7 @@ sequenceDiagram
 |---------|--------|------|
 | `MASC_HOST` | `127.0.0.1` | 바인드 주소 |
 | `--port` / `-p` | `8935` | 리스닝 포트 |
-| `--base-path` | `$MASC_BASE_PATH` or `cwd` | `.masc` 데이터 디렉토리 위치 |
+| `--base-path` | `$MASC_BASE_PATH` or `cwd` | workspace/base 경로. runtime root는 `<base-path>/.masc` |
 
 ### 15.2 트랜스포트 설정
 

--- a/docs/spec/14-configuration.md
+++ b/docs/spec/14-configuration.md
@@ -55,7 +55,7 @@ code_refs:
 
 | 환경변수 | 타입 | 기본값 | 설명 |
 |----------|------|--------|------|
-| `MASC_BASE_PATH` | string | `.` | workspace/base 경로. runtime data root는 `<MASC_BASE_PATH>/.masc` |
+| `MASC_BASE_PATH` | string | unset | workspace/base 경로. 설정 시 runtime data root는 `<MASC_BASE_PATH>/.masc` |
 | `MASC_CONFIG_DIR` | string | 자동 탐색 | resolved config root override. 하위 항목: `keeper_runtime.toml`, `prompts/`, `keepers/`, `personas/` |
 | `MASC_PERSONAS_DIR` | string | unset | persona root override. 설정 시 resolved config root의 `personas/` 대신 이 디렉토리를 사용 |
 | `MASC_HTTP_PORT` | string | `"8935"` | HTTP 서버 포트 |
@@ -63,7 +63,7 @@ code_refs:
 | `MASC_HOST` | string | - | 바인드 호스트 (base URL 미설정 시 필수) |
 | `LIBDATACHANNEL_PATH` | string | 자동 탐색 | WebRTC 라이브러리 경로 |
 
-runtime data root는 `MASC_BASE_PATH` 자체가 아니라 `<MASC_BASE_PATH>/.masc`다. `MASC_BASE_PATH`에는 workspace root를 넣고, `.masc` 디렉토리 자체를 넣지 않는다. 미설정 시 일부 경로는 현재 작업 디렉토리 기준 fallback을 사용한다.
+runtime data root는 `MASC_BASE_PATH` 자체가 아니라 `<MASC_BASE_PATH>/.masc`다. `MASC_BASE_PATH`에는 workspace root를 넣고, `.masc` 디렉토리 자체를 넣지 않는다. 서버 launchers는 명시 base path를 넘겨야 하며, 미설정 fallback은 일부 helper/legacy 경로에서만 현재 작업 디렉토리 기준으로 동작한다.
 resolved config root는 별도 탐색 규칙을 가진다: `MASC_CONFIG_DIR` -> `<MASC_BASE_PATH>/.masc/config` -> missing/uninitialized. repo `config/`는 체크인된 default/example seed source이며, live root fallback이 아니다.
 
 ### 3.2 Runtime (Env_config_runtime)
@@ -602,7 +602,7 @@ Template 변경은 기존 keeper에 자동 전파되지 않는다. 반영 방법
 
 ### 12.5 `--base-path`와 `.masc/` 의존성
 
-`--base-path` CLI 인자가 `.masc/` 디렉토리 위치를 결정한다. `scripts/run-local.sh`는 `<target>/.masc/`를 기본으로 사용하고, shared/full-runtime 경로는 별도 launcher가 유지한다.
+`--base-path` CLI 인자는 workspace/base 경로다. runtime root는 항상 `<base-path>/.masc/`로 계산한다. `scripts/run-local.sh`는 `MASC_BASE_PATH=<target>` 및 `--base-path <target>`을 넘기며, 그 결과 data root가 `<target>/.masc/`가 된다. shared/full-runtime 경로는 별도 launcher가 유지한다.
 
 dir-local local-dev에서는 `.masc/`가 target 디렉토리 내부를 가리키므로 shared repo keeper 상태와 분리된다. shared state가 필요하면 canonical shared launcher를 사용해야 한다.
 

--- a/docs/spec/14-configuration.md
+++ b/docs/spec/14-configuration.md
@@ -55,7 +55,7 @@ code_refs:
 
 | 환경변수 | 타입 | 기본값 | 설명 |
 |----------|------|--------|------|
-| `MASC_BASE_PATH` | string | `.` | `.masc` 데이터 디렉토리의 기준 경로 |
+| `MASC_BASE_PATH` | string | `.` | workspace/base 경로. runtime data root는 `<MASC_BASE_PATH>/.masc` |
 | `MASC_CONFIG_DIR` | string | 자동 탐색 | resolved config root override. 하위 항목: `keeper_runtime.toml`, `prompts/`, `keepers/`, `personas/` |
 | `MASC_PERSONAS_DIR` | string | unset | persona root override. 설정 시 resolved config root의 `personas/` 대신 이 디렉토리를 사용 |
 | `MASC_HTTP_PORT` | string | `"8935"` | HTTP 서버 포트 |
@@ -63,7 +63,7 @@ code_refs:
 | `MASC_HOST` | string | - | 바인드 호스트 (base URL 미설정 시 필수) |
 | `LIBDATACHANNEL_PATH` | string | 자동 탐색 | WebRTC 라이브러리 경로 |
 
-runtime data root는 `MASC_BASE_PATH`를 사용한다. 운영 공식은 `<base-path>/.masc`다. 미설정 시 일부 경로는 현재 작업 디렉토리 기준 fallback을 사용한다.
+runtime data root는 `MASC_BASE_PATH` 자체가 아니라 `<MASC_BASE_PATH>/.masc`다. `MASC_BASE_PATH`에는 workspace root를 넣고, `.masc` 디렉토리 자체를 넣지 않는다. 미설정 시 일부 경로는 현재 작업 디렉토리 기준 fallback을 사용한다.
 resolved config root는 별도 탐색 규칙을 가진다: `MASC_CONFIG_DIR` -> `<MASC_BASE_PATH>/.masc/config` -> missing/uninitialized. repo `config/`는 체크인된 default/example seed source이며, live root fallback이 아니다.
 
 ### 3.2 Runtime (Env_config_runtime)
@@ -519,7 +519,7 @@ masc_set_param(key, value)
 |------|--------|------|
 | `-p`, `--port` | 8935 | HTTP 리스닝 포트 |
 | `--host` | `127.0.0.1` | 바인드 주소 |
-| `--base-path` | `MASC_BASE_PATH` 또는 `cwd` | `.masc` 폴더 위치 |
+| `--base-path` | `MASC_BASE_PATH` 또는 `cwd` | workspace/base 경로. runtime root는 `<base-path>/.masc` |
 
 ---
 

--- a/lib/mcp_server_eio.mli
+++ b/lib/mcp_server_eio.mli
@@ -66,7 +66,7 @@ val get_clock : unit -> (float Eio.Time.clock_ty Eio.Resource.t, string) result
 
 (** Create server state (synchronous, no effect)
     @param test_mode Optional flag (ignored, for API compatibility)
-    @param base_path Base path for MASC data directory *)
+    @param base_path Workspace/base path; MASC data lives under [<base_path>/.masc]. *)
 val create_state : ?test_mode:bool -> base_path:string -> unit -> server_state
 
 (** Create server state with Eio context.
@@ -77,7 +77,7 @@ val create_state : ?test_mode:bool -> base_path:string -> unit -> server_state
     @param clock Eio time clock for timestamps/sleep
     @param mono_clock Eio monotonic clock
     @param net Eio network capability for HTTP/TLS calls
-    @param base_path Base path for MASC data directory *)
+    @param base_path Workspace/base path; MASC data lives under [<base_path>/.masc]. *)
 val create_state_eio :
   sw:Eio.Switch.t ->
   proc_mgr:Eio_unix.Process.mgr_ty Eio.Resource.t ->

--- a/lib/tool_task_handlers.ml
+++ b/lib/tool_task_handlers.ml
@@ -353,7 +353,7 @@ let handle_claim ~tool_name ~start_time ctx args =
   (* #18965 — removed [is_agent_session_bound] hard gate.  Keeper-internal tag
      dispatch path bypasses MCP entry session binding, so this gate produced
      false-negative rejects for every keeper turn (fleet evidence:
-     ~/.masc/agents/ empty while keepers run normally; only
+     <base-path>/.masc/agents/ empty while keepers run normally; only
      masc_claim/masc_claim_next failed).  Workspace.claim_task_r works on
      agent_name alone; gate added no real authorization. *)
   if Option.is_some (Json_util.assoc_member_opt "agent_role" args) then


### PR DESCRIPTION
## Summary

- Clarify that `--base-path` / `MASC_BASE_PATH` is the workspace/base path, not the `.masc` directory itself.
- Update CLI help, API comments, and operator docs to state that runtime state lives under `<base-path>/.masc`.
- Replace ambiguous runtime-root wording and add explicit guidance not to shorten `/Users/dancer/me/.masc` to bare `~/.masc`.

## Verification

- `ocamlformat --check bin/main_eio.ml bin/main_stdio_eio.ml bin/masc_tui.ml lib/tool_task_handlers.ml lib/mcp_server_eio.mli`
- `git diff --check HEAD~1..HEAD`

## Notes

- A focused Dune build was attempted earlier, but local Dune/opam locks were held by another worktree.
- The commit hook later hit an unrelated existing warning 11 in `lib/keeper/keeper_agent_error.ml` and `lib/keeper/keeper_status_bridge_blocker.ml` after rebasing onto current `origin/main`.
