### PR TITLE
chore(keeper): remove zero-caller dead tool helpers

### DIFF
--- a/lib/keeper/keeper_tool_dispatch_runtime.mli
+++ b/lib/keeper/keeper_tool_dispatch_runtime.mli
@@ -75,9 +75,6 @@ val set_masc_schemas : Masc_domain.tool_schema list -> unit
 (** Immutable snapshot of injected MASC tool schemas. *)
 val masc_schemas_snapshot : unit -> Masc_domain.tool_schema list
 
-(** Scoped schema override for tests that need a synthetic MASC surface. *)
-val with_masc_schemas_for_test : Masc_domain.tool_schema list -> (unit -> 'a) -> 'a
-
 (** Injected masc_* tool names (populated at startup by [inject_masc_schemas]). *)
 val injected_masc_tool_names : unit -> string list
 

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -212,12 +212,6 @@ let keeper_supported_masc_tool_names_from_schemas schemas =
 let inject_masc_schemas (schemas : Masc_domain.tool_schema list) =
   set_masc_schemas (keeper_supported_masc_schemas schemas)
 
-let select_existing_masc_tool_names names =
-  let injected = injected_masc_tool_names () in
-  names
-  |> List.filter (fun name -> List.mem name injected)
-  |> dedupe_tool_names
-
 let is_keeper_maintenance_only_tool name =
   List.mem name (Keeper_tool_descriptor.keeper_maintenance_only_names ())
 

--- a/lib/keeper/keeper_tool_policy.mli
+++ b/lib/keeper/keeper_tool_policy.mli
@@ -44,8 +44,6 @@ val keeper_supported_masc_schemas :
 val keeper_supported_masc_tool_names_from_schemas :
   Masc_domain.tool_schema list -> string list
 
-(** Filter names to only those present in the injected MASC set. *)
-val select_existing_masc_tool_names : string list -> string list
 
 (** {1 Tool Surface Lookup}
 

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -277,15 +277,6 @@ let masc_schemas_snapshot () =
   Stdlib.Mutex.protect masc_schemas_mutex (fun () -> !masc_schemas_state)
 ;;
 
-let with_masc_schemas_for_test schemas f =
-  let previous = masc_schemas_snapshot () in
-  Eio_guard.protect
-    ~finally:(fun () -> set_masc_schemas previous)
-    (fun () ->
-       set_masc_schemas schemas;
-       f ())
-;;
-
 let injected_masc_tool_names () =
   masc_schemas_snapshot ()
   |> List.map (fun (schema : Masc_domain.tool_schema) -> schema.name)

--- a/lib/keeper/keeper_tool_registry.mli
+++ b/lib/keeper/keeper_tool_registry.mli
@@ -78,10 +78,6 @@ val set_masc_schemas : Masc_domain.tool_schema list -> unit
 (** Immutable snapshot of injected MASC tool schemas. *)
 val masc_schemas_snapshot : unit -> Masc_domain.tool_schema list
 
-(** Scoped schema override for tests that need a synthetic MASC surface. *)
-val with_masc_schemas_for_test :
-  Masc_domain.tool_schema list -> (unit -> 'a) -> 'a
-
 (** Names extracted from [masc_schemas_snapshot ()] in declaration order. *)
 val injected_masc_tool_names : unit -> string list
 


### PR DESCRIPTION
chore(keeper): remove zero-caller dead tool helpers

Two helpers in the keeper tool-surface path have no runtime consumers; they
survived only because each .mli re-declared them (suppressing OCaml's
unused-value warning). Found by a read-only audit of the tool-surface
assembly path (the same path that hid the #19864 WebSearch prune).

- with_masc_schemas_for_test (keeper_tool_registry.ml): a test backdoor that
  swaps the global masc_schemas_state ref - zero callers, not even a test.
  Removed from keeper_tool_registry.ml + keeper_tool_registry.mli +
  keeper_tool_dispatch_runtime.mli (re-exported via include Keeper_tool_registry).
- select_existing_masc_tool_names (keeper_tool_policy.ml): intersects a name
  list against the injected masc set - zero callers. Removed from
  keeper_tool_policy.ml + keeper_tool_policy.mli.

No behavior change (both were dead). Verified: dune build (default target)
clean; test_keeper_tool_policy_masc_surface passes.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
