### PR TITLE
fix(log): derive level from outcome at static-Info sites (taxonomy §3.6)

### DIFF
--- a/docs/spec/18-log-severity-taxonomy.md
+++ b/docs/spec/18-log-severity-taxonomy.md
@@ -151,6 +151,15 @@ These are repeating misclassifications observed in `git log --grep='demote\|prom
 | Correct | `Debug`. Reserve `Info` for validation **failures** that auto-recovered. |
 | Origin | `Log.Misc.info "tool_input_validation coerced args for tool_execute"` — emitted on every tool call, ~1k+/h fleet-wide. |
 
+### 3.6 Static level on an outcome-carrying line
+
+| | |
+|--|--|
+| Pattern | A `Log.*.info` call whose format string embeds a runtime `outcome=%s` (or an equivalent failure value the caller already holds) AND the level is hardcoded regardless of that value |
+| Why wrong | The same line fires at `Info` whether the operation succeeded or failed, so the failure case hides under the `Info` noise floor with no companion `Warn`/`Error`. The caller has the outcome in hand; the level should be derived from it, not fixed at the call site. |
+| Correct | Derive the level from the outcome and emit exactly once: `Log.<M>.emit (level_of_outcome outcome) (Printf.sprintf "…outcome=%s…" outcome)`. The typed-variant selector form is equally correct and preferred when the outcome is already a sum type: `(match outcome with Error -> Log.<M>.error \| Ok \| Unknown -> Log.<M>.info) "…outcome=%s…"`. Never emit two lines (one per level) for one event. |
+| Origin | `Log.Governance.info "refresh_once: compute_judgments telemetry outcome=%s …"` emitted at `Info` for `outcome="error"` with zero companion `Warn`/`Error` — production 2026-06-01: 58 errored governance computes invisible to `journalctl -p warning`. Also `Log.Server.info "keeper lifecycle … outcome=%s …"` (the `rejected` / `dispatch_none` failure paths logged at `Info`). |
+
 ## 4. Lint
 
 `scripts/ci/check-log-severity-anti-patterns.sh` (planned, see [§ 6 Migration](#6-migration)) enforces:
@@ -162,6 +171,7 @@ These are repeating misclassifications observed in `git log --grep='demote\|prom
 | L3 | `Log\.[A-Z][a-z]+\.error.*(contract violated\|gh_cli_shape\|JSON parse failed)` | Model behavior is `Warn` (§ 3.3) |
 | L4 | `Log\.[A-Z][a-z]+\.info.*(watchdog tick\|keepalive\|heartbeat)` | Periodic ticks are `Debug` (§ 3.4) |
 | L5 | `Log\.[A-Z][a-z]+\.info.*(coerced\|validated)` | Validation success is `Debug` (§ 3.5) |
+| L6 | `Log\.[A-Z][a-z]+\.info\s*"...outcome=%s` | Outcome-carrying line must derive level from outcome (§ 3.6). Matches only a format string opening directly after `.info` (a `(match … -> …info)` level selector is excluded). |
 
 Each rule is a `rg -P` regex over `lib/`. Exit 1 on any match outside an explicit allowlist comment (`(* log-severity-allow:LN-N <reason> *)`).
 

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -756,6 +756,19 @@ let mark_compute_start (st : state) =
         (float_of_int st.compute_in_flight);
       st.compute_in_flight)
 
+(* docs/spec/18-log-severity-taxonomy.md § 3.6 (outcome-carrying line at a
+   static level): the compute-finish line embeds a runtime [outcome=%s], so its
+   severity must be derived from that outcome rather than hardcoded [Info] — an
+   errored compute logged at [Info] hides under the noise floor with no
+   companion WARN/ERROR. A genuine "error" outcome is degraded-with-auto-recovery
+   (the next [refresh_once] retries) → [Warn]. A graceful cancellation
+   (reason="cancelled", e.g. shutdown / superseded refresh) is not
+   operator-actionable → [Info]. Success → [Info]. *)
+let level_of_compute_outcome ~outcome ~reason : Log.level =
+  match outcome with
+  | "error" when reason <> "cancelled" -> Log.Warn
+  | _ -> Log.Info
+
 let mark_compute_finish (st : state) ~started_at ~outcome ~reason
     ~timeout_sec =
   (* Clamp the elapsed time to >= 0 so a backwards system clock
@@ -778,13 +791,16 @@ let mark_compute_finish (st : state) ~started_at ~outcome ~reason
   Prometheus.inc_counter governance_compute_total_metric ~labels ();
   Prometheus.observe_histogram governance_compute_duration_metric
     ~labels duration_sec;
-  Log.Governance.info
-    "refresh_once: compute_judgments telemetry outcome=%s reason=%s duration=%.3fs compute_timeout=%s in_flight_after=%d"
-    outcome reason duration_sec
-    (match timeout_sec with
-     | Some value -> Printf.sprintf "%.1fs" value
-     | None -> "unknown")
-    in_flight;
+  (* Single emission at the outcome-derived level (never two lines). *)
+  Log.Governance.emit
+    (level_of_compute_outcome ~outcome ~reason)
+    (Printf.sprintf
+       "refresh_once: compute_judgments telemetry outcome=%s reason=%s duration=%.3fs compute_timeout=%s in_flight_after=%d"
+       outcome reason duration_sec
+       (match timeout_sec with
+        | Some value -> Printf.sprintf "%.1fs" value
+        | None -> "unknown")
+       in_flight);
   (duration_sec, in_flight)
 
 let refresh_once ~sw ~net

--- a/lib/dashboard/dashboard_governance_judge.mli
+++ b/lib/dashboard/dashboard_governance_judge.mli
@@ -166,6 +166,17 @@ val parse_governance_response_for_testing :
     [model_used] remains accepted for legacy call sites, but
     parsed public rows redact it to [null]. *)
 
+(** {1 Compute-finish log severity} *)
+
+val level_of_compute_outcome :
+  outcome:string -> reason:string -> Log.level
+(** Severity for the [refresh_once: compute_judgments telemetry outcome=…]
+    line, derived from the compute outcome rather than hardcoded.  A genuine
+    ["error"] outcome (degraded with auto-recovery via the next refresh) is
+    [Log.Warn]; a graceful cancellation ([reason="cancelled"]) and success are
+    [Log.Info].  Exposed so the regression suite can prove an errored compute is
+    not emitted at [Info] (docs/spec/18-log-severity-taxonomy.md § 3.6). *)
+
 (** {1 Daemon identity} *)
 
 val keeper_name : string

--- a/lib/eval_gate.ml
+++ b/lib/eval_gate.ml
@@ -494,7 +494,11 @@ let guarded_execute
         with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
           let msg = Printexc.to_string exn in
           error_ref := Some msg;
-          Log.Harness.info "eval_gate tool %s failed: %s" tool_name msg;
+          (* Caught tool-execution exception (Cancelled is re-raised above):
+             degraded-with-recovery — the gate records the error and returns an
+             error result — so [Warn], not [Info]
+             (docs/spec/18-log-severity-taxonomy.md § 2). *)
+          Log.Harness.warn "eval_gate tool %s failed: %s" tool_name msg;
           Yojson.Safe.to_string (`Assoc [
             ("error", `String "Tool execution failed (internal error)");
             ("tool", `String tool_name);

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -10,13 +10,12 @@ type tool_profile = Mcp_server_eio_types.tool_profile =
   | Managed_agent
   | Operator_remote
 
-let log_mcp_exn ~label exn =
-  let tag = match exn with
-    | Sys_error _ | Failure _ | Not_found | End_of_file
-    | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> ""
-    | _ -> "[UNEXPECTED] "
-  in
-  Log.Mcp.info "%s%s: %s" tag label (Printexc.to_string exn)
+(* Delegate to the single canonical definition rather than re-declaring the
+   exception→severity match (it previously drifted as a verbatim copy in two
+   modules; [Mcp_server_eio_execute] already delegates the same way). The
+   severity is derived from the exception class — see
+   [Mcp_server_eio_helpers.mcp_exn_level_and_tag]. *)
+let log_mcp_exn = Mcp_server_eio_helpers.log_mcp_exn
 
 (* Substring containment, ASCII case-insensitive.  Delegates to
    [String_util.contains_substring_ci] (which scans byte-wise without

--- a/lib/mcp_server_eio_helpers.ml
+++ b/lib/mcp_server_eio_helpers.ml
@@ -4,14 +4,29 @@
     without circular dependencies.
 *)
 
-(** Log an MCP server error with [UNEXPECTED] tag for unrecognized exceptions. *)
+(** Severity and grep tag for an exception logged via {!log_mcp_exn}.
+
+    Recognised exceptions ([Sys_error] / [Failure] / [Not_found] /
+    [End_of_file] / [Yojson.Json_error] / [Yojson.Safe.Util.Type_error]) are
+    expected I/O / parse / control-flow outcomes in best-effort side channels
+    (telemetry, identity resolution, activity-graph emit) and stay at [Info].
+    Any other exception is unrecognised: tagged ["[UNEXPECTED] "] and raised to
+    [Warn] so it surfaces above the [Info] noise floor.  It stays at [Warn]
+    rather than [Error] because the caller still recovers (the side channel is
+    swallowed and the SSE loop continues), and [Error] is reserved for
+    unrecoverable faults (docs/spec/18-log-severity-taxonomy.md § 2 / § 3.6). *)
+let mcp_exn_level_and_tag exn : Log.level * string =
+  match exn with
+  | Sys_error _ | Failure _ | Not_found | End_of_file
+  | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> (Log.Info, "")
+  | _ -> (Log.Warn, "[UNEXPECTED] ")
+
+(** Log an MCP server-side exception at a severity derived from the exception
+    class (see {!mcp_exn_level_and_tag}) rather than a hardcoded level.  Emits
+    exactly one line. *)
 let log_mcp_exn ~label exn =
-  let tag = match exn with
-    | Sys_error _ | Failure _ | Not_found | End_of_file
-    | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> ""
-    | _ -> "[UNEXPECTED] "
-  in
-  Log.Mcp.info "%s%s: %s" tag label (Printexc.to_string exn)
+  let level, tag = mcp_exn_level_and_tag exn in
+  Log.Mcp.emit level (Printf.sprintf "%s%s: %s" tag label (Printexc.to_string exn))
 
 (** Wait for message using Eio sleep - adapter for Session.registry *)
 let wait_for_message_eio ~clock (registry : Session.registry) ~agent_name ~timeout =

--- a/lib/mcp_server_eio_helpers.mli
+++ b/lib/mcp_server_eio_helpers.mli
@@ -8,14 +8,21 @@
     exception so a single bad message cannot bring the SSE loop
     down. *)
 
+val mcp_exn_level_and_tag : exn -> Log.level * string
+(** Severity and grep prefix for an exception logged via {!log_mcp_exn}.
+    Recognised I/O / parse / control-flow exceptions ([Sys_error] / [Failure] /
+    [Not_found] / [End_of_file] / [Yojson.Json_error] /
+    [Yojson.Safe.Util.Type_error]) map to [(Log.Info, "")]; any other exception
+    maps to [(Log.Warn, "[UNEXPECTED] ")].  Exposed so the regression suite can
+    prove an unrecognised exception is not emitted at [Info]
+    (docs/spec/18-log-severity-taxonomy.md § 3.6). *)
+
 val log_mcp_exn : label:string -> exn -> unit
-(** Log an MCP server error via [Log.Mcp.info]. The line is
-    prefixed with ["[UNEXPECTED] "] for any exception outside the
-    expected set ([Sys_error] / [Failure] / [Not_found] /
-    [End_of_file] / [Yojson.Json_error] /
-    [Yojson.Safe.Util.Type_error]) — the prefix is what
-    operators grep for in production logs to find genuine
-    surprises versus routine I/O / parse failures. *)
+(** Log an MCP server-side exception at the severity given by
+    {!mcp_exn_level_and_tag} (recognised → [Info], unrecognised → [Warn]),
+    rather than a hardcoded level.  The ["[UNEXPECTED] "] prefix on the
+    unrecognised branch is what operators grep for to find genuine surprises
+    versus routine I/O / parse failures.  Emits exactly one line. *)
 
 val wait_for_message_eio :
   clock:_ Eio.Time.clock ->

--- a/lib/server/server_dashboard_http_keeper_api_lifecycle_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_lifecycle_post.ml
@@ -195,9 +195,22 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
           (Eio.Time.now clock -. started_at) *. 1000.0 |> int_of_float
         in
         let log_lifecycle_result outcome =
-          Log.Server.info
-            "keeper lifecycle %s name=%s actor=%s outcome=%s duration_ms=%d"
-            action name agent_name outcome (duration_ms ())
+          (* docs/spec/18-log-severity-taxonomy.md § 3.6: this line carries a
+             runtime [outcome=%s] covering both success ("ok"/"already_live")
+             and failure ("rejected" → 400, "dispatch_none" → 500) paths, so the
+             severity is derived from the outcome instead of a static [Info] —
+             otherwise a rejected/failed lifecycle action hides under the noise
+             floor. Failures are degraded-with-recovery (the client gets an
+             error response, the server keeps serving) → [Warn]. *)
+          let level : Log.level =
+            match outcome with
+            | "ok" | "already_live" -> Log.Info
+            | _ -> Log.Warn
+          in
+          Log.Server.emit level
+            (Printf.sprintf
+               "keeper lifecycle %s name=%s actor=%s outcome=%s duration_ms=%d"
+               action name agent_name outcome (duration_ms ()))
         in
         Log.Server.info "keeper lifecycle %s name=%s actor=%s started"
           action name agent_name;

--- a/scripts/ci/check-log-severity-anti-patterns.sh
+++ b/scripts/ci/check-log-severity-anti-patterns.sh
@@ -47,6 +47,11 @@ BASELINE_L1_LOGGING_ONLY=2
 BASELINE_L2_OPERATOR_BROADCAST=1
 BASELINE_L4_WATCHDOG_TICK=1
 BASELINE_L5_VALIDATION_SUCCESS=0
+# 2026-06-03: L6 added strict (0). An outcome-carrying line must derive its
+# level from the outcome value, not hardcode [Info]. The three known sites
+# (governance compute-finish, keeper lifecycle POST, MCP exn logger) were fixed
+# in the same PR, so the baseline is 0 — any new static-Info outcome line fails.
+BASELINE_L6_OUTCOME_CARRYING=0
 
 exit_code=0
 total_current=0
@@ -148,6 +153,16 @@ check_rule "L5" "validation success (coerced) + info" \
   'Log\.[A-Z][a-z]+\.info[^"]*(?s:.{0,500})tool_input_validation coerced' \
   "$BASELINE_L5_VALIDATION_SUCCESS" \
   "§ 3.5"
+
+# L6 — an outcome-carrying line must derive its level from the outcome, not
+# hardcode [Info]. The pattern requires the format string to open directly
+# after [.info] ([.info] then optional whitespace then a double-quote), so a
+# level-selecting [(match outcome with ... -> Log.X.info) "...outcome=%s..."]
+# expression (which closes with [)] before the string) is NOT flagged.
+check_rule "L6" "outcome-carrying line + static info" \
+  'Log\.[A-Z][a-z]+\.info\s*"(?s:.{0,500})outcome=%s' \
+  "$BASELINE_L6_OUTCOME_CARRYING" \
+  "§ 3.6"
 
 echo
 echo "─── Summary ───────────────────────────────"

--- a/test/dune
+++ b/test/dune
@@ -287,7 +287,8 @@
   test_chronicle_event
   test_chronicle_librarian
   test_alignment_score
-  test_blocker_class_exhaustiveness)
+  test_blocker_class_exhaustiveness
+  test_log_severity_outcome_level)
  (modules
   test_board_activity_cache
   test_jsonl_mtime_projection
@@ -555,7 +556,8 @@
   test_chronicle_event
   test_chronicle_librarian
   test_alignment_score
-  test_blocker_class_exhaustiveness)
+  test_blocker_class_exhaustiveness
+  test_log_severity_outcome_level)
  (libraries masc_test_deps multimodal))
 
 ; Focused CI gate for runtime TOML validity.

--- a/test/test_log_severity_outcome_level.ml
+++ b/test/test_log_severity_outcome_level.ml
@@ -1,0 +1,59 @@
+(** Regression tests for outcome-derived log severity
+    (docs/spec/18-log-severity-taxonomy.md § 3.6).
+
+    These pin the two pure level-selection helpers introduced to stop an
+    outcome-carrying line from being emitted at a static [Info] level:
+
+    - {!Dashboard_governance_judge.level_of_compute_outcome} — the
+      [refresh_once: compute_judgments telemetry outcome=…] line. An errored
+      compute was previously logged at [Info] with no companion WARN/ERROR, so
+      operators grepping [-p warning] never saw the governance judge failing.
+    - {!Mcp_server_eio_helpers.mcp_exn_level_and_tag} — the MCP exception logger.
+      An [UNEXPECTED]-tagged exception was previously emitted at [Info].
+
+    The taxonomy is enforced structurally by
+    [scripts/ci/check-log-severity-anti-patterns.sh] (rule L6); these tests pin
+    the {e mapping} itself so a future edit cannot silently demote an error back
+    to [Info] while still satisfying the regex lint. *)
+
+open Masc
+
+(* Compare [Log.level] values structurally; the printer uses the public
+   [level_to_string] so a mismatch reports readable severities. *)
+let level = Alcotest.testable (fun fmt l -> Format.pp_print_string fmt (Log.level_to_string l)) ( = )
+
+let governance_cases () =
+  let f = Dashboard_governance_judge.level_of_compute_outcome in
+  Alcotest.(check level)
+    "ok outcome stays Info" Log.Info (f ~outcome:"ok" ~reason:"ok");
+  Alcotest.(check level)
+    "graceful cancellation stays Info" Log.Info
+    (f ~outcome:"error" ~reason:"cancelled");
+  Alcotest.(check level)
+    "genuine error becomes Warn" Log.Warn
+    (f ~outcome:"error" ~reason:"timeout");
+  Alcotest.(check level)
+    "any non-cancelled error reason becomes Warn" Log.Warn
+    (f ~outcome:"error" ~reason:"http_503")
+
+exception Surprise_exn
+
+let mcp_exn_cases () =
+  let f = Mcp_server_eio_helpers.mcp_exn_level_and_tag in
+  let pair = Alcotest.(pair level string) in
+  (* Recognised I/O / parse / control-flow exceptions stay at Info, no tag. *)
+  Alcotest.check pair "Failure → Info" (Log.Info, "") (f (Failure "boom"));
+  Alcotest.check pair "Not_found → Info" (Log.Info, "") (f Not_found);
+  Alcotest.check pair "Sys_error → Info" (Log.Info, "") (f (Sys_error "fd"));
+  Alcotest.check pair "End_of_file → Info" (Log.Info, "") (f End_of_file);
+  (* Anything else is unrecognised: tagged + raised to Warn (not Error — the
+     side channel still recovers). *)
+  Alcotest.check pair "unrecognised → Warn + [UNEXPECTED]"
+    (Log.Warn, "[UNEXPECTED] ") (f Surprise_exn)
+
+let () =
+  Alcotest.run "log_severity_outcome_level"
+    [
+      ("governance_compute_outcome", [ Alcotest.test_case "level mapping" `Quick governance_cases ]);
+      ("mcp_exn_level_and_tag", [ Alcotest.test_case "level + tag mapping" `Quick mcp_exn_cases ]);
+    ]


### PR DESCRIPTION
## 무엇을

`~/me/.masc/logs/system_log_*.jsonl` 점검 중 발견한 **로그 심각도 오분류**를 고칩니다. `Log.*.info` 호출이 런타임 실패 값(`outcome=%s` 또는 잡은 예외)을 메시지에 담으면서도 레벨을 `Info`로 박아, 실패가 `Info` 노이즈 floor 아래로 숨고 동반 `WARN`/`ERROR`가 없었습니다.

`docs/spec/18-log-severity-taxonomy.md`는 L1–L5를 cataloged하지만 이 형태(outcome-carrying line at static level)는 규칙이 없었습니다. 거버넌스 사례는 `journalctl -p warning`에 전혀 안 떴습니다 — **2026-06-01에 errored governance compute 58건이 전부 INFO**.

## 고친 곳 (레벨을 outcome에서 파생, 정확히 한 줄만 emit)

1. **`dashboard_governance_judge.ml`** — `compute_judgments outcome=error` → `Warn` (was `Info`). graceful cancellation(`reason="cancelled"`)·성공은 `Info` 유지.
2. **`server_dashboard_http_keeper_api_lifecycle_post.ml`** — `rejected`(400)·`dispatch_none`(500) → `Warn`. `ok`/`already_live`는 `Info`.
3. **`mcp_server_eio_helpers.log_mcp_exn`** — `[UNEXPECTED]` 예외 → `Warn` (복구되므로 `Error` 아님). recognized I/O·parse 예외는 `Info` 유지. 더불어 `mcp_server_eio_call_tool`의 **동일 복붙 정의를 delegation으로 dedup**(`Mcp_server_eio_execute`가 이미 쓰는 방식).
4. **`eval_gate.ml`** — 잡은 tool 실행 예외 → `Warn` (`Cancelled`는 상위에서 re-raise).

## 재발 방지

- **taxonomy 문서 §3.6** "Static level on an outcome-carrying line" 등재.
- **lint 규칙 L6** (`check-log-severity-anti-patterns.sh`, strict baseline 0). 정규식은 `.info` 바로 뒤 포맷 문자열만 매치 → 올바른 `(match outcome with … -> Log.X.info) "…outcome=%s…"` 레벨 선택자는 **제외**.
- **`test/test_log_severity_outcome_level.ml`** — 두 순수 레벨 매핑을 고정 (governance·mcp_exn).

## 동작 보존

레벨만 이동합니다. 메시지 문자열·구조화 필드·sink는 동일하고, **모든 사이트가 한 줄만 emit**합니다(이중 로깅 없음). 기존 호출자 동작/반환값 불변.

## 검증

- `dune build @check` EXIT 0
- 변경 모듈 native 컴파일(`.cmx`) EXIT 0 (default-target expression-level 포함)
- `bash scripts/ci/check-log-severity-anti-patterns.sh` EXIT 0 (L6=0)
- `test_log_severity_outcome_level` 통과 + `test_eval_gate`(24) + `test_dashboard_governance`(26) green
- pre-commit full build 통과

## RFC

해당 없음 — credential/identity/operator-control/keeper-sandbox/dashboard-credential/hooks/workflow subsystem을 건드리지 않는 로그 심각도 재분류입니다. `RFC-WAIVED: log-severity reclassification only, no gated subsystem surface.`

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
