### PR TITLE
fix: repair keeper tool observation follow-up

### DIFF
--- a/lib/keeper/keeper_agent_result.ml
+++ b/lib/keeper/keeper_agent_result.ml
@@ -45,6 +45,19 @@ let tool_names_of_calls (tool_calls : tool_call_detail list) : string list =
   |> List.map (fun detail -> Keeper_tool_resolution.canonical_tool_name detail.tool_name)
 ;;
 
+let synthetic_tool_call_detail ?(provider = "keeper_synthetic") ?(outcome = "ok")
+      ?route_evidence tool_name
+  =
+  { tool_name
+  ; provider
+  ; outcome
+  ; typed_outcome = None
+  ; latency_ms = 0.0
+  ; task_id = None
+  ; route_evidence
+  }
+;;
+
 (** Result of a single Agent.run() keeper turn. *)
 type run_result =
   { response_text : string
@@ -70,6 +83,11 @@ type run_result =
 
 let tool_names (result : run_result) = tool_names_of_calls result.tool_calls
 let tool_call_count (result : run_result) = List.length result.tool_calls
+
+let append_synthetic_tool_call ?provider ?outcome ?route_evidence tool_name result =
+  let detail = synthetic_tool_call_detail ?provider ?outcome ?route_evidence tool_name in
+  { result with tool_calls = result.tool_calls @ [ detail ] }
+;;
 
 (* RFC-0132 PR-2: agent-result surface label = external boundary; redact via SSOT. *)
 let runtime_lane_label =

--- a/lib/keeper/keeper_agent_result.mli
+++ b/lib/keeper/keeper_agent_result.mli
@@ -39,8 +39,21 @@ val tool_call_detail_to_json : tool_call_detail -> Yojson.Safe.t
     the public surface is exposed under [Keeper_agent_run.mli]. *)
 
 val tool_names_of_calls : tool_call_detail list -> string list
+val synthetic_tool_call_detail :
+  ?provider:string ->
+  ?outcome:string ->
+  ?route_evidence:Yojson.Safe.t ->
+  string ->
+  tool_call_detail
 val tool_names : run_result -> string list
 val tool_call_count : run_result -> int
+val append_synthetic_tool_call :
+  ?provider:string ->
+  ?outcome:string ->
+  ?route_evidence:Yojson.Safe.t ->
+  string ->
+  run_result ->
+  run_result
 
 val runtime_lane_label : string
 (** Boundary-redacted label used wherever MASC's keeper metrics surface

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -31,6 +31,9 @@ module For_testing = struct
     Contract_helpers.progress_keeper_tool_names_for_contract
   let no_progress_success_tool_names_for_contract =
     Contract_helpers.no_progress_success_tool_names_for_contract
+
+  let failed_tool_only_contract_violation =
+    Contract_helpers.failed_tool_only_contract_violation
 end
 
 (** Run a single keeper turn via OAS Agent.run().
@@ -586,10 +589,24 @@ let run_turn
                    Contract_helpers.observed_completion_contract_status
                      ~had_owned_active_task_at_turn_start
                      ~actual_keeper_tool_names:progress_keeper_tool_names
+                     ~tool_calls:acc.tool_calls
                  in
                  let text_result =
-                   acc.receipt_completion_contract_result <- completion_contract_status ();
-                   Ok (`Provider_text text)
+                   let contract_status = completion_contract_status () in
+                   acc.receipt_completion_contract_result <- contract_status;
+                   if
+                     Contract_helpers.failed_tool_only_contract_violation
+                       ~actual_keeper_tool_names:progress_keeper_tool_names
+                       ~tool_calls:acc.tool_calls
+                   then
+                     Error
+                       (Keeper_internal_error.sdk_error_of_masc_internal_error
+                          (Keeper_internal_error.Internal_contract_rejected
+                             {
+                               reason =
+                                 "completion_contract_violation: failed tool-only turn";
+                             }))
+                   else Ok (`Provider_text text)
                  in
                    match text_result with
                    | Error e -> Error e

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -32,6 +32,10 @@ module For_testing : sig
   val no_progress_success_tool_names_for_contract
     :  tool_calls:tool_call_detail list
     -> string list
+  val failed_tool_only_contract_violation
+    :  actual_keeper_tool_names:string list
+    -> tool_calls:tool_call_detail list
+    -> bool
 end
 
 val per_provider_timeout_for_turn

--- a/lib/keeper/keeper_agent_run_contract_helpers.ml
+++ b/lib/keeper/keeper_agent_run_contract_helpers.ml
@@ -46,13 +46,29 @@ let no_progress_success_tool_names_for_contract
   keeper_tool_names_for_outcome ~tool_calls ~outcome:"ok_no_progress"
 ;;
 
+let failed_tool_only_contract_violation
+      ~(actual_keeper_tool_names : string list)
+      ~(tool_calls : Keeper_agent_result.tool_call_detail list)
+  =
+  actual_keeper_tool_names = []
+  && tool_calls <> []
+  && List.for_all
+       (fun (detail : Keeper_agent_result.tool_call_detail) ->
+          (not (String.equal detail.outcome "ok"))
+          && not (String.equal detail.outcome "ok_no_progress"))
+       tool_calls
+;;
+
 let observed_completion_contract_status
-      ~had_owned_active_task_at_turn_start ~actual_keeper_tool_names
+      ~tool_calls ~had_owned_active_task_at_turn_start ~actual_keeper_tool_names
   : Keeper_execution_receipt.completion_contract_result
   =
-  Keeper_agent_run_turn_helpers.completion_contract_result_for_progress_evidence
-    ~had_owned_active_task_at_turn_start
-    ~actual_keeper_tool_names
+  if failed_tool_only_contract_violation ~actual_keeper_tool_names ~tool_calls
+  then Contract_violated
+  else
+    Keeper_agent_run_turn_helpers.completion_contract_result_for_progress_evidence
+      ~had_owned_active_task_at_turn_start
+      ~actual_keeper_tool_names
 ;;
 
 let text_only_violation_contract_status ~actual_keeper_tool_names ~fallback

--- a/lib/keeper/keeper_agent_run_contract_helpers.mli
+++ b/lib/keeper/keeper_agent_run_contract_helpers.mli
@@ -18,6 +18,12 @@ val no_progress_success_tool_names_for_contract :
   string list
 
 val observed_completion_contract_status :
+  tool_calls:Keeper_agent_result.tool_call_detail list ->
   had_owned_active_task_at_turn_start:bool ->
   actual_keeper_tool_names:string list ->
   Keeper_execution_receipt.completion_contract_result
+
+val failed_tool_only_contract_violation :
+  actual_keeper_tool_names:string list ->
+  tool_calls:Keeper_agent_result.tool_call_detail list ->
+  bool

--- a/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.ml
+++ b/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.ml
@@ -377,6 +377,18 @@ let apply_output_to_result ~(meta : keeper_meta)
   | Request_help, Board_post when tool_names = [] ->
       (match deliver_request_help_post ~meta ~state with
       | Request_help_posted ->
+          let result =
+            Keeper_agent_result.append_synthetic_tool_call
+              ~provider:"keeper_social_model"
+              ~route_evidence:
+                (`Assoc
+                  [ "source", `String "bdi_speech_v1"
+                  ; "speech_act", `String "request_help"
+                  ; "delivery_surface", `String "board_post"
+                  ])
+              "keeper_board_post"
+              result
+          in
           ({ result with response_text = "" }, state)
       | Request_help_deduped | Request_help_failed ->
           ({ result with response_text = "" }, state))

--- a/lib/server/server_dashboard_http_composite_claims.ml
+++ b/lib/server/server_dashboard_http_composite_claims.ml
@@ -300,6 +300,27 @@ let composite_execution_claim_no_eligible execution =
   | _ -> false
 ;;
 
+let composite_execution_contract_blocker_reason execution =
+  let recoverable_disposition =
+    string_opt_is_any
+      (json_string "operator_disposition" execution)
+      [ "pause_human"; "pass_next_model"; "fail_open_next_runtime" ]
+  in
+  if not recoverable_disposition
+  then None
+  else
+    match lower_string_opt (json_string "completion_contract_result" execution) with
+    | Some ("surface_mismatch" as reason) | Some ("no_capable_provider" as reason) ->
+      Some ("completion_contract_result:" ^ reason)
+    | _ -> None
+;;
+
+let composite_execution_contract_blocked execution =
+  match composite_execution_contract_blocker_reason execution with
+  | Some _ -> true
+  | None -> false
+;;
+
 let composite_execution_config_drift execution =
   match json_member "config_drift" execution with
   | `Assoc _ as config_drift ->
@@ -311,6 +332,7 @@ let keeper_activation_readiness_json = Server_dashboard_fleet_readiness.keeper_a
 
 let composite_execution_blocked execution =
   composite_execution_claim_no_eligible execution
+  || composite_execution_contract_blocked execution
   || string_opt_is_any (json_string "operator_disposition" execution) [ "pause_human" ]
   || (match lower_string_opt (json_string "terminal_reason_code" execution) with
       | Some terminal -> terminal <> "" && terminal <> "completed"
@@ -406,15 +428,18 @@ let composite_runtime_attention ~snapshot ~execution =
     then None
     else if composite_execution_claim_no_eligible execution
     then Some "claim_scope_no_eligible"
-    else match json_string "operator_disposition_reason" execution with
-    | Some value -> String_util.trim_to_option value
-    | _ ->
-      (match json_string "terminal_reason_code" execution with
+    else match composite_execution_contract_blocker_reason execution with
+    | Some _ as reason -> reason
+    | None ->
+      (match json_string "operator_disposition_reason" execution with
        | Some value -> String_util.trim_to_option value
-       | _ when needs_attention && composite_execution_config_drift execution ->
-         Some "keeper_runtime_override_drift"
-       | _ when blocked -> Some "runtime_blocked"
-       | _ -> None)
+       | _ ->
+         (match json_string "terminal_reason_code" execution with
+          | Some value -> String_util.trim_to_option value
+          | _ when needs_attention && composite_execution_config_drift execution ->
+            Some "keeper_runtime_override_drift"
+          | _ when blocked -> Some "runtime_blocked"
+          | _ -> None))
   in
   let reason =
     match execution_reason with

--- a/lib/server/server_dashboard_http_composite_claims.mli
+++ b/lib/server/server_dashboard_http_composite_claims.mli
@@ -39,6 +39,8 @@ val composite_execution_claim_no_eligible : Yojson.Safe.t -> bool
 val composite_execution_config_drift : Yojson.Safe.t -> bool
 val keeper_activation_readiness_json :
   Keeper_meta_contract.keeper_meta -> Yojson.Safe.t
+val composite_execution_contract_blocker_reason : Yojson.Safe.t -> string option
+val composite_execution_contract_blocked : Yojson.Safe.t -> bool
 val composite_execution_blocked : Yojson.Safe.t -> bool
 val composite_execution_receipt_present : Yojson.Safe.t -> bool
 val composite_execution_receipt_epoch : Yojson.Safe.t -> float option

--- a/lib/server/server_dashboard_http_composite_recommendations.ml
+++ b/lib/server/server_dashboard_http_composite_recommendations.ml
@@ -81,6 +81,11 @@ let composite_recommended_actions_json ~keeper_name ~snapshot ~execution ~attent
       [ probe ("Inspect keeper claim scope: " ^ reason)
       ; message ("Resolve keeper claim scope before retry: " ^ reason)
       ]
+    else if composite_execution_contract_blocked execution
+    then
+      [ probe ("Inspect keeper tool-route contract blocker: " ^ reason)
+      ; message ("Resolve keeper tool-route contract blocker before retry: " ^ reason)
+      ]
     else if composite_execution_config_blocked execution
     then
       [ probe ("Inspect configuration/auth blocker: " ^ reason)

--- a/test/dune
+++ b/test/dune
@@ -969,6 +969,13 @@
  (modules test_dashboard_operator_nudges)
  (libraries masc_test_deps))
 
+; Keeper composite attention preserves recoverable tool-route contract blockers.
+
+(test
+ (name test_server_dashboard_composite_attention)
+ (modules test_server_dashboard_composite_attention)
+ (libraries masc_test_deps))
+
 ; Typed JSON field extraction helper (RFC-0142 Phase 1).
 
 (test

--- a/test/test_keeper_unified_claim_progress.ml
+++ b/test/test_keeper_unified_claim_progress.ml
@@ -133,6 +133,37 @@ let test_contract_progress_filters_no_progress_tool_results () =
          ])
 ;;
 
+let test_failed_tool_only_turn_violates_contract () =
+  let failed_only = [ tool_call_detail ~outcome:"error" "ToolThatDoesNotExist" ] in
+  check
+    bool
+    "failed-only tool turn is a violation"
+    true
+    (KAR.For_testing.failed_tool_only_contract_violation
+       ~actual_keeper_tool_names:[]
+       ~tool_calls:failed_only);
+  check
+    string
+    "failed-only tool turn is not satisfied completion"
+    "violated"
+    (KAR.Contract_helpers.observed_completion_contract_status
+       ~had_owned_active_task_at_turn_start:false
+       ~actual_keeper_tool_names:[]
+       ~tool_calls:failed_only
+     |> Masc.Keeper_execution_receipt.completion_contract_result_to_string)
+;;
+
+let test_synthetic_board_post_tool_detail () =
+  let detail =
+    KAR.synthetic_tool_call_detail
+      ~provider:"keeper_social_model"
+      "keeper_board_post"
+  in
+  check string "synthetic tool name" "keeper_board_post" detail.tool_name;
+  check string "synthetic tool outcome" "ok" detail.outcome;
+  check string "synthetic provider" "keeper_social_model" detail.provider
+;;
+
 let () =
   run
     "keeper_unified_claim_progress"
@@ -157,6 +188,14 @@ let () =
             "contract progress filters no-progress tool results"
             `Quick
             test_contract_progress_filters_no_progress_tool_results
+        ; test_case
+            "failed tool-only turn violates contract"
+            `Quick
+            test_failed_tool_only_turn_violates_contract
+        ; test_case
+            "synthetic board-post evidence keeps progress visible"
+            `Quick
+            test_synthetic_board_post_tool_detail
         ] )
     ]
 ;;

--- a/test/test_server_dashboard_composite_attention.ml
+++ b/test/test_server_dashboard_composite_attention.ml
@@ -1,0 +1,86 @@
+open Alcotest
+open Yojson.Safe.Util
+
+let snapshot =
+  `Assoc
+    [ "is_live", `Bool false
+    ; "fiber_stop_flag", `Bool false
+    ; "turn_phase", `String "idle"
+    ; "decision", `Assoc [ "stage", `String "undecided" ]
+    ; "runtime", `Assoc [ "state", `String "idle" ]
+    ; "compaction", `Assoc [ "stage", `String "accumulating" ]
+    ]
+;;
+
+let execution completion_contract_result =
+  `Assoc
+    [ "latest_receipt_present", `Bool true
+    ; "recorded_at", `String "2026-06-05T00:00:00Z"
+    ; "completion_contract_result", `String completion_contract_result
+    ; "operator_disposition", `String "pass_next_model"
+    ; "operator_disposition_reason", `Null
+    ; "terminal_reason_code", `Null
+    ; "error", `Null
+    ; "claim_scope", `Assoc [ "status", `String "ok" ]
+    ; "config_drift", `Assoc [ "runtime_override", `Bool false ]
+    ]
+;;
+
+let test_contract_blocker_marks_attention () =
+  let execution = execution "surface_mismatch" in
+  let attention =
+    Server_dashboard_http_composite.composite_runtime_attention ~snapshot ~execution
+  in
+  check bool "blocked" true attention.cra_blocked;
+  check bool "needs_attention" true attention.cra_needs_attention;
+  check string "state" "blocked" attention.cra_state;
+  check
+    (option string)
+    "reason"
+    (Some "completion_contract_result:surface_mismatch")
+    attention.cra_reason
+;;
+
+let test_contract_blocker_recommends_route_actions () =
+  let execution = execution "no_capable_provider" in
+  let attention =
+    Server_dashboard_http_composite.composite_runtime_attention ~snapshot ~execution
+  in
+  let actions =
+    Server_dashboard_http_composite.composite_recommended_actions_json
+      ~keeper_name:"keeper-a"
+      ~snapshot
+      ~execution
+      ~attention
+    |> to_list
+  in
+  check
+    (list string)
+    "action types"
+    [ "keeper_message"; "keeper_probe" ]
+    (actions
+     |> List.map (fun action -> action |> member "action_type" |> to_string)
+     |> List.sort String.compare);
+  check
+    bool
+    "route reason"
+    true
+    (actions
+     |> List.for_all (fun action ->
+       let reason = action |> member "reason" |> to_string in
+       String.starts_with ~prefix:"Inspect keeper tool-route contract blocker" reason
+       || String.starts_with
+            ~prefix:"Resolve keeper tool-route contract blocker before retry"
+            reason))
+;;
+
+let () =
+  run
+    "server_dashboard_composite_attention"
+    [ ( "tool-route contract blockers"
+      , [ test_case "marks runtime attention" `Quick test_contract_blocker_marks_attention
+        ; test_case "emits route actions" `Quick
+            test_contract_blocker_recommends_route_actions
+        ] )
+    ]
+;;


### PR DESCRIPTION
Follow-up for #20156 after it merged before the review fixes landed. Fixes failed tool-only contract violations, restores synthetic keeper_board_post evidence for request-help board posts, and restores composite attention/recommendations for recoverable tool-route contract blockers. Verified with focused dune build plus test_keeper_unified_claim_progress and test_server_dashboard_composite_attention.