### PR TITLE
refactor(keeper): account cost_usd independent of token-trust (remove no-op cost-suppression)

### DIFF
--- a/lib/keeper/keeper_hooks_oas_cost_events.ml
+++ b/lib/keeper/keeper_hooks_oas_cost_events.ml
@@ -22,7 +22,13 @@ let () =
 let classify_cost_usd_source ~usage_missing ~usage_trusted ~runtime_unmetered
     ~cost_usd =
   if usage_missing then cost_label_usage_missing
-  else if not usage_trusted then cost_label_usage_untrusted
+  (* token⊥cost: an untrusted *token count* does not gate the provider's
+     authoritative cost_usd. A positive cost_usd is labelled [computed] even when
+     token usage is untrusted; only zero/absent cost on an untrusted turn keeps
+     the [usage_untrusted] source label. Keeps the value and the source label in
+     sync with [cost_status_for_event]. *)
+  else if (not usage_trusted) && not (cost_usd > 0.0) then
+    cost_label_usage_untrusted
   else if runtime_unmetered then cost_source_unmetered_provider
   else if cost_usd > 0.0 then cost_source_computed
   else cost_label_oas_cost_unreported
@@ -89,8 +95,12 @@ let assemble_cost_event_payload
   let provider = runtime_lane_label in
   let runtime_unknown = false in
   let runtime_unmetered = false in
-  (* Classify cost_status using raw cost_usd so OAS-reported cost is
-     considered before the safe-value mask below. *)
+  (* Classify cost_status from the raw cost_usd. cost_usd is the provider's
+     authoritative cost field and is accounted independently of token-count
+     trust (token⊥cost): a positive cost_usd yields Cost_reported (and is kept
+     by the safe-value mask below) even when token usage is untrusted. Only the
+     token COUNTS are zeroed for untrusted usage (safe_input/output_tokens
+     above). *)
   let cost_status =
     cost_status_for_event
       ~runtime_unknown

--- a/lib/keeper/keeper_hooks_oas_types.ml
+++ b/lib/keeper/keeper_hooks_oas_types.ml
@@ -152,7 +152,11 @@ let cost_status_for_event
     ~(output_tokens : int)
     ~(cost_usd : float) =
   if usage_missing then Cost_usage_missing
-  else if not usage_trusted then Cost_usage_untrusted
+  (* token⊥cost: an untrusted *token count* does not gate the provider's
+     authoritative cost_usd. A positive cost_usd is accounted (Cost_reported)
+     even when token usage is untrusted; only zero/absent cost on an untrusted
+     turn keeps the Cost_usage_untrusted label. *)
+  else if (not usage_trusted) && not (cost_usd > 0.0) then Cost_usage_untrusted
   else if cost_usd > 0.0 then Cost_reported
   else if input_tokens <= 0 && output_tokens <= 0 then Cost_no_tokens
   else if runtime_unmetered then Cost_known_free

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -27,17 +27,10 @@ let handle_keeper_up = Keeper_turn_up.handle_keeper_up
 let handle_keeper_down = Keeper_turn_lifecycle.handle_keeper_down
 
 let turn_cost_for_result (result : Keeper_agent_run.run_result) : float =
-  let usage_trust =
-    Keeper_unified_metrics.classify_usage_trust
-      ~usage_reported:result.usage_reported
-      ~usage:result.usage
-      ~context_max:0
-  in
-  if Keeper_unified_metrics.usage_trust_is_trusted usage_trust then
-    Keeper_unified_metrics.estimate_trusted_usage_cost_usd
-      ~usage_trusted:true
-      result.usage
-  else 0.0
+  (* cost_usd is accounted independently of token-count trust (token⊥cost). The
+     provider's authoritative cost field is used directly; missing/non-positive
+     cost remains 0.0. *)
+  Keeper_unified_metrics.estimate_usage_cost_usd result.usage
 
 let update_direct_turn_meta (meta : keeper_meta) ~(latency_ms : int)
     (result : Keeper_agent_run.run_result) : keeper_meta =

--- a/lib/keeper/keeper_unified_metrics.mli
+++ b/lib/keeper/keeper_unified_metrics.mli
@@ -38,13 +38,13 @@ val classify_usage_trust :
 
 val usage_trust_is_trusted : usage_trust -> bool
 
-val estimate_trusted_usage_cost_usd :
-  usage_trusted:bool ->
+val estimate_usage_cost_usd :
   Agent_sdk.Types.api_usage ->
   float
-(** Return the OAS-reported turn cost for trusted usage.  MASC does not
-    estimate provider/model pricing locally; missing or non-positive cost
-    remains [0.0]. *)
+(** Return the OAS-reported turn cost. cost_usd is the provider's authoritative
+    cost field and is accounted independently of token-count trust (token⊥cost).
+    MASC does not estimate provider/model pricing locally; missing or
+    non-positive cost remains [0.0]. *)
 
 val usage_trust_to_string : usage_trust -> string
 

--- a/lib/keeper/keeper_unified_metrics_result.ml
+++ b/lib/keeper/keeper_unified_metrics_result.ml
@@ -45,11 +45,9 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
   let trusted_total_tokens =
     if usage_trusted then Keeper_context_runtime.total_tokens result.usage else 0
   in
-  let turn_cost =
-    estimate_trusted_usage_cost_usd
-      ~usage_trusted
-      result.usage
-  in
+  (* Token counts above are zeroed when usage is untrusted; cost is accounted
+     independently of token-trust (token⊥cost). *)
+  let turn_cost = estimate_usage_cost_usd result.usage in
   let substantive_tool_call_count =
     result.tools_used
     |> List.filter (fun name -> not (is_observation_only_tool_name name))

--- a/lib/keeper/keeper_unified_metrics_support.ml
+++ b/lib/keeper/keeper_unified_metrics_support.ml
@@ -185,12 +185,15 @@ let record_turn_latency_by_model_bucket
 
 let usage_trust_is_trusted = Keeper_usage_trust.is_trusted
 
-let estimate_trusted_usage_cost_usd ~usage_trusted usage =
-  if usage_trusted then
-    match usage.Agent_sdk.Types.cost_usd with
-    | Some cost when cost > 0.0 -> cost
-    | Some _ | None -> 0.0
-  else 0.0
+(* cost_usd is the provider's authoritative cost field; it is independent of
+   whether token *counts* are trusted (token⊥cost). This function accounts the
+   reported cost directly and does NOT gate it on token-trust. Token counts may
+   still be zeroed for untrusted usage — that is the separate token-metrics
+   concern handled by callers, not a reason to drop a real reported cost. *)
+let estimate_usage_cost_usd usage =
+  match usage.Agent_sdk.Types.cost_usd with
+  | Some cost when cost > 0.0 -> cost
+  | Some _ | None -> 0.0
 
 let usage_trust_to_string = Keeper_usage_trust.to_string
 

--- a/lib/keeper/keeper_unified_metrics_support.mli
+++ b/lib/keeper/keeper_unified_metrics_support.mli
@@ -29,8 +29,7 @@ val classify_usage_trust :
 
 val usage_trust_is_trusted : usage_trust -> bool
 
-val estimate_trusted_usage_cost_usd :
-  usage_trusted:bool ->
+val estimate_usage_cost_usd :
   Agent_sdk.Types.api_usage ->
   float
 

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -10,16 +10,9 @@ open Keeper_meta_contract
 let runtime_lane_label =
   Boundary_redaction.to_string Boundary_redaction.runtime_model_label
 
-let turn_cost result =
-  let usage_trust_for_cost =
-    KUM.classify_usage_trust
-      ~usage_reported:result.Keeper_agent_run.usage_reported
-      ~usage:result.usage
-      ~context_max:0
-  in
-  KUM.estimate_trusted_usage_cost_usd
-    ~usage_trusted:(KUM.usage_trust_is_trusted usage_trust_for_cost)
-    result.usage
+(* cost_usd is accounted independently of token-count trust (token⊥cost), so the
+   turn cost no longer needs a usage-trust classification. *)
+let turn_cost result = KUM.estimate_usage_cost_usd result.Keeper_agent_run.usage
 ;;
 
 let apply_lifecycle ~config ~base_dir ~meta ~final_execution ~current_turn_blocker_info result =

--- a/test/dune
+++ b/test/dune
@@ -107,6 +107,7 @@
   test_keeper_usage_trust_counter
   test_llm_metric_bridge
   test_cost_usd_source_attribution_10318
+  test_cost_token_decouple
   test_response_model_empty_10083
   test_keeper_proactive_skip_counter
   test_keeper_tool_selection_passive_streak
@@ -368,6 +369,7 @@
   test_keeper_usage_trust_counter
   test_llm_metric_bridge
   test_cost_usd_source_attribution_10318
+  test_cost_token_decouple
   test_response_model_empty_10083
   test_keeper_proactive_skip_counter
   test_keeper_tool_selection_passive_streak

--- a/test/test_cost_token_decouple.ml
+++ b/test/test_cost_token_decouple.ml
@@ -1,0 +1,119 @@
+(** token⊥cost: provider cost_usd is accounted independently of token-count trust.
+
+    Before this decoupling, an untrusted *token count* (e.g.
+    [zero_token_usage_reported]) forced the accounted [cost_usd] to 0.0 and the
+    source label to [usage_untrusted], even when the provider reported a positive
+    authoritative cost. Empirically this had never suppressed a real dollar (all
+    untrusted ledger rows carried raw_cost_usd=0.0), so the gate was a no-op that
+    carried a latent footgun: a future provider reporting 0 tokens + nonzero
+    cost_usd would have real spend silently dropped from accounting.
+
+    These tests pin the decoupled contract on the assembled cost-ledger payload:
+
+    - untrusted token usage + positive cost_usd => the positive cost is accounted
+      ([cost_usd] field), [cost_status="reported"], [cost_usd_source="computed"],
+      WHILE [usage_trust="untrusted"] is still surfaced (token-trust visibility
+      preserved — only the COST coupling was removed).
+    - untrusted token usage + zero/absent cost_usd => 0.0 accounted, and the
+      [usage_untrusted] labels are retained (no-op vs. pre-decouple behavior, as
+      every real untrusted row carries cost_usd=0.0 today). *)
+
+open Alcotest
+
+module H = Masc.Keeper_hooks_oas
+module Trust = Masc.Keeper_usage_trust
+
+let string_field payload key =
+  match payload with
+  | `Assoc fields -> (
+      match List.assoc_opt key fields with
+      | Some (`String s) -> s
+      | Some other -> Alcotest.failf "%s not a string: %s" key (Yojson.Safe.to_string other)
+      | None -> Alcotest.failf "%s absent from payload" key)
+  | _ -> Alcotest.fail "payload not an object"
+
+let float_field payload key =
+  match payload with
+  | `Assoc fields -> (
+      match List.assoc_opt key fields with
+      | Some (`Float f) -> f
+      | Some (`Int i) -> float_of_int i
+      | Some other -> Alcotest.failf "%s not a number: %s" key (Yojson.Safe.to_string other)
+      | None -> Alcotest.failf "%s absent from payload" key)
+  | _ -> Alcotest.fail "payload not an object"
+
+(* The canonical untrusted-token signal: provider reported zero token counts. *)
+let untrusted_zero_tokens : Trust.t =
+  Trust.Usage_untrusted [ "zero_token_usage_reported" ]
+
+let payload ~cost_usd ~usage_trust =
+  H.cost_event_payload
+    ~agent_name:"test_agent"
+    ~task_id:None
+    ~input_tokens:0
+    ~output_tokens:0
+    ~cost_usd
+    ~usage_trust
+    ()
+
+(* --- the decoupling: untrusted tokens must not drop a real reported cost --- *)
+
+let test_untrusted_tokens_positive_cost_is_accounted () =
+  (* 0 tokens (untrusted) but a positive provider cost: the footgun row. *)
+  let p = payload ~cost_usd:0.0123 ~usage_trust:untrusted_zero_tokens in
+  check (float 1e-9) "positive cost_usd is accounted, not masked to 0.0" 0.0123
+    (float_field p "cost_usd");
+  check string "cost_status reflects the reported cost" "reported"
+    (string_field p "cost_status");
+  check string "cost_usd_source labels the accounted cost as computed" "computed"
+    (string_field p "cost_usd_source")
+
+let test_untrusted_tokens_still_surface_trust () =
+  (* Token-trust visibility is preserved: decoupling cost does NOT silence the
+     usage_trust signal that operators alert on. *)
+  let p = payload ~cost_usd:0.0123 ~usage_trust:untrusted_zero_tokens in
+  check string "usage_trust still surfaces untrusted" "untrusted"
+    (string_field p "usage_trust")
+
+(* --- no-op leg: untrusted tokens + zero/absent cost stays 0.0 + untrusted --- *)
+
+let test_untrusted_tokens_zero_cost_stays_zero () =
+  let p = payload ~cost_usd:0.0 ~usage_trust:untrusted_zero_tokens in
+  check (float 1e-9) "zero cost stays 0.0" 0.0 (float_field p "cost_usd");
+  check string "cost_usd_source remains usage_untrusted for zero cost"
+    "usage_untrusted" (string_field p "cost_usd_source");
+  check string "usage_trust still untrusted" "untrusted"
+    (string_field p "usage_trust")
+
+let test_trusted_tokens_positive_cost_unchanged () =
+  (* Regression guard: the always-trusted path is unaffected. *)
+  let p =
+    H.cost_event_payload ~agent_name:"test_agent" ~task_id:None
+      ~input_tokens:100 ~output_tokens:50 ~cost_usd:0.0042
+      ~usage_trust:Trust.Usage_trusted ()
+  in
+  check (float 1e-9) "trusted positive cost accounted" 0.0042
+    (float_field p "cost_usd");
+  check string "trusted positive cost => computed" "computed"
+    (string_field p "cost_usd_source");
+  check string "trusted positive cost => reported" "reported"
+    (string_field p "cost_status")
+
+let () =
+  run "cost_token_decouple"
+    [
+      ( "decouple",
+        [
+          test_case "untrusted tokens + positive cost is accounted" `Quick
+            test_untrusted_tokens_positive_cost_is_accounted;
+          test_case "untrusted tokens still surface usage_trust" `Quick
+            test_untrusted_tokens_still_surface_trust;
+        ] );
+      ( "no-op-leg",
+        [
+          test_case "untrusted tokens + zero cost stays 0.0/untrusted" `Quick
+            test_untrusted_tokens_zero_cost_stays_zero;
+          test_case "trusted tokens + positive cost unchanged" `Quick
+            test_trusted_tokens_positive_cost_unchanged;
+        ] );
+    ]


### PR DESCRIPTION
## What

The keeper cost-accounting path forced `cost_usd` to `0.0` whenever token usage was "untrusted" (e.g. `zero_token_usage_reported`). This **conflates two independent signals**: token-count trust and cost trust. `cost_usd` is the provider's authoritative cost field, separate from input/output token counts. This PR decouples them (token ⊥ cost): `cost_usd` is accounted directly and is no longer gated on token-trust.

## This change is provably a no-op today (the gate never suppressed a real dollar)

Replayed against `~/.masc/costs.jsonl` + daily shards (`costs/2026-*/`), **142,616 rows total**:

| query | count |
|---|---|
| rows with `cost_usd_source="untrusted_usage"` (historical label, 2026-04-26 → 05-14) | **161** |
| rows with `cost_usd_source="usage_untrusted"` (current label after mid-May rename) | **17,708** |
| ...of those **17,869 untrusted rows**, how many have `raw_cost_usd > 0` | **0** |
| distinct `raw_cost_usd` among untrusted rows | only `0.0` |
| rows **anywhere** with `cost_usd==0 AND raw_cost_usd>0` (the suppressed-real-dollar case) | **0** |

> Note on the count vs the original "22 rows": the task cited the historical `untrusted_usage` label (161 rows here; the cited subset). The label was renamed `untrusted_usage` → `usage_untrusted` mid-May, so the current ledger carries 17,708 more under the new name. The no-op holds for **both** labels (0 suppressed dollars in all 17,869).

Every untrusted turn already had `cost_usd=0.0` AND `raw_cost_usd=0.0`, so accounting `cost_usd` directly still yields `0.0` for every row that has ever occurred. **The footgun it removes**: a future provider reporting 0 tokens + a nonzero `cost_usd` would have had real spend silently dropped from accounting.

## Why this is structural, not cosmetic

`Keeper_usage_trust.classify` (keeper_usage_trust.ml:47-69) inspects **only** token counts (`input_tokens`/`output_tokens`/`cache_*`) and `context_max` — it never reads or mutates `usage.cost_usd`. So an untrusted turn preserves the provider's `cost_usd` unchanged into the accounting layer; the gate removed here was the **only** token→cost coupling at this layer. Removing it is meaningful (closes the footgun), not a label rename.

## Changes (8 lib files + 1 test + dune)

- **`keeper_unified_metrics_support.ml` / `.mli`**: `estimate_trusted_usage_cost_usd ~usage_trusted` → `estimate_usage_cost_usd` (drops the misleading "trusted" name and the gate). Returns `usage.cost_usd` when `Some c, c > 0.0` else `0.0`, regardless of token-trust.
- **`keeper_unified_metrics.mli`**: re-export signature + docstring updated (was "Return the OAS-reported turn cost **for trusted usage**").
- **Callers updated** (all 3 — no N-of-M gap):
  - `keeper_unified_metrics_result.ml` — drop `~usage_trusted` (token counts above still zeroed for untrusted; `usage_trusted` binding retained for that).
  - `keeper_unified_turn_success.ml` — `turn_cost` no longer needs a trust classification.
  - `keeper_turn.ml` `turn_cost_for_result` — collapse the caller-side `if is_trusted … else 0.0` gate (a 3rd coupling site).
- **`keeper_hooks_oas_types.ml`** `cost_status_for_event`: narrow `not usage_trusted` → `(not usage_trusted) && not (cost_usd > 0.0)`, so a positive `cost_usd` reaches `Cost_reported` even when token usage is untrusted.
- **`keeper_hooks_oas_cost_events.ml`** `classify_cost_usd_source`: same narrowing (`&& not (cost_usd > 0.0)`; guarded rather than hoisted so it does not reorder past `runtime_unmetered`), keeping the accounted value and the `cost_usd_source` label in sync.
- **The lying comment fixed**: `keeper_hooks_oas_cost_events.ml` claimed "OAS-reported cost is considered before the safe-value mask" — false for untrusted turns on base (the `not usage_trusted` short-circuit ran first). Comment now describes the now-correct decoupled behavior.

**Narrowing, not deleting.** Deleting the untrusted branch outright would reclassify the label fields (`cost_status`, `cost_usd_source`, and the `record_cost_emit_source` Prometheus counter) for every untrusted-zero-cost turn — a label/distribution shift today, not a no-op. The `&& not (cost_usd > 0.0)` guard is byte-identical today (0 untrusted+cost>0 rows) and only changes the never-occurred footgun path.

## Kept intact (verified)

`Keeper_usage_trust` classification (`classify`, the 3-variant `Usage_missing | Usage_trusted | Usage_untrusted`, `warns_operator`, `json_fields`) and token-count zeroing for untrusted usage are unchanged. The trust bindings removed in `turn_cost`/`turn_cost_for_result` fed **only** the cost gate; trust classification for the metrics/warning path survives (`keeper_turn.ml:40,46` in `update_direct_turn_meta`; `keeper_unified_turn_success.ml:512,517`), so `warns_operator` still fires for genuine non-zero-token untrusted anomalies.

## Test

`test/test_cost_token_decouple.ml` exercises the real `cost_event_payload` assembly (not just the leaf classifier — `raw_cost_usd` is written from the same `~cost_usd` param, so this is the production emit shape):

- untrusted tokens + `cost_usd=0.0123` → emitted `cost_usd=0.0123`, `cost_status="reported"`, `cost_usd_source="computed"`, **and** `usage_trust="untrusted"` still surfaced.
- untrusted tokens + `0.0` → `0.0`, `cost_usd_source="usage_untrusted"` (no-op leg preserved).
- trusted + positive cost → unchanged (regression guard).

4/4 pass.

## Build verification

`main` may be broken by unrelated recent work (Masc_mcp→Masc rename + a half-done board decouple). The mega-lib is `(name masc)`. All changed modules compile in isolation (`--root .`, EXIT=0):
- `masc__Keeper_unified_metrics_support.cmo`, `masc__Keeper_hooks_oas_types.cmo`, `masc__Keeper_hooks_oas_cost_events.cmo` (3 cited)
- `masc__Keeper_unified_metrics_result.cmo`, `masc__Keeper_unified_turn_success.cmo`, `masc__Keeper_turn.cmo`, `masc__Keeper_unified_metrics.cmo` (callers/re-export)
- `test_cost_token_decouple.exe` builds and runs green.

The pre-commit whole-tree `dune build` hook passed (no false-block); commit made normally (no `--no-verify` needed).

## Pre-existing failure flagged (NOT introduced here)

`test/test_cost_usd_source_attribution_10318.ml` already fails on base `d884554ff1` with **2 failures** (`missing_usage`/`untrusted_usage` precedence cases assert stale label strings vs current constants `usage_missing`/`usage_untrusted`, from a mid-May label rename whose paired test-update was missed). Verified identical pre/post this change — my narrowing keeps those cases (`~cost_usd:0.0`) returning the same labels. **Not fixed here** (separate bug, surgical scope) → tracked in #19945. A reviewer/auto-merge gate should not attribute those 2 failures to this PR.

RFC-WAIVED: token⊥cost decoupling, keeper cost-accounting path, no guarded subsystem (`pr-rfc-check.sh` EXIT=0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
