### PR TITLE
fix(exec): seal safe shell promotion

### DIFF
--- a/lib/exec_policy/exec_policy.ml
+++ b/lib/exec_policy/exec_policy.ml
@@ -191,6 +191,8 @@ type block_reason =
   | Unsafe_redirect
   | Pipes_not_allowed
   | Direct_dune_invocation
+  | Unsafe_capability of string
+  | Mutation_not_allowed of string
   | Command_not_allowed of string
 
 let block_reason_to_string = function
@@ -217,6 +219,15 @@ let block_reason_to_string = function
      scripts/dune-local.sh's machine-wide build lock and can trigger \
      host-wide ENFILE/EMFILE pressure. Use `scripts/dune-local.sh build ...` \
      from the repo root instead."
+  | Unsafe_capability name ->
+    Printf.sprintf
+      "Command blocked: '%s' requires write, network, spawn, or wrapper capability \
+       and cannot be promoted to Safe_IR."
+      name
+  | Mutation_not_allowed risk ->
+    Printf.sprintf
+      "Command blocked: shell IR risk %s cannot be promoted to Safe_IR."
+      risk
   | Command_not_allowed name -> command_blocked_hint name
 ;;
 
@@ -957,6 +968,8 @@ let block_reason_tag = function
   | Unsafe_redirect -> "unsafe_redirect"
   | Pipes_not_allowed -> "pipes_not_allowed"
   | Direct_dune_invocation -> "direct_dune_invocation"
+  | Unsafe_capability _ -> "unsafe_capability"
+  | Mutation_not_allowed _ -> "mutation_not_allowed"
   | Command_not_allowed _ -> "command_not_allowed"
 ;;
 
@@ -969,6 +982,7 @@ let attribution_of_validation ~cmd (result : (unit, block_reason) result) : Attr
     let command_name =
       match br with
       | Command_not_allowed name -> Some name
+      | Unsafe_capability name -> Some name
       | Direct_dune_invocation -> Some "dune"
       | _ -> None
     in
@@ -991,8 +1005,16 @@ type safe = Typed_capabilities.safe
 type unsafe = Typed_capabilities.unsafe
 type 'a verified_ir = 'a Typed_capabilities.verified_ir
 
+let block_reason_of_promotion_error = function
+  | Typed_capabilities.Unsafe_capability name -> Unsafe_capability name
+  | Typed_capabilities.Mutation_not_allowed risk -> Mutation_not_allowed risk
+;;
+
 let promote_to_safe ~allowed_commands ir =
   match validate_command_with_allowlist ~allowed_commands ir with
-  | Ok () -> Ok (Typed_capabilities.Safe_IR ir)
-  | Error br -> Error br
+  | Error _ as error -> error
+  | Ok () ->
+    (match Typed_capabilities.promote ir with
+     | Ok verified -> Ok verified
+     | Error error -> Error (block_reason_of_promotion_error error))
 ;;

--- a/lib/exec_policy/exec_policy.mli
+++ b/lib/exec_policy/exec_policy.mli
@@ -12,6 +12,8 @@ type block_reason =
   | Unsafe_redirect
   | Pipes_not_allowed
   | Direct_dune_invocation
+  | Unsafe_capability of string
+  | Mutation_not_allowed of string
   | Command_not_allowed of string
 
 val block_reason_to_string : block_reason -> string

--- a/lib/exec_policy/sandbox_backend.ml
+++ b/lib/exec_policy/sandbox_backend.ml
@@ -6,7 +6,8 @@ type exec_result = {
   exit_code : int;
 }
 
-let run (Safe_IR ir : safe verified_ir) (_env : Eio_unix.Stdenv.base) : exec_result =
+let run (verified : safe verified_ir) (_env : Eio_unix.Stdenv.base) : exec_result =
+  let ir = shell_ir verified in
   match ir with
   | Masc_exec.Shell_ir.Simple simple ->
       let bin = Masc_exec.Exec_program.to_string simple.bin in

--- a/lib/exec_policy/typed_capabilities.ml
+++ b/lib/exec_policy/typed_capabilities.ml
@@ -17,6 +17,10 @@ type cap_flags = {
   spawn : bool;
 }
 
+type promotion_error =
+  | Unsafe_capability of string
+  | Mutation_not_allowed of string
+
 (** Deduce capability flags for a known binary. *)
 let classify_flags : Masc_exec.Exec_program.known -> cap_flags = function
   (* Read-only filesystem operations *)
@@ -50,3 +54,54 @@ let classify_program_flags (p : Masc_exec.Exec_program.t) : cap_flags =
   | None ->
       (* Fail-closed: classify unknown binaries as needing full capabilities *)
       { read_fs = true; write_fs = true; network = true; spawn = true }
+
+let validate_safe_capabilities ir =
+  let validate_simple (simple : Masc_exec.Shell_ir.simple) =
+    let bin = simple.Masc_exec.Shell_ir.bin in
+    let bin_name = Masc_exec.Exec_program.to_string bin in
+    let flags = classify_program_flags bin in
+    if String.equal bin_name "env"
+    then Error (Unsafe_capability bin_name)
+    else if flags.write_fs || flags.network || flags.spawn
+    then Error (Unsafe_capability bin_name)
+    else Ok ()
+  in
+  let rec loop = function
+    | Masc_exec.Shell_ir.Simple simple -> validate_simple simple
+    | Masc_exec.Shell_ir.Pipeline stages ->
+      let rec loop_stages = function
+        | [] -> Ok ()
+        | stage :: rest ->
+          (match loop stage with
+           | Ok () -> loop_stages rest
+           | Error _ as error -> error)
+      in
+      loop_stages stages
+  in
+  loop ir
+;;
+
+let validate_safe_risk ir =
+  let decided =
+    Masc_exec.Shell_ir_risk.(classify (undecided ir))
+  in
+  match Masc_exec.Shell_ir_risk.risk_class decided with
+  | R0_Read -> Ok ()
+  | risk ->
+    Error
+      (Mutation_not_allowed (Masc_exec.Shell_ir_risk.string_of_risk_class risk))
+;;
+
+let promote ir =
+  match validate_safe_capabilities ir with
+  | Error _ as error -> error
+  | Ok () ->
+    (match validate_safe_risk ir with
+     | Error _ as error -> error
+     | Ok () -> Ok (Safe_IR ir))
+;;
+
+let shell_ir : type phase. phase verified_ir -> Masc_exec.Shell_ir.t = function
+  | Safe_IR ir -> ir
+  | Unsafe_IR ir -> ir
+;;

--- a/lib/exec_policy/typed_capabilities.mli
+++ b/lib/exec_policy/typed_capabilities.mli
@@ -6,9 +6,7 @@ type no = No
 type safe = Safe_tag
 type unsafe = Unsafe_tag
 
-type _ verified_ir =
-  | Safe_IR : Masc_exec.Shell_ir.t -> safe verified_ir
-  | Unsafe_IR : Masc_exec.Shell_ir.t -> unsafe verified_ir
+type _ verified_ir
 
 type cap_flags = {
   read_fs : bool;
@@ -17,5 +15,15 @@ type cap_flags = {
   spawn : bool;
 }
 
+type promotion_error =
+  | Unsafe_capability of string
+  | Mutation_not_allowed of string
+
 val classify_flags : Masc_exec.Exec_program.known -> cap_flags
 val classify_program_flags : Masc_exec.Exec_program.t -> cap_flags
+
+val promote :
+  Masc_exec.Shell_ir.t ->
+  (safe verified_ir, promotion_error) result
+
+val shell_ir : _ verified_ir -> Masc_exec.Shell_ir.t

--- a/lib/keeper/keeper_tool_execute_readonly_policy.ml
+++ b/lib/keeper/keeper_tool_execute_readonly_policy.ml
@@ -230,6 +230,27 @@ let diagnosis_of_block_reason reason =
       ; rewrite = None
       ; tool_suggestion = None
       }
+  | Exec_policy.Unsafe_capability name ->
+    Some
+      { Exec_core.rule_id = "unsafe_capability"
+      ; explanation =
+          Printf.sprintf
+            "'%s' requires write, network, spawn, or wrapper capability and cannot \
+             be promoted as a safe shell IR."
+            name
+      ; rewrite = None
+      ; tool_suggestion = None
+      }
+  | Exec_policy.Mutation_not_allowed risk ->
+    Some
+      { Exec_core.rule_id = "mutation_not_allowed"
+      ; explanation =
+          Printf.sprintf
+            "The shell IR was classified as %s, so it cannot be promoted as safe."
+            risk
+      ; rewrite = None
+      ; tool_suggestion = None
+      }
   | Exec_policy.Empty_command ->
     Some
       { Exec_core.rule_id = "command_empty"

--- a/ppx/ppx_safe_shell/ppx_safe_shell.ml
+++ b/ppx/ppx_safe_shell/ppx_safe_shell.ml
@@ -1,25 +1,96 @@
 open Ppxlib
 
-let rec validate_ir_capabilities = function
+let validate_promotable_ir ir =
+  match
+    Exec_policy.promote_to_safe
+      ~allowed_commands:Exec_policy.readonly_allowed_commands
+      ir
+  with
+  | Ok _ -> Ok ()
+  | Error br -> Error (Exec_policy.block_reason_to_string br)
+;;
+
+let expr_of_bool ~loc value =
+  if value then [%expr true] else [%expr false]
+;;
+
+let expr_of_arg_meta ~loc (meta : Masc_exec.Shell_ir.arg_meta) =
+  let quoted = expr_of_bool ~loc meta.quoted in
+  let glob = expr_of_bool ~loc meta.glob in
+  let escaped = expr_of_bool ~loc meta.escaped in
+  [%expr
+    ({ quoted = [%e quoted]; glob = [%e glob]; escaped = [%e escaped] }
+     : Masc_exec.Shell_ir.arg_meta)]
+;;
+
+let rec expr_of_arg ~loc = function
+  | Masc_exec.Shell_ir.Lit (text, meta) ->
+    let text = Ast_builder.Default.estring ~loc text in
+    let meta = expr_of_arg_meta ~loc meta in
+    [%expr Masc_exec.Shell_ir.Lit ([%e text], [%e meta])]
+  | Masc_exec.Shell_ir.Var (name, meta) ->
+    let name = Ast_builder.Default.estring ~loc name in
+    let meta = expr_of_arg_meta ~loc meta in
+    [%expr Masc_exec.Shell_ir.Var ([%e name], [%e meta])]
+  | Masc_exec.Shell_ir.Concat parts ->
+    let parts = Ast_builder.Default.elist ~loc (List.map (expr_of_arg ~loc) parts) in
+    [%expr Masc_exec.Shell_ir.Concat [%e parts]]
+;;
+
+let expr_of_bin ~loc bin =
+  let bin_name =
+    Ast_builder.Default.estring ~loc (Masc_exec.Exec_program.to_string bin)
+  in
+  [%expr
+    match Masc_exec.Exec_program.of_string [%e bin_name] with
+    | Ok bin -> bin
+    | Error (`Unknown name) ->
+      invalid_arg ("safe_sh generated unknown executable: " ^ name)]
+;;
+
+let expr_of_env_binding ~loc (name, value) =
+  let name = Ast_builder.Default.estring ~loc name in
+  let value = expr_of_arg ~loc value in
+  [%expr [%e name], [%e value]]
+;;
+
+let expr_of_simple ~loc (simple : Masc_exec.Shell_ir.simple) =
+  match simple.cwd, simple.redirects, simple.sandbox with
+  | None, [], Masc_exec.Sandbox_target.Host ->
+    let bin = expr_of_bin ~loc simple.bin in
+    let args =
+      Ast_builder.Default.elist ~loc (List.map (expr_of_arg ~loc) simple.args)
+    in
+    let env =
+      Ast_builder.Default.elist
+        ~loc
+        (List.map (expr_of_env_binding ~loc) simple.env)
+    in
+    [%expr
+      ({ bin = [%e bin]
+       ; args = [%e args]
+       ; env = [%e env]
+       ; cwd = None
+       ; redirects = []
+       ; sandbox = Masc_exec.Sandbox_target.host ()
+       }
+       : Masc_exec.Shell_ir.simple)]
+  | _ ->
+    Location.raise_errorf
+      ~loc
+      "safe_sh only preserves host Shell IR without cwd overrides or redirects"
+;;
+
+let rec expr_of_ir ~loc = function
   | Masc_exec.Shell_ir.Simple simple ->
-      let flags = Typed_capabilities.classify_program_flags simple.bin in
-      let bin_name = Masc_exec.Exec_program.to_string simple.bin in
-      let is_dev = Exec_policy.is_dev_allowed bin_name in
-      if flags.spawn && not is_dev then
-        Error ("Command requires subprocess spawn capability but is not in dev allowlist: " ^ bin_name)
-      else if flags.network && not is_dev then
-        Error ("Command requires network capability but is not in dev allowlist: " ^ bin_name)
-      else
-        Ok ()
+    let simple = expr_of_simple ~loc simple in
+    [%expr Masc_exec.Shell_ir.Simple [%e simple]]
   | Masc_exec.Shell_ir.Pipeline stages ->
-      let rec loop = function
-        | [] -> Ok ()
-        | stage :: rest ->
-            (match validate_ir_capabilities stage with
-             | Ok () -> loop rest
-             | Error _ as err -> err)
-      in
-      loop stages
+    let stages =
+      Ast_builder.Default.elist ~loc (List.map (expr_of_ir ~loc) stages)
+    in
+    [%expr Masc_exec.Shell_ir.Pipeline [%e stages]]
+;;
 
 
 let expand ~loc ~path:_ (expr : expression) =
@@ -28,27 +99,14 @@ let expand ~loc ~path:_ (expr : expression) =
       let trimmed = String.trim cmd_str in
       (match Exec_policy.parse_string_to_ir ~mode:Exec_policy.Strict trimmed with
        | Ok ir ->
-           let allowed = Exec_policy.dev_allowed_commands in
-           (match Exec_policy.validate_command_with_allowlist ~allowed_commands:allowed ir with
+           (match validate_promotable_ir ir with
             | Ok () ->
-                (match validate_ir_capabilities ir with
-                 | Ok () ->
-                     let literal = Ast_builder.Default.estring ~loc trimmed in
-                     [%expr
-                       match
-                         Exec_policy.parse_string_to_ir ~mode:Exec_policy.Strict
-                           [%e literal]
-                       with
-                       | Ok ir ->
-                           Exec_policy.promote_to_safe
-                             ~allowed_commands:Exec_policy.dev_allowed_commands
-                             ir
-                       | Error br -> Error br
-                     ]
-                 | Error msg ->
-                     Location.raise_errorf ~loc "Compile-time capability violation: %s" msg)
-            | Error br ->
-                let reason = Exec_policy.block_reason_to_string br in
+              let ir_expr = expr_of_ir ~loc ir in
+              [%expr
+                Exec_policy.promote_to_safe
+                  ~allowed_commands:Exec_policy.readonly_allowed_commands
+                  [%e ir_expr]]
+            | Error reason ->
                 Location.raise_errorf ~loc "Compile-time guardrail violation: %s" reason)
        | Error br ->
            let reason = Exec_policy.block_reason_to_string br in

--- a/test/test_exec_shell_command_gate.ml
+++ b/test/test_exec_shell_command_gate.ml
@@ -110,6 +110,8 @@ let policy_tag (result : (unit, Policy.block_reason) result) : string =
   | Error Policy.Unsafe_redirect -> "unsafe_redirect"
   | Error Policy.Pipes_not_allowed -> "pipes_not_allowed"
   | Error Policy.Direct_dune_invocation -> "direct_dune_invocation"
+  | Error (Policy.Unsafe_capability _) -> "unsafe_capability"
+  | Error (Policy.Mutation_not_allowed _) -> "mutation_not_allowed"
   | Error (Policy.Command_not_allowed _) -> "command_not_allowed"
 ;;
 

--- a/test/test_ppx_safe_shell.ml
+++ b/test/test_ppx_safe_shell.ml
@@ -3,14 +3,57 @@ open Alcotest
 let test_valid_safe_sh () =
   let result = [%safe_sh "ls"] in
   match result with
-  | Ok (Typed_capabilities.Safe_IR _) ->
-      Alcotest.(check bool) "is safe IR" true true
+  | Ok verified ->
+      let ir = Typed_capabilities.shell_ir verified in
+      let rendered = Format.asprintf "%a" Masc_exec.Shell_ir.pp ir in
+      Alcotest.(check string) "preserves checked IR" "safe:ls" rendered
   | Error _ ->
       Alcotest.fail "Expected Ok, got Error"
+
+let parse_or_fail cmd =
+  match Exec_policy.parse_string_to_ir ~mode:Exec_policy.Strict cmd with
+  | Ok ir -> ir
+  | Error br ->
+    Alcotest.failf
+      "parse %S failed: %s"
+      cmd
+      (Exec_policy.block_reason_to_string br)
+;;
+
+let promote cmd =
+  cmd
+  |> parse_or_fail
+  |> Exec_policy.promote_to_safe
+       ~allowed_commands:Exec_policy.readonly_allowed_commands
+;;
+
+let test_promote_rejects_risk_mutation () =
+  match promote "git push --force origin main" with
+  | Error (Exec_policy.Unsafe_capability "git") -> ()
+  | Error reason ->
+    Alcotest.failf
+      "expected git unsafe capability, got %s"
+      (Exec_policy.block_reason_tag reason)
+  | Ok _ -> Alcotest.fail "expected git push to be rejected"
+;;
+
+let test_promote_rejects_dev_mutation () =
+  match promote "npm install" with
+  | Error (Exec_policy.Command_not_allowed "npm") -> ()
+  | Error reason ->
+    Alcotest.failf
+      "expected npm to miss readonly allowlist, got %s"
+      (Exec_policy.block_reason_tag reason)
+  | Ok _ -> Alcotest.fail "expected npm install to be rejected"
+;;
 
 let () =
   run "ppx_safe_shell" [
     "valid", [
       test_case "safe_sh ls" `Quick test_valid_safe_sh;
+    ];
+    "promotion", [
+      test_case "rejects git mutation" `Quick test_promote_rejects_risk_mutation;
+      test_case "rejects dev mutation" `Quick test_promote_rejects_dev_mutation;
     ];
   ]


### PR DESCRIPTION
## Summary

- hide `Typed_capabilities.Safe_IR` / `Unsafe_IR` constructors from the public interface and route access through `shell_ir`
- make `Typed_capabilities.promote` self-validating instead of accepting arbitrary caller-provided validation
- make `safe_sh` preserve the compile-time parsed Shell IR in generated OCaml instead of reparsing the literal at runtime
- switch `safe_sh` / `promote_to_safe` to readonly promotion, rejecting mutating or unsafe-capability commands

## Review Residue Addressed

- PR #20090 review: compile-time `safe_sh` validation discarded the parsed IR and reparsed at runtime
- PR #20090 review: `safe_sh` used dev allowlist semantics that could admit mutating commands
- PR #20090 review: public `Safe_IR` constructor let callers wrap arbitrary Shell IR

## Validation

- `ocamlformat --check lib/exec_policy/typed_capabilities.mli lib/exec_policy/typed_capabilities.ml lib/exec_policy/exec_policy.ml lib/exec_policy/exec_policy.mli lib/exec_policy/sandbox_backend.ml lib/keeper/keeper_tool_execute_readonly_policy.ml ppx/ppx_safe_shell/ppx_safe_shell.ml test/test_ppx_safe_shell.ml test/test_exec_shell_command_gate.ml`
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_safe_shell_promotion dune build --root . --display=quiet -j 1 test/test_ppx_safe_shell.exe`
- `_build_safe_shell_promotion/default/test/test_ppx_safe_shell.exe`
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_safe_shell_promotion dune build --root . --display=quiet -j 1 test/test_exec_shell_command_gate.exe`
- `_build_safe_shell_promotion/default/test/test_exec_shell_command_gate.exe`
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_safe_shell_promotion dune build --root . --display=quiet -j 1 test/test_keeper_readonly_hints.exe`
- `_build_safe_shell_promotion/default/test/test_keeper_readonly_hints.exe`
- `git diff --check`
