### PR TITLE
ci: fix Tool_catalog path in meta audit

### DIFF
--- a/scripts/audit-hardcoding-truth.sh
+++ b/scripts/audit-hardcoding-truth.sh
@@ -72,10 +72,24 @@ echo "Head: $(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
 section "Typed Boundary Metadata"
 legacy_helper_pattern='is_main_''worktree_''boundary_''exempt'
 legacy_phrase_pattern='main-''worktree ''boundary|worktree ''boundary'
-legacy_boundary_matches="$(
-  rg -n "${legacy_helper_pattern}|${legacy_phrase_pattern}" \
-    lib/tool_catalog.ml lib/tool_catalog.mli 2>/dev/null || true
-)"
+tool_catalog_candidates=(
+  lib/tool/tool_catalog.ml
+  lib/tool/tool_catalog.mli
+  lib/tool_catalog.ml
+  lib/tool_catalog.mli
+)
+tool_catalog_files=()
+for file in "${tool_catalog_candidates[@]}"; do
+  [ -f "$file" ] && tool_catalog_files+=("$file")
+done
+
+legacy_boundary_matches=""
+if [ "${#tool_catalog_files[@]}" -gt 0 ]; then
+  legacy_boundary_matches="$(
+    rg -n "${legacy_helper_pattern}|${legacy_phrase_pattern}" \
+      "${tool_catalog_files[@]}" 2>/dev/null || true
+  )"
+fi
 if [ -n "$legacy_boundary_matches" ]; then
   mark_confirmed "legacy checkout follow-up helper surface still exists"
   printf '%s\n' "$legacy_boundary_matches"
@@ -83,7 +97,8 @@ else
   echo "PASS: legacy checkout follow-up helper surface is absent."
 fi
 
-if rg -q 'type effect_domain' lib/tool_catalog.ml lib/tool_catalog.mli; then
+if [ "${#tool_catalog_files[@]}" -gt 0 ] \
+  && rg -q 'type effect_domain' "${tool_catalog_files[@]}"; then
   echo "PASS: Tool_catalog exposes typed effect_domain metadata."
 else
   mark_confirmed "Tool_catalog lacks typed effect_domain metadata"


### PR DESCRIPTION
## Summary
- update scripts/audit-hardcoding-truth.sh to scan current Tool_catalog leaf paths
- keep legacy root Tool_catalog paths as candidates, but only pass existing files to ripgrep
- remove noisy missing-file rg warnings and restore Meta Guards typed effect_domain detection

## Validation
- bash -n scripts/audit-hardcoding-truth.sh
- bash scripts/audit-hardcoding-truth.sh --fail-on-confirmed
- git diff --check

## Context
- Follow-up for post-merge #19834 PR Sync Meta Guards failure.
- The failure was not from the new MASC domain ratchet; it was path drift after Tool_catalog moved to lib/tool/tool_catalog.ml{,mli}.