### PR TITLE
refactor(keeper): decouple progress names from tool enum

### DIFF
--- a/lib/keeper/keeper_meta_tool_access.ml
+++ b/lib/keeper/keeper_meta_tool_access.ml
@@ -8,12 +8,7 @@
 open Keeper_types_profile
 
 let tool_names_include_board name_list =
-  List.exists
-    (fun name ->
-       match Tool_name.of_string name with
-       | Some tool -> Tool_name.is_board tool
-       | None -> false)
-    name_list
+  List.exists Keeper_tool_name.is_board_surface_name name_list
 ;;
 
 let normalize_tool_names names =

--- a/lib/keeper/keeper_meta_tool_access.mli
+++ b/lib/keeper/keeper_meta_tool_access.mli
@@ -4,8 +4,9 @@
     [keeper_meta.tool_access : string list].  There is no wrapper type;
     the allowlist IS the policy. *)
 
-(** Returns true if any name in the list resolves to a [Tool_name.is_board]
-    tool. Used to detect implicit board surface. *)
+(** Returns true if any name in the list resolves to a keeper board wrapper or
+    legacy public [masc_board_*] surface. Used to detect implicit board
+    surface. *)
 val tool_names_include_board : string list -> bool
 
 (** Trim, drop blanks, dedupe (preserve first-seen order). *)

--- a/lib/keeper/keeper_tool_name.ml
+++ b/lib/keeper/keeper_tool_name.ml
@@ -155,3 +155,86 @@ let of_string = function
 ;;
 
 let pp fmt t = Format.pp_print_string fmt (to_string t)
+;;
+
+let legacy_masc_claim_next_name = "masc_claim_next"
+let legacy_masc_deliver_name = "masc_deliver"
+
+let is_keeper_board_tool = function
+  | Board_comment
+  | Board_comment_vote
+  | Board_curation_read
+  | Board_curation_submit
+  | Board_get
+  | Board_list
+  | Board_post
+  | Board_search
+  | Board_stats
+  | Board_sub_board_create
+  | Board_sub_board_delete
+  | Board_sub_board_get
+  | Board_sub_board_list
+  | Board_sub_board_update
+  | Board_vote -> true
+  | Execute
+  | Broadcast
+  | Context_status
+  | Fs_edit
+  | Fs_write
+  | Fs_read
+  | Ide_annotate
+  | Handoff
+  | Library_read
+  | Library_search
+  | Memory_search
+  | Memory_write
+  | Search_files
+  | Stay_silent
+  | Task_claim
+  | Task_create
+  | Task_done
+  | Task_submit_for_verification
+  | Task_force_done
+  | Task_force_release
+  | Tasks_audit
+  | Tasks_list
+  | Time_now
+  | Tool_search
+  | Tools_list
+  | Voice_agent
+  | Voice_listen
+  | Voice_session_end
+  | Voice_session_start
+  | Voice_sessions
+  | Voice_speak -> false
+;;
+
+let legacy_masc_board_surface_names =
+  [ "masc_board_cleanup"
+  ; "masc_board_comment"
+  ; "masc_board_comment_vote"
+  ; "masc_board_curation_read"
+  ; "masc_board_curation_submit"
+  ; "masc_board_delete"
+  ; "masc_board_get"
+  ; "masc_board_hearths"
+  ; "masc_board_list"
+  ; "masc_board_post"
+  ; "masc_board_profile"
+  ; "masc_board_reaction"
+  ; "masc_board_search"
+  ; "masc_board_stats"
+  ; "masc_board_sub_board_create"
+  ; "masc_board_sub_board_delete"
+  ; "masc_board_sub_board_get"
+  ; "masc_board_sub_board_list"
+  ; "masc_board_sub_board_update"
+  ; "masc_board_vote"
+  ]
+;;
+
+let is_board_surface_name name =
+  match of_string name with
+  | Some tool -> is_keeper_board_tool tool
+  | None -> List.mem name legacy_masc_board_surface_names
+;;

--- a/lib/keeper/keeper_tool_name.mli
+++ b/lib/keeper/keeper_tool_name.mli
@@ -56,3 +56,13 @@ type t =
 val to_string : t -> string
 val of_string : string -> t option
 val pp : Format.formatter -> t -> unit
+
+(** Public MCP-client names still accepted while runtime descriptors project
+    keeper-owned tools onto the public MCP surface. *)
+val legacy_masc_claim_next_name : string
+
+val legacy_masc_deliver_name : string
+
+(** Returns true for keeper board wrapper names and legacy public
+    [masc_board_*] names without depending on the central [Tool_name] enum. *)
+val is_board_surface_name : string -> bool

--- a/lib/keeper/keeper_tool_progress.ml
+++ b/lib/keeper/keeper_tool_progress.ml
@@ -53,9 +53,7 @@ let effect_of_progress_class = function
 ;;
 
 let claim_context_tool_names : string list =
-  [ Tool_name.Task_name.to_string Tool_name.Task_name.Claim_next
-  ; Keeper_tool_name.(to_string Task_claim)
-  ]
+  [ Keeper_tool_name.legacy_masc_claim_next_name; Keeper_tool_name.(to_string Task_claim) ]
 ;;
 
 let completion_tool_names : string list =
@@ -67,7 +65,7 @@ let completion_tool_names : string list =
      breaker). Without this, 4+ events/day were rejected as passive_only even
      though the LLM had decided no fit (sangsu/janitor/taskmaster on 2026-04-27
      00:17-00:58 UTC, idle_seconds 28-40h, claimable_count 44-46). *)
-  Tool_name.(to_string (Masc Deliver))
+  Keeper_tool_name.legacy_masc_deliver_name
   :: List.map
        Keeper_tool_name.to_string
        Keeper_tool_name.
@@ -81,36 +79,17 @@ let completion_tool_names : string list =
 
 let is_claim_tool_name name =
   let name = Keeper_tool_resolution.canonical_tool_name name in
-  (match Keeper_tool_name.of_string name with
-   | Some Task_claim -> true
-   | _ -> false)
-  || (match Tool_name.of_string name with
-      | Some
-          (Tool_name.Masc
-             (Tool_name.Masc.Domain
-                (Tool_name.Domain_tool.Task Tool_name.Task_name.Claim_next))) ->
-        true
-      | _ -> false)
+  List.mem name claim_context_tool_names
 ;;
 
 let is_claim_context_tool_name name =
   let name = Keeper_tool_resolution.canonical_tool_name name in
-  let canonical_name =
-    match Tool_name.of_string name with
-    | Some tool -> Tool_name.to_string tool
-    | None -> name
-  in
-  List.mem canonical_name claim_context_tool_names
+  List.mem name claim_context_tool_names
 ;;
 
 let is_completion_tool_name name =
   let name = Keeper_tool_resolution.canonical_tool_name name in
-  let canonical_name =
-    match Tool_name.of_string name with
-    | Some tool -> Tool_name.to_string tool
-    | None -> name
-  in
-  List.mem canonical_name completion_tool_names
+  List.mem name completion_tool_names
 ;;
 
 let is_stay_silent_tool_name name =

--- a/test/test_keeper_unified_claim_progress.ml
+++ b/test/test_keeper_unified_claim_progress.ml
@@ -1,6 +1,7 @@
 open Alcotest
 
 module KAR = Masc.Keeper_agent_run
+module KMA = Masc.Keeper_meta_tool_access
 module KTP = Masc.Keeper_tool_progress
 
 let test_claim_tool_classification_covers_supported_claim_tools () =
@@ -29,6 +30,42 @@ let test_claim_tool_classification_covers_supported_claim_tools () =
     "task list is not claim tool"
     false
     (KTP.is_claim_tool_name "keeper_tasks_list")
+;;
+
+let test_completion_tool_classification_covers_keeper_and_public_projection () =
+  check
+    bool
+    "keeper task done is completion"
+    true
+    (KTP.is_completion_tool_name "keeper_task_done");
+  check
+    bool
+    "public masc deliver is completion"
+    true
+    (KTP.is_completion_tool_name "masc_deliver");
+  check
+    bool
+    "task list is not completion"
+    false
+    (KTP.is_completion_tool_name "keeper_tasks_list")
+;;
+
+let test_board_tool_access_uses_keeper_owned_surface_names () =
+  check
+    bool
+    "keeper board wrapper counts as board surface"
+    true
+    (KMA.tool_names_include_board [ "keeper_board_post" ]);
+  check
+    bool
+    "legacy public board name counts as board surface"
+    true
+    (KMA.tool_names_include_board [ "masc_board_post" ]);
+  check
+    bool
+    "non-board keeper task tool does not count as board surface"
+    false
+    (KMA.tool_names_include_board [ "keeper_task_claim" ])
 ;;
 
 let test_claim_contract_result_counts_initial_claim_as_execution () =
@@ -108,6 +145,14 @@ let () =
             "claim tool classification covers supported claim tools"
             `Quick
             test_claim_tool_classification_covers_supported_claim_tools
+        ; test_case
+            "completion classification covers keeper and public projection"
+            `Quick
+            test_completion_tool_classification_covers_keeper_and_public_projection
+        ; test_case
+            "board access check uses keeper-owned surface names"
+            `Quick
+            test_board_tool_access_uses_keeper_owned_surface_names
         ; test_case
             "initial claim counts as contract progress"
             `Quick


### PR DESCRIPTION
Summary:
- move legacy public claim/deliver and board surface projection into Keeper_tool_name
- remove direct Tool_name enum parsing from keeper progress and meta tool-access helpers
- add regression coverage for completion classification and board tool_access detection

Verification:
- env DUNE_CACHE=disabled DUNE_BUILD_DIR=/tmp/masc-dune-keeper-progress-name-boundary dune build --root . @install test/test_keeper_unified_claim_progress.exe --force
- /tmp/masc-dune-keeper-progress-name-boundary/default/test/test_keeper_unified_claim_progress.exe
- bash scripts/lint/tool-keeper-boundary-ratchet.sh --print
- scripts/audit-keeper-tool-boundary-matrix.sh
- rg -n "Tool_name\." lib/keeper/keeper_tool_progress.ml lib/keeper/keeper_meta_tool_access.ml
- git diff --check

Notes:
- Follow-up to the Tool/Keeper boundary decoupling docs. This keeps legacy public masc_* names as keeper-owned projection strings, but removes the local dependency on the central Tool_name enum in the touched helpers.