### PR TITLE
fix(dashboard): clarify FSM Hub operator semantics

### DIFF
--- a/dashboard/src/components/fsm-hub-invariant-analysis.test.ts
+++ b/dashboard/src/components/fsm-hub-invariant-analysis.test.ts
@@ -257,7 +257,7 @@ describe('deriveOperationalInsight', () => {
       now,
     )
     expect(insight.tone).toBe('ok')
-    expect(insight.headline).toContain('Idle')
+    expect(insight.headline).toContain('대기')
   })
 
   it('reports ok when not live without last_outcome', () => {
@@ -267,7 +267,7 @@ describe('deriveOperationalInsight', () => {
       now,
     )
     expect(insight.tone).toBe('ok')
-    expect(insight.detail).toContain('not captured')
+    expect(insight.detail).toContain('아직 완료된 turn')
   })
 
   it('reports info when runtime is selecting', () => {
@@ -358,7 +358,7 @@ describe('deriveOperationalInsight', () => {
       noObservations,
       now,
     )
-    expect(insight.nextStep).toContain('first live turn')
+    expect(insight.nextStep).toContain('첫 live turn')
   })
 
   it('gives correct nextStep for Failing+exhausted', () => {

--- a/dashboard/src/components/fsm-hub-invariant-analysis.ts
+++ b/dashboard/src/components/fsm-hub-invariant-analysis.ts
@@ -64,8 +64,8 @@ function invariantDetail(
 function nextExpectedStep(snapshot: KeeperCompositeSnapshot): string {
   if (!snapshot.is_live) {
     return snapshot.last_outcome
-      ? '다음 live turn 이 idle placeholder 로부터 KTC/KDP/KCL 을 repopulate 해야 함.'
-      : '아직 완료된 턴 없음 — first live turn 이 observer 를 채워야 함.'
+      ? '다음 live turn 이 시작되면 KTC/KDP/KCL 이 실제 turn 값으로 갱신되어야 함.'
+      : '아직 완료된 turn 없음 — 첫 live turn 이 시작되면 관측값이 채워져야 함.'
   }
   // `collapsed_from` carries the raw KSM phase when the composite has folded
   // it under a parent projection. When present it is the operator-actionable
@@ -209,10 +209,10 @@ export function deriveOperationalInsight(
       : 'no completed turn yet'
     return {
       tone: 'ok',
-      headline: 'Idle 스냅샷 정상',
+      headline: '대기 상태 정상',
       detail: snapshot.last_outcome
-        ? `sub-FSM 들이 idle placeholder 로 fallback 됨; 마지막 완료 turn 은 ${idleSince} 전 종료.`
-        : 'observer 가 idle — has not captured a completed turn yet.',
+        ? `현재 live turn 없음. KTC/KDP/KCL 은 대기값이며, 마지막 완료 turn 은 ${idleSince} 전 종료.`
+        : '현재 live turn 없음. 아직 완료된 turn 을 관측하지 못함.',
       nextStep: nextExpectedStep(snapshot),
       evidence: [
         `KSM ${snapshot.phase}`,

--- a/dashboard/src/components/fsm-hub-lane-analysis.ts
+++ b/dashboard/src/components/fsm-hub-lane-analysis.ts
@@ -62,7 +62,7 @@ function laneMeaning(
         case 'running':
           return snapshot.is_live
             ? { tone: 'info', meaning: 'parent lifecycle 정상 — live turn 진행 중' }
-            : { tone: 'ok', meaning: 'live turn 없음 — 다음 observation cycle 대기' }
+            : { tone: 'ok', meaning: 'keeper 는 살아있고 현재 진행 중인 turn 은 없음' }
         case 'failing':
           return { tone: 'error', meaning: 'parent lifecycle degraded — healthy turn 재개 전 해소 필요' }
         case 'overflowed':
@@ -79,7 +79,7 @@ function laneMeaning(
     case 'turn':
       switch (value) {
         case 'idle':
-          return { tone: snapshot.is_live ? 'info' : 'ok', meaning: snapshot.is_live ? 'turn context 존재하지만 work 미진행' : 'in-flight turn 관측되지 않음' }
+          return { tone: snapshot.is_live ? 'info' : 'ok', meaning: snapshot.is_live ? 'turn context 존재하지만 work 미진행' : '현재 진행 중인 turn 없음' }
         case 'prompting':
           return { tone: 'info', meaning: 'prompt assembly 가 turn input 준비 중' }
         case 'executing':
@@ -94,7 +94,7 @@ function laneMeaning(
     case 'decision':
       switch (value) {
         case 'undecided':
-          return { tone: snapshot.is_live ? 'info' : 'ok', meaning: snapshot.is_live ? 'decision work 미커밋' : 'idle snapshot 은 의도적으로 decision state 비움' }
+          return { tone: snapshot.is_live ? 'info' : 'ok', meaning: snapshot.is_live ? 'decision work 미커밋' : '진행 중인 turn 이 없어 결정 단계 없음' }
         case 'guard_ok':
           return { tone: 'info', meaning: 'guardrail 통과 — turn 계속 진행 허용' }
         case 'gate_rejected':
@@ -107,7 +107,7 @@ function laneMeaning(
     case 'runtime':
       switch (value) {
         case 'idle':
-          return { tone: 'ok', meaning: 'provider failover work 비활성' }
+          return { tone: 'ok', meaning: 'provider/runtime 실행 중 아님' }
         case 'selecting':
           return { tone: 'info', meaning: 'provider routing 이 다음 execution path 선택 중' }
         case 'trying':
@@ -122,7 +122,7 @@ function laneMeaning(
     case 'compaction':
       switch (value) {
         case 'accumulating':
-          return { tone: 'ok', meaning: 'memory 가 compaction 후보 수집 중 — 아직 실행 안 함' }
+          return { tone: 'ok', meaning: '메모리 누적 중 — compaction 실행 중 아님' }
         case 'compacting':
           return { tone: 'warn', meaning: 'memory compaction 이 context state 를 rewrite 중' }
         case 'done':
@@ -137,7 +137,7 @@ function laneMeaning(
         case 'clean':
           return { tone: 'ok', meaning: 'circuit breaker clean — 최근 tool failure streak 없음' }
         case 'warning':
-          return { tone: 'warn', meaning: '연속된 tool failure 누적 중 — class 가 동일하게 유지되면 trip 가능' }
+          return { tone: 'warn', meaning: '동일 유형 도구 실패가 누적 중 — 계속되면 breaker 작동 가능' }
         case 'cooling':
           return { tone: 'info', meaning: 'breaker 가 과거에 trip — 현재 reset 됐고 active streak 없음' }
         default:

--- a/dashboard/src/components/fsm-hub-pipeline-panels.ts
+++ b/dashboard/src/components/fsm-hub-pipeline-panels.ts
@@ -96,7 +96,7 @@ export function OperationalMeaningPanel({
     >
       <div class="flex items-start justify-between gap-3 flex-wrap">
         <div class="min-w-0">
-          <div class="text-3xs font-semibold uppercase tracking-2 text-[var(--color-fg-muted)]">오퍼레이터 의미</div>
+          <div class="text-3xs font-semibold uppercase tracking-2 text-[var(--color-fg-muted)]">상태 해석</div>
           <div class="mt-1 text-xl font-semibold text-[var(--color-fg-secondary)]">${insight.headline}</div>
           <div class="mt-1 text-2xs text-[var(--color-fg-disabled)] leading-relaxed">${insight.detail}</div>
         </div>
@@ -106,7 +106,7 @@ export function OperationalMeaningPanel({
       </div>
 
       <div class="mt-2 text-3xs text-[var(--color-fg-primary)]">
-        <span class="font-semibold text-[var(--color-fg-muted)]">Next:</span> ${insight.nextStep}
+        <span class="font-semibold text-[var(--color-fg-muted)]">다음 관측:</span> ${insight.nextStep}
       </div>
 
       <div class="mt-2 flex flex-wrap gap-1.5">
@@ -147,7 +147,7 @@ export function OperationalMeaningPanel({
                 <div class="mt-0.5 text-3xs text-[var(--color-fg-disabled)]">${lane.label}</div>
                 <div class="mt-1.5 text-3xs leading-relaxed text-[var(--color-fg-primary)]">${lane.meaning}</div>
                 <div class="mt-1 text-3xs font-mono text-[var(--color-fg-disabled)]">
-                  ${lane.transitionCount} observed edge${lane.transitionCount === 1 ? '' : 's'}
+                  ${lane.transitionCount} 화면 내 상태 변화
                 </div>
               </div>
             `)}

--- a/dashboard/src/components/fsm-hub.test.ts
+++ b/dashboard/src/components/fsm-hub.test.ts
@@ -207,7 +207,7 @@ describe('fsm-hub derived state', () => {
     )
 
     expect(result.tone).toBe('ok')
-    expect(result.headline).toContain('Idle 스냅샷 정상')
+    expect(result.headline).toContain('대기 상태 정상')
     expect(result.detail).toContain('25s')
   })
 

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -172,6 +172,7 @@ function runtimeProviderAttemptClass(trace: KeeperRuntimeTraceResponse): string 
 
 function runtimeProviderAttemptLabel(trace: KeeperRuntimeTraceResponse): string {
   const provider = trace.provider_attempts
+  if (provider.started_count === 0 && provider.finished_count === 0) return 'prov none'
   const status = shortText(provider.terminal_status, 18) || 'unknown'
   return ['prov', status].filter(Boolean).join(' ')
 }
@@ -253,7 +254,7 @@ function RuntimeEvidenceSummary({
   const title = runtimeTraceTitle(trace)
   return html`
     <span class=${`${commonClass} ${runtimeTraceClass(trace)}`} title=${title}>
-      증거 ${trace.health || 'unknown'}
+      trace ${trace.health || 'unknown'}
     </span>
 	    <span class=${`${commonClass} border-[var(--color-border-default)] text-[var(--color-fg-primary)]`} title=${title}>
 	      ${runtimeTraceTurnLabel(trace)}

--- a/lib/server/server_dashboard_http_composite_claims.ml
+++ b/lib/server/server_dashboard_http_composite_claims.ml
@@ -235,6 +235,12 @@ let string_opt_present value =
   | None -> false
 ;;
 
+let string_opt_has_prefix value ~prefix =
+  match lower_string_opt value with
+  | Some value -> string_has_prefix ~prefix value
+  | None -> false
+;;
+
 let json_string_eq key json expected =
   match json_string key json with
   | Some value -> String.equal value expected
@@ -330,12 +336,28 @@ let composite_execution_config_drift execution =
 
 let keeper_activation_readiness_json = Server_dashboard_fleet_readiness.keeper_activation_readiness_json
 
+let composite_execution_budget_exhausted_pass execution =
+  string_opt_is_any (json_string "operator_disposition" execution) [ "pass" ]
+  && string_opt_has_prefix
+       (json_string "terminal_reason_code" execution)
+       ~prefix:"turn_budget_exhausted"
+  &&
+  match lower_string_opt (json_string "operator_disposition_reason" execution) with
+  | None -> true
+  | Some "" -> true
+  | Some "healthy" -> true
+  | Some reason -> string_has_prefix ~prefix:"turn_budget_exhausted" reason
+;;
+
 let composite_execution_blocked execution =
   composite_execution_claim_no_eligible execution
   || composite_execution_contract_blocked execution
   || string_opt_is_any (json_string "operator_disposition" execution) [ "pause_human" ]
   || (match lower_string_opt (json_string "terminal_reason_code" execution) with
-      | Some terminal -> terminal <> "" && terminal <> "completed"
+      | Some terminal ->
+        terminal <> ""
+        && terminal <> "completed"
+        && not (composite_execution_budget_exhausted_pass execution)
       | None -> false)
   ||
   match json_member "error" execution with
@@ -430,6 +452,7 @@ let composite_runtime_attention ~snapshot ~execution =
     then Some "claim_scope_no_eligible"
     else match composite_execution_contract_blocker_reason execution with
     | Some _ as reason -> reason
+    | None when not blocked -> None
     | None ->
       (match json_string "operator_disposition_reason" execution with
        | Some value -> String_util.trim_to_option value

--- a/test/test_server_dashboard_composite_attention.ml
+++ b/test/test_server_dashboard_composite_attention.ml
@@ -26,6 +26,20 @@ let execution completion_contract_result =
     ]
 ;;
 
+let completed_budget_execution =
+  `Assoc
+    [ "latest_receipt_present", `Bool true
+    ; "recorded_at", `String "2999-01-01T00:00:00Z"
+    ; "completion_contract_result", `Null
+    ; "operator_disposition", `String "pass"
+    ; "operator_disposition_reason", `String "healthy"
+    ; "terminal_reason_code", `String "turn_budget_exhausted:1070/1070"
+    ; "error", `Null
+    ; "claim_scope", `Assoc [ "status", `String "ok" ]
+    ; "config_drift", `Assoc [ "runtime_override", `Bool false ]
+    ]
+;;
+
 let test_contract_blocker_marks_attention () =
   let execution = execution "surface_mismatch" in
   let attention =
@@ -74,6 +88,18 @@ let test_contract_blocker_recommends_route_actions () =
             reason))
 ;;
 
+let test_completed_budget_exhaustion_is_not_blocked () =
+  let attention =
+    Server_dashboard_http_composite.composite_runtime_attention
+      ~snapshot
+      ~execution:completed_budget_execution
+  in
+  check bool "blocked" false attention.cra_blocked;
+  check bool "needs_attention" false attention.cra_needs_attention;
+  check string "state" "ok" attention.cra_state;
+  check (option string) "reason" None attention.cra_reason
+;;
+
 let () =
   run
     "server_dashboard_composite_attention"
@@ -81,6 +107,12 @@ let () =
       , [ test_case "marks runtime attention" `Quick test_contract_blocker_marks_attention
         ; test_case "emits route actions" `Quick
             test_contract_blocker_recommends_route_actions
+        ] )
+    ; ( "completed receipt semantics"
+      , [ test_case
+            "pass/healthy turn-budget exhaustion is not blocked"
+            `Quick
+            test_completed_budget_exhaustion_is_not_blocked
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary

Clarifies the Keeper FSM Hub operator surface so idle snapshots and runtime trace chips read as deterministic dashboard state rather than LLM/operator judgment.

- Rewords the FSM Hub idle state from `Idle snapshot` / placeholder language to explicit `no live turn` semantics.
- Renames the explanatory panel from operator meaning to state interpretation and makes lane transition counts read as screen-local state changes.
- Shows provider trace rows with no provider attempts as `prov none` instead of `prov unknown`.
- Prevents successful `pass` + `healthy` turn-budget exhaustion receipts from being marked as `runtime_attention.blocked`.

## Why

The previous copy made the surface look like an LLM had inferred meaning from the run, and the backend attention classifier could mark a healthy budget-exhausted pass receipt as blocked. That made the Keeper detail page harder to trust during normal idle periods.

## Validation

- `pnpm --dir dashboard typecheck`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/fsm-hub.test.ts src/components/fsm-hub-invariant-analysis.test.ts --no-file-parallelism --maxWorkers=1`
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_fsm_hub_semantics dune build --root . test/test_server_dashboard_composite_attention.exe`
- `./_build_fsm_hub_semantics/default/test/test_server_dashboard_composite_attention.exe`
- `git diff --check`