### PR TITLE
test(keeper): init default runtime in supervisor auto-resume sweep tests (3→1 failures)

### DIFF
--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -367,6 +367,54 @@ let make_meta name =
   | Ok meta -> meta
   | Error err -> fail ("make_meta: " ^ err)
 
+(* Sweep paths that resolve a keeper's runtime id reach
+   [Keeper_meta_contract.runtime_id_of_meta], which falls back to
+   [Runtime.get_default_runtime_id ()] for keepers without an explicit
+   [[runtime.assignments]] entry.  That fallback fail-fasts until
+   [Runtime.init_default] has run (RFC-0206 §2.1, no silent fallback).
+   In a booted server [init_default] runs at startup
+   (server_runtime_bootstrap.ml); a bare [dune exec] test binary must
+   stand the default runtime up itself.  Mirrors the established pattern in
+   test_keeper_lifecycle_registry_dispatch.ml. *)
+let test_runtime_toml =
+  {|
+[runtime]
+default = "test_provider.test_model"
+
+[providers.test_provider]
+display-name = "Test Provider"
+protocol = "provider_d-http"
+endpoint = "http://127.0.0.1:1"
+
+[models.test_model]
+api-name = "test-model"
+max-context = 8192
+tools-support = true
+streaming = true
+
+[test_provider.test_model]
+is-default = true
+max-concurrent = 1
+|}
+
+let ensure_test_runtime =
+  let initialized = ref false in
+  fun () ->
+    if not !initialized then (
+      let path = Filename.temp_file "keeper_supervisor_runtime_" ".toml" in
+      let oc = open_out path in
+      Fun.protect
+        ~finally:(fun () -> close_out_noerr oc)
+        (fun () -> output_string oc test_runtime_toml);
+      Fun.protect
+        ~finally:(fun () ->
+          try Sys.remove path with
+          | Sys_error _ -> ())
+        (fun () ->
+          match Masc_mcp.Runtime.init_default ~config_path:path with
+          | Ok () -> initialized := true
+          | Error msg -> fail msg))
+
 let test_persona_drift_check_uses_toml_persona_name () =
   with_config_dir @@ fun config_dir ->
   let keepers_dir = Filename.concat config_dir "keepers" in
@@ -1529,6 +1577,7 @@ let test_oas_auto_resume_after_sec_doubles_on_repause () =
 (* Test: Phase 3.5 sweep auto-resumes a keeper whose timer has elapsed. *)
 let test_sweep_auto_resumes_after_backoff () =
   with_restart_launch_noop @@ fun () ->
+  ensure_test_runtime ();
   Eio_main.run @@ fun env ->
   ensure_fs env;
   Eio.Switch.run @@ fun sw ->
@@ -1603,6 +1652,7 @@ let test_sweep_auto_resumes_after_backoff () =
         (baseline_auto_resume +. 1.0) after_auto_resume)
 
 let test_sweep_auto_resumes_registered_paused_entry () =
+  ensure_test_runtime ();
   Eio_main.run @@ fun env ->
   ensure_fs env;
   Eio.Switch.run @@ fun sw ->


### PR DESCRIPTION
## 목표
`test_keeper_supervisor`의 auto-resume sweep 테스트 2개가 bare `dune exec`에서 런타임 미초기화로 크래시하던 것을 harness 수정으로 해소한다 (make_meta fixture fix #19858가 unmask한 잔여 2/3 실패).

## 분류: harness 아티팩트 (lib 버그 아님)
- production `sweep_and_recover` auto-resume 로직은 **정확**.
- 실패 원인: `keeper_supervisor.ml:535` `runtime_id_of_meta meta` → runtime.assignments 없는 keeper → `Runtime.get_default_runtime_id ()`가 **RFC-0206 §2.1 의도된 fail-fast**(no silent fallback)로 raise. production은 부팅 시 `Runtime.init_default`를 돌려(server_runtime_bootstrap.ml, fatal-if-fails) 절대 발생 안 함. bare `dune exec`만 이 초기화를 안 함.
- guard `paused_meta_auto_resume_due`/iso8601 parse/timer(7200≥3600)는 전부 satisfied — 크래시는 probe 이전(line 535)에서 발생.

## 변경 (test-only)
- `test_runtime_toml` + memoized `ensure_test_runtime ()` 헬퍼 추가(기존 `test_keeper_lifecycle_registry_dispatch.ml:45-82` 패턴 미러), 두 실패 테스트 본문 상단에서 호출 → production startup처럼 default runtime 기동.

## lib 미수정 이유
`runtime_id_of_meta`에 기본값/catch를 넣으면 RFC-0206이 금지하는 Unknown→Permissive 안티패턴 재도입. fail-fast가 의도된 동작.

## 결과
`test_keeper_supervisor`: **3 → 1 failures** (84 tests). auto-resume case 2,3 PASS(전 경로 probe→write_meta→Operator_resume→fiber_wakeup→AutoResumedTotal+1 검증). 남은 1 = out-of-scope `failure_policy_bridge 0` scope-label drift(별도).

## 검증
`dune build @check --root .` = 0, `lib/masc_mcp.cmxa` native = 0, `dune exec test/test_keeper_supervisor.exe` = 1 failure(was 3).

RFC-WAIVED: test-only harness 수정. guarded subsystem 미접촉. (RFC-0206 fail-fast는 보존.)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
