### PR TITLE
refactor(keeper): remove dead denied tool gate

### DIFF
--- a/lib/keeper/keeper_tool_dispatch_runtime.ml
+++ b/lib/keeper/keeper_tool_dispatch_runtime.ml
@@ -71,8 +71,6 @@ let dedupe_tool_search_schemas schemas =
 
 let default_tool_search_schemas () =
   Tool_shard.all_keeper_tool_schemas @ [ keeper_tool_search_schema ]
-  |> List.filter (fun (schema : Masc_domain.tool_schema) ->
-    not (is_keeper_denied schema.name))
   |> dedupe_tool_search_schemas
 ;;
 

--- a/lib/keeper/keeper_tool_dispatch_runtime.mli
+++ b/lib/keeper/keeper_tool_dispatch_runtime.mli
@@ -88,8 +88,7 @@ val is_core_always_tool : string -> bool
 val dedupe_tool_names : string list -> string list
 
 (** Inject all masc_* schemas for keeper descriptor/registry surface filtering.
-    Must be called once during server initialization.
-    Keeper_denied tools are excluded at injection time. *)
+    Must be called once during server initialization. *)
 val inject_masc_schemas : Masc_domain.tool_schema list -> unit
 
 (** Load tool group definitions from [config/tool_policy.toml].
@@ -98,11 +97,6 @@ val inject_masc_schemas : Masc_domain.tool_schema list -> unit
     Call [inject_masc_schemas] before the first resolution so injected
     [masc_*] schemas can join the active keeper surface. *)
 val init_policy_config : base_path:string -> (unit, string) result
-
-(** Check if a tool name is in the Keeper_denied surface (Tool_catalog).
-    Denied tools are excluded from both the schema list sent to the LLM
-    and blocked at execution time by the pre_tool_use hook. *)
-val is_keeper_denied : string -> bool
 
 (** Classification of a keeper tool result payload for circuit-breaker
     bookkeeping.

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -112,11 +112,6 @@ let init_policy_config ~base_path =
   | Error msg ->
     Error msg
 
-(* ── Denied-tool set (O(1) lookup) ────────────────────────────── *)
-
-let keeper_denied_set : (string, unit) Hashtbl.t =
-  Hashtbl.create 0
-
 let dedupe_tool_schemas (schemas : Masc_domain.tool_schema list) =
   let seen = Hashtbl.create (max 16 (List.length schemas)) in
   List.filter
@@ -127,9 +122,6 @@ let dedupe_tool_schemas (schemas : Masc_domain.tool_schema list) =
         Hashtbl.replace seen schema.name ();
         true))
     schemas
-
-let is_keeper_denied (name : string) : bool =
-  Hashtbl.mem keeper_denied_set name
 
 (* ── Schema injection filter ──────────────────────────────────── *)
 
@@ -205,7 +197,6 @@ let keeper_supported_masc_schemas (schemas : Masc_domain.tool_schema list) =
       String.starts_with ~prefix:"masc_" s.name
       && not (is_keeper_mcp_context_required s.name)
       && supported_in_keeper s.name
-      && not (is_keeper_denied s.name)
       && not (has_keeper_board_wrapper s.name))
       schemas
 

--- a/lib/keeper/keeper_tool_policy.mli
+++ b/lib/keeper/keeper_tool_policy.mli
@@ -162,8 +162,5 @@ val dedupe_tool_schemas :
     Returns [None] for unknown tools. *)
 val tool_hint_of : string -> string option
 
-(** Check if a tool name is in the keeper denied set. *)
-val is_keeper_denied : string -> bool
-
 (** Check if a tool requires MCP context injection. *)
 val is_keeper_mcp_context_required : string -> bool


### PR DESCRIPTION
## Summary

- remove the empty `keeper_denied_set` and `is_keeper_denied` policy export
- drop the no-op denied filters from MASC schema injection and keeper tool search
- remove stale `Keeper_denied` comments from the dispatch runtime interface

## Rationale

`keeper_denied_set` was never populated, so the gate always returned `false`.
Keeping it made `Keeper_tool_policy` look like a second per-tool policy SSOT even
though the live behavior had no denied-tool data behind it.

## Verification

- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=/tmp/masc-dune-remove-denied-set dune build --root . @install test/test_keeper_tool_descriptor_registry_integrity.exe --force`
- `/tmp/masc-dune-remove-denied-set/default/test/test_keeper_tool_descriptor_registry_integrity.exe`
- `ocamlformat --check lib/keeper/keeper_tool_policy.ml lib/keeper/keeper_tool_policy.mli lib/keeper/keeper_tool_dispatch_runtime.ml lib/keeper/keeper_tool_dispatch_runtime.mli`
- `git diff --check`
- `scripts/audit-keeper-tool-boundary-matrix.sh`
- `scripts/lint/tool-keeper-boundary-ratchet.sh`

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`codex/remove-dead-keeper-denied-set-20260604` → `main` · 1 commit(s) · synced 2026-06-04T01:55:51Z

| sha | subject | date |
|---|---|---|
| `544a7f466` | refactor(keeper): remove dead denied tool gate | 2026-06-04 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->