### PR TITLE
docs: remove keeper persona authoring residue

### DIFF
--- a/docs/archive/audit/AUTH-CREDENTIAL-AUDIT-2026-04.md
+++ b/docs/archive/audit/AUTH-CREDENTIAL-AUDIT-2026-04.md
@@ -25,10 +25,8 @@
 - `lib/keeper/keeper_identity.{ml,mli}`
 - `lib/workspace/workspace_identity.{ml,mli}`
 
-**Credential + allowlist (4 pairs)**:
+**Credential + allowlist (2 pairs)**:
 - `lib/keeper/credential_provider.{ml,mli}` — credential trait (RFC-0008)
-- `lib/keeper/keeper_persona_authoring.{ml,mli}`
-- `lib/keeper/keeper_persona_authoring_contract.{ml,mli}`
 - `lib/keeper/keeper_routine_allowlist.{ml,mli}`
 
 **Role (1 pair)**:
@@ -52,7 +50,6 @@ Phase 1 marks these as **candidates**, not certainties. Phase 2 will narrow per-
 
 Conservative candidates flagged for Phase 2 verification:
 - `auth_login.ml:refresh_bearer_token` — possibly inline rotation logic; Phase 2 will check whether a dedicated rotation module is needed
-- `keeper_persona_authoring_contract.ml` — "contract" suggests validation; Phase 2 will check property-test coverage
 - `auth_diagnostic.ml` — health check vs. live validation responsibilities may be conflated
 
 ## 3. Severity rationale

--- a/docs/audit-responses/2026-05-05-integrated-improvement-design.md
+++ b/docs/audit-responses/2026-05-05-integrated-improvement-design.md
@@ -345,7 +345,6 @@ cleanup 트랙에 추가 가능.
 |------|------|
 | `lib/keeper/keeper_types_profile.ml:299, 473, 923` | `string list option` 타입 + default + ser/de |
 | `lib/keeper/keeper_meta_json_parse.ml:623-626` | TOML/JSON parse |
-| `lib/keeper/keeper_persona_authoring.ml:209, 544` | persona authoring path |
 | `lib/keeper/keeper_run_tools.ml:908` | `Option.value ~default:[] meta.work_discovery_sources` — runtime consumer |
 | `test/test_keeper_toml.ml:685, 712` | TOML round-trip 검증 |
 

--- a/docs/audit/2026-05-18-godfile-decomposition-build-plan.html
+++ b/docs/audit/2026-05-18-godfile-decomposition-build-plan.html
@@ -661,7 +661,6 @@ ocamlformat --check &lt;touched .ml/.mli files&gt;</code></pre>
           <tr><td class="num">1022</td><td><a href="../../lib/tool_catalog.ml">lib/tool_catalog.ml</a></td><td>tools</td></tr>
           <tr><td class="num">1020</td><td><a href="../../lib/keeper/keeper_turn_runtime_budget.ml">lib/keeper/keeper_turn_runtime_budget.ml</a></td><td>keeper</td></tr>
           <tr><td class="num">1019</td><td><a href="../../lib/memory_oas_bridge.ml">lib/memory_oas_bridge.ml</a></td><td>memory</td></tr>
-          <tr><td class="num">1017</td><td><a href="../../lib/keeper/keeper_persona_authoring.ml">lib/keeper/keeper_persona_authoring.ml</a></td><td>keeper</td></tr>
           <tr><td class="num">1005</td><td><a href="../../lib/sse.ml">lib/sse.ml</a></td><td>sse</td></tr>
           <tr><td class="num">1001</td><td><a href="../../lib/workspace/workspace_task_schedule.ml">lib/workspace/workspace_task_schedule.ml</a></td><td>workspace</td></tr>
           <tr><td class="num">1000</td><td><a href="../../lib/backend/backend.ml">lib/backend/backend.ml</a></td><td>backend</td></tr>

--- a/docs/audit/OAS-MASC-BOUNDARY-AUDIT-2026-04-PHASE2.md
+++ b/docs/audit/OAS-MASC-BOUNDARY-AUDIT-2026-04-PHASE2.md
@@ -53,13 +53,12 @@ Each is a *type annotation* on storage or a parameter. The actual `Oas.Agent.run
 rg -l "Masc_oas_bridge\." lib/keeper/ lib/server/ lib/dashboard/ lib/local/ 2>/dev/null
 ```
 
-Five files use `Masc_oas_bridge` directly:
-- `lib/keeper/keeper_persona_authoring.ml`
+Four files use `Masc_oas_bridge` directly:
 - `lib/dashboard/dashboard_operator_judge.ml`
 - `lib/dashboard/dashboard_governance_judge.ml`
 - `lib/server/server_openai_compat.{ml,mli}`
 
-This is the *intended* path: Layer C → `Masc_oas_bridge.run_with_caller` → Layer A. Five sites is fewer than expected for ~30 Layer C files; the remainder route through other Layer B modules (`Keeper_tools_oas`, `Oas_worker`, `Keeper_hooks_oas`). The *fan-in to Layer B is wide*, not a single throat.
+This is the *intended* path: Layer C → `Masc_oas_bridge.run_with_caller` → Layer A. Four sites is fewer than expected for ~30 Layer C files; the remainder route through other Layer B modules (`Keeper_tools_oas`, `Oas_worker`, `Keeper_hooks_oas`). The *fan-in to Layer B is wide*, not a single throat.
 
 ## 4. New module: `track2_sync_boundary` (PR #12102 MERGED)
 

--- a/docs/audit/OAS-MASC-BOUNDARY-AUDIT-2026-04-PHASE3.md
+++ b/docs/audit/OAS-MASC-BOUNDARY-AUDIT-2026-04-PHASE3.md
@@ -54,7 +54,6 @@ $ rg -l "Masc_oas_bridge\." \
     --glob 'lib/server/**/*.ml' \
     --glob 'lib/dashboard/**/*.ml' \
     --glob 'lib/local/**/*.ml'
-lib/keeper/keeper_persona_authoring.ml
 lib/dashboard/dashboard_operator_judge.ml
 lib/dashboard/dashboard_governance_judge.ml
 lib/server/server_openai_compat.ml

--- a/docs/rfc/RFC-0047-caller-inventory.txt
+++ b/docs/rfc/RFC-0047-caller-inventory.txt
@@ -150,8 +150,6 @@ lib/keeper/keeper_lifecycle_events.ml:2:Oas_events
 lib/keeper/keeper_lifecycle_events.ml:6:Oas_events
 lib/keeper/keeper_lifecycle_events.ml:89:Oas_events
 lib/keeper/keeper_lifecycle_events.mli:29:Oas_events
-lib/keeper/keeper_persona_authoring.ml:960:Oas_worker
-lib/keeper/keeper_persona_authoring.ml:979:Oas_worker
 lib/keeper/keeper_run_tools.ml:113:Oas_worker
 lib/keeper/keeper_run_tools.ml:477:Oas_worker
 lib/keeper/keeper_run_tools.mli:85:Oas_worker

--- a/docs/rfc/RFC-0071-inventory.csv
+++ b/docs/rfc/RFC-0071-inventory.csv
@@ -456,9 +456,6 @@ lib/keeper/keeper_msg_async.ml,152,None,unclassified
 lib/keeper/keeper_msg_async.ml,304,None,unclassified
 lib/keeper/keeper_passive_loop_detector.ml,96,false,unclassified
 lib/keeper/keeper_passive_loop_detector.ml,101,false,unclassified
-lib/keeper/keeper_persona_authoring.ml,34,None,unclassified
-lib/keeper/keeper_persona_authoring.ml,671,None,unclassified
-lib/keeper/keeper_persona_authoring.ml,886,None,unclassified
 lib/keeper/keeper_post_turn.ml,123,None,unclassified
 lib/keeper/keeper_post_turn.ml,799,false,unclassified
 lib/keeper/keeper_post_turn.ml,844,None,unclassified

--- a/docs/rfc/RFC-0143-keeper-runtime-profile-typed-catalog.md
+++ b/docs/rfc/RFC-0143-keeper-runtime-profile-typed-catalog.md
@@ -106,7 +106,6 @@ lib/dashboard_runtime_config.ml
 lib/keeper/keeper_runtime_profile.ml         (self)
 lib/keeper/keeper_error_classify.ml
 lib/keeper/keeper_runtime_resilience.ml
-lib/keeper/keeper_persona_authoring.ml
 lib/keeper/keeper_runtime.ml
 lib/keeper/keeper_status_bridge.ml
 lib/keeper/keeper_turn_runtime_budget_routing.ml
@@ -171,7 +170,7 @@ This RFC requires careful phased migration because the variant rename touches ~2
 
 2. **PR-2 — call-site migration, batch A (6 sites in `keeper_runtime_profile.ml` itself)**: switch the seven sites listed above to the new query. Each `false`/`[]` arm gets an explicit `Catalog_unavailable` branch.
 
-3. **PR-3 — call-site migration, batch B (8 caller files in `lib/keeper/` outside the SSOT)**: `keeper_runtime`, `keeper_runtime_resilience`, `keeper_status_bridge`, `keeper_unified_turn`, `keeper_persona_authoring`, `keeper_turn_up_args`, `keeper_turn_runtime_budget_routing`, `keeper_world_observation`.
+3. **PR-3 — call-site migration, batch B (7 caller files in `lib/keeper/` outside the SSOT)**: `keeper_runtime`, `keeper_runtime_resilience`, `keeper_status_bridge`, `keeper_unified_turn`, `keeper_turn_up_args`, `keeper_turn_runtime_budget_routing`, `keeper_world_observation`.
 
 4. **PR-4 — call-site migration, batch C (5 caller files in `lib/runtime/` + dashboard + server)**.
 

--- a/docs/rfc/RFC-0164-voice-tool-abstraction-integrity.md
+++ b/docs/rfc/RFC-0164-voice-tool-abstraction-integrity.md
@@ -137,7 +137,7 @@ All four sites delete cleanly when the field is removed from the record.
 
 ### 2.4 Other files in the deletion blast radius
 
-From earlier `rg` survey, 19 files in `lib/keeper/` reference `voice_enabled` / `voice_channel` / `default_voice_enabled_for` / `policy_voice_enabled` / `voice_agent_id`:
+From earlier `rg` survey, 18 files in `lib/keeper/` reference `voice_enabled` / `voice_channel` / `default_voice_enabled_for` / `policy_voice_enabled` / `voice_agent_id`:
 
 ```
 lib/keeper/keeper_meta_json_parse.{ml,mli}
@@ -147,7 +147,6 @@ lib/keeper/keeper_turn_up_update.ml
 lib/keeper/keeper_turn_up_args.{ml,mli}
 lib/keeper/keeper_types_profile.{ml,mli}
 lib/keeper/keeper_types_profile_defaults.{ml,mli}
-lib/keeper/keeper_persona_authoring.ml
 lib/keeper/keeper_schema.ml
 lib/keeper/keeper_meta_json.ml
 lib/keeper/keeper_meta_contract.{ml,mli}

--- a/docs/rfc/RFC-0182-masc-descriptor-projection.md
+++ b/docs/rfc/RFC-0182-masc-descriptor-projection.md
@@ -261,7 +261,7 @@ After PR #18823 (21 descriptors via dispatch-ref pattern, 83% non-portal coverag
 | `masc_keeper_msg` | `Keeper_msg_async.submit ~clock ~sw` + Turn dispatch | `Tool_keeper_ops.handle_keeper_msg` (lib/tool_keeper_ops.ml:438) |
 | `masc_keeper_sandbox_status` | `load_or_materialize_boot_meta` (clock-aware) | `Tool_keeper.handle_keeper_sandbox_status` |
 | `masc_keeper_create_from_persona` | `execute_keeper_up` → Turn lifecycle | `Tool_keeper_ops.handle_keeper_create_from_persona` |
-| `masc_persona_generate` | LLM call via Eio fiber | `Keeper_persona_authoring.handle_persona_generate` (line 812) |
+| `masc_persona_generate` | retired on main | no backing function |
 | `masc_operator_snapshot` | `Operator_control.context` (sw/clock/proc_mgr/net/mcp_session_id) | `Tool_operator.dispatch` |
 | `masc_operator_digest` | same | same |
 | `masc_operator_action` | same | same |
@@ -328,7 +328,7 @@ Each sub-PR independently mergeable, gated by PR-A.
 From the 17-iter /loop session that built PR #18823:
 
 1. `Eio_guard.with_mutex` (Eio.Mutex.create) — pure inside [`Keeper_status_detail`](../../lib/keeper/keeper_status_detail.ml).  Did NOT block status projection.
-2. `Keeper_persona_authoring → Keeper_turn_driver` transitive cycle (line 880) — resolved via [`Persona_dispatch_ref`](../../lib/persona_dispatch_ref.ml).
+2. The former persona-generate turn-driver cycle is gone on main; the tool is retired and has no backing function.
 3. `Keeper_turn_up.handle_keeper_up` surface ctx.config-only BUT `start_keepalive` transitively requires Eio.  Cannot ctx-free.
 4. `handle_keeper_repair` carried `ignore (ctx.sw, ctx.clock, ctx.config)` warning-suppression scaffolding — was phantom dependency, real body returns stub.
 

--- a/docs/rfc/RFC-0215-keeper-sublibrary-extraction-campaign.md
+++ b/docs/rfc/RFC-0215-keeper-sublibrary-extraction-campaign.md
@@ -3,7 +3,7 @@ rfc: "0215"
 title: "Keeper sub-library extraction campaign — sequence and per-PR gates"
 status: Draft
 created: 2026-06-04
-updated: 2026-06-04
+updated: 2026-06-05
 author: jeong-sik (with Claude Opus 4.8)
 supersedes: []
 superseded_by: null
@@ -162,10 +162,14 @@ only to pre-empt that misattribution.
 
 The first cluster cannot extract as a pure leaf today because no cluster has
 zero flat-ns fan-out (§5 table). The pre-work is: relocate or invert the
-handful of flat-ns refs that are **not** of the cluster's own domain (a
-credential sub-lib must not reach `Masc_oas_bridge`). That inversion — callback
-or interface, per the dependency-direction rule — is a separate PR that ships
-*before* the `dune` stanza.
+handful of flat-ns refs that are **not** of the cluster's own domain. That
+inversion — callback or interface, per the dependency-direction rule — is a
+separate PR that ships *before* the `dune` stanza.
+
+2026-06-05 correction: the former split persona implementation
+module has been removed from current `main`; it is no longer an extraction
+candidate. Keep the public persona profile tools on the existing
+`keeper_persona` path instead of reviving a separate authoring module.
 
 ## 5. Extraction sequence
 
@@ -174,30 +178,21 @@ Fan-in is shown for context but does not gate extraction.
 
 | Order | Cluster | Modules | flat-ns fan-out (G1 blockers) | Distinct flat-ns refs |
 |---|---|---|---|---|
-| 1 | credential (`keeper_persona_authoring*`) | 3 | **3** | `Agent_sdk_response`, `Approval_callbacks`, `Masc_oas_bridge` |
-| 2 | registry (`keeper_registry_*`) | 19 | 6 | `Admission_queue`, `Governance_registry`, `Prometheus`, `Runtime_params`, `Shutdown`, `Sse` |
-| 3 | error-classify (`*failure*`, `*error_class*`) | 31 | 6 | `Governance_registry`, `Prometheus`, `Runtime_params`, `Shutdown`, `Telemetry_coverage_gap`, `Workspace` |
-| 4 | runtime-binding (`keeper_heartbeat*`/`keeper_runtime*`/`keeper_attempt*`) | 30 | 6 | `Governance_registry`, `Prometheus`, `Runtime_params`, `Sse`, `Telemetry_coverage_gap`, `Workspace` |
-| 5 | hooks (`keeper_hook_oas_*`, `keeper_guard_*`) | ~9 | TBD (medium per workflow audit) | re-run G1 before scheduling |
-| 6 | state-fsm (`keeper_turn_*`, `keeper_working_*`, `keeper_reconcile_*`, `keeper_lifecycle_*`) | ~41 | TBD | extract after 1–4 establish base |
-| 7 | observability (`keeper_alert_*`, `keeper_metric_*`, `keeper_event_*`, `keeper_trace_*`) | ~13 | TBD (sink — many writers) | mid-campaign |
-| 8 | execution (`keeper_agent_run_*`, `keeper_tool_*`, `keeper_sandbox_*`, `keeper_run_*`) | ~70 | highest | last — the mesh hub |
+| 1 | registry (`keeper_registry_*`) | 19 | 6 | `Admission_queue`, `Governance_registry`, `Prometheus`, `Runtime_params`, `Shutdown`, `Sse` |
+| 2 | error-classify (`*failure*`, `*error_class*`) | 31 | 6 | `Governance_registry`, `Prometheus`, `Runtime_params`, `Shutdown`, `Telemetry_coverage_gap`, `Workspace` |
+| 3 | runtime-binding (`keeper_heartbeat*`/`keeper_runtime*`/`keeper_attempt*`) | 30 | 6 | `Governance_registry`, `Prometheus`, `Runtime_params`, `Sse`, `Telemetry_coverage_gap`, `Workspace` |
+| 4 | hooks (`keeper_hook_oas_*`, `keeper_guard_*`) | ~9 | TBD (medium per workflow audit) | re-run G1 before scheduling |
+| 5 | state-fsm (`keeper_turn_*`, `keeper_working_*`, `keeper_reconcile_*`, `keeper_lifecycle_*`) | ~41 | TBD | extract after 1–4 establish base |
+| 6 | observability (`keeper_alert_*`, `keeper_metric_*`, `keeper_event_*`, `keeper_trace_*`) | ~13 | TBD (sink — many writers) | mid-campaign |
+| 7 | execution (`keeper_agent_run_*`, `keeper_tool_*`, `keeper_sandbox_*`, `keeper_run_*`) | ~70 | highest | last — the mesh hub |
 
-**Recommended first extraction: credential (`keeper_persona_authoring*`).**
-It is the smallest *decoupling surface* — 3 modules, 3 flat-ns refs to invert.
-But note the honest caveat: those 3 refs (`Agent_sdk_response`,
-`Approval_callbacks`, `Masc_oas_bridge`) are **not** credential-domain, so they
-cannot move into the credential sub-lib; they must be inverted (callback /
-interface) in a pre-work PR (§4.3) before the `dune` stanza. Clusters 2–4 have
-fan-out dominated by shared infra (`Prometheus`, `Governance_registry`,
-`Runtime_params`, `Sse`), which is harder to invert because it is genuinely
-cross-cutting. Credential's 3 refs are point fixes; the infra refs are systemic.
-That asymmetry — not fan-in — is why credential goes first.
-
-If the §4.3 inversion proves larger than a single PR, registry (cluster 2) is
-the fallback first move: its 6 refs are all shared-infra modules that several
-*future* clusters also reach, so an infra-facing interface built for registry
-amortizes across 2–4.
+**Recommended first extraction: registry (`keeper_registry_*`).** It is now the
+lowest live fan-out cluster after removing the retired split persona
+module from the extraction queue. Its 6 refs are shared-infra modules that
+several future clusters also reach, so an infra-facing interface built for
+registry amortizes across registry, error-classify, and runtime-binding. The
+tradeoff is that these refs are genuinely cross-cutting; each inversion must be
+small enough to avoid creating a new facade god-module.
 
 ### 5.1 Per-PR shape
 

--- a/docs/rfc/withdrawn/RFC-0030-masc-create-cli.md
+++ b/docs/rfc/withdrawn/RFC-0030-masc-create-cli.md
@@ -14,7 +14,7 @@ withdrawn_reason: "Authoring CLI never implemented. masc uses MCP tools + dashbo
 - **Created**: 2026-05-05
 - **Audit reference**: `docs/audit-responses/2026-05-05-integrated-improvement-design.md` §2-1, §2-2
 - **Related**: RFC-0027 (typed runtime), RFC-0019 (keeper credential unification),
-  RFC-0008 (credential provider), `lib/keeper/keeper_persona_authoring.ml`,
+  RFC-0008 (credential provider), `lib/keeper/keeper_persona.ml`,
   `lib/runtime/runtime_config.ml`
 
 ## 1. Problem
@@ -91,8 +91,8 @@ masc create persona \
 Implementation:
 
 - New module `lib/keeper/keeper_persona_create.ml` that owns the
-  TOML-write side. `keeper_persona_authoring.ml` already parses /
-  validates; this RFC adds the *generative* counterpart.
+  TOML-write side. `keeper_persona.ml` owns the current persona schema/save
+  tool path; this RFC adds the *generative* counterpart.
 - `--dry-run` writes nothing, prints the rendered TOML + the validation
   result to stdout. No filesystem effect.
 - Validation runs the same pipeline as autoboot (`keeper_meta_json_parse`
@@ -133,8 +133,8 @@ Implementation:
   preconditions for runtime reload — without it, this command does
   nothing safe.
 - `runtime delete` refuses if any keeper TOML references the profile.
-  The check uses `keeper_persona_authoring`'s reverse index (added in
-  the same PR).
+  The retired authoring reverse index no longer exists; reviving this withdrawn
+  command would need a fresh current-code check.
 
 This surface has the largest risk: runtime routing is hot-path.
 Mitigation:

--- a/scripts/lint/exhaustive-guard.allowlist
+++ b/scripts/lint/exhaustive-guard.allowlist
@@ -456,9 +456,6 @@ lib/keeper/keeper_msg_async.ml:113
 lib/keeper/keeper_msg_async.ml:146
 lib/keeper/keeper_msg_async.ml:152
 lib/keeper/keeper_msg_async.ml:304
-lib/keeper/keeper_persona_authoring.ml:34
-lib/keeper/keeper_persona_authoring.ml:671
-lib/keeper/keeper_persona_authoring.ml:886
 lib/keeper/keeper_post_turn.ml:123
 lib/keeper/keeper_post_turn.ml:799
 lib/keeper/keeper_post_turn.ml:844


### PR DESCRIPTION
Summary
- Remove stale keeper persona authoring module references from RFC inventories, audits, and exhaustive-guard allowlist.
- Update RFC-0215 to drop the removed split persona implementation from the extraction queue and make registry the first live extraction candidate.
- Keep public persona profile tool surfaces on the existing keeper_persona path.

Verification
- rg -n 'Keeper_persona_authoring|keeper_persona_authoring' .  # no matches\n- rg --files | rg 'keeper_persona_authoring|persona_authoring'  # no matches\n- bash scripts/lint/no-retired-tool-husks.sh\n- bash scripts/lint/exhaustive-guard.sh  # advisory warnings only, exit 0\n- git diff --check\n- scripts/check-pr-hygiene.sh --base origin/main --head HEAD