### PR TITLE
fix(run): auto-create missing run records on get

### DIFF
--- a/lib/keeper/keeper_tag_dispatch.ml
+++ b/lib/keeper/keeper_tag_dispatch.ml
@@ -110,7 +110,8 @@ let dispatch
         ({ Tool_local_runtime_core.config; agent_name } : Tool_local_runtime_core.context)
         ~name
         ~args
-    | Mod_run -> Tool_run.dispatch { Tool_run.config } ~name ~args
+    | Mod_run ->
+      Tool_run.dispatch { Tool_run.config; agent_name = Some agent_name } ~name ~args
     | Mod_agent -> Tool_agent.dispatch { Tool_agent.config; agent_name } ~name ~args
     | Mod_state -> Tool_workspace.dispatch { Tool_workspace.config; agent_name } ~name ~args
     | Mod_control ->

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -1157,7 +1157,8 @@ let internal_descriptors : t list =
   ; masc_run_descriptor "masc_run_list"
       "List recent runs." ~readonly:true
   ; masc_run_descriptor "masc_run_get"
-      "Read a single run by id." ~readonly:true
+      "Read a single run by id, creating an empty run record when missing."
+      ~readonly:false
   ; masc_run_descriptor "masc_run_log"
       "Read or append run log events." ~readonly:false
   ; masc_run_descriptor "masc_run_plan"

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -153,8 +153,8 @@ let handle_masc_plan ~(config : Workspace.config) ~name ~args =
   Tool_plan.dispatch ctx ~name ~args |> dispatch_option_to_string ~name
 ;;
 
-let handle_masc_run ~(config : Workspace.config) ~name ~args =
-  let ctx : Tool_run.context = { config } in
+let handle_masc_run ~(config : Workspace.config) ~(meta : keeper_meta) ~name ~args =
+  let ctx : Tool_run.context = { config; agent_name = Some meta.name } in
   Tool_run.dispatch ctx ~name ~args |> dispatch_option_to_string ~name
 ;;
 

--- a/lib/keeper/keeper_tool_in_process_runtime.mli
+++ b/lib/keeper/keeper_tool_in_process_runtime.mli
@@ -110,9 +110,10 @@ val handle_masc_plan
 (** RFC-0182 §3.1 — [handle_masc_run] is the descriptor-projection
     cluster handler for [masc_run_*] tools (deliverable / get / init /
     list / log / plan). Constructs a [Tool_run.context] from [config] and
-    calls [Tool_run.dispatch]. *)
+    keeper [meta], then calls [Tool_run.dispatch]. *)
 val handle_masc_run
   :  config:Workspace.config
+  -> meta:keeper_meta
   -> name:string
   -> args:Yojson.Safe.t
   -> string

--- a/lib/keeper/keeper_tool_runtime.ml
+++ b/lib/keeper/keeper_tool_runtime.ml
@@ -203,6 +203,7 @@ let handle_in_process ctx descriptor args =
     Some
       (Keeper_tool_in_process_runtime.handle_masc_run
          ~config:ctx.config
+         ~meta:ctx.meta
          ~name
          ~args)
   | Tool_masc_agent_dispatch ->

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -287,7 +287,10 @@ let execute_tool_eio
                  (* Mod_handover, Mod_heartbeat, Mod_auth removed: tools pruned *)
                  | Mod_compact -> None
                  | Mod_run ->
-                   Tool_run.dispatch { Tool_run.config } ~name ~args:coerced_args
+                   Tool_run.dispatch
+                     { Tool_run.config; agent_name = Some agent_name }
+                     ~name
+                     ~args:coerced_args
                  | Mod_agent ->
                    Tool_agent.dispatch
                      { Tool_agent.config; agent_name }

--- a/lib/run_eio.ml
+++ b/lib/run_eio.ml
@@ -109,8 +109,7 @@ let read_run config task_id : (run_record, string) result =
   if not (path_exists config path) then
     Error
       (Printf.sprintf
-         "Run not found for task %s (expected at %s). \
-          Call masc_run_init with this task_id first to create the run."
+         "No execution run record exists yet for task %s (expected run.json at %s)."
          task_id path)
   else
     match run_record_of_json (read_json config path) with
@@ -262,28 +261,36 @@ let read_logs config ~task_id ?limit () : log_entry list =
         file;
       List.of_seq (Queue.to_seq ring)
 
-(** Get run details *)
-let get config ~task_id : (Yojson.Safe.t, string) result =
-  match read_run config task_id with
+(** Get run details. Missing runs are bootstrapped so resume/read paths do
+    not block autonomous keeper turns before any explicit masc_run_init call. *)
+let get ?agent_name config ~task_id : (Yojson.Safe.t, string) result =
+  let read_or_create_run () =
+    let path = run_json_path config task_id in
+    if path_exists config path then
+      read_run config task_id
+    else
+      init config ~task_id ~agent_name
+  in
+  match read_or_create_run () with
   | Error e -> Error e
   | Ok run ->
-      let plan_content =
-        let text = read_text_file (plan_path config task_id) in
-        if text = "" then run.plan else text
-      in
-      let deliverable_content =
-        let text = read_text_file (deliverable_path config task_id) in
-        if text = "" then run.deliverable else text
-      in
-      let logs = read_logs config ~task_id ~limit:50 () in
-      let json = `Assoc [
-        ("run", run_record_to_json run);
-        ("plan", `String plan_content);
-        ("deliverable", `String deliverable_content);
-        ("logs", `List (List.map log_entry_to_json logs));
-        ("log_count", `Int (List.length logs));
-      ] in
-      Ok json
+    let plan_content =
+      let text = read_text_file (plan_path config task_id) in
+      if text = "" then run.plan else text
+    in
+    let deliverable_content =
+      let text = read_text_file (deliverable_path config task_id) in
+      if text = "" then run.deliverable else text
+    in
+    let logs = read_logs config ~task_id ~limit:50 () in
+    let json = `Assoc [
+      ("run", run_record_to_json run);
+      ("plan", `String plan_content);
+      ("deliverable", `String deliverable_content);
+      ("logs", `List (List.map log_entry_to_json logs));
+      ("log_count", `Int (List.length logs));
+    ] in
+    Ok json
 
 (** List runs *)
 let list config : Yojson.Safe.t =

--- a/lib/run_eio.mli
+++ b/lib/run_eio.mli
@@ -113,8 +113,10 @@ val read_logs :
   log_entry list
 
 (** Bundle {!run_record} + plan text + deliverable text + last 50 logs
-    into a single JSON object. *)
+    into a single JSON object. Creates the run scaffold first when
+    [run.json] is missing. *)
 val get :
+  ?agent_name:string ->
   Workspace_utils.config ->
   task_id:string ->
   (Yojson.Safe.t, string) result

--- a/lib/tool/tool_catalog.ml
+++ b/lib/tool/tool_catalog.ml
@@ -277,7 +277,7 @@ let explicit_metadata : (string * metadata) list =
     ("masc_tool_stats", read_state_tool);
     ("masc_pause", broadcast_tool);
     ("masc_resume", broadcast_tool);
-    ("masc_run_get", read_state_tool);
+    ("masc_run_get", broadcast_tool);
     ("masc_run_list", read_state_tool);
     ("masc_run_init", broadcast_tool);
     ("masc_run_plan", broadcast_tool);

--- a/lib/tool_run.ml
+++ b/lib/tool_run.ml
@@ -24,6 +24,7 @@ module Float = Stdlib.Float
 (** Tool handler context *)
 type context = {
   config: Workspace.config;
+  agent_name: string option;
 }
 
 open Tool_args
@@ -113,7 +114,7 @@ let handle_run_get ~tool_name ~start_time ctx args : Tool_result.result =
   if String.equal task_id "" then
     task_id_required ~tool_name ~start_time
   else
-    match Run_eio.get ctx.config ~task_id with
+    match Run_eio.get ?agent_name:ctx.agent_name ctx.config ~task_id with
     | Ok json -> Tool_result.make_ok ~tool_name ~start_time ~data:json ()
     | Error e ->
         Tool_result.make_err
@@ -233,7 +234,7 @@ After recording, the run shows as completed in masc_run_list and masc_run_get.";
   (* masc_run_get *)
   {
     name = "masc_run_get";
-    description = "Retrieve full execution history (plan, timestamped logs, deliverable) for a task as markdown. \\nUse when resuming work on a task, reviewing progress, or preparing a handoff. \\nPair with masc_run_list to find task IDs, masc_run_log to add entries.";
+    description = "Retrieve full execution history (plan, timestamped logs, deliverable) for a task as markdown. \\nIf the task has no run record yet, create an empty run scaffold and return it so resume flow can continue. \\nUse when resuming work on a task, reviewing progress, or preparing a handoff. \\nPair with masc_run_log to add entries.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -262,7 +263,7 @@ After recording, the run shows as completed in masc_run_list and masc_run_get.";
 (* Tool_spec registration                                           *)
 (* ================================================================ *)
 
-let read_only_tools = [ "masc_run_get"; "masc_run_list" ]
+let read_only_tools = [ "masc_run_list" ]
 
 let () =
   List.iter

--- a/lib/tool_run.mli
+++ b/lib/tool_run.mli
@@ -8,6 +8,7 @@
 (** Tool handler context *)
 type context = {
   config: Workspace.config;
+  agent_name: string option;
 }
 
 (** {1 Individual Handlers} *)

--- a/lib/tool_schemas/tool_schemas_run.ml
+++ b/lib/tool_schemas/tool_schemas_run.ml
@@ -81,7 +81,7 @@ let schemas : Masc_domain.tool_schema list =
     {
       name = "masc_run_get";
       description =
-        "Retrieve the full execution history for a task including plan revisions, log notes, and deliverables. Use when reviewing progress before handoff or for post-mortem analysis.";
+        "Retrieve the full execution history for a task including plan revisions, log notes, and deliverables. If the task has no run record yet, create an empty run scaffold and return it. Use when reviewing progress before handoff or for post-mortem analysis.";
       input_schema =
         `Assoc
           [

--- a/lib/tool_schemas/tool_schemas_run.mli
+++ b/lib/tool_schemas/tool_schemas_run.mli
@@ -11,7 +11,8 @@
     - [masc_run_deliverable] — record the final output;
       required [task_id], [deliverable].
     - [masc_run_get]         — retrieve plan + logs +
-      deliverables for one run; required [task_id].
+      deliverables for one run, creating an empty scaffold when
+      missing; required [task_id].
     - [masc_run_list]        — list all runs with status; no
       required params.
 

--- a/test/test_run_eio_coverage.ml
+++ b/test/test_run_eio_coverage.ml
@@ -257,9 +257,15 @@ let test_get_run () =
 
 let test_get_nonexistent () =
   with_initialized_masc @@ fun config ->
-  match Run_eio.get config ~task_id:"nonexistent" with
-  | Error _ -> ()
-  | Ok _ -> fail "expected error"
+  match Run_eio.get ~agent_name:"keeper-auto" config ~task_id:"nonexistent" with
+  | Error e -> failf "get should auto-create missing run: %s" e
+  | Ok json ->
+      let open Yojson.Safe.Util in
+      let run = json |> member "run" in
+      check string "task_id" "nonexistent" (run |> member "task_id" |> to_string);
+      check string "agent_name" "keeper-auto" (run |> member "agent_name" |> to_string);
+      check bool "run.json created" true
+        (Sys.file_exists (Run_eio.run_json_path config "nonexistent"))
 
 let test_list_empty () =
   with_initialized_masc @@ fun config ->


### PR DESCRIPTION
## Summary
- auto-create an empty run scaffold when masc_run_get sees a missing run.json
- pass caller agent_name through keeper and MCP run dispatch paths for generated run records
- mark masc_run_get as write-capable in descriptors/catalog because it can create files

## Root Cause
masc_run_get treated a missing run.json as a hard runtime failure, so keeper resume/read flow could stop before any explicit masc_run_init call.

## Validation
- git diff --check
- env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_run_get_autocreate dune build --root . test/test_run_eio_coverage.exe --display=short -j 1
- env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_run_get_autocreate dune exec --root . --display=short ./test/test_run_eio_coverage.exe
