### PR TITLE
fix(keeper): clarify board tool descriptors

### DIFF
--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -109,8 +109,9 @@ Knowledge lookup:
 - Research docs and references: keeper_library_search first, then keeper_library_read for full text
 
 Board and communication:
-- Read/write board posts: keeper_board_get, keeper_board_post (hearth required), keeper_board_comment, keeper_board_vote
-- List recent posts: keeper_board_list
+- Discover board post IDs: keeper_board_list for recent posts, keeper_board_search for keyword lookup. Use these before get/comment/vote when no post_id is already visible.
+- Read or react to an existing board post: keeper_board_get, keeper_board_comment, and keeper_board_vote all require an exact post_id. Never call keeper_board_get with `{}` or without post_id.
+- Create a new board post: keeper_board_post (hearth required)
 - When posting to the board, always set hearth to your keeper name (e.g. hearth="sangsu"). Never post without hearth.
 - Broadcast to all agents: keeper_broadcast
 - Speak aloud: keeper_voice_speak (requires voice_config.json with tts.endpoints configured)

--- a/config/prompts/keeper.tool_hints.toml
+++ b/config/prompts/keeper.tool_hints.toml
@@ -20,8 +20,8 @@ description = "create a new backlog task with keeper-native evidence"
 
 [[hints]]
 name = "keeper_board_get"
-call = "`keeper_board_get` { id: \"POST_ID\" }"
-description = "read a board post before replying"
+call = "`keeper_board_get` { post_id: \"POST_ID\" }"
+description = "read one board post only after you have its post_id"
 
 [[hints]]
 name = "keeper_board_comment"

--- a/config/prompts/keeper.turn_intent.board_activity_guidance.md
+++ b/config/prompts/keeper.turn_intent.board_activity_guidance.md
@@ -2,4 +2,4 @@
 description: keeper turn-intent board activity guidance bullet (board_get + comment pairing)
 category: keeper
 ---
-- See board activity? Use the listed post_id. If the preview is enough, comment directly with keeper_board_comment. If you need the full post, call keeper_board_get and keeper_board_comment in the same response; keeper_board_get alone is passive and fails actionable turns.
+- See board activity? Use the listed post_id. If no post_id is listed, call keeper_board_list or keeper_board_search to discover one before any keeper_board_get, comment, or vote. Never call keeper_board_get with {} or without post_id. If the preview is enough, comment directly with keeper_board_comment. If you need the full post, call keeper_board_get with that post_id; pair it with keeper_board_comment in the same response only when the full post gives you a concrete reply. keeper_board_get alone is passive and fails actionable turns.

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -308,11 +308,11 @@ let keeper_selection_bm25_prefilter_n = 30
    Execute/Grep rows. *)
 let tool_search_alias_entries =
   [ "keeper_board_post", "게시판 글 작성 올리기 포스트"
-  ; "keeper_board_get", "게시판 글 읽기 조회 확인"
-  ; "keeper_board_list", "게시판 목록 최근글"
+  ; "keeper_board_get", "게시판 글 상세 단건 본문 댓글 post_id 읽기 보기"
+  ; "keeper_board_list", "게시판 목록 최근글 post_id 찾기 조회 나열"
   ; "keeper_board_comment", "게시판 댓글 답글 코멘트"
   ; "keeper_board_vote", "게시판 투표 추천 반대"
-  ; "keeper_board_search", "게시판 검색 키워드 글찾기"
+  ; "keeper_board_search", "게시판 검색 키워드 post_id 찾기 과거글"
   ; "keeper_board_stats", "게시판 통계 활동 참여 게시글수"
   ; "keeper_board_curation_read", "게시판 AI 큐레이션 추천순서 하이라이트"
   ; "keeper_board_curation_submit", "게시판 AI 큐레이션 요약 태그 답변매칭 건강도 제출"

--- a/lib/keeper/keeper_hooks_oas_idle.ml
+++ b/lib/keeper/keeper_hooks_oas_idle.ml
@@ -22,6 +22,28 @@ let suggest_alternatives ~(allowed_tools : string list)
      if len <= max_suggestions then candidates
      else List.filteri (fun i _ -> i < max_suggestions) candidates
 
+let includes_tool name tools = List.exists (String.equal name) tools
+
+let board_get_recovery_hint ~allowed_tools ~tool_names =
+  if not (includes_tool "keeper_board_get" tool_names) then
+    None
+  else
+    let discovery_tools =
+      [ "keeper_board_list"; "keeper_board_search" ]
+      |> List.filter (fun name -> includes_tool name allowed_tools)
+    in
+    let discovery =
+      match discovery_tools with
+      | [] -> "a visible board activity post_id"
+      | [ one ] -> one
+      | many -> String.concat " or " many
+    in
+    Some
+      (Printf.sprintf
+         "keeper_board_get requires post_id; if no post_id is visible, use %s first. \
+          Do not call keeper_board_get with {}."
+         discovery)
+
 (** Pure decision logic for the on_idle hook.  Testable without Workspace.config.
 
     Graduated response to repeated tool calls uses the configured
@@ -55,20 +77,30 @@ let on_idle_decision_with_threshold ~skip_at ~consecutive_idle_turns
     | [] -> "keeper_tool_search or keeper_stay_silent"
     | alts -> String.concat ", " alts
   in
+  let recovery_hint =
+    board_get_recovery_hint ~allowed_tools ~tool_names
+  in
+  let append_hint msg =
+    match recovery_hint with
+    | None -> msg
+    | Some hint -> msg ^ " " ^ hint
+  in
   if consecutive_idle_turns >= skip_at then
     Agent_sdk.Hooks.Skip
   else if consecutive_idle_turns = skip_at - 1 then
     Agent_sdk.Hooks.Nudge
-      (Printf.sprintf
-         "FINAL WARNING: you repeated %s %d times. Next idle = turn ends. \
-          Use one of these instead: %s — or call keeper_stay_silent to do nothing."
-         tools_str consecutive_idle_turns alt_str)
+      (append_hint
+         (Printf.sprintf
+            "FINAL WARNING: you repeated %s %d times. Next idle = turn ends. \
+             Use one of these instead: %s — or call keeper_stay_silent to do nothing."
+            tools_str consecutive_idle_turns alt_str))
   else
     Agent_sdk.Hooks.Nudge
-      (Printf.sprintf
-         "You are repeating %s without progress. \
-          Available alternatives: %s."
-         tools_str alt_str)
+      (append_hint
+         (Printf.sprintf
+            "You are repeating %s without progress. \
+             Available alternatives: %s."
+            tools_str alt_str))
 
 (** Wrapper around {!on_idle_decision_with_threshold} that supplies the
     [idle_skip_threshold] constant from [Env_config_keeper.KeeperKeepalive].

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -1100,7 +1100,7 @@ let internal_descriptors : t list =
     (* ── board cluster (RFC-0179 PR-3, 14 tools) ──────────────── *)
   ; board_descriptor
       "keeper_board_comment"
-      "Post a comment on a board entry."
+      "Comment on one board post. Requires an exact post_id from board activity, keeper_board_list, keeper_board_search, or keeper_board_get."
       ~last_turn_safe:true
       ~readonly:false
   ; board_descriptor
@@ -1118,11 +1118,11 @@ let internal_descriptors : t list =
       ~readonly:false
   ; board_descriptor
       "keeper_board_get"
-      "Fetch a single board entry."
+      "Read one board post by exact post_id. Use keeper_board_list or keeper_board_search first when no post_id is visible; do not call with empty arguments."
       ~readonly:true
   ; board_descriptor
       "keeper_board_list"
-      "List board entries."
+      "List recent board posts and return post_id values for follow-up board get/comment/vote calls."
       ~readonly:true
   ; board_descriptor
       "keeper_board_post"
@@ -1131,7 +1131,7 @@ let internal_descriptors : t list =
       ~readonly:false
   ; board_descriptor
       "keeper_board_search"
-      "Search board entries."
+      "Search board posts by keyword and return post_id values for follow-up board get/comment/vote calls."
       ~readonly:true
   ; board_descriptor
       "keeper_board_stats"
@@ -1159,7 +1159,7 @@ let internal_descriptors : t list =
       ~readonly:false
   ; board_descriptor
       "keeper_board_vote"
-      "Vote on a board entry."
+      "Vote on one board post. Requires an exact post_id from board activity, keeper_board_list, keeper_board_search, or keeper_board_get."
       ~readonly:false
   (* ── RFC-0182 §3.1 — masc_task_* cluster (7 entries) ─────────── *)
   ; masc_task_descriptor "add" "masc_add_task"

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -329,11 +329,15 @@ let fallback_externalized_bullet key =
        not listed."
   else if String.equal key Keeper_prompt_names.turn_intent_board_activity_guidance then
     Some
-      "- See board activity? Use the listed post_id. If the preview is \
-       enough, comment directly with keeper_board_comment. If you need the \
-       full post, call keeper_board_get and keeper_board_comment in the same \
-       response when the post gives you a concrete reply. If it does not, \
-       report no-work or the blocker instead of inventing a comment."
+      "- See board activity? Use the listed post_id. If no post_id is \
+       listed, call keeper_board_list or keeper_board_search to discover one \
+       before any keeper_board_get, comment, or vote. Never call \
+       keeper_board_get with {} or without post_id. If the preview is enough, \
+       comment directly with keeper_board_comment. If you need the full post, \
+       call keeper_board_get with that post_id; pair it with \
+       keeper_board_comment in the same response only when the full post gives \
+       you a concrete reply. keeper_board_get alone is passive and fails \
+       actionable turns."
   else if String.equal key Keeper_prompt_names.turn_intent_board_post_guidance then
     Some
       "- Have a substantive finding or update? Call keeper_board_post with \

--- a/lib/tool_board_schemas.ml
+++ b/lib/tool_board_schemas.ml
@@ -133,7 +133,10 @@ let tool_post_create : Masc_domain.tool_schema =
 
 let tool_post_list : Masc_domain.tool_schema =
   { name = "masc_board_list"
-  ; description = "List posts on the MASC internal board with sorting options"
+  ; description =
+      "List MASC internal board posts and return post_id values for follow-up \
+       masc_board_get, masc_board_comment, or masc_board_vote calls. Use this when \
+       you need recent board state or a post_id and do not already have one."
   ; input_schema =
       `Assoc
         [ "type", `String "object"
@@ -246,27 +249,11 @@ let tool_post_list : Masc_domain.tool_schema =
 let tool_post_get : Masc_domain.tool_schema =
   { name = "masc_board_get"
   ; description =
-      "Get a specific post with its full comment thread. Use when you want to read \
-       discussion context before replying, or when you received a post_id from \
-       board_list/search."
-  ; input_schema =
-      `Assoc
-        [ "type", `String "object"
-        ; ( "properties"
-          , `Assoc
-              [ ( "post_id"
-                , `Assoc [ "type", `String "string"; "description", `String "Post ID" ] )
-              ] )
-        ; "required", `List [ `String "post_id" ]
-        ]
-  }
-;;
-
-let tool_comment_add : Masc_domain.tool_schema =
-  { name = "masc_board_comment"
-  ; description =
-      "Add a comment to an existing board post. Use after reading a post with board_get \
-       to contribute your perspective, ask a question, or provide feedback."
+      "Read one existing board post by exact post_id, including its full comment \
+       thread. Use only after you already have a post_id from masc_board_list, \
+       masc_board_search, or visible board context. If no post_id is visible, call \
+       masc_board_list or masc_board_search first; never call this tool with empty \
+       arguments."
   ; input_schema =
       `Assoc
         [ "type", `String "object"
@@ -277,8 +264,36 @@ let tool_comment_add : Masc_domain.tool_schema =
                     [ "type", `String "string"
                     ; ( "description"
                       , `String
-                          "Post ID (format: p-xxxx...). Get from masc_board_list \
-                           results." )
+                          "Required exact board post ID (format: p-xxxx). Get it from \
+                           masc_board_list, masc_board_search, or visible board context \
+                           before calling masc_board_get." )
+                    ] )
+              ] )
+        ; "required", `List [ `String "post_id" ]
+        ]
+  }
+;;
+
+let tool_comment_add : Masc_domain.tool_schema =
+  { name = "masc_board_comment"
+  ; description =
+      "Add a comment to one existing board post by exact post_id. Use after the \
+       post_id is visible from board context, masc_board_list, masc_board_search, or \
+       masc_board_get to contribute your perspective, ask a question, or provide \
+       feedback."
+  ; input_schema =
+      `Assoc
+        [ "type", `String "object"
+        ; ( "properties"
+          , `Assoc
+              [ ( "post_id"
+                , `Assoc
+                    [ "type", `String "string"
+                    ; ( "description"
+                      , `String
+                          "Required exact board post ID (format: p-xxxx). Get it from \
+                           masc_board_list, masc_board_search, masc_board_get, or visible \
+                           board context." )
                     ] )
               ; ( "content"
                 , `Assoc
@@ -308,8 +323,9 @@ let tool_comment_add : Masc_domain.tool_schema =
 let tool_vote : Masc_domain.tool_schema =
   { name = "masc_board_vote"
   ; description =
-      "Vote on a board post (up or down) to signal agreement or quality. Use when you \
-       find a post valuable or want to deprioritize noise."
+      "Vote on one existing board post by exact post_id to signal agreement or quality. \
+       Use after the post_id is visible from board context, masc_board_list, \
+       masc_board_search, or masc_board_get."
   ; input_schema =
       `Assoc
         [ "type", `String "object"
@@ -320,8 +336,9 @@ let tool_vote : Masc_domain.tool_schema =
                     [ "type", `String "string"
                     ; ( "description"
                       , `String
-                          "Post ID (format: p-xxxx...). Get from masc_board_list \
-                           results." )
+                          "Required exact board post ID (format: p-xxxx). Get it from \
+                           masc_board_list, masc_board_search, masc_board_get, or visible \
+                           board context." )
                     ] )
               ; ( "voter"
                 , `Assoc [ "type", `String "string"; "description", `String "Voter name" ]
@@ -349,8 +366,9 @@ let tool_stats : Masc_domain.tool_schema =
 let tool_search : Masc_domain.tool_schema =
   { name = "masc_board_search"
   ; description =
-      "Search board posts by keyword across titles and content. Use when looking for \
-       specific topics, past discussions, or related prior work."
+      "Search board posts by keyword across titles and content and return post_id values \
+       for follow-up masc_board_get, masc_board_comment, or masc_board_vote calls. Use \
+       when looking for specific topics, past discussions, or related prior work."
   ; input_schema =
       `Assoc
         [ "type", `String "object"

--- a/lib/tool_surface/tool_prefilter.ml
+++ b/lib/tool_surface/tool_prefilter.ml
@@ -114,6 +114,8 @@ let synonyms : (string * string list) list =
       ; "view post"
       ; "get post"
       ; "board post detail"
+      ; "post id detail"
+      ; "read post by post_id"
       ; "show post"
       ; "inspect post"
       ] )
@@ -129,6 +131,8 @@ let synonyms : (string * string list) list =
     , [ "list posts"
       ; "browse board"
       ; "recent posts"
+      ; "find post id"
+      ; "discover post_id"
       ; "forum"
       ; "feed"
       ; "board posts"
@@ -139,7 +143,12 @@ let synonyms : (string * string list) list =
   ; ( "keeper_board_vote"
     , [ "upvote"; "downvote"; "rate"; "like"; "agree disagree"; "vote on" ] )
   ; ( "keeper_board_search"
-    , [ "search board"; "find post"; "search discussion"; "keyword search board" ] )
+    , [ "search board"
+      ; "find post"
+      ; "find post_id"
+      ; "search discussion"
+      ; "keyword search board"
+      ] )
   ; ( "keeper_board_stats"
     , [ "board statistics"; "activity stats"; "engagement"; "post count" ] )
   ; ( "keeper_tasks_list"

--- a/lib/tool_surface/tool_shard_types_schemas_board.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_board.ml
@@ -5,10 +5,12 @@ open Tool_shard_types_enum_mirrors
 let board_tools : Masc_domain.tool_schema list =
   [ { name = "keeper_board_get"
     ; description =
-        "Read a single board post with all its comments and votes. Use before deciding \
-         to comment, vote, or escalate. Returns post content, author, timestamp, \
-         vote_count, and comment thread. post_id format: 'p-xxxx'. Get post_id from \
-         BoardList results."
+        "Read one existing board post by exact post_id, including comments and votes. \
+         Use only after you already have a post_id from keeper_board_list, \
+         keeper_board_search, or the current board activity context. If no post_id is \
+         visible, call keeper_board_list or keeper_board_search first; never call this \
+         tool with empty arguments. Returns post content, author, timestamp, vote_count, \
+         and comment thread."
     ; input_schema =
         `Assoc
           [ "type", `String "object"
@@ -18,7 +20,10 @@ let board_tools : Masc_domain.tool_schema list =
                   , `Assoc
                       [ "type", `String "string"
                       ; ( "description"
-                        , `String "Post ID (format: p-xxxx). Get from BoardList."
+                        , `String
+                            "Required exact board post ID (format: p-xxxx). Get it \
+                             from keeper_board_list, keeper_board_search, or visible \
+                             board activity context before calling keeper_board_get."
                         )
                       ] )
                 ] )
@@ -109,9 +114,12 @@ let board_tools : Masc_domain.tool_schema list =
     }
   ; { name = "keeper_board_list"
     ; description =
-        "List recent posts on the MASC Board. Filter by hearth (topic channel) to see \
-         specific topics. Returns post_id, author, hearth, timestamp, vote_count, \
-         comment_count, and content preview for each post."
+        "List recent MASC Board posts and discover post_id values for follow-up \
+         keeper_board_get, keeper_board_comment, or keeper_board_vote calls. Use this \
+         when you need board state, recent posts, or a post_id and do not already have \
+         one. Filter by hearth (topic channel) to see specific topics. Returns post_id, \
+         author, hearth, timestamp, vote_count, comment_count, and content preview for \
+         each post."
     ; input_schema =
         `Assoc
           [ "type", `String "object"
@@ -153,8 +161,10 @@ let board_tools : Masc_domain.tool_schema list =
     }
   ; { name = "keeper_board_comment"
     ; description =
-        "Add a comment to a board post by post_id. Use to respond to questions, provide \
-         feedback, or continue a discussion thread."
+        "Add a comment to one existing board post by exact post_id. Use to respond to \
+         questions, provide feedback, or continue a discussion thread only after the \
+         post_id is visible from board activity, keeper_board_list, keeper_board_search, \
+         or keeper_board_get."
     ; input_schema =
         `Assoc
           [ "type", `String "object"
@@ -165,8 +175,9 @@ let board_tools : Masc_domain.tool_schema list =
                       [ "type", `String "string"
                       ; ( "description"
                         , `String
-                            "Post ID (format: p-xxxx...). Get from BoardList \
-                             results." )
+                            "Required exact board post ID (format: p-xxxx). Get it \
+                             from keeper_board_list, keeper_board_search, \
+                             keeper_board_get, or visible board activity context." )
                       ] )
                 ; ( "content"
                   , `Assoc
@@ -179,8 +190,10 @@ let board_tools : Masc_domain.tool_schema list =
     }
   ; { name = "keeper_board_vote"
     ; description =
-        "Vote on a board post (up or down). Use to signal agreement/support or \
-         disagreement with a proposal or finding."
+        "Vote on one existing board post by exact post_id. Use to signal \
+         agreement/support or disagreement with a proposal or finding only after the \
+         post_id is visible from board activity, keeper_board_list, keeper_board_search, \
+         or keeper_board_get."
     ; input_schema =
         `Assoc
           [ "type", `String "object"
@@ -191,8 +204,9 @@ let board_tools : Masc_domain.tool_schema list =
                       [ "type", `String "string"
                       ; ( "description"
                         , `String
-                            "Post ID (format: p-xxxx...). Get from BoardList \
-                             results." )
+                            "Required exact board post ID (format: p-xxxx). Get it \
+                             from keeper_board_list, keeper_board_search, \
+                             keeper_board_get, or visible board activity context." )
                       ] )
                 ; (* Issue #8506: derive from local mirror that tracks
            [Board_votes.valid_vote_direction_strings]. *)
@@ -216,8 +230,10 @@ let board_tools : Masc_domain.tool_schema list =
     }
   ; { name = "keeper_board_search"
     ; description =
-        "Search board posts by keyword across titles and content. Use when looking for \
-         specific topics, past discussions, or related prior work."
+        "Search board posts by keyword across titles and content and discover post_id \
+         values for follow-up keeper_board_get, keeper_board_comment, or \
+         keeper_board_vote calls. Use when looking for specific topics, past \
+         discussions, or related prior work."
     ; input_schema =
         `Assoc
           [ "type", `String "object"

--- a/test/test_keeper_retrieval_quality.ml
+++ b/test/test_keeper_retrieval_quality.ml
@@ -138,7 +138,12 @@ let test_board_post_en () =
 let test_board_read_kr () =
   let idx = build_keeper_index () in
   ignore (assert_retrieves ~label:"board_read_kr" idx
-    "게시판 글 읽기 조회" "keeper_board_get")
+    "게시판 글 상세 단건 post_id 읽기" "keeper_board_get")
+
+let test_board_list_kr () =
+  let idx = build_keeper_index () in
+  ignore (assert_retrieves ~label:"board_list_kr" idx
+    "게시판 목록 조회 post_id 찾기" "keeper_board_list")
 
 (* ================================================================ *)
 (* Scenarios: build and test                                        *)
@@ -317,6 +322,7 @@ let () =
         [
           Alcotest.test_case "board post (en)" `Quick test_board_post_en;
           Alcotest.test_case "board read (kr)" `Quick test_board_read_kr;
+          Alcotest.test_case "board list (kr)" `Quick test_board_list_kr;
         ] );
       ( "build_test",
         [

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -24,6 +24,7 @@ module Exec = Masc.Keeper_tool_dispatch_runtime
 module Registry = Masc.Keeper_tool_registry
 module Resolution = Masc.Keeper_tool_descriptor_resolution
 module Surface = Masc.Keeper_agent_tool_surface
+module Board = Tool_shard_types_schemas_board
 module Tool_board_registry = Masc.Tool_board_registry
 
 let all_descriptors () : Descriptor.t list = Descriptor.all_descriptors ()
@@ -175,10 +176,36 @@ let required_public_descriptor name =
   | None -> Alcotest.failf "missing public descriptor: %s" name
 ;;
 
+let required_internal_descriptor name =
+  match Descriptor.descriptors_for_internal name with
+  | descriptor :: _ -> descriptor
+  | [] -> Alcotest.failf "missing internal descriptor: %s" name
+;;
+
 let schema_property_description schema name =
   let open Yojson.Safe.Util in
   schema |> member "properties" |> member name |> member "description"
   |> to_string_option
+;;
+
+let required_board_schema name =
+  match List.find_opt (fun (s : Masc_domain.tool_schema) -> s.name = name) Board.board_tools with
+  | Some schema -> schema
+  | None -> Alcotest.failf "missing board schema: %s" name
+;;
+
+let required_masc_board_schema name =
+  match
+    List.find_opt
+      (fun (s : Masc_domain.tool_schema) -> s.name = name)
+      Tool_board_registry.tools
+  with
+  | Some schema -> schema
+  | None -> Alcotest.failf "missing masc board schema: %s" name
+;;
+
+let check_contains label ~sub text =
+  Alcotest.(check bool) label true (string_contains ~sub text)
 ;;
 
 let test_read_descriptor_spells_out_path_basis () =
@@ -223,6 +250,101 @@ let test_execute_descriptor_spells_out_argv_basis () =
     "Execute argv schema includes grep example"
     true
     (string_contains ~sub:"executable='grep', argv=['-rn', 'pattern', 'lib']" argv_description)
+;;
+
+let test_board_descriptions_disambiguate_post_id_flow () =
+  let get_descriptor = required_internal_descriptor "keeper_board_get" in
+  let get_schema = required_board_schema "keeper_board_get" in
+  let list_schema = required_board_schema "keeper_board_list" in
+  let search_schema = required_board_schema "keeper_board_search" in
+  let comment_schema = required_board_schema "keeper_board_comment" in
+  let vote_schema = required_board_schema "keeper_board_vote" in
+  let get_post_id_description =
+    schema_property_description get_schema.input_schema "post_id"
+    |> Option.value ~default:""
+  in
+  check_contains
+    "board_get descriptor points to list/search first"
+    ~sub:"Use keeper_board_list or keeper_board_search first"
+    get_descriptor.description;
+  check_contains
+    "board_get schema forbids empty args"
+    ~sub:"never call this tool with empty arguments"
+    get_schema.description;
+  check_contains
+    "board_get post_id field says exact ID is required"
+    ~sub:"Required exact board post ID"
+    get_post_id_description;
+  check_contains
+    "board_list schema says it discovers post_id"
+    ~sub:"discover post_id values"
+    list_schema.description;
+  check_contains
+    "board_search schema says it discovers post_id"
+    ~sub:"discover post_id values"
+    search_schema.description;
+  List.iter
+    (fun ((label, schema) : string * Masc_domain.tool_schema) ->
+       let post_id_description =
+         schema_property_description schema.input_schema "post_id"
+         |> Option.value ~default:""
+       in
+       check_contains
+         (label ^ " post_id field says exact ID is required")
+         ~sub:"Required exact board post ID"
+         post_id_description)
+    [ "board_comment", comment_schema; "board_vote", vote_schema ];
+  List.iter
+    (fun (schema : Masc_domain.tool_schema) ->
+       if string_contains ~sub:"BoardList" schema.description
+       then
+         Alcotest.failf
+           "%s description references non-canonical BoardList"
+           schema.name)
+    Board.board_tools
+;;
+
+let test_masc_board_descriptions_disambiguate_post_id_flow () =
+  let get_schema = required_masc_board_schema "masc_board_get" in
+  let list_schema = required_masc_board_schema "masc_board_list" in
+  let search_schema = required_masc_board_schema "masc_board_search" in
+  let comment_schema = required_masc_board_schema "masc_board_comment" in
+  let vote_schema = required_masc_board_schema "masc_board_vote" in
+  let get_post_id_description =
+    schema_property_description get_schema.input_schema "post_id"
+    |> Option.value ~default:""
+  in
+  check_contains
+    "masc_board_get schema points to list/search first"
+    ~sub:"masc_board_list or masc_board_search first"
+    get_schema.description;
+  check_contains
+    "masc_board_get schema forbids empty args"
+    ~sub:"never call this tool with empty arguments"
+    get_schema.description;
+  check_contains
+    "masc_board_get post_id field says exact ID is required"
+    ~sub:"Required exact board post ID"
+    get_post_id_description;
+  check_contains
+    "masc_board_list schema says it returns post_id"
+    ~sub:"return post_id values"
+    list_schema.description;
+  check_contains
+    "masc_board_search schema says it returns post_id"
+    ~sub:"return post_id values"
+    search_schema.description;
+  List.iter
+    (fun ((label, schema) : string * Masc_domain.tool_schema) ->
+       let post_id_description =
+         schema_property_description schema.input_schema "post_id"
+         |> Option.value ~default:""
+       in
+       check_contains
+         (label ^ " post_id field says exact ID is required")
+         ~sub:"Required exact board post ID"
+         post_id_description)
+    [ "masc_board_comment", comment_schema; "masc_board_vote", vote_schema ]
 ;;
 
 let test_masc_board_registry_has_descriptor_projection () =
@@ -634,6 +756,14 @@ let () =
             "Execute argv basis is explicit"
             `Quick
             test_execute_descriptor_spells_out_argv_basis
+        ; test_case
+            "Board get/list descriptions disambiguate post_id flow"
+            `Quick
+            test_board_descriptions_disambiguate_post_id_flow
+        ; test_case
+            "MASC board descriptions disambiguate post_id flow"
+            `Quick
+            test_masc_board_descriptions_disambiguate_post_id_flow
         ] )
     ; ( "masc-board"
       , [ test_case

--- a/test/test_keeper_unified_metacognition.ml
+++ b/test/test_keeper_unified_metacognition.ml
@@ -43,6 +43,44 @@ let test_on_idle_nudge_at_first_idle () =
             (Agent_sdk.Hooks.classify_decision other)))
 ;;
 
+let test_on_idle_board_get_nudge_names_post_id_discovery () =
+  let decision =
+    HK.on_idle_decision_with_threshold
+      ~skip_at:3
+      ~consecutive_idle_turns:1
+      ~allowed_tools:
+        [ "keeper_board_get"
+        ; "keeper_board_list"
+        ; "keeper_board_search"
+        ; "keeper_stay_silent"
+        ]
+      ~tool_names:[ "keeper_board_get" ]
+  in
+  match decision with
+  | Agent_sdk.Hooks.Nudge msg ->
+    check
+      bool
+      "board_get nudge says post_id is required"
+      true
+      (contains_substring msg "keeper_board_get requires post_id");
+    check
+      bool
+      "board_get nudge points to board discovery tools"
+      true
+      (contains_substring msg "keeper_board_list or keeper_board_search");
+    check
+      bool
+      "board_get nudge forbids empty args"
+      true
+      (contains_substring msg "Do not call keeper_board_get with {}")
+  | other ->
+    fail
+      (Printf.sprintf
+         "expected Nudge, got %s"
+         (Agent_sdk.Hooks.decision_kind_to_string
+            (Agent_sdk.Hooks.classify_decision other)))
+;;
+
 let test_on_idle_final_warning_before_skip () =
   let decision =
     HK.on_idle_decision_with_threshold
@@ -136,6 +174,10 @@ let () =
     "keeper unified metacognition"
     [ ( "metacognition"
       , [ test_case "on_idle nudge at first idle" `Quick test_on_idle_nudge_at_first_idle
+        ; test_case
+            "on_idle board_get nudge names post_id discovery"
+            `Quick
+            test_on_idle_board_get_nudge_names_post_id_discovery
         ; test_case
             "on_idle final warning before skip"
             `Quick


### PR DESCRIPTION
## Summary

- Clarify keeper/masc board tool descriptions so list/search discover `post_id` and get/comment/vote require an exact `post_id`.
- Fix `keeper_board_get` prompt hint to use `post_id`, and add board_get-specific idle nudge recovery guidance.
- Split Korean retrieval aliases so board list/search own `post_id` discovery while board get owns exact post detail.
- Add descriptor/nudge/retrieval regression tests for the `post_id` flow.

## Validation

- `git diff --check origin/main...HEAD`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_tool_descriptor_clarity scripts/dune-local.sh build test/test_keeper_tool_descriptor_registry_integrity.exe`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_tool_descriptor_clarity scripts/dune-local.sh build test/test_keeper_unified_metacognition.exe test/test_keeper_retrieval_quality.exe test/test_limit_schema_widen.exe test/test_tool_board_coverage.exe`
- `_build_tool_descriptor_clarity/default/test/test_keeper_tool_descriptor_registry_integrity.exe`
- `_build_tool_descriptor_clarity/default/test/test_keeper_unified_metacognition.exe`
- `_build_tool_descriptor_clarity/default/test/test_keeper_retrieval_quality.exe test board`
- `_build_tool_descriptor_clarity/default/test/test_tool_board_coverage.exe test schemas`
- `_build_tool_descriptor_clarity/default/test/test_limit_schema_widen.exe`

## Notes

- Full unfiltered `test_keeper_retrieval_quality` currently has unrelated failures in voice/github/worktree/stat alias cases; the changed board group passes.
- Full unfiltered `test_tool_board_coverage` currently has unrelated `keeper_board_post` meta source failures; the changed schema group passes.
- CI `Tool -> Keeper dependency-direction ratchet (RFC-0194 §3)` fails on files not touched by this PR (`lib/tool_deep_review.ml`, `lib/tool_inline_dispatch.ml`). Tracked separately in #20074.
- CI `OCaml Structure Ratchet` fails on current main-level `lib_other_mli_missing` drift. Existing tracker: #19914.
- Several aggregate CI jobs are canceled after those ratchet failures; local focused builds/tests for this change pass.
