### PR TITLE
refactor(keeper): decouple surface class from MCP catalog

### DIFF
--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -117,6 +117,14 @@ let tool_surface_class_of_string raw =
 let tool_surface_class_to_yojson cls =
   `String (tool_surface_class_to_string cls)
 
+let tool_surface_class_for_tool_names = function
+  | [] -> Surface_none
+  | names
+    when List.for_all
+           Keeper_tool_descriptor_resolution.is_public_mcp_surface_name
+           names -> Surface_public_only
+  | _ -> Surface_mixed
+
 type tool_surface_metrics =
   { turn_lane : turn_lane
   ; tool_surface_class : tool_surface_class

--- a/lib/keeper/keeper_agent_tool_surface.mli
+++ b/lib/keeper/keeper_agent_tool_surface.mli
@@ -83,6 +83,7 @@ type tool_surface_class =
 val tool_surface_class_to_string : tool_surface_class -> string
 val tool_surface_class_of_string : string -> tool_surface_class option
 val tool_surface_class_to_yojson : tool_surface_class -> Yojson.Safe.t
+val tool_surface_class_for_tool_names : string list -> tool_surface_class
 
 (** Diagnostic surface metrics emitted into trajectory entries. *)
 type tool_surface_metrics =

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -703,11 +703,8 @@ let prepare_agent_setup
     in
     let visible_tool_count = List.length turn_visible_tool_names in
     let tool_surface_class : Keeper_agent_tool_surface.tool_surface_class =
-      if visible_tool_count = 0
-      then Surface_none
-      else if List.for_all Tool_catalog.is_public_mcp turn_visible_tool_names
-      then Surface_public_only
-      else Surface_mixed
+      Keeper_agent_tool_surface.tool_surface_class_for_tool_names
+        turn_visible_tool_names
     in
     let tool_requirement =
       if visible_tool_count = 0 then No_tools else Optional

--- a/lib/keeper/keeper_tool_descriptor_resolution.ml
+++ b/lib/keeper/keeper_tool_descriptor_resolution.ml
@@ -44,6 +44,15 @@ let public_names_for_allowed_internal_names internal_names =
   |> Keeper_types_profile_toml_normalizers.dedupe_keep_order
 ;;
 
+let is_public_mcp_surface_name tool_name =
+  let stripped = Keeper_tool_alias.strip_mcp_masc_prefix tool_name in
+  match descriptor_for_tool_name stripped with
+  | Some descriptor ->
+    String.equal descriptor.Keeper_tool_descriptor.public_name stripped
+    && Tool_catalog.is_public_mcp stripped
+  | None -> false
+;;
+
 let effect_domain_for_tool_name tool_name =
   match descriptor_for_tool_name tool_name with
   | Some descriptor -> descriptor.Keeper_tool_descriptor.policy.effect_domain

--- a/lib/keeper/keeper_tool_descriptor_resolution.mli
+++ b/lib/keeper/keeper_tool_descriptor_resolution.mli
@@ -15,6 +15,12 @@ val public_name_for_internal : string -> string option
 
 val public_names_for_allowed_internal_names : string list -> string list
 
+(** [is_public_mcp_surface_name name] answers the narrow diagnostic question
+    "is this runtime-observed name the descriptor-backed public MCP surface
+    name?" Keep per-turn keeper classification behind this projection instead
+    of letting turn setup query the MCP catalog directly. *)
+val is_public_mcp_surface_name : string -> bool
+
 val effect_domain_for_tool_name : string -> Tool_catalog.effect_domain option
 
 val capability_has : Tool_capability.kind -> string -> bool

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -23,6 +23,7 @@ module Policy = Masc.Keeper_tool_policy
 module Exec = Masc.Keeper_tool_dispatch_runtime
 module Registry = Masc.Keeper_tool_registry
 module Resolution = Masc.Keeper_tool_descriptor_resolution
+module Surface = Masc.Keeper_agent_tool_surface
 module Tool_board_registry = Masc.Tool_board_registry
 
 let all_descriptors () : Descriptor.t list = Descriptor.all_descriptors ()
@@ -65,6 +66,29 @@ let descriptor_internal_name_set () =
     (fun d -> Hashtbl.replace tbl d.Descriptor.internal_name ())
     (all_descriptors ());
   tbl
+;;
+
+let contains_substring haystack needle =
+  let haystack_len = String.length haystack in
+  let needle_len = String.length needle in
+  if needle_len = 0
+  then true
+  else
+    let rec loop i =
+      i + needle_len <= haystack_len
+      &&
+      (String.equal (String.sub haystack i needle_len) needle || loop (i + 1))
+    in
+    loop 0
+;;
+
+let source_path rel =
+  let source_root =
+    match Sys.getenv_opt "DUNE_SOURCEROOT" with
+    | Some root -> root
+    | None -> Sys.getcwd ()
+  in
+  Filename.concat source_root rel
 ;;
 
 let find_duplicates ~key (xs : Descriptor.t list) : (string * int) list =
@@ -405,6 +429,44 @@ let test_public_name_projection_uses_descriptor_resolution () =
        [ "tool_execute"; "tool_search_files" ])
 ;;
 
+let test_surface_class_uses_keeper_projection () =
+  Alcotest.(check string)
+    "empty surface"
+    "none"
+    (Surface.tool_surface_class_to_string
+       (Surface.tool_surface_class_for_tool_names []));
+  Alcotest.(check string)
+    "descriptor-backed public MCP surface"
+    "public_only"
+    (Surface.tool_surface_class_to_string
+       (Surface.tool_surface_class_for_tool_names
+          [ "masc_tasks"; "mcp__masc__masc_transition" ]));
+  Alcotest.(check string)
+    "LLM-native keeper aliases are not public MCP"
+    "mixed"
+    (Surface.tool_surface_class_to_string
+       (Surface.tool_surface_class_for_tool_names [ "Execute" ]));
+  Alcotest.(check string)
+    "keeper private surface stays mixed"
+    "mixed"
+    (Surface.tool_surface_class_to_string
+       (Surface.tool_surface_class_for_tool_names
+          [ "keeper_board_post"; "masc_tasks" ]))
+;;
+
+let test_run_tools_setup_has_no_direct_public_mcp_catalog_read () =
+  let ic = open_in (source_path "lib/keeper/keeper_run_tools_setup.ml") in
+  let source =
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr ic)
+      (fun () -> really_input_string ic (in_channel_length ic))
+  in
+  Alcotest.(check bool)
+    "keeper_run_tools_setup does not classify with Tool_catalog.is_public_mcp"
+    false
+    (contains_substring source "Tool_catalog.is_public_mcp")
+;;
+
 let test_mutation_boundary_delegates_to_descriptor_policy () =
   let search_input = `Assoc [ "pattern", `String "Keeper_tool_descriptor" ] in
   Alcotest.(check bool)
@@ -602,6 +664,14 @@ let () =
             "public names project through descriptor resolution"
             `Quick
             test_public_name_projection_uses_descriptor_resolution
+        ; test_case
+            "tool surface class uses keeper projection"
+            `Quick
+            test_surface_class_uses_keeper_projection
+        ; test_case
+            "keeper_run_tools_setup avoids public MCP catalog classifier"
+            `Quick
+            test_run_tools_setup_has_no_direct_public_mcp_catalog_read
         ; test_case
             "mutation boundary delegates to descriptor policy"
             `Quick


### PR DESCRIPTION
## Summary
- Move keeper per-turn surface classification behind `Keeper_agent_tool_surface.tool_surface_class_for_tool_names`.
- Centralize the narrow public-MCP diagnostic projection in `Keeper_tool_descriptor_resolution` instead of querying `Tool_catalog.is_public_mcp` inside `keeper_run_tools_setup`.
- Add regression coverage for public-only/mixed classification and a source guard that keeps `keeper_run_tools_setup` off the direct MCP catalog classifier.

## Plan reference
- Follows the Tool⊥Keeper MCP-surface awareness cut from the boundary docs: leak #1 (`keeper_run_tools_setup` self-classifying via `Tool_catalog.is_public_mcp`).

## Verification
- env DUNE_CACHE=disabled DUNE_BUILD_DIR=/tmp/masc-dune-keeper-surface-decouple dune build --root . @install test/test_keeper_tool_descriptor_registry_integrity.exe --force
- /tmp/masc-dune-keeper-surface-decouple/default/test/test_keeper_tool_descriptor_registry_integrity.exe
- rg -n "Tool_catalog\.is_public_mcp" lib/keeper/keeper_run_tools_setup.ml (no matches)
- git diff --check
- scripts/audit-keeper-tool-boundary-matrix.sh
- bash scripts/lint/tool-keeper-boundary-ratchet.sh --print