### PR TITLE
feat(keeper): load runtime defaults from external runtime files

### DIFF
--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -140,6 +140,66 @@ let load_persona_defaults ~name : keeper_profile_defaults option =
                })
 ;;
 
+(* ── Runtime defaults loading ──────────────────────────────────────────── *)
+
+let load_runtime_defaults ~name : keeper_profile_defaults option =
+  let runtime_dir_opt () =
+    try
+      Config_dir_resolver.log_warnings ~context:"KeeperTypesProfile" ();
+      match Config_dir_resolver.current_env_config_dir_opt () with
+      | None -> None
+      | Some dir -> Some (Filename.concat dir "runtimes")
+    with
+    | Sys_error _ -> None
+    | exn ->
+      Log.Keeper.warn
+        "load_runtime_defaults runtime_dir_opt unexpected: %s"
+        (Printexc.to_string exn);
+      None
+  in
+  match runtime_dir_opt () with
+  | None -> None
+  | Some root ->
+      let path = Filename.concat root (name ^ ".json") in
+      if not (Fs_compat.file_exists path)
+      then None
+      else
+        (match
+           Safe_ops.read_json_file_logged ~label:"load_runtime_defaults" path
+         with
+         | None -> None
+         | Some json ->
+             let bool_ key = Safe_ops.json_bool_opt key json in
+             let int_ key = Safe_ops.json_int_opt key json in
+             let str key = Safe_ops.json_string_opt key json in
+             let strs key =
+               match Safe_ops.json_string_list key json with
+               | [] -> None
+               | xs -> Some xs
+             in
+             Some
+               {
+                 empty_keeper_profile_defaults with
+                 sandbox_profile =
+                   Option.bind (str "sandbox_profile") sandbox_profile_of_string;
+                 sandbox_image = str "sandbox_image";
+                 network_mode =
+                   Option.bind (str "network_mode") network_mode_of_string;
+                 tool_access = strs "tool_access";
+                 tool_denylist = strs "tool_denylist";
+                 proactive_enabled = bool_ "proactive_enabled";
+                 proactive_idle_sec = int_ "proactive_idle_sec";
+                 proactive_cooldown_sec = int_ "proactive_cooldown_sec";
+                 max_turns_per_call = int_ "max_turns_per_call";
+                 max_turns_per_call_scheduled_autonomous =
+                   int_ "max_turns_per_call_scheduled_autonomous";
+                 always_approve = bool_ "always_approve";
+                 autoboot_enabled = bool_ "autoboot_enabled";
+                 shards = strs "shards";
+                 allowed_paths = strs "allowed_paths";
+               })
+;;
+
 (* ── JSON workspace-seq helpers ───────────────────────────────────────── *)
 
 let workspace_seq_map_to_json (items : (string * int) list) : Yojson.Safe.t =
@@ -360,22 +420,38 @@ let load_keeper_profile_defaults_result_uncached name :
   (* Priority: TOML config/keepers/<name>.toml > persona profile.json.
      If TOML sets [persona_name], load that persona first and treat TOML as a
      thin overlay instead of duplicating the full keeper profile. *)
-  match keeper_toml_path_opt name with
-  | Some toml_path ->
-    (match load_keeper_toml toml_path with
-     | Ok (_name, defaults) -> (
-         match defaults.persona_name with
-         | Some persona_name ->
-             let persona_defaults =
-               load_keeper_profile_defaults_from_persona persona_name
-             in
-             Ok
-               (merge_keeper_profile_defaults ~agent_name:name
-                  ~base:persona_defaults ~overlay:defaults)
-         | None -> Ok defaults)
-     | Error e -> Error e)
-  | None ->
-    Ok (load_keeper_profile_defaults_from_persona name)
+  let result =
+    match keeper_toml_path_opt name with
+    | Some toml_path ->
+      (match load_keeper_toml toml_path with
+       | Ok (_name, defaults) -> (
+           match defaults.persona_name with
+           | Some persona_name ->
+               let persona_defaults =
+                 load_keeper_profile_defaults_from_persona persona_name
+               in
+               Ok
+                 (merge_keeper_profile_defaults ~agent_name:name
+                    ~base:persona_defaults ~overlay:defaults)
+           | None -> Ok defaults)
+       | Error e -> Error e)
+    | None ->
+      Ok (load_keeper_profile_defaults_from_persona name)
+  in
+  (* Runtime overlay: if the resolved config has runtime_ref, load the
+     runtime file and merge it as base (keeper config wins on conflict). *)
+  match result with
+  | Error _ -> result
+  | Ok defaults ->
+      match defaults.runtime_ref with
+      | None -> result
+      | Some runtime_name ->
+          match load_runtime_defaults ~name:runtime_name with
+          | None -> result
+          | Some runtime_defaults ->
+              Ok
+                (merge_keeper_profile_defaults ~agent_name:name
+                   ~base:runtime_defaults ~overlay:defaults)
 
 (* Classify a [load_keeper_toml] failure message into a low-cardinality
    label suitable for Prometheus. The raw error string embeds user input

--- a/lib/keeper/keeper_types_profile.mli
+++ b/lib/keeper/keeper_types_profile.mli
@@ -157,6 +157,7 @@ val keeper_default_source_snapshot : string -> keeper_default_source_snapshot
 val persona_description_max_chars : int
 val load_persona_extended : ?max_chars:int -> string -> string option
 val load_persona_defaults : name:string -> keeper_profile_defaults option
+val load_runtime_defaults : name:string -> keeper_profile_defaults option
 val load_persona_summary : string -> persona_summary option
 val load_persona_summary_from_path : string -> string -> persona_summary option
 val list_persona_summaries : unit -> persona_summary list


### PR DESCRIPTION
## Summary
Adds `load_runtime_defaults` that reads runtime configuration from
`.masc/runtimes/{name}.json`.

When keeper config has `runtime_ref` set (from PR-1), the loader now:
1. Resolves keeper config via TOML or persona (existing behavior)
2. Loads runtime defaults from external runtime file
3. Merges: runtime as base, keeper config as overlay (keeper wins)

This completes the template-instance separation for execution
environment (runtime) independent of keeper identity.

## Changes
- `keeper_types_profile.ml`: add `load_runtime_defaults` + integrate into `load_keeper_profile_defaults_result_uncached`
- `keeper_types_profile.mli`: expose `load_runtime_defaults`

## Runtime File Structure
```
.masc/runtimes/
  {name}.json  # { sandbox_profile, network_mode, tool_access, proactive_enabled, ... }
```

## Stacked PR Series
- #19974 (merged): type fields + codec
- #19978 (merged): persona file loading
- **This PR**: runtime file loading
- Next: remove deprecated inline fields

## Verification
- `dune build @check` passes

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>