### PR TITLE
[codex] repair post-19916 meta guards

### DIFF
--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -5,6 +5,9 @@ open Keeper_tool_shared_runtime
 
 (** Compute a structured command descriptor from Shell IR.
     Used by the IDE bridge for deterministic PR/issue event detection. *)
+let first_int_arg args =
+  List.find_map int_of_string_opt args |> Option.value ~default:0
+
 let compute_command_descriptor (ir : Masc_exec.Shell_ir.t) : Ide_event_types.command_descriptor =
   match ir with
   | Masc_exec.Shell_ir.Simple simple ->
@@ -19,42 +22,24 @@ let compute_command_descriptor (ir : Masc_exec.Shell_ir.t) : Ide_event_types.com
           ) "main" (List.map (fun s -> String.split_on_char ' ' s) rest) in
           Gh_pr_create { title = Option.value title ~default:""; base; draft }
         | "pr", Some "merge" ->
-          let pr_number = List.fold_left (fun acc -> function
-            | n when (try ignore (int_of_string n); true with _ -> false) -> int_of_string n
-            | _ -> acc
-          ) 0 rest in
+          let pr_number = first_int_arg rest in
           Gh_pr_merge { pr_number; squash }
         | "pr", Some "comment" ->
-          let pr_number = List.fold_left (fun acc -> function
-            | n when (try ignore (int_of_string n); true with _ -> false) -> int_of_string n
-            | _ -> acc
-          ) 0 rest in
+          let pr_number = first_int_arg rest in
           Gh_pr_comment { pr_number; body = Option.value body ~default:"" }
         | "pr", Some "close" ->
-          let pr_number = List.fold_left (fun acc -> function
-            | n when (try ignore (int_of_string n); true with _ -> false) -> int_of_string n
-            | _ -> acc
-          ) 0 rest in
+          let pr_number = first_int_arg rest in
           Gh_pr_close { pr_number }
         | "pr", Some "edit" ->
-          let pr_number = List.fold_left (fun acc -> function
-            | n when (try ignore (int_of_string n); true with _ -> false) -> int_of_string n
-            | _ -> acc
-          ) 0 rest in
+          let pr_number = first_int_arg rest in
           Gh_pr_edit { pr_number; title }
         | "pr", Some "review" ->
-          let pr_number = List.fold_left (fun acc -> function
-            | n when (try ignore (int_of_string n); true with _ -> false) -> int_of_string n
-            | _ -> acc
-          ) 0 rest in
+          let pr_number = first_int_arg rest in
           Gh_pr_review { pr_number }
         | "issue", Some "create" ->
           Gh_issue_create { title = Option.value title ~default:""; body = Option.value body ~default:"" }
         | "issue", Some "close" ->
-          let issue_number = List.fold_left (fun acc -> function
-            | n when (try ignore (int_of_string n); true with _ -> false) -> int_of_string n
-            | _ -> acc
-          ) 0 rest in
+          let issue_number = first_int_arg rest in
           Gh_issue_close { issue_number }
         | _ -> Generic)
      | Masc_exec.Shell_ir_typed_types.W (Masc_exec.Shell_ir_typed_types.Git_push { force; force_with_lease = _; set_upstream = _; remote; branch }) ->

--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-06-03T10:59:47Z (HEAD: 0451548491)
+Generated: 2026-06-03T13:10:43Z (HEAD: ecf96a6490)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 
@@ -132,7 +132,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | KeeperSocialModelMagenticLedger.tla | KeeperSocialModelMagenticLedger | manual | 2 | 1 | clean={inv:TypeOK, inv:ClassifyTypeOK, inv:StalledNeedsGoalOrFailure, prop:ProgressDominates, prop:ReactiveDominatesIdleTimeout, prop:StalledStickyWithGoal, prop:QuietWhenNoDrivers} buggy={inv:StalledNeedsGoalOrFailureMustHold} | 1dd4fa238ae4 |
 | KeeperStateMachine.tla | KeeperStateMachine | manual | 3 | 2 | clean={inv:TypeOK, prop:DeadIsForever, prop:StoppedIsForever, prop:ZombieIsForever, prop:BudgetNeverRevives, prop:RestartCountMonotonic, prop:RunningRequiresFiber, prop:StoppedRequiresDrain, prop:DeadRequiresNoBudget, prop:OfflineRequiresLaunchPending, prop:ZombieRequiresTerminalFailureLatched, prop:FailingResolves, prop:CrashedRestartsEventually, prop:DrainingResolves, prop:CompactingResolves, prop:HandoffResolves, prop:CompactionClearsOverflow, prop:OverflowedResolves} buggy={inv:TypeOK} overflow-buggy={inv:TypeOK} | f23ad5705391 |
 | KeeperTaskAcquisition.tla | KeeperTaskAcquisition | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | cd9f3f8545c5 |
-| KeeperToolSurface.tla | KeeperToolSurface | manual | 2 | 1 | clean={inv:SafetyInvariant} buggy={inv:SafetyInvariant} | 79e36ad80382 |
+| KeeperToolSurface.tla | KeeperToolSurface | manual | 2 | 1 | clean={inv:SafetyInvariant} buggy={inv:SafetyInvariant} | 68a837adbd60 |
 | KeeperTraceSpec.tla | KeeperTraceSpec | manual | 2 | 1 | clean={inv:TypeOK, inv:RunningRequiresFiber, inv:OfflineRequiresLaunchPending, inv:StoppedRequiresDrain, inv:DeadRequiresNoBudget, inv:DerivePhaseAgreement, prop:RestartCountMonotonic, prop:BudgetNeverRevives, prop:TransitionMatrixAgreement} buggy={inv:TypeOK, inv:DerivePhaseAgreementMustHold} | 733248761720 |
 | KeeperTurnCycle.tla | KeeperTurnCycle | manual | 2 | 1 | clean={inv:TypeOK, inv:Safety, prop:Liveness} buggy={inv:SelectingRequiresToolPolicyMustHold} | d6d719d016a0 |
 | KeeperTurnSlot.tla | KeeperTurnSlot | manual | 2 | 1 | clean={inv:Safety} buggy={inv:RetryPhaseRequiresReleased} | a9e690736bb8 |

--- a/test/test_command_descriptor.ml
+++ b/test/test_command_descriptor.ml
@@ -2,7 +2,7 @@
 
 open Alcotest
 
-module Desc = Masc_mcp.Keeper_tool_execute_runtime.For_testing
+module Desc = Masc.Keeper_tool_execute_runtime.For_testing
 
 let with_temp_dir f =
   let dir = Filename.temp_file "cmd_desc_test" "" in
@@ -16,9 +16,9 @@ let with_temp_dir f =
 
 (** Helper: parse command string to Shell_ir.t via Exec_policy. *)
 let parse_ir cmd =
-  match Masc_mcp.Exec_policy.parse_string_to_ir ~mode:Masc_mcp.Exec_policy.Strict cmd with
+  match Masc.Exec_policy.parse_string_to_ir ~mode:Masc.Exec_policy.Strict cmd with
   | Ok ir -> ir
-  | Error reason -> failf "parse failed: %s" (Masc_mcp.Exec_policy.block_reason_to_string reason)
+  | Error reason -> failf "parse failed: %s" (Masc.Exec_policy.block_reason_to_string reason)
 ;;
 
 let test_gh_pr_create () =

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -81,10 +81,10 @@ let with_exec_fixture ?tool_access name fn =
       Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Masc.Workspace.default_config dir in
       let meta = make_meta ?tool_access () in
-      ignore (Masc_mcp.Keeper_registry.register ~base_path:config.base_path meta.name meta);
+      ignore (Masc.Keeper_registry.register ~base_path:config.base_path meta.name meta);
       Fun.protect
         ~finally:(fun () ->
-          Masc_mcp.Keeper_registry.unregister ~base_path:config.base_path meta.name)
+          Masc.Keeper_registry.unregister ~base_path:config.base_path meta.name)
         (fun () -> fn ~config ~meta ~ctx_work:(make_ctx ())))
 
 let payload_kind = function

--- a/test/test_voice_runtime_overlay.ml
+++ b/test/test_voice_runtime_overlay.ml
@@ -163,7 +163,7 @@ let make_keeper_meta name =
           ; "agent_name", `String name
           ; "trace_id", `String "voice-queue-test"
           ; ( "tool_access"
-            , Masc_mcp.Keeper_meta_tool_access.tool_access_to_json
+            , Masc.Keeper_meta_tool_access.tool_access_to_json
                 [ "keeper_voice_speak" ] )
           ])
   with
@@ -182,7 +182,7 @@ let test_keeper_voice_speak_returns_queued_with_root_switch () =
   Eio_context.with_test_env ~net ~clock ~mono_clock ~sw (fun () ->
     let meta = make_keeper_meta "voice-queue-keeper" in
     let raw =
-      Masc_mcp.Keeper_tool_voice_runtime.handle_voice_tool
+      Masc.Keeper_tool_voice_runtime.handle_voice_tool
         ~meta
         ~name:"keeper_voice_speak"
         ~args:(`Assoc [ "message", `String "hello from queued voice test" ])


### PR DESCRIPTION
## Summary
- refresh specs/INDEX.md after #19916 changed KeeperToolSurface.tla
- replace silent int parsing in keeper command descriptor with int_of_string_opt
- update tests from Masc_mcp to Masc after #19912 rename

## Validation
- scripts/ci/check-silent-failure-patterns.sh
- scripts/lint/spec-line-refs.sh
- scripts/check-spec-truth.sh
- env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-post-19916 dune build --root . test/test_keeper_tool_dispatch_runtime.exe test/test_voice_runtime_overlay.exe test/test_command_descriptor.exe
- _build-codex-post-19916/default/test/test_keeper_tool_dispatch_runtime.exe
- _build-codex-post-19916/default/test/test_voice_runtime_overlay.exe
- _build-codex-post-19916/default/test/test_command_descriptor.exe