### PR TITLE
fix(server): restore keeper stream SSE adapter

### DIFF
--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -527,6 +527,71 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
   let now_id () = int_of_float (Time_compat.now () *. 1000.0) in
   let thread_id = "keeper:" ^ payload.name in
 
+  let sse_adapter_loop ~events ~writer ~mutex ~closed =
+    let current_thread_id = ref Ag_ui.default_thread_id in
+    let current_run_id = ref None in
+    let current_message_id = ref None in
+    let run_id_or_unknown () = Option.value ~default:"unknown" !current_run_id in
+    let ag_role (role : Keeper_chat_events.role) =
+      match role with
+      | Keeper_chat_events.User -> Ag_ui.User
+      | Keeper_chat_events.Assistant -> Ag_ui.Assistant
+    in
+    let rec loop () =
+      if not !closed then
+        match Keeper_chat_events.subscribe events with
+        | Run_started { run_id; thread_id } ->
+            current_thread_id := thread_id;
+            current_run_id := Some run_id;
+            if
+              keeper_stream_send_event writer mutex closed
+                Ag_ui.(make_event ~thread_id ~run_id:(Some run_id) Run_started)
+            then loop ()
+        | Text_message_start { message_id; role } ->
+            current_message_id := Some message_id;
+            if
+              keeper_stream_send_event writer mutex closed
+                Ag_ui.(
+                  make_event ~thread_id:!current_thread_id ~run_id:!current_run_id
+                    ~message_id:(Some message_id) ~role:(Some (ag_role role))
+                    Text_message_start)
+            then loop ()
+        | Text_delta text ->
+            if
+              keeper_stream_send_event writer mutex closed
+                Ag_ui.(
+                  make_event ~thread_id:!current_thread_id ~run_id:!current_run_id
+                    ~message_id:!current_message_id ~delta:(Some text)
+                    Text_message_content)
+            then loop ()
+        | Text_message_end ->
+            if
+              keeper_stream_send_event writer mutex closed
+                Ag_ui.(
+                  make_event ~thread_id:!current_thread_id ~run_id:!current_run_id
+                    ~message_id:!current_message_id Text_message_end)
+            then loop ()
+        | Custom { name; value } ->
+            if
+              keeper_stream_send_event writer mutex closed
+                Ag_ui.(
+                  make_event ~thread_id:!current_thread_id ~run_id:!current_run_id
+                    ~custom_name:(Some name) ~custom_value:(Some value) Custom)
+            then loop ()
+        | Error { message } ->
+            send_keeper_error writer mutex closed ~thread_id:!current_thread_id
+              ~run_id:(run_id_or_unknown ()) message
+        | Run_finished { run_id } ->
+            current_run_id := Some run_id;
+            ignore
+              (keeper_stream_send_event writer mutex closed
+                 Ag_ui.(
+                   make_event ~thread_id:!current_thread_id ~run_id:(Some run_id)
+                     Run_finished))
+    in
+    loop ()
+  in
+
   let process_single_turn ~payload ~run_id ~message_id ~agent_name
       ~(events : Keeper_chat_events.keeper_chat_event Eio.Stream.t) =
     Keeper_chat_events.publish events


### PR DESCRIPTION
## Summary

Restore the missing keeper chat SSE adapter loop introduced by the event-stream refactor.

The adapter consumes `Keeper_chat_events` and translates them back into AG-UI SSE events for the dashboard stream.

## Product impact

- User-visible change: fixes current `main` build failure: `Unbound value sse_adapter_loop` in `server_routes_http_keeper_stream.ml`.

## Evidence

- Reproduced compile failure on current `main`: `dune build .` failed at `lib/server/server_routes_http_keeper_stream.ml:731`.
- `ocamlformat --check lib/server/server_routes_http_keeper_stream.ml`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-sse-adapter scripts/dune-local.sh build bin/main_eio.exe`

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 3/3
provenance: direct
stages:
  - reproduce_main_compile_error
  - restore_sse_adapter_loop
  - build_main_eio
```

## GOAL LOOP ACT checklist

- [x] Observe — current main compile failed with `Unbound value sse_adapter_loop`.
- [x] Orient — RFC-0217 event-stream refactor added `Keeper_chat_events` and adapter call sites, but the adapter definition was missing.
- [x] Decide — restore the narrow local adapter instead of reverting the event-stream refactor.
- [x] Act — added `sse_adapter_loop` inside keeper stream handling, preserving AG-UI SSE behavior.
- [x] Verify — focused server binary build passed.
- [x] Loop — none for this PR.

## Review evidence

- Not run; compile-break hotfix with focused build evidence.

## Linked issue

- Closes #N/A
- Relates #N/A

## Variant addition checklist

- [ ] **OCaml** — N/A, no variant added/removed/renamed.
- [ ] **TypeScript** — N/A, no dashboard union change.
- [ ] **TLA+ spec** — N/A, no domain literal change.
- [ ] **Event / JSON schema** — N/A, no schema enum change.
- [ ] **`make check-variants` passes** — N/A, no variant/schema change.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`fix/main-sse-adapter-loop-20260606` → `main` · 1 commit(s) · synced 2026-06-06T02:39:44Z

| sha | subject | date |
|---|---|---|
| `7ded95b32` | fix(server): restore keeper stream SSE adapter | 2026-06-06 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->