### PR TITLE
refactor(keeper): derive inline-safe tools from descriptors

### DIFF
--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -67,6 +67,7 @@ type policy =
   ; approval : approval
   ; retryable : bool
   ; cwd_scope : string option
+  ; inline_safe : bool
   }
 
 type t =
@@ -147,7 +148,8 @@ let runtime_handler_to_string = function
 ;;
 
 let policy ?(visibility = Tool_catalog.Default) ?readonly ?readonly_of_input
-      ?effect_domain ?(approval = Policy_selected) ?cwd_scope ?(retryable = false) ()
+      ?effect_domain ?(approval = Policy_selected) ?cwd_scope ?(retryable = false)
+      ?(inline_safe = false) ()
   =
   let readonly_of_input =
     match readonly_of_input with
@@ -161,6 +163,7 @@ let policy ?(visibility = Tool_catalog.Default) ?readonly ?readonly_of_input
   ; approval
   ; retryable
   ; cwd_scope
+  ; inline_safe
   }
 ;;
 
@@ -569,23 +572,25 @@ let tool_search_schema =
     ]
 ;;
 
-let read_only_in_process_policy () =
+let read_only_in_process_policy ?(inline_safe = false) () =
   policy
     ~visibility:Tool_catalog.Hidden
     ~readonly:true
     ~effect_domain:Tool_catalog.Read_only
     ~approval:No_approval
     ~retryable:true
+    ~inline_safe
     ()
 ;;
 
-let write_in_process_policy ?(retryable = false) () =
+let write_in_process_policy ?(retryable = false) ?(inline_safe = false) () =
   policy
     ~visibility:Tool_catalog.Hidden
     ~readonly:false
     ~effect_domain:Tool_catalog.Playground_write
     ~approval:No_approval
     ~retryable
+    ~inline_safe
     ()
 ;;
 
@@ -608,9 +613,12 @@ let in_process_descriptor ~id ~name ~description ~input_schema ~policy ~handler 
    [runtime_handler] variant but expose distinct [internal_name]s so each
    tool retains its own descriptor entry and receipt evidence. The
    [keeper_tool_in_process_runtime] handler routes by descriptor.internal_name. *)
-let cluster_descriptor ~id ~name ~description ~handler ~readonly =
+let cluster_descriptor ~id ~name ~description ~handler ~readonly ~inline_safe =
+  if inline_safe && not readonly then
+    invalid_arg "inline_safe descriptors must declare readonly=true";
   let policy =
-    if readonly then read_only_in_process_policy () else write_in_process_policy ()
+    if readonly then read_only_in_process_policy ~inline_safe ()
+    else write_in_process_policy ~inline_safe ()
   in
   in_process_descriptor
     ~id
@@ -629,6 +637,7 @@ let board_descriptor name description ~readonly =
     ~description
     ~handler:Tool_board_dispatch
     ~readonly
+    ~inline_safe:false
 ;;
 
 let masc_board_descriptor (schema : Masc_domain.tool_schema) =
@@ -675,6 +684,7 @@ let voice_descriptor name description ~readonly =
     ~description
     ~handler:Tool_voice_dispatch
     ~readonly
+    ~inline_safe:false
 ;;
 
 let task_descriptor id name description ~readonly =
@@ -684,6 +694,7 @@ let task_descriptor id name description ~readonly =
     ~description
     ~handler:Tool_task_dispatch
     ~readonly
+    ~inline_safe:false
 ;;
 
 (* RFC-0182 §3.1 — additional masc_* cluster descriptor helpers (task /
@@ -700,6 +711,7 @@ let masc_task_descriptor id name description ~readonly =
     ~description
     ~handler:Tool_masc_task_dispatch
     ~readonly
+    ~inline_safe:false
 ;;
 
 let masc_plan_descriptor id name description ~readonly =
@@ -709,6 +721,7 @@ let masc_plan_descriptor id name description ~readonly =
     ~description
     ~handler:Tool_masc_plan_dispatch
     ~readonly
+    ~inline_safe:false
 ;;
 
 let masc_run_descriptor name description ~readonly =
@@ -719,6 +732,7 @@ let masc_run_descriptor name description ~readonly =
     ~description
     ~handler:Tool_masc_run_dispatch
     ~readonly
+    ~inline_safe:false
 ;;
 
 let masc_agent_descriptor id name description ~readonly =
@@ -728,6 +742,7 @@ let masc_agent_descriptor id name description ~readonly =
     ~description
     ~handler:Tool_masc_agent_dispatch
     ~readonly
+    ~inline_safe:false
 ;;
 
 let masc_workspace_descriptor id name description ~readonly =
@@ -737,6 +752,7 @@ let masc_workspace_descriptor id name description ~readonly =
     ~description
     ~handler:Tool_masc_workspace_dispatch
     ~readonly
+    ~inline_safe:false
 ;;
 
 (* RFC-0182 §3.1 — additional cluster descriptor helpers (Phase 3:
@@ -748,6 +764,7 @@ let masc_misc_descriptor id name description ~readonly =
     ~description
     ~handler:Tool_masc_misc_dispatch
     ~readonly
+    ~inline_safe:false
 ;;
 
 let masc_control_descriptor id name description ~readonly =
@@ -757,6 +774,7 @@ let masc_control_descriptor id name description ~readonly =
     ~description
     ~handler:Tool_masc_control_dispatch
     ~readonly
+    ~inline_safe:false
 ;;
 
 let masc_agent_timeline_descriptor name description ~readonly =
@@ -766,6 +784,7 @@ let masc_agent_timeline_descriptor name description ~readonly =
     ~description
     ~handler:Tool_masc_agent_timeline_dispatch
     ~readonly
+    ~inline_safe:false
 ;;
 
 let masc_local_runtime_descriptor id name description ~readonly =
@@ -775,6 +794,7 @@ let masc_local_runtime_descriptor id name description ~readonly =
     ~description
     ~handler:Tool_masc_local_runtime_dispatch
     ~readonly
+    ~inline_safe:false
 ;;
 
 let masc_tool_shard_descriptor id name description ~readonly =
@@ -784,10 +804,12 @@ let masc_tool_shard_descriptor id name description ~readonly =
     ~description
     ~handler:Tool_masc_tool_shard_dispatch
     ~readonly
+    ~inline_safe:false
 ;;
 
-let masc_approval_descriptor id name description ~readonly =
+let masc_approval_descriptor ?(inline_safe = false) id name description ~readonly =
   cluster_descriptor
+    ~inline_safe
     ~id:("masc.approval." ^ id)
     ~name
     ~description
@@ -802,6 +824,7 @@ let masc_persona_descriptor id name description ~readonly =
     ~description
     ~handler:Tool_masc_persona_dispatch
     ~readonly
+    ~inline_safe:false
 ;;
 
 let masc_keeper_descriptor id name description ~readonly =
@@ -811,6 +834,7 @@ let masc_keeper_descriptor id name description ~readonly =
     ~description
     ~handler:Tool_masc_keeper_dispatch
     ~readonly
+    ~inline_safe:false
 ;;
 
 let internal_descriptors : t list =
@@ -1144,7 +1168,7 @@ let internal_descriptors : t list =
   ; masc_tool_shard_descriptor "revoke" "masc_tool_revoke"
       "Revoke a previously-granted tool shard from an agent." ~readonly:false
   (* ── RFC-0182 §3.1 — masc_approval_* cluster (3 entries) ─────── *)
-  ; masc_approval_descriptor "pending" "masc_approval_pending"
+  ; masc_approval_descriptor ~inline_safe:true "pending" "masc_approval_pending"
       "List pending operator approval requests." ~readonly:true
   ; masc_approval_descriptor "get" "masc_approval_get"
       "Read a single pending approval by id." ~readonly:true
@@ -1197,6 +1221,7 @@ let internal_descriptors : t list =
       ~description:"Read dashboard surface readiness snapshot (optionally for a single surface)."
       ~handler:Tool_masc_surface_audit
       ~readonly:true
+      ~inline_safe:false
   ]
   @ masc_board_descriptors
 ;;
@@ -1238,6 +1263,12 @@ let readonly_internal_names () =
     match readonly_static_hint d with
     | Some true -> internal_names d
     | Some false | None -> [])
+  |> List.sort_uniq String.compare
+;;
+
+let keeper_safe_inline_names () =
+  all_descriptors ()
+  |> List.concat_map (fun d -> if d.policy.inline_safe then internal_names d else [])
   |> List.sort_uniq String.compare
 ;;
 
@@ -1285,6 +1316,7 @@ let route_evidence_json d =
      ; "approval", `String (approval_to_string policy.approval)
      ; "retryable", `Bool policy.retryable
      ; "cwd_scope", Json_util.string_opt_to_json policy.cwd_scope
+     ; "inline_safe", `Bool policy.inline_safe
      ]
      @ policy_fields)
 ;;

--- a/lib/keeper/keeper_tool_descriptor.mli
+++ b/lib/keeper/keeper_tool_descriptor.mli
@@ -72,6 +72,7 @@ type policy =
   ; approval : approval
   ; retryable : bool
   ; cwd_scope : string option
+  ; inline_safe : bool
   }
 
 type t =
@@ -127,6 +128,10 @@ val readonly_for_input : t -> input:Yojson.Safe.t -> bool option
 (** Descriptor-owned read-only projection. The returned names are internal
     handler names whose descriptor policy declares a static read-only hint. *)
 val readonly_internal_names : unit -> string list
+
+(** Descriptor-owned inline-safe projection. The returned names are internal
+    MASC tools safe for keeper use without an MCP session context. *)
+val keeper_safe_inline_names : unit -> string list
 
 val public_input_schema : string -> Yojson.Safe.t option
 val translate_input : public:string -> Yojson.Safe.t -> Yojson.Safe.t

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -133,11 +133,11 @@ let is_keeper_denied (name : string) : bool =
 
 (* ── Schema injection filter ──────────────────────────────────── *)
 
-let keeper_safe_inline_tools =
-  [ "masc_approval_pending" ]
+let keeper_safe_inline_tools () =
+  Keeper_tool_descriptor.keeper_safe_inline_names ()
 
 let is_keeper_safe_inline_tool name =
-  List.mem name keeper_safe_inline_tools
+  List.mem name (keeper_safe_inline_tools ())
 
 let is_keeper_mcp_context_required name =
   let stripped = Keeper_tool_alias.strip_mcp_masc_prefix name in
@@ -168,7 +168,7 @@ let keeper_supported_masc_schemas (schemas : Masc_domain.tool_schema list) =
       Keeper_types_profile.schemas
   in
   let supported_in_keeper name =
-    if List.mem name keeper_safe_inline_tools then
+    if is_keeper_safe_inline_tool name then
       true
     else if is_keeper_management_tool name then
       (* Reliable pre-init too: [Keeper_tool_surface.schemas] is a static list,

--- a/lib/keeper/keeper_tool_policy.mli
+++ b/lib/keeper/keeper_tool_policy.mli
@@ -30,10 +30,6 @@ val reset_policy_config_for_test : unit -> unit
 
 (** {1 MASC Schema Injection} *)
 
-(** Inline MCP-runtime tools that are safe for keepers without an MCP session
-    context. Shared by keeper policy and MCP protocol context metadata. *)
-val keeper_safe_inline_tools : string list
-
 val is_keeper_safe_inline_tool : string -> bool
 
 (** Filter and inject MASC schemas for keeper tool selection.

--- a/specs/keeper-state-machine/KeeperReconcileLiveness.tla
+++ b/specs/keeper-state-machine/KeeperReconcileLiveness.tla
@@ -34,7 +34,7 @@
 \* mechanism has been REMOVED ENTIRELY from both the canonical spec
 \* and the OCaml impl (verified: zero occurrences in
 \* specs/keeper-state-machine/KeeperStateMachine.tla and
-\* lib/keeper/keeper_state_machine.ml as of 2026-04-20).  The audit
+\* lib/keeper_state/keeper_state_machine.ml as of 2026-04-20).  The audit
 \* model is retained as a forensic record of the design lesson:
 \* recovery actions must clear ALL latches that block their target
 \* state, not just the most obvious one.  The named TurnSucceeded /
@@ -55,7 +55,7 @@
 \* Bug model: recovery only dispatches Turn_succeeded (old code).
 \* The liveness property MUST be violated in the buggy variant.
 \*
-\* Mirrors: lib/keeper/keeper_state_machine.ml (update_conditions)
+\* Mirrors: lib/keeper_state/keeper_state_machine.ml (update_conditions)
 \*          lib/keeper/keeper_heartbeat_snapshot.ml:write_heartbeat_snapshot (heartbeat recovery)
 
 EXTENDS Naturals

--- a/specs/keeper-state-machine/KeeperStateMachine.tla
+++ b/specs/keeper-state-machine/KeeperStateMachine.tla
@@ -12,7 +12,7 @@
 \*   - Budget monotonicity (restart_budget_remaining never revives)
 \*   - Overflowed transitions bounded (auto-compact or Paused, never loops)
 \*
-\* Mirrors: lib/keeper/keeper_state_machine.ml
+\* Mirrors: lib/keeper_state/keeper_state_machine.ml
 
 EXTENDS Naturals, FiniteSets
 

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -326,6 +326,22 @@ let test_readonly_policy_projects_to_input_aware_registry () =
        ~input:(`Assoc [ "path", `String "x"; "content", `String "y" ]))
 
 let test_mcp_context_policy_uses_descriptor_resolution () =
+  Alcotest.(check (list string))
+    "safe inline tools project from descriptors"
+    [ "masc_approval_pending" ]
+    (Descriptor.keeper_safe_inline_names ());
+  Alcotest.(check bool)
+    "approval_pending is descriptor-marked inline safe"
+    true
+    (Policy.is_keeper_safe_inline_tool "masc_approval_pending");
+  Alcotest.(check bool)
+    "approval_get is not inline safe"
+    false
+    (Policy.is_keeper_safe_inline_tool "masc_approval_get");
+  Alcotest.(check bool)
+    "approval_resolve is not inline safe"
+    false
+    (Policy.is_keeper_safe_inline_tool "masc_approval_resolve");
   Alcotest.(check bool)
     "approval_pending does not require MCP session"
     false


### PR DESCRIPTION
## Summary

- add `inline_safe` as a descriptor policy axis
- mark only `masc_approval_pending` as keeper inline-safe in the descriptor table
- replace the `Keeper_tool_policy` hardcoded safe-inline list with descriptor projection and drop the exported list
- pin the projection in `test_keeper_tool_descriptor_registry_integrity`
- update stale TLA `Mirrors:` annotations after the keeper state sublib extraction so Meta Guards resolve live source paths

## Verification

- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=/tmp/masc-dune-descriptor-safe-inline dune build --root . @install test/test_keeper_tool_descriptor_registry_integrity.exe --force`
- `/tmp/masc-dune-descriptor-safe-inline/default/test/test_keeper_tool_descriptor_registry_integrity.exe`
- `ocamlformat --check lib/keeper/keeper_tool_descriptor.ml lib/keeper/keeper_tool_descriptor.mli lib/keeper/keeper_tool_policy.ml lib/keeper/keeper_tool_policy.mli test/test_keeper_tool_descriptor_registry_integrity.ml`
- `git diff --check`
- `scripts/audit-keeper-tool-boundary-matrix.sh`
- `bash scripts/check-spec-truth.sh`
