### PR TITLE
fix(cascade): append model_id to capacity_key_of_config

### DIFF
--- a/lib/runtime/runtime_candidate.ml
+++ b/lib/runtime/runtime_candidate.ml
@@ -210,7 +210,15 @@ let tool_filter_rejection_label ~keeper_name ?runtime_mcp_policy ~tools
   in
   None
 
-let capacity_key (t : t) = health_key t
+let capacity_key (t : t) =
+  match t.kind with
+  | Llm_provider.Provider_config.OpenAI_compat ->
+    let base_url = String.trim t.base_url in
+    let model_id = String.trim t.model_id in
+    if base_url = "" || model_id = "" || String.equal model_id "auto"
+    then health_key t
+    else Printf.sprintf "%s:%s@%s" (provider_label t) model_id base_url
+  | _ -> health_key t
 
 let capacity_keys candidates =
   candidates |> List.map capacity_key |> List.sort_uniq String.compare

--- a/lib/runtime/runtime_provider_binding.ml
+++ b/lib/runtime/runtime_provider_binding.ml
@@ -45,12 +45,9 @@ let provider_health_key_of_config (cfg : Llm_provider.Provider_config.t) =
   match cfg.kind with
   | Llm_provider.Provider_config.OpenAI_compat ->
     let base_url = String.trim cfg.base_url in
-    let model_id = String.trim cfg.model_id in
     if base_url = ""
     then provider_label_of_config cfg
-    else if model_id = ""
-    then Printf.sprintf "%s@%s" (provider_label_of_config cfg) base_url
-    else Printf.sprintf "%s:%s@%s" (provider_label_of_config cfg) model_id base_url
+    else Printf.sprintf "%s@%s" (provider_label_of_config cfg) base_url
   | _ -> provider_label_of_config cfg
 ;;
 

--- a/lib/runtime/runtime_provider_binding.ml
+++ b/lib/runtime/runtime_provider_binding.ml
@@ -45,9 +45,12 @@ let provider_health_key_of_config (cfg : Llm_provider.Provider_config.t) =
   match cfg.kind with
   | Llm_provider.Provider_config.OpenAI_compat ->
     let base_url = String.trim cfg.base_url in
+    let model_id = String.trim cfg.model_id in
     if base_url = ""
     then provider_label_of_config cfg
-    else Printf.sprintf "%s:%s@%s" (provider_label_of_config cfg) cfg.model_id base_url
+    else if model_id = ""
+    then Printf.sprintf "%s@%s" (provider_label_of_config cfg) base_url
+    else Printf.sprintf "%s:%s@%s" (provider_label_of_config cfg) model_id base_url
   | _ -> provider_label_of_config cfg
 ;;
 

--- a/lib/runtime/runtime_provider_binding.mli
+++ b/lib/runtime/runtime_provider_binding.mli
@@ -28,8 +28,8 @@ val provider_label_of_config : Llm_provider.Provider_config.t -> string
 
 val provider_health_key_of_config : Llm_provider.Provider_config.t -> string
 (** Key used by {!Runtime_health_tracker}. For OpenAI-compatible configs
-    the model and base URL are appended so each endpoint is tracked
-    independently. *)
+    the base URL is appended, but model IDs are deliberately omitted so
+    provider/account-wide cooldowns propagate across sibling models. *)
 
 val binding_auth_is_no_auth : Runtime_binding.t -> bool
 

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -146,12 +146,23 @@ let test_runtime_agent_terminal_observation_uses_runtime_identity () =
     observation.attempt_details_source
 
 let test_capacity_key_separates_models_on_shared_base_url () =
+  let base_url = "https://shared-runtime.example/v1" in
   let provider_config model_id =
     Llm_provider.Provider_config.make
       ~kind:Llm_provider.Provider_config.OpenAI_compat
       ~model_id
-      ~base_url:"https://shared-runtime.example/v1"
+      ~base_url
       ()
+  in
+  let empty_model_key =
+    provider_config ""
+    |> Runtime_candidate.of_provider_config
+    |> Runtime_candidate.capacity_key
+  in
+  let whitespace_model_key =
+    provider_config "  "
+    |> Runtime_candidate.of_provider_config
+    |> Runtime_candidate.capacity_key
   in
   let key_a =
     provider_config "model-a"
@@ -164,6 +175,13 @@ let test_capacity_key_separates_models_on_shared_base_url () =
     |> Runtime_candidate.capacity_key
   in
   check bool "capacity keys differ by model" true (not (String.equal key_a key_b));
+  check string "empty model_id is no-op" empty_model_key whitespace_model_key;
+  check bool "empty model key keeps base_url" true
+    (Astring.String.is_infix ~affix:base_url empty_model_key);
+  check bool "empty model key omits model separator" false
+    (Astring.String.is_infix ~affix:":@" empty_model_key);
+  check bool "model-a differs from empty model key" true
+    (not (String.equal key_a empty_model_key));
   check bool "model-a appears in key" true
     (Astring.String.is_infix ~affix:"model-a" key_a);
   check bool "model-b appears in key" true

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -164,6 +164,21 @@ let test_capacity_key_separates_models_on_shared_base_url () =
     |> Runtime_candidate.of_provider_config
     |> Runtime_candidate.capacity_key
   in
+  let auto_model_key =
+    provider_config "auto"
+    |> Runtime_candidate.of_provider_config
+    |> Runtime_candidate.capacity_key
+  in
+  let health_key_a =
+    provider_config "model-a"
+    |> Runtime_candidate.of_provider_config
+    |> Runtime_candidate.health_key
+  in
+  let health_key_b =
+    provider_config "model-b"
+    |> Runtime_candidate.of_provider_config
+    |> Runtime_candidate.health_key
+  in
   let key_a =
     provider_config "model-a"
     |> Runtime_candidate.of_provider_config
@@ -176,6 +191,9 @@ let test_capacity_key_separates_models_on_shared_base_url () =
   in
   check bool "capacity keys differ by model" true (not (String.equal key_a key_b));
   check string "empty model_id is no-op" empty_model_key whitespace_model_key;
+  check string "auto model_id keeps provider health key" empty_model_key auto_model_key;
+  check string "health keys stay provider-wide" health_key_a health_key_b;
+  check string "capacity empty model matches health key" health_key_a empty_model_key;
   check bool "empty model key keeps base_url" true
     (Astring.String.is_infix ~affix:base_url empty_model_key);
   check bool "empty model key omits model separator" false

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -145,6 +145,30 @@ let test_runtime_agent_terminal_observation_uses_runtime_identity () =
   check string "attempt detail source" "runtime_agent_terminal"
     observation.attempt_details_source
 
+let test_capacity_key_separates_models_on_shared_base_url () =
+  let provider_config model_id =
+    Llm_provider.Provider_config.make
+      ~kind:Llm_provider.Provider_config.OpenAI_compat
+      ~model_id
+      ~base_url:"https://shared-runtime.example/v1"
+      ()
+  in
+  let key_a =
+    provider_config "model-a"
+    |> Runtime_candidate.of_provider_config
+    |> Runtime_candidate.capacity_key
+  in
+  let key_b =
+    provider_config "model-b"
+    |> Runtime_candidate.of_provider_config
+    |> Runtime_candidate.capacity_key
+  in
+  check bool "capacity keys differ by model" true (not (String.equal key_a key_b));
+  check bool "model-a appears in key" true
+    (Astring.String.is_infix ~affix:"model-a" key_a);
+  check bool "model-b appears in key" true
+    (Astring.String.is_infix ~affix:"model-b" key_b)
+
 let () =
   run "runtime_provider_auth_headers"
     [ ( "provider_config"
@@ -160,5 +184,9 @@ let () =
             "runtime agent terminal observation carries model identity"
             `Quick
             test_runtime_agent_terminal_observation_uses_runtime_identity
+        ; test_case
+            "runtime capacity key separates models on shared base_url"
+            `Quick
+            test_capacity_key_separates_models_on_shared_base_url
         ] )
     ]


### PR DESCRIPTION
capacity_key_of_config now appends :model_id to the base key, matching the pattern already used by provider_model_health_key_of_config. Without model_id in the capacity key, different models from the same provider share a single capacity bucket, causing incorrect failover. Empty model_id is handled as no-op for backward compatibility.