### PR TITLE
chore: purge required-tool wording from transition schema

### DIFF
--- a/lib/task/tool_task_schemas.ml
+++ b/lib/task/tool_task_schemas.ml
@@ -223,9 +223,8 @@ submit_for_verification, approve, reject, or submit_pr_evidence. \
 Call when you pick up, finish, or abandon a task. Supports CAS via expected_version. \
 After %s or %s; pair with masc_deliver before action='done'. \
 Use submit_for_verification to request cross-agent review; approve/reject for verifier actions. \
-Use submit_pr_evidence to submit a merged PR as evidence for a todo task that requires tools \
-unavailable to you — this transitions the task directly to awaiting_verification so an agent \
-with the required tools can verify and close it. For compatibility, \
+Use submit_pr_evidence to submit a merged PR as evidence for a todo task you did not claim; \
+this transitions the task directly to awaiting_verification so a verifier can inspect and close it. For compatibility, \
 submit_for_verification with evidence on a todo task is treated as submit_pr_evidence. \
 Tasks created through %s complete via action='done' after LLM completion review; \
 they do not route normal completion through the verifier agent."

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -1796,9 +1796,9 @@ let () = test "dispatch_transition_claim_uses_server_surface_not_payload_surface
 )
 
 (* Regression for issue: tool_execute-gated tasks stay todo after merged PR
-   evidence. submit_pr_evidence must bypass the required_tool claim guard and
-   transition Todo -> AwaitingVerification without claiming. *)
-let () = test "submit_pr_evidence_bypasses_required_tool_gate_on_todo_task" (fun () ->
+   evidence. submit_pr_evidence must ignore legacy required_tools task-contract
+   residue and transition Todo -> AwaitingVerification without claiming. *)
+let () = test "submit_pr_evidence_ignores_legacy_required_tools_on_todo_task" (fun () ->
   with_env "MASC_VERIFICATION_FSM_ENABLED" (Some "true") (fun () ->
     let ctx = make_test_ctx_with_agent "agent_code-mcp-client" in
     add_task_requiring_tools ctx ~title:"Needs bash" [ "tool_execute" ];

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -193,6 +193,15 @@ let test_masc_transition_schema () =
   match find_registered_tool "masc_transition" with
   | None -> Alcotest.fail "masc_transition not found"
   | Some schema ->
+      Alcotest.(check bool) "description omits task required_tools"
+        false
+        (contains_substring ~needle:"required_tools" schema.description);
+      Alcotest.(check bool) "description omits required tools routing"
+        false
+        (contains_substring ~needle:"required tools" schema.description);
+      Alcotest.(check bool) "description omits requires tools routing"
+        false
+        (contains_substring ~needle:"requires tools" schema.description);
       (match get_json_assoc "properties" schema.input_schema with
       | Some props ->
           Alcotest.(check bool) "has completion_contract" true


### PR DESCRIPTION
## Summary

- remove stale `required_tools` / "required tools" routing language from the public `masc_transition` description
- add a schema ratchet so `masc_transition` cannot reintroduce that retired task-contract wording
- rename the `submit_pr_evidence` regression test to describe the current legacy-residue behavior

## Product impact

- User-visible change: `masc_transition` no longer tells agents to route `submit_pr_evidence` through retired required-tool task-contract semantics.

## Evidence

- `ocamlformat --check lib/task/tool_task_schemas.ml test/test_tools_coverage.ml test/test_tool_task_coverage.ml`
- `git diff --check`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build ./test/test_tools_coverage.exe ./test/test_tool_task_coverage.exe`
- `./_build/default/test/test_tools_coverage.exe` - 48 tests passed
- `./_build/default/test/test_tool_task_coverage.exe` - 90 tests passed

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 5/5
provenance: direct
stages:
  - command: ocamlformat --check lib/task/tool_task_schemas.ml test/test_tools_coverage.ml test/test_tool_task_coverage.ml
    result: pass
  - command: git diff --check
    result: pass
  - command: env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build ./test/test_tools_coverage.exe ./test/test_tool_task_coverage.exe
    result: pass
  - command: ./_build/default/test/test_tools_coverage.exe
    result: pass
  - command: ./_build/default/test/test_tool_task_coverage.exe
    result: pass
```

## GOAL LOOP ACT checklist

- [x] Observe - live board/backlog references still pointed agents at retired required-tool task-contract wording.
- [x] Orient - current code has removed production `required_tools` task-contract routing; this PR addresses the remaining public transition schema wording.
- [x] Decide - narrow schema-text ratchet is the next bounded action because claim routing already ignores/removes this field.
- [x] Act - changed only `masc_transition` schema text and focused regression coverage.
- [x] Verify - focused formatting, build, and affected tests pass.
- [x] Loop - no follow-up in this PR; broader dirty purge worktree remains separate and untouched.

## Review evidence

- Cross-model review: not run; narrow wording/test ratchet change.

## Linked issue

- Closes N/A
- Relates N/A

## Variant addition checklist

- [ ] **OCaml** - N/A, no variants added/removed/renamed.
- [ ] **TypeScript** - N/A, no TypeScript union change.
- [ ] **TLA+ spec** - N/A, no TLA+ domain change.
- [ ] **Event / JSON schema** - N/A, no event type string or JSON schema enum change.
- [ ] **`make check-variants` passes** - N/A, no variant/domain literal change.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`codex/purge-required-tool-wording-20260604` → `main` · 1 commit(s) · synced 2026-06-04T06:34:38Z

| sha | subject | date |
|---|---|---|
| `2ea5155d8` | chore: purge required-tool wording from transition schema | 2026-06-04 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->