### PR TITLE
fix(config): require MASC_BASE_PATH, remove cwd fallback

### DIFF
--- a/lib/config/env_config_core.ml
+++ b/lib/config/env_config_core.ml
@@ -370,14 +370,14 @@ let base_path_prod_guard path =
         else path
   end
 
-(** Project base path. Missing [MASC_BASE_PATH] falls back to cwd, not HOME. *)
+(** Project base path. [MASC_BASE_PATH] is required. *)
 let base_path () =
-  let raw =
-    match base_path_opt () with
-    | Some path -> path
-    | None -> "."
-  in
-  base_path_prod_guard raw
+  match base_path_opt () with
+  | Some path -> base_path_prod_guard path
+  | None ->
+      raise (Config_error
+        "MASC_BASE_PATH is not set. Set MASC_BASE_PATH to the project root \
+         containing the .masc/ directory.")
 
 let sb_path_opt () =
   match base_path_opt () with

--- a/test/test_tool_assignment_telemetry.ml
+++ b/test/test_tool_assignment_telemetry.ml
@@ -32,7 +32,7 @@ let with_eio_temp_base_path f =
     ~finally:(fun () ->
       (match prev with
        | Some v -> Unix.putenv "MASC_BASE_PATH" v
-       | None -> ());
+       | None -> Unix.putenv "MASC_BASE_PATH" "");
       cleanup_dir dir)
     (fun () ->
       Eio_main.run @@ fun env ->


### PR DESCRIPTION
## Summary
- `Env_config_core.base_path()` no longer falls back to cwd when `MASC_BASE_PATH` is unset.
- Raises `Config_error` with a clear message instead of silently using `.`.
- Test helper `with_eio_temp_base_path` properly clears `MASC_BASE_PATH` (set to empty string) when restoring previous unset state.

## Why
`MASC_BASE_PATH` is the SSOT for workspace identity. Silent cwd fallback caused:
- Data written to unintended paths (e.g. `~/.masc/repos/masc/`)
- Cross-workspace contamination
- Hard-to-debug \"where did my data go\" issues

## Test plan
- [x] `lib/config/` compiles cleanly
- [x] `test/test_tool_assignment_telemetry.ml` compiles
- [x] `test/test_server_base_path_diagnostics.ml` compiles
- [ ] Full `@check` blocked by pre-existing `keeper_hooks_oas.ml` partial-match warnings (unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)