### PR TITLE
refactor(keeper): decouple persona authoring tool results

### DIFF
--- a/lib/keeper/keeper_persona_authoring.ml
+++ b/lib/keeper/keeper_persona_authoring.ml
@@ -328,7 +328,10 @@ let schema_json ?(include_examples = false) () =
 (* RFC-0182 §3.1 — ctx-free body shared with Persona_dispatch_ref path. *)
 let handle_persona_schema_no_ctx args =
   let include_examples = get_bool args "include_examples" false in
-  Keeper_types_profile.tool_result_ok (Yojson.Safe.to_string (schema_json ~include_examples ()))
+  Tool_result.ok
+    ~tool_name:""
+    ~start_time:(Time_compat.now ())
+    (Yojson.Safe.to_string (schema_json ~include_examples ()))
 ;;
 
 let handle_persona_schema _ctx args = handle_persona_schema_no_ctx args
@@ -586,14 +589,22 @@ let handle_persona_save_no_ctx args =
   let dry_run = get_bool args "dry_run" false in
   match assoc_get "profile" args with
   | None ->
-    Keeper_types_profile.tool_result_error
+    Tool_result.error
+      ~tool_name:""
+      ~start_time:(Time_compat.now ())
       (error_response_typed ~code:Validation_error "profile is required")
   | Some profile ->
     (match save_persona ~overwrite ~dry_run ~handle profile with
      | Error msg ->
-       Keeper_types_profile.tool_result_error (error_response_typed ~code:Validation_error msg)
+       Tool_result.error
+         ~tool_name:""
+         ~start_time:(Time_compat.now ())
+         (error_response_typed ~code:Validation_error msg)
      | Ok result ->
-       Keeper_types_profile.tool_result_ok (Yojson.Safe.to_string (save_result_to_json ~dry_run result)))
+       Tool_result.ok
+         ~tool_name:""
+         ~start_time:(Time_compat.now ())
+         (Yojson.Safe.to_string (save_result_to_json ~dry_run result)))
 ;;
 
 let handle_persona_save _ctx args = handle_persona_save_no_ctx args

--- a/lib/keeper/keeper_persona_authoring.mli
+++ b/lib/keeper/keeper_persona_authoring.mli
@@ -65,10 +65,10 @@ val schema_json : ?include_examples:bool -> unit -> Yojson.Safe.t
 
 (** Tool-handler entry for [keeper_persona_schema]. *)
 val handle_persona_schema :
-  _ Keeper_types_profile.context -> Yojson.Safe.t -> Keeper_types_profile.tool_result
+  'ctx -> Yojson.Safe.t -> Tool_result.result
 
 (** RFC-0182 §3.1 — ctx-free body for Persona_dispatch_ref path. *)
-val handle_persona_schema_no_ctx : Yojson.Safe.t -> Keeper_types_profile.tool_result
+val handle_persona_schema_no_ctx : Yojson.Safe.t -> Tool_result.result
 
 (** {1 Persona save / normalize} *)
 
@@ -98,10 +98,10 @@ val save_result_to_json :
 
 (** Tool-handler entry for [keeper_persona_save]. *)
 val handle_persona_save :
-  _ Keeper_types_profile.context -> Yojson.Safe.t -> Keeper_types_profile.tool_result
+  'ctx -> Yojson.Safe.t -> Tool_result.result
 
 (** RFC-0182 §3.1 — ctx-free body for Persona_dispatch_ref path. *)
-val handle_persona_save_no_ctx : Yojson.Safe.t -> Keeper_types_profile.tool_result
+val handle_persona_save_no_ctx : Yojson.Safe.t -> Tool_result.result
 
 (** {1 Persona archetype helpers} *)
 


### PR DESCRIPTION
## Summary

- Change `keeper_persona_authoring` handler return types from `Keeper_types_profile.tool_result` to `Tool_result.result`.
- Make ignored handler context polymorphic instead of requiring `Keeper_types_profile.context`.
- Replace persona authoring `Keeper_types_profile.tool_result_ok/error` calls with direct `Tool_result.ok/error` constructors.

## Product impact

- No user-facing behavior change intended.
- Reduces the credential/persona authoring cluster's dependency on the wider keeper profile facade, moving RFC-0215 pre-work closer to a real sub-library extraction boundary.

## Evidence

- `gtimeout 180 dune build --root . @check`
- `gtimeout 120 dune exec --root . ./test/test_keeper_toml.exe`
- `ocamlformat --check lib/keeper/keeper_persona_authoring.ml lib/keeper/keeper_persona_authoring.mli`
- `git diff --check`
- `bash scripts/ci/check-determinism-contract.sh`
- `rg -n "Keeper_types_profile\\.tool_result|Keeper_types_profile\\.context|Keeper_types_profile\\.tool_result_ok|Keeper_types_profile\\.tool_result_error" lib/keeper/keeper_persona_authoring.ml lib/keeper/keeper_persona_authoring.mli`

## Direct evidence

schema_version: 1
direct_ratio: 6/6
provenance: direct

- `dune build --root . @check` passed.
- `test_keeper_toml.exe` passed: 97 tests.
- `ocamlformat --check` passed.
- `git diff --check` passed.
- determinism contract passed.
- targeted `rg` returned no matches for the removed authoring result/context surface.

## Review evidence

- RFC-0215 recommends credential/persona authoring as the first keeper extraction cluster; this PR is a narrow pre-work slice for that direction.

## Linked issue

- Follow-up to RFC-0215 keeper sub-library extraction campaign.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`codex/persona-authoring-tool-result-20260604` → `main` · 1 commit(s) · synced 2026-06-04T13:53:36Z

| sha | subject | date |
|---|---|---|
| `1ef18c8df` | refactor(keeper): decouple persona authoring tool results | 2026-06-04 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->