### PR TITLE
docs(tool): add Pipeline usage examples to Execute tool description

### DIFF
--- a/lib/tool_shard_types_schemas_execute.ml
+++ b/lib/tool_shard_types_schemas_execute.ml
@@ -225,6 +225,13 @@ let tool_execute_description =
    use Grep when visible; for file edits use Edit. Long-running commands must \
    be split or run through a dedicated structured workflow; this tool no longer \
    exposes background task lifecycle tools. \
+   PIPELINE USAGE: When you need to chain commands (e.g., 'cmd1 | cmd2'), use \
+   the 'pipeline' field instead of shell syntax. Each stage is an object with \
+   'executable' and 'argv'. Example: pipeline=[{executable='rg', argv=['-n', \
+   'pattern', 'file.ml']}, {executable='head', argv=['-60']}]. \
+   NEVER use 'sh -c' or 'bash -c' — shell interpreters are not in the allowlist. \
+   Instead of 'sh -c \"awk ...\"', use 'sed' or 'rg' directly. \
+   Instead of 'sh -c \"cmd1 | cmd2\"', use pipeline with two stages. \
    COMMON REJECTIONS: 'executable' must be a non-empty allowlisted command name \
    (e.g. 'cat', 'ls', 'gh'); never the empty string ''. Never collapse the entire \
    command into a single string like \"'' -c 'ls -la'\" — that is shell-style and \


### PR DESCRIPTION
## Changes

Execute tool description에 Pipeline 사용법 구체적인 예시 추가.

**문제**: Keeper가 `sh -c 'awk ... | head -60'` 같은 명령을 시도하지만 `sh`는 allowlist에 없어서 차단됨.

**해결**: Tool description에 다음 명시:
1. `sh -c`나 `bash -c`는 사용 불가 (allowlist에 없음)
2. `awk` 대신 `sed` 또는 `rg` 직접 사용
3. 파이프 체인은 `pipeline` 필드로 구현
4. 구체적인 예시 추가

## Example

**잘못된 형식:**
```json
{"executable": "sh", "argv": ["-c", "awk '/pattern/' file | head -60"]}
```

**올바른 형식:**
```json
{"pipeline": [
  {"executable": "rg", "argv": ["-n", "pattern", "file.ml"]},
  {"executable": "head", "argv": ["-60"]}
]}
```

## Related
- Keeper nick0cave 에러 로그 (2026-06-04 01:49:34)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>