### PR TITLE
fix(worker): block destructive action-flags on the worker shell surface (RFC-0208)

### DIFF
--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -396,6 +396,32 @@ let make_shell_exec_with_allowlist
                    ())
               on_exec;
             tool_error (block_reason_to_string reason)
+          | Ok context
+            when Masc_exec.Shell_ir_risk.is_destructive
+                   (Masc_exec.Shell_ir_risk.classify
+                      (Masc_exec.Shell_ir_risk.undecided
+                         context.Exec_shell_gate.ast)) ->
+            (* RFC-0208: this worker shell surface authorizes by allowlist
+               only — unlike the keeper path (agent_tool_execute_runtime) it
+               has no risk pre-gate. find -delete is allowlisted because find
+               is a read tool, but the risk classifier rates it
+               Destructive_protected (the delete action, like rm, is on no
+               allowlist). Refuse it here so the worker matches the keeper: a
+               Destructive command is blocked for every tool_access. R1
+               writes stay allowed — this dev surface is write-capable by
+               design. *)
+            Option.iter
+              (fun (f : tool_exec_observer) ->
+                 f
+                   ~tool_name:"shell_exec"
+                   ~success:false
+                   ~duration_ms:0
+                   ~error_kind:Command_blocked
+                   ~error_message:"destructive_operation_blocked"
+                   ())
+              on_exec;
+            tool_error
+              "This command is destructive and is blocked for all tool_access."
           | Ok context ->
             let path_workdir =
               match workdir with

--- a/test/test_worker_dev_tools.ml
+++ b/test/test_worker_dev_tools.ml
@@ -381,6 +381,39 @@ let test_shell_exec_echo () =
    | Error { Agent_sdk.Types.message = e; _ } ->
      Alcotest.fail (Printf.sprintf "expected Ok, got Error: %s" e))
 
+(* RFC-0208: the worker shell surface authorizes by allowlist only, so a
+   destructive action-flag on an allowlisted read tool (find -delete) must be
+   refused by the risk guard before dispatch — matching the keeper path. The
+   canary verifies the guard fires before execution (no file is deleted). *)
+let test_shell_exec_find_delete_blocked () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let proc_mgr = Eio.Stdenv.process_mgr env in
+  let clock = Eio.Stdenv.clock env in
+  let workdir = Filename.temp_file "wdt_find_delete_" "" in
+  Fun.protect
+    ~finally:(fun () -> try cleanup_path workdir with _ -> ())
+    (fun () ->
+       Sys.remove workdir;
+       Unix.mkdir workdir 0o755;
+       let canary = Filename.concat workdir "canary.txt" in
+       let oc = open_out canary in
+       output_string oc "keep";
+       close_out oc;
+       let tools = Worker_dev_tools.make_tools ~proc_mgr ~clock ~workdir () in
+       let tool = find_tool "shell_exec" tools in
+       (match
+          Tool.execute tool (`Assoc [ ("command", `String "find . -delete") ])
+        with
+        | Ok _ ->
+          Alcotest.fail "find . -delete must be blocked on the worker shell surface"
+        | Error { Agent_sdk.Types.message = e; _ } ->
+          Alcotest.(check bool)
+            "blocked as destructive"
+            true
+            (contains_substring e "destructive"));
+       Alcotest.(check bool) "canary survived block" true (Sys.file_exists canary))
+
 let test_shell_exec_uses_shell_ir_dispatch_cwd () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -754,6 +787,8 @@ let () =
       Alcotest.test_case "timeout floor for load-bearing commands" `Quick
         test_shell_exec_timeout_floor_for_load_bearing_commands;
       Alcotest.test_case "blocked command" `Quick test_shell_exec_blocked_command;
+      Alcotest.test_case "find -delete blocked (destructive)" `Quick
+        test_shell_exec_find_delete_blocked;
       Alcotest.test_case "env wrapper blocked command" `Quick
         test_shell_exec_blocks_env_wrapped_disallowed_command;
       Alcotest.test_case "outside path arg blocked" `Quick


### PR DESCRIPTION
## 목적 (#19802 후속 — 같은 클래스의 두 번째 surface)

#19802는 keeper 경로(`agent_tool_execute_runtime`)의 risk pre-gate가 find/sed/sort action-flag을 보도록 risk classifier를 고쳤습니다. 하지만 **worker shell surface**(`worker_dev_tools`, local/Fleet 워커가 `make_tools`로 사용)는 **allowlist만으로 인가**하고 risk pre-gate가 없습니다. 그래서 `find -delete`(find는 allowlist된 read 도구)가 worker에서 여전히 실행됩니다 — 이 surface는 risk envelope을 아예 보지 않기 때문. keeper만 고치면 N-of-M.

## 수정

worker shell_exec chokepoint에 risk 가드 추가: risk classifier가 `Destructive_protected`로 분류하는 명령(`find -delete` 등)은 모든 tool_access에서 거부 — keeper와 동작 일치. R1 쓰기는 허용(dev 워커는 설계상 write-capable). 같은 `Shell_ir_risk` classifier(SSOT)를 재사용하므로 두 exec surface가 단일 소스로 일관(N-of-M 아님). `when is_destructive` 가드 arm 하나라 기존 본문 무변경.

worker는 string-input(`parse_string_to_ir`)이라 `find -exec`(typed `;`/`{}`)는 파서가 too_complex로 이미 거부 → 실 노출은 `find -delete`(Destructive).

## 검증

- green base(#19802의 `4a20451`)에서: `dune build .` EXIT=0, `test_worker_dev_tools`의 신규 `find -delete blocked` 테스트 통과(canary 파일 생존 = 가드가 dispatch 전 발화 확인).
- 회귀 테스트는 `find -delete`가 차단되고 canary가 살아남음을 단언.

## ⚠️ 현재 main blocker (이 PR 변경과 무관)

origin/main(`8a0395ea`)이 **broken** 상태입니다: `keeper_unified_turn.ml:138/513`이 `Keeper_meta_contract.runtime_id_of_meta`를 참조하나 그 함수가 `lib/keeper`에 정의 없음(RFC-0207 #19704는 머지됐으나 후속 리팩토링이 정의를 제거/이동하며 참조 미수정으로 추정). keeper lib가 컴파일 안 돼 `test_worker_dev_tools`를 **현재 main 위에서 빌드·검증 불가**. 이 PR의 코드는 keeper와 무관하며, main이 green 복귀하면 검증+머지 가능. **main green 전까지 Ready 금지.**

## 미해결 / 노트

- pre-existing: `validate_command_tool_execute`의 env-wrapper 테스트 2건(`env -S` peel 미구현, #19788이 `gate_typed`에만 적용)이 base에서 실패 — 이 PR과 무관, 별도 follow-up.

RFC-0208. #19802 후속.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
