### PR TITLE
fix(keeper): gate rotation cap on contract errors only (#19930)

### DIFF
--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -525,6 +525,26 @@ let degraded_rotation_candidates
   |> List.filter (fun candidate ->
          not (String.equal candidate normalized_effective))
 
+(** [true] when the error is a completion contract violation.
+    Contract violations should cap rotation because retrying the same
+    or different runtime will not satisfy the contract. Non-contract
+    errors (provider timeout, rate limit, server error) are transient
+    and should allow cycling through candidates again. *)
+let is_completion_contract_violation (err : Agent_sdk.Error.sdk_error) : bool =
+  match err with
+  | Agent_sdk.Error.Agent (Agent_sdk.Error.CompletionContractViolation _) ->
+    true
+  | Agent_sdk.Error.Api _
+  | Agent_sdk.Error.Provider _
+  | Agent_sdk.Error.Agent _
+  | Agent_sdk.Error.Mcp _
+  | Agent_sdk.Error.Config _
+  | Agent_sdk.Error.Serialization _
+  | Agent_sdk.Error.Io _
+  | Agent_sdk.Error.Orchestration _
+  | Agent_sdk.Error.A2a _
+  | Agent_sdk.Error.Internal _ -> false
+
 let degraded_rotation_after_recoverable_error
     ?fallback_hint
     ~(base_runtime : string)
@@ -544,13 +564,34 @@ let degraded_rotation_after_recoverable_error
         |> List.map (normalized_runtime_id ~catalog_names)
         |> dedupe_keep_order
       in
-      degraded_rotation_candidates
-        ~catalog_names
-        ~fallback_hint
-        ~base_runtime ~effective_runtime ~tool_requirement
-      |> List.find_opt (fun candidate ->
+      let candidates =
+        degraded_rotation_candidates
+          ~catalog_names
+          ~fallback_hint
+          ~base_runtime ~effective_runtime ~tool_requirement
+      in
+      let untried =
+        List.find_opt
+          (fun candidate ->
              not (List.exists (String.equal candidate) attempted))
-      |> Option.map (fun next_runtime -> { next_runtime; fallback_reason })
+          candidates
+      in
+      (match untried with
+       | Some next_runtime ->
+         Some { next_runtime; fallback_reason }
+       | None when not (is_completion_contract_violation err) ->
+         (* Non-contract errors (provider timeout, rate limit, server error)
+            are transient. Allow cycling through candidates again because
+            the same runtime may succeed on a subsequent attempt. Only
+            contract violations cap rotation — retrying cannot satisfy the
+            contract. #19930 *)
+         (match candidates with
+          | [] -> None
+          | first_candidate :: _ ->
+            Some { next_runtime = first_candidate; fallback_reason })
+       | None ->
+         (* Contract violation: all candidates exhausted. Cap rotation. *)
+         None)
 
 let is_auto_recoverable_turn_error (err : Agent_sdk.Error.sdk_error) : bool =
   is_transient_network_error err

--- a/lib/keeper/keeper_error_classify.mli
+++ b/lib/keeper/keeper_error_classify.mli
@@ -54,6 +54,11 @@ val is_ambiguous_side_effect_error : Agent_sdk.Error.sdk_error -> bool
 (** [true] when a structured error indicates context overflow. *)
 val is_context_overflow : Agent_sdk.Error.sdk_error -> bool
 
+(** [true] when the error is a completion contract violation.
+    Contract violations should cap rotation because retrying the same
+    or different runtime will not satisfy the contract. *)
+val is_completion_contract_violation : Agent_sdk.Error.sdk_error -> bool
+
 (** [true] when the error is an OAS [InputRequired] — the agent paused
     to request human input.  Not a failure; a special stop condition. *)
 val is_input_required_error : Agent_sdk.Error.sdk_error -> bool
@@ -142,6 +147,11 @@ val degraded_retry_after_recoverable_error :
     target via [runtime.toml]. The hint is normalized and deduplicated like
     any other candidate; if it duplicates the effective runtime or has
     already been attempted, the next legal candidate is returned.
+
+    Non-contract errors (provider timeout, rate limit, server error) allow
+    cycling through candidates again when all are exhausted, because the
+    same runtime may succeed on a subsequent attempt. Contract violations
+    cap rotation — retrying cannot satisfy the contract.
     @since 0.174.0 *)
 val degraded_rotation_after_recoverable_error :
   ?fallback_hint:string ->

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -115,6 +115,54 @@ let () =
 ;;
 
 (* ------------------------------------------------------------------ *)
+(* 1b. is_completion_contract_violation: contract errors return true,  *)
+(*     all other error families return false. #19930                    *)
+(* ------------------------------------------------------------------ *)
+
+module EC = Masc.Keeper_error_classify
+
+let () =
+  (* Contract violation → true *)
+  check "contract violation: CompletionContractViolation"
+    (EC.is_completion_contract_violation
+       (Agent_sdk.Error.Agent
+          (Agent_sdk.Error.CompletionContractViolation
+             { contract = Agent_sdk.Completion_contract_id.Require_tool_use
+             ; reason = "test"
+             ; violation_detail = None
+             })));
+  (* Non-contract errors → false *)
+  check "non-contract: provider timeout"
+    (not (EC.is_completion_contract_violation
+            (Agent_sdk.Error.Api
+               (Llm_provider.Retry.Timeout
+                  { message = "timeout" }))));
+  check "non-contract: rate limited"
+    (not (EC.is_completion_contract_violation
+            (Agent_sdk.Error.Api
+               (Llm_provider.Retry.RateLimited
+                  { message = "rate limited"; retry_after = None }))));
+  check "non-contract: server error"
+    (not (EC.is_completion_contract_violation
+            (Agent_sdk.Error.Api
+               (Llm_provider.Retry.ServerError
+                  { message = "server error"; status = 500 }))));
+  check "non-contract: overloaded"
+    (not (EC.is_completion_contract_violation
+            (Agent_sdk.Error.Api
+               (Llm_provider.Retry.Overloaded
+                  { message = "overloaded" }))));
+  check "non-contract: MaxTurnsExceeded"
+    (not (EC.is_completion_contract_violation
+            (Agent_sdk.Error.Agent
+               (Agent_sdk.Error.MaxTurnsExceeded
+                  { turns = 8; limit = 8 }))));
+  check "non-contract: Internal"
+    (not (EC.is_completion_contract_violation
+            (Agent_sdk.Error.Internal "internal error")));
+;;
+
+(* ------------------------------------------------------------------ *)
 (* 2. (disposition, reason) equivalence vs a frozen copy of the OLD    *)
 (*    substring classifier.                                            *)
 (* ------------------------------------------------------------------ *)


### PR DESCRIPTION
## Summary
Fix rotation cap mis-firing on non-contract errors after PR #19909 removed `Require_tool_use` contract handling.

## Root Cause
After PR #19909, `degraded_rotation_after_recoverable_error` stopped rotation for ALL errors when all candidate runtimes were exhausted (`attempted_runtimes >= 2`). This prematurely stopped fail-open rotation for transient errors (provider timeout, rate limit, server error).

## Solution
Add `is_completion_contract_violation` to distinguish contract errors from non-contract errors:
- **Non-contract errors** (provider timeout, rate limit, server error): Allow cycling through candidates again
- **Contract violations**: Cap rotation, since retrying cannot satisfy the contract

## Changes
1. **`lib/keeper/keeper_error_classify.ml`**: Add `is_completion_contract_violation` function, modify rotation cap logic
2. **`lib/keeper/keeper_error_classify.mli`**: Expose new function, update docs
3. **`test/test_keeper_terminal_reason_typed.ml`**: Tests for contract vs non-contract error classification

## Verification
```bash
dune build --root .  # ✅
# test_keeper_terminal_reason_typed: OK (262656 matrix cases, 0 mismatches)
```

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>