### PR TITLE
fix(runtime): skip public MCP policy without bearer

### DIFF
--- a/lib/runtime/runtime_transport_runtime_mcp_policy_of_tool_names.ml
+++ b/lib/runtime/runtime_transport_runtime_mcp_policy_of_tool_names.ml
@@ -37,6 +37,18 @@ let dedupe_preserve_order (items : string list) =
    used only by this sibling. *)
 ;;
 
+let workspace_auth_requires_bearer () =
+  try
+    let base_path = Env_config_core.base_path () in
+    let auth_config = Auth.load_auth_config base_path in
+    auth_config.Masc_domain.enabled && auth_config.Masc_domain.require_token
+  with
+  | Env_config_core.Config_error _ ->
+    (* No resolvable workspace auth state means we cannot safely build an
+       unauthenticated local-MASC runtime policy. *)
+    true
+;;
+
 let runtime_mcp_policy_of_tool_names
       ?agent_name
       ?(allow_agent_internal = false)
@@ -71,9 +83,10 @@ let runtime_mcp_policy_of_tool_names
             ~provider_label:"masc"
             ~outcome:
               (Ok { Auth_resolve.raw = token; source = Auth_resolve.Internal_keeper_env });
-          ("x-masc-internal-token", token)
-          :: ("x-masc-keeper-name", keeper_name)
-          :: agent_header
+          Some
+            (("x-masc-internal-token", token)
+             :: ("x-masc-keeper-name", keeper_name)
+             :: agent_header)
         | _ ->
           let env_token = Mcp_policy_helpers.first_nonempty_env [ "MASC_TOKEN" ] in
           (* Phase A F1: when MASC_TOKEN is unset, fall back to the
@@ -95,29 +108,33 @@ let runtime_mcp_policy_of_tool_names
             | None, None ->
               Error (Auth_resolve.Api_key_env_unset { var_name = "MASC_TOKEN" })
           in
-          Auth_resolve.emit_resolution_trace
-            ~runtime:"runtime_mcp_policy"
-            ~keeper_id:keeper_name
-            ~provider_label:"masc"
-            ~outcome:resolved;
           (match resolved with
-           | Ok { raw; _ } -> [ "Authorization", "Bearer " ^ raw ]
-           | Error _ -> [])
+           | Ok { raw; _ } ->
+             Auth_resolve.emit_resolution_trace
+               ~runtime:"runtime_mcp_policy"
+               ~keeper_id:keeper_name
+               ~provider_label:"masc"
+               ~outcome:resolved;
+             Some [ "Authorization", "Bearer " ^ raw ]
+           | Error _ when workspace_auth_requires_bearer () -> None
+           | Error _ -> Some [])
       in
-      Some
-        { Llm_provider.Llm_transport.empty_runtime_mcp_policy with
-          servers =
-            [ Llm_provider.Llm_transport.Http_server
-                { name = "masc"
-                ; url = Env_config_runtime.Local_runtime.mcp_url ()
-                ; headers = masc_headers
-                }
-            ]
-        ; allowed_server_names = [ "masc" ]
-        ; allowed_tool_names = tool_names
-        ; strict = true
-        ; disable_builtin_tools = true
-        })
+      Option.map
+        (fun masc_headers ->
+           { Llm_provider.Llm_transport.empty_runtime_mcp_policy with
+             servers =
+               [ Llm_provider.Llm_transport.Http_server
+                   { name = "masc"
+                   ; url = Env_config_runtime.Local_runtime.mcp_url ()
+                   ; headers = masc_headers
+                   }
+               ]
+           ; allowed_server_names = [ "masc" ]
+           ; allowed_tool_names = tool_names
+           ; strict = true
+           ; disable_builtin_tools = true
+           })
+        masc_headers)
 ;;
 
 let public_mcp_runtime_policy_of_tool_names ?agent_name (tool_names : string list)

--- a/test/dune
+++ b/test/dune
@@ -259,6 +259,7 @@
   test_shell_ir_typed_review_followup
   test_exec_shell_command_gate
   test_auth_resolve_labels
+  test_runtime_mcp_policy_auth
   test_keeper_classifier_helper
   test_persona_tool_reachability
   test_turn_id_propagation
@@ -511,6 +512,7 @@
   test_shell_ir_typed_review_followup
   test_exec_shell_command_gate
   test_auth_resolve_labels
+  test_runtime_mcp_policy_auth
   test_keeper_classifier_helper
   test_persona_tool_reachability
   test_turn_id_propagation

--- a/test/test_runtime_mcp_policy_auth.ml
+++ b/test/test_runtime_mcp_policy_auth.ml
@@ -1,0 +1,147 @@
+open Alcotest
+
+module Policy = Runtime_transport
+module Auth = Masc.Auth
+
+let with_env name value f =
+  let previous = Sys.getenv_opt name in
+  (match value with
+   | Some v -> Unix.putenv name v
+   | None -> Unix.putenv name "");
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some v -> Unix.putenv name v
+      | None -> Unix.putenv name "")
+    f
+;;
+
+let with_workspace f =
+  let unique =
+    Printf.sprintf
+      "masc-runtime-mcp-policy-auth-%d-%d"
+      (Unix.getpid ())
+      (int_of_float (Unix.gettimeofday () *. 1000.))
+  in
+  let dir = Filename.concat (Filename.get_temp_dir_name ()) unique in
+  Unix.mkdir dir 0o755;
+  let masc_dir = Filename.concat dir Common.masc_dirname in
+  Unix.mkdir masc_dir 0o755;
+  Fun.protect
+    ~finally:(fun () ->
+      let rec rm_rf path =
+        if Sys.file_exists path
+        then
+          if Sys.is_directory path
+          then (
+            Array.iter
+              (fun child -> rm_rf (Filename.concat path child))
+              (Sys.readdir path);
+            Unix.rmdir path)
+          else Sys.remove path
+      in
+      rm_rf dir)
+    (fun () ->
+       with_env "MASC_BASE_PATH" (Some dir) (fun () ->
+         with_env "MASC_BASE_PATH_INPUT" None (fun () ->
+           with_env "MASC_HTTP_BASE_URL" (Some "http://127.0.0.1:8935") (fun () ->
+             f dir))))
+;;
+
+let masc_headers policy =
+  policy.Llm_provider.Llm_transport.servers
+  |> List.find_map (function
+    | Llm_provider.Llm_transport.Http_server { name = "masc"; headers; _ } ->
+      Some headers
+    | _ -> None)
+  |> Option.value ~default:[]
+;;
+
+let find_header key headers =
+  let key_lc = String.lowercase_ascii key in
+  List.find_map
+    (fun (actual, value) ->
+       if String.equal (String.lowercase_ascii actual) key_lc
+       then Some value
+       else None)
+    headers
+;;
+
+let save_auth_config dir ~enabled ~require_token =
+  Auth.save_auth_config dir { Masc_domain.default_auth_config with enabled; require_token }
+;;
+
+let test_public_policy_absent_without_required_bearer () =
+  with_workspace (fun dir ->
+    save_auth_config dir ~enabled:true ~require_token:true;
+    with_env "MASC_TOKEN" None (fun () ->
+      with_env "MASC_INTERNAL_MCP_TOKEN" (Some "internal-token") (fun () ->
+        check
+          bool
+          "required bearer missing returns no public runtime-MCP policy"
+          true
+          (Option.is_none
+             (Policy.public_mcp_runtime_policy_of_tool_names [ "masc_tasks" ])))))
+;;
+
+let test_public_policy_allowed_when_bearer_not_required () =
+  with_workspace (fun dir ->
+    save_auth_config dir ~enabled:true ~require_token:false;
+    with_env "MASC_TOKEN" None (fun () ->
+      match Policy.public_mcp_runtime_policy_of_tool_names [ "masc_tasks" ] with
+      | None -> fail "auth-optional workspace should allow headerless runtime-MCP policy"
+      | Some policy ->
+        check (list (pair string string)) "no auth headers" [] (masc_headers policy)))
+;;
+
+let test_keeper_policy_uses_internal_token_without_public_bearer () =
+  with_workspace (fun dir ->
+    save_auth_config dir ~enabled:true ~require_token:true;
+    let internal_token = "deterministic-internal-token" in
+    Auth.save_internal_keeper_token_hash dir ~raw_token:internal_token;
+    with_env "MASC_TOKEN" None (fun () ->
+      with_env "MASC_INTERNAL_MCP_TOKEN" (Some internal_token) (fun () ->
+        match
+          Policy.runtime_mcp_policy_of_tool_names
+            ~agent_name:"keeper-rondo-agent"
+            [ "masc_tasks" ]
+        with
+        | None -> fail "keeper runtime-MCP policy should use internal token"
+        | Some policy ->
+          let headers = masc_headers policy in
+          check
+            (option string)
+            "internal token header"
+            (Some internal_token)
+            (find_header "x-masc-internal-token" headers);
+          check
+            (option string)
+            "keeper identity header"
+            (Some "rondo")
+            (find_header "x-masc-keeper-name" headers);
+          check
+            (option string)
+            "agent identity header"
+            (Some "keeper-rondo-agent")
+            (find_header "x-masc-agent-name" headers))))
+;;
+
+let () =
+  run
+    "runtime_mcp_policy_auth"
+    [ ( "auth"
+      , [ test_case
+            "public policy absent when required bearer is missing"
+            `Quick
+            test_public_policy_absent_without_required_bearer
+        ; test_case
+            "public policy allowed when bearer is optional"
+            `Quick
+            test_public_policy_allowed_when_bearer_not_required
+        ; test_case
+            "keeper policy uses internal token without public bearer"
+            `Quick
+            test_keeper_policy_uses_internal_token_without_public_bearer
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

Runtime MCP policy creation now fails closed for public `masc` tool forwarding when workspace auth requires a bearer token but neither `MASC_TOKEN` nor a per-agent token is available.

Keeper/internal runtime MCP policy creation still uses `MASC_INTERNAL_MCP_TOKEN` with keeper identity headers.

## Product impact

- User-visible change: removes repeated `auth_resolve: runtime=runtime_mcp_policy provider=masc keeper=- outcome=error reason=api_key_env_unset(var=MASC_TOKEN)` noise for public runtime MCP policy fallback paths, while preserving authenticated keeper tool callbacks.

## Evidence

- Observed live log pattern: `auth_resolve: runtime=runtime_mcp_policy provider=masc keeper=- outcome=error reason=api_key_env_unset(var=MASC_TOKEN)`.
- `ocamlformat --check lib/runtime/runtime_transport_runtime_mcp_policy_of_tool_names.ml test/test_runtime_mcp_policy_auth.ml`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-runtime-mcp-auth scripts/dune-local.sh build test/test_runtime_mcp_policy_auth.exe`
- `_build-codex-runtime-mcp-auth/default/test/test_runtime_mcp_policy_auth.exe`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-runtime-mcp-auth-main scripts/dune-local.sh build bin/main_eio.exe`

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 5/5
provenance: direct
stages:
  - observe_live_log_pattern
  - add_policy_guard
  - add_regression_test
  - run_focused_test
  - build_server_binary
```

## GOAL LOOP ACT checklist

- [x] Observe — live logs showed public `runtime_mcp_policy` resolving `keeper=-` without `MASC_TOKEN`.
- [x] Orient — workspace auth requires bearer tokens, so a headerless public runtime MCP policy would only create a failing local MCP request path.
- [x] Decide — smallest bounded fix is in runtime MCP policy construction, not server auth or keeper internal-token auth.
- [x] Act — public missing-bearer path returns no runtime MCP policy; internal keeper token path remains enabled.
- [x] Verify — added focused regression tests and built `bin/main_eio.exe`.
- [x] Loop — none for this PR; separate existing warnings remain outside this scope.

## Review evidence

- Not run; focused operational regression with local unit coverage and server binary build.

## Linked issue

- Closes #N/A
- Relates #N/A

## Variant addition checklist

- [ ] **OCaml** — N/A, no variant added/removed/renamed.
- [ ] **TypeScript** — N/A, no dashboard union change.
- [ ] **TLA+ spec** — N/A, no domain literal change.
- [ ] **Event / JSON schema** — N/A, no schema enum change.
- [ ] **`make check-variants` passes** — N/A, no variant/schema change.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`fix/runtime-mcp-auth-required-fallback-20260606` → `main` · 1 commit(s) · synced 2026-06-06T02:23:38Z

| sha | subject | date |
|---|---|---|
| `8a35e3c19` | fix(runtime): skip public MCP policy without bearer | 2026-06-05 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->