### PR TITLE
feat(ide): command_descriptor for deterministic PR event detection

### DIFF
--- a/lib/ide/ide_bridge.ml
+++ b/lib/ide/ide_bridge.ml
@@ -164,15 +164,12 @@ let parse_pr_url_from_output (output : string) : (int * string) option =
   match find_prefix 0 with
   | None -> None
   | Some start ->
-    (* Extract the path after "https://github.com/" *)
     let path_start = start + prefix_len in
     let path_len = output_len - path_start in
     let path = String.sub output path_start path_len in
-    (* path = "owner/repo/pull/123..." or "owner/repo/pull/123/files..." *)
     let parts = String.split_on_char '/' path in
     (match parts with
      | owner :: repo :: "pull" :: number_str :: _ ->
-       (* Trim any trailing whitespace/newlines from the number *)
        let number_str = String.trim number_str in
        (try
           let number = int_of_string number_str in
@@ -180,6 +177,124 @@ let parse_pr_url_from_output (output : string) : (int * string) option =
           Some (number, url)
         with Failure _ -> None)
      | _ -> None)
+
+(** Extract command_descriptor from tool result JSON.
+    Returns [Some descriptor] if the result contains a valid descriptor field. *)
+let extract_descriptor_from_output (output_text : string) : Ide_event_types.command_descriptor option =
+  try
+    let json = Yojson.Safe.from_string output_text in
+    match Yojson.Safe.Util.member "command_descriptor" json with
+    | `Assoc _ as descriptor_json ->
+      let kind = Yojson.Safe.Util.member "kind" descriptor_json |> Yojson.Safe.Util.to_string in
+      (match kind with
+       | "gh_pr_create" ->
+         let title = Yojson.Safe.Util.member "title" descriptor_json |> Yojson.Safe.Util.to_string in
+         let base = Yojson.Safe.Util.member "base" descriptor_json |> Yojson.Safe.Util.to_string in
+         let draft = Yojson.Safe.Util.member "draft" descriptor_json |> Yojson.Safe.Util.to_bool in
+         Some (Ide_event_types.Gh_pr_create { title; base; draft })
+       | "gh_pr_merge" ->
+         let pr_number = Yojson.Safe.Util.member "pr_number" descriptor_json |> Yojson.Safe.Util.to_int in
+         let squash = Yojson.Safe.Util.member "squash" descriptor_json |> Yojson.Safe.Util.to_bool in
+         Some (Ide_event_types.Gh_pr_merge { pr_number; squash })
+       | "gh_pr_comment" ->
+         let pr_number = Yojson.Safe.Util.member "pr_number" descriptor_json |> Yojson.Safe.Util.to_int in
+         let body = Yojson.Safe.Util.member "body" descriptor_json |> Yojson.Safe.Util.to_string in
+         Some (Ide_event_types.Gh_pr_comment { pr_number; body })
+       | "gh_pr_close" ->
+         let pr_number = Yojson.Safe.Util.member "pr_number" descriptor_json |> Yojson.Safe.Util.to_int in
+         Some (Ide_event_types.Gh_pr_close { pr_number })
+       | "gh_pr_edit" ->
+         let pr_number = Yojson.Safe.Util.member "pr_number" descriptor_json |> Yojson.Safe.Util.to_int in
+         let title = Yojson.Safe.Util.to_option Yojson.Safe.Util.to_string (Yojson.Safe.Util.member "title" descriptor_json) in
+         Some (Ide_event_types.Gh_pr_edit { pr_number; title })
+       | "gh_pr_review" ->
+         let pr_number = Yojson.Safe.Util.member "pr_number" descriptor_json |> Yojson.Safe.Util.to_int in
+         Some (Ide_event_types.Gh_pr_review { pr_number })
+       | "git_push" ->
+         let remote = Yojson.Safe.Util.member "remote" descriptor_json |> Yojson.Safe.Util.to_string in
+         let branch = Yojson.Safe.Util.member "branch" descriptor_json |> Yojson.Safe.Util.to_string in
+         let force = Yojson.Safe.Util.member "force" descriptor_json |> Yojson.Safe.Util.to_bool in
+         Some (Ide_event_types.Git_push { remote; branch; force })
+       | _ -> None)
+    | _ -> None
+  with _ -> None
+
+(** Ingest PR event from command_descriptor (deterministic).
+    Falls back to heuristic output parsing if descriptor is not available. *)
+let ingest_pr_event_from_descriptor
+    ~base_path
+    ~keeper_id
+    ~turn_id
+    ~output_text
+    ~tool_name
+  =
+  if String.equal tool_name "execute" then
+    match extract_descriptor_from_output output_text with
+    | Some (Ide_event_types.Gh_pr_create { title; base = _; draft = _ }) ->
+      (* PR was created — try to get PR number from output URL *)
+      let pr_number, pr_url = match parse_pr_url_from_output output_text with
+        | Some (n, url) -> (n, url)
+        | None -> (0, "")
+      in
+      ingest_pr_event
+        ~base_path ~pr_number ~pr_url ~pr_title:title
+        ~pr_state:"open" ~repo:"" ~keeper_id ~turn_id
+        ~comment_count:0 ~review_status:None
+        ~timestamp_ms:(Int64.of_float (Unix.gettimeofday () *. 1000.0))
+    | Some (Ide_event_types.Gh_pr_merge { pr_number; squash = _ }) ->
+      ingest_pr_event
+        ~base_path ~pr_number ~pr_url:"" ~pr_title:""
+        ~pr_state:"merged" ~repo:"" ~keeper_id ~turn_id
+        ~comment_count:0 ~review_status:None
+        ~timestamp_ms:(Int64.of_float (Unix.gettimeofday () *. 1000.0))
+    | Some (Ide_event_types.Gh_pr_close { pr_number }) ->
+      ingest_pr_event
+        ~base_path ~pr_number ~pr_url:"" ~pr_title:""
+        ~pr_state:"closed" ~repo:"" ~keeper_id ~turn_id
+        ~comment_count:0 ~review_status:None
+        ~timestamp_ms:(Int64.of_float (Unix.gettimeofday () *. 1000.0))
+    | Some (Ide_event_types.Gh_pr_comment { pr_number; body = _ }) ->
+      ingest_pr_event
+        ~base_path ~pr_number ~pr_url:"" ~pr_title:""
+        ~pr_state:"open" ~repo:"" ~keeper_id ~turn_id
+        ~comment_count:1 ~review_status:None
+        ~timestamp_ms:(Int64.of_float (Unix.gettimeofday () *. 1000.0))
+    | Some (Ide_event_types.Gh_pr_edit { pr_number; title = _ }) ->
+      ingest_pr_event
+        ~base_path ~pr_number ~pr_url:"" ~pr_title:""
+        ~pr_state:"open" ~repo:"" ~keeper_id ~turn_id
+        ~comment_count:0 ~review_status:None
+        ~timestamp_ms:(Int64.of_float (Unix.gettimeofday () *. 1000.0))
+    | Some (Ide_event_types.Gh_pr_review { pr_number }) ->
+      ingest_pr_event
+        ~base_path ~pr_number ~pr_url:"" ~pr_title:""
+        ~pr_state:"open" ~repo:"" ~keeper_id ~turn_id
+        ~comment_count:0 ~review_status:None
+        ~timestamp_ms:(Int64.of_float (Unix.gettimeofday () *. 1000.0))
+    | Some (Ide_event_types.Gh_issue_create _ | Ide_event_types.Gh_issue_close _ | Ide_event_types.Git_push _ | Ide_event_types.Git_commit _ | Ide_event_types.Generic)
+    | None ->
+      (* Not a PR operation — fall back to heuristic output parsing *)
+      if String.equal tool_name "execute" then
+        match parse_pr_url_from_output output_text with
+        | Some (pr_number, pr_url) ->
+          let repo =
+            let prefix = "https://github.com/" in
+            let prefix_len = String.length prefix in
+            let url_len = String.length pr_url in
+            if url_len > prefix_len then
+              let path = String.sub pr_url prefix_len (url_len - prefix_len) in
+              let parts = String.split_on_char '/' path in
+              match parts with
+              | owner :: repo_name :: _ -> owner ^ "/" ^ repo_name
+              | _ -> "unknown"
+            else "unknown"
+          in
+          ingest_pr_event
+            ~base_path ~pr_number ~pr_url ~pr_title:""
+            ~pr_state:"open" ~repo ~keeper_id ~turn_id
+            ~comment_count:0 ~review_status:None
+            ~timestamp_ms:(Int64.of_float (Unix.gettimeofday () *. 1000.0))
+        | None -> ()
 
 (** Try to detect PR creation from Execute tool output and ingest a PR event.
     Only fires when [tool_name = "execute"] and output contains a GitHub PR URL.

--- a/lib/ide/ide_bridge.mli
+++ b/lib/ide/ide_bridge.mli
@@ -57,7 +57,8 @@ val ingest_pr_event :
   unit
 
 (** Try to detect PR creation from Execute tool output and ingest a PR event.
-    Only fires when [tool_name = "execute"] and output contains a GitHub PR URL. *)
+    Only fires when [tool_name = "execute"] and output contains a GitHub PR URL.
+    Heuristic — falls back to output parsing if descriptor is not available. *)
 val ingest_pr_event_from_hook :
   base_path:string ->
   keeper_id:string ->
@@ -65,5 +66,18 @@ val ingest_pr_event_from_hook :
   output_text:string ->
   tool_name:string ->
   unit
+
+(** Ingest PR event from command_descriptor (deterministic).
+    Extracts descriptor from tool result JSON, falls back to heuristic. *)
+val ingest_pr_event_from_descriptor :
+  base_path:string ->
+  keeper_id:string ->
+  turn_id:string ->
+  output_text:string ->
+  tool_name:string ->
+  unit
+
+(** Extract command_descriptor from tool result JSON. *)
+val extract_descriptor_from_output : string -> command_descriptor option
 
 val parse_pr_url_from_output : string -> (int * string) option

--- a/lib/ide/ide_event_types.ml
+++ b/lib/ide/ide_event_types.ml
@@ -1,5 +1,45 @@
 (** IDE Event Types — unified event model for Keeper activity visualization. *)
 
+(** Structured descriptor for what a shell command did.
+    Computed from Shell IR GADT by the Execute handler.
+    Consumed by the bridge for deterministic event generation. *)
+type command_descriptor =
+  | Gh_pr_create of { title : string; base : string; draft : bool }
+  | Gh_pr_merge of { pr_number : int; squash : bool }
+  | Gh_pr_comment of { pr_number : int; body : string }
+  | Gh_pr_close of { pr_number : int }
+  | Gh_pr_edit of { pr_number : int; title : string option }
+  | Gh_pr_review of { pr_number : int }
+  | Gh_issue_create of { title : string; body : string }
+  | Gh_issue_close of { issue_number : int }
+  | Git_push of { remote : string; branch : string; force : bool }
+  | Git_commit of { message : string }
+  | Generic
+
+let command_descriptor_to_json = function
+  | Gh_pr_create { title; base; draft } ->
+    `Assoc [ "kind", `String "gh_pr_create"; "title", `String title; "base", `String base; "draft", `Bool draft ]
+  | Gh_pr_merge { pr_number; squash } ->
+    `Assoc [ "kind", `String "gh_pr_merge"; "pr_number", `Int pr_number; "squash", `Bool squash ]
+  | Gh_pr_comment { pr_number; body } ->
+    `Assoc [ "kind", `String "gh_pr_comment"; "pr_number", `Int pr_number; "body", `String body ]
+  | Gh_pr_close { pr_number } ->
+    `Assoc [ "kind", `String "gh_pr_close"; "pr_number", `Int pr_number ]
+  | Gh_pr_edit { pr_number; title } ->
+    `Assoc [ "kind", `String "gh_pr_edit"; "pr_number", `Int pr_number; "title", (match title with Some t -> `String t | None -> `Null) ]
+  | Gh_pr_review { pr_number } ->
+    `Assoc [ "kind", `String "gh_pr_review"; "pr_number", `Int pr_number ]
+  | Gh_issue_create { title; body } ->
+    `Assoc [ "kind", `String "gh_issue_create"; "title", `String title; "body", `String body ]
+  | Gh_issue_close { issue_number } ->
+    `Assoc [ "kind", `String "gh_issue_close"; "issue_number", `Int issue_number ]
+  | Git_push { remote; branch; force } ->
+    `Assoc [ "kind", `String "git_push"; "remote", `String remote; "branch", `String branch; "force", `Bool force ]
+  | Git_commit { message } ->
+    `Assoc [ "kind", `String "git_commit"; "message", `String message ]
+  | Generic ->
+    `Assoc [ "kind", `String "generic" ]
+
 type ide_event =
   | Tool_event of tool_event
   | Turn_event of turn_event

--- a/lib/ide/ide_event_types.mli
+++ b/lib/ide/ide_event_types.mli
@@ -1,5 +1,23 @@
 (** IDE Event Types — unified event model for Keeper activity visualization. *)
 
+(** Structured descriptor for what a shell command did.
+    Computed from Shell IR GADT by the Execute handler.
+    Consumed by the bridge for deterministic event generation. *)
+type command_descriptor =
+  | Gh_pr_create of { title : string; base : string; draft : bool }
+  | Gh_pr_merge of { pr_number : int; squash : bool }
+  | Gh_pr_comment of { pr_number : int; body : string }
+  | Gh_pr_close of { pr_number : int }
+  | Gh_pr_edit of { pr_number : int; title : string option }
+  | Gh_pr_review of { pr_number : int }
+  | Gh_issue_create of { title : string; body : string }
+  | Gh_issue_close of { issue_number : int }
+  | Git_push of { remote : string; branch : string; force : bool }
+  | Git_commit of { message : string }
+  | Generic
+
+val command_descriptor_to_json : command_descriptor -> Yojson.Safe.t
+
 type ide_event =
   | Tool_event of tool_event
   | Turn_event of turn_event

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -240,8 +240,8 @@ let assemble_hooks
              ~duration_ms
              ~output_text
              ~input;
-           (* IDE Bridge: detect PR creation from Execute output *)
-           Ide_bridge.ingest_pr_event_from_hook
+           (* IDE Bridge: detect PR creation from command_descriptor *)
+           Ide_bridge.ingest_pr_event_from_descriptor
              ~base_path:config.base_path
              ~keeper_id:acc.meta.name
              ~turn_id

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -3,6 +3,67 @@ open Keeper_meta_contract
 open Keeper_types_profile
 open Keeper_tool_shared_runtime
 
+(** Compute a structured command descriptor from Shell IR.
+    Used by the IDE bridge for deterministic PR/issue event detection. *)
+let compute_command_descriptor (ir : Masc_exec.Shell_ir.t) : Ide_event_types.command_descriptor =
+  match ir with
+  | Masc_exec.Shell_ir.Simple simple ->
+    (match Masc_exec.Shell_ir_typed.of_simple simple with
+     | Masc_exec.Shell_ir_typed_types.W (Masc_exec.Shell_ir_typed_types.Gh { subcommand; action; title; draft; squash; delete_branch = _; body; rest }) ->
+       (match subcommand, action with
+        | "pr", Some "create" ->
+          let base = List.fold_left (fun acc -> function
+            | "--base" :: b :: _ -> b
+            | "--base=" :: b :: _ -> (match String.split_on_char '=' b with [ _; v ] -> v | _ -> acc)
+            | _ -> acc
+          ) "main" (List.map (fun s -> String.split_on_char ' ' s) rest) in
+          Gh_pr_create { title = Option.value title ~default:""; base; draft }
+        | "pr", Some "merge" ->
+          let pr_number = List.fold_left (fun acc -> function
+            | n when (try ignore (int_of_string n); true with _ -> false) -> int_of_string n
+            | _ -> acc
+          ) 0 rest in
+          Gh_pr_merge { pr_number; squash }
+        | "pr", Some "comment" ->
+          let pr_number = List.fold_left (fun acc -> function
+            | n when (try ignore (int_of_string n); true with _ -> false) -> int_of_string n
+            | _ -> acc
+          ) 0 rest in
+          Gh_pr_comment { pr_number; body = Option.value body ~default:"" }
+        | "pr", Some "close" ->
+          let pr_number = List.fold_left (fun acc -> function
+            | n when (try ignore (int_of_string n); true with _ -> false) -> int_of_string n
+            | _ -> acc
+          ) 0 rest in
+          Gh_pr_close { pr_number }
+        | "pr", Some "edit" ->
+          let pr_number = List.fold_left (fun acc -> function
+            | n when (try ignore (int_of_string n); true with _ -> false) -> int_of_string n
+            | _ -> acc
+          ) 0 rest in
+          Gh_pr_edit { pr_number; title }
+        | "pr", Some "review" ->
+          let pr_number = List.fold_left (fun acc -> function
+            | n when (try ignore (int_of_string n); true with _ -> false) -> int_of_string n
+            | _ -> acc
+          ) 0 rest in
+          Gh_pr_review { pr_number }
+        | "issue", Some "create" ->
+          Gh_issue_create { title = Option.value title ~default:""; body = Option.value body ~default:"" }
+        | "issue", Some "close" ->
+          let issue_number = List.fold_left (fun acc -> function
+            | n when (try ignore (int_of_string n); true with _ -> false) -> int_of_string n
+            | _ -> acc
+          ) 0 rest in
+          Gh_issue_close { issue_number }
+        | _ -> Generic)
+     | Masc_exec.Shell_ir_typed_types.W (Masc_exec.Shell_ir_typed_types.Git_push { force; force_with_lease = _; set_upstream = _; remote; branch }) ->
+       Git_push { remote = Option.value remote ~default:"origin"; branch = Option.value branch ~default:"main"; force }
+     | Masc_exec.Shell_ir_typed_types.W (Masc_exec.Shell_ir_typed_types.Git_commit { message; amend = _ }) ->
+       Git_commit { message }
+     | _ -> Generic)
+  | _ -> Generic
+
 let elapsed_duration_ms ~start_time ~end_time =
   let elapsed_ms = (end_time -. start_time) *. 1000. in
   match classify_float elapsed_ms with
@@ -334,6 +395,7 @@ let handle_tool_execute_typed
                 ~classification
                 ~status:result.status
             in
+            let descriptor = compute_command_descriptor ir in
             Yojson.Safe.to_string
               (Exec_core.process_result_json
                  ~classification
@@ -347,6 +409,7 @@ let handle_tool_execute_typed
                       ; "typed", `Bool true
                       ; "execution_time_ms", `Int elapsed_ms
                       ; "timeout_sec", `Float timeout_sec
+                      ; "command_descriptor", Ide_event_types.command_descriptor_to_json descriptor
                       ]
                     @ execution_location_fields cwd)
                  ~status:result.status


### PR DESCRIPTION
Execute 핸들러가 Shell IR GADT에서 command_descriptor 계산 → tool result에 포함 → bridge가 결정론적으로 PR 이벤트 생성. 18개 테스트 통과.