### PR TITLE
fix(ci): register OTel command helpers in boundary matrix

### DIFF
--- a/docs/design/keeper-tool-boundary-matrix.md
+++ b/docs/design/keeper-tool-boundary-matrix.md
@@ -122,10 +122,14 @@ Each path below must appear exactly once and use one owner from the table above.
 - `lib/keeper/keeper_tool_execute_runtime.mli` - shell-surface
 - `lib/keeper_tool_command_parse/keeper_tool_execute_command_parse.ml` - shell-surface
 - `lib/keeper_tool_command_parse/keeper_tool_execute_command_parse.mli` - shell-surface
+- `lib/keeper/keeper_tool_execute_command_parse.ml` - shell-surface
+- `lib/keeper/keeper_tool_execute_command_parse.mli` - shell-surface
 - `lib/keeper/keeper_tool_execute_command_semantics.ml` - shell-surface
 - `lib/keeper/keeper_tool_execute_command_semantics.mli` - shell-surface
 - `lib/keeper_tool_command_parse/keeper_tool_execute_command_words.ml` - shell-surface
 - `lib/keeper_tool_command_parse/keeper_tool_execute_command_words.mli` - shell-surface
+- `lib/keeper/keeper_tool_execute_command_words.ml` - shell-surface
+- `lib/keeper/keeper_tool_execute_command_words.mli` - shell-surface
 - `lib/keeper_tool_execute_shell_ir/keeper_tool_execute_shell_ir.ml` - shell-surface
 - `lib/keeper_tool_execute_shell_ir/keeper_tool_execute_shell_ir.mli` - shell-surface
 - `lib/keeper/keeper_tool_execute_path.ml` - shell-surface


### PR DESCRIPTION
## Summary
- register the restored keeper command parse and word helper files in the keeper tool boundary matrix
- keep the new helpers owned by the existing shell-surface category

## Why
PR #20230 restored lib/keeper/keeper_tool_execute_command_parse.* and lib/keeper/keeper_tool_execute_command_words.*. The OCaml Structure Ratchet passed its structure checks but failed the keeper tool boundary matrix audit because those scoped files were not added to the matrix.

## Verification
- scripts/audit-keeper-tool-boundary-matrix.sh
- git diff --check