### PR TITLE
fix(keeper): surface preserved sandbox repo currency

### DIFF
--- a/lib/keeper/keeper_tool_execute_path.ml
+++ b/lib/keeper/keeper_tool_execute_path.ml
@@ -40,9 +40,9 @@ let sync_repo_currency_best_effort ~config ~meta ~repo_name =
         Log.Keeper.info "currency: advanced sandbox repo %s by %d commit(s)"
           repo_name commits
       | Preserved reason ->
-        (* Local/divergent work kept; expected when a keeper has uncommitted or
-           branched changes. Debug so it does not drown the actionable case. *)
-        Log.Keeper.debug "currency: preserved sandbox repo %s (%s)" repo_name reason
+        (* Local/divergent work kept. Keep this visible: otherwise a dirty or
+           task-branch sandbox looks like the runtime simply forgot to update. *)
+        Log.Keeper.info "currency: preserved sandbox repo %s (%s)" repo_name reason
       | Skipped reason ->
         (* Currency could not be established (missing/corrupt clone, no
            credential, or fetch failure). Visible by default so a recurring


### PR DESCRIPTION
## Summary
- make sandbox repo currency preservation visible at INFO level
- keeps dirty/task-branch clones protected, but stops making them look like repo sync never ran

## Context
The rondo playground clone was dirty and on a task branch: 15 ahead / 621 behind origin/main. The currency path correctly preserved it instead of pulling/rebasing, but the reason was logged only at debug level.

## Verification
- opam exec -- ocamlformat --check lib/keeper/keeper_tool_execute_path.ml
- git diff --check

## Not run
- scripts/dune-local.sh build lib/masc.cma: blocked by unrelated bare Dune processes outside the wrapper