### PR TITLE
fix(dashboard): keeper chat panel state isolation + markdown rendering

### DIFF
--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -1,4 +1,6 @@
 import { html } from 'htm/preact'
+import { marked } from 'marked'
+import DOMPurify from 'dompurify'
 import { JsonViewerCard } from '../common/json-viewer'
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import { ActionButton } from '../common/button'
@@ -221,9 +223,15 @@ function ChatMessageBubble({
           </div>`
         : null}
 
-      <div class="whitespace-pre-wrap break-words text-base leading-airy text-[var(--color-fg-primary)]">
-        ${entry.text || (entry.delivery === 'streaming' ? '' : '(empty reply)')}
-      </div>
+      <div
+        class="markdown-body whitespace-pre-wrap break-words text-base leading-airy text-[var(--color-fg-primary)]"
+        dangerouslySetInnerHTML=${{
+          __html: DOMPurify.sanitize(
+            marked.parse(entry.text || (entry.delivery === 'streaming' ? '' : '(empty reply)')) as string,
+            { ALLOWED_TAGS: ['p', 'br', 'strong', 'em', 'code', 'pre', 'ul', 'ol', 'li', 'h1', 'h2', 'h3', 'h4', 'blockquote', 'a', 'hr'] }
+          )
+        }}
+      />
       ${entry.error
         ? html`
             <div class="rounded-[var(--r-1)] border border-[var(--err-border)] bg-[var(--bad-soft)] px-3 py-2 text-xs leading-paragraph text-[var(--bad-light)]">

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -115,8 +115,13 @@ function ChatMessageBubble({
 }) {
   const [expandedRaw, setExpandedRaw] = useState(false)
   const [rawExpandedRaw, setRawExpandedRaw] = useState(false)
+  const [messageCollapsed, setMessageCollapsed] = useState(true)
   const expanded = showMetadata && expandedRaw
   const rawExpanded = showMetadata && rawExpandedRaw
+  const messageText = entry.text || (entry.delivery === 'streaming' ? '' : '(empty reply)')
+  const messageLength = messageText.length
+  const collapseThreshold = 1200
+  const isCollapsible = messageLength > collapseThreshold
   const tone = bubbleTone(entry)
   const isMessenger = variant === 'messenger'
   const detailItems = detailSummary(entry.details)
@@ -224,14 +229,25 @@ function ChatMessageBubble({
         : null}
 
       <div
-        class="markdown-body whitespace-pre-wrap break-words text-base leading-airy text-[var(--color-fg-primary)]"
+        class=${`markdown-body whitespace-pre-wrap break-words text-base leading-airy text-[var(--color-fg-primary)] ${isCollapsible && messageCollapsed ? 'max-h-96 overflow-hidden' : ''}`}
         dangerouslySetInnerHTML=${{
           __html: DOMPurify.sanitize(
-            marked.parse(entry.text || (entry.delivery === 'streaming' ? '' : '(empty reply)')) as string,
+            marked.parse(messageText) as string,
             { ALLOWED_TAGS: ['p', 'br', 'strong', 'em', 'code', 'pre', 'ul', 'ol', 'li', 'h1', 'h2', 'h3', 'h4', 'blockquote', 'a', 'hr'] }
           )
         }}
       />
+      ${isCollapsible
+        ? html`
+            <button
+              type="button"
+              class="self-start rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-1 text-2xs font-medium text-[var(--color-fg-muted)] transition-colors hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-primary)]"
+              onClick=${() => { setMessageCollapsed(!messageCollapsed) }}
+            >
+              ${messageCollapsed ? '더 보기' : '접기'}
+            </button>
+          `
+        : null}
       ${entry.error
         ? html`
             <div class="rounded-[var(--r-1)] border border-[var(--err-border)] bg-[var(--bad-soft)] px-3 py-2 text-xs leading-paragraph text-[var(--bad-light)]">

--- a/dashboard/src/components/keeper-chat-panel.ts
+++ b/dashboard/src/components/keeper-chat-panel.ts
@@ -3,7 +3,7 @@
 
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
-import { useEffect } from 'preact/hooks'
+import { useEffect, useMemo, useRef } from 'preact/hooks'
 import {
   streamKeeperMessage,
   fetchKeeperChatHistory,
@@ -25,14 +25,6 @@ export interface ChatMessage {
   timestamp: number
 }
 
-const chatMessages = signal<ChatMessage[]>([])
-const chatInput = signal('')
-const streaming = signal(false)
-const streamBuffer = signal('')
-const streamStartedAt = signal<number | null>(null)
-const chatError = signal('')
-const searchQuery = signal('')
-
 /**
  * Pure filter: case-insensitive substring match over message content.
  * Empty or whitespace-only queries return the input unchanged.
@@ -42,8 +34,6 @@ export function filterChatMessages(messages: ChatMessage[], query: string): Chat
   if (!q) return messages
   return messages.filter((m) => m.content.toLowerCase().includes(q))
 }
-
-let activeAbort: AbortController | null = null
 
 function toConversationEntry(
   keeperName: string,
@@ -90,70 +80,78 @@ export function normalizeKeeperChatErrorValue(value: unknown): string {
   return '스트림 오류'
 }
 
-function cancelStream(): void {
-  if (activeAbort) activeAbort.abort()
-  activeAbort = null
-  streaming.value = false
-  streamBuffer.value = ''
-  streamStartedAt.value = null
-}
-
-async function sendChat(keeperName: string): Promise<void> {
-  const text = chatInput.value.trim()
-  if (!text || streaming.value) return
-
-  chatInput.value = ''
-  chatError.value = ''
-  streamBuffer.value = ''
-  streamStartedAt.value = Date.now()
-
-  chatMessages.value = [
-    ...chatMessages.value,
-    { role: 'user', content: text, timestamp: Date.now() },
-  ]
-
-  streaming.value = true
-  activeAbort = new AbortController()
-
-  try {
-    await streamKeeperMessage(keeperName, text, {
-      signal: activeAbort.signal,
-      onEvent: (event: KeeperChatStreamEvent) => {
-        if (isKeeperTextContentEvent(event) && typeof event.delta === 'string') {
-          streamBuffer.value += event.delta
-        } else if (event.type === 'RUN_FINISHED') {
-          const finalText = streamBuffer.value.trim() || '(no response)'
-          chatMessages.value = [
-            ...chatMessages.value,
-            { role: 'assistant', content: finalText, timestamp: Date.now() },
-          ]
-          streamBuffer.value = ''
-        } else if (event.type === 'RUN_ERROR') {
-          chatError.value = normalizeKeeperChatErrorValue(event.value)
-        }
-      },
-    })
-  } catch (err) {
-    if (err instanceof DOMException && err.name === 'AbortError') return
-    const msg = err instanceof Error ? err.message : '채팅 실패'
-    chatError.value = msg
-    showToast(msg, 'error')
-  } finally {
-    streaming.value = false
-    activeAbort = null
-    streamStartedAt.value = null
-  }
-}
-
 export function KeeperChatPanel({ name }: { name: string }) {
-  useEffect(() => {
-    cancelStream()
-    chatInput.value = ''
+  // Per-instance signals — each KeeperChatPanel has its own state.
+  // Fixes: global signal sharing caused cross-keeper state clobbering
+  // and effect re-initialization wiped messages on parent re-render.
+  const chatMessages = useMemo(() => signal<ChatMessage[]>([]), [])
+  const chatInput = useMemo(() => signal(''), [])
+  const streaming = useMemo(() => signal(false), [])
+  const streamBuffer = useMemo(() => signal(''), [])
+  const streamStartedAt = useMemo(() => signal<number | null>(null), [])
+  const chatError = useMemo(() => signal(''), [])
+  const searchQuery = useMemo(() => signal(''), [])
+
+  const activeAbortRef = useRef<AbortController | null>(null)
+
+  function cancelStream(): void {
+    if (activeAbortRef.current) activeAbortRef.current.abort()
+    activeAbortRef.current = null
+    streaming.value = false
     streamBuffer.value = ''
     streamStartedAt.value = null
+  }
+
+  async function sendChat(keeperName: string): Promise<void> {
+    const text = chatInput.value.trim()
+    if (!text || streaming.value) return
+
+    chatInput.value = ''
     chatError.value = ''
-    chatMessages.value = []
-    searchQuery.value = ''
+    streamBuffer.value = ''
+    streamStartedAt.value = Date.now()
+
+    chatMessages.value = [
+      ...chatMessages.value,
+      { role: 'user', content: text, timestamp: Date.now() },
+    ]
+
+    streaming.value = true
+    activeAbortRef.current = new AbortController()
+
+    try {
+      await streamKeeperMessage(keeperName, text, {
+        signal: activeAbortRef.current.signal,
+        onEvent: (event: KeeperChatStreamEvent) => {
+          if (isKeeperTextContentEvent(event) && typeof event.delta === 'string') {
+            streamBuffer.value += event.delta
+          } else if (event.type === 'RUN_FINISHED') {
+            const finalText = streamBuffer.value.trim() || '(no response)'
+            chatMessages.value = [
+              ...chatMessages.value,
+              { role: 'assistant', content: finalText, timestamp: Date.now() },
+            ]
+            streamBuffer.value = ''
+          } else if (event.type === 'RUN_ERROR') {
+            chatError.value = normalizeKeeperChatErrorValue(event.value)
+          }
+        },
+      })
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') return
+      const msg = err instanceof Error ? err.message : '채팅 실패'
+      chatError.value = msg
+      showToast(msg, 'error')
+    } finally {
+      streaming.value = false
+      activeAbortRef.current = null
+      streamStartedAt.value = null
+    }
+  }
+
+  useEffect(() => {
+    // Only fetch history; do NOT wipe messages.
+    // Previous global-signal design wiped messages on every parent re-render.
     let stale = false
     void fetchKeeperChatHistory(name)
       .then((history) => {
@@ -167,10 +165,6 @@ export function KeeperChatPanel({ name }: { name: string }) {
         }
       })
       .catch((err: unknown) => {
-        // P1 silent-failure fix: fetchKeeperChatHistory now throws on
-        // HTTP non-2xx / network / shape errors instead of returning [].
-        // Surface via chatError so the operator distinguishes "no
-        // history yet" from "load failed" in the UI.
         if (stale) return
         const msg = errorToString(err)
         chatError.value = `이전 대화 불러오기 실패: ${msg}`
@@ -239,7 +233,7 @@ export function KeeperChatPanel({ name }: { name: string }) {
           entries=${transcriptEntries}
           emptyText=${hasQuery && messages.length > 0
             ? '검색어와 일치하는 메시지가 없습니다.'
-            : '직접 프롬프트를 보내 키퍼 대화를 시작하세요.'}
+            : '직접 프롬프트를 본내 키퍼 대화를 시작하세요.'}
           showMetadata=${false}
         />
       </div>


### PR DESCRIPTION
## Summary

Fixes 3 reported UI bugs in the Dashboard Direct Dialog (Keeper Chat Panel).

## Changes

### keeper-chat-panel.ts
- Move module-level signals into component scope (useMemo)
- Fixes: cross-keeper state clobbering + effect re-init wiping messages
- Remove chatMessages.value = [] from useEffect
- Move activeAbort, cancelStream, sendChat into component

### primitives.ts
- Add marked + DOMPurify for markdown rendering
- Add message collapse toggle for replies over 1200 chars

## Fixes

1. Conversation reset on turn completion
2. Raw markdown display (**bold**, 1. list not rendered)
3. Long tool-run output dominating chat lane

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>