### PR TITLE
[codex] add interfaces for extracted helper modules

### DIFF
--- a/lib/auth/auth_credential_base.mli
+++ b/lib/auth/auth_credential_base.mli
@@ -1,0 +1,82 @@
+(** Credential storage and auth config helpers. *)
+
+open Masc_domain
+
+val generate_token : unit -> string
+val sha256_hash : string -> string
+
+val auth_dir : string -> string
+val agents_dir : string -> string
+val workspace_secret_file : string -> string
+val auth_config_file : string -> string
+val initial_admin_file : string -> string
+val internal_keeper_token_hash_file : string -> string
+val internal_keeper_token_env_key : string
+
+val file_exists : string -> bool
+val read_text_file : string -> string
+val write_text_file : string -> string -> unit
+val chmod : string -> int -> unit
+val read_dir : string -> string array
+val remove_file : string -> unit
+
+val ensure_auth_dirs : string -> unit
+val write_initial_admin : string -> string -> unit
+val save_private_text_file : string -> string -> unit
+
+val verify_internal_keeper_token : string -> token:string -> bool
+val ensure_internal_keeper_token : string -> string
+val read_initial_admin : string -> string option
+
+val persist_auth_config : string -> auth_config -> unit
+val load_auth_config : string -> auth_config
+val save_auth_config : string -> auth_config -> unit
+
+val credential_file : string -> string -> string
+val is_generated_nickname_shape : string -> bool
+val keeper_transport_alias_stable_name : string -> string option
+val extract_agent_type_prefix : string -> string option
+val credential_agent_name : string -> string
+
+val load_redirect_target : string -> string -> string option
+val load_credential : string -> string -> agent_credential option
+
+type load_credential_error =
+  | Credential_missing of { ctx_agent_name : string }
+  | Credential_mismatch of
+      { ctx_agent_name : string
+      ; resolved_credential_stem : string
+      }
+
+val pp_load_credential_error :
+  Format.formatter -> load_credential_error -> unit
+
+val show_load_credential_error : load_credential_error -> string
+
+val load_credential_of :
+  string ->
+  ctx_agent_name:string ->
+  resolved_credential_stem:string ->
+  (agent_credential, load_credential_error) result
+
+val save_credential : string -> agent_credential -> unit
+
+val ensure_credential_alias :
+  string ->
+  canonical_name:string ->
+  alias_name:string ->
+  (unit, masc_error) result
+
+val load_raw_token : string -> agent_name:string -> string option
+val persist_raw_token : string -> agent_name:string -> string -> unit
+val delete_credential : string -> string -> unit
+val list_credentials : string -> agent_credential list
+
+val invalidate_credential_index_cache : string -> unit
+
+val credential_token_index :
+  string -> (string, agent_credential list) Hashtbl.t
+
+val group_credentials_by_token : string -> (string * agent_credential list) list
+val token_hash_prefix_of : string -> string
+val audit_token_uniqueness : string -> (string * string list) list

--- a/lib/auth/auth_credential_token.mli
+++ b/lib/auth/auth_credential_token.mli
@@ -1,0 +1,51 @@
+(** Token operations for MASC authentication. *)
+
+open Masc_domain
+
+val find_credential_by_token :
+  string -> token:string -> (agent_credential, masc_error) result
+
+val resolve_agent_from_token :
+  string -> token:string -> (string, masc_error) result
+
+val save_raw_token_credential :
+  string ->
+  agent_name:string ->
+  role:agent_role ->
+  raw_token:string ->
+  (agent_credential, masc_error) result
+
+val save_raw_token_credential_without_expiry :
+  string ->
+  agent_name:string ->
+  role:agent_role ->
+  raw_token:string ->
+  (agent_credential, masc_error) result
+
+val create_token :
+  string ->
+  agent_name:string ->
+  role:agent_role ->
+  (string * agent_credential, masc_error) result
+
+val create_token_without_expiry :
+  string ->
+  agent_name:string ->
+  role:agent_role ->
+  (string * agent_credential, masc_error) result
+
+type rotation_outcome =
+  { token_hash_prefix : string
+  ; rotated_agents : (string * (unit, masc_error) result) list
+  }
+
+val rotate_shared_tokens : string -> rotation_outcome list
+
+val rotate_shared_tokens_for_agents :
+  string -> agent_names:string list -> rotation_outcome list
+
+val verify_token :
+  string ->
+  agent_name:string ->
+  token:string ->
+  (agent_credential, masc_error) result

--- a/lib/dune
+++ b/lib/dune
@@ -28,14 +28,12 @@
  keeper_turn_metrics_snapshot_failure_site
  keeper_metric_emit_dropped_site
  keeper_post_turn_wirein_failure_site
- silent_dashboard_actor_outcome
  sse_jsonrpc_filter
  keeper_tool_call_log_context
 
  board_prometheus_hooks
  workspace_prometheus_hooks
 
- keeper_persona_authoring_contract
  keeper_types_profile_sandbox
  keeper_types_profile_persona keeper_types_profile_persona_defaults
  keeper_types_profile_oas_env
@@ -285,6 +283,10 @@
      masc.runtime
      masc.masc_event_bus
      masc.provider_tool_support
+     masc.keeper_metrics
+     masc.pool_metrics
+     masc.json_field
+     masc.lockfree_atomic
      masc.keeper_internal_error
      masc.prometheus
      masc.auth

--- a/lib/fd_accountant/dune
+++ b/lib/fd_accountant/dune
@@ -4,6 +4,10 @@
  (name fd_accountant)
  (public_name masc.fd_accountant)
  (wrapped false)
+ (flags
+  :standard
+  -open
+  Masc_lockfree_atomic)
  (libraries
   eio
   eio.unix
@@ -15,6 +19,7 @@
   masc.fs_compat
   masc.dated_jsonl
   masc.cdal_runtime
-  masc.masc_process)
+  masc.masc_process
+  masc.lockfree_atomic)
  (preprocess
   (pps ppx_deriving_yojson ppx_deriving.show ppx_deriving.eq)))

--- a/lib/json_field.ml
+++ b/lib/json_field.ml
@@ -1,0 +1,1 @@
+include Masc_json_field.Json_field

--- a/lib/json_field/dune
+++ b/lib/json_field/dune
@@ -1,0 +1,6 @@
+(include_subdirs no)
+
+(library
+ (name masc_json_field)
+ (public_name masc.json_field)
+ (libraries yojson masc.masc_log))

--- a/lib/keeper_internal_error/dune
+++ b/lib/keeper_internal_error/dune
@@ -4,6 +4,10 @@
  (name keeper_internal_error)
  (public_name masc.keeper_internal_error)
  (wrapped false)
- (libraries yojson agent_sdk masc.masc_core masc.masc_types masc.prometheus)
+ (flags
+  :standard
+  -open
+  Masc_json_field)
+ (libraries yojson agent_sdk masc.masc_core masc.masc_types masc.prometheus masc.json_field)
  (preprocess
   (pps ppx_deriving_yojson ppx_deriving.show ppx_deriving.eq)))

--- a/lib/keeper_metrics.ml
+++ b/lib/keeper_metrics.ml
@@ -1,0 +1,1 @@
+include Masc_keeper_metrics.Keeper_metrics

--- a/lib/keeper_metrics/dune
+++ b/lib/keeper_metrics/dune
@@ -1,0 +1,5 @@
+(include_subdirs no)
+
+(library
+ (name masc_keeper_metrics)
+ (public_name masc.keeper_metrics))

--- a/lib/lockfree_atomic.ml
+++ b/lib/lockfree_atomic.ml
@@ -1,0 +1,1 @@
+include Masc_lockfree_atomic.Lockfree_atomic

--- a/lib/lockfree_atomic/dune
+++ b/lib/lockfree_atomic/dune
@@ -1,0 +1,5 @@
+(include_subdirs no)
+
+(library
+ (name masc_lockfree_atomic)
+ (public_name masc.lockfree_atomic))

--- a/lib/pool_metrics.ml
+++ b/lib/pool_metrics.ml
@@ -1,0 +1,1 @@
+include Masc_pool_metrics.Pool_metrics

--- a/lib/pool_metrics/dune
+++ b/lib/pool_metrics/dune
@@ -1,0 +1,6 @@
+(include_subdirs no)
+
+(library
+ (name masc_pool_metrics)
+ (public_name masc.pool_metrics)
+ (libraries masc.http_client))

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -1,0 +1,1 @@
+include Masc_prometheus.Prometheus

--- a/lib/prometheus/dune
+++ b/lib/prometheus/dune
@@ -4,6 +4,12 @@
  (name masc_prometheus)
  (public_name masc.prometheus)
  (wrapped false)
+ (flags
+  :standard
+  -open
+  Masc_keeper_metrics
+  -open
+  Masc_pool_metrics)
  (libraries
   yojson
   unix
@@ -15,6 +21,12 @@
   eio
   masc.masc_log
   agent_sdk
-  agent_sdk.llm_provider)
+  agent_sdk.llm_provider
+  masc.keeper_metrics
+  masc.pool_metrics
+  masc.config_dir_resolver
+  masc.fs_compat
+  masc.dated_jsonl
+  mtime.clock.os)
  (preprocess
   (pps ppx_deriving_yojson ppx_deriving.show ppx_deriving.eq)))

--- a/lib/prometheus/prometheus_format.mli
+++ b/lib/prometheus/prometheus_format.mli
@@ -1,0 +1,3 @@
+(** Text formatting helpers for Prometheus exposition. *)
+
+val labels_to_string : (string * string) list -> string

--- a/lib/prometheus/prometheus_key.mli
+++ b/lib/prometheus/prometheus_key.mli
@@ -1,0 +1,6 @@
+(** Stable metric store keys. *)
+
+type label = string * string
+
+val labels_key : label list -> string
+val metric_key : string -> label list -> string

--- a/lib/prometheus/prometheus_process.mli
+++ b/lib/prometheus/prometheus_process.mli
@@ -1,0 +1,9 @@
+(** Process-level Prometheus metrics. *)
+
+val fd_warn_threshold : int
+val approximate_open_fd_count : unit -> int
+
+val update_fd_gauges :
+  set_gauge:(string -> float -> unit) ->
+  metric_open_fds:string ->
+  unit

--- a/test/dune
+++ b/test/dune
@@ -123,7 +123,6 @@
   test_auth_load_credential_of
   test_keeper_wake_telemetry
   test_keeper_timing
-  test_token_count
   test_keeper_chat_store
   test_keeper_runtime_trust_snapshot
   test_keeper_tool_audit_snapshot
@@ -376,7 +375,6 @@
   test_auth_load_credential_of
   test_keeper_wake_telemetry
   test_keeper_timing
-  test_token_count
   test_keeper_chat_store
   test_keeper_runtime_trust_snapshot
   test_keeper_tool_audit_snapshot
@@ -772,7 +770,6 @@
   test_goal_verification
   test_string_util
   test_system_error_class
-  test_provider_error_class
   test_set_util
   test_board_core_payload
   test_board_attachment_meta
@@ -955,7 +952,6 @@
   test_goal_verification
   test_string_util
   test_system_error_class
-  test_provider_error_class
   test_set_util
   test_board_core_payload
   test_board_attachment_meta

--- a/test/test_json_field.ml
+++ b/test/test_json_field.ml
@@ -7,7 +7,7 @@
     confirm the new module preserves the diagnostic. *)
 
 open Masc
-module J = Json_field
+module J = Masc.Json_field
 
 let assoc fields : Yojson.Safe.t = `Assoc fields
 


### PR DESCRIPTION
## Summary
- Add missing interfaces for extracted auth/prometheus helpers so structure ratchet no longer reports public .ml files without .mli.
- Restore the extracted OCaml leaf build graph for keeper_metrics, pool_metrics, json_field, and lockfree_atomic with root aliases preserving Masc.* callers.
- Remove stale Dune references to deleted/moved modules and dead tests left by the main refactor.

## Validation
- ocamlformat --check lib/keeper_metrics.ml lib/pool_metrics.ml lib/json_field.ml lib/lockfree_atomic.ml test/test_json_field.ml lib/auth/auth_credential_base.mli lib/auth/auth_credential_token.mli lib/prometheus/prometheus_format.mli lib/prometheus/prometheus_key.mli lib/prometheus/prometheus_process.mli
- git diff --check origin/main..HEAD
- scripts/ocaml-structure-ratchet.sh
- scripts/check-pr-hygiene.sh --base origin/main --head HEAD

## Local build note
- Focused local Dune build could not complete because another worktree held /tmp/me-dune-local.lock. The branch was pushed for GitHub CI compile validation.