### PR TITLE
fix(keeper): treat turn budget as continuation

### DIFF
--- a/lib/keeper/keeper_memory_policy.ml
+++ b/lib/keeper/keeper_memory_policy.ml
@@ -812,14 +812,16 @@ let cap_for_kind (caps : (string * int) list) (kind : string) : int =
 
 (** Synthesize a [STATE] block from run metadata when the model omits one.
     Produces a deterministic snapshot from tool usage, stop reason, and goal
-    so generation continuity is never broken. Tagged [SYNTHETIC] for
-    downstream consumers to distinguish from model-generated blocks. *)
+    so generation continuity is never broken. Budget exhaustion is a
+    continuation checkpoint, not a model-authored decision or task
+    completion, so it records only progress and next-cycle guidance. *)
 let synthesize_state_from_run_result
     ~(goal : string)
     ~(tools_used : string list)
     ~(stop_reason : string)
     ~(response_text : string)
     : keeper_state_snapshot =
+  let budget_exhausted = String.equal stop_reason "budget_exhausted" in
   let progress =
     match tools_used with
     | [] -> Some "No tools used this generation"
@@ -828,28 +830,34 @@ let synthesize_state_from_run_result
       Some (Printf.sprintf "Used: %s" (String.concat ", " unique))
   in
   let next_summary =
-    if stop_reason = "budget_exhausted"
+    if budget_exhausted
     then
       Some
         "Resume from the OAS checkpoint and inspect the latest assistant/tool \
          context before choosing the next action."
     else None
   in
-  let response_hint =
-    let trimmed = String.trim response_text in
-    if trimmed = "" then None
-    else
-      Some (String_util.utf8_safe ~max_bytes:103 ~suffix:"..." trimmed
-            |> String_util.to_string)
-  in
   let decisions =
-    match response_hint with
-    | Some hint -> [Keeper_synthetic_marker.tag (Printf.sprintf "Last output: %s" hint)]
-    | None -> [Keeper_synthetic_marker.tag "No visible output this generation"]
+    if budget_exhausted
+    then []
+    else (
+      let response_hint =
+        let trimmed = String.trim response_text in
+        if trimmed = ""
+        then None
+        else
+          Some
+            (String_util.utf8_safe ~max_bytes:103 ~suffix:"..." trimmed
+             |> String_util.to_string)
+      in
+      match response_hint with
+      | Some hint ->
+        [ Keeper_synthetic_marker.tag (Printf.sprintf "Last output: %s" hint) ]
+      | None -> [ Keeper_synthetic_marker.tag "No visible output this generation" ])
   in
   { goal = (let g = String.trim goal in if g = "" then None else Some g);
     progress;
-    done_summary = progress;
+    done_summary = (if budget_exhausted then None else progress);
     next_summary;
     next_items = [];
     decisions;

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -90,7 +90,7 @@ type worker_lifecycle_classification =
 let worker_lifecycle_classification_of_result = function
   | Ok _ -> { event = "completed"; status = "completed"; error = None }
   | Error (Agent_sdk.Error.Agent (Agent_sdk.Error.MaxTurnsExceeded _)) ->
-    { event = "completed"; status = "budget_exhausted"; error = None }
+    { event = "completed"; status = "continuation_checkpoint"; error = None }
   | Error (Agent_sdk.Error.Agent (Agent_sdk.Error.AgentExecutionTimeout _)) ->
     { event = "failed"; status = "agent_execution_timeout"; error = None }
   | Error (Agent_sdk.Error.Agent (Agent_sdk.Error.AgentExecutionIdleTimeout _)) ->
@@ -385,7 +385,7 @@ let run_duration_ms_since started_at =
 
 let dashboard_status_of_stop_reason = function
   | Completed -> Dashboard_oas_bridge.Success
-  | TurnBudgetExhausted _ -> Dashboard_oas_bridge.Timeout
+  | TurnBudgetExhausted _ -> Dashboard_oas_bridge.Success
   | MutationBoundaryReached _ ->
       Dashboard_oas_bridge.Cancelled { reason = "mutation_boundary_reached" }
 
@@ -609,12 +609,15 @@ let run
       let partial_response =
         partial_response_of_stop
           ~session_id
-          ~text:(Printf.sprintf
-            "[turn budget exhausted: %d/%d turns used]" r.turns r.limit)
+          ~text:
+            "Continuation checkpoint saved; keeper remains scheduled for the \
+             next cycle."
       in
       record_dashboard_oas_response ~config
         ~total_duration_ms:run_total_duration_ms
-        ~status:Dashboard_oas_bridge.Timeout partial_response;
+        ~status:(dashboard_status_of_stop_reason
+                   (TurnBudgetExhausted { turns_used = r.turns; limit = r.limit }))
+        partial_response;
       let runtime_observation =
         runtime_observation_for_completed_config
           ~total_duration_ms:run_total_duration_ms config

--- a/lib/runtime/runtime_agent.mli
+++ b/lib/runtime/runtime_agent.mli
@@ -33,12 +33,12 @@ type stop_reason = Runtime_agent_context.stop_reason =
       turns_used : int;
       tool_name : string option;
     }
-(** Why the run terminated.  [Completed] is the success
-    path; [TurnBudgetExhausted] fires when the per-call
-    [max_turns] is hit; [MutationBoundaryReached] fires
-    when the keeper hit a mutation tool while in
-    read-only mode (the [tool_name] surfaces which tool
-    triggered the gate). *)
+(** Why this single OAS call yielded control. [Completed] is the
+    model's success path; [TurnBudgetExhausted] means the per-call
+    [max_turns] checkpoint was reached and the keeper should continue
+    from the persisted checkpoint on the next cycle; [MutationBoundaryReached]
+    fires when the keeper hit a mutation tool while in read-only mode
+    (the [tool_name] surfaces which tool triggered the gate). *)
 
 (** {1 Config} *)
 

--- a/test/test_keeper_agent_memory_episode_activity.ml
+++ b/test/test_keeper_agent_memory_episode_activity.ml
@@ -163,7 +163,7 @@ let test_synthetic_success_snapshot_does_not_emit_episode () =
         ~goal:"Fix task"
         ~tools_used:["tool_execute"]
         ~stop_reason:"budget_exhausted"
-        ~response_text:"[turn budget exhausted: 8/8 turns used]"
+        ~response_text:"Continuation checkpoint saved; keeper remains scheduled"
     in
     with_activity_emit counting_emit (fun () ->
       Episode.record_success ~config ~keeper_name:keeper ~memory ~turn:12

--- a/test/test_keeper_memory_write.ml
+++ b/test/test_keeper_memory_write.ml
@@ -180,7 +180,7 @@ let test_synthetic_snapshot_source_drops_memory_candidates () =
       ~goal:"Fix task"
       ~tools_used:["tool_execute"; "tool_read_file"]
       ~stop_reason:"budget_exhausted"
-      ~response_text:"[turn budget exhausted: 8/8 turns used]"
+      ~response_text:"Continuation checkpoint saved; keeper remains scheduled"
   in
   let selection =
     Keeper_memory_bank.memory_candidates_from_snapshot_source

--- a/test/test_keeper_state_snapshot_json.ml
+++ b/test/test_keeper_state_snapshot_json.ml
@@ -265,19 +265,21 @@ let test_budget_synthesis_does_not_invent_next_items () =
       ~goal:"Fix task"
       ~tools_used:["tool_execute"; "tool_read_file"]
       ~stop_reason:"budget_exhausted"
-      ~response_text:"[turn budget exhausted: 8/8 turns used]"
+      ~response_text:"Continuation checkpoint saved; keeper remains scheduled"
   in
   Alcotest.(check (list string)) "no invented next_items" [] snapshot.next_items;
+  Alcotest.(check (option string)) "budget continuation is not done" None
+    snapshot.done_summary;
   Alcotest.(check bool)
     "checkpoint resume summary present"
     true
     (match snapshot.next_summary with
      | Some text -> contains_substring text "OAS checkpoint"
      | None -> false);
-  Alcotest.(check bool)
-    "synthetic marker present"
-    true
-    (List.exists Masc.Keeper_synthetic_marker.contains_marker snapshot.decisions)
+  Alcotest.(check (list string))
+    "budget continuation does not invent decisions"
+    []
+    snapshot.decisions
 
 (* ── Test runner ─────────────────────────────────────────────────── *)
 

--- a/test/test_keeper_working_state.ml
+++ b/test/test_keeper_working_state.ml
@@ -140,7 +140,7 @@ let test_projector_ignores_budget_synthetic_summary_as_loop () =
       ~goal:"Fix task"
       ~tools_used:["tool_execute"]
       ~stop_reason:"budget_exhausted"
-      ~response_text:"[turn budget exhausted: 8/8 turns used]"
+      ~response_text:"Continuation checkpoint saved; keeper remains scheduled"
   in
   let state =
     Masc.Keeper_working_state_projector.of_state_snapshot

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -148,6 +148,17 @@ let test_runtime_agent_terminal_observation_uses_runtime_identity () =
   check string "attempt detail source" "runtime_agent_terminal"
     observation.attempt_details_source
 
+let test_runtime_agent_max_turns_is_continuation_checkpoint () =
+  let lifecycle =
+    Runtime_agent.worker_lifecycle_classification_of_result
+      (Error
+         (Agent_sdk.Error.Agent
+            (Agent_sdk.Error.MaxTurnsExceeded { turns = 24; limit = 24 })))
+  in
+  check string "event" "completed" lifecycle.event;
+  check string "status" "continuation_checkpoint" lifecycle.status;
+  check (option string) "no error" None lifecycle.error
+
 let () =
   run "runtime_provider_auth_headers"
     [ ( "provider_config"
@@ -163,5 +174,9 @@ let () =
             "runtime agent terminal observation carries model identity"
             `Quick
             test_runtime_agent_terminal_observation_uses_runtime_identity
+        ; test_case
+            "max turns is continuation checkpoint"
+            `Quick
+            test_runtime_agent_max_turns_is_continuation_checkpoint
         ] )
     ]


### PR DESCRIPTION
## Summary
- Treat OAS MaxTurnsExceeded as a continuation checkpoint instead of a timeout/error surface.
- Stop writing budget exhaustion text as synthetic "Last output" decisions or DONE summaries.
- Add regression coverage for continuation lifecycle status and budget snapshot synthesis.

## Validation
- git diff --check origin/main..HEAD
- env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_state_snapshot_json.exe test/test_keeper_working_state.exe test/test_keeper_memory_write.exe test/test_keeper_agent_memory_episode_activity.exe test/test_runtime_provider_auth_headers.exe
- ./_build/default/test/test_keeper_state_snapshot_json.exe
- ./_build/default/test/test_keeper_working_state.exe
- ./_build/default/test/test_keeper_memory_write.exe
- ./_build/default/test/test_keeper_agent_memory_episode_activity.exe
- ./_build/default/test/test_runtime_provider_auth_headers.exe