### PR TITLE
[codex] Recover keeper library search argument misses

### DIFF
--- a/lib/keeper/keeper_status_bridge_blocker.ml
+++ b/lib/keeper/keeper_status_bridge_blocker.ml
@@ -208,6 +208,13 @@ let stale_kill_class_summary (kill_class : Keeper_registry.stale_kill_class) =
       noop_count
 ;;
 
+let sdk_tool_retry_exhausted_code_prefix = "agent_error_tool_retry_exhausted"
+
+let provider_runtime_code_is_sdk_tool_retry_exhausted code =
+  String.equal code sdk_tool_retry_exhausted_code_prefix
+  || String.starts_with ~prefix:(sdk_tool_retry_exhausted_code_prefix ^ ":") code
+;;
+
 let runtime_blocker_surface_of_failure_reason (reason : Keeper_registry.failure_reason) =
   match reason with
   | Keeper_registry.Heartbeat_consecutive_failures count ->
@@ -277,6 +284,16 @@ let runtime_blocker_surface_of_failure_reason (reason : Keeper_registry.failure_
               "No tool-capable provider available (registry path): %s"
               detail)
          (Runtime_exhausted no_tool_capable))
+  | Keeper_registry.Provider_runtime_error { code; detail; _ }
+    when provider_runtime_code_is_sdk_tool_retry_exhausted code ->
+    Some
+      (runtime_blocker_surface_of_typed_class
+         ~summary:
+           (Printf.sprintf
+              "OAS tool retry budget exhausted; inspect tool arguments/schema \
+               first. Detail: %s"
+              detail)
+         Sdk_tool_retry_exhausted)
   | Keeper_registry.Provider_runtime_error { code; detail; _ } ->
     Some
       { blocker_class = "provider_runtime_error"

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -646,6 +646,25 @@ let tool_search_schema =
     ]
 ;;
 
+let library_search_schema =
+  object_schema
+    [ property
+        "query"
+        "string"
+        "Search query string; empty or missing returns a workflow error."
+    ]
+;;
+
+let library_read_schema =
+  object_schema
+    ~required:[ "topic" ]
+    [ property
+        "topic"
+        "string"
+        "Exact document topic name from search results or known context."
+    ]
+;;
+
 let read_only_in_process_policy ?(inline_safe = false) ?(maintenance_only = false)
       ?(last_turn_safe = false) ()
   =
@@ -976,14 +995,14 @@ let internal_descriptors : t list =
       ~id:"keeper.library.search"
       ~name:"keeper_library_search"
       ~description:"Search the keeper library catalog."
-      ~input_schema:passthrough_object_schema
+      ~input_schema:library_search_schema
       ~policy:(read_only_in_process_policy ())
       ~handler:Tool_library_search
   ; in_process_descriptor
       ~id:"keeper.library.read"
       ~name:"keeper_library_read"
       ~description:"Read a library entry by id."
-      ~input_schema:passthrough_object_schema
+      ~input_schema:library_read_schema
       ~policy:(read_only_in_process_policy ())
       ~handler:Tool_library_read
     (* ── IDE (RFC-0179 PR-3) ──────────────────────────────────── *)

--- a/lib/tool_library.ml
+++ b/lib/tool_library.ml
@@ -453,7 +453,7 @@ let tool_definitions = [
     ("confidence", "number", true, "New confidence score (must be >= 0.5)");
   ]);
   ("masc_library_search", {|Search library documents by content or tags.|}, [
-    ("query", "string", true, "Search query");
+    ("query", "string", false, "Search query; empty or missing returns a workflow error");
   ]);
 ]
 
@@ -567,10 +567,9 @@ Pair with masc_library_read to fetch matching documents in full.";
       ("properties", `Assoc [
         ("query", `Assoc [
           ("type", `String "string");
-          ("description", `String "Search query");
+          ("description", `String "Search query; empty or missing returns a workflow error");
         ]);
       ]);
-      ("required", `List [`String "query"]);
     ];
   };
 

--- a/lib/tool_surface/tool_shard_types_schemas_library.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_library.ml
@@ -14,10 +14,12 @@ let library_tools : Masc_domain.tool_schema list =
                 [ ( "query"
                   , `Assoc
                       [ "type", `String "string"
-                      ; "description", `String "Search query string"
+                      ; ( "description"
+                        , `String
+                            "Search query string; empty or missing returns a \
+                             workflow error" )
                       ] )
                 ] )
-          ; "required", `List [ `String "query" ]
           ]
     }
   ; { name = "keeper_library_read"

--- a/test/test_blocker_class_exhaustiveness.ml
+++ b/test/test_blocker_class_exhaustiveness.ml
@@ -11,6 +11,21 @@ open Alcotest
 module Kmc = Masc.Keeper_meta_contract
 open Kmc
 
+let string_contains ~needle haystack =
+  let needle_len = String.length needle in
+  let haystack_len = String.length haystack in
+  if needle_len = 0
+  then true
+  else
+    let rec loop i =
+      if i + needle_len > haystack_len
+      then false
+      else
+        String.equal (String.sub haystack i needle_len) needle || loop (i + 1)
+    in
+    loop 0
+;;
+
 (* ── All variants listed exhaustively ──────────────────────────── *)
 
 (** Canonical list of all [blocker_class] variants.  When a new variant is
@@ -255,11 +270,16 @@ let test_structural_timeout_maps_to_oas_timeout () =
    non-no_tool_capable provider error still falls through to the
    provider_runtime_error catch-all (no widening). *)
 
-let no_tool_capable_surface_exn ~reason ~code =
+let no_tool_capable_surface_exn
+      ?(detail = "no tool-capable provider found (runtime=r labels=[a])")
+      ~reason
+      ~code
+      ()
+  =
   let failure_reason =
     Reg.Provider_runtime_error
       { code
-      ; detail = "no tool-capable provider found (runtime=r labels=[a])"
+      ; detail
       ; provider_id = None
       ; http_status = None
       ; runtime_id = Some "r"
@@ -281,11 +301,13 @@ let test_no_tool_capable_typed_reason_surface () =
            (No_tool_capable
               (Some { configured_labels = [ "a" ]; provider_rejections = [] })))
       ~code:"no_tool_capable_provider"
+      ()
   in
   let none_shape =
     no_tool_capable_surface_exn
       ~reason:(Some (No_tool_capable None))
       ~code:"no_tool_capable_provider"
+      ()
   in
   List.iter
     (fun (label, surface) ->
@@ -306,6 +328,7 @@ let test_non_no_tool_capable_provider_error_falls_through () =
     no_tool_capable_surface_exn
       ~reason:(Some Connection_refused)
       ~code:"runtime_exhausted_connection_refused"
+      ()
   in
   check string
     "non-NTC provider error -> provider_runtime_error catch-all"
@@ -316,11 +339,39 @@ let test_non_no_tool_capable_provider_error_falls_through () =
 let test_reason_none_provider_error_falls_through () =
   let surface =
     no_tool_capable_surface_exn ~reason:None ~code:"provider_error"
+      ()
   in
   check string
     "reason=None provider error -> provider_runtime_error catch-all"
     "provider_runtime_error"
     surface.KSB.blocker_class
+;;
+
+let test_tool_retry_provider_error_uses_sdk_surface () =
+  let surface =
+    no_tool_capable_surface_exn
+      ~reason:None
+      ~code:"agent_error_tool_retry_exhausted:attempts=2,limit=2"
+      ~detail:"Tool retry budget exhausted after 2/2 retries: masc_library_search {}"
+      ()
+  in
+  check string
+    "tool retry code -> sdk_tool_retry_exhausted surface"
+    "sdk_tool_retry_exhausted"
+    surface.KSB.blocker_class;
+  check bool "continue_gate false" false surface.KSB.continue_gate;
+  check bool
+    "summary points at tool args"
+    true
+    (string_contains ~needle:"tool arguments/schema" surface.KSB.summary);
+  check bool
+    "summary keeps retry detail"
+    true
+    (string_contains ~needle:"Tool retry budget exhausted" surface.KSB.summary);
+  check bool
+    "summary avoids provider catch-all wording"
+    false
+    (string_contains ~needle:"Provider runtime catch-all" surface.KSB.summary)
 ;;
 
 (* ── Runner ────────────────────────────────────────────────────── *)
@@ -349,6 +400,8 @@ let () =
             test_non_no_tool_capable_provider_error_falls_through
         ; test_case "reason=None provider error falls through" `Quick
             test_reason_none_provider_error_falls_through
+        ; test_case "tool retry provider record uses sdk surface" `Quick
+            test_tool_retry_provider_error_uses_sdk_surface
         ] )
     ]
 ;;

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -186,6 +186,25 @@ let schema_property_description schema name =
   |> to_string_option
 ;;
 
+let schema_required_fields schema =
+  match schema with
+  | `Assoc fields ->
+    (match List.assoc_opt "required" fields with
+     | Some (`List values) ->
+       List.map
+         (function
+           | `String value -> value
+           | other ->
+             Alcotest.failf
+               "required contains non-string: %s"
+               (Yojson.Safe.to_string other))
+         values
+     | Some other ->
+       Alcotest.failf "required is not a list: %s" (Yojson.Safe.to_string other)
+     | None -> [])
+  | other -> Alcotest.failf "input_schema is not an object: %s" (Yojson.Safe.to_string other)
+;;
+
 let required_board_schema name =
   match List.find_opt (fun (s : Masc_domain.tool_schema) -> s.name = name) Board.board_tools with
   | Some schema -> schema
@@ -371,6 +390,22 @@ let test_masc_board_registry_has_descriptor_projection () =
        | [] -> Alcotest.failf "missing descriptor for %s" schema.name
        | _ :: _ :: _ -> Alcotest.failf "duplicate descriptor for %s" schema.name)
     Tool_board_registry.tools
+
+let test_library_search_descriptor_has_recoverable_query_schema () =
+  let descriptor = required_internal_descriptor "keeper_library_search" in
+  let query_description =
+    schema_property_description descriptor.Descriptor.input_schema "query"
+    |> Option.value ~default:""
+  in
+  check_contains
+    "keeper_library_search descriptor documents query"
+    ~sub:"Search query"
+    query_description;
+  Alcotest.(check bool)
+    "keeper_library_search query is not validation-required"
+    false
+    (List.mem "query" (schema_required_fields descriptor.input_schema))
+;;
 
 let test_readonly_policy_projects_to_registry () =
   let projected = Descriptor.readonly_internal_names () in
@@ -701,6 +736,10 @@ let () =
             "MASC board descriptions disambiguate post_id flow"
             `Quick
             test_masc_board_descriptions_disambiguate_post_id_flow
+        ; test_case
+            "Library search query is runtime-recoverable"
+            `Quick
+            test_library_search_descriptor_has_recoverable_query_schema
         ] )
     ; ( "masc-board"
       , [ test_case

--- a/test/test_tool_library_coverage.ml
+++ b/test/test_tool_library_coverage.ml
@@ -17,6 +17,49 @@ let msg_contains ~needle haystack =
   try ignore (Str.search_forward (Str.regexp_string ln) lc 0); true
   with Not_found -> false
 
+let required_schema name =
+  match
+    List.find_opt
+      (fun (schema : Masc_domain.tool_schema) -> String.equal schema.name name)
+      Tool_library.schemas
+  with
+  | Some schema -> schema
+  | None -> Alcotest.failf "missing schema for %s" name
+
+let schema_required_fields (schema : Masc_domain.tool_schema) =
+  match schema.input_schema with
+  | `Assoc fields ->
+    (match List.assoc_opt "required" fields with
+     | Some (`List values) ->
+       List.map
+         (function
+           | `String value -> value
+           | other ->
+             Alcotest.failf
+               "%s required contains non-string: %s"
+               schema.name
+               (Yojson.Safe.to_string other))
+         values
+     | Some other ->
+       Alcotest.failf
+         "%s required is not a list: %s"
+         schema.name
+         (Yojson.Safe.to_string other)
+     | None -> [])
+  | other ->
+    Alcotest.failf
+      "%s input_schema is not an object: %s"
+      schema.name
+      (Yojson.Safe.to_string other)
+
+let schema_has_property (schema : Masc_domain.tool_schema) property =
+  match schema.input_schema with
+  | `Assoc fields ->
+    (match List.assoc_opt "properties" fields with
+     | Some (`Assoc properties) -> List.mem_assoc property properties
+     | _ -> false)
+  | _ -> false
+
 let test_counter = ref 0
 
 let temp_dir () =
@@ -212,6 +255,17 @@ let test_search_empty_query () =
     Alcotest.(check bool) "error mentions query" true (msg_contains ~needle:"query" msg)
   )
 
+let test_search_schema_allows_runtime_query_rejection () =
+  let schema = required_schema "masc_library_search" in
+  Alcotest.(check bool)
+    "query property remains documented"
+    true
+    (schema_has_property schema "query");
+  Alcotest.(check bool)
+    "query is not validation-required"
+    false
+    (List.mem "query" (schema_required_fields schema))
+
 let test_search_with_query () =
   with_temp_base_path (fun ctx ->
     let args = `Assoc [("query", `String "test")] in
@@ -348,6 +402,10 @@ let () =
     ]);
     ("library_search", [
       Alcotest.test_case "empty query" `Quick test_search_empty_query;
+      Alcotest.test_case
+        "schema lets runtime reject empty query"
+        `Quick
+        test_search_schema_allows_runtime_query_rejection;
       Alcotest.test_case "with query" `Quick test_search_with_query;
     ]);
     ("library_promote", [


### PR DESCRIPTION
## Summary

- Make `masc_library_search` and `keeper_library_search` schema validation recoverable when `query` is missing, while preserving runtime workflow rejection for empty queries.
- Give keeper library descriptors explicit search/read schemas instead of passthrough objects.
- Classify OAS tool retry exhaustion provider errors as `sdk_tool_retry_exhausted` so operator disposition no longer falls through to the generic provider catch-all.

## Root Cause

A keeper turn called `masc_library_search` with `{}`. The MCP/OAS schema advertised `query` as required, so validation rejected the call before the library handler could return its normal workflow error. That exhausted the tool retry budget and then surfaced as an unmapped provider runtime disposition.

## Validation

- `scripts/dune-local.sh build test/test_tool_library_coverage.exe test/test_keeper_tool_descriptor_registry_integrity.exe test/test_blocker_class_exhaustiveness.exe test/test_tool_shard_coverage.exe`
- `_build/default/test/test_tool_library_coverage.exe`
- `_build/default/test/test_keeper_tool_descriptor_registry_integrity.exe`
- `_build/default/test/test_blocker_class_exhaustiveness.exe`
- `_build/default/test/test_tool_shard_coverage.exe`
- `ocamlformat --check lib/tool_library.ml lib/tool_surface/tool_shard_types_schemas_library.ml lib/keeper/keeper_tool_descriptor.ml lib/keeper/keeper_status_bridge_blocker.ml test/test_tool_library_coverage.ml test/test_keeper_tool_descriptor_registry_integrity.ml test/test_blocker_class_exhaustiveness.ml`