### PR TITLE
fix(keeper): add missing contract helpers and synthetic tool call appender

### DIFF
--- a/lib/keeper/keeper_agent_result.ml
+++ b/lib/keeper/keeper_agent_result.ml
@@ -71,6 +71,20 @@ type run_result =
 let tool_names (result : run_result) = tool_names_of_calls result.tool_calls
 let tool_call_count (result : run_result) = List.length result.tool_calls
 
+let append_synthetic_tool_call ~provider ?route_evidence tool_name result =
+  let synthetic_call =
+    { tool_name
+    ; provider
+    ; outcome = "ok"
+    ; typed_outcome = None
+    ; latency_ms = 0.0
+    ; task_id = None
+    ; route_evidence
+    }
+  in
+  { result with tool_calls = result.tool_calls @ [ synthetic_call ] }
+;;
+
 (* RFC-0132 PR-2: agent-result surface label = external boundary; redact via SSOT. *)
 let runtime_lane_label =
   Boundary_redaction.to_string Boundary_redaction.runtime_model_label

--- a/lib/keeper/keeper_agent_result.mli
+++ b/lib/keeper/keeper_agent_result.mli
@@ -42,6 +42,15 @@ val tool_names_of_calls : tool_call_detail list -> string list
 val tool_names : run_result -> string list
 val tool_call_count : run_result -> int
 
+val append_synthetic_tool_call
+  :  provider:string
+  -> ?route_evidence:Yojson.Safe.t
+  -> string
+  -> run_result
+  -> run_result
+(** [append_synthetic_tool_call ~provider ?route_evidence tool_name result] appends
+    a synthetic tool call detail to the end of the [result.tool_calls] list. *)
+
 val runtime_lane_label : string
 (** Boundary-redacted label used wherever MASC's keeper metrics surface
     exposes a model identity field. OAS owns concrete provider/model

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -587,13 +587,8 @@ let run_turn
                      ~had_owned_active_task_at_turn_start
                      ~actual_keeper_tool_names:progress_keeper_tool_names
                  in
-                 let text_result =
-                   acc.receipt_completion_contract_result <- completion_contract_status ();
-                   Ok (`Provider_text text)
-                 in
-                   match text_result with
-                   | Error e -> Error e
-                   | Ok (`Provider_text text) ->
+                 let contract_status = completion_contract_status () in
+                 acc.receipt_completion_contract_result <- contract_status;
                      (match
                         Keeper_tool_response.normalize_response_text
                           ~text


### PR DESCRIPTION
Expose missing append_synthetic_tool_call in Keeper_agent_result to restore compilation after tool observation gate removal, and clean up residue failed_tool_only_contract_violation references.