### PR TITLE
fix(dashboard): unify StatTile grid layout for consistent UI

### DIFF
--- a/dashboard/src/components/cost-dashboard.ts
+++ b/dashboard/src/components/cost-dashboard.ts
@@ -1324,7 +1324,7 @@ function CostDashboardContent({ view }: { view: CostView }) {
         />
 
         ${t ? html`
-          <div class="grid grid-cols-2 gap-2 md:grid-cols-4 lg:grid-cols-6">
+          <div class="grid grid-cols-2 gap-2 md:grid-cols-4">
             <${StatTile}
               label="Total Cost"
               value=${formatCost(t.totalCost)}
@@ -1348,6 +1348,18 @@ function CostDashboardContent({ view }: { view: CostView }) {
               delta=${{ direction: 'flat', text: mode === 'model' && modelTotals.value ? `${formatTokens(modelTotals.value.totalReasoning)} total` : 'keeper view' }}
             />
             <${StatTile}
+              label="Error Rate"
+              value=${t.errorRate != null ? formatPct1(t.errorRate) : '—'}
+              status=${t.errorRate != null ? (t.errorRate > 0.1 ? 'crit' : t.errorRate > 0 ? 'warn' : 'ok') : undefined}
+              delta=${{ direction: 'flat', text: `${t.totalError} errors / ${t.totalSuccess} success` }}
+            />
+            <${StatTile}
+              label="Avg TTFRC"
+              value=${t.avgTtfrc != null ? `${t.avgTtfrc}ms` : '—'}
+              status=${t.avgTtfrc != null && t.avgTtfrc > 3000 ? 'warn' : undefined}
+              delta=${{ direction: 'flat', text: 'streaming first chunk' }}
+            />
+            <${StatTile}
               label="p50 Latency (avg)"
               value=${`${Math.round(t.p50Avg)}ms`}
               delta=${{ direction: 'flat', text: 'across entries' }}
@@ -1359,22 +1371,6 @@ function CostDashboardContent({ view }: { view: CostView }) {
               delta=${{ direction: t.p95Max > 8000 ? 'down' : 'flat', text: t.p95Max > 8000 ? 'over 8s budget' : 'within budget' }}
             />
           </div>
-          ${mode === 'model' ? html`
-            <div class="grid grid-cols-2 gap-2 md:grid-cols-4">
-              <${StatTile}
-                label="Error Rate"
-                value=${t.errorRate != null ? formatPct1(t.errorRate) : '—'}
-                status=${t.errorRate != null ? (t.errorRate > 0.1 ? 'crit' : t.errorRate > 0 ? 'warn' : 'ok') : undefined}
-                delta=${{ direction: 'flat', text: `${t.totalError} errors / ${t.totalSuccess} success` }}
-              />
-              <${StatTile}
-                label="Avg TTFRC"
-                value=${t.avgTtfrc != null ? `${t.avgTtfrc}ms` : '—'}
-                status=${t.avgTtfrc != null && t.avgTtfrc > 3000 ? 'warn' : undefined}
-                delta=${{ direction: 'flat', text: 'streaming first chunk' }}
-              />
-            </div>
-          ` : null}
         ` : null}
 
         ${showMatrix ? html`<${CostMatrix} models=${activeState.data as DashboardRuntimeModelMetric[]} />` : null}


### PR DESCRIPTION
## Summary

대시보드 StatTile 그리드 레이아웃 일관성 개선.

### Before
- 6개 타일 + 2개 타일 분리된 그리드 → 시각적 불균형
- Error Rate / TTFRC 타일이 model 모드에서만 표시
- 두 번째 행이 4칸 중 2칸만 채워져 반쪽짜리

### After
- 단일 4-col 반응형 그리드 (4×2)
- 모든 모드에서 동일한 8개 타일 표시
- 균형 잡힌 레이아웃:

| Total Cost | Tokens In/Out | Cache Hit | Reasoning |
|:----------:|:-------------:|:---------:|:---------:|
| Error Rate | Avg TTFRC     | p50 Latency | p95 Latency |

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>