### PR TITLE
fix(keeper): root fix sandbox worktree auto-recreation for docker mounts

### DIFF
--- a/lib/keeper/keeper_repo_readiness.ml
+++ b/lib/keeper/keeper_repo_readiness.ml
@@ -369,6 +369,71 @@ let ensure_ready ~(config : Workspace.config) ~(meta : keeper_meta) ~repo_name (
            "repo %s is in state %s; auto-repair not applicable"
            repo_name other)
 
+(** [ensure_worktree_ready ~config ~meta ~repo_name ~task_name ~worktree_path ()]
+    ensures a git worktree exists at [worktree_path] inside the sandbox clone for
+    [repo_name].  If the worktree is missing, first ensures the parent repo is
+    ready (reclone if needed), then creates the worktree via
+    [git worktree add].  Returns [Ok ()] when the worktree is a valid git
+    checkout, or [Error msg] if creation failed.
+
+    Root fix for the docker sandbox mount issue: when the keeper cwd targets a
+    worktree path that doesn't exist in the sandbox clone (e.g. because the
+    worktree was created on the host but the docker container's clone is fresh),
+    this function recreates the worktree instead of failing with
+    [sandbox_repo_not_ready]. *)
+let ensure_worktree_ready
+      ~(config : Workspace.config)
+      ~(meta : keeper_meta)
+      ~(repo_name : string)
+      ~(task_name : string)
+      ~(worktree_path : string)
+      () : (unit, string) result =
+  if not (safe_repo_component repo_name) then
+    Error (Printf.sprintf "invalid repo_name: %s" repo_name)
+  else if not (safe_repo_component task_name) then
+    Error (Printf.sprintf "invalid task_name: %s" task_name)
+  else
+    (* Fast path: worktree already exists and is a valid git checkout.
+       Skip parent repo validation — the parent may be "dirty" from worktree
+       metadata (.git/worktrees/), which is normal and expected. *)
+    let probe =
+      run_git ~timeout_sec:read_only_probe_timeout_sec
+        ~clone_path:worktree_path
+        [ "rev-parse"; "--show-toplevel" ]
+    in
+    if probe.ok then Ok ()
+    else
+      (* Worktree missing or corrupt — ensure parent repo exists, then create *)
+      match ensure_ready ~config ~meta ~repo_name () with
+      | Error msg ->
+        Error (Printf.sprintf "parent repo %s not ready: %s" repo_name msg)
+      | Ok () ->
+        let repo_path = clone_path ~config ~meta ~repo_name in
+        (* [git worktree add --detach] creates a detached HEAD worktree *)
+        let add_result =
+          run_git ~timeout_sec:(read_only_probe_timeout_sec *. 2.0)
+            ~clone_path:repo_path
+            [ "worktree"; "add"; "--detach"; worktree_path ]
+        in
+        if add_result.ok then (
+          (* Create a task branch in the new worktree *)
+          let branch_name = Printf.sprintf "task/%s" task_name in
+          let checkout =
+            run_git ~timeout_sec:read_only_probe_timeout_sec
+              ~clone_path:worktree_path
+              [ "checkout"; "-b"; branch_name ]
+          in
+          if checkout.ok then Ok ()
+          else
+            (* worktree created but branch checkout failed — still usable *)
+            Ok ()
+        )
+        else
+          Error
+            (Printf.sprintf
+               "worktree add failed for %s/%s at %s: %s"
+               repo_name task_name worktree_path add_result.output)
+
 (* ── Sandbox repo currency (fetch + work-preserving fast-forward) ──── *)
 
 (** Build a minimal [repository] record for the sandbox clone lane.

--- a/lib/keeper/keeper_repo_readiness.mli
+++ b/lib/keeper/keeper_repo_readiness.mli
@@ -84,6 +84,21 @@ val ensure_ready :
   unit ->
   (unit, string) result
 
+(** [ensure_worktree_ready ~config ~meta ~repo_name ~task_name ~worktree_path ()]
+    ensures a git worktree exists at [worktree_path] inside the sandbox clone.
+    If the worktree is missing, first ensures the parent repo is ready (reclone
+    if needed), then creates the worktree via [git worktree add].  Returns
+    [Ok ()] when the worktree is a valid git checkout, or [Error msg] if
+    creation failed. *)
+val ensure_worktree_ready :
+  config:Workspace.config ->
+  meta:Keeper_meta_contract.keeper_meta ->
+  repo_name:string ->
+  task_name:string ->
+  worktree_path:string ->
+  unit ->
+  (unit, string) result
+
 (** Outcome of an [ensure_current] pass. Every non-[Advanced] case leaves the
     working tree byte-for-byte untouched. *)
 type currency_outcome =

--- a/lib/keeper/keeper_tool_execute_path.ml
+++ b/lib/keeper/keeper_tool_execute_path.ml
@@ -191,12 +191,43 @@ let repo_cwd_not_ready_error ~repo_name ~path_root ~git_toplevel =
   Printf.sprintf
     "sandbox_repo_not_ready: sandbox path is under repos/%s, but %s is not an \
      independent git checkout (git_toplevel=%s). Repair or reclone the sandbox \
-     repo under repos/%s, then retry with cwd=\"repos/%s\"."
+     repo under repos/%s, then retry with cwd=\"repos/%s\". If the call is \
+     running inside a docker sandbox, ensure the docker playground mount \
+     includes the worktree subdirectory (or set cwd to the in-place repo root \
+     \"repos/%s\" if the keeper works directly in the clone)."
     repo_name
     path_root
     (Option.value ~default:"<none>" git_toplevel)
     repo_name
     repo_name
+    repo_name
+
+(** [extract_worktree_task_name cwd] extracts the task name if [cwd] is under a
+    [.worktrees/<task>] path.  Returns [Some (repo_name, task_name, worktree_root)]
+    or [None]. *)
+let extract_worktree_task_name ~(config : Workspace.config) ~(meta : keeper_meta) cwd =
+  let playground =
+    keeper_playground_root ~config ~meta
+    |> normalize_repo_cwd_path
+  in
+  let repos_root = Filename.concat playground "repos" |> normalize_repo_cwd_path in
+  let cwd = normalize_repo_cwd_path cwd in
+  let prefix = repos_root ^ "/" in
+  if not (String.starts_with ~prefix cwd) then None
+  else
+    let suffix =
+      String.sub cwd (String.length prefix) (String.length cwd - String.length prefix)
+    in
+    match String.split_on_char '/' suffix with
+    | repo_name :: ".worktrees" :: task_name :: _
+      when Keeper_repo_readiness.safe_repo_component repo_name
+           && Keeper_repo_readiness.safe_repo_component task_name ->
+      let worktree_root =
+        Filename.concat (Filename.concat (Filename.concat repos_root repo_name) ".worktrees") task_name
+        |> normalize_repo_cwd_path
+      in
+      Some (repo_name, task_name, worktree_root)
+    | _ -> None
 
 let validate_repo_path_ready
       ~(config : Workspace.config)
@@ -209,40 +240,49 @@ let validate_repo_path_ready
   | Some (repo_name, _repo_root, path_root, accepted_toplevels) ->
     sync_repo_currency_best_effort ~config ~meta ~repo_name;
     let check_probe () =
-      if not (safe_is_dir probe_path) then
-        Error
-          (repo_cwd_not_ready_error ~repo_name ~path_root ~git_toplevel:None)
+      let top =
+        Keeper_repo_readiness.run_git
+          ~timeout_sec:Keeper_repo_readiness.read_only_probe_timeout_sec
+          ~clone_path:probe_path
+          [ "rev-parse"; "--show-toplevel" ]
+      in
+      let top_opt = if top.ok then Some top.output else None in
+      let top_matches =
+        top.ok
+        && List.exists
+             (fun expected ->
+                String.equal
+                  (normalize_repo_cwd_path top.output)
+                  (normalize_repo_cwd_path expected))
+             accepted_toplevels
+      in
+      if top_matches then Ok ()
       else
-        let top =
-          Keeper_repo_readiness.run_git
-            ~timeout_sec:Keeper_repo_readiness.read_only_probe_timeout_sec
-            ~clone_path:probe_path
-            [ "rev-parse"; "--show-toplevel" ]
-        in
-        let top_opt = if top.ok then Some top.output else None in
-        let top_matches =
-          top.ok
-          && List.exists
-               (fun expected ->
-                  String.equal
-                    (normalize_repo_cwd_path top.output)
-                    (normalize_repo_cwd_path expected))
-               accepted_toplevels
-        in
-        if top_matches then Ok ()
-        else
-          Error
-            (repo_cwd_not_ready_error ~repo_name ~path_root ~git_toplevel:top_opt)
+        Error
+          (repo_cwd_not_ready_error ~repo_name ~path_root ~git_toplevel:top_opt)
     in
     match check_probe () with
     | Ok () -> Ok ()
     | Error _ as initial_err ->
-      (* Auto-repair: attempt reclone when sandbox repo is missing or corrupt *)
-      (match
-         Keeper_repo_readiness.ensure_ready ~config ~meta ~repo_name ()
-       with
-       | Ok () -> check_probe ()
-       | Error _repair_err -> initial_err)
+      (* Auto-repair: for worktree paths, try worktree creation first;
+         for direct repo paths, try reclone. *)
+      let worktree_result =
+        match extract_worktree_task_name ~config ~meta cwd with
+        | Some (wt_repo_name, task_name, worktree_root) ->
+          Keeper_repo_readiness.ensure_worktree_ready
+            ~config ~meta ~repo_name:wt_repo_name ~task_name
+            ~worktree_path:worktree_root ()
+        | None -> Error "not a worktree path"
+      in
+      match worktree_result with
+      | Ok () -> check_probe ()
+      | Error _ ->
+        (* Fall back to repo-level reclone *)
+        (match
+           Keeper_repo_readiness.ensure_ready ~config ~meta ~repo_name ()
+         with
+         | Ok () -> check_probe ()
+         | Error _repair_err -> initial_err)
 
 let validate_repo_cwd_ready ~(config : Workspace.config) ~(meta : keeper_meta) cwd =
   validate_repo_path_ready ~config ~meta ~probe_path:cwd cwd

--- a/test/test_command_descriptor.ml
+++ b/test/test_command_descriptor.ml
@@ -274,7 +274,8 @@ let test_descriptor_to_pr_event () =
       ~keeper_id:"k1"
       ~turn_id:"t1"
       ~output_text:output
-      ~tool_name:"execute";
+      ~tool_name:"execute"
+      ~success:true;
     let dir = Ide_paths.partition_store_dir ~base_dir:base_dir Ide_paths.Orphan in
     let path = Filename.concat dir "pr_events.jsonl" in
     check bool "file exists" true (Sys.file_exists path);
@@ -296,7 +297,8 @@ let test_descriptor_merge_event () =
       ~keeper_id:"k1"
       ~turn_id:"t1"
       ~output_text:output
-      ~tool_name:"execute";
+      ~tool_name:"execute"
+      ~success:true;
     let dir = Ide_paths.partition_store_dir ~base_dir:base_dir Ide_paths.Orphan in
     let path = Filename.concat dir "pr_events.jsonl" in
     check bool "file exists" true (Sys.file_exists path);

--- a/test/test_keeper_repo_readiness.ml
+++ b/test/test_keeper_repo_readiness.ml
@@ -341,6 +341,92 @@ let test_auto_provisionable_workspace_repo_before_wide_workspace_storm () =
     Yojson.Safe.Util.(json |> member "workspace_repo_match" |> to_string)
 
 
+let test_ensure_worktree_ready_creates_worktree () =
+  let base_path = temp_dir "masc-worktree-ready" in
+  let remote = Filename.concat base_path ".remote-masc.git" in
+  (* Create a bare remote repo *)
+  git_ok ~cwd:base_path [ "init"; "--bare"; "-q"; "--initial-branch=main"; remote ];
+  (* Clone into the sandbox path *)
+  let config = Masc.Workspace.default_config base_path in
+  let meta = make_meta "keeper-one" in
+  let clone_path =
+    Masc.Keeper_repo_readiness.clone_path ~config ~meta ~repo_name:"masc"
+  in
+  mkdir_p (Filename.dirname clone_path);
+  git_ok ~cwd:base_path [ "clone"; "-q"; remote; clone_path ];
+  git_ok ~cwd:clone_path [ "config"; "user.email"; "test@example.com" ];
+  git_ok ~cwd:clone_path [ "config"; "user.name"; "Test" ];
+  let readme = Filename.concat clone_path "README.md" in
+  let oc = open_out readme in
+  output_string oc "# test\n";
+  close_out oc;
+  git_ok ~cwd:clone_path [ "add"; "README.md" ];
+  git_ok ~cwd:clone_path [ "commit"; "-q"; "-m"; "init" ];
+  git_ok ~cwd:clone_path [ "push"; "-q"; "origin"; "main" ];
+  (* Worktree path *)
+  let worktree_path =
+    Filename.concat clone_path ".worktrees/task-575-test"
+  in
+  (* Call ensure_worktree_ready *)
+  let result =
+    Masc.Keeper_repo_readiness.ensure_worktree_ready
+      ~config ~meta ~repo_name:"masc" ~task_name:"task-575-test"
+      ~worktree_path ()
+  in
+  (match result with
+   | Ok () -> ()
+   | Error msg -> fail ("ensure_worktree_ready failed: " ^ msg));
+  (* Verify worktree exists and is a valid git checkout *)
+  check bool "worktree dir exists" true (Sys.file_exists worktree_path);
+  check bool "worktree is directory" true (Sys.is_directory worktree_path);
+  let probe =
+    Masc.Keeper_repo_readiness.run_git
+      ~timeout_sec:Masc.Keeper_repo_readiness.read_only_probe_timeout_sec
+      ~clone_path:worktree_path
+      [ "rev-parse"; "--show-toplevel" ]
+  in
+  check bool "worktree is valid git checkout" true probe.ok
+
+let test_ensure_worktree_ready_idempotent () =
+  let base_path = temp_dir "masc-worktree-ready" in
+  let remote = Filename.concat base_path ".remote-masc.git" in
+  git_ok ~cwd:base_path [ "init"; "--bare"; "-q"; "--initial-branch=main"; remote ];
+  let config = Masc.Workspace.default_config base_path in
+  let meta = make_meta "keeper-one" in
+  let clone_path =
+    Masc.Keeper_repo_readiness.clone_path ~config ~meta ~repo_name:"masc"
+  in
+  mkdir_p (Filename.dirname clone_path);
+  git_ok ~cwd:base_path [ "clone"; "-q"; remote; clone_path ];
+  git_ok ~cwd:clone_path [ "config"; "user.email"; "test@example.com" ];
+  git_ok ~cwd:clone_path [ "config"; "user.name"; "Test" ];
+  let readme = Filename.concat clone_path "README.md" in
+  let oc = open_out readme in
+  output_string oc "# test\n";
+  close_out oc;
+  git_ok ~cwd:clone_path [ "add"; "README.md" ];
+  git_ok ~cwd:clone_path [ "commit"; "-q"; "-m"; "init" ];
+  git_ok ~cwd:clone_path [ "push"; "-q"; "origin"; "main" ];
+  let worktree_path =
+    Filename.concat clone_path ".worktrees/task-idem-test"
+  in
+  (* First call creates the worktree *)
+  let r1 =
+    Masc.Keeper_repo_readiness.ensure_worktree_ready
+      ~config ~meta ~repo_name:"masc" ~task_name:"task-idem-test"
+      ~worktree_path ()
+  in
+  (match r1 with Ok () -> () | Error msg -> fail ("first call failed: " ^ msg));
+  (* Second call should succeed without error (idempotent) *)
+  let r2 =
+    Masc.Keeper_repo_readiness.ensure_worktree_ready
+      ~config ~meta ~repo_name:"masc" ~task_name:"task-idem-test"
+      ~worktree_path ()
+  in
+  match r2 with
+  | Ok () -> ()
+  | Error msg -> fail ("second call failed: " ^ msg)
+
 let () =
   Random.self_init ();
   run "Keeper_repo_readiness"
@@ -354,5 +440,12 @@ let () =
         test_case "invalid repo_name" `Quick test_invalid_repo_name;
         test_case "missing clone skips workspace discovery" `Quick
           test_missing_clone_skips_workspace_discovery;
+      ];
+      "ensure_worktree_ready",
+      [
+        test_case "creates worktree" `Quick
+          test_ensure_worktree_ready_creates_worktree;
+        test_case "idempotent" `Quick
+          test_ensure_worktree_ready_idempotent;
       ];
     ]


### PR DESCRIPTION
## Root fix: sandbox worktree auto-recreation for docker mounts

Supersedes [PR #20007](https://github.com/jeong-sik/masc-mcp/pull/20007) (diagnostic-only) with actual root fix.

### Root cause

`validate_repo_path_ready` only attempted repo-level reclone (`ensure_ready`) when the git probe failed. For worktree paths (`repos/masc-mcp/.worktrees/task-575-...`), the probe fails because the **worktree doesn't exist** in the docker sandbox clone — but `ensure_ready` doesn't create worktrees, only clones.

```
sandbox_repo_not_ready: sandbox path is under repos/masc-mcp, but
/Users/dancer/me/.masc/playground/docker/analyst/repos/masc-mcp/.worktrees/task-575-...
is not an independent git checkout (git_toplevel=<none>)
```

### Fix

1. **`keeper_repo_readiness.ml`**: Add `ensure_worktree_ready` that:
   - Fast path: if worktree already exists (valid git checkout), return immediately
   - Slow path: ensure parent repo is ready, then `git worktree add --detach` + `checkout -b task/<name>`

2. **`keeper_tool_execute_path.ml`**:
   - Remove `safe_is_dir probe_path` host-stat fast-path (false positive for docker sandbox — path exists on host but not in container)
   - When probe fails, try worktree creation first (`extract_worktree_task_name` + `ensure_worktree_ready`), then fall back to repo-level reclone
   - Add docker sandbox mount hint to error message

3. **`test_command_descriptor.ml`**: Fix missing `~success` parameter from PR #19991 (pre-existing build error on main)

4. **`test_keeper_repo_readiness.ml`**: 2 new tests — worktree creation + idempotency

### Build verification

```
$ dune build --root .    # exit 0
$ dune exec --root . test/test_keeper_repo_readiness.exe    # 7/7 PASS
$ dune exec --root . test/test_command_descriptor.exe        # 32/32 PASS
$ bash scripts/ocaml-structure-ratchet.sh                    # OK
```

### PR-RFC check

RFC-WAIVED: keeper sandbox path resolver auto-repair. credential/identity/operator/hooks/workflow 미포함. Root fix for docker mount layout issue documented in PR #20007.

🤖 Generated with [Claude Code](https://claude.com/claude-code)