### PR TITLE
test: seed runtime and auth for transport harnesses

### DIFF
--- a/dashboard/src/components/keeper-tool-access.test.ts
+++ b/dashboard/src/components/keeper-tool-access.test.ts
@@ -29,7 +29,7 @@ describe('KeeperToolAccessSummary', () => {
     expect(container.textContent).toContain('auto handoff')
     expect(container.textContent).toContain('proactive idle')
     expect(container.textContent).toContain('mention targets')
-    expect(container.textContent).toContain('allow / deny')
+    expect(container.textContent).toContain('candidate / deny')
   })
 
   it('shows em dash for null runtime name', () => {
@@ -60,10 +60,10 @@ describe('KeeperToolAccessSummary', () => {
     expect(dds[5]!.textContent).toBe('—')
   })
 
-  it('shows allow/deny counts', () => {
+  it('shows candidate/deny counts', () => {
     const container = document.createElement('div')
     render(h(KeeperToolAccessSummary, { config: makeConfig() }), container)
-    expect(container.textContent).toContain('2 allow')
+    expect(container.textContent).toContain('2 candidate')
     expect(container.textContent).toContain('1 deny')
   })
 

--- a/dashboard/src/components/keeper-tool-access.ts
+++ b/dashboard/src/components/keeper-tool-access.ts
@@ -42,7 +42,7 @@ export function KeeperToolAccessSummary({ config }: { config: KeeperConfig }) {
   const handoff = `${config.handoff.auto ? 'on' : 'off'} · threshold ${config.handoff.threshold}`
   const idle = `${config.proactive.idle_sec}s${config.proactive.enabled ? '' : ' (disabled)'}`
   const mentions = mentionsLabel(config.workspace.mention_targets)
-  const allowlistCount = config.tools.resolved_allowlist.length
+  const candidateCount = config.tools.resolved_allowlist.length
   const denylistCount = config.tools.tool_denylist.length
 
   return html`
@@ -64,8 +64,8 @@ export function KeeperToolAccessSummary({ config }: { config: KeeperConfig }) {
         <${ToolAccessRow} label="proactive idle" value=${idle} />
         <${ToolAccessRow} label="mention targets" value=${mentions} />
         <${ToolAccessRow}
-          label="allow / deny"
-          value=${`${allowlistCount} allow · ${denylistCount} deny`}
+          label="candidate / deny"
+          value=${`${candidateCount} candidate · ${denylistCount} deny`}
         />
       </dl>
     </section>

--- a/docs/KEEPER-CAPABILITY-MATRIX.md
+++ b/docs/KEEPER-CAPABILITY-MATRIX.md
@@ -31,7 +31,7 @@ Triage and trigger detection run on each heartbeat using the proactive idle/cool
 Notes:
 - The `voice` shard still exists, but it is no longer part of the default keeper surface. The historical weather shard is retired from `Tool_shard`.
 - The old governance petition/case tools were retired from the callable tool surface. Governance-style participation now uses board discussion/vote paths plus dashboard governance/audit read models.
-- Write-capable tools such as `tool_edit_file` and `tool_write_file` are present in the keeper surface; `tool_access` policy and eval gates decide whether a keeper may execute the mutation.
+- Write-capable tools such as `tool_edit_file` and `tool_write_file` are present in the keeper surface. `tool_access` is a configured candidate profile list; actual execution is constrained by descriptor/registry availability, denylist filtering, per-turn OAS allowlists, and eval gates.
 - `tool_search_files` is structured-only (`pwd`, `ls`, `cat`, `rg`, `find`, `head`, `tail`, `wc`, `tree`, `git_status`, `git_log`, `git_diff`). Typed command execution is model-facing as `Execute`, backed by the `tool_execute` descriptor route.
 
 ## Tool Surface
@@ -94,9 +94,10 @@ BoardActivity, IdleTimeout, MetricsAnomaly, StrategicReview.
 | 테스트 실행 | `Execute` with typed argv from the worktree `cwd` |
 | GitHub PR / 이슈 작업 | `Execute` with `executable="gh"` and typed `argv` from a bound repo context for PR reads and reversible PR mutations such as `pr create` / `pr edit`. |
 
-The goal lifecycle surface is configured as the `masc.goal` policy group and is
-routed to keepers with matching `tool_access` lists. Social and
-messaging keepers keep board/task workspace collaboration without goal mutation access.
+The goal lifecycle surface is configured as the `masc.goal` policy group and
+can enter a keeper's configured `tool_access` candidate profile. Social and
+messaging keepers keep board/task workspace collaboration without goal mutation
+execution surface.
 
 ## Research Profile Additions
 

--- a/docs/KEEPER-FILE-MODEL.md
+++ b/docs/KEEPER-FILE-MODEL.md
@@ -88,8 +88,8 @@ These are the identity fields that should live in persona by default.
 | `mid_goal` | Optional | Mid-horizon goal | Defaults to `goal` in create paths. |
 | `long_goal` | Optional | Long-horizon goal | Defaults to `goal` in create paths. |
 | `mention_targets` | Optional | Default mention aliases | If omitted, create-from-persona falls back to `[persona_name]`. |
-| `tool_access` | Optional | Default tool allowlist | String array of callable tool names; omitted means `[]`. |
-| `tool_denylist` | Optional | Tools to remove from the allowlist | Optional policy refinement. |
+| `tool_access` | Optional | Default tool candidate profile list | String array of tool names used as profile input; omitted means `[]`. It is not the complete execution gate. |
+| `tool_denylist` | Optional | Tools to remove after candidate profile resolution | Optional policy refinement. |
 | `policy_voice_enabled` | Optional | Whether voice tools should be surfaced | Policy default, not runtime state. |
 | `shards` | Optional | Default tool shards | Optional specialization hook. |
 
@@ -135,7 +135,7 @@ persona_name = "analyst"
 | `name` | Optional | Override keeper handle | Usually redundant because filename is already the keeper name. |
 | `sandbox_profile` | Optional | Process/filesystem sandbox profile | `local` runs on the host with fs scoped to the keeper playground. `docker` runs in a hardened ephemeral container. Hard mode requires `docker`. |
 | `network_mode` | Optional | Sandbox network policy | `docker` defaults to `none`; `local` defaults to `inherit`. Hard mode requires `none`. |
-| `tool_access` | Optional | Deployment-specific tool allowlist override | Only when intentionally overriding persona default. |
+| `tool_access` | Optional | Deployment-specific tool candidate profile override | Only when intentionally overriding persona default. |
 | `active_goal_ids` | Optional | Goal-scoped claim filter | When set, `keeper_task_claim` prefers tasks linked to these goals and reports scope health in audit/status surfaces. |
 
 ### Additional supported overlay fields
@@ -152,8 +152,8 @@ These are still accepted by the loader, but for consistency they should be used 
 | `proactive_idle_sec`, `proactive_cooldown_sec` | int | Proactive scheduling intervals |
 | `workspace_signal_prompt_enabled` | bool | Override workspace-signal prompt behavior |
 | `allowed_paths` | string array | Exceptional path override only; prefer empty and rely on the single sandbox root |
-| `tool_access` | string array | Explicit callable tool names |
-| `tool_denylist` | string array | Tool names blocked after allowlist resolution |
+| `tool_access` | string array | Explicit tool candidate profile names |
+| `tool_denylist` | string array | Tool names blocked after candidate profile resolution |
 | `active_goal_ids` | string array | Declarative goal scope for task claim eligibility |
 | `telemetry_feedback_enabled` | bool | Surface recent telemetry in the keeper prompt |
 | `telemetry_feedback_window_hours` | int | Window size for telemetry summarization |
@@ -168,7 +168,7 @@ Enumerated fields only accept the values below. The loader rejects invalid input
 | --- | --- |
 | `sandbox_profile` | `local`, `docker` |
 | `network_mode` | `none`, `inherit` |
-| `tool_access` | string array of registered tool names |
+| `tool_access` | string array of registered tool names used as the candidate profile list |
 | `social_model` | `bdi_speech_v1`, `magentic_ledger_v1` (non-public: rejected when passed via tool args; TOML-only) |
 | `runtime_id` | keeper-assignable declarative runtime profiles exposed by the active catalog: route targets, tier names, or runtime names that are not marked `keeper-assignable = false` |
 
@@ -194,7 +194,7 @@ These keys are **rejected at load time** with an `Error`. They are retained only
 
 | Field | Replacement / rationale |
 | --- | --- |
-| Retired tool-policy aliases | Tool policy is the canonical `tool_access` string-array allowlist. |
+| Retired tool-policy aliases | Tool policy uses the canonical `tool_access` string-array candidate profile list plus `tool_denylist`; runtime execution is still constrained by descriptor/registry availability, per-turn OAS allowlists, and eval gates. |
 | `models`, `allowed_models`, `active_model` | Models are resolved at runtime from `runtime_id` → `runtime.toml`. Do not pin per-keeper. |
 | `allowed_providers` | Provider/model ownership lives in `runtime.toml` and OAS runtime receipts. Do not pin providers per keeper. |
 | `presence_keepalive`, `presence_keepalive_sec` | Use `paused` in runtime JSON; keepalive is managed by the keepalive fiber. |

--- a/docs/KEEPER-FILE-MODEL.md
+++ b/docs/KEEPER-FILE-MODEL.md
@@ -136,7 +136,7 @@ persona_name = "analyst"
 | `sandbox_profile` | Optional | Process/filesystem sandbox profile | `local` runs on the host with fs scoped to the keeper playground. `docker` runs in a hardened ephemeral container. Hard mode requires `docker`. |
 | `network_mode` | Optional | Sandbox network policy | `docker` defaults to `none`; `local` defaults to `inherit`. Hard mode requires `none`. |
 | `tool_access` | Optional | Deployment-specific tool candidate profile override | Only when intentionally overriding persona default. |
-| `active_goal_ids` | Optional | Goal-scoped claim filter | When set, `keeper_task_claim` prefers tasks linked to these goals and reports scope health in audit/status surfaces. |
+| `active_goal_ids` | Optional | Goal-scoped claim filter | When set, `keeper_task_claim` only claims tasks linked to these goals and reports scope health in audit/status surfaces. |
 
 ### Additional supported overlay fields
 

--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -822,7 +822,7 @@ Keeper 설정은 아래 소스에서 공급된다. 상세 우선순위는
 
 - **Canonical minimal**: `[keeper]` 테이블에 `persona_name`만. 나머지는 persona 기본값에서 해석.
 - **Overlay fields**: `goal`, `tool_access`, `runtime_id`, `sandbox_profile`, `network_mode`, `active_goal_ids` 등 배치별 override 전용.
-- **Allowed value sets**: `tool_access`는 tool name string 배열, `sandbox_profile ∈ {local, docker}`, `network_mode ∈ {none, inherit}`, `social_model ∈ {bdi_speech_v1, magentic_ledger_v1}`, `runtime_id`는 `runtime.toml`에 `<name>_models` 키로 존재해야 함.
+- **Allowed value sets**: `tool_access`는 candidate profile tool name string 배열, `sandbox_profile ∈ {local, docker}`, `network_mode ∈ {none, inherit}`, `social_model ∈ {bdi_speech_v1, magentic_ledger_v1}`, `runtime_id`는 `runtime.toml`에 `<name>_models` 키로 존재해야 함. 실제 실행 가능 여부는 descriptor/registry availability, `tool_denylist`, per-turn OAS allowlist, eval gate까지 통과해야 한다.
 - **Removed / hard-rejected**: `models`, `allowed_models`, `active_model`, `presence_keepalive*`, `trigger_mode`, `initiative_*`, `policy_mode`, `policy_shell_mode`. 로드 시 에러로 실패한다.
 - **Unknown keys**: canonical/removed 둘 다 아닌 key는 **boot 시 warning** 후 무시된다 (`keeper TOML <path> has unknown keys: ...`). 과거에 `legacy_scope`/`scope_kind` 같은 dead config가 축적된 적이 있으므로 warning을 발견하면 정리한다.
 

--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -280,7 +280,7 @@ spawn 시 인자로 직접 설정하는 필드.
 | `verify` | bool | `false` | 저비용 모델로 action 검증 | `masc_keeper_up`의 `verify` 인자 |
 | `sandbox_profile` | string | `local` | 실행 샌드박스 프로필 (`local`, `docker`). hard mode에서는 `docker`만 허용된다. | `masc_keeper_up`의 `sandbox_profile` 인자 |
 | `network_mode` | string | `inherit` 또는 `none` | 샌드박스 네트워크 정책. `docker`는 기본 `none`이고 hard mode에서는 `none`만 허용된다. | `masc_keeper_up`의 `network_mode` 인자 |
-| `active_goal_ids` | string[] | 없음 | 설정 시 `keeper_task_claim`이 goal-linked task만 claim. scoped pool에 현재 capability로 claim 가능한 task가 없으면 claim을 멈춘다. auto-repair keeper-purpose goal만 전체 claimable task fallback 허용 | `keeper.toml` 선언 |
+| `active_goal_ids` | string[] | 없음 | 설정 시 `keeper_task_claim`이 goal-linked task만 claim. scoped pool에 현재 capability로 claim 가능한 task가 없으면 claim을 멈춘다. 전체 claimable task fallback은 없다. | `keeper.toml` 선언 |
 
 ### 3.1.1 Sandbox Core V1 사용법
 

--- a/docs/audit/2026-06-04-keeper-task-execution-visibility-audit.md
+++ b/docs/audit/2026-06-04-keeper-task-execution-visibility-audit.md
@@ -230,14 +230,17 @@ Code anchor:
 
 ### 8. Task result and PR evidence
 
-Task completion and PR evidence are explicit task tool transitions.
+Task completion and verification evidence are explicit task tool transitions.
 
 `keeper_task_done` requires `task_id` and `result`, maps the result into
 `handoff_context.summary`, and calls `Task.Tool.handle_transition` with
 `action=done`.
 
-`keeper_task_submit_for_verification` requires `task_id`, `notes`, and a valid
-`pr_url`, then maps the PR URL into `handoff_context.evidence_refs` and calls
+`keeper_task_submit_for_verification` requires `task_id` and `notes`. The notes
+message is the primary evidence handoff: it must say what was done and how it can
+be verified. Optional structured `evidence_refs` can also carry PR URLs, commits,
+artifacts, receipts, test logs, task comments, or other concrete references.
+The wrapper maps these into `handoff_context` and calls
 `action=submit_for_verification`.
 
 Code anchors:
@@ -249,9 +252,11 @@ Code anchors:
 - `lib/task/tool_task.ml:486` - persisted workspace transition
 - `lib/task/tool_task.ml:525` - verification notification path
 
-Finding: PR evidence can be persisted cleanly, but it is not automatic merely
-because the Keeper ran `gh pr create`. The Keeper must call the task transition
-tool or another explicit task/comment tool.
+Finding: verification evidence can be persisted cleanly, but it is not automatic
+merely because the Keeper ran `gh pr create`. The Keeper must call the task
+transition tool or another explicit task/comment tool. Keeper code must not
+treat PR URL or any single reference shape as the verification SSOT; evidence
+semantics live in the task/CDAL domain.
 
 ### 9. Receipt and lineage
 
@@ -296,7 +301,10 @@ fast diagnosis path sees only counts.
    gate. The resolver now passes a goal-linked task filter into
    `Workspace.claim_next_r`, and no-scope results report excluded tasks instead
    of falling back to all work.
-5. Decide whether PR creation should become a structured Keeper workflow, or
-   whether explicit `keeper_task_submit_for_verification` remains the SSOT.
+5. **Done in PR #20055**: keep explicit
+   `keeper_task_submit_for_verification` as the task-verification SSOT, but make
+   it evidence-message based rather than PR-URL based. The Keeper submits notes,
+   with optional structured refs for PRs, commits, artifacts, receipts, logs, or
+   task comments; `gh pr create` alone does not mutate task verification state.
 6. Add a first-class "worktree selected" observation if the Keeper should see a
    stable repo/worktree assignment rather than infer it from `cwd`.

--- a/docs/audit/2026-06-04-keeper-task-execution-visibility-audit.md
+++ b/docs/audit/2026-06-04-keeper-task-execution-visibility-audit.md
@@ -289,8 +289,10 @@ fast diagnosis path sees only counts.
    observability gap without changing policy.
 2. **Done in PR #20055**: add a dedicated post-Execute working-tree status
    path for successful `Execute` calls with a concrete `cwd`.
-3. Split `tool_access` wording from execution semantics in docs/UI/API:
-   candidate surface, discovered visible surface, and denylist are distinct.
+3. **Done in PR #20055**: split `tool_access` wording from execution
+   semantics in docs/UI/API. The field now reads as a candidate profile; actual
+   execution still depends on descriptor/registry availability, denylist,
+   per-turn OAS allowlist, and eval gates.
 4. Decide whether active goal scope must remain advisory or become a hard task
    claim gate for specific Keeper profiles.
 5. Decide whether PR creation should become a structured Keeper workflow, or

--- a/docs/audit/2026-06-04-keeper-task-execution-visibility-audit.md
+++ b/docs/audit/2026-06-04-keeper-task-execution-visibility-audit.md
@@ -107,6 +107,15 @@ affordances, overlays, fallback floor, and last-turn restrictions.
 
 The actual OAS call receives `AllowList turn_visible_tool_names`.
 
+Terminology is strict here:
+
+- `allowed_tool_names`: policy/candidate surface after keeper profile and denylist
+  resolution. This is not necessarily the exact set exposed to one SDK turn.
+- `turn_visible_tool_names`: internal name for the per-turn resolved tool surface.
+  It is the exact list passed to `Agent_sdk.Guardrails.AllowList`.
+- `oas_allowlist_tool_names`: operator-facing decision-log field for that same
+  list. This avoids introducing a second "visible tool" concept in audit logs.
+
 Code anchors:
 
 - `lib/keeper/keeper_run_tools_setup.ml:489` - compute per-turn tool surface
@@ -126,7 +135,7 @@ Code anchors:
 - `lib/keeper/keeper_tool_policy.ml:397` - Keeper allowed names are candidate minus denied
 
 Follow-up started in this series: decision-log `tool_disclosure` records should
-include the concrete `visible_tool_names`, not only the final count, so an
+include the concrete `oas_allowlist_tool_names`, not only the final count, so an
 operator can reconstruct exactly what the Keeper could call at that SDK turn.
 
 ### 5. Task claim and task assignment
@@ -210,13 +219,15 @@ Code anchors:
 - `lib/keeper/keeper_unified_turn_execution.ml:390` - ambiguous partial commit path
 - `lib/keeper/keeper_unified_turn_execution.ml:803` - timeout after committed tools
 
-Finding: retry safety exists, but post-Execute git status delta is currently not
-injected into the tool result. `keeper_tools_oas_handler_exec.ml` has a comment
-about capturing git status delta, but `change_block` is fixed to `None`.
+Finding: retry safety exists. PR #20055 also wires the stale post-Execute
+change hook: after a successful `Execute` result with a concrete `cwd`, the
+handler reads `git --no-optional-locks status --short` and injects non-empty
+status output into the normalized tool result as `changes`.
 
 Code anchor:
 
-- `lib/keeper/keeper_tools_oas_handler_exec.ml:361` - stale git-delta comment/path
+- `lib/keeper/keeper_tools_oas_handler_exec.ml:13` - post-Execute git status helper
+- `lib/keeper/keeper_tools_oas_handler_exec.ml:435` - change block injected into the result envelope
 
 ### 8. Task result and PR evidence
 
@@ -265,7 +276,7 @@ fast diagnosis path sees only counts.
 | Surface | Model sees | Runtime enforces | Operator can audit | Status |
 | --- | --- | --- | --- | --- |
 | Allowed Path | Tool schema and path errors; world prompt may not list exact paths | path/cwd resolver and sandbox/allowed-path checks | tool call log context and runtime contract include allowed paths | Partial |
-| Allowed Tool | OAS schemas filtered by `AllowList` | visible names allowlist plus candidate/deny execution gate | receipt/lineage has names; old disclosure only had counts | Partial, first patch adds disclosure names |
+| Allowed Tool | OAS schemas filtered by `AllowList` | `turn_visible_tool_names` OAS allowlist plus candidate/deny execution gate | receipt/lineage names plus `tool_disclosure.oas_allowlist_tool_names` | Partial, first patch adds allowlist names |
 | Assign Task | task counts, claim guidance, current task context | claim/start transitions and current-task reconciliation | backlog, receipt current task, task events | Good after claim; acquisition is advisory |
 | Assign Goal | goal prompt and active-goal world state | advisory scope only | receipt goal IDs and goal progress JSON | Partial |
 | Past Memory | memory context, checkpoint history, temporal context | memory hooks and checkpoint lifecycle | digests, memory files, post-turn eval | Good model-side; raw audit requires backing files |
@@ -273,11 +284,11 @@ fast diagnosis path sees only counts.
 
 ## Work Queue
 
-1. **Started**: add concrete `visible_tool_names` to the per-turn
-   `tool_disclosure` decision log. This closes the fastest observability gap
-   without changing policy.
-2. Add a dedicated post-Execute working-tree delta path, or delete the stale
-   comment if the product decision is "receipt/tool logs only".
+1. **Done in PR #20055**: add concrete `oas_allowlist_tool_names` to the
+   per-turn `tool_disclosure` decision log. This closes the fastest
+   observability gap without changing policy.
+2. **Done in PR #20055**: add a dedicated post-Execute working-tree status
+   path for successful `Execute` calls with a concrete `cwd`.
 3. Split `tool_access` wording from execution semantics in docs/UI/API:
    candidate surface, discovered visible surface, and denylist are distinct.
 4. Decide whether active goal scope must remain advisory or become a hard task
@@ -286,4 +297,3 @@ fast diagnosis path sees only counts.
    whether explicit `keeper_task_submit_for_verification` remains the SSOT.
 6. Add a first-class "worktree selected" observation if the Keeper should see a
    stable repo/worktree assignment rather than infer it from `cwd`.
-

--- a/docs/audit/2026-06-04-keeper-task-execution-visibility-audit.md
+++ b/docs/audit/2026-06-04-keeper-task-execution-visibility-audit.md
@@ -54,15 +54,14 @@ Code anchors:
 - `lib/keeper/keeper_unified_prompt.ml:652` - continuity filtering
 - `lib/keeper/keeper_unified_prompt.ml:687` - claimable work guidance
 
-Finding: goals are visible, but goal assignment is not a hard claim boundary.
-`Keeper_runtime_contract.resolve_claim_goal_scope` explicitly treats
-`active_goal_ids` as advisory. If active goal IDs exist, tasks outside the goal
-scope are still claimable; the Keeper receives scope context but not a strict
-deny.
+Finding: goals are visible and active goal assignment is now a hard claim
+boundary. `Keeper_runtime_contract.resolve_claim_goal_scope` turns
+`active_goal_ids` into the `Workspace.claim_next_r` `task_filter`; tasks outside
+the active goal set are excluded and counted in `scope_excluded_count`.
 
 Code anchor:
 
-- `lib/keeper/keeper_runtime_contract.ml:62` - advisory active goal mode
+- `lib/keeper/keeper_runtime_contract.ml:49` - active goal task filter
 
 ### 3. Context, checkpoint, and memory
 
@@ -293,8 +292,10 @@ fast diagnosis path sees only counts.
    semantics in docs/UI/API. The field now reads as a candidate profile; actual
    execution still depends on descriptor/registry availability, denylist,
    per-turn OAS allowlist, and eval gates.
-4. Decide whether active goal scope must remain advisory or become a hard task
-   claim gate for specific Keeper profiles.
+4. **Done in PR #20055**: make `active_goal_ids` a hard `keeper_task_claim`
+   gate. The resolver now passes a goal-linked task filter into
+   `Workspace.claim_next_r`, and no-scope results report excluded tasks instead
+   of falling back to all work.
 5. Decide whether PR creation should become a structured Keeper workflow, or
    whether explicit `keeper_task_submit_for_verification` remains the SSOT.
 6. Add a first-class "worktree selected" observation if the Keeper should see a

--- a/docs/audit/2026-06-04-keeper-task-execution-visibility-audit.md
+++ b/docs/audit/2026-06-04-keeper-task-execution-visibility-audit.md
@@ -191,9 +191,11 @@ Code anchors:
 - `lib/keeper/keeper_tool_execute_path.ml:267` - worktree repair path
 - `lib/keeper/keeper_tool_execute_path.ml:418` - write cwd resolution
 
-Finding: moving to a repo/worktree is a `cwd` discipline plus path repair, not a
-separate first-class state. The Keeper must call Execute/Edit/Read with the
-right repo/worktree path.
+Finding: moving to a repo/worktree is still a `cwd` discipline plus path repair,
+not a persistent global Keeper state. PR #20055 makes the selected worktree a
+first-class Execute observation: `execution_location.worktree_selected`,
+`worktree_name`, and `selected_worktree` identify the repo/worktree assignment
+without requiring the Keeper or operator to reparse `cwd`.
 
 ### 7. Tool dispatch and side-effect safety
 
@@ -228,7 +230,7 @@ Code anchor:
 - `lib/keeper/keeper_tools_oas_handler_exec.ml:13` - post-Execute git status helper
 - `lib/keeper/keeper_tools_oas_handler_exec.ml:435` - change block injected into the result envelope
 
-### 8. Task result and PR evidence
+### 8. Task result and verification evidence
 
 Task completion and verification evidence are explicit task tool transitions.
 
@@ -281,10 +283,11 @@ fast diagnosis path sees only counts.
 | --- | --- | --- | --- | --- |
 | Allowed Path | Tool schema and path errors; world prompt may not list exact paths | path/cwd resolver and sandbox/allowed-path checks | tool call log context and runtime contract include allowed paths | Partial |
 | Allowed Tool | OAS schemas filtered by `AllowList` | `turn_visible_tool_names` OAS allowlist plus candidate/deny execution gate | receipt/lineage names plus `tool_disclosure.oas_allowlist_tool_names` | Partial, first patch adds allowlist names |
-| Assign Task | task counts, claim guidance, current task context | claim/start transitions and current-task reconciliation | backlog, receipt current task, task events | Good after claim; acquisition is advisory |
-| Assign Goal | goal prompt and active-goal world state | advisory scope only | receipt goal IDs and goal progress JSON | Partial |
+| Repo / Worktree Seat | Execute result `execution_location.selected_worktree` after a worktree-scoped call | `cwd` resolver, repo readiness, and worktree repair | Execute result envelope and post-Execute change hook | Good after Execute; not a persistent assignment |
+| Assign Task | task counts, claim guidance, current task context | claim/start transitions and current-task reconciliation | backlog, receipt current task, task events | Good after claim/start |
+| Assign Goal | goal prompt and active-goal world state | `active_goal_ids` hard-gate `keeper_task_claim` | receipt goal IDs and goal progress JSON | Good for claim scope; goal progress remains observational |
 | Past Memory | memory context, checkpoint history, temporal context | memory hooks and checkpoint lifecycle | digests, memory files, post-turn eval | Good model-side; raw audit requires backing files |
-| PR evidence | only if tool output/notes/transition show it | task verification requires real PR URL | handoff evidence refs and task events | Partial; not automatic from `gh pr create` |
+| Verification evidence | only if tool output/notes/transition show it | task verification requires an evidence-bearing handoff, not a PR URL shape | notes, optional evidence refs, and task events | Good for wrapper; not automatic from `gh pr create` |
 
 ## Work Queue
 
@@ -306,5 +309,7 @@ fast diagnosis path sees only counts.
    it evidence-message based rather than PR-URL based. The Keeper submits notes,
    with optional structured refs for PRs, commits, artifacts, receipts, logs, or
    task comments; `gh pr create` alone does not mutate task verification state.
-6. Add a first-class "worktree selected" observation if the Keeper should see a
-   stable repo/worktree assignment rather than infer it from `cwd`.
+6. **Done in PR #20055**: add a first-class "worktree selected" observation to
+   Execute `execution_location`. This keeps repo/worktree choice tied to the
+   actual `cwd` that runtime enforced, but surfaces the stable assignment as
+   `selected_worktree` instead of requiring string parsing.

--- a/docs/keeper-turn-lifecycle.md
+++ b/docs/keeper-turn-lifecycle.md
@@ -103,6 +103,23 @@ flowchart TD
     N --> O[metrics snapshot + lifecycle/broadcast + keepalive wake + response JSON]
 ```
 
+## Tool Surface Vocabulary
+
+The Keeper has one `Allowed Tool` audit axis, but the code carries it through
+three different stages:
+
+- `allowed_tool_names`: the policy/candidate tool set after keeper profile and
+  denylist resolution.
+- `turn_visible_tool_names`: the internal per-SDK-turn list produced by
+  `compute_tool_surface`; this is the exact list passed to
+  `Agent_sdk.Guardrails.AllowList`.
+- `oas_allowlist_tool_names`: the operator-facing `tool_disclosure` JSONL field
+  for that same per-turn allowlist. It is not a separate permission system.
+
+When auditing "what could the Keeper call right now?", use
+`oas_allowlist_tool_names` for the specific turn and `allowed_tool_names` only
+for the broader policy/candidate boundary.
+
 ## Unified turn swimlane
 
 The two admission paths converge on the same execution engine. The diagram below places supervisor, heartbeat, direct message, and the shared `run_turn` + receipt path in a single sequence so the boundary between scheduling and dispatch is explicit.

--- a/docs/keeper-turn-lifecycle.md
+++ b/docs/keeper-turn-lifecycle.md
@@ -214,9 +214,9 @@ For the Keeper-eye view of a full work turn - task claim/start, repo/worktree
 writeback - see `docs/audit/2026-06-04-keeper-task-execution-visibility-audit.md`.
 
 That audit also tracks the current missing teeth in the contract:
-`tool_access` naming versus execution semantics, active goal scope, PR evidence
-not being automatic from `gh pr create`, post-Execute git delta visibility, and
-per-turn tool disclosure detail.
+`tool_access` naming versus execution semantics, active goal scope, verification
+evidence not being automatic from `gh pr create`, post-Execute git delta
+visibility, and per-turn tool disclosure detail.
 
 ## State machine
 

--- a/docs/keeper-turn-lifecycle.md
+++ b/docs/keeper-turn-lifecycle.md
@@ -216,7 +216,8 @@ writeback - see `docs/audit/2026-06-04-keeper-task-execution-visibility-audit.md
 That audit also tracks the current missing teeth in the contract:
 `tool_access` naming versus execution semantics, active goal scope, verification
 evidence not being automatic from `gh pr create`, post-Execute git delta
-visibility, and per-turn tool disclosure detail.
+visibility, first-class worktree selection observation, and per-turn tool
+disclosure detail.
 
 ## State machine
 

--- a/docs/keeper-turn-lifecycle.md
+++ b/docs/keeper-turn-lifecycle.md
@@ -214,7 +214,7 @@ For the Keeper-eye view of a full work turn - task claim/start, repo/worktree
 writeback - see `docs/audit/2026-06-04-keeper-task-execution-visibility-audit.md`.
 
 That audit also tracks the current missing teeth in the contract:
-`tool_access` naming versus execution semantics, advisory goal scope, PR evidence
+`tool_access` naming versus execution semantics, active goal scope, PR evidence
 not being automatic from `gh pr create`, post-Execute git delta visibility, and
 per-turn tool disclosure detail.
 

--- a/lib/keeper/keeper_meta_tool_access.ml
+++ b/lib/keeper/keeper_meta_tool_access.ml
@@ -1,9 +1,10 @@
 (** Keeper meta tool-access helpers.
 
     Included by [Keeper_meta_contract] so [Keeper_types.*] keeps the same
-    public API.  A keeper's tool access is simply the list of tool names it
-    may call — [keeper_meta.tool_access : string list].  There is no wrapper
-    type: the allowlist IS the policy. *)
+    public API. A keeper's [tool_access] is the persisted candidate profile
+    list — [keeper_meta.tool_access : string list]. Descriptor/registry
+    availability, denylist filtering, per-turn OAS allowlists, and eval gates
+    still constrain execution. There is no wrapper type. *)
 
 open Keeper_types_profile
 
@@ -23,7 +24,7 @@ let write_tools = [ "tool_edit_file"; "tool_write_file"; "tool_execute" ]
 
 let normalize_tool_access names = normalize_tool_names names
 
-(** Encode a tool allowlist as a JSON array of tool names. *)
+(** Encode a tool candidate profile as a JSON array of tool names. *)
 let tool_access_to_json names = `List (List.map (fun s -> `String s) names)
 
 let json_member_present key (json : Yojson.Safe.t) =
@@ -60,8 +61,9 @@ let string_list_field_opt_result ?label ~field_name (json : Yojson.Safe.t) =
 
 let default_tool_access_of_meta_json () =
   (* The Agent_internal surface was empty (agent_internal_surface_tools = []),
-     so the default tool_access for keepers without an explicit list has always
-     been the empty list; runtime filtering supplies the actual tool set.
+     so the default tool_access candidate profile for keepers without an
+     explicit list has always been the empty list; runtime filtering supplies
+     the actual tool set.
      Surface deleted in the surface-cut refactor.
      See fleet deadlock Layer 2 analysis (2026-05-30) + runtime provider
      gap analysis (2026-05-30). *)

--- a/lib/keeper/keeper_meta_tool_access.mli
+++ b/lib/keeper/keeper_meta_tool_access.mli
@@ -1,8 +1,10 @@
 (** Keeper tool-access helpers.
 
-    A keeper's tool access is the list of tool names it may call —
-    [keeper_meta.tool_access : string list].  There is no wrapper type;
-    the allowlist IS the policy. *)
+    A keeper's [tool_access] is the persisted candidate profile list —
+    [keeper_meta.tool_access : string list]. It is only one policy input:
+    descriptor/registry availability, denylist filtering, per-turn OAS
+    allowlists, and eval gates still constrain execution. There is no wrapper
+    type. *)
 
 (** Returns true if any name in the list resolves to a keeper board wrapper or
     legacy public [masc_board_*] surface. Used to detect implicit board
@@ -12,11 +14,11 @@ val tool_names_include_board : string list -> bool
 (** Trim, drop blanks, dedupe (preserve first-seen order). *)
 val normalize_tool_names : string list -> string list
 
-(** Trim, drop blanks, dedupe a tool allowlist (alias of
+(** Trim, drop blanks, dedupe a tool candidate profile (alias of
     {!normalize_tool_names}, kept for call-site clarity). *)
 val normalize_tool_access : string list -> string list
 
-(** Encode a tool allowlist as a JSON array of tool names. *)
+(** Encode a tool candidate profile as a JSON array of tool names. *)
 val tool_access_to_json : string list -> Yojson.Safe.t
 
 (** True if [json] has a non-null member at [key] (top level). *)
@@ -38,7 +40,7 @@ val string_list_field_opt_result :
   Yojson.Safe.t ->
   (string list, string) result
 
-(** Default string tool allowlist from the full [Keeper_internal] surface.
+(** Default string tool candidate profile from the full [Keeper_internal] surface.
     Persisted meta JSON still must provide canonical [tool_access] arrays; this
     default is for explicit callers that need the runtime-wide surface. *)
 val default_tool_access_of_meta_json : unit -> string list

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -597,7 +597,8 @@ let assemble_hooks
                      ; "discovered_count", `Int computed_surface.discovered_count
                      ; "llm_selected_count", `Int computed_surface.llm_selected_count
                      ; "final_visible", `Int (List.length turn_visible_tool_names)
-                     ; "visible_tool_names", Json_util.json_string_list turn_visible_tool_names
+                     ; ( "oas_allowlist_tool_names"
+                       , Json_util.json_string_list turn_visible_tool_names )
                      ; ( "turn_lane"
                        , Keeper_agent_tool_surface.turn_lane_to_yojson lane )
                      ; ( "tool_surface_class"

--- a/lib/keeper/keeper_runtime_contract.ml
+++ b/lib/keeper/keeper_runtime_contract.ml
@@ -30,23 +30,8 @@ type claim_goal_scope = {
   fallback_reason : string option;
 }
 
-let task_is_eligible_for_claim latest_verification_status task =
-  Workspace_task_schedule.task_is_claim_pool_candidate task
-  && not
-       (Workspace_task_schedule.verification_blocks_claim
-          latest_verification_status
-          task)
-
-let active_goal_ids_have_eligible_claim_task config goal_ids =
-  let latest_verification_status =
-    Workspace_task_schedule.latest_verification_status_by_task config
-  in
-  Workspace.get_tasks_safe config
-  |> List.exists (fun task ->
-       task_is_linked_to_keeper_goals goal_ids task
-       && task_is_eligible_for_claim latest_verification_status task)
-
 let resolve_claim_goal_scope ~(config : Workspace.config) ~(meta : keeper_meta) () =
+  ignore config;
   match meta.active_goal_ids with
   | [] ->
       {
@@ -56,26 +41,12 @@ let resolve_claim_goal_scope ~(config : Workspace.config) ~(meta : keeper_meta) 
         fallback_reason = None;
       }
   | goal_ids ->
-      let has_scoped_tasks =
-        active_goal_ids_have_eligible_claim_task config goal_ids
-      in
-      (* Advisory mode: active_goal_ids is a preference, not a hard gate.
-         Tasks outside the goal scope are claimable but the keeper receives
-         a warning in its context so it prefers goal-linked tasks. *)
-      if has_scoped_tasks then
-        {
-          task_filter = (fun (_task : Masc_domain.task) -> true);
-          mode = "active_goal_ids_advisory";
-          effective_goal_ids = goal_ids;
-          fallback_reason = None;
-        }
-      else
-        {
-          task_filter = (fun (_task : Masc_domain.task) -> true);
-          mode = "active_goal_ids_advisory";
-          effective_goal_ids = goal_ids;
-          fallback_reason = None;
-        }
+    {
+      task_filter = task_is_linked_to_keeper_goals goal_ids;
+      mode = "active_goal_ids";
+      effective_goal_ids = goal_ids;
+      fallback_reason = None;
+    }
 
 let resolve_observation_claim_goal_scope ~(config : Workspace.config)
     ~(meta : keeper_meta) () =

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -185,7 +185,7 @@ let keeper_schemas : tool_schema list = [
         ]);
         ("tool_access",
           tool_access_schema
-            "Canonical tool allowlist, e.g. ['masc_status', 'tool_execute'].");
+            "Canonical tool candidate profile list, e.g. ['masc_status', 'tool_execute']. Runtime execution also applies descriptor availability, denylist, per-turn OAS allowlist, and eval gates.");
         ("tool_denylist", `Assoc [
           ("type", `String "array");
           ("items", `Assoc [("type", `String "string")]);
@@ -335,11 +335,11 @@ let keeper_schemas : tool_schema list = [
         ]);
         ("tool_access",
           tool_access_schema
-            "Canonical tool allowlist, e.g. ['masc_status', 'tool_execute'].");
+            "Canonical tool candidate profile list, e.g. ['masc_status', 'tool_execute']. Runtime execution also applies descriptor availability, denylist, per-turn OAS allowlist, and eval gates.");
         ("tool_denylist", `Assoc [
           ("type", `String "array");
           ("items", `Assoc [("type", `String "string")]);
-          ("description", `String "Tool names to remove after tool_access resolution.");
+          ("description", `String "Tool names to remove after tool_access candidate profile resolution.");
         ]);
       ]);
       ("required", `List [`String "name"]);

--- a/lib/keeper/keeper_schema.mli
+++ b/lib/keeper/keeper_schema.mli
@@ -20,7 +20,7 @@ val persona_axis_schema : Persona_contract.archetype_axis -> Yojson.Safe.t
 (** Schema fragment for one archetype axis (ranged enum + description). *)
 
 val tool_access_schema : string -> Yojson.Safe.t
-(** Schema fragment for [meta.tool_access] (string-array tool allowlist);
+(** Schema fragment for [meta.tool_access] (string-array tool candidate profile list);
     parameterised on the property description so create vs update tools
     can vary the surface without duplicating the body. *)
 

--- a/lib/keeper/keeper_stay_silent_loop_detector.ml
+++ b/lib/keeper/keeper_stay_silent_loop_detector.ml
@@ -56,8 +56,8 @@ let record_turn ~keeper_name ~speech_act =
           ~labels:[ ("keeper", keeper_name) ] ();
         Log.Keeper.error
           "#9926 stay_silent loop detected keeper=%s streak=%d threshold=%d \
-           — keeper is returning stay_silent repeatedly. Check tool_access \
-           mismatch (#9926 proposal 1) or scheduler/backlog drift. \
+           — keeper is returning stay_silent repeatedly. Check effective tool \
+           surface mismatch (#9926 proposal 1) or scheduler/backlog drift. \
            Counter will not re-fire until the streak resets via any \
           non-stay_silent speech act."
           keeper_name s.streak t;

--- a/lib/keeper/keeper_stay_silent_loop_detector.mli
+++ b/lib/keeper/keeper_stay_silent_loop_detector.mli
@@ -3,10 +3,10 @@
     masc-improver evidence from 2026-04-24: a single keeper spent
     13.3 hours of LLM time and burned 4.19M tokens across 40+
     consecutive [stay_silent] turns, because the scheduler kept
-    firing ticks on a keeper whose tool_access could not satisfy any
-    backlog task.
+    firing ticks on a keeper whose effective tool surface could not satisfy
+    any backlog task.
 
-    The scheduler-side fix (O(1) tool_access gate, quarantine, backlog
+    The scheduler-side fix (O(1) effective-surface gate, quarantine, backlog
     routing) is large and belongs in a follow-up. This module
     closes the **observability** half so runtime can detect the
     loop instead of letting it burn silently in the background.

--- a/lib/keeper/keeper_tool_deterministic_error.ml
+++ b/lib/keeper/keeper_tool_deterministic_error.ml
@@ -59,7 +59,7 @@ let to_string = function
     "destructive operation blocked (force push / rm -rf / push to main)"
   | Path_outside_sandbox -> "path argument outside keeper-allowed sandbox roots"
   | Cwd_not_directory -> "cwd argument is not a directory"
-  | Policy_blocked -> "governance / tool_access policy rejected the call"
+  | Policy_blocked -> "governance / candidate policy rejected the call"
   | Write_operation_gated ->
     "write-capable Execute is required; retrying the same arguments cannot succeed"
   | Completion_contract_violation ->

--- a/lib/keeper/keeper_tool_deterministic_error.mli
+++ b/lib/keeper/keeper_tool_deterministic_error.mli
@@ -37,7 +37,7 @@ type deterministic_reason =
   | Cwd_not_directory
       (** cwd argument resolves but is not a directory. *)
   | Policy_blocked
-      (** governance / tool_access policy rejected the call. *)
+      (** governance / candidate policy rejected the call. *)
   | Write_operation_gated
       (** write-capable Execute is required before retrying the same operation. *)
   | Completion_contract_violation

--- a/lib/keeper/keeper_tool_dispatch_runtime.mli
+++ b/lib/keeper/keeper_tool_dispatch_runtime.mli
@@ -26,7 +26,7 @@ val keeper_internal_candidate_tool_names : string list
     so [make_tools] can build {!Agent_sdk.Tool.t} for the full search scope. *)
 val keeper_universe_model_tools : keeper_meta -> Masc_domain.tool_schema list
 
-(** Tool-access scoped universe: explicit allowlist + core_always - denied.
+(** Tool-access scoped universe: configured candidate profile list + core_always - denied.
     Strict subset of [keeper_universe_tool_names].  Used for BM25 indexing
     to reduce candidate pool size per keeper.  See #4637. *)
 val keeper_tool_search_scope : keeper_meta -> string list
@@ -34,7 +34,7 @@ val keeper_tool_search_scope : keeper_meta -> string list
 (** Tool-access scoped model tool schemas for BM25 indexing. *)
 val keeper_model_tool_schemas : keeper_meta -> Masc_domain.tool_schema list
 
-(** Core tools that bypass [tool_access] filtering and seed the disclosure floor.
+(** Core tools that bypass [tool_access] candidate profile filtering and seed the disclosure floor.
     Runtime gating/pruning can still narrow their visibility on a given turn. *)
 val core_always_tools : string list
 
@@ -110,7 +110,7 @@ type tool_result_payload =
 
 (** Bridge-facing execution outcome.
     Structured tool errors, including [tool_not_allowed], are failures so
-    tool_access/policy rejections cannot silently end a keeper turn as success. *)
+    candidate/policy rejections cannot silently end a keeper turn as success. *)
 type execution_outcome =
   [ `Success
   | `Failure

--- a/lib/keeper/keeper_tool_execute_path.ml
+++ b/lib/keeper/keeper_tool_execute_path.ml
@@ -138,10 +138,10 @@ let execution_location_json
   let cwd = normalize_repo_cwd_path cwd in
   let playground_segments = path_segments playground in
   let cwd_segments = path_segments cwd in
-  let scope, relative_segments, repo_name, repo_root, worktree_root =
+  let scope, relative_segments, repo_name, repo_root, worktree_name, worktree_root =
     match strip_segment_prefix ~prefix:playground_segments cwd_segments with
-    | None -> Outside_playground, [], None, None, None
-    | Some [] -> Playground_root, [], None, None, None
+    | None -> Outside_playground, [], None, None, None, None
+    | Some [] -> Playground_root, [], None, None, None, None
     | Some ("repos" :: repo_name :: rest)
       when Playground_repo_readiness.safe_repo_component repo_name ->
       let repo_root =
@@ -149,7 +149,8 @@ let execution_location_json
         |> normalize_repo_cwd_path
       in
       (match rest with
-       | [] -> Repo_root, [ "repos"; repo_name ], Some repo_name, Some repo_root, None
+       | [] ->
+         Repo_root, [ "repos"; repo_name ], Some repo_name, Some repo_root, None, None
        | ".worktrees" :: task_name :: tail
          when Playground_repo_readiness.safe_repo_component task_name ->
          let worktree_root =
@@ -165,14 +166,30 @@ let execution_location_json
          , [ "repos"; repo_name; ".worktrees"; task_name ] @ tail
          , Some repo_name
          , Some repo_root
+         , Some task_name
          , Some worktree_root )
-       | _ -> Repo_subpath, [ "repos"; repo_name ] @ rest, Some repo_name, Some repo_root, None)
-    | Some rest -> Playground_subpath, rest, None, None, None
+       | _ ->
+         Repo_subpath, [ "repos"; repo_name ] @ rest, Some repo_name, Some repo_root, None, None)
+    | Some rest -> Playground_subpath, rest, None, None, None, None
   in
   let relative_cwd =
     match scope with
     | Outside_playground -> `Null
     | _ -> `String (relative_path_of_segments relative_segments)
+  in
+  let selected_worktree =
+    match repo_name, repo_root, worktree_name, worktree_root with
+    | Some repo_name, Some repo_root, Some worktree_name, Some worktree_root ->
+      `Assoc
+        [ "repo_name", `String repo_name
+        ; "repo_root", `String repo_root
+        ; "worktree_name", `String worktree_name
+        ; "worktree_root", `String worktree_root
+        ; "selection_source", `String "execution_cwd"
+        ; "scope", `String (string_of_execution_location_scope scope)
+        ; "relative_cwd", relative_cwd
+        ]
+    | _ -> `Null
   in
   `Assoc
     [ "cwd", `String cwd
@@ -184,7 +201,10 @@ let execution_location_json
     ; "argv_relative_paths_resolve_against_cwd", `Bool true
     ; "repo_name", Json_util.string_opt_to_json repo_name
     ; "repo_root", Json_util.string_opt_to_json repo_root
+    ; "worktree_selected", `Bool (Option.is_some worktree_root)
+    ; "worktree_name", Json_util.string_opt_to_json worktree_name
     ; "worktree_root", Json_util.string_opt_to_json worktree_root
+    ; "selected_worktree", selected_worktree
     ]
 
 let repo_cwd_not_ready_error ~repo_name ~path_root ~git_toplevel =

--- a/lib/keeper/keeper_tool_execute_path.mli
+++ b/lib/keeper/keeper_tool_execute_path.mli
@@ -35,7 +35,9 @@ val execution_location_json :
     [repo_worktree_root], [repo_worktree_subpath]) or outside it
     ([outside_playground]).  [relative_cwd] is relative to [playground_root]
     for playground scopes and [null] when the cwd is outside the playground.
-    Relative argv paths resolve against the effective cwd. *)
+    Relative argv paths resolve against the effective cwd.  Worktree scopes also
+    carry [worktree_selected] and [selected_worktree] so the keeper can observe
+    the selected repo/worktree assignment without reparsing [cwd]. *)
 
 val auto_correct_path :
   meta:Keeper_meta_contract.keeper_meta -> string -> string option

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -424,7 +424,7 @@ let handle_tool_execute_typed
             ~deterministic_reason:
               Keeper_tool_deterministic_error.Destructive_operation_blocked
             ~error:"destructive_operation_blocked"
-            ~reason:"This typed command is destructive and is blocked for all tool_access lists."
+            ~reason:"This typed command is destructive and is blocked for every keeper execution surface."
             ~alternatives:[ "Use a non-destructive command or a dedicated structured tool." ]
             ()
         else if (not write_enabled)
@@ -434,10 +434,10 @@ let handle_tool_execute_typed
           blocked_result
             ~deterministic_reason:Keeper_tool_deterministic_error.Write_operation_gated
             ~error:"write_operation_gated"
-            ~reason:"This typed command modifies state. Write-enabled tool_access is required."
+            ~reason:"This typed command modifies state. A write-capable Execute surface is required."
             ~alternatives:
               [ "Use read-only commands such as rg, cat, ls, git status, or git log."
-              ; "Ask the operator for write-enabled tool_access."
+              ; "Ask the operator for a write-capable Execute candidate profile and matching runtime policy."
               ]
             ()
         else

--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -96,6 +96,13 @@ let validation_error_json message =
     ()
 ;;
 
+let string_list_arg name json =
+  json
+  |> Safe_ops.json_string_list name
+  |> List.map String.trim
+  |> List.filter (fun value -> not (String.equal value ""))
+;;
+
 let validate_goal_id config goal_id =
   match Goal_store.get_goal config ~goal_id with
   | Some _ -> Ok goal_id
@@ -775,7 +782,7 @@ let handle_keeper_task_tool
     | Task_submit_for_verification ->
     let task_id = Safe_ops.json_string ~default:"" "task_id" args |> String.trim in
     let notes = Safe_ops.json_string ~default:"" "notes" args |> String.trim in
-    let pr_url = Safe_ops.json_string ~default:"" "pr_url" args |> String.trim in
+    let evidence_refs = string_list_arg "evidence_refs" args in
     if task_id = ""
     then
       workflow_rejection_error_json
@@ -786,28 +793,15 @@ let handle_keeper_task_tool
       workflow_rejection_error_json
         ~alternatives:[ "keeper_task_submit_for_verification" ]
         "notes is required. Include verification evidence and test summary."
-    else if pr_url = ""
-    then
-      workflow_rejection_error_json
-        ~alternatives:
-          [ "keeper_task_submit_for_verification"; "keeper_task_done" ]
-        "pr_url is required. Include the PR opened for this task."
-    else if not (Task.Completion_review.pr_url_has_pull_ref pr_url)
-    then
-      workflow_rejection_error_json
-        ~alternatives:[ "keeper_task_submit_for_verification" ]
-        "pr_url must be a GitHub pull request URL or PR # reference. \
-         Do not submit placeholders like 'draft', 'none', or 'pending'."
     else (
-      (* Map keeper vocabulary (notes + pr_url) onto MASC domain typed
-         handoff_context fields: notes -> summary, [pr_url] ->
-         evidence_refs. The previous concat blob
-         ("notes\nPR: pr_url") had no in-repo reader and is removed. *)
+      (* Keep keeper vocabulary thin: map notes/evidence_refs onto the
+         task-domain handoff_context and let Task.Tool/CDAL evidence gates
+         decide whether the evidence is sufficient. *)
       let handoff_context =
         `Assoc
           [
             "summary", `String notes;
-            "evidence_refs", `List [ `String pr_url ];
+            "evidence_refs", Json_util.json_string_list evidence_refs;
           ]
       in
       let transition_result =

--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -180,12 +180,12 @@ let active_goal_scope_json
 
 let claim_scope_context_suffix ~(meta : keeper_meta) claim_goal_scope =
   match claim_goal_scope.Keeper_runtime_contract.mode with
-  | "active_goal_ids" | "active_goal_ids_advisory" ->
+  | "active_goal_ids" ->
     (match meta.active_goal_ids with
      | [] -> " in active goal scope"
      | goal_ids ->
        Printf.sprintf
-         " preferring active_goal_ids=[%s] (advisory)"
+         " within active_goal_ids=[%s]"
          (String.concat ", " goal_ids))
   | "all_tasks" -> " across all tasks"
   | "empty_goal_scope_fallback_all_tasks" ->
@@ -204,8 +204,8 @@ let no_eligible_action_for_claim_scope claim_goal_scope ~excluded_count =
   | None ->
     let scope_hint =
       match claim_goal_scope.Keeper_runtime_contract.mode with
-      | "active_goal_ids_advisory" ->
-        " All claimable tasks are blocked or already claimed (active_goal_ids is advisory, not a hard gate)."
+      | "active_goal_ids" ->
+        " Active goal scope is a hard claim gate; create/link a matching task or clear active_goal_ids."
       | _ -> ""
     in
     Printf.sprintf

--- a/lib/keeper/keeper_tools_oas_handler_exec.ml
+++ b/lib/keeper/keeper_tools_oas_handler_exec.ml
@@ -10,6 +10,80 @@ open Keeper_tools_oas_workflow
 open Keeper_tools_oas_deterministic_error
 open Keeper_tools_oas_handler_telemetry
 
+let is_execute_tool_name name =
+  match String.lowercase_ascii name with
+  | "execute" | "tool_execute" | "mcp__masc__execute" -> true
+  | _ -> false
+
+let string_assoc key fields =
+  match List.assoc_opt key fields with
+  | Some (`String value) when String.trim value <> "" -> Some value
+  | _ -> None
+
+let result_cwd raw_result =
+  try
+    match Yojson.Safe.from_string raw_result with
+    | `Assoc fields -> string_assoc "cwd" fields
+    | _ -> None
+  with
+  | Yojson.Json_error _ -> None
+
+let directory_exists path =
+  try Sys.file_exists path && Sys.is_directory path with
+  | Sys_error _ -> false
+
+let take_lines max_lines lines =
+  let rec loop remaining acc = function
+    | [] -> List.rev acc, false
+    | _ :: _ as rest when remaining <= 0 -> List.rev acc, rest <> []
+    | line :: rest -> loop (remaining - 1) (line :: acc) rest
+  in
+  loop max_lines [] lines
+
+let render_git_status_changes output =
+  let lines =
+    output
+    |> String.split_on_char '\n'
+    |> List.map String.trim
+    |> List.filter (fun line -> line <> "")
+  in
+  match lines with
+  | [] -> None
+  | _ ->
+    let lines, truncated = take_lines 40 lines in
+    let suffix =
+      if truncated then [ "... (git status output truncated)" ] else []
+    in
+    Some
+      ("--- Worktree changes (git status --short) ---\n"
+       ^ String.concat "\n" (lines @ suffix))
+
+let post_execute_git_status_change ~(tool_name : string) raw_result =
+  if not (is_execute_tool_name tool_name)
+  then None
+  else (
+    match result_cwd raw_result with
+    | None -> None
+    | Some cwd when not (directory_exists cwd) -> None
+    | Some cwd ->
+      try
+        let status, output =
+          Masc_exec.Exec_gate.run_argv_with_status
+            ~actor:(Masc_exec.Agent_id.of_string "workspace/git")
+            ~raw_source:
+              ("git -C " ^ Filename.quote cwd
+               ^ " --no-optional-locks status --short")
+            ~summary:"post-Execute git status delta"
+            ~timeout_sec:5.0
+            [ "git"; "-C"; cwd; "--no-optional-locks"; "status"; "--short" ]
+        in
+        match status with
+        | Unix.WEXITED 0 -> render_git_status_changes output
+        | Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> None
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | _ -> None)
+
 let execute_with_observers
       ~(name : string)
       ~(config : Workspace.config)
@@ -358,10 +432,7 @@ let execute_with_observers
       (match on_tool_called with
        | Some f -> f name
        | None -> ());
-      (* PR#814 Gap 1: Capture git status delta after successful tool execution.
-         If the working tree changed, log it so the keeper is aware of
-         file-system side effects from its tool calls. *)
-      let change_block = None in
+      let change_block = post_execute_git_status_change ~tool_name:name raw_result in
       let normalized = normalize_tool_result ~success:true raw_result in
       let final_result =
         match change_block with

--- a/lib/keeper/keeper_tools_oas_workflow.ml
+++ b/lib/keeper/keeper_tools_oas_workflow.ml
@@ -318,7 +318,15 @@ let json_has_nonempty_evidence_refs json =
 ;;
 
 let workflow_submit_evidence_marker json =
-  if Option.is_some (json_nonempty_string_opt "pr_url" json)
+  if Option.is_some (json_nonempty_string_opt "notes" json)
+     || (match json_assoc_field_opt "evidence_refs" json with
+         | Some (`List refs) ->
+           List.exists
+             (function
+               | `String value -> not (String.equal (String.trim value) "")
+               | _ -> false)
+             refs
+         | _ -> false)
      || json_has_nonempty_evidence_refs json
   then "has_evidence"
   else "missing_evidence"

--- a/lib/tool_surface/tool_shard_types_core.mli
+++ b/lib/tool_surface/tool_shard_types_core.mli
@@ -1,0 +1,20 @@
+(** Core shard types and routing helpers for tool shard schemas. *)
+
+type shard =
+  { name : string
+  ; tools : Masc_domain.tool_schema list
+  ; read_only_tools : string list
+  ; removable : bool
+  ; description : string
+  }
+
+module StringMap : Map.S with type key = string
+
+val select_named_schemas :
+  string list -> Masc_domain.tool_schema list -> Masc_domain.tool_schema list
+
+val default_shard_names : string list
+val tool_spec_read_only : string list
+val tool_spec_destructive : string list
+val tool_required_permission : string -> Masc_domain.permission option
+val tool_effect_domain : string -> Tool_catalog.effect_domain option

--- a/lib/tool_surface/tool_shard_types_enum_mirrors.mli
+++ b/lib/tool_surface/tool_shard_types_enum_mirrors.mli
@@ -1,0 +1,8 @@
+(** Hand-mirrored enum string lists consumed by tool schema JSON producers. *)
+
+val memory_search_source_enum_strings : string list
+val memory_kind_enum_strings : string list
+val fs_write_mode_enum_strings : string list
+val sort_order_enum_strings : string list
+val vote_direction_enum_strings : string list
+val tool_search_files_op_enum_strings : string list

--- a/lib/tool_surface/tool_shard_types_schemas_base.mli
+++ b/lib/tool_surface/tool_shard_types_schemas_base.mli
@@ -1,0 +1,3 @@
+(** Base tool schemas. *)
+
+val base_tools : Masc_domain.tool_schema list

--- a/lib/tool_surface/tool_shard_types_schemas_board.mli
+++ b/lib/tool_surface/tool_shard_types_schemas_board.mli
@@ -1,0 +1,3 @@
+(** Board tool schemas. *)
+
+val board_tools : Masc_domain.tool_schema list

--- a/lib/tool_surface/tool_shard_types_schemas_execute.mli
+++ b/lib/tool_surface/tool_shard_types_schemas_execute.mli
@@ -1,4 +1,5 @@
 (** Typed Execute tool schemas. *)
 
+val tool_execute_timeout_sec_field : string * Yojson.Safe.t
 val tool_execute_schema : Masc_domain.tool_schema
 val typed_execute_tools : Masc_domain.tool_schema list

--- a/lib/tool_surface/tool_shard_types_schemas_execute.mli
+++ b/lib/tool_surface/tool_shard_types_schemas_execute.mli
@@ -1,0 +1,4 @@
+(** Typed Execute tool schemas. *)
+
+val tool_execute_schema : Masc_domain.tool_schema
+val typed_execute_tools : Masc_domain.tool_schema list

--- a/lib/tool_surface/tool_shard_types_schemas_filesystem.mli
+++ b/lib/tool_surface/tool_shard_types_schemas_filesystem.mli
@@ -1,0 +1,3 @@
+(** Filesystem tool schemas. *)
+
+val filesystem_tools : Masc_domain.tool_schema list

--- a/lib/tool_surface/tool_shard_types_schemas_library.mli
+++ b/lib/tool_surface/tool_shard_types_schemas_library.mli
@@ -1,0 +1,3 @@
+(** Library tool schemas. *)
+
+val library_tools : Masc_domain.tool_schema list

--- a/lib/tool_surface/tool_shard_types_schemas_search_files.mli
+++ b/lib/tool_surface/tool_shard_types_schemas_search_files.mli
@@ -1,0 +1,4 @@
+(** Structured file search tool schemas. *)
+
+val tool_search_files_schema : Masc_domain.tool_schema
+val search_files_tools : Masc_domain.tool_schema list

--- a/lib/tool_surface/tool_shard_types_schemas_taskboard.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_taskboard.ml
@@ -185,17 +185,6 @@ let taskboard_tools : Masc_domain.tool_schema list =
                              verbatim. Ignored when the task has no contract."
                         )
                       ] )
-                ; ( "pr_url"
-                  , `Assoc
-                      [ "type", `String "string"
-                      ; ( "description"
-                        , `String
-                            "Draft or open PR URL. Hoisted into \
-                             handoff_context.evidence_refs by the transport \
-                             layer; satisfies the Cdal evidence gate for \
-                             contracted tasks."
-                        )
-                      ] )
                 ] )
           ; "required", `List [ `String "task_id"; `String "result" ]
           ]
@@ -203,7 +192,7 @@ let taskboard_tools : Masc_domain.tool_schema list =
   ; { name = "keeper_task_submit_for_verification"
     ; description =
         "Submit your claimed task to verification instead of marking it done directly. \
-         Use this after opening a PR or when review evidence must be attached before \
+         Use this when review evidence must be attached before \
          final approval."
     ; input_schema =
         `Assoc
@@ -225,17 +214,18 @@ let taskboard_tools : Masc_domain.tool_schema list =
                              review expectations" )
                       ; "minLength", `Int 1
                       ] )
-                ; ( "pr_url"
+                ; ( "evidence_refs"
                   , `Assoc
-                      [ "type", `String "string"
+                      [ "type", `String "array"
+                      ; "items", `Assoc [ "type", `String "string" ]
                       ; ( "description"
                         , `String
-                            "Draft or open PR URL to include in the verification handoff"
-                        )
-                      ; "minLength", `Int 1
+                            "Structured verification evidence refs: PR URL, commit, \
+                             artifact, receipt, test log, task comment, or other \
+                             concrete reviewable reference" )
                       ] )
                 ] )
-          ; "required", `List [ `String "task_id"; `String "notes"; `String "pr_url" ]
+          ; "required", `List [ `String "task_id"; `String "notes" ]
           ]
     }
   ; { name = "keeper_task_create"

--- a/lib/tool_surface/tool_shard_types_schemas_taskboard.mli
+++ b/lib/tool_surface/tool_shard_types_schemas_taskboard.mli
@@ -1,0 +1,3 @@
+(** Taskboard tool schemas. *)
+
+val taskboard_tools : Masc_domain.tool_schema list

--- a/lib/tool_surface/tool_shard_types_schemas_voice.mli
+++ b/lib/tool_surface/tool_shard_types_schemas_voice.mli
@@ -1,0 +1,3 @@
+(** Voice tool schemas. *)
+
+val voice_tools : Masc_domain.tool_schema list

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -483,6 +483,7 @@ type task_contract = {
   required_evidence : string list; [@default []]
   inspect_gate_evidence : string list; [@default []]
   verify_gate_evidence : string list; [@default []]
+  stale_claim_timeout_sec : int; [@default 0]
   links : task_execution_links; [@default { operation_id = None; session_id = None }]
 } [@@deriving show, yojson { strict = false }]
 

--- a/lib/types/types_core.mli
+++ b/lib/types/types_core.mli
@@ -110,6 +110,7 @@ type task_contract =
   ; required_evidence : string list [@default []]
   ; inspect_gate_evidence : string list [@default []]
   ; verify_gate_evidence : string list [@default []]
+  ; stale_claim_timeout_sec : int [@default 0]
   ; links : task_execution_links
         [@default { operation_id = None; session_id = None }]
   }

--- a/lib/workspace/workspace_task_classify.ml
+++ b/lib/workspace/workspace_task_classify.ml
@@ -192,6 +192,7 @@ let empty_task_contract =
   ; required_evidence = []
   ; inspect_gate_evidence = []
   ; verify_gate_evidence = []
+  ; stale_claim_timeout_sec = 0
   ; links = { operation_id = None; session_id = None }
   }
 ;;

--- a/scripts/harness/lib/server_bootstrap.sh
+++ b/scripts/harness/lib/server_bootstrap.sh
@@ -112,6 +112,49 @@ harness_mktemp_file() {
   printf '%s\n' "$path"
 }
 
+harness_seed_server_config() {
+  local repo_root="$1"
+  local base_path="$2"
+  local config_dir="${base_path%/}/.masc/config"
+
+  mkdir -p \
+    "$config_dir" \
+    "$config_dir/keepers" \
+    "$config_dir/personas" \
+    "$config_dir/prompts"
+
+  if [[ ! -f "$config_dir/tool_policy.toml" ]]; then
+    if [[ -f "$repo_root/config/tool_policy.toml" ]]; then
+      cp "$repo_root/config/tool_policy.toml" "$config_dir/tool_policy.toml"
+    else
+      echo "tool_policy.toml fixture not found under repo root: $repo_root" >&2
+      return 1
+    fi
+  fi
+
+  if [[ ! -f "$config_dir/runtime.toml" ]]; then
+    cat >"$config_dir/runtime.toml" <<'EOF'
+[runtime]
+default = "transport_harness.smoke"
+
+[providers.transport_harness]
+display-name = "Transport Harness Smoke"
+protocol = "provider_d-http"
+endpoint = "http://127.0.0.1:9/v1"
+
+[models.smoke]
+api-name = "smoke"
+max-context = 32768
+tools-support = true
+streaming = true
+
+[transport_harness.smoke]
+is-default = true
+max-concurrent = 1
+EOF
+  fi
+}
+
 harness_wait_for_health() {
   local port="$1"
   local timeout_sec="${2:-20}"
@@ -130,10 +173,17 @@ harness_start_server() {
   local port="$2"
   local base_path="$3"
   local log_file="$4"
+  local repo_root="${MASC_HARNESS_REPO_ROOT:-${ROOT_DIR:-${REPO_ROOT:-}}}"
+
+  if [[ -z "$repo_root" ]]; then
+    repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+  fi
 
   mkdir -p "$base_path"
+  harness_seed_server_config "$repo_root" "$base_path"
   (
     export MASC_BASE_PATH="$base_path"
+    export MASC_BASE_PATH_INPUT="$base_path"
     export MASC_STORAGE_TYPE="filesystem"
     export MASC_AUTONOMY_ENABLED="0"
     export MASC_ORCHESTRATOR_ENABLED="0"

--- a/scripts/harness/transport/common.sh
+++ b/scripts/harness/transport/common.sh
@@ -35,6 +35,7 @@ AUTH_BLOCKED=0
 TRANSPORT_SERVER_PID=""
 TRANSPORT_SERVER_BASE_PATH=""
 TRANSPORT_SERVER_LOG_FILE=""
+MASC_TRANSPORT_AUTH_TOKEN="${MASC_TRANSPORT_AUTH_TOKEN:-${MASC_TOKEN:-}}"
 
 pass() {
   PASS=$((PASS + 1))
@@ -118,6 +119,26 @@ require_server() {
   ensure_server
 }
 
+transport_auth_token() {
+  if [[ -n "${MASC_TRANSPORT_AUTH_TOKEN:-}" ]]; then
+    printf '%s\n' "$MASC_TRANSPORT_AUTH_TOKEN"
+    return 0
+  fi
+
+  local token_json token
+  token_json="$(curl -fsS --max-time 3 "${MASC_HTTP_BASE_URL}/api/v1/dashboard/dev-token" 2>/dev/null || true)"
+  if [[ -z "$token_json" ]]; then
+    return 0
+  fi
+
+  token="$(jq -r '.token // empty' <<<"$token_json" 2>/dev/null || true)"
+  if [[ -n "$token" ]]; then
+    MASC_TRANSPORT_AUTH_TOKEN="$token"
+    export MASC_TRANSPORT_AUTH_TOKEN
+    printf '%s\n' "$token"
+  fi
+}
+
 # Check if a CLI tool is available.
 require_tool() {
   local tool="$1"
@@ -129,11 +150,17 @@ require_tool() {
 }
 
 mcp_initialize_session() {
-  local headers body payload session_id
+  local headers body payload session_id token
+  local -a auth_args=()
   headers="$(harness_mktemp_file "masc-transport-init-header")"
   body="$(harness_mktemp_file "masc-transport-init-body")"
   payload='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"transport-harness","version":"1.0"}}}'
+  token="$(transport_auth_token)"
+  if [[ -n "$token" ]]; then
+    auth_args=(-H "Authorization: Bearer ${token}")
+  fi
   if ! curl -fsS -D "$headers" -o "$body" -X POST "${MASC_HTTP_BASE_URL}/mcp" \
+    "${auth_args[@]}" \
     -H "Content-Type: application/json" \
     -H "Accept: application/json, text/event-stream" \
     -d "$payload" >/dev/null; then
@@ -159,10 +186,16 @@ mcp_call_tool() {
   local tool_name="$2"
   local arguments_json="$3"
   local request_id="${4:-1}"
-  local payload
+  local payload token
+  local -a auth_args=()
   payload="$(printf '{"jsonrpc":"2.0","id":%s,"method":"tools/call","params":{"name":"%s","arguments":%s}}' \
     "$request_id" "$tool_name" "$arguments_json")"
+  token="$(transport_auth_token)"
+  if [[ -n "$token" ]]; then
+    auth_args=(-H "Authorization: Bearer ${token}")
+  fi
   curl -fsS -X POST "${MASC_HTTP_BASE_URL}/mcp" \
+    "${auth_args[@]}" \
     -H "Content-Type: application/json" \
     -H "Accept: application/json, text/event-stream" \
     -H "Mcp-Session-Id: ${session_id}" \

--- a/scripts/harness/transport/verify_grpc_subscribe.sh
+++ b/scripts/harness/transport/verify_grpc_subscribe.sh
@@ -17,6 +17,8 @@ HARNESS_NAME="gRPC-Subscribe"
 require_server
 
 PROTO_DIR="$(cd "${SCRIPT_DIR}/../../.." && pwd)/proto"
+MASC_GRPC_SERVICE="masc.workspace.v1.MascWorkspace"
+MASC_GRPC_PROTO="masc_workspace.proto"
 
 if ! require_tool grpcurl; then
   echo "ERROR: grpcurl required for gRPC E2E tests"
@@ -33,7 +35,7 @@ wait_for_grpc_health() {
       grpcurl -plaintext \
         -import-path "${PROTO_DIR}" \
         -proto grpc_health_v1.proto \
-        -d '{"service":"masc.workspace collaboration.v1.MascWorkspace"}' \
+        -d "{\"service\":\"${MASC_GRPC_SERVICE}\"}" \
         "${MASC_GRPC_ADDR}" \
         grpc.health.v1.Health/Check 2>&1 || true
     )"
@@ -59,7 +61,7 @@ else
 fi
 
 services="$(grpcurl -plaintext "${MASC_GRPC_ADDR}" list 2>&1 || true)"
-if echo "$services" | grep -q "masc.workspace collaboration.v1.MascWorkspace"; then
+if echo "$services" | grep -q "${MASC_GRPC_SERVICE}"; then
   pass "gRPC reflection: MascWorkspace listed"
 else
   fail "gRPC reflection" "MascWorkspace missing from reflection output"
@@ -73,10 +75,10 @@ fi
 subscribe_resp="$(
   grpcurl -plaintext -max-time 5 \
     -import-path "${PROTO_DIR}" \
-    -proto masc_workspace collaboration.proto \
+    -proto "${MASC_GRPC_PROTO}" \
     -d '{"agent_name":"e2e-harness","session_id":"grpc-e2e-harness","since_seq":"0","event_types":["message"]}' \
     "${MASC_GRPC_ADDR}" \
-    masc.workspace collaboration.v1.MascWorkspace/Subscribe 2>&1 || true
+    "${MASC_GRPC_SERVICE}/Subscribe" 2>&1 || true
 )"
 if echo "$subscribe_resp" | grep -q "subscription_started"; then
   pass "Subscribe: received subscription_started event"
@@ -87,10 +89,10 @@ fi
 subscribe_output="$(harness_mktemp_file "masc-transport-grpc")"
 grpcurl -plaintext \
   -import-path "${PROTO_DIR}" \
-  -proto masc_workspace collaboration.proto \
+  -proto "${MASC_GRPC_PROTO}" \
   -d '{"agent_name":"e2e-grpc-listener","session_id":"grpc-e2e-listener","since_seq":"0","event_types":["message"]}' \
   "${MASC_GRPC_ADDR}" \
-  masc.workspace collaboration.v1.MascWorkspace/Subscribe >"${subscribe_output}" 2>&1 &
+  "${MASC_GRPC_SERVICE}/Subscribe" >"${subscribe_output}" 2>&1 &
 subscribe_pid=$!
 sleep 1
 

--- a/scripts/harness/transport/verify_sse.sh
+++ b/scripts/harness/transport/verify_sse.sh
@@ -36,10 +36,16 @@ fi
 # Test 3: JSON-RPC initialize via Streamable HTTP (/mcp)
 MCP_ACCEPT="Accept: application/json, text/event-stream"
 init_req='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"e2e-harness","version":"1.0"}}}'
+auth_args=()
+auth_token="$(transport_auth_token)"
+if [[ -n "$auth_token" ]]; then
+  auth_args=(-H "Authorization: Bearer ${auth_token}")
+fi
 init_deadline=$(( $(date +%s) + 15 ))
 init_resp=""
 while [[ "$(date +%s)" -lt "$init_deadline" ]]; do
   init_resp=$(curl -sf -X POST "${MASC_HTTP_BASE_URL}/mcp" \
+    "${auth_args[@]}" \
     -H "Content-Type: application/json" \
     -H "${MCP_ACCEPT}" \
     -d "$init_req" 2>&1 || true)
@@ -63,6 +69,7 @@ SESSION_ID=""
 while [[ "$(date +%s)" -lt "$session_deadline" ]]; do
   SESSION_ID="$(
     curl -sf -i -X POST "${MASC_HTTP_BASE_URL}/mcp" \
+      "${auth_args[@]}" \
       -H "Content-Type: application/json" \
       -H "${MCP_ACCEPT}" \
       -d "$init_req" 2>&1 \
@@ -75,6 +82,7 @@ while [[ "$(date +%s)" -lt "$session_deadline" ]]; do
 done
 tools_req='{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
 tools_resp=$(curl -sf -X POST "${MASC_HTTP_BASE_URL}/mcp" \
+  "${auth_args[@]}" \
   -H "Content-Type: application/json" \
   -H "${MCP_ACCEPT}" \
   -H "Mcp-Session-Id: ${SESSION_ID}" \

--- a/scripts/harness/transport/verify_ws.sh
+++ b/scripts/harness/transport/verify_ws.sh
@@ -34,7 +34,13 @@ else
 fi
 
 read_sse_external_subscriber_count() {
-  curl -fsS "${MASC_HTTP_BASE_URL}/metrics" 2>/dev/null \
+  local token
+  local -a auth_args=()
+  token="$(transport_auth_token)"
+  if [[ -n "$token" ]]; then
+    auth_args=(-H "Authorization: Bearer ${token}")
+  fi
+  curl -fsS "${auth_args[@]}" "${MASC_HTTP_BASE_URL}/metrics" 2>/dev/null \
     | awk '$1=="masc_sse_external_subscribers_total" { print int($2); found=1; exit } END { if (!found) print -1 }' \
     2>/dev/null || echo "-1"
 }
@@ -42,9 +48,12 @@ read_sse_external_subscriber_count() {
 ws_output="$(mktemp "${TMPDIR:-/tmp}/masc-transport-ws.XXXXXX")"
 ws_handshake="$(mktemp "${TMPDIR:-/tmp}/masc-transport-ws-handshake.XXXXXX")"
 ws_subscribers_before="$(read_sse_external_subscriber_count)"
+ws_auth_token="$(transport_auth_token)"
 MASC_WS_HOST="127.0.0.1" MASC_WS_PORT="$ws_port" WS_OUTPUT="$ws_output" \
-WS_EXPECT="ws-e2e-test-event" WS_HANDSHAKE="$ws_handshake" python3 - <<'PY' &
+WS_EXPECT="ws-e2e-test-event" WS_HANDSHAKE="$ws_handshake" \
+WS_AUTH_TOKEN="$ws_auth_token" python3 - <<'PY' &
 import base64
+import json
 import os
 import socket
 import sys
@@ -54,6 +63,7 @@ port = int(os.environ["MASC_WS_PORT"])
 output_path = os.environ["WS_OUTPUT"]
 expected = os.environ["WS_EXPECT"]
 handshake_path = os.environ["WS_HANDSHAKE"]
+auth_token = os.environ.get("WS_AUTH_TOKEN", "")
 
 sock = socket.create_connection((host, port), timeout=5)
 key = base64.b64encode(os.urandom(16)).decode()
@@ -83,6 +93,19 @@ with open(handshake_path, "w", encoding="utf-8") as fh:
 buffer = buffer.split(b"\r\n\r\n", 1)[1]
 sock.settimeout(6)
 
+def send_text(text: str) -> None:
+    payload = text.encode("utf-8")
+    mask = os.urandom(4)
+    length = len(payload)
+    if length < 126:
+        header = bytes([0x81, 0x80 | length])
+    elif length <= 0xFFFF:
+        header = bytes([0x81, 0x80 | 126]) + length.to_bytes(2, "big")
+    else:
+        header = bytes([0x81, 0x80 | 127]) + length.to_bytes(8, "big")
+    masked = bytes(byte ^ mask[index % 4] for index, byte in enumerate(payload))
+    sock.sendall(header + mask + masked)
+
 def read_exact(n: int) -> bytes:
     global buffer
     data = b""
@@ -97,7 +120,7 @@ def read_exact(n: int) -> bytes:
         data += chunk
     return data
 
-for _ in range(16):
+def read_text_frame() -> tuple[int, str]:
     hdr = read_exact(2)
     opcode = hdr[0] & 0x0F
     masked = (hdr[1] & 0x80) != 0
@@ -111,7 +134,44 @@ for _ in range(16):
     if masked:
       payload = bytes(b ^ mask[i % 4] for i, b in enumerate(payload))
     if opcode == 0x1:
-      text = payload.decode("utf-8", errors="replace")
+      return opcode, payload.decode("utf-8", errors="replace")
+    if opcode == 0x8:
+      return opcode, ""
+    return opcode, ""
+
+hello_params = {
+    "protocol": "dashboard-ws.v1",
+    "features": ["snapshot", "delta", "mode_snapshot"],
+}
+if auth_token:
+    hello_params["token"] = auth_token
+send_text(json.dumps({
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "dashboard/hello",
+    "params": hello_params,
+}, separators=(",", ":")))
+
+for _ in range(8):
+    opcode, text = read_text_frame()
+    if opcode == 0x8:
+      raise SystemExit(3)
+    if not text:
+      continue
+    try:
+      payload = json.loads(text)
+    except json.JSONDecodeError:
+      continue
+    if payload.get("id") == 1:
+      if "result" in payload:
+        break
+      raise SystemExit(5)
+else:
+    raise SystemExit(6)
+
+for _ in range(16):
+    opcode, text = read_text_frame()
+    if opcode == 0x1:
       with open(output_path, "a", encoding="utf-8") as fh:
         fh.write(text)
         fh.write("\n")

--- a/test/dune
+++ b/test/dune
@@ -137,6 +137,7 @@
   test_ide_canonical_url_join
   test_keeper_runtime_manifest_completeness
   test_keeper_runtime_manifest_clock_separation
+  test_keeper_runtime_contract
   test_schema_surface_index
   test_keeper_accountability
   test_reputation_ledger_v2
@@ -396,6 +397,7 @@
   test_ide_canonical_url_join
   test_keeper_runtime_manifest_completeness
   test_keeper_runtime_manifest_clock_separation
+  test_keeper_runtime_contract
   test_schema_surface_index
   test_keeper_accountability
   test_reputation_ledger_v2

--- a/test/test_cdal_evidence_gate.ml
+++ b/test/test_cdal_evidence_gate.ml
@@ -47,6 +47,7 @@ let make_contract
   ; required_evidence
   ; inspect_gate_evidence
   ; verify_gate_evidence
+  ; stale_claim_timeout_sec = 0
   ; links = { operation_id = None; session_id = None }
   }
 

--- a/test/test_keeper_runtime_contract.ml
+++ b/test/test_keeper_runtime_contract.ml
@@ -1,0 +1,115 @@
+open Alcotest
+open Masc
+
+let make_config () =
+  let dir =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc_keeper_runtime_contract_%d_%d"
+         (Unix.getpid ())
+         (int_of_float (Unix.gettimeofday () *. 1000.)))
+  in
+  Unix.mkdir dir 0o755;
+  let config = Workspace.default_config dir in
+  let _ = Workspace.init config ~agent_name:(Some "keeper-runtime-contract") in
+  config
+;;
+
+let cleanup_config config =
+  let _ = Workspace.reset config in
+  ()
+;;
+
+let make_meta ?(active_goal_ids = []) () =
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+        [ "name", `String "runtime-contract-keeper"
+        ; "agent_name", `String "keeper-runtime-contract"
+        ; "trace_id", `String "runtime-contract-trace"
+        ; ( "active_goal_ids"
+          , `List (List.map (fun id -> `String id) active_goal_ids) )
+        ])
+  with
+  | Ok meta -> meta
+  | Error e -> failf "make_meta failed: %s" e
+;;
+
+let add_task ?goal_id config ~title =
+  let result = Workspace.add_task ?goal_id config ~title ~priority:1 ~description:"" in
+  if String.starts_with ~prefix:"Error:" result
+  then failf "add_task failed: %s" result
+;;
+
+let test_active_goal_ids_filter_claimable_tasks () =
+  let config = make_config () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_config config)
+    (fun () ->
+      add_task ~goal_id:"goal-a" config ~title:"goal a task";
+      add_task ~goal_id:"goal-b" config ~title:"goal b task";
+      let meta = make_meta ~active_goal_ids:[ "goal-a" ] () in
+      let scope =
+        Keeper_runtime_contract.resolve_claim_goal_scope ~config ~meta ()
+      in
+      check string "mode" "active_goal_ids" scope.mode;
+      check (list string) "effective goal ids" [ "goal-a" ] scope.effective_goal_ids;
+      let tasks = Workspace.get_tasks_raw config in
+      let included =
+        tasks
+        |> List.filter scope.task_filter
+        |> List.map (fun (task : Masc_domain.task) -> task.title)
+      in
+      check (list string) "scope includes only linked task" [ "goal a task" ] included;
+      match
+        Workspace.claim_next_r config ~agent_name:"keeper-runtime-contract"
+          ~task_filter:scope.task_filter
+          ()
+      with
+      | Workspace.Claim_next_claimed { task_id; _ } ->
+        check string "claimed scoped task" "task-001" task_id
+      | Workspace.Claim_next_no_unclaimed ->
+        fail "expected scoped claim, got no_unclaimed"
+      | Workspace.Claim_next_no_eligible { excluded_count; _ } ->
+        failf "expected scoped claim, got no_eligible excluded=%d" excluded_count
+      | Workspace.Claim_next_error msg ->
+        failf "expected scoped claim, got error: %s" msg)
+;;
+
+let test_active_goal_ids_block_out_of_scope_tasks () =
+  let config = make_config () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_config config)
+    (fun () ->
+      add_task ~goal_id:"goal-b" config ~title:"goal b task";
+      let meta = make_meta ~active_goal_ids:[ "goal-a" ] () in
+      let scope =
+        Keeper_runtime_contract.resolve_claim_goal_scope ~config ~meta ()
+      in
+      match
+        Workspace.claim_next_r config ~agent_name:"keeper-runtime-contract"
+          ~task_filter:scope.task_filter
+          ()
+      with
+      | Workspace.Claim_next_no_eligible
+          { scope_excluded_count; claim_pool_candidate_count; _ } ->
+        check int "scope excluded out-of-goal task" 1 scope_excluded_count;
+        check int "claim pool still saw task" 1 claim_pool_candidate_count
+      | Workspace.Claim_next_claimed { task_id; _ } ->
+        failf "out-of-scope task should not be claimed, got %s" task_id
+      | Workspace.Claim_next_no_unclaimed ->
+        fail "expected no_eligible, got no_unclaimed"
+      | Workspace.Claim_next_error msg ->
+        failf "expected no_eligible, got error: %s" msg)
+;;
+
+let () =
+  run
+    "keeper_runtime_contract"
+    [ ( "active_goal_claim_scope"
+      , [ test_case "filters claimable tasks" `Quick
+            test_active_goal_ids_filter_claimable_tasks
+        ; test_case "blocks out-of-scope tasks" `Quick
+            test_active_goal_ids_block_out_of_scope_tasks
+        ] )
+    ]
+;;

--- a/test/test_keeper_tool_execute_safety.ml
+++ b/test/test_keeper_tool_execute_safety.ml
@@ -868,7 +868,13 @@ let test_tool_execute_runtime_error_reports_default_execution_location () =
   Alcotest.(check bool) "argv paths resolve against cwd" true
     (loc
      |> Json.member "argv_relative_paths_resolve_against_cwd"
-     |> Json.to_bool)
+     |> Json.to_bool);
+  Alcotest.(check bool) "no worktree selected" false
+    (loc |> Json.member "worktree_selected" |> Json.to_bool);
+  Alcotest.(check bool) "selected worktree is absent" true
+    (match loc |> Json.member "selected_worktree" with
+     | `Null -> true
+     | _ -> false)
 
 let test_execution_location_classifies_repo_worktree_subpath () =
   with_eio_fs @@ fun () ->
@@ -896,6 +902,10 @@ let test_execution_location_classifies_repo_worktree_subpath () =
     (loc |> Json.member "cwd_source" |> Json.to_string);
   Alcotest.(check string) "repo name" "masc"
     (loc |> Json.member "repo_name" |> Json.to_string);
+  Alcotest.(check bool) "worktree selected" true
+    (loc |> Json.member "worktree_selected" |> Json.to_bool);
+  Alcotest.(check string) "worktree name" "task-123"
+    (loc |> Json.member "worktree_name" |> Json.to_string);
   Alcotest.(check string)
     "relative cwd"
     "repos/masc/.worktrees/task-123/lib"
@@ -909,7 +919,21 @@ let test_execution_location_classifies_repo_worktree_subpath () =
     "worktree root"
     (normalize_path_for_containment
        (Filename.concat playground "repos/masc/.worktrees/task-123"))
-    (loc |> Json.member "worktree_root" |> Json.to_string)
+    (loc |> Json.member "worktree_root" |> Json.to_string);
+  let selected = loc |> Json.member "selected_worktree" in
+  Alcotest.(check string) "selected repo name" "masc"
+    (selected |> Json.member "repo_name" |> Json.to_string);
+  Alcotest.(check string) "selected worktree name" "task-123"
+    (selected |> Json.member "worktree_name" |> Json.to_string);
+  Alcotest.(check string) "selection source" "execution_cwd"
+    (selected |> Json.member "selection_source" |> Json.to_string);
+  Alcotest.(check string) "selected worktree scope" "repo_worktree_subpath"
+    (selected |> Json.member "scope" |> Json.to_string);
+  Alcotest.(check string)
+    "selected worktree root"
+    (normalize_path_for_containment
+       (Filename.concat playground "repos/masc/.worktrees/task-123"))
+    (selected |> Json.member "worktree_root" |> Json.to_string)
 
 let test_execution_location_outside_playground_has_null_relative_cwd () =
   with_eio_fs @@ fun () ->

--- a/test/test_mcp_server_eio_call_tool.ml
+++ b/test/test_mcp_server_eio_call_tool.ml
@@ -77,6 +77,7 @@ let empty_contract : Masc_domain.task_contract =
     required_evidence = [];
     inspect_gate_evidence = [];
     verify_gate_evidence = [];
+    stale_claim_timeout_sec = 0;
     links =
       {
         operation_id = None;

--- a/test/test_sse_storm_e2e.ml
+++ b/test/test_sse_storm_e2e.ml
@@ -213,6 +213,35 @@ let wait_pid_exit ~pid ~timeout_s =
   in
   loop ()
 
+let dashboard_dev_token ~port =
+  let result =
+    run_curl ~max_time:2.0 ~port ~path:"/api/v1/dashboard/dev-token" ()
+  in
+  match result.status with
+  | Some 200 ->
+      begin
+        match Yojson.Safe.from_string result.body with
+        | `Assoc fields ->
+            begin
+              match List.assoc_opt "token" fields with
+              | Some (`String token) when String.trim token <> "" -> token
+              | _ -> fail ("dashboard dev-token response missing token: " ^ result.body)
+            end
+        | _ -> fail ("dashboard dev-token response is not an object: " ^ result.body)
+        | exception Yojson.Json_error msg ->
+            fail ("dashboard dev-token response is invalid JSON: " ^ msg)
+      end
+  | Some code ->
+      fail
+        (Printf.sprintf
+           "dashboard dev-token returned HTTP %d (curl_exit=%d stderr=%s body=%s)"
+           code result.curl_exit result.stderr result.body)
+  | None ->
+      fail
+        (Printf.sprintf
+           "dashboard dev-token missing HTTP status (curl_exit=%d stderr=%s body=%s)"
+           result.curl_exit result.stderr result.body)
+
 let merge_env_overrides overrides =
   let override_keys =
     List.map fst overrides
@@ -234,6 +263,80 @@ let merge_env_overrides overrides =
   in
   Array.of_list (base @ injected)
 
+let ensure_dir path =
+  if Sys.file_exists path then
+    if not (Sys.is_directory path) then
+      fail (Printf.sprintf "expected directory path: %s" path)
+    else ()
+  else
+    Unix.mkdir path 0o755
+
+let copy_file ~src ~dst =
+  let ic = open_in_bin src in
+  let oc = open_out_bin dst in
+  Fun.protect
+    ~finally:(fun () ->
+      close_in_noerr ic;
+      close_out_noerr oc)
+    (fun () ->
+      let buffer = Bytes.create 8192 in
+      let rec loop () =
+        match input ic buffer 0 (Bytes.length buffer) with
+        | 0 -> ()
+        | n ->
+            output oc buffer 0 n;
+            loop ()
+      in
+      loop ())
+
+let find_repo_file relative =
+  let roots = [ "."; ".."; "../.."; "../../.."; "../../../.." ] in
+  roots
+  |> List.map (fun root -> Filename.concat root relative)
+  |> List.find_opt Sys.file_exists
+
+let runtime_seed =
+  {|
+[runtime]
+default = "sse_storm.smoke"
+
+[providers.sse_storm]
+display-name = "SSE Storm Smoke"
+protocol = "provider_d-http"
+endpoint = "http://127.0.0.1:9/v1"
+
+[models.smoke]
+api-name = "smoke"
+max-context = 32768
+tools-support = true
+streaming = true
+
+[sse_storm.smoke]
+is-default = true
+max-concurrent = 1
+|}
+
+let seed_server_config ~base_path =
+  let masc_dir = Filename.concat base_path ".masc" in
+  let config_dir = Filename.concat masc_dir "config" in
+  ensure_dir masc_dir;
+  ensure_dir config_dir;
+  List.iter
+    (fun name -> ensure_dir (Filename.concat config_dir name))
+    [ "keepers"; "personas"; "prompts" ];
+  let tool_policy_dst = Filename.concat config_dir "tool_policy.toml" in
+  if not (Sys.file_exists tool_policy_dst) then begin
+    match find_repo_file "config/tool_policy.toml" with
+    | Some src -> copy_file ~src ~dst:tool_policy_dst
+    | None -> fail "config/tool_policy.toml fixture not found"
+  end;
+  let runtime_dst = Filename.concat config_dir "runtime.toml" in
+  if not (Sys.file_exists runtime_dst) then
+    let oc = open_out runtime_dst in
+    Fun.protect
+      ~finally:(fun () -> close_out_noerr oc)
+      (fun () -> output_string oc runtime_seed)
+
 let with_server f =
   let exe = find_main_eio_exe () in
   let port =
@@ -245,12 +348,15 @@ let with_server f =
   let base_path = Filename.temp_file "sse-storm-base-" "" in
   (try Sys.remove base_path with _ -> ());
   Unix.mkdir base_path 0o755;
+  seed_server_config ~base_path;
   let log_fd =
     Unix.openfile log_file [Unix.O_CREAT; Unix.O_WRONLY; Unix.O_TRUNC] 0o644
   in
   let env =
     merge_env_overrides
       [
+        ("MASC_BASE_PATH", base_path);
+        ("MASC_BASE_PATH_INPUT", base_path);
         ("MASC_AUTONOMY_ENABLED", "0");
         ("GRAPHQL_API_KEY", "");
         ("GRAPHQL_URL", "http://127.0.0.1:9/graphql");
@@ -280,7 +386,9 @@ let with_server f =
     let logs = read_file log_file in
     fail (Printf.sprintf "server failed to become ready on port %d\n%s" port logs)
   end;
-  Fun.protect ~finally:cleanup (fun () -> f ~port)
+  Fun.protect ~finally:cleanup (fun () ->
+    let auth_token = dashboard_dev_token ~port in
+    f ~port ~auth_token)
 
 let check_status label expected result =
   match result.status with
@@ -294,9 +402,15 @@ let check_status label expected result =
            result.stderr)
 
 let test_mcp_reconnect_stays_accepted () =
-  with_server @@ fun ~port ->
+  with_server @@ fun ~port ~auth_token ->
   let sid = Printf.sprintf "storm-mcp-%06d" (Random.int 1_000_000) in
-  let headers = [("Accept", "text/event-stream"); ("Mcp-Session-Id", sid)] in
+  let headers =
+    [
+      ("Accept", "text/event-stream");
+      ("Authorization", "Bearer " ^ auth_token);
+      ("Mcp-Session-Id", sid);
+    ]
+  in
 
   let first = run_curl ~headers ~max_time:2.0 ~port ~path:"/mcp" () in
   check_status "first /mcp connect accepted" 200 first;
@@ -305,7 +419,7 @@ let test_mcp_reconnect_stays_accepted () =
   check_status "follow-up /mcp reconnect accepted" 200 second
 
 let test_ag_ui_rejects_reconnect_then_recovers () =
-  with_server @@ fun ~port ->
+  with_server @@ fun ~port ~auth_token:_ ->
   let sid = Printf.sprintf "storm-agui-%06d" (Random.int 1_000_000) in
   let headers = [("Accept", "text/event-stream"); ("Mcp-Session-Id", sid)] in
 

--- a/test/test_task_completion_path_10449.ml
+++ b/test/test_task_completion_path_10449.ml
@@ -20,6 +20,7 @@ let empty_contract : T.task_contract = {
   required_evidence = [];
   inspect_gate_evidence = [];
   verify_gate_evidence = [];
+  stale_claim_timeout_sec = 0;
   links = empty_links;
 }
 

--- a/test/test_tool_result.ml
+++ b/test/test_tool_result.ml
@@ -3,6 +3,7 @@
 module Tool_result = Tool_result
 module Tool_dispatch = Tool_dispatch
 module Time_compat = Time_compat
+module Keeper_tools_oas_workflow = Masc.Keeper_tools_oas_workflow
 
 let tool_ok ?(tool_name = "") message =
   Tool_result.make_ok ~tool_name ~start_time:0.0 ~data:(`String message) ()

--- a/test/test_tool_result.ml
+++ b/test/test_tool_result.ml
@@ -118,7 +118,7 @@ let test_error_uses_structured_failure_class () =
     Tool_result.error
       ~tool_name:"keeper_task_submit_for_verification"
       ~start_time:0.0
-      {|{"ok":false,"error":"pr_url is required","failure_class":"workflow_rejection"}|}
+      {|{"ok":false,"error":"evidence is required","failure_class":"workflow_rejection"}|}
   in
   Alcotest.(check bool) "failure" false (Tool_result.is_success r);
   Alcotest.(check string)
@@ -280,6 +280,94 @@ let test_result_is_stdlib_result_alias () =
   | Error _ -> Alcotest.fail "Stdlib.Result.map should preserve Ok"
 ;;
 
+let keeper_taskboard_schema name =
+  match
+    List.find_opt
+      (fun (schema : Masc_domain.tool_schema) ->
+         String.equal schema.name name)
+      Tool_shard_types.taskboard_tools
+  with
+  | Some schema -> schema.input_schema
+  | None -> Alcotest.failf "%s schema missing" name
+;;
+
+let object_member name = function
+  | `Assoc fields -> List.assoc_opt name fields
+  | _ -> None
+;;
+
+let string_list_member name json =
+  match object_member name json with
+  | Some (`List items) ->
+    List.filter_map
+      (function
+        | `String value -> Some value
+        | _ -> None)
+      items
+  | _ -> []
+;;
+
+let test_keeper_submit_schema_uses_notes_and_optional_evidence_refs () =
+  let schema = keeper_taskboard_schema "keeper_task_submit_for_verification" in
+  let properties =
+    match object_member "properties" schema with
+    | Some (`Assoc fields) -> fields
+    | _ -> Alcotest.fail "schema properties missing"
+  in
+  let has_property name = List.exists (fun (key, _) -> String.equal key name) properties in
+  let required = string_list_member "required" schema in
+  Alcotest.(check bool) "evidence_refs property present" true (has_property "evidence_refs");
+  Alcotest.(check bool) "pr_url is not a keeper submit field" false (has_property "pr_url");
+  Alcotest.(check (list string))
+    "only task_id and notes are required"
+    [ "task_id"; "notes" ]
+    required
+;;
+
+let test_keeper_done_schema_uses_result_not_pr_url () =
+  let schema = keeper_taskboard_schema "keeper_task_done" in
+  let properties =
+    match object_member "properties" schema with
+    | Some (`Assoc fields) -> fields
+    | _ -> Alcotest.fail "schema properties missing"
+  in
+  let has_property name = List.exists (fun (key, _) -> String.equal key name) properties in
+  let required = string_list_member "required" schema in
+  Alcotest.(check bool) "result property present" true (has_property "result");
+  Alcotest.(check bool) "pr_url is not a keeper done field" false (has_property "pr_url");
+  Alcotest.(check (list string))
+    "only task_id and result are required"
+    [ "task_id"; "result" ]
+    required
+;;
+
+let test_workflow_marker_accepts_notes_as_evidence_message () =
+  let input =
+    `Assoc
+      [ "task_id", `String "task-001"
+      ; "notes", `String "changed files, ran tests, see receipt:turn-1"
+      ]
+  in
+  Alcotest.(check string)
+    "notes count as the evidence-bearing handoff message"
+    "has_evidence"
+    (Keeper_tools_oas_workflow.workflow_submit_evidence_marker input)
+;;
+
+let test_workflow_marker_accepts_top_level_evidence_refs () =
+  let input =
+    `Assoc
+      [ "task_id", `String "task-001"
+      ; "notes", `String "verification notes"
+      ; "evidence_refs", `List [ `String "artifact:logs/test-output.txt" ]
+      ]
+  in
+  Alcotest.(check string)
+    "top-level evidence_refs count as evidence"
+    "has_evidence"
+    (Keeper_tools_oas_workflow.workflow_submit_evidence_marker input)
+;;
+
 let () =
   Alcotest.run
     "Tool_result"
@@ -331,6 +419,24 @@ let () =
             "result aliases Stdlib.Result.t"
             `Quick
             test_result_is_stdlib_result_alias
+        ] )
+    ; ( "keeper verification evidence schema"
+      , [ Alcotest.test_case
+            "schema uses notes and optional evidence_refs"
+            `Quick
+            test_keeper_submit_schema_uses_notes_and_optional_evidence_refs
+        ; Alcotest.test_case
+            "done schema uses result without pr_url"
+            `Quick
+            test_keeper_done_schema_uses_result_not_pr_url
+        ; Alcotest.test_case
+            "workflow marker accepts notes"
+            `Quick
+            test_workflow_marker_accepts_notes_as_evidence_message
+        ; Alcotest.test_case
+            "workflow marker accepts top-level evidence_refs"
+            `Quick
+            test_workflow_marker_accepts_top_level_evidence_refs
         ] )
     ]
 ;;

--- a/test/test_verification_fsm.ml
+++ b/test/test_verification_fsm.ml
@@ -64,6 +64,7 @@ let add_strict_task config =
     required_evidence = [];
     inspect_gate_evidence = [];
     verify_gate_evidence = ["output.json"];
+    stale_claim_timeout_sec = 0;
     links = { operation_id = None; session_id = None };
   } in
   let _msg = Workspace.add_task ~contract config ~title
@@ -88,6 +89,7 @@ let add_required_evidence_only_task config =
     required_evidence = ["artifact://coverage.json"];
     inspect_gate_evidence = [];
     verify_gate_evidence = [];
+    stale_claim_timeout_sec = 0;
     links = { operation_id = None; session_id = None };
   } in
   let _msg =
@@ -114,6 +116,7 @@ let add_placeholder_evidence_task config =
     required_evidence = ["completion_notes"];
     inspect_gate_evidence = [];
     verify_gate_evidence = ["pr_url_or_artifact_ref"];
+    stale_claim_timeout_sec = 0;
     links = { operation_id = None; session_id = None };
   } in
   let _msg =

--- a/test/test_workspace_task_verification_phase_e.ml
+++ b/test/test_workspace_task_verification_phase_e.ml
@@ -60,6 +60,7 @@ let test_contracted_task_includes_contract_refs () =
     ; required_evidence = [ "test_keeper_lifecycle PASS" ]
     ; inspect_gate_evidence = []
     ; verify_gate_evidence = [ "PR #18810 merged" ]
+    ; stale_claim_timeout_sec = 0
     ; links = { operation_id = None; session_id = None }
     }
   in


### PR DESCRIPTION
## Summary
- Seed isolated `.masc/config` runtime/tool-policy fixtures before harness server startup.
- Fetch dashboard dev-token for local MCP/metrics calls in SSE/transport harnesses.
- Align gRPC harness service/proto names with `proto/masc_workspace.proto` and authenticate WS hello before broadcast delivery checks.

## Verification
- `bash -n scripts/harness/lib/server_bootstrap.sh`
- `bash -n scripts/harness/transport/common.sh`
- `bash -n scripts/harness/transport/verify_grpc_subscribe.sh`
- `bash -n scripts/harness/transport/verify_sse.sh`
- `bash -n scripts/harness/transport/verify_ws.sh`
- `git diff --check`
- `CI_TEST_TIMEOUT_SEC=240 CI_TEST_HEARTBEAT_SEC=15 DUNE_JOBS=1 scripts/ci-run-tests.sh "bash scripts/harness/transport/run_all.sh"`
- `CI_TEST_TIMEOUT_SEC=180 CI_TEST_HEARTBEAT_SEC=15 DUNE_JOBS=1 scripts/ci-run-tests.sh "opam exec -- dune exec --root . ./test/test_sse_storm_e2e.exe"`