### PR TITLE
fix(otel): stop tick loop after poisoned mutex

### DIFF
--- a/lib/otel_spans/opentelemetry_client_cohttp_eio.ml
+++ b/lib/otel_spans/opentelemetry_client_cohttp_eio.ml
@@ -446,6 +446,14 @@ module Backend (Emitter : EMITTER) : Opentelemetry.Collector.BACKEND = struct
   let set_on_tick_callbacks = Emitter.set_on_tick_callbacks
 end
 
+let stop_tick_after_poisoned_mutex ~stop cause =
+  Atomic.set stop true;
+  Log.Telemetry.error
+    "otel tick failed with Eio.Mutex.Poisoned; stopping tick fiber; OTEL metrics \
+     export degraded until backend restart; underlying cause: %s"
+    (Printexc.to_string cause)
+;;
+
 let create_backend ~sw ?(stop = Atomic.make false) ?(config = Config.make ()) env
   : (module OT.Collector.BACKEND)
   =
@@ -456,10 +464,7 @@ let create_backend ~sw ?(stop = Atomic.make false) ?(config = Config.make ()) en
       Eio.Time.sleep env#clock 0.5;
       try B.tick () with
       | Eio.Cancel.Cancelled _ as e -> raise e
-      | Eio.Mutex.Poisoned cause ->
-        Log.Telemetry.error
-          "otel tick failed with Eio.Mutex.Poisoned; underlying cause: %s"
-          (Printexc.to_string cause)
+      | Eio.Mutex.Poisoned cause -> stop_tick_after_poisoned_mutex ~stop cause
       | exn -> Log.Telemetry.warn "otel tick failed: %s" (Printexc.to_string exn)
     done);
   (module B)

--- a/test/dune
+++ b/test/dune
@@ -1533,6 +1533,8 @@
 (include stanzas/test_operator_mcp_e2e.inc)
 
 
+(include stanzas/test_otel_tick_poison_source.inc)
+
 (include stanzas/test_otel_trace_context.inc)
 
 (include stanzas/test_personality_diff_summary_10269.inc)

--- a/test/stanzas/test_otel_tick_poison_source.inc
+++ b/test/stanzas/test_otel_tick_poison_source.inc
@@ -1,0 +1,7 @@
+; OTEL tick loop must stop after Eio.Mutex.Poisoned instead of spamming logs.
+; Pure source-text inspection; no MASC_BASE_PATH, no project libs.
+
+(test
+ (name test_otel_tick_poison_source)
+ (modules test_otel_tick_poison_source)
+ (deps ../lib/otel_spans/opentelemetry_client_cohttp_eio.ml))

--- a/test/test_otel_tick_poison_source.ml
+++ b/test/test_otel_tick_poison_source.ml
@@ -1,0 +1,77 @@
+(* Regression guard: once the OTEL tick path hits Eio.Mutex.Poisoned, the
+   backend is already degraded. The tick fiber must stop instead of logging the
+   same poisoned mutex failure on every scheduled tick. *)
+
+let read_file path =
+  let ic = open_in path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () -> In_channel.input_all ic)
+
+let position haystack needle =
+  let n = String.length needle in
+  let h = String.length haystack in
+  let rec scan i =
+    if i + n > h then None
+    else if String.sub haystack i n = needle then Some i
+    else scan (i + 1)
+  in
+  scan 0
+
+let contains haystack needle =
+  match position haystack needle with
+  | Some _ -> true
+  | None -> false
+
+let assert_contains ~label haystack needle =
+  if not (contains haystack needle)
+  then failwith (Printf.sprintf "[%s] expected source to contain %S" label needle)
+
+let assert_order ~label haystack first second =
+  match position haystack first, position haystack second with
+  | Some a, Some b when a < b -> ()
+  | _ ->
+    failwith
+      (Printf.sprintf
+         "[%s] expected %S to appear before %S in opentelemetry_client_cohttp_eio.ml"
+         label
+         first
+         second)
+
+let source () =
+  let parent p = Filename.dirname p in
+  let exe = Sys.executable_name in
+  let project_root = parent (parent (parent (parent exe))) in
+  let rel = "lib/otel_spans/opentelemetry_client_cohttp_eio.ml" in
+  let candidates =
+    [ Filename.concat project_root rel
+    ; rel
+    ; Filename.concat ".." rel
+    ]
+  in
+  match List.find_opt Sys.file_exists candidates with
+  | Some path -> read_file path
+  | None ->
+    failwith
+      (Printf.sprintf
+         "no opentelemetry_client_cohttp_eio.ml source path resolved (cwd=%s, exe=%s)"
+         (Sys.getcwd ())
+         exe)
+
+let () =
+  let src = source () in
+  let helper = "let stop_tick_after_poisoned_mutex ~stop cause =" in
+  let stop_flag = "Atomic.set stop true" in
+  let degraded_log_prefix = "OTEL metrics \\" in
+  let degraded_log_suffix = "export degraded until backend restart" in
+  let poison_catch =
+    "| Eio.Mutex.Poisoned cause -> stop_tick_after_poisoned_mutex ~stop cause"
+  in
+  assert_contains ~label:"poison helper" src helper;
+  assert_contains ~label:"poison helper stops tick loop" src stop_flag;
+  assert_contains ~label:"poison log explains degradation prefix" src degraded_log_prefix;
+  assert_contains ~label:"poison log explains degradation suffix" src degraded_log_suffix;
+  assert_contains ~label:"tick catch delegates to poison helper" src poison_catch;
+  assert_order ~label:"stop before degraded log" src stop_flag degraded_log_prefix;
+  assert_order ~label:"helper before catch" src helper poison_catch;
+  print_endline "test_otel_tick_poison_source: OK"


### PR DESCRIPTION
## Summary
- stop the OTEL tick fiber after Eio.Mutex.Poisoned instead of retrying the poisoned backend forever
- clarify the log message: OTEL metrics export is degraded until backend restart
- add a source regression guard for the poisoned tick policy

## Verification
- ocamlformat --check lib/otel_spans/opentelemetry_client_cohttp_eio.ml test/test_otel_tick_poison_source.ml
- env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-otel-tick scripts/dune-local.sh build test/test_otel_tick_poison_source.exe lib/otel_spans/masc_otel_spans.cma
- _build-codex-otel-tick/default/test/test_otel_tick_poison_source.exe