### PR TITLE
fix(otel): stop tick fiber on Eio_mutex.Poisoned instead of WARN spam

### DIFF
--- a/lib/otel_spans/opentelemetry_client_cohttp_eio.ml
+++ b/lib/otel_spans/opentelemetry_client_cohttp_eio.ml
@@ -453,7 +453,28 @@ let create_backend ~sw ?(stop = Atomic.make false) ?(config = Config.make ()) en
       Eio.Time.sleep env#clock 0.5;
       try B.tick () with
       | Eio.Cancel.Cancelled _ as e -> raise e
-      | exn -> Log.Telemetry.warn "otel tick failed: %s" (Printexc.to_string exn)
+      | exn ->
+        let msg = Printexc.to_string exn in
+        (* Eio_mutex.Poisoned is unrecoverable — the internal GC_metrics mutex
+           is permanently damaged and every subsequent tick will fail with the
+           same error.  Stop the fiber instead of spamming WARN every 500ms.
+           Otel data is already lost; the next server restart will recreate
+           the backend. *)
+        let is_poisoned =
+          let target = "Poisoned" in
+          let tlen = String.length target in
+          let mlen = String.length msg in
+          let rec scan i =
+            i + tlen <= mlen &&
+            (String.sub msg i tlen = target || scan (i + 1))
+          in
+          scan 0
+        in
+        if is_poisoned then begin
+          Log.Otel.warn "otel tick mutex poisoned, stopping tick fiber (otel degraded until restart)";
+          Atomic.set stop true
+        end else
+          Log.Telemetry.warn "otel tick failed: %s" msg
     done);
   (module B)
 ;;


### PR DESCRIPTION
## Problem

`otel tick failed: Eio__Eio_mutex.Poisoned(_)` 가 500ms마다 반복 출력.

opentelemetry 라이브러리 내부 `GC_metrics` 모듈의 `Eio.Mutex`가 fiber cancellation에 의해 poisoning됨. `Fun.protect`는 async exception(`Eio.Cancel.Cancelled`)을 완전히 보호하지 못함. 한 번 망가지면 서버 재시작 전까지 복구 불가.

## Fix

tick 루프에서 `Poisoned` 감지 시 fiber 정지(`Atomic.set stop true`). otel 데이터는 이미 손실 상태이므로 재시도 의미 없음. WARN spam만 제거.

```
before: WARN every 500ms (영구)
after:  WARN 1회 + fiber stop (조용히 degrade)
```

## Test

- 로컬 main이 duplicate library 에러로 빌드 불가 (pre-existing). CI로 검증 예정.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
