### PR TITLE
fix: return alternatives for denied shell helpers

### DIFF
--- a/lib/keeper/agent_tool_execute_typed_input.ml
+++ b/lib/keeper/agent_tool_execute_typed_input.ml
@@ -599,6 +599,15 @@ let executable_not_allowlisted_hint ~name ~mode =
     | _ -> None
 ;;
 
+let executable_not_allowlisted_alternatives ~name ~mode:_ =
+  match name with
+  | "mkdir" -> [ "tool_write_file"; "tool_edit_file"; "git" ]
+  | "touch" -> [ "tool_write_file"; "tool_edit_file" ]
+  | "test" ->
+    [ "stat"; "ls"; "tool_search_files"; "tool_read_file"; "keeper_tasks_list" ]
+  | _ -> []
+;;
+
 let pp_validation_error ppf = function
   | Executable_not_allowlisted { name; mode } ->
     (match executable_not_allowlisted_hint ~name ~mode with
@@ -667,6 +676,8 @@ let pp_validation_error ppf = function
 ;;
 
 let validation_error_alternatives : validation_error -> string list = function
+  | Executable_not_allowlisted { name; mode } ->
+    executable_not_allowlisted_alternatives ~name ~mode
   | Argv_contains_shell_metachar _ -> [ "Pipeline" ]
   | Argv_contains_shell_redirection _ ->
     [ "discard_stderr"; "discard_stdout"; "Pipeline" ]

--- a/lib/keeper/agent_tool_execute_typed_input.mli
+++ b/lib/keeper/agent_tool_execute_typed_input.mli
@@ -160,7 +160,8 @@ val pp_validation_error : Format.formatter -> validation_error -> unit
 
 val validation_error_alternatives : validation_error -> string list
 (** Structured alternatives for machine consumers (JSON responses).
-    Returns tool names or field names the LLM should use instead of the
-    rejected pattern.  Empty list when no typed alternative exists.
+    Returns tool names, field names, or allowlisted executable names the LLM
+    should use instead of the rejected pattern.  Empty list when no typed
+    alternative exists.
     SSOT: each variant maps to exactly one alternatives list here;
     callers must not add ad-hoc alternatives at the JSON layer. *)

--- a/test/test_agent_tool_execute_typed_input.ml
+++ b/test/test_agent_tool_execute_typed_input.ml
@@ -942,9 +942,24 @@ let test_validation_error_alternatives () =
        { executable = "find"; index = 3; token = "foo\nbar" })
     [ "Pipeline" ];
   check_alts
-    ~name:"Executable_not_allowlisted has no alternatives"
+    ~name:"Executable_not_allowlisted rm has no alternatives"
     (Execute_input.Executable_not_allowlisted { name = "rm"; mode = Execute_input.Dev_full })
     [];
+  check_alts
+    ~name:"Executable_not_allowlisted mkdir alternatives"
+    (Execute_input.Executable_not_allowlisted
+       { name = "mkdir"; mode = Execute_input.Dev_full })
+    [ "tool_write_file"; "tool_edit_file"; "git" ];
+  check_alts
+    ~name:"Executable_not_allowlisted touch alternatives"
+    (Execute_input.Executable_not_allowlisted
+       { name = "touch"; mode = Execute_input.Dev_full })
+    [ "tool_write_file"; "tool_edit_file" ];
+  check_alts
+    ~name:"Executable_not_allowlisted test alternatives"
+    (Execute_input.Executable_not_allowlisted
+       { name = "test"; mode = Execute_input.Dev_full })
+    [ "stat"; "ls"; "tool_search_files"; "tool_read_file"; "keeper_tasks_list" ];
   check_alts
     ~name:"Empty_executable has no alternatives"
     (Execute_input.Empty_executable { argv = [ "ls" ] })


### PR DESCRIPTION
## Summary

- Add structured `alternatives` for denied `mkdir`, `touch`, and `test` Execute requests.
- Keep `mkdir`, `touch`, and `test` out of the Execute allowlist.
- Update the alternatives interface docs and SSOT regression test.

## Product impact

- User-visible change: keeper Execute errors now carry machine-readable alternatives for common shell-helper mistakes, reducing repeated denied tool calls without expanding shell authority.

## Evidence

- `git diff --check`
- `env DUNE_CACHE=disabled dune build --root . --build-dir _build-codex-exec-direct --display short -j 1 ./test/test_agent_tool_execute_typed_input.exe`
- `./_build-codex-exec-direct/default/test/test_agent_tool_execute_typed_input.exe`

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 3/3
provenance: direct
stages:
  - name: whitespace check
    command: git diff --check
    result: pass
  - name: focused typed input build
    command: env DUNE_CACHE=disabled dune build --root . --build-dir _build-codex-exec-direct --display short -j 1 ./test/test_agent_tool_execute_typed_input.exe
    result: pass
  - name: typed input test binary
    command: ./_build-codex-exec-direct/default/test/test_agent_tool_execute_typed_input.exe
    result: pass
```

## GOAL LOOP ACT checklist

- [x] Observe — keeper logs show denied `mkdir`, `touch`, and `test` Execute calls repeating without structured alternatives.
- [x] Orient — root cause is `Executable_not_allowlisted` only emitted prose hints while `validation_error_alternatives` returned `[]`.
- [x] Decide — bounded fix adds alternatives for the repeated denied helpers without adding shell authority.
- [x] Act — code and SSOT test changed in the typed Execute input layer.
- [x] Verify — focused typed input build and test binary pass locally.
- [x] Loop — no follow-up in this PR.

## Review evidence

- Not run; small scoped contract/test change.

## Linked issue

- Closes #N/A
- Relates #N/A

## Variant addition checklist

- [ ] **OCaml** — N/A: no variant added, removed, or renamed.
- [ ] **TypeScript** — N/A: no dashboard union change.
- [ ] **TLA+ spec** — N/A: no spec domain literal change.
- [ ] **Event / JSON schema** — N/A: no event/schema enum change.
- [ ] **`make check-variants` passes** — N/A: no variant/schema enum change.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`fix/execute-denial-alternatives` → `main` · 1 commit(s) · synced 2026-06-02T01:47:42Z

| sha | subject | date |
|---|---|---|
| `72d0ae365` | fix: return alternatives for denied shell helpers | 2026-06-02 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->