### PR TITLE
fix(config): restore keeper tool hint entry header

### DIFF
--- a/config/prompts/keeper.tool_hints.toml
+++ b/config/prompts/keeper.tool_hints.toml
@@ -73,6 +73,7 @@ name = "WebFetch"
 call = "`WebFetch` { url: \"https://example.com/page\", timeout: {{web_fetch_timeout}} }"
 description = "fetch and read a web page before citing it"
 
+[[hints]]
 name = "masc_transition"
 call = "`masc_transition` { task_id: \"TASK_ID\", action: \"approve\", notes: \"verification evidence\" }"
 description = "approve or reject an awaiting_verification task after inspecting evidence"


### PR DESCRIPTION
## Summary

- Restore the missing `[[hints]]` table header before the `masc_transition` keeper tool hint.
- Fix current `main` TOML syntax drift that breaks `scripts/check-toml-syntax.sh` and unrelated PR lint runs.

## Product impact

- Keeps keeper tool guidance hints parseable at runtime.
- Unblocks unrelated PR CI that evaluates the merge ref against current `main`.

## Evidence

- `scripts/check-toml-syntax.sh`
- `git diff --check`

## Direct evidence

schema_version: 1
direct_ratio: 2/2
provenance: direct

- `scripts/check-toml-syntax.sh` parsed all TOML files successfully.
- `git diff --check` passed with no output.

## Review evidence

- Not applicable; this is a one-line config syntax repair.

## Linked issue

- Follow-up from #20106 Lint failure on current `main` drift.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`fix/keeper-tool-hints-toml-20260604` → `main` · 1 commit(s) · synced 2026-06-04T13:27:39Z

| sha | subject | date |
|---|---|---|
| `510798c29` | fix(config): restore keeper tool hint entry header | 2026-06-04 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->