### PR TITLE
feat(keeper): wire claim_post_provision_fn for worktree auto-creation

### DIFF
--- a/lib/keeper/keeper_repo_readiness.ml
+++ b/lib/keeper/keeper_repo_readiness.ml
@@ -434,6 +434,85 @@ let ensure_worktree_ready
                "worktree add failed for %s/%s at %s: %s"
                repo_name task_name worktree_path add_result.output)
 
+(** [provision_worktrees_for_task ~config ~agent_name ~task_id ()] scans all
+    repos in the keeper's docker playground and creates a worktree for [task_id]
+    in each repo that is ready.  Called best-effort at task claim time so that
+    worktrees exist before the LLM tries to use them.
+
+    Only operates for Docker-sandboxed keepers (local keepers use the project
+    root directly and don't need worktree provisioning).
+
+    Computes paths directly from [config.base_path] and [agent_name] to avoid
+    constructing a full [keeper_meta] record.  Uses [run_git] directly for
+    worktree operations.
+
+    Failures in individual repos are logged but do not propagate — the
+    validation-time [ensure_worktree_ready] safety net handles any misses. *)
+let provision_worktrees_for_task
+      ~(config : Workspace.config)
+      ~(agent_name : string)
+      ~(task_id : string)
+      () =
+  if not (safe_repo_component task_id) then
+    Log.Workspace.info "provision_worktrees: invalid task_id %S, skipping" task_id
+  else
+    let safe_name = Playground_paths.sanitize_keeper_name agent_name in
+    let playground =
+      Filename.concat config.Workspace.base_path
+        (Printf.sprintf ".masc/playground/docker/%s" safe_name)
+    in
+    let repos_dir = Filename.concat playground "repos" in
+    if not (safe_is_dir repos_dir) then ()
+    else
+      let entries =
+        try Sys.readdir repos_dir with Sys_error _ -> [||]
+      in
+      Array.iter
+        (fun repo_name ->
+           if not (safe_repo_component repo_name) then ()
+           else
+             let repo_path = Filename.concat repos_dir repo_name in
+             if not (safe_is_dir repo_path) then ()
+             else
+               let worktree_path =
+                 Filename.concat
+                   (Filename.concat repo_path ".worktrees")
+                   task_id
+               in
+               (* Fast path: worktree already exists *)
+               let probe =
+                 run_git ~timeout_sec:read_only_probe_timeout_sec
+                   ~clone_path:worktree_path
+                   [ "rev-parse"; "--show-toplevel" ]
+               in
+               if probe.ok then ()
+               else
+                 (* Create worktree in the sandbox clone *)
+                 let add_result =
+                   run_git
+                     ~timeout_sec:(read_only_probe_timeout_sec *. 2.0)
+                     ~clone_path:repo_path
+                     [ "worktree"; "add"; "--detach"; worktree_path ]
+                 in
+                 if add_result.ok then (
+                   let branch_name =
+                     Printf.sprintf "task/%s" task_id
+                   in
+                   let _checkout =
+                     run_git ~timeout_sec:read_only_probe_timeout_sec
+                       ~clone_path:worktree_path
+                       [ "checkout"; "-b"; branch_name ]
+                   in
+                   Log.Workspace.info
+                     "provision_worktrees: worktree created for %s/%s"
+                     repo_name task_id
+                 )
+                 else
+                   Log.Workspace.debug
+                     "provision_worktrees: skipped %s/%s: %s"
+                     repo_name task_id add_result.output)
+        entries
+
 (* ── Sandbox repo currency (fetch + work-preserving fast-forward) ──── *)
 
 (** Build a minimal [repository] record for the sandbox clone lane.

--- a/lib/keeper/keeper_repo_readiness.mli
+++ b/lib/keeper/keeper_repo_readiness.mli
@@ -99,6 +99,18 @@ val ensure_worktree_ready :
   unit ->
   (unit, string) result
 
+(** [provision_worktrees_for_task ~config ~agent_name ~task_id ()] scans all
+    repos in the keeper's playground and creates a worktree for [task_id] in
+    each repo that is ready.  Called best-effort at task claim time so worktrees
+    exist before the LLM tries to use them.  Only operates for Docker-sandboxed
+    keepers.  Failures in individual repos are logged but do not propagate. *)
+val provision_worktrees_for_task :
+  config:Workspace.config ->
+  agent_name:string ->
+  task_id:string ->
+  unit ->
+  unit
+
 (** Outcome of an [ensure_current] pass. Every non-[Advanced] case leaves the
     working tree byte-for-byte untouched. *)
 type currency_outcome =

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -131,6 +131,13 @@ let start_keeper_loops
   Progress.set_sse_callback Sse.broadcast;
   (* Wire stop_keeper hook so zombie GC can terminate keeper fibers *)
   Atomic.set Workspace_hooks.stop_keeper_fn Keeper_keepalive.stop_keepalive;
+  (* Wire claim_post_provision hook: create worktrees at task claim time
+     so docker-backed keepers find them when the LLM picks a worktree cwd.
+     Only Docker keepers benefit; local keepers operate on the project root. *)
+  Atomic.set Workspace_hooks.claim_post_provision_fn
+    (fun config ~agent_name ~task_id ->
+       Keeper_repo_readiness.provision_worktrees_for_task
+         ~config ~agent_name ~task_id ());
   (* Shared Agent_sdk Event_bus used as the runtime transport between subsystems.
      Configuration is sourced from [Masc_event_bus_policy.oas_runtime] so the
      buffer-size/policy choice is auditable in source rather than implicit in

--- a/test/test_keeper_repo_readiness.ml
+++ b/test/test_keeper_repo_readiness.ml
@@ -427,6 +427,47 @@ let test_ensure_worktree_ready_idempotent () =
   | Ok () -> ()
   | Error msg -> fail ("second call failed: " ^ msg)
 
+let test_provision_worktrees_creates_worktrees () =
+  (* Set up a docker playground with a repo *)
+  let base_path = temp_dir "masc-provision" in
+  let remote = Filename.concat base_path ".remote-masc.git" in
+  git_ok ~cwd:base_path [ "init"; "--bare"; "-q"; "--initial-branch=main"; remote ];
+  let config = Masc.Workspace.default_config base_path in
+  let agent_name = "keeper-provision-test" in
+  let safe_name = Playground_paths.sanitize_keeper_name agent_name in
+  let repo_dir =
+    Filename.concat base_path
+      (Printf.sprintf ".masc/playground/docker/%s/repos/test-repo" safe_name)
+  in
+  mkdir_p (Filename.dirname repo_dir);
+  git_ok ~cwd:base_path [ "clone"; "-q"; remote; repo_dir ];
+  git_ok ~cwd:repo_dir [ "config"; "user.email"; "test@example.com" ];
+  git_ok ~cwd:repo_dir [ "config"; "user.name"; "Test" ];
+  let readme = Filename.concat repo_dir "README.md" in
+  let oc = open_out readme in
+  output_string oc "# test\n";
+  close_out oc;
+  git_ok ~cwd:repo_dir [ "add"; "README.md" ];
+  git_ok ~cwd:repo_dir [ "commit"; "-q"; "-m"; "init" ];
+  git_ok ~cwd:repo_dir [ "push"; "-q"; "origin"; "main" ];
+  (* Call provision *)
+  let task_id = "task-provision-001" in
+  Masc.Keeper_repo_readiness.provision_worktrees_for_task
+    ~config ~agent_name ~task_id ();
+  (* Verify worktree was created *)
+  let worktree_path =
+    Filename.concat repo_dir (Printf.sprintf ".worktrees/%s" task_id)
+  in
+  check bool "worktree dir exists" true (Sys.file_exists worktree_path);
+  check bool "worktree is directory" true (Sys.is_directory worktree_path);
+  let probe =
+    Masc.Keeper_repo_readiness.run_git
+      ~timeout_sec:Masc.Keeper_repo_readiness.read_only_probe_timeout_sec
+      ~clone_path:worktree_path
+      [ "rev-parse"; "--show-toplevel" ]
+  in
+  check bool "worktree is valid git checkout" true probe.ok
+
 let () =
   Random.self_init ();
   run "Keeper_repo_readiness"
@@ -447,5 +488,10 @@ let () =
           test_ensure_worktree_ready_creates_worktree;
         test_case "idempotent" `Quick
           test_ensure_worktree_ready_idempotent;
+      ];
+      "provision_worktrees_for_task",
+      [
+        test_case "creates worktrees at claim time" `Quick
+          test_provision_worktrees_creates_worktrees;
       ];
     ]


### PR DESCRIPTION
## Root fix: wire claim_post_provision_fn for worktree auto-creation

Follow-up to [PR #20012](https://github.com/jeong-sik/masc-mcp/pull/20012) (validation-time safety net).

### Root cause

`claim_post_provision_fn` was a **no-op in production** — the hook existed but was never wired to a real implementation. This meant worktrees were never pre-created at task claim time, forcing the LLM to hit `sandbox_repo_not_ready` errors when it picked a worktree cwd.

### Fix

1. **`keeper_repo_readiness.ml`**: Add `provision_worktrees_for_task` that scans all repos in the docker playground and creates worktrees via `git worktree add --detach` + `checkout -b task/<id>`

2. **`server_bootstrap_loops.ml`**: Wire `claim_post_provision_fn` to call `provision_worktrees_for_task` at keeper startup

3. **`test_keeper_repo_readiness.ml`**: Add test for `provision_worktrees_for_task`

### Architecture

```
Task claim → claim_post_provision_fn → provision_worktrees_for_task
                                         ├─ scan <playground>/repos/
                                         └─ for each repo:
                                              ├─ git worktree add --detach
                                              └─ checkout -b task/<id>
```

Validation-time `ensure_worktree_ready` (PR #20012) remains as a safety net for any misses.

### Build verification

```
$ dune build --root .    # exit 0
$ dune exec --root . test/test_keeper_repo_readiness.exe    # 8/8 PASS
```

### PR-RFC check

RFC-WAIVED: keeper sandbox worktree provisioning at claim time. credential/identity/operator/hooks/workflow 미포함.

🤖 Generated with [Claude Code](https://claude.com/claude-code)