### PR TITLE
fix(tool): add interfaces for tool surface shards

### DIFF
--- a/lib/tool_surface/tool_shard_types_core.mli
+++ b/lib/tool_surface/tool_shard_types_core.mli
@@ -1,0 +1,30 @@
+(** Core tool-shard types and pure routing helpers. *)
+
+(** A named collection of tools that can be granted or revoked. *)
+type shard =
+  { name : string
+  ; tools : Masc_domain.tool_schema list
+  ; read_only_tools : string list
+  ; removable : bool
+  ; description : string
+  }
+
+module StringMap : Map.S with type key = string
+
+val select_named_schemas
+  :  string list
+  -> Masc_domain.tool_schema list
+  -> Masc_domain.tool_schema list
+(** Pick named schemas from a schema pool, preserving the requested order. *)
+
+val default_shard_names : string list
+(** Default shards granted to a fresh agent. *)
+
+val tool_spec_read_only : string list
+val tool_spec_destructive : string list
+
+val tool_required_permission : string -> Masc_domain.permission option
+(** Required permission for Tool_shard MASC tools. *)
+
+val tool_effect_domain : string -> Tool_catalog.effect_domain option
+(** Tool-catalog effect-domain classification for Tool_shard MASC tools. *)

--- a/lib/tool_surface/tool_shard_types_enum_mirrors.mli
+++ b/lib/tool_surface/tool_shard_types_enum_mirrors.mli
@@ -1,0 +1,8 @@
+(** Hand-mirrored enum string lists used by tool schema JSON producers. *)
+
+val memory_search_source_enum_strings : string list
+val memory_kind_enum_strings : string list
+val fs_write_mode_enum_strings : string list
+val sort_order_enum_strings : string list
+val vote_direction_enum_strings : string list
+val tool_search_files_op_enum_strings : string list

--- a/lib/tool_surface/tool_shard_types_schemas_base.mli
+++ b/lib/tool_surface/tool_shard_types_schemas_base.mli
@@ -1,0 +1,3 @@
+(** Always-on keeper tool schemas. *)
+
+val base_tools : Masc_domain.tool_schema list

--- a/lib/tool_surface/tool_shard_types_schemas_board.mli
+++ b/lib/tool_surface/tool_shard_types_schemas_board.mli
@@ -1,0 +1,3 @@
+(** keeper_board_* tool schemas. *)
+
+val board_tools : Masc_domain.tool_schema list

--- a/lib/tool_surface/tool_shard_types_schemas_execute.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_execute.ml
@@ -205,8 +205,9 @@ let tool_execute_stderr_field =
 let tool_execute_description =
   "Execute one command through the typed execution gates via typed argv. \
    Provide EITHER executable/argv OR pipeline, never both. Use executable/argv for one process, \
-   or pipeline for explicit Shell IR pipelines. IMPORTANT: there is no 'cmd' \
-   or 'command' field. Those fields are not supported and will be rejected. \
+   or pipeline for explicit Shell IR pipelines. IMPORTANT: the legacy 'cmd' \
+   string field is no longer accepted. There is no 'cmd' or 'command' field. \
+   Those fields are not supported and will be rejected. \
    Always use 'executable' (string) and 'argv' (string array) instead. \
    Accepted fields: executable, argv, pipeline, env, cwd, timeout_sec, stdin, stdout, stderr. \
    For I/O redirection use the typed stdin/stdout/stderr objects \

--- a/lib/tool_surface/tool_shard_types_schemas_execute.mli
+++ b/lib/tool_surface/tool_shard_types_schemas_execute.mli
@@ -1,0 +1,7 @@
+(** Typed tool_execute schema fragments and aggregate schema. *)
+
+val tool_execute_timeout_sec_field : string * Yojson.Safe.t
+(** Timeout field schema kept public for the widening regression test. *)
+
+val tool_execute_schema : Masc_domain.tool_schema
+val typed_execute_tools : Masc_domain.tool_schema list

--- a/lib/tool_surface/tool_shard_types_schemas_filesystem.mli
+++ b/lib/tool_surface/tool_shard_types_schemas_filesystem.mli
@@ -1,0 +1,3 @@
+(** File and IDE annotation tool schemas. *)
+
+val filesystem_tools : Masc_domain.tool_schema list

--- a/lib/tool_surface/tool_shard_types_schemas_library.mli
+++ b/lib/tool_surface/tool_shard_types_schemas_library.mli
@@ -1,0 +1,3 @@
+(** Knowledge-library tool schemas. *)
+
+val library_tools : Masc_domain.tool_schema list

--- a/lib/tool_surface/tool_shard_types_schemas_search_files.mli
+++ b/lib/tool_surface/tool_shard_types_schemas_search_files.mli
@@ -1,0 +1,4 @@
+(** Structured file-search tool schemas. *)
+
+val tool_search_files_schema : Masc_domain.tool_schema
+val search_files_tools : Masc_domain.tool_schema list

--- a/lib/tool_surface/tool_shard_types_schemas_taskboard.mli
+++ b/lib/tool_surface/tool_shard_types_schemas_taskboard.mli
@@ -1,0 +1,3 @@
+(** Task, task-audit, and broadcast tool schemas. *)
+
+val taskboard_tools : Masc_domain.tool_schema list

--- a/lib/tool_surface/tool_shard_types_schemas_voice.mli
+++ b/lib/tool_surface/tool_shard_types_schemas_voice.mli
@@ -1,0 +1,3 @@
+(** Voice bridge tool schemas. *)
+
+val voice_tools : Masc_domain.tool_schema list


### PR DESCRIPTION
## Summary

- add explicit `.mli` interfaces for the ten new `lib/tool_surface/tool_shard_types_*` split modules
- restore the `tool_execute` descriptor phrase expected by the typed descriptor regression test
- bring `lib_other_mli_missing` back to the committed baseline after #20057 introduced the split modules

## Product impact

- User-visible change: none intended; this is a CI/structure-ratchet unblocker.

## Evidence

- `scripts/ocaml-structure-ratchet.sh` - pass
- `ocamlformat --check lib/tool_surface/tool_shard_types_schemas_execute.ml lib/tool_surface/tool_shard_types_core.mli lib/tool_surface/tool_shard_types_enum_mirrors.mli lib/tool_surface/tool_shard_types_schemas_base.mli lib/tool_surface/tool_shard_types_schemas_board.mli lib/tool_surface/tool_shard_types_schemas_execute.mli lib/tool_surface/tool_shard_types_schemas_filesystem.mli lib/tool_surface/tool_shard_types_schemas_library.mli lib/tool_surface/tool_shard_types_schemas_search_files.mli lib/tool_surface/tool_shard_types_schemas_taskboard.mli lib/tool_surface/tool_shard_types_schemas_voice.mli`
- `git diff --check`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_JOBS=1 dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-tool-surface-mli-20260604 ./test/test_tool_shard_coverage.exe ./test/test_execute_timeout_schema_widen.exe ./test/test_keeper_tool_execute_descriptor_variant.exe`
- `./_build/default/test/test_tool_shard_coverage.exe` - 45 tests passed
- `./_build/default/test/test_execute_timeout_schema_widen.exe` - 2 tests passed
- `./_build/default/test/test_keeper_tool_execute_descriptor_variant.exe` - 3 tests passed

Note: the focused build used direct `dune` with `DUNE_JOBS=1` after repeated `scripts/dune-local.sh` attempts were interrupted while queued behind other worktrees' shared Dune lock. The repo opt-in `MASC_DUNE_ALLOW_BARE_DUNE=1` was set.

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 7/7
provenance: direct
stages:
  - command: scripts/ocaml-structure-ratchet.sh
    result: pass
  - command: ocamlformat --check lib/tool_surface/tool_shard_types_schemas_execute.ml lib/tool_surface/tool_shard_types_core.mli lib/tool_surface/tool_shard_types_enum_mirrors.mli lib/tool_surface/tool_shard_types_schemas_base.mli lib/tool_surface/tool_shard_types_schemas_board.mli lib/tool_surface/tool_shard_types_schemas_execute.mli lib/tool_surface/tool_shard_types_schemas_filesystem.mli lib/tool_surface/tool_shard_types_schemas_library.mli lib/tool_surface/tool_shard_types_schemas_search_files.mli lib/tool_surface/tool_shard_types_schemas_taskboard.mli lib/tool_surface/tool_shard_types_schemas_voice.mli
    result: pass
  - command: git diff --check
    result: pass
  - command: env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_JOBS=1 dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-tool-surface-mli-20260604 ./test/test_tool_shard_coverage.exe ./test/test_execute_timeout_schema_widen.exe ./test/test_keeper_tool_execute_descriptor_variant.exe
    result: pass
  - command: ./_build/default/test/test_tool_shard_coverage.exe
    result: pass
  - command: ./_build/default/test/test_execute_timeout_schema_widen.exe
    result: pass
  - command: ./_build/default/test/test_keeper_tool_execute_descriptor_variant.exe
    result: pass
```

## GOAL LOOP ACT checklist

- [x] Observe - current `origin/main` failed `OCaml Structure Ratchet` with `lib_other_mli_missing: 12 > baseline 2`.
- [x] Orient - the new debt came from ten `lib/tool_surface/*.ml` split modules without sibling interfaces; the remaining two missing files are committed baseline debt.
- [x] Decide - add hand-written minimal interfaces rather than regenerating the baseline upward.
- [x] Act - added interfaces and restored the execute descriptor phrase expected by the current regression test.
- [x] Verify - ratchet, formatting, whitespace, focused build, and direct consumer tests pass.
- [x] Loop - this unblocks ordinary PR CI; no follow-up in this PR.

## Review evidence

- Cross-model review: not run; narrow CI unblocker with local direct evidence.

## Linked issue

- Closes N/A
- Relates #20057
- Relates #20059

## Variant addition checklist

- [ ] **OCaml** - N/A, no variants added/removed/renamed.
- [ ] **TypeScript** - N/A, no TypeScript union change.
- [ ] **TLA+ spec** - N/A, no TLA+ domain change.
- [ ] **Event / JSON schema** - N/A, no event type string or JSON schema enum change.
- [ ] **`make check-variants` passes** - N/A, no variant/domain literal change.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`fix/tool-surface-mli-20260604` → `main` · 1 commit(s) · synced 2026-06-04T07:04:47Z

| sha | subject | date |
|---|---|---|
| `06162042f` | fix(tool): add interfaces for tool surface shards | 2026-06-04 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->