### PR TITLE
Improve WebFetch response handling

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -28,14 +28,12 @@
  keeper_turn_metrics_snapshot_failure_site
  keeper_metric_emit_dropped_site
  keeper_post_turn_wirein_failure_site
- silent_dashboard_actor_outcome
  sse_jsonrpc_filter
  keeper_tool_call_log_context
 
  board_prometheus_hooks
  workspace_prometheus_hooks
 
- keeper_persona_authoring_contract
  keeper_types_profile_sandbox
  keeper_types_profile_persona keeper_types_profile_persona_defaults
  keeper_types_profile_oas_env

--- a/lib/tool_local_runtime_http.ml
+++ b/lib/tool_local_runtime_http.ml
@@ -21,16 +21,99 @@ let default_timeout_sec = 10
 
 include Tool_local_runtime_core
 
+type http_get_response =
+  { http_status : int option
+  ; effective_url : string option
+  ; redirect_url : string option
+  ; content_type : string option
+  ; downloaded_bytes : int option
+  ; body : string
+  }
+
+let curl_meta_marker = "\n--MASC-CURL-META--\n"
+
+let curl_write_out =
+  curl_meta_marker
+  ^ "%{http_code}\n%{url_effective}\n%{redirect_url}\n%{content_type}\n%{size_download}"
+
+let trim_to_option raw =
+  let trimmed = String.trim raw in
+  if String.equal trimmed "" then None else Some trimmed
+
+let find_last_substring ~needle haystack =
+  let needle_len = String.length needle in
+  let haystack_len = String.length haystack in
+  if needle_len = 0 || needle_len > haystack_len then None
+  else
+    let rec loop idx best =
+      if idx > haystack_len - needle_len then best
+      else
+        let best =
+          if String.equal (String.sub haystack idx needle_len) needle then Some idx
+          else best
+        in
+        loop (idx + 1) best
+    in
+    loop 0 None
+
+let parse_downloaded_bytes raw =
+  match parse_int_opt (String.trim raw) with
+  | Some _ as value -> value
+  | None -> (
+      match Stdlib.float_of_string_opt (String.trim raw) with
+      | Some value -> Some (int_of_float value)
+      | None -> None)
+
+let response_of_payload_and_meta payload meta =
+  let lines = String.split_on_char '\n' meta in
+  match lines with
+  | status_raw :: effective_url_raw :: redirect_url_raw :: content_type_raw :: size_raw :: _ ->
+      { http_status = parse_int_opt (String.trim status_raw)
+      ; effective_url = trim_to_option effective_url_raw
+      ; redirect_url = trim_to_option redirect_url_raw
+      ; content_type = trim_to_option content_type_raw
+      ; downloaded_bytes = parse_downloaded_bytes size_raw
+      ; body = payload
+      }
+  | _ ->
+      { http_status = None
+      ; effective_url = None
+      ; redirect_url = None
+      ; content_type = None
+      ; downloaded_bytes = None
+      ; body = payload
+      }
+
+let split_http_body_and_response body =
+  match find_last_substring ~needle:curl_meta_marker body with
+  | Some marker_idx ->
+      let payload = String.sub body 0 marker_idx in
+      let meta_start = marker_idx + String.length curl_meta_marker in
+      let meta = String.sub body meta_start (String.length body - meta_start) in
+      response_of_payload_and_meta payload meta
+  | None ->
+      let payload, http_status =
+        match String.rindex_opt body '\n' with
+        | None -> (body, None)
+        | Some idx ->
+            let payload = String.sub body 0 idx in
+            let status_raw =
+              String.sub body (idx + 1) (String.length body - idx - 1)
+              |> String.trim
+            in
+            (payload, parse_int_opt status_raw)
+      in
+      { http_status
+      ; effective_url = None
+      ; redirect_url = None
+      ; content_type = None
+      ; downloaded_bytes = None
+      ; body = payload
+      }
 
 let split_http_body_and_status body =
-  match String.rindex_opt body '\n' with
-  | None -> (body, None)
-  | Some idx ->
-      let payload = String.sub body 0 idx in
-      let status_raw =
-        String.sub body (idx + 1) (String.length body - idx - 1) |> String.trim
-      in
-      (payload, parse_int_opt status_raw)
+  let response = split_http_body_and_response body in
+  (response.body, response.http_status)
 
 let header_args headers =
   List.concat_map (fun (name, value) -> [ "-H"; name ^ ": " ^ value ]) headers
@@ -60,7 +143,7 @@ let curl_get_argv ?(timeout_sec = default_timeout_sec) ?(headers = [])
   @ redirect_args
   @ header_args headers
   @ max_response_args max_response_bytes
-  @ [ "-w"; "\n%{http_code}"; url ]
+  @ [ "-w"; curl_write_out; url ]
 
 let curl_post_json_argv ~timeout_sec ?(headers = []) ~url ~body_json () =
   let timeout_sec = max 1 timeout_sec in
@@ -78,7 +161,7 @@ let curl_post_json_argv ~timeout_sec ?(headers = []) ~url ~body_json () =
 
 let curl_get_argv_for_test = curl_get_argv
 
-let http_get_text_with_status_with_headers ?(timeout_sec = default_timeout_sec)
+let http_get_text_response_with_headers ?(timeout_sec = default_timeout_sec)
     ?(headers = []) ?(follow_redirects = false) ?(max_redirects = 3)
     ?(compressed = false) ?max_response_bytes url =
   let timeout_sec = max 1 timeout_sec in
@@ -97,14 +180,22 @@ let http_get_text_with_status_with_headers ?(timeout_sec = default_timeout_sec)
   in
   match status with
   | Unix.WEXITED 0 ->
-      let payload, http_status = split_http_body_and_status body in
-      Ok (http_status, payload)
+      Ok (split_http_body_and_response body)
   | Unix.WEXITED code ->
       Error (Printf.sprintf "curl exit code %d for %s" code url)
   | Unix.WSIGNALED sig_num ->
       Error (Printf.sprintf "curl signal %d for %s" sig_num url)
   | Unix.WSTOPPED sig_num ->
       Error (Printf.sprintf "curl stopped %d for %s" sig_num url)
+
+let http_get_text_with_status_with_headers ?timeout_sec ?headers ?follow_redirects
+    ?max_redirects ?compressed ?max_response_bytes url =
+  match
+    http_get_text_response_with_headers ?timeout_sec ?headers ?follow_redirects
+      ?max_redirects ?compressed ?max_response_bytes url
+  with
+  | Error _ as err -> err
+  | Ok response -> Ok (response.http_status, response.body)
 
 let http_get_text_with_status ?timeout_sec url =
   http_get_text_with_status_with_headers ?timeout_sec url

--- a/lib/tool_local_runtime_http.mli
+++ b/lib/tool_local_runtime_http.mli
@@ -42,6 +42,34 @@ val string_member : Yojson.Safe.t -> string -> string option
 
 (** {1 GET helpers} *)
 
+type http_get_response =
+  { http_status : int option
+  ; effective_url : string option
+  ; redirect_url : string option
+  ; content_type : string option
+  ; downloaded_bytes : int option
+  ; body : string
+  }
+(** Structured curl GET response metadata.  [body] is the response body with
+    curl's write-out metadata stripped.  [effective_url], [redirect_url],
+    [content_type], and [downloaded_bytes] are populated from curl write-out
+    fields when available. *)
+
+val http_get_text_response_with_headers :
+  ?timeout_sec:int ->
+  ?headers:(string * string) list ->
+  ?follow_redirects:bool ->
+  ?max_redirects:int ->
+  ?compressed:bool ->
+  ?max_response_bytes:int ->
+  string ->
+  (http_get_response, string) Result.t
+(** [http_get_text_response_with_headers ?timeout_sec ?headers url] issues a
+    [GET url] via curl and returns both body text and curl write-out metadata.
+
+    It is the metadata-preserving form of
+    {!http_get_text_with_status_with_headers}. *)
+
 val http_get_text_with_status_with_headers :
   ?timeout_sec:int ->
   ?headers:(string * string) list ->
@@ -65,7 +93,7 @@ val http_get_text_with_status_with_headers :
     [follow_redirects] defaults to [false]; when [true], curl follows
     redirects up to [max_redirects] (default 3).
     [compressed] enables curl's transparent compression handling.
-    [max_response_bytes], when set, asks curl to cap/range the response.
+    [max_response_bytes], when set, asks curl to cap the response.
 
     Errors include curl exit code, signals, and stop reasons. *)
 

--- a/lib/tool_misc_web_fetch.ml
+++ b/lib/tool_misc_web_fetch.ml
@@ -27,6 +27,32 @@ type extract_mode =
   | Markdown
   | Text
 
+type extraction_source =
+  | Article
+  | Main
+  | Body
+  | Document
+  | Raw_text
+
+let extraction_source_to_string = function
+  | Article -> "article"
+  | Main -> "main"
+  | Body -> "body"
+  | Document -> "document"
+  | Raw_text -> "raw_text"
+
+type content_kind =
+  | Html
+  | Plain_text
+  | Json_text
+  | Xml_text
+
+let content_kind_to_string = function
+  | Html -> "html"
+  | Plain_text -> "text"
+  | Json_text -> "json"
+  | Xml_text -> "xml"
+
 let extract_mode_to_string = function
   | Markdown -> "markdown"
   | Text -> "text"
@@ -264,21 +290,22 @@ let first_group pattern html =
 
 let select_readable_html html =
   let html = strip_noise html in
-  let selected =
+  let selected, source =
     match longest_nonempty (first_group article_re html) with
-    | Some article -> article
+    | Some article -> (article, Article)
     | None -> (
         match longest_nonempty (first_group main_re html) with
-        | Some main -> main
+        | Some main -> (main, Main)
         | None -> (
             match first_group body_re html with
-            | body :: _ -> body
-            | [] -> html))
+            | body :: _ -> (body, Body)
+            | [] -> (html, Document)))
   in
-  List.fold_left
-    (fun acc re -> Re.replace_string re ~by:"" acc)
-    selected
-    remove_boilerplate_res
+  ( List.fold_left
+      (fun acc re -> Re.replace_string re ~by:"" acc)
+      selected
+      remove_boilerplate_res
+  , source )
 
 let clean_inline html =
   Tool_misc_web_search.clean_search_text html
@@ -338,10 +365,50 @@ let render_markdown html =
   |> normalize_markdown
 
 let render_extracted_text ~extract_mode html =
-  let readable = select_readable_html html in
-  match extract_mode with
-  | Markdown -> render_markdown readable
-  | Text -> Tool_misc_web_search.clean_search_text readable
+  let readable, source = select_readable_html html in
+  let text =
+    match extract_mode with
+    | Markdown -> render_markdown readable
+    | Text -> Tool_misc_web_search.clean_search_text readable
+  in
+  text, source
+
+let content_type_base raw =
+  match String.split_on_char ';' raw with
+  | base :: _ -> String.lowercase_ascii (String.trim base)
+  | [] -> String.lowercase_ascii (String.trim raw)
+
+let content_kind_of_content_type = function
+  | None -> Ok Html
+  | Some raw ->
+      let base = content_type_base raw in
+      if String.equal base "" then Ok Html
+      else if String.equal base "text/html"
+              || String.equal base "application/xhtml+xml"
+              || ends_with ~suffix:"+html" base
+      then Ok Html
+      else if String.equal base "text/plain"
+              || String.equal base "text/markdown"
+              || String.equal base "text/csv"
+      then Ok Plain_text
+      else if String.equal base "application/json"
+              || ends_with ~suffix:"+json" base
+      then Ok Json_text
+      else if String.equal base "text/xml"
+              || String.equal base "application/xml"
+              || ends_with ~suffix:"+xml" base
+      then Ok Xml_text
+      else if String.starts_with ~prefix:"text/" base then Ok Plain_text
+      else Error raw
+
+let normalize_raw_text text =
+  text |> Re.replace_string horizontal_space_re ~by:" " |> normalize_markdown
+
+let render_payload ~extract_mode ~content_kind payload =
+  match content_kind with
+  | Html -> render_extracted_text ~extract_mode payload
+  | Plain_text -> (normalize_raw_text payload, Raw_text)
+  | Json_text | Xml_text -> (String.trim payload, Raw_text)
 
 let truncate_text ~max_chars text =
   if String.length text <= max_chars then text, false
@@ -416,51 +483,136 @@ type fetch_failure =
   | Transport_error of string   (* raw transport-layer detail, already redacted *)
   | Http_status of int          (* upstream returned a non-2xx HTTP status *)
   | No_http_status              (* protocol level: status line missing *)
+  | Redirect_blocked of string  (* redirect target failed URL/host policy *)
+  | Redirect_limit_exceeded
+  | Unsupported_content_type of string
 
 let fetch_failure_to_string = function
   | Transport_error detail -> Printf.sprintf "fetch failed: %s" detail
   | Http_status status -> Printf.sprintf "HTTP %d" status
   | No_http_status -> "no HTTP status received"
+  | Redirect_blocked reason -> "redirect blocked: " ^ reason
+  | Redirect_limit_exceeded ->
+      Printf.sprintf "redirect limit exceeded (max %d)" max_redirects
+  | Unsupported_content_type content_type ->
+      Printf.sprintf "unsupported content type: %s" content_type
 
 let fetch_failure_class : fetch_failure -> Tool_result.tool_failure_class =
   function
   | Transport_error _ -> Tool_result.Transient_error
   | Http_status _ -> Tool_result.Runtime_failure
   | No_http_status -> Tool_result.Runtime_failure
+  | Redirect_blocked _ -> Tool_result.Workflow_rejection
+  | Redirect_limit_exceeded -> Tool_result.Runtime_failure
+  | Unsupported_content_type _ -> Tool_result.Runtime_failure
 
-type http_get =
+type fetch_response =
+  { http_status : int option
+  ; final_url : string
+  ; redirect_count : int
+  ; content_type : string option
+  ; downloaded_bytes : int option
+  ; body : string
+  }
+
+type http_fetch =
   timeout_sec:int ->
   headers:(string * string) list ->
   max_response_bytes:int ->
   string ->
-  (int option * string, string) Result.t
+  (fetch_response, fetch_failure) Result.t
 
-let default_http_get ~timeout_sec ~headers ~max_response_bytes url =
-  Tool_local_runtime_http.http_get_text_with_status_with_headers
-    ~timeout_sec
-    ~headers
-    ~follow_redirects:true
-    ~max_redirects
-    ~compressed:true
-    ~max_response_bytes
-    url
+let resolve_redirect_url ~base_url target =
+  Uri.resolve "" (Uri.of_string base_url) (Uri.of_string target) |> Uri.to_string
 
-let http_get_mutex = Mutex.create ()
-let http_get_ref = ref default_http_get
+let redirect_status = function
+  | Some status -> status >= 300 && status < 400
+  | None -> false
 
-let current_http_get () =
-  Mutex.protect http_get_mutex (fun () -> !http_get_ref)
+let fetch_response_of_http_response ~request_url ~redirect_count
+    (response : Tool_local_runtime_http.http_get_response) =
+  { http_status = response.http_status
+  ; final_url =
+      Option.value response.effective_url ~default:request_url
+      |> String.trim
+  ; redirect_count
+  ; content_type = response.content_type
+  ; downloaded_bytes = response.downloaded_bytes
+  ; body = response.body
+  }
 
-let with_http_get_for_test http_get f =
+let validate_redirect_target target =
+  if not (valid_url target) then
+    Error "redirect target must be a valid http or https URL"
+  else
+    match blocked_host_reason target with
+    | Some reason -> Error ("target host is blocked: " ^ reason)
+    | None -> Ok ()
+
+let default_http_fetch ~timeout_sec ~headers ~max_response_bytes url =
+  let rec loop ~redirect_count request_url =
+    match
+      Tool_local_runtime_http.http_get_text_response_with_headers
+        ~timeout_sec
+        ~headers
+        ~follow_redirects:false
+        ~compressed:true
+        ~max_response_bytes
+        request_url
+    with
+    | Error detail ->
+        Error (Transport_error (redact_transport_error_detail detail))
+    | Ok response when redirect_status response.http_status -> (
+        match response.redirect_url with
+        | None | Some "" ->
+            Ok (fetch_response_of_http_response ~request_url ~redirect_count response)
+        | Some redirect_url ->
+            if redirect_count >= max_redirects then Error Redirect_limit_exceeded
+            else
+              let next_url =
+                resolve_redirect_url ~base_url:request_url redirect_url
+              in
+              match validate_redirect_target next_url with
+              | Error reason -> Error (Redirect_blocked reason)
+              | Ok () -> loop ~redirect_count:(redirect_count + 1) next_url)
+    | Ok response ->
+        Ok (fetch_response_of_http_response ~request_url ~redirect_count response)
+  in
+  loop ~redirect_count:0 url
+
+let http_fetch_mutex = Mutex.create ()
+let http_fetch_ref = ref default_http_fetch
+
+let current_http_fetch () =
+  Mutex.protect http_fetch_mutex (fun () -> !http_fetch_ref)
+
+let with_http_fetch_for_test http_fetch f =
   let previous =
-    Mutex.protect http_get_mutex (fun () ->
-        let previous = !http_get_ref in
-        http_get_ref := http_get;
+    Mutex.protect http_fetch_mutex (fun () ->
+        let previous = !http_fetch_ref in
+        http_fetch_ref := http_fetch;
         previous)
   in
   Stdlib.Fun.protect
     ~finally:(fun () ->
-      Mutex.protect http_get_mutex (fun () -> http_get_ref := previous))
+      Mutex.protect http_fetch_mutex (fun () -> http_fetch_ref := previous))
+    f
+
+let with_http_get_for_test http_get f =
+  with_http_fetch_for_test
+    (fun ~timeout_sec ~headers ~max_response_bytes url ->
+      match http_get ~timeout_sec ~headers ~max_response_bytes url with
+      | Ok (http_status, body) ->
+          Ok
+            { http_status
+            ; final_url = url
+            ; redirect_count = 0
+            ; content_type = None
+            ; downloaded_bytes = Some (String.length body)
+            ; body
+            }
+      | Error detail ->
+          Error (Transport_error (redact_transport_error_detail detail)))
     f
 
 (** Main fetch implementation *)
@@ -474,17 +626,39 @@ let fetch_impl ~url ~timeout_sec ~extract_mode ~max_chars =
       ("Accept-Language", "en-US,en;q=0.8,ko;q=0.7");
     ]
   in
-  match (current_http_get ()) ~timeout_sec ~headers ~max_response_bytes url with
-  | Error detail ->
-      Error (Transport_error (redact_transport_error_detail detail))
-  | Ok (Some status, payload) when status >= 200 && status < 300 ->
-      let title = extract_title payload in
-      let description = extract_description payload in
-      let rendered = render_extracted_text ~extract_mode payload in
-      let text, truncated = truncate_text ~max_chars rendered in
-      Ok (status, title, description, text, truncated)
-  | Ok (Some status, _) -> Error (Http_status status)
-  | Ok (None, _) -> Error No_http_status
+  match (current_http_fetch ()) ~timeout_sec ~headers ~max_response_bytes url with
+  | Error failure -> Error failure
+  | Ok response -> (
+      match response.http_status with
+      | Some status when status >= 200 && status < 300 -> (
+          match content_kind_of_content_type response.content_type with
+          | Error content_type -> Error (Unsupported_content_type content_type)
+          | Ok content_kind ->
+              let title =
+                match content_kind with
+                | Html -> extract_title response.body
+                | Plain_text | Json_text | Xml_text -> None
+              in
+              let description =
+                match content_kind with
+                | Html -> extract_description response.body
+                | Plain_text | Json_text | Xml_text -> None
+              in
+              let rendered, extraction_source =
+                render_payload ~extract_mode ~content_kind response.body
+              in
+              let text, truncated = truncate_text ~max_chars rendered in
+              Ok
+                ( response
+                , status
+                , content_kind
+                , extraction_source
+                , title
+                , description
+                , text
+                , truncated ))
+      | Some status -> Error (Http_status status)
+      | None -> Error No_http_status)
 
 (* RFC-0189 PR-1b.8 — typed result.
    Failure-class assignments live with construction:
@@ -563,16 +737,37 @@ let handle ~tool_name ~start_time args : Tool_result.result =
                       message
                 | Ok () -> (
                     match fetch_impl ~url ~timeout_sec:timeout ~extract_mode ~max_chars with
-                    | Ok (http_status, title, description, text, truncated) ->
+                    | Ok
+                        ( response
+                        , http_status
+                        , content_kind
+                        , extraction_source
+                        , title
+                        , description
+                        , text
+                        , truncated ) ->
                         let fields =
                           [
                             ("url", `String url);
+                            ("final_url", `String response.final_url);
                             ("http_status", `Int http_status);
+                            ("redirect_count", `Int response.redirect_count);
                             ("extract_mode", `String extract_mode_label);
+                            ("content_kind", `String (content_kind_to_string content_kind));
+                            ( "extraction_source",
+                              `String (extraction_source_to_string extraction_source) );
                             ("text", `String text);
                             ("content_chars", `Int (String.length text));
                             ("truncated", `Bool truncated);
                           ]
+                          @
+                          (match response.content_type with
+                          | Some value -> [ ("content_type", `String value) ]
+                          | None -> [])
+                          @
+                          (match response.downloaded_bytes with
+                          | Some value -> [ ("downloaded_bytes", `Int value) ]
+                          | None -> [])
                           @
                           (match title with
                           | Some t -> [ ("title", `String t) ]

--- a/lib/tool_misc_web_fetch.mli
+++ b/lib/tool_misc_web_fetch.mli
@@ -25,11 +25,18 @@ val handle : tool_name:string -> start_time:float -> Yojson.Safe.t -> Tool_resul
     [`Assoc [ "text", `String json ]] where [json] is the serialized
     [Tool_args.ok_response] envelope holding:
 	    - [url]: the requested URL
+	    - [final_url]: final URL after validated redirects
 	    - [http_status]: HTTP status code
+	    - [redirect_count]: number of followed redirects
 	    - [extract_mode]: output extraction mode
+	    - [content_kind]: [html], [text], [json], or [xml]
+	    - [extraction_source]: [article], [main], [body], [document], or
+	      [raw_text]
 	    - [text]: readable extracted content, truncated at [maxChars]
 	    - [content_chars]: length of [text]
 	    - [truncated]: whether output truncation was applied
+	    - [content_type]: optional upstream content type
+	    - [downloaded_bytes]: optional curl-reported download size
 	    - [title]: optional, extracted from [<title>] tag
 	    - [description]: optional, extracted from [<meta name="description">]
       or [og:description]
@@ -39,6 +46,34 @@ val handle : tool_name:string -> start_time:float -> Yojson.Safe.t -> Tool_resul
     - [Transient_error]:    rate-limit hit + transport-layer failure;
                             both retry-friendly.
     - [Runtime_failure]:    upstream HTTP non-2xx or missing status. *)
+
+type fetch_response =
+  { http_status : int option
+  ; final_url : string
+  ; redirect_count : int
+  ; content_type : string option
+  ; downloaded_bytes : int option
+  ; body : string
+  }
+
+type fetch_failure =
+  | Transport_error of string
+  | Http_status of int
+  | No_http_status
+  | Redirect_blocked of string
+  | Redirect_limit_exceeded
+  | Unsupported_content_type of string
+
+val with_http_fetch_for_test :
+  (timeout_sec:int ->
+   headers:(string * string) list ->
+   max_response_bytes:int ->
+   string ->
+   (fetch_response, fetch_failure) result) ->
+  (unit -> 'a) ->
+  'a
+(** [with_http_fetch_for_test http_fetch f] temporarily replaces the
+    structured HTTP fetch boundary used by {!handle}. *)
 
 val with_http_get_for_test :
   (timeout_sec:int ->

--- a/test/dune
+++ b/test/dune
@@ -123,7 +123,7 @@
   test_auth_load_credential_of
   test_keeper_wake_telemetry
   test_keeper_timing
-  test_token_count
+  test_keeper_token_count
   test_keeper_chat_store
   test_keeper_runtime_trust_snapshot
   test_keeper_tool_audit_snapshot
@@ -376,7 +376,7 @@
   test_auth_load_credential_of
   test_keeper_wake_telemetry
   test_keeper_timing
-  test_token_count
+  test_keeper_token_count
   test_keeper_chat_store
   test_keeper_runtime_trust_snapshot
   test_keeper_tool_audit_snapshot
@@ -638,6 +638,7 @@
   test_keeper_container_name
   test_worker_runtime
   test_capability_registry
+  test_tool_misc_web_fetch
   test_tool_local_runtime_probe
   test_board_ttl
   test_keeper_path_check_error
@@ -772,7 +773,7 @@
   test_goal_verification
   test_string_util
   test_system_error_class
-  test_provider_error_class
+  test_keeper_provider_error_class
   test_set_util
   test_board_core_payload
   test_board_attachment_meta
@@ -822,6 +823,7 @@
   test_keeper_container_name
   test_worker_runtime
   test_capability_registry
+  test_tool_misc_web_fetch
   test_tool_local_runtime_probe
   test_board_ttl
   test_keeper_path_check_error
@@ -955,7 +957,7 @@
   test_goal_verification
   test_string_util
   test_system_error_class
-  test_provider_error_class
+  test_keeper_provider_error_class
   test_set_util
   test_board_core_payload
   test_board_attachment_meta

--- a/test/test_tool_local_runtime_probe.ml
+++ b/test/test_tool_local_runtime_probe.ml
@@ -3,6 +3,19 @@ open Alcotest
 let check_float_close label expected actual =
   check bool label true (Float.abs (expected -. actual) < 0.001)
 
+let contains_substring text needle =
+  let len_text = String.length text in
+  let len_needle = String.length needle in
+  if len_needle = 0 then true
+  else if len_needle > len_text then false
+  else
+    let rec loop idx =
+      if idx > len_text - len_needle then false
+      else if String.equal (String.sub text idx len_needle) needle then true
+      else loop (idx + 1)
+    in
+    loop 0
+
 let test_ollama_ps_parser_extracts_loaded_models () =
   let json =
     Yojson.Safe.from_string
@@ -103,9 +116,10 @@ let test_auto_think_policy_prioritizes_response () =
 let test_runtime_probe_reports_effective_think_mode () =
   let open Yojson.Safe.Util in
   let run mode =
+    Eio_main.run @@ fun _env ->
     Masc.Tool_local_runtime_probe.runtime_ollama_probe_json
-      ~server_url:"http://127.0.0.1:1" ~model:"dummy-probe-model"
-      ~think_mode:mode ~timeout_sec:3 ~ps_timeout_sec:1 ()
+      ~server_url:"http://127.0.0.1:1" ~model:"dummy-probe-model" ~think_mode:mode
+      ~timeout_sec:3 ~ps_timeout_sec:1 ()
   in
   let auto = run Masc.Tool_local_runtime_probe.Think_auto in
   check string "auto mode reported" "auto"
@@ -126,9 +140,10 @@ let test_runtime_probe_status_only_skip_is_telemetry () =
       ~labels ()
   in
   let json =
+    Eio_main.run @@ fun _env ->
     Masc.Tool_local_runtime_probe.runtime_ollama_probe_json
-      ~server_url:"http://127.0.0.1:1" ~model:"dummy-probe-model"
-      ~run_generate:false ~timeout_sec:3 ~ps_timeout_sec:1 ()
+      ~server_url:"http://127.0.0.1:1" ~model:"dummy-probe-model" ~run_generate:false
+      ~timeout_sec:3 ~ps_timeout_sec:1 ()
   in
   let after =
     Masc.Prometheus.metric_value_or_zero
@@ -177,6 +192,12 @@ let test_curl_get_argv_keeps_curl_as_executable_with_headers () =
   check bool "compression arg present" true (List.mem "--compressed" argv);
   check bool "body cap arg present" true (List.mem "--max-filesize" argv);
   check bool "body cap does not force range response" false (List.mem "--range" argv);
+  check bool "curl emits structured metadata" true
+    (List.exists
+       (fun arg ->
+         contains_substring arg "%{url_effective}"
+         && contains_substring arg "%{content_type}")
+       argv);
   check bool "curl is not repeated after headers" false (List.mem "curl" (List.tl argv))
 
 let test_ollama_ps_non_200_is_reported_as_error () =

--- a/test/test_tool_misc_web_fetch.ml
+++ b/test/test_tool_misc_web_fetch.ml
@@ -1,0 +1,135 @@
+open Alcotest
+
+let contains_substring text needle =
+  let len_text = String.length text in
+  let len_needle = String.length needle in
+  if len_needle = 0 then true
+  else if len_needle > len_text then false
+  else
+    let rec loop idx =
+      if idx > len_text - len_needle then false
+      else if String.equal (String.sub text idx len_needle) needle then true
+      else loop (idx + 1)
+    in
+    loop 0
+
+let handle ?(extract_mode = "markdown") ?(max_chars = 5_000) url =
+  Eio_main.run @@ fun _env ->
+  Masc.Tool_misc_web_fetch.handle ~tool_name:"masc_web_fetch"
+    ~start_time:(Unix.gettimeofday ())
+    (`Assoc
+       [
+         ("url", `String url);
+         ("extractMode", `String extract_mode);
+         ("maxChars", `Int max_chars);
+       ])
+
+let success_json result =
+  if not (Tool_result.is_success result) then
+    fail ("unexpected failure: " ^ Tool_result.message result);
+  Yojson.Safe.from_string (Tool_result.message result)
+
+let test_html_metadata_and_article_extraction () =
+  let html =
+    {|
+<!doctype html>
+<html>
+  <head>
+    <title>Fetch Title &amp; Proof</title>
+    <meta property="og:description" content="Fetch description &amp; detail">
+  </head>
+  <body>
+    <nav>drop me</nav>
+    <article>
+      <h1>Primary Article</h1>
+      <p>Readable <b>content</b> &amp; links <a href="https://example.com/ref">ref</a>.</p>
+    </article>
+  </body>
+</html>|}
+  in
+  Masc.Tool_misc_web_fetch.with_http_fetch_for_test
+    (fun ~timeout_sec:_ ~headers:_ ~max_response_bytes:_ url ->
+      check string "requested url" "https://example.com/start" url;
+      Ok
+        { Masc.Tool_misc_web_fetch.http_status = Some 200
+        ; final_url = "https://example.com/final"
+        ; redirect_count = 1
+        ; content_type = Some "text/html; charset=utf-8"
+        ; downloaded_bytes = Some (String.length html)
+        ; body = html
+        })
+    (fun () ->
+      let json = success_json (handle "https://example.com/start") in
+      let open Yojson.Safe.Util in
+      check string "final url" "https://example.com/final"
+        (json |> member "final_url" |> to_string);
+      check int "redirect count" 1 (json |> member "redirect_count" |> to_int);
+      check string "content kind" "html" (json |> member "content_kind" |> to_string);
+      check string "source" "article"
+        (json |> member "extraction_source" |> to_string);
+      check string "title" "Fetch Title & Proof" (json |> member "title" |> to_string);
+      check string "description" "Fetch description & detail"
+        (json |> member "description" |> to_string);
+      check string "content type" "text/html; charset=utf-8"
+        (json |> member "content_type" |> to_string);
+      check int "downloaded bytes" (String.length html)
+        (json |> member "downloaded_bytes" |> to_int);
+      let text = json |> member "text" |> to_string in
+      check bool "heading rendered" true (contains_substring text "# Primary Article");
+      check bool "link rendered" true
+        (contains_substring text "[ref](https://example.com/ref)");
+      check bool "nav dropped" false (contains_substring text "drop me"))
+
+let test_plain_text_preserves_angle_brackets () =
+  let body = "Keep <literal> tokens\nand second line." in
+  Masc.Tool_misc_web_fetch.with_http_fetch_for_test
+    (fun ~timeout_sec:_ ~headers:_ ~max_response_bytes:_ _url ->
+      Ok
+        { Masc.Tool_misc_web_fetch.http_status = Some 200
+        ; final_url = "https://example.com/plain.txt"
+        ; redirect_count = 0
+        ; content_type = Some "text/plain"
+        ; downloaded_bytes = Some (String.length body)
+        ; body
+        })
+    (fun () ->
+      let json = success_json (handle "https://example.com/plain.txt") in
+      let open Yojson.Safe.Util in
+      check string "content kind" "text" (json |> member "content_kind" |> to_string);
+      check string "source" "raw_text"
+        (json |> member "extraction_source" |> to_string);
+      let text = json |> member "text" |> to_string in
+      check bool "literal brackets preserved" true
+        (contains_substring text "<literal>"))
+
+let test_redirect_block_is_workflow_rejection () =
+  Masc.Tool_misc_web_fetch.with_http_fetch_for_test
+    (fun ~timeout_sec:_ ~headers:_ ~max_response_bytes:_ _url ->
+      Error
+        (Masc.Tool_misc_web_fetch.Redirect_blocked
+           "target host is blocked: localhost is not allowed"))
+    (fun () ->
+      let result = handle "https://example.com/redirects-local" in
+      check bool "failed" false (Tool_result.is_success result);
+      check
+        (option string)
+        "failure class"
+        (Some "workflow_rejection")
+        (Tool_result.failure_class result
+        |> Option.map Tool_result.tool_failure_class_to_string);
+      check bool "message" true
+        (contains_substring (Tool_result.message result) "redirect blocked"))
+
+let () =
+  run "tool_misc_web_fetch"
+    [
+      ( "fetch",
+        [
+          test_case "html metadata and article extraction" `Quick
+            test_html_metadata_and_article_extraction;
+          test_case "plain text preserves angle brackets" `Quick
+            test_plain_text_preserves_angle_brackets;
+          test_case "redirect block class" `Quick
+            test_redirect_block_is_workflow_rejection;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

- Harden `WebFetch` around curl metadata parsing, redirect validation, and content-type-aware extraction.
- Add structured HTTP response metadata from the local curl runtime: final URL, redirect URL, content type, downloaded bytes, and status.
- Add focused WebFetch tests for HTML extraction, plain-text preservation, and blocked redirects.
- Remove stale Dune private module entries and align renamed test module references that currently block focused test stanzas on `main`.

## Product impact

`WebFetch` no longer relies on a fragile trailing HTTP status split and now returns enough metadata to diagnose redirect/content handling. Text, JSON, XML, and HTML responses are treated by content kind instead of stripping tags from every payload.

## Evidence

- `ocamlformat --check lib/tool_local_runtime_http.ml lib/tool_local_runtime_http.mli lib/tool_misc_web_fetch.ml lib/tool_misc_web_fetch.mli test/test_tool_local_runtime_probe.ml test/test_tool_misc_web_fetch.ml`
- `curl -sS --http1.1 --max-time 10 -w '\n--MASC-CURL-META--\n%{http_code}\n%{url_effective}\n%{redirect_url}\n%{content_type}\n%{size_download}' https://example.com`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_tool_misc_web_fetch.exe test/test_tool_local_runtime_probe.exe` currently fails before the WebFetch tests because `origin/main` still has extraction fallout in Dune/library boundaries, including missing `Pool_metrics`, `Dated_jsonl`, `Lockfree_atomic`, `Json_field`, `Tool_args`, and follow-on keeper/dashboard/server dependency errors.

## Direct evidence

schema_version: 1
direct_ratio: 3/3
provenance: direct

- Formatting check passed with exit 0.
- Direct curl smoke returned metadata marker with `200`, `https://example.com/`, `text/html`, and `528` downloaded bytes.
- Focused Dune build was executed directly; failure is a current base build blocker, not a WebFetch assertion failure.

## Review evidence

- Added regression coverage in `test/test_tool_misc_web_fetch.ml`.
- Existing runtime probe coverage now checks curl write-out metadata fields.
- Redirect validation is manual and host-policy checked before following each redirect.

## Linked issue

None.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`codex/webfetch-quality-20260605` → `main` · 1 commit(s) · synced 2026-06-05T01:04:01Z

| sha | subject | date |
|---|---|---|
| `e6cd8a2ca` | improve WebFetch response handling | 2026-06-04 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->