### PR TITLE
feat(otel): startup probe, retry, and health check fiber

### DIFF
--- a/lib/otel_spans/dune
+++ b/lib/otel_spans/dune
@@ -12,6 +12,7 @@
   ambient-context-eio
   eio
   eio.unix
+  unix
   cohttp
   cohttp-eio
   uri

--- a/lib/otel_spans/otel_spans.ml
+++ b/lib/otel_spans/otel_spans.ml
@@ -11,6 +11,9 @@ let initialized = Atomic.make false
 let exporter_active = Atomic.make false
 let enabled_override : bool option ref = ref None
 
+let _last_successful_export = Atomic.make None
+let _consecutive_failures = Atomic.make 0
+
 let event_emitter_override
       : (name:string -> attrs:OT.key_value list -> unit) option ref
   =
@@ -37,6 +40,8 @@ let init () =
     Internally forks a 500ms tick fiber under [sw] for periodic batch flush.
     No-op when OTel is explicitly disabled. *)
 let is_exporter_active () = Atomic.get exporter_active
+let last_successful_export () = Atomic.get _last_successful_export
+let consecutive_failures () = Atomic.get _consecutive_failures
 
 let setup_exporter_with ?(enabled = Otel_config.enabled) ~endpoint ~setup () =
   if enabled then begin
@@ -44,6 +49,8 @@ let setup_exporter_with ?(enabled = Otel_config.enabled) ~endpoint ~setup () =
     try
       setup ();
       Atomic.set exporter_active true;
+      Atomic.set _last_successful_export (Some (Unix.gettimeofday ()));
+      Atomic.set _consecutive_failures 0;
       Log.Otel.info "OTLP exporter started -> %s" endpoint
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
@@ -53,15 +60,93 @@ let setup_exporter_with ?(enabled = Otel_config.enabled) ~endpoint ~setup () =
           endpoint (Printexc.to_string exn)
   end
 
+(** Probe OTLP collector endpoint via TCP connect with DNS resolution.
+    Lightweight: resolves host, opens connection, and immediately closes.
+    Returns [true] if the collector is reachable. *)
+let probe_endpoint ~(env : Eio_unix.Stdenv.base) endpoint =
+  try
+    let uri = Uri.of_string endpoint in
+    let host = Option.value (Uri.host uri) ~default:"localhost" in
+    let port = Option.value (Uri.port uri) ~default:4318 in
+    let net = env#net in
+    let addrs = Eio.Net.getaddrinfo_stream net host ~service:(string_of_int port) in
+    match addrs with
+    | [] -> false
+    | addr :: _ ->
+      Eio.Switch.run (fun sw ->
+        let conn = Eio.Net.connect ~sw net addr in
+        Eio.Flow.close conn);
+      true
+  with
+  | _ -> false
+
 let setup_exporter ~sw (env : Eio_unix.Stdenv.base) =
   let endpoint = Otel_config.endpoint in
-  let setup () =
-    let config =
-      Opentelemetry_client_cohttp_eio.Config.make ~url:endpoint ()
-    in
-    Opentelemetry_client_cohttp_eio.setup ~sw ~config env
+  let clock = Eio.Stdenv.clock env in
+  let rec try_setup attempt =
+    if not (enabled ()) then ()
+    else begin
+      init ();
+      let setup () =
+        let config =
+          Opentelemetry_client_cohttp_eio.Config.make ~url:endpoint ()
+        in
+        Opentelemetry_client_cohttp_eio.setup ~sw ~config env
+      in
+      if not (probe_endpoint ~env endpoint) then
+        if attempt < 5 then begin
+          let delay = Float.of_int (1 lsl attempt) in
+          Log.Otel.warn "OTLP collector unreachable (%s), retry %d/5 in %.1fs"
+            endpoint (attempt + 1) delay;
+          Eio.Time.sleep clock delay;
+          try_setup (attempt + 1)
+        end else begin
+          Log.Otel.warn "OTLP collector unreachable after 5 retries (%s), continuing without export"
+            endpoint;
+          Atomic.set exporter_active false
+        end
+      else
+        try
+          setup ();
+          Atomic.set exporter_active true;
+          Atomic.set _last_successful_export (Some (Unix.gettimeofday ()));
+          Atomic.set _consecutive_failures 0;
+          Log.Otel.info "OTLP exporter started -> %s" endpoint;
+          (* Health check fiber: probe collector every 30s *)
+          let rec health_loop () =
+            Eio.Time.sleep clock 30.0;
+            if probe_endpoint ~env endpoint then begin
+              Atomic.set _consecutive_failures 0;
+              health_loop ()
+            end else begin
+              let failures = Atomic.get _consecutive_failures + 1 in
+              Atomic.set _consecutive_failures failures;
+              Log.Otel.warn "OTLP health check failed (%d consecutive) -> %s"
+                failures endpoint;
+              if Atomic.get exporter_active && failures >= 3 then begin
+                Log.Otel.error "OTLP exporter marked inactive after %d consecutive failures -> %s"
+                  failures endpoint;
+                Atomic.set exporter_active false
+              end;
+              health_loop ()
+            end
+          in
+          Eio.Fiber.fork ~sw health_loop
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | exn when attempt < 5 ->
+          let delay = Float.of_int (1 lsl attempt) in
+          Log.Otel.warn "OTLP exporter attempt %d/6 failed, retry in %.1fs: %s"
+            (attempt + 1) delay (Printexc.to_string exn);
+          Eio.Time.sleep clock delay;
+          try_setup (attempt + 1)
+        | exn ->
+          Atomic.set exporter_active false;
+          Log.Otel.warn "OTLP exporter unavailable after 6 attempts (%s): %s"
+            endpoint (Printexc.to_string exn)
+    end
   in
-  setup_exporter_with ~endpoint ~setup ()
+  try_setup 0
 
 (** Flush pending spans and remove the OTLP backend.
     Safe to call when disabled (no-op). *)
@@ -71,7 +156,9 @@ let shutdown ?(enabled = Otel_config.enabled) () =
     Log.Otel.info "OTLP exporter stopped"
   end;
   Atomic.set exporter_active false;
-  Atomic.set initialized false
+  Atomic.set initialized false;
+  Atomic.set _last_successful_export None;
+  Atomic.set _consecutive_failures 0
 
 (** Wrap a function in an OTel span. No-op when disabled.
     Returns the result of [f]. *)

--- a/lib/otel_spans/otel_spans.mli
+++ b/lib/otel_spans/otel_spans.mli
@@ -12,6 +12,14 @@ val init : unit -> unit
 (** [is_exporter_active ()] reports whether an OTLP exporter backend is registered. *)
 val is_exporter_active : unit -> bool
 
+(** [last_successful_export ()] returns the Unix timestamp of the last
+    successful export, or [None] if the exporter has never been active. *)
+val last_successful_export : unit -> float option
+
+(** [consecutive_failures ()] returns the number of consecutive health check
+    or export failures since the last successful connection. *)
+val consecutive_failures : unit -> int
+
 (** Setup OTLP exporter with a custom setup thunk.
     No-op when [enabled=false]. Sets [is_exporter_active] accordingly. *)
 val setup_exporter_with :


### PR DESCRIPTION
## Summary

Improve OTel OTLP exporter connection resilience.

## Changes

- Startup TCP probe: DNS resolve + TCP connect to collector before exporter setup
- Exponential backoff retry: 1s, 2s, 4s, 8s, 16s for unreachable collector (max 5 retries)
- Health check fiber: Periodic probe every 30s under Eio switch
- Auto-deactivation: Mark exporter inactive after 3 consecutive health check failures
- Observability: Expose last_successful_export and consecutive_failures
- Clean shutdown: Reset state tracking on shutdown

## Verification

- dune build @check passes
- 3 files changed, +103/-7 lines

## RFC

Telemetry OTel unification S3. OTel is SSOT; this improves connection reliability.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
