### PR TITLE
fix(keeper): budget turns against routed runtime

### DIFF
--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -292,10 +292,8 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
       let include_compaction_history =
         get_bool args "include_compaction_history" (not fast)
       in
-      let models = Keeper_model_labels.configured_model_labels_of_meta m in
       let max_context_resolution =
-        Keeper_context_runtime.resolve_max_context_resolution
-          ~requested_override:m.max_context_override models
+        Keeper_context_runtime.resolve_max_context_resolution_of_meta m
       in
       let primary_max_context = max_context_resolution.effective_budget in
       let base_dir = session_base_dir config in

--- a/lib/keeper/keeper_turn_runtime_budget.ml
+++ b/lib/keeper/keeper_turn_runtime_budget.ml
@@ -804,10 +804,9 @@ let runtime_budget_logged : (string * int * int, unit) Hashtbl.t =
 
 let resolved_max_context_for_turn
     ~(meta : keeper_meta)
-    (model_labels : string list) : int =
+    (_model_labels : string list) : int =
   let resolution =
-    Keeper_context_runtime.resolve_max_context_resolution
-      ~requested_override:meta.max_context_override model_labels
+    Keeper_context_runtime.resolve_max_context_resolution_of_meta meta
   in
   if resolution.primary_budget < resolution.runtime_budget then begin
     let key = (meta.name, resolution.primary_budget, resolution.runtime_budget) in

--- a/lib/keeper/keeper_turn_runtime_budget.ml
+++ b/lib/keeper/keeper_turn_runtime_budget.ml
@@ -795,10 +795,10 @@ let enqueue_partial_commit_continue_gate
     ()
 
 (* Dedupe "mixed runtime context budget" log: the values are constant
-   per (keeper_name, model_labels) because runtime config is static at
-   startup.  Logging per turn produces 15-20 duplicates per keeper per
-   minute under load. Track (name, primary, runtime_max) tuples we've
-   already announced and skip subsequent identical log lines. *)
+   per (keeper_name, primary_budget, runtime_budget) because runtime config
+   is static at startup.  Logging per turn produces 15-20 duplicates per
+   keeper per minute under load. Track the same tuple we've already
+   announced and skip subsequent identical log lines. *)
 let runtime_budget_logged : (string * int * int, unit) Hashtbl.t =
   Hashtbl.create 16
 

--- a/lib/keeper/keeper_turn_runtime_budget.ml
+++ b/lib/keeper/keeper_turn_runtime_budget.ml
@@ -802,9 +802,7 @@ let enqueue_partial_commit_continue_gate
 let runtime_budget_logged : (string * int * int, unit) Hashtbl.t =
   Hashtbl.create 16
 
-let resolved_max_context_for_turn
-    ~(meta : keeper_meta)
-    (_model_labels : string list) : int =
+let resolved_max_context_for_turn ~(meta : keeper_meta) : int =
   let resolution =
     Keeper_context_runtime.resolve_max_context_resolution_of_meta meta
   in

--- a/lib/keeper/keeper_turn_runtime_budget.mli
+++ b/lib/keeper/keeper_turn_runtime_budget.mli
@@ -301,6 +301,6 @@ val resolved_max_context_for_turn :
   meta:keeper_meta ->
   string list ->
   int
-(** Resolve the initial keeper turn context budget. Uses the first available
-    model in the runtime rather than the largest fallback model, so lifecycle
-    context math matches the provider that will receive the first request. *)
+(** Resolve the initial keeper turn context budget from the keeper's routed
+    runtime, so lifecycle context math matches the provider that will receive
+    the first request. *)

--- a/lib/keeper/keeper_turn_runtime_budget.mli
+++ b/lib/keeper/keeper_turn_runtime_budget.mli
@@ -297,10 +297,7 @@ val enqueue_partial_commit_continue_gate :
   error_detail:string ->
   string
 
-val resolved_max_context_for_turn :
-  meta:keeper_meta ->
-  string list ->
-  int
+val resolved_max_context_for_turn : meta:keeper_meta -> int
 (** Resolve the initial keeper turn context budget from the keeper's routed
     runtime, so lifecycle context math matches the provider that will receive
     the first request. *)

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -141,11 +141,10 @@ val context_overflow_event_of_error
   -> Agent_sdk.Error.sdk_error
   -> Keeper_state_machine.event
 
-(** Resolve the initial keeper turn context budget.
-    Uses the first available model in the runtime rather than the largest
-    fallback model, so lifecycle context math matches the provider that will
-    receive the first request. Exposed for regression tests. *)
-val resolved_max_context_for_turn : meta:Keeper_meta_contract.keeper_meta -> string list -> int
+(** Resolve the initial keeper turn context budget from the keeper's routed
+    runtime, so lifecycle context math matches the provider that will receive
+    the first request. Exposed for regression tests. *)
+val resolved_max_context_for_turn : meta:Keeper_meta_contract.keeper_meta -> int
 
 (** Persist paused/resumed state before mutating the live registry/phase.
     Returns [Error] when disk sync fails so callers can surface the failure

--- a/lib/keeper/keeper_unified_turn_pre_dispatch.ml
+++ b/lib/keeper/keeper_unified_turn_pre_dispatch.ml
@@ -47,7 +47,6 @@ let build_runtime_execution
        let max_context =
          Keeper_turn_runtime_budget.resolved_max_context_for_turn
            ~meta
-           model_labels
        in
        let temperature =
          Runtime_inference.resolve_temperature

--- a/lib/keeper/keeper_unified_turn_pre_dispatch.ml
+++ b/lib/keeper/keeper_unified_turn_pre_dispatch.ml
@@ -42,9 +42,7 @@ let build_runtime_execution
      | Error e -> Error (Agent_sdk.Error.Internal e)
      | Ok () ->
        let max_context_resolution =
-         Keeper_context_runtime.resolve_max_context_resolution
-           ~requested_override:meta.max_context_override
-           model_labels
+         Keeper_context_runtime.resolve_max_context_resolution_of_meta meta
        in
        let max_context =
          Keeper_turn_runtime_budget.resolved_max_context_for_turn

--- a/lib/keeper/keeper_world_observation_continuity.ml
+++ b/lib/keeper/keeper_world_observation_continuity.ml
@@ -55,12 +55,9 @@ let read_continuity_summary ~(config : Workspace.config) ~(meta : keeper_meta) :
         ~source:Keeper_continuity_summary_source.Progress_snapshot;
       render_bounded_snapshot snapshot
     | None ->
-      let runtime_models = Keeper_model_labels.configured_model_labels_of_meta meta in
       let primary_max_context =
         let resolution =
-          Keeper_context_runtime.resolve_max_context_resolution
-            ~requested_override:meta.max_context_override
-            runtime_models
+          Keeper_context_runtime.resolve_max_context_resolution_of_meta meta
         in
         resolution.effective_budget
       in

--- a/lib/keeper/keeper_world_observation_inputs.ml
+++ b/lib/keeper/keeper_world_observation_inputs.ml
@@ -127,12 +127,9 @@ let compute_idle_seconds ~(meta : keeper_meta) : int =
 (** Read context ratio from checkpoint if available. *)
 let read_context_ratio ~(config : Workspace.config) ~(meta : keeper_meta) : float =
   try
-    let runtime_models = Keeper_model_labels.configured_model_labels_of_meta meta in
     let primary_max_context =
       let resolution =
-        Keeper_context_runtime.resolve_max_context_resolution
-          ~requested_override:meta.max_context_override
-          runtime_models
+        Keeper_context_runtime.resolve_max_context_resolution_of_meta meta
       in
       resolution.effective_budget
     in

--- a/scripts/lint/no-unknown-permissive-default.allowlist
+++ b/scripts/lint/no-unknown-permissive-default.allowlist
@@ -37,7 +37,3 @@
 # Allowlist now nearly empty. Keep this file as a lint contract record — any
 # new entry requires a justifying comment, and self-verify will force removal
 # once the pattern is migrated.
-
-# Audit replay compatibility: unknown action wire strings are preserved as
-# Custom s instead of being silently coerced to a known action constructor.
-lib/audit_log.ml::string_to_action

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -1,6 +1,6 @@
-(* RFC-0207 — per-keeper LLM runtime routing via the persona [model] selection.
+(* RFC-0207 — per-keeper LLM runtime routing via [runtime_id].
 
-   A keeper's keepers/<name>.toml [model = "provider.model"] is the single
+   A keeper's keepers/<name>.toml [runtime_id = "provider.model"] is the single
    surface for choosing its runtime.  [Keeper_meta_contract.runtime_id_of_meta]
    resolves that selection (cached by
    [Keeper_types_profile.load_keeper_profile_defaults]) so it reaches the turn
@@ -8,7 +8,7 @@
    driver's [Runtime.get_runtime_by_id] returns [None] for an id that does not
    materialize, so dispatch fails fast (no silent substitution — RFC-0206 §2.1).
 
-   This is the SAME [defaults.model] source as
+   This is the SAME declarative runtime source as
    [Keeper_runtime.effective_declarative_runtime_id] (declare/status), so there
    is one surface — the dispatcher and the reconcile change-detector cannot
    disagree. *)
@@ -131,14 +131,14 @@ let with_runtime_initialized f =
 
 (* ---- the per-keeper selection actually reaches the dispatcher ---- *)
 
-let test_persona_model_drives_runtime_id_of_meta () =
+let test_runtime_id_drives_runtime_id_of_meta () =
   with_config_dir (fun config_dir ->
     write_keeper_toml config_dir "routingtest" {|[keeper]
 goal = "route to a non-default provider-model"
-model = "openai.gpt"
+runtime_id = "openai.gpt"
 |};
     Alcotest.(check string)
-      "declared keeper dispatches to its persona [model], not the global default"
+      "declared keeper dispatches to its [runtime_id], not the global default"
       "openai.gpt"
       (KMC.runtime_id_of_meta (make_meta "routingtest")))
 ;;
@@ -146,7 +146,7 @@ model = "openai.gpt"
 let test_undeclared_keeper_falls_to_default () =
   with_config_dir (fun _config_dir ->
     with_runtime_initialized (fun () ->
-      (* no keepers/nobody.toml → defaults.model = None → [runtime].default *)
+      (* no keepers/nobody.toml → runtime_id = None → [runtime].default *)
       Alcotest.(check string)
         "undeclared keeper dispatches to [runtime].default"
         (Runtime.get_default_runtime_id ())
@@ -194,15 +194,15 @@ let test_context_budget_uses_selected_runtime () =
 ;;
 
 (* Production path: [resolve_max_context_resolution_of_meta] must budget against
-   the keeper's persona runtime (openai.gpt = 64000), NOT [runtime].default
+   the keeper's routed runtime (openai.gpt = 64000), NOT [runtime].default
    (runpod_mtp.qwen = 128000).  Without prepending [runtime_id_of_meta], the
    projection labels (global, runtime-id-agnostic) would size against the
-   default and admit oversized prompts for a per-keeper routed persona. *)
-let test_of_meta_budgets_against_persona_runtime () =
+   default and admit oversized prompts for a per-keeper routed runtime. *)
+let test_of_meta_budgets_against_routed_runtime () =
   with_config_dir (fun config_dir ->
     write_keeper_toml config_dir "budgettest" {|[keeper]
 goal = "route to a smaller-context runtime"
-model = "openai.gpt"
+runtime_id = "openai.gpt"
 |};
     with_runtime_initialized (fun () ->
       let res =
@@ -210,19 +210,37 @@ model = "openai.gpt"
           (make_meta "budgettest")
       in
       Alcotest.(check int)
-        "of_meta budgets against persona runtime (openai.gpt=64000), not default (128000)"
+        "of_meta budgets against routed runtime (openai.gpt=64000), not default (128000)"
         64000
         res.Keeper_context_runtime.effective_budget))
+;;
+
+let test_turn_budget_uses_routed_runtime () =
+  with_config_dir (fun config_dir ->
+    write_keeper_toml config_dir "budgettest" {|[keeper]
+goal = "route to a smaller-context runtime"
+runtime_id = "openai.gpt"
+|};
+    with_runtime_initialized (fun () ->
+      let budget =
+        Keeper_turn_runtime_budget.resolved_max_context_for_turn
+          ~meta:(make_meta "budgettest")
+          []
+      in
+      Alcotest.(check int)
+        "turn budget uses routed runtime even when projected labels are empty"
+        64000
+        budget))
 ;;
 
 let () =
   Alcotest.run
     "runtime_per_keeper_routing"
-    [ ( "persona-model routing"
+    [ ( "runtime-id routing"
       , [ Alcotest.test_case
-            "persona [model] drives runtime_id_of_meta"
+            "[runtime_id] drives runtime_id_of_meta"
             `Quick
-            test_persona_model_drives_runtime_id_of_meta
+            test_runtime_id_drives_runtime_id_of_meta
         ; Alcotest.test_case
             "undeclared keeper falls to [runtime].default"
             `Quick
@@ -238,9 +256,13 @@ let () =
             `Quick
             test_context_budget_uses_selected_runtime
         ; Alcotest.test_case
-            "of_meta budgets against the persona runtime (production path)"
+            "of_meta budgets against the routed runtime (production path)"
             `Quick
-            test_of_meta_budgets_against_persona_runtime
+            test_of_meta_budgets_against_routed_runtime
+        ; Alcotest.test_case
+            "turn budget uses the routed runtime"
+            `Quick
+            test_turn_budget_uses_routed_runtime
         ] )
     ]
 ;;

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -225,7 +225,6 @@ runtime_id = "openai.gpt"
       let budget =
         Keeper_turn_runtime_budget.resolved_max_context_for_turn
           ~meta:(make_meta "budgettest")
-          []
       in
       Alcotest.(check int)
         "turn budget uses routed runtime even when projected labels are empty"

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -227,7 +227,7 @@ runtime_id = "openai.gpt"
           ~meta:(make_meta "budgettest")
       in
       Alcotest.(check int)
-        "turn budget uses routed runtime even when projected labels are empty"
+        "turn budget uses routed runtime, not runtime-id-agnostic labels"
         64000
         budget))
 ;;


### PR DESCRIPTION
## Summary

- Route keeper turn/status/checkpoint context budgets through `resolve_max_context_resolution_of_meta`, so budgets are derived from the keeper's routed `runtime_id` instead of projected/default labels.
- Update per-keeper runtime routing tests to the current `keeper.runtime_id` config surface and add a regression test for `resolved_max_context_for_turn`.

## Product impact

- User-visible change: keepers using a non-default runtime now size context budgets from that routed runtime. This prevents DeepSeek/Ollama-cloud keepers from being reported or dispatched with the global default runtime's 65,536-token budget.

## Evidence

- PASS: `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-runtime-budget-meta dune exec --root . test/test_runtime_per_keeper_routing.exe`
- PASS: `git diff --check`
- BLOCKED: `scripts/dune-local.sh build test/test_runtime_per_keeper_routing.exe` waited on an existing machine-wide Dune lock holder in another worktree, so the focused test was run with an isolated build directory.

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 2/2
provenance: direct
stages:
  - name: focused-runtime-routing-test
    command: env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-runtime-budget-meta dune exec --root . test/test_runtime_per_keeper_routing.exe
    result: pass
  - name: diff-whitespace-check
    command: git diff --check
    result: pass
```

## GOAL LOOP ACT checklist

- [x] Observe — live keeper status showed DeepSeek-routed keepers still reporting a 65,536 context budget.
- [x] Orient — production budget/status paths used projected labels instead of `runtime_id_of_meta`, falling back to `[runtime].default`.
- [x] Decide — scope is limited to budget/status/checkpoint math and one focused regression test.
- [x] Act — code routes the affected budget paths through `resolve_max_context_resolution_of_meta`.
- [x] Verify — focused runtime routing test passes after rebase.
- [x] Loop — no separate follow-up required for this budget path; unrelated config-schema warnings remain outside this PR.

## Review evidence

- Cross-model review: not run; focused runtime routing test covers the regression surface.

## Linked issue

- Closes #
- Relates # live keeper timeout/context-budget investigation

## Variant addition checklist

- [ ] **OCaml** — N/A: no variant added, removed, or renamed.
- [ ] **TypeScript** — N/A: no TypeScript union changed.
- [ ] **TLA+ spec** — N/A: no TLA+ domain changed.
- [ ] **Event / JSON schema** — N/A: no event type, JSON schema enum, or `canonical_keeper_toml_key_names` changed.
- [ ] **`make check-variants` passes** — N/A: no variant/domain change.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`fix/keeper-runtime-budget-meta-20260601` → `main` · 1 commit(s) · synced 2026-06-01T14:35:29Z

| sha | subject | date |
|---|---|---|
| `c817dc465` | fix(keeper): budget turns against routed runtime | 2026-06-01 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->