### PR TITLE
fix(keeper): add persona to meta JSON seed to stop unknown_keys spam

### DIFF
--- a/lib/keeper/keeper_meta_json.ml
+++ b/lib/keeper/keeper_meta_json.ml
@@ -173,6 +173,7 @@ let canonical_keeper_meta_key_names =
     `Assoc
       [ "name", `String "__keeper-meta-key-seed__"
       ; "agent_name", `String "__keeper-meta-key-seed__"
+      ; "persona", `String "__keeper-meta-key-seed__"
       ; "trace_id", `String "__keeper-meta-key-seed__"
       ; "tool_access", `List []
       ]


### PR DESCRIPTION
## Problem
PR #19960 added `persona` field to keeper_meta type but missed the seed JSON in `keeper_meta_json.ml`. The canonical key derivation uses a seed round-trip (parse→serialize) to determine valid keys. Since `persona` wasn't in the seed, every heartbeat logged:

```
keeper meta rondo.json has unknown keys: persona
```

~2,700 lines/day across all keepers.

## Fix
Add `persona` to the seed JSON. One line.

## Impact
Eliminates ~2,700 WARN log lines/day. The fallback list already had `persona` (line 108), but the seed path succeeds so fallback is never reached.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>