### PR TITLE
task-629: replace load_procedures_text with format_for_dna

### DIFF
--- a/lib/memory_hooks.ml
+++ b/lib/memory_hooks.ml
@@ -64,7 +64,7 @@ let render_memory_context
         Memory_oas_bridge.load_world_text ~backend:world_backend
           ~memory ~limit:world_limit)
     ; Memory_oas_bridge.load_episodes_text ~limit:episode_limit
-    ; Memory_oas_bridge.load_procedures_text ~agent_name ~limit:procedure_limit
+    ; Some (Procedural_memory.format_for_dna ~agent_name ~limit:procedure_limit)
     ]
     |> List.filter_map Fun.id
   in

--- a/lib/memory_hooks.ml
+++ b/lib/memory_hooks.ml
@@ -64,7 +64,9 @@ let render_memory_context
         Memory_oas_bridge.load_world_text ~backend:world_backend
           ~memory ~limit:world_limit)
     ; Memory_oas_bridge.load_episodes_text ~limit:episode_limit
-    ; Some (Procedural_memory.format_for_dna ~agent_name ~limit:procedure_limit)
+    ; Memory_oas_bridge.load_procedures_dna_text
+        ~agent_name
+        ~limit:procedure_limit
     ]
     |> List.filter_map Fun.id
   in

--- a/lib/memory_oas_bridge.ml
+++ b/lib/memory_oas_bridge.ml
@@ -729,6 +729,11 @@ let load_procedures_text ~(agent_name : string) ~(limit : int) : string option =
     Some (Printf.sprintf "[procedural memory: %d procedures]\n%s"
       (List.length ps) (String.concat "\n" lines))
 
+let load_procedures_dna_text ~(agent_name : string) ~(limit : int) : string option =
+  match top_procedures_cached ~agent_name ~limit with
+  | [] -> None
+  | ps -> Some (Procedural_memory.format_procedures_for_dna ps)
+
 let compact_world_text raw =
   raw
   |> String.map (function '\n' | '\r' | '\t' -> ' ' | c -> c)

--- a/lib/memory_oas_bridge.mli
+++ b/lib/memory_oas_bridge.mli
@@ -182,6 +182,12 @@ val load_procedures_text :
     renders them for prompt injection.  Same fail-soft
     contract as {!load_episodes_text}. *)
 
+val load_procedures_dna_text :
+  agent_name:string -> limit:int -> string option
+(** Reads cached top procedures for [agent_name] and renders the same
+    DNA capsule format as {!Procedural_memory.format_for_dna}. Returns
+    [None] when no procedures qualify. *)
+
 val load_world_text :
   backend:Agent_sdk.Memory.long_term_backend option ->
   memory:Agent_sdk.Memory.t ->

--- a/lib/procedural_memory.ml
+++ b/lib/procedural_memory.ml
@@ -191,8 +191,7 @@ let top_procedures ~agent_name ~limit : procedure list =
   |> List.filteri (fun i _ -> i < limit)
 
 (** Format procedures for capsule injection. *)
-let format_for_dna ~agent_name ~limit : string =
-  let procs = top_procedures ~agent_name ~limit in
+let format_procedures_for_dna procs : string =
   if procs = [] then ""
   else
     let lines = List.map (fun p ->
@@ -200,3 +199,6 @@ let format_for_dna ~agent_name ~limit : string =
         p.pattern (p.confidence *. 100.0) (List.length p.evidence)
     ) procs in
     "[PROCEDURES]\n" ^ String.concat "\n" lines ^ "\n[/PROCEDURES]"
+
+let format_for_dna ~agent_name ~limit : string =
+  top_procedures ~agent_name ~limit |> format_procedures_for_dna

--- a/lib/procedural_memory.mli
+++ b/lib/procedural_memory.mli
@@ -74,7 +74,11 @@ val is_crystallized : procedure -> bool
 (** Top-N crystallised procedures sorted by confidence (descending). *)
 val top_procedures : agent_name:string -> limit:int -> procedure list
 
-(** Format top-N crystallised procedures as a capsule-injection
+(** Format an already-selected procedure list as a capsule-injection
     fragment: ["[PROCEDURES]\n- <pattern> (confidence: N%, evidence: N)\n…[/PROCEDURES]"].
-    Empty string when no procedures qualify. *)
+    Empty string when the list is empty. *)
+val format_procedures_for_dna : procedure list -> string
+
+(** Format top-N crystallised procedures as a capsule-injection
+    fragment. Empty string when no procedures qualify. *)
 val format_for_dna : agent_name:string -> limit:int -> string

--- a/test/test_procedural_memory.ml
+++ b/test/test_procedural_memory.ml
@@ -61,6 +61,21 @@ let test_single_perfect_does_not_crystallize () =
     (P.is_crystallized p)
 ;;
 
+let test_format_procedures_for_dna_empty () =
+  check string "empty procedure list renders empty string" ""
+    (P.format_procedures_for_dna [])
+;;
+
+let test_format_procedures_for_dna_selected_list () =
+  let p = procedure ~evidence:[ "a"; "b" ] ~confidence:0.75 () in
+  check string "renders selected procedures as DNA capsule"
+    "[PROCEDURES]\n\
+     - When a pattern appears, reuse the learned action (confidence: 75%, \
+     evidence: 2)\n\
+     [/PROCEDURES]"
+    (P.format_procedures_for_dna [ p ])
+;;
+
 let () =
   run "procedural_memory"
     [
@@ -75,6 +90,13 @@ let () =
             test_rare_near_perfect_does_not_crystallize;
           test_case "single perfect does not crystallize" `Quick
             test_single_perfect_does_not_crystallize;
+        ] );
+      ( "format",
+        [
+          test_case "empty list renders empty string" `Quick
+            test_format_procedures_for_dna_empty;
+          test_case "selected list renders DNA capsule" `Quick
+            test_format_procedures_for_dna_selected_list;
         ] );
     ]
 ;;


### PR DESCRIPTION
RFC-MASC-004 Phase 3: render procedural memory with the DNA capsule format in the hook-first memory path. Scope now includes the hook callsite, a cached Memory_oas_bridge DNA loader that preserves the empty None contract, a reusable Procedural_memory formatter for already-selected procedures, and focused regression tests.