### PR TITLE
refactor(keeper): centralize done promise resolution

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -383,10 +383,13 @@ let dispatch_fiber_started ~base_path keeper_name =
 
 let resolve_registry_done
       (entry : Keeper_registry.registry_entry)
+      ~source
       (value : [ `Stopped | `Crashed of string ])
   : bool
   =
-  Keeper_registry.try_resolve_done entry value
+  match Keeper_registry.resolve_done entry ~source value with
+  | Keeper_registry.Done_resolved _ -> true
+  | Keeper_registry.Done_already_resolved _ -> false
 ;;
 
 let record_keeper_stopped
@@ -396,7 +399,7 @@ let record_keeper_stopped
       ~detail
   : bool
   =
-  if resolve_registry_done entry `Stopped
+  if resolve_registry_done entry ~source:"keepalive_record_stopped" `Stopped
   then (
     Keeper_registry.dispatch_event_unit
       ~base_path
@@ -423,7 +426,7 @@ let record_keeper_crashed
   : unit
   =
   let reason = Keeper_registry.failure_reason_to_string failure_reason in
-  if resolve_registry_done entry (`Crashed reason)
+  if resolve_registry_done entry ~source:"keepalive_record_crashed" (`Crashed reason)
   then (
     let outcome = reason in
     Keeper_registry.set_failure_reason ~base_path keeper_name (Some failure_reason);

--- a/lib/keeper/keeper_registry_types.ml
+++ b/lib/keeper/keeper_registry_types.ml
@@ -31,6 +31,8 @@ type turn_measurement =
   ; tm_auto_rules : Keeper_state_machine.auto_rule_summary
   }
 
+type done_resolution = [ `Stopped | `Crashed of string ]
+
 type registry_entry =
   { base_path : string
   ; name : string
@@ -44,8 +46,8 @@ type registry_entry =
   ; event_queue : Keeper_event_queue.t Atomic.t
   ; started_at : float
   ; grpc_close : (unit -> unit) option Atomic.t
-  ; done_p : [ `Stopped | `Crashed of string ] Eio.Promise.t
-  ; done_r : [ `Stopped | `Crashed of string ] Eio.Promise.u
+  ; done_p : done_resolution Eio.Promise.t
+  ; done_r : done_resolution Eio.Promise.u
   ; restart_count : int
   ; last_restart_ts : float
   ; dead_since_ts : float option
@@ -92,15 +94,28 @@ and completed_turn_observation =
   ; ct_selected_model : string option
   }
 
-let try_resolve_done entry value =
+type done_resolve_result =
+  | Done_resolved of { source : string }
+  | Done_already_resolved of
+      { source : string
+      ; previous : done_resolution
+      }
+
+let resolve_done entry ~source (value : done_resolution) =
   match Eio.Promise.peek entry.done_p with
-  | Some _ -> false
+  | Some previous -> Done_already_resolved { source; previous }
   | None ->
     (try
        Eio.Promise.resolve entry.done_r value;
-       true
+       Done_resolved { source }
      with
-     | Invalid_argument _ -> false)
+     | Invalid_argument _ ->
+       let previous =
+         match Eio.Promise.peek entry.done_p with
+         | Some previous -> previous
+         | None -> value
+       in
+       Done_already_resolved { source; previous })
 ;;
 
 let registry_key ~base_path name =

--- a/lib/keeper/keeper_registry_types.mli
+++ b/lib/keeper/keeper_registry_types.mli
@@ -412,6 +412,8 @@ type turn_measurement = {
   tm_auto_rules : Keeper_state_machine.auto_rule_summary;
 }
 
+type done_resolution = [ `Stopped | `Crashed of string ]
+
 type registry_entry = {
   base_path : string;
   name : string;
@@ -431,10 +433,11 @@ type registry_entry = {
           and the [TurnDequeue] action. *)
   started_at : float;
   grpc_close : (unit -> unit) option Atomic.t;
-  done_p : [ `Stopped | `Crashed of string ] Eio.Promise.t;
-  done_r : [ `Stopped | `Crashed of string ] Eio.Promise.u;
-      (** Exposed so keeper lifecycle agents can resolve stop/crash exactly once.
-          Callers must preserve a single terminal outcome per keeper run. *)
+  done_p : done_resolution Eio.Promise.t;
+  done_r : done_resolution Eio.Promise.u;
+      (** Completion resolver owned by {!resolve_done}. Runtime callers must
+          not resolve this field directly; use {!resolve_done} so
+          double-resolve races return the prior terminal outcome. *)
   restart_count : int;
   last_restart_ts : float;
   dead_since_ts : float option;
@@ -531,10 +534,20 @@ and completed_turn_observation = {
   ct_selected_model : string option;
 }
 
+type done_resolve_result =
+  | Done_resolved of { source : string }
+  | Done_already_resolved of {
+      source : string;
+      previous : done_resolution;
+    }
+
 (** Resolve a keeper run completion promise at most once.
-    Returns [false] if another fiber won the resolve race. *)
-val try_resolve_done :
-  registry_entry -> [ `Stopped | `Crashed of string ] -> bool
+
+    [source] identifies the lifecycle branch attempting the resolve. The
+    function never raises on a double-resolve race; instead it returns the
+    already-resolved outcome. *)
+val resolve_done :
+  registry_entry -> source:string -> done_resolution -> done_resolve_result
 
 (** Internal: keeper registry key composition (base_path ^ \\x1f ^ name).
     Exposed via mli so keeper_registry.ml's state functions can use it

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -242,8 +242,14 @@ let sweep_and_recover (ctx : _ context) =
          "%s: force-released stale slots after watchdog crash: %s"
          entry.name
          summary);
-	    if Keeper_registry.try_resolve_done entry (`Crashed msg)
-	    then (
+	    (match
+         Keeper_registry.resolve_done
+           entry
+           ~source:"supervisor_force_watchdog_crash"
+           (`Crashed msg)
+       with
+       | Keeper_registry.Done_already_resolved _ -> ()
+       | Keeper_registry.Done_resolved _ ->
 	      let outcome = msg in
 	      ignore
 	        (Keeper_registry.dispatch_event_and_log

--- a/lib/keeper/keeper_supervisor_launch.ml
+++ b/lib/keeper/keeper_supervisor_launch.ml
@@ -116,20 +116,17 @@ let launch_supervised_fiber
          Setting the flag from the cancel handler keeps the typed
          [fiber_drop_cause] payload accurate. *)
       let cancelled_by_parent = ref false in
-      let resolve_done value =
+      let resolve_done ~source value =
         if not !resolved then
           (* Issue #18335: the keepalive layer (keeper_keepalive.ml:760-791)
              may have already resolved done_p via record_keeper_stopped.
              When the Promise is already resolved, treat it as success —
              the keeper completed normally via the keepalive exit path. *)
-          if Keeper_registry.try_resolve_done reg value then (
+          match Keeper_registry.resolve_done reg ~source value with
+          | Keeper_registry.Done_resolved _
+          | Keeper_registry.Done_already_resolved _ ->
             resolved := true;
-            true)
-          else if Option.is_some (Eio.Promise.peek reg.done_p) then (
-            resolved := true;
-            true)
-          else
-            false
+            true
         else
           false
       in
@@ -236,7 +233,7 @@ let launch_supervised_fiber
                   Log.Keeper.warn
                     "supervisor: Fiber_terminated dispatch failed: %s"
                     (Keeper_state_machine.transition_error_to_string e));
-               if resolve_done (`Crashed reason)
+               if resolve_done ~source:"supervisor_watchdog_crash" (`Crashed reason)
                then
                  publish_phase_lifecycle
                    ~phase:Keeper_state_machine.Crashed
@@ -275,7 +272,7 @@ let launch_supervised_fiber
                   Log.Keeper.warn
                     "supervisor: Drain_complete dispatch failed: %s"
                     (Keeper_state_machine.transition_error_to_string e));
-               if resolve_done `Stopped
+               if resolve_done ~source:"supervisor_normal_exit" `Stopped
                then
                  publish_phase_lifecycle
                    ~phase:Keeper_state_machine.Stopped
@@ -334,7 +331,7 @@ let launch_supervised_fiber
                ~reason
                ~restart_count:rc;
              Keeper_registry_error_recording.record ~base_path meta.name reason;
-             if resolve_done (`Crashed reason)
+             if resolve_done ~source:"supervisor_exception_handler" (`Crashed reason)
              then
                publish_phase_lifecycle
                  ~phase:Keeper_state_machine.Crashed
@@ -386,7 +383,10 @@ let launch_supervised_fiber
                   (Some (Keeper_registry.Fiber_unresolved Graceful_shutdown));
                 Keeper_registry.mark_dead ~base_path meta.name ~at:(Time_compat.now ());
                 (* fire-and-forget: resolve_done signals completion *)
-                ignore (resolve_done (`Crashed "shutdown")))
+                ignore
+                  (resolve_done
+                     ~source:"supervisor_shutdown_cleanup"
+                     (`Crashed "shutdown")))
               else if !cancelled_by_parent
               then (
                 (* Issue #18901 follow-up: parent-cancel branch. The
@@ -406,7 +406,10 @@ let launch_supervised_fiber
                   (Some (Keeper_registry.Fiber_unresolved Cancelled_by_parent));
                 Keeper_registry.mark_dead ~base_path meta.name ~at:(Time_compat.now ());
                 (* fire-and-forget: resolve_done signals completion *)
-                ignore (resolve_done (`Crashed "cancelled_by_parent")))
+                ignore
+                  (resolve_done
+                     ~source:"supervisor_parent_cancel_cleanup"
+                     (`Crashed "cancelled_by_parent")))
               else (
 	                let reason =
 	                  Keeper_registry.failure_reason_to_string
@@ -475,7 +478,7 @@ let launch_supervised_fiber
 	                  ~base_path
 	                  meta.name
 	                  (Keeper_state_machine.Fiber_terminated { outcome; provider_id = None; http_status = None });
-                if resolve_done (`Crashed reason)
+                if resolve_done ~source:"supervisor_unresolved_cleanup" (`Crashed reason)
                 then
                   publish_phase_lifecycle
                     ~phase:Keeper_state_machine.Crashed

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -58,6 +58,9 @@ let make_meta name =
   | Ok meta -> meta
   | Error err -> Alcotest.fail ("make_meta failed: " ^ err)
 
+let resolve_done_for_test reg value =
+  ignore (R.resolve_done reg ~source:"test_fixture" value)
+
 let eio_test name fn =
   test_case name `Quick (fun () -> Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env); fn ())
@@ -82,7 +85,7 @@ let test_crash_heartbeat_failure () =
     (KSM.Fiber_terminated { outcome = "heartbeat_failure"; provider_id = None; http_status = None }));
   R.record_crash ~base_path:bp "hb-crash" 1000.0 reason_str;
   Masc.Keeper_registry_error_recording.record ~base_path:bp "hb-crash" reason_str;
-  Eio.Promise.resolve reg.done_r (`Crashed reason_str);
+  resolve_done_for_test reg (`Crashed reason_str);
   (* Assert: registry state *)
   (match R.get ~base_path:bp "hb-crash" with
    | None -> fail "expected hb-crash in registry"
@@ -114,7 +117,7 @@ let test_crash_generic_exception () =
     (KSM.Fiber_terminated { outcome = "exception"; provider_id = None; http_status = None }));
   R.record_crash ~base_path:bp "exn-crash" 1001.0 reason_str;
   Masc.Keeper_registry_error_recording.record ~base_path:bp "exn-crash" reason_str;
-  Eio.Promise.resolve reg.done_r (`Crashed reason_str);
+  resolve_done_for_test reg (`Crashed reason_str);
   match R.get ~base_path:bp "exn-crash" with
   | None -> fail "expected exn-crash"
   | Some e ->
@@ -139,7 +142,7 @@ let test_crash_fiber_unresolved () =
   Masc.Keeper_registry_error_recording.record ~base_path:bp "unresolved" reason_str;
   ignore (R.dispatch_event ~base_path:bp "unresolved"
     (KSM.Fiber_terminated { outcome = "unresolved"; provider_id = None; http_status = None }));
-  Eio.Promise.resolve reg.done_r (`Crashed reason_str);
+  resolve_done_for_test reg (`Crashed reason_str);
   match R.get ~base_path:bp "unresolved" with
   | None -> fail "expected unresolved"
   | Some e ->
@@ -162,7 +165,7 @@ let test_dead_tombstone_full_lifecycle () =
   check string "initially running" "running"
     (KSM.phase_to_string (Option.get (R.get ~base_path:bp "mortal")).phase);
   (* Crash *)
-  Eio.Promise.resolve reg.done_r (`Crashed "test");
+  resolve_done_for_test reg (`Crashed "test");
   ignore (R.dispatch_event ~base_path:bp "mortal"
     (KSM.Fiber_terminated { outcome = "test"; provider_id = None; http_status = None }));
   (* Simulate budget exhaustion *)
@@ -303,7 +306,7 @@ let test_reconcile_predicate_stopped_resolved () =
   let reg = R.register ~base_path:bp "s1" (make_meta "s1") in
   ignore (R.dispatch_event ~base_path:bp "s1" KSM.Stop_requested);
   ignore (R.dispatch_event ~base_path:bp "s1" KSM.Drain_complete);
-  Eio.Promise.resolve reg.done_r `Stopped;
+  resolve_done_for_test reg `Stopped;
   (* Stopped + resolved done_p = reconcile-eligible *)
   (match R.get ~base_path:bp "s1" with
    | Some e ->
@@ -352,7 +355,7 @@ let test_restart_state_preservation () =
   R.clear ();
   let meta = make_meta "restartable" in
   let reg1 = R.register ~base_path:bp "restartable" meta in
-  Eio.Promise.resolve reg1.done_r (`Crashed "first crash");
+  resolve_done_for_test reg1 (`Crashed "first crash");
   ignore (R.dispatch_event ~base_path:bp "restartable"
     (KSM.Fiber_terminated { outcome = "first crash"; provider_id = None; http_status = None }));
   R.record_crash ~base_path:bp "restartable" 100.0 "first crash";
@@ -391,7 +394,7 @@ let test_crash_turn_failures () =
     (KSM.Fiber_terminated { outcome = "turn failure"; provider_id = None; http_status = None }));
   R.record_crash ~base_path:bp "turn-crash" 2000.0 reason_str;
   Masc.Keeper_registry_error_recording.record ~base_path:bp "turn-crash" reason_str;
-  Eio.Promise.resolve reg.done_r (`Crashed reason_str);
+  resolve_done_for_test reg (`Crashed reason_str);
   match R.get ~base_path:bp "turn-crash" with
   | None -> fail "expected turn-crash"
   | Some e ->
@@ -566,7 +569,10 @@ let test_stop_keepalive_preserves_existing_crash_outcome () =
   let reason = "already crashed" in
   ignore (R.dispatch_event ~base_path:bp keeper_name
     (KSM.Fiber_terminated { outcome = "already crashed"; provider_id = None; http_status = None }));
-  Eio.Promise.resolve reg.done_r (`Crashed reason);
+  (match R.resolve_done reg ~source:"test_existing_crash" (`Crashed reason) with
+   | R.Done_resolved { source } ->
+     check string "resolve source" "test_existing_crash" source
+   | R.Done_already_resolved _ -> fail "first resolve should win");
   Masc.Keeper_keepalive.stop_keepalive keeper_name;
   match R.get ~base_path:bp keeper_name with
   | None -> fail "expected crashed-before-stop in registry"
@@ -576,6 +582,21 @@ let test_stop_keepalive_preserves_existing_crash_outcome () =
      | Some (`Crashed msg) -> check string "crash reason preserved" reason msg
      | Some `Stopped -> fail "manual stop should not overwrite a crashed promise"
      | None -> fail "expected crash promise to remain resolved")
+
+let test_resolve_done_reports_prior_outcome () =
+  R.clear ();
+  let keeper_name = "double-resolve-contract" in
+  let reg = R.register ~base_path:bp keeper_name (make_meta keeper_name) in
+  (match R.resolve_done reg ~source:"test_first" (`Crashed "first") with
+   | R.Done_resolved { source } -> check string "first source" "test_first" source
+   | R.Done_already_resolved _ -> fail "first resolve should succeed");
+  match R.resolve_done reg ~source:"test_second" `Stopped with
+  | R.Done_resolved _ -> fail "second resolve must not overwrite prior outcome"
+  | R.Done_already_resolved { source; previous = `Crashed msg } ->
+    check string "second source" "test_second" source;
+    check string "previous outcome" "first" msg
+  | R.Done_already_resolved { previous = `Stopped; _ } ->
+    fail "previous outcome should remain crashed"
 
 (* ══════════════════════════════════════════════════════════
    9. RFC-0002: pipeline_stage_of_phase deterministic mapping
@@ -704,6 +725,8 @@ let () =
         test_stop_keepalive_force_releases_held_slots;
       test_case "manual stop preserves crashed outcome" `Quick
         test_stop_keepalive_preserves_existing_crash_outcome;
+      test_case "resolve_done reports prior outcome" `Quick
+        test_resolve_done_reports_prior_outcome;
     ];
     "pipeline_stage_phase", [
       test_case "exhaustive 11-phase mapping" `Quick

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -51,6 +51,9 @@ let rec mkdir_p path =
 let write_file path content =
   Out_channel.with_open_bin path (fun oc -> output_string oc content)
 
+let resolve_done_for_test reg value =
+  ignore (Reg.resolve_done reg ~source:"test_fixture" value)
+
 let restore_env name = function
   | Some value -> Unix.putenv name value
   | None -> Unix.putenv name ""
@@ -784,7 +787,7 @@ let test_fiber_health_respects_max_restarts_override () =
   let meta = make_meta name in
   let reg = Reg.register ~base_path:bp name meta in
   (* Simulate crash: resolve done_p as Crashed *)
-  Eio.Promise.resolve reg.done_r (`Crashed "test crash");
+  resolve_done_for_test reg (`Crashed "test crash");
   (* Set restart_count to 3 *)
   Reg.restore_supervisor_state ~base_path:bp name
     ~restart_count:3 ~last_restart_ts:0.0 ~crash_log:[];
@@ -908,7 +911,7 @@ let test_restart_path_emits_attempt_and_started_outcome_metrics () =
        | Ok () -> ()
        | Error err -> fail err);
       let reg = Reg.register ~base_path:config.base_path name meta in
-      Eio.Promise.resolve reg.done_r (`Crashed "ordinary crash");
+      resolve_done_for_test reg (`Crashed "ordinary crash");
       Reg.restore_supervisor_state ~base_path:config.base_path name
         ~restart_count:0 ~last_restart_ts:0.0 ~crash_log:[];
       let attempt_labels = [ ("keeper", name) ] in
@@ -965,7 +968,7 @@ let test_restart_path_emits_meta_unavailable_outcome_metric () =
       ignore (Masc.Workspace.init config ~agent_name:(Some "supervisor"));
       let meta = make_meta name in
       let reg = Reg.register ~base_path:config.base_path name meta in
-      Eio.Promise.resolve reg.done_r (`Crashed "ordinary crash");
+      resolve_done_for_test reg (`Crashed "ordinary crash");
       Reg.restore_supervisor_state ~base_path:config.base_path name
         ~restart_count:0 ~last_restart_ts:0.0 ~crash_log:[];
       let attempt_labels = [ ("keeper", name) ] in
@@ -1034,7 +1037,7 @@ let test_max_restarts_exhaustion_emits_dead_alert () =
       (* Drive the entry to Crashed with restart_count already at the
          default budget (5) so sweep takes the Dead branch on the first
          pass, not the restart branch. *)
-      Eio.Promise.resolve reg.done_r (`Crashed "synthetic exhaustion");
+      resolve_done_for_test reg (`Crashed "synthetic exhaustion");
       Reg.set_failure_reason ~base_path:config.base_path name
         (Some (Reg.Heartbeat_consecutive_failures 9));
       let max_restarts =
@@ -1174,7 +1177,7 @@ let test_stale_storm_pause_skips_restart () =
        | Ok () -> ()
        | Error err -> fail err);
       let reg = Reg.register ~base_path:config.base_path name meta in
-      Eio.Promise.resolve reg.done_r (`Crashed "synthetic stale storm");
+      resolve_done_for_test reg (`Crashed "synthetic stale storm");
       (* [restore_supervisor_state] resets [last_failure_reason] to [None],
          so it MUST run before [set_failure_reason] (otherwise the storm
          latch is wiped and the supervisor sweeps the entry through the
@@ -1248,7 +1251,7 @@ let test_legacy_stale_fleet_batch_routes_to_restart_budget () =
        | Ok () -> ()
        | Error err -> fail err);
       let reg = Reg.register ~base_path:config.base_path name meta in
-      Eio.Promise.resolve reg.done_r (`Crashed "legacy stale fleet batch");
+      resolve_done_for_test reg (`Crashed "legacy stale fleet batch");
       let max_restarts =
         Masc.Runtime_params.get
           Masc.Governance_registry.keeper_supervisor_max_restarts
@@ -1305,7 +1308,7 @@ let test_provider_timeout_loop_pause_skips_restart () =
        | Ok () -> ()
        | Error err -> fail err);
       let reg = Reg.register ~base_path:config.base_path name meta in
-      Eio.Promise.resolve reg.done_r (`Crashed "synthetic provider timeout loop");
+      resolve_done_for_test reg (`Crashed "synthetic provider timeout loop");
       Reg.restore_supervisor_state ~base_path:config.base_path name
         ~restart_count:0 ~last_restart_ts:0.0 ~crash_log:[];
       Reg.set_failure_reason ~base_path:config.base_path name
@@ -1421,7 +1424,7 @@ let test_non_storm_crashed_restarts_normally () =
        | Ok () -> ()
        | Error err -> fail err);
       let reg = Reg.register ~base_path:config.base_path name meta in
-      Eio.Promise.resolve reg.done_r (`Crashed "ordinary crash");
+      resolve_done_for_test reg (`Crashed "ordinary crash");
       let max_restarts =
         Masc.Runtime_params.get
           Masc.Governance_registry.keeper_supervisor_max_restarts
@@ -1486,7 +1489,7 @@ let test_storm_pause_requires_manual_resume () =
        | Ok () -> ()
        | Error err -> fail err);
       let reg = Reg.register ~base_path:config.base_path name meta in
-      Eio.Promise.resolve reg.done_r (`Crashed "storm");
+      resolve_done_for_test reg (`Crashed "storm");
       Reg.restore_supervisor_state ~base_path:config.base_path name
         ~restart_count:0 ~last_restart_ts:0.0 ~crash_log:[];
       Reg.set_failure_reason ~base_path:config.base_path name
@@ -1547,7 +1550,7 @@ let test_oas_auto_resume_after_sec_doubles_on_repause () =
        | Ok () -> ()
        | Error err -> fail err);
       let reg = Reg.register ~base_path:config.base_path name initial_meta in
-      Eio.Promise.resolve reg.done_r (`Crashed "provider timeout loop");
+      resolve_done_for_test reg (`Crashed "provider timeout loop");
       Reg.restore_supervisor_state ~base_path:config.base_path name
         ~restart_count:0 ~last_restart_ts:0.0 ~crash_log:[];
       Reg.set_failure_reason ~base_path:config.base_path name
@@ -1988,7 +1991,7 @@ let test_initial_auto_resume_capped_at_max () =
        | Ok () -> ()
        | Error err -> fail err);
       let reg = Reg.register ~base_path:config.base_path name meta in
-      Eio.Promise.resolve reg.done_r (`Crashed "storm");
+      resolve_done_for_test reg (`Crashed "storm");
       Reg.restore_supervisor_state ~base_path:config.base_path name
         ~restart_count:0 ~last_restart_ts:0.0 ~crash_log:[];
       Reg.set_failure_reason ~base_path:config.base_path name
@@ -2048,7 +2051,7 @@ let test_persisted_blocker_survives_unregister () =
        | Ok () -> ()
        | Error err -> fail err);
       let reg = Reg.register ~base_path:config.base_path name meta in
-      Eio.Promise.resolve reg.done_r (`Crashed "storm");
+      resolve_done_for_test reg (`Crashed "storm");
       Reg.restore_supervisor_state ~base_path:config.base_path name
         ~restart_count:0 ~last_restart_ts:0.0 ~crash_log:[];
       Reg.set_failure_reason ~base_path:config.base_path name


### PR DESCRIPTION
## Summary
- replace the boolean keeper done-promise helper with a typed `resolve_done ~source` result
- route keepalive and supervisor stop/crash completion through the registry-owned resolver
- add regression coverage that double resolution preserves the first terminal outcome

## Stack
- Stacked on #20155 (`fix/main-build-ci-20260605`) because current `main` does not locally compile before that build-fix PR.

## Verification
- `ocamlformat --check lib/keeper/keeper_registry_types.ml lib/keeper/keeper_registry_types.mli lib/keeper/keeper_keepalive.ml lib/keeper/keeper_supervisor.ml lib/keeper/keeper_supervisor_launch.ml test/test_heartbeat_integration.ml test/test_keeper_supervisor.ml`
- `git diff --check`
- `rg -n "Eio\\.Promise\\.resolve .*done_r|try_resolve_done|legacy_try_resolve_done|\\.done_r|resolve_registry_done entry" lib bin test`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_BUILD_DIR=/private/tmp/masc-dune-keeper-done-resolve-on-20155 scripts/dune-local.sh build lib/masc.cma test/test_heartbeat_integration.exe test/test_keeper_supervisor.exe`
- `env MASC_STORAGE_TYPE=filesystem MASC_BASE_PATH= GRAPHQL_API_KEY= ZAI_API_KEY= MASC_KEEPER_SANDBOX_PREFLIGHT_ENABLED=false MASC_KEEPER_DOCKER_PLAYGROUND=false /private/tmp/masc-dune-keeper-done-resolve-on-20155/default/test/test_heartbeat_integration.exe`
- `env MASC_STORAGE_TYPE=filesystem MASC_BASE_PATH= GRAPHQL_API_KEY= ZAI_API_KEY= MASC_KEEPER_SANDBOX_PREFLIGHT_ENABLED=false MASC_KEEPER_DOCKER_PLAYGROUND=false /private/tmp/masc-dune-keeper-done-resolve-on-20155/default/test/test_keeper_supervisor.exe`
