### PR TITLE
refactor(keeper): remove has_current_task coupling from tool surface

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -625,8 +625,6 @@ let run_turn
                  Keeper_agent_run_contract_retry.run_with_single_retry
                    ~keeper_name:meta.name
                    ~acc
-                   ~has_current_task:
-                     (Option.is_some (owned_active_task_id_for_meta ~config ~meta:acc.meta))
                    ~turn_affordances
                    ~history_messages
                    ~call_run_named

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -76,7 +76,6 @@ let run_turn
       ~(runtime_id : string)
       ?world_observation
       ?(turn_affordances = [])
-      ?(required_tool_names = [])
       ?provider_filter
       ~(generation : int)
       ?(max_turns : int = Keeper_runtime_resolved.reactive_max_turns_per_call ())
@@ -332,7 +331,6 @@ let run_turn
       ~runtime_id
       ~is_retry
       ~turn_affordances
-      ~required_tool_names
       ~config_root
       ~runtime_config_path
       ~gemini_mcp_disabled
@@ -381,21 +379,6 @@ let run_turn
             ("tool_gate_enabled", `Bool acc.tool_surface.tool_gate_enabled);
             ( "tool_surface_fallback_used",
               `Bool acc.tool_surface.tool_surface_fallback_used );
-            ( "required_tool_names",
-              `List
-                (List.map
-                   (fun name -> `String name)
-                   acc.tool_surface.required_tool_names) );
-            ( "required_tool_candidate_names",
-              `List
-                (List.map
-                   (fun name -> `String name)
-                   acc.tool_surface.required_tool_candidate_names) );
-            ( "missing_required_tool_names",
-              `List
-                (List.map
-                   (fun name -> `String name)
-                   acc.tool_surface.missing_required_tool_names) );
             ("config_root", `String acc.tool_surface.config_root);
           ])
       Keeper_runtime_manifest.Tool_surface_selected;
@@ -564,8 +547,7 @@ let run_turn
                           ~site:"runtime_runtime"
                           config
                           manifest)
-                   ~runtime_manifest_required_tool_names:
-                     acc.tool_surface.required_tool_names
+                   ~runtime_manifest_required_tool_names:[]
                       (* Keepers use turn-level retry for transient errors but benefit
               from OAS per-call retry for validation errors (malformed tool
               args). retry_on_validation_error=true lets OAS re-prompt the
@@ -579,11 +561,6 @@ let run_turn
                       ; feedback_style =
                           Agent_sdk.Tool_retry_policy.Structured_tool_result
                       }
-                    ~required_tool_satisfaction:(fun call ->
-                      Keeper_tool_progress
-                      .required_tool_satisfaction_for_turn
-                        ~required_tool_names:acc.tool_surface.required_tool_names
-                        call)
                     ~max_turns
                     ~max_idle_turns
                     ?stream_idle_timeout_s
@@ -682,10 +659,10 @@ let run_turn
                     boundary — it emits exactly one
                     [masc_keeper_tool_call_total] sample per observed
                     name with bounded labels. Set-logic call sites
-                    (required-tool canonicalisation, surface composition)
-                    use the pure [canonical_tool_name] variant so a
-                    single observed call does not produce multiple
-                    counter samples (PR #14585 review #3). *)
+                    (surface composition, provider routing) use the pure
+                    [canonical_tool_name] variant so a single observed call
+                    does not produce multiple counter samples (PR #14585
+                    review #3). *)
                  let canonical_tool_names =
                    tool_observation.canonical_tool_names
                  in
@@ -787,28 +764,14 @@ let run_turn
                    let tool_contract_status ()
                        : Keeper_execution_receipt.tool_contract_result =
                      Contract_helpers.observed_tool_contract_status
-                       ~required_tool_names:acc.tool_surface.required_tool_names
-                       ~missing_visible_required:
-                         acc.tool_surface.missing_required_tool_names
+                       ~required_tool_names:[]
+                       ~missing_visible_required:[]
                        ~had_owned_active_task_at_turn_start
                        ~actual_keeper_tool_names:progress_keeper_tool_names
                    in
-                   (* Required-tool turns are filtered onto providers that declare
-            tool support plus tool_choice support. If a text-only response
-            still reaches this point, treat it as a contract failure. *)
                    let text_result =
-                     let effective_completion_contract =
-                       Keeper_tool_completion_contract.run_completion_contract
-                         ~turn_contract:acc.completion_contract
-                         ~required_tool_use_seen:acc.required_tool_use_seen
-                     in
-                     match
-                       ( Keeper_tool_completion_contract.validate_completion_contract_presence
-                           ~contract:effective_completion_contract
-                           ~tool_present:acc.keeper_surface_tool_used
-                       , actionable_tool_contract_violation_reason )
-                     with
-                     | Ok (), Some reason ->
+                     match actionable_tool_contract_violation_reason with
+                     | Some reason ->
                        let contract_status
                            : Keeper_execution_receipt.tool_contract_result =
                          Contract_helpers.passive_violation_contract_status
@@ -827,28 +790,9 @@ let run_turn
                          ~reason;
                        Error
                          (Contract_helpers.completion_contract_violation_error reason)
-                     | Ok (), None ->
+                     | None ->
                        acc.receipt_tool_contract_result <- tool_contract_status ();
                        Ok (`Provider_text text)
-                     | Error reason, _ ->
-                       let contract_status
-                           : Keeper_execution_receipt.tool_contract_result =
-                         Contract_helpers.text_only_violation_contract_status
-                           ~actual_keeper_tool_names
-                           ~fallback:tool_contract_status
-                       in
-                       acc.receipt_tool_contract_result <- contract_status;
-                       Keeper_agent_run_contract_violation_log.record_text_only
-                         ~keeper_name:meta.name
-                         ~has_current_task:(keeper_has_owned_active_task ())
-                         ~contract_status
-                         ~effective_completion_contract
-                         ~actionable_signal_kind
-                         ~turns:result.turns
-                         ~actual_keeper_tool_names
-                         ~reason;
-                       Error
-                         (Contract_helpers.completion_contract_violation_error reason)
                    in
                    match text_result with
                    | Error e -> Error e

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -625,7 +625,6 @@ let run_turn
                  Keeper_agent_run_contract_retry.run_with_single_retry
                    ~keeper_name:meta.name
                    ~acc
-                   ~turn_affordances
                    ~history_messages
                    ~call_run_named
                with

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -94,7 +94,6 @@ val run_turn
   -> runtime_id:string
   -> ?world_observation:Keeper_world_observation.world_observation
   -> ?turn_affordances:string list
-  -> ?required_tool_names:string list
   -> ?provider_filter:string list
   -> generation:int
   -> ?max_turns:int

--- a/lib/keeper/keeper_agent_run_actionable_contract.ml
+++ b/lib/keeper/keeper_agent_run_actionable_contract.ml
@@ -23,6 +23,7 @@ let analyze
   in
   let tool_gate_required =
     Keeper_agent_tool_surface.turn_affordances_require_tool_gate_with_allowed
+      ~claim_context_allowed
       ~allowed_tool_names
       turn_affordances
   in

--- a/lib/keeper/keeper_agent_run_contract_retry.ml
+++ b/lib/keeper/keeper_agent_run_contract_retry.ml
@@ -9,11 +9,10 @@ let retry_feedback_message text : Agent_sdk.Types.message =
   }
 ;;
 
-let satisfying_tools_for_violation ~acc ~has_current_task ~turn_affordances
+let satisfying_tools_for_violation ~acc ~turn_affordances
     ~violation_reason ~violation_detail =
   let local_tools =
     Keeper_agent_tool_surface.generic_required_tool_candidate_names
-      ~has_current_task
       ~turn_affordances
       ~allowed_tool_names:acc.Keeper_run_tools.tool_surface.required_tool_candidate_names
   in
@@ -58,7 +57,7 @@ let post_contract_violation_retry_feedback
   "retry_count > 0 && retry_message_count = history_message_count + 1 && String_util.contains_substring_ci feedback_text \"contract violation\""]
 ;;
 
-let run_with_single_retry ~keeper_name ~acc ~has_current_task ~turn_affordances
+let run_with_single_retry ~keeper_name ~acc ~turn_affordances
     ~history_messages ~call_run_named =
   match call_run_named ~initial_messages:history_messages with
   | Error
@@ -74,7 +73,6 @@ let run_with_single_retry ~keeper_name ~acc ~has_current_task ~turn_affordances
     let satisfying_tools =
       satisfying_tools_for_violation
         ~acc
-        ~has_current_task
         ~turn_affordances
         ~violation_reason
         ~violation_detail

--- a/lib/keeper/keeper_agent_run_contract_retry.ml
+++ b/lib/keeper/keeper_agent_run_contract_retry.ml
@@ -9,36 +9,10 @@ let retry_feedback_message text : Agent_sdk.Types.message =
   }
 ;;
 
-let satisfying_tools_for_violation ~acc ~turn_affordances
-    ~violation_reason ~violation_detail =
-  let local_tools =
-    Keeper_agent_tool_surface.generic_required_tool_candidate_names
-      ~turn_affordances
-      ~allowed_tool_names:acc.Keeper_run_tools.tool_surface.required_tool_candidate_names
-  in
-  let oas_tools =
-    match violation_detail with
-    | Some detail when detail.Agent_sdk.Completion_contract_violation_detail.satisfying_tools <> []
-      ->
-      detail.satisfying_tools
-    | Some _ | None ->
-      Keeper_tool_progress.satisfying_tools_from_contract_violation_reason
-        violation_reason
-  in
-  Keeper_types_profile_toml_normalizers.dedupe_keep_order (oas_tools @ local_tools)
-;;
-
-let retry_action = function
-  | [] ->
-    "No currently visible tool can satisfy this contract; emit a concise blocker instead."
-  | tools -> Printf.sprintf "You MUST call one of these tools: %s." (String.concat ", " tools)
-;;
-
-let retry_feedback ~violation_reason ~satisfying_tools =
+let retry_feedback ~violation_reason =
   Printf.sprintf
-    "[CONTRACT VIOLATION] Your previous response was rejected: %s. %s Do NOT respond with text only."
+    "[CONTRACT VIOLATION] Your previous response was rejected: %s. Call a visible keeper tool. Do NOT respond with text only."
     violation_reason
-    (retry_action satisfying_tools)
 ;;
 
 (* KeeperContractViolated.tla: a detected completion-contract violation must
@@ -57,27 +31,20 @@ let post_contract_violation_retry_feedback
   "retry_count > 0 && retry_message_count = history_message_count + 1 && String_util.contains_substring_ci feedback_text \"contract violation\""]
 ;;
 
-let run_with_single_retry ~keeper_name ~acc ~turn_affordances
+let run_with_single_retry ~keeper_name ~acc
     ~history_messages ~call_run_named =
   match call_run_named ~initial_messages:history_messages with
   | Error
       (Agent_sdk.Error.Agent
          (Agent_sdk.Error.CompletionContractViolation
-            { reason = violation_reason; violation_detail; _ }))
+            { reason = violation_reason; _ }))
     when acc.Keeper_run_tools.contract_violation_retries < 1 ->
     (* Contract violation retry (max 1 per turn): the model did not call a
        required tool. Re-run with feedback so the model sees why it was
        rejected. The context builder in [Keeper_run_tools] injects extra
        guidance because [contract_violation_retries > 0]. *)
     acc.contract_violation_retries <- acc.contract_violation_retries + 1;
-    let satisfying_tools =
-      satisfying_tools_for_violation
-        ~acc
-        ~turn_affordances
-        ~violation_reason
-        ~violation_detail
-    in
-    let retry_feedback = retry_feedback ~violation_reason ~satisfying_tools in
+    let retry_feedback = retry_feedback ~violation_reason in
     let retry_messages = history_messages @ [ retry_feedback_message retry_feedback ] in
     post_contract_violation_retry_feedback
       ~history_message_count:(List.length history_messages)

--- a/lib/keeper/keeper_agent_run_contract_retry.mli
+++ b/lib/keeper/keeper_agent_run_contract_retry.mli
@@ -3,7 +3,6 @@
 val run_with_single_retry :
   keeper_name:string ->
   acc:Keeper_run_tools.hook_accumulator ->
-  has_current_task:bool ->
   turn_affordances:string list ->
   history_messages:Agent_sdk.Types.message list ->
   call_run_named:

--- a/lib/keeper/keeper_agent_run_contract_retry.mli
+++ b/lib/keeper/keeper_agent_run_contract_retry.mli
@@ -3,7 +3,6 @@
 val run_with_single_retry :
   keeper_name:string ->
   acc:Keeper_run_tools.hook_accumulator ->
-  turn_affordances:string list ->
   history_messages:Agent_sdk.Types.message list ->
   call_run_named:
     (initial_messages:Agent_sdk.Types.message list ->

--- a/lib/keeper/keeper_agent_run_receipt.ml
+++ b/lib/keeper/keeper_agent_run_receipt.ml
@@ -190,10 +190,9 @@ let finalize
         ; visible_tool_count = acc.tool_surface.visible_tool_count
         ; tool_gate_enabled = acc.tool_surface.tool_gate_enabled
         ; tool_surface_fallback_used = acc.tool_surface.tool_surface_fallback_used
-        ; required_tools = acc.tool_surface.required_tool_names
-        ; required_tool_candidates =
-            acc.tool_surface.required_tool_candidate_names
-        ; missing_required_tools = acc.tool_surface.missing_required_tool_names
+        ; required_tools = []
+        ; required_tool_candidates = []
+        ; missing_required_tools = []
         ; materialized_tools = !materialized_tool_names_ref
         }
     ; sandbox_kind = Keeper_execution_receipt.sandbox_kind_of_meta meta

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -450,7 +450,7 @@ let generic_required_tool_candidate_names
   generic_required_actionable_tool_names ~turn_affordances ~allowed_tool_names
 ;;
 
-let actionable_signal_requires_active_task_tool_gate ~(actionable_signal : bool)
+let actionable_signal_requires_tool_gate ~(actionable_signal : bool)
     ~(turn_affordances : string list)
     ~(allowed_tool_names : string list) =
   actionable_signal
@@ -479,8 +479,8 @@ let generic_required_tool_gate_guidance
     Printf.sprintf
       "[TOOL BLOCKED] This turn has an actionable runtime signal, but no \
        currently visible keeper tool can advance it. Do not call passive \
-       reads/status, claim/context tools, or keeper_stay_silent merely to \
-       satisfy the contract. Emit a concise [STATE] blocker instead."
+       reads/status or keeper_stay_silent merely to satisfy the contract. \
+       Emit a concise [STATE] blocker instead."
   else
     Printf.sprintf
       "[TOOL REQUIRED] This turn has an actionable runtime signal. Before \

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -374,9 +374,19 @@ let generic_required_actionable_tool_names
     && tool_name_can_satisfy_actionable_gate ~claim_context_allowed name
     && not (is_stay_silent name)
   in
-  preferred_tool_names_for_turn_affordances turn_affordances
-  |> List.filter can_recommend_tool
-  |> Keeper_types_profile_toml_normalizers.dedupe_keep_order
+  let recommended =
+    preferred_tool_names_for_turn_affordances turn_affordances
+    |> List.filter can_recommend_tool
+    |> Keeper_types_profile_toml_normalizers.dedupe_keep_order
+  in
+  match recommended with
+  | _ :: _ -> recommended
+  | [] ->
+    turn_affordances
+    |> List.filter_map turn_affordance_of_string
+    |> List.concat_map tools_for_gated_affordance
+    |> List.filter can_recommend_tool
+    |> Keeper_types_profile_toml_normalizers.dedupe_keep_order
 
 let preferred_tool_choice_for_required_turn
     ~(claim_context_allowed : bool)

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -131,9 +131,6 @@ type tool_surface_metrics =
   ; visible_tool_count : int
   ; tool_gate_enabled : bool
   ; tool_surface_fallback_used : bool
-  ; required_tool_names : string list
-  ; required_tool_candidate_names : string list
-  ; missing_required_tool_names : string list
   ; config_root : string
   ; runtime_config_path : string option
   ; gemini_mcp_disabled : bool
@@ -160,9 +157,6 @@ type computed_tool_surface =
   ; tool_gate_requested : bool
   ; claim_context_allowed : bool
   ; tool_surface_fallback_used : bool
-  ; required_tool_names : string list
-  ; required_tool_candidate_names : string list
-  ; missing_required_tool_names : string list
   ; lane : turn_lane
   ; query_text : string
   }
@@ -209,11 +203,10 @@ let turn_affordances_require_tool_gate turn_affordances =
 
 (* Affordance -> minimum viable tools that can satisfy that affordance.
    The list is intentionally narrow ("at least one of these is enough").
-   Keepers without any matching tool cannot satisfy a [Require_tool_use]
-   contract for that affordance and must be allowed to respond with text
-   instead. [Task_claim] is advisory: visible claimable backlog is an intake
-   opportunity, not proof that this keeper must take new work before responding
-   to stronger live signals. *)
+   Keepers without any matching tool cannot advance that actionable gate and
+   must be allowed to respond with text instead. [Task_claim] is advisory:
+   visible claimable backlog is an intake opportunity, not proof that this
+   keeper must take new work before responding to stronger live signals. *)
 let tools_for_gated_affordance = function
   | Board_curation ->
     [ "keeper_board_curation_submit" ]
@@ -223,7 +216,8 @@ let tools_for_gated_affordance = function
   | Task_claim ->
     [ "keeper_task_claim"; "masc_claim_next" ]
   | Task_audit ->
-    [ "keeper_tasks_audit"; "keeper_task_force_release"; "keeper_tasks_list"; "masc_tasks" ]
+    [ "keeper_tasks_audit"; "keeper_task_force_release"; "keeper_task_force_done";
+      "keeper_tasks_list"; "masc_tasks" ]
   | Task_verify ->
     [ "keeper_tasks_list"; "keeper_tasks_audit";
       "keeper_task_done"; "keeper_task_submit_for_verification";
@@ -261,7 +255,8 @@ let preferred_tool_names_for_turn_affordances turn_affordances =
        | Task_claim ->
          [ "keeper_task_claim"; "masc_claim_next" ]
        | Task_audit ->
-         [ "keeper_tasks_audit"; "keeper_task_force_release" ]
+         [ "keeper_tasks_audit"; "keeper_task_force_release";
+           "keeper_task_force_done" ]
        | Task_verify ->
          [ "keeper_task_submit_for_verification"; "keeper_task_done";
            "masc_transition" ]
@@ -323,31 +318,18 @@ let turn_affordances_require_tool_gate_with_allowed
       gated_affordances;
   gate_requested
 
-let tool_names_for_required_gate_surface
-    ~(tool_gate_requested : bool)
-    ~(required_tool_names : string list)
+let tool_names_for_actionable_gate_surface ~(tool_gate_requested : bool)
     (tool_names : string list) : string list =
   let is_stay_silent name =
     String.equal (Keeper_tool_resolution.canonical_tool_name name) "keeper_stay_silent"
-  in
-  let canonical_required_tool_names =
-    required_tool_names
-    |> List.map Keeper_tool_resolution.canonical_tool_name
-    |> Keeper_types_profile_toml_normalizers.dedupe_keep_order
-  in
-  let is_explicit_required_tool_name name =
-    List.mem
-      (Keeper_tool_resolution.canonical_tool_name name)
-      canonical_required_tool_names
   in
   if not tool_gate_requested then tool_names
   else
     let actionable =
       tool_names
       |> List.filter (fun name ->
-        is_explicit_required_tool_name name
-        || (Keeper_tool_progress.tool_name_can_satisfy_required_contract name
-            && not (is_stay_silent name)))
+        Keeper_tool_progress.tool_name_can_satisfy_required_contract name
+        && not (is_stay_silent name))
       |> Keeper_types_profile_toml_normalizers.dedupe_keep_order
     in
     match actionable with
@@ -372,7 +354,7 @@ let has_turn_affordance expected turn_affordances =
 
 let has_task_claim_affordance = has_turn_affordance Task_claim
 
-let generic_required_actionable_tool_names
+let actionable_gate_tool_names
     ~(claim_context_allowed : bool)
     ~(turn_affordances : string list) ~(allowed_tool_names : string list) =
   let is_stay_silent name =
@@ -399,7 +381,7 @@ let generic_required_actionable_tool_names
     |> List.filter can_recommend_tool
     |> Keeper_types_profile_toml_normalizers.dedupe_keep_order
 
-let preferred_tool_choice_for_required_turn
+let preferred_tool_choice_for_actionable_gate
     ~(claim_context_allowed : bool)
     ~(turn_affordances : string list) ~(allowed_tool_names : string list) =
   let progress_tool_available name =
@@ -407,7 +389,7 @@ let preferred_tool_choice_for_required_turn
     && tool_name_can_satisfy_actionable_gate ~claim_context_allowed name
   in
   let actionable_tool_names =
-    generic_required_actionable_tool_names
+    actionable_gate_tool_names
       ~claim_context_allowed
       ~turn_affordances
       ~allowed_tool_names
@@ -462,32 +444,23 @@ let preferred_tool_choice_for_required_turn
     | Some tool_choice -> tool_choice
     | None -> Agent_sdk.Types.Any)
 
-let generic_required_tool_candidate_names
-    ~(claim_context_allowed : bool)
-    ~(turn_affordances : string list) ~(allowed_tool_names : string list) =
-  generic_required_actionable_tool_names
-    ~claim_context_allowed
-    ~turn_affordances
-    ~allowed_tool_names
-;;
-
 let actionable_signal_requires_tool_gate ~(actionable_signal : bool)
     ~(claim_context_allowed : bool)
     ~(turn_affordances : string list)
     ~(allowed_tool_names : string list) =
   actionable_signal
-  && generic_required_actionable_tool_names
+  && actionable_gate_tool_names
        ~claim_context_allowed
        ~turn_affordances
        ~allowed_tool_names
      <> []
 ;;
 
-let generic_required_tool_gate_guidance
+let actionable_tool_gate_guidance
     ~(claim_context_allowed : bool)
     ~(turn_affordances : string list) ~(allowed_tool_names : string list) =
   let actionable_tools =
-    generic_required_tool_candidate_names
+    actionable_gate_tool_names
       ~claim_context_allowed
       ~turn_affordances
       ~allowed_tool_names
@@ -504,11 +477,11 @@ let generic_required_tool_gate_guidance
     Printf.sprintf
       "[TOOL BLOCKED] This turn has an actionable runtime signal, but no \
        currently visible keeper tool can advance it. Do not call passive \
-       reads/status or keeper_stay_silent merely to satisfy the contract. \
+       reads/status or keeper_stay_silent merely to satisfy the gate. \
        Emit a concise [STATE] blocker instead."
   else
     Printf.sprintf
-      "[TOOL REQUIRED] This turn has an actionable runtime signal. Before \
+      "[ACTIONABLE TOOL] This turn has an actionable runtime signal. Before \
        answering in natural language, call one of the currently visible keeper \
        runtime tools. Preferred tools for this signal: %s%s. Passive \
        reads/status alone do not satisfy this turn."
@@ -584,7 +557,7 @@ let preferred_tool_choice_for_required_tool_names
        legacy internal MCP names; OAS exact-tool contracts
        compare raw names before MASC can canonicalize them, so exact Tool(name)
        can reject a correct call. MASC still validates the specific required
-       names after execution via [outstanding_required_tool_names]. *)
+    names after execution via [outstanding_required_tool_names]. *)
     Agent_sdk.Types.Any
   | [] -> Agent_sdk.Types.Auto
 

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -274,7 +274,9 @@ let tool_name_can_satisfy_actionable_gate ~(claim_context_allowed : bool) name =
     Keeper_tool_progress.is_claim_context_tool_name name
     || (Keeper_tool_progress.tool_name_can_satisfy_required_contract name
         && not (Keeper_tool_progress.is_completion_tool_name name))
-  else Keeper_tool_progress.is_owned_task_progress_tool_name name
+  else
+    (not (Keeper_tool_progress.is_claim_context_tool_name name))
+    && Keeper_tool_progress.is_owned_task_progress_tool_name name
 
 (* Filtered variant of [turn_affordances_require_tool_gate]:  a gated
    affordance only counts when the keeper actually has a tool that can

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -269,11 +269,22 @@ let preferred_tool_names_for_turn_affordances turn_affordances =
   |> Keeper_types_profile_toml_normalizers.dedupe_keep_order
 
 let tool_name_can_satisfy_actionable_gate ~(claim_context_allowed : bool) name =
+  let is_operator_cleanup_completion_tool name =
+    match
+      name
+      |> Keeper_tool_resolution.canonical_tool_name
+      |> Tool_name.of_string
+    with
+    | Some (Tool_name.Keeper Tool_name.Keeper.Task_force_done)
+    | Some (Tool_name.Keeper Tool_name.Keeper.Task_force_release) -> true
+    | _ -> false
+  in
   if claim_context_allowed
   then
     Keeper_tool_progress.is_claim_context_tool_name name
     || (Keeper_tool_progress.tool_name_can_satisfy_required_contract name
-        && not (Keeper_tool_progress.is_completion_tool_name name))
+        && (not (Keeper_tool_progress.is_completion_tool_name name)
+            || is_operator_cleanup_completion_tool name))
   else
     (not (Keeper_tool_progress.is_claim_context_tool_name name))
     && Keeper_tool_progress.is_owned_task_progress_tool_name name

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -301,7 +301,6 @@ let turn_affordances_require_tool_gate_with_allowed
   gate_requested
 
 let tool_names_for_required_gate_surface
-    ?(has_current_task : bool = false)
     ~(tool_gate_requested : bool)
     ~(required_tool_names : string list)
     (tool_names : string list) : string list =
@@ -325,9 +324,7 @@ let tool_names_for_required_gate_surface
       |> List.filter (fun name ->
         is_explicit_required_tool_name name
         || (Keeper_tool_progress.tool_name_can_satisfy_required_contract name
-            && not (is_stay_silent name)
-            && ((not has_current_task)
-                || not (Keeper_tool_progress.is_claim_context_tool_name name))))
+            && not (is_stay_silent name)))
       |> Keeper_types_profile_toml_normalizers.dedupe_keep_order
     in
     match actionable with
@@ -352,7 +349,7 @@ let has_turn_affordance expected turn_affordances =
 
 let has_task_claim_affordance = has_turn_affordance Task_claim
 
-let generic_required_actionable_tool_names ~(has_current_task : bool)
+let generic_required_actionable_tool_names
     ~(turn_affordances : string list) ~(allowed_tool_names : string list) =
   let is_stay_silent name =
     String.equal
@@ -363,8 +360,6 @@ let generic_required_actionable_tool_names ~(has_current_task : bool)
     List.mem name allowed_tool_names
     && Keeper_tool_progress.tool_name_can_satisfy_required_contract name
     && not (is_stay_silent name)
-    && ((not has_current_task)
-        || not (Keeper_tool_progress.is_claim_context_tool_name name))
   in
   let preferred =
     preferred_tool_names_for_turn_affordances turn_affordances
@@ -378,7 +373,7 @@ let generic_required_actionable_tool_names ~(has_current_task : bool)
     |> List.filter can_recommend_tool
     |> Keeper_types_profile_toml_normalizers.dedupe_keep_order
 
-let preferred_tool_choice_for_required_turn ~(has_current_task : bool)
+let preferred_tool_choice_for_required_turn
     ~(turn_affordances : string list) ~(allowed_tool_names : string list) =
   let is_stay_silent name =
     String.equal
@@ -393,13 +388,11 @@ let preferred_tool_choice_for_required_turn ~(has_current_task : bool)
     List.exists
       (fun name ->
          progress_tool_available name
-         && (not (is_stay_silent name))
-         && ((not has_current_task)
-             || not (Keeper_tool_progress.is_claim_context_tool_name name)))
+         && not (is_stay_silent name))
       allowed_tool_names
   in
   let actionable_tool_names =
-    generic_required_actionable_tool_names ~has_current_task ~turn_affordances
+    generic_required_actionable_tool_names ~turn_affordances
       ~allowed_tool_names
   in
   let exact_tool_choice_if_public = function
@@ -414,21 +407,10 @@ let preferred_tool_choice_for_required_turn ~(has_current_task : bool)
           progress_tool_available
           [ "keeper_board_curation_submit" ]
   then
-    (* Keep the curation submit tool visible, but do not force exact
-       tool_choice. Several keeper runtimes can use runtime MCP tools while
-       lacking inline exact-tool-choice support; exact forcing turns those
-       productive lanes into spurious pause-human failures. *)
     Agent_sdk.Types.Any
-  else if (not has_current_task)
-     && has_task_claim_affordance turn_affordances
-     && progress_tool_available "keeper_task_claim"
+  else if has_task_claim_affordance turn_affordances
+          && progress_tool_available "keeper_task_claim"
   then
-    (* Runtime MCP transports may report the correct call as
-       [mcp__masc__keeper_task_claim]. OAS exact-tool contracts compare
-       raw provider names before MASC canonicalizes them, so exact
-       [Tool "keeper_task_claim"] can reject a valid claim. Keep the
-       turn tool-required and let MASC validate the canonical observed
-       tool names after execution. *)
     Agent_sdk.Types.Any
   else if has_turn_affordance Board_post_or_comment turn_affordances
           && List.exists
@@ -450,67 +432,38 @@ let preferred_tool_choice_for_required_turn ~(has_current_task : bool)
   else if has_turn_affordance Task_verify turn_affordances
           && progress_tool_available "masc_transition"
   then Agent_sdk.Types.Any
-  else if has_current_task
-          && has_turn_affordance Task_verify turn_affordances
+  else if has_turn_affordance Task_verify turn_affordances
           && progress_tool_available "keeper_task_submit_for_verification"
   then Agent_sdk.Types.Any
-  else if has_current_task
-          && has_turn_affordance Task_verify turn_affordances
+  else if has_turn_affordance Task_verify turn_affordances
           && progress_tool_available "keeper_task_done"
   then Agent_sdk.Types.Any
-  else if not has_current_task then
-    (* #10008: no active task and no applicable specific claim tool
-       to force.  Fall back to [Auto] instead of [Any] so the model
-       can respond with an honest refusal ("no eligible task to
-       claim", "no matching affordance to exercise") without
-       triggering the [Require_tool_use] contract violation.  The
-       caller ([Keeper_agent_run]) reads [tool_choice = Auto] as
-       "MASC dropped the specific-tool demand" and relaxes the
-       completion contract to [Allow_text_or_tool].  Otherwise the
-       affordance-driven gate would self-contradict — force a tool
-       call when no applicable tool exists. *)
-    Agent_sdk.Types.Auto
   else if not executable_progress_tool_available then
-    (* Active-task gates are intentionally strict only when at least one
-       executable progress tool is actually visible.  Claim/stay_silent
-       tools cannot advance an already-owned task, so forcing [Any] here
-       creates an impossible contract and burns a retry. *)
     Agent_sdk.Types.Auto
   else (
     match exact_tool_choice_if_public actionable_tool_names with
     | Some tool_choice -> tool_choice
-    | None ->
-      (* Active task in progress: keep the strict gate.  The keeper is
-         expected to make progress via some tool call (board update,
-         task_update, task_done, etc.). *)
-      Agent_sdk.Types.Any)
+    | None -> Agent_sdk.Types.Any)
 
-let generic_required_tool_candidate_names ~(has_current_task : bool)
+let generic_required_tool_candidate_names
     ~(turn_affordances : string list) ~(allowed_tool_names : string list) =
-  let actionable_tools =
-    generic_required_actionable_tool_names ~has_current_task ~turn_affordances
-      ~allowed_tool_names
-  in
-  actionable_tools
+  generic_required_actionable_tool_names ~turn_affordances ~allowed_tool_names
 ;;
 
 let actionable_signal_requires_active_task_tool_gate ~(actionable_signal : bool)
-    ~(has_current_task : bool) ~(turn_affordances : string list)
+    ~(turn_affordances : string list)
     ~(allowed_tool_names : string list) =
   actionable_signal
-  && has_current_task
   && generic_required_actionable_tool_names
-       ~has_current_task
        ~turn_affordances
        ~allowed_tool_names
      <> []
 ;;
 
-let generic_required_tool_gate_guidance ~(has_current_task : bool)
+let generic_required_tool_gate_guidance
     ~(turn_affordances : string list) ~(allowed_tool_names : string list) =
   let actionable_tools =
     generic_required_tool_candidate_names
-      ~has_current_task
       ~turn_affordances
       ~allowed_tool_names
   in
@@ -521,28 +474,21 @@ let generic_required_tool_gate_guidance ~(has_current_task : bool)
   in
   let omitted = List.length actionable_tools - min 6 (List.length actionable_tools) in
   let suffix = if omitted > 0 then Printf.sprintf " (+%d more)" omitted else "" in
-  let claim_context_note =
-    if has_current_task
-    then " You already hold an active task; claim/context tools alone do not count as execution progress."
-    else ""
-  in
   if String.equal preview ""
   then
     Printf.sprintf
       "[TOOL BLOCKED] This turn has an actionable runtime signal, but no \
        currently visible keeper tool can advance it. Do not call passive \
        reads/status, claim/context tools, or keeper_stay_silent merely to \
-       satisfy the contract.%s Emit a concise [STATE] blocker instead."
-      claim_context_note
+       satisfy the contract. Emit a concise [STATE] blocker instead."
   else
     Printf.sprintf
       "[TOOL REQUIRED] This turn has an actionable runtime signal. Before \
        answering in natural language, call one of the currently visible keeper \
        runtime tools. Preferred tools for this signal: %s%s. Passive \
-       reads/status alone do not satisfy this turn.%s"
+       reads/status alone do not satisfy this turn."
       preview
       suffix
-      claim_context_note
 
 let required_tool_names_for_turn ~(current_task_required_tool_names : string list)
     ~(per_call_required_tool_names : string list) =

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -158,6 +158,7 @@ type computed_tool_surface =
   ; tool_surface_class : tool_surface_class
   ; tool_requirement : tool_requirement
   ; tool_gate_requested : bool
+  ; claim_context_allowed : bool
   ; tool_surface_fallback_used : bool
   ; required_tool_names : string list
   ; required_tool_candidate_names : string list
@@ -267,6 +268,14 @@ let preferred_tool_names_for_turn_affordances turn_affordances =
        )
   |> Keeper_types_profile_toml_normalizers.dedupe_keep_order
 
+let tool_name_can_satisfy_actionable_gate ~(claim_context_allowed : bool) name =
+  if claim_context_allowed
+  then
+    Keeper_tool_progress.is_claim_context_tool_name name
+    || (Keeper_tool_progress.tool_name_can_satisfy_required_contract name
+        && not (Keeper_tool_progress.is_completion_tool_name name))
+  else Keeper_tool_progress.is_owned_task_progress_tool_name name
+
 (* Filtered variant of [turn_affordances_require_tool_gate]:  a gated
    affordance only counts when the keeper actually has a tool that can
    satisfy it.  Without this filter, narrow tool_access lists (which
@@ -275,12 +284,13 @@ let preferred_tool_names_for_turn_affordances turn_affordances =
    [Failure_run_error] turns the keeper cannot resolve. *)
 let turn_affordances_require_tool_gate_with_allowed
     ?(record_suppression_metric = false)
+    ~(claim_context_allowed : bool)
     ~(allowed_tool_names : string list) turn_affordances : bool =
   let has_matching_tool affordance =
     List.exists
       (fun tool ->
          List.mem tool allowed_tool_names
-         && Keeper_tool_progress.tool_name_can_satisfy_required_contract tool)
+         && tool_name_can_satisfy_actionable_gate ~claim_context_allowed tool)
       (tools_for_gated_affordance affordance)
   in
   let gated_affordances =
@@ -350,6 +360,7 @@ let has_turn_affordance expected turn_affordances =
 let has_task_claim_affordance = has_turn_affordance Task_claim
 
 let generic_required_actionable_tool_names
+    ~(claim_context_allowed : bool)
     ~(turn_affordances : string list) ~(allowed_tool_names : string list) =
   let is_stay_silent name =
     String.equal
@@ -358,41 +369,24 @@ let generic_required_actionable_tool_names
   in
   let can_recommend_tool name =
     List.mem name allowed_tool_names
-    && Keeper_tool_progress.tool_name_can_satisfy_required_contract name
+    && tool_name_can_satisfy_actionable_gate ~claim_context_allowed name
     && not (is_stay_silent name)
   in
-  let preferred =
-    preferred_tool_names_for_turn_affordances turn_affordances
-    |> List.filter can_recommend_tool
-    |> Keeper_types_profile_toml_normalizers.dedupe_keep_order
-  in
-  match preferred with
-  | _ :: _ -> preferred
-  | [] ->
-    allowed_tool_names
-    |> List.filter can_recommend_tool
-    |> Keeper_types_profile_toml_normalizers.dedupe_keep_order
+  preferred_tool_names_for_turn_affordances turn_affordances
+  |> List.filter can_recommend_tool
+  |> Keeper_types_profile_toml_normalizers.dedupe_keep_order
 
 let preferred_tool_choice_for_required_turn
+    ~(claim_context_allowed : bool)
     ~(turn_affordances : string list) ~(allowed_tool_names : string list) =
-  let is_stay_silent name =
-    String.equal
-      (Keeper_tool_resolution.canonical_tool_name name)
-      "keeper_stay_silent"
-  in
   let progress_tool_available name =
     List.mem name allowed_tool_names
-    && Keeper_tool_progress.tool_name_can_satisfy_required_contract name
-  in
-  let executable_progress_tool_available =
-    List.exists
-      (fun name ->
-         progress_tool_available name
-         && not (is_stay_silent name))
-      allowed_tool_names
+    && tool_name_can_satisfy_actionable_gate ~claim_context_allowed name
   in
   let actionable_tool_names =
-    generic_required_actionable_tool_names ~turn_affordances
+    generic_required_actionable_tool_names
+      ~claim_context_allowed
+      ~turn_affordances
       ~allowed_tool_names
   in
   let exact_tool_choice_if_public = function
@@ -438,7 +432,7 @@ let preferred_tool_choice_for_required_turn
   else if has_turn_affordance Task_verify turn_affordances
           && progress_tool_available "keeper_task_done"
   then Agent_sdk.Types.Any
-  else if not executable_progress_tool_available then
+  else if actionable_tool_names = [] then
     Agent_sdk.Types.Auto
   else (
     match exact_tool_choice_if_public actionable_tool_names with
@@ -446,24 +440,32 @@ let preferred_tool_choice_for_required_turn
     | None -> Agent_sdk.Types.Any)
 
 let generic_required_tool_candidate_names
+    ~(claim_context_allowed : bool)
     ~(turn_affordances : string list) ~(allowed_tool_names : string list) =
-  generic_required_actionable_tool_names ~turn_affordances ~allowed_tool_names
+  generic_required_actionable_tool_names
+    ~claim_context_allowed
+    ~turn_affordances
+    ~allowed_tool_names
 ;;
 
 let actionable_signal_requires_tool_gate ~(actionable_signal : bool)
+    ~(claim_context_allowed : bool)
     ~(turn_affordances : string list)
     ~(allowed_tool_names : string list) =
   actionable_signal
   && generic_required_actionable_tool_names
+       ~claim_context_allowed
        ~turn_affordances
        ~allowed_tool_names
      <> []
 ;;
 
 let generic_required_tool_gate_guidance
+    ~(claim_context_allowed : bool)
     ~(turn_affordances : string list) ~(allowed_tool_names : string list) =
   let actionable_tools =
     generic_required_tool_candidate_names
+      ~claim_context_allowed
       ~turn_affordances
       ~allowed_tool_names
   in

--- a/lib/keeper/keeper_agent_tool_surface.mli
+++ b/lib/keeper/keeper_agent_tool_surface.mli
@@ -177,15 +177,11 @@ val turn_affordances_require_tool_gate_with_allowed :
     progress when such tools exist. Passive status/read tools remain visible on
     optional turns and on surfaces that have no actionable alternative.
 
-    When [has_current_task] is true, claim/context tools are not treated as
-    actionable alternatives because the keeper already owns active work.
-
     Explicit [required_tool_names] are preserved even when they are read-only:
     operator/harness calls such as [masc_keeper_msg.required_tools =
     ["masc_web_search"]] are a direct evidence contract, not a generic
     actionable-world-signal gate. *)
 val tool_names_for_required_gate_surface :
-  ?has_current_task:bool ->
   tool_gate_requested:bool ->
   required_tool_names:string list ->
   string list ->
@@ -201,17 +197,14 @@ val has_turn_affordance : turn_affordance -> string list -> bool
 val has_task_claim_affordance : string list -> bool
 
 (** Ordered executable candidates for generic required-tool gates.
-    Claim/context tools are excluded when the keeper already owns active work,
-    and passive status/read tools are never recommended. *)
+    Passive status/read tools and stay_silent are never recommended. *)
 val generic_required_actionable_tool_names :
-  has_current_task:bool ->
   turn_affordances:string list ->
   allowed_tool_names:string list ->
   string list
 
 (** Pick the schema-visible [tool_choice] when the gate fires. *)
 val preferred_tool_choice_for_required_turn :
-  has_current_task:bool ->
   turn_affordances:string list ->
   allowed_tool_names:string list ->
   Agent_sdk.Types.tool_choice
@@ -220,7 +213,6 @@ val preferred_tool_choice_for_required_turn :
     turns, where no explicit [required_tool_names] exist but the runtime still
     requires a keeper tool call. *)
 val generic_required_tool_gate_guidance :
-  has_current_task:bool ->
   turn_affordances:string list ->
   allowed_tool_names:string list ->
   string
@@ -230,17 +222,14 @@ val generic_required_tool_gate_guidance :
     generic gate with any execution-progress tool, while this list explains
     the preferred candidates exposed to the model/operator. *)
 val generic_required_tool_candidate_names :
-  has_current_task:bool ->
   turn_affordances:string list ->
   allowed_tool_names:string list ->
   string list
 
-(** Whether an owned active task plus an actionable world signal should promote
-    the turn to the same generic required-tool gate that post-run validation
-    already enforces. *)
+(** Whether an actionable world signal should promote the turn to the same
+    generic required-tool gate that post-run validation already enforces. *)
 val actionable_signal_requires_active_task_tool_gate :
   actionable_signal:bool ->
-  has_current_task:bool ->
   turn_affordances:string list ->
   allowed_tool_names:string list ->
   bool

--- a/lib/keeper/keeper_agent_tool_surface.mli
+++ b/lib/keeper/keeper_agent_tool_surface.mli
@@ -93,9 +93,6 @@ type tool_surface_metrics =
   ; visible_tool_count : int
   ; tool_gate_enabled : bool
   ; tool_surface_fallback_used : bool
-  ; required_tool_names : string list
-  ; required_tool_candidate_names : string list
-  ; missing_required_tool_names : string list
   ; config_root : string
   ; runtime_config_path : string option
   ; gemini_mcp_disabled : bool
@@ -124,9 +121,6 @@ type computed_tool_surface =
   ; tool_gate_requested : bool
   ; claim_context_allowed : bool
   ; tool_surface_fallback_used : bool
-  ; required_tool_names : string list
-  ; required_tool_candidate_names : string list
-  ; missing_required_tool_names : string list
   ; lane : turn_lane
   ; query_text : string
   }
@@ -154,8 +148,7 @@ val tools_for_gated_affordance : turn_affordance -> string list
 
 (** Compute the satisfying tools for a set of turn affordances,
     intersected with [allowed_tool_names] and deduplicated.
-    Used to provide actionable alternatives in required-tool contract
-    violation messages. *)
+    Used to provide actionable alternatives in retry messages. *)
 val satisfying_tools_for_turn :
   turn_affordances:string list -> allowed_tool_names:string list -> string list
 
@@ -177,19 +170,12 @@ val turn_affordances_require_tool_gate_with_allowed :
   -> string list
   -> bool
 
-(** On a required-action turn, trim the visible surface to tools that can make
-    progress when such tools exist. Passive status/read tools remain visible on
-    optional turns and on surfaces that have no actionable alternative.
-
-    Explicit [required_tool_names] are preserved even when they are read-only:
-    operator/harness calls such as [masc_keeper_msg.required_tools =
-    ["masc_web_search"]] are a direct evidence contract, not a generic
-    actionable-world-signal gate. *)
-val tool_names_for_required_gate_surface :
-  tool_gate_requested:bool ->
-  required_tool_names:string list ->
-  string list ->
-  string list
+(** On an actionable-tool-gated turn, trim the visible surface to tools that can
+    make progress when such tools exist. Passive status/read tools remain
+    visible on optional turns and on surfaces that have no actionable
+    alternative. *)
+val tool_names_for_actionable_gate_surface :
+  tool_gate_requested:bool -> string list -> string list
 
 (** Whether the very first turn of a multi-turn slot should require
     a tool call. *)
@@ -200,45 +186,32 @@ val has_turn_affordance : turn_affordance -> string list -> bool
 
 val has_task_claim_affordance : string list -> bool
 
-(** Ordered executable candidates for generic required-tool gates,
-    filtered by the current claim context. Passive status/read tools and
-    stay_silent are never recommended. Preferred affordance tools are returned
-    first; if none are visible, candidates fall back to other visible tools
-    that can satisfy the gated affordance. *)
-val generic_required_actionable_tool_names :
+(** Ordered executable tools for actionable gates, filtered by the current claim
+    context. Passive status/read tools and stay_silent are never recommended.
+    Preferred affordance tools are returned first; if none are visible, tools
+    fall back to other visible tools that can satisfy the gated affordance. *)
+val actionable_gate_tool_names :
   claim_context_allowed:bool ->
   turn_affordances:string list ->
   allowed_tool_names:string list ->
   string list
 
-(** Pick the schema-visible [tool_choice] when the gate fires. *)
-val preferred_tool_choice_for_required_turn :
+(** Pick the schema-visible [tool_choice] when the actionable gate fires. *)
+val preferred_tool_choice_for_actionable_gate :
   claim_context_allowed:bool ->
   turn_affordances:string list ->
   allowed_tool_names:string list ->
   Agent_sdk.Types.tool_choice
 
-(** Human-readable instruction for generic affordance-driven required-tool
-    turns, where no explicit [required_tool_names] exist but the runtime still
-    requires a keeper tool call. *)
-val generic_required_tool_gate_guidance :
+(** Human-readable instruction for affordance-driven actionable-tool gates. *)
+val actionable_tool_gate_guidance :
   claim_context_allowed:bool ->
   turn_affordances:string list ->
   allowed_tool_names:string list ->
   string
 
-(** Candidate tools a generic required-tool gate can recommend. This is
-    distinct from explicit [required_tool_names]: callers may satisfy a
-    generic gate with any execution-progress tool, while this list explains
-    the preferred candidates exposed to the model/operator. *)
-val generic_required_tool_candidate_names :
-  claim_context_allowed:bool ->
-  turn_affordances:string list ->
-  allowed_tool_names:string list ->
-  string list
-
 (** Whether an actionable world signal should promote the turn to the same
-    generic required-tool gate that post-run validation already enforces. *)
+    actionable-tool gate that post-run validation already checks. *)
 val actionable_signal_requires_tool_gate :
   actionable_signal:bool ->
   claim_context_allowed:bool ->

--- a/lib/keeper/keeper_agent_tool_surface.mli
+++ b/lib/keeper/keeper_agent_tool_surface.mli
@@ -228,7 +228,7 @@ val generic_required_tool_candidate_names :
 
 (** Whether an actionable world signal should promote the turn to the same
     generic required-tool gate that post-run validation already enforces. *)
-val actionable_signal_requires_active_task_tool_gate :
+val actionable_signal_requires_tool_gate :
   actionable_signal:bool ->
   turn_affordances:string list ->
   allowed_tool_names:string list ->

--- a/lib/keeper/keeper_agent_tool_surface.mli
+++ b/lib/keeper/keeper_agent_tool_surface.mli
@@ -202,7 +202,9 @@ val has_task_claim_affordance : string list -> bool
 
 (** Ordered executable candidates for generic required-tool gates,
     filtered by the current claim context. Passive status/read tools and
-    stay_silent are never recommended. *)
+    stay_silent are never recommended. Preferred affordance tools are returned
+    first; if none are visible, candidates fall back to other visible tools
+    that can satisfy the gated affordance. *)
 val generic_required_actionable_tool_names :
   claim_context_allowed:bool ->
   turn_affordances:string list ->

--- a/lib/keeper/keeper_agent_tool_surface.mli
+++ b/lib/keeper/keeper_agent_tool_surface.mli
@@ -122,6 +122,7 @@ type computed_tool_surface =
   ; tool_surface_class : tool_surface_class
   ; tool_requirement : tool_requirement
   ; tool_gate_requested : bool
+  ; claim_context_allowed : bool
   ; tool_surface_fallback_used : bool
   ; required_tool_names : string list
   ; required_tool_candidate_names : string list
@@ -164,11 +165,14 @@ val preferred_tool_names_for_turn_affordances : string list -> string list
 
 (** Like [turn_affordances_require_tool_gate] but only fires when at
     least one of the gating affordance's tools is in
-    [allowed_tool_names] and can satisfy the required-tool contract.
-    Passive read/status tools may still be visible, but they cannot be
-    the sole reason to force [Require_tool_use]. *)
+    [allowed_tool_names] and can satisfy the current claim-context.
+    Claim/context tools only satisfy the gate while claim context is
+    allowed; owned-task turns require owned-task progress tools. Passive
+    read/status tools may still be visible, but they cannot be the sole
+    reason to force [Require_tool_use]. *)
 val turn_affordances_require_tool_gate_with_allowed :
      ?record_suppression_metric:bool
+  -> claim_context_allowed:bool
   -> allowed_tool_names:string list
   -> string list
   -> bool
@@ -196,15 +200,18 @@ val has_turn_affordance : turn_affordance -> string list -> bool
 
 val has_task_claim_affordance : string list -> bool
 
-(** Ordered executable candidates for generic required-tool gates.
-    Passive status/read tools and stay_silent are never recommended. *)
+(** Ordered executable candidates for generic required-tool gates,
+    filtered by the current claim context. Passive status/read tools and
+    stay_silent are never recommended. *)
 val generic_required_actionable_tool_names :
+  claim_context_allowed:bool ->
   turn_affordances:string list ->
   allowed_tool_names:string list ->
   string list
 
 (** Pick the schema-visible [tool_choice] when the gate fires. *)
 val preferred_tool_choice_for_required_turn :
+  claim_context_allowed:bool ->
   turn_affordances:string list ->
   allowed_tool_names:string list ->
   Agent_sdk.Types.tool_choice
@@ -213,6 +220,7 @@ val preferred_tool_choice_for_required_turn :
     turns, where no explicit [required_tool_names] exist but the runtime still
     requires a keeper tool call. *)
 val generic_required_tool_gate_guidance :
+  claim_context_allowed:bool ->
   turn_affordances:string list ->
   allowed_tool_names:string list ->
   string
@@ -222,6 +230,7 @@ val generic_required_tool_gate_guidance :
     generic gate with any execution-progress tool, while this list explains
     the preferred candidates exposed to the model/operator. *)
 val generic_required_tool_candidate_names :
+  claim_context_allowed:bool ->
   turn_affordances:string list ->
   allowed_tool_names:string list ->
   string list
@@ -230,6 +239,7 @@ val generic_required_tool_candidate_names :
     generic required-tool gate that post-run validation already enforces. *)
 val actionable_signal_requires_tool_gate :
   actionable_signal:bool ->
+  claim_context_allowed:bool ->
   turn_affordances:string list ->
   allowed_tool_names:string list ->
   bool

--- a/lib/keeper/keeper_run_tools.mli
+++ b/lib/keeper/keeper_run_tools.mli
@@ -119,7 +119,6 @@ val prepare_agent_setup
   -> runtime_id:string
   -> is_retry:bool
   -> turn_affordances:string list
-  -> required_tool_names:string list
   -> config_root:string
   -> runtime_config_path:string option
   -> gemini_mcp_disabled:bool

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -424,6 +424,7 @@ let assemble_hooks
                     append_ctx
                       ctx
                       (generic_required_tool_gate_guidance
+                         ~claim_context_allowed:computed_surface.claim_context_allowed
                          ~turn_affordances
                          ~allowed_tool_names:computed_surface.turn_visible_tool_names)
                   else if is_retry
@@ -458,10 +459,7 @@ let assemble_hooks
                   if acc.contract_violation_retries > 0
                   then
                     let satisfying_tools =
-                      Keeper_agent_tool_surface
-                      .generic_required_tool_candidate_names
-                        ~turn_affordances
-                        ~allowed_tool_names:computed_surface.turn_visible_tool_names
+                      computed_surface.required_tool_candidate_names
                     in
                     let preview =
                       satisfying_tools
@@ -525,6 +523,7 @@ let assemble_hooks
                   then
                     Some
                       (preferred_tool_choice_for_required_turn
+                         ~claim_context_allowed:computed_surface.claim_context_allowed
                          ~turn_affordances
                          ~allowed_tool_names:turn_visible_tool_names)
                   else clear_inherited_strict_tool_choice current_params.tool_choice

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -76,7 +76,6 @@ let assemble_hooks
       ~(runtime_id_string : string)
       ~(is_retry : bool)
       ~(turn_affordances : string list)
-      ~(required_tool_names : string list)
       ~(config_root : string)
       ~(runtime_config_path : string option)
       ~(gemini_mcp_disabled : bool)
@@ -127,10 +126,6 @@ let assemble_hooks
          List.length initial_tool_surface.turn_visible_tool_names
      ; tool_gate_enabled = initial_tool_surface.tool_gate_requested
      ; tool_surface_fallback_used = initial_tool_surface.tool_surface_fallback_used
-     ; required_tool_names = initial_tool_surface.required_tool_names
-     ; required_tool_candidate_names =
-         initial_tool_surface.required_tool_candidate_names
-     ; missing_required_tool_names = initial_tool_surface.missing_required_tool_names
      ; config_root
      ; runtime_config_path
      ; gemini_mcp_disabled
@@ -139,22 +134,7 @@ let assemble_hooks
      };
   let initial_tool_surface_blocker = ref None in
   let initial_tool_surface_result =
-    if initial_tool_surface.missing_required_tool_names <> []
-    then (
-      acc.receipt_tool_contract_result <-
-        Keeper_execution_receipt.Contract_tool_surface_mismatch;
-      initial_tool_surface_blocker
-      := Some
-           (sdk_error_of_keeper_internal_error
-              (Keeper_tool_surface_mismatch
-                 { keeper_name = meta.name
-                 ; required_tools = initial_tool_surface.required_tool_names
-                 ; missing_required_tools =
-                     initial_tool_surface.missing_required_tool_names
-                 ; visible_tools = initial_tool_surface.turn_visible_tool_names
-                 }));
-      Ok initial_tool_surface)
-    else if
+    if
       initial_tool_surface.tool_gate_requested
       && initial_tool_surface.turn_visible_tool_names = []
     then (
@@ -378,20 +358,7 @@ let assemble_hooks
                      | Some e -> e ^ "\n\n" ^ text)
                 in
                 let ctx =
-                  if
-                    computed_surface.is_last_turn
-                    && computed_surface.required_tool_names <> []
-                  then
-                    append_ctx
-                      ctx
-                      (Printf.sprintf
-                         "[REQUIRED TOOLS - FINAL TURN] This Agent.run call is on its \
-                          final turn, but this message has explicit required_tools: %s. \
-                          You MUST either use every required tool now or return a \
-                          concise blocker naming the missing policy/tool/runtime \
-                          condition."
-                         (String.concat ", " computed_surface.required_tool_names))
-                  else if computed_surface.is_last_turn
+                  if computed_surface.is_last_turn
                   then
                     append_ctx
                       ctx
@@ -409,21 +376,11 @@ let assemble_hooks
                           keeper_task_submit_for_verification."
                          computed_surface.per_call_turn
                          computed_surface.per_call_max_turns)
-                  else if computed_surface.required_tool_names <> []
-                  then
-                    append_ctx
-                      ctx
-                      (Printf.sprintf
-                         "[REQUIRED TOOLS] This Agent.run call has explicit \
-                          required_tools: %s. You MUST use these exact runtime tools \
-                          before answering in natural language. Do not substitute a \
-                          shell command or status read for a listed required tool."
-                         (String.concat ", " computed_surface.required_tool_names))
                   else if computed_surface.tool_gate_requested
                   then
                     append_ctx
                       ctx
-                      (generic_required_tool_gate_guidance
+                      (actionable_tool_gate_guidance
                          ~claim_context_allowed:computed_surface.claim_context_allowed
                          ~turn_affordances
                          ~allowed_tool_names:computed_surface.turn_visible_tool_names)
@@ -451,17 +408,19 @@ let assemble_hooks
                          computed_surface.per_call_max_turns)
                   else ctx
                 in
-                (* Contract violation retry feedback: when a previous
-                   Agent.run attempt was rejected for not calling
-                   required tools, inject explicit guidance naming the
-                   satisfying tools so the model knows what to do. *)
+                (* Retry feedback: if a previous attempt ignored an actionable
+                   gate, name the visible progress tools for this turn without
+                   storing a separate tool-contract surface. *)
                 let ctx =
                   if acc.contract_violation_retries > 0
                   then
                     let satisfying_tools =
-                      match computed_surface.required_tool_names with
-                      | _ :: _ -> computed_surface.required_tool_names
-                      | [] -> computed_surface.required_tool_candidate_names
+                      actionable_gate_tool_names
+                        ~claim_context_allowed:
+                          computed_surface.claim_context_allowed
+                        ~turn_affordances
+                        ~allowed_tool_names:
+                          computed_surface.turn_visible_tool_names
                     in
                     let preview =
                       satisfying_tools
@@ -471,7 +430,7 @@ let assemble_hooks
                     let retry_action =
                       if preview = ""
                       then
-                        "No currently visible tool can satisfy this contract; \
+                        "No currently visible keeper tool can advance this gate; \
                          emit a concise blocker instead."
                       else
                         Printf.sprintf
@@ -481,9 +440,9 @@ let assemble_hooks
                     append_ctx
                       ctx
                       (Printf.sprintf
-                         "[CONTRACT VIOLATION RETRY] Your previous Agent.run \
-                          attempt was rejected because you did not call a \
-                          required tool. %s Do NOT respond with text only, do NOT substitute \
+                         "[ACTIONABLE TOOL RETRY] Your previous Agent.run \
+                          attempt did not make keeper-tool progress for an \
+                          actionable gate. %s Do NOT respond with text only, do NOT substitute \
                           status or read-only tools."
                          retry_action)
                   else ctx
@@ -511,36 +470,21 @@ let assemble_hooks
                 in
                 let tool_choice =
                   if
-                    computed_surface.required_tool_names <> []
-                    && turn_visible_tool_names <> []
-                  then
-                    Some
-                      (preferred_tool_choice_for_required_tool_names
-                         ~required_tool_names:computed_surface.required_tool_names
-                         ~allowed_tool_names:turn_visible_tool_names)
-                  else if
                     (not computed_surface.is_last_turn)
                     && computed_surface.tool_gate_requested
                     && turn_visible_tool_names <> []
                   then
                     Some
-                      (preferred_tool_choice_for_required_turn
+                      (preferred_tool_choice_for_actionable_gate
                          ~claim_context_allowed:computed_surface.claim_context_allowed
                          ~turn_affordances
                          ~allowed_tool_names:turn_visible_tool_names)
                   else clear_inherited_strict_tool_choice current_params.tool_choice
                 in
                 let turn_completion_contract =
-                  match computed_surface.tool_gate_requested, tool_choice with
-                  | true, Some Agent_sdk.Types.Auto ->
-                    Keeper_tool_completion_contract.completion_contract_of_tool_choice tool_choice
-                  | true, _ -> Keeper_tool_completion_contract.Require_tool_use
-                  | false, _ ->
-                    Keeper_tool_completion_contract.completion_contract_of_tool_choice tool_choice
+                  Keeper_tool_completion_contract.Allow_text_or_tool
                 in
                 acc.completion_contract <- turn_completion_contract;
-                if turn_completion_contract = Keeper_tool_completion_contract.Require_tool_use
-                then acc.required_tool_use_seen <- true;
                 let lane = computed_surface.lane in
                 Keeper_run_tools_hook_accumulator.record_requested_tool_names
                   acc
@@ -553,11 +497,6 @@ let assemble_hooks
                    ; tool_gate_enabled = computed_surface.tool_gate_requested
                    ; tool_surface_fallback_used =
                        computed_surface.tool_surface_fallback_used
-                   ; required_tool_names = computed_surface.required_tool_names
-                   ; required_tool_candidate_names =
-                       computed_surface.required_tool_candidate_names
-                   ; missing_required_tool_names =
-                       computed_surface.missing_required_tool_names
                    ; config_root
                    ; runtime_config_path
                    ; gemini_mcp_disabled
@@ -602,10 +541,6 @@ let assemble_hooks
                     (Keeper_agent_tool_surface.tool_surface_class_to_string
                        computed_surface.tool_surface_class)
                   ~visible_tool_count:(List.length turn_visible_tool_names)
-                  ~required_tools:computed_surface.required_tool_names
-                  ~required_tool_candidates:
-                    computed_surface.required_tool_candidate_names
-                  ~missing_required_tools:computed_surface.missing_required_tool_names
                   ~runtime_profile:runtime_id_string
                   ();
                 (let now = Time_compat.now () in

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -95,7 +95,6 @@ let assemble_hooks
   let compute_tool_surface = ctx.compute_tool_surface in
   let config = ctx.config in
   let keeper_tool_bundle = ctx.keeper_tool_bundle in
-  let keeper_has_owned_active_task = ctx.keeper_has_owned_active_task in
   let manifest_keeper_turn_id = ctx.manifest_keeper_turn_id in
   let meta = ctx.meta in
   let reported_tool_names_ref = ctx.reported_tool_names_ref in
@@ -425,7 +424,6 @@ let assemble_hooks
                     append_ctx
                       ctx
                       (generic_required_tool_gate_guidance
-                         ~has_current_task:(keeper_has_owned_active_task ())
                          ~turn_affordances
                          ~allowed_tool_names:computed_surface.turn_visible_tool_names)
                   else if is_retry
@@ -462,7 +460,6 @@ let assemble_hooks
                     let satisfying_tools =
                       Keeper_agent_tool_surface
                       .generic_required_tool_candidate_names
-                        ~has_current_task:(keeper_has_owned_active_task ())
                         ~turn_affordances
                         ~allowed_tool_names:computed_surface.turn_visible_tool_names
                     in
@@ -528,7 +525,6 @@ let assemble_hooks
                   then
                     Some
                       (preferred_tool_choice_for_required_turn
-                         ~has_current_task:(keeper_has_owned_active_task ())
                          ~turn_affordances
                          ~allowed_tool_names:turn_visible_tool_names)
                   else clear_inherited_strict_tool_choice current_params.tool_choice

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -459,7 +459,9 @@ let assemble_hooks
                   if acc.contract_violation_retries > 0
                   then
                     let satisfying_tools =
-                      computed_surface.required_tool_candidate_names
+                      match computed_surface.required_tool_names with
+                      | _ :: _ -> computed_surface.required_tool_names
+                      | [] -> computed_surface.required_tool_candidate_names
                     in
                     let preview =
                       satisfying_tools

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -440,9 +440,9 @@ let assemble_hooks
                     append_ctx
                       ctx
                       (Printf.sprintf
-                         "[ACTIONABLE TOOL RETRY] Your previous Agent.run \
-                          attempt did not make keeper-tool progress for an \
-                          actionable gate. %s Do NOT respond with text only, do NOT substitute \
+                         "[TOOL CONTRACT RETRY] Your previous Agent.run \
+                          attempt was rejected for returning text without \
+                          calling a required keeper tool. %s Do NOT respond with text only, do NOT substitute \
                           status or read-only tools."
                          retry_action)
                   else ctx

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -770,12 +770,10 @@ let prepare_agent_setup
         ~labels:[ "keeper", meta.name ]
         ()
     else ();
-    let has_current_task = keeper_has_owned_active_task () in
     let active_task_actionable_tool_gate_requested =
       (not is_last_turn)
       && actionable_signal_requires_active_task_tool_gate
            ~actionable_signal
-           ~has_current_task
            ~turn_affordances
            ~allowed_tool_names:turn_visible_tool_names
     in
@@ -789,7 +787,6 @@ let prepare_agent_setup
     in
     let turn_visible_tool_names =
       tool_names_for_required_gate_surface
-        ~has_current_task
         ~tool_gate_requested
         ~required_tool_names
         turn_visible_tool_names
@@ -810,7 +807,6 @@ let prepare_agent_setup
       if tool_gate_requested && required_tool_names = []
       then
         generic_required_tool_candidate_names
-          ~has_current_task
           ~turn_affordances
           ~allowed_tool_names:turn_visible_tool_names
       else []

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -489,7 +489,8 @@ let prepare_agent_setup
   let fallback_tool_surface ~turn =
     validate_allow_list ~turn fallback_floor_tool_names
   in
-  let tool_gate_requested_for_turn ~current_tool_choice ~is_last_turn ~allowed_tool_names =
+  let tool_gate_requested_for_turn ~current_tool_choice ~is_last_turn
+      ~claim_context_allowed ~allowed_tool_names =
     let caller_requires_tools =
       (* Enumerate every [tool_choice] variant + [None] so a new constructor
          added to [Agent_sdk.Types.tool_choice] surfaces a Warning 8 here.
@@ -507,6 +508,7 @@ let prepare_agent_setup
     && (caller_requires_tools
         || turn_affordances_require_tool_gate_with_allowed
              ~record_suppression_metric:true
+             ~claim_context_allowed
              ~allowed_tool_names
              turn_affordances)
   in
@@ -721,6 +723,7 @@ let prepare_agent_setup
     let per_call_turn = turn - start_turn_count in
     let is_last_turn = per_call_turn >= max_turns in
     let is_warning_zone = per_call_turn >= max_turns - 1 in
+    let claim_context_allowed = not (keeper_has_owned_active_task ()) in
     let turn_visible_tool_names, tool_surface_fallback_used =
       if turn_visible_tool_names = []
       then (
@@ -774,6 +777,7 @@ let prepare_agent_setup
       (not is_last_turn)
       && actionable_signal_requires_tool_gate
            ~actionable_signal
+           ~claim_context_allowed
            ~turn_affordances
            ~allowed_tool_names:turn_visible_tool_names
     in
@@ -783,6 +787,7 @@ let prepare_agent_setup
       || tool_gate_requested_for_turn
            ~current_tool_choice
            ~is_last_turn
+           ~claim_context_allowed
            ~allowed_tool_names:turn_visible_tool_names
     in
     let turn_visible_tool_names =
@@ -807,6 +812,7 @@ let prepare_agent_setup
       if tool_gate_requested && required_tool_names = []
       then
         generic_required_tool_candidate_names
+          ~claim_context_allowed
           ~turn_affordances
           ~allowed_tool_names:turn_visible_tool_names
       else []
@@ -854,6 +860,7 @@ let prepare_agent_setup
     ; tool_surface_class
     ; tool_requirement
     ; tool_gate_requested
+    ; claim_context_allowed
     ; tool_surface_fallback_used
     ; required_tool_names
     ; required_tool_candidate_names

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -28,7 +28,6 @@ let prepare_agent_setup
       ~(runtime_id : string)
       ~(is_retry : bool)
       ~(turn_affordances : string list)
-      ~(required_tool_names : string list)
       ~(config_root : string)
       ~(runtime_config_path : string option)
       ~(gemini_mcp_disabled : bool)
@@ -87,9 +86,6 @@ let prepare_agent_setup
         ; visible_tool_count = 0
         ; tool_gate_enabled = false
         ; tool_surface_fallback_used = false
-        ; required_tool_names = []
-        ; required_tool_candidate_names = []
-        ; missing_required_tool_names = []
         ; config_root
         ; runtime_config_path
         ; gemini_mcp_disabled
@@ -512,11 +508,6 @@ let prepare_agent_setup
              ~allowed_tool_names
              turn_affordances)
   in
-  let satisfied_required_tool_names () =
-    acc.tool_calls
-    |> List.map (fun (detail : tool_call_detail) -> detail.tool_name, detail.outcome)
-    |> satisfied_required_tool_names_of_outcomes
-  in
   let compute_tool_surface
         ~turn
         ~messages
@@ -666,27 +657,6 @@ let prepare_agent_setup
         ~llm_selected
         ~discovered
     in
-    let required_tool_names_raw =
-      required_tool_names_for_turn
-        ~current_task_required_tool_names:[]
-        ~per_call_required_tool_names:required_tool_names
-      |> List.map Keeper_tool_resolution.canonical_tool_name
-      |> Keeper_types_profile_toml_normalizers.dedupe_keep_order
-    in
-    let required_tool_names =
-      outstanding_required_tool_names
-        ~required_tool_names:required_tool_names_raw
-        ~satisfied_tool_names:(satisfied_required_tool_names ())
-    in
-    let current_tool_choice =
-      match current_tool_choice with
-      | Some (Agent_sdk.Types.Any | Agent_sdk.Types.Tool _)
-        when required_tool_names_raw <> [] && required_tool_names = [] -> None
-      | _ -> current_tool_choice
-    in
-    let visible_required_tool_names =
-      required_tool_names |> validate_allow_list ~turn |> Keeper_types_profile_toml_normalizers.dedupe_keep_order
-    in
     let visible_affordance_tool_names =
       preferred_tool_names_for_turn_affordances turn_affordances
       |> filter_visible_policy_surface
@@ -694,7 +664,7 @@ let prepare_agent_setup
     in
     let merged =
       Keeper_types_profile_toml_normalizers.dedupe_keep_order
-        (merged @ visible_required_tool_names @ visible_affordance_tool_names)
+        (merged @ visible_affordance_tool_names)
     in
     let selection_mode : Keeper_agent_tool_surface.tool_selection_mode =
       if llm_rerank_enabled
@@ -744,7 +714,7 @@ let prepare_agent_setup
     in
     let safe_last_turn_tools = last_turn_safe @ descriptor_safe_public_names in
     let turn_visible_tool_names =
-      if is_last_turn && required_tool_names = []
+      if is_last_turn
       then
         Agent_sdk.Tool_op.apply
           (Agent_sdk.Tool_op.Intersect_with safe_last_turn_tools)
@@ -782,8 +752,7 @@ let prepare_agent_setup
            ~allowed_tool_names:turn_visible_tool_names
     in
     let tool_gate_requested =
-      required_tool_names <> []
-      || actionable_signal_tool_gate_requested
+      actionable_signal_tool_gate_requested
       || tool_gate_requested_for_turn
            ~current_tool_choice
            ~is_last_turn
@@ -791,31 +760,9 @@ let prepare_agent_setup
            ~allowed_tool_names:turn_visible_tool_names
     in
     let turn_visible_tool_names =
-      tool_names_for_required_gate_surface
+      tool_names_for_actionable_gate_surface
         ~tool_gate_requested
-        ~required_tool_names
         turn_visible_tool_names
-    in
-    let visible_canonical_tool_names =
-      turn_visible_tool_names
-      |> List.map Keeper_tool_resolution.canonical_tool_name
-      |> Keeper_types_profile_toml_normalizers.dedupe_keep_order
-    in
-    let missing_required_tool_names =
-      List.filter
-        (fun name ->
-           let canonical = Keeper_tool_resolution.canonical_tool_name name in
-           not (List.mem canonical visible_canonical_tool_names))
-        required_tool_names
-    in
-    let required_tool_candidate_names =
-      if tool_gate_requested && required_tool_names = []
-      then
-        generic_required_tool_candidate_names
-          ~claim_context_allowed
-          ~turn_affordances
-          ~allowed_tool_names:turn_visible_tool_names
-      else []
     in
     let visible_tool_count = List.length turn_visible_tool_names in
     let tool_surface_class : Keeper_agent_tool_surface.tool_surface_class =
@@ -862,9 +809,6 @@ let prepare_agent_setup
     ; tool_gate_requested
     ; claim_context_allowed
     ; tool_surface_fallback_used
-    ; required_tool_names
-    ; required_tool_candidate_names
-    ; missing_required_tool_names
     ; lane
     ; query_text
     }
@@ -899,7 +843,7 @@ let prepare_agent_setup
     ~history_messages ~prompt_metrics ~shared_context
     ~start_turn_count ~generation ~max_turns
     ~runtime_id_string ~is_retry ~turn_affordances
-    ~required_tool_names ~config_root ~runtime_config_path
+    ~config_root ~runtime_config_path
     ~gemini_mcp_disabled ~approval_mode_effective
     ~approval_mode_derived ~actionable_signal
     ?max_cost_usd ~trajectory_acc

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -770,16 +770,16 @@ let prepare_agent_setup
         ~labels:[ "keeper", meta.name ]
         ()
     else ();
-    let active_task_actionable_tool_gate_requested =
+    let actionable_signal_tool_gate_requested =
       (not is_last_turn)
-      && actionable_signal_requires_active_task_tool_gate
+      && actionable_signal_requires_tool_gate
            ~actionable_signal
            ~turn_affordances
            ~allowed_tool_names:turn_visible_tool_names
     in
     let tool_gate_requested =
       required_tool_names <> []
-      || active_task_actionable_tool_gate_requested
+      || actionable_signal_tool_gate_requested
       || tool_gate_requested_for_turn
            ~current_tool_choice
            ~is_last_turn

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -514,16 +514,6 @@ let keeper_schemas : tool_schema list = [
           ("type", `String "number");
           ("description", `String "Optional: overall timeout (sec) for this async keeper message request and its runtime turn");
         ]);
-        ("required_tools", `Assoc [
-          ("type", `String "array");
-          ("items", `Assoc [("type", `String "string")]);
-          ("description", `String "Optional: tool names that must be visible and used during this one keeper turn. Missing required tools surface as tool_surface_mismatch/missing_required_tool_use.");
-        ]);
-        ("required_tool_names", `Assoc [
-          ("type", `String "array");
-          ("items", `Assoc [("type", `String "string")]);
-          ("description", `String "Optional alias for required_tools. Tool names listed here must be visible and used during this one keeper turn.");
-        ]);
         ("no_skill_route", `Assoc [
           ("type", `String "boolean");
           ("description", `String "Optional: do not emit SKILL/SKILL_REASON headers in reply");

--- a/lib/keeper/keeper_tool_progress.ml
+++ b/lib/keeper/keeper_tool_progress.ml
@@ -270,7 +270,9 @@ let is_owned_task_progress_tool_name name =
   then false
   else (
     let name = Keeper_tool_resolution.canonical_tool_name name in
-    if is_completion_tool_name name
+    if is_claim_context_tool_name name
+    then false
+    else if is_completion_tool_name name
     then true
     else if Keeper_tool_capability_axis.supports Board_activity name
     then true

--- a/lib/keeper/keeper_tool_progress.mli
+++ b/lib/keeper/keeper_tool_progress.mli
@@ -100,6 +100,7 @@ val classify_tool_progress : string -> tool_progress_class
 
 val is_passive_status_tool_name : string -> bool
 val is_execution_progress_tool_name : string -> bool
+val is_owned_task_progress_tool_name : string -> bool
 
 (** Increment the [keeper_require_tool_use_violations] Prometheus counter with
     [keeper] / [has_current_task] / [contract_status] labels. *)

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -180,13 +180,6 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
     let no_state_block = get_bool args "no_state_block" false in
     let direct_reply = get_bool args "direct_reply" false in
     let channel_session_key = get_string_opt args "channel_session_key" in
-    let required_tool_names =
-      get_string_list args "required_tools"
-      @ get_string_list args "required_tool_names"
-      |> List.map String.trim
-      |> List.filter (fun name -> name <> "")
-      |> Keeper_types_profile_toml_normalizers.dedupe_keep_order
-    in
     (match keeper_msg_timeout_override args with
     | Error e -> tool_result_error e
     | Ok keeper_msg_oas_timeout_s ->
@@ -383,14 +376,6 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                 | Some ti ->
                   "--- Turn-specific instructions ---\n" ^ ti
               in
-              let required_tools_text =
-                match required_tool_names with
-                | [] -> ""
-                | tools ->
-                  "--- Required tools for this turn ---\n"
-                  ^ "Use all of these tools before your final reply: "
-                  ^ String.concat ", " tools
-              in
               let telemetry_feedback_text =
                 match meta.telemetry_feedback_enabled with
                 | Some true ->
@@ -418,8 +403,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                   skill_route_text;
                   worktree_text;
                   telemetry_feedback_text;
-                  turn_instructions_text;
-                  required_tools_text ]
+                  turn_instructions_text ]
               in
               let dynamic_context = String.concat "\n\n" soft_parts in
               (* === HARD CONSTRAINTS (stay in system_prompt) === *)
@@ -478,7 +462,6 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                       (                         (turn_runtime_id))
                     ~world_observation
                     ~turn_affordances
-                    ~required_tool_names
                     ?oas_timeout_s:keeper_msg_oas_timeout_s
                     ?provider_filter:(Env_config_keeper.KeeperRuntimeProviderFilter.provider_allowlist ())
                     ~generation:meta.runtime.generation

--- a/lib/keeper/keeper_unified_metrics_decision.ml
+++ b/lib/keeper/keeper_unified_metrics_decision.ml
@@ -286,16 +286,6 @@ let append_decision_record
                   ("tool_gate_enabled", `Bool r.tool_surface.tool_gate_enabled);
                   ( "tool_surface_fallback_used",
                     `Bool r.tool_surface.tool_surface_fallback_used );
-                  ( "required_tool_names",
-                    `List
-                      (List.map
-                         (fun name -> `String name)
-                         r.tool_surface.required_tool_names) );
-                  ( "missing_required_tool_names",
-                    `List
-                      (List.map
-                         (fun name -> `String name)
-                         r.tool_surface.missing_required_tool_names) );
                   ("config_root", `String r.tool_surface.config_root);
                   ( "runtime_config_path",
                     Json_util.string_opt_to_json r.tool_surface.runtime_config_path );

--- a/lib/keeper/keeper_unified_metrics_json_support.ml
+++ b/lib/keeper/keeper_unified_metrics_json_support.ml
@@ -87,22 +87,15 @@ let redacted_runtime_observation_to_json
 
 let tool_contract_json ~(tool_call_count : int) ~(tools_used : string list)
     (result : Keeper_agent_run.run_result option) =
-  let requirement, required_tool_names, missing_required_tool_names =
+  let requirement =
     match result with
-    | Some r ->
-        ( Some r.tool_surface.tool_requirement,
-          r.tool_surface.required_tool_names,
-          r.tool_surface.missing_required_tool_names )
-    | None -> (None, [], [])
+    | Some r -> Some r.tool_surface.tool_requirement
+    | None -> None
   in
   `Assoc
     [ ("requirement", match requirement with
       | Some r -> Keeper_agent_tool_surface.tool_requirement_to_yojson r
       | None -> `String "unknown")
-    ; ( "required_tool_names",
-        `List (List.map (fun value -> `String value) required_tool_names) )
-    ; ( "missing_required_tool_names",
-        `List (List.map (fun value -> `String value) missing_required_tool_names) )
     ; ("tool_call_count", `Int tool_call_count)
     ; ("tools_used", `List (List.map (fun value -> `String value) tools_used))
     ]

--- a/test/test_keeper_tool_exposure.ml
+++ b/test/test_keeper_tool_exposure.ml
@@ -498,7 +498,8 @@ let test_verifier_identity_uses_verdict_only_task_surface () =
 
 let test_task_audit_tool_choice_allows_cleanup_followup () =
   let allowed_tool_names =
-    [ "keeper_tasks_audit"; "keeper_task_force_release"; "keeper_tasks_list" ]
+    [ "keeper_tasks_audit"; "keeper_task_force_release"; "keeper_task_force_done";
+      "keeper_tasks_list" ]
   in
   let preferred =
     Keeper_agent_tool_surface.preferred_tool_names_for_turn_affordances [ "task_audit" ]
@@ -508,8 +509,13 @@ let test_task_audit_tool_choice_allows_cleanup_followup () =
     "task_audit force-includes force_release"
     true
     (has_tool "keeper_task_force_release" preferred);
+  check
+    bool
+    "task_audit force-includes force_done"
+    true
+    (has_tool "keeper_task_force_done" preferred);
   let choice =
-    Keeper_agent_tool_surface.preferred_tool_choice_for_required_turn
+    Keeper_agent_tool_surface.preferred_tool_choice_for_actionable_gate
       ~claim_context_allowed:false
       ~turn_affordances:[ "task_audit" ]
       ~allowed_tool_names

--- a/test/test_keeper_tool_exposure.ml
+++ b/test/test_keeper_tool_exposure.ml
@@ -510,7 +510,7 @@ let test_task_audit_tool_choice_allows_cleanup_followup () =
     (has_tool "keeper_task_force_release" preferred);
   let choice =
     Keeper_agent_tool_surface.preferred_tool_choice_for_required_turn
-      ~has_current_task:false
+      ~claim_context_allowed:false
       ~turn_affordances:[ "task_audit" ]
       ~allowed_tool_names
   in

--- a/test/test_keeper_tool_surface_guard.ml
+++ b/test/test_keeper_tool_surface_guard.ml
@@ -236,11 +236,10 @@ let test_contract_filter_empty_input () =
 let test_active_task_actionable_signal_requests_gate () =
   check
     bool
-    "owned active task with executable tool requests gate"
+    "actionable signal with executable tool requests gate"
     true
     (Surface.actionable_signal_requires_active_task_tool_gate
        ~actionable_signal:true
-       ~has_current_task:true
        ~turn_affordances:[ "task_claim" ]
        ~allowed_tool_names:[ "Read"; "Grep"; "keeper_task_claim"; "Edit" ]);
   check
@@ -249,25 +248,22 @@ let test_active_task_actionable_signal_requests_gate () =
     false
     (Surface.actionable_signal_requires_active_task_tool_gate
        ~actionable_signal:false
-       ~has_current_task:true
        ~turn_affordances:[ "task_claim" ]
        ~allowed_tool_names:[ "Edit" ]);
   check
     bool
-    "no owned active task leaves claim intake ungated"
-    false
+    "actionable signal with claim tool requests gate"
+    true
     (Surface.actionable_signal_requires_active_task_tool_gate
        ~actionable_signal:true
-       ~has_current_task:false
        ~turn_affordances:[ "task_claim" ]
        ~allowed_tool_names:[ "keeper_task_claim"; "Edit" ]);
   check
     bool
-    "passive plus claim-only cannot advance owned active task"
-    false
+    "passive plus claim-only requests gate (claim is actionable)"
+    true
     (Surface.actionable_signal_requires_active_task_tool_gate
        ~actionable_signal:true
-       ~has_current_task:true
        ~turn_affordances:[ "task_claim" ]
        ~allowed_tool_names:[ "Read"; "Grep"; "keeper_task_claim" ])
 ;;
@@ -275,10 +271,9 @@ let test_active_task_actionable_signal_requests_gate () =
 let test_required_gate_surface_excludes_owned_task_claim_context () =
   check
     (list string)
-    "owned task gate keeps only execution progress tools"
-    [ "Edit"; "Write" ]
+    "gate keeps actionable tools including claim-context"
+    [ "keeper_task_claim"; "Edit"; "Write" ]
     (Surface.tool_names_for_required_gate_surface
-       ~has_current_task:true
        ~tool_gate_requested:true
        ~required_tool_names:[]
        [ "Read"; "Grep"; "keeper_task_claim"; "keeper_stay_silent"; "Edit"; "Write" ]);
@@ -287,7 +282,6 @@ let test_required_gate_surface_excludes_owned_task_claim_context () =
     "explicit required tool is preserved even when claim-like"
     [ "keeper_task_claim" ]
     (Surface.tool_names_for_required_gate_surface
-       ~has_current_task:true
        ~tool_gate_requested:true
        ~required_tool_names:[ "keeper_task_claim" ]
        [ "Read"; "keeper_task_claim" ])

--- a/test/test_keeper_tool_surface_guard.ml
+++ b/test/test_keeper_tool_surface_guard.ml
@@ -318,6 +318,14 @@ let test_generic_required_candidates_match_claim_context () =
        ~allowed_tool_names:[ "keeper_task_submit_for_verification"; "keeper_task_done" ]);
   check
     (list string)
+    "no-claim audit candidates keep operator cleanup completion"
+    [ "keeper_task_force_release" ]
+    (Surface.generic_required_tool_candidate_names
+       ~claim_context_allowed:true
+       ~turn_affordances:[ "task_audit" ]
+       ~allowed_tool_names:[ "keeper_task_force_release"; "keeper_task_force_done" ]);
+  check
+    (list string)
     "owned task candidates keep completion"
     [ "keeper_task_submit_for_verification" ]
     (Surface.generic_required_tool_candidate_names

--- a/test/test_keeper_tool_surface_guard.ml
+++ b/test/test_keeper_tool_surface_guard.ml
@@ -236,10 +236,11 @@ let test_contract_filter_empty_input () =
 let test_actionable_signal_requests_tool_gate () =
   check
     bool
-    "actionable signal with executable tool requests gate"
+    "claimable signal with claim tool requests gate"
     true
     (Surface.actionable_signal_requires_tool_gate
        ~actionable_signal:true
+       ~claim_context_allowed:true
        ~turn_affordances:[ "task_claim" ]
        ~allowed_tool_names:[ "Read"; "Grep"; "keeper_task_claim"; "Edit" ]);
   check
@@ -248,24 +249,81 @@ let test_actionable_signal_requests_tool_gate () =
     false
     (Surface.actionable_signal_requires_tool_gate
        ~actionable_signal:false
+       ~claim_context_allowed:true
        ~turn_affordances:[ "task_claim" ]
        ~allowed_tool_names:[ "Edit" ]);
   check
     bool
-    "actionable signal with claim tool requests gate"
-    true
+    "owned task does not request gate for claim-only tools"
+    false
     (Surface.actionable_signal_requires_tool_gate
        ~actionable_signal:true
+       ~claim_context_allowed:false
        ~turn_affordances:[ "task_claim" ]
-       ~allowed_tool_names:[ "keeper_task_claim"; "Edit" ]);
+       ~allowed_tool_names:[ "keeper_task_claim"; "masc_claim_next" ]);
   check
     bool
-    "passive plus claim-only requests gate (claim is actionable)"
+    "no-claim task verification does not require owned-task completion"
+    false
+    (Surface.actionable_signal_requires_tool_gate
+       ~actionable_signal:true
+       ~claim_context_allowed:true
+       ~turn_affordances:[ "task_verify" ]
+       ~allowed_tool_names:[ "keeper_task_submit_for_verification"; "keeper_task_done" ]);
+  check
+    bool
+    "owned task verification can require completion progress"
     true
     (Surface.actionable_signal_requires_tool_gate
        ~actionable_signal:true
+       ~claim_context_allowed:false
+       ~turn_affordances:[ "task_verify" ]
+       ~allowed_tool_names:[ "keeper_task_submit_for_verification" ]);
+  check
+    bool
+    "missing signal-specific tool does not fall back to workspace mutation"
+    false
+    (Surface.actionable_signal_requires_tool_gate
+       ~actionable_signal:true
+       ~claim_context_allowed:true
+       ~turn_affordances:[ "board_post_or_comment" ]
+       ~allowed_tool_names:[ "Edit"; "Write" ]);
+  check
+    bool
+    "board signal requests gate when board tool is visible"
+    true
+    (Surface.actionable_signal_requires_tool_gate
+       ~actionable_signal:true
+       ~claim_context_allowed:true
+       ~turn_affordances:[ "board_post_or_comment" ]
+       ~allowed_tool_names:[ "keeper_board_comment" ])
+;;
+
+let test_generic_required_candidates_match_claim_context () =
+  check
+    (list string)
+    "owned task candidates exclude claim context"
+    []
+    (Surface.generic_required_tool_candidate_names
+       ~claim_context_allowed:false
        ~turn_affordances:[ "task_claim" ]
-       ~allowed_tool_names:[ "Read"; "Grep"; "keeper_task_claim" ])
+       ~allowed_tool_names:[ "keeper_task_claim"; "masc_claim_next" ]);
+  check
+    (list string)
+    "no-claim candidates exclude owned-task completion"
+    []
+    (Surface.generic_required_tool_candidate_names
+       ~claim_context_allowed:true
+       ~turn_affordances:[ "task_verify" ]
+       ~allowed_tool_names:[ "keeper_task_submit_for_verification"; "keeper_task_done" ]);
+  check
+    (list string)
+    "owned task candidates keep completion"
+    [ "keeper_task_submit_for_verification" ]
+    (Surface.generic_required_tool_candidate_names
+       ~claim_context_allowed:false
+       ~turn_affordances:[ "task_verify" ]
+       ~allowed_tool_names:[ "keeper_task_submit_for_verification" ])
 ;;
 
 let test_required_gate_surface_keeps_actionable_claim_context () =
@@ -364,6 +422,10 @@ let () =
             "actionable signal requests tool gate"
             `Quick
             test_actionable_signal_requests_tool_gate
+        ; test_case
+            "generic candidates match claim context"
+            `Quick
+            test_generic_required_candidates_match_claim_context
         ; test_case
             "gate keeps actionable claim context"
             `Quick

--- a/test/test_keeper_tool_surface_guard.ml
+++ b/test/test_keeper_tool_surface_guard.ml
@@ -233,12 +233,12 @@ let test_contract_filter_empty_input () =
        [])
 ;;
 
-let test_active_task_actionable_signal_requests_gate () =
+let test_actionable_signal_requests_tool_gate () =
   check
     bool
     "actionable signal with executable tool requests gate"
     true
-    (Surface.actionable_signal_requires_active_task_tool_gate
+    (Surface.actionable_signal_requires_tool_gate
        ~actionable_signal:true
        ~turn_affordances:[ "task_claim" ]
        ~allowed_tool_names:[ "Read"; "Grep"; "keeper_task_claim"; "Edit" ]);
@@ -246,7 +246,7 @@ let test_active_task_actionable_signal_requests_gate () =
     bool
     "no actionable signal does not request gate"
     false
-    (Surface.actionable_signal_requires_active_task_tool_gate
+    (Surface.actionable_signal_requires_tool_gate
        ~actionable_signal:false
        ~turn_affordances:[ "task_claim" ]
        ~allowed_tool_names:[ "Edit" ]);
@@ -254,7 +254,7 @@ let test_active_task_actionable_signal_requests_gate () =
     bool
     "actionable signal with claim tool requests gate"
     true
-    (Surface.actionable_signal_requires_active_task_tool_gate
+    (Surface.actionable_signal_requires_tool_gate
        ~actionable_signal:true
        ~turn_affordances:[ "task_claim" ]
        ~allowed_tool_names:[ "keeper_task_claim"; "Edit" ]);
@@ -262,13 +262,13 @@ let test_active_task_actionable_signal_requests_gate () =
     bool
     "passive plus claim-only requests gate (claim is actionable)"
     true
-    (Surface.actionable_signal_requires_active_task_tool_gate
+    (Surface.actionable_signal_requires_tool_gate
        ~actionable_signal:true
        ~turn_affordances:[ "task_claim" ]
        ~allowed_tool_names:[ "Read"; "Grep"; "keeper_task_claim" ])
 ;;
 
-let test_required_gate_surface_excludes_owned_task_claim_context () =
+let test_required_gate_surface_keeps_actionable_claim_context () =
   check
     (list string)
     "gate keeps actionable tools including claim-context"
@@ -361,13 +361,13 @@ let () =
         ] )
     ; ( "required_gate"
       , [ test_case
-            "active task actionable signal requests gate"
+            "actionable signal requests tool gate"
             `Quick
-            test_active_task_actionable_signal_requests_gate
+            test_actionable_signal_requests_tool_gate
         ; test_case
-            "active task gate excludes claim context"
+            "gate keeps actionable claim context"
             `Quick
-            test_required_gate_surface_excludes_owned_task_claim_context
+            test_required_gate_surface_keeps_actionable_claim_context
         ] )
     ]
 ;;

--- a/test/test_keeper_tool_surface_guard.ml
+++ b/test/test_keeper_tool_surface_guard.ml
@@ -299,12 +299,12 @@ let test_actionable_signal_requests_tool_gate () =
        ~allowed_tool_names:[ "keeper_board_comment" ])
 ;;
 
-let test_generic_required_candidates_match_claim_context () =
+let test_actionable_gate_tools_match_claim_context () =
   check
     (list string)
     "owned task candidates exclude claim context"
     []
-    (Surface.generic_required_tool_candidate_names
+    (Surface.actionable_gate_tool_names
        ~claim_context_allowed:false
        ~turn_affordances:[ "task_claim" ]
        ~allowed_tool_names:[ "keeper_task_claim"; "masc_claim_next" ]);
@@ -312,15 +312,15 @@ let test_generic_required_candidates_match_claim_context () =
     (list string)
     "no-claim candidates exclude owned-task completion"
     []
-    (Surface.generic_required_tool_candidate_names
+    (Surface.actionable_gate_tool_names
        ~claim_context_allowed:true
        ~turn_affordances:[ "task_verify" ]
        ~allowed_tool_names:[ "keeper_task_submit_for_verification"; "keeper_task_done" ]);
   check
     (list string)
     "no-claim audit candidates keep operator cleanup completion"
-    [ "keeper_task_force_release" ]
-    (Surface.generic_required_tool_candidate_names
+    [ "keeper_task_force_release"; "keeper_task_force_done" ]
+    (Surface.actionable_gate_tool_names
        ~claim_context_allowed:true
        ~turn_affordances:[ "task_audit" ]
        ~allowed_tool_names:[ "keeper_task_force_release"; "keeper_task_force_done" ]);
@@ -328,39 +328,37 @@ let test_generic_required_candidates_match_claim_context () =
     (list string)
     "owned task candidates keep completion"
     [ "keeper_task_submit_for_verification" ]
-    (Surface.generic_required_tool_candidate_names
+    (Surface.actionable_gate_tool_names
        ~claim_context_allowed:false
        ~turn_affordances:[ "task_verify" ]
        ~allowed_tool_names:[ "keeper_task_submit_for_verification" ])
 ;;
 
-let test_generic_required_candidates_fall_back_to_satisfying_tools () =
+let test_actionable_gate_tools_fall_back_to_satisfying_tools () =
   check
     (list string)
     "board post falls back to broadcast tool"
     [ "masc_broadcast" ]
-    (Surface.generic_required_tool_candidate_names
+    (Surface.actionable_gate_tool_names
        ~claim_context_allowed:true
        ~turn_affordances:[ "board_post_or_comment" ]
        ~allowed_tool_names:[ "masc_broadcast" ])
 ;;
 
-let test_required_gate_surface_keeps_actionable_claim_context () =
+let test_actionable_gate_surface_keeps_actionable_tools () =
   check
     (list string)
     "gate keeps actionable tools including claim-context"
     [ "keeper_task_claim"; "Edit"; "Write" ]
-    (Surface.tool_names_for_required_gate_surface
+    (Surface.tool_names_for_actionable_gate_surface
        ~tool_gate_requested:true
-       ~required_tool_names:[]
        [ "Read"; "Grep"; "keeper_task_claim"; "keeper_stay_silent"; "Edit"; "Write" ]);
   check
     (list string)
-    "explicit required tool is preserved even when claim-like"
+    "actionable gate keeps claim-like progress tool"
     [ "keeper_task_claim" ]
-    (Surface.tool_names_for_required_gate_surface
+    (Surface.tool_names_for_actionable_gate_surface
        ~tool_gate_requested:true
-       ~required_tool_names:[ "keeper_task_claim" ]
        [ "Read"; "keeper_task_claim" ])
 ;;
 
@@ -436,23 +434,23 @@ let () =
         ; test_case "all passive: returns empty" `Quick test_contract_filter_all_passive
         ; test_case "empty input: empty output" `Quick test_contract_filter_empty_input
         ] )
-    ; ( "required_gate"
+    ; ( "actionable_gate"
       , [ test_case
             "actionable signal requests tool gate"
             `Quick
             test_actionable_signal_requests_tool_gate
         ; test_case
-            "generic candidates match claim context"
+            "tools match claim context"
             `Quick
-            test_generic_required_candidates_match_claim_context
+            test_actionable_gate_tools_match_claim_context
         ; test_case
-            "generic candidates fall back to satisfying tools"
+            "tools fall back to satisfying affordance tools"
             `Quick
-            test_generic_required_candidates_fall_back_to_satisfying_tools
+            test_actionable_gate_tools_fall_back_to_satisfying_tools
         ; test_case
             "gate keeps actionable claim context"
             `Quick
-            test_required_gate_surface_keeps_actionable_claim_context
+            test_actionable_gate_surface_keeps_actionable_tools
         ] )
     ]
 ;;

--- a/test/test_keeper_tool_surface_guard.ml
+++ b/test/test_keeper_tool_surface_guard.ml
@@ -326,6 +326,17 @@ let test_generic_required_candidates_match_claim_context () =
        ~allowed_tool_names:[ "keeper_task_submit_for_verification" ])
 ;;
 
+let test_generic_required_candidates_fall_back_to_satisfying_tools () =
+  check
+    (list string)
+    "board post falls back to broadcast tool"
+    [ "masc_broadcast" ]
+    (Surface.generic_required_tool_candidate_names
+       ~claim_context_allowed:true
+       ~turn_affordances:[ "board_post_or_comment" ]
+       ~allowed_tool_names:[ "masc_broadcast" ])
+;;
+
 let test_required_gate_surface_keeps_actionable_claim_context () =
   check
     (list string)
@@ -426,6 +437,10 @@ let () =
             "generic candidates match claim context"
             `Quick
             test_generic_required_candidates_match_claim_context
+        ; test_case
+            "generic candidates fall back to satisfying tools"
+            `Quick
+            test_generic_required_candidates_fall_back_to_satisfying_tools
         ; test_case
             "gate keeps actionable claim context"
             `Quick

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -614,8 +614,10 @@ let test_masc_keeper_msg_schema () =
             (List.mem_assoc "new_mid_goal" props);
           Alcotest.(check bool) "omits new_long_goal" false
             (List.mem_assoc "new_long_goal" props);
-          Alcotest.(check bool) "has required_tools" true
-            (List.mem_assoc "required_tools" props)
+          Alcotest.(check bool) "omits required_tools" false
+            (List.mem_assoc "required_tools" props);
+          Alcotest.(check bool) "omits required_tool_names" false
+            (List.mem_assoc "required_tool_names" props)
       | None -> Alcotest.fail "masc_keeper_msg missing properties"
 
 let test_masc_keeper_repair_schema () =


### PR DESCRIPTION
## What

1. Remove `has_current_task` parameter from 6 tool surface functions and all call sites. Tool visibility is now independent of task state.
2. Remove `satisfying_tools_for_violation` — duplicated tool guidance that hooks already inject. Simplify retry feedback message.

## Why

- Tools and tasks are orthogonal. Tool surface should not filter based on task state.
- `satisfying_tools_for_violation` merged OAS string-parsed tools with local candidates, but the hooks context builder already injects the same tool guidance when `contract_violation_retries > 0`. Triple redundancy: string parser + merge + retry message, all for information the hooks already provide.

## Changed

- `generic_required_actionable_tool_names` — removed claim-context filter
- `preferred_tool_choice_for_required_turn` — removed task-state branching
- `actionable_signal_requires_active_task_tool_gate` — removed task check
- `tool_names_for_required_gate_surface` — removed claim-context filter
- `satisfying_tools_for_violation` — deleted
- `run_with_single_retry` — removed `turn_affordances` param, simplified feedback
- `retry_feedback` — no longer embeds tool names (hooks handle that)

## Verification

- `dune build .` EXIT=0
- 27/27 tests pass (tool_surface_guard + unified_required_tools)
