### PR TITLE
chore(tool): purge inline dispatch runtime facade

### DIFF
--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -132,16 +132,16 @@ interface SimpleRoute {
 // corresponding server emitter exists in lib/ are kept; dead keys were
 // removed after cross-referencing the OCaml sources under lib/.
 const SIMPLE_ROUTES: Record<string, SimpleRoute> = {
-  // Agent lifecycle — emitted by lib/tool_inline_dispatch_workspace.ml
+  // Agent lifecycle — emitted by lib/mcp_tool_runtime_workspace.ml
   'masc/agent_bound':  { target: 'execution' },
   'masc/agent_unbound':    { target: 'execution' },
-  // Broadcasts — emitted by lib/tool_inline_dispatch_comm.ml
+  // Broadcasts — emitted by lib/mcp_tool_runtime_comm.ml
   'masc/broadcast':     { target: 'execution' },
   // Keeper lifecycle (also triggers operator refresh via handler)
   keeper_handoff:       { target: 'execution' },
   keeper_compaction:    { target: 'execution' },
   keeper_phase_changed: { target: 'execution' },
-  // Board content — emitted by lib/tool_inline_dispatch_extra.ml
+  // Board content — emitted by lib/mcp_tool_runtime_board.ml
   'masc/board_post':    { target: 'board' },
   board_comment:        { target: 'board' },
   'masc/board_delete':  { target: 'board' },

--- a/docs/audits/2026-05-11-workspace-inline-audit.md
+++ b/docs/audits/2026-05-11-workspace-inline-audit.md
@@ -96,7 +96,7 @@ PR-N2가 `Tool_scope.keeper_internal_list`에 추가할 5개 — `Config.surface
 
 ### naming / structure 별도 정리
 - `inline_*` prefix의 의미가 schema 디렉토리 구조에만 존재 (도구 이름엔 `masc_*`). 별도 refactor 필요 없음 — 단 `tool_schemas_inline_*.ml` 파일 분리 자체는 책임 묶음으로 정당화됨.
-- `workspace_*` / `inline_*` 파일 분리는 dispatch 모듈 (`tool_workspace.ml`, `tool_inline_dispatch.ml`)과 1:1 매핑되어 있어 유지.
+- `workspace_*` / `inline_*` 파일 분리는 dispatch 모듈 (`tool_workspace.ml`, `mcp_tool_runtime.ml`)과 1:1 매핑되어 있어 유지.
 
 ## 다음 단계
 

--- a/docs/design/keeper-continuity-diagnosis-rfc.md
+++ b/docs/design/keeper-continuity-diagnosis-rfc.md
@@ -132,7 +132,7 @@ Phase 1 결과에 따라 결정. 미리 설계하지 않는다.
 ### 수정 범위
 
 - `set_workspace`/`join` 시 해당 workspace에서 `cleanup_zombies` 1회 호출
-  - 구현 위치: `tool_inline_dispatch_workspace.ml:185` (set_workspace), `:226` (join)
+  - 구현 위치: `mcp_tool_runtime_workspace.ml:185` (set_workspace), `:226` (join)
   - **주의**: `set_workspace` 핸들러는 중간에 `state.Mcp_server.workspace_config`를 교체. `cleanup_zombies` 호출은 **새로 resolve된 config**로. 교체 전 `ctx.config`로 호출하면 이전 workspace에서 GC 실행.
 - multi-workspace gap 증명 필요: gap이 없으면 "set_workspace 시 1회 cleanup" 연결만으로 종결.
 

--- a/docs/rfc/RFC-0034-cap-all-callers.md
+++ b/docs/rfc/RFC-0034-cap-all-callers.md
@@ -18,7 +18,7 @@
 | `keeper/agent_tool_task_runtime.ml:336` (`keeper_task_create`) | ✅ 전달 (#13981) | cap 작동 |
 | `tool_task.ml:485` (`handle_add_task` for `masc_add_task`) | ❌ 미전달 | **cap 우회** |
 | `task_dispatch.ml:59` | ❌ 미전달 | cap 우회 |
-| `tool_inline_dispatch_workspace.ml:103` | ❌ 미전달 | cap 우회 |
+| `mcp_tool_runtime_workspace.ml:103` | ❌ 미전달 | cap 우회 |
 | `operator/operator_control.ml:235` | ❌ 미전달 | cap 우회 |
 
 board의 "8 tasks open in oas-bridge-stabilization"는 (2)~(5) 어느 경로로든 들어온 결과로 추정 — 가장 유력한 건 `masc_add_task` MCP tool.
@@ -89,7 +89,7 @@ Workspace.add_task config ?goal_id
   ~reject_if:(Workspace_task_capacity.rejection_for_add_task ?goal_id)
   ~title ~priority ~description
 
-(* lib/tool_inline_dispatch_workspace.ml:103 *)
+(* lib/mcp_tool_runtime_workspace.ml:103 *)
 Workspace_task.add_task active_config ?goal_id
   ~reject_if:(Workspace_task_capacity.rejection_for_add_task ?goal_id)
   ~title:task_title ~priority:3 ~description:""
@@ -110,7 +110,7 @@ caller 본문에 `goal_id`가 어떻게 전달되는지 확인 필요. 만약 ca
 
 - `masc_add_task`: 현재 `(false, "Error: ...")` 튜플 반환 → `Error: <message>` 형식 유지. 클라이언트 측 변경 불필요.
 - `task_dispatch`: 동일.
-- `tool_inline_dispatch_workspace`: 동일.
+- `mcp_tool_runtime_workspace`: 동일.
 - `operator_control`: 동일.
 
 ## 4. Migration
@@ -127,7 +127,7 @@ JSON 응답 형식 동일 — `error_to_json` 그대로. `keeper_task_create`의
 - 신규 테스트 4건 추가:
   - `test_masc_add_task_caps_per_goal` — masc_add_task가 4번째 같은 goal_id 거부
   - `test_task_dispatch_caps_per_goal` — task_dispatch path 거부
-  - `test_inline_dispatch_caps_per_goal` — inline dispatch path 거부
+  - `test_mcp_runtime_caps_per_goal` — MCP runtime path 거부
   - `test_operator_task_inject_caps_per_goal` — operator path 거부
 
 ## 5. TLA+ Spec 매핑

--- a/docs/rfc/RFC-0062-typed-tool-result-and-blocker-class.md
+++ b/docs/rfc/RFC-0062-typed-tool-result-and-blocker-class.md
@@ -104,7 +104,7 @@ This RFC chooses the structural fix: **closed sum types + exhaustive match**. Ne
 | **2** | 50+ `Tool_*.dispatch` signatures → `Tool_result.t option` (Big Bang) | #14482 | Merged |
 | **3** | `execute_tool_eio` / `dispatch_by_tag` return `Tool_result.t` directly; remove `tuple_of_tool_result` reverse adapter | #14486 | Merged |
 | **4c-1** | 9 core tool handlers (`tool_args`, `retired_file_tool`, `retired_file_write_tool`, `tool_control`, `tool_library`, `tool_plan`, `tool_run`, `tool_task`, retired repo-isolation handler) + keeper dispatch handlers migrated | #14528 | Merged |
-| **4c-2** | `wrap_result` removal in `tool_operator`, `tool_misc` + sub-modules, `tool_autoresearch`, `tool_agent_timeline`, `tool_inline_dispatch` | superseded by RFC-0189 PR-2 | Removed |
+| **4c-2** | `wrap_result` removal in `tool_operator`, `tool_misc` + sub-modules, `tool_autoresearch`, `tool_agent_timeline`, `mcp_tool_runtime` | superseded by RFC-0189 PR-2 | Removed |
 | **4d** | Standalone handlers (`progress`, `session`, `subscriptions`, former adversarial review, `tool_bridge`); delete remaining Tool_result compatibility adapters and `Workspace_types.tool_result` | superseded by RFC-0189 PR-2 | Removed |
 
 ## 6. Test Strategy

--- a/docs/rfc/RFC-0069-awareness-channel-split.md
+++ b/docs/rfc/RFC-0069-awareness-channel-split.md
@@ -101,7 +101,7 @@ let broadcast ?trace_context config ~from_agent ~content =
 | `workspace_lifecycle.rejoin` | `workspace_lifecycle.ml:108` | `👋 <agent> rebound the namespace` |
 | `workspace_lifecycle.join` | `workspace_lifecycle.ml:172` | `👋 <agent> bound the namespace` |
 | `workspace_lifecycle.leave` | `workspace_lifecycle.ml:237` | `👋 <agent> left the namespace` |
-| 사용자 채팅/멘션 | `tool_inline_dispatch_comm.ml:37` 경유 | 일반 broadcast (멘션 포함) |
+| 사용자 채팅/멘션 | `mcp_tool_runtime_comm.ml:37` 경유 | 일반 broadcast (멘션 포함) |
 
 확인된 사실: **`workspace_gc.ml:17` `heartbeat` 함수는 broadcast 채널에 publish하지 않는다.**
 heartbeat는 `agent_file`의 `last_seen`만 갱신한다. heartbeat가 채널 트래픽을 만드는

--- a/docs/rfc/RFC-0071-inventory.csv
+++ b/docs/rfc/RFC-0071-inventory.csv
@@ -840,10 +840,10 @@ lib/tool_workspace.ml,283,false,unclassified
 lib/tool_workspace.ml,797,None,unclassified
 lib/tool_workspace.ml,823,None,unclassified
 lib/tool_help_registry.ml,231,None,unclassified
-lib/tool_inline_dispatch_extra.ml,57,None,unclassified
-lib/tool_inline_dispatch_extra.ml,451,None,unclassified
-lib/tool_inline_dispatch.ml,235,None,unclassified
-lib/tool_inline_dispatch.ml,253,None,unclassified
+lib/mcp_tool_runtime_board.ml,57,None,unclassified
+lib/mcp_tool_runtime_board.ml,451,None,unclassified
+lib/mcp_tool_runtime.ml,235,None,unclassified
+lib/mcp_tool_runtime.ml,253,None,unclassified
 lib/tool_input_validation.ml,82,false,unclassified
 lib/tool_keeper.ml,861,None,unclassified
 lib/tool_keeper.ml,909,false,unclassified

--- a/docs/rfc/RFC-0084-keeper-tool-dispatch-unification.md
+++ b/docs/rfc/RFC-0084-keeper-tool-dispatch-unification.md
@@ -128,7 +128,7 @@ let dispatch_structured ~(token : Tool_token.t) ~args : Tool_result.result optio
 | Tuple slot | 현재 상태 |
 |---|---|
 | `Span` (OTel) | 0 emission. `lib/otel/otel_dispatch_hook.ml:103` 등록만 있고 span 시작/종료 없음. |
-| `Audit` | `Audit_log.record` caller 10+곳 분산 (`dashboard_tool_host_events`, `governance_anomaly`, `mcp_server_eio_call_tool`, `mcp_server_eio_execute`, `operator/operator_control`, `tool_inline_dispatch_comm` 등). dispatch path에서 SSOT 없음. |
+| `Audit` | `Audit_log.record` caller 10+곳 분산 (`dashboard_tool_host_events`, `governance_anomaly`, `mcp_server_eio_call_tool`, `mcp_server_eio_execute`, `operator/operator_control`, `mcp_tool_runtime_comm` 등). dispatch path에서 SSOT 없음. |
 | `Metric` | `tool_metrics.install` (`lib/tool_metrics.ml:127`)가 observer로 등록하지만 `dispatch:127-129`가 handler `None` 반환 시 observer 미호출 → metric silent skip. Tool-selection failure counters now live on the run-tools setup path. |
 | `Trace_id` | propagation 메커니즘 0. LLM turn ↔ tool call ↔ side-effect 연결 단절. |
 
@@ -169,7 +169,7 @@ keeper→tool 실행이 *macOS 운영자 workstation의 특정 디렉토리 layo
 | `lib/keeper/keeper_runtime_resilience.ml:24-43` | scheduling guard | runtime resilience check before autonomous fan-out |
 | `agent_tool_execute_command_parse.ml:217` | dispatch (gh family) | `[ "/bin/zsh"; "-lc"; ... ]` remaining gh command-parse site |
 | `lib/keeper/keeper_workspace_ops.ml:339,387,661,702,746` | dispatch (shell ops) | `"/bin/ls"`, `"/bin/cat"`, `"/bin/pwd"`, `"/usr/bin/head"`, `"/usr/bin/tail"`, `"/usr/bin/wc"` 6 sites |
-| `lib/tool_inline_dispatch_workspace.ml:185-187, 267-268`, `mcp_server_eio_execute.ml:191, 210, 253, 331, 570` | persistence (agent identity) | `Printf.sprintf "/tmp/.masc_agent[_mcp]_%s" sid` **7 sites**. `TERM_SESSION_ID` 없으면 `"default"` silent collision |
+| `lib/mcp_tool_runtime_workspace.ml:185-187, 267-268`, `mcp_server_eio_execute.ml:191, 210, 253, 331, 570` | persistence (agent identity) | `Printf.sprintf "/tmp/.masc_agent[_mcp]_%s" sid` **7 sites**. `TERM_SESSION_ID` 없으면 `"default"` silent collision |
 | `lib/retired_worker_shell_facade:85` | dispatch (Fleet worker) | hard-coded home workspace root — 사용자별 binding |
 | `lib/workspace/workspace_utils_backend_setup.ml:103`, `config_dir_resolver.ml:59`, `env_config_core.ml:353`, `cdal/adversarial_eval.ml:294, 301` | test-mode auto-detection | `String.starts_with ~prefix:"test_" executable` 5 sites — 보안 risk (binary rename으로 test mode silently 진입) |
 
@@ -187,7 +187,7 @@ OAS측 `Tool.disclosure_level` Hybrid + `Disclosure_resolver`는 `lib/pipeline/s
 |---|---|
 | **#2 String/substring classifier** | `keeper_internal_tools` 32-entry string list (`tool_catalog_surfaces.ml:28-96`) + `Tool_dispatch.registry : (string, handler) Hashtbl.t`. 두 repo 횡단 동일 anti-pattern. |
 | **#2 Prefix-gated** | `String.starts_with ~prefix:"masc_"` (`mcp_server_eio_tool_profile.ml:296`), `String.starts_with ~prefix:"test_"` 5 sites |
-| **Unknown → Permissive Default** | `Option.value ~default:"default" (Sys.getenv_opt "TERM_SESSION_ID")` (`tool_inline_dispatch_workspace.ml:186, 266`) → silent identity collision |
+| **Unknown → Permissive Default** | `Option.value ~default:"default" (Sys.getenv_opt "TERM_SESSION_ID")` (`mcp_tool_runtime_workspace.ml:186, 266`) → silent identity collision |
 | **#1 Scattered hardcoded default** | ~~`/tmp/.masc_agent[_mcp]_<sid>` 7 sites, `/bin/zsh` 5 sites, `.masc-ide` 4 sites~~ — *모두 closed*: `/tmp/.masc_agent` (§1.5 PR-D), `/bin/zsh` (§1.5 PR-B), `.masc-ide` (#15533). `lib/` 잔존 0건; test 에 migration guard 만 유지. |
 | **Telemetry-as-fix** | Counter without fix는 본 RFC가 자체 안 함 — 4-tuple emission은 typed Outcome이 *fix*된 결과. counter는 alarm이 아닌 invariant check. |
 
@@ -491,7 +491,7 @@ let () = QCheck.Test.check_exn @@ QCheck.Test.make
 - `lib/keeper/keeper_tag_dispatch.ml` — Entry 3 fallback
 - `Host_config.cred_root` — retired repo-auth temp root
 - `lib/keeper/agent_tool_execute_runtime.ml:745, 802` — `/bin/bash`
-- `lib/tool_inline_dispatch_workspace.ml:185-187, 267-268`, `mcp_server_eio_execute.ml:191-570` — `/tmp/.masc_agent[_mcp]_<sid>` 7 sites
+- `lib/mcp_tool_runtime_workspace.ml:185-187, 267-268`, `mcp_server_eio_execute.ml:191-570` — `/tmp/.masc_agent[_mcp]_<sid>` 7 sites
 - `lib/worker_oas.ml` (886 lines) — disclosure activation 대상
 
 ### 9.2 분석 보고서 (`~/me/.tmp/keeper-tool-cycle-audit/`)

--- a/docs/rfc/RFC-0148-typed-tool-error-variant.md
+++ b/docs/rfc/RFC-0148-typed-tool-error-variant.md
@@ -18,7 +18,7 @@ Both code phases shipped same-day as the RFC body:
 | Phase | PR | Scope | Merged |
 |-------|-----|------|--------|
 | PR-1 | #16948 | `lib/tool_error.{ml,mli}` 7-variant closed sum + `of_exn` mapping + 7 Alcotest cases | 2026-05-20 |
-| PR-2 | #16958 | 6 LLM-facing site codemod (`tool_library` 3 + `retired_file_write_tool` 2 + `tool_inline_dispatch_workspace` 1) + RFC §1.1 hallucination correction (audit-cited 8 sites → measured 6 sites with line-drift fixes) | 2026-05-20 |
+| PR-2 | #16958 | 6 LLM-facing site codemod (`tool_library` 3 + `retired_file_write_tool` 2 + `mcp_tool_runtime_workspace` 1) + RFC §1.1 hallucination correction (audit-cited 8 sites → measured 6 sites with line-drift fixes) | 2026-05-20 |
 
 The closed-sum post-condition described in §2 (compile-time exhaustive
 match across all LLM-facing failure surfaces) holds — `rg
@@ -85,7 +85,7 @@ LLM 이 호출하는 tool 들의 *실패 분류* 가 현재 `Failure msg` (catch
 | `lib/tool_library.ml` | 324 | `Tool_result.error ... (sprintf "Promote error: %s" ...)` | library promote 실패 |
 | `retired file-write tool module` | 452 | `Tool_result.error ... (Printf.sprintf "Write failed: %s" ...)` | write 분기 |
 | `retired file-write tool module` | 582 | `Tool_result.error ... (Printf.sprintf "Edit failed: %s" ...)` | edit 분기 |
-| `lib/tool_inline_dispatch_workspace.ml` | 95 | `let msg = Printexc.to_string exn in ... Error msg` → 후속 `Tool_result.error` | indirect surface — join 실패 |
+| `lib/mcp_tool_runtime_workspace.ml` | 95 | `let msg = Printexc.to_string exn in ... Error msg` → 후속 `Tool_result.error` | indirect surface — join 실패 |
 
 검증 grep:
 
@@ -97,7 +97,7 @@ rg 'Tool_result\.error.*Printexc\.to_string|let\s+\w+\s*=\s*Printexc\.to_string'
 
 다음 site 의 `Printexc.to_string exn` 은 *Log.warn/debug/error* 로만 흘러 LLM-facing 아님. 본 RFC 의 *비-목표*:
 
-- `lib/tool_inline_dispatch_workspace.ml:192,246` (`Log.Gc.debug/error`, `Log.Institution.warn`)
+- `lib/mcp_tool_runtime_workspace.ml:192,246` (`Log.Gc.debug/error`, `Log.Institution.warn`)
 - `lib/tool_workspace.ml:169,191,205,213,221` (모두 `Log.Workspace.warn`)
 - `lib/tool_agent.ml:230` (`Log.Agent.warn` 추정)
 - `lib/tool_assignment_telemetry.ml:342` (telemetry observation, LLM-facing 여부 별도 audit 필요 — 보수적으로 본 PR 제외)
@@ -204,7 +204,7 @@ LLM-side prompt 는 *kind* field 만으로 1차 분류 가능. *detail* 은 user
 | PR | Scope | LoC 추정 | Blocker |
 |----|-------|---------|---------|
 | **PR-1** | `Tool_error.t` 모듈 + 6 Alcotest | +250 / -0 | (본 RFC 머지) |
-| **PR-2** | **실측 6 site codemod** (`tool_library` × 3 + `retired_file_write_tool` × 2 + `tool_inline_dispatch_workspace` × 1) + backsliding lint. (원본 audit 의 "8 sites" 는 §1.3 hallucination — 실측 정정.) | +60 / -30 | PR-1 |
+| **PR-2** | **실측 6 site codemod** (`tool_library` × 3 + `retired_file_write_tool` × 2 + `mcp_tool_runtime_workspace` × 1) + backsliding lint. (원본 audit 의 "8 sites" 는 §1.3 hallucination — 실측 정정.) | +60 / -30 | PR-1 |
 | **PR-3** | LLM prompt 의 `kind` field 인식 추가 (`prompts/keeper-tool-error-instruct.md`) | +30 / -5 | PR-2 + 1주일 production canary |
 | **PR-4** (optional) | 2차 사이트 (~22) codemod — keeper hook / persistence 영역 | +400 / -150 | PR-2 |
 

--- a/docs/rfc/RFC-0182-masc-descriptor-projection.md
+++ b/docs/rfc/RFC-0182-masc-descriptor-projection.md
@@ -90,7 +90,7 @@ After the body merged (PR #18726 → renumber #18731), a 5-prong dead/live audit
 | Verdict | Tools | Decision |
 |---|---|---|
 | **dead** (no handler, no live caller) | `masc_execute`, `masc_execute_dry_run`, `masc_admin_cleanup`, `masc_admin_reset`, `masc_gc_force`, `masc_workspace_delete`, `masc_force_unbind` | delete tool_catalog metadata; do not migrate |
-| **dead** (after ambiguous decision) | `masc_spawn` (dispatch explicitly removed with comment `"masc_spawn removed: vendor-specific agent spawning belongs to OAS domain"` at `tool_inline_dispatch.ml:287`; metadata and test fixture left behind) | delete metadata + test fixture (completes the in-progress cleanup) |
+| **dead** (after ambiguous decision) | `masc_spawn` (dispatch explicitly removed with comment `"masc_spawn removed: vendor-specific agent spawning belongs to OAS domain"` at `mcp_tool_runtime.ml:287`; metadata and test fixture left behind) | delete metadata + test fixture (completes the in-progress cleanup) |
 | **live** | `masc_bind`, `masc_unbind`, `masc_broadcast`, `masc_messages`, `channel_gate`, `masc_set_param`, `masc_tool_revoke` (7 tools) | migrate to `Tool_spec.register`; descriptor projection added |
 | **deferred** (separate RFC) | `masc_portal_open`, `masc_portal_close`, `masc_portal_send` | live, but dispatch is at `mcp_server_eio_protocol.ml` protocol level — not in-process. This RFC's cluster-variant pattern does not fit. Tracked for a separate RFC (RFC-0183 candidate). Excluded from this RFC's scope. |
 
@@ -135,13 +135,13 @@ Each of the 10 live metadata-only tools gets a corresponding `Tool_spec.register
 
 | Tool | Proposed module | Q3 visibility |
 |---|---|---|
-| `masc_bind`, `masc_unbind`, `masc_broadcast`, `masc_messages`, `channel_gate` | `tool_inline_dispatch.ml` (Mod_inline) | `Default` (preserved) |
-| `masc_set_param` | `tool_inline_dispatch.ml` or new `tool_admin.ml` | **`Hidden`** (preserved from current `hidden_active`, Q3 decision) |
+| `masc_bind`, `masc_unbind`, `masc_broadcast`, `masc_messages`, `channel_gate` | `mcp_tool_runtime.ml` (Mod_inline) | `Default` (preserved) |
+| `masc_set_param` | `mcp_tool_runtime.ml` or new `tool_admin.ml` | **`Hidden`** (preserved from current `hidden_active`, Q3 decision) |
 | `masc_tool_revoke` | `tool_shard.ml` (Mod_shard) — existing `masc_tool_grant` is registered here | `Default` (preserved) |
 
 All 7 use `handler_binding = Tag_dispatch` to match the existing 103-tool norm. Permission metadata (`required_permission = Some Masc_domain.CanXxx`) is preserved as-is — moved from raw `tool_catalog.ml` entries to `Tool_spec.create ~required_permission`.
 
-Q1 (module layout) resolution: **hybrid — no new tool_admin.ml module**. Audit found existing dispatchers (`tool_inline_dispatch.ml`, `tool_shard.ml`) already host functionally-adjacent registrations. New module would proliferate single-purpose files and violate `[feedback_radical_improvement_over_diff_size]` (avoid unnecessary file growth in user-of-one codebase). `masc_set_param` placement is implementer's choice between `tool_inline_dispatch.ml` and a new `tool_admin.ml`; if only `masc_set_param` needs it, prefer existing.
+Q1 (module layout) resolution: **hybrid — no new tool_admin.ml module**. Audit found existing dispatchers (`mcp_tool_runtime.ml`, `tool_shard.ml`) already host functionally-adjacent registrations. New module would proliferate single-purpose files and violate `[feedback_radical_improvement_over_diff_size]` (avoid unnecessary file growth in user-of-one codebase). `masc_set_param` placement is implementer's choice between `mcp_tool_runtime.ml` and a new `tool_admin.ml`; if only `masc_set_param` needs it, prefer existing.
 
 ### 3.3 Dead tool metadata + test cleanup (8 tools)
 
@@ -157,7 +157,7 @@ masc_admin_reset        — no handler, no dispatch, no live caller
 masc_gc_force           — no handler, no dispatch, no live caller
 masc_workspace_delete        — no handler, no dispatch, no live caller
 masc_force_unbind        — no handler, no dispatch, no live caller
-masc_spawn              — dispatch explicitly removed (tool_inline_dispatch.ml:287
+masc_spawn              — dispatch explicitly removed (mcp_tool_runtime.ml:287
                           comment `"masc_spawn removed: vendor-specific agent
                           spawning belongs to OAS domain"`), metadata+test left
                           behind. This RFC completes the cleanup.
@@ -239,13 +239,13 @@ Rollback: revert is a single PR revert. RFC-0179 set the precedent — squash me
 | 3 | Closeout: flip RFC-0182 status from Draft → Implemented, add the implementation PR number to `implementation_prs:` frontmatter, audit `scripts/audit-rfc-closeout-lag.sh`. |
 | 4 (separate) | RFC-0183 candidate: portal trio descriptor model (protocol-level dispatch layer). |
 
-Implementation PR target diff: ~1200-1800 LoC, ~8-9 files (`agent_tool_descriptor.ml`, `agent_tool_descriptor.mli`, `agent_tool_in_process_runtime.ml`, `agent_tool_in_process_runtime.mli`, `agent_tool_runtime.ml`, `agent_tool_runtime.mli`, `tool_spec.ml` (remove Match_chain), `tool_spec.mli`, `tool_catalog.ml` (delete 8 dead rows), `tool_inline_dispatch.ml` (add 9-10 registrations), `tool_shard.ml` (add masc_tool_revoke), test files affected by dead-tool cleanup).
+Implementation PR target diff: ~1200-1800 LoC, ~8-9 files (`agent_tool_descriptor.ml`, `agent_tool_descriptor.mli`, `agent_tool_in_process_runtime.ml`, `agent_tool_in_process_runtime.mli`, `agent_tool_runtime.ml`, `agent_tool_runtime.mli`, `tool_spec.ml` (remove Match_chain), `tool_spec.mli`, `tool_catalog.ml` (delete 8 dead rows), `mcp_tool_runtime.ml` (add 9-10 registrations), `tool_shard.ml` (add masc_tool_revoke), test files affected by dead-tool cleanup).
 
 ## 11. Open questions — resolved
 
 The original §11 had three open architectural questions. The post-merge audit (§2a) and user decision chain resolved them as follows:
 
-- **Q1 (module layout)** — *resolved*: hybrid. No new `tool_admin.ml` module; keep approval dispatch in the keeper-owned surface (`Keeper_tool_surface` / `Keeper_tool_in_process_runtime`) and reuse `tool_shard.ml` for shard tools (existing `masc_tool_grant` lives there). `masc_set_param` may either reuse `tool_inline_dispatch.ml` or get a new single-purpose module — implementer's choice with preference for the former. Rationale in §3.2.
+- **Q1 (module layout)** — *resolved*: hybrid. No new `tool_admin.ml` module; keep approval dispatch in the keeper-owned surface (`Keeper_tool_surface` / `Keeper_tool_in_process_runtime`) and reuse `tool_shard.ml` for shard tools (existing `masc_tool_grant` lives there). `masc_set_param` may either reuse `mcp_tool_runtime.ml` or get a new single-purpose module — implementer's choice with preference for the former. Rationale in §3.2.
 - **Q2 (`channel_gate` rename)** — *resolved*: keep as-is. The audit (§2a) confirmed `channel_gate` is live with HTTP subsystem dispatch (`server_routes_http_routes_channel_gate.ml`). Renaming would force prompt/persona/config updates with no architectural benefit; the unconventional name is preserved for backward compatibility. Migration is to `Tool_spec.register` only.
 - **Q3 (`masc_set_param` visibility)** — *resolved*: keep `Hidden`. The audit confirmed live HTTP dispatch with admin auth (`server_routes_http_routes_activity.ml:with_tool_auth`). Visibility-level isolation reflects the original design intent (internal HTTP runtime-parameter mutation route). Registered as `Tool_spec.create ~visibility:Hidden ~required_permission:(Some CanAdmin)`.
 
@@ -336,7 +336,7 @@ From the 17-iter /loop session that built PR #18823:
 
 - RFC-0183 (portal trio): protocol-level dispatch design.
 - `masc_set_param` (HTTP route only — not internal-callable).
-- `masc_session` (Tool_inline_dispatch with `load/save_mcp_sessions` callbacks — caller-injected closures, not ctx Eio fields).
+- `masc_session` (Mcp_tool_runtime with `load/save_mcp_sessions` callbacks — caller-injected closures, not ctx Eio fields).
 
 ---
 

--- a/docs/rfc/RFC-0189-typed-tool-result-variant.md
+++ b/docs/rfc/RFC-0189-typed-tool-result-variant.md
@@ -97,7 +97,7 @@ Constructor distribution (`rg "Tool_result\.(ok|error|of_exn|quick_)" lib/`):
 | `mcp_server_eio_execute.ml` | 16 |
 | `tool_task.ml` | 14 |
 | `tool_types/tool_args.ml` | 13 |
-| `tool_inline_dispatch.ml` | 13 |
+| `mcp_tool_runtime.ml` | 13 |
 | ... (remaining) | 115 |
 | **Total** | **285** |
 

--- a/docs/rfc/RFC-0190-descriptor-visibility-ssot.md
+++ b/docs/rfc/RFC-0190-descriptor-visibility-ssot.md
@@ -28,9 +28,9 @@ Result:
 | descriptor ∖ surface | 82 | `keeper_board_*` (managed-keeper twins), `masc_board_delete`, `masc_config`, `masc_get_metrics`, … (intentionally not operator-visible) |
 | intersect | 46 | already descriptor-backed surface entries |
 
-Two SSOTs that should be one. RFC-0179 + RFC-0182 brought descriptors to *most* of the `masc_*` operator surface, but **9 lifecycle/authoring tools never entered the descriptor system at all** because their handlers live in `lib/tool_inline_dispatch.ml` (MCP server-level inline path), not in `Tool_workspace.dispatch` or the cluster `*_dispatch_ref` references the descriptor `runtime_handler` enum routes to.
+Two SSOTs that should be one. RFC-0179 + RFC-0182 brought descriptors to *most* of the `masc_*` operator surface, but **9 lifecycle/authoring tools never entered the descriptor system at all** because their handlers live in `lib/mcp_tool_runtime.ml` (MCP server-level inline path), not in `Tool_workspace.dispatch` or the cluster `*_dispatch_ref` references the descriptor `runtime_handler` enum routes to.
 
-The descriptor enum (`In_process | Filesystem | Shell_ir`) is closed and assumes the descriptor *owns* execution. Tools handled by inline dispatch have no slot.
+The descriptor enum (`In_process | Filesystem | Shell_ir`) is closed and assumes the descriptor *owns* execution. Tools handled by MCP runtime have no slot.
 
 ## 1. Hypothesis the audit invalidated
 
@@ -48,7 +48,7 @@ Make `Agent_tool_descriptor.t` the single source of truth for *visibility and me
 - `Tool_catalog_surfaces.public_mcp_surface_tools` is computed as
   `filter (fun d -> d.policy.visibility = Public_mcp) all_descriptors`.
 - Every entry on every surface (`public_mcp_surface_tools`, `spawned_agent_surface_tools`, `local_worker_surface_tools`, `session_min_surface_tools`, `admin_surface_tools`) has a descriptor.
-- Dispatch routing remains opt-in: descriptors whose execution lives in `Tool_inline_dispatch` declare `executor = External_inline` and `runtime_handler = Tool_external_inline`, and the descriptor dispatcher returns `None` for them, leaving the inline path unchanged.
+- Dispatch routing remains opt-in: descriptors whose execution lives in `Mcp_tool_runtime` declare `executor = External_inline` and `runtime_handler = Tool_external_inline`, and the descriptor dispatcher returns `None` for them, leaving the inline path unchanged.
 - The surface↔descriptor diff becomes a compile-/test-time invariant (Phase 4).
 
 ## 3. Non-goals
@@ -65,7 +65,7 @@ type executor =
   | Filesystem
   | In_process
   | External_inline  (* NEW: descriptor is metadata-only;
-                        execution owned by tool_inline_dispatch *)
+                        execution owned by mcp_tool_runtime *)
 
 type runtime_handler =
   | ... (* existing variants *)
@@ -80,7 +80,7 @@ let handle ctx ~descriptor ~args =
   | Filesystem      -> handle_filesystem ctx descriptor args
   | Shell_ir        -> handle_shell_ir   ctx descriptor args
   | In_process      -> handle_in_process ctx descriptor args
-  | External_inline -> None  (* fall through to inline_dispatch *)
+  | External_inline -> None  (* fall through to MCP runtime *)
 ```
 
 `handle_internal` already returns `string option`; existing callers treat `None` as "descriptor system declines, let the next path handle." The inline path is *that* next path for MCP-server entry points; for keeper-facing entry it is unknown-tool (correct — these tools were never keeper-callable).
@@ -101,7 +101,7 @@ let handle ctx ~descriptor ~args =
 | `masc_persona_generate` | `masc.persona.generate` | persona authoring schema |
 | `masc_keeper_create_from_persona` | `masc.persona.create_from` | persona authoring schema |
 
-Each entry pulls `description` and `input_schema` from the inline dispatch's existing schema registration; **no duplication is introduced** — descriptors reference the same `Masc_domain.tool_schema` records the inline path already publishes.
+Each entry pulls `description` and `input_schema` from the MCP runtime's existing schema registration; **no duplication is introduced** — descriptors reference the same `Masc_domain.tool_schema` records the inline path already publishes.
 
 ## 6. Implementation phases
 
@@ -126,12 +126,12 @@ This RFC does *not* trigger workaround signatures:
 ## 8. Open questions
 
 1. Should `External_inline` permit a non-empty `runtime_handler` other than `Tool_external_inline` for future inline-cluster splits? Pinning to one variant is the conservative choice; reconsider only if a real second consumer appears.
-2. `masc_persona_generate` and `masc_keeper_create_from_persona` may have stricter `approval` semantics than current handler defaults — confirm against `tool_inline_dispatch` `inline_tool_requires_*` lists in P4.
+2. `masc_persona_generate` and `masc_keeper_create_from_persona` may have stricter `approval` semantics than current handler defaults — confirm against `mcp_tool_runtime` `inline_tool_requires_*` lists in P4.
 3. RFC-0064 hard-cut public set (7 LLM-native names) is unchanged; the visibility projection covers MCP surface only.
 
 ## 9. Rejected alternatives
 
-- **(A-pragmatic)** Add 9 descriptors with `In_process` executor + dispatch arms in `handle_masc_workspace` / `handle_masc_persona` / `handle_masc_keeper` that call back into `Tool_inline_dispatch`. Rejected: introduces dual handlers for the same tool name (descriptor cluster *and* inline path), guaranteed drift under future changes.
+- **(A-pragmatic)** Add 9 descriptors with `In_process` executor + dispatch arms in `handle_masc_workspace` / `handle_masc_persona` / `handle_masc_keeper` that call back into `Mcp_tool_runtime`. Rejected: introduces dual handlers for the same tool name (descriptor cluster *and* inline path), guaranteed drift under future changes.
 - **(B-only)** Keep the hand list, add a test that asserts every surface entry exists in *some* known set (descriptor or allowlist). Rejected as the *final* state — drift cannot be eliminated, only reported. Acceptable as an *interim* gate (see RFC-0190 implementation companion: invariant test PR can land before P1 to ratchet the count down).
 
 ## 10. Acceptance criteria

--- a/docs/rfc/RFC-0191-descriptor-policy-ssot.md
+++ b/docs/rfc/RFC-0191-descriptor-policy-ssot.md
@@ -86,7 +86,7 @@ type policy =
     audience             : audience_class
     (* Tool-access grant required to expose this tool. *)
   ; required_tool_access : string option
-    (* Whether the tool is permitted on the inline-dispatch fast path
+    (* Whether the tool is permitted on the MCP-runtime fast path
        (no Eio plumbing). Currently a hand list. *)
   ; inline_safe          : bool
   ; (* Maintenance-only tools require an explicit operator gate. *)

--- a/lib/dune
+++ b/lib/dune
@@ -185,10 +185,10 @@
   tool_local_runtime_bench
   tool_local_runtime_status
   tool_local_runtime_probe
-  ;; tool_inline_dispatch sub-modules
-  tool_inline_dispatch_types
-  tool_inline_dispatch_workspace
-  tool_inline_dispatch_comm
+  ;; mcp_tool_runtime sub-modules
+  mcp_tool_runtime_types
+  mcp_tool_runtime_workspace
+  mcp_tool_runtime_comm
   workspace_goals_verification
   tool_misc_admin
   keeper_tool_persona_audit

--- a/lib/institution_eio.mli
+++ b/lib/institution_eio.mli
@@ -19,7 +19,7 @@
     The {!institution} record is kept abstract at this
     boundary because external callers
     ([mcp_server_eio_resource.ml],
-    [tool_inline_dispatch_workspace.ml]) only round-trip it
+    [mcp_tool_runtime_workspace.ml]) only round-trip it
     through {!institution_of_json} → {!format_for_injection}
     without touching its fields.  The {!episode} record stays
     concrete because [.id] / [.summary] / [.participants] are
@@ -86,7 +86,7 @@ type institution
 (** Held abstract because callers do not pattern-match on its
     fields — the only consumers
     ([mcp_server_eio_resource.ml],
-    [tool_inline_dispatch_workspace.ml]) round-trip through
+    [mcp_tool_runtime_workspace.ml]) round-trip through
     {!institution_of_json} → {!format_for_injection}.  The
     .ml retains the concrete record (with [identity],
     [memory], [culture], [succession], [current_agents],
@@ -154,7 +154,7 @@ val load_and_format_for_welcome :
 (** Loads the structured [institution.json] and returns a
     welcome-banner Markdown block (different surface than
     {!format_for_injection} — narrower, used by the
-    operator dashboard and the inline dispatch path).
+    operator dashboard and the MCP runtime path).
     Returns the empty string when the file is missing or
     any load / parse error occurs.  The [~fs] argument is
     accepted polymorphically and ignored by the .ml — the

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -906,7 +906,7 @@ let resolve_with_policy
     [Error (Already_resolved _)] if the atomic update found no matching
     entry (concurrent resolve race).
     Called from the dashboard approval HTTP handler
-    ([server_dashboard_http.ml]) and MCP inline dispatch. *)
+    ([server_dashboard_http.ml]) and MCP runtime. *)
 let resolve ~id ~(decision : Agent_sdk.Hooks.approval_decision)
   : (unit, resolve_error) result
   =

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -257,7 +257,7 @@ val resolve_with_policy :
 
 (** Convenience over [resolve_with_policy] that discards the
     resolution result. Called from the dashboard approval HTTP
-    handler and the MCP inline dispatch. *)
+    handler and the MCP runtime. *)
 val resolve :
   id:string ->
   decision:Agent_sdk.Hooks.approval_decision ->

--- a/lib/keeper/keeper_supervisor_launch.ml
+++ b/lib/keeper/keeper_supervisor_launch.ml
@@ -514,7 +514,7 @@ let launch_supervised_fiber
 (* #10993: persona drift visibility.
 
    [Keeper_identity.normalize_all_names ~check_persona:true] runs on
-   every dispatch via [Tool_inline_dispatch_workspace] (RFC P3-a
+   every dispatch via [Mcp_tool_runtime_workspace] (RFC P3-a
    logging-only mode), but its [Persona_not_found] branch emits a
    Log.Misc.warn that is hard to triage:
 

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -343,7 +343,7 @@ let execute_tool_eio
                       then Tool_result.ok ~tool_name:name ~start_time message
                       else Tool_result.error ~tool_name:name ~start_time message)
                  | Mod_inline ->
-                   let inline_ctx : Tool_inline_dispatch.context =
+                   let mcp_runtime_ctx : Mcp_tool_runtime.context =
                      { config
                      ; agent_name
                      ; registry
@@ -352,7 +352,7 @@ let execute_tool_eio
                      ; clock
                      ; arguments = coerced_args
                      ; mcp_session_id
-                     ; (* The inline-dispatch surface caches under the
+                     ; (* The MCP runtime surface caches under the
                           already-resolved session identity, so carry the
                           ephemerality decided above. *)
                        record_mcp_session_agent =
@@ -367,7 +367,7 @@ let execute_tool_eio
                      ; save_mcp_sessions = Mcp_server_eio_governance.save_mcp_sessions
                      }
                    in
-                   Tool_inline_dispatch.dispatch inline_ctx ~name)
+                   Mcp_tool_runtime.dispatch mcp_runtime_ctx ~name)
             in
             (* #9784: enrich Unknown tool errors with closest-name suggestions so the
      LLM can self-correct on the next turn rather than re-emit the same

--- a/lib/mcp_server_eio_governance.ml
+++ b/lib/mcp_server_eio_governance.ml
@@ -1,7 +1,7 @@
 (** Mcp_server_eio_governance — Governance configuration and MCP session helpers
 
     Extracted from mcp_server_eio.ml to reduce file size and enable reuse
-    from Tool_inline_dispatch without circular dependencies.
+    from Mcp_tool_runtime without circular dependencies.
 *)
 
 (** {1 Governance} *)

--- a/lib/mcp_server_eio_governance.mli
+++ b/lib/mcp_server_eio_governance.mli
@@ -2,7 +2,7 @@
     MCP session helpers.
 
     Extracted from [mcp_server_eio.ml] to reduce file size and
-    enable reuse from {!Tool_inline_dispatch} without
+    enable reuse from {!Mcp_tool_runtime} without
     re-introducing the dependency cycle the split was designed
     to break. {!Mcp_server_eio} re-exports the two record types
     via [type t = Mcp_server_eio_governance.t = { … }] and

--- a/lib/mcp_server_eio_helpers.ml
+++ b/lib/mcp_server_eio_helpers.ml
@@ -1,6 +1,6 @@
 (** Mcp_server_eio_helpers — Small utility functions extracted from mcp_server_eio.ml
 
-    Provides functions needed by both mcp_server_eio.ml and tool_inline_dispatch.ml
+    Provides functions needed by both mcp_server_eio.ml and mcp_tool_runtime.ml
     without circular dependencies.
 *)
 

--- a/lib/mcp_server_eio_helpers.mli
+++ b/lib/mcp_server_eio_helpers.mli
@@ -1,6 +1,6 @@
 (** Mcp_server_eio_helpers — small utility functions extracted
     from [mcp_server_eio.ml] so [mcp_server_eio.ml] and
-    [tool_inline_dispatch.ml] can share them without a circular
+    [mcp_tool_runtime.ml] can share them without a circular
     dependency.
 
     Both helpers re-raise [Eio.Cancel.Cancelled] so an ambient

--- a/lib/mcp_session/mcp_session.ml
+++ b/lib/mcp_session/mcp_session.ml
@@ -5,7 +5,7 @@
    a constructor forces compilation in [action_to_string] AND extends
    [valid_action_strings]; the schema in [tool_schemas_inline_infra.ml]
    mirrors the SSOT (cycle-aware, sync test) and the dispatcher in
-   [tool_inline_dispatch.ml] consumes the Variant via
+   [mcp_tool_runtime.ml] consumes the Variant via
    [action_of_string_opt]. The previous code had two independent
    string lists (schema enum + match arms) with no compile-time
    linkage. *)

--- a/lib/mcp_session/mcp_session.mli
+++ b/lib/mcp_session/mcp_session.mli
@@ -7,7 +7,7 @@
     Variant SSOT for the [masc_session] tool action. Adding a constructor
     forces recompilation of [action_to_string] and extends
     [valid_action_strings]; the schema in [tool_schemas_inline_infra.ml] and
-    the dispatcher in [tool_inline_dispatch.ml] both consume this type via
+    the dispatcher in [mcp_tool_runtime.ml] both consume this type via
     {!action_of_string_opt}. *)
 
 type action =

--- a/lib/mcp_tool_runtime.ml
+++ b/lib/mcp_tool_runtime.ml
@@ -16,23 +16,23 @@ module Int = Stdlib.Int
 module Float = Stdlib.Float
 
 
-(** Tool_inline_dispatch — thin dispatch router for inline tool handlers.
+(** Mcp_tool_runtime — MCP server-local tool runtime.
 
     Delegates to sub-modules:
-    - Tool_inline_dispatch_workspace: masc_start
-    - Tool_inline_dispatch_comm: masc_broadcast, masc_messages
-    - Tool_inline_dispatch_extra: remaining tools (board, etc.)
+    - Mcp_tool_runtime_workspace: masc_start
+    - Mcp_tool_runtime_comm: masc_broadcast, masc_messages
+    - Mcp_tool_runtime_board: remaining tools (board, etc.)
 
-    Keeps inline: mcp_session plus MCP-state helpers.
+    Keeps MCP-only server helpers that need per-request server state.
 
     RFC-0062 Phase 4c-2: handlers now return [Tool_result.result] directly;
     [wrap_result] adapter removed. *)
 
 (** Re-export shared types so callers can use
-    [Tool_inline_dispatch.context] and [Tool_inline_dispatch.tool_result]
+    [Mcp_tool_runtime.context] and [Mcp_tool_runtime.tool_result]
     without knowing about the types sub-module. *)
-type tool_result = Tool_inline_dispatch_types.tool_result
-type context = Tool_inline_dispatch_types.context = {
+type tool_result = Mcp_tool_runtime_types.tool_result
+type context = Mcp_tool_runtime_types.context = {
   config : Workspace.config;
   agent_name : string;
   registry : Session.registry;
@@ -55,17 +55,17 @@ type context = Tool_inline_dispatch_types.context = {
     Workspace.config -> Mcp_server_eio_governance.mcp_session_record list -> unit;
 }
 
-(* RFC-0189 PR-2: inline helpers return [Tool_result.result] directly.
+(* RFC-0189 PR-2: MCP runtime helpers return [Tool_result.result] directly.
    Two patterns:
 
-   - [inline_ok] handles both plain-text and JSON-string success bodies.
+   - [runtime_ok] handles both plain-text and JSON-string success bodies.
      [structured_payload_of_message] lifts JSON envelopes into [data];
      plain strings fall through as [`String body].
-   - [inline_err_workflow] commits caller-input rejections to
+   - [runtime_err_workflow] commits caller-input rejections to
      [Workflow_rejection]: every error path in this dispatch
      ("id is required", unknown enum action, not-found lookups) is
      caller-side. *)
-let inline_ok ~tool_name ~start_time body : Tool_result.result =
+let runtime_ok ~tool_name ~start_time body : Tool_result.result =
   let data =
     match Tool_result.structured_payload_of_message body with
     | Some json -> json
@@ -74,7 +74,7 @@ let inline_ok ~tool_name ~start_time body : Tool_result.result =
   Tool_result.make_ok ~tool_name ~start_time ~data ()
 ;;
 
-let inline_err_workflow ~tool_name ~start_time msg : Tool_result.result =
+let runtime_err_workflow ~tool_name ~start_time msg : Tool_result.result =
   Tool_result.make_err
     ~tool_name
     ~class_:Tool_result.Workflow_rejection
@@ -120,13 +120,13 @@ let dispatch (ctx : context) ~(name : string) : Tool_result.result option =
   match name with
   (* ── Workspace lifecycle (delegated) ─────────────────────────────── *)
   | "masc_start" ->
-      Tool_inline_dispatch_workspace.handle_start ~tool_name:name ~start_time:start ctx
+      Mcp_tool_runtime_workspace.handle_start ~tool_name:name ~start_time:start ctx
 
   (* ── Communication (delegated) ──────────────────────────────── *)
   | "masc_broadcast" ->
-      Tool_inline_dispatch_comm.handle_broadcast ~tool_name:name ~start_time:start ctx
+      Mcp_tool_runtime_comm.handle_broadcast ~tool_name:name ~start_time:start ctx
   | "masc_messages" ->
-      Tool_inline_dispatch_comm.handle_messages ~tool_name:name ~start_time:start ctx
+      Mcp_tool_runtime_comm.handle_messages ~tool_name:name ~start_time:start ctx
 
   (* Verification tools removed: pruned *)
 
@@ -138,7 +138,7 @@ let dispatch (ctx : context) ~(name : string) : Tool_result.result option =
       let raw = arg_get_string "action" "" in
       (match Mcp_session.action_of_string_opt raw with
        | None ->
-         Some (inline_err_workflow ~tool_name:name ~start_time:start
+         Some (runtime_err_workflow ~tool_name:name ~start_time:start
            (Printf.sprintf
              "action must be one of [%s]; got %S"
              (String.concat "|" Mcp_session.valid_action_strings) raw))
@@ -198,48 +198,48 @@ let dispatch (ctx : context) ~(name : string) : Tool_result.result option =
             end
       in
       (match response with
-       | Ok json -> Some (inline_ok ~tool_name:name ~start_time:start (Yojson.Safe.to_string json))
-       | Error e -> Some (inline_err_workflow ~tool_name:name ~start_time:start e)))
+       | Ok json -> Some (runtime_ok ~tool_name:name ~start_time:start (Yojson.Safe.to_string json))
+       | Error e -> Some (runtime_err_workflow ~tool_name:name ~start_time:start e)))
 
   (* ── Fallthrough to extra dispatch ──────────────────────────── *)
   | _ ->
-      Tool_inline_dispatch_extra.dispatch ~config ~agent_name ~arguments ~state ~sw ~clock ~name ~start_time:start
+      Mcp_tool_runtime_board.dispatch ~config ~agent_name ~arguments ~state ~sw ~clock ~name ~start_time:start
 
 (* ================================================================ *)
 (* Tool_spec registration (RFC-0182 §3.2)                           *)
 (* ================================================================ *)
 
-(* Migrates inline-dispatched workspace tools from the legacy
+(* Migrates MCP server-local workspace tools from the legacy
    register_module_tag bootstrap (mcp_server_eio.ml) to the Tool_spec
    single-call SSOT.
 
    Excluded (deferred, semantic-widening would be required):
    - [masc_set_param], [channel_gate] —
      no Masc_domain.tool_schema record exists. They are dispatched via
-     HTTP routes / inline arms but never advertised to MCP. Promoting
+     HTTP routes / MCP runtime arms but never advertised to MCP. Promoting
      them to Tool_spec.register requires authoring new input schemas
      and deciding visibility semantics for MCP exposure. Tracked as
      RFC-0182 follow-up scope.
    The retired [masc_tool_*] shard-management tools are intentionally absent
    from this list and from the MCP ToolSpec surface. *)
 
-let inline_register_targets =
+let runtime_register_targets =
   [ "masc_broadcast"; "masc_messages" ]
 
-let inline_tool_read_only =
+let runtime_tool_read_only =
   [ "masc_messages" ]
 
-let inline_tool_requires_actor_binding = []
+let runtime_tool_requires_actor_binding = []
 
-let inline_tool_mcp_context_required =
+let runtime_tool_mcp_context_required =
   [ "masc_broadcast"; "masc_messages" ]
 
-let inline_tool_effect_domain name : Tool_catalog.effect_domain =
-  if List.mem name inline_tool_read_only then Tool_catalog.Read_only
+let runtime_tool_effect_domain name : Tool_catalog.effect_domain =
+  if List.mem name runtime_tool_read_only then Tool_catalog.Read_only
   else Tool_catalog.Masc_workspace
 
 let () =
-  inline_register_targets
+  runtime_register_targets
   |> List.iter (fun name ->
     match
       List.find_opt
@@ -248,7 +248,7 @@ let () =
     with
     | None -> ()
     | Some (schema : Masc_domain.tool_schema) ->
-      let is_read_only = List.mem name inline_tool_read_only in
+      let is_read_only = List.mem name runtime_tool_read_only in
       Tool_spec.register
         (Tool_spec.create
            ~name:schema.name
@@ -258,7 +258,7 @@ let () =
            ~handler_binding:Tag_dispatch
            ~is_read_only
            ~is_idempotent:is_read_only
-           ~mcp_context_required:(List.mem name inline_tool_mcp_context_required)
-           ~requires_actor_binding:(List.mem name inline_tool_requires_actor_binding)
-           ~effect_domain:(inline_tool_effect_domain name)
+           ~mcp_context_required:(List.mem name runtime_tool_mcp_context_required)
+           ~requires_actor_binding:(List.mem name runtime_tool_requires_actor_binding)
+           ~effect_domain:(runtime_tool_effect_domain name)
            ()))

--- a/lib/mcp_tool_runtime.mli
+++ b/lib/mcp_tool_runtime.mli
@@ -1,16 +1,16 @@
 
-(** Tool_inline_dispatch — thin dispatch router for inline tool handlers.
+(** Mcp_tool_runtime — MCP server-local tool runtime.
 
-    Delegates to sub-modules for workspace, comm, and extra tool handling.
-    Keeps inline: mcp_session plus MCP-state helpers.
+    Delegates to sub-modules for workspace, comm, and board tool handling.
+    Keeps MCP-only server helpers that need per-request server state.
 
     @since 0.1.0 *)
 
-(** {1 Types} (re-exported from Tool_inline_dispatch_types) *)
+(** {1 Types} (re-exported from Mcp_tool_runtime_types) *)
 
-type tool_result = Tool_inline_dispatch_types.tool_result
+type tool_result = Mcp_tool_runtime_types.tool_result
 
-type context = Tool_inline_dispatch_types.context = {
+type context = Mcp_tool_runtime_types.context = {
   config : Workspace.config;
   agent_name : string;
   registry : Session.registry;

--- a/lib/mcp_tool_runtime_board.ml
+++ b/lib/mcp_tool_runtime_board.ml
@@ -16,7 +16,7 @@ module Int = Stdlib.Int
 module Float = Stdlib.Float
 
 
-(** Tool_inline_dispatch_extra — additional inline tool dispatch arms
+(** Mcp_tool_runtime_board — MCP server-local board tool runtime
     (recall, board, conversation).
     Returns [Some (Tool_result.result)] if handled, [None] otherwise.
 

--- a/lib/mcp_tool_runtime_board.mli
+++ b/lib/mcp_tool_runtime_board.mli
@@ -1,10 +1,8 @@
-(** Tool_inline_dispatch_extra — fallback inline-tool dispatch
-    branch (board / mention handlers extracted from
-    {!Tool_inline_dispatch}).
+(** Mcp_tool_runtime_board — MCP server-local board tool runtime.
 
     Two external entries:
-    - {!dispatch}: invoked when the main inline dispatch table has
-      no match (catch-all branch in {!Tool_inline_dispatch.dispatch}).
+    - {!dispatch}: invoked when the main MCP runtime router has
+      no match (catch-all branch in {!Mcp_tool_runtime.dispatch}).
     - {!ensure_board_post_author}: caller-identity enforcement on
       [masc_board_post] [author] field, exposed for direct test
       coverage.
@@ -50,7 +48,7 @@ val enforce_caller_identity :
     [_comment_vote]).  Prefer {!ensure_board_post_author} for the
     [masc_board_post]/[author] specialisation. *)
 
-(** {1 Inline dispatch fallback} *)
+(** {1 MCP runtime fallback} *)
 
 val dispatch :
   config:Workspace.config ->
@@ -63,8 +61,8 @@ val dispatch :
   start_time:float ->
   Tool_result.result option
 (** [dispatch ~config ~agent_name ~arguments ~state ~sw ~clock
-      ~name ~start_time] handles inline dispatch for tool [name]
-    when the main table has no match.  Currently routes:
+      ~name ~start_time] handles MCP server-local routing for tool [name]
+    when the main runtime router has no match.  Currently routes:
 
     - [masc_board_post] -> identity enforcement +
       {!Board_dispatch.create_post} +

--- a/lib/mcp_tool_runtime_comm.ml
+++ b/lib/mcp_tool_runtime_comm.ml
@@ -15,17 +15,17 @@ module Char = Stdlib.Char
 module Int = Stdlib.Int
 module Float = Stdlib.Float
 
-(** Tool_inline_dispatch_comm — communication tool handlers.
+(** Mcp_tool_runtime_comm — communication tool handlers.
 
     Handles: masc_broadcast, masc_messages.
 
-    Extracted from tool_inline_dispatch.ml to reduce file size. *)
+    Extracted from mcp_tool_runtime.ml to keep the runtime router small. *)
 
-open Tool_inline_dispatch_types
+open Mcp_tool_runtime_types
 
-type tool_result = Tool_inline_dispatch_types.tool_result
+type tool_result = Mcp_tool_runtime_types.tool_result
 
-type context = Tool_inline_dispatch_types.context
+type context = Mcp_tool_runtime_types.context
 
 (** Argument extraction helpers bound to ctx.arguments. *)
 let arg_get_string ctx key default =
@@ -69,7 +69,7 @@ let handle_broadcast ~tool_name ~start_time (ctx : context) : tool_result option
       Workspace_task_cache_invariant.rewrite_broadcast_content
         ~config
         ~from_agent:agent_name
-        ~module_name:"tool_inline_dispatch_comm"
+        ~module_name:"mcp_tool_runtime_comm"
         ~content:message
     in
     let trace_context = Otel_trace_context.from_ambient () in

--- a/lib/mcp_tool_runtime_comm.mli
+++ b/lib/mcp_tool_runtime_comm.mli
@@ -1,4 +1,4 @@
-(** Tool_inline_dispatch_comm — communication tool handlers.
+(** Mcp_tool_runtime_comm — communication tool handlers.
 
     Handles: masc_broadcast, masc_messages.
 
@@ -7,7 +7,7 @@
 
     @since 0.1.0 *)
 
-type context = Tool_inline_dispatch_types.context
+type context = Mcp_tool_runtime_types.context
 
 (** {1 Handlers} *)
 

--- a/lib/mcp_tool_runtime_types.ml
+++ b/lib/mcp_tool_runtime_types.ml
@@ -15,15 +15,15 @@ module Char = Stdlib.Char
 module Int = Stdlib.Int
 module Float = Stdlib.Float
 
-(** Tool_inline_dispatch_types — shared types for inline dispatch modules.
+(** Mcp_tool_runtime_types — shared types for MCP server-local tool modules.
 
     Extracted to avoid circular dependencies between
-    tool_inline_dispatch, tool_inline_dispatch_workspace, and tool_inline_dispatch_comm. *)
+    mcp_tool_runtime, mcp_tool_runtime_workspace, and mcp_tool_runtime_comm. *)
 
 type tool_result = Tool_result.result
 
 (** Context record capturing all bindings from execute_tool_eio
-    that the inline dispatch block needs. *)
+    that the MCP runtime block needs. *)
 type context = {
   config : Workspace.config;
   agent_name : string;

--- a/lib/mcp_tool_runtime_types.mli
+++ b/lib/mcp_tool_runtime_types.mli
@@ -1,15 +1,15 @@
-(** Tool_inline_dispatch_types — shared types for inline dispatch modules.
+(** Mcp_tool_runtime_types — shared types for MCP server-local tool modules.
 
     Extracted to avoid circular dependencies between
-    [tool_inline_dispatch], [tool_inline_dispatch_workspace], and
-    [tool_inline_dispatch_comm]. *)
+    [mcp_tool_runtime], [mcp_tool_runtime_workspace], and
+    [mcp_tool_runtime_comm]. *)
 
 type tool_result = Tool_result.result
-(** Structural alias — all inline dispatch handlers return
+(** Structural alias — all MCP runtime handlers return
     [Tool_result.result option]. *)
 
 (** Context record capturing all bindings from [execute_tool_eio]
-    that the inline dispatch block needs. Pure data — callers
+    that the MCP runtime block needs. Pure data — callers
     populate all fields. *)
 type context = {
   config : Workspace.config;

--- a/lib/mcp_tool_runtime_workspace.ml
+++ b/lib/mcp_tool_runtime_workspace.ml
@@ -15,20 +15,20 @@ module Char = Stdlib.Char
 module Int = Stdlib.Int
 module Float = Stdlib.Float
 
-(** Tool_inline_dispatch_workspace — project startup tool handler.
+(** Mcp_tool_runtime_workspace — project startup tool handler.
 
     Handles: masc_start.
 
-    Extracted from tool_inline_dispatch.ml to reduce file size. *)
+    Extracted from mcp_tool_runtime.ml to keep the runtime router small. *)
 
 module Planning_eio = Task.Planning_eio
 
-open Tool_inline_dispatch_types
+open Mcp_tool_runtime_types
 
 (* RFC-0189 PR-2: lifecycle handlers return [Tool_result.result option]
-   directly, matching the shared inline dispatch alias. *)
+   directly, matching the shared MCP runtime alias. *)
 
-let inline_ok ~tool_name ~start_time body : Tool_result.result =
+let runtime_ok ~tool_name ~start_time body : Tool_result.result =
   let data =
     match Tool_result.structured_payload_of_message body with
     | Some json -> json
@@ -37,7 +37,7 @@ let inline_ok ~tool_name ~start_time body : Tool_result.result =
   Tool_result.make_ok ~tool_name ~start_time ~data ()
 ;;
 
-let inline_err_runtime ~tool_name ~start_time msg : Tool_result.result =
+let runtime_err_runtime ~tool_name ~start_time msg : Tool_result.result =
   Tool_result.make_err
     ~tool_name
     ~class_:Tool_result.Runtime_failure
@@ -45,7 +45,7 @@ let inline_err_runtime ~tool_name ~start_time msg : Tool_result.result =
     msg
 ;;
 
-let inline_err_workflow ~tool_name ~start_time msg : Tool_result.result =
+let runtime_err_workflow ~tool_name ~start_time msg : Tool_result.result =
   Tool_result.make_err
     ~tool_name
     ~class_:Tool_result.Workflow_rejection
@@ -112,7 +112,7 @@ let handle_start ~tool_name ~start_time (ctx : context) : Tool_result.result opt
       (* workspace_result Error sources are all caller-input rejections:
          missing [path] argument or non-existent directory. *)
       Some
-        (inline_err_workflow ~tool_name ~start_time
+        (runtime_err_workflow ~tool_name ~start_time
            (Printf.sprintf "masc_start failed while setting project scope: %s" e))
   | Ok active_config ->
     (* Step 2: bind session (idempotent) *)
@@ -128,13 +128,13 @@ let handle_start ~tool_name ~start_time (ctx : context) : Tool_result.result opt
     | Error e ->
       (* Session binding exception caught from [Workspace.bind_session] — internal failure. *)
       Some
-        (inline_err_runtime ~tool_name ~start_time
+        (runtime_err_runtime ~tool_name ~start_time
            (Printf.sprintf "masc_start failed while binding agent session: %s" e))
     | Ok () ->
       (* Step 3: add_task + claim + plan_set_task (if task_title provided) *)
       if String.equal task_title "" then
         Some
-          (inline_ok ~tool_name ~start_time
+          (runtime_ok ~tool_name ~start_time
              (Printf.sprintf
                 "masc_start complete (project scope set + session bound as %s). No task created — use %s to create one."
                 agent_name
@@ -167,7 +167,7 @@ let handle_start ~tool_name ~start_time (ctx : context) : Tool_result.result opt
         in
         if String.equal task_id "" then
           Some
-            (inline_ok ~tool_name ~start_time
+            (runtime_ok ~tool_name ~start_time
                (Printf.sprintf
                   "masc_start partial: session bound as %s, but task creation failed: %s"
                   agent_name add_result))
@@ -176,10 +176,10 @@ let handle_start ~tool_name ~start_time (ctx : context) : Tool_result.result opt
           match Planning_eio.set_current_task active_config ~task_id with
           | Error msg ->
             (* [Planning_eio.set_current_task] internal store failure. *)
-            Some (inline_err_runtime ~tool_name ~start_time msg)
+            Some (runtime_err_runtime ~tool_name ~start_time msg)
           | Ok () ->
               Some
-                (inline_ok ~tool_name ~start_time
+                (runtime_ok ~tool_name ~start_time
                    (Printf.sprintf
                       "masc_start complete: project scope set, session bound as %s, task %s created+claimed+set as current."
                       agent_name task_id))

--- a/lib/mcp_tool_runtime_workspace.mli
+++ b/lib/mcp_tool_runtime_workspace.mli
@@ -1,9 +1,9 @@
-(** Tool_inline_dispatch_workspace — project startup tool handler.
+(** Mcp_tool_runtime_workspace — project startup tool handler.
 
     Handles project root setup and optional task bootstrapping.
 
-    Extracted from {!Tool_inline_dispatch} to keep the dispatch
-    table file under the lint cap.  The handler returns
+    Extracted from {!Mcp_tool_runtime} to keep the runtime
+    router under the lint cap.  The handler returns
     [Tool_result.result option] — [Some] when the tool name matches,
     [None] when the dispatcher should fall through to a default handler.
 
@@ -12,7 +12,7 @@
 
 val handle_start :
   tool_name:string -> start_time:float ->
-  Tool_inline_dispatch_types.context ->
+  Mcp_tool_runtime_types.context ->
   Tool_result.result option
 (** [handle_start ~tool_name ~start_time ctx] handles [masc_start] —
     the compound "set project root + join + optional task" onboarding flow.

--- a/lib/subscriptions.ml
+++ b/lib/subscriptions.ml
@@ -152,7 +152,7 @@ let session_registry_ref : (Yojson.Safe.t -> int) option ref = ref None
 
 (** One-shot gate for the "registry not wired" message below. Keeps the
     log from flooding when callers on a hot path (Task.Tool,
-    tool_inline_dispatch_comm) invoke push_event_to_sessions before
+    mcp_tool_runtime_comm) invoke push_event_to_sessions before
     bootstrap wires the bridge — or in test harnesses that never wire
     it at all. *)
 let unwired_warned = Atomic.make false

--- a/lib/tool/tool_registry.ml
+++ b/lib/tool/tool_registry.ml
@@ -32,12 +32,10 @@ module Float = Stdlib.Float
 type call_source =
   | External_mcp
   | Agent_internal
-  | Inline_dispatch
 
 let string_of_source = function
   | External_mcp -> "external_mcp"
   | Agent_internal -> "agent_internal"
-  | Inline_dispatch -> "inline_dispatch"
 ;;
 
 (** Per-tool call statistics *)
@@ -49,7 +47,6 @@ type call_stats =
   ; total_duration_ms : int Atomic.t
   ; external_mcp_count : int Atomic.t
   ; agent_internal_count : int Atomic.t
-  ; inline_dispatch_count : int Atomic.t
   ; last_assignment_id : string option Atomic.t
   }
 
@@ -116,7 +113,6 @@ let get_or_create_stats tool_name =
           ; total_duration_ms = Atomic.make 0
           ; external_mcp_count = Atomic.make 0
           ; agent_internal_count = Atomic.make 0
-          ; inline_dispatch_count = Atomic.make 0
           ; last_assignment_id = Atomic.make None
           }
         in
@@ -136,8 +132,7 @@ let record_call
   Atomic.incr stats.call_count;
   (match source with
    | External_mcp -> Atomic.incr stats.external_mcp_count
-   | Agent_internal -> Atomic.incr stats.agent_internal_count
-   | Inline_dispatch -> Atomic.incr stats.inline_dispatch_count);
+   | Agent_internal -> Atomic.incr stats.agent_internal_count);
   if success then Atomic.incr stats.success_count else Atomic.incr stats.failure_count;
   Atomic.set stats.last_called_at (Time_compat.now ());
   ignore (Atomic.fetch_and_add stats.total_duration_ms duration_ms);
@@ -234,7 +229,6 @@ let stats_to_json (name, (stats : call_stats)) : Yojson.Safe.t =
       , `Assoc
           [ "external_mcp", `Int (Atomic.get stats.external_mcp_count)
           ; "agent_internal", `Int (Atomic.get stats.agent_internal_count)
-          ; "inline_dispatch", `Int (Atomic.get stats.inline_dispatch_count)
           ] )
     ]
 ;;
@@ -299,7 +293,6 @@ let warm_up (stats_by_tool : (string * warm_up_stats) list) : int =
              ; total_duration_ms = Atomic.make 0
              ; external_mcp_count = Atomic.make 0
              ; agent_internal_count = Atomic.make 0
-             ; inline_dispatch_count = Atomic.make 0
              ; last_assignment_id = Atomic.make None
              };
            Stdlib.incr count))

--- a/lib/tool/tool_registry.mli
+++ b/lib/tool/tool_registry.mli
@@ -11,7 +11,6 @@
 type call_source =
   | External_mcp
   | Agent_internal
-  | Inline_dispatch
 
 type call_stats = {
   call_count : int Atomic.t;
@@ -21,7 +20,6 @@ type call_stats = {
   total_duration_ms : int Atomic.t;
   external_mcp_count : int Atomic.t;
   agent_internal_count : int Atomic.t;
-  inline_dispatch_count : int Atomic.t;
   last_assignment_id : string option Atomic.t;
 }
 

--- a/lib/tool_schemas/tool_schemas_inline.ml
+++ b/lib/tool_schemas/tool_schemas_inline.ml
@@ -1,10 +1,10 @@
-(** MCP tool schemas for inline-dispatched tools.
+(** MCP tool schemas for MCP-runtime tools.
     Split into sub-modules by functional group. *)
 
 (* RFC-0057 PR-2d: inline_workspace tools (masc_start/broadcast/messages)
    moved to Tool_descriptors_gen. They flow through
    Tool_schemas_misc.schemas, but downstream consumers still identify
-   inline-dispatched tools by membership in this list — so we re-include
+   MCP-runtime tools by membership in this list — so we re-include
    them here by filtering Tool_schemas_misc.schemas to the inline_workspace
    names. *)
 let inline_workspace_codegen_names =

--- a/lib/tool_schemas/tool_schemas_inline.mli
+++ b/lib/tool_schemas/tool_schemas_inline.mli
@@ -1,4 +1,4 @@
-(** MCP tool schemas for inline-dispatched tools (facade).
+(** MCP tool schemas for MCP-runtime tools (facade).
 
     Concatenates the [inline_workspace] subset of {!Tool_schemas_misc} (six
     [masc_*] names: start/join/leave/broadcast/messages/who, moved out

--- a/lib/tool_schemas/tool_schemas_inline_episodes.mli
+++ b/lib/tool_schemas/tool_schemas_inline_episodes.mli
@@ -1,4 +1,4 @@
-(** Tool schemas for inline-dispatched episode tools.
+(** Tool schemas for MCP-runtime episode tools.
 
     Currently empty — episode tools have been pruned from the inline
     dispatch surface. The module remains as a registration slot for

--- a/lib/tool_schemas/tool_schemas_workspace_core.ml
+++ b/lib/tool_schemas/tool_schemas_workspace_core.ml
@@ -2,7 +2,7 @@
 
     Only schemas dispatched by Tool_workspace remain here.
     Other schemas have been moved to their owning modules:
-      Tool_inline_dispatch (via Tool_schemas_inline) *)
+      Mcp_tool_runtime (via Tool_schemas_inline) *)
 
 open Masc_domain
 

--- a/lib/workspace/workspace_task_capacity.mli
+++ b/lib/workspace/workspace_task_capacity.mli
@@ -4,7 +4,7 @@
     By living in [lib/workspace/], the cap helpers are reachable from all 5 task
     creation entrypoints without violating layering (workspace ← keeper, but
     keeper ↛ workspace-callers like [tool_task], [task_dispatch],
-    [tool_inline_dispatch_workspace], [operator/operator_control]).
+    [mcp_tool_runtime_workspace], [operator/operator_control]).
 
     The cap rejects creation of a 4th open task linked to the same
     [goal_id]. Tasks with no [goal_id] (orphan tasks) are not capped. *)

--- a/lib/workspace/workspace_utils_backend_setup.ml
+++ b/lib/workspace/workspace_utils_backend_setup.ml
@@ -387,7 +387,7 @@ let build_default_config base_path =
   sync_test_base_path_env resolved_path;
   let backend_config = backend_config_for resolved_path in
   (* #10919: this factory is invoked per-tool-dispatch (8 call sites:
-     mcp_server_eio_call_tool, inline_dispatch_workspace,
+     mcp_server_eio_call_tool, mcp_tool_runtime_workspace,
      keeper_rollover, ...) — 1745 inits / 2 days = 3490 INFO events
      for what is conceptually a static config.  Demote the success
      path to DEBUG; the failure / fallback paths below stay at

--- a/scripts/lint/exhaustive-guard.allowlist
+++ b/scripts/lint/exhaustive-guard.allowlist
@@ -827,10 +827,10 @@ lib/tool_workspace.ml:283
 lib/tool_workspace.ml:797
 lib/tool_workspace.ml:823
 lib/tool_help_registry.ml:231
-lib/tool_inline_dispatch_extra.ml:57
-lib/tool_inline_dispatch_extra.ml:451
-lib/tool_inline_dispatch.ml:235
-lib/tool_inline_dispatch.ml:253
+lib/mcp_tool_runtime_board.ml:57
+lib/mcp_tool_runtime_board.ml:451
+lib/mcp_tool_runtime.ml:235
+lib/mcp_tool_runtime.ml:253
 lib/tool_input_validation.ml:82
 lib/tool_keeper.ml:861
 lib/tool_keeper.ml:909

--- a/test/dune
+++ b/test/dune
@@ -1790,7 +1790,7 @@
 
 ; RFC-0084 host-config-cleanup-D — agent runtime root migration.
 ; Pins 0 occurrences of /tmp/.masc_agent[_mcp]_<sid> literals
-; across mcp_server_eio_execute.ml + tool_inline_dispatch_workspace.ml
+; across mcp_server_eio_execute.ml + mcp_tool_runtime_workspace.ml
 ; and exactly 1 Host_config.host binding per module.
 
 (test

--- a/test/test_board_author_identity_10297.ml
+++ b/test/test_board_author_identity_10297.ml
@@ -28,7 +28,7 @@
 
 open Alcotest
 
-module D = Masc.Tool_inline_dispatch_extra
+module D = Masc.Mcp_tool_runtime_board
 module Prom = Masc.Prometheus
 
 (* --- helpers ----------------------------------------------------- *)

--- a/test/test_pr_d_agent_runtime_migration.ml
+++ b/test/test_pr_d_agent_runtime_migration.ml
@@ -41,7 +41,7 @@ let count_across_files ~files ~needle =
 
 let consumer_files =
   [ "lib/mcp_server_eio_execute.ml"
-  ; "lib/tool_inline_dispatch_workspace.ml"
+  ; "lib/mcp_tool_runtime_workspace.ml"
   ]
 ;;
 

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -489,7 +489,7 @@ let test_inline_board_post_author_rewrites_caller_claim () =
       ]
   in
   let normalized =
-    Tool_inline_dispatch_extra.ensure_board_post_author
+    Mcp_tool_runtime_board.ensure_board_post_author
       ~agent_name:"keeper-velvet-hammer-agent" args
   in
   Alcotest.(check string) "author from ctx" "velvet-hammer"
@@ -512,7 +512,7 @@ let test_inline_board_post_author_accepts_matching_alias () =
       ]
   in
   let normalized =
-    Tool_inline_dispatch_extra.ensure_board_post_author
+    Mcp_tool_runtime_board.ensure_board_post_author
       ~agent_name:"keeper-analyst-agent" args
   in
   Alcotest.(check string) "author canonical" "analyst"
@@ -1122,47 +1122,47 @@ let test_board_curation_submit_roundtrips_to_read () =
     "Board has one high-priority routing item."
     Yojson.Safe.Util.(read_json |> member "summary" |> to_string)
 
-let inline_board_dispatch ~sw ~clock name args =
+let mcp_runtime_board_dispatch ~sw ~clock name args =
   let state = Mcp_server.create_state ~base_path:_test_base_path in
-  Tool_inline_dispatch_extra.dispatch ~config:state.Mcp_server.workspace_config
-    ~agent_name:"inline-curator" ~arguments:args ~state ~sw ~clock ~name
+  Mcp_tool_runtime_board.dispatch ~config:state.Mcp_server.workspace_config
+    ~agent_name:"mcp-runtime-curator" ~arguments:args ~state ~sw ~clock ~name
     ~start_time:(Unix.gettimeofday ())
 
-let require_inline_result ~sw ~clock name args =
-  match inline_board_dispatch ~sw ~clock name args with
+let require_mcp_runtime_result ~sw ~clock name args =
+  match mcp_runtime_board_dispatch ~sw ~clock name args with
   | Some result -> ((Tool_result.is_success result), (Tool_result.message result))
-  | None -> Alcotest.failf "%s not routed by inline board dispatch" name
+  | None -> Alcotest.failf "%s not routed by MCP runtime board dispatch" name
 
-let test_board_curation_inline_dispatch_routes_read_and_submit () =
+let test_board_curation_mcp_runtime_routes_read_and_submit () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
   Eio.Switch.run @@ fun sw ->
   let clock = Eio.Stdenv.clock env in
   let read_ok, read_body =
-    require_inline_result ~sw ~clock "masc_board_curation_read" (make_args [])
+    require_mcp_runtime_result ~sw ~clock "masc_board_curation_read" (make_args [])
   in
-  Alcotest.(check bool) "inline curation read ok" true read_ok;
-  Alcotest.(check string) "inline curation read empty" "null" read_body;
+  Alcotest.(check bool) "MCP runtime curation read ok" true read_ok;
+  Alcotest.(check string) "MCP runtime curation read empty" "null" read_body;
   let submit_ok, submit_body =
-    require_inline_result ~sw ~clock "masc_board_curation_submit"
+    require_mcp_runtime_result ~sw ~clock "masc_board_curation_submit"
       (make_args
          [
-           ("submitted_by", `String "inline-curator");
-           ("summary", `String "Inline MCP curation route works.");
+           ("submitted_by", `String "mcp-runtime-curator");
+           ("summary", `String "MCP runtime curation route works.");
            ("rationale", `String "Pin schema-to-dispatch curation routing");
          ])
   in
-  Alcotest.(check bool) "inline curation submit ok" true submit_ok;
+  Alcotest.(check bool) "MCP runtime curation submit ok" true submit_ok;
   let submitted = Yojson.Safe.from_string submit_body in
-  Alcotest.(check string) "inline submitted_by persisted" "inline-curator"
+  Alcotest.(check string) "MCP runtime submitted_by persisted" "mcp-runtime-curator"
     Yojson.Safe.Util.(submitted |> member "submitted_by" |> to_string);
   let read2_ok, read2_body =
-    require_inline_result ~sw ~clock "masc_board_curation_read" (make_args [])
+    require_mcp_runtime_result ~sw ~clock "masc_board_curation_read" (make_args [])
   in
-  Alcotest.(check bool) "inline curation read after submit ok" true read2_ok;
-  Alcotest.(check string) "inline curation read after submit summary"
-    "Inline MCP curation route works."
+  Alcotest.(check bool) "MCP runtime curation read after submit ok" true read2_ok;
+  Alcotest.(check string) "MCP runtime curation read after submit summary"
+    "MCP runtime curation route works."
     Yojson.Safe.Util.(
       Yojson.Safe.from_string read2_body |> member "summary" |> to_string)
 
@@ -1852,9 +1852,9 @@ let () =
             `Quick test_board_dashboard_json_hides_unvoted_scores_when_blind;
           Alcotest.test_case "board dashboard json embeds contributor quality"
             `Quick test_board_dashboard_json_embeds_contributor_quality;
-          Alcotest.test_case "inline board post author rewrites caller claim"
+          Alcotest.test_case "MCP runtime board post author rewrites caller claim"
             `Quick test_inline_board_post_author_rewrites_caller_claim;
-          Alcotest.test_case "inline board post author accepts matching alias"
+          Alcotest.test_case "MCP runtime board post author accepts matching alias"
             `Quick test_inline_board_post_author_accepts_matching_alias;
         ] );
       ( "json_helpers",
@@ -1905,8 +1905,8 @@ let () =
             test_board_curation_read_empty_returns_json_null;
           Alcotest.test_case "curation submit roundtrips to read" `Quick
             test_board_curation_submit_roundtrips_to_read;
-          Alcotest.test_case "curation inline dispatch routes read and submit" `Quick
-            test_board_curation_inline_dispatch_routes_read_and_submit;
+          Alcotest.test_case "curation MCP runtime routes read and submit" `Quick
+            test_board_curation_mcp_runtime_routes_read_and_submit;
           Alcotest.test_case "accept automation reject system" `Quick
             test_post_create_accepts_automation_rejects_system;
           Alcotest.test_case "create empty content" `Quick test_post_create_empty_content;

--- a/test/test_tool_registry.ml
+++ b/test/test_tool_registry.ml
@@ -192,6 +192,11 @@ let () =
               (match by_source |> member "deprecated_alias" with
                | `Null -> true
                | _ -> false);
+            let removed_inline_source = "inline" ^ "_dispatch" in
+            check bool "legacy inline source removed" true
+              (match by_source |> member removed_inline_source with
+               | `Null -> true
+               | _ -> false);
             ())
         ; test_case "respects top_n" `Quick (fun () ->
             Tool_registry.reset ();

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -2184,11 +2184,11 @@ let () = test "rfc_0034_v2_task_dispatch_orphan_bypasses_cap" (fun () ->
            "task_dispatch orphan path returned Error: %s"
            (Masc_error.to_string err)))
 
-(* RFC-0034.v2 Test 3: Tool_inline_dispatch_workspace — verified through
+(* RFC-0034.v2 Test 3: Mcp_tool_runtime_workspace — verified through
    direct Workspace_task.add_task with the same [reject_if] hook the
-   inline dispatcher wires. Confirms the [rejection_for_add_task ?goal_id:None]
+   MCP runtime wires. Confirms the [rejection_for_add_task ?goal_id:None]
    call shape compiles AND is non-blocking for orphan tasks. *)
-let () = test "rfc_0034_v2_inline_dispatch_orphan_bypasses_cap" (fun () ->
+let () = test "rfc_0034_v2_mcp_runtime_orphan_bypasses_cap" (fun () ->
   let ctx = make_test_ctx () in
   let goal, _ =
     match Goal_store.upsert_goal ctx.config ~title:"RFC-0034 inline goal" () with
@@ -2216,11 +2216,11 @@ let () = test "rfc_0034_v2_inline_dispatch_orphan_bypasses_cap" (fun () ->
   then
     failwith
       (Printf.sprintf
-         "inline-dispatch orphan path should add, got: %s"
+         "MCP-runtime orphan path should add, got: %s"
          result))
 
 (* RFC-0034.v2 Test 4: operator_control task_inject — same shape as
-   inline dispatch. Pins that the orphan-task call site does not
+   MCP runtime. Pins that the orphan-task call site does not
    regress to a rejection. *)
 let () = test "rfc_0034_v2_operator_task_inject_orphan_bypasses_cap" (fun () ->
   let ctx = make_test_ctx () in

--- a/test/test_workspace_bind_fail_closed.ml
+++ b/test/test_workspace_bind_fail_closed.ml
@@ -6,7 +6,7 @@
 
     This test verifies the gate function at the unit level.  It does NOT call
     [handle_join] directly (which requires a full
-    [Tool_inline_dispatch_types.context] with Eio fiber infrastructure).
+    [Mcp_tool_runtime_types.context] with Eio fiber infrastructure).
 
     Note on persona path resolution: [normalize_all_names] uses
     [Config_dir_resolver.personas_dir_opt()] first, which can ignore


### PR DESCRIPTION
## Summary

- Rename the MCP server-local runtime modules from `Tool_inline_dispatch*` to `Mcp_tool_runtime*`.
- Update callers, tests, docs, dashboard comments, and exhaustive-guard allowlist references to the MCP runtime naming.
- Remove the unused `Inline_dispatch` / `inline_dispatch_count` source axis from `Tool_registry`.
- Add a registry test pinning that the legacy inline source key is absent from stats JSON.

## Verification

Passed:

- `git diff --check`
- `ocamlformat --check <changed .ml/.mli files>`
- `scripts/lint/tool-keeper-boundary-ratchet.sh --fail`
- `bash scripts/check-toml-syntax.sh`
- `rg -n "Inline_dispatch|inline_dispatch|tool_inline_dispatch|Tool_inline_dispatch|tool_inline_dispatch_|inline dispatch|inline-dispatch|inline dispatcher|inline-dispatched|MCP inline dispatch|MCP MCP" lib test docs dashboard scripts config bin .github` returned no matches.

Blocked by shared local opam pin drift:

- `scripts/check-oas-pin.sh --local-only` currently reports `agent_sdk` pinned to `oas#6807d1530ee6e1433dad4f8ce6fe5145a0fbc240`, while this branch expects `oas#8f74ef155198f928572f15975b981bd8a8f39170`.
- Focused Dune build with `MASC_SKIP_PIN_CHECK=1` fails in unrelated `Agent_sdk` API mismatch sites (`A2a`, `CompletionContractViolation`, `Completion_contract_violation_detail`) before reaching this change set.
- I attempted `scripts/opam-pin-external-deps.sh --install`; it can pin to this branch, but concurrent worktrees repin the shared switch immediately, so the local Dune check is not stable in this session.
