### PR TITLE
refactor(keeper): drop economy budget prompt hints

### DIFF
--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -621,18 +621,6 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
     (Printf.sprintf "### Context\n- Utilization: %.0f%%\n- Idle: %ds\n"
        (observation.context_ratio *. 100.0)
        observation.idle_seconds);
-  (match observation.last_turn_budget with
-   | Some (used, total) when used > 0 ->
-     Buffer.add_string ubuf
-       (Printf.sprintf "- Previous turn budget: %d/%d used\n" used total)
-   | _ -> ());
-  (match observation.economic_pressure with
-   | Economy.Normal -> ()
-   | Frugal ->
-       Buffer.add_string ubuf "- Economy: Frugal (reduce token usage)\n"
-   | Hustle ->
-        Buffer.add_string ubuf
-          "- Economy: Hustle (minimize actions, conserve budget)\n");
   (* 4. Autonomous trigger — lower churn than reactive inboxes *)
   let turn_decision =
     Keeper_world_observation.keeper_cycle_decision ~meta observation

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -35,7 +35,6 @@ type world_observation =
   ; active_goals : string list
   ; continuity_summary : string
   ; context_ratio : float
-  ; economic_pressure : Economy.pressure_mode
   ; unclaimed_task_count : int
   ; claimable_task_count : int
   ; provider_capacity_blocked_task_count : int
@@ -43,7 +42,6 @@ type world_observation =
   ; pending_verification_count : int
   ; backlog_updated_since_last_scheduled_autonomous : bool
   ; active_agent_count : int
-  ; last_turn_budget : (int * int) option
   }
 
 type keeper_cycle_channel =
@@ -450,9 +448,6 @@ let observe
   let idle_seconds = compute_idle_seconds ~meta in
   let context_ratio = read_context_ratio ~config ~meta in
   let continuity_summary = read_continuity_summary ~config ~meta in
-  let economic_pressure =
-    Economy.economic_pressure ~base_path:config.base_path ~agent_name:meta.name
-  in
   let pending_board_events =
     match pending_board_events with
     | Some events -> events
@@ -470,7 +465,6 @@ let observe
   ; active_goals = meta.active_goal_ids
   ; continuity_summary
   ; context_ratio
-  ; economic_pressure
   ; unclaimed_task_count
   ; claimable_task_count
   ; provider_capacity_blocked_task_count
@@ -478,7 +472,6 @@ let observe
   ; pending_verification_count
   ; backlog_updated_since_last_scheduled_autonomous
   ; active_agent_count
-  ; last_turn_budget = None
   }
 ;;
 
@@ -504,8 +497,6 @@ let observe_direct_keeper_msg ~(config : Workspace.config) ~(meta : keeper_meta)
   ; active_goals = meta.active_goal_ids
   ; continuity_summary = read_continuity_summary ~config ~meta
   ; context_ratio = read_context_ratio ~config ~meta
-  ; economic_pressure =
-      Economy.economic_pressure ~base_path:config.base_path ~agent_name:meta.name
   ; unclaimed_task_count
   ; claimable_task_count
   ; provider_capacity_blocked_task_count
@@ -513,7 +504,6 @@ let observe_direct_keeper_msg ~(config : Workspace.config) ~(meta : keeper_meta)
   ; pending_verification_count
   ; backlog_updated_since_last_scheduled_autonomous
   ; active_agent_count = count_active_agents ~config
-  ; last_turn_budget = None
   }
 ;;
 

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -57,9 +57,6 @@ type world_observation = {
   context_ratio : float;
   (** Current context window utilization [0.0, 1.0]. *)
 
-  economic_pressure : Economy.pressure_mode;
-  (** Agent economy mode: Normal, Frugal, or Hustle. *)
-
   unclaimed_task_count : int;
   (** Number of unclaimed tasks in the workspace backlog. *)
 
@@ -84,9 +81,6 @@ type world_observation = {
 
   active_agent_count : int;
   (** Number of agents currently active in the workspace. *)
-
-  last_turn_budget : (int * int) option;
-  (** Previous generation's turn usage as [(used, total)], if available. *)
 }
 
 type keeper_cycle_channel =

--- a/test/test_keeper_unified_verification_surface.ml
+++ b/test/test_keeper_unified_verification_surface.ml
@@ -2,7 +2,6 @@ open Alcotest
 
 module WO = Masc.Keeper_world_observation
 module UM = Masc.Keeper_unified_metrics
-module AE = Economy
 
 let base_observation : WO.world_observation =
   {
@@ -14,7 +13,6 @@ let base_observation : WO.world_observation =
     active_goals = [];
     continuity_summary = "";
     context_ratio = 0.0;
-    economic_pressure = AE.Normal;
     unclaimed_task_count = 0;
     claimable_task_count = 0;
     provider_capacity_blocked_task_count = 0;
@@ -22,7 +20,6 @@ let base_observation : WO.world_observation =
     pending_verification_count = 0;
     backlog_updated_since_last_scheduled_autonomous = false;
     active_agent_count = 0;
-    last_turn_budget = None;
   }
 
 let sample_board_event : WO.pending_board_event =


### PR DESCRIPTION
## Summary
- remove Keeper world-observation fields that only fed budget/economy prompt hints
- stop injecting previous-turn budget and economy pressure instructions into the unified prompt
- update the unified verification-surface fixture for the narrower observation record

## Verification
- PASS: ocamlformat --check lib/keeper/keeper_world_observation.mli lib/keeper/keeper_world_observation.ml lib/keeper/keeper_unified_prompt.ml test/test_keeper_unified_verification_surface.ml
- PASS: git diff --check
- PASS: rg -n 'last_turn_budget|Previous turn budget|reduce token usage|conserve budget' lib/keeper test docs -g '!_build/**' returned no hits
- BLOCKED: focused dune build is currently blocked by origin/main Dune wiring fallout from the keeper extraction; a separate local worktree fix-main-build-ci-20260605 is repairing that base build surface.