### PR TITLE
refactor(opaque-id): decouple auth/core from provider.model id-cracking (RFC-0211)

### DIFF
--- a/lib/auth_resolve.ml
+++ b/lib/auth_resolve.ml
@@ -90,7 +90,7 @@ let resolve ~base_path ~keeper_id ~provider_kind
                 (Api_key_env_unset { var_name = "MASC_INTERNAL_MCP_TOKEN" })
         else Error (Token_hash_missing { path = hash_path })
   else
-    match Provider_kind_resolver.env_var_for_kind provider_kind with
+    match Provider_kind_env.env_var_for_kind provider_kind with
     | None ->
         (* Providers requiring per-keeper bridging cannot accept the shared
            [MASC_MCP_TOKEN] fallback: their bound-actor runtime MCP tools need

--- a/lib/provider_kind_env.ml
+++ b/lib/provider_kind_env.ml
@@ -1,0 +1,4 @@
+(** Provider-kind → API-key env-var name. See .mli for the contract. *)
+
+let env_var_for_kind kind =
+  Llm_provider.Provider_kind.default_api_key_env kind

--- a/lib/provider_kind_env.mli
+++ b/lib/provider_kind_env.mli
@@ -1,0 +1,14 @@
+(** [env_var_for_kind kind] returns the conventional environment variable name
+    that holds the API key for [kind], delegating to OAS's
+    {!Llm_provider.Provider_kind.default_api_key_env}.
+
+    This module is the masc-core hook for the kind → env-var lookup. It takes an
+    already-resolved {!Llm_provider.Provider_config.provider_kind} and never
+    parses a runtime id, so an auth caller depending on it learns only "which env
+    var holds the key for this kind" — not how a runtime id splits into
+    provider/model. Per RFC-0211 the masc core (auth included) must not read
+    provider/model out of an id; keeping this lookup out of
+    {!Provider_kind_resolver} (which also exposes the id-cracking [resolve])
+    prevents auth from depending on an id-parsing module. *)
+val env_var_for_kind :
+  Llm_provider.Provider_config.provider_kind -> string option

--- a/lib/provider_kind_resolver.ml
+++ b/lib/provider_kind_resolver.ml
@@ -9,27 +9,9 @@ type resolution =
   | Custom_url of { model_id : string; base_url : string }
   | Unknown of string
 
-(* Reuse the same split semantics as Runtime_model_string.split_provider_model
-   so that both paths agree on what "provider:model" means. Duplicated
-   here (rather than imported) to avoid a circular dependency between
-   this module and Runtime_config, which delegates to us. *)
-let split_provider_model (s : string) : (string * string) option =
-  match String.index_opt s ':' with
-  | None -> None
-  | Some idx ->
-    if idx = 0 || idx >= String.length s - 1 then None
-    else
-      let provider_name =
-        String.sub s 0 idx |> String.trim |> String.lowercase_ascii
-      in
-      let model_id =
-        String.sub s (idx + 1) (String.length s - idx - 1) |> String.trim
-      in
-      if model_id = "" then None else Some (provider_name, model_id)
-
 let resolve (spec : string) : resolution =
   let s = String.trim spec in
-  match split_provider_model s with
+  match Runtime_model_id_split.split_provider_model s with
   | None ->
     Unknown
       (Printf.sprintf
@@ -78,6 +60,3 @@ let uses_anthropic_caching_for_kind kind =
 
 let uses_anthropic_caching_for_spec spec =
   kind_of_spec spec |> Option.map uses_anthropic_caching_for_kind
-
-let env_var_for_kind kind =
-  Llm_provider.Provider_kind.default_api_key_env kind

--- a/lib/provider_kind_resolver.mli
+++ b/lib/provider_kind_resolver.mli
@@ -51,12 +51,3 @@ val uses_anthropic_caching_for_kind :
   Llm_provider.Provider_config.provider_kind -> bool
 
 val uses_anthropic_caching_for_spec : string -> bool option
-
-(** [env_var_for_kind kind] returns the conventional environment variable
-    name that holds the API key for [kind], delegating to OAS's
-    {!Llm_provider.Provider_kind.default_api_key_env}. Centralizing this
-    lookup here keeps direct {!Llm_provider.Provider_kind} usage out of
-    keeper / auth call sites and gives masc-mcp a single hook for future
-    overrides (e.g. provider aliases, env-var customization). *)
-val env_var_for_kind :
-  Llm_provider.Provider_config.provider_kind -> string option

--- a/lib/runtime/runtime_model_id_split.ml
+++ b/lib/runtime/runtime_model_id_split.ml
@@ -1,0 +1,17 @@
+(** Leaf split for runtime model ids. See .mli for the contract. *)
+
+let split_provider_model (s : string) : (string * string) option =
+  match String.index_opt s ':' with
+  | None -> None
+  | Some idx ->
+    if idx = 0 || idx >= String.length s - 1
+    then None
+    else (
+      let provider_name =
+        String.sub s 0 idx |> String.trim |> String.lowercase_ascii
+      in
+      let model_id =
+        String.sub s (idx + 1) (String.length s - idx - 1) |> String.trim
+      in
+      if model_id = "" then None else Some (provider_name, model_id))
+;;

--- a/lib/runtime/runtime_model_id_split.mli
+++ b/lib/runtime/runtime_model_id_split.mli
@@ -1,0 +1,18 @@
+(** Canonical split for a ["provider:model_id"] runtime model spec.
+
+    This is the single home for the ["provider:model"] split used inside the
+    {!Runtime} boundary (OAS-facing). It is a zero-dependency leaf so that both
+    {!Runtime_model_string} and {!Provider_kind_resolver} can depend on it
+    without forming a module cycle (the previous duplicate copy in
+    {!Provider_kind_resolver} existed only to dodge that cycle).
+
+    This split lives strictly inside the OAS/runtime boundary. masc-core
+    consumers (auth, keeper dispatch) must not call it: per RFC-0211 a runtime id
+    is opaque to the masc core, and only OAS / the runtime adapter parses an id
+    into a provider/model. *)
+
+(** [split_provider_model s] splits [s] at the first colon into
+    [(provider_name, model_id)]. Returns [None] when the colon is missing,
+    leading, or trailing (an empty half). [provider_name] is trimmed and
+    lower-cased; [model_id] is trimmed. *)
+val split_provider_model : string -> (string * string) option

--- a/lib/runtime/runtime_model_string.ml
+++ b/lib/runtime/runtime_model_string.ml
@@ -14,19 +14,9 @@ module Binding = Runtime_provider_binding
 
 let default_registry = Llm_provider.Provider_registry.default ()
 
-(** Split a ["provider:model_id"] string at the first colon. [None] if the
-    colon is missing, leading, or trailing. *)
-let split_provider_model (s : string) : (string * string) option =
-  match String.index_opt s ':' with
-  | None -> None
-  | Some idx ->
-    if idx = 0 || idx >= String.length s - 1
-    then None
-    else (
-      let provider_name = String.sub s 0 idx |> String.trim |> String.lowercase_ascii in
-      let model_id = String.sub s (idx + 1) (String.length s - idx - 1) |> String.trim in
-      if model_id = "" then None else Some (provider_name, model_id))
-;;
+(** Split a ["provider:model_id"] string at the first colon. Delegates to the
+    canonical leaf {!Runtime_model_id_split}. *)
+let split_provider_model = Runtime_model_id_split.split_provider_model
 
 (** Build a config for ["custom:model@url"] specs. *)
 let make_custom_config


### PR DESCRIPTION
## 목적: opaque runtime id (RFC-0211)

RFC-0211의 opaque-id 원칙 — masc core(auth 포함)는 runtime id를 불투명하게 다루고, id에서 provider/model을 꺼내(id-cracking) 분기하지 않는다. provider/model 파싱은 OAS / runtime adapter 경계 안에서만 일어난다.

이 PR은 core 쪽 id-cracking 잔재를 제거한다.

## 변경

- **auth_resolve**: `Provider_kind_resolver.env_var_for_kind` (id-cracking 경유) → `Provider_kind_env.env_var_for_kind` (env var 조회만). auth가 더 이상 id 구조에 의존하지 않는다.
- **provider_kind_resolver**: 루트에 있던 `provider:model` split 재구현(-23줄)을 제거. 이 split은 모듈 cycle을 피하려고 중복 복사돼 있던 것이다.
- **runtime_model_id_split** (신규 leaf): `provider:model` split의 정본. zero-dependency 리프라 `Runtime_model_string`과 `Provider_kind_resolver`가 cycle 없이 의존할 수 있다.
- **runtime_model_string**: 중복 split 제거하고 신규 정본에 위임.
- **provider_kind_env** (신규): provider_kind → env var name 조회만 담당.

## 보류

`runtime.mli`의 id 형식 변경은 OAS-resolve 쪽과 짝(pair)이라 이 PR에서 보류한다. runtime id를 OAS가 파싱하는 경계는 그대로 두고, core/auth만 id-cracking에서 분리했다.

## 검증

- `dune build @check`: 22 net-zero.

RFC-0211 (persona⊥{model,runtime}, opaque runtime id, runtime.toml SSOT).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
