### PR TITLE
refactor(shell-ir): retire fake typed-gh round-trip; gh floor-owned by design (RFC-0208 B1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -573,6 +573,20 @@ jobs:
         run: |
           opam exec -- dune build @test/runtest-test_runtime_config_validity
 
+      - name: Shell IR differential-safety harness gate
+        # RFC-0208: the differential harness asserts the monotone-safety
+        # invariant (the composed verdict is never below the word-list
+        # floor, so the typed path can only escalate) and pins the
+        # structurally-typed ratchet (git checkout -> R1, reset -> R2).
+        # Hard-fail (no continue-on-error) so a typed arm weakened below
+        # the floor blocks merge. The quick suite runs it too via
+        # `dune test`, but that step is continue-on-error (non-gating) and
+        # is also superseded under main churn — which let the P4 gh-parser
+        # commit drop silently from #19762. This focused gate is the fix.
+        # See: lib/exec/test/test_shell_ir_differential.ml.
+        run: |
+          opam exec -- dune build @lib/exec/test/runtest-test_shell_ir_differential
+
       - name: Env knob catalog drift gate
         # Detects when lib/config/env_config_*.ml has been edited
         # (new MASC_* env var added, doc reworded, knob removed) but

--- a/docs/rfc/RFC-0208-shell-ir-compositional-risk-ast.md
+++ b/docs/rfc/RFC-0208-shell-ir-compositional-risk-ast.md
@@ -248,6 +248,41 @@ current corpus.
 (Detailed per-phase design lands as each phase's PR; P5+ depends on the morbig
 spike outcome.)
 
+### Revision (2026-06-02): gh is string-borne — P4 withdrawn, P7 scoped
+
+P4 above proposed a typed `Gh.method` field to make `gh api -X METHOD`
+typed-redundant and complete floor retirement for gh. **That direction is
+withdrawn.** An adversarial audit (11-agent workflow + 3-lens refutation)
+showed gh risk is *irreducibly string-borne*: beyond `-X METHOD`, a write
+is also implied by bare `-f`/`--field`/`--raw-field` (forces POST), by the
+graphql mutation body (`body_contains_r2_mutation`), and by a large,
+evolving set of subcommands. Typing only `method` silently under-classifies
+`gh api -f title=… /repos/o/r/issues` (R1 today → R0). Typing *all* of it
+would re-implement `classify_repo_hosting_cli` reading from typed fields —
+a **second** gh-risk implementation, i.e. more duplication, not less. And
+because `classify = max(risk_of_typed, floor)`, typing the structural subset
+(`pr merge`, `repo delete`) changes nothing at the gate — it is cosmetic.
+
+Decision (B1): the typed path returns `R0` for `Gh`, and the word-list floor
+(`classify_repo_hosting_cli`, on the original words) owns gh risk **by
+design and permanently**. This removes the fake P3 round-trip (which had
+mis-parsed `-X DELETE` to R0) and the duplicate invocation —
+`classify_repo_hosting_cli` is now called from one site (the floor). The
+boundary: **structural** risk (`rm -rf`, `git reset`, `sudo`) is typed;
+**string-borne** risk (gh) is floor-owned. P7 floor retirement is therefore
+scoped to structurally-typed classes only and never covers gh; the
+differential harness reports structural vs string-borne load-bearing
+separately so "READY" means "every structural class is typed," not "gh is
+typed." The capability axis (`Gh → \`Audited`) is unaffected (P10).
+
+Incident note: PR #19762's squash dropped the P4 commit (`40e6f7e265`)
+entirely, so merged `d33d87dc2f` was 94% (gh `-X` load-bearing), not the
+100% reported from the branch tip. Only re-running the harness *on the
+merged tree* caught it — `@check` EXIT=0 ("compiles") did not. The quick
+suite runs the harness but is `continue-on-error` (non-gating), so it could
+not block the drop. B1 adds a hard-fail focused harness gate in the `build`
+job (`@lib/exec/test/runtest-test_shell_ir_differential`).
+
 ## §5 · Workaround Rejection Bar (self-check)
 
 | Signature | This RFC |

--- a/lib/exec/shell_ir_risk.ml
+++ b/lib/exec/shell_ir_risk.ml
@@ -401,8 +401,11 @@ let classify_words (words : string list) : risk_class =
    (curl/sed/git pull stay R0; git push/commit stay R1; rm -rf protected
    stays Destructive). [Gh] and [Generic] return R0 here because the
    type cannot see their risk-bearing tokens (gh -X METHOD / graphql
-   body live in [rest]); the word-list floor in [classify] supplies it.
-   Dropping that floor is gated on the typed model subsuming it. *)
+   body / -f fields live in argv strings, not the typed shape); the
+   word-list floor in [classify] supplies it. For gh this is by design
+   and permanent — gh risk is irreducibly string-borne, so floor
+   retirement (P7) is scoped to structurally-typed classes and never
+   covers gh. *)
 
 let npm_write_subcommands =
   [ "add"; "install"; "link"; "prune"; "publish"; "remove"; "unlink";
@@ -555,16 +558,20 @@ let risk_of_typed (w : Shell_ir_typed.wrapped) : risk_class =
      "rm"/"git push" arms never fired (silent R0). Privilege escalation
      always requires approval. *)
   | W (Sudo _) -> Destructive_protected
-  (* RFC-0208 P3: gh risk lives in the HTTP method (-X DELETE) and the
-     graphql body, which the typed [Gh] constructor still carries as an
-     untyped [rest]. Round-trip the command back to its words and reuse
-     the SAME gh classifier the floor uses, so the floor becomes redundant
-     for gh without a second gh-risk implementation. Capturing the method
-     and graphql body as typed fields (dropping this delegation) is P6. *)
-  | W (Gh _ as gh) ->
-    (match literal_words_of_simple (Shell_ir_typed.to_simple gh) with
-     | Some words -> classify_repo_hosting_cli words
-     | None -> R0_Read)
+  (* RFC-0208: gh risk is irreducibly string-borne. The HTTP method
+     (-X DELETE), -f/--field key=values, the graphql mutation body, and a
+     large, evolving set of subcommands all live in argv strings, not in
+     the command's typed shape. Unlike [rm -rf] / [git reset] / [sudo],
+     whose risk IS structural and typeable, gh has no risk-bearing typed
+     shape for [risk_of_typed] to read, so it returns R0 and [classify]'s
+     word-list floor ([classify_words] -> [classify_repo_hosting_cli] on
+     the original, un-round-tripped words) owns gh risk by design. This is
+     the honest boundary: an earlier version round-tripped the IR back to
+     words here to fake a typed opinion, but the round-trip mis-parsed
+     `-X DELETE` and silently under-classified it to R0 — strictly worse
+     than the floor it duplicated. gh stays floor-owned; P7 floor
+     retirement is scoped to structurally-typed classes only. *)
+  | W (Gh _) -> R0_Read
   | W (Docker _) -> R0_Read
   (* File operations — cp/mv/ln/touch are reversible or low-risk mutations *)
   | W (Cp _) -> R1_Reversible_mutation

--- a/lib/exec/test/test_shell_ir_differential.ml
+++ b/lib/exec/test/test_shell_ir_differential.ml
@@ -148,9 +148,22 @@ let test_monotone_safety () =
     corpus
 ;;
 
+(* A command whose risk is irreducibly string-borne: [risk_of_typed]
+   returns R0 by design and the word-list floor owns it permanently
+   (RFC-0208 B1). gh is the only such class today. These are EXPECTED to
+   stay load-bearing — they are not a typing work-list and never reach
+   floor-retirement readiness. Floor-retirement readiness is therefore
+   judged on the STRUCTURAL load-bearing remainder only. *)
+let is_string_borne = function
+  | S (b, _) -> b = "gh"
+  | P stages -> List.exists (fun (b, _) -> b = "gh") stages
+;;
+
 (* Report: typed coverage and floor-retirement readiness. The load-bearing
    list is the set of commands the floor still classifies stricter than the
-   typed model — i.e. the floor cannot be dropped for these yet. *)
+   typed model — i.e. the floor cannot be dropped for these yet. It is split
+   into a structural work-list (should reach 0) and the string-borne classes
+   (gh; floor-owned by design). *)
 let test_report_floor_readiness () =
   let n = List.length corpus in
   Alcotest.(check bool) "harness ran over a non-empty corpus" true (n > 0);
@@ -160,6 +173,7 @@ let test_report_floor_readiness () =
       (fun e -> not (ge (typed_only (ir_of e)) (Risk.classify_words (words_of e))))
       corpus
   in
+  let string_borne, structural = List.partition is_string_borne load_bearing in
   let redundant = n - List.length load_bearing in
   let pct x = 100.0 *. float_of_int x /. float_of_int n in
   Printf.printf "\n=== RFC-0208 P2 differential-safety harness ===\n";
@@ -174,38 +188,53 @@ let test_report_floor_readiness () =
     redundant
     n
     (pct redundant);
-  Printf.printf "floor still load-bearing: %d\n" (List.length load_bearing);
-  List.iter
-    (fun e ->
-       Printf.printf
-         "  - %s  (typed_only=%s, floor=%s)\n"
-         (label e)
-         (Risk.string_of_risk_class (typed_only (ir_of e)))
-         (Risk.string_of_risk_class (Risk.classify_words (words_of e))))
-    load_bearing;
   Printf.printf
-    "floor retirement readiness: %s\n"
-    (if load_bearing = []
-     then "READY — typed model dominates the whole corpus"
+    "floor still load-bearing: %d (structural: %d, string-borne/gh: %d)\n"
+    (List.length load_bearing)
+    (List.length structural)
+    (List.length string_borne);
+  let print_entry e =
+    Printf.printf
+      "  - %s  (typed_only=%s, floor=%s)\n"
+      (label e)
+      (Risk.string_of_risk_class (typed_only (ir_of e)))
+      (Risk.string_of_risk_class (Risk.classify_words (words_of e)))
+  in
+  if structural <> [] then begin
+    Printf.printf "structural load-bearing (typing work-list, should reach 0):\n";
+    List.iter print_entry structural
+  end;
+  if string_borne <> [] then begin
+    Printf.printf "string-borne load-bearing (gh; floor-owned by design, expected):\n";
+    List.iter print_entry string_borne
+  end;
+  Printf.printf
+    "floor retirement readiness (structural classes only): %s\n"
+    (if structural = []
+     then
+       "READY — typed model dominates every structurally-typed class; the \
+        floor remains only for string-borne gh by design"
      else
        Printf.sprintf
-         "NOT READY — %d command-class(es) still need the floor"
-         (List.length load_bearing));
+         "NOT READY — %d structural command-class(es) still need the floor"
+         (List.length structural));
   (* The harness reports; it never auto-retires the floor. *)
   ()
 ;;
 
-(* RFC-0208 P3 ratchet: these classes were closed by typed-classifier
-   completion (git checkout/reset typed arms; gh pr/graphql via the shared
-   classifier) and must stay floor-redundant. A regression here means a
-   typed arm was weakened back below the floor. *)
+(* RFC-0208 P3 ratchet: these classes are closed by GENUINELY typed
+   classifier arms (git checkout -> R1, git reset -> R2) whose risk is
+   structural and read directly from the typed shape. They must stay
+   floor-redundant; a regression here means a typed arm was weakened back
+   below the floor. gh is deliberately NOT in this list: gh risk is
+   string-borne (HTTP method / -f fields / graphql body), so [risk_of_typed]
+   returns R0 and the word-list floor owns gh by design (RFC-0208 B1). gh
+   commands therefore stay load-bearing in the readiness report — that is
+   the honest state, not a regression. *)
 let test_p3_closed_redundant () =
   let closed =
     [ S ("git", [ "checkout"; "-b"; "feature" ])
     ; S ("git", [ "reset"; "--hard"; "HEAD~1" ])
-    ; S ("gh", [ "pr"; "create"; "--title"; "t" ])
-    ; S ("gh", [ "pr"; "merge"; "123" ])
-    ; S ("gh", [ "api"; "graphql"; "-f"; "query=mutation{deleteRef}" ])
     ]
   in
   List.iter


### PR DESCRIPTION
## 목적 (RFC-0208 B1)

`risk_of_typed`의 `Gh` arm이 typed GADT 필드를 **하나도 읽지 않고** IR을 다시 words로 round-trip(`Shell_ir_typed.to_simple`)해 floor와 **동일한** word-list 분류기(`classify_repo_hosting_cli`)를 호출하고 있었습니다 — typed 옷을 입은 string 분류기. 게다가 round-trip이 `-X DELETE`를 오파싱(action-grab이 method 값을 action으로 가져감)해 조용히 R0으로 under-classify했고, floor가 원본 words로 R2를 backstop해 덮고 있었습니다.

이 PR은 그 **가짜(round-trip)와 중복 호출을 제거**합니다.

## 근거: gh 위험은 환원 불가능하게 string-borne

적대적 감사(11-agent workflow + 3-lens refutation)로 확인:
- gh `api` 위험은 `-X METHOD`뿐 아니라 bare `-f`/`--field`(POST 강제), graphql mutation 본문, 수백 개의 진화하는 subcommand에 내재.
- `method`만 타입화하면 `gh api -f title=... /repos/o/r/issues`(R1) → R0으로 under-classify (refuter 3/3 confirmed).
- 전부 타입화하면 `classify_repo_hosting_cli`를 typed 필드로 **재구현** = 두 번째 구현 = 중복 *증가*.
- `classify = max(typed, floor)`이므로 구조적 부분(`pr merge`, `repo delete`)만 타입화해도 게이트엔 무변화(cosmetic).

## 결정 (B1)

`risk_of_typed`의 Gh arm → `R0_Read`. word-list floor가 gh를 **설계상·영구적으로** 소유. 경계: **구조적** 위험(`rm -rf` / `git reset` / `sudo`)은 typed, **string-borne** 위험(gh)은 floor-owned. 운영 무변화(max가 이미 floor verdict 반환), 보안 동일.

> 이것은 워크어라운드가 아닙니다. word-list floor를 유지하는 것은 string-borne gh에 대한 **올바른 도구**이며, 이 PR은 typed 분류기를 가장한 fake를 *제거*하고 호출처를 2→1로 줄입니다(중복 제거). 닫힌 sum + exhaustive match 유지(catch-all 추가 없음).

## 변경

- `shell_ir_risk.ml`: Gh arm → R0(경계 문서화); stale 정책 주석 정정(다시 참).
- `test_shell_ir_differential.ml`: 구조적 ratchet에서 gh 제거(git checkout/reset 유지); readiness 리포트를 **structural(work-list, 0이어야 함)** vs **string-borne(gh, 영구 예상)**으로 분리. 정직한 수치: structural load-bearing **0**, gh load-bearing 5.
- `ci.yml`: `build` job에 **continue-on-error 없는** focused 하네스 게이트 추가. quick suite도 하네스를 돌리나 `continue-on-error: true`(비-게이팅)라 **PR #19762 squash가 P4 커밋(`40e6f7e265`)을 통째로 누락**(머지 main=94%, branch tip 측정 100% 아님)한 걸 못 막았습니다 — 이 게이트가 그 fix.
- `RFC-0208`: string-borne 경계 revision. P4(typed Gh.method) 철회, P7 floor 은퇴를 구조적 클래스에 한정.

## 검증

- whole-program `dune build @check --root .` **EXIT=0** (머지된 `d33d87dc2f` 기준 + 본 변경).
- `lib/exec` runtest green; focused 게이트 `@lib/exec/test/runtest-test_shell_ir_differential` **EXIT=0**.
- `ocamlformat --check` 변경 .ml clean. ci.yml valid YAML.
- 단조-안전 불변 유지: 전 corpus `full = max(typed, floor) >= floor` (예: `gh api -X DELETE → full=R2`).

## RFC

RFC-0208 §revision(2026-06-02) 참조. 본 PR은 그 revision을 구현.

## 리뷰 포인트 (거부 가능)

B1은 RFC-0208의 P6(typed gh.method) 야심을 **철회**합니다 — gh를 영구 floor-owned로 둠. 야심찬 typed-gh 버전을 원하면 이 PR을 거부하세요. Draft 상태로, 머지 전 검토 가능합니다.
