### PR TITLE
fix(server): clean keeper stream close path

### DIFF
--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -453,18 +453,6 @@ let send_keeper_error writer mutex closed ~thread_id ~run_id err =
            ~custom_value:(Some (`Assoc [ ("message", `String err) ]))
            Run_error))
 
-(** Send Text_message_end + Run_finished sequence to complete the stream. *)
-let send_keeper_stream_finish writer mutex closed ~thread_id ~run_id
-    ~message_id =
-  ignore
-    (keeper_stream_send_event writer mutex closed
-       Ag_ui.(
-         make_event ~thread_id ~run_id:(Some run_id)
-           ~message_id:(Some message_id) Text_message_end));
-  ignore
-    (keeper_stream_send_event writer mutex closed
-       Ag_ui.(make_event ~thread_id ~run_id:(Some run_id) Run_finished))
-
 (** Extract visible reply from the keeper pipeline result body.
     Parses JSON if possible and strips internal markers. *)
 let extract_visible_reply body =
@@ -519,7 +507,7 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
       (* Catch all exceptions including Cancelled — this function is called
          from Switch.on_release where re-raising would mask the original exn. *)
       (try Httpun.Body.Writer.close writer
-       with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+       with exn ->
          Log.Misc.warn "keeper_stream writer close: %s"
            (Printexc.to_string exn))
     end


### PR DESCRIPTION
## Summary

- Remove the unused keeper SSE stream finish helper left behind after the event-adapter consolidation.
- Align `close_stream` with its `Switch.on_release` cleanup contract by swallowing close exceptions, including cancellation, instead of re-raising and potentially masking the original shutdown cause.

## Validation

- `ocamlformat --check lib/server/server_routes_http_keeper_stream.ml`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-keeper-stream-cleanup scripts/dune-local.sh build bin/main_eio.exe`
- `bash scripts/lint/no-tool-substrate-adapter-surface.sh`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-keeper-stream-cleanup scripts/dune-local.sh build test/test_otel_tick_poison_source.exe test/test_tool_catalog_system_internal_hidden.exe test/test_tool_descriptors_gen.exe`
- `_build-codex-keeper-stream-cleanup/default/test/test_otel_tick_poison_source.exe`
- `_build-codex-keeper-stream-cleanup/default/test/test_tool_catalog_system_internal_hidden.exe`
- `_build-codex-keeper-stream-cleanup/default/test/test_tool_descriptors_gen.exe`
