### PR TITLE
refactor(keeper): move keeper name validation to ids

### DIFF
--- a/docs/rfc/RFC-0215-keeper-sublibrary-extraction-campaign.md
+++ b/docs/rfc/RFC-0215-keeper-sublibrary-extraction-campaign.md
@@ -184,6 +184,11 @@ not a hot keeper runtime path, so it can create the persona profile directory
 with `Fs_compat.mkdir_p` and write JSON through `Fs_compat.save_file_atomic`
 without importing the keeper filesystem metrics/cache module.
 
+Keeper/persona handle validation now lives on the extracted type boundary:
+`Ids.Keeper_id.Name.validate`. `Keeper_config_text.validate_name` remains as a
+config-facing facade, but credential authoring no longer imports full
+`Keeper_config` just to validate a handle.
+
 ## 5. Extraction sequence
 
 Candidate clusters and their re-measured **flat-ns fan-out** (the G1 metric).
@@ -191,7 +196,7 @@ Fan-in is shown for context but does not gate extraction.
 
 | Order | Cluster | Modules | flat-ns fan-out (G1 blockers) | Distinct flat-ns refs |
 |---|---|---|---|---|
-| 1 | credential (`keeper_persona_authoring*`) | 3 | **3** | `Keeper_config`, `Keeper_types_profile_persona`, `Keeper_types_profile_toml_normalizers` |
+| 1 | credential (`keeper_persona_authoring*`) | 3 | **2** | `Keeper_types_profile_persona`, `Keeper_types_profile_toml_normalizers` |
 | 2 | registry (`keeper_registry_*`) | 19 | 6 | `Admission_queue`, `Governance_registry`, `Prometheus`, `Runtime_params`, `Shutdown`, `Sse` |
 | 3 | error-classify (`*failure*`, `*error_class*`) | 31 | 6 | `Governance_registry`, `Prometheus`, `Runtime_params`, `Shutdown`, `Telemetry_coverage_gap`, `Workspace` |
 | 4 | runtime-binding (`keeper_heartbeat*`/`keeper_runtime*`/`keeper_attempt*`) | 30 | 6 | `Governance_registry`, `Prometheus`, `Runtime_params`, `Sse`, `Telemetry_coverage_gap`, `Workspace` |
@@ -201,9 +206,9 @@ Fan-in is shown for context but does not gate extraction.
 | 8 | execution (`keeper_agent_run_*`, `keeper_tool_*`, `keeper_sandbox_*`, `keeper_run_*`) | ~70 | highest | last — the mesh hub |
 
 **Recommended first extraction: credential (`keeper_persona_authoring*`).**
-It is the smallest *decoupling surface* — 3 modules, 3 flat-ns refs to invert.
-As of the credential pre-work stack, those direct refs are profile/config
-support (`Keeper_config`, `Keeper_types_profile_persona`,
+It is the smallest *decoupling surface* — 3 modules, 2 flat-ns refs left to
+resolve. As of the credential pre-work stack, those direct refs are profile
+support (`Keeper_types_profile_persona`,
 `Keeper_types_profile_toml_normalizers`), not the older OAS/approval bridge
 refs. The remaining work is therefore to decide which profile support belongs
 inside the credential extraction unit and which parts should move behind a

--- a/lib/keeper/keeper_config_text.ml
+++ b/lib/keeper/keeper_config_text.ml
@@ -37,10 +37,7 @@ let bool_of_env_opt name =
 
 (* ── Name validation ────────────────────────────────────────── *)
 
-let valid_name_re = Re.Pcre.re "^[A-Za-z0-9._-]+$" |> Re.compile
-
-let validate_name name =
-  name <> "" && Re.execp valid_name_re name
+let validate_name = Ids.Keeper_id.Name.validate
 
 (* ── Configuration constants ────────────────────────────────── *)
 

--- a/lib/keeper/keeper_persona_authoring.ml
+++ b/lib/keeper/keeper_persona_authoring.ml
@@ -492,7 +492,7 @@ let normalize_keeper_json ~handle keeper_json =
 ;;
 
 let normalize_profile ~handle profile =
-  if not (Keeper_config.validate_name handle)
+  if not (Ids.Keeper_id.Name.validate handle)
   then Error "handle must match [A-Za-z0-9._-]+"
   else if Keeper_types_profile_persona.json_has_operator_todo_placeholder profile
   then

--- a/lib/types/ids.ml
+++ b/lib/types/ids.ml
@@ -131,6 +131,9 @@ module Keeper_id : sig
   val generate : name:string -> path:string -> t
   val to_yojson : t -> Yojson.Safe.t
   val of_yojson : Yojson.Safe.t -> (t, string) result
+  module Name : sig
+    val validate : string -> bool
+  end
   module Trace_id : sig
     type t
     val of_string : string -> (t, string) result
@@ -159,6 +162,22 @@ end = struct
         Error
           (Printf.sprintf "Expected string for Keeper_id (received %s)"
              (Json_util.kind_name other))
+  module Name = struct
+    let validate name =
+      let len = String.length name in
+      len > 0
+      &&
+      let rec check index =
+        if index = len then true
+        else
+          match name.[index] with
+          | 'a'..'z' | 'A'..'Z' | '0'..'9' | '.' | '_' | '-' ->
+            check (index + 1)
+          | _ -> false
+      in
+      check 0
+  end
+
   module Keeper_name = struct
     type t = string
     let is_valid s =

--- a/lib/types/ids.mli
+++ b/lib/types/ids.mli
@@ -67,6 +67,9 @@ module Keeper_id : sig
   val generate : name:string -> path:string -> t
   val to_yojson : t -> Yojson.Safe.t
   val of_yojson : Yojson.Safe.t -> (t, string) result
+  module Name : sig
+    val validate : string -> bool
+  end
   module Trace_id : sig
     type t
     val of_string : string -> (t, string) result


### PR DESCRIPTION
Stacked on #20131. Moves keeper/persona handle validation to the extracted types boundary via Ids.Keeper_id.Name.validate, keeps Keeper_config_text.validate_name as the config-facing facade, and points keeper_persona_authoring at the extracted type boundary instead of full Keeper_config. Updates RFC-0215 with the measured credential fan-out now at 2 direct flat refs. Verification: gtimeout 300 dune exec --root . ./test/test_keeper_toml.exe; ocamlformat --check lib/types/ids.ml lib/types/ids.mli lib/keeper/keeper_config_text.ml lib/keeper/keeper_persona_authoring.ml; git diff --check origin/codex/persona-authoring-fs-compat-20260604...HEAD; rg confirms no Keeper_config.* direct calls remain in keeper_persona_authoring; analyze_lib_deps shows Keeper_persona_authoring outbound edges are now only Keeper_types_profile_persona and Keeper_types_profile_toml_normalizers.