### PR TITLE
chore(types): purge dead A2A/Portal subsystem (unreachable, 0 live callers)

### DIFF
--- a/lib/client_identity.ml
+++ b/lib/client_identity.ml
@@ -33,8 +33,7 @@ module Random = Stdlib.Random
    shared state can produce duplicate values or corrupt internal
    state.  The previous doc comment claiming "Fiber-safe" was
    incorrect.  Guard the shared state with an [Eio.Mutex] and route
-   every RNG access through [with_identity_rng].  Same discipline
-   used by [Lib.A2a_tools] ([a2a_rng] / [a2a_rng_mutex]). *)
+   every RNG access through [with_identity_rng]. *)
 
 module StringMap = Set_util.StringMap
 

--- a/lib/mcp_server_eio_tool_profile.ml
+++ b/lib/mcp_server_eio_tool_profile.ml
@@ -25,12 +25,6 @@ Do not assume that the public /mcp surface and the managed-agent surface have th
 
 let managed_agent_passthrough_tool_names =
   Keeper_tool_surfaces.spawned_agent_public_tool_names
-  |> List.filter (fun name ->
-         not
-           (List.mem name
-             [
-                "masc_a2a_delegate";
-              ]))
 
 (* O(1) membership view of [managed_agent_passthrough_tool_names].
    Used by [tool_schemas_for_profile Managed_agent] to filter
@@ -233,8 +227,6 @@ let custom_tool_titles : (string * string) list = [
   (* Communication *)
   ("masc_broadcast", "Broadcast Message");
   ("masc_messages", "Read Messages");
-  ("masc_a2a_delegate", "Agent-to-Agent Delegate");
-  ("masc_a2a_subscribe", "Subscribe to Agent Events");
   (* Planning *)
   ("masc_plan_init", "Initialize Plan");
   ("masc_plan_get", "Get Plan");

--- a/lib/mention_inbox.ml
+++ b/lib/mention_inbox.ml
@@ -22,8 +22,7 @@ type mention_record = {
 (* RNG for mention-id generation.  [Random.State.t] is NOT fiber-safe —
    the previous doc comment claiming otherwise was incorrect.  Guard
    the shared state with an [Eio.Mutex] and route every RNG access
-   through [with_mention_rng].
-   ([a2a_rng] / [a2a_rng_mutex]). *)
+   through [with_mention_rng]. *)
 let mention_rng = Random.State.make_self_init ()
 let mention_rng_mutex = Eio.Mutex.create ()
 let with_mention_rng f =

--- a/lib/tool_access_role.ml
+++ b/lib/tool_access_role.ml
@@ -77,7 +77,7 @@ let admin_only_tools () = Lazy.force admin_only_tools_lazy
 
 (* ================================================================ *)
 (* Worker-only tools (CanAddTask + CanClaimTask + CanCompleteTask + *)
-(*                    CanBroadcast + CanVote) *)
+(*                    CanBroadcast + CanVote)                        *)
 (* ================================================================ *)
 
 let worker_only_tools () = Lazy.force worker_only_tools_lazy

--- a/lib/tools.ml
+++ b/lib/tools.ml
@@ -2,7 +2,7 @@
 
     All schemas are now owned by individual modules.
     This file assembles cycle-free schemas; config.ml adds
-    modules that depend on Config (Tool_control, Tool_a2a, Tool_misc). *)
+    modules that depend on Config (Tool_control, Tool_misc). *)
 
 open Masc_domain
 

--- a/lib/tools.mli
+++ b/lib/tools.mli
@@ -1,7 +1,7 @@
 (** Tools — MCP tool schema assembly for MASC.
 
     Collects schemas from individual modules into a unified list.
-    Config.ml adds modules that depend on Config (Tool_control, Tool_a2a, Tool_misc).
+    Config.ml adds modules that depend on Config (Tool_control, Tool_misc).
 
     @since 0.1.0 *)
 

--- a/lib/workspace/nickname.ml
+++ b/lib/workspace/nickname.ml
@@ -23,8 +23,7 @@ let animals = [|
 (* RNG for nickname generation.  [Random.State.t] is NOT fiber-safe —
    the previous doc comment claiming otherwise was incorrect.  Guard
    the shared state with an [Eio.Mutex] and route every RNG access
-   through [with_nickname_rng].
-   ([a2a_rng] / [a2a_rng_mutex]). *)
+   through [with_nickname_rng]. *)
 let nickname_rng = Random.State.make_self_init ()
 let nickname_rng_mutex = Eio.Mutex.create ()
 let with_nickname_rng f =

--- a/test/test_briefing_compactors.ml
+++ b/test/test_briefing_compactors.ml
@@ -16,8 +16,8 @@
          within 3600s of [now_ts] (even when status is dead).
 
     2. {b compact_session_json strict shape} — output assoc has
-       exactly 16 keys including [communication_summary] derived
-       as ["%s · broadcast %d · portal %d"].
+       exactly 15 keys including [communication_summary] derived
+       as ["%s · broadcast %d"].
 
     3. {b compact_session_json fallback contract} — empty
        [recent_events] produces a sentinel last_event with
@@ -51,7 +51,7 @@ let assoc_keys_sorted j =
 let session_fixture ?(session_id = "s-1") ?(project = "workspace-A")
     ?(workspace_id = "workspace-A") ?(goal = "ship feature") ?(status = "active")
     ?(summary_status = "active") ?(comm_mode = "async")
-    ?(broadcast = 3) ?(portal = 5) ?(recent = []) () =
+    ?(broadcast = 3) ?(recent = []) () =
   `Assoc
     [
       ("session_id", json_string session_id);
@@ -87,7 +87,6 @@ let session_fixture ?(session_id = "s-1") ?(project = "workspace-A")
                 [
                   ("mode", json_string comm_mode);
                   ("broadcast_count", `Int broadcast);
-                  ("portal_count", `Int portal);
                 ] );
           ] );
       ("recent_events", `List recent);
@@ -281,7 +280,7 @@ let test_compact_session_strict_keys () =
 let test_compact_session_communication_summary_format () =
   (* "%s · broadcast %d" *)
   let s =
-    session_fixture ~comm_mode:"async" ~broadcast:7 ~portal:11 ()
+    session_fixture ~comm_mode:"async" ~broadcast:7 ()
   in
   let out = C.compact_session_json s in
   match out with

--- a/test/test_briefing_sections.ml
+++ b/test/test_briefing_sections.ml
@@ -40,12 +40,11 @@ let briefing_summary ?(workspace_health = "ok") ?(incidents = 0)
       ("top_attention_summary", s_str top_attention);
     ]
 
-let session ?(broadcast = 0) ?(portal = 0) ?(mode = "unknown")
+let session ?(broadcast = 0) ?(mode = "unknown")
     ?(goal = "unassigned") () =
   `Assoc
     [
       ("broadcast_count", `Int broadcast);
-      ("portal_count", `Int portal);
       ("communication_mode", s_str mode);
       ("goal", s_str goal);
     ]
@@ -355,7 +354,7 @@ let test_evidence_capped_at_two () =
     List.init 5 (fun _ -> recent_msg ())
   in
   let s_with_signals =
-    session ~broadcast:5 ~portal:7 ~mode:"async" ()
+    session ~broadcast:5 ~mode:"async" ()
   in
   let _ws, sections =
     S.build_briefing_sections

--- a/test/test_dashboard_briefing_sections.ml
+++ b/test/test_dashboard_briefing_sections.ml
@@ -424,7 +424,6 @@ let test_build_briefing_sections_keeps_metadata_evidence_visible () =
         ("required_agents", `Int 1);
         ("communication_mode", `String "broadcast");
         ("broadcast_count", `Int 1);
-        ("portal_count", `Int 0);
         ("communication_summary", `String "broadcast · broadcast 1");
         ("last_event", `Assoc []);
       ]

--- a/test/test_keeper_tool_matrix_cases.ml
+++ b/test/test_keeper_tool_matrix_cases.ml
@@ -355,7 +355,6 @@ let extra_guard_fragments_for_name = function
   | "masc_board_migrate" -> [ "requires postgresql backend" ]
   | "masc_get_metrics" -> [ "no metrics found" ]
   | "masc_library_promote" -> [ "no candidate matching" ]
-  | "masc_portal_send" -> [ "no portal open" ]
   | "masc_keeper_list" | "masc_keeper_msg" | "masc_keeper_msg_result"
   | "masc_keeper_status" ->
       [ "keeper management tool"; "use MCP client" ]

--- a/test/test_masc_error_is_retryable.ml
+++ b/test/test_masc_error_is_retryable.ml
@@ -8,8 +8,8 @@
     "retryable or not" decision.
 
     Properties pinned:
-    1. {b Domain-state errors are non-retryable} — Task / Agent /
-       Portal variants.
+    1. {b Domain-state errors are non-retryable} — Task / Agent
+       variants.
     2. {b Auth — only TokenExpired retryable} — refresh-then-retry
        semantics; Unauthorized / Forbidden / InvalidToken are not.
     3. {b System — only transient I/O retryable} — IoError /

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -820,7 +820,6 @@ let guard_fragments_for_name name =
     List.exists
       (fun prefix -> string_starts_with ~prefix name)
       [
-        "masc_a2a_";
         "masc_handover_";
         "masc_keeper_";
         "masc_local_runtime_";


### PR DESCRIPTION
## chore(types): purge dead A2A/Portal subsystem (unreachable, 0 live callers)

Removes the abandoned masc-owned **A2A task / Portal** subsystem. This is the typed data model (Google A2A Protocol task objects + bidirectional portal connections) and its tool surface, not the live agent-to-agent messaging.

### Deadness evidence

- **Physically unreachable**: `Tool_dispatch.lookup_tag` returns `None` for `masc_portal_*` / `masc_a2a_*`, so invoking one errors `"Unknown tool (registry inconsistency)"` (`mcp_server_eio_execute.ml:556-561`). The portal tools were registered in the catalog with auth metadata but had no dispatch path.
- **Self-documented dead**: `governance_pipeline_risk.ml:87` states `masc_a2a_query_skill` "was dead code for a non-existent feature". (Comment left intact — it explains why `residual_risk_overrides` is empty.)
- **0 live callers**: `notify_portal` had no production caller; `a2a_task` / `portal` type constructors appeared only in codec round-trip tests; `portal_count` was an orphan read in dashboard/briefing code with **no writer** anywhere in the tree.
- **Docs already purged**: masc-oas-docs #124 removed a2a/portal/swarm from external docs.
- RFC-0182's "live" claim for portal is refuted by code (its only protocol reference sat behind a success-gate the portal can never reach).

Audit reference: `~/me/reports/masc-tool-boundary-audit-2026-06-04.md` §7 (dead-concept ledger, A2A/Portal = the one real purge).

### Blast radius (compiler-guided, exhaustive)

- `lib/types/types_core.{ml,mli}`: removed `a2a_task_status`, `a2a_task`, `portal_state`, `portal` + all `_to_string/_of_string/_to_yojson/_of_yojson` codecs.
- `lib/types/masc_error.{ml,mli}`: removed `module Portal_error` + the `| Portal of Portal_error.t` variant; dropped the now-dead arms in `to_string` / `code` / `is_retryable` (internal) and the external exhaustive arms in `server_auth.ml` and `workspace_task_schedule.ml`.
- `lib/types/types_auth.{ml,mli}`: removed permission variants `CanOpenPortal` / `CanSendPortal` + their refs in `permission_to_string`, `permissions_for_role`, `has_permission`, and in `tool_access_role.ml`'s `required_role_of_permission`.
- `lib/notify.{ml,mli}`: removed event `PortalMessage` + `notify_portal`.
- `lib/tool/tool_catalog.ml`: removed catalog entries `masc_portal_open` / `masc_portal_close` / `masc_portal_send`.
- `lib/mcp_server_eio_protocol.ml`: removed portal tool names from the resource-notification match (left `masc_broadcast`).
- `lib/mcp_server_eio_tool_profile.ml`: removed the `masc_a2a_delegate` passthrough-exclusion husk (it was already a no-op — not in `spawned_agent_public_tool_names`) and the `masc_a2a_delegate` / `masc_a2a_subscribe` display labels.
- Dashboard orphan `portal_count` reads (`briefing_sections.ml`, `dashboard_execution_sessions.ml`, `briefing_compactors.ml`): removed reads + dropped `· portal %d` from `communication_summary` (the field had no writer; always 0).
- Stale comments referencing already-deleted `Tool_a2a` / `Lib.A2a_tools` / `a2a_rng` in `tools.{ml,mli}`, `client_identity.ml`, `mention_inbox.ml`, `nickname.ml`.
- Tests: trimmed only the A2A/Portal cases (files kept) in `test_types_coverage.ml`, `test_types_utils_coverage.ml`, `test_tool_access_role.ml`, `test_notify_coverage.ml`, `test_masc_error_is_retryable.ml`; removed dead guard fragments for deleted tools in `test_keeper_tool_matrix_cases.ml` and `test_mcp_tool_matrix_cases.ml`; updated the string-keyed dashboard fixtures/assertions in `test_briefing_compactors.ml`, `test_briefing_sections.ml`, `test_dashboard_briefing_sections.ml`.

### Explicitly NOT touched (these are LIVE)

1. The ~23 `Agent_sdk.Error.A2a _` exhaustive match arms across `lib/keeper/keeper_error_classify*.ml`, `keeper_agent_error.ml`, `keeper_turn_driver*.ml`, `keeper_event_bridge_error_json.ml`, `keeper_status_bridge_blocker.ml`, `keeper_runtime_attempt.ml`, `lib/server/openai_compat_error_map.ml` — exhaustiveness over the EXTERNAL `agent_sdk` error type; removing them breaks compilation. (Their test, `test_openai_compat_error_map.ml`, is also left intact.)
2. The workspace "A2A communication" auto-subscribe at `lib/workspace/workspace_eio.ml:~390` — live messaging, unrelated to the dead types.
3. Swarm regression guards (`test_legacy_swarm_tools_removed`, operator snapshot `swarm_status=Null`) and the `test_capability_registry` absence guards (`masc_a2a_delegate` / `masc_portal_send` omission) — kept as re-introduction guards.

### Correction to the original purge scope

`docs/MASC_A2A.tla` / `docs/MASC_A2A.cfg` were listed as deletion candidates but are **NOT dead**: they formally model the LIVE broadcast/subscribe/delivery protocol (`messageQueue` / `Broadcast` / `Subscribe`, zero `portal`/`a2a_task` refs) — the same live messaging as `workspace_eio.ml:390`. Kept.

### Follow-up blocker (deferred, NOT in this PR)

In-repo prose specs still describe the dead types and need surgical edits with renumber / dangling-anchor risk — deferred to keep this PR a clean code purge. No masc-mcp CI/doc/anchor gate keys on these (`rg 'a2a_task|portal_state|CanOpenPortal|MASC_A2A' .github/ scripts/` = 0), so the lag cannot redden main:
- `docs/spec/02-types-and-invariants.md`: §2.13 (A2A Task) + §2.14 (Portal) sections (forces renumber of §2.15+), plus inline refs in the error-variant block (~316 `PortalNotOpen`/`PortalAlreadyOpen`/`PortalClosed`), the permission block (~533 `CanOpenPortal`/`CanSendPortal` + Worker-role table ~541), and `Mod_a2a` in the module-id block (~389).
- `docs/spec/03-workspace-state.md`: §10.2 (Portal), INV-WORKSPACE-014, and the mermaid topology referencing `workspace_portal`.
- `docs/design/external-agent-framework-patterns-rfc.md`: A2A sections (~15 refs).

### Verification

- Baseline: fresh `origin/main` (`c038399d2b`) `dune build @check` = **0 errors** (the previously-pre-existing #19991 test-RED `ignored-partial-application` ×2 was fixed by the merged paired-update; my bar is 0, not 2).
- Post-change: `dune build @check` = **0 errors** (EXIT 0); `dune build lib/` = clean.
- Affected test executables run: `test_briefing_compactors`, `test_briefing_sections`, `test_dashboard_briefing_sections`, `test_tool_access_role`, `test_masc_error_is_retryable` PASS. `test_types_coverage` / `test_types_utils_coverage` / `test_notify_coverage` show the **same** pre-existing failure sets on `origin/main` and this branch (`agent_credential`/`auth_config`/`backlog_of_yojson`, `auth_config`, `render_focus_template`/`agent_emoji`) — zero new failures introduced.
- Orphan ref scan over `lib/` and `test/`: only the intentional KEEPs remain.

RFC-WAIVED: dead A2A/Portal subsystem removal — physically unreachable (lookup_tag→None), 0 live callers, no live auth path (CanOpenPortal/CanSendPortal never granted or checked at runtime); masc-oas-docs #124 already purged.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
