### PR TITLE
fix(keeper): refresh sandbox factory meta at resolve

### DIFF
--- a/lib/keeper/keeper_sandbox_factory.ml
+++ b/lib/keeper/keeper_sandbox_factory.ml
@@ -4,7 +4,7 @@ type t = {
   turn_id : int;
   default_network_override : Keeper_types_profile_sandbox.network_mode option;
   cache :
-    ((bool * string), Keeper_turn_sandbox_runtime.t) Hashtbl.t;
+    ((bool * string * string * string), Keeper_turn_sandbox_runtime.t) Hashtbl.t;
   mutex : Eio.Mutex.t;
 }
 
@@ -28,9 +28,19 @@ let normalize p =
   Keeper_alerting_path.normalize_path_for_check p
   |> strip_trailing_slashes
 
-let in_playground_of_cwd (t : t) ~cwd =
+let current_meta (t : t) =
+  match Keeper_registry.get ~base_path:t.config.base_path t.meta.name with
+  | Some entry -> entry.meta
+  | None -> t.meta
+
+let runtime_image (meta : Keeper_meta_contract.keeper_meta) =
+  match meta.sandbox_image with
+  | Some img when String.trim img <> "" -> img
+  | _ -> Env_config_sandbox.Runtime.docker_image ()
+
+let in_playground_of_cwd (t : t) ~meta ~cwd =
   let host_root =
-    Keeper_sandbox.host_root_abs_of_meta ~config:t.config t.meta
+    Keeper_sandbox.host_root_abs_of_meta ~config:t.config meta
     |> normalize
   in
   let cwd_norm = normalize cwd in
@@ -39,9 +49,10 @@ let in_playground_of_cwd (t : t) ~cwd =
 
 let resolve (t : t) ~cwd =
   with_lock t (fun () ->
-    let in_playground = in_playground_of_cwd t ~cwd in
+    let meta = current_meta t in
+    let in_playground = in_playground_of_cwd t ~meta ~cwd in
     let (effective_profile, effective_network) =
-      Keeper_sandbox_runner.effective_sandbox_profile ~meta:t.meta
+      Keeper_sandbox_runner.effective_sandbox_profile ~meta
     in
     let actual_network =
       Option.value t.default_network_override ~default:effective_network
@@ -49,8 +60,16 @@ let resolve (t : t) ~cwd =
     match effective_profile with
     | Keeper_types_profile_sandbox.Local -> None
     | Keeper_types_profile_sandbox.Docker ->
+      let host_root =
+        Keeper_sandbox.host_root_abs_of_meta ~config:t.config meta
+        |> normalize
+      in
+      let image = runtime_image meta in
       let key =
-        (in_playground, Keeper_types_profile_sandbox.network_mode_to_string actual_network)
+        ( in_playground
+        , Keeper_types_profile_sandbox.network_mode_to_string actual_network
+        , host_root
+        , image )
       in
       match Hashtbl.find_opt t.cache key with
       | Some r -> Some r
@@ -58,7 +77,7 @@ let resolve (t : t) ~cwd =
         let r =
           Keeper_turn_sandbox_runtime.create
             ~config:t.config
-            ~meta:t.meta
+            ~meta
             ~network_mode:actual_network
             ~turn_id:t.turn_id
             ()

--- a/lib/keeper/keeper_sandbox_factory.mli
+++ b/lib/keeper/keeper_sandbox_factory.mli
@@ -14,8 +14,11 @@
     [meta.sandbox_profile] eagerly at turn-start.  With the factory the
     runtime decision is evaluated per call site, never at turn-start, and
     the memo prevents the cold-start-every-call pattern that lingered after
-    PR-3.  The declared sandbox profile remains the execution contract:
-    [Local] resolves to [None] even when DockerPlayground is enabled.
+    PR-3.  Resolution also refreshes the keeper's current registry meta so
+    a turn-start factory cannot keep using stale sandbox fields after the
+    registry has reconciled TOML/runtime overlays.  The declared sandbox
+    profile remains the execution contract: [Local] resolves to [None] even
+    when DockerPlayground is enabled.
 
     The dependency on {!Keeper_sandbox_docker} stays acyclic:
     [keeper_sandbox_docker] only consumes [Keeper_turn_sandbox_runtime.t]
@@ -38,10 +41,12 @@ val resolve :
   cwd:string ->
   Keeper_turn_sandbox_runtime.t option
 (** Returns [Some runtime] when {!Keeper_sandbox_runner.effective_sandbox_profile}
-    yields [Docker]. [in_playground] is derived from [cwd] vs the
-    keeper's playground root for runtime workspace reuse only. Memoizes per
-    [(in_playground, network_mode)] so subsequent calls reuse the same
-    container. *)
+    yields [Docker] for the current registry meta, falling back to the
+    construction meta when the keeper is not registered. [in_playground] is
+    derived from [cwd] vs the keeper's playground root for runtime workspace
+    reuse only. Memoizes per [(in_playground, network_mode, host_root, image)]
+    so subsequent compatible calls reuse the same container without crossing
+    sandbox-profile or image drift. *)
 
 val resolve_opt :
   t option ->

--- a/scripts/gen-grpc-descriptors.sh
+++ b/scripts/gen-grpc-descriptors.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 PROTO_DIR="${REPO_ROOT}/proto"
-TARGET_ML="${REPO_ROOT}/lib/grpc/masc_grpc_server.ml"
+TARGET_ML="${REPO_ROOT}/lib/server/masc_grpc_server.ml"
 
 check_protoc() {
   if ! command -v protoc &>/dev/null; then

--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -232,6 +232,30 @@ let with_turn_sandbox_factory ~config ~meta f =
   Fun.protect ~finally:(fun () -> Keeper_sandbox_factory.cleanup factory) @@ fun () ->
   f factory
 
+let test_turn_sandbox_factory_uses_refreshed_registry_meta () =
+  setup ~sandbox:Keeper_types_profile_sandbox.Local
+  @@ fun ~config ~meta ~playground:_ ->
+  let docker_meta =
+    { meta with
+      Keeper_meta_contract.sandbox_profile = Keeper_types_profile_sandbox.Docker
+    }
+  in
+  let factory = Keeper_sandbox_factory.create ~config ~meta () in
+  ignore (Keeper_registry.register ~base_path:config.Workspace.base_path meta.name docker_meta);
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_sandbox_factory.cleanup factory;
+      Keeper_registry.unregister ~base_path:config.Workspace.base_path meta.name)
+  @@ fun () ->
+  let docker_playground = Keeper_sandbox.host_root_abs_of_meta ~config docker_meta in
+  match Keeper_sandbox_factory.resolve factory ~cwd:docker_playground with
+  | None -> Alcotest.fail "expected refreshed registry Docker meta to resolve a turn runtime"
+  | Some runtime ->
+    Alcotest.(check string)
+      "runtime host root follows refreshed Docker meta"
+      (Keeper_alerting_path.normalize_path_for_check_stripped docker_playground)
+      (Keeper_turn_sandbox_runtime.host_root runtime)
+
 let with_fake_docker script f =
   let dir = temp_dir () in
   let docker_path = Filename.concat dir "docker" in
@@ -2032,6 +2056,9 @@ let () =
           Alcotest.test_case
             "turn sandbox file writes use bind-mounted host path"
             `Quick test_turn_sandbox_file_write_uses_host_bind_mount;
+          Alcotest.test_case
+            "turn sandbox factory uses refreshed registry meta"
+            `Quick test_turn_sandbox_factory_uses_refreshed_registry_meta;
           Alcotest.test_case
             "tool_execute typed pipeline uses local shell ir dispatch"
             `Quick test_execute_typed_pipeline_uses_local_shell_ir_dispatch;


### PR DESCRIPTION
## Summary

- Refresh `Keeper_sandbox_factory` against the current keeper registry meta at resolve time.
- Expand the turn-runtime cache key with host root and image so reused runtimes do not cross sandbox/image drift.
- Add a Docker-route regression test for a turn-start Local factory after registry meta refreshes to Docker.
- Repair the gRPC descriptor lint script target after `masc_grpc_server.ml` moved to `lib/server/`.

## Root Cause

The tool dispatch path refreshes keeper meta from `Keeper_registry` before executing a tool, but the turn sandbox factory was created earlier and kept the old meta. If the old factory meta resolved as Local while the refreshed dispatch meta resolved as Docker, typed Shell IR selected Docker dispatch and then the factory returned `None`, surfacing `typed Shell IR Docker dispatch requires a turn sandbox factory`.

The first CI run also exposed a stale lint-script path: `scripts/gen-grpc-descriptors.sh --check` still read `lib/grpc/masc_grpc_server.ml`, while the actual descriptor source now lives in `lib/server/masc_grpc_server.ml`.

## Validation

- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_sandbox_docker_route.exe`
- `_build/default/test/test_keeper_sandbox_docker_route.exe test --color=never --show-errors docker_route_contract 3`
- `scripts/gen-grpc-descriptors.sh --check`