### PR TITLE
fix(keeper): gate active-task actionable turns

### DIFF
--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -301,6 +301,7 @@ let turn_affordances_require_tool_gate_with_allowed
   gate_requested
 
 let tool_names_for_required_gate_surface
+    ?(has_current_task : bool = false)
     ~(tool_gate_requested : bool)
     ~(required_tool_names : string list)
     (tool_names : string list) : string list =
@@ -326,7 +327,9 @@ let tool_names_for_required_gate_surface
       |> List.filter (fun name ->
         is_explicit_required_tool_name name
         || (Keeper_tool_progress.tool_name_can_satisfy_required_contract name
-            && not (is_stay_silent name)))
+            && not (is_stay_silent name)
+            && ((not has_current_task)
+                || not (Keeper_tool_progress.is_claim_context_tool_name name))))
       |> Keeper_types_profile_toml_normalizers.dedupe_keep_order
     in
     match actionable with
@@ -482,6 +485,18 @@ let generic_required_tool_candidate_names ~(has_current_task : bool)
       ~allowed_tool_names
   in
   actionable_tools
+;;
+
+let actionable_signal_requires_active_task_tool_gate ~(actionable_signal : bool)
+    ~(has_current_task : bool) ~(turn_affordances : string list)
+    ~(allowed_tool_names : string list) =
+  actionable_signal
+  && has_current_task
+  && generic_required_actionable_tool_names
+       ~has_current_task
+       ~turn_affordances
+       ~allowed_tool_names
+     <> []
 ;;
 
 let generic_required_tool_gate_guidance ~(has_current_task : bool)

--- a/lib/keeper/keeper_agent_tool_surface.mli
+++ b/lib/keeper/keeper_agent_tool_surface.mli
@@ -177,6 +177,9 @@ val turn_affordances_require_tool_gate_with_allowed :
     progress when such tools exist. Passive status/read tools remain visible on
     optional turns and on surfaces that have no actionable alternative.
 
+    When [has_current_task] is true, claim/context tools are not treated as
+    actionable alternatives because the keeper already owns active work.
+
     Explicit [required_tool_names] are preserved even when they are read-only:
     operator/harness calls such as [masc_keeper_msg.required_tools =
     ["masc_web_search"]] are a direct evidence contract, not a generic

--- a/lib/keeper/keeper_agent_tool_surface.mli
+++ b/lib/keeper/keeper_agent_tool_surface.mli
@@ -182,6 +182,7 @@ val turn_affordances_require_tool_gate_with_allowed :
     ["masc_web_search"]] are a direct evidence contract, not a generic
     actionable-world-signal gate. *)
 val tool_names_for_required_gate_surface :
+  ?has_current_task:bool ->
   tool_gate_requested:bool ->
   required_tool_names:string list ->
   string list ->
@@ -230,6 +231,16 @@ val generic_required_tool_candidate_names :
   turn_affordances:string list ->
   allowed_tool_names:string list ->
   string list
+
+(** Whether an owned active task plus an actionable world signal should promote
+    the turn to the same generic required-tool gate that post-run validation
+    already enforces. *)
+val actionable_signal_requires_active_task_tool_gate :
+  actionable_signal:bool ->
+  has_current_task:bool ->
+  turn_affordances:string list ->
+  allowed_tool_names:string list ->
+  bool
 
 (** Per-call [masc_keeper_msg.required_tools] is an explicit operator/harness
     contract for this turn. When present, it takes precedence over the keeper's

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -770,8 +770,18 @@ let prepare_agent_setup
         ~labels:[ "keeper", meta.name ]
         ()
     else ();
+    let has_current_task = keeper_has_owned_active_task () in
+    let active_task_actionable_tool_gate_requested =
+      (not is_last_turn)
+      && actionable_signal_requires_active_task_tool_gate
+           ~actionable_signal
+           ~has_current_task
+           ~turn_affordances
+           ~allowed_tool_names:turn_visible_tool_names
+    in
     let tool_gate_requested =
       required_tool_names <> []
+      || active_task_actionable_tool_gate_requested
       || tool_gate_requested_for_turn
            ~current_tool_choice
            ~is_last_turn
@@ -779,6 +789,7 @@ let prepare_agent_setup
     in
     let turn_visible_tool_names =
       tool_names_for_required_gate_surface
+        ~has_current_task
         ~tool_gate_requested
         ~required_tool_names
         turn_visible_tool_names

--- a/test/test_keeper_tool_surface_guard.ml
+++ b/test/test_keeper_tool_surface_guard.ml
@@ -1,6 +1,7 @@
 open Alcotest
 module KTO = Masc_mcp.Keeper_tool_observation
 module Resolution = Masc_mcp.Keeper_tool_resolution
+module Surface = Masc_mcp.Keeper_agent_tool_surface
 module KTS = Masc_mcp.Keeper_tool_selection
 
 let test_unexpected_tool_names_accepts_keeper_surface () =
@@ -232,6 +233,66 @@ let test_contract_filter_empty_input () =
        [])
 ;;
 
+let test_active_task_actionable_signal_requests_gate () =
+  check
+    bool
+    "owned active task with executable tool requests gate"
+    true
+    (Surface.actionable_signal_requires_active_task_tool_gate
+       ~actionable_signal:true
+       ~has_current_task:true
+       ~turn_affordances:[ "task_claim" ]
+       ~allowed_tool_names:[ "Read"; "Grep"; "keeper_task_claim"; "Edit" ]);
+  check
+    bool
+    "no actionable signal does not request gate"
+    false
+    (Surface.actionable_signal_requires_active_task_tool_gate
+       ~actionable_signal:false
+       ~has_current_task:true
+       ~turn_affordances:[ "task_claim" ]
+       ~allowed_tool_names:[ "Edit" ]);
+  check
+    bool
+    "no owned active task leaves claim intake ungated"
+    false
+    (Surface.actionable_signal_requires_active_task_tool_gate
+       ~actionable_signal:true
+       ~has_current_task:false
+       ~turn_affordances:[ "task_claim" ]
+       ~allowed_tool_names:[ "keeper_task_claim"; "Edit" ]);
+  check
+    bool
+    "passive plus claim-only cannot advance owned active task"
+    false
+    (Surface.actionable_signal_requires_active_task_tool_gate
+       ~actionable_signal:true
+       ~has_current_task:true
+       ~turn_affordances:[ "task_claim" ]
+       ~allowed_tool_names:[ "Read"; "Grep"; "keeper_task_claim" ])
+;;
+
+let test_required_gate_surface_excludes_owned_task_claim_context () =
+  check
+    (list string)
+    "owned task gate keeps only execution progress tools"
+    [ "Edit"; "Write" ]
+    (Surface.tool_names_for_required_gate_surface
+       ~has_current_task:true
+       ~tool_gate_requested:true
+       ~required_tool_names:[]
+       [ "Read"; "Grep"; "keeper_task_claim"; "keeper_stay_silent"; "Edit"; "Write" ]);
+  check
+    (list string)
+    "explicit required tool is preserved even when claim-like"
+    [ "keeper_task_claim" ]
+    (Surface.tool_names_for_required_gate_surface
+       ~has_current_task:true
+       ~tool_gate_requested:true
+       ~required_tool_names:[ "keeper_task_claim" ]
+       [ "Read"; "keeper_task_claim" ])
+;;
+
 let () =
   run
     "keeper_tool_surface_guard"
@@ -303,6 +364,16 @@ let () =
             test_contract_filter_strips_passive
         ; test_case "all passive: returns empty" `Quick test_contract_filter_all_passive
         ; test_case "empty input: empty output" `Quick test_contract_filter_empty_input
+        ] )
+    ; ( "required_gate"
+      , [ test_case
+            "active task actionable signal requests gate"
+            `Quick
+            test_active_task_actionable_signal_requests_gate
+        ; test_case
+            "active task gate excludes claim context"
+            `Quick
+            test_required_gate_surface_excludes_owned_task_claim_context
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- Promote owned-active-task actionable keeper turns to the generic required-tool gate when execution/progress candidates are visible.
- Exclude claim/context/passive tools from that generic owned-task gate surface so a no-progress claim loop cannot satisfy the turn.
- Add regression coverage for active-task actionable gate selection and explicit required-tool preservation.

## Product impact
Fixes a keeper runtime mismatch where an owned active task with `has_unclaimed_tasks` could receive an optional tool surface, spend the turn reading/searching, then fail the post-run contract as no-progress.

## Evidence
- Live receipt reproduced the mismatch for `masc-improver` at `2026-06-01T15:05:37Z`: `tool_requirement=optional`, `tool_gate_enabled=false`, `required_tools=[]`, followed by `completion_contract_violation:require_tool_use`.
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-active-task-gate dune build --root . test/test_keeper_tool_surface_guard.exe test/test_keeper_unified_required_tools.exe`
- `_build-codex-active-task-gate/default/test/test_keeper_tool_surface_guard.exe`
- `_build-codex-active-task-gate/default/test/test_keeper_unified_required_tools.exe`
- `ocamlformat --check lib/keeper/keeper_agent_tool_surface.ml lib/keeper/keeper_agent_tool_surface.mli lib/keeper/keeper_run_tools_setup.ml test/test_keeper_tool_surface_guard.ml`
- `git diff --check`
- Pre-commit hook: `dune build --root .`

## Direct evidence
schema_version: 1
direct_ratio: 7/7
provenance: direct

The runtime receipt, focused Dune builds, focused test binaries, formatter check, whitespace check, and pre-commit full Dune build were run directly in this worktree.

## Review evidence
Not yet reviewed.

## Linked issue
None.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`codex/active-task-tool-gate` → `main` · 1 commit(s) · synced 2026-06-01T15:50:24Z

| sha | subject | date |
|---|---|---|
| `75da9b064` | fix(keeper): gate active-task actionable turns | 2026-06-01 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->