### PR TITLE
docs(tool): state Execute argv does not expand globs (no shell)

### DIFF
--- a/lib/tool_shard_types_schemas_execute.ml
+++ b/lib/tool_shard_types_schemas_execute.ml
@@ -28,7 +28,11 @@ let tool_execute_exec_stage_schema =
                        executable as argv[0]. Example: executable='grep', argv=['-rn', \
                        'pattern', 'lib']; not argv=['grep', ...]. Shell \
                        metacharacters are data; use pipeline for multi-stage \
-                       execution." )
+                       execution. Wildcards (*, ?, [...]) are NOT expanded: argv \
+                       reaches the process unchanged with no shell, so 'foo*.ml' \
+                       matches a file literally named 'foo*.ml'. Pass exact paths, \
+                       or list the directory first (executable='ls', argv=['some/dir']) \
+                       then act on the names it returns." )
                 ] )
           ] )
     ; "required", `List [ `String "executable" ]
@@ -59,7 +63,9 @@ let tool_execute_argv_field =
             "Typed argv form: arguments after executable, passed verbatim. Do not \
              repeat executable as argv[0]. Example: executable='git', argv=['status', \
              '--short']; example: executable='grep', argv=['-rn', 'pattern', 'lib']. \
-             A literal '|' token is data, not a pipe." )
+             A literal '|' token is data, not a pipe. Wildcards (*, ?, [...]) are \
+             NOT expanded either: there is no shell, so 'foo*.ml' is a literal \
+             filename, not a glob. Use exact paths or list a directory first." )
       ] )
 ;;
 


### PR DESCRIPTION
## 배경

keeper(executor)가 fleet 로그에서 반복적으로 경로 명령에 실패했습니다:

```
ls: repos/masc-mcp/lib/server/server_dashboard_http_core*.ml: No such file or directory
```

진단 결과 **cwd(`.../playground/executor/`)와 repo base(`repos/masc-mcp`)는 맞았고**, 실패 원인은 **glob `*`이 전개되지 않은 것**입니다. Execute 도구는 `executable` + `argv`를 shell 없이 직접 execve 하므로 `server_dashboard_http_core*.ml`이 리터럴 파일명으로 전달돼 매치 0 → 실패. keeper가 shell 의미론(glob 전개)을 가정한 것이 wrong info의 원천이었습니다.

## 변경

`lib/tool_shard_types_schemas_execute.ml`의 두 argv description에 다음을 명시:
- 와일드카드(`*`, `?`, `[...]`)는 **전개되지 않음** — shell이 없어 argv가 프로세스에 그대로 전달됨.
- 정확한 경로를 쓰거나, 먼저 디렉터리를 나열(`executable='ls', argv=['some/dir']`)한 뒤 반환된 이름으로 작업할 것.

description-only 변경입니다. 스키마 shape이나 execution-path 로직은 건드리지 않았습니다.

## 검증

- `masc__Tool_shard_types_schemas_execute.cmo` 격리 빌드 통과 (exit 0).
- 가드 subsystem 비해당(스키마 description, sandbox/credential 로직 아님) → RFC 게이트 불필요.

## 비고

이번 로그는 glob 갭이었고 cwd base는 정상이었습니다. playground 클론이 origin/main보다 1170 커밋 뒤(dirty→currency-sync Preserved로 동결)인 **별개의 stale-clone 문제**는 repo_manager 가드 영역이라 분리 추적합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
