### PR TITLE
refactor(keeper): derive last-turn fallback from descriptors

### DIFF
--- a/docs/rfc/RFC-0191-descriptor-policy-ssot.md
+++ b/docs/rfc/RFC-0191-descriptor-policy-ssot.md
@@ -118,6 +118,14 @@ and audience_class =
 | **P5** | Drop everything in `keeper_tool_policy.ml` that has no agent-level role. Target: < 250 LoC, only agent-side state + path normalization + descriptor projections. | LoC reduction ~420. |
 | **P6** (follow-up RFC) | Re-evaluate whether `Keeper_tool_policy_config` (TOML loader) can be regenerated from descriptors instead of edited by operators. Likely no — operators tune policy bundles, not per-tool policy. | Out of scope. |
 
+Progress note (2026-06-04): P2 projections for inline-safe and
+maintenance-only tools are descriptor-owned, and the no-op denied set was
+removed. P3 now has a bridge field, `policy.last_turn_safe`, and
+`last_turn_safe_tool_names` uses that descriptor projection as the
+config-unloaded fallback while preserving the operator-tunable TOML group when
+loaded. `extend_turns` remains the explicit SDK/core exception outside the
+descriptor spine.
+
 P1's cross-check test is the central safety device. The test compares every descriptor's projected predicate against the existing `keeper_tool_policy` answer; **the migration is only permitted to advance if all descriptors agree**. Disagreements found in P1 are P1's job to resolve (by descriptor edit, never by changing the predicate to be more permissive).
 
 ## 6. Workaround-bar check

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -69,6 +69,7 @@ type policy =
   ; cwd_scope : string option
   ; inline_safe : bool
   ; maintenance_only : bool
+  ; last_turn_safe : bool
   }
 
 type t =
@@ -150,7 +151,7 @@ let runtime_handler_to_string = function
 
 let policy ?(visibility = Tool_catalog.Default) ?readonly ?readonly_of_input
       ?effect_domain ?(approval = Policy_selected) ?cwd_scope ?(retryable = false)
-      ?(inline_safe = false) ?(maintenance_only = false) ()
+      ?(inline_safe = false) ?(maintenance_only = false) ?(last_turn_safe = false) ()
   =
   let readonly_of_input =
     match readonly_of_input with
@@ -166,6 +167,7 @@ let policy ?(visibility = Tool_catalog.Default) ?readonly ?readonly_of_input
   ; cwd_scope
   ; inline_safe
   ; maintenance_only
+  ; last_turn_safe
   }
 ;;
 
@@ -412,6 +414,7 @@ let public_descriptors =
            ~effect_domain:Tool_catalog.Playground_write
            ~cwd_scope:"keeper_sandbox_or_allowed_path"
            ~retryable:false
+           ~last_turn_safe:true
            ())
       ~executor:Shell_ir
       ~backend:Sandbox_process
@@ -434,6 +437,7 @@ let public_descriptors =
            ~effect_domain:Tool_catalog.Read_only
            ~cwd_scope:"keeper_sandbox_or_allowed_path"
            ~retryable:true
+           ~last_turn_safe:true
            ())
       ~executor:Shell_ir
       ~backend:Sandbox_process
@@ -455,6 +459,7 @@ let public_descriptors =
            ~effect_domain:Tool_catalog.Read_only
            ~cwd_scope:"keeper_sandbox_or_allowed_path"
            ~retryable:true
+           ~last_turn_safe:true
            ())
       ~executor:Filesystem
       ~backend:Sandbox_process
@@ -507,6 +512,7 @@ let public_descriptors =
            ~effect_domain:Tool_catalog.Read_only
            ~approval:Policy_selected
            ~retryable:true
+           ~last_turn_safe:true
            ())
       ~executor:In_process
       ~backend:Ocaml_runtime
@@ -525,6 +531,7 @@ let public_descriptors =
            ~effect_domain:Tool_catalog.Read_only
            ~approval:Policy_selected
            ~retryable:true
+           ~last_turn_safe:true
            ())
       ~executor:In_process
       ~backend:Ocaml_runtime
@@ -574,7 +581,9 @@ let tool_search_schema =
     ]
 ;;
 
-let read_only_in_process_policy ?(inline_safe = false) ?(maintenance_only = false) () =
+let read_only_in_process_policy ?(inline_safe = false) ?(maintenance_only = false)
+      ?(last_turn_safe = false) ()
+  =
   policy
     ~visibility:Tool_catalog.Hidden
     ~readonly:true
@@ -583,11 +592,12 @@ let read_only_in_process_policy ?(inline_safe = false) ?(maintenance_only = fals
     ~retryable:true
     ~inline_safe
     ~maintenance_only
+    ~last_turn_safe
     ()
 ;;
 
 let write_in_process_policy ?(retryable = false) ?(inline_safe = false)
-      ?(maintenance_only = false) ()
+      ?(maintenance_only = false) ?(last_turn_safe = false) ()
   =
   policy
     ~visibility:Tool_catalog.Hidden
@@ -597,6 +607,7 @@ let write_in_process_policy ?(retryable = false) ?(inline_safe = false)
     ~retryable
     ~inline_safe
     ~maintenance_only
+    ~last_turn_safe
     ()
 ;;
 
@@ -619,14 +630,15 @@ let in_process_descriptor ~id ~name ~description ~input_schema ~policy ~handler 
    [runtime_handler] variant but expose distinct [internal_name]s so each
    tool retains its own descriptor entry and receipt evidence. The
    [keeper_tool_in_process_runtime] handler routes by descriptor.internal_name. *)
-let cluster_descriptor ~id ~name ~description ~handler ~readonly ~inline_safe
-      ~maintenance_only
+let cluster_descriptor ~last_turn_safe ~id ~name ~description ~handler ~readonly
+      ~inline_safe ~maintenance_only
   =
   if inline_safe && not readonly then
     invalid_arg "inline_safe descriptors must declare readonly=true";
   let policy =
-    if readonly then read_only_in_process_policy ~inline_safe ~maintenance_only ()
-    else write_in_process_policy ~inline_safe ~maintenance_only ()
+    if readonly
+    then read_only_in_process_policy ~inline_safe ~maintenance_only ~last_turn_safe ()
+    else write_in_process_policy ~inline_safe ~maintenance_only ~last_turn_safe ()
   in
   in_process_descriptor
     ~id
@@ -637,8 +649,9 @@ let cluster_descriptor ~id ~name ~description ~handler ~readonly ~inline_safe
     ~handler
 ;;
 
-let board_descriptor name description ~readonly =
+let board_descriptor ?(last_turn_safe = false) name description ~readonly =
   cluster_descriptor
+    ~last_turn_safe
     ~id:("keeper.board." ^ String.sub name (String.length "keeper_board_")
          (String.length name - String.length "keeper_board_"))
     ~name
@@ -685,8 +698,9 @@ let masc_board_descriptors =
   List.map masc_board_descriptor Tool_board_registry.tools
 ;;
 
-let voice_descriptor name description ~readonly =
+let voice_descriptor ?(last_turn_safe = false) name description ~readonly =
   cluster_descriptor
+    ~last_turn_safe
     ~id:("keeper.voice." ^ String.sub name (String.length "keeper_voice_")
          (String.length name - String.length "keeper_voice_"))
     ~name
@@ -697,8 +711,9 @@ let voice_descriptor name description ~readonly =
     ~maintenance_only:false
 ;;
 
-let task_descriptor id name description ~readonly =
+let task_descriptor ?(last_turn_safe = false) id name description ~readonly =
   cluster_descriptor
+    ~last_turn_safe
     ~id:("keeper.task." ^ id)
     ~name
     ~description
@@ -715,8 +730,9 @@ let task_descriptor id name description ~readonly =
    (Task.Tool / Tool_plan / Tool_run / Tool_agent / Tool_workspace) are not
    schema-registry-backed. The handler routes by descriptor.internal_name
    through the existing typed dispatcher. *)
-let masc_task_descriptor id name description ~readonly =
+let masc_task_descriptor ?(last_turn_safe = false) id name description ~readonly =
   cluster_descriptor
+    ~last_turn_safe
     ~id:("masc.task." ^ id)
     ~name
     ~description
@@ -726,8 +742,9 @@ let masc_task_descriptor id name description ~readonly =
     ~maintenance_only:false
 ;;
 
-let masc_plan_descriptor id name description ~readonly =
+let masc_plan_descriptor ?(last_turn_safe = false) id name description ~readonly =
   cluster_descriptor
+    ~last_turn_safe
     ~id:("masc.plan." ^ id)
     ~name
     ~description
@@ -737,8 +754,9 @@ let masc_plan_descriptor id name description ~readonly =
     ~maintenance_only:false
 ;;
 
-let masc_run_descriptor name description ~readonly =
+let masc_run_descriptor ?(last_turn_safe = false) name description ~readonly =
   cluster_descriptor
+    ~last_turn_safe
     ~id:("masc.run." ^ String.sub name (String.length "masc_run_")
          (String.length name - String.length "masc_run_"))
     ~name
@@ -749,8 +767,9 @@ let masc_run_descriptor name description ~readonly =
     ~maintenance_only:false
 ;;
 
-let masc_agent_descriptor id name description ~readonly =
+let masc_agent_descriptor ?(last_turn_safe = false) id name description ~readonly =
   cluster_descriptor
+    ~last_turn_safe
     ~id:("masc.agent." ^ id)
     ~name
     ~description
@@ -760,8 +779,11 @@ let masc_agent_descriptor id name description ~readonly =
     ~maintenance_only:false
 ;;
 
-let masc_workspace_descriptor ?(maintenance_only = false) id name description ~readonly =
+let masc_workspace_descriptor ?(maintenance_only = false) ?(last_turn_safe = false) id
+      name description ~readonly
+  =
   cluster_descriptor
+    ~last_turn_safe
     ~id:("masc.workspace." ^ id)
     ~name
     ~description
@@ -773,8 +795,9 @@ let masc_workspace_descriptor ?(maintenance_only = false) id name description ~r
 
 (* RFC-0182 §3.1 — additional cluster descriptor helpers (Phase 3:
    misc / control / agent_timeline / local_runtime). *)
-let masc_misc_descriptor id name description ~readonly =
+let masc_misc_descriptor ?(last_turn_safe = false) id name description ~readonly =
   cluster_descriptor
+    ~last_turn_safe
     ~id:("masc.misc." ^ id)
     ~name
     ~description
@@ -784,8 +807,9 @@ let masc_misc_descriptor id name description ~readonly =
     ~maintenance_only:false
 ;;
 
-let masc_control_descriptor id name description ~readonly =
+let masc_control_descriptor ?(last_turn_safe = false) id name description ~readonly =
   cluster_descriptor
+    ~last_turn_safe
     ~id:("masc.control." ^ id)
     ~name
     ~description
@@ -795,8 +819,9 @@ let masc_control_descriptor id name description ~readonly =
     ~maintenance_only:false
 ;;
 
-let masc_agent_timeline_descriptor name description ~readonly =
+let masc_agent_timeline_descriptor ?(last_turn_safe = false) name description ~readonly =
   cluster_descriptor
+    ~last_turn_safe
     ~id:"masc.agent_timeline"
     ~name
     ~description
@@ -806,8 +831,9 @@ let masc_agent_timeline_descriptor name description ~readonly =
     ~maintenance_only:false
 ;;
 
-let masc_local_runtime_descriptor id name description ~readonly =
+let masc_local_runtime_descriptor ?(last_turn_safe = false) id name description ~readonly =
   cluster_descriptor
+    ~last_turn_safe
     ~id:("masc.local_runtime." ^ id)
     ~name
     ~description
@@ -817,8 +843,9 @@ let masc_local_runtime_descriptor id name description ~readonly =
     ~maintenance_only:false
 ;;
 
-let masc_tool_shard_descriptor id name description ~readonly =
+let masc_tool_shard_descriptor ?(last_turn_safe = false) id name description ~readonly =
   cluster_descriptor
+    ~last_turn_safe
     ~id:("masc.tool_shard." ^ id)
     ~name
     ~description
@@ -828,8 +855,11 @@ let masc_tool_shard_descriptor id name description ~readonly =
     ~maintenance_only:false
 ;;
 
-let masc_approval_descriptor ?(inline_safe = false) id name description ~readonly =
+let masc_approval_descriptor ?(inline_safe = false) ?(last_turn_safe = false) id name
+      description ~readonly
+  =
   cluster_descriptor
+    ~last_turn_safe
     ~inline_safe
     ~id:("masc.approval." ^ id)
     ~name
@@ -839,8 +869,9 @@ let masc_approval_descriptor ?(inline_safe = false) id name description ~readonl
     ~maintenance_only:false
 ;;
 
-let masc_persona_descriptor id name description ~readonly =
+let masc_persona_descriptor ?(last_turn_safe = false) id name description ~readonly =
   cluster_descriptor
+    ~last_turn_safe
     ~id:("masc.persona." ^ id)
     ~name
     ~description
@@ -850,8 +881,9 @@ let masc_persona_descriptor id name description ~readonly =
     ~maintenance_only:false
 ;;
 
-let masc_keeper_descriptor id name description ~readonly =
+let masc_keeper_descriptor ?(last_turn_safe = false) id name description ~readonly =
   cluster_descriptor
+    ~last_turn_safe
     ~id:("masc.keeper." ^ id)
     ~name
     ~description
@@ -870,7 +902,7 @@ let internal_descriptors : t list =
         "Return the current wall-clock time as ISO 8601 and Unix epoch \
          seconds. No arguments."
       ~input_schema:empty_object_schema
-      ~policy:(read_only_in_process_policy ())
+      ~policy:(read_only_in_process_policy ~last_turn_safe:true ())
       ~handler:Tool_time_now
   ; in_process_descriptor
       ~id:"keeper.stay_silent"
@@ -897,7 +929,7 @@ let internal_descriptors : t list =
         "Search keeper tool schemas by free-text query. Returns ranked tool \
          descriptions and input schemas."
       ~input_schema:tool_search_schema
-      ~policy:(read_only_in_process_policy ())
+      ~policy:(read_only_in_process_policy ~last_turn_safe:true ())
       ~handler:Tool_tool_search
     (* ── memory / context (RFC-0179 PR-3) ─────────────────────── *)
   ; in_process_descriptor
@@ -907,7 +939,7 @@ let internal_descriptors : t list =
         "Return current context window usage and recent-message stats for \
          this keeper turn."
       ~input_schema:empty_object_schema
-      ~policy:(read_only_in_process_policy ())
+      ~policy:(read_only_in_process_policy ~last_turn_safe:true ())
       ~handler:Tool_context_status
   ; in_process_descriptor
       ~id:"keeper.memory.search"
@@ -977,6 +1009,7 @@ let internal_descriptors : t list =
       "list"
       "keeper_tasks_list"
       "List MASC tasks visible to this keeper."
+      ~last_turn_safe:true
       ~readonly:true
   ; task_descriptor
       "audit"
@@ -997,6 +1030,7 @@ let internal_descriptors : t list =
       "broadcast"
       "keeper_broadcast"
       "Broadcast a workspace message to the MASC workspace."
+      ~last_turn_safe:true
       ~readonly:false
   ; task_descriptor
       "claim"
@@ -1012,16 +1046,19 @@ let internal_descriptors : t list =
       "done"
       "keeper_task_done"
       "Mark the claimed MASC task as done."
+      ~last_turn_safe:true
       ~readonly:false
   ; task_descriptor
       "submit_for_verification"
       "keeper_task_submit_for_verification"
       "Submit task work for verification by another keeper."
+      ~last_turn_safe:true
       ~readonly:false
     (* ── board cluster (RFC-0179 PR-3, 14 tools) ──────────────── *)
   ; board_descriptor
       "keeper_board_comment"
       "Post a comment on a board entry."
+      ~last_turn_safe:true
       ~readonly:false
   ; board_descriptor
       "keeper_board_comment_vote"
@@ -1034,6 +1071,7 @@ let internal_descriptors : t list =
   ; board_descriptor
       "keeper_board_curation_submit"
       "Submit a board entry for curation."
+      ~last_turn_safe:true
       ~readonly:false
   ; board_descriptor
       "keeper_board_get"
@@ -1046,6 +1084,7 @@ let internal_descriptors : t list =
   ; board_descriptor
       "keeper_board_post"
       "Post a new board entry. Quantitative claims require code-anchor evidence."
+      ~last_turn_safe:true
       ~readonly:false
   ; board_descriptor
       "keeper_board_search"
@@ -1089,9 +1128,9 @@ let internal_descriptors : t list =
   ; masc_task_descriptor "task_history" "masc_task_history"
       "Read history events for a task." ~readonly:true
   ; masc_task_descriptor "tasks" "masc_tasks"
-      "List tasks visible to the caller." ~readonly:true
+      "List tasks visible to the caller." ~last_turn_safe:true ~readonly:true
   ; masc_task_descriptor "transition" "masc_transition"
-      "Transition a task to a new status." ~readonly:false
+      "Transition a task to a new status." ~last_turn_safe:true ~readonly:false
   ; masc_task_descriptor "update_priority" "masc_update_priority"
       "Update the priority of a task." ~readonly:false
   (* ── RFC-0182 §3.1 — masc_plan_* + note + deliver (8 entries) ── *)
@@ -1247,6 +1286,7 @@ let internal_descriptors : t list =
       ~readonly:true
       ~inline_safe:false
       ~maintenance_only:false
+      ~last_turn_safe:false
   ]
   @ masc_board_descriptors
 ;;
@@ -1304,6 +1344,12 @@ let keeper_maintenance_only_names () =
   |> List.sort_uniq String.compare
 ;;
 
+let keeper_last_turn_safe_names () =
+  all_descriptors ()
+  |> List.concat_map (fun d -> if d.policy.last_turn_safe then internal_names d else [])
+  |> List.sort_uniq String.compare
+;;
+
 let public_name_for_internal internal_name =
   match public_descriptors_for_internal internal_name with
   | [] -> None
@@ -1350,6 +1396,7 @@ let route_evidence_json d =
      ; "cwd_scope", Json_util.string_opt_to_json policy.cwd_scope
      ; "inline_safe", `Bool policy.inline_safe
      ; "maintenance_only", `Bool policy.maintenance_only
+     ; "last_turn_safe", `Bool policy.last_turn_safe
      ]
      @ policy_fields)
 ;;

--- a/lib/keeper/keeper_tool_descriptor.mli
+++ b/lib/keeper/keeper_tool_descriptor.mli
@@ -74,6 +74,7 @@ type policy =
   ; cwd_scope : string option
   ; inline_safe : bool
   ; maintenance_only : bool
+  ; last_turn_safe : bool
   }
 
 type t =
@@ -137,6 +138,12 @@ val keeper_safe_inline_names : unit -> string list
 (** Descriptor-owned maintenance-only projection. The returned names are
     internal MASC tools excluded from ordinary keeper candidate sets. *)
 val keeper_maintenance_only_names : unit -> string list
+
+(** Descriptor-owned last-turn-safe projection. The returned names are
+    descriptor-backed internal tools that may remain visible on the keeper's
+    final turn. SDK/core tools outside the descriptor spine are appended by
+    [Keeper_tool_policy]. *)
+val keeper_last_turn_safe_names : unit -> string list
 
 val public_input_schema : string -> Yojson.Safe.t option
 val translate_input : public:string -> Yojson.Safe.t -> Yojson.Safe.t

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -258,15 +258,12 @@ let resolve_policy_group ~(fallback : string list) (group_name : string) : strin
 (** Tools allowed on the keeper's last turn.
     Reads [groups.last_turn_safe] from tool_policy.toml. *)
 let last_turn_safe_tool_names () =
-  resolve_policy_group
-    ~fallback:[ "keeper_board_post"; "keeper_board_comment";
-                "keeper_context_status"; "extend_turns";
-                "keeper_time_now"; "keeper_tool_search";
-                "keeper_broadcast"; "keeper_tasks_list"; "keeper_task_done";
-                "keeper_task_submit_for_verification"; "masc_tasks";
-                "masc_transition"; "tool_read_file"; "tool_search_files";
-                "tool_execute"; "masc_web_search"; "masc_web_fetch" ]
-    "last_turn_safe"
+  let fallback =
+    Keeper_tool_descriptor.keeper_last_turn_safe_names ()
+    @ [ "extend_turns" ]
+    |> dedupe_tool_names
+  in
+  resolve_policy_group ~fallback "last_turn_safe"
 
 let tool_policy_of_meta (meta : keeper_meta) =
   let allow = Tool_access_policy.Names meta.tool_access in

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -346,6 +346,31 @@ let test_mcp_context_policy_uses_descriptor_resolution () =
     "maintenance-only tools project from descriptors"
     [ "masc_heartbeat" ]
     (Descriptor.keeper_maintenance_only_names ());
+  Alcotest.(check (list string))
+    "last-turn-safe tools project from descriptors"
+    [ "keeper_board_comment"
+    ; "keeper_board_curation_submit"
+    ; "keeper_board_post"
+    ; "keeper_broadcast"
+    ; "keeper_context_status"
+    ; "keeper_task_done"
+    ; "keeper_task_submit_for_verification"
+    ; "keeper_tasks_list"
+    ; "keeper_time_now"
+    ; "keeper_tool_search"
+    ; "masc_tasks"
+    ; "masc_transition"
+    ; "masc_web_fetch"
+    ; "masc_web_search"
+    ; "tool_execute"
+    ; "tool_read_file"
+    ; "tool_search_files"
+    ]
+    (Descriptor.keeper_last_turn_safe_names ());
+  Alcotest.(check bool)
+    "last-turn-safe fallback includes SDK core extend_turns"
+    true
+    (List.mem "extend_turns" (Policy.last_turn_safe_tool_names ()));
   Alcotest.(check bool)
     "approval_pending does not require MCP session"
     false


### PR DESCRIPTION
## Summary

- Add `policy.last_turn_safe` to keeper tool descriptors and expose `keeper_last_turn_safe_names`.
- Replace the hardcoded `last_turn_safe_tool_names` config-unloaded fallback list with the descriptor projection plus the SDK/core `extend_turns` exception.
- Pin the projected last-turn-safe set in `test_keeper_tool_descriptor_registry_integrity` and record the RFC-0191 progress note.

## Product impact

Keeps the operator-editable `config/tool_policy.toml [groups.last_turn_safe]` behavior intact when config is loaded, while removing another per-tool policy string list from keeper runtime code.

## Evidence

- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=/tmp/masc-dune-last-turn-safe-policy dune build --root . @install test/test_keeper_tool_descriptor_registry_integrity.exe --force`
- `/tmp/masc-dune-last-turn-safe-policy/default/test/test_keeper_tool_descriptor_registry_integrity.exe`
- `scripts/audit-keeper-tool-boundary-matrix.sh`
- `scripts/lint/tool-keeper-boundary-ratchet.sh`
- `ocamlformat --check lib/keeper/keeper_tool_descriptor.ml lib/keeper/keeper_tool_descriptor.mli lib/keeper/keeper_tool_policy.ml test/test_keeper_tool_descriptor_registry_integrity.ml`

## Direct evidence

schema_version: 1
direct_ratio: 5/5
provenance: direct

Changed files and local verification were produced in the branch worktree on top of current `origin/main`.

## Review evidence

- Confirmed `rg -n "~fallback:\\[|keeper_board_post.*keeper_board_comment|keeper_last_turn_safe_names" ...` no longer finds the old policy fallback list.
- Confirmed RFC-0191 keeps TOML as operator-tunable and descriptor policy as the source-of-truth layer.

## Linked issue

- RFC-0191 descriptor policy SSOT follow-up.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`codex/descriptor-last-turn-safe-policy-20260604` → `main` · 1 commit(s) · synced 2026-06-04T02:28:34Z

| sha | subject | date |
|---|---|---|
| `6572a85ff` | refactor(keeper): derive last-turn fallback from descriptors | 2026-06-04 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->