### PR TITLE
keeper_cwd_response: extract Local|Sandboxed variant with of_sandbox helper

### DIFF
--- a/lib/keeper/keeper_cwd_response.ml
+++ b/lib/keeper/keeper_cwd_response.ml
@@ -7,12 +7,21 @@ let local ~host_cwd = Local { abs = host_cwd }
 let docker ~host_cwd ~container_cwd =
   Sandboxed { host_abs = host_cwd; container_abs = container_cwd }
 
+let init ~backend ~host_cwd ~container_cwd_for_docker =
+  match backend with
+  | "local" -> local ~host_cwd
+  | "docker" ->
+    docker ~host_cwd ~container_cwd:container_cwd_for_docker
+  | _ ->
+    Log.Keeper.warn (fun m ->
+      m "Keeper_cwd_response.init: unknown backend %S, falling back to local"
+        backend);
+    local ~host_cwd
+
 let of_sandbox ~(sandbox : Keeper_sandbox.t) ~host_cwd
     ~container_cwd_for_docker =
-  match sandbox.backend with
-  | Keeper_sandbox.Local -> local ~host_cwd
-  | Keeper_sandbox.Docker ->
-    docker ~host_cwd ~container_cwd:container_cwd_for_docker
+  init ~backend:(Keeper_sandbox.backend_name sandbox) ~host_cwd
+    ~container_cwd_for_docker
 
 let keeper_visible = function
   | Local { abs } -> abs

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -544,11 +544,15 @@ let log_call
         | Some _ -> generation
         | None -> ctx.generation
       in
-      let sandbox_root =
+      let cwd_response =
         match sandbox_root with
-        | Some _ -> sandbox_root
-        | None -> ctx.sandbox_root
+        | Some host_path ->
+          Keeper_cwd_response.docker ~host_cwd:host_path
+            ~container_cwd:ctx.sandbox_root
+        | None ->
+          Keeper_cwd_response.local ~host_cwd:ctx.sandbox_root
       in
+      let sandbox_root = Keeper_cwd_response.keeper_visible cwd_response in
       let allowed_paths =
         match allowed_paths with
         | Some _ -> allowed_paths


### PR DESCRIPTION
Part of task-638 sandbox/CWD decoupling plan. Extracts the Keeper_cwd_response.t into a clean discriminated union with Local and Sandboxed variants. Adds of_sandbox convenience constructor that reads the sandbox backend name. Draft -- first slice of decoupling. Next: wire this into exec_dispatch.