### PR TITLE
refactor(board): type board metric label dimensions as closed sums

### DIFF
--- a/lib/board_core_classify.ml
+++ b/lib/board_core_classify.ml
@@ -73,13 +73,9 @@ let take = List.take
     pattern-match on [author_kind] — adding a new automation label or
     system actor fails compilation at every match site. *)
 
-type automation_label =
-  | Auto_prefixed       (** "auto-" prefix *)
-  | Qa_prefixed         (** "qa-" prefix *)
-  | Researcher_named    (** contains "researcher" *)
-  | Harness_named       (** contains "harness" *)
-  | Smoke_named         (** contains "smoke" *)
-  | Probe_named         (** contains "probe" *)
+(* [automation_label] relocated to Board_types; supplied here via
+   [include Board_types] above so constructors (Auto_prefixed, ...)
+   resolve unchanged. *)
 
 type system_actor =
   | Ecosystem
@@ -118,17 +114,11 @@ let classify_author (author : string) : author_kind =
        | Some label -> Automation_author label
        | None -> Human_author)
 
-(** Render the legacy author classification as a stable metric/log token.
-    Kept narrow — *not* a parser
-    inverse (no [_of_string]); the typed variant flows in only one
-    direction (boundary parse -> internal use -> string for log). *)
-let automation_label_token = function
-  | Auto_prefixed -> "auto-prefix"
-  | Qa_prefixed -> "qa-prefix"
-  | Researcher_named -> "researcher"
-  | Harness_named -> "harness"
-  | Smoke_named -> "smoke"
-  | Probe_named -> "probe"
+(* The automation-label -> metric-string rendering moved to the
+   Prometheus adapter (board_prometheus_hooks.ml,
+   [automation_label_to_label]). The hook now carries the typed
+   [Board_types.automation_label] so the compiler checks every label
+   value and the string lives only at the emission boundary. *)
 
 let meta_source = function
   | Some (`Assoc fields) -> (
@@ -210,14 +200,16 @@ let legacy_migrate_post_kind ~meta_json ~author ~visibility ~expires_at ~hearth 
   | Automation_author label ->
       (* #9919 audit follow-up: emit a labelled metric hook so operators can
          see which legacy authors still drive the migration path.
-         The typed [automation_label] flows through
-         [automation_label_token] to keep label cardinality bounded (6
-         values) alongside the per-author label.  Both labels emitted so
-         existing dashboards (keyed on raw [author]) keep working while
-         operators gain a bounded breakdown. *)
+         The typed [automation_label] flows through unchanged (the
+         metric-string rendering lives in the Prometheus adapter) to keep
+         label cardinality bounded (6 values) alongside the per-author
+         label.  Both labels emitted so existing dashboards (keyed on raw
+         [author]) keep working while operators gain a bounded breakdown.
+         [author] stays a raw string: it is an unbounded external-identity
+         label, out of scope for this closed-sum pass. *)
       Board_metrics_hooks.inc_legacy_migrate_post_kind
         ~author
-        ~automation_label:(automation_label_token label);
+        ~automation_label:label;
       Automation_post
   | Human_author -> Human_post
 

--- a/lib/board_core_classify.mli
+++ b/lib/board_core_classify.mli
@@ -67,7 +67,10 @@ val post_kind_of_string : string -> post_kind option
 
 (** {1 Author classification (RFC-0089 §4-3 G2)} *)
 
-type automation_label =
+(** Re-export of {!Board_types.automation_label} (relocated there so the
+    board metric hook surface can reference it without a dependency
+    cycle). The type equation keeps existing users compiling unchanged. *)
+type automation_label = Board_types.automation_label =
   | Auto_prefixed       (** Author starts with ["auto-"]. *)
   | Qa_prefixed         (** Author starts with ["qa-"]. *)
   | Researcher_named    (** Author contains ["researcher"]. *)

--- a/lib/board_dispatch.ml
+++ b/lib/board_dispatch.ml
@@ -204,7 +204,7 @@ let ensure_flusher_actor store =
                 match exn with
                 | Invalid_argument msg when String.equal msg "Switch finished!" ->
                     Board_metrics_hooks.inc_dispatch_flusher_start_outcome
-                      ~outcome:"switch_finished";
+                      ~outcome:Switch_finished;
                     Log.BoardLog.warn
                       "Skipping board flusher actor startup on finished switch"
                 | _ -> raise exn
@@ -215,7 +215,7 @@ let ensure_flusher_actor store =
               loop (attempts_left - 1)
             end else begin
               Board_metrics_hooks.inc_dispatch_flusher_start_outcome
-                ~outcome:"cas_exhausted";
+                ~outcome:Cas_exhausted;
               Log.BoardLog.warn
                 "Board flusher actor startup CAS contention exhausted; retrying on next backend access"
             end

--- a/lib/board_metrics_hooks.ml
+++ b/lib/board_metrics_hooks.ml
@@ -1,15 +1,35 @@
 (** Board-owned metric hooks.
 
     Board core modules call this neutral hook surface instead of reaching into
-    Prometheus directly. The composition layer installs the concrete observer. *)
+    Prometheus directly. The composition layer installs the concrete observer.
+
+    Label dimensions are typed closed sums so the compiler checks every label
+    value at each call site. The variant -> Prometheus label string mapping
+    lives only in the adapter (board_prometheus_hooks.ml). [author] on
+    {!inc_legacy_migrate_post_kind} is deliberately left as [string]: it is an
+    unbounded external-identity label (a raw actor name), out of scope for this
+    closed-sum pass. *)
+
+(** Persistence surface that recorded a read drop. Single value today; the
+    sum keeps the dimension typed and adding a surface a compile obligation.
+    This is a board-persistence-row surface, unrelated to the deleted
+    Tool-layer [surface] type (#19854). *)
+type board_persist_surface = Board_post_meta_json
+
+(** Outcome of an attempt to start the board dispatch flusher actor. *)
+type flusher_outcome =
+  | Switch_finished  (** Switch was already finished when startup ran. *)
+  | Cas_exhausted    (** CAS contention exhausted the retry budget. *)
 
 type observer = {
   observe_persist_lock_acquire_sec : float -> unit;
   observe_persist_lock_held_sec : float -> unit;
-  inc_dispatch_flusher_start_outcome : outcome:string -> unit;
+  inc_dispatch_flusher_start_outcome : outcome:flusher_outcome -> unit;
   inc_vote_fixture_detected : count:int -> unit;
-  inc_persistence_read_drop : surface:string -> reason:string -> unit;
-  inc_legacy_migrate_post_kind : author:string -> automation_label:string -> unit;
+  inc_persistence_read_drop :
+    surface:board_persist_surface -> reason:Read_drop_reason.t -> unit;
+  inc_legacy_migrate_post_kind :
+    author:string -> automation_label:Board_types.automation_label -> unit;
 }
 
 let noop_observer = {

--- a/lib/board_prometheus_hooks.ml
+++ b/lib/board_prometheus_hooks.ml
@@ -1,4 +1,37 @@
-(** Prometheus adapter for neutral Board metric hooks. *)
+(** Prometheus adapter for neutral Board metric hooks.
+
+    Holds the only [variant -> Prometheus label string] mappings for the
+    typed label dimensions on {!Board_metrics_hooks.observer}. The emitted
+    strings are byte-identical to the values the pre-typed string hooks
+    passed, so existing dashboards and alerts keyed on these labels keep
+    working. The mappings are total (no [_ ->] wildcard) so adding a label
+    variant is a compile obligation here. *)
+
+(* surface label for masc_persistence_read_drops_total *)
+let board_persist_surface_to_label :
+  Board_metrics_hooks.board_persist_surface -> string = function
+  | Board_post_meta_json -> "board_post_meta_json"
+
+(* outcome label for masc_board_dispatch_flusher_start_outcomes_total *)
+let flusher_outcome_to_label : Board_metrics_hooks.flusher_outcome -> string =
+  function
+  | Switch_finished -> "switch_finished"
+  | Cas_exhausted -> "cas_exhausted"
+
+(* automation_label label for masc_board_legacy_migrate_post_kind_total *)
+let automation_label_to_label : Board_types.automation_label -> string = function
+  | Auto_prefixed -> "auto-prefix"
+  | Qa_prefixed -> "qa-prefix"
+  | Researcher_named -> "researcher"
+  | Harness_named -> "harness"
+  | Smoke_named -> "smoke"
+  | Probe_named -> "probe"
+
+(* reason label for masc_persistence_read_drops_total; reuses the
+   SSOT wire mapping in Read_drop_reason (byte-identical to the old
+   Safe_ops.persistence_read_drop_reason_* constants). *)
+let read_drop_reason_to_label : Read_drop_reason.t -> string =
+  Read_drop_reason.to_wire
 
 let install () =
   Board_metrics_hooks.set_observer
@@ -17,7 +50,7 @@ let install () =
         (fun ~outcome ->
            Prometheus.inc_counter
              Prometheus.metric_board_dispatch_flusher_start_outcomes
-             ~labels:[ ("outcome", outcome) ]
+             ~labels:[ ("outcome", flusher_outcome_to_label outcome) ]
              ());
       inc_vote_fixture_detected =
         (fun ~count ->
@@ -30,12 +63,18 @@ let install () =
         (fun ~surface ~reason ->
            Prometheus.inc_counter
              Prometheus.metric_persistence_read_drops
-             ~labels:[ ("surface", surface); ("reason", reason) ]
+             ~labels:
+               [ ("surface", board_persist_surface_to_label surface)
+               ; ("reason", read_drop_reason_to_label reason)
+               ]
              ());
       inc_legacy_migrate_post_kind =
         (fun ~author ~automation_label ->
            Prometheus.inc_counter
              "masc_board_legacy_migrate_post_kind_total"
-             ~labels:[ ("author", author); ("automation_label", automation_label) ]
+             ~labels:
+               [ ("author", author)
+               ; ("automation_label", automation_label_to_label automation_label)
+               ]
              ());
     }

--- a/lib/board_types/board_types.ml
+++ b/lib/board_types/board_types.ml
@@ -130,6 +130,19 @@ type post_kind =
   | System_post [@tla.symbol "system_post"]
 [@@deriving tla]
 
+(* Closed sum for the legacy automation-author classification. Relocated
+   here from board_core_classify so the board metric hook surface
+   (board_metrics_hooks.ml / board_prometheus_hooks.ml) can reference it
+   without a board_core_classify -> board_metrics_hooks -> board_core_classify
+   cycle. board_core_classify re-exports it via [include Board_types]. *)
+type automation_label =
+  | Auto_prefixed       (* "auto-" prefix *)
+  | Qa_prefixed         (* "qa-" prefix *)
+  | Researcher_named    (* contains "researcher" *)
+  | Harness_named       (* contains "harness" *)
+  | Smoke_named         (* contains "smoke" *)
+  | Probe_named         (* contains "probe" *)
+
 type post = {
   id: Post_id.t;
   author: Agent_id.t;

--- a/lib/board_types/board_types.mli
+++ b/lib/board_types/board_types.mli
@@ -75,6 +75,18 @@ type post_kind =
   | System_post
 [@@deriving tla]
 
+(** Legacy automation-author classification (RFC-0089 §4-3 G2). Defined
+    here so the board metric hook surface can reference it without a
+    dependency cycle through [Board_core_classify]; [Board_core_classify]
+    re-exports it via [include Board_types]. *)
+type automation_label =
+  | Auto_prefixed       (** Author starts with ["auto-"]. *)
+  | Qa_prefixed         (** Author starts with ["qa-"]. *)
+  | Researcher_named    (** Author contains ["researcher"]. *)
+  | Harness_named       (** Author contains ["harness"]. *)
+  | Smoke_named         (** Author contains ["smoke"]. *)
+  | Probe_named         (** Author contains ["probe"]. *)
+
 (** {1 Records — Mandatory TTL} *)
 
 type post = {

--- a/lib/board_votes_json.ml
+++ b/lib/board_votes_json.ml
@@ -2,12 +2,10 @@
 
 include Board_core
 
-let post_meta_json_persistence_surface = "board_post_meta_json"
-
 let record_post_meta_json_read_drop () =
   Board_metrics_hooks.inc_persistence_read_drop
-    ~surface:post_meta_json_persistence_surface
-    ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
+    ~surface:Board_metrics_hooks.Board_post_meta_json
+    ~reason:Read_drop_reason.Invalid_payload
 ;;
 
 let visibility_of_string = Board_core_classify.visibility_of_string

--- a/test/dune
+++ b/test/dune
@@ -585,7 +585,8 @@
   test_prompt_registry_pbt
   test_clean_only_bug_mirrors
   test_keeper_phase_drift_contract
-  test_event_priority_monotone_pbt)
+  test_event_priority_monotone_pbt
+  test_board_metrics_labels)
  (modules
   test_pbt_mention
   test_pbt_validation
@@ -597,7 +598,8 @@
   test_prompt_registry_pbt
   test_clean_only_bug_mirrors
   test_keeper_phase_drift_contract
-  test_event_priority_monotone_pbt)
+  test_event_priority_monotone_pbt
+  test_board_metrics_labels)
  (libraries masc_test_deps))
 
 ; Focused single-module tests

--- a/test/test_board_metrics_labels.ml
+++ b/test/test_board_metrics_labels.ml
@@ -1,0 +1,78 @@
+(* test/test_board_metrics_labels.ml
+
+   Pins the Prometheus label strings emitted for the typed metric-label
+   closed sums on [Board_metrics_hooks.observer]. The refactor replaced
+   bare [string] label params with closed sums; the [variant -> string]
+   mapping lives only in the Prometheus adapter
+   ([Board_prometheus_hooks.*_to_label]).
+
+   These strings are wire contracts: dashboards and alerts are keyed on
+   them. The expected values below are the exact strings the pre-typed
+   string hooks passed, so this test fails if any future variant change
+   drifts a Prometheus label. *)
+
+module BPH = Masc_mcp.Board_prometheus_hooks
+module BMH = Masc_mcp.Board_metrics_hooks
+module BCC = Masc_mcp.Board_core_classify
+module RDR = Read_drop_reason
+
+let check_label name expected actual =
+  Alcotest.(check string) name expected actual
+
+(* surface label for masc_persistence_read_drops_total. Old code passed
+   the literal "board_post_meta_json". *)
+let test_board_persist_surface_to_label () =
+  check_label "Board_post_meta_json" "board_post_meta_json"
+    (BPH.board_persist_surface_to_label BMH.Board_post_meta_json)
+
+(* outcome label for masc_board_dispatch_flusher_start_outcomes_total.
+   Old code passed "switch_finished" / "cas_exhausted". *)
+let test_flusher_outcome_to_label () =
+  check_label "Switch_finished" "switch_finished"
+    (BPH.flusher_outcome_to_label BMH.Switch_finished);
+  check_label "Cas_exhausted" "cas_exhausted"
+    (BPH.flusher_outcome_to_label BMH.Cas_exhausted)
+
+(* automation_label label for masc_board_legacy_migrate_post_kind_total.
+   Old [automation_label_token] produced exactly these strings; the table
+   below mirrors it constructor-for-constructor. *)
+let test_automation_label_to_label () =
+  let cases =
+    [ (BCC.Auto_prefixed, "auto-prefix")
+    ; (BCC.Qa_prefixed, "qa-prefix")
+    ; (BCC.Researcher_named, "researcher")
+    ; (BCC.Harness_named, "harness")
+    ; (BCC.Smoke_named, "smoke")
+    ; (BCC.Probe_named, "probe")
+    ]
+  in
+  List.iter
+    (fun (variant, expected) ->
+      check_label expected expected (BPH.automation_label_to_label variant))
+    cases
+
+(* reason label for masc_persistence_read_drops_total. The board only
+   emits Invalid_payload; the adapter reuses Read_drop_reason.to_wire,
+   which is byte-identical to the old
+   Safe_ops.persistence_read_drop_reason_invalid_payload = "invalid_payload". *)
+let test_read_drop_reason_to_label () =
+  check_label "Invalid_payload" "invalid_payload"
+    (BPH.read_drop_reason_to_label RDR.Invalid_payload);
+  (* Match the old Safe_ops constant directly to prove no drift. *)
+  check_label "matches Safe_ops constant"
+    Safe_ops.persistence_read_drop_reason_invalid_payload
+    (BPH.read_drop_reason_to_label RDR.Invalid_payload)
+
+let () =
+  Alcotest.run "board_metrics_labels"
+    [ ( "to_label byte-identity"
+      , [ Alcotest.test_case "board_persist_surface" `Quick
+            test_board_persist_surface_to_label
+        ; Alcotest.test_case "flusher_outcome" `Quick
+            test_flusher_outcome_to_label
+        ; Alcotest.test_case "automation_label" `Quick
+            test_automation_label_to_label
+        ; Alcotest.test_case "read_drop_reason" `Quick
+            test_read_drop_reason_to_label
+        ] )
+    ]


### PR DESCRIPTION
## 목표
`board_metrics_hooks`의 callback-inverted observer가 들고 있던 **string label dimension을 closed sum으로** 타입화한다. inversion은 이미 올바르므로 label만 tightening — Prometheus 라벨 문자열은 **byte-identical 보존**.

## 변경
- closed sum: `board_persist_surface`(=`Board_post_meta_json`), `flusher_outcome`(`Switch_finished`/`Cas_exhausted`) — `board_metrics_hooks.ml`. `automation_label`(6변형)은 `board_types` leaf로 relocate.
- `reason`은 기존 SSOT `Read_drop_reason.t`(lib/core) 재사용(중복 회피, advisor 권고).
- 유일한 `variant -> string` 매핑 = Prometheus adapter(`board_prometheus_hooks.ml`)의 total `*_to_label`. observer 시그니처 + noop + 호출부(board_dispatch 2, board_votes_json 1).
- **`author`는 string 유지** — unbounded external-identity(high cardinality)라 범위 밖(주석). identity refactor로 안 번짐.
- `surface`는 board-persistence row(단일값 `board_post_meta_json`), 삭제된 Tool surface(#19854)와 무관.

## 검증
- `dune build @check`=0, `lib/masc_mcp.cmxa` native=0, `dune build .`(default)=0.
- `to_label` byte-identity: switch_finished/cas_exhausted/board_post_meta_json/auto-prefix/qa-prefix/researcher/harness/smoke/probe/invalid_payload — 옛 inline과 일치(대시보드/알람 무영향).
- 신규 test 4/4. 모든 `to_label` total(no `_->`).

RFC-WAIVED: board/metrics 타입화. guarded subsystem 미접촉.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
