### PR TITLE
fix(keeper): restore contract helper evidence after gate removal

### DIFF
--- a/lib/keeper/keeper_agent_result.ml
+++ b/lib/keeper/keeper_agent_result.ml
@@ -45,6 +45,19 @@ let tool_names_of_calls (tool_calls : tool_call_detail list) : string list =
   |> List.map (fun detail -> Keeper_tool_resolution.canonical_tool_name detail.tool_name)
 ;;
 
+let synthetic_tool_call_detail ?(provider = "keeper_synthetic") ?(outcome = "ok")
+      ?route_evidence tool_name
+  =
+  { tool_name
+  ; provider
+  ; outcome
+  ; typed_outcome = None
+  ; latency_ms = 0.0
+  ; task_id = None
+  ; route_evidence
+  }
+;;
+
 (** Result of a single Agent.run() keeper turn. *)
 type run_result =
   { response_text : string
@@ -70,6 +83,11 @@ type run_result =
 
 let tool_names (result : run_result) = tool_names_of_calls result.tool_calls
 let tool_call_count (result : run_result) = List.length result.tool_calls
+
+let append_synthetic_tool_call ?provider ?outcome ?route_evidence tool_name result =
+  let detail = synthetic_tool_call_detail ?provider ?outcome ?route_evidence tool_name in
+  { result with tool_calls = result.tool_calls @ [ detail ] }
+;;
 
 (* RFC-0132 PR-2: agent-result surface label = external boundary; redact via SSOT. *)
 let runtime_lane_label =

--- a/lib/keeper/keeper_agent_result.mli
+++ b/lib/keeper/keeper_agent_result.mli
@@ -39,8 +39,21 @@ val tool_call_detail_to_json : tool_call_detail -> Yojson.Safe.t
     the public surface is exposed under [Keeper_agent_run.mli]. *)
 
 val tool_names_of_calls : tool_call_detail list -> string list
+val synthetic_tool_call_detail :
+  ?provider:string ->
+  ?outcome:string ->
+  ?route_evidence:Yojson.Safe.t ->
+  string ->
+  tool_call_detail
 val tool_names : run_result -> string list
 val tool_call_count : run_result -> int
+val append_synthetic_tool_call :
+  ?provider:string ->
+  ?outcome:string ->
+  ?route_evidence:Yojson.Safe.t ->
+  string ->
+  run_result ->
+  run_result
 
 val runtime_lane_label : string
 (** Boundary-redacted label used wherever MASC's keeper metrics surface

--- a/lib/keeper/keeper_agent_run_contract_helpers.ml
+++ b/lib/keeper/keeper_agent_run_contract_helpers.ml
@@ -46,13 +46,31 @@ let no_progress_success_tool_names_for_contract
   keeper_tool_names_for_outcome ~tool_calls ~outcome:"ok_no_progress"
 ;;
 
+let tool_call_has_success_outcome (detail : Keeper_agent_result.tool_call_detail) =
+  match detail.outcome with
+  | "ok" | "ok_no_progress" -> true
+  | _ -> false
+;;
+
+let failed_tool_only_contract_violation
+      ~(actual_keeper_tool_names : string list)
+      ~(tool_calls : Keeper_agent_result.tool_call_detail list)
+  =
+  actual_keeper_tool_names = []
+  && tool_calls <> []
+  && List.for_all (fun detail -> not (tool_call_has_success_outcome detail)) tool_calls
+;;
+
 let observed_completion_contract_status
-      ~had_owned_active_task_at_turn_start ~actual_keeper_tool_names
+      ~had_owned_active_task_at_turn_start ~actual_keeper_tool_names ~tool_calls
   : Keeper_execution_receipt.completion_contract_result
   =
-  Keeper_agent_run_turn_helpers.completion_contract_result_for_progress_evidence
-    ~had_owned_active_task_at_turn_start
-    ~actual_keeper_tool_names
+  if failed_tool_only_contract_violation ~actual_keeper_tool_names ~tool_calls
+  then Contract_violated
+  else
+    Keeper_agent_run_turn_helpers.completion_contract_result_for_progress_evidence
+      ~had_owned_active_task_at_turn_start
+      ~actual_keeper_tool_names
 ;;
 
 let text_only_violation_contract_status ~actual_keeper_tool_names ~fallback

--- a/lib/keeper/keeper_agent_run_contract_helpers.mli
+++ b/lib/keeper/keeper_agent_run_contract_helpers.mli
@@ -17,7 +17,13 @@ val no_progress_success_tool_names_for_contract :
   tool_calls:Keeper_agent_result.tool_call_detail list ->
   string list
 
+val failed_tool_only_contract_violation :
+  actual_keeper_tool_names:string list ->
+  tool_calls:Keeper_agent_result.tool_call_detail list ->
+  bool
+
 val observed_completion_contract_status :
   had_owned_active_task_at_turn_start:bool ->
   actual_keeper_tool_names:string list ->
+  tool_calls:Keeper_agent_result.tool_call_detail list ->
   Keeper_execution_receipt.completion_contract_result

--- a/test/test_keeper_unified_claim_progress.ml
+++ b/test/test_keeper_unified_claim_progress.ml
@@ -133,6 +133,37 @@ let test_contract_progress_filters_no_progress_tool_results () =
          ])
 ;;
 
+let test_failed_tool_only_turn_violates_contract () =
+  let failed_only = [ tool_call_detail ~outcome:"error" "ToolThatDoesNotExist" ] in
+  check
+    bool
+    "failed-only tool turn is a violation"
+    true
+    (KAR.For_testing.failed_tool_only_contract_violation
+       ~actual_keeper_tool_names:[]
+       ~tool_calls:failed_only);
+  check
+    string
+    "failed-only tool turn is not satisfied completion"
+    "violated"
+    (KAR.Contract_helpers.observed_completion_contract_status
+       ~had_owned_active_task_at_turn_start:false
+       ~actual_keeper_tool_names:[]
+       ~tool_calls:failed_only
+     |> Masc.Keeper_execution_receipt.completion_contract_result_to_string)
+;;
+
+let test_synthetic_board_post_tool_detail () =
+  let detail =
+    KAR.synthetic_tool_call_detail
+      ~provider:"keeper_social_model"
+      "keeper_board_post"
+  in
+  check string "synthetic tool name" "keeper_board_post" detail.tool_name;
+  check string "synthetic tool outcome" "ok" detail.outcome;
+  check string "synthetic provider" "keeper_social_model" detail.provider
+;;
+
 let () =
   run
     "keeper_unified_claim_progress"
@@ -157,6 +188,14 @@ let () =
             "contract progress filters no-progress tool results"
             `Quick
             test_contract_progress_filters_no_progress_tool_results
+        ; test_case
+            "failed tool-only turn violates contract"
+            `Quick
+            test_failed_tool_only_turn_violates_contract
+        ; test_case
+            "synthetic board-post evidence keeps progress visible"
+            `Quick
+            test_synthetic_board_post_tool_detail
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- restore synthetic keeper tool-call helpers used by social model board-post delivery
- restore failed tool-only contract helper and wire observed completion status through tool call outcomes
- add focused regression tests for failed tool-only turns and synthetic board-post evidence

## Verification
- PASS: scripts/dune-local.sh build lib/masc.cmxa test/test_keeper_unified_claim_progress.exe (pre-main PR-head worktree)
- PASS: _build/default/test/test_keeper_unified_claim_progress.exe (7 tests, pre-main PR-head worktree)
- Attempted the same build after rebasing onto origin/main, but local Dune wrapper was blocked by another worktree lock; PR CI is the final main-based verification.