### PR TITLE
refactor(voice): remove dead elevenlabs_voice_ids lookup table

### DIFF
--- a/lib/voice/voice_bridge_core.ml
+++ b/lib/voice/voice_bridge_core.ml
@@ -320,12 +320,10 @@ let get_voice_for_agent agent_id =
     TTS Adapters
     ============================================ *)
 
-let elevenlabs_voice_ids = [
-  ("Sarah",  "EXAVITQu4vr4xnSDxMaL");
-  ("Roger",  "CwhRBWXzGAHq8TQ4Fs17");
-  ("George", "JBFqnCBsd6RMkjVDRZzb");
-  ("Laura",  "FGY2WhTYpPnrIDTdsKH5");
-]
+(* elevenlabs_voice_ids removed: dead code. Voice name → ID resolution
+   is config-driven via Voice_config.load () → agent_voices. The
+   ElevenLabs API accepts voice names directly, making a hardcoded
+   lookup table unnecessary. *)
 
 let trim_opt = Env_config_core.trim_opt
 

--- a/lib/voice/voice_bridge_core.mli
+++ b/lib/voice/voice_bridge_core.mli
@@ -4,7 +4,7 @@
     Internal helpers ([log_prefix], [split_path_env],
     [find_executable_in_path], [local_playback_argvs],
     [record_playback], the dedup [last_playback] state, the playback
-    mutex, the [elevenlabs_voice_ids] constant table, [trim_opt],
+    mutex, [trim_opt],
     [resolved_base_path_opt], [strip_provider_metadata], and
     [provider_metadata_keys]) are hidden — callers consume the
     public configuration / URI / playback / metadata-projection


### PR DESCRIPTION
## Why
`elevenlabs_voice_ids` was a hardcoded lookup table mapping 4 voice names to ElevenLabs IDs, but it was **dead code** — never referenced by any caller. Voice name → ID resolution is already config-driven via `Voice_config.load()` → `agent_voices`, and the ElevenLabs API accepts voice names directly.

Hardcoding voice IDs in `.ml` means every voice change in ElevenLabs requires recompilation. Config-driven resolution is the correct pattern.

## Changes
- Removed `elevenlabs_voice_ids` from `voice_bridge_core.ml`
- Updated `.mli` docstring to remove reference

## Stacked PR
Base PR for #20152 (cleanup redundant voice references in keeper_tool_policy)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
