### PR TITLE
refactor(tool): cut domain vocabulary out of the Tool substrate type structure

### DIFF
--- a/lib/governance_pipeline_risk.ml
+++ b/lib/governance_pipeline_risk.ml
@@ -145,30 +145,36 @@ let classify_name name =
 
 let risk_of_masc (m : Tool_name.Masc.t) : risk_level =
   let open Tool_name.Masc in
-  (* PR-S1: domain tool names moved to Task/Board/Goal/Operator submodules.
-     Risk classification is NON-uniform across each domain (e.g. Board_delete
-     is Critical but Board_list is Low), so this match stays flat over
-     [Masc.t] with each domain constructor mechanically wrapped — the bucket
-     groupings are byte-for-byte unchanged from before the partition, and the
-     compiler still enforces exhaustiveness over every variant. *)
+  let open Tool_name.Domain_tool in
+  (* PR-S2: domain tool names are carried behind one neutral [Domain] arm
+     ([Domain (Board _)] etc.). Risk classification is NON-uniform across each
+     domain (e.g. Board_delete is Critical but Board_list is Low), so this
+     consumer reaches the domain members through the neutral carrier and keeps
+     its flat per-member buckets — byte-for-byte unchanged behavior, with the
+     compiler still enforcing exhaustiveness over every variant. *)
   match m with
-  | Task Add_task | Agent_fitness | Agent_card | Agents | Task Batch_add_tasks
-  | Board Board_cleanup | Board Board_comment | Board Board_comment_vote | Board Board_curation_read
-  | Board Board_curation_submit | Board Board_get | Board Board_hearths | Board Board_list | Board Board_post
-  | Board Board_profile | Board Board_reaction | Board Board_search | Board Board_stats | Board Board_vote
-  | Board Board_sub_board_get | Board Board_sub_board_list | Broadcast | Check
-  | Cleanup_zombies | Dashboard | Deliver | Goal Goal_list | Goal Goal_transition
-  | Heartbeat | Messages | Note_add | Operator Operator_action | Operator Operator_digest
-  | Operator Operator_snapshot | Plan_clear_task | Plan_get | Plan_get_task | Plan_init
-  | Plan_set_task | Status | Task Task_history | Task Tasks | Tool_grant | Tool_help
-  | Tool_list | Tool_revoke | Task Transition | Web_fetch | Web_search
+  | Domain (Task Add_task) | Agent_fitness | Agent_card | Agents | Domain (Task Batch_add_tasks)
+  | Domain (Board Board_cleanup) | Domain (Board Board_comment) | Domain (Board Board_comment_vote)
+  | Domain (Board Board_curation_read)
+  | Domain (Board Board_curation_submit) | Domain (Board Board_get) | Domain (Board Board_hearths)
+  | Domain (Board Board_list) | Domain (Board Board_post)
+  | Domain (Board Board_profile) | Domain (Board Board_reaction) | Domain (Board Board_search)
+  | Domain (Board Board_stats) | Domain (Board Board_vote)
+  | Domain (Board Board_sub_board_get) | Domain (Board Board_sub_board_list) | Broadcast | Check
+  | Cleanup_zombies | Dashboard | Deliver | Domain (Goal Goal_list) | Domain (Goal Goal_transition)
+  | Heartbeat | Messages | Note_add | Domain (Operator Operator_action) | Domain (Operator Operator_digest)
+  | Domain (Operator Operator_snapshot) | Plan_clear_task | Plan_get | Plan_get_task | Plan_init
+  | Plan_set_task | Status | Domain (Task Task_history) | Domain (Task Tasks) | Tool_grant | Tool_help
+  | Tool_list | Tool_revoke | Domain (Task Transition) | Web_fetch | Web_search
   | Approval_pending | Approval_get | Config | Gc | Get_metrics | Mcp_session
   | Tool_admin_snapshot | Tool_stats -> Low
-  | Task Claim_next | Goal Goal_upsert | Goal Goal_verify | Operator Operator_confirm
+  | Domain (Task Claim_next) | Domain (Goal Goal_upsert) | Domain (Goal Goal_verify)
+  | Domain (Operator Operator_confirm)
   | Pause | Resume | Start -> Medium
-  | Agent_update | Board Board_sub_board_create | Board Board_sub_board_update | Plan_update
-  | Task Update_priority | Tool_admin_update -> High
-  | Board Board_delete | Board Board_sub_board_delete | Reset -> Critical
+  | Agent_update | Domain (Board Board_sub_board_create) | Domain (Board Board_sub_board_update)
+  | Plan_update
+  | Domain (Task Update_priority) | Tool_admin_update -> High
+  | Domain (Board Board_delete) | Domain (Board Board_sub_board_delete) | Reset -> Critical
 ;;
 
 let risk_of_typed : Tool_name.t -> risk_level = function
@@ -343,7 +349,7 @@ let baseline_risk ~tool_name ~input =
         goal_transition_risk input
       else if
         String.equal tool_name
-          (Tool_name.Masc.to_string (Tool_name.Masc.Task Tool_name.Task_name.Transition))
+          (Tool_name.Task_name.to_string Tool_name.Task_name.Transition)
       then (
         (* transition risk depends on the action verb, not the tool name *)
         match transition_action input with

--- a/lib/keeper/keeper_tool_capability_axis.ml
+++ b/lib/keeper/keeper_tool_capability_axis.ml
@@ -28,7 +28,7 @@ let candidate_names name =
 ;;
 
 let claim_task_tool_names =
-  [ "keeper_task_claim"; masc_name (Tool_name.Masc.Task Tool_name.Task_name.Claim_next) ]
+  [ "keeper_task_claim"; Tool_name.Task_name.to_string Tool_name.Task_name.Claim_next ]
 ;;
 
 let board_activity_tool_names =

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -193,9 +193,7 @@ let keeper_supported_masc_schemas (schemas : Masc_domain.tool_schema list) =
      author/voter fields. Exposing both leads to the LLM calling the raw
      masc_* variant without the required author, causing "author is required". *)
   let has_keeper_board_wrapper name =
-    let eq v =
-      String.equal name (Tool_name.Masc.to_string (Tool_name.Masc.Board v))
-    in
+    let eq v = String.equal name (Tool_name.Board_name.to_string v) in
     eq Tool_name.Board_name.Board_comment
     || eq Tool_name.Board_name.Board_curation_submit
     || eq Tool_name.Board_name.Board_post

--- a/lib/keeper/keeper_tool_progress.ml
+++ b/lib/keeper/keeper_tool_progress.ml
@@ -54,7 +54,7 @@ let effect_of_progress_class = function
 ;;
 
 let claim_context_tool_names : string list =
-  [ Tool_name.(to_string (Masc (Masc.Task Task_name.Claim_next)))
+  [ Tool_name.Task_name.to_string Tool_name.Task_name.Claim_next
   ; Keeper_tool_name.(to_string Task_claim)
   ]
 ;;
@@ -86,7 +86,10 @@ let is_claim_tool_name name =
    | Some Task_claim -> true
    | _ -> false)
   || (match Tool_name.of_string name with
-      | Some (Tool_name.Masc (Tool_name.Masc.Task Tool_name.Task_name.Claim_next)) ->
+      | Some
+          (Tool_name.Masc
+             (Tool_name.Masc.Domain
+                (Tool_name.Domain_tool.Task Tool_name.Task_name.Claim_next))) ->
         true
       | _ -> false)
 ;;

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -244,15 +244,15 @@ let reconcile_safe_tools =
       ; Task_done
       ]
   @ List.map
-      Tool_name.to_string
-      Tool_name.
-        [ Masc (Masc.Board Board_name.Board_post)
-        ; Masc (Masc.Board Board_name.Board_comment)
-        ; Masc (Masc.Board Board_name.Board_vote)
-        ; Masc (Masc.Board Board_name.Board_comment_vote)
-        ; Masc (Masc.Board Board_name.Board_curation_submit)
-        ; Masc Broadcast
+      Tool_name.Board_name.to_string
+      Tool_name.Board_name.
+        [ Board_post
+        ; Board_comment
+        ; Board_vote
+        ; Board_comment_vote
+        ; Board_curation_submit
         ]
+  @ [ Tool_name.to_string (Tool_name.Masc Tool_name.Masc.Broadcast) ]
 ;;
 
 let reconcile_safe_set : (string, unit) Hashtbl.t =

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -501,12 +501,11 @@ let start_keeper_loops
   Keeper_subprocess_registry.register_default_cleanup_hook ();
   (* Build read-only tool surface shared by both judges. *)
   let judge_tool_names =
-    List.map
-      Tool_name.Masc.to_string
-      Tool_name.Masc.
-        [ Status; Task Tool_name.Task_name.Tasks; Agents
-        ; Board Tool_name.Board_name.Board_list
-        ]
+    [ Tool_name.Masc.to_string Tool_name.Masc.Status
+    ; Tool_name.Task_name.to_string Tool_name.Task_name.Tasks
+    ; Tool_name.Masc.to_string Tool_name.Masc.Agents
+    ; Tool_name.Board_name.to_string Tool_name.Board_name.Board_list
+    ]
   in
   let judge_masc_tools =
     match Keeper_tool_surfaces.local_worker_tool_schemas ~names:judge_tool_names () with

--- a/lib/tool/tool_catalog_inference.ml
+++ b/lib/tool/tool_catalog_inference.ml
@@ -13,7 +13,11 @@ module List = Stdlib.List
     Moving it out shrinks the facade and isolates churn when new
     [Tool_name] variants are added. *)
 
-type effect_domain =
+(* PR-S2 (tool⊥domain cut): [effect_domain] is defined in the zero-dep leaf
+   [Tool_tag_types] so the domain side ([Tool_name.Domain_tool]) can produce it.
+   Re-exported here by type-equality so the facade [Tool_catalog] and the public
+   [tool_catalog.mli] / this module's [.mli] are unchanged. *)
+type effect_domain = Tool_tag_types.effect_domain =
   | Read_only
   | Masc_workspace
   | Playground_write
@@ -28,81 +32,44 @@ let effect_domain_to_string = function
 module TN = Tool_name
 module TM = Tool_name.Masc
 
-(* PR-S1: domain tool names live in these submodules; [TM.Task]/[TM.Board]/
-   [TM.Goal]/[TM.Operator] wrap them into [Masc.t]. *)
-module TTask = Tool_name.Task_name
-module TBoard = Tool_name.Board_name
-module TGoal = Tool_name.Goal_name
-module TOp = Tool_name.Operator_name
-
-(* PR-S1: NON-uniform across each domain (Board members split Read_only vs
-   Masc_workspace; Operator members split three ways), so this match stays flat
-   over [Masc.t] with each domain constructor mechanically wrapped — bucket
-   groupings unchanged, exhaustiveness still enforced. *)
+(* PR-S2: domain tool names are carried behind one neutral [TM.Domain] arm; the
+   per-member effect classification (NON-uniform: Board splits Read_only vs
+   Masc_workspace; Operator splits three ways) is owned domain-side by
+   [Tool_name.Domain_tool.effect_domain]. The substrate no longer enumerates any
+   domain constructor (Task/Board/Goal/Operator). The flat admin/lifecycle/misc
+   names keep their explicit buckets here. *)
 let inferred_effect_domain_of_typed_tool_name = function
+  | TN.Masc (TM.Domain d) -> Some (Tool_name.Domain_tool.effect_domain d)
   | TN.Masc TM.Deliver
-  | TN.Masc (TM.Operator TOp.Operator_action)
   | TN.Masc TM.Start ->
       Some Host_repo_write
   | TN.Masc TM.Agent_fitness
   | TN.Masc TM.Agent_card
   | TN.Masc TM.Agents
-  | TN.Masc (TM.Board TBoard.Board_get)
-  | TN.Masc (TM.Board TBoard.Board_curation_read)
-  | TN.Masc (TM.Board TBoard.Board_hearths)
-  | TN.Masc (TM.Board TBoard.Board_list)
-  | TN.Masc (TM.Board TBoard.Board_profile)
-  | TN.Masc (TM.Board TBoard.Board_search)
-  | TN.Masc (TM.Board TBoard.Board_stats)
   | TN.Masc TM.Check
   | TN.Masc TM.Config
   | TN.Masc TM.Dashboard
   | TN.Masc TM.Get_metrics
-  | TN.Masc (TM.Goal TGoal.Goal_list)
   | TN.Masc TM.Mcp_session
   | TN.Masc TM.Messages
-  | TN.Masc (TM.Operator TOp.Operator_digest)
-  | TN.Masc (TM.Operator TOp.Operator_snapshot)
   | TN.Masc TM.Plan_get
   | TN.Masc TM.Plan_get_task
   | TN.Masc TM.Status
-  | TN.Masc (TM.Task TTask.Task_history)
-  | TN.Masc (TM.Task TTask.Tasks)
   | TN.Masc TM.Tool_admin_snapshot
   | TN.Masc TM.Tool_help
   | TN.Masc TM.Tool_list
   | TN.Masc TM.Tool_stats
   | TN.Masc TM.Web_fetch
   | TN.Masc TM.Web_search
-  | TN.Masc (TM.Board TBoard.Board_sub_board_get)
-  | TN.Masc (TM.Board TBoard.Board_sub_board_list)
   | TN.Masc TM.Approval_pending
   | TN.Masc TM.Approval_get ->
       Some Read_only
-  | TN.Masc (TM.Task TTask.Add_task)
   | TN.Masc TM.Agent_update
-  | TN.Masc (TM.Task TTask.Batch_add_tasks)
-  | TN.Masc (TM.Board TBoard.Board_cleanup)
-  | TN.Masc (TM.Board TBoard.Board_comment)
-  | TN.Masc (TM.Board TBoard.Board_comment_vote)
-  | TN.Masc (TM.Board TBoard.Board_curation_submit)
-  | TN.Masc (TM.Board TBoard.Board_delete)
-  | TN.Masc (TM.Board TBoard.Board_post)
-  | TN.Masc (TM.Board TBoard.Board_reaction)
-  | TN.Masc (TM.Board TBoard.Board_sub_board_create)
-  | TN.Masc (TM.Board TBoard.Board_sub_board_delete)
-  | TN.Masc (TM.Board TBoard.Board_sub_board_update)
-  | TN.Masc (TM.Board TBoard.Board_vote)
   | TN.Masc TM.Broadcast
-  | TN.Masc (TM.Task TTask.Claim_next)
   | TN.Masc TM.Cleanup_zombies
   | TN.Masc TM.Gc
-  | TN.Masc (TM.Goal TGoal.Goal_transition)
-  | TN.Masc (TM.Goal TGoal.Goal_upsert)
-  | TN.Masc (TM.Goal TGoal.Goal_verify)
   | TN.Masc TM.Heartbeat
   | TN.Masc TM.Note_add
-  | TN.Masc (TM.Operator TOp.Operator_confirm)
   | TN.Masc TM.Pause
   | TN.Masc TM.Plan_clear_task
   | TN.Masc TM.Plan_init
@@ -112,9 +79,7 @@ let inferred_effect_domain_of_typed_tool_name = function
   | TN.Masc TM.Resume
   | TN.Masc TM.Tool_admin_update
   | TN.Masc TM.Tool_grant
-  | TN.Masc TM.Tool_revoke
-  | TN.Masc (TM.Task TTask.Transition)
-  | TN.Masc (TM.Task TTask.Update_priority) ->
+  | TN.Masc TM.Tool_revoke ->
       Some Masc_workspace
 let inferred_effect_domain name =
   match Tool_name.of_string name with

--- a/lib/tool/tool_dispatch.ml
+++ b/lib/tool/tool_dispatch.ml
@@ -260,7 +260,11 @@ let is_registered name = Hashtbl.mem registry name
     Known tool names map to module tags through a compile-time match or the
     tag registry. Handler registration does not authorize tool names. *)
 
-type module_tag =
+(* PR-S2 (tool⊥domain cut): [module_tag] is defined in the zero-dep leaf
+   [Tool_tag_types] so the domain side ([Tool_name.Domain_tool]) can produce it.
+   Re-exported here by type-equality, so external [Tool_dispatch.Mod_*] call
+   sites and [tool_dispatch.mli] are unchanged. *)
+type module_tag = Tool_tag_types.module_tag =
   | Mod_plan | Mod_operator
   | Mod_local_runtime
   | Mod_run
@@ -276,18 +280,11 @@ let static_tag_of_tool_name (tool : Tool_name.t) : module_tag option =
   | Tool_name.Masc m ->
     let open Tool_name.Masc in
     match m with
-    (* Domain tool-NAME groups collapse to a single tag each: the substrate no
-       longer enumerates the per-operation names. Tag alignment proof (PR-S1):
-       every member of each domain submodule mapped to the same tag before the
-       partition, so [| Domain _ ->] is exact, not a downgrade.
-         Task     -> Mod_task     (was 7 arms, all Mod_task)
-         Board    -> Mod_inline   (was 20 Board_* arms, all Mod_inline)
-         Goal     -> Mod_state    (was 4 Goal_* arms, all Mod_state)
-         Operator -> Mod_operator (was 4 Operator_* arms, all Mod_operator) *)
-    | Task _ -> Some Mod_task
-    | Board _ -> Some Mod_inline
-    | Goal _ -> Some Mod_state
-    | Operator _ -> Some Mod_operator
+    (* Domain tool names are carried behind one neutral arm; the domain side
+       owns the per-domain tag. The substrate no longer enumerates any domain
+       constructor (Task/Board/Goal/Operator). Per-domain tags are unchanged:
+       Task->Mod_task, Board->Mod_inline, Goal->Mod_state, Operator->Mod_operator. *)
+    | Domain d -> Some (Tool_name.Domain_tool.module_tag d)
     | Agent_fitness
     | Agent_card
     | Agent_update

--- a/lib/tool/tool_name.ml
+++ b/lib/tool/tool_name.ml
@@ -187,16 +187,124 @@ module Operator_name = struct
   let pp fmt t = Format.pp_print_string fmt (to_string t)
 end
 
-module Masc = struct
-  (* Domain tool-NAME operations (Task/Board/Goal/Operator) are owned by the
-     domain submodules above; [Masc.t] composes them rather than enumerating
-     each operation flat. The remaining variants are admin/lifecycle/misc
-     tool names that have no domain owner yet and stay flat here. *)
+(** Domain_tool — the single domain-owned grouping of Task/Board/Goal/Operator
+    tool names, together with the substrate classifications each domain attaches
+    to its members.
+
+    PR-S2 (tool⊥domain cut): the Tool substrate must not enumerate domain
+    constructors. This module is the ONLY place that destructures
+    [Task]/[Board]/[Goal]/[Operator]; [Masc.t] carries it behind one neutral
+    arm ([Domain of Domain_tool.t]), and [Tool_dispatch]/[Tool_catalog_inference]
+    consume it through [module_tag]/[effect_domain] without spelling any domain
+    constructor. The [module_tag] / [effect_domain] result types live in the
+    zero-dep leaf [Tool_tag_types], re-exported by the substrate by
+    type-equality so external call sites and [.mli] contracts are unchanged.
+
+    Every [masc_*] wire string is preserved: [to_string]/[of_string] delegate to
+    the domain submodules, which own the complete strings. *)
+module Domain_tool = struct
   type t =
     | Task of Task_name.t
     | Board of Board_name.t
     | Goal of Goal_name.t
     | Operator of Operator_name.t
+
+  let to_string = function
+    | Task t -> Task_name.to_string t
+    | Board b -> Board_name.to_string b
+    | Goal g -> Goal_name.to_string g
+    | Operator o -> Operator_name.to_string o
+  ;;
+
+  let of_string s =
+    (* Domain submodules are tried in turn; each returns [None] for names it
+       does not own. The string namespaces are disjoint, so order is
+       irrelevant for correctness. *)
+    match Task_name.of_string s with
+    | Some t -> Some (Task t)
+    | None ->
+      match Board_name.of_string s with
+      | Some b -> Some (Board b)
+      | None ->
+        match Goal_name.of_string s with
+        | Some g -> Some (Goal g)
+        | None ->
+          match Operator_name.of_string s with
+          | Some o -> Some (Operator o)
+          | None -> None
+  ;;
+
+  let is_board = function
+    | Board _ -> true
+    | Task _ | Goal _ | Operator _ -> false
+  ;;
+
+  (* Dispatch routing tag. Uniform per domain: every member of a domain maps to
+     the same tag (Tag alignment proof, PR-S1):
+       Task     -> Mod_task     (was 7 arms, all Mod_task)
+       Board    -> Mod_inline   (was 20 Board_* arms, all Mod_inline)
+       Goal     -> Mod_state    (was 4 Goal_* arms, all Mod_state)
+       Operator -> Mod_operator (was 4 Operator_* arms, all Mod_operator) *)
+  let module_tag : t -> Tool_tag_types.module_tag = function
+    | Task _ -> Tool_tag_types.Mod_task
+    | Board _ -> Tool_tag_types.Mod_inline
+    | Goal _ -> Tool_tag_types.Mod_state
+    | Operator _ -> Tool_tag_types.Mod_operator
+  ;;
+
+  (* Inferred effect classification. NON-uniform within Board (Read_only vs
+     Masc_workspace) and Operator (three ways), so the mapping is per-member.
+     Transcribed member-for-member from the prior flat match in
+     [tool_catalog_inference]; exhaustiveness is compiler-enforced. *)
+  let effect_domain : t -> Tool_tag_types.effect_domain = function
+    | Operator Operator_name.Operator_action -> Tool_tag_types.Host_repo_write
+    | Board Board_name.Board_get
+    | Board Board_name.Board_curation_read
+    | Board Board_name.Board_hearths
+    | Board Board_name.Board_list
+    | Board Board_name.Board_profile
+    | Board Board_name.Board_search
+    | Board Board_name.Board_stats
+    | Board Board_name.Board_sub_board_get
+    | Board Board_name.Board_sub_board_list
+    | Goal Goal_name.Goal_list
+    | Operator Operator_name.Operator_digest
+    | Operator Operator_name.Operator_snapshot
+    | Task Task_name.Task_history
+    | Task Task_name.Tasks -> Tool_tag_types.Read_only
+    | Task Task_name.Add_task
+    | Task Task_name.Batch_add_tasks
+    | Task Task_name.Claim_next
+    | Task Task_name.Transition
+    | Task Task_name.Update_priority
+    | Board Board_name.Board_cleanup
+    | Board Board_name.Board_comment
+    | Board Board_name.Board_comment_vote
+    | Board Board_name.Board_curation_submit
+    | Board Board_name.Board_delete
+    | Board Board_name.Board_post
+    | Board Board_name.Board_reaction
+    | Board Board_name.Board_sub_board_create
+    | Board Board_name.Board_sub_board_delete
+    | Board Board_name.Board_sub_board_update
+    | Board Board_name.Board_vote
+    | Goal Goal_name.Goal_transition
+    | Goal Goal_name.Goal_upsert
+    | Goal Goal_name.Goal_verify
+    | Operator Operator_name.Operator_confirm -> Tool_tag_types.Masc_workspace
+  ;;
+
+  let pp fmt t = Format.pp_print_string fmt (to_string t)
+end
+
+module Masc = struct
+  (* Domain tool-NAME operations (Task/Board/Goal/Operator) are owned by
+     [Domain_tool]; [Masc.t] carries them behind one neutral [Domain] arm so
+     the Tool substrate never enumerates domain constructors. The remaining
+     variants are admin/lifecycle/misc tool names that have no domain owner
+     and stay flat here. *)
+  type t =
+    | Domain of Domain_tool.t
     | Agent_fitness
     | Agent_update
     | Agent_card
@@ -237,10 +345,7 @@ module Masc = struct
     | Tool_stats
 
   let to_string = function
-    | Task t -> Task_name.to_string t
-    | Board b -> Board_name.to_string b
-    | Goal g -> Goal_name.to_string g
-    | Operator o -> Operator_name.to_string o
+    | Domain d -> Domain_tool.to_string d
     | Agent_fitness -> "masc_agent_fitness"
     | Agent_update -> "masc_agent_update"
     | Agent_card -> "masc_agent_card"
@@ -282,21 +387,13 @@ module Masc = struct
   ;;
 
   let of_string s =
-    (* Domain submodules are tried first; their [of_string] returns [None] for
-       non-domain names, so a flat fallthrough resolves the remainder. The
-       string namespaces are disjoint, so order is irrelevant for correctness. *)
-    match Task_name.of_string s with
-    | Some t -> Some (Task t)
+    (* Domain names resolve through [Domain_tool]; its [of_string] returns
+       [None] for non-domain names, so the flat fallthrough resolves the
+       remainder. The string namespaces are disjoint, so order is irrelevant
+       for correctness. *)
+    match Domain_tool.of_string s with
+    | Some d -> Some (Domain d)
     | None ->
-      match Board_name.of_string s with
-      | Some b -> Some (Board b)
-      | None ->
-        match Goal_name.of_string s with
-        | Some g -> Some (Goal g)
-        | None ->
-          match Operator_name.of_string s with
-          | Some o -> Some (Operator o)
-          | None ->
             match s with
             | "masc_agent_fitness" -> Some Agent_fitness
             | "masc_agent_update" -> Some Agent_update
@@ -340,7 +437,10 @@ module Masc = struct
   ;;
 
   let is_board = function
-    | Board _ -> true
+    | Domain d -> Domain_tool.is_board d
+    (* Flat admin/lifecycle/misc tool names are never board tools. The [Domain]
+       arm above is explicit, so this wildcard covers only the non-domain
+       admin variants — it does not mask a domain constructor. *)
     | _ -> false
   ;;
 

--- a/lib/tool/tool_name.mli
+++ b/lib/tool/tool_name.mli
@@ -74,12 +74,29 @@ module Operator_name : sig
   val pp : Stdlib.Format.formatter -> t -> unit
 end
 
-module Masc : sig
+(** Domain_tool — single domain-owned grouping of Task/Board/Goal/Operator tool
+    names plus the substrate classifications ([module_tag]/[effect_domain]) each
+    domain attaches. This is the only module that enumerates the domain
+    constructors; the substrate consumes it through these functions without
+    spelling any domain constructor. *)
+module Domain_tool : sig
   type t =
     | Task of Task_name.t
     | Board of Board_name.t
     | Goal of Goal_name.t
     | Operator of Operator_name.t
+
+  val to_string : t -> string
+  val of_string : string -> t option
+  val is_board : t -> bool
+  val module_tag : t -> Tool_tag_types.module_tag
+  val effect_domain : t -> Tool_tag_types.effect_domain
+  val pp : Stdlib.Format.formatter -> t -> unit
+end
+
+module Masc : sig
+  type t =
+    | Domain of Domain_tool.t
     | Agent_fitness
     | Agent_update
     | Agent_card

--- a/lib/tool/tool_tag_types.ml
+++ b/lib/tool/tool_tag_types.ml
@@ -1,0 +1,37 @@
+(** Tool_tag_types — neutral classification variants for the Tool substrate.
+
+    Zero-dependency leaf module. Holds the two pure nullary sums that the
+    domain side ([Tool_name.Domain_tool]) attaches to each tool and that the
+    substrate ([Tool_dispatch], [Tool_catalog_inference]) consumes:
+
+    - [module_tag]: dispatch routing tag.
+    - [effect_domain]: inferred effect classification.
+
+    PR-S2 (tool⊥domain cut): these types live below [Tool_name] so the domain
+    submodules can produce them. [Tool_dispatch] and [Tool_catalog_inference]
+    re-export them by type-equality, keeping their public contracts and all
+    [Tool_dispatch.Mod_*] / [Tool_catalog.<effect_domain>] call sites
+    byte-identical. *)
+
+type module_tag =
+  | Mod_plan
+  | Mod_operator
+  | Mod_local_runtime
+  | Mod_run
+  | Mod_compact
+  | Mod_agent
+  | Mod_task
+  | Mod_state
+  | Mod_control
+  | Mod_agent_timeline
+  | Mod_misc
+  | Mod_library
+  | Mod_external
+  | Mod_inline
+  | Mod_shard
+
+type effect_domain =
+  | Read_only
+  | Masc_workspace
+  | Playground_write
+  | Host_repo_write

--- a/lib/tool_inline_dispatch_workspace.ml
+++ b/lib/tool_inline_dispatch_workspace.ml
@@ -52,7 +52,7 @@ let inline_err_workflow ~tool_name ~start_time msg : Tool_result.result =
 ;;
 
 let masc_add_task_name =
-  Tool_name.Masc.to_string (Tool_name.Masc.Task Tool_name.Task_name.Add_task)
+  Tool_name.Task_name.to_string Tool_name.Task_name.Add_task
 
 (** Argument extraction helpers bound to ctx.arguments. *)
 let arg_get_string ctx key default =

--- a/lib/tool_resource_axis.ml
+++ b/lib/tool_resource_axis.ml
@@ -168,32 +168,33 @@ let classify_structured_shell_op args =
 
 let classify_masc_tool (tool : Tool_name.Masc.t) =
   let open Tool_name.Masc in
-  (* PR-S1: domain tool names moved to Task/Board/Goal/Operator submodules.
-     Resource classification is NON-uniform across each domain (e.g.
-     Board_post is Board_write but Board_list is Ungated), so this match stays
-     flat over [Masc.t] with each domain constructor mechanically wrapped —
-     bucket groupings are byte-for-byte unchanged from before the partition,
-     and the compiler still enforces exhaustiveness over every variant. *)
+  let open Tool_name.Domain_tool in
+  (* PR-S2: domain tool names are carried behind one neutral [Domain] arm
+     ([Domain (Board _)] etc.). Resource classification is NON-uniform across
+     each domain (e.g. Board_post is Board_write but Board_list is Ungated), so
+     this consumer reaches the domain members through the neutral carrier and
+     keeps its flat per-member buckets — byte-for-byte unchanged behavior, with
+     the compiler still enforcing exhaustiveness over every variant. *)
   match tool with
   | Web_fetch | Web_search -> Web
-  | Board Board_post
-  | Board Board_cleanup
-  | Board Board_comment
-  | Board Board_comment_vote
-  | Board Board_curation_submit
-  | Board Board_delete
-  | Board Board_reaction
-  | Board Board_sub_board_create
-  | Board Board_sub_board_delete
-  | Board Board_sub_board_update
-  | Board Board_vote -> Board_write
-  | Task Add_task
-  | Task Batch_add_tasks
-  | Task Claim_next
+  | Domain (Board Board_post)
+  | Domain (Board Board_cleanup)
+  | Domain (Board Board_comment)
+  | Domain (Board Board_comment_vote)
+  | Domain (Board Board_curation_submit)
+  | Domain (Board Board_delete)
+  | Domain (Board Board_reaction)
+  | Domain (Board Board_sub_board_create)
+  | Domain (Board Board_sub_board_delete)
+  | Domain (Board Board_sub_board_update)
+  | Domain (Board Board_vote) -> Board_write
+  | Domain (Task Add_task)
+  | Domain (Task Batch_add_tasks)
+  | Domain (Task Claim_next)
   | Deliver
-  | Goal Goal_transition
-  | Goal Goal_upsert
-  | Goal Goal_verify
+  | Domain (Goal Goal_transition)
+  | Domain (Goal Goal_upsert)
+  | Domain (Goal Goal_verify)
   | Heartbeat
   | Note_add
   | Plan_clear_task
@@ -203,46 +204,46 @@ let classify_masc_tool (tool : Tool_name.Masc.t) =
   | Reset
   | Tool_grant
   | Tool_revoke
-  | Task Transition
-  | Task Update_priority -> Workspace_write
+  | Domain (Task Transition)
+  | Domain (Task Update_priority) -> Workspace_write
   | Agent_update
   | Broadcast
   | Cleanup_zombies
   | Gc
-  | Operator Operator_action
-  | Operator Operator_confirm
+  | Domain (Operator Operator_action)
+  | Domain (Operator Operator_confirm)
   | Tool_admin_update -> Generic_write
   | Agent_card
   | Agent_fitness
   | Agents
   | Approval_get
   | Approval_pending
-  | Board Board_curation_read
-  | Board Board_get
-  | Board Board_hearths
-  | Board Board_list
-  | Board Board_profile
-  | Board Board_search
-  | Board Board_stats
-  | Board Board_sub_board_get
-  | Board Board_sub_board_list
+  | Domain (Board Board_curation_read)
+  | Domain (Board Board_get)
+  | Domain (Board Board_hearths)
+  | Domain (Board Board_list)
+  | Domain (Board Board_profile)
+  | Domain (Board Board_search)
+  | Domain (Board Board_stats)
+  | Domain (Board Board_sub_board_get)
+  | Domain (Board Board_sub_board_list)
   | Check
   | Config
   | Dashboard
   | Get_metrics
-  | Goal Goal_list
+  | Domain (Goal Goal_list)
   | Mcp_session
   | Messages
-  | Operator Operator_digest
-  | Operator Operator_snapshot
+  | Domain (Operator Operator_digest)
+  | Domain (Operator Operator_snapshot)
   | Pause
   | Plan_get
   | Plan_get_task
   | Resume
   | Start
   | Status
-  | Task Task_history
-  | Task Tasks
+  | Domain (Task Task_history)
+  | Domain (Task Tasks)
   | Tool_admin_snapshot
   | Tool_help
   | Tool_list

--- a/lib/tool_task_schemas.ml
+++ b/lib/tool_task_schemas.ml
@@ -22,9 +22,9 @@ module Float = Stdlib.Float
     @since God file decomposition — extracted from tool_task.ml *)
 
 let masc_add_task_name =
-  Tool_name.Masc.to_string (Tool_name.Masc.Task Tool_name.Task_name.Add_task)
+  Tool_name.Task_name.to_string Tool_name.Task_name.Add_task
 let masc_claim_next_name =
-  Tool_name.Masc.to_string (Tool_name.Masc.Task Tool_name.Task_name.Claim_next)
+  Tool_name.Task_name.to_string Tool_name.Task_name.Claim_next
 
 let schemas : Masc_domain.tool_schema list = [
   {


### PR DESCRIPTION
## The violation

The Tool substrate must not know any domain. The dune library boundary already prevents `lib/tool/` from depending on keeper/domain modules, but `Tool_name.Masc.t` still SPELLED domain vocabulary in its TYPE STRUCTURE:

- `Masc.t` wrapped the Task/Board/Goal/Operator tool names in four domain-named arms (`Task of Task_name.t | Board of … | Goal of … | Operator of …`).
- `tool_dispatch.static_tag_of_tool_name` destructured them (`Task _ -> Mod_task | Board _ -> Mod_inline | …`).
- `tool_catalog_inference` enumerated the domain constructors for `effect_domain`.

This is the residual type-structural leak after the PR-S1 submodule split (which only moved the *strings* into domain submodules).

## The cut (neutral carrier)

Mirrors the `Mod_keeper → Mod_external` neutral-tag precedent (#19811): one neutral arm at the substrate, the concrete domain wiring on the domain side.

- New `Tool_name.Domain_tool` submodule owns the single grouping `Task/Board/Goal/Operator` plus the classifications each domain attaches: `module_tag` (uniform per domain) and `effect_domain` (the non-uniform per-member mapping — Board splits Read_only/Masc_workspace, Operator three ways — transcribed member-for-member from the prior flat match). This is now the ONLY place that enumerates the domain constructors.
- `Masc.t` carries them behind one arm: `Domain of Domain_tool.t`. The ~40 flat admin/lifecycle/misc names stay flat.
- New zero-dep leaf `Tool_tag_types` holds `module_tag` + `effect_domain` so the domain side can produce them. `Tool_dispatch` and `Tool_catalog_inference` re-export those types by type-equality, so external `Tool_dispatch.Mod_*` and `Tool_catalog.<effect_domain>` call sites and the `.mli` contracts are byte-unchanged.
- `static_tag_of_tool_name` and `inferred_effect_domain_of_typed_tool_name` now match a single `Domain d` arm and delegate. The substrate spells NO domain constructor.

## Migrated consumers

- Construct sites that only needed the wire string now call the submodule `to_string` directly (`Task_name.to_string Add_task`, `Board_name.to_string Board_post`), removing the `Masc.` indirection and preserving the string by construction: `tool_task_schemas`, `tool_inline_dispatch_workspace`, `governance_pipeline_risk` (transition name), `keeper_tool_policy`, `keeper_tool_progress`, `keeper_tool_capability_axis`, `keeper_tool_registry`, `server_bootstrap_loops`.
- Domain-aware exhaustive classifiers in the mega-lib (`tool_resource_axis`, `governance_pipeline_risk` risk match) reach the domain members through the neutral `Domain` carrier and keep their per-member buckets. Their resource/risk vocabulary lives DOWNSTREAM of the substrate library, so this classification cannot move into `Domain_tool` without inverting the dune boundary — these consumers are domain-aware by design (same as keeper stayed keeper-aware behind `Mod_external`).

## Wire-string preservation

Every `masc_*` wire string is byte-identical — only the OCaml type structure changes. `of_string`/`to_string` round-trip verified for all 21 domain tool names through both `Tool_name` and the new `Domain_tool` carrier. Exhaustive matches throughout; no wildcard masks the removal.

## Verification

- `dune build @check --root .` = 0
- `dune build lib/masc_mcp.cmxa --root .` = 0
- `dune build @all --root .` = 0 (lib + test + bin native; catches expression-level constructor errors that @check misses, per #19145)
- `test_tool_spec` 15/15, `test_keeper_tag_dispatch` 5/5 pass.
- `test_tool_dispatch` and `test_tool_capability_typed` show the SAME single failure as baseline `0ee897eca1` (`tool_execute -> Mod_shard`, `tool_read_file` Read_only) — pre-existing registry-not-populated artifacts on non-domain tools, not regressions. The domain assertions (`masc_board_delete -> Mod_inline`, `masc_goal_list -> Mod_state`) PASS in this branch, confirming routing is preserved.

RFC-WAIVED: type-structural decoupling of the Tool substrate (no credential/identity/auth, operator control plane, sandbox/containment, dashboard credential, hooks, or workflow-doc surface touched). Follows the established Mod_external neutral-tag pattern (#19811) and the domain-taxonomy decouple roadmap.
