### PR TITLE
fix(keeper): expose cwd response constructors

### DIFF
--- a/lib/keeper/keeper_cwd_response.mli
+++ b/lib/keeper/keeper_cwd_response.mli
@@ -5,6 +5,12 @@ type t =
   | Local of { abs : string }
   | Sandboxed of { host_abs : string; container_abs : string }
 
+(** [local ~host_cwd] builds a local-backend CWD response. *)
+val local : host_cwd:string -> t
+
+(** [docker ~host_cwd ~container_cwd] builds a Docker-backed CWD response. *)
+val docker : host_cwd:string -> container_cwd:string -> t
+
 (** [of_sandbox ~sandbox ~host_cwd ~container_cwd_for_docker] builds
     a {!t} according to the backend kind (Local or Docker). *)
 val of_sandbox


### PR DESCRIPTION
## Summary
- expose Keeper_cwd_response.local and Keeper_cwd_response.docker in the interface
- unblock modules that already call the constructors after the keeper extraction merge

## Verification
- PASS: DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_fix_keeper_cwd_response dune build --root . test/test_keeper_cwd_response.exe test/test_keeper_sandbox_docker_cwd_response.exe test/test_keeper_tool_command_runtime_cwd_response.exe test/test_llm_metric_bridge.exe
- PASS: DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_fix_keeper_cwd_response dune exec --root . test/test_keeper_cwd_response.exe
- PASS: DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_fix_keeper_cwd_response dune exec --root . test/test_keeper_tool_command_runtime_cwd_response.exe
- NOTE: test/test_keeper_sandbox_docker_cwd_response.exe still fails in translation.001 with Eio_mutex.Poisoned during Keeper_sandbox_factory.cleanup; this appears outside the interface exposure fix.
- NOTE: test/test_llm_metric_bridge.exe compiles now, but currently fails metric expectation assertions after the Prometheus retirement state on main.