### PR TITLE
refactor(keeper): decouple completion contract from tool surface

### DIFF
--- a/lib/dashboard/dashboard_goals_types_builder.ml
+++ b/lib/dashboard/dashboard_goals_types_builder.ml
@@ -182,8 +182,11 @@ let runtime_trust_from_receipt_fallback ~config ~(meta : Keeper_meta_contract.ke
       ( "execution_summary",
         `Assoc
           [
-            ( "tool_contract_result",
-              Option.value ~default:`Null (Json_util.assoc_member_opt "tool_contract_result" receipt) );
+            ( "completion_contract_result",
+              (* Missing receipt field stays JSON null; this projection does
+                 not invent a runtime contract outcome. *)
+              (* sound-partial: allow *)
+              Option.value ~default:`Null (Json_util.assoc_member_opt "completion_contract_result" receipt) );
             ("latest_receipt_at", `String ts);
           ] );
       ("runtime_blockers", `Assoc runtime_blocker_fields);

--- a/lib/dashboard/dashboard_http_keeper_trust.ml
+++ b/lib/dashboard/dashboard_http_keeper_trust.ml
@@ -73,9 +73,12 @@ let keeper_trust_json ?(include_receipt = false)
         match latest_receipt with
         | Some receipt -> Option.value ~default:(`String "no_receipt") (Json_util.assoc_member_opt "operator_disposition_reason" receipt)
         | None -> `String "no_receipt" );
-      ( "tool_contract_result",
+      ( "completion_contract_result",
         match latest_receipt with
-        | Some receipt -> Option.value ~default:(`String "unknown") (Json_util.assoc_member_opt "tool_contract_result" receipt)
+        (* Missing receipt field stays a UI sentinel; this is not a runtime
+           contract decision. *)
+        (* sound-partial: allow *)
+        | Some receipt -> Option.value ~default:(`String "unknown") (Json_util.assoc_member_opt "completion_contract_result" receipt)
         | None -> `String "unknown" );
       ("requested_tool_count", `Int (List.length requested_tools));
       ("tools_used", `List (List.map (fun value -> `String value) tools_used));

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -21,8 +21,8 @@ let no_progress_success_tool_names_for_contract =
   Contract_helpers.no_progress_success_tool_names_for_contract
 ;;
 
-let tool_contract_result_for_observed_tools =
-  Turn_helpers.tool_contract_result_for_observed_tools
+let completion_contract_result_for_progress_evidence =
+  Turn_helpers.completion_contract_result_for_progress_evidence
 
 module For_testing = struct
   let sse_event_progress_kind = Turn_helpers.sse_event_progress_kind
@@ -677,7 +677,7 @@ let run_turn
                  if valid_tool_calls_present then acc.keeper_surface_tool_used <- true;
                  if unexpected_tool_names <> [] && not valid_tool_calls_present
                  then (
-                   acc.receipt_tool_contract_result <-
+                   acc.receipt_completion_contract_result <-
                      Keeper_execution_receipt.Contract_violated;
                    Error
                      (Keeper_agent_run_tool_surface_violation.to_sdk_error
@@ -732,14 +732,14 @@ let run_turn
                        ~history_messages
                        ~actual_input_tokens:(Some usage.input_tokens)
                    in
-                   let tool_contract_status ()
-                       : Keeper_execution_receipt.tool_contract_result =
-                     Contract_helpers.observed_tool_contract_status
+                   let completion_contract_status ()
+                       : Keeper_execution_receipt.completion_contract_result =
+                     Contract_helpers.observed_completion_contract_status
                        ~had_owned_active_task_at_turn_start
                        ~actual_keeper_tool_names:progress_keeper_tool_names
                    in
                    let text_result =
-                     acc.receipt_tool_contract_result <- tool_contract_status ();
+                     acc.receipt_completion_contract_result <- completion_contract_status ();
                      Ok (`Provider_text text)
                    in
                    match text_result with

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -13,10 +13,10 @@ include module type of Keeper_agent_checkpoint_hygiene
 module Contract_helpers = Keeper_agent_run_contract_helpers
 module Turn_helpers = Keeper_agent_run_turn_helpers
 
-val tool_contract_result_for_observed_tools
+val completion_contract_result_for_progress_evidence
   :  had_owned_active_task_at_turn_start:bool
   -> actual_keeper_tool_names:string list
-  -> Keeper_execution_receipt.tool_contract_result
+  -> Keeper_execution_receipt.completion_contract_result
 
 module For_testing : sig
   val sse_event_progress_kind : Agent_sdk.Types.sse_event -> string option

--- a/lib/keeper/keeper_agent_run_contract_helpers.ml
+++ b/lib/keeper/keeper_agent_run_contract_helpers.ml
@@ -54,17 +54,17 @@ let no_progress_success_tool_names_for_contract
   keeper_tool_names_for_outcome ~allowed_tool_names ~tool_calls ~outcome:"ok_no_progress"
 ;;
 
-let observed_tool_contract_status
+let observed_completion_contract_status
       ~had_owned_active_task_at_turn_start ~actual_keeper_tool_names
-  : Keeper_execution_receipt.tool_contract_result
+  : Keeper_execution_receipt.completion_contract_result
   =
-  Keeper_agent_run_turn_helpers.tool_contract_result_for_observed_tools
+  Keeper_agent_run_turn_helpers.completion_contract_result_for_progress_evidence
     ~had_owned_active_task_at_turn_start
     ~actual_keeper_tool_names
 ;;
 
 let text_only_violation_contract_status ~actual_keeper_tool_names ~fallback
-  : Keeper_execution_receipt.tool_contract_result
+  : Keeper_execution_receipt.completion_contract_result
   =
   if actual_keeper_tool_names = []
   then Contract_violated

--- a/lib/keeper/keeper_agent_run_contract_helpers.mli
+++ b/lib/keeper/keeper_agent_run_contract_helpers.mli
@@ -19,7 +19,7 @@ val no_progress_success_tool_names_for_contract :
   tool_calls:Keeper_agent_result.tool_call_detail list ->
   string list
 
-val observed_tool_contract_status :
+val observed_completion_contract_status :
   had_owned_active_task_at_turn_start:bool ->
   actual_keeper_tool_names:string list ->
-  Keeper_execution_receipt.tool_contract_result
+  Keeper_execution_receipt.completion_contract_result

--- a/lib/keeper/keeper_agent_run_receipt.ml
+++ b/lib/keeper/keeper_agent_run_receipt.ml
@@ -125,10 +125,10 @@ let finalize
       ( Some (Keeper_execution_receipt.error_kind_of_string (Keeper_agent_error.sdk_error_kind err))
       , Some (Agent_sdk.Error.to_string err) )
   in
-  let tool_contract_result
-      : Keeper_execution_receipt.tool_contract_result =
+  let completion_contract_result
+      : Keeper_execution_receipt.completion_contract_result =
     match turn_result with
-    | _ -> acc.receipt_tool_contract_result
+    | _ -> acc.receipt_completion_contract_result
   in
   let terminal_reason_code =
     match turn_result with
@@ -177,7 +177,7 @@ let finalize
     ; canonical_tools = !canonical_tool_names_ref
     ; unexpected_tools = !unexpected_tool_names_ref
     ; tools_used = !actual_keeper_tool_names_ref
-    ; tool_contract_result
+    ; completion_contract_result
     ; tool_surface =
         { turn_lane = acc.tool_surface.turn_lane
         ; tool_surface_class = acc.tool_surface.tool_surface_class

--- a/lib/keeper/keeper_agent_run_turn_helpers.ml
+++ b/lib/keeper/keeper_agent_run_turn_helpers.ml
@@ -73,10 +73,10 @@ let registry_progress_on_event ~record_turn_progress downstream event =
   Option.iter (fun cb -> cb event) downstream
 
 
-let tool_contract_result_for_observed_tools
+let completion_contract_result_for_progress_evidence
     ~(had_owned_active_task_at_turn_start : bool)
     ~(actual_keeper_tool_names : string list) :
-    Keeper_execution_receipt.tool_contract_result =
+    Keeper_execution_receipt.completion_contract_result =
   let class_of name = Keeper_tool_progress.classify_tool_progress name in
   let classes = List.map class_of actual_keeper_tool_names in
   let has_class wanted = List.exists (( = ) wanted) classes in

--- a/lib/keeper/keeper_agent_run_turn_helpers.mli
+++ b/lib/keeper/keeper_agent_run_turn_helpers.mli
@@ -20,10 +20,10 @@ val registry_progress_on_event :
   Agent_sdk.Types.sse_event ->
   unit
 
-val tool_contract_result_for_observed_tools :
+val completion_contract_result_for_progress_evidence :
   had_owned_active_task_at_turn_start:bool ->
   actual_keeper_tool_names:string list ->
-  Keeper_execution_receipt.tool_contract_result
+  Keeper_execution_receipt.completion_contract_result
 
 val emit_turn_end_safely : keeper_name:string -> unit -> unit
 val digest_text : string -> string

--- a/lib/keeper/keeper_contract_classifier.ml
+++ b/lib/keeper/keeper_contract_classifier.ml
@@ -4,7 +4,7 @@ type actionable_signal =
   | No_actionable_signal
 
 type contract_status =
-  | Tool_surface_mismatch of { missing : string list }
+  | Surface_mismatch of { missing : string list }
   | Claim_only_after_owned_task
   | Needs_execution_progress
   | Passive_only
@@ -17,7 +17,7 @@ let actionable_signal_label = function
   | No_actionable_signal -> "no_actionable_signal"
 
 let contract_status_label = function
-  | Tool_surface_mismatch _ -> "tool_surface_mismatch"
+  | Surface_mismatch _ -> "surface_mismatch"
   | Claim_only_after_owned_task -> "claim_only_after_owned_task"
   | Needs_execution_progress -> "needs_execution_progress"
   | Passive_only -> "passive_only"
@@ -25,8 +25,8 @@ let contract_status_label = function
   | Satisfied_execution -> "satisfied_execution"
 
 let pp_contract_status fmt = function
-  | Tool_surface_mismatch { missing } ->
-      Format.fprintf fmt "tool_surface_mismatch(missing=[%s])"
+  | Surface_mismatch { missing } ->
+      Format.fprintf fmt "surface_mismatch(missing=[%s])"
         (String.concat ", " missing)
   | other -> Format.pp_print_string fmt (contract_status_label other)
 

--- a/lib/keeper/keeper_contract_classifier.mli
+++ b/lib/keeper/keeper_contract_classifier.mli
@@ -8,7 +8,7 @@ type actionable_signal =
           world snapshot. *)
 
 type contract_status =
-  | Tool_surface_mismatch of { missing : string list }
+  | Surface_mismatch of { missing : string list }
   | Claim_only_after_owned_task
   | Needs_execution_progress
   | Passive_only

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -370,8 +370,8 @@ let operator_disposition (receipt : t)
        match exhaustive without a wildcard. *)
     let tool_route_failure =
       List.mem
-        receipt.tool_contract_result
-        [ Contract_tool_surface_mismatch; Contract_no_tool_capable_provider ]
+        receipt.completion_contract_result
+        [ Contract_surface_mismatch; Contract_no_capable_provider ]
     in
     if tool_route_failure
     then
@@ -392,7 +392,7 @@ let operator_disposition (receipt : t)
     else if
       receipt.outcome = `Ok
       && receipt.runtime_outcome = Runtime_not_dispatched
-      && receipt.tool_contract_result = Contract_not_dispatched
+      && receipt.completion_contract_result = Contract_not_dispatched
       &&
       (match terminal_reason with
        | Keeper_terminal_reason.Pre_dispatch_success _ -> true
@@ -438,12 +438,12 @@ let operator_disposition (receipt : t)
           ();
         Log.Keeper.warn
           "operator_disposition: unmapped (outcome=%s runtime_outcome=%s \
-           terminal_reason=%s tool_contract_result=%s error_kind=%s) — investigate \
+           terminal_reason=%s completion_contract_result=%s error_kind=%s) — investigate \
            regression of #11651 silent-path fix"
           (outcome_kind_to_string receipt.outcome)
           (runtime_outcome_to_string receipt.runtime_outcome)
           receipt.terminal_reason_code
-          (tool_contract_result_to_string receipt.tool_contract_result)
+          (completion_contract_result_to_string receipt.completion_contract_result)
           (Option.value
              (Option.map error_kind_to_string receipt.error_kind)
              ~default:"<none>");
@@ -532,8 +532,8 @@ let to_json (receipt : t) =
     ; "unexpected_tools", list_json receipt.unexpected_tools
     ; "tools_used", list_json receipt.tools_used
     ; "tool_descriptor_summary", tool_descriptor_summary_json receipt
-    ; ( "tool_contract_result"
-      , `String (tool_contract_result_to_string receipt.tool_contract_result) )
+    ; ( "completion_contract_result"
+      , `String (completion_contract_result_to_string receipt.completion_contract_result) )
     ; ( "tool_surface"
       , `Assoc
           [ ( "turn_lane"
@@ -731,8 +731,8 @@ let operator_broadcast_payload (receipt : t) ~disposition ~reason =
     ; "response_text_present", `Bool receipt.response_text_present
     ; "runtime_id", `String (receipt.runtime_id)
     ; "runtime_outcome", `String (runtime_outcome_to_string receipt.runtime_outcome)
-    ; ( "tool_contract_result"
-      , `String (tool_contract_result_to_string receipt.tool_contract_result) )
+    ; ( "completion_contract_result"
+      , `String (completion_contract_result_to_string receipt.completion_contract_result) )
     ; ( "last_tool_name", string_opt_json (last_tool_name receipt) )
     ; "tools_used", list_json receipt.tools_used
     ; ( "contract_violation_detail"
@@ -744,26 +744,6 @@ let operator_broadcast_payload (receipt : t) ~disposition ~reason =
             ; "called_tools", list_json called
             ; "satisfying_tools", list_json satisfying
             ] )
-    ; ( "tool_contract"
-      , `Assoc
-          [ ( "result"
-            , `String (tool_contract_result_to_string receipt.tool_contract_result) )
-          ; "visible_tool_count", `Int receipt.tool_surface.visible_tool_count
-          ; ( "tool_requirement"
-            , Keeper_agent_tool_surface.tool_requirement_to_yojson
-                receipt.tool_surface.tool_requirement )
-          ; ( "turn_lane"
-            , Keeper_agent_tool_surface.turn_lane_to_yojson
-                receipt.tool_surface.turn_lane )
-          ; ( "tool_surface_class"
-            , Keeper_agent_tool_surface.tool_surface_class_to_yojson
-                receipt.tool_surface.tool_surface_class )
-          ; "tool_gate_enabled", `Bool receipt.tool_surface.tool_gate_enabled
-          ; ( "tool_surface_fallback_used"
-            , `Bool receipt.tool_surface.tool_surface_fallback_used )
-          ; ( "materialized_tools"
-            , list_json receipt.tool_surface.materialized_tools )
-          ] )
     ; ( "sandbox"
       , `Assoc
           [ "kind", `String (Keeper_types_profile_sandbox.sandbox_profile_to_string receipt.sandbox_kind)

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -124,29 +124,29 @@ type runtime_outcome =
 
 val runtime_outcome_to_string : runtime_outcome -> string
 
-(** Receipt-level tool-contract evaluation result. Closed union of three
+(** Receipt-level completion-contract evaluation result. Closed union of three
     producer paths: (i) initial-state sentinel [Contract_unknown];
     (ii) boundary-state overrides [Contract_not_dispatched],
-    [Contract_violated], [Contract_no_tool_capable_provider]; (iii) the
+    [Contract_violated], [Contract_no_capable_provider]; (iii) the
     six classifier outcomes mirrored from
     [Keeper_contract_classifier.contract_status]. *)
-type tool_contract_result =
+type completion_contract_result =
   | Contract_unknown
   | Contract_not_dispatched
   | Contract_violated
-  | Contract_tool_surface_mismatch
-  | Contract_no_tool_capable_provider
+  | Contract_surface_mismatch
+  | Contract_no_capable_provider
   | Contract_claim_only_after_owned_task
   | Contract_needs_execution_progress
   | Contract_passive_only
   | Contract_satisfied_completion
   | Contract_satisfied_execution
 
-val tool_contract_result_to_string : tool_contract_result -> string
+val completion_contract_result_to_string : completion_contract_result -> string
 
-val tool_contract_result_of_contract_status
+val completion_contract_result_of_contract_status
   :  Keeper_contract_classifier.contract_status
-  -> tool_contract_result
+  -> completion_contract_result
 
 (** {2 Structured contract-violation encoding} *)
 
@@ -207,7 +207,7 @@ type t =
   ; canonical_tools : string list
   ; unexpected_tools : string list
   ; tools_used : string list
-  ; tool_contract_result : tool_contract_result
+  ; completion_contract_result : completion_contract_result
   ; tool_surface : tool_surface
   ; sandbox_kind : Keeper_types_profile_sandbox.sandbox_profile
   ; sandbox_root : string option
@@ -306,7 +306,7 @@ val terminal_prefix_idle_timeout : string
 (** [true] when [terminal_reason] is a turn/time-budget cut-off
     ([MaxTurnsExceeded] / [AgentExecutionTimeout] / [AgentExecutionIdleTimeout]):
     auto-recoverable, the keeper resumes from its checkpoint, so it must NOT be
-    classified as a tool-contract failure. *)
+    classified as a completion-contract failure. *)
 val is_auto_recoverable_turn_budget_terminal : string -> bool
 
 (** Derived display pair (disposition, reason) computed from receipt fields.

--- a/lib/keeper/keeper_execution_receipt_types.ml
+++ b/lib/keeper/keeper_execution_receipt_types.ml
@@ -1,5 +1,5 @@
 (* Keeper_execution_receipt_types — receipt type definitions,
-   outcome/runtime/slot classification, tool contract types, and
+   outcome/runtime/slot classification, completion contract types, and
    JSON helpers. Extracted from keeper_execution_receipt.ml during
    godfile decomposition. *)
 
@@ -123,41 +123,41 @@ let runtime_outcome_to_string = function
   | Runtime_not_dispatched -> "not_dispatched"
 ;;
 
-(* Receipt-level result of the tool-contract evaluation for the turn.
+(* Receipt-level result of the completion-contract evaluation for the turn.
    Closed union of three producer paths:
      1. Initial-state sentinel from [keeper_run_tools]: [Contract_unknown].
      2. Boundary-state overrides: [Contract_violated] (agent_run
         CompletionContractViolation), [Contract_not_dispatched]
-        (turn_helpers pre-dispatch), [Contract_no_tool_capable_provider]
+        (turn_helpers pre-dispatch), [Contract_no_capable_provider]
         (run_tools no-provider escape).
      3. Six outcomes mirrored from
         [Keeper_contract_classifier.contract_status_label]:
-        [Contract_tool_surface_mismatch], [Contract_claim_only_after_owned_task],
+        [Contract_surface_mismatch], [Contract_claim_only_after_owned_task],
         [Contract_needs_execution_progress], [Contract_passive_only],
         [Contract_satisfied_completion],
         [Contract_satisfied_execution].
    JSON wire form is the lowercase string via
-   [tool_contract_result_to_string].  No raw ["satisfied"] variant —
+   [completion_contract_result_to_string].  No raw ["satisfied"] variant —
    producer never emits it; closed type makes the fictional test fixture
    string unrepresentable. *)
-type tool_contract_result =
+type completion_contract_result =
   | Contract_unknown
   | Contract_not_dispatched
   | Contract_violated
-  | Contract_tool_surface_mismatch
-  | Contract_no_tool_capable_provider
+  | Contract_surface_mismatch
+  | Contract_no_capable_provider
   | Contract_claim_only_after_owned_task
   | Contract_needs_execution_progress
   | Contract_passive_only
   | Contract_satisfied_completion
   | Contract_satisfied_execution
 
-let tool_contract_result_to_string = function
+let completion_contract_result_to_string = function
   | Contract_unknown -> "unknown"
   | Contract_not_dispatched -> "not_dispatched"
   | Contract_violated -> "violated"
-  | Contract_tool_surface_mismatch -> "tool_surface_mismatch"
-  | Contract_no_tool_capable_provider -> "no_tool_capable_provider"
+  | Contract_surface_mismatch -> "surface_mismatch"
+  | Contract_no_capable_provider -> "no_capable_provider"
   | Contract_claim_only_after_owned_task -> "claim_only_after_owned_task"
   | Contract_needs_execution_progress -> "needs_execution_progress"
   | Contract_passive_only -> "passive_only"
@@ -166,13 +166,13 @@ let tool_contract_result_to_string = function
 ;;
 
 (* Lift the typed [Keeper_contract_classifier.contract_status] into the
-   receipt-level [tool_contract_result].  Bridges the six classifier
+   receipt-level [completion_contract_result].  Bridges the six classifier
    outcomes; the four boundary states are emitted only by producer sites
    that already know they hold one of those states. *)
-let tool_contract_result_of_contract_status
-  : Keeper_contract_classifier.contract_status -> tool_contract_result
+let completion_contract_result_of_contract_status
+  : Keeper_contract_classifier.contract_status -> completion_contract_result
   = function
-  | Tool_surface_mismatch _ -> Contract_tool_surface_mismatch
+  | Surface_mismatch _ -> Contract_surface_mismatch
   | Claim_only_after_owned_task -> Contract_claim_only_after_owned_task
   | Needs_execution_progress -> Contract_needs_execution_progress
   | Passive_only -> Contract_passive_only
@@ -288,7 +288,7 @@ type t =
   ; canonical_tools : string list
   ; unexpected_tools : string list
   ; tools_used : string list
-  ; tool_contract_result : tool_contract_result
+  ; completion_contract_result : completion_contract_result
   ; tool_surface : tool_surface
   ; sandbox_kind : Keeper_types_profile_sandbox.sandbox_profile
   ; sandbox_root : string option

--- a/lib/keeper/keeper_execution_receipt_types.mli
+++ b/lib/keeper/keeper_execution_receipt_types.mli
@@ -53,20 +53,20 @@ type runtime_outcome =
   | Runtime_not_observed
   | Runtime_not_dispatched
 val runtime_outcome_to_string : runtime_outcome -> string
-type tool_contract_result =
+type completion_contract_result =
     Contract_unknown
   | Contract_not_dispatched
   | Contract_violated
-  | Contract_tool_surface_mismatch
-  | Contract_no_tool_capable_provider
+  | Contract_surface_mismatch
+  | Contract_no_capable_provider
   | Contract_claim_only_after_owned_task
   | Contract_needs_execution_progress
   | Contract_passive_only
   | Contract_satisfied_completion
   | Contract_satisfied_execution
-val tool_contract_result_to_string : tool_contract_result -> string
-val tool_contract_result_of_contract_status :
-  Keeper_contract_classifier.contract_status -> tool_contract_result
+val completion_contract_result_to_string : completion_contract_result -> string
+val completion_contract_result_of_contract_status :
+  Keeper_contract_classifier.contract_status -> completion_contract_result
 val encode_tool_list : string list -> string
 val encode_contract_violation_reason :
   called_tools:string list ->
@@ -107,7 +107,7 @@ type t = {
   canonical_tools : string list;
   unexpected_tools : string list;
   tools_used : string list;
-  tool_contract_result : tool_contract_result;
+  completion_contract_result : completion_contract_result;
   tool_surface : tool_surface;
   sandbox_kind : Keeper_types_profile_sandbox.sandbox_profile;
   sandbox_root : string option;

--- a/lib/keeper/keeper_health_probe.ml
+++ b/lib/keeper/keeper_health_probe.ml
@@ -18,7 +18,7 @@ type runtime_pressure_class =
   | Provider_error
   | Turn_stale_timeout
   | Keeper_liveness_failure
-  | Tool_contract_failure
+  | Completion_contract_failure
   | Runtime_failure
 
 let runtime_pressure_class_to_string = function
@@ -30,7 +30,7 @@ let runtime_pressure_class_to_string = function
   | Provider_error -> "provider_error"
   | Turn_stale_timeout -> "turn_stale_timeout"
   | Keeper_liveness_failure -> "keeper_liveness_failure"
-  | Tool_contract_failure -> "tool_contract_failure"
+  | Completion_contract_failure -> "completion_contract_failure"
   | Runtime_failure -> "runtime_failure"
 ;;
 
@@ -46,8 +46,8 @@ let runtime_pressure_class_of_label label =
   | "turn_stale_timeout" | "stale_turn_timeout" -> Some Turn_stale_timeout
   | "keeper_liveness_failure" | "heartbeat_failures" | "turn_failures" ->
     Some Keeper_liveness_failure
-  | "tool_contract_failure" ->
-    Some Tool_contract_failure
+  | "completion_contract_failure" ->
+    Some Completion_contract_failure
   | "runtime_failure" | "fiber_unresolved" | "exception" -> Some Runtime_failure
   | _ -> None
 ;;

--- a/lib/keeper/keeper_health_probe.mli
+++ b/lib/keeper/keeper_health_probe.mli
@@ -25,7 +25,7 @@ type runtime_pressure_class =
   | Provider_error
   | Turn_stale_timeout
   | Keeper_liveness_failure
-  | Tool_contract_failure
+  | Completion_contract_failure
   | Runtime_failure
 
 val runtime_pressure_class_to_string : runtime_pressure_class -> string

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -28,8 +28,8 @@ type hook_accumulator = Keeper_run_tools_hook_accumulator.hook_accumulator =
   ; mutable tool_surface : tool_surface_metrics
   ; mutable requested_tool_names : string list
   ; mutable requested_tool_names_seen : string list
-  ; mutable receipt_tool_contract_result :
-      Keeper_execution_receipt.tool_contract_result
+  ; mutable receipt_completion_contract_result :
+      Keeper_execution_receipt.completion_contract_result
   }
 
 type hook_outputs = Keeper_run_tools_hook_accumulator.hook_outputs =
@@ -41,8 +41,8 @@ type hook_outputs = Keeper_run_tools_hook_accumulator.hook_outputs =
   ; out_tool_surface : tool_surface_metrics
   ; out_requested_tool_names : string list
   ; out_requested_tool_names_seen : string list
-  ; out_receipt_tool_contract_result :
-      Keeper_execution_receipt.tool_contract_result
+  ; out_receipt_completion_contract_result :
+      Keeper_execution_receipt.completion_contract_result
   }
 
 let freeze = Keeper_run_tools_hook_accumulator.freeze

--- a/lib/keeper/keeper_run_tools.mli
+++ b/lib/keeper/keeper_run_tools.mli
@@ -26,8 +26,8 @@ type hook_accumulator =
   ; mutable tool_surface : tool_surface_metrics
   ; mutable requested_tool_names : string list
   ; mutable requested_tool_names_seen : string list
-  ; mutable receipt_tool_contract_result :
-      Keeper_execution_receipt.tool_contract_result
+  ; mutable receipt_completion_contract_result :
+      Keeper_execution_receipt.completion_contract_result
   }
 
 (** Immutable snapshot of hook outputs after OAS execution completes. *)
@@ -40,8 +40,8 @@ type hook_outputs =
   ; out_tool_surface : tool_surface_metrics
   ; out_requested_tool_names : string list
   ; out_requested_tool_names_seen : string list
-  ; out_receipt_tool_contract_result :
-      Keeper_execution_receipt.tool_contract_result
+  ; out_receipt_completion_contract_result :
+      Keeper_execution_receipt.completion_contract_result
   }
 
 val freeze : hook_accumulator -> hook_outputs

--- a/lib/keeper/keeper_run_tools_hook_accumulator.ml
+++ b/lib/keeper/keeper_run_tools_hook_accumulator.ml
@@ -22,8 +22,8 @@ type hook_accumulator =
   ; mutable tool_surface : tool_surface_metrics
   ; mutable requested_tool_names : string list
   ; mutable requested_tool_names_seen : string list
-  ; mutable receipt_tool_contract_result :
-      Keeper_execution_receipt.tool_contract_result
+  ; mutable receipt_completion_contract_result :
+      Keeper_execution_receipt.completion_contract_result
   }
 
 type hook_outputs =
@@ -35,8 +35,8 @@ type hook_outputs =
   ; out_tool_surface : tool_surface_metrics
   ; out_requested_tool_names : string list
   ; out_requested_tool_names_seen : string list
-  ; out_receipt_tool_contract_result :
-      Keeper_execution_receipt.tool_contract_result
+  ; out_receipt_completion_contract_result :
+      Keeper_execution_receipt.completion_contract_result
   }
 
 let freeze (acc : hook_accumulator) : hook_outputs =
@@ -48,7 +48,7 @@ let freeze (acc : hook_accumulator) : hook_outputs =
   ; out_tool_surface = acc.tool_surface
   ; out_requested_tool_names = acc.requested_tool_names
   ; out_requested_tool_names_seen = acc.requested_tool_names_seen
-  ; out_receipt_tool_contract_result = acc.receipt_tool_contract_result
+  ; out_receipt_completion_contract_result = acc.receipt_completion_contract_result
   }
 ;;
 

--- a/lib/keeper/keeper_run_tools_hook_accumulator.mli
+++ b/lib/keeper/keeper_run_tools_hook_accumulator.mli
@@ -10,8 +10,8 @@ type hook_accumulator =
   ; mutable tool_surface : Keeper_agent_tool_surface.tool_surface_metrics
   ; mutable requested_tool_names : string list
   ; mutable requested_tool_names_seen : string list
-  ; mutable receipt_tool_contract_result :
-      Keeper_execution_receipt.tool_contract_result
+  ; mutable receipt_completion_contract_result :
+      Keeper_execution_receipt.completion_contract_result
   }
 
 type hook_outputs =
@@ -23,8 +23,8 @@ type hook_outputs =
   ; out_tool_surface : Keeper_agent_tool_surface.tool_surface_metrics
   ; out_requested_tool_names : string list
   ; out_requested_tool_names_seen : string list
-  ; out_receipt_tool_contract_result :
-      Keeper_execution_receipt.tool_contract_result
+  ; out_receipt_completion_contract_result :
+      Keeper_execution_receipt.completion_contract_result
   }
 
 val freeze : hook_accumulator -> hook_outputs

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -136,8 +136,8 @@ let assemble_hooks
       initial_tool_surface.tool_gate_requested
       && initial_tool_surface.turn_visible_tool_names = []
     then (
-      acc.receipt_tool_contract_result <-
-        Keeper_execution_receipt.Contract_no_tool_capable_provider;
+      acc.receipt_completion_contract_result <-
+        Keeper_execution_receipt.Contract_no_capable_provider;
       Prometheus.inc_counter
         Prometheus.metric_empty_tool_universe_observed
         ~labels:

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -91,7 +91,7 @@ let prepare_agent_setup
         }
     ; requested_tool_names = []
     ; requested_tool_names_seen = []
-    ; receipt_tool_contract_result =
+    ; receipt_completion_contract_result =
         Keeper_execution_receipt.Contract_unknown
     }
   in

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -22,16 +22,16 @@ let terminal_reason_from_receipt receipt =
     json_string_opt_member "operator_disposition_reason" receipt
     |> Option.map String.lowercase_ascii
   in
-  let tool_contract_result =
-    json_string_opt_member "tool_contract_result" receipt
+  let completion_contract_result =
+    json_string_opt_member "completion_contract_result" receipt
     |> Option.map String.lowercase_ascii
   in
   let receipt_requires_tool_attention =
-    match operator_disposition, operator_disposition_reason, tool_contract_result with
+    match operator_disposition, operator_disposition_reason, completion_contract_result with
     | _, Some "tool_route_recoverable_failure", _
     | _, _, Some "needs_execution_progress"
-    | _, _, Some "tool_surface_mismatch"
-    | _, _, Some "no_tool_capable_provider"
+    | _, _, Some "surface_mismatch"
+    | _, _, Some "no_capable_provider"
     | _, _, Some "passive_only"
     | _, _, Some "violated" ->
         true
@@ -43,13 +43,13 @@ let terminal_reason_from_receipt receipt =
                        || String.equal code "success") ->
       Some
         (Keeper_turn_terminal.of_code ~source:"execution_receipt"
-           "tool_contract_unsatisfied")
+           "completion_contract_unsatisfied")
   | Some code ->
       Some (Keeper_turn_terminal.of_code ~source:"execution_receipt" code)
   | None when receipt_requires_tool_attention ->
       Some
         (Keeper_turn_terminal.of_code ~source:"execution_receipt"
-           "tool_contract_unsatisfied")
+           "completion_contract_unsatisfied")
   | None -> None
 
 (* JSON-deserialization boundary: maps a runtime_blocker_class wire
@@ -73,7 +73,7 @@ let disposition_of_runtime_blocker_class raw_blocker_class =
       Keeper_turn_disposition.Post_commit_ambiguous
   | "sdk_input_required" ->
       Keeper_turn_disposition.Input_required
-  | ("runtime_exhausted" | "no_tool_capable_provider"
+  | ("runtime_exhausted" | "no_capable_provider"
      | "provider_runtime_error") as cls ->
       Keeper_turn_disposition.Provider_error
         (Keeper_turn_terminal_code.Provider_runtime_error cls)
@@ -494,8 +494,8 @@ let execution_summary_json ~(meta : Keeper_meta_contract.keeper_meta) ~latest_re
         |> json_string_opt_member "sandbox_root"
     | None -> None
   in
-  let tool_contract_result =
-    Option.bind latest_receipt (json_string_opt_member "tool_contract_result")
+  let completion_contract_result =
+    Option.bind latest_receipt (json_string_opt_member "completion_contract_result")
   in
   let requested_tools =
     match latest_receipt with
@@ -538,7 +538,7 @@ let execution_summary_json ~(meta : Keeper_meta_contract.keeper_meta) ~latest_re
     | json -> json_string_opt_member "selected_model" json
   in
   let mutation_guard_summary =
-    match tool_contract_result with
+    match completion_contract_result with
     | Some "violated" -> "mutation_contract_violated"
     | Some ("satisfied" | "satisfied_execution" | "satisfied_completion") ->
         "mutation_contract_satisfied"
@@ -547,9 +547,9 @@ let execution_summary_json ~(meta : Keeper_meta_contract.keeper_meta) ~latest_re
   in
   `Assoc
     [
-      ("tool_contract_result", Json_util.string_opt_to_json tool_contract_result);
+      ("completion_contract_result", Json_util.string_opt_to_json completion_contract_result);
       ( "runtime_proof_status",
-        Json_util.string_opt_to_json tool_contract_result );
+        Json_util.string_opt_to_json completion_contract_result );
       ("requested_tools", Json_util.json_string_list requested_tools);
       ("tools_used", Json_util.json_string_list tools_used);
       ("unexpected_tools", Json_util.json_string_list unexpected_tools);

--- a/lib/keeper/keeper_runtime_trust_timeline.ml
+++ b/lib/keeper/keeper_runtime_trust_timeline.ml
@@ -347,8 +347,8 @@ let receipt_timeline_event receipt =
           json_string_opt_member "outcome" receipt
           |> Option.value ~default:"unknown"
         in
-        let tool_contract_result =
-          json_string_opt_member "tool_contract_result" receipt
+        let completion_contract_result =
+          json_string_opt_member "completion_contract_result" receipt
           |> Option.value ~default:"unknown"
         in
         let runtime_outcome =
@@ -365,7 +365,7 @@ let receipt_timeline_event receipt =
           match error_kind with
           | Some _ -> "bad"
           | None ->
-              if String.equal tool_contract_result "violated" then "bad"
+              if String.equal completion_contract_result "violated" then "bad"
               else if
                 String.equal runtime_outcome "passed_to_next_model"
                 || (receipt |> json_member "runtime"
@@ -383,8 +383,8 @@ let receipt_timeline_event receipt =
              ~ts_unix ~kind:"execution_receipt"
              ~title:"Execution Receipt"
              ~summary:
-               (Printf.sprintf "%s · tool_contract=%s · runtime=%s"
-                  outcome tool_contract_result runtime_outcome)
+               (Printf.sprintf "%s · completion_contract=%s · runtime=%s"
+                  outcome completion_contract_result runtime_outcome)
              ~severity ())
 
 let blocker_timeline_event ?task_id ?(goal_ids = []) ?trace_id

--- a/lib/keeper/keeper_turn_disposition.mli
+++ b/lib/keeper/keeper_turn_disposition.mli
@@ -91,8 +91,8 @@ val next_action : t -> string option
     - [External_cancel] → ["external_cancel"]
     - [Turn_wall_clock_timeout] → ["turn_wall_clock_timeout"]
     - [Runtime_attempts_exhausted] → ["runtime_attempts_exhausted"]
-    - [Tool_contract_no_tool_call] → ["tool_contract_no_tool_call"]
-    - [Tool_contract_unsatisfied] → ["tool_contract_unsatisfied"]
+    - [Completion_contract_no_progress] → ["completion_contract_no_progress"]
+    - [Completion_contract_unsatisfied] → ["completion_contract_unsatisfied"]
     - [Post_commit_ambiguous] → ["post_commit_ambiguous"]
     - [Provider_error code] → [Keeper_turn_terminal_code.to_wire code]
     - [Unknown { raw_error = "" }] → ["unknown_error"]
@@ -103,7 +103,7 @@ val to_wire : t -> string
     exactly. Unrecognised strings first try
     [Keeper_turn_terminal_code.of_wire]; if that succeeds, the result
     is wrapped via [of_termination_code] (which may itself collapse to
-    a non-Provider_error disposition such as [Tool_contract_unsatisfied]).
+    a non-Provider_error disposition such as [Completion_contract_unsatisfied]).
     Otherwise [Unknown { raw_error = wire }] is returned. *)
 val of_wire : string -> t
 
@@ -114,7 +114,7 @@ val of_wire : string -> t
 
     A runtime cause maps to a non-[Provider_error] disposition only
     when the runtime classification fully determines the operator
-    action (e.g., [Tool_required_unsatisfied → Tool_contract_unsatisfied]).
+    action (e.g., [Tool_required_unsatisfied → Completion_contract_unsatisfied]).
     Otherwise the runtime cause is preserved by wrapping with
     [Provider_error] so dashboards keep the typed runtime trace. *)
 val of_termination_code : Keeper_turn_terminal_code.t -> t

--- a/lib/keeper/keeper_turn_helpers.ml
+++ b/lib/keeper/keeper_turn_helpers.ml
@@ -244,7 +244,7 @@ let record_pre_dispatch_terminal_observation
     ; canonical_tools = []
     ; unexpected_tools = []
     ; tools_used = []
-    ; tool_contract_result = Keeper_execution_receipt.Contract_not_dispatched
+    ; completion_contract_result = Keeper_execution_receipt.Contract_not_dispatched
     ; tool_surface = pre_dispatch_tool_surface
     ; sandbox_kind = Keeper_execution_receipt.sandbox_kind_of_meta meta
     ; sandbox_root = Some (Keeper_sandbox.host_root_abs_of_meta ~config meta)

--- a/lib/keeper/keeper_turn_terminal.ml
+++ b/lib/keeper/keeper_turn_terminal.ml
@@ -66,8 +66,8 @@ let contract_code_from_error_text raw_error =
   if
     contains_ci raw_error "no ToolUse block"
     || contains_ci raw_error "returned no keeper tool"
-  then "tool_contract_no_tool_call"
-  else "tool_contract_unsatisfied"
+  then "completion_contract_no_progress"
+  else "completion_contract_unsatisfied"
 ;;
 
 let of_failure ?(post_commit_ambiguous = false) ?(tool_call_count = 0) ~raw_error err =

--- a/lib/keeper/keeper_turn_terminal_code.mli
+++ b/lib/keeper/keeper_turn_terminal_code.mli
@@ -64,7 +64,7 @@ type t =
           internal). The payload is the existing parametrised wire
           format produced by [Keeper_agent_error.terminal_reason_code_of_sdk_error]
           (e.g. ["agent_error_max_turns_exceeded:turns=10,limit=10"],
-          ["completion_contract_violation:tool_contract"],
+          ["completion_contract_violation:completion_contract"],
           ["api_error_server:502"]). PR-2.5 wraps the existing typed
           accessors in this variant so the typed bridge becomes a
           single source of truth for [Keeper_turn_terminal.t.code]

--- a/lib/keeper/keeper_unified_metrics_decision.ml
+++ b/lib/keeper/keeper_unified_metrics_decision.ml
@@ -162,7 +162,7 @@ let append_decision_record
                terminal_reason.Keeper_turn_terminal.severity) );
         ("terminal_reason_source", `String terminal_reason.source);
         ("provider_context", provider_context_json ~meta result);
-        ("tool_contract", tool_contract_json ~tool_call_count ~tools_used result);
+        ("tool_surface", tool_surface_json ~tool_call_count ~tools_used result);
         ("pending_approval_count", `Int pending_approval_count);
         ("approval_mode", Json_util.string_opt_to_json approval_mode);
         ("channel", `String (decision_channel_of_observation observation));

--- a/lib/keeper/keeper_unified_metrics_json_support.ml
+++ b/lib/keeper/keeper_unified_metrics_json_support.ml
@@ -85,7 +85,7 @@ let redacted_runtime_observation_to_json
     ]
 ;;
 
-let tool_contract_json ~(tool_call_count : int) ~(tools_used : string list)
+let tool_surface_json ~(tool_call_count : int) ~(tools_used : string list)
     (result : Keeper_agent_run.run_result option) =
   let requirement =
     match result with

--- a/lib/keeper/keeper_unified_metrics_json_support.mli
+++ b/lib/keeper/keeper_unified_metrics_json_support.mli
@@ -14,7 +14,7 @@ val provider_context_json :
 val redacted_runtime_observation_to_json :
   Runtime_observation.runtime_observation -> Yojson.Safe.t
 
-val tool_contract_json :
+val tool_surface_json :
   tool_call_count:int ->
   tools_used:string list ->
   Keeper_agent_run.run_result option ->

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -192,7 +192,7 @@ let run_keeper_cycle
                      ; reason = Keeper_meta_contract.No_tool_capable _
                      ; _
                      }) ->
-                Keeper_turn_fsm.Failure_no_tool_capable_provider
+                Keeper_turn_fsm.Failure_no_capable_provider
                   { runtime_id = runtime_id
                   ; detail = error_message
                   }
@@ -654,7 +654,7 @@ let run_keeper_cycle
                                 ; reason = Keeper_meta_contract.No_tool_capable _
                                 ; _
                                 }) ->
-                           Keeper_turn_fsm.Failure_no_tool_capable_provider
+                           Keeper_turn_fsm.Failure_no_capable_provider
                              { runtime_id = runtime_id
                              ; detail = short_preview e_str
                              }

--- a/lib/keeper/keeper_unified_turn_failure.ml
+++ b/lib/keeper/keeper_unified_turn_failure.ml
@@ -76,7 +76,7 @@ let record_failure_and_maybe_escalate
         true
       | Error sync_err ->
         let auto_pause_kind =
-          if runtime_auto_paused then "runtime" else "tool_contract"
+          if runtime_auto_paused then "runtime" else "completion_contract"
         in
         Log.Keeper.error
           "%s: %s auto-pause sync failed: %s (persistent failure remains on the crash path)"
@@ -90,7 +90,7 @@ let record_failure_and_maybe_escalate
             ; ( "site"
               , if runtime_auto_paused
                 then "auto_pause"
-                else "tool_contract_auto_pause" )
+                else "completion_contract_auto_pause" )
             ]
           ();
         false)

--- a/lib/runtime/runtime_oas_runner.ml
+++ b/lib/runtime/runtime_oas_runner.ml
@@ -45,13 +45,16 @@ let resolve_runtime_providers
       ?provider_filter:_
       ?(require_tool_choice_support = false)
       ?(require_tool_support = false)
-      ?runtime_mcp_policy
+      ?runtime_mcp_policy:_
       ~runtime_id:_
       ()
   =
+  ignore require_tool_choice_support;
+  ignore require_tool_support;
   (* RFC-0206 single-binding: runtime catalog resolution removed. The providers
-     are the default runtime's single provider_config. [provider_filter] is moot
-     with one provider. Required tool-use filter removed — concept unused. *)
+     are the default runtime's single provider_config. [provider_filter] and
+     the historical require-tool gates are moot with one provider; runtime tool
+     surface compatibility is handled by runtime MCP policy resolution. *)
   match Runtime.get_default_runtime () with
   | None -> Error "no default runtime configured"
   | Some rt ->
@@ -159,4 +162,3 @@ let cli_tool_a_cannot_carry_keeper_bound_runtime_mcp
            Runtime_agent.runtime_mcp_tool_requires_bound_actor
            policy.allowed_tool_names
     | _ -> false)
-

--- a/lib/server/server_dashboard_compact_receipt_json.ml
+++ b/lib/server/server_dashboard_compact_receipt_json.ml
@@ -65,7 +65,7 @@ let compact_receipt_tool_surface_json receipt =
   let surface =
     match json_member "tool_surface" receipt with
     | `Assoc _ as surface -> surface
-    | _ -> json_member "tool_contract" receipt
+    | _ -> `Null
   in
   match surface with
   | `Assoc _ as surface ->

--- a/lib/server/server_dashboard_http_composite_claims.ml
+++ b/lib/server/server_dashboard_http_composite_claims.ml
@@ -190,7 +190,7 @@ let composite_execution_receipt_json ~(config : Workspace.config) ~keeper_name =
       ; "operator_disposition_reason", `Null
       ; "model_used", `Null
       ; "stop_reason", `Null
-      ; "tool_contract_result", `Null
+      ; "completion_contract_result", `Null
       ; "duration_ms", `Null
       ; "error", `Null
       ; "runtime", `Null
@@ -213,8 +213,8 @@ let composite_execution_receipt_json ~(config : Workspace.config) ~keeper_name =
         )
       ; "model_used", `Null
       ; "stop_reason", Json_util.string_opt_to_json (json_string "stop_reason" receipt)
-      ; ( "tool_contract_result"
-        , Json_util.string_opt_to_json (json_string "tool_contract_result" receipt) )
+      ; ( "completion_contract_result"
+        , Json_util.string_opt_to_json (json_string "completion_contract_result" receipt) )
       ; ( "unexpected_tools"
         , Json_util.json_string_list (Json_util.get_string_list receipt "unexpected_tools") )
       ; ( "unexpected_tool_count"
@@ -292,9 +292,9 @@ let composite_snapshot_is_idle snapshot =
 
 let composite_execution_tool_route_blocked execution =
   string_opt_is_any
-    (json_string "tool_contract_result" execution)
-    [ "tool_surface_mismatch"
-    ; "no_tool_capable_provider"
+    (json_string "completion_contract_result" execution)
+    [ "surface_mismatch"
+    ; "no_capable_provider"
     ]
   || string_opt_is_any
        (json_string "operator_disposition_reason" execution)

--- a/lib/turn_fsm/turn_fsm.ml
+++ b/lib/turn_fsm/turn_fsm.ml
@@ -26,12 +26,12 @@ type failure_reason =
       base : string;
       resolved : string option;
     }
-  | Failure_no_tool_capable_provider of {
+  | Failure_no_capable_provider of {
       runtime_id : string;
       detail : string;
     }
   | Failure_provider_error of { kind : string; detail : string }
-  | Failure_tool_contract_violation of { reason_code : string }
+  | Failure_completion_contract_violation of { reason_code : string }
   | Failure_receipt_lost of {
       primary_error : string;
       fallback_path : string option;
@@ -102,9 +102,9 @@ let cancel_reason_label = function
 
 let failure_reason_label = function
   | Failure_runtime_unavailable _ -> "runtime_unavailable"
-  | Failure_no_tool_capable_provider _ -> "no_tool_capable_provider"
+  | Failure_no_capable_provider _ -> "no_capable_provider"
   | Failure_provider_error _ -> "provider_error"
-  | Failure_tool_contract_violation _ -> "tool_contract_violation"
+  | Failure_completion_contract_violation _ -> "completion_contract_violation"
   | Failure_receipt_lost _ -> "receipt_lost"
   | Failure_turn_livelock_blocked _ -> "turn_livelock_blocked"
   | Failure_runtime_error _ -> "runtime_error"
@@ -125,13 +125,13 @@ let pp_failure_reason fmt = function
       Format.fprintf fmt "runtime_unavailable(base=%s,resolved=%s)"
         base
         (Option.value resolved ~default:"-")
-  | Failure_no_tool_capable_provider { runtime_id; detail } ->
-      Format.fprintf fmt "no_tool_capable_provider(runtime=%s,detail=%s)"
+  | Failure_no_capable_provider { runtime_id; detail } ->
+      Format.fprintf fmt "no_capable_provider(runtime=%s,detail=%s)"
         runtime_id detail
   | Failure_provider_error { kind; detail } ->
       Format.fprintf fmt "provider_error(kind=%s,detail=%s)" kind detail
-  | Failure_tool_contract_violation { reason_code } ->
-      Format.fprintf fmt "tool_contract_violation(%s)" reason_code
+  | Failure_completion_contract_violation { reason_code } ->
+      Format.fprintf fmt "completion_contract_violation(%s)" reason_code
   | Failure_receipt_lost { primary_error; fallback_path } ->
       Format.fprintf fmt "receipt_lost(err=%s,fallback=%s)"
         primary_error
@@ -257,7 +257,7 @@ let classify_transition ?ctx ~(from_state: _ turn_state) ~(to_state: _ turn_stat
   | Any Runtime_routing, Any (Failed (Failure_turn_livelock_blocked _))
     when not stop_signaled_before ->
       Some LivelockBlocked
-  | Any Runtime_routing, Any (Failed (Failure_no_tool_capable_provider _))
+  | Any Runtime_routing, Any (Failed (Failure_no_capable_provider _))
     when not stop_signaled_before ->
       Some NoToolCapableProvider
   | Any Runtime_routing, Any (Failed (Failure_provider_error _))
@@ -274,7 +274,7 @@ let classify_transition ?ctx ~(from_state: _ turn_state) ~(to_state: _ turn_stat
       Some ToolReturned
   | Any Streaming, Any Completing when not stop_signaled_before ->
       Some StreamComplete
-  | Any Streaming, Any (Failed (Failure_tool_contract_violation _))
+  | Any Streaming, Any (Failed (Failure_completion_contract_violation _))
     when not stop_signaled_before ->
       Some ContractViolation
   | Any Streaming, Any (Failed (Failure_receipt_lost _))
@@ -288,7 +288,7 @@ let classify_transition ?ctx ~(from_state: _ turn_state) ~(to_state: _ turn_stat
       Some ProviderTimeout
   | Any Completing, Any Done when not stop_signaled_before ->
       Some ContractOk
-  | Any Completing, Any (Failed (Failure_tool_contract_violation _))
+  | Any Completing, Any (Failed (Failure_completion_contract_violation _))
     when not stop_signaled_before ->
       Some ContractViolation
   | Any Completing, Any (Failed (Failure_receipt_lost _))

--- a/lib/turn_fsm/turn_fsm.mli
+++ b/lib/turn_fsm/turn_fsm.mli
@@ -26,12 +26,12 @@ type failure_reason =
       base : string;
       resolved : string option;
     }
-  | Failure_no_tool_capable_provider of {
+  | Failure_no_capable_provider of {
       runtime_id : string;
       detail : string;
     }
   | Failure_provider_error of { kind : string; detail : string }
-  | Failure_tool_contract_violation of { reason_code : string }
+  | Failure_completion_contract_violation of { reason_code : string }
   | Failure_receipt_lost of {
       primary_error : string;
       fallback_path : string option;

--- a/scripts/audit-keeper-fleet-readiness.py
+++ b/scripts/audit-keeper-fleet-readiness.py
@@ -314,11 +314,6 @@ def tools_from_decision(row: dict[str, Any]) -> list[str]:
         values = row.get(key)
         if isinstance(values, list):
             tools.extend(v for v in values if isinstance(v, str))
-    contract = row.get("tool_contract")
-    if isinstance(contract, dict):
-        values = contract.get("tools_used")
-        if isinstance(values, list):
-            tools.extend(v for v in values if isinstance(v, str))
     calls = row.get("tool_calls")
     if isinstance(calls, list):
         for call in calls:

--- a/scripts/keeper-turn-slot-evidence.sh
+++ b/scripts/keeper-turn-slot-evidence.sh
@@ -93,7 +93,7 @@ for f in "${files[@]}"; do
         end;
       def tool_count:
         (.tool_call_count | n) as $top
-        | if $top > 0 then $top else (.tool_contract.tool_call_count | n) end;
+        | if $top > 0 then $top else (.tool_surface.visible_tool_count | n) end;
       def turn_mode: (.turn_mode // .result_kind // "");
       def is_normal_success:
         (.outcome == "success")

--- a/test/test_keeper_contract_classifier_pure.ml
+++ b/test/test_keeper_contract_classifier_pure.ml
@@ -44,10 +44,10 @@ let test_signal_label_none () =
 
 (* ── contract_status_label ───────────────────────────────────────────── *)
 
-let test_status_label_tool_surface_mismatch () =
+let test_status_label_surface_mismatch () =
   let rendered =
     Format.asprintf "%a" KCC.pp_contract_status
-      (KCC.Tool_surface_mismatch { missing = [ "keeper_task_claim"; "masc_broadcast" ] })
+      (KCC.Surface_mismatch { missing = [ "keeper_task_claim"; "masc_broadcast" ] })
   in
   (* The stable label is intentionally low-cardinality; the pretty printer
      carries missing tool names for grep/debug output. *)
@@ -115,8 +115,8 @@ let () =
         ] );
       ( "contract_status_label",
         [
-          Alcotest.test_case "Tool_surface_mismatch carries missing names"
-            `Quick test_status_label_tool_surface_mismatch;
+          Alcotest.test_case "Surface_mismatch carries missing names"
+            `Quick test_status_label_surface_mismatch;
           Alcotest.test_case "Satisfied_completion stable token" `Quick
             test_status_label_satisfied_completion;
           Alcotest.test_case "Satisfied_execution stable token" `Quick

--- a/test/test_keeper_disposition_budget.ml
+++ b/test/test_keeper_disposition_budget.ml
@@ -41,7 +41,7 @@ let () =
     ; "agent_error_tripwire_violation:tripwire=y"
     ; "agent_error_idle_detected:consecutive_idle_turns=3"
     ; "agent_error_exit_condition_met:turn=4"
-    ; "completion_contract_violation:tool_contract"
+    ; "completion_contract_violation:completion_contract"
     ; "api_error_timeout"
     ; "provider_error"
     ; "runtime_exhausted"

--- a/test/test_keeper_reaction_ledger.ml
+++ b/test/test_keeper_reaction_ledger.ml
@@ -131,7 +131,7 @@ let test_execution_receipt_links_to_reaction_ledger () =
       [ "schema", `String "keeper.execution_receipt.v1"
       ; "trace_id", `String "trace-1"
       ; "outcome", `String "receipt_failed"
-      ; "terminal_reason_code", `String "tool_contract_violation"
+      ; "terminal_reason_code", `String "completion_contract_violation"
       ]
   in
   Keeper_reaction_ledger.record_execution_receipt_reaction
@@ -142,7 +142,7 @@ let test_execution_receipt_links_to_reaction_ledger () =
     ~current_task_id:(Some "task-275")
     ~goal_ids:[ "goal-world-reactivity-p0-20260517" ]
     ~outcome:"receipt_failed"
-    ~terminal_reason_code:"tool_contract_violation"
+    ~terminal_reason_code:"completion_contract_violation"
     ~receipt_json
     ();
   let row =
@@ -155,7 +155,7 @@ let test_execution_receipt_links_to_reaction_ledger () =
   check_member_string "terminal reaction kind" "terminal_reason" "kind" reaction;
   check_member_string
     "terminal reason"
-    "tool_contract_violation"
+    "completion_contract_violation"
     "terminal_reason_code"
     reaction;
   check_member_string

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -832,7 +832,7 @@ let test_sweep_restores_reconcile_gate_for_paused_keeper () =
               last_blocker =
                 Some
                   (Keeper_meta_contract.blocker_info_of_class
-                     ~detail:"turn outcome ambiguous after committed mutating tool call(s): [keeper_board_post]; retry disabled to avoid duplicate mutation; original_error=Completion contract [tool_contract] violated"
+                     ~detail:"turn outcome ambiguous after committed mutating tool call(s): [keeper_board_post]; retry disabled to avoid duplicate mutation; original_error=Completion contract [completion_contract] violated"
                      Keeper_meta_contract.Ambiguous_post_commit_timeout);
             };
         }

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -50,8 +50,8 @@ let roundtrip_corpus =
   ; "api_error_context_overflow"
   ; "api_error_oas_agent_execution_timeout"
     (* completion-contract-violation (legacy + enriched forms) *)
-  ; "completion_contract_violation:tool_contract"
-  ; "completion_contract_violation:tool_contract:called[a,b]:satisfying[c]"
+  ; "completion_contract_violation:completion_contract"
+  ; "completion_contract_violation:completion_contract:called[a,b]:satisfying[c]"
     (* turn-livelock *)
   ; "turn_livelock:stuck_age_exceeded"
     (* budget cut-offs *)
@@ -62,7 +62,7 @@ let roundtrip_corpus =
   ; "provider_error_server:500"
   ; "provider_error_missing_api_key"
   ; "provider_error_hard_quota:openai"
-  ; "no_tool_capable_provider"
+  ; "no_capable_provider"
   ; "mcp_error"
   ; "serialization_error"
   ; "io_error"
@@ -183,8 +183,8 @@ let frozen_operator_disposition (receipt : R.t)
   else (
     let tool_route_failure =
       List.mem
-        receipt.tool_contract_result
-        [ R.Contract_tool_surface_mismatch; R.Contract_no_tool_capable_provider ]
+        receipt.completion_contract_result
+        [ R.Contract_surface_mismatch; R.Contract_no_capable_provider ]
     in
     if tool_route_failure
     then
@@ -205,7 +205,7 @@ let frozen_operator_disposition (receipt : R.t)
     else if
       receipt.outcome = `Ok
       && receipt.runtime_outcome = R.Runtime_not_dispatched
-      && receipt.tool_contract_result = R.Contract_not_dispatched
+      && receipt.completion_contract_result = R.Contract_not_dispatched
       && String.equal terminal_reason "pre_dispatch_success"
     then R.Disp_pass, R.Reason_healthy
     else (
@@ -255,7 +255,7 @@ let base_receipt : R.t =
   ; canonical_tools = []
   ; unexpected_tools = []
   ; tools_used = []
-  ; tool_contract_result = R.Contract_unknown
+  ; completion_contract_result = R.Contract_unknown
   ; tool_surface = base_tool_surface
   ; sandbox_kind = Masc.Keeper_types_profile_sandbox.Local
   ; sandbox_root = None
@@ -313,11 +313,11 @@ let runtime_outcomes =
   ; R.Runtime_not_dispatched
   ]
 
-let tool_contract_results =
+let completion_contract_results =
   [ R.Contract_unknown
   ; R.Contract_not_dispatched
-  ; R.Contract_no_tool_capable_provider
-  ; R.Contract_tool_surface_mismatch
+  ; R.Contract_no_capable_provider
+  ; R.Contract_surface_mismatch
   ; R.Contract_needs_execution_progress
   ; R.Contract_satisfied_completion
   ]
@@ -361,7 +361,7 @@ let () =
                                             ; degraded_retry_applied = degraded
                                             ; runtime_fallback_applied = fallback
                                             ; runtime_outcome
-                                            ; tool_contract_result = tcr
+                                            ; completion_contract_result = tcr
                                             ; tools_used
                                             ; outcome
                                             }
@@ -388,7 +388,7 @@ let () =
                                                    (R.outcome_kind_to_string outcome)
                                                    (R.runtime_outcome_to_string
                                                       runtime_outcome)
-                                                   (R.tool_contract_result_to_string tcr)
+                                                   (R.completion_contract_result_to_string tcr)
                                                    (tools_used <> [])
                                                    degraded
                                                    fallback
@@ -397,7 +397,7 @@ let () =
                                                 false))
                                        outcomes)
                                   tools_used_variants)
-                             tool_contract_results)
+                             completion_contract_results)
                         runtime_outcomes)
                    fallback_bools)
               degraded_bools)

--- a/test/test_keeper_turn_fsm_emit.ml
+++ b/test/test_keeper_turn_fsm_emit.ml
@@ -54,9 +54,9 @@ let test_turn_state_labels_cover_every_variant () =
     ; F.Any (F.Failed (F.Failure_runtime_error "x")), "failed:runtime_error"
     ; ( F.Any
           (F.Failed
-             (F.Failure_no_tool_capable_provider
+             (F.Failure_no_capable_provider
                 { runtime_id = "tools"; detail = "no candidate supports tools" }))
-      , "failed:no_tool_capable_provider" )
+      , "failed:no_capable_provider" )
     ; F.Any (F.Cancelled F.Cancelled_phase_gate_close), "cancelled:phase_gate_close"
     ]
   in
@@ -104,7 +104,7 @@ let test_transition_actions_cover_tla_next () =
     ~from_state:F.Runtime_routing
     ~to_state:
       (F.Failed
-         (F.Failure_no_tool_capable_provider
+         (F.Failure_no_capable_provider
             { runtime_id = "tools"; detail = "no provider supports requested tool surface" }));
   check_action
     F.ProviderError
@@ -123,7 +123,7 @@ let test_transition_actions_cover_tla_next () =
     F.ContractViolation
     ~from_state:F.Streaming
     ~to_state:
-      (F.Failed (F.Failure_tool_contract_violation { reason_code = "tool_contract" }));
+      (F.Failed (F.Failure_completion_contract_violation { reason_code = "completion_contract" }));
   check_action
     F.ReceiptLost
     ~from_state:F.Streaming
@@ -143,7 +143,7 @@ let test_transition_actions_cover_tla_next () =
     F.ContractViolation
     ~from_state:F.Completing
     ~to_state:
-      (F.Failed (F.Failure_tool_contract_violation { reason_code = "passive_only" }));
+      (F.Failed (F.Failure_completion_contract_violation { reason_code = "passive_only" }));
   check_action
     F.ReceiptLost
     ~from_state:F.Completing
@@ -355,11 +355,11 @@ let test_failure_reason_labels_documented () =
   let pairs : (F.failure_reason * string) list =
     [ ( F.Failure_runtime_unavailable { base = "ollama:7b"; resolved = None }
       , "runtime_unavailable" )
-    ; ( F.Failure_no_tool_capable_provider
+    ; ( F.Failure_no_capable_provider
           { runtime_id = "tools"; detail = "no candidate supports tools" }
-      , "no_tool_capable_provider" )
+      , "no_capable_provider" )
     ; F.Failure_provider_error { kind = "k"; detail = "d" }, "provider_error"
-    ; F.Failure_tool_contract_violation { reason_code = "rc" }, "tool_contract_violation"
+    ; F.Failure_completion_contract_violation { reason_code = "rc" }, "completion_contract_violation"
     ; F.Failure_receipt_lost { primary_error = "e"; fallback_path = None }, "receipt_lost"
     ; ( F.Failure_turn_livelock_blocked { reason = "stuck_after_sec" }
       , "turn_livelock_blocked" )

--- a/test/test_keeper_turn_terminal_disposition_field.ml
+++ b/test/test_keeper_turn_terminal_disposition_field.ml
@@ -28,7 +28,7 @@ let constructor_cases : (string * T.t) list =
   ; "of_code/explicit", T.of_code "post_commit_ambiguous"
   ; "of_code/legacy_persisted/completed", T.of_code "completed"
   ; ( "of_code/sdk_error/contract_violation"
-    , T.of_code "completion_contract_violation:tool_contract" )
+    , T.of_code "completion_contract_violation:completion_contract" )
   ; "of_code/sdk_error/api_error_timeout", T.of_code "api_error_timeout"
   ; "of_code/sdk_error/api_error_overloaded", T.of_code "api_error_overloaded"
   ; ( "of_code/sdk_error/agent_error_max_turns"
@@ -38,7 +38,7 @@ let constructor_cases : (string * T.t) list =
   ; "of_code/turn_wall_clock", T.of_code "turn_wall_clock_timeout"
   ; "of_code/turn_overflow_pause", T.of_code "turn_overflow_pause"
   ; "of_code/turn_livelock_pause", T.of_code "turn_livelock_pause"
-  ; "of_code/tool_contract", T.of_code "tool_contract_no_tool_call"
+  ; "of_code/completion_contract", T.of_code "completion_contract_no_progress"
   ]
 ;;
 

--- a/test/test_keeper_typed_labels.ml
+++ b/test/test_keeper_typed_labels.ml
@@ -60,9 +60,9 @@ let test_cancel_reason_labels_unique () =
 let all_failure_reasons : Keeper_turn_fsm.failure_reason list =
   [
     Failure_runtime_unavailable { base = "x"; resolved = None };
-    Failure_no_tool_capable_provider { runtime_id = "x"; detail = "d" };
+    Failure_no_capable_provider { runtime_id = "x"; detail = "d" };
     Failure_provider_error { kind = "k"; detail = "d" };
-    Failure_tool_contract_violation { reason_code = "rc" };
+    Failure_completion_contract_violation { reason_code = "rc" };
     Failure_receipt_lost { primary_error = "e"; fallback_path = None };
     Failure_runtime_error "msg";
     Failure_unexpected_exception { exn = "exn"; backtrace = None };
@@ -208,7 +208,7 @@ let test_is_actionable_matches_variants () =
 let all_contract_statuses
     : Keeper_contract_classifier.contract_status list =
   [
-    Tool_surface_mismatch { missing = [ "x" ] };
+    Surface_mismatch { missing = [ "x" ] };
     Claim_only_after_owned_task;
     Needs_execution_progress;
     Passive_only;
@@ -227,7 +227,7 @@ let test_contract_status_labels_unique () =
 let test_pp_contract_status_surfaces_missing_list () =
   let s =
     format_to_string Keeper_contract_classifier.pp_contract_status
-      (Tool_surface_mismatch { missing = [ "keeper_task_claim"; "masc_claim_next" ] })
+      (Surface_mismatch { missing = [ "keeper_task_claim"; "masc_claim_next" ] })
   in
   Alcotest.(check bool)
     "pp_contract_status surfaces first missing tool"

--- a/test/test_keeper_unified_claim_progress.ml
+++ b/test/test_keeper_unified_claim_progress.ml
@@ -33,10 +33,10 @@ let test_claim_tool_classification_covers_supported_claim_tools () =
 
 let test_claim_contract_result_counts_initial_claim_as_execution () =
   let result ?(had_owned_active_task_at_turn_start = false) tools =
-    KAR.tool_contract_result_for_observed_tools
+    KAR.completion_contract_result_for_progress_evidence
       ~had_owned_active_task_at_turn_start
       ~actual_keeper_tool_names:tools
-    |> Masc.Keeper_execution_receipt.tool_contract_result_to_string
+    |> Masc.Keeper_execution_receipt.completion_contract_result_to_string
   in
   check
     string

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -381,7 +381,7 @@ let test_lightweight_snapshot_surfaces_paused_keeper_runtime_trust () =
                   Some
                     (Keeper_meta_contract.blocker_info_of_class
                       ~detail:
-                         "Completion contract [tool_contract] violated: no ToolUse block"
+                         "Completion contract [completion_contract] violated: no ToolUse block"
                        Keeper_meta_contract.Completion_contract_violation);
               };
           }
@@ -401,11 +401,11 @@ let test_lightweight_snapshot_surfaces_paused_keeper_runtime_trust () =
             ("turn_count", `Int 12);
             ("outcome", `String "error");
             ( "terminal_reason_code",
-              `String "completion_contract_violation:tool_contract" );
+              `String "completion_contract_violation:completion_contract" );
             ("operator_disposition", `String "pause_human");
             ( "operator_disposition_reason",
               `String "unmapped_runtime_state" );
-            ( "tool_contract_result",
+            ( "completion_contract_result",
               `String "violated" );
             ("tools_used", `List []);
             ( "tool_surface",
@@ -457,7 +457,7 @@ let test_lightweight_snapshot_surfaces_paused_keeper_runtime_trust () =
         "unmapped_runtime_state"
         (trust |> member "operator_disposition_reason" |> to_string);
       Alcotest.(check string) "terminal code preserved"
-        "completion_contract_violation:tool_contract"
+        "completion_contract_violation:completion_contract"
         (trust |> member "latest_terminal_reason" |> member "code"
        |> to_string);
       Operator_control.invalidate_snapshot_cache ();
@@ -643,7 +643,7 @@ let test_lightweight_snapshot_preserves_receipt_latest_causal_event () =
             ("outcome", `String "ok");
             ("operator_disposition", `String "pass");
             ("operator_disposition_reason", `String "healthy");
-            ("tool_contract_result", `String "satisfied");
+            ("completion_contract_result", `String "satisfied");
             ("tools_used", `List [ `String "keeper_status" ]);
             ("requested_tools", `List [ `String "keeper_status" ]);
             ( "runtime",


### PR DESCRIPTION
## Summary

- Rename keeper execution contract surfaces from tool-contract wording to completion-contract wording.
- Remove the nested `completion_contract` JSON block that duplicated tool counts and tool requirement details.
- Keep tool-use/read-model information under `tool_surface` and `tools_used`, including dashboard compact receipt fallback.

## Root Cause

`#19956` removed required tool-use semantics, but keeper receipt/turn FSM/dashboard labels still exposed contract state as if it were a tool contract. That kept completion/progress contract state coupled to tool availability/read-model details.

## Verification

- `scripts/check-oas-pin.sh --local-only`
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=/private/tmp/masc-completion-contract-decouple-build4 dune build --root . .`
