### PR TITLE
fix(dashboard): surface keeper live activity source

### DIFF
--- a/dashboard/src/components/agent-roster.test.ts
+++ b/dashboard/src/components/agent-roster.test.ts
@@ -94,6 +94,28 @@ describe('rosterStateNote — RFC-0135 §1.1 typed-state conditioning', () => {
     })
   })
 
+  it('shows a pending approval gate before stale runtime blocker summaries', () => {
+    const note = rosterStateNote(
+      k({
+        runtime_blocker_class: 'turn_timeout',
+        runtime_blocker_summary: '턴 응답 만료',
+        current_gate: {
+          kind: 'approval_required',
+          source: 'audit_approvals',
+          tool: 'Write',
+          risk: 'high',
+          disposition_reason: 'waiting_approval',
+        },
+      }),
+      null,
+      null,
+    )
+    expect(note).toEqual({
+      label: '승인 대기',
+      text: '도구 Write · 위험도 high · 사유 waiting_approval',
+    })
+  })
+
   it('RFC §1.1 EXACT — blocker set BUT receipt is stale (execution_current=false) → 이전 차단', () => {
     // The exact 2026-05-19 lifecycle-worker scenario. Backend emits
     // execution_current=false (`server_dashboard_http.ml:1061-1074`)

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -132,6 +132,19 @@ export function rosterStateNote(
 ): RosterStateNote | null {
   if (!keeper) return null
 
+  const gate = keeper.current_gate
+  if (gate?.kind === 'approval_required') {
+    const tool = gate.tool?.trim()
+    const risk = gate.risk?.trim()
+    const reason = gate.disposition_reason?.trim()
+    const text = [
+      tool ? `도구 ${tool}` : '도구 승인 필요',
+      risk ? `위험도 ${risk}` : null,
+      reason ? `사유 ${reason}` : null,
+    ].filter((part): part is string => part !== null).join(' · ')
+    return { label: '승인 대기', text }
+  }
+
   const state = deriveKeeperOperationalState({ keeper, composite })
 
   if (state.kind === 'paused') {

--- a/dashboard/src/keeper-store-normalize.test.ts
+++ b/dashboard/src/keeper-store-normalize.test.ts
@@ -104,6 +104,46 @@ describe('normalizeKeepers phase field', () => {
 })
 
 describe('normalizeKeepers lifecycle metrics', () => {
+  it('normalizes live activity projection and current approval gate', () => {
+    const [keeper] = normalizeKeepers([
+      {
+        name: 'sangsu',
+        status: 'active',
+        last_activity_at: '2026-06-06T02:49:01Z',
+        last_activity_source: 'approval_pending',
+        live_activity: {
+          source: 'approval_pending',
+          at: '2026-06-06T02:49:01Z',
+          age_s: 5,
+          tool: 'Write',
+        },
+        current_gate: {
+          kind: 'approval_required',
+          source: 'audit_approvals',
+          tool: 'Write',
+          risk: 'high',
+          turn_id: 178,
+          at: '2026-06-06T02:49:01Z',
+        },
+      },
+    ])
+
+    expect(keeper?.last_activity_source).toBe('approval_pending')
+    expect(keeper?.last_activity_at).toBe('2026-06-06T02:49:01Z')
+    expect(keeper?.live_activity).toMatchObject({
+      source: 'approval_pending',
+      tool: 'Write',
+      age_s: 5,
+    })
+    expect(keeper?.current_gate).toMatchObject({
+      kind: 'approval_required',
+      source: 'audit_approvals',
+      tool: 'Write',
+      risk: 'high',
+      turn_id: 178,
+    })
+  })
+
   it('accepts flat backend handoff fields', () => {
     const [keeper] = normalizeKeepers([
       {

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -32,6 +32,48 @@ function normalizeRuntimeRef(raw: unknown): RuntimeRef | null {
   return { group, item }
 }
 
+function normalizeKeeperLiveActivitySource(raw: unknown): Keeper['last_activity_source'] {
+  const source = asString(raw)?.trim()
+  switch (source) {
+    case 'keeper_meta':
+    case 'tool_call':
+    case 'approval_pending':
+      return source
+    default:
+      return null
+  }
+}
+
+function normalizeKeeperLiveActivity(raw: unknown): Keeper['live_activity'] {
+  if (!isRecord(raw)) return null
+  return {
+    source: normalizeKeeperLiveActivitySource(raw.source),
+    at: toIsoTimestamp(raw.at) ?? asString(raw.at) ?? null,
+    age_s: asNumber(raw.age_s) ?? null,
+    tool: asString(raw.tool) ?? null,
+    turn: asNumber(raw.turn) ?? null,
+    keeper_turn_id: asNumber(raw.keeper_turn_id) ?? null,
+  }
+}
+
+function normalizeKeeperCurrentGate(raw: unknown): Keeper['current_gate'] {
+  if (!isRecord(raw)) return null
+  const kind = asString(raw.kind) ?? null
+  if (!kind) return null
+  return {
+    kind,
+    source: asString(raw.source) ?? null,
+    id: asString(raw.id) ?? null,
+    tool: asString(raw.tool) ?? null,
+    risk: asString(raw.risk) ?? null,
+    turn_id: asNumber(raw.turn_id) ?? null,
+    at: toIsoTimestamp(raw.at) ?? asString(raw.at) ?? null,
+    age_s: asNumber(raw.age_s) ?? null,
+    disposition: asString(raw.disposition) ?? null,
+    disposition_reason: asString(raw.disposition_reason) ?? null,
+  }
+}
+
 function normalizeKeeperTrustSeverity(raw: unknown): KeeperTrustLatestEvent['severity'] | null {
   const severity = asString(raw)?.trim().toLowerCase()
   switch (severity) {
@@ -735,6 +777,10 @@ export function normalizeKeepers(raw: unknown): Keeper[] {
         last_proactive_ago_s: asNumber(row.last_proactive_ago_s),
         last_proactive_reason: asString(row.last_proactive_reason) ?? null,
         last_activity_ago_s: asNumber(row.last_activity_ago_s),
+        last_activity_at: toIsoTimestamp(row.last_activity_at) ?? asString(row.last_activity_at) ?? null,
+        last_activity_source: normalizeKeeperLiveActivitySource(row.last_activity_source),
+        live_activity: normalizeKeeperLiveActivity(row.live_activity),
+        current_gate: normalizeKeeperCurrentGate(row.current_gate),
         last_proactive_preview: asString(row.last_proactive_preview) ?? null,
         social_model: null,
         configured_social_model: null,

--- a/dashboard/src/lib/keeper-runtime-display.test.ts
+++ b/dashboard/src/lib/keeper-runtime-display.test.ts
@@ -355,6 +355,29 @@ describe('keeperActivityDisplay', () => {
     })
   })
 
+  it('uses live activity source labels for tool and approval activity', () => {
+    expect(
+      keeperActivityDisplay({
+        last_activity_at: '2026-04-24T17:59:30Z',
+        last_activity_source: 'approval_pending',
+        last_heartbeat: '2026-04-24T17:54:00Z',
+      }),
+    ).toEqual({
+      source: 'approval_pending',
+      label: '승인 대기',
+      timestamp: '2026-04-24T17:59:30Z',
+      ageSeconds: 30,
+    })
+
+    const toolActivity = keeperActivityDisplay({
+      last_activity_at: '2026-04-24T17:58:00Z',
+      last_activity_source: 'tool_call',
+      last_turn_ago_s: 180,
+    })
+    expect(toolActivity.source).toBe('tool_call')
+    expect(toolActivity.label).toBe('도구 활동')
+  })
+
   it('does not let agent last_seen override keeper runtime signals', () => {
     expect(
       keeperActivityDisplay(

--- a/dashboard/src/lib/keeper-runtime-display.ts
+++ b/dashboard/src/lib/keeper-runtime-display.ts
@@ -9,6 +9,9 @@ const HEARTBEAT_ALIVE_THRESHOLD_S = 120
 export type KeeperActivitySource =
   | 'autonomous_action'
   | 'heartbeat'
+  | 'keeper_meta'
+  | 'tool_call'
+  | 'approval_pending'
   | 'last_activity'
   | 'last_turn'
   | 'agent_seen'
@@ -48,6 +51,8 @@ type KeeperModelDisplaySource = {
 type KeeperActivityDisplaySource = {
   last_autonomous_action_at?: string | null
   last_heartbeat?: string | null
+  last_activity_at?: string | null
+  last_activity_source?: Keeper['last_activity_source'] | null
   last_activity_ago_s?: number | null
   last_turn_ago_s?: number | null
   created_at?: string | null
@@ -102,11 +107,44 @@ function ageCandidate(
   }
 }
 
+function activitySourceLabel(source: Keeper['last_activity_source'] | null | undefined): string {
+  switch (source) {
+    case 'approval_pending':
+      return '승인 대기'
+    case 'tool_call':
+      return '도구 활동'
+    case 'keeper_meta':
+      return '최근 활동'
+    case null:
+    case undefined:
+      return '최근 활동'
+  }
+}
+
+function activityDisplaySource(source: Keeper['last_activity_source'] | null | undefined): KeeperActivitySource {
+  switch (source) {
+    case 'approval_pending':
+      return 'approval_pending'
+    case 'tool_call':
+      return 'tool_call'
+    case 'keeper_meta':
+      return 'keeper_meta'
+    case null:
+    case undefined:
+      return 'last_activity'
+  }
+}
+
 export function keeperActivityDisplay(
   keeper: KeeperActivityDisplaySource | null | undefined,
   fallbackAgentLastSeen?: string | null,
 ): KeeperActivityDisplay {
   const candidates = [
+    timestampCandidate(
+      activityDisplaySource(keeper?.last_activity_source),
+      activitySourceLabel(keeper?.last_activity_source),
+      keeper?.last_activity_at,
+    ),
     timestampCandidate('autonomous_action', '마지막 행동', keeper?.last_autonomous_action_at),
     timestampCandidate('heartbeat', '하트비트', keeper?.last_heartbeat),
     ageCandidate('last_activity', '최근 활동', keeper?.last_activity_ago_s),

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -454,6 +454,34 @@ export const KEEPER_RUNTIME_BLOCKER_CLASSES = [
 ] as const
 
 export type KeeperRuntimeBlockerClass = (typeof KEEPER_RUNTIME_BLOCKER_CLASSES)[number]
+
+export type KeeperLiveActivitySource =
+  | 'keeper_meta'
+  | 'tool_call'
+  | 'approval_pending'
+
+export interface KeeperLiveActivity {
+  source?: KeeperLiveActivitySource | null
+  at?: string | null
+  age_s?: number | null
+  tool?: string | null
+  turn?: number | null
+  keeper_turn_id?: number | null
+}
+
+export interface KeeperCurrentGate {
+  kind?: 'approval_required' | string | null
+  source?: string | null
+  id?: string | null
+  tool?: string | null
+  risk?: string | null
+  turn_id?: number | null
+  at?: string | null
+  age_s?: number | null
+  disposition?: string | null
+  disposition_reason?: string | null
+}
+
 // Wire emit: `lib/keeper/keeper_status_bridge.ml:720` —
 //   `pause_state = if meta.paused then "paused" else "active"`.
 // Closed 2-arm; the previous `| string` catch-all hid the fact that
@@ -997,6 +1025,10 @@ export interface Keeper {
   total_tokens?: number
   last_latency_ms?: number
   last_activity_ago_s?: number
+  last_activity_at?: string | null
+  last_activity_source?: KeeperLiveActivitySource | null
+  live_activity?: KeeperLiveActivity | null
+  current_gate?: KeeperCurrentGate | null
   context_ratio?: number
   context_tokens?: number
   context_max?: number

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -43,6 +43,185 @@ let keeper_names (config : Workspace.config) =
 let keeper_count (config : Workspace.config) : int =
   List.length (keeper_names config)
 
+type keeper_activity_source =
+  | Keeper_meta
+  | Tool_call of Yojson.Safe.t
+  | Approval_pending of Yojson.Safe.t
+
+let nonempty_json_string_opt key json =
+  match Safe_ops.json_string_opt key json with
+  | Some value ->
+      let value = String.trim value in
+      if value = "" then None else Some value
+  | None -> None
+
+let positive_json_float_opt key json =
+  match Safe_ops.json_float_opt key json with
+  | Some value ->
+      (match classify_float value with
+       | FP_normal | FP_subnormal | FP_zero when value > 0.0 -> Some value
+       | FP_normal | FP_subnormal | FP_zero | FP_infinite | FP_nan -> None)
+  | None -> None
+
+let activity_source_to_string = function
+  | Keeper_meta -> "keeper_meta"
+  | Tool_call _ -> "tool_call"
+  | Approval_pending _ -> "approval_pending"
+
+let activity_source_ts meta_ts = function
+  | Keeper_meta -> meta_ts
+  | Tool_call json
+  | Approval_pending json ->
+      positive_json_float_opt "ts" json |> Option.value ~default:0.0
+
+let activity_source_tool_opt = function
+  | Keeper_meta -> None
+  | Tool_call json ->
+      (match nonempty_json_string_opt "tool" json with
+       | Some tool -> Some tool
+       | None -> nonempty_json_string_opt "tool_name" json)
+  | Approval_pending json ->
+      (match nonempty_json_string_opt "tool" json with
+       | Some tool -> Some tool
+       | None -> nonempty_json_string_opt "tool_name" json)
+
+let latest_keeper_tool_activity keeper_name =
+  try
+    match Keeper_tool_call_log.read_latest ~keeper_name () with
+    | Some json ->
+        (match positive_json_float_opt "ts" json with
+         | Some _ -> Some json
+         | None -> None)
+    | None -> None
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+      Log.Dashboard.warn
+        "keeper dashboard tool_call activity read failed for %s: %s"
+        keeper_name (Printexc.to_string exn);
+      None
+
+let approval_row_newer left right =
+  let left_ts = positive_json_float_opt "ts" left |> Option.value ~default:0.0 in
+  let right_ts = positive_json_float_opt "ts" right |> Option.value ~default:0.0 in
+  left_ts > right_ts
+
+let latest_rows_by_approval_id rows =
+  let table = Hashtbl.create 16 in
+  List.iter
+    (fun row ->
+      match nonempty_json_string_opt "id" row with
+      | None -> ()
+      | Some id ->
+          let should_replace =
+            match Hashtbl.find_opt table id with
+            | None -> true
+            | Some existing -> approval_row_newer row existing
+          in
+          if should_replace then Hashtbl.replace table id row)
+    rows;
+  Hashtbl.fold (fun _ row acc -> row :: acc) table []
+
+let unresolved_pending_approval row =
+  match nonempty_json_string_opt "event" row with
+  | Some "pending" ->
+      (match nonempty_json_string_opt "decision" row with
+       | None -> true
+       | Some _ -> false)
+  | _ -> false
+
+let latest_pending_approval ~base_path ~keeper_name =
+  let rows =
+    try
+      Keeper_approval_queue.read_recent_audit
+        ~base_path ~keeper_name ~n:128 ()
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn ->
+        Log.Dashboard.warn
+          "keeper dashboard approval activity read failed for %s: %s"
+          keeper_name (Printexc.to_string exn);
+        []
+  in
+  latest_rows_by_approval_id rows
+  |> List.filter unresolved_pending_approval
+  |> List.fold_left
+       (fun acc row ->
+         match acc with
+         | None -> Some row
+         | Some existing when approval_row_newer row existing -> Some row
+         | Some _ -> acc)
+       None
+
+let freshest_activity_source ~meta_ts ~latest_tool ~pending_approval =
+  let candidates =
+    (if meta_ts > 0.0 then [ Keeper_meta ] else [])
+    @ (match latest_tool with Some json -> [ Tool_call json ] | None -> [])
+    @ (match pending_approval with Some json -> [ Approval_pending json ] | None -> [])
+  in
+  List.fold_left
+    (fun acc source ->
+      match acc with
+      | None -> Some source
+      | Some best ->
+          if activity_source_ts meta_ts source > activity_source_ts meta_ts best
+          then Some source
+          else acc)
+    None
+    candidates
+
+let activity_age_json ~now_ts ts =
+  if ts <= 0.0 then `Null else `Float (max 0.0 (now_ts -. ts))
+
+let activity_at_json ts =
+  if ts <= 0.0 then `Null
+  else `String (Masc_domain.iso8601_of_unix_seconds ts)
+
+let activity_turn_opt source =
+  match source with
+  | Keeper_meta -> None
+  | Tool_call json -> Safe_ops.json_int_opt "turn" json
+  | Approval_pending json -> Safe_ops.json_int_opt "turn" json
+
+let activity_keeper_turn_id_opt source =
+  match source with
+  | Keeper_meta -> None
+  | Tool_call json -> Safe_ops.json_int_opt "keeper_turn_id" json
+  | Approval_pending json -> Safe_ops.json_int_opt "keeper_turn_id" json
+
+let live_activity_json ~now_ts ~meta_ts source =
+  let ts = activity_source_ts meta_ts source in
+  `Assoc [
+    ("source", `String (activity_source_to_string source));
+    ("at", activity_at_json ts);
+    ("age_s", activity_age_json ~now_ts ts);
+    ("tool", Json_util.string_opt_to_json (activity_source_tool_opt source));
+    ("turn", Json_util.int_opt_to_json (activity_turn_opt source));
+    ("keeper_turn_id", Json_util.int_opt_to_json (activity_keeper_turn_id_opt source));
+  ]
+
+let pending_approval_gate_json ~now_ts row =
+  let ts = positive_json_float_opt "ts" row |> Option.value ~default:0.0 in
+  `Assoc [
+    ("kind", `String "approval_required");
+    ("source", `String "audit_approvals");
+    ("id", Json_util.string_opt_to_json (nonempty_json_string_opt "id" row));
+    ("tool", Json_util.string_opt_to_json (activity_source_tool_opt (Approval_pending row)));
+    ("risk", Json_util.string_opt_to_json (nonempty_json_string_opt "risk" row));
+    ("turn_id", Json_util.int_opt_to_json (Safe_ops.json_int_opt "turn_id" row));
+    ("at", activity_at_json ts);
+    ("age_s", activity_age_json ~now_ts ts);
+    ("disposition", Json_util.string_opt_to_json (nonempty_json_string_opt "disposition" row));
+    ("disposition_reason",
+      Json_util.string_opt_to_json (nonempty_json_string_opt "disposition_reason" row));
+  ]
+
+let pending_approval_summary row =
+  let tool = activity_source_tool_opt (Approval_pending row) |> Option.value ~default:"tool" in
+  match nonempty_json_string_opt "risk" row with
+  | Some risk -> Printf.sprintf "승인 대기 · %s (%s)" tool risk
+  | None -> Printf.sprintf "승인 대기 · %s" tool
+
 let running_keeper_count (config : Workspace.config) : int =
   keeper_names config
   |> List.fold_left
@@ -118,13 +297,55 @@ let keepers_dashboard_json ?(compact = false) (config : Workspace.config) : Yojs
           in
           (* C-3 fix: compute last_activity from the most recent activity timestamp
              to avoid showing misleading staleness when agent is actually active *)
-          let last_activity_ts =
+          let meta_activity_ts =
             List.fold_left max 0.0
               [ m.runtime.usage.last_turn_ts; m.runtime.proactive_rt.last_ts; m.runtime.last_handoff_ts;
                 m.runtime.compaction_rt.last_ts; created_ts ]
           in
+          let latest_tool_activity = latest_keeper_tool_activity m.name in
+          let pending_approval =
+            latest_pending_approval ~base_path:config.base_path ~keeper_name:m.name
+          in
+          let activity_source =
+            freshest_activity_source
+              ~meta_ts:meta_activity_ts
+              ~latest_tool:latest_tool_activity
+              ~pending_approval
+          in
+          let last_activity_ts =
+            match activity_source with
+            | Some source -> activity_source_ts meta_activity_ts source
+            | None -> 0.0
+          in
           let last_activity_ago_s =
             if last_activity_ts <= 0.0 then 0.0 else now_ts -. last_activity_ts
+          in
+          let live_activity_fields =
+            let source_json =
+              match activity_source with
+              | Some source -> `String (activity_source_to_string source)
+              | None -> `Null
+            in
+            let activity_json =
+              match activity_source with
+              | Some source -> live_activity_json ~now_ts ~meta_ts:meta_activity_ts source
+              | None -> `Null
+            in
+            let gate_json =
+              match pending_approval with
+              | Some row -> pending_approval_gate_json ~now_ts row
+              | None -> `Null
+            in
+            [
+              ("last_activity_source", source_json);
+              ("last_activity_at", activity_at_json last_activity_ts);
+              ("live_activity", activity_json);
+              ("current_gate", gate_json);
+            ]
+            @
+            (match pending_approval with
+             | Some row -> [ ("runtime_blocker_summary", `String (pending_approval_summary row)) ]
+             | None -> [])
           in
           let trace_history_count = List.length m.runtime.trace_history in
           (* RFC-0149 §3.3 — removed [_effective_runtime_id] zombie
@@ -706,6 +927,7 @@ let keepers_dashboard_json ?(compact = false) (config : Workspace.config) : Yojs
 	                else `String m.runtime.proactive_rt.last_preview);
             ]
             @ Keeper_status_bridge.social_runtime_fields_json m
+            @ live_activity_fields
             @ [
 	              ("skill_primary", Json_util.string_opt_to_json last_skill_primary);
 	              ("skill_secondary",


### PR DESCRIPTION
## Summary

- fold keeper meta, latest tool-call activity, and unresolved approval audit rows into the Keeper Fleet row projection
- expose `last_activity_source`, `last_activity_at`, `live_activity`, and `current_gate` so the dashboard can show the live source instead of stale durable meta only
- prioritize pending approval gates in the roster/detail display, so stale timeout summaries do not hide `approval_required` states

## Root Cause

Keeper Fleet rows were mostly driven by durable keeper meta. In-flight OAS/tool/approval state lived in separate stores, so the UI could show an old timeout while the live runtime was actually waiting on an approval gate.

## Validation

- `pnpm --dir dashboard typecheck`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/lib/keeper-runtime-display.test.ts src/components/agent-roster.test.ts src/keeper-store-normalize.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm lint`
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=/private/tmp/masc-dune-dashboard-keeper-live-activity-ssot dune build --root . lib/masc.cma`
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=/private/tmp/masc-dune-dashboard-keeper-live-activity-ssot dune build --root . lib/dashboard/masc_dashboard.cma`
- Playwright rendered validation with mocked Keeper Fleet approval gate (`/private/tmp/masc-dashboard-live-activity-check.png`)