### PR TITLE
fix(keeper): repair #19797 tool-boundary hard-cut fallout (6 sites)

### DIFF
--- a/lib/keeper/keeper_tool_alias.ml
+++ b/lib/keeper/keeper_tool_alias.ml
@@ -55,19 +55,17 @@ let known_internal_names_tbl : (string, unit) Hashtbl.t =
   Hashtbl.iter
     (fun _ r ->
        List.iter
-         (fun internal_name -> Hashtbl.replace t internal_name ())
+         (fun internal_name ->
+            Hashtbl.replace t internal_name ();
+            (* Also admit the public MCP counterpart (e.g. [masc_board_post])
+               so successful MCP routes do not collapse to [tool="unknown"]
+               (PR #14585 review).  Sourced from the descriptor SSOT after the
+               keeper-internal catalog list was severed (#19797). *)
+            match Agent_tool_descriptor.public_name_for_internal internal_name with
+            | Some public -> Hashtbl.replace t public ()
+            | None -> ())
          (Agent_tool_descriptor.internal_names r.descriptor))
     routing_table;
-  List.iter
-    (fun internal ->
-       Hashtbl.replace t internal ();
-       (* Also admit the public MCP counterpart (e.g. [masc_board_post])
-          so successful MCP routes do not collapse to [tool="unknown"]
-          (PR #14585 review). *)
-       match Tool_catalog_surfaces.keeper_internal_replacement internal with
-       | Some public -> Hashtbl.replace t public ()
-       | None -> ())
-    Tool_catalog_surfaces.keeper_internal_tools;
   List.iter
     (fun public_mcp -> Hashtbl.replace t public_mcp ())
     Tool_catalog_surfaces.public_mcp_surface_tools;
@@ -119,13 +117,20 @@ let public_name_for_internal = Agent_tool_descriptor.public_name_for_internal
 (* ── MCP surface routing (separate concern) ──────────────────────── *)
 
 let public_masc_to_internal_tbl =
+  (* Reverse (public MCP name -> internal name) map, rebuilt from the
+     descriptor SSOT after the keeper-internal catalog list + replacement
+     table were severed (#19797).  Each descriptor's internal names map to
+     their canonical public name when one exists. *)
   let t = Hashtbl.create 16 in
-  List.iter
-    (fun internal ->
-       match Tool_catalog_surfaces.keeper_internal_replacement internal with
-       | Some public -> Hashtbl.replace t public internal
-       | None -> ())
-    Tool_catalog_surfaces.keeper_internal_tools;
+  Hashtbl.iter
+    (fun _ r ->
+       List.iter
+         (fun internal ->
+            match Agent_tool_descriptor.public_name_for_internal internal with
+            | Some public -> Hashtbl.replace t public internal
+            | None -> ())
+         (Agent_tool_descriptor.internal_names r.descriptor))
+    routing_table;
   t
 ;;
 

--- a/lib/keeper/keeper_tool_resolution.ml
+++ b/lib/keeper/keeper_tool_resolution.ml
@@ -101,11 +101,6 @@ let resolve name =
                   ; Tool_catalog_surfaces.System_internal
                   ]
                 in
-                let _excluded_must_deny : Tool_catalog_surfaces.surface list =
-                  (* PR-7 will route [Keeper_denied] through the capability gate
-                     before admission; do not list it as an admit surface here. *)
-                  [ Tool_catalog_surfaces.Keeper_denied ]
-                in
                 let rec check_surfaces = function
                   | [] ->
                       let tried =

--- a/lib/keeper/keeper_types_profile_defaults.ml
+++ b/lib/keeper/keeper_types_profile_defaults.ml
@@ -31,8 +31,13 @@ type keeper_profile_defaults = {
   (* Telemetry Feedback — inject behavioral stats into keeper context *)
   telemetry_feedback_enabled : bool option;
   telemetry_feedback_window_hours : int option;
+  per_provider_timeout_state : per_provider_timeout_state;
+  (* Per-provider timeout for runtime fallback. None = use turn budget heuristic. *)
+  per_provider_timeout : float option;
   always_approve : bool option;
   social_model : string option;
+  model : string option;
+  models : string list option;
   (* Turn budget overrides. None = inherit env default
      (MASC_KEEPER_OAS_MAX_TURNS_PER_CALL / ..._SCHEDULED_AUTONOMOUS). *)
   max_turns_per_call : int option;
@@ -81,8 +86,12 @@ let empty_keeper_profile_defaults =
     active_goal_ids = None;
     telemetry_feedback_enabled = None;
     telemetry_feedback_window_hours = None;
+    per_provider_timeout_state = Per_provider_timeout_unset;
+    per_provider_timeout = None;
     always_approve = None;
     social_model = None;
+    model = None;
+    models = None;
     max_turns_per_call = None;
     max_turns_per_call_scheduled_autonomous = None;
     unknown_toml_keys = [];

--- a/lib/keeper/keeper_types_profile_defaults.mli
+++ b/lib/keeper/keeper_types_profile_defaults.mli
@@ -32,8 +32,12 @@ type keeper_profile_defaults = {
   active_goal_ids : string list option;
   telemetry_feedback_enabled : bool option;
   telemetry_feedback_window_hours : int option;
+  per_provider_timeout_state : per_provider_timeout_state;
+  per_provider_timeout : float option;
   always_approve : bool option;
   social_model : string option;
+  model : string option;
+  models : string list option;
   max_turns_per_call : int option;
   max_turns_per_call_scheduled_autonomous : int option;
   oas_env : (string * string) list;

--- a/lib/tool_catalog_surfaces/tool_catalog_surfaces.mli
+++ b/lib/tool_catalog_surfaces/tool_catalog_surfaces.mli
@@ -22,6 +22,11 @@ val public_mcp_surface_tools : string list
 val system_internal_surface_tools : string list
 val workspace_role_tools : string list
 
+(** Role-catalog tools for worker/execution agents.  Consumed by
+    [Agent_tool_surfaces.execution_tool_names]; sibling of
+    {!workspace_role_tools}. *)
+val execution_role_tools : string list
+
 (** {1 Surface variant} *)
 
 (** Tool catalog surface — each variant identifies a curated


### PR DESCRIPTION
## 무엇을

`#19797 [codex] hard cut keeper/tool boundary coupling`이 **red CI 상태로 머지**되면서, 제거된 심볼을 소비자들이 여전히 참조해 **6개 사이트에서 빌드가 깨졌습니다.** 이 PR은 그 fallout만 정확히 복구합니다.

## 왜

`#19797`은 일부는 의도된 hard-cut이지만, **tool/keeper 경계와 무관한 심볼까지 과도하게 제거**했고 stale consumer를 남겼습니다. `#19803`이 `per_provider_timeout_state` **타입**만 복구했을 뿐 **레코드 필드**는 복구하지 않아 TOML 파서가 여전히 깨집니다.

## 변경 내용

**복구 (collateral — 경계와 무관, 여전히 사용 중):**
- `keeper_types_profile_defaults`: `per_provider_timeout_state` / `per_provider_timeout` / `model` / `models` 레코드 필드 (TOML 파서가 생성, `#19803`은 타입만 복구)
- `tool_dispatch.module_tag`: `Mod_keeper` variant (`.mli` + keeper-side 5개 소비자가 매칭; `Masc_keeper -> Mod_keeper` static mapping은 cut 의도대로 제거 유지)
- `tool_catalog_surfaces.mli`: `execution_role_tools` re-export (`.ml` 정의 생존, sibling `workspace_role_tools`도 생존)

**cut 완성 (진짜 keeper-internal surface 제거):**
- `keeper_tool_resolution`: 제거된 `Keeper_denied` surface variant를 참조하던 dead `_excluded_must_deny` 블록 삭제
- `keeper_tool_alias`: `known_internal_names_tbl` / `public_masc_to_internal_tbl`을 제거된 `keeper_internal_tools` / `keeper_internal_replacement` 카탈로그 대신 **`Agent_tool_descriptor` SSOT**(생존한 internal<->public 매핑)에서 재구성

## RFC

**RFC-0194 §3 (Tool->Keeper dependency-direction)** instantiate: tool-layer가 `lib/keeper`에 새 의존을 추가하지 않음. alias 재구성은 descriptor SSOT를 읽어 경계를 severed 상태로 유지. `#19797`의 의도된 cut 부분은 보존하고, 과도 제거된 collateral만 복구.

§1/§2/§4/§5 not-invoked.

## 검증

- `dune build .` (default target closure) **통과**
- `dune build @check`에서 본 PR이 건드린 6개 파일은 **무에러**

## CI 관련 주의

origin/main은 본 PR과 **별개의 미완성 머지들**로 더 광범위하게 red 상태입니다 (`Keeper_meta_contract.runtime_id_of_meta` ~30곳 unbound, `Tool_name.Keeper` 생성자, `usage.last_model_used`, `save_oas_checkpoint` 시그니처 등 — runtime 모델 에디터/cascade 제거 계열). 그 파동들이 별도로 해결되기 전까지 **전체 CI는 red로 남을 수 있습니다.** 본 PR은 `#19797` 조각만 정확히 해결하는 N개 수정 중 첫 조각입니다.

RFC-WAIVED 아님 — RFC-0194 §3 cite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
