### PR TITLE
fix(dashboard): use canonical briefing routes

### DIFF
--- a/dashboard/src/api/core.test.ts
+++ b/dashboard/src/api/core.test.ts
@@ -441,7 +441,7 @@ describe('get bootstrap warm-up mapping', () => {
     expect(data.task_backlog?.todo).toBe(0)
   })
 
-  it('maps mission not-initialized 5xx to empty mission payload', async () => {
+  it('maps briefing not-initialized 5xx to empty briefing payload', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response('{"error":"not initialized"}', {
         status: 500,
@@ -456,7 +456,7 @@ describe('get bootstrap warm-up mapping', () => {
       incidents?: unknown[]
       command_focus?: Record<string, unknown>
       operator_targets?: { keepers?: unknown[] }
-    }>('/api/v1/dashboard/mission')
+    }>('/api/v1/dashboard/briefing')
 
     expect(data.generated_at).toBeDefined()
     expect(data.summary?.workspace_health).toBe('initializing')

--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -282,7 +282,7 @@ const DASHBOARD_BOOTSTRAP_WARM_PATHS = new Set([
   '/api/v1/dashboard/workspace-truth',
   '/api/v1/dashboard/execution',
   '/api/v1/dashboard/planning',
-  '/api/v1/dashboard/mission',
+  '/api/v1/dashboard/briefing',
 ])
 
 import { isRecord } from '../lib/type-guards'
@@ -452,7 +452,7 @@ function bootstrapInitializingPayload(path: string): unknown | null {
           violations: [],
         },
       }
-    case '/api/v1/dashboard/mission':
+    case '/api/v1/dashboard/briefing':
       return {
         generated_at: generatedAt,
         summary: {

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -5,10 +5,13 @@ import {
   fetchDashboardGovernance,
   fetchDashboardGoalDetail,
   fetchDashboardGoalsTree,
+  fetchDashboardBriefing,
   fetchDashboardTools,
   fetchKeeperToolCalls,
   fetchKeeperToolStats,
   fetchDashboardMemory,
+  fetchDashboardMission,
+  fetchDashboardMissionBriefing,
   fetchCostLatency,
   fetchKeeperConfig,
   fetchKeeperCostMetrics,
@@ -179,6 +182,79 @@ describe('fetchDashboardExecutionTrust', () => {
       keeper_name: 'sangsu',
       trace_id: 'trace-exec-gap',
     })
+  })
+})
+
+describe('dashboard briefing fetchers', () => {
+  it('requests the canonical briefing surface', async () => {
+    const rawResponse = {
+      summary: { workspace_health: 'ok' },
+      incidents: [],
+      recommended_actions: [],
+      command_focus: {},
+      operator_targets: { keepers: [], pending_confirms: [], available_actions: [] },
+      attention_queue: [],
+      sessions: [],
+      agent_briefs: [],
+      keeper_briefs: [],
+      internal_signals: [],
+    }
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(rawResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await fetchDashboardBriefing()
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/dashboard/briefing')
+  })
+
+  it('keeps the mission snapshot fetcher as a compatibility alias', async () => {
+    const rawResponse = {
+      summary: { workspace_health: 'ok' },
+      incidents: [],
+      recommended_actions: [],
+      command_focus: {},
+      operator_targets: { keepers: [], pending_confirms: [], available_actions: [] },
+      attention_queue: [],
+      sessions: [],
+      agent_briefs: [],
+      keeper_briefs: [],
+      internal_signals: [],
+    }
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(rawResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await fetchDashboardMission()
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/dashboard/briefing')
+  })
+
+  it('requests canonical briefing sections and preserves force', async () => {
+    const rawResponse = {
+      status: 'ok',
+      criteria: [],
+      sections: [],
+    }
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(rawResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await fetchDashboardMissionBriefing(true)
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/dashboard/briefing/sections?force=1')
   })
 })
 

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -526,8 +526,12 @@ export async function decideGovernanceExecutionOrder(
   throw governanceCasesRetiredError()
 }
 
+export function fetchDashboardBriefing(): Promise<DashboardMissionResponse> {
+  return get('/api/v1/dashboard/briefing')
+}
+
 export function fetchDashboardMission(): Promise<DashboardMissionResponse> {
-  return get('/api/v1/dashboard/mission')
+  return fetchDashboardBriefing()
 }
 
 export function fetchDashboardMissionSession(
@@ -1279,7 +1283,7 @@ export function fetchDashboardMissionBriefing(
   opts?: { signal?: AbortSignal },
 ): Promise<DashboardMissionBriefingResponse> {
   const query = force ? '?force=1' : ''
-  return get(`/api/v1/dashboard/mission/briefing${query}`, { signal: opts?.signal })
+  return get(`/api/v1/dashboard/briefing/sections${query}`, { signal: opts?.signal })
 }
 
 export function fetchDashboardPlanning(): Promise<DashboardPlanningResponse> {

--- a/docs/BENCHMARK-RUNBOOK.md
+++ b/docs/BENCHMARK-RUNBOOK.md
@@ -142,7 +142,7 @@ scripts/harness/workload/agent_swarm_live.sh
 
 ## session runtime local64 compat lane
 
-Removed. Team-session compat harnesses and the command-plane HTTP lane are both retired; use board_posts + keeper FSM read models for workspace collaboration truth and the canonical dashboard projections (`/api/v1/dashboard/mission`, `/api/v1/dashboard/execution`, `/api/v1/dashboard/board`) for live proof.
+Removed. Team-session compat harnesses and the command-plane HTTP lane are both retired; use board_posts + keeper FSM read models for workspace collaboration truth and the canonical dashboard projections (`/api/v1/dashboard/briefing`, `/api/v1/dashboard/execution`, `/api/v1/dashboard/board`) for live proof.
 
 Operation/unit/detachment tool variants were removed (no implementation existed).
 

--- a/docs/DASHBOARD-INTEGRATION.md
+++ b/docs/DASHBOARD-INTEGRATION.md
@@ -188,7 +188,8 @@ code_refs:
   - canonical surface inventory + readiness refs
 
 ## Supporting / Compatibility Read Models
-- `GET /api/v1/dashboard/mission`
+- `GET /api/v1/dashboard/briefing`
+- `GET /api/v1/dashboard/briefing/sections`
 - `GET /api/v1/dashboard/execution`
 - `GET /api/v1/dashboard/governance`
 - `GET /api/v1/dashboard/proof`

--- a/docs/RELEASE-EVIDENCE.md
+++ b/docs/RELEASE-EVIDENCE.md
@@ -21,7 +21,7 @@ code_refs:
 - local boot + `/health`: isolated base path에서 서버 부팅 후 health payload 저장
 - MCP handshake: `initialize` + `tools/list` raw capture 저장
 - repo workspace collaboration read path: `masc_status` raw capture 저장
-- dashboard read paths: `/api/v1/dashboard/project-snapshot`, `/api/v1/dashboard/namespace-truth` raw capture 저장
+- dashboard read paths: `/api/v1/dashboard/briefing`, `/api/v1/dashboard/namespace-truth` raw capture 저장
 - quantitative readiness: `docs/PRODUCTION-READINESS-GATES.md`의 release artifact, keeper turn evidence, performance SLO, OAS pin/boundary gate 결과를 함께 첨부
 - raw evidence: headers/body/json 정규화본 + `server.log`
 

--- a/docs/spec/10-dashboard.md
+++ b/docs/spec/10-dashboard.md
@@ -664,9 +664,9 @@ dashboard prefix:
 | Endpoint | Method | 용도 |
 |----------|--------|------|
 | `/api/v1/dashboard/execution` | GET | Historical execution projection (current v1 nav의 primary surface는 아님) |
-| `/api/v1/dashboard/mission` | GET | Historical mission projection |
+| `/api/v1/dashboard/briefing` | GET | Mission briefing projection |
 | `/api/v1/dashboard/session?session_id=X` | GET | Mission session detail |
-| `/api/v1/dashboard/mission/briefing` | GET | Mission briefing (LLM 생성) |
+| `/api/v1/dashboard/briefing/sections` | GET | Mission briefing sections (LLM 생성) |
 | `/api/v1/dashboard/proof?session_id=X` | GET | Historical proof projection |
 | `/api/v1/dashboard/governance` | GET | Historical governance projection |
 | `/api/v1/dashboard/config` | GET | Config introspection snapshot |

--- a/scripts/harness_dashboard_briefing_smoke.sh
+++ b/scripts/harness_dashboard_briefing_smoke.sh
@@ -140,8 +140,8 @@ if ! run_with_timeout "$FIXTURE_TIMEOUT_SEC" "fixture setup" \
   exit 1
 fi
 
-if ! wait_for_http "http://${HOST}:${PORT}/api/v1/dashboard/mission" 15; then
-  echo "Dashboard mission endpoint did not become ready after fixture setup. See $SERVER_LOG" >&2
+if ! wait_for_http "http://${HOST}:${PORT}/api/v1/dashboard/briefing" 15; then
+  echo "Dashboard briefing endpoint did not become ready after fixture setup. See $SERVER_LOG" >&2
   exit 1
 fi
 

--- a/scripts/release-evidence.sh
+++ b/scripts/release-evidence.sh
@@ -10,7 +10,7 @@ The bundle includes:
   - artifact install smoke (`--version` from an installed location)
   - local boot + /health capture
   - MCP initialize + tools/list + masc_status captures
-  - dashboard read-path captures for project snapshot + namespace truth
+  - dashboard read-path captures for briefing + namespace truth
 
 Raw files are written next to OUTPUT_MARKDOWN.
 EOF
@@ -54,9 +54,9 @@ tools_json="$out_dir/tools-list.json"
 status_headers="$out_dir/masc-status.headers"
 status_body="$out_dir/masc-status.body"
 status_json="$out_dir/masc-status.json"
-project_snapshot_headers="$out_dir/dashboard-project-snapshot.headers"
-project_snapshot_body="$out_dir/dashboard-project-snapshot.body"
-project_snapshot_json="$out_dir/dashboard-project-snapshot.json"
+briefing_headers="$out_dir/dashboard-briefing.headers"
+briefing_body="$out_dir/dashboard-briefing.body"
+briefing_json="$out_dir/dashboard-briefing.json"
 namespace_headers="$out_dir/namespace-truth.headers"
 namespace_body="$out_dir/namespace-truth.body"
 namespace_json="$out_dir/namespace-truth.json"
@@ -112,6 +112,25 @@ PY
 status_code() {
   local header_file="$1"
   awk 'toupper($1) ~ /^HTTP\/[0-9.]+$/ { code=$2 } END { print code }' "$header_file"
+}
+
+normalize_http_json() {
+  local headers="$1"
+  local body="$2"
+  local dest="$3"
+  local label="$4"
+  local code
+  code="$(status_code "$headers")"
+  case "$code" in
+    2*) ;;
+    *)
+      echo "release-evidence: ${label} returned HTTP ${code:-<missing>}" >&2
+      head -c 400 "$body" >&2 || true
+      echo >&2
+      exit 1
+      ;;
+  esac
+  normalize_json "$body" "$dest"
 }
 
 header_value() {
@@ -312,15 +331,17 @@ post_json "$MCP_URL" "$status_payload" "$status_headers" "$status_body" \
   -H "Mcp-Protocol-Version: ${protocol_version}"
 normalize_json "$status_body" "$status_json"
 
-curl -sS -D "$project_snapshot_headers" -o "$project_snapshot_body" \
+curl -sS -D "$briefing_headers" -o "$briefing_body" \
   -H 'Accept: application/json' \
-  "${BASE_URL}/api/v1/dashboard/project-snapshot"
-normalize_json "$project_snapshot_body" "$project_snapshot_json"
+  "${BASE_URL}/api/v1/dashboard/briefing"
+normalize_http_json "$briefing_headers" "$briefing_body" "$briefing_json" \
+  "/api/v1/dashboard/briefing"
 
 curl -sS -D "$namespace_headers" -o "$namespace_body" \
   -H 'Accept: application/json' \
   "${BASE_URL}/api/v1/dashboard/namespace-truth"
-normalize_json "$namespace_body" "$namespace_json"
+normalize_http_json "$namespace_headers" "$namespace_body" "$namespace_json" \
+  "/api/v1/dashboard/namespace-truth"
 
 python3 - \
   "$OUTFILE" \
@@ -333,7 +354,7 @@ python3 - \
   "$health_json" \
   "$tools_json" \
   "$status_json" \
-  "$project_snapshot_json" \
+  "$briefing_json" \
   "$namespace_json" \
   "$initialize_json" \
   "$server_log" <<'PY'
@@ -353,7 +374,7 @@ from datetime import datetime, timezone
     health_json,
     tools_json,
     status_json,
-    project_snapshot_json,
+    briefing_json,
     namespace_json,
     initialize_json,
     server_log,
@@ -366,7 +387,7 @@ def load(path):
 health = load(health_json)
 tools = load(tools_json)
 status = load(status_json)
-project_snapshot = load(project_snapshot_json)
+briefing = load(briefing_json)
 namespace_truth = load(namespace_json)
 initialize = load(initialize_json)
 
@@ -378,7 +399,7 @@ for item in content:
       status_text = item.get("text", "")
       break
 
-project_snapshot_keys = sorted(project_snapshot.keys())[:10]
+briefing_keys = sorted(briefing.keys())[:10]
 namespace_keys = sorted(namespace_truth.keys())[:10]
 health_keys = sorted(health.keys())[:10]
 generated_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -419,7 +440,7 @@ md = f"""# Release Evidence Bundle
 
 ## Dashboard Read Paths
 
-- `/api/v1/dashboard/project-snapshot` returned HTTP-shaped JSON with keys: `{", ".join(project_snapshot_keys)}`
+- `/api/v1/dashboard/briefing` returned HTTP-shaped JSON with keys: `{", ".join(briefing_keys)}`
 - `/api/v1/dashboard/namespace-truth` returned keys: `{", ".join(namespace_keys)}`
 
 ## Raw Captures
@@ -431,7 +452,7 @@ md = f"""# Release Evidence Bundle
 - `initialize.json`
 - `tools-list.json`
 - `masc-status.json`
-- `dashboard-project-snapshot.json`
+- `dashboard-briefing.json`
 - `namespace-truth.json`
 - `server.log`
 

--- a/scripts/verify-dashboard.sh
+++ b/scripts/verify-dashboard.sh
@@ -127,10 +127,10 @@ check_http "dashboard execution 200" "$BASE/api/v1/dashboard/execution" "200"
 check_json "dashboard execution exposes provenance" "$BASE/api/v1/dashboard/execution" "'status' in d and 'agents' in d and 'execution_queue' in d and d.get('dashboard_surface') == '/api/v1/dashboard/execution' and d.get('source') == 'dashboard_execution_read_model' and d.get('retention', {}).get('scope') == 'dashboard_execution' and d.get('query', {}).get('default_light_request') is True and d.get('cache', {}).get('cache_state') in ('fresh', 'stale', 'initializing', 'request_swr_or_inline_compute')" '^True$'
 check_http "dashboard execution trust 200" "$BASE/api/v1/dashboard/execution-trust" "200"
 check_json "dashboard execution trust exposes provenance" "$BASE/api/v1/dashboard/execution-trust" "'dashboard_surface' in d and 'keepers' in d and 'coverage_gaps' in d" '^True$'
-check_http "dashboard mission 200" "$BASE/api/v1/dashboard/mission" "200"
-check_json "dashboard mission exposes summary and keepers" "$BASE/api/v1/dashboard/mission" "'summary' in d and 'keeper_briefs' in d" '^True$'
-check_http "dashboard mission briefing 200" "$BASE/api/v1/dashboard/mission/briefing" "200"
-check_json "dashboard mission briefing exposes provenance" "$BASE/api/v1/dashboard/mission/briefing" "'provenance' in d and 'criteria' in d" '^True$'
+check_http "dashboard briefing 200" "$BASE/api/v1/dashboard/briefing" "200"
+check_json "dashboard briefing exposes summary and keepers" "$BASE/api/v1/dashboard/briefing" "'summary' in d and 'keeper_briefs' in d" '^True$'
+check_http "dashboard briefing sections 200" "$BASE/api/v1/dashboard/briefing/sections" "200"
+check_json "dashboard briefing sections exposes provenance" "$BASE/api/v1/dashboard/briefing/sections" "'provenance' in d and 'criteria' in d" '^True$'
 check_http "surface-readiness 200" "$BASE/api/v1/dashboard/surface-readiness" "200"
 check_json \
   "surface-readiness has canonical surface count" \

--- a/test/test_dashboard_briefing.ml
+++ b/test/test_dashboard_briefing.ml
@@ -192,7 +192,7 @@ let test_dashboard_briefing_http_full_contract () =
           ~state
           ~sw
           ~clock
-          (request "/api/v1/dashboard/mission?agent_name=test-dashboard-http")
+          (request "/api/v1/dashboard/briefing?agent_name=test-dashboard-http")
       in
       let open Yojson.Safe.Util in
       check bool "operator targets present in mission http payload" true
@@ -217,7 +217,7 @@ let test_dashboard_briefing_http_default_bootstraps_first_success () =
           ~state
           ~sw
           ~clock
-          (request "/api/v1/dashboard/mission")
+          (request "/api/v1/dashboard/briefing")
       in
       let open Yojson.Safe.Util in
       check string "default mission cache becomes fresh" "fresh"
@@ -251,7 +251,7 @@ let test_dashboard_briefing_keeper_tool_audit_fallback () =
           ~state
           ~sw
           ~clock
-          (request "/api/v1/dashboard/mission")
+          (request "/api/v1/dashboard/briefing")
       in
       let open Yojson.Safe.Util in
       check string "default mission cache becomes fresh" "fresh"
@@ -291,7 +291,7 @@ let test_dashboard_briefing_http_cache_isolation () =
         Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir_b ()
       in
       let request =
-        request ("/api/v1/dashboard/mission?agent_name=" ^ actor)
+        request ("/api/v1/dashboard/briefing?agent_name=" ^ actor)
       in
       let json_a =
         Lib.Server_dashboard_http.dashboard_briefing_http_json


### PR DESCRIPTION
## Summary

- Move release evidence, dashboard client fetchers, and smoke scripts from retired `/api/v1/dashboard/mission` URLs to canonical `/api/v1/dashboard/briefing` routes.
- Add dashboard API regression tests for the canonical briefing and briefing-sections paths.
- Align release/dashboard docs with the routes currently exposed by the server router.

## Product impact

- Restores the main release-evidence bundle path that failed after receiving a non-JSON body from the retired mission URL.
- Prevents dashboard mission/overview reads from calling removed API paths.

## Evidence

- `bash -n scripts/release-evidence.sh scripts/verify-dashboard.sh scripts/harness_dashboard_briefing_smoke.sh`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec vitest run --config vitest.config.ts src/api/dashboard.test.ts src/api/core.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec eslint src/api/dashboard.ts src/api/core.ts src/api/dashboard.test.ts src/api/core.test.ts` (0 errors; configured target list ignores `core*` and `dashboard.test.ts`)
- `bash scripts/check-doc-truth.sh`
- `git diff --check`
- Not run: `scripts/dune-local.sh build test/test_dashboard_briefing.exe test/test_dashboard_briefing_sections.exe` because the machine-wide Dune/opam locks were held by other active worktrees; the repo-wide pre-commit hook was also stopped after it started a bare full `dune build --root .`.

## Direct evidence

schema_version: 1
direct_ratio: 6/7
provenance: direct

## Review evidence

- Main CI run `26751081423` failed in `Generate main release evidence bundle` with `no JSON payload found in ... dashboard-mission.body`.
- Local route audit found no server route for `/api/v1/dashboard/mission`; current HTTP/1 and H2 routers expose `/api/v1/dashboard/briefing` and `/api/v1/dashboard/briefing/sections`.

## Linked issue

- None.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`fix-dashboard-runtime-lens-test-20260601` → `main` · 1 commit(s) · synced 2026-06-01T13:06:25Z

| sha | subject | date |
|---|---|---|
| `d0e75b0fa` | fix(dashboard): use canonical briefing routes | 2026-06-01 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->