### PR TITLE
fix(keeper): remove legacy models field from keeper_profile_defaults (RFC-0211 S4)

### DIFF
--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -260,7 +260,6 @@ let load_keeper_profile_defaults_from_persona name : keeper_profile_defaults =
                             path raw;
                           None
                       | None -> None));
-                models = None;
                 (* oas_env lives only in keeper TOML, not persona JSON —
                    persona profiles are a design-time artifact whereas
                    transport env is an ops-time toggle. *)

--- a/lib/keeper/keeper_types_profile_defaults.ml
+++ b/lib/keeper/keeper_types_profile_defaults.ml
@@ -35,12 +35,6 @@ type keeper_profile_defaults = {
   per_provider_timeout : float option;
   always_approve : bool option;
   social_model : string option;
-  (* NB: there is no per-keeper [model]/[runtime_id] field. persona⊥
-     {model,runtime}: keeper→runtime assignment is the sole responsibility of
-     runtime.toml [[runtime.assignments]] (keyed by keeper name), resolved via
-     {!Runtime.runtime_id_for_keeper}.  Neither persona JSON nor keeper TOML
-     carries a runtime selection. *)
-  models : string list option;
   (* Turn budget overrides. None = inherit env default
      (MASC_KEEPER_OAS_MAX_TURNS_PER_CALL / ..._SCHEDULED_AUTONOMOUS). *)
   max_turns_per_call : int option;
@@ -93,7 +87,6 @@ let empty_keeper_profile_defaults =
     per_provider_timeout = None;
     always_approve = None;
     social_model = None;
-    models = None;
     max_turns_per_call = None;
     max_turns_per_call_scheduled_autonomous = None;
     unknown_toml_keys = [];

--- a/lib/keeper/keeper_types_profile_defaults.mli
+++ b/lib/keeper/keeper_types_profile_defaults.mli
@@ -38,7 +38,6 @@ type keeper_profile_defaults = {
   social_model : string option;
   (* No per-keeper [model]/[runtime_id] field: keeper→runtime assignment lives
      solely in runtime.toml [[runtime.assignments]] (persona⊥{model,runtime}). *)
-  models : string list option;
   max_turns_per_call : int option;
   max_turns_per_call_scheduled_autonomous : int option;
   oas_env : (string * string) list;

--- a/lib/keeper/keeper_types_profile_toml.mli
+++ b/lib/keeper/keeper_types_profile_toml.mli
@@ -172,7 +172,6 @@ type keeper_profile_defaults =
   per_provider_timeout : float option;
   always_approve : bool option;
   social_model : string option;
-  models : string list option;
   max_turns_per_call : int option;
   max_turns_per_call_scheduled_autonomous : int option;
   oas_env : (string * string) list;

--- a/lib/keeper/keeper_types_profile_toml_io.mli
+++ b/lib/keeper/keeper_types_profile_toml_io.mli
@@ -172,7 +172,6 @@ type keeper_profile_defaults =
   per_provider_timeout : float option;
   always_approve : bool option;
   social_model : string option;
-  models : string list option;
   max_turns_per_call : int option;
   max_turns_per_call_scheduled_autonomous : int option;
   oas_env : (string * string) list;

--- a/lib/keeper/keeper_types_profile_toml_normalizers.mli
+++ b/lib/keeper/keeper_types_profile_toml_normalizers.mli
@@ -172,7 +172,6 @@ type keeper_profile_defaults =
   per_provider_timeout : float option;
   always_approve : bool option;
   social_model : string option;
-  models : string list option;
   max_turns_per_call : int option;
   max_turns_per_call_scheduled_autonomous : int option;
   oas_env : (string * string) list;

--- a/lib/keeper/keeper_types_profile_toml_parser.ml
+++ b/lib/keeper/keeper_types_profile_toml_parser.ml
@@ -180,7 +180,6 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
         max_turns_per_call_scheduled_autonomous =
           int_ "max_turns_per_call_scheduled_autonomous";
         social_model = normalize_social_model_opt (str "social_model");
-        models = None;
         oas_env = extract_oas_env_from_doc doc;
         unknown_toml_keys = [];
       })
@@ -400,7 +399,6 @@ let merge_keeper_profile_defaults
     per_provider_timeout;
     always_approve = prefer overlay.always_approve base.always_approve;
     social_model = prefer overlay.social_model base.social_model;
-    models = None;
     max_turns_per_call = prefer overlay.max_turns_per_call base.max_turns_per_call;
     max_turns_per_call_scheduled_autonomous =
       prefer overlay.max_turns_per_call_scheduled_autonomous

--- a/lib/keeper/keeper_types_profile_toml_parser.mli
+++ b/lib/keeper/keeper_types_profile_toml_parser.mli
@@ -172,7 +172,6 @@ type keeper_profile_defaults =
   per_provider_timeout : float option;
   always_approve : bool option;
   social_model : string option;
-  models : string list option;
   max_turns_per_call : int option;
   max_turns_per_call_scheduled_autonomous : int option;
   oas_env : (string * string) list;


### PR DESCRIPTION
## Summary

RFC-0211 Section 4: Remove the legacy `models` field from keeper profile defaults and all dependent types/interfaces.

This field was part of the pre-decoupling runtime/provider taxonomy and is no longer referenced by any consumer after PR #19842 (OAS runtime contract alignment).

## Changes

- `lib/keeper/keeper_types_profile.ml` — remove `models` from profile record
- `lib/keeper/keeper_types_profile_defaults.ml` — remove `models` default mapping
- `lib/keeper/keeper_types_profile_defaults.mli` — remove `models` from signature
- `lib/keeper/keeper_types_profile_toml.mli` — remove `models` from TOML schema
- `lib/keeper/keeper_types_profile_toml_io.mli` — remove `models` from IO contract
- `lib/keeper/keeper_types_profile_toml_normalizers.mli` — remove `models` from normalizer
- `lib/keeper/keeper_types_profile_toml_parser.ml` — remove `models` parsing logic
- `lib/keeper/keeper_types_profile_toml_parser.mli` — remove `models` from parser signature

## Verification

- `dune build @check` — exit 0
- `dune build .` — exit 0
- 8 files changed, 15 deletions only (no additions)

## RFC Reference

- RFC-0211 §S4: Profile schema simplification — remove legacy `models` field

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>