### PR TITLE
fix(ide): case-insensitive tool_name comparison for PR event ingestion

### DIFF
--- a/lib/ide/ide_bridge.ml
+++ b/lib/ide/ide_bridge.ml
@@ -258,7 +258,7 @@ let ingest_pr_event_from_descriptor
     ~output_text
     ~tool_name
   =
-  if String.equal tool_name "execute" then
+  if String.equal (String.lowercase_ascii tool_name) "execute" then
     match extract_descriptor_from_output output_text with
     | Some (Ide_event_types.Gh_pr_create { title; base = _; draft = _ }) ->
       (* PR was created — try to get PR number from output URL *)
@@ -326,7 +326,7 @@ let ingest_pr_event_from_descriptor
     | Some (Ide_event_types.Gh_issue_create _ | Ide_event_types.Gh_issue_close _ | Ide_event_types.Git_push _ | Ide_event_types.Git_commit _ | Ide_event_types.Pipe_chain _ | Ide_event_types.Generic)
     | None ->
       (* Not a PR operation — fall back to heuristic output parsing *)
-      if String.equal tool_name "execute" then
+      if String.equal (String.lowercase_ascii tool_name) "execute" then
         match parse_pr_url_from_output output_text with
         | Some (pr_number, pr_url) ->
           let repo =
@@ -363,7 +363,7 @@ let ingest_pr_event_from_hook
     ~output_text
     ~tool_name
   =
-  if String.equal tool_name "execute" then
+  if String.equal (String.lowercase_ascii tool_name) "execute" then
     match parse_pr_url_from_output output_text with
     | Some (pr_number, pr_url) ->
       let repo =


### PR DESCRIPTION
## Changes

IDE bridge의 `ingest_pr_event_from_descriptor`에서 tool_name 비교를 대소문자 구분 없이 수정.

**버그**: `String.equal tool_name "execute"` (소문자)로 체크했지만, 실제 tool 이름은 `"Execute"` (대문자)로 전달됨. 결과적으로 PR 이벤트가 전혀 생성되지 않았음.

**수정**: `String.equal (String.lowercase_ascii tool_name) "execute"`로 변경하여 대소문자 구분 없이 매칭.

## Evidence

런타임 로그 분석 (2026-06-03):
- Execute tool 호출: 551회
- Typed (Shell IR) 호출: 215회 (39%)
- git_commit descriptor: 7회
- git_push descriptor: 7회
- PR 이벤트 생성: 0회 (버그로 인해)

## Related
- PR #19953 (pipe chain descriptor)
- PR #19958 (descriptor extraction fix)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>