### PR TITLE
fix(dashboard): resolve TypeScript import in keeper-chat-panel test

### DIFF
--- a/dashboard/src/components/keeper-chat-panel.test.ts
+++ b/dashboard/src/components/keeper-chat-panel.test.ts
@@ -6,6 +6,7 @@ import {
   isKeeperTextContentEvent,
   normalizeKeeperChatErrorValue,
 } from './keeper-chat-panel'
+import type { ChatMessage } from '../keeper-chat-store'
 
 describe('isKeeperTextContentEvent', () => {
   it('accepts current AG-UI text content events', () => {


### PR DESCRIPTION
Follow-up to #20181

Fixes a TypeScript import error in `keeper-chat-panel.test.ts` — `ChatMessage` type import was missing after the type was moved to `keeper-chat-store` in the parent PR.

**Changes:**
- `dashboard/src/components/keeper-chat-panel.test.ts`: add `import type { ChatMessage } from '../keeper-chat-store'`

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
