### PR TITLE
[codex] Drop non-catalog resource classifier

### DIFF
--- a/lib/tool_surface/tool_resource_axis.ml
+++ b/lib/tool_surface/tool_resource_axis.ml
@@ -164,12 +164,6 @@ let classify_structured_shell_op args =
   | None -> Ungated
 ;;
 
-let classify_non_catalog_tool ~tool_name =
-  match tool_name with
-  | "shell_exec" -> Some Shell
-  | _ -> None
-;;
-
 let classify_catalog_tool ~tool_name =
   match tool_name with
   | "masc_web_fetch" | "masc_web_search" -> Some Web
@@ -249,6 +243,7 @@ let classify_descriptor_tool ~tool_name ~arguments =
   | "tool_search_files" -> Some (classify_structured_shell_op arguments)
   | "tool_read_file" -> Some Filesystem_read
   | "tool_write_file" | "tool_edit_file" -> Some Workspace_write
+  | "shell_exec" -> Some Shell
   | _ -> None
 ;;
 
@@ -258,10 +253,7 @@ let classify_normalized ~tool_name ~arguments ~is_read_only =
   | None ->
     (match classify_catalog_tool ~tool_name with
      | Some resource_class -> resource_class
-     | None ->
-       (match classify_non_catalog_tool ~tool_name with
-        | Some resource_class -> resource_class
-        | None -> if is_read_only then Ungated else Generic_write))
+     | None -> if is_read_only then Ungated else Generic_write)
 ;;
 
 let classify ~tool_name ~arguments ~is_read_only =


### PR DESCRIPTION
## Summary
- Close #20213 as superseded/no-op after it drifted into unrelated catalog/schema ownership changes.
- Remove classify_non_catalog_tool and fold shell_exec into descriptor classification.
- Preserve existing shell resource behavior while removing the extra non-catalog classifier axis.

## Verification
- env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_drop_non_catalog_tool_classifier dune build --root . lib/tool_surface/masc_tool_surface.cma test/test_tool_resource_gate.exe --display=short -j 1
- ./_build_drop_non_catalog_tool_classifier/default/test/test_tool_resource_gate.exe
- git diff --check
- rg -n "classify_non_catalog_tool|classify_catalog_metadata_tool|descriptor_owned_internal_tool_schemas|role_catalog_available_tool_names" lib test bin -S (no matches)