### PR TITLE
feat(keeper): add persona field to keeper_meta

### DIFF
--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -571,6 +571,7 @@ type keeper_meta =
     id : Ids.Keeper_id.t option [@default None]
   ; name : string
   ; agent_name : string
+  ; persona : string option
   ; goal : string
   ; short_goal : string
   ; mid_goal : string

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -324,6 +324,7 @@ type keeper_meta = {
   id : Ids.Keeper_id.t option;
   name : string;
   agent_name : string;
+  persona : string option;
   goal : string;
   short_goal : string;
   mid_goal : string;

--- a/lib/keeper/keeper_meta_json.ml
+++ b/lib/keeper/keeper_meta_json.ml
@@ -15,6 +15,10 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
   `Assoc
     [ "name", `String m.name
     ; "agent_name", `String m.agent_name
+    ; ( "persona"
+      , match m.persona with
+        | Some s -> `String s
+        | None -> `Null )
     ; "trace_id", `String (Keeper_id.Trace_id.to_string rt.trace_id)
     ; "tool_access", tool_access_to_json m.tool_access
     ; "trace_history", `List (List.map (fun s -> `String s) rt.trace_history)
@@ -101,6 +105,7 @@ include Keeper_meta_json_parse
 let fallback_canonical_keeper_meta_key_names =
   [ "name"
   ; "agent_name"
+  ; "persona"
   ; "trace_id"
   ; "tool_access"
   ; "trace_history"

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -11,6 +11,7 @@ open Keeper_meta_json_scrub
 type parsed_keeper_identity =
   { pk_name : string
   ; pk_agent_name : string
+  ; pk_persona : string option
   ; pk_trace_id : Keeper_id.Trace_id.t
   ; pk_trace_history : string list
   ; pk_goal : string
@@ -69,6 +70,7 @@ let parse_keeper_identity (json : Yojson.Safe.t) : (parsed_keeper_identity, stri
   with
   | Error e -> Error ("keeper meta parse error: " ^ e)
   | Ok pk_trace_id ->
+    let pk_persona = Safe_ops.json_string_opt "persona" json in
     let pk_trace_history =
       Safe_ops.json_string_list "trace_history" json |> List.filter validate_name
     in
@@ -116,6 +118,7 @@ let parse_keeper_identity (json : Yojson.Safe.t) : (parsed_keeper_identity, stri
     Ok
       { pk_name
       ; pk_agent_name
+      ; pk_persona
       ; pk_trace_id
       ; pk_trace_history
       ; pk_goal
@@ -543,6 +546,7 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
                        (if identity.pk_agent_name = ""
                         then Keeper_identity.keeper_agent_name identity.pk_name
                         else identity.pk_agent_name)
+                   ; persona = identity.pk_persona
                    ; goal = identity.pk_goal
                    ; short_goal = identity.pk_short_goal
                    ; mid_goal = identity.pk_mid_goal


### PR DESCRIPTION
## Summary
Adds `persona : string option` to `keeper_meta` type and JSON codec.
- `keeper_meta_contract`: type definition in `.mli` and `.ml`
- `keeper_meta_json_parse`: parse `persona` from JSON, include in `meta_of_json`
- `keeper_meta_json`: serialize `persona` in `meta_to_json`, add to canonical key list

## Why
Persona (identity) is used as a creation-time label when spawning keepers from
persona profiles. Treating it as a generation ID lets the meta JSON persist
this mapping so diagnostics and audits can trace which persona profile a keeper
was derived from.

## Test plan
- [x] `lib/keeper/` compiles cleanly
- [ ] Full `@check` blocked by pre-existing partial-match warnings (unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)