### PR TITLE
refactor(dashboard): forward-safe tool inventory surfaces for tool-layer decouple

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -435,6 +435,35 @@ describe('fetchDashboardTools', () => {
     expect(tools[2]).toMatchObject({ name: 'tool_c', category: 'uncategorized', tier: 'essential' })
   })
 
+  it('totalizes a missing surfaces field to an empty array', async () => {
+    // Tool-layer decoupling groundwork: the OCaml tool layer is shedding the
+    // `surfaces` classification. Once the endpoint stops emitting it, the
+    // normalizer must still hand consumers an array, not undefined.
+    const rawResponse = {
+      tool_inventory: {
+        tools: [
+          { name: 'tool_no_surfaces' },
+          { name: 'tool_with_surfaces', surfaces: ['public_mcp'] },
+        ],
+      },
+      tool_usage: { total_calls: 0, distinct_tools_called: 0, top_20: [], never_called_count: 0, dispatch_v2_enabled: false, registered_count: 2 },
+    }
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(rawResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchDashboardTools()
+
+    const tools = result.tool_inventory.tools
+    expect(tools[0]).toMatchObject({ name: 'tool_no_surfaces', surfaces: [] })
+    expect(tools[1]).toMatchObject({ name: 'tool_with_surfaces', surfaces: ['public_mcp'] })
+  })
+
   it('returns a new object without mutating the raw response', async () => {
     const tools = [{ name: 'tool_x' }]
     const rawResponse = {

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -1990,6 +1990,14 @@ export async function fetchDashboardTools(opts?: AbortableRequestOptions): Promi
     ...t,
     category: t.category ?? 'uncategorized',
     tier: t.tier ?? '(unknown tier)',
+    // Tool-layer decoupling groundwork: the OCaml tool layer is shedding actor
+    // classification (Tool_catalog.surface / tool_group). The `/dashboard/tools`
+    // endpoint still emits `surfaces` today (tool_misc_admin.ml), but will drop
+    // it once classification moves to consumers. Totalize here so the field is
+    // never absent downstream — consumers (tool-state.ts hasSurface /
+    // surfaceCountForFilter, tool-full-inventory) keep working with [] and the
+    // surface filter simply degrades to zero counts. Mirrors category/tier above.
+    surfaces: t.surfaces ?? [],
   }))
   return {
     ...raw,


### PR DESCRIPTION
## 목적

진행 중인 OCaml decoupling(tool layer가 actor/domain 분류를 벗고, "agent"가 Keeper/Client로 분해)에 앞서 대시보드(TS/React)를 정렬하는 **물밑작업(groundwork)**. OCaml API가 실제로 바뀌기 전에 안전하게 적용 가능한 부분만 손댄다.

## 변경 (category (a) — safe now)

`fetchDashboardTools` normalizer에서 tool inventory `surfaces` 필드를 totalize.

- `dashboard/src/api/dashboard.ts:1989` — 기존 `category`/`tier` 기본값 옆에 `surfaces: t.surfaces ?? []` 추가.
- `dashboard/src/api/dashboard.test.ts` — `surfaces` 누락 시 `[]`로 정규화됨을 검증하는 테스트 추가.

근거: `/api/v1/dashboard/tools` 엔드포인트는 **지금은** `surfaces`/`surface_summary`를 계속 emit한다 (`lib/tool_misc_admin.ml:176-189`, `lib/tool/tool_catalog.ml:538`). tool layer decouple이 landing되면 이 필드는 사라진다. 소비자(`tool-state.ts`의 `hasSurface`/`surfaceCountForFilter`, `tool-full-inventory.ts`)는 이미 `?? []`로 방어 중이므로, producer seam을 total하게 만들어 필드가 사라져도 surface 필터가 zero count로 graceful degrade하게 한다. parse-don't-validate 경계에서 처리.

서버가 필드를 계속 emit하는 동안 **동작 변화 없음**.

## 영향 reference 분류 (a/b)

decoupling 키워드로 `dashboard/src` 전수 스캔 결과:

**(a) safe now — 본 PR에서 처리**
- `dashboard.ts:1989` tool inventory `surfaces` → totalize (위)

**(b) blocked until OCaml API lands — 변경하지 않음 (서버가 아직 옛 형태로 emit)**
- `tool-state.ts:22-38` `SurfaceFilter` / `SURFACE_MAP` / `SURFACE_LABELS` — `public_mcp`/`spawned_agent_mcp`/`keeper_standard`/`local_worker` 등 OCaml surface 토큰을 그대로 참조. `lib/capability_registry.ml:85`, `lib/tool/tool_catalog.ml:66`에 enum이 여전히 존재. 필터 UI 제거는 서버가 `surfaces`를 drop한 뒤. (제거가 아닌 make-optional만 안전했고 그건 normalizer로 처리됨)
- `tool-full-inventory.ts:83-122` surface 필터 UI — 위와 동일. 데이터 사라지면 zero count로 degrade.
- `telemetry-unified.ts:1181` `inv?.surface_summary?.public_mcp?.count` — 이미 완전 옵셔널 체이닝 + `?? 0`. 변경 불필요.
- `toolGroup`/`tool_group` — 대시보드는 `tool_group`/`toolGroup`를 **읽지 않음** (`dashboard/src` 0 hit). 서버 측 `lib/tool/tool_catalog.ml:566`만 emit. dashboard no-op.

**(b) wire-format — 절대 rename 금지 (서버 emit key/value 확인됨)**
- `agent_health` (`transport-health.ts:298,567`, `transport-health` schema) — 서버가 JSON key `"agent_health"`를 **계속 emit** (`lib/transport_metrics.ml:743`, `stale_total`/`lifecycle_dispatch_rejections_total`). wire key가 그대로이므로 (b) 분류는 이 사실만으로 확정. 추가로 이 블록은 worker-pool stale 메트릭으로 보여 economy/reputation/health triad와 별개로 *판단*되나, OCaml 모듈 동일성까지는 미확인. 어느 쪽이든 emit key가 `agent_health`라 대시보드 read가 정확하고, rename하면 read가 깨짐(silent default 0).
- `agent_reputation` (board `source` 값, `board.test.ts` 등) — 서버가 `source: "agent_reputation"`를 emit (`lib/server/server_utils.ml:221`). wire payload **값**(대시보드 소유 식별자 아님). `target_kind`/`source`는 대시보드 타입상 plain `string`. 테스트 문자열은 서버가 보내는 것을 assert하므로 정확함.

**없음 (task의 "stale agent_* names" 기대와 mismatch — 정직하게 보고)**
- `tool_group`/`toolGroup`: dashboard/src 0 hit.
- `agent_economy`/`agent_identity`: dashboard/src 0 hit.
- `agent_tool`: 주석 1건만 (`fsm-hub-types.ts:308`, OCaml 파일 경로 인용). 코드 참조 없음.
- agent→keeper dissolution(#19838)은 이미 머지됨 — 대시보드 tool-execution 머신은 이미 정렬된 상태.

**runtime opaque-id (Class 3)**
- `decodeRuntimeProviderSnapshot` (`dashboard.ts:696-716)이 이미 redact: `kind:'runtime'` 강제, `models:[]`, `default_model:null`, `endpoint_url:null`, `discovered_model:null`. runtime id에서 provider/model 구조를 derive하는 소비자 없음. 이미 처리됨 → 변경 불필요.

## 검증

- `pnpm typecheck` (tsc --noEmit): PASS
- `pnpm lint` (eslint src): clean
- `pnpm exec vitest run --config vitest.config.ts`: **521 files, 6573 tests passed**
- `pnpm exec vitest run --config vitest.solid.config.ts`: **7 files, 85 tests passed**
- 신규 surfaces 테스트 포함 (86 → 87 in targeted run)

OCaml `lib/`는 건드리지 않음. Draft only — 머지하지 않음.

RFC-WAIVED: `dashboard/src/api/dashboard.ts` + `dashboard.test.ts`만 변경. credential* / keeper-repo-mapping subsystem 비해당 (guarded 경로 아님).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

