### PR TITLE
fix(keeper): currency-sync cancellation-safe + observable (RFC-0210 follow-up)

### DIFF
--- a/lib/keeper/agent_tool_execute_path.ml
+++ b/lib/keeper/agent_tool_execute_path.ml
@@ -18,8 +18,11 @@ let currency_last_sync : (string, float) Hashtbl.t = Hashtbl.create 64
 let currency_min_interval_sec = 30.0
 
 (* Keep the keeper's sandbox clone current with origin/<default_branch> before
-   code work. Best-effort: never raises, never blocks the turn; the advance is
-   fast-forward-only and work-preserving (see [Keeper_repo_readiness]). *)
+   code work. Best-effort: a failed advance never fails the turn, but
+   [Eio.Cancel.Cancelled] is re-raised so turn cancellation is preserved. The
+   advance is fast-forward-only and work-preserving (see [Keeper_repo_readiness]).
+   The typed outcome is logged rather than dropped: a [Skipped] sync is the very
+   "repo silently frozen" failure this exists to fix, so it stays visible. *)
 let sync_repo_currency_best_effort ~config ~meta ~repo_name =
   let cpath = Keeper_repo_readiness.clone_path ~config ~meta ~repo_name in
   let now = Unix.gettimeofday () in
@@ -30,9 +33,24 @@ let sync_repo_currency_best_effort ~config ~meta ~repo_name =
   in
   if due then begin
     Hashtbl.replace currency_last_sync cpath now;
-    (try
-       ignore (Keeper_repo_readiness.ensure_current ~config ~meta ~repo_name ())
-     with _ -> ())
+    try
+      match Keeper_repo_readiness.ensure_current ~config ~meta ~repo_name () with
+      | Keeper_repo_readiness.Up_to_date -> ()
+      | Advanced commits ->
+        Log.Keeper.info "currency: advanced sandbox repo %s by %d commit(s)"
+          repo_name commits
+      | Preserved reason ->
+        (* Local/divergent work kept; expected when a keeper has uncommitted or
+           branched changes. Debug so it does not drown the actionable case. *)
+        Log.Keeper.debug "currency: preserved sandbox repo %s (%s)" repo_name reason
+      | Skipped reason ->
+        (* Currency could not be established (missing/corrupt clone, no
+           credential, or fetch failure). Visible by default so a recurring
+           failure does not re-freeze the repo invisibly. *)
+        Log.Keeper.info "currency: skipped sandbox repo %s (%s)" repo_name reason
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | _ -> ()
   end
 
 let repo_path_context ~(config : Workspace.config) ~(meta : keeper_meta) cwd =


### PR DESCRIPTION
## 목표

RFC-0210 (#19813)의 post-merge follow-up. 머지된 `sync_repo_currency_best_effort`의 두 결함을 고칩니다. 둘 다 #19813이 broken main으로 admin-merge되면서 CI가 잡았으나 머지된 상태입니다.

## 결함 (둘 다 현재 main에 존재)

1. **Cancellation 흡수**: `try ... with _ -> ()`가 `Eio.Cancel.Cancelled`까지 삼켜 keeper turn 취소 의미론을 깨뜨립니다. `lib/keeper/` 전반은 `Eio.Cancel.Cancelled _ as e -> raise e`로 cancellation만 통과시키는데(수십 개 사이트), 이 catch-all은 그 관용구를 위반합니다 — `KeeperOASAdvanced.tla`가 모델링한 `Cancelled` 흡수 안티패턴.
2. **Silent drop**: typed `currency_outcome`를 `ignore`로 통째 버립니다. `Skipped` sync(= 이 feature가 고치려는 "repo가 *조용히* frozen" 바로 그 실패)가 invisible해집니다. 이게 `ignore() justification` CI 게이트 fail의 직접 원인이기도 합니다.

## 변경 (1 파일, `lib/keeper/agent_tool_execute_path.ml`)

- `Eio.Cancel.Cancelled`를 re-raise하고 나머지만 swallow.
- typed `currency_outcome`를 match해 레벨별 로그: `Advanced`/`Skipped` → `info`(default visible), `Preserved` → `debug`(의도된 work 보존이라 actionable 케이스를 가리지 않게). `ignore ()` 사이트가 사라져 CI 게이트 통과.

## 검증 (정직 기재)

- ✅ 모듈 격리 컴파일 green: `dune build lib/.masc_mcp.objs/byte/masc_mcp__Agent_tool_execute_path.cmo` 성공 (typed match / `Log.Keeper` / Cancelled arm 전부 valid).
- ✅ 0 new whole-program errors: `dune build .`의 44 errors는 전부 #19797 fallout(`Keeper_meta_contract.runtime_id_of_meta` unbound 등), 제 파일은 에러 목록에 없음.
- ✅ work-preservation primitive standalone 증명 (`git merge --ff-only`): clean-behind clone → advance(exit 0); diverged clone → refuse(non-zero) + HEAD/tree 불변(divergent 로컬 커밋 보존). `Repo_git.fast_forward`가 wrapping하는 git 보장.
- ⏳ whole-program `dune build .` + `ensure_current` OCaml 테스트: **broken main(#19797 fallout, 44 errors)에 막힘**. 모든 test가 단일 거대 `(tests (names ...))` stanza로 broken `masc_mcp` lib에 커플링되어 main green 전까지 실행 불가.

## RFC

owning RFC: **RFC-0210** (#19813에서 main에 머지). 이 PR은 그 구현 결함의 post-merge 수정이며 RFC 계약을 변경하지 않습니다.

## 범위 밖

- broken-main(#19797 boundary cut fallout) 복구는 별건 (사용자 PAUSE 결정, 별도 repair 브랜치들 in-flight).
- `ensure_current` 통합 테스트(dirty/diverged/feature/detached → `Preserved`)는 main green 후 추가.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
