### PR TITLE
fix(dashboard): keeper chat multimodal bug fixes

### DIFF
--- a/dashboard/src/components/keeper-chat-panel.ts
+++ b/dashboard/src/components/keeper-chat-panel.ts
@@ -67,7 +67,9 @@ async function resizeImage(file: File, maxWidth = 1920): Promise<File> {
   if (!file.type.startsWith('image/')) return file
   return new Promise((resolve) => {
     const img = new Image()
+    const objectUrl = URL.createObjectURL(file)
     img.onload = () => {
+      URL.revokeObjectURL(objectUrl)
       if (img.width <= maxWidth) { resolve(file); return }
       const canvas = document.createElement('canvas')
       const scale = maxWidth / img.width
@@ -81,8 +83,11 @@ async function resizeImage(file: File, maxWidth = 1920): Promise<File> {
         resolve(new File([blob], file.name, { type: file.type }))
       }, file.type)
     }
-    img.onerror = () => resolve(file)
-    img.src = URL.createObjectURL(file)
+    img.onerror = () => {
+      URL.revokeObjectURL(objectUrl)
+      resolve(file)
+    }
+    img.src = objectUrl
   })
 }
 
@@ -112,7 +117,7 @@ function toConversationEntry(
     timestamp: new Date(msg.timestamp).toISOString(),
     delivery: 'delivered',
     streamState: null,
-    details: null,
+    details: msg.attachments ? { rawPayload: { attachments: msg.attachments } } : null,
   }
 }
 
@@ -422,7 +427,11 @@ export function KeeperChatPanel({ name }: { name: string }) {
             class="hidden"
             multiple
             accept="image/png,image/jpeg,image/gif,image/webp,text/plain,text/markdown,application/json,text/csv"
-            onChange=${(e: Event) => { void handleFileSelect((e.target as HTMLInputElement).files) }}
+            onChange=${(e: Event) => {
+              const target = e.target as HTMLInputElement
+              void handleFileSelect(target.files)
+              target.value = ''
+            }}
           />
           <div class="flex-1">
             <${ChatComposer}


### PR DESCRIPTION
## Summary

Fix 3 bugs found in keeper chat multimodal implementation (PR #20200).

## Bug Fixes

| # | Bug | Fix |
|---|-----|-----|
| 1 | **Memory leak** in `resizeImage` — `URL.createObjectURL` created blob URLs that were never revoked. | Store object URL in a local variable and call `URL.revokeObjectURL` in both `onload` and `onerror` handlers. |
| 2 | **Attachments not displayed** in chat history — `toConversationEntry` dropped `msg.attachments` instead of passing them to `ChatTranscript`. | Pass attachments via `details.rawPayload.attachments` so the transcript renderer can access them. |
| 3 | **File input re-selection blocked** — selecting the same file twice did not trigger `onChange` because the input value was unchanged. | Clear `target.value = ''` after processing the file list. |

## Verification

- [x] `tsc --noEmit` clean
- [x] `vitest run src/keeper-chat-store.test.ts` — 21/21 passed

## Affected File

- `dashboard/src/components/keeper-chat-panel.ts`

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
