### PR TITLE
feat(exec): add Shell IR oracle sidecar

### DIFF
--- a/lib/exec/test/fixtures/shell_ir_oracle/heredoc.json
+++ b/lib/exec/test/fixtures/shell_ir_oracle/heredoc.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "parser": "mvdan-sh-syntax-prototype",
+  "parser": "mvdan.cc/sh/v3/syntax@v3.10.0",
   "command": "cat <<EOF\nhello\nEOF",
   "parse_status": "ok",
   "features": {

--- a/lib/exec/test/fixtures/shell_ir_oracle/parse_error.json
+++ b/lib/exec/test/fixtures/shell_ir_oracle/parse_error.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "parser": "mvdan-sh-syntax-prototype",
+  "parser": "mvdan.cc/sh/v3/syntax@v3.10.0",
   "command": "echo \"unterminated",
   "parse_status": "parse_error",
   "features": {
@@ -15,5 +15,5 @@
     "process_substitution": false
   },
   "commands": [],
-  "error": "unterminated quoted string"
+  "error": "1:6: reached EOF without closing quote `\"`"
 }

--- a/lib/exec/test/fixtures/shell_ir_oracle/pipeline.json
+++ b/lib/exec/test/fixtures/shell_ir_oracle/pipeline.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "parser": "mvdan-sh-syntax-prototype",
+  "parser": "mvdan.cc/sh/v3/syntax@v3.10.0",
   "command": "cat file.txt | wc -l",
   "parse_status": "ok",
   "features": {

--- a/lib/exec/test/fixtures/shell_ir_oracle/redirect_write.json
+++ b/lib/exec/test/fixtures/shell_ir_oracle/redirect_write.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "parser": "mvdan-sh-syntax-prototype",
+  "parser": "mvdan.cc/sh/v3/syntax@v3.10.0",
   "command": "echo hello > out.txt",
   "parse_status": "ok",
   "features": {

--- a/lib/exec/test/fixtures/shell_ir_oracle/simple.json
+++ b/lib/exec/test/fixtures/shell_ir_oracle/simple.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "parser": "mvdan-sh-syntax-prototype",
+  "parser": "mvdan.cc/sh/v3/syntax@v3.10.0",
   "command": "echo hello",
   "parse_status": "ok",
   "features": {

--- a/lib/exec/test/fixtures/shell_ir_oracle/unknown_feature.json
+++ b/lib/exec/test/fixtures/shell_ir_oracle/unknown_feature.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "parser": "mvdan-sh-syntax-prototype",
+  "parser": "manual-unknown-feature-fixture",
   "command": "echo hello",
   "parse_status": "ok",
   "features": {

--- a/sidecars/shell-ir-oracle/README.md
+++ b/sidecars/shell-ir-oracle/README.md
@@ -1,0 +1,31 @@
+# Shell IR Oracle Sidecar
+
+Non-production fixture emitter for Shell IR parser hardening.
+
+This sidecar parses a shell command with `mvdan.cc/sh/v3/syntax` and emits the
+data-only JSON contract consumed by `lib/exec/shell_ir_oracle.ml`.
+
+It does not execute commands, make policy decisions, or participate in runtime
+authorization. OCaml remains the owner of descriptor parity, risk floors,
+receipts, and enforcement.
+
+## Usage
+
+```sh
+go run . --pretty --command 'echo hello > out.txt'
+printf 'cat file.txt | wc -l\n' | go run . --pretty
+```
+
+Parse errors still emit a JSON fact with `parse_status: "parse_error"` and
+`commands: []`, so OCaml callers can fail closed without scraping stderr.
+
+## Contract
+
+- `schema_version`: `1`
+- `parser`: `mvdan.cc/sh/v3/syntax@v3.10.0`
+- JSON shape: `Shell_ir_oracle.t`
+- Intended destination: `lib/exec/test/fixtures/shell_ir_oracle/*.json`
+
+The dependency version was selected from `go list -m -versions mvdan.cc/sh/v3`
+on 2026-06-04 KST. `v3.10.0` is the newest checked release whose module
+declares compatibility with the repository CI Go version (`go 1.22`).

--- a/sidecars/shell-ir-oracle/go.mod
+++ b/sidecars/shell-ir-oracle/go.mod
@@ -1,0 +1,5 @@
+module github.com/jeong-sik/masc-mcp/sidecars/shell-ir-oracle
+
+go 1.22
+
+require mvdan.cc/sh/v3 v3.10.0

--- a/sidecars/shell-ir-oracle/go.sum
+++ b/sidecars/shell-ir-oracle/go.sum
@@ -1,0 +1,12 @@
+github.com/go-quicktest/qt v1.101.0 h1:O1K29Txy5P2OK0dGo59b7b0LR6wKfIhttaAhHUyn7eI=
+github.com/go-quicktest/qt v1.101.0/go.mod h1:14Bz/f7NwaXPtdYEgzsx46kqSxVwTbzVZsDC26tQJow=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
+github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
+mvdan.cc/sh/v3 v3.10.0 h1:v9z7N1DLZ7owyLM/SXZQkBSXcwr2IGMm2LY2pmhVXj4=
+mvdan.cc/sh/v3 v3.10.0/go.mod h1:z/mSSVyLFGZzqb3ZIKojjyqIx/xbmz/UHdCSv9HmqXY=

--- a/sidecars/shell-ir-oracle/main.go
+++ b/sidecars/shell-ir-oracle/main.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"mvdan.cc/sh/v3/syntax"
+)
+
+const (
+	schemaVersion = 1
+	parserName    = "mvdan.cc/sh/v3/syntax@v3.10.0"
+)
+
+type features struct {
+	Pipeline            bool `json:"pipeline"`
+	Redirect            bool `json:"redirect"`
+	Heredoc             bool `json:"heredoc"`
+	Subshell            bool `json:"subshell"`
+	CommandSubstitution bool `json:"command_substitution"`
+	Variable            bool `json:"variable"`
+	Glob                bool `json:"glob"`
+	EnvAssignment       bool `json:"env_assignment"`
+	ProcessSubstitution bool `json:"process_substitution"`
+}
+
+type commandFact struct {
+	Name string   `json:"name"`
+	Argv []string `json:"argv"`
+}
+
+type oracleFact struct {
+	SchemaVersion int           `json:"schema_version"`
+	Parser        string        `json:"parser"`
+	Command       string        `json:"command"`
+	ParseStatus   string        `json:"parse_status"`
+	Features      features      `json:"features"`
+	Commands      []commandFact `json:"commands"`
+	Error         *string       `json:"error"`
+}
+
+func main() {
+	commandFlag := flag.String("command", "", "shell command to parse; stdin is used when omitted")
+	pretty := flag.Bool("pretty", false, "indent JSON output")
+	flag.Parse()
+
+	command, err := readCommand(*commandFlag, flag.Args(), os.Stdin)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
+
+	fact := analyze(command)
+	if err := writeFact(os.Stdout, fact, *pretty); err != nil {
+		fmt.Fprintf(os.Stderr, "encode oracle fact: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func readCommand(flagValue string, args []string, stdin io.Reader) (string, error) {
+	switch {
+	case flagValue != "":
+		return flagValue, nil
+	case len(args) > 0:
+		return strings.Join(args, " "), nil
+	default:
+		raw, err := io.ReadAll(stdin)
+		if err != nil {
+			return "", fmt.Errorf("read stdin: %w", err)
+		}
+		command := strings.TrimRight(string(raw), "\n")
+		if command == "" {
+			return "", errors.New("missing command: pass --command, argv, or stdin")
+		}
+		return command, nil
+	}
+}
+
+func analyze(command string) oracleFact {
+	fact := oracleFact{
+		SchemaVersion: schemaVersion,
+		Parser:        parserName,
+		Command:       command,
+		ParseStatus:   "ok",
+		Features:      features{},
+		Commands:      []commandFact{},
+		Error:         nil,
+	}
+
+	parser := syntax.NewParser()
+	file, err := parser.Parse(strings.NewReader(command), "")
+	if err != nil {
+		msg := err.Error()
+		fact.ParseStatus = "parse_error"
+		fact.Error = &msg
+		return fact
+	}
+
+	fact.Features = collectFeatures(file)
+	fact.Commands = collectCommands(file)
+	return fact
+}
+
+func writeFact(w io.Writer, fact oracleFact, pretty bool) error {
+	encoder := json.NewEncoder(w)
+	encoder.SetEscapeHTML(false)
+	if pretty {
+		encoder.SetIndent("", "  ")
+	}
+	return encoder.Encode(fact)
+}
+
+func collectFeatures(file *syntax.File) features {
+	var out features
+	syntax.Walk(file, func(node syntax.Node) bool {
+		switch n := node.(type) {
+		case *syntax.BinaryCmd:
+			if n.Op == syntax.Pipe || n.Op == syntax.PipeAll {
+				out.Pipeline = true
+			}
+		case *syntax.Redirect:
+			out.Redirect = true
+			if n.Hdoc != nil {
+				out.Heredoc = true
+			}
+		case *syntax.Subshell:
+			out.Subshell = true
+		case *syntax.CmdSubst:
+			out.CommandSubstitution = true
+		case *syntax.ParamExp:
+			out.Variable = true
+		case *syntax.Assign:
+			out.EnvAssignment = true
+		case *syntax.ProcSubst:
+			out.ProcessSubstitution = true
+		case *syntax.ExtGlob:
+			out.Glob = true
+		case *syntax.Lit:
+			if strings.ContainsAny(n.Value, "*?[") {
+				out.Glob = true
+			}
+		}
+		return true
+	})
+	return out
+}
+
+func collectCommands(file *syntax.File) []commandFact {
+	var commands []commandFact
+	printer := syntax.NewPrinter()
+	syntax.Walk(file, func(node syntax.Node) bool {
+		call, ok := node.(*syntax.CallExpr)
+		if !ok || len(call.Args) == 0 {
+			return true
+		}
+
+		argv := make([]string, 0, len(call.Args))
+		for _, word := range call.Args {
+			argv = append(argv, wordString(printer, word))
+		}
+		commands = append(commands, commandFact{Name: argv[0], Argv: argv})
+		return true
+	})
+	return commands
+}
+
+func wordString(printer *syntax.Printer, word *syntax.Word) string {
+	var buf bytes.Buffer
+	if err := printer.Print(&buf, word); err != nil {
+		return ""
+	}
+	return buf.String()
+}

--- a/sidecars/shell-ir-oracle/main_test.go
+++ b/sidecars/shell-ir-oracle/main_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestAnalyzeSimple(t *testing.T) {
+	fact := analyze("echo hello")
+	if fact.ParseStatus != "ok" {
+		t.Fatalf("status = %q", fact.ParseStatus)
+	}
+	if len(fact.Commands) != 1 {
+		t.Fatalf("commands = %d", len(fact.Commands))
+	}
+	if fact.Commands[0].Name != "echo" {
+		t.Fatalf("name = %q", fact.Commands[0].Name)
+	}
+	if got := fact.Commands[0].Argv; len(got) != 2 || got[0] != "echo" || got[1] != "hello" {
+		t.Fatalf("argv = %#v", got)
+	}
+	if fact.Features.Redirect || fact.Features.Pipeline {
+		t.Fatalf("unexpected features: %#v", fact.Features)
+	}
+}
+
+func TestAnalyzeFeatures(t *testing.T) {
+	fact := analyze("FOO=bar echo $FOO > out.txt | wc -l")
+	if fact.ParseStatus != "ok" {
+		t.Fatalf("status = %q error=%v", fact.ParseStatus, fact.Error)
+	}
+	if !fact.Features.Pipeline {
+		t.Fatal("pipeline feature not detected")
+	}
+	if !fact.Features.Redirect {
+		t.Fatal("redirect feature not detected")
+	}
+	if !fact.Features.Variable {
+		t.Fatal("variable feature not detected")
+	}
+	if !fact.Features.EnvAssignment {
+		t.Fatal("env assignment feature not detected")
+	}
+}
+
+func TestAnalyzeHeredocAndSubstitution(t *testing.T) {
+	fact := analyze("cat <<EOF\n$(date)\nEOF")
+	if fact.ParseStatus != "ok" {
+		t.Fatalf("status = %q error=%v", fact.ParseStatus, fact.Error)
+	}
+	if !fact.Features.Heredoc {
+		t.Fatal("heredoc feature not detected")
+	}
+	if !fact.Features.CommandSubstitution {
+		t.Fatal("command substitution feature not detected")
+	}
+}
+
+func TestAnalyzeParseErrorEmitsJSONFact(t *testing.T) {
+	fact := analyze("echo \"unterminated")
+	if fact.ParseStatus != "parse_error" {
+		t.Fatalf("status = %q", fact.ParseStatus)
+	}
+	if fact.Error == nil || *fact.Error == "" {
+		t.Fatal("missing parse error")
+	}
+	if len(fact.Commands) != 0 {
+		t.Fatalf("commands = %#v", fact.Commands)
+	}
+	if fact.Commands == nil {
+		t.Fatal("commands must encode as [] instead of null")
+	}
+	if _, err := json.Marshal(fact); err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+}
+
+func TestWriteFactDoesNotHTMLEscapeShellOperators(t *testing.T) {
+	fact := analyze("echo hello > out.txt")
+	var buf bytes.Buffer
+	if err := writeFact(&buf, fact, true); err != nil {
+		t.Fatalf("write fact: %v", err)
+	}
+	if strings.Contains(buf.String(), `\u003e`) {
+		t.Fatalf("escaped shell operator in JSON: %s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "echo hello > out.txt") {
+		t.Fatalf("missing readable command: %s", buf.String())
+	}
+}


### PR DESCRIPTION
## Summary

- add non-production `sidecars/shell-ir-oracle`, a fixture emitter backed by `mvdan.cc/sh/v3/syntax`
- emit the existing `Shell_ir_oracle.t` JSON shape without executing commands or making policy decisions
- update oracle fixtures from the prototype parser label to the concrete parser/source, while keeping the unknown-feature fixture explicitly manual

## Product impact

- User-visible change: none. This is a test/fixture sidecar for Shell IR hardening.
- Runtime behavior change: none. OCaml remains the owner of descriptor parity, risk floors, receipts, and enforcement.

## Evidence

- `go list -m -versions mvdan.cc/sh/v3`
- checked upstream module `go.mod` for `v3.13.1`, `v3.12.0`, `v3.11.0`, and `v3.10.0`
- `env GOCACHE=/private/tmp/masc-shell-ir-oracle-go-build GOMODCACHE=/private/tmp/masc-shell-ir-oracle-go-mod go test ./...`
- `jq -e . lib/exec/test/fixtures/shell_ir_oracle/*.json`
- `env MASC_DUNE_THROTTLE=0 MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_OPAM_LOCK=0 MASC_SKIP_OPAM_LOCK=1 MASC_SKIP_PIN_CHECK=1 MASC_SKIP_DEPS_CHECK=1 DUNE_LOCAL_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build lib/exec/test/test_shell_ir_oracle.exe`
- `_build/default/lib/exec/test/test_shell_ir_oracle.exe`
- `scripts/audit-shell-ir-consumption.sh --baseline scripts/shell-ir-consumption-baseline.json`
- `git diff --check origin/main...HEAD`

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 7/7
provenance: direct
stages:
  - name: dependency_version_check
    command: go list -m -versions mvdan.cc/sh/v3
    result: pass
  - name: go_sidecar_tests
    command: env GOCACHE=/private/tmp/masc-shell-ir-oracle-go-build GOMODCACHE=/private/tmp/masc-shell-ir-oracle-go-mod go test ./...
    result: pass
  - name: fixture_json_parse
    command: jq -e . lib/exec/test/fixtures/shell_ir_oracle/*.json
    result: pass
  - name: focused_ocaml_build
    command: scripts/dune-local.sh build lib/exec/test/test_shell_ir_oracle.exe
    result: pass
  - name: focused_ocaml_test
    command: _build/default/lib/exec/test/test_shell_ir_oracle.exe
    result: pass
  - name: shell_ir_ratchet
    command: scripts/audit-shell-ir-consumption.sh --baseline scripts/shell-ir-consumption-baseline.json
    result: pass
  - name: diff_whitespace
    command: git diff --check origin/main...HEAD
    result: pass
```

## GOAL LOOP ACT checklist

- [x] Observe — shell-ir guide gap was a fixture/oracle implementation gap after #20101 added the OCaml data contract.
- [x] Orient — next bounded step is a non-production parser oracle emitter, not runtime policy wiring.
- [x] Decide — scope is limited to sidecar fixture generation plus parser fixture labels.
- [x] Act — added sidecar under `sidecars/shell-ir-oracle`; no runtime integration.
- [x] Verify — focused Go, JSON, OCaml, and Shell IR ratchet checks passed locally.
- [x] Loop — remaining follow-up is descriptor parity wiring from generated corpus output into broader differential tests.

## Review evidence

- Cross-model review: not run for this small non-runtime sidecar slice.
- Local evidence above covers parser output shape, fixture parsing, and Shell IR ratchet.

## Linked issue

- Closes #
- Relates #20101

## Variant addition checklist

- [x] **OCaml** — N/A; no OCaml variant added/removed.
- [x] **TypeScript** — N/A; no TypeScript union member changed.
- [x] **TLA+ spec** — N/A; no TLA+ domain literal changed.
- [x] **Event / JSON schema** — N/A; no event type or schema enum changed.
- [x] **`make check-variants` passes** — N/A for sidecar/fixture-only change; no variants touched.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`codex/shell-ir-oracle-sidecar-20260604` → `main` · 1 commit(s) · synced 2026-06-04T12:29:26Z

| sha | subject | date |
|---|---|---|
| `60f4258df` | feat(exec): add shell ir oracle sidecar | 2026-06-04 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->