### PR TITLE
feat(dashboard): add runtime.toml editor

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,11 +201,11 @@ Cross-model review evidence should use direct `sb glm-text` when available. If a
 
 ### MODEL Runtime
 
-- Runtime order is controlled by `Provider_registry` and `config/keeper_runtime.toml` (hot-reloaded)
-- Missing or invalid `keeper_runtime.toml` is a config error; the retired `runtime.json` fallback is not used.
+- Runtime order is controlled by `runtime.toml` at the resolved config root.
+- Missing or invalid `runtime.toml` is a config error; the retired `runtime.json` fallback is not used.
 - If a slot returns empty or errors, the next slot is tried
 - Claude API keys are rotated round-robin per heartbeat tick
-- Configuration in `config/keeper_runtime.toml`, hot-reloaded by mtime check
+- Runtime catalog changes in `runtime.toml` apply on the next runtime resolve.
 
 ### Runtime Lens Boundary (provider/model identity in JSON)
 

--- a/README.md
+++ b/README.md
@@ -232,13 +232,13 @@ Reload 계약 ([docs/TOML-RELOAD-MATRIX.md](docs/TOML-RELOAD-MATRIX.md)):
 
 - env vars → boot 시점 고정 (런타임 control plane 이 명시적으로 reload 하지 않는 한)
 - `config/keepers/*.toml` → 다음 supervisor sweep 에서 reconcile
-- `config/keeper_runtime.toml` → 다음 model resolve / turn 에서 in-memory render
-- `config/keeper_runtime.toml`, `config/tool_policy.toml` → restart 필요
+- `config/runtime.toml` runtime catalog / assignments → 다음 model resolve / turn 에서 in-memory render
+- `config/runtime.toml` 의 boot-only keeper env seed, `config/tool_policy.toml` → restart 필요
 
 ## Model Runtime
 
 - 작성 매뉴얼: [docs/spec/14-configuration.md](docs/spec/14-configuration.md)
-- live SSOT: `config/keeper_runtime.toml` (`config/runtime.json` 은 retired, 더 이상 생성/소비되지 않음)
+- live SSOT: `config/runtime.toml` (`config/runtime.json` 은 retired, 더 이상 생성/소비되지 않음)
 - 스키마 / parsing / 선택 정책 은 MASC 소유. OAS 에는 *해결된 단일 provider/model* 만 넘어갑니다.
 - keeper TOML 안의 `runtime_id` 으로 per-keeper override 가능.
 - 시드에서 keeper 가 정상 선택할 수 있는 프로필은 `primary` 뿐. `default`, `local_only`, `local_recovery`, `scoring` 은 시스템 전용 plumbing.
@@ -386,7 +386,7 @@ raw `opam exec -- dune ...` 은 의도적인 CI-parity 점검 때만. 평소 개
 | [docs/QUICK-START.md](docs/QUICK-START.md) | 설치, health, 첫 워크플로 |
 | [docs/BOOT-ENV-STATE-INVENTORY.md](docs/BOOT-ENV-STATE-INVENTORY.md) | boot / path / state / active config inventory |
 | [docs/MCP-TEMPLATE.md](docs/MCP-TEMPLATE.md) | HTTP / stdio MCP 클라이언트 템플릿 |
-| [docs/spec/14-configuration.md](docs/spec/14-configuration.md) | keeper_runtime.toml 작성 매뉴얼 |
+| [docs/spec/14-configuration.md](docs/spec/14-configuration.md) | runtime.toml 작성 매뉴얼 |
 | [docs/OAS-MASC-BOUNDARY.md](docs/OAS-MASC-BOUNDARY.md) | OAS / MASC 소유 경계 |
 | [docs/KEEPER-USER-MANUAL.md](docs/KEEPER-USER-MANUAL.md) | keeper 라이프사이클, sandbox profile, Docker one-shot/managed 실행, 트러블슈팅 |
 | [docs/SUPERVISOR-MODE.md](docs/SUPERVISOR-MODE.md) | supervisor / operator 워크플로 |

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -18,7 +18,9 @@ import {
   fetchKeeperDecisions,
   fetchMemorySubsystems,
   fetchRuntimeProviders,
+  fetchRuntimeTomlConfig,
   fetchRuntimeModelMetrics,
+  saveRuntimeTomlConfig,
   fetchDashboardCacheStats,
   fetchTelemetry,
   fetchTelemetrySummary,
@@ -1609,6 +1611,59 @@ describe('fetchKeeperConfig', () => {
       expect(result.runtime.runtime_blocker_class).toBe(blockerClass)
       expect(keeperRuntimeBlockerLabel(result.runtime.runtime_blocker_class)).toBe(label)
     }
+  })
+})
+
+describe('runtime.toml raw config API', () => {
+  it('fetches and normalizes the raw runtime.toml source', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        ok: true,
+        path: '/tmp/.masc/config/runtime.toml',
+        file_name: 'runtime.toml',
+        source_text: '[runtime]\ndefault = "runpod_mtp.qwen"\n',
+        reloaded: false,
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchRuntimeTomlConfig()
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/runtime/config/raw')
+    expect(result.path).toBe('/tmp/.masc/config/runtime.toml')
+    expect(result.file_name).toBe('runtime.toml')
+    expect(result.source_text).toContain('[runtime]')
+    expect(result.reloaded).toBe(false)
+  })
+
+  it('posts the full raw TOML source through source_text', async () => {
+    const sourceText = '[runtime]\ndefault = "openai.gpt"\n'
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        ok: true,
+        path: '/tmp/.masc/config/runtime.toml',
+        file_name: 'runtime.toml',
+        source_text: sourceText,
+        reloaded: true,
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await saveRuntimeTomlConfig(sourceText)
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('/api/v1/runtime/config/raw')
+    expect(init.method).toBe('POST')
+    expect(JSON.parse(init.body as string)).toEqual({ source_text: sourceText })
+    expect(result.reloaded).toBe(true)
+    expect(result.source_text).toBe(sourceText)
   })
 })
 

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -2254,6 +2254,37 @@ export function patchKeeperConfig(
   ).then(raw => normalizeKeeperConfig(raw, name))
 }
 
+// --- Runtime config (raw runtime.toml editor) ---
+
+export interface RuntimeTomlConfig {
+  ok: boolean
+  path: string | null
+  file_name: string
+  source_text: string
+  reloaded: boolean
+}
+
+function normalizeRuntimeTomlConfig(raw: unknown): RuntimeTomlConfig {
+  const record = isRecord(raw) ? raw : {}
+  return {
+    ok: asBoolean(record.ok) ?? true,
+    path: asNullableString(record.path),
+    file_name: asString(record.file_name) ?? 'runtime.toml',
+    source_text: asString(record.source_text, ''),
+    reloaded: asBoolean(record.reloaded) ?? false,
+  }
+}
+
+export function fetchRuntimeTomlConfig(): Promise<RuntimeTomlConfig> {
+  return get<unknown>('/api/v1/runtime/config/raw').then(normalizeRuntimeTomlConfig)
+}
+
+export function saveRuntimeTomlConfig(sourceText: string): Promise<RuntimeTomlConfig> {
+  return post<unknown>('/api/v1/runtime/config/raw', {
+    source_text: sourceText,
+  }).then(normalizeRuntimeTomlConfig)
+}
+
 // --- Keeper trajectory (tool call history) ---
 
 type TrajectoryGate = {

--- a/dashboard/src/components/runtime-panel.test.ts
+++ b/dashboard/src/components/runtime-panel.test.ts
@@ -18,6 +18,9 @@ async function loadRuntimePanel() {
   vi.doMock('./runtime-monitor', () => ({
     RuntimeMonitor: () => html`<div data-testid="runtime-monitor">RuntimeMonitor</div>`,
   }))
+  vi.doMock('./runtime-toml-editor', () => ({
+    RuntimeTomlEditor: () => html`<div data-testid="runtime-toml-editor">RuntimeTomlEditor</div>`,
+  }))
   vi.doMock('./otel-metrics', () => ({
     OtelMetrics: () => html`<div data-testid="metrics">OtelMetrics</div>`,
   }))
@@ -62,6 +65,7 @@ describe('RuntimePanel', () => {
     vi.doUnmock('../router')
     vi.doUnmock('./oas-health-chip')
     vi.doUnmock('./runtime-monitor')
+    vi.doUnmock('./runtime-toml-editor')
     vi.doUnmock('./otel-metrics')
     vi.doUnmock('./verification-specs-panel')
     vi.doUnmock('./cost-dashboard')
@@ -135,6 +139,17 @@ describe('RuntimePanel', () => {
     expect(container.textContent).not.toContain('OtelMetrics')
   })
 
+  it('renders the raw runtime.toml editor for config view', async () => {
+    route.value.params = { view: 'config' }
+    const { RuntimePanel } = await loadRuntimePanel()
+    render(html`<${RuntimePanel} />`, container)
+    await flushUi()
+
+    expect(container.textContent).toContain('RuntimeTomlEditor')
+    expect(container.textContent).not.toContain('OasHealthChip')
+    expect(container.textContent).not.toContain('RuntimeMonitor')
+  })
+
   it('renders only OtelMetrics for metrics view', async () => {
     route.value.params = { view: 'metrics' }
     const { RuntimePanel } = await loadRuntimePanel()
@@ -155,16 +170,17 @@ describe('RuntimePanel', () => {
     const chips = container.querySelectorAll('[data-testid="chip"]')
     // Chips are split across two FilterChips strips (Primary then Advanced)
     // with a divider between them. The positional order reflects the
-    // Primary[default, providers] → Advanced[cost, audit, stress,
+    // Primary[default, providers, runtime.toml] → Advanced[cost, audit, stress,
     // metrics, verification] layout.
-    expect(chips.length).toBe(7)
+    expect(chips.length).toBe(8)
     expect(chips[0]?.textContent).toBe('전체')
     expect(chips[1]?.textContent).toBe('런타임')
-    expect(chips[2]?.textContent).toBe('비용 / 지연')
-    expect(chips[3]?.textContent).toBe('감사')
-    expect(chips[4]?.textContent).toBe('스트레스')
-    expect(chips[5]?.textContent).toBe('메트릭')
-    expect(chips[6]?.textContent).toBe('형식검증')
+    expect(chips[2]?.textContent).toBe('runtime.toml')
+    expect(chips[3]?.textContent).toBe('비용 / 지연')
+    expect(chips[4]?.textContent).toBe('감사')
+    expect(chips[5]?.textContent).toBe('스트레스')
+    expect(chips[6]?.textContent).toBe('메트릭')
+    expect(chips[7]?.textContent).toBe('형식검증')
   })
 
   it('routes runtime diagnostic views through CostDashboard', async () => {

--- a/dashboard/src/components/runtime-panel.ts
+++ b/dashboard/src/components/runtime-panel.ts
@@ -10,7 +10,7 @@
 // NN/g progressive disclosure: respect working-memory limits, defer detail.
 //
 // Explicit drill-down via FilterChips, split into two strips (PR #17014):
-//   Primary strip   — default · providers · inspector
+//   Primary strip   — default · providers · runtime.toml
 //   Advanced strip  — cost · audit · stress · metrics · verification
 //                     (the first three are spread from TELEMETRY_VIEW_CHIPS,
 //                      owned by telemetry-panel.ts; PR #17044 / #17052)
@@ -18,7 +18,7 @@
 // Per-view dispatch:
 //   default      — Signal strip + collapsed diagnostic/raw accordions
 //   providers    — OAS health chip + runtime monitor only
-//   inspector    — runtime strategy trace / lane health drill-down
+//   config       — raw runtime.toml editor
 //   cost / audit / stress — TelemetryPanel → CostDashboard
 //   metrics   — raw OTel metrics only
 //   verification — formal specs only
@@ -31,6 +31,7 @@ import { FilterChips } from './common/filter-chips'
 import { CollapsibleSection } from './common/collapsible'
 import { OasHealthChip } from './oas-health-chip'
 import { RuntimeMonitor } from './runtime-monitor'
+import { RuntimeTomlEditor } from './runtime-toml-editor'
 import { OtelMetrics } from './otel-metrics'
 import { VerificationSpecsPanel } from './verification-specs-panel'
 import { TelemetryPanel, isTelemetryView, TELEMETRY_VIEW_CHIPS } from './telemetry-panel'
@@ -39,6 +40,7 @@ import { RouteLink } from './common/route-link'
 type RuntimeView =
   | 'default'
   | 'providers'
+  | 'config'
   | 'cost'
   | 'audit'
   | 'stress'
@@ -48,6 +50,7 @@ type RuntimeView =
 const RUNTIME_VIEWS: RuntimeView[] = [
   'default',
   'providers',
+  'config',
   'cost',
   'audit',
   'stress',
@@ -71,6 +74,7 @@ const activeView = computed<RuntimeView>(() => {
 const PRIMARY_VIEW_CHIPS: Array<{ key: RuntimeView; label: string }> = [
   { key: 'default', label: '전체' },
   { key: 'providers', label: '런타임' },
+  { key: 'config', label: 'runtime.toml' },
 ]
 
 // Advanced chips are infra/billing telemetry plus the raw / formal layers.
@@ -165,6 +169,8 @@ export function RuntimePanel() {
             <${OasHealthChip} />
             <${RuntimeMonitor} />
           `
+        : view === 'config'
+          ? html`<${RuntimeTomlEditor} />`
         : isTelemetryView(view)
           ? html`<${TelemetryPanel} view=${view} />`
         : view === 'metrics'

--- a/dashboard/src/components/runtime-toml-editor.test.ts
+++ b/dashboard/src/components/runtime-toml-editor.test.ts
@@ -1,0 +1,121 @@
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { fireEvent, waitFor } from '@testing-library/preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const apiMocks = vi.hoisted(() => ({
+  fetchRuntimeTomlConfig: vi.fn(),
+  saveRuntimeTomlConfig: vi.fn(),
+}))
+
+vi.mock('../api/dashboard', () => ({
+  fetchRuntimeTomlConfig: apiMocks.fetchRuntimeTomlConfig,
+  saveRuntimeTomlConfig: apiMocks.saveRuntimeTomlConfig,
+}))
+
+import { RuntimeTomlEditor } from './runtime-toml-editor'
+
+const baseConfig = {
+  ok: true,
+  path: '/tmp/.masc/config/runtime.toml',
+  file_name: 'runtime.toml',
+  source_text: '[runtime]\ndefault = "runpod_mtp.qwen"\n',
+  reloaded: false,
+}
+
+describe('RuntimeTomlEditor', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    apiMocks.fetchRuntimeTomlConfig.mockReset()
+    apiMocks.saveRuntimeTomlConfig.mockReset()
+    apiMocks.fetchRuntimeTomlConfig.mockResolvedValue(baseConfig)
+    apiMocks.saveRuntimeTomlConfig.mockImplementation(async (sourceText: string) => ({
+      ...baseConfig,
+      source_text: sourceText,
+      reloaded: true,
+    }))
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+  })
+
+  it('loads and displays the full runtime.toml source', async () => {
+    render(html`<${RuntimeTomlEditor} />`, container)
+
+    await waitFor(() => {
+      expect(apiMocks.fetchRuntimeTomlConfig).toHaveBeenCalledTimes(1)
+      expect(container.textContent).toContain('/tmp/.masc/config/runtime.toml')
+    })
+
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement
+    const saveButton = container.querySelector('[data-testid="runtime-toml-save"]') as HTMLButtonElement
+
+    expect(textarea.value).toBe(baseConfig.source_text)
+    expect(saveButton.disabled).toBe(true)
+    expect(container.querySelector('[data-testid="runtime-toml-status"]')?.textContent).toContain('saved')
+  })
+
+  it('saves the edited TOML source and clears the dirty state', async () => {
+    render(html`<${RuntimeTomlEditor} />`, container)
+
+    await waitFor(() => {
+      expect((container.querySelector('textarea') as HTMLTextAreaElement | null)?.value).toBe(baseConfig.source_text)
+    })
+
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement
+    const saveButton = container.querySelector('[data-testid="runtime-toml-save"]') as HTMLButtonElement
+    const nextSource = `${baseConfig.source_text}\n[runtime.assignments]\nsangsu = "runpod_mtp.qwen"\n`
+
+    fireEvent.input(textarea, { target: { value: nextSource } })
+
+    await waitFor(() => {
+      expect((container.querySelector('[data-testid="runtime-toml-save"]') as HTMLButtonElement).disabled).toBe(false)
+      expect(container.querySelector('[data-testid="runtime-toml-status"]')?.textContent).toContain('modified')
+    })
+
+    fireEvent.click(container.querySelector('[data-testid="runtime-toml-save"]') as HTMLButtonElement)
+
+    await waitFor(() => {
+      expect(apiMocks.saveRuntimeTomlConfig).toHaveBeenCalledWith(nextSource)
+      expect(container.textContent).toContain('저장됨')
+    })
+    expect(saveButton.disabled).toBe(true)
+    expect((container.querySelector('textarea') as HTMLTextAreaElement).value).toBe(nextSource)
+  })
+
+  it('shows load errors without losing the editor surface', async () => {
+    apiMocks.fetchRuntimeTomlConfig.mockRejectedValueOnce(new Error('runtime config path not found'))
+
+    render(html`<${RuntimeTomlEditor} />`, container)
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('runtime config path not found')
+    })
+    expect(container.querySelector('textarea')).not.toBeNull()
+  })
+
+  it('keeps the dirty draft when save validation fails', async () => {
+    apiMocks.saveRuntimeTomlConfig.mockRejectedValueOnce(new Error('runtime config parse failed'))
+    render(html`<${RuntimeTomlEditor} />`, container)
+
+    await waitFor(() => {
+      expect((container.querySelector('textarea') as HTMLTextAreaElement | null)?.value).toBe(baseConfig.source_text)
+    })
+
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement
+    const saveButton = container.querySelector('[data-testid="runtime-toml-save"]') as HTMLButtonElement
+    fireEvent.input(textarea, { target: { value: '[runtime]\ndefault = "missing.runtime"\n' } })
+    fireEvent.click(saveButton)
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('runtime config parse failed')
+    })
+    expect((container.querySelector('textarea') as HTMLTextAreaElement).value).toBe('[runtime]\ndefault = "missing.runtime"\n')
+    expect(saveButton.disabled).toBe(false)
+  })
+})

--- a/dashboard/src/components/runtime-toml-editor.ts
+++ b/dashboard/src/components/runtime-toml-editor.ts
@@ -1,0 +1,150 @@
+import { html } from 'htm/preact'
+import { useCallback, useEffect, useState } from 'preact/hooks'
+import {
+  fetchRuntimeTomlConfig,
+  saveRuntimeTomlConfig,
+  type RuntimeTomlConfig,
+} from '../api/dashboard'
+import { errorToString } from '../lib/format-string'
+import { ActionButton } from './common/button'
+import { SectionCard } from './common/card'
+import { ErrorState, LoadingState } from './common/feedback-state'
+import { TextArea } from './common/input'
+
+type LoadState = 'idle' | 'loading' | 'loaded'
+
+function runtimeTomlStatusLabel(
+  loadState: LoadState,
+  dirty: boolean,
+  saving: boolean,
+): string {
+  if (saving) return 'saving'
+  if (loadState === 'loading') return 'loading'
+  if (dirty) return 'modified'
+  if (loadState === 'loaded') return 'saved'
+  return 'idle'
+}
+
+export function RuntimeTomlEditor() {
+  const [loadState, setLoadState] = useState<LoadState>('loading')
+  const [config, setConfig] = useState<RuntimeTomlConfig | null>(null)
+  const [draft, setDraft] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [notice, setNotice] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+
+  const dirty = config !== null && draft !== config.source_text
+
+  const refresh = useCallback(async () => {
+    setLoadState('loading')
+    setError(null)
+    setNotice(null)
+    try {
+      const next = await fetchRuntimeTomlConfig()
+      setConfig(next)
+      setDraft(next.source_text)
+      setLoadState('loaded')
+    } catch (err: unknown) {
+      setError(errorToString(err))
+      setLoadState('idle')
+    }
+  }, [])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  async function handleSave() {
+    if (!dirty || saving || loadState === 'loading') return
+    setSaving(true)
+    setError(null)
+    setNotice(null)
+    try {
+      const saved = await saveRuntimeTomlConfig(draft)
+      setConfig(saved)
+      setDraft(saved.source_text)
+      setNotice('저장됨')
+    } catch (err: unknown) {
+      setError(errorToString(err))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const statusLabel = runtimeTomlStatusLabel(loadState, dirty, saving)
+  const path = config?.path ?? 'runtime.toml'
+
+  return html`
+    <${SectionCard}
+      label="runtime.toml"
+      testId="runtime-toml-editor"
+      right=${html`
+        <span
+          class="rounded-[var(--r-0)] border border-[var(--color-border-subtle)] px-2 py-0.5 text-2xs font-medium uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]"
+          data-testid="runtime-toml-status"
+        >
+          ${statusLabel}
+        </span>
+      `}
+    >
+      <div class="flex flex-col gap-3">
+        <div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+          <div class="min-w-0">
+            <div class="text-2xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">path</div>
+            <div class="truncate font-mono text-xs text-[var(--color-fg-primary)]" data-testid="runtime-toml-path">
+              ${path}
+            </div>
+          </div>
+          <div class="flex shrink-0 flex-wrap items-center gap-2">
+            <${ActionButton}
+              variant="ghost"
+              size="sm"
+              onClick=${refresh}
+              disabled=${saving || loadState === 'loading'}
+              ariaBusy=${loadState === 'loading'}
+              testId="runtime-toml-refresh"
+            >
+              새로고침
+            <//>
+            <${ActionButton}
+              variant="primary"
+              size="sm"
+              onClick=${handleSave}
+              disabled=${!dirty || saving || loadState === 'loading'}
+              ariaBusy=${saving}
+              testId="runtime-toml-save"
+            >
+              ${saving ? '저장 중' : '저장'}
+            <//>
+          </div>
+        </div>
+
+        ${error ? html`<${ErrorState} message=${error} />` : null}
+        ${notice ? html`
+          <div
+            class="rounded-[var(--r-0)] border border-[var(--ok-30)] bg-[var(--ok-12)] px-3 py-2 text-xs text-[var(--ok-light)]"
+            role="status"
+          >
+            ${notice}
+          </div>
+        ` : null}
+
+        ${loadState === 'loading'
+          ? html`<${LoadingState}>runtime.toml 불러오는 중...<//>`
+          : html`
+            <${TextArea}
+              ariaLabel="runtime.toml source"
+              value=${draft}
+              rows=${28}
+              class="min-h-[28rem] font-mono text-xs leading-relaxed"
+              disabled=${saving}
+              onInput=${(event: Event) => {
+                setDraft((event.target as HTMLTextAreaElement).value)
+                setNotice(null)
+              }}
+            />
+          `}
+      </div>
+    <//>
+  `
+}

--- a/docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md
+++ b/docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md
@@ -371,7 +371,7 @@ curl -sS -X POST http://127.0.0.1:8935/api/v1/runtime/config/raw \
 
 ```json
 {
-  "source_text": "{ ...raw runtime json... }"
+  "source_text": "[runtime]\ndefault = \"provider.model\"\n"
 }
 ```
 

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -187,6 +187,29 @@ let config_path () : string option =
   | Invalid_env | Missing -> None
 ;;
 
+let runtime_config_path_result ?runtime_config_path () =
+  match runtime_config_path with
+  | Some path -> Ok path
+  | None ->
+    (match config_path () with
+     | Some path -> Ok path
+     | None -> Error "runtime config path not found")
+;;
+
+let load_config_text ?runtime_config_path () =
+  match runtime_config_path_result ?runtime_config_path () with
+  | Error _ as e -> e
+  | Ok path ->
+    (try Ok (path, Fs_compat.load_file path) with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | exn ->
+       Error
+         (Printf.sprintf
+            "failed to read runtime config %s: %s"
+            path
+            (Printexc.to_string exn)))
+;;
+
 let contains_newline s =
   String.exists (function
     | '\n' | '\r' -> true
@@ -400,6 +423,21 @@ let validate_runtime_config_text ~config_path content =
      | Error _ as e -> e)
 ;;
 
+let save_config_text ?runtime_config_path content =
+  match runtime_config_path_result ?runtime_config_path () with
+  | Error _ as e -> e
+  | Ok path ->
+    (match validate_runtime_config_text ~config_path:path content with
+     | Error _ as e -> e
+     | Ok () ->
+       (match Fs_compat.save_file_atomic path content with
+        | Error _ as e -> e
+        | Ok () ->
+          (match init_default ~config_path:path with
+           | Ok () -> Ok ()
+           | Error msg -> Error ("runtime config saved but reload failed: " ^ msg))))
+;;
+
 let set_runtime_id_for_keeper ?runtime_config_path ~keeper_name ~runtime_id () =
   let keeper_name = String.trim keeper_name in
   let runtime_id = String.trim runtime_id in
@@ -412,19 +450,12 @@ let set_runtime_id_for_keeper ?runtime_config_path ~keeper_name ~runtime_id () =
   else if contains_newline runtime_id
   then Error "runtime_id must not contain newlines"
   else
-    let path_result =
-      match runtime_config_path with
-      | Some path -> Ok path
-      | None ->
-        (match config_path () with
-         | Some path -> Ok path
-         | None -> Error "runtime config path not found")
-    in
-    match path_result with
+    match runtime_config_path_result ?runtime_config_path () with
     | Error _ as e -> e
     | Ok path ->
       let content_result =
         try Ok (Fs_compat.load_file path) with
+        | Eio.Cancel.Cancelled _ as exn -> raise exn
         | exn ->
           Error
             (Printf.sprintf

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -70,6 +70,15 @@ val config_path : unit -> string option
     deleted [Runtime.config_path] (delegates to
     [Config_dir_resolver]). *)
 
+val load_config_text :
+  ?runtime_config_path:string -> unit -> ((string * string), string) result
+(** Load the raw runtime.toml source text. Returns [(path, source_text)]. *)
+
+val save_config_text :
+  ?runtime_config_path:string -> string -> (unit, string) result
+(** Validate and atomically persist raw runtime.toml source text, then refresh
+    the in-process runtime cache. *)
+
 val set_runtime_id_for_keeper :
   ?runtime_config_path:string ->
   keeper_name:string ->

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -9,6 +9,8 @@ open Server_dashboard_http
 open Server_routes_http_common
 open Server_routes_http_keeper_stream
 
+module Runtime_config_file = Runtime
+
 include Server_routes_http_routes_dashboard_setup
 
 let config_cache_ttl_s = Server_dashboard_http_core_cache.config_cache_ttl_s
@@ -35,6 +37,32 @@ let respond_dashboard_ok ?request reqd =
   Http.Response.json_value ?request ~compress:true
     (`Assoc [ ("ok", `Bool true) ])
     reqd
+
+let runtime_config_raw_json ~path ~source_text ~reloaded =
+  `Assoc
+    [ ("ok", `Bool true)
+    ; ("path", `String path)
+    ; ("file_name", `String "runtime.toml")
+    ; ("source_text", `String source_text)
+    ; ("reloaded", `Bool reloaded)
+    ]
+
+let parse_runtime_config_raw_body body_str =
+  try
+    match Yojson.Safe.from_string body_str with
+    | `Assoc _ as json ->
+      (match Json_util.assoc_member_opt "source_text" json with
+       | Some (`String source_text) -> Ok source_text
+       | Some _ -> Error "source_text must be a string"
+       | None -> Error "source_text required")
+    | _ -> Error "JSON object body required"
+  with
+  | Yojson.Json_error err -> Error ("invalid json: " ^ err)
+
+let runtime_config_path_error_status message =
+  if String.equal message "runtime config path not found"
+  then `Not_found
+  else `Internal_server_error
 
 let add_routes ~sw ~clock router =
   router
@@ -154,6 +182,44 @@ let add_routes ~sw ~clock router =
          Http.Response.json_value ~compress:true ~request:req json reqd
        in
        with_tool_auth ~tool_name:"masc_runtime_ollama_probe" handle request reqd)
+  |> Http.Router.get "/api/v1/runtime/config/raw" (fun request reqd ->
+       with_token_permission_auth ~permission:Masc_domain.CanAdmin
+         (fun _state _agent_name req reqd ->
+           match Runtime_config_file.load_config_text () with
+           | Ok (path, source_text) ->
+             Http.Response.json_value ~compress:true ~request:req
+               (runtime_config_raw_json ~path ~source_text ~reloaded:false)
+               reqd
+           | Error msg ->
+             respond_dashboard_error
+               ~status:(runtime_config_path_error_status msg)
+               ~request:req reqd msg)
+         request reqd)
+  |> Http.Router.post "/api/v1/runtime/config/raw" (fun request reqd ->
+       with_token_permission_auth ~permission:Masc_domain.CanAdmin
+         (fun _state _agent_name req reqd ->
+           Http.Request.read_body_async reqd (fun body_str ->
+             match parse_runtime_config_raw_body body_str with
+             | Error msg ->
+               respond_dashboard_error ~status:`Bad_request ~request:req reqd msg
+             | Ok source_text ->
+               (match Runtime_config_file.save_config_text source_text with
+                | Error msg ->
+                  respond_dashboard_error ~status:`Bad_request ~request:req reqd msg
+                | Ok () ->
+                  (match Runtime_config_file.load_config_text () with
+                   | Ok (path, saved_text) ->
+                     Http.Response.json_value ~compress:true ~request:req
+                       (runtime_config_raw_json
+                          ~path
+                          ~source_text:saved_text
+                          ~reloaded:true)
+                       reqd
+                   | Error msg ->
+                     respond_dashboard_error
+                       ~status:(runtime_config_path_error_status msg)
+                       ~request:req reqd msg)))
+         ) request reqd)
   (* Phase 1 Action 2 — live Dashboard_cache state surface.  Renders
      hit_ratio, in-flight compute count, per-entry ttl_remaining, and
      timeout-circuit-open counts so operators can correlate slow endpoints

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -135,6 +135,43 @@ max-concurrent = 1
 |}
 ;;
 
+let runtime_config_openai_default =
+  {|
+[runtime]
+default = "openai.gpt"
+
+[providers.runpod_mtp]
+display-name = "RunPod"
+protocol = "provider_d-http"
+endpoint = "https://runpod.example/v1"
+
+[providers.openai]
+display-name = "OpenAI"
+protocol = "provider_d-http"
+endpoint = "https://api.openai.example/v1"
+
+[models.qwen]
+api-name = "qwen"
+max-context = 128000
+tools-support = true
+streaming = true
+
+[models.gpt]
+api-name = "gpt"
+max-context = 64000
+tools-support = true
+streaming = true
+
+[runpod_mtp.qwen]
+is-default = true
+max-concurrent = 4
+
+[openai.gpt]
+is-default = true
+max-concurrent = 1
+|}
+;;
+
 let with_runtime_file f =
   with_temp_dir "runtime-per-keeper-routing-runtime" @@ fun dir ->
   let path = Filename.concat dir "runtime.toml" in
@@ -211,6 +248,58 @@ let test_runtime_assignment_writer_rejects_unknown_runtime_without_write () =
       "in-process assignment cache unchanged"
       (Some "openai.gpt")
       (Runtime.runtime_id_for_keeper "routingtest"))
+;;
+
+let test_runtime_config_text_loads_runtime_toml () =
+  with_runtime_file (fun path ->
+    match Runtime.load_config_text ~runtime_config_path:path () with
+    | Error msg -> Alcotest.failf "load_config_text failed: %s" msg
+    | Ok (loaded_path, source_text) ->
+      Alcotest.(check string) "loaded path" path loaded_path;
+      Alcotest.(check string) "loaded source text" runtime_config source_text)
+;;
+
+let test_runtime_config_text_save_reloads_runtime_cache () =
+  with_runtime_file (fun path ->
+    (match
+       Runtime.save_config_text
+         ~runtime_config_path:path
+         runtime_config_openai_default
+     with
+     | Ok () -> ()
+     | Error msg -> Alcotest.failf "save_config_text failed: %s" msg);
+    Alcotest.(check string)
+      "runtime.toml raw source saved exactly"
+      runtime_config_openai_default
+      (Fs_compat.load_file path);
+    Alcotest.(check string)
+      "runtime cache reloaded"
+      "openai.gpt"
+      (Runtime.get_default_runtime_id ()))
+;;
+
+let test_runtime_config_text_save_rejects_invalid_without_write () =
+  with_runtime_file (fun path ->
+    let before = Fs_compat.load_file path in
+    (match
+       Runtime.save_config_text
+         ~runtime_config_path:path
+         "[runtime]\ndefault = \"missing.runtime\"\n"
+     with
+     | Ok () -> Alcotest.fail "expected invalid raw runtime.toml to fail"
+     | Error msg ->
+       Alcotest.(check bool)
+         "error mentions unresolved default"
+         true
+         (string_contains msg "missing.runtime"));
+    Alcotest.(check string)
+      "runtime.toml unchanged after raw validation failure"
+      before
+      (Fs_compat.load_file path);
+    Alcotest.(check string)
+      "runtime cache unchanged"
+      "runpod_mtp.qwen"
+      (Runtime.get_default_runtime_id ()))
 ;;
 
 let test_runtime_id_tool_arg_is_not_removed_keeper_arg () =
@@ -325,6 +414,18 @@ let () =
             "unknown assignment is rejected before runtime.toml write"
             `Quick
             test_runtime_assignment_writer_rejects_unknown_runtime_without_write
+        ; Alcotest.test_case
+            "dashboard raw runtime.toml load returns full source"
+            `Quick
+            test_runtime_config_text_loads_runtime_toml
+        ; Alcotest.test_case
+            "dashboard raw runtime.toml save validates and reloads cache"
+            `Quick
+            test_runtime_config_text_save_reloads_runtime_cache
+        ; Alcotest.test_case
+            "dashboard raw runtime.toml save rejects invalid source before write"
+            `Quick
+            test_runtime_config_text_save_rejects_invalid_without_write
         ; Alcotest.test_case
             "runtime_id API arg is not rejected as a removed keeper arg"
             `Quick


### PR DESCRIPTION
## Summary
- add admin raw runtime.toml GET/POST API with validation, atomic save, and runtime cache reload
- add Monitor > Runtime > runtime.toml editor UI with dirty/save/error states
- update runtime.toml docs/tests and remove current keeper_runtime.toml references from active README/CONTRIBUTING surfaces

## Verification
- env DUNE_CACHE=disabled DUNE_BUILD_DIR=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/runtime-toml-editor-20260606/_build/codex-runtime-toml-final dune build --root . test/test_runtime_per_keeper_routing.exe
- _build/codex-runtime-toml-final/default/test/test_runtime_per_keeper_routing.exe
- pnpm exec vitest run --config vitest.config.ts src/api/dashboard.test.ts src/components/runtime-panel.test.ts src/components/runtime-toml-editor.test.ts --no-file-parallelism --maxWorkers=1
- pnpm run typecheck
- pnpm exec eslint src/api/dashboard.ts src/api/dashboard.test.ts src/components/runtime-panel.ts src/components/runtime-panel.test.ts src/components/runtime-toml-editor.ts src/components/runtime-toml-editor.test.ts (test files ignored by existing ESLint config)
- pnpm run build
- playwright screenshot --wait-for-timeout=3000 'http://localhost:5173/dashboard/#monitoring?section=runtime&view=config' /tmp/runtime-toml-editor.png (live 8935 backend was old binary, so UI rendered with expected 404 for the new route)
