### PR TITLE
Fix stale sandbox repo root Execute gate

### DIFF
--- a/lib/keeper/keeper_tool_execute_path.ml
+++ b/lib/keeper/keeper_tool_execute_path.ml
@@ -7,15 +7,36 @@ let normalize_repo_cwd_path path =
   Keeper_alerting_path.normalize_path_for_check path
   |> Keeper_alerting_path.strip_trailing_slashes
 
+type currency_cache_entry =
+  { at : float
+  ; outcome : Playground_repo_readiness.currency_outcome option
+  }
+
 (* Currency-sync fetch-rate cache. [Playground_repo_readiness.ensure_current]
    fetches origin before deciding whether to fast-forward, so calling it on
    every repo-targeting tool call would refetch many times per turn. This is a
    per-clone-path rate cache for an *idempotent* operation (not a failure
    cooldown): the fetch+advance runs at most once per [currency_min_interval_sec]
    per clone, which bounds the cost to roughly once per keeper turn. *)
-let currency_last_sync : (string, float) Hashtbl.t = Hashtbl.create 64
+let currency_sync_cache : (string, currency_cache_entry) Hashtbl.t =
+  Hashtbl.create 64
 
 let currency_min_interval_sec = 30.0
+
+let log_currency_outcome ~repo_name = function
+  | Playground_repo_readiness.Up_to_date -> ()
+  | Advanced commits ->
+    Log.Keeper.info "currency: advanced sandbox repo %s by %d commit(s)"
+      repo_name commits
+  | Preserved reason ->
+    (* Local/divergent work kept. Keep this visible: otherwise a dirty or
+       task-branch sandbox looks like the runtime simply forgot to update. *)
+    Log.Keeper.info "currency: preserved sandbox repo %s (%s)" repo_name reason
+  | Skipped reason ->
+    (* Currency could not be established (missing/corrupt clone, no
+       credential, or fetch failure). Visible by default so a recurring
+       failure does not re-freeze the repo invisibly. *)
+    Log.Keeper.info "currency: skipped sandbox repo %s (%s)" repo_name reason
 
 (* Keep the keeper's sandbox clone current with origin/<default_branch> before
    code work. Best-effort: a failed advance never fails the turn, but
@@ -23,35 +44,36 @@ let currency_min_interval_sec = 30.0
    advance is fast-forward-only and work-preserving (see [Playground_repo_readiness]).
    The typed outcome is logged rather than dropped: a [Skipped] sync is the very
    "repo silently frozen" failure this exists to fix, so it stays visible. *)
-let sync_repo_currency_best_effort ~config ~meta ~repo_name =
+let repo_currency_outcome_best_effort ~config ~meta ~repo_name =
   let cpath = Playground_repo_readiness.clone_path ~config ~meta ~repo_name in
   let now = Unix.gettimeofday () in
+  let cached = Hashtbl.find_opt currency_sync_cache cpath in
   let due =
-    match Hashtbl.find_opt currency_last_sync cpath with
-    | Some last -> now -. last >= currency_min_interval_sec
+    match cached with
+    | Some { at; _ } -> now -. at >= currency_min_interval_sec
     | None -> true
   in
   if due then begin
-    Hashtbl.replace currency_last_sync cpath now;
     try
-      match Playground_repo_readiness.ensure_current ~config ~meta ~repo_name () with
-      | Playground_repo_readiness.Up_to_date -> ()
-      | Advanced commits ->
-        Log.Keeper.info "currency: advanced sandbox repo %s by %d commit(s)"
-          repo_name commits
-      | Preserved reason ->
-        (* Local/divergent work kept. Keep this visible: otherwise a dirty or
-           task-branch sandbox looks like the runtime simply forgot to update. *)
-        Log.Keeper.info "currency: preserved sandbox repo %s (%s)" repo_name reason
-      | Skipped reason ->
-        (* Currency could not be established (missing/corrupt clone, no
-           credential, or fetch failure). Visible by default so a recurring
-           failure does not re-freeze the repo invisibly. *)
-        Log.Keeper.info "currency: skipped sandbox repo %s (%s)" repo_name reason
+      let outcome =
+        Playground_repo_readiness.ensure_current ~config ~meta ~repo_name ()
+      in
+      log_currency_outcome ~repo_name outcome;
+      Hashtbl.replace currency_sync_cache cpath { at = now; outcome = Some outcome };
+      Some outcome
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
-    | _ -> ()
+    | _ ->
+      Hashtbl.replace currency_sync_cache cpath { at = now; outcome = None };
+      None
   end
+  else
+    match cached with
+    | Some { outcome; _ } -> outcome
+    | None -> None
+
+let sync_repo_currency_best_effort ~config ~meta ~repo_name =
+  ignore (repo_currency_outcome_best_effort ~config ~meta ~repo_name)
 
 let repo_path_context ~(config : Workspace.config) ~(meta : keeper_meta) cwd =
   let playground =
@@ -83,6 +105,85 @@ let repo_path_context ~(config : Workspace.config) ~(meta : keeper_meta) cwd =
         let repo_root = normalize_repo_cwd_path repo_root in
         Some (repo_name, repo_root, repo_root, [ repo_root ])
       | _ -> None
+
+let normalize_command_name command_name =
+  let command_name = Filename.basename command_name |> String.lowercase_ascii in
+  if String.ends_with ~suffix:".exe" command_name
+  then String.sub command_name 0 (String.length command_name - String.length ".exe")
+  else command_name
+
+let git_subcommand args =
+  let rec scan = function
+    | [] -> None
+    | ("-C" | "-c" | "--git-dir" | "--work-tree" | "--namespace") :: _value :: rest ->
+      scan rest
+    | arg :: rest
+      when String.starts_with ~prefix:"-C" arg && String.length arg > 2 ->
+      scan rest
+    | arg :: rest
+      when String.starts_with ~prefix:"--git-dir=" arg
+           || String.starts_with ~prefix:"--work-tree=" arg
+           || String.starts_with ~prefix:"--namespace=" arg ->
+      scan rest
+    | arg :: rest when String.starts_with ~prefix:"-" arg -> scan rest
+    | subcommand :: _ -> Some (String.lowercase_ascii subcommand)
+  in
+  scan args
+
+let git_subcommand_is_direct_repo_diagnostic = function
+  | "status" | "branch" | "log" | "diff" | "remote" | "rev-parse" | "fetch"
+  | "worktree" ->
+    true
+  | _ -> false
+
+let direct_repo_diagnostic_command ir =
+  match Keeper_tool_execute_command_semantics.effective_stages_of_ir ir with
+  | [ stage ] when String.equal (normalize_command_name stage.bin) "git" -> (
+    match git_subcommand stage.args with
+    | Some subcommand -> git_subcommand_is_direct_repo_diagnostic subcommand
+    | None -> false)
+  | _ -> false
+
+let repo_currency_not_ready_error ~repo_name ~reason ~cwd =
+  Printf.sprintf
+    "sandbox_repo_stale: sandbox repo root repos/%s is not current and was \
+     preserved (%s). Direct repo-root Execute is blocked so the agent does not \
+     run against stale local state. Use cwd=\"repos/%s/.worktrees/<task>\" for \
+     task work, or run diagnostic git status/branch/log/diff/remote/rev-parse/\
+     fetch/worktree and clean, stash, or repair the sandbox repo root before \
+     retrying. cwd=%s"
+    repo_name
+    reason
+    repo_name
+    cwd
+
+let validate_repo_cwd_currency_ready
+      ~(config : Workspace.config)
+      ~(meta : keeper_meta)
+      ~(cwd : string)
+      (ir : Masc_exec.Shell_ir.t)
+  =
+  match repo_path_context ~config ~meta cwd with
+  | None -> Ok ()
+  | Some (repo_name, repo_root, path_root, _accepted_toplevels)
+    when not
+           (String.equal
+              (normalize_repo_cwd_path repo_root)
+              (normalize_repo_cwd_path path_root)) ->
+    Ok ()
+  | Some (repo_name, _repo_root, _path_root, _accepted_toplevels) ->
+    if direct_repo_diagnostic_command ir then Ok ()
+    else
+      match repo_currency_outcome_best_effort ~config ~meta ~repo_name with
+      | Some Playground_repo_readiness.Up_to_date | Some (Advanced _) -> Ok ()
+      | Some (Preserved reason) | Some (Skipped reason) ->
+        Error (repo_currency_not_ready_error ~repo_name ~reason ~cwd)
+      | None ->
+        Error
+          (repo_currency_not_ready_error
+             ~repo_name
+             ~reason:"currency probe failed"
+             ~cwd)
 
 type execution_location_scope =
   | Playground_root

--- a/lib/keeper/keeper_tool_execute_path.mli
+++ b/lib/keeper/keeper_tool_execute_path.mli
@@ -23,6 +23,19 @@ val validate_repo_path_args_ready :
     commands run from the playground root with arguments like
     [./repos/masc/lib/foo.ml]. *)
 
+val validate_repo_cwd_currency_ready :
+  config:Workspace.config ->
+  meta:Keeper_meta_contract.keeper_meta ->
+  cwd:string ->
+  Masc_exec.Shell_ir.t ->
+  (unit, string) result
+(** Reject non-diagnostic typed Execute commands from a direct sandbox
+    [repos/<repo>] cwd when the repo could not be advanced to
+    [origin/main]. Dirty, detached, task-branch, diverged, or unregistered
+    direct roots are preserved by the repo currency layer; this guard prevents
+    normal work from continuing against that stale root while still allowing
+    focused git diagnostics. Repo worktree cwd values are not gated here. *)
+
 val execution_location_json :
   config:Workspace.config ->
   meta:Keeper_meta_contract.keeper_meta ->

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -464,11 +464,20 @@ let handle_tool_execute_typed
           let dispatch_result =
             Keeper_tool_execute_shell_ir.dispatch_classified
               ~before_path_validation:(fun ir ->
-                Keeper_tool_execute_path.validate_repo_path_args_ready
-                  ~config
-                  ~meta
-                  ~cwd
-                  ir)
+                match
+                  Keeper_tool_execute_path.validate_repo_cwd_currency_ready
+                    ~config
+                    ~meta
+                    ~cwd
+                    ir
+                with
+                | Error _ as err -> err
+                | Ok () ->
+                  Keeper_tool_execute_path.validate_repo_path_args_ready
+                    ~config
+                    ~meta
+                    ~cwd
+                    ir)
               ~allowed_commands
               ~keeper_id:meta.name
               ~base_path:root

--- a/test/test_keeper_tool_execute_safety.ml
+++ b/test/test_keeper_tool_execute_safety.ml
@@ -374,6 +374,52 @@ let run_process_ok ~cwd prog argv =
       (Masc.Keeper_sandbox_exec_failure.status_label status)
       stdout stderr
 
+let git_ok ~cwd args = run_process_ok ~cwd "git" args
+
+let write_file path content =
+  ensure_dir (Filename.dirname path);
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc content)
+
+let write_repositories_toml ~base_path ~repo_name ~url =
+  let config_dir = Filename.concat base_path ".masc/config" in
+  ensure_dir config_dir;
+  write_file
+    (Filename.concat config_dir "repositories.toml")
+    (Printf.sprintf
+       "[repository.%s]\nname = \"%s\"\nurl = \"%s\"\n"
+       repo_name
+       repo_name
+       (String.escaped url))
+
+let setup_preserved_sandbox_repo ~keeper_name =
+  let base_path, config = make_config () in
+  let meta = make_local_meta keeper_name in
+  let remote = Filename.concat base_path ".remote-masc.git" in
+  let seed = Filename.concat base_path "seed-masc" in
+  git_ok ~cwd:base_path
+    [ "init"; "--bare"; "-q"; "--initial-branch=main"; remote ];
+  git_ok ~cwd:base_path [ "clone"; "-q"; remote; seed ];
+  git_ok ~cwd:seed [ "config"; "user.email"; "test@example.com" ];
+  git_ok ~cwd:seed [ "config"; "user.name"; "Test" ];
+  write_file (Filename.concat seed "README.md") "v1\n";
+  git_ok ~cwd:seed [ "add"; "README.md" ];
+  git_ok ~cwd:seed [ "commit"; "-q"; "-m"; "init" ];
+  git_ok ~cwd:seed [ "push"; "-q"; "origin"; "main" ];
+  let playground = Filename.concat base_path (playground_path_of meta.name) in
+  let repo_dir = Filename.concat playground "repos/masc" in
+  ensure_dir (Filename.dirname repo_dir);
+  git_ok ~cwd:(Filename.dirname repo_dir) [ "clone"; "-q"; remote; repo_dir ];
+  write_repositories_toml ~base_path ~repo_name:"masc" ~url:remote;
+  write_file (Filename.concat seed "README.md") "v2\n";
+  git_ok ~cwd:seed [ "add"; "README.md" ];
+  git_ok ~cwd:seed [ "commit"; "-q"; "-m"; "advance" ];
+  git_ok ~cwd:seed [ "push"; "-q"; "origin"; "main" ];
+  write_file (Filename.concat repo_dir "local-dirty.txt") "dirty\n";
+  base_path, config, meta, repo_dir
+
 let parse_error_field raw =
   Yojson.Safe.from_string raw
   |> Json.member "error"
@@ -627,6 +673,71 @@ let test_tool_execute_missing_worktree_cwd_does_not_create_directory () =
       false
       (Sys.file_exists missing_worktree)
   | None -> Alcotest.fail ("expected error json, got: " ^ raw)
+
+let test_tool_execute_blocks_preserved_direct_repo_git_show () =
+  with_eio_fs @@ fun () ->
+  let base_path, config, meta, _repo_dir =
+    setup_preserved_sandbox_repo ~keeper_name:"stale-direct-git-show"
+  in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  Keeper_registry.clear ();
+  let raw =
+    Keeper_tool_command_runtime.handle_tool_execute
+      ~turn_sandbox_factory:None
+      ~exec_cache:None
+      ~config
+      ~meta
+      ~args:
+        (`Assoc
+           [ "executable", `String "git"
+           ; "argv", `List [ `String "show"; `String "origin/main:README.md" ]
+           ; "cwd", `String "repos/masc"
+           ])
+      ()
+  in
+  match parse_error_field raw with
+  | Some err ->
+    Alcotest.(check bool) "stale direct repo root is rejected" true
+      (String_util.contains_substring err "sandbox_repo_stale");
+    Alcotest.(check bool) "preserved reason is surfaced" true
+      (String_util.contains_substring err "uncommitted changes");
+    Alcotest.(check bool) "worktree remedy is surfaced" true
+      (String_util.contains_substring err "repos/masc/.worktrees/<task>");
+    Alcotest.(check bool) "git show did not execute" false
+      (String_util.contains_substring raw "v2")
+  | None -> Alcotest.fail ("expected stale repo error json, got: " ^ raw)
+
+let test_tool_execute_allows_preserved_direct_repo_git_status () =
+  with_eio_fs @@ fun () ->
+  let base_path, config, meta, _repo_dir =
+    setup_preserved_sandbox_repo ~keeper_name:"stale-direct-git-status"
+  in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  Keeper_registry.clear ();
+  let raw =
+    Keeper_tool_command_runtime.handle_tool_execute
+      ~turn_sandbox_factory:None
+      ~exec_cache:None
+      ~config
+      ~meta
+      ~args:
+        (`Assoc
+           [ "executable", `String "git"
+           ; "argv", `List [ `String "status"; `String "--short" ]
+           ; "cwd", `String "repos/masc"
+           ])
+      ()
+  in
+  let json = Yojson.Safe.from_string raw in
+  Alcotest.(check bool) "diagnostic git status succeeds" true
+    (json |> Json.member "ok" |> Json.to_bool);
+  Alcotest.(check bool) "dirty file is visible for diagnosis" true
+    (json
+     |> Json.member "output"
+     |> Json.to_string
+     |> fun output -> String_util.contains_substring output "local-dirty.txt");
+  Alcotest.(check bool) "stale gate did not block diagnostic" false
+    (String_util.contains_substring raw "sandbox_repo_stale")
 
 let test_tool_execute_elapsed_duration_preserves_positive_sub_ms () =
   let elapsed = Keeper_tool_command_runtime.For_testing.elapsed_duration_ms in
@@ -1642,6 +1753,14 @@ let () =
             "missing worktree cwd rejects without mkdir"
             `Quick
             test_tool_execute_missing_worktree_cwd_does_not_create_directory
+        ; Alcotest.test_case
+            "preserved direct repo root blocks git show"
+            `Quick
+            test_tool_execute_blocks_preserved_direct_repo_git_show
+        ; Alcotest.test_case
+            "preserved direct repo root allows git status"
+            `Quick
+            test_tool_execute_allows_preserved_direct_repo_git_status
         ] )
     ; ( "edge"
       , [ Alcotest.test_case


### PR DESCRIPTION
## Summary
- cache and reuse sandbox repo currency outcomes instead of logging them only
- block non-diagnostic Execute commands from direct repos/<repo> cwd when ensure_current preserves or skips the repo
- keep focused git diagnostics available on preserved roots and add regression coverage for git show vs git status

## Why
A dirty/task-branch sandbox clone is intentionally preserved by ensure_current, so forcing pull/reset would destroy agent work. The bug was that Execute still treated that preserved direct repo root as a normal cwd, letting commands run against stale local state.

## Validation
- opam exec -- ocamlformat --check lib/keeper/keeper_tool_execute_path.ml lib/keeper/keeper_tool_execute_path.mli lib/keeper/keeper_tool_execute_runtime.ml test/test_keeper_tool_execute_safety.ml
- git diff --check origin/main...HEAD
- scripts/lint-spawn-bounded.sh
- scripts/check-boundary-guard-mli-pairs.sh

## Not run
- scripts/dune-local.sh build test/test_keeper_tool_execute_safety.exe: blocked by unrelated bare Dune process outside scripts/dune-local.sh (PID 17435, root .worktrees/purge-dna-memory-loop-20260604)