### PR TITLE
refactor(task): remove legacy planning_eio facade and resolve aliases

### DIFF
--- a/lib/planning_eio.ml
+++ b/lib/planning_eio.ml
@@ -1,1 +1,0 @@
-include Task.Planning_eio

--- a/lib/planning_eio.mli
+++ b/lib/planning_eio.mli
@@ -1,3 +1,0 @@
-include module type of struct
-  include Task.Planning_eio
-end

--- a/lib/tool_inline_dispatch_workspace.ml
+++ b/lib/tool_inline_dispatch_workspace.ml
@@ -21,6 +21,8 @@ module Float = Stdlib.Float
 
     Extracted from tool_inline_dispatch.ml to reduce file size. *)
 
+module Planning_eio = Task.Planning_eio
+
 open Tool_inline_dispatch_types
 
 (* RFC-0189 PR-2: lifecycle handlers return [Tool_result.result option]

--- a/lib/tool_plan.ml
+++ b/lib/tool_plan.ml
@@ -22,6 +22,8 @@ module Float = Stdlib.Float
               error_add, error_resolve, plan_set_task, plan_get_task, plan_clear_task
 *)
 
+module Planning_eio = Task.Planning_eio
+
 (** Tool handler context *)
 type context = {
   config: Workspace.config;

--- a/lib/tool_workspace.ml
+++ b/lib/tool_workspace.ml
@@ -20,6 +20,8 @@ module Float = Stdlib.Float
     Note: stateful workspace helpers remain in server dispatch modules
 *)
 
+module Planning_eio = Task.Planning_eio
+
 open Workspace_types
 open Tool_args
 

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -1026,7 +1026,7 @@ let test_handle_request_tools_call_transition_claim_guidance () =
   in
   let steps = workflow_next_step_names response in
   Alcotest.(check (option string)) "claim binds current_task" (Some "task-001")
-    (Masc.Planning_eio.get_current_task state.workspace_config);
+    (Masc.Task.Planning_eio.get_current_task state.workspace_config);
   Alcotest.(check bool) "claim guidance omits plan_set_task" false
     (List.mem "masc_plan_set_task" steps);
   cleanup_dir base_path
@@ -1551,7 +1551,7 @@ let test_execute_tool_hyphenated_generated_alias_claim_next_reuses_base_token ()
     (contains_substring ((Tool_result.message result)) "task-001");
   Alcotest.(check (option string)) "current task set after claim_next"
     (Some "task-001")
-    (Masc.Planning_eio.get_current_task state.workspace_config);
+    (Masc.Task.Planning_eio.get_current_task state.workspace_config);
   Alcotest.(check bool) "explicit alias joined" true
     (Masc.Workspace.is_agent_session_bound state.workspace_config
        ~agent_name:"qa-king-warm-heron");
@@ -1582,7 +1582,7 @@ let test_execute_tool_claim_next_requires_auth_before_mutation () =
     (Tool_result.is_success result) ((Tool_result.message result));
   check_task_still_todo state.workspace_config "task-001";
   Alcotest.(check (option string)) "no current task after rejected claim_next" None
-    (Masc.Planning_eio.get_current_task state.workspace_config);
+    (Masc.Task.Planning_eio.get_current_task state.workspace_config);
   cleanup_dir base_path
 
 let test_execute_tool_transition_requires_auth_before_mutation () =
@@ -1616,7 +1616,7 @@ let test_execute_tool_transition_requires_auth_before_mutation () =
     (Tool_result.is_success result) ((Tool_result.message result));
   check_task_still_todo state.workspace_config "task-001";
   Alcotest.(check (option string)) "no current task after rejected transition" None
-    (Masc.Planning_eio.get_current_task state.workspace_config);
+    (Masc.Task.Planning_eio.get_current_task state.workspace_config);
   cleanup_dir base_path
 
 let test_execute_tool_add_task_with_admin_token_without_join () =

--- a/test/test_planning_eio.ml
+++ b/test/test_planning_eio.ml
@@ -2,6 +2,7 @@
 
 open Alcotest
 open Masc
+module Planning_eio = Masc.Task.Planning_eio
 
 let temp_dir = ref ""
 

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -3,6 +3,7 @@ module Types = Masc_domain
 (** Coverage tests for Task.Tool *)
 
 open Masc
+module Planning_eio = Masc.Task.Planning_eio
 
 let () = Random.self_init ()
 let () = Keeper_task_owner_backend.install_hooks ()

--- a/test/test_tool_workspace_coverage.ml
+++ b/test/test_tool_workspace_coverage.ml
@@ -4,6 +4,7 @@ module Types = Masc_domain
 
 open Masc
 open Workspace_types
+module Planning_eio = Masc.Task.Planning_eio
 
 let () = Random.self_init ()
 

--- a/test/test_verification_fsm.ml
+++ b/test/test_verification_fsm.ml
@@ -10,6 +10,7 @@ module Types = Masc_domain
     - FSM disabled path: error message *)
 
 open Masc
+module Planning_eio = Masc.Task.Planning_eio
 
 let rng_initialized = ref false
 


### PR DESCRIPTION
Clean up the remaining legacy planning_eio facade files and update all internal module references/aliases to Task.Planning_eio.