### PR TITLE
chore: remove not_recorded metric fallback

### DIFF
--- a/lib/keeper/keeper_unified_metrics_result.ml
+++ b/lib/keeper/keeper_unified_metrics_result.ml
@@ -75,7 +75,7 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
         Social.
           {
             social_model = meta.social_model;
-            belief_summary = "not_recorded";
+            belief_summary = "";
             active_desire = None;
             current_intention = None;
             blocker = None;


### PR DESCRIPTION
## Summary
- replace the remaining not_recorded runtime fallback with the empty-string missing convention
- keep social-state absence from leaking a string marker into runtime metrics

## Verification
- rg -n -i "sentinel|not_recorded"
- git diff --check
- env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_not_recorded_sentinel scripts/dune-local.sh build test/test_keeper_usage_trust_counter.exe test/test_keeper_proactive_skip_counter.exe test/test_keeper_compaction_noop_counter_9943.exe