### PR TITLE
fix(exec): harden git gh readonly risk classification

### DIFF
--- a/lib/exec/shell_ir_risk.ml
+++ b/lib/exec/shell_ir_risk.ml
@@ -82,12 +82,152 @@ let git_branch_args_are_read_only args =
   | _ -> git_branch_has_flag read_flags args
 ;;
 
+let is_env_assignment arg =
+  match String.index_opt arg '=' with
+  | None -> false
+  | Some 0 -> false
+  | Some i ->
+    let name = String.sub arg 0 i in
+    String.for_all
+      (function
+        | 'A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '_' -> true
+        | _ -> false)
+      name
+;;
+
+let rec strip_env_prefix words =
+  let rec strip_env_args = function
+    | [] -> []
+    | "--" :: rest -> rest
+    | ("-i" | "--ignore-environment" | "--null" | "-0") :: rest ->
+      strip_env_args rest
+    | ("-u" | "--unset") :: _ :: rest -> strip_env_args rest
+    | arg :: rest
+      when String.starts_with ~prefix:"--unset=" arg
+           || String.starts_with ~prefix:"-u" arg
+           || is_env_assignment arg ->
+      strip_env_args rest
+    | rest -> rest
+  in
+  match words with
+  | "env" :: rest -> strip_env_prefix (strip_env_args rest)
+  | _ -> words
+;;
+
+let rec skip_git_global_options = function
+  | [] -> []
+  | "--" :: rest -> rest
+  | ("-C" | "-c" | "--git-dir" | "--work-tree" | "--namespace" | "--super-prefix"
+    | "--config-env" | "--exec-path") :: _ :: rest ->
+    skip_git_global_options rest
+  | ("--bare" | "--no-pager" | "--paginate" | "--no-replace-objects"
+    | "--literal-pathspecs" | "--glob-pathspecs" | "--noglob-pathspecs"
+    | "--icase-pathspecs" | "--no-optional-locks" | "--version" | "-v") :: rest ->
+    skip_git_global_options rest
+  | opt :: rest
+    when String.length opt > 1
+         && opt.[0] = '-'
+         && (String.starts_with ~prefix:"--git-dir=" opt
+             || String.starts_with ~prefix:"--work-tree=" opt
+             || String.starts_with ~prefix:"--namespace=" opt
+             || String.starts_with ~prefix:"--exec-path=" opt
+             || String.starts_with ~prefix:"--config-env=" opt
+             || String.starts_with ~prefix:"-c" opt) ->
+    skip_git_global_options rest
+  | parts -> parts
+;;
+
+let rec skip_gh_global_options = function
+  | [] -> []
+  | ("--repo" | "-R" | "--hostname" | "--config" | "--git-protocol") :: _ :: rest ->
+    skip_gh_global_options rest
+  | ("--help" | "-h" | "--version" | "--debug" | "--verbose" | "--no-color"
+    | "--paginate") :: rest ->
+    skip_gh_global_options rest
+  | opt :: rest
+    when String.length opt > 1
+         && opt.[0] = '-'
+         && (String.starts_with ~prefix:"--repo=" opt
+             || String.starts_with ~prefix:"-R=" opt
+             || String.starts_with ~prefix:"--hostname=" opt
+             || String.starts_with ~prefix:"--config=" opt
+             || String.starts_with ~prefix:"--git-protocol=" opt) ->
+    skip_gh_global_options rest
+  | parts -> parts
+;;
+
+let normalize_command_words words =
+  match strip_env_prefix words with
+  | "git" :: rest -> "git" :: skip_git_global_options rest
+  | "gh" :: rest -> "gh" :: skip_gh_global_options rest
+  | words -> words
+;;
+
+(* STR-OK: Shell argv boundary parser; git option strings are normalized here
+   before risk is converted into the typed [risk_class] envelope. *)
+let git_config_arg_is_read_flag = function
+  | "--get" | "--get-all" | "--get-regexp" | "--list" | "-l" | "--show-origin"
+  | "--show-scope" | "--name-only" | "--null" | "-z" ->
+    true
+  | _ -> false
+;;
+
+let git_config_arg_is_write_flag = function
+  | "--add" | "--replace-all" | "--unset" | "--unset-all" | "--remove-section"
+  | "--rename-section" | "--edit" | "-e" ->
+    true
+  | _ -> false
+;;
+
+let git_config_args_are_read_only args =
+  match args with
+  | [] -> false
+  | _ ->
+    List.exists git_config_arg_is_read_flag args
+    && not (List.exists git_config_arg_is_write_flag args)
+;;
+
+let git_remote_args_are_read_only = function
+  | [] -> true
+  | ("-v" | "--verbose") :: _ -> true
+  | ("show" | "get-url") :: _ -> true
+  | _ -> false
+;;
+
+let git_tag_args_are_read_only = function
+  | [] -> true
+  | args ->
+    let is_read_flag = function
+      | "-l" | "--list" | "-n" | "--points-at" -> true
+      | _ -> false
+    in
+    let is_write_flag = function
+      | "-a" | "--annotate" | "-s" | "--sign" | "-d" | "--delete" | "-f" ->
+        true
+      | _ -> false
+    in
+    List.exists is_read_flag args && not (List.exists is_write_flag args)
+;;
+
+let git_clean_args_are_dry_run args =
+  let is_dry_run_flag = function
+    | "-n" | "--dry-run" -> true
+    | _ -> false
+  in
+  List.exists is_dry_run_flag args
+;;
+
 let classify_write_detail (words : string list) : risk_class option =
   match words with
   | "git" :: sub :: rest ->
     (match sub with
-     | "push" | "merge" | "rebase" | "commit" -> Some R1_Reversible_mutation
+     | "push" | "merge" | "rebase" | "commit" | "add" | "apply" | "am"
+     | "cherry-pick" | "revert" | "switch" | "restore" | "pull" | "fetch"
+     | "worktree" | "submodule" | "config" | "remote" ->
+       Some R1_Reversible_mutation
      | "reset" -> Some R2_Irreversible
+     | "clean" ->
+       if git_clean_args_are_dry_run rest then None else Some R2_Irreversible
      | "branch" ->
        if git_branch_args_are_read_only rest
        then None
@@ -124,7 +264,7 @@ let repo_hosting_cli_irreversible_ops =
 let repo_hosting_cli_reversible_mutations =
   [
     ("pr",
-     [ "create"; "close"; "reopen"; "edit"; "comment"; "review"; "lock";
+     [ "create"; "close"; "reopen"; "edit"; "comment"; "review"; "lock"; "checkout";
        "unlock" ]);
     ("issue",
      [ "create"; "close"; "reopen"; "edit"; "comment"; "lock"; "unlock";
@@ -327,11 +467,17 @@ let flat_stage_words (ir : Shell_ir.t) : string list =
 let is_write_operation (words : string list) =
   match words with
   | "git" :: "branch" :: rest -> not (git_branch_args_are_read_only rest)
+  | "git" :: "clean" :: rest -> not (git_clean_args_are_dry_run rest)
+  | "git" :: "config" :: rest -> not (git_config_args_are_read_only rest)
+  | "git" :: "remote" :: rest -> not (git_remote_args_are_read_only rest)
+  | "git" :: "tag" :: rest -> not (git_tag_args_are_read_only rest)
   | "git" :: sub :: _ ->
-    List.mem
-      sub
-      [ "push"; "commit"; "merge"; "rebase"; "reset"; "checkout"; "tag";
-        "stash"; "clone"; "init" ]
+    not
+      (List.mem
+         sub
+         [ "status"; "log"; "show"; "diff"; "blame"; "rev-parse"; "merge-base";
+           "ls-files"; "ls-tree"; "cat-file"; "describe"; "name-rev"; "for-each-ref";
+           "shortlog"; "grep"; "help"; "--help"; "--version"; "version" ])
   | "dune" :: sub :: _ -> List.mem sub [ "clean"; "promote" ]
   | "make" :: sub :: _ -> List.mem sub [ "clean"; "deploy"; "install"; "publish" ]
   | ("npm" | "pnpm" | "yarn") :: sub :: _ ->
@@ -465,6 +611,7 @@ let action_flag_risk (words : string list) : risk_class =
    [risk_of_typed] must never under-classify. *)
 
 let classify_words (words : string list) : risk_class =
+  let words = normalize_command_words words in
   if is_destructive_bash_operation words then Destructive_protected
   else
     (* find/sed/sort action-flags are checked before the write/gh/R0

--- a/test/test_shell_ir_risk.ml
+++ b/test/test_shell_ir_risk.ml
@@ -40,7 +40,16 @@ let test_r0_read_commands () =
   check "git log --oneline -5" Shell_ir_risk.R0_Read;
   check "git branch -a --list '*20083*'" Shell_ir_risk.R0_Read;
   check "git branch --show-current" Shell_ir_risk.R0_Read;
+  check "git -C /repo status" Shell_ir_risk.R0_Read;
+  check "git -c color.ui=false branch --show-current" Shell_ir_risk.R0_Read;
+  check "git rev-parse HEAD" Shell_ir_risk.R0_Read;
+  check "git remote -v" Shell_ir_risk.R0_Read;
+  check "git config --get remote.origin.url" Shell_ir_risk.R0_Read;
+  check "git config --global --get user.email" Shell_ir_risk.R0_Read;
+  check "git tag -l" Shell_ir_risk.R0_Read;
+  check "env FOO=bar git status" Shell_ir_risk.R0_Read;
   check "gh pr view 123" Shell_ir_risk.R0_Read;
+  check "gh --repo owner/repo pr view 123" Shell_ir_risk.R0_Read;
   check "dune build" Shell_ir_risk.R0_Read;
   check "npm run build" Shell_ir_risk.R0_Read
 ;;
@@ -55,6 +64,18 @@ let test_r1_reversible_commands () =
   check "chgrp group file" Shell_ir_risk.R1_Reversible_mutation;
   check "git push origin main" Shell_ir_risk.R1_Reversible_mutation;
   check "git commit -m msg" Shell_ir_risk.R1_Reversible_mutation;
+  check "git add file.txt" Shell_ir_risk.R1_Reversible_mutation;
+  check "git apply patch.diff" Shell_ir_risk.R1_Reversible_mutation;
+  check "git -C /repo push origin branch" Shell_ir_risk.R1_Reversible_mutation;
+  check "git -c user.name=x commit -m msg" Shell_ir_risk.R1_Reversible_mutation;
+  check "git switch feature" Shell_ir_risk.R1_Reversible_mutation;
+  check "git restore file.txt" Shell_ir_risk.R1_Reversible_mutation;
+  check "git pull --ff-only" Shell_ir_risk.R1_Reversible_mutation;
+  check "git fetch origin main" Shell_ir_risk.R1_Reversible_mutation;
+  check "git config --global user.email x@example.com" Shell_ir_risk.R1_Reversible_mutation;
+  check "git remote set-head origin -a" Shell_ir_risk.R1_Reversible_mutation;
+  check "env FOO=bar git push origin branch" Shell_ir_risk.R1_Reversible_mutation;
+  check "cat patch.diff | git apply" Shell_ir_risk.R1_Reversible_mutation;
   check "git checkout branch" Shell_ir_risk.R1_Reversible_mutation;
   check "git branch new-branch" Shell_ir_risk.R1_Reversible_mutation;
   check "git branch -d old-branch" Shell_ir_risk.R1_Reversible_mutation;
@@ -76,7 +97,11 @@ let test_r2_irreversible_commands () =
   check "install file dest" Shell_ir_risk.R2_Irreversible;
   check "dd if=/dev/zero of=disk" Shell_ir_risk.R2_Irreversible;
   check "git reset --hard HEAD" Shell_ir_risk.R2_Irreversible;
+  check "git -C /repo reset --hard HEAD" Shell_ir_risk.R2_Irreversible;
+  check "git clean -fd" Shell_ir_risk.R2_Irreversible;
+  check "env git reset --hard HEAD" Shell_ir_risk.R2_Irreversible;
   check "gh pr merge 123" Shell_ir_risk.R2_Irreversible;
+  check "gh --repo owner/repo pr merge 123" Shell_ir_risk.R2_Irreversible;
   check "gh repo delete owner/repo" Shell_ir_risk.R2_Irreversible;
   check "shred -u file.txt" Shell_ir_risk.R2_Irreversible
 ;;
@@ -84,7 +109,10 @@ let test_r2_irreversible_commands () =
 let test_destructive_commands () =
   check "rm -rf /" Shell_ir_risk.Destructive_protected;
   check "git push --force origin main" Shell_ir_risk.Destructive_protected;
-  check "git push -f origin main" Shell_ir_risk.Destructive_protected
+  check "git push -f origin main" Shell_ir_risk.Destructive_protected;
+  check "git -C /repo push --force origin main" Shell_ir_risk.Destructive_protected;
+  check "env git push --force origin main" Shell_ir_risk.Destructive_protected;
+  check "cat ref | git push --force origin main" Shell_ir_risk.Destructive_protected
 ;;
 
 let test_gh_r0_read () =
@@ -99,6 +127,8 @@ let test_gh_r0_read () =
 let test_gh_r1_reversible () =
   check "gh pr create" Shell_ir_risk.R1_Reversible_mutation;
   check "gh pr close 123" Shell_ir_risk.R1_Reversible_mutation;
+  check "gh --repo owner/repo pr close 123" Shell_ir_risk.R1_Reversible_mutation;
+  check "gh pr checkout 123" Shell_ir_risk.R1_Reversible_mutation;
   check "gh pr reopen 123" Shell_ir_risk.R1_Reversible_mutation;
   check "gh issue create" Shell_ir_risk.R1_Reversible_mutation;
   check "gh issue edit 123" Shell_ir_risk.R1_Reversible_mutation;
@@ -118,6 +148,8 @@ let test_gh_r1_reversible () =
   check "gh api repos/owner/repo/issues --method POST" Shell_ir_risk.R1_Reversible_mutation;
   check "gh api repos/owner/repo/issues -X PUT" Shell_ir_risk.R1_Reversible_mutation;
   check "gh api repos/owner/repo/issues -X PATCH" Shell_ir_risk.R1_Reversible_mutation;
+  check "printf data | gh api -X PATCH repos/owner/repo" Shell_ir_risk.R1_Reversible_mutation;
+  check "env GH_TOKEN=x gh pr close 123" Shell_ir_risk.R1_Reversible_mutation;
   check "gh api graphql" Shell_ir_risk.R1_Reversible_mutation;
   check "gh api repos/owner/repo --field name=value" Shell_ir_risk.R1_Reversible_mutation;
   check "gh api repos/owner/repo --raw-field name=value" Shell_ir_risk.R1_Reversible_mutation


### PR DESCRIPTION
## Summary

- Normalize `env`, git global options, and gh global options before Shell IR word-risk classification.
- Treat mutating git/gh commands as non-readonly even when wrapped by `env`, `git -C`, `git -c`, `gh --repo`, or pipeline stages.
- Preserve known readonly git forms such as `git -C ... status`, `git config --global --get ...`, `git remote -v`, and `git tag -l`.

## Review residue addressed

- PR #20068: readonly Execute/Shell IR bypasses through `git -C`, `git -c`, `env git ...`, and mutating non-head pipeline stages.
- PR #20068 / #20100: avoid carrying `git`/`gh` as a flat allowlist identity; classify the actual subcommand after option normalization.
- PR #20090-adjacent: keep typed Shell IR risk monotone by strengthening the word-list floor where typed shapes cannot see string-borne command risk.

## Verification

- `ocamlformat --check lib/exec/shell_ir_risk.ml test/test_shell_ir_risk.ml`
- `git diff --check HEAD~1 HEAD`
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_shell_ir_risk_fix dune build --root . --display=short -j 1 test/test_shell_ir_risk.exe`
- `_build_shell_ir_risk_fix/default/test/test_shell_ir_risk.exe`

Test output: 7 tests run, all passed.
