### PR TITLE
refactor(tool): partition domain tool-names out of Tool_name god-enum (PR-S1)

### DIFF
--- a/lib/governance_pipeline_risk.ml
+++ b/lib/governance_pipeline_risk.ml
@@ -145,24 +145,30 @@ let classify_name name =
 
 let risk_of_masc (m : Tool_name.Masc.t) : risk_level =
   let open Tool_name.Masc in
+  (* PR-S1: domain tool names moved to Task/Board/Goal/Operator submodules.
+     Risk classification is NON-uniform across each domain (e.g. Board_delete
+     is Critical but Board_list is Low), so this match stays flat over
+     [Masc.t] with each domain constructor mechanically wrapped — the bucket
+     groupings are byte-for-byte unchanged from before the partition, and the
+     compiler still enforces exhaustiveness over every variant. *)
   match m with
-  | Add_task | Agent_fitness | Agent_card | Agents | Batch_add_tasks
-  | Board_cleanup | Board_comment | Board_comment_vote | Board_curation_read
-  | Board_curation_submit | Board_get | Board_hearths | Board_list | Board_post
-  | Board_profile | Board_reaction | Board_search | Board_stats | Board_vote
-  | Board_sub_board_get | Board_sub_board_list | Broadcast | Check
-  | Cleanup_zombies | Dashboard | Deliver | Goal_list | Goal_transition
-  | Heartbeat | Messages | Note_add | Operator_action | Operator_digest
-  | Operator_snapshot | Plan_clear_task | Plan_get | Plan_get_task | Plan_init
-  | Plan_set_task | Status | Task_history | Tasks | Tool_grant | Tool_help
-  | Tool_list | Tool_revoke | Transition | Web_fetch | Web_search
+  | Task Add_task | Agent_fitness | Agent_card | Agents | Task Batch_add_tasks
+  | Board Board_cleanup | Board Board_comment | Board Board_comment_vote | Board Board_curation_read
+  | Board Board_curation_submit | Board Board_get | Board Board_hearths | Board Board_list | Board Board_post
+  | Board Board_profile | Board Board_reaction | Board Board_search | Board Board_stats | Board Board_vote
+  | Board Board_sub_board_get | Board Board_sub_board_list | Broadcast | Check
+  | Cleanup_zombies | Dashboard | Deliver | Goal Goal_list | Goal Goal_transition
+  | Heartbeat | Messages | Note_add | Operator Operator_action | Operator Operator_digest
+  | Operator Operator_snapshot | Plan_clear_task | Plan_get | Plan_get_task | Plan_init
+  | Plan_set_task | Status | Task Task_history | Task Tasks | Tool_grant | Tool_help
+  | Tool_list | Tool_revoke | Task Transition | Web_fetch | Web_search
   | Approval_pending | Approval_get | Config | Gc | Get_metrics | Mcp_session
   | Tool_admin_snapshot | Tool_stats -> Low
-  | Claim_next | Goal_upsert | Goal_verify | Operator_confirm
+  | Task Claim_next | Goal Goal_upsert | Goal Goal_verify | Operator Operator_confirm
   | Pause | Resume | Start -> Medium
-  | Agent_update | Board_sub_board_create | Board_sub_board_update | Plan_update
-  | Update_priority | Tool_admin_update -> High
-  | Board_delete | Board_sub_board_delete | Reset -> Critical
+  | Agent_update | Board Board_sub_board_create | Board Board_sub_board_update | Plan_update
+  | Task Update_priority | Tool_admin_update -> High
+  | Board Board_delete | Board Board_sub_board_delete | Reset -> Critical
 ;;
 
 let risk_of_typed : Tool_name.t -> risk_level = function
@@ -337,7 +343,7 @@ let baseline_risk ~tool_name ~input =
         goal_transition_risk input
       else if
         String.equal tool_name
-          (Tool_name.Masc.to_string Tool_name.Masc.Transition)
+          (Tool_name.Masc.to_string (Tool_name.Masc.Task Tool_name.Task_name.Transition))
       then (
         (* transition risk depends on the action verb, not the tool name *)
         match transition_action input with

--- a/lib/keeper/agent_tool_board_runtime.ml
+++ b/lib/keeper/agent_tool_board_runtime.ml
@@ -80,8 +80,10 @@ let handle_keeper_board_tool
     tool_result_or_error
       (Tool_board.handle_tool tool_name tool_args)
   in
-  let dispatch_board tool tool_args =
-    dispatch (Tool_name.Masc.to_string tool) tool_args
+  (* PR-S1: the board runtime speaks the domain name type [Board_name.t]
+     directly rather than routing through the [Tool_name.Masc] god-enum. *)
+  let dispatch_board (tool : Tool_name.Board_name.t) tool_args =
+    dispatch (Tool_name.Board_name.to_string tool) tool_args
   in
   match name with
   | "keeper_board_post" ->
@@ -101,7 +103,7 @@ let handle_keeper_board_tool
     Log.Keeper.debug "board_args: %s" (Yojson.Safe.pretty_to_string board_args);
     let result =
       Tool_board.handle_tool
-        (Tool_name.Masc.to_string Tool_name.Masc.Board_post)
+        (Tool_name.Board_name.to_string Tool_name.Board_name.Board_post)
         board_args
     in
     let ok = Tool_result.is_success result in
@@ -111,37 +113,37 @@ let handle_keeper_board_tool
       ok
       (String_util.utf8_safe ~max_bytes:203 ~suffix:"..." msg |> String_util.to_string);
     tool_result_or_error result
-  | "keeper_board_list" -> dispatch_board Tool_name.Masc.Board_list args
-  | "keeper_board_get" -> dispatch_board Tool_name.Masc.Board_get args
+  | "keeper_board_list" -> dispatch_board Tool_name.Board_name.Board_list args
+  | "keeper_board_get" -> dispatch_board Tool_name.Board_name.Board_get args
   | "keeper_board_comment" ->
     dispatch_board
-      Tool_name.Masc.Board_comment
+      Tool_name.Board_name.Board_comment
       (assoc_override_string "author" meta.name args)
   | "keeper_board_vote" ->
     dispatch_board
-      Tool_name.Masc.Board_vote
+      Tool_name.Board_name.Board_vote
       (assoc_override_string "voter" meta.name args)
   | "keeper_board_comment_vote" ->
     dispatch_board
-      Tool_name.Masc.Board_comment_vote
+      Tool_name.Board_name.Board_comment_vote
       (assoc_override_string "voter" meta.name args)
-  | "keeper_board_stats" -> dispatch_board Tool_name.Masc.Board_stats args
-  | "keeper_board_search" -> dispatch_board Tool_name.Masc.Board_search args
+  | "keeper_board_stats" -> dispatch_board Tool_name.Board_name.Board_stats args
+  | "keeper_board_search" -> dispatch_board Tool_name.Board_name.Board_search args
   | "keeper_board_curation_read" ->
-    dispatch_board Tool_name.Masc.Board_curation_read args
+    dispatch_board Tool_name.Board_name.Board_curation_read args
   | "keeper_board_curation_submit" ->
     dispatch_board
-      Tool_name.Masc.Board_curation_submit
+      Tool_name.Board_name.Board_curation_submit
       (assoc_override_string "submitted_by" meta.name args)
   | "keeper_board_sub_board_create" ->
-    dispatch_board Tool_name.Masc.Board_sub_board_create args
+    dispatch_board Tool_name.Board_name.Board_sub_board_create args
   | "keeper_board_sub_board_list" ->
-    dispatch_board Tool_name.Masc.Board_sub_board_list args
+    dispatch_board Tool_name.Board_name.Board_sub_board_list args
   | "keeper_board_sub_board_get" ->
-    dispatch_board Tool_name.Masc.Board_sub_board_get args
+    dispatch_board Tool_name.Board_name.Board_sub_board_get args
   | "keeper_board_sub_board_update" ->
-    dispatch_board Tool_name.Masc.Board_sub_board_update args
+    dispatch_board Tool_name.Board_name.Board_sub_board_update args
   | "keeper_board_sub_board_delete" ->
-    dispatch_board Tool_name.Masc.Board_sub_board_delete args
+    dispatch_board Tool_name.Board_name.Board_sub_board_delete args
   | _ -> error_json ~fields:[ "tool", `String name ] "unknown_board_tool"
 ;;

--- a/lib/keeper/keeper_tool_capability_axis.ml
+++ b/lib/keeper/keeper_tool_capability_axis.ml
@@ -28,7 +28,7 @@ let candidate_names name =
 ;;
 
 let claim_task_tool_names =
-  [ "keeper_task_claim"; masc_name Tool_name.Masc.Claim_next ]
+  [ "keeper_task_claim"; masc_name (Tool_name.Masc.Task Tool_name.Task_name.Claim_next) ]
 ;;
 
 let board_activity_tool_names =

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -193,12 +193,14 @@ let keeper_supported_masc_schemas (schemas : Masc_domain.tool_schema list) =
      author/voter fields. Exposing both leads to the LLM calling the raw
      masc_* variant without the required author, causing "author is required". *)
   let has_keeper_board_wrapper name =
-    let eq v = String.equal name (Tool_name.Masc.to_string v) in
-    eq Tool_name.Masc.Board_comment
-    || eq Tool_name.Masc.Board_curation_submit
-    || eq Tool_name.Masc.Board_post
-    || eq Tool_name.Masc.Board_vote
-    || eq Tool_name.Masc.Board_delete
+    let eq v =
+      String.equal name (Tool_name.Masc.to_string (Tool_name.Masc.Board v))
+    in
+    eq Tool_name.Board_name.Board_comment
+    || eq Tool_name.Board_name.Board_curation_submit
+    || eq Tool_name.Board_name.Board_post
+    || eq Tool_name.Board_name.Board_vote
+    || eq Tool_name.Board_name.Board_delete
   in
   List.filter (fun (s : Masc_domain.tool_schema) ->
       String.starts_with ~prefix:"masc_" s.name

--- a/lib/keeper/keeper_tool_progress.ml
+++ b/lib/keeper/keeper_tool_progress.ml
@@ -54,7 +54,9 @@ let effect_of_progress_class = function
 ;;
 
 let claim_context_tool_names : string list =
-  [ Tool_name.(to_string (Masc Claim_next)); Keeper_tool_name.(to_string Task_claim) ]
+  [ Tool_name.(to_string (Masc (Masc.Task Task_name.Claim_next)))
+  ; Keeper_tool_name.(to_string Task_claim)
+  ]
 ;;
 
 let completion_tool_names : string list =
@@ -84,7 +86,8 @@ let is_claim_tool_name name =
    | Some Task_claim -> true
    | _ -> false)
   || (match Tool_name.of_string name with
-      | Some (Masc Claim_next) -> true
+      | Some (Tool_name.Masc (Tool_name.Masc.Task Tool_name.Task_name.Claim_next)) ->
+        true
       | _ -> false)
 ;;
 

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -243,11 +243,11 @@ let reconcile_safe_tools =
   @ List.map
       Tool_name.to_string
       Tool_name.
-        [ Masc Board_post
-        ; Masc Board_comment
-        ; Masc Board_vote
-        ; Masc Board_comment_vote
-        ; Masc Board_curation_submit
+        [ Masc (Masc.Board Board_name.Board_post)
+        ; Masc (Masc.Board Board_name.Board_comment)
+        ; Masc (Masc.Board Board_name.Board_vote)
+        ; Masc (Masc.Board Board_name.Board_comment_vote)
+        ; Masc (Masc.Board Board_name.Board_curation_submit)
         ; Masc Broadcast
         ]
 ;;

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -501,7 +501,12 @@ let start_keeper_loops
   Keeper_subprocess_registry.register_default_cleanup_hook ();
   (* Build read-only tool surface shared by both judges. *)
   let judge_tool_names =
-    List.map Tool_name.Masc.to_string Tool_name.Masc.[ Status; Tasks; Agents; Board_list ]
+    List.map
+      Tool_name.Masc.to_string
+      Tool_name.Masc.
+        [ Status; Task Tool_name.Task_name.Tasks; Agents
+        ; Board Tool_name.Board_name.Board_list
+        ]
   in
   let judge_masc_tools =
     match Agent_tool_surfaces.local_worker_tool_schemas ~names:judge_tool_names () with

--- a/lib/tool_catalog_inference.ml
+++ b/lib/tool_catalog_inference.ml
@@ -39,70 +39,81 @@ let tool_group_to_string = function
 module TN = Tool_name
 module TM = Tool_name.Masc
 
+(* PR-S1: domain tool names live in these submodules; [TM.Task]/[TM.Board]/
+   [TM.Goal]/[TM.Operator] wrap them into [Masc.t]. *)
+module TTask = Tool_name.Task_name
+module TBoard = Tool_name.Board_name
+module TGoal = Tool_name.Goal_name
+module TOp = Tool_name.Operator_name
+
+(* PR-S1: NON-uniform across each domain (Board members split Read_only vs
+   Masc_workspace; Operator members split three ways), so this match stays flat
+   over [Masc.t] with each domain constructor mechanically wrapped — bucket
+   groupings unchanged, exhaustiveness still enforced. *)
 let inferred_effect_domain_of_typed_tool_name = function
   | TN.Masc TM.Deliver
-  | TN.Masc TM.Operator_action
+  | TN.Masc (TM.Operator TOp.Operator_action)
   | TN.Masc TM.Start ->
       Some Host_repo_write
   | TN.Masc TM.Agent_fitness
   | TN.Masc TM.Agent_card
   | TN.Masc TM.Agents
-  | TN.Masc TM.Board_get
-  | TN.Masc TM.Board_curation_read
-  | TN.Masc TM.Board_hearths
-  | TN.Masc TM.Board_list
-  | TN.Masc TM.Board_profile
-  | TN.Masc TM.Board_search
-  | TN.Masc TM.Board_stats
+  | TN.Masc (TM.Board TBoard.Board_get)
+  | TN.Masc (TM.Board TBoard.Board_curation_read)
+  | TN.Masc (TM.Board TBoard.Board_hearths)
+  | TN.Masc (TM.Board TBoard.Board_list)
+  | TN.Masc (TM.Board TBoard.Board_profile)
+  | TN.Masc (TM.Board TBoard.Board_search)
+  | TN.Masc (TM.Board TBoard.Board_stats)
   | TN.Masc TM.Check
   | TN.Masc TM.Config
   | TN.Masc TM.Dashboard
   | TN.Masc TM.Get_metrics
-  | TN.Masc TM.Goal_list
+  | TN.Masc (TM.Goal TGoal.Goal_list)
   | TN.Masc TM.Mcp_session
   | TN.Masc TM.Messages
-  | TN.Masc TM.Operator_digest
-  | TN.Masc TM.Operator_snapshot
+  | TN.Masc (TM.Operator TOp.Operator_digest)
+  | TN.Masc (TM.Operator TOp.Operator_snapshot)
   | TN.Masc TM.Plan_get
   | TN.Masc TM.Plan_get_task
   | TN.Masc TM.Status
-  | TN.Masc TM.Task_history
-  | TN.Masc TM.Tasks
+  | TN.Masc (TM.Task TTask.Task_history)
+  | TN.Masc (TM.Task TTask.Tasks)
   | TN.Masc TM.Tool_admin_snapshot
   | TN.Masc TM.Tool_help
   | TN.Masc TM.Tool_list
   | TN.Masc TM.Tool_stats
   | TN.Masc TM.Web_fetch
   | TN.Masc TM.Web_search
-  | TN.Masc TM.Board_sub_board_get
-  | TN.Masc TM.Board_sub_board_list
+  | TN.Masc (TM.Board TBoard.Board_sub_board_get)
+  | TN.Masc (TM.Board TBoard.Board_sub_board_list)
   | TN.Masc TM.Approval_pending
   | TN.Masc TM.Approval_get ->
       Some Read_only
-  | TN.Masc TM.Add_task
+  | TN.Masc (TM.Task TTask.Add_task)
   | TN.Masc TM.Agent_update
-  | TN.Masc TM.Batch_add_tasks
-  | TN.Masc TM.Board_cleanup
-  | TN.Masc TM.Board_comment
-  | TN.Masc TM.Board_comment_vote
-  | TN.Masc TM.Board_curation_submit
-  | TN.Masc TM.Board_delete
-  | TN.Masc TM.Board_post
-  | TN.Masc TM.Board_reaction
-  | TN.Masc TM.Board_sub_board_create
-  | TN.Masc TM.Board_sub_board_delete
-  | TN.Masc TM.Board_sub_board_update
-  | TN.Masc TM.Board_vote
+  | TN.Masc (TM.Task TTask.Batch_add_tasks)
+  | TN.Masc (TM.Board TBoard.Board_cleanup)
+  | TN.Masc (TM.Board TBoard.Board_comment)
+  | TN.Masc (TM.Board TBoard.Board_comment_vote)
+  | TN.Masc (TM.Board TBoard.Board_curation_submit)
+  | TN.Masc (TM.Board TBoard.Board_delete)
+  | TN.Masc (TM.Board TBoard.Board_post)
+  | TN.Masc (TM.Board TBoard.Board_reaction)
+  | TN.Masc (TM.Board TBoard.Board_sub_board_create)
+  | TN.Masc (TM.Board TBoard.Board_sub_board_delete)
+  | TN.Masc (TM.Board TBoard.Board_sub_board_update)
+  | TN.Masc (TM.Board TBoard.Board_vote)
   | TN.Masc TM.Broadcast
-  | TN.Masc TM.Claim_next
+  | TN.Masc (TM.Task TTask.Claim_next)
   | TN.Masc TM.Cleanup_zombies
   | TN.Masc TM.Gc
-  | TN.Masc TM.Goal_transition
-  | TN.Masc TM.Goal_upsert
-  | TN.Masc TM.Goal_verify
+  | TN.Masc (TM.Goal TGoal.Goal_transition)
+  | TN.Masc (TM.Goal TGoal.Goal_upsert)
+  | TN.Masc (TM.Goal TGoal.Goal_verify)
   | TN.Masc TM.Heartbeat
   | TN.Masc TM.Note_add
-  | TN.Masc TM.Operator_confirm
+  | TN.Masc (TM.Operator TOp.Operator_confirm)
   | TN.Masc TM.Pause
   | TN.Masc TM.Plan_clear_task
   | TN.Masc TM.Plan_init
@@ -113,36 +124,19 @@ let inferred_effect_domain_of_typed_tool_name = function
   | TN.Masc TM.Tool_admin_update
   | TN.Masc TM.Tool_grant
   | TN.Masc TM.Tool_revoke
-  | TN.Masc TM.Transition
-  | TN.Masc TM.Update_priority ->
+  | TN.Masc (TM.Task TTask.Transition)
+  | TN.Masc (TM.Task TTask.Update_priority) ->
       Some Masc_workspace
 let inferred_effect_domain name =
   match Tool_name.of_string name with
   | Some typed_name -> inferred_effect_domain_of_typed_tool_name typed_name
   | None -> None
 
+(* PR-S1: in this grouping each domain IS uniform — all Board names map to
+   [Masc_board], and all Task/Goal/Operator names map to [Masc_core] — so the
+   domains collapse to a single nested wildcard arm each. *)
 let tool_group_of_typed_tool_name = function
-  | TN.Masc
-      ( TM.Board_cleanup
-      | TM.Board_comment
-      | TM.Board_comment_vote
-      | TM.Board_curation_read
-      | TM.Board_curation_submit
-      | TM.Board_delete
-      | TM.Board_get
-      | TM.Board_hearths
-      | TM.Board_list
-      | TM.Board_post
-      | TM.Board_profile
-      | TM.Board_reaction
-      | TM.Board_search
-      | TM.Board_stats
-      | TM.Board_sub_board_create
-      | TM.Board_sub_board_delete
-      | TM.Board_sub_board_get
-      | TM.Board_sub_board_list
-      | TM.Board_sub_board_update
-      | TM.Board_vote ) ->
+  | TN.Masc (TM.Board _) ->
       Some Masc_board
   | TN.Masc
       ( TM.Plan_clear_task
@@ -154,39 +148,29 @@ let tool_group_of_typed_tool_name = function
       Some Masc_plan
   | TN.Masc (TM.Agent_fitness | TM.Agent_update | TM.Agent_card | TM.Agents) ->
       Some Masc_agent
+  | TN.Masc (TM.Task _)
+  | TN.Masc (TM.Goal _)
+  | TN.Masc (TM.Operator _)
   | TN.Masc
-      ( TM.Add_task
-      | TM.Approval_pending
+      ( TM.Approval_pending
       | TM.Approval_get
-      | TM.Batch_add_tasks
       | TM.Broadcast
       | TM.Check
-      | TM.Claim_next
       | TM.Cleanup_zombies
       | TM.Config
       | TM.Dashboard
       | TM.Deliver
       | TM.Gc
       | TM.Get_metrics
-      | TM.Goal_list
-      | TM.Goal_transition
-      | TM.Goal_upsert
-      | TM.Goal_verify
       | TM.Heartbeat
       | TM.Mcp_session
       | TM.Messages
       | TM.Note_add
-      | TM.Operator_action
-      | TM.Operator_confirm
-      | TM.Operator_digest
-      | TM.Operator_snapshot
       | TM.Pause
       | TM.Reset
       | TM.Resume
       | TM.Start
       | TM.Status
-      | TM.Task_history
-      | TM.Tasks
       | TM.Tool_admin_snapshot
       | TM.Tool_admin_update
       | TM.Tool_grant
@@ -194,8 +178,6 @@ let tool_group_of_typed_tool_name = function
       | TM.Tool_list
       | TM.Tool_revoke
       | TM.Tool_stats
-      | TM.Transition
-      | TM.Update_priority
       | TM.Web_fetch
       | TM.Web_search ) ->
       Some Masc_core

--- a/lib/tool_dispatch.ml
+++ b/lib/tool_dispatch.ml
@@ -237,38 +237,23 @@ let static_tag_of_tool_name (tool : Tool_name.t) : module_tag option =
   | Tool_name.Masc m ->
     let open Tool_name.Masc in
     match m with
-    | Add_task
-    | Batch_add_tasks
-    | Claim_next
-    | Task_history
-    | Tasks
-    | Transition
-    | Update_priority -> Some Mod_task
+    (* Domain tool-NAME groups collapse to a single tag each: the substrate no
+       longer enumerates the per-operation names. Tag alignment proof (PR-S1):
+       every member of each domain submodule mapped to the same tag before the
+       partition, so [| Domain _ ->] is exact, not a downgrade.
+         Task     -> Mod_task     (was 7 arms, all Mod_task)
+         Board    -> Mod_inline   (was 20 Board_* arms, all Mod_inline)
+         Goal     -> Mod_state    (was 4 Goal_* arms, all Mod_state)
+         Operator -> Mod_operator (was 4 Operator_* arms, all Mod_operator) *)
+    | Task _ -> Some Mod_task
+    | Board _ -> Some Mod_inline
+    | Goal _ -> Some Mod_state
+    | Operator _ -> Some Mod_operator
     | Agent_fitness
     | Agent_card
     | Agent_update
     | Agents
     | Get_metrics -> Some Mod_agent
-    | Board_cleanup
-    | Board_comment
-    | Board_comment_vote
-    | Board_curation_read
-    | Board_curation_submit
-    | Board_delete
-    | Board_get
-    | Board_hearths
-    | Board_list
-    | Board_post
-    | Board_profile
-    | Board_reaction
-    | Board_search
-    | Board_stats
-    | Board_sub_board_create
-    | Board_sub_board_delete
-    | Board_sub_board_get
-    | Board_sub_board_list
-    | Board_sub_board_update
-    | Board_vote
     | Approval_get
     | Approval_pending
     | Broadcast
@@ -277,10 +262,6 @@ let static_tag_of_tool_name (tool : Tool_name.t) : module_tag option =
     | Start
     -> Some Mod_inline
     | Check
-    | Goal_list
-    | Goal_transition
-    | Goal_upsert
-    | Goal_verify
     | Heartbeat
     | Reset
     | Status -> Some Mod_state
@@ -302,7 +283,6 @@ let static_tag_of_tool_name (tool : Tool_name.t) : module_tag option =
     | Plan_init
     | Plan_set_task
     | Plan_update -> Some Mod_plan
-    | Operator_action | Operator_confirm | Operator_digest | Operator_snapshot -> Some Mod_operator
     | Pause | Resume -> Some Mod_control
     | Tool_grant | Tool_list | Tool_revoke -> Some Mod_shard
 

--- a/lib/tool_inline_dispatch_workspace.ml
+++ b/lib/tool_inline_dispatch_workspace.ml
@@ -51,7 +51,8 @@ let inline_err_workflow ~tool_name ~start_time msg : Tool_result.result =
     msg
 ;;
 
-let masc_add_task_name = Tool_name.Masc.to_string Tool_name.Masc.Add_task
+let masc_add_task_name =
+  Tool_name.Masc.to_string (Tool_name.Masc.Task Tool_name.Task_name.Add_task)
 
 (** Argument extraction helpers bound to ctx.arguments. *)
 let arg_get_string ctx key default =

--- a/lib/tool_name.ml
+++ b/lib/tool_name.ml
@@ -19,16 +19,53 @@ module Float = Stdlib.Float
 
     Replaces stringly-typed tool dispatch with exhaustive variant matching.
     Parse boundary: [of_string] at MCP/JSON ingress only.
-    Internal code uses [t] directly — typos become compile errors. *)
+    Internal code uses [t] directly — typos become compile errors.
 
-module Masc = struct
+    PR-S1 (tool-domain decouple): the Task/Board/Goal/Operator tool *names*
+    are owned by domain-scoped submodules ([Task_name], [Board_name],
+    [Goal_name], [Operator_name]) instead of being enumerated flat in
+    [Masc.t]. The substrate ([Tool_name], [tool_dispatch]) no longer
+    hard-codes those domain operation names in a god-enum + static routing
+    table. Every MCP tool-name STRING is preserved exactly — each domain
+    submodule owns the complete [masc_*] string and [Masc.to_string]/
+    [Masc.of_string] compose over the submodules. *)
+
+module Task_name = struct
   type t =
     | Add_task
-    | Agent_fitness
-    | Agent_update
-    | Agent_card
-    | Agents
     | Batch_add_tasks
+    | Claim_next
+    | Task_history
+    | Tasks
+    | Transition
+    | Update_priority
+
+  let to_string = function
+    | Add_task -> "masc_add_task"
+    | Batch_add_tasks -> "masc_batch_add_tasks"
+    | Claim_next -> "masc_claim_next"
+    | Task_history -> "masc_task_history"
+    | Tasks -> "masc_tasks"
+    | Transition -> "masc_transition"
+    | Update_priority -> "masc_update_priority"
+  ;;
+
+  let of_string = function
+    | "masc_add_task" -> Some Add_task
+    | "masc_batch_add_tasks" -> Some Batch_add_tasks
+    | "masc_claim_next" -> Some Claim_next
+    | "masc_task_history" -> Some Task_history
+    | "masc_tasks" -> Some Tasks
+    | "masc_transition" -> Some Transition
+    | "masc_update_priority" -> Some Update_priority
+    | _ -> None
+  ;;
+
+  let pp fmt t = Format.pp_print_string fmt (to_string t)
+end
+
+module Board_name = struct
+  type t =
     | Board_cleanup
     | Board_comment
     | Board_comment_vote
@@ -49,61 +86,8 @@ module Masc = struct
     | Board_sub_board_list
     | Board_sub_board_update
     | Board_vote
-    | Broadcast
-    | Check
-    | Claim_next
-    | Cleanup_zombies
-    | Dashboard
-    | Deliver
-    | Goal_list
-    | Goal_transition
-    | Goal_upsert
-    | Goal_verify
-    | Heartbeat
-    | Messages
-    | Note_add
-    | Operator_action
-    | Operator_confirm
-    | Operator_digest
-    | Operator_snapshot
-    | Plan_clear_task
-    | Plan_get
-    | Plan_get_task
-    | Plan_init
-    | Plan_set_task
-    | Plan_update
-    | Reset
-    | Status
-    | Task_history
-    | Tasks
-    | Tool_grant
-    | Tool_help
-    | Tool_list
-    | Tool_revoke
-    | Transition
-    | Update_priority
-    | Web_fetch
-    | Web_search
-    | Approval_pending
-    | Approval_get
-    | Config
-    | Gc
-    | Get_metrics
-    | Mcp_session
-    | Pause
-    | Resume
-    | Start
-    | Tool_admin_snapshot
-    | Tool_admin_update
-    | Tool_stats
 
   let to_string = function
-    | Add_task -> "masc_add_task"
-    | Agent_fitness -> "masc_agent_fitness"
-    | Agent_update -> "masc_agent_update"
-    | Agent_card -> "masc_agent_card"
-    | Agents -> "masc_agents"
-    | Batch_add_tasks -> "masc_batch_add_tasks"
     | Board_cleanup -> "masc_board_cleanup"
     | Board_comment -> "masc_board_comment"
     | Board_comment_vote -> "masc_board_comment_vote"
@@ -124,62 +108,9 @@ module Masc = struct
     | Board_sub_board_list -> "masc_board_sub_board_list"
     | Board_sub_board_update -> "masc_board_sub_board_update"
     | Board_vote -> "masc_board_vote"
-    | Broadcast -> "masc_broadcast"
-    | Check -> "masc_check"
-    | Claim_next -> "masc_claim_next"
-    | Cleanup_zombies -> "masc_cleanup_zombies"
-    | Dashboard -> "masc_dashboard"
-    | Deliver -> "masc_deliver"
-    | Goal_list -> "masc_goal_list"
-    | Goal_transition -> "masc_goal_transition"
-    | Goal_upsert -> "masc_goal_upsert"
-    | Goal_verify -> "masc_goal_verify"
-    | Heartbeat -> "masc_heartbeat"
-    | Messages -> "masc_messages"
-    | Note_add -> "masc_note_add"
-    | Operator_action -> "masc_operator_action"
-    | Operator_confirm -> "masc_operator_confirm"
-    | Operator_digest -> "masc_operator_digest"
-    | Operator_snapshot -> "masc_operator_snapshot"
-    | Plan_clear_task -> "masc_plan_clear_task"
-    | Plan_get -> "masc_plan_get"
-    | Plan_get_task -> "masc_plan_get_task"
-    | Plan_init -> "masc_plan_init"
-    | Plan_set_task -> "masc_plan_set_task"
-    | Plan_update -> "masc_plan_update"
-    | Reset -> "masc_reset"
-    | Status -> "masc_status"
-    | Task_history -> "masc_task_history"
-    | Tasks -> "masc_tasks"
-    | Tool_grant -> "masc_tool_grant"
-    | Tool_help -> "masc_tool_help"
-    | Tool_list -> "masc_tool_list"
-    | Tool_revoke -> "masc_tool_revoke"
-    | Transition -> "masc_transition"
-    | Update_priority -> "masc_update_priority"
-    | Web_fetch -> "masc_web_fetch"
-    | Web_search -> "masc_web_search"
-    | Approval_pending -> "masc_approval_pending"
-    | Approval_get -> "masc_approval_get"
-    | Config -> "masc_config"
-    | Gc -> "masc_gc"
-    | Get_metrics -> "masc_get_metrics"
-    | Mcp_session -> "masc_mcp_session"
-    | Pause -> "masc_pause"
-    | Resume -> "masc_resume"
-    | Start -> "masc_start"
-    | Tool_admin_snapshot -> "masc_tool_admin_snapshot"
-    | Tool_admin_update -> "masc_tool_admin_update"
-    | Tool_stats -> "masc_tool_stats"
   ;;
 
   let of_string = function
-    | "masc_add_task" -> Some Add_task
-    | "masc_agent_fitness" -> Some Agent_fitness
-    | "masc_agent_update" -> Some Agent_update
-    | "masc_agent_card" -> Some Agent_card
-    | "masc_agents" -> Some Agents
-    | "masc_batch_add_tasks" -> Some Batch_add_tasks
     | "masc_board_cleanup" -> Some Board_cleanup
     | "masc_board_comment" -> Some Board_comment
     | "masc_board_comment_vote" -> Some Board_comment_vote
@@ -200,77 +131,216 @@ module Masc = struct
     | "masc_board_sub_board_get" -> Some Board_sub_board_get
     | "masc_board_sub_board_list" -> Some Board_sub_board_list
     | "masc_board_sub_board_update" -> Some Board_sub_board_update
-    | "masc_broadcast" -> Some Broadcast
-    | "masc_check" -> Some Check
-    | "masc_claim_next" -> Some Claim_next
-    | "masc_cleanup_zombies" -> Some Cleanup_zombies
-    | "masc_dashboard" -> Some Dashboard
-    | "masc_deliver" -> Some Deliver
+    | _ -> None
+  ;;
+
+  let pp fmt t = Format.pp_print_string fmt (to_string t)
+end
+
+module Goal_name = struct
+  type t =
+    | Goal_list
+    | Goal_transition
+    | Goal_upsert
+    | Goal_verify
+
+  let to_string = function
+    | Goal_list -> "masc_goal_list"
+    | Goal_transition -> "masc_goal_transition"
+    | Goal_upsert -> "masc_goal_upsert"
+    | Goal_verify -> "masc_goal_verify"
+  ;;
+
+  let of_string = function
     | "masc_goal_list" -> Some Goal_list
     | "masc_goal_transition" -> Some Goal_transition
     | "masc_goal_upsert" -> Some Goal_upsert
     | "masc_goal_verify" -> Some Goal_verify
-    | "masc_heartbeat" -> Some Heartbeat
-    | "masc_messages" -> Some Messages
-    | "masc_note_add" -> Some Note_add
+    | _ -> None
+  ;;
+
+  let pp fmt t = Format.pp_print_string fmt (to_string t)
+end
+
+module Operator_name = struct
+  type t =
+    | Operator_action
+    | Operator_confirm
+    | Operator_digest
+    | Operator_snapshot
+
+  let to_string = function
+    | Operator_action -> "masc_operator_action"
+    | Operator_confirm -> "masc_operator_confirm"
+    | Operator_digest -> "masc_operator_digest"
+    | Operator_snapshot -> "masc_operator_snapshot"
+  ;;
+
+  let of_string = function
     | "masc_operator_action" -> Some Operator_action
     | "masc_operator_confirm" -> Some Operator_confirm
     | "masc_operator_digest" -> Some Operator_digest
     | "masc_operator_snapshot" -> Some Operator_snapshot
-    | "masc_plan_clear_task" -> Some Plan_clear_task
-    | "masc_plan_get" -> Some Plan_get
-    | "masc_plan_get_task" -> Some Plan_get_task
-    | "masc_plan_init" -> Some Plan_init
-    | "masc_plan_set_task" -> Some Plan_set_task
-    | "masc_plan_update" -> Some Plan_update
-    | "masc_reset" -> Some Reset
-    | "masc_status" -> Some Status
-    | "masc_task_history" -> Some Task_history
-    | "masc_tasks" -> Some Tasks
-    | "masc_tool_grant" -> Some Tool_grant
-    | "masc_tool_help" -> Some Tool_help
-    | "masc_tool_list" -> Some Tool_list
-    | "masc_tool_revoke" -> Some Tool_revoke
-    | "masc_transition" -> Some Transition
-    | "masc_update_priority" -> Some Update_priority
-    | "masc_web_fetch" -> Some Web_fetch
-    | "masc_web_search" -> Some Web_search
-    | "masc_approval_pending" -> Some Approval_pending
-    | "masc_approval_get" -> Some Approval_get
-    | "masc_config" -> Some Config
-    | "masc_gc" -> Some Gc
-    | "masc_get_metrics" -> Some Get_metrics
-    | "masc_mcp_session" -> Some Mcp_session
-    | "masc_pause" -> Some Pause
-    | "masc_resume" -> Some Resume
-    | "masc_start" -> Some Start
-    | "masc_tool_admin_snapshot" -> Some Tool_admin_snapshot
-    | "masc_tool_admin_update" -> Some Tool_admin_update
-    | "masc_tool_stats" -> Some Tool_stats
     | _ -> None
   ;;
 
+  let pp fmt t = Format.pp_print_string fmt (to_string t)
+end
+
+module Masc = struct
+  (* Domain tool-NAME operations (Task/Board/Goal/Operator) are owned by the
+     domain submodules above; [Masc.t] composes them rather than enumerating
+     each operation flat. The remaining variants are admin/lifecycle/misc
+     tool names that have no domain owner yet and stay flat here. *)
+  type t =
+    | Task of Task_name.t
+    | Board of Board_name.t
+    | Goal of Goal_name.t
+    | Operator of Operator_name.t
+    | Agent_fitness
+    | Agent_update
+    | Agent_card
+    | Agents
+    | Broadcast
+    | Check
+    | Cleanup_zombies
+    | Dashboard
+    | Deliver
+    | Heartbeat
+    | Messages
+    | Note_add
+    | Plan_clear_task
+    | Plan_get
+    | Plan_get_task
+    | Plan_init
+    | Plan_set_task
+    | Plan_update
+    | Reset
+    | Status
+    | Tool_grant
+    | Tool_help
+    | Tool_list
+    | Tool_revoke
+    | Web_fetch
+    | Web_search
+    | Approval_pending
+    | Approval_get
+    | Config
+    | Gc
+    | Get_metrics
+    | Mcp_session
+    | Pause
+    | Resume
+    | Start
+    | Tool_admin_snapshot
+    | Tool_admin_update
+    | Tool_stats
+
+  let to_string = function
+    | Task t -> Task_name.to_string t
+    | Board b -> Board_name.to_string b
+    | Goal g -> Goal_name.to_string g
+    | Operator o -> Operator_name.to_string o
+    | Agent_fitness -> "masc_agent_fitness"
+    | Agent_update -> "masc_agent_update"
+    | Agent_card -> "masc_agent_card"
+    | Agents -> "masc_agents"
+    | Broadcast -> "masc_broadcast"
+    | Check -> "masc_check"
+    | Cleanup_zombies -> "masc_cleanup_zombies"
+    | Dashboard -> "masc_dashboard"
+    | Deliver -> "masc_deliver"
+    | Heartbeat -> "masc_heartbeat"
+    | Messages -> "masc_messages"
+    | Note_add -> "masc_note_add"
+    | Plan_clear_task -> "masc_plan_clear_task"
+    | Plan_get -> "masc_plan_get"
+    | Plan_get_task -> "masc_plan_get_task"
+    | Plan_init -> "masc_plan_init"
+    | Plan_set_task -> "masc_plan_set_task"
+    | Plan_update -> "masc_plan_update"
+    | Reset -> "masc_reset"
+    | Status -> "masc_status"
+    | Tool_grant -> "masc_tool_grant"
+    | Tool_help -> "masc_tool_help"
+    | Tool_list -> "masc_tool_list"
+    | Tool_revoke -> "masc_tool_revoke"
+    | Web_fetch -> "masc_web_fetch"
+    | Web_search -> "masc_web_search"
+    | Approval_pending -> "masc_approval_pending"
+    | Approval_get -> "masc_approval_get"
+    | Config -> "masc_config"
+    | Gc -> "masc_gc"
+    | Get_metrics -> "masc_get_metrics"
+    | Mcp_session -> "masc_mcp_session"
+    | Pause -> "masc_pause"
+    | Resume -> "masc_resume"
+    | Start -> "masc_start"
+    | Tool_admin_snapshot -> "masc_tool_admin_snapshot"
+    | Tool_admin_update -> "masc_tool_admin_update"
+    | Tool_stats -> "masc_tool_stats"
+  ;;
+
+  let of_string s =
+    (* Domain submodules are tried first; their [of_string] returns [None] for
+       non-domain names, so a flat fallthrough resolves the remainder. The
+       string namespaces are disjoint, so order is irrelevant for correctness. *)
+    match Task_name.of_string s with
+    | Some t -> Some (Task t)
+    | None ->
+      match Board_name.of_string s with
+      | Some b -> Some (Board b)
+      | None ->
+        match Goal_name.of_string s with
+        | Some g -> Some (Goal g)
+        | None ->
+          match Operator_name.of_string s with
+          | Some o -> Some (Operator o)
+          | None ->
+            match s with
+            | "masc_agent_fitness" -> Some Agent_fitness
+            | "masc_agent_update" -> Some Agent_update
+            | "masc_agent_card" -> Some Agent_card
+            | "masc_agents" -> Some Agents
+            | "masc_broadcast" -> Some Broadcast
+            | "masc_check" -> Some Check
+            | "masc_cleanup_zombies" -> Some Cleanup_zombies
+            | "masc_dashboard" -> Some Dashboard
+            | "masc_deliver" -> Some Deliver
+            | "masc_heartbeat" -> Some Heartbeat
+            | "masc_messages" -> Some Messages
+            | "masc_note_add" -> Some Note_add
+            | "masc_plan_clear_task" -> Some Plan_clear_task
+            | "masc_plan_get" -> Some Plan_get
+            | "masc_plan_get_task" -> Some Plan_get_task
+            | "masc_plan_init" -> Some Plan_init
+            | "masc_plan_set_task" -> Some Plan_set_task
+            | "masc_plan_update" -> Some Plan_update
+            | "masc_reset" -> Some Reset
+            | "masc_status" -> Some Status
+            | "masc_tool_grant" -> Some Tool_grant
+            | "masc_tool_help" -> Some Tool_help
+            | "masc_tool_list" -> Some Tool_list
+            | "masc_tool_revoke" -> Some Tool_revoke
+            | "masc_web_fetch" -> Some Web_fetch
+            | "masc_web_search" -> Some Web_search
+            | "masc_approval_pending" -> Some Approval_pending
+            | "masc_approval_get" -> Some Approval_get
+            | "masc_config" -> Some Config
+            | "masc_gc" -> Some Gc
+            | "masc_get_metrics" -> Some Get_metrics
+            | "masc_mcp_session" -> Some Mcp_session
+            | "masc_pause" -> Some Pause
+            | "masc_resume" -> Some Resume
+            | "masc_start" -> Some Start
+            | "masc_tool_admin_snapshot" -> Some Tool_admin_snapshot
+            | "masc_tool_admin_update" -> Some Tool_admin_update
+            | "masc_tool_stats" -> Some Tool_stats
+            | _ -> None
+  ;;
+
   let is_board = function
-    | Board_cleanup
-    | Board_comment
-    | Board_comment_vote
-    | Board_curation_read
-    | Board_curation_submit
-    | Board_delete
-    | Board_get
-    | Board_hearths
-    | Board_list
-    | Board_post
-    | Board_profile
-    | Board_reaction
-    | Board_search
-    | Board_stats
-    | Board_sub_board_create
-    | Board_sub_board_delete
-    | Board_sub_board_get
-    | Board_sub_board_list
-    | Board_sub_board_update
-    | Board_vote -> true
+    | Board _ -> true
     | _ -> false
   ;;
 

--- a/lib/tool_name.mli
+++ b/lib/tool_name.mli
@@ -1,16 +1,29 @@
 (** Compile-time verified tool name identifiers.
 
     Use [of_string] at MCP/JSON parse boundaries only.
-    All internal code passes [t] values directly. *)
+    All internal code passes [t] values directly.
 
-module Masc : sig
+    PR-S1: domain tool *names* (Task/Board/Goal/Operator) are owned by the
+    submodules below; [Masc.t] composes them. Each submodule owns the complete
+    [masc_*] string for its operations. *)
+
+module Task_name : sig
   type t =
     | Add_task
-    | Agent_fitness
-    | Agent_update
-    | Agent_card
-    | Agents
     | Batch_add_tasks
+    | Claim_next
+    | Task_history
+    | Tasks
+    | Transition
+    | Update_priority
+
+  val to_string : t -> string
+  val of_string : string -> t option
+  val pp : Stdlib.Format.formatter -> t -> unit
+end
+
+module Board_name : sig
+  type t =
     | Board_cleanup
     | Board_comment
     | Board_comment_vote
@@ -31,23 +44,54 @@ module Masc : sig
     | Board_sub_board_list
     | Board_sub_board_update
     | Board_vote
-    | Broadcast
-    | Check
-    | Claim_next
-    | Cleanup_zombies
-    | Dashboard
-    | Deliver
+
+  val to_string : t -> string
+  val of_string : string -> t option
+  val pp : Stdlib.Format.formatter -> t -> unit
+end
+
+module Goal_name : sig
+  type t =
     | Goal_list
     | Goal_transition
     | Goal_upsert
     | Goal_verify
-    | Heartbeat
-    | Messages
-    | Note_add
+
+  val to_string : t -> string
+  val of_string : string -> t option
+  val pp : Stdlib.Format.formatter -> t -> unit
+end
+
+module Operator_name : sig
+  type t =
     | Operator_action
     | Operator_confirm
     | Operator_digest
     | Operator_snapshot
+
+  val to_string : t -> string
+  val of_string : string -> t option
+  val pp : Stdlib.Format.formatter -> t -> unit
+end
+
+module Masc : sig
+  type t =
+    | Task of Task_name.t
+    | Board of Board_name.t
+    | Goal of Goal_name.t
+    | Operator of Operator_name.t
+    | Agent_fitness
+    | Agent_update
+    | Agent_card
+    | Agents
+    | Broadcast
+    | Check
+    | Cleanup_zombies
+    | Dashboard
+    | Deliver
+    | Heartbeat
+    | Messages
+    | Note_add
     | Plan_clear_task
     | Plan_get
     | Plan_get_task
@@ -56,14 +100,10 @@ module Masc : sig
     | Plan_update
     | Reset
     | Status
-    | Task_history
-    | Tasks
     | Tool_grant
     | Tool_help
     | Tool_list
     | Tool_revoke
-    | Transition
-    | Update_priority
     | Web_fetch
     | Web_search
     | Approval_pending

--- a/lib/tool_resource_axis.ml
+++ b/lib/tool_resource_axis.ml
@@ -168,26 +168,32 @@ let classify_structured_shell_op args =
 
 let classify_masc_tool (tool : Tool_name.Masc.t) =
   let open Tool_name.Masc in
+  (* PR-S1: domain tool names moved to Task/Board/Goal/Operator submodules.
+     Resource classification is NON-uniform across each domain (e.g.
+     Board_post is Board_write but Board_list is Ungated), so this match stays
+     flat over [Masc.t] with each domain constructor mechanically wrapped —
+     bucket groupings are byte-for-byte unchanged from before the partition,
+     and the compiler still enforces exhaustiveness over every variant. *)
   match tool with
   | Web_fetch | Web_search -> Web
-  | Board_post
-  | Board_cleanup
-  | Board_comment
-  | Board_comment_vote
-  | Board_curation_submit
-  | Board_delete
-  | Board_reaction
-  | Board_sub_board_create
-  | Board_sub_board_delete
-  | Board_sub_board_update
-  | Board_vote -> Board_write
-  | Add_task
-  | Batch_add_tasks
-  | Claim_next
+  | Board Board_post
+  | Board Board_cleanup
+  | Board Board_comment
+  | Board Board_comment_vote
+  | Board Board_curation_submit
+  | Board Board_delete
+  | Board Board_reaction
+  | Board Board_sub_board_create
+  | Board Board_sub_board_delete
+  | Board Board_sub_board_update
+  | Board Board_vote -> Board_write
+  | Task Add_task
+  | Task Batch_add_tasks
+  | Task Claim_next
   | Deliver
-  | Goal_transition
-  | Goal_upsert
-  | Goal_verify
+  | Goal Goal_transition
+  | Goal Goal_upsert
+  | Goal Goal_verify
   | Heartbeat
   | Note_add
   | Plan_clear_task
@@ -197,46 +203,46 @@ let classify_masc_tool (tool : Tool_name.Masc.t) =
   | Reset
   | Tool_grant
   | Tool_revoke
-  | Transition
-  | Update_priority -> Workspace_write
+  | Task Transition
+  | Task Update_priority -> Workspace_write
   | Agent_update
   | Broadcast
   | Cleanup_zombies
   | Gc
-  | Operator_action
-  | Operator_confirm
+  | Operator Operator_action
+  | Operator Operator_confirm
   | Tool_admin_update -> Generic_write
   | Agent_card
   | Agent_fitness
   | Agents
   | Approval_get
   | Approval_pending
-  | Board_curation_read
-  | Board_get
-  | Board_hearths
-  | Board_list
-  | Board_profile
-  | Board_search
-  | Board_stats
-  | Board_sub_board_get
-  | Board_sub_board_list
+  | Board Board_curation_read
+  | Board Board_get
+  | Board Board_hearths
+  | Board Board_list
+  | Board Board_profile
+  | Board Board_search
+  | Board Board_stats
+  | Board Board_sub_board_get
+  | Board Board_sub_board_list
   | Check
   | Config
   | Dashboard
   | Get_metrics
-  | Goal_list
+  | Goal Goal_list
   | Mcp_session
   | Messages
-  | Operator_digest
-  | Operator_snapshot
+  | Operator Operator_digest
+  | Operator Operator_snapshot
   | Pause
   | Plan_get
   | Plan_get_task
   | Resume
   | Start
   | Status
-  | Task_history
-  | Tasks
+  | Task Task_history
+  | Task Tasks
   | Tool_admin_snapshot
   | Tool_help
   | Tool_list

--- a/lib/tool_task_schemas.ml
+++ b/lib/tool_task_schemas.ml
@@ -21,8 +21,10 @@ module Float = Stdlib.Float
 
     @since God file decomposition — extracted from tool_task.ml *)
 
-let masc_add_task_name = Tool_name.Masc.to_string Tool_name.Masc.Add_task
-let masc_claim_next_name = Tool_name.Masc.to_string Tool_name.Masc.Claim_next
+let masc_add_task_name =
+  Tool_name.Masc.to_string (Tool_name.Masc.Task Tool_name.Task_name.Add_task)
+let masc_claim_next_name =
+  Tool_name.Masc.to_string (Tool_name.Masc.Task Tool_name.Task_name.Claim_next)
 
 let schemas : Masc_domain.tool_schema list = [
   {

--- a/test/test_tool_name.ml
+++ b/test/test_tool_name.ml
@@ -17,26 +17,51 @@ let all_keeper : Tool_name.Keeper.t list =
   ; Voice_agent; Voice_listen; Voice_session_end; Voice_session_start
   ; Voice_sessions; Voice_speak ]
 
+(* PR-S1: Task/Board/Goal/Operator tool names are owned by domain submodules
+   and wrapped into [Masc.t] via the [Task]/[Board]/[Goal]/[Operator]
+   constructors. The remaining names stay flat. *)
 let all_masc : Tool_name.Masc.t list =
-  [ Add_task; Agent_fitness; Agent_update; Agent_card; Agents
-  ; Batch_add_tasks; Board_cleanup; Board_comment; Board_comment_vote
-  ; Board_curation_read; Board_curation_submit
-  ; Board_delete; Board_get; Board_hearths; Board_list; Board_post
-  ; Board_profile; Board_reaction; Board_search
-  ; Board_stats; Board_sub_board_create; Board_sub_board_delete
-  ; Board_sub_board_get; Board_sub_board_list; Board_sub_board_update
-  ; Board_vote; Broadcast; Check; Claim_next
-  ; Cleanup_zombies; Dashboard; Deliver
-  ; Goal_list; Goal_transition; Goal_upsert; Goal_verify
-  ; Heartbeat; Messages; Note_add
-  ; Operator_action; Operator_confirm; Operator_digest; Operator_snapshot
-  ; Plan_clear_task; Plan_get; Plan_get_task; Plan_init; Plan_set_task
-  ; Plan_update; Reset
-  ; Status; Task_history; Tasks; Tool_grant; Tool_help
-  ; Tool_list; Tool_revoke; Transition; Update_priority; Web_fetch; Web_search
-  ; Approval_pending; Approval_get; Config; Gc; Get_metrics; Mcp_session
-  ; Pause; Resume; Start; Tool_admin_snapshot; Tool_admin_update
-  ; Tool_stats ]
+  let open Tool_name in
+  [ Masc.Task Task_name.Add_task; Masc.Agent_fitness; Masc.Agent_update
+  ; Masc.Agent_card; Masc.Agents
+  ; Masc.Task Task_name.Batch_add_tasks
+  ; Masc.Board Board_name.Board_cleanup; Masc.Board Board_name.Board_comment
+  ; Masc.Board Board_name.Board_comment_vote
+  ; Masc.Board Board_name.Board_curation_read
+  ; Masc.Board Board_name.Board_curation_submit
+  ; Masc.Board Board_name.Board_delete; Masc.Board Board_name.Board_get
+  ; Masc.Board Board_name.Board_hearths; Masc.Board Board_name.Board_list
+  ; Masc.Board Board_name.Board_post
+  ; Masc.Board Board_name.Board_profile; Masc.Board Board_name.Board_reaction
+  ; Masc.Board Board_name.Board_search
+  ; Masc.Board Board_name.Board_stats
+  ; Masc.Board Board_name.Board_sub_board_create
+  ; Masc.Board Board_name.Board_sub_board_delete
+  ; Masc.Board Board_name.Board_sub_board_get
+  ; Masc.Board Board_name.Board_sub_board_list
+  ; Masc.Board Board_name.Board_sub_board_update
+  ; Masc.Board Board_name.Board_vote; Masc.Broadcast; Masc.Check
+  ; Masc.Task Task_name.Claim_next
+  ; Masc.Cleanup_zombies; Masc.Dashboard; Masc.Deliver
+  ; Masc.Goal Goal_name.Goal_list; Masc.Goal Goal_name.Goal_transition
+  ; Masc.Goal Goal_name.Goal_upsert; Masc.Goal Goal_name.Goal_verify
+  ; Masc.Heartbeat; Masc.Messages; Masc.Note_add
+  ; Masc.Operator Operator_name.Operator_action
+  ; Masc.Operator Operator_name.Operator_confirm
+  ; Masc.Operator Operator_name.Operator_digest
+  ; Masc.Operator Operator_name.Operator_snapshot
+  ; Masc.Plan_clear_task; Masc.Plan_get; Masc.Plan_get_task; Masc.Plan_init
+  ; Masc.Plan_set_task
+  ; Masc.Plan_update; Masc.Reset
+  ; Masc.Status; Masc.Task Task_name.Task_history; Masc.Task Task_name.Tasks
+  ; Masc.Tool_grant; Masc.Tool_help
+  ; Masc.Tool_list; Masc.Tool_revoke; Masc.Task Task_name.Transition
+  ; Masc.Task Task_name.Update_priority; Masc.Web_fetch; Masc.Web_search
+  ; Masc.Approval_pending; Masc.Approval_get; Masc.Config; Masc.Gc
+  ; Masc.Get_metrics; Masc.Mcp_session
+  ; Masc.Pause; Masc.Resume; Masc.Start; Masc.Tool_admin_snapshot
+  ; Masc.Tool_admin_update
+  ; Masc.Tool_stats ]
 
 let all_masc_keeper : Tool_name.Masc_keeper.t list =
   [ Clear; Compact; Create_from_persona; Down; List; Msg; Persona_audit; Repair


### PR DESCRIPTION
## 목표 (PR-S1)

Tool dispatch substrate가 도메인 tool 이름을 enumerate하지 않도록 만든다. 기존 `lib/tool_name.ml`의 73-variant god-enum `Tool_name.Masc`에서 Task/Board/Goal/Operator tool-NAME variant를 도메인 소유 name 서브모듈로 분리하고, `lib/tool_dispatch.ml`의 `static_tag_of_tool_name`에서 그 도메인 arm들을 제거한다.

## 설계 선택: Nested domain submodules (shape a)

`Tool_name`에 도메인 스코프 name 서브모듈을 만들고 `Masc.t`를 그 위의 sum으로 재구성:

```
module Task_name = struct type t = Add_task | Batch_add_tasks | Claim_next | ... end
module Board_name = struct type t = Board_cleanup | ... (20 variants) end
module Goal_name = struct type t = Goal_list | Goal_transition | Goal_upsert | Goal_verify end
module Operator_name = struct type t = Operator_action | ... end

module Masc = struct
  type t =
    | Task of Task_name.t
    | Board of Board_name.t
    | Goal of Goal_name.t
    | Operator of Operator_name.t
    | (나머지 flat admin/lifecycle/misc 이름들)
end
```

각 도메인 서브모듈이 자기 operation의 완전한 `masc_*` 문자열을 소유하고, `Masc.to_string`/`of_string`이 서브모듈 위로 compose한다.

### 근거 (rationale)

- **substrate가 도메인 이름을 더 이상 하드코딩하지 않음**: `static_tag_of_tool_name`의 도메인 arm들이 single tag arm으로 collapse (`Task _ -> Mod_task`, `Board _ -> Mod_inline`, `Goal _ -> Mod_state`, `Operator _ -> Mod_operator`). 분리 전 4개 도메인 모두 tag가 uniform이었으므로 이 collapse는 exact (downgrade 아님).
- **(b) incremental cut을 선택하지 않은 이유**: half-cut은 `static_tag`가 계속 enumerate하게 두므로 PR의 hard requirement(god-enum + static routing table 제거)를 만족하지 못함.
- **MCP tool-name 문자열 100% 보존**: 73/73 byte-identical (`to_string` 출력 set이 HEAD와 동일, 그리고 모든 출력이 `of_string`으로 parse back = round-trip closure 확인).

### NON-uniform consumer 보존-and-wrap (silent downgrade 방지)

risk/resource 분류는 도메인 내에서 non-uniform이므로(예: `Board_delete`=Critical, `Board_list`=Low) collapse하지 않고 flat match를 유지한 채 도메인 constructor만 기계적으로 wrap. bucket grouping은 byte-for-byte 동일하며 compiler가 여전히 exhaustiveness를 강제. wrapper-strip diff로 HEAD와 매핑 동일 검증:
- `governance_pipeline_risk.risk_of_masc` (Critical/High/Medium/Low 동일)
- `tool_resource_axis.classify_masc_tool` (Web/Board_write/Workspace_write/Generic_write/Ungated 동일)
- `tool_catalog_inference.inferred_effect_domain_of_typed_tool_name` (Host_repo_write/Read_only/Masc_workspace 동일)

`tool_catalog_inference.tool_group_of_typed_tool_name`은 이 함수 내에서 도메인이 uniform이라(Board→Masc_board, Task/Goal/Operator→Masc_core) collapse.

## 변경 파일

substrate / 타입:
- `lib/tool_name.ml`, `lib/tool_name.mli` — 4개 도메인 서브모듈 + 재구성된 `Masc.t` (`.mli` lockstep)
- `lib/tool_dispatch.ml` — `static_tag_of_tool_name` 도메인 arm collapse

consumer (constructor / exhaustive-match migration):
- `lib/governance_pipeline_risk.ml`, `lib/tool_resource_axis.ml`, `lib/tool_catalog_inference.ml`
- `lib/keeper/agent_tool_board_runtime.ml` (`dispatch_board`이 이제 `Board_name.t`를 직접 받음 — board runtime이 god-enum 대신 도메인 타입을 사용)
- `lib/keeper/keeper_tool_policy.ml`, `lib/keeper/keeper_tool_capability_axis.ml`, `lib/keeper/keeper_tool_progress.ml`, `lib/keeper/keeper_tool_registry.ml`
- `lib/tool_task_schemas.ml`, `lib/tool_inline_dispatch_workspace.ml`, `lib/server/server_bootstrap_loops.ml`
- `test/test_tool_name.ml` — `all_masc`를 새 shape로 (Keeper/Masc_keeper 깨짐은 #19797 pre-existing baseline으로 남김)

## @check 검증 (before/after)

main은 BROKEN 상태(#19797 Runtime⊥Keeper + stale test 잔재). `dune build @check --root .` 기준:

- **before (origin/main baseline): 22 errors**
- **after: 22 errors**
- **error file set이 baseline과 IDENTICAL** — 무관 파일에 net-zero. 새 error 파일 0건. 내가 건드린 13개 lib 파일 모두 clean 컴파일.

CI가 아닌 `@check`로 검증한 이유: broken main에서 CI는 `Detect Changed Surfaces` gate에 걸려 `Build and Test`가 SKIP됨.

## 후속 (unblocks)

이 PR은 PR-S3 (Tool.t library) → LANE 3 (Runtime/Telemetry/Operator)를 unblock한다.

RFC-WAIVED: 순수 타입 partition 리팩토링. credential/identity/operator-control/sandbox subsystem 미변경(touched keeper_tool_* 파일은 RFC-required 목록 밖). 동작 보존(string round-trip + risk/resource 매핑 byte-identical)으로 검증. 상위 plan: `docs/plans/masc-mcp-tool-domain-decouple.html` LANE 2 PR-S1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
