### PR TITLE
[codex] Purge keeper git credential identity fields

### DIFF
--- a/docs/rfc/RFC-0038-phase-2-keeper-identity-canonical.md
+++ b/docs/rfc/RFC-0038-phase-2-keeper-identity-canonical.md
@@ -204,7 +204,8 @@ let transition_task_r ~identity ~task_state =
 **채택: ActivityPub + OIDC Hybrid Model**
 - `keeper_name`을 canonical identifier로 명시. 속성: immutable, never reassigned, locally unique within masc instance.
 - `agent_name`을 display/handle로 분리. `preferredUsername`처럼 mutable, non-unique. UI 표시용.
-- `persona_name` = `keeper_name` (1:1). `credential_stem` = `keeper_name` (1:1). 이 관계를 타입으로 보증.
+- `persona_name` = `keeper_name` (1:1). Credential selection is not a keeper
+  identity field; it is resolved by the credential store / repo mapping layer.
 - `canonical_keeper_name`의 4가지 prefix/suffix 조합 처리를 "legacy alias resolution"으로 재명명. 새 코드는 canonical `keeper_name`만 사용.
 - 단점: 기존 `agent_name`과 `keeper_name`이 다른 keeper들의 마이그레이션 필요. `keeper_name_from_agent_name`의 4-way match는 deprecation path 필요.
 

--- a/docs/rfc/RFC-0191-descriptor-policy-ssot.md
+++ b/docs/rfc/RFC-0191-descriptor-policy-ssot.md
@@ -29,7 +29,6 @@ type policy =
   ; approval             : approval
   ; retryable            : bool
   ; cwd_scope            : string option
-  ; credential_profile   : string option
   }
 ```
 
@@ -84,7 +83,6 @@ type policy =
   ; approval             : approval
   ; retryable            : bool
   ; cwd_scope            : string option
-  ; credential_profile   : string option
   ; (* NEW *)
     audience             : audience_class
     (* Tool-access grant required to expose this tool. *)

--- a/lib/auth.mli
+++ b/lib/auth.mli
@@ -76,11 +76,8 @@ val load_credential_of :
     explicitly}.
 
     Caller is responsible for resolving the requested alias to a
-    [resolved_credential_stem] before calling — typically through
-    {!Keeper_identity.normalize_all_names} on the dispatch site.  This
-    keeps [Auth] free of any dependency on [Keeper_identity] (the
-    inverse direction is required by P3 preflight, so Auth → Keeper
-    would be a cycle).
+    [resolved_credential_stem] before calling. This keeps [Auth] free
+    of any dependency on [Keeper_identity].
 
     Branches (RFC §2.2, adjusted for the dependency direction):
     {ul

--- a/lib/keeper/agent_tool_descriptor.ml
+++ b/lib/keeper/agent_tool_descriptor.ml
@@ -70,7 +70,6 @@ type policy =
   ; approval : approval
   ; retryable : bool
   ; cwd_scope : string option
-  ; credential_profile : string option
   }
 
 type t =
@@ -154,8 +153,7 @@ let runtime_handler_to_string = function
 ;;
 
 let policy ?(visibility = Tool_catalog.Default) ?readonly ?readonly_of_input
-      ?effect_domain ?(approval = Policy_selected) ?cwd_scope ?credential_profile
-      ?(retryable = false) ()
+      ?effect_domain ?(approval = Policy_selected) ?cwd_scope ?(retryable = false) ()
   =
   let readonly_of_input =
     match readonly_of_input with
@@ -169,7 +167,6 @@ let policy ?(visibility = Tool_catalog.Default) ?readonly ?readonly_of_input
   ; approval
   ; retryable
   ; cwd_scope
-  ; credential_profile
   }
 ;;
 
@@ -449,8 +446,9 @@ let public_descriptors =
       ~public_name:"Read"
       ~internal_name:"tool_read_file"
       ~description:
-        "Read one existing file from the keeper sandbox or an allowed path. Pass cwd \
-         explicitly for repo-relative reads; Read never inherits Execute cwd."
+        "Read one existing file from the keeper sandbox or an allowed path with no \
+         implicit cwd. Pass cwd explicitly for repo-relative reads. Read never \
+         inherits Execute cwd."
       ~input_schema:read_file_schema
       ~policy:
         (policy
@@ -1292,7 +1290,6 @@ let route_evidence_json d =
      ; "approval", `String (approval_to_string policy.approval)
      ; "retryable", `Bool policy.retryable
      ; "cwd_scope", Json_util.string_opt_to_json policy.cwd_scope
-     ; "credential_profile", Json_util.string_opt_to_json policy.credential_profile
      ]
      @ policy_fields)
 ;;

--- a/lib/keeper/agent_tool_descriptor.mli
+++ b/lib/keeper/agent_tool_descriptor.mli
@@ -75,7 +75,6 @@ type policy =
   ; approval : approval
   ; retryable : bool
   ; cwd_scope : string option
-  ; credential_profile : string option
   }
 
 type t =

--- a/lib/keeper/keeper_identity.ml
+++ b/lib/keeper/keeper_identity.ml
@@ -124,17 +124,11 @@ type name_bundle = {
   persona_name : string;
   keeper_name : string;
   agent_name : string;
-  credential_stem : string;
 }
 
 type validation_error =
   | Empty_input
   | Persona_not_found of {
-      input : string;
-      resolved : string;
-      searched : string;
-    }
-  | Credential_missing of {
       input : string;
       resolved : string;
       searched : string;
@@ -147,10 +141,6 @@ let pp_validation_error fmt = function
   | Persona_not_found { input; resolved; searched } ->
       Format.fprintf fmt
         "Persona_not_found { input=%S; resolved=%S; searched=%S }" input
-        resolved searched
-  | Credential_missing { input; resolved; searched } ->
-      Format.fprintf fmt
-        "Credential_missing { input=%S; resolved=%S; searched=%S }" input
         resolved searched
   | Name_ambiguous { input; candidates } ->
       Format.fprintf fmt "Name_ambiguous { input=%S; candidates=[%s] }" input
@@ -172,7 +162,6 @@ let show_validation_error err =
 let validation_error_outcome_label = function
   | Empty_input -> "empty_input"
   | Persona_not_found _ -> "persona_not_found"
-  | Credential_missing _ -> "credential_missing"
   | Name_ambiguous _ -> "name_ambiguous"
   | Ephemeral_suffix_rejected _ -> "ephemeral_suffix_rejected"
 
@@ -206,7 +195,7 @@ let persona_path_for ~base_path persona_name =
         persona_name
 
 let normalize_all_names ~input_agent_name ?(base_path = "")
-    ?(check_persona = false) ?(check_credential = false) () :
+    ?(check_persona = false) () :
     (name_bundle, validation_error) result =
   let trimmed = String.trim input_agent_name in
   if trimmed = "" then Error Empty_input
@@ -223,13 +212,11 @@ let normalize_all_names ~input_agent_name ?(base_path = "")
     | Some keeper_first_pass ->
         let keeper_name = strip_nickname_once keeper_first_pass in
         let persona_name = keeper_name in
-        let credential_stem = keeper_name in
         let bundle =
           {
             persona_name;
             keeper_name;
             agent_name = input_agent_name;
-            credential_stem;
           }
         in
         let persona_check () =
@@ -242,22 +229,7 @@ let normalize_all_names ~input_agent_name ?(base_path = "")
                 (Persona_not_found
                    { input = input_agent_name; resolved = persona_name; searched = path })
         in
-        let credential_check () =
-          if not check_credential then Ok ()
-          else
-            let path =
-              Filename.concat
-                (Common.agents_dir_from_base_path ~base_path)
-                (credential_stem ^ ".json")
-            in
-            if Sys.file_exists path then Ok ()
-            else
-              Error
-                (Credential_missing
-                   { input = input_agent_name; resolved = credential_stem; searched = path })
-        in
-        Result.bind (persona_check ()) (fun () ->
-            Result.bind (credential_check ()) (fun () -> Ok bundle))
+        Result.bind (persona_check ()) (fun () -> Ok bundle)
 
 type parsed_identity = {
   keeper_name : string;

--- a/lib/keeper/keeper_identity.mli
+++ b/lib/keeper/keeper_identity.mli
@@ -1,12 +1,11 @@
-(** Keeper_identity — Trace ID generation, git identity, and keeper-name
-    normalization for keeper operations. *)
+(** Keeper_identity — Trace ID generation and keeper-name normalization for
+    keeper operations. *)
 
 val generate_trace_id : ?now:float -> unit -> string
 (** Generate a unique trace ID from an epoch timestamp and monotonic counter.
     [~now] defaults to [Time_compat.now ()] — pass an explicit value in tests
     for deterministic output.  The counter guarantees uniqueness even when
     [now] is pinned to the same value across consecutive calls. *)
-
 val keeper_name_from_agent_name : string -> string option
 val is_keeper_agent_alias : string -> bool
 val canonical_keeper_name_from_agent_name : string -> string option
@@ -38,17 +37,11 @@ type name_bundle = {
   persona_name : string;
   keeper_name : string;
   agent_name : string;
-  credential_stem : string;
 }
 
 type validation_error =
   | Empty_input
   | Persona_not_found of {
-      input : string;
-      resolved : string;
-      searched : string;
-    }
-  | Credential_missing of {
       input : string;
       resolved : string;
       searched : string;
@@ -60,18 +53,16 @@ val normalize_all_names :
   input_agent_name:string ->
   ?base_path:string ->
   ?check_persona:bool ->
-  ?check_credential:bool ->
   unit ->
   (name_bundle, validation_error) result
-(** [normalize_all_names ~input_agent_name ?base_path ?check_persona
-    ?check_credential ()] resolves the four canonical name fields of a
+(** [normalize_all_names ~input_agent_name ?base_path ?check_persona ()]
+    resolves the canonical name fields of a
     keeper from any of its accepted input shapes (bare name, [keeper-X-agent]
     wrapper, generated nickname like [executor-warm-raven], or wrapper +
     nickname combination).
 
-    P1 default: [check_persona = false], [check_credential = false] —
-    pure normalization without filesystem lookups. P3 preflight enables
-    both.
+    P1 default: [check_persona = false] — pure normalization without
+    filesystem lookups. P3 preflight enables persona existence checks.
 
     [base_path] defaults to the empty string, which makes
     [Common.masc_dir_from_base_path] resolve relative to the current

--- a/lib/prometheus_builtin_metrics_part4.ml
+++ b/lib/prometheus_builtin_metrics_part4.ml
@@ -383,8 +383,8 @@ let register
     metric_workspace_bind_normalize_outcome
     "Total Workspace.bind_session identity normalizations by Keeper_identity.normalize_all_names \
      (RFC P3-a). Labels: outcome (ok | empty_input | persona_not_found | \
-     credential_missing | name_ambiguous | ephemeral_suffix_rejected). Non-ok outcomes \
-     reject agent session binding at the fail-closed identity gate; pair with \
+     name_ambiguous | ephemeral_suffix_rejected). Non-ok outcomes reject agent session \
+     binding at the fail-closed identity gate; pair with \
      masc_silent_auth_token_resolve_error_total for auth/name drift diagnosis."
     `Counter;
   add

--- a/lib/workspace_identity_backend.ml
+++ b/lib/workspace_identity_backend.ml
@@ -14,7 +14,6 @@ let validate_join_identity ~base_path ~agent_name =
       ~input_agent_name:agent_name
       ~base_path
       ~check_persona:true
-      ~check_credential:true
       ()
   with
   | Ok bundle -> Ok bundle.keeper_name

--- a/test/test_keeper_identity_normalize.ml
+++ b/test/test_keeper_identity_normalize.ml
@@ -1,7 +1,7 @@
 (** Tests for [Keeper_identity.normalize_all_names] — RFC P1.
 
-    Covers the input-shape × field matrix, round-trip stability across
-    wrappers, and filesystem checks gated by [?check_credential]. *)
+    Covers the input-shape × field matrix and round-trip stability across
+    wrappers. *)
 
 open Alcotest
 open Masc_mcp
@@ -12,8 +12,8 @@ let bundle =
   testable
     (fun fmt (b : Keeper_identity.name_bundle) ->
       Format.fprintf fmt
-        "{ persona_name=%S; keeper_name=%S; agent_name=%S; credential_stem=%S }"
-        b.persona_name b.keeper_name b.agent_name b.credential_stem)
+        "{ persona_name=%S; keeper_name=%S; agent_name=%S }"
+        b.persona_name b.keeper_name b.agent_name)
     ( = )
 
 let validation_error =
@@ -33,37 +33,33 @@ let ok_or_fail label = function
 (* 6 input shapes × 4 field matrix                                        *)
 (* --------------------------------------------------------------------- *)
 
-let check_bundle ~label ~input ~persona ~keeper ~agent ~credential =
+let check_bundle ~label ~input ~persona ~keeper ~agent =
   let b = ok_or_fail label (normalize input) in
   check string (label ^ ": persona_name") persona b.persona_name;
   check string (label ^ ": keeper_name") keeper b.keeper_name;
-  check string (label ^ ": agent_name") agent b.agent_name;
-  check string (label ^ ": credential_stem") credential b.credential_stem
+  check string (label ^ ": agent_name") agent b.agent_name
 
 let test_bare_canonical () =
   check_bundle ~label:"bare canonical" ~input:"sangsu" ~persona:"sangsu"
-    ~keeper:"sangsu" ~agent:"sangsu" ~credential:"sangsu"
+    ~keeper:"sangsu" ~agent:"sangsu"
 
 let test_keeper_dash_agent_wrapper () =
   check_bundle ~label:"keeper-X-agent wrapper" ~input:"keeper-sangsu-agent"
     ~persona:"sangsu" ~keeper:"sangsu" ~agent:"keeper-sangsu-agent"
-    ~credential:"sangsu"
 
 let test_keeper_underscore_agent_wrapper () =
   check_bundle ~label:"keeper_X_agent wrapper" ~input:"keeper_sangsu_agent"
     ~persona:"sangsu" ~keeper:"sangsu" ~agent:"keeper_sangsu_agent"
-    ~credential:"sangsu"
 
 let test_ephemeral_suffix_only () =
   check_bundle ~label:"ephemeral suffix" ~input:"issue_king-pale-llama"
     ~persona:"issue_king" ~keeper:"issue_king"
-    ~agent:"issue_king-pale-llama" ~credential:"issue_king"
+    ~agent:"issue_king-pale-llama"
 
 let test_wrapper_plus_ephemeral () =
   check_bundle ~label:"wrapper + suffix"
     ~input:"keeper-executor-warm-raven-agent" ~persona:"executor"
     ~keeper:"executor" ~agent:"keeper-executor-warm-raven-agent"
-    ~credential:"executor"
 
 let test_empty_input () =
   match normalize "" with
@@ -113,101 +109,8 @@ let test_round_trip_for_name name () =
         canonical_bundle.persona_name b.persona_name;
       check string ("round-trip keeper_name for " ^ shape)
         canonical_bundle.keeper_name b.keeper_name;
-      check string ("round-trip credential_stem for " ^ shape)
-        canonical_bundle.credential_stem b.credential_stem)
+      check string ("round-trip agent_name for " ^ shape) shape b.agent_name)
     (wrappers name)
-
-(* --------------------------------------------------------------------- *)
-(* Fixture-based credential check (?check_credential:true)                *)
-(* --------------------------------------------------------------------- *)
-
-let mkdir_p path =
-  let rec ensure p =
-    if p = "" || p = "/" || Sys.file_exists p then ()
-    else (
-      ensure (Filename.dirname p);
-      try Unix.mkdir p 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ())
-  in
-  ensure path
-
-let rec rm_rf path =
-  if Sys.file_exists path then
-    if Sys.is_directory path then (
-      Array.iter
-        (fun entry -> rm_rf (Filename.concat path entry))
-        (Sys.readdir path);
-      try Unix.rmdir path with Unix.Unix_error _ -> ())
-    else try Sys.remove path with Sys_error _ -> ()
-
-let with_tmp_base f =
-  let tmp_dir = Filename.temp_file "masc_id_p1" "" in
-  Sys.remove tmp_dir;
-  Unix.mkdir tmp_dir 0o755;
-  Fun.protect
-    ~finally:(fun () -> rm_rf tmp_dir)
-    (fun () -> f tmp_dir)
-
-let credential_path base stem =
-  Filename.concat base
-    (Filename.concat ".masc" (Filename.concat "auth" (Filename.concat "agents" (stem ^ ".json"))))
-
-let test_check_credential_present () =
-  with_tmp_base (fun base ->
-      let path = credential_path base "sangsu" in
-      mkdir_p (Filename.dirname path);
-      let ch = open_out path in
-      output_string ch "{}";
-      close_out ch;
-      match
-        Keeper_identity.normalize_all_names ~input_agent_name:"sangsu"
-          ~base_path:base ~check_credential:true ()
-      with
-      | Ok b -> check string "credential_stem" "sangsu" b.credential_stem
-      | Error e ->
-          fail
-            (Printf.sprintf "expected Ok with credential present, got %s"
-               (Keeper_identity.show_validation_error e)))
-
-let test_check_credential_missing () =
-  with_tmp_base (fun base ->
-      let expected_path = credential_path base "sangsu" in
-      match
-        Keeper_identity.normalize_all_names ~input_agent_name:"sangsu"
-          ~base_path:base ~check_credential:true ()
-      with
-      | Ok _ -> fail "expected Credential_missing when file absent"
-      | Error
-          (Keeper_identity.Credential_missing { searched; resolved; input }) ->
-          check string "searched path" expected_path searched;
-          check string "resolved" "sangsu" resolved;
-          check string "input" "sangsu" input
-      | Error other ->
-          fail
-            (Printf.sprintf "expected Credential_missing, got %s"
-               (Keeper_identity.show_validation_error other)))
-
-let test_check_credential_wrapper_input () =
-  (* Caller passes wrapper form; credential file under canonical stem. *)
-  with_tmp_base (fun base ->
-      let path = credential_path base "sangsu" in
-      mkdir_p (Filename.dirname path);
-      let ch = open_out path in
-      output_string ch "{}";
-      close_out ch;
-      match
-        Keeper_identity.normalize_all_names
-          ~input_agent_name:"keeper-sangsu-agent" ~base_path:base
-          ~check_credential:true ()
-      with
-      | Ok b ->
-          check string "credential resolves to canonical stem" "sangsu"
-            b.credential_stem;
-          check string "agent_name preserved" "keeper-sangsu-agent" b.agent_name
-      | Error e ->
-          fail
-            (Printf.sprintf
-               "wrapper input with present credential should Ok, got %s"
-               (Keeper_identity.show_validation_error e)))
 
 (* --------------------------------------------------------------------- *)
 (* Test runner                                                            *)
@@ -239,12 +142,5 @@ let () =
             (test_round_trip_for_name "qa-king");
           test_case "round-trip masc-improver" `Quick
             (test_round_trip_for_name "masc-improver");
-        ] );
-      ( "credential_check",
-        [
-          test_case "credential present" `Quick test_check_credential_present;
-          test_case "credential missing" `Quick test_check_credential_missing;
-          test_case "wrapper input → canonical stem" `Quick
-            test_check_credential_wrapper_input;
         ] );
     ]

--- a/test/test_keeper_identity_outcome_label.ml
+++ b/test/test_keeper_identity_outcome_label.ml
@@ -21,13 +21,6 @@ let test_persona_not_found () =
   in
   check string "Persona_not_found" "persona_not_found" (label_of err)
 
-let test_credential_missing () =
-  let err =
-    Keeper_identity.Credential_missing
-      { input = dummy_input; resolved = "kpper"; searched = "/x" }
-  in
-  check string "Credential_missing" "credential_missing" (label_of err)
-
 let test_name_ambiguous () =
   let err =
     Keeper_identity.Name_ambiguous { input = dummy_input; candidates = [ "a"; "b" ] }
@@ -49,7 +42,6 @@ let () =
         [
           test_case "Empty_input" `Quick test_empty_input;
           test_case "Persona_not_found" `Quick test_persona_not_found;
-          test_case "Credential_missing" `Quick test_credential_missing;
           test_case "Name_ambiguous" `Quick test_name_ambiguous;
           test_case "Ephemeral_suffix_rejected" `Quick
             test_ephemeral_suffix_rejected;

--- a/test/test_workspace_bind_fail_closed.ml
+++ b/test/test_workspace_bind_fail_closed.ml
@@ -10,14 +10,11 @@
 
     Note on persona path resolution: [normalize_all_names] uses
     [Config_dir_resolver.personas_dir_opt()] first, which returns the global
-    config dir and ignores [base_path].  Credential checks DO use [base_path]
-    directly via [Common.agents_dir_from_base_path].  Therefore:
-    - Identity-level rejection tests (empty/whitespace/invalid chars) need no
-      filesystem setup — they fail before filesystem checks.
-    - Credential-only tests use [~check_persona:false] with temp dirs, since
-      credential resolution respects [base_path].
-    - Full-gate tests would require a known persona in the global config dir,
-      which is machine-dependent and excluded from CI. *)
+    config dir and ignores [base_path]. Identity-level rejection tests
+    (empty/whitespace/invalid chars) need no filesystem setup because they fail
+    before filesystem checks. Full-gate persona-present tests would require a
+    known persona in the global config dir, which is machine-dependent and
+    excluded from CI. *)
 
 open Alcotest
 open Masc_mcp
@@ -27,20 +24,16 @@ let () = Server_startup_state.mark_state_ready ~backend_mode:"test"
 let validation_error =
   testable Keeper_identity.pp_validation_error ( = )
 
-let normalize ~input ?base_path ?(check_persona = true) ?(check_credential = true) () =
+let normalize ~input ?base_path ?(check_persona = true) () =
   Keeper_identity.normalize_all_names
     ~input_agent_name:input
     ?base_path
     ~check_persona
-    ~check_credential
     ()
 
 (* Same flags as handle_join uses *)
 let join_normalize ~input ?base_path () =
-  normalize ~input ?base_path ~check_persona:true ~check_credential:true ()
-
-let credential_only_normalize ~input ?base_path () =
-  normalize ~input ?base_path ~check_persona:false ~check_credential:true ()
+  normalize ~input ?base_path ~check_persona:true ()
 
 (* --------------------------------------------------------------------- *)
 (* Identity-level rejections (canonical_keeper_name returns None)         *)
@@ -70,100 +63,16 @@ let test_invalid_chars_rejected () =
            (Keeper_identity.show_validation_error other))
 
 (* --------------------------------------------------------------------- *)
-(* Helpers for temp-dir based credential tests                            *)
-(* --------------------------------------------------------------------- *)
-
-let mkdir_p path =
-  let rec ensure p =
-    if p = "" || p = "/" || Sys.file_exists p then ()
-    else (
-      ensure (Filename.dirname p);
-      try Unix.mkdir p 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ())
-  in
-  ensure path
-
-let rec rm_rf path =
-  if Sys.file_exists path then
-    if Sys.is_directory path then (
-      Array.iter
-        (fun entry -> rm_rf (Filename.concat path entry))
-        (Sys.readdir path);
-      try Unix.rmdir path with Unix.Unix_error _ -> ())
-    else try Sys.remove path with Sys_error _ -> ()
-
-let with_tmp_base f =
-  let tmp_dir = Filename.temp_file "masc_bind_gate" "" in
-  Sys.remove tmp_dir;
-  Unix.mkdir tmp_dir 0o755;
-  Fun.protect
-    ~finally:(fun () -> rm_rf tmp_dir)
-    (fun () -> f tmp_dir)
-
-let credential_path base name =
-  Filename.concat
-    (Filename.concat
-       (Filename.concat base ".masc")
-       (Filename.concat "auth" "agents"))
-    (name ^ ".json")
-
-let write_json path =
-  mkdir_p (Filename.dirname path);
-  let ch = open_out path in
-  output_string ch "{}";
-  close_out ch
-
-(* --------------------------------------------------------------------- *)
-(* Credential gate (check_persona:false — uses base_path directly)        *)
-(* --------------------------------------------------------------------- *)
-
-let test_credential_missing_rejected () =
-  with_tmp_base (fun base ->
-      match credential_only_normalize ~input:"testagent" ~base_path:base () with
-      | Ok _ -> fail "missing credential should be rejected"
-      | Error (Keeper_identity.Credential_missing _) -> ()
-      | Error other ->
-          fail
-            (Printf.sprintf
-               "missing credential expected Credential_missing, got %s"
-               (Keeper_identity.show_validation_error other)))
-
-let test_credential_present_accepted () =
-  with_tmp_base (fun base ->
-      write_json (credential_path base "testagent");
-      match credential_only_normalize ~input:"testagent" ~base_path:base () with
-      | Ok bundle ->
-          check string "keeper_name" "testagent" bundle.keeper_name;
-          check string "credential_stem" "testagent" bundle.credential_stem
-      | Error e ->
-          fail
-            (Printf.sprintf
-               "valid agent with credential should pass, got %s"
-               (Keeper_identity.show_validation_error e)))
-
-let test_wrapper_form_resolves_credential () =
-  with_tmp_base (fun base ->
-      write_json (credential_path base "alice");
-      match credential_only_normalize ~input:"keeper-alice-agent" ~base_path:base () with
-      | Ok bundle ->
-          check string "resolved keeper_name" "alice" bundle.keeper_name;
-          check string "credential_stem" "alice" bundle.credential_stem
-      | Error e ->
-          fail
-            (Printf.sprintf
-               "wrapper form should resolve, got %s"
-               (Keeper_identity.show_validation_error e)))
-
-(* --------------------------------------------------------------------- *)
 (* Join gate flags verification — documents the handle_join contract       *)
 (* --------------------------------------------------------------------- *)
 
-let test_join_gate_uses_both_checks () =
+let test_join_gate_uses_persona_check () =
   (* This is a documentation test: handle_join calls normalize with
-     ~check_persona:true ~check_credential:true.  The join_normalize
-     wrapper mirrors this exactly.  Empty input must fail. *)
+     ~check_persona:true.  The join_normalize wrapper mirrors this exactly.
+     Empty input must fail. *)
   match join_normalize ~input:"" () with
   | Error _ -> ()
-  | Ok _ -> fail "join gate must reject empty input with both checks enabled"
+  | Ok _ -> fail "join gate must reject empty input with persona check enabled"
 
 (* --------------------------------------------------------------------- *)
 (* Test runner                                                            *)
@@ -178,18 +87,9 @@ let () =
           test_case "whitespace input rejected" `Quick test_whitespace_rejected;
           test_case "invalid chars rejected" `Quick test_invalid_chars_rejected;
         ] );
-      ( "credential_gate",
-        [
-          test_case "missing credential rejected" `Quick
-            test_credential_missing_rejected;
-          test_case "credential present accepted" `Quick
-            test_credential_present_accepted;
-          test_case "wrapper form resolves" `Quick
-            test_wrapper_form_resolves_credential;
-        ] );
       ( "join_gate_contract",
         [
-          test_case "join gate uses both checks" `Quick
-            test_join_gate_uses_both_checks;
+          test_case "join gate uses persona check" `Quick
+            test_join_gate_uses_persona_check;
         ] );
     ]

--- a/test/test_workspace_bind_fail_closed.ml
+++ b/test/test_workspace_bind_fail_closed.ml
@@ -9,12 +9,10 @@
     [Tool_inline_dispatch_types.context] with Eio fiber infrastructure).
 
     Note on persona path resolution: [normalize_all_names] uses
-    [Config_dir_resolver.personas_dir_opt()] first, which returns the global
-    config dir and ignores [base_path]. Identity-level rejection tests
-    (empty/whitespace/invalid chars) need no filesystem setup because they fail
-    before filesystem checks. Full-gate persona-present tests would require a
-    known persona in the global config dir, which is machine-dependent and
-    excluded from CI. *)
+    [Config_dir_resolver.personas_dir_opt()] first, which can ignore
+    [base_path].  The join-gate contract test pins [MASC_PERSONAS_DIR] to a
+    known-empty temporary directory so the persona check is deterministic in
+    CI. *)
 
 open Alcotest
 open Masc_mcp
@@ -30,6 +28,40 @@ let normalize ~input ?base_path ?(check_persona = true) () =
     ?base_path
     ~check_persona
     ()
+
+let with_temp_dir prefix f =
+  let dir = Filename.temp_file prefix "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  let rec rm_rf path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then begin
+        Sys.readdir path |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+        Unix.rmdir path
+      end else
+        Sys.remove path
+  in
+  Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
+
+let restore_env name = function
+  | Some value -> Unix.putenv name value
+  | None ->
+      (* This OCaml Unix module does not expose [unsetenv]. Config_dir_resolver
+         normalizes empty env values to [None], so this restores the effective
+         resolver state for these tests. *)
+      Unix.putenv name ""
+
+let with_empty_personas_dir f =
+  with_temp_dir "workspace-bind-personas" @@ fun personas_dir ->
+  let original = Sys.getenv_opt "MASC_PERSONAS_DIR" in
+  Fun.protect
+    ~finally:(fun () ->
+      restore_env "MASC_PERSONAS_DIR" original;
+      Config_dir_resolver.reset ())
+    (fun () ->
+      Unix.putenv "MASC_PERSONAS_DIR" personas_dir;
+      Config_dir_resolver.reset ();
+      f personas_dir)
 
 (* Same flags as handle_join uses *)
 let join_normalize ~input ?base_path () =
@@ -67,12 +99,28 @@ let test_invalid_chars_rejected () =
 (* --------------------------------------------------------------------- *)
 
 let test_join_gate_uses_persona_check () =
-  (* This is a documentation test: handle_join calls normalize with
-     ~check_persona:true.  The join_normalize wrapper mirrors this exactly.
-     Empty input must fail. *)
-  match join_normalize ~input:"" () with
-  | Error _ -> ()
-  | Ok _ -> fail "join gate must reject empty input with persona check enabled"
+  with_empty_personas_dir @@ fun personas_dir ->
+  let input = "missing-persona" in
+  begin
+    match normalize ~input ~check_persona:false () with
+    | Ok _ -> ()
+    | Error other ->
+        fail
+          (Printf.sprintf
+             "plain normalize without persona check should accept valid name, got %s"
+             (Keeper_identity.show_validation_error other))
+  end;
+  match join_normalize ~input () with
+  | Error (Keeper_identity.Persona_not_found { resolved; searched; _ }) ->
+      check string "resolved persona" input resolved;
+      check string "searched persona path"
+        (Filename.concat personas_dir input)
+        searched
+  | Error other ->
+      fail
+        (Printf.sprintf "join gate expected Persona_not_found, got %s"
+           (Keeper_identity.show_validation_error other))
+  | Ok _ -> fail "join gate must reject missing persona with check enabled"
 
 (* --------------------------------------------------------------------- *)
 (* Test runner                                                            *)


### PR DESCRIPTION
## Summary

- Remove keeper identity git helper exports and the stale `credential_stem` normalization field.
- Drop Workspace.bind's legacy credential-file preflight from keeper name normalization.
- Remove the dead descriptor `credential_profile` policy/evidence field and update tests, metrics text, and RFC docs.

## Validation

- `git diff --check origin/main...HEAD`
- `ocamlformat --check lib/keeper/keeper_identity.ml lib/keeper/keeper_identity.mli lib/workspace_identity_backend.ml lib/keeper/agent_tool_descriptor.ml lib/keeper/agent_tool_descriptor.mli lib/prometheus_builtin_metrics_part4.ml lib/auth.mli test/test_keeper_identity_normalize.ml test/test_workspace_bind_fail_closed.ml test/test_keeper_identity_outcome_label.ml`
- Keeper-surface residue scan for `keeper_git_author`, `keeper_git_email`, `git_env_for_keeper`, `check_credential`, `credential_stem`, `credential_missing`, and `credential_profile`

Post-rebase Dune target validation was attempted, but local host Dune contention prevented completion: the repo wrapper refused while another bare Dune process was active, and a focused direct Dune retry in an isolated build dir exited with signal 130 without compiler diagnostics.
