### PR TITLE
fix(docs): update keeper measurement code ref

### DIFF
--- a/docs/design/tool-calling-quality-and-self-healing-rfc.md
+++ b/docs/design/tool-calling-quality-and-self-healing-rfc.md
@@ -1,9 +1,9 @@
 ---
 status: reference
-last_verified: 2026-04-17
+last_verified: 2026-06-05
 code_refs:
   - lib/keeper/keeper_composite_observer.ml
-  - lib/keeper_measurement/keeper_measurement.ml
+  - lib/keeper_metrics/keeper_measurement.ml
 ---
 
 # Tool Calling Quality and Self-Healing RFC


### PR DESCRIPTION
## Summary
- update the stale keeper measurement code_ref to the current keeper_metrics path
- refresh last_verified for the RFC frontmatter

## Why
Meta Guards on #20231 failed because docs/design/tool-calling-quality-and-self-healing-rfc.md referenced lib/keeper_measurement/keeper_measurement.ml, which no longer exists after the keeper metrics leaf move.

## Verification
- bash scripts/check-doc-truth.sh
- scripts/sync-oas-pin-docs.sh --check
- scripts/audit-keeper-tool-boundary-matrix.sh
- git diff --check