### PR TITLE
fix(docs): update keeper measurement code ref

### DIFF
--- a/docs/design/tool-calling-quality-and-self-healing-rfc.md
+++ b/docs/design/tool-calling-quality-and-self-healing-rfc.md
@@ -1,9 +1,9 @@
 ---
 status: reference
-last_verified: 2026-04-17
+last_verified: 2026-06-06
 code_refs:
   - lib/keeper/keeper_composite_observer.ml
-  - lib/keeper_measurement/keeper_measurement.ml
+  - lib/keeper_metrics/keeper_measurement.ml
 ---
 
 # Tool Calling Quality and Self-Healing RFC


### PR DESCRIPTION
## Summary
- update the tool-calling quality RFC code_refs path from the removed keeper_measurement library path to the current keeper_metrics path
- refresh last_verified after checking the current repo path exists
- replaces closed/unmerged PR #20233

## Verification
- bash scripts/check-doc-truth.sh
- scripts/sync-oas-pin-docs.sh --check
- bash scripts/audit-keeper-tool-boundary-matrix.sh
- git diff --check