### PR TITLE
test(otel): remove stale prometheus text export calls

### DIFF
--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -1,12 +1,13 @@
 (** Prometheus-Compatible Metrics for masc
 
-    Provides lightweight metrics collection and Prometheus text format export.
+    Provides lightweight metric accumulation. The in-process store is exported
+    through OTel observable callbacks.
 
     Usage:
     {[
       let () = Prometheus.inc_counter "masc_tasks_total" ~labels:[("status", "completed")]
       let () = Prometheus.set_gauge "masc_active_agents" 5.0
-      let text = Prometheus.to_prometheus_text ()
+      let snapshot = Prometheus.snapshot ()
     ]}
 
     @since 0.4.0
@@ -301,12 +302,12 @@ let set_tool_schema_stats ~count ~approx_tokens =
 ;;
 
 
-(* Track host labels seen in previous scrapes so we can zero out gauges
+(* Track host labels seen in previous exports so we can zero out gauges
    for hosts that disappeared from the pool. Without this, an evicted
    host's last non-zero idle value would persist in the registry forever
    and the metrics table would grow unboundedly with every unique host
    seen. Set is module-local: only [update_pool_metrics_gauges] reads
-   or writes it, and [to_prometheus_text]'s mutex serialises calls. *)
+   or writes it. *)
 let pool_idle_seen_hosts : (string, unit) Hashtbl.t = Hashtbl.create 16
 
 let update_pool_metrics_gauges () =
@@ -346,12 +347,11 @@ let update_pool_metrics_gauges () =
 
 (* RFC-0217 S4 — export the in-process metric store to OTel as an observable
    source. Defined after update_*_gauges so the export tick can refresh the lazy
-   Pool_metrics/Fd gauges into the store first — exactly the refresh that
-   to_prometheus_text did at scrape time. The store (Prometheus_store) stays the
-   accumulator; the backend polls snapshot each tick (push-model replacement for
-   /metrics scrape, S0 spike validated). Dual with to_prometheus_text until S4-2
-   retires the scrape path. register_source only enqueues the callback at module
-   load (no init dependency); the snapshot is read lazily at each tick. *)
+   Pool_metrics/Fd gauges into the store first. The store
+   (Prometheus_store) stays the accumulator; the backend polls snapshot
+   each tick (push-model replacement for the old scrape endpoint, S0 spike
+   validated). register_source only enqueues the callback at module load
+   (no init dependency); the snapshot is read lazily at each tick. *)
 let otel_samples () : Otel_metrics.sample list =
   update_uptime ();
   update_fd_gauges ();
@@ -371,10 +371,8 @@ let otel_samples () : Otel_metrics.sample list =
 
 let () = Otel_metrics.register_source otel_samples
 
-(* RFC-0217 S4-2 — to_prometheus_text (Prometheus /metrics scrape render) removed.
-   The lazy gauge refreshes it performed are now done by otel_samples before each
-   OTLP export tick (S4-1). Prometheus_render is deleted with it; metrics export
-   via OTLP push only. *)
+(* RFC-0217 S4-2 — text scrape rendering removed. Lazy gauge refreshes now
+   happen in [otel_samples] before each OTLP export tick. *)
 
 (** {1 Convenience Functions} *)
 let record_request () = inc_counter metric_mcp_requests ()

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -1,6 +1,6 @@
 (** Prometheus-Compatible Metrics for masc.
 
-    Lightweight metrics collection with Prometheus text format export.
+    Lightweight metric accumulation with OTel observable export.
     Thread-safe via [Stdlib.Mutex] — works across OCaml 5 domains and
     during module initialisation before any Eio scheduler exists.
 
@@ -275,8 +275,7 @@ val metric_mention_dedup_decisions_total : string
 
 val set_tool_schema_stats : count:int -> approx_tokens:int -> unit
 
-(* RFC-0217 S4-2 — to_prometheus_text removed (Prometheus /metrics scrape
-   retired; metrics export via OTLP push). *)
+(* RFC-0217 S4-2 — text scrape rendering retired; metrics export via OTLP push. *)
 
 (** {1 Convenience Functions} *)
 

--- a/lib/prometheus_builtin_metrics_part3.ml
+++ b/lib/prometheus_builtin_metrics_part3.ml
@@ -368,7 +368,7 @@ let register
      because the [inter_chunk_ms] input was non-finite or non-positive. Labels: \
      provider, model, reason (not_finite | non_positive)."
     `Counter;
-  (* Process-level resource gauges.  Sampled on every /metrics scrape via
+  (* Process-level resource gauges.  Sampled on every OTel export tick via
      [update_fd_gauges] so a monotonic ramp (fd leak) is visible in the
      time series before it crosses the OS limit and crashes the server.
      Evidence: 2026-04-16 production incident, 4029 CLOSE_WAIT sockets

--- a/lib/prometheus_builtin_metrics_part4.ml
+++ b/lib/prometheus_builtin_metrics_part4.ml
@@ -33,7 +33,7 @@ let register
     "Whether the shared keeper FD-pressure breaker is active (1 active, 0 inactive)."
     `Gauge;
   (* RFC-0107 Phase D.4 — piaf connection pool metrics.  Snapshot
-     pushed by [update_pool_metrics_gauges] inside [to_prometheus_text]. *)
+     pushed by [update_pool_metrics_gauges] during OTel export. *)
   add
     metric_pool_idle_total
     "Idle (reusable) connections held by the piaf-backed HTTP pool. \

--- a/test/test_cache_metrics_wiring.ml
+++ b/test/test_cache_metrics_wiring.ml
@@ -104,17 +104,16 @@ let test_two_layer_independence () =
   check (float 0.1) "response cache unaffected by prefix cache"
     response_before response_after
 
-(* ── Prometheus export format test ────────────────────── *)
+(* ── Metric registry test ─────────────────────────────── *)
 
-let test_cache_metrics_in_export () =
-  let text = Prometheus.to_prometheus_text () in
-  let has needle =
-    try ignore (Str.search_forward (Str.regexp_string needle) text 0); true
-    with Not_found -> false
+let test_cache_metrics_in_registry () =
+  let has name =
+    Prometheus.snapshot ()
+    |> List.exists (fun (m : Prometheus.metric) -> String.equal m.name name)
   in
-  check bool "export has prefix creation metric" true
+  check bool "registry has prefix creation metric" true
     (has "masc_provider_prefix_cache_creation_tokens_total");
-  check bool "export has prefix read metric" true
+  check bool "registry has prefix read metric" true
     (has "masc_provider_prefix_cache_read_tokens_total")
 
 (* ── Suite ────────────────────────────────────────────── *)
@@ -143,9 +142,9 @@ let () =
           test_case "layers are independent" `Quick
             test_two_layer_independence;
         ] );
-      ( "prometheus_export",
+      ( "metric_registry",
         [
-          test_case "cache metrics in export text" `Quick
-            test_cache_metrics_in_export;
+          test_case "cache metrics in registry" `Quick
+            test_cache_metrics_in_registry;
         ] );
     ]

--- a/test/test_discovery_history_models_10404.ml
+++ b/test/test_discovery_history_models_10404.ml
@@ -63,9 +63,6 @@ let test_single_model_round_trip () =
     (Astring.String.is_infix
        ~affix:"\"model_id\":\"qwen3.6:27b-coding-nvfp4\"" s)
 
-let text_has_literal text literal =
-  Astring.String.is_infix ~affix:literal text
-
 let test_failure_observer_increments_metric () =
   let labels = [("site", "unknown")] in
   let before =
@@ -109,13 +106,16 @@ let test_failure_observer_reraises_cancelled () =
   check bool "cancel is re-raised" true !raised
 
 let test_failure_metric_registered () =
-  let text = P.to_prometheus_text () in
-  check bool "has discovery history failure HELP" true
-    (text_has_literal text
-       ("# HELP " ^ P.metric_discovery_history_failures ^ " "));
-  check bool "has discovery history failure TYPE" true
-    (text_has_literal text
-       ("# TYPE " ^ P.metric_discovery_history_failures ^ " counter"))
+  let metric =
+    P.snapshot ()
+    |> List.find_opt (fun (m : P.metric) ->
+      String.equal m.name P.metric_discovery_history_failures && m.labels = [])
+  in
+  check bool "discovery history failure registered" true (Option.is_some metric);
+  check bool "discovery history failure registered as counter" true
+    (match metric with
+     | Some m -> m.metric_type = P.Counter
+     | None -> false)
 
 let () =
   run "discovery_history_models_10404" [

--- a/test/test_eio_mutex_concurrency.ml
+++ b/test/test_eio_mutex_concurrency.ml
@@ -92,10 +92,8 @@ let test_prometheus_concurrent () =
         ~labels:[("fiber", string_of_int i)] ()
     done
   ));
-  let text = Prom.to_prometheus_text () in
-  check bool "has metric name" true
-    (try ignore (Str.search_forward (Str.regexp_string "test_concurrent_metric") text 0); true
-     with Not_found -> false)
+  check (float 0.0001) "counter total" 1000.0
+    (Prom.metric_total "test_concurrent_metric")
 
 let test_prometheus_gauge_concurrent () =
   Eio.Fiber.all (List.init 5 (fun i -> fun () ->
@@ -105,10 +103,8 @@ let test_prometheus_gauge_concurrent () =
         (float_of_int j)
     done
   ));
-  let text = Prom.to_prometheus_text () in
-  check bool "has gauge name" true
-    (try ignore (Str.search_forward (Str.regexp_string "test_concurrent_gauge") text 0); true
-     with Not_found -> false)
+  check (float 0.0001) "gauge total" 250.0
+    (Prom.metric_total "test_concurrent_gauge")
 
 (** {1 Streamable HTTP Session Concurrency} *)
 

--- a/test/test_fsm_drift_counter.ml
+++ b/test/test_fsm_drift_counter.ml
@@ -25,21 +25,6 @@ let record_fsm_drift ~variant ~force =
     ~variant ~force ~agent_name:"fsm-drift-counter-test"
 ;;
 
-let str_contains haystack needle =
-  let haystack_len = String.length haystack in
-  let needle_len = String.length needle in
-  if needle_len = 0 then true
-  else if needle_len > haystack_len then false
-  else (
-    let found = ref false in
-    let i = ref 0 in
-    while !i <= haystack_len - needle_len && not !found do
-      if String.sub haystack !i needle_len = needle then found := true;
-      incr i
-    done;
-    !found)
-;;
-
 let counter_for ~variant ~force =
   Masc.Prometheus.metric_value_or_zero
     fsm_drift_metric
@@ -50,15 +35,17 @@ let counter_for ~variant ~force =
     ()
 
 let test_metric_name_stable () =
-  let text = Masc.Prometheus.to_prometheus_text () in
+  let metric =
+    Masc.Prometheus.snapshot ()
+    |> List.find_opt (fun (m : Masc.Prometheus.metric) ->
+      String.equal m.name fsm_drift_metric && m.labels = [])
+  in
   Alcotest.(check bool)
-    "fsm drift HELP registered"
+    "fsm drift registered as counter"
     true
-    (str_contains text ("# HELP " ^ fsm_drift_metric));
-  Alcotest.(check bool)
-    "fsm drift TYPE registered"
-    true
-    (str_contains text ("# TYPE " ^ fsm_drift_metric ^ " counter"))
+    (match metric with
+     | Some m -> m.metric_type = Masc.Prometheus.Counter
+     | None -> false)
 
 (* Exhaustive enum → label mapping.  Adding a new
    [Workspace_task_lifecycle.drift] variant forces the reviewer to

--- a/test/test_fsm_drift_per_agent_counter.ml
+++ b/test/test_fsm_drift_per_agent_counter.ml
@@ -15,21 +15,6 @@ let record_fsm_drift_with_agent ~variant ~force ~agent_name =
   (Atomic.get Workspace_hooks.fsm_drift_observer_fn) ~variant ~force ~agent_name
 ;;
 
-let str_contains haystack needle =
-  let haystack_len = String.length haystack in
-  let needle_len = String.length needle in
-  if needle_len = 0 then true
-  else if needle_len > haystack_len then false
-  else (
-    let found = ref false in
-    let i = ref 0 in
-    while !i <= haystack_len - needle_len && not !found do
-      if String.sub haystack !i needle_len = needle then found := true;
-      incr i
-    done;
-    !found)
-;;
-
 let counter_for_per_agent ~variant ~agent_name ~force =
   Masc.Prometheus.metric_value_or_zero
     fsm_drift_per_agent_metric
@@ -50,15 +35,17 @@ let counter_for_variant ~variant ~force =
     ()
 
 let test_metric_name_stable () =
-  let text = Masc.Prometheus.to_prometheus_text () in
+  let metric =
+    Masc.Prometheus.snapshot ()
+    |> List.find_opt (fun (m : Masc.Prometheus.metric) ->
+      String.equal m.name fsm_drift_per_agent_metric && m.labels = [])
+  in
   Alcotest.(check bool)
-    "per-agent HELP registered"
+    "per-agent registered as counter"
     true
-    (str_contains text ("# HELP " ^ fsm_drift_per_agent_metric));
-  Alcotest.(check bool)
-    "per-agent TYPE registered"
-    true
-    (str_contains text ("# TYPE " ^ fsm_drift_per_agent_metric ^ " counter"))
+    (match metric with
+     | Some m -> m.metric_type = Masc.Prometheus.Counter
+     | None -> false)
 
 let test_emits_both_counters () =
   let variant =

--- a/test/test_governance_response_model_empty_9880.ml
+++ b/test/test_governance_response_model_empty_9880.ml
@@ -130,21 +130,18 @@ let test_empty_canonical_id_uses_unknown_source () =
     ~expected_source:"unknown_source"
 ;;
 
-(* Prometheus text export must include the metric name and
-   the [source] label key — PromQL queries depend on this. *)
-let test_export () =
+(* The registry must include the metric name and [source] label key;
+   the OTel exporter reads this snapshot. *)
+let test_registry_snapshot () =
   Prom.inc_counter metric_name ~labels:[ "source", "telemetry_resolved" ] ();
-  let text = Prom.to_prometheus_text () in
-  let contains s sub =
-    let n = String.length s
-    and m = String.length sub in
-    let rec loop i =
-      if i + m > n then false else if String.sub s i m = sub then true else loop (i + 1)
-    in
-    loop 0
+  let has_metric =
+    Prom.snapshot ()
+    |> List.exists (fun (m : Prom.metric) ->
+      String.equal m.name metric_name
+      && m.metric_type = Prom.Counter
+      && List.mem ("source", "telemetry_resolved") m.labels)
   in
-  Alcotest.(check bool) "metric name in export" true (contains text metric_name);
-  Alcotest.(check bool) "source label key in export" true (contains text "source=")
+  Alcotest.(check bool) "metric source label in registry" true has_metric
 ;;
 
 let () =
@@ -182,6 +179,11 @@ let () =
             `Quick
             test_empty_canonical_id_uses_unknown_source
         ] )
-    ; "export", [ Alcotest.test_case "metric + label key in /metrics" `Quick test_export ]
+    ; ( "registry"
+      , [ Alcotest.test_case
+            "metric + label key in registry"
+            `Quick
+            test_registry_snapshot
+        ] )
     ]
 ;;

--- a/test/test_keeper_compaction_noop_counter_9943.ml
+++ b/test/test_keeper_compaction_noop_counter_9943.ml
@@ -114,30 +114,24 @@ let test_per_keeper_isolation () =
     (noop_for ~keeper:b ~trigger)
 ;;
 
-(* Prometheus text export must include the metric name and the
-   keeper / trigger label keys — PromQL queries depend on this. *)
-let test_prometheus_text_export () =
+(* The in-process registry must preserve the metric name and
+   keeper / trigger label keys; the OTel exporter reads this snapshot. *)
+let test_registry_snapshot_includes_label_shape () =
   let keeper = "test-keeper-compaction-noop-9943-export" in
   let trigger = "context_overflow_imminent" in
+  let metric = Masc.Keeper_metrics.(to_string CompactionNoop) in
   Prom.inc_counter
-    Masc.Keeper_metrics.(to_string CompactionNoop)
+    metric
     ~labels:[ "keeper", keeper; "trigger", trigger ]
     ();
-  let text = Prom.to_prometheus_text () in
-  let contains s sub =
-    let n = String.length s
-    and m = String.length sub in
-    let rec loop i =
-      if i + m > n then false else if String.sub s i m = sub then true else loop (i + 1)
-    in
-    loop 0
+  let has_metric =
+    Prom.snapshot ()
+    |> List.exists (fun (m : Prom.metric) ->
+      String.equal m.name metric
+      && List.mem ("keeper", keeper) m.labels
+      && List.mem ("trigger", trigger) m.labels)
   in
-  Alcotest.(check bool)
-    "metric name in export"
-    true
-    (contains text Masc.Keeper_metrics.(to_string CompactionNoop));
-  Alcotest.(check bool) "keeper label key in export" true (contains text "keeper=");
-  Alcotest.(check bool) "trigger label key in export" true (contains text "trigger=")
+  Alcotest.(check bool) "metric label shape in registry" true has_metric
 ;;
 
 let () =
@@ -156,11 +150,11 @@ let () =
             test_distinct_triggers_separate_rows
         ; Alcotest.test_case "per-keeper isolation" `Quick test_per_keeper_isolation
         ] )
-    ; ( "export"
+    ; ( "registry"
       , [ Alcotest.test_case
-            "metric + labels appear in /metrics"
+            "metric + labels appear in registry"
             `Quick
-            test_prometheus_text_export
+            test_registry_snapshot_includes_label_shape
         ] )
     ]
 ;;

--- a/test/test_keeper_supervisor_observability_10125.ml
+++ b/test/test_keeper_supervisor_observability_10125.ml
@@ -151,40 +151,35 @@ let test_counter_per_base_path_isolation () =
     (starts_for ~base_path:a)
 ;;
 
-(* The textual export uses [base_path] as the label key
-   for both metrics, so PromQL queries can join them on
-   that label. *)
-let test_prometheus_text_export_includes_metrics () =
+(* The registry uses [base_path] as the label key for both metrics, so
+   downstream OTel export keeps the join key intact. *)
+let test_registry_snapshot_includes_metrics () =
   let base_path = "/tmp/test-supervisor-obs-export-10125" in
+  let starts = Masc.Keeper_metrics.(to_string SupervisorSweepStarts) in
+  let last_sweep = Masc.Keeper_metrics.(to_string SupervisorLastSweepUnixtime) in
   Prom.inc_counter
-    Masc.Keeper_metrics.(to_string SupervisorSweepStarts)
+    starts
     ~labels:[ "base_path", base_path ]
     ();
   Prom.set_gauge
-    Masc.Keeper_metrics.(to_string SupervisorLastSweepUnixtime)
+    last_sweep
     ~labels:[ "base_path", base_path ]
     (Unix.gettimeofday ());
-  let text = Prom.to_prometheus_text () in
-  let contains s sub =
-    let n = String.length s
-    and m = String.length sub in
-    let rec loop i =
-      if i + m > n then false else if String.sub s i m = sub then true else loop (i + 1)
-    in
-    loop 0
+  let has_metric name metric_type =
+    Prom.snapshot ()
+    |> List.exists (fun (m : Prom.metric) ->
+      String.equal m.name name
+      && m.metric_type = metric_type
+      && List.mem ("base_path", base_path) m.labels)
   in
   Alcotest.(check bool)
-    "counter name appears in export"
+    "counter name appears in registry"
     true
-    (contains text Masc.Keeper_metrics.(to_string SupervisorSweepStarts));
+    (has_metric starts Prom.Counter);
   Alcotest.(check bool)
-    "gauge name appears in export"
+    "gauge name appears in registry"
     true
-    (contains text Masc.Keeper_metrics.(to_string SupervisorLastSweepUnixtime));
-  Alcotest.(check bool)
-    "base_path label appears for export"
-    true
-    (contains text "base_path=")
+    (has_metric last_sweep Prom.Gauge)
 ;;
 
 let () =
@@ -216,11 +211,11 @@ let () =
             `Quick
             test_counter_per_base_path_isolation
         ] )
-    ; ( "export"
+    ; ( "registry"
       , [ Alcotest.test_case
-            "metrics appear in /metrics text"
+            "metrics appear in registry"
             `Quick
-            test_prometheus_text_export_includes_metrics
+            test_registry_snapshot_includes_metrics
         ] )
     ]
 ;;

--- a/test/test_pool_metrics.ml
+++ b/test/test_pool_metrics.ml
@@ -1,16 +1,14 @@
-(** RFC-0107 Phase D.4 — Pool_metrics exporter regression test.
+(** RFC-0107 Phase D.4 — Pool_metrics registry regression test.
 
-    Pinned-name + scrape-shape checks for the piaf connection pool
-    Prometheus exporter.  Verifies:
+    Pinned-name + registry-shape checks for the piaf connection pool
+    metrics.  Verifies:
 
-    - Five metric name constants stay stable (Grafana dashboards pin
-      these names).
+    - Five metric name constants stay stable (dashboards pin these names).
     - [register ()] is idempotent and does not raise.
     - [current_snapshot ()] returns [None] before the pool is
       lazy-initialized (no HTTP traffic from the test).
-    - [Prometheus.to_prometheus_text ()] emits all five metric
-      families with the correct TYPE lines once the metrics are
-      registered.
+    - The Prometheus store registers all metric families with the intended
+      counter/gauge type for the OTel observable source.
 *)
 
 open Alcotest
@@ -45,55 +43,32 @@ let test_current_snapshot_none_when_pool_uninit () =
    | None -> ()
    | Some _ -> fail "pool snapshot should be None before first HTTP call")
 
-let metric_lines_for name text =
-  text
-  |> String.split_on_char '\n'
-  |> List.filter (fun line ->
-       (* Look for "# TYPE <name> ..." or "<name>{...} <value>" /
-          "<name> <value>" — both anchor on the same prefix. *)
-       String.length line >= String.length name
-       && (
-         let prefix_match s =
-           let plen = String.length s in
-           String.length line >= plen
-           && String.sub line 0 plen = s
-         in
-         prefix_match ("# TYPE " ^ name)
-         || prefix_match (name ^ " ")
-         || prefix_match (name ^ "{")))
+let find_metric name =
+  Masc.Prometheus.snapshot ()
+  |> List.find_opt (fun (m : Masc.Prometheus.metric) ->
+    String.equal m.name name && m.labels = [])
 
-let test_to_prometheus_text_contains_metric_families () =
-  let text = Masc.Prometheus.to_prometheus_text () in
+let test_registry_contains_metric_families () =
   List.iter
     (fun (_, name) ->
-      let lines = metric_lines_for name text in
       check bool
-        (Printf.sprintf "/metrics output contains %s" name)
+        (Printf.sprintf "registry contains %s" name)
         true
-        (List.length lines > 0))
+        (Option.is_some (find_metric name)))
     metric_names
 
-let test_inflight_is_gauge_type () =
-  (* TYPE line discipline: idle/inflight should render as gauge,
-     reuse/evict/create as counter.  Pin a representative for each
-     bucket so render-time drift is caught. *)
-  let text = Masc.Prometheus.to_prometheus_text () in
-  let contains needle =
-    let nlen = String.length needle in
-    let len = String.length text in
-    let rec scan i =
-      if i + nlen > len then false
-      else if String.sub text i nlen = needle then true
-      else scan (i + 1)
-    in
-    scan 0
+let test_metric_types_match_intent () =
+  let has_type name metric_type =
+    match find_metric name with
+    | Some m -> m.metric_type = metric_type
+    | None -> false
   in
   check bool "inflight_total is gauge" true
-    (contains "# TYPE masc_pool_inflight_total gauge");
+    (has_type "masc_pool_inflight_total" Masc.Prometheus.Gauge);
   check bool "reuse_total is counter" true
-    (contains "# TYPE masc_pool_reuse_total counter");
+    (has_type "masc_pool_reuse_total" Masc.Prometheus.Counter);
   check bool "create_total is counter" true
-    (contains "# TYPE masc_pool_create_total counter")
+    (has_type "masc_pool_create_total" Masc.Prometheus.Counter)
 
 let () =
   run "Pool_metrics" [
@@ -107,10 +82,10 @@ let () =
       test_case "current_snapshot None before HTTP traffic" `Quick
         test_current_snapshot_none_when_pool_uninit;
     ];
-    "prometheus integration", [
-      test_case "to_prometheus_text contains all 5 metric families" `Quick
-        test_to_prometheus_text_contains_metric_families;
-      test_case "metric TYPE lines match gauge/counter intent" `Quick
-        test_inflight_is_gauge_type;
+    "metric registry", [
+      test_case "registry contains all 5 metric families" `Quick
+        test_registry_contains_metric_families;
+      test_case "metric types match gauge/counter intent" `Quick
+        test_metric_types_match_intent;
     ];
   ]

--- a/test/test_process_timeout_counter.ml
+++ b/test/test_process_timeout_counter.ml
@@ -43,22 +43,21 @@ let test_metric_name_stable () =
 ;;
 
 let test_metric_registered_at_init () =
-  let text = Masc.Prometheus.to_prometheus_text () in
-  let has literal =
-    try
-      ignore (Str.search_forward (Str.regexp_string literal) text 0);
-      true
-    with
-    | Not_found -> false
+  let metric =
+    Masc.Prometheus.snapshot ()
+    |> List.find_opt (fun (m : Masc.Prometheus.metric) ->
+      String.equal m.name Masc.Prometheus.metric_process_timeout && m.labels = [])
   in
   Alcotest.(check bool)
-    "process timeout HELP registered"
+    "process timeout registered"
     true
-    (has "# HELP masc_process_timeout_total");
+    (Option.is_some metric);
   Alcotest.(check bool)
-    "process timeout TYPE registered"
+    "process timeout registered as counter"
     true
-    (has "# TYPE masc_process_timeout_total counter")
+    (match metric with
+     | Some m -> m.metric_type = Masc.Prometheus.Counter
+     | None -> false)
 ;;
 
 let test_argv_program_basename () =

--- a/test/test_transport_metrics.ml
+++ b/test/test_transport_metrics.ml
@@ -43,37 +43,20 @@ let with_env name value_opt f =
    ============================================================ *)
 
 let test_init () =
-  let text = Prometheus.to_prometheus_text () in
+  let has_metric name =
+    Prometheus.snapshot ()
+    |> List.exists (fun (m : Prometheus.metric) -> String.equal m.name name)
+  in
   check bool "sse sessions metric registered" true
-    (try
-       let _ = Str.search_forward
-         (Str.regexp_string "masc_sse_sessions_total") text 0 in
-       true
-     with Not_found -> false);
+    (has_metric "masc_sse_sessions_total");
   check bool "grpc active streams metric registered" true
-    (try
-       let _ = Str.search_forward
-         (Str.regexp_string "masc_grpc_active_streams_total") text 0 in
-       true
-     with Not_found -> false);
+    (has_metric "masc_grpc_active_streams_total");
   check bool "agent heartbeat age metric registered" true
-    (try
-       let _ = Str.search_forward
-         (Str.regexp_string "masc_agent_heartbeat_age_seconds") text 0 in
-       true
-     with Not_found -> false);
+    (has_metric "masc_agent_heartbeat_age_seconds");
   check bool "http accept metric registered" true
-    (try
-       let _ = Str.search_forward
-         (Str.regexp_string "masc_http_accepts_total") text 0 in
-       true
-     with Not_found -> false);
+    (has_metric "masc_http_accepts_total");
   check bool "ws hello latency metric registered" true
-    (try
-       let _ = Str.search_forward
-         (Str.regexp_string "masc_ws_dashboard_hello_latency_seconds") text 0 in
-       true
-     with Not_found -> false)
+    (has_metric "masc_ws_dashboard_hello_latency_seconds")
 
 (* ============================================================
    SSE Metrics


### PR DESCRIPTION
## What changed
- Removed stale `Prometheus.to_prometheus_text` expectations from tests after RFC-0217 removed the text scrape renderer.
- Repointed metric assertions to the live in-process `Prometheus.snapshot` / metric-value surfaces used by OTel observable export.
- Updated stale Prometheus facade comments so they describe store accumulation and OTel export instead of the retired text endpoint.

## Root cause
PR #20082 intentionally removed the Prometheus text scrape path, but several tests still compiled against the deleted `to_prometheus_text` API. That left `dune build .` failing with `Unbound value ... to_prometheus_text`.

## Validation
- `rg -n "to_prometheus_text" lib test docs -g '*.ml' -g '*.mli' -g '*.md' -g '*.html'` -> no matches
- `env MASC_DUNE_THROTTLE=0 MASC_OPAM_LOCK=0 MASC_SKIP_OPAM_LOCK=1 MASC_SKIP_PIN_CHECK=1 MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_compaction_noop_counter_9943.exe test/test_keeper_supervisor_observability_10125.exe test/test_governance_response_model_empty_9880.exe test/test_fsm_drift_per_agent_counter.exe test/test_pool_metrics.exe test/test_cache_metrics_wiring.exe test/test_fsm_drift_counter.exe test/test_process_timeout_counter.exe test/test_discovery_history_models_10404.exe test/test_eio_mutex_concurrency.exe test/test_transport_metrics.exe`
- Ran all 11 changed test executables directly; all passed.