### PR TITLE
refactor(dashboard): purge heuristic label surface

### DIFF
--- a/dashboard/design-system/preview/cb-group-f.jsx
+++ b/dashboard/design-system/preview/cb-group-f.jsx
@@ -1,6 +1,6 @@
 // preview/cb-group-f.jsx
 // Track 3 · OBSERVABILITY PLANE
-// O1 Runtime Inspector · O2 Audit Ledger · O3 Safe Autonomy · O4 Cost · O5 Heuristic + Stress
+// O1 Runtime Inspector · O2 Audit Ledger · O3 Safe Autonomy · O4 Cost · O5 Stress
 
 const P2f = window.MASC_P2;
 

--- a/dashboard/design-system/preview/cb-root.jsx
+++ b/dashboard/design-system/preview/cb-root.jsx
@@ -215,10 +215,8 @@ function App() {
         <DCArtboard id="ct-lat" label="C · Latency histogram + buckets"    width={920}  height={340}><CostLatency/></DCArtboard>
       </DCSection>
 
-      <DCSection id="heur" title="O5 · Heuristic + Stress" subtitle="keeper_hooks_oas firing log + agent_stress.jsonl.">
-        <DCArtboard id="hr-log" label="A · Heuristic firing log"           width={1080} height={420}><HeuristicLog/></DCArtboard>
-        <DCArtboard id="hr-st"  label="B · Stress board (per-agent)"       width={920}  height={240}><StressBoard/></DCArtboard>
-        <DCArtboard id="hr-mod" label="C · Firing rate by module"          width={920}  height={300}><HeuristicByModule/></DCArtboard>
+      <DCSection id="stress" title="O5 · Stress" subtitle="agent_stress.jsonl.">
+        <DCArtboard id="st-board" label="A · Stress board (per-agent)"       width={920}  height={240}><StressBoard/></DCArtboard>
       </DCSection>
 
       {/* ════════ PHASE 2 · TRACK 4 · COGNITION PLANE ════════ */}

--- a/dashboard/design-system/preview/components.css
+++ b/dashboard/design-system/preview/components.css
@@ -570,7 +570,7 @@
 
 
 /* ═══════════════════════════════════════════════════════════════════
-   Track 3 · OBSERVABILITY (O1 Runtime · O2 Audit · O3 SafeAuto · O4 Cost · O5 Heuristic)
+   Track 3 · OBSERVABILITY (O1 Runtime · O2 Audit · O3 SafeAuto · O4 Cost · O5 Stress)
    ═══════════════════════════════════════════════════════════════════ */
 
 /* ═════ O1 · RUNTIME INSPECTOR ═════ */
@@ -676,19 +676,7 @@
 .cs-mat td.z3 { color: var(--color-accent-fg); background: rgb(var(--color-accent-glow)/.22); font-weight:600; }
 .cs-mat td.z4 { color: var(--color-bg-page); background: var(--color-accent-fg); font-weight: 600; }
 
-/* ═════ O5 · HEURISTIC + STRESS ═════ */
-.hr-row { display:grid; grid-template-columns: 70px 130px 1fr 100px 60px 50px; gap: 6px; padding: 4px 8px; border-bottom: 1px solid var(--color-border-default); align-items: baseline; font-family: var(--font-mono); font-size: var(--fs-11); }
-.hr-row.fired { background: rgb(var(--err-glow,255 90 90)/.04); border-left: 2px solid var(--err); padding-left: 6px; }
-.hr-row .ts { color: var(--color-fg-disabled); font-size: var(--fs-10); }
-.hr-row .mod { color: var(--color-fg-primary); font-weight: 500; }
-.hr-row .site { color: var(--color-accent-fg); }
-.hr-row .det { color: var(--color-fg-muted); font-size: var(--fs-10); white-space: normal; }
-.hr-row .num { text-align: right; font-variant-numeric: tabular-nums; color: var(--color-fg-primary); }
-.hr-row .num.over { color: var(--err-fg); font-weight: 600; }
-.hr-row .fl { font-size: var(--fs-9); letter-spacing: .08em; text-transform: uppercase; padding: 1px 4px; border:1px solid var(--color-border-strong); text-align:center; }
-.hr-row .fl.t { color: var(--err-fg); border-color: var(--err-border); background: var(--err-soft); font-weight:600; }
-.hr-row .fl.f { color: var(--color-fg-disabled); }
-
+/* ═════ O5 · STRESS ═════ */
 .st-grid { display:grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 6px; }
 .st-grid .scard { padding: 7px 9px; background: var(--color-bg-surface); border: 1px solid var(--color-border-default); border-left: 3px solid var(--warn); display:flex; flex-direction:column; gap: 4px; }
 .st-grid .scard.runtime_burn { border-left-color: var(--err); }

--- a/dashboard/design-system/preview/design-canvas.jsx
+++ b/dashboard/design-system/preview/design-canvas.jsx
@@ -210,7 +210,7 @@ function DCViewport({ children, minScale = 0.1, maxScale = 8, style = {} }) {
       apply();
     };
 
-    // Mouse-wheel vs trackpad-scroll heuristic. A physical wheel sends
+    // Mouse-wheel vs trackpad-scroll inference. A physical wheel sends
     // line-mode deltas (Firefox) or large integer pixel deltas with no X
     // component (Chrome/Safari, typically multiples of 100/120). Trackpad
     // two-finger scroll sends small/fractional pixel deltas, often with
@@ -622,4 +622,3 @@ function DCPostIt({ children, top, left, right, bottom, rotate = -2, width = 180
 }
 
 Object.assign(window, { DesignCanvas, DCSection, DCArtboard, DCPostIt });
-

--- a/dashboard/design-system/preview/index.html
+++ b/dashboard/design-system/preview/index.html
@@ -97,7 +97,7 @@
       <a class="card" href="components.html#audit"><span class="stripe"></span><span class="n">O2 · 3 variants</span><span class="title">Audit Ledger</span><span class="desc">Streaming ledger · actor filter (sangsu) · event-kind summary.</span></a>
       <a class="card" href="components.html#safe-auto"><span class="stripe"></span><span class="n">O3 · 3 variants</span><span class="title">Safe Autonomy</span><span class="desc">Score gauge + 12 findings · keeper rollup · 15-run trend.</span></a>
       <a class="card" href="components.html#cost"><span class="stripe"></span><span class="n">O4 · 3 variants</span><span class="title">Cost &amp; Latency</span><span class="desc">Per-agent table · provider×model heatmap · latency histogram.</span></a>
-      <a class="card" href="components.html#heur"><span class="stripe"></span><span class="n">O5 · 3 variants</span><span class="title">Heuristic + Stress</span><span class="desc">Firing log · per-agent stress board · firing rate by module.</span></a>
+      <a class="card" href="components.html#stress"><span class="stripe"></span><span class="n">O5 · 1 variant</span><span class="title">Stress</span><span class="desc">Per-agent stress board.</span></a>
     </div>
 
     <h2>Phase 2 · Cognition plane</h2>

--- a/dashboard/design-system/preview/responsive.html
+++ b/dashboard/design-system/preview/responsive.html
@@ -684,7 +684,7 @@
             <span class="pill">runtime</span>
             <span class="pill">audit</span>
             <span class="pill">cost</span>
-            <span class="pill">heuristic</span>
+            <span class="pill">inference</span>
             <span class="pill">decisions</span>
             <span class="pill">episodes</span>
           </div>

--- a/dashboard/design-system/preview/scope-phase2.html
+++ b/dashboard/design-system/preview/scope-phase2.html
@@ -364,7 +364,7 @@
         <li><b>O2</b><a href="#o2">Audit Ledger</a></li>
         <li><b>O3</b><a href="#o3">Safe Autonomy</a></li>
         <li><b>O4</b><a href="#o4">Cost Ledger</a></li>
-        <li><b>O5</b><a href="#o5">Heuristic / Stress</a></li>
+        <li><b>O5</b><a href="#o5">Stress</a></li>
       </ol>
     </div>
     <div>

--- a/dashboard/design-system/preview/snippets.jsx
+++ b/dashboard/design-system/preview/snippets.jsx
@@ -287,30 +287,6 @@ const SNIPPETS = [
 </div>`,
   },
   {
-    id: 'heuristic-row', group: 'phase2', src: 'preview/components.css',
-    title: 'Heuristic firing row',
-    desc: 'Stress / heuristic firing entry. Add .fired class for left-accent + soft red bg.',
-    html:
-`<div style="display:flex;flex-direction:column">
-  <div class="hr-row fired">
-    <span class="ts">12:04</span>
-    <span class="mod">drift_threshold</span>
-    <span class="det">claim_holder churn &gt; 3 in 5min on t-4012</span>
-    <span class="site">runtime.py:412</span>
-    <span class="num over">0.84</span>
-    <span class="fl t">FIRED</span>
-  </div>
-  <div class="hr-row">
-    <span class="ts">12:06</span>
-    <span class="mod">probe_latency</span>
-    <span class="det">p95 above 1.5s on hop 4</span>
-    <span class="site">runtime.py:380</span>
-    <span class="num">1.62</span>
-    <span class="fl f">arm</span>
-  </div>
-</div>`,
-  },
-  {
     id: 'nudge-row', group: 'phase2', src: 'preview/components.css',
     title: 'Operator nudge row',
     desc: 'Operator → keeper nudge log entry.',
@@ -333,7 +309,7 @@ const SNIPPETS = [
 `<div class="ki-bdi">
   <div class="row"><span class="lbl">will</span><div class="v">resolve t-4012 by EOD without ceding claim to drift &gt; 0.5</div></div>
   <div class="row"><span class="lbl">needs</span><div class="v">stable probe latency on runtime-v3 hop 4 · operator approval for window extension</div></div>
-  <div class="row"><span class="lbl">desires</span><div class="v">verified patch in trunk · ep-882 closed · drift heuristic re-armed</div></div>
+  <div class="row"><span class="lbl">desires</span><div class="v">verified patch in trunk · ep-882 closed · drift monitor re-armed</div></div>
   <div class="hz">
     <span class="lbl">horizon</span><span class="v">3 turns</span>
     <span class="lbl">commit</span><span class="v">soft</span>
@@ -424,7 +400,7 @@ const SNIPPETS = [
 
 const GROUPS = [
   { id: 'atoms',  name: 'Atoms',                  desc: 'Smallest reusable building blocks — chips, bars, sparks, buttons.' },
-  { id: 'phase2', name: 'Phase 2 row primitives', desc: 'Reusable rows from board, decisions, memory, audit, runtime, heuristic, nudge, keeper, branch.' },
+  { id: 'phase2', name: 'Phase 2 row primitives', desc: 'Reusable rows from board, decisions, memory, audit, runtime, nudge, keeper, branch.' },
   { id: 'forms',  name: 'Form controls',          desc: 'Inputs, checkboxes, toggles, segmented controls.' },
 ];
 

--- a/dashboard/design-system/ui_kits/cockpit/Planes.jsx
+++ b/dashboard/design-system/ui_kits/cockpit/Planes.jsx
@@ -95,12 +95,12 @@ function CommsPlane({ branch, keepers }) {
 }
 
 // ═════════════════════════════════════════════════════════════
-// OBSERVE PLANE — O1 Runtime · O2 Audit · O3 Safe Auto · O4 Cost · O5 Heuristic
+// OBSERVE PLANE — O1 Runtime · O2 Audit · O3 Safe Auto · O4 Cost · O5 Stress
 // ═════════════════════════════════════════════════════════════
 function ObservePlane({ branch, keepers }) {
   return (
     <PlaneShell
-      title="Observability" subtitle="Runtime · Audit · Safe Autonomy · Cost · Heuristic"
+      title="Observability" subtitle="Runtime · Audit · Safe Autonomy · Cost · Stress"
       popoutId="plane-observe"
       branch={branch} keepers={keepers}
       tabs={[
@@ -116,9 +116,7 @@ function ObservePlane({ branch, keepers }) {
         { id:"ct-agt",  label:"Cost · Per agent",     render: () => <window.CostPerAgent/> },
         { id:"ct-mtx",  label:"Cost · Matrix",        render: () => <window.CostMatrix/> },
         { id:"ct-lat",  label:"Cost · Latency",       render: () => <window.CostLatency/> },
-        { id:"hr-log",  label:"Heuristic · Log",      render: () => <window.HeuristicLog/> },
-        { id:"hr-st",   label:"Stress · Board",       render: () => <window.StressBoard/> },
-        { id:"hr-mod",  label:"Heuristic · By module",render: () => <window.HeuristicByModule/> },
+        { id:"st-board", label:"Stress · Board",      render: () => <window.StressBoard/> },
       ]}
     />
   );

--- a/dashboard/design-system/ui_kits/cockpit/cb-group-f.jsx
+++ b/dashboard/design-system/ui_kits/cockpit/cb-group-f.jsx
@@ -1,6 +1,6 @@
 // preview/cb-group-f.jsx
 // Track 3 · OBSERVABILITY PLANE
-// O1 Runtime Inspector · O2 Audit Ledger · O3 Safe Autonomy · O4 Cost · O5 Heuristic + Stress
+// O1 Runtime Inspector · O2 Audit Ledger · O3 Safe Autonomy · O4 Cost · O5 Stress
 
 const P2f = window.MASC_P2;
 
@@ -429,31 +429,8 @@ function CostLatency() {
 }
 
 // ═════════════════════════════════════════════════════════════════
-// O5 · HEURISTIC + STRESS
+// O5 · STRESS
 // ═════════════════════════════════════════════════════════════════
-
-function HeuristicLog() {
-  return (
-    <section aria-label={`Heuristic firing log · ${P2f.heuristics.filter(h=>h.triggered).length} fired of ${P2f.heuristics.length}`} style={{background:'var(--color-bg-surface)',border:'1px solid var(--color-border-strong)'}}>
-      <div role="heading" aria-level={3} style={{padding:'5px 8px',borderBottom:'1px solid var(--color-border-strong)',display:'flex',gap:'8px',background:'var(--color-bg-panel-alt)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)'}}>
-        <span>tail · keeper_hooks_oas.heuristics.jsonl</span>
-        <span style={{marginLeft:'auto',color:'var(--err-fg)'}}>{P2f.heuristics.filter(h=>h.triggered).length}/{P2f.heuristics.length} fired</span>
-      </div>
-      <div role="log" aria-live="polite" aria-label={`${P2f.heuristics.length} heuristic rows`}>
-        {P2f.heuristics.map((h, i) => (
-          <div key={i} role="listitem" aria-label={`${h.ts.replace('Z','')} · ${h.module} · ${h.site} · value ${h.value} threshold ${h.threshold} · ${h.triggered ? 'fire' : 'ok'}${h.detail ? ' · ' + h.detail : ''}`} className={`hr-row ${h.triggered ? 'fired' : ''}`}>
-            <span className="ts" aria-hidden="true">{h.ts.replace('Z','')}</span>
-            <span className="mod" aria-hidden="true">{h.module}</span>
-            <span className="site" aria-hidden="true">{h.site}<span className="det" style={{display:'block'}}>↳ {h.detail}</span></span>
-            <span className="num" aria-hidden="true">value · <span className={h.triggered?'over':''}>{h.value}</span></span>
-            <span className="num" aria-hidden="true">thr · {h.threshold}</span>
-            <span className={`fl ${h.triggered ? 't' : 'f'}`} aria-hidden="true">{h.triggered ? 'fire' : 'ok'}</span>
-          </div>
-        ))}
-      </div>
-    </section>
-  );
-}
 
 function StressBoard() {
   return (
@@ -478,44 +455,10 @@ function StressBoard() {
   );
 }
 
-function HeuristicByModule() {
-  const byMod = {};
-  P2f.heuristics.forEach(h => {
-    if (!byMod[h.module]) byMod[h.module] = { fired: 0, total: 0, sites: new Set() };
-    byMod[h.module].total++;
-    if (h.triggered) byMod[h.module].fired++;
-    byMod[h.module].sites.add(h.site);
-  });
-  const rows = Object.entries(byMod).sort((a,b) => b[1].fired - a[1].fired);
-  return (
-    <section aria-label={`Heuristic firing rate by module · ${rows.length} modules`} style={{display:'flex',flexDirection:'column',gap:'4px'}}>
-      <div role="heading" aria-level={3} style={{padding:'5px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--color-border-strong)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)',display:'flex'}}>
-        <span>heuristic firing rate · by module</span>
-      </div>
-      <div role="list">
-        {rows.map(([mod, v]) => {
-          const pct = v.total > 0 ? v.fired / v.total * 100 : 0;
-          return (
-            <div key={mod} role="listitem" aria-label={`${mod} · ${v.fired} of ${v.total} fired (${pct.toFixed(0)}%) · sites ${[...v.sites].join(', ')}`} style={{display:'grid',gridTemplateColumns:'160px 80px 1fr 60px',gap:'8px',alignItems:'center',padding:'5px 8px',background:'var(--color-bg-surface)',border:'1px solid var(--color-border-default)'}}>
-              <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-11)',color:'var(--color-fg-primary)'}}>{mod}</span>
-              <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',color:'var(--color-fg-muted)'}}>{v.fired}/{v.total} fired</span>
-              <div aria-hidden="true" style={{height:'10px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--color-border-default)'}}>
-                <div style={{height:'100%',width:`${pct}%`,background: pct > 50 ? 'linear-gradient(90deg, var(--color-status-warn), var(--color-status-err))' : 'linear-gradient(90deg, var(--color-accent-fg-dim), var(--color-accent-fg))'}}></div>
-              </div>
-              <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-11)',color: pct > 50 ? 'var(--err-fg)' : 'var(--color-accent-fg)',fontVariantNumeric:'tabular-nums',textAlign:'right'}}>{pct.toFixed(0)}%</span>
-              <span aria-hidden="true" style={{gridColumn:'1 / -1',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',color:'var(--color-fg-disabled)',letterSpacing:'.04em'}}>sites · {[...v.sites].join(' · ')}</span>
-            </div>
-          );
-        })}
-      </div>
-    </section>
-  );
-}
-
 Object.assign(window, {
   RuntimeList, RuntimeDeepDive, RuntimeCompare,
   AuditLedger, AuditByActor, AuditSummary,
   SafeAutoDashboard, SafeAutoByKeeper, SafeAutoTrend,
   CostPerAgent, CostMatrix, CostLatency,
-  HeuristicLog, StressBoard, HeuristicByModule,
+  StressBoard,
 });

--- a/dashboard/design-system/ui_kits/cockpit/components.css
+++ b/dashboard/design-system/ui_kits/cockpit/components.css
@@ -570,7 +570,7 @@
 
 
 /* ═══════════════════════════════════════════════════════════════════
-   Track 3 · OBSERVABILITY (O1 Runtime · O2 Audit · O3 SafeAuto · O4 Cost · O5 Heuristic)
+   Track 3 · OBSERVABILITY (O1 Runtime · O2 Audit · O3 SafeAuto · O4 Cost · O5 Stress)
    ═══════════════════════════════════════════════════════════════════ */
 
 /* ═════ O1 · RUNTIME INSPECTOR ═════ */
@@ -676,19 +676,7 @@
 .cs-mat td.z3 { color: var(--color-accent-fg); background: rgb(var(--color-accent-glow)/.22); font-weight: var(--fw-semi); }
 .cs-mat td.z4 { color: var(--color-bg-page); background: var(--color-accent-fg); font-weight: var(--fw-semi); }
 
-/* ═════ O5 · HEURISTIC + STRESS ═════ */
-.hr-row { display:grid; grid-template-columns: 70px 130px 1fr 100px 60px 50px; gap: 6px; padding: var(--sp-1) var(--sp-2); border-bottom: 1px solid var(--color-border-default); align-items: baseline; font-family: var(--font-mono); font-size: var(--fs-11); }
-.hr-row.fired { background: rgb(var(--err-glow,255 90 90)/.04); border-left: 2px solid var(--err); padding-left: 6px; }
-.hr-row .ts { color: var(--color-fg-disabled); font-size: var(--fs-10); }
-.hr-row .mod { color: var(--color-fg-primary); font-weight: var(--fw-med); }
-.hr-row .site { color: var(--color-accent-fg); }
-.hr-row .det { color: var(--color-fg-muted); font-size: var(--fs-10); white-space: normal; }
-.hr-row .num { text-align: right; font-variant-numeric: tabular-nums; color: var(--color-fg-primary); }
-.hr-row .num.over { color: var(--err-fg); font-weight: var(--fw-semi); }
-.hr-row .fl { font-size: var(--fs-9); letter-spacing: .08em; text-transform: uppercase; padding: 1px 4px; border:1px solid var(--color-border-strong); text-align:center; }
-.hr-row .fl.t { color: var(--err-fg); border-color: var(--err-border); background: var(--err-soft); font-weight: var(--fw-semi); }
-.hr-row .fl.f { color: var(--color-fg-disabled); }
-
+/* ═════ O5 · STRESS ═════ */
 .st-grid { display:grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 6px; }
 .st-grid .scard { padding: 7px 9px; background: var(--color-bg-surface); border: 1px solid var(--color-border-default); border-left: 3px solid var(--warn); display:flex; flex-direction:column; gap: var(--sp-1); }
 .st-grid .scard.runtime_burn { border-left-color: var(--err); }

--- a/dashboard/design-system/ui_kits/cockpit/data-p2.js
+++ b/dashboard/design-system/ui_kits/cockpit/data-p2.js
@@ -239,17 +239,7 @@ window.MASC_P2 = (function () {
     p50: 1480, p95: 8210, total_cost_usd: 30.16,
   };
 
-  // ─── O5 · HEURISTIC + STRESS ─────────────────────────────────────
-  const heuristics = [
-    { ts:"16:32:18Z", module:"keeper_hooks_oas", site:"post_tool_use_failure",     value:1.0, threshold:0.0, triggered:true,  detail:"qa-king · suite-merge-blockers" },
-    { ts:"16:31:27Z", module:"runtime",          site:"runtime_exhausted",         value:1.0, threshold:0.0, triggered:true,  detail:"sangsu · keeper_unified" },
-    { ts:"16:30:42Z", module:"keeper_hooks_oas", site:"max_turns",                 value:15,  threshold:15,  triggered:true,  detail:"sangsu · 16 turns hit" },
-    { ts:"16:24:04Z", module:"compaction",       site:"context_ratio",             value:0.42,threshold:0.5, triggered:false, detail:"sangsu · within budget" },
-    { ts:"16:18:11Z", module:"keeper_hooks_oas", site:"permission_denial",         value:1.0, threshold:0.0, triggered:true,  detail:"sangsu · serena.activate_project" },
-    { ts:"16:14:00Z", module:"task",             site:"open_task_limit_per_goal",  value:3,   threshold:3,   triggered:true,  detail:"taskmaster · goal-merge-blockers" },
-    { ts:"16:08:33Z", module:"board",            site:"expired_post_count",        value:4,   threshold:5,   triggered:false, detail:"janitor · pruned" },
-    { ts:"15:54:12Z", module:"keeper_hooks_oas", site:"failure_streak",            value:1,   threshold:1,   triggered:true,  detail:"qa-king" },
-  ];
+  // ─── O5 · STRESS ─────────────────────────────────────────────────
   const stress = [
     { agent:"qa-king",       kind:"failure_streak", count:1, workspace:"default", at:"15:54:12Z" },
     { agent:"sangsu",        kind:"runtime_burn",   count:3, workspace:"default", at:"16:31:27Z" },
@@ -349,7 +339,7 @@ window.MASC_P2 = (function () {
     goals, goalSnapshots,
     tasks, ledger, responsibility,
     boardPosts, boardComments, workspaces, messages,
-    runtimeAudit, auditEvents, safeAutonomy, costs, heuristics, stress,
+    runtimeAudit, auditEvents, safeAutonomy, costs, stress,
     keepersFull, decisions, memoryEntries, episodes,
   };
 })();

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -1530,6 +1530,30 @@ describe('fetchKeeperConfig', () => {
     expect(result.runtime_trust?.disposition).toBe('Pass')
   })
 
+  it('normalizes default per-provider timeout mode without legacy label', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          name: 'keeper-sangsu',
+          execution: {
+            per_provider_timeout_sec: null,
+            per_provider_timeout_mode: 'legacy-value',
+          },
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      ),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchKeeperConfig('keeper-sangsu')
+
+    expect(result.execution.per_provider_timeout_sec).toBeNull()
+    expect(result.execution.per_provider_timeout_mode).toBe('turn_budget_default')
+  })
+
   it('preserves missing keeper config latency as null instead of zero', async () => {
     const cases: Array<[string, Record<string, unknown>]> = [
       ['null', { last_latency_ms: null }],

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -2039,7 +2039,7 @@ function normalizePerProviderTimeoutMode(
 ): KeeperConfig['execution']['per_provider_timeout_mode'] {
   return asNullableString(raw) === 'override' || perProviderTimeoutSec != null
     ? 'override'
-    : 'turn_budget_heuristic'
+    : 'turn_budget_default'
 }
 
 function normalizeKeeperConfig(raw: unknown, requestedName: string): KeeperConfig {

--- a/dashboard/src/components/composite-fsm-flowchart.test.ts
+++ b/dashboard/src/components/composite-fsm-flowchart.test.ts
@@ -58,7 +58,7 @@ describe('buildCompositeFsmMermaid', () => {
   })
 
   it('does not emit duplicate top-level node ids (no un-prefixed collisions)', () => {
-    // Heuristic: every declared `id["label"]` anchored on word chars
+    // Inference: every declared `id["label"]` anchored on word chars
     // should have at most one bracket declaration when the id is
     // prefixed. We extract ids and check that each appears exactly
     // once in an initial declaration.

--- a/dashboard/src/components/connector-readiness-rail.ts
+++ b/dashboard/src/components/connector-readiness-rail.ts
@@ -208,7 +208,7 @@ export function deriveRail(
   on: RailHandlers,
   inflight: Partial<Record<RailKey, boolean>> = {},
 ): RailPill[] {
-  // Token: heuristic — if the sidecar is running, the operator has set
+  // Token: inferred — if the sidecar is running, the operator has set
   // a valid token (the bridge would have crashed at startup otherwise).
   // If it's down we can't know, so we suggest setting one.
   const tokenState: RailState = input.sidecarUp ? 'ok' : 'bad'

--- a/dashboard/src/components/fleet-fsm-matrix.test.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.test.ts
@@ -227,7 +227,7 @@ describe('runtimeAttentionForSnapshot', () => {
     expect(attention.title).toContain('latest activity 10m ago')
   })
 
-  it('prefers backend runtime_attention over narrower frontend heuristics', () => {
+  it('prefers backend runtime_attention over narrower frontend fallback inference', () => {
     const snap = snapshot({
       is_live: false,
       execution: execution({

--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -52,7 +52,7 @@ function makeKeeperConfig(overrides: Partial<KeeperConfig> = {}): KeeperConfig {
       models: ['llama:test-balanced'],
       active_model: 'llama:test-balanced',
       per_provider_timeout_sec: null,
-      per_provider_timeout_mode: 'turn_budget_heuristic',
+      per_provider_timeout_mode: 'turn_budget_default',
       verify: true,
       selected_runtime_id: 'tier-group.keeper_unified',
       selected_runtime_canonical: 'tier-group.keeper_unified',

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -347,7 +347,7 @@ function perProviderTimeoutLabel(execution: KeeperConfig['execution']): string {
   ) {
     return formatSeconds(execution.per_provider_timeout_sec)
   }
-  return 'turn budget heuristic'
+  return 'turn budget default'
 }
 
 function MajorSectionHeader({ title }: { title: string }) {

--- a/dashboard/src/components/keeper-detail-body.ts
+++ b/dashboard/src/components/keeper-detail-body.ts
@@ -112,7 +112,7 @@ export function KeeperDetailBody({
           eyebrow="상태 개요"
           title="운영 상태 개요"
         >
-      ${'' /* KeeperLiveTruthPanel (derived "Live truth / 런타임 / 현재 턴 / 최신 증거 / 차단" composite) moved to the 진단 / 운영 section as a default-closed CollapsibleSection — it is a heuristic synthesis on top of composite + keeper + runtime_trace + linked_state and lives below the raw-state alert-strip in information hierarchy. */}
+      ${'' /* KeeperLiveTruthPanel (derived "Live truth / 런타임 / 현재 턴 / 최신 증거 / 차단" composite) moved to the 진단 / 운영 section as a default-closed CollapsibleSection. It is a derived synthesis on top of composite + keeper + runtime_trace + linked_state and lives below the raw-state alert-strip in information hierarchy. */}
       ${'' /* RFC-0046: 6-axis composite snapshot (KSM/KTC/KDP/KCL/KMC/breaker) — SSOT for keeper FSM state */}
       ${'' /* RFC-0046 §7 #2: share useKeeperComposite with FsmHub to dedup the /composite poll */}
       <${CollapsibleSection} title="FSM Hub (6축 상태 머신)" open=${false}>

--- a/dashboard/src/components/keeper-supervisor-helpers.ts
+++ b/dashboard/src/components/keeper-supervisor-helpers.ts
@@ -39,7 +39,7 @@ export function categorizeCrashReason(reason: string | null | undefined): Superv
   const lower = reason.toLowerCase()
   // Defensive exact-match: if backend emits the category name directly
   // (e.g. "heartbeat" instead of "heartbeat_timeout"), prefer that
-  // over prefix heuristic so "heartbeat" does not collide with an
+  // over prefix matching so "heartbeat" does not collide with an
   // unrelated longer prefix.
   if (CRASH_CATEGORY_KEYS.includes(lower as SupervisorCrashCategory)) return lower as SupervisorCrashCategory
   for (const { prefix, category } of CRASH_PREFIX_MAP) {

--- a/dashboard/src/journal-entry.test.ts
+++ b/dashboard/src/journal-entry.test.ts
@@ -18,7 +18,7 @@ function makeEntry(overrides: Partial<JournalEntry> = {}): JournalEntry {
 }
 
 describe('journal severity helpers', () => {
-  it('marks keeper guardrail entries as errors even without text heuristics', () => {
+  it('marks keeper guardrail entries as errors even without text matching', () => {
     expect(defaultJournalSeverity('keeper_guardrail')).toBe('error')
     expect(isErrorJournalEntry(makeEntry({ eventType: 'keeper_guardrail', text: 'stopped by guardrail' }))).toBe(true)
   })

--- a/dashboard/src/lib/keeper-classifiers.ts
+++ b/dashboard/src/lib/keeper-classifiers.ts
@@ -87,7 +87,7 @@ const CRASH_PREFIX_MAP: readonly { prefix: string; category: LibCrashCategory }[
 ]
 
 /** Classify a raw crash reason string into a typed category.
- *  Exact match preferred over prefix heuristic to avoid ambiguity.
+ *  Exact match preferred over prefix matching to avoid ambiguity.
  *  RFC-0174 SSOT source — see file-level note for divergence from the
  *  production `categorizeCrashReason` UI helper. */
 export function classifyCrashReasonLib(raw: string): LibCrashCategory {

--- a/dashboard/src/lib/keeper-runtime-projection.ts
+++ b/dashboard/src/lib/keeper-runtime-projection.ts
@@ -551,21 +551,20 @@ function buildProjectionSignals({
   ]
 }
 
+// Closed set of wire-format values emitted by
+// keeper_execution_receipt.tool_contract_result_to_string.
+const EXECUTION_ATTENTION_CODES: ReadonlySet<string> = new Set([
+  'violated',
+  'tool_surface_mismatch',
+  'no_tool_capable_provider',
+  'claim_only_after_owned_task',
+  'needs_execution_progress',
+  'passive_only',
+  'not_dispatched',
+])
+
 function isExecutionAttentionCode(value: string | null | undefined): boolean {
   const normalized = value?.trim().toLowerCase()
   if (!normalized || normalized === 'unknown' || normalized === 'tool contract unknown') return false
-  if (
-    normalized === 'ok'
-    || normalized === 'pass'
-    || normalized === 'allowed_in_sandbox'
-    || normalized.startsWith('satisfied')
-  ) return false
-  return normalized.includes('violat')
-    || normalized.includes('missing')
-    || normalized.includes('mismatch')
-    || normalized.includes('need')
-    || normalized.includes('fail')
-    || normalized.includes('error')
-    || normalized.includes('passive')
-    || normalized === 'no_tool_capable_provider'
+  return EXECUTION_ATTENTION_CODES.has(normalized)
 }

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -1193,7 +1193,7 @@ interface KeeperConfigExecution {
   active_model_label?: string | null
   last_model_used_label?: string | null
   per_provider_timeout_sec?: number | null
-  per_provider_timeout_mode: 'override' | 'turn_budget_heuristic'
+  per_provider_timeout_mode: 'override' | 'turn_budget_default'
   verify: boolean
   selected_runtime_id: string
   selected_runtime_canonical: string

--- a/lib/dashboard/dashboard_http_keeper_snapshot.ml
+++ b/lib/dashboard/dashboard_http_keeper_snapshot.ml
@@ -285,9 +285,9 @@ let keeper_config_json (config : Workspace.config) (name : string)
             Json_util.float_opt_to_json per_provider_timeout );
           ( "per_provider_timeout_mode",
             `String
-              (match per_provider_timeout with
-               | Some _ -> "override"
-               | None -> "turn_budget_heuristic") );
+               (match per_provider_timeout with
+                | Some _ -> "override"
+                | None -> "turn_budget_default") );
           ("verify", `Bool false);
         ]
       in


### PR DESCRIPTION
## Summary
- replace the dashboard per-provider timeout fallback from `turn_budget_heuristic` to `turn_budget_default` across OCaml JSON, TS types, normalizers, UI label, and tests
- remove dashboard design-system heuristic firing mock surfaces (O5 log/by-module cards, hr-row CSS, sample data, and preview navigation references)
- add missing dashboard blocker support for `tool_route_recoverable_failure` and surface missing required tool names in fleet blocker cause/next step

## Verification
- `rg -n -i "heuristic|turn_budget_heuristic|HeuristicLog|HeuristicByModule|heuristics\.jsonl|hr-row" dashboard/src lib/dashboard dashboard/design-system/preview dashboard/design-system/ui_kits/cockpit --glob '!**/*.map'` (0 matches)
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=/tmp/masc-dune-dashboard-heuristic-label-purge dune build --root . lib/dashboard/dashboard_http_keeper_snapshot.ml`
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=/tmp/masc-dune-dashboard-heuristic-label-purge dune build --root . @install`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/api/dashboard.test.ts src/components/keeper-config-panel.test.ts src/journal-entry.test.ts src/components/fleet-fsm-matrix.test.ts src/components/composite-fsm-flowchart.test.ts`
- `pnpm --dir dashboard exec tsc --noEmit`
- `pnpm --dir dashboard build`
- `git diff --check`