### PR TITLE
[RFC-0217] Server-side attachment support for keeper chat

### DIFF
--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -357,28 +357,50 @@ function isTerminalKeeperStreamEvent(event: KeeperChatStreamEvent): boolean {
   return event.type === 'RUN_FINISHED' || event.type === 'RUN_ERROR'
 }
 
+export interface StreamAttachment {
+  id: string
+  type: 'image' | 'file'
+  name: string
+  size: number
+  mimeType: string
+  data: string
+}
+
 export async function streamKeeperMessage(
   name: string,
   message: string,
   {
     signal,
     onEvent,
+    attachments,
   }: {
     signal?: AbortSignal
     onEvent: (event: KeeperChatStreamEvent) => void
+    attachments?: StreamAttachment[]
   },
 ): Promise<void> {
+  const body: Record<string, unknown> = {
+    name,
+    message,
+    direct_reply: true,
+  }
+  if (attachments && attachments.length > 0) {
+    body.attachments = attachments.map(att => ({
+      id: att.id,
+      type: att.type,
+      name: att.name,
+      size: att.size,
+      mime_type: att.mimeType,
+      data: att.data,
+    }))
+  }
   const res = await fetch('/api/v1/keepers/chat/stream', {
     method: 'POST',
     headers: {
       ...jsonHeaders(),
       Accept: 'text/event-stream',
     },
-    body: JSON.stringify({
-      name,
-      message,
-      direct_reply: true,
-      }),
+    body: JSON.stringify(body),
     signal,
   })
 

--- a/dashboard/src/components/keeper-chat-panel.ts
+++ b/dashboard/src/components/keeper-chat-panel.ts
@@ -12,6 +12,7 @@ import {
   streamKeeperMessage,
   fetchKeeperChatHistory,
   type KeeperChatStreamEvent,
+  type StreamAttachment,
 } from '../api/keeper'
 import { asString, isRecord } from './common/normalize'
 import { showToast } from './common/toast'
@@ -274,9 +275,20 @@ export function KeeperChatPanel({ name }: { name: string }) {
     streaming.value = true
     activeAbortRef.current = new AbortController()
 
+    const apiAttachments: StreamAttachment[] | undefined =
+      userMsg.attachments?.map((att) => ({
+        id: att.id,
+        type: att.type,
+        name: att.name,
+        size: att.size,
+        mimeType: att.mimeType,
+        data: att.data,
+      }))
+
     try {
       await streamKeeperMessage(keeperName, text, {
         signal: activeAbortRef.current.signal,
+        attachments: apiAttachments,
         onEvent: (event: KeeperChatStreamEvent) => {
           if (isKeeperTextContentEvent(event) && typeof event.delta === 'string') {
             streamBuffer.value += event.delta

--- a/lib/keeper/keeper_chat_queue.ml
+++ b/lib/keeper/keeper_chat_queue.ml
@@ -1,0 +1,65 @@
+(** Keeper_chat_queue — thread-safe per-keeper message queue.
+
+    Each keeper owns an in-memory FIFO queue for chat messages that
+    arrive while the keeper is already processing a previous message.
+    When a stream finishes, the queue is drained automatically.
+
+    The queue is transient (not persisted).  Lost on server restart.
+
+    @since 2.145.0 *)
+
+type queued_message = {
+  content : string;
+  attachments : Keeper_chat_store.attachment list;
+  timestamp : float;
+}
+
+type queue_entry = {
+  mutex : Eio.Mutex.t;
+  q : queued_message Queue.t;
+}
+
+(** Global registry protected by a single mutex.
+    Per-keeper queues have their own mutex for independent enqueue/dequeue
+    parallelism; the global mutex is only for lookup/insertion into the
+    registry. *)
+let registry_mutex = Eio.Mutex.create ()
+let registry : (string, queue_entry) Hashtbl.t = Hashtbl.create 16
+
+let get_or_create_entry keeper_name =
+  match Hashtbl.find_opt registry keeper_name with
+  | Some entry -> entry
+  | None ->
+      let entry = { mutex = Eio.Mutex.create (); q = Queue.create () } in
+      Hashtbl.add registry keeper_name entry;
+      entry
+
+let enqueue ~keeper_name msg =
+  Eio.Mutex.use_rw ~protect:true registry_mutex (fun () ->
+      let entry = get_or_create_entry keeper_name in
+      Eio.Mutex.use_rw ~protect:true entry.mutex (fun () ->
+          Queue.push msg entry.q))
+
+let dequeue ~keeper_name =
+  Eio.Mutex.use_rw ~protect:true registry_mutex (fun () ->
+      match Hashtbl.find_opt registry keeper_name with
+      | None -> None
+      | Some entry ->
+          Eio.Mutex.use_rw ~protect:true entry.mutex (fun () ->
+              if Queue.is_empty entry.q then None else Some (Queue.pop entry.q)))
+
+let length ~keeper_name =
+  Eio.Mutex.use_rw ~protect:true registry_mutex (fun () ->
+      match Hashtbl.find_opt registry keeper_name with
+      | None -> 0
+      | Some entry ->
+          Eio.Mutex.use_rw ~protect:true entry.mutex (fun () ->
+              Queue.length entry.q))
+
+let clear ~keeper_name =
+  Eio.Mutex.use_rw ~protect:true registry_mutex (fun () ->
+      match Hashtbl.find_opt registry keeper_name with
+      | None -> ()
+      | Some entry ->
+          Eio.Mutex.use_rw ~protect:true entry.mutex (fun () ->
+              Queue.clear entry.q))

--- a/lib/keeper/keeper_chat_queue.mli
+++ b/lib/keeper/keeper_chat_queue.mli
@@ -1,0 +1,33 @@
+(** Keeper_chat_queue — thread-safe per-keeper message queue.
+
+    Each keeper owns an in-memory FIFO queue for chat messages that
+    arrive while the keeper is already processing a previous message.
+    When a stream finishes, the queue is drained automatically.
+
+    The queue is transient (not persisted).  Lost on server restart.
+
+    @since 2.145.0 *)
+
+(** {1 Types} *)
+
+type queued_message = {
+  content : string;
+  attachments : Keeper_chat_store.attachment list;
+  timestamp : float;
+}
+
+(** {1 Queue operations} *)
+
+(** [enqueue keeper_name msg] adds [msg] to the tail of [keeper_name]'s
+    queue.  Creates the queue lazily if it does not yet exist. *)
+val enqueue : keeper_name:string -> queued_message -> unit
+
+(** [dequeue keeper_name] removes and returns the head message, or
+    [None] if the queue is empty or does not exist. *)
+val dequeue : keeper_name:string -> queued_message option
+
+(** [length keeper_name] returns the number of queued messages. *)
+val length : keeper_name:string -> int
+
+(** [clear keeper_name] empties the queue. *)
+val clear : keeper_name:string -> unit

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -36,23 +36,54 @@ let report_persistence_read_drop ~reason ~path ~detail =
 let ensure_dir_once ~base_dir =
   ignore (Keeper_fs.ensure_dir (chat_dir base_dir))
 
-let encode_line ~role ~content ~ts : string =
-  Yojson.Safe.to_string
-    (`Assoc
-       [
-         ("role", `String role);
-         ("content", `String content);
-         ("ts", `Float ts);
-       ])
+type attachment = {
+  id : string;
+  att_type : string;
+  name : string;
+  size : int;
+  mime_type : string;
+  data : string;
+}
+
+type chat_message = {
+  role : string;
+  content : string;
+  ts : float option;
+  attachments : attachment list option;
+}
+
+let encode_line ~role ~content ~ts ?attachments () : string =
+  let base_fields = [
+    ("role", `String role);
+    ("content", `String content);
+    ("ts", `Float ts);
+  ] in
+  let all_fields =
+    match attachments with
+    | None | Some [] -> base_fields
+    | Some atts ->
+        let att_json = List.map (fun att ->
+          `Assoc [
+            ("id", `String att.id);
+            ("type", `String att.att_type);
+            ("name", `String att.name);
+            ("size", `Int att.size);
+            ("mime_type", `String att.mime_type);
+            ("data", `String att.data);
+          ]
+        ) atts in
+        ("attachments", `List att_json) :: base_fields
+  in
+  Yojson.Safe.to_string (`Assoc all_fields)
 
 let append_pair ~base_dir ~keeper_name
-    ~(user_content : string) ~(assistant_content : string) =
+    ~(user_content : string) ~(assistant_content : string) ~(user_attachments : attachment list) =
   try
     ensure_dir_once ~base_dir;
     let path = chat_path ~base_dir ~keeper_name in
     let ts = Time_compat.now () in
-    let user_line = encode_line ~role:"user" ~content:user_content ~ts in
-    let asst_line = encode_line ~role:"assistant" ~content:assistant_content ~ts in
+    let user_line = encode_line ~role:"user" ~content:user_content ~ts ~attachments:user_attachments () in
+    let asst_line = encode_line ~role:"assistant" ~content:assistant_content ~ts () in
     Fs_compat.append_file path (user_line ^ "\n" ^ asst_line ^ "\n")
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
@@ -64,12 +95,6 @@ let append_pair ~base_dir ~keeper_name
     Log.Keeper.warn "keeper_chat_store: append failed for %s: %s"
       (sanitize_name keeper_name) (Printexc.to_string exn)
 
-type chat_message = {
-  role : string;
-  content : string;
-  ts : float option;
-}
-
 let parse_line ~file_path (line : string) : chat_message option =
   try
     let json = Yojson.Safe.from_string line in
@@ -78,13 +103,35 @@ let parse_line ~file_path (line : string) : chat_message option =
     let ts =
       (try Some ((match Json_util.assoc_member_opt "ts" json with Some (`Float f) -> f | _ -> 0.0))
        with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None) in
+    let attachments =
+      match Json_util.assoc_member_opt "attachments" json with
+      | Some (`List att_list) ->
+          let atts = List.filter_map (fun att_json ->
+            match att_json with
+            | `Assoc _ ->
+                (try
+                  let id = Json_util.get_string_with_default att_json ~key:"id" ~default:"" in
+                  let att_type = Json_util.get_string_with_default att_json ~key:"type" ~default:"" in
+                  let name = Json_util.get_string_with_default att_json ~key:"name" ~default:"" in
+                  let size = (match Json_util.assoc_member_opt "size" att_json with
+                    | Some (`Int i) -> i | _ -> 0) in
+                  let mime_type = Json_util.get_string_with_default att_json ~key:"mime_type" ~default:"" in
+                  let data = Json_util.get_string_with_default att_json ~key:"data" ~default:"" in
+                  if id = "" || data = "" then None
+                  else Some { id; att_type; name; size; mime_type; data }
+                with _ -> None)
+            | _ -> None
+          ) att_list in
+          if atts = [] then None else Some atts
+      | _ -> None
+    in
     if role = "" || content = "" then (
       report_persistence_read_drop
         ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
         ~path:file_path
         ~detail:"chat row missing non-empty role/content";
       None)
-    else Some { role; content; ts }
+    else Some { role; content; ts; attachments }
   with Yojson.Json_error detail ->
     report_persistence_read_drop
       ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
@@ -139,5 +186,19 @@ let to_json_array (messages : chat_message list) : Yojson.Safe.t =
               ("content", `String m.content);
             ] @ (match m.ts with
                  | Some t -> [("ts", `Float t)]
-                 | None -> [])))
+                 | None -> [])
+              @ (match m.attachments with
+                 | None | Some [] -> []
+                 | Some atts ->
+                     let att_json = List.map (fun att ->
+                       `Assoc [
+                         ("id", `String att.id);
+                         ("type", `String att.att_type);
+                         ("name", `String att.name);
+                         ("size", `Int att.size);
+                         ("mime_type", `String att.mime_type);
+                         ("data", `String att.data);
+                       ]
+                     ) atts in
+                     [("attachments", `List att_json)])))
        messages)

--- a/lib/keeper/keeper_chat_store.mli
+++ b/lib/keeper/keeper_chat_store.mli
@@ -10,10 +10,20 @@
 
 (** {1 Types} *)
 
+type attachment = {
+  id : string;
+  att_type : string;
+  name : string;
+  size : int;
+  mime_type : string;
+  data : string;
+}
+
 type chat_message = {
   role : string;
   content : string;
   ts : float option;
+  attachments : attachment list option;
 }
 
 (** {1 I/O} *)
@@ -27,6 +37,7 @@ val append_pair :
   keeper_name:string ->
   user_content:string ->
   assistant_content:string ->
+  user_attachments:attachment list ->
   unit
 
 (** [load ~base_dir ~keeper_name] returns the most recent

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -544,7 +544,8 @@ let append_direct_chat_pair_if_reply ~(config : Workspace.config) ~name ~args re
           ~base_dir:config.base_path
           ~keeper_name:name
           ~user_content
-          ~assistant_content)
+          ~assistant_content
+          ~user_attachments:[])
 ;;
 
 (* RFC-0182 Phase 5 PR-B: ctx-free body for [masc_keeper_msg] descriptor

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -12,6 +12,7 @@ type keeper_chat_stream_request = {
   channel_user_id : string;
   channel_user_name : string;
   channel_workspace_id : string;
+  attachments : Keeper_chat_store.attachment list;
 }
 
 let keeper_chat_stream_error_json message =
@@ -219,6 +220,41 @@ let parse_keeper_chat_stream_request body_str =
         | Some (`Int _) | Some (`Float _) -> Ok None
         | Some _ -> Error "timeout_sec must be a positive number"
       in
+      let attachments : Keeper_chat_store.attachment list =
+        match Json_util.assoc_member_opt "attachments" json with
+        | Some (`List att_list) ->
+            List.filter_map
+              (fun att_json ->
+                match att_json with
+                | `Assoc _ -> (
+                    try
+                      let id =
+                        Json_util.get_string_with_default att_json ~key:"id" ~default:""
+                      in
+                      let att_type =
+                        Json_util.get_string_with_default att_json ~key:"type" ~default:""
+                      in
+                      let name =
+                        Json_util.get_string_with_default att_json ~key:"name" ~default:""
+                      in
+                      let size =
+                        match Json_util.assoc_member_opt "size" att_json with
+                        | Some (`Int i) -> i
+                        | _ -> 0
+                      in
+                      let mime_type =
+                        Json_util.get_string_with_default att_json ~key:"mime_type" ~default:""
+                      in
+                      let data =
+                        Json_util.get_string_with_default att_json ~key:"data" ~default:""
+                      in
+                      if id = "" || data = "" then None
+                      else Some { Keeper_chat_store.id; att_type; name; size; mime_type; data }
+                    with _ -> None)
+                | _ -> None)
+              att_list
+        | _ -> []
+      in
       if name = "" then
         Error "name is required"
       else if message = "" then
@@ -245,6 +281,7 @@ let parse_keeper_chat_stream_request body_str =
                   channel_user_id;
                   channel_user_name;
                   channel_workspace_id;
+                  attachments;
                 }
           | Error err -> Error err )
   with Yojson.Json_error e ->
@@ -521,15 +558,28 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
             else
               payload.message
           in
-          let args =
+          let attachment_json att =
             `Assoc
-              ([ ("name", `String payload.name);
-                 ("message", `String message);
-                 ("direct_reply", `Bool true) ]
-               @
-               match payload.timeout_sec with
+              [ ("id", `String att.Keeper_chat_store.id);
+                ("type", `String att.att_type);
+                ("name", `String att.name);
+                ("size", `Int att.size);
+                ("mime_type", `String att.mime_type);
+                ("data", `String att.data) ]
+          in
+          let args =
+            let base_fields =
+              [ ("name", `String payload.name);
+                ("message", `String message);
+                ("direct_reply", `Bool true) ]
+              @
+              (match payload.timeout_sec with
                | Some timeout_sec -> [ ("timeout_sec", `Int timeout_sec) ]
                | None -> [])
+            in
+            `Assoc
+              (if payload.attachments = [] then base_fields
+               else ("attachments", `List (List.map attachment_json payload.attachments)) :: base_fields)
           in
           let agent_name =
             if has_connector_context then
@@ -600,6 +650,7 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
                         ~base_dir:state.Mcp_server.workspace_config.base_path
                         ~keeper_name:payload.name
                         ~user_content:payload.message
+                        ~user_attachments:payload.attachments
                         ~assistant_content:visible_reply;
                     push_worker_event (Stream_terminal (true, body));
                     Tool_result.ok ~tool_name:"masc_keeper_msg" ~start_time body

--- a/lib/server/server_routes_http_keeper_stream.mli
+++ b/lib/server/server_routes_http_keeper_stream.mli
@@ -48,6 +48,7 @@ type keeper_chat_stream_request = {
   channel_user_id : string;
   channel_user_name : string;
   channel_workspace_id : string;
+  attachments : Keeper_chat_store.attachment list;
 }
 (** Parsed payload of a keeper chat-stream HTTP request.
     [timeout_sec] is clamped to [\[5, 300\]] when


### PR DESCRIPTION
## Summary

RFC-0217 Phase 2 서버 확장 — 대시보드에서 전송한 multimodal attachments를 HTTP API를 통해 수신하고, keeper 도구 인자에 포함하며, JSONL 영속화에 저장합니다.

## Changes

| 파일 | 변경 |
|------|------|
| `lib/keeper/keeper_chat_store.mli` | `attachment` 타입 + `chat_message.attachments` 필드 추가 |
| `lib/keeper/keeper_chat_store.ml` | JSONL encode/decode에 attachments 직렬화/역직렬화 추가 |
| `lib/server/server_routes_http_keeper_stream.mli` | `keeper_chat_stream_request.attachments` 필드 추가 |
| `lib/server/server_routes_http_keeper_stream.ml` | attachments 파싱 + `masc_keeper_msg` args 전달 + `append_pair` 호출 |
| `dashboard/src/api/keeper.ts` | `streamKeeperMessage`에 `attachments` 매개변수 추가 |
| `dashboard/src/components/keeper-chat-panel.ts` | `StreamAttachment` import + `streamKeeperMessage` 호출 시 attachments 전달 |

## Verification

- [x] `dune build --root . @check` 성공
- [ ] CI `Build and Test` (GitHub Actions)

## Related

- RFC-0217: Keeper Chat Enhancements (Queue + Multimodal)
- Dashboard PR #20200 (Phase 1), #20205 (bug fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
