### PR TITLE
fix(keeper): align OAS runtime contract callers

### DIFF
--- a/lib/dashboard/dashboard_http_keeper_snapshot.ml
+++ b/lib/dashboard/dashboard_http_keeper_snapshot.ml
@@ -266,6 +266,10 @@ let keeper_config_json (config : Workspace.config) (name : string)
           `String (runtime)
         | Error (`Unresolved _) -> `Null
       in
+      let profile_defaults =
+        Keeper_types_profile.load_keeper_profile_defaults name
+      in
+      let per_provider_timeout = profile_defaults.per_provider_timeout in
       let execution =
         `Assoc [
           ("selected_runtime_id", `String runtime_id);
@@ -278,10 +282,10 @@ let keeper_config_json (config : Workspace.config) (name : string)
           ("active_model_label", `Null);
           ("last_model_used_label", `Null);
           ( "per_provider_timeout_sec",
-            Json_util.float_opt_to_json m.per_provider_timeout_s );
+            Json_util.float_opt_to_json per_provider_timeout );
           ( "per_provider_timeout_mode",
             `String
-              (match m.per_provider_timeout_s with
+              (match per_provider_timeout with
                | Some _ -> "override"
                | None -> "turn_budget_heuristic") );
           ("verify", `Bool false);

--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -211,17 +211,8 @@ let nonempty_trimmed value =
 
 let selected_model_of_meta = function
   | None -> None
-  | Some (meta : Keeper_meta_contract.keeper_meta) ->
-    (match nonempty_trimmed meta.runtime.usage.last_model_used with
-     | Some _ as selected_model -> selected_model
-     | None ->
-       (try
-          match Keeper_model_labels.configured_model_labels_of_meta meta with
-          | model :: _ -> nonempty_trimmed model
-          | [] -> None
-        with
-        | Eio.Cancel.Cancelled _ as exn -> raise exn
-        | Failure _ | Invalid_argument _ -> None))
+  | Some (_ : Keeper_meta_contract.keeper_meta) ->
+    None
 ;;
 
 let input_op_opt input =

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -43,8 +43,7 @@ module For_testing : sig
 end
 
 val per_provider_timeout_for_turn
-  :  meta:Keeper_meta_contract.keeper_meta
-  -> ?oas_timeout_s:float
+  :  ?oas_timeout_s:float
   -> ?oas_timeout_is_explicit:bool
   -> timeout_s:float
   -> unit

--- a/lib/keeper/keeper_agent_run_turn_helpers.ml
+++ b/lib/keeper/keeper_agent_run_turn_helpers.ml
@@ -40,17 +40,13 @@ let task_link_already_recorded ~keeper ~task_id ~trace_id =
     Hashtbl.mem link_task_cache (keeper, task_id, trace_id))
 
 let per_provider_timeout_for_turn
-    ~(meta : Keeper_meta_contract.keeper_meta)
     ?oas_timeout_s
     ?(oas_timeout_is_explicit = true)
     ~(timeout_s : float)
     () =
   match (oas_timeout_s, oas_timeout_is_explicit) with
   | (Some _ as explicit_timeout), true -> explicit_timeout
-  | _, _ -> (
-      match meta.per_provider_timeout_s with
-      | Some configured -> Some (Float.min configured timeout_s)
-      | None -> Some timeout_s)
+  | _, _ -> Some timeout_s
 
 let sse_event_progress_kind (event : Agent_sdk.Types.sse_event) =
   match event with

--- a/lib/keeper/keeper_agent_run_turn_helpers.mli
+++ b/lib/keeper/keeper_agent_run_turn_helpers.mli
@@ -6,7 +6,6 @@ val task_link_already_recorded :
   keeper:string -> task_id:string -> trace_id:string -> bool
 
 val per_provider_timeout_for_turn :
-  meta:Keeper_meta_contract.keeper_meta ->
   ?oas_timeout_s:float ->
   ?oas_timeout_is_explicit:bool ->
   timeout_s:float ->

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -600,7 +600,7 @@ let apply_post_turn_lifecycle_with_resilience_handles
                ~max_checkpoint_messages:base_meta.compaction.max_checkpoint_messages
                ~session
                ~agent_name:base_meta.agent_name
-               ~model ~ctx:compacted_ctx ~generation:current_generation
+               ~ctx:compacted_ctx ~generation:current_generation
           with
           | Ok saved_cp -> (true, None, compacted_ctx, Some saved_cp)
           | Error e ->
@@ -872,7 +872,7 @@ let recover_latest_checkpoint_for_overflow_retry
               ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages
               ~session
               ~agent_name:retry_meta.agent_name
-              ~model ~ctx:compacted_ctx ~generation:turn_generation
+              ~ctx:compacted_ctx ~generation:turn_generation
           with
           | Ok checkpoint ->
               Some { checkpoint; compaction; turn_generation }

--- a/lib/keeper/keeper_repo_readiness.ml
+++ b/lib/keeper/keeper_repo_readiness.ml
@@ -273,25 +273,9 @@ let inspect
 let find_repo_url ~(config : Workspace.config) ~repo_name =
   Repo_store.find_url_by_id ~base_path:config.Workspace.base_path repo_name
 
-(** Resolve the keeper's mapped credential from [keeper_repo_mappings.toml]. *)
-let resolve_keeper_credential ~(config : Workspace.config) ~(meta : keeper_meta) =
-  match
-    Keeper_repo_mapping.credentials_for_keeper
-      ~base_path:config.Workspace.base_path ~keeper_id:meta.name
-  with
-  | Error reason ->
-    Error (Printf.sprintf "credential mapping error for keeper %s: %s" meta.name reason)
-  | Ok [] ->
-    Error
-      (Printf.sprintf
-         "keeper %s has no credential mapping; add [mapping.%s] to keeper_repo_mappings.toml"
-         meta.name meta.name)
-  | Ok (cred :: _) -> Ok cred
-
-(** Clone a sandbox repo using the keeper's mapped credential.
+(** Clone a sandbox repo using non-interactive repo-manager git.
     Constructs a minimal [repository] record and delegates to [Repo_git.clone]. *)
-let clone_sandbox_repo ~(config : Workspace.config) ~(meta : keeper_meta)
-    ~repo_name ~url ~clone_path ~(credential : Repo_manager_types.credential) =
+let clone_sandbox_repo ~(meta : keeper_meta) ~repo_name ~url ~clone_path =
   let open Repo_manager_types in
   let repo = {
     id = repo_name;
@@ -300,7 +284,6 @@ let clone_sandbox_repo ~(config : Workspace.config) ~(meta : keeper_meta)
     local_path = clone_path;
     aliases = [];
     default_branch = "main";
-    credential_id = credential.id;
     keepers = [ meta.name ];
     status = Active;
     auto_sync = false;
@@ -309,12 +292,11 @@ let clone_sandbox_repo ~(config : Workspace.config) ~(meta : keeper_meta)
     updated_at = 0L;
   }
   in
-  Repo_git.clone ~repository:repo ~credential
+  Repo_git.clone ~repository:repo
 
 (** [ensure_ready ~config ~meta ~repo_name ()] probes the sandbox repo
     via [inspect]. If the repo is [missing_clone] or [not_git_repo],
-    attempts to clone it from the configured repository URL using the
-    keeper's mapped credential. Returns [Ok ()] when the repo is ready,
+    attempts to clone it from the configured repository URL. Returns [Ok ()] when the repo is ready,
     or [Error msg] if repair failed or was not possible. *)
 let ensure_ready ~(config : Workspace.config) ~(meta : keeper_meta) ~repo_name () :
     (unit, string) result =
@@ -364,29 +346,23 @@ let ensure_ready ~(config : Workspace.config) ~(meta : keeper_meta) ~repo_name (
                "repo %s not found in repositories.toml; cannot auto-clone"
                repo_name)
         | Some url -> (
-            match resolve_keeper_credential ~config ~meta with
-            | Error _ as err -> err
-            | Ok credential -> (
-                match
-                  clone_sandbox_repo ~config ~meta ~repo_name ~url
-                    ~clone_path:path ~credential
-                with
-                | Error msg ->
-                  Error (Printf.sprintf "auto-clone failed for %s: %s" repo_name msg)
-                | Ok () ->
-                  (* Verify post-clone state *)
-                  let post = inspect ~config ~meta ~repo_name () in
-                  let post_state =
-                    match Json_util.assoc_member_opt "state" post with
-                    | Some (`String s) -> s
-                    | _ -> "unknown"
-                  in
-                  if post_state = "ready" then Ok ()
-                  else
-                    Error
-                      (Printf.sprintf
-                         "auto-clone succeeded but post-clone state is %s"
-                         post_state))))
+            match clone_sandbox_repo ~meta ~repo_name ~url ~clone_path:path with
+            | Error msg ->
+              Error (Printf.sprintf "auto-clone failed for %s: %s" repo_name msg)
+            | Ok () ->
+              (* Verify post-clone state *)
+              let post = inspect ~config ~meta ~repo_name () in
+              let post_state =
+                match Json_util.assoc_member_opt "state" post with
+                | Some (`String s) -> s
+                | _ -> "unknown"
+              in
+              if post_state = "ready" then Ok ()
+              else
+                Error
+                  (Printf.sprintf
+                     "auto-clone succeeded but post-clone state is %s"
+                     post_state)))
     | other ->
       Error
         (Printf.sprintf
@@ -399,8 +375,8 @@ let ensure_ready ~(config : Workspace.config) ~(meta : keeper_meta) ~repo_name (
     [auto_sync]/[sync_interval] are 0/false because the playground lane is
     advanced explicitly by [ensure_current], not by the [.masc/repos] periodic
     [repo_sync] fiber. *)
-let make_repo_record ~repo_name ~url ~clone_path ~default_branch ~credential_id
-    ~keeper_name : Repo_manager_types.repository =
+let make_repo_record ~repo_name ~url ~clone_path ~default_branch ~keeper_name
+    : Repo_manager_types.repository =
   let open Repo_manager_types in
   {
     id = repo_name;
@@ -409,7 +385,6 @@ let make_repo_record ~repo_name ~url ~clone_path ~default_branch ~credential_id
     local_path = clone_path;
     aliases = [];
     default_branch;
-    credential_id;
     keepers = [ keeper_name ];
     status = Active;
     auto_sync = false;
@@ -428,8 +403,8 @@ type currency_outcome =
       (** not advanced (dirty / detached / task branch / diverged); the
           working tree is left untouched. payload is the reason *)
   | Skipped of string
-      (** not applicable (not a ready clone / no credential or url / fetch
-          failed); payload is the reason *)
+      (** not applicable (not a ready clone / no repository URL / fetch failed);
+          payload is the reason *)
 
 let count_behind ~clone_path ~target_ref =
   let r =
@@ -475,18 +450,14 @@ let ensure_current ~(config : Workspace.config) ~(meta : keeper_meta) ~repo_name
     | "status_failed" ->
         Skipped (Printf.sprintf "repo not a ready clone (state=%s)" state)
     | _ -> (
-        match
-          find_repo_url ~config ~repo_name, resolve_keeper_credential ~config ~meta
-        with
-        | None, _ -> Skipped "repo not in repositories.toml"
-        | _, Error reason -> Skipped (Printf.sprintf "no credential: %s" reason)
-        | Some url, Ok credential -> (
+        match find_repo_url ~config ~repo_name with
+        | None -> Skipped "repo not in repositories.toml"
+        | Some url -> (
             let repo =
               make_repo_record ~repo_name ~url ~clone_path:cpath ~default_branch
-                ~credential_id:credential.Repo_manager_types.id
                 ~keeper_name:meta.name
             in
-            match Repo_git.fetch ~repository:repo ~credential with
+            match Repo_git.fetch ~repository:repo with
             | Error msg -> Skipped (Printf.sprintf "fetch failed: %s" msg)
             | Ok _ -> (
                 let target_ref = "origin/" ^ default_branch in

--- a/lib/keeper/keeper_rollover.ml
+++ b/lib/keeper/keeper_rollover.ml
@@ -279,7 +279,7 @@ let maybe_rollover_oas_handoff
                   ~max_checkpoint_messages:base_meta.compaction.max_checkpoint_messages
                   ~session:new_session
                   ~agent_name:base_meta.agent_name
-                  ~model ~ctx:save_ctx ~generation:next_generation with
+                  ~ctx:save_ctx ~generation:next_generation with
           | Error e ->
               Prometheus.inc_counter
                 Keeper_metrics.(to_string CheckpointFailures)

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -197,7 +197,6 @@ let effective_meta_overlay_hash (meta : keeper_meta) =
     | None -> ""
   in
   let opt_int = Option.fold ~none:"" ~some:string_of_int in
-  let opt_float = Option.fold ~none:"" ~some:(Printf.sprintf "%.6f") in
   let fields =
     [
       ("goal", meta.goal);

--- a/test/test_board_curation.ml
+++ b/test/test_board_curation.ml
@@ -17,7 +17,6 @@ let test_submit_and_retrieve () =
     id           = "cu-test-001";
     generated_at = 1_735_689_600.0;
     submitted_by = "agent-test";
-    model        = Some "model-d";
     summary      = None;
     ordering     = [ "p-aaa"; "p-bbb" ];
     highlights   = [ "p-aaa" ];
@@ -34,7 +33,6 @@ let test_submit_and_retrieve () =
   let s = Option.get got in
   Alcotest.(check string) "id"           "cu-test-001"             s.id;
   Alcotest.(check string) "submitted_by" "agent-test"              s.submitted_by;
-  Alcotest.(check (option string)) "model" (Some "model-d")         s.model;
   Alcotest.(check (list string)) "ordering" [ "p-aaa"; "p-bbb" ]  s.ordering;
   Alcotest.(check string) "rationale"    "Test rationale"          s.rationale
 
@@ -44,7 +42,6 @@ let test_reset_clears () =
     id           = "cu-test-002";
     generated_at = 1_735_689_600.0;
     submitted_by = "agent-test";
-    model        = None;
     summary      = None;
     ordering     = [];
     highlights   = [];
@@ -65,7 +62,7 @@ let test_submit_replaces () =
   Board_curation.reset_for_test ();
   let make id rationale : Board_curation.curation_snapshot = {
     id; generated_at = 1_735_689_600.0; submitted_by = "a";
-    model = None; summary = None; ordering = []; highlights = [];
+    summary = None; ordering = []; highlights = [];
     tag_suggestions = []; answer_matches = []; health_score = None;
     health_components = []; rationale; provenance = `Assoc [];
   } in
@@ -83,7 +80,6 @@ let test_to_yojson_round_trip () =
     id           = "cu-json-01";
     generated_at = 1_748_779_200.0;
     submitted_by = "model-agent";
-    model        = Some "agent_llm_a-3";
     summary      = Some "Two active questions need routing.";
     ordering     = [ "p-1"; "p-2"; "p-3" ];
     highlights   = [ "p-2" ];
@@ -105,7 +101,7 @@ let test_to_yojson_round_trip () =
    | `Assoc kvs ->
      let get k = List.assoc_opt k kvs in
      Alcotest.(check (option pass)) "id present"    (Some (`String "cu-json-01"))    (get "id");
-     Alcotest.(check (option pass)) "model present" (Some (`String "agent_llm_a-3"))      (get "model");
+     Alcotest.(check (option pass)) "model absent" None (get "model");
      Alcotest.(check (option pass)) "summary present"
        (Some (`String "Two active questions need routing.")) (get "summary");
      Alcotest.(check bool) "ordering is list"

--- a/test/test_dashboard_keeper_feature_proof.ml
+++ b/test/test_dashboard_keeper_feature_proof.ml
@@ -93,7 +93,6 @@ let persist_keeper_with_proactive
               base.runtime.usage with
               total_turns;
               last_turn_ts = now;
-              last_model_used = "openai:gpt-5.4";
             };
           proactive_rt =
             {

--- a/test/test_heuristic_theatre_audit.ml
+++ b/test/test_heuristic_theatre_audit.ml
@@ -1,27 +1,23 @@
 (* test/test_heuristic_theatre_audit.ml
 
-   #9919 audit follow-up (tick #24): verify that the two
-   remaining degenerate [Heuristic_metrics.record] emit sites
-   flagged in handoff tick #18 now surface as proper
-   Prometheus counters.
+   #9919 audit follow-up (tick #24): verify that the remaining degenerate
+   [Heuristic_metrics.record] emit site flagged in handoff tick #18 now
+   surfaces as a proper Prometheus counter.
 
-   - [Board_core_classify.legacy_migrate_post_kind_metric]:
-     [author] label for author-heuristic automation migration.
    - [Thompson_sampling.priority_trigger_selected_metric]:
      [agent, trigger] labels for priority-trigger selection.
 
-   Both sites previously emitted constant-tuple records
+   The site previously emitted constant-tuple records
    ([raw, threshold, triggered] with hardcoded values) that
-   [Heuristic_metrics_diagnostics] had to flag as
-   instrumentation theatre.  Counters remove the false
+   [Heuristic_metrics_diagnostics] had to flag as instrumentation theatre.
+   The counter removes the false
    classification and give operators real per-label rates via
    [rate(masc_..._total{...}[5m])].
 
-   This test pins the canonical metric names and the exact
-   label set each counter consumes.  A dashboard-breaking
-   rename or label reshape fails here before it reaches CI. *)
+   This test pins the canonical metric name and the exact label set the
+   counter consumes.  A dashboard-breaking rename or label reshape fails here
+   before it reaches CI. *)
 
-module BC = Masc_mcp.Board_core_classify
 (* Thompson_sampling carved into the masc_thompson leaf (Health/Prometheus
    edges inverted); the metric-name constant is still exported. Reference the
    bare module (re-exported via masc_test_deps) instead of Masc_mcp.*. *)
@@ -30,23 +26,6 @@ module Prom = Masc_mcp.Prometheus
 
 let counter_value metric ~labels =
   Prom.metric_value_or_zero metric ~labels ()
-
-let test_board_metric_name_stable () =
-  Alcotest.(check string)
-    "board legacy migrate counter canonical name"
-    "masc_board_legacy_migrate_post_kind_total"
-    BC.legacy_migrate_post_kind_metric
-
-let test_board_counter_accepts_author_label () =
-  (* Baseline read for a synthetic author — exercising the
-     classifier from this test would require constructing a
-     full Post_types.post record which is schema-heavy.  A
-     baseline-zero check still catches any future typo in the
-     [author] label key. *)
-  let labels = [ ("author", "unused-test-9919-board") ] in
-  Alcotest.(check (float 0.0001))
-    "unused-author baseline is 0" 0.0
-    (counter_value BC.legacy_migrate_post_kind_metric ~labels)
 
 let test_thompson_metric_name_stable () =
   Alcotest.(check string)
@@ -78,13 +57,6 @@ let test_thompson_counter_accepts_label_tuple () =
 let () =
   Alcotest.run "heuristic_theatre_audit_9919"
     [
-      ( "board_core_classify",
-        [
-          Alcotest.test_case "metric name stable" `Quick
-            test_board_metric_name_stable;
-          Alcotest.test_case "author label accepted" `Quick
-            test_board_counter_accepts_author_label;
-        ] );
       ( "thompson_sampling",
         [
           Alcotest.test_case "metric name stable" `Quick

--- a/test/test_keeper_benchmark_canary.ml
+++ b/test/test_keeper_benchmark_canary.ml
@@ -38,7 +38,7 @@ let with_temp_file contents f =
       close_out oc;
       f path)
 
-let make_meta ?(name = "analyst") ?(models = []) () =
+let make_meta ?(name = "analyst") () =
   let base_fields =
     [
       ("name", `String name);
@@ -50,14 +50,7 @@ let make_meta ?(name = "analyst") ?(models = []) () =
       ("network_mode", `String "none");
     ]
   in
-  let fields =
-    match models with
-    | [] -> base_fields
-    | _ ->
-        ("models", `List (List.map (fun value -> `String value) models))
-        :: base_fields
-  in
-  match Keeper_meta_json_parse.meta_of_json (`Assoc fields) with
+  match Keeper_meta_json_parse.meta_of_json (`Assoc base_fields) with
   | Ok meta -> meta
   | Error err -> fail ("meta_of_json failed: " ^ err)
 
@@ -178,15 +171,7 @@ let test_runtime_canary_prepends_recommended_model_only_without_explicit_models 
           KML.configured_model_labels_of_meta (make_meta ~name:"analyst" ())
         in
         check bool "bench recommendation is not a runtime dispatch override"
-          false (List.mem "test-provider:test-model" labels);
-        let explicit_meta =
-          { (make_meta ~name:"analyst" ()) with models = [ "explicit:model" ] }
-        in
-        let explicit_labels =
-          KML.configured_model_labels_of_meta explicit_meta
-        in
-        check bool "legacy explicit models are ignored by runtime labels"
-          false (List.mem "explicit:model" explicit_labels))))
+          false (List.mem "test-provider:test-model" labels))))
 
 let () =
   run "keeper_benchmark_canary"

--- a/test/test_keeper_lifecycle.ml
+++ b/test/test_keeper_lifecycle.ml
@@ -171,7 +171,6 @@ let save_checkpoint ~base_dir ~(meta : Keeper_meta_contract.keeper_meta) ~ctx =
     ~max_checkpoint_messages:120
     ~session
     ~agent_name:meta.agent_name
-    ~model:"llama:auto"
     ~ctx
     ~generation:meta.runtime.generation
   with
@@ -1600,7 +1599,6 @@ let test_save_oas_checkpoint_strips_ephemeral_world_state () =
           ~max_checkpoint_messages:120
           ~session
           ~agent_name:"keeper-lifecycle"
-          ~model:"provider_k:provider_k-5.1"
           ~ctx
           ~generation:1
       with
@@ -1636,7 +1634,6 @@ let test_save_oas_checkpoint_caps_oversized_text () =
           ~max_checkpoint_messages:120
           ~session
           ~agent_name:"keeper-lifecycle"
-          ~model:"provider_k:provider_k-5.1"
           ~ctx
           ~generation:1
       with
@@ -1680,7 +1677,6 @@ let test_save_oas_checkpoint_caps_total_content () =
           ~max_checkpoint_messages:120
           ~session
           ~agent_name:"keeper-lifecycle"
-          ~model:"provider_k:provider_k-5.1"
           ~ctx
           ~generation:1
       with
@@ -1821,7 +1817,6 @@ let test_save_oas_checkpoint_stubs_old_tool_results () =
           ~max_checkpoint_messages:120
           ~session
           ~agent_name:"keeper-lifecycle"
-          ~model:"provider_k:provider_k-5.1"
           ~ctx
           ~generation:1
       with
@@ -1880,7 +1875,6 @@ let test_save_oas_checkpoint_repairs_orphaned_tool_result_after_cap () =
           ~max_checkpoint_messages:2
           ~session
           ~agent_name:"keeper-lifecycle"
-          ~model:"provider_k:provider_k-5.1"
           ~ctx
           ~generation:1
       with
@@ -2084,7 +2078,6 @@ let test_save_oas_checkpoint_strips_summarized_world_state () =
           ~max_checkpoint_messages:120
           ~session
           ~agent_name:"keeper-lifecycle"
-          ~model:"provider_k:provider_k-5.1"
           ~ctx
           ~generation:1
       with

--- a/test/test_keeper_llama_only.ml
+++ b/test/test_keeper_llama_only.ml
@@ -58,9 +58,8 @@ let labels_for_turn meta =
   with_worktree_config_root @@ fun () ->
   Eio_main.run @@ fun _env -> KEC.effective_model_labels_for_turn meta
 
-let make_meta ?(last_model_used = "provider_k-5.1") ?(models = []) () =
-  let base =
-    match
+let make_meta ?(last_model_used = "provider_k-5.1") () =
+  match
     Keeper_meta_json_parse.meta_of_json
       (`Assoc
         [
@@ -72,11 +71,9 @@ let make_meta ?(last_model_used = "provider_k-5.1") ?(models = []) () =
           ("sandbox_profile", `String "local");
           ("network_mode", `String "none");
         ])
-    with
+  with
   | Ok meta -> meta
   | Error err -> fail ("meta_of_json failed: " ^ err)
-  in
-  { base with models }
 
 (* Behavioral: stale model from a different provider is excluded from result.
    MASC does not assert specific vendor labels — only runtime behavior.
@@ -98,17 +95,11 @@ let test_matching_last_model_is_preserved_when_still_in_runtime () =
     match labels with
     | [] -> fail "matching allowed model resolved to empty labels"
     | actual_first :: _ ->
-      check string "matching model stays first" first actual_first
+      check string "runtime model stays first" first actual_first
 
 let test_legacy_explicit_models_do_not_override_runtime_resolution () =
-  let explicit =
-    [ "ollama:qwen3.5:35b-a3b-nvfp4"; "provider_k-coding:provider_k-5.1" ]
-  in
   let baseline = labels_for_turn (make_meta ~last_model_used:"" ()) in
-  let labels =
-    labels_for_turn (make_meta ~last_model_used:"" ~models:explicit ())
-  in
-  check (list string) "legacy explicit models do not override runtime" baseline labels
+  check bool "runtime labels are non-empty" true (baseline <> [])
 
 let test_meta_of_json_rejects_legacy_models () =
   match

--- a/test/test_keeper_masc_bridge.ml
+++ b/test/test_keeper_masc_bridge.ml
@@ -401,18 +401,13 @@ let test_tool_access_missing_defaults_standard_policy () =
 let test_typed_and_string_tool_access_rejections_match () =
   let module Access = Masc_mcp.Keeper_meta_contract in
   let check_rejection label json =
-    let string_error =
-      match Access.tool_access_of_meta_json json with
-      | Ok _ -> Alcotest.failf "string parser accepted %s" label
-      | Error e -> e
-    in
-    let typed_error =
-      match Access.tool_access_of_meta_json_typed json with
-      | Ok _ -> Alcotest.failf "typed parser accepted %s" label
-      | Error e -> e
-    in
-    Alcotest.(check string) (label ^ " typed/string rejection") string_error
-      typed_error
+    match Access.tool_access_of_meta_json json with
+    | Ok _ -> Alcotest.failf "tool_access parser accepted %s" label
+    | Error e ->
+      Alcotest.(check bool)
+        (label ^ " rejection is explicit")
+        true
+        (String.length e > 0)
   in
   check_rejection "missing" (`Assoc []);
   check_rejection "null" (`Assoc [ "tool_access", `Null ])
@@ -821,7 +816,7 @@ let test_denied_tools_excluded_from_injection () =
   let meta = make_meta () in
   let names = KET.keeper_masc_tool_names meta in
   let denied =
-    Tool_catalog.tools_for_surface Tool_catalog.Keeper_denied
+    Tool_catalog.tools_for_surface Tool_catalog.System_internal
   in
   List.iter
     (fun denied_name ->
@@ -846,7 +841,7 @@ let test_denied_excluded_from_allowed_names () =
   in
   let names = KET.keeper_allowed_tool_names meta in
   let denied =
-    Tool_catalog.tools_for_surface Tool_catalog.Keeper_denied
+    Tool_catalog.tools_for_surface Tool_catalog.System_internal
   in
   List.iter
     (fun denied_name ->

--- a/test/test_keeper_safety_gates.ml
+++ b/test/test_keeper_safety_gates.ml
@@ -40,7 +40,7 @@ let make_meta
 
 let full_tool_access () =
   Keeper_meta_tool_access.normalize_tool_access
-    (Tool_catalog.tools_for_surface Tool_catalog.Keeper_internal
+    (Tool_catalog.tools_for_surface Tool_catalog.Agent_internal
      @ Tool_catalog.tools_for_surface Tool_catalog.Public_mcp)
 
 let minimal_tool_access =

--- a/test/test_keeper_tool_exposure.ml
+++ b/test/test_keeper_tool_exposure.ml
@@ -41,7 +41,7 @@ let make_meta
 
 let full_tool_access () =
   Keeper_meta_tool_access.normalize_tool_access
-    (Tool_catalog.tools_for_surface Tool_catalog.Keeper_internal
+    (Tool_catalog.tools_for_surface Tool_catalog.Agent_internal
      @ Tool_catalog.tools_for_surface Tool_catalog.Public_mcp)
 ;;
 

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -470,7 +470,7 @@ let test_oas_wrapper_records_keeper_internal_tool_call () =
               let entry = List.assoc "keeper_stay_silent" stats in
               check int "call_count" 1 (Atomic.get entry.call_count);
               check int "success_count" 1 (Atomic.get entry.success_count);
-              check int "keeper_internal_count" 1 (Atomic.get entry.keeper_internal_count)))
+              check int "agent_internal_count" 1 (Atomic.get entry.agent_internal_count)))
 ;;
 
 let test_oas_tool_callbacks_respect_resource_gate () =

--- a/test/test_tool_access_policy.ml
+++ b/test/test_tool_access_policy.ml
@@ -216,10 +216,10 @@ let test_surface_resolution_respects_candidates () =
     (List.mem "totally_unknown" resolved)
 
 let test_keeper_denied_surface_blocks_tools () =
-  let denied_tools = Tool_catalog.tools_for_surface Tool_catalog.Keeper_denied in
+  let denied_tools = Tool_catalog.tools_for_surface Tool_catalog.System_internal in
   let policy = {
     Tool_access_policy.allow = All;
-    deny = Surface Tool_catalog.Keeper_denied;
+    deny = Surface Tool_catalog.System_internal;
   } in
   check bool "keeper_denied surface has tools" true
     (List.length denied_tools > 0);

--- a/test/test_tool_exposure.ml
+++ b/test/test_tool_exposure.ml
@@ -109,7 +109,7 @@ let () =
                   check bool (name ^ " direct call blocked") false
                     (Tool_catalog.allow_direct_call name);
                   check bool (name ^ " on keeper_internal surface") true
-                    (Tool_catalog.is_on_surface Tool_catalog.Keeper_internal name);
+                    (Tool_catalog.is_on_surface Tool_catalog.Agent_internal name);
                   check bool (name ^ " reason present") true
                     (Option.is_some meta.reason))
                 [ "keeper_time_now"; "keeper_board_post"; "tool_execute" ]);

--- a/test/test_tool_name.ml
+++ b/test/test_tool_name.ml
@@ -1,38 +1,28 @@
-module Types = Masc_domain
-
-(** Test Tool_name: roundtrip, coverage, and invariant checks. *)
-
 open Masc_mcp
 
-let all_keeper : Tool_name.Keeper.t list =
-  [ Execute; Board_comment; Board_comment_vote
-  ; Board_curation_read; Board_curation_submit
-  ; Board_get; Board_list; Board_post; Board_search; Board_stats; Board_vote
-  ; Broadcast; Context_status; Fs_edit; Fs_write; Fs_read
-  ; Handoff; Library_read; Library_search; Memory_search
-  ; Search_files; Stay_silent
-  ; Task_claim; Task_create; Task_done; Task_submit_for_verification
-  ; Task_force_done; Task_force_release
-  ; Tasks_audit; Tasks_list; Time_now; Tool_search; Tools_list
-  ; Voice_agent; Voice_listen; Voice_session_end; Voice_session_start
-  ; Voice_sessions; Voice_speak ]
+(** Test current Tool_name contract: [Tool_name.t] is the public MASC tool
+    namespace. Removed Keeper/Masc_keeper variants must stay absent. *)
 
-(* PR-S1: Task/Board/Goal/Operator tool names are owned by domain submodules
-   and wrapped into [Masc.t] via the [Task]/[Board]/[Goal]/[Operator]
-   constructors. The remaining names stay flat. *)
 let all_masc : Tool_name.Masc.t list =
   let open Tool_name in
-  [ Masc.Task Task_name.Add_task; Masc.Agent_fitness; Masc.Agent_update
-  ; Masc.Agent_card; Masc.Agents
+  [ Masc.Task Task_name.Add_task
+  ; Masc.Agent_fitness
+  ; Masc.Agent_update
+  ; Masc.Agent_card
+  ; Masc.Agents
   ; Masc.Task Task_name.Batch_add_tasks
-  ; Masc.Board Board_name.Board_cleanup; Masc.Board Board_name.Board_comment
+  ; Masc.Board Board_name.Board_cleanup
+  ; Masc.Board Board_name.Board_comment
   ; Masc.Board Board_name.Board_comment_vote
   ; Masc.Board Board_name.Board_curation_read
   ; Masc.Board Board_name.Board_curation_submit
-  ; Masc.Board Board_name.Board_delete; Masc.Board Board_name.Board_get
-  ; Masc.Board Board_name.Board_hearths; Masc.Board Board_name.Board_list
+  ; Masc.Board Board_name.Board_delete
+  ; Masc.Board Board_name.Board_get
+  ; Masc.Board Board_name.Board_hearths
+  ; Masc.Board Board_name.Board_list
   ; Masc.Board Board_name.Board_post
-  ; Masc.Board Board_name.Board_profile; Masc.Board Board_name.Board_reaction
+  ; Masc.Board Board_name.Board_profile
+  ; Masc.Board Board_name.Board_reaction
   ; Masc.Board Board_name.Board_search
   ; Masc.Board Board_name.Board_stats
   ; Masc.Board Board_name.Board_sub_board_create
@@ -40,276 +30,181 @@ let all_masc : Tool_name.Masc.t list =
   ; Masc.Board Board_name.Board_sub_board_get
   ; Masc.Board Board_name.Board_sub_board_list
   ; Masc.Board Board_name.Board_sub_board_update
-  ; Masc.Board Board_name.Board_vote; Masc.Broadcast; Masc.Check
+  ; Masc.Board Board_name.Board_vote
+  ; Masc.Broadcast
+  ; Masc.Check
   ; Masc.Task Task_name.Claim_next
-  ; Masc.Cleanup_zombies; Masc.Dashboard; Masc.Deliver
-  ; Masc.Goal Goal_name.Goal_list; Masc.Goal Goal_name.Goal_transition
-  ; Masc.Goal Goal_name.Goal_upsert; Masc.Goal Goal_name.Goal_verify
-  ; Masc.Heartbeat; Masc.Messages; Masc.Note_add
+  ; Masc.Cleanup_zombies
+  ; Masc.Dashboard
+  ; Masc.Deliver
+  ; Masc.Goal Goal_name.Goal_list
+  ; Masc.Goal Goal_name.Goal_transition
+  ; Masc.Goal Goal_name.Goal_upsert
+  ; Masc.Goal Goal_name.Goal_verify
+  ; Masc.Heartbeat
+  ; Masc.Messages
+  ; Masc.Note_add
   ; Masc.Operator Operator_name.Operator_action
   ; Masc.Operator Operator_name.Operator_confirm
   ; Masc.Operator Operator_name.Operator_digest
   ; Masc.Operator Operator_name.Operator_snapshot
-  ; Masc.Plan_clear_task; Masc.Plan_get; Masc.Plan_get_task; Masc.Plan_init
+  ; Masc.Plan_clear_task
+  ; Masc.Plan_get
+  ; Masc.Plan_get_task
+  ; Masc.Plan_init
   ; Masc.Plan_set_task
-  ; Masc.Plan_update; Masc.Reset
-  ; Masc.Status; Masc.Task Task_name.Task_history; Masc.Task Task_name.Tasks
-  ; Masc.Tool_grant; Masc.Tool_help
-  ; Masc.Tool_list; Masc.Tool_revoke; Masc.Task Task_name.Transition
-  ; Masc.Task Task_name.Update_priority; Masc.Web_fetch; Masc.Web_search
-  ; Masc.Approval_pending; Masc.Approval_get; Masc.Config; Masc.Gc
-  ; Masc.Get_metrics; Masc.Mcp_session
-  ; Masc.Pause; Masc.Resume; Masc.Start; Masc.Tool_admin_snapshot
+  ; Masc.Plan_update
+  ; Masc.Reset
+  ; Masc.Status
+  ; Masc.Task Task_name.Task_history
+  ; Masc.Task Task_name.Tasks
+  ; Masc.Tool_grant
+  ; Masc.Tool_help
+  ; Masc.Tool_list
+  ; Masc.Tool_revoke
+  ; Masc.Task Task_name.Transition
+  ; Masc.Task Task_name.Update_priority
+  ; Masc.Web_fetch
+  ; Masc.Web_search
+  ; Masc.Approval_pending
+  ; Masc.Approval_get
+  ; Masc.Config
+  ; Masc.Gc
+  ; Masc.Get_metrics
+  ; Masc.Mcp_session
+  ; Masc.Pause
+  ; Masc.Resume
+  ; Masc.Start
+  ; Masc.Tool_admin_snapshot
   ; Masc.Tool_admin_update
-  ; Masc.Tool_stats ]
-
-let all_masc_keeper : Tool_name.Masc_keeper.t list =
-  [ Clear; Compact; Create_from_persona; Down; List; Msg; Persona_audit; Repair
-  ; Reset; Status; Up ]
+  ; Masc.Tool_stats
+  ]
 
 let all_tool_names : Tool_name.t list =
-  List.map (fun k -> Tool_name.Keeper k) all_keeper
-  @ List.map (fun m -> Tool_name.Masc m) all_masc
-  @ List.map (fun mk -> Tool_name.Masc_keeper mk) all_masc_keeper
-
-(* ── Roundtrip ─────────────────────────────────────────────── *)
-
-let test_roundtrip_keeper () =
-  List.iter (fun k ->
-    let s = Tool_name.Keeper.to_string k in
-    let parsed = Tool_name.Keeper.of_string s in
-    Alcotest.(check (option (of_pp Tool_name.Keeper.pp)))
-      (Printf.sprintf "roundtrip %s" s) (Some k) parsed
-  ) all_keeper
+  List.map (fun m -> Tool_name.Masc m) all_masc
 
 let test_roundtrip_masc () =
-  List.iter (fun m ->
-    let s = Tool_name.Masc.to_string m in
-    let parsed = Tool_name.Masc.of_string s in
-    Alcotest.(check (option (of_pp Tool_name.Masc.pp)))
-      (Printf.sprintf "roundtrip %s" s) (Some m) parsed
-  ) all_masc
-
-let test_roundtrip_masc_keeper () =
-  List.iter (fun mk ->
-    let s = Tool_name.Masc_keeper.to_string mk in
-    let parsed = Tool_name.Masc_keeper.of_string s in
-    Alcotest.(check (option (of_pp Tool_name.Masc_keeper.pp)))
-      (Printf.sprintf "roundtrip %s" s) (Some mk) parsed
-  ) all_masc_keeper
+  List.iter
+    (fun m ->
+      let s = Tool_name.Masc.to_string m in
+      let parsed = Tool_name.Masc.of_string s in
+      Alcotest.(check (option (of_pp Tool_name.Masc.pp)))
+        (Printf.sprintf "roundtrip %s" s)
+        (Some m)
+        parsed)
+    all_masc
 
 let test_roundtrip_toplevel () =
-  List.iter (fun t ->
-    let s = Tool_name.to_string t in
-    let parsed = Tool_name.of_string s in
-    Alcotest.(check (option (of_pp Tool_name.pp)))
-      (Printf.sprintf "roundtrip %s" s) (Some t) parsed
-  ) all_tool_names
-
-(* ── Prefix invariants ─────────────────────────────────────── *)
-
-(* Keeper variants that intentionally use a non-keeper_ prefix.
-   These are shared-surface tools whose canonical string id starts
-   with "tool_" rather than "keeper_" (see PR #18520, #18779). *)
-let keeper_shared_surface_prefixes =
-  [ "tool_execute"; "tool_edit_file"; "tool_read_file"; "tool_search_files"
-  ; "tool_write_file" ]
-
-let test_keeper_prefix () =
-  List.iter (fun k ->
-    let s = Tool_name.Keeper.to_string k in
-    if not (List.mem s keeper_shared_surface_prefixes) then
-      Alcotest.(check bool)
-        (Printf.sprintf "%s starts with keeper_" s)
-        true
-        (String.length s > 7 && String.sub s 0 7 = "keeper_")
-  ) all_keeper
+  List.iter
+    (fun t ->
+      let s = Tool_name.to_string t in
+      let parsed = Tool_name.of_string s in
+      Alcotest.(check (option (of_pp Tool_name.pp)))
+        (Printf.sprintf "roundtrip %s" s)
+        (Some t)
+        parsed)
+    all_tool_names
 
 let test_masc_prefix () =
-  List.iter (fun m ->
-    let s = Tool_name.Masc.to_string m in
-    Alcotest.(check bool)
-      (Printf.sprintf "%s starts with masc_" s)
-      true
-      (String.length s > 5 && String.sub s 0 5 = "masc_")
-  ) all_masc
-
-let test_masc_keeper_prefix () =
-  List.iter (fun mk ->
-    let s = Tool_name.Masc_keeper.to_string mk in
-    Alcotest.(check bool)
-      (Printf.sprintf "%s starts with masc_keeper_" s)
-      true
-      (String.length s > 12 && String.sub s 0 12 = "masc_keeper_")
-  ) all_masc_keeper
-
-(* ── Uniqueness ────────────────────────────────────────────── *)
+  List.iter
+    (fun m ->
+      let s = Tool_name.Masc.to_string m in
+      Alcotest.(check bool)
+        (Printf.sprintf "%s starts with masc_" s)
+        true
+        (String.length s > 5 && String.sub s 0 5 = "masc_"))
+    all_masc
 
 let test_all_names_unique () =
   let names = List.map Tool_name.to_string all_tool_names in
   let sorted = List.sort String.compare names in
   let rec check = function
     | a :: b :: rest ->
-      if a = b then
+      if String.equal a b then
         Alcotest.fail (Printf.sprintf "duplicate tool name: %s" a)
       else check (b :: rest)
     | _ -> ()
   in
   check sorted
 
-(* ── Unknown strings fail closed ───────────────────────────── *)
+let test_removed_keeper_names_fail_closed () =
+  let removed =
+    [ "keeper_board_post"
+    ; "keeper_board_comment"
+    ; "masc_keeper_status"
+    ; "masc_keeper_sandbox_start"
+    ]
+  in
+  List.iter
+    (fun s ->
+      Alcotest.(check (option (of_pp Tool_name.pp)))
+        (Printf.sprintf "removed %s -> None" s)
+        None
+        (Tool_name.of_string s))
+    removed
 
 let test_unknown_returns_none () =
   let unknowns = [ "keeper_nonexistent"; "masc_fake"; "foobar"; "" ] in
-  List.iter (fun s ->
-    Alcotest.(check (option (of_pp Tool_name.pp)))
-      (Printf.sprintf "unknown %s -> None" s)
-      None (Tool_name.of_string s)
-  ) unknowns
+  List.iter
+    (fun s ->
+      Alcotest.(check (option (of_pp Tool_name.pp)))
+        (Printf.sprintf "unknown %s -> None" s)
+        None
+        (Tool_name.of_string s))
+    unknowns
 
-let test_keeper_board_write_helpers () =
-  let open Tool_name.Keeper in
-  List.iter
-    (fun tool ->
-       Alcotest.(check bool)
-         (Printf.sprintf "%s is board" (to_string tool))
-         true
-         (is_board tool))
-    [ Board_comment; Board_comment_vote; Board_curation_read
-    ; Board_curation_submit; Board_get; Board_list; Board_post
-    ; Board_search; Board_stats; Board_vote ];
-  List.iter
-    (fun tool ->
-       Alcotest.(check bool)
-         (Printf.sprintf "%s is not board" (to_string tool))
-         false
-         (is_board tool))
-    [ Broadcast; Task_done ];
-  Alcotest.(check (list string)) "canonical board write names"
-    [ "keeper_board_post"; "keeper_board_comment"; "keeper_board_vote"; "keeper_board_curation_submit" ]
-    board_write_tool_names;
-  List.iter
-    (fun tool ->
-       Alcotest.(check bool)
-         (Printf.sprintf "%s is board write" (to_string tool))
-         true
-         (is_board_write tool))
-    board_write_tools;
-  List.iter
-    (fun tool ->
-       Alcotest.(check bool)
-         (Printf.sprintf "%s is not board write" (to_string tool))
-         false
-         (is_board_write tool))
-    [ Board_list; Board_get; Board_curation_read; Board_comment_vote; Task_done ];
-  Alcotest.(check (option string)) "post action kind"
-    (Some "post") (board_write_action_kind Board_post);
-  Alcotest.(check (option string)) "comment action kind"
-    (Some "comment") (board_write_action_kind Board_comment);
-  Alcotest.(check (option string)) "vote action kind"
-    (Some "vote") (board_write_action_kind Board_vote);
-  Alcotest.(check (option string)) "curation action kind"
-    (Some "curation") (board_write_action_kind Board_curation_submit);
-  Alcotest.(check (option string)) "non-board action kind"
-    None (board_write_action_kind Board_list)
-
-let test_keeper_board_write_facade_uses_typed_contract () =
-  Alcotest.(check (list string)) "exec context names mirror Tool_name"
-    Tool_name.Keeper.board_write_tool_names
-    Keeper_context_runtime.keeper_board_write_tool_names;
-  Alcotest.(check bool) "comment is board write" true
-    (Keeper_context_runtime.keeper_write_done [ "keeper_board_comment" ]);
-  Alcotest.(check bool) "comment vote is not board write" false
-    (Keeper_context_runtime.keeper_write_done [ "keeper_board_comment_vote" ]);
-  Alcotest.(check string) "post has stable priority" "post"
-    (Keeper_context_runtime.keeper_action_kind_of_tool_names
-       [ "keeper_board_vote"; "keeper_board_post" ]);
-  Alcotest.(check string) "non-board action kind is none" "none"
-    (Keeper_context_runtime.keeper_action_kind_of_tool_names
-       [ "keeper_board_comment_vote"; "unknown" ])
-
-let test_board_predicate_facade_uses_typed_contract () =
+let test_board_predicate_uses_masc_domain_contract () =
   let check_tool label expected name =
-    Alcotest.(check bool) label expected
+    Alcotest.(check bool)
+      label
+      expected
       (match Tool_name.of_string name with
        | Some tool -> Tool_name.is_board tool
        | None -> false)
   in
-  check_tool "keeper board post is board" true "keeper_board_post";
-  check_tool "keeper comment vote is board" true "keeper_board_comment_vote";
   check_tool "masc board post is board" true "masc_board_post";
   check_tool "masc board profile is board" true "masc_board_profile";
-  check_tool "keeper fake board prefix fails closed" false "keeper_board_fake";
   check_tool "masc fake board prefix fails closed" false "masc_board_fake";
-  check_tool "broadcast is not board" false "keeper_broadcast"
+  check_tool "broadcast is not board" false "masc_broadcast"
 
-(* ── Group predicates ──────────────────────────────────────── *)
-
-let test_is_keeper () =
-  List.iter (fun k ->
-    Alcotest.(check bool) "is_keeper" true
-      (Tool_name.is_keeper (Keeper k))
-  ) all_keeper;
-  List.iter (fun m ->
-    Alcotest.(check bool) "masc is not keeper" false
-      (Tool_name.is_keeper (Masc m))
-  ) all_masc
-
-(* ── Coverage: all shard tool schemas must parse ───────────── *)
-
-let test_shard_tools_parse () =
-  let shard_names =
-    [ "base"; "board"; "filesystem"; "search_files"; "voice"; "pr"; "library" ]
-  in
-  let tool_names =
-    List.concat_map (fun sn ->
-      match Tool_shard.get_shard sn with
-      | Some shard ->
-        List.map (fun (t : Masc_domain.tool_schema) -> t.name) shard.tools
-      | None -> []
-    ) shard_names
-  in
-  let unparsed = List.filter (fun name ->
-    Tool_name.of_string name = None
-  ) tool_names in
-  if unparsed <> [] then
-    Alcotest.fail
-      (Printf.sprintf "Tool_shard names not in Tool_name: [%s]"
-         (String.concat "; " unparsed))
+let test_is_masc () =
+  List.iter
+    (fun m ->
+      Alcotest.(check bool) "is_masc" true (Tool_name.is_masc (Masc m)))
+    all_masc
 
 let test_prefilter_synonyms_parse () =
-  let unparsed = List.filter (fun name ->
-    Tool_name.of_string name = None
-  ) Tool_prefilter.synonym_keys in
+  let unparsed =
+    List.filter
+      (fun name ->
+        String.starts_with ~prefix:"masc_" name && Tool_name.of_string name = None)
+      Tool_prefilter.synonym_keys
+  in
   if unparsed <> [] then
     Alcotest.fail
-      (Printf.sprintf "Tool_prefilter synonyms not in Tool_name: [%s]"
+      (Printf.sprintf
+         "MASC Tool_prefilter synonyms not in Tool_name: [%s]"
          (String.concat "; " unparsed))
 
 let () =
-  Alcotest.run "Tool_name" [
-    "roundtrip", [
-      Alcotest.test_case "keeper" `Quick test_roundtrip_keeper;
-      Alcotest.test_case "masc" `Quick test_roundtrip_masc;
-      Alcotest.test_case "masc_keeper" `Quick test_roundtrip_masc_keeper;
-      Alcotest.test_case "toplevel" `Quick test_roundtrip_toplevel;
-    ];
-    "invariants", [
-      Alcotest.test_case "keeper prefix" `Quick test_keeper_prefix;
-      Alcotest.test_case "masc prefix" `Quick test_masc_prefix;
-      Alcotest.test_case "masc_keeper prefix" `Quick test_masc_keeper_prefix;
-      Alcotest.test_case "all unique" `Quick test_all_names_unique;
-      Alcotest.test_case "unknown -> None" `Quick test_unknown_returns_none;
-      Alcotest.test_case "keeper board write helpers" `Quick
-        test_keeper_board_write_helpers;
-      Alcotest.test_case "keeper board write facade" `Quick
-        test_keeper_board_write_facade_uses_typed_contract;
-      Alcotest.test_case "board predicate facade" `Quick
-        test_board_predicate_facade_uses_typed_contract;
-      Alcotest.test_case "is_keeper" `Quick test_is_keeper;
-    ];
-    "coverage", [
-      Alcotest.test_case "shard tools parse" `Quick test_shard_tools_parse;
-      Alcotest.test_case "prefilter synonyms parse" `Quick test_prefilter_synonyms_parse;
-    ];
-  ]
+  Alcotest.run
+    "Tool_name"
+    [ ( "roundtrip"
+      , [ Alcotest.test_case "masc" `Quick test_roundtrip_masc
+        ; Alcotest.test_case "toplevel" `Quick test_roundtrip_toplevel
+        ] )
+    ; ( "invariants"
+      , [ Alcotest.test_case "masc prefix" `Quick test_masc_prefix
+        ; Alcotest.test_case "all unique" `Quick test_all_names_unique
+        ; Alcotest.test_case "removed keeper names fail closed" `Quick
+            test_removed_keeper_names_fail_closed
+        ; Alcotest.test_case "unknown -> None" `Quick test_unknown_returns_none
+        ; Alcotest.test_case "board predicate facade" `Quick
+            test_board_predicate_uses_masc_domain_contract
+        ; Alcotest.test_case "is_masc" `Quick test_is_masc
+        ] )
+    ; ( "coverage"
+      , [ Alcotest.test_case "prefilter synonyms parse" `Quick
+            test_prefilter_synonyms_parse
+        ] )
+    ]

--- a/test/test_tool_name_exhaustive.ml
+++ b/test/test_tool_name_exhaustive.ml
@@ -1,118 +1,46 @@
 open Alcotest
 
-(** RFC-0084 §3.1 Tool_name.t exhaustiveness closure.
+(** Tool_name no longer has a [Masc_keeper] branch. Keeper lifecycle/tool
+    execution names are outside the public MASC tool-name sum, so old
+    [masc_keeper_*] strings must fail closed instead of re-entering typed
+    dispatch through a compatibility branch. *)
 
-    PR-2 adds 4 missing variants to [Tool_name.Masc_keeper.t] so that all
-    dispatched [masc_keeper_*] tool names round-trip through the typed
-    sum without falling back to the runtime tag-registry path in
-    [keeper_tag_dispatch.ml].
-
-    Reference: agent #1 spot-trace (RFC-0084 §1.1) identified that
-    [masc_keeper_sandbox_status/start/stop] and [masc_keeper_msg_result]
-    were dispatched but missing from the typed variant, forcing routes
-    through [static_tag_of_tool_name] to return [None] and fall through
-    to runtime tag-registry. *)
-
-let all_masc_keeper_variants : Tool_name.Masc_keeper.t list =
-  [ Clear
-  ; Compact
-  ; Create_from_persona
-  ; Down
-  ; List
-  ; Msg
-  ; Msg_result
-  ; Persona_audit
-  ; Repair
-  ; Reset
-  ; Sandbox_start
-  ; Sandbox_status
-  ; Sandbox_stop
-  ; Status
-  ; Up
+let removed_masc_keeper_names =
+  [ "masc_keeper_clear"
+  ; "masc_keeper_compact"
+  ; "masc_keeper_create_from_persona"
+  ; "masc_keeper_msg"
+  ; "masc_keeper_msg_result"
+  ; "masc_keeper_persona_audit"
+  ; "masc_keeper_repair"
+  ; "masc_keeper_sandbox_start"
+  ; "masc_keeper_sandbox_status"
+  ; "masc_keeper_sandbox_stop"
+  ; "masc_keeper_status"
   ]
 
-let test_round_trip_all_masc_keeper_variants () =
-  (* Every Masc_keeper.t variant must round-trip through to_string/of_string. *)
+let test_removed_masc_keeper_names_fail_closed () =
   List.iter
-    (fun v ->
-      let s = Tool_name.Masc_keeper.to_string v in
-      match Tool_name.Masc_keeper.of_string s with
-      | Some v' when v = v' -> ()
-      | Some _ ->
-        failf "round-trip mismatch for %s (different variant)" s
-      | None ->
-        failf "round-trip miss: of_string %S returned None" s)
-    all_masc_keeper_variants
+    (fun name ->
+      check (option string)
+        (Printf.sprintf "%s no longer parses through Tool_name" name)
+        None
+        (Option.map Tool_name.to_string (Tool_name.of_string name)))
+    removed_masc_keeper_names
 
-let test_msg_result_typed () =
-  (* RFC-0084 §3.1: masc_keeper_msg_result must resolve to typed variant. *)
-  (check (option string))
-    "masc_keeper_msg_result of_string returns Some Msg_result"
-    (Some "masc_keeper_msg_result")
-    (Option.map
-       Tool_name.Masc_keeper.to_string
-       (Tool_name.Masc_keeper.of_string "masc_keeper_msg_result"))
-
-let test_sandbox_start_typed () =
-  (check (option string))
-    "masc_keeper_sandbox_start of_string returns Some Sandbox_start"
-    (Some "masc_keeper_sandbox_start")
-    (Option.map
-       Tool_name.Masc_keeper.to_string
-       (Tool_name.Masc_keeper.of_string "masc_keeper_sandbox_start"))
-
-let test_sandbox_status_typed () =
-  (check (option string))
-    "masc_keeper_sandbox_status of_string returns Some Sandbox_status"
-    (Some "masc_keeper_sandbox_status")
-    (Option.map
-       Tool_name.Masc_keeper.to_string
-       (Tool_name.Masc_keeper.of_string "masc_keeper_sandbox_status"))
-
-let test_sandbox_stop_typed () =
-  (check (option string))
-    "masc_keeper_sandbox_stop of_string returns Some Sandbox_stop"
-    (Some "masc_keeper_sandbox_stop")
-    (Option.map
-       Tool_name.Masc_keeper.to_string
-       (Tool_name.Masc_keeper.of_string "masc_keeper_sandbox_stop"))
-
-let test_unknown_returns_none () =
-  (check (option string))
-    "unknown masc_keeper_* name returns None"
-    None
-    (Option.map
-       Tool_name.Masc_keeper.to_string
-       (Tool_name.Masc_keeper.of_string "masc_keeper_nonexistent"))
-
-let test_variant_count () =
-  (* Pin the variant count so future additions are caught by this assertion. *)
-  (check int)
-    "Masc_keeper.t variant count (RFC-0084 §3.1; update when adding variants)"
-    15
-    (List.length all_masc_keeper_variants)
-
-let test_top_level_of_string_via_masc_keeper () =
-  (* Top-level Tool_name.of_string routes masc_keeper_* through Masc_keeper. *)
-  match Tool_name.of_string "masc_keeper_sandbox_start" with
-  | Some (Tool_name.Masc_keeper Sandbox_start) -> ()
-  | Some other ->
-    failf
-      "expected Masc_keeper Sandbox_start, got %s"
-      (Tool_name.to_string other)
-  | None -> failf "Tool_name.of_string returned None for masc_keeper_sandbox_start"
+let test_current_masc_name_still_round_trips () =
+  match Tool_name.of_string "masc_status" with
+  | Some tool ->
+    check string "masc_status roundtrip" "masc_status" (Tool_name.to_string tool)
+  | None -> failf "masc_status should still parse"
 
 let () =
   Alcotest.run
-    "RFC-0084 Tool_name.t exhaustive closure"
-    [ ( "masc-keeper-variants"
-      , [ test_case "round-trip-all-variants" `Quick test_round_trip_all_masc_keeper_variants
-        ; test_case "msg-result-typed" `Quick test_msg_result_typed
-        ; test_case "sandbox-start-typed" `Quick test_sandbox_start_typed
-        ; test_case "sandbox-status-typed" `Quick test_sandbox_status_typed
-        ; test_case "sandbox-stop-typed" `Quick test_sandbox_stop_typed
-        ; test_case "unknown-returns-none" `Quick test_unknown_returns_none
-        ; test_case "variant-count-pin" `Quick test_variant_count
-        ; test_case "top-level-of-string" `Quick test_top_level_of_string_via_masc_keeper
+    "Tool_name removed keeper closure"
+    [ ( "removed-masc-keeper"
+      , [ test_case "removed names fail closed" `Quick
+            test_removed_masc_keeper_names_fail_closed
+        ; test_case "current masc name roundtrips" `Quick
+            test_current_masc_name_still_round_trips
         ] )
     ]

--- a/test/test_tool_registration_consistency.ml
+++ b/test/test_tool_registration_consistency.ml
@@ -324,24 +324,21 @@ let test_board_read_only_metadata_registered () =
   Alcotest.(check bool) "board post stays mutable"
     false (Masc_mcp.Tool_capability.has Masc_mcp.Tool_capability.Read_only "masc_board_post")
 
-(* ── Test: keeper alias SSOT — capability_registry derives from surfaces ── *)
+(* ── Test: keeper backend mapping returns registered schemas ─────────── *)
 
 let test_keeper_alias_ssot_consistency () =
   let open Tool_catalog_surfaces in
-  (* Exhaustive: every keeper_internal_tools entry *)
+  let schema_names =
+    List.map (fun (schema : Masc_domain.tool_schema) -> schema.name)
+      Masc_mcp.Config.raw_all_tool_schemas
+  in
   List.iter (fun keeper_name ->
-    let from_surfaces = keeper_internal_replacement keeper_name in
     let from_registry = Capability_registry.keeper_backend_tool_name keeper_name in
-    match from_surfaces with
-    | Some masc_name ->
-        Alcotest.(check string)
-          (Printf.sprintf "%s alias must match" keeper_name)
-          masc_name from_registry
-    | None ->
-        Alcotest.(check string)
-          (Printf.sprintf "%s (native) must be identity" keeper_name)
-          keeper_name from_registry
-  ) keeper_internal_tools;
+    Alcotest.(check bool)
+      (Printf.sprintf "%s backend mapping has schema" keeper_name)
+      true
+      (List.mem from_registry schema_names)
+  ) Capability_registry.privileged_keeper_tool_names;
   (* Pin asymmetric mapping: keeper_tasks_list -> masc_tasks (not masc_tasks_list) *)
   Alcotest.(check string) "keeper_tasks_list quirk"
     "masc_tasks" (Capability_registry.keeper_backend_tool_name "keeper_tasks_list");
@@ -389,7 +386,7 @@ let () =
             "unsharded default tools not flagged as orphan_toml"
             `Quick
             test_unsharded_default_tools_not_orphaned;
-          Alcotest.test_case "keeper_backend_tool_name matches keeper_internal_replacement" `Quick
+          Alcotest.test_case "keeper_backend_tool_name maps to schemas" `Quick
             test_keeper_alias_ssot_consistency;
         ] );
     ]

--- a/test/test_tool_surface_ssot.ml
+++ b/test/test_tool_surface_ssot.ml
@@ -72,7 +72,7 @@ let test_admin_parity () =
 
 let test_keeper_denied_parity () =
   let legacy = set_of Keeper_hooks_oas.keeper_denied_tools in
-  let ssot = set_of (Tool_catalog.tools_for_surface Tool_catalog.Keeper_denied) in
+  let ssot = set_of (Tool_catalog.tools_for_surface Tool_catalog.System_internal) in
   check_set_equal "Keeper_denied" ~expected:legacy ~actual:ssot
 
 (* {1 Structural Invariants — hold regardless of migration phase} *)
@@ -102,7 +102,7 @@ let public_keeper_denied_overlap_allowed =
     ]
 
 let test_keeper_denied_public_mcp_overlap_is_explicit () =
-  let denied = set_of (Tool_catalog.tools_for_surface Tool_catalog.Keeper_denied) in
+  let denied = set_of (Tool_catalog.tools_for_surface Tool_catalog.System_internal) in
   let public = set_of (Tool_catalog.tools_for_surface Tool_catalog.Public_mcp) in
   let overlap = SS.inter denied public in
   let unexpected = SS.diff overlap public_keeper_denied_overlap_allowed in
@@ -117,7 +117,7 @@ let test_keeper_denied_public_mcp_overlap_is_explicit () =
     (SS.is_empty unexpected && SS.is_empty missing)
 
 let test_keeper_internal_disjoint_from_public_mcp () =
-  let internal = set_of (Tool_catalog.tools_for_surface Tool_catalog.Keeper_internal) in
+  let internal = set_of (Tool_catalog.tools_for_surface Tool_catalog.Agent_internal) in
   let public = set_of (Tool_catalog.tools_for_surface Tool_catalog.Public_mcp) in
   let overlap = SS.inter internal public in
   if not (SS.is_empty overlap) then
@@ -127,7 +127,7 @@ let test_keeper_internal_disjoint_from_public_mcp () =
     (SS.is_empty overlap)
 
 let test_keeper_internal_contains_known_tools () =
-  let internal = set_of (Tool_catalog.tools_for_surface Tool_catalog.Keeper_internal) in
+  let internal = set_of (Tool_catalog.tools_for_surface Tool_catalog.Agent_internal) in
   List.iter
     (fun name ->
       Alcotest.(check bool) (name ^ " is internal") true (SS.mem name internal))
@@ -145,34 +145,8 @@ let test_retired_pr_tools_are_not_active_schemas () =
       Alcotest.(check bool) (name ^ " removed from raw schema universe") false
         (Option.is_some (raw_schema_by_name name));
       Alcotest.(check bool) (name ^ " not keeper-internal surface") false
-        (Tool_catalog.is_on_surface Tool_catalog.Keeper_internal name))
+        (Tool_catalog.is_on_surface Tool_catalog.Agent_internal name))
     [ retired_review_tool "read"; retired_review_tool "comment"; retired_review_tool "reply" ]
-
-let test_keeper_voice_replacement_contract () =
-  Alcotest.(check (option string))
-    "voice speak replacement removed"
-    None
-    (Tool_catalog_surfaces.keeper_internal_replacement "keeper_voice_speak");
-  Alcotest.(check (option string))
-    "voice agent replacement removed"
-    None
-    (Tool_catalog_surfaces.keeper_internal_replacement "keeper_voice_agent");
-  Alcotest.(check (option string))
-    "voice sessions replacement removed"
-    None
-    (Tool_catalog_surfaces.keeper_internal_replacement "keeper_voice_sessions");
-  Alcotest.(check (option string))
-    "voice session start replacement removed"
-    None
-    (Tool_catalog_surfaces.keeper_internal_replacement "keeper_voice_session_start");
-  Alcotest.(check (option string))
-    "voice session end replacement removed"
-    None
-    (Tool_catalog_surfaces.keeper_internal_replacement "keeper_voice_session_end");
-  Alcotest.(check (option string))
-    "voice listen remains keeper-only"
-    None
-    (Tool_catalog_surfaces.keeper_internal_replacement "keeper_voice_listen")
 
 let test_is_on_surface_consistent () =
   List.iter (fun surface ->
@@ -202,29 +176,12 @@ let test_destructive_check_tools_are_privileged () =
 let test_privileged_keeper_tools_are_internal () =
   (* Every privileged keeper tool (keeper_* prefixed) should be on the
      Keeper_internal surface. *)
-  let internal = set_of (Tool_catalog.tools_for_surface Tool_catalog.Keeper_internal) in
+  let internal = set_of (Tool_catalog.tools_for_surface Tool_catalog.Agent_internal) in
   List.iter (fun name ->
     if String.starts_with ~prefix:"keeper_" name then
       Alcotest.(check bool) (name ^ " in Keeper_internal") true
         (SS.mem name internal)
   ) Capability_registry.privileged_keeper_tool_names
-
-let test_replacement_targets_have_schemas () =
-  (* Every keeper_internal_replacement target should have a registered schema.
-     Not all need to be public — some are hidden but still callable. *)
-  let internal = Tool_catalog.tools_for_surface Tool_catalog.Keeper_internal in
-  let all_schema_names =
-    List.map (fun (s : Masc_domain.tool_schema) -> s.name)
-      Config.raw_all_tool_schemas
-  in
-  List.iter (fun name ->
-    match Tool_catalog_surfaces.keeper_internal_replacement name with
-    | Some public_name ->
-      Alcotest.(check bool)
-        (Printf.sprintf "%s -> %s has schema" name public_name)
-        true (List.mem public_name all_schema_names)
-    | None -> ()
-  ) internal
 
 let test_keeper_internal_tools_have_schemas () =
   (* Every tool in keeper_internal_tools should have a schema in the
@@ -236,9 +193,7 @@ let test_keeper_internal_tools_have_schemas () =
     |> List.map (fun (s : Masc_domain.tool_schema) -> s.name)
     |> SS.of_list
   in
-  let internal_names =
-    Tool_catalog_surfaces.keeper_internal_tools |> SS.of_list
-  in
+  let internal_names = Capability_registry.privileged_keeper_tool_names |> SS.of_list in
   let missing = SS.diff internal_names schema_names in
   if not (SS.is_empty missing) then
     Alcotest.failf
@@ -382,7 +337,7 @@ let test_keeper_internal_descriptions_no_cross_leak () =
   let internal_schemas =
     Config.raw_all_tool_schemas
     |> List.filter (fun (s : Masc_domain.tool_schema) ->
-           Tool_catalog.is_on_surface Tool_catalog.Keeper_internal s.name)
+           Tool_catalog.is_on_surface Tool_catalog.Agent_internal s.name)
   in
   let violations = ref [] in
   List.iter (fun (schema : Masc_domain.tool_schema) ->
@@ -422,15 +377,6 @@ let test_system_internal_callable () =
     Alcotest.failf "System_internal tools not callable: {%s}"
       (String.concat ", " uncallable);
   Alcotest.(check bool) "all system_internal callable" true (uncallable = [])
-
-let test_workspace_mutating_canonical_used () =
-  (* workspace_mutating_tool_names in tool_catalog_surfaces is the canonical list.
-     Verify no empty or phantom entries. *)
-  Alcotest.(check bool) "non-empty" true
-    (List.length Tool_catalog_surfaces.workspace_mutating_tool_names > 0);
-  List.iter (fun name ->
-    Alcotest.(check bool) (name ^ " non-empty") true (String.length name > 0)
-  ) Tool_catalog_surfaces.workspace_mutating_tool_names
 
 let test_role_catalogs_only_expose_available_tools () =
   let available =
@@ -481,8 +427,6 @@ let () =
             test_keeper_internal_contains_known_tools;
           Alcotest.test_case "retired PR review tools are not active schemas" `Quick
             test_retired_pr_tools_are_not_active_schemas;
-          Alcotest.test_case "Keeper voice replacement contract" `Quick
-            test_keeper_voice_replacement_contract;
           Alcotest.test_case "is_on_surface consistent" `Quick
             test_is_on_surface_consistent;
         ] );
@@ -492,12 +436,8 @@ let () =
             test_destructive_check_tools_are_privileged;
           Alcotest.test_case "privileged keeper tools are internal" `Quick
             test_privileged_keeper_tools_are_internal;
-          Alcotest.test_case "replacement targets have schemas" `Quick
-            test_replacement_targets_have_schemas;
           Alcotest.test_case "keeper internal tools have schemas" `Quick
             test_keeper_internal_tools_have_schemas;
-           Alcotest.test_case "workspace_mutating canonical used" `Quick
-             test_workspace_mutating_canonical_used;
            Alcotest.test_case "role catalogs use only available tools" `Quick
              test_role_catalogs_only_expose_available_tools;
            Alcotest.test_case "built role catalogs drop stale entries" `Quick


### PR DESCRIPTION
## Summary
- Align Keeper/OAS checkpoint callers with the current `save_oas_checkpoint` contract by removing stale caller-supplied model arguments.
- Stop reading removed runtime/model fields from MASC keeper meta (`usage.last_model_used`, `per_provider_timeout_s`) and route status/turn timeout behavior through current runtime/profile contracts.
- Remove stale repo credential plumbing from keeper repo readiness and update tests that still asserted removed Keeper/Masc_keeper, legacy Board metric, and old surface contracts.

## Product impact
- Keeps MASC from re-owning OAS model/provider identity while preserving runtime/status behavior through the current runtime/profile surfaces.
- Restores broad OCaml compile checks after the Board/OAS boundary cleanup chain.
- Does not introduce a DB or persistent storage dependency.

## Evidence
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_JOBS=1 DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-keeper-oas-contract scripts/dune-local.sh build test/test_board_dispatch.exe`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_JOBS=1 DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-keeper-oas-check scripts/dune-local.sh build @check`
- `ocamlformat --check <changed OCaml files>`
- `git diff --check`
- `bash scripts/lint/masc-domain-boundary-ratchet.sh --fail`
- `bash scripts/lint/tool-keeper-boundary-ratchet.sh --fail`
- `scripts/oas-boundary-ratchet.sh`
- `scripts/stringly-boundary-ratchet.sh`
- `bash scripts/check-doc-truth.sh`
- `scripts/ocaml-structure-ratchet.sh`
- `scripts/audit-keeper-tool-boundary-matrix.sh`
- `scripts/sync-oas-pin-docs.sh --check`

## Direct evidence
schema_version: 1
direct_ratio: 12/12
provenance: direct

All evidence above was produced locally from this worktree after the commit.

## Review evidence
- Local review focus: stale contract removal, no DB introduction, no MASC-side model identity resurrection.
- Risk: tests were updated to current hard-cut contracts; old compatibility assertions for Keeper/Masc_keeper surfaces were removed rather than preserved.

## Linked issue
- n/a

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`codex/keeper-oas-contract-drift-20260603` → `main` · 1 commit(s) · synced 2026-06-02T17:26:31Z

| sha | subject | date |
|---|---|---|
| `c50337e49` | fix(keeper): align OAS runtime contract callers | 2026-06-02 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->