### PR TITLE
feat(keeper): ignore legacy persona self-model defaults

### DIFF
--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -267,10 +267,6 @@ let persona_operator_todo_placeholder_fields
       ("keeper.short_goal", defaults.short_goal);
       ("keeper.mid_goal", defaults.mid_goal);
       ("keeper.long_goal", defaults.long_goal);
-      ("keeper.will", defaults.will);
-      ("keeper.needs", defaults.needs);
-      ("keeper.desires", defaults.desires);
-      ("keeper.instructions", defaults.instructions);
     ]
 
 let keeper_toml_path_opt name =
@@ -331,10 +327,10 @@ let load_keeper_profile_defaults_from_persona name : keeper_profile_defaults =
                   long_goal =
                     normalize_goal_horizon_opt
                       (Safe_ops.json_string_opt "long_goal" keeper_json);
-                  will = Safe_ops.json_string_opt "will" keeper_json;
-                  needs = Safe_ops.json_string_opt "needs" keeper_json;
-                  desires = Safe_ops.json_string_opt "desires" keeper_json;
-                  instructions = Safe_ops.json_string_opt "instructions" keeper_json;
+                  will = None;
+                  needs = None;
+                  desires = None;
+                  instructions = None;
                   autoboot_enabled = None;
                   mention_targets = Safe_ops.json_string_list "mention_targets" keeper_json;
                   proactive_enabled = Safe_ops.json_bool_opt "proactive_enabled" keeper_json;

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -910,6 +910,32 @@ let test_persona_resolver_omits_unspecified_tool_access () =
        | `Null -> ()
        | _ -> fail "unspecified tool_access should be omitted")
 
+let test_persona_defaults_ignore_legacy_self_model_fields () =
+  with_personas_dir @@ fun personas_dir ->
+  let persona_dir = Filename.concat personas_dir "probe" in
+  mkdir_p persona_dir;
+  write_file
+    (Filename.concat persona_dir "profile.json")
+    {|
+{
+  "name": "Probe",
+  "keeper": {
+    "goal": "test persona keeper",
+    "will": "legacy will",
+    "needs": "legacy needs",
+    "desires": "legacy desires",
+    "instructions": "legacy instructions"
+  }
+}
+|};
+  let defaults = KTP.load_keeper_profile_defaults_from_persona "probe" in
+  check (option string) "goal still loads" (Some "test persona keeper")
+    defaults.goal;
+  check (option string) "legacy will ignored" None defaults.will;
+  check (option string) "legacy needs ignored" None defaults.needs;
+  check (option string) "legacy desires ignored" None defaults.desires;
+  check (option string) "legacy instructions ignored" None defaults.instructions
+
 let test_persona_resolver_rejects_operator_todo_profile () =
   with_personas_dir @@ fun personas_dir ->
   let persona_dir = Filename.concat personas_dir "probe" in
@@ -1920,6 +1946,8 @@ let () =
           test_case "skips bad files" `Quick test_discover_skips_bad_files;
           test_case "persona resolver omits unspecified tool_access" `Quick
             test_persona_resolver_omits_unspecified_tool_access;
+          test_case "persona defaults ignore legacy self-model fields" `Quick
+            test_persona_defaults_ignore_legacy_self_model_fields;
           test_case "persona resolver rejects OPERATOR_TODO profile" `Quick
             test_persona_resolver_rejects_operator_todo_profile;
           test_case "persona resolver reports placeholder defaults source" `Quick


### PR DESCRIPTION
## Summary
- stop treating legacy persona-profile keeper.will/needs/desires/instructions as defaults
- remove those fields from OPERATOR_TODO placeholder default checks
- add a regression test that legacy persona self-model fields are ignored while keeper goal still loads

## Verification
- PASS: ocamlformat --check lib/keeper/keeper_types_profile.ml test/test_keeper_toml.ml
- PASS: git diff --check
- PASS: env DUNE_CACHE=disabled DUNE_BUILD_DIR=/private/tmp/masc-mcp-pr4-remove-deprecated-fields-build MASC_DUNE_THROTTLE=0 MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build lib/.masc.objs/byte/masc__Keeper_types_profile.cmi
- BLOCKED unrelated: scripts/dune-local.sh exec test/test_keeper_toml.exe currently fails on latest main before this test due unrelated compile errors tracked in #19994

## Notes
- Local full/test verification used MASC_SKIP_PIN_CHECK=1 because the shared opam floor is 0.200.14 while current main pin metadata is 0.200.13; no opam downgrade was performed.