### PR TITLE
fix(keeper): keep streaming attempts progress-based

### DIFF
--- a/docs/rfc/RFC-0022-runtime-attempt-liveness.md
+++ b/docs/rfc/RFC-0022-runtime-attempt-liveness.md
@@ -20,8 +20,8 @@
 Runtime providers are called without any in-attempt liveness contract. A
 single hung HTTP read on the first runtime slot consumes the entire
 turn budget (3600s) before the runtime FSM advances to the next
-provider. This RFC introduces an attempt-level three-tier streaming
-liveness gate (TTFT, inter-chunk idle, wall) that fails the *current
+provider. This RFC introduces an attempt-level streaming liveness
+gate (TTFT, inter-chunk idle, pre-stream wall) that fails the *current
 attempt* — not the turn — when the provider stops emitting evidence of
 forward motion. Thinking tokens count as motion, so adaptive-reasoning
 turns are protected.
@@ -34,7 +34,7 @@ operate on disjoint state and disjoint kill classes:
 | Layer | RFC | State | Decision input | Kill class | Effect on caller |
 |---|---|---|---|---|---|
 | Pre-attempt | RFC-0009 | `Runtime_health_tracker.trust_score` | aggregate failures over time | provider demoted in runtime order | next call sees better order |
-| **In-attempt (this RFC)** | **0022** | per-attempt liveness clock | absence of streaming chunks | `Attempt_no_first_token` / `Attempt_inter_chunk_idle` / `Attempt_wall_exceeded` | this attempt fails, FSM advances to next slot, **turn lives** |
+| **In-attempt (this RFC)** | **0022** | per-attempt liveness clock | absence of streaming chunks | `Attempt_no_first_token` / `Attempt_inter_chunk_idle` / pre-stream `Attempt_wall_exceeded` | this attempt fails, FSM advances to next slot, **turn lives** |
 | Cross-attempt (turn) | RFC-0012 | `turn_observation.last_progress_at` | absence of `oas:event` across all attempts in this turn | `Mid_turn_no_progress` | watchdog terminates fiber, turn dies |
 
 Invariant L1 (layer independence):
@@ -127,7 +127,7 @@ typed runtime failure (not a generic timeout):
 | `Done` | response complete | — | success |
 | `No_first_token` | TTFT exceeded | `Attempt_no_first_token` | persistent |
 | `Inter_chunk_idle` | gap between chunks > idle_max | `Attempt_inter_chunk_idle` | persistent |
-| `Wall_exceeded` | total wall > attempt_wall_max | `Attempt_wall_exceeded` | persistent |
+| `Wall_exceeded` | pre-stream wall > attempt_wall_max | `Attempt_wall_exceeded` | persistent |
 | `Provider_error` | HTTP 4xx/5xx with body | classified by RFC-0009 | depends |
 | `Network_drop` | TCP RST / EOF mid-stream | `Network_drop` | transient |
 | `Cancelled` | upstream Cancel | `Upstream_cancelled` | n/a |

--- a/docs/rfc/RFC-0129-http-idle-timeout-and-streaming-progress.md
+++ b/docs/rfc/RFC-0129-http-idle-timeout-and-streaming-progress.md
@@ -59,7 +59,7 @@ collected during PR-1 implementation contradicted that premise:
 |---|---|---|
 | `oas/lib/llm_provider/http_client.ml` `post_sync` body read | unbounded `take_all` | wrapped in `Eio.Time.with_timeout_exn` via `body_timeout_s` since OAS 0.195.0 (`complete.ml:656-686`) |
 | `oas/lib/llm_provider/http_client.ml` SSE / NDJSON | unbounded line read | per-line `idle_timeout` via `Eio.Time.with_timeout_exn` (`http_client.mli:204-243`) |
-| masc-mcp ↔ OAS per-attempt cap | not wired | wired end-to-end: `effective_timeout_sec` → `per_provider_timeout_s` → `Runtime_agent_context.max_execution_time_s` → `Agent_sdk.Builder.with_max_execution_time` (`runtime_agent_context.ml:178-180`) |
+| masc-mcp ↔ OAS cumulative per-attempt cap | not wired | no longer forwarded for active streaming: `per_provider_timeout_s` does not populate `Runtime_agent_context.max_execution_time_s`; streaming liveness is progress-based |
 | masc-mcp ↔ OAS per-line idle cap | not wired | wired: `Agent_sdk.Builder.with_stream_idle_timeout` (`runtime_agent_context.ml:174`), default `stream_idle_timeout_sec = 120s` (`keeper_runtime_config.mli:75`) |
 
 The premise `keeper_turn_runtime_budget.ml:173-174` was written
@@ -119,12 +119,10 @@ Both comments **predate**:
    raise `Eio.Time.Timeout` if no line arrives within
    `idle_timeout` seconds. The deadline resets on each line.
 3. **masc-mcp wiring**:
-   `Runtime_agent_context.max_execution_time_s` →
-   `Agent_sdk.Builder.with_max_execution_time` (per-attempt cap
-   already plumbed; populated by
-   `keeper_turn_driver_try_provider.max_execution_time_for_attempt`).
-   `stream_idle_timeout_s` similarly wired to
-   `Agent_sdk.Builder.with_stream_idle_timeout`.
+   `stream_idle_timeout_s` is wired to
+   `Agent_sdk.Builder.with_stream_idle_timeout`. Active streaming
+   attempts no longer derive `Runtime_agent_context.max_execution_time_s`
+   from `per_provider_timeout_s`.
 
 Given these three pieces have all landed, the reserve_fraction is
 no longer protecting against "OAS can hang the body read". It is
@@ -150,10 +148,9 @@ A single, narrow change scope:
    `Keeper_turn_runtime_budget.resolve_bounded_oas_timeout_budget_with_turn_budget`.
 2. **Update** the stale comment block to reflect the cap chain that
    now exists end-to-end.
-3. **Keep** the existing wiring: `with_max_execution_time` continues
-   to bound the per-attempt outer wall clock at full usable budget;
-   `with_stream_idle_timeout` continues to bound inter-line silence;
-   OAS `body_timeout_s` continues to bound non-streaming bodies.
+3. **Keep** the streaming-progress wiring: `with_stream_idle_timeout`
+   continues to bound inter-line silence; OAS `body_timeout_s` remains
+   opt-in for explicit non-streaming body ceilings.
 
 Two related-but-non-gating tracks are explicitly separated below
 (§4.2, §4.3) so they cannot stall the fleet fix.
@@ -268,8 +265,8 @@ Expected:
   PR-2).
 - OAS `body_timeout_s` since 0.195.0, `complete.ml:656-686`.
 - OAS streaming `idle_timeout` at `http_client.mli:204-243`.
-- masc-mcp `with_max_execution_time` wiring at
-  `runtime_agent_context.ml:178-180`.
+- masc-mcp `stream_idle_timeout_s` wiring at
+  `runtime_agent_context.ml:174-180`.
 
 ## §9 Open questions
 

--- a/lib/keeper/keeper_attempt_liveness.ml
+++ b/lib/keeper/keeper_attempt_liveness.ml
@@ -87,11 +87,9 @@ let null_recorder = {
    - S1: every chunk except Done advances last_chunk_at.
    - S2: Done in Streaming → Success terminal; no further state moves.
    - T1: Heartbeat / Thinking_delta both count as motion.
-   - L2: TTFT and inter-chunk checks fire before wall when both expire
-         on the same tick (caller of runtime_fsm gets the most specific
-         kill class; matches §1 invariant L2 "no double kill"). Wall still
-         applies in Awaiting, so a shorter attempt wall can kill a no-first-byte
-         attempt before the TTFT ceiling. *)
+   - L2: TTFT and inter-chunk are the specific stream-liveness kill classes.
+         A cumulative wall can only apply before the stream has produced a
+         first chunk; active streaming is judged by inter-chunk progress. *)
 
 let step ?(recorder = null_recorder) (b : budget) (s : state) (e : event)
   : state * output =
@@ -117,8 +115,8 @@ let step ?(recorder = null_recorder) (b : budget) (s : state) (e : event)
 
   (* Awaiting × Tick: check TTFT first, wall second.
      [now - started_at >= ttft_max] is the more specific no-first-token
-     failure. [attempt_wall_max] still applies while Awaiting so an attempt
-     with a shorter global wall cannot wait forever for a first chunk. *)
+     failure. [attempt_wall_max] applies only while Awaiting so a shorter
+     pre-stream backstop cannot wait forever for a first chunk. *)
   | Awaiting { started_at }, Tick now ->
       let wall = now -. started_at in
       if wall >= b.ttft_max then begin
@@ -148,19 +146,15 @@ let step ?(recorder = null_recorder) (b : budget) (s : state) (e : event)
       ( Streaming { started_at; last_chunk_at = received_at }
       , Continue )
 
-  (* Streaming × Tick: check inter-chunk first, wall second.
-     Per L2, the more specific kill class wins when both expire on
-     the same tick — inter-chunk is more specific (gap-based) than
-     wall (cumulative). *)
+  (* Streaming × Tick: once the provider has emitted chunks, liveness is
+     progress-based. A stream that keeps producing chunks must not be killed
+     only because cumulative wall-clock elapsed; the keeper turn watchdog is
+     the outer runaway guard. *)
   | Streaming { started_at; last_chunk_at }, Tick now ->
       let gap = now -. last_chunk_at in
-      let wall = now -. started_at in
       if gap >= b.inter_chunk_max then begin
         recorder.record_liveness_outcome (Some Inter_chunk_idle);
         (Failed Inter_chunk_idle, Outcome Inter_chunk_idle)
-      end else if wall >= b.attempt_wall_max then begin
-        recorder.record_liveness_outcome (Some Wall_exceeded);
-        (Failed Wall_exceeded, Outcome Wall_exceeded)
       end else
         (s, Continue)
 

--- a/lib/keeper/keeper_attempt_liveness.mli
+++ b/lib/keeper/keeper_attempt_liveness.mli
@@ -6,7 +6,8 @@
 
     - {!No_first_token}     — provider produces no chunk within [ttft_max]
     - {!Inter_chunk_idle}   — gap between consecutive chunks exceeds [inter_chunk_max]
-    - {!Wall_exceeded}      — total attempt wall-clock exceeds [attempt_wall_max]
+    - {!Wall_exceeded}      — pre-stream total attempt wall-clock exceeds
+                              [attempt_wall_max]
 
     See [docs/rfc/RFC-0022-runtime-attempt-liveness.md] §4 for the design.
 
@@ -43,7 +44,8 @@ type budget = {
   (** Maximum gap between consecutive chunks once streaming starts. *)
 
   attempt_wall_max : float;
-  (** Hard backstop on total attempt wall-clock duration. *)
+  (** Pre-stream wall-clock backstop. Once streaming starts, chunk progress is
+      governed by [inter_chunk_max] rather than a cumulative wall cap. *)
 }
 
 val bootstrap : budget
@@ -110,8 +112,7 @@ type state =
       (** No chunks received yet. Subject to [ttft_max]. *)
 
   | Streaming of { started_at : float; last_chunk_at : float }
-      (** At least one chunk received. Subject to [inter_chunk_max]
-          and [attempt_wall_max]. *)
+      (** At least one chunk received. Subject to [inter_chunk_max]. *)
 
   | Failed of failure
       (** Terminal failure. *)

--- a/lib/keeper/keeper_attempt_liveness_config.ml
+++ b/lib/keeper/keeper_attempt_liveness_config.ml
@@ -229,14 +229,8 @@ let budget_for_candidate ~candidate_key =
 (* RFC-0022 §1 — see .mli for contract. *)
 let outer_wall_for_attempt
     ~mode ~observer_attached ~per_provider_timeout_s ~candidate_key =
-  match mode, observer_attached with
-  | Enforce, true -> None
-  | _, true ->
-      let resolved = budget_for_candidate ~candidate_key in
-      let budget_wall =
-        resolved.budget.Keeper_attempt_liveness.attempt_wall_max
-      in
-      Option.map
-        (fun t -> Float.max t budget_wall)
-        per_provider_timeout_s
-  | _, false -> per_provider_timeout_s
+  ignore mode;
+  ignore candidate_key;
+  match observer_attached with
+  | true -> None
+  | false -> per_provider_timeout_s

--- a/lib/keeper/keeper_attempt_liveness_config.mli
+++ b/lib/keeper/keeper_attempt_liveness_config.mli
@@ -96,15 +96,9 @@ val outer_wall_for_attempt
     enforce around an attempt, given the active liveness mode and
     whether an observer is attached.
 
-    - [Enforce] + observer attached: returns [None]. The observer is
-      the authority and drives [Switch.fail] on TTFT, inter-chunk, or
-      attempt wall budget breach. The legacy outer wall must not
-      pre-empt it.
-    - [Off] / [Observe] + observer attached: returns
-      [Some (max t (budget_for_candidate ~candidate_key).budget.attempt_wall_max)]
-      when [per_provider_timeout_s = Some t]. Successful prior attempts for
-      the same candidate can raise the legacy wall so a slow-but-honest stream
-      is not killed before the liveness observer's own deadline.
+    - Observer attached: returns [None]. The stream-progress observer and
+      [stream_idle_timeout_s] own liveness; the legacy outer wall must not
+      pre-empt a stream that is still emitting chunks.
     - No observer attached (any mode): returns [per_provider_timeout_s]
       unchanged. Without an observer there is no per-provider budget
       to clamp against, so the caller's legacy knob is honored as-is.

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -165,20 +165,28 @@ let wrap_runtime_mcp_external_tool_hooks
     Some { hooks with before_turn_params }
 
 let max_execution_time_for_attempt ?per_provider_timeout_s () =
-  (* OAS total-run ceiling for a provider attempt. The default cap is
-     removed (None): a blunt total wall-clock cancels a healthy streaming
-     turn mid-stream once the deadline passes, even while tokens are still
-     arriving — the AgentExecutionTimeout that killed long qwen reasoning
-     turns. Liveness instead comes from [stream_idle_timeout_s] (per-line
-     stall -> attempt fall-forward; always set, 120s default) and the
-     keeper stale watchdog (Mid_turn_no_progress / In_turn_hung; RFC-0022
-     attempt liveness). An explicit per-keeper [per_provider_timeout]
-     (profile config) is still honoured as the cap, so a ceiling is
-     re-addable per keeper via config rather than a hardcoded global
-     default. This value also feeds [body_timeout_s] (which falls back to
-     it below), so both OAS total caps drop together when no per-keeper
-     timeout is configured. *)
-  per_provider_timeout_s
+  (* Never forward per-provider timeouts to OAS [max_execution_time_s].
+     That field is a cumulative wall-clock kill switch for one Agent.run /
+     run_stream call; it cancels healthy active streams even while chunks are
+     arriving. Provider-attempt liveness is progress-based instead:
+     [stream_idle_timeout_s] catches inter-line stalls, the liveness observer
+     catches no-first-token / inter-chunk gaps, and the keeper turn watchdog is
+     the outer runaway guard. *)
+  (match per_provider_timeout_s with
+   | Some (_ : float) -> ()
+   | None -> ());
+  None
+
+let stream_idle_timeout_for_attempt ~configured =
+  Some
+    (Option.value
+       ~default:Env_config_keeper.KeeperKeepalive.stream_idle_timeout_sec
+       configured)
+
+let body_timeout_for_attempt ?per_provider_timeout_s () =
+  match Keeper_runtime_resolved.body_timeout_override_sec () with
+  | Some _ as s -> s
+  | None -> max_execution_time_for_attempt ?per_provider_timeout_s ()
 
 (** Run a single provider attempt within the runtime.
 
@@ -297,31 +305,16 @@ let run_try_provider
           ; max_input_tokens = ctx.max_input_tokens
           ; max_cost_usd = ctx.max_cost_usd
           ; stream_idle_timeout_s =
-              (match per_provider_timeout_s with
-               | Some _ as timeout_s -> timeout_s
-               | None ->
-                 Some
-                   (Option.value
-                      ~default:
-                        Env_config_keeper.KeeperKeepalive.stream_idle_timeout_sec
-                      ctx.stream_idle_timeout_s))
+              stream_idle_timeout_for_attempt ~configured:ctx.stream_idle_timeout_s
           ; max_execution_time_s =
               max_execution_time_for_attempt ?per_provider_timeout_s ()
           ; body_timeout_s =
               (* SSOT: Keeper_runtime_resolved.body_timeout_override_sec
-                 (driven by MASC_KEEPER_BODY_TIMEOUT_SEC). When set, the
-                 body-callback wall-clock fires before any turn cap,
-                 surfacing Retry.Timeout so runtime falls forward at the
-                 attempt boundary. When unset (default), it inherits the
-                 per-attempt cap — now [None] unless a per-keeper
-                 [per_provider_timeout] is configured (see
-                 [max_execution_time_for_attempt]). A blunt per-stream
-                 total body deadline is itself a mid-stream killer of a
-                 healthy reasoning burst, so it stays opt-in; stall
-                 detection is handled by [stream_idle_timeout_s]. *)
-              (match Keeper_runtime_resolved.body_timeout_override_sec () with
-               | Some _ as s -> s
-               | None -> max_execution_time_for_attempt ?per_provider_timeout_s ())
+                 (driven by MASC_KEEPER_BODY_TIMEOUT_SEC). When unset, do not
+                 inherit [per_provider_timeout_s]: a cumulative body deadline
+                 is another mid-stream killer for healthy reasoning bursts.
+                 Stall detection is handled by [stream_idle_timeout_s]. *)
+              body_timeout_for_attempt ?per_provider_timeout_s ()
           ; temperature = ctx.temperature
           ; max_idle_turns = ctx.max_idle_turns
           ; guardrails = ctx.guardrails
@@ -509,7 +502,9 @@ let run_try_provider
                 let outer_wall_for_provider =
                   Keeper_attempt_liveness_config.outer_wall_for_attempt
                     ~mode:liveness_mode
-                    ~observer_attached:(Option.is_some liveness_observer_opt)
+                    ~observer_attached:
+                      (Option.is_some liveness_observer_opt
+                       || Option.is_some ctx.on_event)
                     ~per_provider_timeout_s
                     ~candidate_key
                 in
@@ -565,6 +560,8 @@ let run_try_provider
 ;;
 
 module For_testing = struct
+  let max_execution_time_for_attempt = max_execution_time_for_attempt
+  let stream_idle_timeout_for_attempt = stream_idle_timeout_for_attempt
   let sanitize_runtime_mcp_external_tool_choice =
     sanitize_runtime_mcp_external_tool_choice
 end

--- a/lib/keeper/keeper_turn_driver_try_provider.mli
+++ b/lib/keeper/keeper_turn_driver_try_provider.mli
@@ -70,6 +70,12 @@ val run_try_provider :
   * (string * Keeper_attempt_liveness_config.success_sample) option
 
 module For_testing : sig
+  val max_execution_time_for_attempt :
+    ?per_provider_timeout_s:float -> unit -> float option
+
+  val stream_idle_timeout_for_attempt :
+    configured:float option -> float option
+
   val sanitize_runtime_mcp_external_tool_choice :
     runtime_mcp_external_tools:bool ->
     Agent_sdk.Hooks.turn_params ->

--- a/lib/keeper/keeper_turn_runtime_budget_provider_timeout.ml
+++ b/lib/keeper/keeper_turn_runtime_budget_provider_timeout.ml
@@ -18,16 +18,13 @@
    - 30s leaves ~9-12s headroom for actual response
 
    RFC-0129 (2026-05-18): the prior reserve_fraction band-aid below
-   was removed. End-to-end cap chain confirmed:
-     [effective_timeout_sec] ->
-       [Keeper_turn_driver_try_provider.per_provider_timeout_s] ->
-       [Runtime_agent_context.max_execution_time_s] ->
-       [Agent_sdk.Builder.with_max_execution_time]
-   plus OAS 0.195.0+ enforces a per-HTTP cap via [body_timeout_s]
-   (lib/llm_provider/complete.ml:656) and per-stream-line cap via
-   [stream_idle_timeout_s] ([read_sse]/[read_ndjson]). So the
-   original "OAS HTTP body lacking timeout" condition no longer
-   holds and the halving workaround was killing healthy slow
+   was removed. The current live-stream cap chain is progress-based:
+     [Keeper_turn_driver_try_provider.per_provider_timeout_s] is not
+       forwarded to [Runtime_agent_context.max_execution_time_s];
+     [stream_idle_timeout_s] bounds inter-line silence; and
+     [body_timeout_s] is opt-in via the explicit body-timeout override.
+   So the original "OAS HTTP body lacking timeout" condition no longer
+   holds and cumulative per-attempt caps must not kill healthy slow
    streams (14-event 307.5s cluster, 2026-05-17 fleet).
 *)
 

--- a/test/dune
+++ b/test/dune
@@ -68,6 +68,7 @@
   test_d7_retry_admission_gate
   test_keeper_reconcile_state
   test_attempt_state
+  test_keeper_attempt_liveness
   test_actor_mailbox
   test_domain_pool
   test_sse
@@ -338,6 +339,7 @@
   test_d7_retry_admission_gate
   test_keeper_reconcile_state
   test_attempt_state
+  test_keeper_attempt_liveness
   test_actor_mailbox
   test_domain_pool
   test_sse

--- a/test/test_keeper_attempt_liveness.ml
+++ b/test/test_keeper_attempt_liveness.ml
@@ -1,0 +1,132 @@
+open Masc_mcp
+
+let check_float_option name expected actual =
+  Alcotest.(check (option (float 0.0001))) name expected actual
+;;
+
+let budget =
+  { Keeper_attempt_liveness.ttft_max = 5.0
+  ; inter_chunk_max = 10.0
+  ; attempt_wall_max = 30.0
+  }
+;;
+
+let expect_streaming_continue state output =
+  match state, output with
+  | Keeper_attempt_liveness.Streaming _, Keeper_attempt_liveness.Continue -> ()
+  | _, _ -> Alcotest.fail "expected streaming state to continue"
+;;
+
+let test_streaming_progress_is_not_wall_killed () =
+  let state, _ =
+    Keeper_attempt_liveness.step
+      budget
+      (Keeper_attempt_liveness.initial ~started_at:0.0)
+      (Keeper_attempt_liveness.Chunk
+         (Keeper_attempt_liveness.Stream_chunk.Answer_delta, 1.0))
+  in
+  let state, _ =
+    Keeper_attempt_liveness.step
+      budget
+      state
+      (Keeper_attempt_liveness.Chunk
+         (Keeper_attempt_liveness.Stream_chunk.Thinking_delta, 29.0))
+  in
+  let state, output =
+    Keeper_attempt_liveness.step budget state (Keeper_attempt_liveness.Tick 35.0)
+  in
+  expect_streaming_continue state output
+;;
+
+let test_inter_chunk_idle_still_kills_streaming () =
+  let state, _ =
+    Keeper_attempt_liveness.step
+      budget
+      (Keeper_attempt_liveness.initial ~started_at:0.0)
+      (Keeper_attempt_liveness.Chunk
+         (Keeper_attempt_liveness.Stream_chunk.Answer_delta, 1.0))
+  in
+  let state, output =
+    Keeper_attempt_liveness.step budget state (Keeper_attempt_liveness.Tick 12.0)
+  in
+  match state, output with
+  | ( Keeper_attempt_liveness.Failed Keeper_attempt_liveness.Inter_chunk_idle
+    , Keeper_attempt_liveness.Outcome Keeper_attempt_liveness.Inter_chunk_idle ) ->
+    ()
+  | _, _ -> Alcotest.fail "expected inter-chunk idle kill"
+;;
+
+let test_outer_wall_disabled_when_observer_attached () =
+  let got =
+    Keeper_attempt_liveness_config.outer_wall_for_attempt
+      ~mode:Keeper_attempt_liveness_config.Observe
+      ~observer_attached:true
+      ~per_provider_timeout_s:(Some 120.0)
+      ~candidate_key:Keeper_attempt_liveness_config.runtime_candidate_key
+  in
+  check_float_option "observer owns stream liveness" None got
+;;
+
+let test_outer_wall_kept_without_observer () =
+  let got =
+    Keeper_attempt_liveness_config.outer_wall_for_attempt
+      ~mode:Keeper_attempt_liveness_config.Enforce
+      ~observer_attached:false
+      ~per_provider_timeout_s:(Some 120.0)
+      ~candidate_key:Keeper_attempt_liveness_config.runtime_candidate_key
+  in
+  check_float_option "legacy wall without observer" (Some 120.0) got
+;;
+
+let test_per_provider_timeout_does_not_set_agent_execution_cap () =
+  let got =
+    Keeper_turn_driver_try_provider.For_testing.max_execution_time_for_attempt
+      ~per_provider_timeout_s:120.0
+      ()
+  in
+  check_float_option "no Agent SDK wall cap" None got
+;;
+
+let test_per_provider_timeout_does_not_override_stream_idle () =
+  let got =
+    Keeper_turn_driver_try_provider.For_testing.stream_idle_timeout_for_attempt
+      ~configured:(Some 75.0)
+  in
+  check_float_option "stream idle remains configured" (Some 75.0) got
+;;
+
+let () =
+  Alcotest.run
+    "keeper_attempt_liveness"
+    [ ( "streaming"
+      , [ Alcotest.test_case
+            "streaming progress is not wall killed"
+            `Quick
+            test_streaming_progress_is_not_wall_killed
+        ; Alcotest.test_case
+            "inter-chunk idle still kills streaming"
+            `Quick
+            test_inter_chunk_idle_still_kills_streaming
+        ] )
+    ; ( "outer wall"
+      , [ Alcotest.test_case
+            "disabled when observer attached"
+            `Quick
+            test_outer_wall_disabled_when_observer_attached
+        ; Alcotest.test_case
+            "kept without observer"
+            `Quick
+            test_outer_wall_kept_without_observer
+        ] )
+    ; ( "agent sdk caps"
+      , [ Alcotest.test_case
+            "per-provider timeout does not set max_execution_time_s"
+            `Quick
+            test_per_provider_timeout_does_not_set_agent_execution_cap
+        ; Alcotest.test_case
+            "per-provider timeout does not override stream idle"
+            `Quick
+            test_per_provider_timeout_does_not_override_stream_idle
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

- Stop forwarding keeper `per_provider_timeout_s` into OAS `max_execution_time_s` / default `body_timeout_s` for streaming attempts.
- Keep stream liveness progress-based: `stream_idle_timeout_s` handles inter-line stalls, and active streaming is no longer killed by cumulative wall-clock elapsed.
- Add regression coverage for active stream progress, inter-chunk idle, legacy outer wall selection, and Agent SDK cap wiring.

## Product impact

- User-visible change: long-running keeper/model turns that are still emitting chunks are no longer cut off only because a fixed provider wall-clock cap elapsed.

## Evidence

- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-streaming-no-wall-cap MASC_DUNE_ALLOW_BARE_DUNE=1 dune build --root . test/test_keeper_attempt_liveness.exe` — PASS
- `_build-codex-streaming-no-wall-cap/default/test/test_keeper_attempt_liveness.exe` — PASS, 6 tests
- `ocamlformat --check lib/keeper/keeper_attempt_liveness.ml lib/keeper/keeper_attempt_liveness.mli lib/keeper/keeper_attempt_liveness_config.ml lib/keeper/keeper_attempt_liveness_config.mli lib/keeper/keeper_turn_driver_try_provider.ml lib/keeper/keeper_turn_driver_try_provider.mli lib/keeper/keeper_turn_runtime_budget_provider_timeout.ml test/test_keeper_attempt_liveness.ml` — PASS
- `git diff --check` — PASS

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 4/4
provenance: direct
stages:
  - name: focused_build
    command: env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-streaming-no-wall-cap MASC_DUNE_ALLOW_BARE_DUNE=1 dune build --root . test/test_keeper_attempt_liveness.exe
    result: pass
  - name: regression_test
    command: _build-codex-streaming-no-wall-cap/default/test/test_keeper_attempt_liveness.exe
    result: pass
  - name: format_check
    command: ocamlformat --check <changed-ocaml-files>
    result: pass
  - name: diff_check
    command: git diff --check
    result: pass
```

## GOAL LOOP ACT checklist

- [x] Observe — runtime/log audit found `Agent execution timed out after 120.0s` while streaming events were still arriving.
- [x] Orient — mapped to `per_provider_timeout_s` being forwarded into cumulative Agent SDK caps and liveness wall checks.
- [x] Decide — remove cumulative caps from active streaming; keep progress/idle-based liveness.
- [x] Act — scoped changes to keeper attempt liveness and provider-attempt config wiring, plus docs.
- [x] Verify — focused build, regression test, ocamlformat check, and diff check pass.
- [x] Loop — no additional follow-up required for this timeout path.

## Review evidence

- Not run locally; draft PR is for review and CI.

## Linked issue

- Relates #

## Variant addition checklist

- [ ] **OCaml** — N/A; no variant added/removed.
- [ ] **TypeScript** — N/A; no TypeScript union changed.
- [ ] **TLA+ spec** — N/A; no TLA+ domain literal changed.
- [ ] **Event / JSON schema** — N/A; no event/schema enum changed.
- [ ] **`make check-variants` passes** — N/A; no variant/schema change.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`codex/streaming-no-wall-clock-cap` → `main` · 1 commit(s) · synced 2026-06-01T15:10:26Z

| sha | subject | date |
|---|---|---|
| `bf9aedc0d` | fix(keeper): keep streaming attempts progress-based | 2026-06-01 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->