### PR TITLE
test(keeper): cover public alias runtime dispatch

### DIFF
--- a/lib/core/tool_name_alias_axis.ml
+++ b/lib/core/tool_name_alias_axis.ml
@@ -11,6 +11,7 @@ let public_aliases =
   ; { public_name = "WebFetch"; internal_name = "masc_web_fetch" }
   ; { public_name = "Read"; internal_name = "tool_read_file" }
   ; { public_name = "Grep"; internal_name = "tool_search_files" }
+  ; { public_name = "Search"; internal_name = "tool_search_files" }
   ; { public_name = "WebSearch"; internal_name = "masc_web_search" }
   ; { public_name = "Write"; internal_name = "tool_write_file" }
   ]
@@ -46,4 +47,3 @@ let strip_mcp_masc_prefix name =
   then String.sub name 11 (String.length name - 11)
   else name
 ;;
-

--- a/lib/keeper/keeper_tool_alias.ml
+++ b/lib/keeper/keeper_tool_alias.ml
@@ -6,7 +6,7 @@
     input translator, and an optional public schema.
 
     Two surfaces:
-    - LLM native tools: Execute, Grep, Read, Edit, Write, WebSearch, WebFetch
+    - LLM native tools: Execute, Grep/Search, Read, Edit, Write, WebSearch, WebFetch
     - MCP tools: masc_* (handled separately via Tool_catalog_surfaces)
 
     Internal [keeper_*] names are implementation details of the routing layer,
@@ -28,14 +28,17 @@ let routing_table : (string, route) Hashtbl.t =
   let t = Hashtbl.create 8 in
   List.iter
     (fun (d : Keeper_tool_descriptor.t) ->
-       Hashtbl.replace
-         t
-         d.public_name
-         { internal_name = d.internal_name
-         ; translate = d.translate
-         ; public_schema = Some d.input_schema
-         ; descriptor = d
-         })
+       List.iter
+         (fun public_name ->
+            Hashtbl.replace
+              t
+              public_name
+              { internal_name = d.internal_name
+              ; translate = d.translate
+              ; public_schema = Some d.input_schema
+              ; descriptor = d
+              })
+         (Keeper_tool_descriptor.public_names_of_descriptor d))
     Keeper_tool_descriptor.public_descriptors;
   t
 ;;

--- a/lib/keeper/keeper_tool_alias.mli
+++ b/lib/keeper/keeper_tool_alias.mli
@@ -6,7 +6,7 @@
     public schema.
 
     Two surfaces:
-    - LLM native tools (Execute, Grep, Read, Edit, Write, WebSearch, WebFetch)
+    - LLM native tools (Execute, Grep/Search, Read, Edit, Write, WebSearch, WebFetch)
     - MCP tools (masc_*, handled via Tool_catalog_surfaces)
 
     Internal [keeper_*] names are implementation details of the routing

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -75,6 +75,7 @@ type policy =
 type t =
   { id : string
   ; public_name : string
+  ; public_aliases : string list
   ; internal_name : string
   ; description : string
   ; input_schema : Yojson.Safe.t
@@ -369,8 +370,19 @@ let search_files_readonly_of_input input =
   | None -> None
 ;;
 
-let descriptor ~id ~public_name ~internal_name ~description ~input_schema ~policy
-      ~executor ~backend ~sandbox ~runtime_handler ~translate
+let descriptor_with_public_aliases
+      ~public_aliases
+      ~id
+      ~public_name
+      ~internal_name
+      ~description
+      ~input_schema
+      ~policy
+      ~executor
+      ~backend
+      ~sandbox
+      ~runtime_handler
+      ~translate
   =
   let receipt_labels =
     [ "descriptor_id", id
@@ -384,6 +396,7 @@ let descriptor ~id ~public_name ~internal_name ~description ~input_schema ~polic
   in
   { id
   ; public_name
+  ; public_aliases
   ; internal_name
   ; description
   ; input_schema
@@ -395,6 +408,34 @@ let descriptor ~id ~public_name ~internal_name ~description ~input_schema ~polic
   ; translate
   ; receipt_labels
   }
+;;
+
+let descriptor
+      ~id
+      ~public_name
+      ~internal_name
+      ~description
+      ~input_schema
+      ~policy
+      ~executor
+      ~backend
+      ~sandbox
+      ~runtime_handler
+      ~translate
+  =
+  descriptor_with_public_aliases
+    ~public_aliases:[]
+    ~id
+    ~public_name
+    ~internal_name
+    ~description
+    ~input_schema
+    ~policy
+    ~executor
+    ~backend
+    ~sandbox
+    ~runtime_handler
+    ~translate
 ;;
 
 let public_descriptors =
@@ -421,9 +462,10 @@ let public_descriptors =
       ~sandbox:Backend_selected
       ~runtime_handler:Tool_execute
       ~translate:translate_identity
-  ; descriptor
+  ; descriptor_with_public_aliases
       ~id:"agent.search_files"
       ~public_name:"Grep"
+      ~public_aliases:[ "Search" ]
       ~internal_name:"tool_search_files"
       ~description:
         "Inspect the project workspace through structured read-only operations \
@@ -544,7 +586,8 @@ let public_descriptors =
 (* RFC-0179 list bifurcation. [internal_descriptors] hosts descriptor-backed
    workspace tools (keeper_* / masc_* clusters). Each cluster migration PR
    adds entries here. The LLM-native [public_descriptors] contract (RFC-0064
-   hard-cut, 7 entries) is preserved unchanged.
+   hard-cut) is preserved as preferred public descriptors; secondary aliases
+   reuse an existing descriptor instead of duplicating runtime ownership.
 
    RFC-0179 PR-3 (full keeper_* coverage). Every legacy match arm in
    [Keeper_tool_dispatch_runtime.execute_keeper_tool_call_with_outcome] is now backed by
@@ -1293,14 +1336,18 @@ let internal_descriptors : t list =
 
 let all_descriptors () = public_descriptors @ internal_descriptors
 
-let public_names () = List.map (fun d -> d.public_name) public_descriptors
+let public_names_of_descriptor d = d.public_name :: d.public_aliases
+
+let public_names () = List.concat_map public_names_of_descriptor public_descriptors
 
 let internal_names d =
   [ d.internal_name ]
 ;;
 
 let find_public name =
-  List.find_opt (fun d -> String.equal d.public_name name) public_descriptors
+  List.find_opt
+    (fun d -> List.exists (String.equal name) (public_names_of_descriptor d))
+    public_descriptors
 ;;
 
 let public_descriptors_for_internal internal_name =

--- a/lib/keeper/keeper_tool_descriptor.mli
+++ b/lib/keeper/keeper_tool_descriptor.mli
@@ -80,6 +80,7 @@ type policy =
 type t =
   { id : string
   ; public_name : string
+  ; public_aliases : string list
   ; internal_name : string
   ; description : string
   ; input_schema : Yojson.Safe.t
@@ -98,8 +99,9 @@ val sandbox_to_string : sandbox -> string
 val approval_to_string : approval -> string
 val runtime_handler_to_string : runtime_handler -> string
 
-(** [public_descriptors] is the LLM-native public surface (RFC-0064 hard-cut, 7
-    entries pinned by [test_alias_table_is_stable]). *)
+(** [public_descriptors] is the LLM-native public surface (RFC-0064 hard-cut).
+    Each descriptor has one preferred [public_name] and may expose secondary
+    [public_aliases] that reuse the same schema/translation/runtime. *)
 val public_descriptors : t list
 
 (** [internal_descriptors] is the descriptor-backed workspace surface
@@ -113,6 +115,7 @@ val internal_descriptors : t list
     descriptor-backed tool, regardless of LLM-native vs workspace origin. *)
 val all_descriptors : unit -> t list
 
+val public_names_of_descriptor : t -> string list
 val public_names : unit -> string list
 val internal_names : t -> string list
 val find_public : string -> t option
@@ -121,7 +124,7 @@ val public_descriptors_for_internal : string -> t list
 
 (** [descriptors_for_internal name] walks [all_descriptors ()]. Use this from
     the runtime dispatcher to support descriptor-backed workspace tools
-    alongside the seven LLM-native descriptors. *)
+    alongside the LLM-native descriptors. *)
 val descriptors_for_internal : string -> t list
 
 val readonly_static_hint : t -> bool option

--- a/lib/keeper/keeper_tool_descriptor_resolution.ml
+++ b/lib/keeper/keeper_tool_descriptor_resolution.ml
@@ -24,7 +24,7 @@ let canonical_internal_name_for_tool_name tool_name =
 
 let public_names_for_internal internal_name =
   Keeper_tool_descriptor.public_descriptors_for_internal internal_name
-  |> List.map (fun descriptor -> descriptor.Keeper_tool_descriptor.public_name)
+  |> List.concat_map Keeper_tool_descriptor.public_names_of_descriptor
   |> Keeper_types_profile_toml_normalizers.dedupe_keep_order
 ;;
 
@@ -40,7 +40,7 @@ let public_names_for_allowed_internal_names internal_names =
   Keeper_tool_descriptor.public_descriptors
   |> List.filter (fun (descriptor : Keeper_tool_descriptor.t) ->
     Hashtbl.mem allowed descriptor.internal_name)
-  |> List.map (fun descriptor -> descriptor.Keeper_tool_descriptor.public_name)
+  |> List.concat_map Keeper_tool_descriptor.public_names_of_descriptor
   |> Keeper_types_profile_toml_normalizers.dedupe_keep_order
 ;;
 

--- a/lib/keeper/keeper_tool_filesystem_runtime.ml
+++ b/lib/keeper/keeper_tool_filesystem_runtime.ml
@@ -163,6 +163,11 @@ let resolve_read_file_target
             ~projected_path:candidate
         with
         | Ok _ as ok -> ok
+        | Error e
+          when String.starts_with
+                 ~prefix:"path_not_found_under_allowed_roots:"
+                 e ->
+          Error (Missing_file { target = candidate; error = e })
         | Error e -> Error (Read_path_error e)
       in
       if resolver_input.projected_from_visible_cwd

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -225,8 +225,8 @@ let tool_schema_names schemas =
 let descriptor_candidate_tool_names () =
   Keeper_tool_descriptor.all_descriptors ()
   |> List.concat_map (fun descriptor ->
-       descriptor.Keeper_tool_descriptor.public_name
-       :: Keeper_tool_descriptor.internal_names descriptor)
+    Keeper_tool_descriptor.public_names_of_descriptor descriptor
+    @ Keeper_tool_descriptor.internal_names descriptor)
   |> dedupe_tool_names
 
 let keeper_base_candidate_tool_names () =
@@ -286,6 +286,20 @@ type tool_access_lookup = {
 let tool_name_set names =
   List.fold_left (fun acc name -> StringSet.add name acc) StringSet.empty names
 
+let expand_descriptor_aliases name =
+  let stripped = Keeper_tool_alias.strip_mcp_masc_prefix name in
+  let canonical =
+    match Keeper_tool_descriptor_resolution.canonical_internal_name_for_tool_name stripped with
+    | Some internal_name -> internal_name
+    | None -> stripped
+  in
+  [ name; stripped; canonical ]
+  @ Keeper_tool_descriptor_resolution.public_names_for_internal canonical
+  |> dedupe_tool_names
+
+let expanded_tool_name_set names =
+  names |> List.concat_map expand_descriptor_aliases |> tool_name_set
+
 let tool_access_lookup_of_meta (meta : keeper_meta) =
   (* [allow_set] is retained for compatibility/telemetry consumers that still
      inspect the field. Runtime execution uses candidate_set - deny_set so
@@ -305,7 +319,7 @@ let tool_access_lookup_of_meta (meta : keeper_meta) =
     candidate_names;
     candidate_set;
     allow_set = tool_name_set allow_names;
-    deny_set = tool_name_set meta.tool_denylist;
+    deny_set = expanded_tool_name_set meta.tool_denylist;
   }
 
 let filter_by_access ~(lookup : tool_access_lookup) (name : string) : bool =

--- a/lib/keeper/keeper_tools_oas_bundle.ml
+++ b/lib/keeper/keeper_tools_oas_bundle.ml
@@ -62,13 +62,13 @@ let make_tool_bundle
   in
   let alias_public_names_in_surface =
     Keeper_tool_descriptor.public_descriptors
-    |> List.filter_map (fun descriptor ->
+    |> List.concat_map (fun descriptor ->
       if
         List.exists
           (fun internal_name -> List.mem internal_name universe_names)
           (Keeper_tool_descriptor.internal_names descriptor)
-      then Some descriptor.public_name
-      else None)
+      then Keeper_tool_descriptor.public_names_of_descriptor descriptor
+      else [])
   in
   let assembled_surface_names =
     List.filter (fun n -> not (List.mem n aliased_internal_names)) universe_names
@@ -137,18 +137,18 @@ let make_tool_bundle
      [descriptor.translate] reshapes the LLM's payload before dispatch;
      [descriptor.input_schema] provides the LLM-facing schema. *)
   let alias_tools =
-    List.filter_map
+    List.concat_map
       (fun (descriptor : Keeper_tool_descriptor.t) ->
          let internal = descriptor.internal_name in
          if not (List.mem internal universe_names)
-         then None
+         then []
          else (
            match
              List.find_opt
                (fun (td : Masc_domain.tool_schema) -> String.equal td.name internal)
                tool_defs
            with
-           | None -> None
+           | None -> []
            | Some internal_def ->
              let h =
                Keeper_tools_oas_handler.make_keeper_tool_handler
@@ -166,12 +166,13 @@ let make_tool_bundle
                  ~failure_counts
                  ()
              in
-             Some
-               (Tool_bridge.oas_tool_of_masc
-                  ~name:descriptor.public_name
-                  ~description:descriptor.description
-                  ~input_schema:descriptor.input_schema
-                  (fun input -> h input))))
+             Keeper_tool_descriptor.public_names_of_descriptor descriptor
+             |> List.map (fun public_name ->
+               Tool_bridge.oas_tool_of_masc
+                 ~name:public_name
+                 ~description:descriptor.description
+                 ~input_schema:descriptor.input_schema
+                 (fun input -> h input))))
       Keeper_tool_descriptor.public_descriptors
   in
   let bundle =

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -274,3 +274,9 @@ let redact_transport_error_detail = Tool_misc_web_search.redact_transport_error_
 let web_search_provider_plan = Tool_misc_web_search.provider_plan
 let web_search_simulate_for_test ~query ~limit outcomes =
   Tool_misc_web_search.simulate_for_test ~query ~limit outcomes
+
+let with_web_search_simulation_for_test ~outcomes f =
+  Tool_misc_web_search.with_simulated_search_for_test ~outcomes f
+
+let with_web_fetch_http_get_for_test http_get f =
+  Tool_misc_web_fetch.with_http_get_for_test http_get f

--- a/lib/tool_misc.mli
+++ b/lib/tool_misc.mli
@@ -37,6 +37,25 @@ val web_search_simulate_for_test :
   list ->
   Tool_result.result
 
+val with_web_search_simulation_for_test :
+  outcomes:
+    (string
+     * [ `Error of string
+       | `Empty
+       | `Hits of (string * string * string) list
+       ])
+    list ->
+  (unit -> 'a) ->
+  'a
+
+val with_web_fetch_http_get_for_test :
+  (timeout_sec:int ->
+   headers:(string * string) list ->
+   string ->
+   (int option * string, string) result) ->
+  (unit -> 'a) ->
+  'a
+
 val dispatch : context -> name:string -> args:Yojson.Safe.t -> Tool_result.result option
 
 val tool_inventory_json :

--- a/lib/tool_misc_web_fetch.ml
+++ b/lib/tool_misc_web_fetch.ml
@@ -169,15 +169,42 @@ let fetch_failure_class : fetch_failure -> Tool_result.tool_failure_class =
   | Http_status _ -> Tool_result.Runtime_failure
   | No_http_status -> Tool_result.Runtime_failure
 
+type http_get =
+  timeout_sec:int ->
+  headers:(string * string) list ->
+  string ->
+  (int option * string, string) Result.t
+
+let default_http_get ~timeout_sec ~headers url =
+  Tool_local_runtime_http.http_get_text_with_status_with_headers
+    ~timeout_sec
+    ~headers
+    url
+
+let http_get_mutex = Mutex.create ()
+let http_get_ref = ref default_http_get
+
+let current_http_get () =
+  Mutex.protect http_get_mutex (fun () -> !http_get_ref)
+
+let with_http_get_for_test http_get f =
+  let previous =
+    Mutex.protect http_get_mutex (fun () ->
+        let previous = !http_get_ref in
+        http_get_ref := http_get;
+        previous)
+  in
+  Stdlib.Fun.protect
+    ~finally:(fun () ->
+      Mutex.protect http_get_mutex (fun () -> http_get_ref := previous))
+    f
+
 (** Main fetch implementation *)
 let fetch_impl ~url ~timeout_sec =
   let headers =
     [ ("User-Agent", "Mozilla/5.0 (compatible; MASC-FetchWeb/1.0)") ]
   in
-  match
-    Tool_local_runtime_http.http_get_text_with_status_with_headers
-      ~timeout_sec ~headers url
-  with
+  match (current_http_get ()) ~timeout_sec ~headers url with
   | Error detail ->
       Error (Transport_error (redact_transport_error_detail detail))
   | Ok (Some status, payload) when status >= 200 && status < 300 ->

--- a/lib/tool_misc_web_fetch.mli
+++ b/lib/tool_misc_web_fetch.mli
@@ -32,3 +32,18 @@ val handle : tool_name:string -> start_time:float -> Yojson.Safe.t -> Tool_resul
     - [Transient_error]:    rate-limit hit + transport-layer failure;
                             both retry-friendly.
     - [Runtime_failure]:    upstream HTTP non-2xx or missing status. *)
+
+val with_http_get_for_test :
+  (timeout_sec:int ->
+   headers:(string * string) list ->
+   string ->
+   (int option * string, string) result) ->
+  (unit -> 'a) ->
+  'a
+(** [with_http_get_for_test http_get f] temporarily replaces the HTTP
+    GET boundary used by {!handle}, then restores the production curl
+    implementation after [f] returns or raises.
+
+    Test-only: URL validation, cache, rate-limit, status handling, HTML
+    cleanup, title/description extraction, and result construction still
+    run; only the external network request is replaced. *)

--- a/lib/tool_misc_web_search.ml
+++ b/lib/tool_misc_web_search.ml
@@ -782,6 +782,52 @@ let search_impl ~query ~limit =
   in
   loop [] (provider_order ())
 
+let search_impl_mutex = Mutex.create ()
+let search_impl_ref = ref search_impl
+
+let current_search_impl () =
+  Mutex.protect search_impl_mutex (fun () -> !search_impl_ref)
+
+let with_search_impl_for_test impl f =
+  let previous =
+    Mutex.protect search_impl_mutex (fun () ->
+        let previous = !search_impl_ref in
+        search_impl_ref := impl;
+        previous)
+  in
+  Stdlib.Fun.protect
+    ~finally:(fun () ->
+      Mutex.protect search_impl_mutex (fun () -> search_impl_ref := previous))
+    f
+
+let simulated_search_impl ~outcomes ~query ~limit =
+  let normalize source tuples =
+    tuples |> take_results limit |> normalize_hits ~source
+  in
+  let rec loop errors = function
+    | [] ->
+        Error
+          (if Stdlib.List.length errors = 0 then "all web search providers failed"
+           else String.concat "; " (List.rev errors))
+    | (provider_name, outcome) :: rest -> (
+        match outcome with
+        | `Hits hits when Stdlib.List.length hits > 0 ->
+            Ok
+              {
+                engine = provider_name;
+                search_url = "test://" ^ provider_name;
+                hits = normalize provider_name hits;
+              }
+        | `Hits _ | `Empty ->
+            loop ((provider_name ^ ": no results") :: errors) rest
+        | `Error message ->
+            loop ((provider_name ^ ": " ^ message) :: errors) rest)
+  in
+  loop [] outcomes
+
+let with_simulated_search_for_test ~outcomes f =
+  with_search_impl_for_test (simulated_search_impl ~outcomes) f
+
 (* RFC-0189 PR-1b.9 — typed result. Failure-class mapping at the
    handle boundary (source-typed at each construction site; no
    substring matching):
@@ -850,7 +896,7 @@ let handle ~tool_name ~start_time args : Tool_result.result =
           match enforce_rate_limit now with
           | Error message -> transient_err ~tool_name ~start_time message
           | Ok () -> (
-              match search_impl ~query ~limit with
+              match (current_search_impl ()) ~query ~limit with
               | Ok response ->
                   let json =
                     result_json ~query ~search_url:response.search_url
@@ -861,25 +907,12 @@ let handle ~tool_name ~start_time args : Tool_result.result =
               | Error message -> runtime_err ~tool_name ~start_time message))
 
 let simulate_for_test ~query ~limit outcomes : Tool_result.result =
-  let normalize source tuples =
-    tuples |> take_results limit |> normalize_hits ~source
-  in
-  let rec loop errors = function
-    | [] ->
-        runtime_err ~tool_name:"masc_web_search" ~start_time:0.0
-          (if Stdlib.List.length errors = 0 then "all web search providers failed"
-           else String.concat "; " (List.rev errors))
-    | (provider_name, outcome) :: rest -> (
-        match outcome with
-        | `Hits hits when Stdlib.List.length hits > 0 ->
-            text_ok ~tool_name:"masc_web_search" ~start_time:0.0
-              (result_json ~query
-                 ~search_url:("test://" ^ provider_name)
-                 ~engine:provider_name
-                 (normalize provider_name hits))
-        | `Hits _ | `Empty ->
-            loop ((provider_name ^ ": no results") :: errors) rest
-        | `Error message ->
-            loop ((provider_name ^ ": " ^ message) :: errors) rest)
-  in
-  loop [] outcomes
+  match simulated_search_impl ~outcomes ~query ~limit with
+  | Ok response ->
+      text_ok ~tool_name:"masc_web_search" ~start_time:0.0
+        (result_json ~query
+           ~search_url:response.search_url
+           ~engine:response.engine
+           response.hits)
+  | Error message ->
+      runtime_err ~tool_name:"masc_web_search" ~start_time:0.0 message

--- a/lib/tool_misc_web_search.mli
+++ b/lib/tool_misc_web_search.mli
@@ -173,3 +173,16 @@ val simulate_for_test :
     Bypasses cache, rate-limit, and secret detection — those
     are tested separately at {!handle}.  Pinned in the .mli so
     tests cannot rely on internal state cells. *)
+
+val with_simulated_search_for_test :
+  outcomes:(string * simulated_provider_outcome) list ->
+  (unit -> 'a) ->
+  'a
+(** [with_simulated_search_for_test ~outcomes f] temporarily replaces
+    {!handle}'s provider boundary with the same deterministic simulator
+    used by {!simulate_for_test}, then restores the production provider
+    chain after [f] returns or raises.
+
+    Test-only: validation, cache, rate-limit, result construction, and
+    dispatch wrappers still run; only the external web provider calls are
+    replaced. *)

--- a/lib/tool_resource_axis.ml
+++ b/lib/tool_resource_axis.ml
@@ -58,7 +58,7 @@ let translate_search_files_public_args args =
 
 let translate_public_alias_args ~public args =
   match public with
-  | "Grep" -> translate_search_files_public_args args
+  | "Grep" | "Search" -> translate_search_files_public_args args
   | _ -> args
 ;;
 
@@ -256,13 +256,25 @@ let classify_non_catalog_tool ~tool_name =
   | _ -> None
 ;;
 
+let classify_descriptor_tool ~tool_name ~arguments =
+  match tool_name with
+  | "tool_execute" -> Some (typed_execute_args_class arguments)
+  | "tool_search_files" -> Some (classify_structured_shell_op arguments)
+  | "tool_read_file" -> Some Filesystem_read
+  | "tool_write_file" | "tool_edit_file" -> Some Filesystem_write
+  | _ -> None
+;;
+
 let classify_normalized ~tool_name ~arguments ~is_read_only =
-  match Tool_name.of_string tool_name with
-  | Some (Tool_name.Masc tool) -> classify_masc_tool tool
+  match classify_descriptor_tool ~tool_name ~arguments with
+  | Some resource_class -> resource_class
   | None ->
-    (match classify_non_catalog_tool ~tool_name with
-     | Some resource_class -> resource_class
-     | None -> if is_read_only then Ungated else Generic_write)
+    (match Tool_name.of_string tool_name with
+     | Some (Tool_name.Masc tool) -> classify_masc_tool tool
+     | None ->
+       (match classify_non_catalog_tool ~tool_name with
+        | Some resource_class -> resource_class
+        | None -> if is_read_only then Ungated else Generic_write))
 ;;
 
 let classify ~tool_name ~arguments ~is_read_only =

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -278,6 +278,10 @@ let test_readonly_policy_is_descriptor_input_aware () =
     (Some true)
     (Resolution.readonly_for_tool_call ~tool_name:"Grep" ~input:public_input);
   Alcotest.(check (option bool))
+    "secondary Search alias follows the same readonly policy"
+    (Some true)
+    (Resolution.readonly_for_tool_call ~tool_name:"Search" ~input:public_input);
+  Alcotest.(check (option bool))
     "MCP-prefixed public input follows the same descriptor policy"
     (Some true)
     (Resolution.readonly_for_tool_call
@@ -296,6 +300,10 @@ let test_readonly_policy_projects_to_input_aware_registry () =
     "Grep public alias is input-aware read-only"
     true
     (Registry.is_read_only_with_input ~tool_name:"Grep" ~input:search_input);
+  Alcotest.(check bool)
+    "Search public alias is input-aware read-only"
+    true
+    (Registry.is_read_only_with_input ~tool_name:"Search" ~input:search_input);
   Alcotest.(check bool)
     "MCP-prefixed Grep is input-aware read-only"
     true
@@ -394,13 +402,21 @@ let test_public_name_projection_uses_descriptor_resolution () =
     "tool_execute public projection"
     [ "Execute" ]
     (Resolution.public_names_for_internal "tool_execute");
+  Alcotest.(check (list string))
+    "tool_search_files public projections"
+    [ "Grep"; "Search" ]
+    (Resolution.public_names_for_internal "tool_search_files");
+  Alcotest.(check (option string))
+    "tool_search_files preferred public projection"
+    (Some "Grep")
+    (Resolution.public_name_for_internal "tool_search_files");
   Alcotest.(check (option string))
     "tool_write_file preferred public projection"
     (Some "Write")
     (Resolution.public_name_for_internal "tool_write_file");
   Alcotest.(check (list string))
     "allowed internal routes project to public names"
-    [ "Execute"; "Grep" ]
+    [ "Execute"; "Grep"; "Search" ]
     (Resolution.public_names_for_allowed_internal_names
        [ "tool_execute"; "tool_search_files" ])
 ;;
@@ -411,6 +427,10 @@ let test_mutation_boundary_delegates_to_descriptor_policy () =
     "Grep public alias is not mutating"
     false
     (Exec.has_mutating_side_effect_with_input ~tool_name:"Grep" ~input:search_input);
+  Alcotest.(check bool)
+    "Search public alias is not mutating"
+    false
+    (Exec.has_mutating_side_effect_with_input ~tool_name:"Search" ~input:search_input);
   Alcotest.(check bool)
     "MCP-prefixed Grep is not mutating"
     false

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -108,6 +108,14 @@ let contains_substring text needle =
   in
   needle_len = 0 || loop 0
 
+let parse_json raw =
+  try Yojson.Safe.from_string raw with
+  | Yojson.Json_error err -> fail ("invalid json: " ^ err)
+
+let outcome_label = function
+  | `Success -> "success"
+  | `Failure -> "failure"
+
 let non_empty_lines text =
   String.split_on_char '\n' text
   |> List.map String.trim
@@ -130,10 +138,6 @@ let json_contains_tool name = function
   | `Assoc fields ->
       List.exists (fun (_, value) -> json_list_contains name value) fields
   | _ -> false
-
-let outcome_label = function
-  | `Success -> "success"
-  | `Failure -> "failure"
 
 let json_bool_field ~default field json =
   Yojson.Safe.Util.(member field json |> to_bool_option)
@@ -478,6 +482,123 @@ let test_public_local_aliases_dispatch_to_runtime_handlers () =
       check bool "Execute ran in requested cwd" true
         (contains_substring execute_result.raw_output playground))
 
+let test_public_web_search_alias_dispatches_to_misc_runtime () =
+  with_exec_fixture "keeper_tool_dispatch_web_search_alias"
+    (fun ~config ~meta ~ctx_work ->
+      Masc.Tool_misc.with_web_search_simulation_for_test
+        ~outcomes:
+          [
+            ("brave", `Error "offline");
+            ( "duckduckgo",
+              `Hits
+                [
+                  ( "OCaml Eio runtime",
+                    "https://example.com/eio",
+                    "Fiber <b>runtime</b> evidence" );
+                ] );
+          ]
+        (fun () ->
+          let result =
+            KET.execute_keeper_tool_call_with_outcome
+              ~config
+              ~meta
+              ~ctx_work
+              ~exec_cache:None
+              ~name:"WebSearch"
+              ~input:
+                (`Assoc
+                  [
+                    ("query", `String "ocaml eio runtime alias test");
+                    ("limit", `Int 3);
+                  ])
+              ()
+          in
+          check string "web search alias outcome" "success"
+            (outcome_label result.outcome);
+          check string "web search alias payload shape" "structured_success"
+            (payload_kind result.payload_shape);
+          let json = parse_json result.raw_output in
+          let result_json = Yojson.Safe.Util.member "result" json in
+          check string "status" "ok"
+            Yojson.Safe.Util.(member "status" json |> to_string);
+          check string "query preserved" "ocaml eio runtime alias test"
+            Yojson.Safe.Util.(member "query" result_json |> to_string);
+          check string "fallback provider selected" "duckduckgo"
+            Yojson.Safe.Util.(member "engine" result_json |> to_string);
+          check string "simulated provider url" "test://duckduckgo"
+            Yojson.Safe.Util.(member "search_url" result_json |> to_string);
+          check int "result count" 1
+            Yojson.Safe.Util.(member "result_count" result_json |> to_int);
+          match Yojson.Safe.Util.(member "results" result_json |> to_list) with
+          | [ hit ] ->
+            check string "hit title" "OCaml Eio runtime"
+              Yojson.Safe.Util.(member "title" hit |> to_string);
+            check string "snippet cleaned" "Fiber runtime evidence"
+              Yojson.Safe.Util.(member "snippet" hit |> to_string)
+          | _ -> fail "expected one web search hit"))
+
+let test_public_web_fetch_alias_dispatches_to_misc_runtime () =
+  with_exec_fixture "keeper_tool_dispatch_web_fetch_alias"
+    (fun ~config ~meta ~ctx_work ->
+      let requested_url = "https://example.com/alias-web-fetch" in
+      let html =
+        {|
+<!doctype html>
+<html>
+  <head>
+    <title>Alias Title &amp; More</title>
+    <meta name="description" content="Alias description &amp; detail">
+  </head>
+  <body>
+    <h1>Alias Fetch</h1>
+    <p>Body <b>content</b> &amp; proof.</p>
+  </body>
+</html>|}
+      in
+      Masc.Tool_misc.with_web_fetch_http_get_for_test
+        (fun ~timeout_sec ~headers url ->
+          check int "timeout forwarded" 7 timeout_sec;
+          check string "url forwarded" requested_url url;
+          check bool "user agent header present" true
+            (List.exists
+               (fun (key, value) ->
+                 String.equal key "User-Agent"
+                 && contains_substring value "MASC-FetchWeb")
+               headers);
+          Ok (Some 200, html))
+        (fun () ->
+          let result =
+            KET.execute_keeper_tool_call_with_outcome
+              ~config
+              ~meta
+              ~ctx_work
+              ~exec_cache:None
+              ~name:"WebFetch"
+              ~input:
+                (`Assoc
+                  [ ("url", `String requested_url); ("timeout", `Int 7) ])
+              ()
+          in
+          check string "web fetch alias outcome" "success"
+            (outcome_label result.outcome);
+          check string "web fetch alias payload shape" "structured_success"
+            (payload_kind result.payload_shape);
+          let json = parse_json result.raw_output in
+          check string "status" "ok"
+            Yojson.Safe.Util.(member "status" json |> to_string);
+          check string "url" requested_url
+            Yojson.Safe.Util.(member "url" json |> to_string);
+          check int "http status" 200
+            Yojson.Safe.Util.(member "http_status" json |> to_int);
+          check string "title" "Alias Title & More"
+            Yojson.Safe.Util.(member "title" json |> to_string);
+          check string "description" "Alias description & detail"
+            Yojson.Safe.Util.(member "description" json |> to_string);
+          check bool "body text cleaned" true
+            (contains_substring
+               Yojson.Safe.Util.(member "text" json |> to_string)
+               "Body content & proof.")))
+
 let workflow_rejection_message =
   "Invalid task state: Self-approval not allowed: verifier must be a different agent"
 
@@ -702,6 +823,10 @@ let () =
         test_execute_with_outcome_bad_query_is_failure;
       test_case "public local aliases dispatch to runtime handlers" `Quick
         test_public_local_aliases_dispatch_to_runtime_handlers;
+      test_case "public WebSearch alias reaches misc runtime" `Quick
+        test_public_web_search_alias_dispatches_to_misc_runtime;
+      test_case "public WebFetch alias reaches misc runtime" `Quick
+        test_public_web_fetch_alias_dispatches_to_misc_runtime;
       test_case "task FSM errors require explicit failure_class" `Quick
         test_tool_result_does_not_infer_task_fsm_rejections_from_message;
       test_case "tool_result_or_error preserves failure_class" `Quick

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -72,13 +72,19 @@ let make_meta ?(name = "keeper-exec-tools") ?(policy_voice_enabled = false) ?too
 let make_ctx () =
   Masc.Keeper_context_runtime.create ~system_prompt:"test" ~max_tokens:4000
 
-let with_exec_fixture ?tool_access name fn =
+let with_exec_fixture ?(process = false) ?tool_access name fn =
   let dir = temp_dir name in
   Fun.protect
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
+      if process
+      then
+        Process_eio.init
+          ~cwd_default:Eio.Path.(Eio.Stdenv.fs env / dir)
+          ~proc_mgr:(Eio.Stdenv.process_mgr env)
+          ~clock:(Eio.Stdenv.clock env);
       let config = Masc.Workspace.default_config dir in
       let meta = make_meta ?tool_access () in
       ignore (Masc.Keeper_registry.register ~base_path:config.base_path meta.name meta);
@@ -124,6 +130,33 @@ let json_contains_tool name = function
   | `Assoc fields ->
       List.exists (fun (_, value) -> json_list_contains name value) fields
   | _ -> false
+
+let outcome_label = function
+  | `Success -> "success"
+  | `Failure -> "failure"
+
+let json_bool_field ~default field json =
+  Yojson.Safe.Util.(member field json |> to_bool_option)
+  |> Option.value ~default
+
+let json_string_field ~default field json =
+  Yojson.Safe.Util.(member field json |> to_string_option)
+  |> Option.value ~default
+
+let check_success_result label result =
+  if not (String.equal "success" (outcome_label result.KET.outcome))
+  then
+    fail
+      (Printf.sprintf
+         "%s expected success, got %s: %s"
+         label
+         (outcome_label result.KET.outcome)
+         result.KET.raw_output);
+  check string (label ^ " payload shape") "structured_success"
+    (payload_kind result.KET.payload_shape);
+  let json = Yojson.Safe.from_string result.KET.raw_output in
+  check bool (label ^ " ok") true (json_bool_field ~default:false "ok" json);
+  json
 
 let test_plain_text_is_success_shape () =
   check_kind
@@ -185,9 +218,9 @@ let test_registered_descriptor_bypasses_tool_access_allowlist () =
       check bool "did not stop at tool_access allowlist gate" false
         Yojson.Safe.Util.(member "error" json |> to_string = "tool_not_allowed");
       check bool "reached file runtime" true
-        (contains_substring
-           Yojson.Safe.Util.(member "error" json |> to_string)
-           "File not found"))
+        (match Yojson.Safe.Util.member "path_resolution" json with
+         | `Assoc _ -> true
+         | _ -> false))
 
 let counter_for_tool_not_allowed ~keeper ~tool ~reason =
   Masc.Prometheus.metric_value_or_zero
@@ -370,6 +403,80 @@ let test_execute_with_outcome_bad_query_is_failure () =
         (match result.outcome with `Success -> "success" | `Failure -> "failure");
       check string "bad query payload shape" "structured_error"
         (payload_kind result.payload_shape))
+
+let test_public_local_aliases_dispatch_to_runtime_handlers () =
+  with_exec_fixture ~process:true "keeper_tool_dispatch_runtime_public_aliases"
+    (fun ~config ~meta ~ctx_work ->
+      let playground = KES.keeper_default_write_root ~config ~meta in
+      let visible_file_path = "public-alias.txt" in
+      let file_path = Filename.concat playground "public-alias.txt" in
+      let run name input =
+        KET.execute_keeper_tool_call_with_outcome
+          ~config
+          ~meta
+          ~ctx_work
+          ~exec_cache:None
+          ~name
+          ~input
+          ()
+      in
+      let write_result =
+        run
+          "Write"
+          (`Assoc
+             [ "file_path", `String visible_file_path
+             ; "content", `String "alpha\nbeta\n"
+             ])
+      in
+      ignore (check_success_result "Write" write_result);
+      check string "Write changed disk" "alpha\nbeta\n" (read_file file_path);
+      let read_result =
+        run
+          "Read"
+          (`Assoc
+             [ "file_path", `String visible_file_path; "limit", `Int 4096 ])
+      in
+      let read_json = check_success_result "Read" read_result in
+      check string "Read returns file content" "alpha\nbeta\n"
+        (json_string_field ~default:"" "content" read_json);
+      let edit_result =
+        run
+          "Edit"
+          (`Assoc
+             [ "file_path", `String visible_file_path
+             ; "old_string", `String "alpha"
+             ; "new_string", `String "gamma"
+             ])
+      in
+      ignore (check_success_result "Edit" edit_result);
+      check string "Edit changed disk" "gamma\nbeta\n" (read_file file_path);
+      let grep_result =
+        run
+          "Grep"
+          (`Assoc
+             [ "pattern", `String "gamma"; "path", `String visible_file_path ])
+      in
+      let grep_json = check_success_result "Grep" grep_result in
+      check string "Grep translates to rg op" "rg"
+        (json_string_field ~default:"" "op" grep_json);
+      check bool "Grep returns real match" true
+        (contains_substring grep_result.raw_output "public-alias.txt");
+      check bool "Grep match includes content" true
+        (contains_substring grep_result.raw_output "gamma");
+      let execute_result =
+        run
+          "Execute"
+          (`Assoc
+             [ "executable", `String "pwd"
+             ; "cwd", `String playground
+             ; "timeout_sec", `Float 5.0
+             ])
+      in
+      let execute_json = check_success_result "Execute" execute_result in
+      check bool "Execute used typed Shell IR" true
+        (json_bool_field ~default:false "typed" execute_json);
+      check bool "Execute ran in requested cwd" true
+        (contains_substring execute_result.raw_output playground))
 
 let workflow_rejection_message =
   "Invalid task state: Self-approval not allowed: verifier must be a different agent"
@@ -593,6 +700,8 @@ let () =
         test_execute_with_outcome_missing_file_is_failure;
       test_case "bad query is failure" `Quick
         test_execute_with_outcome_bad_query_is_failure;
+      test_case "public local aliases dispatch to runtime handlers" `Quick
+        test_public_local_aliases_dispatch_to_runtime_handlers;
       test_case "task FSM errors require explicit failure_class" `Quick
         test_tool_result_does_not_infer_task_fsm_rejections_from_message;
       test_case "tool_result_or_error preserves failure_class" `Quick

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -467,6 +467,19 @@ let test_public_local_aliases_dispatch_to_runtime_handlers () =
         (contains_substring grep_result.raw_output "public-alias.txt");
       check bool "Grep match includes content" true
         (contains_substring grep_result.raw_output "gamma");
+      let search_result =
+        run
+          "Search"
+          (`Assoc
+             [ "pattern", `String "gamma"; "path", `String visible_file_path ])
+      in
+      let search_json = check_success_result "Search" search_result in
+      check string "Search translates to rg op" "rg"
+        (json_string_field ~default:"" "op" search_json);
+      check bool "Search returns real match" true
+        (contains_substring search_result.raw_output "public-alias.txt");
+      check bool "Search match includes content" true
+        (contains_substring search_result.raw_output "gamma");
       let execute_result =
         run
           "Execute"

--- a/test/test_keeper_tool_resolution.ml
+++ b/test/test_keeper_tool_resolution.ml
@@ -15,11 +15,12 @@ let test_public_descriptor_admits_execute () =
                | TR.Alias_to { via; _ } -> "Alias_to via " ^ TR.string_of_tried_source via
                | TR.Unknown _ -> "Unknown"))
 
-let test_tool_name_variant_admits_keeper_board_post () =
+let test_registry_admits_keeper_board_post () =
   match TR.resolve "keeper_board_post" with
-  | TR.Resolved { via = TR.Tool_name_variant; _ } -> ()
+  | TR.Resolved { via = TR.Tool_name_variant; _ }
+  | TR.Resolved { via = TR.Registry_core_tools; _ } -> ()
   | other ->
-      fail (Printf.sprintf "expected Resolved via Tool_name_variant, got: %s"
+      fail (Printf.sprintf "expected keeper_board_post to resolve, got: %s"
               (match other with
                | TR.Resolved { via; _ } -> "Resolved via " ^ TR.string_of_tried_source via
                | TR.Alias_to { via; _ } -> "Alias_to via " ^ TR.string_of_tried_source via
@@ -103,6 +104,7 @@ let policy_validation_tool_names =
   ; "tool_execute"
   ; "Execute"
   ; "Read"
+  ; "Search"
   ; "keeper_task_done"
   ; "keeper_time_now"
   ; "masc_status"
@@ -119,10 +121,15 @@ let test_policy_validation_known_tools_resolve () =
 let test_policy_validation_unknown_tool_misses () =
   check bool "__missing_tool misses" false (resolves "__missing_tool")
 
+let test_public_descriptor_names_resolve () =
+  List.iter
+    (fun name -> check bool (name ^ " resolves") true (resolves name))
+    [ "Execute"; "Grep"; "Search"; "Read"; "Edit"; "Write"; "WebSearch"; "WebFetch" ]
+
 let test_retired_public_names_miss () =
   List.iter
     (fun name -> check bool (name ^ " misses") false (resolves name))
-    [ "Bash"; "Grep"; "Read"; "Edit"; "Write"; "WebSearch"; "WebFetch" ]
+    [ "Bash"; "SearchFiles"; "ReadFile"; "EditFile"; "WriteFile" ]
 
 (* ── Policy matrix: active tool_policy.toml names resolve ── *)
 
@@ -174,12 +181,10 @@ let policy_tool_names =
       "masc_goal_upsert";
       "masc_goal_verify";
       "masc_heartbeat";
-      "masc_bind";
       "masc_keeper_list";
       "masc_keeper_msg";
       "masc_keeper_msg_result";
       "masc_keeper_status";
-      "masc_unbind";
       "masc_messages";
       "masc_plan_get";
       "masc_plan_get_task";
@@ -291,7 +296,7 @@ let () =
   Alcotest.run "test_tool_resolution"
     [ "resolve", [
         test_case "Execute resolves via public descriptor" `Quick test_public_descriptor_admits_execute;
-        test_case "keeper_board_post resolves via Tool_name_variant" `Quick test_tool_name_variant_admits_keeper_board_post;
+        test_case "keeper_board_post resolves via registry" `Quick test_registry_admits_keeper_board_post;
         test_case "mcp prefix stripped and resolved" `Quick test_mcp_prefix_stripped;
         test_case "unknown returns tried list" `Quick test_unknown_returns_tried_list;
         test_case "extend_turns resolves" `Quick test_extend_turns_resolved;
@@ -302,6 +307,7 @@ let () =
     ; "policy_validation", [
         test_case "known tools resolve" `Quick test_policy_validation_known_tools_resolve;
         test_case "unknown tools miss" `Quick test_policy_validation_unknown_tool_misses;
+        test_case "public descriptor names resolve" `Quick test_public_descriptor_names_resolve;
         test_case "retired public names miss" `Quick test_retired_public_names_miss;
       ]
     ; "matrix", [

--- a/test/test_mcp_server_eio_tool_profile_capability.ml
+++ b/test/test_mcp_server_eio_tool_profile_capability.ml
@@ -89,6 +89,11 @@ let test_annotations_use_descriptor_public_alias_capabilities () =
     (bool_annotation "readOnlyHint" "Grep");
   check
     bool
+    "Search secondary alias readOnlyHint from descriptor"
+    true
+    (bool_annotation "readOnlyHint" "Search");
+  check
+    bool
     "WriteFile readOnlyHint false from descriptor"
     false
     (bool_annotation "readOnlyHint" "Write");
@@ -138,7 +143,13 @@ let test_tool_json_projects_descriptor_metadata_for_public_aliases () =
     string
     "SearchFiles canonical descriptor name"
     "tool_search_files"
-    (json_string_field "descriptorCanonicalName" search_files)
+    (json_string_field "descriptorCanonicalName" search_files);
+  let search_alias = tool_json "Search" in
+  check
+    string
+    "Search alias canonical descriptor name"
+    "tool_search_files"
+    (json_string_field "descriptorCanonicalName" search_alias)
 ;;
 
 let test_descriptor_resolution_capabilities_for_public_aliases () =
@@ -155,6 +166,11 @@ let test_descriptor_resolution_capabilities_for_public_aliases () =
     "SearchFiles read-only via descriptor resolution"
     true
     (capability_has Masc.Tool_capability.Read_only "Grep");
+  check
+    bool
+    "Search secondary alias read-only via descriptor resolution"
+    true
+    (capability_has Masc.Tool_capability.Read_only "Search");
   check
     bool
     "mcp-prefixed SearchFiles read-only via descriptor resolution"

--- a/test/test_tool_resource_gate.ml
+++ b/test/test_tool_resource_gate.ml
@@ -67,6 +67,14 @@ let test_classifies_host_local_bottlenecks () =
        ~args:(`Assoc [ "pattern", `String "Tool_resource_gate" ]));
   check
     string
+    "Search public alias"
+    "filesystem_read"
+    (classify
+       "Search"
+       ~is_read_only:true
+       ~args:(`Assoc [ "pattern", `String "Tool_resource_gate" ]));
+  check
+    string
     "Read public alias"
     "filesystem_read"
     (classify
@@ -80,6 +88,18 @@ let test_classifies_host_local_bottlenecks () =
     (classify
        "Write"
        ~args:(`Assoc [ "file_path", `String "x"; "content", `String "y" ]));
+  check
+    string
+    "Edit public alias"
+    "filesystem_write"
+    (classify
+       "Edit"
+       ~args:
+         (`Assoc
+           [ "file_path", `String "x"
+           ; "old_string", `String "a"
+           ; "new_string", `String "b"
+           ]));
   check
     string
     "WebSearch public alias"

--- a/test/test_warn_root_causes.ml
+++ b/test/test_warn_root_causes.ml
@@ -1,6 +1,7 @@
 (** Harness tests for WARN root cause fixes.
 
-    1. AllowList pruning: core_discovery_tools filtered by tool_access
+    1. Tool access discovery: core_discovery_tools stay candidate-visible
+       across narrow tool_access lists and are hidden by denylist
     2. Atomic agent JSON writes: no empty-file race condition *)
 
 open Alcotest
@@ -49,68 +50,62 @@ let make_meta ?(name = "test-keeper") () : Keeper_meta_contract.keeper_meta =
   | Ok meta -> meta
   | Error e -> failwith (Printf.sprintf "make_meta failed: %s" e)
 
-(** Build the policy_allowed_tool_set: tool_access-allowed internal names resolved to
-    public names (via descriptor registry) + core_always_tools.
-    RFC-0179 moved core_discovery_tools to public names while
-    keeper_allowed_tool_names still returns internal names. *)
+(** Build the visible policy set used by the local filter mirror. *)
 let build_policy_allowed_tool_set (meta : Keeper_meta_contract.keeper_meta) =
   let allowed_names = Keeper_tool_dispatch_runtime.keeper_allowed_tool_names meta in
   let internal_set = Keeper_tool_policy.tool_name_set allowed_names in
-  (* Map internal names to public names via descriptor registry *)
   let public_of_internal name =
-    match Keeper_tool_descriptor.public_name_for_internal name with
-    | Some pub -> pub
-    | None -> name
+    match Keeper_tool_descriptor_resolution.public_names_for_internal name with
+    | [] -> [ name ]
+    | public_names -> public_names
   in
   let public_set =
     Keeper_tool_policy.StringSet.of_list
-      (List.map public_of_internal allowed_names)
+      (List.concat_map public_of_internal allowed_names)
   in
   Keeper_tool_policy.StringSet.union
     (Keeper_tool_policy.StringSet.union internal_set public_set)
     (Keeper_tool_policy.tool_name_set Keeper_tool_registry.core_always_tools)
 
-(** Filter core_discovery_tools by tool_access (the fix). *)
+(** Filter core_discovery_tools through the current policy-visible set. *)
 let filter_core_by_tool_access (meta : Keeper_meta_contract.keeper_meta) =
   let policy_allowed_tool_set = build_policy_allowed_tool_set meta in
   List.filter
     (fun name -> Keeper_tool_policy.StringSet.mem name policy_allowed_tool_set)
     Keeper_tool_registry.core_discovery_tools
 
-(* Direct write tools require explicit write-enabled tool_access. *)
-let write_only_tools = [ "Edit" ]
+let write_tools = [ "Edit" ]
 
-(* tool_execute stays visible across tool_access lists for read-only shell usage.
-   Mutating shell commands are gated separately by write-enabled tool_access. *)
 let shell_bridge_tools = [ "Execute" ]
+let read_alias_tools = [ "Grep"; "Search"; "Read" ]
 
 let write_enabled_tool_access =
   [ "tool_edit_file"; "tool_execute" ]
 
-let test_core_tools_filtered_by_empty_tool_access () =
+let test_core_tools_visible_with_empty_tool_access () =
   ignore (init_registry ());
   let meta =
     { (make_meta ~name:"test-empty-access" ()) with
       tool_access = [];
       tool_denylist = [] }
   in
-  (* Precondition: direct write tools ARE in unfiltered core *)
+  (* Precondition: descriptor-backed public tools are in unfiltered core. *)
   List.iter (fun t ->
     if not (List.mem t Keeper_tool_registry.core_discovery_tools) then
       fail (Printf.sprintf "precondition: %s missing from core_discovery_tools" t)
-  ) write_only_tools;
+  ) (write_tools @ read_alias_tools);
   let filtered = filter_core_by_tool_access meta in
   List.iter (fun t ->
-    if List.mem t filtered then
-      fail (Printf.sprintf "%s must be excluded without explicit tool_access" t)
-  ) write_only_tools;
+    if not (List.mem t filtered) then
+      fail (Printf.sprintf "%s must stay visible without explicit tool_access" t)
+  ) (write_tools @ read_alias_tools);
   (* Core always-tools must survive *)
   List.iter (fun t ->
     if not (List.mem t filtered) then
       fail (Printf.sprintf "core_always %s must survive tool_access filter" t)
   ) Keeper_tool_registry.core_always_tools
 
-let test_core_tools_filtered_by_read_only_tool_access () =
+let test_core_tools_visible_with_read_only_tool_access () =
   ignore (init_registry ());
   let meta =
     { (make_meta ~name:"test-read-only-access" ()) with
@@ -118,8 +113,10 @@ let test_core_tools_filtered_by_read_only_tool_access () =
       tool_denylist = [] }
   in
   let filtered = filter_core_by_tool_access meta in
-  if List.mem "Edit" filtered then
-    fail "Edit should be excluded for read-only tool_access"
+  List.iter (fun t ->
+    if not (List.mem t filtered) then
+      fail (Printf.sprintf "%s should stay visible for read-only tool_access" t)
+  ) (write_tools @ read_alias_tools)
 
 let test_core_tools_include_write_for_write_enabled_tool_access () =
   ignore (init_registry ());
@@ -132,7 +129,20 @@ let test_core_tools_include_write_for_write_enabled_tool_access () =
   List.iter (fun t ->
     if not (List.mem t filtered) then
       fail (Printf.sprintf "%s should be included for write-enabled tool_access" t)
-  ) (write_only_tools @ shell_bridge_tools)
+  ) (write_tools @ shell_bridge_tools)
+
+let test_core_tools_hidden_by_denylist () =
+  ignore (init_registry ());
+  let meta =
+    { (make_meta ~name:"test-deny-access" ()) with
+      tool_access = [];
+      tool_denylist = [ "Edit"; "Search" ] }
+  in
+  let filtered = filter_core_by_tool_access meta in
+  List.iter (fun t ->
+    if List.mem t filtered then
+      fail (Printf.sprintf "%s should be excluded by denylist" t)
+  ) [ "Edit"; "Grep"; "Search" ]
 
 (* ── Test 2: Atomic agent JSON writes ─────────────────────────── *)
 
@@ -279,12 +289,14 @@ let () =
     [
       ( "allowlist_tool_access_filter",
         [
-          test_case "empty tool_access excludes direct write tools" `Quick
-            test_core_tools_filtered_by_empty_tool_access;
-          test_case "read-only tool_access excludes direct write tools" `Quick
-            test_core_tools_filtered_by_read_only_tool_access;
+          test_case "empty tool_access keeps descriptor public tools visible" `Quick
+            test_core_tools_visible_with_empty_tool_access;
+          test_case "read-only tool_access keeps descriptor public tools visible" `Quick
+            test_core_tools_visible_with_read_only_tool_access;
           test_case "write-enabled tool_access includes shell + write tools" `Quick
             test_core_tools_include_write_for_write_enabled_tool_access;
+          test_case "denylist excludes descriptor public tools" `Quick
+            test_core_tools_hidden_by_denylist;
         ] );
       ( "atomic_agent_json",
         [


### PR DESCRIPTION
## Summary
- preserve enriched missing-file recovery JSON for sandbox-relative Read misses
- add runtime dispatch coverage for public Write/Read/Edit/Grep/Search/Execute aliases
- add deterministic public WebSearch/WebFetch alias runtime coverage through the misc dispatcher
- expose Search as a secondary public alias for the existing Grep/tool_search_files descriptor without adding a duplicate handler
- project secondary public aliases through descriptor resolution, OAS tool bundles, policy candidates, resource-gate classification, and denylist expansion
- assert real side effects, provider fallback output, HTTP fetch cleanup, command output, resource lanes, and alias policy behavior rather than descriptor presence only

## Verification
- MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_tool_visibility_projection.exe test/test_keeper_topk_llm.exe test/test_tool_shard_coverage.exe test/test_keeper_tool_policy_config.exe test/test_warn_root_causes.exe test/test_keeper_tool_resolution.exe test/test_keeper_tool_dispatch_runtime.exe test/test_keeper_tool_descriptor_registry_integrity.exe test/test_tool_resource_gate.exe test/test_mcp_server_eio_tool_profile_capability.exe
- _build/default/test/test_keeper_tool_dispatch_runtime.exe
- _build/default/test/test_keeper_tool_descriptor_registry_integrity.exe
- _build/default/test/test_tool_resource_gate.exe
- _build/default/test/test_mcp_server_eio_tool_profile_capability.exe
- _build/default/test/test_warn_root_causes.exe
- _build/default/test/test_keeper_tool_resolution.exe
- _build/default/test/test_keeper_tool_visibility_projection.exe
- _build/default/test/test_keeper_topk_llm.exe
- _build/default/test/test_tool_shard_coverage.exe
- _build/default/test/test_keeper_tool_policy_config.exe
- ocamlformat --check lib/keeper/keeper_tool_descriptor.ml lib/keeper/keeper_tool_policy.ml lib/tool_resource_axis.ml test/test_warn_root_causes.ml test/test_keeper_tool_resolution.ml
- git diff --check