### PR TITLE
refactor(goal): move orphan task escalation to workspace adapter

### DIFF
--- a/lib/dashboard/dashboard_goals_types_accessor.ml
+++ b/lib/dashboard/dashboard_goals_types_accessor.ml
@@ -45,7 +45,9 @@ type attainment_unit =
   | Unknown
 
 let task_is_linked_to_goal (task : Masc_domain.task) goal_id =
-  Convergence.task_matches_goal ~goal_id task
+  match task.goal_id with
+  | Some task_goal_id -> String.equal task_goal_id goal_id
+  | None -> false
 
 let task_linkage_source_opt (task : Masc_domain.task) goal_id =
   match task.goal_id with

--- a/lib/goal/convergence.ml
+++ b/lib/goal/convergence.ml
@@ -9,6 +9,12 @@ type convergence_signal =
   | AllSubTasksDone of { completed : int; total : int }
   | StagnationDetected of { iterations_without_progress : int }
 
+type task_progress = {
+  goal_id : string option;
+  is_terminal : bool;
+  is_completed : bool;
+}
+
 let convergence_signal_to_yojson = function
   | MetricMet { metric; value; threshold } ->
       `Assoc
@@ -32,28 +38,23 @@ let convergence_signal_to_yojson = function
           ("iterations_without_progress", `Int iterations_without_progress);
         ]
 
-let task_has_goal_id ~goal_id (task : Masc_domain.task) =
-  match task.goal_id with
+let progress_matches_goal ~goal_id progress =
+  match progress.goal_id with
   | Some linked_goal_id -> String.equal linked_goal_id goal_id
   | None -> false
 
-let task_matches_goal ~goal_id (task : Masc_domain.task) =
-  task_has_goal_id ~goal_id task
-
-let is_terminal (task : Masc_domain.task) =
-  Masc_domain.task_status_is_terminal task.task_status
-
-let is_completed (task : Masc_domain.task) =
-  Masc_domain.task_status_is_done task.task_status
-
 let check_convergence ~goal_id ~tasks ?(stagnation_threshold = 5)
     ~iterations_without_progress () =
-  let goal_tasks = List.filter (task_matches_goal ~goal_id) tasks in
+  let goal_tasks = List.filter (progress_matches_goal ~goal_id) tasks in
   let total = List.length goal_tasks in
   if total = 0 then None
   else
-    let completed = List_util.count_if is_completed goal_tasks in
-    let all_terminal = List.for_all is_terminal goal_tasks in
+    let completed =
+      List_util.count_if (fun progress -> progress.is_completed) goal_tasks
+    in
+    let all_terminal =
+      List.for_all (fun progress -> progress.is_terminal) goal_tasks
+    in
     if all_terminal && completed = total then
       Some (AllSubTasksDone { completed; total })
     else if iterations_without_progress >= stagnation_threshold then

--- a/lib/goal/convergence.mli
+++ b/lib/goal/convergence.mli
@@ -12,12 +12,12 @@ type convergence_signal =
 (** Serialize a convergence signal to JSON. *)
 val convergence_signal_to_yojson : convergence_signal -> Yojson.Safe.t
 
-(** True when the task's structured [goal_id] field matches. *)
-val task_matches_goal : goal_id:string -> Masc_domain.task -> bool
-
-(** Alias for {!task_matches_goal}; retained for call sites that need the
-    predicate name to be explicit about structured linkage. *)
-val task_has_goal_id : goal_id:string -> Masc_domain.task -> bool
+(** Goal-local view of task progress supplied by the task/workspace owner. *)
+type task_progress = {
+  goal_id : string option;
+  is_terminal : bool;
+  is_completed : bool;
+}
 
 (** Check whether a goal's tasks have converged.
 
@@ -25,8 +25,8 @@ val task_has_goal_id : goal_id:string -> Masc_domain.task -> bool
     [None] when work is still in progress.
 
     @param goal_id  The goal whose tasks to evaluate.
-    @param tasks    All tasks in the workspace, filtered internally by explicit
-                    [task.goal_id].
+    @param tasks    Already-loaded task progress projections, filtered
+                    internally by explicit [goal_id].
     @param stagnation_threshold  Number of iterations without progress before
                                  emitting [StagnationDetected]. Defaults to [5].
     @param iterations_without_progress  Current count of iterations with no task
@@ -34,7 +34,7 @@ val task_has_goal_id : goal_id:string -> Masc_domain.task -> bool
                                         tracking this across invocations. *)
 val check_convergence :
   goal_id:string ->
-  tasks:Masc_domain.task list ->
+  tasks:task_progress list ->
   ?stagnation_threshold:int ->
   iterations_without_progress:int ->
   unit ->

--- a/lib/goal/dune
+++ b/lib/goal/dune
@@ -2,15 +2,10 @@
 
 ;; Goal domain — pure goal logic (store / phase / verification / convergence /
 ;; janitor). Decoupled from the masc_mcp mega-library: persistence goes through
-;; the already-separate masc_workspace library (Workspace_utils / Workspace_query),
-;; never the mega-lib Workspace facade. Dependency direction is one-way:
-;; consumers (workspace_goals adapter, dashboards) depend on masc_goal; masc_goal
-;; depends only on neutral libraries below.
-;;
-;; Known leak to flag (not a build blocker): goal_janitor uses
-;; Workspace_query.get_tasks_safe — Goal reaching into Task state. That is a
-;; semantic Goal<->Task boundary error to sever later (janitor is really an
-;; adapter, not pure Goal domain).
+;; the already-separate masc_workspace library (Workspace_utils), never the
+;; mega-lib Workspace facade. Dependency direction is one-way: consumers
+;; (workspace_goals adapter, dashboards) depend on masc_goal; masc_goal depends
+;; only on neutral libraries below.
 (library
  (name masc_goal)
  (public_name masc_mcp.masc_goal)

--- a/lib/goal/goal_janitor.ml
+++ b/lib/goal/goal_janitor.ml
@@ -5,7 +5,8 @@
     2. Stagnate: mark Active goals with no update for [stagnant_days] as Dropped.
     3. Orphan: invoke registered owner hooks to remove goal bindings
        that reference non-existent goals in the Goal Store.
-    4. Escalate: report stale unclaimed tasks that have no goal linkage.
+    4. Escalate: invoke task-owner hooks for stale unclaimed tasks that have
+       no goal linkage.
 
     @since 2.236.0 *)
 
@@ -104,64 +105,6 @@ let sweep_goals ~(config : sweep_config) (goals : Goal_store.goal list)
   (result, { purged = !purged; stagnated = !stagnated; orphans = 0;
              orphan_tasks = 0 })
 
-let task_age_seconds ?(now = Unix.gettimeofday ()) (task : Masc_domain.task) =
-  match parse_iso_ts task.created_at with
-  | None -> None
-  | Some created_at -> Some (int_of_float (max 0.0 (now -. created_at)))
-
-let task_has_current_goal_link ~valid_goal_ids (task : Masc_domain.task) =
-  match task.goal_id with
-  | Some goal_id -> List.mem goal_id valid_goal_ids
-  | None -> false
-
-let audit_unclaimed_goal_orphan_tasks ?(now = Unix.gettimeofday ())
-    ~valid_goal_ids ~min_age_seconds (tasks : Masc_domain.task list) =
-  tasks
-  |> List.filter_map (fun (task : Masc_domain.task) ->
-    match task.task_status, task.goal_id, task_age_seconds ~now task with
-    | Masc_domain.Todo, None, Some age_seconds
-      when age_seconds >= min_age_seconds
-           && not (task_has_current_goal_link ~valid_goal_ids task) ->
-        Some (task, age_seconds)
-    | _ -> None)
-
-let emit_orphan_task_escalation workspace_config ~threshold_seconds orphan_tasks =
-  match orphan_tasks with
-  | [] -> ()
-  | _ ->
-      let task_ids =
-        List.map
-          (fun ((task, _) : Masc_domain.task * int) -> `String task.id)
-          orphan_tasks
-      in
-      let task_items =
-        List.map
-          (fun ((task, age_seconds) : Masc_domain.task * int) ->
-             `Assoc
-               [ ("task_id", `String task.id)
-               ; ("title", `String task.title)
-               ; ("created_at", `String task.created_at)
-               ; ("age_seconds", `Int age_seconds)
-               ; ("created_by", Json_util.string_opt_to_json task.created_by)
-               ])
-          orphan_tasks
-      in
-      Workspace_utils.log_event workspace_config
-        (`Assoc
-           [ ("type", `String "goal_orphan_task_escalation")
-           ; ("subsystem", `String "goal_janitor")
-           ; ("threshold_seconds", `Int threshold_seconds)
-           ; ("orphan_task_count", `Int (List.length orphan_tasks))
-           ; ("task_ids", `List task_ids)
-           ; ("tasks", `List task_items)
-           ; ( "action",
-               `String "link_task_goal_id_or_cancel_stale_unclaimed_task" )
-           ; ("ts", `String (Masc_domain.now_iso ()))
-           ]);
-      Log.Misc.warn
-        "[GoalJanitor] escalated %d stale unclaimed task(s) without goal linkage"
-        (List.length orphan_tasks)
-
 (** Clean orphaned goal binding IDs.
     Returns the pruned list and count of removed IDs. *)
 let prune_active_goal_ids ~(valid_goal_ids : string list)
@@ -193,6 +136,29 @@ let prune_orphan_goal_bindings workspace_config ~valid_goal_ids =
   let hooks = Atomic.get orphan_goal_binding_hooks in
   hooks.prune_orphan_goal_bindings workspace_config ~valid_goal_ids
 
+type orphan_task_escalation_hooks =
+  { escalate_orphan_tasks :
+      Workspace_utils.config ->
+      valid_goal_ids:string list ->
+      min_age_seconds:int ->
+      int
+  }
+
+let default_orphan_task_escalation_hooks =
+  { escalate_orphan_tasks =
+      (fun _ ~valid_goal_ids:_ ~min_age_seconds:_ -> 0)
+  }
+
+let orphan_task_escalation_hooks =
+  Atomic.make default_orphan_task_escalation_hooks
+
+let set_orphan_task_escalation_hooks hooks =
+  Atomic.set orphan_task_escalation_hooks hooks
+
+let escalate_orphan_tasks workspace_config ~valid_goal_ids ~min_age_seconds =
+  let hooks = Atomic.get orphan_task_escalation_hooks in
+  hooks.escalate_orphan_tasks workspace_config ~valid_goal_ids ~min_age_seconds
+
 (** Run a full sweep: goals + owner-managed goal bindings.
     Writes updated state to disk. *)
 let run ?(config = default_config) (workspace_config : Workspace_utils.config) : sweep_result =
@@ -208,16 +174,13 @@ let run ?(config = default_config) (workspace_config : Workspace_utils.config) :
   let total_orphans =
     prune_orphan_goal_bindings workspace_config ~valid_goal_ids:valid_ids
   in
-  let orphan_task_rows =
-    Workspace_query.get_tasks_safe workspace_config
-    |> audit_unclaimed_goal_orphan_tasks ~valid_goal_ids:valid_ids
-         ~min_age_seconds:config.orphan_task_escalation_age_seconds
+  let orphan_task_count =
+    escalate_orphan_tasks workspace_config
+      ~valid_goal_ids:valid_ids
+      ~min_age_seconds:config.orphan_task_escalation_age_seconds
   in
-  emit_orphan_task_escalation workspace_config
-    ~threshold_seconds:config.orphan_task_escalation_age_seconds
-    orphan_task_rows;
   let result = { partial with orphans = total_orphans;
-                              orphan_tasks = List.length orphan_task_rows } in
+                              orphan_tasks = orphan_task_count } in
   if result.purged > 0 || result.stagnated > 0 || result.orphans > 0
      || result.orphan_tasks > 0 then
     Log.Misc.info

--- a/lib/goal/goal_janitor.mli
+++ b/lib/goal/goal_janitor.mli
@@ -10,7 +10,8 @@
        leftovers do not accumulate.
     3. Orphan: invoke registered owner hooks to remove goal-binding
        entries that reference non-existent goals in the Goal Store.
-    4. Escalate: report stale unclaimed tasks without goal linkage.
+    4. Escalate: invoke registered task-owner hooks to report stale
+       unclaimed tasks without goal linkage.
 
     @since 2.236.0 *)
 
@@ -73,15 +74,17 @@ val set_orphan_goal_binding_hooks : orphan_goal_binding_hooks -> unit
 (** Register owner-specific goal-binding cleanup. Goal_janitor owns
     goal liveness; binding owners own their storage. *)
 
-(** [audit_unclaimed_goal_orphan_tasks ~valid_goal_ids
-    ~min_age_seconds tasks] returns stale [Todo] tasks with no structured
-    [goal_id] linkage. *)
-val audit_unclaimed_goal_orphan_tasks :
-  ?now:float ->
-  valid_goal_ids:string list ->
-  min_age_seconds:int ->
-  Masc_domain.task list ->
-  (Masc_domain.task * int) list
+type orphan_task_escalation_hooks =
+  { escalate_orphan_tasks :
+      Workspace_utils.config ->
+      valid_goal_ids:string list ->
+      min_age_seconds:int ->
+      int
+  }
+
+val set_orphan_task_escalation_hooks : orphan_task_escalation_hooks -> unit
+(** Register owner-specific stale task escalation. Goal_janitor supplies
+    goal liveness and age threshold; task owners own task state and events. *)
 
 (** {1 Entry point} *)
 

--- a/lib/keeper/keeper_runtime_contract.ml
+++ b/lib/keeper/keeper_runtime_contract.ml
@@ -17,7 +17,10 @@ let backend_of_meta (meta : keeper_meta) =
 
 let task_is_linked_to_keeper_goals goal_ids (task : Masc_domain.task) =
   List.exists
-    (fun goal_id -> Convergence.task_matches_goal ~goal_id task)
+    (fun goal_id ->
+       match task.goal_id with
+       | Some task_goal_id -> String.equal task_goal_id goal_id
+       | None -> false)
     goal_ids
 
 type claim_goal_scope = {

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -112,6 +112,7 @@ let create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
   Keeper_runtime_resolved.init ();
   Keeper_task_owner_backend.install_hooks ();
   Keeper_goal_janitor_backend.install_hooks ();
+  Workspace_goal_janitor_backend.install_hooks ();
   (* #9919: active Heuristic_metrics recording moved to Prometheus/Thompson
      paths, but the dashboard still reads the legacy JSONL via
      /api/v1/dashboard/heuristics. Keep storage initialized so existing

--- a/lib/workspace_goal_janitor_backend.ml
+++ b/lib/workspace_goal_janitor_backend.ml
@@ -1,0 +1,67 @@
+(** Workspace-owned task escalation installed behind Goal_janitor hooks. *)
+
+let task_age_seconds ?(now = Unix.gettimeofday ()) (task : Masc_domain.task) =
+  match Masc_domain.parse_iso8601_opt task.created_at with
+  | None -> None
+  | Some created_at -> Some (int_of_float (max 0.0 (now -. created_at)))
+
+let audit_unclaimed_goal_orphan_tasks ?(now = Unix.gettimeofday ())
+    ~valid_goal_ids:_ ~min_age_seconds (tasks : Masc_domain.task list) =
+  tasks
+  |> List.filter_map (fun (task : Masc_domain.task) ->
+    match task.task_status, task.goal_id, task_age_seconds ~now task with
+    | Masc_domain.Todo, None, Some age_seconds
+      when age_seconds >= min_age_seconds ->
+        Some (task, age_seconds)
+    | _ -> None)
+
+let emit_orphan_task_escalation workspace_config ~threshold_seconds orphan_tasks =
+  match orphan_tasks with
+  | [] -> ()
+  | _ ->
+      let task_ids =
+        List.map
+          (fun ((task, _) : Masc_domain.task * int) -> `String task.id)
+          orphan_tasks
+      in
+      let task_items =
+        List.map
+          (fun ((task, age_seconds) : Masc_domain.task * int) ->
+             `Assoc
+               [ ("task_id", `String task.id)
+               ; ("title", `String task.title)
+               ; ("created_at", `String task.created_at)
+               ; ("age_seconds", `Int age_seconds)
+               ; ("created_by", Json_util.string_opt_to_json task.created_by)
+               ])
+          orphan_tasks
+      in
+      Workspace_utils.log_event workspace_config
+        (`Assoc
+           [ ("type", `String "goal_orphan_task_escalation")
+           ; ("subsystem", `String "goal_janitor")
+           ; ("threshold_seconds", `Int threshold_seconds)
+           ; ("orphan_task_count", `Int (List.length orphan_tasks))
+           ; ("task_ids", `List task_ids)
+           ; ("tasks", `List task_items)
+           ; ( "action",
+               `String "link_task_goal_id_or_cancel_stale_unclaimed_task" )
+           ; ("ts", `String (Masc_domain.now_iso ()))
+           ]);
+      Log.Misc.warn
+        "[GoalJanitor] escalated %d stale unclaimed task(s) without goal linkage"
+        (List.length orphan_tasks)
+
+let escalate_orphan_tasks workspace_config ~valid_goal_ids ~min_age_seconds =
+  let orphan_task_rows =
+    Workspace_query.get_tasks_safe workspace_config
+    |> audit_unclaimed_goal_orphan_tasks ~valid_goal_ids ~min_age_seconds
+  in
+  emit_orphan_task_escalation workspace_config
+    ~threshold_seconds:min_age_seconds
+    orphan_task_rows;
+  List.length orphan_task_rows
+
+let install_hooks () =
+  Goal_janitor.set_orphan_task_escalation_hooks
+    { Goal_janitor.escalate_orphan_tasks = escalate_orphan_tasks }

--- a/lib/workspace_goals.ml
+++ b/lib/workspace_goals.ml
@@ -312,13 +312,18 @@ let parse_optional_transition_action args field =
 
 let actor_must_be_operator = Workspace_goals_verification.actor_must_be_operator
 
+let task_has_goal_id ~goal_id (task : Masc_domain.task) =
+  match task.goal_id with
+  | Some task_goal_id -> String.equal task_goal_id goal_id
+  | None -> false
+
 let validate_goal_completion_ready config ~goal_id ~override_note =
   match override_note with
   | Some note when not (String.equal (String.trim note) "") -> Ok ()
   | _ ->
     let linked_tasks =
       Workspace_query.get_tasks_safe config
-      |> List.filter (Convergence.task_matches_goal ~goal_id)
+      |> List.filter (task_has_goal_id ~goal_id)
     in
     let open_count =
       linked_tasks

--- a/scripts/audit-hardcoding-truth.sh
+++ b/scripts/audit-hardcoding-truth.sh
@@ -72,10 +72,24 @@ echo "Head: $(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
 section "Typed Boundary Metadata"
 legacy_helper_pattern='is_main_''worktree_''boundary_''exempt'
 legacy_phrase_pattern='main-''worktree ''boundary|worktree ''boundary'
-legacy_boundary_matches="$(
-  rg -n "${legacy_helper_pattern}|${legacy_phrase_pattern}" \
-    lib/tool_catalog.ml lib/tool_catalog.mli 2>/dev/null || true
-)"
+tool_catalog_candidates=(
+  lib/tool/tool_catalog.ml
+  lib/tool/tool_catalog.mli
+  lib/tool_catalog.ml
+  lib/tool_catalog.mli
+)
+tool_catalog_files=()
+for file in "${tool_catalog_candidates[@]}"; do
+  [ -f "$file" ] && tool_catalog_files+=("$file")
+done
+
+legacy_boundary_matches=""
+if [ "${#tool_catalog_files[@]}" -gt 0 ]; then
+  legacy_boundary_matches="$(
+    rg -n "${legacy_helper_pattern}|${legacy_phrase_pattern}" \
+      "${tool_catalog_files[@]}" 2>/dev/null || true
+  )"
+fi
 if [ -n "$legacy_boundary_matches" ]; then
   mark_confirmed "legacy checkout follow-up helper surface still exists"
   printf '%s\n' "$legacy_boundary_matches"
@@ -83,7 +97,8 @@ else
   echo "PASS: legacy checkout follow-up helper surface is absent."
 fi
 
-if rg -q 'type effect_domain' lib/tool_catalog.ml lib/tool_catalog.mli; then
+if [ "${#tool_catalog_files[@]}" -gt 0 ] \
+  && rg -q 'type effect_domain' "${tool_catalog_files[@]}"; then
   echo "PASS: Tool_catalog exposes typed effect_domain metadata."
 else
   mark_confirmed "Tool_catalog lacks typed effect_domain metadata"

--- a/scripts/lint/masc-domain-boundary-ratchet.baseline
+++ b/scripts/lint/masc-domain-boundary-ratchet.baseline
@@ -3,7 +3,3 @@
 # This file freezes current coupling debt. Entries may SHRINK but must NOT GROW.
 # Regenerate with: bash scripts/lint/masc-domain-boundary-ratchet.sh --regenerate
 #
-goal_to_task_state|lib/goal/convergence.ml
-goal_to_task_state|lib/goal/convergence.mli
-goal_to_task_state|lib/goal/goal_janitor.ml
-goal_to_task_state|lib/goal/goal_janitor.mli

--- a/test/test_goal_janitor.ml
+++ b/test/test_goal_janitor.ml
@@ -176,6 +176,7 @@ let test_escalate_stale_unclaimed_tasks_without_goal_linkage () =
   set_task_created_at config ~title:"Stale unlinked task" ~created_at:stale;
   set_task_created_at config ~title:"Title marker only [goal:g1]" ~created_at:stale;
   set_task_created_at config ~title:"Explicit linked task" ~created_at:stale;
+  Workspace_goal_janitor_backend.install_hooks ();
   let result = Goal_janitor.run config in
   check int "two stale unlinked tasks escalated" 2 result.orphan_tasks;
   let events = event_lines_containing config "goal_orphan_task_escalation" in


### PR DESCRIPTION
## Summary
- remove Goal leaf dependencies on `Masc_domain.task` / `Workspace_query` by changing `Convergence` to consume a goal-local task progress projection
- invert `Goal_janitor` stale task escalation behind an owner hook and move task scan/event emission into `Workspace_goal_janitor_backend`
- install the workspace janitor hook at server bootstrap and shrink `masc-domain-boundary-ratchet` baseline from 4 Goal->Task entries to 0

## Stack
- Stacked on #19835 (`ci: fix Tool_catalog path in meta audit`) because current `main` still has the Meta Guards path drift fixed there.

## Validation
- `bash scripts/lint/masc-domain-boundary-ratchet.sh --fail`
- `bash scripts/lint/tool-keeper-boundary-ratchet.sh --fail`
- `bash scripts/audit-hardcoding-truth.sh --fail-on-confirmed`
- `git diff --check`
- `ocamlc -stop-after parsing lib/workspace_goal_janitor_backend.ml`
- `ocamlc -stop-after parsing lib/goal/goal_janitor.ml`
- `ocamlc -stop-after parsing lib/goal/convergence.ml`
- `scripts/dune-local.sh build @lib/goal/check`

## Known validation blocker
- `scripts/dune-local.sh build test/test_goal_janitor.exe` is blocked by unrelated current-main OCaml drift (`save_oas_checkpoint ~model`, missing `last_model_used`, missing `per_provider_timeout_s`, missing `Keeper_repo_mapping.credentials_for_keeper`). The earlier change-local unbound value in `workspace_goals.ml` was fixed before push.