### PR TITLE
refactor(board): invert Thompson_sampling mega-lib edges -> leaf (unblocks Board)

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -576,6 +576,9 @@
    masc_turn
    ;; Agent token-ledger domain (extracted leaf — earn/spend/balance, Board-callable)
    masc_agent_economy
+   ;; Thompson Sampling agent selection (extracted leaf — Agent_health/Prometheus
+   ;; edges inverted to callbacks; Board-callable record_vote without mega-lib cycle)
+   masc_thompson
    ;; Environment configuration (extracted sub-library)
    masc_mcp.config
    masc_mcp.ide

--- a/lib/thompson/dune
+++ b/lib/thompson/dune
@@ -1,0 +1,36 @@
+(include_subdirs no)
+
+;; Thompson_sampling — Beta-distribution agent selection with starvation
+;; prevention and vote/quality feedback. Carved out of the masc_mcp
+;; mega-library so the Board domain can depend on Thompson_sampling.record_vote
+;; without forcing a Board <-> mega-lib cycle.
+;;
+;; PR-AE (#19826) extracted Agent_economy but could NOT take Thompson along:
+;; Thompson had two load-bearing edges to mega-lib-root modules —
+;; Agent_health.is_healthy and Prometheus.inc_counter. Both have been
+;; inverted via dependency injection: [select_with_feedback] now takes
+;; [~is_healthy] (required) and [?on_priority_selected] (no-op default).
+;; The coupling moved to the call site of [select_with_feedback] (today
+;; test-only); Thompson itself depends only on the neutral libraries below.
+;;
+;; Post_verifier (used by [record_quality_signal]) is NOT a mega-lib edge —
+;; it already lives in the leaf masc_mcp.tool_call_quality_benchmark library
+;; (deps: yojson + masc_core + time_compat, no cycle back to Thompson), so it
+;; is kept as a normal library dependency rather than callback-inverted.
+;;
+;; (wrapped false) keeps the bare `Thompson_sampling` module name so call
+;; sites stay `Thompson_sampling.*`.
+(library
+ (name masc_thompson)
+ (public_name masc_mcp.masc_thompson)
+ (wrapped false)
+ (libraries
+  masc_core
+  masc_config
+  masc_log
+  masc_workspace
+  fs_compat
+  time_compat
+  masc_mcp.tool_call_quality_benchmark
+  yojson
+  eio))

--- a/lib/thompson/thompson_sampling.ml
+++ b/lib/thompson/thompson_sampling.ml
@@ -156,8 +156,15 @@ let trigger_bypasses_health = function
   | Mentioned _ -> true
   | ContentAlert _ | Scheduled | Starved | Thompson -> false
 
-let is_trigger_eligible ~agent_name trigger =
-  trigger_bypasses_health trigger || Agent_health.is_healthy ~agent_name
+(* [is_healthy] is injected by the caller of [select_with_feedback]
+   (dependency inversion). Previously this called [Agent_health.is_healthy]
+   directly, coupling this module to the masc_mcp mega-library root. The
+   caller now supplies the health predicate so this module stays a clean
+   leaf. Required (not optional) — a permissive default would silently make
+   every agent eligible if a caller forgot to wire health (CLAUDE.md
+   "Unknown -> Permissive Default" anti-pattern). *)
+let is_trigger_eligible ~is_healthy ~agent_name trigger =
+  trigger_bypasses_health trigger || is_healthy ~agent_name
 
 let normalized_subscore value =
   Float.max 0.0 (Float.min 0.999 value)
@@ -455,7 +462,16 @@ let record_quality_signal ~agent_name ~(verdict : Post_verifier.verdict) =
 
 (** {1 Selection Algorithm} *)
 
-let select_with_feedback ~agents ~max_n ~pending_triggers ~tick_interval_s =
+(* [on_priority_selected] is an injected observability hook for the
+   priority-trigger selection path. Previously this site called
+   [Prometheus.inc_counter] directly, coupling this module to the masc_mcp
+   mega-library root. Defaulted to a no-op (observability, not behavior) so
+   non-instrumented callers stay simple; an instrumented caller supplies the
+   real Prometheus increment. *)
+let select_with_feedback
+    ~is_healthy
+    ?(on_priority_selected = fun ~agent_name:_ ~trigger_label:_ -> ())
+    ~agents ~max_n ~pending_triggers ~tick_interval_s () =
   (* Drain any pending votes so Beta posteriors reflect recorded feedback
      before sampling. [record_vote] batches into [pending_votes], and
      without this flush the batched evidence never reaches [stats_table] —
@@ -493,7 +509,7 @@ let select_with_feedback ~agents ~max_n ~pending_triggers ~tick_interval_s =
     | Mentioned _ | ContentAlert _
       when List.length !selected < max_n
            && not (is_selected name)
-           && is_trigger_eligible ~agent_name:name trigger ->
+           && is_trigger_eligible ~is_healthy ~agent_name:name trigger ->
         let s = get_stats name in
         let ticks = ticks_since_selection ~stats:s ~tick_interval_s in
         let signal = starvation_bonus ~ticks in
@@ -512,8 +528,7 @@ let select_with_feedback ~agents ~max_n ~pending_triggers ~tick_interval_s =
           | ContentAlert _ -> "content_alert"
           | Scheduled | Starved | Thompson -> "other"
         in
-        Prometheus.inc_counter priority_trigger_selected_metric
-          ~labels:[ ("agent", name); ("trigger", trigger_label) ] ();
+        on_priority_selected ~agent_name:name ~trigger_label;
         add_selected {
           agent_name = name;
           trigger;
@@ -530,7 +545,7 @@ let select_with_feedback ~agents ~max_n ~pending_triggers ~tick_interval_s =
   let max_starvation = Env_config.AgentSelection.max_starvation_ticks in
   let starved = List.filter_map (fun name ->
     if is_selected name then None
-    else if not (is_trigger_eligible ~agent_name:name Starved) then None
+    else if not (is_trigger_eligible ~is_healthy ~agent_name:name Starved) then None
     else begin
       let s = get_stats name in
       let ticks = ticks_since_selection ~stats:s ~tick_interval_s in
@@ -563,7 +578,7 @@ let select_with_feedback ~agents ~max_n ~pending_triggers ~tick_interval_s =
 
     let candidates = List.filter_map (fun name ->
       if is_selected name then None
-      else if not (is_trigger_eligible ~agent_name:name Thompson) then begin
+      else if not (is_trigger_eligible ~is_healthy ~agent_name:name Thompson) then begin
         (* Unhealthy agents excluded from Thompson selection *)
         Log.Metrics.info "thompson sampling skipping %s (unhealthy)" name;
         None

--- a/lib/thompson/thompson_sampling.mli
+++ b/lib/thompson/thompson_sampling.mli
@@ -86,6 +86,16 @@ val init_agent : string -> unit
 
 (** Select agents using Thompson Sampling with starvation prevention.
 
+    @param is_healthy Injected health predicate (dependency inversion). The
+      caller supplies the agent-health check so this module stays a leaf and
+      does not depend on the masc_mcp mega-library root. Required: a default
+      would silently make every agent eligible. Production callers pass
+      [Agent_health.is_healthy].
+    @param on_priority_selected Injected observability hook fired once per
+      priority-trigger selection (Mentioned/ContentAlert), with the agent
+      name and trigger label ("mentioned" | "content_alert"). Defaults to a
+      no-op; an instrumented caller supplies the Prometheus increment for
+      [priority_trigger_selected_metric].
     @param agents List of agent names to consider
     @param max_n Maximum number of agents to select
     @param pending_triggers Priority triggers (Mentioned, ContentAlert).
@@ -93,10 +103,13 @@ val init_agent : string -> unit
     @param tick_interval_s Tick interval in seconds (for starvation calc)
     @return List of selection results, highest score first *)
 val select_with_feedback :
+  is_healthy:(agent_name:string -> bool) ->
+  ?on_priority_selected:(agent_name:string -> trigger_label:string -> unit) ->
   agents:string list ->
   max_n:int ->
   pending_triggers:(string * selection_trigger) list ->
   tick_interval_s:float ->
+  unit ->
   selection_result list
 
 (** {1 Feedback Updates} *)

--- a/test/deps/dune
+++ b/test/deps/dune
@@ -113,6 +113,9 @@
    ;; Agent token-ledger extracted to lib/agent_economy/ (masc_agent_economy).
    ;; Re-export so test code using bare Agent_economy.X resolves after the carve.
    (re_export masc_agent_economy)
+   ;; Thompson Sampling extracted to lib/thompson/ (masc_thompson). Re-export so
+   ;; test code using bare Thompson_sampling.X resolves after the carve.
+   (re_export masc_thompson)
    (re_export masc_types)
    (re_export mirage-crypto)
    (re_export mirage-crypto-rng)

--- a/test/test_heuristic_theatre_audit.ml
+++ b/test/test_heuristic_theatre_audit.ml
@@ -22,7 +22,10 @@
    rename or label reshape fails here before it reaches CI. *)
 
 module BC = Masc_mcp.Board_core_classify
-module TS = Masc_mcp.Thompson_sampling
+(* Thompson_sampling carved into the masc_thompson leaf (Agent_health/Prometheus
+   edges inverted); the metric-name constant is still exported. Reference the
+   bare module (re-exported via masc_test_deps) instead of Masc_mcp.*. *)
+module TS = Thompson_sampling
 module Prom = Masc_mcp.Prometheus
 
 let counter_value metric ~labels =

--- a/test/test_thompson_sampling.ml
+++ b/test/test_thompson_sampling.ml
@@ -3,6 +3,12 @@
 open Alcotest
 open Masc_mcp
 
+(* Production health predicate, injected into [select_with_feedback] after the
+   masc_thompson leaf carve inverted the direct [Agent_health.is_healthy] edge.
+   Wiring the *real* predicate here keeps the health-gate tests below exercising
+   identical behavior — the inversion changed plumbing, not the algorithm. *)
+let is_healthy = Agent_health.is_healthy
+
 (** {1 Beta Distribution Sampling Tests} *)
 
 let test_sample_beta_range () =
@@ -130,10 +136,12 @@ let test_vote_updates_alpha_beta () =
 
 let test_select_empty_agents () =
   let results = Thompson_sampling.select_with_feedback
+    ~is_healthy
     ~agents:[]
     ~max_n:3
     ~pending_triggers:[]
     ~tick_interval_s:14400.0
+    ()
   in
   check int "empty agents = empty selection" 0 (List.length results)
 
@@ -141,10 +149,12 @@ let test_select_respects_max_n () =
   let agents = ["agent-a"; "agent-b"; "agent-c"; "agent-d"; "agent-e"] in
   List.iter Thompson_sampling.init_agent agents;
   let results = Thompson_sampling.select_with_feedback
+    ~is_healthy
     ~agents
     ~max_n:2
     ~pending_triggers:[]
     ~tick_interval_s:14400.0
+    ()
   in
   check int "respects max_n" 2 (List.length results)
 
@@ -155,10 +165,12 @@ let test_select_mentioned_priority () =
     ("agent-y", Thompson_sampling.Mentioned "test mention")
   ] in
   let results = Thompson_sampling.select_with_feedback
+    ~is_healthy
     ~agents
     ~max_n:2
     ~pending_triggers:triggers
     ~tick_interval_s:14400.0
+    ()
   in
   (* Mentioned agent should be first *)
   check bool "mentioned agent selected" true
@@ -173,10 +185,12 @@ let test_select_content_alert_priority () =
     ("agent-r", Thompson_sampling.ContentAlert "urgent content")
   ] in
   let results = Thompson_sampling.select_with_feedback
+    ~is_healthy
     ~agents
     ~max_n:2
     ~pending_triggers:triggers
     ~tick_interval_s:14400.0
+    ()
   in
   check bool "content alert agent selected" true
     (List.exists (fun r -> r.Thompson_sampling.agent_name = "agent-r") results)
@@ -189,10 +203,12 @@ let test_stronger_trigger_replaces_weaker_duplicate () =
     ("agent-dupe", Thompson_sampling.Mentioned "mention");
   ] in
   let results = Thompson_sampling.select_with_feedback
+    ~is_healthy
     ~agents
     ~max_n:1
     ~pending_triggers:triggers
     ~tick_interval_s:14400.0
+    ()
   in
   let selected = List.hd results in
   match selected.Thompson_sampling.trigger with
@@ -210,10 +226,12 @@ let test_stronger_trigger_uses_winner_order () =
     ("agent-a", Thompson_sampling.Mentioned "mention-a");
   ] in
   let results = Thompson_sampling.select_with_feedback
+    ~is_healthy
     ~agents
     ~max_n:2
     ~pending_triggers:triggers
     ~tick_interval_s:14400.0
+    ()
   in
   let first = List.hd results in
   check string "winner ordering follows stronger trigger position" "agent-b" first.agent_name
@@ -293,10 +311,12 @@ let test_unhealthy_excluded_from_thompson () =
     Ah.record_failure ~agent_name:"hg-sick" ~reason:"test_fail"
   done;
   let results = Thompson_sampling.select_with_feedback
+    ~is_healthy
     ~agents:["hg-healthy"; "hg-sick"]
     ~max_n:2
     ~pending_triggers:[]
     ~tick_interval_s:60.0
+    ()
   in
   let has_sick = List.exists (fun r ->
     r.Thompson_sampling.agent_name = "hg-sick") results in
@@ -308,10 +328,12 @@ let test_mentioned_bypasses_health () =
     Ah.record_failure ~agent_name:"hg-mentioned" ~reason:"test_fail"
   done;
   let results = Thompson_sampling.select_with_feedback
+    ~is_healthy
     ~agents:["hg-mentioned"]
     ~max_n:1
     ~pending_triggers:[("hg-mentioned", Thompson_sampling.Mentioned "by-test")]
     ~tick_interval_s:60.0
+    ()
   in
   let selected = List.exists (fun r ->
     r.Thompson_sampling.agent_name = "hg-mentioned") results in
@@ -323,10 +345,12 @@ let test_content_alert_respects_health () =
     Ah.record_failure ~agent_name:"hg-alert" ~reason:"test_fail"
   done;
   let results = Thompson_sampling.select_with_feedback
+    ~is_healthy
     ~agents:["hg-alert"]
     ~max_n:1
     ~pending_triggers:[("hg-alert", Thompson_sampling.ContentAlert "needs-attention")]
     ~tick_interval_s:60.0
+    ()
   in
   let selected = List.exists (fun r ->
     r.Thompson_sampling.agent_name = "hg-alert") results in


### PR DESCRIPTION
## 목적

`Thompson_sampling`을 masc_mcp 메가-라이브러리 루트에 묶어두던 두 load-bearing 엣지를 의존성 주입(callback)으로 역전(invert)하여 `Thompson_sampling`을 중립 leaf로 만든다. PR-AE(#19826)가 `Agent_economy`를 추출하면서 `Thompson_sampling`을 같이 옮기지 못한 이유가 정확히 이 두 엣지였다.

## 역전한 두 엣지

| 엣지 | 위치(이전) | 역전 방식 |
|------|-----------|-----------|
| `Agent_health.is_healthy` | `thompson_sampling.ml:160` (`is_trigger_eligible`, `select_with_feedback`가 3곳에서 호출) | 호출자가 주입하는 `~is_healthy:(agent_name:string -> bool)` (**required** — permissive default 금지, CLAUDE.md "Unknown → Permissive Default" 안티패턴 회피) |
| `Prometheus.inc_counter` | `thompson_sampling.ml:515` (priority-trigger 선택 경로) | `?on_priority_selected:(agent_name:string -> trigger_label:string -> unit)`, 기본값 no-op (관측, 동작 아님) |

### `select_with_feedback` 새 시그니처

```ocaml
val select_with_feedback :
  is_healthy:(agent_name:string -> bool) ->
  ?on_priority_selected:(agent_name:string -> trigger_label:string -> unit) ->
  agents:string list ->
  max_n:int ->
  pending_triggers:(string * selection_trigger) list ->
  tick_interval_s:float ->
  unit ->
  selection_result list
```

### Post_verifier는 엣지가 아님

`record_quality_signal ~verdict:Post_verifier.verdict`는 메가-lib 엣지가 아니다. `Post_verifier`는 이미 leaf 라이브러리 `masc_mcp.tool_call_quality_benchmark`에 있고(deps: yojson + masc_core + time_compat, Thompson으로 돌아오는 cycle 없음), 따라서 callback이 아닌 일반 라이브러리 의존성으로 유지했다.

## 커플링이 이동한 위치 (정직한 기술)

커플링은 **`board_votes`가 아니라 `select_with_feedback`의 호출 지점으로 이동**한다. `board_votes.ml:133`은 `Thompson_sampling.record_vote`를 호출하는데, `record_vote`에는 메가-lib 엣지가 없다(엣지 둘 다 `select_with_feedback` 안에 있었다). `select_with_feedback`의 호출자는 **현재 테스트뿐**이며, 테스트가 production predicate `Agent_health.is_healthy`를 주입하는 identity wiring으로 동작을 그대로 보존한다.

부수 효과: production 호출자가 없고 기본값이 no-op이므로 priority-trigger Prometheus 카운터는 **설계상 dormant** 상태가 된다(`select_with_feedback` 경로에서 카운터가 증가하지 않음). `test_heuristic_theatre_audit`는 metric 이름 문자열과 baseline-zero만 핀하므로(별도 프로세스, 카운터 fire를 단언하지 않음) 영향 없다. instrumented 호출자가 생기면 `on_priority_selected`에 실제 Prometheus increment를 주입하면 된다.

## 이동

`lib/thompson_sampling.ml(+.mli)` → `lib/thompson/` = `masc_thompson` leaf 라이브러리.

- deps: `masc_core / masc_config / masc_log / masc_workspace / fs_compat / time_compat / masc_mcp.tool_call_quality_benchmark / yojson / eio` (전부 중립, cycle 없음)
- `lib/dune`: `masc_mcp → masc_thompson` 배선 (bare `Thompson_sampling.*` 호출부 유지)
- `test/deps/dune`: `(re_export masc_thompson)` 추가 (테스트가 bare `Thompson_sampling.X` 사용)
- `(wrapped false)`로 bare 모듈명 `Thompson_sampling` 유지 (agent_economy와 동일 패턴)

## 검증 (@check before/after)

main은 #19797 boundary cut 이후 BROKEN 상태(keeper/dashboard 사전-존재 에러). 그래서 CI가 아닌 `@check` + `.cmo` + green island로 검증.

| 검증 | 결과 |
|------|------|
| Green island `dune build lib/thompson/` | **EXIT=0** (leaf 컴파일, `.ml`↔`.mli` 일관) |
| `dune build @check` 에러 수 (before = origin/main baseline) | **22** |
| `dune build @check` 에러 수 (after) | **22** (byte-for-byte 동일 에러 셋, Thompson 관련 신규 에러 0) |
| 알고리즘 logic diff | dependency plumbing만 변경; `sample_gamma`/`sample_beta`/`starvation_bonus`/`priority_score`/sort comparators/`take`/`stable_sort` **character-identical** |
| API probe (test 호출 shape를 `masc_thompson`만 의존해 격리 컴파일) | **EXIT=0** (9개 테스트 호출부 + instrumented 형태 typecheck) |

## PR-B(Board) unblock

`Thompson_sampling`이 이제 중립 leaf이므로, 향후 `masc_board` 라이브러리가 Board↔메가-lib cycle 없이 `Thompson_sampling.record_vote`에 의존할 수 있다. (이 PR은 Board를 추출하지 않는다 — Thompson을 leaf로 만들어 Board 추출의 선행 차단을 푸는 것이 목적.)

RFC-WAIVED: 메가-lib leaf 추출(RFC-0056 계열의 mechanical decoupling)로, credential/identity/operator/sandbox/hooks subsystem을 건드리지 않음. tool-domain decouple 계획서(`docs/plans/masc-mcp-tool-domain-decouple.html`) PR-Thompson 트랙.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
