### PR TITLE
[codex] fix dashboard runtime assignment persistence

### DIFF
--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -520,7 +520,8 @@ describe('KeeperConfigPanel', () => {
     expect(mocks.fetchDashboardGoalsTree).toHaveBeenCalledTimes(1)
     expect(mocks.fetchRuntimeProfiles).not.toHaveBeenCalled()
     expect(container.textContent).toContain('편집 가능 범위')
-    expect(container.textContent).toContain('keeper TOML')
+    expect(container.textContent).toContain('runtime.toml')
+    expect(container.textContent).toContain('[runtime.assignments]')
     expect(container.textContent).toContain('Runtime 선택')
     expect(container.textContent).toContain('tier-group.keeper_unified')
     expect(container.textContent).toContain('/tmp/config/keepers/default.toml')
@@ -580,7 +581,7 @@ describe('KeeperConfigPanel', () => {
     )
     expect(container.textContent).toContain('runtime_id')
     expect(container.textContent).toContain('tier-group.keeper_unified')
-    expect(container.textContent).toContain('선택은 /tmp/config/keepers/default.toml 에서 관리됩니다.')
+    expect(container.textContent).toContain('선택은 runtime.toml [runtime.assignments] 에서 관리됩니다.')
     expect(mocks.updateKeeperRuntime).not.toHaveBeenCalled()
   })
 

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -551,10 +551,7 @@ function EditTextarea({ field, label, rows = 3 }: { field: keyof EditDraft; labe
 function runtimeSelectionSummary(c: KeeperConfig): string {
   const selected = c.execution.selected_runtime_id || MISSING_DATA_DASH
   const canonical = c.execution.selected_runtime_canonical || selected
-  const manifest = c.sources.default_manifest_path
-  const selectionPart = manifest
-    ? `선택은 ${manifest} 에서 관리됩니다.`
-    : '선택 source 경로를 확인할 수 없습니다.'
+  const selectionPart = '선택은 runtime.toml [runtime.assignments] 에서 관리됩니다.'
   const canonicalPart =
     canonical !== '' && canonical !== selected
       ? ` 현재 값 ${selected} 는 runtime에서 ${canonical} 으로 정규화됩니다.`
@@ -748,7 +745,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
 
       <${Callout}
         title="편집 가능 범위"
-        body="여기서 저장되는 값은 keeper 프롬프트, live override 계층, keeper TOML의 runtime_id입니다."
+        body="여기서 저장되는 값은 keeper 프롬프트, live override 계층, runtime.toml의 [runtime.assignments]입니다."
       />
 
       ${promptSection}

--- a/dashboard/src/components/keeper-runtime-model-editor.test.ts
+++ b/dashboard/src/components/keeper-runtime-model-editor.test.ts
@@ -159,8 +159,9 @@ describe('KeeperRuntimeModelEditor', () => {
 
     expect(container.querySelector('select[aria-label="model"]')).toBeNull()
     expect(container.textContent).toContain('편집 가능한 TOML 소스가 아니')
-    // Hint names the exact file to add so the operator can unlock editing.
-    expect(container.textContent).toContain('persona-keeper.toml')
+    // Hint names the runtime assignment surface so the operator can unlock editing.
+    expect(container.textContent).toContain('runtime.toml')
+    expect(container.textContent).toContain('[runtime.assignments]')
   })
 
   it('clears a pending selection when the viewed keeper changes', async () => {

--- a/dashboard/src/components/keeper-runtime-model-editor.ts
+++ b/dashboard/src/components/keeper-runtime-model-editor.ts
@@ -1,11 +1,11 @@
 // Keeper runtime editor — a prominent, one-expand-away card that lets an
 // operator change which runtime lane a keeper dispatches on.
 //
-// RFC-0207: a keeper's runtime selection lives in a SINGLE surface — the persona
-// TOML `runtime_id` field (parsed into both `runtime_id` and
-// `model`). The detailed view of that field is buried under
-// 설정 → Keeper 설정 → 소스. This card surfaces the same field at the top of the
-// keeper detail's 진단/운영 section so it is discoverable without digging.
+// RFC-0207: a keeper's runtime selection lives in a SINGLE surface —
+// runtime.toml [runtime.assignments]. The detailed view of that assignment is
+// buried under 설정 → Keeper 설정 → 소스. This card surfaces the same assignment
+// at the top of the keeper detail's 진단/운영 section so it is discoverable
+// without digging.
 //
 // State is SHARED with keeper-config-panel via [configState]/[loadKeeperConfig]
 // (read) and [applyKeeperConfigUpdate] (write) so the two surfaces never show
@@ -50,7 +50,7 @@ export function uniqueNonEmpty(values: readonly string[]): string[] {
 }
 
 /**
- * Editable only when the selection is backed by a writable keeper TOML.
+ * Editable only when the keeper has a writable TOML-backed config source.
  * persona-only / generated keepers have no manifest to patch. Mirrors the
  * `runtimeCanEdit` gate in keeper-config-panel so the two surfaces agree.
  */
@@ -107,8 +107,8 @@ export function KeeperRuntimeModelEditor({ keeperName }: { keeperName: string })
           : null}
         <div class="rounded-[var(--r-1)] border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2 text-2xs leading-relaxed text-[var(--color-status-warn)]">
           이 keeper는 편집 가능한 TOML 소스가 아니라(소스: ${kind}) 여기서 model을 바꿀 수 없습니다.
-          편집하려면 <code>.masc/config/keepers/${keeperName}.toml</code> 에
-          <code>runtime_id = "runtime-lane"</code> 을 추가하고 서버를 재시작하세요.
+          편집하려면 <code>.masc/config/runtime.toml</code> 의
+          <code>[runtime.assignments]</code> 에 keeper 배정을 추가하고 서버를 재시작하세요.
         </div>
       </div>
     `

--- a/lib/keeper/keeper_config_text.ml
+++ b/lib/keeper/keeper_config_text.ml
@@ -57,7 +57,6 @@ let prompt_render_max_bytes = 320
 let removed_keeper_input_key_names =
   [
     "models";
-    "runtime_id";
     "allowed_models";
     "active_model";
     "trigger_mode";

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -16,6 +16,7 @@ type parsed_args = {
   short_goal_opt : string option;
   mid_goal_opt : string option;
   long_goal_opt : string option;
+  runtime_id_opt : string option;
   allowed_paths_opt : string list option;
   autoboot_enabled_opt : bool option;
   mention_targets_in : string list;
@@ -94,6 +95,20 @@ let parse_present_string_list_opt args key =
         (Printf.sprintf "%s must be an array of strings (received %s)" key
            (Json_util.kind_name other))
 
+let parse_runtime_id_opt args =
+  match Json_util.assoc_member_opt "runtime_id" args with
+  | None | Some `Null -> Ok None
+  | Some (`String raw) ->
+      let runtime_id = String.trim raw in
+      if runtime_id = ""
+      then Error "runtime_id must not be empty"
+      else Ok (Some runtime_id)
+  | Some other ->
+      Error
+        (Printf.sprintf
+           "runtime_id must be a string (received %s)"
+           (Json_util.kind_name other))
+
 let resolve_tool_name_list ~preferred ~fallback =
   Dashboard_utils.first_some preferred fallback
   |> Option.value ~default:[]
@@ -131,18 +146,21 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) 
     let tool_access_input_res = parse_tool_access_input args in
     let allowed_paths_opt_res = parse_present_string_list_opt args "allowed_paths" in
     let active_goal_ids_opt_res = parse_present_string_list_opt args "active_goal_ids" in
+    let runtime_id_opt_res = parse_runtime_id_opt args in
     match
       compaction_profile_opt_res, tool_access_input_res, allowed_paths_opt_res,
-      active_goal_ids_opt_res
+      active_goal_ids_opt_res, runtime_id_opt_res
     with
-    | Error e, _, _, _
-    | _, Error e, _, _
-    | _, _, Error e, _
-    | _, _, _, Error e -> Error (tool_result_error e)
+    | Error e, _, _, _, _
+    | _, Error e, _, _, _
+    | _, _, Error e, _, _
+    | _, _, _, Error e, _
+    | _, _, _, _, Error e -> Error (tool_result_error e)
     | Ok compaction_profile_opt,
       Ok tool_access_opt,
       Ok allowed_paths_opt,
-      Ok active_goal_ids_opt ->
+      Ok active_goal_ids_opt,
+      Ok runtime_id_opt ->
     let goal_opt = get_string_opt args "goal" in
     let short_goal_opt = parse_goal_horizon_opt args "short_goal" in
     let mid_goal_opt = parse_goal_horizon_opt args "mid_goal" in
@@ -209,6 +227,7 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) 
       short_goal_opt;
       mid_goal_opt;
       long_goal_opt;
+      runtime_id_opt;
       allowed_paths_opt;
       active_goal_ids_opt;
       autoboot_enabled_opt;

--- a/lib/keeper/keeper_turn_up_args.mli
+++ b/lib/keeper/keeper_turn_up_args.mli
@@ -18,6 +18,7 @@ type parsed_args =
   ; short_goal_opt : string option
   ; mid_goal_opt : string option
   ; long_goal_opt : string option
+  ; runtime_id_opt : string option
   ; allowed_paths_opt : string list option
   ; autoboot_enabled_opt : bool option
   ; mention_targets_in : string list

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -500,6 +500,28 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
         Progress.stop_tracking task_id;
         tool_result_error (Printf.sprintf "initial checkpoint save failed: %s" e)
       | Ok _ ->
+      let runtime_assignment_result =
+        match p.runtime_id_opt with
+        | None -> Ok ()
+        | Some runtime_id ->
+          Runtime.set_runtime_id_for_keeper
+            ~keeper_name:p.name
+            ~runtime_id
+            ()
+      in
+      (match runtime_assignment_result with
+       | Error e ->
+         Prometheus.inc_counter
+           Keeper_metrics.(to_string LifecycleDispatchRejections)
+           ~labels:[("keeper", p.name); ("event", "create_runtime_assignment")]
+           ();
+         Log.Keeper.error
+           "create_keeper failed: runtime assignment error for name=%s: %s"
+           p.name
+           e;
+         Progress.stop_tracking task_id;
+         tool_result_error e
+       | Ok () ->
       Progress.Tracker.step tracker ~message:"Writing keeper metadata" ();
       match write_initial_meta ctx.config meta with
       | Error e ->
@@ -552,4 +574,4 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
           ("handoff_threshold", `Float meta.handoff_threshold);
           ("oas_env", `Assoc (List.map (fun (k, v) -> (k, `String v)) meta.oas_env));
         ] in
-        tool_result_ok (Yojson.Safe.to_string json)
+        tool_result_ok (Yojson.Safe.to_string json))

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -318,14 +318,40 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
              p.name err;
            tool_result_error err
        | Ok () ->
-      (match write_meta ctx.config updated with
-       | Error e ->
-           Prometheus.inc_counter
-             Keeper_metrics.(to_string WriteMetaFailures)
-             ~labels:[("keeper", updated.name); ("phase", "update_keeper")]
-             ();
-           tool_result_error e
-       | Ok () ->
-         stop_keepalive ~base_path:ctx.config.base_path updated.name;
-         start_keepalive ctx updated;
-         tool_result_ok (Yojson.Safe.to_string (Keeper_meta_json.meta_to_json updated))))
+         let runtime_assignment_result =
+           match p.runtime_id_opt with
+           | None -> Ok ()
+           | Some runtime_id ->
+             Runtime.set_runtime_id_for_keeper
+               ~keeper_name:p.name
+               ~runtime_id
+               ()
+         in
+         (match runtime_assignment_result with
+          | Error err ->
+            Prometheus.inc_counter
+              Keeper_metrics.(to_string TurnUpUpdateFailures)
+              ~labels:
+                [ ( "keeper", p.name )
+                ; ( "site"
+                  , Keeper_turn_up_update_failure_site.(to_label Runtime_assignment)
+                  )
+                ]
+              ();
+            Log.Keeper.warn
+              "update_keeper failed runtime assignment for %s: %s"
+              p.name
+              err;
+            tool_result_error err
+          | Ok () ->
+            (match write_meta ctx.config updated with
+             | Error e ->
+                 Prometheus.inc_counter
+                   Keeper_metrics.(to_string WriteMetaFailures)
+                   ~labels:[("keeper", updated.name); ("phase", "update_keeper")]
+                   ();
+                 tool_result_error e
+             | Ok () ->
+               stop_keepalive ~base_path:ctx.config.base_path updated.name;
+               start_keepalive ctx updated;
+               tool_result_ok (Yojson.Safe.to_string (Keeper_meta_json.meta_to_json updated)))))

--- a/lib/keeper/keeper_turn_up_update_failure_site.ml
+++ b/lib/keeper/keeper_turn_up_update_failure_site.ml
@@ -2,9 +2,11 @@ type t =
   | Prompt_cap
   | Sandbox_validation
   | Sandbox_preflight
+  | Runtime_assignment
 
 let to_label = function
   | Prompt_cap -> "prompt_cap"
   | Sandbox_validation -> "sandbox_validation"
   | Sandbox_preflight -> "sandbox_preflight"
+  | Runtime_assignment -> "runtime_assignment"
 ;;

--- a/lib/keeper/keeper_turn_up_update_failure_site.mli
+++ b/lib/keeper/keeper_turn_up_update_failure_site.mli
@@ -1,10 +1,11 @@
 (** Keeper_turn_up_update_failure_site — closed sum for [site] label on
-    [metric_keeper_turn_up_update_failures] (3 sites in
+    [metric_keeper_turn_up_update_failures] (4 sites in
     keeper_turn_up_update.ml). *)
 
 type t =
   | Prompt_cap
   | Sandbox_validation
   | Sandbox_preflight
+  | Runtime_assignment
 
 val to_label : t -> string

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -69,6 +69,33 @@ let validate_keeper_assignments ~(config_path : string) (runtimes : t list)
          (List.length runtimes))
 ;;
 
+let materialize_config ~(config_path : string) (cfg : config)
+  : (t list * t * (string * string) list, string) result
+  =
+  let runtimes = List.filter_map (of_binding cfg) cfg.bindings in
+  let assignments = cfg.keeper_assignments in
+  match cfg.default_runtime_id with
+  | None ->
+    Error
+      (Printf.sprintf
+         "%s: [runtime].default is required (no default runtime configured; \
+          silent fallback removed)"
+         config_path)
+  | Some did ->
+    (match List.find_opt (fun (r : t) -> String.equal r.id did) runtimes with
+     | None ->
+       Error
+         (Printf.sprintf
+            "%s: [runtime].default = %S not found among %d runtimes"
+            config_path
+            did
+            (List.length runtimes))
+     | Some rt ->
+       (match validate_keeper_assignments ~config_path runtimes assignments with
+        | Error _ as e -> e
+        | Ok () -> Ok (runtimes, rt, assignments)))
+;;
+
 let load_list ~(config_path : string)
   : (t list * t * (string * string) list, string) result
   =
@@ -79,29 +106,7 @@ let load_list ~(config_path : string)
          "runtime config parse failed (%s): %d error(s)"
          config_path
          (List.length errs))
-  | Ok cfg ->
-    let runtimes = List.filter_map (of_binding cfg) cfg.bindings in
-    let assignments = cfg.keeper_assignments in
-    (match cfg.default_runtime_id with
-     | None ->
-       Error
-         (Printf.sprintf
-            "%s: [runtime].default is required (no default runtime configured; \
-             silent fallback removed)"
-            config_path)
-     | Some did ->
-       (match List.find_opt (fun (r : t) -> String.equal r.id did) runtimes with
-        | None ->
-          Error
-            (Printf.sprintf
-               "%s: [runtime].default = %S not found among %d runtimes"
-               config_path
-               did
-               (List.length runtimes))
-        | Some rt ->
-          (match validate_keeper_assignments ~config_path runtimes assignments with
-           | Error _ as e -> e
-           | Ok () -> Ok (runtimes, rt, assignments))))
+  | Ok cfg -> materialize_config ~config_path cfg
 
 (* ---- Lazy default runtime singleton ---- *)
 
@@ -203,6 +208,267 @@ let config_path () : string option =
       in
       if Sys.file_exists path then Some path else None
   | Invalid_env | Missing -> None
+;;
+
+let contains_newline s =
+  String.exists (function
+    | '\n' | '\r' -> true
+    | _ -> false)
+    s
+;;
+
+let toml_escape_string s =
+  let buf = Buffer.create (String.length s) in
+  String.iter
+    (function
+      | '"' -> Buffer.add_string buf "\\\""
+      | '\\' -> Buffer.add_string buf "\\\\"
+      | '\n' -> Buffer.add_string buf "\\n"
+      | '\r' -> Buffer.add_string buf "\\r"
+      | '\t' -> Buffer.add_string buf "\\t"
+      | c -> Buffer.add_char buf c)
+    s;
+  Buffer.contents buf
+;;
+
+let assignment_line ~keeper_name ~runtime_id =
+  Printf.sprintf
+    "\"%s\" = \"%s\""
+    (toml_escape_string keeper_name)
+    (toml_escape_string runtime_id)
+;;
+
+let split_lines content =
+  if String.equal content "" then [], false
+  else (
+    let len = String.length content in
+    let trailing_newline = Char.equal content.[len - 1] '\n' in
+    let parts = String.split_on_char '\n' content in
+    let lines =
+      if trailing_newline
+      then (
+        match List.rev parts with
+        | "" :: rest -> List.rev rest
+        | _ -> parts)
+      else parts
+    in
+    lines, trailing_newline)
+;;
+
+let join_lines lines ~trailing_newline =
+  match lines with
+  | [] -> if trailing_newline then "\n" else ""
+  | _ ->
+    let body = String.concat "\n" lines in
+    if trailing_newline then body ^ "\n" else body
+;;
+
+let strip_toml_comment line =
+  match String.index_opt line '#' with
+  | None -> line
+  | Some index -> String.sub line 0 index
+;;
+
+let is_toml_table_header line =
+  let s = line |> strip_toml_comment |> String.trim in
+  let len = String.length s in
+  len >= 2 && Char.equal s.[0] '[' && Char.equal s.[len - 1] ']'
+;;
+
+let is_runtime_assignments_header line =
+  String.equal (line |> strip_toml_comment |> String.trim) "[runtime.assignments]"
+;;
+
+let rec split_at n xs =
+  if n <= 0 then [], xs
+  else
+    match xs with
+    | [] -> [], []
+    | x :: rest ->
+      let before, after = split_at (n - 1) rest in
+      x :: before, after
+;;
+
+let find_index pred xs =
+  let rec loop index = function
+    | [] -> None
+    | x :: rest -> if pred x then Some index else loop (index + 1) rest
+  in
+  loop 0 xs
+;;
+
+let parse_quoted_key raw =
+  let len = String.length raw in
+  if len < 2 || not (Char.equal raw.[0] '"') then None
+  else
+    let buf = Buffer.create len in
+    let rec loop index =
+      if index >= len then None
+      else
+        match raw.[index] with
+        | '"' -> Some (Buffer.contents buf)
+        | '\\' when index + 1 < len ->
+          let escaped =
+            match raw.[index + 1] with
+            | '"' -> '"'
+            | '\\' -> '\\'
+            | 'n' -> '\n'
+            | 'r' -> '\r'
+            | 't' -> '\t'
+            | c -> c
+          in
+          Buffer.add_char buf escaped;
+          loop (index + 2)
+        | c ->
+          Buffer.add_char buf c;
+          loop (index + 1)
+    in
+    loop 1
+;;
+
+let parse_literal_key raw =
+  let len = String.length raw in
+  if len < 2 || not (Char.equal raw.[0] '\'') then None
+  else
+    match String.index_from_opt raw 1 '\'' with
+    | None -> None
+    | Some end_index -> Some (String.sub raw 1 (end_index - 1))
+;;
+
+let assignment_key_of_line line =
+  let trimmed = String.trim line in
+  if String.equal trimmed "" || Char.equal trimmed.[0] '#'
+  then None
+  else
+    match String.index_opt trimmed '=' with
+    | None -> None
+    | Some eq_index ->
+      let key_part = String.sub trimmed 0 eq_index |> String.trim in
+      if String.equal key_part ""
+      then None
+      else if Char.equal key_part.[0] '"'
+      then parse_quoted_key key_part
+      else if Char.equal key_part.[0] '\''
+      then parse_literal_key key_part
+      else Some key_part
+;;
+
+let replace_or_append_assignment section_lines ~keeper_name ~runtime_id =
+  let line = assignment_line ~keeper_name ~runtime_id in
+  let rec loop acc = function
+    | [] -> List.rev_append acc [ line ]
+    | existing :: rest ->
+      (match assignment_key_of_line existing with
+       | Some key when String.equal key keeper_name ->
+         List.rev_append acc (line :: rest)
+       | _ -> loop (existing :: acc) rest)
+  in
+  loop [] section_lines
+;;
+
+let append_runtime_assignments_section lines ~keeper_name ~runtime_id =
+  let section =
+    [ "[runtime.assignments]"; assignment_line ~keeper_name ~runtime_id ]
+  in
+  match List.rev lines with
+  | [] -> section
+  | last :: _ when String.equal (String.trim last) "" -> lines @ section
+  | _ -> lines @ ("" :: section)
+;;
+
+let update_runtime_assignment_text content ~keeper_name ~runtime_id =
+  let lines, _trailing_newline = split_lines content in
+  let updated_lines =
+    match find_index is_runtime_assignments_header lines with
+    | None -> append_runtime_assignments_section lines ~keeper_name ~runtime_id
+    | Some header_index ->
+      let before, from_header = split_at header_index lines in
+      (match from_header with
+       | [] -> append_runtime_assignments_section lines ~keeper_name ~runtime_id
+       | header :: after_header ->
+         let section_lines, after_section =
+           match find_index is_toml_table_header after_header with
+           | None -> after_header, []
+           | Some next_header_index -> split_at next_header_index after_header
+         in
+         before
+         @ (header
+            :: replace_or_append_assignment
+                 section_lines
+                 ~keeper_name
+                 ~runtime_id)
+         @ after_section)
+  in
+  join_lines updated_lines ~trailing_newline:true
+;;
+
+let runtime_parse_errors_to_string errs =
+  errs
+  |> List.map (fun (err : Runtime_toml.parse_error) ->
+    Printf.sprintf "%s: %s" err.path err.message)
+  |> String.concat "; "
+;;
+
+let validate_runtime_config_text ~config_path content =
+  match Runtime_toml.parse_string content with
+  | Error errs ->
+    Error
+      (Printf.sprintf
+         "runtime config parse failed (%s): %s"
+         config_path
+         (runtime_parse_errors_to_string errs))
+  | Ok cfg ->
+    (match materialize_config ~config_path cfg with
+     | Ok _ -> Ok ()
+     | Error _ as e -> e)
+;;
+
+let set_runtime_id_for_keeper ?runtime_config_path ~keeper_name ~runtime_id () =
+  let keeper_name = String.trim keeper_name in
+  let runtime_id = String.trim runtime_id in
+  if String.equal keeper_name ""
+  then Error "keeper_name must not be empty"
+  else if String.equal runtime_id ""
+  then Error "runtime_id must not be empty"
+  else if contains_newline keeper_name
+  then Error "keeper_name must not contain newlines"
+  else if contains_newline runtime_id
+  then Error "runtime_id must not contain newlines"
+  else
+    let path_result =
+      match runtime_config_path with
+      | Some path -> Ok path
+      | None ->
+        (match config_path () with
+         | Some path -> Ok path
+         | None -> Error "runtime config path not found")
+    in
+    match path_result with
+    | Error _ as e -> e
+    | Ok path ->
+      let content_result =
+        try Ok (Fs_compat.load_file path) with
+        | exn ->
+          Error
+            (Printf.sprintf
+               "failed to read runtime config %s: %s"
+               path
+               (Printexc.to_string exn))
+      in
+      (match content_result with
+       | Error _ as e -> e
+       | Ok content ->
+         let next = update_runtime_assignment_text content ~keeper_name ~runtime_id in
+         (match validate_runtime_config_text ~config_path:path next with
+          | Error _ as e -> e
+          | Ok () ->
+            (match Fs_compat.save_file_atomic path next with
+             | Error _ as e -> e
+             | Ok () ->
+               (match init_default ~config_path:path with
+                | Ok () -> Ok ()
+                | Error msg ->
+                  Error ("runtime config saved but reload failed: " ^ msg)))))
 ;;
 
 (* RFC-0206 single-binding: the deleted [Runtime_runtime.resolve_*_max_context]

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -78,6 +78,17 @@ val config_path : unit -> string option
     deleted [Runtime.config_path] (delegates to
     [Config_dir_resolver]). *)
 
+val set_runtime_id_for_keeper :
+  ?runtime_config_path:string ->
+  keeper_name:string ->
+  runtime_id:string ->
+  unit ->
+  (unit, string) result
+(** Persist [keeper_name] -> [runtime_id] in
+    [\[runtime.assignments\]] (runtime.toml SSOT), validate the resulting
+    runtime config, atomically write it, and refresh the in-process runtime
+    assignment cache. *)
+
 val default_max_context : unit -> int
 (** Context-window budget of the default runtime's model (RFC-0206
     single-binding). Replaces the deleted [Runtime_runtime.resolve_*_max_context]

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -43,6 +43,20 @@ let write_file path content =
   Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () -> output_string oc content)
 ;;
 
+let string_contains haystack needle =
+  let haystack_len = String.length haystack in
+  let needle_len = String.length needle in
+  if needle_len = 0 then true
+  else
+    let rec loop index =
+      index + needle_len <= haystack_len
+      &&
+      (String.equal (String.sub haystack index needle_len) needle
+       || loop (index + 1))
+    in
+    loop 0
+;;
+
 (* Point MASC_CONFIG_DIR at an isolated temp dir and reset the resolver cache so
    the new value takes effect; restore the prior value on exit. *)
 let with_config_dir f =
@@ -121,14 +135,18 @@ max-concurrent = 1
 |}
 ;;
 
-let with_runtime_initialized f =
+let with_runtime_file f =
   with_temp_dir "runtime-per-keeper-routing-runtime" @@ fun dir ->
-  let path = Filename.concat dir "keeper_runtime.toml" in
+  let path = Filename.concat dir "runtime.toml" in
   write_file path runtime_config;
   (match Runtime.init_default ~config_path:path with
    | Ok () -> ()
    | Error msg -> Alcotest.failf "runtime init_default failed: %s" msg);
-  f ()
+  f path
+;;
+
+let with_runtime_initialized f =
+  with_runtime_file (fun _path -> f ())
 ;;
 
 (* ---- the per-keeper selection actually reaches the dispatcher ---- *)
@@ -140,6 +158,70 @@ let test_assignment_drives_runtime_id_of_meta () =
       "assigned keeper dispatches to its runtime.toml assignment, not the global default"
       "openai.gpt"
       (KMC.runtime_id_of_meta (make_meta "routingtest")))
+;;
+
+let test_runtime_assignment_writer_updates_runtime_toml () =
+  with_runtime_file (fun path ->
+    (match
+       Runtime.set_runtime_id_for_keeper
+         ~runtime_config_path:path
+         ~keeper_name:"routingtest"
+         ~runtime_id:"runpod_mtp.qwen"
+         ()
+     with
+     | Ok () -> ()
+     | Error msg -> Alcotest.failf "set_runtime_id_for_keeper failed: %s" msg);
+    Alcotest.(check bool)
+      "runtime.toml assignment rewritten"
+      true
+      (string_contains
+         (Fs_compat.load_file path)
+         "\"routingtest\" = \"runpod_mtp.qwen\"");
+    Alcotest.(check (option string))
+      "in-process assignment cache refreshed"
+      (Some "runpod_mtp.qwen")
+      (Runtime.runtime_id_for_keeper "routingtest");
+    Alcotest.(check string)
+      "meta runtime resolver sees updated assignment"
+      "runpod_mtp.qwen"
+      (KMC.runtime_id_of_meta (make_meta "routingtest")))
+;;
+
+let test_runtime_assignment_writer_rejects_unknown_runtime_without_write () =
+  with_runtime_file (fun path ->
+    let before = Fs_compat.load_file path in
+    (match
+       Runtime.set_runtime_id_for_keeper
+         ~runtime_config_path:path
+         ~keeper_name:"routingtest"
+         ~runtime_id:"missing.runtime"
+         ()
+     with
+     | Ok () -> Alcotest.fail "expected unknown runtime assignment to fail"
+     | Error msg ->
+       Alcotest.(check bool)
+         "error mentions unresolved assignment"
+         true
+         (string_contains msg "missing.runtime"));
+    Alcotest.(check string)
+      "runtime.toml unchanged after validation failure"
+      before
+      (Fs_compat.load_file path);
+    Alcotest.(check (option string))
+      "in-process assignment cache unchanged"
+      (Some "openai.gpt")
+      (Runtime.runtime_id_for_keeper "routingtest"))
+;;
+
+let test_runtime_id_tool_arg_is_not_removed_keeper_arg () =
+  match
+    Keeper_types_profile.reject_removed_keeper_input_keys
+      ~tool_name:"masc_keeper_up"
+      (`Assoc [ "runtime_id", `String "openai.gpt" ])
+  with
+  | Ok () -> ()
+  | Error msg ->
+    Alcotest.failf "runtime_id dashboard patch arg should be accepted: %s" msg
 ;;
 
 let test_undeclared_keeper_falls_to_default () =
@@ -235,6 +317,18 @@ let () =
             "unassigned keeper falls to [runtime].default"
             `Quick
             test_undeclared_keeper_falls_to_default
+        ; Alcotest.test_case
+            "dashboard runtime assignment writes runtime.toml and refreshes cache"
+            `Quick
+            test_runtime_assignment_writer_updates_runtime_toml
+        ; Alcotest.test_case
+            "unknown assignment is rejected before runtime.toml write"
+            `Quick
+            test_runtime_assignment_writer_rejects_unknown_runtime_without_write
+        ; Alcotest.test_case
+            "runtime_id API arg is not rejected as a removed keeper arg"
+            `Quick
+            test_runtime_id_tool_arg_is_not_removed_keeper_arg
         ] )
     ; ( "driver lookup"
       , [ Alcotest.test_case


### PR DESCRIPTION
## Summary
- Allow dashboard `runtime_id` PATCH input to flow through keeper update/create parsing instead of being rejected as a removed keeper arg.
- Persist keeper runtime selections to `runtime.toml` `[runtime.assignments]`, validate the resulting runtime config, atomically write it, and refresh the in-process runtime assignment cache.
- Update dashboard copy/tests so the UI points operators at `runtime.toml [runtime.assignments]` instead of keeper TOML `runtime_id`.

## Root Cause
The dashboard already sent `{ runtime_id: ... }`, but the server rejected that key as a removed keeper input. Even if accepted, the keeper update path only wrote keeper metadata and had no writer for `runtime.toml`, so the dashboard could appear to save without changing the runtime assignment SSOT.

## Validation
- `git diff --check`
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_runtime_settings dune build --root . test/test_runtime_per_keeper_routing.exe`
- `_build_runtime_settings/default/test/test_runtime_per_keeper_routing.exe`
- `pnpm typecheck`
- `pnpm exec vitest run --config vitest.config.ts src/components/keeper-config-panel.test.ts src/components/keeper-runtime-model-editor.test.ts --no-file-parallelism --maxWorkers=1`