### PR TITLE
fix(keeper): route transient liveness timeout to runtime-advance, not pause_human

### DIFF
--- a/lib/keeper/keeper_agent_error.ml
+++ b/lib/keeper/keeper_agent_error.ml
@@ -134,11 +134,16 @@ let api_error_terminal_reason_code (err : Agent_sdk.Error.api_error) : string =
   | Agent_sdk.Retry.InvalidRequest _ -> "api_error_invalid_request"
   | Agent_sdk.Retry.NotFound _ -> "api_error_not_found"
   | Agent_sdk.Retry.ContextOverflow _ -> "api_error_context_overflow"
-  | Agent_sdk.Retry.NetworkError _ -> "api_error_network"
+  (* SSOT: the two transient wire codes are owned by [Keeper_terminal_reason]
+     so the consumer-side disposition classifier
+     ([Keeper_terminal_reason.is_transient_provider_runtime_failure]) and this
+     encoder cannot drift. The structural-OAS-timeout branch keeps its own
+     distinct (non-transient) code. *)
+  | Agent_sdk.Retry.NetworkError _ -> Keeper_terminal_reason.wire_api_error_network
   | Agent_sdk.Retry.Timeout { message }
     when Keeper_error_classify.is_structural_oas_timeout_message message ->
     "api_error_oas_agent_execution_timeout"
-  | Agent_sdk.Retry.Timeout _ -> "api_error_timeout"
+  | Agent_sdk.Retry.Timeout _ -> Keeper_terminal_reason.wire_api_error_timeout
 ;;
 
 let provider_error_terminal_reason_code

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -311,6 +311,23 @@ let operator_disposition (receipt : t)
          && (receipt.runtime_fallback_applied
              || receipt.runtime_outcome = Runtime_passed_to_next_model) ->
     Disp_pass_next_model, Reason_runtime_fallback
+  | _
+    when provider_runtime_failure
+         && Keeper_terminal_reason.is_transient_provider_runtime_failure
+              terminal_reason ->
+    (* Retry-recoverable transient (idle-chunk liveness kill wrapped as
+       [Api.Timeout], or a transient [Api.NetworkError]) that the keeper's
+       in-turn retry self-heals. Before this arm it fell through to the
+       [Disp_pause_human] branch below and broadcast an operator page
+       ([needs_operator_broadcast Disp_pause_human = true]) for a transient
+       that already recovered — fleet log [reason=provider_runtime_error] +
+       liveness guard [retry=1/2] then success (deepseek 17/19). Routing to
+       [Disp_fail_open_next_runtime] advances the FSM (RFC-0022 attempt
+       liveness intent) and, since [needs_operator_broadcast] is [false] for
+       that disposition, emits NO page. The structural OAS budget timeout
+       carries a distinct wire code and is NOT transient, so it still pauses
+       via the fall-through below. *)
+    Disp_fail_open_next_runtime, Reason_runtime_fallback
   | _ when provider_runtime_failure ->
     Disp_pause_human, Reason_provider_runtime_error
   | Keeper_terminal_reason.Completion_contract_violation _ ->

--- a/lib/keeper/keeper_terminal_reason.ml
+++ b/lib/keeper/keeper_terminal_reason.ml
@@ -24,6 +24,23 @@ let terminal_prefix_max_turns_exceeded = "agent_error_max_turns_exceeded"
 let terminal_prefix_execution_timeout = "agent_error_execution_timeout"
 let terminal_prefix_idle_timeout = "agent_error_idle_timeout"
 
+(* SSOT for the two retry-recoverable transient wire codes inside the
+   [api_error_*] / [Provider_runtime_failure] family. These are the wire
+   forms of exactly the [Agent_sdk.Error] variants that
+   [Keeper_error_classify.is_transient_network_error] reports as transient:
+   a plain (non-structural) [Api.Timeout] and an [Api.NetworkError]. The
+   producer [Keeper_agent_error.api_error_terminal_reason_code] builds the
+   same strings; it references these constants so encoder and the
+   consumer-side classifier cannot drift.
+
+   NOTE the structural OAS budget timeout is a DISTINCT producer wire code
+   ([api_error_oas_agent_execution_timeout]) and is intentionally NOT in
+   this set — it carries the [(budget=...)] message that
+   [is_transient_network_error] treats as non-transient, so it must still
+   page a human. *)
+let wire_api_error_timeout = "api_error_timeout"
+let wire_api_error_network = "api_error_network"
+
 let is_auto_recoverable_turn_budget_terminal terminal_reason =
   String.starts_with ~prefix:terminal_prefix_max_turns_exceeded terminal_reason
   || String.starts_with ~prefix:terminal_prefix_execution_timeout terminal_reason
@@ -90,4 +107,33 @@ let to_wire = function
   | Auto_recoverable_budget wire -> wire
   | Pre_dispatch_success wire -> wire
   | Other wire -> wire
+;;
+
+(* A [Provider_runtime_failure] whose underlying error is a retry-recoverable
+   transient (idle-chunk liveness kill wrapped as [Api.Timeout], or a
+   transient [Api.NetworkError]). The keeper's in-turn retry typically
+   self-heals these on the next attempt, so the disposition classifier must
+   advance to the next runtime/model rather than page a human.
+
+   Matched by EXACT equality against the two transient wire constants (on a
+   lowercased copy, mirroring [of_wire]). Exact — not prefix — equality is
+   load-bearing: it excludes the structural OAS budget timeout
+   [api_error_oas_agent_execution_timeout] (also [Provider_runtime_failure],
+   but non-transient) and every other [api_error_*] code (rate_limited,
+   overloaded, server:*, context_overflow, …), all of which must still pause.
+   Only [Provider_runtime_failure] is inspected; all other variants are
+   [false]. *)
+let is_transient_provider_runtime_failure = function
+  | Provider_runtime_failure wire ->
+    let lowered = String.lowercase_ascii wire in
+    String.equal lowered wire_api_error_timeout
+    || String.equal lowered wire_api_error_network
+  | Runtime_exhausted _
+  | Config_or_auth _
+  | Completion_contract_violation _
+  | Turn_livelock _
+  | Internal_error _
+  | Auto_recoverable_budget _
+  | Pre_dispatch_success _
+  | Other _ -> false
 ;;

--- a/lib/keeper/keeper_terminal_reason.mli
+++ b/lib/keeper/keeper_terminal_reason.mli
@@ -122,6 +122,33 @@ val terminal_prefix_max_turns_exceeded : string
 val terminal_prefix_execution_timeout : string
 val terminal_prefix_idle_timeout : string
 
+(** {1 Transient provider-runtime wire codes (SSOT)}
+
+    The two retry-recoverable transient wire codes inside the
+    [Provider_runtime_failure] / [api_error_*] family: a plain
+    (non-structural) [Api.Timeout] and an [Api.NetworkError]. These mirror
+    exactly the [Agent_sdk.Error] variants
+    [Keeper_error_classify.is_transient_network_error] reports as transient.
+    The encoder [Keeper_agent_error.api_error_terminal_reason_code]
+    references these so producer and consumer cannot drift.
+
+    The structural OAS budget timeout is a distinct producer code
+    ([api_error_oas_agent_execution_timeout]) and is deliberately excluded —
+    it is non-transient and must still page a human. *)
+val wire_api_error_timeout : string
+
+val wire_api_error_network : string
+
+(** [true] when [t] is a [Provider_runtime_failure] carrying one of the
+    transient wire codes ([wire_api_error_timeout] / [wire_api_error_network])
+    — a retry-recoverable transient the in-turn retry self-heals. EXACT (not
+    prefix) match on the wire payload, so [api_error_oas_agent_execution_timeout]
+    and every other [api_error_*] code return [false]. Every non-
+    [Provider_runtime_failure] variant is [false]. The disposition classifier
+    routes a [true] result to a runtime-advance disposition instead of
+    [Disp_pause_human]. *)
+val is_transient_provider_runtime_failure : t -> bool
+
 (** [true] when [terminal_reason] (assumed already lowercased by the
     caller, as [operator_disposition] does) is a turn/time-budget cut-off:
     auto-recoverable, the keeper resumes from its checkpoint, so it must

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -46,6 +46,7 @@ let roundtrip_corpus =
   ; "api_error_overloaded"
   ; "api_error_server:502"
   ; "api_error_timeout"
+  ; "api_error_network"
   ; "api_error_context_overflow"
   ; "api_error_oas_agent_execution_timeout"
     (* completion-contract-violation (legacy + enriched forms) *)
@@ -398,7 +399,38 @@ let () =
                                           let got =
                                             R.operator_disposition receipt
                                           in
+                                          (* The frozen oracle is a verbatim copy of the
+                                             PRE-FIX classifier, which paged a human for a
+                                             transient provider-runtime timeout/network
+                                             error. The transient-liveness fix deliberately
+                                             diverges on EXACTLY those two wire codes: where
+                                             the old code returned
+                                             [(Disp_pause_human, Reason_provider_runtime_error)]
+                                             with no degraded-retry / runtime-fallback set,
+                                             production now advances to the next runtime/model
+                                             (no operator page). The oracle stays frozen; this
+                                             scoped exception encodes the one intended spec
+                                             change. Every OTHER mismatch (including the
+                                             structural [api_error_oas_agent_execution_timeout]
+                                             and all non-transient [api_error_*] codes) still
+                                             fails — that is what proves the fix is not
+                                             over-broadened. *)
+                                          let lc =
+                                            String.lowercase_ascii code
+                                          in
+                                          let acceptable_transient_divergence =
+                                            (String.equal lc "api_error_timeout"
+                                             || String.equal lc "api_error_network")
+                                            && want
+                                               = ( R.Disp_pause_human
+                                                 , R.Reason_provider_runtime_error )
+                                            && (match fst got with
+                                                | R.Disp_fail_open_next_runtime
+                                                | R.Disp_pass_next_model -> true
+                                                | _ -> false)
+                                          in
                                           if want <> got
+                                             && not acceptable_transient_divergence
                                           then (
                                             incr mismatches;
                                             if !mismatches <= 20
@@ -432,6 +464,73 @@ let () =
     "test_keeper_terminal_reason_typed: matrix cases=%d mismatches=%d\n"
     !count
     !mismatches
+;;
+
+(* ------------------------------------------------------------------ *)
+(* 3. Transient-liveness fix: the USER-VISIBLE property.               *)
+(*                                                                     *)
+(* The bug is "a transient that self-heals still pages a human." The   *)
+(* page is gated by [needs_operator_broadcast (fst disposition)] in    *)
+(* [append]; the disposition label is incidental. So assert the        *)
+(* broadcast decision directly, not just the label.                    *)
+(* ------------------------------------------------------------------ *)
+
+(* A bare provider-runtime failure receipt: no in-turn degraded-retry /
+   runtime-fallback was recorded (this is the real fleet case — the turn
+   recovered via the SAME runtime's retry, so neither cross-runtime flag is
+   set). With these flags clear, the disposition is decided purely by the
+   transient-vs-terminal nature of [terminal_reason_code]. *)
+let bare_provider_runtime_receipt code : R.t =
+  { base_receipt with
+    terminal_reason_code = code
+  ; outcome = `Error
+  ; degraded_retry_applied = false
+  ; degraded_retry_runtime = None
+  ; runtime_fallback_applied = false
+  ; runtime_outcome = R.Runtime_completed
+  ; error_kind = None
+  }
+;;
+
+let () =
+  (* Transient: idle-chunk liveness kill ([api_error_timeout]) and a
+     transient network error ([api_error_network]) must advance the FSM and
+     must NOT page a human. *)
+  List.iter
+    (fun code ->
+       let disposition, _reason =
+         R.operator_disposition (bare_provider_runtime_receipt code)
+       in
+       check
+         (Printf.sprintf "transient-advances: %s -> %s (not pause_human)" code
+            (R.operator_disposition_kind_to_string disposition))
+         (match disposition with
+          | R.Disp_fail_open_next_runtime | R.Disp_pass_next_model -> true
+          | _ -> false);
+       check
+         (Printf.sprintf "transient-no-broadcast: %s" code)
+         (not (R.needs_operator_broadcast disposition)))
+    [ "api_error_timeout"; "api_error_network" ];
+  (* Non-transient provider-runtime failures MUST still page a human:
+     - [api_error_oas_agent_execution_timeout] is the STRUCTURAL OAS budget
+       timeout (distinct wire code, non-transient). This is the strongest
+       anti-over-broadening assertion: it also starts with [api_error_] and
+       parses to [Provider_runtime_failure], yet must stay paused.
+     - a genuine overloaded provider likewise stays paused. *)
+  List.iter
+    (fun code ->
+       let disposition, reason =
+         R.operator_disposition (bare_provider_runtime_receipt code)
+       in
+       check
+         (Printf.sprintf "non-transient-pauses: %s -> %s" code
+            (R.operator_disposition_kind_to_string disposition))
+         (disposition = R.Disp_pause_human
+          && reason = R.Reason_provider_runtime_error);
+       check
+         (Printf.sprintf "non-transient-broadcasts: %s" code)
+         (R.needs_operator_broadcast disposition))
+    [ "api_error_oas_agent_execution_timeout"; "api_error_overloaded" ]
 ;;
 
 let () =


### PR DESCRIPTION
## Problem

A retry-recoverable transient runtime-liveness kill is mis-escalated to `pause_human` (an operator broadcast requiring a human) even though the turn self-heals on in-turn retry. Fleet log:

```
operator_broadcast_required emitted disposition=pause_human reason=provider_runtime_error
Runtime attempt liveness guard killed runtime lane ollama_cloud.deepseek-v4-flash: inter_chunk_idle  retry=1/2
```

The attempt is killed, retried, and recovers — yet a human is still paged. Frequency: deepseek 17/19, `provider_runtime_error` 33/73.

## Mechanism (evidence chain, verified on `origin/main` d480c423)

1. Inter-chunk idle gap >= `inter_chunk_max` (120s) → `Failed Inter_chunk_idle` (`lib/keeper/keeper_attempt_liveness.ml:153-159`).
2. Wrapped as `Api.Timeout` → encoded to wire `api_error_timeout` (`lib/keeper/keeper_agent_error.ml:141`).
3. In-turn retry x2 self-heals; on exhaust, terminal code stays `api_error_timeout`.
4. `Keeper_terminal_reason.of_wire "api_error_timeout"` → `Provider_runtime_failure "api_error_timeout"`.
5. **The defect**: in `operator_disposition` (`lib/keeper/keeper_execution_receipt.ml`), the `Provider_runtime_failure` family had no transient-aware arm. With no degraded-retry / runtime-fallback flag set (the real fleet case — the turn recovered on the *same* runtime's retry, so neither cross-runtime flag is set), it fell through to `Disp_pause_human, Reason_provider_runtime_error`.
6. `needs_operator_broadcast Disp_pause_human = true` → `append` unconditionally broadcasts an operator page.

## Fix (typed, anti-workaround)

Add a transient-aware arm in `operator_disposition`, placed AFTER the two existing advance arms (degraded_retry / runtime_fallback) and BEFORE the `Disp_pause_human` fall-through:

```ocaml
| _ when provider_runtime_failure
         && Keeper_terminal_reason.is_transient_provider_runtime_failure terminal_reason ->
  Disp_fail_open_next_runtime, Reason_runtime_fallback
```

`Disp_fail_open_next_runtime` is an existing "advance to next runtime" disposition; `needs_operator_broadcast` already returns `false` for it, so the page is never reached. This makes the disposition layer honor RFC-0022's stated intent for the in-attempt liveness kill: *"this attempt fails, FSM advances to next slot, turn lives."*

### Why typed, not a string classifier

- The transient distinction lives in the SSOT typed module `Keeper_terminal_reason` as a total predicate `is_transient_provider_runtime_failure : t -> bool`, matching the closed sum exhaustively (no catch-all `_ ->`).
- It uses **exact** equality against two named wire constants (`wire_api_error_timeout`, `wire_api_error_network`) — NOT a prefix/substring match. This excludes the structural OAS budget timeout `api_error_oas_agent_execution_timeout` (also `Provider_runtime_failure`, but non-transient: the producer already splits it into a distinct wire code carrying the `(budget=...)` message that `is_transient_network_error` rejects). Exact match also excludes every other `api_error_*` code (rate_limited / overloaded / server:* / context_overflow), which still pause.
- The transient set (`api_error_timeout`, `api_error_network`) is aligned with the existing SSOT `Keeper_error_classify.is_transient_network_error` (the structured `Agent_sdk.Error` matches `Api (Timeout _ when not structural)` and `Api (NetworkError _)`).
- The wire constants are owned by `Keeper_terminal_reason` and referenced by the producer `Keeper_agent_error`, so encoder and consumer cannot drift.

Constraints honored: did NOT widen the 120s threshold; did NOT add broadcast dedup/suppression/cooldown; did NOT add a catch-all; kept matches exhaustive and typed.

## Test

`test/test_keeper_terminal_reason_typed.ml` extended:

- **Frozen oracle left untouched.** The behavior-equivalence matrix (306432 cases) keeps the verbatim pre-fix classifier as an independent oracle; a scoped `acceptable_transient_divergence` exception encodes the ONE intended divergence (transient `api_error_timeout`/`api_error_network` cells where the old code returned `(pause_human, provider_runtime_error)` and production now advances). Every other mismatch — including the structural OAS timeout and all non-transient `api_error_*` codes — still fails the matrix.
- **User-visible property assertions** (the page, not the label): transient codes → advance disposition AND `needs_operator_broadcast = false`; `api_error_oas_agent_execution_timeout` (structural, the strongest anti-over-broadening case) and `api_error_overloaded` → `Disp_pause_human` AND `needs_operator_broadcast = true`.

### Non-vacuity proof

Temporarily neutralized the new production arm (guard forced false) and re-ran: the 4 focused assertions FAILED (`api_error_timeout`/`api_error_network` → `pause_human`, broadcasts) — confirming the test catches the bug. Restored; test green (`matrix cases=306432 mismatches=0`, `OK`).

## Build verification

main is currently broken by unrelated breakage (a half-done `Masc_mcp` → `Masc` rename leaves several `test/*.ml` with `Unbound module Masc_mcp`; not my files). Verified my change in isolation:

- `dune build lib/ --root .` → exit 0 (includes the 3 changed lib modules).
- `dune build test/test_keeper_terminal_reason_typed.exe --root .` → exit 0.
- `dune exec test/test_keeper_terminal_reason_typed.exe --root .` → `OK`.

## Workaround gate

WORKAROUND-WAIVED: false positive. The gate's STRING_CLASSIFIER signature matched this body's own prose stating the fix uses EXACT `String.equal` against named constants and deliberately avoids a prefix/substring match. The change adds a typed, exhaustive `Keeper_terminal_reason.t` predicate (closed sum, no catch-all) — the RFC-0042 direction that closes string-match surface, the opposite of the anti-pattern the gate guards against. No substring/prefix classifier is introduced.

## RFC

RFC-0022 (Runtime Attempt Liveness Contract) — §1 Layer Separation table, In-attempt row: the `Attempt_inter_chunk_idle` kill class effect is "this attempt fails, FSM advances to next slot, **turn lives**." This PR makes the operator-disposition layer honor that intent instead of paging a human. Also touches the typed terminal-reason classifier introduced by RFC-0042 (keeper-terminal-code-closed-sum), extending its consumer-side SSOT module with a transient predicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
