### PR TITLE
fix(server): add masc.dashboard_tla_specs dep to masc_server (broken main)

### DIFF
--- a/lib/server/dune
+++ b/lib/server/dune
@@ -8,6 +8,11 @@
  (libraries
   masc
   masc.dashboard
+  ;; RFC-0056 #20086 extracted Dashboard_tla_specs out of the masc mega-lib into
+  ;; masc.dashboard_tla_specs; server_routes_http_routes_verification consumes it
+  ;; directly (specs_json / tlc_results_json) and dune does not re-export through
+  ;; the masc dep, so masc_server lists it explicitly.
+  masc.dashboard_tla_specs
   masc.masc_tool_surface
   masc.operator
   yojson


### PR DESCRIPTION
## 증상

`origin/main`(`a705e81c34`)이 빌드되지 않습니다:

```
File "lib/server/server_routes_http_routes_verification.ml", line 79:
  let json = Dashboard_tla_specs.tlc_results_json () in
Error: Unbound module Dashboard_tla_specs
```

## 근본 원인 — 두 PR의 조합 깨짐

각자 green이었으나 순차 머지 후 red가 된 케이스입니다.

- **#20086** (RFC-0056 Phase 1): `Dashboard_tla_specs`를 mega-lib `masc`에서 별도 sub-library `masc.dashboard_tla_specs`로 추출. 당시 main(`679471d5`)에선 `server_routes_http_routes_verification.ml`이 mega-lib 안에 있어, `lib/dune`에 추가한 dep으로 해소됨.
- **#20085**: `lib/server/`를 `masc_server` sub-library로 분리. caller(`server_routes`)가 mega-lib에서 `masc_server`로 이동.
- 조합: `masc_server`가 `Dashboard_tla_specs.specs_json` / `tlc_results_json`을 호출하는데, dune은 `masc` dep을 통해 모듈을 **transitively re-export하지 않으므로** `masc.dashboard_tla_specs`를 못 봄 → Unbound.

## Fix

`lib/server/dune`의 `(libraries)`에 `masc.dashboard_tla_specs`를 직접 추가. `masc_server`가 이미 `masc.dashboard` / `masc.operator` 등을 직접 나열하는 패턴과 동일.

## 검증

```
dune build @check --root .  →  EXIT=0, 0 errors
(직전: 1 error = Unbound module Dashboard_tla_specs)
```

RFC-WAIVED: broken-main build fix; `lib/server/dune`는 guarded subsystem(credential/operator_control/sandbox/hooks/workflow) 아님.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
