### PR TITLE
feat(ide): auto-collect tool/turn events via Keeper hooks

### DIFF
--- a/lib/ide/dune
+++ b/lib/ide/dune
@@ -9,6 +9,8 @@
  (modules
   ide_annotation_types
   ide_annotations
+  ide_bridge
+  ide_event_types
   ide_paths
   ide_region_tracker)
  (libraries

--- a/lib/ide/ide_bridge.ml
+++ b/lib/ide/ide_bridge.ml
@@ -1,0 +1,105 @@
+(** IDE Bridge — collects Keeper activity events and surfaces them in
+    the [.masc-ide/] partition structure for IDE consumption. *)
+
+open Ide_event_types
+
+let default_partition = Ide_paths.Orphan
+
+let append_event ~base_dir ~partition ~(event : ide_event) =
+  let dir = Ide_paths.partition_store_dir ~base_dir partition in
+  (try ignore (Sys.command (Printf.sprintf "mkdir -p %s" dir)) with _ -> ());
+  let file_name =
+    match event with
+    | Tool_event _ -> "tool_events.jsonl"
+    | Turn_event _ -> "turn_events.jsonl"
+  in
+  let path = Filename.concat dir file_name in
+  let json = ide_event_to_json event in
+  let line = Yojson.Safe.to_string json in
+  let oc = open_out_gen [ Open_creat; Open_append; Open_text ] 0o644 path in
+  output_string oc line;
+  output_char oc '\n';
+  close_out oc
+
+let ingest_tool_event
+    ~base_path
+    ~tool_name
+    ~keeper_id
+    ~turn_id
+    ~outcome
+    ~typed_outcome
+    ~latency_ms
+    ~summary
+    ~file_path
+    ~timestamp_ms
+  =
+  let truncated_summary =
+    if String.length summary > 200 then String.sub summary 0 200 ^ "..."
+    else summary
+  in
+  let event =
+    Tool_event
+      { tool_name
+      ; keeper_id
+      ; turn_id
+      ; outcome
+      ; typed_outcome
+      ; latency_ms
+      ; summary = truncated_summary
+      ; file_path
+      ; timestamp_ms
+      }
+  in
+  (try append_event ~base_dir:base_path ~partition:default_partition ~event
+   with exn ->
+     Printf.eprintf "Ide_bridge.ingest_tool_event error: %s\n%!" (Printexc.to_string exn))
+
+let ingest_turn_event
+    ~base_path
+    ~turn_id
+    ~keeper_id
+    ~phase
+    ~model_used
+    ~tools_used
+    ~stop_reason
+    ~duration_ms
+    ~timestamp_ms
+  =
+  let event =
+    Turn_event
+      { turn_id
+      ; keeper_id
+      ; phase
+      ; model_used
+      ; tools_used
+      ; stop_reason
+      ; duration_ms
+      ; timestamp_ms
+      }
+  in
+  (try append_event ~base_dir:base_path ~partition:default_partition ~event
+   with exn ->
+     Printf.eprintf "Ide_bridge.ingest_turn_event error: %s\n%!" (Printexc.to_string exn))
+
+let parse_pr_url_from_output (output : string) : (int * string) option =
+  let prefix = "https://github.com/" in
+  let prefix_len = String.length prefix in
+  let output_len = String.length output in
+  let rec find_prefix i =
+    if i + prefix_len > output_len then None
+    else if String.sub output i prefix_len = prefix then Some i
+    else find_prefix (i + 1)
+  in
+  match find_prefix 0 with
+  | None -> None
+  | Some start ->
+    let rest = String.sub output start (output_len - start) in
+    let parts = String.split_on_char '/' rest in
+    (match parts with
+     | owner :: repo :: "pull" :: number_str :: _ ->
+       (try
+          let number = int_of_string number_str in
+          let url = Printf.sprintf "https://github.com/%s/%s/pull/%d" owner repo number in
+          Some (number, url)
+        with Failure _ -> None)
+     | _ -> None)

--- a/lib/ide/ide_bridge.mli
+++ b/lib/ide/ide_bridge.mli
@@ -1,0 +1,31 @@
+(** IDE Bridge — collects Keeper activity events and surfaces them in
+    the [.masc-ide/] partition structure for IDE consumption. *)
+
+open Ide_event_types
+
+val ingest_tool_event :
+  base_path:string ->
+  tool_name:string ->
+  keeper_id:string ->
+  turn_id:string ->
+  outcome:string ->
+  typed_outcome:string ->
+  latency_ms:int ->
+  summary:string ->
+  file_path:string option ->
+  timestamp_ms:int64 ->
+  unit
+
+val ingest_turn_event :
+  base_path:string ->
+  turn_id:string ->
+  keeper_id:string ->
+  phase:string ->
+  model_used:string option ->
+  tools_used:string list ->
+  stop_reason:string option ->
+  duration_ms:int option ->
+  timestamp_ms:int64 ->
+  unit
+
+val parse_pr_url_from_output : string -> (int * string) option

--- a/lib/ide/ide_event_types.ml
+++ b/lib/ide/ide_event_types.ml
@@ -1,0 +1,59 @@
+(** IDE Event Types — unified event model for Keeper activity visualization. *)
+
+type ide_event =
+  | Tool_event of tool_event
+  | Turn_event of turn_event
+
+and tool_event =
+  { tool_name : string
+  ; keeper_id : string
+  ; turn_id : string
+  ; outcome : string
+  ; typed_outcome : string
+  ; latency_ms : int
+  ; summary : string
+  ; file_path : string option
+  ; timestamp_ms : int64
+  }
+
+and turn_event =
+  { turn_id : string
+  ; keeper_id : string
+  ; phase : string
+  ; model_used : string option
+  ; tools_used : string list
+  ; stop_reason : string option
+  ; duration_ms : int option
+  ; timestamp_ms : int64
+  }
+
+let tool_event_to_json (e : tool_event) : Yojson.Safe.t =
+  `Assoc
+    [ "type", `String "tool"
+    ; "tool_name", `String e.tool_name
+    ; "keeper_id", `String e.keeper_id
+    ; "turn_id", `String e.turn_id
+    ; "outcome", `String e.outcome
+    ; "typed_outcome", `String e.typed_outcome
+    ; "latency_ms", `Int e.latency_ms
+    ; "summary", `String e.summary
+    ; "file_path", (match e.file_path with Some fp -> `String fp | None -> `Null)
+    ; "timestamp_ms", `Intlit (Int64.to_string e.timestamp_ms)
+    ]
+
+let turn_event_to_json (e : turn_event) : Yojson.Safe.t =
+  `Assoc
+    [ "type", `String "turn"
+    ; "turn_id", `String e.turn_id
+    ; "keeper_id", `String e.keeper_id
+    ; "phase", `String e.phase
+    ; "model_used", (match e.model_used with Some m -> `String m | None -> `Null)
+    ; "tools_used", `List (List.map (fun s -> `String s) e.tools_used)
+    ; "stop_reason", (match e.stop_reason with Some r -> `String r | None -> `Null)
+    ; "duration_ms", (match e.duration_ms with Some d -> `Int d | None -> `Null)
+    ; "timestamp_ms", `Intlit (Int64.to_string e.timestamp_ms)
+    ]
+
+let ide_event_to_json = function
+  | Tool_event e -> tool_event_to_json e
+  | Turn_event e -> turn_event_to_json e

--- a/lib/ide/ide_event_types.mli
+++ b/lib/ide/ide_event_types.mli
@@ -1,0 +1,30 @@
+(** IDE Event Types — unified event model for Keeper activity visualization. *)
+
+type ide_event =
+  | Tool_event of tool_event
+  | Turn_event of turn_event
+
+and tool_event =
+  { tool_name : string
+  ; keeper_id : string
+  ; turn_id : string
+  ; outcome : string
+  ; typed_outcome : string
+  ; latency_ms : int
+  ; summary : string
+  ; file_path : string option
+  ; timestamp_ms : int64
+  }
+
+and turn_event =
+  { turn_id : string
+  ; keeper_id : string
+  ; phase : string
+  ; model_used : string option
+  ; tools_used : string list
+  ; stop_reason : string option
+  ; duration_ms : int option
+  ; timestamp_ms : int64
+  }
+
+val ide_event_to_json : ide_event -> Yojson.Safe.t

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -106,6 +106,17 @@ let run_turn
   (* Section 1: Setup — sanitize input, build context, compose prompt. *)
   let user_message = Keeper_run_prompt.sanitize_user_message user_message in
   Masc_runtime_events.emit_turn_start ();
+  (* IDE Bridge: emit turn started event *)
+  Ide_bridge.ingest_turn_event
+    ~base_path:config.base_path
+    ~turn_id:(match meta.current_task_id with Some t -> Keeper_id.Task_id.to_string t | None -> "turn-" ^ meta.name)
+    ~keeper_id:meta.name
+    ~phase:"started"
+    ~model_used:None
+    ~tools_used:[]
+    ~stop_reason:None
+    ~duration_ms:None
+    ~timestamp_ms:(Int64.of_float (Unix.gettimeofday () *. 1000.0));
   Memory_hooks.clear_last_memory_injection meta.agent_name;
   (* Cancel-safe cleanup (#9747): stdlib [Fun.protect] wraps finally
      exceptions in [Fun.Finally_raised], masking the outer
@@ -114,8 +125,26 @@ let run_turn
      already in flight) and log non-cancel exceptions instead of
      propagating them. Mirrors the pattern used in
      [keeper_unified_turn.ml] (#9747 iter 1). *)
+  let turn_start_time = Unix.gettimeofday () in
   let safe_emit_turn_end =
-    Turn_helpers.emit_turn_end_safely ~keeper_name:meta.name
+    (* IDE Bridge: emit turn completed event on turn end *)
+    let emit_ide_bridge_turn_end () =
+      let duration_ms = int_of_float ((Unix.gettimeofday () -. turn_start_time) *. 1000.0) in
+      let turn_id = match meta.current_task_id with Some t -> Keeper_id.Task_id.to_string t | None -> "turn-" ^ meta.name in
+      Ide_bridge.ingest_turn_event
+        ~base_path:config.base_path
+        ~turn_id
+        ~keeper_id:meta.name
+        ~phase:"completed"
+        ~model_used:None
+        ~tools_used:[]
+        ~stop_reason:None
+        ~duration_ms:(Some duration_ms)
+        ~timestamp_ms:(Int64.of_float (Unix.gettimeofday () *. 1000.0))
+    in
+    fun () ->
+      (try emit_ide_bridge_turn_end () with _ -> ());
+      Turn_helpers.emit_turn_end_safely ~keeper_name:meta.name ()
   in
   Eio_guard.protect ~finally:safe_emit_turn_end
   @@ fun () ->
@@ -407,7 +436,7 @@ let run_turn
     let keeper_has_owned_active_task () =
       Option.is_some (owned_active_task_id_for_meta ~config ~meta:acc.meta)
     in
-    (* A claim tool mutates [acc.meta.current_task_id] during this run; contract
+    (* A claim tool mutates [acc.meta.current_task_id_id] during this run; contract
      gating must judge claim-context tools against ownership at turn entry. *)
     let had_owned_active_task_at_turn_start = keeper_has_owned_active_task () in
     (* 8. Run Agent *)

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -218,7 +218,40 @@ let assemble_hooks
              ; task_id
              ; route_evidence
              }
-             :: acc.tool_calls)
+             :: acc.tool_calls;
+          (* IDE Bridge: emit tool event for IDE visualization *)
+          (let typed_outcome_str =
+             match typed_outcome with
+             | Some Keeper_tool_outcome.Progress -> "progress"
+             | Some (Keeper_tool_outcome.No_progress _) -> "no_progress"
+             | Some (Keeper_tool_outcome.Error _) -> "error"
+             | None -> outcome
+           in
+           let file_path =
+             match Yojson.Safe.Util.member "path" input with
+             | `String p -> Some p
+             | _ ->
+               match Yojson.Safe.Util.member "file_path" input with
+               | `String p -> Some p
+               | _ -> None
+           in
+           let summary = if String.length output_text > 200 then String.sub output_text 0 200 else output_text in
+           let turn_id =
+             match acc.meta.Keeper_meta_contract.current_task_id with
+             | Some t -> Keeper_id.Task_id.to_string t
+             | None -> "turn-" ^ string_of_int (List.length acc.tool_calls)
+           in
+           Ide_bridge.ingest_tool_event
+             ~base_path:config.base_path
+             ~tool_name
+             ~keeper_id:acc.meta.name
+             ~turn_id
+             ~outcome
+             ~typed_outcome:typed_outcome_str
+             ~latency_ms:(int_of_float duration_ms)
+             ~summary
+             ~file_path
+             ~timestamp_ms:(Int64.of_float (Unix.gettimeofday () *. 1000.0))))
         ~passive_loop_nudge:(fun () ->
           Keeper_passive_loop_detector.nudge_message ~keeper_name:acc.meta.name)
         ~pre_tool_use_guard:public_alias_pre_tool_use_guard


### PR DESCRIPTION
## Summary

Keeper hooks에서 IDE bridge로 자동 이벤트 수집을 연결합니다.

### 변경 사항

1. **ide_event_types + ide_bridge 모듈 생성** — lib/ide/에 이벤트 타입 정의 + 수집기
2. **on_tool_executed hook 연결** — keeper_run_tools_hooks.ml에서 모든 tool call 완료 시 자동으로 `Ide_bridge.ingest_tool_event` 호출
3. **turn lifecycle 연결** — keeper_agent_run.ml에서 turn 시작/완료 시 `Ide_bridge.ingest_turn_event` 호출

### 데이터 흐름

```
Keeper Turn → Agent.run → on_tool_executed hook
  → Ide_bridge.ingest_tool_event → .masc-ide/tool_events.jsonl

Keeper Turn → run_turn start/end
  → Ide_bridge.ingest_turn_event → .masc-ide/turn_events.jsonl
```

### 수집되는 이벤트

- **tool_event**: tool_name, outcome, typed_outcome, latency_ms, file_path, summary
- **turn_event**: turn_id, keeper_id, phase(started/completed), duration_ms

### 검증

- `dune build @check` 통과