### PR TITLE
fix(keeper): harden typed execute error surface

### DIFF
--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -515,6 +515,11 @@ let handle_tool_execute_typed
               then result.stdout
               else result.stdout ^ result.stderr
             in
+            let failure_error_fields =
+              match result.status, String.trim result.stderr with
+              | Unix.WEXITED 0, _ | _, "" -> []
+              | _, stderr -> [ "error", `String stderr; "stderr", `String stderr ]
+            in
             let classification = Exec_core.classify_command_of_ir ir in
             let deterministic_retry_fields =
               deterministic_retry_fields_for_process_result
@@ -538,6 +543,7 @@ let handle_tool_execute_typed
                  ~cmd
                  ~extra:
                    (deterministic_retry_fields
+                    @ failure_error_fields
                     @ sandbox_extra_fields
                     @ [ "cwd", `String cwd
                       ; "typed", `Bool true

--- a/lib/keeper/keeper_tool_execute_typed_input.ml
+++ b/lib/keeper/keeper_tool_execute_typed_input.ml
@@ -35,6 +35,10 @@ type validation_error =
     }
   | Empty_executable of { argv : string list }
   | Empty_argv of { executable : string }
+  | Executable_repeated_in_argv0 of {
+      executable : string;
+      argv : string list;
+    }
   | Argv_contains_shell_metachar of {
       executable : string;
       index : int;
@@ -407,6 +411,11 @@ let check_exec ~mode ~executable ~argv ~cwd ~env =
   if String.length trimmed = 0 then Error (Empty_executable { argv })
   else if not (is_allowed ~mode trimmed)
   then Error (Executable_not_allowlisted { name = trimmed; mode })
+  else if
+    match argv with
+    | first :: _ -> String.equal first trimmed
+    | [] -> false
+  then Error (Executable_repeated_in_argv0 { executable = trimmed; argv })
   else
     let* () =
       if argv = [] then Ok () else check_argv ~executable argv
@@ -631,6 +640,19 @@ let pp_validation_error ppf = function
        e.g. executable=\"cat\" argv=[\"file.txt\"]"
   | Empty_argv { executable } ->
     Format.fprintf ppf "executable %S invoked with empty argv" executable
+  | Executable_repeated_in_argv0 { executable; argv = (_ :: rest as argv) } ->
+    Format.fprintf
+      ppf
+      "executable %S is repeated as argv[0]; typed Execute argv contains \
+       only arguments after the executable. Rewrite as executable=%S argv=%s."
+      executable
+      executable
+      (Yojson.Safe.to_string (`List (List.map (fun arg -> `String arg) rest)))
+  | Executable_repeated_in_argv0 { executable; argv = [] } ->
+    Format.fprintf
+      ppf
+      "executable %S was reported as duplicated in argv[0], but argv is empty"
+      executable
   | Argv_contains_shell_metachar { executable; index; token } ->
     Format.fprintf
       ppf

--- a/lib/keeper/keeper_tool_execute_typed_input.mli
+++ b/lib/keeper/keeper_tool_execute_typed_input.mli
@@ -82,6 +82,10 @@ type validation_error =
     }
   | Empty_executable of { argv : string list }
   | Empty_argv of { executable : string }
+  | Executable_repeated_in_argv0 of {
+      executable : string;
+      argv : string list;
+    }
   | Argv_contains_shell_metachar of {
       executable : string;
       index : int;
@@ -146,10 +150,10 @@ val to_shell_ir :
 (** Validate and lower [input] into {!Masc_exec.Shell_ir.t}.  [Pipeline]
     inputs become an explicit {!Masc_exec.Shell_ir.Pipeline}; literal ["|"]
     argv tokens remain ordinary argument data and never create a pipeline.
-    [Exec] argv is passed through as authored; the lowerer does not strip a
-    duplicated executable token. [sandbox] defaults to host execution; keeper
-    callers may provide Docker runtime targets after sandbox/profile
-    resolution. *)
+    [Exec] argv is passed through as authored after validation; duplicated
+    executable tokens at [argv[0]] are rejected rather than silently stripped.
+    [sandbox] defaults to host execution; keeper callers may provide Docker
+    runtime targets after sandbox/profile resolution. *)
 
 val pp_validation_error : Format.formatter -> validation_error -> unit
 (** Human-readable formatter for {!validation_error}.  Stable across

--- a/test/test_keeper_tool_execute_safety.ml
+++ b/test/test_keeper_tool_execute_safety.ml
@@ -1013,6 +1013,104 @@ let test_tool_execute_typed_process_runs_via_shell_ir () =
      |> Json.to_string
      |> fun output -> String_util.contains_substring output "typed-ok")
 
+let test_tool_execute_typed_duplicate_argv0_rejected_before_runtime () =
+  with_eio_fs @@ fun () ->
+  let base_path, config = make_config () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  Keeper_registry.clear ();
+  let meta = make_readonly_meta "typed-duplicate-argv0" in
+  let playground = Filename.concat base_path (playground_path_of meta.name) in
+  ensure_dir playground;
+  ignore
+    (Fs_compat.save_file_atomic
+       (Filename.concat playground "keeper_sandbox.mli")
+       "(** Keeper_sandbox contract fixture. *)\n");
+  let raw =
+    Keeper_tool_command_runtime.handle_tool_execute
+      ~turn_sandbox_factory:None
+      ~exec_cache:None
+      ~config
+      ~meta
+      ~args:
+        (`Assoc
+           [ "executable", `String "cat"
+           ; "argv", `List [ `String "cat"; `String "-n"; `String "keeper_sandbox.mli" ]
+           ; "cwd", `String playground
+           ])
+      ()
+  in
+  let json = Yojson.Safe.from_string raw in
+  let err = json |> Json.member "error" |> Json.to_string in
+  Alcotest.(check bool)
+    "error explains argv0 contract"
+    true
+    (String_util.contains_substring err "repeated as argv[0]");
+  Alcotest.(check bool)
+    "file content did not leak into validation error"
+    false
+    (String_util.contains_substring raw "Keeper_sandbox contract fixture")
+
+let test_tool_execute_typed_failure_error_prefers_stderr () =
+  with_eio_fs @@ fun () ->
+  let base_path, config = make_config () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  Keeper_registry.clear ();
+  let meta = make_readonly_meta "typed-failure-stderr" in
+  let playground = Filename.concat base_path (playground_path_of meta.name) in
+  ensure_dir playground;
+  ignore
+    (Fs_compat.save_file_atomic
+       (Filename.concat playground "keeper_sandbox.mli")
+       "(** Keeper_sandbox contract fixture. *)\n");
+  let raw =
+    Keeper_tool_command_runtime.handle_tool_execute
+      ~turn_sandbox_factory:None
+      ~exec_cache:None
+      ~config
+      ~meta
+      ~args:
+        (`Assoc
+           [ "executable", `String "cat"
+           ; "argv", `List [ `String "keeper_sandbox.mli"; `String "missing-file" ]
+           ; "cwd", `String playground
+           ])
+      ()
+  in
+  let json = Yojson.Safe.from_string raw in
+  Alcotest.(check bool) "cat failure is not ok" false
+    (json |> Json.member "ok" |> Json.to_bool);
+  let err = json |> Json.member "error" |> Json.to_string in
+  Alcotest.(check bool)
+    "top-level error uses stderr"
+    true
+    (String_util.contains_substring err "No such file or directory");
+  Alcotest.(check bool)
+    "top-level error excludes stdout file dump"
+    false
+    (String_util.contains_substring err "Keeper_sandbox contract fixture");
+  Alcotest.(check bool)
+    "raw output still preserves stdout for debugging"
+    true
+    (json
+     |> Json.member "output"
+     |> Json.to_string
+     |> fun output -> String_util.contains_substring output "Keeper_sandbox contract fixture");
+  let normalized =
+    Masc.Keeper_tools_oas.normalize_tool_result ~success:false raw
+    |> Yojson.Safe.from_string
+  in
+  let normalized_error = normalized |> Json.member "error" |> Json.to_string in
+  Alcotest.(check bool)
+    "OAS-normalized error also uses stderr"
+    true
+    (String_util.contains_substring normalized_error "No such file or directory");
+  Alcotest.(check bool)
+    "OAS-normalized error excludes stdout file dump"
+    false
+    (String_util.contains_substring
+       normalized_error
+       "Keeper_sandbox contract fixture")
+
 let test_tool_execute_typed_pipeline_runs_via_shell_ir () =
   with_eio_fs @@ fun () ->
   let base_path, config = make_config () in
@@ -1596,6 +1694,14 @@ let () =
             "typed process runs via Shell IR"
             `Quick
             test_tool_execute_typed_process_runs_via_shell_ir
+        ; Alcotest.test_case
+            "typed duplicate argv0 rejects before runtime"
+            `Quick
+            test_tool_execute_typed_duplicate_argv0_rejected_before_runtime
+        ; Alcotest.test_case
+            "typed failure top-level error prefers stderr"
+            `Quick
+            test_tool_execute_typed_failure_error_prefers_stderr
         ; Alcotest.test_case
             "typed pipeline runs via Shell IR"
             `Quick

--- a/test/test_keeper_tool_execute_typed_input.ml
+++ b/test/test_keeper_tool_execute_typed_input.ml
@@ -79,6 +79,14 @@ let cases : case list =
     ; expect_typed = true
     ; rationale = "relative path argv"
     }
+  ; { name = "duplicate_executable_argv0"
+    ; sample_cmd = "cat cat README.md"
+    ; typed = mk_exec "cat" [ "cat"; "README.md" ]
+    ; expect_typed = false
+    ; rationale =
+        "typed Execute argv excludes argv[0]; repeating executable would \
+         execute the wrong file list"
+    }
   ; { name = "unknown_executable"
     ; sample_cmd = "unknown_cmd foo"
     ; typed = mk_exec "unknown_cmd" [ "foo" ]
@@ -265,6 +273,42 @@ let test_empty_executable_with_argv_hints_rewrite () =
       Execute_input.pp_validation_error
       error
   | Ok () -> Alcotest.fail "empty executable should not be accepted"
+;;
+
+let test_duplicate_executable_argv0_rejected () =
+  match
+    Execute_input.validate
+      ~mode:Execute_input.Dev_full
+      (mk_exec "cat" [ "cat"; "-n"; "keeper_sandbox.mli" ])
+  with
+  | Error (Execute_input.Executable_repeated_in_argv0 { executable; argv }) ->
+    Alcotest.(check string) "executable" "cat" executable;
+    Alcotest.(check (list string))
+      "argv preserved for rewrite"
+      [ "cat"; "-n"; "keeper_sandbox.mli" ]
+      argv;
+    let msg =
+      Format.asprintf
+        "%a"
+        Execute_input.pp_validation_error
+        (Execute_input.Executable_repeated_in_argv0 { executable; argv })
+    in
+    Alcotest.(check bool)
+      "error points at argv[0]"
+      true
+      (String_util.contains_substring_ci msg "argv[0]");
+    Alcotest.(check bool)
+      "error rewrites without duplicated executable"
+      true
+      (String_util.contains_substring_ci
+         msg
+         "argv=[\"-n\",\"keeper_sandbox.mli\"]")
+  | Error error ->
+    Alcotest.failf
+      "expected Executable_repeated_in_argv0, got %a"
+      Execute_input.pp_validation_error
+      error
+  | Ok () -> Alcotest.fail "duplicated argv[0] should not be accepted"
 ;;
 
 (* Regression: validate-bypass paths (to_shell_ir_unvalidated /
@@ -684,7 +728,7 @@ let test_pipeline_lowers_to_shell_ir_pipeline () =
     Alcotest.failf "expected Shell_ir.Pipeline, got %a" Masc_exec.Shell_ir.pp other
 ;;
 
-let test_exec_lowering_preserves_duplicate_executable_argv () =
+let test_exec_lowering_rejects_duplicate_executable_argv () =
   let input =
     Execute_input.Exec
       { executable = "git"
@@ -696,14 +740,20 @@ let test_exec_lowering_preserves_duplicate_executable_argv () =
       ; stderr = Execute_input.Inherit
       }
   in
-  match to_shell_ir_exn input with
-  | Masc_exec.Shell_ir.Simple simple ->
-    Alcotest.(check (pair string (list string)))
-      "duplicate executable token is caller data"
-      ("git", [ "git"; "status" ])
-      (shell_simple_tuple simple)
-  | Masc_exec.Shell_ir.Pipeline _ ->
-    Alcotest.fail "single exec input must not create Shell_ir.Pipeline"
+  match Execute_input.to_shell_ir ~mode:Execute_input.Dev_full input with
+  | Error
+      (Execute_input.Executable_repeated_in_argv0
+        { executable = "git"; argv = [ "git"; "status" ] }) -> ()
+  | Error error ->
+    Alcotest.failf
+      "expected Executable_repeated_in_argv0, got %a"
+      Execute_input.pp_validation_error
+      error
+  | Ok ir ->
+    Alcotest.failf
+      "duplicated argv[0] should not produce Shell IR, got %a"
+      Masc_exec.Shell_ir.pp
+      ir
 ;;
 
 let docker_test_sandbox () =
@@ -986,6 +1036,11 @@ let test_validation_error_alternatives () =
     (Execute_input.Empty_executable { argv = [ "ls" ] })
     [];
   check_alts
+    ~name:"Executable_repeated_in_argv0 has no alternatives"
+    (Execute_input.Executable_repeated_in_argv0
+       { executable = "cat"; argv = [ "cat"; "file" ] })
+    [];
+  check_alts
     ~name:"Cwd_not_absolute has no alternatives"
     (Execute_input.Cwd_not_absolute "relative")
     []
@@ -1182,6 +1237,10 @@ let suite =
           `Quick
           test_empty_executable_with_argv_hints_rewrite
       ; Alcotest.test_case
+          "duplicate_executable_argv0_rejected"
+          `Quick
+          test_duplicate_executable_argv0_rejected
+      ; Alcotest.test_case
           "unvalidated_path_preserves_argv_in_error"
           `Quick
           test_unvalidated_path_preserves_argv_in_error
@@ -1248,9 +1307,9 @@ let suite =
           `Quick
           test_pipeline_lowers_to_shell_ir_pipeline
       ; Alcotest.test_case
-          "exec_lowering_preserves_duplicate_executable_argv"
+          "exec_lowering_rejects_duplicate_executable_argv"
           `Quick
-          test_exec_lowering_preserves_duplicate_executable_argv
+          test_exec_lowering_rejects_duplicate_executable_argv
       ; Alcotest.test_case
           "pipeline_lowers_with_injected_docker_sandbox"
           `Quick


### PR DESCRIPTION
## Summary

- Reject typed Execute inputs that repeat the executable in `argv[0]`, e.g. `executable="cat" argv=["cat", ...]`.
- Preserve combined process output for debugging while surfacing stderr as the top-level failure `error` when a typed process exits non-zero.
- Add validator/runtime regressions for the `cat cat -n keeper_sandbox.mli` and stdout+stderr failure cases.

## Product impact

- User-visible change: Keeper Execute failures should stop reporting file stdout dumps as the primary error when stderr contains the actual diagnostic.
- Incorrect typed Execute argv shapes now fail before process dispatch with a self-correction message.

## Evidence

- `git diff --check HEAD~1..HEAD` PASS.
- `bash scripts/check-variants.sh` PASS.
- `scripts/dune-local.sh build test/test_keeper_tool_execute_safety.exe test/test_keeper_tool_execute_typed_input.exe` not run to completion: wrapper refused because unrelated bare `dune build` processes were already running outside `scripts/dune-local.sh`.

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 3/3
provenance: direct
stages:
  - command: git diff --check HEAD~1..HEAD
    result: pass
  - command: bash scripts/check-variants.sh
    result: pass
  - command: scripts/dune-local.sh build test/test_keeper_tool_execute_safety.exe test/test_keeper_tool_execute_typed_input.exe
    result: blocked
    reason: live bare Dune processes outside scripts/dune-local.sh
```

## GOAL LOOP ACT checklist

- [x] Observe — live Keeper logs showed `cat cat -n keeper_sandbox.mli` returning stdout file content as top-level `error`.
- [x] Orient — mapped to typed Execute argv contract drift plus failure normalization choosing `output` when no `error` field existed.
- [x] Decide — scoped to typed Execute validation and failure envelope only.
- [x] Act — added duplicate-argv0 validation and stderr-first failure error field.
- [ ] Verify — focused Dune build blocked locally by unrelated bare Dune processes; regression tests added for CI.
- [x] Loop — no follow-up beyond unblocking/running focused Dune.

## Review evidence

- Local self-review of changed Execute validator/runtime paths.
- Cross-model review not run.

## Linked issue

- Relates #20100

## Variant addition checklist

- [x] **OCaml** — variant added in `.ml`/`.mli`; formatter and alternatives match updated.
- [ ] **TypeScript** — N/A: internal OCaml validation error, not dashboard/event union.
- [ ] **TLA+ spec** — N/A: internal validation error, not lifecycle/domain state.
- [ ] **Event / JSON schema** — N/A: no event enum or JSON schema enum changed.
- [x] **`make check-variants` passes** — `bash scripts/check-variants.sh` PASS.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`fix/execute-typed-argv-error-surface-20260604` → `main` · 1 commit(s) · synced 2026-06-04T12:34:05Z

| sha | subject | date |
|---|---|---|
| `bc3c95c12` | fix(keeper): harden typed execute error surface | 2026-06-04 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->