### PR TITLE
refactor(boundary): decouple Tool⊥Keeper (typed Keeper_tool_name) + extract masc_goal domain lib

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -16,7 +16,6 @@ module Mcp_server = Masc_mcp.Mcp_server
 module Mcp_eio = Masc_mcp.Mcp_server_eio
 module Workspace = Masc_mcp.Workspace
 module Workspace_utils = Workspace_utils
-module Tool_keeper = Masc_mcp.Tool_keeper
 module Keeper_types = Masc_mcp.Keeper_types
 module Keeper_meta_store = Masc_mcp.Keeper_meta_store
 module Keeper_meta_contract = Masc_mcp.Keeper_meta_contract

--- a/lib/dune
+++ b/lib/dune
@@ -570,6 +570,8 @@
    masc_random_id
    ;; Workspace workspace (extracted sub-library)
    masc_workspace
+   ;; Goal domain (extracted sub-library — pure goal logic, decoupled from mega-lib)
+   masc_goal
    ;; Environment configuration (extracted sub-library)
    masc_mcp.config
    masc_mcp.ide

--- a/lib/goal/dune
+++ b/lib/goal/dune
@@ -25,6 +25,7 @@
   time_compat
   fs_compat
   yojson
-  eio)
+  eio
+  unix)
  (preprocess
   (pps ppx_deriving.show ppx_deriving.eq ppx_deriving_yojson)))

--- a/lib/goal/dune
+++ b/lib/goal/dune
@@ -1,0 +1,30 @@
+(include_subdirs no)
+
+;; Goal domain — pure goal logic (store / phase / verification / convergence /
+;; janitor). Decoupled from the masc_mcp mega-library: persistence goes through
+;; the already-separate masc_workspace library (Workspace_utils / Workspace_query),
+;; never the mega-lib Workspace facade. Dependency direction is one-way:
+;; consumers (workspace_goals adapter, dashboards) depend on masc_goal; masc_goal
+;; depends only on neutral libraries below.
+;;
+;; Known leak to flag (not a build blocker): goal_janitor uses
+;; Workspace_query.get_tasks_safe — Goal reaching into Task state. That is a
+;; semantic Goal<->Task boundary error to sever later (janitor is really an
+;; adapter, not pure Goal domain).
+(library
+ (name masc_goal)
+ (public_name masc_mcp.masc_goal)
+ (wrapped false)
+ (libraries
+  masc_types
+  masc_core
+  masc_config
+  masc_log
+  masc_workspace
+  shared_audit
+  time_compat
+  fs_compat
+  yojson
+  eio)
+ (preprocess
+  (pps ppx_deriving.show ppx_deriving.eq ppx_deriving_yojson)))

--- a/lib/goal/goal_janitor.ml
+++ b/lib/goal/goal_janitor.ml
@@ -146,7 +146,7 @@ let emit_orphan_task_escalation workspace_config ~threshold_seconds orphan_tasks
                ])
           orphan_tasks
       in
-      Workspace.log_event workspace_config
+      Workspace_utils.log_event workspace_config
         (`Assoc
            [ ("type", `String "goal_orphan_task_escalation")
            ; ("subsystem", `String "goal_janitor")
@@ -177,7 +177,7 @@ let prune_active_goal_ids ~(valid_goal_ids : string list)
 
 type orphan_goal_binding_hooks =
   { prune_orphan_goal_bindings :
-      Workspace.config -> valid_goal_ids:string list -> int
+      Workspace_utils.config -> valid_goal_ids:string list -> int
   }
 
 let default_orphan_goal_binding_hooks =
@@ -195,7 +195,7 @@ let prune_orphan_goal_bindings workspace_config ~valid_goal_ids =
 
 (** Run a full sweep: goals + owner-managed goal bindings.
     Writes updated state to disk. *)
-let run ?(config = default_config) (workspace_config : Workspace.config) : sweep_result =
+let run ?(config = default_config) (workspace_config : Workspace_utils.config) : sweep_result =
   let st = Goal_store.read_state workspace_config in
   let goals', partial = sweep_goals ~config st.goals in
   let valid_ids = List.map (fun (g : Goal_store.goal) -> g.id) goals' in
@@ -209,7 +209,7 @@ let run ?(config = default_config) (workspace_config : Workspace.config) : sweep
     prune_orphan_goal_bindings workspace_config ~valid_goal_ids:valid_ids
   in
   let orphan_task_rows =
-    Workspace.get_tasks_safe workspace_config
+    Workspace_query.get_tasks_safe workspace_config
     |> audit_unclaimed_goal_orphan_tasks ~valid_goal_ids:valid_ids
          ~min_age_seconds:config.orphan_task_escalation_age_seconds
   in

--- a/lib/goal/goal_janitor.mli
+++ b/lib/goal/goal_janitor.mli
@@ -66,7 +66,7 @@ val prune_active_goal_ids :
 
 type orphan_goal_binding_hooks =
   { prune_orphan_goal_bindings :
-      Workspace.config -> valid_goal_ids:string list -> int
+      Workspace_utils.config -> valid_goal_ids:string list -> int
   }
 
 val set_orphan_goal_binding_hooks : orphan_goal_binding_hooks -> unit
@@ -87,4 +87,4 @@ val audit_unclaimed_goal_orphan_tasks :
 
 (** Run a full sweep: goal purge / stagnate, then owner goal-binding
     prune. Writes updated state to disk. *)
-val run : ?config:sweep_config -> Workspace.config -> sweep_result
+val run : ?config:sweep_config -> Workspace_utils.config -> sweep_result

--- a/lib/goal/goal_store.ml
+++ b/lib/goal/goal_store.ml
@@ -346,17 +346,17 @@ let parse_refresh_mode s =
   | _ -> None
 
 let goals_path config =
-  Filename.concat (Workspace.masc_dir config) "goals.json"
+  Filename.concat (Workspace_utils.masc_dir config) "goals.json"
 
 let snapshots_dir config =
-  Filename.concat (Workspace.masc_dir config) "goals_snapshots"
+  Filename.concat (Workspace_utils.masc_dir config) "goals_snapshots"
 
 let scheduler_state_path config =
-  Filename.concat (Workspace.masc_dir config) "goals_scheduler_state.json"
+  Filename.concat (Workspace_utils.masc_dir config) "goals_scheduler_state.json"
 
 let ensure_dirs config =
-  Workspace.mkdir_p (Workspace.masc_dir config);
-  Workspace.mkdir_p (snapshots_dir config)
+  Workspace_utils.mkdir_p (Workspace_utils.masc_dir config);
+  Workspace_utils.mkdir_p (snapshots_dir config)
 
 let default_state () =
   { version = 1; updated_at = Masc_domain.now_iso (); goals = [] }
@@ -364,8 +364,8 @@ let default_state () =
 let read_state config =
   ensure_dirs config;
   let path = goals_path config in
-  if Workspace.path_exists config path then
-    match state_of_yojson (Workspace.read_json config path) with
+  if Workspace_utils.path_exists config path then
+    match state_of_yojson (Workspace_utils.read_json config path) with
     | Ok state -> { state with goals = List.map normalize_goal state.goals }
     | Error _ -> default_state ()
   else
@@ -373,7 +373,7 @@ let read_state config =
 
 let write_state config state =
   ensure_dirs config;
-  Workspace.write_json config (goals_path config) (state_to_yojson state)
+  Workspace_utils.write_json config (goals_path config) (state_to_yojson state)
 
 let now_ms () =
   int_of_float (Time_compat.now () *. 1000.0)
@@ -390,7 +390,7 @@ let replace_goal goals updated =
 
 let update_state config f =
   let lock_path = goals_path config in
-  Workspace.with_file_lock config lock_path (fun () ->
+  Workspace_utils.with_file_lock config lock_path (fun () ->
       let state = read_state config in
       let next_state = f state in
       write_state config next_state;
@@ -401,7 +401,7 @@ let get_goal config ~goal_id =
 
 let update_goal config ~goal_id f =
   let lock_path = goals_path config in
-  Workspace.with_file_lock config lock_path (fun () ->
+  Workspace_utils.with_file_lock config lock_path (fun () ->
       let state = read_state config in
       match find_goal state.goals goal_id with
       | None -> Error "goal not found"
@@ -611,7 +611,7 @@ let snapshot config ~mode =
   let path =
     Filename.concat (snapshots_dir config) (snapshot_id ^ ".json")
   in
-  Workspace.write_json config path (snapshot_to_yojson snapshot);
+  Workspace_utils.write_json config path (snapshot_to_yojson snapshot);
   snapshot
 
 let parse_yyyy_mm_dd s =
@@ -704,4 +704,4 @@ let active_goals config =
   list_goals config ~status:Active ()
 
 let has_scheduler_state config =
-  Workspace.path_exists config (scheduler_state_path config)
+  Workspace_utils.path_exists config (scheduler_state_path config)

--- a/lib/goal/goal_store.mli
+++ b/lib/goal/goal_store.mli
@@ -162,18 +162,18 @@ val compute_rollup : goal list -> rollup
 
 (** {1 Persistence paths} *)
 
-val goals_path : Workspace.config -> string
-(** [{!Workspace.masc_dir} / "goals.json"]. *)
+val goals_path : Workspace_utils.config -> string
+(** [{!Workspace_utils.masc_dir} / "goals.json"]. *)
 
 (** {1 State I/O} *)
 
-val read_state : Workspace.config -> state
+val read_state : Workspace_utils.config -> state
 (** Reads {!goals_path}; returns an empty default state on
     missing file or parse failure.  Goals loaded from disk
     are passed through the internal normaliser ([priority]
     clamp + phase/status reconciliation). *)
 
-val write_state : Workspace.config -> state -> unit
+val write_state : Workspace_utils.config -> state -> unit
 (** Direct overwrite of {!goals_path} with the supplied state.
     Used by tests that need deterministic initial state without
     the read-modify-write cycle of {!update_state}.
@@ -181,7 +181,7 @@ val write_state : Workspace.config -> state -> unit
     Does *not* acquire the file lock; callers that need atomicity
     should use {!update_state} instead. *)
 
-val update_state : Workspace.config -> (state -> state) -> state
+val update_state : Workspace_utils.config -> (state -> state) -> state
 (** Atomic read-modify-write under the goals file lock.
     [f] receives the current state and returns the next state.
     The file lock protects against concurrent truncation races
@@ -189,10 +189,10 @@ val update_state : Workspace.config -> (state -> state) -> state
 
 (** {1 Single-goal operations} *)
 
-val get_goal : Workspace.config -> goal_id:string -> goal option
+val get_goal : Workspace_utils.config -> goal_id:string -> goal option
 
 val update_goal :
-  Workspace.config ->
+  Workspace_utils.config ->
   goal_id:string ->
   (goal -> goal) ->
   (goal, string) result
@@ -201,14 +201,14 @@ val update_goal :
     and writes back.  Errors when the [goal_id] is unknown. *)
 
 val delete_goal :
-  Workspace.config -> goal_id:string -> (unit, string) result
+  Workspace_utils.config -> goal_id:string -> (unit, string) result
 (** Removes the goal whose [.id] matches.  Errors when the
     id is unknown. *)
 
 (** {1 List + upsert} *)
 
 val list_goals :
-  Workspace.config ->
+  Workspace_utils.config ->
   ?horizon:horizon ->
   ?status:goal_status ->
   ?phase:Goal_phase.t ->
@@ -218,7 +218,7 @@ val list_goals :
     by [(horizon, priority, updated_at desc)]. *)
 
 val upsert_goal :
-  Workspace.config ->
+  Workspace_utils.config ->
   ?id:string ->
   ?horizon:horizon ->
   ?title:string ->

--- a/lib/goal/goal_verification.ml
+++ b/lib/goal/goal_verification.ml
@@ -413,25 +413,25 @@ type quorum_result =
   | Failed
 
 let requests_path config =
-  Filename.concat (Workspace.masc_dir config) "goal_verifications.json"
+  Filename.concat (Workspace_utils.masc_dir config) "goal_verifications.json"
 
 let events_path config =
-  Filename.concat (Workspace.masc_dir config) "goal_events.jsonl"
+  Filename.concat (Workspace_utils.masc_dir config) "goal_events.jsonl"
 
 let default_state () =
   { version = 1; updated_at = Masc_domain.now_iso (); requests = [] }
 
 let read_state config =
   let path = requests_path config in
-  if Workspace.path_exists config path then
-    match state_of_yojson (Workspace.read_json config path) with
+  if Workspace_utils.path_exists config path then
+    match state_of_yojson (Workspace_utils.read_json config path) with
     | Ok state -> state
     | Error _ -> default_state ()
   else
     default_state ()
 
 let write_state config (state : state) =
-  Workspace.write_json config (requests_path config) (state_to_yojson state)
+  Workspace_utils.write_json config (requests_path config) (state_to_yojson state)
 
 let principal_key (principal : goal_principal) =
   Printf.sprintf "%s:%s" (principal_kind_to_string principal.kind) principal.id
@@ -531,7 +531,7 @@ let emit_event config ~(goal_id : string) ~(event_type : string)
 
 let update_state config f =
   let lock_path = requests_path config in
-  Workspace.with_file_lock config lock_path (fun () ->
+  Workspace_utils.with_file_lock config lock_path (fun () ->
       let state = read_state config in
       let next_state = f state in
       write_state config next_state;
@@ -607,7 +607,7 @@ let evaluate_quorum request =
 
 let cancel_request config ~(request_id : string) =
   let lock_path = requests_path config in
-  Workspace.with_file_lock config lock_path (fun () ->
+  Workspace_utils.with_file_lock config lock_path (fun () ->
       let state = read_state config in
       match List.find_opt (fun request -> String.equal request.id request_id) state.requests with
       | None -> Error "goal verification request not found"
@@ -634,7 +634,7 @@ let cancel_request config ~(request_id : string) =
 let submit_vote config ~(request_id : string) ~(principal : goal_principal)
     ~(decision : vote_decision) ?note ?(evidence_refs = []) () =
   let lock_path = requests_path config in
-  Workspace.with_file_lock config lock_path (fun () ->
+  Workspace_utils.with_file_lock config lock_path (fun () ->
       let state = read_state config in
       match List.find_opt (fun request -> String.equal request.id request_id) state.requests with
       | None -> Error "goal verification request not found"

--- a/lib/goal/goal_verification.mli
+++ b/lib/goal/goal_verification.mli
@@ -4,7 +4,7 @@
     Holds the data contract + persistence + workflow for "this
     goal needs N approvals from these principals before it
     can move to [Goal_phase.Completed]".  The state file
-    lives at {!requests_path} under [Workspace.masc_dir]; an
+    lives at {!requests_path} under [Workspace_utils.masc_dir]; an
     append-only audit trail goes to {!events_path}.
 
     The yojson [_to_yojson] / [_of_yojson] pairs are written
@@ -211,18 +211,18 @@ type quorum_result =
 
 (** {1 Persistence paths} *)
 
-val requests_path : Workspace.config -> string
-(** [{!Workspace.masc_dir} config / "goal_verifications.json"].
+val requests_path : Workspace_utils.config -> string
+(** [{!Workspace_utils.masc_dir} config / "goal_verifications.json"].
     The single state file the workspace backend persists. *)
 
-val events_path : Workspace.config -> string
-(** [{!Workspace.masc_dir} config / "goal_events.jsonl"].
+val events_path : Workspace_utils.config -> string
+(** [{!Workspace_utils.masc_dir} config / "goal_events.jsonl"].
     Append-only audit trail; each line is the JSON written by
     {!emit_event}. *)
 
 (** {1 State I/O} *)
 
-val read_state : Workspace.config -> state
+val read_state : Workspace_utils.config -> state
 (** Reads {!requests_path}; returns the empty default state
     if the file does not exist or fails to parse.  Parse
     errors are silently absorbed — the JSONL events file is
@@ -255,7 +255,7 @@ val exclude_requester :
 (** {1 Audit trail} *)
 
 val emit_event :
-  Workspace.config ->
+  Workspace_utils.config ->
   goal_id:string ->
   event_type:string ->
   payload:Yojson.Safe.t ->
@@ -267,7 +267,7 @@ val emit_event :
 (** {1 Workflow} *)
 
 val create_request :
-  Workspace.config ->
+  Workspace_utils.config ->
   goal_id:string ->
   requested_by:goal_principal ->
   policy_snapshot:policy_snapshot ->
@@ -277,7 +277,7 @@ val create_request :
     duration so concurrent creates serialize cleanly. *)
 
 val find_request :
-  Workspace.config -> request_id:string -> goal_verification_request option
+  Workspace_utils.config -> request_id:string -> goal_verification_request option
 (** Lock-free lookup.  Caller is expected to treat the result
     as a snapshot; for mutation use {!submit_vote} or
     {!cancel_request}. *)
@@ -292,7 +292,7 @@ val remaining_possible_votes : goal_verification_request -> int
     [Approve]s are reachable. *)
 
 val cancel_request :
-  Workspace.config ->
+  Workspace_utils.config ->
   request_id:string ->
   (goal_verification_request, string) result
 (** Flips [status] from [Open] to [Cancelled] and stamps
@@ -301,7 +301,7 @@ val cancel_request :
     Errors when [request_id] is unknown. *)
 
 val submit_vote :
-  Workspace.config ->
+  Workspace_utils.config ->
   request_id:string ->
   principal:goal_principal ->
   decision:vote_decision ->

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -268,10 +268,10 @@ let tool_name_can_satisfy_actionable_gate ~(claim_context_allowed : bool) name =
     match
       name
       |> Keeper_tool_resolution.canonical_tool_name
-      |> Tool_name.of_string
+      |> Keeper_tool_name.of_string
     with
-    | Some (Tool_name.Keeper Tool_name.Keeper.Task_force_done)
-    | Some (Tool_name.Keeper Tool_name.Keeper.Task_force_release) -> true
+    | Some Keeper_tool_name.Task_force_done
+    | Some Keeper_tool_name.Task_force_release -> true
     | _ -> false
   in
   if claim_context_allowed
@@ -501,16 +501,16 @@ let sync_current_task_id_for_agent_name =
   Keeper_current_task_reconcile.sync_current_task_id_for_agent_name
 
 let tool_names =
-  List.map Tool_name.to_string
+  List.map Keeper_tool_name.to_string
 
 let fallback_floor_tool_names =
   tool_names
-    Tool_name.[
-      Keeper Context_status;
-      Keeper Task_claim;
-      Keeper Tasks_list;
-      Keeper Board_list;
-      Keeper Board_get;
+    Keeper_tool_name.[
+      Context_status;
+      Task_claim;
+      Tasks_list;
+      Board_list;
+      Board_get;
     ]
 
 let is_claim_tool_name name =

--- a/lib/keeper/keeper_agent_tool_surface.mli
+++ b/lib/keeper/keeper_agent_tool_surface.mli
@@ -244,8 +244,8 @@ val sync_current_task_id_for_agent_name :
   agent_name:string ->
   unit
 
-(** Convenience [List.map Tool_name.to_string]. *)
-val tool_names : Tool_name.t list -> string list
+(** Convenience [List.map Keeper_tool_name.to_string]. *)
+val tool_names : Keeper_tool_name.t list -> string list
 
 val fallback_floor_tool_names : string list
 

--- a/lib/keeper/keeper_tool_name.ml
+++ b/lib/keeper/keeper_tool_name.ml
@@ -1,0 +1,160 @@
+(* Keeper-owned MCP tool-name vocabulary.
+
+   Moved out of the central [Tool_name] module (was the nested [Tool_name.Keeper])
+   so the tool dispatch substrate stays keeper-agnostic: the substrate routes
+   opaque tool names and the keeper subsystem owns the typed vocabulary of its
+   own tools. Dependency direction is keeper -> tool, never the reverse.
+
+   History: [Tool_name.Keeper] was deleted by #19797 (hard cut keeper/tool
+   coupling) without a typed replacement, which regressed keeper tool names to
+   bare strings scattered across keeper code. This restores the single source of
+   truth on the keeper side of the Tool/Keeper boundary. *)
+
+type t =
+  | Execute
+  | Board_comment
+  | Board_comment_vote
+  | Board_curation_read
+  | Board_curation_submit
+  | Board_get
+  | Board_list
+  | Board_post
+  | Board_search
+  | Board_stats
+  | Board_sub_board_create
+  | Board_sub_board_delete
+  | Board_sub_board_get
+  | Board_sub_board_list
+  | Board_sub_board_update
+  | Board_vote
+  | Broadcast
+  | Context_status
+  | Fs_edit
+  | Fs_write
+  | Fs_read
+  | Ide_annotate
+  | Handoff
+  | Library_read
+  | Library_search
+  | Memory_search
+  | Memory_write
+  | Search_files
+  | Stay_silent
+  | Task_claim
+  | Task_create
+  | Task_done
+  | Task_submit_for_verification
+  | Task_force_done
+  | Task_force_release
+  | Tasks_audit
+  | Tasks_list
+  | Time_now
+  | Tool_search
+  | Tools_list
+  | Voice_agent
+  | Voice_listen
+  | Voice_session_end
+  | Voice_session_start
+  | Voice_sessions
+  | Voice_speak
+
+let to_string = function
+  | Execute -> "tool_execute"
+  | Board_comment -> "keeper_board_comment"
+  | Board_comment_vote -> "keeper_board_comment_vote"
+  | Board_curation_read -> "keeper_board_curation_read"
+  | Board_curation_submit -> "keeper_board_curation_submit"
+  | Board_get -> "keeper_board_get"
+  | Board_list -> "keeper_board_list"
+  | Board_post -> "keeper_board_post"
+  | Board_search -> "keeper_board_search"
+  | Board_stats -> "keeper_board_stats"
+  | Board_sub_board_create -> "keeper_board_sub_board_create"
+  | Board_sub_board_delete -> "keeper_board_sub_board_delete"
+  | Board_sub_board_get -> "keeper_board_sub_board_get"
+  | Board_sub_board_list -> "keeper_board_sub_board_list"
+  | Board_sub_board_update -> "keeper_board_sub_board_update"
+  | Board_vote -> "keeper_board_vote"
+  | Broadcast -> "keeper_broadcast"
+  | Context_status -> "keeper_context_status"
+  | Fs_edit -> "tool_edit_file"
+  | Fs_write -> "tool_write_file"
+  | Fs_read -> "tool_read_file"
+  | Ide_annotate -> "keeper_ide_annotate"
+  | Handoff -> "keeper_handoff"
+  | Library_read -> "keeper_library_read"
+  | Library_search -> "keeper_library_search"
+  | Memory_search -> "keeper_memory_search"
+  | Memory_write -> "keeper_memory_write"
+  | Search_files -> "tool_search_files"
+  | Stay_silent -> "keeper_stay_silent"
+  | Task_claim -> "keeper_task_claim"
+  | Task_create -> "keeper_task_create"
+  | Task_done -> "keeper_task_done"
+  | Task_submit_for_verification -> "keeper_task_submit_for_verification"
+  | Task_force_done -> "keeper_task_force_done"
+  | Task_force_release -> "keeper_task_force_release"
+  | Tasks_audit -> "keeper_tasks_audit"
+  | Tasks_list -> "keeper_tasks_list"
+  | Time_now -> "keeper_time_now"
+  | Tool_search -> "keeper_tool_search"
+  | Tools_list -> "keeper_tools_list"
+  | Voice_agent -> "keeper_voice_agent"
+  | Voice_listen -> "keeper_voice_listen"
+  | Voice_session_end -> "keeper_voice_session_end"
+  | Voice_session_start -> "keeper_voice_session_start"
+  | Voice_sessions -> "keeper_voice_sessions"
+  | Voice_speak -> "keeper_voice_speak"
+;;
+
+let of_string = function
+  | "tool_execute" -> Some Execute
+  | "keeper_board_comment" -> Some Board_comment
+  | "keeper_board_comment_vote" -> Some Board_comment_vote
+  | "keeper_board_curation_read" -> Some Board_curation_read
+  | "keeper_board_curation_submit" -> Some Board_curation_submit
+  | "keeper_board_get" -> Some Board_get
+  | "keeper_board_list" -> Some Board_list
+  | "keeper_board_post" -> Some Board_post
+  | "keeper_board_search" -> Some Board_search
+  | "keeper_board_stats" -> Some Board_stats
+  | "keeper_board_vote" -> Some Board_vote
+  | "keeper_board_sub_board_create" -> Some Board_sub_board_create
+  | "keeper_board_sub_board_delete" -> Some Board_sub_board_delete
+  | "keeper_board_sub_board_get" -> Some Board_sub_board_get
+  | "keeper_board_sub_board_list" -> Some Board_sub_board_list
+  | "keeper_board_sub_board_update" -> Some Board_sub_board_update
+  | "keeper_broadcast" -> Some Broadcast
+  | "keeper_context_status" -> Some Context_status
+  | "tool_edit_file" -> Some Fs_edit
+  | "tool_write_file" -> Some Fs_write
+  | "tool_read_file" -> Some Fs_read
+  | "keeper_ide_annotate" -> Some Ide_annotate
+  | "keeper_handoff" -> Some Handoff
+  | "keeper_library_read" -> Some Library_read
+  | "keeper_library_search" -> Some Library_search
+  | "keeper_memory_search" -> Some Memory_search
+  | "keeper_memory_write" -> Some Memory_write
+  | "tool_search_files" -> Some Search_files
+  | "keeper_stay_silent" -> Some Stay_silent
+  | "keeper_task_claim" -> Some Task_claim
+  | "keeper_task_create" -> Some Task_create
+  | "keeper_task_done" -> Some Task_done
+  | "keeper_task_submit_for_verification" -> Some Task_submit_for_verification
+  | "keeper_task_force_done" -> Some Task_force_done
+  | "keeper_task_force_release" -> Some Task_force_release
+  | "keeper_tasks_audit" -> Some Tasks_audit
+  | "keeper_tasks_list" -> Some Tasks_list
+  | "keeper_time_now" -> Some Time_now
+  | "keeper_tool_search" -> Some Tool_search
+  | "keeper_tools_list" -> Some Tools_list
+  | "keeper_voice_agent" -> Some Voice_agent
+  | "keeper_voice_listen" -> Some Voice_listen
+  | "keeper_voice_session_end" -> Some Voice_session_end
+  | "keeper_voice_session_start" -> Some Voice_session_start
+  | "keeper_voice_sessions" -> Some Voice_sessions
+  | "keeper_voice_speak" -> Some Voice_speak
+  | _ -> None
+;;
+
+let pp fmt t = Format.pp_print_string fmt (to_string t)

--- a/lib/keeper/keeper_tool_name.mli
+++ b/lib/keeper/keeper_tool_name.mli
@@ -1,0 +1,58 @@
+(** Keeper-owned MCP tool-name vocabulary.
+
+    Lives on the keeper side of the Tool/Keeper boundary: the tool dispatch
+    substrate routes opaque tool names and the keeper subsystem owns the typed
+    vocabulary of its own tools. Dependency direction is keeper -> tool, never
+    the reverse. See the implementation header for the #19797 history. *)
+
+type t =
+  | Execute
+  | Board_comment
+  | Board_comment_vote
+  | Board_curation_read
+  | Board_curation_submit
+  | Board_get
+  | Board_list
+  | Board_post
+  | Board_search
+  | Board_stats
+  | Board_sub_board_create
+  | Board_sub_board_delete
+  | Board_sub_board_get
+  | Board_sub_board_list
+  | Board_sub_board_update
+  | Board_vote
+  | Broadcast
+  | Context_status
+  | Fs_edit
+  | Fs_write
+  | Fs_read
+  | Ide_annotate
+  | Handoff
+  | Library_read
+  | Library_search
+  | Memory_search
+  | Memory_write
+  | Search_files
+  | Stay_silent
+  | Task_claim
+  | Task_create
+  | Task_done
+  | Task_submit_for_verification
+  | Task_force_done
+  | Task_force_release
+  | Tasks_audit
+  | Tasks_list
+  | Time_now
+  | Tool_search
+  | Tools_list
+  | Voice_agent
+  | Voice_listen
+  | Voice_session_end
+  | Voice_session_start
+  | Voice_sessions
+  | Voice_speak
+
+val to_string : t -> string
+val of_string : string -> t option
+val pp : Format.formatter -> t -> unit

--- a/lib/keeper/keeper_tool_progress.ml
+++ b/lib/keeper/keeper_tool_progress.ml
@@ -54,7 +54,7 @@ let effect_of_progress_class = function
 ;;
 
 let claim_context_tool_names : string list =
-  Tool_name.[ Masc Claim_next; Keeper Task_claim ] |> List.map Tool_name.to_string
+  [ Tool_name.(to_string (Masc Claim_next)); Keeper_tool_name.(to_string Task_claim) ]
 ;;
 
 let completion_tool_names : string list =
@@ -66,22 +66,26 @@ let completion_tool_names : string list =
      breaker). Without this, 4+ events/day were rejected as passive_only even
      though the LLM had decided no fit (sangsu/janitor/taskmaster on 2026-04-27
      00:17-00:58 UTC, idle_seconds 28-40h, claimable_count 44-46). *)
-  Tool_name.
-    [ Masc Deliver
-    ; Keeper Stay_silent
-    ; Keeper Task_done
-    ; Keeper Task_force_done
-    ; Keeper Task_force_release
-    ; Keeper Task_submit_for_verification
-    ]
-  |> List.map Tool_name.to_string
+  Tool_name.(to_string (Masc Deliver))
+  :: List.map
+       Keeper_tool_name.to_string
+       Keeper_tool_name.
+         [ Stay_silent
+         ; Task_done
+         ; Task_force_done
+         ; Task_force_release
+         ; Task_submit_for_verification
+         ]
 ;;
 
 let is_claim_tool_name name =
   let name = Keeper_tool_resolution.canonical_tool_name name in
-  match Tool_name.of_string name with
-  | Some (Keeper Task_claim) | Some (Masc Claim_next) -> true
-  | _ -> false
+  (match Keeper_tool_name.of_string name with
+   | Some Task_claim -> true
+   | _ -> false)
+  || (match Tool_name.of_string name with
+      | Some (Masc Claim_next) -> true
+      | _ -> false)
 ;;
 
 let is_claim_context_tool_name name =
@@ -106,8 +110,8 @@ let is_completion_tool_name name =
 
 let is_stay_silent_tool_name name =
   let name = Keeper_tool_resolution.canonical_tool_name name in
-  match Tool_name.of_string name with
-  | Some (Keeper Stay_silent) -> true
+  match Keeper_tool_name.of_string name with
+  | Some Stay_silent -> true
   | _ -> false
 ;;
 

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -44,8 +44,8 @@ let keeper_voice_tool_schemas =
     See #4961. *)
 let core_always_tools =
   List.map
-    Tool_name.to_string
-    Tool_name.[ Keeper Context_status; Keeper Stay_silent; Keeper Tool_search ]
+    Keeper_tool_name.to_string
+    Keeper_tool_name.[ Context_status; Stay_silent; Tool_search ]
   @ [ "extend_turns" ]
 ;;
 
@@ -71,25 +71,25 @@ let core_always_tools =
 let core_discovery_tools =
   core_always_tools
   @ List.map
-      Tool_name.to_string
-      Tool_name.
+      Keeper_tool_name.to_string
+      Keeper_tool_name.
         [ (* Workspace *)
-          Keeper Broadcast
-        ; Keeper Tasks_list
-        ; Keeper Task_claim
-        ; Keeper Task_done
-        ; Keeper Task_create
-        ; Keeper Memory_search
+          Broadcast
+        ; Tasks_list
+        ; Task_claim
+        ; Task_done
+        ; Task_create
+        ; Memory_search
         ; (* Board: core interaction *)
-          Keeper Board_get
-        ; Keeper Board_post
-        ; Keeper Board_comment
-        ; Keeper Board_vote
-        ; Keeper Board_list
-        ; Keeper Board_curation_read
-        ; Keeper Board_curation_submit
+          Board_get
+        ; Board_post
+        ; Board_comment
+        ; Board_vote
+        ; Board_list
+        ; Board_curation_read
+        ; Board_curation_submit
         ; (* Discovery fallback for meta/admin tools *)
-          Keeper Tools_list
+          Tools_list
         ]
   (* RFC-0064/RFC-016x: public capability names replace internal names
      in the LLM-facing discovery surface. *)
@@ -230,22 +230,26 @@ let is_main_worktree_boundary_exempt_with_input
     be misleading dead entries. *)
 let reconcile_safe_tools =
   List.map
-    Tool_name.to_string
-    Tool_name.
-      [ Keeper Board_post
-      ; Keeper Board_comment
-      ; Keeper Board_vote
-      ; Keeper Board_comment_vote
-      ; Keeper Board_curation_submit
-      ; Keeper Broadcast
-      ; Keeper Task_done
-      ; Masc Board_post
-      ; Masc Board_comment
-      ; Masc Board_vote
-      ; Masc Board_comment_vote
-      ; Masc Board_curation_submit
-      ; Masc Broadcast
+    Keeper_tool_name.to_string
+    Keeper_tool_name.
+      [ Board_post
+      ; Board_comment
+      ; Board_vote
+      ; Board_comment_vote
+      ; Board_curation_submit
+      ; Broadcast
+      ; Task_done
       ]
+  @ List.map
+      Tool_name.to_string
+      Tool_name.
+        [ Masc Board_post
+        ; Masc Board_comment
+        ; Masc Board_vote
+        ; Masc Board_comment_vote
+        ; Masc Board_curation_submit
+        ; Masc Broadcast
+        ]
 ;;
 
 let reconcile_safe_set : (string, unit) Hashtbl.t =
@@ -293,7 +297,7 @@ let injected_masc_tool_names () =
     the keeper tool registry — the canonical owner of keeper-internal tool
     metadata.  Consumed by [keeper_tool_policy.keeper_default_model_tools]. *)
 let keeper_tool_search_schema : Masc_domain.tool_schema =
-  { name = Tool_name.(to_string (Keeper Tool_search))
+  { name = Keeper_tool_name.to_string Keeper_tool_name.Tool_search
   ; description =
       "Search for tools by query describing what you need. Returns tool names, \
        descriptions, and usage guidance. Use when your current tools are insufficient \

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -102,7 +102,7 @@ let run_named
      would see no callable schema and emit misleading diagnostics. *)
   let require_tool_support =
     require_tool_support
-    || keeper_internal_tools_require_materialized_runtime_surface
+    || agent_internal_tools_require_materialized_runtime_surface
          ~keeper_name tools
   in
   (* Parameters that only fed the deleted multi-candidate machinery

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -693,7 +693,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
   in
   let source : Tool_registry.call_source =
     match keeper_entry with
-    | Some _ -> Keeper_internal
+    | Some _ -> Agent_internal
     | None -> External_mcp
   in
   (match keeper_entry with

--- a/lib/tool_catalog_surfaces/tool_catalog_surfaces.mli
+++ b/lib/tool_catalog_surfaces/tool_catalog_surfaces.mli
@@ -21,6 +21,7 @@
 val public_mcp_surface_tools : string list
 val system_internal_surface_tools : string list
 val workspace_role_tools : string list
+val execution_role_tools : string list
 
 (** {1 Surface variant} *)
 

--- a/lib/tool_dispatch.ml
+++ b/lib/tool_dispatch.ml
@@ -228,7 +228,7 @@ type module_tag =
   | Mod_compact
   | Mod_agent | Mod_task | Mod_state
   | Mod_control | Mod_agent_timeline | Mod_misc
-  | Mod_library | Mod_keeper
+  | Mod_library | Mod_external
   | Mod_inline
   | Mod_shard
 

--- a/test/deps/dune
+++ b/test/deps/dune
@@ -104,6 +104,9 @@
    (re_export masc_mcp.masc_exec_command_gate)
    (re_export masc_mcp.masc_exec_bash_parser)
    (re_export masc_workspace)
+   ;; Goal domain extracted to lib/goal/ (masc_goal). Re-export so test code
+   ;; using bare Goal_store.X / Goal_phase.X resolves after decoupling.
+   (re_export masc_goal)
    (re_export masc_types)
    (re_export mirage-crypto)
    (re_export mirage-crypto-rng)

--- a/test/stanzas/test_goal_phase_awaiting_verification_10411.inc
+++ b/test/stanzas/test_goal_phase_awaiting_verification_10411.inc
@@ -1,4 +1,4 @@
 (test
  (name test_goal_phase_awaiting_verification_10411)
  (modules test_goal_phase_awaiting_verification_10411)
- (libraries masc_mcp alcotest))
+ (libraries masc_mcp masc_goal alcotest))

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -599,7 +599,7 @@ let test_dashboard_planning_http_json_keeps_utf8_valid_after_truncation () =
   ignore (Lib.Workspace.init config ~agent_name:(Some "dashboard"));
   let hangul_ga = "\234\176\128" in
   let title = String.concat "" (List.init 40 (fun _ -> hangul_ga)) in
-  (match Lib.Goal_store.upsert_goal config ~title () with
+  (match Goal_store.upsert_goal config ~title () with
    | Ok _ -> ()
    | Error msg -> fail msg);
   let json = Lib.Server_dashboard_http.dashboard_planning_http_json ~config in

--- a/test/test_goal_phase_awaiting_verification_10411.ml
+++ b/test/test_goal_phase_awaiting_verification_10411.ml
@@ -28,7 +28,7 @@
 
 open Alcotest
 
-module GP = Masc_mcp.Goal_phase
+module GP = Goal_phase
 
 (* --- helper: short-hand caller for decide_transition ---- *)
 

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -2,7 +2,7 @@ module Types = Masc_domain
 
 module Mcp_eio = Masc_mcp.Mcp_server_eio
 module Config = Masc_mcp.Config
-module Goal_store = Masc_mcp.Goal_store
+module Goal_store = Goal_store
 
 type init_mode =
   | Fresh


### PR DESCRIPTION
## 목적

mega-library `masc_mcp`의 경계 디커플링 — Tool은 Keeper를 알 필요가 없고, 각 도메인(Goal 등)은 독립이어야 한다는 원칙을 코드로 강제한다. 두 개의 검증된 디커플링 단계를 담는다.

main은 #19797(keeper/tool 경계 hard-cut)이 red CI로 머지되며 컴파일 불가 상태로 남았고, 그 cut이 절반만 완료돼 있었다. 이 PR은 그 cut을 **올바른 방향(typed, 의존성 역전)** 으로 완성하고, 한 발 더 나아가 첫 도메인을 라이브러리로 분리한다.

> 빌드 수정 자체가 목적이 아니라, **올바른 경계 분리**가 목적이다. 경계를 제대로 나누면 관련 빌드 에러는 그 부산물로 해소된다.

## 변경 1 — Tool ⊥ Keeper (typed `Keeper_tool_name`)

#19797이 중앙 `Tool_name.Keeper`(keeper MCP tool 이름의 SSOT)를 **타입 대체 없이 삭제**해 keeper 이름이 bare string으로 흩어졌다(string 분류기 퇴행). 이를 바로잡는다:

- 신규 `lib/keeper/keeper_tool_name.ml(+.mli)` — 삭제된 enum을 keeper subsystem으로 **이동**. substrate는 opaque name만 라우팅하고, keeper가 자기 어휘를 타입으로 소유. 의존 방향 keeper → tool 단방향.
- keeper caller 마이그레이션(`keeper_tool_registry`/`keeper_tool_progress`/`keeper_agent_tool_surface`): `Tool_name.Keeper X` → `Keeper_tool_name.X`. Keeper/Masc 혼합 리스트와 `of_string` 매치를 네임스페이스별로 분리. **동일 MCP 이름 문자열 보존**.
- `tool_dispatch.ml`: `module_tag` `Mod_keeper` → 중립 `Mod_external`(.mli와 일치). composition root는 이미 `Mod_external → Keeper_tool_boundary.dispatch` 배선.
- 부수 정정: `agent_internal_tools_require_materialized_runtime_surface` rename 반영, `Tool_registry.call_source` `Keeper_internal` → `Agent_internal`, `tool_catalog_surfaces.mli`에 `execution_role_tools` 재노출 복원, `bin/main_eio.ml`에서 삭제된 `Tool_keeper` alias 제거.

검증: `dune build @check` 에러 30 → 22. lib/bin의 Tool/Keeper 경계 에러 0. `masc_mcp__Keeper_tool_name.cmo` 격리 빌드 EXIT=0.

## 변경 2 — Goal 도메인 추출 (`masc_goal` 라이브러리)

`lib/goal/`(goal_store/phase/verification/convergence/janitor)가 mega-lib `Workspace` facade에 의존하는 듯 보였으나, 실제론 facade가 **이미 별도 라이브러리 `masc_workspace`를 re-export**하는 착시였다. facade를 우회해 실제 lib로 직접 연결한다:

- goal 모듈의 `Workspace.X` → `Workspace_utils.X` / `Workspace_query.X`(masc_workspace).
- `lib/goal/dune` 신설 — 라이브러리 `masc_goal`, 중립 deps만(`masc_types`/`masc_core`/`masc_config`/`masc_log`/`masc_workspace`/`shared_audit`/`time_compat`/`fs_compat`/`yojson`/`eio`/`unix`). 컴파일러가 mega-lib 독립성을 강제.
- mega-lib(`lib/dune`) + test deps(`test/deps/dune` re_export)에 배선. 테스트의 옛 mega-lib qualifier(`Masc_mcp.Goal_store` 등) 제거.

검증: `masc_goal` 격리 빌드 EXIT=0 (green island). `dune build @check` 22 → 22 (Goal 추출 net-zero 에러 영향).

## 알려진 경계 누수 (후속)

`goal_janitor`가 `Workspace_query.get_tasks_safe`로 **Task 데이터를 읽음** = Goal↔Task 의미적 결합. janitor는 사실 어댑터(goal+task 조율)이므로 순수 Goal에서 분리할 다음 대상. 빌드 blocker는 아님.

## 남은 빌드 에러 (이 PR 범위 밖)

남은 22개는 전부 **Runtime ⊥ Keeper** 직교 경계(별개)다 — `per_provider_timeout_s`/`last_model_used`/`save_oas_checkpoint ~model`/`credentials_for_keeper`(model·timeout·credential이 keeper 레코드에 박혀있음) + PR-1 테스트 마이그레이션 잔여. Tool 작업으로 안 고쳐지며, 별도 PR(migrate 방향)로 분리.

## 검증

- `dune build @check --root .` — 에러 추이 30 → 22 (Tool/Keeper 경계 에러 0, Goal net-zero).
- 격리 cmo/lib 빌드: `masc_mcp__Keeper_tool_name.cmo` EXIT=0, `dune build lib/goal/` EXIT=0.
- CI `Build and Test`는 broken main에서 SKIP되므로 로컬 cmo/격리 빌드가 권위.

RFC-WAIVED: 구조적 경계 디커플링/리팩터(typed enum 이동 + 라이브러리 추출). credential/identity/sandbox/hooks/workflow subsystem 변경 없음 — keeper_tool_* 는 tool-boundary 어휘이며 credential 경로와 무관.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
