### PR TITLE
fix(keeper): remove synthetic tool-call residue

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -589,29 +589,29 @@ let run_turn
                  in
                  let contract_status = completion_contract_status () in
                  acc.receipt_completion_contract_result <- contract_status;
-                     (match
-                        Keeper_tool_response.normalize_response_text
-                          ~text
-                          ~tool_names:actual_keeper_tool_names
-                          ()
-                      with
-                      | Error e -> Error (Agent_sdk.Error.Internal e)
-                      | Ok response_text ->
-                        Keeper_agent_run_finalize_response.finalize
-                          ~config ~meta ~generation ~manifest_keeper_turn_id
-                          ~trace_id ~session ~append_manifest ~model
-                          ~acc
-                          ~actual_keeper_tool_names
-                          ~result ~checkpoint_persistence_error
-                          ~post_turn_t0 ?provider_filter ~runtime_id_string
-                          ~prompt_metrics ~ctx_composition ~usage
-                          ~receipt_response_text_present_ref ~history_assistant_source
-                          ~pre_dispatch_compacted:ctx.pre_dispatch_compacted
-                          ~pre_dispatch_compaction_trigger:ctx.pre_dispatch_compaction_trigger
-                          ~pre_dispatch_compaction_before_tokens:ctx.pre_dispatch_compaction_before_tokens
-                          ~pre_dispatch_compaction_after_tokens:ctx.pre_dispatch_compaction_after_tokens
-                          ~raw_response_text:response_text
-                          ())))
+                 (match
+                    Keeper_tool_response.normalize_response_text
+                      ~text
+                      ~tool_names:actual_keeper_tool_names
+                      ()
+                  with
+                  | Error e -> Error (Agent_sdk.Error.Internal e)
+                  | Ok response_text ->
+                    Keeper_agent_run_finalize_response.finalize
+                      ~config ~meta ~generation ~manifest_keeper_turn_id
+                      ~trace_id ~session ~append_manifest ~model
+                      ~acc
+                      ~actual_keeper_tool_names
+                      ~result ~checkpoint_persistence_error
+                      ~post_turn_t0 ?provider_filter ~runtime_id_string
+                      ~prompt_metrics ~ctx_composition ~usage
+                      ~receipt_response_text_present_ref ~history_assistant_source
+                      ~pre_dispatch_compacted:ctx.pre_dispatch_compacted
+                      ~pre_dispatch_compaction_trigger:ctx.pre_dispatch_compaction_trigger
+                      ~pre_dispatch_compaction_before_tokens:ctx.pre_dispatch_compaction_before_tokens
+                      ~pre_dispatch_compaction_after_tokens:ctx.pre_dispatch_compaction_after_tokens
+                      ~raw_response_text:response_text
+                      ())))
                in
        Keeper_agent_run_receipt.finalize
          ~config

--- a/scripts/ocaml-structure-baseline.json
+++ b/scripts/ocaml-structure-baseline.json
@@ -1,10 +1,10 @@
 {
   "_comment": "OCaml structural-debt baseline. Regenerate with scripts/ocaml-structure-ratchet.sh --regenerate.",
   "_metrics": "See scripts/ocaml-structure-ratchet.sh METRICS array.",
-  "keeper_mli_missing": 15,
+  "keeper_mli_missing": 14,
   "workspace_mli_missing": 2,
   "godsplit_count": 0,
-  "lib_dune_lines": 571,
+  "lib_dune_lines": 585,
   "inferred_dump_headers": 0,
-  "lib_other_mli_missing": 0
+  "lib_other_mli_missing": 11
 }

--- a/scripts/ocaml-structure-baseline.json
+++ b/scripts/ocaml-structure-baseline.json
@@ -4,7 +4,7 @@
   "keeper_mli_missing": 14,
   "workspace_mli_missing": 2,
   "godsplit_count": 0,
-  "lib_dune_lines": 585,
+  "lib_dune_lines": 562,
   "inferred_dump_headers": 0,
-  "lib_other_mli_missing": 11
+  "lib_other_mli_missing": 0
 }

--- a/test/test_keeper_unified_claim_progress.ml
+++ b/test/test_keeper_unified_claim_progress.ml
@@ -133,6 +133,25 @@ let test_contract_progress_filters_no_progress_tool_results () =
          ])
 ;;
 
+let test_failed_tool_only_turn_does_not_fabricate_progress () =
+  let failed_only = [ tool_call_detail ~outcome:"error" "ToolThatDoesNotExist" ] in
+  check
+    (list string)
+    "failed-only tool turn has no progress tools"
+    []
+    (KAR.For_testing.progress_keeper_tool_names_for_contract
+       ~actual_keeper_tool_names:[]
+       ~tool_calls:failed_only);
+  check
+    string
+    "failed-only tool turn falls back to text completion contract"
+    "satisfied_completion"
+    (KAR.Contract_helpers.observed_completion_contract_status
+       ~had_owned_active_task_at_turn_start:false
+       ~actual_keeper_tool_names:[]
+     |> Masc.Keeper_execution_receipt.completion_contract_result_to_string)
+;;
+
 let () =
   run
     "keeper_unified_claim_progress"
@@ -157,6 +176,10 @@ let () =
             "contract progress filters no-progress tool results"
             `Quick
             test_contract_progress_filters_no_progress_tool_results
+        ; test_case
+            "failed tool-only turn does not fabricate progress"
+            `Quick
+            test_failed_tool_only_turn_does_not_fabricate_progress
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- remove synthetic keeper tool-call result helpers from active runtime surfaces
- drop the failed-tool-only completion gate residue from Keeper_agent_run
- update claim-progress test expectations to assert no fabricated progress
- tighten the OCaml structure baseline after rebasing onto current main

## Verification
- scripts/lint/no-synthetic-tool-call-residue.sh --fail
- scripts/ocaml-structure-ratchet.sh
- bash scripts/check-doc-truth.sh
- scripts/sync-oas-pin-docs.sh --check
- scripts/audit-keeper-tool-boundary-matrix.sh
- ocamlformat --check lib/keeper/keeper_agent_run.ml test/test_keeper_unified_claim_progress.ml
- git diff --check
- env OCAMLPARAM=_,warn-error=+a DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_fix_synthetic_residue_rebased4 dune build --root . -j 1 lib/masc.cma test/test_keeper_unified_claim_progress.exe
- gtimeout 60 _build_fix_synthetic_residue_rebased4/default/test/test_keeper_unified_claim_progress.exe
- gtimeout 900 env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_health_pr20177_rebased4 opam exec -- bash scripts/health_snapshot.sh --json-out .health/health-snapshot.json --baseline-ref origin/main --fail-on-lib-regression
