### PR TITLE
fix(dashboard): align telemetry source label test

### DIFF
--- a/dashboard/src/config/telemetry-sources.test.ts
+++ b/dashboard/src/config/telemetry-sources.test.ts
@@ -19,7 +19,7 @@ describe('telemetrySourceLabel', () => {
   })
 
   it('returns Korean label for tool_usage', () => {
-    expect(telemetrySourceLabel('tool_usage')).toBe('Keeper 내부 호출')
+    expect(telemetrySourceLabel('tool_usage')).toBe('Agent 내부 호출')
   })
 
   it('returns Korean label for oas_event', () => {


### PR DESCRIPTION
## Summary

Align the dashboard telemetry source label test with the current `tool_usage` metadata label.

## Product impact

- User-visible change: None. The dashboard source metadata already renders `tool_usage` as `Agent internal`; this fixes the stale test expectation that failed main Dashboard CI after #19842.

## Evidence

- `pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/config/telemetry-sources.test.ts`
- `pnpm --dir dashboard run typecheck`
- `git diff --check`

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 3/3
provenance: direct
stages:
  - command: "pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/config/telemetry-sources.test.ts"
    result: "pass"
  - command: "pnpm --dir dashboard run typecheck"
    result: "pass"
  - command: "git diff --check"
    result: "pass"
```

## GOAL LOOP ACT checklist

- [x] Observe — main Dashboard CI failed on `telemetrySourceLabel('tool_usage')`, expected old label and received current label.
- [x] Orient — drift is a stale dashboard test expectation left after the Agent/Keeper terminology cleanup in #19842.
- [x] Decide — scope is limited to the failing test expectation because production metadata is already on the current label.
- [x] Act — updated the stale test string only.
- [x] Verify — focused Vitest, dashboard typecheck, and diff whitespace check passed locally.
- [x] Loop — remaining follow-up is PR CI.

## Review evidence

- Not run. This is a one-line test expectation fix for a CI regression.

## Linked issue

- Relates #19842

## Variant addition checklist

- [ ] **OCaml** — N/A, no OCaml variant changed.
- [ ] **TypeScript** — N/A, no TypeScript union member changed.
- [ ] **TLA+ spec** — N/A, no TLA+ domain literal changed.
- [ ] **Event / JSON schema** — N/A, no event or schema enum changed.
- [ ] **`make check-variants` passes** — N/A, no variant/schema surface changed.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`codex/dashboard-telemetry-source-label-20260603` → `main` · 1 commit(s) · synced 2026-06-02T17:48:40Z

| sha | subject | date |
|---|---|---|
| `aa851a7bd` | fix(dashboard): align telemetry source label test | 2026-06-02 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->