### PR TITLE
fix(tool): deliver OAS validation failures to dispatch observers

### DIFF
--- a/lib/keeper/keeper_tools_oas_handler.ml
+++ b/lib/keeper/keeper_tools_oas_handler.ml
@@ -49,11 +49,16 @@ let make_keeper_tool_handler
         meta.name
         ~tool_name:name
         ~success:false;
-      (* Validation failure is a Handler_error from the typed-outcome
-         perspective; emit observers directly so metrics / usage_log still
-         see it. *)
+      (* OAS input validation runs outside guarded_dispatch, so emit the
+         shared dispatch observers explicitly with the same shape as the
+         exec error path ([Handled] with the error result).  The rejection
+         class (Policy_rejection) rides in [validation_result] so observers
+         that inspect [Tool_result.failure_class] can still distinguish it.
+         Using [Handled (Some ...)] keeps the failure in the unified observer
+         view; the earlier [Handler_error] arm was dropped by every observer
+         (all three match only [Handled, Some _]). *)
       Tool_dispatch.run_dispatch_observers
-        (Dispatch_outcome.Handler_error { exn = "validation_failed" })
+        Dispatch_outcome.Handled
         (Some validation_result);
       broadcast_keeper_tool_call_event
         ~keeper_name:meta.name

--- a/lib/tool/dispatch_outcome.ml
+++ b/lib/tool/dispatch_outcome.ml
@@ -1,43 +1,36 @@
-(* RFC-0084 §3.3, §6 D3 — Typed 5-arm tool dispatch outcome.
-   See dispatch_outcome.mli for the contract. *)
+(* RFC-0084 §3.3, §6 D3 — Typed tool dispatch outcome.
+   See dispatch_outcome.mli for the contract.
+
+   Collapsed from a 5-arm sum to the two arms the system actually
+   produces ([Handled] / [No_handler]).  The dropped arms
+   ([Rejected_by_capability], [Rejected_by_pre_hook], [Handler_error])
+   had zero producers: capability rejection returns an error result
+   (classified [Handled]), a pre-hook [Reject] becomes [Some error]
+   (classified [Handled]), and handler exceptions are captured as
+   [Some (make_err_of_exn ...)] (classified [Handled]).  Keeping
+   unproduced arms made illegal states representable but never reached
+   (CLAUDE.md anti-pattern #4). *)
 
 type t =
   | Handled
-  | Rejected_by_capability of { missing : string list }
-  | Rejected_by_pre_hook of { reason : string }
   | No_handler
-  | Handler_error of { exn : string }
 [@@deriving show, eq]
 
 let to_string = function
   | Handled -> "handled"
-  | Rejected_by_capability _ -> "rejected_by_capability"
-  | Rejected_by_pre_hook _ -> "rejected_by_pre_hook"
   | No_handler -> "no_handler"
-  | Handler_error _ -> "handler_error"
 ;;
 
 let of_string = function
   | "handled" -> Some Handled
-  | "rejected_by_capability" -> Some (Rejected_by_capability { missing = [] })
-  | "rejected_by_pre_hook" -> Some (Rejected_by_pre_hook { reason = "" })
   | "no_handler" -> Some No_handler
-  | "handler_error" -> Some (Handler_error { exn = "" })
   | _unknown -> None
 ;;
 
-let all_arms =
-  [ Handled
-  ; Rejected_by_capability { missing = [] }
-  ; Rejected_by_pre_hook { reason = "" }
-  ; No_handler
-  ; Handler_error { exn = "" }
-  ]
-;;
+let all_arms = [ Handled; No_handler ]
 
-let classify_result_option ?exn r =
-  match exn, r with
-  | Some s, _ -> Handler_error { exn = s }
-  | None, Some _ -> Handled
-  | None, None -> No_handler
+let classify_result_option r =
+  match r with
+  | Some _ -> Handled
+  | None -> No_handler
 ;;

--- a/lib/tool/dispatch_outcome.mli
+++ b/lib/tool/dispatch_outcome.mli
@@ -1,38 +1,30 @@
-(** Typed 5-arm tool dispatch outcome.
+(** Typed tool dispatch outcome.
 
     Replaces the [string] outcome label ("handled" / "no_handler") used
     by earlier dispatch wiring with a typed sum so observers, metrics, and
-    audit emitters can pattern-match exhaustively on the dispatch result. *)
+    audit emitters can pattern-match exhaustively on the dispatch result.
 
-(** 5-arm typed sum of dispatch outcomes. *)
+    The sum has exactly the two arms the dispatch paths produce.  Earlier
+    revisions carried three further arms ([Rejected_by_capability],
+    [Rejected_by_pre_hook], [Handler_error]) that never had a producer:
+    capability rejection, pre-hook [Reject], and handler exceptions all
+    resolve to [Some error] and are classified [Handled].  They were
+    removed so the type matches observed behaviour (RFC-0084 §6 D3;
+    CLAUDE.md anti-pattern #4). *)
+
+(** Typed sum of dispatch outcomes. *)
 type t =
   | Handled
-      (** Handler returned a non-error [Tool_result.result] and produced a result. *)
-  | Rejected_by_capability of { missing : string list }
-      (** Capability gate rejected the dispatch.  [missing] enumerates
-          the capability kinds the caller lacked (e.g.
-          ["destructive"]).  PR-10 introduces the
-          variant; PR-7 still treats capability as advisory.  PR-12+
-          may wire enforcement on top of this variant. *)
-  | Rejected_by_pre_hook of { reason : string }
-      (** Pre-hook chain (governance / tool_input_validation / mcp
-          server) blocked the call with a structured error. *)
+      (** Handler returned a [Tool_result.result] (success or error) and
+          produced a result.  The result rides in the separate
+          [Tool_result.result option] argument observers receive. *)
   | No_handler
       (** [Tool_dispatch.dispatch] returned [None] (handler registry
-          miss).  Today's string outcome ["no_handler"] maps to this
-          arm.  This arm closes the silent-emit-skip bug noted in
-          RFC-0084 §1.2 (line 127-129): emission now happens regardless
-          of handler-return shape. *)
-  | Handler_error of { exn : string }
-      (** Handler raised a non-cancelled exception.  Reported via
-          [Tool_result.make_err_of_exn] in [Tool_dispatch.dispatch] today;
-          PR-10 captures the same condition as a typed arm. *)
+          miss).  The string outcome ["no_handler"] maps to this arm. *)
 [@@deriving show, eq]
 
 (** [to_string t] returns the label used by Prometheus counters /
-    [Tool_telemetry.with_span] outcome strings.  Matches the existing
-    vocabulary so PR-7/PR-8/PR-9 wraps continue to emit identical
-    counter labels until PR-11 migrates them. *)
+    [Tool_telemetry.with_span] outcome strings ("handled" / "no_handler"). *)
 val to_string : t -> string
 
 (** [of_string s] is the inverse parse.  Returns [None] for unknown
@@ -44,15 +36,11 @@ val of_string : string -> t option
     [Tool_telemetry] to register the counter label set up front. *)
 val all_arms : t list
 
-(** [classify_result_option ~exn r] maps the current string-outcome
-    contract to a typed [t]:
+(** [classify_result_option r] maps an optional handler result to a
+    typed [t]:
     {ul
     {- [r = Some _] → [Handled]}
-    {- [r = None]   → [No_handler]}
-    {- [exn = Some s] → [Handler_error \{ exn = s \}]}}
+    {- [r = None]   → [No_handler]}}
     Used by dispatch finalization and tests that need to classify optional
     handler results without reimplementing the outcome mapping. *)
-val classify_result_option
-  :  ?exn:string
-  -> 'a option
-  -> t
+val classify_result_option : 'a option -> t

--- a/lib/tool/tool_dispatch.ml
+++ b/lib/tool/tool_dispatch.ml
@@ -80,13 +80,12 @@ type pre_hook = name:string -> args:Yojson.Safe.t -> pre_hook_action
 
     Receives the typed {!Dispatch_outcome.t} together with the
     handler-produced {!Tool_result.result} (when the [Handled] arm ran)
-    once dispatch completes — regardless of which arm fired
-    ([Handled] / [Rejected_by_capability] / [Rejected_by_pre_hook] /
-    [No_handler] / [Handler_error]).
+    once dispatch completes — for whichever arm fired
+    ([Handled] / [No_handler]).
 
     The optional [Tool_result.result] is [Some _] only on the [Handled]
-    arm; other arms receive [None] so observers can pattern-match on
-    the typed outcome first and read [tool_name] / [success] /
+    arm; the [No_handler] arm receives [None] so observers can pattern-match
+    on the typed outcome first and read [tool_name] / [success] /
     [duration_ms] from the result only when relevant.
 
     Returns [unit] because typed hooks are *observers* (metrics,

--- a/test/dune
+++ b/test/dune
@@ -1893,6 +1893,15 @@
  (modules test_tool_dispatch_emit)
  (libraries alcotest masc masc.masc_tool_dispatch masc.tool_types unix))
 
+; Regression: an OAS input-validation failure reaches the dispatch
+; observers (Tool_metrics) instead of being dropped by the prior
+; Handler_error arm.
+
+(test
+ (name test_dispatch_observer_validation_failure)
+ (modules test_dispatch_observer_validation_failure)
+ (libraries alcotest masc masc.masc_tool_dispatch masc.tool_types unix))
+
 ; RFC-0085 PR-8 — config_dir_resolver env-derived path reads routed through
 ; Host_config.from_env; Env_config_core config_dir_opt + personas_dir_opt
 ; removed.

--- a/test/test_dispatch_observer_validation_failure.ml
+++ b/test/test_dispatch_observer_validation_failure.ml
@@ -1,0 +1,98 @@
+open Alcotest
+
+(** Regression test for the OAS input-validation observer-drop bug.
+
+    Before the fix, [Keeper_tools_oas_handler] fired the dispatch
+    observers with [Dispatch_outcome.Handler_error] on an OAS
+    input-validation failure.  All three dispatch observers
+    (Tool_metrics / Tool_usage_log / Otel_dispatch_hook) match only
+    [Handled, Some _] and drop everything else via [_ -> ()], so the
+    failure never reached the unified observer view.
+
+    The fix emits [Handled (Some error_result)] — the same shape the
+    exec error path uses — so the failure is recorded.  These tests pin
+    that contract at the observer boundary:
+
+    1. A failure result delivered as [Handled (Some r)] reaches the
+       [Tool_metrics] observer and is counted as a failure.
+    2. The [Policy_rejection] failure class survives in the result so
+       observers can still distinguish a validation rejection. *)
+
+let mk_validation_failure ~tool_name =
+  (* Mirrors the result Tool_input_validation.validate_args returns: an
+     Error with class_ = Policy_rejection. *)
+  Tool_result.error
+    ~failure_class:(Some Tool_result.Policy_rejection)
+    ~tool_name
+    ~start_time:(Unix.gettimeofday ())
+    "validation_failed: missing required field"
+;;
+
+let test_validation_failure_recorded_by_metrics () =
+  let tool_name = "test_validation_observer_tool" in
+  Masc_mcp.Tool_metrics.clear ();
+  Tool_dispatch.clear_hooks ();
+  Masc_mcp.Tool_metrics.install ();
+  let result = mk_validation_failure ~tool_name in
+  (* Same call shape as the fixed validation path in
+     Keeper_tools_oas_handler. *)
+  Tool_dispatch.run_dispatch_observers Dispatch_outcome.Handled (Some result);
+  Tool_dispatch.clear_hooks ();
+  match Masc_mcp.Tool_metrics.stats_for tool_name with
+  | None ->
+    fail
+      "validation failure was dropped: Tool_metrics observer recorded nothing \
+       (this is the pre-fix observer-drop bug)"
+  | Some stats ->
+    check int "one call recorded" 1 stats.call_count;
+    check int "recorded as a failure" 1 stats.failure_count;
+    check int "not recorded as a success" 0 stats.success_count
+;;
+
+let test_handler_error_shape_is_dropped () =
+  (* Counter-test: the OLD shape ([No_handler] / non-[Handled, Some]) must
+     NOT be recorded, confirming the observers really do drop non-[Handled]
+     outcomes and that the fix works precisely by switching to [Handled]. *)
+  let tool_name = "test_validation_observer_dropped_tool" in
+  Masc_mcp.Tool_metrics.clear ();
+  Tool_dispatch.clear_hooks ();
+  Masc_mcp.Tool_metrics.install ();
+  (* No_handler with a result option still does not match [Handled, Some _]. *)
+  Tool_dispatch.run_dispatch_observers Dispatch_outcome.No_handler None;
+  Tool_dispatch.clear_hooks ();
+  match Masc_mcp.Tool_metrics.stats_for tool_name with
+  | None -> ()
+  | Some _ -> fail "No_handler outcome must not be recorded by Tool_metrics"
+;;
+
+let test_policy_rejection_class_survives () =
+  let tool_name = "test_validation_observer_class_tool" in
+  let result = mk_validation_failure ~tool_name in
+  match Tool_result.failure_class result with
+  | Some Tool_result.Policy_rejection -> ()
+  | Some other ->
+    failf
+      "expected Policy_rejection failure class, got %s"
+      (Tool_result.tool_failure_class_to_string other)
+  | None -> fail "validation failure must carry a failure class"
+;;
+
+let () =
+  run
+    "dispatch-observer-validation-failure"
+    [ ( "observer fan-out"
+      , [ test_case
+            "validation failure recorded by Tool_metrics"
+            `Quick
+            test_validation_failure_recorded_by_metrics
+        ; test_case
+            "non-Handled outcome is dropped"
+            `Quick
+            test_handler_error_shape_is_dropped
+        ; test_case
+            "Policy_rejection class survives"
+            `Quick
+            test_policy_rejection_class_survives
+        ] )
+    ]
+;;

--- a/test/test_dispatch_outcome_total.ml
+++ b/test/test_dispatch_outcome_total.ml
@@ -1,19 +1,21 @@
 open Alcotest
 
-(** RFC-0084 PR-10 — Typed Dispatch_outcome.t 5-arm sum invariants.
+(** RFC-0084 PR-10 — Typed Dispatch_outcome.t sum invariants.
 
     Pins:
-    - 5 variant arms exactly (cardinality drift guard)
+    - 2 variant arms exactly (cardinality drift guard). The sum was
+      collapsed from 5 to 2 arms after the dropped arms
+      (Rejected_by_capability / Rejected_by_pre_hook / Handler_error)
+      were confirmed to have zero producers.
     - Round-trip: every arm.to_string |> of_string |> to_string preserves the label
-    - classify_result_option matches the string-outcome contract used
-      by PR-7/PR-8/PR-9 wraps
-    - String vocabulary parity with PR-7~9 (handled / no_handler)
+    - classify_result_option matches the string-outcome contract
+    - String vocabulary parity (handled / no_handler)
 *)
 
 let test_all_arms_cardinality () =
   (check int)
-    "Dispatch_outcome.all_arms enumerates 5 variants (RFC-0084 §6 D3)"
-    5
+    "Dispatch_outcome.all_arms enumerates 2 variants (RFC-0084 §6 D3)"
+    2
     (List.length Dispatch_outcome.all_arms)
 ;;
 
@@ -21,16 +23,9 @@ let test_to_string_labels () =
   let labels =
     List.map Dispatch_outcome.to_string Dispatch_outcome.all_arms
   in
-  let expected =
-    [ "handled"
-    ; "rejected_by_capability"
-    ; "rejected_by_pre_hook"
-    ; "no_handler"
-    ; "handler_error"
-    ]
-  in
+  let expected = [ "handled"; "no_handler" ] in
   (check (list string))
-    "to_string vocabulary matches the 5-arm label set"
+    "to_string vocabulary matches the 2-arm label set"
     expected
     labels
 ;;
@@ -78,22 +73,10 @@ let test_classify_none_is_no_handler () =
       (Dispatch_outcome.to_string other)
 ;;
 
-let test_classify_with_exn_is_handler_error () =
-  match
-    Dispatch_outcome.classify_result_option ~exn:"oops" (Some 1)
-  with
-  | Dispatch_outcome.Handler_error { exn } ->
-    (check string) "exn payload propagated" "oops" exn
-  | other ->
-    failf
-      "classify_result_option ~exn:... should be Handler_error, got %s"
-      (Dispatch_outcome.to_string other)
-;;
-
-let test_string_vocabulary_parity_with_pr7_8_9 () =
-  (* PR-7 / PR-8 / PR-9 wraps emit outcome strings "handled" and "no_handler".
-     Both must remain valid arms in the typed sum so PR-11 migration
-     does not change the prometheus counter label set. *)
+let test_string_vocabulary_parity () =
+  (* Dispatch wraps emit outcome strings "handled" and "no_handler".
+     Both must remain valid arms in the typed sum so the prometheus
+     counter label set is preserved. *)
   (check bool)
     "handled present in typed sum"
     true
@@ -114,8 +97,7 @@ let () =
         ; test_case "of-string-unknown-returns-none" `Quick test_of_string_unknown_returns_none
         ; test_case "classify-some-is-handled" `Quick test_classify_some_is_handled
         ; test_case "classify-none-is-no-handler" `Quick test_classify_none_is_no_handler
-        ; test_case "classify-with-exn-is-handler-error" `Quick test_classify_with_exn_is_handler_error
-        ; test_case "string-vocabulary-parity-with-pr7-8-9" `Quick test_string_vocabulary_parity_with_pr7_8_9
+        ; test_case "string-vocabulary-parity" `Quick test_string_vocabulary_parity
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary

Fixes a HIGH-severity silent-failure in the OAS tool-dispatch observer fan-out, and
collapses the `Dispatch_outcome.t` sum from 5 arms to the 2 arms the system actually
produces.

## Bug B — OAS validation failures dropped from the unified observer view (HIGH)

`Keeper_tools_oas_handler.make_keeper_tool_handler` fired the shared dispatch observers
with `Dispatch_outcome.Handler_error { exn = "validation_failed" }` when OAS input
validation failed. All three registered dispatch observers
(`Tool_metrics`, `Tool_usage_log`, `Otel_dispatch_hook`) match only `Handled, Some _`
and discard everything else via `| _ -> ()`. So OAS validation failures never reached
the unified dispatch-observer view. The code comment claimed "metrics / usage_log still
see it" — that was false.

The exec error path already emits `Handled (Some error_result)` for an error result
(`keeper_tools_oas_handler_exec.ml`) and does reach the observers; the validation-failure
sibling was the inconsistent one.

Fix: emit `Dispatch_outcome.Handled (Some validation_result)` — the same shape as the
exec error path — so the failure is recorded. The rejection class
(`Tool_result.Policy_rejection`, set by `Tool_input_validation.validate_args`) rides in
`validation_result`, so observers that inspect `Tool_result.failure_class` can still
distinguish a validation rejection. The false comment was replaced with an accurate one.

## Anti-pattern A — dead typed variant collapse (CLAUDE.md anti-pattern #4)

`Dispatch_outcome.t` declared 5 arms but the dispatch paths only ever produce 2.
Verified with `rg` that the other three had zero producers:

- `Rejected_by_capability`: zero producers (no capability gate constructs it; capability
  rejection returns an error result classified `Handled`).
- `Rejected_by_pre_hook`: zero producers (a pre-hook `Reject` becomes `Some error`,
  classified `Handled` in `guarded_dispatch`).
- `Handler_error`: the only producer was bug B's site (just changed to `Handled`); the
  `classify_result_option ~exn` path that returns it is invoked only from a test.

Collapsed `Dispatch_outcome.t` to `Handled | No_handler`, removed the dead arms and their
`to_string` / `of_string` / `all_arms` entries, dropped the now-unused `?exn` parameter
from `classify_result_option`, and corrected the aspirational `.mli` text and the
`tool_dispatch.ml` observer doc comment that enumerated all five arms. The observers'
`| _ -> ()` now covers only `No_handler`. `Handled` stays nullary — the result continues
to ride in the separate `Tool_result.result option` argument (no signature change).

## Verification

- `dune build @check --root .` = 0
- `dune build lib/masc_mcp.cmxa --root .` = 0
- New focused test `test/test_dispatch_observer_validation_failure.ml`: an OAS
  validation failure delivered as `Handled (Some r)` is now recorded by the `Tool_metrics`
  observer (`failure_count = 1`); a non-`Handled` outcome is still dropped; the
  `Policy_rejection` class survives. PASS (3 tests).
- `test_dispatch_outcome_total.ml` updated for the 2-arm cardinality. PASS (7 tests).
- No regression on the exec success/error paths: `test_tool_dispatch_emit` (3),
  `test_tool_hooks` (10), `test_tool_metrics` (6) all PASS — they continue to fire
  `Handled` correctly.

WORKAROUND-WAIVED: fixes a silent-failure observer drop + removes dead variant arms

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
