### PR TITLE
[codex] Move web backend schema ownership to descriptors

### DIFF
--- a/bin/gen_tool_descriptors.ml
+++ b/bin/gen_tool_descriptors.ml
@@ -126,67 +126,6 @@ let masc_gc_spec : tool_spec =
   }
 ;;
 
-let masc_web_search_spec : tool_spec =
-  { name = "masc_web_search"
-  ; description =
-      "Search the public web and return top result titles, URLs, and snippets. Read-only \
-       helper for current-information lookups before deeper file or repo work. Uses \
-       configured web-search providers with structured fallback behavior and returns \
-       structured JSON."
-  ; parameters =
-      [ { p_name = "query"
-        ; p_type = T_string { enum = None; default = None }
-        ; p_description = "Search query text"
-        ; p_required = true
-        }
-      ; { p_name = "limit"
-        ; p_type = T_int { min = Some 1; max = Some 10; default = Some 5 }
-        ; p_description = "Maximum number of results to return (default 5, max 10)"
-        ; p_required = false
-        }
-      ]
-  ; additional_properties = false
-  ; behavior_contract = []
-  }
-;;
-
-let masc_web_fetch_spec : tool_spec =
-  { name = "masc_web_fetch"
-  ; description =
-      "Fetch a web page by URL and return agent-readable extracted content. Read-only \
-       helper for reading selected sources after web search before citing them. Prefers \
-       article/main/body content, strips script/style/navigation noise, returns markdown \
-       by default, and extracts <title> plus description metadata when present."
-  ; parameters =
-      [ { p_name = "url"
-        ; p_type = T_string { enum = None; default = None }
-        ; p_description = "URL to fetch (http or https only)"
-        ; p_required = true
-        }
-      ; { p_name = "timeout"
-        ; p_type = T_int { min = Some 1; max = Some 60; default = Some 15 }
-        ; p_description = "Request timeout in seconds (default 15, max 60)"
-        ; p_required = false
-        }
-      ; { p_name = "extractMode"
-        ; p_type =
-            T_string { enum = Some [ "markdown"; "text" ]; default = Some "markdown" }
-        ; p_description =
-            "Output extraction mode. markdown preserves readable headings/lists/links; \
-             text returns flattened plain text."
-        ; p_required = false
-        }
-      ; { p_name = "maxChars"
-        ; p_type = T_int { min = Some 1; max = Some 100000; default = Some 50000 }
-        ; p_description = "Maximum extracted content characters to return"
-        ; p_required = false
-        }
-      ]
-  ; additional_properties = false
-  ; behavior_contract = []
-  }
-;;
-
 let masc_tool_stats_spec : tool_spec =
   { name = "masc_tool_stats"
   ; description =
@@ -477,8 +416,6 @@ let phase6_specs : tool_spec list =
   ; masc_tool_help_spec
   ; masc_dashboard_spec
   ; masc_gc_spec
-  ; masc_web_search_spec
-  ; masc_web_fetch_spec
   ; masc_tool_stats_spec
   ; masc_cleanup_zombies_spec
     (* PR-1 (paving stone): control group *)

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -13,10 +13,22 @@ let dedupe_schemas (schemas : Masc_domain.tool_schema list) =
   in
   List.rev unique
 
+let descriptor_owned_internal_tool_schemas : Masc_domain.tool_schema list =
+  Keeper_tool_descriptor.public_descriptors
+  |> List.filter_map (fun (descriptor : Keeper_tool_descriptor.t) ->
+    if String.starts_with ~prefix:"masc_" descriptor.internal_name then
+      Some
+        { Masc_domain.name = descriptor.internal_name
+        ; description = descriptor.description
+        ; input_schema = descriptor.input_schema
+        }
+    else None)
+
 let raw_all_tool_schemas : Masc_domain.tool_schema list =
   dedupe_schemas
     (Tools.raw_schemas
      @ Tool_schemas_misc.schemas
+     @ descriptor_owned_internal_tool_schemas
      (* Board MCP adapter schemas live outside neutral Tool substrate and
         outside Board domain. *)
      @ Board_tool.tools

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -203,8 +203,6 @@ let schemas = Tool_schemas_misc.schemas
 let tool_spec_read_only =
   [
     "masc_tool_help";
-    "masc_web_search";
-    "masc_web_fetch";
     "masc_dashboard";
   ]
 

--- a/lib/tool_schemas/tool_schemas_misc.ml
+++ b/lib/tool_schemas/tool_schemas_misc.ml
@@ -37,19 +37,9 @@ let config_category_enum_strings =
   ]
 ;;
 
-(* [schemas] is the full generated misc schema set, including the
-   descriptor-backed web tools (masc_web_search / masc_web_fetch).
-   Web tools must stay in this list because it feeds
-   [Config.raw_all_tool_schemas] — the substrate's "all tools that exist"
-   set, which is the source for both (a) the keeper progressive-disclosure
-   universe (Keeper_tool_dispatch_runtime.inject_masc_schemas) and (b) the
-   public MCP surface. Public exclusion is the job of
-   [Tool_catalog.public_mcp_surface_tools] / [is_public_mcp] (web tools are
-   absent from that allowlist), NOT of this inventory. PR #19864 filtered web
-   tools out here as a "keeper-only backend" optimisation; that excluded them
-   from the keeper universe too, so the descriptor bundle never registered
-   WebSearch/WebFetch while [effective_core_tools] still injected the public
-   names every turn — every keeper turn logged "AllowList pruned ... WebSearch,
-   WebFetch". The exclusion belonged on the public-surface layer, not the raw
-   inventory. *)
+(* [schemas] is the generated misc schema set. Descriptor-owned web backend
+   names (masc_web_search / masc_web_fetch) are intentionally not generated
+   here; [Config.raw_all_tool_schemas] projects them from
+   [Keeper_tool_descriptor.public_descriptors] so the keeper universe still
+   knows they exist without duplicating their schema ownership. *)
 let schemas : tool_schema list = Tool_descriptors_gen.schemas

--- a/lib/tool_schemas/tool_schemas_misc.mli
+++ b/lib/tool_schemas/tool_schemas_misc.mli
@@ -37,14 +37,13 @@ val config_category_enum_strings : string list
 (** {1 Tool schema list} *)
 
 val schemas : Masc_domain.tool_schema list
-(** [schemas] is the full generated [Masc_domain.tool_schema list] for the
-    misc tools, including the descriptor-backed web tools
-    ([masc_web_search] / [masc_web_fetch]). Consumed by
-    {!Config.raw_all_tool_schemas} (the substrate inventory feeding both the
-    keeper progressive-disclosure universe and the public MCP surface) and by
-    [Tool_misc] for Tool_spec registration. Public-surface exclusion is
-    enforced downstream by {!Tool_catalog.is_public_mcp} /
-    [public_mcp_surface_tools], not by trimming this inventory. The schema
-    [enum] fields derive from {!dashboard_scope_enum_strings} /
+(** [schemas] is the generated [Masc_domain.tool_schema list] for misc tools.
+    Descriptor-owned web backend names ([masc_web_search] / [masc_web_fetch])
+    are intentionally projected into {!Config.raw_all_tool_schemas} from
+    [Keeper_tool_descriptor.public_descriptors] instead of duplicated here.
+    Public-surface exclusion is enforced downstream by
+    {!Tool_catalog.is_public_mcp} / [public_mcp_surface_tools], not by trimming
+    the raw inventory. The schema [enum] fields derive from
+    {!dashboard_scope_enum_strings} /
     {!config_category_enum_strings} so
     adding a value updates the schema automatically. *)

--- a/test/test_tool_descriptors_gen.ml
+++ b/test/test_tool_descriptors_gen.ml
@@ -13,6 +13,8 @@
 
 open Masc_domain
 
+module Descriptor = Masc.Keeper_tool_descriptor
+
 let yojson_testable : Yojson.Safe.t Alcotest.testable =
   Alcotest.testable
     (fun fmt v -> Format.fprintf fmt "%s" (Yojson.Safe.pretty_to_string v))
@@ -31,6 +33,20 @@ let find_by_name name (schemas : tool_schema list) : tool_schema =
 
 let has_schema name schemas =
   List.exists (fun (s : tool_schema) -> String.equal s.name name) schemas
+;;
+
+let descriptor_internal_schema name : tool_schema =
+  match
+    List.find_opt
+      (fun (descriptor : Descriptor.t) -> String.equal descriptor.internal_name name)
+      Descriptor.public_descriptors
+  with
+  | Some descriptor ->
+    { name = descriptor.internal_name
+    ; description = descriptor.description
+    ; input_schema = descriptor.input_schema
+    }
+  | None -> Alcotest.failf "descriptor %S not in Keeper_tool_descriptor.public_descriptors" name
 ;;
 
 let test_masc_config_name_matches () =
@@ -132,26 +148,33 @@ let test_masc_gc_input_schema_matches () =
     gen.input_schema
 ;;
 
-(* Regression guard for PR #19864 → keeper "AllowList pruned ... WebSearch,
-   WebFetch" spam. Web tools are descriptor-backed keeper tools: they MUST be
-   present in the raw substrate inventory (so the keeper progressive-disclosure
-   universe registers WebSearch/WebFetch and [validate_allow_list] keeps them),
-   and they MUST be absent from the public MCP allowlist (public exclusion is
-   the job of [public_mcp_surface_tools], not of trimming the inventory). *)
-let test_web_tools_present_in_misc_schemas () =
-  Alcotest.(check bool)
-    "masc_web_search present in misc schemas"
-    true
-    (has_schema "masc_web_search" Tool_schemas_misc.schemas);
-  Alcotest.(check bool)
-    "masc_web_fetch present in misc schemas"
-    true
-    (has_schema "masc_web_fetch" Tool_schemas_misc.schemas)
-;;
-
-let test_web_tools_in_raw_inventory_but_not_public_mcp_surface () =
+(* Regression guard for PR #19864 -> keeper "AllowList pruned ... WebSearch,
+   WebFetch" spam. Web tools are descriptor-owned keeper tools: they MUST be
+   absent from generated misc schemas, present in the raw substrate inventory
+   through Config's descriptor projection, and absent from the public MCP
+   allowlist. *)
+let test_web_tools_owned_by_keeper_descriptors () =
   List.iter
     (fun name ->
+      let descriptor = descriptor_internal_schema name in
+      Alcotest.(check bool)
+        (name ^ " absent from Tool_descriptors_gen.schemas")
+        false
+        (has_schema name Tool_descriptors_gen.schemas);
+      Alcotest.(check bool)
+        (name ^ " absent from Tool_schemas_misc.schemas")
+        false
+        (has_schema name Tool_schemas_misc.schemas);
+      let raw = find_by_name name Masc.Config.raw_all_tool_schemas in
+      Alcotest.(check string)
+        (name ^ " raw description matches descriptor")
+        descriptor.description
+        raw.description;
+      Alcotest.check
+        yojson_testable
+        (name ^ " raw input_schema matches descriptor")
+        descriptor.input_schema
+        raw.input_schema;
       Alcotest.(check bool)
         (name ^ " present in Config.raw_all_tool_schemas")
         true
@@ -165,50 +188,6 @@ let test_web_tools_in_raw_inventory_but_not_public_mcp_surface () =
         false
         (List.mem name Tool_catalog_surfaces.public_mcp_surface_tools))
     [ "masc_web_search"; "masc_web_fetch" ]
-;;
-
-let test_masc_web_search_name_matches () =
-  let gen = find_by_name "masc_web_search" Tool_descriptors_gen.schemas in
-  let hand = find_by_name "masc_web_search" Tool_schemas_misc.schemas in
-  Alcotest.(check string) "masc_web_search name" hand.name gen.name
-;;
-
-let test_masc_web_search_description_matches () =
-  let gen = find_by_name "masc_web_search" Tool_descriptors_gen.schemas in
-  let hand = find_by_name "masc_web_search" Tool_schemas_misc.schemas in
-  Alcotest.(check string) "masc_web_search description" hand.description gen.description
-;;
-
-let test_masc_web_search_input_schema_matches () =
-  let gen = find_by_name "masc_web_search" Tool_descriptors_gen.schemas in
-  let hand = find_by_name "masc_web_search" Tool_schemas_misc.schemas in
-  Alcotest.check
-    yojson_testable
-    "masc_web_search input_schema (Yojson.Safe.equal)"
-    hand.input_schema
-    gen.input_schema
-;;
-
-let test_masc_web_fetch_name_matches () =
-  let gen = find_by_name "masc_web_fetch" Tool_descriptors_gen.schemas in
-  let hand = find_by_name "masc_web_fetch" Tool_schemas_misc.schemas in
-  Alcotest.(check string) "masc_web_fetch name" hand.name gen.name
-;;
-
-let test_masc_web_fetch_description_matches () =
-  let gen = find_by_name "masc_web_fetch" Tool_descriptors_gen.schemas in
-  let hand = find_by_name "masc_web_fetch" Tool_schemas_misc.schemas in
-  Alcotest.(check string) "masc_web_fetch description" hand.description gen.description
-;;
-
-let test_masc_web_fetch_input_schema_matches () =
-  let gen = find_by_name "masc_web_fetch" Tool_descriptors_gen.schemas in
-  let hand = find_by_name "masc_web_fetch" Tool_schemas_misc.schemas in
-  Alcotest.check
-    yojson_testable
-    "masc_web_fetch input_schema (Yojson.Safe.equal)"
-    hand.input_schema
-    gen.input_schema
 ;;
 
 let test_masc_tool_stats_name_matches () =
@@ -292,28 +271,9 @@ let () =
         ] )
     ; ( "descriptor-backed web tools"
       , [ Alcotest.test_case
-            "present in misc schemas"
+            "owned by keeper descriptors"
             `Quick
-            test_web_tools_present_in_misc_schemas
-        ; Alcotest.test_case
-            "in raw inventory but not public MCP surface"
-            `Quick
-            test_web_tools_in_raw_inventory_but_not_public_mcp_surface
-        ; Alcotest.test_case "masc_web_search name" `Quick test_masc_web_search_name_matches
-        ; Alcotest.test_case "description" `Quick test_masc_web_search_description_matches
-        ; Alcotest.test_case
-            "masc_web_search input_schema"
-            `Quick
-            test_masc_web_search_input_schema_matches
-        ; Alcotest.test_case "masc_web_fetch name" `Quick test_masc_web_fetch_name_matches
-        ; Alcotest.test_case
-            "masc_web_fetch description"
-            `Quick
-            test_masc_web_fetch_description_matches
-        ; Alcotest.test_case
-            "masc_web_fetch input_schema"
-            `Quick
-            test_masc_web_fetch_input_schema_matches
+            test_web_tools_owned_by_keeper_descriptors
         ] )
     ; ( "masc_tool_stats field-by-field"
       , [ Alcotest.test_case "name" `Quick test_masc_tool_stats_name_matches


### PR DESCRIPTION
## Summary
- remove generated misc specs for masc_web_search and masc_web_fetch
- project descriptor-owned masc_* public descriptors into Config.raw_all_tool_schemas so raw keeper inventory still includes the web backend tools
- update descriptor tests to assert web tools are absent from generated/misc schemas, present via Config raw inventory, and absent from public MCP surface
- keep this PR scoped away from admin cleanup, catalog fallback, and resource-axis cleanup

## Verification
- PASS: git diff --check
- PASS: rg -n 'masc_web_search_spec|masc_web_fetch_spec' bin lib test docs --glob '!_build*/**' returned no matches
- PASS: static residue check shows web literals only in Tool_misc dispatch, misc schema docs, and descriptor ownership test
- BLOCKED: env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_codex_web_descriptor_final dune build --root . test/test_tool_descriptors_gen.exe fails before this PR code builds because current origin/main has duplicate Dune libraries: test/deps/dune reports masc.keeper_runtime twice and lib/dune reports masc.keeper_registry twice