### PR TITLE
refactor(turn): carve pure Turn FSM into masc_turn library (Keeper→Turn)

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -572,6 +572,8 @@
    masc_workspace
    ;; Goal domain (extracted sub-library — pure goal logic, decoupled from mega-lib)
    masc_goal
+   ;; Pure Turn FSM (extracted sub-library — states + transition matrix, Keeper-free)
+   masc_turn
    ;; Environment configuration (extracted sub-library)
    masc_mcp.config
    masc_mcp.ide

--- a/lib/keeper/keeper_turn_fsm.ml
+++ b/lib/keeper/keeper_turn_fsm.ml
@@ -1,309 +1,20 @@
-type cancel_reason =
-  | Cancelled_supervisor_stop
-  | Cancelled_phase_gate_close
-  | Cancelled_provider_timeout
-  | Cancelled_fleet_shutdown
-  | Cancelled_input_required
+(* Keeper-side shim over the pure Turn FSM ([Turn_fsm], library masc_turn).
 
-type failure_reason =
-  | Failure_runtime_unavailable of {
-      base : string;
-      resolved : string option;
-    }
-  | Failure_no_tool_capable_provider of {
-      runtime_id : string;
-      detail : string;
-    }
-  | Failure_provider_error of { kind : string; detail : string }
-  | Failure_tool_contract_violation of { reason_code : string }
-  | Failure_receipt_lost of {
-      primary_error : string;
-      fallback_path : string option;
-    }
-  | Failure_turn_livelock_blocked of { reason : string }
-  | Failure_runtime_error of string
-  | Failure_unexpected_exception of {
-      exn : string;
-      backtrace : string option;
-    }
+   The pure state machine — states, reasons, the [classify_transition] matrix,
+   labels, TLA symbols — lives in [Turn_fsm] (lib/turn_fsm/), which has zero
+   Keeper_* dependencies. This module [include]s it and adds the keeper-coupled
+   tail:
+     - [guard_transition] / [observe_phase_dwell] / [emit_transition]: telemetry
+       / audit / metrics emission (Log.Keeper, Keeper_transition_audit,
+       Prometheus + Keeper_metrics, Keeper_fsm_guard_runtime).
+     - [require_active_state]: identity guard whose [@@fsm_guard] ppx_tla
+       expansion injects [Keeper_fsm_guard_runtime].
 
-type _ turn_state =
-  | Idle : [`Idle] turn_state [@tla.idle]
-  | Phase_gating : [`Phase_gating] turn_state [@tla.active]
-  | Runtime_routing : [`Runtime_routing] turn_state [@tla.active]
-  | Awaiting_provider : [`Awaiting_provider] turn_state [@tla.active]
-  | Streaming : [`Streaming] turn_state [@tla.active]
-  | Awaiting_tool_result : [`Awaiting_tool_result] turn_state [@tla.symbol "awaiting_tool"] [@tla.active]
-  | Completing : [`Completing] turn_state [@tla.active]
-  | Done : [`Done] turn_state [@tla.terminal]
-  | Failed : failure_reason -> [`Failed] turn_state [@tla.terminal]
-  | Cancelled : cancel_reason -> [`Cancelled] turn_state [@tla.terminal]
+   All existing [Keeper_turn_fsm.X] call sites resolve unchanged: pure surface
+   via the [include], glue via the local definitions below. Dependency
+   direction is Keeper -> Turn. *)
 
-module Tla_symbol = struct
-  type t =
-    | Idle [@tla.idle]
-    | Phase_gating [@tla.active]
-    | Runtime_routing [@tla.active]
-    | Awaiting_provider [@tla.active]
-    | Streaming [@tla.active]
-    | Awaiting_tool_result [@tla.symbol "awaiting_tool"] [@tla.active]
-    | Completing [@tla.active]
-    | Done [@tla.terminal]
-    | Failed of failure_reason [@tla.terminal]
-    | Cancelled of cancel_reason [@tla.terminal]
-  [@@deriving tla]
-end
-
-let tla_symbol_variant : type a. a turn_state -> Tla_symbol.t = function
-  | Idle -> Tla_symbol.Idle
-  | Phase_gating -> Tla_symbol.Phase_gating
-  | Runtime_routing -> Tla_symbol.Runtime_routing
-  | Awaiting_provider -> Tla_symbol.Awaiting_provider
-  | Streaming -> Tla_symbol.Streaming
-  | Awaiting_tool_result -> Tla_symbol.Awaiting_tool_result
-  | Completing -> Tla_symbol.Completing
-  | Done -> Tla_symbol.Done
-  | Failed reason -> Tla_symbol.Failed reason
-  | Cancelled reason -> Tla_symbol.Cancelled reason
-
-let to_tla_symbol state = Tla_symbol.to_tla_symbol (tla_symbol_variant state)
-
-let all_symbols = Tla_symbol.all_symbols
-let active_symbols = Tla_symbol.active_symbols
-let terminal_symbols = Tla_symbol.terminal_symbols
-let idle_symbols = Tla_symbol.idle_symbols
-
-let is_active state = Tla_symbol.is_active (tla_symbol_variant state)
-let is_terminal state = Tla_symbol.is_terminal (tla_symbol_variant state)
-let is_idle state = Tla_symbol.is_idle (tla_symbol_variant state)
-
-let cancel_reason_label = function
-  | Cancelled_supervisor_stop -> "supervisor_stop"
-  | Cancelled_phase_gate_close -> "phase_gate_close"
-  | Cancelled_provider_timeout -> "provider_timeout"
-  | Cancelled_fleet_shutdown -> "fleet_shutdown"
-  | Cancelled_input_required -> "input_required"
-
-let failure_reason_label = function
-  | Failure_runtime_unavailable _ -> "runtime_unavailable"
-  | Failure_no_tool_capable_provider _ -> "no_tool_capable_provider"
-  | Failure_provider_error _ -> "provider_error"
-  | Failure_tool_contract_violation _ -> "tool_contract_violation"
-  | Failure_receipt_lost _ -> "receipt_lost"
-  | Failure_turn_livelock_blocked _ -> "turn_livelock_blocked"
-  | Failure_runtime_error _ -> "runtime_error"
-  | Failure_unexpected_exception _ -> "unexpected_exception"
-
-let turn_state_label : type a. a turn_state -> string = function
-  | Failed reason ->
-      to_tla_symbol (Failed reason) ^ ":" ^ failure_reason_label reason
-  | Cancelled reason ->
-      to_tla_symbol (Cancelled reason) ^ ":" ^ cancel_reason_label reason
-  | state -> to_tla_symbol state
-
-let pp_cancel_reason fmt r =
-  Format.pp_print_string fmt (cancel_reason_label r)
-
-let pp_failure_reason fmt = function
-  | Failure_runtime_unavailable { base; resolved } ->
-      Format.fprintf fmt "runtime_unavailable(base=%s,resolved=%s)"
-        base
-        (Option.value resolved ~default:"-")
-  | Failure_no_tool_capable_provider { runtime_id; detail } ->
-      Format.fprintf fmt "no_tool_capable_provider(runtime=%s,detail=%s)"
-        runtime_id detail
-  | Failure_provider_error { kind; detail } ->
-      Format.fprintf fmt "provider_error(kind=%s,detail=%s)" kind detail
-  | Failure_tool_contract_violation { reason_code } ->
-      Format.fprintf fmt "tool_contract_violation(%s)" reason_code
-  | Failure_receipt_lost { primary_error; fallback_path } ->
-      Format.fprintf fmt "receipt_lost(err=%s,fallback=%s)"
-        primary_error
-        (Option.value fallback_path ~default:"-")
-  | Failure_turn_livelock_blocked { reason } ->
-      Format.fprintf fmt "turn_livelock_blocked(%s)" reason
-  | Failure_runtime_error msg ->
-      Format.fprintf fmt "runtime_error(%s)" msg
-  | Failure_unexpected_exception { exn; _ } ->
-      Format.fprintf fmt "unexpected_exception(%s)" exn
-
-let pp_turn_state fmt (s : _ turn_state) =
-  Format.pp_print_string fmt (turn_state_label s)
-
-type transition_action =
-  | StartTurn
-  | PhaseGateSkip
-  | PhaseGateOk
-  | RuntimeRouted
-  | RuntimeUnavailable
-  | ProviderResponded
-  | ProviderTimeout
-  | StreamYieldsTool
-  | ToolReturned
-  | StreamComplete
-  | ContractOk
-  | ContractViolation
-  | ReceiptLost
-  | LivelockBlocked
-  | NoToolCapableProvider
-  | ProviderError
-  | GenericFail
-  | SupervisorRequestsStop
-  | HonorStopSignal
-  | TerminalStutter
-
-let transition_action_label = function
-  | StartTurn -> "StartTurn"
-  | PhaseGateSkip -> "PhaseGateSkip"
-  | PhaseGateOk -> "PhaseGateOk"
-  | RuntimeRouted -> "RuntimeRouted"
-  | RuntimeUnavailable -> "RuntimeUnavailable"
-  | ProviderResponded -> "ProviderResponded"
-  | ProviderTimeout -> "ProviderTimeout"
-  | StreamYieldsTool -> "StreamYieldsTool"
-  | ToolReturned -> "ToolReturned"
-  | StreamComplete -> "StreamComplete"
-  | ContractOk -> "ContractOk"
-  | ContractViolation -> "ContractViolation"
-  | ReceiptLost -> "ReceiptLost"
-  | LivelockBlocked -> "LivelockBlocked"
-  | NoToolCapableProvider -> "NoToolCapableProvider"
-  | ProviderError -> "ProviderError"
-  | GenericFail -> "GenericFail"
-  | SupervisorRequestsStop -> "SupervisorRequestsStop"
-  | HonorStopSignal -> "HonorStopSignal"
-  | TerminalStutter -> "TerminalStutter"
-
-type transition_context = {
-  stop_signaled_before : bool;
-  stop_signaled_after : bool;
-}
-
-let default_transition_context =
-  { stop_signaled_before = false; stop_signaled_after = false }
-
-type transition_violation = {
-  from_state : string;
-  to_state : string;
-  reason : string;
-}
-
-let same_tla_state a b =
-  String.equal (to_tla_symbol a) (to_tla_symbol b)
-
-let same_observable_state a b =
-  String.equal (turn_state_label a) (turn_state_label b)
-
-
-type any_state = Any : _ turn_state -> any_state
-
-let any_state_label (Any s) = turn_state_label s
-let pp_any_state fmt (Any s) = pp_turn_state fmt s
-
-let classify_transition ?ctx ~(from_state: _ turn_state) ~(to_state: _ turn_state) () =
-  let stop_signaled_before =
-    match ctx with
-    | None -> default_transition_context.stop_signaled_before
-    | Some ctx -> ctx.stop_signaled_before
-  in
-  let stop_raised =
-    match ctx with
-    | None -> false
-    | Some ctx -> (not ctx.stop_signaled_before) && ctx.stop_signaled_after
-  in
-  let stop_unchanged =
-    match ctx with
-    | None -> true
-    | Some ctx -> Bool.equal ctx.stop_signaled_before ctx.stop_signaled_after
-  in
-  let honor_stop_signal_allowed =
-    match ctx with
-    | None -> true
-    | Some ctx -> ctx.stop_signaled_before
-  in
-  let supervisor_requests_stop_allowed =
-    match ctx with
-    | None -> true
-    | Some _ -> stop_raised
-  in
-  match Any from_state, Any to_state with
-  | Any Idle, Any Phase_gating when not stop_signaled_before ->
-      Some StartTurn
-  | Any Phase_gating, Any Done when not stop_signaled_before ->
-      Some PhaseGateSkip
-  | Any Phase_gating, Any Runtime_routing when not stop_signaled_before ->
-      Some PhaseGateOk
-  | Any Runtime_routing, Any Awaiting_provider when not stop_signaled_before ->
-      Some RuntimeRouted
-  | Any Runtime_routing, Any (Failed (Failure_runtime_unavailable _))
-    when not stop_signaled_before ->
-      Some RuntimeUnavailable
-  | Any Runtime_routing, Any (Failed (Failure_turn_livelock_blocked _))
-    when not stop_signaled_before ->
-      Some LivelockBlocked
-  | Any Runtime_routing, Any (Failed (Failure_no_tool_capable_provider _))
-    when not stop_signaled_before ->
-      Some NoToolCapableProvider
-  | Any Runtime_routing, Any (Failed (Failure_provider_error _))
-    when not stop_signaled_before ->
-      Some ProviderError
-  | Any Awaiting_provider, Any Streaming when not stop_signaled_before ->
-      Some ProviderResponded
-  | Any Awaiting_provider, Any (Cancelled Cancelled_provider_timeout)
-    when not stop_signaled_before ->
-      Some ProviderTimeout
-  | Any Streaming, Any Awaiting_tool_result when not stop_signaled_before ->
-      Some StreamYieldsTool
-  | Any Awaiting_tool_result, Any Streaming when not stop_signaled_before ->
-      Some ToolReturned
-  | Any Streaming, Any Completing when not stop_signaled_before ->
-      Some StreamComplete
-  | Any Streaming, Any (Failed (Failure_tool_contract_violation _))
-    when not stop_signaled_before ->
-      Some ContractViolation
-  | Any Streaming, Any (Failed (Failure_receipt_lost _))
-    when not stop_signaled_before ->
-      Some ReceiptLost
-  | Any Streaming, Any (Failed (Failure_provider_error _))
-    when not stop_signaled_before ->
-      Some ProviderError
-  | Any Streaming, Any (Cancelled Cancelled_provider_timeout)
-    when not stop_signaled_before ->
-      Some ProviderTimeout
-  | Any Completing, Any Done when not stop_signaled_before ->
-      Some ContractOk
-  | Any Completing, Any (Failed (Failure_tool_contract_violation _))
-    when not stop_signaled_before ->
-      Some ContractViolation
-  | Any Completing, Any (Failed (Failure_receipt_lost _))
-    when not stop_signaled_before ->
-      Some ReceiptLost
-  | _, Any (Failed _) when is_active from_state -> Some GenericFail
-  | _, Any (Cancelled _) when is_active from_state && honor_stop_signal_allowed ->
-      Some HonorStopSignal
-  | _, _
-    when supervisor_requests_stop_allowed
-         && is_active from_state
-         && same_tla_state from_state to_state ->
-      Some SupervisorRequestsStop
-  | _, _
-    when is_terminal from_state
-         && is_terminal to_state
-         && stop_unchanged
-         && same_observable_state from_state to_state ->
-      Some TerminalStutter
-  | _ -> None
-
-let assert_transition_allowed ?ctx ~(from_state: _ turn_state) ~(to_state: _ turn_state) () =
-  match classify_transition ?ctx ~from_state ~to_state () with
-  | Some action -> Ok action
-  | None ->
-      Error
-        {
-          from_state = to_tla_symbol from_state;
-          to_state = to_tla_symbol to_state;
-          reason = "not_in_keeper_turn_fsm_next";
-        }
+include Turn_fsm
 
 let guard_transition ?ctx ~keeper_name ~turn_id ~from_state ~to_state () =
   match assert_transition_allowed ?ctx ~from_state ~to_state () with
@@ -403,7 +114,7 @@ let emit_transition ?ctx ~keeper_name ~turn_id ?prev state =
         Log.Keeper.warn ~keeper_name ~turn_id
           "[fsm:transition:unclassified] %s -> %s — classify_transition \
            has no arm for this (from, to) pair; add one in \
-           lib/keeper/keeper_turn_fsm.ml::classify_transition so the \
+           lib/turn_fsm/turn_fsm.ml::classify_transition so the \
            audit trail captures the action"
           prev_label state_label;
         "unclassified"
@@ -443,7 +154,9 @@ let emit_transition ?ctx ~keeper_name ~turn_id ?prev state =
    payload is parsed by [ppx_tla] and injected as a runtime [assert] at
    the function body entry. The invariant — turn states that have
    already terminated must not re-enter execution paths — was previously
-   only guarded by reviewer-eye inspection of call sites. *)
+   only guarded by reviewer-eye inspection of call sites. Stays here (not in
+   the pure [Turn_fsm] lib) because the ppx expansion references
+   [Keeper_fsm_guard_runtime]. *)
 
 let require_active_state : type a. a turn_state -> (unit, Masc_domain.masc_error) result = fun s ->
   match s with

--- a/lib/keeper/keeper_turn_fsm.mli
+++ b/lib/keeper/keeper_turn_fsm.mli
@@ -1,172 +1,19 @@
-(** Typed FSM vocabulary for keeper turn lifecycle.
+(** Keeper-side shim over the pure Turn FSM ([Turn_fsm], library masc_turn).
 
-    Step 4a of the bloodflow restoration plan introduces the
-    state / failure / cancel-reason ADTs only.  The transition
-    function with telemetry emission is left to a follow-up
-    stack so the type surface lands additively first.
+    Re-exports the pure FSM surface (states, reasons, [classify_transition],
+    labels, TLA symbols) via [include module type of Turn_fsm], and adds the
+    keeper-coupled tail: [require_active_state] (its [@@fsm_guard] expansion
+    references [Keeper_fsm_guard_runtime]) and [emit_transition] (telemetry /
+    audit / metrics). Dependency direction is Keeper -> Turn.
 
-    Cross-reference: [docs/keeper-turn-lifecycle.md] (Step 8 diagram). *)
+    Formal contract for the pure core: [specs/keeper-turn-fsm/KeeperTurnFSM.tla]
+    (verified by [test_keeper_turn_fsm_tla_parity]). *)
 
-type cancel_reason =
-  | Cancelled_supervisor_stop
-      (** Operator/supervisor requested keeper shutdown. *)
-  | Cancelled_phase_gate_close
-      (** Phase transition closed an in-flight turn. *)
-  | Cancelled_provider_timeout
-      (** Underlying provider (CLI subprocess or HTTP) timed out
-          past the cooperative-cancel deadline. *)
-  | Cancelled_fleet_shutdown
-      (** Process is exiting; no more turns will be dispatched. *)
-  | Cancelled_input_required
-      (** Agent paused to request human input (InputRequired). *)
-
-type failure_reason =
-  | Failure_runtime_unavailable of {
-      base : string;
-      resolved : string option;
-    }
-  | Failure_no_tool_capable_provider of {
-      runtime_id : string;
-      detail : string;
-    }
-  | Failure_provider_error of { kind : string; detail : string }
-  | Failure_tool_contract_violation of { reason_code : string }
-  | Failure_receipt_lost of {
-      primary_error : string;
-      fallback_path : string option;
-    }
-  | Failure_turn_livelock_blocked of { reason : string }
-      (** Pre-dispatch livelock guard ([Keeper_turn_livelock])
-          rejected this turn because the keeper is stuck in a
-          loop on the same task.  Distinct from [runtime_error]
-          so PromQL can chart livelock incidence on its own. *)
-  | Failure_runtime_error of string
-  | Failure_unexpected_exception of {
-      exn : string;
-      backtrace : string option;
-    }
-
-(** Turn FSM states.  Mirrors the lanes in
-    [docs/keeper-turn-lifecycle.md]; the runtime [run_keeper_cycle]
-    is currently implicit across multiple files and Step 4b will
-    introduce explicit transitions. *)
-type _ turn_state =
-  | Idle : [`Idle] turn_state [@tla.idle]
-  | Phase_gating : [`Phase_gating] turn_state [@tla.active]
-  | Runtime_routing : [`Runtime_routing] turn_state [@tla.active]
-  | Awaiting_provider : [`Awaiting_provider] turn_state [@tla.active]
-  | Streaming : [`Streaming] turn_state [@tla.active]
-  | Awaiting_tool_result : [`Awaiting_tool_result] turn_state [@tla.symbol "awaiting_tool"] [@tla.active]
-  | Completing : [`Completing] turn_state [@tla.active]
-  | Done : [`Done] turn_state [@tla.terminal]
-  | Failed : failure_reason -> [`Failed] turn_state [@tla.terminal]
-  | Cancelled : cancel_reason -> [`Cancelled] turn_state [@tla.terminal]
-
-(** TLA+ symbol mapping backed by a private [ppx_tla]-derived symbol enum.
-
-    [to_tla_symbol] / [all_symbols] match [TurnStateSet]. The public
-    [active_symbols] / [terminal_symbols] / [is_active] / [is_terminal]
-    wrappers match [ActiveStateSet] and [TerminalStateSet] in
-    [specs/keeper-turn-fsm/KeeperTurnFSM.tla] (verified by
-    [test_keeper_turn_fsm_tla_parity]).
-
-    [@tla.symbol "awaiting_tool"] on [Awaiting_tool_result] covers the
-    OCaml-vs-TLA+ naming difference without renaming either side. *)
-
-val cancel_reason_label : cancel_reason -> string
-val failure_reason_label : failure_reason -> string
-val to_tla_symbol : _ turn_state -> string
-val turn_state_label : _ turn_state -> string
-
-val pp_cancel_reason : Format.formatter -> cancel_reason -> unit
-val pp_failure_reason : Format.formatter -> failure_reason -> unit
-val pp_turn_state : Format.formatter -> _ turn_state -> unit
-
-type transition_action =
-  | StartTurn
-  | PhaseGateSkip
-  | PhaseGateOk
-  | RuntimeRouted
-  | RuntimeUnavailable
-  | ProviderResponded
-  | ProviderTimeout
-  | StreamYieldsTool
-  | ToolReturned
-  | StreamComplete
-  | ContractOk
-  | ContractViolation
-  | ReceiptLost
-  | LivelockBlocked
-  | NoToolCapableProvider
-  | ProviderError
-  | GenericFail
-  | SupervisorRequestsStop
-  | HonorStopSignal
-  | TerminalStutter
-(** Runtime image of [KeeperTurnFSM.tla] [Next] actions.
-
-    [GenericFail] is the OCaml-side structured-failure extension for
-    active-state failures whose carrier is more specific than the compact
-    TLA projection. *)
-
-val transition_action_label : transition_action -> string
-
-type transition_context = {
-  stop_signaled_before : bool;
-  stop_signaled_after : bool;
-}
-(** Orthogonal stop-signal state for a transition.
-
-    Mirrors the TLA+ variable [stop_signaled] in
-    [specs/keeper-turn-fsm/KeeperTurnFSM.tla] (line 59).  Forward
-    transitions require [stop_signaled_before = false];
-    [SupervisorRequestsStop] requires [(not before) && after]. *)
-
-val default_transition_context : transition_context
-(** Both fields [false] — used when stop-signal tracking is not
-    available at the call site. *)
-
-type transition_violation = {
-  from_state : string;
-  to_state : string;
-  reason : string;
-}
-
-val classify_transition :
-  ?ctx:transition_context ->
-  from_state:_ turn_state ->
-  to_state:_ turn_state ->
-  unit ->
-  transition_action option
-(** Return the TLA+ action represented by an OCaml state edge, if the
-    edge is allowed by the keeper-turn FSM contract.
-
-    When [?ctx] is provided, forward transitions guard on
-    [stop_signaled_before = false] (matching the TLA+ [~stop_signaled]
-    precondition on every forward action) and [SupervisorRequestsStop]
-    requires [stop_signaled] to transition from [false] to [true]
-    (matching the TLA+ [~stop_signaled /\ stop_signaled'] guard).
-
-    When [?ctx] is omitted, the behavior is backward-compatible: forward
-    transitions have no stop-signal guard, and [SupervisorRequestsStop]
-    falls back to the same-state heuristic. *)
-
-val assert_transition_allowed :
-  ?ctx:transition_context ->
-  from_state:_ turn_state ->
-  to_state:_ turn_state ->
-  unit ->
-  (transition_action, transition_violation) result
+include module type of Turn_fsm
 
 val require_active_state : _ turn_state -> (unit, Masc_domain.masc_error) result
 (** Identity on [s]; runtime-asserts that [s] is not a terminal state
-    ([Done], [Failed _], [Cancelled _]).
-
-    Cycle 12 / Tier I3 smoke test for the [@@fsm_guard "..."] PPX:
-    this is the first real-module use that the rewriter operates on.
-    The assert lands in the function body via [ppx_tla] so the runtime
-    cost is one match per call. Adopt at sites that enter execution
-    paths assuming the turn is still in flight. *)
+    ([Done], [Failed _], [Cancelled _]) via the [@@fsm_guard] PPX. *)
 
 val emit_transition :
   ?ctx:transition_context ->
@@ -175,32 +22,7 @@ val emit_transition :
   ?prev:_ turn_state ->
   _ turn_state ->
   unit
-(** Emit a structured FSM transition log line.
-
-    Step 4b kicks off the call-site adoption stack: this is an
-    observe-only secondary emit alongside the existing receipt path.  The
-    runtime branch shape is unchanged; the transition is both logged and
-    appended to [Keeper_transition_audit] as a turn-FSM WAL row via the
-    [turn_id] correlator wired in Step 0a (#11154 / #11156 / #11159), so an
-    operator can see the state the runtime *intended* without waiting for the
-    final receipt JSON.
-
-    The line format is
+(** Emit a structured FSM transition log line (+ [Keeper_transition_audit] WAL
+    row + Prometheus counters). The line format is
     [\[fsm:transition\] <prev> -> <state> action=<action> stop_before=.. stop_after=..];
-    a missing [?prev] renders as ["-"].  Stop-signal fields are
-    emitted only when [?ctx] is provided.  Stable for operator
-    regex parsing and pinned by the [test_keeper_turn_fsm_emit]
-    sentinel so a future signature drift fails the build. *)
-
-type any_state = Any : _ turn_state -> any_state
-val any_state_label : any_state -> string
-val pp_any_state : Format.formatter -> any_state -> unit
-
-val all_symbols : string list
-val active_symbols : string list
-val terminal_symbols : string list
-val idle_symbols : string list
-
-val is_active : _ turn_state -> bool
-val is_terminal : _ turn_state -> bool
-val is_idle : _ turn_state -> bool
+    a missing [?prev] renders as ["-"]. Pinned by [test_keeper_turn_fsm_emit]. *)

--- a/lib/turn_fsm/dune
+++ b/lib/turn_fsm/dune
@@ -1,0 +1,13 @@
+(include_subdirs no)
+
+;; Pure Turn FSM library — the agent turn-cycle state machine carved out of
+;; lib/keeper/keeper_turn_fsm.ml. Neutral: depends only on masc_types
+;; (Masc_domain) + ppx_tla; ZERO Keeper_* deps. Keeper depends on this lib,
+;; never the reverse. (wrapped false) keeps the bare `Turn_fsm` module name so
+;; the keeper-side shim can `include Turn_fsm`.
+(library
+ (name masc_turn)
+ (public_name masc_mcp.masc_turn)
+ (wrapped false)
+ (preprocess
+  (pps ppx_tla)))

--- a/lib/turn_fsm/turn_fsm.ml
+++ b/lib/turn_fsm/turn_fsm.ml
@@ -1,0 +1,328 @@
+(* Pure Turn FSM — the agent turn-cycle state machine, independent of Keeper.
+
+   Carved out of lib/keeper/keeper_turn_fsm.ml so the FSM (states + transition
+   matrix) is a neutral library that Keeper *uses*, not a module fused into the
+   keeper. The keeper-side glue (telemetry/audit/metrics emission) stays in
+   lib/keeper/keeper_turn_fsm.ml, which `include`s this module + supplies an
+   [emit_transition] over it.
+
+   Dependency direction: Keeper -> Turn, never the reverse. This module has zero
+   Keeper_* references (deps: Masc_domain from masc_types, ppx_tla, stdlib).
+
+   Formal contract: specs/keeper-turn-fsm/KeeperTurnFSM.tla. The [@tla.*] /
+   [@@deriving tla] / [@@fsm_guard] annotations bind each state and the
+   transition matrix to that spec; test_keeper_turn_fsm_tla_parity verifies
+   parity, so this library can be tlc-checked independently of the driver. *)
+
+type cancel_reason =
+  | Cancelled_supervisor_stop
+  | Cancelled_phase_gate_close
+  | Cancelled_provider_timeout
+  | Cancelled_fleet_shutdown
+  | Cancelled_input_required
+
+type failure_reason =
+  | Failure_runtime_unavailable of {
+      base : string;
+      resolved : string option;
+    }
+  | Failure_no_tool_capable_provider of {
+      runtime_id : string;
+      detail : string;
+    }
+  | Failure_provider_error of { kind : string; detail : string }
+  | Failure_tool_contract_violation of { reason_code : string }
+  | Failure_receipt_lost of {
+      primary_error : string;
+      fallback_path : string option;
+    }
+  | Failure_turn_livelock_blocked of { reason : string }
+  | Failure_runtime_error of string
+  | Failure_unexpected_exception of {
+      exn : string;
+      backtrace : string option;
+    }
+
+type _ turn_state =
+  | Idle : [`Idle] turn_state [@tla.idle]
+  | Phase_gating : [`Phase_gating] turn_state [@tla.active]
+  | Runtime_routing : [`Runtime_routing] turn_state [@tla.active]
+  | Awaiting_provider : [`Awaiting_provider] turn_state [@tla.active]
+  | Streaming : [`Streaming] turn_state [@tla.active]
+  | Awaiting_tool_result : [`Awaiting_tool_result] turn_state [@tla.symbol "awaiting_tool"] [@tla.active]
+  | Completing : [`Completing] turn_state [@tla.active]
+  | Done : [`Done] turn_state [@tla.terminal]
+  | Failed : failure_reason -> [`Failed] turn_state [@tla.terminal]
+  | Cancelled : cancel_reason -> [`Cancelled] turn_state [@tla.terminal]
+
+module Tla_symbol = struct
+  type t =
+    | Idle [@tla.idle]
+    | Phase_gating [@tla.active]
+    | Runtime_routing [@tla.active]
+    | Awaiting_provider [@tla.active]
+    | Streaming [@tla.active]
+    | Awaiting_tool_result [@tla.symbol "awaiting_tool"] [@tla.active]
+    | Completing [@tla.active]
+    | Done [@tla.terminal]
+    | Failed of failure_reason [@tla.terminal]
+    | Cancelled of cancel_reason [@tla.terminal]
+  [@@deriving tla]
+end
+
+let tla_symbol_variant : type a. a turn_state -> Tla_symbol.t = function
+  | Idle -> Tla_symbol.Idle
+  | Phase_gating -> Tla_symbol.Phase_gating
+  | Runtime_routing -> Tla_symbol.Runtime_routing
+  | Awaiting_provider -> Tla_symbol.Awaiting_provider
+  | Streaming -> Tla_symbol.Streaming
+  | Awaiting_tool_result -> Tla_symbol.Awaiting_tool_result
+  | Completing -> Tla_symbol.Completing
+  | Done -> Tla_symbol.Done
+  | Failed reason -> Tla_symbol.Failed reason
+  | Cancelled reason -> Tla_symbol.Cancelled reason
+
+let to_tla_symbol state = Tla_symbol.to_tla_symbol (tla_symbol_variant state)
+
+let all_symbols = Tla_symbol.all_symbols
+let active_symbols = Tla_symbol.active_symbols
+let terminal_symbols = Tla_symbol.terminal_symbols
+let idle_symbols = Tla_symbol.idle_symbols
+
+let is_active state = Tla_symbol.is_active (tla_symbol_variant state)
+let is_terminal state = Tla_symbol.is_terminal (tla_symbol_variant state)
+let is_idle state = Tla_symbol.is_idle (tla_symbol_variant state)
+
+let cancel_reason_label = function
+  | Cancelled_supervisor_stop -> "supervisor_stop"
+  | Cancelled_phase_gate_close -> "phase_gate_close"
+  | Cancelled_provider_timeout -> "provider_timeout"
+  | Cancelled_fleet_shutdown -> "fleet_shutdown"
+  | Cancelled_input_required -> "input_required"
+
+let failure_reason_label = function
+  | Failure_runtime_unavailable _ -> "runtime_unavailable"
+  | Failure_no_tool_capable_provider _ -> "no_tool_capable_provider"
+  | Failure_provider_error _ -> "provider_error"
+  | Failure_tool_contract_violation _ -> "tool_contract_violation"
+  | Failure_receipt_lost _ -> "receipt_lost"
+  | Failure_turn_livelock_blocked _ -> "turn_livelock_blocked"
+  | Failure_runtime_error _ -> "runtime_error"
+  | Failure_unexpected_exception _ -> "unexpected_exception"
+
+let turn_state_label : type a. a turn_state -> string = function
+  | Failed reason ->
+      to_tla_symbol (Failed reason) ^ ":" ^ failure_reason_label reason
+  | Cancelled reason ->
+      to_tla_symbol (Cancelled reason) ^ ":" ^ cancel_reason_label reason
+  | state -> to_tla_symbol state
+
+let pp_cancel_reason fmt r =
+  Format.pp_print_string fmt (cancel_reason_label r)
+
+let pp_failure_reason fmt = function
+  | Failure_runtime_unavailable { base; resolved } ->
+      Format.fprintf fmt "runtime_unavailable(base=%s,resolved=%s)"
+        base
+        (Option.value resolved ~default:"-")
+  | Failure_no_tool_capable_provider { runtime_id; detail } ->
+      Format.fprintf fmt "no_tool_capable_provider(runtime=%s,detail=%s)"
+        runtime_id detail
+  | Failure_provider_error { kind; detail } ->
+      Format.fprintf fmt "provider_error(kind=%s,detail=%s)" kind detail
+  | Failure_tool_contract_violation { reason_code } ->
+      Format.fprintf fmt "tool_contract_violation(%s)" reason_code
+  | Failure_receipt_lost { primary_error; fallback_path } ->
+      Format.fprintf fmt "receipt_lost(err=%s,fallback=%s)"
+        primary_error
+        (Option.value fallback_path ~default:"-")
+  | Failure_turn_livelock_blocked { reason } ->
+      Format.fprintf fmt "turn_livelock_blocked(%s)" reason
+  | Failure_runtime_error msg ->
+      Format.fprintf fmt "runtime_error(%s)" msg
+  | Failure_unexpected_exception { exn; _ } ->
+      Format.fprintf fmt "unexpected_exception(%s)" exn
+
+let pp_turn_state fmt (s : _ turn_state) =
+  Format.pp_print_string fmt (turn_state_label s)
+
+type transition_action =
+  | StartTurn
+  | PhaseGateSkip
+  | PhaseGateOk
+  | RuntimeRouted
+  | RuntimeUnavailable
+  | ProviderResponded
+  | ProviderTimeout
+  | StreamYieldsTool
+  | ToolReturned
+  | StreamComplete
+  | ContractOk
+  | ContractViolation
+  | ReceiptLost
+  | LivelockBlocked
+  | NoToolCapableProvider
+  | ProviderError
+  | GenericFail
+  | SupervisorRequestsStop
+  | HonorStopSignal
+  | TerminalStutter
+
+let transition_action_label = function
+  | StartTurn -> "StartTurn"
+  | PhaseGateSkip -> "PhaseGateSkip"
+  | PhaseGateOk -> "PhaseGateOk"
+  | RuntimeRouted -> "RuntimeRouted"
+  | RuntimeUnavailable -> "RuntimeUnavailable"
+  | ProviderResponded -> "ProviderResponded"
+  | ProviderTimeout -> "ProviderTimeout"
+  | StreamYieldsTool -> "StreamYieldsTool"
+  | ToolReturned -> "ToolReturned"
+  | StreamComplete -> "StreamComplete"
+  | ContractOk -> "ContractOk"
+  | ContractViolation -> "ContractViolation"
+  | ReceiptLost -> "ReceiptLost"
+  | LivelockBlocked -> "LivelockBlocked"
+  | NoToolCapableProvider -> "NoToolCapableProvider"
+  | ProviderError -> "ProviderError"
+  | GenericFail -> "GenericFail"
+  | SupervisorRequestsStop -> "SupervisorRequestsStop"
+  | HonorStopSignal -> "HonorStopSignal"
+  | TerminalStutter -> "TerminalStutter"
+
+type transition_context = {
+  stop_signaled_before : bool;
+  stop_signaled_after : bool;
+}
+
+let default_transition_context =
+  { stop_signaled_before = false; stop_signaled_after = false }
+
+type transition_violation = {
+  from_state : string;
+  to_state : string;
+  reason : string;
+}
+
+let same_tla_state a b =
+  String.equal (to_tla_symbol a) (to_tla_symbol b)
+
+let same_observable_state a b =
+  String.equal (turn_state_label a) (turn_state_label b)
+
+
+type any_state = Any : _ turn_state -> any_state
+
+let any_state_label (Any s) = turn_state_label s
+let pp_any_state fmt (Any s) = pp_turn_state fmt s
+
+let classify_transition ?ctx ~(from_state: _ turn_state) ~(to_state: _ turn_state) () =
+  let stop_signaled_before =
+    match ctx with
+    | None -> default_transition_context.stop_signaled_before
+    | Some ctx -> ctx.stop_signaled_before
+  in
+  let stop_raised =
+    match ctx with
+    | None -> false
+    | Some ctx -> (not ctx.stop_signaled_before) && ctx.stop_signaled_after
+  in
+  let stop_unchanged =
+    match ctx with
+    | None -> true
+    | Some ctx -> Bool.equal ctx.stop_signaled_before ctx.stop_signaled_after
+  in
+  let honor_stop_signal_allowed =
+    match ctx with
+    | None -> true
+    | Some ctx -> ctx.stop_signaled_before
+  in
+  let supervisor_requests_stop_allowed =
+    match ctx with
+    | None -> true
+    | Some _ -> stop_raised
+  in
+  match Any from_state, Any to_state with
+  | Any Idle, Any Phase_gating when not stop_signaled_before ->
+      Some StartTurn
+  | Any Phase_gating, Any Done when not stop_signaled_before ->
+      Some PhaseGateSkip
+  | Any Phase_gating, Any Runtime_routing when not stop_signaled_before ->
+      Some PhaseGateOk
+  | Any Runtime_routing, Any Awaiting_provider when not stop_signaled_before ->
+      Some RuntimeRouted
+  | Any Runtime_routing, Any (Failed (Failure_runtime_unavailable _))
+    when not stop_signaled_before ->
+      Some RuntimeUnavailable
+  | Any Runtime_routing, Any (Failed (Failure_turn_livelock_blocked _))
+    when not stop_signaled_before ->
+      Some LivelockBlocked
+  | Any Runtime_routing, Any (Failed (Failure_no_tool_capable_provider _))
+    when not stop_signaled_before ->
+      Some NoToolCapableProvider
+  | Any Runtime_routing, Any (Failed (Failure_provider_error _))
+    when not stop_signaled_before ->
+      Some ProviderError
+  | Any Awaiting_provider, Any Streaming when not stop_signaled_before ->
+      Some ProviderResponded
+  | Any Awaiting_provider, Any (Cancelled Cancelled_provider_timeout)
+    when not stop_signaled_before ->
+      Some ProviderTimeout
+  | Any Streaming, Any Awaiting_tool_result when not stop_signaled_before ->
+      Some StreamYieldsTool
+  | Any Awaiting_tool_result, Any Streaming when not stop_signaled_before ->
+      Some ToolReturned
+  | Any Streaming, Any Completing when not stop_signaled_before ->
+      Some StreamComplete
+  | Any Streaming, Any (Failed (Failure_tool_contract_violation _))
+    when not stop_signaled_before ->
+      Some ContractViolation
+  | Any Streaming, Any (Failed (Failure_receipt_lost _))
+    when not stop_signaled_before ->
+      Some ReceiptLost
+  | Any Streaming, Any (Failed (Failure_provider_error _))
+    when not stop_signaled_before ->
+      Some ProviderError
+  | Any Streaming, Any (Cancelled Cancelled_provider_timeout)
+    when not stop_signaled_before ->
+      Some ProviderTimeout
+  | Any Completing, Any Done when not stop_signaled_before ->
+      Some ContractOk
+  | Any Completing, Any (Failed (Failure_tool_contract_violation _))
+    when not stop_signaled_before ->
+      Some ContractViolation
+  | Any Completing, Any (Failed (Failure_receipt_lost _))
+    when not stop_signaled_before ->
+      Some ReceiptLost
+  | _, Any (Failed _) when is_active from_state -> Some GenericFail
+  | _, Any (Cancelled _) when is_active from_state && honor_stop_signal_allowed ->
+      Some HonorStopSignal
+  | _, _
+    when supervisor_requests_stop_allowed
+         && is_active from_state
+         && same_tla_state from_state to_state ->
+      Some SupervisorRequestsStop
+  | _, _
+    when is_terminal from_state
+         && is_terminal to_state
+         && stop_unchanged
+         && same_observable_state from_state to_state ->
+      Some TerminalStutter
+  | _ -> None
+
+let assert_transition_allowed ?ctx ~(from_state: _ turn_state) ~(to_state: _ turn_state) () =
+  match classify_transition ?ctx ~from_state ~to_state () with
+  | Some action -> Ok action
+  | None ->
+      Error
+        {
+          from_state = to_tla_symbol from_state;
+          to_state = to_tla_symbol to_state;
+          reason = "not_in_keeper_turn_fsm_next";
+        }
+
+(* NOTE: [require_active_state] is NOT here — its [@@fsm_guard] ppx_tla
+   expansion injects a call to [Keeper_fsm_guard_runtime], which would couple
+   this pure library to the keeper. It stays in the keeper-side shim
+   ([Keeper_turn_fsm]) alongside the other emission glue. The pure FSM
+   (states + transition matrix) is the entire contents of this module. *)

--- a/lib/turn_fsm/turn_fsm.mli
+++ b/lib/turn_fsm/turn_fsm.mli
@@ -1,0 +1,143 @@
+(** Pure Turn FSM — the agent turn-cycle state machine, independent of Keeper.
+
+    States, reasons, and the transition matrix only; no telemetry/audit/metrics
+    emission (that glue lives in [Keeper_turn_fsm], which [include]s this module).
+    Dependency direction is Keeper -> Turn, never the reverse.
+
+    Formal contract: [specs/keeper-turn-fsm/KeeperTurnFSM.tla]. The [@tla.*] /
+    [@@deriving tla] annotations bind states + the transition matrix to that
+    spec; [test_keeper_turn_fsm_tla_parity] verifies parity. *)
+
+type cancel_reason =
+  | Cancelled_supervisor_stop
+      (** Operator/supervisor requested keeper shutdown. *)
+  | Cancelled_phase_gate_close
+      (** Phase transition closed an in-flight turn. *)
+  | Cancelled_provider_timeout
+      (** Underlying provider (CLI subprocess or HTTP) timed out
+          past the cooperative-cancel deadline. *)
+  | Cancelled_fleet_shutdown
+      (** Process is exiting; no more turns will be dispatched. *)
+  | Cancelled_input_required
+      (** Agent paused to request human input (InputRequired). *)
+
+type failure_reason =
+  | Failure_runtime_unavailable of {
+      base : string;
+      resolved : string option;
+    }
+  | Failure_no_tool_capable_provider of {
+      runtime_id : string;
+      detail : string;
+    }
+  | Failure_provider_error of { kind : string; detail : string }
+  | Failure_tool_contract_violation of { reason_code : string }
+  | Failure_receipt_lost of {
+      primary_error : string;
+      fallback_path : string option;
+    }
+  | Failure_turn_livelock_blocked of { reason : string }
+      (** Pre-dispatch livelock guard ([Keeper_turn_livelock])
+          rejected this turn because the keeper is stuck in a
+          loop on the same task.  Distinct from [runtime_error]
+          so PromQL can chart livelock incidence on its own. *)
+  | Failure_runtime_error of string
+  | Failure_unexpected_exception of {
+      exn : string;
+      backtrace : string option;
+    }
+
+(** Turn FSM states.  Mirrors the lanes in
+    [docs/keeper-turn-lifecycle.md]. *)
+type _ turn_state =
+  | Idle : [`Idle] turn_state [@tla.idle]
+  | Phase_gating : [`Phase_gating] turn_state [@tla.active]
+  | Runtime_routing : [`Runtime_routing] turn_state [@tla.active]
+  | Awaiting_provider : [`Awaiting_provider] turn_state [@tla.active]
+  | Streaming : [`Streaming] turn_state [@tla.active]
+  | Awaiting_tool_result : [`Awaiting_tool_result] turn_state [@tla.symbol "awaiting_tool"] [@tla.active]
+  | Completing : [`Completing] turn_state [@tla.active]
+  | Done : [`Done] turn_state [@tla.terminal]
+  | Failed : failure_reason -> [`Failed] turn_state [@tla.terminal]
+  | Cancelled : cancel_reason -> [`Cancelled] turn_state [@tla.terminal]
+
+val cancel_reason_label : cancel_reason -> string
+val failure_reason_label : failure_reason -> string
+val to_tla_symbol : _ turn_state -> string
+val turn_state_label : _ turn_state -> string
+
+val pp_cancel_reason : Format.formatter -> cancel_reason -> unit
+val pp_failure_reason : Format.formatter -> failure_reason -> unit
+val pp_turn_state : Format.formatter -> _ turn_state -> unit
+
+type transition_action =
+  | StartTurn
+  | PhaseGateSkip
+  | PhaseGateOk
+  | RuntimeRouted
+  | RuntimeUnavailable
+  | ProviderResponded
+  | ProviderTimeout
+  | StreamYieldsTool
+  | ToolReturned
+  | StreamComplete
+  | ContractOk
+  | ContractViolation
+  | ReceiptLost
+  | LivelockBlocked
+  | NoToolCapableProvider
+  | ProviderError
+  | GenericFail
+  | SupervisorRequestsStop
+  | HonorStopSignal
+  | TerminalStutter
+(** Runtime image of [KeeperTurnFSM.tla] [Next] actions. *)
+
+val transition_action_label : transition_action -> string
+
+type transition_context = {
+  stop_signaled_before : bool;
+  stop_signaled_after : bool;
+}
+(** Orthogonal stop-signal state for a transition.  Mirrors the TLA+ variable
+    [stop_signaled] in [specs/keeper-turn-fsm/KeeperTurnFSM.tla]. *)
+
+val default_transition_context : transition_context
+
+type transition_violation = {
+  from_state : string;
+  to_state : string;
+  reason : string;
+}
+
+val classify_transition :
+  ?ctx:transition_context ->
+  from_state:_ turn_state ->
+  to_state:_ turn_state ->
+  unit ->
+  transition_action option
+(** Return the TLA+ action represented by an OCaml state edge, if the
+    edge is allowed by the keeper-turn FSM contract. *)
+
+val assert_transition_allowed :
+  ?ctx:transition_context ->
+  from_state:_ turn_state ->
+  to_state:_ turn_state ->
+  unit ->
+  (transition_action, transition_violation) result
+
+(* [require_active_state] lives in the keeper-side shim [Keeper_turn_fsm], not
+   here: its [@@fsm_guard] ppx expansion references [Keeper_fsm_guard_runtime]. *)
+
+type any_state = Any : _ turn_state -> any_state
+val any_state_label : any_state -> string
+val pp_any_state : Format.formatter -> any_state -> unit
+
+val all_symbols : string list
+val active_symbols : string list
+val terminal_symbols : string list
+val idle_symbols : string list
+
+val is_active : _ turn_state -> bool
+val is_terminal : _ turn_state -> bool
+val is_idle : _ turn_state -> bool

--- a/test/deps/dune
+++ b/test/deps/dune
@@ -107,6 +107,9 @@
    ;; Goal domain extracted to lib/goal/ (masc_goal). Re-export so test code
    ;; using bare Goal_store.X / Goal_phase.X resolves after decoupling.
    (re_export masc_goal)
+   ;; Pure Turn FSM extracted to lib/turn_fsm/ (masc_turn). Re-export so test
+   ;; code using bare Turn_fsm.X resolves after the FSM carve.
+   (re_export masc_turn)
    (re_export masc_types)
    (re_export mirage-crypto)
    (re_export mirage-crypto-rng)


### PR DESCRIPTION
## 목적

Turn FSM(에이전트 턴-사이클 상태기계)을 Keeper에서 분리해 자체 라이브러리 `masc_turn`으로 추출한다. 의존 방향을 **Keeper → Turn** 으로 컴파일러가 강제하게 한다 — Keeper는 turn을 *구동*하되 "내가 무슨 턴인지" 추적/소유하지 않는다.

계획: `docs/plans/masc-mcp-tool-domain-decouple.html` (LANE 4). 선례: Goal 추출 #19823.

## 배경 — 왜 분리 가능한가

`keeper_turn_fsm.ml`은 **순수 GADT 상태기계**(`turn_state` 10상태 + `classify_transition` 전이행렬 + `Tla_symbol`)와 **keeper 관측 glue**(emit/audit/metrics)를 한 모듈에 섞어놨다. 순수 FSM 코어는 Keeper_* 참조가 0이며, `specs/keeper-turn-fsm/KeeperTurnFSM.tla`로 형식 명세돼 있다(`[@tla.*]` 어노테이션). 적대적 검증(3-에이전트 워크플로)으로 "Turn = Keeper 실행 코어, 분리 불가" 판정이 거짓임을 확인 — 실제로는 단방향 layer cake이고 순수 FSM이 leaf다.

## 변경

- **신규 `lib/turn_fsm/` (library `masc_turn`)**: 순수 FSM 코어 — `cancel_reason`/`failure_reason`, GADT `turn_state`, `Tla_symbol [@@deriving tla]`, labels/pp, `transition_action`, `classify_transition`, `assert_transition_allowed`, `any_state`, symbols, `is_active/terminal/idle`. deps = **stdlib + ppx_tla만** (Keeper_* 0, masc_types도 불필요).
- **`keeper_turn_fsm.ml`은 얇은 shim**: `include Turn_fsm` + keeper-coupled tail(`guard_transition`/`observe_phase_dwell`/`emit_transition` — Log.Keeper/Keeper_transition_audit/Prometheus+Keeper_metrics/Keeper_fsm_guard_runtime) + `require_active_state`. `.mli`는 `include module type of Turn_fsm` + 2개 glue val.
- **`lib/dune` + `test/deps/dune`**: masc_turn 배선.

## 검증

- `dune build lib/turn_fsm/` EXIT=0 — **green island** (순수 FSM 독립 컴파일).
- `dune build @check` 에러 **22 → 22 (net-zero)**. Turn_fsm/masc_turn 관련 에러 0. 남은 22는 기존 Runtime⊥Keeper + PR-1 test 클러스터(이 PR과 무관).
- **~113개 `Keeper_turn_fsm.X` 호출 사이트 무편집** (shim의 include로 해소).
- 순수 FSM은 `tlc specs/keeper-turn-fsm/KeeperTurnFSM.tla`로 driver와 무관하게 독립 검증 가능.

## 비자명한 발견

`require_active_state`는 정적분석상 "Masc_domain만 쓰는 순수 함수"로 보였으나, 격리 빌드가 그 `[@@fsm_guard]` ppx_tla 확장이 런타임에 `Keeper_fsm_guard_runtime`를 주입함을 잡았다 → 이 한 함수만 shim에 남기고 나머지 순수 코어만 분리. **컴파일러-강제 경계가 정적분석보다 정확함**을 실증.

## 연기

turn **driver**(`keeper_unified_turn.ml` 148 Keeper_* + ~113 driver 파일)는 진짜 keeper-fused이므로 전체 Keeper-lib 카브로 연기. 이 PR은 FSM **코어**만.

RFC-WAIVED: 구조적 경계 디커플링(순수 FSM 라이브러리 추출). credential/identity/sandbox/hooks/workflow subsystem 변경 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
