### PR TITLE
fix(keeper): harden runtime error triage

### DIFF
--- a/lib/keeper/keeper_tool_shared_runtime.ml
+++ b/lib/keeper/keeper_tool_shared_runtime.ml
@@ -132,7 +132,7 @@ let split_repo_relative raw =
   | _ -> None
 ;;
 
-let missing_file_recovery_examples ~(raw_path : string option) =
+let missing_file_recovery_examples ~(raw_path : string option) ~(repo_hint : string option) =
   match raw_path with
   | None -> `Assoc []
   | Some raw ->
@@ -140,11 +140,12 @@ let missing_file_recovery_examples ~(raw_path : string option) =
     let grep_filename =
       Filename.basename raw
       |> fun name ->
-      `Assoc
-        [ "tool", `String "Grep"
-        ; "pattern", `String name
-        ; "path", `String parent
-        ]
+      let path =
+        match split_repo_relative raw, repo_hint with
+        | Some _, _ | _, None -> parent
+        | None, Some repo -> Filename.concat ("repos/" ^ repo) parent
+      in
+      `Assoc [ "tool", `String "Grep"; "pattern", `String name; "path", `String path ]
     in
     let list_parent =
       match split_repo_relative raw with
@@ -157,13 +158,27 @@ let missing_file_recovery_examples ~(raw_path : string option) =
           ; "argv", `List [ `String repo_parent ]
           ]
       | None ->
-        `Assoc
-          [ "tool", `String "Execute"
-          ; "executable", `String "ls"
-          ; "argv", `List [ `String parent ]
-          ]
+        (match repo_hint with
+         | Some repo ->
+           `Assoc
+             [ "tool", `String "Execute"
+             ; "cwd", `String ("repos/" ^ repo)
+             ; "executable", `String "ls"
+             ; "argv", `List [ `String parent ]
+             ]
+         | None ->
+           `Assoc
+             [ "tool", `String "Execute"
+             ; "executable", `String "ls"
+             ; "argv", `List [ `String parent ]
+             ])
     in
     `Assoc [ "grep_filename", grep_filename; "list_parent", list_parent ]
+;;
+
+let visible_repo_hint = function
+  | [ repo ] -> Some repo
+  | _ -> None
 ;;
 
 let missing_file_error_json
@@ -175,41 +190,83 @@ let missing_file_error_json
       ~(fallback_dir : string)
       ~(error : string)
   =
-  ignore (config, fallback_dir);
+  ignore fallback_dir;
   (* #10349: do NOT echo directory entries back to the LLM.  When keeper
      identity drifts, the resolved parent may belong to a sibling sandbox,
      and listing its contents leaks its directory layout (oracle leak).
      The generic error string already contains the path that was tried,
      which is sufficient for the LLM to self-correct. *)
   let playground = Keeper_sandbox.allowed_root_rel_of_meta ~meta in
+  let safe_is_dir path =
+    try Sys.file_exists path && Sys.is_directory path with
+    | Sys_error _ -> false
+  in
+  let safe_file_exists path =
+    try Sys.file_exists path with
+    | Sys_error _ -> false
+  in
+  let available_repos =
+    let repos_dir =
+      Filename.concat (Keeper_sandbox.host_root_abs_of_meta ~config meta) "repos"
+    in
+    if not (safe_is_dir repos_dir)
+    then []
+    else
+      try
+        Sys.readdir repos_dir
+        |> Array.to_list
+        |> List.sort String.compare
+        |> List.filter (fun entry ->
+          let candidate = Filename.concat repos_dir entry in
+          safe_is_dir candidate && safe_file_exists (Filename.concat candidate ".git"))
+      with
+      | Sys_error _ -> []
+  in
+  let repo_hint = visible_repo_hint available_repos in
+  let next_action =
+    match raw_path, repo_hint with
+    | Some path, Some repo when Option.is_none (split_repo_relative path) ->
+      Printf.sprintf
+        "A single sandbox repo is available. Retry with cwd=\"repos/%s\" and \
+         file_path=%S, or use file_path=%S. Use Grep or Execute ls first when \
+         the exact path is unclear."
+        repo
+        path
+        (Filename.concat ("repos/" ^ repo) path)
+    | _ ->
+      "For repo-relative files, pass cwd=\"repos/<repo>\" with \
+       file_path=\"lib/...\", or pass file_path=\"repos/<repo>/lib/...\". \
+       Use Grep or Execute ls first when the exact path is unclear."
+  in
   Yojson.Safe.to_string
     (`Assoc
         [ "ok", `Bool false
         ; "error", `String error
         ; "path", `String target
         ; "your_playground", `String playground
+        ; ( "available_repos"
+          , `List (List.map (fun repo -> `String ("repos/" ^ repo)) available_repos) )
         ; "input_file_path", Json_util.string_opt_to_json raw_path
         ; ( "path_resolution"
           , `Assoc
               [ "implicit_cwd", `Bool false
               ; "explicit_cwd_supported", `Bool true
               ; "cwd", Json_util.string_opt_to_json cwd
+              ; ( "repo_cwd_hint"
+                , Json_util.string_opt_to_json
+                    (Option.map (fun repo -> "repos/" ^ repo) repo_hint) )
               ; "same_path_retry_will_fail", `Bool true
               ; ( "basis"
                 , `String
                     "Read resolves file_path against explicit cwd when cwd is provided; \
                      otherwise it resolves against the keeper sandbox or explicit \
                      allowed_paths. It does not inherit Execute cwd implicitly." )
-              ; ( "next_action"
-                , `String
-                    "For repo-relative files, pass cwd=\"repos/<repo>\" with \
-                     file_path=\"lib/...\", or pass file_path=\"repos/<repo>/lib/...\". \
-                     Use Grep or Execute ls first when the exact path is unclear." )
+              ; "next_action", `String next_action
               ; ( "retry_policy"
                 , `String
                     "Do not retry Read with the same file_path until Grep or Execute ls \
                      confirms the file exists." )
-              ; "recovery_examples", missing_file_recovery_examples ~raw_path
+              ; "recovery_examples", missing_file_recovery_examples ~raw_path ~repo_hint
               ] )
         ])
 ;;

--- a/lib/keeper/keeper_turn_runtime_budget.ml
+++ b/lib/keeper/keeper_turn_runtime_budget.ml
@@ -207,9 +207,18 @@ let reclassify_provider_timeout_for_attempt
     ~(provider_timeout_budget : provider_timeout_budget option)
     (err : Agent_sdk.Error.sdk_error) : Agent_sdk.Error.sdk_error =
   match err, provider_timeout_budget with
-  | Agent_sdk.Error.Api (Timeout { message }), Some _
+  | Agent_sdk.Error.Api (Timeout { message }), Some budget
     when EC.is_structural_oas_timeout_message message ->
-      err
+      Keeper_turn_driver.sdk_error_of_masc_internal_error
+        (Keeper_turn_driver.Provider_timeout
+           { budget_sec = budget.effective_timeout_sec
+           ; keeper_turn_timeout_sec = budget.keeper_turn_timeout_sec
+           ; estimated_input_tokens = budget.estimated_input_tokens
+           ; source = budget.source
+           ; remaining_turn_budget_sec = Some budget.remaining_turn_budget_sec
+           ; min_required_sec = min_provider_timeout_budget_sec
+           ; phase = "runtime_attempt_watchdog"
+           })
   | _ -> err
 
 let attempt_watchdog_outer_turn_reserve_sec = 1.0

--- a/lib/keeper/keeper_turn_runtime_budget.mli
+++ b/lib/keeper/keeper_turn_runtime_budget.mli
@@ -148,9 +148,8 @@ val reclassify_provider_timeout_for_attempt :
   provider_timeout_budget:provider_timeout_budget option ->
   Agent_sdk.Error.sdk_error ->
   Agent_sdk.Error.sdk_error
-(** Preserve upstream structural timeout errors instead of minting a synthetic
-    [Provider_timeout] root cause.  Kept as a named hook while the
-    provider-timeout root-cause ADT is introduced in a later PR. *)
+(** Rewrap structural attempt watchdog timeouts as [Provider_timeout] when
+    the current attempt had an admitted provider-timeout budget. *)
 
 val attempt_watchdog_timeout_sec :
   remaining_turn_budget_s:float ->

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -54,10 +54,10 @@ val provider_retry_budget_available_for_turn
 val degraded_retry_slot_phase_budget_sec : float
 val degraded_retry_slot_phase_available : time_spent_in_turn_s:float -> bool
 
-(** Reclassify a structural OAS timeout only when the current attempt
-    actually dispatched with an provider timeout budget. This prevents a
-    pre-retry turn-budget exhaustion from borrowing a stale previous
-    attempt budget and incorrectly rotating runtimes. *)
+(** Reclassify a structural OAS timeout as [Provider_timeout] only when the
+    current attempt actually dispatched with a provider timeout budget. This
+    prevents a pre-retry turn-budget exhaustion from borrowing a stale
+    previous attempt budget and incorrectly rotating runtimes. *)
 val reclassify_provider_timeout_for_attempt
   :  provider_timeout_budget:provider_timeout_budget option
   -> Agent_sdk.Error.sdk_error

--- a/test/stanzas/test_oas_timeout_budget_strike.inc
+++ b/test/stanzas/test_oas_timeout_budget_strike.inc
@@ -1,4 +1,4 @@
 (test
  (name test_oas_timeout_budget_strike)
  (modules test_oas_timeout_budget_strike)
- (libraries masc alcotest eio eio_main))
+ (libraries masc alcotest eio eio_main agent_sdk))

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -26,6 +26,16 @@ let cleanup_dir path =
   in
   try rm path with _ -> ()
 
+let mkdir_p path =
+  let rec loop dir =
+    if dir = "" || dir = "." || Sys.file_exists dir then
+      ()
+    else (
+      loop (Filename.dirname dir);
+      Unix.mkdir dir 0o755)
+  in
+  loop path
+
 let with_env key value f =
   let prior = Sys.getenv_opt key in
   Unix.putenv key value;
@@ -367,11 +377,17 @@ let test_keeper_tools_list_json_uses_typed_groups () =
 let test_execute_with_outcome_missing_file_is_failure () =
   with_exec_fixture "keeper_tool_dispatch_runtime_missing_file"
     (fun ~config ~meta ~ctx_work ->
+      let repo_dir =
+        Filename.concat
+          (Filename.concat (KES.keeper_playground_root ~config ~meta) "repos")
+          "masc-mcp"
+      in
+      mkdir_p (Filename.concat repo_dir ".git");
       let result =
         KET.execute_keeper_tool_call_with_outcome
           ~config ~meta ~ctx_work ~exec_cache:None
           ~name:"Read"
-          ~input:(`Assoc [ ("file_path", `String "missing.txt") ])
+          ~input:(`Assoc [ ("file_path", `String "config/tool_policy.toml") ])
           ()
       in
       check string "missing file outcome" "failure"
@@ -380,12 +396,22 @@ let test_execute_with_outcome_missing_file_is_failure () =
         (payload_kind result.payload_shape);
       let json = Yojson.Safe.from_string result.raw_output in
       let path_resolution = Yojson.Safe.Util.member "path_resolution" json in
+      check string "single repo surfaced" "repos/masc-mcp"
+        Yojson.Safe.Util.(member "available_repos" json |> to_list |> List.hd |> to_string);
+      check string "repo cwd hint" "repos/masc-mcp"
+        Yojson.Safe.Util.(member "repo_cwd_hint" path_resolution |> to_string);
       check bool "same path retry marked as futile" true
         Yojson.Safe.Util.(member "same_path_retry_will_fail" path_resolution |> to_bool);
       check bool "retry policy discourages same Read" true
         (contains_substring
            Yojson.Safe.Util.(member "retry_policy" path_resolution |> to_string)
            "Do not retry Read");
+      check string "list recovery cwd" "repos/masc-mcp"
+        Yojson.Safe.Util.(
+          member "recovery_examples" path_resolution
+          |> member "list_parent"
+          |> member "cwd"
+          |> to_string);
       check string "grep recovery example" "Grep"
         Yojson.Safe.Util.(
           member "recovery_examples" path_resolution

--- a/test/test_keeper_tool_matrix_cases.ml
+++ b/test/test_keeper_tool_matrix_cases.ml
@@ -245,7 +245,7 @@ let prepare_keeper_name fixture name =
   if
     List.mem name
       [ "keeper_task_force_release"; "keeper_task_force_done";
-        "keeper_task_done"; "keeper_task_submit_for_verification" ]
+        "keeper_task_done" ]
   then
     ensure_keeper_claim fixture;
   if name = "keeper_voice_session_end" then ensure_voice_session fixture;
@@ -340,13 +340,6 @@ let keeper_arguments fixture (schema : Masc_domain.tool_schema) =
   | "keeper_library_read" ->
       `Assoc [ ("topic", `String (Generic.ensure_library_topic fixture.generic)) ]
   | "keeper_tasks_list" -> `Assoc [ ("include_done", `Bool true) ]
-  | "keeper_task_submit_for_verification" ->
-      `Assoc
-        [
-          ("task_id", `String (Generic.ensure_task fixture.generic));
-          ("notes", `String "tool matrix verification notes: completion_notes are done and pr_url_or_artifact_ref is set");
-          ("evidence_refs", `List [ `String "https://github.com/jeong-sik/me/pull/1" ]);
-        ]
   | "keeper_task_force_release" ->
       `Assoc
         [

--- a/test/test_keeper_tool_resolution.ml
+++ b/test/test_keeper_tool_resolution.ml
@@ -127,7 +127,8 @@ let test_public_descriptor_names_resolve () =
 let test_retired_public_names_miss () =
   List.iter
     (fun name -> check bool (name ^ " misses") false (resolves name))
-    [ "Bash"; "SearchFiles"; "ReadFile"; "EditFile"; "WriteFile" ]
+    [ "Bash"; "SearchFiles"; "ReadFile"; "EditFile"; "WriteFile";
+      "keeper_task_submit_for_verification" ]
 
 (* ── Policy matrix: active tool_policy.toml names resolve ── *)
 

--- a/test/test_oas_timeout_budget_strike.ml
+++ b/test/test_oas_timeout_budget_strike.ml
@@ -3,6 +3,7 @@ open Masc
 module KH = Keeper_heartbeat_loop
 module KFP = Keeper_failure_policy
 module KK = Keeper_keepalive
+module KCB = Keeper_turn_runtime_budget
 module KTD = Keeper_turn_driver
 module EC = Keeper_error_classify
 
@@ -84,6 +85,52 @@ let test_cycle_failed_log_level_is_policy_aware () =
     false
     (EC.should_warn_keeper_cycle_failed (turn_timeout_error ()))
 
+let test_attempt_watchdog_timeout_reclassifies_as_provider_timeout () =
+  let budget : KCB.provider_timeout_budget =
+    { effective_timeout_sec = 555.0
+    ; adaptive_timeout_sec = 600.0
+    ; keeper_turn_timeout_sec = 600.0
+    ; remaining_turn_budget_sec = 571.0
+    ; estimated_input_tokens = 10_000
+    ; max_turns = 6
+    ; source = "turn_budget_capped"
+    }
+  in
+  let err =
+    Agent_sdk.Error.Api
+      (Timeout
+         { message =
+             "Turn wall-clock budget exhausted during runtime attempt \
+              (budget=555.0s, watchdog=570.0s)"
+         })
+  in
+  let reclassified =
+    KCB.reclassify_provider_timeout_for_attempt
+      ~provider_timeout_budget:(Some budget)
+      err
+  in
+  (match KTD.classify_masc_internal_error reclassified with
+   | Some (KTD.Provider_timeout timeout) ->
+     Alcotest.(check string)
+       "phase"
+       "runtime_attempt_watchdog"
+       timeout.phase;
+     Alcotest.(check (float 0.001))
+       "budget"
+       555.0
+       timeout.budget_sec
+   | Some other ->
+     Alcotest.failf
+       "expected Provider_timeout, got %s"
+       (Option.value
+          ~default:"<no summary>"
+          (KTD.summary_of_masc_internal_error other))
+   | None -> Alcotest.fail "expected structured Provider_timeout");
+  Alcotest.(check bool)
+    "provider timeout cycle failure is warn"
+    true
+    (EC.should_warn_keeper_cycle_failed reclassified)
+
 let test_strike_limit_routes_through_policy_without_keeper_death () =
   let err = provider_timeout_error ~phase:"stream_idle:streaming_thinking" in
   match
@@ -163,6 +210,10 @@ let () =
           test_strike_limit_is_soft_backoff;
         Alcotest.test_case "cycle failure log level is policy-aware" `Quick
           test_cycle_failed_log_level_is_policy_aware;
+        Alcotest.test_case
+          "attempt watchdog timeout reclassifies as provider timeout"
+          `Quick
+          test_attempt_watchdog_timeout_reclassifies_as_provider_timeout;
         Alcotest.test_case "strike limit uses policy, not keeper death" `Quick
           test_strike_limit_routes_through_policy_without_keeper_death;
         Alcotest.test_case "capacity phase routes to provider tuning" `Quick


### PR DESCRIPTION
## Summary

- remove the retired `keeper_task_submit_for_verification` case from keeper tool matrix fixtures and pin it as a retired public name
- add repo-aware `Read` missing-file recovery hints (`available_repos`, `repo_cwd_hint`, and cwd-aware examples)
- reclassify structural attempt watchdog timeouts into structured `Provider_timeout` with `phase=runtime_attempt_watchdog`

## Verification

- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_pr_runtime_error_triage2 dune build --root . test/test_keeper_tool_resolution.exe test/test_keeper_tool_matrix.exe test/test_keeper_tool_dispatch_runtime.exe test/test_oas_timeout_budget_strike.exe`
- `_build_pr_runtime_error_triage2/default/test/test_keeper_tool_resolution.exe`
- `_build_pr_runtime_error_triage2/default/test/test_keeper_tool_matrix.exe test inventory`
- `_build_pr_runtime_error_triage2/default/test/test_keeper_tool_dispatch_runtime.exe test "execute_keeper_tool_call_with_outcome" 1`
- `_build_pr_runtime_error_triage2/default/test/test_oas_timeout_budget_strike.exe test "strike ledger" 6`

## Notes

- `scripts/dune-local.sh` was attempted first but refused with exit 75 because unrelated bare Dune processes were already active, so verification used an isolated build dir.
