### PR TITLE
[RFC-0217 Phase 3b] Wire process_single_turn into Keeper_chat_consumer

### DIFF
--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -859,13 +859,77 @@ let start_keeper_loops
           "autoboot: supervisor sweep failed to start: %s"
           (Printexc.to_string exn)));
       (* Start queue consumer fiber for async queue drain.
-         handle_turn is a no-op until Phase 3b wires process_single_turn. *)
+         handle_turn wires process_single_turn for actual turn execution. *)
       (try
          Keeper_chat_consumer.start ~sw ~clock
-           ~handle_turn:(fun ~keeper_name ~queued_message:_ ->
-             Log.Keeper.info
-               "keeper_chat_consumer: would drain queued message for keeper=%s"
-               keeper_name)
+           ~handle_turn:(fun ~keeper_name ~queued_message ->
+             let open Server_routes_http_keeper_stream in
+             let now = Time_compat.now () in
+             let run_id =
+               Printf.sprintf "keeper-consumer-run-%d"
+                 (int_of_float (now *. 1000.0))
+             in
+             let message_id =
+               Printf.sprintf "keeper-consumer-msg-%d"
+                 (int_of_float ((now +. 0.001) *. 1000.0))
+             in
+             let payload =
+               {
+                 name = keeper_name;
+                 message = queued_message.content;
+                 timeout_sec = None;
+                 channel =
+                   (match queued_message.source with
+                    | Keeper_chat_queue.Dashboard -> ""
+                    | Keeper_chat_queue.Discord { channel_id; _ } ->
+                        channel_id
+                    | Keeper_chat_queue.Slack { channel; _ } -> channel);
+                 channel_user_id =
+                   (match queued_message.source with
+                    | Keeper_chat_queue.Dashboard -> ""
+                    | Keeper_chat_queue.Discord { user_id; _ } -> user_id
+                    | Keeper_chat_queue.Slack { user_id; _ } -> user_id);
+                 channel_user_name = "";
+                 channel_workspace_id = "";
+                 attachments = queued_message.attachments;
+               }
+             in
+             let agent_name =
+               match queued_message.source with
+               | Keeper_chat_queue.Dashboard -> "dashboard"
+               | Keeper_chat_queue.Discord { channel_id; user_id } ->
+                   Gate_keeper_backend.agent_name_for_channel_actor
+                     ~channel:channel_id
+                     ~channel_workspace_id:""
+                     ~channel_user_id:user_id
+               | Keeper_chat_queue.Slack { channel; user_id } ->
+                   Gate_keeper_backend.agent_name_for_channel_actor
+                     ~channel
+                     ~channel_workspace_id:""
+                     ~channel_user_id:user_id
+             in
+             let events = Keeper_chat_events.create () in
+             let closed = ref false in
+             let thread_id = "keeper-consumer:" ^ keeper_name in
+             (match queued_message.source with
+              | Keeper_chat_queue.Dashboard ->
+                  Log.Keeper.info
+                    "keeper_chat_consumer: processing dashboard queue \
+                     message for keeper=%s"
+                    keeper_name
+              | Keeper_chat_queue.Discord _ ->
+                  Log.Keeper.info
+                    "keeper_chat_consumer: Discord adapter not yet \
+                     implemented for keeper=%s"
+                    keeper_name
+              | Keeper_chat_queue.Slack _ ->
+                  Log.Keeper.info
+                    "keeper_chat_consumer: Slack adapter not yet \
+                     implemented for keeper=%s"
+                    keeper_name);
+             process_single_turn ~state ~clock ~sw ~auth_token:None
+               ~thread_id ~closed ~payload ~run_id ~message_id
+               ~agent_name ~events)
        with
        | Eio.Cancel.Cancelled _ as e -> raise e
        | exn ->

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -497,6 +497,183 @@ type keeper_stream_worker_event =
   | Stream_delta of string
   | Stream_terminal of bool * string
 
+let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
+    ~payload ~run_id ~message_id ~agent_name
+    ~(events : Keeper_chat_events.keeper_chat_event Eio.Stream.t) =
+  Keeper_chat_events.publish events
+    (Run_started { run_id; thread_id });
+  Keeper_chat_events.publish events
+    (Text_message_start { message_id; role = Assistant });
+  let has_connector_context =
+    payload.channel <> "" && payload.channel_user_id <> ""
+  in
+  let message =
+    if has_connector_context then
+      Gate_keeper_backend.contextualize_message
+        ~channel:payload.channel
+        ~channel_user_id:payload.channel_user_id
+        ~channel_user_name:payload.channel_user_name
+        ~channel_workspace_id:payload.channel_workspace_id
+        ~content:payload.message
+    else
+      payload.message
+  in
+  let attachment_json att =
+    `Assoc
+      [ ("id", `String att.Keeper_chat_store.id);
+        ("type", `String att.att_type);
+        ("name", `String att.name);
+        ("size", `Int att.size);
+        ("mime_type", `String att.mime_type);
+        ("data", `String att.data) ]
+  in
+  let args =
+    let base_fields =
+      [ ("name", `String payload.name);
+        ("message", `String message);
+        ("direct_reply", `Bool true) ]
+      @
+      (match payload.timeout_sec with
+       | Some timeout_sec -> [ ("timeout_sec", `Int timeout_sec) ]
+       | None -> [])
+    in
+    `Assoc
+      (if payload.attachments = [] then base_fields
+       else ("attachments", `List (List.map attachment_json payload.attachments)) :: base_fields)
+  in
+  (* Track whether any text deltas were streamed to the client.
+     When streaming is active, the MODEL text is sent token-by-token
+     during the call; we only need to send the final batch chunks
+     if no deltas were emitted (fallback path). *)
+  let deltas_sent = ref false in
+  let worker_events = Eio.Stream.create 512 in
+  let push_worker_event event =
+    if not !closed then
+      try Eio.Stream.add worker_events event
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | exn ->
+          Log.Keeper.warn
+            "keeper_stream: worker event push failed: %s"
+            (Printexc.to_string exn)
+  in
+  let on_text_delta text =
+    if String.length text > 0 then
+      push_worker_event (Stream_delta text)
+  in
+  let timeout_sec = Option.map float_of_int payload.timeout_sec in
+  let request_id =
+    Keeper_msg_async.submit ?timeout_sec ~clock ~sw
+      ~base_path:state.Mcp_server.workspace_config.base_path
+      ~keeper_name:payload.name
+      ~f:(fun () ->
+        let start_time = Time_compat.now () in
+        let dispatch_result =
+          try
+            Ok
+              (execute_keeper_stream_tool_streaming ~sw ~clock
+                 ?auth_token
+                 state ~agent_name ~arguments:args ~on_text_delta)
+          with
+          | Eio.Cancel.Cancelled _ as e -> raise e
+          | exn ->
+              Log.Keeper.warn
+                "keeper_stream: streaming dispatch raised: %s"
+                (Printexc.to_string exn);
+              (try
+                 Ok
+                   (execute_keeper_stream_tool ~sw ~clock
+                      ?auth_token
+                      state ~agent_name ~arguments:args)
+               with
+               | Eio.Cancel.Cancelled _ as e -> raise e
+               | exn2 -> Error (Printexc.to_string exn2))
+        in
+        match dispatch_result with
+        | Ok (true, body) ->
+            let _payload_json_opt, visible_reply = extract_visible_reply body in
+            if not (is_continuation_checkpoint_reply visible_reply) then
+              Keeper_chat_store.append_pair
+                ~base_dir:state.Mcp_server.workspace_config.base_path
+                ~keeper_name:payload.name
+                ~user_content:payload.message
+                ~user_attachments:payload.attachments
+                ~assistant_content:visible_reply;
+            push_worker_event (Stream_terminal (true, body));
+            Tool_result.ok ~tool_name:"masc_keeper_msg" ~start_time body
+        | Ok (false, err) ->
+            push_worker_event (Stream_terminal (false, err));
+            Tool_result.error ~tool_name:"masc_keeper_msg" ~start_time err
+        | Error err ->
+            push_worker_event (Stream_terminal (false, err));
+            Tool_result.error ~tool_name:"masc_keeper_msg" ~start_time err)
+      ()
+  in
+  Keeper_chat_events.publish events
+    (Custom
+       { name = "KEEPER_QUEUE_REQUEST";
+         value =
+           Gate_protocol.message_request_to_json
+             { request_id;
+               destination_type = "keeper";
+               destination_id = payload.name;
+               channel =
+                 (if has_connector_context then payload.channel
+                  else "dashboard");
+               actor_id = Some agent_name;
+               status = Gate_protocol.Queued;
+               modalities = [ "text" ];
+               transport = Some "sse";
+               metadata =
+                 [
+                   ("projection", "keeper_chat_stream");
+                   ("protocol", "gate_message_request");
+                 ];
+             }
+       });
+  let rec consume_worker_events () =
+    match Eio.Stream.take worker_events with
+    | Stream_delta text ->
+        deltas_sent := true;
+        Keeper_chat_events.publish events (Text_delta text);
+        consume_worker_events ()
+    | Stream_terminal (false, err) ->
+        Keeper_chat_events.publish events (Error { message = err })
+    | Stream_terminal (true, body) -> (
+        try
+          let payload_json_opt, visible_reply = extract_visible_reply body in
+          let is_checkpoint =
+            is_continuation_checkpoint_reply visible_reply
+          in
+          if (not !deltas_sent) && not is_checkpoint then
+            split_keeper_reply_chunks visible_reply
+            |> List.iter (fun chunk ->
+                   Keeper_chat_events.publish events (Text_delta chunk));
+          (match payload_json_opt with
+           | Some payload_json ->
+               Keeper_chat_events.publish events
+                 (Custom { name = "KEEPER_REPLY_DETAILS"; value = payload_json })
+           | None -> ());
+          if is_checkpoint then
+            Keeper_chat_events.publish events
+              (Custom
+                 { name = "KEEPER_CONTINUATION_CHECKPOINT";
+                   value =
+                     `Assoc
+                       [ ("request_id", `String request_id);
+                         ("message", `String visible_reply) ]
+                 });
+          Keeper_chat_events.publish events Text_message_end;
+          Keeper_chat_events.publish events (Run_finished { run_id })
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | exn ->
+            Keeper_chat_events.publish events
+              (Error { message = Printexc.to_string exn }))
+  in
+  consume_worker_events ()
+
+
 let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
   let origin = get_origin request in
   let headers =
@@ -603,181 +780,6 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
     loop ()
   in
 
-  let process_single_turn ~payload ~run_id ~message_id ~agent_name
-      ~(events : Keeper_chat_events.keeper_chat_event Eio.Stream.t) =
-    Keeper_chat_events.publish events
-      (Run_started { run_id; thread_id });
-    Keeper_chat_events.publish events
-      (Text_message_start { message_id; role = Assistant });
-    let has_connector_context =
-      payload.channel <> "" && payload.channel_user_id <> ""
-    in
-    let message =
-      if has_connector_context then
-        Gate_keeper_backend.contextualize_message
-          ~channel:payload.channel
-          ~channel_user_id:payload.channel_user_id
-          ~channel_user_name:payload.channel_user_name
-          ~channel_workspace_id:payload.channel_workspace_id
-          ~content:payload.message
-      else
-        payload.message
-    in
-    let attachment_json att =
-      `Assoc
-        [ ("id", `String att.Keeper_chat_store.id);
-          ("type", `String att.att_type);
-          ("name", `String att.name);
-          ("size", `Int att.size);
-          ("mime_type", `String att.mime_type);
-          ("data", `String att.data) ]
-    in
-    let args =
-      let base_fields =
-        [ ("name", `String payload.name);
-          ("message", `String message);
-          ("direct_reply", `Bool true) ]
-        @
-        (match payload.timeout_sec with
-         | Some timeout_sec -> [ ("timeout_sec", `Int timeout_sec) ]
-         | None -> [])
-      in
-      `Assoc
-        (if payload.attachments = [] then base_fields
-         else ("attachments", `List (List.map attachment_json payload.attachments)) :: base_fields)
-    in
-    (* Track whether any text deltas were streamed to the client.
-       When streaming is active, the MODEL text is sent token-by-token
-       during the call; we only need to send the final batch chunks
-       if no deltas were emitted (fallback path). *)
-    let deltas_sent = ref false in
-    let worker_events = Eio.Stream.create 512 in
-    let push_worker_event event =
-      if not !closed then
-        try Eio.Stream.add worker_events event
-        with
-        | Eio.Cancel.Cancelled _ as e -> raise e
-        | exn ->
-            Log.Keeper.warn
-              "keeper_stream: worker event push failed: %s"
-              (Printexc.to_string exn)
-    in
-    let on_text_delta text =
-      if String.length text > 0 then
-        push_worker_event (Stream_delta text)
-    in
-    let timeout_sec = Option.map float_of_int payload.timeout_sec in
-    let request_id =
-      Keeper_msg_async.submit ?timeout_sec ~clock ~sw
-        ~base_path:state.Mcp_server.workspace_config.base_path
-        ~keeper_name:payload.name
-        ~f:(fun () ->
-          let start_time = Time_compat.now () in
-          let dispatch_result =
-            try
-              Ok
-                (execute_keeper_stream_tool_streaming ~sw ~clock
-                   ?auth_token:(auth_token_from_request request)
-                   state ~agent_name ~arguments:args ~on_text_delta)
-            with
-            | Eio.Cancel.Cancelled _ as e -> raise e
-            | exn ->
-                Log.Keeper.warn
-                  "keeper_stream: streaming dispatch raised: %s"
-                  (Printexc.to_string exn);
-                (try
-                   Ok
-                     (execute_keeper_stream_tool ~sw ~clock
-                        ?auth_token:(auth_token_from_request request)
-                        state ~agent_name ~arguments:args)
-                 with
-                 | Eio.Cancel.Cancelled _ as e -> raise e
-                 | exn2 -> Error (Printexc.to_string exn2))
-          in
-          match dispatch_result with
-          | Ok (true, body) ->
-              let _payload_json_opt, visible_reply = extract_visible_reply body in
-              if not (is_continuation_checkpoint_reply visible_reply) then
-                Keeper_chat_store.append_pair
-                  ~base_dir:state.Mcp_server.workspace_config.base_path
-                  ~keeper_name:payload.name
-                  ~user_content:payload.message
-                  ~user_attachments:payload.attachments
-                  ~assistant_content:visible_reply;
-              push_worker_event (Stream_terminal (true, body));
-              Tool_result.ok ~tool_name:"masc_keeper_msg" ~start_time body
-          | Ok (false, err) ->
-              push_worker_event (Stream_terminal (false, err));
-              Tool_result.error ~tool_name:"masc_keeper_msg" ~start_time err
-          | Error err ->
-              push_worker_event (Stream_terminal (false, err));
-              Tool_result.error ~tool_name:"masc_keeper_msg" ~start_time err)
-        ()
-    in
-    Keeper_chat_events.publish events
-      (Custom
-         { name = "KEEPER_QUEUE_REQUEST";
-           value =
-             Gate_protocol.message_request_to_json
-               { request_id;
-                 destination_type = "keeper";
-                 destination_id = payload.name;
-                 channel =
-                   (if has_connector_context then payload.channel
-                    else "dashboard");
-                 actor_id = Some agent_name;
-                 status = Gate_protocol.Queued;
-                 modalities = [ "text" ];
-                 transport = Some "sse";
-                 metadata =
-                   [
-                     ("projection", "keeper_chat_stream");
-                     ("protocol", "gate_message_request");
-                   ];
-               }
-         });
-    let rec consume_worker_events () =
-      match Eio.Stream.take worker_events with
-      | Stream_delta text ->
-          deltas_sent := true;
-          Keeper_chat_events.publish events (Text_delta text);
-          consume_worker_events ()
-      | Stream_terminal (false, err) ->
-          Keeper_chat_events.publish events (Error { message = err })
-      | Stream_terminal (true, body) -> (
-          try
-            let payload_json_opt, visible_reply = extract_visible_reply body in
-            let is_checkpoint =
-              is_continuation_checkpoint_reply visible_reply
-            in
-            if (not !deltas_sent) && not is_checkpoint then
-              split_keeper_reply_chunks visible_reply
-              |> List.iter (fun chunk ->
-                     Keeper_chat_events.publish events (Text_delta chunk));
-            (match payload_json_opt with
-             | Some payload_json ->
-                 Keeper_chat_events.publish events
-                   (Custom { name = "KEEPER_REPLY_DETAILS"; value = payload_json })
-             | None -> ());
-            if is_checkpoint then
-              Keeper_chat_events.publish events
-                (Custom
-                   { name = "KEEPER_CONTINUATION_CHECKPOINT";
-                     value =
-                       `Assoc
-                         [ ("request_id", `String request_id);
-                           ("message", `String visible_reply) ]
-                   });
-            Keeper_chat_events.publish events Text_message_end;
-            Keeper_chat_events.publish events (Run_finished { run_id })
-          with
-          | Eio.Cancel.Cancelled _ as e -> raise e
-          | exn ->
-              Keeper_chat_events.publish events
-                (Error { message = Printexc.to_string exn }))
-    in
-    consume_worker_events ()
-  in
 
   ignore (keeper_stream_send_raw writer mutex closed "retry: 1500\n\n");
   Eio.Fiber.fork ~sw (fun () ->
@@ -805,7 +807,10 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
            let events = Keeper_chat_events.create () in
            Eio.Fiber.fork ~sw:stream_sw (fun () ->
              sse_adapter_loop ~events ~writer ~mutex ~closed);
-           process_single_turn ~payload ~run_id ~message_id ~agent_name ~events;
+           process_single_turn ~state ~clock ~sw
+             ~auth_token:(auth_token_from_request request)
+             ~thread_id ~closed
+             ~payload ~run_id ~message_id ~agent_name ~events;
            (* Queue drain is now handled by Keeper_chat_consumer
               (started in server_bootstrap_loops). *)
            ))

--- a/lib/server/server_routes_http_keeper_stream.mli
+++ b/lib/server/server_routes_http_keeper_stream.mli
@@ -106,3 +106,24 @@ val handle_keeper_chat_stream :
     on switch release; surfaces handler exceptions
     through the SSE stream rather than the HTTP envelope
     once the headers have flushed. *)
+
+(** {1 Turn execution (shared between HTTP handler and queue consumer)} *)
+
+val process_single_turn :
+  state:Mcp_server.server_state ->
+  clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
+  sw:Eio.Switch.t ->
+  auth_token:string option ->
+  thread_id:string ->
+  closed:bool ref ->
+  payload:keeper_chat_stream_request ->
+  run_id:string ->
+  message_id:string ->
+  agent_name:string ->
+  events:Keeper_chat_events.keeper_chat_event Eio.Stream.t ->
+  unit
+(** Execute a single keeper turn, publishing events to the provided
+    event stream.  [closed] is a mutable flag that suppresses worker
+    event pushes when set to [true] (used by the SSE adapter when the
+    HTTP stream is closed).  [auth_token] is [None] for queue-consumer
+    turns where no HTTP request is available. *)


### PR DESCRIPTION
Phase 3b of RFC-0217: Connect queue consumer to actual turn execution.

Changes:
- server_routes_http_keeper_stream.ml: Extract process_single_turn to module level with runtime params
- server_routes_http_keeper_stream.mli: Expose process_single_turn
- server_bootstrap_loops.ml: Implement handle_turn callback with payload construction + source routing

Verification: dune build @check passes

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
🤖 Generated with [Claude Code](https://claude.com/claude-code)