### PR TITLE
refactor(keeper): decouple alias runtime names from MCP catalog

### DIFF
--- a/lib/keeper/keeper_tool_alias.ml
+++ b/lib/keeper/keeper_tool_alias.ml
@@ -5,9 +5,9 @@
     name maps to one route record containing the internal handler name, an
     input translator, and an optional public schema.
 
-    Two surfaces:
+    Two descriptor-backed surfaces:
     - LLM native tools: Execute, Grep/Search, Read, Edit, Write, WebSearch, WebFetch
-    - MCP tools: masc_* (handled separately via Tool_catalog_surfaces)
+    - MCP tools: names with the masc_ prefix
 
     Internal [keeper_*] names are implementation details of the routing layer,
     not a public surface. A tool call for a name we don't handle is a routing
@@ -48,37 +48,88 @@ let routing_table : (string, route) Hashtbl.t =
 (** [is_known_public name] is [true] when [name] has a routing entry. *)
 let is_known_public name = Hashtbl.mem routing_table name
 
-(** Known internal handler names — descriptor [internal_name] values plus the
-    public [masc_*] surface. Used to bound the [routed_to] Prometheus label so
-    unrecognised strings never become a new time series. *)
+let is_masc_mcp_descriptor (d : Keeper_tool_descriptor.t) =
+  match d.runtime_handler with
+  | Tool_masc_board_dispatch
+  | Tool_masc_task_dispatch
+  | Tool_masc_plan_dispatch
+  | Tool_masc_run_dispatch
+  | Tool_masc_agent_dispatch
+  | Tool_masc_workspace_dispatch
+  | Tool_masc_misc_dispatch
+  | Tool_masc_control_dispatch
+  | Tool_masc_agent_timeline_dispatch
+  | Tool_masc_local_runtime_dispatch
+  | Tool_masc_tool_shard_dispatch
+  | Tool_masc_approval_dispatch
+  | Tool_masc_persona_dispatch
+  | Tool_masc_keeper_dispatch
+  | Tool_masc_surface_audit -> true
+  | Tool_execute
+  | Tool_search_files
+  | Tool_read_file
+  | Tool_edit_file
+  | Tool_write_file
+  | Tool_time_now
+  | Tool_stay_silent
+  | Tool_tools_list
+  | Tool_tool_search
+  | Tool_context_status
+  | Tool_memory_search
+  | Tool_memory_write
+  | Tool_library_search
+  | Tool_library_read
+  | Tool_ide_annotate
+  | Tool_voice_dispatch
+  | Tool_task_dispatch
+  | Tool_board_dispatch -> false
+;;
+
+let add_internal_names t (d : Keeper_tool_descriptor.t) =
+  List.iter
+    (fun internal_name -> Hashtbl.replace t internal_name ())
+    (Keeper_tool_descriptor.internal_names d)
+;;
+
+(** Known internal handler names for LLM-native public descriptors. *)
 let known_internal_names_tbl : (string, unit) Hashtbl.t =
   let t = Hashtbl.create 128 in
-  Hashtbl.iter
-    (fun _ r ->
-       List.iter
-         (fun internal_name -> Hashtbl.replace t internal_name ())
-         (Keeper_tool_descriptor.internal_names r.descriptor))
-    routing_table;
+  List.iter (add_internal_names t) Keeper_tool_descriptor.public_descriptors;
+  t
+;;
+
+(** Descriptor-backed runtime names used for telemetry labels and runtime
+    canonicalisation. Kept separate from [is_known_internal] so policy
+    resolution provenance still reaches [Descriptor_registry] for workspace
+    descriptors. *)
+let known_runtime_names_tbl : (string, unit) Hashtbl.t =
+  let t = Hashtbl.create 128 in
+  List.iter (add_internal_names t) Keeper_tool_descriptor.public_descriptors;
+  List.iter
+    (fun d -> if is_masc_mcp_descriptor d then add_internal_names t d)
+    (Keeper_tool_descriptor.all_descriptors ());
   List.iter
     (fun public_mcp -> Hashtbl.replace t public_mcp ())
-    Tool_catalog_surfaces.public_mcp_surface_tools;
+    Keeper_tool_name.pending_public_mcp_inline_names;
   t
 ;;
 
 let is_known_internal name = Hashtbl.mem known_internal_names_tbl name
+
+let is_known_runtime_name name = Hashtbl.mem known_runtime_names_tbl name
 
 (** Bound a label value to a closed set so hallucinated / unbounded
     names never inflate Prometheus cardinality. *)
 let safe_tool_label name =
   if is_known_public name
   then name
-  else if is_known_internal name
+  else if is_known_runtime_name name
   then name
   else "unknown"
 ;;
 
 let safe_routed_to_label name =
-  if name = "none" then name else if is_known_internal name then name else "unknown"
+  if name = "none" then name else if is_known_runtime_name name then name else "unknown"
 ;;
 
 let record_route_outcome ~tool ~routed_to ~result =
@@ -107,9 +158,7 @@ let public_names = Keeper_tool_descriptor.public_names
 
 let public_name_for_internal = Keeper_tool_descriptor.public_name_for_internal
 
-(* ── MCP surface routing (separate concern) ──────────────────────── *)
-
-let public_masc_to_internal _name = None
+(* ── MCP prefix normalisation ────────────────────────────────────── *)
 
 let strip_mcp_masc_prefix name =
   if String.starts_with ~prefix:"mcp__masc__" name
@@ -118,28 +167,21 @@ let strip_mcp_masc_prefix name =
 ;;
 
 type canonical_resolution =
-  | Public_mcp of
-      { stripped : string
-      ; internal : string
-      }
   | Public_alias of { internal : string }
   | Internal of { canonical : string }
   | Unknown
 
 let canonical_resolution name =
   let stripped = strip_mcp_masc_prefix name in
-  match public_masc_to_internal stripped with
-  | Some internal -> Public_mcp { stripped; internal }
+  match route stripped with
+  | Some r -> Public_alias { internal = r.internal_name }
   | None ->
-    (match route stripped with
-     | Some r -> Public_alias { internal = r.internal_name }
-     | None ->
-       if is_known_internal stripped then Internal { canonical = stripped } else Unknown)
+    if is_known_runtime_name stripped then Internal { canonical = stripped } else Unknown
 ;;
 
 let canonical_internal_name name =
   match canonical_resolution name with
-  | Public_mcp { internal; _ } | Public_alias { internal } -> Some internal
+  | Public_alias { internal } -> Some internal
   | Internal { canonical } -> Some canonical
   | Unknown -> None
 ;;

--- a/lib/keeper/keeper_tool_alias.mli
+++ b/lib/keeper/keeper_tool_alias.mli
@@ -5,9 +5,9 @@
     the internal handler name, an input translator, and an optional
     public schema.
 
-    Two surfaces:
+    Two descriptor-backed surfaces:
     - LLM native tools (Execute, Grep/Search, Read, Edit, Write, WebSearch, WebFetch)
-    - MCP tools (masc_*, handled via Tool_catalog_surfaces)
+    - MCP tools (names with the masc_ prefix)
 
     Internal [keeper_*] names are implementation details of the routing
     layer, not a public surface. A tool call for a name not in the routing
@@ -28,9 +28,9 @@ type route =
     [None] means the name is not in our surface — a routing miss. *)
 val route : string -> route option
 
-(** [is_known_internal name] is [true] when [name] is a recognised descriptor
-    internal handler or public [masc_*] tool name. Callers use this to keep
-    Prometheus label cardinality bounded. *)
+(** [is_known_internal name] is [true] when [name] is a recognised LLM-native
+    descriptor internal handler name. Policy resolution uses this narrow source;
+    runtime telemetry has a wider private descriptor-backed label set. *)
 val is_known_internal : string -> bool
 
 (** [public_names ()] returns all LLM-native public names in stable order.
@@ -58,12 +58,7 @@ val public_name_for_internal : string -> string option
     [result] is ["ok"] for a successful route or ["miss"] for an unknown name. *)
 val record_route_outcome : tool:string -> routed_to:string -> result:string -> unit
 
-(** {1 MCP surface routing (separate concern)} *)
-
-(** [public_masc_to_internal name] is retained for callers that still route
-    through [canonical_resolution]. The old keeper-internal replacement table is
-    gone, so public [masc_*] names stay canonical. *)
-val public_masc_to_internal : string -> string option
+(** {1 MCP prefix normalisation} *)
 
 (** [strip_mcp_masc_prefix name] removes the ["mcp__masc__"] prefix if
     present. *)
@@ -72,22 +67,18 @@ val strip_mcp_masc_prefix : string -> string
 (** Pure canonical routing result for set-logic and routing callers that need
     the same alias interpretation without emitting telemetry. *)
 type canonical_resolution =
-  | Public_mcp of
-      { stripped : string
-      ; internal : string
-      }
   | Public_alias of { internal : string }
   | Internal of { canonical : string }
   | Unknown
 
-(** [canonical_resolution name] applies MCP-prefix stripping, public MCP
-    replacement, LLM-native alias routing, and known-internal detection. *)
+(** [canonical_resolution name] applies MCP-prefix stripping, descriptor-backed
+    public alias routing, and known-internal detection. *)
 val canonical_resolution : string -> canonical_resolution
 
 (** [canonical_internal_name name] returns the internal keeper/MASC tool name
-    used for pure set-logic comparisons after applying the same public alias
-    and MCP-prefix routing rules used by runtime dispatch. [None] means the
-    name is not a recognised public, public-MCP, or internal tool. *)
+    used for pure set-logic comparisons after applying the same descriptor
+    public alias and MCP-prefix routing rules used by runtime dispatch. [None]
+    means the name is not a recognised public or internal tool. *)
 val canonical_internal_name : string -> string option
 
 (** {1 Public schemas} *)

--- a/lib/keeper/keeper_tool_execute_typed_input.ml
+++ b/lib/keeper/keeper_tool_execute_typed_input.ml
@@ -545,10 +545,9 @@ let executable_not_allowlisted_hint ~name ~mode =
      descriptor/registry-backed so Keeper does not own the concrete tool-name
      universe. *)
   let is_masc_structured_tool =
-    Keeper_tool_alias.is_known_internal name
-    || Option.is_some (Keeper_tool_alias.public_masc_to_internal name)
+    Option.is_some (Keeper_tool_descriptor_resolution.descriptor_for_tool_name name)
+    || Keeper_tool_alias.is_known_internal name
     || Option.is_some (Keeper_tool_descriptor.find_public name)
-    || Option.is_some (Tool_name.Masc.of_string name)
   in
   if is_masc_structured_tool
   then

--- a/lib/keeper/keeper_tool_name.ml
+++ b/lib/keeper/keeper_tool_name.ml
@@ -158,7 +158,18 @@ let pp fmt t = Format.pp_print_string fmt (to_string t)
 ;;
 
 let legacy_masc_claim_next_name = "masc_claim_next"
+let legacy_masc_broadcast_name = "masc_broadcast"
 let legacy_masc_deliver_name = "masc_deliver"
+
+let pending_public_mcp_inline_names =
+  [ "masc_start"
+  ; legacy_masc_broadcast_name
+  ; "masc_messages"
+  ; "masc_keeper_sandbox_status"
+  ; "masc_persona_generate"
+  ; "masc_keeper_create_from_persona"
+  ]
+;;
 
 let is_keeper_board_tool = function
   | Board_comment

--- a/lib/keeper/keeper_tool_name.mli
+++ b/lib/keeper/keeper_tool_name.mli
@@ -61,7 +61,15 @@ val pp : Format.formatter -> t -> unit
     keeper-owned tools onto the public MCP surface. *)
 val legacy_masc_claim_next_name : string
 
+val legacy_masc_broadcast_name : string
+
 val legacy_masc_deliver_name : string
+
+(** Public MCP names whose handlers still live in inline server dispatch while
+    RFC-0190 descriptor migration is incomplete. Keep this exact allowlist on
+    the keeper side so prefix canonicalisation does not depend on the MCP
+    catalog hand-list. *)
+val pending_public_mcp_inline_names : string list
 
 (** Returns true for keeper board wrapper names and legacy public
     [masc_board_*] names without depending on the central [Tool_name] enum. *)

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -249,7 +249,7 @@ let reconcile_safe_tools =
         ; Board_comment_vote
         ; Board_curation_submit
         ]
-  @ [ Tool_name.to_string (Tool_name.Masc Tool_name.Masc.Broadcast) ]
+  @ [ Keeper_tool_name.legacy_masc_broadcast_name ]
 ;;
 
 let reconcile_safe_set : (string, unit) Hashtbl.t =

--- a/lib/keeper/keeper_tool_resolution.ml
+++ b/lib/keeper/keeper_tool_resolution.ml
@@ -17,11 +17,10 @@ type tried_source =
   | Tool_name_variant           (** S2: Tool_name.of_string *)
   | Public_descriptor           (** S3: Keeper_tool_descriptor.find_public *)
   | Alias_internal              (** S4: Keeper_tool_alias.is_known_internal *)
-  | Alias_masc_to_internal      (** S5: Keeper_tool_alias.public_masc_to_internal *)
-  | Registry_internal_candidate (** S6: Keeper_tool_registry.keeper_internal_candidate_tool_names *)
-  | Registry_core_tools         (** S7: Keeper_tool_registry.effective_core_tools *)
-  | Shard_schema                (** S8: Tool_shard.all_keeper_tool_schemas name extraction *)
-  | Descriptor_registry         (** S8.5: Keeper_tool_descriptor.all_descriptors public_name —
+  | Registry_internal_candidate (** S5: Keeper_tool_registry.keeper_internal_candidate_tool_names *)
+  | Registry_core_tools         (** S6: Keeper_tool_registry.effective_core_tools *)
+  | Shard_schema                (** S7: Tool_shard.all_keeper_tool_schemas name extraction *)
+  | Descriptor_registry         (** S7.5: Keeper_tool_descriptor.all_descriptors public_name —
                                     flat SSOT incl. internal_descriptors (masc_keeper_* live here) *)
 
 type resolution =
@@ -39,7 +38,6 @@ let string_of_tried_source = function
   | Tool_name_variant -> "tool_name_variant"
   | Public_descriptor -> "public_descriptor"
   | Alias_internal -> "alias_internal"
-  | Alias_masc_to_internal -> "alias_masc_to_internal"
   | Registry_internal_candidate -> "registry_internal_candidate"
   | Registry_core_tools -> "registry_core_tools"
   | Shard_schema -> "shard_schema"
@@ -60,67 +58,55 @@ let resolve name =
   else
     match Keeper_tool_descriptor.find_public normalized with
     | Some descriptor ->
-        Alias_to
-          { from_ = normalized
-          ; canonical = descriptor.Keeper_tool_descriptor.internal_name
-          ; via = Public_descriptor
-          }
+      Alias_to
+        { from_ = normalized
+        ; canonical = descriptor.Keeper_tool_descriptor.internal_name
+        ; via = Public_descriptor
+        }
     | None ->
-        if Keeper_tool_alias.is_known_internal normalized then
-          Resolved { canonical = normalized; via = Alias_internal }
-        else begin
-          match Keeper_tool_alias.public_masc_to_internal normalized with
-          | Some internal ->
-              Alias_to
-                { from_ = normalized; canonical = internal; via = Alias_masc_to_internal }
-          | None ->
-              if List.mem normalized Keeper_tool_registry.keeper_internal_candidate_tool_names
-              then
-                Resolved
-                  { canonical = normalized; via = Registry_internal_candidate }
-              else if List.mem normalized (Keeper_tool_registry.effective_core_tools ())
-              then
-                Resolved
-                  { canonical = normalized; via = Registry_core_tools }
-              else if
-                List.mem normalized (tool_schema_names Tool_shard.all_keeper_tool_schemas)
-              then Resolved { canonical = normalized; via = Shard_schema }
-              else if
-                List.exists
-                  (fun (d : Keeper_tool_descriptor.t) ->
-                    String.equal d.Keeper_tool_descriptor.public_name normalized)
-                  (Keeper_tool_descriptor.all_descriptors ())
-              then
-                (* Flat descriptor registry. Descriptor-backed tools live in
-                   [public_descriptors @ internal_descriptors]. masc_keeper_*
-                   (dispatched via Keeper_tool_surface.dispatch, not the handler
-                   registry) sit in internal_descriptors and were orphaned from
-                   resolution when #19797 purged the surface lists. This flat-name
-                   source restores admission without touching dispatch — resolve
-                   is a validity gate; [via] is only used for the error string. *)
-                Resolved
-                  { canonical = normalized; via = Descriptor_registry }
-              else
-                (* The per-actor surface coverage gate (RFC-0084 §1.3) was
-                   removed in the surface-cut refactor: the [surface] type and
-                   its lists are deleted, and keeper tools resolve through the
-                   flat Descriptor_registry source above. A name that reaches
-                   here is admitted by no source — Unknown. *)
-                Unknown
-                  { name
-                  ; tried =
-                      [ Dispatch_table
-                      ; Tool_name_variant
-                      ; Public_descriptor
-                      ; Alias_internal
-                      ; Alias_masc_to_internal
-                      ; Registry_internal_candidate
-                      ; Registry_core_tools
-                      ; Shard_schema
-                      ; Descriptor_registry
-                      ]
-                  }
-        end
+      if Keeper_tool_alias.is_known_internal normalized then
+        Resolved { canonical = normalized; via = Alias_internal }
+      else if
+        List.mem normalized Keeper_tool_registry.keeper_internal_candidate_tool_names
+      then Resolved { canonical = normalized; via = Registry_internal_candidate }
+      else if List.mem normalized (Keeper_tool_registry.effective_core_tools ()) then
+        Resolved { canonical = normalized; via = Registry_core_tools }
+      else if
+        List.mem normalized (tool_schema_names Tool_shard.all_keeper_tool_schemas)
+      then Resolved { canonical = normalized; via = Shard_schema }
+      else if
+        List.exists
+          (fun (d : Keeper_tool_descriptor.t) ->
+             String.equal d.Keeper_tool_descriptor.public_name normalized)
+          (Keeper_tool_descriptor.all_descriptors ())
+      then
+        (* Flat descriptor registry. Descriptor-backed tools live in
+           [public_descriptors @ internal_descriptors]. masc_keeper_* (dispatched
+           via Keeper_tool_surface.dispatch, not the handler registry) sit in
+           internal_descriptors and were orphaned from resolution when #19797
+           purged the surface lists. This flat-name source restores admission
+           without touching dispatch — resolve is a validity gate; [via] is only
+           used for the error string. *)
+        Resolved { canonical = normalized; via = Descriptor_registry }
+      else
+        (* The per-actor surface coverage gate (RFC-0084 §1.3) was removed in
+           the surface-cut refactor: the [surface] type and its lists are
+           deleted, and keeper tools resolve through the flat Descriptor_registry
+           source above. A name that reaches here is admitted by no source —
+           Unknown. *)
+        Unknown
+          { name
+          ; tried =
+              [ Dispatch_table
+              ; Tool_name_variant
+              ; Public_descriptor
+              ; Alias_internal
+              ; Registry_internal_candidate
+              ; Registry_core_tools
+              ; Shard_schema
+              ; Descriptor_registry
+              ]
+          }
 
 (* ── Phase 5: full-probe (no short-circuit) ────────────────────────── *)
 
@@ -138,9 +124,6 @@ let all_admitting_sources name =
     sources := Public_descriptor :: !sources;
   if Keeper_tool_alias.is_known_internal normalized then
     sources := Alias_internal :: !sources;
-  (match Keeper_tool_alias.public_masc_to_internal normalized with
-   | Some _ -> sources := Alias_masc_to_internal :: !sources
-   | None -> ());
   if List.mem normalized (Keeper_tool_registry.keeper_internal_candidate_tool_names) then
     sources := Registry_internal_candidate :: !sources;
   if List.mem normalized (Keeper_tool_registry.effective_core_tools ()) then
@@ -161,10 +144,6 @@ let all_admitting_sources name =
 (* ── RFC-0084 §1.4 — Runtime routing SSOT entry ──────────────────────── *)
 
 type runtime_decision_outcome =
-  | Mcp_mapped of
-      { stripped : string
-      ; internal : string
-      }
   | Route_hit of { internal : string }
   | Already_internal of { canonical : string }
   | Miss
@@ -176,15 +155,12 @@ type runtime_decision_outcome =
     need the pure or telemetry-emitting string projection. *)
 let runtime_decision name =
   match Keeper_tool_alias.canonical_resolution name with
-  | Keeper_tool_alias.Public_mcp { stripped; internal } ->
-    Mcp_mapped { stripped; internal }
   | Keeper_tool_alias.Public_alias { internal } -> Route_hit { internal }
   | Keeper_tool_alias.Internal { canonical } -> Already_internal { canonical }
   | Keeper_tool_alias.Unknown -> Miss
 
 let canonical_tool_name name =
   match runtime_decision name with
-  | Mcp_mapped { internal; _ } -> internal
   | Route_hit { internal } -> internal
   | Already_internal { canonical } -> canonical
   | Miss -> name
@@ -193,9 +169,6 @@ let canonical_tool_name name =
 let canonical_tool_name_observed name =
   let stripped = Keeper_tool_alias.strip_mcp_masc_prefix name in
   match runtime_decision name with
-  | Mcp_mapped { internal; _ } ->
-    Keeper_tool_alias.record_route_outcome ~tool:stripped ~routed_to:internal ~result:"ok";
-    internal
   | Route_hit { internal } ->
     Keeper_tool_alias.record_route_outcome ~tool:stripped ~routed_to:internal ~result:"ok";
     internal

--- a/lib/keeper/keeper_tool_resolution.mli
+++ b/lib/keeper/keeper_tool_resolution.mli
@@ -11,7 +11,6 @@ type tried_source =
   | Tool_name_variant           (** Tool_name.of_string *)
   | Public_descriptor           (** Keeper_tool_descriptor.find_public *)
   | Alias_internal              (** Keeper_tool_alias.is_known_internal *)
-  | Alias_masc_to_internal      (** Keeper_tool_alias.public_masc_to_internal *)
   | Registry_internal_candidate (** keeper_internal_candidate_tool_names *)
   | Registry_core_tools         (** effective_core_tools *)
   | Shard_schema                (** Tool_shard.all_keeper_tool_schemas *)
@@ -40,10 +39,6 @@ val all_admitting_sources : string -> tried_source list
 (** RFC-0084 §1.4 — Single-SSOT entry for runtime tool-name routing. *)
 
 type runtime_decision_outcome =
-  | Mcp_mapped of
-      { stripped : string
-      ; internal : string
-      }
   | Route_hit of { internal : string }
   | Already_internal of { canonical : string }
   | Miss
@@ -53,8 +48,6 @@ type runtime_decision_outcome =
     low-dependency SSOT for runtime tool-name routing.
 
     Result variants:
-    - [Mcp_mapped { stripped; internal }] — name was an MCP-prefixed
-      public alias resolved to an internal canonical name.
     - [Route_hit { internal }] — alias-table hit; internal name returned.
     - [Already_internal { canonical }] — name is already in internal form.
     - [Miss] — name does not resolve through any runtime route. *)

--- a/test/test_executable_not_allowlisted_hint.ml
+++ b/test/test_executable_not_allowlisted_hint.ml
@@ -1,7 +1,6 @@
-(** RFC-0196 P0 §1 acceptance: typed lookup against [Keeper_tool_name] /
-    [Tool_name.Masc] for the "executable not in allowlist" hint. Verified
-    indirectly through [pp_validation_error] so the private helper stays
-    private (no test-backdoor mli widening).
+(** RFC-0196 P0 §1 acceptance: descriptor-backed lookup for the "executable
+    not in allowlist" hint. Verified indirectly through [pp_validation_error]
+    so the private helper stays private (no test-backdoor mli widening).
 
     The MASC tool hint must:
     - fire on real MASC tool names (e.g. [keeper_tasks_list], [masc_status])
@@ -62,7 +61,7 @@ let masc_prefixed_misspelling_no_masc_hint () =
 let bare_unrelated_name_no_masc_hint () =
   let msg = render ~name:"keeperish" ~mode:E.Dev_full in
   Alcotest.(check bool)
-    "unrelated name not in any MASC variant set → no MASC hint"
+    "unrelated name not in descriptor-backed surface → no MASC hint"
     false
     (contains msg masc_hint_text)
 

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -51,13 +51,7 @@ let all_descriptors () : Descriptor.t list = Descriptor.all_descriptors ()
    as a function over [all_descriptors] and this test is rewritten to
    forbid any pending entries. *)
 let rfc_0190_pending_inline_migration =
-  [ "masc_start"
-  ; "masc_broadcast"
-  ; "masc_messages"
-  ; "masc_keeper_sandbox_status"
-  ; "masc_persona_generate"
-  ; "masc_keeper_create_from_persona"
-  ]
+  Masc.Keeper_tool_name.pending_public_mcp_inline_names
 ;;
 
 let descriptor_internal_name_set () =

--- a/test/test_keeper_tool_resolution.ml
+++ b/test/test_keeper_tool_resolution.ml
@@ -38,9 +38,9 @@ let test_unknown_returns_tried_list () =
   match TR.resolve "__nonexistent_tool_xyz" with
   | TR.Unknown { name; tried } ->
       check string "name preserved" "__nonexistent_tool_xyz" name;
-      (* 9 base sources after the per-actor Surface sources were removed in the
-         surface-cut refactor (was >= 13 with the 5 surface admit sources). *)
-      check bool "at least 9 tried sources" true (List.length tried >= 9)
+      (* 8 base sources after the dead public MCP replacement source and the
+         per-actor Surface sources were removed. *)
+      check bool "at least 8 tried sources" true (List.length tried >= 8)
   | _ ->
       fail "__nonexistent_tool_xyz should be Unknown"
 
@@ -84,7 +84,7 @@ let test_tool_execute_resolves () =
       fail (Printf.sprintf "tool_execute should resolve, got Unknown (tried: %s)"
               (TR.string_of_tried tried))
 
-let test_alias_masc_to_internal () =
+let test_masc_board_post_resolves () =
   match TR.resolve "masc_board_post" with
   | TR.Resolved _ | TR.Alias_to _ -> ()
   | TR.Unknown { tried; _ } ->
@@ -302,7 +302,7 @@ let () =
         test_case "extend_turns resolves" `Quick test_extend_turns_resolved;
         test_case "tool_execute resolves" `Quick test_tool_execute_resolves;
         test_case "masc_keeper_* cluster resolves via descriptor registry (boot guard)" `Quick test_descriptor_registry_admits_masc_keeper_cluster;
-        test_case "masc_board_post resolves via alias" `Quick test_alias_masc_to_internal;
+        test_case "masc_board_post resolves" `Quick test_masc_board_post_resolves;
       ]
     ; "policy_validation", [
         test_case "known tools resolve" `Quick test_policy_validation_known_tools_resolve;

--- a/test/test_tool_resolution_runtime_projection.ml
+++ b/test/test_tool_resolution_runtime_projection.ml
@@ -8,8 +8,8 @@ module TR = Masc.Keeper_tool_resolution
     tool-name routing. [Keeper_tool_resolution.canonical_tool_name] is the
     pure string projection over that typed decision.
 
-    Test corpus: a deterministic set of names covering the four outcome
-    variants (Mcp_mapped, Route_hit, Already_internal, Miss) plus a few
+    Test corpus: a deterministic set of names covering the three outcome
+    variants (Route_hit, Already_internal, Miss) plus a few
     edge cases (empty string, all-internal, all-public).
 
     For each name, assert:
@@ -26,6 +26,7 @@ let names_to_probe =
   ; "masc_add_task"
   ; "mcp__masc__tool_execute"
   ; "mcp__masc__masc_status"
+  ; "mcp__masc__masc_broadcast"
   ; "mcp__masc__masc_keeper_msg"
   ; "_definitely_unknown_tool_zzz"
   ; ""
@@ -38,15 +39,12 @@ let names_to_probe =
     abstract types. *)
 let pp_outcome fmt o =
   match o with
-  | TR.Mcp_mapped { stripped; internal } ->
-    Format.fprintf fmt "Mcp_mapped(%s -> %s)" stripped internal
   | TR.Route_hit { internal } -> Format.fprintf fmt "Route_hit(%s)" internal
   | TR.Already_internal { canonical } -> Format.fprintf fmt "Already_internal(%s)" canonical
   | TR.Miss -> Format.fprintf fmt "Miss"
 ;;
 
 let canonical_string name = function
-  | TR.Mcp_mapped { internal; _ } -> internal
   | TR.Route_hit { internal } -> internal
   | TR.Already_internal { canonical } -> canonical
   | TR.Miss -> name
@@ -78,15 +76,23 @@ let test_parity_mcp_prefix_strips () =
   let name = "mcp__masc__tool_execute" in
   let by_resolution = TR.runtime_decision name in
   match by_resolution with
-  | TR.Mcp_mapped { stripped; internal } ->
-    (check string) "stripped form" "tool_execute" stripped;
-    (check string) "internal form" "tool_execute" internal
   | TR.Already_internal { canonical } ->
-    (* Some configurations route mcp_-prefixed internal names directly. *)
     (check string) "canonical form" "tool_execute" canonical
   | other ->
     failf
-      "expected Mcp_mapped or Already_internal for mcp__masc__tool_execute, got: %s"
+      "expected Already_internal for mcp__masc__tool_execute, got: %s"
+      (Format.asprintf "%a" pp_outcome other)
+;;
+
+let test_pending_public_mcp_prefix_strips () =
+  let name = "mcp__masc__masc_broadcast" in
+  let by_resolution = TR.runtime_decision name in
+  match by_resolution with
+  | TR.Already_internal { canonical } ->
+    (check string) "canonical form" "masc_broadcast" canonical
+  | other ->
+    failf
+      "expected Already_internal for mcp__masc__masc_broadcast, got: %s"
       (Format.asprintf "%a" pp_outcome other)
 ;;
 
@@ -97,6 +103,10 @@ let () =
       , [ test_case "parity-each-name" `Quick test_parity_each_name
         ; test_case "parity-unknown-is-miss" `Quick test_parity_unknown_is_miss
         ; test_case "parity-mcp-prefix-strips" `Quick test_parity_mcp_prefix_strips
+        ; test_case
+            "pending-public-mcp-prefix-strips"
+            `Quick
+            test_pending_public_mcp_prefix_strips
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- remove the dead public_masc_to_internal / Public_mcp / Mcp_mapped routing branch from keeper tool alias resolution
- stop deriving keeper alias label cardinality from Tool_catalog_surfaces.public_mcp_surface_tools; use descriptor-backed runtime names instead
- replace remaining Tool_name.Masc direct runtime references in the Execute hint/reconcile-safe path with keeper-owned descriptor/name lookup

## Verification
- dune build --root . test/test_keeper_tool_resolution.exe test/test_tool_resolution_runtime_projection.exe test/test_executable_not_allowlisted_hint.exe
- gtimeout 60 _build/default/test/test_keeper_tool_resolution.exe
- gtimeout 60 _build/default/test/test_tool_resolution_runtime_projection.exe
- gtimeout 60 _build/default/test/test_executable_not_allowlisted_hint.exe
- scripts/audit-keeper-tool-boundary-matrix.sh
- scripts/lint/tool-keeper-boundary-ratchet.sh
- git diff --check origin/main...HEAD