### PR TITLE
feat(keeper): message_source for multi-channel queue (RFC-0217)

### DIFF
--- a/lib/keeper/keeper_chat_queue.ml
+++ b/lib/keeper/keeper_chat_queue.ml
@@ -8,10 +8,16 @@
 
     @since 2.145.0 *)
 
+type message_source =
+  | Dashboard
+  | Discord of { channel_id : string; user_id : string }
+  | Slack of { channel : string; user_id : string }
+
 type queued_message = {
   content : string;
   attachments : Keeper_chat_store.attachment list;
   timestamp : float;
+  source : message_source;
 }
 
 type queue_entry = {

--- a/lib/keeper/keeper_chat_queue.mli
+++ b/lib/keeper/keeper_chat_queue.mli
@@ -6,6 +6,16 @@
 
     The queue is transient (not persisted).  Lost on server restart.
 
+    NOTE: Queue drain is currently coupled to the HTTP request
+    lifecycle in [Server_routes_http_keeper_stream].  External
+    connectors (Discord, Slack, etc.) that enqueue messages here
+    will not see them auto-drained unless a Dashboard HTTP request
+    also arrives for the same keeper.  See RFC-0217 §Future Work.
+
+    TODO: Add [source] field to [queued_message] for multi-channel
+    delivery, and extract the consumer from the HTTP handler into a
+    standalone polling fiber.
+
     @since 2.145.0 *)
 
 (** {1 Types} *)

--- a/lib/keeper/keeper_chat_queue.mli
+++ b/lib/keeper/keeper_chat_queue.mli
@@ -20,10 +20,16 @@
 
 (** {1 Types} *)
 
+type message_source =
+  | Dashboard
+  | Discord of { channel_id : string; user_id : string }
+  | Slack of { channel : string; user_id : string }
+
 type queued_message = {
   content : string;
   attachments : Keeper_chat_store.attachment list;
   timestamp : float;
+  source : message_source;
 }
 
 (** {1 Queue operations} *)

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -756,15 +756,21 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
              match Keeper_chat_queue.dequeue ~keeper_name:payload.name with
              | None -> ()
              | Some queued ->
-                 let run_id = Printf.sprintf "keeper-run-%d" (now_id ()) in
-                 let message_id = Printf.sprintf "keeper-msg-%d" (now_id ()) in
-                 let queued_payload =
-                   { payload with
-                     message = queued.content;
-                     attachments = queued.attachments }
-                 in
-                 process_single_turn ~payload:queued_payload ~run_id ~message_id
-                   ~agent_name;
+                 (match queued.source with
+                  | Keeper_chat_queue.Dashboard ->
+                      let run_id = Printf.sprintf "keeper-run-%d" (now_id ()) in
+                      let message_id = Printf.sprintf "keeper-msg-%d" (now_id ()) in
+                      let queued_payload =
+                        { payload with
+                          message = queued.content;
+                          attachments = queued.attachments }
+                      in
+                      process_single_turn ~payload:queued_payload ~run_id ~message_id
+                        ~agent_name
+                  | Keeper_chat_queue.Discord _ | Keeper_chat_queue.Slack _ ->
+                      Log.Keeper.warn
+                        "keeper_chat_queue: non-Dashboard source dropped for keeper=%s"
+                        payload.name);
                  drain_queue ()
            in
            drain_queue ()))


### PR DESCRIPTION
## Summary
Add [message_source] variant to queued_message for per-channel delivery routing.

## Changes
- Keeper_chat_queue: new [message_source] type (Dashboard | Discord | Slack)
- queued_message: new [source] field
- drain_queue: branch on source; Dashboard -> process_single_turn, Discord/Slack -> warning log

## Why
Current queue drain is bound to HTTP request lifecycle. This PR adds the
metadata foundation for extracting the consumer into a standalone fiber
that can route responses to the correct channel (Dashboard SSE, Discord API,
Slack API).

## Next Steps
- Extract consumer from HTTP handler into independent polling fiber
- Implement Discord/Slack delivery adapters

🤖 Generated with [Claude Code](https://claude.com/code/code)