### PR TITLE
refactor(task): drop keeper tool coupling

### DIFF
--- a/lib/keeper/keeper_task_owner_backend.ml
+++ b/lib/keeper/keeper_task_owner_backend.ml
@@ -56,19 +56,6 @@ let sync_current_task_binding config ~agent_name =
     ~agent_name
 ;;
 
-let keeper_tool_names config ~agent_name =
-  let resolved =
-    resolve_agent_name config agent_name ~log_context:"owner tool surface"
-  in
-  [ agent_name; resolved ]
-  |> List.filter_map Keeper_identity.canonical_keeper_name
-  |> List.sort_uniq String.compare
-  |> List.find_map (fun keeper_name ->
-    match Keeper_registry.get ~base_path:config.base_path keeper_name with
-    | Some entry -> Some (Keeper_tool_policy.keeper_allowed_tool_names entry.meta)
-    | None -> None)
-;;
-
 let meta_for_agent config ~agent_name =
   let resolved = resolve_agent_name config agent_name ~log_context:"owner policy" in
   [ agent_name; resolved ]
@@ -103,7 +90,6 @@ let active_goal_phases_for_agent config ~agent_name =
 let install_hooks () =
   let is_registered_agent_alias_fn = is_registered_agent_alias in
   let sync_current_task_binding_fn = sync_current_task_binding in
-  let keeper_tool_names_fn = keeper_tool_names in
   let transition_action_denylist_fn = transition_action_denylist in
   let active_goal_phases_for_agent_fn = active_goal_phases_for_agent in
   Task.Handlers.set_task_owner_hooks
@@ -112,7 +98,6 @@ let install_hooks () =
           (fun config agent_name -> is_registered_agent_alias_fn config agent_name)
       ; sync_current_task_binding =
           (fun config ~agent_name -> sync_current_task_binding_fn config ~agent_name)
-      ; keeper_tool_names = (fun config ~agent_name -> keeper_tool_names_fn config ~agent_name)
       ; transition_action_denylist =
           (fun config ~agent_name -> transition_action_denylist_fn config ~agent_name)
       ; active_goal_phases_for_agent =

--- a/lib/keeper/keeper_task_owner_backend.mli
+++ b/lib/keeper/keeper_task_owner_backend.mli
@@ -2,7 +2,6 @@
 
 val is_registered_agent_alias : Workspace.config -> string -> bool
 val sync_current_task_binding : Workspace.config -> agent_name:string -> unit
-val keeper_tool_names : Workspace.config -> agent_name:string -> string list option
 val transition_action_denylist : Workspace.config -> agent_name:string -> string list
 val active_goal_phases_for_agent : Workspace.config -> agent_name:string -> string list
 val install_hooks : unit -> unit

--- a/lib/task/anti_rationalization.ml
+++ b/lib/task/anti_rationalization.ml
@@ -117,7 +117,7 @@ type review_result =
    needles like the Korean entries below match correctly without
    needing a Unicode-aware lowercase pass.
 
-   Korean coverage is the immediate gap to close — the keeper
+   Korean coverage is the immediate gap to close — the agent
    fleet's 한국어 LLM output produced 0% detection pre-fix while
    `<base_path>/.masc/institution_episodes.jsonl` carried real entries
    like "나중에", "범위 밖", "재현 안됨".  English false-positives
@@ -611,6 +611,21 @@ let review
      | None -> ());
     result
   in
+  let task_info fmt =
+    Stdlib.Format.ksprintf
+      (fun message -> Log.Task.info "task_id=%s %s" req.task_id message)
+      fmt
+  in
+  let task_warn fmt =
+    Stdlib.Format.ksprintf
+      (fun message -> Log.Task.warn "task_id=%s %s" req.task_id message)
+      fmt
+  in
+  let task_error fmt =
+    Stdlib.Format.ksprintf
+      (fun message -> Log.Task.error "task_id=%s %s" req.task_id message)
+      fmt
+  in
   (* Gate 1: empty or trivially short notes *)
   let notes_trimmed = String.trim req.completion_notes in
   if String.length notes_trimmed < min_notes_length
@@ -644,8 +659,7 @@ let review
     match excuse_match with
     | Some (pattern, reason) when Env_config.AntiRationalization.gate2_fail_closed ->
       (Atomic.get excuse_pattern_observer_fn) ~pattern ~outcome:Terminal_reject;
-      Log.Task.info
-        ~keeper_name:req.task_id
+      task_info
         "[anti-rationalization] agent=%s task=%s excuse_pattern=%s \
          gate2_fail_closed=true → terminal reject"
         req.agent_name
@@ -670,8 +684,7 @@ let review
         | None -> None
         | Some (pattern, reason) ->
           (Atomic.get excuse_pattern_observer_fn) ~pattern ~outcome:Advisory_to_llm;
-          Log.Task.info
-        ~keeper_name:req.task_id
+          task_info
             "[anti-rationalization] agent=%s task=%s excuse_pattern=%s (advisory; \
              deferring to LLM evaluator with context)"
             req.agent_name
@@ -681,7 +694,7 @@ let review
       in
       (* Gate 2.5: legacy local contract check. When the verification FSM is
      enabled, contract judgment is deferred to the Gate 3 LLM prompt instead
-     of routing normal completion through a verifier keeper. When FSM is
+     of routing normal completion through a verifier agent. When FSM is
      disabled, the historical substring check remains as a minimal local
      safety net. *)
       let contract_rejection =
@@ -695,8 +708,7 @@ let review
             if unmet = []
             then None
             else (
-              Log.Task.info
-        ~keeper_name:req.task_id
+              task_info
                 "[anti-rationalization] contract unmet (legacy): agent=%s task=%s \
                  unmet=[%s]"
                 req.agent_name
@@ -727,8 +739,7 @@ let review
          in
          (match generator_runtime with
           | Some gc when gc = evaluator_runtime ->
-            Log.Task.warn
-        ~keeper_name:req.task_id
+            task_warn
               "[anti-rationalization] same runtime for generator (%s) and evaluator (%s) \
                — cross-model separation not active"
               gc
@@ -746,11 +757,11 @@ let review
             let v, gate, fallback_reason =
               match verdict_opt with
               | Some v ->
-                Log.Task.info ~keeper_name:req.task_id "[anti-rationalization] verdict via structured tool call";
+                task_info "[anti-rationalization] verdict via structured tool call";
                 v, Structured_tool, None
               | None ->
                 (* LLM responded with text — lenient fallback *)
-                Log.Task.info ~keeper_name:req.task_id "[anti-rationalization] verdict via text fallback";
+                task_info "[anti-rationalization] verdict via text fallback";
                 (match parse_verdict text with
                  | Ok v -> v, Llm_text_fallback, None
                  | Error "empty review output" ->
@@ -759,18 +770,16 @@ let review
                  no signal, indistinguishable from an unavailable
                  evaluator. Approve by liveness — same policy as the
                  [Error err] branch below — instead of blaming the
-                 completing keeper for an evaluator-side gap. Observed
+                 completing agent for an evaluator-side gap. Observed
                  35 rejects in 2 days (#8688, <base-path>/.masc/tool_calls). *)
-                   Log.Task.warn
-        ~keeper_name:req.task_id
+                   task_warn
                      "[anti-rationalization] evaluator returned empty text (approving by \
                       liveness)";
                    Approve, Fallback, Some "evaluator returned empty response"
                  | Error parse_err ->
                    (* ADR D3: parse failure is NOT silently approved.
                  Use Reject instead of Approve for unknown format. *)
-                   Log.Task.warn
-        ~keeper_name:req.task_id
+                   task_warn
                      "[anti-rationalization] verdict parse failed: %s (rejecting)"
                      parse_err;
                    ( Reject (sprintf "review format unrecognized: %s" parse_err)
@@ -779,8 +788,7 @@ let review
             in
             (match v with
              | Reject reason ->
-               Log.Task.info
-        ~keeper_name:req.task_id
+               task_info
                  "[anti-rationalization] LLM rejected: agent=%s task=%s runtime=%s \
                   reason=%s"
                  req.agent_name
@@ -788,8 +796,7 @@ let review
                  evaluator_runtime
                  reason
              | Approve ->
-               Log.Task.info
-        ~keeper_name:req.task_id
+               task_info
                  "[anti-rationalization] LLM approved: agent=%s task=%s runtime=%s"
                  req.agent_name
                  req.task_title
@@ -810,9 +817,9 @@ let review
           tool-use gate at filter time — there are zero callable
           models, and there will not be any until the runtime config
           (or provider capabilities) changes.  Treating that as a
-          fail-closed safety-net reject blocks every keeper trying to
+          fail-closed safety-net reject blocks every agent trying to
           finish a task with a perfectly legitimate "out of scope"
-          phrase, which is the runtime's bug, not the keeper's
+          phrase, which is the runtime's bug, not the agent's
           purview.  Promote to operator-actionable ERROR and approve
           by liveness — the operator must fix the runtime definition
           before the safety net can do useful work. *)
@@ -835,7 +842,7 @@ let review
                  branches must agree on the excuse-advisory case.
 
                  The original liveness rationale (#10474: do not block
-                 every keeper waiting for a runtime fix) is preserved for
+                 every agent waiting for a runtime fix) is preserved for
                  the [None] case — the vast majority of tasks have no
                  active substring advisory and continue to approve. *)
               match excuse_advisory with
@@ -843,8 +850,7 @@ let review
                 (Atomic.get excuse_pattern_observer_fn)
                   ~pattern
                   ~outcome:Advisory_safety_net_reject_runtime_dead;
-                Log.Task.error
-        ~keeper_name:req.task_id
+                task_error
                   "[anti-rationalization] runtime %s permanently dead AND gate-2 \
                    advisory pattern=%s active: rejecting (safety net) rather than \
                    laundering excuse phrase through liveness.  OPERATOR ACTION \
@@ -873,10 +879,9 @@ let review
                            evaluator_runtime)
                   }
               | None ->
-                Log.Task.error
-        ~keeper_name:req.task_id
+                task_error
                   "[anti-rationalization] runtime %s has zero callable providers — \
-                   ALL keepers using this evaluator are blocked from task \
+                   ALL agents using this evaluator are blocked from task \
                    completion.  Approving by liveness; OPERATOR ACTION REQUIRED: \
                    fix the runtime definition (provider capabilities, MCP policy, \
                    or tool requirements).  See #10474.  err=%s"
@@ -909,8 +914,7 @@ let review
                 (Atomic.get excuse_pattern_observer_fn)
                   ~pattern
                   ~outcome:Advisory_safety_net_reject;
-                Log.Task.warn
-        ~keeper_name:req.task_id
+                task_warn
                   "[anti-rationalization] LLM unavailable + gate-2 advisory pattern=%s \
                    active: rejecting (safety net) (runtime=%s err=%s)"
                   pattern
@@ -931,8 +935,7 @@ let review
                   ; fallback_reason = Some msg
                   }
               | None, Env_config.AntiRationalization.Open ->
-                Log.Task.warn
-        ~keeper_name:req.task_id
+                task_warn
                   "[anti-rationalization] LLM unavailable: %s (approving by default; \
                    mode=open MASC_ANTI_RATIONALIZATION_FAIL_MODE=open)"
                   msg;
@@ -944,8 +947,7 @@ let review
                   ; fallback_reason = Some msg
                   }
               | None, Env_config.AntiRationalization.Closed ->
-                Log.Task.warn
-        ~keeper_name:req.task_id
+                task_warn
                   "[anti-rationalization] LLM unavailable: %s (rejecting by default; \
                    mode=closed MASC_ANTI_RATIONALIZATION_FAIL_MODE=closed)"
                   msg;

--- a/lib/task/planning_eio.ml
+++ b/lib/task/planning_eio.ml
@@ -296,7 +296,7 @@ let current_task_file (config : Workspace.config) =
 
 (* The planning [current_task] path must be a file, but runtime state can be
    corrupted by external writers. Keep these helpers total for directory-shaped
-   corruption so one bad path cannot wedge keeper claim/transition flows. *)
+   corruption so one bad path cannot wedge owner claim/transition flows. *)
 
 let is_directory_path path =
   try Sys.is_directory path with Sys_error _ -> false
@@ -320,13 +320,13 @@ let quarantine_dir_under_trash (config : Workspace.config) ~path ~op =
   in
   try
     Sys.rename path dest;
-    Log.Keeper.warn
+    Log.Task.warn
       "planning_eio.%s: current_task path was a directory; quarantined to %s"
       op dest;
     Ok dest
   with
   | Sys_error msg ->
-    Log.Keeper.warn
+    Log.Task.warn
       "planning_eio.%s: failed to quarantine directory at %s: %s"
       op path msg;
     Error msg
@@ -340,18 +340,18 @@ let remove_empty_current_task_dir ~path ~op =
          true
        with
        | Unix.Unix_error _ as e ->
-         Log.Keeper.warn
+         Log.Task.warn
            "planning_eio.%s: rmdir %s failed: %s"
            op path (Printexc.to_string e);
          false)
     | _ ->
-      Log.Keeper.warn
+      Log.Task.warn
         "planning_eio.%s: %s is a non-empty directory; leaving it in place"
         op path;
       false
   with
   | Sys_error msg ->
-    Log.Keeper.warn
+    Log.Task.warn
       "planning_eio.%s: failed to inspect directory at %s: %s"
       op path msg;
     false
@@ -361,7 +361,7 @@ let get_current_task (config : Workspace.config) : string option =
   let path = current_task_file config in
   if not (Sys.file_exists path) then None
   else if is_directory_path path then begin
-    Log.Keeper.warn
+    Log.Task.warn
       "planning_eio.get_current_task: %s is a directory; treating as cleared"
       path;
     None
@@ -369,7 +369,7 @@ let get_current_task (config : Workspace.config) : string option =
   else
     try Some (String.trim (read_file_content path)) with
     | Sys_error msg when is_directory_path path ->
-      Log.Keeper.warn
+      Log.Task.warn
         "planning_eio.get_current_task: %s became a directory during read: %s"
         path msg;
       None
@@ -384,7 +384,7 @@ let set_current_task (config : Workspace.config) ~task_id : (unit, string) resul
       Ok ()
     with
     | Sys_error msg when is_directory_path path ->
-      Log.Keeper.warn
+      Log.Task.warn
         "planning_eio.set_current_task: %s became a directory during write: %s"
         path msg;
       Error
@@ -399,7 +399,7 @@ let set_current_task (config : Workspace.config) ~task_id : (unit, string) resul
       if remove_empty_current_task_dir ~path ~op:"set_current_task" then
         write_current_task ()
       else begin
-        Log.Keeper.warn
+        Log.Task.warn
           "planning_eio.set_current_task: leaving directory in place after \
            quarantine failure: %s"
           msg;
@@ -420,7 +420,7 @@ let clear_current_task (config : Workspace.config) : unit =
   else
     try Sys.remove path with
     | Sys_error msg when is_directory_path path ->
-      Log.Keeper.warn
+      Log.Task.warn
         "planning_eio.clear_current_task: %s became a directory during remove: %s"
         path msg
 

--- a/lib/task/tool_task.ml
+++ b/lib/task/tool_task.ml
@@ -4,6 +4,21 @@
 open Tool_args
 include Tool_task_handlers
 
+let task_log_info ~task_id fmt =
+  Stdlib.Format.ksprintf
+    (fun message -> Log.Task.info "task_id=%s %s" task_id message)
+    fmt
+
+let task_log_warn ~task_id fmt =
+  Stdlib.Format.ksprintf
+    (fun message -> Log.Task.warn "task_id=%s %s" task_id message)
+    fmt
+
+let task_log_error ~task_id fmt =
+  Stdlib.Format.ksprintf
+    (fun message -> Log.Task.error "task_id=%s %s" task_id message)
+    fmt
+
 let rec handle_done ~tool_name ~start_time ctx args =
   let notes = get_string args "notes" "" in
   handle_transition ~tool_name ~start_time ctx
@@ -62,7 +77,7 @@ and handle_cancel_task ~tool_name ~start_time ctx args =
            ("reason", `String reason);
          ]
    | Error err ->
-       Log.Task.error ~keeper_name:task_id "metrics record failed: %s" (Masc_domain.masc_error_to_string err));
+       task_log_error ~task_id "metrics record failed: %s" (Masc_domain.masc_error_to_string err));
   result_to_response ~tool_name ~start_time result
 
 and handle_transition ~tool_name ~start_time ctx args =
@@ -203,7 +218,7 @@ and handle_transition ~tool_name ~start_time ctx args =
     if force_raw then
       if (Atomic.get Workspace_hooks.is_admin_agent_fn) ~base_path:ctx.config.base_path ~agent_name:ctx.agent_name then true
       else (
-        Log.Task.warn ~keeper_name:task_id "[anti-rationalization] force=true rejected: agent=%s lacks admin privilege"
+        task_log_warn ~task_id "[anti-rationalization] force=true rejected: agent=%s lacks admin privilege"
           ctx.agent_name;
         false
       )
@@ -318,8 +333,8 @@ and handle_transition ~tool_name ~start_time ctx args =
   (* Contracted Done actions are reviewed above by the LLM completion
      reviewer with the persisted completion contract in prompt context.
      Keep AwaitingVerification for explicit submit_for_verification /
-     submit_pr_evidence workflows only; a normal keeper_task_done must
-     not depend on the verifier keeper being alive. *)
+     submit_pr_evidence workflows only; a normal done action must
+     not depend on the verifier agent being alive. *)
   (* RFC-0109 Phase D hard cut: contracted verification submissions
      require substantive evidence. Analysis-only tasks (no contract)
      bypass the gate. *)
@@ -368,8 +383,7 @@ and handle_transition ~tool_name ~start_time ctx args =
     match requested_action, task_opt with
     | ( Masc_domain.Submit_for_verification
       , Some ({ task_status = Masc_domain.Todo; _ } : Masc_domain.task) ) ->
-      Log.Task.info
-        ~keeper_name:task_id
+      task_log_info ~task_id
         "[verification-alias] treating todo submit_for_verification with evidence as submit_pr_evidence task=%s agent=%s"
         task_id
         ctx.agent_name;
@@ -474,7 +488,7 @@ and handle_transition ~tool_name ~start_time ctx args =
                 ?handoff_context ?prepare_verification_request
                 ?prepare_verification_verdict () in
       if is_version_mismatch r && attempt < max_cas_retries then begin
-        Log.Task.info ~keeper_name:task_id "CAS version mismatch on %s (attempt %d/%d), retrying in %.0fms"
+        task_log_info ~task_id "CAS version mismatch on %s (attempt %d/%d), retrying in %.0fms"
           task_id (attempt + 1) max_cas_retries (cas_retry_delay_s *. 1000.0);
         Time_compat.sleep cas_retry_delay_s;
         try_transition (attempt + 1)
@@ -532,8 +546,7 @@ and handle_transition ~tool_name ~start_time ctx args =
              instead of acting on empty strings. *)
           (match verification_id_before with
            | None ->
-             Log.Task.warn
-               ~keeper_name:task_id
+             task_log_warn ~task_id
                "approve_verification action for task %s without verification_id_before (skipping notify)"
                task_id
            | Some verification_id ->
@@ -544,8 +557,7 @@ and handle_transition ~tool_name ~start_time ctx args =
           let reason = if not (String.equal notes "") then notes else reason in
           (match verification_id_before with
            | None ->
-             Log.Task.warn
-               ~keeper_name:task_id
+             task_log_warn ~task_id
                "reject_verification action for task %s without verification_id_before (skipping notify)"
                task_id
            | Some verification_id ->

--- a/lib/task/tool_task_completion_review.ml
+++ b/lib/task/tool_task_completion_review.ml
@@ -61,7 +61,7 @@ let is_placeholder_evidence_ref value =
   value = "" || List.mem value placeholder_evidence_refs
 
 (* [pr_url_has_pull_ref] validates an explicit typed [pr_url] field
-   handed to the task completion adapter (see keeper_tool_task_runtime.ml). The
+   handed to the task completion adapter. The
    substring shape match is a thin guard on a typed input — distinct
    from the retired transition-layer substring gate (RFC-0109 Phase E,
    2026-05-27). *)

--- a/lib/task/tool_task_handlers.ml
+++ b/lib/task/tool_task_handlers.ml
@@ -54,7 +54,6 @@ type context = {
 type task_owner_hooks =
   { is_registered_agent_alias : Workspace.config -> string -> bool
   ; sync_current_task_binding : Workspace.config -> agent_name:string -> unit
-  ; keeper_tool_names : Workspace.config -> agent_name:string -> string list option
   ; transition_action_denylist : Workspace.config -> agent_name:string -> string list
   ; active_goal_phases_for_agent : Workspace.config -> agent_name:string -> string list
   }
@@ -62,7 +61,6 @@ type task_owner_hooks =
 let default_task_owner_hooks =
   { is_registered_agent_alias = (fun _ _ -> false)
   ; sync_current_task_binding = (fun _ ~agent_name:_ -> ())
-  ; keeper_tool_names = (fun _ ~agent_name:_ -> None)
   ; transition_action_denylist = (fun _ ~agent_name:_ -> [])
   ; active_goal_phases_for_agent = (fun _ ~agent_name:_ -> [])
   }
@@ -73,6 +71,26 @@ let set_task_owner_hooks hooks = Atomic.set task_owner_hooks hooks
 let current_task_owner_hooks () = Atomic.get task_owner_hooks
 
 open Tool_args
+
+let task_log_warn ~task_id fmt =
+  Stdlib.Format.ksprintf
+    (fun message -> Log.Task.warn "task_id=%s %s" task_id message)
+    fmt
+
+let task_log_error ~task_id fmt =
+  Stdlib.Format.ksprintf
+    (fun message -> Log.Task.error "task_id=%s %s" task_id message)
+    fmt
+
+let task_agent_log_warn ~agent_name fmt =
+  Stdlib.Format.ksprintf
+    (fun message -> Log.Task.warn "agent_name=%s %s" agent_name message)
+    fmt
+
+let task_agent_log_error ~agent_name fmt =
+  Stdlib.Format.ksprintf
+    (fun message -> Log.Task.error "agent_name=%s %s" agent_name message)
+    fmt
 
 (* RFC-0189: [Masc_domain] backend Error variants (Task_error /
    Agent_error / etc.) currently surface as caller-actionable
@@ -93,8 +111,8 @@ let log_task_transition_failed ~agent_name err =
   let message = Masc_domain.masc_error_to_string err in
   match err with
   | Masc_domain.Task (Masc_domain.Task_error.InvalidState _) ->
-      Log.Task.warn ~keeper_name:agent_name "task transition failed: %s" message
-  | _ -> Log.Task.error ~keeper_name:agent_name "task transition failed: %s" message
+      task_agent_log_warn ~agent_name "task transition failed: %s" message
+  | _ -> task_agent_log_error ~agent_name "task transition failed: %s" message
 
 (** Client-side FSM gate: reject impossible transitions before server dispatch.
     Uses [Workspace_task_classify.valid_next_actions_for_status] as SSOT. *)
@@ -159,7 +177,7 @@ let sync_planning_current_task_with_owned_task (ctx : context) =
         (match Planning_eio.set_current_task ctx.config ~task_id with
          | Ok () -> ()
          | Error msg ->
-             Log.Task.warn ~keeper_name:task_id
+             task_log_warn ~task_id
                "failed to sync planning current_task to %s: %s"
                task_id msg)
     | None -> Planning_eio.clear_current_task ctx.config
@@ -168,9 +186,6 @@ let sync_owner_current_task_binding (ctx : context) =
   (current_task_owner_hooks ()).sync_current_task_binding
     ctx.config
     ~agent_name:ctx.agent_name
-
-let agent_allowed_tool_names (ctx : context) =
-  (current_task_owner_hooks ()).keeper_tool_names ctx.config ~agent_name:ctx.agent_name
 
 let owner_transition_action_denylist (ctx : context) =
   (current_task_owner_hooks ()).transition_action_denylist
@@ -412,7 +427,7 @@ let handle_claim ~tool_name ~start_time ctx args =
           ("auto_released_task_ids", auto_released_json);
           ("timestamp", `Float (Time_compat.now ()));
         ])
-   | Error e -> Log.Task.warn ~keeper_name:task_id "task claim failed for %s: %s" task_id (Masc_domain.masc_error_to_string e));
+   | Error e -> task_log_warn ~task_id "task claim failed for %s: %s" task_id (Masc_domain.masc_error_to_string e));
   let response_result =
     Result.map (fun (o : Workspace.claim_outcome) -> o.message) result
   in

--- a/lib/task/tool_task_schemas.ml
+++ b/lib/task/tool_task_schemas.ml
@@ -55,7 +55,7 @@ Example: %s({title: 'Fix login bug', priority: 1, description: 'Users cannot log
         ]);
         ("goal_id", `Assoc [
           ("type", `String "string");
-          ("description", `String "Optional structured goal link for rollups. If omitted, scoped keepers may auto-link a single active goal; otherwise the task remains unscoped.");
+          ("description", `String "Optional structured goal link for rollups. If omitted, scoped agents may auto-link a single active goal; otherwise the task remains unscoped.");
         ]);
         ("contract", `Assoc [
           ("type", `String "object");
@@ -113,7 +113,7 @@ Example: masc_batch_add_tasks({tasks: [{title: 'Task A', priority: 2}, {title: '
               ]);
               ("goal_id", `Assoc [
                 ("type", `String "string");
-                ("description", `String "Optional structured goal link for rollups. If omitted, scoped keepers may auto-link a single active goal; otherwise the task remains unscoped.");
+                ("description", `String "Optional structured goal link for rollups. If omitted, scoped agents may auto-link a single active goal; otherwise the task remains unscoped.");
               ]);
               ("contract", `Assoc [
                 ("type", `String "object");
@@ -228,7 +228,7 @@ unavailable to you — this transitions the task directly to awaiting_verificati
 with the required tools can verify and close it. For compatibility, \
 submit_for_verification with evidence on a todo task is treated as submit_pr_evidence. \
 Tasks created through %s complete via action='done' after LLM completion review; \
-they do not route normal completion through the verifier keeper."
+they do not route normal completion through the verifier agent."
       masc_add_task_name
       masc_claim_next_name
       masc_add_task_name;


### PR DESCRIPTION
## Summary
- Drop the Task owner hook that exposed Keeper tool-name lookup into task handlers.
- Remove the Keeper adapter export for task-side tool-name lookup.
- Replace Task-side Keeper log context/wording with task_id/agent_name wording.

## Verification
- rg keeper/Keeper/log-context residues in lib/task: 0 matches
- rg keeper_tool_names/owner_tool_names residues on the touched boundary: 0 matches
- git diff --check origin/main..HEAD
- gtimeout 600 env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-task-keeper-boundary dune build --root . lib/task/masc_task_handlers.cmxa test/test_planning_eio.exe test/test_tool_task_args.exe test/test_tool_task_completion_example.exe test/test_anti_rationalization_fail_mode.exe test/test_anti_rationalization_empty_liveness.exe test/test_anti_rationalization_gate2_advisory_10113.exe test/test_anti_rationalization_korean_10385.exe test/test_anti_rationalization_excuse_patterns_writeback.exe
- Ran the built test executables above; all passed.

Closes #20010