### PR TITLE
feat(keeper): Keeper_chat_events module (RFC-0217 Phase 1)

### DIFF
--- a/lib/keeper/keeper_chat_events.ml
+++ b/lib/keeper/keeper_chat_events.ml
@@ -1,0 +1,16 @@
+type role = User | Assistant
+
+type keeper_chat_event =
+  | Run_started of { run_id : string; thread_id : string }
+  | Text_message_start of { message_id : string; role : role }
+  | Text_delta of string
+  | Text_message_end
+  | Run_finished of { run_id : string }
+  | Error of { message : string }
+  | Custom of { name : string; value : Yojson.Safe.t }
+
+let create () = Eio.Stream.create 512
+
+let publish stream event = Eio.Stream.add stream event
+
+let subscribe stream = Eio.Stream.take stream

--- a/lib/keeper/keeper_chat_events.mli
+++ b/lib/keeper/keeper_chat_events.mli
@@ -1,0 +1,33 @@
+(** Keeper_chat_events — channel-agnostic event bus for keeper chat turns.
+
+    Decouples turn processing from delivery. Each turn gets its own
+    event stream instance; adapters consume events and translate to
+    channel-specific protocols (SSE, Discord REST, Slack REST).
+
+    @since 2.145.0 *)
+
+(** {1 Types} *)
+
+type role = User | Assistant
+
+type keeper_chat_event =
+  | Run_started of { run_id : string; thread_id : string }
+  | Text_message_start of { message_id : string; role : role }
+  | Text_delta of string
+  | Text_message_end
+  | Run_finished of { run_id : string }
+  | Error of { message : string }
+  | Custom of { name : string; value : Yojson.Safe.t }
+
+(** {1 Stream operations} *)
+
+(** [create ()] returns a new bounded event stream.
+    Each turn should create its own stream instance. *)
+val create : unit -> keeper_chat_event Eio.Stream.t
+
+(** [publish stream event] adds [event] to the stream.
+    Non-blocking; raises if the stream is full (backpressure). *)
+val publish : keeper_chat_event Eio.Stream.t -> keeper_chat_event -> unit
+
+(** [subscribe stream] blocks until an event is available, then returns it. *)
+val subscribe : keeper_chat_event Eio.Stream.t -> keeper_chat_event


### PR DESCRIPTION
## Summary
Phase 1 of multi-channel keeper chat delivery architecture.

## Changes
- `lib/keeper/keeper_chat_events.mli` — event types + stream interface
- `lib/keeper/keeper_chat_events.ml` — Eio.Stream based implementation

## Event Types
- `Run_started`, `Text_message_start`, `Text_delta`, `Text_message_end`
- `Run_finished`, `Error`, `Custom`

## Design
Each turn creates its own event stream instance. Adapters (SSE, Discord, Slack)
subscribe to the stream and translate events to channel-specific protocols.

## Next
- Phase 2: Refactor process_single_turn to use event stream
- Phase 3: Extract queue consumer into standalone fiber

🤖 Generated with [Claude Code](https://claude.com/code/code)