### PR TITLE
[codex] Clarify keeper dashboard lifecycle state

### DIFF
--- a/dashboard/src/components/common/status-chip.ts
+++ b/dashboard/src/components/common/status-chip.ts
@@ -206,6 +206,7 @@ export interface StatusChipProps {
       where uppercase would change the visual grammar — typically
       file paths, enum values, short textual tags). */
   uppercase?: boolean
+  title?: string
   children?: ComponentChildren
   testId?: string
 }
@@ -214,6 +215,7 @@ export function StatusChip({
   tone = '',
   class: cx,
   uppercase = true,
+  title,
   children,
   testId,
 }: StatusChipProps) {
@@ -237,6 +239,7 @@ export function StatusChip({
     data-status-chip-has-test-id=${summary.hasTestId}
     data-status-chip-class-length=${summary.classNameLength}
     data-status-chip-test-id-length=${summary.testIdLength}
+    title=${title}
     data-testid=${testId}
   >${content}</span>`
 }

--- a/dashboard/src/components/journey-panel.ts
+++ b/dashboard/src/components/journey-panel.ts
@@ -23,6 +23,7 @@ import { Select } from './common/select'
 import { StatusChip, keeperStateTone } from './common/status-chip'
 import { TimeAgo } from './common/time-ago'
 import { formatIndependentCounters } from './counter-format'
+import { pipelineStageDetailLabel } from './keeper-phase-indicator'
 import {
   buildJourneyWaterfall,
   selectDefaultJourneyKeeper,
@@ -493,7 +494,7 @@ export function JourneyPanel() {
                 <div class="flex flex-wrap items-center gap-2 text-2xs">
                   <${StatusChip} tone=${keeperStateTone(selected.status)} uppercase=${false}>${selected.status}<//>
                   ${selected.pipeline_stage
-                    ? html`<${StatusChip} tone="info" uppercase=${false}>${selected.pipeline_stage}<//>`
+                    ? html`<${StatusChip} tone="info" uppercase=${false} title=${selected.pipeline_stage_detail ? pipelineStageDetailLabel(selected.pipeline_stage_detail) ?? selected.pipeline_stage_detail : undefined}>${selected.pipeline_stage}<//>`
                     : null}
                   <span class="font-mono text-[var(--color-fg-muted)]">turns ${selected.turn_count ?? selected.total_turns ?? 'not recorded'}</span>
                 </div>

--- a/dashboard/src/components/keeper-detail-shell.ts
+++ b/dashboard/src/components/keeper-detail-shell.ts
@@ -88,7 +88,12 @@ export function KeeperDetailHeaderInfo({
         <${SectionLabel}>모니터링 / 에이전트 / 키퍼 상세</${SectionLabel}>
         <div class="mt-1 flex flex-wrap items-center gap-2.5">
           <h2 id=${titleId} class="m-0 text-lg font-semibold text-[var(--color-fg-primary)]">${keeper.name}</h2>
-          <${KeeperPhaseAndStage} phase=${keeper.phase} pipelineStage=${keeper.pipeline_stage} phaseEnteredAtSec=${phaseEnteredAtSec} />
+          <${KeeperPhaseAndStage}
+            phase=${keeper.lifecycle_phase ?? keeper.phase}
+            pipelineStage=${keeper.pipeline_stage}
+            pipelineStageDetail=${keeper.pipeline_stage_detail}
+            phaseEnteredAtSec=${phaseEnteredAtSec}
+          />
           <${KeeperModelChip} keeper=${keeper} />
         </div>
         ${keeper.koreanName || keeper.created_at ? html`

--- a/dashboard/src/components/keeper-phase-indicator.test.ts
+++ b/dashboard/src/components/keeper-phase-indicator.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { PHASE_STYLES, getPhaseStyle } from './keeper-phase-indicator'
+import { PHASE_STYLES, getPhaseStyle, pipelineStageDetailLabel } from './keeper-phase-indicator'
 
 // ================================================================
 // PHASE_STYLES
@@ -112,5 +112,18 @@ describe('getPhaseStyle', () => {
       expect(style.label).toBeTruthy()
       expect(style.color).toMatch(/^var\(--/)
     }
+  })
+})
+
+describe('pipelineStageDetailLabel', () => {
+  it('renders operator-facing labels for offline detail reasons', () => {
+    expect(pipelineStageDetailLabel('launch_pending_no_fiber')).toBe('기동 대기')
+    expect(pipelineStageDetailLabel('clean_stop_terminal')).toBe('정상 정지')
+    expect(pipelineStageDetailLabel('restart_budget_exhausted_terminal')).toBe('재시작 한도 소진')
+    expect(pipelineStageDetailLabel('structural_failure_terminal')).toBe('구조 실패')
+  })
+
+  it('keeps unknown future details readable', () => {
+    expect(pipelineStageDetailLabel('future_detail_value')).toBe('future detail value')
   })
 })

--- a/dashboard/src/components/keeper-phase-indicator.ts
+++ b/dashboard/src/components/keeper-phase-indicator.ts
@@ -63,6 +63,30 @@ export const PHASE_STYLES: Record<KeeperPhase, PhaseStyle> = {
   Zombie:     { label: '좀비',         color: 'var(--bad-light)',  bg: 'var(--bad-10)',    border: 'var(--bad-20)',     glow: STRONG_GLOW,   icon: '☠' },
 }
 
+const PIPELINE_STAGE_DETAIL_LABELS: Record<string, string> = {
+  registry_absent: '레지스트리 없음',
+  launch_pending_no_fiber: '기동 대기',
+  phase_running_idle: '대기',
+  health_or_turn_failure_probe: '복구 확인',
+  context_overflow_pending_compaction: '압축 대기',
+  context_compaction_in_progress: '압축 진행',
+  generation_handoff_in_progress: '승계 진행',
+  graceful_shutdown_draining: '종료 정리',
+  operator_or_policy_paused: '일시정지',
+  clean_stop_terminal: '정상 정지',
+  crashed_restart_candidate: '재시작 후보',
+  supervisor_restart_backoff_elapsed: '재시작 대기',
+  restart_budget_exhausted_terminal: '재시작 한도 소진',
+  structural_failure_terminal: '구조 실패',
+}
+
+export function pipelineStageDetailLabel(detail: string | null | undefined): string | null {
+  if (!detail) return null
+  const trimmed = detail.trim()
+  if (!trimmed) return null
+  return PIPELINE_STAGE_DETAIL_LABELS[trimmed] ?? trimmed.replaceAll('_', ' ')
+}
+
 export function getPhaseStyle(phase: KeeperPhase | string | null | undefined): PhaseStyle {
   if (!phase) return PHASE_STYLES.Offline
   // Use the SSOT boundary parser (`toKeeperPhase`) instead of the raw
@@ -110,28 +134,42 @@ export function KeeperPhaseBadge({ phase, compact }: { phase?: KeeperPhase | str
 export function KeeperPhaseAndStage({
   phase,
   pipelineStage,
+  pipelineStageDetail,
   phaseEnteredAtSec,
 }: {
   phase?: KeeperPhase | string | null
   pipelineStage?: string | null
+  pipelineStageDetail?: string | null
   phaseEnteredAtSec?: number | null
 }) {
   const stageLabel = pipelineStage && pipelineStage !== 'idle' && pipelineStage !== 'offline'
     ? pipelineStage.replace('_', ' ')
     : null
+  const detailLabel = pipelineStage === 'offline' || pipelineStage === 'unknown'
+    ? pipelineStageDetailLabel(pipelineStageDetail)
+    : null
+  const title = [
+    phase ? `phase=${phase}` : null,
+    pipelineStage ? `stage=${pipelineStage}` : null,
+    detailLabel ? `reason=${detailLabel}` : null,
+    pipelineStageDetail ? `detail=${pipelineStageDetail}` : null,
+  ].filter((part): part is string => part !== null).join(' · ')
 
   const dwellText = (typeof phaseEnteredAtSec === 'number' && Number.isFinite(phaseEnteredAtSec))
     ? formatDuration(Math.max(0, Date.now() / 1000 - phaseEnteredAtSec))
     : null
 
   return html`
-    <div class="flex items-center gap-2">
+    <div class="flex items-center gap-2" title=${title || undefined}>
       <${KeeperPhaseBadge} phase=${phase} />
       ${dwellText ? html`
         <span class="text-3xs text-[var(--color-fg-muted)] font-mono tracking-tight" title="현재 phase에 머문 시간"><span aria-hidden="true">· </span>${dwellText}</span>
       ` : null}
       ${stageLabel ? html`
         <span class="text-3xs text-[var(--color-fg-disabled)] font-mono tracking-tight opacity-80">${stageLabel}</span>
+      ` : null}
+      ${detailLabel ? html`
+        <span class="text-3xs text-[var(--color-fg-disabled)] font-mono tracking-tight opacity-80">${detailLabel}</span>
       ` : null}
     </div>
   `

--- a/dashboard/src/components/keeper-reactivity-monitor.ts
+++ b/dashboard/src/components/keeper-reactivity-monitor.ts
@@ -16,7 +16,7 @@ import { useSignal } from '@preact/signals'
 import { useEffect, useRef } from 'preact/hooks'
 import { keepers } from '../store'
 import { navigate } from '../router'
-import { KeeperPhaseBadge } from './keeper-phase-indicator'
+import { KeeperPhaseBadge, pipelineStageDetailLabel } from './keeper-phase-indicator'
 import { KeeperPhaseTimeline, refreshKeeperPhaseTimeline } from './keeper-phase-strip'
 import { KeeperLifecycleTimeline, refreshKeeperLifecycleTimeline } from './keeper-lifecycle-timeline'
 import { TurnBudgetGaugePanel } from './turn-budget-gauge'
@@ -240,13 +240,19 @@ function HealthGrid({ allKeepers }: { allKeepers: Keeper[] }) {
                   </button>
                 </td>
                 <td class="py-2 pr-3">
-                  <${PhaseDot} phase=${k.phase} />
+                  <${PhaseDot} phase=${k.lifecycle_phase ?? k.phase} />
                   ${isPaused ? html`
                     <span class="ml-1.5 inline-flex items-center text-3xs text-[var(--paused)] font-semibold">⏸ 일시정지</span>
                   ` : null}
                 </td>
-                <td class="py-2 pr-3 text-[var(--color-fg-muted)] capitalize">
-                  ${k.pipeline_stage ?? '—'}
+                <td
+                  class="py-2 pr-3 text-[var(--color-fg-muted)] capitalize"
+                  title=${k.pipeline_stage_detail ? `${k.pipeline_stage ?? 'unknown'} · ${pipelineStageDetailLabel(k.pipeline_stage_detail)} · ${k.pipeline_stage_detail}` : undefined}
+                >
+                  <span>${k.pipeline_stage ?? '—'}</span>
+                  ${k.pipeline_stage === 'offline' && k.pipeline_stage_detail ? html`
+                    <span class="ml-1.5 text-3xs opacity-70">${pipelineStageDetailLabel(k.pipeline_stage_detail)}</span>
+                  ` : null}
                 </td>
                 <td class="py-2 pr-3 text-[var(--color-fg-muted)] tabular-nums whitespace-nowrap">
                   ${lastActivityMs

--- a/dashboard/src/keeper-store-normalize.test.ts
+++ b/dashboard/src/keeper-store-normalize.test.ts
@@ -46,6 +46,24 @@ describe('normalizeKeepers phase field', () => {
       { name: 'phase-test', status: 'active', phase: 'running' },
     ])
     expect(keeper?.phase).toBe('Running')
+    expect(keeper?.lifecycle_phase).toBe('Running')
+  })
+
+  it('preserves explicit lifecycle phase and pipeline stage detail', () => {
+    const [keeper] = normalizeKeepers([
+      {
+        name: 'offline-detail-test',
+        status: 'offline',
+        phase: 'running',
+        lifecycle_phase: 'Offline',
+        pipeline_stage: 'offline',
+        pipeline_stage_detail: 'launch_pending_no_fiber',
+      },
+    ])
+    expect(keeper?.phase).toBe('Running')
+    expect(keeper?.lifecycle_phase).toBe('Offline')
+    expect(keeper?.pipeline_stage).toBe('offline')
+    expect(keeper?.pipeline_stage_detail).toBe('launch_pending_no_fiber')
   })
 
   it('normalizes handing_off to HandingOff', () => {

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -633,6 +633,10 @@ export function normalizeKeepers(raw: unknown): Keeper[] {
         // can render the keeper as "stage not known yet" rather than
         // routing an arbitrary backend string through a lying type.
         pipeline_stage: toPipelineStage(asString(row.pipeline_stage)) ?? 'unknown',
+        pipeline_stage_detail: asString(row.pipeline_stage_detail) ?? null,
+        lifecycle_phase:
+          toKeeperPhase(asString(row.lifecycle_phase))
+          ?? toKeeperPhase(asString(row.phase)),
         phase: toKeeperPhase(asString(row.phase)),
         paused: asBoolean(row.paused),
         registered:

--- a/dashboard/src/lib/keeper-predicates.test.ts
+++ b/dashboard/src/lib/keeper-predicates.test.ts
@@ -26,6 +26,9 @@ describe('isKeeperPaused — RFC-0135 PR-3 SSOT', () => {
   it('returns true on FSM phase Paused', () => {
     expect(isKeeperPaused(k({ phase: 'Paused' }))).toBe(true)
   })
+  it('returns true on lifecycle_phase Paused even when phase is stale', () => {
+    expect(isKeeperPaused(k({ lifecycle_phase: 'Paused', phase: 'Running' }))).toBe(true)
+  })
   it('returns true on lowercase phase paused from operator snapshots', () => {
     expect(isKeeperPaused({ phase: 'paused' })).toBe(true)
   })
@@ -51,6 +54,9 @@ describe('isKeeperOffline', () => {
     ['Offline'], ['Stopped'], ['Dead'], ['Crashed'], ['Zombie'],
   ])('phase=%s ⇒ offline', (phase) => {
     expect(isKeeperOffline(k({ phase }))).toBe(true)
+  })
+  it('lifecycle_phase overrides stale phase for offline classification', () => {
+    expect(isKeeperOffline(k({ lifecycle_phase: 'Offline', phase: 'Running' }))).toBe(true)
   })
   it.each(['offline', 'stopped', 'dead', 'crashed', 'zombie'])('lowercase phase=%s ⇒ offline', (phase) => {
     expect(isKeeperOffline({ phase })).toBe(true)
@@ -101,6 +107,9 @@ describe('isKeeperCrashed — audit A1 (2026-05-19)', () => {
   })
   it('undefined phase ⇒ NOT crashed', () => {
     expect(isKeeperCrashed(k())).toBe(false)
+  })
+  it('lifecycle_phase overrides stale phase for crashed classification', () => {
+    expect(isKeeperCrashed(k({ lifecycle_phase: 'Dead', phase: 'Running' }))).toBe(true)
   })
 })
 

--- a/dashboard/src/lib/keeper-predicates.ts
+++ b/dashboard/src/lib/keeper-predicates.ts
@@ -34,6 +34,7 @@ function lowerToken(value: string | null | undefined): string {
  *  normalize token casing before comparing. */
 export interface KeeperPausedInput {
   paused?: boolean | null
+  lifecycle_phase?: Keeper['lifecycle_phase'] | string | null
   phase?: Keeper['phase'] | string | null
   pipeline_stage?: Keeper['pipeline_stage'] | string | null
   pause_state?: Keeper['pause_state'] | string | null
@@ -45,6 +46,7 @@ export interface KeeperPausedInput {
  *  status `paused`. */
 export function isKeeperPaused(keeper: KeeperPausedInput): boolean {
   if (keeper.paused === true) return true
+  if (lowerToken(keeper.lifecycle_phase) === PAUSED_PHASE_LOWER) return true
   if (lowerToken(keeper.phase) === PAUSED_PHASE_LOWER) return true
   if (lowerToken(keeper.pipeline_stage) === PAUSED_LOWER_TOKEN) return true
   if (lowerToken(keeper.pause_state) === PAUSED_LOWER_TOKEN) return true
@@ -70,7 +72,7 @@ const CRASHED_PHASES: ReadonlySet<string> = new Set<string>([
 ])
 
 export function isKeeperCrashed(keeper: Keeper): boolean {
-  const phase = keeper.phase
+  const phase = keeper.lifecycle_phase ?? keeper.phase
   return typeof phase === 'string' && CRASHED_PHASES.has(phase)
 }
 
@@ -99,6 +101,7 @@ export function isCrashedPhase(phase: string | null | undefined): boolean {
  *  one of the three off-tokens (`offline | inactive | unbooted`).
  *  Routing them through this predicate closes the undercount. */
 export interface KeeperOfflineInput {
+  lifecycle_phase?: Keeper['lifecycle_phase'] | string | null
   phase?: Keeper['phase'] | string | null
   status?: string | null
 }
@@ -107,7 +110,7 @@ export interface KeeperOfflineInput {
  *  FSM phases (Offline/Stopped/Dead/Crashed/Zombie) or one of the
  *  off-tokens emitted in `keeper.status`. */
 export function isKeeperOffline(keeper: KeeperOfflineInput): boolean {
-  const phase = lowerToken(keeper.phase)
+  const phase = lowerToken(keeper.lifecycle_phase ?? keeper.phase)
   if (
     phase === 'offline'
     || phase === 'stopped'

--- a/dashboard/src/lib/keeper-runtime-display.test.ts
+++ b/dashboard/src/lib/keeper-runtime-display.test.ts
@@ -102,6 +102,34 @@ describe('keeperDisplayStatus', () => {
       })
       expect(keeperDisplayStatus(keeper)).toBe('stopped')
     })
+
+    it('uses lifecycle_phase when heartbeat is alive but status is offline', () => {
+      const keeper = makeKeeper({
+        status: 'offline',
+        phase: 'Running',
+        lifecycle_phase: 'Stopped',
+        last_heartbeat: new Date().toISOString(),
+      })
+      expect(keeperDisplayStatus(keeper)).toBe('stopped')
+    })
+
+    it('does not turn exact Offline lifecycle into idle just because heartbeat is recent', () => {
+      const keeper = makeKeeper({
+        status: 'offline',
+        lifecycle_phase: 'Offline',
+        last_heartbeat: new Date().toISOString(),
+      })
+      expect(keeperDisplayStatus(keeper)).toBe('unbooted')
+    })
+
+    it('lets terminal lifecycle override stale active status', () => {
+      const keeper = makeKeeper({
+        status: 'active',
+        phase: 'Running',
+        lifecycle_phase: 'Dead',
+      })
+      expect(keeperDisplayStatus(keeper)).toBe('dead')
+    })
   })
 })
 

--- a/dashboard/src/lib/keeper-runtime-display.ts
+++ b/dashboard/src/lib/keeper-runtime-display.ts
@@ -133,6 +133,8 @@ export function keeperActivityDisplay(
 
 export function keeperDisplayStatus(keeper: Keeper | null | undefined, fallbackStatus?: string | null): string {
   if (keeper && isKeeperPaused(keeper)) return 'paused'
+  const lifecycleStatus = keeperLifecycleStatus(keeper?.lifecycle_phase)
+  if (lifecycleStatus && lifecycleStatus !== 'running') return lifecycleStatus
   const status = keeper?.status ?? fallbackStatus
   const normalized = (status ?? '').trim().toLowerCase()
 
@@ -142,6 +144,39 @@ export function keeperDisplayStatus(keeper: Keeper | null | undefined, fallbackS
   }
 
   return status && status.trim() !== '' ? status : 'unknown'
+}
+
+function keeperLifecycleStatus(phase: Keeper['lifecycle_phase'] | string | null | undefined): string | null {
+  switch (phase) {
+    case 'Offline':
+      return 'unbooted'
+    case 'Running':
+      return 'running'
+    case 'Failing':
+      return 'failing'
+    case 'Overflowed':
+      return 'overflowed'
+    case 'Compacting':
+      return 'compacting'
+    case 'HandingOff':
+      return 'handoff'
+    case 'Draining':
+      return 'draining'
+    case 'Paused':
+      return 'paused'
+    case 'Stopped':
+      return 'stopped'
+    case 'Crashed':
+      return 'crashed'
+    case 'Restarting':
+      return 'restarting'
+    case 'Dead':
+      return 'dead'
+    case 'Zombie':
+      return 'zombie'
+    default:
+      return null
+  }
 }
 
 function codeLabel(value: string | null | undefined): string | null {
@@ -228,7 +263,7 @@ function refineOfflineStatus(keeper: Keeper | null | undefined): string {
   // only the 13 PascalCase phases, none of which lowercase to
   // `'inactive'`), so the guard was dead defensive.
   if (keeper.last_heartbeat && isHeartbeatAlive(keeper.last_heartbeat)) {
-    const phase = keeper.phase?.trim().toLowerCase()
+    const phase = (keeper.lifecycle_phase ?? keeper.phase)?.trim().toLowerCase()
     if (phase && phase !== 'offline') return phase
     return 'idle'
   }

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -887,6 +887,8 @@ export interface Keeper {
   name: string
   keeper_id?: string | null
   pipeline_stage?: PipelineStage
+  pipeline_stage_detail?: string | null
+  lifecycle_phase?: KeeperPhase | null
   phase?: KeeperPhase | null
   runtime_class?: 'keeper'
   paused?: boolean

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -537,15 +537,31 @@ let keepers_dashboard_json ?(compact = false) (config : Workspace.config) : Yojs
                   ("trust_observatory", trust_observatory);
                 ]
               in
-              let profile = Dashboard_execution_helpers.get_agent_profile m.name in
-	            `Assoc ([
-              ("name", `String m.name);
-              ("pipeline_stage", `String
-                (match registry_entry with
-                 | Some entry ->
-                   Keeper_status_runtime.pipeline_stage_of_phase entry.phase
-                 | None -> "offline"));
-              ("runtime_class", `String "keeper");
+	              let profile = Dashboard_execution_helpers.get_agent_profile m.name in
+	              let lifecycle_phase =
+	                Option.map
+	                  (fun (entry : Keeper_registry.registry_entry) ->
+	                    Keeper_state_machine.phase_to_string entry.phase)
+	                  registry_entry
+	              in
+	              let pipeline_stage =
+	                match registry_entry with
+	                | Some entry ->
+	                  Keeper_status_runtime.pipeline_stage_of_phase entry.phase
+	                | None -> "offline"
+	              in
+	              let pipeline_stage_detail =
+	                match registry_entry with
+	                | Some entry ->
+	                  Keeper_status_runtime.pipeline_stage_detail_of_phase entry.phase
+	                | None -> "registry_absent"
+	              in
+		            `Assoc ([
+	              ("name", `String m.name);
+	              ("pipeline_stage", `String pipeline_stage);
+	              ("lifecycle_phase", Json_util.string_opt_to_json lifecycle_phase);
+	              ("pipeline_stage_detail", `String pipeline_stage_detail);
+	              ("runtime_class", `String "keeper");
               ("phase", Json_util.string_opt_to_json phase);
               ("conditions", conditions_json);
               ("outcomes", outcomes_json);

--- a/lib/dashboard/dashboard_http_keeper_snapshot.ml
+++ b/lib/dashboard/dashboard_http_keeper_snapshot.ml
@@ -350,6 +350,14 @@ let keeper_config_json (config : Workspace.config) (name : string)
         | Some phase -> Keeper_status_runtime.pipeline_stage_of_phase phase
         | None -> "offline"
       in
+      let lifecycle_phase =
+        Option.map Keeper_state_machine.phase_to_string current_phase
+      in
+      let pipeline_stage_detail =
+        match current_phase with
+        | Some phase -> Keeper_status_runtime.pipeline_stage_detail_of_phase phase
+        | None -> "registry_absent"
+      in
       let state_diagram =
         Keeper_state_machine_mermaid.phase_to_mermaid
           ~current:(Option.value ~default:Keeper_state_machine.Offline current_phase)
@@ -391,11 +399,13 @@ let keeper_config_json (config : Workspace.config) (name : string)
          ("network_mode", `String (Keeper_types_profile_sandbox.network_mode_to_string m.network_mode));         ("sandbox_last_error", Json_util.string_opt_to_json sandbox_last_error);
          ("allowed_paths",
            `List (List.map (fun s -> `String s) m.allowed_paths));
-         ("effective_allowed_paths",
-           `List (List.map (fun s -> `String s)
-             (Keeper_alerting_path.effective_allowed_paths ~meta:m)));
-         ("pipeline_stage", `String pipeline_stage);
-         ("state_diagram", `String state_diagram);
+	         ("effective_allowed_paths",
+	           `List (List.map (fun s -> `String s)
+	             (Keeper_alerting_path.effective_allowed_paths ~meta:m)));
+	         ("pipeline_stage", `String pipeline_stage);
+	         ("lifecycle_phase", Json_util.string_opt_to_json lifecycle_phase);
+	         ("pipeline_stage_detail", `String pipeline_stage_detail);
+	         ("state_diagram", `String state_diagram);
          ("decision_pipeline_diagram", `String decision_pipeline_diagram);
          ("prompt", prompt);
          ("execution", execution);

--- a/lib/keeper/keeper_status_runtime.ml
+++ b/lib/keeper/keeper_status_runtime.ml
@@ -548,3 +548,22 @@ let pipeline_stage_of_phase (phase : Keeper_state_machine.phase) : string =
   | Keeper_state_machine.Crashed -> "crashed"
   | Keeper_state_machine.Restarting -> "restarting"
   | Keeper_state_machine.Dead | Keeper_state_machine.Zombie -> "offline"
+
+(** Explain the lossy [pipeline_stage] label without changing its wire value.
+    Consumers that need exact lifecycle authority should read [lifecycle_phase];
+    this field explains why two phases can share a single stage label. *)
+let pipeline_stage_detail_of_phase (phase : Keeper_state_machine.phase) : string =
+  match phase with
+  | Keeper_state_machine.Offline -> "launch_pending_no_fiber"
+  | Keeper_state_machine.Running -> "phase_running_idle"
+  | Keeper_state_machine.Failing -> "health_or_turn_failure_probe"
+  | Keeper_state_machine.Overflowed -> "context_overflow_pending_compaction"
+  | Keeper_state_machine.Compacting -> "context_compaction_in_progress"
+  | Keeper_state_machine.HandingOff -> "generation_handoff_in_progress"
+  | Keeper_state_machine.Draining -> "graceful_shutdown_draining"
+  | Keeper_state_machine.Paused -> "operator_or_policy_paused"
+  | Keeper_state_machine.Stopped -> "clean_stop_terminal"
+  | Keeper_state_machine.Crashed -> "crashed_restart_candidate"
+  | Keeper_state_machine.Restarting -> "supervisor_restart_backoff_elapsed"
+  | Keeper_state_machine.Dead -> "restart_budget_exhausted_terminal"
+  | Keeper_state_machine.Zombie -> "structural_failure_terminal"

--- a/lib/keeper/keeper_status_runtime.mli
+++ b/lib/keeper/keeper_status_runtime.mli
@@ -56,3 +56,8 @@ val keeper_surface_status :
 (** Derive pipeline stage directly from phase (RFC-0002).
     Deterministic mapping, no 30s recency heuristic. *)
 val pipeline_stage_of_phase : Keeper_state_machine.phase -> string
+
+(** Human/operator-facing explanation for the lossy [pipeline_stage] label.
+    For example, [Offline], [Stopped], and [Dead] all map to ["offline"],
+    but their detail strings remain distinct. *)
+val pipeline_stage_detail_of_phase : Keeper_state_machine.phase -> string

--- a/lib/server/server_routes_http_runtime.mli
+++ b/lib/server/server_routes_http_runtime.mli
@@ -136,13 +136,14 @@ val make_health_json :
 
     [paused_keepers.count] and [paused_keepers.names] are the union of
     registry-visible paused keepers and durable [.masc/keepers/*.json]
-    metas with [paused = true].  The nested [running_*] and
+    metas with [paused = true].  The nested [registry_paused_*] and
     [durable_*] fields keep the two sources inspectable so a keeper
     that has been auto-paused and removed from the live keepalive set
-    does not disappear from [/health].  [autoboot_enabled_*] and
-    [details] distinguish auto-recoverable, operator-paused, and
-    reconcile-gated durable pauses without auto-unpausing them.
-    [missing_pause_root_cause] is true when a keeper is auto-recoverable
+    does not disappear from [/health].  [running_*] remains as a legacy
+    alias for [registry_paused_*]; it does not mean FSM phase [Running].
+    [autoboot_enabled_*] and [details] distinguish auto-recoverable,
+    operator-paused, and reconcile-gated durable pauses without auto-unpausing
+    them.  [missing_pause_root_cause] is true when a keeper is auto-recoverable
     but its persisted runtime has no typed [last_blocker].  [read_error_count]
     surfaces corrupt durable meta instead of silently reporting a clean zero.
 

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -81,11 +81,13 @@ let paused_keeper_detail_json ~now ~name ~(autoboot_enabled : bool)
          && Option.is_none meta.runtime.last_blocker) );
   ]
 
-let running_paused_keeper_names () =
+let registry_paused_keeper_names () =
   Keeper_registry.all ()
   |> List.filter_map (fun (e : Keeper_registry.registry_entry) ->
        if e.meta.paused then Some e.name else None)
   |> sorted_unique_strings
+
+let running_paused_keeper_names = registry_paused_keeper_names
 
 let running_keeper_names ?base_path () =
   Keeper_registry.all ?base_path ()
@@ -160,8 +162,12 @@ let paused_keepers_health_json_of_scan ~running_names durable_scan =
   `Assoc [
     ("count", `Int (List.length names));
     ("names", `List (List.map (fun name -> `String name) names));
+    ("registry_paused_count", `Int (List.length running_names));
+    ("registry_paused_names", `List (List.map (fun name -> `String name) running_names));
+    ("registry_paused_semantics", `String "registered keepers whose persisted meta has paused=true; this is not FSM phase=Running");
     ("running_count", `Int (List.length running_names));
     ("running_names", `List (List.map (fun name -> `String name) running_names));
+    ("running_count_semantics", `String "legacy alias for registry_paused_count");
     ("durable_count", `Int (List.length durable_scan.names));
     ("durable_names", `List (List.map (fun name -> `String name) durable_scan.names));
     ( "autoboot_enabled_count",

--- a/lib/server/server_routes_http_runtime_fleet_scan.mli
+++ b/lib/server/server_routes_http_runtime_fleet_scan.mli
@@ -23,17 +23,22 @@ val paused_keeper_detail_json :
   autoboot_enabled:bool ->
   Keeper_meta_contract.keeper_meta ->
   [> `Assoc of (string * Yojson.Safe.t) list ]
+val registry_paused_keeper_names : unit -> String.t list
 val running_paused_keeper_names : unit -> String.t list
 val durable_paused_keeper_scan :
   ?include_details:bool -> Workspace.config -> paused_keeper_scan
 val paused_keepers_health_json_of_scan :
   running_names:String.t list ->
   paused_keeper_scan ->
-  [> `Assoc of (string * [> `Int of int | `List of Yojson.Safe.t list ]) list
+  [> `Assoc of
+       (string * [> `Int of int | `List of Yojson.Safe.t list | `String of string ])
+       list
   ]
 val paused_keepers_health_json :
   unit ->
-  [> `Assoc of (string * [> `Int of int | `List of Yojson.Safe.t list ]) list
+  [> `Assoc of
+       (string * [> `Int of int | `List of Yojson.Safe.t list | `String of string ])
+       list
   ]
 val running_keeper_names : ?base_path:string -> unit -> String.t list
 type autoboot_keeper_scan = {

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -632,6 +632,24 @@ let test_pipeline_stage_of_phase_exhaustive () =
       expected actual
   ) cases
 
+let test_pipeline_stage_detail_distinguishes_offline_projection () =
+  let cases = [
+    (KSM.Offline, "offline", "launch_pending_no_fiber");
+    (KSM.Stopped, "offline", "clean_stop_terminal");
+    (KSM.Dead, "offline", "restart_budget_exhausted_terminal");
+  ] in
+  List.iter
+    (fun (phase, expected_stage, expected_detail) ->
+       check string
+         (Printf.sprintf "%s stage" (KSM.phase_to_string phase))
+         expected_stage
+         (ES.pipeline_stage_of_phase phase);
+       check string
+         (Printf.sprintf "%s stage detail" (KSM.phase_to_string phase))
+         expected_detail
+         (ES.pipeline_stage_detail_of_phase phase))
+    cases
+
 (** Verify non-registered keepers → get_phase returns None, and
     registered keepers in every phase → pipeline_stage_of_phase produces
     a non-None mapping. This tests the production boundary:
@@ -728,11 +746,13 @@ let () =
       test_case "resolve_done reports prior outcome" `Quick
         test_resolve_done_reports_prior_outcome;
     ];
-    "pipeline_stage_phase", [
-      test_case "exhaustive 11-phase mapping" `Quick
-        test_pipeline_stage_of_phase_exhaustive;
-      test_case "unregistered keeper → offline" `Quick
-        test_pipeline_stage_unregistered_is_offline;
+	    "pipeline_stage_phase", [
+	      test_case "exhaustive 11-phase mapping" `Quick
+	        test_pipeline_stage_of_phase_exhaustive;
+	      test_case "offline projection details remain distinct" `Quick
+	        test_pipeline_stage_detail_distinguishes_offline_projection;
+	      test_case "unregistered keeper → offline" `Quick
+	        test_pipeline_stage_unregistered_is_offline;
       test_case "sensitivity: active phases ≠ offline" `Quick
         test_pipeline_stage_sensitivity;
     ];

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1019,11 +1019,19 @@ let test_health_json_surfaces_durable_paused_keepers () =
           let durable_names =
             paused |> member "durable_names" |> to_list |> List.map to_string
           in
-          let names = paused |> member "names" |> to_list |> List.map to_string in
-          Alcotest.(check int) "durable paused count" 1
-            (paused |> member "durable_count" |> to_int);
-          Alcotest.(check (list string)) "durable paused names"
-            [ "durable-paused" ] durable_names;
+	          let names = paused |> member "names" |> to_list |> List.map to_string in
+	          Alcotest.(check int) "durable paused count" 1
+	            (paused |> member "durable_count" |> to_int);
+	          Alcotest.(check int) "registry paused count" 0
+	            (paused |> member "registry_paused_count" |> to_int);
+	          Alcotest.(check string) "legacy running count semantics"
+	            "legacy alias for registry_paused_count"
+	            (paused |> member "running_count_semantics" |> to_string);
+	          Alcotest.(check string) "registry paused semantics"
+	            "registered keepers whose persisted meta has paused=true; this is not FSM phase=Running"
+	            (paused |> member "registry_paused_semantics" |> to_string);
+	          Alcotest.(check (list string)) "durable paused names"
+	            [ "durable-paused" ] durable_names;
           Alcotest.(check int) "durable paused autoboot count" 1
             (paused |> member "autoboot_enabled_count" |> to_int);
           Alcotest.(check (list string)) "durable paused autoboot names"


### PR DESCRIPTION
## Summary

Clarify keeper lifecycle state reporting across the backend dashboard JSON and frontend display layers.

- Add `lifecycle_phase` and `pipeline_stage_detail` beside the existing lossy `pipeline_stage` value.
- Distinguish `Offline`, `Stopped`, `Dead`, and `Zombie` even when they still project to `pipeline_stage="offline"` for compatibility.
- Preserve and prefer `lifecycle_phase` in the dashboard normalizer, predicates, and display helpers so stale `status` values do not win over exact FSM truth.
- Render operator-facing reason labels such as `기동 대기`, `정상 정지`, `재시작 한도 소진`, and `구조 실패` instead of raw snake_case detail strings.
- Clarify paused-keeper health JSON by adding `registry_paused_*` fields while keeping legacy `running_*` aliases documented.

## Root Cause

The backend already had exact keeper FSM phases, but dashboard projections collapsed several distinct phases into `pipeline_stage="offline"`. Frontend normalization also dropped the new exact/detail fields, so user-facing surfaces could still display ambiguous or stale state.

## Validation

- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_codex_clarify_states dune build --root . test/test_heartbeat_integration.exe test/test_server_runtime_bootstrap.exe`
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_codex_clarify_states ./_build_codex_clarify_states/default/test/test_heartbeat_integration.exe`
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_codex_clarify_states ./_build_codex_clarify_states/default/test/test_server_runtime_bootstrap.exe test bootstrap 22`
- `pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/keeper-phase-indicator.test.ts src/keeper-store-normalize.test.ts src/lib/keeper-predicates.test.ts src/lib/keeper-runtime-display.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `git diff --check`