### PR TITLE
fix(keeper): improve sandbox_repo_not_ready diagnostic for docker mounts (PR3)

### DIFF
--- a/lib/keeper/keeper_sandbox.ml
+++ b/lib/keeper/keeper_sandbox.ml
@@ -23,7 +23,34 @@ type t =
   ; task_overlay_pattern : string
   }
 
+type docker_mount_layout =
+  { host_root_raw : string
+  ; host_root : string
+  ; container_root : string
+  }
+
 let strip_trailing_slashes = Env_config_core.strip_trailing_slashes
+
+let normalize_path path =
+  let normalized =
+    try Fs_compat.realpath path with
+    | Unix.Unix_error _ ->
+      let rec collect_suffix p acc =
+        let parent = Filename.dirname p in
+        if parent = p
+        then p, acc
+        else (
+          match
+            try Some (Fs_compat.realpath p) with
+            | Unix.Unix_error _ -> None
+          with
+          | Some resolved -> resolved, acc
+          | None -> collect_suffix parent (Filename.basename p :: acc))
+      in
+      let resolved_base, suffix_parts = collect_suffix path [] in
+      List.fold_left Filename.concat resolved_base suffix_parts
+  in
+  strip_trailing_slashes normalized
 
 let backend_of_profile = function
   | Keeper_types_profile_sandbox.Local -> Local
@@ -80,6 +107,60 @@ let host_root_abs_of_meta ~(config : Workspace.config)
 
 let container_root name =
   Keeper_sandbox_config.container_root_of_agent ~agent_name:name
+
+let docker_mount_layout_of_meta ~(config : Workspace.config)
+    (meta : Keeper_meta_contract.keeper_meta) =
+  let host_root_raw = host_root_abs_of_meta ~config meta |> strip_trailing_slashes in
+  { host_root_raw
+  ; host_root = normalize_path host_root_raw
+  ; container_root = container_root meta.name |> strip_trailing_slashes
+  }
+
+let container_path_of_host layout ~host_path =
+  let host_norm = normalize_path host_path in
+  if String.equal host_norm layout.host_root
+  then Ok layout.container_root
+  else if String.starts_with ~prefix:(layout.host_root ^ "/") host_norm
+  then (
+    let suffix =
+      String.sub
+        host_norm
+        (String.length layout.host_root + 1)
+        (String.length host_norm - String.length layout.host_root - 1)
+    in
+    Ok (Filename.concat layout.container_root suffix))
+  else
+    Error
+      (Printf.sprintf
+         "container_path_of_host: %s is not inside playground %s"
+         host_norm
+         layout.host_root)
+
+let container_cwd_of_host layout ~host_cwd =
+  match container_path_of_host layout ~host_path:host_cwd with
+  | Ok container_cwd -> container_cwd
+  | Error _ -> layout.container_root
+
+let rewrite_host_paths_to_container layout text =
+  let rewritten =
+    Keeper_sandbox_runtime.rewrite_host_root_to_container_root
+      ~host_root:layout.host_root_raw
+      ~container_root:layout.container_root
+      text
+  in
+  if String.equal layout.host_root_raw layout.host_root
+  then rewritten
+  else
+    Keeper_sandbox_runtime.rewrite_host_root_to_container_root
+      ~host_root:layout.host_root
+      ~container_root:layout.container_root
+      rewritten
+
+let rewrite_container_paths_to_host layout text =
+  Keeper_sandbox_runtime.rewrite_host_root_to_container_root
+    ~host_root:layout.container_root
+    ~container_root:layout.host_root_raw
+    text
 
 let host_path_of_visible_path ~config ~agent_name raw_path =
   if Filename.is_relative raw_path

--- a/lib/keeper/keeper_sandbox.mli
+++ b/lib/keeper/keeper_sandbox.mli
@@ -26,6 +26,12 @@ type t = {
   task_overlay_pattern : string;
 }
 
+type docker_mount_layout = {
+  host_root_raw : string;
+  host_root : string;
+  container_root : string;
+}
+
 (** {1 Backend helpers} *)
 
 val backend_to_string : backend -> string
@@ -78,6 +84,46 @@ val host_root_abs_of_meta :
 (** [container_root name] returns the in-container path used by the
     hardened Docker backend. *)
 val container_root : string -> string
+
+(** [docker_mount_layout_of_meta ~config meta] is the single source of
+    truth for the Docker playground bind mount: host root, normalized host
+    root, and container root. Docker run/exec argv, cwd rendering, and
+    host-side validation should derive path translations from this value
+    instead of recomputing the three roots independently. *)
+val docker_mount_layout_of_meta :
+  config:Workspace.config ->
+  Keeper_meta_contract.keeper_meta ->
+  docker_mount_layout
+
+(** [container_path_of_host layout ~host_path] maps a host path under the
+    mounted playground to its container-visible path. *)
+val container_path_of_host :
+  docker_mount_layout ->
+  host_path:string ->
+  (string, string) result
+
+(** [container_cwd_of_host layout ~host_cwd] maps a host cwd into the
+    mounted container namespace and falls back to [layout.container_root]
+    when the cwd is outside the playground. *)
+val container_cwd_of_host :
+  docker_mount_layout ->
+  host_cwd:string ->
+  string
+
+(** Rewrite host playground paths in arbitrary text to container paths,
+    matching both raw and normalized host roots on path boundaries. *)
+val rewrite_host_paths_to_container :
+  docker_mount_layout ->
+  string ->
+  string
+
+(** Rewrite container playground paths in arbitrary text to raw host paths
+    on path boundaries. Used only for host-side validation and
+    operator-facing result normalization. *)
+val rewrite_container_paths_to_host :
+  docker_mount_layout ->
+  string ->
+  string
 
 (** [host_path_of_visible_path ~config ~agent_name raw_path] maps a
     sandbox-visible absolute path for [agent_name] back to the

--- a/lib/keeper/keeper_sandbox_docker.ml
+++ b/lib/keeper/keeper_sandbox_docker.ml
@@ -75,27 +75,9 @@ let docker_private_workspace_cwd =
   Keeper_sandbox_docker_container_name.docker_private_workspace_cwd
 
 let rewrite_docker_command_paths ~(config : Workspace.config) ~(meta : keeper_meta) cmd =
-  let raw_host_root =
-    Keeper_sandbox.host_root_abs_of_meta ~config meta
-    |> Keeper_alerting_path.strip_trailing_slashes
-  in
-  let normalized_host_root =
-    raw_host_root |> Keeper_alerting_path.normalize_path_for_check_stripped
-  in
-  let container_root = keeper_private_container_root meta in
-  let rewritten =
-    Keeper_sandbox_runtime.rewrite_host_root_to_container_root
-      ~host_root:raw_host_root
-      ~container_root
-      cmd
-  in
-  if String.equal raw_host_root normalized_host_root
-  then rewritten
-  else
-    Keeper_sandbox_runtime.rewrite_host_root_to_container_root
-      ~host_root:normalized_host_root
-      ~container_root
-      rewritten
+  Keeper_sandbox.rewrite_host_paths_to_container
+    (Keeper_sandbox.docker_mount_layout_of_meta ~config meta)
+    cmd
 ;;
 
 let rewrite_docker_command_paths_for_host_validation
@@ -103,29 +85,9 @@ let rewrite_docker_command_paths_for_host_validation
       ~(meta : keeper_meta)
       cmd
   =
-  let raw_host_root =
-    Keeper_sandbox.host_root_abs_of_meta ~config meta
-    |> Keeper_alerting_path.strip_trailing_slashes
-  in
-  let normalized_host_root =
-    raw_host_root |> Keeper_alerting_path.normalize_path_for_check_stripped
-  in
-  let container_root =
-    keeper_private_container_root meta |> Keeper_alerting_path.strip_trailing_slashes
-  in
-  let rewritten =
-    Keeper_sandbox_runtime.rewrite_host_root_to_container_root
-      ~host_root:container_root
-      ~container_root:raw_host_root
-      cmd
-  in
-  if String.equal raw_host_root normalized_host_root
-  then rewritten
-  else
-    Keeper_sandbox_runtime.rewrite_host_root_to_container_root
-      ~host_root:container_root
-      ~container_root:normalized_host_root
-      rewritten
+  Keeper_sandbox.rewrite_container_paths_to_host
+    (Keeper_sandbox.docker_mount_layout_of_meta ~config meta)
+    cmd
 ;;
 
 (* Invariant: the declared sandbox profile is the execution contract. *)

--- a/lib/keeper/keeper_sandbox_docker_container_name.ml
+++ b/lib/keeper/keeper_sandbox_docker_container_name.ml
@@ -43,24 +43,7 @@ let docker_private_workspace_cwd
       ~(meta : Keeper_meta_contract.keeper_meta)
       host_cwd
   =
-  let normalize_path_for_containment path =
-    Keeper_alerting_path.normalize_path_for_check_stripped path
-  in
-  let host_root =
-    Keeper_sandbox.host_root_abs_of_meta ~config meta |> normalize_path_for_containment
-  in
-  let container_root = keeper_private_container_root meta in
-  let host_cwd = normalize_path_for_containment host_cwd in
-  if host_cwd = host_root
-  then container_root
-  else if String.starts_with ~prefix:(host_root ^ "/") host_cwd
-  then (
-    let suffix =
-      String.sub
-        host_cwd
-        (String.length host_root + 1)
-        (String.length host_cwd - String.length host_root - 1)
-    in
-    Filename.concat container_root suffix)
-  else container_root
+  Keeper_sandbox.container_cwd_of_host
+    (Keeper_sandbox.docker_mount_layout_of_meta ~config meta)
+    ~host_cwd
 ;;

--- a/lib/keeper/keeper_sandbox_read_backend.ml
+++ b/lib/keeper/keeper_sandbox_read_backend.ml
@@ -21,34 +21,16 @@ let should_route_read ~(meta : keeper_meta) : bool =
 let strip_trailing_slashes = Env_config_core.strip_trailing_slashes
 
 let host_playground_root ~config ~(meta : keeper_meta) =
-  Keeper_sandbox.host_root_abs_of_meta ~config meta
-  |> Keeper_alerting_path.normalize_path_for_check
-  |> strip_trailing_slashes
+  (Keeper_sandbox.docker_mount_layout_of_meta ~config meta).host_root
 
 let container_root ~(meta : keeper_meta) =
   Keeper_sandbox.container_root meta.name
 
 let container_path_of_host ~config ~(meta : keeper_meta) ~host_path
     : (string, string) result =
-  let host_root = host_playground_root ~config ~meta in
-  let host_norm =
-    Keeper_alerting_path.normalize_path_for_check host_path
-    |> strip_trailing_slashes
-  in
-  let croot = container_root ~meta in
-  if host_norm = host_root then Ok croot
-  else if String.starts_with ~prefix:(host_root ^ "/") host_norm then
-    let suffix =
-      String.sub host_norm
-        (String.length host_root + 1)
-        (String.length host_norm - String.length host_root - 1)
-    in
-    Ok (Filename.concat croot suffix)
-  else
-    Error
-      (Printf.sprintf
-         "container_path_of_host: %s is not inside playground %s"
-         host_norm host_root)
+  Keeper_sandbox.container_path_of_host
+    (Keeper_sandbox.docker_mount_layout_of_meta ~config meta)
+    ~host_path
 
 (* Argv prefix kept private — distinct from keeper_tool_command_runtime's bash
    argv to avoid coupling the two surfaces. The trailing

--- a/lib/keeper/keeper_tool_execute_path.ml
+++ b/lib/keeper/keeper_tool_execute_path.ml
@@ -287,6 +287,46 @@ let validate_repo_path_ready
 let validate_repo_cwd_ready ~(config : Workspace.config) ~(meta : keeper_meta) cwd =
   validate_repo_path_ready ~config ~meta ~probe_path:cwd cwd
 
+let raw_docker_host_path_of_normalized ~(config : Workspace.config) ~(meta : keeper_meta) path =
+  let layout = Keeper_sandbox.docker_mount_layout_of_meta ~config meta in
+  let path = normalize_repo_cwd_path path in
+  if String.equal path layout.host_root then
+    layout.host_root_raw
+  else if String.starts_with ~prefix:(layout.host_root ^ "/") path then (
+    let suffix =
+      String.sub
+        path
+        (String.length layout.host_root + 1)
+        (String.length path - String.length layout.host_root - 1)
+    in
+    Filename.concat layout.host_root_raw suffix)
+  else
+    path
+
+let docker_repo_worktree_cwd_fallback ~(config : Workspace.config) ~(meta : keeper_meta) cwd =
+  match meta.sandbox_profile with
+  | Local -> None
+  | Docker ->
+    (match repo_path_context ~config ~meta cwd with
+     | Some (repo_name, repo_root, path_root, _accepted_toplevels)
+       when not
+              (String.equal
+                 (normalize_repo_cwd_path repo_root)
+                 (normalize_repo_cwd_path path_root)) ->
+       (match validate_repo_path_ready ~config ~meta ~probe_path:repo_root repo_root with
+        | Ok () ->
+          let raw_repo_root =
+            raw_docker_host_path_of_normalized ~config ~meta repo_root
+          in
+          Log.Keeper.info
+            "docker cwd normalized from nested worktree %s to repo root %s for %s"
+            path_root
+            raw_repo_root
+            repo_name;
+          Some raw_repo_root
+        | Error _ -> None)
+     | _ -> None)
+
 let resolve_missing_cwd
       ~(config : Workspace.config)
       ~(meta : keeper_meta)
@@ -300,6 +340,22 @@ let resolve_missing_cwd
   | None ->
     let _created_path = Keeper_fs.ensure_dir cwd in
     Ok cwd
+
+let resolve_repo_cwd_candidate_from_raw
+      ~(config : Workspace.config)
+      ~(meta : keeper_meta)
+      raw_cwd
+  =
+  match playground_relative_unless_allowed_root ~config ~meta raw_cwd with
+  | Error _ -> None
+  | Ok normalized ->
+    let root = Keeper_alerting_path.project_root_of_config config in
+    let candidate =
+      if Filename.is_relative normalized then Filename.concat root normalized else normalized
+    in
+    (match repo_path_context ~config ~meta candidate with
+     | Some _ -> Some candidate
+     | None -> None)
 
 let resolve_tool_read_cwd
       ~(config : Workspace.config)
@@ -424,17 +480,28 @@ let resolve_tool_write_cwd
   let resolved =
     if raw_cwd = ""
     then Ok (keeper_default_write_root ~config ~meta)
-    else resolve_keeper_path ~config ~meta ~raw_path:raw_cwd
+    else (
+      match resolve_keeper_path ~config ~meta ~raw_path:raw_cwd with
+      | Ok _ as ok -> ok
+      | Error _ as err ->
+        (match resolve_repo_cwd_candidate_from_raw ~config ~meta raw_cwd with
+         | Some cwd -> Ok cwd
+         | None -> err))
   in
   match resolved with
   | Error _ as err -> err
   | Ok cwd when Fs_compat.file_exists cwd && Sys.is_directory cwd ->
     (match validate_repo_cwd_ready ~config ~meta cwd with
      | Ok () -> Ok cwd
-     | Error _ as err -> err)
+     | Error _ as err ->
+       (match docker_repo_worktree_cwd_fallback ~config ~meta cwd with
+        | Some fallback -> Ok fallback
+        | None -> err))
   | Ok cwd ->
     if not (Fs_compat.file_exists cwd) then
-      resolve_missing_cwd ~config ~meta cwd
+      match docker_repo_worktree_cwd_fallback ~config ~meta cwd with
+      | Some fallback -> Ok fallback
+      | None -> resolve_missing_cwd ~config ~meta cwd
     else
       Error (Printf.sprintf "cwd_not_directory: %s (path_is_file_not_directory)" cwd)
 

--- a/lib/keeper/keeper_tool_execute_runtime_paths.ml
+++ b/lib/keeper/keeper_tool_execute_runtime_paths.ml
@@ -2,35 +2,13 @@ open Keeper_types
 open Keeper_meta_contract
 open Keeper_types_profile
 
-let replace_all_substrings ~needle ~replacement text =
-  let needle_len = String.length needle in
-  if needle_len = 0 || not (String_util.contains_substring text needle) then text
-  else
-    let text_len = String.length text in
-    let buf = Buffer.create text_len in
-    let rec loop i =
-      if i >= text_len then ()
-      else if i + needle_len <= text_len
-              && String.sub text i needle_len = needle then (
-        Buffer.add_string buf replacement;
-        loop (i + needle_len))
-      else (
-        Buffer.add_char buf text.[i];
-        loop (i + 1))
-    in
-    loop 0;
-    Buffer.contents buf
-
 let rewrite_turn_runtime_paths_to_host
       ~(config : Workspace.config)
       ~(meta : keeper_meta)
       text
   =
-  replace_all_substrings
-    ~needle:(Keeper_sandbox.container_root meta.name)
-    ~replacement:
-      (Keeper_sandbox.host_root_abs_of_meta ~config meta
-       |> Keeper_alerting_path.strip_trailing_slashes)
+  Keeper_sandbox.rewrite_container_paths_to_host
+    (Keeper_sandbox.docker_mount_layout_of_meta ~config meta)
     text
 
 let rewrite_docker_host_paths_to_container
@@ -38,24 +16,6 @@ let rewrite_docker_host_paths_to_container
       ~(meta : keeper_meta)
       text
   =
-  let raw_host_root =
-    Keeper_sandbox.host_root_abs_of_meta ~config meta
-    |> Keeper_alerting_path.strip_trailing_slashes
-  in
-  let normalized_host_root =
-    raw_host_root
-    |> Keeper_alerting_path.normalize_path_for_check
-    |> Keeper_alerting_path.strip_trailing_slashes
-  in
-  let container_root =
-    Keeper_sandbox.container_root meta.name
-    |> Keeper_alerting_path.strip_trailing_slashes
-  in
-  let rewritten =
-    Keeper_sandbox_runtime.rewrite_host_root_to_container_root
-      ~host_root:raw_host_root ~container_root text
-  in
-  if String.equal raw_host_root normalized_host_root then rewritten
-  else
-    Keeper_sandbox_runtime.rewrite_host_root_to_container_root
-      ~host_root:normalized_host_root ~container_root rewritten
+  Keeper_sandbox.rewrite_host_paths_to_container
+    (Keeper_sandbox.docker_mount_layout_of_meta ~config meta)
+    text

--- a/lib/keeper/keeper_tool_execute_runtime_paths.mli
+++ b/lib/keeper/keeper_tool_execute_runtime_paths.mli
@@ -1,8 +1,5 @@
 (** Runtime path rewrites for tool execute responses and Docker commands. *)
 
-val replace_all_substrings :
-  needle:string -> replacement:string -> string -> string
-
 val rewrite_turn_runtime_paths_to_host :
   config:Workspace.config ->
   meta:Keeper_meta_contract.keeper_meta ->

--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -10,7 +10,7 @@ type t =
   { config : Workspace.config
   ; meta : keeper_meta
   ; turn_id : int
-  ; raw_host_root : string
+  ; mount_layout : Keeper_sandbox.docker_mount_layout
   ; host_root : string
   ; container_root : string
   ; uid : int
@@ -30,18 +30,13 @@ let create
       ~turn_id
       ()
   =
-  let raw_host_root =
-    Keeper_sandbox.host_root_abs_of_meta ~config meta
-    |> Keeper_alerting_path.strip_trailing_slashes
-  in
+  let mount_layout = Keeper_sandbox.docker_mount_layout_of_meta ~config meta in
   { config
   ; meta
   ; turn_id
-  ; raw_host_root
-  ; host_root = raw_host_root |> normalize_path
-  ; container_root =
-      Keeper_sandbox.container_root meta.name
-      |> Keeper_alerting_path.strip_trailing_slashes
+  ; mount_layout
+  ; host_root = mount_layout.host_root
+  ; container_root = mount_layout.container_root
   ; uid = Unix.getuid ()
   ; gid = Unix.getgid ()
   ; network_mode
@@ -73,30 +68,11 @@ let container_name_of (t : t) =
 ;;
 
 let container_path_of_host (t : t) ~host_path =
-  let host_norm = normalize_path host_path in
-  if host_norm = t.host_root
-  then Ok t.container_root
-  else if String.starts_with ~prefix:(t.host_root ^ "/") host_norm
-  then (
-    let suffix =
-      String.sub
-        host_norm
-        (String.length t.host_root + 1)
-        (String.length host_norm - String.length t.host_root - 1)
-    in
-    Ok (Filename.concat t.container_root suffix))
-  else
-    Error
-      (Printf.sprintf
-         "container_path_of_host: %s is not inside playground %s"
-         host_norm
-         t.host_root)
+  Keeper_sandbox.container_path_of_host t.mount_layout ~host_path
 ;;
 
 let container_cwd_of_host (t : t) ~host_cwd =
-  match container_path_of_host t ~host_path:host_cwd with
-  | Ok container_cwd -> container_cwd
-  | Error _ -> t.container_root
+  Keeper_sandbox.container_cwd_of_host t.mount_layout ~host_cwd
 ;;
 
 let format_docker_exec_error ~head_program ~st ~out =
@@ -418,20 +394,7 @@ let run_exec_with_status_once
     let container_cwd = container_cwd_of_host t ~host_cwd:cwd in
     let command_argv =
       List.map
-        (fun arg ->
-           let rewritten =
-             Keeper_sandbox_runtime.rewrite_host_root_to_container_root
-               ~host_root:t.host_root
-               ~container_root:t.container_root
-               arg
-           in
-           if String.equal t.raw_host_root t.host_root
-           then rewritten
-           else
-             Keeper_sandbox_runtime.rewrite_host_root_to_container_root
-               ~host_root:t.raw_host_root
-               ~container_root:t.container_root
-               rewritten)
+        (Keeper_sandbox.rewrite_host_paths_to_container t.mount_layout)
         command_argv
     in
     let argv =
@@ -481,20 +444,7 @@ type exec_pipeline_stage = {
 
 let rewrite_command_argv (t : t) command_argv =
   List.map
-    (fun arg ->
-      let rewritten =
-        Keeper_sandbox_runtime.rewrite_host_root_to_container_root
-          ~host_root:t.host_root
-          ~container_root:t.container_root
-          arg
-      in
-      if String.equal t.raw_host_root t.host_root
-      then rewritten
-      else
-        Keeper_sandbox_runtime.rewrite_host_root_to_container_root
-          ~host_root:t.raw_host_root
-          ~container_root:t.container_root
-          rewritten)
+    (Keeper_sandbox.rewrite_host_paths_to_container t.mount_layout)
     command_argv
 ;;
 
@@ -575,12 +525,7 @@ let run_command ?(ok_exit_codes = [ 0 ]) t ~cwd ~command_argv ~max_bytes ~timeou
 
 let run_bash_with_status (t : t) ~(cwd : string) ~(cmd : string) ~(timeout_sec : float) ()
   =
-  let cmd =
-    Keeper_sandbox_runtime.rewrite_host_root_to_container_root
-      ~host_root:t.host_root
-      ~container_root:t.container_root
-      cmd
-  in
+  let cmd = Keeper_sandbox.rewrite_host_paths_to_container t.mount_layout cmd in
   let container_cwd = container_cwd_of_host t ~host_cwd:cwd in
   let docker_exec_argv ~container_name =
     Keeper_sandbox_runtime.docker_command_argv ()

--- a/test/dune
+++ b/test/dune
@@ -1404,6 +1404,8 @@
 
 (include stanzas/test_keeper_tool_command_runtime_cwd_response.inc)
 
+(include stanzas/test_keeper_tool_execute_path_message.inc)
+
 (include stanzas/test_keeper_tool_dispatch_runtime.inc)
 
 (include stanzas/test_keeper_fs.inc)

--- a/test/stanzas/test_keeper_tool_execute_path_message.inc
+++ b/test/stanzas/test_keeper_tool_execute_path_message.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_tool_execute_path_message)
+ (modules test_keeper_tool_execute_path_message)
+ (libraries astring alcotest))

--- a/test/test_keeper_path_ssot.ml
+++ b/test/test_keeper_path_ssot.ml
@@ -211,6 +211,66 @@ let test_config_agent_projection_rejects_legacy_alias () =
             ~base_path:config.Workspace.base_path
             ~agent_name:"keeper-sangsu-agent"))
 
+let test_docker_mount_layout_maps_host_to_container () =
+  let config = make_config () in
+  let meta = make_meta ~name:"analyst" ~sandbox:Keeper_types_profile_sandbox.Docker in
+  let layout = Keeper_sandbox.docker_mount_layout_of_meta ~config meta in
+  let host_repo =
+    Filename.concat (Filename.concat layout.host_root "repos") "masc-mcp"
+  in
+  let host_file = Filename.concat host_repo "lib/keeper/foo.ml" in
+  let container_file =
+    Filename.concat
+      (Filename.concat layout.container_root "repos/masc-mcp")
+      "lib/keeper/foo.ml"
+  in
+  Alcotest.(check string)
+    "host root"
+    (Keeper_sandbox.host_root_abs_of_meta ~config meta
+     |> Masc.Keeper_alerting_path.normalize_path_for_check
+     |> Masc.Keeper_alerting_path.strip_trailing_slashes)
+    layout.host_root;
+  Alcotest.(check string)
+    "container root"
+    (Keeper_sandbox.container_root meta.name)
+    layout.container_root;
+  (match Keeper_sandbox.container_path_of_host layout ~host_path:host_file with
+   | Ok actual ->
+     Alcotest.(check string)
+       "host path maps to container path"
+       container_file actual
+   | Error err -> Alcotest.failf "host path did not map to container path: %s" err);
+  Alcotest.(check string)
+    "host cwd maps to container cwd"
+    container_file
+    (Keeper_sandbox.container_cwd_of_host layout ~host_cwd:host_file)
+
+let test_docker_mount_layout_rewrites_raw_and_normalized_roots () =
+  let config = make_config () in
+  let meta = make_meta ~name:"analyst" ~sandbox:Keeper_types_profile_sandbox.Docker in
+  let layout = Keeper_sandbox.docker_mount_layout_of_meta ~config meta in
+  let raw_host =
+    Keeper_sandbox.host_root_abs_of_meta ~config meta
+    |> Masc.Keeper_alerting_path.strip_trailing_slashes
+  in
+  let text =
+    Printf.sprintf "cd %s/repos/masc && test -d %s2" raw_host raw_host
+  in
+  let rewritten = Keeper_sandbox.rewrite_host_paths_to_container layout text in
+  Alcotest.(check string)
+    "host root rewritten on path boundary only"
+    (Printf.sprintf
+       "cd %s/repos/masc && test -d %s2"
+       layout.container_root
+       raw_host)
+    rewritten;
+  Alcotest.(check string)
+    "container root rewrites back to raw host root"
+    (Printf.sprintf "cd %s/repos/masc" layout.host_root_raw)
+    (Keeper_sandbox.rewrite_container_paths_to_host
+       layout
+       (Printf.sprintf "cd %s/repos/masc" layout.container_root))
+
 (* ── Egress policy file path SSOT ─────────────────────────────────────────
 
    Leak 11 (2026-04-27): keeper "executor" had its egress.json placed at
@@ -304,6 +364,13 @@ let () =
           test_config_agent_projection_local;
         Alcotest.test_case "legacy profile rejected" `Quick
           test_config_agent_projection_rejects_legacy_alias;
+      ] );
+    ( "docker mount layout",
+      [
+        Alcotest.test_case "host paths map to container paths" `Quick
+          test_docker_mount_layout_maps_host_to_container;
+        Alcotest.test_case "path rewrites use boundary-safe roots" `Quick
+          test_docker_mount_layout_rewrites_raw_and_normalized_roots;
       ] );
     ( "egress_policy_path SSOT",
       [

--- a/test/test_keeper_tool_execute_path_message.ml
+++ b/test/test_keeper_tool_execute_path_message.ml
@@ -1,0 +1,153 @@
+(** Source-level wiring guard for PR3 of the [Keeper_tool_execute_path]
+    [sandbox_repo_not_ready] error message.
+
+    This test pins the operator-facing message format added in PR3:
+    the [repo_cwd_not_ready_error] formatter must carry a docker
+    sandbox mount hint so an operator who sees the error in a
+    docker-backed keeper can immediately tell whether the failure
+    is a host-side checkout problem (reclone) or a docker mount
+    layout problem (worktree subdir not visible to the container).
+
+    PR3 also removes the host-stat fast-path ([safe_is_dir probe_path])
+    at the top of [validate_repo_path_ready] — that fast-path was a
+    false-positive for docker sandbox cwd where the path is not present
+    on the host.  The git probe alone is the source of truth.
+
+    Pinned invariants:
+    - the original "Repair or reclone" hint is still present
+      (regression guard — never remove without operator migration)
+    - the docker mount hint added in PR3 is present
+    - [Option.value ~default:"<none>"] fallback for git_toplevel is
+      still wired (so operators can tell "git probe failed" from
+      "git probe returned a non-matching toplevel")
+    - the host-stat fast-path has been removed; the git
+      [rev-parse --show-toplevel] probe is still the authority
+
+    Substrings are intentionally short and chosen to land on a
+    single source line (no OCaml `\` line continuation), because
+    line continuation stitches the literal across line breaks at
+    compile time and the stitched result is not visible at the
+    source-text level.  Each test here is a regression guard, not
+    a full string match — the load-bearing assertion is "the
+    substring is present in the source", which suffices to catch
+    the realistic failure modes (someone deletes the docker hint,
+    re-introduces the safe_is_dir fast-path, or removes the
+    Option.value fallback). *)
+
+open Alcotest
+
+let read_source path =
+  let ic = open_in path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () ->
+      let buf = Buffer.create 16384 in
+      (try
+         while true do
+           Buffer.add_string buf (input_line ic);
+           Buffer.add_char buf '\n'
+         done
+       with End_of_file -> ());
+      Buffer.contents buf)
+
+let find_source_path () =
+  List.find_opt Sys.file_exists
+    [
+      "lib/keeper/keeper_tool_execute_path.ml"
+    ; "../lib/keeper/keeper_tool_execute_path.ml"
+    ; "../../lib/keeper/keeper_tool_execute_path.ml"
+    ]
+
+let src_opt () = Option.map read_source (find_source_path ())
+
+let has_substring_opt src_opt needle =
+  match src_opt with
+  | None -> false
+  | Some src ->
+    let n = String.length needle in
+    let rec loop i =
+      if i + n > String.length src then false
+      else if String.sub src i n = needle then true
+      else loop (i + 1)
+    in
+    loop 0
+
+let test_reclone_hint_present () =
+  check bool
+    "original reclone hint still present (regression guard)"
+    true
+    (has_substring_opt
+       (src_opt ())
+       "Repair or reclone")
+
+let test_retry_cwd_hint_present () =
+  check bool
+    "retry-cwd hint still present"
+    true
+    (has_substring_opt
+       (src_opt ())
+       "then retry with cwd=\\\"repos/")
+
+let test_docker_mount_hint_present () =
+  check bool
+    "docker sandbox hint is present (PR3 add)"
+    true
+    (has_substring_opt (src_opt ()) "If the call");
+  check bool
+    "docker hint mentions docker playground mount"
+    true
+    (has_substring_opt (src_opt ()) "the docker playground mount");
+  check bool
+    "docker hint mentions worktree subdirectory"
+    true
+    (has_substring_opt (src_opt ()) "worktree subdirectory");
+  check bool
+    "docker hint offers in-place repo root cwd alternative"
+    true
+    (has_substring_opt (src_opt ()) "set cwd to the in-place repo root")
+
+let test_git_toplevel_none_fallback_present () =
+  check bool
+    "Option.value ~default:\"<none>\" git_toplevel fallback present"
+    true
+    (has_substring_opt
+       (src_opt ())
+       "Option.value ~default:\"<none>\" git_toplevel")
+
+let test_safe_is_dir_fast_path_removed () =
+  (* PR3 removes the host-stat fast-path so the git probe alone is
+     the source of truth — docker sandbox cwd is not present on
+     the host, so a host stat is a false positive. *)
+  check bool
+    "host-stat fast-path (safe_is_dir probe_path) is removed"
+    false
+    (has_substring_opt (src_opt ()) "safe_is_dir probe_path")
+
+let test_git_rev_parse_probe_present () =
+  check bool
+    "git rev-parse --show-toplevel probe is still the authority"
+    true
+    (has_substring_opt (src_opt ()) "rev-parse")
+
+let () =
+  run "keeper_tool_execute_path_message"
+    [
+      ( "sandbox_repo_not_ready error message (PR3)"
+      , [
+          test_case "reclone hint regression guard" `Quick
+            test_reclone_hint_present
+        ; test_case "retry-cwd hint regression guard" `Quick
+            test_retry_cwd_hint_present
+        ; test_case "docker mount hint (PR3 add)" `Quick
+            test_docker_mount_hint_present
+        ; test_case "git_toplevel <none> fallback" `Quick
+            test_git_toplevel_none_fallback_present
+        ] )
+    ; ( "validate_repo_path_ready probe simplification (PR3)"
+      , [
+          test_case "host-stat fast-path removed" `Quick
+            test_safe_is_dir_fast_path_removed
+        ; test_case "git rev-parse probe present" `Quick
+            test_git_rev_parse_probe_present
+        ] )
+    ]

--- a/test/test_keeper_tool_execute_safety.ml
+++ b/test/test_keeper_tool_execute_safety.ml
@@ -593,6 +593,37 @@ let test_tool_execute_missing_worktree_cwd_does_not_create_directory () =
       (Sys.file_exists missing_worktree)
   | None -> Alcotest.fail ("expected error json, got: " ^ raw)
 
+let test_tool_execute_docker_worktree_cwd_falls_back_to_repo_root () =
+  with_eio_fs @@ fun () ->
+  let base = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  let config = Workspace.default_config base in
+  let meta = make_docker_meta "sangsu" in
+  let playground = Keeper_sandbox.host_root_abs_of_meta ~config meta in
+  let repo_dir = Filename.concat playground "repos/masc" in
+  let missing_worktree = Filename.concat repo_dir ".worktrees/task-missing" in
+  ensure_dir repo_dir;
+  run_process_ok ~cwd:repo_dir "git" [ "init"; "-q"; "--initial-branch=main" ];
+  let args =
+    `Assoc
+      [ "executable", `String "ls"
+      ; "argv", `List []
+      ; "cwd", `String "repos/masc/.worktrees/task-missing"
+      ]
+  in
+  match
+    Masc.Keeper_tool_execute_path.resolve_tool_write_cwd ~config ~meta ~args
+  with
+  | Ok cwd ->
+    Alcotest.(check string)
+      "docker nested worktree cwd normalizes to repo root"
+      repo_dir cwd;
+    Alcotest.(check bool)
+      "missing worktree was not materialized"
+      false
+      (Sys.file_exists missing_worktree)
+  | Error err -> Alcotest.failf "expected docker cwd fallback, got: %s" err
+
 let test_tool_execute_elapsed_duration_preserves_positive_sub_ms () =
   let elapsed = Keeper_tool_command_runtime.For_testing.elapsed_duration_ms in
   Alcotest.(check int) "sub-ms positive duration rounds up to 1" 1
@@ -1481,6 +1512,10 @@ let () =
             "missing worktree cwd rejects without mkdir"
             `Quick
             test_tool_execute_missing_worktree_cwd_does_not_create_directory
+        ; Alcotest.test_case
+            "docker worktree cwd falls back to repo root"
+            `Quick
+            test_tool_execute_docker_worktree_cwd_falls_back_to_repo_root
         ] )
     ; ( "edge"
       , [ Alcotest.test_case


### PR DESCRIPTION
## Keeper docker sandbox cwd/root fix

This PR now contains both parts of the `sandbox_repo_not_ready` cleanup:

1. Diagnostic fix: keep `git rev-parse --show-toplevel` as the readiness source of truth and include the Docker mount hint in `sandbox_repo_not_ready`.
2. Root fix: centralize Docker playground mount layout and use it for cwd/path translation across keeper Docker execution surfaces.

### What changed

- `Keeper_sandbox` now exposes one Docker mount layout contract:
  - raw host root
  - normalized host root
  - container root
  - host to container path mapping
  - container to host path rewriting
- Docker path rewriting now derives from that layout in:
  - `keeper_sandbox_docker`
  - `keeper_sandbox_docker_container_name`
  - `keeper_sandbox_read_backend`
  - `keeper_tool_execute_runtime_paths`
  - `keeper_turn_sandbox_runtime`
- `resolve_tool_write_cwd` now handles Docker keeper cwd under `repos/<repo>/.worktrees/<task>` by falling back to the in-place repo root when the repo root is ready.
- Local keepers still reject missing/stale `.worktrees/<task>` cwd and do not materialize that directory.

### Why

The original failure was not just an unclear error message. Docker-backed keepers had multiple places recomputing host root, normalized host root, container root, cwd mapping, and output rewriting. That let cwd validation and Docker execution disagree about the same playground path.

The PR now makes Docker mount layout a single keeper sandbox contract, then routes cwd determination and Docker path rendering through it.

### Verification

```bash
env MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build \
  test/test_keeper_path_ssot.exe \
  test/test_keeper_tool_execute_safety.exe \
  test/test_keeper_sandbox_docker_cwd_response.exe \
  test/test_keeper_sandbox_read_backend.exe \
  test/test_keeper_sandbox_runner.exe \
  test/test_keeper_tool_execute_path_message.exe

./_build/default/test/test_keeper_path_ssot.exe
./_build/default/test/test_keeper_tool_execute_safety.exe test playground_guard 7,13,14 --show-errors
./_build/default/test/test_keeper_tool_execute_safety.exe test turn_runtime_paths --show-errors
./_build/default/test/test_keeper_tool_execute_path_message.exe
./_build/default/test/test_keeper_sandbox_docker_cwd_response.exe
./_build/default/test/test_keeper_sandbox_read_backend.exe
./_build/default/test/test_keeper_sandbox_runner.exe
```

All commands above passed locally after rebasing onto current `origin/main` (`c038399d2b`).

### Note

The full `test_keeper_tool_execute_safety.exe` still has unrelated existing failures in allowlist/tool_search timeout expectations on this checkout; the mount/cwd-related subsets added or affected by this PR pass.
