### PR TITLE
fix(keeper): correct Provider_timeout signal semantics

### DIFF
--- a/lib/keeper/keeper_turn_runtime_budget.ml
+++ b/lib/keeper/keeper_turn_runtime_budget.ml
@@ -208,13 +208,16 @@ let reclassify_provider_timeout_for_attempt
   match err, provider_timeout_budget with
   | Agent_sdk.Error.Api (Timeout { message }), Some budget
     when EC.is_structural_oas_timeout_message message ->
+      let estimated_remaining_after_timeout =
+        Float.max 0.0 (budget.remaining_turn_budget_sec -. budget.effective_timeout_sec)
+      in
       Keeper_turn_driver.sdk_error_of_masc_internal_error
         (Keeper_turn_driver.Provider_timeout
            { budget_sec = budget.effective_timeout_sec
            ; keeper_turn_timeout_sec = budget.keeper_turn_timeout_sec
            ; estimated_input_tokens = budget.estimated_input_tokens
            ; source = budget.source
-           ; remaining_turn_budget_sec = Some budget.remaining_turn_budget_sec
+           ; remaining_turn_budget_sec = Some estimated_remaining_after_timeout
            ; min_required_sec = min_provider_timeout_budget_sec
            ; phase = "runtime_attempt_watchdog"
            })

--- a/lib/keeper/keeper_turn_runtime_budget_provider_timeout.ml
+++ b/lib/keeper/keeper_turn_runtime_budget_provider_timeout.ml
@@ -88,8 +88,8 @@ let resolve_bounded_provider_timeout_budget_with_turn_budget
     | Some (effective_timeout_sec, used_wall_clock_retry_budget) ->
       let source =
         if used_wall_clock_retry_budget
-        then "turn_budget_wall_clock_retry"
-        else "turn_budget_per_attempt_retry"
+        then "retry_wall_clock_limited"
+        else "retry_per_attempt_limited"
       in
       Some
         {
@@ -121,8 +121,8 @@ let resolve_bounded_provider_timeout_budget_with_turn_budget
       in
       let source =
         if capped_by_turn_budget
-        then "turn_budget_capped"
-        else "turn_budget"
+        then "first_attempt_limited_by_turn_budget"
+        else "first_attempt_adaptive_timeout"
       in
       Some
         {


### PR DESCRIPTION
## Problem

Provider_timeout JSON carried two contradictory signals:

1. remaining_turn_budget_sec was captured at attempt start time, so after a 554.98s attempt timed out it still reported ~599.98s remaining -- the same value as at start. This made the error look like the turn had just begun, confusing diagnosis.

2. source = "turn_budget_capped" was computed at budget-allocation time (effective_timeout_sec < adaptive_timeout_sec) but read as if it were the timeout root cause. Combined with an untouched remaining_turn_budget_sec, it appeared to claim the turn budget was exhausted when it was nearly full.

## Fix

- reclassify_provider_timeout_for_attempt now subtracts the attempt's effective_timeout_sec from the start-of-attempt remaining budget to produce an estimated_remaining_after_timeout. This gives operators the post-timeout residual, not the stale pre-attempt value.

- Rename source labels to describe which budget path was taken, not a faux root cause:
  - "turn_budget_capped" -> "first_attempt_limited_by_turn_budget"
  - "turn_budget"        -> "first_attempt_adaptive_timeout"
  - "turn_budget_wall_clock_retry" -> "retry_wall_clock_limited"
  - "turn_budget_per_attempt_retry" -> "retry_per_attempt_limited"

## Verification

- dune build @check passes in worktree.
- No hardcoded old source values found in test/.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>