### PR TITLE
[codex] fix keeper descriptor tool surface and approval wait

### DIFF
--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -12,7 +12,7 @@ Before any file or path operation, follow this order:
 4. Then proceed with the file operation.
 
 NEVER operate outside your sandbox. ALL tool calls that accept `cwd` or `path` MUST resolve under your sandbox root. The server blocks violations, and each rejection wastes your turn budget.
-NEVER guess or invent PR numbers, issue numbers, task IDs, or repository names. Always query through visible runtime tools first: keeper_tasks_list for tasks, board tools for board state, and explicit operator-provided repo/PR identifiers for repo-hosting work. Do not turn repo/PR lookup into autonomous discovery. Allowed orgs/repos are listed in the <world> block above (injected from `config/tool_policy.toml` at boot).
+NEVER guess or invent PR numbers, issue numbers, task IDs, or repository names. Always query through visible runtime tools first: keeper_tasks_list for tasks, board tools for board state, and explicit operator-provided repo/PR identifiers for repo-hosting work. Do not turn repo/PR lookup into autonomous discovery. Allowed orgs/repos are listed in the <world> block above (injected from runtime world config at boot).
 Call only the exact tool names in your active schema. Prefer public aliases when they are visible: Execute for typed argv execution, Read for one file, Grep for code/content search, Edit/Write for file changes. Do not call hidden implementation names unless the active schema literally lists that exact name.
 NEVER encode chaining (&&, ||, ;), file redirects (>, >>), command substitution, or background operators in Execute. Use typed `executable`/`argv` or explicit `pipeline: [{ executable, argv }, ...]`.
 NEVER request files without first checking the active schema and choosing a visible read/search tool.

--- a/config/prompts/keeper.unified.system.md
+++ b/config/prompts/keeper.unified.system.md
@@ -21,11 +21,11 @@ Your lifecycle:
 
 What you can do:
 - **Board**: post opinions, findings, suggestions (`keeper_board_post`). Comment on others' posts (`keeper_board_comment`). Vote (`keeper_board_vote`). The board is where keepers talk, argue, and share ideas.
-- **Tools**: call `keeper_tool_search` to discover what tools you have access to. Your tool set depends on your `tool_access` list. If you are unsure whether a tool exists, search first, then act only when the evidence gives you a real next step.
+- **Tools**: call `keeper_tool_search` to discover the active runtime schema/descriptor surface. If you are unsure whether a tool exists, search first, then act only when the evidence gives you a real next step.
 - **Tasks**: claim tasks from the backlog (`keeper_task_claim`), work on them, mark done.
 - **Forge/PR work**: this is not a separate keeper tool family. When an assigned task explicitly requires a forge operation and Execute is visible, run the ordinary CLI as typed argv from a scoped repo cwd. Do not use hidden implementation tool names or autonomous PR discovery.
 - **Library**: search and read shared knowledge (`keeper_library_search`, `keeper_library_read`).
-- **Shell**: inspect files and search source with the visible aliases (`Read`, `Grep`). Use `Execute` for command execution when your policy exposes it. Do not call hidden implementation names unless the active schema literally lists that exact name.
+- **Shell**: inspect files and search source with the visible aliases (`Read`, `Grep`). Use `Execute` for command execution when the active schema exposes it. Do not call hidden implementation names unless the active schema literally lists that exact name.
 - **Memory**: your checkpoint and decision records persist. Use `keeper_memory_search` to recall past context.
 
 Task state is tool state, not repo file state. Do not use shell commands to read
@@ -77,7 +77,7 @@ When you see actionable context (mentions, board activity, tasks, repo changes),
 Decide what to do based on the current world state below.
 
 ### Tool-first principle
-- Read before concluding: if available, use `Read`, `Grep`, or `keeper_library_search` to gather facts before stating opinions. Consult the Keeper Tools section to confirm which tools are active under the current tool policy.
+- Read before concluding: if available, use `Read`, `Grep`, or `keeper_library_search` to gather facts before stating opinions. Consult the Keeper Tools section to confirm which tools are active in the current runtime schema.
 - On actionable turns, do not stop after read/search/list/status tools when the evidence shows real work. Continue with the tool that fits the live signal, or explicitly report the concrete blocker/no-work result.
 - Act before reporting when a tool is the correct way to handle the signal: `keeper_board_comment`, `keeper_board_post`, `keeper_task_claim`, or another active tool. Claiming backlog work is optional unless you are actually taking that work.
 - A turn with zero tool calls is acceptable when the answer is already known from context or the correct result is no-op/blocker reporting.

--- a/lib/board/board_agent_effect_hooks.mli
+++ b/lib/board/board_agent_effect_hooks.mli
@@ -1,0 +1,5 @@
+(** Agent/economy adapter for neutral Board side-effect hooks. *)
+
+val install : unit -> unit
+(** Install the concrete economy and Thompson-sampling observer for board
+    side-effect hooks. *)

--- a/lib/board/board_core_persist.mli
+++ b/lib/board/board_core_persist.mli
@@ -1,0 +1,119 @@
+(** Board core persistence and mutation helpers.
+
+    This is the persistence split consumed by [Board_core]. It intentionally
+    exposes the helper surface that [Board_core] includes and builds on. *)
+
+include module type of struct
+  include Board_core_classify
+end
+
+include module type of struct
+  include Board_core_payload
+end
+
+include module type of struct
+  include Board_core_json
+end
+
+val flush_interval_sec : float
+val persist_error_count : unit -> int
+val record_persist_error : where:string -> string -> unit
+
+val create_store : unit -> store
+val reset_comment_rate_tracker : unit -> unit
+val check_comment_rate_limit : author:string -> now:float -> float option
+val record_comment_timestamp : author:string -> now:float -> unit
+
+val invalidate_post_caches : store -> unit
+val invalidate_comment_caches : store -> unit
+val mark_dirty_post : store -> string -> unit
+val mark_dirty_comment : store -> string -> unit
+val with_lock : store -> (unit -> 'a) -> 'a
+val with_persist_lock : store -> (unit -> 'a) -> 'a
+val sweep : store -> int * int
+val maybe_sweep : store -> unit
+
+val board_base_path : unit -> string
+val board_masc_dir : unit -> string
+val persist_path : unit -> string
+val comments_path : unit -> string
+val reactions_path : unit -> string
+val sub_boards_path : unit -> string
+val ensure_dir : string -> unit
+val ensure_masc_dir : unit -> unit
+val max_jsonl_bytes : int
+val rotate_if_needed : string -> unit
+
+val posts_jsonl_unlocked : store -> string
+val save_posts_jsonl : string -> unit
+val rewrite_posts : store -> unit
+val rewrite_comments : store -> unit
+val reactions_jsonl_unlocked : store -> string
+val save_reactions_jsonl : string -> unit
+val rewrite_reactions_unlocked : store -> unit
+val rewrite_reactions : store -> unit
+val append_post : post -> unit
+val append_comment : comment -> unit
+
+val sub_board_access_to_string : sub_board_access -> string
+val sub_board_access_of_string_opt : string -> sub_board_access option
+val sub_board_post_counts_unlocked : store -> (string, int) Hashtbl.t
+val sub_board_post_count_from_counts : (string, int) Hashtbl.t -> string -> int
+val sub_board_with_post_count_unlocked : store -> sub_board -> sub_board
+val sub_board_with_post_count : (string, int) Hashtbl.t -> sub_board -> sub_board
+val sub_board_author_allowed : sub_board -> author_id:Agent_id.t -> bool
+val validate_sub_board_post_policy_unlocked :
+  store -> author_id:Agent_id.t -> hearth:string option -> (unit, board_error) result
+
+type create_post_outcome =
+  | Fresh_post of post
+  | Dedup_hit of post
+  | Rolled_up_post of post
+
+val post_of_create_post_outcome : create_post_outcome -> post
+val status_rollup_task_id :
+  title:string -> body:string -> meta_json:Yojson.Safe.t option -> string option
+val is_status_rollup_candidate :
+  post_kind:post_kind ->
+  title:string ->
+  body:string ->
+  meta_json:Yojson.Safe.t option ->
+  bool
+val find_status_rollup_target_unlocked :
+  store ->
+  author_id:Agent_id.t ->
+  hearth:string option ->
+  visibility:visibility ->
+  task_id:string ->
+  now:float ->
+  post option
+
+val create_post_with_outcome :
+  store ->
+  author:string ->
+  content:string ->
+  ?title:string ->
+  ?body:string ->
+  post_kind:post_kind ->
+  ?meta_json:Yojson.Safe.t ->
+  ?visibility:visibility ->
+  ?ttl_hours:int ->
+  ?hearth:string ->
+  ?thread_id:string ->
+  unit ->
+  (create_post_outcome, board_error) result
+
+val create_post :
+  store ->
+  author:string ->
+  content:string ->
+  ?title:string ->
+  ?body:string ->
+  post_kind:post_kind ->
+  ?meta_json:Yojson.Safe.t ->
+  ?visibility:visibility ->
+  ?ttl_hours:int ->
+  ?hearth:string ->
+  ?thread_id:string ->
+  unit ->
+  (post, board_error) result

--- a/lib/board/board_core_status_rollup.mli
+++ b/lib/board/board_core_status_rollup.mli
@@ -1,0 +1,27 @@
+(** Status-rollup classification and target search for board automation posts. *)
+
+include module type of struct
+  include Board_types
+end
+
+val status_rollup_window_sec : float
+val max_status_rollup_body_length : int
+
+val status_rollup_task_id :
+  title:string -> body:string -> meta_json:Yojson.Safe.t option -> string option
+
+val is_status_rollup_candidate :
+  post_kind:post_kind ->
+  title:string ->
+  body:string ->
+  meta_json:Yojson.Safe.t option ->
+  bool
+
+val find_status_rollup_target_unlocked :
+  store ->
+  author_id:Agent_id.t ->
+  hearth:string option ->
+  visibility:visibility ->
+  task_id:string ->
+  now:float ->
+  post option

--- a/lib/board/board_effect_hooks.mli
+++ b/lib/board/board_effect_hooks.mli
@@ -1,0 +1,33 @@
+(** Board-owned side-effect hooks. *)
+
+type earn_kind =
+  | Board_post
+  | Upvote
+
+type vote_direction =
+  | Up
+  | Down
+
+type observer =
+  { earn :
+      base_path:string ->
+      agent_name:string ->
+      kind:earn_kind ->
+      reason:string ->
+      unit ->
+      (unit, string) result
+  ; record_vote : agent_name:string -> direction:vote_direction -> unit
+  }
+
+val set_observer : observer -> unit
+val reset_for_test : unit -> unit
+
+val earn :
+  base_path:string ->
+  agent_name:string ->
+  kind:earn_kind ->
+  reason:string ->
+  unit ->
+  (unit, string) result
+
+val record_vote : agent_name:string -> direction:vote_direction -> unit

--- a/lib/board/board_metrics_hooks.mli
+++ b/lib/board/board_metrics_hooks.mli
@@ -1,0 +1,30 @@
+(** Board-owned metric hooks with typed label dimensions. *)
+
+type board_persist_surface =
+  | Board_post_meta_json
+
+type flusher_outcome =
+  | Switch_finished
+  | Cas_exhausted
+
+type observer =
+  { observe_persist_lock_acquire_sec : float -> unit
+  ; observe_persist_lock_held_sec : float -> unit
+  ; inc_dispatch_flusher_start_outcome : outcome:flusher_outcome -> unit
+  ; inc_vote_fixture_detected : count:int -> unit
+  ; inc_persistence_read_drop :
+      surface:board_persist_surface -> reason:Read_drop_reason.t -> unit
+  ; inc_legacy_migrate_post_kind :
+      author:string -> automation_label:Board_types.automation_label -> unit
+  }
+
+val set_observer : observer -> unit
+val reset_for_test : unit -> unit
+val observe_persist_lock_acquire_sec : float -> unit
+val observe_persist_lock_held_sec : float -> unit
+val inc_dispatch_flusher_start_outcome : outcome:flusher_outcome -> unit
+val inc_vote_fixture_detected : count:int -> unit
+val inc_persistence_read_drop :
+  surface:board_persist_surface -> reason:Read_drop_reason.t -> unit
+val inc_legacy_migrate_post_kind :
+  author:string -> automation_label:Board_types.automation_label -> unit

--- a/lib/eio_context/eio_context.ml
+++ b/lib/eio_context/eio_context.ml
@@ -77,6 +77,9 @@ let get_mono_clock_opt () =
 let set_switch sw =
   Atomic.set current_sw (Some sw)
 
+let get_root_switch_opt () =
+  Atomic.get current_sw
+
 let set_env env =
   Atomic.set current_env (Some env)
 

--- a/lib/eio_context/eio_context.mli
+++ b/lib/eio_context/eio_context.mli
@@ -24,6 +24,11 @@ val set_switch : Eio.Switch.t -> unit
 (** Set the global Eio switch (server root_sw). Written once at server
     bootstrap; survives until process exit. *)
 
+val get_root_switch_opt : unit -> Eio.Switch.t option
+(** Get the server root switch without consulting the fiber-local
+    turn-scoped binding. Use only for work that must survive a single
+    keeper turn, such as queued background voice playback. *)
+
 val set_env : Eio_unix.Stdenv.base -> unit
 (** Set the global Eio standard environment.  Required by long-lived
     consumers that need more than [net]/[clock] (e.g. piaf

--- a/lib/governance_pipeline_risk.ml
+++ b/lib/governance_pipeline_risk.ml
@@ -181,6 +181,23 @@ let risk_of_typed : Tool_name.t -> risk_level = function
   | Tool_name.Masc m -> risk_of_masc m
 ;;
 
+let risk_of_keeper (k : Keeper_tool_name.t) : risk_level =
+  let open Keeper_tool_name in
+  match k with
+  | Execute -> Critical
+  | Board_comment | Board_comment_vote | Board_curation_read | Board_curation_submit
+  | Board_get | Board_list | Board_post | Board_search | Board_stats
+  | Board_sub_board_get | Board_sub_board_list | Board_vote | Broadcast
+  | Context_status | Handoff | Library_read | Library_search | Memory_search
+  | Memory_write | Search_files | Stay_silent | Tasks_audit | Tasks_list | Time_now
+  | Tool_search | Tools_list | Voice_agent | Voice_listen | Voice_session_end
+  | Voice_session_start | Voice_sessions | Voice_speak -> Low
+  | Board_sub_board_create | Board_sub_board_update | Task_claim | Task_create | Task_done
+  | Task_submit_for_verification -> Medium
+  | Fs_edit | Fs_write | Fs_read | Ide_annotate -> High
+  | Board_sub_board_delete | Task_force_done | Task_force_release -> Critical
+;;
+
 (* Non-typed names absent from [Tool_name] keep an explicit override; the
    substring path would misclassify them (e.g. "query_skill" contains
    "kill" -> Critical). Empty = all known names are in [Tool_name]. *)
@@ -341,10 +358,16 @@ let classify_with_payload ~tool_name ~input =
       then Some Critical
       else None
 
+let pre_metadata_risk_overrides : (string * risk_level) list =
+  [ "masc_bind", Medium; "masc_unbind", Medium ]
+
 let baseline_risk ~tool_name ~input =
-  match classify_with_metadata ~tool_name with
+  match List.assoc_opt tool_name pre_metadata_risk_overrides with
   | Some level -> level
   | None ->
+    match classify_with_metadata ~tool_name with
+    | Some level -> level
+    | None ->
       if String.equal tool_name "masc_goal_transition" then
         goal_transition_risk input
       else if
@@ -359,11 +382,14 @@ let baseline_risk ~tool_name ~input =
         match Tool_name.of_string tool_name with
         | Some typed -> risk_of_typed typed
         | None -> (
-            (* not a registered Tool_name: explicit residual override,
-               else substring fallback (defense for unknown/typo names) *)
-            match List.assoc_opt tool_name residual_risk_overrides with
-            | Some level -> level
-            | None -> classify_name tool_name))
+            match Keeper_tool_name.of_string tool_name with
+            | Some typed -> risk_of_keeper typed
+            | None -> (
+                (* not a registered Tool_name: explicit residual override,
+                   else substring fallback (defense for unknown/typo names) *)
+                match List.assoc_opt tool_name residual_risk_overrides with
+                | Some level -> level
+                | None -> classify_name tool_name)))
 
 let keeper_mutation_requires_high_floor ~tool_name ~input =
   match tool_name with

--- a/lib/keeper/keeper_agent_tool_surface.mli
+++ b/lib/keeper/keeper_agent_tool_surface.mli
@@ -147,7 +147,7 @@ val satisfying_tools_for_turn :
   turn_affordances:string list -> allowed_tool_names:string list -> string list
 
 (** Specific tools that should be force-included/preferred for an
-    affordance, when the keeper policy exposes them. *)
+    affordance, when the active runtime schema exposes them. *)
 val preferred_tool_names_for_turn_affordances : string list -> string list
 
 val has_turn_affordance : turn_affordance -> string list -> bool

--- a/lib/keeper/keeper_guards.ml
+++ b/lib/keeper/keeper_guards.ml
@@ -181,8 +181,8 @@ let gate_decision_to_string = function
   | Gate_approval_required -> "approval_required"
 
 let gate_decision_is_rejection = function
-  | Gate_override | Gate_approval_required -> true
-  | Gate_continue -> false
+  | Gate_override -> true
+  | Gate_continue | Gate_approval_required -> false
 
 type gate_rejection_log_severity =
   | Gate_rejection_first_warn
@@ -310,11 +310,11 @@ let notify_gate_decision on_gate_decision (event : gate_decision_event) =
     - [reason_text]         human-readable detail
     - [source]              "hook" (distinguishes from legacy paths) *)
 (* Spec mapping: GateRejected action — KeeperTurnCycle.tla lines 189-200.
-   The two-arm match below routes Gate_override | Gate_approval_required to
-   Keeper_registry.mark_turn_gate_rejected_by_name, which fires the
-   decision_stage = "gate_rejected" / turn_phase = "finalizing" transition.
-   The Gate_continue branch skips the spec action entirely and only emits
-   the Event_bus Custom event below.
+   Gate_override routes to Keeper_registry.mark_turn_gate_rejected_by_name,
+   which fires the decision_stage = "gate_rejected" / turn_phase =
+   "finalizing" transition. Gate_approval_required is not terminal: OAS
+   suspends in the approval callback and may still execute the tool after
+   approval.
 
    Cycle 49 observability addition: when the gate rejects, the turn
    becomes terminal WITHOUT any runtime tier ever being attempted.  A
@@ -332,7 +332,7 @@ let notify_gate_decision on_gate_decision (event : gate_decision_event) =
     - [keeper]   ∈ keeper agent names (finite per fleet)
     - [tool]     ∈ tool names (finite, registry-controlled)
     - [reason]   ∈ guard reason_code strings (finite, defined by guards)
-    - [decision] ∈ {override, approval_required} *)
+    - [decision] ∈ {override} *)
 let gate_rejected_terminal_metric =
   Keeper_metrics.(to_string TurnGateRejectedTerminal)
 
@@ -370,7 +370,12 @@ let emit_gate_event
       "keeper:%s tool:%s decision=%s reason_code=%s runtime=none \
        (gate rejected before runtime attempt)"
       agent_name tool_name decision_label reason_code
-  end;
+  end
+  else if decision = Gate_approval_required then
+    Log.Keeper.info
+      "keeper:%s tool:%s decision=%s reason_code=%s runtime=none \
+       (approval pending before runtime attempt)"
+      agent_name tool_name decision_label reason_code;
   match Masc_event_bus.get () with
   | None -> ()
   | Some bus ->
@@ -385,7 +390,11 @@ let emit_gate_event
       ("stage_latency_ms", `Float stage_latency_ms);
       ("reason_text", `String reason_text);
       ("source", `String "hook");
-      ("runtime_attempted", `Bool (not is_gate_rejection));
+      ( "runtime_attempted"
+      , `Bool
+          (match decision with
+           | Gate_continue -> true
+           | Gate_override | Gate_approval_required -> false) );
       ("source_path", Json_util.string_opt_to_json source_path);
       ("source_line", Json_util.int_opt_to_json source_line);
     ] in

--- a/lib/keeper/keeper_hooks_oas_idle.ml
+++ b/lib/keeper/keeper_hooks_oas_idle.ml
@@ -52,7 +52,7 @@ let on_idle_decision_with_threshold ~skip_at ~consecutive_idle_turns
       ~max_suggestions:5
   in
   let alt_str = match alternatives with
-    | [] -> "keeper_tool_search, keeper_board_post, or stay_silent"
+    | [] -> "keeper_tool_search or keeper_stay_silent"
     | alts -> String.concat ", " alts
   in
   if consecutive_idle_turns >= skip_at then

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -378,6 +378,51 @@ let assemble_hooks
                     (String.length computed_surface.query_text)
                     (Keeper_agent_tool_surface.tool_selection_mode_to_string
                        computed_surface.selection_mode);
+                let turn_visible_tool_names =
+                  computed_surface.turn_visible_tool_names
+                in
+                let tool_visible name = List.mem name turn_visible_tool_names in
+                let last_turn_decision_hint =
+                  if tool_visible "keeper_board_post"
+                  then
+                    "(2) call keeper_board_post to hand off the current task \
+                     and ask another keeper or operator for judgment when the \
+                     work needs a decision you cannot make alone"
+                  else if tool_visible "keeper_broadcast"
+                  then
+                    "(2) call keeper_broadcast to hand off the current task \
+                     when the work needs a decision you cannot make alone"
+                  else
+                    "(2) include the decision blocker in your [STATE] block \
+                     when the work needs a decision you cannot make alone"
+                in
+                let last_turn_task_close_hint =
+                  if
+                    tool_visible "keeper_task_done"
+                    || tool_visible "keeper_task_submit_for_verification"
+                  then
+                    "; (3) if you claimed a task, close it NOW before session \
+                     ends with keeper_task_done or \
+                     keeper_task_submit_for_verification"
+                  else ""
+                in
+                let budget_blocker_hint =
+                  if tool_visible "keeper_board_post"
+                  then
+                    "If you are blocked on a decision or external input, post \
+                     a question to the board via keeper_board_post rather than \
+                     burning turns retrying — that is the intended \
+                     judgment-escalation path."
+                  else if tool_visible "keeper_broadcast"
+                  then
+                    "If you are blocked on a decision or external input, \
+                     broadcast the blocker via keeper_broadcast rather than \
+                     burning turns retrying."
+                  else
+                    "If you are blocked on a decision or external input, \
+                     record the blocker in [STATE] rather than burning turns \
+                     retrying."
+                in
                 let append_ctx ctx text =
                   Some
                     (match ctx with
@@ -395,14 +440,11 @@ let assemble_hooks
                           now summarizing what you accomplished and what the next \
                           generation should do. Do NOT start new tool work. Three escape \
                           hatches, in priority order: (1) call extend_turns if the task \
-                          is almost finished and more turns will close it out; (2) call \
-                          keeper_board_post to hand off the current task and ask another \
-                          keeper or operator for judgment when the work needs a decision \
-                          you cannot make alone; (3) if you claimed a task, close it NOW \
-                          before session ends with keeper_task_done or \
-                          keeper_task_submit_for_verification."
+                          is almost finished and more turns will close it out; %s%s."
                          computed_surface.per_call_turn
-                         computed_surface.per_call_max_turns)
+                         computed_surface.per_call_max_turns
+                         last_turn_decision_hint
+                         last_turn_task_close_hint)
                   else if is_retry
                   then
                     append_ctx
@@ -419,12 +461,10 @@ let assemble_hooks
                       (Printf.sprintf
                          "[BUDGET] %d/%d turns used in this Agent.run call. Wrap up \
                           current work and emit a [STATE] block. If more turns will \
-                          genuinely finish the task, call extend_turns. If you are \
-                          blocked on a decision or external input, post a question to \
-                          the board via keeper_board_post rather than burning turns \
-                          retrying — that is the intended judgment-escalation path."
+                          genuinely finish the task, call extend_turns. %s"
                          computed_surface.per_call_turn
-                         computed_surface.per_call_max_turns)
+                         computed_surface.per_call_max_turns
+                         budget_blocker_hint)
                   else ctx
                 in
                 if computed_surface.is_warning_zone
@@ -438,9 +478,6 @@ let assemble_hooks
                     computed_surface.per_call_turn
                     computed_surface.per_call_max_turns
                     computed_surface.is_last_turn;
-                let turn_visible_tool_names =
-                  computed_surface.turn_visible_tool_names
-                in
                 let tool_filter =
                   Agent_sdk.Guardrails.AllowList turn_visible_tool_names
                 in

--- a/lib/keeper/keeper_run_tools_search.ml
+++ b/lib/keeper/keeper_run_tools_search.ml
@@ -7,7 +7,7 @@ type tool_search_hit_partition =
 let partition_tool_search_hits ~core ~core_always ~allowed ~retrieved ~max_results =
   (* PR #14574 review #1/#7: only expose a public alias (e.g. "Execute") when
      its routed internal handler is actually in the
-     incoming [allowed] set for this tool_access list. Adding all [public_names ()]
+     incoming active surface. Adding all [public_names ()]
      unconditionally let [keeper_tool_search] return aliases even when
      their backing tool was not permitted for the turn, which would invite
      the model to attempt unregistered tool calls. *)
@@ -38,4 +38,3 @@ let partition_tool_search_hits ~core ~core_always ~allowed ~retrieved ~max_resul
   ; filtered_by_policy = List.length retrieved - List.length allowed_retrieved
   }
 ;;
-

--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -154,14 +154,19 @@ let active_turn_stale_status
     ~active_turn_timeout_sec
     ~progress_timeout_sec
     ~fiber_age
-    ~startup_grace =
+    ~startup_grace
+    ~suppress_for_pending_approval =
   let active_seconds = now -. started_at in
   let since_progress_seconds = now -. last_progress_at in
   let outside_startup_grace = fiber_age >= startup_grace in
   { active_total_stale =
-      active_seconds > active_turn_timeout_sec && outside_startup_grace
+      (not suppress_for_pending_approval)
+      && active_seconds > active_turn_timeout_sec
+      && outside_startup_grace
   ; progress_stale =
-      since_progress_seconds > progress_timeout_sec && outside_startup_grace
+      (not suppress_for_pending_approval)
+      && since_progress_seconds > progress_timeout_sec
+      && outside_startup_grace
   ; active_seconds
   ; since_progress_seconds
   }
@@ -444,6 +449,9 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
              in
              let progress_timeout = progress_timeout_sec () in
              let active_slot_holder_age = slot_holder_age ~now meta.name in
+             let approval_pending =
+               Keeper_approval_queue.has_pending_for_keeper ~keeper_name:meta.name
+             in
              let idle_stale, active_total_stale, progress_stale, in_turn_age,
                  since_progress_age, last_progress_kind, idle_skip_suppressed =
                match entry.current_turn_observation with
@@ -457,6 +465,7 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                      ~progress_timeout_sec:progress_timeout
                      ~fiber_age
                      ~startup_grace
+                     ~suppress_for_pending_approval:approval_pending
                  in
                 ( false
                 , status.active_total_stale
@@ -513,7 +522,10 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                  ~started_at:entry.started_at
                  ~last_completed_turn_ended_at
              in
-             let stale = idle_stale || in_turn_stale || failure_loop in
+             let stale =
+               (not approval_pending)
+               && (idle_stale || in_turn_stale || failure_loop)
+             in
              (* The tick line is a sampled state snapshot. Stale termination
                 and broadcasts below remain ERROR, so INFO does not need every
                 intermediate heartbeat/noop snapshot. *)

--- a/lib/keeper/keeper_stale_watchdog.mli
+++ b/lib/keeper/keeper_stale_watchdog.mli
@@ -55,6 +55,7 @@ val active_turn_stale_status_for_test :
   progress_timeout_sec:float ->
   fiber_age:float ->
   startup_grace:float ->
+  suppress_for_pending_approval:bool ->
   active_turn_stale_status
 (** Test-only view of the active-turn liveness classifier. *)
 

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -837,7 +837,8 @@ let internal_descriptors : t list =
       ~id:"keeper.tools_list"
       ~name:"keeper_tools_list"
       ~description:
-        "List the keeper-allowed tools for the current tool_access list. No arguments."
+        "List the active keeper tool surface from descriptors and registered schemas. \
+         No arguments."
       ~input_schema:empty_object_schema
       ~policy:(read_only_in_process_policy ())
       ~handler:Tool_tools_list

--- a/lib/keeper/keeper_tool_descriptor_resolution.mli
+++ b/lib/keeper/keeper_tool_descriptor_resolution.mli
@@ -19,6 +19,9 @@ val effect_domain_for_tool_name : string -> Tool_catalog.effect_domain option
 
 val capability_has : Tool_capability.kind -> string -> bool
 
+val descriptor_and_input_for_tool_call :
+  tool_name:string -> input:Yojson.Safe.t -> (Keeper_tool_descriptor.t * Yojson.Safe.t) option
+
 val readonly_for_tool_name : string -> bool option
 
 val readonly_for_tool_call : tool_name:string -> input:Yojson.Safe.t -> bool option

--- a/lib/keeper/keeper_tool_dispatch_runtime.ml
+++ b/lib/keeper/keeper_tool_dispatch_runtime.ml
@@ -2,7 +2,7 @@
 
     Split into multiple layers:
     - [Keeper_tool_registry]: declarative tool name lists (data)
-    - [Keeper_tool_policy]: access control, tool_access, allowed-tool resolution (logic)
+    - [Keeper_tool_policy]: descriptor/registry surface + denylist resolution (logic)
     - [Keeper_tool_*_runtime]: dedicated runtime modules for tool categories
     - This module: execution dispatch + shared helpers (side-effects) *)
 
@@ -370,10 +370,11 @@ let execute_keeper_tool_call_with_outcome
                "'%s' is blocked by your current policy. Ask operator to grant access."
                name )
          else
-           ( "not_in_allow_set"
+           ( "not_executable"
            , Printf.sprintf
-               "'%s' exists but your tool_access list does not allow it. Use keeper_tools_list to \
-                see available tools."
+               "'%s' exists but is not executable in this keeper runtime. Use \
+                keeper_tool_search to find an active tool or ask the operator \
+                to inspect the descriptor/denylist state."
                name )
        in
        Prometheus.inc_counter
@@ -413,13 +414,26 @@ let execute_keeper_tool_call_with_outcome
            ; mcp_session_id
            }
        in
-       match Keeper_tool_runtime.handle_internal keeper_tool_runtime_context ~name ~args with
+       let descriptor_output =
+         match
+           Keeper_tool_descriptor_resolution.descriptor_and_input_for_tool_call
+             ~tool_name:name
+             ~input:args
+         with
+         | Some (descriptor, translated_args) ->
+           Keeper_tool_runtime.handle
+             keeper_tool_runtime_context
+             ~descriptor
+             ~args:translated_args
+         | None -> Keeper_tool_runtime.handle_internal keeper_tool_runtime_context ~name ~args
+       in
+       match descriptor_output with
        | Some raw_output -> make_executed_tool_result raw_output
        | None ->
-       (* Descriptor-backed dispatch did not recognize this name. Check
-          registered backend tools before returning a suggestion-enriched
-          unknown-tool error. *)
-       let unknown_name = name in
+         (* Descriptor-backed dispatch did not recognize this name. Check
+            registered backend tools before returning a suggestion-enriched
+            unknown-tool error. *)
+         let unknown_name = name in
          (match
             Keeper_tool_registered_runtime.handle_registered_tool
               ~config

--- a/lib/keeper/keeper_tool_dispatch_runtime.mli
+++ b/lib/keeper/keeper_tool_dispatch_runtime.mli
@@ -87,7 +87,7 @@ val is_core_always_tool : string -> bool
 (** Deduplicate tool names, preserving order. *)
 val dedupe_tool_names : string list -> string list
 
-(** Inject all masc_* schemas for keeper allowlist/denylist filtering.
+(** Inject all masc_* schemas for keeper descriptor/registry surface filtering.
     Must be called once during server initialization.
     Keeper_denied tools are excluded at injection time. *)
 val inject_masc_schemas : Masc_domain.tool_schema list -> unit
@@ -95,8 +95,8 @@ val inject_masc_schemas : Masc_domain.tool_schema list -> unit
 (** Load tool group definitions from [config/tool_policy.toml].
     Must be called once during server initialization.
     Raises [Failure] if the config file is missing or malformed.
-    For tool_access-scoped allowlist filtering to include injected [masc_*]
-    schemas, call [inject_masc_schemas] before the first resolution. *)
+    Call [inject_masc_schemas] before the first resolution so injected
+    [masc_*] schemas can join the active keeper surface. *)
 val init_policy_config : base_path:string -> (unit, string) result
 
 (** Check if a tool name is in the Keeper_denied surface (Tool_catalog).

--- a/lib/keeper/keeper_tool_execute_readonly_policy.ml
+++ b/lib/keeper/keeper_tool_execute_readonly_policy.ml
@@ -69,11 +69,11 @@ let readonly_hint_of_category = function
   | "redirect" ->
     "Redirects (`>`, `>>`, `| tee`) are blocked in readonly shell. \
      Use Write/Edit when a file must change, or Execute only when the \
-     active policy exposes a write-capable Execute surface. \
+     active runtime schema exposes a write-capable Execute surface. \
      Good: Write file_path='notes.md' content='...'. \
      Bad: raw shell text 'echo hi > notes.md'."
   | "git_write" ->
-    "Use Execute only when the active policy exposes write-capable command \
+    "Use Execute only when the active runtime schema exposes write-capable command \
      execution for git writes. \
      Good: Execute executable='git' argv=['add','lib/foo.ml']. \
      Bad: raw shell text 'git commit -m x' without write access \
@@ -84,7 +84,7 @@ let readonly_hint_of_category = function
      Bad: raw shell text 'opam install eio' without write access \
      does not accept package installs)."
   | "destructive" ->
-    "Use Execute only when the active policy exposes write-capable command \
+    "Use Execute only when the active runtime schema exposes write-capable command \
      execution, not readonly shell. \
      Good: Execute executable='rm' argv=['.tmp/scratch.log']. \
      Bad: raw shell text 'rm -rf .tmp/' (readonly shell does \
@@ -224,7 +224,9 @@ let diagnosis_of_block_reason reason =
     Some
       { Exec_core.rule_id = "command_not_allowed"
       ; explanation =
-          Printf.sprintf "'%s' is not on the allowed command list for this tool_access list." name
+          Printf.sprintf
+            "'%s' is not on the allowed command list for this Execute surface."
+            name
       ; rewrite = None
       ; tool_suggestion = None
       }

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -299,7 +299,7 @@ let handle_tool_execute_typed
             ~deterministic_reason:
               Keeper_tool_deterministic_error.Destructive_operation_blocked
             ~error:"destructive_operation_blocked"
-            ~reason:"This typed command is destructive and is blocked for all tool_access lists."
+            ~reason:"This typed command is destructive and is blocked for all Execute surfaces."
             ~alternatives:[ "Use a non-destructive command or a dedicated structured tool." ]
             ()
         else if (not write_enabled)

--- a/lib/keeper/keeper_tool_execute_typed_input.ml
+++ b/lib/keeper/keeper_tool_execute_typed_input.ml
@@ -559,8 +559,8 @@ let executable_not_allowlisted_hint ~name ~mode =
     match mode, name with
     | Readonly, "gh" | Readonly, "git" ->
       Some
-        "This tool_access list is read-only. Use Read/Grep when visible; \
-         otherwise ask for a write/execute-capable schema before using git/gh."
+        "The active Execute surface is read-only. Use Read/Grep when visible; \
+         otherwise ask for a write/execute-capable runtime surface before using git/gh."
     | _, "bash" | _, "sh" | _, "zsh" ->
       Some
         "Shell interpreters are intentionally unavailable. Use typed \

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -1,7 +1,8 @@
-(** Keeper_tool_policy — tool access control and allowed-tool resolution.
+(** Keeper_tool_policy — keeper tool surface and denylist resolution.
 
     Group definitions are loaded from [config/tool_policy.toml] at startup
-    via {!Keeper_tool_policy_config}.  See that module for the config format.
+    via {!Keeper_tool_policy_config} for legacy/recovery surfaces. They do not
+    form the runtime execution allowlist for descriptor-backed keeper tools.
 
     Consumes [Keeper_tool_registry] for candidate aggregation and core tools.
     Produces the access-policy types and functions used by the dispatch layer. *)
@@ -228,15 +229,26 @@ let keeper_maintenance_only_tools =
 let is_keeper_maintenance_only_tool name =
   List.mem name keeper_maintenance_only_tools
 
-(* ── Candidate aggregation (config-driven) ────────────────────── *)
+(* ── Candidate aggregation (descriptor/registry-driven) ───────── *)
+
+let tool_schema_names schemas =
+  List.map (fun (schema : Masc_domain.tool_schema) -> schema.name) schemas
+
+let descriptor_candidate_tool_names () =
+  Keeper_tool_descriptor.all_descriptors ()
+  |> List.concat_map (fun descriptor ->
+       descriptor.Keeper_tool_descriptor.public_name
+       :: Keeper_tool_descriptor.internal_names descriptor)
+  |> dedupe_tool_names
 
 let keeper_base_candidate_tool_names () =
-  let config_tools =
-    with_policy_config_or ~accessor:"keeper_base_candidate_tool_names"
-      ~default:[] Keeper_tool_policy_config.all_group_tools
-  in
+  (* Candidate existence is registry/descriptor driven. [tool_access] and
+     tool_policy.toml groups must not be a second execution allowlist for
+     keeper-owned tools. *)
   dedupe_tool_names
-    ( config_tools
+    ( effective_core_tools ()
+    @ tool_schema_names Tool_shard.all_keeper_tool_schemas
+    @ descriptor_candidate_tool_names ()
     @ keeper_internal_candidate_tool_names
     @ injected_masc_tool_names () )
   |> List.filter (fun name -> not (is_keeper_maintenance_only_tool name))
@@ -290,9 +302,10 @@ let tool_name_set names =
   List.fold_left (fun acc name -> StringSet.add name acc) StringSet.empty names
 
 let tool_access_lookup_of_meta (meta : keeper_meta) =
-  (* keeper_base_candidate_tool_names pulls [groups.voice] from
-     tool_policy.toml via all_group_tools — voice tools are present iff
-     the keeper's allowlist includes the voice group. No per-keeper gate. *)
+  (* [allow_set] is retained for compatibility/telemetry consumers that still
+     inspect the field. Runtime execution uses candidate_set - deny_set so
+     empty or narrow [tool_access] cannot hide descriptor-backed board/voice
+     tools. *)
   let base = keeper_base_candidate_tool_names () in
   let candidate_names = dedupe_tool_names base in
   let candidate_set = tool_name_set candidate_names in
@@ -312,7 +325,6 @@ let tool_access_lookup_of_meta (meta : keeper_meta) =
 
 let filter_by_access ~(lookup : tool_access_lookup) (name : string) : bool =
   StringSet.mem name lookup.candidate_set
-  && StringSet.mem name lookup.allow_set
   && not (StringSet.mem name lookup.deny_set)
 
 (** Universe check: candidate minus denied, ignoring policy allowlist.
@@ -321,7 +333,8 @@ let filter_by_universe ~(lookup : tool_access_lookup) (name : string) : bool =
   StringSet.mem name lookup.candidate_set
   && not (StringSet.mem name lookup.deny_set)
 
-(** Execution gate: core tools bypass policy, others require policy allowlist.
+(** Execution gate: core tools bypass candidate_set; all other tools must be
+    registered candidates and not denied.
     All tools must exist in candidate_set — rejects hallucinated tool names. *)
 let can_execute ~(lookup : tool_access_lookup) (name : string) : bool =
   if Keeper_tool_registry.is_core_always_tool name then
@@ -330,7 +343,7 @@ let can_execute ~(lookup : tool_access_lookup) (name : string) : bool =
   else if not (StringSet.mem name lookup.candidate_set) then
     false
   else
-    filter_by_access ~lookup name
+    filter_by_universe ~lookup name
 
 (* ── Public query functions ───────────────────────────────────── *)
 
@@ -428,19 +441,14 @@ let keeper_universe_tool_names (meta : keeper_meta) : string list =
   in
   dedupe_tool_names (from_candidates @ from_core)
 
-(** Scoped tool universe: explicit [tool_access] + core_always - denied.
-    Strict subset of [keeper_universe_tool_names].  Used for BM25 indexing
-    to improve signal-to-noise ratio: a narrowly scoped keeper indexes fewer
-    tools instead of the full universe.  Execution gate still uses the full universe so
-    externally-granted tools (tool_overlay) remain callable.
-    See #4637 (Samchon harness: absence > prohibition). *)
+(** Search scope: registered candidates + core_always - denied.
+    Kept separate from [keeper_universe_tool_names] for call-site clarity;
+    it intentionally does not treat [tool_access] as an execution allowlist. *)
 let keeper_tool_search_scope (meta : keeper_meta) : string list =
   let lookup = tool_access_lookup_of_meta meta in
   let from_allowlist =
-    meta.tool_access
-    |> List.filter (fun name ->
-         StringSet.mem name lookup.candidate_set
-         && not (StringSet.mem name lookup.deny_set))
+    lookup.candidate_names
+    |> List.filter (fun name -> not (StringSet.mem name lookup.deny_set))
   in
   let from_core =
     Keeper_tool_registry.core_always_tools
@@ -466,7 +474,7 @@ let filter_schemas_by_names (names : string list)
   |> dedupe_tool_schemas
 
 (** Scoped model tool schemas for BM25 indexing.
-    Returns schemas only for the tool_access-scoped universe. *)
+    Returns schemas for the active descriptor/registry surface minus denied tools. *)
 let keeper_model_tool_schemas (meta : keeper_meta) : Masc_domain.tool_schema list =
   let scoped = keeper_tool_search_scope meta in
   all_keeper_schemas ~masc_schemas_fn:keeper_universe_masc_tool_schemas meta
@@ -485,9 +493,9 @@ let keeper_allowed_model_tools ?(write_done = false) (meta : keeper_meta) :
     let count = List.length result in
     if count > Keeper_config.tool_policy_count_warn_threshold then
       Log.Keeper.warn
-        "tool policy allows %d schemas (~%dKB). Progressive disclosure \
+        "keeper tool surface exposes %d schemas (~%dKB). Progressive disclosure \
          limits actual LLM context to ~20-40, but universe build cost scales \
-         with policy size. Consider a narrower tool_access list."
+         with surface size. Consider tightening denylist/visibility settings."
         count (count * 470 / 1024);
     result
 

--- a/lib/keeper/keeper_tool_policy.mli
+++ b/lib/keeper/keeper_tool_policy.mli
@@ -1,8 +1,8 @@
-(** Keeper_tool_policy — tool access control and allowed-tool resolution.
+(** Keeper_tool_policy — keeper tool surface and denylist resolution.
 
     Group definitions are loaded from [config/tool_policy.toml] at startup
-    via {!Keeper_tool_policy_config}.  Consumes {!Keeper_tool_registry} for
-    candidate aggregation and core tools.
+    via {!Keeper_tool_policy_config} for legacy/recovery surfaces. Runtime
+    execution is descriptor/registry driven and filtered by denylist.
 
     @since v2.200.0 *)
 
@@ -15,7 +15,8 @@ module StringSet : Set.S with type elt = string
 (** {1 Policy Initialization} *)
 
 (** Load tool policy configuration from [config/tool_policy.toml].
-    Must be called once at server startup before tool_access resolution. *)
+    Must be called once at server startup before legacy/recovery surface
+    resolution. *)
 val init_policy_config :
   base_path:string -> (unit, string) result
 
@@ -50,9 +51,9 @@ val keeper_supported_masc_tool_names_from_schemas :
 (** Filter names to only those present in the injected MASC set. *)
 val select_existing_masc_tool_names : string list -> string list
 
-(** {1 Tool Access Lookup}
+(** {1 Tool Surface Lookup}
 
-    Per-tool access checks using immutable StringSet. *)
+    Per-tool candidate/deny checks using immutable StringSet. *)
 
 type tool_access_lookup = {
   candidate_names : string list;
@@ -67,14 +68,15 @@ val tool_name_set : string list -> StringSet.t
 (** Build a lookup structure from keeper metadata. *)
 val tool_access_lookup_of_meta : keeper_meta -> tool_access_lookup
 
-(** Check if a tool passes candidate + policy + deny filters. *)
+(** Check if a tool passes candidate + deny filters. *)
 val filter_by_access : lookup:tool_access_lookup -> string -> bool
 
-(** Check candidate membership minus denied, ignoring policy.
+(** Check candidate membership minus denied.
     Used as execution gate for BM25-discovered tools. *)
 val filter_by_universe : lookup:tool_access_lookup -> string -> bool
 
-(** Execution gate: core tools bypass policy, others require allowlist.
+(** Execution gate: core tools bypass candidate_set; other tools must be
+    registered candidates and not denied.
     Rejects hallucinated tool names not in candidate_set. *)
 val can_execute : lookup:tool_access_lookup -> string -> bool
 
@@ -120,7 +122,7 @@ val failing_minimum_tool_names : unit -> string list
     sync regression test. *)
 val essential_masc_minimum_names : string list
 
-(** Policy-filtered allowed tool names.
+(** Active descriptor/registry tool names minus denied tools.
     Returns empty list when [write_done] is true.
     When [phase] is [Failing] and decision layer level >= 2,
     returns [failing_minimum_tool_names] instead (recovery floor). *)
@@ -132,7 +134,7 @@ val keeper_allowed_tool_names :
 (** Universe tool names: candidates minus denied, no policy filter. *)
 val keeper_universe_tool_names : keeper_meta -> string list
 
-(** Tool-access scoped universe: explicit allowlist + core_always - denied. *)
+(** Tool search scope: active candidates + core_always - denied. *)
 val keeper_tool_search_scope : keeper_meta -> string list
 
 (** Tools safe to call on the keeper's last turn. *)
@@ -140,14 +142,14 @@ val last_turn_safe_tool_names : unit -> string list
 
 (** {1 Tool Schema Assembly} *)
 
-(** Policy-filtered model tool schemas. *)
+(** Active model tool schemas minus denied tools. *)
 val keeper_allowed_model_tools :
   ?write_done:bool -> keeper_meta -> Masc_domain.tool_schema list
 
 (** Universe model tool schemas for Agent.run(). *)
 val keeper_universe_model_tools : keeper_meta -> Masc_domain.tool_schema list
 
-(** Tool-access scoped universe model tool schemas for BM25 indexing. *)
+(** Active descriptor/registry model tool schemas for BM25 indexing. *)
 val keeper_model_tool_schemas : keeper_meta -> Masc_domain.tool_schema list
 
 (** Filter schemas by a set of allowed names.  O(1) per schema. *)

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -1,12 +1,9 @@
 (** Keeper_tool_registry -- runtime tool name sources and schema injection.
 
-    Static tool name lists have been moved to config/tool_policy.toml.
-    This module retains only runtime-resolved names (Tool_catalog,
-    Tool_shard, injected MASC tools), core always-visible tools, and
-    dynamic schema injection.
-
-    See Keeper_tool_policy_config for the declarative tool groups used by
-    keeper tool_access lists. *)
+    This module retains runtime-resolved names (Tool_catalog, Tool_shard,
+    injected MASC tools), core always-visible tools, and dynamic schema
+    injection. Execution surfaces are resolved from descriptors/registries
+    and then denylist-filtered. *)
 
 open Keeper_types
 open Keeper_meta_contract

--- a/lib/keeper/keeper_tool_registry.mli
+++ b/lib/keeper/keeper_tool_registry.mli
@@ -1,12 +1,9 @@
 (** Keeper_tool_registry — runtime tool name sources and schema injection.
 
-    Static tool name lists have been moved to config/tool_policy.toml.
-    This module retains only runtime-resolved names (Tool_catalog,
-    Tool_shard, injected MASC tools), core always-visible tools,
-    and dynamic schema injection.
-
-    See [Keeper_tool_policy_config] for the declarative tool groups used by
-    keeper tool_access lists. *)
+    This module retains runtime-resolved names (Tool_catalog, Tool_shard,
+    injected MASC tools), core always-visible tools, and dynamic schema
+    injection. Execution surfaces are resolved from descriptors/registries
+    and then denylist-filtered. *)
 
 (** Trim, drop empty entries, and dedupe a list preserving order. *)
 val dedupe_tool_names : string list -> string list

--- a/lib/keeper/keeper_tool_shared_runtime.ml
+++ b/lib/keeper/keeper_tool_shared_runtime.ml
@@ -113,6 +113,59 @@ let actionable_path_error
 
 let file_not_found_prefix = "File not found:"
 
+let dirname_opt path =
+  let trimmed = String.trim path in
+  if trimmed = ""
+  then None
+  else (
+    match String.rindex_opt trimmed '/' with
+    | None -> Some "."
+    | Some 0 -> Some "/"
+    | Some idx -> Some (String.sub trimmed 0 idx))
+;;
+
+let split_repo_relative raw =
+  match String.split_on_char '/' raw with
+  | "repos" :: repo :: rest when repo <> "" ->
+    let rel = String.concat "/" rest in
+    Some (repo, rel)
+  | _ -> None
+;;
+
+let missing_file_recovery_examples ~(raw_path : string option) =
+  match raw_path with
+  | None -> `Assoc []
+  | Some raw ->
+    let parent = dirname_opt raw |> Option.value ~default:"." in
+    let grep_filename =
+      Filename.basename raw
+      |> fun name ->
+      `Assoc
+        [ "tool", `String "Grep"
+        ; "pattern", `String name
+        ; "path", `String parent
+        ]
+    in
+    let list_parent =
+      match split_repo_relative raw with
+      | Some (repo, rel) ->
+        let repo_parent = dirname_opt rel |> Option.value ~default:"." in
+        `Assoc
+          [ "tool", `String "Execute"
+          ; "cwd", `String ("repos/" ^ repo)
+          ; "executable", `String "ls"
+          ; "argv", `List [ `String repo_parent ]
+          ]
+      | None ->
+        `Assoc
+          [ "tool", `String "Execute"
+          ; "executable", `String "ls"
+          ; "argv", `List [ `String parent ]
+          ]
+    in
+    `Assoc [ "grep_filename", grep_filename; "list_parent", list_parent ]
+;;
+
 let missing_file_error_json
       ~(raw_path : string option)
       ~(cwd : string option)
@@ -141,6 +194,7 @@ let missing_file_error_json
               [ "implicit_cwd", `Bool false
               ; "explicit_cwd_supported", `Bool true
               ; "cwd", Json_util.string_opt_to_json cwd
+              ; "same_path_retry_will_fail", `Bool true
               ; ( "basis"
                 , `String
                     "Read resolves file_path against explicit cwd when cwd is provided; \
@@ -151,6 +205,11 @@ let missing_file_error_json
                     "For repo-relative files, pass cwd=\"repos/<repo>\" with \
                      file_path=\"lib/...\", or pass file_path=\"repos/<repo>/lib/...\". \
                      Use Grep or Execute ls first when the exact path is unclear." )
+              ; ( "retry_policy"
+                , `String
+                    "Do not retry Read with the same file_path until Grep or Execute ls \
+                     confirms the file exists." )
+              ; "recovery_examples", missing_file_recovery_examples ~raw_path
               ] )
         ])
 ;;

--- a/lib/keeper/keeper_tool_voice_runtime.ml
+++ b/lib/keeper/keeper_tool_voice_runtime.ml
@@ -56,13 +56,13 @@ let handle_speak ~(meta : keeper_meta) ~(args : Yojson.Safe.t) =
   then error_json "message is required. Good: message='Hello team.'. Bad: message=''."
   else (
     match
-      ( Eio_context.get_switch_opt ()
+      ( Eio_context.get_root_switch_opt ()
       , Eio_context.get_clock_opt ()
       , Eio_context.get_net_opt () )
     with
     | Some sw, Some clock, Some net ->
       (match
-         Voice_bridge.agent_speak
+         Voice_bridge.enqueue_agent_speak
            ~sw
            ~clock
            ~net

--- a/lib/keeper/keeper_tools_oas_bundle.ml
+++ b/lib/keeper/keeper_tools_oas_bundle.ml
@@ -46,7 +46,7 @@ let make_tool_bundle
   let turn_sandbox_factory = Some (Keeper_sandbox_factory.create ~config ~meta ()) in
   let exec_cache = Some (Masc_exec.Exec_cache.create ()) in
   (* Build Tool.t for the full universe so BM25 and Tool_op can
-     discover tools beyond the active tool_access list.  Progressive disclosure
+     discover tools beyond the current turn-visible schema.  Progressive disclosure
      (AllowList filter in before_turn_hook) controls LLM visibility;
      execute_keeper_tool_call uses can_execute for the execution gate. *)
   let universe_names = Keeper_tool_dispatch_runtime.keeper_universe_tool_names meta in

--- a/lib/prometheus_builtin_metrics_part5.ml
+++ b/lib/prometheus_builtin_metrics_part5.ml
@@ -70,14 +70,13 @@ let register
     `Counter;
   add
     Keeper_metrics.(to_string ToolNotAllowed)
-    "Total keeper tool calls denied because the tool is not in the keeper's allowlist \
-     (tool_access drift, deny-list, or unknown tool name). Labels: keeper, tool, reason. \
-     reason ∈ {not_in_candidate_set, denied_by_policy, not_in_allow_set}. Alert on a \
-     non-zero rate for any (keeper, tool) pair: it means the keeper's BDI is attempting \
-     tools that its tool_access policy does not permit, causing the keeper to loop without \
-     making progress. Distinct from masc_keeper_tool_use_failure_total (post-execution \
-     hook failure) and masc_keeper_turn_gate_rejected_terminal_total (pre_tool_use guard \
-     hard-reject)."
+    "Total keeper tool calls denied before runtime dispatch because the name is not in \
+     the descriptor/registry candidate set or is denied by policy. Labels: keeper, \
+     tool, reason. reason ∈ {not_in_candidate_set, denied_by_policy, not_executable}. \
+     Alert on a non-zero rate for any (keeper, tool) pair: it means the keeper is \
+     attempting unavailable or denied tools and may loop without making progress. \
+     Distinct from masc_keeper_tool_use_failure_total (post-execution hook failure) \
+     and masc_keeper_turn_gate_rejected_terminal_total (pre_tool_use guard hard-reject)."
     `Counter;
   add
     metric_after_turn_response_model_empty

--- a/lib/server/server_dashboard_http_keeper_api_post.mli
+++ b/lib/server/server_dashboard_http_keeper_api_post.mli
@@ -1,0 +1,90 @@
+(** Keeper HTTP API POST handlers and runtime-trace helpers. *)
+
+module Http = Http_server_eio
+
+include module type of Server_dashboard_http_keeper_api_types
+
+val dedupe_tool_names : string list -> string list
+val json_list_length : Yojson.Safe.t -> int
+val trajectory_line_ts : Trajectory.trajectory_line -> float
+val dedupe_thinking_lines :
+  Trajectory.trajectory_line list -> Trajectory.trajectory_line list
+val read_internal_history_lines :
+  config:Workspace.config -> trace_id:string -> Trajectory.trajectory_line list
+val merge_keeper_trace_lines :
+  config:Workspace.config ->
+  trace_id:string ->
+  Trajectory.trajectory_line list ->
+  Trajectory.trajectory_line list
+
+val keeper_tools_response_json : Keeper_meta_contract.keeper_meta -> Yojson.Safe.t
+val error_json : ?ok:bool -> string -> Yojson.Safe.t
+val respond_error :
+  ?status:Httpun.Status.t ->
+  ?request:Httpun.Request.t ->
+  ?ok:bool ->
+  Httpun.Reqd.t ->
+  string ->
+  unit
+
+val handle_keeper_tools_post :
+  Mcp_server.server_state -> Httpun.Request.t -> Httpun.Reqd.t -> unit
+
+val stat_json_of_path : string -> Yojson.Safe.t
+val oas_checkpoint_summary_json :
+  source_kind:string ->
+  snapshot_id:string ->
+  path:string ->
+  is_current:bool ->
+  fallback_generation:int ->
+  Agent_sdk.Checkpoint.t ->
+  Yojson.Safe.t
+val keeper_checkpoint_inventory_json :
+  Workspace.config -> string -> [ `Not_found | `OK ] * Yojson.Safe.t
+
+include module type of Server_dashboard_http_keeper_runtime_manifest_scan
+
+val keeper_runtime_trace_json :
+  Workspace.config ->
+  string ->
+  ?trace_id:string ->
+  ?turn_id:int ->
+  ?limit:int ->
+  unit ->
+  [ `Not_found | `OK ] * Yojson.Safe.t
+
+val handle_keeper_checkpoints_post :
+  Mcp_server.server_state -> Httpun.Request.t -> Httpun.Reqd.t -> string -> unit
+
+val refresh_keeper_execution_surfaces :
+  config:Workspace_utils.config -> name:String.t -> string -> unit
+val invalidate_keeper_execution_surfaces :
+  config:Workspace_utils.config -> unit -> unit
+
+val handle_keeper_config_post :
+  sw:Eio.Switch.t ->
+  clock:[> float Eio.Time.clock_ty ] Eio.Time.clock ->
+  Mcp_server.server_state ->
+  string ->
+  Httpun.Request.t ->
+  Httpun.Reqd.t ->
+  string ->
+  unit
+
+val handle_keeper_lifecycle_post :
+  ?body_str:string ->
+  sw:Eio.Switch.t ->
+  clock:[> float Eio.Time.clock_ty ] Eio.Time.clock ->
+  tool_name:string ->
+  action:String.t ->
+  Mcp_server.server_state ->
+  string ->
+  Httpun.Request.t ->
+  Httpun.Reqd.t ->
+  unit
+
+val handle_keeper_directive_post :
+  Mcp_server.server_state -> 'a -> Httpun.Request.t -> Httpun.Reqd.t -> string -> unit
+
+val handle_keeper_bulk_directive_post :
+  Mcp_server.server_state -> 'a -> Httpun.Request.t -> Httpun.Reqd.t -> string -> unit

--- a/lib/server/server_routes_http_routes_dashboard_setup.mli
+++ b/lib/server/server_routes_http_routes_dashboard_setup.mli
@@ -1,0 +1,34 @@
+(** Setup helpers consumed by the dashboard route builder. *)
+
+module Http = Http_server_eio
+module Provider_logs = Server_routes_http_dashboard_provider_logs
+module Keeper_api = Server_dashboard_http_keeper_api
+
+val dashboard_logs_store_path : masc_root:string -> string
+val dashboard_logs_json :
+  config:Workspace.config ->
+  limit:int ->
+  level_filter:string ->
+  applied_level:Log.level ->
+  min_level:int ->
+  module_filter:string ->
+  since_seq:int option ->
+  Log.Ring.entry list ->
+  Yojson.Safe.t
+
+val trimmed_query_param : Httpun.Request.t -> string -> string option
+val oas_telemetry_limit_param : Httpun.Request.t -> int
+val oas_telemetry_provider_param : Httpun.Request.t -> string option
+
+val dashboard_dev_token_path : string -> string
+val ensure_dashboard_dev_token : string -> (string, string) result
+
+val handle_broadcast :
+  Mcp_server.server_state -> string -> Httpun.Reqd.t -> string -> unit
+val handle_dashboard_link_previews :
+  Mcp_server.server_state -> Httpun.Request.t -> Httpun.Reqd.t -> string -> unit
+val handle_dashboard_task_history :
+  Mcp_server.server_state -> Httpun.Request.t -> Httpun.Reqd.t -> unit
+val handle_dashboard_workspace :
+  Mcp_server.server_state -> Httpun.Request.t -> Httpun.Reqd.t -> unit
+val handle_telemetry : Httpun.Request.t -> Httpun.Reqd.t -> unit

--- a/lib/tool_shard_types_schemas_base.ml
+++ b/lib/tool_shard_types_schemas_base.ml
@@ -148,8 +148,8 @@ let base_tools : Masc_domain.tool_schema list =
     ; description =
         "List all tools currently available to you, grouped by category. Use when asked \
          'what can you do?' or when you need to discover your capabilities. Returns tool \
-         names organized by category. Only includes tools allowed by your current \
-         tool_access list and policy."
+         names organized by category. Includes the active runtime schema/descriptor \
+         surface after denylist filtering."
     ; input_schema = `Assoc [ "type", `String "object"; "properties", `Assoc [] ]
     }
   ]

--- a/lib/voice/voice_bridge.ml
+++ b/lib/voice/voice_bridge.ml
@@ -655,6 +655,149 @@ let agent_speak ~sw ~clock ~net ~agent_id ~message ?provider ?(priority = 1) () 
     else try_endpoints [] endpoints)
 ;;
 
+type queued_agent_speak_job =
+  { job_id : string
+  ; agent_id : string
+  ; message : string
+  ; provider : string option
+  ; priority : int
+  ; submitted_at : float
+  ; sequence : int
+  }
+
+let speak_queue_mu = Stdlib.Mutex.create ()
+let speak_queue : queued_agent_speak_job list ref = ref []
+let speak_worker_running = ref false
+let speak_next_sequence = Atomic.make 0
+
+let job_precedes a b =
+  if a.priority <> b.priority
+  then a.priority > b.priority
+  else a.sequence < b.sequence
+
+let insert_speak_job job queue =
+  let rec loop acc = function
+    | [] -> List.rev (job :: acc)
+    | head :: rest when job_precedes job head ->
+      List.rev_append acc (job :: head :: rest)
+    | head :: rest -> loop (head :: acc) rest
+  in
+  loop [] queue
+
+let message_preview message =
+  String.sub message 0 (min 80 (String.length message))
+
+let dequeue_speak_job () =
+  Stdlib.Mutex.protect speak_queue_mu (fun () ->
+    match !speak_queue with
+    | [] ->
+      speak_worker_running := false;
+      None
+    | job :: rest ->
+      speak_queue := rest;
+      Some job)
+
+let queue_size () =
+  Stdlib.Mutex.protect speak_queue_mu (fun () -> List.length !speak_queue)
+
+let rec drain_agent_speak_queue ~sw ~clock ~net () =
+  match dequeue_speak_job () with
+  | None -> ()
+  | Some job ->
+    (try
+       match
+         agent_speak
+           ~sw
+           ~clock
+           ~net
+           ~agent_id:job.agent_id
+           ~message:job.message
+           ?provider:job.provider
+           ~priority:job.priority
+           ()
+       with
+       | Ok _ ->
+         Log.Transport.info
+           "voice_queue completed job=%s agent=%s remaining=%d"
+           job.job_id
+           job.agent_id
+           (queue_size ())
+       | Error err ->
+         Log.Transport.error
+           "voice_queue failed job=%s agent=%s error=%s"
+           job.job_id
+           job.agent_id
+           err
+     with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | exn ->
+       Log.Transport.error
+         "voice_queue exception job=%s agent=%s exn=%s"
+         job.job_id
+         job.agent_id
+         (Printexc.to_string exn));
+    drain_agent_speak_queue ~sw ~clock ~net ()
+
+let enqueue_agent_speak ~sw ~clock ~net ~agent_id ~message ?provider ?(priority = 1) () =
+  let message = String.trim message in
+  if message = ""
+  then Error "message is required. Good: message='Hello team.'. Bad: message=''."
+  else (
+    let sequence = Atomic.fetch_and_add speak_next_sequence 1 in
+    let submitted_at = Time_compat.now () in
+    let job_id =
+      Printf.sprintf
+        "voice-%s-%d"
+        (safe_agent_id agent_id)
+        sequence
+    in
+    let job =
+      { job_id
+      ; agent_id
+      ; message
+      ; provider =
+          (provider
+           |> Option.map String.trim
+           |> function
+           | Some value when value <> "" -> Some value
+           | _ -> None)
+      ; priority = max 1 priority
+      ; submitted_at
+      ; sequence
+      }
+    in
+    let should_start, queue_position, queue_size =
+      Stdlib.Mutex.protect speak_queue_mu (fun () ->
+        speak_queue := insert_speak_job job !speak_queue;
+        let rec position index = function
+          | [] -> index
+          | queued :: _
+            when queued.sequence = sequence && String.equal queued.job_id job_id -> index
+          | _ :: rest -> position (index + 1) rest
+        in
+        let queue_position = position 1 !speak_queue in
+        let queue_size = List.length !speak_queue in
+        let should_start = not !speak_worker_running in
+        if should_start then speak_worker_running := true;
+        should_start, queue_position, queue_size)
+    in
+    if should_start
+    then Eio.Fiber.fork ~sw (fun () -> drain_agent_speak_queue ~sw ~clock ~net ());
+    Ok
+      (`Assoc
+          [ "status", `String "queued"
+          ; "job_id", `String job_id
+          ; "agent_id", `String agent_id
+          ; "voice", `String (get_voice_for_agent agent_id)
+          ; "queue_position", `Int queue_position
+          ; "queue_size", `Int queue_size
+          ; "priority", `Int job.priority
+          ; "submitted_at", `Float submitted_at
+          ; "execution", `String "background_voice_queue"
+          ; "message_preview", `String (message_preview message)
+          ]))
+;;
+
 (** List active voice sessions *)
 let list_voice_sessions ~sw ~clock ~net =
   if not (is_voice_server_available ~sw ~clock ~net)

--- a/lib/voice/voice_bridge.mli
+++ b/lib/voice/voice_bridge.mli
@@ -53,6 +53,21 @@ val agent_speak :
   unit ->
   (Yojson.Safe.t, string) result
 
+val enqueue_agent_speak :
+  sw:Eio.Switch.t ->
+  clock:_ Eio.Time.clock ->
+  net:_ Eio.Net.t ->
+  agent_id:string ->
+  message:string ->
+  ?provider:string ->
+  ?priority:int ->
+  unit ->
+  (Yojson.Safe.t, string) result
+(** Queue speech for serialized background playback. The caller gets a
+    [status="queued"] result immediately; a single worker drains queued
+    speech by priority and FIFO sequence so multiple keepers do not overlap
+    local playback. *)
+
 val get_agent_voice :
   agent_id:string -> (Yojson.Safe.t, string) result
 

--- a/specs/keeper-state-machine/KeeperToolSurface.tla
+++ b/specs/keeper-state-machine/KeeperToolSurface.tla
@@ -30,9 +30,9 @@
 \*   floor_fired             | fallback-floor conditional fires (sets tool_surface_fallback_used = true)          | lib/keeper/keeper_run_tools_hooks.ml:compute_tool_surface
 \*   after_floor             | all_allowed after the fallback floor                                               | lib/keeper/keeper_run_tools_hooks.ml:compute_tool_surface
 \*   after_last_turn_safe    | Intersect_with safe_last_turn_tools (when is_last_turn)                            | lib/keeper/keeper_run_tools_hooks.ml:compute_tool_surface
-\*   after_passive           | provider required-tool satisfaction does not filter passive tools                  | lib/keeper/keeper_tool_progress.ml:required_tool_satisfaction
+\*   after_passive           | progress classification remains separate from surface construction                | lib/keeper/keeper_tool_progress.ml:classify_tool_progress
 \*   emitted                 | all_allowed final return — max_tools truncation (essential / non_essential split)  | lib/keeper/keeper_run_tools_hooks.ml:compute_tool_surface
-\*   required                | outstanding_required_tool_names (post-satisfaction required set)                   | lib/keeper/keeper_run_tools_hooks.ml:compute_tool_surface
+\*   required                | outstanding_required_tool_names carried through surface construction               | lib/keeper/keeper_run_tools_hooks.ml:compute_tool_surface
 \*
 \* Provider opacity (G3 acceptance gate):
 \*   The Tools universe is an abstract set of atoms ("t1", "t2", …) only.
@@ -74,7 +74,7 @@ VARIABLES
     after_floor,            \* SUBSET Tools — after the floor stage
     after_last_turn_safe,   \* SUBSET Tools — after the last-turn-safe intersect
     is_last_turn,           \* BOOLEAN — whether the last-turn-safe stage runs
-    after_passive,          \* SUBSET Tools — after provider required-tool satisfaction
+    after_passive,          \* SUBSET Tools — after progress classification
     emitted,                \* SUBSET Tools — final pipeline output (after truncation)
     step                    \* action count
 
@@ -172,8 +172,8 @@ ComputePipeline ==
        \*   - the validate_allow_list gate + merged-tools step in
        \*     compute_tool_surface ensures required
        \*     (post validate_allow_list) is in pre_floor.
-\*   - the Keeper_tool_progress.required_tool_satisfaction boundary
-       \*     (from compute_tool_surface) does not drop required-affordanced tools.
+       \*   - the Keeper_tool_progress.classify_tool_progress boundary
+       \*     remains observational and does not drop required-affordanced tools.
        \*   - the safe_last_turn_tools construction in compute_tool_surface
        \*     includes required-affordanced tools when is_last_turn fires.
        /\ r_aff \subseteq p

--- a/test/test_governance_pipeline.ml
+++ b/test/test_governance_pipeline.ml
@@ -246,6 +246,11 @@ let test_risk_medium_keeper_task_create () =
   Alcotest.(check string) "keeper_task_create is medium"
     "medium" (Gp.risk_level_to_string risk)
 
+let test_risk_low_keeper_memory_write () =
+  let risk = Gp.assess_risk ~tool_name:"keeper_memory_write" ~input:no_args in
+  Alcotest.(check string) "keeper_memory_write is low"
+    "low" (Gp.risk_level_to_string risk)
+
 let test_risk_medium_transition_start () =
   let risk =
     Gp.assess_risk ~tool_name:generic_transition_tool ~input:transition_start_input
@@ -932,6 +937,8 @@ let () =
         test_risk_critical_tool_execute_default;
       Alcotest.test_case "medium: keeper task create" `Quick
         test_risk_medium_keeper_task_create;
+      Alcotest.test_case "low: keeper memory write" `Quick
+        test_risk_low_keeper_memory_write;
       Alcotest.test_case "payload: rm -rf is critical" `Quick
         test_risk_payload_destructive_rm_rf;
       Alcotest.test_case "payload: $(date) is medium not critical" `Quick

--- a/test/test_keeper_guards.ml
+++ b/test/test_keeper_guards.ml
@@ -169,7 +169,7 @@ let test_gate_decision_vocabulary () =
     (KG.gate_decision_is_rejection KG.Gate_override);
   check bool "continue does not reject" false
     (KG.gate_decision_is_rejection KG.Gate_continue);
-  check bool "approval rejects" true
+  check bool "approval waits without rejection" false
     (KG.gate_decision_is_rejection KG.Gate_approval_required)
 
 let test_gate_rejection_log_severity_splits_repeats () =

--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -144,6 +144,11 @@ let run_process_ok ~cwd prog argv =
 let git_ok ~cwd args =
   run_process_ok ~cwd "git" (Array.of_list ("git" :: args))
 
+let ensure_git_repo repo =
+  ensure_dir repo;
+  if not (Sys.file_exists (Filename.concat repo ".git")) then
+    git_ok ~cwd:repo [ "init"; "-q" ]
+
 let docker_image_available image =
   let cmd =
     Printf.sprintf "docker image inspect %s > /dev/null 2>&1" (Filename.quote image)
@@ -1035,11 +1040,11 @@ let test_execute_git_push_requires_write_tool_access_before_docker () =
   (match parse_bool_field raw "ok" with
    | Some true -> Alcotest.failf "push unexpectedly succeeded: %s" raw
    | Some false | None -> ());
-  Alcotest.(check (option string)) "readonly allowlist before docker"
-    (Some
-       "executable \"git\" not in readonly allowlist. This tool_access list is read-only. \
-        Use ReadFile/SearchFiles when visible; otherwise ask for a \
-        write/execute-capable schema before using git/gh.")
+	  Alcotest.(check (option string)) "readonly allowlist before docker"
+	    (Some
+	       "executable \"git\" not in readonly allowlist. The active Execute surface is \
+	        read-only. Use Read/Grep when visible; otherwise ask for a \
+	        write/execute-capable runtime surface before using git/gh.")
     (parse_string_field raw "error");
   let log = if Sys.file_exists log_path then read_file log_path else "" in
   Alcotest.(check bool) "docker container was not invoked" false
@@ -1690,6 +1695,7 @@ let test_execute_rg_no_match_remains_successful_in_docker_route () =
       (Filename.concat (Filename.concat playground "repos") "masc")
       "lib"
   in
+  ensure_git_repo (Filename.dirname lib);
   ensure_dir lib;
   ignore (Fs_compat.save_file_atomic (Filename.concat lib "sample.ml") "alpha\n");
   let log_path = Filename.concat config.Workspace.base_path "docker.log" in
@@ -1796,7 +1802,7 @@ let test_execute_rewrites_host_path_command_for_docker () =
   setup ~sandbox:Keeper_types_profile_sandbox.Docker
   @@ fun ~config ~meta ~playground ->
   let container_root = Keeper_sandbox.container_root meta.name in
-  ensure_dir (Filename.concat (Filename.concat playground "repos") "masc");
+  ensure_git_repo (Filename.concat (Filename.concat playground "repos") "masc");
   with_turn_sandbox_factory ~config ~meta @@ fun factory ->
   let raw =
     Keeper_tool_command_runtime.handle_tool_execute ~turn_sandbox_factory:(Some factory) ~exec_cache:None ~config ~meta

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -81,7 +81,11 @@ let with_exec_fixture ?tool_access name fn =
       Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Masc_mcp.Workspace.default_config dir in
       let meta = make_meta ?tool_access () in
-      fn ~config ~meta ~ctx_work:(make_ctx ()))
+      ignore (Masc_mcp.Keeper_registry.register ~base_path:config.base_path meta.name meta);
+      Fun.protect
+        ~finally:(fun () ->
+          Masc_mcp.Keeper_registry.unregister ~base_path:config.base_path meta.name)
+        (fun () -> fn ~config ~meta ~ctx_work:(make_ctx ())))
 
 let payload_kind = function
   | KET.Structured_success -> "structured_success"
@@ -161,25 +165,29 @@ let test_malformed_json_like_payload_detected () =
       (Printf.sprintf "expected malformed_structured, got %s"
          (payload_kind other))
 
-let test_execute_with_outcome_policy_gate_is_failure () =
+let test_registered_descriptor_bypasses_tool_access_allowlist () =
   with_exec_fixture
     ~tool_access:([ "keeper_tools_list" ])
-    "keeper_tool_dispatch_runtime_policy_gate"
+    "keeper_tool_dispatch_runtime_descriptor_bypass"
     (fun ~config ~meta ~ctx_work ->
       let result =
         KET.execute_keeper_tool_call_with_outcome
           ~config ~meta ~ctx_work ~exec_cache:None
-          ~name:"tool_read_file"
-          ~input:(`Assoc [ ("path", `String "blocked.txt") ])
+          ~name:"Read"
+          ~input:(`Assoc [ ("file_path", `String "blocked.txt") ])
           ()
       in
-      check string "policy gate outcome" "failure"
+      check string "runtime outcome" "failure"
         (match result.outcome with `Success -> "success" | `Failure -> "failure");
-      check string "policy gate payload shape" "structured_error"
+      check string "runtime payload shape" "structured_error"
         (payload_kind result.payload_shape);
       let json = Yojson.Safe.from_string result.raw_output in
-      check string "policy gate error" "tool_not_allowed"
-        Yojson.Safe.Util.(member "error" json |> to_string))
+      check bool "did not stop at tool_access allowlist gate" false
+        Yojson.Safe.Util.(member "error" json |> to_string = "tool_not_allowed");
+      check bool "reached file runtime" true
+        (contains_substring
+           Yojson.Safe.Util.(member "error" json |> to_string)
+           "File not found"))
 
 let counter_for_tool_not_allowed ~keeper ~tool ~reason =
   Masc_mcp.Prometheus.metric_value_or_zero
@@ -188,12 +196,13 @@ let counter_for_tool_not_allowed ~keeper ~tool ~reason =
     ()
 
 (* #13xxx: tool_not_allowed Prometheus counter *)
-let test_tool_not_allowed_increments_counter () =
-  (* A keeper with only keeper_tools_list allowed tries to call
-     tool_read_file — should land in reason=not_in_allow_set. *)
+let test_tool_not_allowed_increments_counter_for_unknown_tool () =
+  (* Unknown names are still rejected by the descriptor/registry existence
+     gate. Registered tools are not rejected merely because tool_access is
+     narrow or empty. *)
   let keeper = "test-exec-tools-not-allowed-a" in
-  let tool = "tool_read_file" in
-  let reason = "not_in_allow_set" in
+  let tool = "keeper_not_a_real_tool" in
+  let reason = "not_in_candidate_set" in
   with_exec_fixture
     ~tool_access:([ "keeper_tools_list" ])
     "keeper_tool_dispatch_runtime_not_allowed_counter"
@@ -205,9 +214,9 @@ let test_tool_not_allowed_increments_counter () =
            ~meta:{ meta with name = keeper }
            ~ctx_work ~exec_cache:None
            ~name:tool
-           ~input:(`Assoc [ ("path", `String "blocked.txt") ])
+           ~input:(`Assoc [])
            ());
-      check (float 0.0001) "not_in_allow_set counter +1"
+      check (float 0.0001) "not_in_candidate_set counter +1"
         (before +. 1.0)
         (counter_for_tool_not_allowed ~keeper ~tool ~reason))
 
@@ -268,19 +277,18 @@ let test_tool_not_allowed_reason_label_is_bounded () =
   (* Verify that the reason label written into the JSON payload is one
      of the three bounded vocabulary values, not a free-form string. *)
   with_exec_fixture
-    ~tool_access:([ "keeper_tools_list" ])
     "keeper_tool_dispatch_runtime_reason_bounded"
     (fun ~config ~meta ~ctx_work ->
       let result =
         KET.execute_keeper_tool_call_with_outcome
           ~config ~meta ~ctx_work ~exec_cache:None
-          ~name:"tool_read_file"
-          ~input:(`Assoc [ ("path", `String "x") ])
+          ~name:"keeper_not_a_real_tool"
+          ~input:(`Assoc [])
           ()
       in
       let json = Yojson.Safe.from_string result.raw_output in
       let reason = Yojson.Safe.Util.(member "reason" json |> to_string) in
-      let valid = [ "not_in_candidate_set"; "denied_by_policy"; "not_in_allow_set" ] in
+      let valid = [ "not_in_candidate_set"; "denied_by_policy"; "not_executable" ] in
       check bool "reason label is bounded vocabulary"
         true (List.mem reason valid))
 
@@ -325,14 +333,28 @@ let test_execute_with_outcome_missing_file_is_failure () =
       let result =
         KET.execute_keeper_tool_call_with_outcome
           ~config ~meta ~ctx_work ~exec_cache:None
-          ~name:"tool_read_file"
-          ~input:(`Assoc [ ("path", `String "missing.txt") ])
+          ~name:"Read"
+          ~input:(`Assoc [ ("file_path", `String "missing.txt") ])
           ()
       in
       check string "missing file outcome" "failure"
         (match result.outcome with `Success -> "success" | `Failure -> "failure");
       check string "missing file payload shape" "structured_error"
-        (payload_kind result.payload_shape))
+        (payload_kind result.payload_shape);
+      let json = Yojson.Safe.from_string result.raw_output in
+      let path_resolution = Yojson.Safe.Util.member "path_resolution" json in
+      check bool "same path retry marked as futile" true
+        Yojson.Safe.Util.(member "same_path_retry_will_fail" path_resolution |> to_bool);
+      check bool "retry policy discourages same Read" true
+        (contains_substring
+           Yojson.Safe.Util.(member "retry_policy" path_resolution |> to_string)
+           "Do not retry Read");
+      check string "grep recovery example" "Grep"
+        Yojson.Safe.Util.(
+          member "recovery_examples" path_resolution
+          |> member "grep_filename"
+          |> member "tool"
+          |> to_string))
 
 let test_execute_with_outcome_bad_query_is_failure () =
   with_exec_fixture "keeper_tool_dispatch_runtime_bad_query"
@@ -565,8 +587,8 @@ let () =
         test_malformed_json_like_payload_detected;
     ]);
     ("execute_keeper_tool_call_with_outcome", [
-      test_case "policy gate is failure" `Quick
-        test_execute_with_outcome_policy_gate_is_failure;
+      test_case "registered descriptor bypasses tool_access allowlist" `Quick
+        test_registered_descriptor_bypasses_tool_access_allowlist;
       test_case "missing file is failure" `Quick
         test_execute_with_outcome_missing_file_is_failure;
       test_case "bad query is failure" `Quick
@@ -585,8 +607,8 @@ let () =
         test_registered_dispatch_preserves_workflow_failure_class;
     ]);
     ("tool_not_allowed_counter", [
-      test_case "increments for not_in_allow_set" `Quick
-        test_tool_not_allowed_increments_counter;
+      test_case "increments for not_in_candidate_set" `Quick
+        test_tool_not_allowed_increments_counter_for_unknown_tool;
       test_case "increments for denied_by_policy" `Quick
         test_tool_not_allowed_denied_by_policy_counter;
       test_case "reason label is bounded vocabulary" `Quick

--- a/test/test_stale_kill_class.ml
+++ b/test/test_stale_kill_class.ml
@@ -249,6 +249,7 @@ let test_active_turn_progress_stale_inside_outer_budget () =
       ~progress_timeout_sec:300.0
       ~fiber_age:500.0
       ~startup_grace:360.0
+      ~suppress_for_pending_approval:false
   in
   Alcotest.(check bool)
     "active turn is below the outer wall"
@@ -269,6 +270,7 @@ let test_active_turn_progress_stale_respects_grace () =
       ~progress_timeout_sec:300.0
       ~fiber_age:120.0
       ~startup_grace:360.0
+      ~suppress_for_pending_approval:false
   in
   Alcotest.(check bool)
     "startup grace suppresses total stale"
@@ -276,6 +278,27 @@ let test_active_turn_progress_stale_respects_grace () =
     status.active_total_stale;
   Alcotest.(check bool)
     "startup grace suppresses progress stale"
+    false
+    status.progress_stale
+
+let test_active_turn_pending_approval_suppresses_stale () =
+  let status =
+    SW.active_turn_stale_status_for_test
+      ~now:701.0
+      ~started_at:0.0
+      ~last_progress_at:100.0
+      ~active_turn_timeout_sec:600.0
+      ~progress_timeout_sec:300.0
+      ~fiber_age:700.0
+      ~startup_grace:360.0
+      ~suppress_for_pending_approval:true
+  in
+  Alcotest.(check bool)
+    "pending approval suppresses active-total stale"
+    false
+    status.active_total_stale;
+  Alcotest.(check bool)
+    "pending approval suppresses progress stale"
     false
     status.progress_stale
 
@@ -465,6 +488,8 @@ let () =
             test_active_turn_progress_stale_inside_outer_budget;
           Alcotest.test_case "progress stale respects startup grace" `Quick
             test_active_turn_progress_stale_respects_grace;
+          Alcotest.test_case "pending approval suppresses stale" `Quick
+            test_active_turn_pending_approval_suppresses_stale;
         ] );
       ( "missing_registry",
         [

--- a/test/test_voice_runtime_overlay.ml
+++ b/test/test_voice_runtime_overlay.ml
@@ -36,18 +36,11 @@ let test_voice_auth_env_resolution () =
     (Voice.auth_env_name ~endpoint_api_key_env:"VOICE_PROXY_KEY" openai_compat)
 ;;
 
-let test_default_agent_voices_preserve_runtime_defaults () =
+let test_default_agent_voices_are_config_driven () =
   check
     (list (pair string string))
-    "agent voice defaults"
-    [ "llama", "Laura"
-    ; "agent_llm_a", "Sarah"
-    ; "agent_code", "George"
-    ; "provider_f", "Roger"
-    ; "agent_llm_a-api", "Sarah"
-    ; "agent_code-api", "George"
-    ; "provider_f-api", "Roger"
-    ]
+    "agent voice defaults are not hardcoded"
+    []
     (Voice.default_agent_voices ())
 ;;
 
@@ -162,6 +155,45 @@ let test_stt_request_mcp_rejected () =
   | Error _ -> ()
 ;;
 
+let make_keeper_meta name =
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+          [ "name", `String name
+          ; "agent_name", `String name
+          ; "trace_id", `String "voice-queue-test"
+          ; ( "tool_access"
+            , Masc_mcp.Keeper_meta_tool_access.tool_access_to_json
+                [ "keeper_voice_speak" ] )
+          ])
+  with
+  | Ok meta -> meta
+  | Error err -> fail ("make_keeper_meta: " ^ err)
+;;
+
+let test_keeper_voice_speak_returns_queued_with_root_switch () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let net = Eio.Stdenv.net env in
+  let clock = Eio.Stdenv.clock env in
+  let mono_clock = Eio.Stdenv.mono_clock env in
+  Eio_context.with_test_env ~net ~clock ~mono_clock ~sw (fun () ->
+    let meta = make_keeper_meta "voice-queue-keeper" in
+    let raw =
+      Masc_mcp.Keeper_tool_voice_runtime.handle_voice_tool
+        ~meta
+        ~name:"keeper_voice_speak"
+        ~args:(`Assoc [ "message", `String "hello from queued voice test" ])
+    in
+    let json = Yojson.Safe.from_string raw in
+    check string "queued status" "queued"
+      Yojson.Safe.Util.(member "status" json |> to_string);
+    check string "background execution" "background_voice_queue"
+      Yojson.Safe.Util.(member "execution" json |> to_string))
+;;
+
 let () =
   run
     "voice_runtime_overlay"
@@ -169,9 +201,9 @@ let () =
       , [ test_case "resolve voice aliases" `Quick test_resolve_voice_aliases
         ; test_case "voice auth env resolution" `Quick test_voice_auth_env_resolution
         ; test_case
-            "default agent voices preserve runtime defaults"
+            "default agent voices are config driven"
             `Quick
-            test_default_agent_voices_preserve_runtime_defaults
+            test_default_agent_voices_are_config_driven
         ; test_case
             "voice mcp env no longer overrides default session url"
             `Quick
@@ -184,6 +216,12 @@ let () =
             test_stt_request_elevenlabs_direct
         ; test_case "stt request provider_d compat" `Quick test_stt_request_openai_compat
         ; test_case "stt request mcp rejected" `Quick test_stt_request_mcp_rejected
+        ] )
+    ; ( "keeper_voice_queue"
+      , [ test_case
+            "keeper_voice_speak queues on root switch"
+            `Quick
+            test_keeper_voice_speak_returns_queued_with_root_switch
         ] )
     ]
 ;;


### PR DESCRIPTION

## Summary

- Stop treating keeper `tool_access` as the runtime execution allowlist for descriptor-backed keeper tools. Keeper execution now uses descriptor/registry candidates minus denylist, so board/read/write/edit/voice tools are not hidden by an empty or narrow legacy field.
- Route public keeper tool aliases through Tool Descriptor resolution before dispatch, so public calls like `Read` translate into the internal handler shape before execution.
- Keep HITL approval waits out of terminal gate rejection accounting and suppress stale watchdog kills while a keeper has a pending approval.
- Queue `keeper_voice_speak` through a serialized background voice queue on the root Eio switch, returning `status=queued` immediately.
- Add missing-file recovery metadata so repeated `Read` calls on the same missing path are discouraged with Grep and `Execute ls` examples.

## Product impact

- Board posting and other keeper-owned tools can be discovered and executed from the active descriptor surface instead of silently failing with legacy allowlist errors.
- Keepers waiting on operator approval should no longer be crashed by the stale watchdog before the approval queue timeout expires.
- Multiple keeper voice calls should not block the tool turn or overlap playback.
- File lookup failures now give keepers a concrete recovery path instead of encouraging same-path retries.

## Evidence

- Checked PR #19909 on 2026-06-03: `refactor(keeper): remove Require_tool_use contract handling` is draft/open and currently conflicting. This PR does not add new `Require_tool_use` handling and keeps stale-watchdog changes scoped to pending approvals.
- Verified `preferred_tool_choice` and `not_in_allow_set` are absent in `lib`, `test`, `config`, and `docs` after this change.

## Direct evidence

- `git diff --check`
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-approval-watchdog dune build --root . test/test_governance_pipeline.exe test/test_keeper_guards.exe test/test_stale_kill_class.exe test/test_keeper_tool_dispatch_runtime.exe test/test_voice_runtime_overlay.exe test/test_keeper_sandbox_docker_route.exe`
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-approval-watchdog dune exec --root . test/test_governance_pipeline.exe`
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-approval-watchdog dune exec --root . test/test_keeper_guards.exe`
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-approval-watchdog dune exec --root . test/test_stale_kill_class.exe`
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-approval-watchdog dune exec --root . test/test_keeper_tool_dispatch_runtime.exe`
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-approval-watchdog dune exec --root . test/test_voice_runtime_overlay.exe`
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-approval-watchdog dune exec --root . test/test_keeper_sandbox_docker_route.exe`

## Review evidence

- Local focused tests passed after rebasing on latest `origin/main`.
- The sandbox docker route test initially exposed a stale fixture that created `repos/masc` as a plain directory. The fixture now initializes that path as a git repo before testing repo-routed Execute commands.

## Linked issue

- Related PR: #19909
