### PR TITLE
fix(execute): report execution location

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -560,7 +560,31 @@ jobs:
           # See: https://github.com/jeong-sik/masc-mcp/issues/2957
           DUNE_JOBS: 1
         run: |
-          opam exec -- dune build
+          set -euo pipefail
+
+          opam exec -- dune build &
+          build_pid=$!
+
+          (
+            elapsed=0
+            while kill -0 "${build_pid}" 2>/dev/null; do
+              sleep 60
+              elapsed=$((elapsed + 60))
+              if kill -0 "${build_pid}" 2>/dev/null; then
+                echo "[ci-heartbeat] dune build still running (${elapsed}s elapsed)"
+              fi
+            done
+          ) &
+          heartbeat_pid=$!
+
+          set +e
+          wait "${build_pid}"
+          build_status=$?
+          set -e
+
+          kill "${heartbeat_pid}" 2>/dev/null || true
+          wait "${heartbeat_pid}" 2>/dev/null || true
+          exit "${build_status}"
 
       - name: Runtime TOML validity gate
         # RFC-0058 §9: config/keeper_runtime.toml is the authoring SSOT.

--- a/lib/keeper/agent_tool_execute_path.ml
+++ b/lib/keeper/agent_tool_execute_path.ml
@@ -36,6 +36,100 @@ let repo_path_context ~(config : Workspace.config) ~(meta : keeper_meta) cwd =
         Some (repo_name, repo_root, repo_root, [ repo_root ])
       | _ -> None
 
+type execution_location_scope =
+  | Playground_root
+  | Playground_subpath
+  | Repo_root
+  | Repo_subpath
+  | Repo_worktree_root
+  | Repo_worktree_subpath
+  | Outside_playground
+
+let string_of_execution_location_scope = function
+  | Playground_root -> "playground_root"
+  | Playground_subpath -> "playground_subpath"
+  | Repo_root -> "repo_root"
+  | Repo_subpath -> "repo_subpath"
+  | Repo_worktree_root -> "repo_worktree_root"
+  | Repo_worktree_subpath -> "repo_worktree_subpath"
+  | Outside_playground -> "outside_playground"
+
+let path_segments path =
+  path
+  |> normalize_repo_cwd_path
+  |> String.split_on_char '/'
+  |> List.filter (fun segment -> not (String.equal segment ""))
+
+let strip_segment_prefix ~prefix segments =
+  let rec loop prefix segments =
+    match prefix, segments with
+    | [], rest -> Some rest
+    | p :: ps, s :: ss when String.equal p s -> loop ps ss
+    | _ -> None
+  in
+  loop prefix segments
+
+let relative_path_of_segments = function
+  | [] -> "."
+  | segments -> String.concat "/" segments
+
+let execution_location_json
+      ~(config : Workspace.config)
+      ~(meta : keeper_meta)
+      ~(args : Yojson.Safe.t)
+      ~(cwd : string)
+  =
+  let raw_cwd = Safe_ops.json_string ~default:"" "cwd" args |> String.trim in
+  let cwd_source =
+    if String.equal raw_cwd "" then "default_playground_root" else "explicit_cwd"
+  in
+  let playground =
+    keeper_playground_root ~config ~meta
+    |> normalize_repo_cwd_path
+  in
+  let cwd = normalize_repo_cwd_path cwd in
+  let playground_segments = path_segments playground in
+  let cwd_segments = path_segments cwd in
+  let scope, relative_segments, repo_name, repo_root, worktree_root =
+    match strip_segment_prefix ~prefix:playground_segments cwd_segments with
+    | None -> Outside_playground, [], None, None, None
+    | Some [] -> Playground_root, [], None, None, None
+    | Some ("repos" :: repo_name :: rest)
+      when Keeper_repo_readiness.safe_repo_component repo_name ->
+      let repo_root = Filename.concat (Filename.concat playground "repos") repo_name in
+      (match rest with
+       | [] -> Repo_root, [ "repos"; repo_name ], Some repo_name, Some repo_root, None
+       | ".worktrees" :: task_name :: tail
+         when Keeper_repo_readiness.safe_repo_component task_name ->
+         let worktree_root =
+           Filename.concat (Filename.concat repo_root ".worktrees") task_name
+         in
+         let scope =
+           match tail with
+           | [] -> Repo_worktree_root
+           | _ -> Repo_worktree_subpath
+         in
+         ( scope
+         , [ "repos"; repo_name; ".worktrees"; task_name ] @ tail
+         , Some repo_name
+         , Some repo_root
+         , Some worktree_root )
+       | _ -> Repo_subpath, [ "repos"; repo_name ] @ rest, Some repo_name, Some repo_root, None)
+    | Some rest -> Playground_subpath, rest, None, None, None
+  in
+  `Assoc
+    [ "cwd", `String cwd
+    ; "cwd_source", `String cwd_source
+    ; "scope", `String (string_of_execution_location_scope scope)
+    ; "playground_root", `String playground
+    ; "relative_cwd", `String (relative_path_of_segments relative_segments)
+    ; "relative_path_base", `String cwd
+    ; "argv_relative_paths_resolve_against_cwd", `Bool true
+    ; "repo_name", Json_util.string_opt_to_json repo_name
+    ; "repo_root", Json_util.string_opt_to_json repo_root
+    ; "worktree_root", Json_util.string_opt_to_json worktree_root
+    ]
+
 let repo_cwd_not_ready_error ~repo_name ~path_root ~git_toplevel =
   Printf.sprintf
     "sandbox_repo_not_ready: sandbox path is under repos/%s, but %s is not an \

--- a/lib/keeper/agent_tool_execute_path.ml
+++ b/lib/keeper/agent_tool_execute_path.ml
@@ -123,12 +123,17 @@ let execution_location_json
        | _ -> Repo_subpath, [ "repos"; repo_name ] @ rest, Some repo_name, Some repo_root, None)
     | Some rest -> Playground_subpath, rest, None, None, None
   in
+  let relative_cwd =
+    match scope with
+    | Outside_playground -> `Null
+    | _ -> `String (relative_path_of_segments relative_segments)
+  in
   `Assoc
     [ "cwd", `String cwd
     ; "cwd_source", `String cwd_source
     ; "scope", `String (string_of_execution_location_scope scope)
     ; "playground_root", `String playground
-    ; "relative_cwd", `String (relative_path_of_segments relative_segments)
+    ; "relative_cwd", relative_cwd
     ; "relative_path_base", `String cwd
     ; "argv_relative_paths_resolve_against_cwd", `Bool true
     ; "repo_name", Json_util.string_opt_to_json repo_name

--- a/lib/keeper/agent_tool_execute_path.ml
+++ b/lib/keeper/agent_tool_execute_path.ml
@@ -29,10 +29,12 @@ let repo_path_context ~(config : Workspace.config) ~(meta : keeper_meta) cwd =
         let repo_root = Filename.concat repos_root repo_name in
         let worktree_root =
           Filename.concat (Filename.concat repo_root ".worktrees") task_name
+          |> normalize_repo_cwd_path
         in
-        Some (repo_name, repo_root, worktree_root, [ worktree_root ])
+        Some (repo_name, normalize_repo_cwd_path repo_root, worktree_root, [ worktree_root ])
       | repo_name :: _ when Keeper_repo_readiness.safe_repo_component repo_name ->
         let repo_root = Filename.concat repos_root repo_name in
+        let repo_root = normalize_repo_cwd_path repo_root in
         Some (repo_name, repo_root, repo_root, [ repo_root ])
       | _ -> None
 
@@ -96,13 +98,17 @@ let execution_location_json
     | Some [] -> Playground_root, [], None, None, None
     | Some ("repos" :: repo_name :: rest)
       when Keeper_repo_readiness.safe_repo_component repo_name ->
-      let repo_root = Filename.concat (Filename.concat playground "repos") repo_name in
+      let repo_root =
+        Filename.concat (Filename.concat playground "repos") repo_name
+        |> normalize_repo_cwd_path
+      in
       (match rest with
        | [] -> Repo_root, [ "repos"; repo_name ], Some repo_name, Some repo_root, None
        | ".worktrees" :: task_name :: tail
          when Keeper_repo_readiness.safe_repo_component task_name ->
          let worktree_root =
            Filename.concat (Filename.concat repo_root ".worktrees") task_name
+           |> normalize_repo_cwd_path
          in
          let scope =
            match tail with

--- a/lib/keeper/agent_tool_execute_path.mli
+++ b/lib/keeper/agent_tool_execute_path.mli
@@ -23,6 +23,17 @@ val validate_repo_path_args_ready :
     commands run from the playground root with arguments like
     [./repos/masc-mcp/lib/foo.ml]. *)
 
+val execution_location_json :
+  config:Workspace.config ->
+  meta:Keeper_meta_contract.keeper_meta ->
+  args:Yojson.Safe.t ->
+  cwd:string ->
+  Yojson.Safe.t
+(** Structured cwd contract for Execute responses.  The JSON tells the agent
+    whether the effective cwd is the keeper playground root, a sandbox repo,
+    or a sandbox worktree, and records that relative argv paths resolve against
+    that effective cwd. *)
+
 val auto_correct_path :
   meta:Keeper_meta_contract.keeper_meta -> string -> string option
 (** Auto-correct common LLM-hallucinated path prefixes

--- a/lib/keeper/agent_tool_execute_path.mli
+++ b/lib/keeper/agent_tool_execute_path.mli
@@ -30,9 +30,12 @@ val execution_location_json :
   cwd:string ->
   Yojson.Safe.t
 (** Structured cwd contract for Execute responses.  The JSON tells the agent
-    whether the effective cwd is the keeper playground root, a sandbox repo,
-    or a sandbox worktree, and records that relative argv paths resolve against
-    that effective cwd. *)
+    whether the effective cwd is inside the keeper playground
+    ([playground_root], [playground_subpath], [repo_root], [repo_subpath],
+    [repo_worktree_root], [repo_worktree_subpath]) or outside it
+    ([outside_playground]).  [relative_cwd] is relative to [playground_root]
+    for playground scopes and [null] when the cwd is outside the playground.
+    Relative argv paths resolve against the effective cwd. *)
 
 val auto_correct_path :
   meta:Keeper_meta_contract.keeper_meta -> string -> string option

--- a/lib/keeper/agent_tool_execute_runtime.ml
+++ b/lib/keeper/agent_tool_execute_runtime.ml
@@ -88,11 +88,18 @@ let handle_tool_execute_typed
   match Agent_tool_execute_path.resolve_tool_write_cwd ~config ~meta ~args with
     | Error e -> error_json e
     | Ok cwd ->
+      let execution_location_fields cwd =
+        [ ( "execution_location"
+          , Agent_tool_execute_path.execution_location_json ~config ~meta ~args ~cwd )
+        ]
+      in
       let typed_args = assoc_upsert "cwd" (`String cwd) args in
       match Agent_tool_execute_typed_input.of_json typed_args with
       | Error e ->
         error_json
-          ~fields:[ "typed", `Bool true; "cwd", `String cwd ]
+          ~fields:
+            ([ "typed", `Bool true; "cwd", `String cwd ]
+             @ execution_location_fields cwd)
           e
       | Ok input ->
         let cmd = typed_input_command_text input in
@@ -150,13 +157,16 @@ let handle_tool_execute_typed
            error_json
              ~fields:
                ([ "typed", `Bool true; "cmd", `String cmd; "cwd", `String cwd ]
+                @ execution_location_fields cwd
                 @ fields)
              message
          | Ok (dispatch_sandbox, sandbox_extra_fields) ->
         match root_git_cwd_error with
         | Some e ->
           error_json
-            ~fields:[ "typed", `Bool true; "cmd", `String cmd; "cwd", `String cwd ]
+            ~fields:
+              ([ "typed", `Bool true; "cmd", `String cmd; "cwd", `String cwd ]
+               @ execution_location_fields cwd)
             e
         | None ->
         (* RFC-0160 S1: lower-then-classify. Typed argv → Shell IR
@@ -169,6 +179,7 @@ let handle_tool_execute_typed
           let alts = Agent_tool_execute_typed_input.validation_error_alternatives e in
           let fields =
             [ "typed", `Bool true; "cmd", `String cmd; "cwd", `String cwd ]
+            @ execution_location_fields cwd
             @
             (match alts with
              | [] -> []
@@ -190,6 +201,7 @@ let handle_tool_execute_typed
         in
         let typed_error_fields =
           [ "typed", `Bool true; "cmd", `String cmd_for_log; "cwd", `String cwd ]
+          @ execution_location_fields cwd
         in
         let blocked_result ?deterministic_reason ~error ~reason ~alternatives () =
           (* RFC-0208 P1: a blocked typed command emits a Keeper-level audit
@@ -221,9 +233,11 @@ let handle_tool_execute_typed
                ~extra:
                  (deterministic_retry_fields
                   @ [ "cmd", `String cmd_for_log
+                    ; "cwd", `String cwd
                     ; "typed", `Bool true
                     ; "execution_time_ms", `Int 0
-                    ])
+                    ]
+                  @ execution_location_fields cwd)
                ())
         in
         let envelope = Agent_tool_execute_shell_ir.classify ir in
@@ -297,7 +311,9 @@ let handle_tool_execute_typed
               meta.name
               cmd_for_log
               (message_for_log e);
-            error_json ~fields:[ "blocked_cmd", `String cmd_for_log ] e
+            error_json
+              ~fields:(("blocked_cmd", `String cmd_for_log) :: typed_error_fields)
+              e
           | Ok result ->
             let elapsed_ms =
               (* NDT-OK: second wall-clock read closes the elapsed telemetry
@@ -341,7 +357,8 @@ let handle_tool_execute_typed
                       ; "typed", `Bool true
                       ; "execution_time_ms", `Int elapsed_ms
                       ; "timeout_sec", `Float timeout_sec
-                      ])
+                      ]
+                    @ execution_location_fields cwd)
                  ~status:result.status
                  ~output
                  ~env_snapshot:env_snap

--- a/scripts/lint/no-unknown-permissive-default.allowlist
+++ b/scripts/lint/no-unknown-permissive-default.allowlist
@@ -37,7 +37,3 @@
 # Allowlist now nearly empty. Keep this file as a lint contract record — any
 # new entry requires a justifying comment, and self-verify will force removal
 # once the pattern is migrated.
-
-# Audit replay compatibility: unknown action wire strings are preserved as
-# Custom s instead of being silently coerced to a known action constructor.
-lib/audit_log.ml::string_to_action

--- a/test/test_agent_tool_execute_safety.ml
+++ b/test/test_agent_tool_execute_safety.ml
@@ -824,6 +824,84 @@ let parse_hint raw =
   |> Json.member "hint"
   |> Json.to_string_option
 
+let test_tool_execute_runtime_error_reports_default_execution_location () =
+  with_eio_fs @@ fun () ->
+  let base_path, config = make_config () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  Keeper_registry.clear ();
+  let meta = make_readonly_meta "exec-location" in
+  let playground = Filename.concat base_path (playground_path_of meta.name) in
+  let playground_canonical = normalize_path_for_containment playground in
+  ensure_dir playground;
+  let raw =
+    Agent_tool_command_runtime.handle_tool_execute
+      ~turn_sandbox_factory:None
+      ~turn_sandbox_factory_git:None
+      ~exec_cache:None
+      ~config
+      ~meta
+      ~args:
+        (`Assoc
+           [ "executable", `String "ls"
+           ; "argv", `List [ `String "definitely-missing" ]
+           ])
+      ()
+  in
+  let json = Yojson.Safe.from_string raw in
+  Alcotest.(check bool) "runtime failure is surfaced" false
+    (json |> Json.member "ok" |> Json.to_bool);
+  Alcotest.(check string) "top-level cwd is default playground" playground
+    (json |> Json.member "cwd" |> Json.to_string);
+  let loc = json |> Json.member "execution_location" in
+  Alcotest.(check string) "scope" "playground_root"
+    (loc |> Json.member "scope" |> Json.to_string);
+  Alcotest.(check string) "cwd source" "default_playground_root"
+    (loc |> Json.member "cwd_source" |> Json.to_string);
+  Alcotest.(check string) "relative cwd" "."
+    (loc |> Json.member "relative_cwd" |> Json.to_string);
+  Alcotest.(check string) "relative path base" playground_canonical
+    (loc |> Json.member "relative_path_base" |> Json.to_string);
+  Alcotest.(check bool) "argv paths resolve against cwd" true
+    (loc
+     |> Json.member "argv_relative_paths_resolve_against_cwd"
+     |> Json.to_bool)
+
+let test_execution_location_classifies_repo_worktree_subpath () =
+  with_eio_fs @@ fun () ->
+  let base_path, config = make_config () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  let meta = make_readonly_meta "exec-location-worktree" in
+  let playground = Filename.concat base_path (playground_path_of meta.name) in
+  let cwd =
+    Filename.concat playground "repos/masc-mcp/.worktrees/task-123/lib"
+  in
+  let loc =
+    Masc_mcp.Agent_tool_execute_path.execution_location_json
+      ~config
+      ~meta
+      ~args:
+        (`Assoc
+           [ ( "cwd"
+             , `String "repos/masc-mcp/.worktrees/task-123/lib" )
+           ])
+      ~cwd
+  in
+  Alcotest.(check string) "scope" "repo_worktree_subpath"
+    (loc |> Json.member "scope" |> Json.to_string);
+  Alcotest.(check string) "cwd source" "explicit_cwd"
+    (loc |> Json.member "cwd_source" |> Json.to_string);
+  Alcotest.(check string) "repo name" "masc-mcp"
+    (loc |> Json.member "repo_name" |> Json.to_string);
+  Alcotest.(check string)
+    "relative cwd"
+    "repos/masc-mcp/.worktrees/task-123/lib"
+    (loc |> Json.member "relative_cwd" |> Json.to_string);
+  Alcotest.(check string)
+    "worktree root"
+    (normalize_path_for_containment
+       (Filename.concat playground "repos/masc-mcp/.worktrees/task-123"))
+    (loc |> Json.member "worktree_root" |> Json.to_string)
+
 let test_tool_execute_typed_process_runs_via_shell_ir () =
   with_eio_fs @@ fun () ->
   let base_path, config = make_config () in
@@ -1429,6 +1507,14 @@ let () =
         ] )
     ; ( "typed_shell_ir"
       , [ Alcotest.test_case
+            "runtime errors report default execution location"
+            `Quick
+            test_tool_execute_runtime_error_reports_default_execution_location
+        ; Alcotest.test_case
+            "execution location classifies worktree subpaths"
+            `Quick
+            test_execution_location_classifies_repo_worktree_subpath
+        ; Alcotest.test_case
             "typed process runs via Shell IR"
             `Quick
             test_tool_execute_typed_process_runs_via_shell_ir

--- a/test/test_agent_tool_execute_safety.ml
+++ b/test/test_agent_tool_execute_safety.ml
@@ -907,6 +907,28 @@ let test_execution_location_classifies_repo_worktree_subpath () =
        (Filename.concat playground "repos/masc-mcp/.worktrees/task-123"))
     (loc |> Json.member "worktree_root" |> Json.to_string)
 
+let test_execution_location_outside_playground_has_null_relative_cwd () =
+  with_eio_fs @@ fun () ->
+  let base_path, config = make_config () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  let meta = make_readonly_meta "exec-location-outside" in
+  let cwd = Filename.concat base_path "outside" in
+  let loc =
+    Masc_mcp.Agent_tool_execute_path.execution_location_json
+      ~config
+      ~meta
+      ~args:(`Assoc [ "cwd", `String cwd ])
+      ~cwd
+  in
+  Alcotest.(check string) "scope" "outside_playground"
+    (loc |> Json.member "scope" |> Json.to_string);
+  Alcotest.(check string) "cwd source" "explicit_cwd"
+    (loc |> Json.member "cwd_source" |> Json.to_string);
+  Alcotest.(check bool) "relative cwd is not applicable" true
+    (match loc |> Json.member "relative_cwd" with
+     | `Null -> true
+     | _ -> false)
+
 let test_tool_execute_typed_process_runs_via_shell_ir () =
   with_eio_fs @@ fun () ->
   let base_path, config = make_config () in
@@ -1519,6 +1541,10 @@ let () =
             "execution location classifies worktree subpaths"
             `Quick
             test_execution_location_classifies_repo_worktree_subpath
+        ; Alcotest.test_case
+            "execution location outside playground has no relative cwd"
+            `Quick
+            test_execution_location_outside_playground_has_null_relative_cwd
         ; Alcotest.test_case
             "typed process runs via Shell IR"
             `Quick

--- a/test/test_agent_tool_execute_safety.ml
+++ b/test/test_agent_tool_execute_safety.ml
@@ -897,6 +897,11 @@ let test_execution_location_classifies_repo_worktree_subpath () =
     "repos/masc-mcp/.worktrees/task-123/lib"
     (loc |> Json.member "relative_cwd" |> Json.to_string);
   Alcotest.(check string)
+    "repo root"
+    (normalize_path_for_containment
+       (Filename.concat playground "repos/masc-mcp"))
+    (loc |> Json.member "repo_root" |> Json.to_string);
+  Alcotest.(check string)
     "worktree root"
     (normalize_path_for_containment
        (Filename.concat playground "repos/masc-mcp/.worktrees/task-123"))


### PR DESCRIPTION
## Summary
- Add a structured `execution_location` object for typed Execute responses.
- Classify effective cwd as playground root/subpath, sandbox repo, or sandbox worktree using path segments.
- Wire the location contract into typed Execute success, runtime failure, validation error, path reject, and blocked responses.
- Add regression coverage for no-cwd runtime failures and worktree-subpath classification.

## Product impact
- Keepers can see where Execute actually ran before interpreting relative argv paths.
- A no-cwd call now explicitly reports `cwd_source=default_playground_root`, `scope=playground_root`, and `argv_relative_paths_resolve_against_cwd=true`.
- This addresses the confusion where `ls repos/masc-mcp/...` was interpreted as repo-context execution even though Execute was running from the keeper playground root.

## Evidence
- PASS: `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-exec-location dune build --root . test/test_agent_tool_execute_safety.exe`
- PASS: `_build-codex-exec-location/default/test/test_agent_tool_execute_safety.exe test typed_shell_ir`
- PASS: `bash scripts/lint/no-unknown-permissive-default.sh`
- NOTE: the full `test_agent_tool_execute_safety.exe` suite currently has unrelated pre-existing failures in allowlist/read-op/timeout-floor assertions; the new `typed_shell_ir` coverage passes.

## Direct evidence
schema_version: 1
direct_ratio: 3/3
provenance: direct

## Review evidence
- The new cwd classifier avoids substring heuristics and derives scope from normalized path segments.
- `git diff --check HEAD~1..HEAD` passes.

## Linked issue
- None.
