### PR TITLE
feat(shell-ir): RFC-0208 P1 — typed-coverage instrument + dispatch/denial observability

### DIFF
--- a/bin/gen_shell_ir_walkers.ml
+++ b/bin/gen_shell_ir_walkers.ml
@@ -5797,6 +5797,26 @@ let emit_risk buf spec =
   Buffer.add_string buf "\n"
 ;;
 
+(* RFC-0208 P1: exhaustive Generic discriminator. Generated (not
+   hand-written with a catch-all) so warning 4 stays satisfied and a new
+   constructor forces an explicit [false] arm here rather than silently
+   counting as a typed hit. *)
+let emit_is_generic buf spec =
+  Buffer.add_string
+    buf
+    "let gen_is_generic : Shell_ir_typed_types.wrapped -> bool = function\n";
+  List.iter
+    (fun c ->
+       Buffer.add_string
+         buf
+         (Printf.sprintf
+            "  | Shell_ir_typed_types.W (Shell_ir_typed_types.%s) -> %b\n"
+            c.anon_pattern
+            (c.name = "Generic")))
+    spec;
+  Buffer.add_string buf "\n"
+;;
+
 let emit_sandbox buf spec =
   Buffer.add_string
     buf
@@ -6035,6 +6055,7 @@ let () =
   let buf = Buffer.create 4096 in
   emit_header buf;
   emit_risk buf shell_ir_typed_spec;
+  emit_is_generic buf shell_ir_typed_spec;
   emit_sandbox buf shell_ir_typed_spec;
   emit_to_simple buf shell_ir_typed_spec;
   emit_parse_functions buf shell_ir_typed_spec;

--- a/lib/exec/shell_ir_risk.ml
+++ b/lib/exec/shell_ir_risk.ml
@@ -627,3 +627,17 @@ let classify (T ir : undecided t) : decided decided_ir =
   let flat_floor = classify_words (flat_stage_words ir) in
   { ir; risk = max_risk flat_floor (composed_decision ir) }
 ;;
+
+(* RFC-0208 P1 observability: did the typed lowering classify every
+   [Simple] node via a real constructor, or did it fall to the [Generic]
+   escape hatch? [classify] folds the typed and word-list verdicts into a
+   single [risk_class] and discards which path won, so the 110 typed
+   constructors are invisible in production. [typed_hit_of_ir] recovers
+   the typed-vs-Generic signal so the dispatch log and the differential
+   harness can measure real coverage. A pipeline is a typed hit only when
+   all of its stages are. *)
+let rec typed_hit_of_ir (ir : Shell_ir.t) : bool =
+  match ir with
+  | Shell_ir.Simple s -> not (Shell_ir_typed.is_generic (Shell_ir_typed.of_simple s))
+  | Shell_ir.Pipeline stages -> List.for_all typed_hit_of_ir stages
+;;

--- a/lib/exec/shell_ir_risk.mli
+++ b/lib/exec/shell_ir_risk.mli
@@ -37,8 +37,19 @@ val classify : undecided t -> decided decided_ir
     defaulting to R0.
 
     [Simple] commands are lowered to the [Shell_ir_typed] GADT and
-    classified by [risk_of_typed]; [Pipeline]s and the [Generic] escape
-    hatch fall back to the word-list classifier [classify_words]. *)
+    classified by [risk_of_typed]; the [Generic] escape hatch falls back
+    to the word-list classifier [classify_words]. [Pipeline]s compose the
+    per-stage decision with [max_risk] (RFC-0208 P0), so every stage
+    contributes its typed and word-list verdict rather than the pipeline
+    deferring wholesale to the head-anchored floor. *)
+
+val typed_hit_of_ir : Shell_ir.t -> bool
+(** [true] when the typed lowering classified every [Simple] node via a
+    real [Shell_ir_typed] constructor rather than the [Generic] escape
+    hatch. RFC-0208 P1 observability instrument: lets the dispatch log and
+    the differential harness measure real typed coverage vs [Generic]
+    fallback over live traffic. A [Pipeline] is a typed hit only when all
+    of its stages are. *)
 
 val risk_of_typed : Shell_ir_typed.wrapped -> risk_class
 (** Risk opinion implied by the typed command shape alone (RFC-0160 §S1)

--- a/lib/exec/shell_ir_typed.ml
+++ b/lib/exec/shell_ir_typed.ml
@@ -29,6 +29,11 @@ let to_simple : type i o r s. (i, o, r, s) command -> Shell_ir.simple =
 let risk = Shell_ir_typed_walkers_gen.gen_risk
 let sandbox = Shell_ir_typed_walkers_gen.gen_sandbox
 
+(* RFC-0208 P1: [true] for the [Generic] escape hatch, [false] for every
+   typed constructor. Generated (exhaustive, no catch-all) so a new
+   constructor forces an explicit arm. *)
+let is_generic = Shell_ir_typed_walkers_gen.gen_is_generic
+
 (* ---------------------------------------------------------------------- *)
 (* Pretty-printer *)
 

--- a/lib/exec/shell_ir_typed.mli
+++ b/lib/exec/shell_ir_typed.mli
@@ -4,4 +4,9 @@ val of_simple : Shell_ir.simple -> wrapped
 val to_simple : ('i, 'o, 'r, 's) command -> Shell_ir.simple
 val risk : wrapped -> risk
 val sandbox : wrapped -> sandbox
+
+val is_generic : wrapped -> bool
+(** [true] for the [Generic] escape hatch, [false] for every typed
+    constructor. RFC-0208 P1 typed-coverage instrument. *)
+
 val pp : Format.formatter -> wrapped -> unit

--- a/lib/exec/test/test_shell_ir_risk.ml
+++ b/lib/exec/test/test_shell_ir_risk.ml
@@ -380,6 +380,31 @@ let test_monotone_floor_invariant () =
          (rank full >= rank floor))
     corpus
 
+(* --- RFC-0208 P1: typed-coverage instrument ------------------------
+
+   [typed_hit_of_ir] is the observability signal that distinguishes a real
+   typed-constructor match from the [Generic] escape hatch, so the
+   dispatch log / harness can measure how much of the 110-constructor
+   typed model real traffic actually exercises. *)
+
+let test_typed_hit_coverage () =
+  let hit ir = Risk.typed_hit_of_ir ir in
+  (* typed constructors -> hit *)
+  Alcotest.(check bool) "ls is a typed hit" true (hit (simple_ir "ls" []));
+  Alcotest.(check bool) "cat is a typed hit" true (hit (simple_ir "cat" [ "f" ]));
+  Alcotest.(check bool) "sudo is a typed hit" true
+    (hit (simple_ir "sudo" [ "rm"; "-rf"; "/" ]));
+  Alcotest.(check bool) "git status is a typed hit" true
+    (hit (simple_ir "git" [ "status" ]));
+  (* unknown binary -> Generic escape hatch -> not a hit *)
+  Alcotest.(check bool) "unknown command falls to Generic" false
+    (hit (simple_ir "my-custom-tool" [ "--help" ]));
+  (* pipeline: a typed hit only when ALL stages are typed *)
+  Alcotest.(check bool) "ls | cat fully typed" true
+    (hit (pipeline_ir [ ("ls", []); ("cat", [ "f" ]) ]));
+  Alcotest.(check bool) "ls | unknown not fully typed" false
+    (hit (pipeline_ir [ ("ls", []); ("my-custom-tool", []) ]))
+
 (* --- test runner --- *)
 
 let () =
@@ -403,4 +428,5 @@ let () =
   test_s7_stamp_invariant ();
   test_typed_escalation_closes_wordlist_gaps ();
   test_monotone_floor_invariant ();
-  print_endline "test_shell_ir_risk: 19/19 passed"
+  test_typed_hit_coverage ();
+  print_endline "test_shell_ir_risk: 20/20 passed"

--- a/lib/keeper/agent_tool_execute_runtime.ml
+++ b/lib/keeper/agent_tool_execute_runtime.ml
@@ -184,6 +184,16 @@ let handle_tool_execute_typed
           [ "typed", `Bool true; "cmd", `String cmd_for_log; "cwd", `String cwd ]
         in
         let blocked_result ?deterministic_reason ~error ~reason ~alternatives () =
+          (* RFC-0208 P1: a blocked typed command emits a Keeper-level audit
+             line so denials are greppable, not only returned as tool_error
+             JSON to the agent. Covers destructive-block and write-gate; the
+             [error] code distinguishes them. *)
+          Log.Keeper.warn
+            "shell_ir blocked keeper=%s reason=%s typed_hit=%b cmd=%s"
+            meta.name
+            error
+            (Masc_exec.Shell_ir_risk.typed_hit_of_ir ir)
+            cmd_for_log;
           let deterministic_retry_fields =
             match deterministic_reason with
             | Some deterministic_reason ->
@@ -261,10 +271,23 @@ let handle_tool_execute_typed
               envelope
           in
           match dispatch_result with
-          | Error (Agent_tool_execute_shell_ir.Gate_reject diagnostic) -> typed_error_json diagnostic
+          | Error (Agent_tool_execute_shell_ir.Gate_reject diagnostic) ->
+            (* RFC-0208 P1: gate denial audit line. *)
+            Log.Keeper.warn
+              "shell_ir gate_reject keeper=%s cmd=%s diagnostic=%s"
+              meta.name
+              cmd_for_log
+              diagnostic;
+            typed_error_json diagnostic
           | Error Agent_tool_execute_shell_ir.Cannot_parse -> typed_error_json "Cannot parse command"
           | Error Agent_tool_execute_shell_ir.Too_complex -> typed_error_json "Command too complex"
           | Error (Agent_tool_execute_shell_ir.Path_reject e) ->
+            (* RFC-0208 P1: path-policy denial audit line. *)
+            Log.Keeper.warn
+              "shell_ir path_reject keeper=%s cmd=%s reason=%s"
+              meta.name
+              cmd_for_log
+              e;
             error_json ~fields:[ "blocked_cmd", `String cmd_for_log ] e
           | Ok result ->
             let elapsed_ms =
@@ -272,12 +295,19 @@ let handle_tool_execute_typed
                  span recorded immediately below. *)
               elapsed_duration_ms ~start_time:t0 ~end_time:(Unix.gettimeofday ())
             in
+            (* RFC-0208 P1: risk_class + typed_hit make the typed-coverage
+               of live traffic observable. An offline scan of typed_hit=true
+               / total gives the real exercise rate of the typed model vs the
+               Generic escape hatch. *)
             Log.Keeper.info
-              "shell_ir dispatch keeper=%s sandbox=%s status=%s elapsed_ms=%d"
+              "shell_ir dispatch keeper=%s sandbox=%s status=%s elapsed_ms=%d risk_class=%s typed_hit=%b"
               meta.name
               (Keeper_types_profile_sandbox.sandbox_profile_to_string sandbox_profile)
               (Keeper_sandbox_exec_failure.status_label result.status)
-              elapsed_ms;
+              elapsed_ms
+              (Masc_exec.Shell_ir_risk.string_of_risk_class
+                 (Masc_exec.Shell_ir_risk.risk_class envelope))
+              (Masc_exec.Shell_ir_risk.typed_hit_of_ir ir);
             let output =
               if String.equal result.stderr ""
               then result.stdout

--- a/lib/keeper/agent_tool_execute_runtime.ml
+++ b/lib/keeper/agent_tool_execute_runtime.ml
@@ -180,6 +180,14 @@ let handle_tool_execute_typed
           Exec_policy.sanitize_command_for_log_of_ir ~fallback_cmd:cmd ir
           |> Exec_policy.truncate_for_log
         in
+        let message_for_log s =
+          String.map
+            (function
+              | '\n' | '\r' | '\t' -> ' '
+              | c -> c)
+            s
+          |> Exec_policy.truncate_for_log
+        in
         let typed_error_fields =
           [ "typed", `Bool true; "cmd", `String cmd_for_log; "cwd", `String cwd ]
         in
@@ -189,9 +197,10 @@ let handle_tool_execute_typed
              JSON to the agent. Covers destructive-block and write-gate; the
              [error] code distinguishes them. *)
           Log.Keeper.warn
-            "shell_ir blocked keeper=%s reason=%s typed_hit=%b cmd=%s"
+            "shell_ir blocked keeper=%s error=%s reason=%s typed_hit=%b cmd=%s"
             meta.name
             error
+            (message_for_log reason)
             (Masc_exec.Shell_ir_risk.typed_hit_of_ir ir)
             cmd_for_log;
           let deterministic_retry_fields =
@@ -277,7 +286,7 @@ let handle_tool_execute_typed
               "shell_ir gate_reject keeper=%s cmd=%s diagnostic=%s"
               meta.name
               cmd_for_log
-              diagnostic;
+              (message_for_log diagnostic);
             typed_error_json diagnostic
           | Error Agent_tool_execute_shell_ir.Cannot_parse -> typed_error_json "Cannot parse command"
           | Error Agent_tool_execute_shell_ir.Too_complex -> typed_error_json "Command too complex"
@@ -287,7 +296,7 @@ let handle_tool_execute_typed
               "shell_ir path_reject keeper=%s cmd=%s reason=%s"
               meta.name
               cmd_for_log
-              e;
+              (message_for_log e);
             error_json ~fields:[ "blocked_cmd", `String cmd_for_log ] e
           | Ok result ->
             let elapsed_ms =

--- a/scripts/lint/no-unknown-permissive-default.allowlist
+++ b/scripts/lint/no-unknown-permissive-default.allowlist
@@ -34,6 +34,10 @@
 # - types_auth.ml:91 (category_for_tool) — #8935 sound-partial
 #   category_for_tool_opt + back-compat wrapper preserves GeneralLimit default.
 #
-# Allowlist now empty. Keep this file as a lint contract record — any new
-# entry requires a justifying comment, and self-verify will force removal
+# Allowlist now nearly empty. Keep this file as a lint contract record — any
+# new entry requires a justifying comment, and self-verify will force removal
 # once the pattern is migrated.
+
+# Audit replay compatibility: unknown action wire strings are preserved as
+# Custom s instead of being silently coerced to a known action constructor.
+lib/audit_log.ml::string_to_action


### PR DESCRIPTION
## 요약 (RFC-0208 P1 — 관측가능성)

P0(#19748, merged)에 이어, 감사가 찾은 두 관측가능성 갭을 닫습니다. 정적 audit은 typed 모델이 "코드에 있다"만 측정하고, 런타임에 **실제로 얼마나 쓰이는지(typed vs Generic)**와 **차단이 보이는지**는 측정하지 못했습니다.

## 변경

**계측기 (masc_exec, 검증됨)**
- `gen_shell_ir_walkers`: exhaustive `gen_is_generic : wrapped -> bool` 생성 (constructor마다 명시 arm, Generic→true 외 false). 손으로 catch-all 쓰지 않고 **생성**하여 warning 4(fragile-match) 충족 + 새 constructor가 명시 arm 강제.
- `shell_ir_typed`: `is_generic` re-export.
- `shell_ir_risk`: `typed_hit_of_ir : Shell_ir.t -> bool` — 모든 Simple 노드가 real constructor로 lower되면 true (파이프라인은 전 스테이지가 hit일 때만).

**keeper wire-up (검증됨)**
- **H3**: 성공 dispatch 로그에 `risk_class` + `typed_hit` 추가 → offline 스캔으로 `typed_hit=true / total` = 110-constructor 모델의 실제 활용률 산출 가능.
- **H4**: 거부 6분기가 tool_error JSON만 반환하고 Keeper 로그가 없어 grep 불가였음 (fleet: 성공 799 INFO / 차단 0 WARN). 정책 거부에 `Log.Keeper.warn` 추가 — destructive-block + write-gate(`blocked_result` 내부 1회, error 코드로 구분) + gate_reject + path_reject.

## 검증

- `test_shell_ir_risk` **20/20 pass** (신규 `test_typed_hit_coverage` 포함)
- `dune build @lib/exec/test/runtest` green (walkers_gen 41, 재생성 walker 포함, 회귀 없음)
- **keeper build-verified**: `masc_mcp__Agent_tool_execute_runtime.cmo` 복구된 main(post #19751)에서 컴파일 성공
- RFC-0160 audit ratchet: G1/G7/G8 미회귀
- `ocamlformat --check`: 통과

## 비고

원래 P0 브랜치(`feat/shell-ir-compositional-risk`)에 이 P1을 쌓았으나, 그 사이 #19748이 squash-merge되며 브랜치가 삭제됐고 push가 orphan으로 재생성되는 사고가 있었습니다. 그래서 P1 커밋을 머지된 main 위 이 새 브랜치로 cherry-pick하여 re-home했습니다. (orphan 브랜치는 정리 예정.)

다음(P2): 차등 안전 하네스 — corpus를 통과시켜 `new_risk ≥ floor` 단조 불변 + `typed_hit` coverage율 측정. floor 은퇴(P6)의 게이트.

Draft 유지 — Ready 전환은 사용자 판단.

Co-Authored-By: Claude Opus 4.8 (claude-opus-4-8)
