### PR TITLE
Clean keeper config and dashboard labels

### DIFF
--- a/config/keepers/base.toml
+++ b/config/keepers/base.toml
@@ -30,9 +30,3 @@ MASC 기본 소양 — 모든 keeper의 공통 행동 기반. persona instructio
 6. Execute 규칙: `Execute`가 노출된 경우 한 번에 하나의 typed argv 명령만 실행한다. shell quote, glob, brace expansion을 쓰지 않는다. 경로 인자는 plain path. command shape block 또는 workflow_rejection을 받으면 Execute 변형 재시도 대신 active schema에 보이는 typed tool (keeper_tasks_list, Grep, Read 등)로 전환한다.
 7. 협업: 다중 keeper 환경에서는 masc_broadcast (전체 공지) 또는 masc_messages (1:1)로 소통한다. 특정 keeper 호출은 @mention. 진행 상태는 masc_heartbeat로 유지한다.
 """
-
-[provider_health]
-ttfrc_degraded_ms = 5000.0
-ttfrc_unhealthy_ms = 15000.0
-timeout_count_5m_unhealthy = 3
-prefill_degraded_ms = 2000.0

--- a/dashboard/src/components/agent-roster.test.ts
+++ b/dashboard/src/components/agent-roster.test.ts
@@ -570,6 +570,20 @@ describe('AgentRoster live-only cards', () => {
     expect(text).not.toContain('파생')
   })
 
+  it('does not expose synthetic implementation labels in agent rows', async () => {
+    agents.value = [makeAgent({ name: 'runtime-shadow', synthetic: true })]
+    keepers.value = []
+
+    await act(async () => {
+      render(html`<${AgentRoster} />`, container)
+    })
+    await flushUi()
+
+    const text = container.textContent ?? ''
+    expect(text).toContain('runtime-shadow')
+    expect(text).not.toContain('파생')
+  })
+
   it('renders the operations list with a selected detail pane', async () => {
     agents.value = [
       makeAgent({ name: 'alpha-agent', current_task: 'alpha task' }),

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -1033,7 +1033,6 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                       <span class="block truncate text-sm font-semibold text-[var(--color-fg-secondary)]">${row.displayName}</span>
                       <span class="mt-0.5 flex flex-wrap items-center gap-1.5 text-3xs text-[var(--color-fg-muted)]">
                         <${AgentPresence} status=${row.presenceDisplay.status} detail=${row.presenceDisplay.detail} size="sm" />
-                        ${row.agent.synthetic && !row.isKeeper ? html`<span class="rounded-[var(--r-0)] border border-dashed border-[var(--color-border-default)] px-1.5 py-0.5 italic">파생</span>` : null}
                       </span>
                     </span>
                   </span>

--- a/dashboard/src/components/tools/config-resolution-panel.test.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.test.ts
@@ -161,6 +161,8 @@ describe('ConfigResolutionPanel', () => {
     expect(container.textContent).toContain('keeper runtime limits')
     expect(container.textContent).toContain('Per-keeper runtime caps and timeouts. These values are not the live keeper count.')
     expect(container.textContent).toContain('bootstrap max active keepers')
+    expect(container.textContent).toContain('default')
+    expect(container.textContent).not.toContain('derived')
   })
   it('keeps the full path on hover title and hides duplicate source badges', () => {
     render(

--- a/dashboard/src/components/tools/config-resolution-panel.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.ts
@@ -108,6 +108,8 @@ function sourceLabel(source: string): string {
       return 'runtime data'
     case 'prompt_registry':
       return 'prompt registry'
+    case 'derived':
+      return 'default'
     default:
       return 'missing'
   }
@@ -381,7 +383,7 @@ function KeeperRuntimePanel({ runtime }: { runtime: KeeperRuntimeResolved | null
               <div class="text-2xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">${row.label}</div>
               <div class="flex items-center gap-2">
                 <span class="font-mono text-xs text-[var(--color-fg-primary)]">${fmtKeeperValue(field.value, row.fmt)}</span>
-                <span class="text-3xs px-1.5 py-0.5 rounded-[var(--r-1)] ${sourceTone(field.source)}">${field.source}</span>
+                <span class="text-3xs px-1.5 py-0.5 rounded-[var(--r-1)] ${sourceTone(field.source)}">${sourceLabel(field.source)}</span>
               </div>
             </div>
           `

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -1471,6 +1471,26 @@ legacy_scope = "removed"
     check (list string) "base include is a loader key"
       ["keeper.legacy_scope"] unknown
 
+let test_detect_unknown_keys_flags_provider_health_table () =
+  let input = {|
+[keeper]
+goal = "g"
+mention_targets = ["a"]
+
+[provider_health]
+ttfrc_degraded_ms = 5000.0
+timeout_count_5m_unhealthy = 3
+|} in
+  match TL.parse_toml input with
+  | Error e -> fail e
+  | Ok doc ->
+    let unknown = KTP.detect_unknown_keeper_toml_keys doc in
+    check (list string) "provider health table is not keeper config"
+      [ "provider_health.timeout_count_5m_unhealthy"
+      ; "provider_health.ttfrc_degraded_ms"
+      ]
+      (List.sort String.compare unknown)
+
 let test_oas_env_parses_allowed_keys () =
   let input = {|
 [keeper]
@@ -1917,6 +1937,8 @@ let () =
             test_detect_unknown_keys_accepts_tool_access_array;
           test_case "accepts loader base include" `Quick
             test_detect_unknown_keys_accepts_loader_base;
+          test_case "flags provider_health table as unknown" `Quick
+            test_detect_unknown_keys_flags_provider_health_table;
           test_case "oas_env keys not flagged as unknown" `Quick
             test_oas_env_not_flagged_as_unknown;
           test_case "load_keeper_toml captures unknown keys on profile" `Quick


### PR DESCRIPTION
## Summary

- Remove the unused `[provider_health]` table from the keeper base TOML seed.
- Hide the dashboard's internal synthetic-agent "파생" badge.
- Render keeper runtime `derived` sources as operator-facing `default` labels.
- Add TOML and dashboard regression coverage.

## Product impact

Operators no longer see internal/synthetic implementation labels in the keeper roster or runtime config panel. The seeded keeper config also stops carrying a table that the TOML schema treats as unknown config.

## Evidence

- `pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/agent-roster.test.ts src/components/tools/config-resolution-panel.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_toml.exe`
- `./_build/default/test/test_keeper_toml.exe`

## Direct evidence

schema_version: 1
direct_ratio: 4/4
provenance: direct

- Focused dashboard tests passed: 2 files, 43 tests.
- Dashboard TypeScript check passed.
- Focused OCaml TOML test executable built.
- `Keeper TOML Loader` passed: 98 tests.

## Review evidence

- Added coverage that synthetic agent rows do not expose `파생`.
- Added coverage that the keeper runtime panel shows `default` instead of `derived`.
- Added coverage that `[provider_health]` is unknown keeper TOML config.

## Linked issue

None.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`codex/dashboard-config-label-cleanup-20260604` → `main` · 1 commit(s) · synced 2026-06-04T14:31:12Z

| sha | subject | date |
|---|---|---|
| `231c2593a` | Clean keeper config and dashboard labels | 2026-06-04 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->