### PR TITLE
feat(ide): pipe chain descriptor + exit code semantics + cmd category

### DIFF
--- a/lib/ide/ide_bridge.ml
+++ b/lib/ide/ide_bridge.ml
@@ -301,7 +301,7 @@ let ingest_pr_event_from_descriptor
         ~pr_state:"open" ~repo ~keeper_id ~turn_id
         ~comment_count:1 ~review_status:None
         ~timestamp_ms:(Int64.of_float (Unix.gettimeofday () *. 1000.0))
-    | Some (Ide_event_types.Gh_issue_create _ | Ide_event_types.Gh_issue_close _ | Ide_event_types.Git_push _ | Ide_event_types.Git_commit _ | Ide_event_types.Generic)
+    | Some (Ide_event_types.Gh_issue_create _ | Ide_event_types.Gh_issue_close _ | Ide_event_types.Git_push _ | Ide_event_types.Git_commit _ | Ide_event_types.Pipe_chain _ | Ide_event_types.Generic)
     | None ->
       (* Not a PR operation — fall back to heuristic output parsing *)
       if String.equal tool_name "execute" then

--- a/lib/ide/ide_event_types.ml
+++ b/lib/ide/ide_event_types.ml
@@ -17,6 +17,7 @@ type command_descriptor =
   | Gh_api_pr_create of { repo : string; title : string; base : string }
   | Gh_api_pr_merge of { repo : string; pr_number : int }
   | Gh_api_pr_comment of { repo : string; pr_number : int; body : string }
+  | Pipe_chain of { first_cmd : string; last_cmd : string; length : int }
   | Generic
 
 let command_descriptor_to_json = function
@@ -46,6 +47,8 @@ let command_descriptor_to_json = function
     `Assoc [ "kind", `String "gh_api_pr_merge"; "repo", `String repo; "pr_number", `Int pr_number ]
   | Gh_api_pr_comment { repo; pr_number; body } ->
     `Assoc [ "kind", `String "gh_api_pr_comment"; "repo", `String repo; "pr_number", `Int pr_number; "body", `String body ]
+  | Pipe_chain { first_cmd; last_cmd; length } ->
+    `Assoc [ "kind", `String "pipe_chain"; "first_cmd", `String first_cmd; "last_cmd", `String last_cmd; "length", `Int length ]
   | Generic ->
     `Assoc [ "kind", `String "generic" ]
 
@@ -136,3 +139,56 @@ let ide_event_to_json = function
   | Tool_event e -> tool_event_to_json e
   | Turn_event e -> turn_event_to_json e
   | Pr_event e -> pr_event_to_json e
+
+(** Exit code semantics — many commands use exit codes to convey
+    information beyond success/failure. Inspired by Claude Code's
+    commandSemantics.ts. *)
+type exit_semantics =
+  | Success
+  | No_matches
+  | Files_differ
+  | Condition_false
+  | Error of string
+
+let interpret_exit_code ~(cmd_name : string) ~(exit_code : int) : exit_semantics =
+  match cmd_name, exit_code with
+  (* grep/rg/ag/ack: 0=matches found, 1=no matches, 2+=error *)
+  | ("grep" | "rg" | "ag" | "ack"), 0 -> Success
+  | ("grep" | "rg" | "ag" | "ack"), 1 -> No_matches
+  | ("grep" | "rg" | "ag" | "ack"), n -> Error (Printf.sprintf "exit %d" n)
+  (* diff: 0=no differences, 1=differences found, 2+=error *)
+  | "diff", 0 -> Success
+  | "diff", 1 -> Files_differ
+  | "diff", n -> Error (Printf.sprintf "exit %d" n)
+  (* test/[: 0=condition true, 1=condition false, 2+=error *)
+  | ("test" | "["), 0 -> Success
+  | ("test" | "["), 1 -> Condition_false
+  | ("test" | "["), n -> Error (Printf.sprintf "exit %d" n)
+  (* find: 0=success, 1=partial success, 2+=error *)
+  | "find", 0 -> Success
+  | "find", 1 -> Success (* partial success is still success *)
+  | "find", n -> Error (Printf.sprintf "exit %d" n)
+  (* General: 0=success, anything else=error *)
+  | _, 0 -> Success
+  | _, n -> Error (Printf.sprintf "exit %d" n)
+
+(** Classify a command into a broad category for UI display.
+    Inspired by Claude Code's BASH_SEARCH/READ/LIST/SILENT_COMMANDS sets. *)
+type cmd_category =
+  | Search_cmd
+  | Read_cmd
+  | List_cmd
+  | Silent_cmd
+  | Neutral_cmd
+  | Write_cmd
+
+let classify_cmd_category ~(cmd_name : string) : cmd_category =
+  match cmd_name with
+  | "find" | "grep" | "rg" | "ag" | "ack" | "locate" | "which" | "whereis" -> Search_cmd
+  | "cat" | "head" | "tail" | "less" | "more" | "wc" | "stat" | "file" | "strings"
+  | "jq" | "awk" | "cut" | "sort" | "uniq" | "tr" -> Read_cmd
+  | "ls" | "tree" | "du" -> List_cmd
+  | "mv" | "cp" | "rm" | "mkdir" | "rmdir" | "chmod" | "chown" | "chgrp"
+  | "touch" | "ln" | "cd" | "export" | "unset" | "wait" -> Silent_cmd
+  | "echo" | "printf" | "true" | "false" | ":" -> Neutral_cmd
+  | _ -> Write_cmd

--- a/lib/ide/ide_event_types.mli
+++ b/lib/ide/ide_event_types.mli
@@ -17,9 +17,32 @@ type command_descriptor =
   | Gh_api_pr_create of { repo : string; title : string; base : string }
   | Gh_api_pr_merge of { repo : string; pr_number : int }
   | Gh_api_pr_comment of { repo : string; pr_number : int; body : string }
+  | Pipe_chain of { first_cmd : string; last_cmd : string; length : int }
   | Generic
 
 val command_descriptor_to_json : command_descriptor -> Yojson.Safe.t
+
+(** Exit code semantics — many commands use exit codes to convey
+    information beyond success/failure. *)
+type exit_semantics =
+  | Success
+  | No_matches
+  | Files_differ
+  | Condition_false
+  | Error of string
+
+val interpret_exit_code : cmd_name:string -> exit_code:int -> exit_semantics
+
+(** Classify a command into a broad category for UI display. *)
+type cmd_category =
+  | Search_cmd
+  | Read_cmd
+  | List_cmd
+  | Silent_cmd
+  | Neutral_cmd
+  | Write_cmd
+
+val classify_cmd_category : cmd_name:string -> cmd_category
 
 type ide_event =
   | Tool_event of tool_event

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -39,107 +39,154 @@ let extract_number_from_rest (rest : string list) : int =
   scan rest
 ;;
 
+(** Get the command name from a Shell_ir simple command. *)
+let cmd_name_of_simple (simple : Masc_exec.Shell_ir.simple) : string =
+  Masc_exec.Exec_program.to_string simple.bin
+
+(** Get the command name from any Shell_ir.t node.
+    For pipelines, returns the last command name (exit code determiner). *)
+let rec cmd_name_of_ir (ir : Masc_exec.Shell_ir.t) : string =
+  match ir with
+  | Masc_exec.Shell_ir.Simple simple -> cmd_name_of_simple simple
+  | Masc_exec.Shell_ir.Pipeline cmds ->
+    (match List.rev cmds with
+     | last :: _ -> cmd_name_of_ir last
+     | [] -> "")
+
+(** Count the number of stages in a pipeline. *)
+let rec pipeline_length (ir : Masc_exec.Shell_ir.t) : int =
+  match ir with
+  | Masc_exec.Shell_ir.Simple _ -> 1
+  | Masc_exec.Shell_ir.Pipeline cmds -> List.length cmds
+
+(** Get the first command name from a pipeline. *)
+let rec first_cmd_name_of_ir (ir : Masc_exec.Shell_ir.t) : string =
+  match ir with
+  | Masc_exec.Shell_ir.Simple simple -> cmd_name_of_simple simple
+  | Masc_exec.Shell_ir.Pipeline (first :: _) -> first_cmd_name_of_ir first
+  | Masc_exec.Shell_ir.Pipeline [] -> ""
+
+(** Compute a structured command descriptor from a simple command.
+    Helper for the main [compute_command_descriptor]. *)
+let compute_command_descriptor_simple (simple : Masc_exec.Shell_ir.simple) : Ide_event_types.command_descriptor =
+  match Masc_exec.Shell_ir_typed.of_simple simple with
+  | Masc_exec.Shell_ir_typed_types.W (Masc_exec.Shell_ir_typed_types.Gh { subcommand; action; title; draft; squash; delete_branch; body; rest }) ->
+    (match subcommand, action with
+     (* PR operations *)
+     | "pr", Some "create" ->
+       let base = extract_flag_from_rest rest ~flag:"--base" ~short:(Some "-b") ~default:"main" in
+       Gh_pr_create { title = Option.value title ~default:""; base; draft }
+     | "pr", Some "merge" ->
+       Gh_pr_merge { pr_number = extract_number_from_rest rest; squash }
+     | "pr", Some "comment" ->
+       Gh_pr_comment { pr_number = extract_number_from_rest rest; body = Option.value body ~default:"" }
+     | "pr", Some "close" ->
+       Gh_pr_close { pr_number = extract_number_from_rest rest }
+     | "pr", Some "edit" ->
+       Gh_pr_edit { pr_number = extract_number_from_rest rest; title }
+     | "pr", Some "review" ->
+       Gh_pr_review { pr_number = extract_number_from_rest rest }
+     | "pr", Some "reopen" ->
+       Gh_pr_close { pr_number = extract_number_from_rest rest } (* reopen uses same structure *)
+     | "pr", Some "ready" ->
+       Gh_pr_review { pr_number = extract_number_from_rest rest }
+     (* Issue operations *)
+     | "issue", Some "create" ->
+       Gh_issue_create { title = Option.value title ~default:""; body = Option.value body ~default:"" }
+     | "issue", Some "close" ->
+       Gh_issue_close { issue_number = extract_number_from_rest rest }
+     | "issue", Some "reopen" ->
+       Gh_issue_close { issue_number = extract_number_from_rest rest }
+     (* Unknown gh subcommand *)
+     | _ -> Generic)
+  | Masc_exec.Shell_ir_typed_types.W (Masc_exec.Shell_ir_typed_types.Git_push { force; force_with_lease; set_upstream = _; remote; branch }) ->
+    Git_push {
+      remote = Option.value remote ~default:"origin";
+      branch = Option.value branch ~default:"main";
+      force = force || force_with_lease
+    }
+  | Masc_exec.Shell_ir_typed_types.W (Masc_exec.Shell_ir_typed_types.Git_commit { message; amend }) ->
+    Git_commit { message = if amend then message ^ " (amend)" else message }
+  | Masc_exec.Shell_ir_typed_types.W (Masc_exec.Shell_ir_typed_types.Git_merge { squash; branch; _ }) ->
+    Gh_pr_merge { pr_number = 0; squash } (* git merge is analogous to pr merge *)
+  | Masc_exec.Shell_ir_typed_types.W (Masc_exec.Shell_ir_typed_types.Curl { url; method_; body; _ }) ->
+    (* Detect GitHub API PR operations via curl *)
+    let is_github_api = String.length url > 23 && String.sub url 0 23 = "https://api.github.com/" in
+    if is_github_api then
+      let parts = String.split_on_char '/' url in
+      let find_repo parts =
+        let rec scan = function
+          | "repos" :: owner :: repo :: _ -> Some (owner ^ "/" ^ repo)
+          | _ :: rest -> scan rest
+          | [] -> None
+        in
+        scan parts
+      in
+      let find_pr_number parts =
+        let rec scan = function
+          | "pulls" :: n :: _ -> (match int_of_string_opt n with Some i -> i | None -> 0)
+          | "pull" :: n :: _ -> (match int_of_string_opt n with Some i -> i | None -> 0)
+          | _ :: rest -> scan rest
+          | [] -> 0
+        in
+        scan parts
+      in
+      let extract_title body_str =
+        try
+          let json = Yojson.Safe.from_string body_str in
+          Yojson.Safe.Util.member "title" json |> Yojson.Safe.Util.to_string
+        with _ -> ""
+      in
+      let extract_base body_str =
+        try
+          let json = Yojson.Safe.from_string body_str in
+          Yojson.Safe.Util.member "base" json |> Yojson.Safe.Util.to_string
+        with _ -> "main"
+      in
+      match find_repo parts with
+      | Some repo ->
+        (match method_ with
+         | `POST ->
+           let title = match body with Some b -> extract_title b | None -> "" in
+           let base = match body with Some b -> extract_base b | None -> "main" in
+           Gh_api_pr_create { repo; title; base }
+         | `PUT ->
+           let pr_number = find_pr_number parts in
+           Gh_api_pr_merge { repo; pr_number }
+         | `DELETE ->
+           let pr_number = find_pr_number parts in
+           Gh_api_pr_comment { repo; pr_number; body = "" }
+         | _ -> Generic)
+      | None -> Generic
+    else Generic
+  | _ -> Generic
+;;
+
 (** Compute a structured command descriptor from Shell IR.
-    Used by the IDE bridge for deterministic PR/issue event detection. *)
-let compute_command_descriptor (ir : Masc_exec.Shell_ir.t) : Ide_event_types.command_descriptor =
+    Used by the IDE bridge for deterministic PR/issue event detection.
+
+    For pipelines, classifies based on the last command (exit code determiner)
+    and wraps in Pipe_chain to preserve pipeline structure. *)
+let rec compute_command_descriptor (ir : Masc_exec.Shell_ir.t) : Ide_event_types.command_descriptor =
   match ir with
   | Masc_exec.Shell_ir.Simple simple ->
-    (match Masc_exec.Shell_ir_typed.of_simple simple with
-     | Masc_exec.Shell_ir_typed_types.W (Masc_exec.Shell_ir_typed_types.Gh { subcommand; action; title; draft; squash; delete_branch; body; rest }) ->
-       (match subcommand, action with
-        (* PR operations *)
-        | "pr", Some "create" ->
-          let base = extract_flag_from_rest rest ~flag:"--base" ~short:(Some "-b") ~default:"main" in
-          Gh_pr_create { title = Option.value title ~default:""; base; draft }
-        | "pr", Some "merge" ->
-          Gh_pr_merge { pr_number = extract_number_from_rest rest; squash }
-        | "pr", Some "comment" ->
-          Gh_pr_comment { pr_number = extract_number_from_rest rest; body = Option.value body ~default:"" }
-        | "pr", Some "close" ->
-          Gh_pr_close { pr_number = extract_number_from_rest rest }
-        | "pr", Some "edit" ->
-          Gh_pr_edit { pr_number = extract_number_from_rest rest; title }
-        | "pr", Some "review" ->
-          Gh_pr_review { pr_number = extract_number_from_rest rest }
-        | "pr", Some "reopen" ->
-          Gh_pr_close { pr_number = extract_number_from_rest rest } (* reopen uses same structure *)
-        | "pr", Some "ready" ->
-          Gh_pr_review { pr_number = extract_number_from_rest rest }
-        (* Issue operations *)
-        | "issue", Some "create" ->
-          Gh_issue_create { title = Option.value title ~default:""; body = Option.value body ~default:"" }
-        | "issue", Some "close" ->
-          Gh_issue_close { issue_number = extract_number_from_rest rest }
-        | "issue", Some "reopen" ->
-          Gh_issue_close { issue_number = extract_number_from_rest rest }
-        (* Unknown gh subcommand *)
-        | _ -> Generic)
-     | Masc_exec.Shell_ir_typed_types.W (Masc_exec.Shell_ir_typed_types.Git_push { force; force_with_lease; set_upstream = _; remote; branch }) ->
-       Git_push {
-         remote = Option.value remote ~default:"origin";
-         branch = Option.value branch ~default:"main";
-         force = force || force_with_lease
-       }
-     | Masc_exec.Shell_ir_typed_types.W (Masc_exec.Shell_ir_typed_types.Git_commit { message; amend }) ->
-       Git_commit { message = if amend then message ^ " (amend)" else message }
-     | Masc_exec.Shell_ir_typed_types.W (Masc_exec.Shell_ir_typed_types.Git_merge { squash; branch; _ }) ->
-       Gh_pr_merge { pr_number = 0; squash } (* git merge is analogous to pr merge *)
-     | Masc_exec.Shell_ir_typed_types.W (Masc_exec.Shell_ir_typed_types.Curl { url; method_; body; _ }) ->
-       (* Detect GitHub API PR operations via curl *)
-       let is_github_api = String.length url > 23 && String.sub url 0 23 = "https://api.github.com/" in
-       if is_github_api then
-         let parts = String.split_on_char '/' url in
-         (* URL pattern: https://api.github.com/repos/{owner}/{repo}/pulls/{number} *)
-         let find_repo parts =
-           let rec scan = function
-             | "repos" :: owner :: repo :: _ -> Some (owner ^ "/" ^ repo)
-             | _ :: rest -> scan rest
-             | [] -> None
-           in
-           scan parts
-         in
-         let find_pr_number parts =
-           let rec scan = function
-             | "pulls" :: n :: _ -> (match int_of_string_opt n with Some i -> i | None -> 0)
-             | "pull" :: n :: _ -> (match int_of_string_opt n with Some i -> i | None -> 0)
-             | _ :: rest -> scan rest
-             | [] -> 0
-           in
-           scan parts
-         in
-         let extract_title body_str =
-           try
-             let json = Yojson.Safe.from_string body_str in
-             Yojson.Safe.Util.member "title" json |> Yojson.Safe.Util.to_string
-           with _ -> ""
-         in
-         let extract_base body_str =
-           try
-             let json = Yojson.Safe.from_string body_str in
-             Yojson.Safe.Util.member "base" json |> Yojson.Safe.Util.to_string
-           with _ -> "main"
-         in
-         match find_repo parts with
-         | Some repo ->
-           (match method_ with
-            | `POST ->
-              (* POST /repos/{owner}/{repo}/pulls = create PR *)
-              let title = match body with Some b -> extract_title b | None -> "" in
-              let base = match body with Some b -> extract_base b | None -> "main" in
-              Gh_api_pr_create { repo; title; base }
-            | `PUT ->
-              (* PUT /repos/{owner}/{repo}/pulls/{number}/merge = merge PR *)
-              let pr_number = find_pr_number parts in
-              Gh_api_pr_merge { repo; pr_number }
-            | `DELETE ->
-              (* DELETE /repos/{owner}/{repo}/pulls/{number} = close PR *)
-              let pr_number = find_pr_number parts in
-              Gh_api_pr_comment { repo; pr_number; body = "" }
-            | _ -> Generic)
-         | None -> Generic
-       else Generic
-     | _ -> Generic)
-  | _ -> Generic
+    compute_command_descriptor_simple simple
+  | Masc_exec.Shell_ir.Pipeline cmds ->
+    let len = List.length cmds in
+    let first = first_cmd_name_of_ir ir in
+    let last = cmd_name_of_ir ir in
+    (* Try to classify the last command as a known type *)
+    (match List.rev cmds with
+     | last_cmd :: _ ->
+       let last_descriptor = compute_command_descriptor last_cmd in
+       (match last_descriptor with
+        | Ide_event_types.Generic ->
+          (* Last command is generic, wrap in Pipe_chain *)
+          Ide_event_types.Pipe_chain { first_cmd = first; last_cmd = last; length = len }
+        | known ->
+          (* Last command is a known type (gh, git, curl etc.), use it directly *)
+          known)
+     | [] -> Ide_event_types.Generic)
 
 let elapsed_duration_ms ~start_time ~end_time =
   let elapsed_ms = (end_time -. start_time) *. 1000. in

--- a/test/test_command_descriptor.ml
+++ b/test/test_command_descriptor.ml
@@ -162,9 +162,97 @@ let test_generic_unknown () =
 let test_generic_pipeline () =
   let ir = parse_ir "cat file.txt | grep pattern" in
   match Desc.compute_command_descriptor ir with
-  | Ide_event_types.Generic -> ()
-  | other -> failf "expected Generic for pipeline, got %s" (Yojson.Safe.to_string (Ide_event_types.command_descriptor_to_json other))
+  | Ide_event_types.Pipe_chain { first_cmd; last_cmd; length } ->
+    check string "first_cmd" "cat" first_cmd;
+    check string "last_cmd" "grep" last_cmd;
+    check int "length" 2 length
+  | other -> failf "expected Pipe_chain, got %s" (Yojson.Safe.to_string (Ide_event_types.command_descriptor_to_json other))
 ;;
+
+(** {1 Pipe chain classification} *)
+
+let test_pipe_chain_rg_grep_head () =
+  let ir = parse_ir "rg foo | grep bar | head" in
+  match Desc.compute_command_descriptor ir with
+  | Ide_event_types.Pipe_chain { first_cmd; last_cmd; length } ->
+    check string "first_cmd" "rg" first_cmd;
+    check string "last_cmd" "head" last_cmd;
+    check int "length" 3 length
+  | other -> failf "expected Pipe_chain, got %s" (Yojson.Safe.to_string (Ide_event_types.command_descriptor_to_json other))
+;;
+
+let test_pipe_chain_gh_in_last () =
+  (* When the last command is gh, the pipeline should resolve to the gh descriptor *)
+  let ir = parse_ir "cat file.txt | gh pr create --title test" in
+  match Desc.compute_command_descriptor ir with
+  | Ide_event_types.Gh_pr_create { title; _ } ->
+    check string "title" "test" title
+  | other -> failf "expected Gh_pr_create, got %s" (Yojson.Safe.to_string (Ide_event_types.command_descriptor_to_json other))
+;;
+
+let test_pipe_chain_git_push () =
+  (* When the last command is git push, use that directly *)
+  let ir = parse_ir "echo pushing | git push origin main" in
+  match Desc.compute_command_descriptor ir with
+  | Ide_event_types.Git_push { remote; branch; _ } ->
+    check string "remote" "origin" remote;
+    check string "branch" "main" branch
+  | other -> failf "expected Git_push, got %s" (Yojson.Safe.to_string (Ide_event_types.command_descriptor_to_json other))
+;;
+
+(** {1 Exit code semantics} *)
+
+let test_exit_code_grep_no_match () =
+  match Ide_event_types.interpret_exit_code ~cmd_name:"grep" ~exit_code:1 with
+  | Ide_event_types.No_matches -> ()
+  | other -> failf "expected No_matches, got different"
+
+let test_exit_code_grep_error () =
+  match Ide_event_types.interpret_exit_code ~cmd_name:"grep" ~exit_code:2 with
+  | Ide_event_types.Error _ -> ()
+  | _ -> failf "expected Error"
+
+let test_exit_code_diff_files_differ () =
+  match Ide_event_types.interpret_exit_code ~cmd_name:"diff" ~exit_code:1 with
+  | Ide_event_types.Files_differ -> ()
+  | _ -> failf "expected Files_differ"
+
+let test_exit_code_general_success () =
+  match Ide_event_types.interpret_exit_code ~cmd_name:"ls" ~exit_code:0 with
+  | Ide_event_types.Success -> ()
+  | _ -> failf "expected Success"
+
+let test_exit_code_general_error () =
+  match Ide_event_types.interpret_exit_code ~cmd_name:"ls" ~exit_code:1 with
+  | Ide_event_types.Error _ -> ()
+  | _ -> failf "expected Error"
+
+(** {1 Command category classification} *)
+
+let test_category_search () =
+  match Ide_event_types.classify_cmd_category ~cmd_name:"rg" with
+  | Ide_event_types.Search_cmd -> ()
+  | _ -> failf "expected Search_cmd"
+
+let test_category_read () =
+  match Ide_event_types.classify_cmd_category ~cmd_name:"cat" with
+  | Ide_event_types.Read_cmd -> ()
+  | _ -> failf "expected Read_cmd"
+
+let test_category_list () =
+  match Ide_event_types.classify_cmd_category ~cmd_name:"ls" with
+  | Ide_event_types.List_cmd -> ()
+  | _ -> failf "expected List_cmd"
+
+let test_category_silent () =
+  match Ide_event_types.classify_cmd_category ~cmd_name:"mv" with
+  | Ide_event_types.Silent_cmd -> ()
+  | _ -> failf "expected Silent_cmd"
+
+let test_category_write () =
+  match Ide_event_types.classify_cmd_category ~cmd_name:"dune" with
+  | Ide_event_types.Write_cmd -> ()
+  | _ -> failf "expected Write_cmd"
 
 (** {1 Bridge integration} *)
 
@@ -248,6 +336,25 @@ let () =
     ; ( "generic"
       , [ test_case "unknown command" `Quick test_generic_unknown
         ; test_case "pipeline" `Quick test_generic_pipeline
+        ] )
+    ; ( "pipe_chain"
+      , [ test_case "rg|grep|head" `Quick test_pipe_chain_rg_grep_head
+        ; test_case "gh in last position" `Quick test_pipe_chain_gh_in_last
+        ; test_case "git push in last" `Quick test_pipe_chain_git_push
+        ] )
+    ; ( "exit_code_semantics"
+      , [ test_case "grep no match" `Quick test_exit_code_grep_no_match
+        ; test_case "grep error" `Quick test_exit_code_grep_error
+        ; test_case "diff files differ" `Quick test_exit_code_diff_files_differ
+        ; test_case "general success" `Quick test_exit_code_general_success
+        ; test_case "general error" `Quick test_exit_code_general_error
+        ] )
+    ; ( "cmd_category"
+      , [ test_case "search" `Quick test_category_search
+        ; test_case "read" `Quick test_category_read
+        ; test_case "list" `Quick test_category_list
+        ; test_case "silent" `Quick test_category_silent
+        ; test_case "write" `Quick test_category_write
         ] )
     ; ( "bridge_integration"
       , [ test_case "extract descriptor" `Quick test_extract_descriptor_gh_pr_create


### PR DESCRIPTION
## Changes

### 1. Pipe chain classification
- `Pipeline`에서 마지막 명령 기준 descriptor 추출
- 마지막 명령이 known type(gh, git, curl)이면 직접 사용
- Generic이면 `Pipe_chain { first_cmd; last_cmd; length }`로 감싸기
- `rg foo | grep bar | head` → `Pipe_chain { first_cmd="rg"; last_cmd="head"; length=3 }`

### 2. Exit code semantics
- `interpret_exit_code`: cmd_name + exit_code → exit_semantics
- grep/rg/ag: 1=no_matches (에러 아님)
- diff: 1=files_differ
- test/[: 1=condition_false
- find: 1=partial_success (success로 처리)

### 3. Command category classification
- `classify_cmd_category`: cmd_name → cmd_category
- Search/Read/List/Silent/Neutral/Write 6분류
- Claude Code의 BASH_SEARCH/READ/LIST/SILENT_COMMANDS 세트에서 영감

### 4. Tests (13개 추가)
- pipe_chain: rg|grep|head, gh in last position, git push in last
- exit_code_semantics: grep no match, grep error, diff files differ, general success/error
- cmd_category: search, read, list, silent, write

## Related
- PR #19944 (error handling fix)
- Claude Code Bash tool 분석 결과 적용

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>