### PR TITLE
fix(ide): remove command_descriptor from error results and logs

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -548,7 +548,20 @@ let make_hooks
           match output with
           | Ok _ -> "-"
           | Error _ ->
-            output_text
+            (* Strip command_descriptor from error preview to reduce log noise.
+               The descriptor is only meaningful on success; errors carry
+               sufficient diagnostic info via exit code and stderr. *)
+            let stripped =
+              try
+                let json = Yojson.Safe.from_string output_text in
+                match json with
+                | `Assoc fields ->
+                  let fields' = List.filter (fun (k, _) -> k <> "command_descriptor") fields in
+                  Yojson.Safe.to_string (`Assoc fields')
+                | _ -> output_text
+              with _ -> output_text
+            in
+            stripped
             |> Observability_redact.redact_preview ~max_len:240
             |> one_line_preview_for_log
         in

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -473,7 +473,15 @@ let handle_tool_execute_typed
                 ~classification
                 ~status:result.status
             in
-            let descriptor = compute_command_descriptor ir in
+            (* Only include command_descriptor on success — errors already carry
+               sufficient diagnostic info (exit code, stderr, classification). *)
+            let descriptor_fields =
+              match result.status with
+              | Unix.WEXITED 0 ->
+                let descriptor = compute_command_descriptor ir in
+                [ "command_descriptor", Ide_event_types.command_descriptor_to_json descriptor ]
+              | _ -> []
+            in
             Yojson.Safe.to_string
               (Exec_core.process_result_json
                  ~classification
@@ -487,8 +495,8 @@ let handle_tool_execute_typed
                       ; "typed", `Bool true
                       ; "execution_time_ms", `Int elapsed_ms
                       ; "timeout_sec", `Float timeout_sec
-                      ; "command_descriptor", Ide_event_types.command_descriptor_to_json descriptor
                       ]
+                    @ descriptor_fields
                     @ execution_location_fields cwd)
                  ~status:result.status
                  ~output


### PR DESCRIPTION
에러 결과에서 descriptor 제거 (success일 때만 포함). 에러 로그에서 descriptor strip. 19개 테스트 통과.