### PR TITLE
docs(keeper): remove repo identity wording

### DIFF
--- a/docs/KEEPER-FILE-MODEL.md
+++ b/docs/KEEPER-FILE-MODEL.md
@@ -189,7 +189,7 @@ Operational intent:
 - private writable lane: the keeper sandbox. The current local/docker storage path is `.masc/playground/<keeper>/...`, but keeper tools should use sandbox-relative paths such as `repos/<repo>` and `mind/<file>`.
 - no arbitrary shared writable shell directory
 - `sandbox_profile=docker`는 `allowed_paths=["*"]`를 거부하고, private sandbox root 밖 경로도 허용하지 않는다
-- `MASC_KEEPER_SANDBOX_HARD_MODE=true`에서는 Docker container의 ambient operator credential 사용이 꺼지고, keeper TOML의 별도 repo identity 필드로 credential을 선택하지 않는다.
+- `MASC_KEEPER_SANDBOX_HARD_MODE=true`에서는 Docker container의 ambient operator credential 사용이 꺼지고, keeper TOML 필드로 credential을 선택하지 않는다.
 
 ### Removed / forbidden fields (hard-rejected)
 


### PR DESCRIPTION
## Summary

- Remove the last active-doc mention of `repo identity` as a keeper TOML credential selector.
- Keep the hard-mode statement direct: keeper TOML does not choose credentials.

## Product impact

- User-visible change: active keeper docs no longer preserve a retired config concept in wording.
- No runtime behavior change.

## Evidence

- Targeted active-doc grep for repo identity / retired git credential config terms returned 0 hits.
- `git diff --check` passed.

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 2/2
provenance: direct
stages:
  - command: rg repo identity wording residue
    result: pass
  - command: git diff --check
    result: pass
```

Commands:

- `rg -n "repo identity|repo_identity|repo CLI identity|repo_cli_identity|git_identity_mode|credential-dispatch|credential dispatch" docs/KEEPER-USER-MANUAL.md docs/KEEPER-FILE-MODEL.md`
- `git diff --check`

## GOAL LOOP ACT checklist

- [x] Observe — merged docs still had one `repo identity` wording survivor.
- [x] Orient — credential selection should not be modeled as a keeper TOML repo identity field.
- [x] Decide — one-line docs-only follow-up.
- [x] Act — replaced the wording with generic keeper TOML credential-selection denial.
- [x] Verify — targeted grep and `git diff --check` passed.
- [x] Loop — none.

## Review evidence

- Local docs-only review; pre-commit skipped Dune for docs-only change.

## Linked issue

- None.

## Variant addition checklist

- [ ] **OCaml** — N/A docs-only change.
- [ ] **TypeScript** — N/A docs-only change.
- [ ] **TLA+ spec** — N/A docs-only change.
- [ ] **Event / JSON schema** — N/A docs-only change.
- [ ] **`make check-variants` passes** — N/A docs-only change.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`codex/purge-repo-identity-wording-20260601` → `main` · 1 commit(s) · synced 2026-06-01T13:24:22Z

| sha | subject | date |
|---|---|---|
| `b1167ba11` | docs(keeper): remove repo identity wording | 2026-06-01 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->