### PR TITLE
fix(goal): add .last-good backup/restore for goals and verifications

### DIFF
--- a/lib/goal/goal_store.ml
+++ b/lib/goal/goal_store.ml
@@ -348,6 +348,9 @@ let parse_refresh_mode s =
 let goals_path config =
   Filename.concat (Workspace_utils.masc_dir config) "goals.json"
 
+let goals_recovery_path config =
+  goals_path config ^ ".last-good"
+
 let snapshots_dir config =
   Filename.concat (Workspace_utils.masc_dir config) "goals_snapshots"
 
@@ -365,15 +368,70 @@ let read_state config =
   ensure_dirs config;
   let path = goals_path config in
   if Workspace_utils.path_exists config path then
-    match state_of_yojson (Workspace_utils.read_json config path) with
-    | Ok state -> { state with goals = List.map normalize_goal state.goals }
-    | Error _ -> default_state ()
+    match Workspace_utils.read_json_result config path with
+    | Ok json ->
+        (match state_of_yojson json with
+         | Ok state -> { state with goals = List.map normalize_goal state.goals }
+         | Error primary_msg ->
+             let recovery = goals_recovery_path config in
+             if Workspace_utils.path_exists config recovery then
+               match Workspace_utils.read_json_result config recovery with
+               | Ok recovery_json ->
+                   (match state_of_yojson recovery_json with
+                    | Ok state ->
+                        Log.Misc.warn
+                          "goal_store: primary goals.json corrupt (%s), recovered from %s"
+                          primary_msg recovery;
+                        { state with goals = List.map normalize_goal state.goals }
+                    | Error recovery_msg ->
+                        Log.Misc.error
+                          "goal_store: both primary and recovery goals.json corrupt (primary: %s, recovery: %s)"
+                          primary_msg recovery_msg;
+                        default_state ())
+               | Error recovery_read_msg ->
+                   Log.Misc.warn
+                     "goal_store: goals.json corrupt (%s), recovery read failed: %s"
+                     primary_msg recovery_read_msg;
+                   default_state ()
+             else
+               (Log.Misc.warn
+                  "goal_store: goals.json corrupt (%s), no .last-good available"
+                  primary_msg;
+                default_state ()))
+    | Error primary_msg ->
+        let recovery = goals_recovery_path config in
+        if Workspace_utils.path_exists config recovery then
+          match Workspace_utils.read_json_result config recovery with
+          | Ok recovery_json ->
+              (match state_of_yojson recovery_json with
+               | Ok state ->
+                   Log.Misc.warn
+                     "goal_store: primary goals.json unreadable (%s), recovered from %s"
+                     primary_msg recovery;
+                   { state with goals = List.map normalize_goal state.goals }
+               | Error recovery_msg ->
+                   Log.Misc.error
+                     "goal_store: primary unreadable (%s), recovery corrupt (%s)"
+                     primary_msg recovery_msg;
+                   default_state ())
+          | Error recovery_msg ->
+              Log.Misc.error
+                "goal_store: primary unreadable (%s), recovery unreadable (%s)"
+                primary_msg recovery_msg;
+              default_state ()
+        else
+          (Log.Misc.warn
+             "goal_store: goals.json unreadable (%s), no .last-good available"
+             primary_msg;
+           default_state ())
   else
     default_state ()
 
 let write_state config state =
   ensure_dirs config;
-  Workspace_utils.write_json config (goals_path config) (state_to_yojson state)
+  let json = state_to_yojson state in
+  Workspace_utils.write_json config (goals_path config) json;
+  Workspace_utils.write_json config (goals_recovery_path config) json
 
 let now_ms () =
   int_of_float (Time_compat.now () *. 1000.0)

--- a/lib/goal/goal_verification.ml
+++ b/lib/goal/goal_verification.ml
@@ -415,6 +415,9 @@ type quorum_result =
 let requests_path config =
   Filename.concat (Workspace_utils.masc_dir config) "goal_verifications.json"
 
+let requests_recovery_path config =
+  requests_path config ^ ".last-good"
+
 let events_path config =
   Filename.concat (Workspace_utils.masc_dir config) "goal_events.jsonl"
 
@@ -424,14 +427,69 @@ let default_state () =
 let read_state config =
   let path = requests_path config in
   if Workspace_utils.path_exists config path then
-    match state_of_yojson (Workspace_utils.read_json config path) with
-    | Ok state -> state
-    | Error _ -> default_state ()
+    match Workspace_utils.read_json_result config path with
+    | Ok json ->
+        (match state_of_yojson json with
+         | Ok state -> state
+         | Error primary_msg ->
+             let recovery = requests_recovery_path config in
+             if Workspace_utils.path_exists config recovery then
+               match Workspace_utils.read_json_result config recovery with
+               | Ok recovery_json ->
+                   (match state_of_yojson recovery_json with
+                    | Ok state ->
+                        Log.Misc.warn
+                          "goal_verification: primary goal_verifications.json corrupt (%s), recovered from %s"
+                          primary_msg recovery;
+                        state
+                    | Error recovery_msg ->
+                        Log.Misc.error
+                          "goal_verification: both primary and recovery corrupt (primary: %s, recovery: %s)"
+                          primary_msg recovery_msg;
+                        default_state ())
+               | Error recovery_read_msg ->
+                   Log.Misc.warn
+                     "goal_verification: primary corrupt (%s), recovery read failed: %s"
+                     primary_msg recovery_read_msg;
+                   default_state ()
+             else
+               (Log.Misc.warn
+                  "goal_verification: goal_verifications.json corrupt (%s), no .last-good available"
+                  primary_msg;
+                default_state ()))
+    | Error primary_msg ->
+        let recovery = requests_recovery_path config in
+        if Workspace_utils.path_exists config recovery then
+          match Workspace_utils.read_json_result config recovery with
+          | Ok recovery_json ->
+              (match state_of_yojson recovery_json with
+               | Ok state ->
+                   Log.Misc.warn
+                     "goal_verification: primary unreadable (%s), recovered from %s"
+                     primary_msg recovery;
+                   state
+               | Error recovery_msg ->
+                   Log.Misc.error
+                     "goal_verification: primary unreadable (%s), recovery corrupt (%s)"
+                     primary_msg recovery_msg;
+                   default_state ())
+          | Error recovery_msg ->
+              Log.Misc.error
+                "goal_verification: primary unreadable (%s), recovery unreadable (%s)"
+                primary_msg recovery_msg;
+              default_state ()
+        else
+          (Log.Misc.warn
+             "goal_verification: goal_verifications.json unreadable (%s), no .last-good available"
+             primary_msg;
+           default_state ())
   else
     default_state ()
 
 let write_state config (state : state) =
-  Workspace_utils.write_json config (requests_path config) (state_to_yojson state)
+  let json = state_to_yojson state in
+  Workspace_utils.write_json config (requests_path config) json;
+  Workspace_utils.write_json config (requests_recovery_path config) json
 
 let principal_key (principal : goal_principal) =
   Printf.sprintf "%s:%s" (principal_kind_to_string principal.kind) principal.id


### PR DESCRIPTION
## 변경 내용

`workspace_backlog.ml`의 `.last-good` 패턴을 Goal Store와 Goal Verification에 적용하여,
JSON 파일 손상 시 silent data loss를 방지한다.

### 변경 파일 (2개, +124/-8)

**lib/goal/goal_store.ml:**
- `goals_recovery_path`: `goals.json.last-good` 경로 생성
- `read_state`: primary parse/read 실패 → `.last-good` 복구 시도 → 둘 다 실패 시 WARN 로그 + 빈 상태
- `write_state`: primary + `.last-good` 동시 기록

**lib/goal/goal_verification.ml:**
- `requests_recovery_path`: `goal_verifications.json.last-good` 경로 생성
- 동일한 read/write 패턴 적용

### 로그 레벨

| 상황 | 레벨 | 메시지 |
|------|------|--------|
| Primary 손상, recovery 성공 | WARN | "primary corrupt, recovered from .last-good" |
| Primary + recovery 모두 손상 | ERROR | "both primary and recovery corrupt" |
| Primary 손상, recovery 없음 | WARN | "corrupt, no .last-good available" |

### 기존 동작 (before)

- JSON parse 실패 → `default_state()` 반환 (빈 Store)
- 로그 없음, 알림 없음 → **silent data loss**

### 근거

Goal Store는 workspace의 모든 Goal 상태를 `.masc/goals.json` 하나에 저장한다.
파일 손상(disk full, crash during write, manual edit error) 시 기존에는
모든 Goal이 증발했고, snapshot도 복원 기능이 없었다.

### 테스트

- `dune build lib/goal/ --root .` PASS

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
