### PR TITLE
fix(keeper): keep synthesized state out of durable memory

### DIFF
--- a/lib/keeper/keeper_agent_memory_episode.ml
+++ b/lib/keeper/keeper_agent_memory_episode.ml
@@ -81,10 +81,11 @@ let record_success
     ~(turn : int)
     ?(oas_turn_count : int option)
     ~(trace_id : string)
+    ?state_snapshot_source
     ~(snapshot : Keeper_memory_policy.keeper_state_snapshot)
     () : unit =
   try
-    Memory_oas_bridge.store_episode_from_snapshot ~memory
+    Memory_oas_bridge.store_episode_from_snapshot ?state_snapshot_source ~memory
       ~keeper_name ~turn ?oas_turn_count ~trace_id snapshot;
     let episodes, procedures =
       Memory_oas_bridge.flush_incremental ~memory ~agent_name:keeper_name

--- a/lib/keeper/keeper_agent_memory_episode.mli
+++ b/lib/keeper/keeper_agent_memory_episode.mli
@@ -28,6 +28,7 @@ val record_success :
   turn:int ->
   ?oas_turn_count:int ->
   trace_id:string ->
+  ?state_snapshot_source:string ->
   snapshot:Keeper_memory_policy.keeper_state_snapshot ->
   unit ->
   unit

--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -174,6 +174,7 @@ let finalize
       ~response_text
       ~actual_tools:actual_keeper_tool_names
       ~state_snapshot
+      ~state_snapshot_source
       ~post_turn_t0
       ?provider_filter
       ~runtime_id:runtime_id_string

--- a/lib/keeper/keeper_agent_run_post_turn_memory.ml
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.ml
@@ -11,6 +11,7 @@ let run
   ~response_text
   ~actual_tools
   ~state_snapshot
+  ~state_snapshot_source
   ~post_turn_t0
   ?provider_filter
   ~runtime_id
@@ -26,6 +27,7 @@ let run
          config
          meta
          ~snapshot:state_snapshot
+         ~state_snapshot_source
          ~turn
          ~reply:response_text
          ()
@@ -80,6 +82,7 @@ let run
     ~turn
     ~oas_turn_count
     ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+    ~state_snapshot_source
     ~snapshot:state_snapshot
     ();
 

--- a/lib/keeper/keeper_agent_run_post_turn_memory.mli
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.mli
@@ -17,6 +17,7 @@ val run :
   response_text:string ->
   actual_tools:string list ->
   state_snapshot:Keeper_memory_policy.keeper_state_snapshot ->
+  state_snapshot_source:string ->
   post_turn_t0:float ->
   ?provider_filter:string list ->
   runtime_id:string ->

--- a/lib/keeper/keeper_memory_bank.ml
+++ b/lib/keeper/keeper_memory_bank.ml
@@ -689,12 +689,14 @@ let append_memory_notes_from_reply
     (config : Workspace.config)
     (meta : keeper_meta)
     ?snapshot
+    ?state_snapshot_source
     ~(turn : int)
     ~(reply : string)
     () : (int * string list) =
   let (snapshot, source) =
     match snapshot with
-    | Some s -> (s, "message_metadata")
+    | Some s ->
+      (s, Option.value state_snapshot_source ~default:"message_metadata")
     | None ->
       (match parse_state_snapshot_from_reply reply with
     | Some s -> (s, "reply_state_block")
@@ -715,7 +717,9 @@ let append_memory_notes_from_reply
           },
           "meta_goal_fallback" ))
   in
-  let selection = memory_candidates_from_snapshot snapshot in
+  let selection =
+    memory_candidates_from_snapshot_source ~state_snapshot_source:source snapshot
+  in
   let notes = selection.selected in
   if selection.dropped_by_total_cap > 0 || selection.dropped_by_kind <> [] then
     Log.Keeper.warn

--- a/lib/keeper/keeper_memory_bank.mli
+++ b/lib/keeper/keeper_memory_bank.mli
@@ -255,6 +255,13 @@ val memory_candidates_from_snapshot :
 (** Lift snapshot fields into candidate triples and run the cap +
     selection pipeline. *)
 
+val memory_candidates_from_snapshot_source :
+  state_snapshot_source:string ->
+  keeper_state_snapshot ->
+  candidate_selection_result
+(** Source-aware variant used by post-turn persistence. Runtime-synthesized
+    snapshots are resume aids, not model-authored durable memory. *)
+
 (** {1 Bank wire format} *)
 
 type keeper_memory_row_raw = {
@@ -332,6 +339,7 @@ val append_memory_notes_from_reply :
   Workspace.config ->
   Keeper_meta_contract.keeper_meta ->
   ?snapshot:keeper_state_snapshot ->
+  ?state_snapshot_source:string ->
   turn:int -> reply:string -> unit -> int * string list
 (** Persist new memory rows derived from a turn's [reply] (and
     optional [snapshot]); returns [(rows_written, drop_reasons)]. *)

--- a/lib/keeper/keeper_memory_bank_selection.ml
+++ b/lib/keeper/keeper_memory_bank_selection.ml
@@ -37,6 +37,9 @@ type candidate_selection_result = {
   dropped_by_total_cap: int;
 }
 
+let empty_candidate_selection =
+  { selected = []; dropped_by_kind = []; dropped_by_total_cap = 0 }
+
 let select_memory_candidates
     (rows : (string * string * int) list) : candidate_selection_result =
   let total_cap = total_cap () in
@@ -271,3 +274,8 @@ let memory_candidates_from_snapshot
          if c <> 0 then c else String.compare ta tb)
   in
   select_memory_candidates raw
+
+let memory_candidates_from_snapshot_source ~state_snapshot_source snapshot =
+  if state_snapshot_source_is_synthetic state_snapshot_source
+  then empty_candidate_selection
+  else memory_candidates_from_snapshot snapshot

--- a/lib/keeper/keeper_memory_bank_selection.mli
+++ b/lib/keeper/keeper_memory_bank_selection.mli
@@ -194,3 +194,10 @@ val max_memory_text_length : unit -> int
 val is_meaningful_memory_text : string -> bool
 val memory_candidates_from_snapshot :
   keeper_state_snapshot -> candidate_selection_result
+
+val memory_candidates_from_snapshot_source :
+  state_snapshot_source:string ->
+  keeper_state_snapshot ->
+  candidate_selection_result
+  (** Source-aware variant used by post-turn persistence. Runtime-synthesized
+      snapshots are resume aids, not model-authored durable memory. *)

--- a/lib/keeper/keeper_memory_policy.ml
+++ b/lib/keeper/keeper_memory_policy.ml
@@ -109,6 +109,11 @@ let empty_keeper_state_snapshot = {
   constraints = [];
 }
 
+let state_snapshot_source_is_synthetic source =
+  let source = String.trim source in
+  String.equal source "synthesized"
+  || String.starts_with ~prefix:"synthesized_" source
+
 type keeper_memory_line = {
   kind: string;
   text: string;
@@ -822,10 +827,13 @@ let synthesize_state_from_run_result
       let unique = List.sort_uniq String.compare ts in
       Some (Printf.sprintf "Used: %s" (String.concat ", " unique))
   in
-  let next_items =
-    if stop_reason = "budget_exhausted" then
-      ["Continue previous work"; "Review results from last generation"]
-    else []
+  let next_summary =
+    if stop_reason = "budget_exhausted"
+    then
+      Some
+        "Resume from the OAS checkpoint and inspect the latest assistant/tool \
+         context before choosing the next action."
+    else None
   in
   let response_hint =
     let trimmed = String.trim response_text in
@@ -842,10 +850,8 @@ let synthesize_state_from_run_result
   { goal = (let g = String.trim goal in if g = "" then None else Some g);
     progress;
     done_summary = progress;
-    next_summary = (match next_items with
-                    | [] -> None
-                    | items -> Some (String.concat "; " items));
-    next_items;
+    next_summary;
+    next_items = [];
     decisions;
     open_questions = [];
     constraints = [];

--- a/lib/keeper/keeper_memory_policy.mli
+++ b/lib/keeper/keeper_memory_policy.mli
@@ -70,6 +70,11 @@ val empty_keeper_state_snapshot : keeper_state_snapshot
 (** All-empty snapshot used as a default when no [STATE] block was
     emitted. *)
 
+val state_snapshot_source_is_synthetic : string -> bool
+(** True for runtime-synthesized continuity snapshots. Synthetic snapshots may
+    remain in checkpoints/sidecars for resume, but must not be promoted as
+    model-authored durable memory or active work. *)
+
 type compaction_source =
   | Pre_dispatch_hygiene
   | MASC_policy

--- a/lib/keeper/keeper_working_state_projector.ml
+++ b/lib/keeper/keeper_working_state_projector.ml
@@ -5,15 +5,12 @@ module State = Keeper_working_state
 
 type source_field =
   | Next_item
-  | Open_question
 
 let source_field_name = function
   | Next_item -> "next_items"
-  | Open_question -> "open_questions"
 
 let source_field_why = function
   | Next_item -> "keeper_state_snapshot.next_items"
-  | Open_question -> "keeper_state_snapshot.open_questions"
 
 
 let normalized_items values =
@@ -59,16 +56,12 @@ let loops_of_items ~keeper_name ~trace_id ~keeper_turn_id ~updated_at_iso
 let of_state_snapshot ~keeper_name ~trace_id ~keeper_turn_id ~updated_at_iso
     ~updated_at_unix (snapshot : Snapshot.keeper_state_snapshot) =
   let next_items = normalized_items snapshot.next_items in
-  let open_questions = normalized_items snapshot.open_questions in
   let active_loops =
     loops_of_items ~keeper_name ~trace_id ~keeper_turn_id ~updated_at_iso
       ~updated_at_unix ~source:Next_item next_items
-    @ loops_of_items ~keeper_name ~trace_id ~keeper_turn_id ~updated_at_iso
-        ~updated_at_unix ~source:Open_question open_questions
   in
   State.compact { State.empty with active_loops }
 
 let active_open_loop_count_of_state_snapshot
     (snapshot : Snapshot.keeper_state_snapshot) =
   List.length (normalized_items snapshot.next_items)
-  + List.length (normalized_items snapshot.open_questions)

--- a/lib/memory_oas_bridge.ml
+++ b/lib/memory_oas_bridge.ml
@@ -349,12 +349,16 @@ let institution_episode_of_oas ~(agent_name : string)
     Metadata keys match what [institution_episode_of_oas] expects, so
     the round-trip Institution_eio -> OAS -> Institution_eio is lossless. *)
 let store_episode_from_snapshot
+    ?state_snapshot_source
     ~(memory : Agent_sdk.Memory.t)
     ~(keeper_name : string)
     ~(turn : int)
     ?(oas_turn_count : int option)
     ~(trace_id : string)
     (snapshot : Keeper_memory_policy.keeper_state_snapshot) : unit =
+  match state_snapshot_source with
+  | Some source when Keeper_memory_policy.state_snapshot_source_is_synthetic source -> ()
+  | _ ->
   let parts =
     List.filter_map Fun.id
       [

--- a/lib/memory_oas_bridge.mli
+++ b/lib/memory_oas_bridge.mli
@@ -73,6 +73,7 @@ val oas_procedure_of_masc :
 (** {1 Episode persistence} *)
 
 val store_episode_from_snapshot :
+  ?state_snapshot_source:string ->
   memory:Agent_sdk.Memory.t ->
   keeper_name:string ->
   turn:int ->

--- a/test/test_keeper_agent_memory_episode_activity.ml
+++ b/test/test_keeper_agent_memory_episode_activity.ml
@@ -143,6 +143,36 @@ let test_zero_flush_is_noop () =
         ();
       check bool "zero flush does not call activity emit" false !called))
 
+let test_synthetic_success_snapshot_does_not_emit_episode () =
+  with_config (fun config ->
+    let keeper = "keeper-memory-activity-synthetic" in
+    let called = ref false in
+    let counting_emit _config ~actor:_ ?subject ~kind:_ ~payload:_ ~tags:_ () =
+      ignore subject;
+      called := true
+    in
+    let memory =
+      Memory_oas_bridge.create_memory
+        ~agent_name:keeper
+        ~base_dir:(Workspace_utils.masc_dir config)
+        ~session_id:"synthetic-source-test"
+        ()
+    in
+    let snapshot =
+      Keeper_memory_policy.synthesize_state_from_run_result
+        ~goal:"Fix task"
+        ~tools_used:["tool_execute"]
+        ~stop_reason:"budget_exhausted"
+        ~response_text:"[turn budget exhausted: 8/8 turns used]"
+    in
+    with_activity_emit counting_emit (fun () ->
+      Episode.record_success ~config ~keeper_name:keeper ~memory ~turn:12
+        ~oas_turn_count:8 ~trace_id:"trace-synthetic"
+        ~state_snapshot_source:"synthesized"
+        ~snapshot
+        ();
+      check bool "synthetic snapshot does not flush an episode" false !called))
+
 let () =
   run "keeper_agent_memory_episode_activity" [
     "activity emit visibility", [
@@ -153,5 +183,7 @@ let () =
       test_case "failure flush emit failure increments metric" `Quick
         test_activity_emit_failure_increments_failure_metric;
       test_case "zero flush remains a no-op" `Quick test_zero_flush_is_noop;
+      test_case "synthetic snapshot does not emit episode" `Quick
+        test_synthetic_success_snapshot_does_not_emit_episode;
     ];
   ]

--- a/test/test_keeper_memory_write.ml
+++ b/test/test_keeper_memory_write.ml
@@ -16,6 +16,8 @@
     coverage for the new code paths. *)
 
 module Keeper_tool_memory_runtime = Masc.Keeper_tool_memory_runtime
+module Keeper_memory_bank = Masc.Keeper_memory_bank
+module Keeper_memory_policy = Masc.Keeper_memory_policy
 
 (* --- helpers ------------------------------------------------------- *)
 
@@ -172,6 +174,24 @@ let test_valid_call_empty_title_uses_content_alone () =
       (Keeper_tool_memory_runtime.memory_write_error_kind_to_string r.error_kind)
 ;;
 
+let test_synthetic_snapshot_source_drops_memory_candidates () =
+  let snapshot =
+    Keeper_memory_policy.synthesize_state_from_run_result
+      ~goal:"Fix task"
+      ~tools_used:["tool_execute"; "tool_read_file"]
+      ~stop_reason:"budget_exhausted"
+      ~response_text:"[turn budget exhausted: 8/8 turns used]"
+  in
+  let selection =
+    Keeper_memory_bank.memory_candidates_from_snapshot_source
+      ~state_snapshot_source:"synthesized"
+      snapshot
+  in
+  Alcotest.(check int)
+    "synthetic source writes no durable memory candidates"
+    0
+    (List.length selection.Keeper_memory_bank.selected)
+
 (* --- constants ----------------------------------------------------- *)
 
 let test_max_title_chars_constant () =
@@ -232,6 +252,10 @@ let () =
             "empty title -> content alone as body"
             `Quick
             test_valid_call_empty_title_uses_content_alone
+        ; Alcotest.test_case
+            "synthetic snapshot source drops candidates"
+            `Quick
+            test_synthetic_snapshot_source_drops_memory_candidates
         ] )
     ; ( "constants"
       , [ Alcotest.test_case "max_title_chars = 120" `Quick test_max_title_chars_constant

--- a/test/test_keeper_state_snapshot_json.ml
+++ b/test/test_keeper_state_snapshot_json.ml
@@ -259,6 +259,26 @@ let test_text_parse_matches_json_parse () =
        Alcotest.(check (list string)) "open_questions" text_snap.open_questions json_snap.open_questions;
        Alcotest.(check (list string)) "constraints" text_snap.constraints json_snap.constraints)
 
+let test_budget_synthesis_does_not_invent_next_items () =
+  let snapshot =
+    KMP.synthesize_state_from_run_result
+      ~goal:"Fix task"
+      ~tools_used:["tool_execute"; "tool_read_file"]
+      ~stop_reason:"budget_exhausted"
+      ~response_text:"[turn budget exhausted: 8/8 turns used]"
+  in
+  Alcotest.(check (list string)) "no invented next_items" [] snapshot.next_items;
+  Alcotest.(check bool)
+    "checkpoint resume summary present"
+    true
+    (match snapshot.next_summary with
+     | Some text -> contains_substring text "OAS checkpoint"
+     | None -> false);
+  Alcotest.(check bool)
+    "synthetic marker present"
+    true
+    (List.exists Masc.Keeper_synthetic_marker.contains_marker snapshot.decisions)
+
 (* ── Test runner ─────────────────────────────────────────────────── *)
 
 let () =
@@ -288,5 +308,9 @@ let () =
       ( "dual_source",
         [
           Alcotest.test_case "text matches json" `Quick test_text_parse_matches_json_parse;
+          Alcotest.test_case
+            "budget synthesis does not invent next items"
+            `Quick
+            test_budget_synthesis_does_not_invent_next_items;
         ] );
     ]

--- a/test/test_keeper_working_state.ml
+++ b/test/test_keeper_working_state.ml
@@ -124,10 +124,36 @@ let test_projector_maps_snapshot_items_to_active_loops () =
       ~updated_at_unix:3.0
       snapshot
   in
-  check int "deduped active loop count" 2 (WS.active_open_loop_count state);
+  check int "deduped active loop count" 1 (WS.active_open_loop_count state);
+  check (list string)
+    "open questions do not become active loops"
+    [ "finish PR" ]
+    (state.WS.active_loops |> List.map (fun loop -> loop.WS.title));
   check (list string) "digest covers active loops"
     (List.map (fun loop -> loop.WS.id) state.active_loops)
     state.prompt_digest_ids;
+  check bool "valid projected state" true (Result.is_ok (WS.validate state))
+
+let test_projector_ignores_budget_synthetic_summary_as_loop () =
+  let snapshot =
+    Masc.Keeper_memory_policy.synthesize_state_from_run_result
+      ~goal:"Fix task"
+      ~tools_used:["tool_execute"]
+      ~stop_reason:"budget_exhausted"
+      ~response_text:"[turn budget exhausted: 8/8 turns used]"
+  in
+  let state =
+    Masc.Keeper_working_state_projector.of_state_snapshot
+      ~keeper_name:"keeper-a"
+      ~trace_id:"trace-1"
+      ~keeper_turn_id:8
+      ~updated_at_iso:"2026-05-21T02:00:00+09:00"
+      ~updated_at_unix:4.0
+      snapshot
+  in
+  check int "synthetic budget summary is not an active loop" 0
+    (WS.active_open_loop_count state);
+  check (list string) "no prompt digest loops" [] state.prompt_digest_ids;
   check bool "valid projected state" true (Result.is_ok (WS.validate state))
 
 (* Resume-merge / readback (ResumeFromDigest) tests.
@@ -349,6 +375,8 @@ let () =
           test_case "json roundtrip" `Quick test_json_roundtrip;
           test_case "projector maps snapshot items to active loops" `Quick
             test_projector_maps_snapshot_items_to_active_loops;
+          test_case "projector ignores budget synthetic summary as loop" `Quick
+            test_projector_ignores_budget_synthetic_summary_as_loop;
         ] );
       ( "resume_merge",
         [


### PR DESCRIPTION
## Summary

- Stop runtime-synthesized keeper state from becoming durable memory or active work.
- Keep budget-exhausted synthetic continuity as checkpoint-resume guidance only.
- Prevent `open_questions` from becoming working-state active loops.

## Product impact

Keeper resume still works through the OAS checkpoint, but fallback/synthetic state no longer invents todos, long-term memory rows, or successful episodic memory from bookkeeping text.

## Evidence

- `ocamlformat --check lib/keeper/keeper_memory_policy.ml lib/keeper/keeper_memory_policy.mli lib/keeper/keeper_memory_bank_selection.ml lib/keeper/keeper_memory_bank_selection.mli lib/keeper/keeper_memory_bank.ml lib/keeper/keeper_memory_bank.mli lib/memory_oas_bridge.ml lib/memory_oas_bridge.mli lib/keeper/keeper_agent_memory_episode.ml lib/keeper/keeper_agent_memory_episode.mli lib/keeper/keeper_agent_run_post_turn_memory.ml lib/keeper/keeper_agent_run_post_turn_memory.mli lib/keeper/keeper_agent_run_finalize_response.ml lib/keeper/keeper_working_state_projector.ml test/test_keeper_memory_write.ml test/test_keeper_agent_memory_episode_activity.ml test/test_keeper_state_snapshot_json.ml test/test_keeper_working_state.ml`
- `git diff --check origin/main..HEAD`
- `DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_state_snapshot_json.exe test/test_keeper_working_state.exe test/test_keeper_memory_write.exe test/test_keeper_agent_memory_episode_activity.exe`
- `./_build/default/test/test_keeper_state_snapshot_json.exe`
- `./_build/default/test/test_keeper_working_state.exe`
- `./_build/default/test/test_keeper_memory_write.exe`
- `./_build/default/test/test_keeper_agent_memory_episode_activity.exe`

## Direct evidence

schema_version: 1
direct_ratio: 6/6
provenance: direct

- Added regression coverage for budget synthesis not inventing `next_items`.
- Added regression coverage for synthetic budget summaries not becoming working-state loops.
- Added regression coverage for synthetic snapshot sources producing no durable memory candidates.
- Added regression coverage for synthetic success snapshots not emitting an OAS episode.

## Review evidence

- Compared state producers and consumers across `[STATE]` synthesis, working-state projection, memory bank persistence, and OAS episodic memory.
- Verified the branch after rebasing onto current `origin/main`.

## Linked issue

n/a

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`fix/keeper-budget-synthetic-state-20260604` → `main` · 1 commit(s) · synced 2026-06-04T06:16:26Z

| sha | subject | date |
|---|---|---|
| `344efc796` | fix(keeper): keep synthesized state out of durable memory | 2026-06-04 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->