### PR TITLE
fix(ide): remove silent mkdir failure in bridge

### DIFF
--- a/lib/ide/ide_bridge.ml
+++ b/lib/ide/ide_bridge.ml
@@ -7,7 +7,7 @@ let default_partition = Ide_paths.Orphan
 
 let append_event ~base_dir ~partition ~(event : ide_event) =
   let dir = Ide_paths.partition_store_dir ~base_dir partition in
-  (try ignore (Sys.command (Printf.sprintf "mkdir -p %s" dir)) with _ -> ());
+  Fs_compat.mkdir_p dir;
   let file_name =
     match event with
     | Tool_event _ -> "tool_events.jsonl"


### PR DESCRIPTION
## Summary

- Replace `Sys.command "mkdir -p ..."` in `Ide_bridge.append_event` with `Fs_compat.mkdir_p`.
- Remove the critical `try ignore ... with _ -> ()` silent-failure pattern introduced on `main`.

## Product impact

- No intended user-facing behavior change: IDE bridge still creates the partition directory before appending event JSONL.
- Directory creation failures now propagate to the existing ingest-level error logging instead of being silently swallowed.

## Evidence

- `bash scripts/ci/check-silent-failure-patterns.sh`
- `ocamlformat --check lib/ide/ide_bridge.ml`
- `git diff --check`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_JOBS=1 DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-ide-bridge-object scripts/dune-local.sh build lib/ide/.masc_ide.objs/native/ide_bridge.cmx`

## Direct evidence

schema_version: 1
direct_ratio: n/a
provenance: direct
- Local Meta Guards reproduction found `scripts/ci/check-silent-failure-patterns.sh` failing on `lib/ide/ide_bridge.ml:10`.
- After this patch, `scripts/ci/check-silent-failure-patterns.sh` reports `SIL gate: PASS`.

## Review evidence

- Scope is one line in `lib/ide/ide_bridge.ml`.
- `masc_ide` already depends on `fs_compat`, so this does not add a new library edge.

## Linked issue

- Unblocks the `Meta Guards` silent-failure component observed while checking PR #19874.
- Separate repository policy drift recorded in #19875.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`codex/fix-ide-bridge-mkdir-silent-20260603` → `main` · 1 commit(s) · synced 2026-06-03T06:38:12Z

| sha | subject | date |
|---|---|---|
| `f8a3bdd13` | fix(ide): remove silent mkdir failure in bridge | 2026-06-03 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->