### PR TITLE
fix(dashboard): clarify keeper count axes

### DIFF
--- a/dashboard/src/components/agent-roster.test.ts
+++ b/dashboard/src/components/agent-roster.test.ts
@@ -302,6 +302,8 @@ describe('countRuntimeKinds', () => {
       agents: 0,
       keepers: 1,
       pausedKeepers: 0,
+      offlineKeepers: 0,
+      keeperRows: 1,
       totalRuntimes: 1,
     })
   })
@@ -332,6 +334,8 @@ describe('countRuntimeKinds', () => {
       agents: 0,
       keepers: 0,
       pausedKeepers: 1,
+      offlineKeepers: 0,
+      keeperRows: 1,
       totalRuntimes: 1,
     })
   })
@@ -360,6 +364,8 @@ describe('countRuntimeKinds', () => {
       agents: 0,
       keepers: 1,
       pausedKeepers: 0,
+      offlineKeepers: 0,
+      keeperRows: 1,
       totalRuntimes: 1,
     })
   })
@@ -389,6 +395,8 @@ describe('countRuntimeKinds', () => {
       agents: 0,
       keepers: 1,
       pausedKeepers: 0,
+      offlineKeepers: 0,
+      keeperRows: 1,
       totalRuntimes: 1,
     })
   })
@@ -414,7 +422,46 @@ describe('countRuntimeKinds', () => {
       agents: 1,
       keepers: 1,
       pausedKeepers: 0,
+      offlineKeepers: 0,
+      keeperRows: 1,
       totalRuntimes: 2,
+    })
+  })
+
+  it('does not count offline non-paused keeper rows as running fibers', () => {
+    const runningKeepers = Array.from({ length: 2 }, (_, index) => ({
+      name: `running-${index}`,
+      status: 'active',
+      registered: true,
+      keepalive_running: true,
+    } as Keeper))
+    const pausedKeepers = Array.from({ length: 6 }, (_, index) => ({
+      name: `paused-${index}`,
+      status: 'paused',
+      paused: true,
+      registered: true,
+      keepalive_running: false,
+    } as Keeper))
+    const offlineKeepers = Array.from({ length: 9 }, (_, index) => ({
+      name: `offline-${index}`,
+      status: 'offline',
+      registered: true,
+      keepalive_running: false,
+    } as Keeper))
+
+    const result = countRuntimeKinds([], [
+      ...runningKeepers,
+      ...pausedKeepers,
+      ...offlineKeepers,
+    ])
+
+    expect(result).toEqual({
+      agents: 0,
+      keepers: 2,
+      pausedKeepers: 6,
+      offlineKeepers: 9,
+      keeperRows: 17,
+      totalRuntimes: 17,
     })
   })
 })

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -50,6 +50,7 @@ import {
   expectedRuntimeDetailRows,
   formatKeeperCountBreakdown,
   formatRuntimeRosterCount,
+  keeperRowLooksRunning,
   resolveRuntimeCounts,
   runtimeDetailRows,
   runtimeCountSourceLabel,
@@ -345,7 +346,7 @@ function expectedCountForKeeperFilter(
   keeperFilter: KeeperFilterMode,
   counts: ReturnType<typeof resolveRuntimeCounts>,
 ): number {
-  // Roster fallback messages compare against detail rows, not active runtime
+  // Roster fallback messages compare against detail rows, not running runtime
   // fibers. A paused keeper is not live capacity, but it is still a row the
   // operator expects to see in the directory.
   const useDetailRows = runtimeDetailRows(counts) > 0
@@ -357,7 +358,7 @@ function expectedCountForKeeperFilter(
 const FILTER_META: Record<StatusFilter, { label: string; description: string }> = {
   all: {
     label: '전체 상세',
-    description: 'execution 상세 행 전체를 보여줍니다. 활성 runtime 총계와는 별도 기준입니다.',
+    description: 'execution 상세 행 전체를 보여줍니다. 런타임 가동 총계와는 별도 기준입니다.',
   },
   active: { label: runtimeBandMeta('active').label, description: runtimeBandMeta('active').description },
   attention: { label: runtimeBandMeta('attention').label, description: runtimeBandMeta('attention').description },
@@ -561,7 +562,14 @@ function countAgentsByStatus(
 export function countRuntimeKinds(
   agentList: Agent[],
   keeperList: Keeper[],
-): { agents: number; keepers: number; pausedKeepers: number; totalRuntimes: number } {
+): {
+  agents: number
+  keepers: number
+  pausedKeepers: number
+  offlineKeepers: number
+  keeperRows: number
+  totalRuntimes: number
+} {
   const runtimeKeepers = runtimeBackedKeepers(keeperList, agentList)
   const rosterAgents = buildAgentRoster(agentList, runtimeKeepers)
   const keeperLookup = buildKeeperRuntimeLookup(runtimeKeepers)
@@ -570,17 +578,25 @@ export function countRuntimeKinds(
   // Agent rows only carry `keeper_id`/`keeper_name`, not the full Keeper, so
   // `a.keeper` was undefined here and `isKeeperPaused(undefined)` silently
   // returned false, leaving the paused count stuck at 0.
-  const pausedKeepers = allKeepers.filter(a => {
-    const keeper = findKeeperRuntimeForAgent(a, keeperLookup)
-    return keeper ? isKeeperPaused(keeper) : false
-  }).length
-  const runningKeepers = allKeepers.length - pausedKeepers
+  let pausedKeepers = 0
+  let runningKeepers = 0
+  for (const row of allKeepers) {
+    const keeper = findKeeperRuntimeForAgent(row, keeperLookup)
+    if (keeper && isKeeperPaused(keeper)) {
+      pausedKeepers += 1
+    } else if (keeperRowLooksRunning(keeper)) {
+      runningKeepers += 1
+    }
+  }
   const agentCount = scopeAgentsByKeeperFilter(rosterAgents, runtimeKeepers, 'agent-only', keeperLookup).length
+  const keeperRows = allKeepers.length
 
   return {
     agents: agentCount,
     keepers: runningKeepers,
     pausedKeepers,
+    offlineKeepers: Math.max(0, keeperRows - runningKeepers - pausedKeepers),
+    keeperRows,
     totalRuntimes: rosterAgents.length,
   }
 }
@@ -634,13 +650,26 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
     const allKeepers = scopeAgentsByKeeperFilter(rosterAgents, runtimeKeeperList, 'keeper-only', keeperRuntimeLookup)
     // See countRuntimeKinds(): Agent rows expose only keeper identifiers, so
     // `a.keeper` is undefined and isKeeperPaused needs the hydrated Keeper.
-    const pausedCount = allKeepers.filter(a => {
-      const keeper = findKeeperRuntimeForAgent(a, keeperRuntimeLookup)
-      return keeper ? isKeeperPaused(keeper) : false
-    }).length
-    const runningCount = allKeepers.length - pausedCount
+    let pausedCount = 0
+    let runningCount = 0
+    for (const row of allKeepers) {
+      const keeper = findKeeperRuntimeForAgent(row, keeperRuntimeLookup)
+      if (keeper && isKeeperPaused(keeper)) {
+        pausedCount += 1
+      } else if (keeperRowLooksRunning(keeper)) {
+        runningCount += 1
+      }
+    }
     const agentCount = scopeAgentsByKeeperFilter(rosterAgents, runtimeKeeperList, 'agent-only', keeperRuntimeLookup).length
-    return { agents: agentCount, keepers: runningCount, pausedKeepers: pausedCount, totalRuntimes: rosterAgents.length }
+    const keeperRows = allKeepers.length
+    return {
+      agents: agentCount,
+      keepers: runningCount,
+      pausedKeepers: pausedCount,
+      offlineKeepers: Math.max(0, keeperRows - runningCount - pausedCount),
+      keeperRows,
+      totalRuntimes: rosterAgents.length,
+    }
   }, [rosterAgents, runtimeKeeperList, keeperRuntimeLookup])
 
   const runtimeCounts = resolveRuntimeCounts({
@@ -648,6 +677,8 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
     agentsCount: liveRuntimeCounts.agents,
     keepersCount: liveRuntimeCounts.keepers,
     pausedKeepersCount: liveRuntimeCounts.pausedKeepers,
+    offlineKeepersCount: liveRuntimeCounts.offlineKeepers,
+    keeperRowsCount: liveRuntimeCounts.keeperRows,
     namespaceTruthCounts: namespaceTruth.value?.root.counts,
     namespaceTruthConfiguredKeepers: namespaceTruth.value?.root.configured_keepers,
     shellCounts: shellCounts.value,
@@ -759,21 +790,39 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
   }))
   const liveKeepers = runtimeCounts.live.keepers
   const livePausedKeepers = runtimeCounts.live.pausedKeepers
+  const liveOfflineKeepers = runtimeCounts.live.offlineKeepers
   const configuredKeepers = runtimeCounts.configured.keepers
-  const configuredKeeperDelta = Math.max(0, configuredKeepers - liveKeepers - livePausedKeepers)
+  const configuredKeeperDelta = Math.max(0, configuredKeepers - runtimeCounts.live.keeperRows)
+  const rawPausedKeepers = keeperList.filter(isKeeperPaused).length
+  const pausedOutsideDetail = Math.max(0, rawPausedKeepers - livePausedKeepers)
+  const notStartedKeepers = Math.max(0, configuredKeeperDelta - pausedOutsideDetail)
   const scopeLabel = keeperFilter === 'keeper-only'
     ? formatKeeperCountBreakdown({
         liveKeepers,
         pausedKeepers: livePausedKeepers,
+        offlineKeepers: liveOfflineKeepers,
         configuredKeepers,
       })
     : keeperFilter === 'agent-only'
-      ? `일반 에이전트 활성 ${runtimeCounts.live.agents}`
+      ? `일반 에이전트 런타임 가동 ${runtimeCounts.live.agents}`
       : formatRuntimeRosterCount(runtimeCounts)
+  const keeperStateHints = (
+    keeperFilter === 'keeper-only'
+      ? [
+          pausedOutsideDetail > 0 ? `목록 밖 일시정지 ${pausedOutsideDetail}개` : null,
+          notStartedKeepers > 0 ? `미기동 ${notStartedKeepers}개` : null,
+        ]
+      : [
+          livePausedKeepers > 0 ? `일시정지 ${livePausedKeepers}개` : null,
+          liveOfflineKeepers > 0 ? `오프라인 ${liveOfflineKeepers}개` : null,
+          pausedOutsideDetail > 0 ? `목록 밖 일시정지 ${pausedOutsideDetail}개` : null,
+          notStartedKeepers > 0 ? `미기동 ${notStartedKeepers}개` : null,
+        ]
+  ).filter((item): item is string => item != null)
   const configuredIdleHint =
-    keeperFilter === 'agent-only' || configuredKeeperDelta === 0
+    keeperFilter === 'agent-only' || keeperStateHints.length === 0
       ? null
-      : `일시정지/미기동 ${configuredKeeperDelta}개`
+      : `키퍼 ${keeperStateHints.join(' · ')}`
   const fallbackStateTitle =
     executionError.value
       ? '상세 상태 불러오기 실패'

--- a/dashboard/src/components/agents-unified.test.ts
+++ b/dashboard/src/components/agents-unified.test.ts
@@ -54,7 +54,7 @@ vi.mock('./common/filter-chips', () => ({
 }))
 vi.mock('./agent-roster', () => ({
   AgentRoster: ({ keeperFilter }: { keeperFilter: string }) => h('div', { 'data-testid': 'agent-roster', 'data-filter': keeperFilter }, 'AgentRoster'),
-  countRuntimeKinds: vi.fn(() => ({ agents: 0, keepers: 0, pausedKeepers: 0, totalRuntimes: 0 })),
+  countRuntimeKinds: vi.fn(() => ({ agents: 0, keepers: 0, pausedKeepers: 0, offlineKeepers: 0, keeperRows: 0, totalRuntimes: 0 })),
 }))
 
 vi.mock('../router', () => ({
@@ -68,15 +68,16 @@ vi.mock('../store', () => ({
   agents: { value: [] },
   keepers: { value: [] },
   executionLoaded: { value: false },
+  shellCounts: { value: null },
 }))
 vi.mock('../namespace-truth-store', () => ({
   namespaceTruth: { value: null },
 }))
 vi.mock('../runtime-counts', () => ({
-  formatKeeperRosterCount: vi.fn(() => '상세 16 / 활성 4 / 일시정지 12 / 설정 16'),
-  formatRuntimeRosterCount: vi.fn(() => '상세 20 / 활성 8 / 키퍼 설정 16'),
+  formatKeeperRosterCount: vi.fn(() => '상세 16 / 런타임 가동 4 / 일시정지 12 / 설정 16'),
+  formatRuntimeRosterCount: vi.fn(() => '상세 20 / 런타임 가동 8 / 키퍼 설정 16'),
   resolveRuntimeCounts: vi.fn(() => ({
-    live: { agents: 4, keepers: 4, pausedKeepers: 12, tasks: 0, totalRuntimes: 8, available: true },
+    live: { agents: 4, keepers: 4, pausedKeepers: 12, offlineKeepers: 0, keeperRows: 16, tasks: 0, totalRuntimes: 8, available: true },
     configured: { keepers: 16, totalRuntimes: 8, source: 'namespace-truth' },
     source: 'execution',
   })),
@@ -121,9 +122,9 @@ describe('AgentsUnified', () => {
     expect(roster!.getAttribute('data-filter')).toBe('all')
     expect(container.querySelector('[data-testid="keeper-spawn-panel"]')).not.toBeNull()
     expect(container.querySelector('[data-testid="chip-count-all"]')?.textContent)
-      .toBe('상세 20 / 활성 8 / 키퍼 설정 16')
+      .toBe('상세 20 / 런타임 가동 8 / 키퍼 설정 16')
     expect(container.querySelector('[data-testid="chip-count-keepers"]')?.textContent)
-      .toBe('상세 16 / 활성 4 / 일시정지 12 / 설정 16')
+      .toBe('상세 16 / 런타임 가동 4 / 일시정지 12 / 설정 16')
   })
 
   it('switches to agents view via filter chips', async () => {

--- a/dashboard/src/components/agents-unified.ts
+++ b/dashboard/src/components/agents-unified.ts
@@ -7,7 +7,7 @@ import { useState } from 'preact/hooks'
 import { computed } from '@preact/signals'
 import { FilterChips } from './common/filter-chips'
 import { navigate, route } from '../router'
-import { agents, keepers, executionLoaded } from '../store'
+import { agents, keepers, executionLoaded, shellCounts } from '../store'
 import { AgentRoster, countRuntimeKinds } from './agent-roster'
 import { AgentProfile } from './agent-profile'
 import { KeeperDetailPage } from './keeper-detail-page'
@@ -63,12 +63,16 @@ export function AgentsUnified() {
     agentsCount: liveRuntimeCounts.agents,
     keepersCount: liveRuntimeCounts.keepers,
     pausedKeepersCount: liveRuntimeCounts.pausedKeepers,
+    offlineKeepersCount: liveRuntimeCounts.offlineKeepers,
+    keeperRowsCount: liveRuntimeCounts.keeperRows,
     namespaceTruthCounts: namespaceTruth.value?.root.counts,
     namespaceTruthConfiguredKeepers: namespaceTruth.value?.root.configured_keepers,
+    shellCounts: shellCounts.value,
+    shellConfiguredKeepers: shellCounts.value?.configured_keepers,
   })
   function chipCount(id: AgentsView): number | string | null {
     if (id === 'all') return formatRuntimeRosterCount(runtimeCounts)
-    if (id === 'agents') return `활성 ${runtimeCounts.live.agents}`
+    if (id === 'agents') return `런타임 가동 ${runtimeCounts.live.agents}`
     if (id === 'keepers') return formatKeeperRosterCount(runtimeCounts)
     return null
   }

--- a/dashboard/src/components/dashboard-shell.test.ts
+++ b/dashboard/src/components/dashboard-shell.test.ts
@@ -73,9 +73,9 @@ describe('dashboardHealthChips', () => {
       'execution-error',
     ])
     expect(chips.find(chip => chip.key === 'keeper-count-basis')?.label)
-      .toBe('키퍼 활성 1 / 일시정지 1 / 설정 2')
+      .toBe('키퍼 런타임 가동 1 / 일시정지 1 / 설정 2')
     expect(chips.find(chip => chip.key === 'keeper-count-basis')?.detail)
-      .toBe('활성=shell runtime, paused=상세 행 lifecycle, 설정=shell keeper inventory.')
+      .toBe('런타임 가동=shell, paused=상세 행 lifecycle, offline=상세 행 status, 설정=shell keeper inventory.')
   })
 
   it('does not label an intentional server/base split as data source mismatch', () => {
@@ -115,9 +115,9 @@ describe('dashboardHealthChips', () => {
     })
 
     expect(chips.find(chip => chip.key === 'keeper-count-basis')?.label)
-      .toBe('키퍼 활성 2 / 설정 16')
+      .toBe('키퍼 런타임 가동 2 / 설정 16')
     expect(chips.find(chip => chip.key === 'keeper-count-basis')?.detail)
-      .toBe('활성=shell runtime, paused=상세 행 lifecycle, 설정=project snapshot keeper inventory.')
+      .toBe('런타임 가동=shell, paused=상세 행 lifecycle, offline=상세 행 status, 설정=project snapshot keeper inventory.')
   })
 
   it('returns a healthy chip when no runtime risk is visible', () => {

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -15,6 +15,7 @@ import { namespaceTruth, namespaceTruthInitializing } from '../namespace-truth-s
 import {
   configuredCountSourceLabel,
   formatKeeperCountBreakdown,
+  keeperRowLooksRunning,
   resolveRuntimeCounts,
   runtimeCountSourceLabel,
 } from '../runtime-counts'
@@ -457,12 +458,15 @@ export function dashboardHealthChips(input: DashboardHealthInput): DashboardHeal
   }
 
   const pausedKeepers = input.keepers.filter(isKeeperPaused).length
-  const fallbackRunningKeepers = Math.max(0, input.keepers.length - pausedKeepers)
+  const fallbackRunningKeepers = input.keepers.filter(keeperRowLooksRunning).length
+  const fallbackOfflineKeepers = Math.max(0, input.keepers.length - fallbackRunningKeepers - pausedKeepers)
   const runtimeCounts = resolveRuntimeCounts({
     executionLoaded: input.counts !== null || input.keepers.length > 0,
     agentsCount: input.counts?.agents ?? 0,
     keepersCount: input.counts?.keepers ?? fallbackRunningKeepers,
     pausedKeepersCount: pausedKeepers,
+    offlineKeepersCount: input.counts !== null ? 0 : fallbackOfflineKeepers,
+    keeperRowsCount: input.keepers.length,
     namespaceTruthCounts: input.namespaceTruthCounts,
     namespaceTruthConfiguredKeepers: input.namespaceTruthConfiguredKeepers,
     shellCounts: input.counts,
@@ -470,20 +474,21 @@ export function dashboardHealthChips(input: DashboardHealthInput): DashboardHeal
   })
   const configured = runtimeCounts.configured.keepers
   const liveKeepers = runtimeCounts.live.keepers
-  const activeCountSource = input.counts !== null
+  const runningCountSource = input.counts !== null
     ? 'shell'
     : input.keepers.length > 0
       ? '상세 행'
       : runtimeCountSourceLabel(runtimeCounts.source)
-  if (configured > 0 && (configured !== liveKeepers || pausedKeepers > 0)) {
+  if (configured > 0 && (configured !== liveKeepers || pausedKeepers > 0 || runtimeCounts.live.offlineKeepers > 0)) {
     chips.push({
       key: 'keeper-count-basis',
       label: formatKeeperCountBreakdown({
         liveKeepers,
         pausedKeepers,
+        offlineKeepers: runtimeCounts.live.offlineKeepers,
         configuredKeepers: configured,
       }),
-      detail: `활성=${activeCountSource} runtime, paused=상세 행 lifecycle, 설정=${configuredCountSourceLabel(runtimeCounts.configured.source)} keeper inventory.`,
+      detail: `런타임 가동=${runningCountSource}, paused=상세 행 lifecycle, offline=상세 행 status, 설정=${configuredCountSourceLabel(runtimeCounts.configured.source)} keeper inventory.`,
       tone: 'muted',
     })
   }

--- a/dashboard/src/components/status-tray.test.ts
+++ b/dashboard/src/components/status-tray.test.ts
@@ -116,10 +116,12 @@ describe('summarizeStatusTray', () => {
 
     expect(summary.items.transport.tone).toBe('ok')
     expect(summary.items.fleet.tone).toBe('warn')
-    expect(summary.items.fleet.value).toBe('1/2')
+    expect(summary.items.fleet.value).toBe('fresh 1/2')
+    expect(summary.items.fleet.detail).toBe('1 stale heartbeat; freshness is separate from running fibers')
     expect(summary.items.attention.tone).toBe('err')
     expect(summary.items.attention.value).toBe('4')
     expect(summary.counts).toMatchObject({
+      freshKeepers: 1,
       staleKeepers: 1,
       keeperAttention: 1,
       pendingVerificationTasks: 1,
@@ -162,7 +164,7 @@ describe('summarizeStatusTray', () => {
 
     expect(summary.counts.keeperAttention).toBe(1)
     expect(summary.items.fleet.tone).toBe('warn')
-    expect(summary.items.fleet.detail).toBe('1 keeper need attention')
+    expect(summary.items.fleet.detail).toBe('1 keeper need attention; heartbeat freshness is current')
     expect(summary.items.attention.tone).toBe('warn')
     expect(summary.items.attention.value).toBe('1')
   })

--- a/dashboard/src/components/status-tray.ts
+++ b/dashboard/src/components/status-tray.ts
@@ -57,6 +57,7 @@ export interface StatusTraySummary {
   latestJournalEntries: JournalEntry[]
   counts: {
     totalKeepers: number
+    freshKeepers: number
     staleKeepers: number
     keeperAttention: number
     pendingVerificationTasks: number
@@ -174,7 +175,7 @@ export function summarizeStatusTray(input: StatusTrayInput): StatusTraySummary {
   const totalKeepers = input.keepers.length
   const staleCount = input.keepers.filter(keeper => input.staleKeeperNames.has(keeper.name)).length
   const keeperAttention = countKeeperAttention(input.keepers)
-  const activeKeepers = Math.max(0, totalKeepers - staleCount)
+  const freshKeepers = Math.max(0, totalKeepers - staleCount)
   const pendingVerificationTasks = countPendingVerification(input.tasks)
 
   let transport: StatusTrayItem
@@ -268,6 +269,7 @@ export function summarizeStatusTray(input: StatusTrayInput): StatusTraySummary {
     latestJournalEntries: latest,
     counts: {
       totalKeepers,
+      freshKeepers,
       staleKeepers: staleCount,
       keeperAttention,
       pendingVerificationTasks,
@@ -281,11 +283,11 @@ export function summarizeStatusTray(input: StatusTrayInput): StatusTraySummary {
         key: 'fleet',
         tone: fleetTone,
         label: 'Keepers',
-        value: totalKeepers === 0 ? 'none' : `${activeKeepers}/${totalKeepers}`,
+        value: totalKeepers === 0 ? 'none' : `fresh ${freshKeepers}/${totalKeepers}`,
         detail: staleCount > 0
-          ? `${staleCount} stale heartbeat${staleCount === 1 ? '' : 's'}`
+          ? `${staleCount} stale heartbeat${staleCount === 1 ? '' : 's'}; freshness is separate from running fibers`
           : keeperAttention > 0
-            ? `${keeperAttention} keeper${keeperAttention === 1 ? '' : 's'} need attention`
+            ? `${keeperAttention} keeper${keeperAttention === 1 ? '' : 's'} need attention; heartbeat freshness is current`
             : 'keeper heartbeats are current',
       },
       activity: {
@@ -395,8 +397,8 @@ function PopoverContent({
       <div class="grid gap-3">
         <div class="grid grid-cols-3 gap-2">
           <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-1.5">
-            <div class="font-mono text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Total</div>
-            <div class="mt-0.5 text-sm font-semibold tabular-nums">${summary.counts.totalKeepers}</div>
+            <div class="font-mono text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Fresh</div>
+            <div class="mt-0.5 text-sm font-semibold tabular-nums">${summary.counts.freshKeepers}/${summary.counts.totalKeepers}</div>
           </div>
           <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-1.5">
             <div class="font-mono text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Stale</div>

--- a/dashboard/src/runtime-counts.test.ts
+++ b/dashboard/src/runtime-counts.test.ts
@@ -9,6 +9,7 @@ import {
   formatKeeperCountBreakdown,
   formatKeeperRosterCount,
   formatRuntimeRosterCount,
+  keeperRowLooksRunning,
   keeperDetailRows,
   resolveRuntimeCounts,
   runtimeDetailRows,
@@ -26,7 +27,7 @@ describe('resolveRuntimeCounts', () => {
       namespaceTruthConfiguredKeepers: 5,
       shellCounts: { agents: 1, keepers: 1, tasks: 4 },
     })).toEqual({
-      live: { agents: 0, keepers: 0, pausedKeepers: 0, tasks: 0, totalRuntimes: 0, available: false },
+      live: { agents: 0, keepers: 0, pausedKeepers: 0, offlineKeepers: 0, keeperRows: 0, tasks: 0, totalRuntimes: 0, available: false },
       configured: { keepers: 5, totalRuntimes: 5, source: 'namespace-truth' },
       source: 'project-snapshot',
     })
@@ -40,7 +41,7 @@ describe('resolveRuntimeCounts', () => {
       shellCounts: { agents: 4, keepers: 1, tasks: 9 },
       shellConfiguredKeepers: 3,
     })).toEqual({
-      live: { agents: 0, keepers: 0, pausedKeepers: 0, tasks: 0, totalRuntimes: 0, available: false },
+      live: { agents: 0, keepers: 0, pausedKeepers: 0, offlineKeepers: 0, keeperRows: 0, tasks: 0, totalRuntimes: 0, available: false },
       configured: { keepers: 3, totalRuntimes: 5, source: 'shell' },
       source: 'shell',
     })
@@ -55,7 +56,7 @@ describe('resolveRuntimeCounts', () => {
       shellCounts: { agents: 6, keepers: 1, tasks: 9, total_runtimes: 8 },
       shellConfiguredKeepers: 7,
     })).toEqual({
-      live: { agents: 0, keepers: 0, pausedKeepers: 0, tasks: 0, totalRuntimes: 0, available: false },
+      live: { agents: 0, keepers: 0, pausedKeepers: 0, offlineKeepers: 0, keeperRows: 0, tasks: 0, totalRuntimes: 0, available: false },
       configured: { keepers: 3, totalRuntimes: 5, source: 'namespace-truth' },
       source: 'project-snapshot',
     })
@@ -68,7 +69,7 @@ describe('resolveRuntimeCounts', () => {
       keepersCount: 0,
       namespaceTruthCounts: { agents: 2, keepers: 3, tasks: 12 },
     })).toEqual({
-      live: { agents: 0, keepers: 0, pausedKeepers: 0, tasks: 0, totalRuntimes: 0, available: false },
+      live: { agents: 0, keepers: 0, pausedKeepers: 0, offlineKeepers: 0, keeperRows: 0, tasks: 0, totalRuntimes: 0, available: false },
       configured: { keepers: 3, totalRuntimes: 5, source: 'namespace-truth' },
       source: 'project-snapshot',
     })
@@ -83,7 +84,7 @@ describe('resolveRuntimeCounts', () => {
       shellCounts: { agents: 3, keepers: 2, tasks: 9, total_runtimes: 5 },
       shellConfiguredKeepers: 2,
     })).toEqual({
-      live: { agents: 0, keepers: 0, pausedKeepers: 0, tasks: 0, totalRuntimes: 0, available: false },
+      live: { agents: 0, keepers: 0, pausedKeepers: 0, offlineKeepers: 0, keeperRows: 0, tasks: 0, totalRuntimes: 0, available: false },
       configured: { keepers: 0, totalRuntimes: 0, source: 'namespace-truth' },
       source: 'project-snapshot',
     })
@@ -98,7 +99,7 @@ describe('resolveRuntimeCounts', () => {
       namespaceTruthCounts: { agents: 2, keepers: 3, tasks: 12 },
       namespaceTruthConfiguredKeepers: 5,
     })).toEqual({
-      live: { agents: 2, keepers: 3, pausedKeepers: 0, tasks: 1, totalRuntimes: 5, available: true },
+      live: { agents: 2, keepers: 3, pausedKeepers: 0, offlineKeepers: 0, keeperRows: 3, tasks: 1, totalRuntimes: 5, available: true },
       configured: { keepers: 5, totalRuntimes: 5, source: 'namespace-truth' },
       source: 'execution',
     })
@@ -114,7 +115,7 @@ describe('resolveRuntimeCounts', () => {
       shellCounts: { agents: 13, keepers: 12, tasks: 103, total_runtimes: 25 },
       shellConfiguredKeepers: 14,
     })).toEqual({
-      live: { agents: 0, keepers: 12, pausedKeepers: 0, tasks: 0, totalRuntimes: 12, available: false },
+      live: { agents: 0, keepers: 12, pausedKeepers: 0, offlineKeepers: 0, keeperRows: 12, tasks: 0, totalRuntimes: 12, available: false },
       configured: { keepers: 14, totalRuntimes: 14, source: 'namespace-truth' },
       source: 'partial',
     })
@@ -128,16 +129,16 @@ describe('resolveRuntimeCounts', () => {
       namespaceTruthCounts: { agents: 2, keepers: 3, tasks: 12 },
       namespaceTruthConfiguredKeepers: 4,
     })).toEqual({
-      live: { agents: 0, keepers: 0, pausedKeepers: 0, tasks: 0, totalRuntimes: 0, available: true },
+      live: { agents: 0, keepers: 0, pausedKeepers: 0, offlineKeepers: 0, keeperRows: 0, tasks: 0, totalRuntimes: 0, available: true },
       configured: { keepers: 4, totalRuntimes: 5, source: 'namespace-truth' },
       source: 'project-snapshot',
     })
   })
 
   it('reports both 2 live and 16 configured keepers in the fluctuation scenario without picking a winner', () => {
-    // Real-world reproduction: composite API returns 2 active fiber keepers
+    // Real-world reproduction: composite API returns 2 running fiber keepers
     // while .masc/keepers/ holds 16 persona registrations. Both must surface
-    // simultaneously so the UI can render "활성 2 / 설정 16" instead of swapping.
+    // simultaneously so the UI can render "런타임 가동 2 / 설정 16" instead of swapping.
     expect(resolveRuntimeCounts({
       executionLoaded: true,
       agentsCount: 0,
@@ -145,8 +146,25 @@ describe('resolveRuntimeCounts', () => {
       namespaceTruthCounts: { agents: 0, keepers: 16, tasks: 0 },
       namespaceTruthConfiguredKeepers: 16,
     })).toEqual({
-      live: { agents: 0, keepers: 2, pausedKeepers: 0, tasks: 0, totalRuntimes: 2, available: true },
+      live: { agents: 0, keepers: 2, pausedKeepers: 0, offlineKeepers: 0, keeperRows: 2, tasks: 0, totalRuntimes: 2, available: true },
       configured: { keepers: 16, totalRuntimes: 16, source: 'namespace-truth' },
+      source: 'execution',
+    })
+  })
+
+  it('treats paused or offline detail rows as execution evidence even when no keeper is running', () => {
+    expect(resolveRuntimeCounts({
+      executionLoaded: true,
+      agentsCount: 0,
+      keepersCount: 0,
+      pausedKeepersCount: 1,
+      offlineKeepersCount: 2,
+      keeperRowsCount: 3,
+      namespaceTruthCounts: { agents: 0, keepers: 3, tasks: 0 },
+      namespaceTruthConfiguredKeepers: 3,
+    })).toEqual({
+      live: { agents: 0, keepers: 0, pausedKeepers: 1, offlineKeepers: 2, keeperRows: 3, tasks: 0, totalRuntimes: 0, available: true },
+      configured: { keepers: 3, totalRuntimes: 3, source: 'namespace-truth' },
       source: 'execution',
     })
   })
@@ -157,7 +175,7 @@ describe('resolveRuntimeCounts', () => {
       agentsCount: 0,
       keepersCount: 0,
     })).toEqual({
-      live: { agents: 0, keepers: 0, pausedKeepers: 0, tasks: 0, totalRuntimes: 0, available: false },
+      live: { agents: 0, keepers: 0, pausedKeepers: 0, offlineKeepers: 0, keeperRows: 0, tasks: 0, totalRuntimes: 0, available: false },
       configured: { keepers: 0, totalRuntimes: 0, source: 'none' },
       source: 'unknown',
     })
@@ -194,54 +212,67 @@ describe('configuredCountSourceLabel', () => {
   })
 })
 
+describe('keeperRowLooksRunning', () => {
+  it('uses keepalive_running as the strongest running signal', () => {
+    expect(keeperRowLooksRunning({ status: 'offline', keepalive_running: true })).toBe(true)
+    expect(keeperRowLooksRunning({ status: 'active', keepalive_running: false })).toBe(false)
+  })
+
+  it('falls back to runtime status only when keepalive truth is absent', () => {
+    expect(keeperRowLooksRunning({ status: 'active' })).toBe(true)
+    expect(keeperRowLooksRunning({ status: 'offline' })).toBe(false)
+    expect(keeperRowLooksRunning({ phase: 'Paused', status: 'active' })).toBe(false)
+  })
+})
+
 describe('formatActiveOverConfigured', () => {
-  it('formats keeper counts as "활성 N / 설정 M"', () => {
+  it('formats keeper counts as "런타임 가동 N / 설정 M"', () => {
     const counts = {
-      live: { agents: 0, keepers: 2, pausedKeepers: 0, tasks: 0, totalRuntimes: 2, available: true },
+      live: { agents: 0, keepers: 2, pausedKeepers: 0, offlineKeepers: 0, keeperRows: 2, tasks: 0, totalRuntimes: 2, available: true },
       configured: { keepers: 16, totalRuntimes: 16, source: 'namespace-truth' as const },
     }
-    expect(formatActiveOverConfigured(counts, 'keeper')).toBe('활성 2 / 설정 16')
+    expect(formatActiveOverConfigured(counts, 'keeper')).toBe('런타임 가동 2 / 설정 16')
   })
 
   it('includes paused count in keeper formatting when paused keepers exist', () => {
     const counts = {
-      live: { agents: 0, keepers: 4, pausedKeepers: 3, tasks: 0, totalRuntimes: 4, available: true },
+      live: { agents: 0, keepers: 4, pausedKeepers: 3, offlineKeepers: 0, keeperRows: 7, tasks: 0, totalRuntimes: 4, available: true },
       configured: { keepers: 24, totalRuntimes: 24, source: 'namespace-truth' as const },
     }
-    expect(formatActiveOverConfigured(counts, 'keeper')).toBe('활성 4 / 일시정지 3 / 설정 24')
+    expect(formatActiveOverConfigured(counts, 'keeper')).toBe('런타임 가동 4 / 일시정지 3 / 설정 24')
   })
 
-  it('formats runtime totals as "활성 N / 설정 M"', () => {
+  it('formats runtime totals as "런타임 가동 N / 설정 M"', () => {
     const counts = {
-      live: { agents: 3, keepers: 2, pausedKeepers: 0, tasks: 0, totalRuntimes: 5, available: true },
+      live: { agents: 3, keepers: 2, pausedKeepers: 0, offlineKeepers: 0, keeperRows: 2, tasks: 0, totalRuntimes: 5, available: true },
       configured: { keepers: 16, totalRuntimes: 20, source: 'namespace-truth' as const },
     }
-    expect(formatActiveOverConfigured(counts, 'runtime')).toBe('활성 5 / 설정 20')
+    expect(formatActiveOverConfigured(counts, 'runtime')).toBe('런타임 가동 5 / 설정 20')
   })
 
   it('defaults kind to "keeper" when omitted', () => {
     const counts = {
-      live: { agents: 0, keepers: 0, pausedKeepers: 0, tasks: 0, totalRuntimes: 0, available: false },
+      live: { agents: 0, keepers: 0, pausedKeepers: 0, offlineKeepers: 0, keeperRows: 0, tasks: 0, totalRuntimes: 0, available: false },
       configured: { keepers: 0, totalRuntimes: 0, source: 'none' as const },
     }
-    expect(formatActiveOverConfigured(counts)).toBe('활성 0 / 설정 0')
+    expect(formatActiveOverConfigured(counts)).toBe('런타임 가동 0 / 설정 0')
   })
 })
 
 describe('runtime count role helpers', () => {
   const counts = {
-    live: { agents: 4, keepers: 4, pausedKeepers: 12, tasks: 0, totalRuntimes: 8, available: true },
+    live: { agents: 4, keepers: 4, pausedKeepers: 12, offlineKeepers: 0, keeperRows: 16, tasks: 0, totalRuntimes: 8, available: true },
     configured: { keepers: 16, totalRuntimes: 8, source: 'namespace-truth' as const },
   }
 
-  it('keeps detail rows distinct from active runtime totals', () => {
+  it('keeps detail rows distinct from running runtime totals', () => {
     expect(keeperDetailRows(counts)).toBe(16)
     expect(runtimeDetailRows(counts)).toBe(20)
   })
 
   it('keeps configured keeper inventory as the expected detail-row floor', () => {
     const partialCounts = {
-      live: { agents: 4, keepers: 4, pausedKeepers: 0, tasks: 0, totalRuntimes: 8, available: true },
+      live: { agents: 4, keepers: 4, pausedKeepers: 0, offlineKeepers: 0, keeperRows: 4, tasks: 0, totalRuntimes: 8, available: true },
       configured: { keepers: 16, totalRuntimes: 8, source: 'namespace-truth' as const },
     }
     expect(expectedKeeperDetailRows(partialCounts)).toBe(16)
@@ -253,12 +284,23 @@ describe('runtime count role helpers', () => {
       liveKeepers: 4,
       pausedKeepers: 12,
       configuredKeepers: 16,
-    })).toBe('키퍼 활성 4 / 일시정지 12 / 설정 16')
+    })).toBe('키퍼 런타임 가동 4 / 일시정지 12 / 설정 16')
   })
 
-  it('formats roster chips with detail rows, active runtimes, and configured inventory', () => {
-    expect(formatKeeperRosterCount(counts)).toBe('상세 16 / 활성 4 / 일시정지 12 / 설정 16')
-    expect(formatRuntimeRosterCount(counts)).toBe('상세 20 / 활성 8 / 키퍼 설정 16')
+  it('formats roster chips with detail rows, running runtimes, and configured inventory', () => {
+    expect(formatKeeperRosterCount(counts)).toBe('상세 16 / 런타임 가동 4 / 일시정지 12 / 설정 16')
+    expect(formatRuntimeRosterCount(counts)).toBe('상세 20 / 런타임 가동 8 / 키퍼 설정 16')
+  })
+
+  it('surfaces offline keeper detail rows separately from running capacity', () => {
+    const splitCounts = {
+      live: { agents: 0, keepers: 2, pausedKeepers: 6, offlineKeepers: 9, keeperRows: 17, tasks: 0, totalRuntimes: 2, available: true },
+      configured: { keepers: 17, totalRuntimes: 17, source: 'namespace-truth' as const },
+    }
+
+    expect(keeperDetailRows(splitCounts)).toBe(17)
+    expect(formatKeeperRosterCount(splitCounts)).toBe('상세 17 / 런타임 가동 2 / 일시정지 6 / 오프라인 9 / 설정 17')
+    expect(formatRuntimeRosterCount(splitCounts)).toBe('상세 17 / 런타임 가동 2 / 키퍼 설정 17')
   })
 
   it('formats command target sections as mission targets, not live runtime counts', () => {

--- a/dashboard/src/runtime-counts.ts
+++ b/dashboard/src/runtime-counts.ts
@@ -13,6 +13,8 @@ export interface LiveRuntimeView {
   agents: number
   keepers: number
   pausedKeepers: number
+  offlineKeepers: number
+  keeperRows: number
   tasks: number
   totalRuntimes: number
   available: boolean
@@ -33,6 +35,7 @@ export interface RuntimeCounts {
 export interface KeeperCountBreakdownInput {
   liveKeepers: number
   pausedKeepers?: number
+  offlineKeepers?: number
   configuredKeepers: number
 }
 
@@ -43,6 +46,8 @@ interface ResolveRuntimeCountsOptions {
   agentsCount: number
   keepersCount: number
   pausedKeepersCount?: number
+  offlineKeepersCount?: number
+  keeperRowsCount?: number
   tasksCount?: number
   namespaceTruthCounts?: DashboardNamespaceTruthResponse['root']['counts']
   namespaceTruthConfiguredKeepers?: number
@@ -54,6 +59,50 @@ function normalizeCount(value: unknown): number {
   return typeof value === 'number' && Number.isFinite(value) && value > 0
     ? Math.floor(value)
     : 0
+}
+
+function normalizeRuntimeToken(value: unknown): string {
+  return typeof value === 'string' ? value.trim().toLowerCase() : ''
+}
+
+export interface KeeperRuntimeCountRow {
+  status?: string | null
+  phase?: string | null
+  pipeline_stage?: string | null
+  paused?: boolean | null
+  keepalive_running?: boolean | null
+}
+
+const TERMINAL_KEEPER_RUNTIME_TOKENS = new Set(['paused', 'stopped', 'dead', 'zombie', 'crashed'])
+const OFFLINE_KEEPER_RUNTIME_TOKENS = new Set(['offline', 'inactive'])
+const RUNNING_KEEPER_RUNTIME_TOKENS = new Set(['active', 'busy', 'listening', 'idle', 'running'])
+
+export function keeperRowLooksRunning(row: KeeperRuntimeCountRow | null | undefined): boolean {
+  if (!row || row.paused === true) return false
+
+  const status = normalizeRuntimeToken(row.status)
+  const phase = normalizeRuntimeToken(row.phase)
+  const stage = normalizeRuntimeToken(row.pipeline_stage)
+  if (
+    TERMINAL_KEEPER_RUNTIME_TOKENS.has(status)
+    || TERMINAL_KEEPER_RUNTIME_TOKENS.has(phase)
+    || TERMINAL_KEEPER_RUNTIME_TOKENS.has(stage)
+  ) return false
+
+  if (row.keepalive_running === true) return true
+  if (row.keepalive_running === false) return false
+
+  if (
+    OFFLINE_KEEPER_RUNTIME_TOKENS.has(status)
+    || OFFLINE_KEEPER_RUNTIME_TOKENS.has(phase)
+    || OFFLINE_KEEPER_RUNTIME_TOKENS.has(stage)
+  ) return false
+
+  return (
+    RUNNING_KEEPER_RUNTIME_TOKENS.has(status)
+    || RUNNING_KEEPER_RUNTIME_TOKENS.has(phase)
+    || RUNNING_KEEPER_RUNTIME_TOKENS.has(stage)
+  )
 }
 
 function normalizeCounts(
@@ -119,10 +168,11 @@ function deriveStatusSource({
   live: LiveRuntimeView
   configured: ConfiguredRuntimeView
 }): RuntimeCountSource {
-  if (executionLoaded && (live.totalRuntimes > 0 || configured.totalRuntimes === 0)) {
+  const liveDetailRows = live.agents + live.keeperRows
+  if (executionLoaded && (liveDetailRows > 0 || configured.totalRuntimes === 0)) {
     return 'execution'
   }
-  if (live.totalRuntimes > 0) return 'partial'
+  if (liveDetailRows > 0) return 'partial'
   if (configured.source === 'namespace-truth') return 'project-snapshot'
   if (configured.source === 'shell') return 'shell'
   return executionLoaded ? 'execution' : 'unknown'
@@ -133,6 +183,8 @@ export function resolveRuntimeCounts({
   agentsCount,
   keepersCount,
   pausedKeepersCount = 0,
+  offlineKeepersCount,
+  keeperRowsCount,
   tasksCount = 0,
   namespaceTruthCounts,
   namespaceTruthConfiguredKeepers,
@@ -142,11 +194,18 @@ export function resolveRuntimeCounts({
   const liveAgents = normalizeCount(agentsCount)
   const liveKeepers = normalizeCount(keepersCount)
   const livePausedKeepers = normalizeCount(pausedKeepersCount)
+  const liveOfflineKeepers = normalizeCount(offlineKeepersCount)
+  const liveKeeperRows = Math.max(
+    normalizeCount(keeperRowsCount),
+    liveKeepers + livePausedKeepers + liveOfflineKeepers,
+  )
   const liveTasks = normalizeCount(tasksCount)
   const live: LiveRuntimeView = {
     agents: liveAgents,
     keepers: liveKeepers,
     pausedKeepers: livePausedKeepers,
+    offlineKeepers: Math.max(0, liveKeeperRows - liveKeepers - livePausedKeepers),
+    keeperRows: liveKeeperRows,
     tasks: liveTasks,
     totalRuntimes: liveAgents + liveKeepers,
     available: executionLoaded,
@@ -205,17 +264,19 @@ export function formatActiveOverConfigured(
   if (kind === 'keeper') {
     const running = counts.live.keepers
     const paused = counts.live.pausedKeepers
+    const offline = counts.live.offlineKeepers
     const configured = counts.configured.keepers
-    const parts = [`활성 ${running}`]
+    const parts = [`런타임 가동 ${running}`]
     if (paused > 0) parts.push(`일시정지 ${paused}`)
+    if (offline > 0) parts.push(`오프라인 ${offline}`)
     parts.push(`설정 ${configured}`)
     return parts.join(' / ')
   }
-  return `활성 ${counts.live.totalRuntimes} / 설정 ${counts.configured.totalRuntimes}`
+  return `런타임 가동 ${counts.live.totalRuntimes} / 설정 ${counts.configured.totalRuntimes}`
 }
 
 export function keeperDetailRows(counts: Pick<RuntimeCounts, 'live'>): number {
-  return counts.live.keepers + counts.live.pausedKeepers
+  return counts.live.keeperRows
 }
 
 export function runtimeDetailRows(counts: Pick<RuntimeCounts, 'live'>): number {
@@ -233,11 +294,14 @@ export function expectedRuntimeDetailRows(counts: Pick<RuntimeCounts, 'live' | '
 export function formatKeeperCountBreakdown({
   liveKeepers,
   pausedKeepers = 0,
+  offlineKeepers = 0,
   configuredKeepers,
 }: KeeperCountBreakdownInput): string {
-  const parts = [`키퍼 활성 ${normalizeCount(liveKeepers)}`]
+  const parts = [`키퍼 런타임 가동 ${normalizeCount(liveKeepers)}`]
   const paused = normalizeCount(pausedKeepers)
+  const offline = normalizeCount(offlineKeepers)
   if (paused > 0) parts.push(`일시정지 ${paused}`)
+  if (offline > 0) parts.push(`오프라인 ${offline}`)
   parts.push(`설정 ${normalizeCount(configuredKeepers)}`)
   return parts.join(' / ')
 }
@@ -248,6 +312,7 @@ export function formatKeeperRosterCount(counts: Pick<RuntimeCounts, 'live' | 'co
     formatKeeperCountBreakdown({
       liveKeepers: counts.live.keepers,
       pausedKeepers: counts.live.pausedKeepers,
+      offlineKeepers: counts.live.offlineKeepers,
       configuredKeepers: counts.configured.keepers,
     }).replace(/^키퍼 /, ''),
   ].join(' / ')
@@ -256,7 +321,7 @@ export function formatKeeperRosterCount(counts: Pick<RuntimeCounts, 'live' | 'co
 export function formatRuntimeRosterCount(counts: Pick<RuntimeCounts, 'live' | 'configured'>): string {
   return [
     `상세 ${runtimeDetailRows(counts)}`,
-    `활성 ${counts.live.totalRuntimes}`,
+    `런타임 가동 ${counts.live.totalRuntimes}`,
     `키퍼 설정 ${counts.configured.keepers}`,
   ].join(' / ')
 }


### PR DESCRIPTION
## Summary

- Split dashboard keeper counts into explicit axes: running runtime (`런타임 가동`), paused, offline detail rows, configured inventory, and heartbeat freshness.
- Stop treating offline non-paused keeper rows as running fibers in the roster count helpers.
- Rename status tray fleet value from an ambiguous `N/M` to `fresh N/M` so it no longer conflicts with running keeper capacity.
- Thread shell configured keeper counts into the unified Keeper Fleet chips so they do not fall back to `키퍼 설정 0`.

## Root Cause

The dashboard mixed three different count meanings under similar labels:

- execution/detail rows
- actual running keeper runtime capacity
- heartbeat freshness

That made the live runtime state look inconsistent even though the runtime SSOT was returning coherent data. Fixes #20197.

## Validation

- `pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/runtime-counts.test.ts src/components/agent-roster.test.ts src/components/agents-unified.test.ts src/components/dashboard-shell.test.ts src/components/status-tray.test.ts` — pass, 90 tests
- `pnpm run lint` — pass
- `pnpm run build` — pass
- Playwright screenshot against local Vite + live `127.0.0.1:8935` backend: `/tmp/masc-dashboard-keeper-roster-count-axes-rebased.png`

## Known unrelated blocker

- `pnpm run typecheck` currently fails on `origin/main` due to duplicate `ChatMessage` type imports in `dashboard/src/components/keeper-chat-panel.test.ts`. Tracked separately in #20202.