### PR TITLE
refactor(keeper): type terminal_reason_code into a closed sum (RFC-0042 substring-classifier purge)

### DIFF
--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -231,53 +231,64 @@ let operator_disposition_reason_to_string = function
 ;;
 
 (* Terminal-reason prefixes for OAS agent-execution errors that exhaust a
-   turn/time budget before the turn completes. SSOT shared with the encoder
-   [Keeper_agent_error.agent_error_terminal_reason_code]. A turn cut off by
-   the per-call turn cap ([MaxTurnsExceeded]), the wall-clock ceiling
-   ([AgentExecutionTimeout]), or the progress-aware idle watchdog
-   ([AgentExecutionIdleTimeout]) did NOT violate the tool contract — it never
-   reached a verdict. The keeper checkpoints and the supervisor auto-resumes
-   ([Keeper_error_classify.is_auto_recoverable_turn_error] /
-   [Keeper_supervisor] auto_resume). Scope is deliberately narrow: token/cost
+   turn/time budget before the turn completes. The SSOT now lives in
+   [Keeper_terminal_reason] (RFC-0042 PR-4) so the typed classifier owns
+   the constants the [Auto_recoverable_budget] bucket matches; these
+   re-exports keep [Keeper_agent_error] and the public [.mli] byte-stable.
+   A turn cut off by the per-call turn cap ([MaxTurnsExceeded]), the
+   wall-clock ceiling ([AgentExecutionTimeout]), or the progress-aware idle
+   watchdog ([AgentExecutionIdleTimeout]) did NOT violate the tool
+   contract — it never reached a verdict. The keeper checkpoints and the
+   supervisor auto-resumes. Scope is deliberately narrow: token/cost
    budget, guardrail, and tripwire terminals stay out, since those are
    genuine ceilings an operator should see, not transient turn cut-offs. *)
-let terminal_prefix_max_turns_exceeded = "agent_error_max_turns_exceeded"
-let terminal_prefix_execution_timeout = "agent_error_execution_timeout"
-let terminal_prefix_idle_timeout = "agent_error_idle_timeout"
+let terminal_prefix_max_turns_exceeded =
+  Keeper_terminal_reason.terminal_prefix_max_turns_exceeded
+;;
 
-let is_auto_recoverable_turn_budget_terminal terminal_reason =
-  String.starts_with ~prefix:terminal_prefix_max_turns_exceeded terminal_reason
-  || String.starts_with ~prefix:terminal_prefix_execution_timeout terminal_reason
-  || String.starts_with ~prefix:terminal_prefix_idle_timeout terminal_reason
+let terminal_prefix_execution_timeout =
+  Keeper_terminal_reason.terminal_prefix_execution_timeout
+;;
+
+let terminal_prefix_idle_timeout = Keeper_terminal_reason.terminal_prefix_idle_timeout
+
+let is_auto_recoverable_turn_budget_terminal =
+  Keeper_terminal_reason.is_auto_recoverable_turn_budget_terminal
 ;;
 
 let operator_disposition (receipt : t)
   : operator_disposition_kind * operator_disposition_reason
   =
-  let terminal_reason = String.lowercase_ascii receipt.terminal_reason_code in
+  (* Parse the wire string ONCE into the typed classification
+     ([Keeper_terminal_reason], RFC-0042 PR-4). The earlier
+     [String.starts_with] / [string_contains] chain is now a single
+     [of_wire] call; each former string predicate is a variant test,
+     preserving the original [if/else] priority order. The error_kind
+     sub-predicates stay here (they read the receipt record, not the wire
+     string) and remain OR'd with the variant test at the same branch. *)
+  let terminal_reason = Keeper_terminal_reason.of_wire receipt.terminal_reason_code in
   let error_kind =
     Option.map
       (fun kind -> String.lowercase_ascii (error_kind_to_string kind))
       receipt.error_kind
   in
   let provider_runtime_failure =
-    String.starts_with ~prefix:"api_error_" terminal_reason
-    || String.equal terminal_reason "provider_error"
+    (match terminal_reason with
+     | Keeper_terminal_reason.Provider_runtime_failure _ -> true
+     | _ -> false)
     ||
     match error_kind with
     | Some ("api" | "mcp" | "io" | "orchestration" | "serialization") -> true
     | Some _ | None -> false
   in
   let preflight_config_failure =
+    (match terminal_reason with
+     | Keeper_terminal_reason.Config_or_auth _ -> true
+     | _ -> false)
+    ||
     match error_kind with
-    | Some kind ->
-      string_contains_ci kind "config"
-      || string_contains_ci kind "auth"
-      || string_contains_ci terminal_reason "config"
-      || string_contains_ci terminal_reason "auth"
-    | None ->
-      string_contains_ci terminal_reason "config"
-      || string_contains_ci terminal_reason "auth"
+    | Some kind -> string_contains_ci kind "config" || string_contains_ci kind "auth"
+    | None -> false
   in
   (* Pre-typing, this branch also matched runtime_outcome="runtime_exhausted"
      and "exhausted" — neither is in the producer's closed [runtime_outcome]
@@ -285,23 +296,24 @@ let operator_disposition (receipt : t)
      [_not_dispatched]).  Those branches were unreachable workarounds; the
      typed migration drops them.  Runtime exhaustion still reaches this
      branch via [terminal_reason="runtime_exhausted"]. *)
-  if String.equal terminal_reason "runtime_exhausted"
-  then Disp_alert_exhausted, Reason_runtime_exhausted
-  else if preflight_config_failure
-  then Disp_pause_human, Reason_preflight_config_error
-  else if
-    provider_runtime_failure
-    && (receipt.degraded_retry_applied || Option.is_some receipt.degraded_retry_runtime)
-  then Disp_fail_open_next_runtime, Reason_degraded_retry
-  else if
-    provider_runtime_failure
-    && (receipt.runtime_fallback_applied
-        || receipt.runtime_outcome = Runtime_passed_to_next_model)
-  then Disp_pass_next_model, Reason_runtime_fallback
-  else if provider_runtime_failure
-  then Disp_pause_human, Reason_provider_runtime_error
-  else if String.starts_with ~prefix:"completion_contract_violation:" terminal_reason
-  then
+  match terminal_reason with
+  | Keeper_terminal_reason.Runtime_exhausted _ ->
+    Disp_alert_exhausted, Reason_runtime_exhausted
+  | _ when preflight_config_failure ->
+    Disp_pause_human, Reason_preflight_config_error
+  | _
+    when provider_runtime_failure
+         && (receipt.degraded_retry_applied
+             || Option.is_some receipt.degraded_retry_runtime) ->
+    Disp_fail_open_next_runtime, Reason_degraded_retry
+  | _
+    when provider_runtime_failure
+         && (receipt.runtime_fallback_applied
+             || receipt.runtime_outcome = Runtime_passed_to_next_model) ->
+    Disp_pass_next_model, Reason_runtime_fallback
+  | _ when provider_runtime_failure ->
+    Disp_pause_human, Reason_provider_runtime_error
+  | Keeper_terminal_reason.Completion_contract_violation _ ->
     (* The downstream completion-contract layer has already decided the turn
        violated [require_tool_use] (or another contract sub-clause) and emits
        [terminal_reason="completion_contract_violation:<sub_clause>"]. The
@@ -312,22 +324,21 @@ let operator_disposition (receipt : t)
        authoritative — the disposition is the same as the explicit
        [tool_required_unsatisfied] branch below. *)
     Disp_pause_human, Reason_tool_required_unsatisfied
-  else if
-    String.starts_with ~prefix:"turn_livelock:" terminal_reason
-    ||
-    match error_kind with
-    | Some "turn_livelock_blocked" -> true
-    | Some _ | None -> false
-  then Disp_pause_human, Reason_turn_livelock_blocked
-  else if
-    String.equal terminal_reason "internal_error"
-    ||
-    match error_kind with
-    | Some "internal" -> true
-    | Some _ | None -> false
-  then Disp_pause_human, Reason_internal_error
-  else if is_auto_recoverable_turn_budget_terminal terminal_reason
-  then
+  | Keeper_terminal_reason.Turn_livelock _ ->
+    Disp_pause_human, Reason_turn_livelock_blocked
+  | _
+    when (match error_kind with
+          | Some "turn_livelock_blocked" -> true
+          | Some _ | None -> false) ->
+    Disp_pause_human, Reason_turn_livelock_blocked
+  | Keeper_terminal_reason.Internal_error _ ->
+    Disp_pause_human, Reason_internal_error
+  | _
+    when (match error_kind with
+          | Some "internal" -> true
+          | Some _ | None -> false) ->
+    Disp_pause_human, Reason_internal_error
+  | Keeper_terminal_reason.Auto_recoverable_budget _ ->
     (* The turn was cut off by its per-call turn cap / wall-clock ceiling /
        idle watchdog before producing a verdict. This is auto-recoverable
        (the supervisor resumes from the checkpoint), NOT a tool-contract
@@ -339,7 +350,17 @@ let operator_disposition (receipt : t)
        #19714 removed the blunt default wall-clock; this closes the
        disposition-side half of the same mis-signal. *)
     Disp_pass, Reason_turn_budget_exhausted
-  else
+  | Config_or_auth _
+  | Provider_runtime_failure _
+  | Pre_dispatch_success _
+  | Other _ ->
+    (* Generic tool-gate fall-through. [Config_or_auth] and
+       [Provider_runtime_failure] are caught by the guarded branches above
+       (their constructors force [preflight_config_failure] /
+       [provider_runtime_failure] true), so only [Pre_dispatch_success] and
+       [Other] reach here in practice; the first two are listed to keep the
+       match exhaustive without a wildcard. This block reproduces the
+       pre-typing [else] branch verbatim. *)
     let canonical_names names =
       names
       |> List.map Keeper_tool_resolution.canonical_tool_name
@@ -418,7 +439,17 @@ let operator_disposition (receipt : t)
       receipt.outcome = `Ok
       && receipt.runtime_outcome = Runtime_not_dispatched
       && receipt.tool_contract_result = Contract_not_dispatched
-      && String.equal terminal_reason "pre_dispatch_success"
+      &&
+      (match terminal_reason with
+       | Keeper_terminal_reason.Pre_dispatch_success _ -> true
+       | Runtime_exhausted _
+       | Config_or_auth _
+       | Provider_runtime_failure _
+       | Completion_contract_violation _
+       | Turn_livelock _
+       | Internal_error _
+       | Auto_recoverable_budget _
+       | Other _ -> false)
     then Disp_pass, Reason_healthy
     (* "healthy" requires an explicit success signal: turn completed without
        error AND runtime reached the configured terminal. Any other fallthrough
@@ -457,7 +488,7 @@ let operator_disposition (receipt : t)
            regression of #11651 silent-path fix"
           (outcome_kind_to_string receipt.outcome)
           (runtime_outcome_to_string receipt.runtime_outcome)
-          terminal_reason
+          receipt.terminal_reason_code
           (tool_contract_result_to_string receipt.tool_contract_result)
           (Option.value
              (Option.map error_kind_to_string receipt.error_kind)

--- a/lib/keeper/keeper_terminal_reason.ml
+++ b/lib/keeper/keeper_terminal_reason.ml
@@ -1,0 +1,93 @@
+(* RFC-0042 PR-4: consumer-side closed sum for the keeper disposition
+   classifier's view of [receipt.terminal_reason_code]. See the [.mli]
+   for why this is a third terminal-reason type and how it relates to
+   [Keeper_turn_terminal_code] (producer side) and
+   [Keeper_turn_disposition] (operator-facing side).
+
+   The whole point is to parse the wire string ONCE here and let
+   [Keeper_execution_receipt.operator_disposition] exhaustive-match,
+   replacing its chain of [String.starts_with] / [string_contains]
+   tests. Wire bytes are preserved: payload-bearing variants carry the
+   original string and [to_wire] returns it verbatim. *)
+
+(* SSOT for the turn/time-budget cut-off prefixes. These were previously
+   defined in [Keeper_execution_receipt]; moved down here so the typed
+   classifier owns them and [Keeper_execution_receipt] re-exports for
+   backward compatibility (the encoder [Keeper_agent_error] still reads
+   them through [Keeper_execution_receipt]). A turn cut off by the
+   per-call turn cap ([MaxTurnsExceeded]), the wall-clock ceiling
+   ([AgentExecutionTimeout]), or the progress-aware idle watchdog
+   ([AgentExecutionIdleTimeout]) did NOT violate the tool contract — it
+   never reached a verdict; the supervisor auto-resumes from the
+   checkpoint. *)
+let terminal_prefix_max_turns_exceeded = "agent_error_max_turns_exceeded"
+let terminal_prefix_execution_timeout = "agent_error_execution_timeout"
+let terminal_prefix_idle_timeout = "agent_error_idle_timeout"
+
+let is_auto_recoverable_turn_budget_terminal terminal_reason =
+  String.starts_with ~prefix:terminal_prefix_max_turns_exceeded terminal_reason
+  || String.starts_with ~prefix:terminal_prefix_execution_timeout terminal_reason
+  || String.starts_with ~prefix:terminal_prefix_idle_timeout terminal_reason
+;;
+
+type t =
+  | Runtime_exhausted of string
+  | Config_or_auth of string
+  | Provider_runtime_failure of string
+  | Completion_contract_violation of string
+  | Turn_livelock of string
+  | Internal_error of string
+  | Auto_recoverable_budget of string
+  | Pre_dispatch_success of string
+  | Other of string
+
+let contains_config_or_auth lowered =
+  String_util.contains_substring lowered "config"
+  || String_util.contains_substring lowered "auth"
+;;
+
+(* Priority-ranked partition. The bucket order replicates the [if/else]
+   order of the pre-typing [operator_disposition] string predicates;
+   [of_wire] returns the FIRST matching bucket. The original
+   (case-preserving) [wire] is carried in payload-bearing variants so
+   [to_wire] reproduces it byte-for-byte; classification is done on a
+   lowercased copy to match [operator_disposition], which lowercased
+   [terminal_reason_code] before testing. *)
+let of_wire wire =
+  let lowered = String.lowercase_ascii wire in
+  if String.equal lowered "runtime_exhausted"
+  then Runtime_exhausted wire
+  else if contains_config_or_auth lowered
+  then Config_or_auth wire
+  else if
+    String.starts_with ~prefix:"api_error_" lowered
+    || String.equal lowered "provider_error"
+  then Provider_runtime_failure wire
+  else if String.starts_with ~prefix:"completion_contract_violation:" lowered
+  then Completion_contract_violation wire
+  else if String.starts_with ~prefix:"turn_livelock:" lowered
+  then Turn_livelock wire
+  else if String.equal lowered "internal_error"
+  then Internal_error wire
+  else if is_auto_recoverable_turn_budget_terminal lowered
+  then Auto_recoverable_budget wire
+  else if String.equal lowered "pre_dispatch_success"
+  then Pre_dispatch_success wire
+  else Other wire
+;;
+
+(* Byte-identical inverse: every variant carries the original wire string,
+   so [to_wire (of_wire s) = s] holds for every [s] including mixed-case
+   inputs. The exact-match variants carry a payload only for this
+   round-trip fidelity; [operator_disposition] ignores it. *)
+let to_wire = function
+  | Runtime_exhausted wire -> wire
+  | Config_or_auth wire -> wire
+  | Provider_runtime_failure wire -> wire
+  | Completion_contract_violation wire -> wire
+  | Turn_livelock wire -> wire
+  | Internal_error wire -> wire
+  | Auto_recoverable_budget wire -> wire
+  | Pre_dispatch_success wire -> wire
+  | Other wire -> wire
+;;

--- a/lib/keeper/keeper_terminal_reason.mli
+++ b/lib/keeper/keeper_terminal_reason.mli
@@ -1,0 +1,130 @@
+(** RFC-0042 PR-4: closed sum for the keeper-side classification of a
+    receipt's [terminal_reason_code] string.
+
+    {1 Why a third terminal-reason type}
+
+    Two typed terminal-reason modules already exist:
+
+    - [Keeper_turn_terminal_code] (RFC-0042 PR-1/PR-2.5) is the
+      {e producer-side} bridge from [Keeper_registry.failure_reason] /
+      [Agent_sdk.Error.sdk_error]. Its [of_wire] returns [None] for the
+      SDK-error codes ([api_error_*], [completion_contract_violation:*],
+      [turn_livelock:*], the budget prefixes, [internal_error]) because
+      they are all collapsed into its [Sdk_error of string] blob — the
+      sub-sum RFC-0042 §5.2 explicitly defers. Matching on [Sdk_error s]
+      would force the substring re-parse back into the open, so it cannot
+      be the consumer's parse target.
+    - [Keeper_turn_disposition] (RFC-0047) is the operator-facing layer;
+      its [of_termination_code] routes through the same producer collapse
+      and produces a different output type.
+
+    This module is the missing {e consumer-side} parse target that
+    RFC-0042 PR-4 calls for: it parses [receipt.terminal_reason_code]
+    {e once} into the exact distinctions [Keeper_execution_receipt.operator_disposition]
+    branches on, so that classifier becomes an exhaustive [match] instead
+    of a chain of [String.starts_with] / [string_contains] tests.
+
+    {1 Partition discipline}
+
+    [of_wire] is a {e priority-ranked partition}: it tests the buckets in
+    the same order the old [operator_disposition] [if/else] chain tested
+    its string predicates and returns the first match. This is a faithful
+    re-encoding of the [if/else] order — pathological overlaps (a contract
+    id containing ["auth"], a budget string that also matches a later
+    bucket) resolve identically to the pre-typing code. The order is
+    load-bearing; see the [.ml] for the ranked list.
+
+    The escape arm [Other] is a {e named} typed escape for genuinely
+    unmatched legacy codes, not a permissive default: callers route it
+    explicitly to the same generic tool-gate logic the old code's
+    fall-through used.
+
+    {1 Wire byte-preservation}
+
+    [terminal_reason_code] is serialised verbatim into receipt JSON and
+    read + classified by dashboards. The receipt's JSON emission is
+    {b unchanged} — this module is used only inside the keeper-side
+    disposition classifier. [of_wire] lowercases internally for
+    classification but carries the {e original} (case-preserving) string
+    in every payload-bearing variant, so [to_wire (of_wire s) = s] holds
+    byte-for-byte. *)
+
+type t =
+  | Runtime_exhausted of string
+  (** Exact wire ["runtime_exhausted"] (modulo case). Payload is the
+          original string, carried only so [to_wire] is a byte-identical
+          inverse; the disposition classifier ignores it. *)
+  | Config_or_auth of string
+  (** Wire string contains ["config"] or ["auth"] (case-insensitive).
+          Ranked above the provider family so [api_error_auth],
+          [provider_error_auth:*], [provider_error_invalid_config:*], and
+          [config_error] land here — matching the pre-typing preflight
+          branch which was checked before the provider prefixes. Payload is
+          the original string. *)
+  | Provider_runtime_failure of string
+  (** Wire [String.starts_with ~prefix:"api_error_"] OR exact
+          ["provider_error"]. The parametrised [provider_error_*] codes
+          (server/hard_quota/capacity/missing_api_key/…) do NOT match the
+          exact test and, absent a config/auth substring, fall to [Other] —
+          preserving the pre-typing behaviour. Payload is the original
+          string. *)
+  | Completion_contract_violation of string
+  (** Wire [String.starts_with ~prefix:"completion_contract_violation:"],
+          including the extended [:called[..]:satisfying[..]] form. Payload
+          is the original string. *)
+  | Turn_livelock of string
+  (** Wire [String.starts_with ~prefix:"turn_livelock:"]. Payload is the
+          original string. *)
+  | Internal_error of string
+  (** Exact wire ["internal_error"] (modulo case). Payload is the original
+          string, carried only for [to_wire] round-trip fidelity. *)
+  | Auto_recoverable_budget of string
+  (** Wire matches one of the turn/time-budget cut-off prefixes
+          ([agent_error_max_turns_exceeded] / [agent_error_execution_timeout]
+          / [agent_error_idle_timeout]): the turn was cut off before a
+          verdict and the supervisor auto-resumes from its checkpoint.
+          Payload is the original string. *)
+  | Pre_dispatch_success of string
+  (** Exact wire ["pre_dispatch_success"] (modulo case): a turn that
+          completed without dispatching to a provider. Payload is the
+          original string, carried only for [to_wire] round-trip fidelity. *)
+  | Other of string
+  (** Named typed escape for any wire string none of the above buckets
+          matched (e.g. [provider_error_server:500], [no_tool_capable_provider],
+          [mcp_error], [registry_phase_missing], [supervisor_stop]). NOT a
+          permissive default: the disposition classifier routes it to the
+          same generic tool-gate logic the pre-typing fall-through used.
+          Payload is the original string. *)
+
+(** Parse a [terminal_reason_code] wire string into the typed
+    classification. Priority-ranked partition (see module doc); returns
+    the first matching bucket. Total — every string maps to exactly one
+    variant, with [Other] as the explicit escape. The argument is the
+    raw (case-preserving) wire string; classification is case-insensitive
+    but the original bytes are retained in payload-bearing variants. *)
+val of_wire : string -> t
+
+(** Reconstruct the exact wire string [of_wire] parsed. Byte-identical
+    inverse: [to_wire (of_wire s) = s] for every [s]. *)
+val to_wire : t -> string
+
+(** {1 Turn/time-budget cut-off prefixes (SSOT)}
+
+    Wire prefixes for OAS agent-execution errors that exhaust a turn/time
+    budget before the turn completes. The encoder
+    [Keeper_agent_error.agent_error_terminal_reason_code] builds the wire
+    strings from these constants, and the classifier matches on them via
+    the [Auto_recoverable_budget] bucket. Owned here so the typed parser
+    and the producer share one source. [Keeper_execution_receipt]
+    re-exports these for backward compatibility. *)
+val terminal_prefix_max_turns_exceeded : string
+
+val terminal_prefix_execution_timeout : string
+val terminal_prefix_idle_timeout : string
+
+(** [true] when [terminal_reason] (assumed already lowercased by the
+    caller, as [operator_disposition] does) is a turn/time-budget cut-off:
+    auto-recoverable, the keeper resumes from its checkpoint, so it must
+    NOT be classified as a tool-contract failure. Equivalent to
+    [of_wire s] returning [Auto_recoverable_budget _]. *)
+val is_auto_recoverable_turn_budget_terminal : string -> bool

--- a/test/dune
+++ b/test/dune
@@ -1405,6 +1405,8 @@
 
 (include stanzas/test_keeper_disposition_budget.inc)
 
+(include stanzas/test_keeper_terminal_reason_typed.inc)
+
 (include stanzas/test_keeper_failure_policy.inc)
 
 (include stanzas/test_keeper_tool_command_runtime_cwd_response.inc)

--- a/test/stanzas/test_keeper_terminal_reason_typed.inc
+++ b/test/stanzas/test_keeper_terminal_reason_typed.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_terminal_reason_typed)
+ (modules test_keeper_terminal_reason_typed)
+ (libraries masc_test_deps))

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -1,0 +1,444 @@
+(* RFC-0042 PR-4 behavioural equivalence + wire round-trip test.
+
+   Two properties are pinned:
+
+   1. [to_wire (of_wire s) = s] byte-for-byte for every representative
+      producer code string (and a few adversarial ones). This proves the
+      typed parse loses no information — every payload-bearing variant
+      carries the original bytes.
+
+   2. The NEW [Keeper_execution_receipt.operator_disposition] (which now
+      parses [terminal_reason_code] once via [Keeper_terminal_reason.of_wire]
+      and exhaustive-matches) returns the SAME (disposition, reason) pair as
+      a FROZEN verbatim copy of the pre-typing substring-classifier logic,
+      over the cartesian product of (producer-string corpus) x (the small
+      finite field matrix the classifier branches on). The frozen copy is
+      the independent oracle — it is intentionally NOT refactored to share
+      code with production, so a priority-order regression in production is
+      caught here. *)
+
+module R = Masc_mcp.Keeper_execution_receipt
+module Tr = Masc_mcp.Keeper_terminal_reason
+
+let failures = ref []
+let check name cond = if not cond then failures := name :: !failures
+
+(* ------------------------------------------------------------------ *)
+(* 1. Wire round-trip corpus: built from the PRODUCER sites, not from   *)
+(*    the classifier prefixes. Includes the enriched contract-violation *)
+(*    form, both api_error/provider_error families, the budget strings, *)
+(*    direct producer strings, and one mixed-case adversarial input.    *)
+(* ------------------------------------------------------------------ *)
+
+let roundtrip_corpus =
+  [ (* exact-match buckets *)
+    "runtime_exhausted"
+  ; "internal_error"
+  ; "pre_dispatch_success"
+  ; "provider_error"
+    (* config/auth preflight (ranked above provider) *)
+  ; "config_error"
+  ; "api_error_auth"
+  ; "provider_error_auth:openai"
+  ; "provider_error_invalid_config:field_x"
+    (* provider family (api_error_ prefix) *)
+  ; "api_error_rate_limited"
+  ; "api_error_overloaded"
+  ; "api_error_server:502"
+  ; "api_error_timeout"
+  ; "api_error_context_overflow"
+  ; "api_error_oas_agent_execution_timeout"
+    (* completion-contract-violation (legacy + enriched forms) *)
+  ; "completion_contract_violation:require_tool_use"
+  ; "completion_contract_violation:require_tool_use:called[a,b]:satisfying[c]"
+    (* turn-livelock *)
+  ; "turn_livelock:stuck_age_exceeded"
+    (* budget cut-offs *)
+  ; "agent_error_max_turns_exceeded:turns=8,limit=8"
+  ; "agent_error_execution_timeout:elapsed_sec=120.0,timeout_sec=120.0,turn_count=7,max_turns=8"
+  ; "agent_error_idle_timeout:idle_sec=120.0,idle_timeout_sec=120.0,turn_count=7,max_turns=8"
+    (* genuine Other (preserve-don't-fix) *)
+  ; "provider_error_server:500"
+  ; "provider_error_missing_api_key"
+  ; "provider_error_hard_quota:openai"
+  ; "no_tool_capable_provider"
+  ; "mcp_error"
+  ; "serialization_error"
+  ; "io_error"
+  ; "orchestration_error"
+  ; "a2a_error"
+  ; "agent_error_token_budget_exceeded:kind=output,used=100,limit=50"
+  ; "agent_error_guardrail_violation:validator=x"
+  ; "agent_error_idle_detected:consecutive_idle_turns=3"
+  ; "registry_phase_missing"
+  ; "supervisor_stop"
+    (* adversarial: mixed case must round-trip to the original bytes *)
+  ; "Runtime_Exhausted"
+  ; "API_ERROR_Auth"
+  ; ""
+  ]
+
+let () =
+  List.iter
+    (fun s ->
+       let got = Tr.to_wire (Tr.of_wire s) in
+       check
+         (Printf.sprintf "roundtrip: %S -> %S" s got)
+         (String.equal got s))
+    roundtrip_corpus
+;;
+
+(* ------------------------------------------------------------------ *)
+(* 2. (disposition, reason) equivalence vs a frozen copy of the OLD    *)
+(*    substring classifier.                                            *)
+(* ------------------------------------------------------------------ *)
+
+(* Frozen verbatim copy of the pre-typing [operator_disposition] body.
+   DO NOT refactor to call production helpers — this is the oracle. It is
+   a byte-for-byte transcription of the git-history version (the
+   String.starts_with / string_contains chain) and must stay that way. *)
+let string_contains_ci = String_util.contains_substring_ci
+
+let frozen_terminal_prefix_max_turns_exceeded = "agent_error_max_turns_exceeded"
+let frozen_terminal_prefix_execution_timeout = "agent_error_execution_timeout"
+let frozen_terminal_prefix_idle_timeout = "agent_error_idle_timeout"
+
+let frozen_is_auto_recoverable_turn_budget_terminal terminal_reason =
+  String.starts_with ~prefix:frozen_terminal_prefix_max_turns_exceeded terminal_reason
+  || String.starts_with ~prefix:frozen_terminal_prefix_execution_timeout terminal_reason
+  || String.starts_with ~prefix:frozen_terminal_prefix_idle_timeout terminal_reason
+;;
+
+let frozen_operator_disposition (receipt : R.t)
+  : R.operator_disposition_kind * R.operator_disposition_reason
+  =
+  let terminal_reason = String.lowercase_ascii receipt.terminal_reason_code in
+  let error_kind =
+    Option.map
+      (fun kind -> String.lowercase_ascii (R.error_kind_to_string kind))
+      receipt.error_kind
+  in
+  let provider_runtime_failure =
+    String.starts_with ~prefix:"api_error_" terminal_reason
+    || String.equal terminal_reason "provider_error"
+    ||
+    match error_kind with
+    | Some ("api" | "mcp" | "io" | "orchestration" | "serialization") -> true
+    | Some _ | None -> false
+  in
+  let preflight_config_failure =
+    match error_kind with
+    | Some kind ->
+      string_contains_ci kind "config"
+      || string_contains_ci kind "auth"
+      || string_contains_ci terminal_reason "config"
+      || string_contains_ci terminal_reason "auth"
+    | None ->
+      string_contains_ci terminal_reason "config"
+      || string_contains_ci terminal_reason "auth"
+  in
+  if String.equal terminal_reason "runtime_exhausted"
+  then R.Disp_alert_exhausted, R.Reason_runtime_exhausted
+  else if preflight_config_failure
+  then R.Disp_pause_human, R.Reason_preflight_config_error
+  else if
+    provider_runtime_failure
+    && (receipt.degraded_retry_applied || Option.is_some receipt.degraded_retry_runtime)
+  then R.Disp_fail_open_next_runtime, R.Reason_degraded_retry
+  else if
+    provider_runtime_failure
+    && (receipt.runtime_fallback_applied
+        || receipt.runtime_outcome = R.Runtime_passed_to_next_model)
+  then R.Disp_pass_next_model, R.Reason_runtime_fallback
+  else if provider_runtime_failure
+  then R.Disp_pause_human, R.Reason_provider_runtime_error
+  else if String.starts_with ~prefix:"completion_contract_violation:" terminal_reason
+  then R.Disp_pause_human, R.Reason_tool_required_unsatisfied
+  else if
+    String.starts_with ~prefix:"turn_livelock:" terminal_reason
+    ||
+    match error_kind with
+    | Some "turn_livelock_blocked" -> true
+    | Some _ | None -> false
+  then R.Disp_pause_human, R.Reason_turn_livelock_blocked
+  else if
+    String.equal terminal_reason "internal_error"
+    ||
+    match error_kind with
+    | Some "internal" -> true
+    | Some _ | None -> false
+  then R.Disp_pause_human, R.Reason_internal_error
+  else if frozen_is_auto_recoverable_turn_budget_terminal terminal_reason
+  then R.Disp_pass, R.Reason_turn_budget_exhausted
+  else (
+    let used_tool_names =
+      receipt.canonical_tools @ receipt.observed_tools @ receipt.tools_used
+    in
+    let generic_claim_context_progress =
+      List.exists
+        Masc_mcp.Keeper_tool_progress.is_claim_context_tool_name
+        (List.map
+           Masc_mcp.Keeper_tool_resolution.canonical_tool_name
+           used_tool_names)
+    in
+    let ok_followup_progress =
+      receipt.outcome = `Ok
+      && receipt.runtime_outcome = R.Runtime_completed
+      && receipt.tool_contract_result = R.Contract_needs_execution_progress
+      && generic_claim_context_progress
+    in
+    let tool_gate_unsatisfied =
+      receipt.tool_surface.tool_requirement = Masc_mcp.Keeper_agent_tool_surface.Required
+      && (List.mem
+            receipt.tool_contract_result
+            [ R.Contract_violated
+            ; R.Contract_unknown
+            ; R.Contract_needs_execution_progress
+            ; R.Contract_missing_required_tool_use
+            ; R.Contract_passive_only
+            ; R.Contract_claim_only_after_owned_task
+            ; R.Contract_tool_surface_mismatch
+            ; R.Contract_no_tool_capable_provider
+            ]
+          || receipt.tools_used = [])
+      && not ok_followup_progress
+    in
+    let required_tool_route_failure =
+      List.mem
+        receipt.tool_contract_result
+        [ R.Contract_tool_surface_mismatch; R.Contract_no_tool_capable_provider ]
+    in
+    if tool_gate_unsatisfied && required_tool_route_failure
+    then
+      if receipt.degraded_retry_applied || Option.is_some receipt.degraded_retry_runtime
+      then R.Disp_fail_open_next_runtime, R.Reason_tool_route_recoverable_failure
+      else if
+        receipt.runtime_fallback_applied
+        || receipt.runtime_outcome = R.Runtime_passed_to_next_model
+      then R.Disp_pass_next_model, R.Reason_tool_route_recoverable_failure
+      else R.Disp_pause_human, R.Reason_tool_route_recoverable_failure
+    else if tool_gate_unsatisfied
+    then R.Disp_pause_human, R.Reason_tool_required_unsatisfied
+    else if
+      receipt.degraded_retry_applied || Option.is_some receipt.degraded_retry_runtime
+    then R.Disp_fail_open_next_runtime, R.Reason_degraded_retry
+    else if
+      receipt.runtime_fallback_applied
+      || receipt.runtime_outcome = R.Runtime_passed_to_next_model
+    then R.Disp_pass_next_model, R.Reason_runtime_fallback
+    else if
+      receipt.outcome = `Ok
+      && receipt.runtime_outcome = R.Runtime_not_dispatched
+      && receipt.tool_contract_result = R.Contract_not_dispatched
+      && String.equal terminal_reason "pre_dispatch_success"
+    then R.Disp_pass, R.Reason_healthy
+    else (
+      match receipt.outcome with
+      | `Cancelled -> R.Disp_user_cancelled, R.Reason_cancelled
+      | `Skipped -> R.Disp_skipped, R.Reason_phase_skipped
+      | `Ok when receipt.runtime_outcome = R.Runtime_completed ->
+        R.Disp_pass, R.Reason_healthy
+      | `Ok when receipt.runtime_outcome = R.Runtime_not_dispatched ->
+        R.Disp_pass, R.Reason_healthy
+      | _ -> R.Disp_unknown, R.Reason_unmapped_runtime_state))
+;;
+
+(* ------------------------------------------------------------------ *)
+(* Base receipt + field-matrix axes.                                   *)
+(* ------------------------------------------------------------------ *)
+
+let base_tool_surface : R.tool_surface =
+  { turn_lane = Masc_mcp.Keeper_agent_tool_surface.Lane_tool_required
+  ; tool_surface_class = Masc_mcp.Keeper_agent_tool_surface.Surface_public_only
+  ; tool_requirement = Masc_mcp.Keeper_agent_tool_surface.Required
+  ; visible_tool_count = 3
+  ; tool_gate_enabled = true
+  ; tool_surface_fallback_used = false
+  ; materialized_tools = []
+  }
+;;
+
+let base_receipt : R.t =
+  { keeper_name = "test-keeper"
+  ; agent_name = "test-agent"
+  ; trace_id = "trace-1"
+  ; generation = 1
+  ; turn_count = Some 1
+  ; oas_turn_count = None
+  ; oas_dispatch_mode = None
+  ; oas_internal_runtime_disabled = false
+  ; current_task_id = None
+  ; goal_ids = []
+  ; outcome = `Error
+  ; terminal_reason_code = ""
+  ; response_text_present = false
+  ; model_used = None
+  ; requested_tools = []
+  ; reported_tools = []
+  ; observed_tools = []
+  ; canonical_tools = []
+  ; unexpected_tools = []
+  ; tools_used = []
+  ; tool_contract_result = R.Contract_unknown
+  ; tool_surface = base_tool_surface
+  ; sandbox_kind = Masc_mcp.Keeper_types_profile_sandbox.Local
+  ; sandbox_root = None
+  ; network_mode = Masc_mcp.Keeper_types_profile_sandbox.Network_none
+  ; approval_profile = None
+  ; approval_profile_derived = false
+  ; runtime_id = "runtime-1"
+  ; runtime_selected_model = None
+  ; runtime_attempt_count = 1
+  ; runtime_fallback_applied = false
+  ; runtime_outcome = R.Runtime_completed
+  ; oas_internal_runtime_allowed = true
+  ; degraded_retry_applied = false
+  ; degraded_retry_runtime = None
+  ; fallback_reason = None
+  ; runtime_rotation_attempts = []
+  ; stop_reason = None
+  ; error_kind = None
+  ; error_message = None
+  ; started_at = "2026-06-03T00:00:00Z"
+  ; ended_at = "2026-06-03T00:00:01Z"
+  ; extra_system_context_digest = None
+  ; extra_system_context_injected_size = None
+  ; extra_system_context_computed_size = None
+  ; pre_dispatch_compacted = false
+  ; pre_dispatch_compaction_trigger = None
+  ; pre_dispatch_compaction_before_tokens = None
+  ; pre_dispatch_compaction_after_tokens = None
+  }
+;;
+
+(* Field matrix axes. Kept small but covering the dimensions the
+   classifier branches on. *)
+let codes = roundtrip_corpus
+
+let error_kinds =
+  [ None
+  ; Some (R.error_kind_of_string "config")
+  ; Some (R.error_kind_of_string "auth")
+  ; Some (R.error_kind_of_string "api")
+  ; Some (R.error_kind_of_string "mcp")
+  ; Some (R.error_kind_of_string "internal")
+  ; Some (R.error_kind_of_string "turn_livelock_blocked")
+  ; Some (R.error_kind_of_string "provider")
+  ; Some (R.error_kind_of_string "io")
+  ]
+
+let degraded_bools = [ false; true ]
+let fallback_bools = [ false; true ]
+
+let runtime_outcomes =
+  [ R.Runtime_completed
+  ; R.Runtime_passed_to_next_model
+  ; R.Runtime_not_observed
+  ; R.Runtime_not_dispatched
+  ]
+
+let tool_contract_results =
+  [ R.Contract_unknown
+  ; R.Contract_not_dispatched
+  ; R.Contract_no_tool_capable_provider
+  ; R.Contract_tool_surface_mismatch
+  ; R.Contract_missing_required_tool_use
+  ; R.Contract_needs_execution_progress
+  ; R.Contract_satisfied_completion
+  ]
+
+let tools_used_variants = [ []; [ "some_tool" ] ]
+let outcomes = [ `Ok; `Error; `Cancelled; `Skipped ]
+
+let disp_pair_to_string (d, r) =
+  Printf.sprintf
+    "(%s, %s)"
+    (R.operator_disposition_kind_to_string d)
+    (R.operator_disposition_reason_to_string r)
+;;
+
+(* To keep the product bounded we vary the most behaviour-determining axes
+   fully and pin the others to representative values per code, plus a
+   focused sub-matrix over the provider/route axes. *)
+let () =
+  let count = ref 0 in
+  let mismatches = ref 0 in
+  List.iter
+    (fun code ->
+       List.iter
+         (fun error_kind ->
+            List.iter
+              (fun degraded ->
+                 List.iter
+                   (fun fallback ->
+                      List.iter
+                        (fun runtime_outcome ->
+                           List.iter
+                             (fun tcr ->
+                                List.iter
+                                  (fun tools_used ->
+                                     List.iter
+                                       (fun outcome ->
+                                          let receipt =
+                                            { base_receipt with
+                                              terminal_reason_code = code
+                                            ; error_kind
+                                            ; degraded_retry_applied = degraded
+                                            ; runtime_fallback_applied = fallback
+                                            ; runtime_outcome
+                                            ; tool_contract_result = tcr
+                                            ; tools_used
+                                            ; outcome
+                                            }
+                                          in
+                                          incr count;
+                                          let want =
+                                            frozen_operator_disposition receipt
+                                          in
+                                          let got =
+                                            R.operator_disposition receipt
+                                          in
+                                          if want <> got
+                                          then (
+                                            incr mismatches;
+                                            if !mismatches <= 20
+                                            then
+                                              check
+                                                (Printf.sprintf
+                                                   "disp-mismatch code=%S ek=%s out=%s ro=%s tcr=%s tools=%b deg=%b fb=%b want=%s got=%s"
+                                                   code
+                                                   (match error_kind with
+                                                    | None -> "none"
+                                                    | Some k -> R.error_kind_to_string k)
+                                                   (R.outcome_kind_to_string outcome)
+                                                   (R.runtime_outcome_to_string
+                                                      runtime_outcome)
+                                                   (R.tool_contract_result_to_string tcr)
+                                                   (tools_used <> [])
+                                                   degraded
+                                                   fallback
+                                                   (disp_pair_to_string want)
+                                                   (disp_pair_to_string got))
+                                                false))
+                                       outcomes)
+                                  tools_used_variants)
+                             tool_contract_results)
+                        runtime_outcomes)
+                   fallback_bools)
+              degraded_bools)
+         error_kinds)
+    codes;
+  Printf.printf
+    "test_keeper_terminal_reason_typed: matrix cases=%d mismatches=%d\n"
+    !count
+    !mismatches
+;;
+
+let () =
+  match !failures with
+  | [] -> print_endline "test_keeper_terminal_reason_typed: OK"
+  | xs ->
+    List.iter (fun n -> print_endline ("FAIL: " ^ n)) (List.rev xs);
+    failwith
+      (Printf.sprintf "%d terminal-reason-typed assertion(s) failed" (List.length xs))
+;;


### PR DESCRIPTION
## Goal

Purge the `terminal_reason_code : string` substring classifier in keeper execution-receipt disposition. The keeper terminal reason was classified by ~10 `String.starts_with`/`string_contains` prefixes (`completion_contract_violation:`, `runtime_exhausted`, `api_error_`, `turn_livelock:`, budget prefixes, `config`/`auth` contains, ...) — the anti-pattern RFC-0042 targets. PR #19857 (B1) typed only the runtime-exhaustion slice; this types the full terminal-reason classification into a closed sum, so a new terminal reason is a compile error rather than a silent `unmapped` WARN.

## Change

- New `lib/keeper/keeper_terminal_reason.{ml,mli}`: closed sum `terminal_reason` (9 variants) + `of_wire` (parse once at the boundary; priority-ranked partition replicating the old if/else order) + `to_wire` (returns the carried original string verbatim).
- `keeper_execution_receipt.ml` `operator_disposition`: the ~10-test substring chain becomes one `of_wire` call + an exhaustive `match` (no `_ ->` wildcard except the explicit `Other` escape that preserves the original string). The budget-prefix SSOT (`terminal_prefix_*`, `is_auto_recoverable_turn_budget_terminal`) moved into the new module and is re-exported byte-stable.
- Producers unchanged (still emit strings); the string is parsed once at the consumer boundary. Typing the ~40 producer emit sites is deferred to RFC-0042 PR-3.

## Wire preservation

`to_wire` carries the original string verbatim, so the JSON `code` field dashboards read is byte-identical. Dashboard-side string reads are untouched (separate follow-up).

## Verification (local, branch tip)

- `dune build @check --root .` = 0
- `dune build lib/masc_mcp.cmxa --root .` = 0 (native target; catches expr-level errors `@check` misses)
- `test/test_keeper_terminal_reason_typed.ml`: a frozen verbatim copy of the old substring classifier is the independent oracle; the new `operator_disposition` is asserted result-equal over a corpus x field matrix = **298,368 cases / 0 mismatches**, plus `to_wire (of_wire s) = s` round-trip over the full corpus including mixed-case adversarial inputs (`Runtime_Exhausted`, `API_ERROR_Auth`, `""`).
- Exhaustiveness guarantee verified empirically: a temporary `Probe_unused` variant produced non-exhaustive-match errors at all three readers (`operator_disposition`, the inner pre-dispatch check, `to_wire`), then reverted — a new variant is a compile error, not a runtime WARN.
- Related tests green: `test_keeper_disposition_budget`, `test_keeper_receipt_outcome_tla_parity`, `test_keeper_receipt_authoritative`.

This PR removes a substring classifier and replaces it with a closed sum + exhaustive match (typed-strengthening, the inverse of the workaround anti-pattern). RFC-0042 closure.

## Not in this PR (follow-up)

- Dashboard-side wire-string reads (separate PR per the original scope).
- RFC-0042 PR-3: typing the ~40 producer emit sites.
- Pre-existing behavior: `provider` error_kind and `provider_error_missing_api_key` fall to the generic `unmapped` gate. This is pinned by the equivalence test (identical old and new) and flagged for follow-up, NOT changed here.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
