### PR TITLE
fix(keeper): release turn slot during transient-retry backoff to match degraded-retry path

### DIFF
--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -673,16 +673,55 @@ let run (ctx : ctx)
               ; "phase", Keeper_oas_execution_error_phase.(to_label Recoverable_runtime_transient)
               ]
             ();
+          (* Release the outer turn slot for the duration of the transient
+             backoff so a stalled/retrying keeper does not hold a concurrency
+             slot it is not actively using. This matches the degraded-retry
+             path above (release_for_retry before the gap,
+             reacquire_after_retry before recursing). *)
+          (match turn_slot_control with
+           | Some slot_control ->
+             slot_control.Keeper_turn_slot.release_for_retry ()
+           | None -> ());
           Eio.Time.sleep clock delay;
-          retry_loop
-            { run_meta
-            ; execution
-            ; run_generation
-            ; attempt = attempt + 1
-            ; is_retry = true
-            ; allow_degraded_wall_clock_retry_budget = false
-            ; attempted_runtimes
-            }
+          let run_retry () =
+            retry_loop
+              { run_meta
+              ; execution
+              ; run_generation
+              ; attempt = attempt + 1
+              ; is_retry = true
+              ; allow_degraded_wall_clock_retry_budget = false
+              ; attempted_runtimes
+              }
+          in
+          (match turn_slot_control with
+           | None -> run_retry ()
+           | Some slot_control ->
+             (match
+                slot_control.Keeper_turn_slot.reacquire_after_retry ()
+              with
+              | Ok wait_ms ->
+                Log.Keeper.info
+                  "%s: reacquired keeper turn slot for transient retry on \
+                   runtime=%s wait_ms=%d"
+                  meta.name
+                  execution_runtime_id
+                  wait_ms;
+                run_retry ()
+              | Error (`Semaphore_wait_timeout timeout) ->
+                let slot_err =
+                  sdk_error_of_retry_slot_reacquire_timeout
+                    ~keeper_name:meta.name
+                    timeout
+                in
+                Log.Keeper.warn
+                  "%s: transient retry on runtime=%s skipped because turn \
+                   slot reacquire timed out: %s"
+                  meta.name
+                  execution_runtime_id
+                  (short_preview (Agent_sdk.Error.to_string slot_err));
+                mark_terminal_error slot_err;
+                Error slot_err))
         | No_degraded_retry when EC.is_context_overflow err ->
           let current_turn_event_bus =
             drain_turn_event_bus ~site:"context_overflow_capture" ()


### PR DESCRIPTION
## Summary

`retry_loop` in `lib/keeper/keeper_unified_turn_execution.ml` holds the outer turn concurrency slot (`with_keeper_turn_slot`) for its entire duration. It has two recoverable-failure retry paths that treated the slot inconsistently:

- **Degraded retry (runtime rotation)** releases the slot during the retry gap via `release_for_retry ()`, then re-queues and re-acquires via `reacquire_after_retry ()`, ending the cycle when the reacquire hits `Semaphore_wait_timeout`.
- **Transient network error retry** (`No_degraded_retry when EC.is_transient_network_error err ...`) slept through `EC.transient_backoff_sec attempt` and recursed **while still holding the slot**.

A keeper hitting a transient error (e.g. `inter_chunk_idle`) therefore held its concurrency slot across the original stall (up to ~120s liveness) plus the backoff sleep plus the retry attempt's stall. Fleet evidence: this produced ~325s slot holds, starving the reactive pool — other keepers skip their turn after the 180s semaphore wait elapses.

## Change

The transient-retry branch now releases the outer turn slot for the duration of the backoff and re-queues fairly before recursing, matching the degraded-retry path:

1. Before `Eio.Time.sleep clock delay`: `release_for_retry ()` when a `turn_slot_control` is present, so the slot is free during the backoff.
2. Keep the backoff sleep.
3. After the sleep, wrap the recursion in `reacquire_after_retry ()`; on `Semaphore_wait_timeout` the cycle ends via `sdk_error_of_retry_slot_reacquire_timeout` (same termination the degraded path uses).

The recursion fields are unchanged from the prior transient branch: same `execution` (transient stays on the same runtime), `attempt = attempt + 1`, `allow_degraded_wall_clock_retry_budget = false`, `attempted_runtimes` unchanged. This is a backpressure-correctness alignment of two retry paths, not symptom suppression: a stalled or retrying keeper no longer occupies a concurrency slot it is not actively using, and re-queues fairly when it resumes.

`release_for_retry`/`reacquire_after_retry` are held-state-guarded and the outer `with_keeper_turn_slot` finalizer is idempotent (`keeper_turn_slot.ml`), so the release→sleep window and the `Error` unwind path are safe — the degraded path already relies on the same invariant.

## Verification

- `dune build @check --root .` — 0 errors before and after (net-zero; baseline on `origin/main` was 0).
- `dune build @all --root .` — native build EXITCODE 0, 0 errors (catches expression-level type errors).
- Tests run (all pass):
  - `test/test_keeper_turn_slot_holders.exe` 16/16 — includes `retry control releases and reacquires reactive slot`, which asserts the slot is freed during the gap and reacquired after.
  - `test/test_keeper_turn_slot_force_release.exe` 4/4
  - `test/test_keeper_semaphore_fairness.exe` 15/15
  - `test/test_oas_timeout_budget_strike.exe` 9/9

No new test was added: the slot-level release/reacquire invariant that this fix depends on is already covered by `test_keeper_turn_slot_holders`, and the transient branch now wires that primitive identically to the already-tested degraded branch. A transient-network-error integration scenario would require a stalling mock SDK runtime; that seam was judged not clean enough to assert against without fabrication.

## Files

- `lib/keeper/keeper_unified_turn_execution.ml`

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
