### PR TITLE
feat(telemetry): close observability pipeline gaps

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -624,6 +624,7 @@ export interface DashboardRuntimeModelMetric {
   total_input_tokens?: number | null
   total_output_tokens?: number | null
   total_cache_read_tokens?: number | null
+  total_cache_creation_tokens?: number | null
   total_reasoning_tokens?: number | null
   usage_sample_count?: number | null
   telemetry_sample_count?: number | null
@@ -762,6 +763,7 @@ function decodeRuntimeModelMetric(raw: unknown): DashboardRuntimeModelMetric | n
     total_input_tokens: asNumber(raw.total_input_tokens) ?? null,
     total_output_tokens: asNumber(raw.total_output_tokens) ?? null,
     total_cache_read_tokens: asNumber(raw.total_cache_read_tokens) ?? null,
+    total_cache_creation_tokens: asNumber(raw.total_cache_creation_tokens) ?? null,
     total_reasoning_tokens: asNumber(raw.total_reasoning_tokens) ?? null,
     usage_sample_count: asNumber(raw.usage_sample_count) ?? null,
     telemetry_sample_count: asNumber(raw.telemetry_sample_count) ?? null,

--- a/dashboard/src/components/cost-dashboard.ts
+++ b/dashboard/src/components/cost-dashboard.ts
@@ -295,25 +295,42 @@ const modelTotals = computed(() => {
   let totalOut = 0
   let totalCache = 0
   let totalReasoning = 0
+  let totalSuccess = 0
+  let totalError = 0
   let p50Sum = 0
   let p50Count = 0
   let p95Max = 0
+  let ttfrcSum = 0
+  let ttfrcCount = 0
   for (const m of data) {
     totalCost += m.total_cost_usd ?? 0
     totalIn += m.total_input_tokens ?? 0
     totalOut += m.total_output_tokens ?? 0
     totalCache += m.total_cache_read_tokens ?? 0
     totalReasoning += m.total_reasoning_tokens ?? 0
+    totalSuccess += m.success_count ?? 0
+    totalError += m.error_count ?? 0
     if (m.p50_latency_ms != null) {
       p50Sum += m.p50_latency_ms
       p50Count += 1
     }
     if (m.p95_latency_ms != null && m.p95_latency_ms > p95Max) p95Max = m.p95_latency_ms
+    // Aggregate TTFRC from recent entries
+    if (m.recent_entries) {
+      for (const e of m.recent_entries) {
+        if (e.streaming_ttfrc_ms != null) {
+          ttfrcSum += e.streaming_ttfrc_ms
+          ttfrcCount += 1
+        }
+      }
+    }
   }
   const p50Avg = p50Count > 0 ? Math.round(p50Sum / p50Count) : 0
   const cacheRatio = totalIn > 0 ? totalCache / totalIn : null
   const reasoningRatio = totalOut > 0 ? totalReasoning / totalOut : null
-  return { totalCost, totalIn, totalOut, totalCache, totalReasoning, cacheRatio, reasoningRatio, p50Avg, p95Max, count: data.length }
+  const errorRate = (totalSuccess + totalError) > 0 ? totalError / (totalSuccess + totalError) : null
+  const avgTtfrc = ttfrcCount > 0 ? Math.round(ttfrcSum / ttfrcCount) : null
+  return { totalCost, totalIn, totalOut, totalCache, totalReasoning, totalSuccess, totalError, cacheRatio, reasoningRatio, errorRate, avgTtfrc, p50Avg, p95Max, count: data.length }
 })
 
 const keeperTotals = computed(() => {
@@ -337,7 +354,7 @@ const keeperTotals = computed(() => {
     if (k.p95_latency_ms != null && k.p95_latency_ms > p95Max) p95Max = k.p95_latency_ms
   }
   const p50Avg = p50Count > 0 ? Math.round(p50Sum / p50Count) : 0
-  return { totalCost, totalIn, totalOut, p50Avg, p95Max, count: data.length }
+  return { totalCost, totalIn, totalOut, p50Avg, p95Max, count: data.length, totalSuccess: 0, totalError: 0, errorRate: null, avgTtfrc: null, totalCache: 0, totalReasoning: 0, cacheRatio: null, reasoningRatio: null }
 })
 
 function ThRight({ children }: { children: unknown }) {
@@ -392,6 +409,18 @@ function ModelRow({
   const cacheRatio = inTok > 0 && cacheRead != null ? cacheRead / inTok : null
   const reasoningRatio = outTok > 0 && reasoning != null ? reasoning / outTok : null
 
+  // Error rate
+  const errCount = model.error_count ?? 0
+  const succCount = model.success_count ?? 0
+  const totalTurns = errCount + succCount
+  const errRate = totalTurns > 0 ? errCount / totalTurns : null
+
+  // Average TTFRC from recent entries
+  const ttfrcEntries = model.recent_entries?.filter(e => e.streaming_ttfrc_ms != null) ?? []
+  const avgTtfrc = ttfrcEntries.length > 0
+    ? Math.round(ttfrcEntries.reduce((sum, e) => sum + (e.streaming_ttfrc_ms ?? 0), 0) / ttfrcEntries.length)
+    : null
+
   // Derive latest usage_trust from recent_entries
   const latestTrust = model.recent_entries?.length
     ? (model.recent_entries[model.recent_entries.length - 1]?.usage_trust ?? null)
@@ -435,6 +464,12 @@ function ModelRow({
             style=${`width: ${p95Pct.toFixed(1)}%`}
           ></div>
         </div>
+      </td>
+      <td class="px-2 py-1.5 text-right font-mono text-xs">
+        ${avgTtfrc != null ? html`<span class="text-text-muted">${avgTtfrc}ms</span>` : html`<span class="text-text-disabled">—</span>`}
+      </td>
+      <td class="px-2 py-1.5 text-right font-mono text-xs ${errRate != null && errRate > 0.1 ? 'text-[var(--color-status-err)]' : errRate != null && errRate > 0 ? 'text-[var(--color-status-warn)]' : ''}">
+        ${errRate != null ? formatPct1(errRate) : html`<span class="text-text-disabled">—</span>`}
       </td>
       <td class="px-2 py-1.5 text-center">
         ${coverage != null
@@ -1318,6 +1353,22 @@ function CostDashboardContent({ view }: { view: CostView }) {
               delta=${{ direction: t.p95Max > 8000 ? 'down' : 'flat', text: t.p95Max > 8000 ? 'over 8s budget' : 'within budget' }}
             />
           </div>
+          ${mode === 'model' ? html`
+            <div class="grid grid-cols-2 gap-2 md:grid-cols-4">
+              <${StatTile}
+                label="Error Rate"
+                value=${t.errorRate != null ? formatPct1(t.errorRate) : '—'}
+                status=${t.errorRate != null ? (t.errorRate > 0.1 ? 'crit' : t.errorRate > 0 ? 'warn' : 'ok') : undefined}
+                delta=${{ direction: 'flat', text: `${t.totalError} errors / ${t.totalSuccess} success` }}
+              />
+              <${StatTile}
+                label="Avg TTFRC"
+                value=${t.avgTtfrc != null ? `${t.avgTtfrc}ms` : '—'}
+                status=${t.avgTtfrc != null && t.avgTtfrc > 3000 ? 'warn' : undefined}
+                delta=${{ direction: 'flat', text: 'streaming first chunk' }}
+              />
+            </div>
+          ` : null}
         ` : null}
 
         ${showMatrix ? html`<${CostMatrix} models=${activeState.data as DashboardRuntimeModelMetric[]} />` : null}
@@ -1358,6 +1409,8 @@ function CostDashboardContent({ view }: { view: CostView }) {
                   <${ThRight}>p95</${ThRight}>
                   <th scope="col" class="px-2 py-1.5 text-left">p95 trend</th>
                   ${mode === 'model' ? html`
+                    <${ThRight}>ttfrc</${ThRight}>
+                    <${ThRight}>err%</${ThRight}>
                     <${ThRight}>coverage</${ThRight}>
                     <${ThRight}>trust</${ThRight}>
                   ` : null}

--- a/dashboard/src/components/cost-dashboard.ts
+++ b/dashboard/src/components/cost-dashboard.ts
@@ -294,6 +294,7 @@ const modelTotals = computed(() => {
   let totalIn = 0
   let totalOut = 0
   let totalCache = 0
+  let totalCacheCreation = 0
   let totalReasoning = 0
   let totalSuccess = 0
   let totalError = 0
@@ -307,6 +308,7 @@ const modelTotals = computed(() => {
     totalIn += m.total_input_tokens ?? 0
     totalOut += m.total_output_tokens ?? 0
     totalCache += m.total_cache_read_tokens ?? 0
+    totalCacheCreation += m.total_cache_creation_tokens ?? 0
     totalReasoning += m.total_reasoning_tokens ?? 0
     totalSuccess += m.success_count ?? 0
     totalError += m.error_count ?? 0
@@ -330,7 +332,7 @@ const modelTotals = computed(() => {
   const reasoningRatio = totalOut > 0 ? totalReasoning / totalOut : null
   const errorRate = (totalSuccess + totalError) > 0 ? totalError / (totalSuccess + totalError) : null
   const avgTtfrc = ttfrcCount > 0 ? Math.round(ttfrcSum / ttfrcCount) : null
-  return { totalCost, totalIn, totalOut, totalCache, totalReasoning, totalSuccess, totalError, cacheRatio, reasoningRatio, errorRate, avgTtfrc, p50Avg, p95Max, count: data.length }
+  return { totalCost, totalIn, totalOut, totalCache, totalCacheCreation, totalReasoning, totalSuccess, totalError, cacheRatio, reasoningRatio, errorRate, avgTtfrc, p50Avg, p95Max, count: data.length }
 })
 
 const keeperTotals = computed(() => {
@@ -354,7 +356,7 @@ const keeperTotals = computed(() => {
     if (k.p95_latency_ms != null && k.p95_latency_ms > p95Max) p95Max = k.p95_latency_ms
   }
   const p50Avg = p50Count > 0 ? Math.round(p50Sum / p50Count) : 0
-  return { totalCost, totalIn, totalOut, p50Avg, p95Max, count: data.length, totalSuccess: 0, totalError: 0, errorRate: null, avgTtfrc: null, totalCache: 0, totalReasoning: 0, cacheRatio: null, reasoningRatio: null }
+  return { totalCost, totalIn, totalOut, p50Avg, p95Max, count: data.length, totalSuccess: 0, totalError: 0, errorRate: null, avgTtfrc: null, totalCache: 0, totalCacheCreation: 0, totalReasoning: 0, cacheRatio: null, reasoningRatio: null }
 })
 
 function ThRight({ children }: { children: unknown }) {
@@ -397,6 +399,7 @@ function ModelRow({
   const inTok = model.total_input_tokens ?? 0
   const outTok = model.total_output_tokens ?? 0
   const cacheRead = model.total_cache_read_tokens ?? null
+  const cacheCreation = model.total_cache_creation_tokens ?? null
   const reasoning = model.total_reasoning_tokens ?? null
   const thinkingFrac = model.thinking_fraction ?? null
   const coverage = model.coverage_status ?? null
@@ -436,6 +439,9 @@ function ModelRow({
       <td class="px-2 py-1.5 text-right font-mono text-xs">${formatCostTokens(outTok)}</td>
       <td class="px-2 py-1.5 text-right font-mono text-xs ${cacheRatioColor(cacheRatio)}">
         ${cacheRatio != null ? formatPct1(cacheRatio) : html`<span class="text-text-disabled">—</span>`}
+      </td>
+      <td class="px-2 py-1.5 text-right font-mono text-xs">
+        ${cacheCreation != null ? formatTokens(cacheCreation) : html`<span class="text-text-disabled">—</span>`}
       </td>
       <td class="px-2 py-1.5 text-right font-mono text-xs ${reasoningRatioColor(reasoningRatio)}">
         ${reasoning != null ? html`${formatTokens(reasoning)}${reasoningRatio != null ? html` <span class="text-text-muted">(${formatPct1(reasoningRatio)})</span>` : ''}` : html`<span class="text-text-disabled">—</span>`}
@@ -1400,6 +1406,7 @@ function CostDashboardContent({ view }: { view: CostView }) {
                   <${ThRight}>out tok</${ThRight}>
                   ${mode === 'model' ? html`
                     <${ThRight}>cache%</${ThRight}>
+                    <${ThRight}>creation</${ThRight}>
                     <${ThRight}>reason</${ThRight}>
                     <${ThRight}>think%</${ThRight}>
                   ` : null}

--- a/lib/llm_metric_bridge.ml
+++ b/lib/llm_metric_bridge.ml
@@ -221,6 +221,51 @@ let error_reason_label = function
   | Reason_provider_error -> "provider_error"
   | Reason_unmapped _ | Reason_absent -> "unknown"
 
+(* ── JSONL persistence for inference error/retry events ──────── *)
+
+(** Lazy-initialised Dated_jsonl store for inference events.
+    Created on first call to [init ~base_path]; events emitted
+    before [init] are silently dropped (Prometheus-only), matching
+    the pre-JSONL baseline. *)
+let inference_store_ref : (string * Dated_jsonl.t) option ref = ref None
+
+(** Initialise the inference-events JSONL store rooted at
+    [base_path/data/inference-events/].  Idempotent for the same
+    base_path; a different base_path replaces the previous store
+    (mirrors [Tool_metrics_persist.get_or_create_store]). *)
+let init ~base_path =
+  match !inference_store_ref with
+  | Some (cached, _) when String.equal cached base_path -> ()
+  | _ ->
+    let dir =
+      Filename.concat
+        (Config_dir_resolver.data_dir ~base_path)
+        "inference-events"
+    in
+    Fs_compat.mkdir_p dir;
+    let store = Dated_jsonl.create ~base_dir:dir ~retention_days:30 () in
+    inference_store_ref := Some (base_path, store)
+
+(** Best-effort append of an inference event to JSONL.  Catches all
+    exceptions (including Cancel, which we re-raise) so that a JSONL
+    write failure never blocks the Prometheus hot path. *)
+let append_inference_event (json : Yojson.Safe.t) =
+  match !inference_store_ref with
+  | None -> ()  (* pre-init: Prometheus-only, as before *)
+  | Some (_, store) ->
+    try Dated_jsonl.append store json
+    with Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
+      Log.Metrics.warn "llm_metric_bridge: inference event JSONL write failed: %s"
+        (Printexc.to_string exn)
+
+(** Look up the cached provider for a model_id, returning the
+    [unknown_provider_label] sentinel when absent. *)
+let provider_for_model model_id =
+  Stdlib.Mutex.protect provider_cache_mutex (fun () ->
+    Option.value ~default:unknown_provider_label
+      (Hashtbl.find_opt provider_by_model model_id))
+
 let emit_error ~model_id ~error =
   Prometheus.inc_counter error_metric
     ~labels:[("model", model_id)]
@@ -229,7 +274,20 @@ let emit_error ~model_id ~error =
   Prometheus.inc_counter error_by_reason_metric
     ~labels:
       [ ("model", model_id); ("error_reason", error_reason_label reason) ]
-    ()
+    ();
+  (* JSONL persistence *)
+  let json =
+    `Assoc
+      [
+        ("ts", `String (Masc_domain.now_iso ()));
+        ("event_type", `String "llm_error");
+        ("model_id", `String model_id);
+        ("provider", `String (provider_for_model model_id));
+        ("error_reason", `String (error_reason_label reason));
+        ("error_message", `String error);
+      ]
+  in
+  append_inference_event json
 
 let emit_retry ~provider ~model_id ~attempt =
   remember_provider ~model_id ~provider;
@@ -240,7 +298,19 @@ let emit_retry ~provider ~model_id ~attempt =
         ("model", model_id);
         ("attempt", string_of_int attempt);
       ]
-    ()
+    ();
+  (* JSONL persistence *)
+  let json =
+    `Assoc
+      [
+        ("ts", `String (Masc_domain.now_iso ()));
+        ("event_type", `String "llm_retry");
+        ("model_id", `String model_id);
+        ("provider", `String provider);
+        ("attempt", `Int attempt);
+      ]
+  in
+  append_inference_event json
 
 let emit_token_usage ~provider ~model_id ~input_tokens ~output_tokens =
   remember_provider ~model_id ~provider;

--- a/lib/llm_metric_bridge.mli
+++ b/lib/llm_metric_bridge.mli
@@ -92,6 +92,12 @@ val emit_fallback_triggered : kind:string -> detail:string -> unit
     touching global state. *)
 val make_sink : unit -> Llm_provider.Metrics.t
 
+(** Initialise the inference-events JSONL store under
+    [base_path/data/inference-events/].  Must be called before
+    any LLM call for events to be persisted; events emitted
+    before [init] go to Prometheus only (no crash). *)
+val init : base_path:string -> unit
+
 (** Install the bridge as the process-wide default metrics sink.
     Idempotent; should be called once during server bootstrap
     before any keeper turn fires its first LLM call. *)

--- a/lib/model_inference_metrics_aggregate.ml
+++ b/lib/model_inference_metrics_aggregate.ml
@@ -133,6 +133,8 @@ let aggregate_by_model (entries : raw_entry list) : model_stats list =
              sum_int_opt (List.filter_map (fun e -> e.output_tokens) success_entries)
          ; total_cache_read_tokens =
              sum_int_opt (List.filter_map (fun e -> e.cache_read_tokens) success_entries)
+         ; total_cache_creation_tokens =
+             sum_int_opt (List.filter_map (fun e -> e.cache_creation_tokens) success_entries)
          ; total_reasoning_tokens =
              sum_int_opt (List.filter_map (fun e -> e.reasoning_tokens) success_entries)
          ; usage_sample_count

--- a/lib/model_inference_metrics_entry.ml
+++ b/lib/model_inference_metrics_entry.ml
@@ -95,6 +95,7 @@ type model_stats =
   ; total_input_tokens : int option
   ; total_output_tokens : int option
   ; total_cache_read_tokens : int option
+  ; total_cache_creation_tokens : int option
   ; total_reasoning_tokens : int option
   ; usage_sample_count : int
   ; telemetry_sample_count : int
@@ -167,6 +168,7 @@ type raw_entry =
   ; input_tokens : int option
   ; output_tokens : int option
   ; cache_read_tokens : int option
+  ; cache_creation_tokens : int option
   ; reasoning_tokens : int option
   ; fallback_applied : bool
   ; cost_usd : float option

--- a/lib/model_inference_metrics_json.ml
+++ b/lib/model_inference_metrics_json.ml
@@ -63,6 +63,7 @@ let model_stats_to_json ?(model_label = public_runtime_label) (s : model_stats)
     ; "total_input_tokens", Json_util.int_opt_to_json s.total_input_tokens
     ; "total_output_tokens", Json_util.int_opt_to_json s.total_output_tokens
     ; "total_cache_read_tokens", Json_util.int_opt_to_json s.total_cache_read_tokens
+    ; "total_cache_creation_tokens", Json_util.int_opt_to_json s.total_cache_creation_tokens
     ; "total_reasoning_tokens", Json_util.int_opt_to_json s.total_reasoning_tokens
     ; "usage_sample_count", `Int s.usage_sample_count
     ; "telemetry_sample_count", `Int s.telemetry_sample_count

--- a/lib/model_inference_metrics_parser.ml
+++ b/lib/model_inference_metrics_parser.ml
@@ -147,6 +147,7 @@ let parse_telemetry_entry (json : Yojson.Safe.t) ~since_unix
              ; input_tokens = None
              ; output_tokens = None
              ; cache_read_tokens = None
+             ; cache_creation_tokens = None
              ; reasoning_tokens = None
              ; fallback_applied = false
              ; cost_usd = None
@@ -229,6 +230,11 @@ let parse_telemetry_entry (json : Yojson.Safe.t) ~since_unix
            let input_tokens_raw = json_int_field_opt "input_tokens" tfields in
            let output_tokens_raw = json_int_field_opt "output_tokens" tfields in
            let cache_read_tokens_raw = json_int_field_opt "cache_read_tokens" tfields in
+           let cache_creation_tokens_raw =
+             match json_int_field_opt "cache_creation_tokens" tfields with
+             | Some _ as v -> v
+             | None -> json_int_field_opt "cache_creation_input_tokens" tfields
+           in
            let reasoning_tokens_raw = json_int_field_opt "reasoning_tokens" tfields in
            let fallback_applied =
              match List.assoc_opt "fallback_applied" tfields with
@@ -272,6 +278,9 @@ let parse_telemetry_entry (json : Yojson.Safe.t) ~since_unix
            let cache_read_tokens =
              if usage_untrusted then None else cache_read_tokens_raw
            in
+           let cache_creation_tokens =
+             if usage_untrusted then None else cache_creation_tokens_raw
+           in
            let reasoning_tokens =
              if usage_untrusted then None else reasoning_tokens_raw
            in
@@ -311,6 +320,7 @@ let parse_telemetry_entry (json : Yojson.Safe.t) ~since_unix
              ; input_tokens
              ; output_tokens
              ; cache_read_tokens
+             ; cache_creation_tokens
              ; reasoning_tokens
              ; fallback_applied
              ; cost_usd
@@ -461,6 +471,14 @@ let parse_cost_entry (json : Yojson.Safe.t) ~since_unix
        let input_tokens = if usage_untrusted then None else input_tokens_raw in
        let output_tokens = if usage_untrusted then None else output_tokens_raw in
        let cache_read_tokens = if usage_untrusted then None else cache_read_tokens_raw in
+       let cache_creation_tokens_raw =
+         match json_int_field_opt "cache_creation_tokens" fields with
+         | Some _ as v -> v
+         | None -> json_int_field_opt "cache_creation_input_tokens" fields
+       in
+       let cache_creation_tokens =
+         if usage_untrusted then None else cache_creation_tokens_raw
+       in
        let prompt_tok_per_sec =
          match List.assoc_opt "prompt_per_second" fields with
          | Some (`Float f) when f > 0.0 -> Some f
@@ -496,6 +514,7 @@ let parse_cost_entry (json : Yojson.Safe.t) ~since_unix
          ; input_tokens
          ; output_tokens
          ; cache_read_tokens
+         ; cache_creation_tokens
          ; reasoning_tokens =
              (if usage_untrusted
               then None

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -409,7 +409,8 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
          call (e.g. a warmup probe, early keeper fiber) to capture
          the default noop sink instead of the Prometheus-backed one. *)
       Llm_metric_bridge.install ();
-      Log.Server.info "Llm_metric_bridge installed (masc_llm_provider_http_status_total)";
+      Llm_metric_bridge.init ~base_path;
+      Log.Server.info "Llm_metric_bridge installed (masc_llm_provider_http_status_total, inference-events JSONL)";
       (* #13885: install backend mutex observers from the top-level
          masc layer.  Backend/workspace sub-libraries cannot depend on
          Prometheus without creating dependency cycles, but the global


### PR DESCRIPTION
## Summary

텔레메트리/로깅 파이프라인에서 기존에 놓쳤던 갭을 발견하고 수정.

### Bridge Layer
- **Error/Retry JSONL**: 개별 LLM 오류/재시도 이벤트를 `data/inference-events/YYYY-MM/DD.jsonl`에 기록 (기존엔 Prometheus counter만)
  - `llm_error`: ts, model_id, provider, error_reason, error_message
  - `llm_retry`: ts, model_id, provider, attempt
  - Dated_jsonl (30일 보존, lazy init, best-effort append)
  - `Eio.Cancel.Cancelled` 재발행; 쓰기 실패가 Prometheus hot path를 차단하지 않음

### Storage Layer
- **cache_creation_tokens 전체 파이프라인**: JSONL 기록은 되어 있었으나 read-back 파이프라인이 없었음
  - `raw_entry` → parser (fallback to `cache_creation_input_tokens`) → aggregate → JSON serializer → TS decoder

### Dashboard
- **cache_creation_tokens** 컬럼 추가 (cache% 옆)
- **TTFRC** (time-to-first-response-chunk) 컬럼 + 상단 StatTile (agent 구현)
- **Error Rate** 컬럼 + 상단 StatTile (agent 구현)
- Keeper cost breakdown — 이미 구현되어 있어 변경 없음

## Gap Analysis Results

| 항목 | 이전 | 이후 |
|------|:----:|:----:|
| LLM error events | Prometheus only | Prometheus + JSONL |
| LLM retry events | Prometheus only | Prometheus + JSONL |
| cache_creation_tokens | JSONL write만 | Full read-back pipeline |
| TTFRC display | JSONL만 | Dashboard 컬럼 |
| Error rate display | Prometheus만 | Dashboard 컬럼 |
| reasoning_tokens | ✅ 이미 완전 연결 | 변경 없음 |
| streaming metrics | ✅ 이미 JSONL에 있음 | 변경 없음 |
| keeper cost breakdown | ✅ 이미 구현됨 | 변경 없음 |

## Files Changed (9 files, +115/-5)

- `lib/llm_metric_bridge.ml` — JSONL persistence for error/retry
- `lib/llm_metric_bridge.mli` — init 노출
- `lib/server/server_runtime_bootstrap.ml` — init 배선
- `lib/model_inference_metrics_entry.ml` — cache_creation_tokens 필드
- `lib/model_inference_metrics_parser.ml` — cache_creation 파싱 (fallback 포함)
- `lib/model_inference_metrics_aggregate.ml` — cache_creation 집계
- `lib/model_inference_metrics_json.ml` — cache_creation JSON 출력
- `dashboard/src/api/dashboard.ts` — TS 타입 + 디코더
- `dashboard/src/components/cost-dashboard.ts` — UI 컬럼 + StatTiles

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>