### PR TITLE
fix(dashboard): clarify keeper paused vs offline states

### DIFF
--- a/dashboard/src/components/agent-roster.test.ts
+++ b/dashboard/src/components/agent-roster.test.ts
@@ -642,6 +642,27 @@ describe('AgentRoster live-only cards', () => {
     expect(text).not.toContain('상세 상태 부분 동기화')
   })
 
+  it('does not show keeper boot hints on offline non-keeper agent rows', async () => {
+    agents.value = [
+      makeAgent({
+        name: 'mission-shadow',
+        status: 'offline',
+      }),
+    ]
+    keepers.value = []
+
+    await act(async () => {
+      render(html`<${AgentRoster} keeperFilter="agent-only" />`, container)
+    })
+    await flushUi()
+
+    const text = container.textContent ?? ''
+    expect(text).toContain('mission-shadow')
+    expect(text).toContain('오프라인')
+    expect(text).toContain('연결 없음')
+    expect(text).not.toContain('기동 필요')
+  })
+
   it('does not report source mismatch on default keeper ops when keeper projection has rows', async () => {
     agents.value = []
     keepers.value = [

--- a/dashboard/src/components/agent-roster.test.ts
+++ b/dashboard/src/components/agent-roster.test.ts
@@ -614,6 +614,14 @@ describe('AgentRoster live-only cards', () => {
         pipeline_stage: 'idle',
         keepalive_running: true,
       } as Keeper,
+      {
+        name: 'qa-king',
+        agent_name: 'keeper-qa-king-agent',
+        status: 'offline',
+        phase: 'Offline',
+        pipeline_stage: 'offline',
+        keepalive_running: false,
+      } as Keeper,
     ]
 
     await act(async () => {
@@ -623,10 +631,14 @@ describe('AgentRoster live-only cards', () => {
 
     const rows = container.querySelectorAll('[data-testid="keeper-operations-row"]')
     const text = container.textContent ?? ''
-    expect(rows.length).toBe(2)
+    expect(rows.length).toBe(3)
     expect(text).toContain('albini')
     expect(text).toContain('rondo')
+    expect(text).toContain('qa-king')
     expect(text).toContain('일시정지')
+    expect(text).toContain('재개 대기')
+    expect(text).toContain('오프라인')
+    expect(text).toContain('기동 필요')
     expect(text).not.toContain('상세 상태 부분 동기화')
   })
 

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -78,12 +78,12 @@ type StatusFilter = 'all' | RuntimeBand
 type RosterStateNote = { label: string; text: string; kind?: string }
 type RosterPresenceDisplay = { status: string | null; detail: string | null }
 
-function rosterBandActionHint(band: RuntimeBand): string {
+function rosterBandActionHint(band: RuntimeBand, isKeeper: boolean): string {
   switch (band) {
     case 'active': return '감시 중'
     case 'attention': return '확인 필요'
     case 'paused': return '재개 대기'
-    case 'offline': return '기동 필요'
+    case 'offline': return isKeeper ? '기동 필요' : '연결 없음'
   }
 }
 
@@ -930,8 +930,8 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
       agent,
       keeperRuntime,
       band,
-      bandActionHint: rosterBandActionHint(band.key),
       isKeeper,
+      bandActionHint: rosterBandActionHint(band.key, isKeeper),
       displayName,
       currentWork,
       summaryText,

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -78,6 +78,15 @@ type StatusFilter = 'all' | RuntimeBand
 type RosterStateNote = { label: string; text: string; kind?: string }
 type RosterPresenceDisplay = { status: string | null; detail: string | null }
 
+function rosterBandActionHint(band: RuntimeBand): string {
+  switch (band) {
+    case 'active': return '감시 중'
+    case 'attention': return '확인 필요'
+    case 'paused': return '재개 대기'
+    case 'offline': return '기동 필요'
+  }
+}
+
 // PipelineStage SSOT: branches aligned to `types/core.ts#PipelineStage`.
 // Legacy `tool_use` / `scheduled_autonomous` / `thinking` removed — the
 // backend never emits them as pipeline_stage.
@@ -120,10 +129,11 @@ function rosterContextMeta(
  *  - stuck             → `현재 차단`  (text: backend summary or typed reason)
  *  - running + staleBlocker → `이전 차단` (informational; not a headline)
  *  - running           → fallback to diagnostic error / monitoring hint
- *  - paused / offline  → null — these states are signaled by the row's
- *                         phase badge and dedicated chips elsewhere; the
- *                         state-note slot stays available for extra
- *                         operational context only.
+ *  - paused           → pause cause when available, because it explains the
+ *                       resume gate.
+ *  - offline          → interrupted work / diagnostics / monitoring hint when
+ *                       available; otherwise the row action axis carries the
+ *                       "start required" state.
  */
 export function rosterStateNote(
   keeper: Keeper | null | undefined,
@@ -920,6 +930,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
       agent,
       keeperRuntime,
       band,
+      bandActionHint: rosterBandActionHint(band.key),
       isKeeper,
       displayName,
       currentWork,
@@ -1083,8 +1094,12 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                     </span>
                   </span>
 
-                  <span class="inline-flex w-fit items-center rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-0.5 text-3xs font-medium text-[var(--color-fg-primary)] lg:w-auto">
-                    ${row.band.label}
+                  <span
+                    class="inline-flex w-fit min-w-[4.5rem] flex-col items-start rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-1 text-3xs font-medium leading-tight text-[var(--color-fg-primary)] lg:w-auto"
+                    title=${row.band.description}
+                  >
+                    <span>${row.band.label}</span>
+                    <span class="mt-0.5 text-[10px] font-normal text-[var(--color-fg-muted)]">${row.bandActionHint}</span>
                   </span>
 
                   <span class="min-w-0 text-xs leading-snug text-[var(--color-fg-primary)]">
@@ -1149,6 +1164,10 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                     ${selectedRow.fsmStageText}
                   </span>
                 ` : null}
+                <span class="inline-flex items-center rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-0.5 text-3xs text-[var(--color-fg-muted)]" title=${selectedRow.band.description}>
+                  상태 액션
+                  <span class="ml-1 text-[var(--color-fg-primary)]">${selectedRow.bandActionHint}</span>
+                </span>
                 <span class="inline-flex items-center rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-0.5 text-3xs text-[var(--color-fg-muted)]">
                   ${selectedRow.lastActivityLabel}
                   <span class="ml-1 text-[var(--color-fg-primary)]">

--- a/dashboard/src/components/dashboard-shell.test.ts
+++ b/dashboard/src/components/dashboard-shell.test.ts
@@ -75,7 +75,11 @@ describe('dashboardHealthChips', () => {
     expect(chips.find(chip => chip.key === 'keeper-count-basis')?.label)
       .toBe('키퍼 런타임 가동 1 / 일시정지 1 / 설정 2')
     expect(chips.find(chip => chip.key === 'keeper-count-basis')?.detail)
-      .toBe('런타임 가동=shell, paused=상세 행 lifecycle, offline=상세 행 status, 설정=shell keeper inventory.')
+      .toBe('런타임 가동=shell; 일시정지=재개 대기 lifecycle row; 오프라인=프로세스/하트비트 없음으로 기동 필요 row; 설정=shell keeper 설정.')
+    expect(chips.find(chip => chip.key === 'paused-keepers')?.label)
+      .toBe('일시정지 keeper 1')
+    expect(chips.find(chip => chip.key === 'paused-keepers')?.detail)
+      .toBe('재개 대기 상태의 keeper가 있습니다. board/tool 활동은 조용해 보일 수 있습니다.')
   })
 
   it('does not label an intentional server/base split as data source mismatch', () => {
@@ -117,7 +121,7 @@ describe('dashboardHealthChips', () => {
     expect(chips.find(chip => chip.key === 'keeper-count-basis')?.label)
       .toBe('키퍼 런타임 가동 2 / 설정 16')
     expect(chips.find(chip => chip.key === 'keeper-count-basis')?.detail)
-      .toBe('런타임 가동=shell, paused=상세 행 lifecycle, offline=상세 행 status, 설정=project snapshot keeper inventory.')
+      .toBe('런타임 가동=shell; 일시정지=재개 대기 lifecycle row; 오프라인=프로세스/하트비트 없음으로 기동 필요 row; 설정=project snapshot keeper 설정.')
   })
 
   it('returns a healthy chip when no runtime risk is visible', () => {

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -166,7 +166,7 @@ interface DashboardHealthChip {
   tone: DashboardHealthChipTone
   // Optional drill-down route. When set, DashboardHealthStrip renders this
   // chip as a RouteLink so operators can jump from "Source mismatch" /
-  // "Paused keepers N" / "Reaction ledger pending N" straight to the page
+  // "일시정지 keeper N" / "Reaction ledger pending N" straight to the page
   // that explains the signal. Chips without a route render as static spans
   // (e.g. transport-offline — no view helps).
   route?: DashboardHealthChipRoute
@@ -488,7 +488,7 @@ export function dashboardHealthChips(input: DashboardHealthInput): DashboardHeal
         offlineKeepers: runtimeCounts.live.offlineKeepers,
         configuredKeepers: configured,
       }),
-      detail: `런타임 가동=${runningCountSource}, paused=상세 행 lifecycle, offline=상세 행 status, 설정=${configuredCountSourceLabel(runtimeCounts.configured.source)} keeper inventory.`,
+      detail: `런타임 가동=${runningCountSource}; 일시정지=재개 대기 lifecycle row; 오프라인=프로세스/하트비트 없음으로 기동 필요 row; 설정=${configuredCountSourceLabel(runtimeCounts.configured.source)} keeper 설정.`,
       tone: 'muted',
     })
   }
@@ -496,8 +496,8 @@ export function dashboardHealthChips(input: DashboardHealthInput): DashboardHeal
   if (pausedKeepers > 0) {
     chips.push({
       key: 'paused-keepers',
-      label: `Paused keepers ${pausedKeepers}`,
-      detail: 'One or more keeper rows are paused; board/tool activity may look quiet.',
+      label: `일시정지 keeper ${pausedKeepers}`,
+      detail: '재개 대기 상태의 keeper가 있습니다. board/tool 활동은 조용해 보일 수 있습니다.',
       tone: 'warn',
     })
   }

--- a/dashboard/src/lib/monitoring-runtime.test.ts
+++ b/dashboard/src/lib/monitoring-runtime.test.ts
@@ -38,12 +38,15 @@ describe('runtimeBandMeta', () => {
     const meta = runtimeBandMeta('paused')
     expect(meta.key).toBe('paused')
     expect(meta.label).toContain('일시정지')
+    expect(meta.description).toContain('재개')
+    expect(meta.description).not.toContain('운영자')
   })
 
   it('returns offline meta', () => {
     const meta = runtimeBandMeta('offline')
     expect(meta.key).toBe('offline')
     expect(meta.label).toContain('오프라인')
+    expect(meta.description).toContain('기동')
   })
 })
 
@@ -111,6 +114,20 @@ describe('summarizeMonitoringEvidence', () => {
 })
 
 describe('summarizeKeeperMonitoring', () => {
+  it('describes paused keepers as resume-waiting instead of operator-only', () => {
+    const summary = summarizeKeeperMonitoring({
+      name: 'keeper-paused',
+      status: 'paused',
+      phase: 'Paused',
+      pipeline_stage: 'paused',
+      paused: true,
+    } as Keeper)
+
+    expect(summary.band.key).toBe('paused')
+    expect(summary.hint).toContain('재개 대기')
+    expect(summary.hint).not.toContain('운영자')
+  })
+
   it('ignores stale last_blocker text when no live runtime blocker is present', () => {
     const summary = summarizeKeeperMonitoring({
       name: 'keeper-a',

--- a/dashboard/src/lib/monitoring-runtime.ts
+++ b/dashboard/src/lib/monitoring-runtime.ts
@@ -59,7 +59,7 @@ const PHASE_LABELS: Record<string, PhaseMeta> = {
   Compacting: { key: 'Compacting', label: '압축중', description: '컨텍스트를 정리하는 중입니다.' },
   HandingOff: { key: 'HandingOff', label: '승계중', description: '새 세대로 넘기는 중입니다.' },
   Draining: { key: 'Draining', label: '종료중', description: '현재 작업을 마무리하는 중입니다.' },
-  Paused: { key: 'Paused', label: '일시정지', description: '운영자가 keeper를 일시정지했습니다.' },
+  Paused: { key: 'Paused', label: '일시정지', description: 'keeper가 재개 대기 상태로 멈춰 있습니다.' },
   Stopped: { key: 'Stopped', label: '정지', description: '정상 정지된 런타임입니다.' },
   Crashed: { key: 'Crashed', label: '비정상종료', description: 'fiber가 비정상적으로 종료되었습니다.' },
   Restarting: { key: 'Restarting', label: '재시작중', description: '복구를 시도하고 있습니다.' },
@@ -69,7 +69,7 @@ const PHASE_LABELS: Record<string, PhaseMeta> = {
   busy: { key: 'busy', label: '작업중', description: '프로세스는 살아 있고 현재 작업을 수행 중입니다.' },
   listening: { key: 'listening', label: '대기중', description: '프로세스는 살아 있고 입력을 기다리고 있습니다.' },
   idle: { key: 'idle', label: '대기', description: '프로세스는 살아 있지만 현재 턴 작업은 없습니다.' },
-  paused: { key: 'paused', label: '일시정지', description: '운영자가 keeper를 일시정지했습니다.' },
+  paused: { key: 'paused', label: '일시정지', description: 'keeper가 재개 대기 상태로 멈춰 있습니다.' },
   stopped: { key: 'stopped', label: '정지', description: '이전에 실행되었지만 현재는 정지 상태입니다.' },
   unbooted: { key: 'unbooted', label: '미기동', description: '등록만 되어 있고 아직 부팅되지 않았습니다.' },
   offline: { key: 'offline', label: '오프라인', description: '런타임 연결을 확인하지 못했습니다.' },
@@ -123,12 +123,12 @@ const BAND_META: Record<RuntimeBand, RuntimeBandMeta> = {
   paused: {
     key: 'paused',
     label: '일시정지',
-    description: '운영자가 의도적으로 멈춰 둔 상태입니다.',
+    description: '실행은 멈춰 있지만 재개 대상으로 남아 있는 상태입니다.',
   },
   offline: {
     key: 'offline',
     label: '오프라인',
-    description: '프로세스가 내려갔거나 아직 부팅되지 않았습니다.',
+    description: '프로세스나 하트비트를 확인하지 못해 기동이 필요한 상태입니다.',
   },
 }
 
@@ -182,7 +182,7 @@ function keeperHint(
 ): string | null {
   const signalHint = projection.signals.find(signal => signal.contributesToAttention && signal.hint !== null)?.hint
   if (signalHint) return signalHint
-  if (band === 'paused') return '운영자가 멈춰 둔 상태입니다.'
+  if (band === 'paused') return '재개 대기 상태입니다. 원인은 차단/오류 근거를 확인하세요.'
   if (band === 'attention') return stage.description
   if (band === 'offline' && keeper.generation === 0 && (keeper.turn_count ?? 0) === 0) {
     return '아직 부팅된 적 없는 등록 런타임입니다.'


### PR DESCRIPTION
## Summary
- show a small action-axis hint on keeper roster state badges: paused = 재개 대기, keeper offline = 기동 필요
- gate boot-required hints to keeper rows; non-keeper offline rows now show neutral 연결 없음
- update monitoring copy so paused is not described as operator-only
- clarify the dashboard health chip count basis for paused/offline/configured keeper counts

## Verification
- pnpm exec vitest run --config vitest.config.ts src/components/agent-roster.test.ts src/components/dashboard-shell.test.ts src/lib/monitoring-runtime.test.ts --no-file-parallelism --maxWorkers=1 (68 passed)
- pnpm exec tsc --noEmit --pretty false
- pnpm exec eslint --no-warn-ignored src/components/agent-roster.ts src/components/dashboard-shell.ts src/lib/monitoring-runtime.ts
- GitHub CI: Dashboard, Lint, Health, Build and Test, TLA+ Model Checking, CI Gate passed
- Conflict check: git merge-tree --write-tree HEAD origin/main completed without conflicts