### PR TITLE
refactor(keeper): extract keeper OUTPUT-dir path SSOT (Phase 0: input/output config split)

### DIFF
--- a/lib/core/common.ml
+++ b/lib/core/common.ml
@@ -36,8 +36,22 @@ let protect ~module_name ~finally_label ~finally f =
 
 let masc_dirname = ".masc"
 
+(* OUTPUT root segment for server-written keeper runtime state (meta json +
+   metrics/memory/decisions/receipts sidecars). The SINGLE literal behind both
+   keeper-dir SSOT functions; the input/output relocation (RFC) flips this one
+   string (e.g. to "runtime/keepers"). *)
+let keepers_runtime_dirname = "keepers"
+
 let masc_dir_from_base_path ~base_path =
   Filename.concat base_path masc_dirname
+
+(* Default-cluster keeper OUTPUT dir for callers holding only [base_path].
+   Low-level on purpose: the cluster-aware [Workspace.keepers_runtime_dir]
+   cannot be called from workspace-internal or accountability modules without a
+   dependency cycle, so those route through here (matching their prior
+   default-cluster behavior). *)
+let keepers_runtime_dir_of_base ~base_path =
+  Filename.concat (masc_dir_from_base_path ~base_path) keepers_runtime_dirname
 
 let auth_dir_from_base_path ~base_path =
   Filename.concat (masc_dir_from_base_path ~base_path) "auth"

--- a/lib/core/common.mli
+++ b/lib/core/common.mli
@@ -45,6 +45,15 @@ val masc_dir_from_base_path : base_path:string -> string
     [Filename.concat base_path masc_dirname]. Canonical way to spell
     [<base_path>/.masc]. *)
 
+val keepers_runtime_dirname : string
+(** OUTPUT root segment for server-written keeper runtime state. Single literal
+    behind both keeper-dir SSOT functions; the input/output relocation flips it. *)
+
+val keepers_runtime_dir_of_base : base_path:string -> string
+(** [<base_path>/.masc/keepers] for callers holding only a [base_path]
+    (default cluster). Low-level SSOT that avoids the Workspace dependency cycle
+    the cluster-aware [Workspace.keepers_runtime_dir] would impose. *)
+
 val auth_dir_from_base_path : base_path:string -> string
 (** [<base_path>/.masc/auth]. SSOT path so {!Auth} and
     {!Keeper_identity} can both compute it without depending on each

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -64,7 +64,7 @@ let keepers_dashboard_json ?(compact = false) (config : Workspace.config) : Yojs
     Runtime_params.get Governance_registry.keeper_supervisor_max_restarts
   in
   let keepers_dir =
-    Filename.concat (Workspace.masc_root_dir config) "keepers"
+    Workspace.keepers_runtime_dir config
   in
   let shared_sp_events =
     try
@@ -812,7 +812,7 @@ let execution_trust_dashboard_json (config : Workspace.config) : Yojson.Safe.t =
   in
   let now = Unix.gettimeofday () in
   let keeper_names = keeper_names config in
-  let keepers_root = Filename.concat (Workspace.masc_root_dir config) "keepers" in
+  let keepers_root = Workspace.keepers_runtime_dir config in
   let exists = Sys.file_exists keepers_root in
   let entry_count = count_execution_receipt_entries config keeper_names in
   let latest_ts = latest_receipt_ts_of_keeper_rows keepers in

--- a/lib/dashboard/dashboard_http_keeper_execution_receipt.ml
+++ b/lib/dashboard/dashboard_http_keeper_execution_receipt.ml
@@ -25,13 +25,13 @@ include Dashboard_http_keeper_types
 
 let execution_receipt_dir config keeper_name =
   Filename.concat
-    (Filename.concat (Filename.concat (Workspace.masc_root_dir config) "keepers")
+    (Filename.concat (Workspace.keepers_runtime_dir config)
        keeper_name)
     "execution-receipts"
 
 let execution_receipt_store_pattern config =
   Filename.concat
-    (Filename.concat (Workspace.masc_root_dir config) "keepers")
+    (Workspace.keepers_runtime_dir config)
     "*/execution-receipts"
 
 let count_execution_receipt_entries config keeper_names =

--- a/lib/keeper/keeper_accountability.ml
+++ b/lib/keeper/keeper_accountability.ml
@@ -35,7 +35,7 @@ let candidate_decision_keeper_names keeper_name =
 
 let keeper_decision_log_path (config : Workspace_query.config) name =
   let keepers_dir =
-    Filename.concat (Common.masc_dir_from_base_path ~base_path:config.base_path) "keepers"
+    Common.keepers_runtime_dir_of_base ~base_path:config.base_path
   in
   Filename.concat keepers_dir (name ^ ".decisions.jsonl")
 ;;

--- a/lib/keeper/keeper_crash_persistence.mli
+++ b/lib/keeper/keeper_crash_persistence.mli
@@ -3,7 +3,7 @@
     Non-yielding enqueue + background drain fiber.
     Dated_jsonl under [keepers_dir]/<name>/crash-events/.
     Callers must pass the cluster-scoped keepers directory
-    (e.g. [Filename.concat (Workspace.masc_root_dir config) "keepers"]).
+    (e.g. [Workspace.keepers_runtime_dir config]).
     Separate from Keeper_registry to preserve its non-yielding contract.
 
     @since 3.0.0 *)

--- a/lib/keeper/keeper_fs.ml
+++ b/lib/keeper/keeper_fs.ml
@@ -121,7 +121,7 @@ let save_json_atomic (path : string) (json : Yojson.Safe.t) : (unit, string) res
 (* ================================================================ *)
 
 let keeper_dir (config : Workspace.config) : string =
-  let d = Filename.concat (Workspace.masc_root_dir config) "keepers" in
+  let d = Workspace.keepers_runtime_dir config in
   ensure_dir d
 
 let session_base_dir (config : Workspace.config) : string =

--- a/lib/keeper/keeper_runtime_manifest.ml
+++ b/lib/keeper/keeper_runtime_manifest.ml
@@ -665,7 +665,7 @@ let execution_receipt_path_for_today config ~keeper_name =
 let base_dir config ~keeper_name =
   Filename.concat
     (Filename.concat
-       (Filename.concat (Workspace.masc_root_dir config) "keepers")
+       (Workspace.keepers_runtime_dir config)
        keeper_name)
     "runtime-manifests"
 

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -370,7 +370,7 @@ let sweep_and_recover (ctx : _ context) =
     Keeper_registry.all ~base_path () |> active_supervision_keeper_count
   in
   let restart_list =
-    let keepers_dir = Filename.concat (Workspace.masc_root_dir ctx.config) "keepers" in
+    let keepers_dir = Workspace.keepers_runtime_dir ctx.config in
     apply_self_preservation ~keepers_dir ~total_keepers:active_count !to_restart
   in
   (* Restart crashed keepers *)

--- a/lib/keeper/keeper_supervisor_launch.ml
+++ b/lib/keeper/keeper_supervisor_launch.ml
@@ -42,7 +42,7 @@ let launch_supervised_fiber
       (reg : Keeper_registry.registry_entry)
   =
   let base_path = ctx.config.base_path in
-  let keepers_dir = Filename.concat (Workspace.masc_root_dir ctx.config) "keepers" in
+  let keepers_dir = Workspace.keepers_runtime_dir ctx.config in
   (match Keeper_registry.prepare_fiber_launch ~base_path meta.name with
    | Ok _ -> ()
    | Error err ->

--- a/lib/keeper/keeper_trace_emit.ml
+++ b/lib/keeper/keeper_trace_emit.ml
@@ -36,7 +36,7 @@ let enabled () =
 
 let trace_path ~base_path ~keeper_name =
   Filename.concat
-    (Filename.concat (Common.masc_dir_from_base_path ~base_path) "keepers")
+    (Common.keepers_runtime_dir_of_base ~base_path)
     (keeper_name ^ ".tla-trace.jsonl")
 
 let emit_transition

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -650,7 +650,7 @@ let load_persona_summary_from_path =
 let list_persona_summaries = Keeper_types_profile_persona.list_persona_summaries
 
 let keeper_dir (config : Workspace.config) =
-  let d = Filename.concat (Workspace.masc_root_dir config) "keepers" in
+  let d = Workspace.keepers_runtime_dir config in
   ensure_dir d
 
 let keeper_meta_path config name =

--- a/lib/keeper/keeper_types_support.ml
+++ b/lib/keeper/keeper_types_support.ml
@@ -9,7 +9,7 @@ include Keeper_config
 let ensure_dir_ = Keeper_fs.ensure_dir
 
 let keeper_dir_ (config : Workspace.config) =
-  let d = Filename.concat (Workspace.masc_root_dir config) "keepers" in
+  let d = Workspace.keepers_runtime_dir config in
   ensure_dir_ d
 
 let session_base_dir_ (config : Workspace.config) =

--- a/lib/model_inference_metrics_reader.ml
+++ b/lib/model_inference_metrics_reader.ml
@@ -18,7 +18,7 @@ open Model_inference_metrics_parser
 
 let read_all_decisions ~base_path ~since_unix : raw_entry list =
   let keeper_dir =
-    Filename.concat (Common.masc_dir_from_base_path ~base_path) "keepers"
+    Common.keepers_runtime_dir_of_base ~base_path
   in
   if not (Sys.file_exists keeper_dir)
   then []

--- a/lib/server/server_runtime_startup_credentials.ml
+++ b/lib/server/server_runtime_startup_credentials.ml
@@ -21,7 +21,7 @@ let audit_keeper_egress_policies (state : Mcp_server.server_state) =
      exception is logged and swallowed so a misbehaving keepers/ tree
      can't keep the server from starting. *)
   let config = state.Mcp_server.workspace_config in
-  let keepers_dir = Filename.concat (Workspace.masc_root_dir config) "keepers" in
+  let keepers_dir = Workspace.keepers_runtime_dir config in
   let metas =
     if not (Sys.file_exists keepers_dir) then []
     else

--- a/lib/workspace/workspace_gc.ml
+++ b/lib/workspace/workspace_gc.ml
@@ -359,7 +359,7 @@ let gc config ?(days=7) () =
   (* 5. Cleanup orphan keeper sidecar files (.metrics.jsonl/.memory.jsonl without .json)
         and orphan date-split metrics directories (<name>/metrics/ without <name>.json) *)
   let keeper_orphan_count = ref 0 in
-  let pk_dir = Filename.concat (Common.masc_dir_from_base_path ~base_path:config.base_path) "keepers" in
+  let pk_dir = Common.keepers_runtime_dir_of_base ~base_path:config.base_path in
   if Sys.file_exists pk_dir then begin
     let entries = Sys.readdir pk_dir |> Array.to_list in
     (* Active keepers = those with a .json config file *)

--- a/lib/workspace/workspace_task_receipts.ml
+++ b/lib/workspace/workspace_task_receipts.ml
@@ -142,7 +142,7 @@ let receipt_sort_key json =
 ;;
 
 let latest_execution_receipt_json config ~agent_name =
-  let keeper_root = Filename.concat (masc_root_dir config) "keepers" in
+  let keeper_root = keepers_runtime_dir config in
   keeper_receipt_candidate_names config ~agent_name
   |> List.filter_map (fun keeper_name ->
     let base_dir =

--- a/lib/workspace/workspace_utils_paths_backend.ml
+++ b/lib/workspace/workspace_utils_paths_backend.ml
@@ -38,6 +38,15 @@ let state_path config = Filename.concat (masc_dir config) "state.json"
 let backlog_path config = Filename.concat (tasks_dir config) "backlog.json"
 let archive_path config = Filename.concat (masc_dir config) "tasks-archive.json"
 
+(* Cluster-aware keeper OUTPUT directory (server-written state + sidecars). The
+   trailing segment is [Common.keepers_runtime_dirname] — the single literal,
+   shared with [Common.keepers_runtime_dir_of_base] — so the input/output
+   relocation flips one constant, not a call-site sweep. Callers holding only a
+   base_path, and workspace-internal / accountability modules that cannot depend
+   on Workspace without a cycle, use the Common variant instead. *)
+let keepers_runtime_dir config =
+  Filename.concat (masc_root_dir config) Common.keepers_runtime_dirname
+
 (** Shared in-memory pubsub for FileSystem and Memory backends.
     All supported backends now share the same in-memory pubsub. *)
 let shared_pubsub = Backend_types.Pubsub_mem.create ()

--- a/lib/workspace/workspace_utils_paths_backend.mli
+++ b/lib/workspace/workspace_utils_paths_backend.mli
@@ -27,6 +27,12 @@ val state_path : config -> string
 val backlog_path : config -> string
 val archive_path : config -> string
 
+(** Cluster-aware keeper OUTPUT directory (server-written state + sidecars). The
+    trailing segment is [Common.keepers_runtime_dirname]; relocating the OUTPUT
+    root flips that one constant. base_path-only and cycle-bound callers use
+    [Common.keepers_runtime_dir_of_base] instead. *)
+val keepers_runtime_dir : config -> string
+
 (** Cluster-root state.json path. Used by bootstrap/init to gate
     one-time root setup. *)
 val root_state_path : config -> string

--- a/test/dune
+++ b/test/dune
@@ -1432,6 +1432,8 @@
 
 (include stanzas/test_keeper_alerting_path_norms.inc)
 
+(include stanzas/test_keepers_runtime_dir_ssot.inc)
+
 (include stanzas/test_keeper_auto_pause_blocker_persist_12683.inc)
 
 

--- a/test/stanzas/test_keepers_runtime_dir_ssot.inc
+++ b/test/stanzas/test_keepers_runtime_dir_ssot.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keepers_runtime_dir_ssot)
+ (modules test_keepers_runtime_dir_ssot)
+ (libraries masc_test_deps))

--- a/test/test_keepers_runtime_dir_ssot.ml
+++ b/test/test_keepers_runtime_dir_ssot.ml
@@ -1,0 +1,42 @@
+(** Phase 0 SSOT guard for the keeper OUTPUT directory.
+
+    The runtime-keeper directory resolves through a single constant,
+    [Common.keepers_runtime_dirname], shared by the two SSOT functions:
+    [Common.keepers_runtime_dir_of_base] (base_path-only / cycle-bound callers)
+    and [Workspace.keepers_runtime_dir] (cluster-aware callers). These pin the
+    CURRENT pre-relocation path. The input/output relocation flips
+    [keepers_runtime_dirname] in ONE place; the expected values here update once,
+    mirroring that single-line source change. *)
+
+open Alcotest
+
+(* The single literal behind every keeper OUTPUT path. *)
+let test_dirname_constant () =
+  check string "keeper OUTPUT dir segment" "keepers"
+    Common.keepers_runtime_dirname
+
+(* base_path variant resolves to <base>/.masc/keepers (default cluster). *)
+let test_of_base_resolves_under_masc () =
+  check string "default-cluster keeper OUTPUT dir" "/tmp/base/.masc/keepers"
+    (Common.keepers_runtime_dir_of_base ~base_path:"/tmp/base")
+
+(* The base variant must equal masc_dir + the shared dirname constant — i.e. it
+   is built from the SSOT constant, not an inlined literal. *)
+let test_of_base_uses_constant () =
+  check string "of_base is masc_dir ^ dirname constant"
+    (Filename.concat
+       (Common.masc_dir_from_base_path ~base_path:"/tmp/base")
+       Common.keepers_runtime_dirname)
+    (Common.keepers_runtime_dir_of_base ~base_path:"/tmp/base")
+
+let () =
+  run "keepers_runtime_dir_ssot"
+    [ ( "ssot"
+      , [ test_case "dirname constant is the single literal" `Quick
+            test_dirname_constant
+        ; test_case "of_base resolves under .masc" `Quick
+            test_of_base_resolves_under_masc
+        ; test_case "of_base built from constant" `Quick
+            test_of_base_uses_constant
+        ] )
+    ]


### PR DESCRIPTION
## 목적

keeper OUTPUT 디렉토리(서버가 쓰는 meta json + metrics/memory/decisions/receipts sidecars) 경로 SSOT 추출. **입력(선언 TOML) / 출력(런타임 상태) config 분리의 Phase 0.**

## 문제

`masc_root/"keepers"` 경로가 **17곳에 산재** — 3개 parallel `keeper_dir` def + 14개 inline literal. 그중 4곳은 non-cluster `Common.masc_dir_from_base_path`로 drift해 `MASC_CLUSTER_NAME` 무관하게 default cluster로 resolve(cluster keeper 누락 잠재 버그). CLAUDE.md "scattered hardcoded defaults" 안티패턴.

## 변경

단일 literal `Common.keepers_runtime_dirname = "keepers"` + 2개 레이어 SSOT 함수로 collapse:
- `Common.keepers_runtime_dir_of_base ~base_path` (default cluster) — Workspace 의존 시 순환하는 저수준 / workspace-internal / accountability callers용.
- `Workspace.keepers_runtime_dir config` (cluster-aware) — 나머지.

각 call site는 원래 동작 보존(cluster-aware는 cluster-aware, default는 default). **zero behavior change.**

## 검증

- `dune build @check` + `dune build lib`(expression-level) 통과.
- `test/test_keepers_runtime_dir_ssot.ml` 3/3 (상수 + base-variant 경로 pin → relocation 시 expected 1곳만 변경).
- `ocamlformat --check` 변경 18파일 OK.

## 비대상 (named follow-up)

- **cluster-aware/default 통일 보류** — 4개 non-cluster caller의 cluster-correctness 버그는 base_path-only 시그니처에 cluster context를 흘려야 해서 이 refactor 범위 밖. 별도 작업.
- **Phase 1+** (persona+keeper TOML 통합, runtime-meta `.masc/runtime/keepers/` 이동, json→toml 검토)은 후속 PR. relocation은 `keepers_runtime_dirname` 한 줄 변경(Phase 3)으로 축소됨 — 본 PR의 목적.

RFC-WAIVED: Phase 0는 OLD location 순수 경로 SSOT 추출(zero behavior change). config-dir relocation(RFC-0121이 governs)은 Phase 3에서 별도 RFC. credential/identity/operator/sandbox/hooks/workflow subsystem 비해당.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
