### PR TITLE
fix(plan): auto-create missing planning contexts on get

### DIFF
--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -1140,7 +1140,8 @@ let internal_descriptors : t list =
   ; masc_plan_descriptor "update" "masc_plan_update"
       "Update a workspace plan." ~readonly:false
   ; masc_plan_descriptor "get" "masc_plan_get"
-      "Read the current plan." ~readonly:true
+      "Read the current plan, creating an empty planning context when missing."
+      ~readonly:false
   ; masc_plan_descriptor "set_task" "masc_plan_set_task"
       "Bind a task to a plan slot." ~readonly:false
   ; masc_plan_descriptor "get_task" "masc_plan_get_task"

--- a/lib/task/planning_eio.ml
+++ b/lib/task/planning_eio.ml
@@ -53,6 +53,8 @@ let create_context ~task_id =
 let planning_dir (config : Workspace.config) task_id =
   Filename.concat config.base_path (Printf.sprintf "planning/%s" task_id)
 
+let context_path config task_id = Filename.concat (planning_dir config task_id) "context.json"
+
 (** File read via Fs_compat (Eio-native when available, blocking fallback) *)
 let read_file_content path =
   if Fs_compat.file_exists path then
@@ -63,6 +65,13 @@ let read_file_content path =
 let write_file_content path content =
   Fs_compat.mkdir_p (Filename.dirname path);
   Fs_compat.save_file path content
+
+let write_file_if_missing path content =
+  if not (Fs_compat.file_exists path) then write_file_content path content
+
+let read_non_skeleton path skeleton =
+  let value = String.trim (read_file_content path) in
+  if String.equal value skeleton then "" else value
 
 let find_substring_from haystack ~needle ~from =
   if from > String.length haystack then None
@@ -137,11 +146,27 @@ let init (config : Workspace.config) ~task_id : (planning_context, string) resul
   | Eio.Cancel.Cancelled _ as e -> raise e
   | e -> Error (Printexc.to_string e)
 
+let init_missing (config : Workspace.config) ~task_id : (planning_context, string) result =
+  try
+    let dir = planning_dir config task_id in
+    Fs_compat.mkdir_p dir;
+    write_file_if_missing (Filename.concat dir "task_plan.md") "# Task Plan\n\n";
+    write_file_if_missing (Filename.concat dir "notes.md") "# Notes & Observations\n\n";
+    write_file_if_missing (Filename.concat dir "errors.md") "# Errors & Failures (PDCA Check)\n\n";
+    write_file_if_missing (Filename.concat dir "deliverable.md") "";
+    let task_plan = read_non_skeleton (Filename.concat dir "task_plan.md") "# Task Plan" in
+    let deliverable = String.trim (read_file_content (Filename.concat dir "deliverable.md")) in
+    let ctx = { (create_context ~task_id) with task_plan; deliverable } in
+    write_file_content (context_path config task_id) (Yojson.Safe.pretty_to_string (planning_context_to_yojson ctx));
+    Ok ctx
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e -> Error (Printexc.to_string e)
+
 (** Load planning context *)
 let load (config : Workspace.config) ~task_id : (planning_context, string) result =
   try
-    let dir = planning_dir config task_id in
-    let ctx_path = Filename.concat dir "context.json" in
+    let ctx_path = context_path config task_id in
     if not (Sys.file_exists ctx_path) then
       Error (Printf.sprintf "Planning context not found for task %s" task_id)
     else begin
@@ -153,11 +178,17 @@ let load (config : Workspace.config) ~task_id : (planning_context, string) resul
   | Eio.Cancel.Cancelled _ as e -> raise e
   | e -> Error (Printexc.to_string e)
 
+(** Load planning context, creating an empty scaffold when it has not been
+    initialized yet. Malformed existing context still fails loudly. *)
+let load_or_init (config : Workspace.config) ~task_id : (planning_context, string) result =
+  if Sys.file_exists (context_path config task_id) then load config ~task_id
+  else init_missing config ~task_id
+
 (** Update task plan *)
 let update_plan (config : Workspace.config) ~task_id ~content : (planning_context, string) result =
   try
     let dir = planning_dir config task_id in
-    match load config ~task_id with
+    match load_or_init config ~task_id with
     | Error e -> Error e
     | Ok ctx ->
         let parsed = parse_full_context_markdown content in
@@ -188,7 +219,7 @@ let update_plan (config : Workspace.config) ~task_id ~content : (planning_contex
 let add_note (config : Workspace.config) ~task_id ~note : (planning_context, string) result =
   try
     let dir = planning_dir config task_id in
-    match load config ~task_id with
+    match load_or_init config ~task_id with
     | Error e -> Error e
     | Ok ctx ->
         let timestamp = Masc_domain.now_iso () in

--- a/lib/task/planning_eio.mli
+++ b/lib/task/planning_eio.mli
@@ -56,15 +56,19 @@ val create_context : task_id:string -> planning_context
 val init :
   Workspace_core.config -> task_id:string -> (planning_context, string) result
 (** [init config ~task_id] creates the planning directory and an
-    empty Markdown skeleton.  Returns [Error _] when the directory
-    already has content. *)
+    empty Markdown skeleton. *)
 
 val load :
   Workspace_core.config -> task_id:string -> (planning_context, string) result
-(** [load config ~task_id] reads the persisted planning markdown
-    and parses sections via the internal markdown parser.  Returns
-    [Error _] when the directory does not exist or the markdown
-    is malformed. *)
+(** [load config ~task_id] reads the persisted planning context JSON.
+    Returns [Error _] when [context.json] does not exist or is malformed. *)
+
+val load_or_init :
+  Workspace_core.config -> task_id:string -> (planning_context, string) result
+(** [load_or_init config ~task_id] reads the persisted planning context,
+    creating a scaffold when [context.json] is missing.  Existing
+    [task_plan.md] and [deliverable.md] content is recovered into the new
+    context; existing malformed context still returns [Error _]. *)
 
 val update_plan :
   Workspace_core.config ->

--- a/lib/tool/tool_catalog.ml
+++ b/lib/tool/tool_catalog.ml
@@ -208,7 +208,7 @@ let explicit_metadata : (string * metadata) list =
     ( "masc_board_curation_submit",
       actor_broadcast_tool );
     ("masc_tool_help", read_state_tool);
-    ("masc_plan_get", read_state_tool);
+    ("masc_plan_get", broadcast_tool);
     ("masc_claim_next", claim_task_tool);
     ("masc_transition", complete_task_tool);
     ("masc_plan_set_task", actor_broadcast_tool);

--- a/lib/tool_plan.ml
+++ b/lib/tool_plan.ml
@@ -65,7 +65,7 @@ open Tool_args
      (Planning_eio is the persistence boundary; the error is opaque
       to the caller and not retryable with different args).
    - "task_id is required" / "content is required" / resolve_task_id
-     parse errors / "not found" lookups / set_current_task validation
+     parse errors / set_current_task validation
      → Workflow_rejection (caller-input violations; same args won't
       succeed on retry). *)
 
@@ -171,7 +171,7 @@ let handle_plan_get ~tool_name ~start_time ctx args : Tool_result.result =
         ~start_time
         e
   | Ok task_id ->
-      let result = Planning_eio.load ctx.config ~task_id in
+      let result = Planning_eio.load_or_init ctx.config ~task_id in
       match result with
       | Ok plan_ctx ->
           let markdown = Planning_eio.get_context_markdown plan_ctx in
@@ -184,9 +184,9 @@ let handle_plan_get ~tool_name ~start_time ctx args : Tool_result.result =
       | Error e ->
           Tool_result.make_err
             ~tool_name
-            ~class_:Tool_result.Workflow_rejection
+            ~class_:Tool_result.Runtime_failure
             ~start_time
-            (Printf.sprintf "Planning context not found: %s" e)
+            (Printf.sprintf "Failed to load planning context: %s" e)
 
 let handle_plan_set_task ~tool_name ~start_time ctx args : Tool_result.result =
   let task_id = get_string args "task_id" "" in
@@ -255,7 +255,7 @@ let dispatch ctx ~name ~args : Tool_result.result option =
 (* Tool_spec registration                                           *)
 (* ================================================================ *)
 
-let tool_spec_read_only = [ "masc_plan_get" ]
+let tool_spec_read_only = [ "masc_plan_get_task" ]
 
 let () =
   let is_plan = function

--- a/test/test_tool_plan_coverage.ml
+++ b/test/test_tool_plan_coverage.ml
@@ -52,6 +52,29 @@ let make_ctx () : Tool_plan.context =
   let config = Masc.Workspace.default_config "/tmp/test-plan" in
   ({ config } : Tool_plan.context)
 
+let make_ctx_unique label : Tool_plan.context =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_path =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf
+         "test-plan-%s-%d-%d"
+         label
+         (Unix.getpid ())
+         (Random.bits ()))
+  in
+  let config = Masc.Workspace.default_config base_path in
+  ({ config } : Tool_plan.context)
+
+let planning_context_path (ctx : Tool_plan.context) task_id =
+  Filename.concat
+    (Filename.concat ctx.config.Masc.Workspace.base_path (Printf.sprintf "planning/%s" task_id))
+    "context.json"
+
+let planning_task_plan_path ctx task_id =
+  Filename.concat (Filename.dirname (planning_context_path ctx task_id)) "task_plan.md"
+
 let test_dispatch_plan_init () =
   let ctx = make_ctx () in
   let args = `Assoc [("task_id", `String "task-001")] in
@@ -65,14 +88,38 @@ let test_dispatch_plan_update () =
   let ctx = make_ctx () in
   let args = `Assoc [("task_id", `String "task-001"); ("content", `String "test")] in
   match Tool_plan.dispatch ctx ~name:"masc_plan_update" ~args with
-  | Some result -> check bool "has message" true (String.length (Tool_result.message result) > 0)
+  | Some result ->
+      check bool "has message" true (String.length (Tool_result.message result) > 0);
+      check bool "plan_update succeeds" true (Tool_result.is_success result)
+  | None -> fail "expected Some"
+
+let test_dispatch_plan_update_autocreates () =
+  let ctx = make_ctx_unique "update-autocreate" in
+  let task_id = "task-plan-update-autocreate" in
+  let args = `Assoc [("task_id", `String task_id); ("content", `String "test")] in
+  match Tool_plan.dispatch ctx ~name:"masc_plan_update" ~args with
+  | Some result ->
+      check bool "plan_update succeeds" true (Tool_result.is_success result);
+      check bool "context created" true (Sys.file_exists (planning_context_path ctx task_id))
   | None -> fail "expected Some"
 
 let test_dispatch_note_add () =
   let ctx = make_ctx () in
   let args = `Assoc [("task_id", `String "task-001"); ("note", `String "test note")] in
   match Tool_plan.dispatch ctx ~name:"masc_note_add" ~args with
-  | Some result -> check bool "has message" true (String.length (Tool_result.message result) > 0)
+  | Some result ->
+      check bool "has message" true (String.length (Tool_result.message result) > 0);
+      check bool "note_add succeeds" true (Tool_result.is_success result)
+  | None -> fail "expected Some"
+
+let test_dispatch_note_add_autocreates () =
+  let ctx = make_ctx_unique "note-autocreate" in
+  let task_id = "task-note-autocreate" in
+  let args = `Assoc [("task_id", `String task_id); ("note", `String "test note")] in
+  match Tool_plan.dispatch ctx ~name:"masc_note_add" ~args with
+  | Some result ->
+      check bool "note_add succeeds" true (Tool_result.is_success result);
+      check bool "context created" true (Sys.file_exists (planning_context_path ctx task_id))
   | None -> fail "expected Some"
 
 let test_dispatch_deliver () =
@@ -86,7 +133,39 @@ let test_dispatch_plan_get () =
   let ctx = make_ctx () in
   let args = `Assoc [("task_id", `String "task-001")] in
   match Tool_plan.dispatch ctx ~name:"masc_plan_get" ~args with
-  | Some result -> check bool "has message" true (String.length (Tool_result.message result) > 0)
+  | Some result ->
+      check bool "has message" true (String.length (Tool_result.message result) > 0);
+      check bool "plan_get succeeds" true (Tool_result.is_success result)
+  | None -> fail "expected Some"
+
+let test_dispatch_plan_get_autocreates () =
+  let ctx = make_ctx_unique "get-autocreate" in
+  let task_id = "task-plan-get-autocreate" in
+  let args = `Assoc [("task_id", `String task_id)] in
+  match Tool_plan.dispatch ctx ~name:"masc_plan_get" ~args with
+  | Some result ->
+      check bool "plan_get succeeds" true (Tool_result.is_success result);
+      check bool "context created" true (Sys.file_exists (planning_context_path ctx task_id));
+      let open Yojson.Safe.Util in
+      check string "task_id" task_id (Tool_result.data result |> member "task_id" |> to_string)
+  | None -> fail "expected Some"
+
+let test_dispatch_plan_get_preserves_existing_markdown () =
+  let ctx = make_ctx_unique "get-preserves-existing" in
+  let task_id = "task-plan-get-preserves-existing" in
+  let task_plan_path = planning_task_plan_path ctx task_id in
+  Fs_compat.mkdir_p (Filename.dirname task_plan_path);
+  Fs_compat.save_file task_plan_path "existing plan body";
+  let args = `Assoc [("task_id", `String task_id)] in
+  match Tool_plan.dispatch ctx ~name:"masc_plan_get" ~args with
+  | Some result ->
+      check bool "plan_get succeeds" true (Tool_result.is_success result);
+      check string "existing markdown preserved" "existing plan body" (Fs_compat.load_file task_plan_path);
+      let open Yojson.Safe.Util in
+      check string
+        "existing markdown recovered into context"
+        "existing plan body"
+        (Tool_result.data result |> member "context" |> member "task_plan" |> to_string)
   | None -> fail "expected Some"
 
 let test_dispatch_error_add () =
@@ -162,9 +241,16 @@ let () =
     "dispatch", [
       test_case "plan_init" `Quick test_dispatch_plan_init;
       test_case "plan_update" `Quick test_dispatch_plan_update;
+      test_case "plan_update_autocreates" `Quick test_dispatch_plan_update_autocreates;
       test_case "note_add" `Quick test_dispatch_note_add;
+      test_case "note_add_autocreates" `Quick test_dispatch_note_add_autocreates;
       test_case "deliver" `Quick test_dispatch_deliver;
       test_case "plan_get" `Quick test_dispatch_plan_get;
+      test_case "plan_get_autocreates" `Quick test_dispatch_plan_get_autocreates;
+      test_case
+        "plan_get_preserves_existing_markdown"
+        `Quick
+        test_dispatch_plan_get_preserves_existing_markdown;
       test_case "error_add" `Quick test_dispatch_error_add;
       test_case "error_resolve" `Quick test_dispatch_error_resolve;
       test_case "plan_set_task" `Quick test_dispatch_plan_set_task;


### PR DESCRIPTION
## Summary
- make `masc_plan_get` create a missing planning context scaffold instead of returning a workflow rejection
- share that missing-context recovery with `masc_plan_update` and `masc_note_add`
- mark `masc_plan_get` as a write-capable/broadcast tool because it can create `planning/<task>/context.json`
- preserve existing markdown files and recover simple `task_plan.md` / `deliverable.md` content into the new context

## Validation
- `git diff --check`
- `ocamlformat --check lib/task/planning_eio.ml lib/task/planning_eio.mli lib/tool_plan.ml lib/keeper/keeper_tool_descriptor.ml lib/tool/tool_catalog.ml test/test_tool_plan_coverage.ml`
- `rg "Stdlib\.Lazy\.(force|from_val)|Fun\.protect|Mutex\.(lock|unlock)|failwith|assert false|Eio\.traceln|Sys\.(readdir|command)" ...` (only pre-existing comment/current_task recovery hit)
- `scripts/dune-local.sh build test/test_tool_plan_coverage.exe` blocked by live bare Dune processes (exit 75)
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_plan_get_autocreate dune build --root . test/test_tool_plan_coverage.exe --display=short -j 1` blocked before this change compiles by current-main duplicate Dune libraries; tracked separately in #20221