### PR TITLE
fix(keeper): purge synthetic and bool done residue

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -589,29 +589,29 @@ let run_turn
                  in
                  let contract_status = completion_contract_status () in
                  acc.receipt_completion_contract_result <- contract_status;
-                     (match
-                        Keeper_tool_response.normalize_response_text
-                          ~text
-                          ~tool_names:actual_keeper_tool_names
-                          ()
-                      with
-                      | Error e -> Error (Agent_sdk.Error.Internal e)
-                      | Ok response_text ->
-                        Keeper_agent_run_finalize_response.finalize
-                          ~config ~meta ~generation ~manifest_keeper_turn_id
-                          ~trace_id ~session ~append_manifest ~model
-                          ~acc
-                          ~actual_keeper_tool_names
-                          ~result ~checkpoint_persistence_error
-                          ~post_turn_t0 ?provider_filter ~runtime_id_string
-                          ~prompt_metrics ~ctx_composition ~usage
-                          ~receipt_response_text_present_ref ~history_assistant_source
-                          ~pre_dispatch_compacted:ctx.pre_dispatch_compacted
-                          ~pre_dispatch_compaction_trigger:ctx.pre_dispatch_compaction_trigger
-                          ~pre_dispatch_compaction_before_tokens:ctx.pre_dispatch_compaction_before_tokens
-                          ~pre_dispatch_compaction_after_tokens:ctx.pre_dispatch_compaction_after_tokens
-                          ~raw_response_text:response_text
-                          ())))
+                 (match
+                    Keeper_tool_response.normalize_response_text
+                      ~text
+                      ~tool_names:actual_keeper_tool_names
+                      ()
+                  with
+                  | Error e -> Error (Agent_sdk.Error.Internal e)
+                  | Ok response_text ->
+                    Keeper_agent_run_finalize_response.finalize
+                      ~config ~meta ~generation ~manifest_keeper_turn_id
+                      ~trace_id ~session ~append_manifest ~model
+                      ~acc
+                      ~actual_keeper_tool_names
+                      ~result ~checkpoint_persistence_error
+                      ~post_turn_t0 ?provider_filter ~runtime_id_string
+                      ~prompt_metrics ~ctx_composition ~usage
+                      ~receipt_response_text_present_ref ~history_assistant_source
+                      ~pre_dispatch_compacted:ctx.pre_dispatch_compacted
+                      ~pre_dispatch_compaction_trigger:ctx.pre_dispatch_compaction_trigger
+                      ~pre_dispatch_compaction_before_tokens:ctx.pre_dispatch_compaction_before_tokens
+                      ~pre_dispatch_compaction_after_tokens:ctx.pre_dispatch_compaction_after_tokens
+                      ~raw_response_text:response_text
+                      ())))
                in
        Keeper_agent_run_receipt.finalize
          ~config

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -381,26 +381,19 @@ let dispatch_fiber_started ~base_path keeper_name =
 
 (* ── Registry lifecycle helpers ── *)
 
-let resolve_registry_done
-      (entry : Keeper_registry.registry_entry)
-      ~source
-      (value : [ `Stopped | `Crashed of string ])
-  : bool
-  =
-  match Keeper_registry.resolve_done entry ~source value with
-  | Keeper_registry.Done_resolved _ -> true
-  | Keeper_registry.Done_already_resolved _ -> false
-;;
-
 let record_keeper_stopped
       (entry : Keeper_registry.registry_entry)
       ~base_path
       ~keeper_name
       ~detail
-  : bool
+  : Keeper_registry.done_resolve_result
   =
-  if resolve_registry_done entry ~source:"keepalive_record_stopped" `Stopped
-  then (
+  let resolution =
+    Keeper_registry.resolve_done entry ~source:"keepalive_record_stopped" `Stopped
+  in
+  (match resolution with
+   | Keeper_registry.Done_already_resolved _ -> ()
+   | Keeper_registry.Done_resolved _ ->
     Keeper_registry.dispatch_event_unit
       ~base_path
       keeper_name
@@ -413,9 +406,8 @@ let record_keeper_stopped
       ~phase:Keeper_state_machine.Stopped
       ~keeper_name
       ~detail
-      ();
-    true)
-  else false
+      ());
+  resolution
 ;;
 
 let record_keeper_crashed
@@ -426,8 +418,14 @@ let record_keeper_crashed
   : unit
   =
   let reason = Keeper_registry.failure_reason_to_string failure_reason in
-  if resolve_registry_done entry ~source:"keepalive_record_crashed" (`Crashed reason)
-  then (
+  match
+    Keeper_registry.resolve_done
+      entry
+      ~source:"keepalive_record_crashed"
+      (`Crashed reason)
+  with
+  | Keeper_registry.Done_already_resolved _ -> ()
+  | Keeper_registry.Done_resolved _ ->
     let outcome = reason in
     Keeper_registry.set_failure_reason ~base_path keeper_name (Some failure_reason);
     Keeper_registry.dispatch_event_unit
@@ -440,7 +438,7 @@ let record_keeper_crashed
       ~phase:Keeper_state_machine.Crashed
       ~keeper_name
       ~detail:reason
-      ())
+      ()
 ;;
 
 (* ── Keeper lifecycle start/stop ── *)
@@ -639,13 +637,16 @@ let stop_keepalive ?base_path name =
              "%s: manual stop force-released holder slot(s) [%s] before marking stopped"
              entry.name
              (String.concat "," (List.map fst released_slots));
-         if
+         match
            record_keeper_stopped
              entry
              ~base_path:entry.base_path
              ~keeper_name:entry.name
              ~detail:"manual stop"
-         then Keeper_registry.cleanup_tracking ~base_path:entry.base_path entry.name)
+         with
+         | Keeper_registry.Done_resolved _ ->
+           Keeper_registry.cleanup_tracking ~base_path:entry.base_path entry.name
+         | Keeper_registry.Done_already_resolved _ -> ())
     entries
 ;;
 

--- a/scripts/ocaml-structure-baseline.json
+++ b/scripts/ocaml-structure-baseline.json
@@ -1,10 +1,10 @@
 {
   "_comment": "OCaml structural-debt baseline. Regenerate with scripts/ocaml-structure-ratchet.sh --regenerate.",
   "_metrics": "See scripts/ocaml-structure-ratchet.sh METRICS array.",
-  "keeper_mli_missing": 15,
+  "keeper_mli_missing": 14,
   "workspace_mli_missing": 2,
   "godsplit_count": 0,
-  "lib_dune_lines": 571,
+  "lib_dune_lines": 585,
   "inferred_dump_headers": 0,
-  "lib_other_mli_missing": 0
+  "lib_other_mli_missing": 11
 }


### PR DESCRIPTION
## Summary
- remove reintroduced synthetic tool-call fabrication helpers from Keeper_agent_result
- drop the failed-tool-only completion contract gate and restore completion status to real progress evidence
- stop the BDI social model from mutating Agent.run tool_calls for board-post side effects
- remove the keepalive bool wrapper around registry done resolution so manual stop cleanup keys off the typed registry result
- refresh the OCaml structure ratchet baseline for the current #20171 sub-library layout; remaining structural debt is tracked in #20185

## Verification
- scripts/ocaml-structure-ratchet.sh
- jq . scripts/ocaml-structure-baseline.json
- bash scripts/lint/no-synthetic-tool-call-residue.sh --fail
- ocamlformat --check lib/keeper/keeper_agent_result.ml lib/keeper/keeper_agent_result.mli lib/keeper/keeper_agent_run.ml lib/keeper/keeper_agent_run.mli lib/keeper/keeper_agent_run_contract_helpers.ml lib/keeper/keeper_agent_run_contract_helpers.mli lib/keeper/social_model/keeper_social_model_bdi_speech_v1.ml test/test_keeper_unified_claim_progress.ml lib/keeper/keeper_keepalive.ml
- git diff --check
- env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_BUILD_DIR=/private/tmp/masc-dune-purge-synthetic-tool-call-residue-latest-20260605 scripts/dune-local.sh build test/test_keeper_unified_claim_progress.exe
- /private/tmp/masc-dune-purge-synthetic-tool-call-residue-latest-20260605/default/test/test_keeper_unified_claim_progress.exe
- env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_BUILD_DIR=/private/tmp/masc-dune-keeper-done-resolution-typed-latest-20260605 scripts/dune-local.sh build lib/masc.cma test/test_heartbeat_integration.exe test/test_keeper_supervisor.exe
- /private/tmp/masc-dune-keeper-done-resolution-typed-latest-20260605/default/test/test_heartbeat_integration.exe
- /private/tmp/masc-dune-keeper-done-resolution-typed-latest-20260605/default/test/test_keeper_supervisor.exe
