### PR TITLE
fix(tool): add tool_tag_types.mli (paired-update missed in #19906)

### DIFF
--- a/lib/tool/tool_tag_types.mli
+++ b/lib/tool/tool_tag_types.mli
@@ -1,0 +1,35 @@
+(** Tool_tag_types — neutral classification variants for the Tool substrate.
+
+    Zero-dependency leaf module. Holds the two pure nullary sums that the
+    domain side ([Tool_name.Domain_tool]) attaches to each tool and that the
+    substrate ([Tool_dispatch], [Tool_catalog_inference]) consume.
+
+    Constructors are exposed (not abstract): [Tool_dispatch] and
+    [Tool_catalog_inference] re-export these types by type-equality, so the
+    [Tool_dispatch.Mod_*] / [Tool_catalog.<effect_domain>] call sites must keep
+    seeing the constructors. Hiding them would break the re-export contract. *)
+
+(** Dispatch routing tag attached to each tool name. *)
+type module_tag =
+  | Mod_plan
+  | Mod_operator
+  | Mod_local_runtime
+  | Mod_run
+  | Mod_compact
+  | Mod_agent
+  | Mod_task
+  | Mod_state
+  | Mod_control
+  | Mod_agent_timeline
+  | Mod_misc
+  | Mod_library
+  | Mod_external
+  | Mod_inline
+  | Mod_shard
+
+(** Inferred effect classification for a tool. *)
+type effect_domain =
+  | Read_only
+  | Masc_workspace
+  | Playground_write
+  | Host_repo_write


### PR DESCRIPTION
## 목표

`#19906`이 추가한 `lib/tool/tool_tag_types.ml`(zero-dep leaf, `module_tag` + `effect_domain`)에 `.mli`가 빠져 있어 `lib_other_mli_missing` structure-ratchet metric이 baseline을 넘었습니다. `#19906`이 함께 ship 했어야 할 인터페이스를 추가하는 paired-update입니다.

## 변경

- `lib/tool/tool_tag_types.mli` 신규 — 두 nullary sum을 전 constructor 노출(abstract 아님). `Tool_dispatch` / `Tool_catalog_inference`가 type-equality로 재-export 하므로 constructor가 보여야 합니다.

## 로컬 검증

- `dune build @check --root .` = 0 (0줄)
- `dune build lib/masc_mcp.cmxa --root .` = 0

## 남은 debt (이 PR 범위 밖)

`OCaml Structure Ratchet` 체크는 이 브랜치에서 **여전히 red**입니다. `#19907`(board sub-lib 추출)이 만든 `lib/board/*.ml` 5개 파일이 `.mli` 없이 metric을 지배하기 때문입니다(7 > baseline 2). 그 중 `board_core_persist.ml`은 599줄/59 defs로, 인터페이스 노출/은닉 결정은 sub-lib 소유자의 아키텍처 판단입니다 — 별도 이슈로 추적합니다. 이 PR은 `#19906`이 유발한 1개 파일만 정리합니다.

## Self-review

- 목표: #19906 paired-update 누락 보정 (drift 8→7)
- 변경 파일: `lib/tool/tool_tag_types.mli` (신규, type-only)
- 검증: @check 0, cmxa 0
- 미검증: 전체 test suite (이 변경은 인터페이스 노출만, 동작 무변경 — 재-export 모듈 @check 통과로 type-equality 확인됨)

RFC-WAIVED: lib/tool/tool_tag_types는 guarded subsystem(credential/operator/sandbox/dashboard-credential/hooks/workflow) 아님. `pr-rfc-check.sh` rc=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
