### PR TITLE
feat(telemetry): persist streaming TTFRC and inter-chunk metrics to decisions.jsonl

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -658,6 +658,9 @@ export interface DashboardRuntimeModelMetric {
     usage_anomaly_reasons?: string[] | null
     coverage_reason?: string | null
     coverage_stage?: string | null
+    streaming_ttfrc_ms?: number | null
+    streaming_inter_chunk_count?: number | null
+    streaming_inter_chunk_avg_ms?: number | null
   }> | null
   buckets?: BucketMetric[] | null
 }

--- a/lib/keeper/keeper_unified_metrics_decision.ml
+++ b/lib/keeper/keeper_unified_metrics_decision.ml
@@ -262,6 +262,13 @@ let append_decision_record
                     let runtime_id =
                       co.runtime_id
                     in
+                    let streaming_fields =
+                      [
+                        ("streaming_ttfrc_ms", Json_util.float_opt_to_json co.streaming_ttfrc_ms);
+                        ("streaming_inter_chunk_count", `Int co.streaming_inter_chunk_count);
+                        ("streaming_inter_chunk_avg_ms", Json_util.float_opt_to_json co.streaming_inter_chunk_avg_ms);
+                      ]
+                    in
                     [
                       ("runtime_id", `String runtime_id);
                       ("strategy", Json_util.string_opt_to_json co.strategy);
@@ -270,7 +277,7 @@ let append_decision_record
                       ("fallback_applied", `Bool co.fallback_applied);
                       ("fallback_hops", match co.fallback_hops with Some n -> `Int n | None -> `Int 0);
                       ("candidate_models", `List []);
-                    ]
+                    ] @ streaming_fields
                 | None -> []
               in
               let tool_surface_fields =

--- a/lib/model_inference_metrics.mli
+++ b/lib/model_inference_metrics.mli
@@ -26,6 +26,9 @@ type recent_entry = {
   re_usage_anomaly_reasons : string list;
   re_coverage_reason : string option;
   re_coverage_stage : string option;
+  re_streaming_ttfrc_ms : float option;
+  re_streaming_inter_chunk_count : int option;
+  re_streaming_inter_chunk_avg_ms : float option;
 }
 
 type coverage_reason_count = {

--- a/lib/model_inference_metrics_aggregate.ml
+++ b/lib/model_inference_metrics_aggregate.ml
@@ -194,6 +194,9 @@ let aggregate_by_model (entries : raw_entry list) : model_stats list =
                ; re_usage_anomaly_reasons = e.usage_anomaly_reasons
                ; re_coverage_reason = coverage_reason_of_entry e
                ; re_coverage_stage = coverage_stage_of_entry e
+               ; re_streaming_ttfrc_ms = e.streaming_ttfrc_ms
+               ; re_streaming_inter_chunk_count = e.streaming_inter_chunk_count
+               ; re_streaming_inter_chunk_avg_ms = e.streaming_inter_chunk_avg_ms
                })
          ; buckets = []
          }

--- a/lib/model_inference_metrics_entry.ml
+++ b/lib/model_inference_metrics_entry.ml
@@ -38,6 +38,9 @@ type recent_entry =
   ; re_usage_anomaly_reasons : string list
   ; re_coverage_reason : string option
   ; re_coverage_stage : string option
+  ; re_streaming_ttfrc_ms : float option
+  ; re_streaming_inter_chunk_count : int option
+  ; re_streaming_inter_chunk_avg_ms : float option
   }
 
 type coverage_reason_count =
@@ -176,6 +179,9 @@ type raw_entry =
   ; coverage_reason : string option
   ; coverage_stage : string option
   ; is_error : bool
+  ; streaming_ttfrc_ms : float option
+  ; streaming_inter_chunk_count : int option
+  ; streaming_inter_chunk_avg_ms : float option
   }
 
 (* ── Parse-level failure variants ─────────────────────────────────────────────

--- a/lib/model_inference_metrics_json.ml
+++ b/lib/model_inference_metrics_json.ml
@@ -117,6 +117,9 @@ let model_stats_to_json ?(model_label = public_runtime_label) (s : model_stats)
                            r.re_usage_anomaly_reasons) )
                   ; "coverage_reason", Json_util.string_opt_to_json r.re_coverage_reason
                   ; "coverage_stage", Json_util.string_opt_to_json r.re_coverage_stage
+                  ; "streaming_ttfrc_ms", Json_util.float_opt_to_json r.re_streaming_ttfrc_ms
+                  ; "streaming_inter_chunk_count", Json_util.int_opt_to_json r.re_streaming_inter_chunk_count
+                  ; "streaming_inter_chunk_avg_ms", Json_util.float_opt_to_json r.re_streaming_inter_chunk_avg_ms
                   ])
              s.recent_entries) )
     ; "buckets", `List (List.map bucket_metric_to_json s.buckets)

--- a/lib/model_inference_metrics_parser.ml
+++ b/lib/model_inference_metrics_parser.ml
@@ -160,6 +160,9 @@ let parse_telemetry_entry (json : Yojson.Safe.t) ~since_unix
              ; coverage_reason = json_string_field_opt "coverage_reason" tfields
              ; coverage_stage = json_string_field_opt "coverage_stage" tfields
              ; is_error = true
+             ; streaming_ttfrc_ms = json_float_field_opt "streaming_ttfrc_ms" tfields
+             ; streaming_inter_chunk_count = json_int_field_opt "streaming_inter_chunk_count" tfields
+             ; streaming_inter_chunk_avg_ms = json_float_field_opt "streaming_inter_chunk_avg_ms" tfields
              })
          else (
            (* Success turns: full telemetry parsing.
@@ -326,6 +329,9 @@ let parse_telemetry_entry (json : Yojson.Safe.t) ~since_unix
                     | None -> Some "keeper")
                   else json_string_field_opt "coverage_stage" tfields)
              ; is_error = false
+             ; streaming_ttfrc_ms = json_float_field_opt "streaming_ttfrc_ms" tfields
+             ; streaming_inter_chunk_count = json_int_field_opt "streaming_inter_chunk_count" tfields
+             ; streaming_inter_chunk_avg_ms = json_float_field_opt "streaming_inter_chunk_avg_ms" tfields
              })
        | _ -> Error No_telemetry_object)
     | _ -> Error Not_assoc)
@@ -506,6 +512,9 @@ let parse_cost_entry (json : Yojson.Safe.t) ~since_unix
          ; coverage_reason = None
          ; coverage_stage = Some "costs_jsonl"
          ; is_error = false
+         ; streaming_ttfrc_ms = None
+         ; streaming_inter_chunk_count = None
+         ; streaming_inter_chunk_avg_ms = None
          }))
   | _ -> Error Not_assoc
 ;;

--- a/lib/runtime_observation.ml
+++ b/lib/runtime_observation.ml
@@ -27,6 +27,9 @@ type runtime_observation = {
   attempt_details_available : bool;
   attempt_details_source : string;
   oas_internal_runtime_allowed : bool;
+  streaming_ttfrc_ms : float option;
+  streaming_inter_chunk_count : int;
+  streaming_inter_chunk_avg_ms : float option;
 }
 
 and runtime_attempt = {
@@ -158,6 +161,9 @@ let runtime_observation_of_candidates ~runtime_id ?strategy ~configured_labels
     ?(attempt_details_available = false)
     ?(attempt_details_source = "opaque_named_runtime")
     ?(oas_internal_runtime_allowed = false)
+    ?(streaming_ttfrc_ms = None)
+    ?(streaming_inter_chunk_count = 0)
+    ?(streaming_inter_chunk_avg_ms = None)
     () : runtime_observation =
   let candidate_models =
     List.init (max 0 candidate_count) (fun _ -> public_runtime_model_label)
@@ -196,16 +202,30 @@ let runtime_observation_of_candidates ~runtime_id ?strategy ~configured_labels
     attempt_details_available;
     attempt_details_source;
     oas_internal_runtime_allowed;
+    streaming_ttfrc_ms;
+    streaming_inter_chunk_count;
+    streaming_inter_chunk_avg_ms;
   }
 
 (* ================================================================ *)
 (* Metrics capture callbacks                                         *)
 (* ================================================================ *)
 
+type streaming_metrics_capture = {
+  mutable ttfrc_ms : float option;
+      (** Time To First Response Chunk in milliseconds. [None] until
+          the first [on_streaming_first_chunk] callback fires. *)
+  mutable inter_chunk_count : int;
+      (** Number of inter-chunk intervals observed. *)
+  mutable inter_chunk_total_ms : float;
+      (** Cumulative inter-chunk latency in milliseconds. *)
+}
+
 type runtime_metrics_capture = {
   mutable next_attempt_index : int;
   mutable attempts_rev : runtime_attempt list;
   mutable fallback_events_rev : runtime_fallback_event list;
+  mutable streaming : streaming_metrics_capture;
 }
 
 (* Non-redacted JSON encoders for the internal audit log
@@ -341,9 +361,24 @@ let record_fallback_event (capture : runtime_metrics_capture)
     }
     :: capture.fallback_events_rev
 
+let empty_streaming_capture () : streaming_metrics_capture =
+  { ttfrc_ms = None; inter_chunk_count = 0; inter_chunk_total_ms = 0.0 }
+
+let streaming_metrics_of_capture (s : streaming_metrics_capture) =
+  let avg =
+    if s.inter_chunk_count > 0
+    then Some (s.inter_chunk_total_ms /. Float.of_int s.inter_chunk_count)
+    else None
+  in
+  (s.ttfrc_ms, s.inter_chunk_count, avg)
+
 let runtime_metrics_for_candidates ~candidate_count:(_ : int) () =
   let capture =
-    { next_attempt_index = 0; attempts_rev = []; fallback_events_rev = [] }
+    { next_attempt_index = 0
+    ; attempts_rev = []
+    ; fallback_events_rev = []
+    ; streaming = empty_streaming_capture ()
+    }
   in
   let metrics : Llm_provider.Metrics.t =
     { Llm_provider.Metrics.
@@ -392,9 +427,14 @@ let runtime_metrics_for_candidates ~candidate_count:(_ : int) () =
       on_tool_calls = (fun ~provider ~model_id ~count ->
         Llm_metric_bridge.emit_tool_calls ~provider ~model_id ~count);
       on_streaming_first_chunk = (fun ~provider ~model_id ~ttfrc_ms ->
+        capture.streaming.ttfrc_ms <- Some ttfrc_ms;
         Llm_metric_bridge.emit_streaming_first_chunk ~provider ~model_id
           ~ttfrc_ms);
       on_streaming_chunk = (fun ~provider ~model_id ~chunk_index ~inter_chunk_ms ->
+        capture.streaming.inter_chunk_count <-
+          capture.streaming.inter_chunk_count + 1;
+        capture.streaming.inter_chunk_total_ms <-
+          capture.streaming.inter_chunk_total_ms +. inter_chunk_ms;
         Llm_metric_bridge.emit_streaming_chunk ~provider ~model_id
           ~chunk_index ~inter_chunk_ms);
     }
@@ -407,6 +447,9 @@ let runtime_observation_with_metrics ~runtime_id ?strategy ~configured_labels
     ?(attempt_details_source = "oas_metrics_callbacks")
     ?(oas_internal_runtime_allowed = false)
     () =
+  let ttfrc, chunk_count, chunk_avg =
+    streaming_metrics_of_capture capture.streaming
+  in
   runtime_observation_of_candidates ~runtime_id ?strategy ~configured_labels
     ~candidate_count ~selected_model_raw
     ~attempts:(List.rev capture.attempts_rev)
@@ -414,6 +457,9 @@ let runtime_observation_with_metrics ~runtime_id ?strategy ~configured_labels
     ~attempt_details_available:true
     ~attempt_details_source
     ~oas_internal_runtime_allowed
+    ~streaming_ttfrc_ms:ttfrc
+    ~streaming_inter_chunk_count:chunk_count
+    ~streaming_inter_chunk_avg_ms:chunk_avg
     ()
 
 (* ================================================================ *)
@@ -446,6 +492,9 @@ let runtime_observation_to_json (obs : runtime_observation) : Yojson.Safe.t =
       ("attempt_details_available", `Bool obs.attempt_details_available);
       ("attempt_details_source", `String obs.attempt_details_source);
       ("oas_internal_runtime_allowed", `Bool obs.oas_internal_runtime_allowed);
+      ("streaming_ttfrc_ms", Json_util.float_opt_to_json obs.streaming_ttfrc_ms);
+      ("streaming_inter_chunk_count", `Int obs.streaming_inter_chunk_count);
+      ("streaming_inter_chunk_avg_ms", Json_util.float_opt_to_json obs.streaming_inter_chunk_avg_ms);
     ]
 
 let get_runtime_audit_store store_opt =

--- a/lib/runtime_observation.mli
+++ b/lib/runtime_observation.mli
@@ -74,6 +74,9 @@ type runtime_observation = {
   attempt_details_available : bool;
   attempt_details_source : string;
   oas_internal_runtime_allowed : bool;
+  streaming_ttfrc_ms : float option;
+  streaming_inter_chunk_count : int;
+  streaming_inter_chunk_avg_ms : float option;
 }
 (** Per-turn runtime execution snapshot.  [attempts] is
     in chronological order (the internal capture stores


### PR DESCRIPTION
## Summary

Streaming metrics (TTFRC, inter-chunk latency) were previously only emitted to Prometheus histograms via `llm_metric_bridge.ml`. This change persists them through the full data path so historical streaming performance is queryable from the dashboard.

## Data Path

1. `Runtime_observation.streaming_metrics_capture` accumulates `ttfrc_ms`, `inter_chunk_count`, and `inter_chunk_total_ms` from OAS `on_streaming_first_chunk` / `on_streaming_chunk` callbacks
2. `runtime_observation` carries the aggregated values as fields
3. `keeper_unified_metrics_decision.append_decision_record` writes them to the telemetry JSON in decisions.jsonl
4. `model_inference_metrics_parser` reads them back from JSONL
5. `model_inference_metrics_json` serializes them to the dashboard API response
6. Dashboard TS type (`DashboardRuntimeModelMetric.recent_entries`) includes the new fields

## Fields Added

| Field | Type | Description |
|-------|------|-------------|
| `streaming_ttfrc_ms` | `float option` | Time To First Response Chunk in milliseconds |
| `streaming_inter_chunk_count` | `int option` | Number of inter-chunk intervals observed |
| `streaming_inter_chunk_avg_ms` | `float option` | Average inter-chunk gap in milliseconds |

## Files Changed (9)

- `lib/runtime_observation.ml` + `.mli`: `streaming_metrics_capture` type + accumulation in OAS callbacks + fields on `runtime_observation`
- `lib/keeper/keeper_unified_metrics_decision.ml`: streaming fields in telemetry JSON
- `lib/model_inference_metrics_entry.ml`: fields on `raw_entry` + `recent_entry`
- `lib/model_inference_metrics_parser.ml`: parse streaming fields from JSONL
- `lib/model_inference_metrics_aggregate.ml`: populate `recent_entry` streaming fields
- `lib/model_inference_metrics_json.ml`: serialize streaming fields to JSON
- `lib/model_inference_metrics.mli`: expose new fields
- `dashboard/src/api/dashboard.ts`: TS type for recent_entries

## Verification

- `dune build @check` passes (0 errors)
- Individual module builds pass (`Runtime_observation`, `Model_inference_metrics_entry`, `Keeper_unified_metrics_decision`)

## Backward Compatibility

All new fields are optional (`float option`, `int option`). Legacy JSONL rows without streaming data will parse as `None`. Costs.jsonl entries (which never have streaming data) default to `None`.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
