### PR TITLE
feat(exec): add Shell IR oracle fixture contract

### DIFF
--- a/lib/exec/shell_ir_oracle.ml
+++ b/lib/exec/shell_ir_oracle.ml
@@ -1,0 +1,251 @@
+type parse_status =
+  | Parsed_ok
+  | Parse_error
+  | Incomplete
+  | Timeout
+  | Unavailable
+
+let parse_status_of_string = function
+  | "ok" -> Ok Parsed_ok
+  | "parse_error" -> Ok Parse_error
+  | "incomplete" -> Ok Incomplete
+  | "timeout" -> Ok Timeout
+  | "unavailable" -> Ok Unavailable
+  | other -> Error (Printf.sprintf "unknown parse_status: %s" other)
+;;
+
+let string_of_parse_status = function
+  | Parsed_ok -> "ok"
+  | Parse_error -> "parse_error"
+  | Incomplete -> "incomplete"
+  | Timeout -> "timeout"
+  | Unavailable -> "unavailable"
+;;
+
+type features = {
+  pipeline : bool;
+  redirect : bool;
+  heredoc : bool;
+  subshell : bool;
+  command_substitution : bool;
+  variable : bool;
+  glob : bool;
+  env_assignment : bool;
+  process_substitution : bool;
+  unknown_enabled : string list;
+}
+
+type command = {
+  name : string;
+  argv : string list;
+}
+
+type t = {
+  schema_version : int;
+  parser : string option;
+  command : string;
+  parse_status : parse_status;
+  features : features;
+  commands : command list;
+  error : string option;
+}
+
+let ( let* ) = Result.bind
+
+let assoc_opt key = function
+  | `Assoc fields -> List.assoc_opt key fields
+  | _ -> None
+;;
+
+let require_field key json =
+  match assoc_opt key json with
+  | Some value -> Ok value
+  | None -> Error (Printf.sprintf "missing field: %s" key)
+;;
+
+let require_int key json =
+  let* value = require_field key json in
+  match value with
+  | `Int n -> Ok n
+  | _ -> Error (Printf.sprintf "%s must be int" key)
+;;
+
+let require_string key json =
+  let* value = require_field key json in
+  match value with
+  | `String s -> Ok s
+  | _ -> Error (Printf.sprintf "%s must be string" key)
+;;
+
+let optional_string key json =
+  match assoc_opt key json with
+  | None | Some `Null -> Ok None
+  | Some (`String s) -> Ok (Some s)
+  | Some _ -> Error (Printf.sprintf "%s must be string or null" key)
+;;
+
+let string_list key json =
+  let* value = require_field key json in
+  match value with
+  | `List items ->
+    let rec loop acc = function
+      | [] -> Ok (List.rev acc)
+      | `String s :: rest -> loop (s :: acc) rest
+      | _ :: _ -> Error (Printf.sprintf "%s must contain only strings" key)
+    in
+    loop [] items
+  | _ -> Error (Printf.sprintf "%s must be string array" key)
+;;
+
+let known_feature_names =
+  [ "pipeline"
+  ; "redirect"
+  ; "heredoc"
+  ; "subshell"
+  ; "command_substitution"
+  ; "variable"
+  ; "glob"
+  ; "env_assignment"
+  ; "process_substitution"
+  ]
+;;
+
+let feature_bool fields key =
+  match List.assoc_opt key fields with
+  | None -> Ok false
+  | Some (`Bool b) -> Ok b
+  | Some _ -> Error (Printf.sprintf "features.%s must be bool" key)
+;;
+
+let parse_features json =
+  let* value = require_field "features" json in
+  match value with
+  | `Assoc fields ->
+    let unknown_enabled =
+      List.filter_map
+        (fun (key, value) ->
+           if List.mem key known_feature_names then None
+           else
+             match value with
+             | `Bool true -> Some key
+             | _ -> None)
+        fields
+    in
+    let* pipeline = feature_bool fields "pipeline" in
+    let* redirect = feature_bool fields "redirect" in
+    let* heredoc = feature_bool fields "heredoc" in
+    let* subshell = feature_bool fields "subshell" in
+    let* command_substitution = feature_bool fields "command_substitution" in
+    let* variable = feature_bool fields "variable" in
+    let* glob = feature_bool fields "glob" in
+    let* env_assignment = feature_bool fields "env_assignment" in
+    let* process_substitution = feature_bool fields "process_substitution" in
+    Ok
+      { pipeline
+      ; redirect
+      ; heredoc
+      ; subshell
+      ; command_substitution
+      ; variable
+      ; glob
+      ; env_assignment
+      ; process_substitution
+      ; unknown_enabled
+      }
+  | _ -> Error "features must be object"
+;;
+
+let command_of_yojson = function
+  | `Assoc _ as json ->
+    let* name = require_string "name" json in
+    let* argv = string_list "argv" json in
+    Ok { name; argv }
+  | _ -> Error "commands entries must be objects"
+;;
+
+let commands_of_yojson json =
+  let* value = require_field "commands" json in
+  match value with
+  | `List items ->
+    let rec loop acc = function
+      | [] -> Ok (List.rev acc)
+      | item :: rest ->
+        let* command = command_of_yojson item in
+        loop (command :: acc) rest
+    in
+    loop [] items
+  | _ -> Error "commands must be an array"
+;;
+
+let of_yojson json =
+  let* schema_version = require_int "schema_version" json in
+  let* parser = optional_string "parser" json in
+  let* command = require_string "command" json in
+  let* parse_status_raw = require_string "parse_status" json in
+  let* parse_status = parse_status_of_string parse_status_raw in
+  let* features = parse_features json in
+  let* commands = commands_of_yojson json in
+  let* error = optional_string "error" json in
+  Ok { schema_version; parser; command; parse_status; features; commands; error }
+;;
+
+let of_string raw =
+  try Yojson.Safe.from_string raw |> of_yojson with
+  | Yojson.Json_error msg -> Error (Printf.sprintf "invalid JSON: %s" msg)
+;;
+
+let feature_names t =
+  let f = t.features in
+  [ "pipeline", f.pipeline
+  ; "redirect", f.redirect
+  ; "heredoc", f.heredoc
+  ; "subshell", f.subshell
+  ; "command_substitution", f.command_substitution
+  ; "variable", f.variable
+  ; "glob", f.glob
+  ; "env_assignment", f.env_assignment
+  ; "process_substitution", f.process_substitution
+  ]
+  |> List.filter_map (fun (name, enabled) -> if enabled then Some name else None)
+  |> fun known -> known @ List.map (fun name -> "unknown:" ^ name) f.unknown_enabled
+;;
+
+let syntax_blockers t =
+  let f = t.features in
+  [ "redirect", f.redirect
+  ; "heredoc", f.heredoc
+  ; "subshell", f.subshell
+  ; "command_substitution", f.command_substitution
+  ; "env_assignment", f.env_assignment
+  ; "process_substitution", f.process_substitution
+  ]
+  |> List.filter_map (fun (name, enabled) -> if enabled then Some name else None)
+  |> fun known -> known @ List.map (fun name -> "unknown:" ^ name) f.unknown_enabled
+;;
+
+let descriptor_parity_blockers t =
+  match t.parse_status with
+  | Parsed_ok -> syntax_blockers t
+  | (Parse_error | Incomplete | Timeout | Unavailable) as status ->
+    [ "parse_status=" ^ string_of_parse_status status ]
+;;
+
+let read_only_descriptor_compatible t =
+  match descriptor_parity_blockers t with
+  | [] -> Ok ()
+  | blockers ->
+    Error
+      (Printf.sprintf
+         "read-only descriptor incompatible with oracle facts: %s"
+         (String.concat "," blockers))
+;;
+
+let syntax_floor t =
+  match t.parse_status with
+  | Parsed_ok ->
+    if syntax_blockers t = []
+    then Shell_ir_risk.R0_Read
+    else Shell_ir_risk.R1_Reversible_mutation
+  | Parse_error | Incomplete | Timeout | Unavailable ->
+    Shell_ir_risk.Destructive_protected
+;;

--- a/lib/exec/shell_ir_oracle.mli
+++ b/lib/exec/shell_ir_oracle.mli
@@ -1,0 +1,57 @@
+(** Shell_ir_oracle — parser-oracle fact subset for Shell IR hardening.
+
+    This module is intentionally data-only.  A non-production sidecar can
+    emit this JSON shape from a real shell parser, while OCaml owns policy,
+    descriptor parity, risk floors, and receipts. *)
+
+type parse_status =
+  | Parsed_ok
+  | Parse_error
+  | Incomplete
+  | Timeout
+  | Unavailable
+
+val parse_status_of_string : string -> (parse_status, string) result
+val string_of_parse_status : parse_status -> string
+
+type features = {
+  pipeline : bool;
+  redirect : bool;
+  heredoc : bool;
+  subshell : bool;
+  command_substitution : bool;
+  variable : bool;
+  glob : bool;
+  env_assignment : bool;
+  process_substitution : bool;
+  unknown_enabled : string list;
+}
+
+type command = {
+  name : string;
+  argv : string list;
+}
+
+type t = {
+  schema_version : int;
+  parser : string option;
+  command : string;
+  parse_status : parse_status;
+  features : features;
+  commands : command list;
+  error : string option;
+}
+
+val of_yojson : Yojson.Safe.t -> (t, string) result
+val of_string : string -> (t, string) result
+val feature_names : t -> string list
+
+val descriptor_parity_blockers : t -> string list
+(** Features that a read-only descriptor must not silently ignore.
+    Non-[Parsed_ok] parser status is also a blocker. *)
+
+val read_only_descriptor_compatible : t -> (unit, string) result
+val syntax_floor : t -> Shell_ir_risk.risk_class
+(** Conservative oracle-derived syntax floor.  This is not final policy:
+    it exists so differential tests can prove parser facts never lower
+    the existing Shell IR decision. *)

--- a/lib/exec/shell_ir_risk.ml
+++ b/lib/exec/shell_ir_risk.ml
@@ -668,13 +668,31 @@ let risk_rank = function
 
 let max_risk a b = if risk_rank a >= risk_rank b then a else b
 
+let redirect_risk = function
+  | Redirect_scope.File { mode = (Redirect_scope.Write | Redirect_scope.Append); _ } ->
+    R1_Reversible_mutation
+  | Redirect_scope.File { mode = Redirect_scope.Read; _ }
+  | Redirect_scope.Fd_to_fd _ ->
+    R0_Read
+;;
+
+let redirect_floor redirects =
+  List.fold_left
+    (fun acc redirect -> max_risk acc (redirect_risk redirect))
+    R0_Read
+    redirects
+;;
+
 (* Per-[Simple] decision: the stricter of the typed-shape opinion and
    the word-list floor for that single command. Both opinions are scoped
    to one command's own words, so a pipeline can compose them stage by
    stage instead of flattening every stage into one head-anchored list.
    When [literal_words_of_simple] returns [None] (env/redirect/$VAR present)
    the word-list floor cannot be computed and falls back to [R0_Read];
-   the typed opinion still supplies escalation for those cases. *)
+   the typed opinion still supplies escalation for those cases. Redirect
+   writes are command syntax rather than argv tokens, so they get their
+   own floor here; otherwise [echo hi > file] can remain R0 in receipts
+   even though capability policy correctly sees [Write_path]. *)
 let decision_of_simple (s : Shell_ir.simple) : risk_class =
   let typed = risk_of_typed (Shell_ir_typed.of_simple s) in
   let floor =
@@ -682,7 +700,7 @@ let decision_of_simple (s : Shell_ir.simple) : risk_class =
     | Some words -> classify_words words
     | None -> R0_Read
   in
-  max_risk typed floor
+  max_risk (redirect_floor s.redirects) (max_risk typed floor)
 ;;
 
 (* RFC-0208 P0: compose the per-stage decision across a pipeline with

--- a/lib/exec/shell_ir_risk.mli
+++ b/lib/exec/shell_ir_risk.mli
@@ -34,7 +34,8 @@ val classify : undecided t -> decided decided_ir
 (** Run the unified risk classifier over the wrapped IR.
     Uses [Exec_policy_mutation_classifier] for bash operations,
     then repo-hosting CLI subcommand tables for ["gh"] command operations,
-    defaulting to R0.
+    defaulting to R0. Write/append redirects add an R1 syntax floor because
+    redirects are not argv tokens and must not disappear from receipts.
 
     [Simple] commands are lowered to the [Shell_ir_typed] GADT and
     classified by [risk_of_typed]; the [Generic] escape hatch falls back

--- a/lib/exec/test/dune
+++ b/lib/exec/test/dune
@@ -9,7 +9,9 @@
         test_shell_ir_risk_repo_hosting_cli_stress
         test_shell_ir_typed_e2e
         test_shell_ir_differential
+        test_shell_ir_oracle
         test_exec_gate_env_wrapper
         test_shell_ir_risk_action_flags)
  (libraries masc_exec masc_exec_bash_parser masc_exec_command_gate masc_process
-            masc_core masc_config alcotest eio eio_main yojson unix re))
+            masc_core masc_config alcotest eio eio_main yojson unix re)
+ (deps (glob_files fixtures/shell_ir_oracle/*.json)))

--- a/lib/exec/test/fixtures/shell_ir_oracle/heredoc.json
+++ b/lib/exec/test/fixtures/shell_ir_oracle/heredoc.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "parser": "mvdan-sh-syntax-prototype",
+  "command": "cat <<EOF\nhello\nEOF",
+  "parse_status": "ok",
+  "features": {
+    "pipeline": false,
+    "redirect": false,
+    "heredoc": true,
+    "subshell": false,
+    "command_substitution": false,
+    "variable": false,
+    "glob": false,
+    "env_assignment": false,
+    "process_substitution": false
+  },
+  "commands": [
+    { "name": "cat", "argv": ["cat"] }
+  ],
+  "error": null
+}

--- a/lib/exec/test/fixtures/shell_ir_oracle/parse_error.json
+++ b/lib/exec/test/fixtures/shell_ir_oracle/parse_error.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "parser": "mvdan-sh-syntax-prototype",
+  "command": "echo \"unterminated",
+  "parse_status": "parse_error",
+  "features": {
+    "pipeline": false,
+    "redirect": false,
+    "heredoc": false,
+    "subshell": false,
+    "command_substitution": false,
+    "variable": false,
+    "glob": false,
+    "env_assignment": false,
+    "process_substitution": false
+  },
+  "commands": [],
+  "error": "unterminated quoted string"
+}

--- a/lib/exec/test/fixtures/shell_ir_oracle/pipeline.json
+++ b/lib/exec/test/fixtures/shell_ir_oracle/pipeline.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 1,
+  "parser": "mvdan-sh-syntax-prototype",
+  "command": "cat file.txt | wc -l",
+  "parse_status": "ok",
+  "features": {
+    "pipeline": true,
+    "redirect": false,
+    "heredoc": false,
+    "subshell": false,
+    "command_substitution": false,
+    "variable": false,
+    "glob": false,
+    "env_assignment": false,
+    "process_substitution": false
+  },
+  "commands": [
+    { "name": "cat", "argv": ["cat", "file.txt"] },
+    { "name": "wc", "argv": ["wc", "-l"] }
+  ],
+  "error": null
+}

--- a/lib/exec/test/fixtures/shell_ir_oracle/redirect_write.json
+++ b/lib/exec/test/fixtures/shell_ir_oracle/redirect_write.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "parser": "mvdan-sh-syntax-prototype",
+  "command": "echo hello > out.txt",
+  "parse_status": "ok",
+  "features": {
+    "pipeline": false,
+    "redirect": true,
+    "heredoc": false,
+    "subshell": false,
+    "command_substitution": false,
+    "variable": false,
+    "glob": false,
+    "env_assignment": false,
+    "process_substitution": false
+  },
+  "commands": [
+    { "name": "echo", "argv": ["echo", "hello"] }
+  ],
+  "error": null
+}

--- a/lib/exec/test/fixtures/shell_ir_oracle/simple.json
+++ b/lib/exec/test/fixtures/shell_ir_oracle/simple.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "parser": "mvdan-sh-syntax-prototype",
+  "command": "echo hello",
+  "parse_status": "ok",
+  "features": {
+    "pipeline": false,
+    "redirect": false,
+    "heredoc": false,
+    "subshell": false,
+    "command_substitution": false,
+    "variable": false,
+    "glob": false,
+    "env_assignment": false,
+    "process_substitution": false
+  },
+  "commands": [
+    { "name": "echo", "argv": ["echo", "hello"] }
+  ],
+  "error": null
+}

--- a/lib/exec/test/fixtures/shell_ir_oracle/unknown_feature.json
+++ b/lib/exec/test/fixtures/shell_ir_oracle/unknown_feature.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 1,
+  "parser": "mvdan-sh-syntax-prototype",
+  "command": "echo hello",
+  "parse_status": "ok",
+  "features": {
+    "pipeline": false,
+    "redirect": false,
+    "heredoc": false,
+    "subshell": false,
+    "command_substitution": false,
+    "variable": false,
+    "glob": false,
+    "env_assignment": false,
+    "process_substitution": false,
+    "future_feature": true
+  },
+  "commands": [
+    { "name": "echo", "argv": ["echo", "hello"] }
+  ],
+  "error": null
+}

--- a/lib/exec/test/test_shell_ir_oracle.ml
+++ b/lib/exec/test/test_shell_ir_oracle.ml
@@ -1,0 +1,148 @@
+module IR = Masc_exec.Shell_ir
+module Oracle = Masc_exec.Shell_ir_oracle
+module Risk = Masc_exec.Shell_ir_risk
+
+let fixture_path name =
+  let rel = "fixtures/shell_ir_oracle/" ^ name ^ ".json" in
+  if Sys.file_exists rel then rel else "lib/exec/test/" ^ rel
+;;
+
+let load name =
+  match Yojson.Safe.from_file (fixture_path name) |> Oracle.of_yojson with
+  | Ok facts -> facts
+  | Error msg -> Alcotest.failf "%s: %s" name msg
+;;
+
+let contains_substring haystack needle =
+  let hay_len = String.length haystack in
+  let needle_len = String.length needle in
+  let rec loop i =
+    if i + needle_len > hay_len then false
+    else if String.sub haystack i needle_len = needle then true
+    else loop (i + 1)
+  in
+  needle_len = 0 || loop 0
+;;
+
+let bin s = Result.get_ok (Masc_exec.Exec_program.of_string s)
+let lit s = IR.Lit (s, IR.default_meta)
+
+let simple ?(redirects = []) bin_str args =
+  IR.Simple
+    { IR.bin = bin bin_str
+    ; args = List.map lit args
+    ; env = []
+    ; cwd = None
+    ; redirects
+    ; sandbox = Masc_exec.Sandbox_target.host ()
+    }
+;;
+
+let write_redirect raw =
+  let target = Masc_exec.Path_scope.classify ~raw ~cwd:"/tmp" in
+  Masc_exec.Redirect_scope.File
+    { fd = 1; target; mode = Masc_exec.Redirect_scope.Write }
+;;
+
+let test_simple_fixture () =
+  let facts = load "simple" in
+  Alcotest.(check int) "schema" 1 facts.Oracle.schema_version;
+  Alcotest.(check string) "command" "echo hello" facts.command;
+  Alcotest.(check string) "status" "ok"
+    (Oracle.string_of_parse_status facts.parse_status);
+  Alcotest.(check (list string)) "features" [] (Oracle.feature_names facts);
+  Alcotest.(check string) "syntax floor" "R0"
+    (Risk.string_of_risk_class (Oracle.syntax_floor facts));
+  Alcotest.(check bool) "read-only compatible" true
+    (Result.is_ok (Oracle.read_only_descriptor_compatible facts));
+  match facts.commands with
+  | [ cmd ] ->
+    Alcotest.(check string) "name" "echo" cmd.Oracle.name;
+    Alcotest.(check (list string)) "argv" [ "echo"; "hello" ] cmd.argv
+  | _ -> Alcotest.fail "expected one command"
+;;
+
+let test_pipeline_fixture () =
+  let facts = load "pipeline" in
+  Alcotest.(check (list string)) "features" [ "pipeline" ] (Oracle.feature_names facts);
+  Alcotest.(check string) "syntax floor" "R0"
+    (Risk.string_of_risk_class (Oracle.syntax_floor facts));
+  Alcotest.(check bool) "pipeline alone is read-only compatible" true
+    (Result.is_ok (Oracle.read_only_descriptor_compatible facts))
+;;
+
+let test_redirect_fixture_blocks_read_only () =
+  let facts = load "redirect_write" in
+  Alcotest.(check (list string)) "features" [ "redirect" ] (Oracle.feature_names facts);
+  Alcotest.(check string) "syntax floor" "R1"
+    (Risk.string_of_risk_class (Oracle.syntax_floor facts));
+  match Oracle.read_only_descriptor_compatible facts with
+  | Ok () -> Alcotest.fail "redirect must block read-only descriptor parity"
+  | Error msg ->
+    Alcotest.(check bool) "mentions redirect" true (contains_substring msg "redirect")
+;;
+
+let test_heredoc_fixture_blocks_read_only () =
+  let facts = load "heredoc" in
+  Alcotest.(check (list string)) "features" [ "heredoc" ] (Oracle.feature_names facts);
+  Alcotest.(check string) "syntax floor" "R1"
+    (Risk.string_of_risk_class (Oracle.syntax_floor facts));
+  match Oracle.read_only_descriptor_compatible facts with
+  | Ok () -> Alcotest.fail "heredoc must block read-only descriptor parity"
+  | Error msg ->
+    Alcotest.(check bool) "mentions heredoc" true (contains_substring msg "heredoc")
+;;
+
+let test_parse_error_fixture_fails_closed () =
+  let facts = load "parse_error" in
+  Alcotest.(check string) "status" "parse_error"
+    (Oracle.string_of_parse_status facts.parse_status);
+  Alcotest.(check string) "syntax floor" "Destructive_protected"
+    (Risk.string_of_risk_class (Oracle.syntax_floor facts));
+  match Oracle.read_only_descriptor_compatible facts with
+  | Ok () -> Alcotest.fail "parse error must fail closed"
+  | Error msg ->
+    Alcotest.(check bool) "mentions status" true (contains_substring msg "parse_status")
+;;
+
+let test_unknown_feature_fails_closed () =
+  let facts = load "unknown_feature" in
+  Alcotest.(check (list string)) "features" [ "unknown:future_feature" ]
+    (Oracle.feature_names facts);
+  match Oracle.read_only_descriptor_compatible facts with
+  | Ok () -> Alcotest.fail "unknown enabled feature must fail closed"
+  | Error msg ->
+    Alcotest.(check bool) "mentions unknown" true
+      (contains_substring msg "unknown:future_feature")
+;;
+
+let test_write_redirect_adds_shell_ir_risk_floor () =
+  let ir = simple ~redirects:[ write_redirect "out.txt" ] "echo" [ "hello" ] in
+  let decided = Risk.classify (Risk.undecided ir) in
+  Alcotest.(check string) "echo > file is R1" "R1"
+    (Risk.string_of_risk_class decided.Risk.risk)
+;;
+
+let test_read_redirect_stays_r0 () =
+  let target = Masc_exec.Path_scope.classify ~raw:"in.txt" ~cwd:"/tmp" in
+  let redirect =
+    Masc_exec.Redirect_scope.File
+      { fd = 0; target; mode = Masc_exec.Redirect_scope.Read }
+  in
+  let ir = simple ~redirects:[ redirect ] "cat" [] in
+  let decided = Risk.classify (Risk.undecided ir) in
+  Alcotest.(check string) "cat < file stays R0" "R0"
+    (Risk.string_of_risk_class decided.Risk.risk)
+;;
+
+let () =
+  test_simple_fixture ();
+  test_pipeline_fixture ();
+  test_redirect_fixture_blocks_read_only ();
+  test_heredoc_fixture_blocks_read_only ();
+  test_parse_error_fixture_fails_closed ();
+  test_unknown_feature_fails_closed ();
+  test_write_redirect_adds_shell_ir_risk_floor ();
+  test_read_redirect_stays_r0 ();
+  print_endline "test_shell_ir_oracle: oracle contract passed"
+;;


### PR DESCRIPTION
## Summary

Adds a data-only Shell IR parser-oracle contract for future sidecar fixtures and pins the first fixture corpus in `masc_exec`.

Also raises Shell IR risk classification for write/append redirects to R1 so redirect writes cannot remain R0 in execution receipts.

## Product impact

- User-visible change: no UI change; execution/risk evidence becomes stricter for `echo ... > file` style Shell IR redirects.
- Runtime route change: none. The oracle module is fixture/contract-only in this PR.

## Evidence

- `ocamlformat --check lib/exec/test/test_shell_ir_oracle.ml lib/exec/shell_ir_oracle.ml lib/exec/shell_ir_oracle.mli lib/exec/shell_ir_risk.ml lib/exec/shell_ir_risk.mli`
- `jq -e . lib/exec/test/fixtures/shell_ir_oracle/*.json`
- `env MASC_DUNE_THROTTLE=0 MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_OPAM_LOCK=0 MASC_SKIP_OPAM_LOCK=1 MASC_SKIP_PIN_CHECK=1 MASC_SKIP_DEPS_CHECK=1 DUNE_LOCAL_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build lib/exec/test/test_shell_ir_oracle.exe`
- `_build/default/lib/exec/test/test_shell_ir_oracle.exe`
- `env MASC_DUNE_THROTTLE=0 MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_OPAM_LOCK=0 MASC_SKIP_OPAM_LOCK=1 MASC_SKIP_PIN_CHECK=1 MASC_SKIP_DEPS_CHECK=1 DUNE_LOCAL_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build lib/exec/test/test_shell_ir_risk.exe lib/exec/test/test_shell_ir_differential.exe`
- `_build/default/lib/exec/test/test_shell_ir_risk.exe`
- `_build/default/lib/exec/test/test_shell_ir_differential.exe`
- `scripts/audit-shell-ir-consumption.sh --baseline scripts/shell-ir-consumption-baseline.json`

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 8/8
provenance: direct
stages:
  - ocamlformat_check
  - fixture_json_validation
  - oracle_focused_build
  - oracle_focused_test
  - risk_and_differential_build
  - shell_ir_risk_test
  - shell_ir_differential_test
  - shell_ir_consumption_ratchet
```

## GOAL LOOP ACT checklist

- [x] Observe — Shell IR Library Adoption Guide calls out missing parser-oracle fixture and descriptor parity evidence path.
- [x] Orient — existing `Shell_ir_risk`/differential harness existed, but parser-oracle facts and redirect syntax floor were not pinned.
- [x] Decide — first bounded scope is contract/fixtures plus redirect risk floor; no runtime sidecar route is enabled.
- [x] Act — added `Shell_ir_oracle`, fixtures, focused test, and redirect R1 floor.
- [x] Verify — focused builds/tests and Shell IR consumption ratchet passed.
- [x] Loop — next slice is the actual non-production `mvdan/sh` sidecar emitter.

## Review evidence

- Not run. This PR is draft and includes direct local test evidence for the first implementation slice.

## Linked issue

- Relates: Shell IR Library Adoption Guide follow-up.

## Variant addition checklist

- [x] **OCaml** — added `Shell_ir_oracle.parse_status` and exhaustive matches in the new module.
- [ ] **TypeScript** — N/A; no dashboard union or UI type changed.
- [ ] **TLA+ spec** — N/A; no TLA domain literal changed.
- [ ] **Event / JSON schema** — N/A; fixture contract is local OCaml parser contract, not an emitted runtime event schema yet.
- [ ] **`make check-variants` passes** — N/A for this scoped exec-library fixture contract; focused OCaml builds/tests passed.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`codex/shell-ir-oracle-fixtures-20260604` → `main` · 1 commit(s) · synced 2026-06-04T11:52:01Z

| sha | subject | date |
|---|---|---|
| `f324210b4` | feat(exec): add shell ir oracle fixture contract | 2026-06-04 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->