### PR TITLE
[codex] harden WebFetch extraction and curl argv

### DIFF
--- a/bin/gen_tool_descriptors.ml
+++ b/bin/gen_tool_descriptors.ml
@@ -156,10 +156,10 @@ let masc_web_search_spec : tool_spec =
 let masc_web_fetch_spec : tool_spec =
   { name = "masc_web_fetch"
   ; description =
-      "Fetch a web page by URL and return cleaned text content. Read-only helper for \
-       reading selected sources after web search before citing them. Strips HTML tags, \
-       decodes entities, normalizes whitespace, and optionally extracts <title> and \
-       <meta name=\"description\">. Returns structured JSON with the cleaned text."
+      "Fetch a web page by URL and return agent-readable extracted content. Read-only \
+       helper for reading selected sources after web search before citing them. Prefers \
+       article/main/body content, strips script/style/navigation noise, returns markdown \
+       by default, and extracts <title> plus description metadata when present."
   ; parameters =
       [ { p_name = "url"
         ; p_type = T_string { enum = None; default = None }
@@ -169,6 +169,19 @@ let masc_web_fetch_spec : tool_spec =
       ; { p_name = "timeout"
         ; p_type = T_int { min = Some 1; max = Some 60; default = Some 15 }
         ; p_description = "Request timeout in seconds (default 15, max 60)"
+        ; p_required = false
+        }
+      ; { p_name = "extractMode"
+        ; p_type =
+            T_string { enum = Some [ "markdown"; "text" ]; default = Some "markdown" }
+        ; p_description =
+            "Output extraction mode. markdown preserves readable headings/lists/links; \
+             text returns flattened plain text."
+        ; p_required = false
+        }
+      ; { p_name = "maxChars"
+        ; p_type = T_int { min = Some 1; max = Some 100000; default = Some 50000 }
+        ; p_description = "Maximum extracted content characters to return"
         ; p_required = false
         }
       ]

--- a/config/prompts/keeper.tool_hints.toml
+++ b/config/prompts/keeper.tool_hints.toml
@@ -70,8 +70,8 @@ description = "look up current public context before time-sensitive claims"
 
 [[hints]]
 name = "WebFetch"
-call = "`WebFetch` { url: \"https://example.com/page\", timeout: {{web_fetch_timeout}} }"
-description = "fetch and read a web page before citing it"
+call = "`WebFetch` { url: \"https://example.com/page\", timeout: {{web_fetch_timeout}}, extractMode: \"markdown\" }"
+description = "fetch and read an agent-readable web page before citing it"
 
 [[hints]]
 name = "masc_transition"

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -265,10 +265,40 @@ let search_web_schema =
 ;;
 
 let fetch_web_schema =
-  object_schema
-    ~required:[ "url" ]
-    [ property "url" "string" "URL to fetch."
-    ; property "timeout" "integer" "Request timeout in seconds."
+  `Assoc
+    [ "type", `String "object"
+    ; ( "properties",
+        `Assoc
+          [ property "url" "string" "URL to fetch."
+          ; ( "timeout",
+              `Assoc
+                [ "type", `String "integer"
+                ; "description", `String "Request timeout in seconds."
+                ; "minimum", `Int 1
+                ; "maximum", `Int 60
+                ; "default", `Int 15
+                ] )
+          ; ( "extractMode",
+              `Assoc
+                [ "type", `String "string"
+                ; "enum", `List [ `String "markdown"; `String "text" ]
+                ; "description",
+                  `String
+                    "Output extraction mode. markdown preserves headings/lists/links; \
+                     text returns flattened plain text."
+                ; "default", `String "markdown"
+                ] )
+          ; ( "maxChars",
+              `Assoc
+                [ "type", `String "integer"
+                ; "description", `String "Maximum extracted content characters to return."
+                ; "minimum", `Int 1
+                ; "maximum", `Int 100000
+                ; "default", `Int 50000
+                ] )
+          ] )
+    ; "required", `List [ `String "url" ]
+    ; "additionalProperties", `Bool false
     ]
 ;;
 

--- a/lib/tool_local_runtime_http.ml
+++ b/lib/tool_local_runtime_http.ml
@@ -32,31 +32,65 @@ let split_http_body_and_status body =
       in
       (payload, parse_int_opt status_raw)
 
-let append_headers args headers =
-  (* Accumulate header args without repeated list concatenation, then reverse
-     them back so curl sees headers in the same left-to-right order as the
-     input list. *)
-  let header_args_rev =
-    List.fold_left
-      (fun acc (name, value) -> (name ^ ": " ^ value) :: "-H" :: acc)
-      [] headers
-  in
-  List.rev_append header_args_rev args
+let header_args headers =
+  List.concat_map (fun (name, value) -> [ "-H"; name ^ ": " ^ value ]) headers
 
-let http_get_text_with_status_with_headers ?(timeout_sec = default_timeout_sec) ?(headers = []) url =
-  let argv =
-    append_headers
+let max_response_args = function
+  | None -> []
+  | Some bytes when bytes <= 0 -> []
+  | Some bytes ->
       [
-        "curl";
-        "-sS";
-        "--http1.1";
-        "--max-time";
-        Int.to_string (max 1 timeout_sec);
-        "-w";
-        "\n%{http_code}";
-        url;
+        "--max-filesize";
+        Int.to_string bytes;
+        "--range";
+        "0-" ^ Int.to_string (bytes - 1);
       ]
-      headers
+
+let curl_get_argv ?(timeout_sec = default_timeout_sec) ?(headers = [])
+    ?(follow_redirects = false) ?(max_redirects = 3) ?(compressed = false)
+    ?max_response_bytes url =
+  let timeout_sec = max 1 timeout_sec in
+  let redirect_args =
+    if follow_redirects then [ "--location"; "--max-redirs"; Int.to_string max_redirects ]
+    else []
+  in
+  let compression_args = if compressed then [ "--compressed" ] else [] in
+  [
+    "curl";
+    "-sS";
+    "--http1.1";
+    "--max-time";
+    Int.to_string timeout_sec;
+  ]
+  @ compression_args
+  @ redirect_args
+  @ header_args headers
+  @ max_response_args max_response_bytes
+  @ [ "-w"; "\n%{http_code}"; url ]
+
+let curl_post_json_argv ~timeout_sec ?(headers = []) ~url ~body_json () =
+  let timeout_sec = max 1 timeout_sec in
+  [
+    "curl";
+    "-sS";
+    "--http1.1";
+    "--max-time";
+    Int.to_string timeout_sec;
+    "-H";
+    "Content-Type: application/json";
+  ]
+  @ header_args headers
+  @ [ "-d"; body_json; "-w"; "\n%{http_code}"; url ]
+
+let curl_get_argv_for_test = curl_get_argv
+
+let http_get_text_with_status_with_headers ?(timeout_sec = default_timeout_sec)
+    ?(headers = []) ?(follow_redirects = false) ?(max_redirects = 3)
+    ?(compressed = false) ?max_response_bytes url =
+  let timeout_sec = max 1 timeout_sec in
+  let argv =
+    curl_get_argv ~timeout_sec ~headers ~follow_redirects ~max_redirects
+      ~compressed ?max_response_bytes url
   in
   let status, body =
     Fd_accountant.with_slot ~kind:Sandbox_exec (fun () ->
@@ -64,7 +98,7 @@ let http_get_text_with_status_with_headers ?(timeout_sec = default_timeout_sec) 
         ~actor:(Masc_exec.Agent_id.of_string "tool/local_runtime")
         ~raw_source:(String.concat " " (List.map Filename.quote argv))
         ~summary:"tool local runtime http get"
-        ~timeout_sec:(Stdlib.Float.of_int (max 1 timeout_sec))
+        ~timeout_sec:(Stdlib.Float.of_int timeout_sec)
         argv)
   in
   match status with
@@ -89,32 +123,17 @@ let http_get_json_with_status ?(timeout_sec = default_timeout_sec) url =
       with Yojson.Json_error msg ->
         Error (Printf.sprintf "invalid json from %s: %s" url msg))
 
-let http_post_json_text_with_status_with_headers ~timeout_sec ?(headers = []) ~url ~body_json () =
-  let argv =
-    append_headers
-      [
-        "curl";
-        "-sS";
-        "--http1.1";
-        "--max-time";
-        Int.to_string (max 1 timeout_sec);
-        "-H";
-        "Content-Type: application/json";
-        "-d";
-        body_json;
-        "-w";
-        "\n%{http_code}";
-        url;
-      ]
-      headers
-  in
+let http_post_json_text_with_status_with_headers ~timeout_sec ?(headers = []) ~url
+    ~body_json () =
+  let timeout_sec = max 1 timeout_sec in
+  let argv = curl_post_json_argv ~timeout_sec ~headers ~url ~body_json () in
   let status, body =
     Fd_accountant.with_slot ~kind:Sandbox_exec (fun () ->
       Masc_exec.Exec_gate.run_argv_with_status
         ~actor:(Masc_exec.Agent_id.of_string "tool/local_runtime")
         ~raw_source:(String.concat " " (List.map Filename.quote argv))
         ~summary:"tool local runtime http post"
-        ~timeout_sec:(Stdlib.Float.of_int (max 1 timeout_sec))
+        ~timeout_sec:(Stdlib.Float.of_int timeout_sec)
         argv)
   in
   match status with

--- a/lib/tool_local_runtime_http.mli
+++ b/lib/tool_local_runtime_http.mli
@@ -17,8 +17,7 @@
     receive the core surface transitively via
     [include Tool_local_runtime_http].
 
-    Internal helpers ([split_http_body_and_status],
-    [append_headers]) stay private. *)
+    Internal helpers stay private. *)
 
 include module type of struct
   include Tool_local_runtime_core
@@ -46,6 +45,10 @@ val string_member : Yojson.Safe.t -> string -> string option
 val http_get_text_with_status_with_headers :
   ?timeout_sec:int ->
   ?headers:(string * string) list ->
+  ?follow_redirects:bool ->
+  ?max_redirects:int ->
+  ?compressed:bool ->
+  ?max_response_bytes:int ->
   string ->
   ((int option * string), string) Result.t
 (** [http_get_text_with_status_with_headers ?timeout_sec ?headers url]
@@ -59,8 +62,24 @@ val http_get_text_with_status_with_headers :
     [timeout_sec] defaults to 10 (floored at 1).
     [headers] defaults to [\[\]]; appended in left-to-right order
     (each pair becomes [-H "name: value"]).
+    [follow_redirects] defaults to [false]; when [true], curl follows
+    redirects up to [max_redirects] (default 3).
+    [compressed] enables curl's transparent compression handling.
+    [max_response_bytes], when set, asks curl to cap/range the response.
 
     Errors include curl exit code, signals, and stop reasons. *)
+
+val curl_get_argv_for_test :
+  ?timeout_sec:int ->
+  ?headers:(string * string) list ->
+  ?follow_redirects:bool ->
+  ?max_redirects:int ->
+  ?compressed:bool ->
+  ?max_response_bytes:int ->
+  string ->
+  string list
+
+(** Pure curl argv builder exposed for focused regression tests. *)
 
 val http_get_text_with_status :
   ?timeout_sec:int ->

--- a/lib/tool_misc.mli
+++ b/lib/tool_misc.mli
@@ -51,6 +51,7 @@ val with_web_search_simulation_for_test :
 val with_web_fetch_http_get_for_test :
   (timeout_sec:int ->
    headers:(string * string) list ->
+   max_response_bytes:int ->
    string ->
    (int option * string, string) result) ->
   (unit -> 'a) ->
@@ -68,4 +69,3 @@ val register_dashboard_handler :
    Yojson.Safe.t ->
    Tool_result.result) ->
   unit
-

--- a/lib/tool_misc_web_fetch.ml
+++ b/lib/tool_misc_web_fetch.ml
@@ -18,6 +18,26 @@ module Float = Stdlib.Float
 open Tool_args
 
 let default_timeout_sec = 15
+let default_max_chars = 50_000
+let max_chars_cap = 100_000
+let max_response_bytes = 2_000_000
+let max_redirects = 3
+
+type extract_mode =
+  | Markdown
+  | Text
+
+let extract_mode_to_string = function
+  | Markdown -> "markdown"
+  | Text -> "text"
+
+let extract_mode_of_string raw =
+  match String.lowercase_ascii (String.trim raw) with
+  | "" | "markdown" | "md" -> Some Markdown
+  | "text" | "plain" | "plain_text" -> Some Text
+  | _ -> None
+
+let default_extract_mode = Markdown
 
 (** Extract <title> from HTML *)
 let title_tag_re =
@@ -85,6 +105,248 @@ let valid_url url =
     | Some "http" | Some "https" -> true
     | _ -> false
 
+let ends_with ~suffix s =
+  let len_s = String.length s in
+  let len_suffix = String.length suffix in
+  len_suffix <= len_s
+  && String.equal (String.sub s (len_s - len_suffix) len_suffix) suffix
+
+let ipv4_private_reason host =
+  match String.split_on_char '.' host |> List.map Stdlib.int_of_string_opt with
+  | [ Some a; Some b; Some _; Some _ ]
+    when a = 0
+         || a = 10
+         || a = 127
+         || a >= 224
+         || (a = 169 && b = 254)
+         || (a = 172 && b >= 16 && b <= 31)
+         || (a = 192 && b = 168)
+         || (a = 100 && b >= 64 && b <= 127)
+         || (a = 198 && (b = 18 || b = 19)) ->
+      Some "private/internal/special-use IPv4 address"
+  | [ Some 192; Some 0; Some 2; Some _ ]
+  | [ Some 198; Some 51; Some 100; Some _ ]
+  | [ Some 203; Some 0; Some 113; Some _ ] ->
+      Some "documentation-only IPv4 address"
+  | [ Some _; Some _; Some _; Some _ ] -> None
+  | _ -> None
+
+let ipv6_private_reason host =
+  let lower = String.lowercase_ascii host in
+  if String.equal lower "::1"
+     || String.equal lower "0:0:0:0:0:0:0:1"
+     || String.equal lower "::"
+  then Some "private/internal/special-use IPv6 address"
+  else if String.starts_with ~prefix:"fc" lower
+          || String.starts_with ~prefix:"fd" lower
+          || String.starts_with ~prefix:"fe8" lower
+          || String.starts_with ~prefix:"fe9" lower
+          || String.starts_with ~prefix:"fea" lower
+          || String.starts_with ~prefix:"feb" lower
+  then Some "private/internal/special-use IPv6 address"
+  else None
+
+let blocked_host_reason url =
+  let uri = Uri.of_string (String.trim url) in
+  match Uri.host uri with
+  | None -> Some "url must include a host"
+  | Some raw_host ->
+      let host = String.lowercase_ascii (String.trim raw_host) in
+      if String.equal host "" then Some "url must include a host"
+      else if String.equal host "localhost" || ends_with ~suffix:".localhost" host
+      then Some "localhost is not allowed"
+      else if String.equal host "metadata.google.internal"
+              || String.equal host "169.254.169.254"
+      then Some "cloud metadata endpoints are not allowed"
+      else if not (String.contains host '.') && not (String.contains host ':')
+      then Some "single-label internal hostnames are not allowed"
+      else
+        match ipv4_private_reason host with
+        | Some _ as reason -> reason
+        | None -> if String.contains host ':' then ipv6_private_reason host else None
+
+let html_block_re tag =
+  Re.Pcre.re
+    ~flags:[ `CASELESS; `DOTALL ]
+    (Printf.sprintf "<%s\\b[^>]*>[\\s\\S]*?</%s>" tag tag)
+  |> Re.compile
+
+let remove_html_noise_res =
+  List.map html_block_re
+    [ "script"; "style"; "noscript"; "svg"; "canvas"; "template"; "iframe" ]
+
+let remove_boilerplate_res =
+  List.map html_block_re [ "nav"; "footer"; "aside"; "form" ]
+
+let html_comment_re =
+  Re.Pcre.re ~flags:[ `DOTALL ] "<!--[\\s\\S]*?-->" |> Re.compile
+
+let article_re =
+  Re.Pcre.re ~flags:[ `CASELESS; `DOTALL ] "<article\\b[^>]*>([\\s\\S]*?)</article>"
+  |> Re.compile
+
+let main_re =
+  Re.Pcre.re ~flags:[ `CASELESS; `DOTALL ] "<main\\b[^>]*>([\\s\\S]*?)</main>"
+  |> Re.compile
+
+let body_re =
+  Re.Pcre.re ~flags:[ `CASELESS; `DOTALL ] "<body\\b[^>]*>([\\s\\S]*?)</body>"
+  |> Re.compile
+
+let heading_re =
+  Re.Pcre.re ~flags:[ `CASELESS; `DOTALL ] "<h([1-6])\\b[^>]*>([\\s\\S]*?)</h[1-6]>"
+  |> Re.compile
+
+let link_re =
+  Re.Pcre.re
+    ~flags:[ `CASELESS; `DOTALL ]
+    "<a\\b[^>]*href\\s*=\\s*['\"]([^'\"]+)['\"][^>]*>([\\s\\S]*?)</a>"
+  |> Re.compile
+
+let paragraph_open_re = Re.Pcre.re ~flags:[ `CASELESS ] "<p\\b[^>]*>" |> Re.compile
+let paragraph_close_re = Re.Pcre.re ~flags:[ `CASELESS ] "</p>" |> Re.compile
+let br_re = Re.Pcre.re ~flags:[ `CASELESS ] "<br\\s*/?>" |> Re.compile
+let li_open_re = Re.Pcre.re ~flags:[ `CASELESS ] "<li\\b[^>]*>" |> Re.compile
+let li_close_re = Re.Pcre.re ~flags:[ `CASELESS ] "</li>" |> Re.compile
+let block_open_re =
+  Re.Pcre.re ~flags:[ `CASELESS ] "<(div|section|tr|table|ul|ol)\\b[^>]*>"
+  |> Re.compile
+let block_close_re =
+  Re.Pcre.re ~flags:[ `CASELESS ] "</(div|section|tr|table|ul|ol)>"
+  |> Re.compile
+let residual_tag_re = Re.Pcre.re "<[^>]+>" |> Re.compile
+let horizontal_space_re = Re.Pcre.re "[ \t\r]+" |> Re.compile
+let blank_lines_re = Re.Pcre.re "\n{3,}" |> Re.compile
+
+let html_entity_replacements =
+  [
+    ("&amp;", "&");
+    ("&lt;", "<");
+    ("&gt;", ">");
+    ("&quot;", "\"");
+    ("&#39;", "'");
+    ("&#039;", "'");
+    ("&apos;", "'");
+    ("&nbsp;", " ");
+  ]
+  |> List.map (fun (entity, replacement) ->
+         (Re.str entity |> Re.compile, replacement))
+
+let decode_html_entities text =
+  List.fold_left
+    (fun acc (entity_re, replacement) ->
+      Re.replace_string entity_re ~by:replacement acc)
+    text
+    html_entity_replacements
+
+let strip_noise html =
+  remove_html_noise_res
+  |> List.fold_left
+       (fun acc re -> Re.replace_string re ~by:"" acc)
+       (Re.replace_string html_comment_re ~by:"" html)
+
+let longest_nonempty blocks =
+  List.fold_left
+    (fun best block ->
+      let candidate = String.trim block in
+      if String.equal candidate "" then best
+      else
+        match best with
+        | None -> Some candidate
+        | Some current ->
+            if String.length candidate > String.length current then Some candidate
+            else best)
+    None
+    blocks
+
+let first_group pattern html =
+  Re.all pattern html |> List.map (fun groups -> Re.Group.get groups 1)
+
+let select_readable_html html =
+  let html = strip_noise html in
+  let selected =
+    match longest_nonempty (first_group article_re html) with
+    | Some article -> article
+    | None -> (
+        match longest_nonempty (first_group main_re html) with
+        | Some main -> main
+        | None -> (
+            match first_group body_re html with
+            | body :: _ -> body
+            | [] -> html))
+  in
+  List.fold_left
+    (fun acc re -> Re.replace_string re ~by:"" acc)
+    selected
+    remove_boilerplate_res
+
+let clean_inline html =
+  Tool_misc_web_search.clean_search_text html
+
+let render_links html =
+  Re.replace link_re html ~f:(fun groups ->
+      let href = Re.Group.get groups 1 |> String.trim in
+      let label = Re.Group.get groups 2 |> clean_inline in
+      if String.equal label "" then ""
+      else if valid_url href then Printf.sprintf "[%s](%s)" label href
+      else label)
+
+let render_headings html =
+  Re.replace heading_re html ~f:(fun groups ->
+      let level =
+        Re.Group.get groups 1 |> Stdlib.int_of_string_opt |> Option.value ~default:2
+      in
+      let marker = String.make (max 1 (min 6 level)) '#' in
+      let label = Re.Group.get groups 2 |> clean_inline in
+      if String.equal label "" then "\n" else "\n" ^ marker ^ " " ^ label ^ "\n")
+
+let normalize_markdown text =
+  let lines =
+    text
+    |> Re.replace_string horizontal_space_re ~by:" "
+    |> String.split_on_char '\n'
+    |> List.map String.trim
+  in
+  let buf = Buffer.create (String.length text) in
+  let previous_blank = ref true in
+  List.iter
+    (fun line ->
+      if String.equal line "" then (
+        if not !previous_blank then (
+          Buffer.add_char buf '\n';
+          previous_blank := true))
+      else (
+        if Buffer.length buf > 0 && not !previous_blank then Buffer.add_char buf '\n';
+        Buffer.add_string buf line;
+        previous_blank := false))
+    lines;
+  Buffer.contents buf |> Re.replace_string blank_lines_re ~by:"\n\n" |> String.trim
+
+let render_markdown html =
+  html
+  |> render_links
+  |> render_headings
+  |> Re.replace_string br_re ~by:"\n"
+  |> Re.replace_string paragraph_open_re ~by:"\n"
+  |> Re.replace_string paragraph_close_re ~by:"\n"
+  |> Re.replace_string li_open_re ~by:"\n- "
+  |> Re.replace_string li_close_re ~by:"\n"
+  |> Re.replace_string block_open_re ~by:"\n"
+  |> Re.replace_string block_close_re ~by:"\n"
+  |> Re.replace_string residual_tag_re ~by:""
+  |> decode_html_entities
+  |> normalize_markdown
+
+let render_extracted_text ~extract_mode html =
+  let readable = select_readable_html html in
+  match extract_mode with
+  | Markdown -> render_markdown readable
+  | Text -> Tool_misc_web_search.clean_search_text readable
+
+let truncate_text ~max_chars text =
+  if String.length text <= max_chars then text, false
+  else String.sub text 0 max_chars ^ "\n[TRUNCATED]", true
+
 (** Cache + rate limit — same pattern as web_search but separate state *)
 type cache_entry = {
   response : string;
@@ -138,9 +400,6 @@ let enforce_rate_limit now =
         Queue.push now request_times;
         Ok ()))
 
-(** Max content length — prevent context overflow *)
-let max_content_length = 100_000
-
 (** Redact transport error detail before the " for " suffix *)
 let redact_transport_error_detail message =
   match String.index_opt message ' ' with
@@ -172,13 +431,18 @@ let fetch_failure_class : fetch_failure -> Tool_result.tool_failure_class =
 type http_get =
   timeout_sec:int ->
   headers:(string * string) list ->
+  max_response_bytes:int ->
   string ->
   (int option * string, string) Result.t
 
-let default_http_get ~timeout_sec ~headers url =
+let default_http_get ~timeout_sec ~headers ~max_response_bytes url =
   Tool_local_runtime_http.http_get_text_with_status_with_headers
     ~timeout_sec
     ~headers
+    ~follow_redirects:true
+    ~max_redirects
+    ~compressed:true
+    ~max_response_bytes
     url
 
 let http_get_mutex = Mutex.create ()
@@ -200,24 +464,25 @@ let with_http_get_for_test http_get f =
     f
 
 (** Main fetch implementation *)
-let fetch_impl ~url ~timeout_sec =
+let fetch_impl ~url ~timeout_sec ~extract_mode ~max_chars =
   let headers =
-    [ ("User-Agent", "Mozilla/5.0 (compatible; MASC-FetchWeb/1.0)") ]
+    [
+      ( "User-Agent",
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 \
+         (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36 MASC-FetchWeb/1.0" );
+      ("Accept", "text/html,application/xhtml+xml,text/plain;q=0.9,*/*;q=0.5");
+      ("Accept-Language", "en-US,en;q=0.8,ko;q=0.7");
+    ]
   in
-  match (current_http_get ()) ~timeout_sec ~headers url with
+  match (current_http_get ()) ~timeout_sec ~headers ~max_response_bytes url with
   | Error detail ->
       Error (Transport_error (redact_transport_error_detail detail))
   | Ok (Some status, payload) when status >= 200 && status < 300 ->
       let title = extract_title payload in
       let description = extract_description payload in
-      let text =
-        let cleaned = Tool_misc_web_search.clean_search_text payload in
-        if String.length cleaned > max_content_length then
-          String.sub cleaned 0 max_content_length
-          ^ "\n[TRUNCATED at 100KB]"
-        else cleaned
-      in
-      Ok (status, title, description, text)
+      let rendered = render_extracted_text ~extract_mode payload in
+      let text, truncated = truncate_text ~max_chars rendered in
+      Ok (status, title, description, text, truncated)
   | Ok (Some status, _) -> Error (Http_status status)
   | Ok (None, _) -> Error No_http_status
 
@@ -242,66 +507,87 @@ let fetch_impl ~url ~timeout_sec =
 let handle ~tool_name ~start_time args : Tool_result.result =
   let url = get_string args "url" "" in
   let timeout = max 1 (min 60 (get_int args "timeout" default_timeout_sec)) in
-  if not (valid_url url) then
+  let max_chars = max 1 (min max_chars_cap (get_int args "maxChars" default_max_chars)) in
+  let extract_mode_raw =
+    get_string args "extractMode" (extract_mode_to_string default_extract_mode)
+  in
+  let make_workflow_err message =
     Tool_result.make_err
       ~tool_name
       ~class_:Tool_result.Workflow_rejection
       ~start_time
-      "url must be a valid http or https URL"
+      message
+  in
+  if not (valid_url url) then
+    make_workflow_err "url must be a valid http or https URL"
   else
-    (* RFC-0189 follow-up — store the parsed JSON envelope in
-       [~data] instead of wrapping as [`Assoc [ "text", `String body ]].
-       The wrapped form corrupted [result.message] for callers (and
-       tests) that round-tripped through [parse_json result.message],
-       because the wrapper was serialised instead of the envelope. Both
-       the cache and fresh paths produce [Tool_args.ok_response] strings,
-       so both go through
-       [structured_payload_of_message]; plain-text fallback retained
-       only for defence in depth. *)
-    let ok_from_envelope body =
-      let data =
-        match Tool_result.structured_payload_of_message body with
-        | Some json -> json
-        | None -> `String body
-      in
-      Tool_result.make_ok ~tool_name ~start_time ~data ()
-    in
-    let now = Unix.gettimeofday () in
-    let key = url ^ "|" ^ Int.to_string timeout in
-    match cache_lookup key now with
-    | Some cached -> ok_from_envelope cached
-    | None -> (
-        match enforce_rate_limit now with
-        | Error message ->
-            Tool_result.make_err
-              ~tool_name
-              ~class_:Tool_result.Transient_error
-              ~start_time
-              message
-        | Ok () -> (
-            match fetch_impl ~url ~timeout_sec:timeout with
-            | Ok (http_status, title, description, text) ->
-                let fields =
-                  [
-                    ("url", `String url);
-                    ("http_status", `Int http_status);
-                    ("text", `String text);
-                  ]
-                  @
-                  (match title with
-                  | Some t -> [ ("title", `String t) ]
-                  | None -> [])
-                  @
-                  (match description with
-                  | Some d -> [ ("description", `String d) ]
-                  | None -> [])
-                in
-                let json = Tool_args.ok_response fields in
-                cache_store key json now;
-                ok_from_envelope json
-            | Error failure ->
-                Tool_result.make_err
-                  ~tool_name
-                  ~class_:(fetch_failure_class failure)
-                  ~start_time
-                  (fetch_failure_to_string failure)))
+    match extract_mode_of_string extract_mode_raw with
+    | None -> make_workflow_err "extractMode must be one of: markdown, text"
+    | Some extract_mode -> (
+        match blocked_host_reason url with
+        | Some reason -> make_workflow_err ("url host is blocked: " ^ reason)
+        | None ->
+            let extract_mode_label = extract_mode_to_string extract_mode in
+            (* RFC-0189 follow-up — store the parsed JSON envelope in
+               [~data] instead of wrapping as [`Assoc [ "text", `String body ]].
+               The wrapped form corrupted [result.message] for callers (and
+               tests) that round-tripped through [parse_json result.message],
+               because the wrapper was serialised instead of the envelope. Both
+               the cache and fresh paths produce [Tool_args.ok_response] strings,
+               so both go through
+               [structured_payload_of_message]; plain-text fallback retained
+               only for defence in depth. *)
+            let ok_from_envelope body =
+              let data =
+                match Tool_result.structured_payload_of_message body with
+                | Some json -> json
+                | None -> `String body
+              in
+              Tool_result.make_ok ~tool_name ~start_time ~data ()
+            in
+            let now = Unix.gettimeofday () in
+            let key =
+              String.concat
+                "|"
+                [ url; Int.to_string timeout; extract_mode_label; Int.to_string max_chars ]
+            in
+            match cache_lookup key now with
+            | Some cached -> ok_from_envelope cached
+            | None -> (
+                match enforce_rate_limit now with
+                | Error message ->
+                    Tool_result.make_err
+                      ~tool_name
+                      ~class_:Tool_result.Transient_error
+                      ~start_time
+                      message
+                | Ok () -> (
+                    match fetch_impl ~url ~timeout_sec:timeout ~extract_mode ~max_chars with
+                    | Ok (http_status, title, description, text, truncated) ->
+                        let fields =
+                          [
+                            ("url", `String url);
+                            ("http_status", `Int http_status);
+                            ("extract_mode", `String extract_mode_label);
+                            ("text", `String text);
+                            ("content_chars", `Int (String.length text));
+                            ("truncated", `Bool truncated);
+                          ]
+                          @
+                          (match title with
+                          | Some t -> [ ("title", `String t) ]
+                          | None -> [])
+                          @
+                          (match description with
+                          | Some d -> [ ("description", `String d) ]
+                          | None -> [])
+                        in
+                        let json = Tool_args.ok_response fields in
+                        cache_store key json now;
+                        ok_from_envelope json
+                    | Error failure ->
+                        Tool_result.make_err
+                          ~tool_name
+                          ~class_:(fetch_failure_class failure)
+                          ~start_time
+                          (fetch_failure_to_string failure))))

--- a/lib/tool_misc_web_fetch.mli
+++ b/lib/tool_misc_web_fetch.mli
@@ -11,20 +11,27 @@
 val default_timeout_sec : int
 (** Default timeout for HTTP fetch operations (seconds). *)
 
+val default_max_chars : int
+(** Default maximum output length for extracted content. *)
+
 val handle : tool_name:string -> start_time:float -> Yojson.Safe.t -> Tool_result.result
 (** [handle ~tool_name ~start_time args] handles [masc_web_fetch] tool dispatch.
     Required: [url] (string, http/https only).
     Optional: [timeout] (int, clamped to [\[1, 60\]], default {!default_timeout_sec}).
+    Optional: [extractMode] ("markdown" or "text", default "markdown").
+    Optional: [maxChars] (int, clamped to [\[1, 100000\]], default {!default_max_chars}).
 
     On success the payload [data] is wrapped as
     [`Assoc [ "text", `String json ]] where [json] is the serialized
     [Tool_args.ok_response] envelope holding:
-    - [url]: the requested URL
-    - [http_status]: HTTP status code
-    - [text]: cleaned text content (HTML tags stripped, entities decoded,
-      whitespace normalized, truncated at 100KB)
-    - [title]: optional, extracted from [<title>] tag
-    - [description]: optional, extracted from [<meta name="description">]
+	    - [url]: the requested URL
+	    - [http_status]: HTTP status code
+	    - [extract_mode]: output extraction mode
+	    - [text]: readable extracted content, truncated at [maxChars]
+	    - [content_chars]: length of [text]
+	    - [truncated]: whether output truncation was applied
+	    - [title]: optional, extracted from [<title>] tag
+	    - [description]: optional, extracted from [<meta name="description">]
       or [og:description]
 
     Failure classes (RFC-0189):
@@ -36,6 +43,7 @@ val handle : tool_name:string -> start_time:float -> Yojson.Safe.t -> Tool_resul
 val with_http_get_for_test :
   (timeout_sec:int ->
    headers:(string * string) list ->
+   max_response_bytes:int ->
    string ->
    (int option * string, string) result) ->
   (unit -> 'a) ->

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -569,8 +569,9 @@ let test_public_web_fetch_alias_dispatches_to_misc_runtime () =
 </html>|}
       in
       Masc.Tool_misc.with_web_fetch_http_get_for_test
-        (fun ~timeout_sec ~headers url ->
+        (fun ~timeout_sec ~headers ~max_response_bytes url ->
           check int "timeout forwarded" 7 timeout_sec;
+          check int "max response bytes forwarded" 2_000_000 max_response_bytes;
           check string "url forwarded" requested_url url;
           check bool "user agent header present" true
             (List.exists
@@ -589,7 +590,12 @@ let test_public_web_fetch_alias_dispatches_to_misc_runtime () =
               ~name:"WebFetch"
               ~input:
                 (`Assoc
-                  [ ("url", `String requested_url); ("timeout", `Int 7) ])
+                  [
+                    ("url", `String requested_url);
+                    ("timeout", `Int 7);
+                    ("extractMode", `String "markdown");
+                    ("maxChars", `Int 200);
+                  ])
               ()
           in
           check string "web fetch alias outcome" "success"
@@ -603,14 +609,46 @@ let test_public_web_fetch_alias_dispatches_to_misc_runtime () =
             Yojson.Safe.Util.(member "url" json |> to_string);
           check int "http status" 200
             Yojson.Safe.Util.(member "http_status" json |> to_int);
+          check string "extract mode" "markdown"
+            Yojson.Safe.Util.(member "extract_mode" json |> to_string);
+          check bool "not truncated" false
+            Yojson.Safe.Util.(member "truncated" json |> to_bool);
           check string "title" "Alias Title & More"
             Yojson.Safe.Util.(member "title" json |> to_string);
           check string "description" "Alias description & detail"
             Yojson.Safe.Util.(member "description" json |> to_string);
+          check bool "heading rendered as markdown" true
+            (contains_substring
+               Yojson.Safe.Util.(member "text" json |> to_string)
+               "# Alias Fetch");
           check bool "body text cleaned" true
             (contains_substring
                Yojson.Safe.Util.(member "text" json |> to_string)
                "Body content & proof.")))
+
+let test_public_web_fetch_blocks_localhost_before_runtime () =
+  with_exec_fixture "keeper_tool_dispatch_web_fetch_blocks_localhost"
+    (fun ~config ~meta ~ctx_work ->
+      Masc.Tool_misc.with_web_fetch_http_get_for_test
+        (fun ~timeout_sec:_ ~headers:_ ~max_response_bytes:_ _url ->
+          fail "blocked URL should not reach the HTTP runtime")
+        (fun () ->
+          let result =
+            KET.execute_keeper_tool_call_with_outcome
+              ~config
+              ~meta
+              ~ctx_work
+              ~exec_cache:None
+              ~name:"WebFetch"
+              ~input:(`Assoc [ ("url", `String "http://127.0.0.1:8935/health") ])
+              ()
+          in
+          check string "web fetch local outcome" "failure"
+            (outcome_label result.outcome);
+          check string "web fetch local payload shape" "structured_error"
+            (payload_kind result.payload_shape);
+          check bool "blocked host message" true
+            (contains_substring result.raw_output "url host is blocked")))
 
 let workflow_rejection_message =
   "Invalid task state: Self-approval not allowed: verifier must be a different agent"
@@ -840,6 +878,8 @@ let () =
         test_public_web_search_alias_dispatches_to_misc_runtime;
       test_case "public WebFetch alias reaches misc runtime" `Quick
         test_public_web_fetch_alias_dispatches_to_misc_runtime;
+      test_case "public WebFetch blocks localhost before runtime" `Quick
+        test_public_web_fetch_blocks_localhost_before_runtime;
       test_case "task FSM errors require explicit failure_class" `Quick
         test_tool_result_does_not_infer_task_fsm_rejections_from_message;
       test_case "tool_result_or_error preserves failure_class" `Quick

--- a/test/test_tool_local_runtime_probe.ml
+++ b/test/test_tool_local_runtime_probe.ml
@@ -156,6 +156,28 @@ let test_endpoint_urls_use_normalized_base () =
     (Masc.Tool_local_runtime_probe.ollama_generate_url
        "http://127.0.0.1:11434///")
 
+let test_curl_get_argv_keeps_curl_as_executable_with_headers () =
+  let argv =
+    Masc.Tool_local_runtime_http.curl_get_argv_for_test
+      ~timeout_sec:30
+      ~headers:
+        [
+          ("User-Agent", "Mozilla/5.0 (compatible; MASC-FetchWeb/1.0)");
+          ("Accept-Language", "en-US,en;q=0.8");
+        ]
+      ~follow_redirects:true
+      ~max_redirects:3
+      ~compressed:true
+      ~max_response_bytes:2_000_000
+      "https://example.com/page"
+  in
+  check string "argv0 remains curl" "curl" (List.hd argv);
+  check bool "header arg present" true (List.mem "-H" argv);
+  check bool "redirect arg present" true (List.mem "--location" argv);
+  check bool "compression arg present" true (List.mem "--compressed" argv);
+  check bool "body cap arg present" true (List.mem "--max-filesize" argv);
+  check bool "curl is not repeated after headers" false (List.mem "curl" (List.tl argv))
+
 let test_ollama_ps_non_200_is_reported_as_error () =
   check string "ps non-200 surfaced" "ollama ps returned http 503"
     (Masc.Tool_local_runtime_probe.ollama_http_error "ps" (Some 503))
@@ -238,6 +260,8 @@ let () =
             test_normalize_server_url_strips_trailing_slashes;
           test_case "builds normalized endpoint urls" `Quick
             test_endpoint_urls_use_normalized_base;
+          test_case "curl argv keeps executable before headers" `Quick
+            test_curl_get_argv_keeps_curl_as_executable_with_headers;
           test_case "reports ps non-200 as error" `Quick
             test_ollama_ps_non_200_is_reported_as_error;
           test_case "omits keep_alive by default" `Quick


### PR DESCRIPTION
## Summary

Harden WebFetch into an agent-readable fetch tool:

- build curl argv through a pure typed helper so headers cannot precede the `curl` executable
- add markdown/text extraction with article/main/body selection, boilerplate removal, metadata extraction, and truncation metadata
- add WebFetch schema and hint support for `extractMode` and `maxChars`
- reject localhost/private/special-use hosts before the HTTP runtime is called

## Product impact

- User-visible change: `WebFetch` now returns structured, agent-readable page content by default instead of flattened raw-ish HTML text, and the original header argv failure path is covered by a regression test.

## Evidence

- PASS: `ocamlformat --check lib/tool_misc_web_fetch.ml lib/tool_local_runtime_http.ml lib/tool_local_runtime_http.mli lib/tool_misc_web_fetch.mli lib/tool_misc.mli bin/gen_tool_descriptors.ml lib/keeper/keeper_tool_descriptor.ml test/test_tool_local_runtime_probe.ml test/test_keeper_tool_dispatch_runtime.ml`
- PASS: `git diff --check`
- PASS: `./_build/default/test/test_keeper_tool_dispatch_runtime.exe` (24 tests)
- PASS: `./_build/default/test/test_tool_descriptors_gen.exe` (33 tests)
- PASS: `./_build/default/test/test_tool_local_runtime_probe.exe test generate 2` (new curl argv regression test)
- NOTE: a focused `scripts/dune-local.sh build test/test_keeper_tool_dispatch_runtime.exe test/test_tool_local_runtime_probe.exe test/test_tool_descriptors_gen.exe` retry could not complete before PR open because the shared Dune wrapper lock queue was occupied by other worktrees; CI should perform the fresh rebuild.

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 5/6
provenance: direct
stages:
  - stage: format
    command: ocamlformat --check ...
    result: pass
  - stage: whitespace
    command: git diff --check
    result: pass
  - stage: keeper_dispatch_runtime
    command: ./_build/default/test/test_keeper_tool_dispatch_runtime.exe
    result: pass
  - stage: descriptor_generation
    command: ./_build/default/test/test_tool_descriptors_gen.exe
    result: pass
  - stage: curl_argv_regression
    command: ./_build/default/test/test_tool_local_runtime_probe.exe test generate 2
    result: pass
  - stage: focused_build
    command: scripts/dune-local.sh build test/test_keeper_tool_dispatch_runtime.exe test/test_tool_local_runtime_probe.exe test/test_tool_descriptors_gen.exe
    result: blocked_by_shared_local_lock_queue
```

## GOAL LOOP ACT checklist

- [x] Observe — WebFetch failed with `Process Executable "-H" not found`, showing curl argv ordering was corrupted.
- [x] Orient — the failure maps to HTTP transport argv construction plus weak WebFetch extraction/schema behavior.
- [x] Decide — this scope fixes the transport regression and upgrades extraction/schema without changing unrelated tool routing.
- [x] Act — changed WebFetch, local HTTP helper, public descriptors, hints, and focused tests only.
- [x] Verify — focused local tests listed above passed; CI remains the fresh rebuild gate because local Dune lock queue was occupied.
- [x] Loop — no separate follow-up is required for this slice.

## Review evidence

- Not run yet. This PR is opened as draft for CI and bot review.

## Linked issue

- None.

## Variant addition checklist

- [x] **OCaml** — added local `extract_mode` variant in WebFetch implementation only; exhaustive matches added.
- [ ] **TypeScript** — N/A, no dashboard union changed.
- [ ] **TLA+ spec** — N/A, no state-machine domain literal changed.
- [x] **Event / JSON schema** — WebFetch JSON schema enum updated for `extractMode`.
- [ ] **`make check-variants` passes** — N/A for local-only WebFetch extract mode; focused schema/tests listed above passed.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`codex/webfetch-v2-20260604` → `main` · 1 commit(s) · synced 2026-06-04T14:34:00Z

| sha | subject | date |
|---|---|---|
| `28587d2f0` | harden WebFetch extraction and curl argv | 2026-06-04 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->