### PR TITLE
fix(test): include strict in tool validation fixture

### DIFF
--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -31,7 +31,7 @@ let validate_via_oas ~tool_name ~(schema : Yojson.Safe.t) ~(args : Yojson.Safe.t
   if parameters = [] then Pass
   else
     let oas_schema : Agent_sdk.Types.tool_schema =
-      { name = tool_name; description = ""; parameters }
+      { name = tool_name; description = ""; parameters; strict = None }
     in
     match Agent_sdk.Tool_input_validation.validate oas_schema args with
     | Agent_sdk.Tool_input_validation.Valid coerced ->


### PR DESCRIPTION
## Summary

- Add the new OAS `tool_schema.strict` field to the `test_tool_input_validation` fixture.

## Product impact

- User-visible change: none. This keeps the test fixture compiling after the OAS `0.200.13` pin from #19950.

## Evidence

- `scripts/check-oas-pin.sh --local-only`
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_oas_pin_fix_verify dune build --root . test/test_tool_input_validation.exe`
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_oas_pin_fix_verify dune exec --root . test/test_tool_input_validation.exe`

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 0/3
provenance: operator_proxy
stages:
  - name: check-oas-pin
    command: scripts/check-oas-pin.sh --local-only
    result: pass
  - name: focused-dune-build
    command: env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_oas_pin_fix_verify dune build --root . test/test_tool_input_validation.exe
    result: pass
  - name: focused-test
    command: env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_oas_pin_fix_verify dune exec --root . test/test_tool_input_validation.exe
    result: pass
```

## GOAL LOOP ACT checklist

- [x] Observe — merged #19950 left one test fixture still using the old `tool_schema` record shape.
- [x] Orient — this is compile drift from OAS `0.200.13`.
- [x] Decide — keep the fix to the one stale fixture.
- [x] Act — add `strict = None`.
- [x] Verify — focused build and test passed locally.
- [x] Loop — no follow-up known.

## Review evidence

- Cross-model review not run; draft PR opened for CI/review.

## Linked issue

- Closes #N/A
- Relates #19950

## Variant addition checklist

- [ ] **OCaml** — N/A, no variant changed.
- [ ] **TypeScript** — N/A, no TypeScript union changed.
- [ ] **TLA+ spec** — N/A, no spec domain literal changed.
- [ ] **Event / JSON schema** — N/A, no event/schema enum changed.
- [ ] **`make check-variants` passes** — N/A, no variant/domain change.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`codex/oas-pin-tool-validation-fixture` → `main` · 1 commit(s) · synced 2026-06-03T15:06:20Z

| sha | subject | date |
|---|---|---|
| `bbdcd565d` | fix(test): include strict in tool validation fixture | 2026-06-03 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->