### PR TITLE
test(keeper): guard legacy tool names in keeper configs

### DIFF
--- a/scripts/lint/no-legacy-tool-surface-name.sh
+++ b/scripts/lint/no-legacy-tool-surface-name.sh
@@ -1,17 +1,19 @@
 #!/usr/bin/env bash
 # Guard against re-emergence of pre-RFC-0064 public tool names in the
-# descriptor-backed tool surface and keeper-facing prompt/persona files.
+# descriptor-backed tool surface and keeper-facing prompt/persona/config files.
 #
 # After RFC-0202 tool name alignment, the active LLM-native public names are:
-#   Execute, Read, Edit, Write, Grep, WebSearch, WebFetch
+#   Execute, Read, Edit, Write, Grep, Search, WebSearch, WebFetch
 #
 # The retired names — Bash, ReadFile, WriteFile, EditFile, SearchFiles,
 # SearchWeb, FetchWeb — must not reappear as quoted string literals in active
-# tool-surface modules or as prompt-visible tool names in keeper prompts and
-# personas. This script is intentionally narrow: it only scans files that
-# declare/route public tool names plus prompt/persona files that tell keepers
-# what to call. Identifiers and code symbols (e.g. OCaml `Read` modules) are
-# untouched.
+# tool-surface modules or as prompt-visible tool names in keeper prompts,
+# personas, and keeper TOML configs. Prompt-visible text must also not tell
+# keepers to call stale implementation names such as keeper_bash or
+# keeper_shell. This script is intentionally narrow: it only scans files that
+# declare/route public tool names plus prompt/persona/config files that tell
+# keepers what to call. Identifiers and code symbols (e.g. OCaml `Read`
+# modules) are untouched.
 #
 # Baseline = 0 occurrences. Allowlist is a debt ledger; entries are exact
 # `path:line:literal` keys that drift with line numbers, forcing same-PR
@@ -65,15 +67,17 @@ SCAN_GLOBS=(
 )
 
 PROMPT_SCAN_FILES=("docs/KEEPER-CAPABILITY-MATRIX.md")
-for prompt_dir in config/prompts config/personas; do
+for prompt_dir in config/prompts config/personas config/keepers; do
   [[ -d "$prompt_dir" ]] || continue
   while IFS= read -r prompt_file; do
     PROMPT_SCAN_FILES+=("$prompt_file")
   done < <(find "$prompt_dir" -type f | sort)
 done
 
-LITERAL_PATTERN='"(Bash|ReadFile|WriteFile|EditFile|SearchFiles|SearchWeb|FetchWeb)"'
-PROMPT_TOKEN_PATTERN='\b(Bash|ReadFile|WriteFile|EditFile|SearchFiles|SearchWeb|FetchWeb)\b'
+RETIRED_PUBLIC_NAME_PATTERN='Bash|ReadFile|WriteFile|EditFile|SearchFiles|SearchWeb|FetchWeb'
+STALE_KEEPER_IMPLEMENTATION_PATTERN='keeper_bash|keeper_shell|keeper_fs_read|keeper_fs_edit|keeper_fs_write|keeper_fs_delete'
+LITERAL_PATTERN='"('"$RETIRED_PUBLIC_NAME_PATTERN"')"'
+PROMPT_TOKEN_PATTERN='\b('"$RETIRED_PUBLIC_NAME_PATTERN"'|'"$STALE_KEEPER_IMPLEMENTATION_PATTERN"')\b'
 
 current_tmp="$(mktemp -t legacy-tool-surface-name.current.XXXXXX)"
 allow_tmp="$(mktemp -t legacy-tool-surface-name.allow.XXXXXX)"
@@ -139,9 +143,9 @@ fail=0
 
 if [[ -s "$new_tmp" ]]; then
   echo
-  echo "[no-legacy-tool-surface-name] DRIFT UP: legacy public tool name re-emerged in active surface" >&2
+  echo "[no-legacy-tool-surface-name] DRIFT UP: legacy tool name re-emerged in active surface" >&2
   sed 's/^/  - /' "$new_tmp" >&2
-  echo "  Use the descriptor-owned name (Execute, Read, Edit, Write, Grep, WebSearch, WebFetch)." >&2
+  echo "  Use the descriptor-owned name (Execute, Read, Edit, Write, Grep, Search, WebSearch, WebFetch)." >&2
   echo "  See lib/keeper/keeper_tool_descriptor.ml for the canonical surface." >&2
   fail=1
 fi


### PR DESCRIPTION
## Summary

- Extend the legacy tool surface name ratchet to scan `config/keepers/*.toml`.
- Block prompt-visible stale keeper implementation names such as `keeper_shell`, `keeper_bash`, and old `keeper_fs_*` names in addition to retired public names.
- Update the guard text to include the current `Search` public alias.

## Product impact

Keeper TOML instructions can now no longer reintroduce stale internal tool names that conflict with the public tool surface. This closes the same config shape found in live `.masc` evidence where a keeper was still instructed to use `keeper_shell op=ls`.

## Evidence

- `bash scripts/lint/no-legacy-tool-surface-name.sh --fail`
- `bash scripts/lint/no-legacy-tool-surface-name.sh --print`
- `bash -n scripts/lint/no-legacy-tool-surface-name.sh`
- `git diff --check`
- Negative probe: temporary `config/keepers/__legacy_tool_guard_probe.toml` containing `keeper_shell` made the ratchet fail with `config/keepers/__legacy_tool_guard_probe.toml:2:keeper_shell`; the probe file was removed before commit.

## Direct evidence

schema_version: 1
direct_ratio: 5/5
provenance: direct

- Direct log/config research found stale `keeper_shell op=ls` in live keeper TOML shape under `~/me/.masc/config/keepers/qa-king.toml`.
- Direct code inspection showed the existing ratchet scanned `config/prompts` and `config/personas`, but not `config/keepers`.
- Direct negative probe verified the expanded guard catches stale keeper implementation names in keeper TOML.
- Direct clean runs verified current tracked repo state has zero legacy hits and zero allowlist debt.
- Direct diff review confirmed the change is limited to `scripts/lint/no-legacy-tool-surface-name.sh`.

## Review evidence

- Boundary: no runtime OCaml code changed.
- Scope: one CI ratchet script, no allowlist expansion.
- Residual risk: this prevents tracked config regressions; live untracked config still needs separate sync/cleanup where stale instructions already exist.

## Linked issue

- None.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`fix/keeper-config-legacy-tool-name-gate-20260604` → `main` · 1 commit(s) · synced 2026-06-04T05:41:08Z

| sha | subject | date |
|---|---|---|
| `b65db2a82` | test(keeper): guard legacy tool names in keeper configs | 2026-06-04 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->