### PR TITLE
fix: restore main CI after metrics purge

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -1565,7 +1565,7 @@ describe('fetchKeeperConfig', () => {
 
   it('preserves terminal runtime blocker classes through config fetch and display labeling', async () => {
     const cases = [
-      ['no_tool_capable_provider', '도구 실행 런타임 없음'],
+      ['runtime_exhausted', '런타임 후보 소진'],
       ['provider_runtime_error', '런타임 호출 오류'],
       ['tool_route_recoverable_failure', '도구 라우팅 복구 가능 실패'],
       ['fiber_unresolved', 'Fiber 미해결'],

--- a/dashboard/src/api/schemas/transport-health.ts
+++ b/dashboard/src/api/schemas/transport-health.ts
@@ -110,7 +110,7 @@ const GrpcSchema = object({
 
 // Diagnostic counters for the WS delivery path.  Each field falls back
 // to 0 so this remains forward-compatible with servers that have not
-// yet landed the corresponding Prometheus metric (e.g. a dashboard
+// yet landed the corresponding OTel metric (e.g. a dashboard
 // pointed at an older build should not surface schema errors, it
 // should show zeroes and let the operator know the metric is absent).
 const WebsocketDeliverySchema = object({

--- a/dashboard/src/components/agent-roster.test.ts
+++ b/dashboard/src/components/agent-roster.test.ts
@@ -656,8 +656,8 @@ describe('AgentRoster live-only cards', () => {
         paused: true,
         registered: false,
         keepalive_running: false,
-        runtime_blocker_class: 'no_tool_capable_provider',
-        runtime_blocker_summary: 'no_tool_capable_provider',
+        runtime_blocker_class: 'runtime_exhausted',
+        runtime_blocker_summary: 'runtime_exhausted',
         agent: {
           exists: true,
           status: 'busy',
@@ -684,8 +684,8 @@ describe('AgentRoster live-only cards', () => {
     expect(labels).not.toContain('작업 중')
 
     const text = container.textContent ?? ''
-    expect(text).toContain('일시정지 원인: 도구 실행 런타임 없음')
-    expect(text).toContain('요구 도구를 실행할 수 있는 runtime lane이 없어 descriptor 또는 tool surface 확인이 필요합니다.')
+    expect(text).toContain('일시정지 원인: 런타임 후보 소진')
+    expect(text).toContain('런타임 후보가 모두 소진되어 runtime 상태 확인이 필요합니다.')
   })
 
   it('uses heartbeat and full keeper model for cards when action/model fallbacks disagree', async () => {

--- a/dashboard/src/components/fleet-fsm-matrix.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.ts
@@ -907,7 +907,7 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
     () => (data ? tallyInvariantViolations(data.snapshots) : null),
     [data],
   )
-  // Backend emits this Prometheus counter (`metric_fsm_guard_violation`)
+  // Backend emits this OTel counter (`metric_fsm_guard_violation`)
   // as a fleet-wide total duplicated onto every snapshot — see
   // keeper_composite_observer.ml:452. Reading [0] is intentional;
   // summing across snapshots would multiply the count by fleet size.

--- a/dashboard/src/components/fleet-telemetry-utils.test.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.test.ts
@@ -233,7 +233,7 @@ describe('buildFleetRows runtime labels', () => {
         status: 'active',
         keepalive_running: true,
         stop_cause: {
-          code: 'no_tool_capable_provider',
+          code: 'runtime_exhausted',
           source: 'runtime_blocker_class',
           label: 'no tool capable provider',
           summary: 'no provider can satisfy tool surface',
@@ -244,7 +244,7 @@ describe('buildFleetRows runtime labels', () => {
     ], EMPTY_TOOL_QUALITY)
 
     expect(row?.stop_cause).toMatchObject({
-      code: 'no_tool_capable_provider',
+      code: 'runtime_exhausted',
       source: 'runtime_blocker_class',
       summary: 'no provider can satisfy tool surface',
     })

--- a/dashboard/src/components/keeper-chat-panel.test.ts
+++ b/dashboard/src/components/keeper-chat-panel.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import type { KeeperChatStreamEvent } from '../api/keeper'
+import type { ChatMessage } from '../keeper-chat-store'
 import {
   filterChatMessages,
   isKeeperTextContentEvent,
   normalizeKeeperChatErrorValue,
-  type ChatMessage,
 } from './keeper-chat-panel'
 
 describe('isKeeperTextContentEvent', () => {

--- a/dashboard/src/components/keeper-reactivity-monitor.test.ts
+++ b/dashboard/src/components/keeper-reactivity-monitor.test.ts
@@ -5,7 +5,7 @@ import {
   extractBatchTerminations,
 } from './keeper-reactivity-monitor'
 import { isKeeperPaused } from '../lib/keeper-predicates'
-import type { ParsedMetric } from './prometheus-metrics'
+import type { ParsedMetric } from './otel-metrics'
 import type { Keeper } from '../types'
 
 // ── Helpers ──────────────────────────────────────────────────────────────

--- a/dashboard/src/components/keeper-reactivity-monitor.ts
+++ b/dashboard/src/components/keeper-reactivity-monitor.ts
@@ -4,11 +4,11 @@
 // Implements five data views:
 //   1. Health Grid     — compact grid: phase, pause status, last activity
 //   2. Lifecycle       — transition timeline (delegates to KeeperPhaseTimeline)
-//   3. Auto-Pause      — keepers in Paused phase + Prometheus pause counters
+//   3. Auto-Pause      — keepers in Paused phase + OTel pause counters
 //   4. Proactive       — proactive turn skip reasons from /metrics
 //   5. Stale           — stale termination class breakdown from /metrics
 //
-// All Prometheus data is fetched lazily from the existing /metrics endpoint;
+// All OTel data is fetched lazily from the existing /metrics endpoint;
 // there are no new backend changes required.
 
 import { html } from 'htm/preact'
@@ -20,10 +20,10 @@ import { KeeperPhaseBadge } from './keeper-phase-indicator'
 import { KeeperPhaseTimeline, refreshKeeperPhaseTimeline } from './keeper-phase-strip'
 import { KeeperLifecycleTimeline, refreshKeeperLifecycleTimeline } from './keeper-lifecycle-timeline'
 import { TurnBudgetGaugePanel } from './turn-budget-gauge'
-import { parsePrometheusText, type ParsedMetric } from './prometheus-metrics'
+import { parseOpenMetricsText, type ParsedMetric } from './otel-metrics'
 import { isKeeperCrashed, isKeeperPaused } from '../lib/keeper-predicates'
 import { fetchWithTimeout, authHeaders } from '../api/core'
-import { PROMETHEUS_FETCH_TIMEOUT_MS } from '../config/constants'
+import { METRICS_FETCH_TIMEOUT_MS } from '../config/constants'
 import { TimeAgo } from './common/time-ago'
 import { LoadingState, ErrorRecoverable } from './common/feedback-state'
 import { EmptyState } from './common/feedback-state'
@@ -56,7 +56,7 @@ export interface BatchTerminationRow {
 
 // ── Helper functions ───────────────────────────────────────────────────────
 
-/** Extract per-keeper stop/pause summaries from parsed Prometheus metrics. */
+/** Extract per-keeper stop/pause summaries from parsed OTel metrics. */
 export function extractKeeperStopSummaries(
   metrics: ParsedMetric[],
 ): KeeperStopSummary[] {
@@ -167,10 +167,10 @@ export function extractBatchTerminations(
   return total > 0 ? [{ batch: 'fleet', count: total }] : []
 }
 
-// ── Prometheus fetch ───────────────────────────────────────────────────────
+// ── OTel fetch ───────────────────────────────────────────────────────
 
 async function fetchMetricsText(): Promise<string> {
-  const res = await fetchWithTimeout('/metrics', { headers: authHeaders() }, PROMETHEUS_FETCH_TIMEOUT_MS)
+  const res = await fetchWithTimeout('/metrics', { headers: authHeaders() }, METRICS_FETCH_TIMEOUT_MS)
   if (!res.ok) throw new Error(`/metrics returned ${res.status}`)
   return res.text()
 }
@@ -266,7 +266,7 @@ function HealthGrid({ allKeepers }: { allKeepers: Keeper[] }) {
   `
 }
 
-/** Auto-Pause panel — keepers in paused phase + Prometheus pause event counts. */
+/** Auto-Pause panel — keepers in paused phase + OTel pause event counts. */
 function AutoPausePanel({
   allKeepers,
   summaries,
@@ -341,7 +341,7 @@ function AutoPausePanel({
       ${summaries.some(s => s.storm_pauses > 0 || s.provider_timeout_loop_pauses > 0) ? html`
         <div>
           <div class="mb-2 text-2xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)]">
-            자동 일시정지 이력 (Prometheus)
+            자동 일시정지 이력 (OTel)
           </div>
           <div class="overflow-x-auto">
             <table class="w-full text-xs" aria-label="자동 일시정지 이력">
@@ -591,7 +591,7 @@ export function KeeperReactivityMonitor({ defaultView }: { defaultView?: Reactiv
     try {
       const text = await fetchMetricsText()
       if (gen !== loadGen.current) return  // a newer request superseded this one
-      parsedMetrics.value = parsePrometheusText(text)
+      parsedMetrics.value = parseOpenMetricsText(text)
       metricsUpdatedAt.value = new Date().toLocaleTimeString('ko-KR')
     } catch (e) {
       if (gen !== loadGen.current) return  // stale error — discard
@@ -651,12 +651,12 @@ export function KeeperReactivityMonitor({ defaultView }: { defaultView?: Reactiv
 
       ${metricsError.value && isNonLifecycle ? html`
         <${ErrorRecoverable}
-          title="Prometheus 메트릭을 불러오지 못했습니다"
+          title="OTel 메트릭을 불러오지 못했습니다"
           detail=${metricsError.value}
           onRetry=${() => { void loadMetrics() }}
         />
       ` : metricsLoading.value && parsedMetrics.value.length === 0 && isNonLifecycle ? html`
-        <${LoadingState}>Prometheus 메트릭 불러오는 중...<//>
+        <${LoadingState}>OTel 메트릭 불러오는 중...<//>
       ` : html`
         <div>
           ${activeView.value === 'health'

--- a/dashboard/src/components/mission-agent-cards.test.ts
+++ b/dashboard/src/components/mission-agent-cards.test.ts
@@ -92,7 +92,7 @@ describe('mission keeper runtime helpers', () => {
   })
 
   it('labels backend runtime blocker classes used by keeper_status_bridge', () => {
-    expect(keeperRuntimeBlockerLabel('no_tool_capable_provider')).toBe('도구 실행 런타임 없음')
+    expect(keeperRuntimeBlockerLabel('runtime_exhausted')).toBe('런타임 후보 소진')
     expect(keeperRuntimeBlockerLabel('fiber_unresolved')).toBe('Fiber 미해결')
     expect(keeperRuntimeBlockerLabel('stale_turn_timeout')).toBe('오래된 턴 만료')
     expect(keeperRuntimeBlockerLabel('stale_termination_storm')).toBe('Stale 종료 폭주')
@@ -107,12 +107,12 @@ describe('mission keeper runtime helpers', () => {
     const keeper = {
       name: 'tool-less',
       status: 'idle',
-      runtime_blocker_class: 'no_tool_capable_provider',
-      runtime_blocker_summary: 'no_tool_capable_provider',
+      runtime_blocker_class: 'runtime_exhausted',
+      runtime_blocker_summary: 'runtime_exhausted',
     } as Keeper
 
     expect(keeperRuntimeHint(keeper)).toBe(
-      '요구 도구를 실행할 수 있는 runtime lane이 없어 descriptor 또는 tool surface 확인이 필요합니다.',
+      '런타임 후보가 모두 소진되어 runtime 상태 확인이 필요합니다.',
     )
   })
 

--- a/dashboard/src/components/otel-metrics.test.ts
+++ b/dashboard/src/components/otel-metrics.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { parsePrometheusText } from './prometheus-metrics'
+import { parseOpenMetricsText } from './otel-metrics'
 
 const SAMPLE = `# HELP masc_uptime_seconds Server uptime in seconds
 # TYPE masc_uptime_seconds gauge
@@ -21,9 +21,9 @@ masc_inference_duration_seconds{quantile="0.99"} 5.67
 masc_sse_connections 3
 `
 
-describe('parsePrometheusText', () => {
+describe('parseOpenMetricsText', () => {
   it('parses HELP + TYPE + sample lines', () => {
-    const metrics = parsePrometheusText(SAMPLE)
+    const metrics = parseOpenMetricsText(SAMPLE)
     expect(metrics.length).toBe(5)
 
     const uptime = metrics.find(m => m.name === 'masc_uptime_seconds')!
@@ -34,7 +34,7 @@ describe('parsePrometheusText', () => {
   })
 
   it('parses labels from samples', () => {
-    const metrics = parsePrometheusText(SAMPLE)
+    const metrics = parseOpenMetricsText(SAMPLE)
     const heartbeat = metrics.find(m => m.name === 'masc_agent_heartbeat_age_seconds')!
     expect(heartbeat.samples.length).toBe(2)
     expect(heartbeat.samples[0]!.labels).toEqual({ keeper: 'janitor' })
@@ -42,8 +42,8 @@ describe('parsePrometheusText', () => {
   })
 
   it('handles empty input', () => {
-    expect(parsePrometheusText('')).toEqual([])
-    expect(parsePrometheusText('# only comments')).toEqual([])
+    expect(parseOpenMetricsText('')).toEqual([])
+    expect(parseOpenMetricsText('# only comments')).toEqual([])
   })
 })
 

--- a/dashboard/src/components/otel-metrics.ts
+++ b/dashboard/src/components/otel-metrics.ts
@@ -1,5 +1,5 @@
-// MASC Dashboard — Prometheus Metrics Surface
-// Fetches /metrics (Prometheus text format) and renders as categorized tables.
+// MASC Dashboard — OTel Metrics Surface
+// Fetches /metrics (OTel text format) and renders as categorized tables.
 
 import { html } from 'htm/preact'
 import { useSignal } from '@preact/signals'
@@ -9,10 +9,10 @@ import { EmptyState } from './common/feedback-state'
 import { ErrorState, LoadingState } from './common/feedback-state'
 import { TextInput } from './common/input'
 import { fetchWithTimeout, authHeaders } from '../api/core'
-import { PROMETHEUS_FETCH_TIMEOUT_MS } from '../config/constants'
+import { METRICS_FETCH_TIMEOUT_MS } from '../config/constants'
 import { navigate } from '../router'
 
-// --- Prometheus text format parser ---
+// --- OTel text format parser ---
 
 export interface ParsedMetric {
   name: string
@@ -27,7 +27,7 @@ interface MetricSample {
   value: number
 }
 
-export function parsePrometheusText(text: string): ParsedMetric[] {
+export function parseOpenMetricsText(text: string): ParsedMetric[] {
   const metrics: ParsedMetric[] = []
   const lines = text.split('\n')
   let current: ParsedMetric | null = null
@@ -192,11 +192,11 @@ function labelPills(labels: Record<string, string>): ReturnType<typeof html> | n
 
 // --- Fetch ---
 
-async function fetchPrometheusText(signal?: AbortSignal): Promise<string> {
+async function fetchMetricsText(signal?: AbortSignal): Promise<string> {
   const res = await fetchWithTimeout(
     '/metrics',
     { headers: authHeaders(), signal },
-    PROMETHEUS_FETCH_TIMEOUT_MS,
+    METRICS_FETCH_TIMEOUT_MS,
   )
   if (!res.ok) throw new Error(`/metrics returned ${res.status}`)
   return res.text()
@@ -216,7 +216,7 @@ function metricMatchesSearch(m: ParsedMetric, q: string): boolean {
 
 // --- Component ---
 
-export function PrometheusMetrics() {
+export function OtelMetrics() {
   const loading = useSignal(true)
   const error = useSignal<string | null>(null)
   const metrics = useSignal<ParsedMetric[]>([])
@@ -228,8 +228,8 @@ export function PrometheusMetrics() {
     loading.value = true
     error.value = null
     try {
-      const text = await fetchPrometheusText()
-      metrics.value = parsePrometheusText(text)
+      const text = await fetchMetricsText()
+      metrics.value = parseOpenMetricsText(text)
       lastUpdated.value = new Date().toLocaleTimeString('ko-KR')
     } catch (e) {
       error.value = e instanceof Error ? e.message : String(e)
@@ -241,7 +241,7 @@ export function PrometheusMetrics() {
   useEffect(() => { void refresh() }, [])
 
   if (loading.value && metrics.value.length === 0) {
-    return html`<${LoadingState} label="Prometheus /metrics" />`
+    return html`<${LoadingState} label="OTel /metrics" />`
   }
 
   if (error.value && metrics.value.length === 0) {
@@ -294,7 +294,7 @@ export function PrometheusMetrics() {
     <div class="flex flex-col gap-4">
       <div class="flex items-center justify-between">
         <div>
-          <h2 class="text-lg font-semibold text-[var(--text-heading)]">Prometheus 메트릭</h2>
+          <h2 class="text-lg font-semibold text-[var(--text-heading)]">OTel 메트릭</h2>
           <p class="text-xs text-[var(--color-fg-muted)]">
             /metrics endpoint (${totalMetrics}개 메트릭, ${totalSamples}개 샘플, ${nonZeroSamples}개 활성)
           </p>
@@ -370,7 +370,7 @@ export function PrometheusMetrics() {
 
             ${expanded && html`
               <div class="mt-3 overflow-x-auto">
-                <table class="w-full text-xs" aria-label="Prometheus 메트릭 시계열">
+                <table class="w-full text-xs" aria-label="OTel 메트릭 시계열">
                   <thead>
                     <tr class="border-b border-[var(--color-border-default)] text-[var(--color-fg-muted)]">
                       <th scope="col" class="pb-2 text-left font-normal">메트릭</th>

--- a/dashboard/src/components/runtime-panel.test.ts
+++ b/dashboard/src/components/runtime-panel.test.ts
@@ -18,8 +18,8 @@ async function loadRuntimePanel() {
   vi.doMock('./runtime-monitor', () => ({
     RuntimeMonitor: () => html`<div data-testid="runtime-monitor">RuntimeMonitor</div>`,
   }))
-  vi.doMock('./prometheus-metrics', () => ({
-    PrometheusMetrics: () => html`<div data-testid="prometheus">PrometheusMetrics</div>`,
+  vi.doMock('./otel-metrics', () => ({
+    OtelMetrics: () => html`<div data-testid="metrics">OtelMetrics</div>`,
   }))
   vi.doMock('./verification-specs-panel', () => ({
     VerificationSpecsPanel: () => html`<div data-testid="verification-specs">VerificationSpecsPanel</div>`,
@@ -62,7 +62,7 @@ describe('RuntimePanel', () => {
     vi.doUnmock('../router')
     vi.doUnmock('./oas-health-chip')
     vi.doUnmock('./runtime-monitor')
-    vi.doUnmock('./prometheus-metrics')
+    vi.doUnmock('./otel-metrics')
     vi.doUnmock('./verification-specs-panel')
     vi.doUnmock('./cost-dashboard')
     vi.doUnmock('./common/filter-chips')
@@ -86,7 +86,7 @@ describe('RuntimePanel', () => {
     expect(container.textContent).toContain('Transport diagnostics')
     expect(container.textContent).toContain('Feature cleanup')
     expect(container.textContent).toContain('RuntimeMonitor')
-    expect(container.textContent).toContain('PrometheusMetrics')
+    expect(container.textContent).toContain('OtelMetrics')
     expect(container.textContent).toContain('VerificationSpecsPanel')
   })
 
@@ -102,7 +102,7 @@ describe('RuntimePanel', () => {
 
     const detailIds = [
       'runtime-details-providers',
-      'runtime-details-prometheus',
+      'runtime-details-metrics',
       'runtime-details-verification',
     ]
     for (const id of detailIds) {
@@ -114,14 +114,14 @@ describe('RuntimePanel', () => {
   })
 
   it('explicit drill-down views bypass progressive disclosure', async () => {
-    route.value.params = { view: 'prometheus' }
+    route.value.params = { view: 'metrics' }
     const { RuntimePanel } = await loadRuntimePanel()
     render(html`<${RuntimePanel} />`, container)
     await flushUi()
 
-    const prometheus = container.querySelector('[data-testid="prometheus"]')
-    expect(prometheus).not.toBeNull()
-    expect(prometheus?.closest('details')).toBeNull()
+    const metrics = container.querySelector('[data-testid="metrics"]')
+    expect(metrics).not.toBeNull()
+    expect(metrics?.closest('details')).toBeNull()
   })
 
   it('renders only OasHealthChip and RuntimeMonitor for providers view', async () => {
@@ -132,18 +132,18 @@ describe('RuntimePanel', () => {
 
     expect(container.textContent).toContain('OasHealthChip')
     expect(container.textContent).toContain('RuntimeMonitor')
-    expect(container.textContent).not.toContain('PrometheusMetrics')
+    expect(container.textContent).not.toContain('OtelMetrics')
   })
 
-  it('renders only PrometheusMetrics for prometheus view', async () => {
-    route.value.params = { view: 'prometheus' }
+  it('renders only OtelMetrics for metrics view', async () => {
+    route.value.params = { view: 'metrics' }
     const { RuntimePanel } = await loadRuntimePanel()
     render(html`<${RuntimePanel} />`, container)
     await flushUi()
 
     expect(container.textContent).not.toContain('OasHealthChip')
     expect(container.textContent).not.toContain('RuntimeMonitor')
-    expect(container.textContent).toContain('PrometheusMetrics')
+    expect(container.textContent).toContain('OtelMetrics')
   })
 
   it('renders FilterChips with runtime view options', async () => {
@@ -156,7 +156,7 @@ describe('RuntimePanel', () => {
     // Chips are split across two FilterChips strips (Primary then Advanced)
     // with a divider between them. The positional order reflects the
     // Primary[default, providers] → Advanced[cost, audit, stress,
-    // prometheus, verification] layout.
+    // metrics, verification] layout.
     expect(chips.length).toBe(7)
     expect(chips[0]?.textContent).toBe('전체')
     expect(chips[1]?.textContent).toBe('런타임')
@@ -187,7 +187,7 @@ describe('RuntimePanel', () => {
 
     expect(container.textContent).toContain('OasHealthChip')
     expect(container.textContent).toContain('RuntimeMonitor')
-    expect(container.textContent).toContain('PrometheusMetrics')
+    expect(container.textContent).toContain('OtelMetrics')
   })
 
   it('passes current view value to FilterChips', async () => {

--- a/dashboard/src/components/runtime-panel.ts
+++ b/dashboard/src/components/runtime-panel.ts
@@ -1,17 +1,17 @@
 // RuntimePanel — Monitor "Runtime" lane.
-// Renders OasHealthChip / RuntimeMonitor / PrometheusMetrics /
+// Renders OasHealthChip / RuntimeMonitor / OtelMetrics /
 // VerificationSpecsPanel inline, and delegates telemetry views to
 // TelemetryPanel (cost / audit / stress).
 //
 // Progressive-disclosure default view (density reduction, 2026-04):
 //   Signal layer     — OasHealthChip always expanded (summary StatCells)
 //   Diagnostic layer — Runtime lanes via CollapsibleSection (closed)
-//   Raw layer        — Prometheus metrics, Formal specs via CollapsibleSection (closed)
+//   Raw layer        — OTel metrics, Formal specs via CollapsibleSection (closed)
 // NN/g progressive disclosure: respect working-memory limits, defer detail.
 //
 // Explicit drill-down via FilterChips, split into two strips (PR #17014):
 //   Primary strip   — default · providers · inspector
-//   Advanced strip  — cost · audit · stress · prometheus · verification
+//   Advanced strip  — cost · audit · stress · metrics · verification
 //                     (the first three are spread from TELEMETRY_VIEW_CHIPS,
 //                      owned by telemetry-panel.ts; PR #17044 / #17052)
 //
@@ -20,7 +20,7 @@
 //   providers    — OAS health chip + runtime monitor only
 //   inspector    — runtime strategy trace / lane health drill-down
 //   cost / audit / stress — TelemetryPanel → CostDashboard
-//   prometheus   — raw Prometheus metrics only
+//   metrics   — raw OTel metrics only
 //   verification — formal specs only
 // Pattern: mirrors fleet-health-panel.ts (unidirectional flow via URL).
 
@@ -31,7 +31,7 @@ import { FilterChips } from './common/filter-chips'
 import { CollapsibleSection } from './common/collapsible'
 import { OasHealthChip } from './oas-health-chip'
 import { RuntimeMonitor } from './runtime-monitor'
-import { PrometheusMetrics } from './prometheus-metrics'
+import { OtelMetrics } from './otel-metrics'
 import { VerificationSpecsPanel } from './verification-specs-panel'
 import { TelemetryPanel, isTelemetryView, TELEMETRY_VIEW_CHIPS } from './telemetry-panel'
 import { RouteLink } from './common/route-link'
@@ -42,7 +42,7 @@ type RuntimeView =
   | 'cost'
   | 'audit'
   | 'stress'
-  | 'prometheus'
+  | 'metrics'
   | 'verification'
 
 const RUNTIME_VIEWS: RuntimeView[] = [
@@ -51,7 +51,7 @@ const RUNTIME_VIEWS: RuntimeView[] = [
   'cost',
   'audit',
   'stress',
-  'prometheus',
+  'metrics',
   'verification',
 ]
 
@@ -76,11 +76,11 @@ const PRIMARY_VIEW_CHIPS: Array<{ key: RuntimeView; label: string }> = [
 // Advanced chips are infra/billing telemetry plus the raw / formal layers.
 // The first three chips (cost / audit / stress) are owned by
 // telemetry-panel.ts — both their labels and their dispatch live there.
-// The remaining two (prometheus / verification) stay inline because
+// The remaining two (metrics / verification) stay inline because
 // runtime-panel still renders them directly.
 const ADVANCED_VIEW_CHIPS: Array<{ key: RuntimeView; label: string }> = [
   ...TELEMETRY_VIEW_CHIPS,
-  { key: 'prometheus', label: '메트릭' },
+  { key: 'metrics', label: '메트릭' },
   { key: 'verification', label: '형식검증' },
 ]
 
@@ -167,8 +167,8 @@ export function RuntimePanel() {
           `
         : isTelemetryView(view)
           ? html`<${TelemetryPanel} view=${view} />`
-        : view === 'prometheus'
-          ? html`<${PrometheusMetrics} />`
+        : view === 'metrics'
+          ? html`<${OtelMetrics} />`
         : view === 'verification'
           ? html`<${VerificationSpecsPanel} />`
         : html`
@@ -177,8 +177,8 @@ export function RuntimePanel() {
             <${CollapsibleSection} id="runtime-details-providers" title="런타임">
               <${RuntimeMonitor} />
             <//>
-            <${CollapsibleSection} id="runtime-details-prometheus" title="메트릭">
-              <${PrometheusMetrics} />
+            <${CollapsibleSection} id="runtime-details-metrics" title="메트릭">
+              <${OtelMetrics} />
             <//>
             <${CollapsibleSection} id="runtime-details-verification" title="형식검증">
               <${VerificationSpecsPanel} />

--- a/dashboard/src/components/telemetry-panel.test.ts
+++ b/dashboard/src/components/telemetry-panel.test.ts
@@ -20,9 +20,9 @@ describe('isTelemetryView', () => {
   })
 
   it('returns false for raw / verification advanced views', () => {
-    // prometheus and verification live next to telemetry on the Advanced
+    // metrics and verification live next to telemetry on the Advanced
     // chip strip but are NOT routed through TelemetryPanel.
-    expect(isTelemetryView('prometheus')).toBe(false)
+    expect(isTelemetryView('metrics')).toBe(false)
     expect(isTelemetryView('verification')).toBe(false)
   })
 

--- a/dashboard/src/config/constants.ts
+++ b/dashboard/src/config/constants.ts
@@ -85,8 +85,8 @@ export const TRUNCATE_DEFAULT = 260
 // --- TLA+ verification panel poll interval ---
 export const TLA_POLL_INTERVAL_MS = 60_000
 
-// --- Prometheus /metrics fetch timeout ---
-export const PROMETHEUS_FETCH_TIMEOUT_MS = 10_000
+// --- OTel /metrics fetch timeout ---
+export const METRICS_FETCH_TIMEOUT_MS = 10_000
 
 // --- Default query window (minutes) ---
 export const DEFAULT_WINDOW_MINUTES_24H = 1440

--- a/dashboard/src/keeper-chat-store.test.ts
+++ b/dashboard/src/keeper-chat-store.test.ts
@@ -62,7 +62,7 @@ describe('keeper-chat-store', () => {
 
       const buf = getChatMessageBuffer('keeper-c')
       expect(buf).toHaveLength(1)
-      expect(buf[0].content).toBe('new')
+      expect(buf[0]!.content).toBe('new')
     })
   })
 
@@ -113,7 +113,7 @@ describe('keeper-chat-store', () => {
       ])
 
       const buf = getChatMessageBuffer('keeper-g')
-      expect(buf[0].source).toBe('dashboard')
+      expect(buf[0]!.source).toBe('dashboard')
     })
   })
 
@@ -127,9 +127,9 @@ describe('keeper-chat-store', () => {
       flushStreamBuffer('keeper-i', 'partial response')
       const buf = getChatMessageBuffer('keeper-i')
       expect(buf).toHaveLength(1)
-      expect(buf[0].role).toBe('assistant')
-      expect(buf[0].content).toBe('partial response')
-      expect(buf[0].source).toBe('dashboard')
+      expect(buf[0]!.role).toBe('assistant')
+      expect(buf[0]!.content).toBe('partial response')
+      expect(buf[0]!.source).toBe('dashboard')
     })
   })
 })

--- a/dashboard/src/lib/format-string.ts
+++ b/dashboard/src/lib/format-string.ts
@@ -112,7 +112,7 @@ export function escapeRegExp(value: string): string {
  * `components/ide/interject-store`, `components/journey-panel`,
  * `components/keeper-chat-panel`, `components/keeper-reactivity-monitor`,
  * `components/keeper-spawn/keeper-spawn-state`,
- * `components/prometheus-metrics`, `components/task-manage/task-manage-state`,
+ * `components/otel-metrics`, `components/task-manage/task-manage-state`,
  * `components/telemetry-unified`,
  * `components/tool-executor/tool-executor-state`,
  * `components/tool-executor/tool-result-display`,

--- a/dashboard/src/lib/keeper-runtime-display.test.ts
+++ b/dashboard/src/lib/keeper-runtime-display.test.ts
@@ -201,7 +201,7 @@ describe('keeperRuntimeBlockerLabel', () => {
     expect(keeperRuntimeBlockerLabel('provider_runtime_error')).toBe(
       '런타임 호출 오류',
     )
-    expect(keeperRuntimeBlockerLabel('no_tool_capable_provider')).toBe('도구 실행 런타임 없음')
+    expect(keeperRuntimeBlockerLabel('runtime_exhausted')).toBe('런타임 후보 소진')
   })
 
   it('labels the 9 RFC-0062 SDK blocker variants', () => {
@@ -236,10 +236,10 @@ describe('keeperRuntimeBlockerHint', () => {
   it('explains recoverable tool-route failures when no summary is available', () => {
     expect(
       keeperRuntimeBlockerHint(makeKeeper({
-        runtime_blocker_class: 'no_tool_capable_provider',
-        runtime_blocker_summary: 'no_tool_capable_provider',
+        runtime_blocker_class: 'runtime_exhausted',
+        runtime_blocker_summary: 'runtime_exhausted',
       })),
-    ).toBe('요구 도구를 실행할 수 있는 runtime lane이 없어 descriptor 또는 tool surface 확인이 필요합니다.')
+    ).toBe('런타임 후보가 모두 소진되어 runtime 상태 확인이 필요합니다.')
   })
 
   it('explains admission queue waits as keeper FIFO waits, not OAS waits', () => {

--- a/dashboard/src/lib/keeper-runtime-display.ts
+++ b/dashboard/src/lib/keeper-runtime-display.ts
@@ -283,7 +283,6 @@ const runtimeBlockerLabels = {
   turn_livelock_blocked: '턴 livelock 차단',
   completion_contract_violation: '완료 계약 위반',
   runtime_exhausted: '런타임 후보 소진',
-  no_tool_capable_provider: '도구 실행 런타임 없음',
   provider_runtime_error: '런타임 호출 오류',
   tool_route_recoverable_failure: '도구 라우팅 복구 가능 실패',
   fiber_unresolved: 'Fiber 미해결',
@@ -348,9 +347,6 @@ export function keeperRuntimeBlockerHint(keeper: Keeper | null | undefined): str
   }
   if (blockerClass === 'runtime_exhausted') {
     return '런타임 후보가 모두 소진되어 runtime 상태 확인이 필요합니다.'
-  }
-  if (blockerClass === 'no_tool_capable_provider') {
-    return '요구 도구를 실행할 수 있는 runtime lane이 없어 descriptor 또는 tool surface 확인이 필요합니다.'
   }
   if (blockerClass === 'tool_route_recoverable_failure') {
     return '도구 라우팅이 복구 가능한 실패로 끝나 descriptor, tool surface, runtime lane 확인이 필요합니다.'

--- a/dashboard/src/lib/runtime-blocker-class.ts
+++ b/dashboard/src/lib/runtime-blocker-class.ts
@@ -57,7 +57,6 @@ const BACKEND_KEEPER_META_BLOCKER_CLASSES = [
   'turn_timeout',
   'turn_livelock_blocked',
   'completion_contract_violation',
-  'no_tool_capable_provider',
   'stay_silent_loop',
   'fiber_unresolved',
   'stale_turn_timeout',

--- a/dashboard/src/store-normalizers.test.ts
+++ b/dashboard/src/store-normalizers.test.ts
@@ -120,12 +120,12 @@ describe('normalizeExecutionQueueItem', () => {
       summary: 'keeper turn is blocked',
       target_type: 'keeper',
       target_id: 'sangsu',
-      runtime_blocker_class: 'no_tool_capable_provider',
+      runtime_blocker_class: 'runtime_exhausted',
       runtime_blocker_summary: 'no provider can satisfy tool surface',
       attention_reason: 'tool_contract_failed',
     })).toMatchObject({
       stop_cause: {
-        code: 'no_tool_capable_provider',
+        code: 'runtime_exhausted',
         source: 'runtime_blocker_class',
         summary: 'no provider can satisfy tool surface',
       },

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -423,7 +423,6 @@ export const KEEPER_RUNTIME_BLOCKER_CLASSES = [
   'turn_livelock_blocked',
   'completion_contract_violation',
   'runtime_exhausted',
-  'no_tool_capable_provider',
   'provider_runtime_error',
   'tool_route_recoverable_failure',
   'fiber_unresolved',

--- a/lib/board_tool_adapter/board_tool_dispatch.mli
+++ b/lib/board_tool_adapter/board_tool_dispatch.mli
@@ -1,0 +1,5 @@
+(** Tool routing and registration for the board MCP adapter. *)
+
+val handle_tool : string -> Yojson.Safe.t -> Tool_result.result
+val tool_spec_read_only : string list
+val register : unit -> unit

--- a/lib/board_tool_adapter/board_tool_format.mli
+++ b/lib/board_tool_adapter/board_tool_format.mli
@@ -1,0 +1,43 @@
+(** Formatting and JSON-boundary helpers for the board MCP adapter. *)
+
+open Masc_board_handlers
+
+type truncation_signal =
+  | Odd_fence
+  | Odd_inline_tick
+  | Unfinished_link
+  | Unfinished_image
+  | Odd_double_asterisk
+
+type sort_order = Board_dispatch.sort_order =
+  | Hot
+  | Trending
+  | Recent
+  | Updated
+  | Discussed
+
+val strip_state_blocks_text : string -> string
+val format_timestamp_relative : float -> string
+val board_error_to_string : Board.board_error -> string
+val board_error_failure_class : Board.board_error -> Tool_result.tool_failure_class
+val error_of_board_error : tool_name:string -> start_time:float -> Board.board_error -> Tool_result.result
+val visibility_of_string : string -> Board.visibility option
+val format_post : Board.post -> string
+val format_post_compact : Board.post -> string
+val format_comment_tree : ?max_depth:int -> Board.comment list -> string list
+val sources_footer : Yojson.Safe.t list -> string
+val truncation_signal_to_string : truncation_signal -> string
+val detect_truncated_markdown_with_reason : string -> truncation_signal option
+val parse_sort_order : string -> (sort_order, string) Result.t
+val judgment_arg : Yojson.Safe.t -> Yojson.Safe.t option
+val normalize_board_post_meta : Yojson.Safe.t -> Yojson.Safe.t option
+val source_entries_arg : Yojson.Safe.t -> Yojson.Safe.t list option
+val merge_sources_into_meta : Yojson.Safe.t option -> Yojson.Safe.t list -> Yojson.Safe.t option
+val string_field : (string * Yojson.Safe.t) list -> string -> string -> string
+val float_field : (string * Yojson.Safe.t) list -> string -> float -> float
+val string_list_field : (string * Yojson.Safe.t) list -> string -> string list
+val string_opt_arg : Yojson.Safe.t -> string -> string option
+val string_list_arg : Yojson.Safe.t -> string -> string list
+val object_list_arg : Yojson.Safe.t -> string -> (string * Yojson.Safe.t) list list
+val provenance_arg : Yojson.Safe.t -> (Yojson.Safe.t, string) result
+val with_yojson_boundary : tool_name:string -> start_time:float -> (unit -> Tool_result.result) -> Tool_result.result

--- a/lib/board_tool_adapter/board_tool_registry.mli
+++ b/lib/board_tool_adapter/board_tool_registry.mli
@@ -1,0 +1,3 @@
+(** Tool schemas advertised by the board MCP adapter. *)
+
+val tools : Masc_domain.tool_schema list

--- a/lib/board_tool_adapter/dune
+++ b/lib/board_tool_adapter/dune
@@ -12,6 +12,12 @@
  (name board_tool_adapter)
  (public_name masc.board_tool_adapter)
  (wrapped false)
+ (private_modules
+  board_tool_cache
+  board_tool_curation
+  board_tool_handlers
+  board_tool_post
+  board_tool_sub_board)
  (modules
   board_tool
   board_tool_cache

--- a/lib/dune
+++ b/lib/dune
@@ -14,23 +14,10 @@
  keeper_event_bus_drain_site
  sse_jsonrpc_filter
  keeper_tool_call_log_context
-
- board_metric_hooks_adapter
- workspace_metric_hooks
-
- keeper_types_profile_persona keeper_types_profile_persona_defaults
- keeper_types_profile_oas_env
- keeper_types_profile_defaults
- keeper_types_profile
- keeper_meta_tool_access
- keeper_meta_contract
- keeper_personality_io
- keeper_meta_json_parse
- keeper_meta_json
- keeper_types_support
- keeper_meta_store
-
-
+ board_metric_hooks_adapter workspace_metric_hooks
+ keeper_types_profile_persona keeper_types_profile_persona_defaults keeper_types_profile_oas_env
+ keeper_types_profile_defaults keeper_types_profile keeper_meta_tool_access keeper_meta_contract
+ keeper_personality_io keeper_meta_json_parse keeper_meta_json keeper_types_support keeper_meta_store
  mcp_server_eio_tool_timeout
   keeper_tool_descriptor keeper_tool_descriptor_resolution keeper_tool_runtime keeper_tool_registry
   keeper_tool_resolution
@@ -517,23 +504,14 @@
    masc_turn
    ;; Agent token-ledger domain (extracted leaf — earn/spend/balance, Board-callable)
    masc_economy
-   ;; Tool dispatch substrate (extracted lib — PR-S3, RFC-0056 LANE 2).
-   ;; tool_dispatch / tool_name / tool_catalog / tool_registry / tool_token /
-   ;; dispatch_outcome / tool_catalog_inference. The compiler enforces
-   ;; Tool⊥Keeper/Runtime/Goal/Task/Board: masc_tool_dispatch's (libraries)
-   ;; admits only neutral leaves. Telemetry (Tool_telemetry.with_span) and
-   ;; warm-up stats (Telemetry_eio) are injected at the composition root.
-   ;; (wrapped false) keeps bare Tool_dispatch.X / Tool_catalog.X refs working.
+   ;; Tool dispatch substrate. The compiler enforces Tool⊥Keeper/Runtime/Goal/Task/Board
+   ;; via masc_tool_dispatch's neutral-only (libraries).
    masc.masc_tool_dispatch
-   ;; RFC-0056 Phase 2 / LANE 6 — pure tool surface leaf, above the dispatch
-   ;; substrate. (libraries) admits no keeper/runtime/domain/server module, so a
-   ;; re-coupling is a dune cycle. Pure schema/vocab/policy, zero mega-outbound.
+   ;; Pure tool surface leaf above the dispatch substrate.
    masc.masc_tool_surface
-   ;; RFC-0217 S2 — OTel metric bridge leaf (Otel_metric_store_core snapshot -> OTLP
-   ;; observable). Otel_metric_store depends on this; the leaf has no masc dep.
+   ;; OTel metric bridge leaf (Otel_metric_store_core snapshot -> OTLP observable).
    masc.otel_metrics
-   ;; Thompson Sampling agent selection (extracted leaf — Health/Otel_metric_store
-   ;; edges inverted to callbacks; Board-callable record_vote without mega-lib cycle)
+   ;; Thompson Sampling leaf; health/Otel_metric_store edges are callbacks.
    masc_thompson
    ;; Environment configuration (extracted sub-library)
    masc.config

--- a/lib/keeper_pressure/keeper_disk_pressure.mli
+++ b/lib/keeper_pressure/keeper_disk_pressure.mli
@@ -1,0 +1,58 @@
+(** Process-local disk exhaustion guard. *)
+
+type disk_snapshot = {
+  path : string;
+  filesystem : string;
+  total_bytes : int;
+  used_bytes : int;
+  available_bytes : int;
+  capacity_percent : float;
+  available_percent : float;
+  mounted_on : string;
+}
+
+type snapshot_result =
+  | Snapshot of disk_snapshot
+  | Probe_error of string
+
+type admission_block =
+  | Disk_pressure_cooldown of float
+  | Disk_probe_error of { detail : string }
+  | Disk_free_space_low of {
+      path : string;
+      available_bytes : int;
+      min_free_bytes : int;
+      effective_min_free_bytes : int;
+      available_percent : float;
+      min_free_percent : float;
+      percent_floor_max_bytes : int;
+    }
+
+type admission_decision =
+  | Admit
+  | Block of admission_block
+
+val is_disk_exhaustion_text : string -> bool
+val is_disk_exhaustion_exn : exn -> bool
+val note_if_disk_exhaustion : ?site:string -> string -> unit
+val note_exception : ?site:string -> exn -> unit
+val active : ?now:float -> unit -> bool
+val remaining_sec : ?now:float -> unit -> float
+val reset_for_tests : unit -> unit
+val probe_path : ?now:float -> string -> snapshot_result
+val probe_masc_root : ?now:float -> masc_root:string -> unit -> snapshot_result
+val admission_decision_of_snapshot : ?now:float -> snapshot_result -> admission_decision
+val admission_decision : ?now:float -> masc_root:string -> unit -> admission_decision
+val admit_turn : ?now:float -> masc_root:string -> unit -> bool
+val disk_snapshot_to_json : disk_snapshot -> Yojson.Safe.t
+val snapshot_result_to_json : snapshot_result -> Yojson.Safe.t
+val admission_block_to_json : admission_block -> Yojson.Safe.t
+val admission_decision_to_json : admission_decision -> Yojson.Safe.t
+val snapshot_json : ?now:float -> masc_root:string -> unit -> Yojson.Safe.t
+
+module For_testing : sig
+  val reset : unit -> unit
+  val is_disk_exhaustion_text : string -> bool
+  val is_disk_exhaustion_exn : exn -> bool
+  val admission_decision_of_snapshot : ?now:float -> snapshot_result -> admission_decision
+end

--- a/lib/keeper_pressure/keeper_fd_pressure.mli
+++ b/lib/keeper_pressure/keeper_fd_pressure.mli
@@ -1,0 +1,110 @@
+(** Process-local file-descriptor exhaustion guard. *)
+
+type nofile_cache =
+  | Uninitialized
+  | In_flight
+  | Resolved of int option
+
+val nofile_soft_limit_cache : nofile_cache Atomic.t
+
+type system_fd_snapshot = {
+  open_files : int;
+  max_files : int;
+  max_files_per_process : int option;
+}
+
+type admission_block =
+  | Fd_pressure_cooldown of float
+  | Probe_unknown of {
+      probe : string;
+      active_keepers : int;
+      starting_keepers : int;
+      projected_fds : int;
+    }
+  | Projected_fd_budget_exhausted of {
+      soft_limit : int;
+      open_fds : int option;
+      active_keepers : int;
+      starting_keepers : int;
+      projected_fds : int;
+    }
+  | System_fd_budget_exhausted of {
+      open_files : int;
+      max_files : int;
+      remaining_files : int;
+      required_headroom : int;
+      projected_fds : int;
+      active_keepers : int;
+      starting_keepers : int;
+    }
+  | Host_fd_hotspot_budget_exhausted of {
+      open_files : int;
+      max_files_per_process : int;
+      remaining_files : int;
+      required_headroom : int;
+      projected_fds : int;
+      active_keepers : int;
+      starting_keepers : int;
+    }
+
+type admission_decision =
+  | Admit
+  | Block of admission_block
+
+type external_level =
+  | External_warn
+  | External_crit
+
+val is_fd_exhaustion_text : string -> bool
+val is_fd_exhaustion_exn : exn -> bool
+val cooldown_sec : unit -> float
+val cas_monotonic_max : atom:float Atomic.t -> float -> bool
+val note : ?site:string -> ?detail:string -> unit -> unit
+val note_if_fd_exhaustion : ?site:string -> string -> unit
+val note_exception : ?site:string -> exn -> unit
+val active : ?now:float -> unit -> bool
+val remaining_sec : ?now:float -> unit -> float
+val projection_fields : ?now:float -> unit -> (string * Yojson.Safe.t) list
+val degraded_projection_json : ?now:float -> unit -> Yojson.Safe.t
+val degraded_trust_json : ?now:float -> unit -> Yojson.Safe.t
+val engage_external : reason:string -> level:external_level -> ts:float -> unit -> unit
+val reset_for_tests : unit -> unit
+val process_nofile_soft_limit : unit -> int option
+val process_open_fd_count : unit -> int option
+val min_nofile_for_fleet : unit -> int
+val admission_decision :
+  ?soft_limit:int option ->
+  ?open_fds:int option ->
+  ?system_fds:system_fd_snapshot option ->
+  active_keepers:int ->
+  starting_keepers:int ->
+  unit ->
+  admission_decision
+val admission_block_to_json : admission_block -> Yojson.Safe.t
+val admission_decision_to_json : admission_decision -> Yojson.Safe.t
+val admission_block_kind : admission_block -> string
+val runtime_state_json :
+  ?soft_limit:int option ->
+  ?open_fds:int option ->
+  ?system_fds:system_fd_snapshot option ->
+  active_keepers:int ->
+  starting_keepers:int ->
+  requested_keepers:int ->
+  unit ->
+  Yojson.Safe.t
+val admit_start :
+  ?soft_limit:int option ->
+  ?open_fds:int option ->
+  ?system_fds:system_fd_snapshot option ->
+  active_keepers:int ->
+  starting_keepers:int ->
+  unit ->
+  bool
+val admit_turn :
+  ?soft_limit:int option ->
+  ?open_fds:int option ->
+  ?system_fds:system_fd_snapshot option ->
+  active_keepers:int ->
+  unit ->
+  bool
+val cap_active_keepers_for_nofile : ?soft_limit:int option -> int -> int

--- a/lib/otel_metric_store/otel_metric_key.mli
+++ b/lib/otel_metric_store/otel_metric_key.mli
@@ -1,0 +1,6 @@
+(** Stable metric key encoding for the in-memory OTel metric store. *)
+
+type label = string * string
+
+val labels_key : label list -> string
+val metric_key : string -> label list -> string

--- a/lib/telemetry_unified_source/telemetry_unified_source_meta.mli
+++ b/lib/telemetry_unified_source/telemetry_unified_source_meta.mli
@@ -1,0 +1,34 @@
+(** Metadata and store discovery helpers for unified telemetry sources. *)
+
+open Telemetry_unified_source
+
+val observe_source_read_failure : source -> site:string -> error:string -> unit
+val observe_source_read_failure_exn : source -> site:string -> exn -> unit
+val protect_source_read : source -> site:string -> default:'a -> (unit -> 'a) -> 'a
+
+type read_result = {
+  entries : Yojson.Safe.t list;
+  total_matching_entries : int;
+  truncated : bool;
+}
+
+val fixed_store_dir : masc_root:string -> base_path:string -> source -> string option
+val source_freshness_slo_s : source -> float
+val source_producer : source -> string
+val source_dashboard_surface : source -> string
+val source_durable_store : masc_root:string -> base_path:string -> source -> string
+val source_metadata_fields : base_path:string -> masc_root:string -> source -> (string * Yojson.Safe.t) list
+val replay_retention_json : base_path:string -> masc_root:string -> sources:source list -> Yojson.Safe.t
+
+type store_dir_state =
+  | Store_missing
+  | Store_directory
+  | Store_invalid
+
+val classify_store_dir : source -> site:string -> string -> store_dir_state
+val discover_keeper_metric_dirs : string -> (string * string) list
+val is_directory : source -> site:string -> string -> bool
+val is_jsonl_file : source -> site:string -> string -> bool
+val discover_trajectory_keeper_dirs_in_root : string -> (string * string) list
+val discover_trajectory_keeper_dirs : string -> (string * string) list
+val discover_execution_receipt_dirs : string -> (string * string) list


### PR DESCRIPTION
## Summary
- add missing OCaml interfaces and private module metadata so the structure ratchet stays below baseline
- remove remaining dashboard Prometheus/no_tool_capable residue by renaming the metrics surface to OTel and dropping the stale blocker class
- fix dashboard strict TS test types exposed by main CI

## Verification
- env DUNE_CACHE=disabled DUNE_BUILD_DIR=/private/tmp/masc-main-ci-fix-4 dune build --root . -j 4 .
- scripts/ocaml-structure-ratchet.sh
- pnpm typecheck
- pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/runtime-panel.test.ts src/components/otel-metrics.test.ts src/lib/keeper-runtime-display.test.ts src/components/mission-agent-cards.test.ts src/components/agent-roster.test.ts src/api/dashboard.test.ts src/store-normalizers.test.ts src/components/fleet-telemetry-utils.test.ts
- rg residue check for Prometheus / no_tool_capable returned no matches