### PR TITLE
fix(test): update runtime adapter module reference

### DIFF
--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -62,7 +62,7 @@ let test_runtime_adapter_keeps_auth_out_of_headers () =
     ; keeper_assignments = []
     }
   in
-  match Masc.Runtime_adapter.binding_to_provider_config cfg runpod_binding with
+  match Runtime_adapter.binding_to_provider_config cfg runpod_binding with
   | Error msg -> failf "unexpected adapter error: %s" msg
   | Ok provider_cfg ->
     check string "api key" "rp-test-token" provider_cfg.api_key;
@@ -91,7 +91,7 @@ let test_runtime_adapter_filters_toml_auth_headers () =
     ; keeper_assignments = []
     }
   in
-  match Masc.Runtime_adapter.binding_to_provider_config cfg runpod_binding with
+  match Runtime_adapter.binding_to_provider_config cfg runpod_binding with
   | Error msg -> failf "unexpected adapter error: %s" msg
   | Ok provider_cfg ->
     check string "api key" "rp-test-token" provider_cfg.api_key;
@@ -121,7 +121,7 @@ let provider_cfg () =
     ; keeper_assignments = []
     }
   in
-  match Masc.Runtime_adapter.binding_to_provider_config cfg runpod_binding with
+  match Runtime_adapter.binding_to_provider_config cfg runpod_binding with
   | Ok provider_cfg -> provider_cfg
   | Error msg -> failf "unexpected adapter error: %s" msg
 


### PR DESCRIPTION
Follow-up to #20203.

## Summary
- Update `test_runtime_provider_auth_headers` to call `Runtime_adapter` directly after the tools/runtime library extraction removed the stale `Masc.Runtime_adapter` alias.

## Verification
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-pr20203-followup-direct dune build --root . @test/runtest-test_runtime_provider_auth_headers`
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-pr20203-followup-direct dune build --root . @check`
- `git diff --check`