### PR TITLE
fix(exec): use canonical file tool names in block hints

### DIFF
--- a/lib/exec_policy.ml
+++ b/lib/exec_policy.ml
@@ -53,8 +53,8 @@ let command_blocked_hint ?allowed_commands name =
   let alt =
     match name with
     | "sort" | "uniq" -> " Use rg or jq for filtering."
-    | "sed" | "awk" -> " Use EditFile or WriteFile for file changes."
-    | "find" -> " Use rg --files or SearchFiles."
+    | "sed" | "awk" -> " Use Edit or Write for file changes."
+    | "find" -> " Use rg --files or Grep."
     | "curl" | "wget" ->
       " Use masc_web_fetch to fetch page content, or masc_web_search to find sources."
     | "gh" ->
@@ -80,8 +80,8 @@ let command_blocked_hint ?allowed_commands name =
          through masc_web_search or masc_web_fetch tools."
         name
     | _ when looks_like_source_code name ->
-      " This looks like source code, not a shell command - use EditFile / \
-       WriteFile / ReadFile instead."
+      " This looks like source code, not a shell command - use Edit / Write / \
+       Read instead."
     | _ -> ""
   in
   let list_label, commands =
@@ -91,8 +91,8 @@ let command_blocked_hint ?allowed_commands name =
   in
   Printf.sprintf
     "Command blocked: '%s' is not allowed. %s: %s.%s See \
-     keeper_tools_list for the exhaustive tool surface, and ReadFile / \
-     EditFile / WriteFile for file operations."
+     keeper_tools_list for the exhaustive tool surface, and Read / Edit / \
+     Write for file operations."
     name
     list_label
     commands
@@ -116,13 +116,13 @@ let block_reason_to_string = function
      per call. To change directory, use the `cwd` argument instead of `cd` - Good: \
      cwd='repos/masc-mcp', cmd='scripts/dune-local.sh build'. Bad:  cmd='cd repos/masc-mcp && dune \
      build'. For pipelines like `rg foo | wc -l`, run the primary command and process \
-     output at the LLM layer. To write files, use WriteFile."
+     output at the LLM layer. To write files, use Write."
   | Injection ->
     "Shell injection syntax (;, &&, standalone &, `, $) not allowed. Run ONE command per \
      call. To change directory, use the `cwd` argument - Good: cwd='repos/masc-mcp', \
      cmd='scripts/dune-local.sh build'. Bad:  cmd='cd repos/masc-mcp && dune build' or cmd='cmd1 ; cmd2'. \
      Relative paths resolve from `cwd` (defaults to playground root). For file writes, \
-     use EditFile or WriteFile."
+     use Edit or Write."
   | Process_substitution -> "Process substitution (<(...) or >(...)) is not allowed."
   | Unsafe_redirect ->
     "Redirect syntax is not allowed in this shell surface. Consume stdout/stderr \

--- a/test/test_worker_dev_tools.ml
+++ b/test/test_worker_dev_tools.ml
@@ -1189,6 +1189,33 @@ let () =
         Alcotest.(check bool) "still suggests tool_edit_file for A.B names"
           true
           (contains_substring msg "Edit"));
+      Alcotest.test_case "blocked-command hints use canonical file tool names" `Quick (fun () ->
+        let messages =
+          [ Worker_dev_tools.block_reason_to_string
+              (Worker_dev_tools.Command_not_allowed "sed")
+          ; Worker_dev_tools.block_reason_to_string
+              (Worker_dev_tools.Command_not_allowed "find")
+          ; Worker_dev_tools.block_reason_to_string
+              (Worker_dev_tools.Command_not_allowed "Foo.bar")
+          ; Worker_dev_tools.block_reason_to_string Worker_dev_tools.Chain_or_redirect
+          ; Worker_dev_tools.block_reason_to_string Worker_dev_tools.Injection
+          ]
+        in
+        let joined = String.concat "\n" messages in
+        List.iter
+          (fun retired ->
+             Alcotest.(check bool)
+               ("does not mention " ^ retired)
+               false
+               (contains_substring joined retired))
+          [ "ReadFile"; "EditFile"; "WriteFile"; "SearchFiles" ];
+        List.iter
+          (fun canonical ->
+             Alcotest.(check bool)
+               ("mentions " ^ canonical)
+               true
+               (contains_substring joined canonical))
+          [ "Read"; "Edit"; "Write"; "Grep" ]);
     ];
     "attribution", [
       Alcotest.test_case "Ok () → Passed with cmd in evidence" `Quick (fun () ->


### PR DESCRIPTION
## Summary\n- replace retired ReadFile/EditFile/WriteFile/SearchFiles names in exec command-blocking hints with Read/Edit/Write/Grep\n- add a worker_dev_tools regression test that command-blocked hints do not reintroduce retired file tool names\n\n## Validation\n- ocamlformat --check lib/exec_policy.ml test/test_worker_dev_tools.ml\n- rg legacy file-tool aliases in lib/exec_policy.ml\n- git diff --check\n\nNote: focused Dune build was attempted with scripts/dune-local.sh build test/test_worker_dev_tools.exe, but the wrapper refused to start because unrelated bare Dune processes were already active on this host.