### PR TITLE
refactor(keeper): decouple capability axis names from tool enum

### DIFF
--- a/lib/keeper/keeper_tool_capability_axis.ml
+++ b/lib/keeper/keeper_tool_capability_axis.ml
@@ -10,9 +10,9 @@ type t =
   | Board_activity
   | Shell_command_input
 
-let masc_name (tool : Tool_name.Masc.t) =
-  Tool_name.to_string (Tool_name.Masc tool)
-;;
+let legacy_masc_claim_next_name = "masc_claim_next"
+let legacy_masc_broadcast_name = "masc_broadcast"
+let legacy_masc_keeper_msg_name = "masc_keeper_msg"
 
 let canonical_tool_name name =
   let stripped = Keeper_tool_alias.strip_mcp_masc_prefix name in
@@ -28,14 +28,14 @@ let candidate_names name =
 ;;
 
 let claim_task_tool_names =
-  [ "keeper_task_claim"; Tool_name.Task_name.to_string Tool_name.Task_name.Claim_next ]
+  [ Keeper_tool_name.(to_string Task_claim); legacy_masc_claim_next_name ]
 ;;
 
 let board_activity_tool_names =
-  [ "keeper_board_post"
-  ; "keeper_board_comment"
-  ; masc_name Tool_name.Masc.Broadcast
-  ; "masc_keeper_msg"
+  [ Keeper_tool_name.(to_string Board_post)
+  ; Keeper_tool_name.(to_string Board_comment)
+  ; legacy_masc_broadcast_name
+  ; legacy_masc_keeper_msg_name
   ]
 ;;
 

--- a/test/dune
+++ b/test/dune
@@ -184,6 +184,7 @@
   test_runtime_provider_auth_headers
   test_keeper_tool_policy_config
   test_keeper_tool_visibility_projection
+  test_keeper_tool_capability_axis
   test_keeper_tool_resolution
   test_tool_resolution_runtime_projection
   test_claim_post_provision_hook
@@ -441,6 +442,7 @@
   test_runtime_provider_auth_headers
   test_keeper_tool_policy_config
   test_keeper_tool_visibility_projection
+  test_keeper_tool_capability_axis
   test_keeper_tool_resolution
   test_tool_resolution_runtime_projection
   test_claim_post_provision_hook

--- a/test/test_keeper_tool_capability_axis.ml
+++ b/test/test_keeper_tool_capability_axis.ml
@@ -1,0 +1,39 @@
+open Alcotest
+
+module Axis = Masc.Keeper_tool_capability_axis
+
+let check_support capability name expected =
+  check bool name expected (Axis.supports capability name)
+;;
+
+let test_claim_task_supports_keeper_and_public_projection () =
+  check_support Axis.Claim_task "keeper_task_claim" true;
+  check_support Axis.Claim_task "masc_claim_next" true;
+  check_support Axis.Claim_task "mcp__masc__masc_claim_next" true;
+  check_support Axis.Claim_task "keeper_tasks_list" false
+;;
+
+let test_board_activity_supports_keeper_and_public_projection () =
+  check_support Axis.Board_activity "keeper_board_post" true;
+  check_support Axis.Board_activity "keeper_board_comment" true;
+  check_support Axis.Board_activity "masc_broadcast" true;
+  check_support Axis.Board_activity "mcp__masc__masc_broadcast" true;
+  check_support Axis.Board_activity "masc_keeper_msg" true;
+  check_support Axis.Board_activity "keeper_board_list" false
+;;
+
+let () =
+  run
+    "keeper_tool_capability_axis"
+    [ ( "supports"
+      , [ test_case
+            "claim task supports keeper and public projection names"
+            `Quick
+            test_claim_task_supports_keeper_and_public_projection
+        ; test_case
+            "board activity supports keeper and public projection names"
+            `Quick
+            test_board_activity_supports_keeper_and_public_projection
+        ] )
+    ]
+;;


### PR DESCRIPTION
Summary:
- remove Tool_name.Masc construction from keeper capability-axis classification
- keep public MCP projection names as explicit external aliases while deriving keeper-owned names from Keeper_tool_name
- add regression tests for claim and board-activity capability support across keeper/public/prefixed names

Verification:
- env DUNE_CACHE=disabled DUNE_BUILD_DIR=/tmp/masc-dune-keeper-capability-axis-boundary dune build --root . @install test/test_keeper_tool_capability_axis.exe --force
- /tmp/masc-dune-keeper-capability-axis-boundary/default/test/test_keeper_tool_capability_axis.exe
- bash scripts/lint/tool-keeper-boundary-ratchet.sh --print
- scripts/audit-keeper-tool-boundary-matrix.sh
- rg -n "Tool_name\." lib/keeper/keeper_tool_capability_axis.ml
- git diff --check

Notes:
- Follow-up to the Tool/Keeper MCP-surface boundary plan. This is intentionally narrow and does not depend on #20035.