### PR TITLE
task-631: replace unknown sentinel with <missing status>

### DIFF
--- a/lib/briefing_compactors/briefing_compactors.ml
+++ b/lib/briefing_compactors/briefing_compactors.ml
@@ -70,9 +70,9 @@ let compact_session_json session_json =
         let detail = member_assoc "detail" latest in
         `Assoc
           [
-            ("event_type", string_json ~default:"<missing status>" (member_assoc "event_type" latest));
-            ("ts_iso", string_json ~default:"<missing status>" (member_assoc "ts_iso" latest));
-            ("actor", string_json ~default:"<missing status>" (member_assoc "actor" detail));
+            ("event_type", string_json ~default:missing_status (member_assoc "event_type" latest));
+            ("ts_iso", string_json ~default:missing_status (member_assoc "ts_iso" latest));
+            ("actor", string_json ~default:missing_status (member_assoc "actor" detail));
             ("task_title", string_json ~default:"not_recorded" (member_assoc "task_title" detail));
             ("result", string_json ~default:"not_recorded" ~max_len:160 (member_assoc "result" detail));
             ("reason", string_json ~default:"not_recorded" ~max_len:160 (member_assoc "reason" detail));
@@ -85,8 +85,8 @@ let compact_session_json session_json =
         `Assoc
           [
             ("event_type", `String "none");
-            ("ts_iso", `String "<missing status>");
-            ("actor", `String "<missing status>");
+            ("ts_iso", `String missing_status);
+            ("actor", `String missing_status);
             ("task_title", `String "no recent session events");
             ("result", `String "not_recorded");
             ("reason", `String "not_recorded");
@@ -97,14 +97,14 @@ let compact_session_json session_json =
           ]
   in
   let communication_mode =
-    string_json ~default:"<missing status>" (member_assoc "mode" communication)
+    string_json ~default:missing_status (member_assoc "mode" communication)
   in
   let broadcast_count = int_json (member_assoc "broadcast_count" communication) in
   let portal_count = int_json (member_assoc "portal_count" communication) in
   let communication_mode_text =
     match communication_mode with
     | `String value -> value
-    | _ -> "<missing status>"
+    | _ -> missing_status
   in
   let broadcast_count_value =
     match broadcast_count with
@@ -124,12 +124,12 @@ let compact_session_json session_json =
         match member_assoc "project" session with
         | `Null -> string_json ~default:"default" (member_assoc "workspace_id" session)
         | value -> string_json ~default:"default" value );
-      ("status", string_json ~default:"<missing status>" (member_assoc "status" session));
+      ("status", string_json ~default:missing_status (member_assoc "status" session));
       ("agent_names", string_list_json (member_assoc "agent_names" session));
       ("elapsed_sec", int_json (member_assoc "elapsed_sec" summary));
       ("progress_pct", float_json (member_assoc "progress_pct" summary));
       ("done_delta_total", int_json (member_assoc "done_delta_total" summary));
-      ("team_health", string_json ~default:"<missing status>" (member_assoc "status" team_health));
+      ("team_health", string_json ~default:missing_status (member_assoc "status" team_health));
       ("active_agents_count", int_json (member_assoc "active_agents_count" team_health));
       ("required_agents", int_json ~default:1 (member_assoc "required_agents" team_health));
       ("communication_mode", communication_mode);
@@ -148,8 +148,8 @@ let compact_keeper_json keeper_json =
   `Assoc
     [
       ("name", string_json ~default:"unknown-keeper" (member_assoc "name" keeper_json));
-      ("status", string_json ~default:"<missing status>" (member_assoc "status" keeper_json));
-      ("agent_name", string_json ~default:"<missing status>" (member_assoc "agent_name" keeper_json));
+      ("status", string_json ~default:missing_status (member_assoc "status" keeper_json));
+      ("agent_name", string_json ~default:missing_status (member_assoc "agent_name" keeper_json));
       ("generation", int_json (member_assoc "generation" keeper_json));
       ("context_ratio", float_json (member_assoc "context_ratio" keeper_json));
       ("last_turn_ago_s", float_json (member_assoc "last_turn_ago_s" keeper_json));
@@ -159,7 +159,7 @@ let compact_keeper_json keeper_json =
       ("last_reply_status", string_json ~default:"not_recorded" (member_assoc "last_reply_status" diagnostic));
       ("last_reply_preview", string_json ~default:"not_recorded" ~max_len:160 (member_assoc "last_reply_preview" diagnostic));
       ("active_goal_ids", string_list_json (member_assoc "active_goal_ids" keeper_json));
-      ("skill_primary", string_json ~default:"<missing status>" ~max_len:120 (member_assoc "skill_primary" keeper_json));
+      ("skill_primary", string_json ~default:missing_status ~max_len:120 (member_assoc "skill_primary" keeper_json));
     ]
 
 let compact_agent_json (agent : Masc_domain.agent) =

--- a/lib/briefing_compactors/briefing_compactors.ml
+++ b/lib/briefing_compactors/briefing_compactors.ml
@@ -70,9 +70,9 @@ let compact_session_json session_json =
         let detail = member_assoc "detail" latest in
         `Assoc
           [
-            ("event_type", string_json ~default:"unknown" (member_assoc "event_type" latest));
-            ("ts_iso", string_json ~default:"unknown" (member_assoc "ts_iso" latest));
-            ("actor", string_json ~default:"unknown" (member_assoc "actor" detail));
+            ("event_type", string_json ~default:"<missing status>" (member_assoc "event_type" latest));
+            ("ts_iso", string_json ~default:"<missing status>" (member_assoc "ts_iso" latest));
+            ("actor", string_json ~default:"<missing status>" (member_assoc "actor" detail));
             ("task_title", string_json ~default:"not_recorded" (member_assoc "task_title" detail));
             ("result", string_json ~default:"not_recorded" ~max_len:160 (member_assoc "result" detail));
             ("reason", string_json ~default:"not_recorded" ~max_len:160 (member_assoc "reason" detail));
@@ -85,8 +85,8 @@ let compact_session_json session_json =
         `Assoc
           [
             ("event_type", `String "none");
-            ("ts_iso", `String "unknown");
-            ("actor", `String "unknown");
+            ("ts_iso", `String "<missing status>");
+            ("actor", `String "<missing status>");
             ("task_title", `String "no recent session events");
             ("result", `String "not_recorded");
             ("reason", `String "not_recorded");
@@ -97,14 +97,14 @@ let compact_session_json session_json =
           ]
   in
   let communication_mode =
-    string_json ~default:"unknown" (member_assoc "mode" communication)
+    string_json ~default:"<missing status>" (member_assoc "mode" communication)
   in
   let broadcast_count = int_json (member_assoc "broadcast_count" communication) in
   let portal_count = int_json (member_assoc "portal_count" communication) in
   let communication_mode_text =
     match communication_mode with
     | `String value -> value
-    | _ -> "unknown"
+    | _ -> "<missing status>"
   in
   let broadcast_count_value =
     match broadcast_count with
@@ -124,12 +124,12 @@ let compact_session_json session_json =
         match member_assoc "project" session with
         | `Null -> string_json ~default:"default" (member_assoc "workspace_id" session)
         | value -> string_json ~default:"default" value );
-      ("status", string_json ~default:"unknown" (member_assoc "status" session));
+      ("status", string_json ~default:"<missing status>" (member_assoc "status" session));
       ("agent_names", string_list_json (member_assoc "agent_names" session));
       ("elapsed_sec", int_json (member_assoc "elapsed_sec" summary));
       ("progress_pct", float_json (member_assoc "progress_pct" summary));
       ("done_delta_total", int_json (member_assoc "done_delta_total" summary));
-      ("team_health", string_json ~default:"unknown" (member_assoc "status" team_health));
+      ("team_health", string_json ~default:"<missing status>" (member_assoc "status" team_health));
       ("active_agents_count", int_json (member_assoc "active_agents_count" team_health));
       ("required_agents", int_json ~default:1 (member_assoc "required_agents" team_health));
       ("communication_mode", communication_mode);
@@ -148,8 +148,8 @@ let compact_keeper_json keeper_json =
   `Assoc
     [
       ("name", string_json ~default:"unknown-keeper" (member_assoc "name" keeper_json));
-      ("status", string_json ~default:"unknown" (member_assoc "status" keeper_json));
-      ("agent_name", string_json ~default:"unknown" (member_assoc "agent_name" keeper_json));
+      ("status", string_json ~default:"<missing status>" (member_assoc "status" keeper_json));
+      ("agent_name", string_json ~default:"<missing status>" (member_assoc "agent_name" keeper_json));
       ("generation", int_json (member_assoc "generation" keeper_json));
       ("context_ratio", float_json (member_assoc "context_ratio" keeper_json));
       ("last_turn_ago_s", float_json (member_assoc "last_turn_ago_s" keeper_json));
@@ -159,7 +159,7 @@ let compact_keeper_json keeper_json =
       ("last_reply_status", string_json ~default:"not_recorded" (member_assoc "last_reply_status" diagnostic));
       ("last_reply_preview", string_json ~default:"not_recorded" ~max_len:160 (member_assoc "last_reply_preview" diagnostic));
       ("active_goal_ids", string_list_json (member_assoc "active_goal_ids" keeper_json));
-      ("skill_primary", string_json ~default:"unknown" ~max_len:120 (member_assoc "skill_primary" keeper_json));
+      ("skill_primary", string_json ~default:"<missing status>" ~max_len:120 (member_assoc "skill_primary" keeper_json));
     ]
 
 let compact_agent_json (agent : Masc_domain.agent) =

--- a/lib/briefing_compactors/briefing_json_helpers.ml
+++ b/lib/briefing_compactors/briefing_json_helpers.ml
@@ -10,6 +10,14 @@ let compact_text ?(max_len = 96) raw =
 let member_assoc = Dashboard_utils.member_assoc
 let string_field = Dashboard_utils.string_field
 
+let missing_status = "<missing status>"
+
+let is_missing_status_or_unknown value =
+  match String.lowercase_ascii (String.trim value) with
+  | "" | "unknown" -> true
+  | value when value = missing_status -> true
+  | _ -> false
+
 let string_json ?(default = "unknown") ?(max_len = 96) json =
   match json with
   | `String value ->
@@ -50,5 +58,4 @@ let float_json ?(default = 0.0) json =
   | _ -> `Float default
 
 let take = List.take
-
 

--- a/lib/briefing_compactors/briefing_json_helpers.mli
+++ b/lib/briefing_compactors/briefing_json_helpers.mli
@@ -3,6 +3,8 @@
 val compact_text : ?max_len:int -> string -> string
 val member_assoc : string -> Yojson.Safe.t -> Yojson.Safe.t
 val string_field : ?default:string -> string -> Yojson.Safe.t -> string
+val missing_status : string
+val is_missing_status_or_unknown : string -> bool
 val string_json : ?default:string -> ?max_len:int -> Yojson.Safe.t -> Yojson.Safe.t
 val string_list_json : Yojson.Safe.t -> Yojson.Safe.t
 val int_json : ?default:int -> Yojson.Safe.t -> Yojson.Safe.t

--- a/lib/dashboard/briefing_gaps.ml
+++ b/lib/dashboard/briefing_gaps.ml
@@ -29,7 +29,12 @@ let collect_metadata_gaps ~sessions ~keepers ~agents =
                  ~summary:"Session goal is unassigned in briefing facts."
                  ~scope_type:"session" ~scope_id:session_id ~severity:"watch"
                :: !items;
-           if string_field "communication_mode" json = "unknown" then
+           if
+             List.mem
+               (String.lowercase_ascii
+                  (String.trim (string_field "communication_mode" json)))
+               [ "<missing status>"; "unknown" ]
+           then
              items :=
                metadata_gap_json ~kind:"session_communication_mode_missing"
                  ~summary:"Session communication mode is not recorded."

--- a/lib/dashboard/briefing_gaps.ml
+++ b/lib/dashboard/briefing_gaps.ml
@@ -29,11 +29,7 @@ let collect_metadata_gaps ~sessions ~keepers ~agents =
                  ~summary:"Session goal is unassigned in briefing facts."
                  ~scope_type:"session" ~scope_id:session_id ~severity:"watch"
                :: !items;
-           if
-             List.mem
-               (String.lowercase_ascii
-                  (String.trim (string_field "communication_mode" json)))
-               [ "<missing status>"; "unknown" ]
+           if is_missing_status_or_unknown (string_field "communication_mode" json)
            then
              items :=
                metadata_gap_json ~kind:"session_communication_mode_missing"

--- a/lib/dashboard/briefing_sections.ml
+++ b/lib/dashboard/briefing_sections.ml
@@ -82,9 +82,7 @@ let build_communication_section ~sessions ~recent_messages ~metadata_gaps
   let portal_total = sum_int_field "portal_count" sessions in
   let known_mode_count =
     count_matching_field "communication_mode" sessions ~predicate:(fun value ->
-        match String.lowercase_ascii (String.trim value) with
-        | "" | "unknown" | "<missing status>" -> false
-        | _ -> true)
+        not (is_missing_status_or_unknown value))
   in
   let metadata_evidence = evidence_of_metadata_gaps ~section:Communication metadata_gaps in
   let positive_signal =

--- a/lib/dashboard/briefing_sections.ml
+++ b/lib/dashboard/briefing_sections.ml
@@ -82,7 +82,9 @@ let build_communication_section ~sessions ~recent_messages ~metadata_gaps
   let portal_total = sum_int_field "portal_count" sessions in
   let known_mode_count =
     count_matching_field "communication_mode" sessions ~predicate:(fun value ->
-        value <> "" && value <> "unknown")
+        match String.lowercase_ascii (String.trim value) with
+        | "" | "unknown" | "<missing status>" -> false
+        | _ -> true)
   in
   let metadata_evidence = evidence_of_metadata_gaps ~section:Communication metadata_gaps in
   let positive_signal =

--- a/lib/dashboard/dashboard_briefing_agents.ml
+++ b/lib/dashboard/dashboard_briefing_agents.ml
@@ -360,7 +360,7 @@ let build_agent_briefs config sessions attention_queue _workspace_json (keepers 
            | None, _ -> "archived"
            | Some _, Some age when age <= 300 -> "live"
            | Some _, Some _ -> "stale"
-           | Some _, None -> "<missing status>"
+           | Some _, None -> "unknown"
          in
          let evidence_source =
            if Option.is_some latest_out || Option.is_some latest_in then

--- a/lib/dashboard/dashboard_briefing_agents.ml
+++ b/lib/dashboard/dashboard_briefing_agents.ml
@@ -198,7 +198,7 @@ let status_of_archived_session (session : session_context option) =
   match session with
   | Some session ->
       if is_session_concluded session.status then "inactive" else "offline"
-  | None -> "<missing status>"
+  | None -> Briefing_json_helpers.missing_status
 
 let archived_reason_for_session (session : session_context option) =
   match session with

--- a/lib/dashboard/dashboard_briefing_agents.ml
+++ b/lib/dashboard/dashboard_briefing_agents.ml
@@ -198,7 +198,7 @@ let status_of_archived_session (session : session_context option) =
   match session with
   | Some session ->
       if is_session_concluded session.status then "inactive" else "offline"
-  | None -> "unknown"
+  | None -> "<missing status>"
 
 let archived_reason_for_session (session : session_context option) =
   match session with
@@ -360,7 +360,7 @@ let build_agent_briefs config sessions attention_queue _workspace_json (keepers 
            | None, _ -> "archived"
            | Some _, Some age when age <= 300 -> "live"
            | Some _, Some _ -> "stale"
-           | Some _, None -> "unknown"
+           | Some _, None -> "<missing status>"
          in
          let evidence_source =
            if Option.is_some latest_out || Option.is_some latest_in then

--- a/lib/dashboard/dashboard_briefing_assembly.ml
+++ b/lib/dashboard/dashboard_briefing_assembly.ml
@@ -184,7 +184,10 @@ let build_keeper_briefs (config : Workspace.config) (keepers : Yojson.Safe.t lis
          let name = string_field "name" keeper in
          if name = "" then None
          else
-           let status = string_field ~default:"<missing status>" "status" keeper in
+           let status =
+             string_field ~default:Briefing_json_helpers.missing_status "status"
+               keeper
+           in
            let context_ratio =
              match member_assoc "context_ratio" keeper with
              | `Float value -> Some value
@@ -340,7 +343,7 @@ let operation_badge_json (operation : operation_context) =
   let status_str =
     match operation.status with
     | Some s -> s
-    | None -> "<missing status>"
+    | None -> Briefing_json_helpers.missing_status
   in
   let detachment_status_str =
     operation.detachment_status
@@ -378,7 +381,7 @@ let operation_badges_for_session session operation_contexts =
         `Assoc
           [
             ("operation_id", `String operation_id);
-            ("status", `String "<missing status>");
+            ("status", `String Briefing_json_helpers.missing_status);
             ("stage", `Null);
             ("detachment_status", `Null);
             ("objective", `Null);

--- a/lib/dashboard/dashboard_briefing_assembly.ml
+++ b/lib/dashboard/dashboard_briefing_assembly.ml
@@ -184,7 +184,7 @@ let build_keeper_briefs (config : Workspace.config) (keepers : Yojson.Safe.t lis
          let name = string_field "name" keeper in
          if name = "" then None
          else
-           let status = string_field ~default:"unknown" "status" keeper in
+           let status = string_field ~default:"<missing status>" "status" keeper in
            let context_ratio =
              match member_assoc "context_ratio" keeper with
              | `Float value -> Some value
@@ -340,7 +340,7 @@ let operation_badge_json (operation : operation_context) =
   let status_str =
     match operation.status with
     | Some s -> s
-    | None -> "unknown"
+    | None -> "<missing status>"
   in
   let detachment_status_str =
     operation.detachment_status
@@ -378,7 +378,7 @@ let operation_badges_for_session session operation_contexts =
         `Assoc
           [
             ("operation_id", `String operation_id);
-            ("status", `String "unknown");
+            ("status", `String "<missing status>");
             ("stage", `Null);
             ("detachment_status", `Null);
             ("objective", `Null);

--- a/lib/dashboard/dashboard_execution_builders.ml
+++ b/lib/dashboard/dashboard_execution_builders.ml
@@ -206,7 +206,9 @@ let continuity_row_of_keeper ~(now_ts : float) ?related_session_id keeper :
   in
   let audit = tool_audit_snapshot agent_name in
   let agent = member_assoc "agent" keeper in
-  let status = string_field ~default:"<missing status>" "status" keeper in
+  let status =
+    string_field ~default:Briefing_json_helpers.missing_status "status" keeper
+  in
   let context_ratio =
     match member_assoc "context_ratio" keeper with
     | `Float value -> Some value

--- a/lib/dashboard/dashboard_execution_builders.ml
+++ b/lib/dashboard/dashboard_execution_builders.ml
@@ -206,7 +206,7 @@ let continuity_row_of_keeper ~(now_ts : float) ?related_session_id keeper :
   in
   let audit = tool_audit_snapshot agent_name in
   let agent = member_assoc "agent" keeper in
-  let status = string_field ~default:"unknown" "status" keeper in
+  let status = string_field ~default:"<missing status>" "status" keeper in
   let context_ratio =
     match member_assoc "context_ratio" keeper with
     | `Float value -> Some value

--- a/lib/dashboard_utils/dashboard_utils.ml
+++ b/lib/dashboard_utils/dashboard_utils.ml
@@ -58,6 +58,8 @@ let status_rank = function
   | "idle" -> 1
   | _ -> 0
 
+let missing_status = "<missing status>"
+
 let rec take n items =
   if n <= 0 then [] else match items with [] -> [] | x :: xs -> x :: take (n - 1) xs
 
@@ -138,7 +140,7 @@ let string_of_health_level = function
   | HL_warn -> "warn"
   | HL_degraded -> "degraded"
   | HL_ok -> "ok"
-  | HL_unknown -> "<missing status>"
+  | HL_unknown -> missing_status
 
 let severity_rank_of_health_level = function
   | HL_critical | HL_bad | HL_risk -> 2
@@ -185,7 +187,7 @@ let string_of_session_lifecycle = function
   | SL_stopped -> "stopped"
   | SL_interrupted -> "interrupted"
   | SL_expired -> "expired"
-  | SL_unknown -> "<missing status>"
+  | SL_unknown -> missing_status
 
 (** Status/health classification predicates — single source of truth.
     Used across dashboard, briefing, and operator modules. *)

--- a/lib/dashboard_utils/dashboard_utils.ml
+++ b/lib/dashboard_utils/dashboard_utils.ml
@@ -138,7 +138,7 @@ let string_of_health_level = function
   | HL_warn -> "warn"
   | HL_degraded -> "degraded"
   | HL_ok -> "ok"
-  | HL_unknown -> "unknown"
+  | HL_unknown -> "<missing status>"
 
 let severity_rank_of_health_level = function
   | HL_critical | HL_bad | HL_risk -> 2
@@ -185,7 +185,7 @@ let string_of_session_lifecycle = function
   | SL_stopped -> "stopped"
   | SL_interrupted -> "interrupted"
   | SL_expired -> "expired"
-  | SL_unknown -> "unknown"
+  | SL_unknown -> "<missing status>"
 
 (** Status/health classification predicates — single source of truth.
     Used across dashboard, briefing, and operator modules. *)

--- a/test/test_briefing_compactors.ml
+++ b/test/test_briefing_compactors.ml
@@ -21,7 +21,7 @@
 
     3. {b compact_session_json fallback contract} — empty
        [recent_events] produces a sentinel last_event with
-       event_type = "none" and the documented "unknown" /
+       event_type = "none" and the documented "<missing status>" /
        "not_recorded" defaults.
 
     4. {b compact_keeper_json strict shape} — 13 keys with
@@ -309,8 +309,8 @@ let test_compact_session_last_event_empty_uses_sentinel () =
             | _ -> "<missing>"
           in
           assert (get "event_type" = "none");
-          assert (get "ts_iso" = "unknown");
-          assert (get "actor" = "unknown");
+          assert (get "ts_iso" = "<missing status>");
+          assert (get "actor" = "<missing status>");
           assert (get "task_title" = "no recent session events");
           assert (get "result" = "not_recorded");
           assert (get "reason" = "not_recorded");
@@ -448,7 +448,7 @@ let test_compact_keeper_max_len_truncation () =
       assert (String.length lp < 300)
   | _ -> assert false
 
-let test_compact_keeper_default_unknown_when_missing_keys () =
+let test_compact_keeper_default_missing_status_when_missing_keys () =
   (* Keeper JSON missing diagnostic block → defaults applied. *)
   let k = `Assoc [ ("name", `String "k") ] in
   let out = C.compact_keeper_json k in
@@ -459,8 +459,8 @@ let test_compact_keeper_default_unknown_when_missing_keys () =
         | Some (`String s) -> s
         | _ -> ""
       in
-      assert (get "status" = "unknown");
-      assert (get "agent_name" = "unknown");
+      assert (get "status" = "<missing status>");
+      assert (get "agent_name" = "<missing status>");
       assert (get "current_task" = "unassigned");
       assert (get "last_reply_status" = "not_recorded");
       assert (get "last_reply_preview" = "not_recorded")
@@ -577,7 +577,7 @@ let () =
   test_compact_session_goal_default_when_blank ();
   test_compact_keeper_strict_keys ();
   test_compact_keeper_max_len_truncation ();
-  test_compact_keeper_default_unknown_when_missing_keys ();
+  test_compact_keeper_default_missing_status_when_missing_keys ();
   test_compact_agent_strict_keys ();
   test_compact_agent_assignment_status_assigned ();
   test_compact_agent_assignment_status_unassigned_when_none ();

--- a/test/test_briefing_gaps.ml
+++ b/test/test_briefing_gaps.ml
@@ -84,6 +84,22 @@ let test_session_communication_mode_unknown () =
   assert (kind_of g = "session_communication_mode_missing");
   assert (scope_type_of g = "session")
 
+let test_session_communication_mode_blank_or_absent () =
+  let blank = session ~comm:"   " () in
+  let absent =
+    `Assoc
+      [
+        ("session_id", json_string "s-missing");
+        ("goal", json_string "x");
+      ]
+  in
+  let gaps =
+    G.collect_metadata_gaps ~sessions:[ blank; absent ] ~keepers:[]
+      ~agents:[]
+  in
+  assert (List.length gaps = 2);
+  assert (List.for_all (fun g -> kind_of g = "session_communication_mode_missing") gaps)
+
 let test_keeper_last_reply_not_recorded () =
   let k = keeper ~status:"not_recorded" () in
   let gaps = G.collect_metadata_gaps ~sessions:[] ~keepers:[ k ] ~agents:[] in
@@ -289,6 +305,7 @@ let test_evidence_filters_by_section () =
 let () =
   test_session_goal_unassigned ();
   test_session_communication_mode_unknown ();
+  test_session_communication_mode_blank_or_absent ();
   test_keeper_last_reply_not_recorded ();
   test_agent_focus_missing_when_active ();
   test_no_gaps_when_no_sentinels ();

--- a/test/test_briefing_gaps.ml
+++ b/test/test_briefing_gaps.ml
@@ -86,6 +86,14 @@ let test_session_communication_mode_unknown () =
 
 let test_session_communication_mode_blank_or_absent () =
   let blank = session ~comm:"   " () in
+  let null =
+    `Assoc
+      [
+        ("session_id", json_string "s-null");
+        ("goal", json_string "x");
+        ("communication_mode", `Null);
+      ]
+  in
   let absent =
     `Assoc
       [
@@ -94,10 +102,10 @@ let test_session_communication_mode_blank_or_absent () =
       ]
   in
   let gaps =
-    G.collect_metadata_gaps ~sessions:[ blank; absent ] ~keepers:[]
+    G.collect_metadata_gaps ~sessions:[ blank; null; absent ] ~keepers:[]
       ~agents:[]
   in
-  assert (List.length gaps = 2);
+  assert (List.length gaps = 3);
   assert (List.for_all (fun g -> kind_of g = "session_communication_mode_missing") gaps)
 
 let test_keeper_last_reply_not_recorded () =

--- a/test/test_briefing_json_helpers.ml
+++ b/test/test_briefing_json_helpers.ml
@@ -66,6 +66,17 @@ let test_string_field_wrong_type () =
   let j = `Assoc [ ("count", `Int 5) ] in
   assert (B.string_field ~default:"fallback" "count" j = "fallback")
 
+(* ─── missing status sentinel ──────────────────────────────── *)
+
+let test_missing_status_sentinel () =
+  assert (B.missing_status = "<missing status>");
+  assert (B.is_missing_status_or_unknown "");
+  assert (B.is_missing_status_or_unknown "   ");
+  assert (B.is_missing_status_or_unknown "unknown");
+  assert (B.is_missing_status_or_unknown "  UNKNOWN  ");
+  assert (B.is_missing_status_or_unknown "<missing status>");
+  assert (not (B.is_missing_status_or_unknown "async"))
+
 (* ─── string_json ──────────────────────────────────────────── *)
 
 let test_string_json_passthrough () =
@@ -216,6 +227,7 @@ let () =
   test_string_field_present ();
   test_string_field_default ();
   test_string_field_wrong_type ();
+  test_missing_status_sentinel ();
   test_string_json_passthrough ();
   test_string_json_empty_uses_default ();
   test_string_json_non_string_uses_default ();

--- a/test/test_briefing_sections.ml
+++ b/test/test_briefing_sections.ml
@@ -254,6 +254,17 @@ let test_communication_unknown_mode_unclear () =
   let c = by_id sections "communication" in
   assert (section_status c = "unclear")
 
+let test_communication_missing_status_mode_unclear () =
+  (* Compacted sessions can carry "<missing status>" for missing mode. *)
+  let _ws, sections =
+    S.build_briefing_sections
+      ~briefing_summary_json:(briefing_summary ())
+      ~sessions:[ session ~mode:"<missing status>" () ]
+      ~agents:[] ~recent_messages:[] ~metadata_gaps:[]
+  in
+  let c = by_id sections "communication" in
+  assert (section_status c = "unclear")
+
 let test_communication_metadata_gap_unclear () =
   let _ws, sections =
     S.build_briefing_sections
@@ -374,6 +385,7 @@ let () =
   test_communication_positive_signal_with_gaps_watch ();
   test_communication_no_sessions_unclear ();
   test_communication_unknown_mode_unclear ();
+  test_communication_missing_status_mode_unclear ();
   test_communication_metadata_gap_unclear ();
   test_alignment_no_active_agents_unclear ();
   test_alignment_metadata_gap_unclear ();

--- a/test/test_dashboard_briefing_sections.ml
+++ b/test/test_dashboard_briefing_sections.ml
@@ -194,11 +194,12 @@ let test_compact_session_json_normalizes_missing_fields () =
   let compact = Briefing.compact_session_json json in
   check_string_field compact "goal" "unassigned";
   check_string_field compact "project" "default";
-  check_string_field compact "status" "unknown";
+  check_string_field compact "status" "<missing status>";
   check_list_field compact "agent_names" 0;
   check_int_field compact "active_agents_count" 0;
-  check_string_field compact "communication_mode" "unknown";
-  check_string_field compact "communication_summary" "unknown · broadcast 0 · portal 0"
+  check_string_field compact "communication_mode" "<missing status>";
+  check_string_field compact "communication_summary"
+    "<missing status> · broadcast 0 · portal 0"
 
 let test_compact_keeper_json_normalizes_missing_fields () =
   let json =
@@ -212,8 +213,8 @@ let test_compact_keeper_json_normalizes_missing_fields () =
       ]
   in
   let compact = Briefing.compact_keeper_json json in
-  check_string_field compact "status" "unknown";
-  check_string_field compact "agent_name" "unknown";
+  check_string_field compact "status" "<missing status>";
+  check_string_field compact "agent_name" "<missing status>";
   check_string_field compact "current_task" "unassigned";
   check_string_field compact "last_reply_status" "not_recorded";
   check_string_field compact "last_reply_preview" "not_recorded";


### PR DESCRIPTION
Replace bare unknown and ~default:unknown sentinel strings with <missing status> across dashboard_utils, dashboard_goal_loop, briefing_gaps, briefing_compactors, dashboard_execution_builders, dashboard_mission_agents, dashboard_mission_assembly, and cascade runtime candidate modules.