### PR TITLE
[codex] Remove keeper default model tools facade

### DIFF
--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -353,10 +353,6 @@ let keeper_universe_masc_tool_schemas (meta : keeper_meta) : Masc_domain.tool_sc
   |> List.filter (fun (schema : Masc_domain.tool_schema) ->
     filter_by_universe ~lookup schema.name)
 
-let keeper_default_model_tools (_meta : keeper_meta) : Masc_domain.tool_schema list =
-  keeper_model_tools @ keeper_voice_tool_schemas
-  @ [ keeper_tool_search_schema ]
-
 (** Recovery minimum tools: non-removable shards only.
     Used in Failing phase to guarantee minimum tool availability.
     Phase B2: TLA+ RecoveryFloorMaintained invariant.
@@ -436,7 +432,9 @@ let keeper_tool_search_scope = keeper_universe_tool_names
     depending on the caller's access scope. *)
 let all_keeper_schemas ~(masc_schemas_fn : keeper_meta -> Masc_domain.tool_schema list)
     (meta : keeper_meta) : Masc_domain.tool_schema list =
-  (keeper_default_model_tools meta)
+  keeper_model_tools
+  @ keeper_voice_tool_schemas
+  @ [ keeper_tool_search_schema ]
   @ (masc_schemas_fn meta)
 
 (** Filter schemas by a set of allowed names.  Uses Hashtbl for O(1) lookup

--- a/lib/keeper/keeper_tool_policy.mli
+++ b/lib/keeper/keeper_tool_policy.mli
@@ -80,9 +80,6 @@ val keeper_masc_tool_names : keeper_meta -> string list
 (** Universe (policy-independent) MASC tool schemas for BM25 indexing. *)
 val keeper_universe_masc_tool_schemas : keeper_meta -> Masc_domain.tool_schema list
 
-(** Default model tools (keeper_model_tools + voice + tool_search). *)
-val keeper_default_model_tools : keeper_meta -> Masc_domain.tool_schema list
-
 (** {1 E6: .masc/ Write Protection} *)
 
 (** Check if a path is in the keeper-writable whitelist.

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -286,7 +286,7 @@ let injected_masc_tool_names () =
 
 (** SSOT schema for keeper_tool_search.  Defined here because this is
     the keeper tool registry — the canonical owner of keeper-internal tool
-    metadata.  Consumed by [keeper_tool_policy.keeper_default_model_tools]. *)
+    metadata. *)
 let keeper_tool_search_schema : Masc_domain.tool_schema =
   { name = Keeper_tool_name.to_string Keeper_tool_name.Tool_search
   ; description =

--- a/lib/keeper/keeper_tool_registry.mli
+++ b/lib/keeper/keeper_tool_registry.mli
@@ -82,6 +82,5 @@ val masc_schemas_snapshot : unit -> Masc_domain.tool_schema list
 val injected_masc_tool_names : unit -> string list
 
 (** SSOT schema for [keeper_tool_search]. Defined here because this
-    module is the canonical owner of keeper-internal tool metadata.
-    Consumed by [Keeper_tool_policy.keeper_default_model_tools]. *)
+    module is the canonical owner of keeper-internal tool metadata. *)
 val keeper_tool_search_schema : Masc_domain.tool_schema

--- a/test/test_tool_shard_coverage.ml
+++ b/test/test_tool_shard_coverage.ml
@@ -178,9 +178,8 @@ let test_tools_of_shards_unknown_ignored () =
 
 let test_keeper_model_tools_count () =
   let tools = Tool_shard.keeper_model_tools in
-  (* keeper_model_tools = default shards plus unsharded default tools.
-     Standalone keeper schemas (keeper_tool_search) are added downstream
-     in keeper_tool_policy.keeper_default_model_tools, not here. *)
+  (* keeper_model_tools = default shards plus unsharded execute tools.
+     Standalone keeper schemas are assembled by keeper_tool_policy, not here. *)
   let expected =
     Tool_shard.tools_of_shards Tool_shard.default_shard_names
 	    @ Tool_shard_types.typed_execute_tools


### PR DESCRIPTION
## Summary

Removes the dead `Keeper_tool_policy.keeper_default_model_tools` facade from the keeper tool policy surface.

The remaining schema assembly now happens directly inside the private `all_keeper_schemas` helper, while the public `.mli` export and stale comments that referred to the removed facade are gone.

## Product impact

No runtime behavior change intended. This narrows the keeper tool policy API by deleting a metadata-only helper that no longer carried independent meaning.

## Evidence

- `rg "keeper_default_model_tools|default_model_tools|Default model tools" .` -> no matches
- `git diff --check` -> passed
- `ocamlformat --check lib/keeper/keeper_tool_policy.ml lib/keeper/keeper_tool_policy.mli lib/keeper/keeper_tool_registry.ml lib/keeper/keeper_tool_registry.mli test/test_tool_shard_coverage.ml` -> passed
- `scripts/dune-local.sh build lib/masc.cmxa test/test_tool_shard_coverage.exe` -> blocked by existing missing Dune modules on current main: `Silent_dashboard_actor_outcome`, `Test_token_count`, `Test_provider_error_class`

## Direct evidence

schema_version: 1
direct_ratio: 4/4
provenance: direct

All evidence above was produced from the local worktree after rebasing onto current `origin/main`.

## Review evidence

Draft PR for review. No external reviewer evidence yet.

## Linked issue

None.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`codex/remove-keeper-default-model-tools-20260605` → `main` · 1 commit(s) · synced 2026-06-05T00:49:55Z

| sha | subject | date |
|---|---|---|
| `a6b1d8933` | refactor(keeper): remove default model tools facade | 2026-06-04 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->