### PR TITLE
fix(keeper): classify turn/time-budget cut-offs as auto-recoverable, not pause_human

### DIFF
--- a/lib/keeper/keeper_agent_error.ml
+++ b/lib/keeper/keeper_agent_error.ml
@@ -220,11 +220,18 @@ let agent_error_terminal_reason_code = function
       "completion_contract_violation:%s"
       (Agent_sdk.Completion_contract_id.to_string contract)
   | Agent_sdk.Error.MaxTurnsExceeded { turns; limit } ->
-    Printf.sprintf "agent_error_max_turns_exceeded:turns=%d,limit=%d" turns limit
+    (* SSOT prefix: [Keeper_execution_receipt.is_auto_recoverable_turn_budget_terminal]
+       matches on it to route the disposition to [Reason_turn_budget_exhausted]. *)
+    Printf.sprintf
+      "%s:turns=%d,limit=%d"
+      Keeper_execution_receipt.terminal_prefix_max_turns_exceeded
+      turns
+      limit
   | Agent_sdk.Error.AgentExecutionTimeout
       { elapsed_sec; timeout_sec; turn_count; max_turns } ->
     Printf.sprintf
-      "agent_error_execution_timeout:elapsed_sec=%.1f,timeout_sec=%.1f,turn_count=%d,max_turns=%d"
+      "%s:elapsed_sec=%.1f,timeout_sec=%.1f,turn_count=%d,max_turns=%d"
+      Keeper_execution_receipt.terminal_prefix_execution_timeout
       elapsed_sec
       timeout_sec
       turn_count
@@ -232,7 +239,8 @@ let agent_error_terminal_reason_code = function
   | Agent_sdk.Error.AgentExecutionIdleTimeout
       { idle_sec; idle_timeout_sec; turn_count; max_turns } ->
     Printf.sprintf
-      "agent_error_idle_timeout:idle_sec=%.1f,idle_timeout_sec=%.1f,turn_count=%d,max_turns=%d"
+      "%s:idle_sec=%.1f,idle_timeout_sec=%.1f,turn_count=%d,max_turns=%d"
+      Keeper_execution_receipt.terminal_prefix_idle_timeout
       idle_sec
       idle_timeout_sec
       turn_count

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -207,6 +207,7 @@ type operator_disposition_reason =
   | Reason_internal_error
   | Reason_tool_required_unsatisfied
   | Reason_tool_route_recoverable_failure
+  | Reason_turn_budget_exhausted
   | Reason_turn_livelock_blocked
   | Reason_cancelled
   | Reason_phase_skipped
@@ -222,10 +223,32 @@ let operator_disposition_reason_to_string = function
   | Reason_internal_error -> "internal_error"
   | Reason_tool_required_unsatisfied -> "tool_required_unsatisfied"
   | Reason_tool_route_recoverable_failure -> "tool_route_recoverable_failure"
+  | Reason_turn_budget_exhausted -> "turn_budget_exhausted"
   | Reason_turn_livelock_blocked -> "turn_livelock_blocked"
   | Reason_cancelled -> "cancelled"
   | Reason_phase_skipped -> "phase_skipped"
   | Reason_unmapped_runtime_state -> "unmapped_runtime_state"
+;;
+
+(* Terminal-reason prefixes for OAS agent-execution errors that exhaust a
+   turn/time budget before the turn completes. SSOT shared with the encoder
+   [Keeper_agent_error.agent_error_terminal_reason_code]. A turn cut off by
+   the per-call turn cap ([MaxTurnsExceeded]), the wall-clock ceiling
+   ([AgentExecutionTimeout]), or the progress-aware idle watchdog
+   ([AgentExecutionIdleTimeout]) did NOT violate the tool contract — it never
+   reached a verdict. The keeper checkpoints and the supervisor auto-resumes
+   ([Keeper_error_classify.is_auto_recoverable_turn_error] /
+   [Keeper_supervisor] auto_resume). Scope is deliberately narrow: token/cost
+   budget, guardrail, and tripwire terminals stay out, since those are
+   genuine ceilings an operator should see, not transient turn cut-offs. *)
+let terminal_prefix_max_turns_exceeded = "agent_error_max_turns_exceeded"
+let terminal_prefix_execution_timeout = "agent_error_execution_timeout"
+let terminal_prefix_idle_timeout = "agent_error_idle_timeout"
+
+let is_auto_recoverable_turn_budget_terminal terminal_reason =
+  String.starts_with ~prefix:terminal_prefix_max_turns_exceeded terminal_reason
+  || String.starts_with ~prefix:terminal_prefix_execution_timeout terminal_reason
+  || String.starts_with ~prefix:terminal_prefix_idle_timeout terminal_reason
 ;;
 
 let operator_disposition (receipt : t)
@@ -303,6 +326,19 @@ let operator_disposition (receipt : t)
     | Some "internal" -> true
     | Some _ | None -> false
   then Disp_pause_human, Reason_internal_error
+  else if is_auto_recoverable_turn_budget_terminal terminal_reason
+  then
+    (* The turn was cut off by its per-call turn cap / wall-clock ceiling /
+       idle watchdog before producing a verdict. This is auto-recoverable
+       (the supervisor resumes from the checkpoint), NOT a tool-contract
+       failure. Without this branch the turn falls through to the generic
+       [required_tool_contract_unsatisfied] check below, which — because a
+       cut-off turn has [tools_used = []] on a [tool_requirement = Required]
+       lane — returned [Disp_pause_human, Reason_tool_required_unsatisfied],
+       falsely paging an operator while the keeper silently auto-resumed.
+       #19714 removed the blunt default wall-clock; this closes the
+       disposition-side half of the same mis-signal. *)
+    Disp_pass, Reason_turn_budget_exhausted
   else
     let canonical_names names =
       names

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -283,12 +283,29 @@ type operator_disposition_reason =
   | Reason_internal_error
   | Reason_tool_required_unsatisfied
   | Reason_tool_route_recoverable_failure
+  | Reason_turn_budget_exhausted
   | Reason_turn_livelock_blocked
   | Reason_cancelled
   | Reason_phase_skipped
   | Reason_unmapped_runtime_state
 
 val operator_disposition_reason_to_string : operator_disposition_reason -> string
+
+(** Terminal-reason prefixes for OAS agent-execution errors that exhaust a
+    turn/time budget before the turn completes. SSOT: the encoder
+    [Keeper_agent_error.agent_error_terminal_reason_code] builds the wire
+    strings from these, and [operator_disposition] /
+    [is_auto_recoverable_turn_budget_terminal] match on them. *)
+val terminal_prefix_max_turns_exceeded : string
+
+val terminal_prefix_execution_timeout : string
+val terminal_prefix_idle_timeout : string
+
+(** [true] when [terminal_reason] is a turn/time-budget cut-off
+    ([MaxTurnsExceeded] / [AgentExecutionTimeout] / [AgentExecutionIdleTimeout]):
+    auto-recoverable, the keeper resumes from its checkpoint, so it must NOT be
+    classified as a tool-contract failure. *)
+val is_auto_recoverable_turn_budget_terminal : string -> bool
 
 (** Derived display pair (disposition, reason) computed from receipt fields.
     Exposed for test access; the runtime path consumes it via [append]. *)

--- a/test/dune
+++ b/test/dune
@@ -1451,6 +1451,7 @@
 
 (include stanzas/test_keeper_cwd_response.inc)
 
+(include stanzas/test_keeper_disposition_budget.inc)
 
 (include stanzas/test_keeper_failure_policy.inc)
 

--- a/test/stanzas/test_keeper_disposition_budget.inc
+++ b/test/stanzas/test_keeper_disposition_budget.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_disposition_budget)
+ (modules test_keeper_disposition_budget)
+ (libraries masc_test_deps))

--- a/test/test_keeper_disposition_budget.ml
+++ b/test/test_keeper_disposition_budget.ml
@@ -1,0 +1,59 @@
+(* Regression for the operator_disposition catch-all fall-through.
+
+   A keeper turn cut off by its per-call turn cap ([MaxTurnsExceeded]), the
+   wall-clock ceiling ([AgentExecutionTimeout]), or the progress-aware idle
+   watchdog ([AgentExecutionIdleTimeout]) is auto-recoverable: the keeper
+   checkpoints and the supervisor resumes. Before this fix those terminal
+   reasons matched none of [operator_disposition]'s early branches and fell
+   through to the generic tool-contract check, where a cut-off turn's empty
+   [tools_used] on a [Required] lane produced
+   [Disp_pause_human, Reason_tool_required_unsatisfied] — falsely paging an
+   operator while the keeper silently auto-resumed.
+
+   The literal strings below are the exact wire form emitted by
+   [Keeper_agent_error.agent_error_terminal_reason_code] (which now builds them
+   from the same [terminal_prefix_*] constants the predicate matches, so the
+   two cannot drift). Pinning the literals also guards wire compatibility with
+   receipts persisted before the refactor. *)
+
+module R = Masc_mcp.Keeper_execution_receipt
+
+let failures = ref []
+let check name cond = if not cond then failures := name :: !failures
+
+(* Mirror [operator_disposition], which lower-cases terminal_reason_code. *)
+let pred s = R.is_auto_recoverable_turn_budget_terminal (String.lowercase_ascii s)
+
+let () =
+  (* Budget/time cut-offs: auto-recoverable, must NOT page an operator. *)
+  List.iter
+    (fun s -> check ("expected-recoverable: " ^ s) (pred s))
+    [ "agent_error_max_turns_exceeded:turns=8,limit=8"
+    ; "agent_error_execution_timeout:elapsed_sec=120.0,timeout_sec=120.0,turn_count=7,max_turns=8"
+    ; "agent_error_idle_timeout:idle_sec=120.0,idle_timeout_sec=120.0,turn_count=7,max_turns=8"
+    ];
+  (* Genuine ceilings and non-budget terminals must NOT be reclassified as
+     transient — an operator should still see them. The prefix is precise:
+     [idle_detected] is a distinct signal from [idle_timeout]. *)
+  List.iter
+    (fun s -> check ("expected-not-recoverable: " ^ s) (not (pred s)))
+    [ "agent_error_token_budget_exceeded:kind=output,used=100,limit=50"
+    ; "agent_error_cost_budget_exceeded:spent_usd=1.00,limit_usd=0.50"
+    ; "agent_error_guardrail_violation:validator=x"
+    ; "agent_error_tripwire_violation:tripwire=y"
+    ; "agent_error_idle_detected:consecutive_idle_turns=3"
+    ; "agent_error_exit_condition_met:turn=4"
+    ; "completion_contract_violation:require_tool_use"
+    ; "api_error_timeout"
+    ; "provider_error"
+    ; "runtime_exhausted"
+    ; "internal_error"
+    ; "pre_dispatch_success"
+    ];
+  match !failures with
+  | [] -> print_endline "test_keeper_disposition_budget: OK"
+  | xs ->
+    List.iter (fun n -> print_endline ("FAIL: " ^ n)) (List.rev xs);
+    failwith
+      (Printf.sprintf "%d disposition-budget assertion(s) failed" (List.length xs))
+;;


### PR DESCRIPTION
## 무엇을 / 왜

`operator_disposition` (keeper_execution_receipt.ml)이 `agent_error_max_turns_exceeded` / `agent_error_execution_timeout` / `agent_error_idle_timeout` terminal reason 에 대한 분기를 갖고 있지 않았다. 이 셋은 early branch (runtime_exhausted / config / provider / completion_contract / livelock / internal) 어디에도 매칭되지 않고 generic tool-contract 평가로 fall-through 했고, 거기서 cut-off 된 턴의 빈 `tools_used` 가 `Required` 레인과 만나 `(Disp_pause_human, Reason_tool_required_unsatisfied)` 을 반환했다.

결과: per-call 턴 cap / wall-clock / idle watchdog 로 **중단된** 턴(= auto-recoverable, supervisor 가 checkpoint 에서 resume)이 **운영자 개입 필요**로 잘못 표시되어, 실제로는 keeper 가 조용히 auto-resume 하는데도 대시보드가 "주의 필요 / pause" 로 보였다. #19714 가 producer 쪽(blunt 기본 wall-clock 제거)을 고쳤고, 본 PR 은 disposition 쪽 나머지 절반을 닫는다.

## 어떻게

- keeper_execution_receipt 에 SSOT prefix 상수 3개(`terminal_prefix_max_turns_exceeded` / `_execution_timeout` / `_idle_timeout`)와 술어 `is_auto_recoverable_turn_budget_terminal` 추가.
- 인코더 `Keeper_agent_error.agent_error_terminal_reason_code` 가 동일 상수로 wire 문자열을 생성하도록 변경 → 인코더/디코더가 같은 상수를 참조하므로 prefix drift 가 컴파일 타임에 불가능.
- `operator_disposition` 에 명시적 early branch 추가: budget cut-off → `(Disp_pass, Reason_turn_budget_exhausted)` (신규 reason variant). 이는 catch-all fall-through 를 닫는 것(CLAUDE.md anti-pattern #4)이며 string 분류기 보강이 아니다.

## 범위(의도적으로 좁음)

token/cost budget, guardrail, tripwire terminal 은 제외 — 이들은 transient 턴 cut-off 가 아니라 운영자가 봐야 할 실제 ceiling 이므로 기존 분류를 유지한다. `idle_detected` ≠ `idle_timeout` 도 prefix 로 구분된다(테스트로 pin).

## 검증

- `dune build lib/ --root .` EXIT=0, `dune build --root .`(whole-program) EXIT=0.
- 신규 회귀 테스트 `test/test_keeper_disposition_budget.ml`: budget cut-off 3종 → recoverable, ceiling/contract/provider terminal 12종 → not-recoverable. `dune exec ... --root .` PASS.
- 대시보드(TS)는 disposition reason 을 free string 으로 렌더(exhaustive map 아님)하므로 신규 reason 에 코드 변경 불필요.

## 미포함(후속)

이 PR 은 disposition **오분류**만 닫는다. keeper non-convergence 의 행동 root(reasoning 모델이 tool 은 호출하나 수렴 못 함; unbounded goal; pipeline EndTurn 의 thinking-only 처리)는 별도 조사/PR 대상이며 여기 포함하지 않는다.

Refs: RFC-0129, RFC-0153
