### PR TITLE
fix(tool-policy): remove dead masc_keeper_* entries from config + timeout dead match

### DIFF
--- a/config/tool_policy.toml
+++ b/config/tool_policy.toml
@@ -125,10 +125,6 @@ tools = [
   "masc_dashboard",
   "masc_agent_card",
   "masc_tool_help",
-  "masc_keeper_msg",
-  "masc_keeper_msg_result",
-  "masc_keeper_list",
-  "masc_keeper_status",
 ]
 
 # Goal lifecycle: Goal Store + FSM proof surface.

--- a/lib/mcp_server_eio_tool_timeout.ml
+++ b/lib/mcp_server_eio_tool_timeout.ml
@@ -42,11 +42,6 @@ let tool_timeout ~(tool_name : string) ~(_arguments : Yojson.Safe.t) :
   resolved_tool_timeout option
   =
   match tool_name with
-  | "masc_keeper_msg" ->
-    (* No fixed timeout for keeper_msg. Keeper has its own internal limits
-       (max_turns, max_cost_usd, max_tokens) that control call duration.
-       A fixed external timeout conflicts with multi-turn tool-use loops. *)
-    None
   | "masc_transition" ->
     (* Transition can trigger anti-rationalization review on completion
        paths. A fixed timeout can report a false error while the state


### PR DESCRIPTION
## Problem

PR #19797 purged `masc_keeper_msg`/`msg_result`/`list`/`status` from Tool_catalog surface lists, but `config/tool_policy.toml` still listed them in `[masc.dispatch]`.

Boot gate (`keeper_tool_policy_config` -> `Keeper_tool_resolution.resolve`) consults 12 sources; none matched these 4 names -> `Unknown` -> `server_runtime_bootstrap` exit 1.

PR #19848 added a `Descriptor_registry` workaround to unblock boot. This PR removes the root cause so the workaround is no longer load-bearing.

## Changes

- `config/tool_policy.toml`: remove 4 dead tool names from `[masc.dispatch]`
- `lib/mcp_server_eio_tool_timeout.ml`: remove dead `masc_keeper_msg` timeout match arm

## Verification

- `dune build @check` — exit 0

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>