### PR TITLE
[refactor] persona⊥{model,runtime} + runtime.toml SSOT keeper-assignment (RFC-0211)

### DIFF
--- a/config/keepers/base.toml
+++ b/config/keepers/base.toml
@@ -9,7 +9,13 @@
 # disabling autoboot for this file. discover_keepers_toml still loads it
 # as a profile-defaults source for downstream keepers.
 autoboot_enabled = false
-runtime_id = "runpod_mtp.qwen-runpod"
+# persona⊥{model,runtime}: keeper TOML no longer carries a runtime/model
+# selection (the parser now fail-loud rejects `runtime_id`/`model` keys).
+# keeper→runtime assignment is the sole responsibility of runtime.toml
+# [[runtime.assignments]], keyed by keeper name. The former value here was
+# `runtime_id = "runpod_mtp.qwen-runpod"`; operators preserving that exact
+# routing must add the keeper(s) inheriting this base to runtime.toml
+# [[runtime.assignments]] (otherwise they fall back to [runtime].default).
 sandbox_profile = "docker"
 network_mode = "inherit"
 

--- a/docs/rfc/RFC-0206-runtime-concept-runtime-rebirth.md
+++ b/docs/rfc/RFC-0206-runtime-concept-runtime-rebirth.md
@@ -3,6 +3,7 @@
 - Status: Draft
 - Date: 2026-05-30
 - Supersedes 라우팅 레이어: RFC-0038(routing-intent), RFC-0041(group-item-hierarchy), RFC-0058 §Layer-4/5(routes/aliases), RFC-0181(routes+phonebook dual-SSOT)
+- Superseded (partial): binding-key id 형식(`id = "provider.model"`, §2)은 RFC-0211이 supersede — id는 masc에 opaque, OAS만 parser. single-binding 모델/fail-fast load/§2.1은 유지.
 - Builds on: RFC-0058(provider/model/binding 선언 스키마, Layers 1-3), keeper_meta_contract(HEAD; exhaustion 분류)
 - Context: PR #19536이 `lib/runtime*`(170+파일) 전면 삭제 + 빌드 의도적 broken. 본 RFC는 그 후속 "Runtime 구현 채우기"의 설계 SSOT.
 

--- a/docs/rfc/RFC-0207-per-keeper-runtime-routing-ordered-failover.md
+++ b/docs/rfc/RFC-0207-per-keeper-runtime-routing-ordered-failover.md
@@ -7,7 +7,11 @@ updated: 2026-06-01
 author: jeong-sik
 supersedes: []
 superseded_by: null
-related: ["0001", "0206"]
+superseded_sections:
+  - section: "§2"
+    by: "0211"
+    note: "Surface choice (persona model field as the single surface) is superseded by RFC-0211 (runtime.toml keeper-assignment SSOT). Part A routing mechanism stands."
+related: ["0001", "0206", "0211"]
 implementation_prs: []
 ---
 

--- a/docs/rfc/RFC-0211-persona-runtime-decouple-opaque-id-runtime-toml-ssot.md
+++ b/docs/rfc/RFC-0211-persona-runtime-decouple-opaque-id-runtime-toml-ssot.md
@@ -1,0 +1,364 @@
+---
+rfc: "0211"
+title: "Persona ⊥ {model, runtime}, opaque runtime id, runtime.toml keeper-assignment SSOT"
+status: Draft
+created: 2026-06-02
+updated: 2026-06-02
+author: jeong-sik
+supersedes: []
+related: ["0206", "0207", "0001"]
+implementation_prs: []
+---
+
+# RFC-0211 — Persona ⊥ {model, runtime}, opaque runtime id, runtime.toml keeper-assignment SSOT
+
+- Status: Draft. Pairs with an in-flight implementation branch
+  (`feat-keeper-persona-runtime-decouple`); this document is the design SSOT, the
+  implementation confirms the as-built TOML shape.
+- Date: 2026-06-02
+- Builds on: RFC-0206 (single-binding `Runtime`), RFC-0207 (per-keeper runtime
+  routing, Part A), RFC-0001 (silent-substitution anti-pattern).
+- Supersedes (partial): RFC-0207 §2 (surface choice), RFC-0206 (runtime id
+  format). See §9.
+
+## 0. Summary
+
+A keeper's runtime is decided in one place: the `runtime.toml` keeper→runtime
+assignment table. A persona carries no `model` and no `runtime` field. The masc
+core treats a runtime id as an opaque token — it dispatches on the id and never
+reads a provider or model out of it. The only component that parses an id into a
+provider/model/spec is OAS (the external `agent_sdk` opam package), at the
+TOML-binding boundary.
+
+This keeps RFC-0207's per-keeper routing mechanism (the dispatcher honours a
+per-keeper runtime selection, fail-fast on an unresolved id) and redirects the
+*source* that mechanism reads from: persona-`model` (RFC-0207 §2) becomes the
+`runtime.toml` keeper-assignment table. It also replaces RFC-0206's
+`"provider.model"` binding-key id with an opaque token, so that no masc core
+module can read provider identity out of an id.
+
+## 1. Problem
+
+Three coupled defects in the current main (SHA `8ed74a37c9`):
+
+1. **Persona leaks model.** The persona JSON reader populates
+   `keeper_profile_defaults.model` from a `model` key
+   (`keeper_types_profile.ml:249-250`). A persona — a declarative role/identity
+   description — should not name a provider-model. The persona *summary* type is
+   already clean (`Keeper_types_profile_persona.persona_summary` =
+   `persona_name; display_name; role; trait; profile_path; has_keeper_defaults`,
+   no model/runtime field); the leak is in the separate `keeper_profile_defaults`
+   blob the persona reader fills.
+
+2. **Runtime id is not opaque.** `Runtime.t.id` is the binding key
+   `"provider.model"` (RFC-0206; `runtime.mli:11,18,43-47`). `get_runtime_by_id`
+   resolves a runtime by parsing that string. Any masc consumer that splits the
+   id on `.` reads the provider out of the core, violating the masc ⊥
+   Model/Provider goal.
+
+3. **Two definitions of the runtime resolver disagree.**
+   `keeper_meta_contract.runtime_id_of_meta` is defined twice in the same file:
+
+   - line 648 (shadowed; zero call sites in the file), defaulting via
+     `Keeper_config.default_runtime_id ()`;
+   - line 750 (the binding the `.mli` exports), defaulting via
+     `Runtime.get_default_runtime_id ()`.
+
+   OCaml binds the later definition, so external callers reach line 750 and 648
+   is dead. But two live definitions disagreeing on the *default source* is
+   precisely the split-brain this RFC removes, observed in current code. The
+   shadow is a broken-main merge artifact; §6 records its removal.
+
+These are coupled: as long as the per-keeper runtime lives in the persona
+(RFC-0207 §2) and the id is a parseable `"provider.model"`, masc cannot be made
+provider-agnostic and the resolver source stays forkable.
+
+## 2. Concept model: persona → keeper → runtime.toml → OAS
+
+Four layers, each with one job, in dependency order:
+
+- **persona** — a *declarative idea*. A pure role/identity definition. Knows
+  nothing about model, provider, or runtime. This is the raw, unparsed input.
+- **keeper** — a *materialized* execution instance derived from a persona. The
+  runtime binding is injected at materialization time, read from the
+  `runtime.toml` keeper-assignment table. This is the parsed, runnable value.
+- **runtime.toml** — the *single source of truth*. It defines runtimes
+  (provider/model/binding declarations, RFC-0206 layers 1-3 + `[runtime].default`)
+  **and** the keeper→runtime assignment. Nothing else assigns a keeper a runtime.
+- **OAS** (`agent_sdk` opam package) — the *only parser*. It turns an opaque
+  runtime id (and the TOML provider/model/binding declarations) into a concrete
+  `Llm_provider.Provider_config.t`. masc holds the id and dispatches; OAS
+  resolves the id to an implementation.
+
+This is Alexis King's "parse, don't validate" applied across the whole system:
+the persona is the raw idea, the keeper is the parsed value, and parsing
+(id → provider/model/spec) happens exactly once, at the OAS boundary. The masc
+core stays in the unparsed (opaque-id) world and cannot accidentally read
+provider identity out of a token it was never meant to interpret.
+
+### 2.1 persona ⊥ {model, runtime}
+
+A persona TOML/JSON carries no `model` and no `runtime` key. Model-level
+differentiation (an analyst keeper on a larger model, a worker keeper on a
+smaller one) is expressed by *assigning different runtimes* in the
+keeper-assignment table, never by a persona naming a `provider.model`. A persona
+does not know which runtime it runs on; a keeper learns its runtime from
+`runtime.toml` at materialization. Per-keeper runtime differentiation remains
+fully supported — it just moves from the persona to the assignment table.
+
+### 2.2 opaque runtime id
+
+A runtime id is an opaque token to masc. masc compares ids for equality and
+dispatches on them; it does not parse them. The `[providers.*]`, `[models.*]`,
+and binding declarations in `runtime.toml` — and the id → provider/model/spec
+resolution — are the OAS-adapter boundary. `get_runtime_by_id` /
+`runtime_id_of_meta` perform opaque-id dispatch only and never inspect an
+internal provider or model.
+
+This matches the openclaw registry seam ("a lane label must carry no readable
+provider field"): the masc core deals in lanes; the OAS registry resolves a lane
+to an implementation. It is the same "parse, don't validate" discipline as §2,
+stated at the id level — masc holds an unparsed opaque token, OAS is the sole
+parser.
+
+## 3. Design
+
+### 3.1 Remove the persona model leak
+
+Delete the `model` field from `keeper_profile_defaults` and the persona-JSON
+reader that fills it (`keeper_types_profile.ml:249-250`). The persona summary
+type is already clean and is untouched.
+
+### 3.2 runtime.toml keeper-assignment table + parser
+
+`runtime.toml` gains a keeper→runtime assignment. Today the parser
+(`runtime_toml.ml`) reads only "layers 1-3 plus `[runtime].default`" and reserves
+the top-level namespaces `providers`, `models`, `runtime` (the routing
+namespaces `system`, `routes`, etc. are dropped, RFC-0206 §2). There is **no**
+keeper-assignment namespace today; this RFC adds one.
+
+The assignment maps each keeper name to a runtime id (an opaque token that must
+resolve to a materialized runtime, i.e. one of the binding keys the TOML
+declares). A keeper with no entry falls back to `[runtime].default` — a
+documented default, **not** a silent substitution (RFC-0001, RFC-0206 §2.1).
+
+The concrete table *shape* (a `[keeper_assignment]` table vs. a
+`[[keeper]]` array vs. an `assignment` key under `[runtime]`) is proposed below
+but **the as-built form is fixed in the implementation PR**, since the parallel
+implementation session owns the parser. Proposed shape, to be confirmed:
+
+```toml
+# runtime.toml
+[runtime]
+default = "<opaque-runtime-id>"
+
+# keeper → runtime assignment (one SSOT)
+[keeper_assignment]
+echo    = "<opaque-runtime-id>"
+analyst = "<opaque-runtime-id>"
+```
+
+The id values are opaque tokens. Whether the id remains the legacy
+`"provider.model"` string for one transition window, or moves to a separately
+declared `[runtime].<name>` token immediately, is an implementation decision
+(§7 staging); either way masc must not parse it.
+
+### 3.3 Redirect `runtime_id_of_meta` to the assignment table
+
+`runtime_id_of_meta` resolves a keeper's runtime from the `runtime.toml`
+keeper-assignment table instead of `keeper_profile_defaults.model`:
+
+- assignment has an entry for `meta.name` → that opaque id;
+- otherwise → `[runtime].default` (`Runtime.get_default_runtime_id ()`), not a
+  silent substitution.
+
+The duplicate definition (§1.3) collapses to one. The reconcile change-detector
+and the dashboard/operator status override (which RFC-0207 §3 kept reading from
+the same source as the dispatcher) read the same assignment table, so they
+cannot disagree — one surface, no reconcile storm (§4).
+
+### 3.4 Opaque id at the seam
+
+`Runtime.t.id` and `get_runtime_by_id` are treated by masc as opaque. The
+resolution of an id into `provider`/`model`/`provider_config` is owned by the
+OAS adapter (`runtime_adapter` / `agent_sdk`). The format change from
+`"provider.model"` to an opaque token (RFC-0206 supersede, §9) is the
+implementation's call on timing; the invariant this RFC fixes is *masc must not
+read provider/model out of an id*, independent of the exact token format.
+
+### Validation (fail-fast at dispatch, RFC-0206 §2.1)
+
+An assignment id is validated at dispatch, not startup: the driver calls
+`Runtime.get_runtime_by_id id`; an id that does not resolve to a materialized
+runtime returns `None`, and the driver returns an `Agent_sdk.Error.Internal`
+rather than silently substituting the default. A typo in the assignment table
+surfaces as a loud dispatch error on that keeper's first turn. This is the same
+fail-fast contract RFC-0207 §3 established; only the source of the id changes.
+
+## 4. Why one surface, and why no reconcile storm
+
+RFC-0207 §2 (lines 58-63) rejected adding a second per-keeper surface
+(`[llm_runtime.<keeper>]` alongside the persona `model` field) because the
+dispatcher would read one surface and the reconcile/status layer the other, with
+opposite precedence — flagging `runtime` drift on every ~30 s reconcile sweep, a
+re-sync write storm (cf. #10061).
+
+That argument is conditioned on **two surfaces coexisting**. This RFC does not
+add a second surface alongside the persona field; it **removes the persona
+`model` field entirely** and makes `runtime.toml` the sole surface. The
+load-bearing precondition is total removal of persona-`model` — if the persona
+field were left in place as a fallback, two surfaces would coexist and the
+RFC-0207 §2 storm argument would re-apply. With one surface, the dispatcher and
+the reconcile/status layer read the same assignment table; the change-detector
+(`runtime_changed`) is false unless the assignment table actually changed. No
+storm.
+
+This is why RFC-0211 supersedes RFC-0207 §2 rather than coexisting with it: the
+two designs cannot both hold. §2 says the single surface is the persona field;
+this RFC says the single surface is `runtime.toml`. Choosing this RFC requires
+deleting the persona field.
+
+## 5. Why opaque id
+
+**For (opaque token):**
+- The masc core becomes structurally unable to read provider/model from an id; a
+  consumer that splits the id on `.` no longer compiles against a meaningful
+  parse, removing a class of boundary violations at the type/usage level.
+- It aligns the runtime seam with the openclaw lane-label rule (no readable
+  provider field in a core label) — one consistent boundary across the system.
+- It localises provider knowledge to OAS, the one component that legitimately
+  needs real provider/model names.
+
+**Against / cost:**
+- An opaque id is not human-legible in logs and dashboards without a lookup
+  (`id → display`) through the runtime table. Operator-facing surfaces must
+  resolve the id for display, adding an indirection that the `"provider.model"`
+  string gave for free.
+- The transition has a window where some surfaces still treat the id as
+  `"provider.model"`; mixing the two interpretations during migration is a
+  correctness risk (§7 stages it explicitly, one interpretation at a time).
+- Equality-on-opaque-token loses the incidental ability to group runtimes by
+  provider prefix; any such grouping must move to OAS or to an explicit field.
+
+The format change from `"provider.model"` is RFC-0206's supersede (§9); RFC-0211
+fixes the invariant (masc does not parse the id) and defers the exact token
+encoding to the implementation.
+
+## 6. Dead duplicate: `runtime_id_of_meta`
+
+On SHA `8ed74a37c9`, `keeper_meta_contract.ml` defines `runtime_id_of_meta`
+twice (lines 648 and 750). The `.mli` exports one symbol; OCaml binds the later
+(750), and line 648 has zero call sites in the file (a grep of the 649-749 window
+finds no call). Line 648 is dead, shadowed, and defaults via a *different* source
+(`Keeper_config.default_runtime_id ()`) than the live 750
+(`Runtime.get_default_runtime_id ()`).
+
+This is a broken-main merge artifact (the file's recent history includes
+boundary-cut and remnant-clearing merges, #19797/#19806/#19729). The
+implementation removes line 648 as part of §3.3 (the surviving definition is
+rewritten to read the assignment table). Recorded here so the removal is not
+mistaken for a behaviour change: the live behaviour is line 750's; deleting 648
+is dead-code removal.
+
+## 7. Migration
+
+Staged so that exactly one id interpretation and one assignment source are live
+at each step. Fail-fast (RFC-0206 §2.1) is preserved throughout.
+
+1. **Add the `runtime.toml` keeper-assignment parser** (new namespace in
+   `runtime_toml.ml`). Parse-only; nothing reads it yet. Bad/unresolvable ids are
+   a load-time `Error` for the assignment table, consistent with the existing
+   layer-1-3 validation.
+2. **Redirect `runtime_id_of_meta`** to read the assignment table (§3.3),
+   defaulting to `[runtime].default`. Remove the dead duplicate (§6). At this
+   step both the persona `model` field and the assignment table can resolve an
+   id; the assignment table takes precedence, and the persona field is read by
+   nothing once the reader is removed.
+3. **Remove the persona-JSON model reader and the
+   `keeper_profile_defaults.model` field** (§3.1). After this step the persona
+   field is gone and `runtime.toml` is the sole surface (§4 precondition
+   satisfied).
+4. **Make the id opaque at the seam** (§3.4): keep the format change isolated to
+   the OAS adapter, so masc consumers never parse the id. The exact token
+   encoding (legacy `"provider.model"` retained vs. new opaque token) is fixed
+   here by the implementation.
+
+The consumer surface for step 2/3 is wide: `runtime_id_of_meta` is referenced by
+32 files on SHA `8ed74a37c9`, spanning the keeper (26), dashboard (3), operator
+(2), and the tool-call layer (1). Most are read-only consumers of the resolved
+id; they are unaffected by the source change as long as the resolved id and its
+fail-fast contract are unchanged. (RFC-0207's "12 callers" figure was a subset;
+the measured caller set is 32 files.)
+
+## 8. Tests
+
+- assignment table drives `runtime_id_of_meta` (an assigned keeper resolves to
+  its assigned id, not the default);
+- an unassigned keeper falls to `[runtime].default`;
+- an assignment id that does not resolve to a materialized runtime makes the
+  driver fail fast (`Internal`), not silently substitute the default
+  (RFC-0001 regression guard);
+- a persona with no `model` field (the new shape) materializes and routes
+  correctly via the assignment table;
+- the reconcile change-detector is false when only the persona file changes and
+  the assignment table is unchanged (no-storm guard for §4).
+
+Whole-program `dune build @check` and `dune build .` must be green. The
+fail-fast test is the load-bearing one: it proves the assignment source did not
+re-introduce a silent default.
+
+## 9. Supersede relationships
+
+- **RFC-0207 §2** ("There is only one surface: the persona `model` field") is
+  superseded. The single surface is `runtime.toml`'s keeper-assignment table, not
+  the persona field; the persona is model/runtime-agnostic (§2.1). RFC-0207's
+  per-keeper routing *mechanism* (Part A: dispatcher honours a per-keeper
+  selection, fail-fast on unresolved id, §3-§4) is **kept** — only the source the
+  mechanism reads changes. RFC-0207 §6 (Part B, ordered failover) is out of scope
+  and unchanged.
+- **RFC-0206** binding-key id format (`id = "provider.model"`) is superseded in
+  intent: the id is opaque to masc (§2.2, §5), parsed only by OAS. RFC-0206's
+  single-binding `Runtime` model, fail-fast load (§2.1), and "code does not know
+  provider/model names" principle are kept and strengthened by this RFC.
+
+RFC-0207 is only partially superseded (Part A stands); its `superseded_by` is not
+flipped wholesale. The §2-specific supersede is recorded in this RFC's frontmatter
+and in this section.
+
+## 10. Open items (implementation-dependent — not asserted here)
+
+- **As-built keeper-assignment TOML shape.** The §3.2 `[keeper_assignment]` shape
+  is a proposal. The parallel implementation session owns the parser; the
+  concrete table form (table vs. array vs. nested key) and key naming are fixed in
+  the implementation PR, not here.
+- **Opaque id encoding and transition window.** Whether the id stays the legacy
+  `"provider.model"` string for one window or moves to a new opaque token
+  immediately (§3.4, §7 step 4) is an implementation decision. This RFC fixes the
+  invariant (masc does not parse the id), not the encoding.
+- **OAS de-anonymization scope.** OAS is the sole parser and must know real
+  provider/model names; any anonymized provider labels inside the OAS parser are a
+  separate cleanup, scoped by an OAS change map, not by this RFC.
+
+## 11. Risks
+
+- **R1 (two-surface fallback re-opens the storm):** if step 3 (persona-`model`
+  removal) is skipped or partially done, the persona field and the assignment
+  table coexist and the RFC-0207 §2 reconcile storm re-applies (§4). Total
+  removal is the load-bearing precondition; do not leave the persona field as a
+  fallback.
+- **R2 (mixed id interpretation):** during the format transition, a surface that
+  still treats the id as `"provider.model"` while another treats it as opaque is a
+  correctness hazard. §7 stages one interpretation at a time; do not interleave.
+- **R3 (silent-default regression):** the assignment-table fallback must remain a
+  documented `[runtime].default`, never a silent substitution (RFC-0001). The §8
+  fail-fast test guards this; do not weaken it to accept a default on an
+  unresolved assignment id.
+- **R4 (parallel conflict):** the implementation runs in a separate worktree
+  editing `lib/`. This RFC touches `docs/rfc/` only. The two must not edit the
+  same files; the as-built shape (§10) flows from the implementation PR back into
+  this RFC, not the other way.
+- **R5 (frozen operator seam):** the exhaustion/blocker_class strings
+  (`keeper_meta_contract`, RFC-0206 §5) that operator dashboards parse are
+  unaffected by this change and must stay frozen; the id is not part of that seam,
+  but display surfaces that show the id must resolve an opaque id to a label
+  rather than print the raw token if legibility is required.

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -731,12 +731,16 @@ let effective_meta_result (meta : keeper_meta) : (keeper_meta, string) result =
   | Ok defaults -> effective_meta_of_profile_defaults defaults meta
 ;;
 
+(* persona⊥{model,runtime}: a keeper's runtime is assigned in runtime.toml
+   ([[runtime.assignments]], the sole SSOT), keyed by keeper name — NOT read
+   from the persona profile [model] field. An unassigned keeper falls to the
+   default runtime (the designed fallback; RFC-0206 §2.1 fail-fast still applies
+   to the default itself). The id is opaque here; only the OAS adapter parses
+   it. *)
 let runtime_id_of_meta (meta : keeper_meta) =
-  match Keeper_types_profile.load_keeper_profile_defaults_result meta.name with
-  | Ok { Keeper_types_profile.model = Some runtime_id; _ }
-    when String.trim runtime_id <> "" ->
-    String.trim runtime_id
-  | Ok _ | Error _ -> Runtime.get_default_runtime_id ()
+  match Runtime.runtime_id_for_keeper meta.name with
+  | Some runtime_id when String.trim runtime_id <> "" -> String.trim runtime_id
+  | Some _ | None -> Runtime.get_default_runtime_id ()
 ;;
 
 let proactive_cycle_outcome_to_string = function

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -635,22 +635,6 @@ let missing_required_sandbox_profile_error ~keeper_name
     manifest_hint
 ;;
 
-let runtime_id_of_profile_defaults
-    (defaults : Keeper_types_profile.keeper_profile_defaults) =
-  match defaults.model with
-  | Some runtime_id ->
-    let runtime_id = String.trim runtime_id in
-    if String.equal runtime_id "" then Keeper_config.default_runtime_id ()
-    else runtime_id
-  | None -> Keeper_config.default_runtime_id ()
-;;
-
-let runtime_id_of_meta (meta : keeper_meta) =
-  match Keeper_types_profile.load_keeper_profile_defaults_result meta.name with
-  | Ok defaults -> runtime_id_of_profile_defaults defaults
-  | Error _ -> Keeper_config.default_runtime_id ()
-;;
-
 let effective_meta_of_profile_defaults
     (defaults : Keeper_types_profile.keeper_profile_defaults)
     (meta : keeper_meta) : (keeper_meta, string) result =

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -138,18 +138,16 @@ let invalid_profile_defaults_error ~keeper_name detail =
     Printf.sprintf "invalid keeper profile for keeper %s: %s" keeper_name detail
 
 let effective_declarative_runtime_id
-    (defaults : Keeper_types_profile.keeper_profile_defaults)
+    (_defaults : Keeper_types_profile.keeper_profile_defaults)
     (meta : keeper_meta) =
-  (* [runtime_id]/[model] is the persona's per-keeper runtime selection
-     ("provider.model").  RFC-0207: this resolves from the SAME [defaults.model]
-     source as {!Keeper_meta_contract.runtime_id_of_meta} (the dispatcher), so
-     the declare/status view and the wire never disagree.  Do NOT re-fork this
-     onto a different source — divergence makes the reconcile change-detector
-     flag [runtime] every sweep (perpetual re-sync storm, cf. #10061). *)
-  match defaults.model, defaults.manifest_path with
-  | Some runtime_id, _ -> String.trim runtime_id
-  | None, Some _ -> (Keeper_config.default_runtime_id ())
-  | None, None -> String.trim (runtime_id_of_meta meta)
+  (* persona⊥{model,runtime}: the keeper's runtime is assigned in runtime.toml,
+     not in [defaults].  Delegate to {!Keeper_meta_contract.runtime_id_of_meta}
+     (the dispatcher) so the declare/status view and the wire share ONE source
+     by construction — divergence is structurally impossible, not convention-
+     enforced (prevents the reconcile re-sync storm, cf. #10061).  [_defaults]
+     is retained in the signature for caller call-sites but no longer carries a
+     runtime selection. *)
+  runtime_id_of_meta meta
 
 let resynced_tool_access
     (defaults : Keeper_types_profile.keeper_profile_defaults)

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -23,18 +23,15 @@ let workspace_surface_json (meta : keeper_meta) =
 ;;
 
 let effective_declarative_runtime_id
-      (defaults : keeper_profile_defaults)
+      (_defaults : keeper_profile_defaults)
       (meta : keeper_meta)
   =
-  (* RFC-0207: same [defaults.model] source as
-     {!Keeper_meta_contract.runtime_id_of_meta} (the dispatcher) and the
-     keeper_runtime.ml copy of this function — keep them on one source so the
-     status override view matches the wire.  Re-forking causes a re-sync storm
-     (cf. #10061). *)
-  match defaults.model, defaults.manifest_path with
-  | Some runtime_id, _ -> String.trim runtime_id
-  | None, Some _ -> (Keeper_config.default_runtime_id ())
-  | None, None -> String.trim (runtime_id_of_meta meta)
+  (* persona⊥{model,runtime}: the keeper's runtime is assigned in runtime.toml,
+     not in [_defaults].  Delegate to
+     {!Keeper_meta_contract.runtime_id_of_meta} (the dispatcher), matching the
+     keeper_runtime.ml copy, so the status override view and the wire share ONE
+     source by construction (no re-sync storm, cf. #10061). *)
+  runtime_id_of_meta meta
 ;;
 
 type override_field_detail =

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -177,6 +177,20 @@ let load_keeper_profile_defaults_from_persona name : keeper_profile_defaults =
               ~field:"per_provider_timeout"
               keeper_json
           in
+          (* persona⊥{model,runtime}: persona profiles do not own a
+             runtime/model selection — that lives in runtime.toml
+             ([[runtime.assignments]]), keyed by keeper name.  A [model] key in
+             persona JSON is ignored (mirrors the keeper TOML parser, which
+             rejects [keeper.model]).  Warn so an operator sees the stale key is
+             no longer honored. *)
+          (match Safe_ops.json_string_opt "model" keeper_json with
+           | Some raw ->
+               Log.Keeper.warn
+                 "persona profile %s has a [model] key (%s); ignored — \
+                  keeper->runtime assignment lives in \
+                  runtime.toml [[runtime.assignments]]"
+                 path raw
+           | None -> ());
           match keeper_json with
           | `Assoc _ ->
               {
@@ -246,22 +260,6 @@ let load_keeper_profile_defaults_from_persona name : keeper_profile_defaults =
                             path raw;
                           None
                       | None -> None));
-                (* persona⊥{model,runtime}: persona profiles do not own a
-                   runtime/model selection — that lives in runtime.toml
-                   ([[runtime.assignments]]), keyed by keeper name.  A [model]
-                   key in persona JSON is ignored (mirrors the keeper TOML
-                   parser, which rejects [keeper.model]).  Warn so an operator
-                   sees the stale key is no longer honored. *)
-                model =
-                  (match Safe_ops.json_string_opt "model" keeper_json with
-                   | Some raw ->
-                       Log.Keeper.warn
-                         "persona profile %s has a [model] key (%s); ignored — \
-                          keeper->runtime assignment lives in \
-                          runtime.toml [[runtime.assignments]]"
-                         path raw;
-                       None
-                   | None -> None);
                 models = None;
                 (* oas_env lives only in keeper TOML, not persona JSON —
                    persona profiles are a design-time artifact whereas

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -246,8 +246,22 @@ let load_keeper_profile_defaults_from_persona name : keeper_profile_defaults =
                             path raw;
                           None
                       | None -> None));
+                (* persona⊥{model,runtime}: persona profiles do not own a
+                   runtime/model selection — that lives in runtime.toml
+                   ([[runtime.assignments]]), keyed by keeper name.  A [model]
+                   key in persona JSON is ignored (mirrors the keeper TOML
+                   parser, which rejects [keeper.model]).  Warn so an operator
+                   sees the stale key is no longer honored. *)
                 model =
-                  Safe_ops.json_string_opt "model" keeper_json;
+                  (match Safe_ops.json_string_opt "model" keeper_json with
+                   | Some raw ->
+                       Log.Keeper.warn
+                         "persona profile %s has a [model] key (%s); ignored — \
+                          keeper->runtime assignment lives in \
+                          runtime.toml [[runtime.assignments]]"
+                         path raw;
+                       None
+                   | None -> None);
                 models = None;
                 (* oas_env lives only in keeper TOML, not persona JSON —
                    persona profiles are a design-time artifact whereas

--- a/lib/keeper/keeper_types_profile_defaults.ml
+++ b/lib/keeper/keeper_types_profile_defaults.ml
@@ -35,7 +35,11 @@ type keeper_profile_defaults = {
   per_provider_timeout : float option;
   always_approve : bool option;
   social_model : string option;
-  model : string option;
+  (* NB: there is no per-keeper [model]/[runtime_id] field. persona⊥
+     {model,runtime}: keeper→runtime assignment is the sole responsibility of
+     runtime.toml [[runtime.assignments]] (keyed by keeper name), resolved via
+     {!Runtime.runtime_id_for_keeper}.  Neither persona JSON nor keeper TOML
+     carries a runtime selection. *)
   models : string list option;
   (* Turn budget overrides. None = inherit env default
      (MASC_KEEPER_OAS_MAX_TURNS_PER_CALL / ..._SCHEDULED_AUTONOMOUS). *)
@@ -89,7 +93,6 @@ let empty_keeper_profile_defaults =
     per_provider_timeout = None;
     always_approve = None;
     social_model = None;
-    model = None;
     models = None;
     max_turns_per_call = None;
     max_turns_per_call_scheduled_autonomous = None;

--- a/lib/keeper/keeper_types_profile_defaults.mli
+++ b/lib/keeper/keeper_types_profile_defaults.mli
@@ -36,7 +36,8 @@ type keeper_profile_defaults = {
   per_provider_timeout : float option;
   always_approve : bool option;
   social_model : string option;
-  model : string option;
+  (* No per-keeper [model]/[runtime_id] field: keeper→runtime assignment lives
+     solely in runtime.toml [[runtime.assignments]] (persona⊥{model,runtime}). *)
   models : string list option;
   max_turns_per_call : int option;
   max_turns_per_call_scheduled_autonomous : int option;

--- a/lib/keeper/keeper_types_profile_toml.mli
+++ b/lib/keeper/keeper_types_profile_toml.mli
@@ -172,7 +172,6 @@ type keeper_profile_defaults =
   per_provider_timeout : float option;
   always_approve : bool option;
   social_model : string option;
-  model : string option;
   models : string list option;
   max_turns_per_call : int option;
   max_turns_per_call_scheduled_autonomous : int option;

--- a/lib/keeper/keeper_types_profile_toml_io.mli
+++ b/lib/keeper/keeper_types_profile_toml_io.mli
@@ -172,7 +172,6 @@ type keeper_profile_defaults =
   per_provider_timeout : float option;
   always_approve : bool option;
   social_model : string option;
-  model : string option;
   models : string list option;
   max_turns_per_call : int option;
   max_turns_per_call_scheduled_autonomous : int option;

--- a/lib/keeper/keeper_types_profile_toml_normalizers.mli
+++ b/lib/keeper/keeper_types_profile_toml_normalizers.mli
@@ -172,7 +172,6 @@ type keeper_profile_defaults =
   per_provider_timeout : float option;
   always_approve : bool option;
   social_model : string option;
-  model : string option;
   models : string list option;
   max_turns_per_call : int option;
   max_turns_per_call_scheduled_autonomous : int option;

--- a/lib/keeper/keeper_types_profile_toml_parser.ml
+++ b/lib/keeper/keeper_types_profile_toml_parser.ml
@@ -88,17 +88,26 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
                      raw))
         | None -> Ok ())
   in
-  let runtime_id_result =
-    let trimmed key =
+  (* persona⊥{model,runtime}: keeper TOML no longer carries a runtime/model
+     selection.  keeper→runtime assignment is the sole responsibility of
+     runtime.toml [[runtime.assignments]] (keyed by keeper name), resolved via
+     {!Runtime.runtime_id_for_keeper}.  Both the legacy [keeper.model] and the
+     (now removed) [keeper.runtime_id] keys are rejected at load — fail loud
+     rather than silently discard, pointing the operator at the new SSOT.
+     BREAKING: a keeper TOML still carrying [runtime_id] fails to load; migrate
+     its value to runtime.toml [[runtime.assignments]]. *)
+  let runtime_assignment_result =
+    let present key =
       match str key with
-      | None -> None
-      | Some raw ->
-        let value = String.trim raw in
-        if value = "" then None else Some value
+      | None -> false
+      | Some raw -> String.trim raw <> ""
     in
-    match trimmed "model", trimmed "runtime_id" with
-    | Some _, _ -> Error "removed keeper.model key. Use keeper.runtime_id."
-    | None, runtime_id -> Ok runtime_id
+    match present "model", present "runtime_id" with
+    | true, _ | _, true ->
+      Error
+        "keeper.model / keeper.runtime_id are removed. Assign the keeper's \
+         runtime in runtime.toml [[runtime.assignments]] (keyed by keeper name)."
+    | false, false -> Ok ()
   in
   let result =
     Result.bind result (fun () ->
@@ -114,14 +123,13 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
         | _ -> Ok ())
   in
   let result =
-    Result.bind result (fun () -> tool_access_defaults_result)
+    Result.bind result (fun () -> runtime_assignment_result)
   in
   let result =
-    Result.bind result (fun tool_access ->
-      Result.map (fun runtime_id_opt -> tool_access, runtime_id_opt) runtime_id_result)
+    Result.bind result (fun () -> tool_access_defaults_result)
   in
   Result.map
-    (fun (tool_access, runtime_id_opt) ->
+    (fun tool_access ->
       {
         id = None;
         manifest_path = None;
@@ -172,7 +180,6 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
         max_turns_per_call_scheduled_autonomous =
           int_ "max_turns_per_call_scheduled_autonomous";
         social_model = normalize_social_model_opt (str "social_model");
-        model = runtime_id_opt;
         models = None;
         oas_env = extract_oas_env_from_doc doc;
         unknown_toml_keys = [];
@@ -213,7 +220,6 @@ let parsed_field_key_names =
   ; "max_turns_per_call"
   ; "max_turns_per_call_scheduled_autonomous"
   ; "social_model"
-  ; "runtime_id"
   ]
 
 (** Canonical TOML key names used by [detect_unknown_keeper_toml_keys].
@@ -256,7 +262,6 @@ let canonical_keeper_toml_key_names =
   ; "max_turns_per_call"
   ; "max_turns_per_call_scheduled_autonomous"
   ; "social_model"
-  ; "runtime_id"
   ]
 
 let loader_level_keeper_toml_key_names = [ "base" ]
@@ -395,7 +400,6 @@ let merge_keeper_profile_defaults
     per_provider_timeout;
     always_approve = prefer overlay.always_approve base.always_approve;
     social_model = prefer overlay.social_model base.social_model;
-    model = prefer overlay.model base.model;
     models = None;
     max_turns_per_call = prefer overlay.max_turns_per_call base.max_turns_per_call;
     max_turns_per_call_scheduled_autonomous =

--- a/lib/keeper/keeper_types_profile_toml_parser.mli
+++ b/lib/keeper/keeper_types_profile_toml_parser.mli
@@ -172,7 +172,6 @@ type keeper_profile_defaults =
   per_provider_timeout : float option;
   always_approve : bool option;
   social_model : string option;
-  model : string option;
   models : string list option;
   max_turns_per_call : int option;
   max_turns_per_call_scheduled_autonomous : int option;

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -43,7 +43,35 @@ let of_binding (cfg : config) (b : binding) : t option =
     fail-fast: [\[runtime\] default] 가 없거나 그 id 가 목록에 없으면 [Error].
     silent fallback 일절 없음 (runtime→Runtime 비전: TOML 에 default 없으면
     프로그램 실행 불가). *)
-let load_list ~(config_path : string) : (t list * t, string) result =
+(* RFC keeper→runtime assignment validation: every [[runtime.assignments]]
+   target must resolve to a configured runtime. An unknown id is an operator
+   error rejected at load (mirrors [runtime].default validation), NOT a silent
+   fallback to the default — that would mask a typo'd assignment
+   (Unknown→Permissive anti-pattern). A keeper *absent* from the table is the
+   intended designed fallback to the default and is handled at lookup time, not
+   here. *)
+let validate_keeper_assignments ~(config_path : string) (runtimes : t list)
+    (assignments : (string * string) list) : (unit, string) result =
+  let runtime_exists id =
+    List.exists (fun (r : t) -> String.equal r.id id) runtimes
+  in
+  match
+    List.find_opt (fun (_, runtime_id) -> not (runtime_exists runtime_id)) assignments
+  with
+  | None -> Ok ()
+  | Some (keeper_name, runtime_id) ->
+    Error
+      (Printf.sprintf
+         "%s: [runtime.assignments].%s = %S not found among %d runtimes"
+         config_path
+         keeper_name
+         runtime_id
+         (List.length runtimes))
+;;
+
+let load_list ~(config_path : string)
+  : (t list * t * (string * string) list, string) result
+  =
   match Runtime_toml.parse_file config_path with
   | Error errs ->
     Error
@@ -53,6 +81,7 @@ let load_list ~(config_path : string) : (t list * t, string) result =
          (List.length errs))
   | Ok cfg ->
     let runtimes = List.filter_map (of_binding cfg) cfg.bindings in
+    let assignments = cfg.keeper_assignments in
     (match cfg.default_runtime_id with
      | None ->
        Error
@@ -62,19 +91,28 @@ let load_list ~(config_path : string) : (t list * t, string) result =
             config_path)
      | Some did ->
        (match List.find_opt (fun (r : t) -> String.equal r.id did) runtimes with
-        | Some rt -> Ok (runtimes, rt)
         | None ->
           Error
             (Printf.sprintf
                "%s: [runtime].default = %S not found among %d runtimes"
                config_path
                did
-               (List.length runtimes))))
+               (List.length runtimes))
+        | Some rt ->
+          (match validate_keeper_assignments ~config_path runtimes assignments with
+           | Error _ as e -> e
+           | Ok () -> Ok (runtimes, rt, assignments))))
 
 (* ---- Lazy default runtime singleton ---- *)
 
 let default_runtime_ref : t option ref = ref None
 let runtimes_ref : t list ref = ref []
+
+(* keeper name → runtime id ["provider.model"], from [[runtime.assignments]].
+   Populated by [init_default]; read by [runtime_id_for_keeper]. Validated at
+   load (every target resolves to a runtime), so a hit here is always a
+   configured runtime. *)
+let keeper_assignments_ref : (string * string) list ref = ref []
 
 let runtime_ids runtimes = List.map (fun (rt : t) -> rt.id) runtimes
 
@@ -102,9 +140,10 @@ let required_tool_runtime_ids runtimes =
 
 let init_default ~config_path =
   match load_list ~config_path with
-  | Ok (runtimes, rt) ->
+  | Ok (runtimes, rt, assignments) ->
     runtimes_ref := runtimes;
     default_runtime_ref := Some rt;
+    keeper_assignments_ref := assignments;
     Ok ()
   | Error _ as e -> e
 
@@ -112,6 +151,16 @@ let get_default_runtime () = !default_runtime_ref
 let get_runtimes () = !runtimes_ref
 let get_runtime_ids () = runtime_ids !runtimes_ref
 let get_required_tool_runtime_ids () = required_tool_runtime_ids !runtimes_ref
+
+(* RFC persona⊥{model,runtime}: keeper→runtime assignment is sourced from
+   [[runtime.assignments]] (runtime.toml SSOT), NOT from persona JSON or keeper
+   TOML. [None] = no explicit assignment; the caller falls back to
+   {!get_default_runtime_id}. The returned id is opaque (masc never parses it;
+   only the OAS adapter resolves it to provider/model/spec). Reads
+   [keeper_assignments_ref], never a module-level eager binding. *)
+let runtime_id_for_keeper (keeper_name : string) : string option =
+  List.assoc_opt keeper_name !keeper_assignments_ref
+;;
 
 (* RFC-0207: resolve a runtime by its binding-key id ["provider.model"].  The
    keeper turn driver dispatches to the *requested* runtime (a keeper's persona

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -17,7 +17,15 @@ type t =
 
 val id_of_binding : binding -> string
 val of_binding : config -> binding -> t option
-val load_list : config_path:string -> (t list * t, string) result
+
+val load_list :
+  config_path:string -> (t list * t * (string * string) list, string) result
+(** [load_list ~config_path] parses runtime.toml into [(runtimes, default,
+    keeper_assignments)]. Fails ([Error]) if [\[runtime\].default] is missing /
+    unresolved, or if any [\[runtime.assignments\]] target does not resolve to a
+    configured runtime (mirrors default validation — no silent fallback for a
+    typo'd assignment). [keeper_assignments] is the keeper→runtime-id list. *)
+
 val runtime_ids : t list -> string list
 
 val runtime_supports_required_tools : t -> bool
@@ -38,6 +46,14 @@ val get_default_runtime : unit -> t option
 val get_runtimes : unit -> t list
 val get_runtime_ids : unit -> string list
 val get_required_tool_runtime_ids : unit -> string list
+
+val runtime_id_for_keeper : string -> string option
+(** [runtime_id_for_keeper keeper_name] is the runtime id assigned to
+    [keeper_name] in [\[runtime.assignments\]] (runtime.toml SSOT), or [None]
+    when no explicit assignment exists (caller falls back to
+    {!get_default_runtime_id}). The id is opaque (only the OAS adapter parses
+    it). persona⊥{model,runtime}: keeper→runtime assignment is NOT sourced from
+    persona JSON or keeper TOML. *)
 
 val get_runtime_by_id : string -> t option
 (** [get_runtime_by_id id] is the materialized runtime whose binding-key id

--- a/lib/runtime/runtime_schema.ml
+++ b/lib/runtime/runtime_schema.ml
@@ -183,6 +183,15 @@ type config =
   ; models : model_spec list
   ; bindings : binding list
   ; default_runtime_id : string option
+  ; keeper_assignments : (string * string) list
+    (** [\[runtime.assignments\]] — keeper name → runtime id ["provider.model"].
+        runtime.toml is the sole SSOT for keeper→runtime assignment (persona⊥
+        {model,runtime}: persona JSON and keeper TOML no longer carry a runtime
+        selection). A keeper absent from this table routes to the default
+        runtime; an assignment to an unknown id is rejected at load
+        ({!Runtime.load_list}), mirroring [\[runtime\].default] validation. The
+        id is an opaque binding key here — only the OAS adapter parses it into
+        provider/model/spec. *)
   }
 [@@deriving show, eq]
 

--- a/lib/runtime/runtime_schema.mli
+++ b/lib/runtime/runtime_schema.mli
@@ -129,6 +129,12 @@ type config =
   ; models : model_spec list
   ; bindings : binding list
   ; default_runtime_id : string option
+  ; keeper_assignments : (string * string) list
+    (** [\[runtime.assignments\]] — keeper name → runtime id ["provider.model"].
+        Sole SSOT for keeper→runtime assignment (persona⊥{model,runtime}). A
+        keeper absent from this table routes to the default runtime; an
+        assignment to an unknown id is rejected at load. The id is an opaque
+        binding key (only the OAS adapter parses it into provider/model/spec). *)
   }
 [@@deriving show, eq]
 

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -524,11 +524,47 @@ let extract_after_all_errors_guard ~label = function
          label)
 ;;
 
+(* [[runtime.assignments]] — keeper name → runtime id ["provider.model"]. The
+   sole SSOT for keeper→runtime assignment (persona⊥{model,runtime}). Each
+   value must be a TOML string (an opaque runtime id resolved later against the
+   binding list at {!Runtime.load_list}). A non-string value is a parse error,
+   not a silent drop — an operator typo (e.g. an inline table) must fail loud
+   rather than route the keeper to the default. *)
+let parse_keeper_assignments (toml : Otoml.t)
+  : ((string * string) list, parse_error list) result
+  =
+  match Otoml.find_opt toml Fun.id [ "runtime"; "assignments" ] with
+  | None -> Ok []
+  | Some (Otoml.TomlTable entries | Otoml.TomlInlineTable entries) ->
+    let oks, errs =
+      List.partition_map
+        (fun (keeper_name, value) ->
+          match value with
+          | Otoml.TomlString runtime_id -> Left (keeper_name, runtime_id)
+          | _ ->
+            Right
+              { path = Printf.sprintf "runtime.assignments.%s" keeper_name
+              ; message = "keeper runtime assignment must be a string runtime id"
+              })
+        entries
+    in
+    if errs <> [] then Error errs else Ok oks
+  | Some _ ->
+    Error
+      [ { path = "runtime.assignments"
+        ; message = "[runtime.assignments] must be a table of keeper = runtime-id"
+        }
+      ]
+;;
+
 let parse_toml (toml : Otoml.t) : (Runtime_schema.config, parse_error list) result =
   let providers_result = parse_providers toml in
   let models_result = parse_models toml in
+  let assignments_result = parse_keeper_assignments toml in
   let errs = function Ok _ -> [] | Error errs -> errs in
-  let all_errors = errs providers_result @ errs models_result in
+  let all_errors =
+    errs providers_result @ errs models_result @ errs assignments_result
+  in
   let bindings = parse_bindings toml in
   let default_runtime_id =
     Otoml.find_opt toml Otoml.get_string [ "runtime"; "default" ]
@@ -540,7 +576,16 @@ let parse_toml (toml : Otoml.t) : (Runtime_schema.config, parse_error list) resu
       extract_after_all_errors_guard ~label:"providers" providers_result
     in
     let models = extract_after_all_errors_guard ~label:"models" models_result in
-    Ok { Runtime_schema.providers; models; bindings; default_runtime_id })
+    let keeper_assignments =
+      extract_after_all_errors_guard ~label:"assignments" assignments_result
+    in
+    Ok
+      { Runtime_schema.providers
+      ; models
+      ; bindings
+      ; default_runtime_id
+      ; keeper_assignments
+      })
 ;;
 
 let parse_string (content : string) : (Runtime_schema.config, parse_error list) result =

--- a/test/test_keeper_identity_parse.ml
+++ b/test/test_keeper_identity_parse.ml
@@ -37,9 +37,10 @@ let test_explicit_keeper_name_is_not_nickname_canonicalized () =
   | Error e -> fail ("expected Ok, got Error: " ^ e)
 
 let test_legacy_runtime_id_alias_tolerated () =
-  (* [runtime_id] is now only a legacy alias for pre-scrub persisted
-     payloads. It must remain readable while callers migrate to
-     [runtime_id]. *)
+  (* persona⊥{model,runtime}: a [runtime_id] key in a keeper meta JSON is not a
+     routing input — keeper→runtime assignment lives only in runtime.toml
+     [[runtime.assignments]] ({!Runtime.runtime_id_for_keeper}).  The key parses
+     (tolerated) but an unassigned keeper resolves to [runtime].default. *)
   let json =
     `Assoc
       [
@@ -52,10 +53,10 @@ let test_legacy_runtime_id_alias_tolerated () =
   in
   match Masc_test_deps.meta_of_json_fixture json with
   | Ok meta ->
-      check string "legacy alias collapses to default runtime"
+      check string "unassigned keeper resolves to default runtime"
         (Runtime.get_default_runtime_id ())
         (Keeper_meta_contract.runtime_id_of_meta meta)
-  | Error e -> fail ("expected legacy runtime_id alias to parse, got Error: " ^ e)
+  | Error e -> fail ("expected keeper meta runtime_id key to parse, got Error: " ^ e)
 
 let test_conflicting_runtime_id_and_legacy_runtime_id_rejected () =
   (* Dual-write migration must fail loud when the canonical [runtime_id]

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -623,9 +623,11 @@ let test_load_keeper_toml_inherits_base_defaults () =
       if Sys.file_exists base_path then Sys.remove base_path;
       if Sys.file_exists tmp_dir then Unix.rmdir tmp_dir)
     (fun () ->
+      (* persona⊥{model,runtime}: keeper TOML carries no runtime/model
+         selection (assignment lives in runtime.toml [[runtime.assignments]]).
+         Base inheritance is still exercised by sandbox_profile/network_mode. *)
       write_file base_path {|
 [keeper]
-runtime_id = "route.keeper_turn"
 sandbox_profile = "docker"
 network_mode = "inherit"
 |};
@@ -639,9 +641,6 @@ persona_name = "sangsu"
       | Error e -> fail e
       | Ok (name, defaults) ->
           check string "name from filename" "sangsu" name;
-          (* #19574: [runtime_id] is canonical; [model] is legacy storage. *)
-          check (option string) "base runtime_id" (Some "route.keeper_turn")
-            defaults.model;
           check (option string) "base sandbox" (Some "docker")
             (Option.map KTP.sandbox_profile_to_string defaults.sandbox_profile);
           check (option string) "base network" (Some "inherit")
@@ -857,7 +856,10 @@ max_turns_per_call_scheduled_autonomous = 0
        check int "zero autonomous falls back" 10
          (KTP.effective_max_turns_per_call_scheduled_autonomous d))
 
-let test_profile_accepts_runtime_id () =
+(* persona⊥{model,runtime}: keeper TOML no longer carries a runtime/model
+   selection; a [keeper.runtime_id] (or legacy [keeper.model]) key is rejected
+   at load, pointing the operator at runtime.toml [[runtime.assignments]]. *)
+let test_profile_rejects_runtime_id_key () =
   let input = {|
 [keeper]
 goal = "test"
@@ -867,12 +869,21 @@ runtime_id = "oas-coding_first"
   | Error e -> fail e
   | Ok doc ->
     (match KTP.profile_defaults_of_toml doc with
-     | Error e -> fail e
-     | Ok defaults ->
-       check (option string)
-         "runtime_id"
-         (Some "oas-coding_first")
-         defaults.model)
+     | Ok _ -> fail "expected error: keeper.runtime_id is removed"
+     | Error _ -> ())
+
+let test_profile_rejects_model_key () =
+  let input = {|
+[keeper]
+goal = "test"
+model = "oas-coding_first"
+|} in
+  match TL.parse_toml input with
+  | Error e -> fail e
+  | Ok doc ->
+    (match KTP.profile_defaults_of_toml doc with
+     | Ok _ -> fail "expected error: keeper.model is removed"
+     | Error _ -> ())
 
 let test_persona_resolver_omits_unspecified_tool_access () =
   with_personas_dir @@ fun personas_dir ->
@@ -1836,8 +1847,10 @@ let () =
             test_profile_rejects_removed_model_keys;
           test_case "rejects removed initiative keys" `Quick
             test_profile_rejects_removed_initiative_keys;
-          test_case "runtime_id parsed" `Quick
-            test_profile_accepts_runtime_id;
+          test_case "rejects keeper.runtime_id key" `Quick
+            test_profile_rejects_runtime_id_key;
+          test_case "rejects keeper.model key" `Quick
+            test_profile_rejects_model_key;
           test_case "max_turns overrides parsed and applied" `Quick
             test_profile_max_turns_overrides;
           test_case "max_turns defaults when absent" `Quick

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -1,17 +1,17 @@
-(* RFC-0207 — per-keeper LLM runtime routing via [runtime_id].
+(* Per-keeper LLM runtime routing via runtime.toml [[runtime.assignments]].
 
-   A keeper's keepers/<name>.toml [runtime_id = "provider.model"] is the single
-   surface for choosing its runtime.  [Keeper_meta_contract.runtime_id_of_meta]
-   resolves that selection (cached by
-   [Keeper_types_profile.load_keeper_profile_defaults]) so it reaches the turn
-   driver; an undeclared keeper falls through to [[runtime].default]; and the
-   driver's [Runtime.get_runtime_by_id] returns [None] for an id that does not
-   materialize, so dispatch fails fast (no silent substitution — RFC-0206 §2.1).
+   persona⊥{model,runtime}: runtime.toml is the sole SSOT for keeper→runtime
+   assignment, keyed by keeper name.  [Keeper_meta_contract.runtime_id_of_meta]
+   resolves a keeper's assignment via [Runtime.runtime_id_for_keeper] so it
+   reaches the turn driver; an unassigned keeper falls through to
+   [[runtime].default]; and the driver's [Runtime.get_runtime_by_id] returns
+   [None] for an id that does not materialize, so dispatch fails fast (no silent
+   substitution — RFC-0206 §2.1).
 
-   This is the SAME declarative runtime source as
-   [Keeper_runtime.effective_declarative_runtime_id] (declare/status), so there
-   is one surface — the dispatcher and the reconcile change-detector cannot
-   disagree. *)
+   This is the SAME runtime source as
+   [Keeper_runtime.effective_declarative_runtime_id] (declare/status), which
+   delegates to [runtime_id_of_meta], so there is one surface — the dispatcher
+   and the reconcile change-detector cannot disagree by construction. *)
 
 open Alcotest
 open Masc_mcp
@@ -60,13 +60,6 @@ let with_config_dir f =
       f config_dir)
 ;;
 
-let write_keeper_toml config_dir name body =
-  let keepers_dir = Filename.concat config_dir "keepers" in
-  (try Unix.mkdir keepers_dir 0o755 with
-   | Unix.Unix_error (Unix.EEXIST, _, _) -> ());
-  write_file (Filename.concat keepers_dir (name ^ ".toml")) body
-;;
-
 let make_meta name : KMC.keeper_meta =
   let json =
     `Assoc
@@ -81,11 +74,20 @@ let make_meta name : KMC.keeper_meta =
 ;;
 
 (* Runtime config materializing two bindings: the default ["runpod_mtp.qwen"]
-   and ["openai.gpt"] (used to prove [get_runtime_by_id] resolution). *)
+   and ["openai.gpt"] (used to prove [get_runtime_by_id] resolution).
+
+   persona⊥{model,runtime}: per-keeper routing is declared in
+   [[runtime.assignments]] (runtime.toml SSOT), keyed by keeper name — NOT in
+   keeper TOML.  [routingtest]/[budgettest] route to the non-default
+   [openai.gpt]; an unassigned keeper falls to [runtime].default. *)
 let runtime_config =
   {|
 [runtime]
 default = "runpod_mtp.qwen"
+
+[runtime.assignments]
+routingtest = "openai.gpt"
+budgettest = "openai.gpt"
 
 [providers.runpod_mtp]
 display-name = "RunPod"
@@ -131,14 +133,11 @@ let with_runtime_initialized f =
 
 (* ---- the per-keeper selection actually reaches the dispatcher ---- *)
 
-let test_runtime_id_drives_runtime_id_of_meta () =
-  with_config_dir (fun config_dir ->
-    write_keeper_toml config_dir "routingtest" {|[keeper]
-goal = "route to a non-default provider-model"
-runtime_id = "openai.gpt"
-|};
+let test_assignment_drives_runtime_id_of_meta () =
+  with_runtime_initialized (fun () ->
+    (* [routingtest] is assigned [openai.gpt] in [[runtime.assignments]]. *)
     Alcotest.(check string)
-      "declared keeper dispatches to its [runtime_id], not the global default"
+      "assigned keeper dispatches to its runtime.toml assignment, not the global default"
       "openai.gpt"
       (KMC.runtime_id_of_meta (make_meta "routingtest")))
 ;;
@@ -199,49 +198,41 @@ let test_context_budget_uses_selected_runtime () =
    projection labels (global, runtime-id-agnostic) would size against the
    default and admit oversized prompts for a per-keeper routed runtime. *)
 let test_of_meta_budgets_against_routed_runtime () =
-  with_config_dir (fun config_dir ->
-    write_keeper_toml config_dir "budgettest" {|[keeper]
-goal = "route to a smaller-context runtime"
-runtime_id = "openai.gpt"
-|};
-    with_runtime_initialized (fun () ->
-      let res =
-        Keeper_context_runtime.resolve_max_context_resolution_of_meta
-          (make_meta "budgettest")
-      in
-      Alcotest.(check int)
-        "of_meta budgets against routed runtime (openai.gpt=64000), not default (128000)"
-        64000
-        res.Keeper_context_runtime.effective_budget))
+  with_runtime_initialized (fun () ->
+    (* [budgettest] is assigned [openai.gpt] in [[runtime.assignments]]. *)
+    let res =
+      Keeper_context_runtime.resolve_max_context_resolution_of_meta
+        (make_meta "budgettest")
+    in
+    Alcotest.(check int)
+      "of_meta budgets against routed runtime (openai.gpt=64000), not default (128000)"
+      64000
+      res.Keeper_context_runtime.effective_budget)
 ;;
 
 let test_turn_budget_uses_routed_runtime () =
-  with_config_dir (fun config_dir ->
-    write_keeper_toml config_dir "budgettest" {|[keeper]
-goal = "route to a smaller-context runtime"
-runtime_id = "openai.gpt"
-|};
-    with_runtime_initialized (fun () ->
-      let budget =
-        Keeper_turn_runtime_budget.resolved_max_context_for_turn
-          ~meta:(make_meta "budgettest")
-      in
-      Alcotest.(check int)
-        "turn budget uses routed runtime, not runtime-id-agnostic labels"
-        64000
-        budget))
+  with_runtime_initialized (fun () ->
+    (* [budgettest] is assigned [openai.gpt] in [[runtime.assignments]]. *)
+    let budget =
+      Keeper_turn_runtime_budget.resolved_max_context_for_turn
+        ~meta:(make_meta "budgettest")
+    in
+    Alcotest.(check int)
+      "turn budget uses routed runtime, not runtime-id-agnostic labels"
+      64000
+      budget)
 ;;
 
 let () =
   Alcotest.run
     "runtime_per_keeper_routing"
-    [ ( "runtime-id routing"
+    [ ( "runtime-assignment routing"
       , [ Alcotest.test_case
-            "[runtime_id] drives runtime_id_of_meta"
+            "[runtime.assignments] drives runtime_id_of_meta"
             `Quick
-            test_runtime_id_drives_runtime_id_of_meta
+            test_assignment_drives_runtime_id_of_meta
         ; Alcotest.test_case
-            "undeclared keeper falls to [runtime].default"
+            "unassigned keeper falls to [runtime].default"
             `Quick
             test_undeclared_keeper_falls_to_default
         ] )

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -59,6 +59,7 @@ let test_runtime_adapter_keeps_auth_out_of_headers () =
     ; models = [ qwen_model ]
     ; bindings = [ runpod_binding ]
     ; default_runtime_id = Some "runpod_mtp.qwen"
+    ; keeper_assignments = []
     }
   in
   match Runtime_adapter.binding_to_provider_config cfg runpod_binding with
@@ -87,6 +88,7 @@ let test_runtime_adapter_filters_toml_auth_headers () =
     ; models = [ qwen_model ]
     ; bindings = [ runpod_binding ]
     ; default_runtime_id = Some "runpod_mtp.qwen"
+    ; keeper_assignments = []
     }
   in
   match Runtime_adapter.binding_to_provider_config cfg runpod_binding with
@@ -116,6 +118,7 @@ let provider_cfg () =
     ; models = [ qwen_model ]
     ; bindings = [ runpod_binding ]
     ; default_runtime_id = Some "runpod_mtp.qwen"
+    ; keeper_assignments = []
     }
   in
   match Runtime_adapter.binding_to_provider_config cfg runpod_binding with

--- a/test/test_runtime_required_tool_fallback.ml
+++ b/test/test_runtime_required_tool_fallback.ml
@@ -99,7 +99,7 @@ let with_runtime_config f =
 
 let load_runtimes path =
   match Runtime.load_list ~config_path:path with
-  | Ok (runtimes, _default_runtime) -> runtimes
+  | Ok (runtimes, _default_runtime, _assignments) -> runtimes
   | Error msg -> Alcotest.fail msg
 ;;
 


### PR DESCRIPTION
## 목표

persona를 역할/정체성(role/identity)만 담는 선언으로 되돌린다. persona는 `model`/`provider`/`runtime`을 모른다. keeper의 런타임 배정은 단일 SSOT — `runtime.toml`의 `[runtime.assignments]` keeper→runtime 테이블 — 에서만 결정된다. masc core는 runtime id를 opaque token으로 취급하고, id에서 provider/model을 읽지 않는다 (id 파싱은 OAS/`agent_sdk` 경계의 책임).

설계 근거 및 supersede 관계: **RFC-0211** (이 PR에 동봉).
- RFC-0207 §2 (surface = persona `model` 필드) supersede → source가 `runtime.toml` keeper-assignment 테이블로 이동. RFC-0207 Part A의 per-keeper 라우팅 *메커니즘*(per-keeper 선택을 dispatcher가 존중, 미해결 id는 fail-fast)은 유지된다.
- RFC-0206 runtime id 형식(`"provider.model"` binding-key) supersede → masc core 입장에서 opaque token. RFC-0206의 single-binding `Runtime` 모델 자체는 유지.

## 변경 (S1–S4)

**S1 — `runtime.toml` `[runtime.assignments]` 파서**
- `runtime_toml.ml`에 `parse_keeper_assignments` 추가: keeper name → runtime id 테이블 파싱. 비-string 값/비-table 형태는 typed error로 거부.
- `Runtime.runtime_id_for_keeper : string -> string option` — 명시적 배정이 있으면 그 runtime id, 없으면 `None`(호출자가 `[runtime].default`로 fallback). keeper→runtime 배정의 유일한 SSOT.

**S2 — `runtime_id_of_meta` resolve를 runtime.toml로 redirect + delegation-collapse**
- live `runtime_id_of_meta` resolve 경로가 persona `model`이 아니라 `runtime.toml` 배정을 읽도록 변경.
- `effective_declarative_runtime_id`의 delegation-collapse: 동일 runtime을 매 turn 재해석하던 reconcile 경로(#10061 storm의 구조적 조건)를 제거. one-surface 설계라 reconcile-storm 자체가 발생 불가.
- **dead-dup 제거**: `keeper_meta_contract.ml`에 중복 정의되어 있던 dead `runtime_id_of_meta` 정의 1개를 삭제(live resolve 경로는 유지). 두 정의가 같은 이름으로 공존하던 split을 닫는다.

**S3 — persona-JSON model reader 제거**
- persona JSON에서 model/runtime 선택을 읽던 reader 제거. persona는 더 이상 model/runtime을 carrier하지 않는다.

**S4 — keeper TOML `model`/`runtime_id` 필드 제거 + load-reject**
- `keeper_profile_defaults`의 `model` 필드 제거.
- keeper TOML 파서가 `model` / `runtime_id` 키 발견 시 fail-loud (silent-substitution 대신 명시적 에러 + 마이그레이션 안내). persona⊥{model,runtime} 불변식을 load 시점에 강제.

## 로컬 검증 (직접 측정)

- `dune build @check --root .` EXIT 후 `Error` 22개 — **전부 pre-existing broken-main(#19797 boundary-cut) 잔재**. 측정 SHA `b845a4a5b7`, base `8ed74a37c9`(origin/main).
  - 22개 에러 파일과 이 브랜치가 수정한 파일의 교집합 = **0** (`comm -12`로 확인). 에러는 `Tool_name.Masc_keeper` unbound, `per_provider_timeout_s` 필드 부재(base 8ed74a37c9에 이미 없음, 본 브랜치 미변경), `save_oas_checkpoint` 시그니처 drift, `Keeper_repo_mapping.credentials_for_keeper` unbound 등 — 모두 본 변경과 무관. → **net-zero** (신규 에러 0).
- `dune build lib/runtime/ --root .` EXIT=0 (isolated build green, 직접 측정).

## 미검증 (정직)

- **behavioral test 미실행**: broken main이 `masc_mcp` 링크를 막아 keeper/runtime behavioral 스위트를 빌드/실행할 수 없다. main green 복구 후 머지 SHA에서 재실행 필요. 이 PR은 그 전제에서 Draft로 유지한다.

## BREAKING (operator action 필요)

keeper TOML이 `runtime_id =` (또는 `model =`)을 보유하면 **load 실패**한다 (S4 fail-loud).

- **In-repo 케이스는 이 PR에서 해소**: 유일한 tracked 위반 파일 `config/keepers/base.toml`(line 12 `runtime_id = "runpod_mtp.qwen-runpod"`, profile-defaults loader source)의 해당 필드를 제거하고 마이그레이션 안내를 inline 주석으로 남겼다 (commit `1071139d11`). 이 PR 머지 후 repo의 tracked keeper TOML은 모두 새 파서로 load 가능. (전체 tracked `*.toml` 스캔 결과 `runtime_id=`/`model=` 키 잔존 0건 확인.)
- **operator 로컬 config는 수동 마이그레이션 필요**: gitignored `.masc/config/keepers/*.toml` 및 로컬 `runtime.toml`은 repo에 없으므로 operator가 직접 처리. 각 위반 keeper TOML에서 `runtime_id=`/`model=` 라인 제거.
  - 동일 routing 보존: 제거한 keeper(또는 base를 상속하는 keeper)를 로컬 `runtime.toml`의 `[runtime.assignments]`에 `<keeper> = "<runtime-id>"`로 명시. 명시 안 하면 `[runtime].default`로 fallback (default와 같은 runtime일 때만 라인 삭제만으로 behavior-preserving). `base.toml`의 기존 값은 `runpod_mtp.qwen-runpod`였으므로, 그 routing을 유지하려면 base를 상속하는 keeper들을 `[runtime.assignments]`에 등록해야 한다.
  - 주의: repo에 `runtime.toml`이 tracked되지 않아 `[runtime].default` 값을 PR에서 확인할 수 없다. "라인 삭제만으로 동일 routing"인지는 operator가 로컬 default 대조 후 판단할 것 (위 등록 절차가 안전한 기본).

## 후속 (이 PR 범위 밖)

- opaque id 마무리: `runtime.mli`의 id는 아직 `"provider.model"` encoding. OAS de-anonymize 작업과 합류하여 완전 opaque token으로 전환 예정 (RFC-0211 §9).

---

RFC-0211: `docs/rfc/RFC-0211-persona-runtime-decouple-opaque-id-runtime-toml-ssot.md`
RFC-0207 §2 supersede / RFC-0206 id-format supersede frontmatter 동봉.

이 PR은 워크어라운드를 **제거**한다(persona-model reconcile-storm / #10061 collapse 구조 삭제, typed load-reject 강화). 신규 워크어라운드 도입 없음.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
