### PR TITLE
fix(dashboard): render keeper chat attachments

### DIFF
--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -101,6 +101,44 @@ describe('ChatTranscript', () => {
     expect(latestBody).toBe('')
   })
 
+  it('renders attachments even when metadata is hidden', () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          entry({
+            id: 'u1',
+            text: '첨부 확인',
+            attachments: [
+              {
+                id: 'att-1',
+                type: 'image',
+                name: 'screenshot.png',
+                size: 1024,
+                mimeType: 'image/png',
+                data: 'data:image/png;base64,abc123',
+              },
+              {
+                id: 'att-2',
+                type: 'file',
+                name: 'log.txt',
+                size: 512,
+                mimeType: 'text/plain',
+                data: 'data:text/plain;base64,bG9n',
+              },
+            ],
+          }),
+        ]}
+        emptyText="empty"
+        showMetadata=${false}
+      />`,
+      container,
+    )
+
+    expect(container.querySelector('img[alt="screenshot.png"]')).not.toBeNull()
+    expect(container.textContent).toContain('log.txt')
+    expect(container.textContent).not.toContain('상세 보기')
+  })
+
   it('does not show streaming ellipsis before elapsed time starts', () => {
     render(
       html`<${ChatComposer}

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -6,7 +6,7 @@ import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import { ActionButton } from '../common/button'
 import { formatTimeHms } from '../../lib/format-time'
 import { formatCost } from '../../lib/format-number'
-import type { KeeperConversationDetails, KeeperConversationEntry } from '../../types'
+import type { KeeperConversationAttachment, KeeperConversationDetails, KeeperConversationEntry } from '../../types'
 
 type ChatTranscriptVariant = 'default' | 'messenger'
 
@@ -104,6 +104,79 @@ function overviewRows(details: KeeperConversationDetails): Array<{ label: string
   ].filter((row): row is { label: string; value: string } => Boolean(row))
 }
 
+function formatAttachmentSize(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0 B'
+  if (bytes < 1024) return `${Math.round(bytes)} B`
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+function isSafeAttachmentHref(attachment: KeeperConversationAttachment): boolean {
+  if (attachment.type === 'image') return attachment.data.startsWith('data:image/')
+  return (
+    attachment.data.startsWith('data:text/')
+    || attachment.data.startsWith('data:application/json')
+  )
+}
+
+function isRenderableImageAttachment(attachment: KeeperConversationAttachment): boolean {
+  return attachment.type === 'image' && attachment.data.startsWith('data:image/')
+}
+
+function attachmentMeta(attachment: KeeperConversationAttachment): string {
+  return [attachment.mimeType, formatAttachmentSize(attachment.size)].filter(Boolean).join(' · ')
+}
+
+function renderAttachmentCard(attachment: KeeperConversationAttachment) {
+  const canLink = isSafeAttachmentHref(attachment)
+  const meta = attachmentMeta(attachment)
+  const content = isRenderableImageAttachment(attachment)
+    ? html`
+        <img
+          src=${attachment.data}
+          alt=${attachment.name}
+          class="max-h-52 w-full rounded-[var(--r-1)] object-contain"
+          loading="lazy"
+        />
+      `
+    : html`
+        <div class="flex min-h-18 items-center gap-3 px-3 py-3">
+          <span class="inline-flex h-9 w-11 shrink-0 items-center justify-center rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] text-3xs font-semibold uppercase tracking-3 text-[var(--color-fg-muted)]">
+            FILE
+          </span>
+          <div class="min-w-0">
+            <div class="truncate text-xs font-semibold text-[var(--color-fg-secondary)]">${attachment.name}</div>
+            <div class="mt-1 text-2xs text-[var(--color-fg-muted)]">${meta}</div>
+          </div>
+        </div>
+      `
+
+  return html`
+    <div class="overflow-hidden rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]">
+      ${canLink
+        ? html`
+            <a
+              href=${attachment.data}
+              download=${attachment.name}
+              class="block hover:bg-[var(--color-bg-hover)]"
+              aria-label=${`${attachment.name} 내려받기`}
+            >
+              ${content}
+            </a>
+          `
+        : content}
+      ${isRenderableImageAttachment(attachment)
+        ? html`
+            <div class="border-t border-[var(--color-border-default)] px-3 py-2">
+              <div class="truncate text-xs font-semibold text-[var(--color-fg-secondary)]">${attachment.name}</div>
+              <div class="mt-1 text-2xs text-[var(--color-fg-muted)]">${meta}</div>
+            </div>
+          `
+        : null}
+    </div>
+  `
+}
+
 function ChatMessageBubble({
   entry,
   showMetadata = true,
@@ -130,6 +203,7 @@ function ChatMessageBubble({
   const state = stateRows(entry.details?.stateBlock)
   const delivery = deliveryLabel(entry)
   const timestamp = timeLabel(entry.timestamp)
+  const attachments = entry.attachments ?? []
 
   return html`
     <article
@@ -246,6 +320,13 @@ function ChatMessageBubble({
             >
               ${messageCollapsed ? '더 보기' : '접기'}
             </button>
+          `
+        : null}
+      ${attachments.length > 0
+        ? html`
+            <div class="grid grid-cols-[repeat(auto-fit,minmax(11rem,1fr))] gap-2">
+              ${attachments.map(attachment => renderAttachmentCard(attachment))}
+            </div>
           `
         : null}
       ${entry.error

--- a/dashboard/src/components/keeper-chat-panel.ts
+++ b/dashboard/src/components/keeper-chat-panel.ts
@@ -117,7 +117,8 @@ function toConversationEntry(
     timestamp: new Date(msg.timestamp).toISOString(),
     delivery: 'delivered',
     streamState: null,
-    details: msg.attachments ? { rawPayload: { attachments: msg.attachments } } : null,
+    attachments: msg.attachments,
+    details: null,
   }
 }
 

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -692,6 +692,15 @@ export interface KeeperConversationDetails {
   rawPayload?: unknown
 }
 
+export interface KeeperConversationAttachment {
+  id: string
+  type: 'image' | 'file'
+  name: string
+  size: number
+  mimeType: string
+  data: string
+}
+
 export type KeeperConversationStreamState =
   | 'opening'
   | 'streaming'
@@ -708,6 +717,7 @@ export interface KeeperConversationEntry {
   timestamp?: string | null
   delivery: KeeperConversationDelivery
   streamState?: KeeperConversationStreamState
+  attachments?: KeeperConversationAttachment[]
   details?: KeeperConversationDetails | null
   error?: string | null
 }


### PR DESCRIPTION
Follow-up for merged PR #20205 review comment: https://github.com/jeong-sik/masc-mcp/pull/20205#discussion_r3361017009

Summary:
- Add first-class keeper conversation attachments instead of hiding them in raw metadata.
- Render image/file attachments in the normal chat message body path.
- Keep attachments visible when the keeper chat transcript runs with showMetadata=false.

Validation:
- pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/chat/primitives.test.ts src/keeper-chat-store.test.ts
- pnpm run typecheck
- pnpm run lint
- pnpm run build
- git diff --check