### PR TITLE
refactor(keeper): remove tool_contract — completion_contract rename + drop tool_route_blocked

### DIFF
--- a/lib/dashboard/dashboard_goals_types_builder.ml
+++ b/lib/dashboard/dashboard_goals_types_builder.ml
@@ -182,8 +182,8 @@ let runtime_trust_from_receipt_fallback ~config ~(meta : Keeper_meta_contract.ke
       ( "execution_summary",
         `Assoc
           [
-            ( "tool_contract_result",
-              Option.value ~default:`Null (Json_util.assoc_member_opt "tool_contract_result" receipt) );
+            ( "completion_contract_result",
+              Option.value ~default:`Null (Json_util.assoc_member_opt "completion_contract_result" receipt) );
             ("latest_receipt_at", `String ts);
           ] );
       ("runtime_blockers", `Assoc runtime_blocker_fields);

--- a/lib/dashboard/dashboard_http_keeper_trust.ml
+++ b/lib/dashboard/dashboard_http_keeper_trust.ml
@@ -73,9 +73,9 @@ let keeper_trust_json ?(include_receipt = false)
         match latest_receipt with
         | Some receipt -> Option.value ~default:(`String "no_receipt") (Json_util.assoc_member_opt "operator_disposition_reason" receipt)
         | None -> `String "no_receipt" );
-      ( "tool_contract_result",
+      ( "completion_contract_result",
         match latest_receipt with
-        | Some receipt -> Option.value ~default:(`String "unknown") (Json_util.assoc_member_opt "tool_contract_result" receipt)
+        | Some receipt -> Option.value ~default:(`String "unknown") (Json_util.assoc_member_opt "completion_contract_result" receipt)
         | None -> `String "unknown" );
       ("requested_tool_count", `Int (List.length requested_tools));
       ("tools_used", `List (List.map (fun value -> `String value) tools_used));

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -21,8 +21,8 @@ let no_progress_success_tool_names_for_contract =
   Contract_helpers.no_progress_success_tool_names_for_contract
 ;;
 
-let tool_contract_result_for_observed_tools =
-  Turn_helpers.tool_contract_result_for_observed_tools
+let completion_contract_result_for_progress_evidence =
+  Turn_helpers.completion_contract_result_for_progress_evidence
 
 module For_testing = struct
   let sse_event_progress_kind = Turn_helpers.sse_event_progress_kind
@@ -677,7 +677,7 @@ let run_turn
                  if valid_tool_calls_present then acc.keeper_surface_tool_used <- true;
                  if unexpected_tool_names <> [] && not valid_tool_calls_present
                  then (
-                   acc.receipt_tool_contract_result <-
+                   acc.receipt_completion_contract_result <-
                      Keeper_execution_receipt.Contract_violated;
                    Error
                      (Keeper_agent_run_tool_surface_violation.to_sdk_error
@@ -733,13 +733,13 @@ let run_turn
                        ~actual_input_tokens:(Some usage.input_tokens)
                    in
                    let tool_contract_status ()
-                       : Keeper_execution_receipt.tool_contract_result =
-                     Contract_helpers.observed_tool_contract_status
+                       : Keeper_execution_receipt.completion_contract_result =
+                     Contract_helpers.observed_completion_contract_status
                        ~had_owned_active_task_at_turn_start
                        ~actual_keeper_tool_names:progress_keeper_tool_names
                    in
                    let text_result =
-                     acc.receipt_tool_contract_result <- tool_contract_status ();
+                     acc.receipt_completion_contract_result <- tool_contract_status ();
                      Ok (`Provider_text text)
                    in
                    match text_result with

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -13,10 +13,10 @@ include module type of Keeper_agent_checkpoint_hygiene
 module Contract_helpers = Keeper_agent_run_contract_helpers
 module Turn_helpers = Keeper_agent_run_turn_helpers
 
-val tool_contract_result_for_observed_tools
+val completion_contract_result_for_progress_evidence
   :  had_owned_active_task_at_turn_start:bool
   -> actual_keeper_tool_names:string list
-  -> Keeper_execution_receipt.tool_contract_result
+  -> Keeper_execution_receipt.completion_contract_result
 
 module For_testing : sig
   val sse_event_progress_kind : Agent_sdk.Types.sse_event -> string option

--- a/lib/keeper/keeper_agent_run_contract_helpers.ml
+++ b/lib/keeper/keeper_agent_run_contract_helpers.ml
@@ -54,17 +54,17 @@ let no_progress_success_tool_names_for_contract
   keeper_tool_names_for_outcome ~allowed_tool_names ~tool_calls ~outcome:"ok_no_progress"
 ;;
 
-let observed_tool_contract_status
+let observed_completion_contract_status
       ~had_owned_active_task_at_turn_start ~actual_keeper_tool_names
-  : Keeper_execution_receipt.tool_contract_result
+  : Keeper_execution_receipt.completion_contract_result
   =
-  Keeper_agent_run_turn_helpers.tool_contract_result_for_observed_tools
+  Keeper_agent_run_turn_helpers.completion_contract_result_for_progress_evidence
     ~had_owned_active_task_at_turn_start
     ~actual_keeper_tool_names
 ;;
 
-let text_only_violation_contract_status ~actual_keeper_tool_names ~fallback
-  : Keeper_execution_receipt.tool_contract_result
+let text_only_violation_completion_contract_status ~actual_keeper_tool_names ~fallback
+  : Keeper_execution_receipt.completion_contract_result
   =
   if actual_keeper_tool_names = []
   then Contract_violated

--- a/lib/keeper/keeper_agent_run_contract_helpers.mli
+++ b/lib/keeper/keeper_agent_run_contract_helpers.mli
@@ -19,7 +19,7 @@ val no_progress_success_tool_names_for_contract :
   tool_calls:Keeper_agent_result.tool_call_detail list ->
   string list
 
-val observed_tool_contract_status :
+val observed_completion_contract_status :
   had_owned_active_task_at_turn_start:bool ->
   actual_keeper_tool_names:string list ->
-  Keeper_execution_receipt.tool_contract_result
+  Keeper_execution_receipt.completion_contract_result

--- a/lib/keeper/keeper_agent_run_receipt.ml
+++ b/lib/keeper/keeper_agent_run_receipt.ml
@@ -125,10 +125,10 @@ let finalize
       ( Some (Keeper_execution_receipt.error_kind_of_string (Keeper_agent_error.sdk_error_kind err))
       , Some (Agent_sdk.Error.to_string err) )
   in
-  let tool_contract_result
-      : Keeper_execution_receipt.tool_contract_result =
+  let completion_contract_result
+      : Keeper_execution_receipt.completion_contract_result =
     match turn_result with
-    | _ -> acc.receipt_tool_contract_result
+    | _ -> acc.receipt_completion_contract_result
   in
   let terminal_reason_code =
     match turn_result with
@@ -177,7 +177,7 @@ let finalize
     ; canonical_tools = !canonical_tool_names_ref
     ; unexpected_tools = !unexpected_tool_names_ref
     ; tools_used = !actual_keeper_tool_names_ref
-    ; tool_contract_result
+    ; completion_contract_result
     ; tool_surface =
         { turn_lane = acc.tool_surface.turn_lane
         ; tool_surface_class = acc.tool_surface.tool_surface_class

--- a/lib/keeper/keeper_agent_run_turn_helpers.ml
+++ b/lib/keeper/keeper_agent_run_turn_helpers.ml
@@ -73,10 +73,10 @@ let registry_progress_on_event ~record_turn_progress downstream event =
   Option.iter (fun cb -> cb event) downstream
 
 
-let tool_contract_result_for_observed_tools
+let completion_contract_result_for_progress_evidence
     ~(had_owned_active_task_at_turn_start : bool)
     ~(actual_keeper_tool_names : string list) :
-    Keeper_execution_receipt.tool_contract_result =
+    Keeper_execution_receipt.completion_contract_result =
   let class_of name = Keeper_tool_progress.classify_tool_progress name in
   let classes = List.map class_of actual_keeper_tool_names in
   let has_class wanted = List.exists (( = ) wanted) classes in

--- a/lib/keeper/keeper_agent_run_turn_helpers.mli
+++ b/lib/keeper/keeper_agent_run_turn_helpers.mli
@@ -20,10 +20,10 @@ val registry_progress_on_event :
   Agent_sdk.Types.sse_event ->
   unit
 
-val tool_contract_result_for_observed_tools :
+val completion_contract_result_for_progress_evidence :
   had_owned_active_task_at_turn_start:bool ->
   actual_keeper_tool_names:string list ->
-  Keeper_execution_receipt.tool_contract_result
+  Keeper_execution_receipt.completion_contract_result
 
 val emit_turn_end_safely : keeper_name:string -> unit -> unit
 val digest_text : string -> string

--- a/lib/keeper/keeper_contract_classifier.ml
+++ b/lib/keeper/keeper_contract_classifier.ml
@@ -4,7 +4,6 @@ type actionable_signal =
   | No_actionable_signal
 
 type contract_status =
-  | Tool_surface_mismatch of { missing : string list }
   | Claim_only_after_owned_task
   | Needs_execution_progress
   | Passive_only
@@ -17,18 +16,14 @@ let actionable_signal_label = function
   | No_actionable_signal -> "no_actionable_signal"
 
 let contract_status_label = function
-  | Tool_surface_mismatch _ -> "tool_surface_mismatch"
   | Claim_only_after_owned_task -> "claim_only_after_owned_task"
   | Needs_execution_progress -> "needs_execution_progress"
   | Passive_only -> "passive_only"
   | Satisfied_completion -> "satisfied_completion"
   | Satisfied_execution -> "satisfied_execution"
 
-let pp_contract_status fmt = function
-  | Tool_surface_mismatch { missing } ->
-      Format.fprintf fmt "tool_surface_mismatch(missing=[%s])"
-        (String.concat ", " missing)
-  | other -> Format.pp_print_string fmt (contract_status_label other)
+let pp_contract_status fmt status =
+  Format.pp_print_string fmt (contract_status_label status)
 
 type world_observation = {
   unclaimed_task_count : int;

--- a/lib/keeper/keeper_contract_classifier.mli
+++ b/lib/keeper/keeper_contract_classifier.mli
@@ -8,7 +8,6 @@ type actionable_signal =
           world snapshot. *)
 
 type contract_status =
-  | Tool_surface_mismatch of { missing : string list }
   | Claim_only_after_owned_task
   | Needs_execution_progress
   | Passive_only

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -206,7 +206,6 @@ type operator_disposition_reason =
   | Reason_transient_runtime_retry
   | Reason_provider_runtime_error
   | Reason_internal_error
-  | Reason_tool_route_recoverable_failure
   | Reason_turn_budget_exhausted
   | Reason_turn_livelock_blocked
   | Reason_cancelled
@@ -222,7 +221,6 @@ let operator_disposition_reason_to_string = function
   | Reason_transient_runtime_retry -> "transient_runtime_retry"
   | Reason_provider_runtime_error -> "provider_runtime_error"
   | Reason_internal_error -> "internal_error"
-  | Reason_tool_route_recoverable_failure -> "tool_route_recoverable_failure"
   | Reason_turn_budget_exhausted -> "turn_budget_exhausted"
   | Reason_turn_livelock_blocked -> "turn_livelock_blocked"
   | Reason_cancelled -> "cancelled"
@@ -368,21 +366,7 @@ let operator_disposition (receipt : t)
        [provider_runtime_failure] true), so only [Pre_dispatch_success] and
        [Other] reach here in practice; the first two are listed to keep the
        match exhaustive without a wildcard. *)
-    let tool_route_failure =
-      List.mem
-        receipt.tool_contract_result
-        [ Contract_tool_surface_mismatch; Contract_no_tool_capable_provider ]
-    in
-    if tool_route_failure
-    then
-      if receipt.degraded_retry_applied || Option.is_some receipt.degraded_retry_runtime
-      then Disp_fail_open_next_runtime, Reason_tool_route_recoverable_failure
-      else if
-        receipt.runtime_fallback_applied
-        || receipt.runtime_outcome = Runtime_passed_to_next_model
-      then Disp_pass_next_model, Reason_tool_route_recoverable_failure
-      else Disp_pause_human, Reason_tool_route_recoverable_failure
-    else if
+    if
       receipt.degraded_retry_applied || Option.is_some receipt.degraded_retry_runtime
     then Disp_fail_open_next_runtime, Reason_degraded_retry
     else if
@@ -392,7 +376,6 @@ let operator_disposition (receipt : t)
     else if
       receipt.outcome = `Ok
       && receipt.runtime_outcome = Runtime_not_dispatched
-      && receipt.tool_contract_result = Contract_not_dispatched
       &&
       (match terminal_reason with
        | Keeper_terminal_reason.Pre_dispatch_success _ -> true
@@ -438,12 +421,12 @@ let operator_disposition (receipt : t)
           ();
         Log.Keeper.warn
           "operator_disposition: unmapped (outcome=%s runtime_outcome=%s \
-           terminal_reason=%s tool_contract_result=%s error_kind=%s) — investigate \
+           terminal_reason=%s completion_contract=%s error_kind=%s) — investigate \
            regression of #11651 silent-path fix"
           (outcome_kind_to_string receipt.outcome)
           (runtime_outcome_to_string receipt.runtime_outcome)
           receipt.terminal_reason_code
-          (tool_contract_result_to_string receipt.tool_contract_result)
+          (completion_contract_result_to_string receipt.completion_contract_result)
           (Option.value
              (Option.map error_kind_to_string receipt.error_kind)
              ~default:"<none>");
@@ -532,8 +515,8 @@ let to_json (receipt : t) =
     ; "unexpected_tools", list_json receipt.unexpected_tools
     ; "tools_used", list_json receipt.tools_used
     ; "tool_descriptor_summary", tool_descriptor_summary_json receipt
-    ; ( "tool_contract_result"
-      , `String (tool_contract_result_to_string receipt.tool_contract_result) )
+    ; ( "completion_contract_result"
+      , `String (completion_contract_result_to_string receipt.completion_contract_result) )
     ; ( "tool_surface"
       , `Assoc
           [ ( "turn_lane"
@@ -731,8 +714,8 @@ let operator_broadcast_payload (receipt : t) ~disposition ~reason =
     ; "response_text_present", `Bool receipt.response_text_present
     ; "runtime_id", `String (receipt.runtime_id)
     ; "runtime_outcome", `String (runtime_outcome_to_string receipt.runtime_outcome)
-    ; ( "tool_contract_result"
-      , `String (tool_contract_result_to_string receipt.tool_contract_result) )
+    ; ( "completion_contract_result"
+      , `String (completion_contract_result_to_string receipt.completion_contract_result) )
     ; ( "last_tool_name", string_opt_json (last_tool_name receipt) )
     ; "tools_used", list_json receipt.tools_used
     ; ( "contract_violation_detail"
@@ -744,26 +727,6 @@ let operator_broadcast_payload (receipt : t) ~disposition ~reason =
             ; "called_tools", list_json called
             ; "satisfying_tools", list_json satisfying
             ] )
-    ; ( "tool_contract"
-      , `Assoc
-          [ ( "result"
-            , `String (tool_contract_result_to_string receipt.tool_contract_result) )
-          ; "visible_tool_count", `Int receipt.tool_surface.visible_tool_count
-          ; ( "tool_requirement"
-            , Keeper_agent_tool_surface.tool_requirement_to_yojson
-                receipt.tool_surface.tool_requirement )
-          ; ( "turn_lane"
-            , Keeper_agent_tool_surface.turn_lane_to_yojson
-                receipt.tool_surface.turn_lane )
-          ; ( "tool_surface_class"
-            , Keeper_agent_tool_surface.tool_surface_class_to_yojson
-                receipt.tool_surface.tool_surface_class )
-          ; "tool_gate_enabled", `Bool receipt.tool_surface.tool_gate_enabled
-          ; ( "tool_surface_fallback_used"
-            , `Bool receipt.tool_surface.tool_surface_fallback_used )
-          ; ( "materialized_tools"
-            , list_json receipt.tool_surface.materialized_tools )
-          ] )
     ; ( "sandbox"
       , `Assoc
           [ "kind", `String (Keeper_types_profile_sandbox.sandbox_profile_to_string receipt.sandbox_kind)

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -127,26 +127,23 @@ val runtime_outcome_to_string : runtime_outcome -> string
 (** Receipt-level tool-contract evaluation result. Closed union of three
     producer paths: (i) initial-state sentinel [Contract_unknown];
     (ii) boundary-state overrides [Contract_not_dispatched],
-    [Contract_violated], [Contract_no_tool_capable_provider]; (iii) the
-    six classifier outcomes mirrored from
+    [Contract_violated]; (iii) the five classifier outcomes mirrored from
     [Keeper_contract_classifier.contract_status]. *)
-type tool_contract_result =
+type completion_contract_result =
   | Contract_unknown
   | Contract_not_dispatched
   | Contract_violated
-  | Contract_tool_surface_mismatch
-  | Contract_no_tool_capable_provider
   | Contract_claim_only_after_owned_task
   | Contract_needs_execution_progress
   | Contract_passive_only
   | Contract_satisfied_completion
   | Contract_satisfied_execution
 
-val tool_contract_result_to_string : tool_contract_result -> string
+val completion_contract_result_to_string : completion_contract_result -> string
 
-val tool_contract_result_of_contract_status
+val completion_contract_result_of_contract_status
   :  Keeper_contract_classifier.contract_status
-  -> tool_contract_result
+  -> completion_contract_result
 
 (** {2 Structured contract-violation encoding} *)
 
@@ -207,7 +204,7 @@ type t =
   ; canonical_tools : string list
   ; unexpected_tools : string list
   ; tools_used : string list
-  ; tool_contract_result : tool_contract_result
+  ; completion_contract_result : completion_contract_result
   ; tool_surface : tool_surface
   ; sandbox_kind : Keeper_types_profile_sandbox.sandbox_profile
   ; sandbox_root : string option
@@ -284,7 +281,6 @@ type operator_disposition_reason =
       fall-through emitted. *)
   | Reason_provider_runtime_error
   | Reason_internal_error
-  | Reason_tool_route_recoverable_failure
   | Reason_turn_budget_exhausted
   | Reason_turn_livelock_blocked
   | Reason_cancelled

--- a/lib/keeper/keeper_execution_receipt_types.ml
+++ b/lib/keeper/keeper_execution_receipt_types.ml
@@ -123,41 +123,34 @@ let runtime_outcome_to_string = function
   | Runtime_not_dispatched -> "not_dispatched"
 ;;
 
-(* Receipt-level result of the tool-contract evaluation for the turn.
+(* Receipt-level result of the completion-contract evaluation for the turn.
    Closed union of three producer paths:
      1. Initial-state sentinel from [keeper_run_tools]: [Contract_unknown].
      2. Boundary-state overrides: [Contract_violated] (agent_run
         CompletionContractViolation), [Contract_not_dispatched]
-        (turn_helpers pre-dispatch), [Contract_no_tool_capable_provider]
-        (run_tools no-provider escape).
-     3. Six outcomes mirrored from
+        (turn_helpers pre-dispatch).
+     3. Five outcomes mirrored from
         [Keeper_contract_classifier.contract_status_label]:
-        [Contract_tool_surface_mismatch], [Contract_claim_only_after_owned_task],
+        [Contract_claim_only_after_owned_task],
         [Contract_needs_execution_progress], [Contract_passive_only],
         [Contract_satisfied_completion],
         [Contract_satisfied_execution].
    JSON wire form is the lowercase string via
-   [tool_contract_result_to_string].  No raw ["satisfied"] variant —
-   producer never emits it; closed type makes the fictional test fixture
-   string unrepresentable. *)
-type tool_contract_result =
+   [completion_contract_result_to_string]. *)
+type completion_contract_result =
   | Contract_unknown
   | Contract_not_dispatched
   | Contract_violated
-  | Contract_tool_surface_mismatch
-  | Contract_no_tool_capable_provider
   | Contract_claim_only_after_owned_task
   | Contract_needs_execution_progress
   | Contract_passive_only
   | Contract_satisfied_completion
   | Contract_satisfied_execution
 
-let tool_contract_result_to_string = function
+let completion_contract_result_to_string = function
   | Contract_unknown -> "unknown"
   | Contract_not_dispatched -> "not_dispatched"
   | Contract_violated -> "violated"
-  | Contract_tool_surface_mismatch -> "tool_surface_mismatch"
-  | Contract_no_tool_capable_provider -> "no_tool_capable_provider"
   | Contract_claim_only_after_owned_task -> "claim_only_after_owned_task"
   | Contract_needs_execution_progress -> "needs_execution_progress"
   | Contract_passive_only -> "passive_only"
@@ -166,13 +159,12 @@ let tool_contract_result_to_string = function
 ;;
 
 (* Lift the typed [Keeper_contract_classifier.contract_status] into the
-   receipt-level [tool_contract_result].  Bridges the six classifier
-   outcomes; the four boundary states are emitted only by producer sites
-   that already know they hold one of those states. *)
-let tool_contract_result_of_contract_status
-  : Keeper_contract_classifier.contract_status -> tool_contract_result
+   receipt-level [completion_contract_result].  Bridges the five classifier
+   outcomes; boundary states are emitted only by producer sites that already
+   know they hold one of those states. *)
+let completion_contract_result_of_contract_status
+  : Keeper_contract_classifier.contract_status -> completion_contract_result
   = function
-  | Tool_surface_mismatch _ -> Contract_tool_surface_mismatch
   | Claim_only_after_owned_task -> Contract_claim_only_after_owned_task
   | Needs_execution_progress -> Contract_needs_execution_progress
   | Passive_only -> Contract_passive_only
@@ -288,7 +280,7 @@ type t =
   ; canonical_tools : string list
   ; unexpected_tools : string list
   ; tools_used : string list
-  ; tool_contract_result : tool_contract_result
+  ; completion_contract_result : completion_contract_result
   ; tool_surface : tool_surface
   ; sandbox_kind : Keeper_types_profile_sandbox.sandbox_profile
   ; sandbox_root : string option

--- a/lib/keeper/keeper_execution_receipt_types.mli
+++ b/lib/keeper/keeper_execution_receipt_types.mli
@@ -53,20 +53,18 @@ type runtime_outcome =
   | Runtime_not_observed
   | Runtime_not_dispatched
 val runtime_outcome_to_string : runtime_outcome -> string
-type tool_contract_result =
+type completion_contract_result =
     Contract_unknown
   | Contract_not_dispatched
   | Contract_violated
-  | Contract_tool_surface_mismatch
-  | Contract_no_tool_capable_provider
   | Contract_claim_only_after_owned_task
   | Contract_needs_execution_progress
   | Contract_passive_only
   | Contract_satisfied_completion
   | Contract_satisfied_execution
-val tool_contract_result_to_string : tool_contract_result -> string
-val tool_contract_result_of_contract_status :
-  Keeper_contract_classifier.contract_status -> tool_contract_result
+val completion_contract_result_to_string : completion_contract_result -> string
+val completion_contract_result_of_contract_status :
+  Keeper_contract_classifier.contract_status -> completion_contract_result
 val encode_tool_list : string list -> string
 val encode_contract_violation_reason :
   called_tools:string list ->
@@ -107,7 +105,7 @@ type t = {
   canonical_tools : string list;
   unexpected_tools : string list;
   tools_used : string list;
-  tool_contract_result : tool_contract_result;
+  completion_contract_result : completion_contract_result;
   tool_surface : tool_surface;
   sandbox_kind : Keeper_types_profile_sandbox.sandbox_profile;
   sandbox_root : string option;

--- a/lib/keeper/keeper_internal_error.ml
+++ b/lib/keeper/keeper_internal_error.ml
@@ -553,7 +553,7 @@ let parse_masc_internal_error_json (json : Yojson.Safe.t) :
                    exit_code = int_opt_of_assoc "exit_code" json;
                  })
           | _ -> None)
-      | Some (`String "no_tool_capable_provider") -> (
+      | Some (`String "no_capable_provider") -> (
           match string_opt_of_assoc "runtime_id" json with
           | Some runtime_id ->
             let configured_labels =

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -28,8 +28,8 @@ type hook_accumulator = Keeper_run_tools_hook_accumulator.hook_accumulator =
   ; mutable tool_surface : tool_surface_metrics
   ; mutable requested_tool_names : string list
   ; mutable requested_tool_names_seen : string list
-  ; mutable receipt_tool_contract_result :
-      Keeper_execution_receipt.tool_contract_result
+  ; mutable receipt_completion_contract_result :
+      Keeper_execution_receipt.completion_contract_result
   }
 
 type hook_outputs = Keeper_run_tools_hook_accumulator.hook_outputs =
@@ -41,8 +41,8 @@ type hook_outputs = Keeper_run_tools_hook_accumulator.hook_outputs =
   ; out_tool_surface : tool_surface_metrics
   ; out_requested_tool_names : string list
   ; out_requested_tool_names_seen : string list
-  ; out_receipt_tool_contract_result :
-      Keeper_execution_receipt.tool_contract_result
+  ; out_receipt_completion_contract_result :
+      Keeper_execution_receipt.completion_contract_result
   }
 
 let freeze = Keeper_run_tools_hook_accumulator.freeze

--- a/lib/keeper/keeper_run_tools.mli
+++ b/lib/keeper/keeper_run_tools.mli
@@ -26,8 +26,8 @@ type hook_accumulator =
   ; mutable tool_surface : tool_surface_metrics
   ; mutable requested_tool_names : string list
   ; mutable requested_tool_names_seen : string list
-  ; mutable receipt_tool_contract_result :
-      Keeper_execution_receipt.tool_contract_result
+  ; mutable receipt_completion_contract_result :
+      Keeper_execution_receipt.completion_contract_result
   }
 
 (** Immutable snapshot of hook outputs after OAS execution completes. *)
@@ -40,8 +40,8 @@ type hook_outputs =
   ; out_tool_surface : tool_surface_metrics
   ; out_requested_tool_names : string list
   ; out_requested_tool_names_seen : string list
-  ; out_receipt_tool_contract_result :
-      Keeper_execution_receipt.tool_contract_result
+  ; out_receipt_completion_contract_result :
+      Keeper_execution_receipt.completion_contract_result
   }
 
 val freeze : hook_accumulator -> hook_outputs

--- a/lib/keeper/keeper_run_tools_hook_accumulator.ml
+++ b/lib/keeper/keeper_run_tools_hook_accumulator.ml
@@ -22,8 +22,8 @@ type hook_accumulator =
   ; mutable tool_surface : tool_surface_metrics
   ; mutable requested_tool_names : string list
   ; mutable requested_tool_names_seen : string list
-  ; mutable receipt_tool_contract_result :
-      Keeper_execution_receipt.tool_contract_result
+  ; mutable receipt_completion_contract_result :
+      Keeper_execution_receipt.completion_contract_result
   }
 
 type hook_outputs =
@@ -35,8 +35,8 @@ type hook_outputs =
   ; out_tool_surface : tool_surface_metrics
   ; out_requested_tool_names : string list
   ; out_requested_tool_names_seen : string list
-  ; out_receipt_tool_contract_result :
-      Keeper_execution_receipt.tool_contract_result
+  ; out_receipt_completion_contract_result :
+      Keeper_execution_receipt.completion_contract_result
   }
 
 let freeze (acc : hook_accumulator) : hook_outputs =
@@ -48,7 +48,7 @@ let freeze (acc : hook_accumulator) : hook_outputs =
   ; out_tool_surface = acc.tool_surface
   ; out_requested_tool_names = acc.requested_tool_names
   ; out_requested_tool_names_seen = acc.requested_tool_names_seen
-  ; out_receipt_tool_contract_result = acc.receipt_tool_contract_result
+  ; out_receipt_completion_contract_result = acc.receipt_completion_contract_result
   }
 ;;
 

--- a/lib/keeper/keeper_run_tools_hook_accumulator.mli
+++ b/lib/keeper/keeper_run_tools_hook_accumulator.mli
@@ -10,8 +10,8 @@ type hook_accumulator =
   ; mutable tool_surface : Keeper_agent_tool_surface.tool_surface_metrics
   ; mutable requested_tool_names : string list
   ; mutable requested_tool_names_seen : string list
-  ; mutable receipt_tool_contract_result :
-      Keeper_execution_receipt.tool_contract_result
+  ; mutable receipt_completion_contract_result :
+      Keeper_execution_receipt.completion_contract_result
   }
 
 type hook_outputs =
@@ -23,8 +23,8 @@ type hook_outputs =
   ; out_tool_surface : Keeper_agent_tool_surface.tool_surface_metrics
   ; out_requested_tool_names : string list
   ; out_requested_tool_names_seen : string list
-  ; out_receipt_tool_contract_result :
-      Keeper_execution_receipt.tool_contract_result
+  ; out_receipt_completion_contract_result :
+      Keeper_execution_receipt.completion_contract_result
   }
 
 val freeze : hook_accumulator -> hook_outputs

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -136,8 +136,6 @@ let assemble_hooks
       initial_tool_surface.tool_gate_requested
       && initial_tool_surface.turn_visible_tool_names = []
     then (
-      acc.receipt_tool_contract_result <-
-        Keeper_execution_receipt.Contract_no_tool_capable_provider;
       Prometheus.inc_counter
         Prometheus.metric_empty_tool_universe_observed
         ~labels:

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -91,7 +91,7 @@ let prepare_agent_setup
         }
     ; requested_tool_names = []
     ; requested_tool_names_seen = []
-    ; receipt_tool_contract_result =
+    ; receipt_completion_contract_result =
         Keeper_execution_receipt.Contract_unknown
     }
   in

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -23,15 +23,15 @@ let terminal_reason_from_receipt receipt =
     |> Option.map String.lowercase_ascii
   in
   let tool_contract_result =
-    json_string_opt_member "tool_contract_result" receipt
+    json_string_opt_member "completion_contract_result" receipt
     |> Option.map String.lowercase_ascii
   in
   let receipt_requires_tool_attention =
     match operator_disposition, operator_disposition_reason, tool_contract_result with
     | _, Some "tool_route_recoverable_failure", _
     | _, _, Some "needs_execution_progress"
-    | _, _, Some "tool_surface_mismatch"
-    | _, _, Some "no_tool_capable_provider"
+    | _, _, Some "surface_mismatch"
+    | _, _, Some "no_capable_provider"
     | _, _, Some "passive_only"
     | _, _, Some "violated" ->
         true
@@ -73,7 +73,7 @@ let disposition_of_runtime_blocker_class raw_blocker_class =
       Keeper_turn_disposition.Post_commit_ambiguous
   | "sdk_input_required" ->
       Keeper_turn_disposition.Input_required
-  | ("runtime_exhausted" | "no_tool_capable_provider"
+  | ("runtime_exhausted" | "no_capable_provider"
      | "provider_runtime_error") as cls ->
       Keeper_turn_disposition.Provider_error
         (Keeper_turn_terminal_code.Provider_runtime_error cls)
@@ -495,7 +495,7 @@ let execution_summary_json ~(meta : Keeper_meta_contract.keeper_meta) ~latest_re
     | None -> None
   in
   let tool_contract_result =
-    Option.bind latest_receipt (json_string_opt_member "tool_contract_result")
+    Option.bind latest_receipt (json_string_opt_member "completion_contract_result")
   in
   let requested_tools =
     match latest_receipt with
@@ -547,7 +547,7 @@ let execution_summary_json ~(meta : Keeper_meta_contract.keeper_meta) ~latest_re
   in
   `Assoc
     [
-      ("tool_contract_result", Json_util.string_opt_to_json tool_contract_result);
+      ("completion_contract_result", Json_util.string_opt_to_json tool_contract_result);
       ( "runtime_proof_status",
         Json_util.string_opt_to_json tool_contract_result );
       ("requested_tools", Json_util.json_string_list requested_tools);

--- a/lib/keeper/keeper_runtime_trust_timeline.ml
+++ b/lib/keeper/keeper_runtime_trust_timeline.ml
@@ -348,7 +348,7 @@ let receipt_timeline_event receipt =
           |> Option.value ~default:"unknown"
         in
         let tool_contract_result =
-          json_string_opt_member "tool_contract_result" receipt
+          json_string_opt_member "completion_contract_result" receipt
           |> Option.value ~default:"unknown"
         in
         let runtime_outcome =

--- a/lib/keeper/keeper_status_bridge_blocker.ml
+++ b/lib/keeper/keeper_status_bridge_blocker.ml
@@ -268,7 +268,7 @@ let runtime_blocker_surface_of_failure_reason (reason : Keeper_registry.failure_
        ([keeper_unified_turn_types.runtime_exhausted_failure_reason_of_raw_error])
        carries the already-typed [No_tool_capable] reason on the record.
        Reading the typed field instead of reparsing [code =
-       "no_tool_capable_provider"] removes a typed->string->typed round-trip;
+       "no_capable_provider"] removes a typed->string->typed round-trip;
        the [code] string is retained on the record for wire/dashboard readers. *)
     Some
       (runtime_blocker_surface_of_typed_class

--- a/lib/keeper/keeper_turn_helpers.ml
+++ b/lib/keeper/keeper_turn_helpers.ml
@@ -244,7 +244,7 @@ let record_pre_dispatch_terminal_observation
     ; canonical_tools = []
     ; unexpected_tools = []
     ; tools_used = []
-    ; tool_contract_result = Keeper_execution_receipt.Contract_not_dispatched
+    ; completion_contract_result = Keeper_execution_receipt.Contract_not_dispatched
     ; tool_surface = pre_dispatch_tool_surface
     ; sandbox_kind = Keeper_execution_receipt.sandbox_kind_of_meta meta
     ; sandbox_root = Some (Keeper_sandbox.host_root_abs_of_meta ~config meta)

--- a/lib/keeper/keeper_unified_turn_types.ml
+++ b/lib/keeper/keeper_unified_turn_types.ml
@@ -127,7 +127,7 @@ let runtime_exhausted_failure_reason_of_raw_error ~detail raw_error =
     in
     Some
       (Keeper_registry.Provider_runtime_error
-         { code = "no_tool_capable_provider"
+         { code = "no_capable_provider"
              ; detail =
                  Printf.sprintf
                "no tool-capable provider found (runtime=%s labels=[%s]%s)"
@@ -147,7 +147,7 @@ let runtime_exhausted_failure_reason_of_raw_error ~detail raw_error =
          }) ->
     Some
       (Keeper_registry.Provider_runtime_error
-         { code = "no_tool_capable_provider"
+         { code = "no_capable_provider"
          ; detail = "no tool-capable provider found"
          ; provider_id = None
          ; http_status = None

--- a/lib/server/server_dashboard_compact_receipt_json.ml
+++ b/lib/server/server_dashboard_compact_receipt_json.ml
@@ -62,11 +62,7 @@ let compact_receipt_runtime_json receipt =
 ;;
 
 let compact_receipt_tool_surface_json receipt =
-  let surface =
-    match json_member "tool_surface" receipt with
-    | `Assoc _ as surface -> surface
-    | _ -> json_member "tool_contract" receipt
-  in
+  let surface = json_member "tool_surface" receipt in
   match surface with
   | `Assoc _ as surface ->
     let tool_requirement = json_string "tool_requirement" surface in

--- a/lib/server/server_dashboard_http_composite_claims.ml
+++ b/lib/server/server_dashboard_http_composite_claims.ml
@@ -190,7 +190,7 @@ let composite_execution_receipt_json ~(config : Workspace.config) ~keeper_name =
       ; "operator_disposition_reason", `Null
       ; "model_used", `Null
       ; "stop_reason", `Null
-      ; "tool_contract_result", `Null
+      ; "completion_contract_result", `Null
       ; "duration_ms", `Null
       ; "error", `Null
       ; "runtime", `Null
@@ -213,8 +213,8 @@ let composite_execution_receipt_json ~(config : Workspace.config) ~keeper_name =
         )
       ; "model_used", `Null
       ; "stop_reason", Json_util.string_opt_to_json (json_string "stop_reason" receipt)
-      ; ( "tool_contract_result"
-        , Json_util.string_opt_to_json (json_string "tool_contract_result" receipt) )
+      ; ( "completion_contract_result"
+        , Json_util.string_opt_to_json (json_string "completion_contract_result" receipt) )
       ; ( "unexpected_tools"
         , Json_util.json_string_list (Json_util.get_string_list receipt "unexpected_tools") )
       ; ( "unexpected_tool_count"
@@ -290,17 +290,6 @@ let composite_snapshot_is_idle snapshot =
   && Option.value ~default:"clean" breaker_state = "clean"
 ;;
 
-let composite_execution_tool_route_blocked execution =
-  string_opt_is_any
-    (json_string "tool_contract_result" execution)
-    [ "tool_surface_mismatch"
-    ; "no_tool_capable_provider"
-    ]
-  || string_opt_is_any
-       (json_string "operator_disposition_reason" execution)
-       [ "tool_route_recoverable_failure" ]
-;;
-
 let composite_execution_config_blocked execution =
   string_opt_is_any
     (json_string "operator_disposition_reason" execution)
@@ -331,8 +320,7 @@ let composite_execution_config_drift execution =
 let keeper_activation_readiness_json = Server_dashboard_fleet_readiness.keeper_activation_readiness_json
 
 let composite_execution_blocked execution =
-  composite_execution_tool_route_blocked execution
-  || composite_execution_claim_no_eligible execution
+  composite_execution_claim_no_eligible execution
   || string_opt_is_any (json_string "operator_disposition" execution) [ "pause_human" ]
   || (match lower_string_opt (json_string "terminal_reason_code" execution) with
       | Some terminal -> terminal <> "" && terminal <> "completed"

--- a/lib/server/server_dashboard_http_composite_claims.mli
+++ b/lib/server/server_dashboard_http_composite_claims.mli
@@ -34,7 +34,6 @@ val json_string_eq : string -> Yojson.Safe.t -> String.t -> bool
 val composite_latest_activity_epoch :
   Yojson.Safe.t -> Yojson.Safe.t -> float option
 val composite_snapshot_is_idle : Yojson.Safe.t -> bool
-val composite_execution_tool_route_blocked : Yojson.Safe.t -> bool
 val composite_execution_config_blocked : Yojson.Safe.t -> bool
 val composite_execution_saturated : Yojson.Safe.t -> bool
 val composite_execution_claim_no_eligible : Yojson.Safe.t -> bool

--- a/lib/server/server_dashboard_http_composite_enrich.mli
+++ b/lib/server/server_dashboard_http_composite_enrich.mli
@@ -34,7 +34,6 @@ val json_string_eq : string -> Yojson.Safe.t -> String.t -> bool
 val composite_latest_activity_epoch :
   Yojson.Safe.t -> Yojson.Safe.t -> float option
 val composite_snapshot_is_idle : Yojson.Safe.t -> bool
-val composite_execution_tool_route_blocked : Yojson.Safe.t -> bool
 val composite_execution_config_blocked : Yojson.Safe.t -> bool
 val composite_execution_saturated : Yojson.Safe.t -> bool
 val composite_execution_claim_no_eligible : Yojson.Safe.t -> bool

--- a/lib/server/server_dashboard_http_composite_recommendations.ml
+++ b/lib/server/server_dashboard_http_composite_recommendations.ml
@@ -81,11 +81,6 @@ let composite_recommended_actions_json ~keeper_name ~snapshot ~execution ~attent
       [ probe ("Inspect keeper claim scope: " ^ reason)
       ; message ("Resolve keeper claim scope before retry: " ^ reason)
       ]
-    else if composite_execution_tool_route_blocked execution
-    then
-      [ probe ("Inspect tool-route blocker: " ^ reason)
-      ; message ("Resolve tool-route blocker: " ^ reason)
-      ]
     else if composite_execution_config_blocked execution
     then
       [ probe ("Inspect configuration/auth blocker: " ^ reason)

--- a/lib/server/server_dashboard_http_composite_recommendations.mli
+++ b/lib/server/server_dashboard_http_composite_recommendations.mli
@@ -34,7 +34,6 @@ val json_string_eq : string -> Yojson.Safe.t -> String.t -> bool
 val composite_latest_activity_epoch :
   Yojson.Safe.t -> Yojson.Safe.t -> float option
 val composite_snapshot_is_idle : Yojson.Safe.t -> bool
-val composite_execution_tool_route_blocked : Yojson.Safe.t -> bool
 val composite_execution_config_blocked : Yojson.Safe.t -> bool
 val composite_execution_saturated : Yojson.Safe.t -> bool
 val composite_execution_claim_no_eligible : Yojson.Safe.t -> bool

--- a/lib/server/server_dashboard_http_keeper_runtime_lens_gaps.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_gaps.ml
@@ -128,7 +128,7 @@ let runtime_lens_gaps ~terminal_event_present ~claim_scope ~config_drift scan =
        else gaps)
   |> (fun gaps ->
        match pre_dispatch_reason with
-       | Some reason when string_contains ~needle:"no_tool_capable_provider" reason ->
+       | Some reason when string_contains ~needle:"no_capable_provider" reason ->
          add
            { code = "route_tool_capability_gap"
            ; severity = "bad"

--- a/lib/turn_fsm/turn_fsm.ml
+++ b/lib/turn_fsm/turn_fsm.ml
@@ -102,7 +102,7 @@ let cancel_reason_label = function
 
 let failure_reason_label = function
   | Failure_runtime_unavailable _ -> "runtime_unavailable"
-  | Failure_no_tool_capable_provider _ -> "no_tool_capable_provider"
+  | Failure_no_tool_capable_provider _ -> "no_capable_provider"
   | Failure_provider_error _ -> "provider_error"
   | Failure_tool_contract_violation _ -> "tool_contract_violation"
   | Failure_receipt_lost _ -> "receipt_lost"

--- a/test/test_blocker_class_exhaustiveness.ml
+++ b/test/test_blocker_class_exhaustiveness.ml
@@ -250,7 +250,7 @@ let test_structural_timeout_maps_to_oas_timeout () =
 (* The consumer [runtime_blocker_surface_of_failure_reason] now reads the
    typed [reason = Some (No_tool_capable _)] field on
    [Provider_runtime_error] instead of reparsing [code =
-   "no_tool_capable_provider"].  These tests pin that the typed-match path
+   "no_capable_provider"].  These tests pin that the typed-match path
    yields the same blocker surface the old string-match produced, and that a
    non-no_tool_capable provider error still falls through to the
    provider_runtime_error catch-all (no widening). *)
@@ -280,12 +280,12 @@ let test_no_tool_capable_typed_reason_surface () =
         (Some
            (No_tool_capable
               (Some { configured_labels = [ "a" ]; provider_rejections = [] })))
-      ~code:"no_tool_capable_provider"
+      ~code:"no_capable_provider"
   in
   let none_shape =
     no_tool_capable_surface_exn
       ~reason:(Some (No_tool_capable None))
-      ~code:"no_tool_capable_provider"
+      ~code:"no_capable_provider"
   in
   List.iter
     (fun (label, surface) ->

--- a/test/test_keeper_contract_classifier_pure.ml
+++ b/test/test_keeper_contract_classifier_pure.ml
@@ -44,18 +44,6 @@ let test_signal_label_none () =
 
 (* ── contract_status_label ───────────────────────────────────────────── *)
 
-let test_status_label_tool_surface_mismatch () =
-  let rendered =
-    Format.asprintf "%a" KCC.pp_contract_status
-      (KCC.Tool_surface_mismatch { missing = [ "keeper_task_claim"; "masc_broadcast" ] })
-  in
-  (* The stable label is intentionally low-cardinality; the pretty printer
-     carries missing tool names for grep/debug output. *)
-  check_bool "rendered status mentions missing keeper_task_claim" true
-    (Astring.String.is_infix ~affix:"keeper_task_claim" rendered);
-  check_bool "rendered status mentions missing masc_broadcast" true
-    (Astring.String.is_infix ~affix:"masc_broadcast" rendered)
-
 let test_status_label_satisfied_completion () =
   check_string "Satisfied_completion is a stable token"
     "satisfied_completion"
@@ -115,8 +103,6 @@ let () =
         ] );
       ( "contract_status_label",
         [
-          Alcotest.test_case "Tool_surface_mismatch carries missing names"
-            `Quick test_status_label_tool_surface_mismatch;
           Alcotest.test_case "Satisfied_completion stable token" `Quick
             test_status_label_satisfied_completion;
           Alcotest.test_case "Satisfied_execution stable token" `Quick

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -62,7 +62,7 @@ let roundtrip_corpus =
   ; "provider_error_server:500"
   ; "provider_error_missing_api_key"
   ; "provider_error_hard_quota:openai"
-  ; "no_tool_capable_provider"
+  ; "no_capable_provider"
   ; "mcp_error"
   ; "serialization_error"
   ; "io_error"
@@ -181,21 +181,7 @@ let frozen_operator_disposition (receipt : R.t)
   else if frozen_is_auto_recoverable_turn_budget_terminal terminal_reason
   then R.Disp_pass, R.Reason_turn_budget_exhausted
   else (
-    let tool_route_failure =
-      List.mem
-        receipt.tool_contract_result
-        [ R.Contract_tool_surface_mismatch; R.Contract_no_tool_capable_provider ]
-    in
-    if tool_route_failure
-    then
-      if receipt.degraded_retry_applied || Option.is_some receipt.degraded_retry_runtime
-      then R.Disp_fail_open_next_runtime, R.Reason_tool_route_recoverable_failure
-      else if
-        receipt.runtime_fallback_applied
-        || receipt.runtime_outcome = R.Runtime_passed_to_next_model
-      then R.Disp_pass_next_model, R.Reason_tool_route_recoverable_failure
-      else R.Disp_pause_human, R.Reason_tool_route_recoverable_failure
-    else if
+    if
       receipt.degraded_retry_applied || Option.is_some receipt.degraded_retry_runtime
     then R.Disp_fail_open_next_runtime, R.Reason_degraded_retry
     else if
@@ -205,7 +191,6 @@ let frozen_operator_disposition (receipt : R.t)
     else if
       receipt.outcome = `Ok
       && receipt.runtime_outcome = R.Runtime_not_dispatched
-      && receipt.tool_contract_result = R.Contract_not_dispatched
       && String.equal terminal_reason "pre_dispatch_success"
     then R.Disp_pass, R.Reason_healthy
     else (
@@ -255,7 +240,7 @@ let base_receipt : R.t =
   ; canonical_tools = []
   ; unexpected_tools = []
   ; tools_used = []
-  ; tool_contract_result = R.Contract_unknown
+  ; completion_contract_result = R.Contract_unknown
   ; tool_surface = base_tool_surface
   ; sandbox_kind = Masc.Keeper_types_profile_sandbox.Local
   ; sandbox_root = None
@@ -313,11 +298,9 @@ let runtime_outcomes =
   ; R.Runtime_not_dispatched
   ]
 
-let tool_contract_results =
+let completion_contract_results =
   [ R.Contract_unknown
   ; R.Contract_not_dispatched
-  ; R.Contract_no_tool_capable_provider
-  ; R.Contract_tool_surface_mismatch
   ; R.Contract_needs_execution_progress
   ; R.Contract_satisfied_completion
   ]
@@ -388,7 +371,7 @@ let () =
                                                    (R.outcome_kind_to_string outcome)
                                                    (R.runtime_outcome_to_string
                                                       runtime_outcome)
-                                                   (R.tool_contract_result_to_string tcr)
+                                                   (R.completion_contract_result_to_string tcr)
                                                    (tools_used <> [])
                                                    degraded
                                                    fallback

--- a/test/test_keeper_turn_fsm_emit.ml
+++ b/test/test_keeper_turn_fsm_emit.ml
@@ -357,7 +357,7 @@ let test_failure_reason_labels_documented () =
       , "runtime_unavailable" )
     ; ( F.Failure_no_tool_capable_provider
           { runtime_id = "tools"; detail = "no candidate supports tools" }
-      , "no_tool_capable_provider" )
+      , "no_capable_provider" )
     ; F.Failure_provider_error { kind = "k"; detail = "d" }, "provider_error"
     ; F.Failure_tool_contract_violation { reason_code = "rc" }, "tool_contract_violation"
     ; F.Failure_receipt_lost { primary_error = "e"; fallback_path = None }, "receipt_lost"

--- a/test/test_keeper_typed_labels.ml
+++ b/test/test_keeper_typed_labels.ml
@@ -208,7 +208,6 @@ let test_is_actionable_matches_variants () =
 let all_contract_statuses
     : Keeper_contract_classifier.contract_status list =
   [
-    Tool_surface_mismatch { missing = [ "x" ] };
     Claim_only_after_owned_task;
     Needs_execution_progress;
     Passive_only;
@@ -223,26 +222,6 @@ let test_contract_status_labels_unique () =
   in
   Alcotest.(check (list string))
     "no duplicate contract_status labels" [] (duplicates labels)
-
-let test_pp_contract_status_surfaces_missing_list () =
-  let s =
-    format_to_string Keeper_contract_classifier.pp_contract_status
-      (Tool_surface_mismatch { missing = [ "keeper_task_claim"; "masc_claim_next" ] })
-  in
-  Alcotest.(check bool)
-    "pp_contract_status surfaces first missing tool"
-    true
-    (try
-       ignore (Str.search_forward (Str.regexp_string "keeper_task_claim") s 0);
-       true
-     with Not_found -> false);
-  Alcotest.(check bool)
-    "pp_contract_status surfaces second missing tool"
-    true
-    (try
-       ignore (Str.search_forward (Str.regexp_string "masc_claim_next") s 0);
-       true
-     with Not_found -> false)
 
 (* ── Test runner ─────────────────────────────────────────────── *)
 
@@ -287,7 +266,5 @@ let () =
         [
           Alcotest.test_case "labels unique" `Quick
             test_contract_status_labels_unique;
-          Alcotest.test_case "pp surfaces missing list" `Quick
-            test_pp_contract_status_surfaces_missing_list;
         ] );
     ]

--- a/test/test_keeper_unified_claim_progress.ml
+++ b/test/test_keeper_unified_claim_progress.ml
@@ -33,10 +33,10 @@ let test_claim_tool_classification_covers_supported_claim_tools () =
 
 let test_claim_contract_result_counts_initial_claim_as_execution () =
   let result ?(had_owned_active_task_at_turn_start = false) tools =
-    KAR.tool_contract_result_for_observed_tools
+    KAR.completion_contract_result_for_progress_evidence
       ~had_owned_active_task_at_turn_start
       ~actual_keeper_tool_names:tools
-    |> Masc.Keeper_execution_receipt.tool_contract_result_to_string
+    |> Masc.Keeper_execution_receipt.completion_contract_result_to_string
   in
   check
     string

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -405,7 +405,7 @@ let test_lightweight_snapshot_surfaces_paused_keeper_runtime_trust () =
             ("operator_disposition", `String "pause_human");
             ( "operator_disposition_reason",
               `String "unmapped_runtime_state" );
-            ( "tool_contract_result",
+            ( "completion_contract_result",
               `String "violated" );
             ("tools_used", `List []);
             ( "tool_surface",
@@ -643,7 +643,7 @@ let test_lightweight_snapshot_preserves_receipt_latest_causal_event () =
             ("outcome", `String "ok");
             ("operator_disposition", `String "pass");
             ("operator_disposition_reason", `String "healthy");
-            ("tool_contract_result", `String "satisfied");
+            ("completion_contract_result", `String "satisfied");
             ("tools_used", `List [ `String "keeper_status" ]);
             ("requested_tools", `List [ `String "keeper_status" ]);
             ( "runtime",


### PR DESCRIPTION
## Summary

- Renames `tool_contract_result` → `completion_contract_result` throughout (42 files)
- Removes `Contract_tool_surface_mismatch`, `Contract_no_tool_capable_provider` variants
- Removes `Tool_surface_mismatch` from `Keeper_contract_classifier.contract_status`
- Removes `Reason_tool_route_recoverable_failure` from disposition reason type
- Removes `tool_route_failure` check block from `operator_disposition`
- Removes `"tool_contract"` JSON block from `operator_broadcast_payload`
- Removes `composite_execution_tool_route_blocked` and its callers
- Removes `"tool_contract"` fallback in `compact_receipt_tool_surface_json`

## Wire format

| Before | After |
|--------|-------|
| `"tool_contract_result"` | `"completion_contract_result"` |
| `"tool_surface_mismatch"` | removed (variant gone) |
| `"no_tool_capable_provider"` | removed (variant gone) |
| `"tool_contract"` assoc block | removed |

All string consumers updated in the same commit (no N-of-M split).

## Verification

- `dune build --root . lib/keeper/ lib/server/ lib/dashboard/` — clean
- Supersedes #19971

RFC-WAIVED: dead-concept removal post-#19956 (required tool-use enforcement already gone)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>