### PR TITLE
docs(rfc): RFC-0214 OTel GenAI dual emission design

### DIFF
--- a/docs/rfc/RFC-0214-otel-genai-dual-emission.md
+++ b/docs/rfc/RFC-0214-otel-genai-dual-emission.md
@@ -1,0 +1,192 @@
+# RFC-0214: OTel GenAI Semantic Convention Dual Emission
+
+| | |
+|---|---|
+| **Status** | Draft |
+| **Author** | Claude Opus 4.8 |
+| **Date** | 2026-06-04 |
+| **Supersedes** | — |
+
+## 1. Problem
+
+masc-mcp의 LLM 텔레메트리는 **Prometheus 전용 커스텀 메트릭**(`masc_llm_provider_*`)을 사용한다. OTel GenAI Semantic Convention(`gen_ai.*`)을 따르지 않아:
+
+1. Grafana/Datadog/New Relic이 LLM 메트릭을 자동 분류하지 못함
+2. OTLP export 시 메트릭명 매핑이 필요
+3. span attributes와 metric labels 간 불일치
+
+## 2. Current State
+
+### 2.1 Prometheus Metrics (Internal)
+
+| Prometheus Name | Type | Labels |
+|-----------------|------|--------|
+| `masc_llm_provider_input_tokens_total` | counter | provider, model |
+| `masc_llm_provider_output_tokens_total` | counter | provider, model |
+| `masc_llm_provider_cache_read_tokens_total` | counter | provider, model |
+| `masc_llm_provider_cache_creation_tokens_total` | counter | provider, model |
+| `masc_llm_provider_reasoning_tokens_total` | counter | provider, model |
+| `masc_llm_provider_request_latency_seconds` | histogram | provider, model |
+| `masc_llm_provider_errors_by_reason_total` | counter | model, error_reason |
+| `masc_llm_provider_retries_total` | counter | provider, model, attempt |
+| `masc_llm_provider_streaming_first_chunk_seconds` | histogram | provider, model |
+| `masc_llm_provider_streaming_inter_chunk_seconds` | histogram | provider, model |
+| `masc_llm_provider_cache_hits_total` | counter | provider, model |
+| `masc_llm_provider_cache_misses_total` | counter | provider, model |
+| `masc_llm_provider_circuit_state` | gauge | provider, model |
+
+### 2.2 OTel Span Events (Partial)
+
+Only streaming events emit OTel span attributes:
+
+| Span Event | Attributes |
+|------------|------------|
+| `ttfrc.received` | `gen_ai.provider.name`, `gen_ai.request.model`, `masc.gen_ai.streaming.ttfrc_ms` |
+| `streaming.chunk` | `gen_ai.provider.name`, `gen_ai.request.model`, `masc.gen_ai.streaming.chunk_index`, `masc.gen_ai.streaming.inter_chunk_ms` |
+
+### 2.3 Missing OTel Integration
+
+- Token usage → NOT as OTel metric or span attribute
+- Error events → NOT as OTel span status
+- Cache metrics → NOT in OTel
+- Request duration → NOT as OTel metric
+
+## 3. Target State (OTel GenAI Semconv)
+
+Reference: [OTel GenAI Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/)
+
+### 3.1 OTel Metric: `gen_ai.client.token.usage`
+
+Counter with `gen_ai.token.type` attribute:
+
+| `gen_ai.token.type` value | Source |
+|--------------------------|--------|
+| `input` | `masc_llm_provider_input_tokens_total` |
+| `output` | `masc_llm_provider_output_tokens_total` |
+| `cache_read` | `masc_llm_provider_cache_read_tokens_total` |
+| `cache_creation` | `masc_llm_provider_cache_creation_tokens_total` |
+| `reasoning` | `masc_llm_provider_reasoning_tokens_total` |
+
+### 3.2 OTel Span Event: `gen_ai.client.inference.operation.details`
+
+Attributes to add per-inference:
+
+| Attribute | Source |
+|-----------|--------|
+| `gen_ai.usage.input_tokens` | `response.usage.input_tokens` |
+| `gen_ai.usage.output_tokens` | `response.usage.output_tokens` |
+| `gen_ai.usage.cache_read.input_tokens` | `response.usage.cache_read_input_tokens` |
+| `gen_ai.usage.cache_creation.input_tokens` | `response.usage.cache_creation_input_tokens` |
+| `gen_ai.usage.reasoning.output_tokens` | `response.telemetry.reasoning_tokens` |
+| `gen_ai.response.time_to_first_chunk` | `streaming_ttfrc_ms / 1000` |
+| `gen_ai.response.finish_reasons` | `stop_reason` |
+| `gen_ai.response.model` | `resolved_model_id` |
+
+## 4. Approach: Dual Emission
+
+### 4.1 Strategy
+
+Emit **both** Prometheus counters AND OTel metrics/attributes simultaneously.
+
+Why dual instead of migration:
+- Existing Prometheus dashboards/alerts continue to work
+- Gradual adoption — no breaking change
+- OTLP-enabled environments get automatic LLM dashboards
+- Prometheus remains the primary internal metric source
+
+### 4.2 Implementation Layers
+
+```
+                    ┌─────────────────┐
+                    │  OAS Callbacks   │
+                    │  (on_token_usage, │
+                    │   on_error, etc)  │
+                    └────────┬─────────┘
+                             │
+                    ┌────────▼─────────┐
+                    │  Bridge Layer     │
+                    │  (llm_metric_     │
+                    │   bridge.ml)      │
+                    └───┬──────────┬───┘
+                        │          │
+              ┌─────────▼──┐  ┌───▼──────────┐
+              │ Prometheus  │  │  OTel Metric  │
+              │ Counters    │  │  Exporter     │
+              │ (existing)  │  │  (new)        │
+              └─────────────┘  └──────────────┘
+```
+
+### 4.3 Code Changes
+
+#### Phase A: Span Attributes (Low risk)
+
+In `lib/llm_metric_bridge.ml`, add OTel span attributes to `emit_token_usage`:
+
+```ocaml
+let emit_token_usage ~provider ~model_id ~input_tokens ~output_tokens =
+  (* Existing Prometheus *)
+  Prometheus.inc_counter input_token_metric ...;
+  Prometheus.inc_counter output_token_metric ...;
+  (* NEW: OTel span attributes *)
+  Otel_spans.add_event
+    ~name:"gen_ai.client.token.usage"
+    ~attrs:
+      [ "gen_ai.provider.name", `String provider
+      ; "gen_ai.request.model", `String model_id
+      ; "gen_ai.usage.input_tokens", `Int input_tokens
+      ; "gen_ai.usage.output_tokens", `Int output_tokens
+      ]
+    ()
+```
+
+Similarly for `emit_error` (span status), `emit_streaming_first_chunk` (already partially done).
+
+#### Phase B: OTel Metric Export (Medium risk)
+
+Add a thin OTel metric exporter alongside Prometheus in the bridge:
+
+```ocaml
+(* Dual emission helper *)
+let emit_metric_prometheus_and_otel ~name ~value ~attrs =
+  (* Prometheus: existing counters *)
+  emit_prometheus name value attrs;
+  (* OTel: standard metric *)
+  Otel_metrics.record ~name ~value ~attrs
+```
+
+This requires the `opentelemetry` OCaml library (already in dune-project).
+
+#### Phase C: Custom→Standard Migration (Future)
+
+After Phase B is validated:
+1. Add Prometheus → OTel name mapping table
+2. Grafana dashboards switch to OTel metric names
+3. Eventually deprecate `masc_llm_provider_*` (breaking change, major version bump)
+
+## 5. Scope & Effort
+
+| Phase | Files | Effort | Risk |
+|-------|-------|--------|------|
+| A: Span attributes | `llm_metric_bridge.ml`, `keeper_hooks_oas.ml` | ~50 lines | Low |
+| B: OTel metric export | `llm_metric_bridge.ml`, new `otel_llm_metrics.ml` | ~200 lines | Medium |
+| C: Deprecation | Dashboard, alert configs | ~100 files | High |
+
+## 6. Decision Points
+
+1. **Dual emission vs replacement?** — Dual (recommended). Zero downtime.
+2. **OTLP endpoint configuration?** — Use existing `opentelemetry` lib config (env vars).
+3. **Custom attributes (`masc.gen_ai.*`) migration?** — Phase C, with deprecation period.
+
+## 7. Non-Goals
+
+- Changing Prometheus metric names (breaking change, separate RFC)
+- OTel Logs integration (JSONL → OTLP logs bridge is a separate concern)
+- Replacing JSONL persistence with OTel-only (JSONL remains the durable truth)
+
+## 8. References
+
+- [OTel GenAI Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/)
+- [OTel GenAI Metrics](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics/)
+- PR #19957 — Telemetry pipeline gap fixes (error/retry JSONL, cache_creation pipeline)
+- `lib/llm_metric_bridge.ml` — Bridge layer with partial OTel span events
+- `lib/opentelemetry_client_cohttp_eio.ml` — OTLP exporter (Eio transport)


### PR DESCRIPTION
OTel GenAI Semantic Convention 이중 방출 마이그레이션 설계. 3-Phase: Span attributes -> OTel metric export -> Custom→Standard migration. Non-breaking dual emission approach.