### PR TITLE
feat(rfc-0130): execute fleet capacity supervisor tick

### DIFF
--- a/docs/rfc/RFC-0130-fleet-capacity-supervisor.md
+++ b/docs/rfc/RFC-0130-fleet-capacity-supervisor.md
@@ -8,7 +8,7 @@ author: vincent
 supersedes: []
 superseded_by: null
 related: ["0026", "0064", "0088", "0124"]
-implementation_prs: [16183, 19786]
+implementation_prs: [16183, 19786, 19795]
 ---
 
 # RFC-0130: Fleet Capacity Supervisor
@@ -56,7 +56,7 @@ type observation =
 
 type spawn_request =
   { reason : Spawn_reason.t            (* closed sum, see §3.1 *)
-  ; suggested_keeper_names : string list  (* from autoboot/persona registry *)
+  ; suggested_keeper_count : int
   }
 
 type decision =
@@ -67,15 +67,22 @@ type decision =
 val tick : observation -> decision
 (** Pure function. No I/O. Deterministic given the observation. *)
 
+type execution_result =
+  { decision : decision
+  ; requested_keeper_names : string list
+  ; started_keeper_names : string list
+  ; failed_keeper_names : (string * string) list
+  }
+
 val execute :
-  sw:Eio.Switch.t ->
-  env:Eio_unix.Stdenv.base ->
-  base_path:string ->
+  spawn_keeper:(string -> (unit, string) result) ->
+  suggested_keeper_names:string list ->
   decision ->
-  Result.t
-(** Side-effecting wrapper. Translates [Spawn] into [Masc_keeper_up.run]
-    calls, [Backpressure] into a typed reject for the admission queue,
-    [Noop] into a single observability event. *)
+  execution_result
+(** Execution boundary. Translates [Spawn] into bounded keeper-start
+    callback calls, records per-keeper failures, and keeps [Backpressure] /
+    [Noop] as no-side-effect decisions. The server supplies the concrete
+    keeper boot callback from its Eio startup context. *)
 ```
 
 ### 2.2 Why pure `tick` + `execute` split
@@ -124,12 +131,12 @@ Fleet_capacity_supervisor.tick               (new)
        │
        ▼
 Fleet_capacity_supervisor.execute
-   ├── Spawn → Masc_keeper_up.run sw env ~base_path ~names
-   ├── Backpressure → Workspace.publish_backpressure ~reason
-   └── Noop → Lifecycle event only
+   ├── Spawn → server keeper boot callback for suggested missing names
+   ├── Backpressure → recorded no-side-effect decision
+   └── Noop → recorded no-side-effect decision
 ```
 
-The supervisor runs as a single Eio fiber at startup (via `Switch.run` + `Switch.on_release`), ticking every `fleet_capacity_supervisor_tick_seconds` (default 30s, clamped to ≥10s).
+The supervisor runs as a single Eio fiber after keeper autoboot, ticking every `MASC_FLEET_CAPACITY_SUPERVISOR_TICK_SEC` (default 30s, clamped to ≥10s). The execution loop uses `Keeper_runtime.bootable_keeper_names`, so intentionally paused or declaratively disabled keepers remain excluded from automatic start attempts even though `/health` still reports them in the broader safety surface.
 
 ### 3.3 Cooldown invariant
 
@@ -161,9 +168,11 @@ The supervisor runs as a single Eio fiber at startup (via `Switch.run` + `Switch
 - Test: synthetic 3/13 observation → JSON contains `"supervisor_decision":{"variant":"spawn","reason":"below_target_reaction_capacity"}`.
 
 ### PR-4 (execute, flagged on)
-- Implement `execute` calling `Masc_keeper_up.run` for `Spawn`.
+- Implemented in this PR: `Keeper_fleet_capacity_supervisor.execute` records bounded spawn attempts through an injected keeper-start callback.
+- The server wires a post-autoboot `fleet_capacity_supervisor` loop that converts one tick into keepalive starts for missing bootable keepers.
 - Property test: 3 running / 13 target → after one tick + execute, 13 running.
-- Flag default flips to `true`. Old behavior preserved behind `MASC_FLEET_CAPACITY_SUPERVISOR_TICK_ENABLED=false`.
+- Flag default flips to `true`. Old read-only behavior is preserved behind `MASC_FLEET_CAPACITY_SUPERVISOR_TICK_ENABLED=false`.
+- Tick interval: `MASC_FLEET_CAPACITY_SUPERVISOR_TICK_SEC`, default 30s, clamped to ≥10s.
 
 ### PR-5 (closeout)
 - Frontmatter `status: Implemented`, `implementation_prs: [PR-2#, PR-3#, PR-4#]`.

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -14,9 +14,9 @@ the categorization roadmap. Newly-added typed getters in
 `lib/config/env_config_*.ml` must carry nearby `@category` and
 `@ops_class` tags; existing knobs remain in the backfill lane.
 
-**Total**: 377 unique knobs across 10 modules.
+**Total**: 379 unique knobs across 10 modules.
 
-**Typed getter classification**: 30/232 tagged (`operator`: 30, `algorithm`: 0, `unclassified`: 202).
+**Typed getter classification**: 31/233 tagged (`operator`: 31, `algorithm`: 0, `unclassified`: 202).
 
 ## Env_config_core (29 knobs; typed classification 0/7)
 
@@ -190,31 +190,33 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_TRANSIENT_BACKOFF_BASE_SEC` | typed:float | unclassified | unclassified | 25 | Base delay (seconds) for exponential backoff. Delay at attempt [n] is [base * 2^(n-1)]. Env: [MASC_KEEPER_TRANSIENT_B... |
 | `MASC_KEEPER_TRANSIENT_BACKOFF_CAP_SEC` | typed:float | unclassified | unclassified | 31 | Hard cap on backoff delay (seconds). Env: [MASC_KEEPER_TRANSIENT_BACKOFF_CAP_SEC].  Default: 4.0. |
 
-## Env_config_keeper_supervisor (21 knobs; typed classification 20/20)
+## Env_config_keeper_supervisor (23 knobs; typed classification 21/21)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_KEEPER_ALIVE_BUT_STUCK_DEDUP_TTL_SEC` | typed:float | Timeouts | operator | 153 | Per-keeper dedup window (seconds): once a keeper is flagged the counter is incremented at most once per window, even ... |
-| `MASC_KEEPER_ALIVE_BUT_STUCK_ENABLED` | typed:bool | Policies | operator | 119 | Signal for alive-but-stuck keepers (#12838): keepers that are not Dead/Zombie and not paused, but whose [proactive_rt... |
-| `MASC_KEEPER_ALIVE_BUT_STUCK_RECOVERY_ENABLED` | typed:bool | Policies | operator | 128 | Queue a bounded recovery wakeup when [alive_but_stuck_scan] emits. The recovery uses the Event Layer queue plus [fibe... |
-| `MASC_KEEPER_ALIVE_BUT_STUCK_STALL_FLOOR_SEC` | typed:float | Timeouts | operator | 145 | Hard floor (seconds) so keepers with very small cooldowns are not flagged after a few minutes of legitimate quiet.  T... |
-| `MASC_KEEPER_ALIVE_BUT_STUCK_STALL_MULTIPLIER` | typed:int | Thresholds | operator | 136 | Multiplier on the keeper's own [proactive.cooldown_sec] before a stalled keeper is flagged.  Default: 10 (10 cooldown... |
-| `MASC_KEEPER_AUTO_RESUME_INITIAL_SEC` | typed:float | Timeouts | operator | 64 | Initial auto-resume backoff delay after an auto-pause (seconds). On every successive auto-pause the delay doubles, ca... |
-| `MASC_KEEPER_AUTO_RESUME_MAX_SEC` | typed:float | Timeouts | operator | 70 | Maximum auto-resume backoff delay (seconds).  Default: 86400 (24 hours). @category Timeouts @ops_class operator |
-| `MASC_KEEPER_DEAD_TTL_SEC` | typed:float | Timeouts | operator | 47 | Dead tombstone TTL: seconds before Dead entries are cleaned up. @category Timeouts @ops_class operator |
+| `MASC_FLEET_CAPACITY_SUPERVISOR_TICK_ENABLED` | feature_flag | Policies | operator | 23 | Fleet capacity supervisor execution loop (RFC-0130 PR-4). When enabled, the server periodically converts the typed fl... |
+| `MASC_FLEET_CAPACITY_SUPERVISOR_TICK_SEC` | typed:float | Timeouts | operator | 32 | Interval between fleet capacity supervisor execution ticks. Default: 30s. Clamped to >= 10s to avoid a tight boot ret... |
+| `MASC_KEEPER_ALIVE_BUT_STUCK_DEDUP_TTL_SEC` | typed:float | Timeouts | operator | 173 | Per-keeper dedup window (seconds): once a keeper is flagged the counter is incremented at most once per window, even ... |
+| `MASC_KEEPER_ALIVE_BUT_STUCK_ENABLED` | typed:bool | Policies | operator | 139 | Signal for alive-but-stuck keepers (#12838): keepers that are not Dead/Zombie and not paused, but whose [proactive_rt... |
+| `MASC_KEEPER_ALIVE_BUT_STUCK_RECOVERY_ENABLED` | typed:bool | Policies | operator | 148 | Queue a bounded recovery wakeup when [alive_but_stuck_scan] emits. The recovery uses the Event Layer queue plus [fibe... |
+| `MASC_KEEPER_ALIVE_BUT_STUCK_STALL_FLOOR_SEC` | typed:float | Timeouts | operator | 165 | Hard floor (seconds) so keepers with very small cooldowns are not flagged after a few minutes of legitimate quiet.  T... |
+| `MASC_KEEPER_ALIVE_BUT_STUCK_STALL_MULTIPLIER` | typed:int | Thresholds | operator | 156 | Multiplier on the keeper's own [proactive.cooldown_sec] before a stalled keeper is flagged.  Default: 10 (10 cooldown... |
+| `MASC_KEEPER_AUTO_RESUME_INITIAL_SEC` | typed:float | Timeouts | operator | 84 | Initial auto-resume backoff delay after an auto-pause (seconds). On every successive auto-pause the delay doubles, ca... |
+| `MASC_KEEPER_AUTO_RESUME_MAX_SEC` | typed:float | Timeouts | operator | 90 | Maximum auto-resume backoff delay (seconds).  Default: 86400 (24 hours). @category Timeouts @ops_class operator |
+| `MASC_KEEPER_DEAD_TTL_SEC` | typed:float | Timeouts | operator | 67 | Dead tombstone TTL: seconds before Dead entries are cleaned up. @category Timeouts @ops_class operator |
 | `MASC_KEEPER_DOMAIN_POOL_ENABLED` | feature_flag | n/a | n/a | 12 | Historical keeper Domain_pool pilot flag. The supervisor still reads this for observability, but keepalive fibers rem... |
-| `MASC_KEEPER_LIVENESS_RECOVERY_BACKOFF_BASE_SEC` | typed:float | Timeouts | operator | 95 | Base backoff delay (seconds) between liveness recovery attempts per keeper. Exponential: attempt 0 = base, 1 = 2*base... |
-| `MASC_KEEPER_LIVENESS_RECOVERY_BACKOFF_MAX_SEC` | typed:float | Timeouts | operator | 104 | Maximum backoff delay cap (seconds) for liveness recovery. Default: 3600 (1 hour). @category Timeouts @ops_class oper... |
-| `MASC_KEEPER_LIVENESS_RECOVERY_ENABLED` | typed:bool | Policies | operator | 77 | Liveness Recovery Supervisor (#12801): enable auto-recovery of Dead keepers whose root cause has cleared.  Set to fal... |
-| `MASC_KEEPER_LIVENESS_RECOVERY_MAX_ATTEMPTS` | typed:int | Thresholds | operator | 111 | Maximum total liveness recovery attempts per keeper before giving up permanently.  Default: 5. @category Thresholds @... |
-| `MASC_KEEPER_LIVENESS_RECOVERY_MIN_DEAD_SEC` | typed:float | Timeouts | operator | 85 | Minimum time (seconds) a keeper must have been Dead before a liveness recovery attempt is made.  Allows transient roo... |
-| `MASC_KEEPER_PAUSED_CLEANUP_TTL_SEC` | typed:float | Timeouts | operator | 55 | Paused keeper file TTL: seconds before stale paused keeper meta files are removed from disk. Default: 86400 (24 hours... |
-| `MASC_KEEPER_SELF_PRESERVATION_MIN_CANDIDATES` | typed:int | Thresholds | operator | 42 | Self-preservation: minimum crashed candidates to trigger. @category Thresholds @ops_class operator |
-| `MASC_KEEPER_SELF_PRESERVATION_RATIO` | typed:float | Thresholds | operator | 36 | Self-preservation: ratio of crashed keepers to trigger suppression. @category Thresholds @ops_class operator |
-| `MASC_KEEPER_SUPERVISOR_BACKOFF_BASE_S` | typed:float | Timeouts | operator | 21 | Base delay for exponential backoff between restarts (seconds). @category Timeouts @ops_class operator |
-| `MASC_KEEPER_SUPERVISOR_BACKOFF_MAX_S` | typed:float | Timeouts | operator | 25 | Maximum backoff delay cap (seconds). @category Timeouts @ops_class operator |
-| `MASC_KEEPER_SUPERVISOR_MAX_RESTARTS` | typed:int | Thresholds | operator | 17 | Maximum restart attempts before declaring a keeper dead. @category Thresholds @ops_class operator |
-| `MASC_KEEPER_SUPERVISOR_SWEEP_SEC` | typed:float | Timeouts | operator | 29 | Interval between supervisor sweep runs (seconds). @category Timeouts @ops_class operator |
+| `MASC_KEEPER_LIVENESS_RECOVERY_BACKOFF_BASE_SEC` | typed:float | Timeouts | operator | 115 | Base backoff delay (seconds) between liveness recovery attempts per keeper. Exponential: attempt 0 = base, 1 = 2*base... |
+| `MASC_KEEPER_LIVENESS_RECOVERY_BACKOFF_MAX_SEC` | typed:float | Timeouts | operator | 124 | Maximum backoff delay cap (seconds) for liveness recovery. Default: 3600 (1 hour). @category Timeouts @ops_class oper... |
+| `MASC_KEEPER_LIVENESS_RECOVERY_ENABLED` | typed:bool | Policies | operator | 97 | Liveness Recovery Supervisor (#12801): enable auto-recovery of Dead keepers whose root cause has cleared.  Set to fal... |
+| `MASC_KEEPER_LIVENESS_RECOVERY_MAX_ATTEMPTS` | typed:int | Thresholds | operator | 131 | Maximum total liveness recovery attempts per keeper before giving up permanently.  Default: 5. @category Thresholds @... |
+| `MASC_KEEPER_LIVENESS_RECOVERY_MIN_DEAD_SEC` | typed:float | Timeouts | operator | 105 | Minimum time (seconds) a keeper must have been Dead before a liveness recovery attempt is made.  Allows transient roo... |
+| `MASC_KEEPER_PAUSED_CLEANUP_TTL_SEC` | typed:float | Timeouts | operator | 75 | Paused keeper file TTL: seconds before stale paused keeper meta files are removed from disk. Default: 86400 (24 hours... |
+| `MASC_KEEPER_SELF_PRESERVATION_MIN_CANDIDATES` | typed:int | Thresholds | operator | 62 | Self-preservation: minimum crashed candidates to trigger. @category Thresholds @ops_class operator |
+| `MASC_KEEPER_SELF_PRESERVATION_RATIO` | typed:float | Thresholds | operator | 56 | Self-preservation: ratio of crashed keepers to trigger suppression. @category Thresholds @ops_class operator |
+| `MASC_KEEPER_SUPERVISOR_BACKOFF_BASE_S` | typed:float | Timeouts | operator | 41 | Base delay for exponential backoff between restarts (seconds). @category Timeouts @ops_class operator |
+| `MASC_KEEPER_SUPERVISOR_BACKOFF_MAX_S` | typed:float | Timeouts | operator | 45 | Maximum backoff delay cap (seconds). @category Timeouts @ops_class operator |
+| `MASC_KEEPER_SUPERVISOR_MAX_RESTARTS` | typed:int | Thresholds | operator | 37 | Maximum restart attempts before declaring a keeper dead. @category Thresholds @ops_class operator |
+| `MASC_KEEPER_SUPERVISOR_SWEEP_SEC` | typed:float | Timeouts | operator | 49 | Interval between supervisor sweep runs (seconds). @category Timeouts @ops_class operator |
 
 ## Env_config_oas_bridge (1 knobs; typed classification 0/0)
 
@@ -371,76 +373,76 @@ the categorization roadmap. Newly-added typed getters in
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
 | `MASC_ALLOW_ANONYMOUS_MUTATIONS` | string_literal | n/a | n/a | 29 |  |
-| `MASC_ASSETS_DIR` | string_literal | n/a | n/a | 651 |  |
-| `MASC_BASE_PATH_RESOLUTION_SOURCE` | string_literal | n/a | n/a | 655 |  |
-| `MASC_BASE_PATH_STRICT` | string_literal | n/a | n/a | 657 |  |
-| `MASC_BENCHMARK_RESULTS_DIR` | string_literal | n/a | n/a | 221 |  |
-| `MASC_CHANNEL_GATE_DEDUP_TTL_SEC` | string_literal | n/a | n/a | 311 |  |
-| `MASC_CHANNEL_GATE_MAX_CONTENT_LENGTH` | string_literal | n/a | n/a | 313 |  |
-| `MASC_DASHBOARD_CACHE_MAX_ENTRIES` | string_literal | n/a | n/a | 223 |  |
-| `MASC_DASHBOARD_EXECUTION_REFRESH_TIMEOUT_S` | string_literal | n/a | n/a | 231 |  |
-| `MASC_DASHBOARD_TRANSPORT_HEALTH_TIMEOUT_S` | string_literal | n/a | n/a | 275 |  |
-| `MASC_DECISION_AUDIT_RING_CAPACITY` | string_literal | n/a | n/a | 329 |  |
-| `MASC_DECISION_LAYER_LEVEL` | string_literal | n/a | n/a | 331 |  |
-| `MASC_DISCORD_STATUS_STALE_SEC` | string_literal | n/a | n/a | 315 |  |
-| `MASC_DRIFT_COSINE_WEIGHT` | string_literal | n/a | n/a | 212 |  |
-| `MASC_DRIFT_JACCARD_WEIGHT` | string_literal | n/a | n/a | 211 |  |
-| `MASC_DRIFT_THRESHOLD` | string_literal | n/a | n/a | 210 |  |
-| `MASC_ECONOMY_ENABLED` | string_literal | n/a | n/a | 376 |  |
-| `MASC_ECONOMY_FRUGAL_THRESHOLD` | string_literal | n/a | n/a | 378 |  |
-| `MASC_ECONOMY_HUSTLE_THRESHOLD` | string_literal | n/a | n/a | 380 |  |
-| `MASC_ECONOMY_INITIAL_BALANCE` | string_literal | n/a | n/a | 382 |  |
-| `MASC_ECONOMY_REPUTATION_MULTIPLIER` | string_literal | n/a | n/a | 384 |  |
-| `MASC_ECONOMY_REWARD_BOARD_POST` | string_literal | n/a | n/a | 386 |  |
-| `MASC_ECONOMY_REWARD_MENTION_RESPONSE` | string_literal | n/a | n/a | 388 |  |
-| `MASC_ECONOMY_REWARD_TASK_DONE` | string_literal | n/a | n/a | 390 |  |
-| `MASC_ECONOMY_REWARD_UPVOTE` | string_literal | n/a | n/a | 392 |  |
+| `MASC_ASSETS_DIR` | string_literal | n/a | n/a | 655 |  |
+| `MASC_BASE_PATH_RESOLUTION_SOURCE` | string_literal | n/a | n/a | 659 |  |
+| `MASC_BASE_PATH_STRICT` | string_literal | n/a | n/a | 661 |  |
+| `MASC_BENCHMARK_RESULTS_DIR` | string_literal | n/a | n/a | 225 |  |
+| `MASC_CHANNEL_GATE_DEDUP_TTL_SEC` | string_literal | n/a | n/a | 315 |  |
+| `MASC_CHANNEL_GATE_MAX_CONTENT_LENGTH` | string_literal | n/a | n/a | 317 |  |
+| `MASC_DASHBOARD_CACHE_MAX_ENTRIES` | string_literal | n/a | n/a | 227 |  |
+| `MASC_DASHBOARD_EXECUTION_REFRESH_TIMEOUT_S` | string_literal | n/a | n/a | 235 |  |
+| `MASC_DASHBOARD_TRANSPORT_HEALTH_TIMEOUT_S` | string_literal | n/a | n/a | 279 |  |
+| `MASC_DECISION_AUDIT_RING_CAPACITY` | string_literal | n/a | n/a | 333 |  |
+| `MASC_DECISION_LAYER_LEVEL` | string_literal | n/a | n/a | 335 |  |
+| `MASC_DISCORD_STATUS_STALE_SEC` | string_literal | n/a | n/a | 319 |  |
+| `MASC_DRIFT_COSINE_WEIGHT` | string_literal | n/a | n/a | 216 |  |
+| `MASC_DRIFT_JACCARD_WEIGHT` | string_literal | n/a | n/a | 215 |  |
+| `MASC_DRIFT_THRESHOLD` | string_literal | n/a | n/a | 214 |  |
+| `MASC_ECONOMY_ENABLED` | string_literal | n/a | n/a | 380 |  |
+| `MASC_ECONOMY_FRUGAL_THRESHOLD` | string_literal | n/a | n/a | 382 |  |
+| `MASC_ECONOMY_HUSTLE_THRESHOLD` | string_literal | n/a | n/a | 384 |  |
+| `MASC_ECONOMY_INITIAL_BALANCE` | string_literal | n/a | n/a | 386 |  |
+| `MASC_ECONOMY_REPUTATION_MULTIPLIER` | string_literal | n/a | n/a | 388 |  |
+| `MASC_ECONOMY_REWARD_BOARD_POST` | string_literal | n/a | n/a | 390 |  |
+| `MASC_ECONOMY_REWARD_MENTION_RESPONSE` | string_literal | n/a | n/a | 392 |  |
+| `MASC_ECONOMY_REWARD_TASK_DONE` | string_literal | n/a | n/a | 394 |  |
+| `MASC_ECONOMY_REWARD_UPVOTE` | string_literal | n/a | n/a | 396 |  |
 | `MASC_GRPC_STREAM_MAX_BUFFER` | string_literal | n/a | n/a | 86 |  |
-| `MASC_GUARD_PENALTY_BETA` | string_literal | n/a | n/a | 204 |  |
-| `MASC_HEBBIAN_DECAY` | string_literal | n/a | n/a | 214 |  |
-| `MASC_HEBBIAN_RATE` | string_literal | n/a | n/a | 213 |  |
+| `MASC_GUARD_PENALTY_BETA` | string_literal | n/a | n/a | 208 |  |
+| `MASC_HEBBIAN_DECAY` | string_literal | n/a | n/a | 218 |  |
+| `MASC_HEBBIAN_RATE` | string_literal | n/a | n/a | 217 |  |
 | `MASC_HTTP_HOST` | string_literal | n/a | n/a | 21 |  |
 | `MASC_HTTP_MAX_CONNECTIONS` | string_literal | n/a | n/a | 22 |  |
-| `MASC_IMESSAGE_STATUS_STALE_SEC` | string_literal | n/a | n/a | 317 |  |
-| `MASC_KEEPER_AUTONOMOUS_CONCURRENCY` | string_literal | n/a | n/a | 491 |  |
-| `MASC_KEEPER_AUTONOMOUS_MAX_TOKENS` | string_literal | n/a | n/a | 170 |  |
-| `MASC_KEEPER_COMPACT_MAX_MESSAGES` | string_literal | n/a | n/a | 161 |  |
-| `MASC_KEEPER_COMPACT_MAX_TOKENS` | string_literal | n/a | n/a | 163 |  |
-| `MASC_KEEPER_COMPACT_RATIO` | string_literal | n/a | n/a | 159 |  |
-| `MASC_KEEPER_LLM_RERANK_RUNTIME` | string_literal | n/a | n/a | 557 |  |
-| `MASC_KEEPER_RULE_GUARDRAIL_CONTEXT_MIN` | string_literal | n/a | n/a | 188 |  |
-| `MASC_KEEPER_RULE_GUARDRAIL_GOAL_ALIGNMENT_MAX` | string_literal | n/a | n/a | 184 |  |
-| `MASC_KEEPER_RULE_GUARDRAIL_REPETITION` | string_literal | n/a | n/a | 182 |  |
-| `MASC_KEEPER_RULE_GUARDRAIL_RESPONSE_ALIGNMENT_MAX` | string_literal | n/a | n/a | 186 |  |
-| `MASC_KEEPER_RULE_PLAN_GOAL_ALIGNMENT_MAX` | string_literal | n/a | n/a | 178 |  |
-| `MASC_KEEPER_RULE_PLAN_RESPONSE_ALIGNMENT_MAX` | string_literal | n/a | n/a | 180 |  |
-| `MASC_KEEPER_RULE_REFLECT_REPETITION` | string_literal | n/a | n/a | 176 |  |
-| `MASC_KEEPER_TOOL_AFFINITY_K` | string_literal | n/a | n/a | 561 |  |
-| `MASC_KEEPER_TOOL_AFFINITY_LOOKBACK_DAYS` | string_literal | n/a | n/a | 563 |  |
-| `MASC_KEEPER_TOOL_COST_MAX_USD` | string_literal | n/a | n/a | 165 |  |
-| `MASC_KEEPER_TOOL_DECAY_TURNS` | string_literal | n/a | n/a | 565 |  |
-| `MASC_KEEPER_TURN_LIVELOCK_MAX_ATTEMPTS` | string_literal | n/a | n/a | 517 |  |
-| `MASC_KEEPER_TURN_LIVELOCK_STUCK_AFTER_SEC` | string_literal | n/a | n/a | 519 |  |
-| `MASC_KEEPER_UNIFIED_MAX_TOKENS` | string_literal | n/a | n/a | 168 |  |
-| `MASC_KEEPER_UNIFIED_TEMP` | string_literal | n/a | n/a | 167 |  |
-| `MASC_LOCK_WARN_MS` | string_literal | n/a | n/a | 215 |  |
-| `MASC_OTEL_ENABLED` | string_literal | n/a | n/a | 749 |  |
-| `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 785 |  |
-| `MASC_RUNTIME_ATTEMPT_LIVENESS` | string_literal | n/a | n/a | 474 |  |
-| `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 797 |  |
-| `MASC_SHUTDOWN_CLEANUP_TIMEOUT` | string_literal | n/a | n/a | 697 |  |
-| `MASC_SHUTDOWN_DRAIN_TIMEOUT` | string_literal | n/a | n/a | 699 |  |
-| `MASC_SHUTDOWN_FORCE_TIMEOUT` | string_literal | n/a | n/a | 701 |  |
-| `MASC_SHUTDOWN_NOTIFY_DELAY` | string_literal | n/a | n/a | 703 |  |
-| `MASC_SSE_STREAM_CAPACITY` | string_literal | n/a | n/a | 729 |  |
-| `MASC_STRUCTURED_STATE` | string_literal | n/a | n/a | 151 |  |
+| `MASC_IMESSAGE_STATUS_STALE_SEC` | string_literal | n/a | n/a | 321 |  |
+| `MASC_KEEPER_AUTONOMOUS_CONCURRENCY` | string_literal | n/a | n/a | 495 |  |
+| `MASC_KEEPER_AUTONOMOUS_MAX_TOKENS` | string_literal | n/a | n/a | 174 |  |
+| `MASC_KEEPER_COMPACT_MAX_MESSAGES` | string_literal | n/a | n/a | 165 |  |
+| `MASC_KEEPER_COMPACT_MAX_TOKENS` | string_literal | n/a | n/a | 167 |  |
+| `MASC_KEEPER_COMPACT_RATIO` | string_literal | n/a | n/a | 163 |  |
+| `MASC_KEEPER_LLM_RERANK_RUNTIME` | string_literal | n/a | n/a | 561 |  |
+| `MASC_KEEPER_RULE_GUARDRAIL_CONTEXT_MIN` | string_literal | n/a | n/a | 192 |  |
+| `MASC_KEEPER_RULE_GUARDRAIL_GOAL_ALIGNMENT_MAX` | string_literal | n/a | n/a | 188 |  |
+| `MASC_KEEPER_RULE_GUARDRAIL_REPETITION` | string_literal | n/a | n/a | 186 |  |
+| `MASC_KEEPER_RULE_GUARDRAIL_RESPONSE_ALIGNMENT_MAX` | string_literal | n/a | n/a | 190 |  |
+| `MASC_KEEPER_RULE_PLAN_GOAL_ALIGNMENT_MAX` | string_literal | n/a | n/a | 182 |  |
+| `MASC_KEEPER_RULE_PLAN_RESPONSE_ALIGNMENT_MAX` | string_literal | n/a | n/a | 184 |  |
+| `MASC_KEEPER_RULE_REFLECT_REPETITION` | string_literal | n/a | n/a | 180 |  |
+| `MASC_KEEPER_TOOL_AFFINITY_K` | string_literal | n/a | n/a | 565 |  |
+| `MASC_KEEPER_TOOL_AFFINITY_LOOKBACK_DAYS` | string_literal | n/a | n/a | 567 |  |
+| `MASC_KEEPER_TOOL_COST_MAX_USD` | string_literal | n/a | n/a | 169 |  |
+| `MASC_KEEPER_TOOL_DECAY_TURNS` | string_literal | n/a | n/a | 569 |  |
+| `MASC_KEEPER_TURN_LIVELOCK_MAX_ATTEMPTS` | string_literal | n/a | n/a | 521 |  |
+| `MASC_KEEPER_TURN_LIVELOCK_STUCK_AFTER_SEC` | string_literal | n/a | n/a | 523 |  |
+| `MASC_KEEPER_UNIFIED_MAX_TOKENS` | string_literal | n/a | n/a | 172 |  |
+| `MASC_KEEPER_UNIFIED_TEMP` | string_literal | n/a | n/a | 171 |  |
+| `MASC_LOCK_WARN_MS` | string_literal | n/a | n/a | 219 |  |
+| `MASC_OTEL_ENABLED` | string_literal | n/a | n/a | 753 |  |
+| `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 789 |  |
+| `MASC_RUNTIME_ATTEMPT_LIVENESS` | string_literal | n/a | n/a | 478 |  |
+| `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 801 |  |
+| `MASC_SHUTDOWN_CLEANUP_TIMEOUT` | string_literal | n/a | n/a | 701 |  |
+| `MASC_SHUTDOWN_DRAIN_TIMEOUT` | string_literal | n/a | n/a | 703 |  |
+| `MASC_SHUTDOWN_FORCE_TIMEOUT` | string_literal | n/a | n/a | 705 |  |
+| `MASC_SHUTDOWN_NOTIFY_DELAY` | string_literal | n/a | n/a | 707 |  |
+| `MASC_SSE_STREAM_CAPACITY` | string_literal | n/a | n/a | 733 |  |
+| `MASC_STRUCTURED_STATE` | string_literal | n/a | n/a | 155 |  |
 | `MASC_TELEMETRY_MAX_BYTES` | string_literal | n/a | n/a | 56 |  |
 | `MASC_TELEMETRY_RETENTION_DAYS` | string_literal | n/a | n/a | 53 |  |
-| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | string_literal | n/a | n/a | 765 |  |
-| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | string_literal | n/a | n/a | 767 |  |
-| `MASC_TLA_TRACE` | string_literal | n/a | n/a | 153 |  |
-| `MASC_WORKER_RUNTIME_BACKEND` | string_literal | n/a | n/a | 829 |  |
-| `MASC_WORKER_RUNTIME_DOCKER_IMAGE` | string_literal | n/a | n/a | 831 |  |
-| `MASC_WORKER_RUNTIME_HOST_MCP_BASE_URL` | string_literal | n/a | n/a | 833 |  |
+| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | string_literal | n/a | n/a | 769 |  |
+| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | string_literal | n/a | n/a | 771 |  |
+| `MASC_TLA_TRACE` | string_literal | n/a | n/a | 157 |  |
+| `MASC_WORKER_RUNTIME_BACKEND` | string_literal | n/a | n/a | 833 |  |
+| `MASC_WORKER_RUNTIME_DOCKER_IMAGE` | string_literal | n/a | n/a | 835 |  |
+| `MASC_WORKER_RUNTIME_HOST_MCP_BASE_URL` | string_literal | n/a | n/a | 837 |  |
 | `MASC_WS_CLIENT_BUFFER_LIMIT_BYTES` | string_literal | n/a | n/a | 93 |  |
 | `MASC_WS_SLICE_INDEX_ENABLED` | string_literal | n/a | n/a | 96 |  |

--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -54,6 +54,8 @@ end
 
 module KeeperSupervisor : sig
   val domain_pool_enabled : bool
+  val fleet_capacity_tick_enabled : bool
+  val fleet_capacity_tick_interval_sec : float
   val max_restarts : int
   val backoff_base_s : float
   val backoff_max_s : float

--- a/lib/config/env_config_keeper_supervisor.ml
+++ b/lib/config/env_config_keeper_supervisor.ml
@@ -12,6 +12,26 @@ let domain_pool_enabled =
   Feature_flag_registry.get_bool "MASC_KEEPER_DOMAIN_POOL_ENABLED"
 ;;
 
+(** Fleet capacity supervisor execution loop (RFC-0130 PR-4).
+    When enabled, the server periodically converts the typed fleet
+    shortfall decision into keeper boot attempts for missing bootable
+    keepers. Default: true; set
+    [MASC_FLEET_CAPACITY_SUPERVISOR_TICK_ENABLED=false] to preserve the
+    previous read-only [/health] behavior.
+    @category Policies @ops_class operator *)
+let fleet_capacity_tick_enabled =
+  Feature_flag_registry.get_bool "MASC_FLEET_CAPACITY_SUPERVISOR_TICK_ENABLED"
+;;
+
+(** Interval between fleet capacity supervisor execution ticks.
+    Default: 30s. Clamped to >= 10s to avoid a tight boot retry loop.
+    @category Timeouts @ops_class operator *)
+let fleet_capacity_tick_interval_sec =
+  Float.max
+    10.0
+    (get_float ~default:30.0 "MASC_FLEET_CAPACITY_SUPERVISOR_TICK_SEC")
+;;
+
 (** Maximum restart attempts before declaring a keeper dead.
     @category Thresholds @ops_class operator *)
 let max_restarts = get_int ~default:5 "MASC_KEEPER_SUPERVISOR_MAX_RESTARTS"

--- a/lib/config/env_config_keeper_supervisor.ml
+++ b/lib/config/env_config_keeper_supervisor.ml
@@ -29,7 +29,7 @@ let fleet_capacity_tick_enabled =
 let fleet_capacity_tick_interval_sec =
   Float.max
     10.0
-    (get_float ~default:30.0 "MASC_FLEET_CAPACITY_SUPERVISOR_TICK_SEC")
+    (get_float_nonneg ~default:30.0 "MASC_FLEET_CAPACITY_SUPERVISOR_TICK_SEC")
 ;;
 
 (** Maximum restart attempts before declaring a keeper dead.

--- a/lib/config/env_config_keeper_supervisor.mli
+++ b/lib/config/env_config_keeper_supervisor.mli
@@ -1,6 +1,8 @@
 (** Keeper supervisor runtime configuration. *)
 
 val domain_pool_enabled : bool
+val fleet_capacity_tick_enabled : bool
+val fleet_capacity_tick_interval_sec : float
 val max_restarts : int
 val backoff_base_s : float
 val backoff_max_s : float

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -129,6 +129,10 @@ let inference_entries =
 
 let keeper_entries =
   [
+    entry ~default:"true" "MASC_FLEET_CAPACITY_SUPERVISOR_TICK_ENABLED"
+      "Enable fleet capacity supervisor execution loop";
+    entry ~default:"30.0" "MASC_FLEET_CAPACITY_SUPERVISOR_TICK_SEC"
+      "Fleet capacity supervisor execution tick interval (seconds)";
     entry ~default:"true" "MASC_KEEPER_BOOTSTRAP_ENABLED"
       "Enable keeper auto-bootstrap";
     entry ~default:"300" "MASC_KEEPER_SNAPSHOT_SEC"

--- a/lib/config/feature_flag_registry.ml
+++ b/lib/config/feature_flag_registry.ml
@@ -85,6 +85,11 @@ let all_flags : flag list = [
     default = false; category = "keeper";
     lifecycle = Experimental; since = "2.170.0" };
 
+  { env_name = "MASC_FLEET_CAPACITY_SUPERVISOR_TICK_ENABLED";
+    description = "Fleet capacity supervisor execution loop";
+    default = true; category = "keeper";
+    lifecycle = Active; since = "2.245.0" };
+
   { env_name = "MASC_KEEPER_BOOTSTRAP_ENABLED";
     description = "Startup keeper auto-bootstrap scan";
     default = true; category = "keeper";

--- a/lib/keeper/keeper_fleet_capacity_supervisor.ml
+++ b/lib/keeper/keeper_fleet_capacity_supervisor.ml
@@ -62,6 +62,13 @@ type decision =
   | Backpressure of Backpressure_reason.t
   | Noop of Noop_reason.t
 
+type execution_result =
+  { decision : decision
+  ; requested_keeper_names : string list
+  ; started_keeper_names : string list
+  ; failed_keeper_names : (string * string) list
+  }
+
 let decision_to_string = function
   | Spawn { reason; suggested_keeper_count } ->
     Printf.sprintf
@@ -71,6 +78,45 @@ let decision_to_string = function
   | Backpressure reason ->
     Printf.sprintf "backpressure(%s)" (Backpressure_reason.to_string reason)
   | Noop reason -> Printf.sprintf "noop(%s)" (Noop_reason.to_string reason)
+;;
+
+let take_at_most count values =
+  let rec loop remaining acc = function
+    | _ when remaining <= 0 -> List.rev acc
+    | [] -> List.rev acc
+    | value :: rest -> loop (remaining - 1) (value :: acc) rest
+  in
+  loop count [] values
+;;
+
+(* TEL-OK: pure executor returns requested/started/failed names; caller owns
+   spawn telemetry after binding this result to its concrete boot path. *)
+let execute ~spawn_keeper ~suggested_keeper_names decision =
+  match decision with
+  | Spawn { suggested_keeper_count; _ } ->
+    let requested_keeper_names =
+      take_at_most suggested_keeper_count suggested_keeper_names
+    in
+    let started_keeper_names, failed_keeper_names =
+      List.fold_left
+        (fun (started, failed) keeper_name ->
+           match spawn_keeper keeper_name with
+           | Ok () -> (keeper_name :: started, failed)
+           | Error error -> (started, (keeper_name, error) :: failed))
+        ([], [])
+        requested_keeper_names
+    in
+    { decision
+    ; requested_keeper_names
+    ; started_keeper_names = List.rev started_keeper_names
+    ; failed_keeper_names = List.rev failed_keeper_names
+    }
+  | Backpressure _ | Noop _ ->
+    { decision
+    ; requested_keeper_names = []
+    ; started_keeper_names = []
+    ; failed_keeper_names = []
+    }
 ;;
 
 let cooldown_elapsed ~now ~last_action_at ~cooldown_seconds =

--- a/lib/keeper/keeper_fleet_capacity_supervisor.ml
+++ b/lib/keeper/keeper_fleet_capacity_supervisor.ml
@@ -100,7 +100,11 @@ let execute ~spawn_keeper ~suggested_keeper_names decision =
     let started_keeper_names, failed_keeper_names =
       List.fold_left
         (fun (started, failed) keeper_name ->
-           match spawn_keeper keeper_name with
+           match
+             try spawn_keeper keeper_name with
+             | Eio.Cancel.Cancelled _ as exn -> raise exn
+             | exn -> Error (Printexc.to_string exn)
+           with
            | Ok () -> (keeper_name :: started, failed)
            | Error error -> (started, (keeper_name, error) :: failed))
         ([], [])

--- a/lib/keeper/keeper_fleet_capacity_supervisor.mli
+++ b/lib/keeper/keeper_fleet_capacity_supervisor.mli
@@ -1,13 +1,14 @@
-(** Fleet Capacity Supervisor — pure tick core (RFC-0130 PR-2).
+(** Fleet Capacity Supervisor — tick core and execution boundary (RFC-0130).
 
     Closes the loop on [reaction_capacity_shortfall_count] (PR #16050)
     by converting the typed shortfall signal into a typed spawn decision.
     The decision is closed and total; probe-unknown failure modes are
     fail-closed at the admission boundary (matches RFC-0124 §2.2).
 
-    This module is intentionally I/O-free. [tick] is a deterministic
-    pure function over [observation]. The side-effecting [execute]
-    wrapper lives in a later PR (PR-4 per the RFC phased rollout). *)
+    [tick] is a deterministic pure function over [observation]. [execute]
+    owns the decision-to-spawn sequencing while accepting the concrete
+    side-effect as an injected callback so the server can wire keeper boot
+    without making this module depend on server/runtime plumbing. *)
 
 module Spawn_reason : sig
   type t =
@@ -62,6 +63,26 @@ type decision =
   | Noop of Noop_reason.t
 
 val decision_to_string : decision -> string
+
+type execution_result =
+  { decision : decision
+  ; requested_keeper_names : string list
+  ; started_keeper_names : string list
+  ; failed_keeper_names : (string * string) list
+  }
+
+val execute :
+  spawn_keeper:(string -> (unit, string) result) ->
+  suggested_keeper_names:string list ->
+  decision ->
+  execution_result
+(** Executes a [Spawn] decision by invoking [spawn_keeper] for at most
+    [suggested_keeper_count] names from [suggested_keeper_names].
+
+    [Backpressure] and [Noop] are execution no-ops and return an empty
+    request set. The result is total and records per-keeper failures
+    instead of raising; [spawn_keeper] may still raise cancellation, which
+    callers should preserve at the Eio boundary. *)
 
 val tick : observation -> decision
 (** Pure, total, deterministic.

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -936,11 +936,6 @@ let start_keeper_loops
                 ()
             in
             let bootable_names = Keeper_runtime.bootable_keeper_names config in
-            let registered_names =
-              Keeper_registry.all ~base_path:config.base_path ()
-              |> List.map (fun (entry : Keeper_registry.registry_entry) -> entry.name)
-              |> Server_routes_http_runtime_fleet_scan.sorted_unique_strings
-            in
             let target_count = List.length bootable_names in
             let minimum_running_fibers =
               if target_count <= 1 then target_count else 2
@@ -954,7 +949,7 @@ let start_keeper_loops
             in
             let supervisor_tick =
               Server_routes_http_runtime_fleet_scan.fleet_capacity_supervisor_tick
-                ~running_names:registered_names
+                ~running_names:phase_snapshot.running_names
                 ~autoboot_names:bootable_names
                 ~running_keeper_fiber_count:phase_snapshot.counts.running
                 ~target_reaction_capacity_count:target_count

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -774,18 +774,19 @@ let start_keeper_loops
       let base_warmup = Keeper_config.keeper_bootstrap_proactive_warmup_sec () in
       let stagger_window = Keeper_config.keeper_bootstrap_stagger_step_sec () in
       (* Attempt to boot a single keeper. Returns true if started. *)
-      let try_boot_one _idx name =
+      let try_boot_one ?(log_prefix = "autoboot") _idx name =
         try
-          Log.Keeper.info "autoboot: loading meta for %s" name;
+          Log.Keeper.info "%s: loading meta for %s" log_prefix name;
           match Keeper_runtime.load_or_materialize_boot_meta keeper_boot_ctx name with
           | Error e ->
-            Log.Keeper.error "autoboot: failed to load meta for %s: %s" name e;
+            Log.Keeper.error "%s: failed to load meta for %s: %s" log_prefix name e;
             false
           | Ok { meta = m; materialized } ->
             if Keeper_registry.is_running ~base_path:config.base_path m.name
             then (
               Log.Keeper.info
-                "autoboot: %s already running%s"
+                "%s: %s already running%s"
+                log_prefix
                 m.name
                 (if materialized then " (materialized from TOML)" else "");
               true)
@@ -797,7 +798,8 @@ let start_keeper_loops
                   ~keeper_name:name
               in
               Log.Keeper.info
-                "autoboot: calling start_keepalive for %s (warmup=%ds)"
+                "%s: calling start_keepalive for %s (warmup=%ds)"
+                log_prefix
                 name
                 warmup;
               let ctx : _ Keeper_types_profile.context =
@@ -824,16 +826,21 @@ let start_keeper_loops
                 Keeper_registry.is_registered ~base_path:config.base_path m.name
               in
               if registered
-              then Log.Keeper.info "autoboot: started keepalive for %s" m.name
+              then Log.Keeper.info "%s: started keepalive for %s" log_prefix m.name
               else
                 Log.Keeper.warn
-                  "autoboot: start_keepalive returned but %s not registered"
+                  "%s: start_keepalive returned but %s not registered"
+                  log_prefix
                   m.name;
               registered)
         with
         | Eio.Cancel.Cancelled _ as e -> raise e
         | exn ->
-          Log.Keeper.error "autoboot: exception for %s: %s" name (Printexc.to_string exn);
+          Log.Keeper.error
+            "%s: exception for %s: %s"
+            log_prefix
+            name
+            (Printexc.to_string exn);
           false
       in
       (* Initial boot pass *)
@@ -903,12 +910,114 @@ let start_keeper_loops
          [supervisor_sweep_running] guard makes a second call a
          noop, so this stays correct if [masc_keeper_msg] later
          races into [start_existing_keepalives] anyway. *)
-      try Keeper_runtime.start_supervisor_sweep keeper_boot_ctx with
-      | Eio.Cancel.Cancelled _ as e -> raise e
-      | exn ->
-        Log.Keeper.error
-          "autoboot: supervisor sweep failed to start: %s"
-          (Printexc.to_string exn)));
+      (try Keeper_runtime.start_supervisor_sweep keeper_boot_ctx with
+       | Eio.Cancel.Cancelled _ as e -> raise e
+       | exn ->
+         Log.Keeper.error
+           "autoboot: supervisor sweep failed to start: %s"
+           (Printexc.to_string exn));
+      let start_fleet_capacity_supervisor_loop () =
+        if not Env_config.KeeperSupervisor.fleet_capacity_tick_enabled
+        then
+          Log.Keeper.info
+            "fleet_capacity_supervisor: disabled via \
+             MASC_FLEET_CAPACITY_SUPERVISOR_TICK_ENABLED=false"
+        else (
+          let tick_interval =
+            Env_config.KeeperSupervisor.fleet_capacity_tick_interval_sec
+          in
+          let cooldown_seconds = Float.min 120.0 (tick_interval *. 2.0) in
+          let last_action_at = ref None in
+          let execute_once () =
+            let now = Eio.Time.now clock in
+            let phase_snapshot =
+              Server_routes_http_runtime_fleet_scan.keeper_phase_snapshot
+                ~base_path:config.base_path
+                ()
+            in
+            let bootable_names = Keeper_runtime.bootable_keeper_names config in
+            let registered_names =
+              Keeper_registry.all ~base_path:config.base_path ()
+              |> List.map (fun (entry : Keeper_registry.registry_entry) -> entry.name)
+              |> Server_routes_http_runtime_fleet_scan.sorted_unique_strings
+            in
+            let target_count = List.length bootable_names in
+            let minimum_running_fibers =
+              if target_count <= 1 then target_count else 2
+            in
+            let reaction_capacity_shortfall_count =
+              max
+                0
+                (target_count
+                 - phase_snapshot.counts.running
+                 - phase_snapshot.counts.recovering)
+            in
+            let supervisor_tick =
+              Server_routes_http_runtime_fleet_scan.fleet_capacity_supervisor_tick
+                ~running_names:registered_names
+                ~autoboot_names:bootable_names
+                ~running_keeper_fiber_count:phase_snapshot.counts.running
+                ~target_reaction_capacity_count:target_count
+                ~minimum_running_fibers
+                ~reaction_capacity_shortfall_count
+                ~now
+                ~last_action_at:!last_action_at
+                ~cooldown_seconds
+                ()
+            in
+            match supervisor_tick.decision with
+            | Keeper_fleet_capacity_supervisor.Spawn _ ->
+              let result =
+                Keeper_fleet_capacity_supervisor.execute
+                  ~spawn_keeper:(fun keeper_name ->
+                    if try_boot_one ~log_prefix:"fleet_capacity_supervisor" 0 keeper_name
+                    then Ok ()
+                    else Error "keeper boot did not register")
+                  ~suggested_keeper_names:supervisor_tick.suggested_keeper_names
+                  supervisor_tick.decision
+              in
+              if result.started_keeper_names <> [] then last_action_at := Some now;
+              if result.requested_keeper_names <> []
+              then
+                Log.Keeper.info
+                  "fleet_capacity_supervisor: decision=%s requested=[%s] \
+                   started=[%s] failed=%d"
+                  (Keeper_fleet_capacity_supervisor.decision_to_string
+                     result.decision)
+                  (String.concat ", " result.requested_keeper_names)
+                  (String.concat ", " result.started_keeper_names)
+                  (List.length result.failed_keeper_names);
+              if result.failed_keeper_names <> []
+              then
+                Log.Keeper.warn
+                  "fleet_capacity_supervisor: failed keepers [%s]"
+                  (result.failed_keeper_names
+                   |> List.map (fun (name, error) -> name ^ "=" ^ error)
+                   |> String.concat ", ")
+            | Keeper_fleet_capacity_supervisor.Backpressure reason ->
+              Log.Keeper.warn
+                "fleet_capacity_supervisor: backpressure=%s"
+                (Keeper_fleet_capacity_supervisor.Backpressure_reason.to_string
+                   reason)
+            | Keeper_fleet_capacity_supervisor.Noop _ -> ()
+          in
+          Log.Keeper.info
+            "fleet_capacity_supervisor: enabled interval=%.0fs cooldown=%.0fs"
+            tick_interval
+            cooldown_seconds;
+          let rec loop () =
+            (try execute_once () with
+             | Eio.Cancel.Cancelled _ as e -> raise e
+             | exn ->
+               Log.Keeper.warn
+                 "fleet_capacity_supervisor: tick failed: %s"
+                 (Printexc.to_string exn));
+            Eio.Time.sleep clock tick_interval;
+            loop ()
+          in
+          loop ())
+      in
+      start_fleet_capacity_supervisor_loop ()));
   (* Phase 5: unified startup subsystem summary *)
   Log.info ~ctx:"startup" "subsystems: keeper loops started"
 ;;

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -962,16 +962,24 @@ let start_keeper_loops
             in
             match supervisor_tick.decision with
             | Keeper_fleet_capacity_supervisor.Spawn _ ->
+              let unregistered_missing_autoboot_names =
+                supervisor_tick.missing_autoboot_names
+                |> List.filter (fun name ->
+                  not
+                    (Keeper_registry.is_registered
+                       ~base_path:config.base_path
+                       name))
+              in
               let result =
                 Keeper_fleet_capacity_supervisor.execute
                   ~spawn_keeper:(fun keeper_name ->
                     if try_boot_one ~log_prefix:"fleet_capacity_supervisor" 0 keeper_name
                     then Ok ()
                     else Error "keeper boot did not register")
-                  ~suggested_keeper_names:supervisor_tick.suggested_keeper_names
+                  ~suggested_keeper_names:unregistered_missing_autoboot_names
                   supervisor_tick.decision
               in
-              if result.started_keeper_names <> [] then last_action_at := Some now;
+              if result.requested_keeper_names <> [] then last_action_at := Some now;
               if result.requested_keeper_names <> []
               then
                 Log.Keeper.info
@@ -1012,7 +1020,9 @@ let start_keeper_loops
           in
           loop ())
       in
-      start_fleet_capacity_supervisor_loop ()));
+      fork_subsystem
+        "fleet_capacity_supervisor"
+        start_fleet_capacity_supervisor_loop));
   (* Phase 5: unified startup subsystem summary *)
   Log.info ~ctx:"startup" "subsystems: keeper loops started"
 ;;

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -426,13 +426,24 @@ let take_at_most count values =
   in
   loop count [] values
 
-let supervisor_decision_json
+type fleet_capacity_supervisor_tick =
+  { observation : Keeper_fleet_capacity_supervisor.observation
+  ; decision : Keeper_fleet_capacity_supervisor.decision
+  ; missing_autoboot_names : string list
+  ; suggested_keeper_names : string list
+  }
+
+let fleet_capacity_supervisor_tick
     ~running_names
     ~autoboot_names
     ~running_keeper_fiber_count
     ~target_reaction_capacity_count
     ~minimum_running_fibers
-    ~reaction_capacity_shortfall_count =
+    ~reaction_capacity_shortfall_count
+    ~now
+    ~last_action_at
+    ~cooldown_seconds
+    () =
   let observation : Keeper_fleet_capacity_supervisor.observation =
     { running_keeper_fiber_count
     ; target_reaction_capacity_count
@@ -443,9 +454,9 @@ let supervisor_decision_json
     ; disk_pressure_active = false
     ; fd_pressure_active = false
     ; cold_start_in_progress = false
-    ; now = 0.0
-    ; last_action_at = None
-    ; cooldown_seconds = 0.0
+    ; now
+    ; last_action_at
+    ; cooldown_seconds
     }
   in
   let running_name_set =
@@ -456,18 +467,45 @@ let supervisor_decision_json
   let missing_autoboot_names =
     autoboot_names |> List.filter (fun name -> not (String_set.mem name running_name_set))
   in
-  match Keeper_fleet_capacity_supervisor.tick observation with
-  | Spawn { reason; suggested_keeper_count } ->
-    let suggested_keeper_names =
+  let decision = Keeper_fleet_capacity_supervisor.tick observation in
+  let suggested_keeper_names =
+    match decision with
+    | Spawn { suggested_keeper_count; _ } ->
       take_at_most suggested_keeper_count missing_autoboot_names
-    in
+    | Backpressure _ | Noop _ -> []
+  in
+  { observation; decision; missing_autoboot_names; suggested_keeper_names }
+
+let supervisor_decision_json
+    ~running_names
+    ~autoboot_names
+    ~running_keeper_fiber_count
+    ~target_reaction_capacity_count
+    ~minimum_running_fibers
+    ~reaction_capacity_shortfall_count =
+  let supervisor_tick =
+    fleet_capacity_supervisor_tick
+      ~running_names
+      ~autoboot_names
+      ~running_keeper_fiber_count
+      ~target_reaction_capacity_count
+      ~minimum_running_fibers
+      ~reaction_capacity_shortfall_count
+      ~now:0.0
+      ~last_action_at:None
+      ~cooldown_seconds:0.0
+      ()
+  in
+  match supervisor_tick.decision with
+  | Spawn { reason; suggested_keeper_count } ->
     `Assoc
       [ "variant", `String "spawn"
       ; ( "reason"
         , `String (Keeper_fleet_capacity_supervisor.Spawn_reason.to_string reason) )
       ; "suggested_keeper_count", `Int suggested_keeper_count
       ; ( "suggested_keeper_names"
-        , `List (List.map (fun name -> `String name) suggested_keeper_names) )
+        , `List
+            (List.map (fun name -> `String name) supervisor_tick.suggested_keeper_names) )
       ]
   | Backpressure reason ->
     `Assoc

--- a/lib/server/server_routes_http_runtime_fleet_scan.mli
+++ b/lib/server/server_routes_http_runtime_fleet_scan.mli
@@ -66,6 +66,24 @@ type keeper_phase_snapshot = {
 }
 val keeper_phase_snapshot : ?base_path:string -> unit -> keeper_phase_snapshot
 val keeper_phase_counts : ?base_path:string -> unit -> keeper_phase_counts
+type fleet_capacity_supervisor_tick = {
+  observation : Keeper_fleet_capacity_supervisor.observation;
+  decision : Keeper_fleet_capacity_supervisor.decision;
+  missing_autoboot_names : string list;
+  suggested_keeper_names : string list;
+}
+val fleet_capacity_supervisor_tick :
+  running_names:string list ->
+  autoboot_names:string list ->
+  running_keeper_fiber_count:int ->
+  target_reaction_capacity_count:int ->
+  minimum_running_fibers:int ->
+  reaction_capacity_shortfall_count:int ->
+  now:float ->
+  last_action_at:float option ->
+  cooldown_seconds:float ->
+  unit ->
+  fleet_capacity_supervisor_tick
 val keeper_fleet_safety_health_json :
   ?bootable_names:string list ->
   ?autoboot_scan:autoboot_keeper_scan ->

--- a/test/test_fleet_capacity_supervisor.ml
+++ b/test/test_fleet_capacity_supervisor.ml
@@ -323,6 +323,73 @@ let test_decision_to_string () =
     (Sup.decision_to_string (Sup.Noop Sup.Noop_reason.Capacity_at_target))
 ;;
 
+(* §4. Execution boundary — Spawn decisions invoke bounded keeper starts. *)
+
+let test_execute_spawn_attempts_bounded_names () =
+  let calls = ref [] in
+  let decision =
+    Sup.Spawn
+      { reason = Sup.Spawn_reason.Below_target_reaction_capacity
+      ; suggested_keeper_count = 2
+      }
+  in
+  let result =
+    Sup.execute
+      ~spawn_keeper:(fun name ->
+        calls := name :: !calls;
+        if String.equal name "keeper-b" then Error "boom" else Ok ())
+      ~suggested_keeper_names:[ "keeper-a"; "keeper-b"; "keeper-c" ]
+      decision
+  in
+  check
+    (list string)
+    "requested names are bounded by suggested count"
+    [ "keeper-a"; "keeper-b" ]
+    result.requested_keeper_names;
+  check (list string) "started names preserve order" [ "keeper-a" ] result.started_keeper_names;
+  check int "records one failure" 1 (List.length result.failed_keeper_names);
+  check (list string) "does not call extra names" [ "keeper-b"; "keeper-a" ] !calls
+;;
+
+let test_execute_noop_does_not_call_spawn () =
+  let calls = ref 0 in
+  let result =
+    Sup.execute
+      ~spawn_keeper:(fun _name ->
+        incr calls;
+        Ok ())
+      ~suggested_keeper_names:[ "keeper-a" ]
+      (Sup.Noop Sup.Noop_reason.Capacity_at_target)
+  in
+  check int "spawn callback not called" 0 !calls;
+  check (list string) "no requested keepers" [] result.requested_keeper_names
+;;
+
+let test_execute_shortfall_reaches_target () =
+  let running = ref [ "running-a"; "running-b"; "running-c" ] in
+  let missing =
+    List.init 10 (fun idx -> Printf.sprintf "missing-%02d" (idx + 1))
+  in
+  let obs =
+    { base_obs with
+      running_keeper_fiber_count = 3
+    ; target_reaction_capacity_count = 13
+    ; minimum_running_fibers = 2
+    ; reaction_capacity_shortfall_count = 10
+    }
+  in
+  let result =
+    Sup.execute
+      ~spawn_keeper:(fun name ->
+        running := name :: !running;
+        Ok ())
+      ~suggested_keeper_names:missing
+      (Sup.tick obs)
+  in
+  check int "starts exactly the shortfall" 10 (List.length result.started_keeper_names);
+  check int "running reaches target after one tick and execute" 13 (List.length !running)
+;;
+
 let () =
   run
     "fleet_capacity_supervisor"
@@ -345,5 +412,10 @@ let () =
         ; test_case "tick is total" `Quick test_prop_totality
         ] )
     ; "formatting", [ test_case "decision_to_string" `Quick test_decision_to_string ]
+    ; ( "execute"
+      , [ test_case "spawn attempts bounded names" `Quick test_execute_spawn_attempts_bounded_names
+        ; test_case "noop does not call spawn" `Quick test_execute_noop_does_not_call_spawn
+        ; test_case "shortfall reaches target" `Quick test_execute_shortfall_reaches_target
+        ] )
     ]
 ;;

--- a/test/test_fleet_capacity_supervisor.ml
+++ b/test/test_fleet_capacity_supervisor.ml
@@ -365,6 +365,29 @@ let test_execute_noop_does_not_call_spawn () =
   check (list string) "no requested keepers" [] result.requested_keeper_names
 ;;
 
+let test_execute_records_spawn_exceptions () =
+  let decision =
+    Sup.Spawn
+      { reason = Sup.Spawn_reason.Below_target_reaction_capacity
+      ; suggested_keeper_count = 2
+      }
+  in
+  let result =
+    Sup.execute
+      ~spawn_keeper:(fun name ->
+        if String.equal name "keeper-b" then invalid_arg "spawn failed" else Ok ())
+      ~suggested_keeper_names:[ "keeper-a"; "keeper-b" ]
+      decision
+  in
+  check (list string) "started keeper-a" [ "keeper-a" ] result.started_keeper_names;
+  check int "records one exception failure" 1 (List.length result.failed_keeper_names);
+  match result.failed_keeper_names with
+  | [ name, error ] ->
+    check string "failed keeper name" "keeper-b" name;
+    check bool "records exception text" true (String.length error > 0)
+  | _ -> fail "expected one failed keeper"
+;;
+
 let test_execute_shortfall_reaches_target () =
   let running = ref [ "running-a"; "running-b"; "running-c" ] in
   let missing =
@@ -415,6 +438,7 @@ let () =
     ; ( "execute"
       , [ test_case "spawn attempts bounded names" `Quick test_execute_spawn_attempts_bounded_names
         ; test_case "noop does not call spawn" `Quick test_execute_noop_does_not_call_spawn
+        ; test_case "records spawn exceptions" `Quick test_execute_records_spawn_exceptions
         ; test_case "shortfall reaches target" `Quick test_execute_shortfall_reaches_target
         ] )
     ]


### PR DESCRIPTION
## Summary

- adds the RFC-0130 execution boundary for fleet capacity supervisor spawn decisions
- wires a post-autoboot `fleet_capacity_supervisor` loop that starts missing bootable keepers from one typed tick
- adds the default-on `MASC_FLEET_CAPACITY_SUPERVISOR_TICK_ENABLED` flag plus clamped tick interval docs

## Product impact

- User-visible change: fleet capacity shortfalls can self-heal after autoboot by starting missing bootable keepers; operators can opt out with `MASC_FLEET_CAPACITY_SUPERVISOR_TICK_ENABLED=false`.

## Evidence

- `scripts/dune-local.sh exec ./bin/env_knob_catalog.exe -- docs/runtime-tunables.md`
- `scripts/check-feature-flag-consistency.sh`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build --display short test/test_fleet_capacity_supervisor.exe`
- `_build/default/test/test_fleet_capacity_supervisor.exe` (18 tests)
- pre-commit hook full `dune build --root .`

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 5/5
provenance: direct
stages:
  - name: env knob catalog regeneration
    command: scripts/dune-local.sh exec ./bin/env_knob_catalog.exe -- docs/runtime-tunables.md
    result: pass
  - name: feature flag consistency
    command: scripts/check-feature-flag-consistency.sh
    result: pass
  - name: focused executable build
    command: env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build --display short test/test_fleet_capacity_supervisor.exe
    result: pass
  - name: focused supervisor tests
    command: _build/default/test/test_fleet_capacity_supervisor.exe
    result: pass
  - name: pre-commit build
    command: dune build --root .
    result: pass
```

## GOAL LOOP ACT checklist

- [x] Observe — RFC-0130 documents `/health` shortfall telemetry terminating without execution.
- [x] Orient — PR-4 scope maps the typed `tick` decision to keeper boot attempts.
- [x] Decide — bounded execution loop after autoboot, default-on with an env opt-out.
- [x] Act — code/config/docs/tests changed in the RFC-0130 surfaces only.
- [x] Verify — focused supervisor tests, focused executable build, feature-flag lint, and pre-commit full build pass.
- [x] Loop — PR-5 closeout remains documented in RFC-0130 after this PR merges.

## Review evidence

- Not yet requested; draft PR for CI and review bot pass first.

## Linked issue

- Relates #16168

## Variant addition checklist

- [ ] **OCaml** — N/A: no new OCaml variant was added; existing RFC-0130 variants were matched.
- [ ] **TypeScript** — N/A: no TypeScript union member changed.
- [ ] **TLA+ spec** — N/A: no TLA+ domain literal changed.
- [ ] **Event / JSON schema** — N/A: no event type string or JSON schema enum changed.
- [ ] **`make check-variants` passes** — N/A: no variant/domain addition in this PR.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`feat/rfc-0130-execute-supervisor-20260602` → `main` · 1 commit(s) · synced 2026-06-02T01:46:40Z

| sha | subject | date |
|---|---|---|
| `dc123f5ec` | feat(rfc-0130): execute fleet capacity supervisor tick | 2026-06-02 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->