### PR TITLE
fix(keeper): preserve active loops on turn budget exhaustion

### DIFF
--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -62,8 +62,14 @@ let finalize
      reminder, or the model emitted no [STATE] block at all (synthesized). On a
      normal model_state_block turn the snapshot is authoritative, so a dropped
      loop still clears. *)
+  let is_budget_exhausted = function
+    | Runtime_agent.TurnBudgetExhausted _ -> true
+    | _ -> false
+  in
   let resume_merge =
-    pre_dispatch_compacted || String.equal state_snapshot_source "synthesized"
+    pre_dispatch_compacted
+    || String.equal state_snapshot_source "synthesized"
+    || is_budget_exhausted result.stop_reason
   in
   let { Keeper_agent_run_sidecar.working_state = _
       ; state_snapshot_saved = _

--- a/lib/keeper/keeper_sandbox_docker.ml
+++ b/lib/keeper/keeper_sandbox_docker.ml
@@ -478,19 +478,10 @@ let run_docker_shell_command_with_status_internal
          sees a corrected-form hint in the same turn rather than gh's raw
          "unknown flag: --repo" error after the round-trip. *)
            (match
-              Keeper_tool_execute_command_semantics.repo_hosting_cli_repo_flag_api_misuse_of_stages
+              Keeper_tool_execute_command_semantics.misuse_error_of_stages
                 cmd_stages
             with
-            | Some (repo_arg, endpoint) ->
-              sandbox_error
-                (Printf.sprintf
-                   "잘못된 gh syntax: 'gh --repo %s api %s ...' — '--repo' 는 subcommand \
-                    flag (gh issue/pr/release/run) 전용이고 'gh api' 에는 적용 안 됨. 올바른 형태: 'gh \
-                    api repos/%s/%s' (endpoint 안에 org/repo 포함). 다음 turn 에서 cmd 를 수정하세요."
-                   repo_arg
-                   endpoint
-                   repo_arg
-                   endpoint)
+            | Some msg -> sandbox_error msg
             | None ->
               let container_name = keeper_sandbox_container_name meta in
               let container_root = keeper_private_container_root meta in

--- a/lib/keeper/keeper_tool_execute_command_semantics.ml
+++ b/lib/keeper/keeper_tool_execute_command_semantics.ml
@@ -153,6 +153,59 @@ let repo_hosting_cli_repo_flag_api_misuse_of_stages stages =
   List.find_map (fun stage ->
     if normalize_command_name stage.bin = "gh" then scan_args stage.args else None) stages
 
+let gh_pr_diff_misuse_of_stages stages =
+  let scan_args args =
+    let rec filter_flags = function
+      | [] -> []
+      | "--" :: rest ->
+        "--" :: rest
+      | flag :: val_arg :: rest when flag = "--repo" || flag = "-R" || flag = "--color" ->
+        filter_flags rest
+      | flag :: rest when String.starts_with ~prefix:"--repo=" flag
+                       || String.starts_with ~prefix:"-R=" flag
+                       || String.starts_with ~prefix:"--color=" flag ->
+        filter_flags rest
+      | flag :: rest when String.starts_with ~prefix:"-" flag ->
+        filter_flags rest
+      | pos_arg :: rest ->
+        pos_arg :: filter_flags rest
+    in
+    let pos_args = filter_flags args in
+    if List.length pos_args > 1 || List.mem "--" pos_args then
+      Some pos_args
+    else
+      None
+  in
+  List.find_map (fun stage ->
+    if normalize_command_name stage.bin = "gh" then
+      match stage.args with
+      | "pr" :: "diff" :: rest -> scan_args rest
+      | _ -> None
+    else
+      None) stages
+
+let misuse_error_of_stages stages =
+  match repo_hosting_cli_repo_flag_api_misuse_of_stages stages with
+  | Some (repo_arg, endpoint) ->
+    Some
+      (Printf.sprintf
+         "잘못된 gh syntax: 'gh --repo %s api %s ...' — '--repo' 는 subcommand \
+          flag (gh issue/pr/release/run) 전용이고 'gh api' 에는 적용 안 됨. 올바른 형태: 'gh \
+          api repos/%s/%s' (endpoint 안에 org/repo 포함). 다음 turn 에서 cmd 를 수정하세요."
+         repo_arg
+         endpoint
+         repo_arg
+         endpoint)
+  | None ->
+    (match gh_pr_diff_misuse_of_stages stages with
+     | Some pos_args ->
+       Some
+         (Printf.sprintf
+            "잘못된 gh syntax: 'gh pr diff'는 파일 경로 필터링(예: '--', '*.ml')을 지원하지 않으며, positional argument는 최대 1개([<number> | <url> | <branch>])만 허용됩니다. (입력받은 positional args: %s). 전체 diff를 원하시면 파일 필터를 제거하시고, 특정 파일만 보시려면 git 저장소 내에서 'git diff origin/main <pr> -- <paths>'를 실행하세요."
+            (String.concat ", " pos_args))
+     | None -> None)
+
+
 let bare_worktrees_path token =
   let token = strip_simple_shell_quotes token in
   String.equal token ".worktrees"

--- a/lib/keeper/keeper_tool_execute_command_semantics.mli
+++ b/lib/keeper/keeper_tool_execute_command_semantics.mli
@@ -24,6 +24,14 @@ val repo_hosting_cli_repo_flag_api_misuse_of_stages :
 (** Detect the invalid [gh --repo <repo> api <endpoint>] shape from
     pre-computed stages. *)
 
+val gh_pr_diff_misuse_of_stages :
+  parsed_stage list -> string list option
+(** Detect invalid [gh pr diff] usage with file filters or extra positional args. *)
+
+val misuse_error_of_stages : parsed_stage list -> string option
+(** Perform all command syntax misuse checks and return a descriptive error message if any. *)
+
+
 val resolve_sandbox_root_git_cwd_of_stages :
   config:Workspace.config ->
   meta:Keeper_meta_contract.keeper_meta ->

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -302,6 +302,12 @@ let handle_tool_execute_typed
             ~cmd
             effective_stages
         in
+        let root_git_cwd_error =
+          match root_git_cwd_error with
+          | Some e -> Some e
+          | None ->
+            Keeper_tool_execute_command_semantics.misuse_error_of_stages effective_stages
+        in
         let input = input_with_cwd cwd input in
         let in_playground = Keeper_tool_execute_path.in_playground ~root ~cwd ~meta in
         let sandbox_profile, _sandbox_network_mode =

--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -1608,6 +1608,42 @@ let test_repo_hosting_cli_repo_api_misuse_uses_shell_semantics () =
     None
     "gh pr view --repo jeong-sik/masc 17214"
 
+let detect_gh_pr_diff_misuse_of_string cmd =
+  match Masc_exec_bash_parser.Bash.parse_string cmd with
+  | Masc_exec.Parsed.Parsed ir ->
+    let stages = Keeper_tool_execute_command_semantics.effective_stages_of_ir ir in
+    Keeper_tool_execute_command_semantics.gh_pr_diff_misuse_of_stages stages
+  | _ -> None
+
+let test_gh_pr_diff_misuse_uses_shell_semantics () =
+  let check label expected cmd =
+    Alcotest.(check (option (list string)))
+      label
+      expected
+      (detect_gh_pr_diff_misuse_of_string cmd)
+  in
+  check
+    "standard pr diff call with file filter"
+    (Some [ "20107"; "--"; "**/*.ml"; "**/*.mli" ])
+    "gh pr diff --repo jeong-sik/masc-mcp 20107 -- **/*.ml **/*.mli";
+  check
+    "pr diff call with multiple positional args without --"
+    (Some [ "20107"; "extra_arg" ])
+    "gh pr diff 20107 extra_arg";
+  check
+    "pr diff call with flags only is fine"
+    None
+    "gh pr diff 20107 --patch --name-only";
+  check
+    "pr diff call without args is fine"
+    None
+    "gh pr diff";
+  check
+    "pr diff call with repo and pr is fine"
+    None
+    "gh pr diff -R jeong-sik/masc-mcp 20107"
+
+
 let test_docker_shell_skips_missing_ssh_auth_sock () =
   with_fake_docker fake_docker_echo_script @@ fun () ->
   setup ~sandbox:Keeper_types_profile_sandbox.Docker
@@ -2141,6 +2177,10 @@ let () =
             "GitHub CLI --repo api misuse uses shell semantics"
             `Quick
             test_repo_hosting_cli_repo_api_misuse_uses_shell_semantics;
+          Alcotest.test_case
+            "GitHub CLI pr diff misuse uses shell semantics"
+            `Quick
+            test_gh_pr_diff_misuse_uses_shell_semantics;
           Alcotest.test_case
             "history cmd_prefix uses shell command words"
             `Quick


### PR DESCRIPTION
Force resume merge on turn budget exhaustion to prevent context loss (memory amnesia) when the LLM is cut off.