### PR TITLE
fix: resolve main build errors from PR #19984 rename miss

### DIFF
--- a/lib/server/server_dashboard_http_composite.mli
+++ b/lib/server/server_dashboard_http_composite.mli
@@ -34,7 +34,6 @@ val json_string_eq : string -> Yojson.Safe.t -> String.t -> bool
 val composite_latest_activity_epoch :
   Yojson.Safe.t -> Yojson.Safe.t -> float option
 val composite_snapshot_is_idle : Yojson.Safe.t -> bool
-val composite_execution_tool_route_blocked : Yojson.Safe.t -> bool
 val composite_execution_config_blocked : Yojson.Safe.t -> bool
 val composite_execution_saturated : Yojson.Safe.t -> bool
 val composite_execution_claim_no_eligible : Yojson.Safe.t -> bool

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -369,7 +369,7 @@ let () =
                                             ; degraded_retry_applied = degraded
                                             ; runtime_fallback_applied = fallback
                                             ; runtime_outcome
-                                            ; tool_contract_result = tcr
+                                            ; completion_contract_result = tcr
                                             ; tools_used
                                             ; outcome
                                             }
@@ -405,7 +405,7 @@ let () =
                                                 false))
                                        outcomes)
                                   tools_used_variants)
-                             tool_contract_results)
+                             completion_contract_results)
                         runtime_outcomes)
                    fallback_bools)
               degraded_bools)


### PR DESCRIPTION
## Summary
Fix build errors caused by incomplete rename in PR #19984 (`tool_contract` → `completion_contract`).

## Changes
1. **`lib/server/server_dashboard_http_composite.mli`**: Remove `composite_execution_tool_route_blocked` (deleted in .ml by #19984, .mli not updated)
2. **`test/test_keeper_terminal_reason_typed.ml`**: 
   - `tool_contract_result` → `completion_contract_result` (record field)
   - `tool_contract_results` → `completion_contract_results` (variable name)

## Verification
```bash
dune build --root .  # ✅ passes
```

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>