### PR TITLE
fix(keeper): keep provider timeouts out of partial commit gate

### DIFF
--- a/lib/keeper/keeper_error_classify_post_commit.ml
+++ b/lib/keeper/keeper_error_classify_post_commit.ml
@@ -54,7 +54,7 @@ let is_ambiguous_side_effect_error (err : Agent_sdk.Error.sdk_error) : bool =
   | Some (Keeper_turn_driver.Internal_unhandled_exception _)
   | Some (Keeper_turn_driver.Internal_bridge_exception _)
   | Some (Keeper_turn_driver.Internal_contract_rejected _) ->
-      true
+      false
 
 let reclassify_error_after_side_effect
     ~(tool_names : string list)

--- a/test/test_oas_timeout_budget_strike.ml
+++ b/test/test_oas_timeout_budget_strike.ml
@@ -131,6 +131,19 @@ let test_attempt_watchdog_timeout_reclassifies_as_provider_timeout () =
     true
     (EC.should_warn_keeper_cycle_failed reclassified)
 
+let test_provider_timeout_is_not_ambiguous_side_effect () =
+  Alcotest.(check bool)
+    "provider timeout is not ambiguous without committed tools"
+    false
+    (EC.is_ambiguous_side_effect_error
+       (provider_timeout_error ~phase:"runtime_attempt_watchdog"))
+
+let test_turn_timeout_is_not_ambiguous_side_effect () =
+  Alcotest.(check bool)
+    "turn timeout is not ambiguous without committed tools"
+    false
+    (EC.is_ambiguous_side_effect_error (turn_timeout_error ()))
+
 let test_strike_limit_routes_through_policy_without_keeper_death () =
   let err = provider_timeout_error ~phase:"stream_idle:streaming_thinking" in
   match
@@ -214,6 +227,14 @@ let () =
           "attempt watchdog timeout reclassifies as provider timeout"
           `Quick
           test_attempt_watchdog_timeout_reclassifies_as_provider_timeout;
+        Alcotest.test_case
+          "provider timeout is not ambiguous partial commit"
+          `Quick
+          test_provider_timeout_is_not_ambiguous_side_effect;
+        Alcotest.test_case
+          "turn timeout is not ambiguous partial commit"
+          `Quick
+          test_turn_timeout_is_not_ambiguous_side_effect;
         Alcotest.test_case "strike limit uses policy, not keeper death" `Quick
           test_strike_limit_routes_through_policy_without_keeper_death;
         Alcotest.test_case "capacity phase routes to provider tuning" `Quick


### PR DESCRIPTION
## Summary
- classify provider/turn timeout errors as unambiguous failures, not ambiguous side-effect errors
- add regression coverage so timeout-only turns do not route into partial-commit gates

## Verification
- env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-provider-timeout dune build --root . test/test_oas_timeout_budget_strike.exe
- _build-codex-provider-timeout/default/test/test_oas_timeout_budget_strike.exe