### PR TITLE
fix(shell-ir): classify find/sed/sort action-flags so the keeper risk pre-gate sees them

### DIFF
--- a/lib/exec/shell_ir_risk.ml
+++ b/lib/exec/shell_ir_risk.ml
@@ -362,6 +362,61 @@ let is_destructive_bash_operation (words : string list) =
   | _ -> false
 ;;
 
+(* --- Action-flag danger (allowlisted read tools, dangerous flags) ---
+
+   find/sed/sort are legitimate read tools (on the readonly + dev
+   allowlists), but a single flag turns them destructive or write-capable
+   while the command identity stays "allowlisted read". The command-level
+   allowlist and [is_write_operation]/[classify_write_detail] (head-token
+   keyed) therefore never see the danger. The Find/Sort typed GADT does
+   not model these flags either — like [gh], the risk is string-borne — so
+   [classify_words] owns it as the floor. ([Sed.in_place] IS modeled, so
+   [risk_of_typed] escalates it on the typed path too; the floor stays
+   redundant there.)
+
+   Mapping rationale: [-exec]/[-execdir]/[-ok]/[-okdir] run an arbitrary
+   command (rm/sh are on no keeper allowlist) and [-delete] removes files —
+   the intent is "nobody destroys", so [Destructive_protected] blocks all
+   keepers (dev included). The file-writing primaries ([-fprintf]/[-fls]/
+   [-fprint]/[-fprint0], [sed -i], [sort -o]) are ordinary writes: [R1]
+   (readonly keeper blocked, dev keeper allowed — the split a flat
+   allowlist denylist could not express). *)
+
+let find_destructive_primaries = [ "-delete"; "-exec"; "-execdir"; "-ok"; "-okdir" ]
+let find_write_primaries = [ "-fprintf"; "-fls"; "-fprint"; "-fprint0" ]
+
+(* sed [-i]/[-i.bak]/[-Ei]/[--in-place]/[--in-place=.bak]. No other sed
+   short option carries 'i', so a bundled short flag containing 'i' is
+   in-place edit. *)
+let sed_is_in_place arg =
+  has_short_flag 'i' arg
+  || String.equal arg "--in-place"
+  || String.starts_with ~prefix:"--in-place=" arg
+;;
+
+(* sort [-o FILE]/[-ro FILE]/[--output FILE]/[--output=FILE]. 'o' is the
+   only sort short option, so any short flag containing 'o' writes a file. *)
+let sort_writes_file arg =
+  has_short_flag 'o' arg
+  || String.equal arg "--output"
+  || String.starts_with ~prefix:"--output=" arg
+;;
+
+let action_flag_risk (words : string list) : risk_class =
+  match words with
+  | "find" :: rest ->
+    if List.exists (fun a -> List.mem a find_destructive_primaries) rest
+    then Destructive_protected
+    else if List.exists (fun a -> List.mem a find_write_primaries) rest
+    then R1_Reversible_mutation
+    else R0_Read
+  | "sed" :: rest ->
+    if List.exists sed_is_in_place rest then R1_Reversible_mutation else R0_Read
+  | "sort" :: rest ->
+    if List.exists sort_writes_file rest then R1_Reversible_mutation else R0_Read
+  | _ -> R0_Read
+;;
+
 (* --- Word-list decision (pre-typed-GADT path) -----------------------
 
    Retained for the [Generic] escape hatch (env/redirect/$VAR/unknown
@@ -370,14 +425,21 @@ let is_destructive_bash_operation (words : string list) =
 
 let classify_words (words : string list) : risk_class =
   if is_destructive_bash_operation words then Destructive_protected
-  else if is_write_operation words then
-    (match classify_write_detail words with
-     | Some r -> r
-     | None -> R2_Irreversible)
   else
-    (match words with
-     | "gh" :: _ -> classify_repo_hosting_cli words
-     | _ -> R0_Read)
+    (* find/sed/sort action-flags are checked before the write/gh/R0
+       fall-through; these heads do not overlap [is_write_operation] or
+       [classify_write_detail], so an early escalation here is the max. *)
+    match action_flag_risk words with
+    | (Destructive_protected | R1_Reversible_mutation | R2_Irreversible) as r -> r
+    | R0_Read ->
+      if is_write_operation words then
+        (match classify_write_detail words with
+         | Some r -> r
+         | None -> R2_Irreversible)
+      else
+        (match words with
+         | "gh" :: _ -> classify_repo_hosting_cli words
+         | _ -> R0_Read)
 ;;
 
 (* --- Typed-GADT decision substrate (RFC-0160 §S1 completion) ----------
@@ -419,6 +481,9 @@ let risk_of_typed (w : Shell_ir_typed.wrapped) : risk_class =
   | W (Ls _) -> R0_Read
   | W (Cat _) -> R0_Read
   | W (Rg _) -> R0_Read
+  (* find -delete / -exec / -fprintf carry their danger in action-flags the
+     Find GADT does not model, so (like gh) the risk is string-borne and
+     classify_words owns it as the floor. The typed shape alone is R0. *)
   | W (Find _) -> R0_Read
   | W (Head _) -> R0_Read
   | W (Tail _) -> R0_Read
@@ -427,6 +492,8 @@ let risk_of_typed (w : Shell_ir_typed.wrapped) : risk_class =
   | W (Pwd _) -> R0_Read
   | W (Echo _) -> R0_Read
   | W (Which _) -> R0_Read
+  (* sort -o FILE writes a file; the Sort GADT does not model [-o], so
+     classify_words owns it as the floor (string-borne, like find). R0 here. *)
   | W (Sort _) -> R0_Read
   | W (Cut _) -> R0_Read
   | W (Tr _) -> R0_Read
@@ -479,7 +546,11 @@ let risk_of_typed (w : Shell_ir_typed.wrapped) : risk_class =
   | W (Ssh _) -> R0_Read
   | W (Scp _) -> R0_Read
   | W (Tar _) -> R0_Read
-  | W (Sed _) -> R0_Read
+  (* sed -i / --in-place edits files in place (R1). The GADT models
+     [in_place], so the typed path escalates it; classify_words owns the
+     word-list floor for parity. Non-in-place sed is a read filter (R0). *)
+  | W (Sed { in_place; _ }) ->
+    if in_place then R1_Reversible_mutation else R0_Read
   | W (Rsync _) -> R0_Read
   (* interpreters / build tools the word-list leaves at R0 *)
   | W (Node _) -> R0_Read

--- a/lib/exec/shell_ir_risk.mli
+++ b/lib/exec/shell_ir_risk.mli
@@ -63,7 +63,13 @@ val classify_words : string list -> risk_class
 (** Word-list risk classifier — the pre-GADT decision path, retained as
     the safety floor in [classify] for [Generic]/[Pipeline] and for
     risk-bearing tokens the typed model does not yet capture (gh
-    -X METHOD / graphql body). *)
+    -X METHOD / graphql body).
+
+    Also owns the action-flag danger of allowlisted read tools whose
+    typed GADT does not model the dangerous flag: [find -delete/-exec]
+    (Destructive_protected), [find -fprintf/-fls], [sed -i], [sort -o]
+    (R1). The command identity stays allowlisted; the flag carries the
+    risk, so it is string-borne like gh. *)
 
 val is_write_operation : string list -> bool
 (** [true] when the flattened word list indicates a write-level operation:

--- a/lib/exec/test/dune
+++ b/lib/exec/test/dune
@@ -9,6 +9,7 @@
         test_shell_ir_risk_repo_hosting_cli_stress
         test_shell_ir_typed_e2e
         test_shell_ir_differential
-        test_exec_gate_env_wrapper)
+        test_exec_gate_env_wrapper
+        test_shell_ir_risk_action_flags)
  (libraries masc_exec masc_exec_bash_parser masc_exec_command_gate masc_process
             masc_core masc_config alcotest eio eio_main yojson unix re))

--- a/lib/exec/test/test_shell_ir_risk_action_flags.ml
+++ b/lib/exec/test/test_shell_ir_risk_action_flags.ml
@@ -1,0 +1,118 @@
+(* RFC-0208 action-flag risk regression guard.
+
+   find/sed/sort are on the readonly + dev command allowlists as read
+   tools, but a single flag turns them destructive (find -delete/-exec) or
+   write-capable (find -fprintf, sed -i, sort -o) while the command identity
+   stays "allowlisted read". The keeper authorizes via the risk-envelope
+   pre-gate (agent_tool_execute_runtime: is_destructive blocks all keepers;
+   is_r1/is_r2 blocks a non-write-enabled readonly keeper), so a
+   misclassification to R0_Read let a readonly keeper delete and modify
+   files past the gate.
+
+   These assertions pin the risk_class the pre-gate keys on. They cover the
+   string-parsed path and the typed-input path (the IR built directly from
+   {bin; args}, no Bash) — the latter is what a parser-only fix would miss,
+   and it is the only reachable path for find -exec (the bash parser rejects
+   the `;`/`{}` form as too_complex). *)
+open Masc_exec
+module Risk = Shell_ir_risk
+
+let envelope ir = Risk.classify (Risk.undecided ir)
+let risk_of ir = (envelope ir).Risk.risk
+
+let parse cmd =
+  match Masc_exec_bash_parser.Bash.parse_string cmd with
+  | Parsed.Parsed ir -> ir
+  | _ -> failwith (Printf.sprintf "parse failed/too_complex: %s" cmd)
+;;
+
+let lit s = Shell_ir.Lit (s, Shell_ir.default_meta)
+
+let typed_simple bin args =
+  Shell_ir.Simple
+    { Shell_ir.bin = Result.get_ok (Exec_program.of_string bin)
+    ; args = List.map lit args
+    ; env = []
+    ; cwd = None
+    ; redirects = []
+    ; sandbox = Sandbox_target.host ()
+    }
+;;
+
+let check name cond = if not cond then failwith ("FAIL: " ^ name)
+
+let is_class name expected ir =
+  let got = risk_of ir in
+  if got <> expected then
+    failwith
+      (Printf.sprintf "FAIL: %s — expected %s, got %s" name
+         (Risk.string_of_risk_class expected)
+         (Risk.string_of_risk_class got))
+;;
+
+(* find -delete / -exec / -execdir / -ok / -okdir → Destructive_protected:
+   delete or arbitrary-command exec (rm/sh are on no keeper allowlist), so
+   blocked for ALL keepers including write-enabled dev. *)
+let test_find_destructive () =
+  is_class "find -delete" Risk.Destructive_protected (parse "find . -delete");
+  is_class "find -name + -delete" Risk.Destructive_protected
+    (parse "find . -name *.tmp -delete");
+  (* find -exec: bash parser rejects the `;`/`{}` form, so the typed-input
+     path is the reachable one — and the one a parser-only fix would miss. *)
+  is_class "{find,.,-exec,rm,-rf,{},;} (typed)" Risk.Destructive_protected
+    (typed_simple "find" [ "."; "-exec"; "rm"; "-rf"; "{}"; ";" ]);
+  is_class "{find,.,-execdir,sh,;} (typed)" Risk.Destructive_protected
+    (typed_simple "find" [ "."; "-execdir"; "sh"; ";" ]);
+  is_class "{find,.,-delete} (typed)" Risk.Destructive_protected
+    (typed_simple "find" [ "."; "-delete" ]);
+  (* The keeper pre-gate keys on is_destructive (blocks all tool_access). *)
+  check "find -delete is_destructive" (Risk.is_destructive (envelope (parse "find . -delete")))
+;;
+
+(* find -fprintf / -fls / -fprint / -fprint0 write a named file: R1
+   (readonly blocked by pre-gate, dev allowed — an ordinary write). *)
+let test_find_write () =
+  is_class "find -fprintf" Risk.R1_Reversible_mutation (parse "find . -fprintf out.txt %p");
+  is_class "find -fls" Risk.R1_Reversible_mutation (parse "find . -fls out.txt");
+  is_class "{find,.,-fprint,out} (typed)" Risk.R1_Reversible_mutation
+    (typed_simple "find" [ "."; "-fprint"; "out.txt" ])
+;;
+
+(* sed -i / -i.bak / --in-place edit files in place: R1. *)
+let test_sed_in_place () =
+  is_class "sed -i" Risk.R1_Reversible_mutation (parse "sed -i s/a/b/ file.txt");
+  is_class "sed -i.bak" Risk.R1_Reversible_mutation (parse "sed -i.bak s/a/b/ file.txt");
+  is_class "{sed,-i,s/a/b/,f} (typed)" Risk.R1_Reversible_mutation
+    (typed_simple "sed" [ "-i"; "s/a/b/"; "file.txt" ]);
+  check "sed -i is_r1" (Risk.is_r1 (envelope (parse "sed -i s/a/b/ file.txt")))
+;;
+
+(* sort -o / --output write a file: R1. *)
+let test_sort_output () =
+  is_class "sort -o" Risk.R1_Reversible_mutation (parse "sort -o out.txt in.txt");
+  is_class "{sort,-o,out,in} (typed)" Risk.R1_Reversible_mutation
+    (typed_simple "sort" [ "-o"; "out.txt"; "in.txt" ])
+;;
+
+(* Legitimate read uses stay R0 — no false-reject of normal find/sed/sort
+   searching/filtering. *)
+let test_legit_reads_preserved () =
+  is_class "find -type f" Risk.R0_Read (parse "find . -type f");
+  is_class "find -name" Risk.R0_Read (parse "find . -name foo.txt");
+  is_class "sed (no -i)" Risk.R0_Read (parse "sed s/a/b/ file.txt");
+  is_class "sort (no -o)" Risk.R0_Read (parse "sort in.txt");
+  let legit = envelope (parse "find . -type f") in
+  check "find -type f not gated"
+    (not (Risk.is_destructive legit)
+     && not (Risk.is_r1 legit)
+     && not (Risk.is_r2 legit))
+;;
+
+let () =
+  test_find_destructive ();
+  test_find_write ();
+  test_sed_in_place ();
+  test_sort_output ();
+  test_legit_reads_preserved ();
+  print_endline "[test_shell_ir_risk_action_flags] all tests passed"
+;;


### PR DESCRIPTION
## 목적

readonly keeper가 `find`의 delete/exec primary, `sed` in-place, `sort` output로 파일을 삭제·수정할 수 있는 보안 구멍을 닫습니다. 근본 원인은 risk classifier가 이들을 플래그와 무관하게 `R0_Read`로 분류 → keeper의 risk-envelope pre-gate(`agent_tool_execute_runtime`: `is_destructive` / `is_r1`/`is_r2`)가 차단하지 못함. gate가 아니라 classifier가 keeper의 실제 authorization 레이어입니다.

## 확인된 노출 (probe: `classify` + keeper pre-gate)

| 명령 | 이전 risk | readonly keeper |
|---|---|---|
| `find . -delete` | R0 | 🔴 삭제 실행 |
| `find -exec ...` (typed-input) | R0 | 🔴 임의 명령 실행 |
| `find -fprintf/-fls` | R0 | 🔴 파일 쓰기 |
| `sed -i` | R0 | 🔴 in-place 수정 |
| `sort -o FILE` | R0 | 🔴 파일 쓰기 |

string 경로의 `find -exec`는 파서가 `too_complex`로 거부하지만, **typed-input 경로는 reach** — parser-only fix가 놓치는 지점.

## 수정 (root layer = risk classifier)

- `find` delete/exec/execdir/ok/okdir → `Destructive_protected` (모든 keeper 차단; inner 도구가 어떤 allowlist에도 없음 = "누구도 파괴 불가")
- `find` fprintf/fls/fprint/fprint0, `sed -i`, `sort -o` → `R1` (파일 쓰기; readonly 차단, dev 허용 — 평면 denylist로는 표현 불가한 split)
- `sed`는 typed `Sed.in_place`(risk_of_typed) + floor 양쪽; `find`/`sort`는 floor-owned(classify_words) — string-borne, 기존 `gh` 선례와 동일 (Find/Sort GADT가 해당 플래그를 모델링 안 함)

## Workaround 자가점검

워크어라운드 아님 — 증상 억제(counter/cap/dedup/telemetry-as-fix)가 아니라 authorization SSOT인 risk classifier에서의 근본 수정. find/sort의 string-match는 기존 `gh` floor-ownership 선례와 동일 패턴이며, sed는 typed 경로 사용. find/sort 플래그를 Find/Sort GADT에 타이핑(컴파일 강제로 격상)하는 것은 RFC-0208 follow-up으로 분리. 단일 추출 함수 `action_flag_risk`로 N-of-M 회피.

## 로컬 검증

- `dune build .` (whole-program) EXIT=0
- `dune build @lib/exec/test/runtest` 통과 (differential harness + risk classifier 회귀 0)
- 새 회귀 테스트 `test_shell_ir_risk_action_flags` 통과 (string + typed-input 경로, legit `find -name`/`sed`/`sort` R0 유지)
- gate 테스트 19개 / typed-input 테스트 49개 통과

## 미검증 / follow-up

- 라이브 keeper 행위 (배포 후 확인 필요)
- `git clean -fdx`는 여전히 R0이나 별건: git은 readonly allowlist에 없어 readonly 도달 불가, dev는 destructive-git을 기존 정책상 허용. 의도적 행위변경이라 이 PR 범위 외.
- readonly/dev tier 자체를 Claude Code식 mode+rule+approval로 재설계 = 별도 RFC

RFC-0208 (Shell IR compositional risk / gate authorization). Closes #19789.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
