### PR TITLE
refactor(keeper): classify contract violations via receipt decoder

### DIFF
--- a/lib/keeper/keeper_terminal_reason.ml
+++ b/lib/keeper/keeper_terminal_reason.ml
@@ -63,6 +63,12 @@ let contains_config_or_auth lowered =
   || String_util.contains_substring lowered "auth"
 ;;
 
+let is_completion_contract_violation_wire lowered =
+  match Keeper_execution_receipt_types.decode_contract_violation_reason lowered with
+  | Some _ -> true
+  | None -> false
+;;
+
 (* Priority-ranked partition. The bucket order replicates the [if/else]
    order of the pre-typing [operator_disposition] string predicates;
    [of_wire] returns the FIRST matching bucket. The original
@@ -80,7 +86,7 @@ let of_wire wire =
     String.starts_with ~prefix:"api_error_" lowered
     || String.equal lowered "provider_error"
   then Provider_runtime_failure wire
-  else if String.starts_with ~prefix:"completion_contract_violation:" lowered
+  else if is_completion_contract_violation_wire lowered
   then Completion_contract_violation wire
   else if String.starts_with ~prefix:"turn_livelock:" lowered
   then Turn_livelock wire

--- a/lib/keeper/keeper_terminal_reason.mli
+++ b/lib/keeper/keeper_terminal_reason.mli
@@ -8,7 +8,7 @@
     - [Keeper_turn_terminal_code] (RFC-0042 PR-1/PR-2.5) is the
       {e producer-side} bridge from [Keeper_registry.failure_reason] /
       [Agent_sdk.Error.sdk_error]. Its [of_wire] returns [None] for the
-      SDK-error codes ([api_error_*], [completion_contract_violation:*],
+      SDK-error codes ([api_error_*], receipt contract-violation wires,
       [turn_livelock:*], the budget prefixes, [internal_error]) because
       they are all collapsed into its [Sdk_error of string] blob — the
       sub-sum RFC-0042 §5.2 explicitly defers. Matching on [Sdk_error s]
@@ -69,7 +69,8 @@ type t =
           preserving the pre-typing behaviour. Payload is the original
           string. *)
   | Completion_contract_violation of string
-  (** Wire [String.starts_with ~prefix:"completion_contract_violation:"],
+  (** Wire parsed by
+          [Keeper_execution_receipt_types.decode_contract_violation_reason],
           including the extended [:called[..]:satisfying[..]] form. Payload
           is the original string. *)
   | Turn_livelock of string

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -18,6 +18,7 @@
       caught here. *)
 
 module R = Masc.Keeper_execution_receipt
+module Rt = Masc.Keeper_execution_receipt_types
 module Tr = Masc.Keeper_terminal_reason
 
 let failures = ref []
@@ -86,6 +87,30 @@ let () =
        check
          (Printf.sprintf "roundtrip: %S -> %S" s got)
          (String.equal got s))
+    roundtrip_corpus
+;;
+
+let () =
+  List.iter
+    (fun s ->
+       let decoded =
+         Rt.decode_contract_violation_reason (String.lowercase_ascii s)
+       in
+       let classified =
+         match Tr.of_wire s with
+         | Tr.Completion_contract_violation _ -> true
+         | Tr.Runtime_exhausted _
+         | Tr.Config_or_auth _
+         | Tr.Provider_runtime_failure _
+         | Tr.Turn_livelock _
+         | Tr.Internal_error _
+         | Tr.Auto_recoverable_budget _
+         | Tr.Pre_dispatch_success _
+         | Tr.Other _ -> false
+       in
+       check
+         (Printf.sprintf "contract decoder alignment: %S" s)
+         (Option.is_some decoded = classified))
     roundtrip_corpus
 ;;
 


### PR DESCRIPTION
## Summary

- route `completion_contract_violation:*` terminal-reason classification through the existing receipt contract-violation decoder
- keep the frozen pre-typing substring oracle unchanged
- add a decoder/classifier alignment assertion over the terminal-reason corpus

## Verification

- `git diff --check origin/main...HEAD`
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-terminal-contract-decoder-final dune exec --root . test/test_keeper_terminal_reason_typed.exe`
