### PR TITLE
feat(keeper): add persona_ref and runtime_ref fields

### DIFF
--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -266,6 +266,8 @@ let load_keeper_profile_defaults_from_persona name : keeper_profile_defaults =
                 oas_env = [];
                 (* Persona JSON has no [keeper] TOML; nothing to flag. *)
                 unknown_toml_keys = [];
+                persona_ref = Safe_ops.json_string_opt "persona_ref" keeper_json;
+                runtime_ref = Safe_ops.json_string_opt "runtime_ref" keeper_json;
               }
           | _ -> { empty_keeper_profile_defaults with manifest_path = Some path })
 

--- a/lib/keeper/keeper_types_profile_defaults.ml
+++ b/lib/keeper/keeper_types_profile_defaults.ml
@@ -46,6 +46,13 @@ type keeper_profile_defaults = {
      Applied via Unix.putenv right before each turn so OAS transport
      build_args picks them up.  Empty list = no overrides. *)
   oas_env : (string * string) list;
+  (* Referential separation fields for persona/runtime externalization.
+     When set, the keeper defers to the referenced persona/runtime file
+     instead of inline fields.  This enables the template-instance model
+     where persona (character) and runtime (execution environment) are
+     maintained independently of keeper (operational identity). *)
+  persona_ref : string option;
+  runtime_ref : string option;
   (* Keys present under [keeper] (or other tables) that are NOT in
      [canonical_keeper_toml_key_names].  Captured at load time so
      downstream surfaces (keeper_status_detail, dashboards) can show
@@ -91,6 +98,8 @@ let empty_keeper_profile_defaults =
     max_turns_per_call_scheduled_autonomous = None;
     unknown_toml_keys = [];
     oas_env = [];
+    persona_ref = None;
+    runtime_ref = None;
   }
 ;;
 

--- a/lib/keeper/keeper_types_profile_defaults.mli
+++ b/lib/keeper/keeper_types_profile_defaults.mli
@@ -41,6 +41,11 @@ type keeper_profile_defaults = {
   max_turns_per_call : int option;
   max_turns_per_call_scheduled_autonomous : int option;
   oas_env : (string * string) list;
+  (* Referential separation fields for persona/runtime externalization.
+     When set, the keeper defers to the referenced persona/runtime file
+     instead of inline fields. *)
+  persona_ref : string option;
+  runtime_ref : string option;
   unknown_toml_keys : string list;
 }
 

--- a/lib/keeper/keeper_types_profile_toml.mli
+++ b/lib/keeper/keeper_types_profile_toml.mli
@@ -175,6 +175,8 @@ type keeper_profile_defaults =
   max_turns_per_call : int option;
   max_turns_per_call_scheduled_autonomous : int option;
   oas_env : (string * string) list;
+  persona_ref : string option;
+  runtime_ref : string option;
   unknown_toml_keys : string list;
 }
 val empty_keeper_profile_defaults : keeper_profile_defaults

--- a/lib/keeper/keeper_types_profile_toml_io.mli
+++ b/lib/keeper/keeper_types_profile_toml_io.mli
@@ -175,6 +175,8 @@ type keeper_profile_defaults =
   max_turns_per_call : int option;
   max_turns_per_call_scheduled_autonomous : int option;
   oas_env : (string * string) list;
+  persona_ref : string option;
+  runtime_ref : string option;
   unknown_toml_keys : string list;
 }
 val empty_keeper_profile_defaults : keeper_profile_defaults

--- a/lib/keeper/keeper_types_profile_toml_normalizers.mli
+++ b/lib/keeper/keeper_types_profile_toml_normalizers.mli
@@ -175,6 +175,8 @@ type keeper_profile_defaults =
   max_turns_per_call : int option;
   max_turns_per_call_scheduled_autonomous : int option;
   oas_env : (string * string) list;
+  persona_ref : string option;
+  runtime_ref : string option;
   unknown_toml_keys : string list;
 }
 val empty_keeper_profile_defaults : keeper_profile_defaults

--- a/lib/keeper/keeper_types_profile_toml_parser.ml
+++ b/lib/keeper/keeper_types_profile_toml_parser.ml
@@ -182,6 +182,8 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
         social_model = normalize_social_model_opt (str "social_model");
         oas_env = extract_oas_env_from_doc doc;
         unknown_toml_keys = [];
+        persona_ref = str "persona_ref";
+        runtime_ref = str "runtime_ref";
       })
     result
 
@@ -219,6 +221,8 @@ let parsed_field_key_names =
   ; "max_turns_per_call"
   ; "max_turns_per_call_scheduled_autonomous"
   ; "social_model"
+  ; "persona_ref"
+  ; "runtime_ref"
   ]
 
 (** Canonical TOML key names used by [detect_unknown_keeper_toml_keys].
@@ -261,6 +265,8 @@ let canonical_keeper_toml_key_names =
   ; "max_turns_per_call"
   ; "max_turns_per_call_scheduled_autonomous"
   ; "social_model"
+  ; "persona_ref"
+  ; "runtime_ref"
   ]
 
 let loader_level_keeper_toml_key_names = [ "base" ]
@@ -411,4 +417,6 @@ let merge_keeper_profile_defaults
        surviving_base @ overlay.oas_env);
     unknown_toml_keys =
       merge_string_list ~base:base.unknown_toml_keys overlay.unknown_toml_keys;
+    persona_ref = prefer overlay.persona_ref base.persona_ref;
+    runtime_ref = prefer overlay.runtime_ref base.runtime_ref;
   }

--- a/lib/keeper/keeper_types_profile_toml_parser.mli
+++ b/lib/keeper/keeper_types_profile_toml_parser.mli
@@ -175,6 +175,8 @@ type keeper_profile_defaults =
   max_turns_per_call : int option;
   max_turns_per_call_scheduled_autonomous : int option;
   oas_env : (string * string) list;
+  persona_ref : string option;
+  runtime_ref : string option;
   unknown_toml_keys : string list;
 }
 val empty_keeper_profile_defaults : keeper_profile_defaults


### PR DESCRIPTION
## Summary
Adds `persona_ref` and `runtime_ref` fields to `keeper_profile_defaults` type.
These fields enable externalized persona and runtime configuration,
laying the groundwork for the template-instance separation model.

## Changes
- `keeper_types_profile_defaults`: add `persona_ref` and `runtime_ref` fields
- `keeper_types_profile_toml_parser`: parse new fields from TOML + merge logic
- `keeper_types_profile.ml`: parse new fields from JSON
- Sync all `.mli` files with new type definition

## Stacked PR Series
- **PR-1** (this): type fields + codec
- **PR-2** (upcoming): extract persona files from keeper JSON
- **PR-3** (upcoming): extract runtime files from keeper JSON
- **PR-4** (upcoming): remove deprecated inline fields

## Verification
- `dune build @check` passes

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>