### PR TITLE
refactor(keeper): carry typed no_tool_capable reason instead of string round-trip

### DIFF
--- a/lib/keeper/keeper_status_bridge_blocker.ml
+++ b/lib/keeper/keeper_status_bridge_blocker.ml
@@ -266,16 +266,22 @@ let runtime_blocker_surface_of_failure_reason (reason : Keeper_registry.failure_
                window; keeper was auto-paused before restart loop."
               distinct_count)
          Stale_fleet_batch)
-  | Keeper_registry.Provider_runtime_error { code; detail; runtime_id = _ }
-     when code = "no_tool_capable_provider" ->
+  | Keeper_registry.Provider_runtime_error
+      { reason = Some (No_tool_capable _ as no_tool_capable); detail; _ } ->
+    (* Typed no-tool-capable path: the producer
+       ([keeper_unified_turn_types.runtime_exhausted_failure_reason_of_raw_error])
+       carries the already-typed [No_tool_capable] reason on the record.
+       Reading the typed field instead of reparsing [code =
+       "no_tool_capable_provider"] removes a typed->string->typed round-trip;
+       the [code] string is retained on the record for wire/dashboard readers. *)
     Some
       (runtime_blocker_surface_of_typed_class
          ~summary:
            (Printf.sprintf
               "No tool-capable provider available (registry path): %s"
               detail)
-         (Runtime_exhausted (No_tool_capable None)))
-  | Keeper_registry.Provider_runtime_error { code; detail } ->
+         (Runtime_exhausted no_tool_capable))
+  | Keeper_registry.Provider_runtime_error { code; detail; _ } ->
     Some
       { blocker_class = "provider_runtime_error"
       ; summary =

--- a/lib/keeper/keeper_unified_turn_types.ml
+++ b/lib/keeper/keeper_unified_turn_types.ml
@@ -137,7 +137,7 @@ let runtime_exhausted_failure_reason_of_raw_error ~detail raw_error =
              ; provider_id = None
          ; http_status = None
          ; runtime_id = Some (ntcp_runtime_id)
-         ; reason = None
+         ; reason = Some (Keeper_meta_contract.No_tool_capable (Some detail))
          })
   | Some
       (Keeper_internal_error.Runtime_exhausted
@@ -152,7 +152,7 @@ let runtime_exhausted_failure_reason_of_raw_error ~detail raw_error =
          ; provider_id = None
          ; http_status = None
          ; runtime_id = Some (ntcp_runtime_id)
-         ; reason = None
+         ; reason = Some (Keeper_meta_contract.No_tool_capable None)
          })
   (* Generic Runtime_exhausted catch-all — after No_tool_capable specifics *)
   | Some (Keeper_internal_error.Runtime_exhausted { reason; runtime_id }) ->

--- a/test/test_blocker_class_exhaustiveness.ml
+++ b/test/test_blocker_class_exhaustiveness.ml
@@ -134,6 +134,7 @@ let test_variant_count () =
 module SdkE = Agent_sdk.Error
 module SdkRetry = Agent_sdk.Retry
 module KSB = Masc_mcp.Keeper_status_bridge_blocker
+module Reg = Masc_mcp.Keeper_registry
 
 (** Every [Agent_sdk.Error.Agent _] sub-variant must map to a [Some blocker_class]
     through the two-layer pipeline in [blocker_class_of_sdk_error]:
@@ -232,6 +233,84 @@ let test_structural_timeout_maps_to_oas_timeout () =
   | None -> fail "structural timeout should map to Some blocker_class"
 ;;
 
+(* ── No_tool_capable round-trip removal: typed-reason consumer ──── *)
+
+(* The consumer [runtime_blocker_surface_of_failure_reason] now reads the
+   typed [reason = Some (No_tool_capable _)] field on
+   [Provider_runtime_error] instead of reparsing [code =
+   "no_tool_capable_provider"].  These tests pin that the typed-match path
+   yields the same blocker surface the old string-match produced, and that a
+   non-no_tool_capable provider error still falls through to the
+   provider_runtime_error catch-all (no widening). *)
+
+let no_tool_capable_surface_exn ~reason ~code =
+  let failure_reason =
+    Reg.Provider_runtime_error
+      { code
+      ; detail = "no tool-capable provider found (runtime=r labels=[a])"
+      ; provider_id = None
+      ; http_status = None
+      ; runtime_id = Some "r"
+      ; reason
+      }
+  in
+  match KSB.runtime_blocker_surface_of_failure_reason failure_reason with
+  | Some surface -> surface
+  | None ->
+    fail "runtime_blocker_surface_of_failure_reason returned None for Provider_runtime_error"
+;;
+
+let test_no_tool_capable_typed_reason_surface () =
+  (* Both producer shapes: with and without telemetry detail. *)
+  let detail_shape =
+    no_tool_capable_surface_exn
+      ~reason:
+        (Some
+           (No_tool_capable
+              (Some { configured_labels = [ "a" ]; provider_rejections = [] })))
+      ~code:"no_tool_capable_provider"
+  in
+  let none_shape =
+    no_tool_capable_surface_exn
+      ~reason:(Some (No_tool_capable None))
+      ~code:"no_tool_capable_provider"
+  in
+  List.iter
+    (fun (label, surface) ->
+       check string
+         (label ^ ": blocker_class is runtime_exhausted_no_tool_capable")
+         "runtime_exhausted_no_tool_capable"
+         surface.KSB.blocker_class;
+       (* Old string-match produced [Runtime_exhausted (No_tool_capable None)]
+          with continue_gate = false (Runtime_exhausted _ is non-gating). *)
+       check bool (label ^ ": continue_gate false") false surface.KSB.continue_gate)
+    [ "detail shape", detail_shape; "none shape", none_shape ]
+;;
+
+let test_non_no_tool_capable_provider_error_falls_through () =
+  (* A provider error without a No_tool_capable typed reason must route to the
+     generic provider_runtime_error catch-all, not the no-tool-capable arm. *)
+  let surface =
+    no_tool_capable_surface_exn
+      ~reason:(Some Connection_refused)
+      ~code:"runtime_exhausted_connection_refused"
+  in
+  check string
+    "non-NTC provider error -> provider_runtime_error catch-all"
+    "provider_runtime_error"
+    surface.KSB.blocker_class
+;;
+
+let test_reason_none_provider_error_falls_through () =
+  let surface =
+    no_tool_capable_surface_exn ~reason:None ~code:"provider_error"
+  in
+  check string
+    "reason=None provider error -> provider_runtime_error catch-all"
+    "provider_runtime_error"
+    surface.KSB.blocker_class
+;;
+
 (* ── Runner ────────────────────────────────────────────────────── *)
 
 let () =
@@ -250,6 +329,14 @@ let () =
         ; test_case "Agent variant count pin" `Quick test_agent_variant_count_pin
         ; test_case "structural timeout → oas_agent_execution_timeout" `Quick
             test_structural_timeout_maps_to_oas_timeout
+        ] )
+    ; ( "no_tool_capable_typed_reason"
+      , [ test_case "typed reason -> no_tool_capable surface" `Quick
+            test_no_tool_capable_typed_reason_surface
+        ; test_case "non-NTC provider error falls through" `Quick
+            test_non_no_tool_capable_provider_error_falls_through
+        ; test_case "reason=None provider error falls through" `Quick
+            test_reason_none_provider_error_falls_through
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary

Removes a typed->string->typed round-trip in the keeper no-tool-capable failure path.

The producer in `keeper_unified_turn_types.ml` already held a typed `Keeper_meta_contract.No_tool_capable` reason (bound from `Keeper_internal_error.Runtime_exhausted`), encoded it into `code = "no_tool_capable_provider"`, set the typed `reason` field to `None`, and the consumer in `keeper_status_bridge_blocker.ml` re-derived the typed value with `String.equal` on `code = "no_tool_capable_provider"`. The string was a pointless, fragile intermediate.

## Change

- **Producer** (`keeper_unified_turn_types.ml`): the two no-tool-capable construction sites now set `reason = Some (No_tool_capable (Some detail))` / `reason = Some (No_tool_capable None)` from the value already in scope, instead of `None`. The `Provider_runtime_error.reason` field was added (with a doc-comment naming exactly this use) precisely for this; only the two no-tool-capable producers were still leaving it `None`.
- **Consumer** (`keeper_status_bridge_blocker.ml`): matches `reason = Some (No_tool_capable _)` and passes the bound reason to `runtime_blocker_surface_of_typed_class`, dropping the `when code = "no_tool_capable_provider"` string guard. No wildcard added; the existing non-no-tool-capable provider-error arm is unchanged.

## `code` string: kept (wire)

The `code = "no_tool_capable_provider"` string stays on the record. It still flows to wire via `failure_reason_to_string` and `Keeper_turn_terminal_code`, and separate wire/dashboard readers (`server_dashboard_http_keeper_runtime_lens_gaps`, `server_dashboard_http_composite_claims`, `keeper_runtime_trust_snapshot`) consume that string from wire JSON, not the in-memory record field. The newly-populated `reason` field never reaches wire: the only `failure_reason` -> JSON path (`keeper_event_publisher.ml`) serializes the already-stringified form, which ignores `reason`.

## Behavior preservation

- Consumer surface (`blocker_class`, `continue_gate`) is identical: `blocker_class_to_string` and `blocker_class_continue_gate` are wildcard on `Runtime_exhausted _`, so carrying `No_tool_capable (Some detail)` vs `No_tool_capable None` produces the same output.
- The generic catch-all producer (`keeper_unified_turn_types.ml:158`) can never emit `No_tool_capable` because the two specific arms intercept it top-down, so the consumer's typed match fires only for the two no-tool-capable producers (`code = "ntc"` iff `reason = Some (No_tool_capable _)` over all reachable values; no JSON deserializer reconstructs the record).
- Pause policy: the populated `reason` now reaches the already-typed arm at `keeper_supervisor_pause_policy.ml:224`. Its decision `Runtime_exhausted { retryable = false }` maps to `Pause_current_work`; at `keeper_supervisor.ml:78` both `Pause_current_work` and the prior `None` route to `queue_standard_restart`, so supervisor lifecycle is unchanged. The existing `test_supervisor_policy_runtime_exhausted_terminal_reasons` already pins `Some (No_tool_capable None) -> pause_current_work`.

## Tests

Adds focused old-vs-new equivalence tests in `test_blocker_class_exhaustiveness.ml`:
- both producer shapes route to `runtime_exhausted_no_tool_capable` with `continue_gate = false`;
- a non-no-tool-capable provider error (`Connection_refused`) and a `reason = None` provider error both fall through to the `provider_runtime_error` catch-all (guards against widening).

## Verification

- `dune build @check --root .` = 0
- `dune build lib/masc_mcp.cmxa --root .` = 0 (native)
- `test_blocker_class_exhaustiveness` (11 tests, incl. 3 new) pass
- all five no_tool_capable-referencing test files pass: `test_keeper_terminal_reason_typed` (298368-case matrix, mismatches=0), `test_keeper_typed_labels`, `test_keeper_turn_fsm_emit`, plus the two above
- pre-existing unrelated failure noted: `test_keeper_supervisor.ml` `test_supervisor_policy_pauses_watchdog_provider_timeout_loop` fails identically on clean base `dc46d82b3d` (`Provider_timeout_loop` scope drift, separate path); verified via stash on base.

WORKAROUND-WAIVED: removes a typed->string->typed round-trip, no new classifier added (a string guard is removed, not added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
