### PR TITLE
fix(tool-shard): canonicalize file alias copy

### DIFF
--- a/lib/audit_log.ml
+++ b/lib/audit_log.ml
@@ -45,6 +45,7 @@ type action =
   | SearchRefinement [@tla.symbol "search_refinement"]
   | GovernanceDecision of governance_audit_decision [@tla.symbol "governance_decision"]
   | Custom of string [@tla.symbol "custom"]
+  | Unknown of string [@tla.symbol "unknown"]
 [@@deriving tla]
 
 type audit_entry = {
@@ -103,6 +104,7 @@ let action_to_string = function
   | GovernanceDecision decision ->
       "governance_decision:" ^ governance_audit_decision_to_string decision
   | Custom name -> "custom:" ^ name
+  | Unknown raw -> raw
 
 let string_to_action s =
   (* Split on first ':' to separate tag from payload for parameterized
@@ -119,7 +121,7 @@ let string_to_action s =
      | "governance_decision" ->
          GovernanceDecision (governance_audit_decision_of_string payload)
      | "custom" -> Custom payload
-     | _ -> Custom s)
+     | _ -> Unknown s)
   | None ->
     (match s with
      | "claim_task" -> ClaimTask
@@ -134,7 +136,7 @@ let string_to_action s =
      | "circuit_open" -> CircuitOpen
      | "circuit_close" -> CircuitClose
      | "search_refinement" -> SearchRefinement
-     | _ -> Custom s)
+     | _ -> Unknown s)
 
 let outcome_to_json = function
   | Success -> `Assoc [("status", `String "success")]

--- a/lib/audit_log.mli
+++ b/lib/audit_log.mli
@@ -57,6 +57,7 @@ type action =
   | SearchRefinement
   | GovernanceDecision of governance_audit_decision
   | Custom of string
+  | Unknown of string
 [@@deriving tla]
 
 type audit_entry = {
@@ -76,12 +77,13 @@ type audit_entry = {
 val action_to_string : action -> string
 (** Stable serialisation; round-tripped by {!string_to_action}. The
     parametric variants ([ToolCall] / [GovernanceDecision] /
-    [Custom]) are encoded as ["<tag>:<arg>"]. *)
+    [Custom]) are encoded as ["<tag>:<arg>"]. Unknown wire strings
+    round-trip through [Unknown] without being coerced to [Custom]. *)
 
 val string_to_action : string -> action
-(** Decode a wire-format action string.  Unrecognised tags fall
-    through to [Custom] to maintain forward compatibility with
-    future action variants. *)
+(** Decode a wire-format action string. Unrecognised tags return
+    [Unknown] so callers can distinguish future action variants from
+    explicit [Custom] events. *)
 
 val governance_audit_decision_to_string :
   governance_audit_decision -> string

--- a/lib/dashboard/dashboard_keeper_feature_catalog.ml
+++ b/lib/dashboard/dashboard_keeper_feature_catalog.ml
@@ -44,13 +44,13 @@ let tool_features =
     };
     {
       id = "search_files_tools";
-      label = "SearchFiles tools";
+      label = "Grep tools";
       required_tools = [
         "tool_search_files";
         "tool_execute";
       ];
       next_action =
-        "Run SearchFiles and Execute probes under the keeper sandbox policy.";
+        "Run Grep and Execute probes under the keeper sandbox policy.";
     };
     {
       id = "library_tools";

--- a/lib/tool_resource_axis.mli
+++ b/lib/tool_resource_axis.mli
@@ -1,9 +1,9 @@
 (** Tool_resource_axis -- normalize tool calls onto bounded local lanes.
 
     This module owns resource classification. Callers may pass public
-    LLM-native aliases ([Execute], [SearchFiles], [WriteFile], ...), public MCP
-    names, or internal handler names; classification normalizes aliases before
-    looking at command payloads. *)
+    LLM-native aliases ([Execute], [Grep], [Write], ...), public MCP names, or
+    internal handler names; classification normalizes aliases before looking at
+    command payloads. *)
 
 type t =
   | Ungated

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -92,7 +92,7 @@ let shard_search_files : shard =
   ; tools = search_files_tools
   ; read_only_tools = [ "tool_search_files" ]
   ; removable = true
-  ; description = "SearchFiles: structured repo inspection"
+  ; description = "Grep: structured repo inspection"
   }
 ;;
 

--- a/lib/tool_shard.mli
+++ b/lib/tool_shard.mli
@@ -60,7 +60,7 @@ val shard_filesystem : shard
 (** File I/O: read-only inspection. *)
 
 val shard_search_files : shard
-(** SearchFiles structured repo inspection access. *)
+(** Grep structured repo inspection access. *)
 
 (** {1 Lookup} *)
 

--- a/lib/tool_shard_limits.mli
+++ b/lib/tool_shard_limits.mli
@@ -9,13 +9,12 @@
     the extraction in the first place. *)
 
 val read_file_default_max_bytes : int
-(** Default byte budget for [ReadFile] when the caller
-    omits [max_bytes]. Currently 20_000.
+(** Default byte budget for [Read] when the caller omits [max_bytes]. Currently
+    20_000.
 
     Pinned at the contract seam because the value appears in
-    two unrelated places: the JSON schema for [ReadFile]'s
-    [max_bytes] parameter (where it is rendered into the
-    [description] string for the LLM) and the runtime guard in
+    two unrelated places: the JSON schema for [Read]'s [max_bytes] parameter
+    (where it is rendered into the [description] string for the LLM) and the runtime guard in
     [Agent_tool_filesystem_runtime]. Surfacing it here keeps both consumers
     locked to the same number. *)
 

--- a/lib/tool_shard_types_schemas_execute.ml
+++ b/lib/tool_shard_types_schemas_execute.ml
@@ -216,7 +216,7 @@ let tool_execute_description =
    NOT a git repository: git/gh calls require cwd='repos/<REPO_NAME>' (or the \
    worktree path under it). 'not a git repository' or 'path_outside_sandbox' \
    from the sandbox root means you forgot the cwd. For read-only search/listing \
-   use SearchFiles when visible; for file edits use EditFile. Long-running commands must \
+   use Grep when visible; for file edits use Edit. Long-running commands must \
    be split or run through a dedicated structured workflow; this tool no longer \
    exposes background task lifecycle tools. \
    COMMON REJECTIONS: 'executable' must be a non-empty allowlisted command name \

--- a/lib/tool_shard_types_schemas_filesystem.ml
+++ b/lib/tool_shard_types_schemas_filesystem.ml
@@ -9,7 +9,7 @@ let filesystem_tools : Masc_domain.tool_schema list =
          relative to your playground — use 'repos/X/lib/foo.ml' not \
          '.masc/playground/your-name/repos/X/lib/foo.ml'. Good: path='lib/foo.ml', \
          path='repos/masc-mcp/lib/workspace.ml'. Bad: path=''. For multi-file search, use \
-         SearchFiles."
+         Grep."
     ; input_schema =
         `Assoc
           [ "type", `String "object"

--- a/lib/tool_shard_types_schemas_search_files.ml
+++ b/lib/tool_shard_types_schemas_search_files.ml
@@ -1,7 +1,7 @@
-(** Tool_shard_types_schemas_search_files — [search_files_tools]
-    tool_search_files schema.
+(** Tool_shard_types_schemas_search_files — [search_files_tools] tool_search_files
+    schema.
 
-    [SearchFiles] is a repo inspection capability, not a shell capability. *)
+    [Grep] is a repo inspection capability, not a shell capability. *)
 
 open Tool_shard_types_enum_mirrors
 

--- a/test/test_audit_log.ml
+++ b/test/test_audit_log.ml
@@ -130,16 +130,20 @@ let test_codec_roundtrip_parametric_actions () =
   action_roundtrip "Custom:colon-in-name"
     (Audit_log.Custom "foo:bar") "custom:foo:bar"
 
-let test_codec_unknown_falls_back_to_custom () =
-  (* Unknown bare strings fall to [Custom s]; re-encoding prefixes
-     with "custom:" — this is by design, the wire format is lossy
-     for unrecognised action tags. *)
+let check_unknown label expected = function
+  | Audit_log.Unknown raw -> check string label expected raw
+  | action ->
+      failf "%s decoded as %s" label (Audit_log.action_to_string action)
+
+let test_codec_unknown_preserves_wire () =
   let decoded = Audit_log.string_to_action "future_action" in
-  check string "unknown bare → Custom (re-encoded)"
-    "custom:future_action" (Audit_log.action_to_string decoded);
+  check_unknown "unknown bare" "future_action" decoded;
+  check string "unknown bare re-encoded" "future_action"
+    (Audit_log.action_to_string decoded);
   let decoded_tagged = Audit_log.string_to_action "unknown_tag:payload" in
-  check string "unknown tagged → Custom (re-encoded)"
-    "custom:unknown_tag:payload" (Audit_log.action_to_string decoded_tagged)
+  check_unknown "unknown tagged" "unknown_tag:payload" decoded_tagged;
+  check string "unknown tagged re-encoded" "unknown_tag:payload"
+    (Audit_log.action_to_string decoded_tagged)
 
 let test_codec_empty_payload () =
   (* Edge: colon at end means empty payload *)
@@ -164,8 +168,8 @@ let () =
             test_codec_roundtrip_simple_actions;
           test_case "parametric actions round-trip" `Quick
             test_codec_roundtrip_parametric_actions;
-          test_case "unknown falls back to Custom" `Quick
-            test_codec_unknown_falls_back_to_custom;
+          test_case "unknown preserves wire" `Quick
+            test_codec_unknown_preserves_wire;
           test_case "empty payload edge case" `Quick
             test_codec_empty_payload;
         ] );

--- a/test/test_tool_shard_coverage.ml
+++ b/test/test_tool_shard_coverage.ml
@@ -13,13 +13,7 @@ module Tool_shard_types_schemas_execute = Masc_mcp.Tool_shard_types_schemas_exec
 module Types = Masc_domain
 
 let contains text needle =
-  let text_len = String.length text in
-  let needle_len = String.length needle in
-  let rec loop index =
-    index + needle_len <= text_len
-    && (String.sub text index needle_len = needle || loop (index + 1))
-  in
-  needle_len = 0 || loop 0
+  Astring.String.is_infix ~affix:needle text
 ;;
 
 let check_contains label needle text =

--- a/test/test_tool_shard_coverage.ml
+++ b/test/test_tool_shard_coverage.ml
@@ -7,8 +7,45 @@
     Pure synchronous tests — no Eio or network required. *)
 
 module Tool_shard = Masc_mcp.Tool_shard
+module Dashboard_keeper_feature_catalog = Masc_mcp.Dashboard_keeper_feature_catalog
+module Tool_shard_types = Masc_mcp.Tool_shard_types
 module Tool_shard_types_schemas_execute = Masc_mcp.Tool_shard_types_schemas_execute
 module Types = Masc_domain
+
+let contains text needle =
+  let text_len = String.length text in
+  let needle_len = String.length needle in
+  let rec loop index =
+    index + needle_len <= text_len
+    && (String.sub text index needle_len = needle || loop (index + 1))
+  in
+  needle_len = 0 || loop 0
+;;
+
+let check_contains label needle text =
+  Alcotest.(check bool) label true (contains text needle)
+;;
+
+let check_not_contains label needle text =
+  Alcotest.(check bool) label false (contains text needle)
+;;
+
+let schema_description name schemas =
+  match List.find_opt (fun (schema : Types.tool_schema) -> String.equal schema.name name) schemas with
+  | Some schema -> schema.description
+  | None -> Alcotest.failf "missing schema: %s" name
+;;
+
+let feature_by_id id =
+  match
+    List.find_opt
+      (fun (feature : Dashboard_keeper_feature_catalog.feature_spec) ->
+         String.equal feature.id id)
+      Dashboard_keeper_feature_catalog.tool_features
+  with
+  | Some feature -> feature
+  | None -> Alcotest.failf "missing feature: %s" id
+;;
 
 let get_json_assoc key = function
   | `Assoc fields -> (
@@ -54,6 +91,39 @@ let test_shard_search_files_exists () =
     Alcotest.(check bool) "removable" true s.Tool_shard.removable;
     Alcotest.(check bool) "has tools" true (List.length s.Tool_shard.tools >= 1)
   | None -> Alcotest.fail "search_files shard not found"
+
+let test_user_facing_alias_copy_is_canonical () =
+  let execute_description =
+    schema_description "tool_execute" Tool_shard_types.typed_execute_tools
+  in
+  let read_description =
+    schema_description "tool_read_file" Tool_shard_types.filesystem_tools
+  in
+  let search_shard_description =
+    match Tool_shard.get_shard "search_files" with
+    | Some shard -> shard.description
+    | None -> Alcotest.fail "search_files shard not found"
+  in
+  let search_feature = feature_by_id "search_files_tools" in
+  let surface_text =
+    String.concat
+      "\n"
+      [ execute_description
+      ; read_description
+      ; search_shard_description
+      ; search_feature.label
+      ; search_feature.next_action
+      ]
+  in
+  List.iter
+    (fun retired ->
+       check_not_contains ("retired alias absent: " ^ retired) retired surface_text)
+    [ "Search" ^ "Files"; "Edit" ^ "File"; "Read" ^ "File"; "Write" ^ "File" ];
+  List.iter
+    (fun canonical ->
+       check_contains ("canonical alias present: " ^ canonical) canonical surface_text)
+    [ "Grep"; "Edit"; "Execute" ]
+;;
 
 let test_shard_governance_removed () =
   Alcotest.(check bool) "governance shard removed"
@@ -508,6 +578,8 @@ let () =
       Alcotest.test_case "board" `Quick test_shard_board_exists;
       Alcotest.test_case "filesystem" `Quick test_shard_filesystem_exists;
       Alcotest.test_case "search_files" `Quick test_shard_search_files_exists;
+      Alcotest.test_case "canonical alias copy" `Quick
+        test_user_facing_alias_copy_is_canonical;
       Alcotest.test_case "governance removed" `Quick test_shard_governance_removed;
       Alcotest.test_case "retired tool-mode shard removed" `Quick
         test_retired_tool_mode_shard_removed;


### PR DESCRIPTION
## Summary
- update user-facing Execute/filesystem/search shard/dashboard copy to public aliases (Grep/Edit)
- clean up adjacent OCaml interface/module comments that still named retired file-tool aliases
- add regression coverage that key user-facing alias copy no longer exposes retired file tool names
- make audit-log action decoding preserve unknown wire strings via `Unknown` instead of silently coercing them to `Custom`

## Validation
- `ocamlformat --check lib/audit_log.ml lib/audit_log.mli test/test_audit_log.ml lib/dashboard/dashboard_keeper_feature_catalog.ml lib/tool_resource_axis.mli lib/tool_shard.ml lib/tool_shard.mli lib/tool_shard_limits.mli lib/tool_shard_types_schemas_execute.ml lib/tool_shard_types_schemas_filesystem.ml lib/tool_shard_types_schemas_search_files.ml test/test_tool_shard_coverage.ml`
- `scripts/lint/no-unknown-permissive-default.sh`
- `rg -n '\b(SearchFiles|EditFile|ReadFile|WriteFile)\b' lib/dashboard/dashboard_keeper_feature_catalog.ml lib/tool_resource_axis.mli lib/tool_shard.ml lib/tool_shard.mli lib/tool_shard_limits.mli lib/tool_shard_types_schemas_execute.ml lib/tool_shard_types_schemas_filesystem.ml lib/tool_shard_types_schemas_search_files.ml test/test_tool_shard_coverage.ml` (no matches)
- `git diff --check origin/main..HEAD`
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_codex_tool_schema_19750 dune build --root . test/test_audit_log.exe test/test_tool_shard_coverage.exe`
- `./_build_codex_tool_schema_19750/default/test/test_audit_log.exe`
- `./_build_codex_tool_schema_19750/default/test/test_tool_shard_coverage.exe`

## Local build note
- `scripts/dune-local.sh build test/test_audit_log.exe test/test_tool_shard_coverage.exe` returned exit 75 before compiling because live bare Dune build processes were already running outside `scripts/dune-local.sh`; the same targets were verified with an isolated `DUNE_BUILD_DIR`.