### PR TITLE
refactor(keeper): drop persona runtime selection

### DIFF
--- a/docs/rfc/RFC-0215-keeper-sublibrary-extraction-campaign.md
+++ b/docs/rfc/RFC-0215-keeper-sublibrary-extraction-campaign.md
@@ -167,6 +167,14 @@ credential sub-lib must not reach `Masc_oas_bridge`). That inversion — callbac
 or interface, per the dependency-direction rule — is a separate PR that ships
 *before* the `dune` stanza.
 
+First code slice after the residual rename: remove stale persona-authoring
+runtime selection. Keeper TOML already fail-loud rejects `keeper.runtime_id` /
+`keeper.model` and routes runtime choice through `runtime.toml`
+`[[runtime.assignments]]`; persona authoring still advertised and normalized
+`keeper.runtime_id`, which forced `keeper_persona_authoring.ml` to call the flat
+`Runtime` module. The decoupling PR removes that schema/save path so credential
+authoring no longer reaches Runtime directly.
+
 ## 5. Extraction sequence
 
 Candidate clusters and their re-measured **flat-ns fan-out** (the G1 metric).

--- a/lib/keeper/keeper_persona_authoring.ml
+++ b/lib/keeper/keeper_persona_authoring.ml
@@ -327,7 +327,10 @@ let schema_json ?(include_examples = false) () =
 
 let handle_persona_schema_no_ctx args =
   let include_examples = get_bool args "include_examples" false in
-  Keeper_types_profile.tool_result_ok (Yojson.Safe.to_string (schema_json ~include_examples ()))
+  Tool_result.ok
+    ~tool_name:""
+    ~start_time:(Time_compat.now ())
+    (Yojson.Safe.to_string (schema_json ~include_examples ()))
 ;;
 
 let handle_persona_schema _ctx args = handle_persona_schema_no_ctx args
@@ -584,14 +587,22 @@ let handle_persona_save_no_ctx args =
   let dry_run = get_bool args "dry_run" false in
   match assoc_get "profile" args with
   | None ->
-    Keeper_types_profile.tool_result_error
+    Tool_result.error
+      ~tool_name:""
+      ~start_time:(Time_compat.now ())
       (error_response_typed ~code:Validation_error "profile is required")
   | Some profile ->
     (match save_persona ~overwrite ~dry_run ~handle profile with
      | Error msg ->
-       Keeper_types_profile.tool_result_error (error_response_typed ~code:Validation_error msg)
+       Tool_result.error
+         ~tool_name:""
+         ~start_time:(Time_compat.now ())
+         (error_response_typed ~code:Validation_error msg)
      | Ok result ->
-       Keeper_types_profile.tool_result_ok (Yojson.Safe.to_string (save_result_to_json ~dry_run result)))
+       Tool_result.ok
+         ~tool_name:""
+         ~start_time:(Time_compat.now ())
+         (Yojson.Safe.to_string (save_result_to_json ~dry_run result)))
 ;;
 
 let handle_persona_save _ctx args = handle_persona_save_no_ctx args

--- a/lib/keeper/keeper_persona_authoring.ml
+++ b/lib/keeper/keeper_persona_authoring.ml
@@ -221,12 +221,6 @@ let field_catalog_entries =
         ~choices:social_model_choices_json
         ~field_effect:"Optional social-model runtime for speech or ledger behavior."
         ()
-    ; field_catalog_entry
-        ~path:"keeper.runtime_id"
-        ~typ:"string"
-        ~field_effect:
-          "Optional runtime id override. Must resolve to a known runtime at runtime."
-        ()
   ]
 ;;
 
@@ -354,28 +348,7 @@ let normalize_social_model raw =
          (String.concat ", " Keeper_types_profile.valid_social_model_strings))
 ;;
 
-let normalize_runtime_id raw =
-  let normalized = String.trim raw in
-  (* RFC-0206: the runtime catalog is gone; the only valid runtime id beyond
-     the configured default name is the default runtime id itself. *)
-  let catalog =
-    try [ Runtime.get_default_runtime_id () ] with
-    | Eio.Cancel.Cancelled _ as exn -> raise exn
-    | _ -> []
-  in
-  let known =
-    [ Keeper_config.default_runtime_id () ]
-    @ catalog
-  in
-  if List.mem (String.lowercase_ascii normalized) known
-  then Ok normalized
-  else
-    Error
-      (Printf.sprintf
-         "invalid keeper.runtime_id '%s' (known: %s)"
-         raw
-         (String.concat ", " known))
-;;
+let removed_runtime_selection_fields = [ "runtime_id"; "model" ]
 
 let add_optional_string key fields keeper_json =
   match json_trimmed_string_opt key keeper_json with
@@ -410,8 +383,21 @@ let add_optional_string_list key fields keeper_json =
 let normalize_keeper_json ~handle keeper_json =
   match keeper_json with
   | `Assoc _ ->
-    let unknown = validate_unknown_keeper_fields keeper_json in
-    if unknown <> []
+    let removed_runtime_fields =
+      assoc_keys keeper_json
+      |> List.filter (fun key -> List.mem key removed_runtime_selection_fields)
+    in
+    if removed_runtime_fields <> []
+    then
+      Error
+        (Printf.sprintf
+           "keeper.%s %s removed. Assign keeper runtime in runtime.toml \
+            [[runtime.assignments]] keyed by keeper name."
+           (String.concat " / keeper." removed_runtime_fields)
+           (if List.length removed_runtime_fields = 1 then "is" else "are"))
+    else
+      let unknown = validate_unknown_keeper_fields keeper_json in
+      if unknown <> []
     then
       Error
         (Printf.sprintf
@@ -432,82 +418,66 @@ let normalize_keeper_json ~handle keeper_json =
               Result.map (fun value -> Some value) (normalize_social_model raw)
           in
           Result.bind social_model_result (fun social_model ->
-            let runtime_id_result =
-              match json_trimmed_string_opt "runtime_id" keeper_json with
-              | Some raw ->
-                Result.map (fun value -> Some value) (normalize_runtime_id raw)
-              | None -> Ok None
+            let mention_targets =
+              match json_string_list_normalized "mention_targets" keeper_json with
+              | [] -> [ handle ]
+              | xs -> xs
             in
-            Result.map
-              (fun runtime_id ->
-                 let mention_targets =
-                   match json_string_list_normalized "mention_targets" keeper_json with
-                   | [] -> [ handle ]
-                   | xs -> xs
-                 in
-                 let get_goal_horizon key =
-                   json_trimmed_string_opt key keeper_json |> Option.value ~default:goal
-                 in
-                 let fields =
-                   [ "goal", `String goal
-                   ; "short_goal", `String (get_goal_horizon "short_goal")
-                   ; "mid_goal", `String (get_goal_horizon "mid_goal")
-                   ; "long_goal", `String (get_goal_horizon "long_goal")
-                   ; "mention_targets", string_list_to_json mention_targets
-                   ; ( "proactive_enabled"
-                     , `Bool
-                         (Safe_ops.json_bool
-                            ~default:false
-                            "proactive_enabled"
-                            keeper_json) )
-                   ]
-                 in
-                 let fields =
-                   [ "will"; "needs"; "desires"; "instructions" ]
-                   |> List.fold_left
-                        (fun acc key -> add_optional_string key acc keeper_json)
-                        fields
-                 in
-                 let fields =
-                   [ "telemetry_feedback_enabled"
-                   ; "always_approve"
-                   ]
-                   |> List.fold_left
-                        (fun acc key -> add_optional_bool key acc keeper_json)
-                        fields
-                 in
-                 let fields =
-                   [ "proactive_idle_sec"
-                   ; "proactive_cooldown_sec"
-                   ; "telemetry_feedback_window_hours"
-                   ; "max_turns_per_call"
-                   ; "max_turns_per_call_scheduled_autonomous"
-                   ]
-                   |> List.fold_left
-                        (fun acc key -> add_optional_int key acc keeper_json)
-                        fields
-                 in
-                 let fields =
-                   add_optional_float "per_provider_timeout" fields keeper_json
-                 in
-                 let fields =
-                   [ "tool_denylist"; "shards" ]
-                   |> List.fold_left
-                        (fun acc key -> add_optional_string_list key acc keeper_json)
-                        fields
-                 in
-                 let fields =
-                   match social_model with
-                   | Some value -> assoc_set "social_model" (`String value) fields
-                   | None -> assoc_without "social_model" fields
-                 in
-                 let fields =
-                   match runtime_id with
-                   | Some value -> assoc_set "runtime_id" (`String value) fields
-                   | None -> assoc_without "runtime_id" fields
-                 in
-                 `Assoc (List.rev fields))
-              runtime_id_result)))
+            let get_goal_horizon key =
+              match json_trimmed_string_opt key keeper_json with
+              | Some value -> value
+              | None -> goal
+            in
+            let fields =
+              [ "goal", `String goal
+              ; "short_goal", `String (get_goal_horizon "short_goal")
+              ; "mid_goal", `String (get_goal_horizon "mid_goal")
+              ; "long_goal", `String (get_goal_horizon "long_goal")
+              ; "mention_targets", string_list_to_json mention_targets
+              ; ( "proactive_enabled"
+                , `Bool
+                    (Safe_ops.json_bool
+                       ~default:false
+                       "proactive_enabled"
+                       keeper_json) )
+              ]
+            in
+            let fields =
+              [ "will"; "needs"; "desires"; "instructions" ]
+              |> List.fold_left
+                   (fun acc key -> add_optional_string key acc keeper_json)
+                   fields
+            in
+            let fields =
+              [ "telemetry_feedback_enabled"; "always_approve" ]
+              |> List.fold_left
+                   (fun acc key -> add_optional_bool key acc keeper_json)
+                   fields
+            in
+            let fields =
+              [ "proactive_idle_sec"
+              ; "proactive_cooldown_sec"
+              ; "telemetry_feedback_window_hours"
+              ; "max_turns_per_call"
+              ; "max_turns_per_call_scheduled_autonomous"
+              ]
+              |> List.fold_left
+                   (fun acc key -> add_optional_int key acc keeper_json)
+                   fields
+            in
+            let fields = add_optional_float "per_provider_timeout" fields keeper_json in
+            let fields =
+              [ "tool_denylist"; "shards" ]
+              |> List.fold_left
+                   (fun acc key -> add_optional_string_list key acc keeper_json)
+                   fields
+            in
+            let fields =
+              match social_model with
+              | Some value -> assoc_set "social_model" (`String value) fields
+              | None -> assoc_without "social_model" fields
+            in
+            Ok (`Assoc (List.rev fields)))))
   | other ->
     Error
       (Printf.sprintf

--- a/lib/keeper/keeper_persona_authoring.mli
+++ b/lib/keeper/keeper_persona_authoring.mli
@@ -65,9 +65,10 @@ val schema_json : ?include_examples:bool -> unit -> Yojson.Safe.t
 
 (** Tool-handler entry for [keeper_persona_schema]. *)
 val handle_persona_schema :
-  _ Keeper_types_profile.context -> Yojson.Safe.t -> Keeper_types_profile.tool_result
+  'ctx -> Yojson.Safe.t -> Tool_result.result
 
-val handle_persona_schema_no_ctx : Yojson.Safe.t -> Keeper_types_profile.tool_result
+(** RFC-0182 §3.1 — ctx-free body for Persona_dispatch_ref path. *)
+val handle_persona_schema_no_ctx : Yojson.Safe.t -> Tool_result.result
 
 (** {1 Persona save / normalize} *)
 
@@ -97,9 +98,10 @@ val save_result_to_json :
 
 (** Tool-handler entry for [keeper_persona_save]. *)
 val handle_persona_save :
-  _ Keeper_types_profile.context -> Yojson.Safe.t -> Keeper_types_profile.tool_result
+  'ctx -> Yojson.Safe.t -> Tool_result.result
 
-val handle_persona_save_no_ctx : Yojson.Safe.t -> Keeper_types_profile.tool_result
+(** RFC-0182 §3.1 — ctx-free body for Persona_dispatch_ref path. *)
+val handle_persona_save_no_ctx : Yojson.Safe.t -> Tool_result.result
 
 (** {1 Persona archetype helpers} *)
 

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -1300,6 +1300,34 @@ let test_persona_authoring_allowed_keeper_fields_follow_catalog () =
   check (list string) "allowed keeper fields follow schema catalog" keeper_fields
     (List.sort String.compare KPA.allowed_keeper_fields)
 
+let test_persona_authoring_schema_omits_runtime_selection () =
+  let json = KPA.schema_json () in
+  let rendered = Yojson.Safe.to_string json in
+  check bool "schema omits keeper.runtime_id" false
+    (contains_substring rendered "keeper.runtime_id");
+  check bool "allowed fields omit runtime_id" false
+    (List.mem "runtime_id" KPA.allowed_keeper_fields)
+
+let test_persona_authoring_rejects_runtime_selection () =
+  let profile =
+    `Assoc
+      [
+        ( "keeper",
+          `Assoc
+            [
+              ("goal", `String "test");
+              ("runtime_id", `String "runpod_mtp.qwen");
+            ] );
+      ]
+  in
+  match KPA.normalize_profile ~handle:"probe" profile with
+  | Ok _ -> fail "expected persona runtime selection rejection"
+  | Error e ->
+      check bool "mentions runtime field" true
+        (contains_substring e "keeper.runtime_id");
+      check bool "mentions runtime assignments" true
+        (contains_substring e "runtime.toml [[runtime.assignments]]")
+
 let test_persona_authoring_axes_validate () =
   let args =
     `Assoc
@@ -2013,6 +2041,10 @@ let () =
             test_persona_authoring_social_model_choices_follow_variant_ssot;
           test_case "persona authoring allowed keeper fields follow catalog" `Quick
             test_persona_authoring_allowed_keeper_fields_follow_catalog;
+          test_case "persona authoring schema omits runtime selection" `Quick
+            test_persona_authoring_schema_omits_runtime_selection;
+          test_case "persona authoring rejects runtime selection" `Quick
+            test_persona_authoring_rejects_runtime_selection;
           test_case "persona authoring axes validate" `Quick
             test_persona_authoring_axes_validate;
           test_case "persona authoring axes reject unknown choices" `Quick


### PR DESCRIPTION
## Summary
- remove stale keeper.runtime_id from persona-authoring schema/save normalization
- reject persona-authored runtime/model selection with runtime.toml [[runtime.assignments]] guidance
- document the RFC-0215 credential decoupling slice that removes the direct Runtime edge

## Verification
- gtimeout 300 env DUNE_CACHE=disabled opam exec -- dune build --root . test/test_keeper_toml.exe
- gtimeout 120 _build/default/test/test_keeper_toml.exe
- ocamlformat --check lib/keeper/keeper_persona_authoring.ml test/test_keeper_toml.ml
- python3 scripts/audit-sublib-cycle.py --root .
- scripts/ocaml-structure-ratchet.sh
- bash scripts/check-doc-truth.sh
- bash scripts/lint/tool-keeper-boundary-ratchet.sh --fail
- bash scripts/stringly-boundary-ratchet.sh
- bash scripts/oas-boundary-ratchet.sh
- git diff --check origin/main...HEAD