### PR TITLE
Fix required-tool TLA anchor

### DIFF
--- a/specs/keeper-state-machine/KeeperToolSurface.tla
+++ b/specs/keeper-state-machine/KeeperToolSurface.tla
@@ -30,7 +30,7 @@
 \*   floor_fired             | fallback-floor conditional fires (sets tool_surface_fallback_used = true)          | lib/keeper/keeper_run_tools_hooks.ml:compute_tool_surface
 \*   after_floor             | all_allowed after the fallback floor                                               | lib/keeper/keeper_run_tools_hooks.ml:compute_tool_surface
 \*   after_last_turn_safe    | Intersect_with safe_last_turn_tools (when is_last_turn)                            | lib/keeper/keeper_run_tools_hooks.ml:compute_tool_surface
-\*   after_passive           | contract_enforcement_filter output (invoked from compute_tool_surface)            | lib/keeper/keeper_tool_selection.ml:contract_enforcement_filter
+\*   after_passive           | provider required-tool satisfaction does not filter passive tools                  | lib/keeper/keeper_tool_progress.ml:required_tool_satisfaction
 \*   emitted                 | all_allowed final return — max_tools truncation (essential / non_essential split)  | lib/keeper/keeper_run_tools_hooks.ml:compute_tool_surface
 \*   required                | outstanding_required_tool_names (post-satisfaction required set)                   | lib/keeper/keeper_run_tools_hooks.ml:compute_tool_surface
 \*
@@ -74,7 +74,7 @@ VARIABLES
     after_floor,            \* SUBSET Tools — after the floor stage
     after_last_turn_safe,   \* SUBSET Tools — after the last-turn-safe intersect
     is_last_turn,           \* BOOLEAN — whether the last-turn-safe stage runs
-    after_passive,          \* SUBSET Tools — after contract_enforcement_filter
+    after_passive,          \* SUBSET Tools — after provider required-tool satisfaction
     emitted,                \* SUBSET Tools — final pipeline output (after truncation)
     step                    \* action count
 
@@ -172,7 +172,7 @@ ComputePipeline ==
        \*   - the validate_allow_list gate + merged-tools step in
        \*     compute_tool_surface ensures required
        \*     (post validate_allow_list) is in pre_floor.
-\*   - the Keeper_tool_selection.contract_enforcement_filter call
+\*   - the Keeper_tool_progress.required_tool_satisfaction boundary
        \*     (from compute_tool_surface) does not drop required-affordanced tools.
        \*   - the safe_last_turn_tools construction in compute_tool_surface
        \*     includes required-affordanced tools when is_last_turn fires.


### PR DESCRIPTION
## Summary
- update KeeperToolSurface TLA symbol anchor after required-tool satisfaction moved to Keeper_tool_progress
- remove stale contract_enforcement_filter wording from the spec comments

## Verification
- bash scripts/lint/spec-line-refs.sh
- rg -n "contract_enforcement_filter" specs/keeper-state-machine/KeeperToolSurface.tla
- git diff --check