### PR TITLE
refactor(voice): remove redundant voice tools from keeper_default_model_tools

### DIFF
--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -526,12 +526,11 @@ let required_hints_of_schema (schema : Yojson.Safe.t) : string =
 
 (** Lookup tool description by name from all available schema sources.
     Returns [Some first_sentence] + optional enum/required hints if found, [None] otherwise.
-    Searches shard-resolved tools, inline schemas, injected masc_* schemas,
-    code-write schemas, voice tools, and tool_search schema. *)
+    Searches shard-resolved tools (voice included via shard), inline schemas,
+    injected masc_* schemas, and tool_search schema. *)
 let tool_hint_of (name : string) : string option =
   let all_schemas =
     Tool_shard.keeper_model_tools
-    @ Keeper_tool_registry.keeper_voice_tool_schemas
     @ [ Keeper_tool_registry.keeper_tool_search_schema ]
     @ Tool_schemas_inline.schemas
     @ masc_schemas_snapshot ()

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -354,7 +354,10 @@ let keeper_universe_masc_tool_schemas (meta : keeper_meta) : Masc_domain.tool_sc
     filter_by_universe ~lookup schema.name)
 
 let keeper_default_model_tools (_meta : keeper_meta) : Masc_domain.tool_schema list =
-  keeper_model_tools @ keeper_voice_tool_schemas
+  (* keeper_voice_tool_schemas removed: voice tools already arrive via
+     Tool_shard.all_keeper_tool_schemas in keeper_base_candidate_tool_names,
+     so adding them here was redundant (dedupe masked the overlap). *)
+  keeper_model_tools
   @ [ keeper_tool_search_schema ]
 
 (** Recovery minimum tools: non-removable shards only.

--- a/lib/voice/voice_bridge_core.ml
+++ b/lib/voice/voice_bridge_core.ml
@@ -320,12 +320,10 @@ let get_voice_for_agent agent_id =
     TTS Adapters
     ============================================ *)
 
-let elevenlabs_voice_ids = [
-  ("Sarah",  "EXAVITQu4vr4xnSDxMaL");
-  ("Roger",  "CwhRBWXzGAHq8TQ4Fs17");
-  ("George", "JBFqnCBsd6RMkjVDRZzb");
-  ("Laura",  "FGY2WhTYpPnrIDTdsKH5");
-]
+(* elevenlabs_voice_ids removed: dead code. Voice name → ID resolution
+   is config-driven via Voice_config.load () → agent_voices. The
+   ElevenLabs API accepts voice names directly, making a hardcoded
+   lookup table unnecessary. *)
 
 let trim_opt = Env_config_core.trim_opt
 

--- a/lib/voice/voice_bridge_core.mli
+++ b/lib/voice/voice_bridge_core.mli
@@ -4,7 +4,7 @@
     Internal helpers ([log_prefix], [split_path_env],
     [find_executable_in_path], [local_playback_argvs],
     [record_playback], the dedup [last_playback] state, the playback
-    mutex, the [elevenlabs_voice_ids] constant table, [trim_opt],
+    mutex, [trim_opt],
     [resolved_base_path_opt], [strip_provider_metadata], and
     [provider_metadata_keys]) are hidden — callers consume the
     public configuration / URI / playback / metadata-projection


### PR DESCRIPTION
## Why
Voice tool schemas were redundantly referenced in two places in `keeper_tool_policy.ml`:
1. `keeper_default_model_tools` — voice tools already arrive via `Tool_shard.all_keeper_tool_schemas` in `keeper_base_candidate_tool_names`
2. `tool_hint_of` — voice schemas already included via `Tool_shard.keeper_model_tools`

## Changes
- Removed `keeper_voice_tool_schemas` from `keeper_default_model_tools`
- Removed `Keeper_tool_registry.keeper_voice_tool_schemas` from `tool_hint_of` lookup
- Updated comments explaining the removals

## Stacked on
#20151 (base: remove dead elevenlabs_voice_ids)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
