### PR TITLE
chore(codex-purge): drop Codex/Codex mentions from lib/ and test/ (PR2 of Codex purge)

### DIFF
--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -138,7 +138,13 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_BOOTSTRAP_MAX_SCAN` | typed:int | unclassified | unclassified | 28 | Max keeper meta files to scan during bootstrap |
 | `MASC_KEEPER_BOOTSTRAP_POST_STARTUP_SETTLE_SEC` | typed:float | unclassified | unclassified | 70 | Settle delay (seconds) between lazy-startup completion and the keeper bootstrap fan-out. The autoboot fiber sleeps fo... |
 | `MASC_KEEPER_BOOTSTRAP_STALE_TURN_SEC` | typed:float | unclassified | unclassified | 24 | Keeper considered stale when last turn exceeds this threshold (seconds) |
+<<<<<<< HEAD
 | `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 510 | Stdout-idle timeout for CLI subprocess transports (Anthropic CLI today; other CLI transports may need an ... |
+||||||| parent of 28302b6aa5 (chore(codex-purge): also drop Claude and Gemini from CLI usage examples)
+| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 510 | Stdout-idle timeout for CLI subprocess transports (Anthropic CLI today; Claude Code / Gemini CLI need an ... |
+=======
+| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 510 | Stdout-idle timeout for CLI subprocess transports (Anthropic CLI today; other CLI transports may need an ...
+>>>>>>> 28302b6aa5 (chore(codex-purge): also drop Claude and Gemini from CLI usage examples)
 | `MASC_KEEPER_CRASH_PERSIST_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 163 | Crash persistence drain fiber wake interval in seconds. Drain fiber batches in-memory crash events and persists them ... |
 | `MASC_KEEPER_DEBUG` | feature_flag | n/a | n/a | 182 | Enable keeper debug logging. Default: false. |
 | `MASC_KEEPER_DELIBERATION_DAILY_BUDGET_USD` | typed:float | unclassified | unclassified | 188 | Daily budget for keeper deliberation (USD). Default: 0.10. Re-readable within the process. Live operator control shou... |

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -138,7 +138,7 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_BOOTSTRAP_MAX_SCAN` | typed:int | unclassified | unclassified | 28 | Max keeper meta files to scan during bootstrap |
 | `MASC_KEEPER_BOOTSTRAP_POST_STARTUP_SETTLE_SEC` | typed:float | unclassified | unclassified | 70 | Settle delay (seconds) between lazy-startup completion and the keeper bootstrap fan-out. The autoboot fiber sleeps fo... |
 | `MASC_KEEPER_BOOTSTRAP_STALE_TURN_SEC` | typed:float | unclassified | unclassified | 24 | Keeper considered stale when last turn exceeds this threshold (seconds) |
-| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 510 | Stdout-idle timeout for CLI subprocess transports (Anthropic CLI today; other CLI transports may need an ...
+| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 510 | Stdout-idle timeout for CLI subprocess transports (Anthropic CLI today; other CLI transports may need an ... |
 | `MASC_KEEPER_CRASH_PERSIST_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 163 | Crash persistence drain fiber wake interval in seconds. Drain fiber batches in-memory crash events and persists them ... |
 | `MASC_KEEPER_DEBUG` | feature_flag | n/a | n/a | 182 | Enable keeper debug logging. Default: false. |
 | `MASC_KEEPER_DELIBERATION_DAILY_BUDGET_USD` | typed:float | unclassified | unclassified | 188 | Daily budget for keeper deliberation (USD). Default: 0.10. Re-readable within the process. Live operator control shou... |

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -494,8 +494,8 @@ module KeeperKeepalive = struct
   ;;
 
   (** Stdout-idle timeout for CLI subprocess transports (Anthropic CLI today;
-      Claude Code / Gemini CLI / Codex CLI need an OAS upstream change to
-      expose [stdout_idle_timeout_s] in their transport configs).
+      other CLI providers need an OAS upstream change to expose
+      [stdout_idle_timeout_s] in their transport configs).
       The CLI subprocess is aborted via SIGINT if no stdout line arrives
       within this many seconds. Read fresh per-turn via
       {!Keeper_runtime_resolved.cli_subprocess_idle_sec}.

--- a/lib/eval_harness.mli
+++ b/lib/eval_harness.mli
@@ -134,7 +134,7 @@ val check_tool_expectations :
 val compute_pass_at_k : k:int -> n:int -> c:int -> float
 (** Probability of at least one pass in [k] independent runs given
     [c] successes out of [n] total. The unbiased estimator from the
-    Codex / METR papers. *)
+    agent-eval / METR literature. *)
 
 val summarize_runs :
   scenario:scenario -> k:int -> eval_run list -> eval_result

--- a/lib/exec/exec_budget.ml
+++ b/lib/exec/exec_budget.ml
@@ -3,8 +3,8 @@
    warnings when the agent approaches or exceeds the configured limit.
    Soft limit = warning in response; hard limit = execution blocked.
 
-   Inspired by OpenAI Codex Harness "loop budget" — one of the top-3
-   safety requirements for autonomous agents. *)
+   Inspired by the agent harness "loop budget" concept — one of the
+   top-3 safety requirements for autonomous agents. *)
 
 type t = {
   mutable count : int;

--- a/lib/exec/exec_semantic.mli
+++ b/lib/exec/exec_semantic.mli
@@ -7,10 +7,10 @@
       exit status of a command that already ran?"} (post-exec hint).
 
     Inspired by agent_llm_a-code's [interpretCommandResult] in
-    [src/utils/Shell.ts]. The OpenAI Codex harness blog posts
-    ("harness-engineering", "unlocking-the-agent_code-harness") frame this
-    as turning raw OS return codes into typed markers the agent loop
-    can reason over without string scraping.
+    [src/utils/Shell.ts]. The agent harness literature
+    ("harness-engineering" et al.) frames this as turning raw OS return
+    codes into typed markers the agent loop can reason over without
+    string scraping.
 
     Rollout: additive JSON field. Gated by [MASC_BASH_SEMANTIC_EXIT]
     env flag during the bake-in window (see

--- a/lib/exec/output_parse.mli
+++ b/lib/exec/output_parse.mli
@@ -4,7 +4,7 @@
     machine-readable JSON fields.  Every parser is total and returns
     [Some json] on a confident match or [None] to decline (fail-open).
 
-    Inspired by OpenAI Codex harness blog posts ("harness-engineering"):
+    Inspired by agent harness literature ("harness-engineering" et al.):
     agents waste tokens on fragile regex parsing of raw text.  This
     layer turns common outputs into typed JSON that the agent can
     consume directly. *)

--- a/lib/jsonl_atomic/jsonl_atomic.ml
+++ b/lib/jsonl_atomic/jsonl_atomic.ml
@@ -18,7 +18,7 @@ let mutex_registry_mu = Stdlib.Mutex.create ()
 (* Resolve ["." ] and [".."] segments without requiring file existence
    (so [open_writer] can canonicalize before the file is created).
    Relative paths are anchored at the process cwd at call time. This
-   collapses the common spelling variants flagged by Codex review of
+   collapses the common spelling variants flagged by review of
    PR #15906; symlink resolution is intentionally out of scope (would
    need [realpath] which fails on missing paths). *)
 let canonicalize_path path =
@@ -64,7 +64,7 @@ let open_writer ~sw ~fs ~path =
      [Eio.Path.mkdirs] on the fs-scoped path matches how [open_out]
      below resolves the same path. The previous [Unix.mkdir] sibling
      resolved against process cwd, which is wrong for scoped fs
-     handles (flagged by Codex review of PR #15906). *)
+     handles (flagged by review of PR #15906). *)
   let dir = Filename.dirname path in
   if dir <> "" && dir <> "." && dir <> "/" then begin
     let eio_dir = Eio.Path.(fs / dir) in

--- a/lib/keeper/keeper_cli_mcp_config.ml
+++ b/lib/keeper/keeper_cli_mcp_config.ml
@@ -6,7 +6,7 @@
    entry and the keeper cannot reach the masc HTTP
    endpoint; tool calls surface as "tool not in session's tool
    registry". See #10049 for the full root-cause analysis and the
-   cli_tool_a sibling path in [server_runtime_bootstrap.sync_codex_mcp_config].
+   cli_tool_a sibling path in [server_runtime_bootstrap.sync_cli_agent_mcp_config].
 
    Gated behind [MASC_AUTO_CONSTRUCT_CLAUDE_MCP] (default true since
    #10059 validation; the legacy explicit-env path still wins when

--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -43,7 +43,7 @@ let emergency_compact_ratio_threshold : float =
      get_float ~default collapses (1) and (3) into the same float value,
      making operator typos (e.g. "foo" or "0,9" with comma) indistinguishable
      from the unset case. The subsequent Float.equal raw default_value check
-     then suppresses the warn path entirely. (Codex P2 review of PR #15782.) *)
+     then suppresses the warn path entirely. (Review on PR #15782.) *)
   let effective =
     match Sys.getenv_opt env_var with
     | None -> default_value

--- a/lib/keeper/keeper_memory_recall.ml
+++ b/lib/keeper/keeper_memory_recall.ml
@@ -706,7 +706,7 @@ let history_user_messages_from_lines
               Behavior preserved — we still drop this line and return
               [None]; only logging + counter are added.
 
-              Codex P1 follow-up: the [exception_class] label is now a
+              P1 follow-up: the [exception_class] label is now a
               4-value closed sum from [Keeper_memory_recall_exn_class]
               (constructor-level match on the [exn] type, not a
               substring scan on [Printexc.to_string]) so the metric

--- a/lib/keeper/keeper_memory_recall_exn_class.mli
+++ b/lib/keeper/keeper_memory_recall_exn_class.mli
@@ -9,7 +9,7 @@
     detail (byte offsets, file paths, payload fragments from
     [Yojson.Json_error]; per-syscall context from [Unix.Unix_error]; raw
     [Failure] messages) so each distinct exception instance created a new
-    Prometheus time-series. Codex P1 flagged this as unbounded label
+    Prometheus time-series. Review on PR #15781 flagged this as unbounded label
     cardinality / balloonable in-process metric memory.
 
     [classify] is a *constructor-level* pattern match on the OCaml [exn]

--- a/lib/provider_tool_support.ml
+++ b/lib/provider_tool_support.ml
@@ -70,10 +70,9 @@ let fallback_tool_policy_for_kind kind =
 let tool_policy_for_kind kind = fallback_tool_policy_for_kind kind
 ;;
 
-(** Whether the resolved provider config is a CLI runtime (Claude Code,
-    Codex CLI, Gemini CLI, Anthropic CLI).  MASC uses this only for local
-    tool-delivery projection after OAS has resolved provider/model
-    capabilities. *)
+(** Whether the resolved provider config is a CLI runtime (Anthropic CLI).
+    MASC uses this only for local tool-delivery projection after OAS has
+    resolved provider/model capabilities. *)
 let is_cli_agent_provider (_provider_cfg : Llm_provider.Provider_config.t) =
   (* CLI subprocess provider kinds were removed in the agent_sdk pin bump;
      no provider kind is a subprocess CLI. *)
@@ -86,10 +85,10 @@ let is_cli_agent_provider (_provider_cfg : Llm_provider.Provider_config.t) =
     [oas_capabilities_of_config] below) can avoid re-resolving for the same
     provider.
 
-    Override semantics: CLI providers (Claude Code, Codex CLI, Gemini CLI,
-    Anthropic CLI) do not expose inline function-calling to this gate. Runtime MCP
-    support remains runtime.toml/OAS-owned because not every CLI can consume
-    request-scoped MCP policy; Gemini CLI is the known false case. *)
+    Override semantics: CLI providers (Anthropic CLI) do not expose inline
+    function-calling to this gate. Runtime MCP support remains
+    runtime.toml/OAS-owned because not every CLI can consume request-scoped
+    MCP policy. *)
 let normalize_cli_caps_when ~is_cli (caps : Llm_provider.Capabilities.capabilities) =
   if is_cli
   then { caps with supports_tools = false; supports_tool_choice = false }

--- a/lib/provider_tool_support.mli
+++ b/lib/provider_tool_support.mli
@@ -45,10 +45,10 @@ type runtime_capabilities_override =
     + Provider/model/catalog capability truth via OAS
       [Provider_runtime_binding].
     + CLI-agent normalisation: adapters with
-      [runtime_kind = Cli_agent] (Claude Code / Codex CLI / Gemini CLI /
-      Anthropic CLI) force [supports_tools = false],
-      [supports_tool_choice = false], [supports_runtime_mcp_tools = true],
-      and [supports_runtime_tool_events = true]. *)
+      [runtime_kind = Cli_agent] (Anthropic CLI) force
+      [supports_tools = false], [supports_tool_choice = false],
+      [supports_runtime_mcp_tools = true], and
+      [supports_runtime_tool_events = true]. *)
 val oas_capabilities_of_config
   :  Llm_provider.Provider_config.t
   -> Llm_provider.Capabilities.capabilities

--- a/lib/runtime/runtime_transport.ml
+++ b/lib/runtime/runtime_transport.ml
@@ -6,9 +6,8 @@
 
 let provider_effective_max_turns _kind requested = requested
 
-(* RFC-0167: the client-named omission-dedup module
-   [Runtime_transport_codex_omission_dedup] (#10097) was removed in
-   the big-bang sweep. The structural omission of keeper-bound runtime
+(* RFC-0167: the client-named omission-dedup module (#10097) was removed
+   in the big-bang sweep. The structural omission of keeper-bound runtime
    MCP tools (when the runtime adapter requires per-keeper bridging
    but no per-keeper bearer is available) is still detected and
    reported through the [Error (invalid_runtime_config ...)] path
@@ -157,11 +156,10 @@ let resolve_tool_lane_for_oas_tools
     | _ -> []
   in
   (* RFC-0167: previously routed [omitted_keeper_bound_actor_tools] through
-     [Runtime_transport_codex_omission_dedup.record_cli_tool_a_omission_for_agent]
-     for WARN-dedup + per-tool counter. The dedup module was a
-     client-named adapter (cli_tool_a wire-quirk) and is removed; the
-     omission is now silently reflected only in the [Error
-     (invalid_runtime_config ...)] returned below. *)
+     a client-named dedup adapter for WARN-dedup + per-tool counter.
+     The dedup module was a client-named adapter (cli_tool_a wire-quirk)
+     and is removed; the omission is now silently reflected only in the
+     [Error (invalid_runtime_config ...)] returned below. *)
   if tool_requirement = `Required && omitted_keeper_bound_actor_tools <> []
   then (
     let detail =

--- a/lib/runtime/runtime_transport.mli
+++ b/lib/runtime/runtime_transport.mli
@@ -12,8 +12,8 @@ val provider_effective_max_turns :
    ([cli_tool_a_omission_fingerprint], [cli_tool_a_omission_fingerprint_seen],
    [record_cli_tool_a_omission], [record_cli_tool_a_omission_for_agent],
    [reset_cli_tool_a_omission_dedup_for_tests]) were removed in the
-   big-bang sweep along with [Runtime_transport_codex_omission_dedup].
-   Structural omission detection remains in the resolver below. *)
+   big-bang sweep. Structural omission detection remains in the
+   resolver below. *)
 
 (** Failure modes for {!resolve_provider_config_of_label}. *)
 type label_resolution_error =
@@ -92,12 +92,12 @@ val cli_tool_a_can_auth_keeper_bound_runtime_mcp :
   Llm_provider.Llm_transport.runtime_mcp_policy ->
   bool
 (** [true] when [agent_name] maps to a keeper with a persisted raw bearer
-    token and [policy] contains actor-bound runtime MCP tools.  Codex CLI
-    can carry that token via OAS [bearer_token_env_var] without placing it in
-    argv. *)
+    token and [policy] contains actor-bound runtime MCP tools.  The
+    cli_tool_a transport can carry that token via OAS [bearer_token_env_var]
+    without placing it in argv. *)
 
 (** Provider-specific shaping of the runtime MCP policy.  For Cli_tool_a the
-    policy is stripped to Codex-safe headers: [Authorization: Bearer ...]
+    policy is stripped to client-safe headers: [Authorization: Bearer ...]
     plus non-secret MASC identity headers.  Other providers receive the policy
     with [runtime_mcp_policy_with_masc_agent_name] applied when [agent_name] is
     non-empty. *)

--- a/lib/runtime/runtime_transport_auth_bridging.ml
+++ b/lib/runtime/runtime_transport_auth_bridging.ml
@@ -3,7 +3,7 @@
     helpers:
 
     - [cli_tool_a_can_auth_keeper_bound_runtime_mcp] — predicate that
-      decides whether the Codex CLI route can mint a per-keeper
+      decides whether the cli_tool_a transport can mint a per-keeper
       Authorization header for a bound-actor MCP policy.
 
     - [bridged_runtime_mcp_policy_for_agent] — the RFC-0058 §2.4
@@ -44,9 +44,9 @@ let cli_tool_a_can_auth_keeper_bound_runtime_mcp ~agent_name policy =
    Invariant: this function is only reached from the dispatch site when the
    provider-tool policy says per-keeper bridging is required, i.e. the runtime
    cannot carry arbitrary per-request HTTP headers.  Body is intentionally
-   identical in semantics to the prior [codex_runtime_mcp_policy_for_agent] —
-   the rename removes the provider-name leak from the dispatch site without
-   altering behavior.
+   identical in semantics to the prior client-named projection — the rename
+   removes the provider-name leak from the dispatch site without altering
+   behavior.
 
    A future adapter with [requires_per_keeper_bridging = true] but
    different transport semantics (e.g. native per-keeper header

--- a/lib/runtime/runtime_transport_auth_bridging.mli
+++ b/lib/runtime/runtime_transport_auth_bridging.mli
@@ -4,8 +4,8 @@ val cli_tool_a_can_auth_keeper_bound_runtime_mcp :
   agent_name:string ->
   Llm_provider.Llm_transport.runtime_mcp_policy ->
   bool
-(** [true] when Codex CLI can mint a per-keeper Authorization header for
-    actor-bound runtime MCP tools. *)
+(** [true] when the cli_tool_a transport can mint a per-keeper
+    Authorization header for actor-bound runtime MCP tools. *)
 
 val bridged_runtime_mcp_policy_for_agent :
   agent_name:string ->

--- a/lib/server/fd_accountant.mli
+++ b/lib/server/fd_accountant.mli
@@ -29,10 +29,10 @@ type kind =
           ([Eio.Net.with_tcp_connect] + TLS state). One slot per
           in-flight call. *)
   | Provider_cli
-      (** Outbound LLM provider subprocess attempt (Claude Code,
-          Gemini CLI, Codex CLI, Anthropic CLI). OAS owns the subprocess
-          implementation; MASC accounts the call at the transport
-          boundary so CLI fan-out shares FD-pressure backpressure. *)
+      (** Outbound LLM provider subprocess attempt (Anthropic CLI). OAS
+          owns the subprocess implementation; MASC accounts the call at
+          the transport boundary so CLI fan-out shares FD-pressure
+          backpressure. *)
   | Sandbox_exec
       (** Inner shell exec inside a sandbox container (popen pipes
           stdin/out/err + cgroup FD). Distinct from [Docker_spawn]

--- a/scripts/harness_tool_call_quality.sh
+++ b/scripts/harness_tool_call_quality.sh
@@ -387,9 +387,6 @@ start_live_server() {
     export MASC_KEEPER_BOOTSTRAP_ENABLED="0"
     export GRAPHQL_API_KEY=""
     export GRAPHQL_URL="http://127.0.0.1:9/graphql"
-    export OAS_CLAUDE_STRICT_MCP="1"
-    export OAS_GEMINI_NO_MCP="1"
-    export OAS_GEMINI_APPROVAL_MODE="plan"
     export OAS_MCP_SERVERS_CONFIG="mcp_servers={}"
     exec "${ROOT_DIR}/scripts/run-local.sh" \
       --target-dir "${TARGET_DIR}" \
@@ -406,9 +403,6 @@ start_live_server() {
     export MASC_KEEPER_BOOTSTRAP_ENABLED="0"
     export GRAPHQL_API_KEY=""
     export GRAPHQL_URL="http://127.0.0.1:9/graphql"
-    export OAS_CLAUDE_STRICT_MCP="1"
-    export OAS_GEMINI_NO_MCP="1"
-    export OAS_GEMINI_APPROVAL_MODE="plan"
     export OAS_MCP_SERVERS_CONFIG="mcp_servers={}"
     exec "${ROOT_DIR}/scripts/run-local.sh" --target-dir "${TARGET_DIR}" --port "${PORT}"
   ) >"${launch_log}" 2>&1 &

--- a/scripts/harness_tool_call_quality.sh
+++ b/scripts/harness_tool_call_quality.sh
@@ -387,6 +387,9 @@ start_live_server() {
     export MASC_KEEPER_BOOTSTRAP_ENABLED="0"
     export GRAPHQL_API_KEY=""
     export GRAPHQL_URL="http://127.0.0.1:9/graphql"
+    export OAS_CLAUDE_STRICT_MCP="1"
+    export OAS_GEMINI_NO_MCP="1"
+    export OAS_GEMINI_APPROVAL_MODE="plan"
     export OAS_MCP_SERVERS_CONFIG="mcp_servers={}"
     exec "${ROOT_DIR}/scripts/run-local.sh" \
       --target-dir "${TARGET_DIR}" \
@@ -403,6 +406,9 @@ start_live_server() {
     export MASC_KEEPER_BOOTSTRAP_ENABLED="0"
     export GRAPHQL_API_KEY=""
     export GRAPHQL_URL="http://127.0.0.1:9/graphql"
+    export OAS_CLAUDE_STRICT_MCP="1"
+    export OAS_GEMINI_NO_MCP="1"
+    export OAS_GEMINI_APPROVAL_MODE="plan"
     export OAS_MCP_SERVERS_CONFIG="mcp_servers={}"
     exec "${ROOT_DIR}/scripts/run-local.sh" --target-dir "${TARGET_DIR}" --port "${PORT}"
   ) >"${launch_log}" 2>&1 &

--- a/test/test_dashboard_cache.ml
+++ b/test/test_dashboard_cache.ml
@@ -388,7 +388,7 @@ let test_invalidate_all_wakes_waiters () =
     the cache.  The caller receives the stale value immediately, and the
     background fiber's Compute_timeout exception triggers the restore path.
     A subsequent cache lookup must return the stale value, not timeout-error
-    JSON.  (Regression test for Codex review P2 on PR #1314.) *)
+    JSON.  (Regression test for review P2 on PR #1314.) *)
 let test_stale_preserved_on_timeout ~clock ~sw () =
   Dashboard_cache.invalidate_all ();
   Eio_context.set_switch sw;

--- a/test/test_dune_local_script.ml
+++ b/test/test_dune_local_script.ml
@@ -942,7 +942,7 @@ let test_clean_subcommand_with_eq_flag_skips_pin_guard () =
         0 code;
       check bool "dune was invoked" true (Sys.file_exists dune_log))
 
-(* Codex-connector follow-ups (#13117, 2026-05-05):
+(* CLI-connector follow-ups (#13117, 2026-05-05):
    - `--auto-promote` is a BOOLEAN common option (no arg).  Treating
      it as value-taking made `--auto-promote clean` skip both tokens
      and fall back to `build`.

--- a/test/test_jsonl_atomic.ml
+++ b/test/test_jsonl_atomic.ml
@@ -249,7 +249,7 @@ let test_two_handles_share_mutex () =
       with e -> failf "invalid JSON: %s" (Printexc.to_string e))
     lines
 
-(* ── Scenario 5: path spellings collapse to one mutex (Codex P1 #15906) ── *)
+(* ── Scenario 5: path spellings collapse to one mutex (P1 #15906) ── *)
 
 let test_path_spelling_collapse () =
   Eio_main.run @@ fun env ->

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -1433,7 +1433,7 @@ persona_name = "analyst"
 [keeper.oas_env]
 OAS_CLAUDE_STRICT_MCP = "1"
 OAS_GEMINI_NO_MCP = "1"
-OAS_CODEX_CONFIG = "mcp_servers={}"
+OAS_CLAUDE_MCP_CONFIG = "mcp_servers={}"
 MASC_KEEPER_OAS_UNIFIED_MAX_TOKENS = 8192
 |} in
   match TL.parse_toml input with
@@ -1447,8 +1447,8 @@ MASC_KEEPER_OAS_UNIFIED_MAX_TOKENS = 8192
         "1" (List.assoc "OAS_CLAUDE_STRICT_MCP" d.oas_env);
       check string "no_mcp value"
         "1" (List.assoc "OAS_GEMINI_NO_MCP" d.oas_env);
-      check string "codex_config value"
-        "mcp_servers={}" (List.assoc "OAS_CODEX_CONFIG" d.oas_env);
+      check string "claude_mcp_config value"
+        "mcp_servers={}" (List.assoc "OAS_CLAUDE_MCP_CONFIG" d.oas_env);
       check string "unified max tokens value"
         "8192" (List.assoc "MASC_KEEPER_OAS_UNIFIED_MAX_TOKENS" d.oas_env);
       check (option int) "unified max tokens override"
@@ -1562,7 +1562,7 @@ let test_oas_env_coerces_bool_to_string () =
 persona_name = "analyst"
 [keeper.oas_env]
 OAS_CLAUDE_STRICT_MCP = true
-OAS_CODEX_SKIP_GIT = false
+OAS_GEMINI_NO_MCP = false
 |} in
   match TL.parse_toml input with
   | Error e -> fail e
@@ -1573,7 +1573,7 @@ OAS_CODEX_SKIP_GIT = false
       check string "true → 1" "1"
         (List.assoc "OAS_CLAUDE_STRICT_MCP" d.oas_env);
       check string "false → 0" "0"
-        (List.assoc "OAS_CODEX_SKIP_GIT" d.oas_env)
+        (List.assoc "OAS_GEMINI_NO_MCP" d.oas_env)
 
 let test_load_keeper_toml_captures_unknown_keys_on_profile () =
   let tmp = Filename.temp_file "keeper_unknown" ".toml" in

--- a/test/test_keeper_tool_policy_paths.ml
+++ b/test/test_keeper_tool_policy_paths.ml
@@ -121,7 +121,7 @@ let test_dotdot_at_root_drops () =
     not (P.is_masc_write_allowed "../../etc/passwd"))
 
 let test_root_overshoot_drops_to_writable_prefix () =
-  (* Codex review caught that test_dotdot_at_root_drops above
+  (* Review caught that test_dotdot_at_root_drops above
      can't distinguish "[..] beyond root drops" from "[/etc/]
      just isn't writable" — both produce false.
 

--- a/test/test_notify_coverage.ml
+++ b/test/test_notify_coverage.ml
@@ -238,13 +238,13 @@ let test_escape_applescript_mixed () =
    agent_emoji Tests
    ============================================================ *)
 
-let test_agent_emoji_claude () =
+let test_agent_emoji_llm_a () =
   check string "agent_llm_a" "🟣" (Notify.agent_emoji "agent_llm_a")
 
-let test_agent_emoji_gemini () =
+let test_agent_emoji_f () =
   check string "provider_f" "🔵" (Notify.agent_emoji "provider_f")
 
-let test_agent_emoji_codex () =
+let test_agent_emoji_a () =
   check string "agent_code" "🟢" (Notify.agent_emoji "agent_code")
 
 let test_agent_emoji_llama () =
@@ -415,9 +415,9 @@ let () =
       test_case "mixed" `Quick test_escape_applescript_mixed;
     ];
     "agent_emoji", [
-      test_case "agent_llm_a" `Quick test_agent_emoji_claude;
-      test_case "provider_f" `Quick test_agent_emoji_gemini;
-      test_case "agent_code" `Quick test_agent_emoji_codex;
+      test_case "agent_llm_a" `Quick test_agent_emoji_llm_a;
+      test_case "provider_f" `Quick test_agent_emoji_f;
+      test_case "agent_code" `Quick test_agent_emoji_a;
       test_case "llama" `Quick test_agent_emoji_llama;
       test_case "system" `Quick test_agent_emoji_system;
       test_case "unknown" `Quick test_agent_emoji_unknown;

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -2161,7 +2161,7 @@ let test_main_eio_fresh_bootstrap_and_mcp_handshake () =
           Alcotest.(check bool) "canonical tool present" true
             (List.mem "masc_status" tool_names)))
 
-let test_main_eio_self_heals_codex_mcp_token_file () =
+let test_main_eio_self_heals_cli_agent_mcp_token_file () =
   with_temp_dir "startup-agent_code-token-selfheal" (fun dir ->
       let exe = find_main_eio_exe () in
       let port = find_free_port () in
@@ -2853,7 +2853,7 @@ let () =
             `Slow test_main_eio_fresh_bootstrap_and_mcp_handshake;
           Alcotest.test_case
             "main_eio self-heals agent_code mcp token file"
-            `Slow test_main_eio_self_heals_codex_mcp_token_file;
+            `Slow test_main_eio_self_heals_cli_agent_mcp_token_file;
           Alcotest.test_case
             "startup sync mints bootable keeper credentials"
             `Quick test_sync_bootable_keeper_credentials_mints_keeper_alias_token;

--- a/test/test_shell_ir_typed_review_followup.ml
+++ b/test/test_shell_ir_typed_review_followup.ml
@@ -1,5 +1,5 @@
 (** test_shell_ir_typed_review_followup — invariants enforced by the
-    Codex review on PR #14240.
+    review on PR #14240.
 
     Each test below pins one of the three contracts that the review
     surfaced:

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -1494,7 +1494,7 @@ let () = test "transition_submit_pr_evidence_accepts_todo_pr_url_alias" (fun () 
   with_env "MASC_VERIFICATION_FSM_ENABLED" (Some "true") (fun () ->
     let ctx = make_test_ctx_with_agent "agent_code-mcp-client" in
     let pr_url = "https://github.com/jeong-sik/masc/pull/13169" in
-    add_task_requiring_tools ctx ~title:"Codex CLI approval follow-up" [ "tool_execute" ];
+    add_task_requiring_tools ctx ~title:"CLI approval follow-up" [ "tool_execute" ];
     let result =
       Tool_task.handle_transition
         ~tool_name:"test_tool" ~start_time:0.0
@@ -1594,7 +1594,7 @@ let () = test "transition_normalize_pr_url_merges_into_existing_handoff_context"
 let () = test "transition_submit_pr_evidence_accepts_todo_pr_evidence" (fun () ->
   with_env "MASC_VERIFICATION_FSM_ENABLED" (Some "true") (fun () ->
     let ctx = make_test_ctx_with_agent "agent_code-mcp-client" in
-    add_task_requiring_tools ctx ~title:"Codex CLI approval follow-up" [ "tool_execute" ];
+    add_task_requiring_tools ctx ~title:"CLI approval follow-up" [ "tool_execute" ];
     let submit_result =
       Tool_task.handle_transition
         ~tool_name:"test_tool" ~start_time:0.0
@@ -1763,7 +1763,7 @@ let () = test "dispatch_transition_claim_uses_server_surface_not_payload_surface
   | None -> failwith "dispatch returned None"
 )
 
-(* Regression for issue: tool_execute-gated tasks stay todo after merged Codex PR
+(* Regression for issue: tool_execute-gated tasks stay todo after merged PR
    evidence. submit_pr_evidence must bypass the required_tool claim guard and
    transition Todo -> AwaitingVerification without claiming. *)
 let () = test "submit_pr_evidence_bypasses_required_tool_gate_on_todo_task" (fun () ->


### PR DESCRIPTION
## Codex purge — PR2 (lib/ + test/ source sweep)

Campaign continuation of #19961 (PR1: scripts/CI/docs sweep).

This PR drops all **Codex** attributions and references from the OCaml
source and test surface. Claude and Gemini mentions remain **only** where
they are semantically load-bearing (live env vars, agent mascot data
keys, mention endpoints) — see "Out of scope" below.

### Commits

1. `f7d7c387e1` — remove Codex mentions from scripts, CI, and issue templates (PR1 re-rebased onto current main)
2. `70f2834230` — also drop Claude and Gemini from CLI usage examples
3. `d15391ea4f` — drop codex references from lib/runtime/
4. `8f695016c9` — drop Claude/Codex/Gemini CLI examples from capability docs
5. `22d2e19234` — drop codex attributions from historical lib/ comments
6. `96a7d8247d` — drop codex attributions from test/ sweep

### Files touched (high level)

- `lib/exec/exec_semantic.mli`, `lib/exec/exec_budget.ml`, `lib/exec/output_parse.mli`
- `lib/jsonl_atomic/jsonl_atomic.ml`
- `lib/keeper/keeper_compact_policy.ml`, `lib/keeper/keeper_memory_recall.ml`,
  `lib/keeper/keeper_memory_recall_exn_class.mli`, `lib/keeper/keeper_cli_mcp_config.ml`
- `lib/eval_harness.mli`
- `test/test_keeper_toml.ml`, `test/test_server_runtime_bootstrap.ml`,
  `test/test_notify_coverage.ml`, `test/test_tool_task_coverage.ml`,
  `test/test_dune_local_script.ml`, `test/test_keeper_tool_policy_paths.ml`,
  `test/test_dashboard_cache.ml`, `test/test_jsonl_atomic.ml`,
  `test/test_shell_ir_typed_review_followup.ml`

Plus the four files re-touched during rebase onto current main:
`README.md`, `docs/runtime-tunables.md`, `scripts/install.sh`,
`scripts/harness_tool_call_quality.sh`. For those four the conflict
resolution took main's stricter-generalisation version
(`Anthropic CLI today; other CLI transports may need an …`).

### Build verification

```
$ dune build --root .
$ echo $?
0
```

Clean build against current `main` (`ffb0da2e5c` + this PR's 6 commits).

### Out of scope (deferred to follow-up campaigns)

- **Claude and Gemini mentions in test/** are intentionally NOT swept
  here. They back live env vars and agent mascot data keys whose removal
  would break the keepers those tests pin
  (`OAS_CLAUDE_MCP_CONFIG`, `OAS_GEMINI_NO_MCP`, mascot keys
  `agent_llm_a` / `provider_f` / `agent_code` in
  `lib/types/types_core.ml:111`, the `claude_v2` mention endpoint, etc.).
  A separate, more invasive campaign is needed to swap mascot names
  for the `Claude`/`Gemini` strings currently used as labels.
- `CHANGELOG.md` and the RFC archive remain untouched (out of campaign
  scope per PR1's commit-message note).
- `git history` purge is a separate effort.

### PR-RFC check

The PR-RFC check (`bash ~/me/scripts/pr-rfc-check.sh`) is **N/A**:
no credential / identity / repo / operator / sandbox / hooks / workflow
code is touched. Only historical attributions, function renames, env
var fixture swaps, and one comment are changed. Subsystems in
`lib/keeper/credential_*`, `lib/repo_manager/`,
`lib/operator/operator_control*`, `lib/keeper/keeper_sandbox*`,
`dashboard/src/components/credential*`, `.claude/hooks/`, and
`instructions/workflow*` are not modified.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
