### PR TITLE
fix(main): complete #8605 typed-variant + Masc_mcp leftover (#19935 follow-up)

### DIFF
--- a/lib/server/server_dashboard_http_keeper_api_lifecycle_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_lifecycle_post.ml
@@ -38,6 +38,13 @@ let invalidate_keeper_execution_surfaces ~config () =
   Dashboard_projection_cache.invalidate_snapshot_json ~config;
   Server_dashboard_http_execution_surfaces.invalidate_execution_cache ()
 
+(* Typed outcome of a keeper lifecycle action, so the log severity is chosen by
+   an exhaustive match rather than a string-parsing wildcard with a permissive
+   default (#8605). [Succeeded]/[Already_live] are successes (Info);
+   [Rejected] (400) and [Dispatch_none] (500) are failures (Warn) — see
+   docs/spec/18-log-severity-taxonomy.md § 3.6. *)
+type lifecycle_outcome = Succeeded | Already_live | Rejected | Dispatch_none
+
 let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
     state agent_name req reqd =
   let req_path = Http.Request.path req in
@@ -194,23 +201,24 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
         let duration_ms () =
           (Eio.Time.now clock -. started_at) *. 1000.0 |> int_of_float
         in
-        let log_lifecycle_result outcome =
-          (* docs/spec/18-log-severity-taxonomy.md § 3.6: this line carries a
-             runtime [outcome=%s] covering both success ("ok"/"already_live")
-             and failure ("rejected" → 400, "dispatch_none" → 500) paths, so the
-             severity is derived from the outcome instead of a static [Info] —
-             otherwise a rejected/failed lifecycle action hides under the noise
-             floor. Failures are degraded-with-recovery (the client gets an
-             error response, the server keeps serving) → [Warn]. *)
-          let level : Log.level =
+        let log_lifecycle_result (outcome : lifecycle_outcome) =
+          (* docs/spec/18-log-severity-taxonomy.md § 3.6: the line carries the
+             outcome, so the severity is derived from it (single emission)
+             instead of a static [Info] — otherwise a rejected/failed lifecycle
+             action hides under the noise floor. Failures are
+             degraded-with-recovery (the client gets an error response, the
+             server keeps serving) → [Warn]. *)
+          let level, outcome_s =
             match outcome with
-            | "ok" | "already_live" -> Log.Info
-            | _ -> Log.Warn
+            | Succeeded -> (Log.Info, "ok")
+            | Already_live -> (Log.Info, "already_live")
+            | Rejected -> (Log.Warn, "rejected")
+            | Dispatch_none -> (Log.Warn, "dispatch_none")
           in
           Log.Server.emit level
             (Printf.sprintf
                "keeper lifecycle %s name=%s actor=%s outcome=%s duration_ms=%d"
-               action name agent_name outcome (duration_ms ()))
+               action name agent_name outcome_s (duration_ms ()))
         in
         Log.Server.info "keeper lifecycle %s name=%s actor=%s started"
           action name agent_name;
@@ -243,7 +251,7 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
              | Some latest -> Keeper_meta_json.meta_to_json latest.meta
              | None -> Keeper_meta_json.meta_to_json entry.meta
            in
-           log_lifecycle_result "already_live";
+           log_lifecycle_result Already_live;
            Http.Response.json_value ~compress:true ~request:req
              (`Assoc
                 [
@@ -269,7 +277,7 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
                  | Some Keeper_state_machine.Paused -> persist_keeper_paused_state true
                  | Some _ | None -> ());
                 invalidate_keeper_execution_surfaces ~config ());
-              log_lifecycle_result "ok";
+              log_lifecycle_result Succeeded;
               Http.Response.json_value ~compress:true ~request:req
                 (`Assoc
                    [
@@ -285,7 +293,7 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
                  persist_keeper_paused_state true;
                  refresh_keeper_execution_surfaces ~config ~name "stopped"
                | _ -> invalidate_keeper_execution_surfaces ~config ());
-              log_lifecycle_result "ok";
+              log_lifecycle_result Succeeded;
               Http.Response.json_value ~compress:true ~request:req
                 (`Assoc
                    [
@@ -296,12 +304,12 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
                 reqd
             | Some result ->
               let body = Tool_result.message result in
-              log_lifecycle_result "rejected";
+              log_lifecycle_result Rejected;
               Http.Response.json_value ~status:`Bad_request ~request:req
                 (`Assoc [("ok", `Bool false); ("error", `String body)])
                 reqd
             | None ->
-              log_lifecycle_result "dispatch_none";
+              log_lifecycle_result Dispatch_none;
               respond_error ~status:`Internal_server_error ~request:req ~ok:false
                 reqd "dispatch returned None"))
 

--- a/test/test_command_descriptor.ml
+++ b/test/test_command_descriptor.ml
@@ -2,7 +2,7 @@
 
 open Alcotest
 
-module Desc = Masc_mcp.Keeper_tool_execute_runtime.For_testing
+module Desc = Masc.Keeper_tool_execute_runtime.For_testing
 
 let with_temp_dir f =
   let dir = Filename.temp_file "cmd_desc_test" "" in
@@ -16,9 +16,9 @@ let with_temp_dir f =
 
 (** Helper: parse command string to Shell_ir.t via Exec_policy. *)
 let parse_ir cmd =
-  match Masc_mcp.Exec_policy.parse_string_to_ir ~mode:Masc_mcp.Exec_policy.Strict cmd with
+  match Masc.Exec_policy.parse_string_to_ir ~mode:Masc.Exec_policy.Strict cmd with
   | Ok ir -> ir
-  | Error reason -> failf "parse failed: %s" (Masc_mcp.Exec_policy.block_reason_to_string reason)
+  | Error reason -> failf "parse failed: %s" (Masc.Exec_policy.block_reason_to_string reason)
 ;;
 
 (** {1 Gh PR operations} *)


### PR DESCRIPTION
## 무엇을 / 왜

main을 깨진 두 지점에서 복구합니다.

### 1. #8605 typed-variant 수정 완성 (PR #19935 follow-up)

PR #19935는 두 커밋 중 **첫 커밋만 squash-merge**(`8c95db3ba8`)됐습니다. `handle_keeper_lifecycle_post`의 로그 레벨 분기를 typed variant로 바꾼 두 번째 커밋이 머지 후 orphan이 되어, **main의 `server_dashboard_http_keeper_api_lifecycle_post.ml`에 `match outcome (string) with … | _ -> Log.Warn`가 남았습니다.** 이는 `scripts/lint/no-unknown-permissive-default.sh`(#8605: permissive default in string-parsing match)가 차단하는 패턴 → main이 해당 Lint로 red, 모든 open PR에 전파.

이 PR이 그 typed-variant 수정을 main 위에 cherry-pick으로 복원합니다:
- `type lifecycle_outcome = Succeeded | Already_live | Rejected | Dispatch_none`
- 레벨은 wildcard 없는 exhaustive match로 파생, outcome 라벨은 단일 소스.
- 4개 call site는 magic string 대신 생성자 전달.

### 2. `Masc_mcp` → `Masc` rename 잔재 (pre-existing)

`test/test_command_descriptor.ml`이 리네임(#19912) 전 `Masc_mcp` 라이브러리를 3곳 참조해 `dune build @check`가 `Unbound module Masc_mcp`로 실패하고 있었습니다 — 제 변경과 무관한 main의 별도 breakage. 기계적 리네임으로 복구.

## 검증

- `dune build @check` EXIT 0 (양쪽 해소)
- `bash scripts/lint/no-unknown-permissive-default.sh` EXIT 0 (#8605 위반 0)
- `bash scripts/ci/check-log-severity-anti-patterns.sh` EXIT 0 (L6=0)
- `test_command_descriptor` 19 tests green
- lifecycle_post native(`.cmx`) 컴파일 EXIT 0

## 동작 보존

레벨/타입만 바뀝니다. 로그 메시지 문자열·필드·sink 동일, 사이트당 한 줄만 emit. HTTP 응답/반환값 불변.

## RFC

해당 없음 — 로그 심각도 재분류 + 테스트 리네임. credential/operator/sandbox/hooks/workflow subsystem 무관. `RFC-WAIVED: log-severity reclassification + test rename, no gated subsystem surface.`

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
