### PR TITLE
fix(dashboard): align keeper heading test

### DIFF
--- a/dashboard/src/components/keeper-shared.test.ts
+++ b/dashboard/src/components/keeper-shared.test.ts
@@ -138,7 +138,7 @@ describe('KeeperConversationPanel', () => {
     expect(container.textContent).toContain('@sangsu')
     expect(container.textContent).toContain('메타데이터 표시')
     expect(container.textContent).toContain('내부 메시지 숨김')
-    expect(container.textContent).toContain('## Current World State')
+    expect(container.textContent).toContain('Current World State')
     expect(container.textContent).not.toContain('Conversation Lane')
     expect(container.textContent).not.toContain('Visible thread')
     expect(container.textContent).not.toContain('Hidden internal')


### PR DESCRIPTION
## Summary
- align KeeperConversationPanel test with rendered markdown heading text
- keep the markdown fixture unchanged while asserting the DOM text users actually see

## Verification
- git diff --check
- pnpm run typecheck
- pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/keeper-shared.test.ts

Note: local full pnpm test was started but stopped after it exceeded the CI-like runtime locally; CI will run the full dashboard suite.