### PR TITLE
fix(dashboard): show paused keeper roster rows

### DIFF
--- a/dashboard/src/components/agent-roster.test.ts
+++ b/dashboard/src/components/agent-roster.test.ts
@@ -278,7 +278,7 @@ describe('rosterBlockerDisplay', () => {
 })
 
 describe('countRuntimeKinds', () => {
-  it('excludes configured-only paused keepers from live runtime counts', () => {
+  it('keeps configured paused keepers as detail rows without counting them as running', () => {
     const result = countRuntimeKinds(
       [],
       [
@@ -301,10 +301,10 @@ describe('countRuntimeKinds', () => {
     expect(result).toEqual({
       agents: 0,
       keepers: 1,
-      pausedKeepers: 0,
+      pausedKeepers: 1,
       offlineKeepers: 0,
-      keeperRows: 1,
-      totalRuntimes: 1,
+      keeperRows: 2,
+      totalRuntimes: 2,
     })
   })
 
@@ -591,6 +591,43 @@ describe('AgentRoster live-only cards', () => {
     expect(text).not.toContain('Source mismatch')
     expect(text).not.toContain('agent registry 0')
     expect(text).not.toContain('파생')
+  })
+
+  it('renders paused configured keepers even without live agent presence', async () => {
+    agents.value = []
+    keepers.value = [
+      {
+        name: 'albini',
+        agent_name: 'keeper-albini-agent',
+        status: 'paused',
+        phase: 'Paused',
+        pipeline_stage: 'paused',
+        paused: true,
+        registered: false,
+        keepalive_running: false,
+      } as Keeper,
+      {
+        name: 'rondo',
+        agent_name: 'keeper-rondo-agent',
+        status: 'idle',
+        phase: 'Running',
+        pipeline_stage: 'idle',
+        keepalive_running: true,
+      } as Keeper,
+    ]
+
+    await act(async () => {
+      render(html`<${AgentRoster} keeperFilter="keeper-only" />`, container)
+    })
+    await flushUi()
+
+    const rows = container.querySelectorAll('[data-testid="keeper-operations-row"]')
+    const text = container.textContent ?? ''
+    expect(rows.length).toBe(2)
+    expect(text).toContain('albini')
+    expect(text).toContain('rondo')
+    expect(text).toContain('일시정지')
+    expect(text).not.toContain('상세 상태 부분 동기화')
   })
 
   it('does not report source mismatch on default keeper ops when keeper projection has rows', async () => {

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -293,15 +293,12 @@ function findKeeperRuntimeForAgent(
 type KeeperFilterMode = 'all' | 'agent-only' | 'keeper-only'
 type RosterAgent = Agent & { rosterSource?: 'agent_registry' | 'keeper_runtime' }
 
-function isRuntimeBackedKeeper(keeper: Keeper): boolean {
+function keeperHasRuntimeDetailRow(keeper: Keeper): boolean {
+  // Paused keepers are not live capacity, but execution still sends them as
+  // operator-visible detail rows. Keep them in the roster so "설정 N" does not
+  // degrade into count-only inventory with missing paused rows.
+  if (isKeeperPaused(keeper)) return true
   if (keeper.registered === false && keeper.keepalive_running === false) return false
-  // RFC-0135 PR-13: use canonical paused predicate. SSOT also covers
-  // `phase === 'Paused'` / `status === 'paused'` / `pipeline_stage ===
-  // 'paused'`. Effect: an FSM-paused but-not-flag-paused keeper that
-  // also lost registration + keepalive is now filtered out, matching
-  // the "no real backing runtime" intent the original `paused === true`
-  // check captured only partially.
-  if (isKeeperPaused(keeper) && keeper.registered !== true && keeper.keepalive_running !== true) return false
   return true
 }
 
@@ -333,13 +330,13 @@ function liveAgentIdentityKeys(agentList: readonly Agent[]): Set<string> {
   return keys
 }
 
-function runtimeBackedKeepers(
+function rosterDetailKeepers(
   keeperList: Keeper[],
   agentList: readonly Agent[] = [],
 ): Keeper[] {
   const liveAgentKeys = liveAgentIdentityKeys(agentList)
   return keeperList.filter(keeper =>
-    isRuntimeBackedKeeper(keeper) || keeperHasLiveAgentPresence(keeper, liveAgentKeys))
+    keeperHasRuntimeDetailRow(keeper) || keeperHasLiveAgentPresence(keeper, liveAgentKeys))
 }
 
 function expectedCountForKeeperFilter(
@@ -570,7 +567,7 @@ export function countRuntimeKinds(
   keeperRows: number
   totalRuntimes: number
 } {
-  const runtimeKeepers = runtimeBackedKeepers(keeperList, agentList)
+  const runtimeKeepers = rosterDetailKeepers(keeperList, agentList)
   const rosterAgents = buildAgentRoster(agentList, runtimeKeepers)
   const keeperLookup = buildKeeperRuntimeLookup(runtimeKeepers)
   const allKeepers = scopeAgentsByKeeperFilter(rosterAgents, runtimeKeepers, 'keeper-only', keeperLookup)
@@ -609,7 +606,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
   const agentList = agents.value
   const keeperList = keepers.value
   const runtimeKeeperList = useMemo(
-    () => runtimeBackedKeepers(keeperList, agentList),
+    () => rosterDetailKeepers(keeperList, agentList),
     [keeperList, agentList],
   )
 


### PR DESCRIPTION
## Summary

- keep paused keeper execution rows visible in the Monitor > Keeper Fleet roster
- rename the private roster helper so it no longer implies every visible row is live runtime capacity
- add regression coverage for paused configured keepers without live agent presence

## Root Cause

The dashboard already received 15 keeper execution rows, but the roster filtered out paused keepers when they lacked `registered` or `keepalive_running` signals. That made the UI show `설정 15` as count-only inventory while rendering only the one running keeper row.

## Validation

- `pnpm exec vitest run --config vitest.config.ts src/components/agent-roster.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec eslint src/components/agent-roster.ts`
