### PR TITLE
refactor(keeper): drop synthetic tool gate residue

### DIFF
--- a/lib/keeper/keeper_agent_result.ml
+++ b/lib/keeper/keeper_agent_result.ml
@@ -45,19 +45,6 @@ let tool_names_of_calls (tool_calls : tool_call_detail list) : string list =
   |> List.map (fun detail -> Keeper_tool_resolution.canonical_tool_name detail.tool_name)
 ;;
 
-let synthetic_tool_call_detail ?(provider = "keeper_synthetic") ?(outcome = "ok")
-      ?route_evidence tool_name
-  =
-  { tool_name
-  ; provider
-  ; outcome
-  ; typed_outcome = None
-  ; latency_ms = 0.0
-  ; task_id = None
-  ; route_evidence
-  }
-;;
-
 (** Result of a single Agent.run() keeper turn. *)
 type run_result =
   { response_text : string
@@ -83,11 +70,6 @@ type run_result =
 
 let tool_names (result : run_result) = tool_names_of_calls result.tool_calls
 let tool_call_count (result : run_result) = List.length result.tool_calls
-
-let append_synthetic_tool_call ?provider ?outcome ?route_evidence tool_name result =
-  let detail = synthetic_tool_call_detail ?provider ?outcome ?route_evidence tool_name in
-  { result with tool_calls = result.tool_calls @ [ detail ] }
-;;
 
 (* RFC-0132 PR-2: agent-result surface label = external boundary; redact via SSOT. *)
 let runtime_lane_label =

--- a/lib/keeper/keeper_agent_result.mli
+++ b/lib/keeper/keeper_agent_result.mli
@@ -39,21 +39,8 @@ val tool_call_detail_to_json : tool_call_detail -> Yojson.Safe.t
     the public surface is exposed under [Keeper_agent_run.mli]. *)
 
 val tool_names_of_calls : tool_call_detail list -> string list
-val synthetic_tool_call_detail :
-  ?provider:string ->
-  ?outcome:string ->
-  ?route_evidence:Yojson.Safe.t ->
-  string ->
-  tool_call_detail
 val tool_names : run_result -> string list
 val tool_call_count : run_result -> int
-val append_synthetic_tool_call :
-  ?provider:string ->
-  ?outcome:string ->
-  ?route_evidence:Yojson.Safe.t ->
-  string ->
-  run_result ->
-  run_result
 
 val runtime_lane_label : string
 (** Boundary-redacted label used wherever MASC's keeper metrics surface

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -31,9 +31,6 @@ module For_testing = struct
     Contract_helpers.progress_keeper_tool_names_for_contract
   let no_progress_success_tool_names_for_contract =
     Contract_helpers.no_progress_success_tool_names_for_contract
-
-  let failed_tool_only_contract_violation =
-    Contract_helpers.failed_tool_only_contract_violation
 end
 
 (** Run a single keeper turn via OAS Agent.run().
@@ -589,24 +586,10 @@ let run_turn
                    Contract_helpers.observed_completion_contract_status
                      ~had_owned_active_task_at_turn_start
                      ~actual_keeper_tool_names:progress_keeper_tool_names
-                     ~tool_calls:acc.tool_calls
                  in
                  let text_result =
-                   let contract_status = completion_contract_status () in
-                   acc.receipt_completion_contract_result <- contract_status;
-                   if
-                     Contract_helpers.failed_tool_only_contract_violation
-                       ~actual_keeper_tool_names:progress_keeper_tool_names
-                       ~tool_calls:acc.tool_calls
-                   then
-                     Error
-                       (Keeper_internal_error.sdk_error_of_masc_internal_error
-                          (Keeper_internal_error.Internal_contract_rejected
-                             {
-                               reason =
-                                 "completion_contract_violation: failed tool-only turn";
-                             }))
-                   else Ok (`Provider_text text)
+                   acc.receipt_completion_contract_result <- completion_contract_status ();
+                   Ok (`Provider_text text)
                  in
                    match text_result with
                    | Error e -> Error e

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -32,10 +32,6 @@ module For_testing : sig
   val no_progress_success_tool_names_for_contract
     :  tool_calls:tool_call_detail list
     -> string list
-  val failed_tool_only_contract_violation
-    :  actual_keeper_tool_names:string list
-    -> tool_calls:tool_call_detail list
-    -> bool
 end
 
 val per_provider_timeout_for_turn

--- a/lib/keeper/keeper_agent_run_contract_helpers.ml
+++ b/lib/keeper/keeper_agent_run_contract_helpers.ml
@@ -46,31 +46,13 @@ let no_progress_success_tool_names_for_contract
   keeper_tool_names_for_outcome ~tool_calls ~outcome:"ok_no_progress"
 ;;
 
-let tool_call_has_success_outcome (detail : Keeper_agent_result.tool_call_detail) =
-  match detail.outcome with
-  | "ok" | "ok_no_progress" -> true
-  | _ -> false
-;;
-
-let failed_tool_only_contract_violation
-      ~(actual_keeper_tool_names : string list)
-      ~(tool_calls : Keeper_agent_result.tool_call_detail list)
-  =
-  actual_keeper_tool_names = []
-  && tool_calls <> []
-  && List.for_all (fun detail -> not (tool_call_has_success_outcome detail)) tool_calls
-;;
-
 let observed_completion_contract_status
-      ~had_owned_active_task_at_turn_start ~actual_keeper_tool_names ~tool_calls
+      ~had_owned_active_task_at_turn_start ~actual_keeper_tool_names
   : Keeper_execution_receipt.completion_contract_result
   =
-  if failed_tool_only_contract_violation ~actual_keeper_tool_names ~tool_calls
-  then Contract_violated
-  else
-    Keeper_agent_run_turn_helpers.completion_contract_result_for_progress_evidence
-      ~had_owned_active_task_at_turn_start
-      ~actual_keeper_tool_names
+  Keeper_agent_run_turn_helpers.completion_contract_result_for_progress_evidence
+    ~had_owned_active_task_at_turn_start
+    ~actual_keeper_tool_names
 ;;
 
 let text_only_violation_contract_status ~actual_keeper_tool_names ~fallback

--- a/lib/keeper/keeper_agent_run_contract_helpers.mli
+++ b/lib/keeper/keeper_agent_run_contract_helpers.mli
@@ -17,13 +17,7 @@ val no_progress_success_tool_names_for_contract :
   tool_calls:Keeper_agent_result.tool_call_detail list ->
   string list
 
-val failed_tool_only_contract_violation :
-  actual_keeper_tool_names:string list ->
-  tool_calls:Keeper_agent_result.tool_call_detail list ->
-  bool
-
 val observed_completion_contract_status :
   had_owned_active_task_at_turn_start:bool ->
   actual_keeper_tool_names:string list ->
-  tool_calls:Keeper_agent_result.tool_call_detail list ->
   Keeper_execution_receipt.completion_contract_result

--- a/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.ml
+++ b/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.ml
@@ -377,18 +377,6 @@ let apply_output_to_result ~(meta : keeper_meta)
   | Request_help, Board_post when tool_names = [] ->
       (match deliver_request_help_post ~meta ~state with
       | Request_help_posted ->
-          let result =
-            Keeper_agent_result.append_synthetic_tool_call
-              ~provider:"keeper_social_model"
-              ~route_evidence:
-                (`Assoc
-                  [ "source", `String "bdi_speech_v1"
-                  ; "speech_act", `String "request_help"
-                  ; "delivery_surface", `String "board_post"
-                  ])
-              "keeper_board_post"
-              result
-          in
           ({ result with response_text = "" }, state)
       | Request_help_deduped | Request_help_failed ->
           ({ result with response_text = "" }, state))

--- a/test/test_keeper_unified_claim_progress.ml
+++ b/test/test_keeper_unified_claim_progress.ml
@@ -133,37 +133,6 @@ let test_contract_progress_filters_no_progress_tool_results () =
          ])
 ;;
 
-let test_failed_tool_only_turn_violates_contract () =
-  let failed_only = [ tool_call_detail ~outcome:"error" "ToolThatDoesNotExist" ] in
-  check
-    bool
-    "failed-only tool turn is a violation"
-    true
-    (KAR.For_testing.failed_tool_only_contract_violation
-       ~actual_keeper_tool_names:[]
-       ~tool_calls:failed_only);
-  check
-    string
-    "failed-only tool turn is not satisfied completion"
-    "violated"
-    (KAR.Contract_helpers.observed_completion_contract_status
-       ~had_owned_active_task_at_turn_start:false
-       ~actual_keeper_tool_names:[]
-       ~tool_calls:failed_only
-     |> Masc.Keeper_execution_receipt.completion_contract_result_to_string)
-;;
-
-let test_synthetic_board_post_tool_detail () =
-  let detail =
-    KAR.synthetic_tool_call_detail
-      ~provider:"keeper_social_model"
-      "keeper_board_post"
-  in
-  check string "synthetic tool name" "keeper_board_post" detail.tool_name;
-  check string "synthetic tool outcome" "ok" detail.outcome;
-  check string "synthetic provider" "keeper_social_model" detail.provider
-;;
-
 let () =
   run
     "keeper_unified_claim_progress"
@@ -188,14 +157,6 @@ let () =
             "contract progress filters no-progress tool results"
             `Quick
             test_contract_progress_filters_no_progress_tool_results
-        ; test_case
-            "failed tool-only turn violates contract"
-            `Quick
-            test_failed_tool_only_turn_violates_contract
-        ; test_case
-            "synthetic board-post evidence keeps progress visible"
-            `Quick
-            test_synthetic_board_post_tool_detail
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary

- Remove the post-merge synthetic tool-call evidence helpers from keeper result surfaces.
- Remove the failed-tool-only completion contract gate that rebuilt turn state from tool-call outcomes.
- Remove the social model's synthetic board-post tool-call injection and the tests that pinned those derived tool evidence paths.

## Verification

- `rg -n "synthetic_tool_call|append_synthetic_tool_call|failed_tool_only_contract_violation|completion_contract_violation: failed tool-only turn|composite_execution_contract_block|tool-route contract blocker|Keeper_cwd_response\\.(local|docker)" lib test` (no matches)
- `ocamlformat --check lib/keeper/keeper_agent_result.ml lib/keeper/keeper_agent_result.mli lib/keeper/keeper_agent_run_contract_helpers.ml lib/keeper/keeper_agent_run_contract_helpers.mli test/test_keeper_unified_claim_progress.ml`
- `git diff --check`
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=/private/tmp/masc-mcp-pr20156-final-dune dune build --root . lib/masc.cma`
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=/private/tmp/masc-mcp-pr20156-final-dune dune build --root . lib/server/masc_server.cma`
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=/private/tmp/masc-mcp-pr20156-final-dune dune exec --root . test/test_keeper_unified_claim_progress.exe`
