### PR TITLE
fix(keeper): reuse active task gate state

### DIFF
--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -810,7 +810,7 @@ let prepare_agent_setup
       if tool_gate_requested && required_tool_names = []
       then
         generic_required_tool_candidate_names
-          ~has_current_task:(keeper_has_owned_active_task ())
+          ~has_current_task
           ~turn_affordances
           ~allowed_tool_names:turn_visible_tool_names
       else []


### PR DESCRIPTION
## Summary

- Reuse the already computed `has_current_task` value when building generic required-tool candidates.
- Avoid a duplicate `keeper_has_owned_active_task ()` call in the same turn setup computation.

## Product impact

This is a narrow Keeper review-response cleanup. It does not change the required-tool gate behavior; it keeps per-turn active-task state consistent within `prepare_agent_setup`.

## Evidence

- `ocamlformat --check lib/keeper/keeper_run_tools_setup.ml`
- `git diff --check`
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-reuse-active-task-state dune build --root . -j 2 test/test_keeper_tool_surface_guard.exe test/test_keeper_unified_required_tools.exe`
- `_build-codex-reuse-active-task-state/default/test/test_keeper_tool_surface_guard.exe` => 20 tests passed
- `_build-codex-reuse-active-task-state/default/test/test_keeper_unified_required_tools.exe` => 7 tests passed
- `git commit` hook completed successfully

## Direct evidence

schema_version: 1
direct_ratio: 6/6
provenance: direct

The commands above were run locally in `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/reuse-active-task-state`.

## Review evidence

Addresses the unresolved Copilot review comment on #19771 asking to reuse `has_current_task` instead of recomputing `keeper_has_owned_active_task ()` for `required_tool_candidate_names`.

## Linked issue

Follow-up to PR #19771 review thread. No separate GitHub issue.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`codex/reuse-active-task-state` → `main` · 1 commit(s) · synced 2026-06-02T00:00:46Z

| sha | subject | date |
|---|---|---|
| `a354c48f3` | fix(keeper): reuse active task gate state | 2026-06-01 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->