### PR TITLE
fix(keeper): expose local and docker in keeper_cwd_response signature

### DIFF
--- a/lib/keeper/keeper_cwd_response.mli
+++ b/lib/keeper/keeper_cwd_response.mli
@@ -5,6 +5,10 @@ type t =
   | Local of { abs : string }
   | Sandboxed of { host_abs : string; container_abs : string }
 
+val local : host_cwd:string -> t
+
+val docker : host_cwd:string -> container_cwd:string -> t
+
 (** [of_sandbox ~sandbox ~host_cwd ~container_cwd_for_docker] builds
     a {!t} according to the backend kind (Local or Docker). *)
 val of_sandbox


### PR DESCRIPTION
Expose local and docker functions in keeper_cwd_response signature to fix compile errors on main where they are still invoked directly without sandbox wrappers.