### PR TITLE
[codex] Remove Keeper tool-choice gate coupling

### DIFF
--- a/docs/rfc/RFC-0096-keeper-turn-contract-multi-turn-and-tier-group-spof.md
+++ b/docs/rfc/RFC-0096-keeper-turn-contract-multi-turn-and-tier-group-spof.md
@@ -79,7 +79,7 @@ let required_tool_satisfaction call =
 
 ### §4.1 증상
 
-`system_log seq 52304` (2026-05-14):
+Retired behavior observed in `system_log seq 52304` (2026-05-14):
 
 ```
 INFO  oas:agent  turn completed turn=16
@@ -90,11 +90,14 @@ INFO  oas:agent  turn completed turn=16
 
 Model 이 `keeper_board_list` 로 *상황 파악* 후 다음 turn 에 mutating
 action 을 호출하려는 자연스러운 reasoning 이 turn-level enforcement
-에 의해 *그 turn 자체* 가 contract violation 으로 변환됨.
+에 의해 *그 turn 자체* 가 contract violation 으로 변환됐던 현상.
+현재 정책에서는 provider-level tool-use 와 Keeper progress/liveness
+판정을 분리하고, observation tool 호출을 required-tool 실패로
+재해석하지 않는다.
 
 ### §4.2 위치 + 현재 동작
 
-`lib/keeper/keeper_tool_progress.ml`:
+Retired `lib/keeper/keeper_tool_progress.ml` shape:
 
 ```ocaml
 let required_tool_satisfaction (call : Agent_sdk.Completion_contract.tool_call) =
@@ -105,10 +108,12 @@ let required_tool_satisfaction (call : Agent_sdk.Completion_contract.tool_call) 
       | _ -> Agent_tool_dispatch_runtime.has_mutating_side_effect_with_input ~tool_name ~input:call.input
     in
     if mutates then Ok ()
-    else Error "tool '%s' is read-only/passive and cannot satisfy a required-tool contract"
+    else Error "<retired passive-tool rejection>"
 ```
 
-Contract 가 *turn-level* — 한 turn 안에서 mutating 호출이 없으면 fail.
+이 모양은 폐기됐다. 현재 `required_tool_satisfaction` 은 실제 tool call
+발생 여부만 provider-level 로 확인하고, mutating progress 여부는 별도
+progress/liveness classification 으로 남긴다.
 
 ### §4.3 제안 모양
 

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -21,9 +21,6 @@ let no_progress_success_tool_names_for_contract =
   Contract_helpers.no_progress_success_tool_names_for_contract
 ;;
 
-let should_require_provider_tool_choice_support =
-  Turn_helpers.should_require_provider_tool_choice_support
-
 let tool_contract_result_for_observed_tools =
   Turn_helpers.tool_contract_result_for_observed_tools
 
@@ -460,14 +457,8 @@ let run_turn
      with
      | Error e -> Error (Agent_sdk.Error.Internal e)
      | Ok oas_allowed_paths ->
-       let require_tool_support =
-         tools <> []
-         && initial_tool_surface.tool_requirement = Required
-       in
-       let require_tool_choice_support =
-         should_require_provider_tool_choice_support
-           ~initial_tool_requirement:initial_tool_surface.tool_requirement
-       in
+       let require_tool_support = false in
+       let require_tool_choice_support = false in
        let timeout_s =
          match oas_timeout_s with
          | Some value -> value

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -13,10 +13,6 @@ include module type of Keeper_agent_checkpoint_hygiene
 module Contract_helpers = Keeper_agent_run_contract_helpers
 module Turn_helpers = Keeper_agent_run_turn_helpers
 
-val should_require_provider_tool_choice_support
-  :  initial_tool_requirement:tool_requirement
-  -> bool
-
 val tool_contract_result_for_observed_tools
   :  missing_visible_required:string list
   -> had_owned_active_task_at_turn_start:bool

--- a/lib/keeper/keeper_agent_run_turn_helpers.ml
+++ b/lib/keeper/keeper_agent_run_turn_helpers.ml
@@ -73,9 +73,6 @@ let registry_progress_on_event ~record_turn_progress downstream event =
   Option.iter (fun cb -> cb event) downstream
 
 
-let should_require_provider_tool_choice_support ~initial_tool_requirement =
-  initial_tool_requirement = Keeper_agent_tool_surface.Required
-
 let tool_contract_result_for_observed_tools
     ~(missing_visible_required : string list)
     ~(had_owned_active_task_at_turn_start : bool)

--- a/lib/keeper/keeper_agent_run_turn_helpers.mli
+++ b/lib/keeper/keeper_agent_run_turn_helpers.mli
@@ -20,10 +20,6 @@ val registry_progress_on_event :
   Agent_sdk.Types.sse_event ->
   unit
 
-val should_require_provider_tool_choice_support :
-  initial_tool_requirement:Keeper_agent_tool_surface.tool_requirement ->
-  bool
-
 val tool_contract_result_for_observed_tools :
   missing_visible_required:string list ->
   had_owned_active_task_at_turn_start:bool ->

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -449,12 +449,9 @@ let assemble_hooks
                   | other -> other
                 in
                 let tool_choice =
-                  if
-                    (not computed_surface.is_last_turn)
-                    && computed_surface.tool_gate_requested
-                    && turn_visible_tool_names <> []
-                  then current_params.tool_choice
-                  else clear_inherited_strict_tool_choice current_params.tool_choice
+                  (* Tool gates are advisory. Do not preserve strict inherited
+                     [tool_choice=Any/Tool] in the keeper turn path. *)
+                  clear_inherited_strict_tool_choice current_params.tool_choice
                 in
                 let lane = computed_surface.lane in
                 Keeper_run_tools_hook_accumulator.record_requested_tool_names

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -483,21 +483,9 @@ let prepare_agent_setup
     validate_allow_list ~turn fallback_floor_tool_names
   in
   let tool_gate_requested_for_turn ~current_tool_choice ~is_last_turn =
-    let caller_requires_tools =
-      (* Enumerate every [tool_choice] variant + [None] so a new constructor
-         added to [Agent_sdk.Types.tool_choice] surfaces a Warning 8 here.
-         [Auto] and [None_] correctly evaluate to [false] (no tool required);
-         the old [_ -> false] catch-all would have absorbed any future variant
-         in the same direction without review. *)
-      match current_tool_choice with
-      | Some (Agent_sdk.Types.Any | Agent_sdk.Types.Tool _) -> true
-      | Some (Agent_sdk.Types.Auto | Agent_sdk.Types.None_)
-      | None ->
-        false
-    in
-    max_turns > 1
-    && (not is_last_turn)
-    && caller_requires_tools
+    ignore current_tool_choice;
+    ignore is_last_turn;
+    false
   in
   let compute_tool_surface
         ~turn

--- a/lib/keeper/keeper_tool_progress.ml
+++ b/lib/keeper/keeper_tool_progress.ml
@@ -157,35 +157,12 @@ let required_tool_satisfaction ?(satisfying_tools : string list = [])
   (call : Agent_sdk.Completion_contract.tool_call)
   : (unit, string) result
   =
-  let tool_name = Keeper_tool_resolution.canonical_tool_name call.name in
-  (* Generic Require_tool_use is a required-action contract at the keeper
-     boundary. Passive read/status/search tools can support a later action, but
-     they must not satisfy the action predicate by themselves. *)
-  if is_completion_tool_name tool_name
-  then Ok ()
-  else (
-    let mutates =
-      match effect_domain_for_tool_name call.name with
-      | Some Tool_catalog.Read_only -> false
-      | _ ->
-        Keeper_tool_dispatch_runtime.has_mutating_side_effect_with_input ~tool_name ~input:call.input
-    in
-    if mutates
-    then Ok ()
-    else
-      let base_msg =
-        Printf.sprintf
-          "tool '%s' is read-only/passive and cannot satisfy a required-tool contract"
-          tool_name
-      in
-      match satisfying_tools with
-      | [] -> Error base_msg
-      | _ ->
-        Error
-          (Printf.sprintf
-             "%s. Call one of these instead: [%s]"
-             base_msg
-             (String.concat "; " satisfying_tools)))
+  ignore satisfying_tools;
+  ignore call;
+  (* Provider-level [Require_tool_use] only means a tool call happened. Keeper
+     progress/liveness classification remains separate; do not reinterpret the
+     provider contract as "must mutate state" or "passive reads do not count". *)
+  Ok ()
 ;;
 
 let parse_tool_csv text =

--- a/lib/keeper/keeper_tool_progress.mli
+++ b/lib/keeper/keeper_tool_progress.mli
@@ -61,14 +61,15 @@ val is_completion_tool_name : string -> bool
 (** [true] iff the canonicalized name is keeper_stay_silent. *)
 val is_stay_silent_tool_name : string -> bool
 
-(** [true] iff the tool name represents productive execution progress for a
-    required-action gate. Completion tools are exempted even when read-only;
-    passive keeper observation tools remain [false]. *)
+(** [true] iff the tool name represents productive execution progress.
+    Completion tools are exempted even when read-only; passive keeper
+    observation tools remain [false]. *)
 val tool_name_can_satisfy_required_contract : string -> bool
 
-(** Validate an observed generic [Require_tool_use] call. This accepts mutating
-    tools and completion tools. Keeper-local observation/discovery tools and
-    LLM-native read/search aliases remain passive. *)
+(** Validate an observed generic [Require_tool_use] call. This is a
+    provider-level contract: any actual tool call satisfies it. Keeper
+    progress/liveness classification is handled separately and must not be
+    reinterpreted as a mutating-tool requirement. *)
 val required_tool_satisfaction
   :  ?satisfying_tools:string list
   -> Agent_sdk.Completion_contract.tool_call

--- a/test/test_keeper_unified_required_tools.ml
+++ b/test/test_keeper_unified_required_tools.ml
@@ -11,22 +11,22 @@ let satisfies_required_tool name input =
   Result.is_ok (KTP.required_tool_satisfaction (required_tool_call name input))
 ;;
 
-let test_required_tool_satisfaction_rejects_passive_tools () =
-  check bool "global masc_status remains passive" false
+let test_required_tool_satisfaction_accepts_observation_tools () =
+  check bool "global masc_status satisfies provider tool-use" true
     (satisfies_required_tool "masc_status" (`Assoc []));
-  check bool "keeper_tasks_list cannot satisfy required-action contract" false
+  check bool "keeper_tasks_list satisfies provider tool-use" true
     (satisfies_required_tool "keeper_tasks_list" (`Assoc []));
-  check bool "keeper_context_status cannot satisfy required-action contract" false
+  check bool "keeper_context_status satisfies provider tool-use" true
     (satisfies_required_tool "keeper_context_status" (`Assoc []));
-  check bool "keeper_memory_search cannot satisfy required-action contract" false
+  check bool "keeper_memory_search satisfies provider tool-use" true
     (satisfies_required_tool "keeper_memory_search" (`Assoc []));
-  check bool "keeper_tool_search cannot satisfy required-action contract" false
+  check bool "keeper_tool_search satisfies provider tool-use" true
     (satisfies_required_tool "keeper_tool_search" (`Assoc []));
-  check bool "keeper_board_get cannot satisfy required-action contract" false
+  check bool "keeper_board_get satisfies provider tool-use" true
     (satisfies_required_tool "keeper_board_get" (`Assoc []));
-  check bool "keeper_board_list cannot satisfy required-action contract" false
+  check bool "keeper_board_list satisfies provider tool-use" true
     (satisfies_required_tool "keeper_board_list" (`Assoc []));
-  check bool "keeper_time_now cannot satisfy required-action contract" false
+  check bool "keeper_time_now satisfies provider tool-use" true
     (satisfies_required_tool "keeper_time_now" (`Assoc []));
   check bool "keeper_memory_search remains passive progress" true
     (KTP.is_passive_status_tool_name "keeper_memory_search");
@@ -34,13 +34,13 @@ let test_required_tool_satisfaction_rejects_passive_tools () =
     (KTP.is_execution_progress_tool_name "keeper_memory_search");
   check bool "keeper_stay_silent satisfies as completion" true
     (satisfies_required_tool "keeper_stay_silent" (`Assoc []));
-  check bool "Read alias cannot satisfy required-action contract" false
+  check bool "Read alias satisfies provider tool-use" true
     (satisfies_required_tool "Read" (`Assoc []));
-  check bool "Grep alias cannot satisfy required-action contract" false
+  check bool "Grep alias satisfies provider tool-use" true
     (satisfies_required_tool "Grep" (`Assoc []));
-  check bool "mcp-prefixed Grep remains passive" false
+  check bool "mcp-prefixed Grep satisfies provider tool-use" true
     (satisfies_required_tool "mcp__masc__Grep" (`Assoc []));
-  check bool "WebSearch alias cannot satisfy required-action contract" false
+  check bool "WebSearch alias satisfies provider tool-use" true
     (satisfies_required_tool "WebSearch" (`Assoc []));
   check bool "Read alias remains passive progress" true
     (KTP.is_passive_status_tool_name "Read");
@@ -48,7 +48,7 @@ let test_required_tool_satisfaction_rejects_passive_tools () =
     (KTP.is_passive_status_tool_name "Grep");
   check bool "WebSearch alias remains passive progress" true
     (KTP.is_passive_status_tool_name "WebSearch");
-  check bool "tool_search_files gh op does not satisfy required-action contract" false
+  check bool "tool_search_files gh op satisfies provider tool-use" true
     (satisfies_required_tool
        "tool_search_files"
        (`Assoc [ "op", `String "gh"; "cmd", `String "pr view 123" ]))
@@ -79,46 +79,32 @@ let test_required_tool_satisfaction_accepts_mutating_tools () =
        ~output_text:"Worktree already exists:\n  Path: /tmp/wt")
 ;;
 
-let test_required_tool_satisfaction_includes_satisfying_tools_hint () =
-  let base_error =
-    KTP.required_tool_satisfaction (required_tool_call "masc_status" (`Assoc []))
-  in
-  check string "base rejection has no suggestion suffix"
-    "tool 'masc_status' is read-only/passive and cannot satisfy a required-tool contract"
-    (Result.get_error base_error);
-  let hinted_error =
-    KTP.required_tool_satisfaction
-      ~satisfying_tools:[ "keeper_board_post"; "keeper_board_comment" ]
-      (required_tool_call "masc_status" (`Assoc []))
-  in
-  check string "hinted rejection includes satisfying tools"
-    "tool 'masc_status' is read-only/passive and cannot satisfy a required-tool \
-     contract. Call one of these instead: [keeper_board_post; keeper_board_comment]"
-    (Result.get_error hinted_error);
+let test_required_tool_satisfaction_ignores_satisfying_tools_hint () =
+  check bool "base observation tool call satisfies provider tool-use" true
+    (Result.is_ok
+       (KTP.required_tool_satisfaction
+          (required_tool_call "masc_status" (`Assoc []))));
+  check bool "satisfying_tools hint does not turn observation into rejection" true
+    (Result.is_ok
+       (KTP.required_tool_satisfaction
+          ~satisfying_tools:[ "keeper_board_post"; "keeper_board_comment" ]
+          (required_tool_call "masc_status" (`Assoc []))));
   check bool "mutating tool still satisfies regardless of satisfying_tools" true
     (Result.is_ok
        (KTP.required_tool_satisfaction
           ~satisfying_tools:[ "keeper_board_post" ]
           (required_tool_call "tool_execute"
              (`Assoc [ "op", `String "echo"; "cmd", `String "hello" ]))));
-  let empty_hint_error =
-    KTP.required_tool_satisfaction
-      ~satisfying_tools:[]
-      (required_tool_call "keeper_tasks_list" (`Assoc []))
-  in
-  check string "empty satisfying_tools uses base message"
-    "tool 'keeper_tasks_list' is read-only/passive and cannot satisfy a required-tool \
-     contract"
-    (Result.get_error empty_hint_error);
-  let hinted_passive =
-    KTP.required_tool_satisfaction
-      ~satisfying_tools:[ "keeper_task_claim" ]
-      (required_tool_call "masc_status" (`Assoc []))
-  in
-  check string "rejection forwards satisfying_tools hint"
-    "tool 'masc_status' is read-only/passive and cannot satisfy a required-tool \
-     contract. Call one of these instead: [keeper_task_claim]"
-    (Result.get_error hinted_passive)
+  check bool "empty satisfying_tools still accepts observation tools" true
+    (Result.is_ok
+       (KTP.required_tool_satisfaction
+          ~satisfying_tools:[]
+          (required_tool_call "keeper_tasks_list" (`Assoc []))));
+  check bool "passive hint path stays accepted" true
+    (Result.is_ok
+       (KTP.required_tool_satisfaction
+          ~satisfying_tools:[ "keeper_task_claim" ]
+          (required_tool_call "masc_status" (`Assoc []))))
 ;;
 
 let test_satisfying_tools_for_turn_computes_from_affordances () =
@@ -179,17 +165,17 @@ let () =
     "keeper_unified_required_tools"
     [ ( "required_tools"
       , [ test_case
-            "required tool predicate handles passive tools"
+            "required tool predicate accepts observation tools"
             `Quick
-            test_required_tool_satisfaction_rejects_passive_tools
+            test_required_tool_satisfaction_accepts_observation_tools
         ; test_case
             "required tool predicate accepts mutating tools"
             `Quick
             test_required_tool_satisfaction_accepts_mutating_tools
         ; test_case
-            "required tool satisfaction includes satisfying tools hint"
+            "required tool satisfaction ignores satisfying tools hint"
             `Quick
-            test_required_tool_satisfaction_includes_satisfying_tools_hint
+            test_required_tool_satisfaction_ignores_satisfying_tools_hint
         ; test_case
             "satisfying_tools_for_turn computes from affordances"
             `Quick


### PR DESCRIPTION
## Summary
- Removes the remaining Keeper-side strict `tool_choice` inheritance so advisory tool gates do not become provider-required turns.
- Treats provider-level required tool-use satisfaction as an observed tool call, keeping Keeper progress/liveness classification separate.
- Updates the focused regression test and RFC-0096 note so passive observation is no longer rejected as a required-tool failure.

## Validation
- `ocamlformat --check lib/keeper/keeper_agent_run.ml lib/keeper/keeper_agent_run.mli lib/keeper/keeper_agent_run_turn_helpers.ml lib/keeper/keeper_agent_run_turn_helpers.mli lib/keeper/keeper_run_tools_hooks.ml lib/keeper/keeper_run_tools_setup.ml lib/keeper/keeper_tool_progress.ml lib/keeper/keeper_tool_progress.mli test/test_keeper_unified_required_tools.ml`
- `git diff --check`
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-pr-tool-choice dune build --root . test/test_keeper_unified_required_tools.exe`
- `./_build-codex-pr-tool-choice/default/test/test_keeper_unified_required_tools.exe`