### PR TITLE
refactor(runtime): move provider kind resolver into boundary

### DIFF
--- a/lib/runtime/provider_kind_resolver.ml
+++ b/lib/runtime/provider_kind_resolver.ml
@@ -1,4 +1,5 @@
-(** Sum-typed provider-kind resolver. See .mli for the contract. *)
+(** Sum-typed provider-kind resolver inside the runtime/OAS boundary.
+    See .mli for the contract. *)
 
 type resolution =
   | Registered of {

--- a/lib/runtime/provider_kind_resolver.mli
+++ b/lib/runtime/provider_kind_resolver.mli
@@ -1,7 +1,9 @@
 (** Sum-typed provider-kind resolver for runtime model specs.
 
     Resolves a ["provider:model"] spec to a {!Provider_config.provider_kind}
-    via the {!Provider_registry}.
+    via the {!Provider_registry}. This module lives inside the runtime/OAS
+    boundary; masc-core callers should route by opaque runtime id instead of
+    parsing provider/model strings.
 
     This module exists to prevent a recurring anti-pattern where
     callers classify provider kind by substring match over the spec

--- a/scripts/check-oas-internals.sh
+++ b/scripts/check-oas-internals.sh
@@ -13,11 +13,11 @@
 #
 #   warn     (--include-internals):
 #     - `Llm_provider.Provider_kind` qualified module access
-#       outside lib/provider_kind_resolver.{ml,mli}
+#       outside lib/runtime/provider_kind_resolver.{ml,mli}
 #       (informational; allowed uses include serialization, type
 #       annotations, local-module aliases, and comments).
 #     - `Llm_provider.Constants` qualified access outside
-#       lib/oas_compat/ and lib/provider_kind_resolver.{ml,mli}
+#       lib/oas_compat/ and lib/runtime/provider_kind_resolver.{ml,mli}
 #       (informational; runtime subsystem currently legitimately
 #       reads default inference params).
 #
@@ -96,16 +96,16 @@ scan_strict_agent_sdk_internal() {
 }
 
 scan_warn_provider_kind_external() {
-  # Provider_kind qualified access outside provider_kind_resolver.
+  # Provider_kind qualified access outside runtime/provider_kind_resolver.
   local matches
   matches="$(rg -n 'Llm_provider\.Provider_kind|\bProvider_kind\.' lib/ "${RG_BASE_FLAGS[@]}" 2>/dev/null \
-    | grep -v 'lib/provider_kind_resolver\.' \
+    | grep -v 'lib/runtime/provider_kind_resolver\.' \
     | filter_noise || true)"
   if [[ -n "$matches" ]]; then
     if [[ "$strict_internals" -eq 1 ]]; then
-      echo "FAIL [internals]: Llm_provider.Provider_kind raw access outside provider_kind_resolver" >&2
+      echo "FAIL [internals]: Llm_provider.Provider_kind raw access outside runtime/provider_kind_resolver" >&2
     else
-      echo "WARN [internals]: Llm_provider.Provider_kind raw access outside provider_kind_resolver" >&2
+      echo "WARN [internals]: Llm_provider.Provider_kind raw access outside runtime/provider_kind_resolver" >&2
     fi
     echo "$matches" >&2
     return 1
@@ -114,17 +114,17 @@ scan_warn_provider_kind_external() {
 }
 
 scan_warn_constants_external() {
-  # Llm_provider.Constants outside oas_compat / provider_kind_resolver.
+  # Llm_provider.Constants outside oas_compat / runtime/provider_kind_resolver.
   local matches
   matches="$(rg -n 'Llm_provider\.Constants' lib/ "${RG_BASE_FLAGS[@]}" 2>/dev/null \
     | grep -v 'lib/oas_compat/' \
-    | grep -v 'lib/provider_kind_resolver\.' \
+    | grep -v 'lib/runtime/provider_kind_resolver\.' \
     | filter_noise || true)"
   if [[ -n "$matches" ]]; then
     if [[ "$strict_internals" -eq 1 ]]; then
-      echo "FAIL [internals]: Llm_provider.Constants raw access outside oas_compat / provider_kind_resolver" >&2
+      echo "FAIL [internals]: Llm_provider.Constants raw access outside oas_compat / runtime/provider_kind_resolver" >&2
     else
-      echo "WARN [internals]: Llm_provider.Constants raw access outside oas_compat / provider_kind_resolver" >&2
+      echo "WARN [internals]: Llm_provider.Constants raw access outside oas_compat / runtime/provider_kind_resolver" >&2
     fi
     echo "$matches" >&2
     return 1

--- a/scripts/lint/exhaustive-guard.allowlist
+++ b/scripts/lint/exhaustive-guard.allowlist
@@ -678,7 +678,7 @@ lib/process/exec_tap.ml:171
 lib/process/process_eio.ml:113
 lib/process/process_eio.ml:809
 lib/prompt_registry/prompt_registry.ml:276
-lib/provider_kind_resolver.ml:40
+lib/runtime/provider_kind_resolver.ml:38
 lib/repo_manager/keeper_repo_mapping.ml:428
 lib/reputation_autonomy.ml:23
 lib/reputation_ledger_v2.ml:176


### PR DESCRIPTION
## Summary

- Move `Provider_kind_resolver` from root `lib/` into `lib/runtime/`, keeping provider/model spec parsing inside the runtime/OAS boundary.
- Update OAS-internals and exhaustive-guard allowlists to point at the new runtime-boundary location.

## Product impact

- No user-visible behavior change intended.
- This is a boundary-only refactor: MASC core should keep routing by opaque runtime identity instead of parsing provider/model strings.

## Evidence

- `scripts/check-oas-internals.sh`
- `scripts/check-oas-internals.sh --include-internals`
- `scripts/lint/masc-domain-boundary-ratchet.sh --fail`
- `scripts/oas-boundary-ratchet.sh`
- `scripts/stringly-boundary-ratchet.sh`
- `git diff --cached --check`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_JOBS=1 DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-provider-kind-runtime-boundary scripts/dune-local.sh build @lib/check`

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 7/7
provenance: direct
notes:
  - "check-oas-internals include-internals remains warn-tier for existing raw Provider_kind/Constants accesses outside this slice."
```

## Review evidence

- Local review focused on boundary direction: provider/model resolver now physically lives under `lib/runtime/`; current call sites are runtime modules.
- No cross-model review requested in this slice.

## Linked issue

- N/A

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`codex/provider-kind-runtime-boundary-20260603` → `main` · 1 commit(s) · synced 2026-06-02T18:11:35Z

| sha | subject | date |
|---|---|---|
| `bfb784d94` | refactor(runtime): move provider kind resolver into boundary | 2026-06-02 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->