### PR TITLE
feat(ide): auto-collect PR events from Execute tool output

### DIFF
--- a/lib/ide/ide_bridge.ml
+++ b/lib/ide/ide_bridge.ml
@@ -12,6 +12,7 @@ let append_event ~base_dir ~partition ~(event : ide_event) =
     match event with
     | Tool_event _ -> "tool_events.jsonl"
     | Turn_event _ -> "turn_events.jsonl"
+    | Pr_event _ -> "pr_events.jsonl"
   in
   let path = Filename.concat dir file_name in
   let json = ide_event_to_json event in
@@ -81,6 +82,37 @@ let ingest_turn_event
    with exn ->
      Printf.eprintf "Ide_bridge.ingest_turn_event error: %s\n%!" (Printexc.to_string exn))
 
+let ingest_pr_event
+    ~base_path
+    ~pr_number
+    ~pr_url
+    ~pr_title
+    ~pr_state
+    ~repo
+    ~keeper_id
+    ~turn_id
+    ~comment_count
+    ~review_status
+    ~timestamp_ms
+  =
+  let event =
+    Pr_event
+      { pr_number
+      ; pr_url
+      ; pr_title
+      ; pr_state
+      ; repo
+      ; keeper_id
+      ; turn_id
+      ; comment_count
+      ; review_status
+      ; timestamp_ms
+      }
+  in
+  (try append_event ~base_dir:base_path ~partition:default_partition ~event
+   with exn ->
+     Printf.eprintf "Ide_bridge.ingest_pr_event error: %s\n%!" (Printexc.to_string exn))
+
 (** Extract tool event parameters from raw hook data and ingest.
     This is the function called from [keeper_run_tools_hooks.on_tool_executed].
     Separated for direct testability. *)
@@ -147,3 +179,41 @@ let parse_pr_url_from_output (output : string) : (int * string) option =
           Some (number, url)
         with Failure _ -> None)
      | _ -> None)
+
+(** Try to detect PR creation from Execute tool output and ingest a PR event.
+    Only fires when [tool_name = "execute"] and output contains a GitHub PR URL. *)
+let ingest_pr_event_from_hook
+    ~base_path
+    ~keeper_id
+    ~turn_id
+    ~output_text
+    ~tool_name
+  =
+  if String.equal tool_name "execute" then
+    match parse_pr_url_from_output output_text with
+    | Some (pr_number, pr_url) ->
+      let repo =
+        let prefix = "https://github.com/" in
+        let prefix_len = String.length prefix in
+        let url_len = String.length pr_url in
+        if url_len > prefix_len then
+          let path = String.sub pr_url prefix_len (url_len - prefix_len) in
+          let parts = String.split_on_char '/' path in
+          match parts with
+          | owner :: repo_name :: _ -> owner ^ "/" ^ repo_name
+          | _ -> "unknown"
+        else "unknown"
+      in
+      ingest_pr_event
+        ~base_path
+        ~pr_number
+        ~pr_url
+        ~pr_title:""
+        ~pr_state:"open"
+        ~repo
+        ~keeper_id
+        ~turn_id
+        ~comment_count:0
+        ~review_status:None
+        ~timestamp_ms:(Int64.of_float (Unix.gettimeofday () *. 1000.0))
+    | None -> ()

--- a/lib/ide/ide_bridge.mli
+++ b/lib/ide/ide_bridge.mli
@@ -42,4 +42,28 @@ val ingest_tool_event_from_hook :
   input:Yojson.Safe.t ->
   unit
 
+val ingest_pr_event :
+  base_path:string ->
+  pr_number:int ->
+  pr_url:string ->
+  pr_title:string ->
+  pr_state:string ->
+  repo:string ->
+  keeper_id:string ->
+  turn_id:string ->
+  comment_count:int ->
+  review_status:string option ->
+  timestamp_ms:int64 ->
+  unit
+
+(** Try to detect PR creation from Execute tool output and ingest a PR event.
+    Only fires when [tool_name = "execute"] and output contains a GitHub PR URL. *)
+val ingest_pr_event_from_hook :
+  base_path:string ->
+  keeper_id:string ->
+  turn_id:string ->
+  output_text:string ->
+  tool_name:string ->
+  unit
+
 val parse_pr_url_from_output : string -> (int * string) option

--- a/lib/ide/ide_event_types.ml
+++ b/lib/ide/ide_event_types.ml
@@ -3,6 +3,7 @@
 type ide_event =
   | Tool_event of tool_event
   | Turn_event of turn_event
+  | Pr_event of pr_event
 
 and tool_event =
   { tool_name : string
@@ -24,6 +25,19 @@ and turn_event =
   ; tools_used : string list
   ; stop_reason : string option
   ; duration_ms : int option
+  ; timestamp_ms : int64
+  }
+
+and pr_event =
+  { pr_number : int
+  ; pr_url : string
+  ; pr_title : string
+  ; pr_state : string
+  ; repo : string
+  ; keeper_id : string
+  ; turn_id : string
+  ; comment_count : int
+  ; review_status : string option
   ; timestamp_ms : int64
   }
 
@@ -54,6 +68,22 @@ let turn_event_to_json (e : turn_event) : Yojson.Safe.t =
     ; "timestamp_ms", `Intlit (Int64.to_string e.timestamp_ms)
     ]
 
+let pr_event_to_json (e : pr_event) : Yojson.Safe.t =
+  `Assoc
+    [ "type", `String "pr"
+    ; "pr_number", `Int e.pr_number
+    ; "pr_url", `String e.pr_url
+    ; "pr_title", `String e.pr_title
+    ; "pr_state", `String e.pr_state
+    ; "repo", `String e.repo
+    ; "keeper_id", `String e.keeper_id
+    ; "turn_id", `String e.turn_id
+    ; "comment_count", `Int e.comment_count
+    ; "review_status", (match e.review_status with Some s -> `String s | None -> `Null)
+    ; "timestamp_ms", `Intlit (Int64.to_string e.timestamp_ms)
+    ]
+
 let ide_event_to_json = function
   | Tool_event e -> tool_event_to_json e
   | Turn_event e -> turn_event_to_json e
+  | Pr_event e -> pr_event_to_json e

--- a/lib/ide/ide_event_types.mli
+++ b/lib/ide/ide_event_types.mli
@@ -3,6 +3,7 @@
 type ide_event =
   | Tool_event of tool_event
   | Turn_event of turn_event
+  | Pr_event of pr_event
 
 and tool_event =
   { tool_name : string
@@ -24,6 +25,19 @@ and turn_event =
   ; tools_used : string list
   ; stop_reason : string option
   ; duration_ms : int option
+  ; timestamp_ms : int64
+  }
+
+and pr_event =
+  { pr_number : int
+  ; pr_url : string
+  ; pr_title : string
+  ; pr_state : string
+  ; repo : string
+  ; keeper_id : string
+  ; turn_id : string
+  ; comment_count : int
+  ; review_status : string option
   ; timestamp_ms : int64
   }
 

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -241,7 +241,14 @@ let assemble_hooks
              ~typed_outcome_str
              ~duration_ms
              ~output_text
-             ~input))
+             ~input;
+           (* IDE Bridge: detect PR creation from Execute output *)
+           Ide_bridge.ingest_pr_event_from_hook
+             ~base_path:config.base_path
+             ~keeper_id:acc.meta.name
+             ~turn_id
+             ~output_text
+             ~tool_name))
         ~passive_loop_nudge:(fun () ->
           Keeper_passive_loop_detector.nudge_message ~keeper_name:acc.meta.name)
         ~pre_tool_use_guard:public_alias_pre_tool_use_guard

--- a/test/test_ide_bridge.ml
+++ b/test/test_ide_bridge.ml
@@ -245,6 +245,81 @@ let test_hook_typed_outcome_mapping () =
     check string "typed_outcome" "error" typed)
 ;;
 
+let test_pr_event_ingest () =
+  with_temp_dir (fun base_dir ->
+    Ide_bridge.ingest_pr_event
+      ~base_path:base_dir
+      ~pr_number:19872
+      ~pr_url:"https://github.com/jeong-sik/masc-mcp/pull/19872"
+      ~pr_title:"feat(ide): auto-collect tool/turn events"
+      ~pr_state:"open"
+      ~repo:"jeong-sik/masc-mcp"
+      ~keeper_id:"keeper-alpha"
+      ~turn_id:"turn-123"
+      ~comment_count:0
+      ~review_status:None
+      ~timestamp_ms:1717400000000L;
+    let dir = Ide_paths.partition_store_dir ~base_dir:base_dir Ide_paths.Orphan in
+    let path = Filename.concat dir "pr_events.jsonl" in
+    check bool "file exists" true (Sys.file_exists path);
+    let ic = open_in path in
+    let line = input_line ic in
+    close_in ic;
+    let json = Yojson.Safe.from_string line in
+    let pr_number = Yojson.Safe.Util.member "pr_number" json |> Yojson.Safe.Util.to_int in
+    let pr_url = Yojson.Safe.Util.member "pr_url" json |> Yojson.Safe.Util.to_string in
+    check int "pr_number" 19872 pr_number;
+    check string "pr_url" "https://github.com/jeong-sik/masc-mcp/pull/19872" pr_url)
+;;
+
+let test_pr_event_from_hook_detects_url () =
+  with_temp_dir (fun base_dir ->
+    let output = "remote: https://github.com/jeong-sik/masc-mcp/pull/123\n" in
+    Ide_bridge.ingest_pr_event_from_hook
+      ~base_path:base_dir
+      ~keeper_id:"k1"
+      ~turn_id:"t1"
+      ~output_text:output
+      ~tool_name:"execute";
+    let dir = Ide_paths.partition_store_dir ~base_dir:base_dir Ide_paths.Orphan in
+    let path = Filename.concat dir "pr_events.jsonl" in
+    check bool "file exists" true (Sys.file_exists path);
+    let ic = open_in path in
+    let line = input_line ic in
+    close_in ic;
+    let json = Yojson.Safe.from_string line in
+    let pr_number = Yojson.Safe.Util.member "pr_number" json |> Yojson.Safe.Util.to_int in
+    check int "pr_number" 123 pr_number)
+;;
+
+let test_pr_event_from_hook_ignores_non_execute () =
+  with_temp_dir (fun base_dir ->
+    let output = "https://github.com/owner/repo/pull/456" in
+    Ide_bridge.ingest_pr_event_from_hook
+      ~base_path:base_dir
+      ~keeper_id:"k1"
+      ~turn_id:"t1"
+      ~output_text:output
+      ~tool_name:"fs_write";
+    let dir = Ide_paths.partition_store_dir ~base_dir:base_dir Ide_paths.Orphan in
+    let path = Filename.concat dir "pr_events.jsonl" in
+    check bool "file not created" false (Sys.file_exists path))
+;;
+
+let test_pr_event_from_hook_ignores_no_url () =
+  with_temp_dir (fun base_dir ->
+    let output = "file written successfully\n" in
+    Ide_bridge.ingest_pr_event_from_hook
+      ~base_path:base_dir
+      ~keeper_id:"k1"
+      ~turn_id:"t1"
+      ~output_text:output
+      ~tool_name:"execute";
+    let dir = Ide_paths.partition_store_dir ~base_dir:base_dir Ide_paths.Orphan in
+    let path = Filename.concat dir "pr_events.jsonl" in
+    check bool "file not created" false (Sys.file_exists path))
+;;
+
 let () =
   run
     "ide_bridge"
@@ -266,5 +341,11 @@ let () =
         ; test_case "no file_path (execute)" `Quick test_hook_no_file_path
         ; test_case "summary truncation" `Quick test_hook_summary_truncation
         ; test_case "typed_outcome mapping" `Quick test_hook_typed_outcome_mapping
+        ] )
+    ; ( "pr_event"
+      , [ test_case "pr event ingest" `Quick test_pr_event_ingest
+        ; test_case "from hook detects url" `Quick test_pr_event_from_hook_detects_url
+        ; test_case "from hook ignores non-execute" `Quick test_pr_event_from_hook_ignores_non_execute
+        ; test_case "from hook ignores no url" `Quick test_pr_event_from_hook_ignores_no_url
         ] )
     ]


### PR DESCRIPTION
Execute 도구 출력에서 GitHub PR URL 자동 감지하여 pr_events.jsonl에 기록. 17개 테스트 통과.