### PR TITLE
fix(keeper): preserve visible path projection boundary

### DIFF
--- a/lib/keeper/keeper_tool_execute_path.ml
+++ b/lib/keeper/keeper_tool_execute_path.ml
@@ -421,6 +421,20 @@ let resolve_tool_write_cwd
       ~(args : Yojson.Safe.t)
   =
   let raw_cwd = Safe_ops.json_string ~default:"" "cwd" args |> String.trim in
+  let raw_cwd_is_own_container_path =
+    if Filename.is_relative raw_cwd
+       || meta.sandbox_profile <> Keeper_types_profile_sandbox.Docker
+    then false
+    else (
+      let normalize path =
+        Keeper_alerting_path.normalize_path_for_check path
+        |> Keeper_alerting_path.strip_trailing_slashes
+      in
+      let container_root = Keeper_sandbox.container_root meta.name |> normalize in
+      let raw_norm = normalize raw_cwd in
+      String.equal raw_norm container_root
+      || String.starts_with ~prefix:(container_root ^ "/") raw_norm)
+  in
   let resolved =
     if raw_cwd = ""
     then Ok (keeper_default_write_root ~config ~meta)
@@ -429,9 +443,12 @@ let resolve_tool_write_cwd
   match resolved with
   | Error _ as err -> err
   | Ok cwd when Fs_compat.file_exists cwd && Sys.is_directory cwd ->
-    (match validate_repo_cwd_ready ~config ~meta cwd with
-     | Ok () -> Ok cwd
-     | Error _ as err -> err)
+    if raw_cwd_is_own_container_path
+    then Ok cwd
+    else (
+      match validate_repo_cwd_ready ~config ~meta cwd with
+      | Ok () -> Ok cwd
+      | Error _ as err -> err)
   | Ok cwd ->
     if not (Fs_compat.file_exists cwd) then
       resolve_missing_cwd ~config ~meta cwd
@@ -549,44 +566,18 @@ let resolve_tool_read_path
     let fallback_path = if raw_path = "" then "." else raw_path in
     resolve_with_autocorrect fallback_path
   | Ok cwd ->
-    let resolved_raw_path =
-      if raw_path = "" then
-        cwd
-      else if not (Filename.is_relative raw_path) then
-        raw_path
-      else
-        (* Guard against playground path doubling: when cwd already
-           contains a playground prefix (e.g. .../playground/keeper/)
-           and raw_path also starts with a playground-relative segment
-           (e.g. ".masc/playground/keeper/repos"), concatenating would
-           produce a doubled path.  Detect and resolve against project
-           root instead. *)
-        let pg = Playground_paths.all_playgrounds_prefix in
-        let contains s sub =
-          let sl = String.length s and nl = String.length sub in
-          if nl > sl then false
-          else
-            let rec scan i =
-              if i + nl > sl then false
-              else if String.sub s i nl = sub then true
-              else scan (i + 1)
-            in scan 0
-        in
-        let cwd_has_pg = contains cwd pg in
-        let path_has_pg = contains raw_path pg in
-        if cwd_has_pg && path_has_pg then
-          raw_path
-        else
-          Filename.concat cwd raw_path
-    in
-    let resolver_path =
-      if raw_path = "" || Filename.is_relative raw_path then
-        Option.value ~default:resolved_raw_path
-          (project_relative_host_path ~config resolved_raw_path)
-      else
-        resolved_raw_path
-    in
-    resolve_with_autocorrect resolver_path
+    if raw_path = ""
+    then Ok cwd
+    else if
+      (not (Filename.is_relative raw_path)) || is_playground_lane_relative_path raw_path
+    then resolve_with_autocorrect raw_path
+    else
+      let projected_path = Filename.concat cwd raw_path in
+      resolve_projected_keeper_read_path
+        ~config
+        ~meta
+        ~raw_for_error:raw_path
+        ~projected_path
 
 let executable_file path =
   try

--- a/lib/keeper/keeper_tool_filesystem_runtime.ml
+++ b/lib/keeper/keeper_tool_filesystem_runtime.ml
@@ -54,6 +54,11 @@ type read_file_resolution_error =
       }
   | Read_path_error of string
 
+type read_file_resolver_input =
+  { resolver_path : string
+  ; projected_from_visible_cwd : bool
+  }
+
 let string_opt_nonempty name json =
   match Safe_ops.json_string_opt name json with
   | None -> None
@@ -89,20 +94,17 @@ let resolve_read_file_cwd ~(config : Workspace.config) ~(meta : keeper_meta) ~cw
             cwd))
 ;;
 
-let read_file_path_relative_to_project_root ~(config : Workspace.config) path =
-  match project_relative_host_path ~config path with
-  | Some relative -> relative
-  | None -> path
-;;
-
-let read_file_resolver_input ~(config : Workspace.config) ~cwd ~(raw_path : string) =
+let read_file_resolver_input ~cwd ~(raw_path : string) =
   let raw_path = String.trim raw_path in
   if
     raw_path = ""
     || (not (Filename.is_relative raw_path))
     || sandbox_rooted_relative_path raw_path
-  then raw_path
-  else Filename.concat cwd raw_path |> read_file_path_relative_to_project_root ~config
+  then { resolver_path = raw_path; projected_from_visible_cwd = false }
+  else
+    { resolver_path = Filename.concat cwd raw_path
+    ; projected_from_visible_cwd = true
+    }
 ;;
 
 let resolve_read_file_target
@@ -121,11 +123,9 @@ let resolve_read_file_target
   else match resolve_read_file_cwd ~config ~meta ~cwd with
   | Error e -> Error (Read_path_error e)
   | Ok cwd_abs ->
-    let resolver_input = read_file_resolver_input ~config ~cwd:cwd_abs ~raw_path in
+    let resolver_input = read_file_resolver_input ~cwd:cwd_abs ~raw_path in
     let resolve_once candidate =
-      match playground_relative_unless_allowed_root ~config ~meta candidate with
-      | Error e -> Error (Read_path_error e)
-      | Ok normalized ->
+      let resolve_alerting normalized =
         (match
            Keeper_alerting_path.resolve_keeper_read_path
              ~config
@@ -148,11 +148,39 @@ let resolve_read_file_target
          | Error rej ->
            Error
              (Read_path_error (Keeper_alerting_path.rejection_to_user_message rej)))
+      in
+      let resolve_shared candidate =
+        match resolve_keeper_read_path ~config ~meta ~raw_path:candidate with
+        | Ok _ as ok -> ok
+        | Error e -> Error (Read_path_error e)
+      in
+      let resolve_projected candidate =
+        match
+          resolve_projected_keeper_read_path
+            ~config
+            ~meta
+            ~raw_for_error:raw_path
+            ~projected_path:candidate
+        with
+        | Ok _ as ok -> ok
+        | Error e -> Error (Read_path_error e)
+      in
+      if resolver_input.projected_from_visible_cwd
+         || sandbox_rooted_relative_path candidate
+         || not (Filename.is_relative candidate)
+      then
+        if resolver_input.projected_from_visible_cwd
+        then resolve_projected candidate
+        else resolve_shared candidate
+      else (
+        match playground_relative_unless_allowed_root ~config ~meta candidate with
+        | Error e -> Error (Read_path_error e)
+        | Ok normalized -> resolve_alerting normalized)
     in
-    (match resolve_once resolver_input with
+    (match resolve_once resolver_input.resolver_path with
      | Ok _ as ok -> ok
      | Error original ->
-       (match Keeper_tool_execute_path.auto_correct_path ~meta resolver_input with
+       (match Keeper_tool_execute_path.auto_correct_path ~meta resolver_input.resolver_path with
         | Some corrected ->
           (match resolve_once corrected with
            | Ok _ as ok -> ok

--- a/lib/keeper/keeper_tool_shared_runtime.ml
+++ b/lib/keeper/keeper_tool_shared_runtime.ml
@@ -412,14 +412,22 @@ let project_relative_host_path ~(config : Workspace.config) (path : string) =
   else None
 ;;
 
+type playground_projection =
+  { projected_path : string
+  ; projected_from_visible : bool
+  }
+
+let raw_projection projected_path = { projected_path; projected_from_visible = false }
+let visible_projection projected_path = { projected_path; projected_from_visible = true }
+
 (* Bare filenames and canonical sandbox lanes default to the keeper sandbox,
    but rooted-looking relative paths (for example
    "workspace/..." or "lib/...") keep project-root/boundary semantics. *)
-let playground_relative_unless_allowed_root
+let playground_relative_projection_unless_allowed_root
       ~(config : Workspace.config)
       ~(meta : keeper_meta)
       (raw : string)
-  : (string, string) result
+  : (playground_projection, string) result
   =
   let trimmed = String.trim raw in
   let mapped_from_container, trimmed =
@@ -439,16 +447,149 @@ let playground_relative_unless_allowed_root
   in
   match rewrite_single_repo_relative_path ~config ~meta trimmed with
   | Error _ as err -> err
-  | Ok (Some rewritten) -> Ok rewritten
+  | Ok (Some rewritten) -> Ok (visible_projection rewritten)
   | Ok None ->
     if
       trimmed = ""
       || (not (Filename.is_relative trimmed))
       || (String.contains trimmed '/' && not (is_playground_lane_relative_path trimmed))
       || relative_path_targets_allowed_root ~meta trimmed
-    then Ok trimmed
+    then Ok (if mapped_from_container then visible_projection trimmed else raw_projection trimmed)
     else (
-      Ok (keeper_playground_relative_path ~meta trimmed))
+      Ok (visible_projection (keeper_playground_relative_path ~meta trimmed)))
+;;
+
+let playground_relative_unless_allowed_root ~config ~meta raw =
+  match playground_relative_projection_unless_allowed_root ~config ~meta raw with
+  | Error _ as err -> err
+  | Ok projection -> Ok projection.projected_path
+;;
+
+type projected_allowed_path =
+  { candidate : string
+  ; search_roots : string list
+  }
+
+let user_message_error (rej : Keeper_alerting_path.keeper_path_rejection) =
+  Keeper_alerting_path.rejection_to_telemetry rej;
+  Error (Keeper_alerting_path.rejection_to_user_message rej)
+;;
+
+let resolve_projected_allowed_path
+      ~(config : Workspace.config)
+      ~(allowed_paths : string list)
+      ~(raw_for_error : string)
+      ~(projected_path : string)
+  : (projected_allowed_path, string) result
+  =
+  let root = Keeper_alerting_path.project_root_of_config config in
+  let candidate =
+    if Filename.is_relative projected_path
+    then Filename.concat root projected_path
+    else projected_path
+  in
+  let root_norm =
+    Keeper_alerting_path.normalize_path_for_check root
+    |> Keeper_alerting_path.strip_trailing_slashes
+  in
+  let target_norm =
+    Keeper_alerting_path.normalize_path_for_check candidate
+    |> Keeper_alerting_path.strip_trailing_slashes
+  in
+  let within_root =
+    target_norm = root_norm || String.starts_with ~prefix:(root_norm ^ "/") target_norm
+  in
+  if not within_root
+  then user_message_error (Keeper_alerting_path.Outside_project_root { raw = raw_for_error })
+  else (
+    let allowed_norms =
+      if allowed_paths = []
+      then []
+      else
+        allowed_paths
+        |> List.filter_map (Keeper_alerting_path.normalize_allowed_path_for_check ~root:root_norm)
+    in
+    if allowed_paths <> [] && allowed_norms = []
+    then
+      user_message_error
+        (Keeper_alerting_path.Allowed_paths_normalized_empty
+           { count = List.length allowed_paths })
+    else (
+      let within_allowed =
+        allowed_norms = []
+        || Keeper_alerting_path.is_within_allowed_norms ~target_norm allowed_norms
+      in
+      if not within_allowed
+      then user_message_error (Keeper_alerting_path.Outside_sandbox { raw = raw_for_error })
+      else (
+        let search_roots = if allowed_norms = [] then [ root_norm ] else allowed_norms in
+        Ok { candidate; search_roots })))
+;;
+
+let resolve_projected_read_path
+      ~(config : Workspace.config)
+      ~(allowed_paths : string list)
+      ~(raw_for_error : string)
+      ~(projected_path : string)
+  : (string, string) result
+  =
+  match
+    resolve_projected_allowed_path
+      ~config
+      ~allowed_paths
+      ~raw_for_error
+      ~projected_path
+  with
+  | Error _ as err -> err
+  | Ok { candidate; search_roots } ->
+    if
+      Keeper_alerting_path.path_exists candidate
+      || Keeper_alerting_path.allows_missing_leaf_read
+           ~raw:raw_for_error
+           ~candidate
+    then Ok candidate
+    else (
+      match
+        Keeper_alerting_path.maybe_resolve_missing_relative_read_path
+          ~roots:search_roots
+          ~raw_path:raw_for_error
+      with
+      | Ok (Some resolved) -> Ok resolved
+      | Ok None ->
+        user_message_error
+          (Keeper_alerting_path.Not_found_relative { raw = raw_for_error })
+      | Error e -> user_message_error e)
+;;
+
+let resolve_projected_write_path
+      ~(config : Workspace.config)
+      ~(allowed_paths : string list)
+      ~(raw_for_error : string)
+      ~(projected_path : string)
+  : (string, string) result
+  =
+  match
+    resolve_projected_allowed_path
+      ~config
+      ~allowed_paths
+      ~raw_for_error
+      ~projected_path
+  with
+  | Error _ as err -> err
+  | Ok { candidate; _ } -> Ok candidate
+;;
+
+let resolve_projected_keeper_read_path
+      ~(config : Workspace.config)
+      ~(meta : keeper_meta)
+      ~(raw_for_error : string)
+      ~(projected_path : string)
+  =
+  resolve_projected_read_path
+    ~config
+    ~allowed_paths:(keeper_effective_allowed_paths ~meta)
+    ~raw_for_error
+    ~projected_path
 ;;
 
 let resolve_keeper_path
@@ -456,13 +597,19 @@ let resolve_keeper_path
       ~(meta : keeper_meta)
       ~(raw_path : string)
   =
-  match playground_relative_unless_allowed_root ~config ~meta raw_path with
+  match playground_relative_projection_unless_allowed_root ~config ~meta raw_path with
   | Error e -> Error e
-  | Ok normalized ->
+  | Ok { projected_path; projected_from_visible = true } ->
+    resolve_projected_write_path
+      ~config
+      ~allowed_paths:(keeper_effective_write_allowed_paths ~meta)
+      ~raw_for_error:raw_path
+      ~projected_path
+  | Ok { projected_path; projected_from_visible = false } ->
     match Keeper_alerting_path.resolve_keeper_target_path
       ~config
       ~allowed_paths:(keeper_effective_write_allowed_paths ~meta)
-      ~raw_path:normalized
+      ~raw_path:projected_path
     with
     | Error rej -> Error (Keeper_alerting_path.rejection_to_user_message rej)
     | Ok p -> Ok p
@@ -473,13 +620,19 @@ let resolve_keeper_read_path
       ~(meta : keeper_meta)
       ~(raw_path : string)
   =
-  match playground_relative_unless_allowed_root ~config ~meta raw_path with
+  match playground_relative_projection_unless_allowed_root ~config ~meta raw_path with
   | Error e -> Error e
-  | Ok normalized ->
+  | Ok { projected_path; projected_from_visible = true } ->
+    resolve_projected_read_path
+      ~config
+      ~allowed_paths:(keeper_effective_allowed_paths ~meta)
+      ~raw_for_error:raw_path
+      ~projected_path
+  | Ok { projected_path; projected_from_visible = false } ->
     match Keeper_alerting_path.resolve_keeper_read_path
       ~config
       ~allowed_paths:(keeper_effective_allowed_paths ~meta)
-      ~raw_path:normalized
+      ~raw_path:projected_path
     with
     | Error rej -> Error (Keeper_alerting_path.rejection_to_user_message rej)
     | Ok p -> Ok p

--- a/lib/keeper/keeper_tool_shared_runtime.mli
+++ b/lib/keeper/keeper_tool_shared_runtime.mli
@@ -138,6 +138,16 @@ val resolve_keeper_read_path
   -> raw_path:string
   -> (string, string) result
 
+(** Resolve an already projected host path that came from a
+    Keeper-visible [cwd] + relative [file_path] composition. [raw_for_error]
+    is the model-facing path to keep diagnostics in the visible namespace. *)
+val resolve_projected_keeper_read_path
+  :  config:Workspace.config
+  -> meta:Keeper_meta_contract.keeper_meta
+  -> raw_for_error:string
+  -> projected_path:string
+  -> (string, string) result
+
 val keeper_agent_sender : meta:Keeper_meta_contract.keeper_meta -> string
 
 (** Clamp [args.limit] to [1..200] (default 40) for read-only

--- a/test/dune
+++ b/test/dune
@@ -2019,6 +2019,11 @@
 
 (include stanzas/test_tool_resource_gate.inc)
 
+(test
+ (name test_keeper_visible_path_projection)
+ (modules test_keeper_visible_path_projection)
+ (libraries masc_test_deps))
+
 (executable
  (name test_config_runtime_split)
  (modules test_config_runtime_split)

--- a/test/test_keeper_visible_path_projection.ml
+++ b/test/test_keeper_visible_path_projection.ml
@@ -1,0 +1,217 @@
+module Workspace = Masc.Workspace
+module Json = Yojson.Safe.Util
+module Keeper_registry = Masc.Keeper_registry
+module Keeper_sandbox = Masc.Keeper_sandbox
+module Keeper_tool_filesystem_runtime = Masc.Keeper_tool_filesystem_runtime
+module Keeper_tool_shared_runtime = Masc.Keeper_tool_shared_runtime
+module Keeper_types_profile_sandbox = Masc.Keeper_types_profile_sandbox
+
+let temp_dir () =
+  let d = Filename.temp_file "keeper-visible-path-projection-" "" in
+  Unix.unlink d;
+  Unix.mkdir d 0o755;
+  d
+;;
+
+let rec ensure_dir path =
+  if path = "" || path = "." || path = "/"
+  then ()
+  else if Sys.file_exists path
+  then ()
+  else (
+    let parent = Filename.dirname path in
+    if parent <> path then ensure_dir parent;
+    Unix.mkdir path 0o755)
+;;
+
+let cleanup_dir dir =
+  let rec rm path =
+    match Unix.lstat path with
+    | { Unix.st_kind = Unix.S_DIR; _ } ->
+      Array.iter (fun name -> rm (Filename.concat path name)) (Sys.readdir path);
+      Unix.rmdir path
+    | _ -> Unix.unlink path
+    | exception Unix.Unix_error _ -> ()
+  in
+  try rm dir with
+  | _ -> ()
+;;
+
+let write_file path content =
+  ensure_dir (Filename.dirname path);
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc content)
+;;
+
+let make_meta ?(sandbox = Keeper_types_profile_sandbox.Local) name =
+  let json =
+    `Assoc
+      [ "name", `String name
+      ; "agent_name", `String ("agent-" ^ name)
+      ; "trace_id", `String ("trace-" ^ name)
+      ; "goal", `String "visible path projection test"
+      ; ( "sandbox_profile"
+        , `String (Keeper_types_profile_sandbox.sandbox_profile_to_string sandbox) )
+      ]
+  in
+  match Masc_test_deps.meta_of_json_fixture json with
+  | Ok meta -> meta
+  | Error e -> Alcotest.fail e
+;;
+
+let with_eio_fs f =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Process_eio.init
+    ~cwd_default:(Eio.Stdenv.cwd env)
+    ~proc_mgr:(Eio.Stdenv.process_mgr env)
+    ~clock:(Eio.Stdenv.clock env);
+  f ()
+;;
+
+let setup ?sandbox f =
+  with_eio_fs
+  @@ fun () ->
+  let base = temp_dir () in
+  ensure_dir (Filename.concat base Common.masc_dirname);
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base)
+    (fun () ->
+       Keeper_registry.clear ();
+       let config = Workspace.default_config base in
+       let meta = make_meta ?sandbox "tester" in
+       let playground = Keeper_sandbox.host_root_abs_of_meta ~config meta in
+       ensure_dir playground;
+       ignore (Keeper_registry.register ~base_path:base meta.name meta);
+       f ~config ~meta ~playground)
+;;
+
+let parse raw = Yojson.Safe.from_string raw
+
+let parse_ok raw =
+  parse raw |> Json.member "ok" |> Json.to_bool_option |> Option.value ~default:false
+;;
+
+let parse_string key raw = parse raw |> Json.member key |> Json.to_string_option
+
+let allow_repo ~config ~(meta : Masc.Keeper_meta_contract.keeper_meta) repo_id =
+  let mapping : Repo_manager_types.keeper_repo_mapping =
+    { keeper_id = meta.name
+    ; repository_ids = [ repo_id ]
+    }
+  in
+  match Keeper_repo_mapping.save_mapping ~base_path:config.Workspace.base_path mapping with
+  | Ok () -> ()
+  | Error e -> Alcotest.fail ("failed to seed keeper repo mapping: " ^ e)
+;;
+
+let test_visible_mind_read_resolves_to_private_storage () =
+  setup
+  @@ fun ~config ~meta ~playground ->
+  let target = Filename.concat playground "mind/README.md" in
+  write_file target "visible mind\n";
+  match
+    Keeper_tool_shared_runtime.resolve_keeper_read_path
+      ~config
+      ~meta
+      ~raw_path:"mind/README.md"
+  with
+  | Ok path -> Alcotest.(check string) "resolved path" target path
+  | Error e -> Alcotest.fail ("visible mind path should resolve: " ^ e)
+;;
+
+let test_direct_private_storage_read_stays_blocked () =
+  setup
+  @@ fun ~config ~meta ~playground:_ ->
+  let private_raw =
+    Masc.Keeper_sandbox.allowed_root_rel_of_meta ~meta ^ "mind/README.md"
+  in
+  match
+    Keeper_tool_shared_runtime.resolve_keeper_read_path
+      ~config
+      ~meta
+      ~raw_path:private_raw
+  with
+  | Ok path -> Alcotest.fail ("direct private storage path should be blocked: " ^ path)
+  | Error e ->
+    Alcotest.(check bool)
+      "task state/private path blocked"
+      true
+      (String.starts_with ~prefix:"task_state_file_path_blocked:" e)
+;;
+
+let test_read_with_visible_repo_cwd_and_relative_file_path () =
+  setup
+  @@ fun ~config ~meta ~playground ->
+  allow_repo ~config ~meta "masc";
+  let target = Filename.concat playground "repos/masc/README.md" in
+  write_file target "repo readme\n";
+  let raw =
+    Keeper_tool_filesystem_runtime.handle_read_file
+      ~turn_sandbox_factory:None
+      ~config
+      ~keeper_name:meta.name
+      ~args:
+        (`Assoc
+            [ "cwd", `String "repos/masc"
+            ; "path", `String "README.md"
+            ; "max_bytes", `Int 4096
+            ])
+  in
+  if not (parse_ok raw) then Alcotest.failf "expected Read ok, got: %s" raw;
+  Alcotest.(check (option string))
+    "content"
+    (Some "repo readme\n")
+    (parse_string "content" raw)
+;;
+
+let test_write_visible_mind_path () =
+  setup ~sandbox:Keeper_types_profile_sandbox.Docker
+  @@ fun ~config ~meta ~playground ->
+  let raw =
+    Keeper_tool_filesystem_runtime.handle_file_write
+      ~turn_sandbox_factory:None
+      ~config
+      ~keeper_name:meta.name
+      ~args:
+        (`Assoc
+            [ "path", `String "mind/allowed.txt"
+            ; "mode", `String "overwrite"
+            ; "content", `String "allowed"
+            ])
+  in
+  if not (parse_ok raw) then Alcotest.failf "expected Write ok, got: %s" raw;
+  Alcotest.(check string)
+    "content landed"
+    "allowed"
+    (Fs_compat.load_file (Filename.concat playground "mind/allowed.txt"))
+;;
+
+let () =
+  Alcotest.run
+    "Keeper_visible_path_projection"
+    [ ( "shared_projection"
+      , [ Alcotest.test_case
+            "visible mind read resolves to private storage"
+            `Quick
+            test_visible_mind_read_resolves_to_private_storage
+        ; Alcotest.test_case
+            "direct private storage read stays blocked"
+            `Quick
+            test_direct_private_storage_read_stays_blocked
+        ] )
+    ; ( "file_tools"
+      , [ Alcotest.test_case
+            "Read cwd=repos/<repo> plus relative file path"
+            `Quick
+            test_read_with_visible_repo_cwd_and_relative_file_path
+        ; Alcotest.test_case
+            "Write visible mind path"
+            `Quick
+            test_write_visible_mind_path
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary
- Preserve the boundary between Keeper-visible paths and private playground storage paths.
- Route projected visible paths through typed allowed-path validation instead of re-feeding private playground storage strings into task-state path blocking.
- Make Read cwd+relative file resolution and search-files read path resolution use the same projected-read boundary.
- Keep direct private storage paths blocked while allowing visible `mind/...`, `repos/...`, and `cwd="repos/<repo>"` flows.

## Verification
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_visible_path_projection.exe`
- `./_build/default/test/test_keeper_visible_path_projection.exe`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_tool_search_files_containment.exe test/test_keeper_fs_edit_containment.exe test/test_keeper_fs_edit_patch.exe`
- `./_build/default/test/test_keeper_tool_search_files_containment.exe`
- `./_build/default/test/test_keeper_fs_edit_containment.exe`
- `./_build/default/test/test_keeper_fs_edit_patch.exe`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_tool_execute_safety.exe`

## Known Local Suite State
- `./_build/default/test/test_keeper_tool_execute_safety.exe` still has 4 failures in existing allowlist/readonly/timeout expectations: allowed `grep --include`, `make test` readonly classification, wrapped git repo arg allowlist ordering, recursive grep timeout floor.
- The focused projection/search/file tests above are green.
