### PR TITLE
refactor(keeper): decouple board wrapper policy from tool enum

### DIFF
--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -123,6 +123,15 @@ let dedupe_tool_schemas (schemas : Masc_domain.tool_schema list) =
         true))
     schemas
 
+let masc_board_tools_with_keeper_wrappers =
+  [
+    "masc_board_comment";
+    "masc_board_curation_submit";
+    "masc_board_post";
+    "masc_board_vote";
+    "masc_board_delete";
+  ]
+
 (* ── Schema injection filter ──────────────────────────────────── *)
 
 let keeper_safe_inline_tools () =
@@ -186,12 +195,7 @@ let keeper_supported_masc_schemas (schemas : Masc_domain.tool_schema list) =
      author/voter fields. Exposing both leads to the LLM calling the raw
      masc_* variant without the required author, causing "author is required". *)
   let has_keeper_board_wrapper name =
-    let eq v = String.equal name (Tool_name.Board_name.to_string v) in
-    eq Tool_name.Board_name.Board_comment
-    || eq Tool_name.Board_name.Board_curation_submit
-    || eq Tool_name.Board_name.Board_post
-    || eq Tool_name.Board_name.Board_vote
-    || eq Tool_name.Board_name.Board_delete
+    List.mem name masc_board_tools_with_keeper_wrappers
   in
   List.filter (fun (s : Masc_domain.tool_schema) ->
       String.starts_with ~prefix:"masc_" s.name

--- a/test/dune
+++ b/test/dune
@@ -183,6 +183,7 @@
   test_runtime_toml_overrides
   test_runtime_provider_auth_headers
   test_keeper_tool_policy_config
+  test_keeper_tool_policy_masc_surface
   test_keeper_tool_visibility_projection
   test_keeper_tool_resolution
   test_tool_resolution_runtime_projection
@@ -440,6 +441,7 @@
   test_runtime_toml_overrides
   test_runtime_provider_auth_headers
   test_keeper_tool_policy_config
+  test_keeper_tool_policy_masc_surface
   test_keeper_tool_visibility_projection
   test_keeper_tool_resolution
   test_tool_resolution_runtime_projection

--- a/test/test_keeper_tool_policy_masc_surface.ml
+++ b/test/test_keeper_tool_policy_masc_surface.ml
@@ -1,0 +1,35 @@
+open Alcotest
+
+let names_from_board_registry () =
+  Masc.Keeper_tool_policy.keeper_supported_masc_tool_names_from_schemas
+    Masc.Tool_board_registry.tools
+
+let check_member label name expected names =
+  check bool label expected (List.mem name names)
+
+let test_raw_board_wrappers_filtered_without_hiding_read_tools () =
+  let names = names_from_board_registry () in
+  check_member "raw board post filtered" "masc_board_post" false names;
+  check_member "raw board comment filtered" "masc_board_comment" false names;
+  check_member "raw board vote filtered" "masc_board_vote" false names;
+  check_member
+    "raw board curation submit filtered"
+    "masc_board_curation_submit"
+    false
+    names;
+  check_member "raw board delete filtered" "masc_board_delete" false names;
+  check_member "board list remains visible" "masc_board_list" true names;
+  check_member "board get remains visible" "masc_board_get" true names;
+  check_member "board stats remains visible" "masc_board_stats" true names
+
+let () =
+  Alcotest.run "keeper_tool_policy_masc_surface"
+    [
+      ( "board wrapper filter",
+        [
+          test_case
+            "filters raw board write tools with keeper wrappers"
+            `Quick
+            test_raw_board_wrappers_filtered_without_hiding_read_tools;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- replace keeper board-wrapper policy's direct `Tool_name.Board_name` enum dependency with a keeper-local exact name set
- preserve the existing raw `masc_board_*` write-tool filter while keeping read-only board tools visible
- add a focused regression test over `Tool_board_registry.tools`

## Boundary note
This is the next narrow cut from `tool-keeper-mcp-surface.md` Finding B leak 2: keeper policy no longer reaches into the MCP tool enum for board wrapper filtering.

## Verification
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=/tmp/masc-dune-keeper-policy-board-wrapper-boundary dune build --root . @install test/test_keeper_tool_policy_masc_surface.exe --force`
- `/tmp/masc-dune-keeper-policy-board-wrapper-boundary/default/test/test_keeper_tool_policy_masc_surface.exe`
- `bash scripts/lint/tool-keeper-boundary-ratchet.sh --print`
- `scripts/audit-keeper-tool-boundary-matrix.sh`
- `rg -n "Tool_name\." lib/keeper/keeper_tool_policy.ml` (0 matches)
- `git diff --check`