### PR TITLE
fix(observability): typed agent_name option eliminates silent client_name collapse

### DIFF
--- a/lib/dashboard_tool_host_events.ml
+++ b/lib/dashboard_tool_host_events.ml
@@ -16,7 +16,12 @@ module Int = Stdlib.Int
 module Float = Stdlib.Float
 
 type report = {
-  agent_name : string;
+  agent_name : string option;
+      (** [None] when no agent is involved — the client called the tool
+          directly without keeper mediation. Previously this silently
+          collapsed to [client_name] via [Option.value ~default:],
+          making direct calls indistinguishable from keeper-mediated
+          calls downstream. *)
   client_name : string;
   tool_name : string;
   transport : string;
@@ -69,10 +74,10 @@ let report_of_yojson ?fallback_agent (json : Yojson.Safe.t) :
             Option.bind (stringish_member_opt json "agent_name") String_util.trim_to_option
           in
           let fallback_agent = Option.bind fallback_agent String_util.trim_to_option in
-          let agent_name =
-            match explicit_agent with
-            | Some value -> value
-            | None -> Option.value ~default:client_name fallback_agent
+          (* No silent collapse to client_name — None means "no agent involved". *)
+          let agent_name = match explicit_agent with
+            | Some _ as v -> v
+            | None -> fallback_agent
           in
           let transport =
             Option.value ~default:"mcp_http"
@@ -136,7 +141,11 @@ let record ?fs config (report : report) =
   Log.client_tool_host_error
     ~module_name:Failure_envelope.tool_host_log_module_name ~details
     (ring_message report);
-  Audit_log.log_client_tool_host_failure config ~agent_id:report.agent_name
+  Audit_log.log_client_tool_host_failure config
+    ~agent_id:
+      (* Audit requires attribution; when no agent is involved the client
+         is the actor. This is an explicit choice, not a silent collapse. *)
+      (Option.value ~default:report.client_name report.agent_name)
     ~client_name:report.client_name ~tool_name:report.tool_name
     ~transport:report.transport ~message:report.message ?phase:report.phase
     ?request_id:report.request_id ?session_id:report.session_id

--- a/lib/dashboard_tool_host_events.mli
+++ b/lib/dashboard_tool_host_events.mli
@@ -20,7 +20,7 @@
     rows, so a future "let's rename agent_name to actor_name" change
     must touch this contract explicitly. *)
 type report = {
-  agent_name : string;
+  agent_name : string option;
   client_name : string;
   tool_name : string;
   transport : string;
@@ -41,10 +41,9 @@ val report_of_yojson :
 
     Optional fields default with operator-visible literals:
     - [client_name]: [fallback_agent] (trimmed) or "tool-host"
-    - [agent_name]: explicit [agent_name] field, then [fallback_agent],
-      then [client_name].  The three-level fallback is deliberate so a
-      single-keeper deployment never reports an empty agent_name in
-      audit logs.
+    - [agent_name]: explicit [agent_name] field, then [fallback_agent].
+      [None] when no agent is involved (direct client tool call without
+      keeper mediation). Previously this silently collapsed to [client_name].
     - [transport]: "mcp_http"
 
     Returns [Error] for non-object payloads ("request body must be a

--- a/lib/failure_envelope.ml
+++ b/lib/failure_envelope.ml
@@ -77,7 +77,7 @@ let summary_for_tool_host ~client_name ~tool_name ~transport = function
         transport
   | _ -> Printf.sprintf "%s %s failed on %s" client_name tool_name transport
 
-let tool_host_failure ~agent_name ~client_name ~tool_name ~transport ?phase
+let tool_host_failure ~agent_name:(agent_name : string option) ~client_name ~tool_name ~transport ?phase
     ?request_id ?session_id ?trace_id ?timeout_ms ~message () =
   let cause_code = tool_host_cause_code ?timeout_ms message in
   {
@@ -98,7 +98,7 @@ let tool_host_failure ~agent_name ~client_name ~tool_name ~transport ?phase
         (List.filter_map
            Fun.id
            [
-             Some ("agent_name", `String agent_name);
+             Option.map (fun value -> ("agent_name", `String value)) agent_name;
              Some ("client_name", `String client_name);
              Some ("tool_name", `String tool_name);
              Some ("transport", `String transport);

--- a/lib/failure_envelope.mli
+++ b/lib/failure_envelope.mli
@@ -30,7 +30,7 @@ val attach_to_details : Yojson.Safe.t -> t -> Yojson.Safe.t
 val find_in_json : Yojson.Safe.t -> t option
 
 val tool_host_failure :
-  agent_name:string ->
+  agent_name:string option ->
   client_name:string ->
   tool_name:string ->
   transport:string ->

--- a/test/test_dashboard_tool_host_events.ml
+++ b/test/test_dashboard_tool_host_events.ml
@@ -29,7 +29,7 @@ let test_report_of_yojson_defaults () =
   match Dashboard_tool_host_events.report_of_yojson ~fallback_agent:"agent_code" json with
   | Error err -> fail err
   | Ok report ->
-      check string "agent defaulted from fallback" "agent_code" report.agent_name;
+      check (option string) "agent defaulted from fallback" (Some "agent_code") report.agent_name;
       check string "client defaulted from fallback" "agent_code" report.client_name;
       check string "transport default" "mcp_http" report.transport;
       check (option string) "phase missing" None report.phase
@@ -65,7 +65,7 @@ let test_record_writes_audit_ring_and_telemetry () =
       let config = Workspace.default_config base_dir in
       let report =
         {
-          Dashboard_tool_host_events.agent_name = "agent_code";
+          Dashboard_tool_host_events.agent_name = Some "agent_code";
           client_name = "agent_code";
           tool_name = "masc_keeper_msg";
           transport = "mcp_http";
@@ -138,7 +138,7 @@ let test_generic_failure_envelope_is_retryable_without_operator_action () =
   let details =
     Dashboard_tool_host_events.details_json
       {
-        agent_name = "agent_code";
+        agent_name = Some "agent_code";
         client_name = "agent_code";
         tool_name = "masc_keeper_msg";
         transport = "mcp_http";
@@ -162,7 +162,7 @@ let test_blank_entity_id_is_normalized_out () =
   let details =
     Dashboard_tool_host_events.details_json
       {
-        agent_name = "agent_code";
+        agent_name = Some "agent_code";
         client_name = "agent_code";
         tool_name = "masc_keeper_msg";
         transport = "mcp_http";


### PR DESCRIPTION
Problem: report.agent_name was string with Option.value ~default:client_name fallback — when no agent was involved (direct client tool call), agent_name silently became indistinguishable from client_name. Changes (5 files, +26/-18): report.agent_name : string -> string option, Failure_envelope.tool_host_failure ~agent_name:string option, Audit_log explicit Option.value with documented rationale, tests updated. Verification: dune build @check EXIT 0. Weird-coupling #5. Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>