### PR TITLE
refactor(keeper): split keeper name validation

### DIFF
--- a/docs/rfc/RFC-0215-keeper-sublibrary-extraction-campaign.md
+++ b/docs/rfc/RFC-0215-keeper-sublibrary-extraction-campaign.md
@@ -180,6 +180,11 @@ Follow-up credential pre-work narrows persona authoring away from the flat
 normalizer and persona-placeholder modules directly, keeping the same behavior
 while removing a non-domain facade dependency from the first cluster.
 
+The next slice moves keeper/persona handle validation into `Keeper_name`.
+`Keeper_config_text.validate_name` still exposes the legacy config-facing API,
+but persona authoring no longer imports the full `Keeper_config` surface just
+to validate a handle.
+
 ## 5. Extraction sequence
 
 Candidate clusters and their re-measured **flat-ns fan-out** (the G1 metric).

--- a/lib/keeper/keeper_config_text.ml
+++ b/lib/keeper/keeper_config_text.ml
@@ -37,10 +37,7 @@ let bool_of_env_opt name =
 
 (* ── Name validation ────────────────────────────────────────── *)
 
-let valid_name_re = Re.Pcre.re "^[A-Za-z0-9._-]+$" |> Re.compile
-
-let validate_name name =
-  name <> "" && Re.execp valid_name_re name
+let validate_name = Keeper_name.validate
 
 (* ── Configuration constants ────────────────────────────────── *)
 

--- a/lib/keeper/keeper_name.ml
+++ b/lib/keeper/keeper_name.ml
@@ -1,0 +1,6 @@
+(** Keeper name validation. *)
+
+let valid_re = Re.Pcre.re "^[A-Za-z0-9._-]+$" |> Re.compile
+
+let validate name =
+  name <> "" && Re.execp valid_re name

--- a/lib/keeper/keeper_name.mli
+++ b/lib/keeper/keeper_name.mli
@@ -1,0 +1,6 @@
+(** Keeper name validation.
+
+    Small SSOT for keeper/persona handle syntax so persona authoring does not
+    need to depend on the full [Keeper_config] runtime/config surface. *)
+
+val validate : string -> bool

--- a/lib/keeper/keeper_persona_authoring.ml
+++ b/lib/keeper/keeper_persona_authoring.ml
@@ -493,7 +493,7 @@ let normalize_keeper_json ~handle keeper_json =
 ;;
 
 let normalize_profile ~handle profile =
-  if not (Keeper_config.validate_name handle)
+  if not (Keeper_name.validate handle)
   then Error "handle must match [A-Za-z0-9._-]+"
   else if Keeper_types_profile_persona.json_has_operator_todo_placeholder profile
   then


### PR DESCRIPTION
Stacked on #20127. Moves keeper/persona handle validation into a small Keeper_name SSOT, keeps Keeper_config_text.validate_name as the config-facing API, and points keeper_persona_authoring at Keeper_name instead of the full Keeper_config surface. Updates RFC-0215 with the credential pre-work note. Verification: gtimeout 120 dune exec --root . ./test/test_keeper_toml.exe; ocamlformat --check lib/keeper/keeper_name.ml lib/keeper/keeper_name.mli lib/keeper/keeper_config_text.ml lib/keeper/keeper_persona_authoring.ml; git diff --cached --check before commit; analyze_lib_deps shows Keeper_persona_authoring edges now omit Keeper_config.