### PR TITLE
chore(runtime): delete dead supports_parallel_tool_calls config field

### DIFF
--- a/lib/runtime/runtime_schema.ml
+++ b/lib/runtime/runtime_schema.ml
@@ -93,7 +93,6 @@ type thinking_control_format =
     duplicated here, to avoid two-SSOT drift. *)
 type model_capabilities =
   { max_output_tokens : int option
-  ; supports_parallel_tool_calls : bool
   ; supports_tool_choice : bool
   ; supports_extended_thinking : bool
   ; supports_reasoning_budget : bool
@@ -118,7 +117,6 @@ type model_capabilities =
 
 let model_capabilities_default =
   { max_output_tokens = None
-  ; supports_parallel_tool_calls = false
   ; supports_tool_choice = false
   ; supports_extended_thinking = false
   ; supports_reasoning_budget = false

--- a/lib/runtime/runtime_schema.mli
+++ b/lib/runtime/runtime_schema.mli
@@ -67,7 +67,6 @@ type thinking_control_format =
 
 type model_capabilities =
   { max_output_tokens : int option
-  ; supports_parallel_tool_calls : bool
   ; supports_tool_choice : bool
   ; supports_extended_thinking : bool
   ; supports_reasoning_budget : bool

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -302,7 +302,6 @@ let parse_model_capabilities ~(path : string) (tbl : Otoml.t)
     | Some raw -> parse_thinking_control_format ~path raw
   in
   { Runtime_schema.max_output_tokens = positive_int_opt_field "max-output-tokens"
-  ; supports_parallel_tool_calls = b "supports-parallel-tool-calls"
   ; supports_tool_choice = b "supports-tool-choice"
   ; supports_extended_thinking = b "supports-extended-thinking"
   ; supports_reasoning_budget = b "supports-reasoning-budget"


### PR DESCRIPTION
## What

Delete the dead runtime-config field `supports_parallel_tool_calls`.

## The dead field

`supports_parallel_tool_calls` is a `model_capabilities` field that is parsed and defaulted but **never read by any consumer**:

- defined: `lib/runtime/runtime_schema.ml:96` + `runtime_schema.mli:70`
- defaulted (`false`): `lib/runtime/runtime_schema.ml:121` (`model_capabilities_default`)
- parsed: `lib/runtime/runtime_toml.ml:305` (key `supports-parallel-tool-calls`)

The only field-level reader of `model_capabilities` is `runtime.ml` `runtime_supports_required_tools`, which reads `supports_tool_choice` — never this field. No TOML in the repo sets the `supports-parallel-tool-calls` key. The type's own doc comment says it mirrors OAS `Llm_provider.Capabilities` "for the fields callers branch on"; this field is never branched on, so it is a vestigial mirror field.

## Why delete, not wire

Wiring this field into `disable_parallel_tool_use` would **regress**. Its default is `false`, so wiring it in would disable the parallel read-only tool batching that currently works. Deletion is behavior-preserving because the field does nothing today.

## Preserved (not the dead field)

`runtime_wire_overlay.ml:40` has a same-named field, but it reads `Llm_provider.Capabilities` (the OAS provider-capabilities type) and writes `Agent_sdk.Provider.capabilities`. That mapping is unrelated to the runtime config field and is preserved. The audit that flagged this field listed `wire_overlay.ml:40` as its "forward-copy reader"; that is actually a different same-named field on the OAS→Agent_sdk capability mapping, not the runtime config field.

## Verification

- `dune build @check --root .` = 0
- `dune build lib/masc_mcp.cmxa --root .` = 0 (library `(name masc_mcp)` after the `masc_mcp → masc` public_name rename)
- `rg supports_parallel_tool_calls lib/ test/` returns only the OAS `wire_overlay` mapping
- `test_runtime_required_tool_fallback` passes (3 tests)
- The 8 `test_keeper_runtime_toml` failures are pre-existing on the base commit `0ee897eca1` (verified by stashing this change and rerunning — identical 8 failures); they concern keeper boot/turn-cost overrides and parse-error cases, unrelated to this deletion.
