### PR TITLE
chore(otel): RFC-0217 S3 — OTLP collector config + runbook

### DIFF
--- a/infrastructure/monitoring/MASC-OTEL-S3-RUNBOOK.md
+++ b/infrastructure/monitoring/MASC-OTEL-S3-RUNBOOK.md
@@ -1,0 +1,96 @@
+# MASC OTel S3 Runbook — restore metrics after the Prometheus scrape removal
+
+RFC-0217 S4-2 (PR #20082, merged `dc7d067629`) removed `to_prometheus_text` and
+the `/metrics` scrape endpoint from masc. Metrics now leave the process **only**
+via OTLP push, gated by `MASC_OTEL_ENABLED` (default `false`). Until the steps
+below are done, a freshly deployed masc emits **no metrics anywhere** — there is
+no scrape fallback. This runbook closes that gap.
+
+The exporter itself is already wired in
+`lib/server/server_bootstrap_maintenance.ml:84` (`Otel_spans.setup_exporter`);
+no code change is needed. This is purely environment setup.
+
+## Chain
+
+```
+masc  ──OTLP/HTTP :4318──▶  otel-collector  ──:8889/metrics──▶  Prometheus server  ──▶  Grafana
+        (MASC_OTEL_ENABLED=true)             (prometheus exporter)   (scrape job)        (datasource)
+```
+
+## Step 1 — run the collector
+
+```bash
+docker run --rm -p 4318:4318 -p 8889:8889 \
+  -v "$PWD/infrastructure/monitoring/otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml" \
+  otel/opentelemetry-collector-contrib:latest
+```
+
+Or add it to `docker-compose.yml` next to the `masc` service:
+
+```yaml
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:latest
+    container_name: masc-otel-collector
+    command: ["--config=/etc/otelcol-contrib/config.yaml"]
+    volumes:
+      - ./infrastructure/monitoring/otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml
+    ports:
+      - "4318:4318"   # OTLP/HTTP in
+      - "8889:8889"   # Prometheus metrics out
+```
+
+## Step 2 — enable OTLP export in masc
+
+```bash
+export MASC_OTEL_ENABLED=true
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318   # collector host
+# optional: export OTEL_SERVICE_NAME=masc   (default is already "masc")
+```
+
+If masc runs in the compose network, use the service name:
+`OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318`.
+
+## Step 3 — point Prometheus at the collector
+
+The collector exposes the metrics at `:8889/metrics`. Repoint your existing
+Prometheus server's scrape target from the old masc `/metrics` to the collector:
+
+```yaml
+scrape_configs:
+  - job_name: masc
+    static_configs:
+      - targets: ["localhost:8889"]   # was: masc:<port> /metrics
+```
+
+Grafana keeps querying the same Prometheus datasource, so the dashboards in this
+directory need no datasource change.
+
+Alternative (no Prometheus server): swap the collector's `prometheus` exporter
+for `prometheusremotewrite` pointed at your Prometheus/Mimir remote-write URL.
+
+## Step 4 — verify (do not skip)
+
+```bash
+# 1. Collector is receiving and re-exposing masc metrics:
+curl -s localhost:8889/metrics | grep -c '^masc_'        # expect > 0
+
+# 2. Names match what the dashboards query (check for drift — counters, suffixes):
+curl -s localhost:8889/metrics | grep '^masc_' | head -30
+```
+
+Then open a Grafana dashboard and confirm panels render. If a panel is empty,
+the likely cause is a metric **name drift** introduced by the OTLP→Prometheus
+translation (counter `_total` suffixing, label/namespace changes). The collector
+config sets `add_metric_suffixes: false` to minimise this, but the gauge values
+that masc previously refreshed lazily during a `/metrics` scrape are now pushed
+on the OTel export tick — confirm gauges (FD, pool, uptime) are non-stale.
+
+## Known follow-ups (not blocking S3)
+
+- **Gauge freshness**: the lazy gauge refresh that the scrape used to trigger now
+  rides the OTel export tick (`otel_samples`). Confirm FD/pool/uptime gauges
+  update at the expected cadence.
+- **LANE 3 / S5**: `Prometheus.inc_counter` and the metric store still live in the
+  mega lib (dual shim). Extracting a `masc_telemetry` leaf (RFC-0215 LANE 3) is a
+  separate refactor — it is the lynchpin that also unblocks the LANE 6 tool_board
+  extraction (which depends on mega-resident `Prometheus`).

--- a/infrastructure/monitoring/otel-collector-config.yaml
+++ b/infrastructure/monitoring/otel-collector-config.yaml
@@ -1,0 +1,56 @@
+# masc-mcp OTel Collector — RFC-0217 S3 (telemetry Otel single-backend)
+#
+# Context: PR #20082 (S4-2) removed the in-process Prometheus `/metrics` scrape
+# endpoint from masc. Metrics now leave the process only via OTLP push, and only
+# when MASC_OTEL_ENABLED=true. This collector receives that OTLP push and
+# re-exposes the metrics in Prometheus text format on :8889/metrics, so an
+# existing Prometheus server (and the Grafana dashboards in this directory) keep
+# working with no dashboard rewrite.
+#
+# Run with otelcol-contrib (the prometheus exporter lives in -contrib, not core):
+#   docker run --rm -p 4318:4318 -p 8889:8889 \
+#     -v "$PWD/infrastructure/monitoring/otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml" \
+#     otel/opentelemetry-collector-contrib:latest
+
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318   # masc cohttp_eio OTLP/HTTP target (masc_network_defaults.otel_default_url)
+      grpc:
+        endpoint: 0.0.0.0:4317   # optional; masc pushes over HTTP by default
+
+processors:
+  batch:
+    timeout: 10s
+
+exporters:
+  prometheus:
+    endpoint: 0.0.0.0:8889
+    # Preserve masc_* names exactly as emitted. The collector's default behaviour
+    # appends `_total` to monotonic counters and unit suffixes; that would drift
+    # from the names the Grafana dashboards query. Disable it and verify names
+    # against a live scrape (see runbook step 4) before trusting the dashboards.
+    add_metric_suffixes: false
+    # Surface resource attributes (service.name=masc, etc.) as Prometheus labels.
+    resource_to_telemetry_conversion:
+      enabled: true
+
+  # masc also emits spans when OTEL is enabled. Without a tracing backend, drop
+  # them here. Replace `debug` with an `otlp` exporter to Tempo/Jaeger if wanted.
+  debug:
+    verbosity: basic
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [prometheus]
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]
+  telemetry:
+    logs:
+      level: info


### PR DESCRIPTION
## 목적 (S3 — 당신 환경 unblock)

RFC-0217 **S4-2 (PR #20082, merged `dc7d067629`)**가 `to_prometheus_text` + `/metrics` scrape 엔드포인트를 제거했습니다. 메트릭은 이제 **OTLP push로만** 나가고, `MASC_OTEL_ENABLED`(기본 `false`) 게이트입니다. 따라서 main을 그대로 재배포하면 **메트릭이 어디로도 안 나갑니다** (scrape fallback 없음).

이 PR은 코드 변경이 아니라, 그 공백을 닫는 **운영 config + runbook**입니다. exporter 자체는 이미 `lib/server/server_bootstrap_maintenance.ml:84`(`Otel_spans.setup_exporter`)에 배선돼 있습니다.

## 내용

- `infrastructure/monitoring/otel-collector-config.yaml` — otelcol-contrib: OTLP in(:4318) → `prometheus` exporter(:8889/metrics). `add_metric_suffixes: false`로 `masc_*` 이름 보존(대시보드 drift 최소화).
- `infrastructure/monitoring/MASC-OTEL-S3-RUNBOOK.md` — 체인 다이어그램, collector 실행(docker/compose), masc env 2줄, Prometheus 재지정, **검증 단계**(이름 drift/gauge 신선도 확인).

## 체인

\`\`\`
masc ──OTLP/HTTP :4318──▶ otel-collector ──:8889/metrics──▶ Prometheus ──▶ Grafana
\`\`\`

기존 Grafana 대시보드(이 디렉토리 3개)는 datasource 변경 없이 유지됩니다.

## 검증 / tradeoff

- 결정론적 부분(masc→collector→/metrics)은 확정 config. Grafana 연결은 토폴로지 가정 없이 2옵션(Prometheus scrape 재지정 / remote_write) 제시.
- **미검증**: OTLP→Prometheus 변환 시 counter `_total` suffix·label drift 가능 → runbook step 4에서 라이브 scrape로 확인 필요. lazy gauge(FD/pool/uptime) 신선도도 확인 대상.

## 범위 밖 (후속)

- LANE 3 / S5 `masc_telemetry` leaf 추출(= LANE 6 tool_board unblock의 lynchpin)은 별도 RFC. `Prometheus.inc_counter`/store는 dual shim으로 mega 유지 중.

RFC-0217 (telemetry Otel single-backend) 후속.

🤖 Generated with [Claude Code](https://claude.com/claude-code)