### PR TITLE
[codex] fix keeper sandbox Git cwd paths

### DIFF
--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -207,11 +207,35 @@ let deterministic_retry_fields_for_process_result
   | _ -> []
 ;;
 
+let sandbox_extra_uses_docker sandbox_extra_fields =
+  List.exists
+    (function
+      | "via", `String "docker" -> true
+      | _ -> false)
+    sandbox_extra_fields
+
+let typed_execute_response_cwd_json
+      ~turn_sandbox_factory
+      ~cwd
+      ~sandbox_extra_fields
+  =
+  if sandbox_extra_uses_docker sandbox_extra_fields then
+    match Keeper_sandbox_factory.resolve_opt turn_sandbox_factory ~cwd with
+    | Some runtime ->
+      let container_cwd =
+        Keeper_turn_sandbox_runtime.container_cwd_of_host runtime ~host_cwd:cwd
+      in
+      Keeper_cwd_response.docker ~host_cwd:cwd ~container_cwd
+      |> Keeper_cwd_response.to_yojson_response
+    | None -> `String cwd
+  else `String cwd
+
 module For_testing = struct
   let elapsed_duration_ms = elapsed_duration_ms
   let deterministic_retry_fields_for_process_result =
     deterministic_retry_fields_for_process_result
   let compute_command_descriptor = compute_command_descriptor
+  let typed_execute_response_cwd_json = typed_execute_response_cwd_json
 end
 
 (* Typed Execute input projections extracted to
@@ -343,11 +367,19 @@ let handle_tool_execute_typed
                 @ fields)
              message
          | Ok (dispatch_sandbox, sandbox_extra_fields) ->
+        let response_cwd_json =
+          typed_execute_response_cwd_json
+            ~turn_sandbox_factory
+            ~cwd
+            ~sandbox_extra_fields
+        in
+        let response_cwd_field = [ "cwd", response_cwd_json ] in
         match root_git_cwd_error with
         | Some e ->
           error_json
             ~fields:
-              ([ "typed", `Bool true; "cmd", `String cmd; "cwd", `String cwd ]
+              ([ "typed", `Bool true; "cmd", `String cmd ]
+               @ response_cwd_field
                @ execution_location_fields cwd)
             e
         | None ->
@@ -360,7 +392,8 @@ let handle_tool_execute_typed
         | Error e ->
           let alts = Keeper_tool_execute_typed_input.validation_error_alternatives e in
           let fields =
-            [ "typed", `Bool true; "cmd", `String cmd; "cwd", `String cwd ]
+            [ "typed", `Bool true; "cmd", `String cmd ]
+            @ response_cwd_field
             @ execution_location_fields cwd
             @
             (match alts with
@@ -382,7 +415,8 @@ let handle_tool_execute_typed
           |> Exec_policy.truncate_for_log
         in
         let typed_error_fields =
-          [ "typed", `Bool true; "cmd", `String cmd_for_log; "cwd", `String cwd ]
+          [ "typed", `Bool true; "cmd", `String cmd_for_log ]
+          @ response_cwd_field
           @ execution_location_fields cwd
         in
         let blocked_result ?deterministic_reason ~error ~reason ~alternatives () =
@@ -415,10 +449,10 @@ let handle_tool_execute_typed
                ~extra:
                  (deterministic_retry_fields
                   @ [ "cmd", `String cmd_for_log
-                    ; "cwd", `String cwd
                     ; "typed", `Bool true
                     ; "execution_time_ms", `Int 0
                     ]
+                  @ response_cwd_field
                   @ execution_location_fields cwd)
                ())
         in
@@ -560,11 +594,11 @@ let handle_tool_execute_typed
                    (deterministic_retry_fields
                     @ failure_error_fields
                     @ sandbox_extra_fields
-                    @ [ "cwd", `String cwd
-                      ; "typed", `Bool true
+                    @ [ "typed", `Bool true
                       ; "execution_time_ms", `Int elapsed_ms
                       ; "timeout_sec", `Float timeout_sec
                       ]
+                    @ response_cwd_field
                     @ descriptor_fields
                     @ execution_location_fields cwd)
                  ~status:result.status

--- a/lib/keeper/keeper_tool_execute_runtime.mli
+++ b/lib/keeper/keeper_tool_execute_runtime.mli
@@ -19,4 +19,9 @@ module For_testing : sig
     status:Unix.process_status ->
     (string * Yojson.Safe.t) list
   val compute_command_descriptor : Masc_exec.Shell_ir.t -> Ide_event_types.command_descriptor
+  val typed_execute_response_cwd_json :
+    turn_sandbox_factory:Keeper_sandbox_factory.t option ->
+    cwd:string ->
+    sandbox_extra_fields:(string * Yojson.Safe.t) list ->
+    Yojson.Safe.t
 end

--- a/lib/playground_repo_readiness.ml
+++ b/lib/playground_repo_readiness.ml
@@ -435,6 +435,85 @@ let worktree_base_ref ~repo_path =
   in
   first_existing_ref ~repo_path candidates
 
+let is_standard_worktree_path ~repo_path ~task_name ~worktree_path =
+  let expected_worktree_path =
+    Filename.concat (Filename.concat repo_path ".worktrees") task_name
+  in
+  same_path worktree_path expected_worktree_path
+
+let relative_gitdir_of_pointer ~repo_path pointer =
+  let prefix = "gitdir:" in
+  if not (String.starts_with ~prefix pointer) then
+    Error "worktree .git file is not a gitdir pointer"
+  else
+    let gitdir =
+      String.sub
+        pointer
+        (String.length prefix)
+        (String.length pointer - String.length prefix)
+      |> String.trim
+    in
+    if gitdir = "" then Error "worktree .git file has an empty gitdir pointer"
+    else if Filename.is_relative gitdir then Ok None
+    else
+      let gitdir = normalize_path gitdir in
+      let worktrees_dir =
+        Filename.concat (Filename.concat repo_path ".git") "worktrees"
+        |> normalize_path
+      in
+      if String.starts_with ~prefix:(worktrees_dir ^ "/") gitdir then
+        let suffix =
+          String.sub
+            gitdir
+            (String.length worktrees_dir + 1)
+            (String.length gitdir - String.length worktrees_dir - 1)
+        in
+        Ok (Some (Printf.sprintf "../../.git/worktrees/%s" suffix))
+      else
+        Error
+          (Printf.sprintf
+             "worktree gitdir %s is not under %s"
+             gitdir worktrees_dir)
+
+let read_file_trim path =
+  let ic = open_in path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () ->
+       let len = in_channel_length ic in
+       really_input_string ic len |> String.trim)
+
+let write_file path contents =
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc contents)
+
+let normalize_worktree_gitdir_file ~repo_path ~task_name ~worktree_path =
+  if not (is_standard_worktree_path ~repo_path ~task_name ~worktree_path) then
+    Ok ()
+  else
+    let git_file = Filename.concat worktree_path ".git" in
+    if not (Sys.file_exists git_file) then
+      Error (Printf.sprintf "worktree %s has no .git file" worktree_path)
+    else if Sys.is_directory git_file then Ok ()
+    else (
+      try
+        let current = read_file_trim git_file in
+        match relative_gitdir_of_pointer ~repo_path current with
+        | Error msg ->
+          Error (Printf.sprintf "worktree %s %s" worktree_path msg)
+        | Ok None -> Ok ()
+        | Ok (Some relative_gitdir) ->
+          write_file git_file ("gitdir: " ^ relative_gitdir ^ "\n");
+          Ok ()
+      with
+      | Sys_error msg ->
+        Error
+          (Printf.sprintf
+             "failed to normalize worktree gitdir for %s: %s"
+             worktree_path msg))
+
 (** [ensure_worktree_ready ~config ~meta ~repo_name ~task_name ~worktree_path ()]
     ensures a git worktree exists at [worktree_path] inside the sandbox clone for
     [repo_name].  If the worktree is missing, first ensures the parent repo is a
@@ -443,11 +522,13 @@ let worktree_base_ref ~repo_path =
     not block creating a separate task worktree.  Returns [Ok ()] when the
     worktree is a valid git checkout, or [Error msg] if creation failed.
 
-    Root fix for the docker sandbox mount issue: when the keeper cwd targets a
-    worktree path that doesn't exist in the sandbox clone (e.g. because the
-    worktree was created on the host but the docker container's clone is fresh),
-    this function recreates the worktree instead of failing with
-    [sandbox_repo_not_ready]. *)
+    Root fixes for the Docker sandbox Git/CWD boundary:
+    - when the keeper cwd targets a worktree path that doesn't exist in the
+      sandbox clone, recreate it instead of failing with
+      [sandbox_repo_not_ready];
+    - when the worktree exists, normalize its [.git] gitdir pointer to a
+      relative path so Git can resolve the metadata from both the host and the
+      container mount. *)
 let ensure_worktree_ready
       ~(config : Workspace.config)
       ~(meta : keeper_meta)
@@ -464,7 +545,9 @@ let ensure_worktree_ready
        Skip parent repo validation — the parent may be "dirty" from worktree
        metadata (.git/worktrees/), which is normal and expected. *)
     match git_toplevel worktree_path with
-    | Some top when same_path worktree_path top -> Ok ()
+    | Some top when same_path worktree_path top ->
+      let repo_path = clone_path ~config ~meta ~repo_name in
+      normalize_worktree_gitdir_file ~repo_path ~task_name ~worktree_path
     | Some top ->
       Error
         (Printf.sprintf
@@ -491,17 +574,22 @@ let ensure_worktree_ready
               [ "worktree"; "add"; "--detach"; worktree_path; base_ref ]
           in
           if add_result.ok then (
-            (* Create a task branch in the new worktree *)
-            let branch_name = Printf.sprintf "task/%s" task_name in
-            let checkout =
-              run_git ~timeout_sec:read_only_probe_timeout_sec
-                ~clone_path:worktree_path
-                [ "checkout"; "-b"; branch_name ]
-            in
-            if checkout.ok then Ok ()
-            else
-              (* worktree created but branch checkout failed — still usable *)
-              Ok ())
+            match
+              normalize_worktree_gitdir_file ~repo_path ~task_name ~worktree_path
+            with
+            | Error msg -> Error msg
+            | Ok () ->
+              (* Create a task branch in the new worktree *)
+              let branch_name = Printf.sprintf "task/%s" task_name in
+              let checkout =
+                run_git ~timeout_sec:read_only_probe_timeout_sec
+                  ~clone_path:worktree_path
+                  [ "checkout"; "-b"; branch_name ]
+              in
+              if checkout.ok then Ok ()
+              else
+                (* worktree created but branch checkout failed — still usable *)
+                Ok ())
           else
             Error
               (Printf.sprintf
@@ -577,6 +665,17 @@ let provision_worktrees_for_task
                          [ "worktree"; "add"; "--detach"; worktree_path; base_ref ]
                      in
                      if add_result.ok then (
+                       (match
+                          normalize_worktree_gitdir_file
+                            ~repo_path
+                            ~task_name:task_id
+                            ~worktree_path
+                        with
+                        | Ok () -> ()
+                        | Error msg ->
+                          Log.Workspace.debug
+                            "provision_worktrees: gitdir normalization failed for %s/%s: %s"
+                            repo_name task_id msg);
                        let branch_name =
                          Printf.sprintf "task/%s" task_id
                        in

--- a/lib/playground_repo_readiness.mli
+++ b/lib/playground_repo_readiness.mli
@@ -89,7 +89,9 @@ val ensure_ready :
     If the worktree is missing, first ensures the parent repo is a valid git
     clone (reclone if needed), then creates the worktree from the fetched
     default origin branch. Parent clone dirtiness is preserved and does not block
-    creating a separate task worktree. Returns [Ok ()] when the worktree is a
+    creating a separate task worktree. Existing and newly-created worktrees have
+    their [.git] gitdir pointer normalized to a relative path so Docker-mounted
+    Git can resolve the worktree metadata. Returns [Ok ()] when the worktree is a
     valid git checkout, or [Error msg] if creation failed. *)
 val ensure_worktree_ready :
   config:Workspace.config ->

--- a/test/test_keeper_sandbox_docker_cwd_response.ml
+++ b/test/test_keeper_sandbox_docker_cwd_response.ml
@@ -92,6 +92,44 @@ let test_container_path_translation_under_sandbox () =
         host_cwd
         (Keeper_cwd_response.operator_host cwd_response))
 
+let test_typed_execute_response_cwd_uses_container_path () =
+  let base = temp_dir "typed_exec_docker_cwd_resp_" in
+  let config = Workspace.default_config base in
+  let meta = make_docker_meta ~name:"typed-exec-cwd-pin" in
+  let factory = Keeper_sandbox_factory.create ~config ~meta ~turn_id:42 () in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_sandbox_factory.cleanup factory;
+      cleanup_dir base)
+    (fun () ->
+      let host_root = Keeper_sandbox.host_root_abs_of_meta ~config meta in
+      let host_cwd =
+        Filename.concat host_root "repos/masc/.worktrees/task-cwd-pin"
+      in
+      let response_cwd =
+        Keeper_tool_execute_runtime.For_testing.typed_execute_response_cwd_json
+          ~turn_sandbox_factory:(Some factory)
+          ~cwd:host_cwd
+          ~sandbox_extra_fields:
+            [
+              "requested_sandbox", `String "docker";
+              "via", `String "docker";
+              "sandbox_profile", `String "docker";
+            ]
+      in
+      let json_str = Yojson.Safe.to_string response_cwd in
+      check bool "typed Execute cwd JSON does NOT contain host base" false
+        (Astring.String.is_infix ~affix:base json_str);
+      check bool "typed Execute cwd JSON does NOT contain host cwd" false
+        (Astring.String.is_infix ~affix:host_cwd json_str);
+      match response_cwd with
+      | `String cwd ->
+        check bool
+          "typed Execute cwd is rooted at /home/keeper/playground"
+          true
+          (Astring.String.is_prefix ~affix:"/home/keeper/playground" cwd)
+      | _ -> fail "typed Execute cwd response should serialize as a string")
+
 (* Source-level pin: assert that no [("cwd", `String <ident>)]
    literal remains in keeper_sandbox_docker.ml. The four sites
    from #11080's sibling leak class must be wired through
@@ -140,6 +178,9 @@ let () =
           test_case
             "host_cwd → container_cwd → JSON does not leak host"
             `Quick test_container_path_translation_under_sandbox
+        ; test_case
+            "typed Execute Docker cwd response does not leak host"
+            `Quick test_typed_execute_response_cwd_uses_container_path
         ] )
     ; ( "source-pin"
       , [

--- a/test/test_playground_repo_readiness.ml
+++ b/test/test_playground_repo_readiness.ml
@@ -44,6 +44,20 @@ let mkdir_p path =
   in
   ensure path
 
+let read_file_trim path =
+  let ic = open_in path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () ->
+       let len = in_channel_length ic in
+       really_input_string ic len |> String.trim)
+
+let write_file path contents =
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc contents)
+
 let json_bool key json =
   Yojson.Safe.Util.(json |> member key |> to_bool)
 
@@ -441,6 +455,58 @@ let test_ensure_worktree_ready_idempotent () =
   | Ok () -> ()
   | Error msg -> fail ("second call failed: " ^ msg)
 
+let test_ensure_worktree_ready_normalizes_gitdir_pointer () =
+  let base_path = temp_dir "masc-worktree-ready-gitdir" in
+  let remote = Filename.concat base_path ".remote-masc.git" in
+  git_ok ~cwd:base_path [ "init"; "--bare"; "-q"; "--initial-branch=main"; remote ];
+  let config = Masc.Workspace.default_config base_path in
+  let meta = make_meta "keeper-one" in
+  let clone_path =
+    Masc.Playground_repo_readiness.clone_path ~config ~meta ~repo_name:"masc"
+  in
+  mkdir_p (Filename.dirname clone_path);
+  git_ok ~cwd:base_path [ "clone"; "-q"; remote; clone_path ];
+  git_ok ~cwd:clone_path [ "config"; "user.email"; "test@example.com" ];
+  git_ok ~cwd:clone_path [ "config"; "user.name"; "Test" ];
+  let readme = Filename.concat clone_path "README.md" in
+  write_file readme "# test\n";
+  git_ok ~cwd:clone_path [ "add"; "README.md" ];
+  git_ok ~cwd:clone_path [ "commit"; "-q"; "-m"; "init" ];
+  git_ok ~cwd:clone_path [ "push"; "-q"; "origin"; "main" ];
+  let task_name = "task-relative-gitdir-test" in
+  let worktree_path = Filename.concat clone_path (".worktrees/" ^ task_name) in
+  let r1 =
+    Masc.Playground_repo_readiness.ensure_worktree_ready
+      ~config ~meta ~repo_name:"masc" ~task_name ~worktree_path ()
+  in
+  (match r1 with
+   | Ok () -> ()
+   | Error msg -> fail ("first call failed: " ^ msg));
+  let git_file = Filename.concat worktree_path ".git" in
+  let absolute_gitdir =
+    Filename.concat
+      (Filename.concat (Filename.concat clone_path ".git") "worktrees")
+      task_name
+  in
+  write_file git_file ("gitdir: " ^ absolute_gitdir ^ "\n");
+  let r2 =
+    Masc.Playground_repo_readiness.ensure_worktree_ready
+      ~config ~meta ~repo_name:"masc" ~task_name ~worktree_path ()
+  in
+  (match r2 with
+   | Ok () -> ()
+   | Error msg -> fail ("second call failed: " ^ msg));
+  check string "worktree gitdir is container-safe relative"
+    ("gitdir: ../../.git/worktrees/" ^ task_name)
+    (read_file_trim git_file);
+  let status =
+    Masc.Playground_repo_readiness.run_git
+      ~timeout_sec:Masc.Playground_repo_readiness.read_only_probe_timeout_sec
+      ~clone_path:worktree_path
+      [ "status"; "--short" ]
+  in
+  check bool "relative gitdir remains host-git usable" true status.ok
+
 let test_ensure_worktree_ready_rejects_nested_plain_directory () =
   let base_path = temp_dir "masc-worktree-ready-nested" in
   let remote = Filename.concat base_path ".remote-masc.git" in
@@ -657,6 +723,8 @@ let () =
           test_ensure_worktree_ready_creates_worktree;
         test_case "idempotent" `Quick
           test_ensure_worktree_ready_idempotent;
+        test_case "normalizes worktree gitdir pointer" `Quick
+          test_ensure_worktree_ready_normalizes_gitdir_pointer;
         test_case "rejects nested plain directory" `Quick
           test_ensure_worktree_ready_rejects_nested_plain_directory;
         test_case "creates worktree from dirty parent clone" `Quick


### PR DESCRIPTION
## Summary

- Normalize sandbox task worktree `.git` gitdir pointers to relative paths so Git resolves metadata from both the host checkout and the Docker container mount.
- Return Docker typed Execute response `cwd` values through `Keeper_cwd_response`, so keepers see the container-visible cwd instead of `/Users/dancer/me/.masc/...` host paths.
- Add regression coverage for both the worktree gitdir normalization and typed Execute Docker cwd serialization.

## Root Cause

Recent keeper logs showed Docker-routed commands succeeding for plain file reads but failing for Git commands in sandbox worktrees. The worktree `.git` files pointed at host-absolute metadata paths such as `/Users/dancer/me/.masc/.../.git/worktrees/<task>`, which Docker Git cannot resolve. Typed Execute also returned a host `cwd` even when `via=docker`, which encouraged later turns to reuse paths that are invalid inside the container.

## Validation

- `git diff --check`
- `ocamlc -stop-after parsing lib/playground_repo_readiness.ml lib/playground_repo_readiness.mli lib/keeper/keeper_tool_execute_runtime.ml lib/keeper/keeper_tool_execute_runtime.mli test/test_playground_repo_readiness.ml test/test_keeper_sandbox_docker_cwd_response.ml`
- `scripts/lint-spawn-bounded.sh`

Blocked by current `origin/main` Dune module drift:

- `scripts/dune-local.sh build test/test_playground_repo_readiness.exe test/test_keeper_sandbox_docker_cwd_response.exe` fails before these tests compile because `test/dune` references missing modules `Test_token_count` and `Test_provider_error_class`.
- `scripts/dune-local.sh build lib/` also fails on unrelated missing modules including `Silent_dashboard_actor_outcome`, `Lockfree_atomic`, `Pool_metrics`, `Dated_jsonl`, `Keeper_metrics`, `Tool_args`, `Json_field`, and `Tool_catalog`.