### PR TITLE
[codex] Restore keeper tool hints TOML syntax

### DIFF
--- a/config/prompts/keeper.tool_hints.toml
+++ b/config/prompts/keeper.tool_hints.toml
@@ -73,6 +73,7 @@ name = "WebFetch"
 call = "`WebFetch` { url: \"https://example.com/page\", timeout: {{web_fetch_timeout}} }"
 description = "fetch and read a web page before citing it"
 
+[[hints]]
 name = "masc_transition"
 call = "`masc_transition` { task_id: \"TASK_ID\", action: \"approve\", notes: \"verification evidence\" }"
 description = "approve or reject an awaiting_verification task after inspecting evidence"


### PR DESCRIPTION
## Summary
- restore the missing [[hints]] table header before the masc_transition keeper tool hint
- fix the TOML syntax failure introduced by the verification alias cleanup merge

## Verification
- scripts/check-toml-syntax.sh
- scripts/validate-prompt-paths.sh
- git diff --check