### PR TITLE
test: align make risk expectations

### DIFF
--- a/test/test_keeper_tool_execute_safety.ml
+++ b/test/test_keeper_tool_execute_safety.ml
@@ -116,6 +116,7 @@ let test_write_ops_detected () =
     "git clone https://github.com/user/repo.git";
     "git init";
     "dune clean";
+    "make test";
     "make deploy";
     "make install";
     "npm publish";
@@ -138,7 +139,6 @@ let test_read_ops_pass () =
     "git diff HEAD";
     "scripts/dune-local.sh build";
     "scripts/dune-local.sh exec test.exe";
-    "make test";
     "npm run build";
     "npm run dev";
     "pnpm run build";

--- a/test/test_shell_ir_risk.ml
+++ b/test/test_shell_ir_risk.ml
@@ -40,7 +40,6 @@ let test_r0_read_commands () =
   check "git log --oneline -5" Shell_ir_risk.R0_Read;
   check "gh pr view 123" Shell_ir_risk.R0_Read;
   check "dune build" Shell_ir_risk.R0_Read;
-  check "make test" Shell_ir_risk.R0_Read;
   check "npm run build" Shell_ir_risk.R0_Read
 ;;
 
@@ -56,6 +55,7 @@ let test_r1_reversible_commands () =
   check "git commit -m msg" Shell_ir_risk.R1_Reversible_mutation;
   check "git checkout branch" Shell_ir_risk.R1_Reversible_mutation;
   check "dune clean" Shell_ir_risk.R1_Reversible_mutation;
+  check "make test" Shell_ir_risk.R1_Reversible_mutation;
   check "make install" Shell_ir_risk.R1_Reversible_mutation;
   check "npm install pkg" Shell_ir_risk.R1_Reversible_mutation;
   check "truncate -s 0 file" Shell_ir_risk.R1_Reversible_mutation;


### PR DESCRIPTION
## Summary

- align Shell IR risk test expectations with the classifier contract for top-level `make`
- move `make test` from R0/read expectations to R1/write expectations in keeper execute safety coverage

## Product impact

- User-visible change: none; test-only contract alignment.

## Verification

- `opam exec -- ocamlformat --check test/test_shell_ir_risk.ml test/test_keeper_tool_execute_safety.ml`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_shell_ir_risk.exe test/test_keeper_tool_execute_safety.exe`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh exec test/test_shell_ir_risk.exe`

## Evidence

- `opam exec -- ocamlformat --check test/test_shell_ir_risk.ml test/test_keeper_tool_execute_safety.ml`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_shell_ir_risk.exe test/test_keeper_tool_execute_safety.exe`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh exec test/test_shell_ir_risk.exe`
  - Result: `Test Successful` in 0.001s; 7 tests run.

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 0/3
provenance: operator_proxy
stages:
  - name: ocamlformat
    provenance: operator_proxy
    command: opam exec -- ocamlformat --check test/test_shell_ir_risk.ml test/test_keeper_tool_execute_safety.ml
    result: pass
  - name: focused-build
    provenance: operator_proxy
    command: env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_shell_ir_risk.exe test/test_keeper_tool_execute_safety.exe
    result: pass
  - name: shell-ir-risk-test
    provenance: operator_proxy
    command: env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh exec test/test_shell_ir_risk.exe
    result: pass
```

## GOAL LOOP ACT checklist

- [x] Observe — CI failed `test/test_shell_ir_risk.ml` because `make test` was expected as R0 while the classifier returns R1.
- [x] Orient — `Shell_ir_risk.classify_write_detail` treats top-level `make` as reversible mutation.
- [x] Decide — scope is test-only alignment with the existing classifier policy.
- [x] Act — moved `make test` to R1/write expectations in the affected tests.
- [x] Verify — focused local format/build/test commands pass.
- [x] Loop — no follow-up known for this test-only alignment.

## Review evidence

- Cross-model review: not requested; test-only follow-up to a CI contract mismatch.

## Linked issue

- Closes #N/A
- Relates #20018

## Variant addition checklist

- [ ] **OCaml** — N/A; no variant added, removed, or renamed.
- [ ] **TypeScript** — N/A; no TypeScript union change.
- [ ] **TLA+ spec** — N/A; no TLA+ domain change.
- [ ] **Event / JSON schema** — N/A; no event or JSON schema enum change.
- [ ] **`make check-variants` passes** — N/A; test-only expectation alignment with no variant surface change.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`fix/make-risk-test-contract-20260604` → `main` · 1 commit(s) · synced 2026-06-04T02:02:58Z

| sha | subject | date |
|---|---|---|
| `4acfbcf1b` | test: align make risk expectations | 2026-06-04 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->