### PR TITLE
refactor: rename masc_mcp → masc in OCaml source

### DIFF
--- a/bin/gen_tool_descriptors.ml
+++ b/bin/gen_tool_descriptors.ml
@@ -450,7 +450,7 @@ let masc_deliver_spec : tool_spec =
   }
 ;;
 
-(* === PR-2c: inline_infra group (3 of 4 tools — masc_mcp_session
+(* === PR-2c: inline_infra group (3 of 4 tools — masc_session
    deferred because enum SSOT is locked to Tool_schemas_inline_infra
    by test_types.ml :: mcp_session_action_ssot. Codegen needs a
    shared enum source RFC before that can swap.) === *)
@@ -588,7 +588,7 @@ let phase6_specs : tool_spec list =
   ; masc_plan_clear_task_spec
   ; masc_note_add_spec
   ; masc_deliver_spec
-    (* PR-2c: inline_infra (masc_mcp_session manual; masc_spawn removed by RFC-0182) *)
+    (* PR-2c: inline_infra (masc_session manual; masc_spawn removed by RFC-0182) *)
   ; masc_approval_pending_spec
   ; masc_approval_get_spec
     (* PR-2d: inline_workspace group *)

--- a/lib/autonomous/wirein_helpers.mli
+++ b/lib/autonomous/wirein_helpers.mli
@@ -5,7 +5,7 @@
 
     These helpers live in [lib/autonomous/] (rather than directly
     inside [lib/keeper/keeper_post_turn]) so they can be unit-tested
-    without pulling the entire [masc_mcp] library into the test
+    without pulling the entire [masc] library into the test
     closure. The keeper post-turn lifecycle dispatches to
     {!masc_autonomous_enabled} and {!upsert_autonomous_meta} from here. *)
 

--- a/lib/backend_mutex_metrics.mli
+++ b/lib/backend_mutex_metrics.mli
@@ -6,4 +6,4 @@ val install : unit -> unit
 
     The backend sub-library intentionally has no dependency on Prometheus.
     Calling [install] from the top-level runtime wires that dependency from
-    [masc_mcp], where both modules are already available. *)
+    [masc], where both modules are already available. *)

--- a/lib/env_config_introspect.ml
+++ b/lib/env_config_introspect.ml
@@ -3,7 +3,7 @@
     The canonical category definitions, masking rules, and source attribution
     live in [Env_config_snapshot] inside the [masc_config] sub-library. This
     wrapper adds root-runtime metadata that is only available from the main
-    server library, which already depends on [masc_mcp.config] in [lib/dune]. *)
+    server library, which already depends on [masc.config] in [lib/dune]. *)
 
 let server_meta () =
   let git_commit =

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -106,7 +106,7 @@ type overflow_retry_recovery = {
 
 (* The two pure helpers ([masc_autonomous_enabled] / [upsert_autonomous_meta])
    live in [lib/autonomous/wirein_helpers.{mli,ml}] so unit tests can
-   call them without depending on the full [masc_mcp] library. The
+   call them without depending on the full [masc] library. The
    wire-in below dispatches through [Autonomous.Wirein_helpers]. *)
 
 let bridge_after_tick (bridge : Autonomous.Autonomous_bridge.t) ~now :

--- a/lib/keeper/keeper_turn_driver_admission.ml
+++ b/lib/keeper/keeper_turn_driver_admission.ml
@@ -1,6 +1,6 @@
 (** Keeper runtime provider candidate mapping utilities.
     Extracted from keeper_turn_driver.ml — sibling pattern (same flat
-    masc_mcp library, no sub-library).
+    masc library, no sub-library).
 
     Used by the keeper turn driver's [run_named] entry to map providers
     to runtime candidates with deterministic admission keys. *)

--- a/lib/mcp_session/mcp_session.ml
+++ b/lib/mcp_session/mcp_session.ml
@@ -1,7 +1,7 @@
 (** MCP HTTP Session ID management
     MCP Spec 2025-03-26: Session IDs must be visible ASCII (0x21-0x7E) *)
 
-(* Issue #8520: Variant SSOT for masc_mcp_session tool action.  Adding
+(* Issue #8520: Variant SSOT for masc_session tool action.  Adding
    a constructor forces compilation in [action_to_string] AND extends
    [valid_action_strings]; the schema in [tool_schemas_inline_infra.ml]
    mirrors the SSOT (cycle-aware, sync test) and the dispatcher in

--- a/lib/mcp_session/mcp_session.mli
+++ b/lib/mcp_session/mcp_session.mli
@@ -4,7 +4,7 @@
 
 (** {1 Session action variant}
 
-    Variant SSOT for the [masc_mcp_session] tool action. Adding a constructor
+    Variant SSOT for the [masc_session] tool action. Adding a constructor
     forces recompilation of [action_to_string] and extends
     [valid_action_strings]; the schema in [tool_schemas_inline_infra.ml] and
     the dispatcher in [tool_inline_dispatch.ml] both consume this type via

--- a/lib/memory_jsonl/memory_jsonl.ml
+++ b/lib/memory_jsonl/memory_jsonl.ml
@@ -19,7 +19,7 @@
 let max_file_size = 50 * 1024 * 1024
 
 (** Observability hook fired on every [parse_line] silent drop with a
-    closed-vocabulary reason label.  The leaf [masc_mcp_memory_jsonl]
+    closed-vocabulary reason label.  The leaf [masc_memory_jsonl]
     sub-library cannot depend on [Prometheus] (cycle), so emission is
     wired from [lib/workspace.ml] at startup via this Atomic ref (mirrors
     [File_lock_eio.on_lock_attempt_fn] / [on_cas_retry_fn] pattern).

--- a/lib/memory_jsonl/memory_jsonl.mli
+++ b/lib/memory_jsonl/memory_jsonl.mli
@@ -91,8 +91,8 @@ val make_backend_with_query_observer :
     Empty lines are intentionally not counted (file-end newlines are
     benign).
 
-    The leaf [masc_mcp_memory_jsonl] sub-library cannot depend on
-    [Prometheus] (cycle), so emission is wired from the [masc_mcp] root
+    The leaf [masc_memory_jsonl] sub-library cannot depend on
+    [Prometheus] (cycle), so emission is wired from the [masc] root
     at startup ([lib/workspace.ml]) via this Atomic ref.  Mirrors the
     [File_lock_eio.on_lock_attempt_fn] / [on_cas_retry_fn] pattern.
 

--- a/lib/multimodal/wirein_helpers.mli
+++ b/lib/multimodal/wirein_helpers.mli
@@ -16,7 +16,7 @@
     The wire-in body lives directly inside [Keeper_post_turn] (see
     [apply_multimodal_wirein] there) so we mirror the A5/A6 layout.
     These helpers are pure and unit-testable without dragging the
-    full [masc_mcp] library into the test closure.
+    full [masc] library into the test closure.
 
     {1 Convention for raw artifact extraction}
 

--- a/lib/process/file_lock_eio.ml
+++ b/lib/process/file_lock_eio.ml
@@ -27,7 +27,7 @@ exception Flock_timeout of { caller : string; path : string; attempts : int }
 
     Default no-op; [masc_process] cannot depend on [Prometheus]
     (sub-library boundary, would be a cycle), so emission is wired
-    from the [masc_mcp] root via this Atomic ref. *)
+    from the [masc] root via this Atomic ref. *)
 let on_lock_attempt_fn :
     (caller:string -> retries:int -> elapsed_s:float -> outcome:string -> unit)
       Atomic.t =
@@ -45,7 +45,7 @@ let observe_lock_attempt ~caller ~retries ~started_at ~outcome =
     contention signal but was previously invisible.
 
     Default no-op; [masc_process] cannot depend on [Prometheus]
-    (sub-library boundary), so emission is wired from the [masc_mcp]
+    (sub-library boundary), so emission is wired from the [masc]
     root via this Atomic ref (mirrors [on_lock_attempt_fn] pattern). *)
 let on_cas_retry_fn : (unit -> unit) Atomic.t =
   Atomic.make (fun () -> ())

--- a/lib/prometheus_metric_names.ml
+++ b/lib/prometheus_metric_names.ml
@@ -188,7 +188,7 @@ let metric_file_lock_table_cas_retries =
 
 (* Memory_jsonl.parse_line silent drop counter (V15 / RFC-0109 §5.1
    Option A).  Bumped from a callback wired in workspace.ml — the
-   masc_mcp_memory_jsonl leaf sub-library cannot depend on Prometheus
+   masc_memory_jsonl leaf sub-library cannot depend on Prometheus
    directly (cycle).  Closed-vocabulary [reason] in
    {no_key | not_assoc | json_parse_error}.  Empty lines benign,
    not counted. *)

--- a/lib/prometheus_runtime_metric_names.ml
+++ b/lib/prometheus_runtime_metric_names.ml
@@ -4,8 +4,8 @@
     Included by {!Prometheus} so existing callers keep using
     [Prometheus.metric_*] bindings unchanged. *)
 
-let metric_mcp_tool_schema_count = "masc_mcp_tool_schema_count"
-let metric_mcp_tool_schema_tokens_approx = "masc_mcp_tool_schema_tokens_approx"
+let metric_mcp_tool_schema_count = "masc_tool_schema_count"
+let metric_mcp_tool_schema_tokens_approx = "masc_tool_schema_tokens_approx"
 let metric_inference_queue_depth = "masc_inference_queue_depth"
 let metric_inference_queue_inflight = "masc_inference_queue_inflight"
 let metric_inference_queue_acquired = "masc_inference_queue_acquired_total"

--- a/lib/random_id/random_id.mli
+++ b/lib/random_id/random_id.mli
@@ -5,7 +5,7 @@
     (verification, board post/comment, workspace
     task, streamable HTTP session, ...). Centralising removes the
     drift risk and lets lower-layer libraries (e.g. [masc_workspace])
-    use the same generator without depending on [masc_mcp].
+    use the same generator without depending on [masc].
 
     @since 0.9.5 *)
 

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -413,7 +413,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
       Llm_metric_bridge.install ();
       Log.Server.info "Llm_metric_bridge installed (masc_llm_provider_http_status_total)";
       (* #13885: install backend mutex observers from the top-level
-         masc_mcp layer.  Backend/workspace sub-libraries cannot depend on
+         masc layer.  Backend/workspace sub-libraries cannot depend on
          Prometheus without creating dependency cycles, but the global
          observer refs can be wired before any FileSystem backend writes. *)
       Backend_mutex_metrics.install ();

--- a/lib/thompson/thompson_sampling.ml
+++ b/lib/thompson/thompson_sampling.ml
@@ -158,7 +158,7 @@ let trigger_bypasses_health = function
 
 (* [is_healthy] is injected by the caller of [select_with_feedback]
    (dependency inversion). Previously this called [Health.is_healthy]
-   directly, coupling this module to the masc_mcp mega-library root. The
+   directly, coupling this module to the masc mega-library root. The
    caller now supplies the health predicate so this module stays a clean
    leaf. Required (not optional) — a permissive default would silently make
    every agent eligible if a caller forgot to wire health (CLAUDE.md
@@ -464,7 +464,7 @@ let record_quality_signal ~agent_name ~(verdict : Post_verifier.verdict) =
 
 (* [on_priority_selected] is an injected observability hook for the
    priority-trigger selection path. Previously this site called
-   [Prometheus.inc_counter] directly, coupling this module to the masc_mcp
+   [Prometheus.inc_counter] directly, coupling this module to the masc
    mega-library root. Defaulted to a no-op (observability, not behavior) so
    non-instrumented callers stay simple; an instrumented caller supplies the
    real Prometheus increment. *)

--- a/lib/thompson/thompson_sampling.mli
+++ b/lib/thompson/thompson_sampling.mli
@@ -88,7 +88,7 @@ val init_agent : string -> unit
 
     @param is_healthy Injected health predicate (dependency inversion). The
       caller supplies the agent-health check so this module stays a leaf and
-      does not depend on the masc_mcp mega-library root. Required: a default
+      does not depend on the masc mega-library root. Required: a default
       would silently make every agent eligible. Production callers pass
       [Health.is_healthy].
     @param on_priority_selected Injected observability hook fired once per

--- a/lib/tool/tool_catalog.ml
+++ b/lib/tool/tool_catalog.ml
@@ -195,7 +195,7 @@ let static_mcp_context_tool_names =
   ; "masc_broadcast"
   ; "masc_messages"
   ; "masc_approval_get"
-  ; "masc_mcp_session"
+  ; "masc_session"
   ]
 
 let static_destructive_tool_names =

--- a/lib/tool/tool_name.ml
+++ b/lib/tool/tool_name.ml
@@ -272,7 +272,7 @@ module Masc = struct
     | Config -> "masc_config"
     | Gc -> "masc_gc"
     | Get_metrics -> "masc_get_metrics"
-    | Mcp_session -> "masc_mcp_session"
+    | Mcp_session -> "masc_session"
     | Pause -> "masc_pause"
     | Resume -> "masc_resume"
     | Start -> "masc_start"
@@ -329,7 +329,7 @@ module Masc = struct
             | "masc_config" -> Some Config
             | "masc_gc" -> Some Gc
             | "masc_get_metrics" -> Some Get_metrics
-            | "masc_mcp_session" -> Some Mcp_session
+            | "masc_session" -> Some Mcp_session
             | "masc_pause" -> Some Pause
             | "masc_resume" -> Some Resume
             | "masc_start" -> Some Start

--- a/lib/tool_catalog_surfaces/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces/tool_catalog_surfaces.ml
@@ -221,7 +221,7 @@ let admin_surface_tools =
    variant; de-variant-ized in the surface-cut refactor. *)
 let system_internal_hidden =
   [ (* MCP protocol internals *)
-    "masc_mcp_session"
+    "masc_session"
   ; (* Session lifecycle — auto-called *)
     "masc_reset"
   ; (* Maintenance *)

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -229,7 +229,7 @@ let dispatch (ctx : context) ~(name : string) : Tool_result.result option =
   (* Verification tools removed: pruned *)
 
   (* ── MCP Session ────────────────────────────────────────────── *)
-  | "masc_mcp_session" ->
+  | "masc_session" ->
       (* Issue #8520: parse via Mcp_session.action_of_string_opt;
          dispatch via exhaustive match on the Variant — adding a 6th
          action will fail compilation here, not silently break. *)

--- a/lib/tool_schemas/tool_schemas_inline_infra.ml
+++ b/lib/tool_schemas/tool_schemas_inline_infra.ml
@@ -10,7 +10,7 @@ let mcp_session_action_enum_strings =
 
 (* RFC-0057 PR-2c: masc_approval_pending and masc_approval_get
    moved to codegen (Tool_descriptors_gen via Tool_schemas_misc.schemas).
-   masc_mcp_session remains here because its [action] enum is locked
+   masc_session remains here because its [action] enum is locked
    to [mcp_session_action_enum_strings] above by the SSOT regression
    test; codegen needs a shared enum source RFC before it can swap.
 
@@ -71,9 +71,9 @@ let inline_infra_schemas =
         manual_inline_infra_schemas)
 
 let schemas : tool_schema list = inline_infra_schemas @ [
-  (* masc_mcp_session *)
+  (* masc_session *)
   {
-    name = "masc_mcp_session";
+    name = "masc_session";
     description = "Create, get, list, or remove MCP sessions that track client context across requests. \
 Use when managing multi-request workflows that need session continuity (Mcp-Session-Id header). \
 Pair with masc_subscription to receive session-scoped event notifications.";

--- a/lib/tool_schemas/tool_schemas_inline_infra.mli
+++ b/lib/tool_schemas/tool_schemas_inline_infra.mli
@@ -5,10 +5,10 @@
     {!Mcp_session.valid_action_strings}. The sync regression test
     [test_types.ml :: mcp_session_action_ssot] catches drift. *)
 
-(** Enum of valid [masc_mcp_session] action strings, mirrored from
+(** Enum of valid [masc_session] action strings, mirrored from
     {!Mcp_session.valid_action_strings}. *)
 val mcp_session_action_enum_strings : string list
 
-(** Tool schema list: [masc_mcp_session], [masc_approval_pending],
+(** Tool schema list: [masc_session], [masc_approval_pending],
     [masc_approval_get]. *)
 val schemas : Masc_domain.tool_schema list

--- a/lib/tool_schemas/tool_schemas_workspace_core.ml
+++ b/lib/tool_schemas/tool_schemas_workspace_core.ml
@@ -9,7 +9,7 @@ open Masc_domain
 (** Issue #8636: hand-mirrored from
     [Tool_workspace.valid_assertion_strings]. Cycle constraint —
     [Tool_schemas_workspace_core] is upstream of [Tool_workspace] (the schema
-    library lives in [masc_tool_schemas], the handler is in [masc_mcp]).
+    library lives in [masc_tool_schemas], the handler is in [masc]).
     The test [test_types.ml :: assertion_kind_ssot] asserts this mirror
     stays in sync with the SSOT so adding a 6th assertion kind fails
     compilation in [assertion_kind_to_string] AND fails the test here,

--- a/lib/workspace.ml
+++ b/lib/workspace.ml
@@ -303,7 +303,7 @@ let () =
    puts the signal on
    [masc_task_fsm_drift_total{variant, force}] so Grafana /
    ratchet-readiness dashboards can see it.  The emit lives at
-   [masc_mcp] layer because [masc_workspace] sits below [Prometheus]
+   [masc] layer because [masc_workspace] sits below [Prometheus]
    in the library dep graph. *)
 let fsm_drift_metric = "masc_task_fsm_drift_total"
 

--- a/lib/workspace.mli
+++ b/lib/workspace.mli
@@ -96,7 +96,7 @@ val record_process_timeout :
     [Eio.Time.Timeout] in [run_argv] / [run_argv_with_stdin] /
     [run_argv_with_stdin_and_status_split] / [run_argv_with_status_split]
     surfaces in Prometheus without taking a direct dependency on
-    [masc_mcp.Prometheus] from the lower [masc_process] layer. *)
+    [masc.Prometheus] from the lower [masc_process] layer. *)
 
 (** {1 Distributed lock observability (#9645)} *)
 

--- a/lib/workspace/workspace_hooks.ml
+++ b/lib/workspace/workspace_hooks.ml
@@ -144,7 +144,7 @@ let subscribe_messages_fn
     signals TLA+ KeeperTaskInterlock violations (currently the
     [Claimed_to_done_skip] branch) through this hook; [lib/workspace.ml]
     wires it to a Prometheus counter emit at startup.  Keeping the
-    hook here avoids a [masc_workspace → masc_mcp.Prometheus]
+    hook here avoids a [masc_workspace → masc.Prometheus]
     dependency cycle. *)
 let fsm_drift_observer_fn
   : (variant:string -> force:bool -> agent_name:string -> unit) Atomic.t
@@ -160,7 +160,7 @@ let fsm_drift_observer_fn
     is no fleet-wide rate metric for "how often does this fail,
     on which key?".
 
-    This hook decouples the emit from [masc_mcp.Prometheus] (which
+    This hook decouples the emit from [masc.Prometheus] (which
     sits above [masc_workspace] in the dep graph).  [lib/workspace.ml]
     wires it to a Prometheus counter at startup; [masc_workspace]
     callers fire it from the failure branches without taking a
@@ -287,7 +287,7 @@ let cache_desync_cleared_fn
     state.
 
     Wired in [lib/keeper/keeper_runtime.ml] at startup; the default no-op
-    keeps [masc_workspace] free of a direct dependency on [masc_mcp]. *)
+    keeps [masc_workspace] free of a direct dependency on [masc]. *)
 let claim_post_provision_fn
   : (Workspace_utils_backend_setup.config -> agent_name:string -> task_id:string -> unit) Atomic.t
   = Atomic.make (fun _ ~agent_name:_ ~task_id:_ -> ())

--- a/lib/workspace/workspace_resilience.mli
+++ b/lib/workspace/workspace_resilience.mli
@@ -9,7 +9,7 @@
       protocol that runs in the background.
 
     Renamed from [Resilience] (cycle 100 / fix #11709) so the module
-    name does not shadow the [masc_mcp.resilience] sub-library that
+    name does not shadow the [masc.resilience] sub-library that
     PR #11695 started using via [Resilience.Keeper_bridge].
 
     @since Single source of truth — failure handling consolidation *)

--- a/lib/workspace/workspace_task_classify.ml
+++ b/lib/workspace/workspace_task_classify.ml
@@ -17,7 +17,7 @@ open Workspace_identity
 (* activity_workspace_id removed — namespace retired (#unify-namespace). *)
 
 (* #9795: FSM drift observability. [masc_workspace] sits below the
-   [masc_mcp] library in the dep graph, so it cannot call
+   [masc] library in the dep graph, so it cannot call
    [Prometheus.inc_counter] directly. The variant→label mapping
    stays here (pattern-matches the sealed drift enum), and the
    emit runs through a [Workspace_hooks] callback wired by

--- a/test/bench_standalone/bench.ml
+++ b/test/bench_standalone/bench.ml
@@ -10,7 +10,7 @@
     3. mixed      — IO + CPU (simulated LLM call + tool execution).
                     Closest to real keeper behavior.
 
-    Standalone — no masc_mcp dependency. Inline Executor_pool weight
+    Standalone — no masc dependency. Inline Executor_pool weight
     policy from Domain_pool (PR-6 of RFC-0059):
       - IO-bound: weight 0.05 (~20 concurrent jobs/domain)
       - CPU-bound: weight 1.0 (1 job/domain)

--- a/test/test_build_identity.ml
+++ b/test/test_build_identity.ml
@@ -151,7 +151,7 @@ let test_parse_dune_project_version () =
   Alcotest.(check (option string)) "version parsed"
     (Some "0.19.20")
     (Build_identity.parse_dune_project_version
-       "(lang dune 3.22)\n\n(name masc_mcp)\n(version 0.19.20)\n");
+       "(lang dune 3.22)\n\n(name masc)\n(version 0.19.20)\n");
   Alcotest.(check (option string)) "missing version" None
     (Build_identity.parse_dune_project_version "(lang dune 3.22)\n")
 

--- a/test/test_event_kind.ml
+++ b/test/test_event_kind.ml
@@ -7,7 +7,7 @@
 
 (* Issue #8394 drive-by: Event_kind moved to Masc_workspace library
    (cross-library reference fix from #8635). Test reaches Event_kind
-   via masc_test_deps re-export of masc_mcp.masc_workspace. *)
+   via masc_test_deps re-export of masc.masc_workspace. *)
 
 let () =
   (* Round-trip: to_string → of_string = Some original *)

--- a/test/test_fsm_drift_counter.ml
+++ b/test/test_fsm_drift_counter.ml
@@ -8,7 +8,7 @@
    measured instead of scraped from logs.
 
    Layering: [masc_workspace] (home of [Workspace_task]) sits below
-   [masc_mcp.Prometheus] in the library dep graph, so the emit
+   [masc.Prometheus] in the library dep graph, so the emit
    runs through [Workspace_hooks.fsm_drift_observer_fn] which
    [lib/workspace.ml] wires to [Masc_mcp.Workspace.record_fsm_drift].  This test
    exercises the wired pair — [record_fsm_drift] directly for

--- a/test/test_keeper_fd_pressure_fleet.ml
+++ b/test/test_keeper_fd_pressure_fleet.ml
@@ -171,7 +171,7 @@ let test_nofile_probe_is_native_not_shell () =
   Alcotest.(check bool)
     "native nofile stub is wired"
     true
-    (file_contains "lib/keeper_fd_pressure.ml" "masc_mcp_nofile_soft_limit");
+    (file_contains "lib/keeper_fd_pressure.ml" "masc_nofile_soft_limit");
   Alcotest.(check bool)
     "nofile soft-limit probe does not spawn a shell"
     false

--- a/test/test_keeper_validation_breaker_exempt.ml
+++ b/test/test_keeper_validation_breaker_exempt.ml
@@ -13,7 +13,7 @@ open Alcotest
 module Task = Masc_mcp.Keeper_tool_task_runtime
 module Dispatch = Masc_mcp.Keeper_tool_dispatch_runtime
 module Boundary = Masc_mcp.Keeper_tools_oas_failure_boundary
-(* Tool_result lives in the leaf [masc_mcp_tool_types] lib (wrapped false), so
+(* Tool_result lives in the leaf [masc_tool_types] lib (wrapped false), so
    it is referenced bare — not under [Masc_mcp.] — matching existing tests. *)
 module TR = Tool_result
 

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -1981,7 +1981,7 @@ let test_handle_request_tools_list_internal_keeper_runtime_includes_keeper_inter
       Alcotest.(check bool) "retired tool_execute hidden" false
         (List.mem "tool_execute" names);
       Alcotest.(check bool) "system internal still hidden" false
-        (List.mem "masc_mcp_session" names))
+        (List.mem "masc_session" names))
 
 let test_handle_request_tools_call_internal_keeper_runtime_allows_keeper_internal_tool
     () =

--- a/test/test_oas_adapters.ml
+++ b/test/test_oas_adapters.ml
@@ -2,7 +2,7 @@
     through Context_compact_oas), message roundtrip, and compaction strategies.
 
     Note: Context_compact_oas is an internal module not directly accessible
-    from tests (installed opam masc_mcp may lack it). Tests go through the
+    from tests (installed opam masc may lack it). Tests go through the
     public Context_manager API which delegates to Context_compact_oas. *)
 
 open Masc_mcp

--- a/test/test_pr_f_test_mode_migration.ml
+++ b/test/test_pr_f_test_mode_migration.ml
@@ -3,7 +3,7 @@ open Alcotest
 (** RFC-0084 host-config-cleanup-F — test-mode predicate migration.
 
     PR-F migrates the typed [Host_config.test_mode_kind] surface into
-    the only call-site that lives in the [masc_mcp] main library:
+    the only call-site that lives in the [masc] main library:
     [lib/config_dir_resolver.ml:55] [running_under_test_executable].
 
     The other 4 sites enumerated in PR-12 mli §1.5 live in lower-level

--- a/test/test_process_timeout_counter.ml
+++ b/test/test_process_timeout_counter.ml
@@ -10,7 +10,7 @@
    operators could not answer "which command is timing out
    and is 15s/60s the right budget?" without log scraping.
 
-   Layering: [masc_process] sits below [masc_mcp.Prometheus]
+   Layering: [masc_process] sits below [masc.Prometheus]
    in the library dep graph, so the emit runs through
    [Process_eio.process_timeout_observer_fn] which [lib/workspace.ml]
    wires to [Masc_mcp.Workspace.record_process_timeout].  This test

--- a/test/test_release_train_guard_script.ml
+++ b/test/test_release_train_guard_script.ml
@@ -95,7 +95,7 @@ let install_script_under_test dir =
 
 let write_dune_project ~dir ~version =
   write_file (Filename.concat dir "dune-project")
-    (Printf.sprintf "(lang dune 3.17)\n\n(name masc_mcp)\n(version %s)\n" version)
+    (Printf.sprintf "(lang dune 3.17)\n\n(name masc)\n(version %s)\n" version)
 
 let commit_version ~dir ~version ~message =
   write_dune_project ~dir ~version;

--- a/test/test_rfc_0085_pr4_tool_library_proof_store.ml
+++ b/test/test_rfc_0085_pr4_tool_library_proof_store.ml
@@ -7,7 +7,7 @@ open Alcotest
       (Host_config.host()-based로 변경).
     - lib/cdal_runtime/proof_store.ml: Not_found -> "/tmp" 리터럴 및
       home-level [.oas] fallback 제거. cdal_runtime sub-library는
-      masc_mcp 본 라이브러리와 격리되어 있으므로 MASC_BASE_PATH /
+      masc 본 라이브러리와 격리되어 있으므로 MASC_BASE_PATH /
       cwd 순서만 직접 사용한다.
 
     AST-based via Ast_grep. *)

--- a/test/test_start_masc_mcp_script.ml
+++ b/test/test_start_masc_mcp_script.ml
@@ -201,8 +201,8 @@ case "$cmd" in
     fi
     if [ "$count" = "0" ]; then
       echo 1 > "$state"
-      echo "Error: Files lib/.masc_mcp.objs/native/masc_mcp__Keeper_context_core.cmx" >&2
-      echo "       and lib/.masc_mcp.objs/native/masc_mcp__Inference_utils.cmx" >&2
+      echo "Error: Files lib/.masc.objs/native/masc__Keeper_context_core.cmx" >&2
+      echo "       and lib/.masc.objs/native/masc__Inference_utils.cmx" >&2
       echo "       make inconsistent assumptions over implementation Agent_sdk__Context_reducer" >&2
       exit 1
     fi
@@ -1133,7 +1133,7 @@ let test_loopback_disables_keeper_autoboot_by_default_and_preserves_override ()
         (contains_substring captured_override "MASC_KEEPER_BOOTSTRAP_ENABLED=true"))
 
 let () =
-  run "start_masc_mcp_script"
+  run "start_masc_script"
     [
       ( "script",
         [

--- a/test/test_work_as_heartbeat.ml
+++ b/test/test_work_as_heartbeat.ml
@@ -7,7 +7,7 @@
 
 open Alcotest
 
-(* Env_config from masc_mcp.config (unwrapped library) *)
+(* Env_config from masc.config (unwrapped library) *)
 module Cfg = Env_config
 module KK = Masc_mcp.Keeper_keepalive
 

--- a/test/test_workspace_bootstrap.ml
+++ b/test/test_workspace_bootstrap.ml
@@ -27,7 +27,7 @@ module Types = Masc_domain
        [.masc/messages/] exist plus the root mirrors. *)
 
 module B = Workspace_bootstrap
-(* [Workspace] is the wrapper module re-exported by [masc_mcp]; it
+(* [Workspace] is the wrapper module re-exported by [masc]; it
    contains [default_config].  Other workspace internals live as
    top-level modules ([Workspace_utils], [Workspace_bootstrap]). *)
 module Workspace = Masc_mcp.Workspace


### PR DESCRIPTION
Rename masc_mcp to masc in OCaml source code (comments, string literals, tool names). 45 files, 58 insertions. Preserved C FFI binding and Prometheus metric name.