### PR TITLE
fix(server): avoid fallback run id in SSE errors

### DIFF
--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -602,11 +602,24 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
     let current_thread_id = ref Ag_ui.default_thread_id in
     let current_run_id = ref None in
     let current_message_id = ref None in
-    let run_id_or_unknown () = Option.value ~default:"unknown" !current_run_id in
     let ag_role (role : Keeper_chat_events.role) =
       match role with
       | Keeper_chat_events.User -> Ag_ui.User
       | Keeper_chat_events.Assistant -> Ag_ui.Assistant
+    in
+    let send_error message =
+      match !current_run_id with
+      | Some run_id ->
+          send_keeper_error writer mutex closed ~thread_id:!current_thread_id
+            ~run_id message
+      | None ->
+          ignore
+            (keeper_stream_send_event writer mutex closed
+               Ag_ui.(
+                 make_event ~thread_id:!current_thread_id
+                   ~custom_name:(Some "KEEPER_CHAT_ERROR")
+                   ~custom_value:(Some (`Assoc [ ("message", `String message) ]))
+                   Run_error))
     in
     let rec loop () =
       if not !closed then
@@ -649,9 +662,7 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
                   make_event ~thread_id:!current_thread_id ~run_id:!current_run_id
                     ~custom_name:(Some name) ~custom_value:(Some value) Custom)
             then loop ()
-        | Error { message } ->
-            send_keeper_error writer mutex closed ~thread_id:!current_thread_id
-              ~run_id:(run_id_or_unknown ()) message
+        | Error { message } -> send_error message
         | Run_finished { run_id } ->
             current_run_id := Some run_id;
             ignore


### PR DESCRIPTION
## Summary

Remove the fallback `"unknown"` run id from keeper stream SSE error adaptation.

When a keeper chat error arrives before a `Run_started` event, the adapter now emits a `RUN_ERROR` without `runId` instead of fabricating one.

## Product impact

- User-visible change: clears the deterministic-boundary guard failure left by the keeper SSE adapter hotfix.

## Evidence

- `ocamlformat --check lib/server/server_routes_http_keeper_stream.ml`
- `bash scripts/ci/check-determinism-contract.sh`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-sse-adapter-det2 scripts/dune-local.sh build bin/main_eio.exe`

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 3/3
provenance: direct
stages:
  - ocamlformat_changed_file
  - deterministic_contract_guard
  - build_main_eio
```

## GOAL LOOP ACT checklist

- [x] Observe — CI Meta Guards failed on `Option.value ~default:"unknown"` in `server_routes_http_keeper_stream.ml`.
- [x] Orient — `Error` events do not always carry a run id; fabricating one violates the deterministic-boundary ratchet.
- [x] Decide — emit run-id-free `RUN_ERROR` when no current run exists.
- [x] Act — replaced the fallback helper with explicit `Some run_id` / `None` handling.
- [x] Verify — deterministic contract guard and focused server binary build pass.
- [x] Loop — none for this PR.

## Review evidence

- Not run; CI guard follow-up with focused local proof.

## Linked issue

- Closes #N/A
- Relates #N/A

## Variant addition checklist

- [ ] **OCaml** — N/A, no variant added/removed/renamed.
- [ ] **TypeScript** — N/A, no dashboard union change.
- [ ] **TLA+ spec** — N/A, no domain literal change.
- [ ] **Event / JSON schema** — N/A, no schema enum change.
- [ ] **`make check-variants` passes** — N/A, no variant/schema change.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`fix/main-sse-adapter-det-20260606` → `main` · 1 commit(s) · synced 2026-06-06T02:53:39Z

| sha | subject | date |
|---|---|---|
| `752e6c572` | fix(server): avoid fallback run id in SSE errors | 2026-06-06 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->