### PR TITLE
fix: repair main CI release evidence

### DIFF
--- a/docs/RELEASE-EVIDENCE.md
+++ b/docs/RELEASE-EVIDENCE.md
@@ -21,7 +21,7 @@ code_refs:
 - local boot + `/health`: isolated base path에서 서버 부팅 후 health payload 저장
 - MCP handshake: `initialize` + `tools/list` raw capture 저장
 - repo workspace collaboration read path: `masc_status` raw capture 저장
-- dashboard read paths: `/api/v1/dashboard/mission`, `/api/v1/dashboard/namespace-truth` raw capture 저장
+- dashboard read paths: `/api/v1/dashboard/project-snapshot`, `/api/v1/dashboard/namespace-truth` raw capture 저장
 - quantitative readiness: `docs/PRODUCTION-READINESS-GATES.md`의 release artifact, keeper turn evidence, performance SLO, OAS pin/boundary gate 결과를 함께 첨부
 - raw evidence: headers/body/json 정규화본 + `server.log`
 

--- a/scripts/release-evidence.sh
+++ b/scripts/release-evidence.sh
@@ -10,7 +10,7 @@ The bundle includes:
   - artifact install smoke (`--version` from an installed location)
   - local boot + /health capture
   - MCP initialize + tools/list + masc_status captures
-  - dashboard read-path captures for mission + namespace truth
+  - dashboard read-path captures for project snapshot + namespace truth
 
 Raw files are written next to OUTPUT_MARKDOWN.
 EOF
@@ -54,9 +54,9 @@ tools_json="$out_dir/tools-list.json"
 status_headers="$out_dir/masc-status.headers"
 status_body="$out_dir/masc-status.body"
 status_json="$out_dir/masc-status.json"
-mission_headers="$out_dir/dashboard-mission.headers"
-mission_body="$out_dir/dashboard-mission.body"
-mission_json="$out_dir/dashboard-mission.json"
+project_snapshot_headers="$out_dir/dashboard-project-snapshot.headers"
+project_snapshot_body="$out_dir/dashboard-project-snapshot.body"
+project_snapshot_json="$out_dir/dashboard-project-snapshot.json"
 namespace_headers="$out_dir/namespace-truth.headers"
 namespace_body="$out_dir/namespace-truth.body"
 namespace_json="$out_dir/namespace-truth.json"
@@ -312,10 +312,10 @@ post_json "$MCP_URL" "$status_payload" "$status_headers" "$status_body" \
   -H "Mcp-Protocol-Version: ${protocol_version}"
 normalize_json "$status_body" "$status_json"
 
-curl -sS -D "$mission_headers" -o "$mission_body" \
+curl -sS -D "$project_snapshot_headers" -o "$project_snapshot_body" \
   -H 'Accept: application/json' \
-  "${BASE_URL}/api/v1/dashboard/mission"
-normalize_json "$mission_body" "$mission_json"
+  "${BASE_URL}/api/v1/dashboard/project-snapshot"
+normalize_json "$project_snapshot_body" "$project_snapshot_json"
 
 curl -sS -D "$namespace_headers" -o "$namespace_body" \
   -H 'Accept: application/json' \
@@ -333,7 +333,7 @@ python3 - \
   "$health_json" \
   "$tools_json" \
   "$status_json" \
-  "$mission_json" \
+  "$project_snapshot_json" \
   "$namespace_json" \
   "$initialize_json" \
   "$server_log" <<'PY'
@@ -353,7 +353,7 @@ from datetime import datetime, timezone
     health_json,
     tools_json,
     status_json,
-    mission_json,
+    project_snapshot_json,
     namespace_json,
     initialize_json,
     server_log,
@@ -366,7 +366,7 @@ def load(path):
 health = load(health_json)
 tools = load(tools_json)
 status = load(status_json)
-mission = load(mission_json)
+project_snapshot = load(project_snapshot_json)
 namespace_truth = load(namespace_json)
 initialize = load(initialize_json)
 
@@ -378,7 +378,7 @@ for item in content:
       status_text = item.get("text", "")
       break
 
-mission_keys = sorted(mission.keys())[:10]
+project_snapshot_keys = sorted(project_snapshot.keys())[:10]
 namespace_keys = sorted(namespace_truth.keys())[:10]
 health_keys = sorted(health.keys())[:10]
 generated_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -419,7 +419,7 @@ md = f"""# Release Evidence Bundle
 
 ## Dashboard Read Paths
 
-- `/api/v1/dashboard/mission` returned HTTP-shaped JSON with keys: `{", ".join(mission_keys)}`
+- `/api/v1/dashboard/project-snapshot` returned HTTP-shaped JSON with keys: `{", ".join(project_snapshot_keys)}`
 - `/api/v1/dashboard/namespace-truth` returned keys: `{", ".join(namespace_keys)}`
 
 ## Raw Captures
@@ -431,7 +431,7 @@ md = f"""# Release Evidence Bundle
 - `initialize.json`
 - `tools-list.json`
 - `masc-status.json`
-- `dashboard-mission.json`
+- `dashboard-project-snapshot.json`
 - `namespace-truth.json`
 - `server.log`
 

--- a/test/test_keeper_effective_meta_overlay.ml
+++ b/test/test_keeper_effective_meta_overlay.ml
@@ -24,6 +24,36 @@ let write_file path content =
     ~finally:(fun () -> close_out_noerr oc)
     (fun () -> output_string oc content)
 
+let runtime_toml =
+  {|
+[runtime]
+default = "test_provider.test_model"
+
+[providers.test_provider]
+display-name = "Test Provider"
+protocol = "provider_d-http"
+endpoint = "http://127.0.0.1:1"
+
+[models.test_model]
+api-name = "test-model"
+max-context = 8192
+tools-support = true
+streaming = true
+
+[test_provider.test_model]
+is-default = true
+max-concurrent = 1
+|}
+;;
+
+let init_runtime_default_for_tests () =
+  let path = Filename.temp_file "keeper_effective_meta_runtime_" ".toml" in
+  write_file path runtime_toml;
+  match Masc_mcp.Runtime.init_default ~config_path:path with
+  | Ok () -> ()
+  | Error e -> Alcotest.failf "Runtime.init_default failed: %s" e
+;;
+
 let rec rm_rf path =
   try
     if Sys.file_exists path then
@@ -132,9 +162,7 @@ let test_toml_overlay_reaches_effective_meta () =
     (Filename.concat keepers_dir (name ^ ".toml"))
     {|[keeper]
 sandbox_profile = "docker"
-
-[keeper.tool_access]
-tools = ["tool_execute", "tool_read_file"]
+tool_access = ["tool_execute", "tool_read_file"]
 |};
   let config = Workspace.default_config base in
   ignore (seed_runtime_meta config name : Masc_mcp.Keeper_meta_contract.keeper_meta);
@@ -314,6 +342,7 @@ goal = "missing sandbox profile"
           | _ -> Alcotest.fail "fleet error row missing effective_meta_error")
 
 let () =
+  init_runtime_default_for_tests ();
   Alcotest.run "keeper_effective_meta_overlay"
     [
       ( "effective_meta",


### PR DESCRIPTION
## Summary
- Update release evidence dashboard capture from retired /api/v1/dashboard/mission to live /api/v1/dashboard/project-snapshot.
- Keep release evidence docs aligned with the current dashboard read path.
- Initialize a default runtime in keeper effective-meta overlay tests and use flat tool_access TOML.

## Verification
- scripts/check-oas-pin.sh --local-only
- ocamlformat --check test/test_keeper_effective_meta_overlay.ml
- rg residue sweep for removed tool preset/kind/custom-list names (no matches)
- env DUNE_BUILD_DIR=/private/tmp/masc-main-build-fix-serial DUNE_CACHE=disabled MASC_SKIP_OPAM_LOCK=1 MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_effective_meta_overlay.exe
- /private/tmp/masc-main-build-fix-serial/default/test/test_keeper_effective_meta_overlay.exe
- env DUNE_BUILD_DIR=/private/tmp/masc-main-build-fix-full DUNE_CACHE=disabled MASC_SKIP_OPAM_LOCK=1 MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build bin/main_eio.exe
- scripts/release-evidence.sh /private/tmp/masc-main-build-fix-full/default/bin/main_eio.exe /private/tmp/masc-release-evidence-check/main-release-evidence.md
- bash scripts/check-doc-truth.sh