### PR TITLE
fix(keeper): restore web tool schemas to raw inventory (stop AllowList prune spam)

### DIFF
--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -223,7 +223,6 @@ let dispatch ctx ~name ~args : Tool_result.result option =
   | _ -> None
 
 let schemas = Tool_schemas_misc.schemas
-let internal_handler_schemas = Tool_schemas_misc.internal_handler_schemas
 
 (* ================================================================ *)
 (* Tool_spec registration                                           *)
@@ -261,7 +260,7 @@ let () =
            ~is_idempotent:(List.mem s.name tool_spec_read_only)
            ?required_permission:(tool_required_permission s.name)
            ()))
-    internal_handler_schemas
+    schemas
 let looks_like_rss_payload = Tool_misc_web_search.looks_like_rss_payload
 let parse_bing_rss_items = Tool_misc_web_search.parse_bing_rss_items
 let parse_searxng_json = Tool_misc_web_search.parse_searxng_json

--- a/lib/tool_schemas/tool_schemas_misc.ml
+++ b/lib/tool_schemas/tool_schemas_misc.ml
@@ -43,18 +43,19 @@ let config_category_enum_strings =
   ]
 ;;
 
-let keeper_internal_web_tool_names =
-  [ "masc_web_search"; "masc_web_fetch" ]
-;;
-
-let is_keeper_internal_web_tool (schema : tool_schema) =
-  List.mem schema.name keeper_internal_web_tool_names
-;;
-
-let internal_handler_schemas : tool_schema list = Tool_descriptors_gen.schemas
-
-let schemas : tool_schema list =
-  List.filter
-    (fun schema -> not (is_keeper_internal_web_tool schema))
-    internal_handler_schemas
-;;
+(* [schemas] is the full generated misc schema set, including the
+   descriptor-backed web tools (masc_web_search / masc_web_fetch).
+   Web tools must stay in this list because it feeds
+   [Config.raw_all_tool_schemas] — the substrate's "all tools that exist"
+   set, which is the source for both (a) the keeper progressive-disclosure
+   universe (Keeper_tool_dispatch_runtime.inject_masc_schemas) and (b) the
+   public MCP surface. Public exclusion is the job of
+   [Tool_catalog.public_mcp_surface_tools] / [is_public_mcp] (web tools are
+   absent from that allowlist), NOT of this inventory. PR #19864 filtered web
+   tools out here as a "keeper-only backend" optimisation; that excluded them
+   from the keeper universe too, so the descriptor bundle never registered
+   WebSearch/WebFetch while [effective_core_tools] still injected the public
+   names every turn — every keeper turn logged "AllowList pruned ... WebSearch,
+   WebFetch". The exclusion belonged on the public-surface layer, not the raw
+   inventory. *)
+let schemas : tool_schema list = Tool_descriptors_gen.schemas

--- a/lib/tool_schemas/tool_schemas_misc.mli
+++ b/lib/tool_schemas/tool_schemas_misc.mli
@@ -48,19 +48,14 @@ val config_category_enum_strings : string list
 (** {1 Tool schema list} *)
 
 val schemas : Masc_domain.tool_schema list
-(** [schemas] is the [Masc_domain.tool_schema list] for the
-    MCP-facing misc tools. Keeper-only web backend tools
-    ([masc_web_search] / [masc_web_fetch]) are intentionally
-    excluded from this public schema inventory. Consumed by
-    {!Config.visible_tool_schemas} via {!Tools.schemas}. The
-    schema [enum] fields derive from
-    {!admin_section_enum_strings} /
-    {!dashboard_scope_enum_strings} /
-    {!config_category_enum_strings} so adding a value updates
-    the schema automatically. *)
-
-val internal_handler_schemas : Masc_domain.tool_schema list
-(** [internal_handler_schemas] keeps the full generated misc schema
-    set for Tool_spec/tag registration. It may contain internal backend
-    tool names that are callable by keeper descriptors but absent from
-    the MCP-facing [schemas] list. *)
+(** [schemas] is the full generated [Masc_domain.tool_schema list] for the
+    misc tools, including the descriptor-backed web tools
+    ([masc_web_search] / [masc_web_fetch]). Consumed by
+    {!Config.raw_all_tool_schemas} (the substrate inventory feeding both the
+    keeper progressive-disclosure universe and the public MCP surface) and by
+    [Tool_misc] for Tool_spec registration. Public-surface exclusion is
+    enforced downstream by {!Tool_catalog.is_public_mcp} /
+    [public_mcp_surface_tools], not by trimming this inventory. The schema
+    [enum] fields derive from {!admin_section_enum_strings} /
+    {!dashboard_scope_enum_strings} / {!config_category_enum_strings} so
+    adding a value updates the schema automatically. *)

--- a/test/test_tool_descriptors_gen.ml
+++ b/test/test_tool_descriptors_gen.ml
@@ -132,27 +132,33 @@ let test_masc_gc_input_schema_matches () =
     gen.input_schema
 ;;
 
-let test_web_tools_absent_from_public_misc_schemas () =
+(* Regression guard for PR #19864 → keeper "AllowList pruned ... WebSearch,
+   WebFetch" spam. Web tools are descriptor-backed keeper tools: they MUST be
+   present in the raw substrate inventory (so the keeper progressive-disclosure
+   universe registers WebSearch/WebFetch and [validate_allow_list] keeps them),
+   and they MUST be absent from the public MCP allowlist (public exclusion is
+   the job of [public_mcp_surface_tools], not of trimming the inventory). *)
+let test_web_tools_present_in_misc_schemas () =
   Alcotest.(check bool)
-    "masc_web_search absent from public misc schemas"
-    false
+    "masc_web_search present in misc schemas"
+    true
     (has_schema "masc_web_search" Tool_schemas_misc.schemas);
   Alcotest.(check bool)
-    "masc_web_fetch absent from public misc schemas"
-    false
+    "masc_web_fetch present in misc schemas"
+    true
     (has_schema "masc_web_fetch" Tool_schemas_misc.schemas)
 ;;
 
-let test_web_tools_absent_from_mcp_inventory () =
+let test_web_tools_in_raw_inventory_but_not_public_mcp_surface () =
   List.iter
     (fun name ->
       Alcotest.(check bool)
-        (name ^ " absent from Config.raw_all_tool_schemas")
-        false
+        (name ^ " present in Config.raw_all_tool_schemas")
+        true
         (has_schema name Masc.Config.raw_all_tool_schemas);
       Alcotest.(check bool)
-        (name ^ " absent from Config.raw_tool_name_set")
-        false
+        (name ^ " present in Config.raw_tool_name_set")
+        true
         (Masc.Config.is_raw_tool_name name);
       Alcotest.(check bool)
         (name ^ " absent from public_mcp_surface_tools")
@@ -163,19 +169,19 @@ let test_web_tools_absent_from_mcp_inventory () =
 
 let test_masc_web_search_name_matches () =
   let gen = find_by_name "masc_web_search" Tool_descriptors_gen.schemas in
-  let hand = find_by_name "masc_web_search" Tool_schemas_misc.internal_handler_schemas in
+  let hand = find_by_name "masc_web_search" Tool_schemas_misc.schemas in
   Alcotest.(check string) "masc_web_search name" hand.name gen.name
 ;;
 
 let test_masc_web_search_description_matches () =
   let gen = find_by_name "masc_web_search" Tool_descriptors_gen.schemas in
-  let hand = find_by_name "masc_web_search" Tool_schemas_misc.internal_handler_schemas in
+  let hand = find_by_name "masc_web_search" Tool_schemas_misc.schemas in
   Alcotest.(check string) "masc_web_search description" hand.description gen.description
 ;;
 
 let test_masc_web_search_input_schema_matches () =
   let gen = find_by_name "masc_web_search" Tool_descriptors_gen.schemas in
-  let hand = find_by_name "masc_web_search" Tool_schemas_misc.internal_handler_schemas in
+  let hand = find_by_name "masc_web_search" Tool_schemas_misc.schemas in
   Alcotest.check
     yojson_testable
     "masc_web_search input_schema (Yojson.Safe.equal)"
@@ -185,19 +191,19 @@ let test_masc_web_search_input_schema_matches () =
 
 let test_masc_web_fetch_name_matches () =
   let gen = find_by_name "masc_web_fetch" Tool_descriptors_gen.schemas in
-  let hand = find_by_name "masc_web_fetch" Tool_schemas_misc.internal_handler_schemas in
+  let hand = find_by_name "masc_web_fetch" Tool_schemas_misc.schemas in
   Alcotest.(check string) "masc_web_fetch name" hand.name gen.name
 ;;
 
 let test_masc_web_fetch_description_matches () =
   let gen = find_by_name "masc_web_fetch" Tool_descriptors_gen.schemas in
-  let hand = find_by_name "masc_web_fetch" Tool_schemas_misc.internal_handler_schemas in
+  let hand = find_by_name "masc_web_fetch" Tool_schemas_misc.schemas in
   Alcotest.(check string) "masc_web_fetch description" hand.description gen.description
 ;;
 
 let test_masc_web_fetch_input_schema_matches () =
   let gen = find_by_name "masc_web_fetch" Tool_descriptors_gen.schemas in
-  let hand = find_by_name "masc_web_fetch" Tool_schemas_misc.internal_handler_schemas in
+  let hand = find_by_name "masc_web_fetch" Tool_schemas_misc.schemas in
   Alcotest.check
     yojson_testable
     "masc_web_fetch input_schema (Yojson.Safe.equal)"
@@ -337,15 +343,15 @@ let () =
         ; Alcotest.test_case "description" `Quick test_masc_gc_description_matches
         ; Alcotest.test_case "input_schema" `Quick test_masc_gc_input_schema_matches
         ] )
-    ; ( "keeper-internal web tools"
+    ; ( "descriptor-backed web tools"
       , [ Alcotest.test_case
-            "absent from public misc schemas"
+            "present in misc schemas"
             `Quick
-            test_web_tools_absent_from_public_misc_schemas
+            test_web_tools_present_in_misc_schemas
         ; Alcotest.test_case
-            "absent from MCP inventory"
+            "in raw inventory but not public MCP surface"
             `Quick
-            test_web_tools_absent_from_mcp_inventory
+            test_web_tools_in_raw_inventory_but_not_public_mcp_surface
         ; Alcotest.test_case "masc_web_search name" `Quick test_masc_web_search_name_matches
         ; Alcotest.test_case "description" `Quick test_masc_web_search_description_matches
         ; Alcotest.test_case


### PR DESCRIPTION
## 증상

`keeper:<name> turn:N AllowList pruned 2 tool(s) outside visible policy surface: WebSearch, WebFetch`

이 WARN이 매 keeper 턴마다 발생합니다. fleet 로그(`~/me/.masc/logs`) 기준:

| 날짜 | prune 건수 |
|------|-----------|
| 2026-06-01 | 0 |
| 2026-06-02 | 0 |
| 2026-06-03 (#19864 머지: 13:01 KST) | 2878 |
| 2026-06-04 | 3704 |

오늘 prune된 건은 **100% 정확히 `WebSearch, WebFetch`** 두 개입니다.

## 근본 원인 — #19864의 over-correction (split-brain)

PR #19864 ("Remove remote MCP executor from keeper tools")가 곁다리로 `lib/tool_schemas/tool_schemas_misc.ml`에 web-tool 스키마 필터를 추가했습니다:

```ocaml
(* #19864 이전 *)
let schemas = Tool_descriptors_gen.schemas
(* #19864 이후 *)
let schemas = List.filter (fun s -> not (is_keeper_internal_web_tool s)) internal_handler_schemas
```

이 필터가 `masc_web_search` / `masc_web_fetch` 스키마를 인벤토리에서 제거하면서 **세 시스템이 불일치**하게 됐습니다:

1. **정책** (`config/tool_policy.toml`): `masc_web_search`/`masc_web_fetch`를 candidate로 인정 → keeper의 `policy_allowed_tool_set`에 public alias `WebSearch`/`WebFetch` 포함.
2. **core 주입** (`keeper_tool_registry.ml:96` `effective_core_tools` → `public_names ()`): universe 멤버십과 무관하게 매 턴 `WebSearch`/`WebFetch`를 후보로 주입.
3. **스키마 스냅샷** (필터된 `Tool_schemas_misc.schemas` → `Config.raw_all_tool_schemas` → `inject_masc_schemas`): keeper universe에서 web 스키마가 빠져 bundle이 `WebSearch`/`WebFetch` 도구를 **등록하지 못함** → `universe_set`에 부재.

결과: `validate_allow_list`이 "policy엔 있는데 universe엔 없는" `WebSearch`/`WebFetch`를 매 턴 prune.

추가로, `Config.raw_all_tool_schemas`는 "존재하는 모든 도구"의 substrate 인벤토리인데 여기서도 web이 빠져 `is_raw_tool_name "masc_web_search" = false` (도구 존재 여부 거짓 보고) + `Tool_help_registry` web 도구 help 깨짐 — 잠복 2차 버그.

핵심: web 도구를 public MCP에서 가리는 것은 이미 `Tool_catalog.public_mcp_surface_tools` allowlist(web 도구 부재)가 처리합니다. #19864의 스키마-인벤토리 필터는 **잘못된 레이어**에 놓였고, public 가리기엔 불필요(중복)했으며 keeper universe만 파괴했습니다.

## 수정 — 잘못된 필터 제거(근본 수정)

#19864의 스키마 sub-change를 되돌립니다:

- `tool_schemas_misc.ml`: `let schemas = Tool_descriptors_gen.schemas`로 복원. dead 헬퍼(`keeper_internal_web_tool_names`/`is_keeper_internal_web_tool`)와 중복 개념(`internal_handler_schemas`) 제거.
- `tool_misc.ml`: Tool_spec 등록을 `schemas`로 복원, 중복 re-export 제거.
- `tool_schemas_misc.mli`: 잘못된 "intentionally excluded from public schema inventory" 주석 정정, `internal_handler_schemas` 선언 제거.
- `test/test_tool_descriptors_gen.ml`: 잘못된 invariant(web이 raw 인벤토리에서 부재) 테스트를 **정정된 invariant**로 교체 — web 도구는 raw 인벤토리(`schemas`/`raw_all_tool_schemas`/`is_raw_tool_name`)에 **존재**하고 public MCP allowlist엔 **부재**. 이는 #19864를 잡았을 회귀 가드입니다.

public MCP tools/list는 `raw_all ∩ is_visible`이고 web은 `is_public_mcp = false`이므로 이 수정 후에도 **public surface는 변하지 않습니다**.

## 경계 (boundary)

데이터/스키마 변경만으로, web 도구를 **기존 descriptor 흐름**(Read/Edit/Write/Execute와 동일 경로)에 복원합니다. keeper→MCP-surface enumeration을 새로 추가하지 않으므로 `tool-keeper-mcp-surface.md`가 기술한 keeper/MCP coupling debt를 악화시키지 않습니다.

## 검증

- `dune exec --root . test/test_tool_descriptors_gen.exe` — **33 tests pass** (신규 `descriptor-backed web tools` 8 케이스 포함). pre-commit 훅의 전체 `dune build` 통과로 트리 전체 컴파일 확인.
- 단위 테스트는 **인벤토리 레이어**를 증명합니다(web ∈ raw_all/schemas/is_raw_tool_name, web ∉ public_mcp_surface_tools). keeper bundle이 실제로 `WebSearch`/`WebFetch`를 등록하고 `validate_allow_list`이 보존하는 end-to-end는 **재배포 후 fleet 로그 prune 0건**으로 확인 예정 (남은 미검증 항목).
- fleet 로그 인과 상관: prune은 #19864 머지(06-03 13:01 KST) 직전 0건 → 직후 수천 건.

## 워크어라운드 게이트

이 PR은 워크어라운드가 **아닙니다** — 증상 억제 필터를 **제거**하고 typed/registered 도구를 복원합니다. counter/cap/cooldown/string-classifier/N-of-M 추가 없음.

## 후속 (별도)

1. **Fragility (Issue 등록 예정)**: `effective_core_tools` → `public_names ()`가 universe 멤버십과 무관하게 무조건 주입 → 미등록 descriptor가 있으면 이 WARN을 다시 유발하는 구조적 취약점. 이 PR 범위 밖.
2. **Web tooling 강화 (별도 PR/RFC)**: markdown 추출, citation char-offset, chunking, domain allow/block, URL-provenance(exfil 방어) 등.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
