### PR TITLE
fix(keeper): avoid duplicate supervisor lifecycle publish

### DIFF
--- a/lib/keeper/keeper_supervisor.mli
+++ b/lib/keeper/keeper_supervisor.mli
@@ -39,6 +39,21 @@ val backoff_delay : int -> float
 val keep_last_n : int -> 'a -> 'a list -> 'a list
 (** [keep_last_n n item lst] prepends [item] and keeps at most [n] entries. *)
 
+type done_signal_resolution =
+  | Done_signal_resolved_now
+  | Done_signal_already_resolved
+  | Done_signal_already_seen
+(** Supervisor-local classification for attempts to resolve a keeper done
+    promise. [Done_signal_already_resolved] still suppresses finally cleanup,
+    but it must not publish a lifecycle event for an already-owned outcome. *)
+
+val done_signal_of_registry_result :
+  Keeper_registry.done_resolve_result -> done_signal_resolution
+(** Collapse the registry result into supervisor-local lifecycle ownership. *)
+
+val should_publish_lifecycle_for_done_signal : done_signal_resolution -> bool
+(** True only when this supervisor branch resolved [done_p] itself. *)
+
 val persona_name_for_drift_check : keeper_meta -> string
 (** Resolve the persona handle used by supervisor persona-drift checks.
     Honors keeper TOML [persona_name] overlays before falling back to

--- a/lib/keeper/keeper_supervisor_launch.ml
+++ b/lib/keeper/keeper_supervisor_launch.ml
@@ -22,6 +22,22 @@ let committed_tools_of_ambiguous_blocker =
   Startup_helpers.committed_tools_of_ambiguous_blocker
 ;;
 
+type done_signal_resolution =
+  | Done_signal_resolved_now
+  | Done_signal_already_resolved
+  | Done_signal_already_seen
+
+let done_signal_of_registry_result = function
+  | Keeper_registry.Done_resolved _ -> Done_signal_resolved_now
+  | Keeper_registry.Done_already_resolved _ -> Done_signal_already_resolved
+;;
+
+let should_publish_lifecycle_for_done_signal = function
+  | Done_signal_resolved_now -> true
+  | Done_signal_already_resolved
+  | Done_signal_already_seen -> false
+;;
+
 (* ── Event publishing (see Keeper_supervisor_publish_lifecycle, #8856/#8605) ─ *)
 
 let publish_lifecycle = Keeper_supervisor_publish_lifecycle.publish_lifecycle
@@ -120,15 +136,17 @@ let launch_supervised_fiber
         if not !resolved then
           (* Issue #18335: the keepalive layer (keeper_keepalive.ml:760-791)
              may have already resolved done_p via record_keeper_stopped.
-             When the Promise is already resolved, treat it as success —
-             the keeper completed normally via the keepalive exit path. *)
-          match Keeper_registry.resolve_done reg ~source value with
-          | Keeper_registry.Done_resolved _
-          | Keeper_registry.Done_already_resolved _ ->
-            resolved := true;
-            true
+             When the Promise is already resolved, suppress finally cleanup,
+             but do not let this supervisor branch publish a second lifecycle
+             event for an outcome it did not own. *)
+          let signal =
+            Keeper_registry.resolve_done reg ~source value
+            |> done_signal_of_registry_result
+          in
+          resolved := true;
+          signal
         else
-          false
+          Done_signal_already_seen
       in
       Eio_guard.protect
         (fun () ->
@@ -233,7 +251,9 @@ let launch_supervised_fiber
                   Log.Keeper.warn
                     "supervisor: Fiber_terminated dispatch failed: %s"
                     (Keeper_state_machine.transition_error_to_string e));
-               if resolve_done ~source:"supervisor_watchdog_crash" (`Crashed reason)
+               if
+                 resolve_done ~source:"supervisor_watchdog_crash" (`Crashed reason)
+                 |> should_publish_lifecycle_for_done_signal
                then
                  publish_phase_lifecycle
                    ~phase:Keeper_state_machine.Crashed
@@ -272,7 +292,9 @@ let launch_supervised_fiber
                   Log.Keeper.warn
                     "supervisor: Drain_complete dispatch failed: %s"
                     (Keeper_state_machine.transition_error_to_string e));
-               if resolve_done ~source:"supervisor_normal_exit" `Stopped
+               if
+                 resolve_done ~source:"supervisor_normal_exit" `Stopped
+                 |> should_publish_lifecycle_for_done_signal
                then
                  publish_phase_lifecycle
                    ~phase:Keeper_state_machine.Stopped
@@ -331,7 +353,9 @@ let launch_supervised_fiber
                ~reason
                ~restart_count:rc;
              Keeper_registry_error_recording.record ~base_path meta.name reason;
-             if resolve_done ~source:"supervisor_exception_handler" (`Crashed reason)
+             if
+               resolve_done ~source:"supervisor_exception_handler" (`Crashed reason)
+               |> should_publish_lifecycle_for_done_signal
              then
                publish_phase_lifecycle
                  ~phase:Keeper_state_machine.Crashed
@@ -478,7 +502,9 @@ let launch_supervised_fiber
 	                  ~base_path
 	                  meta.name
 	                  (Keeper_state_machine.Fiber_terminated { outcome; provider_id = None; http_status = None });
-                if resolve_done ~source:"supervisor_unresolved_cleanup" (`Crashed reason)
+                if
+                  resolve_done ~source:"supervisor_unresolved_cleanup" (`Crashed reason)
+                  |> should_publish_lifecycle_for_done_signal
                 then
                   publish_phase_lifecycle
                     ~phase:Keeper_state_machine.Crashed

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -354,6 +354,39 @@ let test_keep_last_n_never_exceeds () =
   done;
   check bool "length <= n" true (List.length !result <= n)
 
+let test_done_signal_publishes_only_for_fresh_resolution () =
+  check
+    bool
+    "fresh resolve publishes lifecycle"
+    true
+    (Sup.should_publish_lifecycle_for_done_signal Sup.Done_signal_resolved_now);
+  check
+    bool
+    "already resolved does not publish lifecycle"
+    false
+    (Sup.should_publish_lifecycle_for_done_signal Sup.Done_signal_already_resolved);
+  check
+    bool
+    "already seen does not publish lifecycle"
+    false
+    (Sup.should_publish_lifecycle_for_done_signal Sup.Done_signal_already_seen)
+
+let test_done_signal_maps_registry_result () =
+  check
+    bool
+    "registry fresh resolve publishes"
+    true
+    (Reg.Done_resolved { source = "test" }
+     |> Sup.done_signal_of_registry_result
+     |> Sup.should_publish_lifecycle_for_done_signal);
+  check
+    bool
+    "registry already-resolved suppresses publish"
+    false
+    (Reg.Done_already_resolved { source = "test"; previous = `Stopped }
+     |> Sup.done_signal_of_registry_result
+     |> Sup.should_publish_lifecycle_for_done_signal)
+
 (* ── Property: self-preservation subset ────────────────── *)
 
 let bp = "/tmp/test-sp-prop"
@@ -2139,6 +2172,12 @@ let () =
     ];
     "keep_last_n_properties", [
       test_case "never exceeds limit" `Quick test_keep_last_n_never_exceeds;
+    ];
+    "done_signal", [
+      test_case "publish only for fresh resolution" `Quick
+        test_done_signal_publishes_only_for_fresh_resolution;
+      test_case "registry result mapping preserves lifecycle ownership" `Quick
+        test_done_signal_maps_registry_result;
     ];
     "supervision_cohorts", [
       test_case "64 keepers form 8 cohorts of 8" `Quick


### PR DESCRIPTION
Summary
- split supervisor done resolution into fresh/already-resolved/already-seen signals
- keep already-resolved done_p suppressing finally cleanup, but stop treating it as lifecycle publish ownership
- add keeper_supervisor tests for the done signal ownership mapping

Why
- Keeper_registry.resolve_done now preserves whether the caller won the done_p resolve race. keeper_supervisor_launch still collapsed Done_resolved and Done_already_resolved into true, so a supervisor branch could publish a second lifecycle event after keepalive had already owned the final outcome.

Verification
- ocamlformat --check lib/keeper/keeper_supervisor_launch.ml lib/keeper/keeper_supervisor.mli test/test_keeper_supervisor.ml
- git diff --check
- env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_BUILD_DIR=/private/tmp/masc-dune-supervisor-done-publish-20260605 scripts/dune-local.sh build test/test_keeper_supervisor.exe
- /private/tmp/masc-dune-supervisor-done-publish-20260605/default/test/test_keeper_supervisor.exe