### PR TITLE
feat(keeper): wire working-state sidecar readback for resume

### DIFF
--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -57,6 +57,14 @@ let finalize
     then "model_state_block"
     else "synthesized"
   in
+  (* Gate the working-state resume merge (ResumeFromDigest) to turns where active
+     loops can be silently lost: a pre-dispatch compaction may have dropped the
+     reminder, or the model emitted no [STATE] block at all (synthesized). On a
+     normal model_state_block turn the snapshot is authoritative, so a dropped
+     loop still clears. *)
+  let resume_merge =
+    pre_dispatch_compacted || String.equal state_snapshot_source "synthesized"
+  in
   let { Keeper_agent_run_sidecar.working_state = _
       ; state_snapshot_saved = _
       ; working_state_saved = _
@@ -71,6 +79,7 @@ let finalize
       ~session_dir:session.session_dir
       ~state_snapshot
       ~state_snapshot_source
+      ~resume_merge
       ~append_manifest
       ()
   in

--- a/lib/keeper/keeper_agent_run_sidecar.ml
+++ b/lib/keeper/keeper_agent_run_sidecar.ml
@@ -23,6 +23,49 @@ type save_result =
   ; working_state_saved : bool
   }
 
+(* Read back the previously-persisted working-state ledger from the latest
+   sidecar so that resume/compaction can preserve active loops the current
+   [STATE] snapshot omits. The saved payload wraps the ledger under the
+   "working_state" key (see [working_state_payload] below); decode via
+   [Keeper_working_state.of_json], which also validates the TLA-mirrored
+   invariants.
+
+   Returns [None] when the file is absent or any read/parse/decode/validate
+   step fails. This keeps resume strictly additive: a missing or corrupt
+   sidecar falls back to the current empty+snapshot projection rather than
+   crashing the turn. *)
+let read_persisted_working_state ~keeper_name ~latest_path =
+  if not (Fs_compat.file_exists latest_path) then None
+  else
+    match Fs_compat.load_file latest_path with
+    | exception exn ->
+      Log.Keeper.warn
+        "keeper:%s working state readback read failed (%s): %s"
+        keeper_name latest_path (Printexc.to_string exn);
+      None
+    | contents -> (
+      match Yojson.Safe.from_string contents with
+      | exception exn ->
+        Log.Keeper.warn
+          "keeper:%s working state readback parse failed (%s): %s"
+          keeper_name latest_path (Printexc.to_string exn);
+        None
+      | json -> (
+        match Yojson.Safe.Util.member "working_state" json with
+        | `Null ->
+          Log.Keeper.warn
+            "keeper:%s working state readback missing working_state field (%s)"
+            keeper_name latest_path;
+          None
+        | working_state_json -> (
+          match Keeper_working_state.of_json working_state_json with
+          | Ok state -> Some state
+          | Error error ->
+            Log.Keeper.warn
+              "keeper:%s working state readback decode failed (%s): %s"
+              keeper_name latest_path error;
+            None)))
+
 let save_sidecars
     ~keeper_name
     ~agent_name
@@ -33,6 +76,7 @@ let save_sidecars
     ~session_dir
     ~state_snapshot
     ~state_snapshot_source
+    ~resume_merge
     ~(append_manifest : append_manifest_fn)
     () =
   let state_snapshot_sidecar_path =
@@ -53,7 +97,7 @@ let save_sidecars
   in
   let state_snapshot_ts = Masc_domain.now_iso () in
   let state_snapshot_updated_at_unix = Time_compat.now () in
-  let working_state =
+  let projected_working_state =
     Keeper_working_state_projector.of_state_snapshot
       ~keeper_name
       ~trace_id
@@ -61,6 +105,35 @@ let save_sidecars
       ~updated_at_iso:state_snapshot_ts
       ~updated_at_unix:state_snapshot_updated_at_unix
       state_snapshot
+  in
+  (* ResumeFromDigest wire: only on resume/compaction turns do we read the
+     persisted ledger back and merge its active loops, so a persisted open loop
+     survives even if this turn's [STATE] omits it. On a normal turn the
+     snapshot projection is authoritative, preserving completion-by-omission.
+
+     Gating mirrors the TLA [ResumeFromDigest] precondition (compacted \/
+     handed_off); the caller passes [resume_merge] derived from
+     [pre_dispatch_compacted] or a synthesized (no model [STATE]) snapshot. *)
+  let working_state, resume_restored_active_loops =
+    if not resume_merge then (projected_working_state, 0)
+    else
+      match read_persisted_working_state ~keeper_name ~latest_path:latest_working_state_sidecar_path with
+      | None -> (projected_working_state, 0)
+      | Some persisted ->
+        let merged =
+          Keeper_working_state.merge_resume ~persisted ~current:projected_working_state
+        in
+        let restored =
+          Keeper_working_state.active_open_loop_count merged
+          - Keeper_working_state.active_open_loop_count projected_working_state
+        in
+        let restored = if restored < 0 then 0 else restored in
+        Log.Keeper.info
+          "keeper:%s working state resume merge: restored %d active loop(s) from %s (snapshot active=%d, merged active=%d)"
+          keeper_name restored latest_working_state_sidecar_path
+          (Keeper_working_state.active_open_loop_count projected_working_state)
+          (Keeper_working_state.active_open_loop_count merged);
+        (merged, restored)
   in
   let active_open_loop_count =
     Keeper_working_state.active_open_loop_count working_state
@@ -194,6 +267,8 @@ let save_sidecars
           ( "latest_working_state_sidecar_path",
             `String latest_working_state_sidecar_path );
           ("working_state_sidecar_saved", `Bool working_state_saved);
+          ("resume_merge", `Bool resume_merge);
+          ("resume_restored_active_loops", `Int resume_restored_active_loops);
           ("active_open_loop_count", `Int active_open_loop_count);
           ( "working_state_prompt_digest_ids",
             `List

--- a/lib/keeper/keeper_working_state.ml
+++ b/lib/keeper/keeper_working_state.ml
@@ -100,6 +100,53 @@ let compact ?max_digest state =
         ~resolved_loops:state.resolved_loops ()
   }
 
+(* Merge a persisted working-state ledger into the one freshly projected from
+   the current [STATE] snapshot, implementing the TLA [ResumeFromDigest] action:
+   on resume/compaction, persisted active loops must survive even if the current
+   snapshot omits them, while resolved/archived loops must not resurrect.
+
+   Semantics:
+   - active_loops = current active loops, plus each persisted active loop whose
+     id is not already present (in either side's active loops) and is not
+     resolved/archived in either side. This is the union that preserves a
+     persisted open loop the current snapshot dropped.
+   - resolved_loops / archived_loops = persisted history is carried forward; any
+     current entry not already present (by id) is appended. The current side is
+     snapshot-projected (active only) in production, so this defensively keeps
+     both sources without duplicating ids.
+   - A persisted active loop is dropped if the current side has since resolved or
+     archived that id (the snapshot is the newer signal for terminal status).
+
+   This is intentionally gated by the caller to compaction/handoff resume; on a
+   normal turn the current snapshot alone is authoritative, so a loop the model
+   drops from [STATE] still clears (completion-by-omission). *)
+let merge_resume ~persisted ~current =
+  let mem_id id loops = List.exists (fun l -> String.equal l.id id) loops in
+  let current_terminal_ids =
+    ids current.resolved_loops @ ids current.archived_loops
+  in
+  let persisted_terminal_ids =
+    ids persisted.resolved_loops @ ids persisted.archived_loops
+  in
+  let surviving_persisted_active =
+    persisted.active_loops
+    |> List.filter (fun loop ->
+           (not (mem_id loop.id current.active_loops))
+           && (not (List.mem loop.id current_terminal_ids))
+           && not (List.mem loop.id persisted_terminal_ids))
+  in
+  let active_loops = current.active_loops @ surviving_persisted_active in
+  let merge_bucket current_bucket persisted_bucket =
+    let extra =
+      current_bucket
+      |> List.filter (fun loop -> not (mem_id loop.id persisted_bucket))
+    in
+    persisted_bucket @ extra
+  in
+  let resolved_loops = merge_bucket current.resolved_loops persisted.resolved_loops in
+  let archived_loops = merge_bucket current.archived_loops persisted.archived_loops in
+  compact { active_loops; resolved_loops; archived_loops; prompt_digest_ids = [] }
+
 let all_loops state =
   state.active_loops @ state.resolved_loops @ state.archived_loops
 

--- a/lib/keeper/keeper_working_state.mli
+++ b/lib/keeper/keeper_working_state.mli
@@ -78,6 +78,20 @@ val active_open_loop_count : t -> int
     tail, never active responsibility. *)
 val compact : ?max_digest:int -> t -> t
 
+(** Implement the TLA [ResumeFromDigest] action: merge a persisted ledger
+    ([persisted]) into the ledger freshly projected from the current [STATE]
+    snapshot ([current]) on resume/compaction.
+
+    A persisted active loop survives even when [current] omits it, so an open
+    loop is not silently lost when an importance heuristic drops the reminder
+    and the model fails to re-emit it. A loop the [current] snapshot has since
+    resolved/archived does not resurrect, and resolved/archived history is
+    carried forward without duplicating ids.
+
+    Callers gate this to resume/compaction turns only; on a normal turn the
+    current snapshot is authoritative so a dropped loop still clears. *)
+val merge_resume : persisted:t -> current:t -> t
+
 val capture_loop : ?max_digest:int -> t -> loop -> (t, string) result
 
 val resolve_loop :

--- a/test/test_keeper_working_state.ml
+++ b/test/test_keeper_working_state.ml
@@ -130,6 +130,203 @@ let test_projector_maps_snapshot_items_to_active_loops () =
     state.prompt_digest_ids;
   check bool "valid projected state" true (Result.is_ok (WS.validate state))
 
+(* Resume-merge / readback (ResumeFromDigest) tests.
+
+   These reproduce and close the write-only-sidecar silent-loss bug: before the
+   wire, [of_json] had zero callers, so a persisted active loop the model omits
+   from the next [STATE] vanished from both the prompt and the sidecar. *)
+
+let projected_snapshot ?(next_items = []) ?(open_questions = []) () =
+  let snapshot =
+    { Masc_mcp.Keeper_memory_policy.empty_keeper_state_snapshot with
+      next_items
+    ; open_questions
+    }
+  in
+  Masc_mcp.Keeper_working_state_projector.of_state_snapshot
+    ~keeper_name:"keeper-a"
+    ~trace_id:"trace-1"
+    ~keeper_turn_id:1
+    ~updated_at_iso:"2026-05-21T02:00:00+09:00"
+    ~updated_at_unix:3.0
+    snapshot
+
+let active_titles state =
+  state.WS.active_loops |> List.map (fun loop -> loop.WS.title) |> List.sort compare
+
+(* Silent-loss fix: a persisted active loop survives resume even when the
+   current [STATE] snapshot omits it entirely. *)
+let test_merge_resume_preserves_persisted_active_when_snapshot_omits () =
+  let persisted = projected_snapshot ~next_items:[ "finish PR review" ] () in
+  check int "persisted has one active loop" 1 (WS.active_open_loop_count persisted);
+  (* Resume turn: the model re-emits a different loop and OMITS the persisted one. *)
+  let current = projected_snapshot ~next_items:[ "write changelog" ] () in
+  let merged = WS.merge_resume ~persisted ~current in
+  check (list string) "both the persisted and current active loops survive"
+    [ "finish PR review"; "write changelog" ]
+    (active_titles merged);
+  check bool "merged state is valid" true (Result.is_ok (WS.validate merged));
+  List.iter
+    (fun loop ->
+      check bool
+        (Printf.sprintf "active loop %s is in prompt digest" loop.WS.id)
+        true
+        (List.mem loop.WS.id merged.WS.prompt_digest_ids))
+    merged.WS.active_loops
+
+(* Regression guard: a loop the persisted ledger has already resolved must NOT
+   resurrect on resume, even though merge carries persisted history forward. *)
+let test_merge_resume_does_not_resurrect_resolved () =
+  let persisted =
+    capture_exn WS.empty (active_loop ~id:"loop-done" ~title:"closed work" ())
+    |> fun state ->
+    resolve_exn state ~loop_id:"loop-done" ~resolution_refs:[ evidence "merged" ]
+  in
+  check int "persisted has no active loops" 0 (WS.active_open_loop_count persisted);
+  let current = projected_snapshot ~next_items:[ "new task" ] () in
+  let merged = WS.merge_resume ~persisted ~current in
+  check int "resolved loop is not resurrected as active" 1
+    (WS.active_open_loop_count merged);
+  check (list string) "only the current active loop is active" [ "new task" ]
+    (active_titles merged);
+  check int "resolved history carried forward" 1
+    (List.length merged.WS.resolved_loops);
+  check bool "merged state is valid" true (Result.is_ok (WS.validate merged))
+
+(* Completion-by-omission must still work on a NORMAL turn (no resume merge):
+   the snapshot projection alone is authoritative, so a loop the model drops
+   from [STATE] clears. This is the mirror that fails under unconditional union. *)
+let test_normal_turn_projection_drops_omitted_loop () =
+  let turn1 = projected_snapshot ~next_items:[ "finish PR review" ] () in
+  check int "turn 1 has the loop" 1 (WS.active_open_loop_count turn1);
+  (* Turn 2 omits it; on a normal (non-resume) turn no merge happens, so the
+     projection-only state has zero active loops — the loop is completed. *)
+  let turn2 = projected_snapshot ~next_items:[] () in
+  check int "turn 2 projection drops the omitted loop" 0
+    (WS.active_open_loop_count turn2);
+  check (list string) "no active loops remain" [] (active_titles turn2)
+
+(* Readback through the real sidecar payload shape (working_state wrapped under
+   the "working_state" key, latest filename working-state.latest.json). *)
+let sidecar_payload working_state =
+  `Assoc
+    [ ("schema_version", `Int 1)
+    ; ("keeper_name", `String "keeper-a")
+    ; ("working_state", WS.to_json working_state)
+    ]
+
+let test_readback_roundtrip_through_sidecar_payload () =
+  let dir = Filename.temp_file "crw_readback_" "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  let latest_path = Filename.concat dir "working-state.latest.json" in
+  let persisted = projected_snapshot ~next_items:[ "finish PR review" ] () in
+  Fs_compat.save_file latest_path
+    (Yojson.Safe.pretty_to_string (sidecar_payload persisted));
+  match
+    Masc_mcp.Keeper_agent_run_sidecar.read_persisted_working_state
+      ~keeper_name:"keeper-a" ~latest_path
+  with
+  | None -> fail "expected readback to recover the persisted ledger"
+  | Some recovered ->
+    check int "recovered one active loop" 1 (WS.active_open_loop_count recovered);
+    check (list string) "recovered the persisted loop" [ "finish PR review" ]
+      (active_titles recovered)
+
+let test_readback_absent_file_returns_none () =
+  let dir = Filename.temp_file "crw_absent_" "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  let latest_path = Filename.concat dir "working-state.latest.json" in
+  check bool "absent file falls back to None" true
+    (Masc_mcp.Keeper_agent_run_sidecar.read_persisted_working_state
+       ~keeper_name:"keeper-a" ~latest_path
+     = None)
+
+let test_readback_corrupt_file_returns_none () =
+  let dir = Filename.temp_file "crw_corrupt_" "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  let latest_path = Filename.concat dir "working-state.latest.json" in
+  Fs_compat.save_file latest_path "{ this is not valid json";
+  check bool "corrupt file falls back to None" true
+    (Masc_mcp.Keeper_agent_run_sidecar.read_persisted_working_state
+       ~keeper_name:"keeper-a" ~latest_path
+     = None)
+
+(* End-to-end wire test: drive the real [save_sidecars] (the production save
+   seam) so the glue — read-back path, gating, merge, write-back — is exercised,
+   not just the pure components. This is the test that fails if [resume_merge] is
+   inverted, the path is wrong, or the merge result is dropped. *)
+
+let noop_manifest : Masc_mcp.Keeper_agent_run_sidecar.append_manifest_fn =
+  fun ?elapsed_ms:_ ?logical_seq:_ ?status:_ ?decision:_ ?keeper_turn_id:_
+      ?oas_turn_count:_ ?checkpoint_path:_ ?compaction_source:_ ~site:_ _ ->
+  ()
+
+let snapshot_with ?(next_items = []) ?(open_questions = []) () =
+  { Masc_mcp.Keeper_memory_policy.empty_keeper_state_snapshot with
+    next_items
+  ; open_questions
+  }
+
+let save_through_sidecar ~session_dir ~resume_merge ~next_items ~keeper_turn_id =
+  ignore
+    (Masc_mcp.Keeper_agent_run_sidecar.save_sidecars
+       ~keeper_name:"keeper-a"
+       ~agent_name:"agent-a"
+       ~trace_id:"trace-1"
+       ~generation:0
+       ~keeper_turn_id
+       ~oas_turn_count:1
+       ~session_dir
+       ~state_snapshot:(snapshot_with ~next_items ())
+       ~state_snapshot_source:"model_state_block"
+       ~resume_merge
+       ~append_manifest:noop_manifest
+       ())
+
+let read_latest_active_titles ~session_dir =
+  let latest_path = Filename.concat session_dir "working-state.latest.json" in
+  let json = Yojson.Safe.from_file latest_path in
+  match WS.of_json (Yojson.Safe.Util.member "working_state" json) with
+  | Error e -> fail e
+  | Ok state -> active_titles state
+
+let with_temp_session_dir f =
+  let dir = Filename.temp_file "crw_session_" "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  f dir
+
+(* Resume turn: turn 1 persists an active loop, turn 2 (resume_merge=true) omits
+   it from the snapshot -> the latest sidecar still carries it. Without the wire
+   the second save would overwrite the file with the empty projection. *)
+let test_save_sidecars_resume_preserves_omitted_loop () =
+  with_temp_session_dir (fun session_dir ->
+      save_through_sidecar ~session_dir ~resume_merge:false
+        ~next_items:[ "finish PR review" ] ~keeper_turn_id:1;
+      check (list string) "turn 1 persisted the loop" [ "finish PR review" ]
+        (read_latest_active_titles ~session_dir);
+      save_through_sidecar ~session_dir ~resume_merge:true ~next_items:[]
+        ~keeper_turn_id:2;
+      check (list string)
+        "resume turn preserves the omitted loop in the latest sidecar"
+        [ "finish PR review" ]
+        (read_latest_active_titles ~session_dir))
+
+(* Normal turn: omission clears the loop because no merge happens. This proves
+   completion-by-omission still works through the real save seam. *)
+let test_save_sidecars_normal_turn_clears_omitted_loop () =
+  with_temp_session_dir (fun session_dir ->
+      save_through_sidecar ~session_dir ~resume_merge:false
+        ~next_items:[ "finish PR review" ] ~keeper_turn_id:1;
+      save_through_sidecar ~session_dir ~resume_merge:false ~next_items:[]
+        ~keeper_turn_id:2;
+      check (list string)
+        "normal turn drops the omitted loop from the latest sidecar" []
+        (read_latest_active_titles ~session_dir))
+
 let () =
   run "Keeper_working_state"
     [
@@ -152,5 +349,24 @@ let () =
           test_case "json roundtrip" `Quick test_json_roundtrip;
           test_case "projector maps snapshot items to active loops" `Quick
             test_projector_maps_snapshot_items_to_active_loops;
+        ] );
+      ( "resume_merge",
+        [
+          test_case "resume preserves persisted active loop when snapshot omits"
+            `Quick test_merge_resume_preserves_persisted_active_when_snapshot_omits;
+          test_case "resume does not resurrect resolved loop" `Quick
+            test_merge_resume_does_not_resurrect_resolved;
+          test_case "normal turn projection drops omitted loop" `Quick
+            test_normal_turn_projection_drops_omitted_loop;
+          test_case "readback roundtrips through sidecar payload" `Quick
+            test_readback_roundtrip_through_sidecar_payload;
+          test_case "readback of absent file returns none" `Quick
+            test_readback_absent_file_returns_none;
+          test_case "readback of corrupt file returns none" `Quick
+            test_readback_corrupt_file_returns_none;
+          test_case "save_sidecars resume preserves omitted loop" `Quick
+            test_save_sidecars_resume_preserves_omitted_loop;
+          test_case "save_sidecars normal turn clears omitted loop" `Quick
+            test_save_sidecars_normal_turn_clears_omitted_loop;
         ] );
     ]


### PR DESCRIPTION
## What

Wire the keeper working-state sidecar read-back so compaction/resume preserves active loops at the ledger level. This makes the `KeeperWorkingStateLifecycle.tla` `ResumeFromDigest` action load-bearing instead of modeled-only.

## The bug (audit-confirmed)

`lib/keeper/keeper_working_state.ml` is a structured open-loop ledger whose `compact` provably preserves active loops (`CompactionPreservesActive`). But it was **write-only**: `of_json` (the decoder, declared in the `.mli`, tested by roundtrip) had **zero callers in `lib/`** — nothing read `working-state.latest.json` back on resume.

`Keeper_agent_run_sidecar.save_sidecars` rebuilt the ledger from `Keeper_working_state.empty` + the latest LLM `[STATE]` snapshot every turn via `Keeper_working_state_projector.of_state_snapshot`, then overwrote the sidecar. The TLA `ResumeFromDigest` action was modeled but not implemented. Consequence: active-loop preservation in the ledger depended entirely on the LLM re-emitting `[STATE]` each turn. If an importance heuristic dropped the reminder and the LLM omitted the loop, the loop silently vanished from the sidecar, and the proof did not protect against this.

## The fix (gated read-back + merge)

1. `Keeper_working_state.merge_resume ~persisted ~current` (pure, in `.mli`): implements `ResumeFromDigest`. Union of active loops — a persisted active loop survives even if `current` omits it; a loop `current` has since resolved/archived does not resurrect; resolved/archived history is carried forward without duplicating ids.
2. `Keeper_agent_run_sidecar.read_persisted_working_state`: loads `working-state.latest.json`, extracts the `working_state` field, decodes via `Keeper_working_state.of_json` (which validates the TLA-mirrored invariants). Returns `None` on absent/corrupt/decode-fail (logged) — strictly additive, never crashes the turn.
3. `save_sidecars` takes `~resume_merge`. When true it reads the persisted ledger and merges; when false it keeps the empty+snapshot projection.
4. `keeper_agent_run_finalize_response.ml` sets `resume_merge = pre_dispatch_compacted || state_snapshot_source = "synthesized"`, mirroring the TLA precondition (`compacted \/ handed_off`).

## Why gated, not unconditional union

In production `capture_loop`/`resolve_loop`/`archive_resolved_loop` have **zero callers** — a loop clears only by the model dropping it from the next `[STATE]`. `active_loops` has no cap. So an unconditional every-turn union would make every legitimate completion an immortal loop. Gating to resume/compaction turns preserves completion-by-omission on normal turns while closing the silent-loss window on the turn that can drop the reminder. This deviation from "merge unconditionally" is intentional and surfaced here rather than chosen silently.

## Scope (honest): ledger half only

Nothing currently reads the restored ledger into prompt construction (`finalize` discards the returned `working_state`; no `lib/` reader of `working-state.latest.json` into context). This PR makes the **sidecar ledger** durable and makes `of_json` load-bearing — it does not yet remind the model on the next turn. The prompt-consumption seam (feed the restored ledger back into context) is a separate follow-up. This is prerequisite infrastructure for that wire, not the end-to-end prompt fix.

## Known transient

Loop IDs embed list index (`snapshot-{field}-{index}-{digest}`). On a resume turn where the model re-emits a surviving loop at a different position, the persisted id and the new id differ, so both survive (two active entries for one task). `validate` passes (distinct ids). It self-heals on the next normal turn (projection-only save). Disclosed rather than shipped silent; not fixed here.

## Tests

`test/test_keeper_working_state.ml` (+8 cases):
- `merge_resume` preserves a persisted active loop when the snapshot omits it; does not resurrect a resolved loop; normal-turn projection drops the omitted loop.
- `read_persisted_working_state` roundtrips through the real sidecar payload shape; absent and corrupt files fall back to `None`.
- **Integrated through the production seam**: drive `save_sidecars ~resume_merge:true` after persisting a loop and omitting it from the next snapshot, then read `working-state.latest.json` back — the loop is still active. Mirror: `~resume_merge:false` with an omitted loop clears it. A mutation (forcing the merge off) makes the resume test fail, confirming it closes the bug rather than passing vacuously.

## Verification

- `dune build @check --root .` = 0
- `dune build lib/masc_mcp.cmxa --root .` = 0
- `dune exec test/test_keeper_working_state.exe --root .` = 16/16 pass
- `test_warn_root_causes` unaffected (still green)

RFC-WAIVED: ledger-internal sidecar read-back wiring (no credential/identity/operator/sandbox/hooks/workflow surface touched). Subsystems changed: `lib/keeper/keeper_working_state*`, `lib/keeper/keeper_agent_run_sidecar.ml`, `lib/keeper/keeper_agent_run_finalize_response.ml`.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
