### PR TITLE
test(ide): hook extraction tests + refactor bridge call

### DIFF
--- a/lib/ide/ide_bridge.ml
+++ b/lib/ide/ide_bridge.ml
@@ -81,6 +81,44 @@ let ingest_turn_event
    with exn ->
      Printf.eprintf "Ide_bridge.ingest_turn_event error: %s\n%!" (Printexc.to_string exn))
 
+(** Extract tool event parameters from raw hook data and ingest.
+    This is the function called from [keeper_run_tools_hooks.on_tool_executed].
+    Separated for direct testability. *)
+let ingest_tool_event_from_hook
+    ~base_path
+    ~tool_name
+    ~keeper_id
+    ~turn_id
+    ~outcome
+    ~typed_outcome_str
+    ~duration_ms
+    ~output_text
+    ~(input : Yojson.Safe.t)
+  =
+  let file_path =
+    match Yojson.Safe.Util.member "path" input with
+    | `String p -> Some p
+    | _ ->
+      match Yojson.Safe.Util.member "file_path" input with
+      | `String p -> Some p
+      | _ -> None
+  in
+  let summary =
+    if String.length output_text > 200 then String.sub output_text 0 200
+    else output_text
+  in
+  ingest_tool_event
+    ~base_path
+    ~tool_name
+    ~keeper_id
+    ~turn_id
+    ~outcome
+    ~typed_outcome:typed_outcome_str
+    ~latency_ms:(int_of_float duration_ms)
+    ~summary
+    ~file_path
+    ~timestamp_ms:(Int64.of_float (Unix.gettimeofday () *. 1000.0))
+
 let parse_pr_url_from_output (output : string) : (int * string) option =
   let prefix = "https://github.com/" in
   let prefix_len = String.length prefix in

--- a/lib/ide/ide_bridge.mli
+++ b/lib/ide/ide_bridge.mli
@@ -28,4 +28,18 @@ val ingest_turn_event :
   timestamp_ms:int64 ->
   unit
 
+(** Extract and ingest tool event from raw hook parameters.
+    [typed_outcome_str] is pre-computed from [Keeper_tool_outcome.t]. *)
+val ingest_tool_event_from_hook :
+  base_path:string ->
+  tool_name:string ->
+  keeper_id:string ->
+  turn_id:string ->
+  outcome:string ->
+  typed_outcome_str:string ->
+  duration_ms:float ->
+  output_text:string ->
+  input:Yojson.Safe.t ->
+  unit
+
 val parse_pr_url_from_output : string -> (int * string) option

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -227,31 +227,21 @@ let assemble_hooks
              | Some (Keeper_tool_outcome.Error _) -> "error"
              | None -> outcome
            in
-           let file_path =
-             match Yojson.Safe.Util.member "path" input with
-             | `String p -> Some p
-             | _ ->
-               match Yojson.Safe.Util.member "file_path" input with
-               | `String p -> Some p
-               | _ -> None
-           in
-           let summary = if String.length output_text > 200 then String.sub output_text 0 200 else output_text in
            let turn_id =
              match acc.meta.Keeper_meta_contract.current_task_id with
              | Some t -> Keeper_id.Task_id.to_string t
              | None -> "turn-" ^ string_of_int (List.length acc.tool_calls)
            in
-           Ide_bridge.ingest_tool_event
+           Ide_bridge.ingest_tool_event_from_hook
              ~base_path:config.base_path
              ~tool_name
              ~keeper_id:acc.meta.name
              ~turn_id
              ~outcome
-             ~typed_outcome:typed_outcome_str
-             ~latency_ms:(int_of_float duration_ms)
-             ~summary
-             ~file_path
-             ~timestamp_ms:(Int64.of_float (Unix.gettimeofday () *. 1000.0))))
+             ~typed_outcome_str
+             ~duration_ms
+             ~output_text
+             ~input))
         ~passive_loop_nudge:(fun () ->
           Keeper_passive_loop_detector.nudge_message ~keeper_name:acc.meta.name)
         ~pre_tool_use_guard:public_alias_pre_tool_use_guard

--- a/test/test_ide_bridge.ml
+++ b/test/test_ide_bridge.ml
@@ -129,6 +129,122 @@ let test_ingest_multiple_events () =
     check int "two events" 2 !count)
 ;;
 
+let test_hook_extracts_file_path_from_path_key () =
+  with_temp_dir (fun base_dir ->
+    let input = `Assoc [ "path", `String "lib/test.ml"; "content", `String "hello" ] in
+    Ide_bridge.ingest_tool_event_from_hook
+      ~base_path:base_dir
+      ~tool_name:"fs_write"
+      ~keeper_id:"k1"
+      ~turn_id:"t1"
+      ~outcome:"ok"
+      ~typed_outcome_str:"progress"
+      ~duration_ms:100.0
+      ~output_text:"wrote 10 lines"
+      ~input;
+    let dir = Ide_paths.partition_store_dir ~base_dir:base_dir Ide_paths.Orphan in
+    let path = Filename.concat dir "tool_events.jsonl" in
+    let ic = open_in path in
+    let line = input_line ic in
+    close_in ic;
+    let json = Yojson.Safe.from_string line in
+    let fp = Yojson.Safe.Util.member "file_path" json in
+    check string "file_path" "lib/test.ml" (Yojson.Safe.Util.to_string fp))
+;;
+
+let test_hook_extracts_file_path_from_file_path_key () =
+  with_temp_dir (fun base_dir ->
+    let input = `Assoc [ "file_path", `String "src/main.ml" ] in
+    Ide_bridge.ingest_tool_event_from_hook
+      ~base_path:base_dir
+      ~tool_name:"fs_edit"
+      ~keeper_id:"k1"
+      ~turn_id:"t1"
+      ~outcome:"ok"
+      ~typed_outcome_str:"progress"
+      ~duration_ms:50.0
+      ~output_text:"edited"
+      ~input;
+    let dir = Ide_paths.partition_store_dir ~base_dir:base_dir Ide_paths.Orphan in
+    let path = Filename.concat dir "tool_events.jsonl" in
+    let ic = open_in path in
+    let line = input_line ic in
+    close_in ic;
+    let json = Yojson.Safe.from_string line in
+    let fp = Yojson.Safe.Util.member "file_path" json in
+    check string "file_path" "src/main.ml" (Yojson.Safe.Util.to_string fp))
+;;
+
+let test_hook_no_file_path () =
+  with_temp_dir (fun base_dir ->
+    let input = `Assoc [ "command", `String "ls" ] in
+    Ide_bridge.ingest_tool_event_from_hook
+      ~base_path:base_dir
+      ~tool_name:"execute"
+      ~keeper_id:"k1"
+      ~turn_id:"t1"
+      ~outcome:"ok"
+      ~typed_outcome_str:"progress"
+      ~duration_ms:10.0
+      ~output_text:"file1.ml\nfile2.ml"
+      ~input;
+    let dir = Ide_paths.partition_store_dir ~base_dir:base_dir Ide_paths.Orphan in
+    let path = Filename.concat dir "tool_events.jsonl" in
+    let ic = open_in path in
+    let line = input_line ic in
+    close_in ic;
+    let json = Yojson.Safe.from_string line in
+    let fp = Yojson.Safe.Util.member "file_path" json in
+    check bool "file_path is null" true (fp = `Null))
+;;
+
+let test_hook_summary_truncation () =
+  with_temp_dir (fun base_dir ->
+    let long_output = String.make 300 'x' in
+    let input = `Assoc [] in
+    Ide_bridge.ingest_tool_event_from_hook
+      ~base_path:base_dir
+      ~tool_name:"execute"
+      ~keeper_id:"k1"
+      ~turn_id:"t1"
+      ~outcome:"ok"
+      ~typed_outcome_str:"progress"
+      ~duration_ms:10.0
+      ~output_text:long_output
+      ~input;
+    let dir = Ide_paths.partition_store_dir ~base_dir:base_dir Ide_paths.Orphan in
+    let path = Filename.concat dir "tool_events.jsonl" in
+    let ic = open_in path in
+    let line = input_line ic in
+    close_in ic;
+    let json = Yojson.Safe.from_string line in
+    let summary = Yojson.Safe.Util.member "summary" json |> Yojson.Safe.Util.to_string in
+    check bool "summary truncated" true (String.length summary <= 200))
+;;
+
+let test_hook_typed_outcome_mapping () =
+  with_temp_dir (fun base_dir ->
+    let input = `Assoc [] in
+    Ide_bridge.ingest_tool_event_from_hook
+      ~base_path:base_dir
+      ~tool_name:"execute"
+      ~keeper_id:"k1"
+      ~turn_id:"t1"
+      ~outcome:"error"
+      ~typed_outcome_str:"error"
+      ~duration_ms:10.0
+      ~output_text:"command failed"
+      ~input;
+    let dir = Ide_paths.partition_store_dir ~base_dir:base_dir Ide_paths.Orphan in
+    let path = Filename.concat dir "tool_events.jsonl" in
+    let ic = open_in path in
+    let line = input_line ic in
+    close_in ic;
+    let json = Yojson.Safe.from_string line in
+    let typed = Yojson.Safe.Util.member "typed_outcome" json |> Yojson.Safe.Util.to_string in
+    check string "typed_outcome" "error" typed)
+;;
+
 let () =
   run
     "ide_bridge"
@@ -143,5 +259,12 @@ let () =
       , [ test_case "tool event" `Quick test_ingest_tool_event
         ; test_case "turn event" `Quick test_ingest_turn_event
         ; test_case "multiple events" `Quick test_ingest_multiple_events
+        ] )
+    ; ( "hook_extract"
+      , [ test_case "file_path from path key" `Quick test_hook_extracts_file_path_from_path_key
+        ; test_case "file_path from file_path key" `Quick test_hook_extracts_file_path_from_file_path_key
+        ; test_case "no file_path (execute)" `Quick test_hook_no_file_path
+        ; test_case "summary truncation" `Quick test_hook_summary_truncation
+        ; test_case "typed_outcome mapping" `Quick test_hook_typed_outcome_mapping
         ] )
     ]


### PR DESCRIPTION
Refactor: ingest_tool_event_from_hook 함수 분리 (直接 테스트 가능). Tests: 13개 (기존 8 + hook_extract 5). hook_extract는 input JSON에서 file_path 추출, summary truncation, typed_outcome 매핑 검증.