### PR TITLE
fix(monitoring): delete broken zombie/alive-but-stuck alert husks left by #19917

### DIFF
--- a/docs/observability/goal-loop-observe-metrics.md
+++ b/docs/observability/goal-loop-observe-metrics.md
@@ -26,8 +26,6 @@ now contract checked.
 | keeper turn success rate | `masc_keeper_turn_completed_total`, `masc_keeper_turn_scheduled_total` | `GoalLoopKeeperTurnSuccessRateCritical` |
 | keeper semaphore wait p99 | `masc_keeper_semaphore_wait_seconds_bucket` | `GoalLoopKeeperSemaphoreWaitP99Critical` |
 | starvation rate | `masc_keeper_semaphore_wait_timeout_total`, `masc_keeper_turn_scheduled_total` | `GoalLoopKeeperStarvationRateCritical` |
-| keeper alive-but-stuck | `masc_keeper_alive_but_stuck_seconds`, `masc_keeper_alive_but_stuck_threshold_seconds` | `GoalLoopKeeperAliveButStuckCritical` |
-| keeper zombie loop | `masc_keeper_zombie_loop_detected_total` | `GoalLoopKeeperZombieLoopCritical` |
 | provider health probe skipped | `masc_provider_health_probe_skipped_total` | `GoalLoopProviderHealthProbeSkippedWarning` |
 | provider actual health status | `masc_provider_actual_health_status` | `GoalLoopProviderActualHealthUnhealthyCritical` |
 | pricing catalog miss | `masc_pricing_catalog_miss_total` | `GoalLoopPricingCatalogMissCritical` |

--- a/infrastructure/monitoring/goal-loop-observe-alerts.yml
+++ b/infrastructure/monitoring/goal-loop-observe-alerts.yml
@@ -111,37 +111,6 @@ groups:
             semaphore-wait timeouts. This converts the Phase 0
             starvation-rate requirement into an alertable fleet ratio.
 
-      - alert: GoalLoopKeeperAliveButStuckCritical
-        expr: |
-          (
-            /
-          ) > 2
-        for: 5m
-        labels:
-          severity: critical
-          component: goal_loop
-          subsystem: observe
-        annotations:
-          summary: "Keeper {{ $labels.keeper_name }} stuck for > 2x threshold"
-          description: |
-            Supervisor-visible liveness has exceeded the configured
-            stuck threshold by more than 2x and must enter recovery.
-
-      - alert: GoalLoopKeeperZombieLoopCritical
-        expr: |
-          sum by (keeper_name) (
-          ) > 0
-        for: 0m
-        labels:
-          severity: critical
-          component: goal_loop
-          subsystem: observe
-        annotations:
-          summary: "Keeper {{ $labels.keeper_name }} zombie loop detected"
-          description: |
-            A loop made progress-signalling noise without real task progress.
-            This is a direct Observe-phase re-entry trigger.
-
   - name: masc_goal_loop_observe_provider
     interval: 30s
     rules:


### PR DESCRIPTION
## 배경

#19910(`Purge keeper heuristic fibers`) 리뷰에서 Codex가 P1/P2로 지적한 "retired 메트릭이 monitoring contract에 남아 있음"을 #19917이 대응했으나, **alert 표현식에서 메트릭명만 도려내고 alert 블록을 빈 껍데기로 남겼습니다**:

```yaml
GoalLoopKeeperAliveButStuckCritical:  expr: ( / ) > 2
GoalLoopKeeperZombieLoopCritical:     expr: sum by (keeper_name) ( ) > 0
```

이건 invalid PromQL입니다. Prometheus는 rule 파일을 **group 단위로 로드**하므로, 파싱 불가한 표현식 하나가 `masc_goal_loop_observe` group 전체(starvation-rate, semaphore-wait 등 정상 alert 포함)의 로드를 실패시킵니다. 원래 dangling 참조보다 나쁜 회귀입니다.

## 변경

- `infrastructure/monitoring/goal-loop-observe-alerts.yml`: 깨진 husk alert 2개(`GoalLoopKeeperAliveButStuckCritical`, `GoalLoopKeeperZombieLoopCritical`) **블록째 삭제**. retired feature라 alert할 메트릭이 없으므로 표현식 복원이 아니라 제거가 맞습니다.
- `docs/observability/goal-loop-observe-metrics.md`: #19917이 놓친 orphan 행 2개(retired 메트릭→삭제된 alert 매핑) 제거.

## 머지 순서 메모 (정직한 surface)

#19917(monitoring 제거)이 #19910(producer/wiring 제거, **아직 open**)보다 **먼저** 머지돼 순서가 역전됐습니다. main의 `keeper_metrics.ml`은 #19910 머지 전까지 `masc_keeper_zombie_loop_detected_total` / `masc_keeper_alive_but_stuck_*`를 여전히 emit합니다. 그 잔여(emit되지만 watch 안 되는 메트릭)는 무해하고 #19910으로 정리됩니다. 본 PR은 **active harm(broken PromQL) + orphan docs만** 고칩니다.

## 검증

- `yaml.safe_load` 파싱 통과 (9 groups, 17 rules — 2 husk 제거).
- 트리 전체에서 삭제된 alert 이름 잔여 참조 0 (`.masc/playground/*` frozen 클론 제외).
- 변경 파일: `.yml` + `.md`만, OCaml 0개 (가드 subsystem 비해당 → RFC 게이트 불필요).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
