### PR TITLE
fix(keeper): label transient liveness recovery as transient_runtime_retry, not runtime_fallback

### DIFF
--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -203,6 +203,7 @@ type operator_disposition_reason =
   | Reason_preflight_config_error
   | Reason_degraded_retry
   | Reason_runtime_fallback
+  | Reason_transient_runtime_retry
   | Reason_provider_runtime_error
   | Reason_internal_error
   | Reason_tool_required_unsatisfied
@@ -219,6 +220,7 @@ let operator_disposition_reason_to_string = function
   | Reason_preflight_config_error -> "preflight_config_error"
   | Reason_degraded_retry -> "degraded_retry"
   | Reason_runtime_fallback -> "runtime_fallback"
+  | Reason_transient_runtime_retry -> "transient_runtime_retry"
   | Reason_provider_runtime_error -> "provider_runtime_error"
   | Reason_internal_error -> "internal_error"
   | Reason_tool_required_unsatisfied -> "tool_required_unsatisfied"
@@ -326,8 +328,18 @@ let operator_disposition (receipt : t)
        liveness intent) and, since [needs_operator_broadcast] is [false] for
        that disposition, emits NO page. The structural OAS budget timeout
        carries a distinct wire code and is NOT transient, so it still pauses
-       via the fall-through below. *)
-    Disp_fail_open_next_runtime, Reason_runtime_fallback
+       via the fall-through below.
+
+       The reason is [Reason_transient_runtime_retry], NOT
+       [Reason_runtime_fallback]: this arm is reached only AFTER the
+       runtime-fallback arm above excluded [runtime_fallback_applied] /
+       [Runtime_passed_to_next_model], so by construction no cross-runtime
+       fallback happened — the turn recovered via the SAME runtime's in-turn
+       retry. [operator_disposition_reason] is serialised into receipt JSON
+       unconditionally (dashboard-visible), so collapsing this onto the
+       fallback label would mislabel every transient-recovery turn as a
+       genuine fallback. *)
+    Disp_fail_open_next_runtime, Reason_transient_runtime_retry
   | _ when provider_runtime_failure ->
     Disp_pause_human, Reason_provider_runtime_error
   | Keeper_terminal_reason.Completion_contract_violation _ ->

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -275,6 +275,14 @@ type operator_disposition_reason =
   | Reason_preflight_config_error
   | Reason_degraded_retry
   | Reason_runtime_fallback
+  | Reason_transient_runtime_retry
+  (** A retry-recoverable transient provider-runtime failure
+      ([api_error_timeout] / [api_error_network]) that the keeper's in-turn
+      retry self-healed on the SAME runtime — distinct from
+      [Reason_runtime_fallback] (cross-runtime fallback). Paired with
+      [Disp_fail_open_next_runtime]; suppresses the operator page that the
+      pre-fix [Reason_provider_runtime_error] / [Disp_pause_human]
+      fall-through emitted. *)
   | Reason_provider_runtime_error
   | Reason_internal_error
   | Reason_tool_required_unsatisfied

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -498,7 +498,7 @@ let () =
      must NOT page a human. *)
   List.iter
     (fun code ->
-       let disposition, _reason =
+       let disposition, reason =
          R.operator_disposition (bare_provider_runtime_receipt code)
        in
        check
@@ -507,6 +507,16 @@ let () =
          (match disposition with
           | R.Disp_fail_open_next_runtime | R.Disp_pass_next_model -> true
           | _ -> false);
+       (* The reason must be the dedicated transient label, NOT
+          [Reason_runtime_fallback] — this arm fires precisely because no
+          cross-runtime fallback occurred (same-runtime in-turn retry). The
+          reason is serialised into receipt JSON, so the distinct label keeps
+          transient-recovery turns separable from genuine fallback turns on
+          the dashboard. *)
+       check
+         (Printf.sprintf "transient-reason: %s -> %s" code
+            (R.operator_disposition_reason_to_string reason))
+         (reason = R.Reason_transient_runtime_retry);
        check
          (Printf.sprintf "transient-no-broadcast: %s" code)
          (not (R.needs_operator_broadcast disposition)))


### PR DESCRIPTION
## Follow-up to #19936 (honest disposition reason label)

#19936 added the transient-liveness disposition arm that suppresses the spurious `pause_human` operator page. It set the reason to `Reason_runtime_fallback`. That label is false on this branch by construction: the arm is reached ONLY after the preceding runtime-fallback arm already excluded `runtime_fallback_applied` / `runtime_outcome = Runtime_passed_to_next_model`, so no cross-runtime fallback happened — the turn recovered via the SAME runtime's in-turn retry.

`operator_disposition_reason` is serialized into receipt JSON unconditionally (dashboard-visible, independent of whether a broadcast fires). So every transient-recovery turn was emitting `disposition=fail_open_next_runtime reason=runtime_fallback`, colliding with genuine cross-runtime fallback turns on the dashboard — the kind of two-conditions-one-label collapse the `operator_disposition_reason` / `api_error_*` taxonomy exists to avoid.

## Change

- Add a dedicated `Reason_transient_runtime_retry` variant to `operator_disposition_reason` (type + `to_string` + `.mli` doc).
- The transient-liveness arm now emits `Disp_fail_open_next_runtime, Reason_transient_runtime_retry` instead of `Reason_runtime_fallback`.
- Operators can now filter `fail_open_next_runtime + transient_runtime_retry` = same-runtime transient auto-recovery, distinct from cross-runtime fallback.

No behavior change to the page suppression (`needs_operator_broadcast Disp_fail_open_next_runtime = false`, unchanged); this is purely a telemetry-label correctness fix.

## Test

`test/test_keeper_terminal_reason_typed.ml`: the transient focused assertions now pin `reason = Reason_transient_runtime_retry` (previously discarded). The 306432-case behavior-equivalence matrix is unaffected — its `acceptable_transient_divergence` exception keys on the disposition (`fst got`), and the frozen oracle never produces the new reason.

## Build verification

main has unrelated breakage (half-done `Masc_mcp` -> `Masc` rename in several `test/*.ml`). Verified in isolation on `origin/main` (which includes #19936):

- `dune build lib/ --root .` -> exit 0.
- `dune exec test/test_keeper_terminal_reason_typed.exe --root .` -> `matrix cases=306432 mismatches=0`, `OK`.

## RFC

RFC-0022 (Runtime Attempt Liveness Contract) — same in-attempt liveness intent as #19936; this only makes the operator-facing reason label honest. Touches the RFC-0042 typed-disposition surface (`operator_disposition_reason`).

WORKAROUND-WAIVED: false positive. No substring/prefix classifier is introduced; this adds a typed enum variant (richer-enum, the documented preference) to replace a mislabeled reason. The gate may match prose describing the dashboard label collision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
