### PR TITLE
refactor: replace catch-all patterns with exhaustive matches

### DIFF
--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -99,13 +99,44 @@ let is_provider_rejected_parse_error (err : Agent_sdk.Error.sdk_error) : bool =
   | Agent_sdk.Error.Provider
       (Llm_provider.Error.InvalidRequest { reason; _ }) ->
       server_parse_rejection_message_matches reason
-  | _ -> false
+  (* Not a provider-level parse rejection. *)
+  | Agent_sdk.Error.Provider
+      (Llm_provider.Error.NetworkError _ | Llm_provider.Error.Timeout _
+      | Llm_provider.Error.ServerError _ | Llm_provider.Error.RateLimit _
+      | Llm_provider.Error.AuthError _ | Llm_provider.Error.MissingApiKey _
+      | Llm_provider.Error.NotFound _ | Llm_provider.Error.CapacityExhausted _
+      | Llm_provider.Error.HardQuota _
+      | Llm_provider.Error.ProviderUnavailable _
+      | Llm_provider.Error.ProviderTerminal _
+      | Llm_provider.Error.InvalidConfig _
+      | Llm_provider.Error.UnknownVariant _) -> false
+  | Agent_sdk.Error.Api _ -> false
+  | Agent_sdk.Error.Agent _ -> false
+  | Agent_sdk.Error.Mcp _ -> false
+  | Agent_sdk.Error.Config _ -> false
+  | Agent_sdk.Error.Serialization _ -> false
+  | Agent_sdk.Error.Io _ -> false
+  | Agent_sdk.Error.Orchestration _ -> false
+  | Agent_sdk.Error.A2a _ -> false
+  | Agent_sdk.Error.Internal _ -> false
 
 let is_model_rejected_parse_error (err : Agent_sdk.Error.sdk_error) : bool =
   match err with
   | Agent_sdk.Error.Api (InvalidRequest { message }) ->
       server_parse_rejection_message_matches message
-  | _ -> false
+  (* Not a model-level parse rejection. *)
+  | Agent_sdk.Error.Api (NetworkError _ | Timeout _ | Overloaded _
+    | ServerError _ | RateLimited _ | AuthError _ | NotFound _
+    | ContextOverflow _) -> false
+  | Agent_sdk.Error.Provider _ -> false
+  | Agent_sdk.Error.Agent _ -> false
+  | Agent_sdk.Error.Mcp _ -> false
+  | Agent_sdk.Error.Config _ -> false
+  | Agent_sdk.Error.Serialization _ -> false
+  | Agent_sdk.Error.Io _ -> false
+  | Agent_sdk.Error.Orchestration _ -> false
+  | Agent_sdk.Error.A2a _ -> false
+  | Agent_sdk.Error.Internal _ -> false
 
 let is_server_rejected_parse_error (err : Agent_sdk.Error.sdk_error) : bool =
   is_provider_rejected_parse_error err || is_model_rejected_parse_error err
@@ -117,14 +148,43 @@ let is_receipt_lost_error (err : Agent_sdk.Error.sdk_error) : bool =
   match err with
   | Agent_sdk.Error.Internal msg ->
       string_contains_substring ~needle:"execution_receipt_append_failed" msg
-  | _ -> false
+  (* Not a receipt I/O failure. *)
+  | Agent_sdk.Error.Api _ -> false
+  | Agent_sdk.Error.Provider _ -> false
+  | Agent_sdk.Error.Agent _ -> false
+  | Agent_sdk.Error.Mcp _ -> false
+  | Agent_sdk.Error.Config _ -> false
+  | Agent_sdk.Error.Serialization _ -> false
+  | Agent_sdk.Error.Io _ -> false
+  | Agent_sdk.Error.Orchestration _ -> false
+  | Agent_sdk.Error.A2a _ -> false
 
 (** Provider-level timeout (not structural OAS wall-clock budget). *)
 let is_provider_timeout_error (err : Agent_sdk.Error.sdk_error) : bool =
   match err with
   | Agent_sdk.Error.Api (Timeout _) -> true
   | Agent_sdk.Error.Provider (Llm_provider.Error.Timeout _) -> true
-  | _ -> false
+  (* Not a provider-level timeout. *)
+  | Agent_sdk.Error.Api (NetworkError _ | Overloaded _ | ServerError _
+    | RateLimited _ | AuthError _ | InvalidRequest _ | NotFound _
+    | ContextOverflow _) -> false
+  | Agent_sdk.Error.Provider
+      (Llm_provider.Error.NetworkError _ | Llm_provider.Error.ServerError _
+      | Llm_provider.Error.RateLimit _ | Llm_provider.Error.AuthError _
+      | Llm_provider.Error.MissingApiKey _ | Llm_provider.Error.NotFound _
+      | Llm_provider.Error.CapacityExhausted _ | Llm_provider.Error.HardQuota _
+      | Llm_provider.Error.InvalidRequest _ | Llm_provider.Error.InvalidConfig _
+      | Llm_provider.Error.ParseError _ | Llm_provider.Error.ProviderUnavailable _
+      | Llm_provider.Error.ProviderTerminal _
+      | Llm_provider.Error.UnknownVariant _) -> false
+  | Agent_sdk.Error.Agent _ -> false
+  | Agent_sdk.Error.Mcp _ -> false
+  | Agent_sdk.Error.Config _ -> false
+  | Agent_sdk.Error.Serialization _ -> false
+  | Agent_sdk.Error.Io _ -> false
+  | Agent_sdk.Error.Orchestration _ -> false
+  | Agent_sdk.Error.A2a _ -> false
+  | Agent_sdk.Error.Internal _ -> false
 
 (* 524 is Cloudflare's "origin responded too slowly" timeout. At keeper
    orchestration level this means the current provider lane is saturated or

--- a/lib/telemetry_unified.ml
+++ b/lib/telemetry_unified.ml
@@ -658,7 +658,9 @@ let read_unified_result ~base_path ~masc_root ?(sources = all_sources)
           ~n:per_source ()
       | Goal_event ->
         read_goal_events ~masc_root ?since_ts ?until_ts ~n:per_source ()
-      | _ ->
+      (* Fixed-path sources: Agent_event, Tool_call_io, Tool_usage,
+         Oas_event, Tool_metric use directory-based storage. *)
+      | Agent_event | Tool_call_io | Tool_usage | Oas_event | Tool_metric ->
         match fixed_store_dir ~masc_root ~base_path source with
         | Some dir ->
           read_fixed_source dir source ~n:per_source ?since_ts ?until_ts ()
@@ -948,7 +950,9 @@ let summary_json ~base_path ~masc_root () : Yojson.Safe.t =
               ~optional_when_missing:(source_optional_when_missing source)
               ?coverage_gap ()),
         count )
-    | _ ->
+    (* Fixed-path sources: Agent_event, Tool_call_io, Tool_usage,
+       Oas_event, Tool_metric use directory-based storage. *)
+    | Agent_event | Tool_call_io | Tool_usage | Oas_event | Tool_metric ->
       let dir = match fixed_store_dir ~masc_root ~base_path source with
         | Some d -> d | None -> "" in
       let dir_state =

--- a/lib/verification.ml
+++ b/lib/verification.ml
@@ -323,23 +323,25 @@ let evaluate_all output criteria =
   | [] -> Pass  (* No criteria = auto-pass *)
   | _ ->
       let results = List.map (evaluate_criterion output) criteria in
-      let fails = List.filter (function Fail _ -> true | _ -> false) results in
-      let partials = List.filter (function Partial _ -> true | _ -> false) results in
+      let fails = List.filter (function Fail _ -> true | Pass | Partial _ -> false) results in
+      let partials = List.filter (function Partial _ -> true | Pass | Fail _ -> false) results in
       if fails <> [] then
+        (* [fails] was filtered to [Fail _] only; [Pass]/[Partial] are dead. *)
         let reasons = List.filter_map (function
           | Fail r -> Some r
-          | _ -> None
+          | Pass | Partial _ -> None
         ) fails in
         Fail (String.concat "; " reasons)
       else if partials <> [] then
+        (* [partials] was filtered to [Partial _] only; [Pass]/[Fail] are dead. *)
         let scores = List.filter_map (function
           | Partial (s, _) -> Some s
-          | _ -> None
+          | Pass | Fail _ -> None
         ) partials in
         let avg = List.fold_left (+.) 0.0 scores /. Float.of_int (List.length scores) in
         let reasons = List.filter_map (function
           | Partial (_, r) -> Some r
-          | _ -> None
+          | Pass | Fail _ -> None
         ) partials in
         Partial (avg, String.concat "; " reasons)
       else
@@ -557,7 +559,7 @@ let auto_verify ~base_path ~req_id =
   match load_request base_path req_id with
   | Error e -> Error e
   | Ok req ->
-      let has_custom = List.exists (function Custom _ -> true | _ -> false) req.criteria in
+      let has_custom = List.exists (function Custom _ -> true | Schema_match _ | Contains _ | Not_contains _ -> false) req.criteria in
       if has_custom then
         Error "Cannot auto-verify: custom criteria require agent judgment"
       else


### PR DESCRIPTION
## Summary
Replace `_ -> false` and `_ -> None` catch-all patterns on closed sum types with explicit variant matches. Improves compiler-enforced exhaustive checking.

## Changes

### `lib/keeper/keeper_error_classify.ml` (4 functions)
- `is_provider_rejected_parse_error`: explicit `Agent_sdk.Error.Provider` sub-variants
- `is_model_rejected_parse_error`: explicit `Agent_sdk.Error.Api` sub-variants
- `is_receipt_lost_error`: explicit top-level `sdk_error` families
- `is_provider_timeout_error`: explicit `Api` + `Provider` sub-variants

### `lib/telemetry_unified.ml` (2 catch-alls)
- `read_unified_result`: `| _ ->` → `| Agent_event | Tool_call_io | Tool_usage | Oas_event | Tool_metric ->`
- `summary_json`: same expansion

### `lib/verification.ml` (verdict/criterion)
- `evaluate_all` filter predicates: explicit `Pass | Partial _` / `Pass | Fail _` arms
- `evaluate_all` filter_map predicates: explicit verdict arms
- `auto_verify` has_custom: explicit `Schema_match _ | Contains _ | Not_contains _`

## Preserved
All `_ -> false` on `Yojson.Safe.t` polymorphic variants — those are idiomatic for open JSON types.

## Verification
```bash
dune build lib/masc.cma  # ✅
```

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>