### PR TITLE
fix(ide): gate command_descriptor ingestion on tool success (#19931)

### DIFF
--- a/lib/ide/ide_bridge.ml
+++ b/lib/ide/ide_bridge.ml
@@ -256,15 +256,23 @@ let parse_pr_url_from_output (output : string) : (int * string) option =
      | _ -> None)
 
 (** Ingest PR event from command_descriptor (deterministic).
-    Falls back to heuristic output parsing if descriptor is not available. *)
+    Falls back to heuristic output parsing if descriptor is not available.
+    Only proceeds when [success] is [true] — failed tool executions
+    (auth/network/validation errors) must not produce phantom PR events. *)
 let ingest_pr_event_from_descriptor
     ~base_path
     ~keeper_id
     ~turn_id
     ~output_text
     ~tool_name
+    ~success
   =
-  if String.equal (String.lowercase_ascii tool_name) "execute" then
+  (* Gate: only ingest PR events from successful tool executions.
+     Failed commands (auth/network/validation errors) preserve the
+     command_descriptor in their output, which would otherwise produce
+     phantom PR #0 events. *)
+  if not success then ()
+  else if String.equal (String.lowercase_ascii tool_name) "execute" then
     match extract_descriptor_from_output output_text with
     | Some (Ide_event_types.Gh_pr_create { title; base = _; draft = _ }) ->
       (* PR was created — try to get PR number from output URL *)

--- a/lib/ide/ide_bridge.mli
+++ b/lib/ide/ide_bridge.mli
@@ -70,13 +70,16 @@ val ingest_pr_event_from_hook :
   unit
 
 (** Ingest PR event from command_descriptor (deterministic).
-    Extracts descriptor from tool result JSON, falls back to heuristic. *)
+    Extracts descriptor from tool result JSON, falls back to heuristic.
+    Only proceeds when [success] is [true] — failed tool executions
+    (auth/network/validation errors) must not produce phantom PR events. *)
 val ingest_pr_event_from_descriptor :
   base_path:string ->
   keeper_id:string ->
   turn_id:string ->
   output_text:string ->
   tool_name:string ->
+  success:bool ->
   unit
 
 (** Extract command_descriptor from tool result JSON. *)

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -246,7 +246,8 @@ let assemble_hooks
              ~keeper_id:acc.meta.name
              ~turn_id
              ~output_text
-             ~tool_name))
+             ~tool_name
+             ~success))
         ~pre_tool_use_guard:public_alias_pre_tool_use_guard
         ()
     in

--- a/test/test_ide_bridge.ml
+++ b/test/test_ide_bridge.ml
@@ -323,6 +323,44 @@ let test_pr_event_from_hook_ignores_no_url () =
     check bool "file not created" false (Sys.file_exists path))
 ;;
 
+let test_descriptor_gated_on_success () =
+  with_temp_dir (fun base_dir ->
+    (* Failed gh pr create with command_descriptor in output should NOT produce PR event *)
+    let failed_output = {|{"command_descriptor": {"kind": "gh_pr_create", "title": "feat: test", "base": "main", "draft": true}, "error": "authentication failed"}|} in
+    Ide_bridge.ingest_pr_event_from_descriptor
+      ~base_path:base_dir
+      ~keeper_id:"k1"
+      ~turn_id:"t1"
+      ~output_text:failed_output
+      ~tool_name:"execute"
+      ~success:false;
+    let dir = Ide_paths.partition_store_dir ~base_dir:base_dir Ide_paths.Orphan in
+    let path = Filename.concat dir "pr_events.jsonl" in
+    check bool "file not created on failure" false (Sys.file_exists path))
+;;
+
+let test_descriptor_ingested_on_success () =
+  with_temp_dir (fun base_dir ->
+    (* Successful gh pr create with command_descriptor should produce PR event *)
+    let success_output = {|{"command_descriptor": {"kind": "gh_pr_create", "title": "feat: test", "base": "main", "draft": true}}|} in
+    Ide_bridge.ingest_pr_event_from_descriptor
+      ~base_path:base_dir
+      ~keeper_id:"k1"
+      ~turn_id:"t1"
+      ~output_text:success_output
+      ~tool_name:"execute"
+      ~success:true;
+    let dir = Ide_paths.partition_store_dir ~base_dir:base_dir Ide_paths.Orphan in
+    let path = Filename.concat dir "pr_events.jsonl" in
+    check bool "file created on success" true (Sys.file_exists path);
+    let ic = open_in path in
+    let line = input_line ic in
+    close_in ic;
+    let json = Yojson.Safe.from_string line in
+    let pr_number = Yojson.Safe.Util.member "pr_number" json |> Yojson.Safe.Util.to_int in
+    check int "pr_number is 0 (no URL in output)" 0 pr_number)
+;;
+
 let test_concurrent_ingest () =
   with_temp_dir (fun base_dir ->
     (* Simulate parallel tool calls writing to the same file *)
@@ -383,6 +421,8 @@ let () =
         ; test_case "from hook detects url" `Quick test_pr_event_from_hook_detects_url
         ; test_case "from hook ignores non-execute" `Quick test_pr_event_from_hook_ignores_non_execute
         ; test_case "from hook ignores no url" `Quick test_pr_event_from_hook_ignores_no_url
+        ; test_case "descriptor gated on success" `Quick test_descriptor_gated_on_success
+        ; test_case "descriptor ingested on success" `Quick test_descriptor_ingested_on_success
         ] )
     ; ( "concurrency"
       , [ test_case "concurrent ingest" `Quick test_concurrent_ingest


### PR DESCRIPTION
## Summary
Fix phantom PR #0 events caused by failed tool executions preserving command_descriptor metadata.

## Root Cause
`ingest_pr_event_from_descriptor` extracted `command_descriptor` from tool output and created PR events regardless of whether the tool execution succeeded. When `gh pr create` failed (auth/network/validation errors), the descriptor was still present in the output, causing phantom PR #0 events.

## Solution
Gate descriptor ingestion on the tool success flag. Failed executions now skip PR event ingestion entirely.

## Changes
1. **`lib/ide/ide_bridge.ml`**: Add `~success:bool` parameter, early return on `not success`
2. **`lib/ide/ide_bridge.mli`**: Update interface with `~success:bool`
3. **`lib/keeper/keeper_run_tools_hooks.ml`**: Pass `~success` flag from tool execution result
4. **`test/test_ide_bridge.ml`**: 2 new tests for phantom PR #0 prevention

## Verification
```bash
dune build --root .  # ✅
dune runtest --root .  # ✅ all 20 tests pass
```

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>