### PR TITLE
fix(exec): keep git branch list readonly

### DIFF
--- a/lib/exec/shell_ir_risk.ml
+++ b/lib/exec/shell_ir_risk.ml
@@ -43,13 +43,56 @@ let is_destructive e = e.risk = Destructive_protected
 
 (* --- Write sub-classification --------------------------------------- *)
 
+let is_short_option arg = String.length arg > 1 && arg.[0] = '-' && arg.[1] <> '-'
+let has_short_flag flag arg = is_short_option arg && String.contains arg flag
+
+let is_eq_flag flag arg =
+  String.equal arg flag || String.starts_with ~prefix:(flag ^ "=") arg
+;;
+
+let git_branch_has_flag flags args =
+  List.exists
+    (fun arg ->
+       List.exists
+         (fun flag ->
+            if String.length flag = 2 && flag.[0] = '-'
+            then has_short_flag flag.[1] arg
+            else is_eq_flag flag arg)
+         flags)
+    args
+;;
+
+let git_branch_args_are_read_only args =
+  let mutating_flags =
+    [ "-d"; "-D"; "--delete"; "-m"; "-M"; "--move"; "-c"; "-C"; "--copy"
+    ; "-f"; "--force"; "-u"; "--set-upstream-to"; "--unset-upstream"
+    ; "--track"; "--no-track"; "--edit-description"; "--create-reflog"
+    ]
+  in
+  let read_flags =
+    [ "-l"; "--list"; "-a"; "--all"; "-r"; "--remotes"; "--show-current"
+    ; "-v"; "--contains"; "--no-contains"; "--merged"; "--no-merged"
+    ; "--points-at"; "--format"; "--sort"; "--color"; "--no-color"; "--column"
+    ; "--no-column"; "--ignore-case"; "--abbrev"; "--no-abbrev"
+    ]
+  in
+  match args with
+  | [] -> true
+  | _ when git_branch_has_flag mutating_flags args -> false
+  | _ -> git_branch_has_flag read_flags args
+;;
+
 let classify_write_detail (words : string list) : risk_class option =
   match words with
-  | "git" :: sub :: _ ->
+  | "git" :: sub :: rest ->
     (match sub with
      | "push" | "merge" | "rebase" | "commit" -> Some R1_Reversible_mutation
      | "reset" -> Some R2_Irreversible
-     | "checkout" | "branch" | "tag" | "stash" | "clone" | "init" ->
+     | "branch" ->
+       if git_branch_args_are_read_only rest
+       then None
+       else Some R1_Reversible_mutation
+     | "checkout" | "tag" | "stash" | "clone" | "init" ->
        Some R1_Reversible_mutation
      | _ -> None)
   | ("npm" | "pnpm" | "yarn") :: _ -> Some R1_Reversible_mutation
@@ -283,11 +326,12 @@ let flat_stage_words (ir : Shell_ir.t) : string list =
 
 let is_write_operation (words : string list) =
   match words with
+  | "git" :: "branch" :: rest -> not (git_branch_args_are_read_only rest)
   | "git" :: sub :: _ ->
     List.mem
       sub
-      [ "push"; "commit"; "merge"; "rebase"; "reset"; "checkout"; "branch";
-        "tag"; "stash"; "clone"; "init" ]
+      [ "push"; "commit"; "merge"; "rebase"; "reset"; "checkout"; "tag";
+        "stash"; "clone"; "init" ]
   | "dune" :: sub :: _ -> List.mem sub [ "clean"; "promote" ]
   | "make" :: sub :: _ -> List.mem sub [ "clean"; "deploy"; "install"; "publish" ]
   | ("npm" | "pnpm" | "yarn") :: sub :: _ ->
@@ -318,9 +362,6 @@ let is_write_operation (words : string list) =
       ]
   | [] -> false
 ;;
-
-let is_short_option arg = String.length arg > 1 && arg.[0] = '-' && arg.[1] <> '-'
-let has_short_flag flag arg = is_short_option arg && String.contains arg flag
 
 let is_protected_branch_target arg =
   let target = String.lowercase_ascii arg in

--- a/lib/exec/shell_ir_risk.mli
+++ b/lib/exec/shell_ir_risk.mli
@@ -73,8 +73,10 @@ val classify_words : string list -> risk_class
 
 val is_write_operation : string list -> bool
 (** [true] when the flattened word list indicates a write-level operation:
-    git push/commit/merge/rebase/reset/checkout -c/-C/-m/-M/branch,
-    or non-git commands that touch state.
+    git push/commit/merge/rebase/reset/checkout, branch create/delete/rename,
+    or non-git commands that touch state. Read-only branch inspection
+    ([git branch], [git branch -a --list PATTERN], [git branch --show-current])
+    remains R0.
 
     Used by [Exec_policy_mutation_classifier.is_write_operation] for
     the IR-typed entry point. *)

--- a/lib/exec/test/test_shell_ir_risk.ml
+++ b/lib/exec/test/test_shell_ir_risk.ml
@@ -45,6 +45,8 @@ let test_classify_read () =
   let cmds =
     [ simple_ir "ls" []; simple_ir "cat" [ "file.txt" ]; simple_ir "rg" [ "pattern" ];
       simple_ir "git" [ "status" ]; simple_ir "git" [ "log"; "--oneline" ];
+      simple_ir "git" [ "branch"; "-a"; "--list"; "*20083*" ];
+      simple_ir "git" [ "branch"; "--show-current" ];
       simple_ir "gh" [ "pr"; "view"; "123" ]; simple_ir "gh" [ "issue"; "list" ];
       simple_ir "echo" [ "hello" ]; simple_ir "pwd" [] ]
   in
@@ -64,6 +66,9 @@ let test_classify_write_r1 () =
     [ simple_ir "git" [ "commit"; "-m"; "msg" ];
       simple_ir "git" [ "push" ];
       simple_ir "git" [ "checkout"; "-b"; "feature" ];
+      simple_ir "git" [ "branch"; "new-branch" ];
+      simple_ir "git" [ "branch"; "-d"; "old-branch" ];
+      simple_ir "git" [ "branch"; "-m"; "old"; "new" ];
       simple_ir "npm" [ "install" ];
       simple_ir "mkdir" [ "dir" ];
       simple_ir "touch" [ "file" ] ]

--- a/test/test_shell_ir_risk.ml
+++ b/test/test_shell_ir_risk.ml
@@ -38,6 +38,8 @@ let test_r0_read_commands () =
   check "rg pattern lib/" Shell_ir_risk.R0_Read;
   check "git status" Shell_ir_risk.R0_Read;
   check "git log --oneline -5" Shell_ir_risk.R0_Read;
+  check "git branch -a --list '*20083*'" Shell_ir_risk.R0_Read;
+  check "git branch --show-current" Shell_ir_risk.R0_Read;
   check "gh pr view 123" Shell_ir_risk.R0_Read;
   check "dune build" Shell_ir_risk.R0_Read;
   check "npm run build" Shell_ir_risk.R0_Read
@@ -54,6 +56,9 @@ let test_r1_reversible_commands () =
   check "git push origin main" Shell_ir_risk.R1_Reversible_mutation;
   check "git commit -m msg" Shell_ir_risk.R1_Reversible_mutation;
   check "git checkout branch" Shell_ir_risk.R1_Reversible_mutation;
+  check "git branch new-branch" Shell_ir_risk.R1_Reversible_mutation;
+  check "git branch -d old-branch" Shell_ir_risk.R1_Reversible_mutation;
+  check "git branch -m old new" Shell_ir_risk.R1_Reversible_mutation;
   check "dune clean" Shell_ir_risk.R1_Reversible_mutation;
   check "make test" Shell_ir_risk.R1_Reversible_mutation;
   check "make install" Shell_ir_risk.R1_Reversible_mutation;


### PR DESCRIPTION
## Summary

- Keep read-only `git branch` inspection commands at `R0_Read` in Shell IR risk classification.
- Preserve `git branch` create/delete/rename and force/upstream mutations as `R1_Reversible_mutation`.
- Cover the Keeper false-positive case: `git branch -a --list '*20083*'`.

## Product impact

Keeper can inspect branches while using the typed Execute surface without being blocked by `write_operation_gated`. Branch mutation commands still require a write-capable Execute surface.

## Evidence

- `git diff --check`
- `ocamlformat --check lib/exec/shell_ir_risk.ml lib/exec/shell_ir_risk.mli lib/exec/test/test_shell_ir_risk.ml test/test_shell_ir_risk.ml`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build lib/exec/test/test_shell_ir_risk.exe test/test_shell_ir_risk.exe`
- `./_build/default/lib/exec/test/test_shell_ir_risk.exe`
- `./_build/default/test/test_shell_ir_risk.exe`

## Direct evidence

schema_version: 1
direct_ratio: 5/5
provenance: direct

- Directly inspected `lib/exec/shell_ir_risk.ml`.
- Directly patched the legacy write floor for `git branch` read-only forms.
- Directly ran focused build and test binaries in the PR worktree.

## Review evidence

- Self-reviewed the diff for command boundary behavior: read-only branch inspection remains R0; branch mutations remain R1.
- Added regression coverage in both Shell IR risk test surfaces.

## Linked issue

- None.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`fix/git-branch-list-readonly-20260604` → `main` · 1 commit(s) · synced 2026-06-04T11:48:19Z

| sha | subject | date |
|---|---|---|
| `3e364d906` | fix(exec): keep git branch list readonly | 2026-06-04 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->