### PR TITLE
refactor(tool): complete #19797 keeper/tool boundary cut (dependency inversion, not band-aid)

### DIFF
--- a/lib/keeper/keeper_tag_dispatch.ml
+++ b/lib/keeper/keeper_tag_dispatch.ml
@@ -44,7 +44,7 @@ let get_net_opt () = Eio_context.get_net_opt ()
     metric [tag] dimension separated from per-tool [name]. *)
 let string_of_tag (tag : Tool_dispatch.module_tag) : string =
   match tag with
-  | Mod_keeper -> "keeper"
+  | Mod_external -> "external"
   | Mod_library -> "library"
   | Mod_task -> "task"
   | Mod_shard -> "shard"
@@ -138,7 +138,13 @@ let dispatch
         { Tool_task.config; agent_name; sw = Eio_context.get_switch_opt () }
         ~name
         ~args
-    | Mod_keeper ->
+    | Mod_external ->
+      (* [Mod_external] tools are dispatched at the MCP server boundary
+         (mcp_server_eio_execute.dispatch_by_tag), which has the per-request
+         config/agent_name/Eio resources these handlers need. From within a
+         keeper turn that context is unavailable, so reject and direct the
+         caller to the MCP client surface. Currently these are the
+         keeper-management tools registered by [Keeper_tool_surface]. *)
       Some
         (workflow_err
            (Printf.sprintf "tool '%s' is a keeper management tool (use MCP client)" name))

--- a/lib/keeper/keeper_tag_dispatch.mli
+++ b/lib/keeper/keeper_tag_dispatch.mli
@@ -17,7 +17,7 @@
     - [Some (Ok _)] on successful dispatch.
     - [Some (Error _)] when the tool is blocked in keeper context
       ([Mod_control] mutators, most [Mod_inline] tools, [Mod_compact],
-      [Mod_keeper], [Mod_operator]) or when the underlying dispatch reports
+      [Mod_external], [Mod_operator]) or when the underlying dispatch reports
       failure. [masc_approval_pending] is the keeper-safe [Mod_inline]
       exception.
     - [None] only if the selected module does not recognise [name] (does

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -156,24 +156,41 @@ let keeper_supported_keeper_masc_tools =
   ]
 
 let keeper_supported_masc_schemas (schemas : Masc_domain.tool_schema list) =
+  (* #19797 follow-up: keeper-management-tool identification is keeper-owned,
+     not derived from a [Tool_dispatch] tag. Membership in
+     [Keeper_types_profile.schemas] is the SSOT registration set that
+     [Keeper_tool_surface] registers from — an exact name match, NOT a
+     "masc_keeper_" prefix classifier (CLAUDE.md workaround signature #2).
+     Sourced from the low-level types module (already open) rather than
+     [Keeper_tool_surface] to avoid a module dependency cycle. These tools
+     are MCP-client-only except the read/msg subset safe keeper-to-keeper. *)
+  let is_keeper_management_tool name =
+    List.exists
+      (fun (s : Masc_domain.tool_schema) -> String.equal s.name name)
+      Keeper_types_profile.schemas
+  in
   let supported_in_keeper name =
     if List.mem name keeper_safe_inline_tools then
       true
+    else if is_keeper_management_tool name then
+      (* Reliable pre-init too: [Keeper_tool_surface.schemas] is a static list,
+         independent of tag-registry initialization. Placed before the
+         [is_registered]/not-initialized fallbacks so management tools are
+         never over-exposed during boot. *)
+      List.mem name keeper_supported_keeper_masc_tools
     else if Tool_dispatch.is_registered name then
       true
     else if not (Tool_dispatch.is_tag_registry_initialized ()) then
       true
     else
-      match Tool_dispatch.lookup_tag name with
-      | Some Tool_dispatch.Mod_inline
-      | Some Tool_dispatch.Mod_compact
-      | Some Tool_dispatch.Mod_operator
-      | Some Tool_dispatch.Mod_control ->
-          false
-      | Some Tool_dispatch.Mod_keeper ->
-          List.mem name keeper_supported_keeper_masc_tools
-      | Some _ -> true
-      | None -> false
+      (match Tool_dispatch.lookup_tag name with
+       | Some Tool_dispatch.Mod_inline
+       | Some Tool_dispatch.Mod_compact
+       | Some Tool_dispatch.Mod_operator
+       | Some Tool_dispatch.Mod_control ->
+           false
+       | Some _ -> true
+       | None -> false)
   in
   (* masc_board_* tools that have keeper_board_* wrappers with auto-injected
      author/voter fields. Exposing both leads to the LLM calling the raw

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -756,7 +756,7 @@ let () =
         (Tool_spec.create
            ~name:s.name
            ~description:s.description
-           ~module_tag:Tool_dispatch.Mod_keeper
+           ~module_tag:Tool_dispatch.Mod_external
            ~input_schema:s.input_schema
            ~handler_binding:Tag_dispatch
            ~is_read_only:(List.mem s.name tool_spec_read_only)

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -320,7 +320,13 @@ let execute_tool_eio
                      { Tool_library.agent_name }
                      ~name
                      ~args:coerced_args
-                 | Mod_keeper ->
+                 | Mod_external ->
+                   (* Composition root wires the server boundary to the keeper
+                      subsystem: [Mod_external] tools (keeper-management tools)
+                      dispatch through [Keeper_tool_boundary] with the
+                      per-request context built above. The [Tool_dispatch] tag
+                      stays subsystem-agnostic; this is where the concrete
+                      handler is bound. *)
                    Keeper_tool_boundary.dispatch
                      (make_keeper_tool_ctx ())
                      ~name

--- a/lib/tool_dispatch.ml
+++ b/lib/tool_dispatch.ml
@@ -229,6 +229,11 @@ type module_tag =
   | Mod_agent | Mod_task | Mod_state
   | Mod_control | Mod_agent_timeline | Mod_misc
   | Mod_library
+  (* [Mod_external]: dispatched by a server-boundary handler in the
+     composition root (mcp_server_eio_execute.dispatch_by_tag), not by a
+     peer [Tool_*] module. The tool layer does not know which subsystem
+     handles these — that wiring lives at the boundary. *)
+  | Mod_external
   | Mod_inline
   | Mod_shard
 

--- a/lib/tool_dispatch.mli
+++ b/lib/tool_dispatch.mli
@@ -139,7 +139,11 @@ type module_tag =
   | Mod_compact
   | Mod_agent | Mod_task | Mod_state
   | Mod_control | Mod_agent_timeline | Mod_misc
-  | Mod_library | Mod_keeper
+  | Mod_library
+  (* [Mod_external]: dispatched by a server-boundary handler in the
+     composition root, not by a peer [Tool_*] module. The tool layer
+     stays agnostic to which subsystem (e.g. keeper) actually handles it. *)
+  | Mod_external
   | Mod_inline
   | Mod_shard
 


### PR DESCRIPTION
## 무엇을

`#19797 [codex] hard cut keeper/tool boundary coupling`이 `Mod_keeper`를 `tool_dispatch.ml`에서 제거했으나 `.mli`에는 남겨 빌드가 깨졌습니다. 이 PR은 그 경계 절단을 **올바르게 완성**합니다 — tool dispatch 레이어가 더 이상 keeper를 이름으로 알지 않게 합니다.

- `tool_dispatch`: keeper를 명명한 `Mod_keeper`를 중립 `Mod_external`로 교체 ("peer `Tool_*` 모듈이 아니라 server-boundary handler가 dispatch함"). tool 레이어는 어느 subsystem이 처리하는지 모릅니다.
- `mcp_server_eio_execute` (composition root): `Mod_external`을 per-request 컨텍스트와 함께 `Keeper_tool_boundary.dispatch`에 바인딩. concrete handler 배선은 저수준 tag 타입이 아니라 경계에서.
- `keeper_tool_policy`: keeper 관리도구 식별을 dispatch tag가 아닌 keeper 소유 `Keeper_types_profile.schemas` 정확 멤버십으로 수행 (이름 정확 일치, name-prefix 매칭 아님). `Keeper_tool_surface`가 등록하는 동일 저수준 types 모듈에서 가져와 모듈 cycle 회피.
- `keeper_tag_dispatch` / `keeper_tool_surface`: rename 반영.

## 왜 (트레이드오프)

`#19809`은 같은 site를 `Mod_keeper`를 `.ml`에 되살려 고치는데, 이는 `#19797`이 의도한 경계 절단을 **되돌려** tool↔keeper 결합을 재도입합니다. 본 PR은 절단을 유지한 채 빌드를 복구합니다. 장점: tool 레이어가 keeper-agnostic, exhaustive match로 컴파일러가 누락 강제. 단점: 단독으로는 green 불가 — 아래 의존 PR이 함께 필요.

## 검증

- `tool_dispatch.cmo`, `keeper_tag_dispatch.cmo` 격리 빌드 EXIT=0.
- 초기 draft가 유발한 모듈 의존성 cycle (`Keeper_tool_policy -> Keeper_tool_surface`) 제거 확인 (저수준 `Keeper_types_profile`에서 schemas 소싱).
- whole-program 빌드는 `#19797`의 나머지 fallout (~43개: `runtime_id_of_meta`, `Tool_catalog.Keeper_denied` 등)이 남아 아직 red. 그 부분은 `#19806`/`#19808`/`#19809`(단 `tool_dispatch.ml` Mod_keeper hunk 제외)에서 복구.

## 의존

- `#19806`, `#19808`: `#19797` fallout의 비-Mod_keeper 심볼 복구.
- `#19809`: `tool_dispatch.ml`의 `Mod_keeper` 복원 hunk를 빼야 충돌 없음. 나머지 5 sites는 본 PR과 disjoint.

RFC-WAIVED: tool dispatch tag 타입 rename + keeper-owned 식별로의 전환. credential/identity/operator-control/sandbox/hooks subsystem 미해당.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
