### PR TITLE
fix(keeper): remove unused typed execute argv alias

### DIFF
--- a/lib/keeper/keeper_tool_execute_typed_input.ml
+++ b/lib/keeper/keeper_tool_execute_typed_input.ml
@@ -640,7 +640,7 @@ let pp_validation_error ppf = function
        e.g. executable=\"cat\" argv=[\"file.txt\"]"
   | Empty_argv { executable } ->
     Format.fprintf ppf "executable %S invoked with empty argv" executable
-  | Executable_repeated_in_argv0 { executable; argv = (_ :: rest as argv) } ->
+  | Executable_repeated_in_argv0 { executable; argv = _ :: rest } ->
     Format.fprintf
       ppf
       "executable %S is repeated as argv[0]; typed Execute argv contains \


### PR DESCRIPTION
## Summary

- Remove the unused `argv` alias from `Executable_repeated_in_argv0` formatting.
- This fixes the warn-error failure introduced by #20108.

## Product impact

- User-visible change: none beyond unblocking CI for the typed Execute error-surface fix.

## Evidence

- `opam exec -- ocamlformat --check lib/keeper/keeper_tool_execute_typed_input.ml` PASS.
- `git diff --check` PASS.
- `bash scripts/check-variants.sh` PASS.
- `scripts/dune-local.sh build lib/masc.cma` blocked locally by an unrelated bare `dune build` already running outside `scripts/dune-local.sh`.

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 4/4
provenance: direct
stages:
  - command: opam exec -- ocamlformat --check lib/keeper/keeper_tool_execute_typed_input.ml
    result: pass
  - command: git diff --check
    result: pass
  - command: bash scripts/check-variants.sh
    result: pass
  - command: scripts/dune-local.sh build lib/masc.cma
    result: blocked
    reason: live bare Dune process outside scripts/dune-local.sh
```

## GOAL LOOP ACT checklist

- [x] Observe — #20108 Lint failed on warning 26: unused variable `argv`.
- [x] Orient — warning came from the duplicate argv0 formatter alias.
- [x] Decide — one-line follow-up on latest main is the smallest fix.
- [x] Act — removed the unused alias.
- [ ] Verify — focused Dune blocked locally by unrelated bare Dune; CI should verify.
- [x] Loop — no additional follow-up expected.

## Review evidence

- Local self-review of the one-line warning fix.

## Linked issue

- Relates #20108

## Variant addition checklist

- [ ] **OCaml** — N/A: no variant added/removed in this follow-up.
- [ ] **TypeScript** — N/A.
- [ ] **TLA+ spec** — N/A.
- [ ] **Event / JSON schema** — N/A.
- [x] **`make check-variants` passes** — `bash scripts/check-variants.sh` PASS.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`fix/typed-execute-unused-argv-20260604` → `main` · 1 commit(s) · synced 2026-06-04T12:48:13Z

| sha | subject | date |
|---|---|---|
| `9cadafb38` | fix(keeper): remove unused typed execute argv alias | 2026-06-04 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->