### PR TITLE
chore(keeper): purge resurrected required tool fallback label

### DIFF
--- a/lib/keeper/keeper_heartbeat_snapshot.ml
+++ b/lib/keeper/keeper_heartbeat_snapshot.ml
@@ -387,9 +387,8 @@ let write_heartbeat_snapshot
              emitting it on every heartbeat made
              per-provider latency histograms and dashboards show
              ghost provider names long after the binary that wrote
-             them was rebuilt (observed qa-king / nick0cave stuck on
-             "deterministic_required_tool_fallback" across
-             post-#9967 rebuild).  Emit empty string here so
+             them was rebuilt (observed stale synthetic provider
+             labels across post-#9967 rebuild).  Emit empty string here so
              downstream per-provider aggregation ignores heartbeat
              records.  `last_model_used_label` on the keeper state
              JSON still reflects the last real turn for dashboard


### PR DESCRIPTION
## Summary
- remove the required_tool_fallback ghost provider label reintroduced after #19987 advanced main
- keep heartbeat snapshot behavior unchanged: model_used still emits an empty string for snapshot records

## Verification
- rg -n 'required_tool_fallback|deterministic_required_tool_fallback|runtime_required_tool_fallback|test_runtime_required_tool_fallback' lib test docs specs config -g '*.ml' -g '*.mli' -g '*.md' -g '*.tla' -g '*.json' -g '*.toml' (0 matches)
- git diff --check