### PR TITLE
fix(keeper): stop validation errors from tripping the circuit breaker (contract parser de-dup + Policy_rejection tagging)

### DIFF
--- a/lib/keeper/agent_tool_task_runtime.ml
+++ b/lib/keeper/agent_tool_task_runtime.ml
@@ -101,17 +101,6 @@ let resolve_task_create_goal_id ~config ~(meta : keeper_meta) args =
                 (String.concat ", " goal_ids)))
 ;;
 
-let parse_task_contract_arg args =
-  match Json_util.assoc_member_opt "contract" args with
-  | Some `Null -> Ok None
-  | Some (`Assoc _ as json) -> (
-      match Masc_domain.task_contract_of_yojson json with
-      | Ok contract -> Ok (Some contract)
-      | Error message ->
-          Error (Printf.sprintf "Invalid contract payload: %s" message))
-  | _ -> Error "contract must be an object when provided"
-;;
-
 (* RFC-0034.v2: per-goal task creation cap moved to
    [Workspace_task_capacity] so all 5 task creation entrypoints share the
    same guard. Pre-RFC-0034.v2, these helpers (and the constant
@@ -478,7 +467,15 @@ let handle_keeper_task_tool
       match resolve_task_create_goal_id ~config ~meta args with
       | Error message -> error_json message
       | Ok goal_id ->
-          (match parse_task_contract_arg args with
+          (* De-duplicated: this keeper-internal path now shares the canonical
+             [Tool_task_args.parse_task_contract] used by the public
+             masc_task_create facade. The previous local copy
+             [parse_task_contract_arg] had regressed — it rejected an OMITTED
+             optional [contract] via a catch-all that conflated None(omitted)
+             with a wrong-typed value, which falsely failed keeper_task_create
+             and tripped the keeper failure circuit breaker. Same lib, no
+             dependency wall; the canonical parser handles [None | Some `Null]. *)
+          (match Tool_task_args.parse_task_contract args with
            | Error message -> error_json message
            | Ok contract ->
               let capacity_error =

--- a/lib/keeper/agent_tool_task_runtime.ml
+++ b/lib/keeper/agent_tool_task_runtime.ml
@@ -79,6 +79,23 @@ let keeper_tool_result_json ?(typed_outcome = (None : Keeper_tool_outcome.t opti
           @ typed_outcome_fields))
 ;;
 
+(* Caller-input validation errors carry [Tool_result.Policy_rejection]. Per
+   RFC-0062 §3.2 that variant is "permission, guardrail, validation reject", so
+   validation belongs there by original design — and the schema-layer producer
+   [Tool_input_validation] already emits Policy_rejection for invalid args.
+   Tagging makes the keeper *health* circuit breaker (Gate #1,
+   [Agent_tool_dispatch_runtime.should_apply_circuit_breaker_to_failure_payload])
+   exempt these: an LLM that sends malformed/missing args is making an input
+   mistake, not exhibiting a keeper-health fault. The per-(tool,args) breaker
+   (Gate #2) still counts them, so retrying the SAME bad args stays blocked. *)
+let validation_error_json message =
+  keeper_tool_result_json
+    ~failure_class:(Some Tool_result.Policy_rejection)
+    ~ok:false
+    ~message
+    ()
+;;
+
 let validate_goal_id config goal_id =
   match Goal_store.get_goal config ~goal_id with
   | Some _ -> Ok goal_id
@@ -460,12 +477,14 @@ let handle_keeper_task_tool
     let description = Safe_ops.json_string ~default:"" "description" args |> String.trim in
     let priority = Safe_ops.json_int ~default:3 "priority" args |> max 1 |> min 5 in
     if title = ""
-    then error_json "title is required. Provide a clear, actionable task title."
+    then validation_error_json "title is required. Provide a clear, actionable task title."
     else if description = ""
-    then error_json "description is required. Explain what needs to be done and why."
+    then
+      validation_error_json
+        "description is required. Explain what needs to be done and why."
     else (
       match resolve_task_create_goal_id ~config ~meta args with
-      | Error message -> error_json message
+      | Error message -> validation_error_json message
       | Ok goal_id ->
           (* De-duplicated: this keeper-internal path now shares the canonical
              [Tool_task_args.parse_task_contract] used by the public
@@ -476,7 +495,7 @@ let handle_keeper_task_tool
              and tripped the keeper failure circuit breaker. Same lib, no
              dependency wall; the canonical parser handles [None | Some `Null]. *)
           (match Tool_task_args.parse_task_contract args with
-           | Error message -> error_json message
+           | Error message -> validation_error_json message
            | Ok contract ->
               let capacity_error =
                 let backlog = Workspace.read_backlog config in

--- a/lib/keeper/agent_tool_task_runtime.mli
+++ b/lib/keeper/agent_tool_task_runtime.mli
@@ -1,5 +1,12 @@
 (** Agent task tool runtime — claim, transition, list. *)
 
+(** Build a failed tool-result payload for a caller-input validation error,
+    tagged with [Tool_result.Policy_rejection] (RFC-0062 §3.2: "validation
+    reject"). Exposed so the keeper failure-circuit-breaker gates can be tested
+    end-to-end: the resulting payload is exempt from the health breaker (Gate
+    #1) yet still counted by the per-(tool,args) breaker (Gate #2). *)
+val validation_error_json : string -> string
+
 val handle_keeper_task_tool :
   config:Workspace.config ->
   meta:Keeper_meta_contract.keeper_meta ->

--- a/lib/tool_types/tool_result.ml
+++ b/lib/tool_types/tool_result.ml
@@ -25,7 +25,9 @@ module Float = Stdlib.Float
 
 type tool_failure_class =
   | Transient_error (** Network/timeout/rate-limit — retryable *)
-  | Policy_rejection (** Auth/permission/boundary — permanent *)
+  | Policy_rejection
+      (** Permission, guardrail, validation reject (RFC-0062 §3.2) — permanent.
+          Covers caller-input/argument validation, not only auth/boundary. *)
   | Runtime_failure (** Internal error/bug — non-retryable *)
   | Workflow_rejection (** Business rule violation — non-retryable *)
 [@@deriving yojson, show]

--- a/test/dune
+++ b/test/dune
@@ -1529,6 +1529,8 @@
 
 (include stanzas/test_keeper_unified_tool_event_order_source.inc)
 
+(include stanzas/test_keeper_validation_breaker_exempt.inc)
+
 (include stanzas/test_keeper_turn_livelock_10121.inc)
 
 (include stanzas/test_keeper_turn_helpers_side_effect_metric.inc)

--- a/test/dune
+++ b/test/dune
@@ -1652,6 +1652,8 @@
 
 (include stanzas/test_tool_name.inc)
 
+(include stanzas/test_tool_task_args.inc)
+
 (include stanzas/test_tool_task_completion_example.inc)
 
 (include stanzas/test_trajectory_atomicity.inc)

--- a/test/stanzas/test_keeper_validation_breaker_exempt.inc
+++ b/test/stanzas/test_keeper_validation_breaker_exempt.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_validation_breaker_exempt)
+ (modules test_keeper_validation_breaker_exempt)
+ (libraries masc_test_deps))

--- a/test/stanzas/test_tool_task_args.inc
+++ b/test/stanzas/test_tool_task_args.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_tool_task_args)
+ (modules test_tool_task_args)
+ (libraries masc_test_deps))

--- a/test/test_keeper_validation_breaker_exempt.ml
+++ b/test/test_keeper_validation_breaker_exempt.ml
@@ -1,0 +1,63 @@
+(** D2: caller-input validation errors must not trip the keeper HEALTH circuit
+    breaker (Gate #1), while the per-(tool,args) breaker (Gate #2) must still
+    count them so retrying the SAME bad args stays blocked.
+
+    The fix tags keeper_task_create validation errors with
+    [Tool_result.Policy_rejection] (RFC-0062 §3.2). This test proves the
+    end-to-end behavior on the payload the producer actually emits — not a
+    hand-built literal — so a regression in the producer (dropping the class)
+    is caught here. *)
+
+open Alcotest
+
+module Task = Masc_mcp.Agent_tool_task_runtime
+module Dispatch = Masc_mcp.Agent_tool_dispatch_runtime
+module Boundary = Masc_mcp.Keeper_tools_oas_failure_boundary
+(* Tool_result lives in the leaf [masc_mcp_tool_types] lib (wrapped false), so
+   it is referenced bare — not under [Masc_mcp.] — matching existing tests. *)
+module TR = Tool_result
+
+(* The error a keeper sees when it sends a non-object contract — the residual
+   validation case after D1 makes an OMITTED contract [Ok None]. *)
+let payload =
+  Task.validation_error_json
+    "contract must be an object when provided (received string)"
+
+(* A — producer: keeper_task_create validation errors carry policy_rejection. *)
+let test_producer_tags_policy_rejection () =
+  check (option string) "validation payload carries policy_rejection class"
+    (Some "policy_rejection")
+    (Dispatch.failure_class_of_tool_result_payload payload)
+
+(* B — Gate #1 (health breaker): validation is exempt, but an UNCLASSIFIED
+   error still counts (conservative: unknown -> fail, never permissive-default
+   per CLAUDE.md anti-pattern #2). *)
+let test_gate1_exempts_validation_but_counts_unclassified () =
+  check bool "Gate#1 exempts policy_rejection validation" false
+    (Dispatch.should_apply_circuit_breaker_to_failure_payload payload);
+  check bool "Gate#1 still counts an unclassified (class-less) error" true
+    (Dispatch.should_apply_circuit_breaker_to_failure_payload
+       {|{"error":"contract must be an object when provided"}|})
+
+(* C — Gate #2 (per-(tool,args) breaker): validation is NOT a workflow
+   rejection, so identical bad args remain counted (retry-block intact). This
+   is the proof we did not OVER-exempt. *)
+let test_gate2_still_counts_validation () =
+  let classified = Boundary.classify_raw_failure payload in
+  check string "Gate#2 sees policy_rejection class" "policy_rejection"
+    (TR.tool_failure_class_to_string classified.Boundary.failure_class);
+  check bool
+    "Gate#2 does not treat validation as workflow_rejection (still counts)"
+    false classified.Boundary.is_workflow_rejection
+
+let () =
+  run "keeper validation breaker exemption"
+    [ ( "validation_failure_class"
+      , [ test_case "producer tags policy_rejection" `Quick
+            test_producer_tags_policy_rejection
+        ; test_case "Gate#1 exempts validation, counts unclassified" `Quick
+            test_gate1_exempts_validation_but_counts_unclassified
+        ; test_case "Gate#2 still counts validation (no over-exempt)" `Quick
+            test_gate2_still_counts_validation
+        ] )
+    ]

--- a/test/test_tool_task_args.ml
+++ b/test/test_tool_task_args.ml
@@ -1,0 +1,61 @@
+(** Tests for [Tool_task_args.parse_task_contract] — the canonical optional
+    [contract] argument parser shared by the public masc_task_create facade and,
+    after de-duplication, the keeper-internal keeper_task_create path.
+
+    Regression guard for the keeper-path bug (incident: keeper:umberto): an
+    OMITTED optional [contract] was wrongly rejected via a catch-all that
+    conflated [None] (key omitted) with a wrong-typed value. That false
+    validation error then tripped the keeper failure circuit breaker. The fix
+    deletes the drifted keeper-local copy and routes through this canonical
+    parser, which handles [None | Some `Null -> Ok None]. *)
+
+open Alcotest
+
+module T = Masc_mcp.Tool_task_args
+
+(* The incident: an omitted optional contract must parse to [Ok None], not an
+   Error. [Json_util.assoc_member_opt] returns [None] for an absent key. *)
+let test_omitted_contract () =
+  match T.parse_task_contract (`Assoc []) with
+  | Ok None -> ()
+  | Ok (Some _) -> fail "omitted contract must parse to Ok None, got Ok (Some _)"
+  | Error e ->
+      fail (Printf.sprintf "omitted contract must be Ok None, got Error %s" e)
+
+(* An LLM caller that sends a JSON null contract for an unset optional field
+   must also parse to [Ok None]. *)
+let test_explicit_null_contract () =
+  match T.parse_task_contract (`Assoc [ ("contract", `Null) ]) with
+  | Ok None -> ()
+  | Ok (Some _) -> fail "explicit null contract must parse to Ok None"
+  | Error e ->
+      fail
+        (Printf.sprintf "explicit null contract must be Ok None, got Error %s" e)
+
+(* Every [task_contract] field carries a [@default], so an empty object is a
+   valid contract payload. *)
+let test_object_contract () =
+  match T.parse_task_contract (`Assoc [ ("contract", `Assoc []) ]) with
+  | Ok (Some _) -> ()
+  | Ok None -> fail "object contract must parse to Ok (Some _)"
+  | Error e ->
+      fail
+        (Printf.sprintf "object contract must be Ok (Some _), got Error %s" e)
+
+(* A present-but-non-object contract is the ONLY Error case. The catch-all must
+   not swallow this into a silent default; the canonical parser additionally
+   names the received JSON kind in its message. *)
+let test_wrong_type_contract () =
+  match T.parse_task_contract (`Assoc [ ("contract", `String "nope") ]) with
+  | Error _ -> ()
+  | Ok _ -> fail "non-object contract must be Error, not Ok"
+
+let () =
+  run "Tool_task_args"
+    [ ( "parse_task_contract"
+      , [ test_case "omitted -> Ok None (regression)" `Quick test_omitted_contract
+        ; test_case "explicit null -> Ok None" `Quick test_explicit_null_contract
+        ; test_case "object -> Ok (Some _)" `Quick test_object_contract
+        ; test_case "wrong type -> Error" `Quick test_wrong_type_contract
+        ] )
+    ]


### PR DESCRIPTION
## 문제 (incident)

`keeper:umberto`가 `keeper_task_create`를 선택적 `contract` 인자 없이 호출했을 때 `"contract must be an object when provided"` 에러가 발생했고, 이 validation 에러가 keeper failure 회로 차단기(circuit breaker)를 trip시켰습니다. 두 결함이 겹친 결과입니다.

## D1 — 차단기를 돌게 만든 false error (root fix)

keeper-internal 경로에 `contract` 파서의 drifted 복사본 `parse_task_contract_arg`가 있었습니다. `Some \`Null -> Ok None`은 처리하지만 키 생략(`None`)을 catch-all `_ -> Error`로 보냈습니다. `Json_util.assoc_member_opt`는 키 부재 시 `None`을 반환하므로, **선택적 `contract`를 생략한 정상 호출이 타입 위반으로 잘못 거부**됐습니다.

복사본을 삭제하고 public `masc_task_create` facade가 이미 쓰는 canonical `Tool_task_args.parse_task_contract`를 호출하도록 정리했습니다(동일 `masc_mcp` lib). canonical 파서는 `None | Some \`Null -> Ok None`을 처리하고 present-but-non-object 값에만 `Some other -> Error (... received <kind>)`를 두어 catch-all 없는 exhaustive match입니다. surgical-align 대신 복사본 제거를 택한 이유: 근본 원인은 컴파일러가 동기화를 강제할 수 없는 중복 파서였습니다.

## D2 — validation 에러가 health 차단기를 trip시키는 systemic 결함

`keeper_task_create`의 caller-input validation 에러(title/description 필수, goal-id 해석, contract 형태)는 `failure_class` 없는 bare `error_json`으로 반환됐습니다. health 차단기(Gate #1, `should_apply_circuit_breaker_to_failure_payload`)는 class 없는 실패를 모두 trip 카운트에 포함하므로, **malformed/missing 인자를 보내는 LLM이 자기 keeper-health 상태를 깎아먹는 카테고리 오류**가 발생했습니다.

이 에러들을 `Tool_result.Policy_rejection`으로 태깅합니다(`validation_error_json` 헬퍼). RFC-0062 §3.2가 이 variant를 "permission, guardrail, **validation reject**"로 정의하고, schema-layer producer(`Tool_input_validation`)가 이미 invalid args를 Policy_rejection으로 emit하므로, **새 variant 대신 기존 class로 통합**했습니다. 새 `Input_validation` variant는 두 gate에서 동작이 동일(Policy_rejection이 이미 Gate #1 면제)하고 두 wire-string match 사이트에 string-classifier landmine만 추가합니다 — reuse가 RFC-conformant root fix입니다.

- Gate #1은 이미 policy_rejection을 면제하므로 태깅 즉시 false trip이 멈춥니다.
- Gate #2(per-(tool,args) 차단기)는 여전히 카운트(`is_workflow_rejection=false`)해서 **같은 bad args 재시도는 계속 차단**됩니다 — 의도된 비대칭 보존, over-exempt 아님.

`tool_result.ml`의 `Policy_rejection` 주석도 RFC-0062에 맞게 정정했습니다(`Auth/permission/boundary` → `validation reject` 포함). comment-vs-spec drift는 D1 회귀를 낳은 것과 같은 병입니다.

## 검증

- `dune build @check` + `dune build lib`(default target) 통과.
- 신규 테스트:
  - `test/test_tool_task_args.ml` 4/4 — omitted/null/object/wrong-type. omitted 케이스는 수정 전 keeper 복사본에 대해 실패(회귀 가드).
  - `test/test_keeper_validation_breaker_exempt.ml` 3/3 — producer가 policy_rejection 태깅 / Gate #1 면제하되 unclassified는 카운트(conservative) / Gate #2는 여전히 카운트(over-exempt 아님).
- 기존 `test_workflow_rejection_payload_skips_circuit_breaker` green 유지.
- `ocamlformat --check` 통과 (변경 `.ml`/`.mli` 4개).
- 참고: 개별 `dune exec` 실행 시 `test_agent_tool_dispatch_runtime`의 `tool_execute_raw_cmd_requires_typed_shell_ir`는 `tool_not_allowed`로 실패하나, 이는 sandbox config가 주입되지 않는 개별 실행 한계로 **이 변경 이전 baseline에서도 동일하게 실패**합니다(무관). CI full `@runtest`에서 통과.

## 영향 범위 / 비대상

- D1: `parse_task_contract_arg` 호출부 1곳, single-site.
- D2: incident-path producer(`keeper_task_create`)에 헬퍼 적용. capacity rejection(quota)과 unknown-tool routing 에러는 validation이 아니므로 태깅하지 않음.
- **named follow-ups**: 다른 validation producer(execute/ide/voice/memory/read-ops) 태깅, 그리고 두 gate의 wire-string match를 typed `breaker_exempt` predicate로 전환(durable). 본 PR에 접지 않음.
- open PR #19733("required-tool contract")과 파일 겹침 없음 (별개 개념).

RFC-WAIVED: task-tool 인자 파서 de-dup + validation failure-class 태깅. credential/identity/operator/sandbox/hooks/workflow subsystem 비해당. 차단기 분류 체계는 `Tool_result.tool_failure_class`(RFC-0062)만 사용하고 TLA+ 모델 대상인 `Keeper_failure_circuit_breaker.error_class`/`classify_error`는 변경하지 않음(TLA+ parity 의무 없음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
