### PR TITLE
Fix dashboard auth and source status drift

### DIFF
--- a/dashboard/src/components/agent-roster.test.ts
+++ b/dashboard/src/components/agent-roster.test.ts
@@ -541,12 +541,12 @@ describe('AgentRoster live-only cards', () => {
     const text = container.textContent ?? ''
     expect(text).toContain('albini')
     expect(text).toContain('keeper_tools_list')
-    expect(text).toContain('Source mismatch')
-    expect(text).toContain('agent registry 0')
+    expect(text).not.toContain('Source mismatch')
+    expect(text).not.toContain('agent registry 0')
     expect(text).not.toContain('파생')
   })
 
-  it('surfaces source mismatch on default keeper ops when agent registry is empty', async () => {
+  it('does not report source mismatch on default keeper ops when keeper projection has rows', async () => {
     agents.value = []
     keepers.value = [
       {
@@ -565,8 +565,8 @@ describe('AgentRoster live-only cards', () => {
 
     const text = container.textContent ?? ''
     expect(text).toContain('albini')
-    expect(text).toContain('Source mismatch')
-    expect(text).toContain('keeper projection 1')
+    expect(text).not.toContain('Source mismatch')
+    expect(text).not.toContain('keeper projection 1')
     expect(text).not.toContain('파생')
   })
 

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -774,13 +774,6 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
     keeperFilter === 'agent-only' || configuredKeeperDelta === 0
       ? null
       : `일시정지/미기동 ${configuredKeeperDelta}개`
-  const sourceMismatchNotice =
-    keeperFilter !== 'agent-only' && agentList.length === 0 && keeperList.length > 0
-      ? {
-          title: 'Source mismatch',
-          message: `agent registry 0 · keeper projection ${keeperList.length} 기준입니다. live presence는 keeper runtime 상태에서만 표시됩니다.`,
-        }
-      : null
   const fallbackStateTitle =
     executionError.value
       ? '상세 상태 불러오기 실패'
@@ -961,17 +954,6 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
               `
             : null}
 
-          ${sourceMismatchNotice ? html`
-            <div class="rounded-[var(--r-1)] border border-[var(--warn-border)] bg-[var(--warn-10)] px-4 py-3 shadow-[var(--shadow-panel)]">
-              <div class="flex flex-col gap-2">
-                <div class="flex flex-wrap items-center gap-2">
-                  <strong class="text-xs font-semibold text-[var(--color-fg-secondary)]">${sourceMismatchNotice.title}</strong>
-                  <span class="rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-0.5 text-3xs text-[var(--color-fg-muted)]">keeper fleet</span>
-                </div>
-                <p class="m-0 text-xs leading-paragraph text-[var(--color-fg-primary)]">${sourceMismatchNotice.message}</p>
-              </div>
-            </div>
-          ` : null}
         </div>
       </section>
 

--- a/dashboard/src/components/dashboard-shell.test.ts
+++ b/dashboard/src/components/dashboard-shell.test.ts
@@ -78,6 +78,30 @@ describe('dashboardHealthChips', () => {
       .toBe('활성=shell runtime, paused=상세 행 lifecycle, 설정=shell keeper inventory.')
   })
 
+  it('does not label an intentional server/base split as data source mismatch', () => {
+    const chips = dashboardHealthChips({
+      connected: true,
+      counts: { keepers: 1, configured_keepers: 1 },
+      keepers: [{ name: 'keeper-a', status: 'running' } as any],
+      runtimeResolution: {
+        status: 'warn',
+        warnings: [],
+        source_mismatch: false,
+        server_workspace_mismatch: true,
+      } as any,
+      executionError: null,
+      loading: false,
+    })
+
+    expect(chips.find(chip => chip.key === 'source-mismatch')).toBeUndefined()
+    expect(chips).toContainEqual(expect.objectContaining({
+      key: 'server-workspace-split',
+      label: 'Server/base split',
+      tone: 'muted',
+      route: { tab: 'monitoring', params: { section: 'runtime' } },
+    }))
+  })
+
   it('uses namespace truth as the configured keeper count authority in health chips', () => {
     const chips = dashboardHealthChips({
       connected: true,

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -407,6 +407,7 @@ function cdalHealthChip(cdal: DashboardCdalHealth | null | undefined): Dashboard
 function chipRouteFor(key: string): DashboardHealthChipRoute | undefined {
   switch (key) {
     case 'source-mismatch':
+    case 'server-workspace-split':
     case 'runtime-warning':
       return { tab: 'monitoring', params: { section: 'runtime' } }
     case 'paused-keepers':
@@ -432,12 +433,19 @@ export function dashboardHealthChips(input: DashboardHealthInput): DashboardHeal
   }
 
   const runtime = input.runtimeResolution
-  if (runtime?.source_mismatch || runtime?.server_workspace_mismatch) {
+  if (runtime?.source_mismatch) {
     chips.push({
       key: 'source-mismatch',
       label: 'Source mismatch',
       detail: 'Server, workspace, or resolved base path source differs.',
       tone: 'warn',
+    })
+  } else if (runtime?.server_workspace_mismatch) {
+    chips.push({
+      key: 'server-workspace-split',
+      label: 'Server/base split',
+      detail: 'Server binary repo differs from the dashboard base path; data still resolves from the base path.',
+      tone: 'muted',
     })
   } else if (runtime?.status && runtime.status !== 'ready') {
     chips.push({

--- a/dashboard/src/sse-store.test.ts
+++ b/dashboard/src/sse-store.test.ts
@@ -30,7 +30,7 @@ const refreshExecution = vi.fn<() => Promise<void>>(async () => {})
 const refreshBoard = vi.fn<() => void>(() => {})
 const invalidateDashboardCache = vi.fn<() => void>(() => {})
 const hydrateBoardSnapshot = vi.fn<(payload: unknown) => void>(() => {})
-const hydrateShellSnapshot = vi.fn<(payload: unknown) => void>(() => {})
+const hydrateShellSnapshot = vi.fn<(payload: unknown, opts?: unknown) => void>(() => {})
 const hydrateExecutionSnapshot = vi.fn<(payload: unknown) => void>(() => {})
 const hydratePlanningSnapshot = vi.fn<(payload: unknown) => void>(() => {})
 const removeBoardPost = vi.fn<(postId?: string) => void>(() => {})
@@ -516,7 +516,7 @@ describe('setupSSEReaction reconnect hydration', () => {
 
     expect(hydrateShellSnapshot).toHaveBeenCalledWith(
       payloads.shell,
-      { light: true },
+      { light: true, preserveAuth: true },
     )
     expect(hydrateExecutionSnapshot).toHaveBeenCalledWith(payloads.execution)
     expect(hydrateBoardSnapshot).toHaveBeenCalledWith(payloads.board)

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -566,7 +566,7 @@ export function hydrateDashboardSlice(slice: string, payload: unknown, eventType
 
   switch (slice) {
     case 'shell':
-      hydrateShellSnapshot(payload as DashboardShellResponse, { light: true })
+      hydrateShellSnapshot(payload as DashboardShellResponse, { light: true, preserveAuth: true })
       return
     case 'namespace':
       hydrateServerPushEvent({ type: 'project_snapshot', payload } as SSEEvent)

--- a/dashboard/src/store-shell-auth.test.ts
+++ b/dashboard/src/store-shell-auth.test.ts
@@ -63,4 +63,52 @@ describe('refreshShell auth failure handling', () => {
       6000,
     )
   })
+
+  it('preserves request-bound auth when hydrating a pushed shell slice', async () => {
+    const sessionActor = await import('./lib/dashboard-session-actor')
+    const store = await import('./store')
+
+    const verifiedAuth = {
+      enabled: true,
+      require_token: true,
+      token_present: true,
+      requested_agent: 'dashboard',
+      effective_agent: 'dashboard',
+      effective_role: 'admin',
+      default_role: 'worker',
+      token_valid: true,
+      token_agent: 'dashboard',
+      auth_error_code: null,
+      auth_error_detail: null,
+      can_keeper_msg: true,
+      keeper_msg_error: null,
+    } as const
+
+    sessionActor.setCanonicalDashboardActor('dashboard')
+    store.shellAuthSummary.value = verifiedAuth
+
+    store.hydrateShellSnapshot(
+      {
+        generated_at: '2026-06-04T13:26:17Z',
+        status: { project: 'me' },
+        counts: { agents: 0, tasks: 1, keepers: 1, total_runtimes: 1 },
+        auth: {
+          enabled: true,
+          require_token: true,
+          token_present: false,
+          token_valid: false,
+          effective_agent: 'dashboard',
+          effective_role: null,
+          auth_error_code: 'missing_token',
+          auth_error_detail: 'Authentication required',
+          can_keeper_msg: false,
+          keeper_msg_error: 'Authentication required',
+        },
+      } as never,
+      { light: true, preserveAuth: true },
+    )
+
+    expect(store.shellAuthSummary.value).toBe(verifiedAuth)
+    expect(sessionActor.currentCanonicalDashboardActor()).toBe('dashboard')
+  })
 })

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -824,14 +824,20 @@ function normalizeShellAuthSummary(raw: unknown): DashboardShellAuthSummary | nu
   }
 }
 
-export function hydrateShellSnapshot(data: DashboardShellResponse, opts?: { light?: boolean }): void {
+export function hydrateShellSnapshot(
+  data: DashboardShellResponse,
+  opts?: { light?: boolean; preserveAuth?: boolean },
+): void {
   const wantsLight = opts?.light === true
+  const preserveAuth = opts?.preserveAuth === true
   const normalizedAuth = normalizeShellAuthSummary(data.auth)
-  setCanonicalDashboardActor(
-    normalizedAuth?.token_valid
-      ? normalizedAuth.effective_agent ?? normalizedAuth.token_agent ?? null
-      : null,
-  )
+  if (!preserveAuth) {
+    setCanonicalDashboardActor(
+      normalizedAuth?.token_valid
+        ? normalizedAuth.effective_agent ?? normalizedAuth.token_agent ?? null
+        : null,
+    )
+  }
   const normalizedStatus = normalizeServerStatus(data.status, data.generated_at)
   if (normalizedStatus) {
     serverStatus.value = mergeServerStatus(serverStatus.value, normalizedStatus)
@@ -845,7 +851,9 @@ export function hydrateShellSnapshot(data: DashboardShellResponse, opts?: { ligh
       configured_keepers: data.configured_keepers ?? 0,
     }
   }
-  shellAuthSummary.value = normalizedAuth
+  if (!preserveAuth) {
+    shellAuthSummary.value = normalizedAuth
+  }
   const normalizedConfigResolution = normalizeDashboardConfigResolution(data.config_resolution)
   const normalizedRuntimeResolution = normalizeDashboardRuntimeResolution(data.runtime_resolution)
   if (!wantsLight || normalizedConfigResolution) {


### PR DESCRIPTION
## Summary

- Preserve request-bound dashboard auth when hydrating server-pushed shell slices.
- Stop treating keeper runtime projection rows as a source mismatch when the agent registry is empty.
- Split true data source mismatch from the expected server/base-path split and downgrade that split to informational health.

## Product impact

- The dashboard should no longer flicker between `Verified` and unauthenticated/local state after Client WS shell updates.
- Keeper Fleet should render keeper-only rows as first-class runtime rows instead of showing `Source mismatch · agent registry 0`.
- Operators still get a runtime drill-down when the server binary repo differs from the dashboard base path, but it is no longer labeled as a data-source mismatch.

## Evidence

- `pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/agent-roster.test.ts src/components/dashboard-shell.test.ts src/sse-store.test.ts src/store-shell-auth.test.ts`
  - Result: 4 files passed, 65 tests passed.
- `pnpm exec tsc --noEmit --pretty false`
  - Result: pass.
- `git diff --check`
  - Result: pass.
- Playwright screenshot against local patched dev server:
  - URL: `http://127.0.0.1:5174/dashboard/#monitoring?section=agents`
  - Waited for `text=Verified`, then 6 seconds before capture.
  - Result: auth stayed `Verified @dashboard · admin`; Keeper Fleet no longer rendered the inner `Source mismatch` notice.

## Direct evidence

schema_version: 1
direct_ratio: 4/4
provenance: direct

- Live shell without a request auth token reported `auth_error_code=missing_token`, while runtime resolution stayed on base path `/Users/dancer/me` and data root `/Users/dancer/me/.masc`.
- Live execution surface reported 15 keeper rows: 12 `running`, 3 `failing`.
- Live execution-trust surface reported receipt/cache coverage gap and all-root `status=offline`; this PR avoids treating that receipt-only projection as keeper live presence.
- Local browser verification used the patched dashboard dev server proxied to `http://127.0.0.1:8935`.

## Review evidence

- Added regression coverage for pushed shell slices using `{ preserveAuth: true }`.
- Added regression coverage so `server_workspace_mismatch` does not become `source-mismatch`.
- Updated Keeper Fleet tests to assert keeper projection rows do not show source mismatch when agent registry rows are absent.

## Linked issue

- None.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`codex/dashboard-auth-push-source-20260604` → `main` · 1 commit(s) · synced 2026-06-04T13:50:01Z

| sha | subject | date |
|---|---|---|
| `fca9687b2` | Fix dashboard auth and source status drift | 2026-06-04 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->