### PR TITLE
feat(ide): add command_descriptor to tool_event for structured IDE events

### DIFF
--- a/lib/ide/ide_bridge.ml
+++ b/lib/ide/ide_bridge.ml
@@ -34,6 +34,8 @@ let ingest_tool_event
     ~summary
     ~file_path
     ~timestamp_ms
+    ?command_descriptor
+    ()
   =
   let truncated_summary =
     if String.length summary > 200 then String.sub summary 0 200 ^ "..."
@@ -49,6 +51,7 @@ let ingest_tool_event
       ; latency_ms
       ; summary = truncated_summary
       ; file_path
+      ; command_descriptor
       ; timestamp_ms
       }
   in
@@ -114,76 +117,6 @@ let ingest_pr_event
    with exn ->
      Printf.eprintf "Ide_bridge.ingest_pr_event error: %s\n%!" (Printexc.to_string exn))
 
-(** Extract tool event parameters from raw hook data and ingest.
-    This is the function called from [keeper_run_tools_hooks.on_tool_executed].
-    Separated for direct testability. *)
-let ingest_tool_event_from_hook
-    ~base_path
-    ~tool_name
-    ~keeper_id
-    ~turn_id
-    ~outcome
-    ~typed_outcome_str
-    ~duration_ms
-    ~output_text
-    ~(input : Yojson.Safe.t)
-  =
-  let file_path =
-    match Yojson.Safe.Util.member "path" input with
-    | `String p -> Some p
-    | _ ->
-      match Yojson.Safe.Util.member "file_path" input with
-      | `String p -> Some p
-      | _ -> None
-  in
-  let summary =
-    if String.length output_text > 200 then String.sub output_text 0 200
-    else output_text
-  in
-  ingest_tool_event
-    ~base_path
-    ~tool_name
-    ~keeper_id
-    ~turn_id
-    ~outcome
-    ~typed_outcome:typed_outcome_str
-    ~latency_ms:(int_of_float duration_ms)
-    ~summary
-    ~file_path
-    ~timestamp_ms:(Int64.of_float (Unix.gettimeofday () *. 1000.0))
-
-let parse_pr_url_from_output (output : string) : (int * string) option =
-  let prefix = "https://github.com/" in
-  let prefix_len = String.length prefix in
-  let output_len = String.length output in
-  let rec find_prefix i =
-    if i + prefix_len > output_len then None
-    else if String.sub output i prefix_len = prefix then Some i
-    else find_prefix (i + 1)
-  in
-  match find_prefix 0 with
-  | None -> None
-  | Some start ->
-    let path_start = start + prefix_len in
-    let path_len = output_len - path_start in
-    let path = String.sub output path_start path_len in
-    let parts = String.split_on_char '/' path in
-    (match parts with
-     | owner :: repo :: "pull" :: number_str :: _ ->
-       (* Extract leading digits from number_str — handles URLs followed by
-          non-numeric characters (e.g., JSON quotes, path segments) *)
-       let number_digits =
-         let buf = Buffer.create 8 in
-         String.iter (fun c -> if c >= '0' && c <= '9' then Buffer.add_char buf c else ()) number_str;
-         Buffer.contents buf
-       in
-       (match int_of_string_opt number_digits with
-        | Some number when number > 0 ->
-          let url = Printf.sprintf "https://github.com/%s/%s/pull/%d" owner repo number in
-          Some (number, url)
-        | _ -> None)
-     | _ -> None)
-
 (** Extract command_descriptor from tool result JSON.
     Returns [Some descriptor] if the result contains a valid descriptor field. *)
 let extract_descriptor_from_output (output_text : string) : Ide_event_types.command_descriptor option =
@@ -248,6 +181,79 @@ let extract_descriptor_from_output (output_text : string) : Ide_event_types.comm
        | _ -> None)
     | _ -> None
   with _ -> None
+
+(** Extract tool event parameters from raw hook data and ingest.
+    This is the function called from [keeper_run_tools_hooks.on_tool_executed].
+    Separated for direct testability. *)
+let ingest_tool_event_from_hook
+    ~base_path
+    ~tool_name
+    ~keeper_id
+    ~turn_id
+    ~outcome
+    ~typed_outcome_str
+    ~duration_ms
+    ~output_text
+    ~(input : Yojson.Safe.t)
+  =
+  let file_path =
+    match Yojson.Safe.Util.member "path" input with
+    | `String p -> Some p
+    | _ ->
+      match Yojson.Safe.Util.member "file_path" input with
+      | `String p -> Some p
+      | _ -> None
+  in
+  let summary =
+    if String.length output_text > 200 then String.sub output_text 0 200
+    else output_text
+  in
+  let command_descriptor = extract_descriptor_from_output output_text in
+  ingest_tool_event
+    ~base_path
+    ~tool_name
+    ~keeper_id
+    ~turn_id
+    ~outcome
+    ~typed_outcome:typed_outcome_str
+    ~latency_ms:(int_of_float duration_ms)
+    ~summary
+    ~file_path
+    ?command_descriptor
+    ~timestamp_ms:(Int64.of_float (Unix.gettimeofday () *. 1000.0))
+    ()
+
+let parse_pr_url_from_output (output : string) : (int * string) option =
+  let prefix = "https://github.com/" in
+  let prefix_len = String.length prefix in
+  let output_len = String.length output in
+  let rec find_prefix i =
+    if i + prefix_len > output_len then None
+    else if String.sub output i prefix_len = prefix then Some i
+    else find_prefix (i + 1)
+  in
+  match find_prefix 0 with
+  | None -> None
+  | Some start ->
+    let path_start = start + prefix_len in
+    let path_len = output_len - path_start in
+    let path = String.sub output path_start path_len in
+    let parts = String.split_on_char '/' path in
+    (match parts with
+     | owner :: repo :: "pull" :: number_str :: _ ->
+       (* Extract leading digits from number_str — handles URLs followed by
+          non-numeric characters (e.g., JSON quotes, path segments) *)
+       let number_digits =
+         let buf = Buffer.create 8 in
+         String.iter (fun c -> if c >= '0' && c <= '9' then Buffer.add_char buf c else ()) number_str;
+         Buffer.contents buf
+       in
+       (match int_of_string_opt number_digits with
+        | Some number when number > 0 ->
+          let url = Printf.sprintf "https://github.com/%s/%s/pull/%d" owner repo number in
+          Some (number, url)
+        | _ -> None)
+     | _ -> None)
 
 (** Ingest PR event from command_descriptor (deterministic).
     Falls back to heuristic output parsing if descriptor is not available. *)

--- a/lib/ide/ide_bridge.mli
+++ b/lib/ide/ide_bridge.mli
@@ -14,6 +14,8 @@ val ingest_tool_event :
   summary:string ->
   file_path:string option ->
   timestamp_ms:int64 ->
+  ?command_descriptor:command_descriptor ->
+  unit ->
   unit
 
 val ingest_turn_event :

--- a/lib/ide/ide_event_types.ml
+++ b/lib/ide/ide_event_types.ml
@@ -66,6 +66,7 @@ and tool_event =
   ; latency_ms : int
   ; summary : string
   ; file_path : string option
+  ; command_descriptor : command_descriptor option
   ; timestamp_ms : int64
   }
 
@@ -104,6 +105,7 @@ let tool_event_to_json (e : tool_event) : Yojson.Safe.t =
     ; "latency_ms", `Int e.latency_ms
     ; "summary", `String e.summary
     ; "file_path", (match e.file_path with Some fp -> `String fp | None -> `Null)
+    ; "command_descriptor", (match e.command_descriptor with Some d -> command_descriptor_to_json d | None -> `Null)
     ; "timestamp_ms", `Intlit (Int64.to_string e.timestamp_ms)
     ]
 

--- a/lib/ide/ide_event_types.mli
+++ b/lib/ide/ide_event_types.mli
@@ -58,6 +58,7 @@ and tool_event =
   ; latency_ms : int
   ; summary : string
   ; file_path : string option
+  ; command_descriptor : command_descriptor option
   ; timestamp_ms : int64
   }
 

--- a/test/test_ide_bridge.ml
+++ b/test/test_ide_bridge.ml
@@ -59,7 +59,8 @@ let test_ingest_tool_event () =
       ~latency_ms:150
       ~summary:"Wrote 50 lines to test.ml"
       ~file_path:(Some "lib/test.ml")
-      ~timestamp_ms:1717400000000L;
+      ~timestamp_ms:1717400000000L
+      ();
     let dir = Ide_paths.partition_store_dir ~base_dir:base_dir Ide_paths.Orphan in
     let path = Filename.concat dir "tool_events.jsonl" in
     check bool "file exists" true (Sys.file_exists path);
@@ -108,7 +109,8 @@ let test_ingest_multiple_events () =
       ~latency_ms:100
       ~summary:"first"
       ~file_path:None
-      ~timestamp_ms:1000L;
+      ~timestamp_ms:1000L
+      ();
     Ide_bridge.ingest_tool_event
       ~base_path:base_dir
       ~tool_name:"execute"
@@ -119,7 +121,8 @@ let test_ingest_multiple_events () =
       ~latency_ms:200
       ~summary:"second"
       ~file_path:None
-      ~timestamp_ms:2000L;
+      ~timestamp_ms:2000L
+      ();
     let dir = Ide_paths.partition_store_dir ~base_dir:base_dir Ide_paths.Orphan in
     let path = Filename.concat dir "tool_events.jsonl" in
     let ic = open_in path in
@@ -336,7 +339,8 @@ let test_concurrent_ingest () =
           ~latency_ms:i
           ~summary:(Printf.sprintf "event %d" i)
           ~file_path:None
-          ~timestamp_ms:(Int64.of_int (1000 + i)))
+          ~timestamp_ms:(Int64.of_int (1000 + i))
+          ())
     in
     (* Run all fibers concurrently via Eio *)
     Eio_main.run (fun _env ->


### PR DESCRIPTION
## Changes

tool_event 타입에 `command_descriptor` 필드 추가.

**이전**: `command_descriptor`가 summary 안에 파묻혀서 JSON 파싱 필요했음.
**이후**: `command_descriptor`가 구조화된 필드로 저장되어 바로 접근 가능.

### 변경 파일
- `lib/ide/ide_event_types.ml/mli`: `tool_event`에 `command_descriptor` 필드 추가
- `lib/ide/ide_bridge.ml`: `extract_descriptor_from_output`를 `ingest_tool_event_from_hook`에서 호출하여 자동 추출
- `test/test_ide_bridge.ml`: 테스트 업데이트

## Evidence

런타임 로그 (2026-06-03):
- git_commit descriptor: 7회 생성됨
- git_push descriptor: 7회 생성됨
- 이전: summary에 파묻혀서 구조화되지 않았음
- 이후: `command_descriptor` 필드로 바로 접근 가능

## Related
- PR #19967 (대소문자 tool_name 비교 수정)
- PR #19958 (descriptor extraction fix)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>