### PR TITLE
fix: replace cascade_default with agent_default in runtime_model_string.ml

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -169,6 +169,7 @@ let run_keeper_cycle
                 (Keeper_agent_error.terminal_reason_code_of_sdk_error err)
             in
             let error_message = Agent_sdk.Error.to_string err in
+            Log.Keeper.error "%s: pre_dispatch failed: %s" meta.name error_message;
             record_pre_dispatch_terminal_observation
               ~config
               ~meta

--- a/lib/runtime/runtime_model_string.ml
+++ b/lib/runtime/runtime_model_string.ml
@@ -172,8 +172,8 @@ let make_registry_config
     {!Provider_kind_resolver} (Provider_registry as SSOT) — unknown specs are
     never flattened to [OpenAI_compat]. *)
 let parse_model_string
-  ?(temperature = Llm_provider.Constants.Inference_profile.cascade_default.temperature)
-  ?(max_tokens = Llm_provider.Constants.Inference_profile.cascade_default.max_tokens)
+  ?(temperature = Llm_provider.Constants.Inference_profile.agent_default.temperature)
+  ?(max_tokens = Llm_provider.Constants.Inference_profile.agent_default.max_tokens)
   ?system_prompt
   ?(api_key_env_overrides = [])
   ?supports_tool_choice_override


### PR DESCRIPTION
cascade_default was removed in PR #19536 (cascade module deletion). Replace remaining reference with agent_default, matching all other consumer files that already use agent_default/worker_default/deterministic.