### PR TITLE
fix(keeper): allow sandbox git recovery commands

### DIFF
--- a/lib/exec/shell_ir_command_shape.ml
+++ b/lib/exec/shell_ir_command_shape.ml
@@ -185,12 +185,31 @@ let git_clean_recovery_args args =
   in
   loop ~force:false ~dir:false args
 
+let git_args_has_path_changing_option args =
+  let rec scan = function
+    | [] -> false
+    | ("-C" | "--git-dir" | "--work-tree") :: _ :: rest -> true
+    | arg :: rest
+      when String.starts_with ~prefix:"-C" arg && String.length arg > 2 ->
+      true
+    | arg :: rest
+      when String.starts_with ~prefix:"--git-dir=" arg
+           || String.starts_with ~prefix:"--work-tree=" arg ->
+      true
+    | _ :: rest -> scan rest
+  in
+  scan args
+;;
+
 let is_git_recovery_command ir =
   match effective_stages ir with
   | [ stage ] when String.equal (normalize_command_name stage.bin) "git" -> (
-    match git_subcommand_with_args stage.args with
-    | Some ("checkout", args) -> git_checkout_head_restore_args args
-    | Some ("reset", args) -> git_reset_hard_head_args args
-    | Some ("clean", args) -> git_clean_recovery_args args
-    | _ -> false)
+    if git_args_has_path_changing_option stage.args
+    then false
+    else
+      match git_subcommand_with_args stage.args with
+      | Some ("checkout", args) -> git_checkout_head_restore_args args
+      | Some ("reset", args) -> git_reset_hard_head_args args
+      | Some ("clean", args) -> git_clean_recovery_args args
+      | _ -> false)
   | _ -> false

--- a/lib/exec/shell_ir_command_shape.ml
+++ b/lib/exec/shell_ir_command_shape.ml
@@ -188,11 +188,11 @@ let git_clean_recovery_args args =
 let git_args_has_path_changing_option args =
   let rec scan = function
     | [] -> false
-    | ("-C" | "--git-dir" | "--work-tree") :: _ :: rest -> true
-    | arg :: rest
+    | ("-C" | "--git-dir" | "--work-tree") :: _ :: _rest -> true
+    | arg :: _rest
       when String.starts_with ~prefix:"-C" arg && String.length arg > 2 ->
       true
-    | arg :: rest
+    | arg :: _rest
       when String.starts_with ~prefix:"--git-dir=" arg
            || String.starts_with ~prefix:"--work-tree=" arg ->
       true

--- a/lib/exec/shell_ir_command_shape.ml
+++ b/lib/exec/shell_ir_command_shape.ml
@@ -75,6 +75,8 @@ let rec effective_stage stage =
      | bin :: args when not (String.starts_with ~prefix:"-" bin) ->
        Some { bin; args }
      | _ -> None)
+  (* DET-OK: parsed_stages already rejected non-literal argv fragments; this
+     default preserves explicit command shape for later policy checks. *)
   | _ -> Some stage
 
 let effective_stages ir =

--- a/lib/exec/shell_ir_command_shape.ml
+++ b/lib/exec/shell_ir_command_shape.ml
@@ -142,12 +142,7 @@ let git_checkout_head_restore_args args =
 
 let git_reset_hard_head_args args =
   let rec loop ~hard ~target = function
-    | [] ->
-      hard
-      &&
-      (match target with
-       | None | Some "HEAD" | Some "@" -> true
-       | Some _ -> false)
+    | [] -> hard && (match target with Some "HEAD" | Some "@" -> true | None | Some _ -> false)
     | ("-q" | "--quiet") :: rest -> loop ~hard ~target rest
     | "--hard" :: rest -> loop ~hard:true ~target rest
     | "--" :: _ -> false

--- a/lib/exec/shell_ir_command_shape.ml
+++ b/lib/exec/shell_ir_command_shape.ml
@@ -58,13 +58,29 @@ let is_env_assignment token =
   | Some 0 -> false
   | Some i -> is_shell_identifier (String.sub token 0 i)
 
+let env_assignment_name token =
+  match String.index_opt token '=' with
+  | None | Some 0 -> None
+  | Some i ->
+    let name = String.sub token 0 i in
+    if is_shell_identifier name then Some name else None
+
+let is_git_path_env_override = function
+  | "GIT_DIR" | "GIT_WORK_TREE" | "GIT_INDEX_FILE" | "GIT_OBJECT_DIRECTORY"
+  | "GIT_ALTERNATE_OBJECT_DIRECTORIES" | "GIT_COMMON_DIR" ->
+    true
+  | _ -> false
+
 let rec effective_stage stage =
   match normalize_command_name stage.bin, stage.args with
   | "env", args ->
     let rec scan = function
       | [] -> None
       | ("-i" | "--ignore-environment") :: rest -> scan rest
-      | arg :: rest when is_env_assignment arg -> scan rest
+      | arg :: rest when is_env_assignment arg ->
+        (match env_assignment_name arg with
+         | Some name when is_git_path_env_override name -> None
+         | Some _ | None -> scan rest)
       | arg :: _rest when String.starts_with ~prefix:"-" arg -> None
       | bin :: args -> Some { bin; args }
     in
@@ -123,6 +139,7 @@ let simple_relative_git_pathspec path =
   && path <> ".."
   && Filename.is_relative path
   && not (String.starts_with ~prefix:"-" path)
+  && not (String.starts_with ~prefix:":" path)
   && not (String.contains path '\x00')
   && not
        (path
@@ -169,21 +186,39 @@ let git_clean_short_flags_allowed arg =
   in
   loop 1
 
+let git_clean_short_flag_counts arg =
+  let len = String.length arg in
+  if len <= 1
+  then None
+  else
+    let rec loop i force_count dir =
+      if i >= len
+      then Some (force_count, dir)
+      else
+        match arg.[i] with
+        | 'f' -> loop (i + 1) (force_count + 1) dir
+        | 'd' -> loop (i + 1) force_count true
+        | 'q' -> loop (i + 1) force_count dir
+        | _ -> None
+    in
+    loop 1 0 false
+
 let git_clean_recovery_args args =
-  let rec loop ~force ~dir = function
-    | [] -> force && dir
-    | "--" :: [] -> force && dir
-    | "--force" :: rest -> loop ~force:true ~dir rest
-    | "--dir" :: rest -> loop ~force ~dir:true rest
-    | "--quiet" :: rest -> loop ~force ~dir rest
+  let rec loop ~force_count ~dir = function
+    | [] -> force_count = 1 && dir
+    | "--" :: [] -> force_count = 1 && dir
+    | "--force" :: rest -> loop ~force_count:(force_count + 1) ~dir rest
+    | "--dir" :: rest -> loop ~force_count ~dir:true rest
+    | "--quiet" :: rest -> loop ~force_count ~dir rest
     | arg :: rest
       when String.starts_with ~prefix:"-" arg && git_clean_short_flags_allowed arg ->
-      let force = force || String.contains arg 'f' in
-      let dir = dir || String.contains arg 'd' in
-      loop ~force ~dir rest
+      (match git_clean_short_flag_counts arg with
+       | Some (force_delta, short_dir) ->
+         loop ~force_count:(force_count + force_delta) ~dir:(dir || short_dir) rest
+       | None -> false)
     | _ -> false
   in
-  loop ~force:false ~dir:false args
+  loop ~force_count:0 ~dir:false args
 
 let git_args_has_path_changing_option args =
   let rec scan = function

--- a/lib/exec/shell_ir_command_shape.ml
+++ b/lib/exec/shell_ir_command_shape.ml
@@ -1,0 +1,199 @@
+type stage =
+  { bin : string
+  ; args : string list
+  }
+
+let normalize_command_name command_name =
+  let command_name = Filename.basename command_name |> String.lowercase_ascii in
+  if String.ends_with ~suffix:".exe" command_name
+  then String.sub command_name 0 (String.length command_name - String.length ".exe")
+  else command_name
+
+let literal_args args =
+  let rec loop acc = function
+    | [] -> Some (List.rev acc)
+    | Shell_ir.Lit (arg, _) :: rest -> loop (arg :: acc) rest
+    | Shell_ir.Concat _ :: _ | Shell_ir.Var (_, _) :: _ -> None
+  in
+  loop [] args
+
+let stage_of_simple simple =
+  match literal_args simple.Shell_ir.args with
+  | None -> None
+  | Some args -> Some { bin = Exec_program.to_string simple.bin; args }
+
+let parsed_stages ir =
+  let rec loop acc = function
+    | Shell_ir.Simple simple -> (
+      match stage_of_simple simple with
+      | Some stage -> Some (stage :: acc)
+      | None -> None)
+    | Shell_ir.Pipeline stages ->
+      List.fold_left
+        (fun acc stage -> Option.bind acc (fun acc -> loop acc stage))
+        (Some acc)
+        stages
+  in
+  match loop [] ir with
+  | Some stages -> List.rev stages
+  | None -> []
+
+let is_shell_identifier name =
+  let len = String.length name in
+  let is_head = function
+    | 'A' .. 'Z' | 'a' .. 'z' | '_' -> true
+    | _ -> false
+  in
+  let is_tail = function
+    | 'A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '_' -> true
+    | _ -> false
+  in
+  len > 0
+  && is_head name.[0]
+  && Seq.for_all is_tail (String.to_seq (String.sub name 1 (len - 1)))
+
+let is_env_assignment token =
+  match String.index_opt token '=' with
+  | None -> false
+  | Some 0 -> false
+  | Some i -> is_shell_identifier (String.sub token 0 i)
+
+let rec effective_stage stage =
+  match normalize_command_name stage.bin, stage.args with
+  | "env", args ->
+    let rec scan = function
+      | [] -> None
+      | ("-i" | "--ignore-environment") :: rest -> scan rest
+      | arg :: rest when is_env_assignment arg -> scan rest
+      | arg :: _rest when String.starts_with ~prefix:"-" arg -> None
+      | bin :: args -> Some { bin; args }
+    in
+    scan args
+  | "opam", "exec" :: rest ->
+    (match rest with
+     | "--" :: bin :: args -> Some { bin; args }
+     | bin :: args when not (String.starts_with ~prefix:"-" bin) ->
+       Some { bin; args }
+     | _ -> None)
+  | _ -> Some stage
+
+let effective_stages ir =
+  parsed_stages ir |> List.filter_map effective_stage
+
+let git_subcommand_with_args args =
+  let rec scan = function
+    | [] -> None
+    | ("-C" | "-c" | "--git-dir" | "--work-tree" | "--namespace") :: _value :: rest ->
+      scan rest
+    | arg :: rest
+      when String.starts_with ~prefix:"-C" arg && String.length arg > 2 ->
+      scan rest
+    | arg :: rest
+      when String.starts_with ~prefix:"--git-dir=" arg
+           || String.starts_with ~prefix:"--work-tree=" arg
+           || String.starts_with ~prefix:"--namespace=" arg ->
+      scan rest
+    | arg :: rest when String.starts_with ~prefix:"-" arg -> scan rest
+    | subcommand :: rest -> Some (String.lowercase_ascii subcommand, rest)
+  in
+  scan args
+
+let git_subcommand args =
+  Option.map fst (git_subcommand_with_args args)
+
+let git_subcommand_is_diagnostic = function
+  | "status" | "branch" | "log" | "diff" | "remote" | "rev-parse" | "fetch"
+  | "worktree" ->
+    true
+  | _ -> false
+
+let is_git_diagnostic_command ir =
+  match effective_stages ir with
+  | [ stage ] when String.equal (normalize_command_name stage.bin) "git" -> (
+    match git_subcommand stage.args with
+    | Some subcommand -> git_subcommand_is_diagnostic subcommand
+    | None -> false)
+  | _ -> false
+
+let simple_relative_git_pathspec path =
+  let path = String.trim path in
+  path <> ""
+  && path <> ".."
+  && Filename.is_relative path
+  && not (String.starts_with ~prefix:"-" path)
+  && not (String.contains path '\x00')
+  && not
+       (path
+        |> String.split_on_char '/'
+        |> List.exists (fun segment -> String.equal segment ".."))
+
+let drop_git_quiet_flags args =
+  let rec loop = function
+    | ("-q" | "--quiet") :: rest -> loop rest
+    | rest -> rest
+  in
+  loop args
+
+let git_checkout_head_restore_args args =
+  match drop_git_quiet_flags args with
+  | ("HEAD" | "@") :: "--" :: paths ->
+    paths <> [] && List.for_all simple_relative_git_pathspec paths
+  | _ -> false
+
+let git_reset_hard_head_args args =
+  let rec loop ~hard ~target = function
+    | [] ->
+      hard
+      &&
+      (match target with
+       | None | Some "HEAD" | Some "@" -> true
+       | Some _ -> false)
+    | ("-q" | "--quiet") :: rest -> loop ~hard ~target rest
+    | "--hard" :: rest -> loop ~hard:true ~target rest
+    | "--" :: _ -> false
+    | arg :: _ when String.starts_with ~prefix:"-" arg -> false
+    | arg :: rest -> (
+      match target with
+      | None -> loop ~hard ~target:(Some arg) rest
+      | Some _ -> false)
+  in
+  loop ~hard:false ~target:None args
+
+let git_clean_short_flags_allowed arg =
+  let len = String.length arg in
+  len > 1
+  &&
+  let rec loop i =
+    if i >= len then true
+    else
+      match arg.[i] with
+      | 'f' | 'd' | 'q' -> loop (i + 1)
+      | _ -> false
+  in
+  loop 1
+
+let git_clean_recovery_args args =
+  let rec loop ~force ~dir = function
+    | [] -> force && dir
+    | "--" :: [] -> force && dir
+    | "--force" :: rest -> loop ~force:true ~dir rest
+    | "--dir" :: rest -> loop ~force ~dir:true rest
+    | "--quiet" :: rest -> loop ~force ~dir rest
+    | arg :: rest
+      when String.starts_with ~prefix:"-" arg && git_clean_short_flags_allowed arg ->
+      let force = force || String.contains arg 'f' in
+      let dir = dir || String.contains arg 'd' in
+      loop ~force ~dir rest
+    | _ -> false
+  in
+  loop ~force:false ~dir:false args
+
+let is_git_recovery_command ir =
+  match effective_stages ir with
+  | [ stage ] when String.equal (normalize_command_name stage.bin) "git" -> (
+    match git_subcommand_with_args stage.args with
+    | Some ("checkout", args) -> git_checkout_head_restore_args args
+    | Some ("reset", args) -> git_reset_hard_head_args args
+    | Some ("clean", args) -> git_clean_recovery_args args
+    | _ -> false)
+  | _ -> false

--- a/lib/exec/shell_ir_command_shape.mli
+++ b/lib/exec/shell_ir_command_shape.mli
@@ -1,0 +1,30 @@
+(** Pure command-shape helpers for {!Shell_ir}.
+
+    This module has no keeper, cwd, filesystem, or sandbox policy.  It only
+    answers questions that can be derived from the parsed Shell IR. *)
+
+type stage =
+  { bin : string
+  ; args : string list
+  }
+
+val normalize_command_name : string -> string
+(** Normalize a command token to the lowercase basename used for shape checks. *)
+
+val parsed_stages : Shell_ir.t -> stage list
+(** Literal command stages from an IR. Returns [[]] when any stage contains
+    non-literal argv fragments. *)
+
+val effective_stages : Shell_ir.t -> stage list
+(** Literal stages after simple wrapper unwrapping such as [env git ...] and
+    [opam exec -- git ...]. *)
+
+val is_git_diagnostic_command : Shell_ir.t -> bool
+(** [true] for single-stage read/diagnostic git commands such as [git status],
+    [git log], and [git worktree]. *)
+
+val is_git_recovery_command : Shell_ir.t -> bool
+(** [true] for narrow local git recovery forms:
+    [git checkout HEAD -- <relative-path>...], [git reset --hard HEAD], and
+    [git clean -df]. This does not lower risk; it is only command-shape data for
+    callers with separate cwd/sandbox policy. *)

--- a/lib/exec/test/dune
+++ b/lib/exec/test/dune
@@ -16,6 +16,7 @@
   test_exec_adaptive_timeout
   test_risk_classifier
   test_egress_policy
+  test_shell_ir_command_shape
   test_shell_ir_typed
   test_shell_ir_walkers_gen
   test_shell_ir_risk

--- a/lib/exec/test/test_shell_ir_command_shape.ml
+++ b/lib/exec/test/test_shell_ir_command_shape.ml
@@ -1,0 +1,66 @@
+open Masc_exec
+open Masc_exec_bash_parser
+
+let parse cmd =
+  match Bash.parse_string cmd with
+  | Parsed.Parsed ir -> ir
+  | Parsed.Parse_error _ | Parsed.Parse_aborted _ | Parsed.Too_complex _ ->
+    Alcotest.failf "failed to parse: %s" cmd
+
+let check_recovery cmd expected =
+  Alcotest.(check bool)
+    cmd
+    expected
+    (Shell_ir_command_shape.is_git_recovery_command (parse cmd))
+
+let check_diagnostic cmd expected =
+  Alcotest.(check bool)
+    cmd
+    expected
+    (Shell_ir_command_shape.is_git_diagnostic_command (parse cmd))
+
+let test_git_diagnostic_command_shapes () =
+  check_diagnostic "git status --short" true;
+  check_diagnostic "env git log --oneline -5" true;
+  check_diagnostic "git worktree list" true;
+  check_diagnostic "git show HEAD:README.md" false;
+  check_diagnostic "git checkout HEAD -- README.md" false
+
+let test_git_recovery_command_shapes () =
+  check_recovery "git checkout HEAD -- config/deleted-one.txt" true;
+  check_recovery
+    "env FOO=bar git checkout HEAD -- test/fixtures/deleted-two.txt"
+    true;
+  check_recovery "opam exec -- git reset --hard HEAD" true;
+  check_recovery "git reset --hard" true;
+  check_recovery "git clean -df" true;
+  check_recovery "git clean -qfd" true
+
+let test_git_non_recovery_command_shapes () =
+  check_recovery "git checkout other-branch" false;
+  check_recovery "git checkout -b feature" false;
+  check_recovery "git checkout HEAD -- ../outside.txt" false;
+  check_recovery "git reset --hard HEAD~1" false;
+  check_recovery "git reset --soft HEAD" false;
+  check_recovery "git clean -xdf" false;
+  check_recovery "git clean -df some-path" false;
+  check_recovery "git status" false
+
+let () =
+  Alcotest.run
+    "Shell_ir_command_shape"
+    [ ( "git_recovery"
+      , [ Alcotest.test_case
+            "recognizes diagnostic commands"
+            `Quick
+            test_git_diagnostic_command_shapes
+        ; Alcotest.test_case
+            "recognizes narrow recovery commands"
+            `Quick
+            test_git_recovery_command_shapes
+        ; Alcotest.test_case
+            "rejects non-recovery git writes"
+            `Quick
+            test_git_non_recovery_command_shapes
+        ] )
+    ]

--- a/lib/exec/test/test_shell_ir_command_shape.ml
+++ b/lib/exec/test/test_shell_ir_command_shape.ml
@@ -32,7 +32,6 @@ let test_git_recovery_command_shapes () =
     "env FOO=bar git checkout HEAD -- test/fixtures/deleted-two.txt"
     true;
   check_recovery "opam exec -- git reset --hard HEAD" true;
-  check_recovery "git reset --hard" true;
   check_recovery "git clean -df" true;
   check_recovery "git clean -qfd" true
 
@@ -40,6 +39,7 @@ let test_git_non_recovery_command_shapes () =
   check_recovery "git checkout other-branch" false;
   check_recovery "git checkout -b feature" false;
   check_recovery "git checkout HEAD -- ../outside.txt" false;
+  check_recovery "git reset --hard" false;
   check_recovery "git reset --hard HEAD~1" false;
   check_recovery "git reset --soft HEAD" false;
   check_recovery "git clean -xdf" false;

--- a/lib/exec/test/test_shell_ir_command_shape.ml
+++ b/lib/exec/test/test_shell_ir_command_shape.ml
@@ -23,6 +23,7 @@ let test_git_diagnostic_command_shapes () =
   check_diagnostic "git status --short" true;
   check_diagnostic "env git log --oneline -5" true;
   check_diagnostic "git worktree list" true;
+  check_diagnostic "env GIT_DIR=../other/.git git status" false;
   check_diagnostic "git show HEAD:README.md" false;
   check_diagnostic "git checkout HEAD -- README.md" false
 
@@ -39,13 +40,20 @@ let test_git_non_recovery_command_shapes () =
   check_recovery "git checkout other-branch" false;
   check_recovery "git checkout -b feature" false;
   check_recovery "git checkout HEAD -- ../outside.txt" false;
+  check_recovery "git checkout HEAD -- :/" false;
+  check_recovery "git checkout HEAD -- ':(glob)*.ml'" false;
   check_recovery "git -C ../other reset --hard HEAD" false;
   check_recovery "git --work-tree ../other reset --hard HEAD" false;
   check_recovery "git --git-dir=../other/.git clean -df" false;
+  check_recovery
+    "env GIT_DIR=../other/.git GIT_WORK_TREE=../other git reset --hard HEAD"
+    false;
   check_recovery "git reset --hard" false;
   check_recovery "git reset --hard HEAD~1" false;
   check_recovery "git reset --soft HEAD" false;
   check_recovery "git clean -xdf" false;
+  check_recovery "git clean -ffd" false;
+  check_recovery "git clean -f --force -d" false;
   check_recovery "git clean -df some-path" false;
   check_recovery "git status" false
 

--- a/lib/exec/test/test_shell_ir_command_shape.ml
+++ b/lib/exec/test/test_shell_ir_command_shape.ml
@@ -39,6 +39,9 @@ let test_git_non_recovery_command_shapes () =
   check_recovery "git checkout other-branch" false;
   check_recovery "git checkout -b feature" false;
   check_recovery "git checkout HEAD -- ../outside.txt" false;
+  check_recovery "git -C ../other reset --hard HEAD" false;
+  check_recovery "git --work-tree ../other reset --hard HEAD" false;
+  check_recovery "git --git-dir=../other/.git clean -df" false;
   check_recovery "git reset --hard" false;
   check_recovery "git reset --hard HEAD~1" false;
   check_recovery "git reset --soft HEAD" false;

--- a/lib/keeper/keeper_agent_result.ml
+++ b/lib/keeper/keeper_agent_result.ml
@@ -45,19 +45,6 @@ let tool_names_of_calls (tool_calls : tool_call_detail list) : string list =
   |> List.map (fun detail -> Keeper_tool_resolution.canonical_tool_name detail.tool_name)
 ;;
 
-let synthetic_tool_call_detail ?(provider = "keeper_synthetic") ?(outcome = "ok")
-      ?route_evidence tool_name
-  =
-  { tool_name
-  ; provider
-  ; outcome
-  ; typed_outcome = None
-  ; latency_ms = 0.0
-  ; task_id = None
-  ; route_evidence
-  }
-;;
-
 (** Result of a single Agent.run() keeper turn. *)
 type run_result =
   { response_text : string
@@ -83,11 +70,6 @@ type run_result =
 
 let tool_names (result : run_result) = tool_names_of_calls result.tool_calls
 let tool_call_count (result : run_result) = List.length result.tool_calls
-
-let append_synthetic_tool_call ?provider ?outcome ?route_evidence tool_name result =
-  let detail = synthetic_tool_call_detail ?provider ?outcome ?route_evidence tool_name in
-  { result with tool_calls = result.tool_calls @ [ detail ] }
-;;
 
 (* RFC-0132 PR-2: agent-result surface label = external boundary; redact via SSOT. *)
 let runtime_lane_label =

--- a/lib/keeper/keeper_agent_result.mli
+++ b/lib/keeper/keeper_agent_result.mli
@@ -39,21 +39,8 @@ val tool_call_detail_to_json : tool_call_detail -> Yojson.Safe.t
     the public surface is exposed under [Keeper_agent_run.mli]. *)
 
 val tool_names_of_calls : tool_call_detail list -> string list
-val synthetic_tool_call_detail :
-  ?provider:string ->
-  ?outcome:string ->
-  ?route_evidence:Yojson.Safe.t ->
-  string ->
-  tool_call_detail
 val tool_names : run_result -> string list
 val tool_call_count : run_result -> int
-val append_synthetic_tool_call :
-  ?provider:string ->
-  ?outcome:string ->
-  ?route_evidence:Yojson.Safe.t ->
-  string ->
-  run_result ->
-  run_result
 
 val runtime_lane_label : string
 (** Boundary-redacted label used wherever MASC's keeper metrics surface

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -31,9 +31,6 @@ module For_testing = struct
     Contract_helpers.progress_keeper_tool_names_for_contract
   let no_progress_success_tool_names_for_contract =
     Contract_helpers.no_progress_success_tool_names_for_contract
-
-  let failed_tool_only_contract_violation =
-    Contract_helpers.failed_tool_only_contract_violation
 end
 
 (** Run a single keeper turn via OAS Agent.run().
@@ -589,28 +586,9 @@ let run_turn
                    Contract_helpers.observed_completion_contract_status
                      ~had_owned_active_task_at_turn_start
                      ~actual_keeper_tool_names:progress_keeper_tool_names
-                     ~tool_calls:acc.tool_calls
                  in
-                 let text_result =
-                   let contract_status = completion_contract_status () in
-                   acc.receipt_completion_contract_result <- contract_status;
-                   if
-                     Contract_helpers.failed_tool_only_contract_violation
-                       ~actual_keeper_tool_names:progress_keeper_tool_names
-                       ~tool_calls:acc.tool_calls
-                   then
-                     Error
-                       (Keeper_internal_error.sdk_error_of_masc_internal_error
-                          (Keeper_internal_error.Internal_contract_rejected
-                             {
-                               reason =
-                                 "completion_contract_violation: failed tool-only turn";
-                             }))
-                   else Ok (`Provider_text text)
-                 in
-                   match text_result with
-                   | Error e -> Error e
-                   | Ok (`Provider_text text) ->
+                 let contract_status = completion_contract_status () in
+                 acc.receipt_completion_contract_result <- contract_status;
                      (match
                         Keeper_tool_response.normalize_response_text
                           ~text

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -32,10 +32,6 @@ module For_testing : sig
   val no_progress_success_tool_names_for_contract
     :  tool_calls:tool_call_detail list
     -> string list
-  val failed_tool_only_contract_violation
-    :  actual_keeper_tool_names:string list
-    -> tool_calls:tool_call_detail list
-    -> bool
 end
 
 val per_provider_timeout_for_turn

--- a/lib/keeper/keeper_agent_run_contract_helpers.ml
+++ b/lib/keeper/keeper_agent_run_contract_helpers.ml
@@ -46,29 +46,13 @@ let no_progress_success_tool_names_for_contract
   keeper_tool_names_for_outcome ~tool_calls ~outcome:"ok_no_progress"
 ;;
 
-let failed_tool_only_contract_violation
-      ~(actual_keeper_tool_names : string list)
-      ~(tool_calls : Keeper_agent_result.tool_call_detail list)
-  =
-  actual_keeper_tool_names = []
-  && tool_calls <> []
-  && List.for_all
-       (fun (detail : Keeper_agent_result.tool_call_detail) ->
-          (not (String.equal detail.outcome "ok"))
-          && not (String.equal detail.outcome "ok_no_progress"))
-       tool_calls
-;;
-
 let observed_completion_contract_status
-      ~tool_calls ~had_owned_active_task_at_turn_start ~actual_keeper_tool_names
+      ~had_owned_active_task_at_turn_start ~actual_keeper_tool_names
   : Keeper_execution_receipt.completion_contract_result
   =
-  if failed_tool_only_contract_violation ~actual_keeper_tool_names ~tool_calls
-  then Contract_violated
-  else
-    Keeper_agent_run_turn_helpers.completion_contract_result_for_progress_evidence
-      ~had_owned_active_task_at_turn_start
-      ~actual_keeper_tool_names
+  Keeper_agent_run_turn_helpers.completion_contract_result_for_progress_evidence
+    ~had_owned_active_task_at_turn_start
+    ~actual_keeper_tool_names
 ;;
 
 let text_only_violation_contract_status ~actual_keeper_tool_names ~fallback

--- a/lib/keeper/keeper_agent_run_contract_helpers.mli
+++ b/lib/keeper/keeper_agent_run_contract_helpers.mli
@@ -18,12 +18,6 @@ val no_progress_success_tool_names_for_contract :
   string list
 
 val observed_completion_contract_status :
-  tool_calls:Keeper_agent_result.tool_call_detail list ->
   had_owned_active_task_at_turn_start:bool ->
   actual_keeper_tool_names:string list ->
   Keeper_execution_receipt.completion_contract_result
-
-val failed_tool_only_contract_violation :
-  actual_keeper_tool_names:string list ->
-  tool_calls:Keeper_agent_result.tool_call_detail list ->
-  bool

--- a/lib/keeper/keeper_sandbox_docker.ml
+++ b/lib/keeper/keeper_sandbox_docker.ml
@@ -382,7 +382,7 @@ let sandbox_error ~(config : Workspace.config) ~(meta : keeper_meta) ?details me
 ;;
 
 (** Shared by [run_docker_bash] and [run_docker_shell_command_with_status_internal]:
-    parse cmd → resolve cwd → validate paths.  Returns [Ok (cwd, cmd_stages)]
+    parse cmd → resolve cwd → validate paths.  Returns [Ok (cwd, cmd_ir)]
     when every gate passes.
 
     [validate_command_paths] toggles the host-side path validation gate
@@ -396,14 +396,13 @@ let validate_docker_dispatch_context
       ~(cmd : string)
       ()
   =
-  let cmd_stages =
-    match Keeper_tool_execute_command_parse.parse_cmd_to_ir_opt cmd with
-    | Some ir -> Keeper_tool_execute_command_semantics.effective_stages_of_ir ir
-    | None -> []
-  in
+  let cmd_ir = Keeper_tool_execute_command_parse.parse_cmd_to_ir_opt cmd in
   let cwd, sandbox_root_git_blocker =
-    Keeper_tool_execute_command_semantics.resolve_sandbox_root_git_cwd_of_stages
-      ~config ~meta ~cwd ~cmd cmd_stages
+    match cmd_ir with
+    | Some ir ->
+      Keeper_tool_execute_command_semantics.resolve_sandbox_root_git_cwd
+        ~config ~meta ~cwd ~cmd ir
+    | None -> cwd, None
   in
   match sandbox_root_git_blocker with
   | Some message -> Error message
@@ -426,7 +425,7 @@ let validate_docker_dispatch_context
     in
     match path_validation with
     | Error err -> Error (Printf.sprintf "%s [blocked_cmd=%s]" err cmd)
-    | Ok () -> Ok (cwd, cmd_stages)
+    | Ok () -> Ok (cwd, cmd_ir)
 ;;
 
 let run_docker_shell_command_with_status_internal
@@ -458,7 +457,7 @@ let run_docker_shell_command_with_status_internal
           ()
       with
       | Error msg -> sandbox_error msg
-      | Ok (cwd, cmd_stages) ->
+      | Ok (cwd, cmd_ir) ->
       (match fd_admission_error ~config with
        | Some err -> sandbox_error err
        | None ->
@@ -477,10 +476,7 @@ let run_docker_shell_command_with_status_internal
         (* #10855: surface gh syntax misuse before docker exec so the LLM
          sees a corrected-form hint in the same turn rather than gh's raw
          "unknown flag: --repo" error after the round-trip. *)
-           (match
-              Keeper_tool_execute_command_semantics.misuse_error_of_stages
-                cmd_stages
-            with
+           (match Option.bind cmd_ir Keeper_tool_execute_command_semantics.misuse_error with
             | Some msg -> sandbox_error msg
             | None ->
               let container_name = keeper_sandbox_container_name meta in
@@ -739,7 +735,7 @@ let run_docker_bash
     | Some runtime, Network_none ->
       (match validate_docker_dispatch_context ~config ~meta ~cwd ~cmd () with
        | Error message -> sandbox_error_json message
-       | Ok (cwd, cmd_stages) ->
+       | Ok (cwd, _cmd_ir) ->
          (match
             Keeper_turn_sandbox_runtime.run_bash_with_status
               runtime

--- a/lib/keeper/keeper_sandbox_factory.ml
+++ b/lib/keeper/keeper_sandbox_factory.ml
@@ -88,9 +88,43 @@ let resolve (t : t) ~cwd =
 let resolve_opt t_opt ~cwd =
   Option.bind t_opt (fun t -> resolve t ~cwd)
 
+let container_cwd_of_host t ~host_cwd =
+  let meta = current_meta t in
+  let host_root =
+    Keeper_sandbox.host_root_abs_of_meta ~config:t.config meta
+    |> normalize
+  in
+  let container_root =
+    Keeper_sandbox.container_root meta.name
+    |> strip_trailing_slashes
+  in
+  let host_norm = normalize host_cwd in
+  if String.equal host_norm host_root then container_root
+  else if String.starts_with ~prefix:(host_root ^ "/") host_norm then (
+    let suffix =
+      String.sub
+        host_norm
+        (String.length host_root + 1)
+        (String.length host_norm - String.length host_root - 1)
+    in
+    Filename.concat container_root suffix)
+  else
+    match
+      Keeper_cwd_response.profile_independent_cwd
+        ~container_root
+        ~host_cwd
+    with
+    | Some cwd -> cwd
+    | None -> container_root
+
+let container_cwd_of_host_opt t_opt ~host_cwd =
+  Option.map (fun t -> container_cwd_of_host t ~host_cwd) t_opt
+
 let cleanup (t : t) =
-  with_lock t (fun () ->
-    Hashtbl.iter
-      (fun _ r -> Keeper_turn_sandbox_runtime.cleanup r)
-      t.cache;
-    Hashtbl.reset t.cache)
+  if Hashtbl.length t.cache = 0 then ()
+  else
+    with_lock t (fun () ->
+      Hashtbl.iter
+        (fun _ r -> Keeper_turn_sandbox_runtime.cleanup r)
+        t.cache;
+      Hashtbl.reset t.cache)

--- a/lib/keeper/keeper_sandbox_factory.mli
+++ b/lib/keeper/keeper_sandbox_factory.mli
@@ -57,5 +57,9 @@ val resolve_opt :
     on [Keeper_turn_sandbox_runtime.t option] keep the same shape after
     the factory rewrite. *)
 
+val container_cwd_of_host_opt : t option -> host_cwd:string -> string option
+(** Pure Docker CWD projection for response shaping. Unlike {!resolve_opt},
+    this does not create or memoize a turn sandbox runtime. *)
+
 val cleanup : t -> unit
 (** Tears down every runtime created via {!resolve}.  Idempotent. *)

--- a/lib/keeper/keeper_tool_execute_command_semantics.ml
+++ b/lib/keeper/keeper_tool_execute_command_semantics.ml
@@ -12,86 +12,19 @@ type parsed_stage =
 
 let parse_cmd_to_ir_opt = Keeper_tool_execute_command_parse.parse_cmd_to_ir_opt
 
-let literal_args args =
-  let rec loop acc = function
-    | [] -> Some (List.rev acc)
-    | Masc_exec.Shell_ir.Lit (arg, _) :: rest -> loop (arg :: acc) rest
-    | Masc_exec.Shell_ir.Concat _ :: _ | Masc_exec.Shell_ir.Var (_, _) :: _ -> None
-  in
-  loop [] args
-
-let stage_of_simple simple =
-  match literal_args simple.Masc_exec.Shell_ir.args with
-  | None -> None
-  | Some args ->
-    Some { bin = Masc_exec.Exec_program.to_string simple.bin; args }
+let stage_of_shell_ir_shape (stage : Masc_exec.Shell_ir_command_shape.stage) =
+  { bin = stage.bin; args = stage.args }
 
 let parsed_stages_of_ir ir =
-  let rec loop acc = function
-    | Masc_exec.Shell_ir.Simple simple -> (
-        match stage_of_simple simple with
-        | Some stage -> Some (stage :: acc)
-        | None -> None)
-    | Masc_exec.Shell_ir.Pipeline stages ->
-      List.fold_left
-        (fun acc stage -> Option.bind acc (fun acc -> loop acc stage))
-        (Some acc)
-        stages
-  in
-  match loop [] ir with
-  | Some stages -> List.rev stages
-  | None -> []
-
-let is_shell_identifier name =
-  let len = String.length name in
-  let is_head = function
-    | 'A' .. 'Z' | 'a' .. 'z' | '_' -> true
-    | _ -> false
-  in
-  let is_tail = function
-    | 'A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '_' -> true
-    | _ -> false
-  in
-  len > 0
-  && is_head name.[0]
-  && Seq.for_all is_tail (String.to_seq (String.sub name 1 (len - 1)))
-
-let is_env_assignment token =
-  match String.index_opt token '=' with
-  | None -> false
-  | Some 0 -> false
-  | Some i -> is_shell_identifier (String.sub token 0 i)
-
-let normalize_command_name command_name =
-  let command_name = Filename.basename command_name |> String.lowercase_ascii in
-  if String.ends_with ~suffix:".exe" command_name
-  then String.sub command_name 0 (String.length command_name - String.length ".exe")
-  else command_name
-
-let rec effective_stage stage =
-  match normalize_command_name stage.bin, stage.args with
-  | "env", args ->
-    let rec scan = function
-      | [] -> None
-      | ("-i" | "--ignore-environment") :: rest -> scan rest
-      | arg :: rest when is_env_assignment arg -> scan rest
-      | arg :: rest when String.starts_with ~prefix:"-" arg -> None
-      | bin :: args -> Some { bin; args }
-    in
-    scan args
-  | "opam", "exec" :: rest ->
-    (match rest with
-     | "--" :: bin :: args -> Some { bin; args }
-     | bin :: args when not (String.starts_with ~prefix:"-" bin) ->
-       Some { bin; args }
-     | _ -> None)
-  | _ ->
-    (* DET-OK: this is the parsed command itself, not an inferred fallback for
-       an unknown wrapper. *)
-    Some stage
+  Masc_exec.Shell_ir_command_shape.parsed_stages ir
+  |> List.map stage_of_shell_ir_shape
 
 let effective_stages_of_ir ir =
-  parsed_stages_of_ir ir |> List.filter_map effective_stage
+  Masc_exec.Shell_ir_command_shape.effective_stages ir
+  |> List.map stage_of_shell_ir_shape
+
+let normalize_command_name =
+  Masc_exec.Shell_ir_command_shape.normalize_command_name
 
 let strip_simple_shell_quotes token =
   let len = String.length token in

--- a/lib/keeper/keeper_tool_execute_command_semantics.ml
+++ b/lib/keeper/keeper_tool_execute_command_semantics.ml
@@ -1,27 +1,15 @@
 (** Execute command semantics.
 
-    This layer owns command-shape interpretation. Runtime backends call
-    into it when they need deterministic cwd policy for git/gh commands,
-    but it does not execute shell commands and does not construct Docker
-    invocations. *)
+    This layer owns keeper-specific cwd policy and user-facing command
+    guidance. Pure command-shape extraction stays in
+    [Masc_exec.Shell_ir_command_shape]. *)
 
-type parsed_stage =
+type stage = Masc_exec.Shell_ir_command_shape.stage =
   { bin : string
   ; args : string list
   }
 
-let parse_cmd_to_ir_opt = Keeper_tool_execute_command_parse.parse_cmd_to_ir_opt
-
-let stage_of_shell_ir_shape (stage : Masc_exec.Shell_ir_command_shape.stage) =
-  { bin = stage.bin; args = stage.args }
-
-let parsed_stages_of_ir ir =
-  Masc_exec.Shell_ir_command_shape.parsed_stages ir
-  |> List.map stage_of_shell_ir_shape
-
-let effective_stages_of_ir ir =
-  Masc_exec.Shell_ir_command_shape.effective_stages ir
-  |> List.map stage_of_shell_ir_shape
+let effective_stages ir = Masc_exec.Shell_ir_command_shape.effective_stages ir
 
 let normalize_command_name =
   Masc_exec.Shell_ir_command_shape.normalize_command_name
@@ -117,6 +105,12 @@ let gh_pr_diff_misuse_of_stages stages =
     else
       None) stages
 
+let repo_hosting_cli_repo_flag_api_misuse ir =
+  repo_hosting_cli_repo_flag_api_misuse_of_stages (effective_stages ir)
+
+let gh_pr_diff_misuse ir =
+  gh_pr_diff_misuse_of_stages (effective_stages ir)
+
 let misuse_error_of_stages stages =
   match repo_hosting_cli_repo_flag_api_misuse_of_stages stages with
   | Some (repo_arg, endpoint) ->
@@ -137,6 +131,8 @@ let misuse_error_of_stages stages =
             "잘못된 gh syntax: 'gh pr diff'는 파일 경로 필터링(예: '--', '*.ml')을 지원하지 않으며, positional argument는 최대 1개([<number> | <url> | <branch>])만 허용됩니다. (입력받은 positional args: %s). 전체 diff를 원하시면 파일 필터를 제거하시고, 특정 파일만 보시려면 git 저장소 내에서 'git diff origin/main <pr> -- <paths>'를 실행하세요."
             (String.concat ", " pos_args))
      | None -> None)
+
+let misuse_error ir = misuse_error_of_stages (effective_stages ir)
 
 
 let bare_worktrees_path token =
@@ -224,9 +220,10 @@ let repos_path_hint_of_stages ~cmd stages =
            | Some path -> Some (path, cmd)
            | None -> None)) stages
 
-let resolve_sandbox_root_git_cwd_of_stages
-    ~(config : Workspace.config) ~(meta : Keeper_meta_contract.keeper_meta) ~cwd ~cmd stages
+let resolve_sandbox_root_git_cwd
+    ~(config : Workspace.config) ~(meta : Keeper_meta_contract.keeper_meta) ~cwd ~cmd ir
   =
+  let stages = effective_stages ir in
   let host_root =
     Keeper_sandbox.host_root_abs_of_meta ~config meta
     |> Keeper_alerting_path.normalize_path_for_check
@@ -338,8 +335,3 @@ let resolve_sandbox_root_git_cwd_of_stages
          then resolve_without_explicit_git_c ()
          else cwd, None))
   else cwd, None
-
-let effective_stages_of_cmd cmd =
-  match parse_cmd_to_ir_opt cmd with
-  | Some ir -> effective_stages_of_ir ir
-  | None -> []

--- a/lib/keeper/keeper_tool_execute_command_semantics.mli
+++ b/lib/keeper/keeper_tool_execute_command_semantics.mli
@@ -1,49 +1,29 @@
 (** Execute command semantics.
 
-    Pure command-shape and cwd policy helpers shared by Local/Docker shell
-    dispatch. This module does not execute commands and does not know how
-    Docker is launched.
+    This module owns keeper-specific cwd policy and user-facing command
+    guidance. Pure Shell IR command-shape extraction lives in
+    {!Masc_exec.Shell_ir_command_shape}; callers pass [Shell_ir.t] rather than
+    stage lists so the Shell IR boundary stays explicit. *)
 
-    IR-first variants ([parsed_stages_of_ir], [effective_stages_of_ir])
-    accept pre-parsed [Shell_ir.t] and skip re-parsing. *)
-
-type parsed_stage = { bin : string; args : string list }
-
-val parsed_stages_of_ir : Masc_exec.Shell_ir.t -> parsed_stage list
-(** Extract literal command stages from a pre-parsed Shell IR. *)
-
-val effective_stages_of_ir : Masc_exec.Shell_ir.t -> parsed_stage list
-(** Extract effective command stages (after env/opam unwrap) from a
+val repo_hosting_cli_repo_flag_api_misuse :
+  Masc_exec.Shell_ir.t -> (string * string) option
+(** Detect the invalid [gh --repo <repo> api <endpoint>] shape from
     pre-parsed Shell IR. *)
 
-val stages_target_repo_commands : parsed_stage list -> bool
-val stages_target_repo_hosting_cli : parsed_stage list -> bool
-
-val repo_hosting_cli_repo_flag_api_misuse_of_stages :
-  parsed_stage list -> (string * string) option
-(** Detect the invalid [gh --repo <repo> api <endpoint>] shape from
-    pre-computed stages. *)
-
-val gh_pr_diff_misuse_of_stages :
-  parsed_stage list -> string list option
+val gh_pr_diff_misuse :
+  Masc_exec.Shell_ir.t -> string list option
 (** Detect invalid [gh pr diff] usage with file filters or extra positional args. *)
 
-val misuse_error_of_stages : parsed_stage list -> string option
+val misuse_error : Masc_exec.Shell_ir.t -> string option
 (** Perform all command syntax misuse checks and return a descriptive error message if any. *)
 
-
-val resolve_sandbox_root_git_cwd_of_stages :
+val resolve_sandbox_root_git_cwd :
   config:Workspace.config ->
   meta:Keeper_meta_contract.keeper_meta ->
   cwd:string ->
   cmd:string ->
-  parsed_stage list ->
+  Masc_exec.Shell_ir.t ->
   string * string option
-(** Pre-computed stages variant. Callers that already hold
-    [effective_stages_of_ir ir] pass them directly to avoid
-    re-parsing. *)
-
-val effective_stages_of_cmd : string -> parsed_stage list
-(** Parse-and-extract helper for callers that only hold a raw command
-    string. Equivalent to [effective_stages_of_ir] but parses internally.
-    Returns [[]] on parse failure. *)
+(** Resolve deterministic sandbox-root git/gh cwd policy from pre-parsed Shell
+    IR. The command shape comes from {!Masc_exec.Shell_ir_command_shape}; this
+    function adds keeper cwd, sandbox, and filesystem context. *)

--- a/lib/keeper/keeper_tool_execute_path.ml
+++ b/lib/keeper/keeper_tool_execute_path.ml
@@ -113,7 +113,7 @@ let normalize_command_name command_name =
   then String.sub command_name 0 (String.length command_name - String.length ".exe")
   else command_name
 
-let git_subcommand args =
+let git_subcommand_with_args args =
   let rec scan = function
     | [] -> None
     | ("-C" | "-c" | "--git-dir" | "--work-tree" | "--namespace") :: _value :: rest ->
@@ -127,9 +127,12 @@ let git_subcommand args =
            || String.starts_with ~prefix:"--namespace=" arg ->
       scan rest
     | arg :: rest when String.starts_with ~prefix:"-" arg -> scan rest
-    | subcommand :: _ -> Some (String.lowercase_ascii subcommand)
+    | subcommand :: rest -> Some (String.lowercase_ascii subcommand, rest)
   in
   scan args
+
+let git_subcommand args =
+  Option.map fst (git_subcommand_with_args args)
 
 let git_subcommand_is_direct_repo_diagnostic = function
   | "status" | "branch" | "log" | "diff" | "remote" | "rev-parse" | "fetch"
@@ -145,17 +148,167 @@ let direct_repo_diagnostic_command ir =
     | None -> false)
   | _ -> false
 
-let repo_currency_not_ready_error ~repo_name ~reason ~cwd =
+let simple_relative_git_pathspec path =
+  let path = String.trim path in
+  path <> ""
+  && path <> ".."
+  && Filename.is_relative path
+  && not (String.starts_with ~prefix:"-" path)
+  && not (String.contains path '\x00')
+  && not
+       (path
+        |> String.split_on_char '/'
+        |> List.exists (fun segment -> String.equal segment ".."))
+
+let drop_git_quiet_flags args =
+  let rec loop = function
+    | ("-q" | "--quiet") :: rest -> loop rest
+    | rest -> rest
+  in
+  loop args
+
+let git_checkout_head_restore_args args =
+  match drop_git_quiet_flags args with
+  | ("HEAD" | "@") :: "--" :: paths ->
+    paths <> [] && List.for_all simple_relative_git_pathspec paths
+  | _ -> false
+
+let git_reset_hard_head_args args =
+  let rec loop ~hard ~target = function
+    | [] ->
+      hard
+      &&
+      (match target with
+       | None | Some "HEAD" | Some "@" -> true
+       | Some _ -> false)
+    | ("-q" | "--quiet") :: rest -> loop ~hard ~target rest
+    | "--hard" :: rest -> loop ~hard:true ~target rest
+    | "--" :: _ -> false
+    | arg :: _ when String.starts_with ~prefix:"-" arg -> false
+    | arg :: rest -> (
+      match target with
+      | None -> loop ~hard ~target:(Some arg) rest
+      | Some _ -> false)
+  in
+  loop ~hard:false ~target:None args
+
+let git_clean_short_flags_allowed arg =
+  let len = String.length arg in
+  len > 1
+  &&
+  let rec loop i ~force ~dir =
+    if i >= len then Some (force, dir)
+    else
+      match arg.[i] with
+      | 'f' -> loop (i + 1) ~force:true ~dir
+      | 'd' -> loop (i + 1) ~force ~dir:true
+      | 'q' -> loop (i + 1) ~force ~dir
+      | _ -> None
+  in
+  match loop 1 ~force:false ~dir:false with
+  | Some _ -> true
+  | None -> false
+
+let git_clean_recovery_args args =
+  let rec loop ~force ~dir = function
+    | [] -> force && dir
+    | "--" :: [] -> force && dir
+    | "--force" :: rest -> loop ~force:true ~dir rest
+    | "--dir" :: rest -> loop ~force ~dir:true rest
+    | "--quiet" :: rest -> loop ~force ~dir rest
+    | arg :: rest
+      when String.starts_with ~prefix:"-" arg && git_clean_short_flags_allowed arg ->
+      let force = force || String.contains arg 'f' in
+      let dir = dir || String.contains arg 'd' in
+      loop ~force ~dir rest
+    | _ -> false
+  in
+  loop ~force:false ~dir:false args
+
+let readonly_git_recovery_command ~config ~meta ~cwd ir =
+  match repo_path_context ~config ~meta cwd with
+  | None -> false
+  | Some _ -> (
+    match Keeper_tool_execute_command_semantics.effective_stages_of_ir ir with
+    | [ stage ] when String.equal (normalize_command_name stage.bin) "git" -> (
+      match git_subcommand_with_args stage.args with
+      | Some ("checkout", args) -> git_checkout_head_restore_args args
+      | Some ("reset", args) -> git_reset_hard_head_args args
+      | Some ("clean", args) -> git_clean_recovery_args args
+      | _ -> false)
+    | _ -> false)
+
+let cascade_restore_paths =
+  [ "config/cascade.toml"; "test/fixtures/cascade-phonebook.toml" ]
+
+let parse_porcelain_change line =
+  let line = String.trim line in
+  let len = String.length line in
+  if len = 0 then None
+  else if String.starts_with ~prefix:"D  " line && len > 3
+  then Some (`Deleted, String.sub line 3 (len - 3))
+  else if String.starts_with ~prefix:"D " line && len > 2
+  then Some (`Deleted, String.sub line 2 (len - 2))
+  else if len > 3 && Char.equal line.[1] 'D' && Char.equal line.[2] ' '
+  then Some (`Deleted, String.sub line 3 (len - 3))
+  else Some (`Other, line)
+
+let cascade_only_status_hint ~config ~meta ~repo_name =
+  let clone_path = Playground_repo_readiness.clone_path ~config ~meta ~repo_name in
+  let status =
+    Playground_repo_readiness.run_git
+      ~timeout_sec:Playground_repo_readiness.read_only_probe_timeout_sec
+      ~clone_path
+      [ "status"; "--porcelain" ]
+  in
+  if not status.ok then None
+  else
+    let changes =
+      status.output
+      |> String.split_on_char '\n'
+      |> List.filter_map parse_porcelain_change
+    in
+    match changes with
+    | [] -> None
+    | changes ->
+      let deleted_paths =
+        List.filter_map
+          (function
+            | `Deleted, path -> Some path
+            | `Other, _ -> None)
+          changes
+      in
+      if
+        List.length deleted_paths = List.length changes
+        && List.for_all
+             (fun path -> List.mem path cascade_restore_paths)
+             deleted_paths
+      then
+        Some
+          (Printf.sprintf
+             " Dirty status only contains deleted legacy cascade fixtures: %s. \
+              Restore them with: git checkout HEAD -- %s"
+             (String.concat "; " (List.map (fun p -> "D " ^ p) deleted_paths))
+             (String.concat " " deleted_paths))
+      else None
+
+let repo_currency_not_ready_error ~config ~meta ~repo_name ~reason ~cwd =
+  let hint =
+    match cascade_only_status_hint ~config ~meta ~repo_name with
+    | Some hint -> hint
+    | None -> ""
+  in
   Printf.sprintf
     "sandbox_repo_stale: sandbox repo root repos/%s is not current and was \
      preserved (%s). Direct repo-root Execute is blocked so the agent does not \
      run against stale local state. Use cwd=\"repos/%s/.worktrees/<task>\" for \
      task work, or run diagnostic git status/branch/log/diff/remote/rev-parse/\
      fetch/worktree and clean, stash, or repair the sandbox repo root before \
-     retrying. cwd=%s"
+     retrying.%s cwd=%s"
     repo_name
     reason
     repo_name
+    hint
     cwd
 
 let validate_repo_cwd_currency_ready
@@ -173,15 +326,20 @@ let validate_repo_cwd_currency_ready
               (normalize_repo_cwd_path path_root)) ->
     Ok ()
   | Some (repo_name, _repo_root, _path_root, _accepted_toplevels) ->
-    if direct_repo_diagnostic_command ir then Ok ()
+    if
+      direct_repo_diagnostic_command ir
+      || readonly_git_recovery_command ~config ~meta ~cwd ir
+    then Ok ()
     else
       match repo_currency_outcome_best_effort ~config ~meta ~repo_name with
       | Some Playground_repo_readiness.Up_to_date | Some (Advanced _) -> Ok ()
       | Some (Preserved reason) | Some (Skipped reason) ->
-        Error (repo_currency_not_ready_error ~repo_name ~reason ~cwd)
+        Error (repo_currency_not_ready_error ~config ~meta ~repo_name ~reason ~cwd)
       | None ->
         Error
           (repo_currency_not_ready_error
+             ~config
+             ~meta
              ~repo_name
              ~reason:"currency probe failed"
              ~cwd)

--- a/lib/keeper/keeper_tool_execute_path.ml
+++ b/lib/keeper/keeper_tool_execute_path.ml
@@ -107,28 +107,23 @@ let repo_path_context ~(config : Workspace.config) ~(meta : keeper_meta) cwd =
         Some (repo_name, repo_root, repo_root, [ repo_root ])
       | _ -> None
 
-let cwd_is_sandbox_repo_context ~config ~meta ~cwd =
-  match repo_path_context ~config ~meta cwd with
-  | None -> false
-  | Some _ -> true
+type repo_cwd_context =
+  { repo_name : string
+  ; repo_root : string
+  ; path_root : string
+  ; is_direct_root : bool
+  }
 
-let cwd_is_sandbox_repo_root ~config ~meta ~cwd =
+let repo_cwd_context ~config ~meta ~cwd =
   let cwd = normalize_repo_cwd_path cwd in
   match repo_path_context ~config ~meta cwd with
-  | Some (_, repo_root, _, _) -> String.equal repo_root cwd
-  | None -> false
+  | Some (repo_name, repo_root, path_root, _) ->
+    Some { repo_name; repo_root; path_root; is_direct_root = String.equal repo_root cwd }
+  | None -> None
 
 let invalidate_repo_currency_cache ~config ~meta ~repo_name =
   let cpath = Playground_repo_readiness.clone_path ~config ~meta ~repo_name in
   Hashtbl.remove currency_sync_cache cpath
-;;
-
-let invalidate_repo_currency_cache_for_cwd ~config ~meta ~cwd =
-  let cwd = normalize_repo_cwd_path cwd in
-  match repo_path_context ~config ~meta cwd with
-  | Some (repo_name, repo_root, _, _) when String.equal repo_root cwd ->
-    invalidate_repo_currency_cache ~config ~meta ~repo_name
-  | _ -> ()
 ;;
 
 let repo_currency_not_ready_error ~config ~meta ~repo_name ~reason ~cwd =
@@ -155,7 +150,7 @@ let validate_repo_cwd_currency_ready
       ~(config : Workspace.config)
       ~(meta : keeper_meta)
       ~(cwd : string)
-      (ir : Masc_exec.Shell_ir.t)
+      ~allow_stale_preserved_repo_context
   =
   match repo_path_context ~config ~meta cwd with
   | None -> Ok ()
@@ -166,10 +161,7 @@ let validate_repo_cwd_currency_ready
               (normalize_repo_cwd_path path_root)) ->
     Ok ()
   | Some (repo_name, _repo_root, _path_root, _accepted_toplevels) ->
-    if
-      Masc_exec.Shell_ir_command_shape.is_git_diagnostic_command ir
-      || (cwd_is_sandbox_repo_root ~config ~meta ~cwd
-          && Masc_exec.Shell_ir_command_shape.is_git_recovery_command ir)
+    if allow_stale_preserved_repo_context
     then Ok ()
     else
       match repo_currency_outcome_best_effort ~config ~meta ~repo_name with

--- a/lib/keeper/keeper_tool_execute_path.ml
+++ b/lib/keeper/keeper_tool_execute_path.ml
@@ -107,194 +107,15 @@ let repo_path_context ~(config : Workspace.config) ~(meta : keeper_meta) cwd =
         Some (repo_name, repo_root, repo_root, [ repo_root ])
       | _ -> None
 
-let normalize_command_name command_name =
-  let command_name = Filename.basename command_name |> String.lowercase_ascii in
-  if String.ends_with ~suffix:".exe" command_name
-  then String.sub command_name 0 (String.length command_name - String.length ".exe")
-  else command_name
-
-let git_subcommand_with_args args =
-  let rec scan = function
-    | [] -> None
-    | ("-C" | "-c" | "--git-dir" | "--work-tree" | "--namespace") :: _value :: rest ->
-      scan rest
-    | arg :: rest
-      when String.starts_with ~prefix:"-C" arg && String.length arg > 2 ->
-      scan rest
-    | arg :: rest
-      when String.starts_with ~prefix:"--git-dir=" arg
-           || String.starts_with ~prefix:"--work-tree=" arg
-           || String.starts_with ~prefix:"--namespace=" arg ->
-      scan rest
-    | arg :: rest when String.starts_with ~prefix:"-" arg -> scan rest
-    | subcommand :: rest -> Some (String.lowercase_ascii subcommand, rest)
-  in
-  scan args
-
-let git_subcommand args =
-  Option.map fst (git_subcommand_with_args args)
-
-let git_subcommand_is_direct_repo_diagnostic = function
-  | "status" | "branch" | "log" | "diff" | "remote" | "rev-parse" | "fetch"
-  | "worktree" ->
-    true
-  | _ -> false
-
-let direct_repo_diagnostic_command ir =
-  match Keeper_tool_execute_command_semantics.effective_stages_of_ir ir with
-  | [ stage ] when String.equal (normalize_command_name stage.bin) "git" -> (
-    match git_subcommand stage.args with
-    | Some subcommand -> git_subcommand_is_direct_repo_diagnostic subcommand
-    | None -> false)
-  | _ -> false
-
-let simple_relative_git_pathspec path =
-  let path = String.trim path in
-  path <> ""
-  && path <> ".."
-  && Filename.is_relative path
-  && not (String.starts_with ~prefix:"-" path)
-  && not (String.contains path '\x00')
-  && not
-       (path
-        |> String.split_on_char '/'
-        |> List.exists (fun segment -> String.equal segment ".."))
-
-let drop_git_quiet_flags args =
-  let rec loop = function
-    | ("-q" | "--quiet") :: rest -> loop rest
-    | rest -> rest
-  in
-  loop args
-
-let git_checkout_head_restore_args args =
-  match drop_git_quiet_flags args with
-  | ("HEAD" | "@") :: "--" :: paths ->
-    paths <> [] && List.for_all simple_relative_git_pathspec paths
-  | _ -> false
-
-let git_reset_hard_head_args args =
-  let rec loop ~hard ~target = function
-    | [] ->
-      hard
-      &&
-      (match target with
-       | None | Some "HEAD" | Some "@" -> true
-       | Some _ -> false)
-    | ("-q" | "--quiet") :: rest -> loop ~hard ~target rest
-    | "--hard" :: rest -> loop ~hard:true ~target rest
-    | "--" :: _ -> false
-    | arg :: _ when String.starts_with ~prefix:"-" arg -> false
-    | arg :: rest -> (
-      match target with
-      | None -> loop ~hard ~target:(Some arg) rest
-      | Some _ -> false)
-  in
-  loop ~hard:false ~target:None args
-
-let git_clean_short_flags_allowed arg =
-  let len = String.length arg in
-  len > 1
-  &&
-  let rec loop i ~force ~dir =
-    if i >= len then Some (force, dir)
-    else
-      match arg.[i] with
-      | 'f' -> loop (i + 1) ~force:true ~dir
-      | 'd' -> loop (i + 1) ~force ~dir:true
-      | 'q' -> loop (i + 1) ~force ~dir
-      | _ -> None
-  in
-  match loop 1 ~force:false ~dir:false with
-  | Some _ -> true
-  | None -> false
-
-let git_clean_recovery_args args =
-  let rec loop ~force ~dir = function
-    | [] -> force && dir
-    | "--" :: [] -> force && dir
-    | "--force" :: rest -> loop ~force:true ~dir rest
-    | "--dir" :: rest -> loop ~force ~dir:true rest
-    | "--quiet" :: rest -> loop ~force ~dir rest
-    | arg :: rest
-      when String.starts_with ~prefix:"-" arg && git_clean_short_flags_allowed arg ->
-      let force = force || String.contains arg 'f' in
-      let dir = dir || String.contains arg 'd' in
-      loop ~force ~dir rest
-    | _ -> false
-  in
-  loop ~force:false ~dir:false args
-
-let readonly_git_recovery_command ~config ~meta ~cwd ir =
+let cwd_is_sandbox_repo_context ~config ~meta ~cwd =
   match repo_path_context ~config ~meta cwd with
   | None -> false
-  | Some _ -> (
-    match Keeper_tool_execute_command_semantics.effective_stages_of_ir ir with
-    | [ stage ] when String.equal (normalize_command_name stage.bin) "git" -> (
-      match git_subcommand_with_args stage.args with
-      | Some ("checkout", args) -> git_checkout_head_restore_args args
-      | Some ("reset", args) -> git_reset_hard_head_args args
-      | Some ("clean", args) -> git_clean_recovery_args args
-      | _ -> false)
-    | _ -> false)
-
-let cascade_restore_paths =
-  [ "config/cascade.toml"; "test/fixtures/cascade-phonebook.toml" ]
-
-let parse_porcelain_change line =
-  let line = String.trim line in
-  let len = String.length line in
-  if len = 0 then None
-  else if String.starts_with ~prefix:"D  " line && len > 3
-  then Some (`Deleted, String.sub line 3 (len - 3))
-  else if String.starts_with ~prefix:"D " line && len > 2
-  then Some (`Deleted, String.sub line 2 (len - 2))
-  else if len > 3 && Char.equal line.[1] 'D' && Char.equal line.[2] ' '
-  then Some (`Deleted, String.sub line 3 (len - 3))
-  else Some (`Other, line)
-
-let cascade_only_status_hint ~config ~meta ~repo_name =
-  let clone_path = Playground_repo_readiness.clone_path ~config ~meta ~repo_name in
-  let status =
-    Playground_repo_readiness.run_git
-      ~timeout_sec:Playground_repo_readiness.read_only_probe_timeout_sec
-      ~clone_path
-      [ "status"; "--porcelain" ]
-  in
-  if not status.ok then None
-  else
-    let changes =
-      status.output
-      |> String.split_on_char '\n'
-      |> List.filter_map parse_porcelain_change
-    in
-    match changes with
-    | [] -> None
-    | changes ->
-      let deleted_paths =
-        List.filter_map
-          (function
-            | `Deleted, path -> Some path
-            | `Other, _ -> None)
-          changes
-      in
-      if
-        List.length deleted_paths = List.length changes
-        && List.for_all
-             (fun path -> List.mem path cascade_restore_paths)
-             deleted_paths
-      then
-        Some
-          (Printf.sprintf
-             " Dirty status only contains deleted legacy cascade fixtures: %s. \
-              Restore them with: git checkout HEAD -- %s"
-             (String.concat "; " (List.map (fun p -> "D " ^ p) deleted_paths))
-             (String.concat " " deleted_paths))
-      else None
+  | Some _ -> true
 
 let repo_currency_not_ready_error ~config ~meta ~repo_name ~reason ~cwd =
+  let clone_path = Playground_repo_readiness.clone_path ~config ~meta ~repo_name in
   let hint =
-    match cascade_only_status_hint ~config ~meta ~repo_name with
+    match Playground_repo_readiness.deleted_tracked_files_restore_hint ~clone_path with
     | Some hint -> hint
     | None -> ""
   in
@@ -327,8 +148,9 @@ let validate_repo_cwd_currency_ready
     Ok ()
   | Some (repo_name, _repo_root, _path_root, _accepted_toplevels) ->
     if
-      direct_repo_diagnostic_command ir
-      || readonly_git_recovery_command ~config ~meta ~cwd ir
+      Masc_exec.Shell_ir_command_shape.is_git_diagnostic_command ir
+      || (cwd_is_sandbox_repo_context ~config ~meta ~cwd
+          && Masc_exec.Shell_ir_command_shape.is_git_recovery_command ir)
     then Ok ()
     else
       match repo_currency_outcome_best_effort ~config ~meta ~repo_name with

--- a/lib/keeper/keeper_tool_execute_path.ml
+++ b/lib/keeper/keeper_tool_execute_path.ml
@@ -112,6 +112,17 @@ let cwd_is_sandbox_repo_context ~config ~meta ~cwd =
   | None -> false
   | Some _ -> true
 
+let cwd_is_sandbox_repo_root ~config ~meta ~cwd =
+  match repo_path_context ~config ~meta cwd with
+  | Some (_, repo_root, path_root, _) ->
+    String.equal repo_root path_root
+  | None -> false
+
+let invalidate_repo_currency_cache ~config ~meta ~repo_name =
+  let cpath = Playground_repo_readiness.clone_path ~config ~meta ~repo_name in
+  Hashtbl.remove currency_sync_cache cpath
+;;
+
 let repo_currency_not_ready_error ~config ~meta ~repo_name ~reason ~cwd =
   let clone_path = Playground_repo_readiness.clone_path ~config ~meta ~repo_name in
   let hint_suffix =
@@ -454,7 +465,7 @@ let validate_repo_path_args_ready
       | Some args -> Exec_policy.path_argument_values command_name args)
   in
   let path_args_of_effective_stage
-      (stage : Keeper_tool_execute_command_semantics.parsed_stage)
+      (stage : Masc_exec.Shell_ir_command_shape.stage)
     =
     let command_name =
       stage.bin |> Filename.basename |> normalize_repo_command_name
@@ -471,7 +482,7 @@ let validate_repo_path_args_ready
   in
   let all_path_args =
     path_args ir
-    @ (Keeper_tool_execute_command_semantics.effective_stages_of_ir ir
+    @ (Masc_exec.Shell_ir_command_shape.effective_stages ir
        |> List.concat_map path_args_of_effective_stage)
   in
   let validate_target seen raw =

--- a/lib/keeper/keeper_tool_execute_path.ml
+++ b/lib/keeper/keeper_tool_execute_path.ml
@@ -114,9 +114,9 @@ let cwd_is_sandbox_repo_context ~config ~meta ~cwd =
 
 let repo_currency_not_ready_error ~config ~meta ~repo_name ~reason ~cwd =
   let clone_path = Playground_repo_readiness.clone_path ~config ~meta ~repo_name in
-  let hint =
+  let hint_suffix =
     match Playground_repo_readiness.deleted_tracked_files_restore_hint ~clone_path with
-    | Some hint -> hint
+    | Some hint -> " " ^ hint
     | None -> ""
   in
   Printf.sprintf
@@ -129,7 +129,7 @@ let repo_currency_not_ready_error ~config ~meta ~repo_name ~reason ~cwd =
     repo_name
     reason
     repo_name
-    hint
+    hint_suffix
     cwd
 
 let validate_repo_cwd_currency_ready

--- a/lib/keeper/keeper_tool_execute_path.ml
+++ b/lib/keeper/keeper_tool_execute_path.ml
@@ -113,14 +113,22 @@ let cwd_is_sandbox_repo_context ~config ~meta ~cwd =
   | Some _ -> true
 
 let cwd_is_sandbox_repo_root ~config ~meta ~cwd =
+  let cwd = normalize_repo_cwd_path cwd in
   match repo_path_context ~config ~meta cwd with
-  | Some (_, repo_root, path_root, _) ->
-    String.equal repo_root path_root
+  | Some (_, repo_root, _, _) -> String.equal repo_root cwd
   | None -> false
 
 let invalidate_repo_currency_cache ~config ~meta ~repo_name =
   let cpath = Playground_repo_readiness.clone_path ~config ~meta ~repo_name in
   Hashtbl.remove currency_sync_cache cpath
+;;
+
+let invalidate_repo_currency_cache_for_cwd ~config ~meta ~cwd =
+  let cwd = normalize_repo_cwd_path cwd in
+  match repo_path_context ~config ~meta cwd with
+  | Some (repo_name, repo_root, _, _) when String.equal repo_root cwd ->
+    invalidate_repo_currency_cache ~config ~meta ~repo_name
+  | _ -> ()
 ;;
 
 let repo_currency_not_ready_error ~config ~meta ~repo_name ~reason ~cwd =
@@ -160,7 +168,7 @@ let validate_repo_cwd_currency_ready
   | Some (repo_name, _repo_root, _path_root, _accepted_toplevels) ->
     if
       Masc_exec.Shell_ir_command_shape.is_git_diagnostic_command ir
-      || (cwd_is_sandbox_repo_context ~config ~meta ~cwd
+      || (cwd_is_sandbox_repo_root ~config ~meta ~cwd
           && Masc_exec.Shell_ir_command_shape.is_git_recovery_command ir)
     then Ok ()
     else

--- a/lib/keeper/keeper_tool_execute_path.mli
+++ b/lib/keeper/keeper_tool_execute_path.mli
@@ -45,6 +45,22 @@ val cwd_is_sandbox_repo_context :
     repo worktree path. This is cwd policy only; command-shape checks live under
     {!Masc_exec}. *)
 
+val cwd_is_sandbox_repo_root :
+  config:Workspace.config ->
+  meta:Keeper_meta_contract.keeper_meta ->
+  cwd:string ->
+  bool
+(** [true] only when [cwd] resolves to the preserved direct sandbox repo root
+    ([repos/<repo>]), not a repo subdirectory or [.worktrees/<task>] path. *)
+
+val invalidate_repo_currency_cache_for_cwd :
+  config:Workspace.config ->
+  meta:Keeper_meta_contract.keeper_meta ->
+  cwd:string ->
+  unit
+(** Clear the cached currency probe for a direct sandbox repo root cwd. Non-root
+    sandbox repo contexts are ignored. *)
+
 val execution_location_json :
   config:Workspace.config ->
   meta:Keeper_meta_contract.keeper_meta ->

--- a/lib/keeper/keeper_tool_execute_path.mli
+++ b/lib/keeper/keeper_tool_execute_path.mli
@@ -36,16 +36,14 @@ val validate_repo_cwd_currency_ready :
     normal work from continuing against that stale root while still allowing
     focused git diagnostics. Repo worktree cwd values are not gated here. *)
 
-val readonly_git_recovery_command :
+val cwd_is_sandbox_repo_context :
   config:Workspace.config ->
   meta:Keeper_meta_contract.keeper_meta ->
   cwd:string ->
-  Masc_exec.Shell_ir.t ->
   bool
-(** [true] for narrow git cleanup/restore commands that are allowed through the
-    read-only Execute write gate when they run inside a sandbox repo/worktree.
-    The Shell IR risk class remains R1/R2; this is only a runtime recovery
-    exception for keeper sandbox repair. *)
+(** [true] when [cwd] resolves to a keeper sandbox repo root, repo subpath, or
+    repo worktree path. This is cwd policy only; command-shape checks live under
+    {!Masc_exec}. *)
 
 val execution_location_json :
   config:Workspace.config ->

--- a/lib/keeper/keeper_tool_execute_path.mli
+++ b/lib/keeper/keeper_tool_execute_path.mli
@@ -36,6 +36,17 @@ val validate_repo_cwd_currency_ready :
     normal work from continuing against that stale root while still allowing
     focused git diagnostics. Repo worktree cwd values are not gated here. *)
 
+val readonly_git_recovery_command :
+  config:Workspace.config ->
+  meta:Keeper_meta_contract.keeper_meta ->
+  cwd:string ->
+  Masc_exec.Shell_ir.t ->
+  bool
+(** [true] for narrow git cleanup/restore commands that are allowed through the
+    read-only Execute write gate when they run inside a sandbox repo/worktree.
+    The Shell IR risk class remains R1/R2; this is only a runtime recovery
+    exception for keeper sandbox repair. *)
+
 val execution_location_json :
   config:Workspace.config ->
   meta:Keeper_meta_contract.keeper_meta ->

--- a/lib/keeper/keeper_tool_execute_path.mli
+++ b/lib/keeper/keeper_tool_execute_path.mli
@@ -27,39 +27,40 @@ val validate_repo_cwd_currency_ready :
   config:Workspace.config ->
   meta:Keeper_meta_contract.keeper_meta ->
   cwd:string ->
-  Masc_exec.Shell_ir.t ->
+  allow_stale_preserved_repo_context:bool ->
   (unit, string) result
-(** Reject non-diagnostic typed Execute commands from a direct sandbox
-    [repos/<repo>] cwd when the repo could not be advanced to
-    [origin/main]. Dirty, detached, task-branch, diverged, or unregistered
-    direct roots are preserved by the repo currency layer; this guard prevents
-    normal work from continuing against that stale root while still allowing
-    focused git diagnostics. Repo worktree cwd values are not gated here. *)
+(** Reject typed Execute commands from a preserved sandbox [repos/<repo>] root
+    or subpath when the repo could not be advanced to [origin/main]. Dirty,
+    detached, task-branch, diverged, or unregistered roots are preserved by the
+    repo currency layer; this guard prevents normal work from continuing against
+    that stale root. Repo worktree cwd values are not gated here. Command-shape
+    policy is decided by the caller through [allow_stale_preserved_repo_context]. *)
 
-val cwd_is_sandbox_repo_context :
+type repo_cwd_context =
+  { repo_name : string
+  ; repo_root : string
+  ; path_root : string
+  ; is_direct_root : bool
+  }
+(** Path-only facts for a cwd inside a keeper sandbox repo. [path_root] is the
+    selected git toplevel expected for the cwd: either [repo_root] or a worktree
+    root. *)
+
+val repo_cwd_context :
   config:Workspace.config ->
   meta:Keeper_meta_contract.keeper_meta ->
   cwd:string ->
-  bool
-(** [true] when [cwd] resolves to a keeper sandbox repo root, repo subpath, or
-    repo worktree path. This is cwd policy only; command-shape checks live under
-    {!Masc_exec}. *)
+  repo_cwd_context option
+(** Classify [cwd] as a keeper sandbox repo cwd. This reports path facts only;
+    callers own command-shape and write-gate policy. *)
 
-val cwd_is_sandbox_repo_root :
+val invalidate_repo_currency_cache :
   config:Workspace.config ->
   meta:Keeper_meta_contract.keeper_meta ->
-  cwd:string ->
-  bool
-(** [true] only when [cwd] resolves to the preserved direct sandbox repo root
-    ([repos/<repo>]), not a repo subdirectory or [.worktrees/<task>] path. *)
-
-val invalidate_repo_currency_cache_for_cwd :
-  config:Workspace.config ->
-  meta:Keeper_meta_contract.keeper_meta ->
-  cwd:string ->
+  repo_name:string ->
   unit
-(** Clear the cached currency probe for a direct sandbox repo root cwd. Non-root
-    sandbox repo contexts are ignored. *)
+(** Clear the cached currency probe for [repo_name]. Callers decide when a
+    command is allowed to mutate repo currency. *)
 
 val execution_location_json :
   config:Workspace.config ->

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -469,23 +469,20 @@ let handle_tool_execute_typed
             ~reason:"This typed command is destructive and is blocked for every keeper execution surface."
             ~alternatives:[ "Use a non-destructive command or a dedicated structured tool." ]
             ()
-        let is_git_recovery =
-          Keeper_tool_execute_path.cwd_is_sandbox_repo_root ~config ~meta ~cwd
-          && Masc_exec.Shell_ir_command_shape.is_git_recovery_command ir
+        else
+        let is_git_recovery_command =
+          Masc_exec.Shell_ir_command_shape.is_git_recovery_command ir
         in
-        if is_git_recovery
-        then
-          (match Keeper_tool_execute_path.repo_path_context ~config ~meta cwd with
-           | Some (repo_name, _, _, _) ->
-             Keeper_tool_execute_path.invalidate_repo_currency_cache
-               ~config
-               ~meta
-               ~repo_name
-           | None -> ());
-        if (not write_enabled)
-           && (Masc_exec.Shell_ir_risk.is_r1 envelope
-              || Masc_exec.Shell_ir_risk.is_r2 envelope)
-           && not is_git_recovery
+        let is_direct_repo_git_recovery =
+          Keeper_tool_execute_path.cwd_is_sandbox_repo_root ~config ~meta ~cwd
+          && is_git_recovery_command
+        in
+        let readonly_write_like =
+          is_git_recovery_command
+          || Masc_exec.Shell_ir_risk.is_r1 envelope
+          || Masc_exec.Shell_ir_risk.is_r2 envelope
+        in
+        if (not write_enabled) && readonly_write_like && not is_direct_repo_git_recovery
         then
           blocked_result
             ~deterministic_reason:Keeper_tool_deterministic_error.Write_operation_gated
@@ -557,6 +554,13 @@ let handle_tool_execute_typed
               ~fields:(("blocked_cmd", `String cmd_for_log) :: typed_error_fields)
               e
           | Ok result ->
+            (match result.status with
+             | Unix.WEXITED 0 when is_direct_repo_git_recovery ->
+               Keeper_tool_execute_path.invalidate_repo_currency_cache_for_cwd
+                 ~config
+                 ~meta
+                 ~cwd
+             | _ -> ());
             let elapsed_ms =
               (* NDT-OK: second wall-clock read closes the elapsed telemetry
                  span recorded immediately below. *)

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -471,6 +471,12 @@ let handle_tool_execute_typed
         else if (not write_enabled)
              && (Masc_exec.Shell_ir_risk.is_r1 envelope
                 || Masc_exec.Shell_ir_risk.is_r2 envelope)
+             && not
+                  (Keeper_tool_execute_path.readonly_git_recovery_command
+                     ~config
+                     ~meta
+                     ~cwd
+                     ir)
         then
           blocked_result
             ~deterministic_reason:Keeper_tool_deterministic_error.Write_operation_gated

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -271,19 +271,20 @@ let input_with_cwd cwd = function
   | Keeper_tool_execute_typed_input.Pipeline { stages; cwd = _; env } ->
     Keeper_tool_execute_typed_input.Pipeline { stages; cwd = Some cwd; env }
 
-let typed_input_effective_stages ~mode input =
+let typed_input_shell_ir_unvalidated ~mode input =
   match Keeper_tool_execute_typed_input.to_shell_ir_unvalidated ~mode input with
-  | Error _ -> []
-  | Ok ir ->
-    Keeper_tool_execute_command_semantics.effective_stages_of_ir ir
+  | Error _ -> None
+  | Ok ir -> Some ir
 
-let resolve_typed_git_cwd_of_stages ~config ~meta ~cwd ~cmd stages =
-    Keeper_tool_execute_command_semantics.resolve_sandbox_root_git_cwd_of_stages
+let resolve_typed_git_cwd ~config ~meta ~cwd ~cmd = function
+  | None -> cwd, None
+  | Some ir ->
+    Keeper_tool_execute_command_semantics.resolve_sandbox_root_git_cwd
       ~config
       ~meta
       ~cwd
       ~cmd
-      stages
+      ir
 
 let handle_tool_execute_typed
       ~(turn_sandbox_factory : Keeper_sandbox_factory.t option)
@@ -318,20 +319,20 @@ let handle_tool_execute_typed
           then Keeper_tool_execute_typed_input.Dev_full
           else Keeper_tool_execute_typed_input.Readonly
         in
-        let effective_stages = typed_input_effective_stages ~mode input in
+        let input_ir = typed_input_shell_ir_unvalidated ~mode input in
         let cwd, root_git_cwd_error =
-          resolve_typed_git_cwd_of_stages
+          resolve_typed_git_cwd
             ~config
             ~meta
             ~cwd
             ~cmd
-            effective_stages
+            input_ir
         in
         let root_git_cwd_error =
           match root_git_cwd_error with
           | Some e -> Some e
           | None ->
-            Keeper_tool_execute_command_semantics.misuse_error_of_stages effective_stages
+            Option.bind input_ir Keeper_tool_execute_command_semantics.misuse_error
         in
         let input = input_with_cwd cwd input in
         let in_playground = Keeper_tool_execute_path.in_playground ~root ~cwd ~meta in
@@ -468,15 +469,23 @@ let handle_tool_execute_typed
             ~reason:"This typed command is destructive and is blocked for every keeper execution surface."
             ~alternatives:[ "Use a non-destructive command or a dedicated structured tool." ]
             ()
-        else if (not write_enabled)
-             && (Masc_exec.Shell_ir_risk.is_r1 envelope
-                || Masc_exec.Shell_ir_risk.is_r2 envelope)
-             && not
-                  (Keeper_tool_execute_path.cwd_is_sandbox_repo_context
-                     ~config
-                     ~meta
-                     ~cwd
-                   && Masc_exec.Shell_ir_command_shape.is_git_recovery_command ir)
+        let is_git_recovery =
+          Keeper_tool_execute_path.cwd_is_sandbox_repo_root ~config ~meta ~cwd
+          && Masc_exec.Shell_ir_command_shape.is_git_recovery_command ir
+        in
+        if is_git_recovery
+        then
+          (match Keeper_tool_execute_path.repo_path_context ~config ~meta cwd with
+           | Some (repo_name, _, _, _) ->
+             Keeper_tool_execute_path.invalidate_repo_currency_cache
+               ~config
+               ~meta
+               ~repo_name
+           | None -> ());
+        if (not write_enabled)
+           && (Masc_exec.Shell_ir_risk.is_r1 envelope
+              || Masc_exec.Shell_ir_risk.is_r2 envelope)
+           && not is_git_recovery
         then
           blocked_result
             ~deterministic_reason:Keeper_tool_deterministic_error.Write_operation_gated

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -470,12 +470,25 @@ let handle_tool_execute_typed
             ~alternatives:[ "Use a non-destructive command or a dedicated structured tool." ]
             ()
         else
+        let repo_cwd_context =
+          Keeper_tool_execute_path.repo_cwd_context ~config ~meta ~cwd
+        in
+        let is_direct_sandbox_repo_root =
+          match repo_cwd_context with
+          | Some { Keeper_tool_execute_path.is_direct_root = true; _ } -> true
+          | Some _ | None -> false
+        in
+        let is_git_diagnostic_command =
+          Masc_exec.Shell_ir_command_shape.is_git_diagnostic_command ir
+        in
         let is_git_recovery_command =
           Masc_exec.Shell_ir_command_shape.is_git_recovery_command ir
         in
         let is_direct_repo_git_recovery =
-          Keeper_tool_execute_path.cwd_is_sandbox_repo_root ~config ~meta ~cwd
-          && is_git_recovery_command
+          is_direct_sandbox_repo_root && is_git_recovery_command
+        in
+        let allow_stale_preserved_repo_context =
+          is_git_diagnostic_command || is_direct_repo_git_recovery
         in
         let readonly_write_like =
           is_git_recovery_command
@@ -516,7 +529,7 @@ let handle_tool_execute_typed
                     ~config
                     ~meta
                     ~cwd
-                    ir
+                    ~allow_stale_preserved_repo_context
                 with
                 | Error _ as err -> err
                 | Ok () ->
@@ -554,12 +567,12 @@ let handle_tool_execute_typed
               ~fields:(("blocked_cmd", `String cmd_for_log) :: typed_error_fields)
               e
           | Ok result ->
-            (match result.status with
-             | Unix.WEXITED 0 when is_direct_repo_git_recovery ->
-               Keeper_tool_execute_path.invalidate_repo_currency_cache_for_cwd
+            (match result.status, repo_cwd_context with
+             | Unix.WEXITED 0, Some { repo_name; _ } when is_direct_repo_git_recovery ->
+               Keeper_tool_execute_path.invalidate_repo_currency_cache
                  ~config
                  ~meta
-                 ~cwd
+                 ~repo_name
              | _ -> ());
             let elapsed_ms =
               (* NDT-OK: second wall-clock read closes the elapsed telemetry

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -472,11 +472,11 @@ let handle_tool_execute_typed
              && (Masc_exec.Shell_ir_risk.is_r1 envelope
                 || Masc_exec.Shell_ir_risk.is_r2 envelope)
              && not
-                  (Keeper_tool_execute_path.readonly_git_recovery_command
+                  (Keeper_tool_execute_path.cwd_is_sandbox_repo_context
                      ~config
                      ~meta
                      ~cwd
-                     ir)
+                   && Masc_exec.Shell_ir_command_shape.is_git_recovery_command ir)
         then
           blocked_result
             ~deterministic_reason:Keeper_tool_deterministic_error.Write_operation_gated

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -220,13 +220,13 @@ let typed_execute_response_cwd_json
       ~sandbox_extra_fields
   =
   if sandbox_extra_uses_docker sandbox_extra_fields then
-    match Keeper_sandbox_factory.resolve_opt turn_sandbox_factory ~cwd with
-    | Some runtime ->
-      let container_cwd =
-        Keeper_turn_sandbox_runtime.container_cwd_of_host runtime ~host_cwd:cwd
-      in
-      Keeper_cwd_response.Sandboxed
-        { host_abs = cwd; container_abs = container_cwd }
+    match
+      Keeper_sandbox_factory.container_cwd_of_host_opt
+        turn_sandbox_factory
+        ~host_cwd:cwd
+    with
+    | Some container_cwd ->
+      Keeper_cwd_response.docker ~host_cwd:cwd ~container_cwd
       |> Keeper_cwd_response.to_yojson_response
     | None -> `String cwd
   else `String cwd

--- a/lib/keeper/keeper_types_profile_sandbox.ml
+++ b/lib/keeper/keeper_types_profile_sandbox.ml
@@ -9,7 +9,7 @@ type sandbox_profile =
     (** Containerized execution with hardened defaults: cap-drop,
         no-new-privs, read-only rootfs, tmpfs, pids/memory limits.
         Network defaults to [Network_none]; the internal git/gh
-        dispatcher (see [Keeper_tool_execute_command_semantics.stages_target_repo_commands])
+        dispatcher (see [Keeper_tool_execute_command_semantics.resolve_sandbox_root_git_cwd])
         uses network egress plus read-only mounts from the selected
         credential bundle for the duration of a git/gh command. *)
 
@@ -80,7 +80,7 @@ let default_network_mode_for_profile = function
   | Local -> Network_inherit
   | Docker -> Network_none
   (* git/gh dispatch in Docker upgrades to Network_inherit at runtime
-     via Keeper_tool_execute_command_semantics.stages_target_repo_commands; that upgrade is not
+     via Keeper_tool_execute_command_semantics.resolve_sandbox_root_git_cwd; that upgrade is not
      visible here because it's a per-command decision, not a profile
      default. *)
 ;;

--- a/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.ml
+++ b/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.ml
@@ -377,18 +377,6 @@ let apply_output_to_result ~(meta : keeper_meta)
   | Request_help, Board_post when tool_names = [] ->
       (match deliver_request_help_post ~meta ~state with
       | Request_help_posted ->
-          let result =
-            Keeper_agent_result.append_synthetic_tool_call
-              ~provider:"keeper_social_model"
-              ~route_evidence:
-                (`Assoc
-                  [ "source", `String "bdi_speech_v1"
-                  ; "speech_act", `String "request_help"
-                  ; "delivery_surface", `String "board_post"
-                  ])
-              "keeper_board_post"
-              result
-          in
           ({ result with response_text = "" }, state)
       | Request_help_deduped | Request_help_failed ->
           ({ result with response_text = "" }, state))

--- a/lib/playground_repo_readiness.ml
+++ b/lib/playground_repo_readiness.ml
@@ -31,6 +31,69 @@ let run_git ~timeout_sec ~clone_path args =
   in
   { ok = status = Unix.WEXITED 0; output = String.trim output; status }
 
+let deleted_tracked_path_of_porcelain_line line =
+  let line = String.trim line in
+  let len = String.length line in
+  if len = 0 then None
+  else if String.starts_with ~prefix:"D  " line && len > 3
+  then Some (String.sub line 3 (len - 3))
+  else if String.starts_with ~prefix:"D " line && len > 2
+  then Some (String.sub line 2 (len - 2))
+  else None
+
+let shell_quote_path path =
+  let safe_char = function
+    | 'A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '/' | '.' | '_' | '-' -> true
+    | _ -> false
+  in
+  if path <> "" && String.for_all safe_char path
+  then path
+  else
+    "'"
+    ^ (path
+       |> String.split_on_char '\''
+       |> String.concat "'\\''")
+    ^ "'"
+
+let deleted_tracked_files_restore_hint ~clone_path =
+  let status =
+    run_git
+      ~timeout_sec:read_only_probe_timeout_sec
+      ~clone_path
+      [ "status"; "--porcelain" ]
+  in
+  if not status.ok then None
+  else
+    let changes =
+      status.output
+      |> String.split_on_char '\n'
+      |> List.map String.trim
+      |> List.filter (fun line -> line <> "")
+    in
+    match changes with
+    | [] -> None
+    | changes ->
+      let deleted_paths =
+        List.filter_map deleted_tracked_path_of_porcelain_line changes
+      in
+      if List.length deleted_paths = List.length changes
+      then
+        let status_summary =
+          deleted_paths
+          |> List.map (fun path -> "D " ^ path)
+          |> String.concat "; "
+        in
+        let restore_args =
+          deleted_paths |> List.map shell_quote_path |> String.concat " "
+        in
+        Some
+          (Printf.sprintf
+             " Dirty status only contains deleted tracked files: %s. Restore \
+              them with: git checkout HEAD -- %s"
+             status_summary
+             restore_args)
+      else None
+
 let safe_is_dir path =
   try Sys.file_exists path && Sys.is_directory path with
   | Sys_error _ -> false

--- a/lib/playground_repo_readiness.ml
+++ b/lib/playground_repo_readiness.ml
@@ -60,15 +60,15 @@ let deleted_tracked_files_restore_hint ~clone_path =
     run_git
       ~timeout_sec:read_only_probe_timeout_sec
       ~clone_path
-      [ "status"; "--porcelain" ]
+      [ "status"; "--porcelain"; "-z" ]
   in
   if not status.ok then None
   else
     let changes =
       status.output
-      |> String.split_on_char '\n'
+      |> String.split_on_char '\x00'
       |> List.map String.trim
-      |> List.filter (fun line -> line <> "")
+      |> List.filter (fun record -> record <> "")
     in
     match changes with
     | [] -> None

--- a/lib/playground_repo_readiness.ml
+++ b/lib/playground_repo_readiness.ml
@@ -88,7 +88,7 @@ let deleted_tracked_files_restore_hint ~clone_path =
         in
         Some
           (Printf.sprintf
-             " Dirty status only contains deleted tracked files: %s. Restore \
+             "Dirty status only contains deleted tracked files: %s. Restore \
               them with: git checkout HEAD -- %s"
              status_summary
              restore_args)

--- a/lib/playground_repo_readiness.mli
+++ b/lib/playground_repo_readiness.mli
@@ -20,6 +20,10 @@ val read_only_probe_timeout_sec : float
 val run_git :
   timeout_sec:float -> clone_path:string -> string list -> command_result
 
+val deleted_tracked_files_restore_hint : clone_path:string -> string option
+(** Return a concise restore hint when [git status --porcelain] contains only
+    tracked-file deletions, otherwise [None]. *)
+
 (** [safe_is_dir path] is [true] iff [path] exists and is a directory,
     swallowing [Sys_error]. *)
 val safe_is_dir : string -> bool

--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -31,14 +31,11 @@ module Json = Yojson.Safe.Util
 (* ── Helpers ─────────────────────────────────────────────────────── *)
 
 let resolve_sandbox_root_git_cwd_string ~config ~meta ~cwd ~cmd =
-  let stages =
-    match Masc_exec_bash_parser.Bash.parse_string cmd with
-    | Masc_exec.Parsed.Parsed ir ->
-      Keeper_tool_execute_command_semantics.effective_stages_of_ir ir
-    | _ -> []
-  in
-  Keeper_tool_execute_command_semantics.resolve_sandbox_root_git_cwd_of_stages
-    ~config ~meta ~cwd ~cmd stages
+  match Masc_exec_bash_parser.Bash.parse_string cmd with
+  | Masc_exec.Parsed.Parsed ir ->
+    Keeper_tool_execute_command_semantics.resolve_sandbox_root_git_cwd
+      ~config ~meta ~cwd ~cmd ir
+  | _ -> cwd, None
 
 let with_env key value f =
   let prior = try Some (Sys.getenv key) with Not_found -> None in
@@ -143,6 +140,36 @@ let run_process_ok ~cwd prog argv =
 
 let git_ok ~cwd args =
   run_process_ok ~cwd "git" (Array.of_list ("git" :: args))
+
+let write_repositories_toml ~base_path ~repo_name ~url =
+  let config_dir =
+    Filename.concat (Filename.concat base_path Common.masc_dirname) "config"
+  in
+  ensure_dir config_dir;
+  write_file
+    (Filename.concat config_dir "repositories.toml")
+    (Printf.sprintf
+       "[repository.%s]\nname = \"%s\"\nurl = \"%s\"\n"
+       repo_name
+       repo_name
+       (String.escaped url))
+
+let setup_ready_repo_with_origin ~config ~repo_name ~repo =
+  let base_path = config.Workspace.base_path in
+  let remote = Filename.concat base_path (Printf.sprintf ".remote-%s.git" repo_name) in
+  let seed = Filename.concat base_path (Printf.sprintf "seed-%s" repo_name) in
+  git_ok ~cwd:base_path
+    [ "init"; "--bare"; "-q"; "--initial-branch=main"; remote ];
+  git_ok ~cwd:base_path [ "clone"; "-q"; remote; seed ];
+  git_ok ~cwd:seed [ "config"; "user.email"; "test@example.com" ];
+  git_ok ~cwd:seed [ "config"; "user.name"; "Test" ];
+  write_file (Filename.concat seed "README.md") "v1\n";
+  git_ok ~cwd:seed [ "add"; "README.md" ];
+  git_ok ~cwd:seed [ "commit"; "-q"; "-m"; "init" ];
+  git_ok ~cwd:seed [ "push"; "-q"; "origin"; "main" ];
+  ensure_dir (Filename.dirname repo);
+  git_ok ~cwd:(Filename.dirname repo) [ "clone"; "-q"; remote; repo ];
+  write_repositories_toml ~base_path ~repo_name ~url:remote
 
 let ensure_git_repo repo =
   ensure_dir repo;
@@ -892,8 +919,7 @@ let test_execute_git_uses_turn_runtime () =
   with_fake_docker fake_docker_echo_script @@ fun () ->
   setup_with_tool_access ~sandbox:Keeper_types_profile_sandbox.Docker @@ fun ~config ~meta ~playground ->
   let repo = Filename.concat (Filename.concat playground "repos") "masc" in
-  ensure_dir repo;
-  git_ok ~cwd:repo [ "init"; "-q" ];
+  setup_ready_repo_with_origin ~config ~repo_name:"masc" ~repo;
   let log_path = Filename.concat config.Workspace.base_path "docker.log" in
   with_turn_sandbox_factory ~config ~meta @@ fun factory ->
   with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
@@ -927,8 +953,7 @@ let test_execute_git_without_github_bundle_succeeds () =
   with_fake_docker fake_docker_echo_script @@ fun () ->
   setup_with_tool_access ~sandbox:Keeper_types_profile_sandbox.Docker @@ fun ~config ~meta ~playground ->
   let repo = Filename.concat (Filename.concat playground "repos") "masc" in
-  ensure_dir repo;
-  git_ok ~cwd:repo [ "init"; "-q" ];
+  setup_ready_repo_with_origin ~config ~repo_name:"masc" ~repo;
   let log_path = Filename.concat config.Workspace.base_path "docker.log" in
   with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
   with_env "MASC_KEEPER_SANDBOX_SECCOMP_PROFILE" "" @@ fun () ->
@@ -1580,8 +1605,7 @@ let test_cmd_prefix_uses_shell_command_words () =
 let detect_repo_hosting_cli_repo_api_misuse_of_string cmd =
   match Masc_exec_bash_parser.Bash.parse_string cmd with
   | Masc_exec.Parsed.Parsed ir ->
-    let stages = Keeper_tool_execute_command_semantics.effective_stages_of_ir ir in
-    Keeper_tool_execute_command_semantics.repo_hosting_cli_repo_flag_api_misuse_of_stages stages
+    Keeper_tool_execute_command_semantics.repo_hosting_cli_repo_flag_api_misuse ir
   | _ -> None
 
 let test_repo_hosting_cli_repo_api_misuse_uses_shell_semantics () =
@@ -1611,8 +1635,7 @@ let test_repo_hosting_cli_repo_api_misuse_uses_shell_semantics () =
 let detect_gh_pr_diff_misuse_of_string cmd =
   match Masc_exec_bash_parser.Bash.parse_string cmd with
   | Masc_exec.Parsed.Parsed ir ->
-    let stages = Keeper_tool_execute_command_semantics.effective_stages_of_ir ir in
-    Keeper_tool_execute_command_semantics.gh_pr_diff_misuse_of_stages stages
+    Keeper_tool_execute_command_semantics.gh_pr_diff_misuse ir
   | _ -> None
 
 let test_gh_pr_diff_misuse_uses_shell_semantics () =

--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -1122,8 +1122,7 @@ let test_execute_git_push_routes_through_docker () =
   with_fake_docker fake_docker_echo_script @@ fun () ->
   setup_with_tool_access ~sandbox:Keeper_types_profile_sandbox.Docker @@ fun ~config ~meta ~playground ->
   let repo = Filename.concat (Filename.concat playground "repos") "masc" in
-  ensure_dir repo;
-  git_ok ~cwd:repo [ "init"; "-q" ];
+  setup_ready_repo_with_origin ~config ~repo_name:"masc" ~repo;
   let log_path = Filename.concat config.Workspace.base_path "docker.log" in
   with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
   with_turn_sandbox_factory ~config ~meta @@ fun factory ->

--- a/test/test_keeper_tool_execute_safety.ml
+++ b/test/test_keeper_tool_execute_safety.ml
@@ -420,7 +420,7 @@ let setup_preserved_sandbox_repo ~keeper_name =
   write_file (Filename.concat repo_dir "local-dirty.txt") "dirty\n";
   base_path, config, meta, repo_dir
 
-let setup_cascade_deleted_sandbox_repo ~keeper_name =
+let setup_deleted_tracked_files_sandbox_repo ~keeper_name =
   let base_path, config = make_config () in
   let meta = { (make_local_meta keeper_name) with tool_access = [] } in
   let remote = Filename.concat base_path ".remote-masc.git" in
@@ -431,19 +431,19 @@ let setup_cascade_deleted_sandbox_repo ~keeper_name =
   git_ok ~cwd:seed [ "config"; "user.email"; "test@example.com" ];
   git_ok ~cwd:seed [ "config"; "user.name"; "Test" ];
   write_file (Filename.concat seed "README.md") "v1\n";
-  write_file (Filename.concat seed "config/cascade.toml") "legacy cascade\n";
-  write_file
-    (Filename.concat seed "test/fixtures/cascade-phonebook.toml")
-    "legacy fixture\n";
-  git_ok ~cwd:seed [ "add"; "README.md"; "config/cascade.toml"; "test/fixtures/cascade-phonebook.toml" ];
+  write_file (Filename.concat seed "config/deleted-one.txt") "tracked one\n";
+  write_file (Filename.concat seed "test/fixtures/deleted-two.txt") "tracked two\n";
+  git_ok
+    ~cwd:seed
+    [ "add"; "README.md"; "config/deleted-one.txt"; "test/fixtures/deleted-two.txt" ];
   git_ok ~cwd:seed [ "commit"; "-q"; "-m"; "init" ];
   git_ok ~cwd:seed [ "push"; "-q"; "origin"; "main" ];
   let playground = Filename.concat base_path (playground_path_of meta.name) in
   let repo_dir = Filename.concat playground "repos/masc" in
   ensure_dir (Filename.dirname repo_dir);
   git_ok ~cwd:(Filename.dirname repo_dir) [ "clone"; "-q"; remote; repo_dir ];
-  Sys.remove (Filename.concat repo_dir "config/cascade.toml");
-  Sys.remove (Filename.concat repo_dir "test/fixtures/cascade-phonebook.toml");
+  Sys.remove (Filename.concat repo_dir "config/deleted-one.txt");
+  Sys.remove (Filename.concat repo_dir "test/fixtures/deleted-two.txt");
   write_repositories_toml ~base_path ~repo_name:"masc" ~url:remote;
   write_file (Filename.concat seed "README.md") "v2\n";
   git_ok ~cwd:seed [ "add"; "README.md" ];
@@ -738,40 +738,6 @@ let test_tool_execute_blocks_preserved_direct_repo_git_show () =
       (String_util.contains_substring raw "v2")
   | None -> Alcotest.fail ("expected stale repo error json, got: " ^ raw)
 
-let test_tool_execute_preserved_direct_repo_cascade_hint () =
-  with_eio_fs @@ fun () ->
-  let base_path, config, meta, _repo_dir =
-    setup_cascade_deleted_sandbox_repo ~keeper_name:"stale-cascade-hint"
-  in
-  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
-  Keeper_registry.clear ();
-  let raw =
-    Keeper_tool_command_runtime.handle_tool_execute
-      ~turn_sandbox_factory:None
-      ~exec_cache:None
-      ~config
-      ~meta
-      ~args:
-        (`Assoc
-           [ "executable", `String "git"
-           ; "argv", `List [ `String "show"; `String "origin/main:README.md" ]
-           ; "cwd", `String "repos/masc"
-           ])
-      ()
-  in
-  match parse_error_field raw with
-  | Some err ->
-    Alcotest.(check bool) "stale direct repo root is rejected" true
-      (String_util.contains_substring err "sandbox_repo_stale");
-    Alcotest.(check bool) "cascade config deletion is surfaced" true
-      (String_util.contains_substring err "D config/cascade.toml");
-    Alcotest.(check bool) "cascade fixture deletion is surfaced" true
-      (String_util.contains_substring err "D test/fixtures/cascade-phonebook.toml");
-    Alcotest.(check bool) "restore command is surfaced" true
-      (String_util.contains_substring err
-         "git checkout HEAD -- config/cascade.toml test/fixtures/cascade-phonebook.toml")
-  | None -> Alcotest.fail ("expected stale repo error json, got: " ^ raw)
-
 let test_tool_execute_allows_preserved_direct_repo_git_status () =
   with_eio_fs @@ fun () ->
   let base_path, config, meta, _repo_dir =
@@ -807,7 +773,8 @@ let test_tool_execute_allows_preserved_direct_repo_git_status () =
 let test_tool_execute_allows_preserved_direct_repo_git_checkout_head_restore () =
   with_eio_fs @@ fun () ->
   let base_path, config, meta, repo_dir =
-    setup_cascade_deleted_sandbox_repo ~keeper_name:"stale-direct-git-checkout-head"
+    setup_deleted_tracked_files_sandbox_repo
+      ~keeper_name:"stale-direct-git-checkout-head"
   in
   Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
   Keeper_registry.clear ();
@@ -825,8 +792,8 @@ let test_tool_execute_allows_preserved_direct_repo_git_checkout_head_restore () 
                  [ `String "checkout"
                  ; `String "HEAD"
                  ; `String "--"
-                 ; `String "config/cascade.toml"
-                 ; `String "test/fixtures/cascade-phonebook.toml"
+                 ; `String "config/deleted-one.txt"
+                 ; `String "test/fixtures/deleted-two.txt"
                  ] )
            ; "cwd", `String "repos/masc"
            ])
@@ -839,11 +806,10 @@ let test_tool_execute_allows_preserved_direct_repo_git_checkout_head_restore () 
     (String_util.contains_substring raw "write_operation_gated");
   Alcotest.(check bool) "stale gate did not block recovery checkout" false
     (String_util.contains_substring raw "sandbox_repo_stale");
-  Alcotest.(check bool) "cascade config restored" true
-    (Sys.file_exists (Filename.concat repo_dir "config/cascade.toml"));
-  Alcotest.(check bool) "cascade fixture restored" true
-    (Sys.file_exists
-       (Filename.concat repo_dir "test/fixtures/cascade-phonebook.toml"))
+  Alcotest.(check bool) "first tracked file restored" true
+    (Sys.file_exists (Filename.concat repo_dir "config/deleted-one.txt"));
+  Alcotest.(check bool) "second tracked file restored" true
+    (Sys.file_exists (Filename.concat repo_dir "test/fixtures/deleted-two.txt"))
 
 let test_tool_execute_allows_preserved_direct_repo_git_reset_hard_head () =
   with_eio_fs @@ fun () ->
@@ -1956,10 +1922,6 @@ let () =
             "preserved direct repo root blocks git show"
             `Quick
             test_tool_execute_blocks_preserved_direct_repo_git_show
-        ; Alcotest.test_case
-            "preserved direct repo root gives cascade restore hint"
-            `Quick
-            test_tool_execute_preserved_direct_repo_cascade_hint
         ; Alcotest.test_case
             "preserved direct repo root allows git status"
             `Quick

--- a/test/test_keeper_tool_execute_safety.ml
+++ b/test/test_keeper_tool_execute_safety.ml
@@ -873,6 +873,73 @@ let test_tool_execute_allows_preserved_direct_repo_git_clean_df () =
   Alcotest.(check bool) "dirty fixture removed by clean" false
     (Sys.file_exists dirty_path)
 
+let test_tool_execute_git_recovery_invalidates_repo_currency_cache () =
+  with_eio_fs @@ fun () ->
+  let base_path, config, meta, _repo_dir =
+    setup_preserved_sandbox_repo ~keeper_name:"stale-direct-git-clean-cache"
+  in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  Keeper_registry.clear ();
+  let run executable argv =
+    Keeper_tool_command_runtime.handle_tool_execute
+      ~turn_sandbox_factory:None
+      ~exec_cache:None
+      ~config
+      ~meta
+      ~args:
+        (`Assoc
+           [ "executable", `String executable
+           ; "argv", `List (List.map (fun arg -> `String arg) argv)
+           ; "cwd", `String "repos/masc"
+           ])
+      ()
+  in
+  let stale_raw = run "cat" [ "README.md" ] in
+  Alcotest.(check bool) "initial read populates stale cache" true
+    (String_util.contains_substring stale_raw "sandbox_repo_stale");
+  let clean_raw = run "git" [ "clean"; "-df" ] in
+  let clean_json = Yojson.Safe.from_string clean_raw in
+  Alcotest.(check bool) "recovery clean succeeds" true
+    (clean_json |> Json.member "ok" |> Json.to_bool);
+  let retry_raw = run "cat" [ "README.md" ] in
+  Alcotest.(check bool) "immediate retry is not stale-cached" false
+    (String_util.contains_substring retry_raw "sandbox_repo_stale");
+  let retry_json = Yojson.Safe.from_string retry_raw in
+  Alcotest.(check bool) "immediate retry succeeds" true
+    (retry_json |> Json.member "ok" |> Json.to_bool);
+  Alcotest.(check bool) "retry observes advanced repo" true
+    (retry_json
+     |> Json.member "output"
+     |> Json.to_string
+     |> fun output -> String_util.contains_substring output "v2")
+
+let test_tool_execute_readonly_blocks_worktree_git_recovery () =
+  with_eio_fs @@ fun () ->
+  let base_path, config, meta, repo_dir =
+    setup_preserved_sandbox_repo ~keeper_name:"worktree-git-recovery-block"
+  in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  Keeper_registry.clear ();
+  ensure_dir (Filename.concat repo_dir ".worktrees");
+  git_ok ~cwd:repo_dir [ "worktree"; "add"; "-q"; "--detach"; ".worktrees/task"; "HEAD" ];
+  let raw =
+    Keeper_tool_command_runtime.handle_tool_execute
+      ~turn_sandbox_factory:None
+      ~exec_cache:None
+      ~config
+      ~meta
+      ~args:
+        (`Assoc
+           [ "executable", `String "git"
+           ; "argv", `List [ `String "clean"; `String "-df" ]
+           ; "cwd", `String "repos/masc/.worktrees/task"
+           ])
+      ()
+  in
+  Alcotest.(check (option string)) "worktree recovery is write-gated"
+    (Some "write_operation_gated")
+    (parse_error_field raw)
+
 let test_tool_execute_readonly_blocks_non_recovery_git_writes () =
   with_eio_fs @@ fun () ->
   let base_path, config = make_config () in
@@ -1945,6 +2012,14 @@ let () =
             "preserved direct repo root allows git clean -df"
             `Quick
             test_tool_execute_allows_preserved_direct_repo_git_clean_df
+        ; Alcotest.test_case
+            "git recovery invalidates stale currency cache"
+            `Quick
+            test_tool_execute_git_recovery_invalidates_repo_currency_cache
+        ; Alcotest.test_case
+            "readonly Execute blocks worktree git recovery"
+            `Quick
+            test_tool_execute_readonly_blocks_worktree_git_recovery
         ; Alcotest.test_case
             "readonly Execute blocks non-recovery git writes"
             `Quick

--- a/test/test_keeper_tool_execute_safety.ml
+++ b/test/test_keeper_tool_execute_safety.ml
@@ -396,7 +396,7 @@ let write_repositories_toml ~base_path ~repo_name ~url =
 
 let setup_preserved_sandbox_repo ~keeper_name =
   let base_path, config = make_config () in
-  let meta = make_local_meta keeper_name in
+  let meta = { (make_local_meta keeper_name) with tool_access = [] } in
   let remote = Filename.concat base_path ".remote-masc.git" in
   let seed = Filename.concat base_path "seed-masc" in
   git_ok ~cwd:base_path
@@ -418,6 +418,37 @@ let setup_preserved_sandbox_repo ~keeper_name =
   git_ok ~cwd:seed [ "commit"; "-q"; "-m"; "advance" ];
   git_ok ~cwd:seed [ "push"; "-q"; "origin"; "main" ];
   write_file (Filename.concat repo_dir "local-dirty.txt") "dirty\n";
+  base_path, config, meta, repo_dir
+
+let setup_cascade_deleted_sandbox_repo ~keeper_name =
+  let base_path, config = make_config () in
+  let meta = { (make_local_meta keeper_name) with tool_access = [] } in
+  let remote = Filename.concat base_path ".remote-masc.git" in
+  let seed = Filename.concat base_path "seed-masc" in
+  git_ok ~cwd:base_path
+    [ "init"; "--bare"; "-q"; "--initial-branch=main"; remote ];
+  git_ok ~cwd:base_path [ "clone"; "-q"; remote; seed ];
+  git_ok ~cwd:seed [ "config"; "user.email"; "test@example.com" ];
+  git_ok ~cwd:seed [ "config"; "user.name"; "Test" ];
+  write_file (Filename.concat seed "README.md") "v1\n";
+  write_file (Filename.concat seed "config/cascade.toml") "legacy cascade\n";
+  write_file
+    (Filename.concat seed "test/fixtures/cascade-phonebook.toml")
+    "legacy fixture\n";
+  git_ok ~cwd:seed [ "add"; "README.md"; "config/cascade.toml"; "test/fixtures/cascade-phonebook.toml" ];
+  git_ok ~cwd:seed [ "commit"; "-q"; "-m"; "init" ];
+  git_ok ~cwd:seed [ "push"; "-q"; "origin"; "main" ];
+  let playground = Filename.concat base_path (playground_path_of meta.name) in
+  let repo_dir = Filename.concat playground "repos/masc" in
+  ensure_dir (Filename.dirname repo_dir);
+  git_ok ~cwd:(Filename.dirname repo_dir) [ "clone"; "-q"; remote; repo_dir ];
+  Sys.remove (Filename.concat repo_dir "config/cascade.toml");
+  Sys.remove (Filename.concat repo_dir "test/fixtures/cascade-phonebook.toml");
+  write_repositories_toml ~base_path ~repo_name:"masc" ~url:remote;
+  write_file (Filename.concat seed "README.md") "v2\n";
+  git_ok ~cwd:seed [ "add"; "README.md" ];
+  git_ok ~cwd:seed [ "commit"; "-q"; "-m"; "advance" ];
+  git_ok ~cwd:seed [ "push"; "-q"; "origin"; "main" ];
   base_path, config, meta, repo_dir
 
 let parse_error_field raw =
@@ -707,6 +738,40 @@ let test_tool_execute_blocks_preserved_direct_repo_git_show () =
       (String_util.contains_substring raw "v2")
   | None -> Alcotest.fail ("expected stale repo error json, got: " ^ raw)
 
+let test_tool_execute_preserved_direct_repo_cascade_hint () =
+  with_eio_fs @@ fun () ->
+  let base_path, config, meta, _repo_dir =
+    setup_cascade_deleted_sandbox_repo ~keeper_name:"stale-cascade-hint"
+  in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  Keeper_registry.clear ();
+  let raw =
+    Keeper_tool_command_runtime.handle_tool_execute
+      ~turn_sandbox_factory:None
+      ~exec_cache:None
+      ~config
+      ~meta
+      ~args:
+        (`Assoc
+           [ "executable", `String "git"
+           ; "argv", `List [ `String "show"; `String "origin/main:README.md" ]
+           ; "cwd", `String "repos/masc"
+           ])
+      ()
+  in
+  match parse_error_field raw with
+  | Some err ->
+    Alcotest.(check bool) "stale direct repo root is rejected" true
+      (String_util.contains_substring err "sandbox_repo_stale");
+    Alcotest.(check bool) "cascade config deletion is surfaced" true
+      (String_util.contains_substring err "D config/cascade.toml");
+    Alcotest.(check bool) "cascade fixture deletion is surfaced" true
+      (String_util.contains_substring err "D test/fixtures/cascade-phonebook.toml");
+    Alcotest.(check bool) "restore command is surfaced" true
+      (String_util.contains_substring err
+         "git checkout HEAD -- config/cascade.toml test/fixtures/cascade-phonebook.toml")
+  | None -> Alcotest.fail ("expected stale repo error json, got: " ^ raw)
+
 let test_tool_execute_allows_preserved_direct_repo_git_status () =
   with_eio_fs @@ fun () ->
   let base_path, config, meta, _repo_dir =
@@ -738,6 +803,140 @@ let test_tool_execute_allows_preserved_direct_repo_git_status () =
      |> fun output -> String_util.contains_substring output "local-dirty.txt");
   Alcotest.(check bool) "stale gate did not block diagnostic" false
     (String_util.contains_substring raw "sandbox_repo_stale")
+
+let test_tool_execute_allows_preserved_direct_repo_git_checkout_head_restore () =
+  with_eio_fs @@ fun () ->
+  let base_path, config, meta, repo_dir =
+    setup_cascade_deleted_sandbox_repo ~keeper_name:"stale-direct-git-checkout-head"
+  in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  Keeper_registry.clear ();
+  let raw =
+    Keeper_tool_command_runtime.handle_tool_execute
+      ~turn_sandbox_factory:None
+      ~exec_cache:None
+      ~config
+      ~meta
+      ~args:
+        (`Assoc
+           [ "executable", `String "git"
+           ; ( "argv"
+             , `List
+                 [ `String "checkout"
+                 ; `String "HEAD"
+                 ; `String "--"
+                 ; `String "config/cascade.toml"
+                 ; `String "test/fixtures/cascade-phonebook.toml"
+                 ] )
+           ; "cwd", `String "repos/masc"
+           ])
+      ()
+  in
+  let json = Yojson.Safe.from_string raw in
+  Alcotest.(check bool) "recovery checkout succeeds" true
+    (json |> Json.member "ok" |> Json.to_bool);
+  Alcotest.(check bool) "write gate did not block recovery checkout" false
+    (String_util.contains_substring raw "write_operation_gated");
+  Alcotest.(check bool) "stale gate did not block recovery checkout" false
+    (String_util.contains_substring raw "sandbox_repo_stale");
+  Alcotest.(check bool) "cascade config restored" true
+    (Sys.file_exists (Filename.concat repo_dir "config/cascade.toml"));
+  Alcotest.(check bool) "cascade fixture restored" true
+    (Sys.file_exists
+       (Filename.concat repo_dir "test/fixtures/cascade-phonebook.toml"))
+
+let test_tool_execute_allows_preserved_direct_repo_git_reset_hard_head () =
+  with_eio_fs @@ fun () ->
+  let base_path, config, meta, _repo_dir =
+    setup_preserved_sandbox_repo ~keeper_name:"stale-direct-git-reset-head"
+  in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  Keeper_registry.clear ();
+  let raw =
+    Keeper_tool_command_runtime.handle_tool_execute
+      ~turn_sandbox_factory:None
+      ~exec_cache:None
+      ~config
+      ~meta
+      ~args:
+        (`Assoc
+           [ "executable", `String "git"
+           ; "argv", `List [ `String "reset"; `String "--hard"; `String "HEAD" ]
+           ; "cwd", `String "repos/masc"
+           ])
+      ()
+  in
+  let json = Yojson.Safe.from_string raw in
+  Alcotest.(check bool) "recovery reset succeeds" true
+    (json |> Json.member "ok" |> Json.to_bool);
+  Alcotest.(check bool) "write gate did not block recovery reset" false
+    (String_util.contains_substring raw "write_operation_gated");
+  Alcotest.(check bool) "stale gate did not block recovery reset" false
+    (String_util.contains_substring raw "sandbox_repo_stale")
+
+let test_tool_execute_allows_preserved_direct_repo_git_clean_df () =
+  with_eio_fs @@ fun () ->
+  let base_path, config, meta, repo_dir =
+    setup_preserved_sandbox_repo ~keeper_name:"stale-direct-git-clean-df"
+  in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  Keeper_registry.clear ();
+  let dirty_path = Filename.concat repo_dir "local-dirty.txt" in
+  Alcotest.(check bool) "dirty fixture exists before clean" true
+    (Sys.file_exists dirty_path);
+  let raw =
+    Keeper_tool_command_runtime.handle_tool_execute
+      ~turn_sandbox_factory:None
+      ~exec_cache:None
+      ~config
+      ~meta
+      ~args:
+        (`Assoc
+           [ "executable", `String "git"
+           ; "argv", `List [ `String "clean"; `String "-df" ]
+           ; "cwd", `String "repos/masc"
+           ])
+      ()
+  in
+  let json = Yojson.Safe.from_string raw in
+  Alcotest.(check bool) "recovery clean succeeds" true
+    (json |> Json.member "ok" |> Json.to_bool);
+  Alcotest.(check bool) "stale gate did not block recovery clean" false
+    (String_util.contains_substring raw "sandbox_repo_stale");
+  Alcotest.(check bool) "dirty fixture removed by clean" false
+    (Sys.file_exists dirty_path)
+
+let test_tool_execute_readonly_blocks_non_recovery_git_writes () =
+  with_eio_fs @@ fun () ->
+  let base_path, config = make_config () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  Keeper_registry.clear ();
+  let meta =
+    { (make_local_meta "non-recovery-git-write") with tool_access = [] }
+  in
+  let playground = Filename.concat base_path (playground_path_of meta.name) in
+  ensure_dir (Filename.concat playground "repos/masc");
+  let check argv =
+    let raw =
+      Keeper_tool_command_runtime.handle_tool_execute
+        ~turn_sandbox_factory:None
+        ~exec_cache:None
+        ~config
+        ~meta
+        ~args:
+          (`Assoc
+             [ "executable", `String "git"
+             ; "argv", `List (List.map (fun arg -> `String arg) argv)
+             ; "cwd", `String "repos/masc"
+             ])
+        ()
+    in
+    Alcotest.(check (option string)) "non-recovery git write is gated"
+      (Some "write_operation_gated")
+      (parse_error_field raw)
+  in
+  check [ "checkout"; "other-branch" ];
+  check [ "reset"; "--hard"; "HEAD~1" ]
 
 let test_tool_execute_elapsed_duration_preserves_positive_sub_ms () =
   let elapsed = Keeper_tool_command_runtime.For_testing.elapsed_duration_ms in
@@ -1758,9 +1957,29 @@ let () =
             `Quick
             test_tool_execute_blocks_preserved_direct_repo_git_show
         ; Alcotest.test_case
+            "preserved direct repo root gives cascade restore hint"
+            `Quick
+            test_tool_execute_preserved_direct_repo_cascade_hint
+        ; Alcotest.test_case
             "preserved direct repo root allows git status"
             `Quick
             test_tool_execute_allows_preserved_direct_repo_git_status
+        ; Alcotest.test_case
+            "preserved direct repo root allows git checkout HEAD restore"
+            `Quick
+            test_tool_execute_allows_preserved_direct_repo_git_checkout_head_restore
+        ; Alcotest.test_case
+            "preserved direct repo root allows git reset --hard HEAD"
+            `Quick
+            test_tool_execute_allows_preserved_direct_repo_git_reset_hard_head
+        ; Alcotest.test_case
+            "preserved direct repo root allows git clean -df"
+            `Quick
+            test_tool_execute_allows_preserved_direct_repo_git_clean_df
+        ; Alcotest.test_case
+            "readonly Execute blocks non-recovery git writes"
+            `Quick
+            test_tool_execute_readonly_blocks_non_recovery_git_writes
         ] )
     ; ( "edge"
       , [ Alcotest.test_case

--- a/test/test_keeper_tool_execute_safety.ml
+++ b/test/test_keeper_tool_execute_safety.ml
@@ -1437,7 +1437,11 @@ let test_tool_execute_typed_docker_falls_back_to_local_playground () =
   let base_path, config = make_config () in
   Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
   Keeper_registry.clear ();
-  let meta = make_docker_meta "typed-docker" in
+  let meta =
+    { (make_docker_meta "typed-docker") with
+      sandbox_image = Some "masc-test-missing-image:typed-fallback"
+    }
+  in
   let playground = Keeper_sandbox.host_root_abs_of_meta ~config meta in
   ensure_dir playground;
   let raw =

--- a/test/test_keeper_tool_execute_safety.ml
+++ b/test/test_keeper_tool_execute_safety.ml
@@ -374,7 +374,8 @@ let run_process_ok ~cwd prog argv =
       (Masc.Keeper_sandbox_exec_failure.status_label status)
       stdout stderr
 
-let git_ok ~cwd args = run_process_ok ~cwd "git" args
+let git_ok ~cwd args =
+  run_process_ok ~cwd "git" ("-c" :: "core.hooksPath=/dev/null" :: args)
 
 let write_file path content =
   ensure_dir (Filename.dirname path);
@@ -881,7 +882,9 @@ let test_tool_execute_readonly_blocks_non_recovery_git_writes () =
     { (make_local_meta "non-recovery-git-write") with tool_access = [] }
   in
   let playground = Filename.concat base_path (playground_path_of meta.name) in
-  ensure_dir (Filename.concat playground "repos/masc");
+  let repo_dir = Filename.concat playground "repos/masc" in
+  ensure_dir repo_dir;
+  git_ok ~cwd:repo_dir [ "init"; "-q"; "--initial-branch=main" ];
   let check argv =
     let raw =
       Keeper_tool_command_runtime.handle_tool_execute

--- a/test/test_keeper_unified_claim_progress.ml
+++ b/test/test_keeper_unified_claim_progress.ml
@@ -133,37 +133,6 @@ let test_contract_progress_filters_no_progress_tool_results () =
          ])
 ;;
 
-let test_failed_tool_only_turn_violates_contract () =
-  let failed_only = [ tool_call_detail ~outcome:"error" "ToolThatDoesNotExist" ] in
-  check
-    bool
-    "failed-only tool turn is a violation"
-    true
-    (KAR.For_testing.failed_tool_only_contract_violation
-       ~actual_keeper_tool_names:[]
-       ~tool_calls:failed_only);
-  check
-    string
-    "failed-only tool turn is not satisfied completion"
-    "violated"
-    (KAR.Contract_helpers.observed_completion_contract_status
-       ~had_owned_active_task_at_turn_start:false
-       ~actual_keeper_tool_names:[]
-       ~tool_calls:failed_only
-     |> Masc.Keeper_execution_receipt.completion_contract_result_to_string)
-;;
-
-let test_synthetic_board_post_tool_detail () =
-  let detail =
-    KAR.synthetic_tool_call_detail
-      ~provider:"keeper_social_model"
-      "keeper_board_post"
-  in
-  check string "synthetic tool name" "keeper_board_post" detail.tool_name;
-  check string "synthetic tool outcome" "ok" detail.outcome;
-  check string "synthetic provider" "keeper_social_model" detail.provider
-;;
-
 let () =
   run
     "keeper_unified_claim_progress"
@@ -188,14 +157,6 @@ let () =
             "contract progress filters no-progress tool results"
             `Quick
             test_contract_progress_filters_no_progress_tool_results
-        ; test_case
-            "failed tool-only turn violates contract"
-            `Quick
-            test_failed_tool_only_turn_violates_contract
-        ; test_case
-            "synthetic board-post evidence keeps progress visible"
-            `Quick
-            test_synthetic_board_post_tool_detail
         ] )
     ]
 ;;

--- a/test/test_playground_repo_readiness.ml
+++ b/test/test_playground_repo_readiness.ml
@@ -165,6 +165,36 @@ let git_output ~cwd args =
          (String.concat " " args)
          result.output)
 
+let test_deleted_tracked_files_restore_hint () =
+  let clone_path = temp_dir "masc-repo-readiness-status-hint" in
+  git_ok ~cwd:clone_path [ "init"; "-q"; "--initial-branch=main" ];
+  git_ok ~cwd:clone_path [ "config"; "user.email"; "test@example.com" ];
+  git_ok ~cwd:clone_path [ "config"; "user.name"; "Test" ];
+  mkdir_p (Filename.concat clone_path "config");
+  mkdir_p (Filename.concat clone_path "test/fixtures");
+  write_file (Filename.concat clone_path "config/deleted-one.txt") "tracked one\n";
+  write_file
+    (Filename.concat clone_path "test/fixtures/deleted-two.txt")
+    "tracked two\n";
+  git_ok
+    ~cwd:clone_path
+    [ "add"; "config/deleted-one.txt"; "test/fixtures/deleted-two.txt" ];
+  git_ok ~cwd:clone_path [ "commit"; "-q"; "-m"; "init" ];
+  Sys.remove (Filename.concat clone_path "config/deleted-one.txt");
+  Sys.remove (Filename.concat clone_path "test/fixtures/deleted-two.txt");
+  (match Masc.Playground_repo_readiness.deleted_tracked_files_restore_hint ~clone_path with
+   | Some hint ->
+     check bool "restore command surfaced" true
+       (String.equal
+          hint
+          " Dirty status only contains deleted tracked files: D config/deleted-one.txt; D \
+           test/fixtures/deleted-two.txt. Restore them with: git checkout HEAD -- \
+           config/deleted-one.txt test/fixtures/deleted-two.txt")
+   | None -> fail "expected deleted tracked files restore hint");
+  write_file (Filename.concat clone_path "untracked.txt") "untracked\n";
+  check (option string) "mixed dirty status has no restore hint" None
+    (Masc.Playground_repo_readiness.deleted_tracked_files_restore_hint ~clone_path)
+
 let test_parent_git_checkout_does_not_count_as_clone () =
   let base_path = temp_dir "masc-repo-readiness" in
   git_ok ~cwd:base_path [ "init"; "-q"; "--initial-branch=main" ];
@@ -717,6 +747,8 @@ let () =
         test_case "missing clone skips workspace discovery" `Quick
           test_missing_clone_skips_workspace_discovery;
       ];
+      "status_hints", [ test_case "deleted tracked files restore hint" `Quick
+                          test_deleted_tracked_files_restore_hint ];
       "ensure_worktree_ready",
       [
         test_case "creates worktree" `Quick

--- a/test/test_playground_repo_readiness.ml
+++ b/test/test_playground_repo_readiness.ml
@@ -195,6 +195,24 @@ let test_deleted_tracked_files_restore_hint () =
   check (option string) "mixed dirty status has no restore hint" None
     (Masc.Playground_repo_readiness.deleted_tracked_files_restore_hint ~clone_path)
 
+let test_deleted_tracked_files_restore_hint_uses_unquoted_porcelain_paths () =
+  let clone_path = temp_dir "masc-repo-readiness-status-hint-spaces" in
+  git_ok ~cwd:clone_path [ "init"; "-q"; "--initial-branch=main" ];
+  git_ok ~cwd:clone_path [ "config"; "user.email"; "test@example.com" ];
+  git_ok ~cwd:clone_path [ "config"; "user.name"; "Test" ];
+  write_file (Filename.concat clone_path "a b.txt") "tracked with space\n";
+  git_ok ~cwd:clone_path [ "add"; "a b.txt" ];
+  git_ok ~cwd:clone_path [ "commit"; "-q"; "-m"; "init" ];
+  Sys.remove (Filename.concat clone_path "a b.txt");
+  match Masc.Playground_repo_readiness.deleted_tracked_files_restore_hint ~clone_path with
+  | Some hint ->
+    check bool "restore command uses shell-quoted real path" true
+      (String.equal
+         hint
+         "Dirty status only contains deleted tracked files: D a b.txt. Restore them \
+          with: git checkout HEAD -- 'a b.txt'")
+  | None -> fail "expected deleted tracked file restore hint for path with spaces"
+
 let test_parent_git_checkout_does_not_count_as_clone () =
   let base_path = temp_dir "masc-repo-readiness" in
   git_ok ~cwd:base_path [ "init"; "-q"; "--initial-branch=main" ];
@@ -747,8 +765,13 @@ let () =
         test_case "missing clone skips workspace discovery" `Quick
           test_missing_clone_skips_workspace_discovery;
       ];
-      "status_hints", [ test_case "deleted tracked files restore hint" `Quick
-                          test_deleted_tracked_files_restore_hint ];
+      "status_hints",
+      [
+        test_case "deleted tracked files restore hint" `Quick
+          test_deleted_tracked_files_restore_hint;
+        test_case "deleted tracked file with spaces restore hint" `Quick
+          test_deleted_tracked_files_restore_hint_uses_unquoted_porcelain_paths;
+      ];
       "ensure_worktree_ready",
       [
         test_case "creates worktree" `Quick

--- a/test/test_playground_repo_readiness.ml
+++ b/test/test_playground_repo_readiness.ml
@@ -187,7 +187,7 @@ let test_deleted_tracked_files_restore_hint () =
      check bool "restore command surfaced" true
        (String.equal
           hint
-          " Dirty status only contains deleted tracked files: D config/deleted-one.txt; D \
+          "Dirty status only contains deleted tracked files: D config/deleted-one.txt; D \
            test/fixtures/deleted-two.txt. Restore them with: git checkout HEAD -- \
            config/deleted-one.txt test/fixtures/deleted-two.txt")
    | None -> fail "expected deleted tracked files restore hint");


### PR DESCRIPTION
## Summary
- move pure Shell IR command-shape checks into `Masc_exec.Shell_ir_command_shape` for git diagnostics and narrow recovery forms
- keep keeper runtime responsible for composing Shell IR shape, cwd facts, sandbox dispatch, and write-gate exceptions
- keep `Keeper_tool_execute_path` on path facts, repo currency/cache helpers, and path validation; it no longer decides git diagnostic/recovery command policy for stale repo roots
- generalize stale dirty-status guidance to deleted tracked files; no project-specific cascade fixture names remain
- tighten recovery shape tests so `git reset --hard` without explicit `HEAD` is not treated as a read-only recovery exception
- keep typed Execute Docker CWD response shaping on sandbox-factory path projection, without resolving/memoizing a Docker runtime just to shape the response
- rebase onto latest `origin/main` and resolve the #20164 CWD constructor overlap; GitHub now reports `mergeable=MERGEABLE`

## Tests
- PASS: `rg -n "^(<<<<<<<|=======|>>>>>>>)" lib test` (no conflict markers)
- PASS: `git diff --check`
- PASS: `ocamlformat --check lib/exec/shell_ir_command_shape.ml lib/exec/test/test_shell_ir_command_shape.ml lib/keeper/keeper_tool_execute_path.ml lib/keeper/keeper_tool_execute_path.mli lib/keeper/keeper_tool_execute_runtime.ml test/test_keeper_sandbox_docker_route.ml test/test_keeper_tool_execute_safety.ml`
- PASS: `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_execute_git_recovery_4 dune build --root . lib/exec/test/test_shell_ir_command_shape.exe test/test_playground_repo_readiness.exe test/test_keeper_tool_execute_safety.exe test/test_keeper_tool_command_runtime_cwd_response.exe test/test_keeper_sandbox_docker_route.exe`
- PASS: `_build_execute_git_recovery_4/default/lib/exec/test/test_shell_ir_command_shape.exe` (3 tests)
- PASS: `_build_execute_git_recovery_4/default/test/test_playground_repo_readiness.exe` (13 tests)
- PASS: `_build_execute_git_recovery_4/default/test/test_keeper_tool_execute_safety.exe` (60 tests)
- PASS: `_build_execute_git_recovery_4/default/test/test_keeper_tool_command_runtime_cwd_response.exe` (4 tests)
- PASS: `_build_execute_git_recovery_4/default/test/test_keeper_sandbox_docker_route.exe` (55 tests, 1 skipped)
- NOTE: `scripts/dune-local.sh build ...` previously returned exit 75 because other bare Dune processes were already running; focused verification used isolated Dune build dirs.
