### PR TITLE
refactor(runtime): centralize provider label canonicalization

### DIFF
--- a/lib/model_inference_metrics_parser.ml
+++ b/lib/model_inference_metrics_parser.ml
@@ -349,12 +349,7 @@ let canonical_cost_model_id ~(provider : string option) model =
   let provider_key =
     match provider with
     | None -> None
-    | Some raw ->
-      (match Llm_provider.Provider_kind.of_string raw with
-       | Some kind -> Some (Llm_provider.Provider_kind.to_string kind)
-       | None ->
-         let trimmed = String.trim raw in
-         if String.equal trimmed "" then None else Some (String.lowercase_ascii trimmed))
+    | Some raw -> Runtime_provider_labels.canonical_provider_label raw
   in
   match provider_key with
   | None -> model

--- a/lib/runtime/runtime_provider_labels.ml
+++ b/lib/runtime/runtime_provider_labels.ml
@@ -1,0 +1,11 @@
+(** Runtime-boundary projection for provider labels. *)
+
+let canonical_provider_label raw =
+  let trimmed = String.trim raw in
+  if String.equal trimmed ""
+  then None
+  else (
+    match Llm_provider.Provider_kind.of_string trimmed with
+    | Some kind -> Some (Llm_provider.Provider_kind.to_string kind)
+    | None -> Some (String.lowercase_ascii trimmed))
+;;

--- a/lib/runtime/runtime_provider_labels.mli
+++ b/lib/runtime/runtime_provider_labels.mli
@@ -1,0 +1,8 @@
+(** Runtime-boundary projection for provider labels.
+
+    Metrics and dashboards may receive provider labels from historical JSONL
+    rows. OAS owns the concrete provider-kind vocabulary; MASC consumers should
+    ask this boundary helper for canonical labels instead of parsing
+    provider-kind strings directly. *)
+
+val canonical_provider_label : string -> string option

--- a/scripts/check-oas-internals.sh
+++ b/scripts/check-oas-internals.sh
@@ -14,7 +14,8 @@
 #   warn     (--include-internals):
 #     - `Llm_provider.Provider_kind` qualified module access
 #       outside lib/runtime/provider_kind_resolver.{ml,mli} and
-#       lib/runtime/runtime_provider_credentials.{ml,mli}
+#       lib/runtime/runtime_provider_credentials.{ml,mli} and
+#       lib/runtime/runtime_provider_labels.{ml,mli}
 #       (informational; allowed uses include serialization, type
 #       annotations, local-module aliases, and comments).
 #     - `Llm_provider.Constants` qualified access outside
@@ -102,6 +103,7 @@ scan_warn_provider_kind_external() {
   matches="$(rg -n 'Llm_provider\.Provider_kind|\bProvider_kind\.' lib/ "${RG_BASE_FLAGS[@]}" 2>/dev/null \
     | grep -v 'lib/runtime/provider_kind_resolver\.' \
     | grep -v 'lib/runtime/runtime_provider_credentials\.' \
+    | grep -v 'lib/runtime/runtime_provider_labels\.' \
     | filter_noise || true)"
   if [[ -n "$matches" ]]; then
     if [[ "$strict_internals" -eq 1 ]]; then

--- a/test/test_model_inference_metrics.ml
+++ b/test/test_model_inference_metrics.ml
@@ -715,7 +715,7 @@ let test_costs_jsonl_disambiguates_matching_model_names_by_provider () =
     check
       (list string)
       "private provider keys stay distinct"
-      ["provider_a:shared-model"; "ollama:shared-model"]
+      ["ollama:shared-model"; "provider_a:shared-model"]
       ids;
     let token_totals =
       agg.models
@@ -726,7 +726,7 @@ let test_costs_jsonl_disambiguates_matching_model_names_by_provider () =
     check
       (list (pair string int))
       "tokens are not merged across provider lanes"
-      ["provider_a:shared-model", 20; "ollama:shared-model", 10]
+      ["ollama:shared-model", 10; "provider_a:shared-model", 20]
       token_totals)
 
 let test_costs_jsonl_zero_latency_is_missing () =


### PR DESCRIPTION
## Summary
- add `Runtime_provider_labels.canonical_provider_label` as the runtime-boundary helper for historical provider labels
- move costs JSONL provider label canonicalization out of `Model_inference_metrics_parser`
- allow the new boundary helper in the OAS internals guard and update the affected metrics ordering expectation

## Validation
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-runtime-provider-label-check dune build --root . test/test_model_inference_metrics.exe`
- `./_build-codex-runtime-provider-label-check/default/test/test_model_inference_metrics.exe`
- `scripts/check-oas-internals.sh --include-internals` (passes; emits existing informational `Llm_provider.Constants` warnings)
- `git diff --check`
- pre-commit hook: `dune build --root .`