### PR TITLE
ci: remove stale unknown-default allowlist entry

### DIFF
--- a/scripts/lint/no-unknown-permissive-default.allowlist
+++ b/scripts/lint/no-unknown-permissive-default.allowlist
@@ -37,7 +37,3 @@
 # Allowlist now nearly empty. Keep this file as a lint contract record — any
 # new entry requires a justifying comment, and self-verify will force removal
 # once the pattern is migrated.
-
-# Audit replay compatibility: unknown action wire strings are preserved as
-# Custom s instead of being silently coerced to a known action constructor.
-lib/audit_log.ml::string_to_action


### PR DESCRIPTION
## Summary

- Remove the stale `lib/audit_log.ml::string_to_action` entry from `scripts/lint/no-unknown-permissive-default.allowlist`.

## Product impact

- User-visible change: none; CI hygiene only.

## Evidence

- `bash scripts/lint/no-unknown-permissive-default.sh` — PASS
- `git diff --check` — PASS

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 2/2
provenance: direct
stages:
  - name: unknown_default_lint
    command: bash scripts/lint/no-unknown-permissive-default.sh
    result: pass
  - name: diff_check
    command: git diff --check
    result: pass
```

## GOAL LOOP ACT checklist

- [x] Observe — CI Lint failed with a stale allowlist entry for `lib/audit_log.ml::string_to_action`.
- [x] Orient — the lint output explicitly requested removing the stale allowlist entry.
- [x] Decide — mechanical allowlist deletion only; no code behavior change.
- [x] Act — removed the stale entry.
- [x] Verify — focused lint and diff check pass locally.
- [x] Loop — no follow-up required.

## Review evidence

- Not run locally; draft PR is for review and CI.

## Linked issue

- Relates #

## Variant addition checklist

- [ ] **OCaml** — N/A; no variant added/removed.
- [ ] **TypeScript** — N/A; no TypeScript union changed.
- [ ] **TLA+ spec** — N/A; no TLA+ domain literal changed.
- [ ] **Event / JSON schema** — N/A; no event/schema enum changed.
- [ ] **`make check-variants` passes** — N/A; no variant/schema change.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`codex/remove-stale-unknown-default-allowlist` → `main` · 1 commit(s) · synced 2026-06-01T15:19:21Z

| sha | subject | date |
|---|---|---|
| `6cc2e9c8e` | ci: remove stale unknown-default allowlist entry | 2026-06-01 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->