### PR TITLE
refactor(voice): remove dead voice ref from tool_hint_of lookup

### DIFF
--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -521,12 +521,11 @@ let required_hints_of_schema (schema : Yojson.Safe.t) : string =
 
 (** Lookup tool description by name from all available schema sources.
     Returns [Some first_sentence] + optional enum/required hints if found, [None] otherwise.
-    Searches shard-resolved tools, inline schemas, injected masc_* schemas,
-    code-write schemas, voice tools, and tool_search schema. *)
+    Searches shard-resolved tools (voice included via shard), inline schemas,
+    injected masc_* schemas, and tool_search schema. *)
 let tool_hint_of (name : string) : string option =
   let all_schemas =
     Tool_shard.keeper_model_tools
-    @ Keeper_tool_registry.keeper_voice_tool_schemas
     @ [ Keeper_tool_registry.keeper_tool_search_schema ]
     @ Tool_schemas_inline.schemas
     @ masc_schemas_snapshot ()


### PR DESCRIPTION
## Summary

Remove redundant `Keeper_tool_registry.keeper_voice_tool_schemas` reference from `tool_hint_of`. Voice schemas are already included via `Tool_shard.keeper_model_tools` (shard path), making the explicit voice registry lookup dead code.

## Changes
- `lib/keeper/keeper_tool_policy.ml`: Remove `keeper_voice_tool_schemas` from `tool_hint_of` schema concatenation, update docstring

## Verification
- `dune build @check`: 0 new errors (5 pre-existing `Keeper_cwd_response` errors on main)

## Context
Continuation of voice cleanup from PR #20151 (MERGED) and #20158 (MERGED). Third commit from session `490fc424`.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
