### PR TITLE
fix(dashboard): avoid meta warm root switch from workers

### DIFF
--- a/lib/server/server_dashboard_http_core_meta_cognition.ml
+++ b/lib/server/server_dashboard_http_core_meta_cognition.ml
@@ -30,6 +30,13 @@ let meta_cognition_summary_key (config : Workspace.config) =
 
 let clear_meta_cognition_warm_flag = Mc_cache.clear_warm_flag
 
+let eio_switch_fork_unavailable = function
+  | Invalid_argument msg ->
+    String_util.contains_substring msg "Switch accessed from wrong domain"
+    || String_util.contains_substring msg "Switch finished"
+  | _ -> false
+;;
+
 let schedule_meta_cognition_summary_warm (config : Workspace.config) =
   let key = meta_cognition_summary_key config in
   let compute () = Meta_cognition.summary_json config in
@@ -37,7 +44,7 @@ let schedule_meta_cognition_summary_warm (config : Workspace.config) =
   then (
     match Eio_context.get_switch_opt () with
     | Some sw ->
-      Eio.Fiber.fork ~sw (fun () ->
+      let warm () =
         Eio_guard.protect
           ~finally:(fun () -> Mc_cache.clear_warm_flag key)
           (fun () ->
@@ -56,7 +63,14 @@ let schedule_meta_cognition_summary_warm (config : Workspace.config) =
              | exn ->
                Log.Server.warn
                  "dashboard shell meta_cognition warm failed: %s"
-                 (Printexc.to_string exn)))
+                 (Printexc.to_string exn))
+      in
+      (try Eio.Fiber.fork ~sw warm with
+       | exn when eio_switch_fork_unavailable exn ->
+         Mc_cache.clear_warm_flag key
+       | exn ->
+         Mc_cache.clear_warm_flag key;
+         raise exn)
     | None -> Mc_cache.clear_warm_flag key)
 ;;
 

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -159,6 +159,27 @@ let test_run_dashboard_compute_with_pool_uses_executor_domain () =
   check bool "non-PG backend offloads to executor pool domain" true
     (result_domain <> caller_domain)
 
+let test_meta_cognition_cold_cache_worker_domain_skips_root_switch () =
+  with_test_env @@ fun ~env ~sw ~config ->
+  let exec_pool =
+    Eio.Executor_pool.create ~sw ~domain_count:1 (Eio.Stdenv.domain_mgr env)
+  in
+  let key =
+    Server_dashboard_http_core_meta_cognition.meta_cognition_summary_key config
+  in
+  Dashboard_cache.invalidate key;
+  Server_dashboard_http_core_meta_cognition.clear_meta_cognition_warm_flag key;
+  let json =
+    Eio.Executor_pool.submit_exn exec_pool ~weight:1.0 (fun () ->
+      Server_dashboard_http_core_meta_cognition.meta_cognition_summary_cached
+        config)
+  in
+  check bool "cold worker call returns placeholder" true (json = `Null);
+  check bool "worker fork failure clears warm slot" true
+    (Server_dashboard_http_core_meta_cognition.Mc_cache.try_acquire_warm_slot
+       key);
+  Server_dashboard_http_core_meta_cognition.clear_meta_cognition_warm_flag key
+
 let test_dashboard_shell_http_json_includes_paths () =
   with_test_env @@ fun ~env:_ ~sw:_ ~config ->
   let json = Server_dashboard_http_core.dashboard_shell_http_json config in
@@ -1078,6 +1099,8 @@ let () =
             test_run_dashboard_compute_without_pool_stays_in_current_domain;
           test_case "pool uses executor domain" `Quick
             test_run_dashboard_compute_with_pool_uses_executor_domain;
+          test_case "meta-cognition cold worker skips root switch" `Quick
+            test_meta_cognition_cold_cache_worker_domain_skips_root_switch;
           test_case "shell payload includes paths diagnostics" `Quick
             test_dashboard_shell_http_json_includes_paths;
           test_case "shell runtime base_path prefers preserved input" `Quick


### PR DESCRIPTION
## Summary
- guard dashboard meta-cognition warm scheduling when an Executor_pool worker sees the main Eio root switch
- clear the warm-in-flight flag if fork scheduling is unavailable, so later valid calls can retry
- add a worker-domain regression test for cold meta-cognition cache access

## Product impact

- User-visible change: dashboard shell meta-cognition projection no longer fails with `Invalid_argument("Switch accessed from wrong domain!")` when cold-cache warm scheduling is reached from a worker domain.

## Validation
- `git diff --check`
- `ocamlformat --check lib/server/server_dashboard_http_core_meta_cognition.ml test/test_dashboard_http_core.ml`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_dashboard_http_core.exe`
- `./_build/default/test/test_dashboard_http_core.exe test executor_pool 2`

## Evidence

- Focused build passed: `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_dashboard_http_core.exe`
- Regression test passed: `./_build/default/test/test_dashboard_http_core.exe test executor_pool 2`
- Formatting/static checks passed: `git diff --check`; `ocamlformat --check lib/server/server_dashboard_http_core_meta_cognition.ml test/test_dashboard_http_core.ml`

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 4/4
provenance: direct
stages:
  - name: diff_check
    command: git diff --check
    result: pass
  - name: ocamlformat_check
    command: ocamlformat --check lib/server/server_dashboard_http_core_meta_cognition.ml test/test_dashboard_http_core.ml
    result: pass
  - name: focused_build
    command: env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_dashboard_http_core.exe
    result: pass
  - name: regression_test
    command: ./_build/default/test/test_dashboard_http_core.exe test executor_pool 2
    result: pass
```

## GOAL LOOP ACT checklist

- [x] Observe — runtime log pattern reported as `dashboard shell runtime_resolution projection failed: Invalid_argument("Switch accessed from wrong domain!")`; this patch covers the sibling meta-cognition warm fork path with the same worker/root-switch failure mode.
- [x] Orient — mapped to `meta_cognition_summary_cached` cold-cache scheduling via `Eio_context.get_switch_opt ()` fallback to the main root switch.
- [x] Decide — narrow scheduler guard keeps the hot dashboard path from crashing and clears the warm slot for later retry.
- [x] Act — only the meta-cognition warm scheduler and its focused regression test changed.
- [x] Verify — focused build and regression test passed locally.
- [x] Loop — none for this PR; full executable local failures are tracked below as pre-existing local test environment failures.

## Review evidence

- Not run; narrow runtime fix with direct regression coverage.

## Linked issue

- Relates #10125

## Variant addition checklist

- [ ] **OCaml** — N/A, no variant added/removed
- [ ] **TypeScript** — N/A, no TypeScript union changed
- [ ] **TLA+ spec** — N/A, no TLA+ domain literal changed
- [ ] **Event / JSON schema** — N/A, no event or JSON schema enum changed
- [ ] **`make check-variants` passes** — N/A, no variant/schema change

## Notes
- Full `./_build/default/test/test_dashboard_http_core.exe` still has pre-existing local failures in config/runtime/auth/proof tests; testcase 3 fails even when run alone with `Yojson__Safe.Util.Type_error("Can't get member 'path' of non-object type null")` on `config_resolution.runtime_authoring.path` under this sandbox.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`fix/dashboard-meta-warm-domain-decouple-20260604` → `main` · 1 commit(s) · synced 2026-06-04T14:11:26Z

| sha | subject | date |
|---|---|---|
| `7aa590ca5` | fix(dashboard): avoid meta warm root switch from workers | 2026-06-04 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->