### PR TITLE
docs(audit): add Runtime->Keeper boundary severance audit

### DIFF
--- a/docs/audit/2026-05-31-tool-keeper-boundary-severance.md
+++ b/docs/audit/2026-05-31-tool-keeper-boundary-severance.md
@@ -86,3 +86,22 @@ taxonomy). Two acceptable resolutions, user's call:
   RFC-0084. Lower ceremony; the invariant is still enforced by CI.
 
 This PR takes neither stance in code — it cites RFC-0084 as the precedent and flags the gap.
+
+## 7. Follow-up axis: Runtime → Keeper (2026-06-02)
+
+After the Tool→Keeper ratchet reached baseline=0, a systematic cross-subsystem scan
+identified Runtime→Keeper as the next clear boundary violation.
+
+**PR #19801** (MERGED 2026-06-02):
+- `Keeper_oas_checkpoint` -> `Runtime_oas_checkpoint` (0 keeper callers — purely misnamed)
+- `Keeper_observation` -> `Runtime_observation` (shared 9+4, observation is runtime behavior)
+- `Keeper_observation_query_operation` -> `Runtime_observation_query_operation`
+
+Full audit: `docs/audit/2026-06-02-runtime-keeper-boundary-severance.md`
+
+### Ratchet scope gap discovered
+
+`lib/keeper/tool_visibility_projection.ml` matches the ratchet's `tool_*.ml` glob but is
+a keeper-purpose handler. The ratchet excludes `tool_keeper_*` by filename but not
+`lib/keeper/tool_*` by directory. This causes CI failures on the merge commit.
+Fix pending: exclude `lib/keeper/` in the ratchet or rename to `tool_keeper_*`.

--- a/docs/audit/2026-05-31-tool-keeper-boundary-severance.md
+++ b/docs/audit/2026-05-31-tool-keeper-boundary-severance.md
@@ -92,7 +92,7 @@ This PR takes neither stance in code — it cites RFC-0084 as the precedent and 
 After the Tool→Keeper ratchet reached baseline=0, a systematic cross-subsystem scan
 identified Runtime→Keeper as the next clear boundary violation.
 
-**PR #19801** (MERGED 2026-06-02):
+**PR #19801** (2026-06-02):
 - `Keeper_oas_checkpoint` -> `Runtime_oas_checkpoint` (0 keeper callers — purely misnamed)
 - `Keeper_observation` -> `Runtime_observation` (shared 9+4, observation is runtime behavior)
 - `Keeper_observation_query_operation` -> `Runtime_observation_query_operation`

--- a/docs/audit/2026-05-31-tool-keeper-boundary-severance.md
+++ b/docs/audit/2026-05-31-tool-keeper-boundary-severance.md
@@ -99,9 +99,7 @@ identified Runtime→Keeper as the next clear boundary violation.
 
 Full audit: `docs/audit/2026-06-02-runtime-keeper-boundary-severance.md`
 
-### Ratchet scope gap discovered
-
-`lib/keeper/tool_visibility_projection.ml` matches the ratchet's `tool_*.ml` glob but is
-a keeper-purpose handler. The ratchet excludes `tool_keeper_*` by filename but not
-`lib/keeper/tool_*` by directory. This causes CI failures on the merge commit.
-Fix pending: exclude `lib/keeper/` in the ratchet or rename to `tool_keeper_*`.
+### Remaining Runtime→Keeper debt
+`Keeper_identity` (2 calls in `runtime_oas_runner.ml`) and `Keeper_internal_error`
+(1 call in `runtime_inference.ml`) remain after PR #19801. These require a
+separate severance PR — see the full audit doc for details.

--- a/docs/audit/2026-06-02-runtime-keeper-boundary-severance.md
+++ b/docs/audit/2026-06-02-runtime-keeper-boundary-severance.md
@@ -1,0 +1,85 @@
+# Runtime → Keeper Boundary Severance — Audit
+
+**Date**: 2026-06-02
+**PR**: #19801 (MERGED)
+**Goal**: Runtime (infrastructure layer) should not depend on Keeper (application layer). The correct dependency direction is Keeper -> Runtime.
+
+## 1. Discovery
+
+Systematic cross-subsystem scan after Tool→Keeper boundary completion (ratchet baseline=0).
+Method: `rg 'Keeper_[a-zA-Z][a-zA-Z_]*\.[A-Za-z]' lib/` filtered by subsystem prefix,
+excluding comments/string literals, focusing on actual module calls (not variant constructors).
+
+### Scanned axes
+
+| Axis | Files with calls | Nature | Action |
+|------|-----------------|--------|--------|
+| Tool → Keeper | 0 | DONE (ratchet baseline=0) | None |
+| **Runtime → Keeper** | **4 files, ~15 refs** | Real module calls | **Severed** |
+| Operator → Keeper | 7 files, ~70 refs | State snapshot (management) | Future |
+| Config → Keeper | 3 files, ~5 refs | Env config | Future |
+| Dashboard → Keeper | ~25 files | Display (reads state) | Future |
+| Server → Keeper | ~30 files | Wiring layer | Future |
+
+### Runtime → Keeper violations (pre-merge)
+
+| File | Module | Calls | Nature |
+|------|--------|-------|--------|
+| `runtime_agent.ml` | `Keeper_observation` | 5 | Observation/metrics recording |
+| `runtime_agent.ml` | `Keeper_oas_checkpoint` | 5 | Lifecycle/checkpoint re-exports |
+| `runtime_oas_runner.ml` | `Keeper_identity` | 2 | Name resolution |
+| `runtime_inference.ml` | `Keeper_internal_error` | 1 | Error type |
+
+## 2. Root cause
+
+`Keeper_oas_checkpoint` had **zero keeper-internal callers**. It was a runtime module
+misplaced in `lib/keeper/` with the `Keeper_` prefix.
+
+`Keeper_observation` was shared between keeper (9 files) and runtime/server (4 files).
+The observation types (`runtime_attempt`, `runtime_observation`) describe **runtime** behavior,
+not keeper-specific logic. The `Keeper_` prefix was misleading.
+
+## 3. Changes
+
+### Phase 1: Keeper_oas_checkpoint -> Runtime_oas_checkpoint
+- Moved `lib/keeper/keeper_oas_checkpoint.ml(i)` -> `lib/runtime/runtime_oas_checkpoint.ml(i)`
+- Only consumer: `runtime_agent.ml` (re-exported functions)
+- Added to `private_modules` in `lib/dune`
+
+### Phase 2: Keeper_observation -> Runtime_observation
+- Moved `lib/keeper/keeper_observation.ml(i)` -> `lib/runtime_observation.ml(i)`
+- Moved `lib/keeper/keeper_observation_query_operation.ml(i)` -> `lib/runtime_observation_query_operation.ml(i)`
+- Updated 29 files (reference renames across lib/, test/)
+- `Runtime_observation_query_operation` added to `private_modules` (Copilot review)
+
+### Stale doc fixes
+- `Runtime_runner` -> `Runtime_agent` (3 references)
+- `oas_worker.mli` -> `Runtime_agent` (2 references)
+
+## 4. Verification
+
+- `dune build --root . lib/masc_mcp.cma` EXIT=0
+- `dune build --root . @check` EXIT=0
+- Copilot review: 1 actionable comment (private_modules) — addressed
+
+## 5. Open issues
+
+### Tool→Keeper ratchet scope gap
+`lib/keeper/tool_visibility_projection.ml` is a keeper-purpose handler that matches
+the ratchet's `tool_*.ml` glob. The ratchet excludes `tool_keeper_*` but not
+`lib/keeper/tool_*`. Fix: either exclude `lib/keeper/` directory in the ratchet,
+or rename to `tool_keeper_visibility_projection.ml`. This is a pre-existing main issue.
+
+### Next boundary candidates
+- `Keeper_identity` (14 non-keeper callers) — widely shared utility module
+- Operator → Keeper (7 files, ~70 refs) — management layer using keeper internals
+- Config → Keeper (3 files, ~5 refs) — configuration referencing keeper behavior
+
+## 6. Relationship to Tool→Keeper boundary
+
+This is the **second boundary axis** in the subsystem dependency cleanup:
+1. Tool → Keeper (2026-05-31, ratchet baseline=0) — tool surface must not know about keeper
+2. Runtime → Keeper (2026-06-02, PR #19801) — infrastructure must not depend on application
+
+Both follow the same pattern: rename/move misplaced modules, update references.
+The structural root fix (dune sub-library split) remains a future goal.

--- a/docs/audit/2026-06-02-runtime-keeper-boundary-severance.md
+++ b/docs/audit/2026-06-02-runtime-keeper-boundary-severance.md
@@ -1,7 +1,7 @@
 # Runtime → Keeper Boundary Severance — Audit
 
 **Date**: 2026-06-02
-**PR**: #19801 (MERGED)
+**PR**: #19801
 **Goal**: Runtime (infrastructure layer) should not depend on Keeper (application layer). The correct dependency direction is Keeper -> Runtime.
 
 ## 1. Discovery

--- a/docs/audit/2026-06-02-runtime-keeper-boundary-severance.md
+++ b/docs/audit/2026-06-02-runtime-keeper-boundary-severance.md
@@ -15,7 +15,7 @@ excluding comments/string literals, focusing on actual module calls (not variant
 | Axis | Files with calls | Nature | Action |
 |------|-----------------|--------|--------|
 | Tool → Keeper | 0 | DONE (ratchet baseline=0) | None |
-| **Runtime → Keeper** | **4 files, ~15 refs** | Real module calls | **Severed** |
+| **Runtime → Keeper** | **4 files, ~15 refs** | Real module calls | **Partially severed** |
 | Operator → Keeper | 7 files, ~70 refs | State snapshot (management) | Future |
 | Config → Keeper | 3 files, ~5 refs | Env config | Future |
 | Dashboard → Keeper | ~25 files | Display (reads state) | Future |
@@ -64,11 +64,12 @@ not keeper-specific logic. The `Keeper_` prefix was misleading.
 
 ## 5. Open issues
 
-### Tool→Keeper ratchet scope gap
-`lib/keeper/tool_visibility_projection.ml` is a keeper-purpose handler that matches
-the ratchet's `tool_*.ml` glob. The ratchet excludes `tool_keeper_*` but not
-`lib/keeper/tool_*`. Fix: either exclude `lib/keeper/` directory in the ratchet,
-or rename to `tool_keeper_visibility_projection.ml`. This is a pre-existing main issue.
+### Remaining Runtime→Keeper debt
+PR #19801 severed `Keeper_observation` and `Keeper_oas_checkpoint`. Two modules remain:
+- `runtime_oas_runner.ml`: `Keeper_identity.keeper_agent_name`, `Keeper_identity.keeper_name_from_agent_name` (2 calls)
+- `runtime_inference.ml`: `Keeper_internal_error.Max_tokens_ceiling_violation` (1 call)
+These require separate severance: `Keeper_identity` is shared with 14 non-keeper callers,
+`Keeper_internal_error` needs a generic error type extraction.
 
 ### Next boundary candidates
 - `Keeper_identity` (14 non-keeper callers) — widely shared utility module

--- a/docs/audit/2026-06-02-runtime-keeper-boundary-severance.md
+++ b/docs/audit/2026-06-02-runtime-keeper-boundary-severance.md
@@ -68,8 +68,12 @@ not keeper-specific logic. The `Keeper_` prefix was misleading.
 PR #19801 severed `Keeper_observation` and `Keeper_oas_checkpoint`. Two modules remain:
 - `runtime_oas_runner.ml`: `Keeper_identity.keeper_agent_name`, `Keeper_identity.keeper_name_from_agent_name` (2 calls)
 - `runtime_inference.ml`: `Keeper_internal_error.Max_tokens_ceiling_violation` (1 call)
+- `runtime_inference.mli:21`: public signature still returns `Keeper_internal_error.masc_internal_error`
+  — the interface exposes a Keeper type even once the `.ml` constructor is extracted, so a
+  follow-up must sever the `.mli` signature dependency too (not just the `.ml` reference).
 These require separate severance: `Keeper_identity` is shared with 14 non-keeper callers,
-`Keeper_internal_error` needs a generic error type extraction.
+`Keeper_internal_error` needs a generic error type extraction (covering both the `.ml`
+constructor use and the `.mli` return-type dependency).
 
 ### Next boundary candidates
 - `Keeper_identity` (14 non-keeper callers) — widely shared utility module


### PR DESCRIPTION
## Summary

Runtime (infrastructure layer) should not depend on Keeper (application layer). The correct dependency direction is Keeper -> Runtime, not the reverse.

Two modules were misnamed with the `Keeper_` prefix despite being runtime-oriented:

### Phase 1: Keeper_oas_checkpoint -> Runtime_oas_checkpoint
- **0 keeper-internal callers** — purely a runtime module
- Moved from `lib/keeper/` to `lib/runtime/`
- Only consumer: `runtime_agent.ml` (re-exported functions)

### Phase 2: Keeper_observation -> Runtime_observation
- Shared module used by keeper (9 files) and runtime/server (4 files)
- Observation types describe **runtime** behavior, not keeper-specific logic
- Moved from `lib/keeper/` to `lib/` (neutral location)
- `Keeper_observation_query_operation` -> `Runtime_observation_query_operation`

## Verification
- `dune build --root . lib/masc_mcp.cma` EXIT=0
- `dune build --root . @check` EXIT=0

## Context
Follows the Tool->Keeper boundary severance pattern (PR #19595 + #19632, ratchet baseline=0).
This is the next boundary axis: Runtime->Keeper, identified via systematic cross-subsystem scan.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
