### PR TITLE
fix(keeper): use effective meta for turns

### DIFF
--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -702,6 +702,11 @@ let dispatch ctx ~name ~args : tool_result option =
   | "masc_keeper_down" -> Some (tool_result_with_tool_name ~tool_name:name (handle_keeper_down ctx args))
   | "masc_keeper_list" -> Some (tool_result_with_tool_name ~tool_name:name (handle_keeper_list ctx args))
   | "masc_keeper_persona_audit" -> Some (tool_result_with_tool_name ~tool_name:name (handle_keeper_persona_audit ctx args))
+  | "masc_keeper_sandbox_status" ->
+      Some
+        (tool_result_with_tool_name
+           ~tool_name:name
+           (handle_keeper_sandbox_status ctx args))
   | "masc_keeper_reset" -> Some (tool_result_with_tool_name ~tool_name:name (handle_keeper_reset ctx args))
   | "masc_keeper_compact" -> Some (tool_result_with_tool_name ~tool_name:name (handle_keeper_compact ctx args))
   | "masc_keeper_clear" -> Some (tool_result_with_tool_name ~tool_name:name (handle_keeper_clear ctx args))
@@ -727,7 +732,8 @@ let dispatch_stream ~on_text_delta ctx ~name ~args : tool_result option =
 
 let tool_spec_read_only =
   [ "masc_persona_list"; "masc_keeper_list";
-    "masc_keeper_status"; "masc_keeper_persona_audit"; "masc_keeper_msg_queue" ]
+    "masc_keeper_status"; "masc_keeper_persona_audit";
+    "masc_keeper_sandbox_status"; "masc_keeper_msg_queue" ]
 
 let register_keeper_surface_schema (s : Masc_domain.tool_schema) =
   Tool_spec.register
@@ -805,6 +811,17 @@ let () =
         (tool_result_with_tool_name
            ~tool_name:name
            (Keeper_tool_surface_ops.keeper_repair_body ~config ~agent_name args))
+    | "masc_keeper_sandbox_status" ->
+      (match sw, clock with
+       | Some sw, Some clock ->
+         let ctx : _ Keeper_types_profile.context =
+           { config; agent_name; sw; clock; proc_mgr; net }
+         in
+         Some
+           (tool_result_with_tool_name
+              ~tool_name:name
+              (handle_keeper_sandbox_status ctx args))
+       | _ -> eio_context_missing name)
     | "masc_keeper_down" ->
       Keeper_tool_surface_ops.invalidate_keeper_list_cache ();
       Keeper_tool_surface_ops.invalidate_status_cache (Tool_args.get_string args "name" "");

--- a/lib/keeper/keeper_turn_setup.ml
+++ b/lib/keeper/keeper_turn_setup.ml
@@ -7,11 +7,8 @@ open Keeper_meta_contract
 open Keeper_meta_store
 open Keeper_types_profile
 
-let ensure_keeper_exists
-    ~(ctx : _ context)
-    ~name
-  : (keeper_meta, string) result =
-  match read_meta_resolved ctx.config name with
+let ensure_keeper_exists ~(ctx : _ context) ~name : (keeper_meta, string) result =
+  match read_effective_meta_resolved ctx.config name with
   | Error e -> Error e
   | Ok (Some (_resolved_name, m)) -> Ok m
   | Ok None -> Error (Printf.sprintf "keeper not found: %s" name)

--- a/lib/keeper/keeper_turn_setup.mli
+++ b/lib/keeper/keeper_turn_setup.mli
@@ -2,8 +2,9 @@
 
     Extracted from keeper_turn.ml. *)
 
-(** Resolve a keeper by name and return its meta record. Returns
-    [Error] if the keeper does not exist or the meta is unreadable. *)
+(** Resolve a keeper by name and return its effective meta record.
+    Returns [Error] if the keeper does not exist, the meta is unreadable,
+    or TOML/profile overlay cannot be applied. *)
 val ensure_keeper_exists :
   ctx:_ Keeper_types_profile.context ->
   name:string ->

--- a/test/test_keeper_effective_meta_overlay.ml
+++ b/test/test_keeper_effective_meta_overlay.ml
@@ -2,6 +2,7 @@ module Workspace = Masc.Workspace
 module Store = Masc.Keeper_meta_store
 module Profile = Masc.Keeper_types_profile
 module Status_detail = Masc.Keeper_status_detail
+module Turn_setup = Masc.Keeper_turn_setup
 module Keeper_tool_surface = Masc.Keeper_tool_surface
 module Keeper_tool_surface_ops = Masc.Keeper_tool_surface_ops
 
@@ -183,6 +184,41 @@ tool_access = ["tool_execute", "tool_read_file"]
         [ "tool_execute"; "tool_read_file" ]
         meta.tool_access
 
+let test_turn_setup_uses_effective_meta () =
+  with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir ->
+  let name = "turnsetup" in
+  write_file
+    (Filename.concat keepers_dir (name ^ ".toml"))
+    {|[keeper]
+sandbox_profile = "docker"
+tool_access = ["tool_search_files", "tool_read_file"]
+|};
+  let config = Workspace.default_config base in
+  ignore (seed_runtime_meta config name : Masc.Keeper_meta_contract.keeper_meta);
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let ctx : _ Profile.context =
+    {
+      config;
+      agent_name = "test-agent";
+      sw;
+      clock = Eio.Stdenv.clock env;
+      proc_mgr = None;
+      net = None;
+    }
+  in
+  match Turn_setup.ensure_keeper_exists ~ctx ~name with
+  | Error err -> Alcotest.failf "ensure_keeper_exists failed: %s" err
+  | Ok meta ->
+      Alcotest.(check string)
+        "turn setup sees TOML sandbox overlay"
+        "docker"
+        (Profile.sandbox_profile_to_string meta.sandbox_profile);
+      Alcotest.(check (list string))
+        "turn setup sees TOML tool overlay"
+        [ "tool_search_files"; "tool_read_file" ]
+        meta.tool_access
+
 let test_missing_sandbox_profile_fails_loud_for_profile_source () =
   with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir ->
   let name = "nosandbox" in
@@ -349,6 +385,8 @@ let () =
         [
           Alcotest.test_case "TOML sandbox/tool overlay reaches effective meta"
             `Quick test_toml_overlay_reaches_effective_meta;
+          Alcotest.test_case "turn setup uses effective meta" `Quick
+            test_turn_setup_uses_effective_meta;
           Alcotest.test_case
             "profile source without sandbox_profile fails loudly"
             `Quick test_missing_sandbox_profile_fails_loud_for_profile_source;


### PR DESCRIPTION
## Summary
- use effective keeper meta during turn setup so TOML/base overlays such as `sandbox_profile=docker` survive into tool dispatch
- restore `masc_keeper_sandbox_status` dispatch/read-only registration
- add focused coverage for effective-meta sandbox overlay propagation

## Verification
- `ocamlformat --check lib/keeper/keeper_tool_surface.ml lib/keeper/keeper_turn_setup.ml lib/keeper/keeper_turn_setup.mli test/test_keeper_effective_meta_overlay.ml`
- `git diff --check`
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_keeper_effective_meta dune build --root . test/test_keeper_effective_meta_overlay.exe`
- `_build_keeper_effective_meta/default/test/test_keeper_effective_meta_overlay.exe`

## CI
- Current PR head: `d420625dfe5ebb61ea8fc9c30a73c453234a9057`
- GitHub CI is green except the expected Draft Auto-Merge Guard while this PR remains draft.
