### PR TITLE
fix(boot): resolve masc_keeper_* via flat descriptor registry (unblock server boot)

### DIFF
--- a/lib/keeper/keeper_tool_resolution.ml
+++ b/lib/keeper/keeper_tool_resolution.ml
@@ -21,6 +21,8 @@ type tried_source =
   | Registry_internal_candidate (** S6: Keeper_tool_registry.keeper_internal_candidate_tool_names *)
   | Registry_core_tools         (** S7: Keeper_tool_registry.effective_core_tools *)
   | Shard_schema                (** S8: Tool_shard.all_keeper_tool_schemas name extraction *)
+  | Descriptor_registry         (** S8.5: Keeper_tool_descriptor.all_descriptors public_name —
+                                    flat SSOT incl. internal_descriptors (masc_keeper_* live here) *)
   | Surface of Tool_catalog_surfaces.surface  (** S9-12: Tool_catalog_surfaces.is_on_surface *)
 
 type resolution =
@@ -43,6 +45,7 @@ let string_of_tried_source = function
   | Registry_internal_candidate -> "registry_internal_candidate"
   | Registry_core_tools -> "registry_core_tools"
   | Shard_schema -> "shard_schema"
+  | Descriptor_registry -> "descriptor_registry"
   | Surface s -> Printf.sprintf "surface:%s" (Tool_catalog_surfaces.surface_to_string s)
 
 let string_of_tried sources =
@@ -85,6 +88,21 @@ let resolve name =
               else if
                 List.mem normalized (tool_schema_names Tool_shard.all_keeper_tool_schemas)
               then Resolved { canonical = normalized; via = Shard_schema; surface = None }
+              else if
+                List.exists
+                  (fun (d : Keeper_tool_descriptor.t) ->
+                    String.equal d.Keeper_tool_descriptor.public_name normalized)
+                  (Keeper_tool_descriptor.all_descriptors ())
+              then
+                (* Flat descriptor registry. Descriptor-backed tools live in
+                   [public_descriptors @ internal_descriptors]. masc_keeper_*
+                   (dispatched via Keeper_tool_surface.dispatch, not the handler
+                   registry) sit in internal_descriptors and were orphaned from
+                   resolution when #19797 purged the surface lists. This flat-name
+                   source restores admission without touching dispatch — resolve
+                   is a validity gate; [via] is only used for the error string. *)
+                Resolved
+                  { canonical = normalized; via = Descriptor_registry; surface = None }
               else begin
                 (* RFC-0084 §1.3 — surface coverage gate. *)
                 let surfaces_to_check =
@@ -108,6 +126,7 @@ let resolve name =
                         ; Registry_internal_candidate
                         ; Registry_core_tools
                         ; Shard_schema
+                        ; Descriptor_registry
                         ]
                         @ List.map (fun s -> Surface s) surfaces_to_check
                       in
@@ -150,6 +169,12 @@ let all_admitting_sources name =
     sources := Registry_core_tools :: !sources;
   if List.mem normalized (tool_schema_names Tool_shard.all_keeper_tool_schemas) then
     sources := Shard_schema :: !sources;
+  if
+    List.exists
+      (fun (d : Keeper_tool_descriptor.t) ->
+        String.equal d.Keeper_tool_descriptor.public_name normalized)
+      (Keeper_tool_descriptor.all_descriptors ())
+  then sources := Descriptor_registry :: !sources;
   (* RFC-0084 §1.3 — admit-only surfaces. *)
   let surfaces_to_check =
     [ Tool_catalog_surfaces.Public_mcp

--- a/lib/keeper/keeper_tool_resolution.mli
+++ b/lib/keeper/keeper_tool_resolution.mli
@@ -15,6 +15,7 @@ type tried_source =
   | Registry_internal_candidate (** keeper_internal_candidate_tool_names *)
   | Registry_core_tools         (** effective_core_tools *)
   | Shard_schema                (** Tool_shard.all_keeper_tool_schemas *)
+  | Descriptor_registry         (** Keeper_tool_descriptor.all_descriptors public_name (flat SSOT) *)
   | Surface of Tool_catalog_surfaces.surface
 
 (** Resolution outcome for a tool name. *)

--- a/test/test_keeper_tool_resolution.ml
+++ b/test/test_keeper_tool_resolution.ml
@@ -41,6 +41,26 @@ let test_unknown_returns_tried_list () =
   | _ ->
       fail "__nonexistent_tool_xyz should be Unknown"
 
+let test_descriptor_registry_admits_masc_keeper_cluster () =
+  (* Boot regression guard: #19797 purged masc_keeper_* from surface lists but
+     config/tool_policy.toml still lists them -> keeper_tool_policy_config gate
+     returned Unknown -> server exit 1. The flat Descriptor_registry source
+     (over internal_descriptors public names) restores admission without
+     touching dispatch. @check does NOT exercise this path, hence this test. *)
+  List.iter
+    (fun name ->
+      match TR.resolve name with
+      | TR.Resolved { via = TR.Descriptor_registry; _ } -> ()
+      | TR.Resolved { via; _ } | TR.Alias_to { via; _ } ->
+          fail (Printf.sprintf
+                  "%s should resolve via Descriptor_registry, got via: %s"
+                  name (TR.string_of_tried_source via))
+      | TR.Unknown { tried; _ } ->
+          fail (Printf.sprintf
+                  "%s must resolve (boot policy gate would exit 1), got Unknown (tried: %s)"
+                  name (TR.string_of_tried tried)))
+    [ "masc_keeper_msg"; "masc_keeper_msg_result"; "masc_keeper_list"; "masc_keeper_status" ]
+
 let test_extend_turns_resolved () =
   (* extend_turns is in core_always_tools (S7: Registry_core_tools) or
      Tool_name_variant depending on order *)
@@ -275,6 +295,7 @@ let () =
         test_case "unknown returns tried list" `Quick test_unknown_returns_tried_list;
         test_case "extend_turns resolves" `Quick test_extend_turns_resolved;
         test_case "tool_execute resolves via surface" `Quick test_surface_admits_tool_execute;
+        test_case "masc_keeper_* cluster resolves via descriptor registry (boot guard)" `Quick test_descriptor_registry_admits_masc_keeper_cluster;
         test_case "masc_board_post resolves via alias" `Quick test_alias_masc_to_internal;
       ]
     ; "policy_validation", [


### PR DESCRIPTION
fix(boot): masc_keeper_* unresolved -> server exit 1, restored via flat descriptor registry.

#19797 purged masc_keeper_* from surface lists; left in tool_policy.toml + internal_descriptors. resolve() consulted 12 sources, none = internal_descriptors -> Unknown -> bootstrap exit 1 (compiled green, would not boot). Added Descriptor_registry source over all_descriptors() public names. Dispatch-neutral. + boot-guard test (@check cannot catch this). 5 pre-existing matrix/overlap failures are surface-purge rot-detectors, same on base, fixed by the surface-removal PRs.

RFC-WAIVED: tool-name resolution gate, no credential/identity/sandbox logic.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
