### PR TITLE
test(keeper): provide tool_access in test_keeper_supervisor meta fixtures (59→3 failures)

### DIFF
--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -284,6 +284,7 @@ let test_should_cleanup_dead_true () =
         ("goal", `String "goal");
         ("sandbox_profile", `String "local");
         ("network_mode", `String "inherit");
+        ("tool_access", `List []);
       ] in
       match Keeper_meta_json_parse.meta_of_json json with
       | Ok meta -> meta
@@ -304,6 +305,7 @@ let test_should_cleanup_dead_false_when_recent () =
         ("goal", `String "goal");
         ("sandbox_profile", `String "local");
         ("network_mode", `String "inherit");
+        ("tool_access", `List []);
       ] in
       match Keeper_meta_json_parse.meta_of_json json with
       | Ok meta -> meta
@@ -359,6 +361,7 @@ let make_meta name =
     ("goal", `String "test");
     ("sandbox_profile", `String "local");
     ("network_mode", `String "inherit");
+    ("tool_access", `List []);
   ] in
   match Keeper_meta_json_parse.meta_of_json json with
   | Ok meta -> meta


### PR DESCRIPTION
## 목표
`test_keeper_supervisor`의 keeper-meta fixture가 `tool_access`를 누락해 `meta_of_json`이 전부 실패하던 stale fixture를 수정한다 (B1 검증 중 발견된 main breakage).

## 근거
- `meta_of_json`(영속-메타 parser, `keeper_meta_json_parse.ml:166`)는 `tool_access_of_meta_json`(strict)를 호출 — 부재 시 `Error "keeper tool_access must be an array of strings"`.
- production 영속 메타는 항상 `tool_access`를 직렬화(`keeper_turn_up_create`가 write) → strict parser는 parse-don't-validate로 **올바름**. create 시점만 default 허용(`| None -> default_tool_access_of_meta_json ()`).
- `make_meta` 헬퍼 + inline 빌더 2곳이 `tool_access`를 안 넣어 fixture 생성 단계에서 실패 → 그 헬퍼를 쓰는 테스트 다수가 연쇄 실패.

## 변경 (test-only)
- `make_meta`(1) + inline meta 빌더(2)에 `("tool_access", `List [])` 추가 — 문서화된 default(빈 리스트, runtime filtering이 실제 tool 공급).

## 결과
`test_keeper_supervisor`: **59 failures → 3** (84 tests). 남은 3개는 pre-existing·tool_access 무관·별도 follow-up:
- `failure_policy_bridge 0`: `Provider_timeout_loop` scope label drift (Expected "turn"/Received "keeper_liveness").
- `self_healing_circuit_breaker 2,3`: `sweep_and_recover` auto-resume Eio 통합 테스트 — make_meta 에러에 가려져 있던 것. 실제 로직 vs harness/config 설정 원인 **미분류**(별도 조사 필요).

## 검증
`dune build @check --root .` = 0. `dune exec test/test_keeper_supervisor.exe` = 3 failures/84 (was 59).

RFC-WAIVED: test-only fixture 수정. guarded subsystem 미접촉.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
