### PR TITLE
feat(dashboard): edit keeper runtime id

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -1368,6 +1368,7 @@ describe('fetchKeeperConfig', () => {
         verify: 'true',
         selected_runtime_id: 'keeper_unified',
         selected_runtime_canonical: 'keeper_unified',
+        runtime_options: ['keeper_unified', 'runpod_mtp.qwen36-35b-a3b-mtp'],
       },
       compaction: {
         profile: 'balanced',
@@ -1485,6 +1486,7 @@ describe('fetchKeeperConfig', () => {
     expect(result.execution.verify).toBe(true)
     expect(result.execution.selected_runtime_id).toBe('keeper_unified')
     expect(result.execution.selected_runtime_canonical).toBe('keeper_unified')
+    expect(result.execution.runtime_options).toEqual(['keeper_unified', 'runpod_mtp.qwen36-35b-a3b-mtp'])
     expect(result.execution.per_provider_timeout_sec).toBe(12.5)
     expect(result.execution.per_provider_timeout_mode).toBe('override')
     expect(result.hooks?.destructive_check_tools).toEqual(['dynamic_boundary (Tool_dispatch.is_destructive)'])

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -2221,6 +2221,7 @@ function normalizeKeeperConfig(raw: unknown, requestedName: string): KeeperConfi
         asNullableString(execution.selected_runtime_canonical)
         ?? asNullableString(execution.selected_runtime_id)
         ?? '',
+      runtime_options: normalizeStringList(execution.runtime_options),
     },
     compaction: {
       profile: asNullableString(compaction.profile) ?? '(unknown compaction profile)',
@@ -2326,6 +2327,7 @@ export type SandboxNetworkMode = 'none' | 'inherit'
 export type SharedMemoryScope = 'disabled' | 'workspace'
 
 export type KeeperConfigUpdatePayload = {
+  runtime_id?: string
   active_goal_ids?: string[]
   allowed_paths?: string[]
   // Sandbox

--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -56,6 +56,7 @@ function makeKeeperConfig(overrides: Partial<KeeperConfig> = {}): KeeperConfig {
       verify: true,
       selected_runtime_id: 'tier-group.keeper_unified',
       selected_runtime_canonical: 'tier-group.keeper_unified',
+      runtime_options: ['tier-group.keeper_unified', 'tier.resilient_breaker'],
     },
     compaction: {
       profile: 'balanced',
@@ -285,6 +286,16 @@ describe('initRuntimeDraftFromConfig — sandbox fields', () => {
     expect(draft.network_mode).toBe('none')
   })
 
+  it('preserves runtime_id from config', () => {
+    const c = makeKeeperConfigForSandbox({
+      execution: {
+        selected_runtime_id: 'runpod_mtp.qwen36-35b-a3b-mtp',
+      } as KeeperConfig['execution'],
+    })
+    const draft = initRuntimeDraftFromConfig(c)
+    expect(draft.runtime_id).toBe('runpod_mtp.qwen36-35b-a3b-mtp')
+  })
+
   it('defaults sandbox fields when config is missing them', () => {
     const c = makeKeeperConfigForSandbox({
       sandbox_profile: undefined,
@@ -319,6 +330,18 @@ describe('buildRuntimePayload — sandbox diffing', () => {
     const payload = buildRuntimePayload(draftFrom(c), c)
     expect(payload.sandbox_profile).toBeUndefined()
     expect(payload.network_mode).toBeUndefined()
+  })
+
+  it('emits runtime_id when selected runtime changes', () => {
+    const c = makeKeeperConfigForSandbox({
+      execution: {
+        selected_runtime_id: 'tier-group.keeper_unified',
+      } as KeeperConfig['execution'],
+    })
+    const payload = buildRuntimePayload(draftFrom(c, {
+      runtime_id: 'runpod_mtp.qwen36-35b-a3b-mtp',
+    }), c)
+    expect(payload.runtime_id).toBe('runpod_mtp.qwen36-35b-a3b-mtp')
   })
 
   it('emits sandbox_profile when toggled on', () => {
@@ -497,7 +520,7 @@ describe('KeeperConfigPanel', () => {
     expect(mocks.fetchDashboardGoalsTree).toHaveBeenCalledTimes(1)
     expect(mocks.fetchRuntimeProfiles).not.toHaveBeenCalled()
     expect(container.textContent).toContain('편집 가능 범위')
-    expect(container.textContent).toContain('keeper_runtime.toml')
+    expect(container.textContent).toContain('keeper TOML')
     expect(container.textContent).toContain('Runtime 선택')
     expect(container.textContent).toContain('tier-group.keeper_unified')
     expect(container.textContent).toContain('/tmp/config/keepers/default.toml')
@@ -521,20 +544,44 @@ describe('KeeperConfigPanel', () => {
     expect(textareas[0]?.value).toContain('Ship stable keeper ops')
   })
 
-  it('renders runtime selection as read-only resolved config state', async () => {
+  it('patches runtime_id from the dashboard panel', async () => {
+    mocks.patchKeeperConfig.mockResolvedValueOnce(
+      makeKeeperConfig({
+        execution: {
+          ...makeKeeperConfig().execution,
+          selected_runtime_id: 'tier.resilient_breaker',
+          selected_runtime_canonical: 'tier.resilient_breaker',
+        },
+      }),
+    )
+
     render(html`<${KeeperConfigPanel} keeperName="keeper-sangsu" />`, container)
     await flush()
     await flush()
 
-    const runtimeSelect = Array.from(container.querySelectorAll('select')).find(
-      (select) => !select.getAttribute('aria-label'),
+    const runtimeSelect = container.querySelector('select[aria-label="runtime_id"]') as HTMLSelectElement | null
+    expect(runtimeSelect).not.toBeNull()
+    runtimeSelect!.value = 'tier.resilient_breaker'
+    runtimeSelect!.dispatchEvent(new Event('change', { bubbles: true }))
+    await flush()
+
+    const saveButton = Array.from(container.querySelectorAll('button')).find(button =>
+      button.textContent?.includes('런타임 설정 저장'),
     )
-    expect(runtimeSelect).toBeUndefined()
-    expect(container.textContent).toContain('선택 runtime')
+    saveButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flush()
+    await flush()
+
+    expect(mocks.patchKeeperConfig).toHaveBeenCalledWith(
+      'keeper-sangsu',
+      expect.objectContaining({
+        runtime_id: 'tier.resilient_breaker',
+      }),
+    )
+    expect(container.textContent).toContain('runtime_id')
     expect(container.textContent).toContain('tier-group.keeper_unified')
     expect(container.textContent).toContain('선택은 /tmp/config/keepers/default.toml 에서 관리됩니다.')
     expect(mocks.updateKeeperRuntime).not.toHaveBeenCalled()
-    expect(mocks.fetchKeeperConfig).toHaveBeenCalledTimes(1)
   })
 
   it('patches sandbox runtime controls from the dashboard panel', async () => {

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -117,6 +117,7 @@ function buildPayload(draft: EditDraft, orig: KeeperConfig): KeeperConfigUpdateP
 // Runtime config draft for sandbox/proactive/compaction/handoff inline editing
 
 export type RuntimeDraft = {
+  runtime_id: string
   sandbox_profile: SandboxProfile
   active_goal_ids: string[]
   network_mode: SandboxNetworkMode
@@ -150,6 +151,7 @@ export function coerceSharedMemoryScope(raw: string | undefined): SharedMemorySc
 
 export function initRuntimeDraftFromConfig(c: KeeperConfig): RuntimeDraft {
   return {
+    runtime_id: c.execution.selected_runtime_id ?? '',
     sandbox_profile: coerceSandboxProfile(c.sandbox_profile),
     active_goal_ids: c.workspace.active_goal_ids.length > 0
       ? c.workspace.active_goal_ids
@@ -176,6 +178,7 @@ export function buildRuntimePayload(draft: RuntimeDraft, orig: KeeperConfig): Ke
   const origActiveGoalIds = orig.workspace.active_goal_ids.length > 0
     ? orig.workspace.active_goal_ids
     : orig.active_goal_ids
+  if (draft.runtime_id.trim() !== (orig.execution.selected_runtime_id ?? '').trim()) payload.runtime_id = draft.runtime_id.trim()
   if (!sameStringArray(draft.active_goal_ids, origActiveGoalIds)) payload.active_goal_ids = draft.active_goal_ids
   if (JSON.stringify(newPaths) !== JSON.stringify(origPaths)) payload.allowed_paths = newPaths
   if (draft.sandbox_profile !== coerceSandboxProfile(orig.sandbox_profile)) payload.sandbox_profile = draft.sandbox_profile
@@ -569,6 +572,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
   const c = state.data
   const isEditing = editMode.value
   const isSaving = saving.value
+  const runtimeCanEdit = c.sources.default_source_kind === 'toml' && Boolean(c.sources.default_manifest_path)
 
   // Initialize runtime draft if not yet set
   if (!runtimeDraft.value) {
@@ -577,6 +581,14 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
   const rd = runtimeDraft.value
 
   const runtimeHasChanges = rd ? Object.keys(buildRuntimePayload(rd, c)).length > 0 : false
+  const runtimeOptions = rd
+    ? dedupeStrings([
+        rd.runtime_id,
+        c.execution.selected_runtime_id ?? '',
+        c.execution.selected_runtime_canonical ?? '',
+        ...(c.execution.runtime_options ?? []),
+      ])
+    : []
 
   async function saveRuntimeConfig() {
     if (!rd) return
@@ -720,7 +732,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
 
       <${Callout}
         title="편집 가능 범위"
-        body="여기서 저장되는 값은 keeper 프롬프트와 live override 계층입니다. 활성 런타임은 keeper별 설정이 아니라 resolved config root의 keeper_runtime.toml 해석 결과로 결정됩니다."
+        body="여기서 저장되는 값은 keeper 프롬프트, live override 계층, keeper TOML의 runtime_id입니다."
       />
 
       ${promptSection}
@@ -728,7 +740,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       <div class="mt-2">
         <${Callout}
           title="런타임 설정"
-          body="실행 범위 섹션에서 sandbox_profile, network_mode, allowed_paths를 저장할 수 있습니다. 프로액티브, 컴팩션, 핸드오프도 인라인 편집 가능하고, 소스/실행/런타임/조율은 읽기 전용입니다."
+          body="Runtime 선택, 실행 범위, 프로액티브, 컴팩션, 핸드오프를 인라인 편집할 수 있습니다. 레지스트리 상태와 소스 경로는 읽기 전용입니다."
         />
       </div>
 
@@ -738,7 +750,16 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
         body=${runtimeSelectionSummary(c)}
       />
       <${ConfigRow} label="기본 소스" value=${c.sources.default_source_kind || MISSING_DATA_DASH} />
-      <${ConfigRow} label="선택 runtime" value=${c.execution.selected_runtime_id || MISSING_DATA_DASH} />
+      ${rd && runtimeCanEdit ? html`
+        <${InlineSelectRow}
+          label="runtime_id"
+          value=${rd.runtime_id}
+          options=${runtimeOptions}
+          onChange=${(value: string) => updateRuntimeDraft('runtime_id', value)}
+        />
+      ` : html`
+        <${ConfigRow} label="선택 runtime" value=${c.execution.selected_runtime_id || MISSING_DATA_DASH} />
+      `}
       ${c.execution.selected_runtime_canonical
         && c.execution.selected_runtime_canonical !== c.execution.selected_runtime_id
         ? html`<${ConfigRow}

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -1211,6 +1211,7 @@ interface KeeperConfigExecution {
   verify: boolean
   selected_runtime_id: string
   selected_runtime_canonical: string
+  runtime_options: string[]
   runtime_ref?: RuntimeRef | null
 }
 

--- a/lib/dashboard/dashboard_http_keeper_snapshot.ml
+++ b/lib/dashboard/dashboard_http_keeper_snapshot.ml
@@ -245,6 +245,17 @@ let keeper_config_json (config : Workspace.config) (name : string)
         ]
       in
       let runtime_id = Keeper_meta_contract.runtime_id_of_meta m in
+      let runtime_options =
+        let catalog =
+          Runtime.get_runtime_ids ()
+          |> List.map String.trim
+          |> List.filter (fun id -> id <> "")
+        in
+        let with_current =
+          if List.mem runtime_id catalog then catalog else runtime_id :: catalog
+        in
+        List.sort_uniq String.compare with_current
+      in
       (* RFC-0149 §3.3 — Result-returning resolver: on [Error] the
          canonical field surfaces as JSON [null] (parse-don't-validate
          honest signal) instead of the silent [Keeper_turn] rewrite the
@@ -260,6 +271,8 @@ let keeper_config_json (config : Workspace.config) (name : string)
           ("selected_runtime_id", `String runtime_id);
           ( "selected_runtime_canonical",
             selected_runtime_canonical_json );
+          ( "runtime_options",
+            `List (List.map (fun id -> `String id) runtime_options) );
           ("models", `List []);
           ("active_model", `Null);
           ("active_model_label", `Null);

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -41,6 +41,30 @@ let paused_state_requires_approval (old : keeper_meta) =
   Keeper_approval_queue.has_pending_for_keeper ~keeper_name:old.name
   || blocker_requires_continue_gate old
 
+let persist_runtime_id_if_requested (p : parsed_args) =
+  match p.runtime_id_opt with
+  | None -> Ok ()
+  | Some runtime_id ->
+      (match Config_dir_resolver.keeper_toml_path_opt p.name with
+       | None ->
+           Error
+             (Printf.sprintf
+                "runtime_id update for %s requires an existing keeper TOML"
+                p.name)
+       | Some path ->
+           (match
+              Keeper_toml_loader.update_keeper_toml_field ~path
+                ~key:"runtime_id" ~value:runtime_id
+            with
+            | Error err ->
+                Error
+                  (Printf.sprintf "runtime_id update failed for %s: %s"
+                     p.name err)
+            | Ok () ->
+                Keeper_types_profile.invalidate_keeper_profile_defaults_cache
+                  p.name;
+                Ok ()))
+
 let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool_result =
   match resolve_active_goal_ids ctx.config p old.active_goal_ids with
   | Error msg -> tool_result_error msg
@@ -326,6 +350,9 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
              p.name err;
            tool_result_error err
        | Ok () ->
+      (match persist_runtime_id_if_requested p with
+       | Error err -> tool_result_error err
+       | Ok () ->
       (match write_meta ctx.config updated with
        | Error e ->
            Prometheus.inc_counter
@@ -336,4 +363,4 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
        | Ok () ->
          stop_keepalive ~base_path:ctx.config.base_path updated.name;
          start_keepalive ctx updated;
-         tool_result_ok (Yojson.Safe.to_string (Keeper_meta_json.meta_to_json updated))))
+         tool_result_ok (Yojson.Safe.to_string (Keeper_meta_json.meta_to_json updated)))))

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -562,6 +562,12 @@ let load_keeper_profile_defaults_result name :
     Stdlib.Mutex.unlock profile_defaults_mu;
     result
 
+let invalidate_keeper_profile_defaults_cache name =
+  let key = profile_defaults_cache_key name in
+  Stdlib.Mutex.lock profile_defaults_mu;
+  Hashtbl.remove profile_defaults_cache key;
+  Stdlib.Mutex.unlock profile_defaults_mu
+
 let load_keeper_profile_defaults name : keeper_profile_defaults =
   match load_keeper_profile_defaults_result name with
   | Ok defaults -> defaults

--- a/lib/keeper/keeper_types_profile.mli
+++ b/lib/keeper/keeper_types_profile.mli
@@ -116,6 +116,7 @@ val keeper_toml_path_opt : string -> string option
 val load_keeper_profile_defaults_from_persona : string -> keeper_profile_defaults
 val resolved_persona_name : keeper_name:string -> keeper_profile_defaults -> string
 val load_keeper_profile_defaults_result : string -> (keeper_profile_defaults, string) result
+val invalidate_keeper_profile_defaults_cache : string -> unit
 val classify_toml_failure_reason : string -> string
 
 type keeper_toml_config_error =


### PR DESCRIPTION
## Summary
- Re-open the dashboard runtime settings change on a fresh branch.
- Add editable keeper `runtime_id` selection to the dashboard keeper config panel.
- Persist existing keeper runtime changes back to keeper TOML and invalidate the profile cache before restart.
- Surface runtime catalog options in `/api/v1/keepers/:name/config`.

## Product impact
- User-visible change: Operators can change a keeper runtime from the dashboard instead of editing `config/keepers/<name>.toml` manually.
- This PR is stacked on #19791, which reverts the accidental merge of #19787.

## Evidence
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-dashboard-runtime-settings-redo dune build --root . lib/keeper/keeper_turn_up_update.{ml,mli} lib/keeper/keeper_types_profile.{ml,mli} lib/dashboard/dashboard_http_keeper_snapshot.{ml,mli}`
- `pnpm --dir dashboard install --frozen-lockfile`
- `pnpm --dir dashboard exec tsc --noEmit --pretty`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/keeper-config-panel.test.ts src/api/dashboard.test.ts`
- `git diff --check HEAD~1..HEAD`

## Direct evidence
```yaml
schema_version: 1
direct_ratio: 5/5
provenance: direct
stages:
  - ocaml_focused_build
  - dashboard_install
  - dashboard_typecheck
  - dashboard_vitest
  - diff_check
```

## GOAL LOOP ACT checklist
- [x] Observe - #19787 was already merged.
- [x] Orient - re-open the feature as a stacked PR after the revert branch.
- [x] Decide - keep the redo PR draft until #19791 is handled.
- [x] Act - cherry-picked the original feature commit onto the #19791 branch.
- [x] Verify - focused OCaml build, dashboard install, typecheck, targeted vitest, and diff check passed.
- [x] Loop - no further changes in this slice.

## Review evidence
- Local self-review against runtime ownership: persisted runtime_id remains TOML-owned; live meta path unchanged.
- Cross-model review not run for this redo branch.

## Linked issue
- None

## Variant addition checklist
- [ ] **OCaml** - N/A: no variant added/removed.
- [ ] **TypeScript** - N/A: object field added, no union member changed.
- [ ] **TLA+ spec** - N/A: no domain literal changed.
- [ ] **Event / JSON schema** - N/A: no event/schema enum changed.
- [ ] **`make check-variants` passes** - N/A: no variant/schema enum change.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`codex/dashboard-runtime-settings-redo-20260602` → `codex/revert-dashboard-runtime-settings-20260602` · 1 commit(s) · synced 2026-06-02T01:01:38Z

| sha | subject | date |
|---|---|---|
| `2bdeabbe4` | feat(dashboard): edit keeper runtime id | 2026-06-02 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->