### PR TITLE
refactor(keeper): typed runtime-exhaustion retryability replaces string reparse

### DIFF
--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -127,6 +127,33 @@ type runtime_exhaustion_reason =
         [No_tool_capable_provider] variant of [masc_internal_error]. *)
   | Other_detail of string
 
+(** Total typed retryability for a runtime-exhaustion reason.
+
+    Replaces a former string-prefix reparse in
+    [keeper_supervisor_pause_policy] that matched on the wire form of
+    [runtime_exhaustion_reason_code] and biased every unlisted reason to
+    non-retryable via a [_ -> false] catch-all.  That polarity was wrong
+    for transient/connectivity faults (Connection_refused, Dns_failure,
+    No_providers_available, All_providers_failed,
+    Structural_attempt_timeout), which the supervisor should retry.
+
+    Exhaustive match: adding a new [runtime_exhaustion_reason] variant
+    fails compilation here, forcing an explicit retryability decision
+    rather than silently defaulting. *)
+let runtime_exhaustion_reason_retryable
+      (reason : runtime_exhaustion_reason)
+  : bool
+  =
+  match reason with
+  | Candidates_filtered_after_cycles | Max_turns_exceeded | Capacity_exhausted ->
+    true
+  | Connection_refused | Dns_failure | No_providers_available | All_providers_failed ->
+    true (* transient/connectivity — retry into a fresh runtime rotation *)
+  | Structural_attempt_timeout _ -> true
+  | No_tool_capable _ -> false (* capability gap, not transient *)
+  | Other_detail _ -> false (* unknown free-text — conservative *)
+;;
+
 type blocker_class =
   | Runtime_exhausted of runtime_exhaustion_reason
   | Capacity_backpressure

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -200,6 +200,13 @@ val runtime_exhaustion_summary :
 (** Human-readable one-sentence summary per reason variant.
     Used in keeper supervisor logs + dashboard tooltips. *)
 
+val runtime_exhaustion_reason_retryable : runtime_exhaustion_reason -> bool
+(** Total typed retryability per reason variant. Transient/connectivity
+    reasons and bounded-cycle/turn/capacity exhaustion are retryable;
+    [No_tool_capable] (capability gap) and [Other_detail] (unknown
+    free-text) are not. Replaces a string-prefix reparse with a
+    [_ -> false] catch-all that mis-biased transient faults to terminal. *)
+
 val blocker_class_continue_gate : blocker_class -> bool
 (** [blocker_class_continue_gate b] is [true] iff the supervisor
     should retry past this blocker.  Currently only

--- a/lib/keeper/keeper_registry_types.mli
+++ b/lib/keeper/keeper_registry_types.mli
@@ -99,6 +99,7 @@ type failure_reason =
       ; provider_id : string option
       ; http_status : int option
       ; runtime_id : string option
+      ; reason : Keeper_meta_contract.runtime_exhaustion_reason option
       }
       (** Latched from the keeper turn terminal reason when the provider,
           adapter, or runtime fails before useful keeper progress. A later

--- a/lib/keeper/keeper_registry_types_failure.ml
+++ b/lib/keeper/keeper_registry_types_failure.ml
@@ -86,6 +86,14 @@ type failure_reason =
       ; provider_id : string option
       ; http_status : int option
       ; runtime_id : string option
+      ; reason : Keeper_meta_contract.runtime_exhaustion_reason option
+          (** Typed runtime-exhaustion reason, [Some] only on the
+              runtime-exhausted construction path
+              ([keeper_unified_turn_types.runtime_exhausted_failure_reason_of_raw_error]).
+              Lets the supervisor decide retryability via
+              [Keeper_meta_contract.runtime_exhaustion_reason_retryable]
+              instead of reparsing [code]. [None] for non-exhaustion
+              provider/runtime errors. *)
       }
   | Tool_required_unsatisfied of
       { code : string

--- a/lib/keeper/keeper_registry_types_failure.mli
+++ b/lib/keeper/keeper_registry_types_failure.mli
@@ -36,6 +36,7 @@ type failure_reason =
   | Provider_runtime_error of { code : string; detail : string;
       provider_id : string option; http_status : int option;
       runtime_id : string option;
+      reason : Keeper_meta_contract.runtime_exhaustion_reason option;
     }
   | Tool_required_unsatisfied of { code : string; detail : string; }
   | Ambiguous_partial_commit of ambiguous_partial_commit

--- a/lib/keeper/keeper_supervisor_pause_policy.ml
+++ b/lib/keeper/keeper_supervisor_pause_policy.ml
@@ -221,15 +221,12 @@ let failure_reason_policy_decision
     Some (Keeper_failure_policy.decide Keeper_failure_policy.Turn_overflow_pause)
   | Some Keeper_registry.Turn_livelock_pause ->
     Some (Keeper_failure_policy.decide Keeper_failure_policy.Turn_livelock_pause)
-  | Some (Keeper_registry.Provider_runtime_error { code; _ })
-    when String.starts_with ~prefix:"runtime_exhausted_" code ->
-    let retryable =
-      match code with
-      | "runtime_exhausted_candidates_filtered"
-      | "runtime_exhausted_max_turns"
-      | "runtime_exhausted_capacity_exhausted" -> true
-      | _ -> false
-    in
+  | Some (Keeper_registry.Provider_runtime_error { reason = Some reason; _ }) ->
+    (* Typed retryability: read the carried [runtime_exhaustion_reason]
+       directly instead of reparsing the stringified [code]. The former
+       [String.starts_with ~prefix:"runtime_exhausted_"] + [_ -> false]
+       reparse biased transient/connectivity reasons to non-retryable. *)
+    let retryable = Keeper_meta_contract.runtime_exhaustion_reason_retryable reason in
     Some
       (Keeper_failure_policy.decide
          (Keeper_failure_policy.Runtime_exhausted { retryable }))

--- a/lib/keeper/keeper_turn_runtime_budget.ml
+++ b/lib/keeper/keeper_turn_runtime_budget.ml
@@ -609,6 +609,7 @@ let make_post_turn_resilience_executor
          (Keeper_registry.Provider_runtime_error
             { code; detail; provider_id = None; http_status = None
             ; runtime_id = None
+            ; reason = None
             }));
     match
       sync_keeper_paused_state_with_resume_policy

--- a/lib/keeper/keeper_unified_turn_types.ml
+++ b/lib/keeper/keeper_unified_turn_types.ml
@@ -137,6 +137,7 @@ let runtime_exhausted_failure_reason_of_raw_error ~detail raw_error =
              ; provider_id = None
          ; http_status = None
          ; runtime_id = Some (ntcp_runtime_id)
+         ; reason = None
          })
   | Some
       (Keeper_internal_error.Runtime_exhausted
@@ -151,6 +152,7 @@ let runtime_exhausted_failure_reason_of_raw_error ~detail raw_error =
          ; provider_id = None
          ; http_status = None
          ; runtime_id = Some (ntcp_runtime_id)
+         ; reason = None
          })
   (* Generic Runtime_exhausted catch-all — after No_tool_capable specifics *)
   | Some (Keeper_internal_error.Runtime_exhausted { reason; runtime_id }) ->
@@ -161,6 +163,7 @@ let runtime_exhausted_failure_reason_of_raw_error ~detail raw_error =
          ; provider_id = None
          ; http_status = None
          ; runtime_id = Some (runtime_id)
+         ; reason = Some reason
          })
   | Some (Keeper_internal_error.Capacity_backpressure { detail = capacity_detail; _ }) ->
     Some
@@ -170,6 +173,7 @@ let runtime_exhausted_failure_reason_of_raw_error ~detail raw_error =
          ; provider_id = None
          ; http_status = None
          ; runtime_id = None
+         ; reason = None
          })
   | Some
       ( Keeper_internal_error.Resumable_cli_session _
@@ -226,6 +230,7 @@ let registry_failure_reason_of_terminal_reason
          ; provider_id = None
          ; http_status = None
          ; runtime_id = None
+         ; reason = None
          })
   | Keeper_turn_disposition.Runtime_attempts_exhausted ->
     Some
@@ -235,6 +240,7 @@ let registry_failure_reason_of_terminal_reason
          ; provider_id = None
          ; http_status = None
          ; runtime_id = None
+         ; reason = None
          })
   | Keeper_turn_disposition.Success
   | Keeper_turn_disposition.External_cancel

--- a/test/test_keeper_health_probe.ml
+++ b/test/test_keeper_health_probe.ml
@@ -76,6 +76,7 @@ let test_runtime_pressure_classifier () =
           ; provider_id = None
           ; http_status = None
           ; runtime_id = None
+          ; reason = None
           }));
   Alcotest.check
     pressure_label_t
@@ -88,6 +89,7 @@ let test_runtime_pressure_classifier () =
           ; provider_id = None
           ; http_status = None
           ; runtime_id = None
+          ; reason = None
           }));
   Alcotest.check
     pressure_label_t
@@ -100,6 +102,7 @@ let test_runtime_pressure_classifier () =
           ; provider_id = Some "provider_d"
           ; http_status = Some 429
           ; runtime_id = None
+          ; reason = None
           }));
   Alcotest.check
     pressure_label_t
@@ -112,6 +115,7 @@ let test_runtime_pressure_classifier () =
           ; provider_id = Some "zai"
           ; http_status = None
           ; runtime_id = None
+          ; reason = None
           }));
   Alcotest.check
     pressure_label_t
@@ -124,6 +128,7 @@ let test_runtime_pressure_classifier () =
           ; provider_id = None
           ; http_status = Some 504
           ; runtime_id = None
+          ; reason = None
           }));
   Alcotest.check
     pressure_label_t
@@ -136,6 +141,7 @@ let test_runtime_pressure_classifier () =
           ; provider_id = None
           ; http_status = Some 500
           ; runtime_id = None
+          ; reason = None
           }));
   Alcotest.check
     pressure_label_t
@@ -185,6 +191,7 @@ let test_run_once_records_specific_failure_ratio_reason () =
             ; provider_id = Some "zai"
             ; http_status = None
             ; runtime_id = None
+            ; reason = None
             });
        register_crashed
          "provider-dns-b"
@@ -194,6 +201,7 @@ let test_run_once_records_specific_failure_ratio_reason () =
             ; provider_id = Some "zai"
             ; http_status = None
             ; runtime_id = None
+            ; reason = None
             });
        H.run_once ~base_path:base_dir;
        Alcotest.check

--- a/test/test_keeper_registry_provenance.ml
+++ b/test/test_keeper_registry_provenance.ml
@@ -77,6 +77,7 @@ let test_provider_runtime_error_carrier_none () =
       ; provider_id = None
       ; http_status = None
       ; runtime_id = None
+      ; reason = None
       }
   in
   (check string)
@@ -92,6 +93,7 @@ let test_provider_runtime_error_carrier_some () =
       ; provider_id = Some "runpod_mtp"
       ; http_status = Some 502
       ; runtime_id = None
+      ; reason = None
       }
   in
   let s = R.failure_reason_to_string r in

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -163,6 +163,81 @@ let test_supervisor_policy_restarts_stale_turn () =
     (KFP.lifecycle_effect_to_label decision.lifecycle_effect);
   check bool "keeper death allowed" true decision.keeper_death_allowed
 
+(* Typed runtime-exhaustion retryability bridge. The consumer now reads the
+   carried [Keeper_meta_contract.runtime_exhaustion_reason] instead of
+   reparsing the stringified [code]; this pins the polarity, including the
+   correction of transient/connectivity reasons from terminal to retryable. *)
+let provider_runtime_error_of_reason reason =
+  Reg.Provider_runtime_error
+    { code = "ignored_by_typed_path"
+    ; detail = "test"
+    ; provider_id = None
+    ; http_status = None
+    ; runtime_id = None
+    ; reason = Some reason
+    }
+
+let test_supervisor_policy_runtime_exhausted_retryable_reasons () =
+  let retryable_reasons =
+    [ Keeper_meta_contract.Candidates_filtered_after_cycles
+    ; Keeper_meta_contract.Max_turns_exceeded
+    ; Keeper_meta_contract.Capacity_exhausted
+    ; Keeper_meta_contract.Connection_refused
+    ; Keeper_meta_contract.Dns_failure
+    ; Keeper_meta_contract.No_providers_available
+    ; Keeper_meta_contract.All_providers_failed
+    ; Keeper_meta_contract.Structural_attempt_timeout { detail = "30" }
+    ]
+  in
+  List.iter
+    (fun reason ->
+       let decision =
+         policy_decision_exn (Some (provider_runtime_error_of_reason reason))
+       in
+       check string
+         ("retryable reason -> soft_fail_turn ("
+          ^ Keeper_meta_contract.runtime_exhaustion_summary reason ^ ")")
+         "soft_fail_turn"
+         (KFP.lifecycle_effect_to_label decision.lifecycle_effect);
+       check string "reason label" "runtime_exhausted_retryable" decision.reason)
+    retryable_reasons
+
+let test_supervisor_policy_runtime_exhausted_terminal_reasons () =
+  let terminal_reasons =
+    [ Keeper_meta_contract.No_tool_capable None
+    ; Keeper_meta_contract.Other_detail "opaque free-text"
+    ]
+  in
+  List.iter
+    (fun reason ->
+       let decision =
+         policy_decision_exn (Some (provider_runtime_error_of_reason reason))
+       in
+       check string
+         ("terminal reason -> pause_current_work ("
+          ^ Keeper_meta_contract.runtime_exhaustion_summary reason ^ ")")
+         "pause_current_work"
+         (KFP.lifecycle_effect_to_label decision.lifecycle_effect);
+       check string "reason label" "runtime_exhausted_terminal" decision.reason)
+    terminal_reasons
+
+let test_supervisor_policy_runtime_error_no_reason_falls_through () =
+  (* A [Provider_runtime_error] with [reason = None] (non-exhaustion
+     provider/runtime error) must not be classified as runtime-exhausted;
+     it falls through to [None], preserving pre-refactor behavior. *)
+  let r =
+    Reg.Provider_runtime_error
+      { code = "provider_error"
+      ; detail = "boom"
+      ; provider_id = None
+      ; http_status = None
+      ; runtime_id = None
+      ; reason = None
+      }
+  in
+  check bool "reason=None yields no runtime-exhausted decision" true
+    (Sup.failure_reason_policy_decision_for_test (Some r) = None)
+
 (* ── Pure tests: keep_last_n ────────────────────────────── *)
 
 let test_keep_last_n_under_limit () =
@@ -1998,6 +2073,12 @@ let () =
         test_supervisor_policy_pauses_stale_storm;
       test_case "stale turn restarts via policy" `Quick
         test_supervisor_policy_restarts_stale_turn;
+      test_case "runtime-exhausted transient/bounded reasons are retryable" `Quick
+        test_supervisor_policy_runtime_exhausted_retryable_reasons;
+      test_case "runtime-exhausted capability/unknown reasons are terminal" `Quick
+        test_supervisor_policy_runtime_exhausted_terminal_reasons;
+      test_case "provider error with reason=None falls through to no decision" `Quick
+        test_supervisor_policy_runtime_error_no_reason_falls_through;
     ];
     "keep_last_n_properties", [
       test_case "never exceeds limit" `Quick test_keep_last_n_never_exceeds;

--- a/test/test_stale_kill_class.ml
+++ b/test/test_stale_kill_class.ml
@@ -90,7 +90,7 @@ let test_failure_reason_to_string_provider_runtime_error () =
     (failure_reason_to_string
        (Provider_runtime_error
           { code = "provider_error"; detail = "provider_c unicode crash"
-          ; provider_id = None; http_status = None; runtime_id = None }))
+          ; provider_id = None; http_status = None; runtime_id = None; reason = None }))
 
 let test_failure_reason_to_string_tool_required_unsatisfied () =
   r "Tool_required_unsatisfied includes terminal code"
@@ -169,7 +169,7 @@ let test_terminal_failure_cohort_keys () =
        (Some
           (Provider_runtime_error
              { code = "provider_error"; detail = "x"
-             ; provider_id = None; http_status = None; runtime_id = None })));
+             ; provider_id = None; http_status = None; runtime_id = None; reason = None })));
   r "Tool_required_unsatisfied cohort_key" "tool_required_unsatisfied"
     (failure_reason_cohort_key
        (Some
@@ -179,7 +179,7 @@ let test_terminal_failure_cohort_keys () =
 let test_stale_watchdog_preserves_terminal_failure_reason () =
   let prior =
     Provider_runtime_error { code = "provider_error"; detail = "provider_c"
-                           ; provider_id = None; http_status = None; runtime_id = None }
+                           ; provider_id = None; http_status = None; runtime_id = None; reason = None }
   in
   let kill_class = Idle_turn { stall_seconds = 305.0 } in
   match stale_watchdog_failure_reason ~prior:(Some prior) ~kill_class with
@@ -297,7 +297,7 @@ let test_batch_root_cause_provider_auth () =
        [
          Provider_runtime_error
            { code = "auth_error"; detail = "bad key rejected"
-           ; provider_id = None; http_status = None; runtime_id = None };
+           ; provider_id = None; http_status = None; runtime_id = None; reason = None };
        ])
 
 let test_batch_root_cause_fd_exhaustion () =
@@ -314,7 +314,7 @@ let test_batch_root_cause_mixed () =
        [
          Provider_runtime_error
            { code = "auth_error"; detail = "bad key rejected"
-           ; provider_id = None; http_status = None; runtime_id = None };
+           ; provider_id = None; http_status = None; runtime_id = None; reason = None };
          Exception "too many open files";
        ])
 


### PR DESCRIPTION
## 목표
runtime-exhaustion 실패의 **재시도 가능 여부 판단을 string 재파싱에서 typed 총함수로** 교체한다. cleanup sweep(substring 휴리스틱 렌즈)에서 유일한 HIGH로 확인됨.

## 결함
`keeper_supervisor_pause_policy.ml:224`가 typed variant을 string화한 `code`를 다시 파싱했다:
```
| Some (Provider_runtime_error { code; _ })
  when String.starts_with ~prefix:"runtime_exhausted_" code ->
  match code with "...candidates_filtered"|"...max_turns"|"...capacity_exhausted" -> true | _ -> false
```
- (a) `runtime_exhaustion_reason_code`가 만든 string을 소비자가 재파싱 — 정보가 typed→string→typed로 왕복.
- (b) `_ -> false` catch-all이 **transient/connectivity 실패**(Connection_refused, Dns_failure, No_providers_available, All_providers_failed, Structural_attempt_timeout)를 terminal로 오분류 — 폴라리티가 뒤집힘. CLAUDE.md가 금지하는 FSM-sparse-match 안티패턴(새 variant가 compile-clean하게 non-retryable로 default).

## 변경 (Design A — typed reason carry)
- `keeper_meta_contract.ml`: 총함수 `runtime_exhaustion_reason_retryable : runtime_exhaustion_reason -> bool` 추가. **exhaustive 매치, `_ ->` arm 없음** — 새 variant 추가 시 컴파일 강제. transient 폴라리티 교정(retryable=true).
- `Provider_runtime_error` carrier에 `reason : runtime_exhaustion_reason option` 필드 추가(선언 3곳: `keeper_registry_types_failure.ml/.mli`, `keeper_registry_types.mli`).
- 생산자: runtime-exhausted 경로(`keeper_unified_turn_types.ml:158`)만 `Some reason`, 나머지 6 construction은 `None`.
- 소비자: `{ reason = Some reason; _ }` 매치 + `runtime_exhaustion_reason_retryable reason` 호출. string 재파싱·`_ -> false` 제거.

## Dep-cycle 증명 (advisor 요구)
필요한 화살표 `keeper_registry_types_failure → Keeper_meta_contract`는 cycle-free: `keeper_meta_contract.ml`의 `Keeper_registry` 참조는 doc-comment(147/153)뿐. **컴파일로 증명**: `dune build @check`=0 AND `dune build lib/masc_mcp.cmxa`(native archive)=0 (cycle면 둘 다 실패). Design B(bool carry)는 불필요.

## 동작 보존
OLD에서 `runtime_exhausted_` prefix code를 내던 유일한 생산 사이트는 `:158`(`runtime_exhaustion_reason_code reason`)뿐. 검증:
- `:224` `Keeper_turn_terminal_code.to_wire c` — `runtime_exhausted_*` 절대 emit 안 함(grep 0) → OLD에서도 guard 불일치→catch-all→None, NEW(reason=None)→None. 동일.
- `:233` `"runtime_attempts_exhausted"` — prefix `runtime_exhausted_` 불일치(attempts≠exhausted) → 양쪽 None. 동일.
즉 retryable 결정에 도달하는 입력 집합 불변, **폴라리티만 교정**.

## 검증
- `dune build @check --root .` = 0
- `dune build lib/masc_mcp.cmxa --root .` (native) = 0
- 신규 polarity 회귀 테스트(`test_keeper_supervisor` `failure_policy_bridge` 1–5): retryable→`runtime_exhausted_retryable`, capability/unknown→`runtime_exhausted_terminal`, `reason=None`→무결정. PASS.
- `test_keeper_failure_policy`(10), `test_keeper_registry_provenance`(7), `test_stale_kill_class`(36): PASS.
- `test_keeper_supervisor`의 그 외 광범위 실패(59건)는 **base와 byte-identical**(base 59/81 vs B1 59/84, 유일 delta는 신규 통과 3건). root cause는 config 미주입이 아니라 main의 test-fixture↔parser 스키마 drift(`make_meta`가 `tool_access` 없이 meta 생성→`tool_access_of_meta_json` hard error, ~34건) — B1 범위 밖 기존 breakage. **B1 regression 0**.

## 정직한 한계
- **transport는 code-read 검증**(test는 carrier를 소비자에 직접 주입). 단 `failure_reason`의 deserializer가 없어(reconstruct-and-drop 불가) 모든 값이 enumerated construction(전부 `reason` 설정, @check 강제)에서 태어나 in-memory로만 전달 → 필드 도달 confidence high.
- `No_tool_capable`는 production에서 `reason=None`으로 분기(상위 arm에서 peel) → 함수의 `-> false` arm은 totality 전용. `Other_detail`은 production-reachable이고 terminal 유지(실보존 케이스).
- 이 PR은 keeper non-convergence/timeout incident의 fix가 **아니다**(별개 root cause = verifier tool_required loop). typed 재시도성 + transient 폴라리티 교정만.

RFC-WAIVED: guarded subsystem(credential/operator/keeper sandbox/dashboard credential/hooks/workflow) 미접촉. keeper 실패정책 typed 정합.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
