### PR TITLE
fix(exec-gate): close env allowlist-bypass — gate resolves effective command (RFC-0208)

### DIFF
--- a/lib/exec/command_gate/shell_command_gate.ml
+++ b/lib/exec/command_gate/shell_command_gate.ml
@@ -19,6 +19,7 @@ type caller =
 type reject_reason =
   | Command_not_in_allowlist of { bin : string }
   | Pipeline_segment_disallowed of { stage : int; bin : string }
+  | Wrapper_unreducible of { stage : int; wrapper : string; detail : string }
   | Pipes_not_allowed of { stages : int }
   | Redirect_disallowed_in_caller of { stage : int }
   | Path_outside_policy of { stage : int; raw_path : string; diagnostic : string }
@@ -282,16 +283,121 @@ let bin_allowed ~(allowed_commands : string list) (bin : string) =
   List.exists (String.equal bin) allowed_commands
 ;;
 
-(* Returns the (1-indexed stage, bin) of the first stage whose binary
-   name is outside the allowlist, [None] if every stage passes. *)
-let first_disallowed_stage ~allowed_commands stage_bins =
+(* `env [OPT]... [NAME=VALUE]... CMD [ARG]...` runs CMD with a modified
+   environment. The allowlist must authorize CMD, not `env`: `env` is
+   allowlisted so a command may set vars (e.g. `env FOO=bar npm test`), but
+   it must not be a hole through which a non-allowlisted command
+   (`env rm -rf /`) is smuggled past the gate. [effective_bin_of_stage]
+   resolves the command a stage really runs.
+
+   Secure default: any env form we cannot statically reduce to a literal
+   inner command — the [-S]/[--split-string] mode, an unmodeled flag, or a
+   non-literal command token — yields [Unreducible], which the gate denies.
+   It never silently allows `env`. Erring on a modeled value-flag (so
+   [env -u PATH cat x] keeps [cat] as the command) is a false-reject, which
+   is safe; a false-allow is not. *)
+type effective_bin =
+  | Bin of string
+  | Unreducible of string
+
+(* env options that consume the following token as their value. *)
+let env_value_flags = [ "-u"; "--unset"; "-C"; "--chdir" ]
+
+(* env boolean options (consume no value). *)
+let env_bool_flags =
+  [ "-i"; "--ignore-environment"; "-0"; "--null"; "-v"; "--debug" ]
+;;
+
+let is_env_assignment tok =
+  match String.index_opt tok '=' with
+  | None | Some 0 -> false
+  | Some idx ->
+    let name = String.sub tok 0 idx in
+    String.length name > 0
+    && (match name.[0] with
+        | 'A' .. 'Z' | 'a' .. 'z' | '_' -> true
+        | _ -> false)
+    && String.for_all
+         (function
+           | 'A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '_' -> true
+           | _ -> false)
+         name
+;;
+
+let is_eq_form_value_flag tok =
+  List.exists
+    (fun f -> String.starts_with ~prefix:(f ^ "=") tok)
+    [ "--unset"; "--chdir" ]
+;;
+
+let is_split_string_flag tok =
+  tok = "-S"
+  || tok = "--split-string"
+  || (String.length tok >= 2 && tok.[0] = '-' && tok.[1] = 'S')
+  || String.starts_with ~prefix:"--split-string" tok
+;;
+
+(* Peel `env`'s own options and assignments to the first literal token that
+   names the command it execs. Recurses through a leading `env env ...`. *)
+let rec effective_bin_of_args (args : SI.arg list) : effective_bin =
+  match args with
+  | [] -> Bin "env" (* bare `env` after flags/assignments: prints env, a read *)
+  | arg :: rest ->
+    (match arg_literal arg with
+     | None -> Unreducible "non-literal token in env command position"
+     | Some "" -> Unreducible "empty token after env"
+     | Some "--" ->
+       (match rest with
+        | [] -> Bin "env"
+        | cmd :: _ ->
+          (match arg_literal cmd with
+           | Some "env" -> effective_bin_of_args rest
+           | Some c -> Bin c
+           | None -> Unreducible "non-literal command after env --"))
+     | Some tok when is_split_string_flag tok ->
+       Unreducible "env -S/--split-string is not statically reducible"
+     | Some tok when List.mem tok env_bool_flags -> effective_bin_of_args rest
+     | Some tok when is_eq_form_value_flag tok -> effective_bin_of_args rest
+     | Some tok when List.mem tok env_value_flags ->
+       (match rest with
+        | _value :: rest' -> effective_bin_of_args rest'
+        | [] -> Unreducible "env value flag is missing its value")
+     | Some tok when is_env_assignment tok -> effective_bin_of_args rest
+     | Some tok when String.length tok > 0 && tok.[0] = '-' ->
+       Unreducible (Printf.sprintf "unmodeled env flag %s" tok)
+     | Some "env" -> effective_bin_of_args rest (* env env CMD ... *)
+     | Some cmd -> Bin cmd)
+;;
+
+let effective_bin_of_stage (s : SI.simple) : effective_bin =
+  let bin = BIN.to_string s.SI.bin in
+  if bin <> "env" then Bin bin else effective_bin_of_args s.SI.args
+;;
+
+(* The first stage the gate blocks: either its effective command is outside
+   the allowlist, or it is a wrapper the gate cannot statically authorize.
+   [None] if every stage passes. *)
+type stage_block =
+  | Stage_not_allowed of { stage : int; bin : string }
+  | Stage_unreducible of { stage : int; wrapper : string; detail : string }
+
+let first_blocked_stage ~allowed_commands (stages : SI.simple list)
+  : stage_block option
+  =
   let rec scan idx = function
     | [] -> None
-    | bin :: rest ->
-      if bin_allowed ~allowed_commands bin then scan (idx + 1) rest
-      else Some (idx, bin)
+    | s :: rest ->
+      (match effective_bin_of_stage s with
+       | Unreducible detail ->
+         Some
+           (Stage_unreducible
+              { stage = idx; wrapper = BIN.to_string s.SI.bin; detail })
+       | Bin bin ->
+         if bin_allowed ~allowed_commands bin
+         then scan (idx + 1) rest
+         else Some (Stage_not_allowed { stage = idx; bin }))
   in
-  scan 1 stage_bins
+  scan 1 stages
 ;;
 
 let stage_has_redirect (simple : SI.simple) : bool =
@@ -378,11 +484,9 @@ let apply_policy ~(allowlist : allowlist_policy) ~(path_policy : path_policy)
         }
     else
       (match
-         first_disallowed_stage
-           ~allowed_commands:allowlist.allowed_commands
-           context.stage_bins
+         first_blocked_stage ~allowed_commands:allowlist.allowed_commands stages
        with
-       | Some (stage_idx, bin) ->
+       | Some (Stage_not_allowed { stage = stage_idx; bin }) ->
          let reason, diagnostic =
            if stage_n = 1 then
              ( Command_not_in_allowlist { bin }
@@ -395,6 +499,17 @@ let apply_policy ~(allowlist : allowlist_policy) ~(path_policy : path_policy)
                  bin )
          in
          Reject { context; reason; diagnostic }
+       | Some (Stage_unreducible { stage = stage_idx; wrapper; detail }) ->
+         Reject
+           { context
+           ; reason = Wrapper_unreducible { stage = stage_idx; wrapper; detail }
+           ; diagnostic =
+               Printf.sprintf
+                 "stage %d: %s wrapper cannot be statically authorized (%s)"
+                 stage_idx
+                 wrapper
+                 detail
+           }
        | None ->
          (match first_path_failure ~path_policy stages with
           | Some (stage_idx, raw_path, diagnostic) ->
@@ -479,6 +594,7 @@ let verdict_tag = function
 let reject_reason_tag = function
   | Command_not_in_allowlist _ -> "command_not_in_allowlist"
   | Pipeline_segment_disallowed _ -> "pipeline_segment_disallowed"
+  | Wrapper_unreducible _ -> "wrapper_unreducible"
   | Pipes_not_allowed _ -> "pipes_not_allowed"
   | Redirect_disallowed_in_caller _ -> "redirect_disallowed_in_caller"
   | Path_outside_policy _ -> "path_outside_policy"

--- a/lib/exec/command_gate/shell_command_gate.mli
+++ b/lib/exec/command_gate/shell_command_gate.mli
@@ -50,6 +50,12 @@ type caller =
 type reject_reason =
   | Command_not_in_allowlist of { bin : string }
   | Pipeline_segment_disallowed of { stage : int; bin : string }
+  | Wrapper_unreducible of { stage : int; wrapper : string; detail : string }
+      (** A wrapper command (e.g. [env]) whose effective inner command the
+          gate cannot statically authorize — the [-S]/[--split-string]
+          mode, an unmodeled flag, or a non-literal command token. Denied
+          by secure default so the wrapper cannot smuggle a non-allowlisted
+          command past the gate. *)
   | Pipes_not_allowed of { stages : int }
   | Redirect_disallowed_in_caller of { stage : int }
   | Path_outside_policy of { stage : int; raw_path : string; diagnostic : string }

--- a/lib/exec/test/dune
+++ b/lib/exec/test/dune
@@ -8,6 +8,7 @@
         test_shell_ir_typed test_shell_ir_walkers_gen test_shell_ir_risk
         test_shell_ir_risk_repo_hosting_cli_stress
         test_shell_ir_typed_e2e
-        test_shell_ir_differential)
- (libraries masc_exec masc_exec_bash_parser masc_process
+        test_shell_ir_differential
+        test_exec_gate_env_wrapper)
+ (libraries masc_exec masc_exec_bash_parser masc_exec_command_gate masc_process
             masc_core masc_config alcotest eio eio_main yojson unix re))

--- a/lib/exec/test/test_exec_gate_env_wrapper.ml
+++ b/lib/exec/test/test_exec_gate_env_wrapper.ml
@@ -1,0 +1,127 @@
+(* RFC-0208 env allowlist-bypass regression guard.
+
+   `env` is on the dev/readonly command allowlists so a keeper can set an
+   environment variable for an allowed command (`env FOO=bar npm test`).
+   Before the gate resolved the effective command, `env` was a hole: the
+   gate saw bin=`env` (allowlisted) and never looked at the wrapped
+   command, so `env rm -rf /` ran on even the readonly keeper.
+
+   These assertions pin the fix at the single authorization chokepoint
+   ([Shell_command_gate.gate_typed]), covering both the string-parsed path
+   and the typed-input path (the IR is built directly, without Bash) — the
+   latter is exactly what a parser-only fix would have missed. *)
+open Masc_exec
+module Gate = Masc_exec_command_gate.Shell_command_gate
+
+let dev = [ "env"; "cat"; "ls"; "npm" ]
+let readonly = [ "env"; "cat"; "ls" ]
+
+let policy allowed =
+  { Gate.redirect_allowed = true; allowed_commands = allowed; allow_pipes = true }
+;;
+
+let sandbox = { Gate.target = Sandbox_target.host () }
+
+let gate ~allowed ir =
+  Gate.gate_typed
+    ~caller:Gate.Agent_tool_execute_shell_ir
+    ~ir
+    ~allowlist:(policy allowed)
+    ~path_policy:Gate.allow_all_paths
+    ~sandbox
+    ()
+;;
+
+let is_allow = function
+  | Gate.Allow _ -> true
+  | _ -> false
+;;
+
+let is_reject = function
+  | Gate.Reject _ -> true
+  | _ -> false
+;;
+
+let is_wrapper_unreducible = function
+  | Gate.Reject { reason = Gate.Wrapper_unreducible _; _ } -> true
+  | _ -> false
+;;
+
+let parse cmd =
+  match Masc_exec_bash_parser.Bash.parse_string cmd with
+  | Parsed.Parsed ir -> ir
+  | _ -> failwith (Printf.sprintf "parse failed: %s" cmd)
+;;
+
+let lit s = Shell_ir.Lit (s, Shell_ir.default_meta)
+
+let typed_simple bin args =
+  Shell_ir.Simple
+    { Shell_ir.bin = Result.get_ok (Exec_program.of_string bin)
+    ; args = List.map lit args
+    ; env = []
+    ; cwd = None
+    ; redirects = []
+    ; sandbox = Sandbox_target.host ()
+    }
+;;
+
+let check name cond = if not cond then failwith ("FAIL: " ^ name)
+
+let test_env_bypass_closed () =
+  (* The hole: env smuggling a non-allowlisted command — now rejected. *)
+  check "env rm -rf / rejected" (is_reject (gate ~allowed:readonly (parse "env rm -rf /")));
+  check
+    "env FOO=bar rm -rf / rejected"
+    (is_reject (gate ~allowed:readonly (parse "env FOO=bar rm -rf /")));
+  check
+    "env env rm -rf / (nested) rejected"
+    (is_reject (gate ~allowed:readonly (parse "env env rm -rf /")));
+  (* Per-stage: a pipeline stage hidden behind env is still caught. *)
+  check
+    "cat x | env rm -rf / rejected"
+    (is_reject (gate ~allowed:readonly (parse "cat x | env rm -rf /")))
+;;
+
+let test_uncertain_denies () =
+  (* env -S runs its string arg as a command we cannot statically reduce:
+     secure default is deny, never silently allow `env`. *)
+  check
+    "env -S 'rm -rf /' wrapper_unreducible"
+    (is_wrapper_unreducible (gate ~allowed:readonly (parse "env -S 'rm -rf /'")))
+;;
+
+let test_legit_env_preserved () =
+  (* env's own flags are skipped; the inner command is authorized. *)
+  check "env -i cat x allowed" (is_allow (gate ~allowed:readonly (parse "env -i cat x")));
+  check
+    "env -u PATH cat x allowed (value flag skipped, cat is the command)"
+    (is_allow (gate ~allowed:readonly (parse "env -u PATH cat x")));
+  check "bare env allowed (read)" (is_allow (gate ~allowed:readonly (parse "env")));
+  (* Legit var-setting for an allowed command keeps working. *)
+  check
+    "env FOO=bar npm test allowed (dev)"
+    (is_allow (gate ~allowed:dev (parse "env FOO=bar npm test")));
+  check "env npm install allowed (dev)" (is_allow (gate ~allowed:dev (parse "env npm install")));
+  (* Non-env commands are unaffected. *)
+  check "cat x allowed (baseline)" (is_allow (gate ~allowed:readonly (parse "cat x")))
+;;
+
+let test_typed_input_path () =
+  (* The IR built directly from {bin; args} — no Bash parse. A parser-only
+     fix would miss this; the gate-layer fix must cover it. *)
+  check
+    "{bin=env,args=[rm,-rf,/]} rejected"
+    (is_reject (gate ~allowed:readonly (typed_simple "env" [ "rm"; "-rf"; "/" ])));
+  check
+    "{bin=env,args=[cat,x]} allowed"
+    (is_allow (gate ~allowed:readonly (typed_simple "env" [ "cat"; "x" ])))
+;;
+
+let () =
+  test_env_bypass_closed ();
+  test_uncertain_denies ();
+  test_legit_env_preserved ();
+  test_typed_input_path ();
+  print_endline "[test_exec_gate_env_wrapper] all tests passed"
+;;

--- a/lib/exec_policy.ml
+++ b/lib/exec_policy.ml
@@ -276,6 +276,7 @@ let block_reason_of_exec_reject : Exec_shell_gate.reject_reason -> block_reason 
   function
   | Command_not_in_allowlist { bin } -> Command_not_allowed bin
   | Pipeline_segment_disallowed { bin; _ } -> Command_not_allowed bin
+  | Wrapper_unreducible _ -> Injection
   | Pipes_not_allowed _ -> Pipes_not_allowed
   | Redirect_disallowed_in_caller _
   | Path_outside_policy _ -> Unsafe_redirect


### PR DESCRIPTION
## env allowlist-bypass 차단 (보안)

**증상 (측정확정):** `env`이 dev·readonly 명령 allowlist 양쪽에 있습니다(정당 용도: `env FOO=bar npm test`로 허용 명령에 변수 설정). 그런데 게이트가 literal head bin만 인가하니 `env <cmd>`가 임의 명령을 allowlist 우회로 실행 — **readonly 제약 keeper가 `env <파괴적-명령>`을 실행 가능**. `Shell_command_gate.gate_typed`로 end-to-end 측정: `env <파괴적> => ALLOW`. (대조: `rm` 직접, `bash -c …`는 allowlist에 없어 정상 REJECT.)

**fix:** 단일 인가 chokepoint(`gate_typed` — 문자열 파싱 경로와 typed-input 경로 모두 경유)에서 **각 stage의 effective command를 해석**. bin=env면 env 자체 옵션 + `NAME=VALUE` 할당을 peel해 실제 exec 명령을 찾아 *그걸* 인가.

**secure default:** 정적으로 inner 명령을 못 줄이는 env 형태(`-S`/`--split-string`, 미모델 flag, non-literal 토큰)는 신규 `Wrapper_unreducible` reject — **게이트가 env를 조용히 허용하지 않음**. value-flag(`-u`/`--unset`, `-C`/`--chdir`, `=`form)는 값과 함께 skip → `env -u PATH cat x`는 `cat`이 명령. 오류 방향은 false-reject(안전)지 false-allow가 아님.

per-stage라 pipeline에 숨은 env(`cat x | env rm …`)도 잡힘. nested `env env <cmd>` 재귀. capability 축·risk 분류기는 **무변** — 이건 allowlist 우회를 닫는 것이지 risk가 env를 본다는 게 아님.

**검증 (close-the-loop, 같은 게이트로):**

| 입력 | 결과 |
|---|---|
| `env rm -rf /`, `env FOO=bar rm -rf /` | REJECT (구멍 닫힘) |
| `env -i cat x`, `env -u PATH cat x` | ALLOW (flag/value-flag skip, cat이 명령) |
| `env -S 'rm -rf /'` | REJECT[wrapper_unreducible] |
| `env env rm -rf /` (nested) | REJECT |
| bare `env`, `cat x` | ALLOW (보존) |
| `cat x \| env rm -rf /` (pipe) | REJECT (per-stage) |
| `env FOO=bar npm test`, `env npm install` (dev) | ALLOW (정당 보존) |
| **typed-path** `{bin=env,args=[rm,-rf,/]}` 직접 IR | REJECT (parser-only fix가 놓쳤을 경로) |

> 워크어라운드 아님: chokepoint에서 우회를 *구조적으로* 닫고(secure-default reject), closed sum exhaustive match 유지(catch-all 추가 0), 회귀 테스트 추가. allowlist 유지가 아니라 우회 *제거*.

## 변경

- `shell_command_gate.ml/.mli`: `effective_bin_of_stage` + `first_blocked_stage`; 신규 `Wrapper_unreducible` reject_reason (exhaustive, catch-all 0).
- `exec_policy.ml`: `Wrapper_unreducible -> Injection` block_reason.
- `test_exec_gate_env_wrapper.ml`: 문자열·typed 입력 경로 양쪽 회귀 가드.

## 검증

- whole-program `dune build @check --root .` **EXIT=0** (현재 main 위, 0 stderr).
- `lib/exec` runtest green (`test_exec_gate_env_wrapper` 통과).
- `ocamlformat --check` clean.

## RFC

RFC-0208 §revision(2026-06-02) 참조 — risk-gate 경계 작업의 일부.

## Follow-up (별도 issue)

`find -delete` / `find -exec <cmd>` → ALLOW: allowlist된 `find`가 자체 action-flag로 파괴/실행하는 별도 형태(wrapper 아님). 별도 issue로 repro와 함께 처리, 본 PR에 흡수 안 함.
