### PR TITLE
[codex] Fix keeper voice session queue cleanup

### DIFF
--- a/lib/keeper/keeper_tool_voice_runtime.ml
+++ b/lib/keeper/keeper_tool_voice_runtime.ml
@@ -118,7 +118,7 @@ let handle_sessions () =
 
 let handle_session_start ~(meta : keeper_meta) ~(args : Yojson.Safe.t) =
   let voice =
-    Safe_ops.json_string_opt "session_name" args
+    Safe_ops.json_string_opt "voice" args
     |> Option.map String.trim
     |> function
     | Some s when s <> "" -> Some s
@@ -130,11 +130,15 @@ let handle_session_start ~(meta : keeper_meta) ~(args : Yojson.Safe.t) =
 
 let handle_session_end ~(meta : keeper_meta) =
   let mgr = Keeper_voice_local.get_session_manager () in
+  let discarded_voice_queue_jobs =
+    Voice_bridge.discard_queued_agent_speak ~agent_id:meta.name
+  in
   let ended = Voice_session_manager.end_session mgr ~agent_id:meta.name in
   Yojson.Safe.to_string
     (`Assoc
         [ "status", `String (if ended then "ended" else "no_active_session")
         ; "agent_id", `String meta.name
+        ; "discarded_voice_queue_jobs", `Int discarded_voice_queue_jobs
         ])
 
 let handle ~(meta : keeper_meta) ~(command : voice_command) ~(args : Yojson.Safe.t) =

--- a/lib/voice/voice_bridge.ml
+++ b/lib/voice/voice_bridge.ml
@@ -700,6 +700,28 @@ let dequeue_speak_job () =
 let queue_size () =
   Stdlib.Mutex.protect speak_queue_mu (fun () -> List.length !speak_queue)
 
+let discard_queued_agent_speak ~agent_id =
+  let removed, remaining =
+    Stdlib.Mutex.protect speak_queue_mu (fun () ->
+      let rec loop kept removed = function
+        | [] -> removed, List.rev kept
+        | job :: rest when String.equal job.agent_id agent_id ->
+          loop kept (removed + 1) rest
+        | job :: rest -> loop (job :: kept) removed rest
+      in
+      let removed, kept = loop [] 0 !speak_queue in
+      speak_queue := kept;
+      removed, List.length kept)
+  in
+  if removed > 0
+  then
+    Log.Transport.warn
+      "voice_queue discarded queued jobs for ended session agent=%s removed=%d remaining=%d"
+      agent_id
+      removed
+      remaining;
+  removed
+
 let rec drain_agent_speak_queue ~sw ~clock ~net () =
   match dequeue_speak_job () with
   | None -> ()
@@ -738,7 +760,29 @@ let rec drain_agent_speak_queue ~sw ~clock ~net () =
          (Printexc.to_string exn));
     drain_agent_speak_queue ~sw ~clock ~net ()
 
-let enqueue_agent_speak ~sw ~clock ~net ~agent_id ~message ?provider ?(priority = 1) () =
+let reset_speak_worker_running () =
+  Stdlib.Mutex.protect speak_queue_mu (fun () -> speak_worker_running := false)
+
+let run_agent_speak_queue_worker ~sw ~clock ~net () =
+  try drain_agent_speak_queue ~sw ~clock ~net () with
+  | Eio.Cancel.Cancelled _ as exn ->
+    reset_speak_worker_running ();
+    raise exn
+  | exn ->
+    reset_speak_worker_running ();
+    raise exn
+
+let enqueue_agent_speak
+      ~sw
+      ~clock
+      ~net
+      ~agent_id
+      ~message
+      ?provider
+      ?(priority = 1)
+      ?(start_worker = true)
+      ()
+  =
   let message = String.trim message in
   if message = ""
   then Error "message is required. Good: message='Hello team.'. Bad: message=''."
@@ -777,12 +821,12 @@ let enqueue_agent_speak ~sw ~clock ~net ~agent_id ~message ?provider ?(priority 
         in
         let queue_position = position 1 !speak_queue in
         let queue_size = List.length !speak_queue in
-        let should_start = not !speak_worker_running in
+        let should_start = start_worker && not !speak_worker_running in
         if should_start then speak_worker_running := true;
         should_start, queue_position, queue_size)
     in
     if should_start
-    then Eio.Fiber.fork ~sw (fun () -> drain_agent_speak_queue ~sw ~clock ~net ());
+    then Eio.Fiber.fork ~sw (fun () -> run_agent_speak_queue_worker ~sw ~clock ~net ());
     Ok
       (`Assoc
           [ "status", `String "queued"

--- a/lib/voice/voice_bridge.mli
+++ b/lib/voice/voice_bridge.mli
@@ -61,12 +61,18 @@ val enqueue_agent_speak :
   message:string ->
   ?provider:string ->
   ?priority:int ->
+  ?start_worker:bool ->
   unit ->
   (Yojson.Safe.t, string) result
 (** Queue speech for serialized background playback. The caller gets a
     [status="queued"] result immediately; a single worker drains queued
     speech by priority and FIFO sequence so multiple keepers do not overlap
-    local playback. *)
+    local playback. [start_worker] defaults to [true]; tests may set it
+    to [false] to assert queue lifecycle behavior before the worker drains. *)
+
+val discard_queued_agent_speak : agent_id:string -> int
+(** Drop queued, not-yet-started speech jobs for [agent_id]. Returns the number
+    of jobs discarded. The current in-flight playback, if any, is not cancelled. *)
 
 val get_agent_voice :
   agent_id:string -> (Yojson.Safe.t, string) result

--- a/test/test_voice_runtime_overlay.ml
+++ b/test/test_voice_runtime_overlay.ml
@@ -14,6 +14,28 @@ let with_env name value f =
     f
 ;;
 
+let rec rm_rf path =
+  if Sys.file_exists path
+  then if Sys.is_directory path
+  then (
+    Sys.readdir path |> Array.iter (fun entry -> rm_rf (Filename.concat path entry));
+    Unix.rmdir path)
+  else Sys.remove path
+;;
+
+let voice_session_test_base =
+  let path = Filename.temp_file "voice-runtime-overlay-" "" in
+  Sys.remove path;
+  Unix.mkdir path 0o755;
+  path
+;;
+
+let () =
+  Unix.putenv "MASC_BASE_PATH" voice_session_test_base;
+  Unix.putenv "MASC_BASE_PATH_INPUT" voice_session_test_base;
+  at_exit (fun () -> rm_rf voice_session_test_base)
+;;
+
 let test_resolve_voice_aliases () =
   let elevenlabs = Option.get (Voice.resolve_adapter "elevenlabs") in
   check string "elevenlabs alias" "elevenlabs-direct" elevenlabs.canonical_name;
@@ -191,7 +213,79 @@ let test_keeper_voice_speak_returns_queued_with_root_switch () =
     check string "queued status" "queued"
       Yojson.Safe.Util.(member "status" json |> to_string);
     check string "background execution" "background_voice_queue"
-      Yojson.Safe.Util.(member "execution" json |> to_string))
+      Yojson.Safe.Util.(member "execution" json |> to_string);
+    ignore (Masc.Voice_bridge.discard_queued_agent_speak ~agent_id:meta.name))
+;;
+
+let test_keeper_voice_session_start_does_not_store_session_name_as_voice () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let net = Eio.Stdenv.net env in
+  let clock = Eio.Stdenv.clock env in
+  let mono_clock = Eio.Stdenv.mono_clock env in
+  Eio_context.with_test_env ~net ~clock ~mono_clock ~sw (fun () ->
+    let meta = make_keeper_meta "voice-session-name-regression" in
+    let session_name = "shutup-shutup-shutup" in
+    let raw =
+      Masc.Keeper_tool_voice_runtime.handle_voice_tool
+        ~meta
+        ~name:"keeper_voice_session_start"
+        ~args:(`Assoc [ "session_name", `String session_name ])
+    in
+    let json = Yojson.Safe.from_string raw in
+    let voice = Yojson.Safe.Util.(member "voice" json |> to_string) in
+    check bool "session_name is not persisted as voice" true
+      (not (String.equal session_name voice));
+    ignore
+      (Masc.Keeper_tool_voice_runtime.handle_voice_tool
+         ~meta
+         ~name:"keeper_voice_session_end"
+         ~args:(`Assoc [])))
+;;
+
+let test_keeper_voice_session_end_discards_queued_speech () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let net = Eio.Stdenv.net env in
+  let clock = Eio.Stdenv.clock env in
+  let mono_clock = Eio.Stdenv.mono_clock env in
+  Eio_context.with_test_env ~net ~clock ~mono_clock ~sw (fun () ->
+    let meta = make_keeper_meta "voice-session-drain-keeper" in
+    ignore
+      (Masc.Keeper_tool_voice_runtime.handle_voice_tool
+         ~meta
+         ~name:"keeper_voice_session_start"
+         ~args:(`Assoc [ "session_name", `String "drain regression" ]));
+    let queued =
+      Masc.Voice_bridge.enqueue_agent_speak
+        ~sw
+        ~clock
+        ~net
+        ~agent_id:meta.name
+        ~message:"queued voice should be discarded"
+        ~start_worker:false
+        ()
+    in
+    (match queued with
+     | Ok speak_json ->
+       check string "queued status" "queued"
+         Yojson.Safe.Util.(member "status" speak_json |> to_string)
+     | Error err -> fail ("expected queued speech, got error: " ^ err));
+    let end_raw =
+      Masc.Keeper_tool_voice_runtime.handle_voice_tool
+        ~meta
+        ~name:"keeper_voice_session_end"
+        ~args:(`Assoc [])
+    in
+    let end_json = Yojson.Safe.from_string end_raw in
+    check string "session ended" "ended"
+      Yojson.Safe.Util.(member "status" end_json |> to_string);
+    check int "discarded queued job" 1
+      Yojson.Safe.Util.(member "discarded_voice_queue_jobs" end_json |> to_int))
 ;;
 
 let () =
@@ -222,6 +316,14 @@ let () =
             "keeper_voice_speak queues on root switch"
             `Quick
             test_keeper_voice_speak_returns_queued_with_root_switch
+        ; test_case
+            "session_start does not store session_name as voice"
+            `Quick
+            test_keeper_voice_session_start_does_not_store_session_name_as_voice
+        ; test_case
+            "session_end discards queued speech"
+            `Quick
+            test_keeper_voice_session_end_discards_queued_speech
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary

- Discard pending Voice_bridge speech jobs for the ending agent when keeper_voice_session_end runs, and return discarded_voice_queue_jobs in the response.
- Stop treating session_name as the persisted session voice; only an explicit voice argument can override the voice.
- Reset the background speech-worker flag if the drain fiber is cancelled or raises, so the queue cannot get stuck in a permanently running state.
- Add focused regressions for stale queued speech and session_name-as-voice corruption, with isolated test MASC_BASE_PATH setup.

Fixes #20242

## Verification

- ocamlformat --check lib/voice/voice_bridge.ml lib/voice/voice_bridge.mli lib/keeper/keeper_tool_voice_runtime.ml test/test_voice_runtime_overlay.ml
- git diff --check
- env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_voice_session_end_fix dune build --root . --display=short -j 1 test/test_voice_runtime_overlay.exe test/keeper_tool_matrix_case_runner.exe
- ./_build_voice_session_end_fix/default/test/test_voice_runtime_overlay.exe
- ./_build_voice_session_end_fix/default/test/keeper_tool_matrix_case_runner.exe keeper_voice_session_start
- ./_build_voice_session_end_fix/default/test/keeper_tool_matrix_case_runner.exe keeper_voice_session_end
- ./_build_voice_session_end_fix/default/test/keeper_tool_matrix_case_runner.exe keeper_voice_speak