### PR TITLE
fix(exec): split git exit-128 into unknown-revision vs not-a-repo

### DIFF
--- a/lib/exec/exec_semantic.ml
+++ b/lib/exec/exec_semantic.ml
@@ -4,6 +4,7 @@ type t =
   | `Timeout of float
   | `Signaled of int
   | `Git_not_a_repo
+  | `Git_unknown_revision
   | `Oom_killed
   | `Policy_denied of string
   | `Tool_missing of string
@@ -13,6 +14,21 @@ let is_git_argv = function
   | "git" :: _ -> true
   | bin :: _ when Filename.basename bin = "git" -> true
   | _ -> false
+
+(* git exits 128 for many distinct fatals. We disambiguate the
+   unknown-revision / ambiguous-argument case from the not-a-repo case
+   because they require opposite self-correction: not-a-repo -> change
+   cwd or clone; unknown-revision -> the cwd IS a valid repo but the
+   ref/path is wrong. Conflating them gives an LLM "clone the
+   repository" advice while it sits inside a valid checkout, which
+   prolongs its flail loop. The only signal that separates the two is
+   the diagnostic git writes to stderr (same exit code 128), so we
+   match git's own wording. Lowercase once then case-sensitive
+   contains, mirroring [stderr_hints_oom]. *)
+let stderr_hints_unknown_revision stderr =
+  let lower = String.lowercase_ascii stderr in
+  String_util.contains_substring lower "unknown revision"
+  || String_util.contains_substring lower "ambiguous argument"
 
 let stderr_hints_oom stderr =
   let lower = String.lowercase_ascii stderr in
@@ -50,7 +66,9 @@ let interpret ~argv ~status ~stdout:_ ~stderr =
         | [] -> ""
       in
       `Permission_denied path
-  | Unix.WEXITED 128 when is_git_argv argv -> `Git_not_a_repo
+  | Unix.WEXITED 128 when is_git_argv argv ->
+      if stderr_hints_unknown_revision stderr then `Git_unknown_revision
+      else `Git_not_a_repo
   | Unix.WEXITED code -> `Fail code
   | Unix.WSIGNALED n when n = Sys.sigkill && stderr_hints_oom stderr ->
       `Oom_killed
@@ -69,6 +87,10 @@ let to_hint = function
   | `Signaled n -> Some (Printf.sprintf "process terminated by signal %d" n)
   | `Git_not_a_repo ->
       Some "git exit 128 — cwd is not inside a git repository"
+  | `Git_unknown_revision ->
+      Some
+        "git exit 128 — the cwd is a valid repository but the requested \
+         revision or path is unknown/ambiguous"
   | `Oom_killed ->
       Some "process was OOM-killed — try a smaller input or higher mem limit"
   | `Policy_denied rule ->
@@ -93,6 +115,14 @@ let to_alternatives = function
   | `Git_not_a_repo ->
       [ "Run `pwd` to check current directory."
       ; "Clone the repository first: `git clone <url> <dir>` then cd into it."
+      ]
+  | `Git_unknown_revision ->
+      [ "Verify the ref exists: `git rev-parse --verify <ref>` (try \
+         `origin/<ref>` for a remote-tracking branch)."
+      ; "List candidates: `git branch -a` and `git tag` to find the \
+         intended ref."
+      ; "Separate revisions from paths with `--`: `git <cmd> <ref> -- \
+         <path>`."
       ]
   | `Oom_killed ->
       [ "Reduce input size: process fewer files or rows at once."
@@ -119,6 +149,7 @@ let to_kind = function
   | `Timeout _ -> "timeout"
   | `Signaled _ -> "signaled"
   | `Git_not_a_repo -> "git_not_a_repo"
+  | `Git_unknown_revision -> "git_unknown_revision"
   | `Oom_killed -> "oom_killed"
   | `Policy_denied _ -> "policy_denied"
   | `Tool_missing _ -> "tool_missing"
@@ -130,6 +161,7 @@ let to_payload : t -> (string * payload_value) list = function
   | `Timeout s -> [ "seconds", `Float s ]
   | `Signaled n -> [ "signal", `Int n ]
   | `Git_not_a_repo -> []
+  | `Git_unknown_revision -> []
   | `Oom_killed -> []
   | `Policy_denied rule -> [ "rule", `String rule ]
   | `Tool_missing tool -> [ "tool", `String tool ]

--- a/lib/exec/exec_semantic.mli
+++ b/lib/exec/exec_semantic.mli
@@ -23,12 +23,20 @@ type t =
   | `Timeout of float
   | `Signaled of int
   | `Git_not_a_repo
+  | `Git_unknown_revision
   | `Oom_killed
   | `Policy_denied of string
   | `Tool_missing of string
   | `Permission_denied of string ]
 (** Polymorphic variant so downstream modules can narrow the set in
-    their own match arms without introducing a module dependency. *)
+    their own match arms without introducing a module dependency.
+
+    [`Git_not_a_repo] and [`Git_unknown_revision] both stem from git
+    exit 128 but carry opposite self-correction: the former means the
+    cwd is not a repository (change cwd / clone); the latter means the
+    cwd IS a valid repository but the requested ref/path is unknown or
+    ambiguous (fix the ref, e.g. [origin/<ref>] or [--] separation).
+    They are split by inspecting git's stderr diagnostic. *)
 
 val interpret :
   argv:string list ->
@@ -54,7 +62,8 @@ val interpret_cmd :
     for tool-name heuristics; OOM detection scans the merged output.
 
     Heuristics (ported from agent_llm_a-code [interpretCommandResult]):
-    - exit 128 on [git …]  -> [`Git_not_a_repo]
+    - exit 128 on [git …]  -> [`Git_unknown_revision] when stderr names
+      an unknown revision / ambiguous argument, else [`Git_not_a_repo]
     - exit 127             -> [`Tool_missing]
     - exit 126             -> [`Permission_denied]
     - SIGKILL w/ OOM token -> [`Oom_killed]

--- a/lib/exec/test/test_exec_semantic.ml
+++ b/lib/exec/test/test_exec_semantic.ml
@@ -66,6 +66,59 @@ let test_git_not_a_repo_via_path () =
       ~stderr:""
     = `Git_not_a_repo)
 
+(* git exit 128 inside a valid repo with a bad ref must NOT be
+   classified as not-a-repo: the self-correction is opposite. *)
+let test_git_unknown_revision () =
+  assert (
+    Exec_semantic.interpret
+      ~argv:[ "git"; "log"; "origin/task-575" ]
+      ~status:(ws 128)
+      ~stdout:""
+      ~stderr:
+        "fatal: ambiguous argument 'origin/task-575': unknown revision or \
+         path not in the working tree."
+    = `Git_unknown_revision)
+
+let test_git_unknown_revision_unknown_revision_only () =
+  assert (
+    Exec_semantic.interpret
+      ~argv:[ "git"; "rev-parse"; "deadbeef" ]
+      ~status:(ws 128)
+      ~stdout:""
+      ~stderr:"fatal: bad revision 'deadbeef'\nfatal: unknown revision"
+    = `Git_unknown_revision)
+
+(* The merged-output path (interpret_cmd) must reach the same split,
+   since git fatals are written to stderr and merged into [output]. *)
+let test_git_unknown_revision_via_cmd () =
+  assert (
+    Exec_semantic.interpret_cmd
+      ~cmd:"git log origin/task-575"
+      ~status:(ws 128)
+      ~output:"fatal: ambiguous argument 'origin/task-575': unknown revision"
+    = `Git_unknown_revision)
+
+let test_git_unknown_revision_hint_and_alternatives () =
+  (match Exec_semantic.to_hint `Git_unknown_revision with
+   | Some h ->
+       assert (String_util.contains_substring h "valid repository");
+       (* must NOT recycle the not-a-repo wording *)
+       assert (not (String_util.contains_substring h "not inside a git"))
+   | None -> assert false);
+  (match Exec_semantic.to_alternatives `Git_unknown_revision with
+   | alts ->
+       assert (List.length alts > 0);
+       (* must NOT advise cloning — the repo already exists *)
+       assert (
+         not
+           (List.exists
+              (fun a -> String_util.contains_substring a "git clone")
+              alts)))
+
+let test_git_unknown_revision_kind_and_payload () =
+  assert (Exec_semantic.to_kind `Git_unknown_revision = "git_unknown_revision");
+  assert (Exec_semantic.to_payload `Git_unknown_revision = [])
+
 let test_non_git_128_is_fail () =
   assert (
     Exec_semantic.interpret
@@ -143,6 +196,11 @@ let () =
   test_permission_denied ();
   test_git_not_a_repo ();
   test_git_not_a_repo_via_path ();
+  test_git_unknown_revision ();
+  test_git_unknown_revision_unknown_revision_only ();
+  test_git_unknown_revision_via_cmd ();
+  test_git_unknown_revision_hint_and_alternatives ();
+  test_git_unknown_revision_kind_and_payload ();
   test_non_git_128_is_fail ();
   test_oom_killed ();
   test_signaled_plain ();


### PR DESCRIPTION
## 목적

`Exec_semantic` 가 모든 git exit-128 을 `Git_not_a_repo` 로 매핑하여, cwd 가 정상 repo 인데도 ref/path 가 잘못된 경우(`fatal: ambiguous argument ... unknown revision or path`)에 "cwd is not inside a git repository" 힌트와 "clone the repository" 대안을 제시했습니다. 이는 올바른 자가 수정과 정반대 방향이라 LLM 에이전트의 flail loop 를 연장시켰습니다 (task-575-capacity-backpressure-dashboard keeper:analyst Execute 실패 진단).

## 변경

- `Exec_semantic.t` 에 typed `Git_unknown_revision` variant 추가 (closed-sum 확장).
- exit-128 git arm 을 stderr diagnostic 으로 분기: stderr 가 unknown revision / ambiguous argument 를 명시하면 `Git_unknown_revision`, 그 외에는 기존 `Git_not_a_repo` (empty-stderr 기본 동작 포함 불변).
- `Git_unknown_revision` 의 hint/alternatives 는 `origin/<ref>`, `git rev-parse --verify <ref>`, `--` 분리를 안내합니다 (clone/not-a-repo 안내 아님).
- `to_kind`/`to_payload`/`.mli` exhaustive arm 추가, 테스트 5종 추가.

이것은 외부 도구(git) 출력의 OS-process 경계에서 typed variant 로 parse 하는 root fix 입니다. typing 을 회피하기 위해 추가한 string classifier 가 아닙니다 (CLAUDE.md 워크어라운드 시그니처 #2 의 정반대 — closed-sum exhaustive match 강화).

## 로컬 검증

- `dune build --root . lib/exec/.masc_exec.objs/byte/masc_exec__Exec_semantic.cmo` — EXIT 0
- `dune build --root . lib/exec/test/test_exec_semantic.exe` — EXIT 0
- `dune exec --root . lib/exec/test/test_exec_semantic.exe` — `test_exec_semantic: ok`
- 변경 3파일 ocamlformat-clean (0.29.0 janestreet)
- 기존 `test_git_not_a_repo` / `test_git_not_a_repo_via_path` (empty-stderr) 회귀 없음

## 미검증 / 후속

- 다른 git exit-128 fatal(merge conflict, lock file, bad config)은 여전히 `Git_not_a_repo` 로 떨어집니다. 이 catch-all 의 over-broad 함은 별도 follow-up 으로 남깁니다.

RFC-WAIVED: lib/exec/ 는 execution semantics (post-exec 분류) 레이어로 keeper/sandbox/credential/operator RFC-gate 경로에 해당하지 않습니다.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
