### PR TITLE
Fix PR descriptor ingest call contract

### DIFF
--- a/lib/ide/ide_bridge.ml
+++ b/lib/ide/ide_bridge.ml
@@ -5,6 +5,14 @@ open Ide_event_types
 
 let default_partition = Ide_paths.Orphan
 
+type pr_event_descriptor_ingest =
+  { pr_base_path : string
+  ; pr_keeper_id : string
+  ; pr_turn_id : string
+  ; pr_output_text : string
+  ; pr_success : bool
+  }
+
 let append_event ~base_dir ~partition ~(event : ide_event) =
   let dir = Ide_paths.partition_store_dir ~base_dir partition in
   Fs_compat.mkdir_p dir;
@@ -256,23 +264,22 @@ let parse_pr_url_from_output (output : string) : (int * string) option =
      | _ -> None)
 
 (** Ingest PR event from command_descriptor (deterministic).
-    Falls back to heuristic output parsing if descriptor is not available.
     Only proceeds when [success] is [true] — failed tool executions
     (auth/network/validation errors) must not produce phantom PR events. *)
 let ingest_pr_event_from_descriptor
-    ~base_path
-    ~keeper_id
-    ~turn_id
-    ~output_text
-    ~tool_name
-    ~success
+    { pr_base_path = base_path
+    ; pr_keeper_id = keeper_id
+    ; pr_turn_id = turn_id
+    ; pr_output_text = output_text
+    ; pr_success = success
+    }
   =
   (* Gate: only ingest PR events from successful tool executions.
      Failed commands (auth/network/validation errors) preserve the
      command_descriptor in their output, which would otherwise produce
      phantom PR #0 events. *)
   if not success then ()
-  else if String.equal (String.lowercase_ascii tool_name) "execute" then
+  else
     match extract_descriptor_from_output output_text with
     | Some (Ide_event_types.Gh_pr_create { title; base = _; draft = _ }) ->
       (* PR was created — try to get PR number from output URL *)
@@ -338,70 +345,4 @@ let ingest_pr_event_from_descriptor
         ~comment_count:1 ~review_status:None
         ~timestamp_ms:(Int64.of_float (Unix.gettimeofday () *. 1000.0))
     | Some (Ide_event_types.Gh_issue_create _ | Ide_event_types.Gh_issue_close _ | Ide_event_types.Git_push _ | Ide_event_types.Git_commit _ | Ide_event_types.Pipe_chain _ | Ide_event_types.Generic)
-    | None ->
-      (* Not a PR operation — fall back to heuristic output parsing *)
-      if String.equal (String.lowercase_ascii tool_name) "execute" then
-        match parse_pr_url_from_output output_text with
-        | Some (pr_number, pr_url) ->
-          let repo =
-            let prefix = "https://github.com/" in
-            let prefix_len = String.length prefix in
-            let url_len = String.length pr_url in
-            if url_len > prefix_len then
-              let path = String.sub pr_url prefix_len (url_len - prefix_len) in
-              let parts = String.split_on_char '/' path in
-              match parts with
-              | owner :: repo_name :: _ -> owner ^ "/" ^ repo_name
-              | _ -> "unknown"
-            else "unknown"
-          in
-          ingest_pr_event
-            ~base_path ~pr_number ~pr_url ~pr_title:""
-            ~pr_state:"open" ~repo ~keeper_id ~turn_id
-            ~comment_count:0 ~review_status:None
-            ~timestamp_ms:(Int64.of_float (Unix.gettimeofday () *. 1000.0))
-        | None -> ()
-
-(** Try to detect PR creation from Execute tool output and ingest a PR event.
-    Only fires when [tool_name = "execute"] and output contains a GitHub PR URL.
-
-    FIXME: This is a heuristic. It parses stdout/stderr for GitHub PR URLs
-    which is fragile — output format changes, non-GitHub hosts, or URL
-    in unexpected position will silently miss. A dedicated [Pr_create] tool
-    in the keeper vocabulary would make this deterministic. Until then,
-    this is best-effort and may produce false negatives. *)
-let ingest_pr_event_from_hook
-    ~base_path
-    ~keeper_id
-    ~turn_id
-    ~output_text
-    ~tool_name
-  =
-  if String.equal (String.lowercase_ascii tool_name) "execute" then
-    match parse_pr_url_from_output output_text with
-    | Some (pr_number, pr_url) ->
-      let repo =
-        let prefix = "https://github.com/" in
-        let prefix_len = String.length prefix in
-        let url_len = String.length pr_url in
-        if url_len > prefix_len then
-          let path = String.sub pr_url prefix_len (url_len - prefix_len) in
-          let parts = String.split_on_char '/' path in
-          match parts with
-          | owner :: repo_name :: _ -> owner ^ "/" ^ repo_name
-          | _ -> "unknown"
-        else "unknown"
-      in
-      ingest_pr_event
-        ~base_path
-        ~pr_number
-        ~pr_url
-        ~pr_title:""
-        ~pr_state:"open"
-        ~repo
-        ~keeper_id
-        ~turn_id
-        ~comment_count:0
-        ~review_status:None
-        ~timestamp_ms:(Int64.of_float (Unix.gettimeofday () *. 1000.0))
     | None -> ()

--- a/lib/ide/ide_bridge.mli
+++ b/lib/ide/ide_bridge.mli
@@ -58,29 +58,18 @@ val ingest_pr_event :
   timestamp_ms:int64 ->
   unit
 
-(** Try to detect PR creation from Execute tool output and ingest a PR event.
-    Only fires when [tool_name = "execute"] and output contains a GitHub PR URL.
-    Heuristic — falls back to output parsing if descriptor is not available. *)
-val ingest_pr_event_from_hook :
-  base_path:string ->
-  keeper_id:string ->
-  turn_id:string ->
-  output_text:string ->
-  tool_name:string ->
-  unit
+type pr_event_descriptor_ingest =
+  { pr_base_path : string
+  ; pr_keeper_id : string
+  ; pr_turn_id : string
+  ; pr_output_text : string
+  ; pr_success : bool
+  }
 
 (** Ingest PR event from command_descriptor (deterministic).
-    Extracts descriptor from tool result JSON, falls back to heuristic.
     Only proceeds when [success] is [true] — failed tool executions
     (auth/network/validation errors) must not produce phantom PR events. *)
-val ingest_pr_event_from_descriptor :
-  base_path:string ->
-  keeper_id:string ->
-  turn_id:string ->
-  output_text:string ->
-  tool_name:string ->
-  success:bool ->
-  unit
+val ingest_pr_event_from_descriptor : pr_event_descriptor_ingest -> unit
 
 (** Extract command_descriptor from tool result JSON. *)
 val extract_descriptor_from_output : string -> command_descriptor option

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -242,12 +242,12 @@ let assemble_hooks
              ~input;
            (* IDE Bridge: detect PR creation from command_descriptor *)
            Ide_bridge.ingest_pr_event_from_descriptor
-             ~base_path:config.base_path
-             ~keeper_id:acc.meta.name
-             ~turn_id
-             ~output_text
-             ~tool_name
-             ~success))
+             { Ide_bridge.pr_base_path = config.base_path
+             ; pr_keeper_id = acc.meta.name
+             ; pr_turn_id = turn_id
+             ; pr_output_text = output_text
+             ; pr_success = success
+             }))
         ~pre_tool_use_guard:public_alias_pre_tool_use_guard
         ()
     in

--- a/test/test_command_descriptor.ml
+++ b/test/test_command_descriptor.ml
@@ -270,12 +270,12 @@ let test_descriptor_to_pr_event () =
   with_temp_dir (fun base_dir ->
     let output = {|{"ok":true,"output":"https://github.com/jeong-sik/masc/pull/999","command_descriptor":{"kind":"gh_pr_create","title":"test PR","base":"main","draft":false}}|} in
     Ide_bridge.ingest_pr_event_from_descriptor
-      ~base_path:base_dir
-      ~keeper_id:"k1"
-      ~turn_id:"t1"
-      ~output_text:output
-      ~tool_name:"execute"
-      ~success:true;
+      { Ide_bridge.pr_base_path = base_dir
+      ; pr_keeper_id = "k1"
+      ; pr_turn_id = "t1"
+      ; pr_output_text = output
+      ; pr_success = true
+      };
     let dir = Ide_paths.partition_store_dir ~base_dir:base_dir Ide_paths.Orphan in
     let path = Filename.concat dir "pr_events.jsonl" in
     check bool "file exists" true (Sys.file_exists path);
@@ -293,12 +293,12 @@ let test_descriptor_merge_event () =
   with_temp_dir (fun base_dir ->
     let output = {|{"ok":true,"output":"","command_descriptor":{"kind":"gh_pr_merge","pr_number":456,"squash":true}}|} in
     Ide_bridge.ingest_pr_event_from_descriptor
-      ~base_path:base_dir
-      ~keeper_id:"k1"
-      ~turn_id:"t1"
-      ~output_text:output
-      ~tool_name:"execute"
-      ~success:true;
+      { Ide_bridge.pr_base_path = base_dir
+      ; pr_keeper_id = "k1"
+      ; pr_turn_id = "t1"
+      ; pr_output_text = output
+      ; pr_success = true
+      };
     let dir = Ide_paths.partition_store_dir ~base_dir:base_dir Ide_paths.Orphan in
     let path = Filename.concat dir "pr_events.jsonl" in
     check bool "file exists" true (Sys.file_exists path);

--- a/test/test_ide_bridge.ml
+++ b/test/test_ide_bridge.ml
@@ -275,65 +275,17 @@ let test_pr_event_ingest () =
     check string "pr_url" "https://github.com/jeong-sik/masc/pull/19872" pr_url)
 ;;
 
-let test_pr_event_from_hook_detects_url () =
-  with_temp_dir (fun base_dir ->
-    let output = "remote: https://github.com/jeong-sik/masc/pull/123\n" in
-    Ide_bridge.ingest_pr_event_from_hook
-      ~base_path:base_dir
-      ~keeper_id:"k1"
-      ~turn_id:"t1"
-      ~output_text:output
-      ~tool_name:"execute";
-    let dir = Ide_paths.partition_store_dir ~base_dir:base_dir Ide_paths.Orphan in
-    let path = Filename.concat dir "pr_events.jsonl" in
-    check bool "file exists" true (Sys.file_exists path);
-    let ic = open_in path in
-    let line = input_line ic in
-    close_in ic;
-    let json = Yojson.Safe.from_string line in
-    let pr_number = Yojson.Safe.Util.member "pr_number" json |> Yojson.Safe.Util.to_int in
-    check int "pr_number" 123 pr_number)
-;;
-
-let test_pr_event_from_hook_ignores_non_execute () =
-  with_temp_dir (fun base_dir ->
-    let output = "https://github.com/owner/repo/pull/456" in
-    Ide_bridge.ingest_pr_event_from_hook
-      ~base_path:base_dir
-      ~keeper_id:"k1"
-      ~turn_id:"t1"
-      ~output_text:output
-      ~tool_name:"fs_write";
-    let dir = Ide_paths.partition_store_dir ~base_dir:base_dir Ide_paths.Orphan in
-    let path = Filename.concat dir "pr_events.jsonl" in
-    check bool "file not created" false (Sys.file_exists path))
-;;
-
-let test_pr_event_from_hook_ignores_no_url () =
-  with_temp_dir (fun base_dir ->
-    let output = "file written successfully\n" in
-    Ide_bridge.ingest_pr_event_from_hook
-      ~base_path:base_dir
-      ~keeper_id:"k1"
-      ~turn_id:"t1"
-      ~output_text:output
-      ~tool_name:"execute";
-    let dir = Ide_paths.partition_store_dir ~base_dir:base_dir Ide_paths.Orphan in
-    let path = Filename.concat dir "pr_events.jsonl" in
-    check bool "file not created" false (Sys.file_exists path))
-;;
-
 let test_descriptor_gated_on_success () =
   with_temp_dir (fun base_dir ->
     (* Failed gh pr create with command_descriptor in output should NOT produce PR event *)
     let failed_output = {|{"command_descriptor": {"kind": "gh_pr_create", "title": "feat: test", "base": "main", "draft": true}, "error": "authentication failed"}|} in
     Ide_bridge.ingest_pr_event_from_descriptor
-      ~base_path:base_dir
-      ~keeper_id:"k1"
-      ~turn_id:"t1"
-      ~output_text:failed_output
-      ~tool_name:"execute"
-      ~success:false;
+      { Ide_bridge.pr_base_path = base_dir
+      ; pr_keeper_id = "k1"
+      ; pr_turn_id = "t1"
+      ; pr_output_text = failed_output
+      ; pr_success = false
+      };
     let dir = Ide_paths.partition_store_dir ~base_dir:base_dir Ide_paths.Orphan in
     let path = Filename.concat dir "pr_events.jsonl" in
     check bool "file not created on failure" false (Sys.file_exists path))
@@ -344,12 +296,12 @@ let test_descriptor_ingested_on_success () =
     (* Successful gh pr create with command_descriptor should produce PR event *)
     let success_output = {|{"command_descriptor": {"kind": "gh_pr_create", "title": "feat: test", "base": "main", "draft": true}}|} in
     Ide_bridge.ingest_pr_event_from_descriptor
-      ~base_path:base_dir
-      ~keeper_id:"k1"
-      ~turn_id:"t1"
-      ~output_text:success_output
-      ~tool_name:"execute"
-      ~success:true;
+      { Ide_bridge.pr_base_path = base_dir
+      ; pr_keeper_id = "k1"
+      ; pr_turn_id = "t1"
+      ; pr_output_text = success_output
+      ; pr_success = true
+      };
     let dir = Ide_paths.partition_store_dir ~base_dir:base_dir Ide_paths.Orphan in
     let path = Filename.concat dir "pr_events.jsonl" in
     check bool "file created on success" true (Sys.file_exists path);
@@ -418,9 +370,6 @@ let () =
         ] )
     ; ( "pr_event"
       , [ test_case "pr event ingest" `Quick test_pr_event_ingest
-        ; test_case "from hook detects url" `Quick test_pr_event_from_hook_detects_url
-        ; test_case "from hook ignores non-execute" `Quick test_pr_event_from_hook_ignores_non_execute
-        ; test_case "from hook ignores no url" `Quick test_pr_event_from_hook_ignores_no_url
         ; test_case "descriptor gated on success" `Quick test_descriptor_gated_on_success
         ; test_case "descriptor ingested on success" `Quick test_descriptor_ingested_on_success
         ] )


### PR DESCRIPTION
## Summary
- replace `ingest_pr_event_from_descriptor` labeled args with a single record payload so future required fields fail as record-field errors instead of ignored partial applications
- remove `tool_name` and heuristic PR URL fallback from IDE PR descriptor ingestion
- keep IDE descriptor ingestion deterministic: successful command descriptors produce PR events, missing/non-PR descriptors do nothing
- update command descriptor and IDE bridge tests for the new boundary

## Boundary notes
- IDE bridge does not import Keeper tool vocabulary
- descriptor ingestion is descriptor-driven only
- Task -> Keeper cleanup is tracked separately in #20010 and not mixed into this partial-application fix

## Verification
- `gtimeout 600 env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-command-descriptor-no-heuristic dune build --root . test/test_command_descriptor.exe test/test_ide_bridge.exe`
- `./_build-codex-command-descriptor-no-heuristic/default/test/test_command_descriptor.exe`
- `./_build-codex-command-descriptor-no-heuristic/default/test/test_ide_bridge.exe`
- `gtimeout 900 env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-command-descriptor-no-heuristic dune build --root . .`
- `git diff --check`