### PR TITLE
[codex] avoid range requests in WebFetch curl cap

### DIFF
--- a/lib/tool_local_runtime_http.ml
+++ b/lib/tool_local_runtime_http.ml
@@ -38,13 +38,7 @@ let header_args headers =
 let max_response_args = function
   | None -> []
   | Some bytes when bytes <= 0 -> []
-  | Some bytes ->
-      [
-        "--max-filesize";
-        Int.to_string bytes;
-        "--range";
-        "0-" ^ Int.to_string (bytes - 1);
-      ]
+  | Some bytes -> [ "--max-filesize"; Int.to_string bytes ]
 
 let curl_get_argv ?(timeout_sec = default_timeout_sec) ?(headers = [])
     ?(follow_redirects = false) ?(max_redirects = 3) ?(compressed = false)

--- a/test/test_tool_local_runtime_probe.ml
+++ b/test/test_tool_local_runtime_probe.ml
@@ -176,6 +176,7 @@ let test_curl_get_argv_keeps_curl_as_executable_with_headers () =
   check bool "redirect arg present" true (List.mem "--location" argv);
   check bool "compression arg present" true (List.mem "--compressed" argv);
   check bool "body cap arg present" true (List.mem "--max-filesize" argv);
+  check bool "body cap does not force range response" false (List.mem "--range" argv);
   check bool "curl is not repeated after headers" false (List.mem "curl" (List.tl argv))
 
 let test_ollama_ps_non_200_is_reported_as_error () =


### PR DESCRIPTION
## Summary

Remove the default `--range` curl argument from WebFetch response capping.

The previous WebFetch v2 cap used both `--max-filesize` and `--range 0-N`.
That avoids oversized downloads, but it also turns ordinary small pages into
HTTP `206 Partial Content` responses whenever the server honors Range requests.
This PR keeps the cap via `--max-filesize` while preserving normal `200`
status behavior for ordinary pages.

## Product impact

- User-visible change: `WebFetch` should report normal `200` responses for small pages instead of forcing `206 Partial Content` just because the tool has a response-size cap.

## Evidence

- PASS: `ocamlformat --check lib/tool_local_runtime_http.ml test/test_tool_local_runtime_probe.ml`
- PASS: `git diff --check`
- PASS: direct curl behavior check with `--max-filesize 2000000` and no `--range` returned `200` for `https://example.com/`.
- OBSERVED: live WebFetch harness against the prior merged implementation succeeded through `Tool_local_runtime_http` outside the Codex command sandbox but returned `206`, proving the Range side effect.
- BLOCKED locally: `scripts/dune-local.sh build test/test_tool_local_runtime_probe.exe` cannot compile in the current shared opam switch because `agent_sdk` is pinned to a different OAS worktree/API. Errors include missing `Agent_sdk.Memory`, `Agent_sdk.Error.A2a`, and `Agent_sdk.Error.CompletionContractViolation`. CI should verify against the repo-pinned dependency set.

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 4/5
provenance: direct
stages:
  - stage: format
    command: ocamlformat --check lib/tool_local_runtime_http.ml test/test_tool_local_runtime_probe.ml
    result: pass
  - stage: whitespace
    command: git diff --check
    result: pass
  - stage: direct_curl_without_range
    command: curl --max-filesize 2000000 https://example.com/
    result: pass_http_200
  - stage: live_webfetch_prior_impl
    command: live WebFetch harness outside Codex command sandbox
    result: pass_dispatch_but_http_206_due_to_range
  - stage: focused_build
    command: scripts/dune-local.sh build test/test_tool_local_runtime_probe.exe
    result: blocked_by_shared_agent_sdk_pin_mismatch
```

## GOAL LOOP ACT checklist

- [x] Observe — live WebFetch verification showed the prior implementation returned `206` because `--range` was always present.
- [x] Orient — `--max-filesize` is sufficient for the cap; `--range` changes HTTP semantics for normal pages.
- [x] Decide — remove only `--range` and add a regression assertion that body caps do not force Range requests.
- [x] Act — changed `Tool_local_runtime_http.max_response_args` and the curl argv regression test.
- [x] Verify — format, diff check, and direct curl behavior passed; focused local build is blocked by unrelated shared opam pin mismatch.
- [x] Loop — CI remains the compile/test gate for this small follow-up.

## Review evidence

- Not run yet. This PR is opened as draft for CI and bot review.

## Linked issue

- Follow-up to #20135.

## Variant addition checklist

- [ ] **OCaml** — N/A, no variant added/removed.
- [ ] **TypeScript** — N/A.
- [ ] **TLA+ spec** — N/A.
- [ ] **Event / JSON schema** — N/A.
- [ ] **`make check-variants` passes** — N/A; no variant/schema enum changed.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`codex/webfetch-no-range-20260604` → `main` · 1 commit(s) · synced 2026-06-04T15:09:39Z

| sha | subject | date |
|---|---|---|
| `fa2fa17ec` | avoid range requests in WebFetch curl cap | 2026-06-04 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->