### PR TITLE
fix(keeper): auto-recover transient timeout pauses

### DIFF
--- a/dashboard/src/components/mission-agent-cards.test.ts
+++ b/dashboard/src/components/mission-agent-cards.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Keeper } from '../types'
 import {
   keeperDisplayStatus,
+  isKeeperAutoRecoverPause,
   keeperRuntimeBlockerLabel,
   keeperRecentActionLabel,
   keeperRecentHeartbeatLabel,
@@ -55,6 +56,38 @@ describe('mission keeper runtime helpers', () => {
     } as Keeper
 
     expect(keeperRuntimeHint(keeper)).toBe('일시정지됨')
+  })
+
+  it('labels timeout pauses as auto-retry wait instead of operator pause', () => {
+    const keeper = {
+      name: 'timeout-paused',
+      status: 'paused',
+      paused: true,
+      keepalive_running: false,
+      runtime_blocker_class: 'turn_timeout',
+      runtime_blocker_summary: 'turn_timeout',
+    } as Keeper
+
+    expect(isKeeperAutoRecoverPause(keeper)).toBe(true)
+    expect(keeperRuntimeHint(keeper)).toBe(
+      '자동 재시도 대기 · 턴 실행 시간이 제한 시간을 초과했습니다.',
+    )
+  })
+
+  it('labels TLS handshake provider-runtime pauses as auto-retry wait', () => {
+    const keeper = {
+      name: 'tls-paused',
+      status: 'paused',
+      paused: true,
+      runtime_blocker_class: 'provider_runtime_error',
+      runtime_blocker_summary:
+        'Provider runtime catch-all (internal_unhandled_exception): TLS alert from peer: handshake failure',
+    } as Keeper
+
+    expect(isKeeperAutoRecoverPause(keeper)).toBe(true)
+    expect(keeperRuntimeHint(keeper)).toBe(
+      '자동 재시도 대기 · Provider runtime catch-all (internal_unhandled_exception): TLS alert from peer: handshake failure',
+    )
   })
 
   it('prefers structured runtime blocker hints over paused/blocker text', () => {

--- a/dashboard/src/lib/keeper-operational-state.test.ts
+++ b/dashboard/src/lib/keeper-operational-state.test.ts
@@ -101,6 +101,21 @@ describe('deriveKeeperOperationalState — paused branch', () => {
     })
   })
 
+  it('paused auto_recover cause when blocker is retryable timeout', () => {
+    const state = deriveKeeperOperationalState({
+      keeper: makeKeeper({
+        paused: true,
+        runtime_blocker_class: 'turn_timeout',
+      }),
+      composite: null,
+    })
+    expect(state).toMatchObject({
+      kind: 'paused',
+      attention: 'clean',
+      cause: 'auto_recover',
+    })
+  })
+
   it('paused operator cause when pause_state === paused', () => {
     const state = deriveKeeperOperationalState({
       keeper: makeKeeper({ pause_state: 'paused' }),

--- a/dashboard/src/lib/keeper-operational-state.ts
+++ b/dashboard/src/lib/keeper-operational-state.ts
@@ -46,7 +46,10 @@ import type {
   KeeperCompositeSnapshot,
 } from '../api/schemas/keeper-composite'
 import { deriveBlockerReason } from './keeper-blocker-reason'
-import { keeperDisplayStatus } from './keeper-runtime-display'
+import {
+  isKeeperAutoRecoverPause,
+  keeperDisplayStatus,
+} from './keeper-runtime-display'
 import {
   isKeeperOffline,
   isKeeperPaused,
@@ -177,6 +180,7 @@ function isPaused(k: Keeper, c: KeeperCompositeSnapshot | null): boolean {
 
 function derivePausedCause(k: Keeper, c: KeeperCompositeSnapshot | null): PausedCause {
   if (k.runtime_blocker_class === 'supervisor_paused') return 'supervisor'
+  if (isKeeperAutoRecoverPause(k)) return 'auto_recover'
   if (c?.phase_diagnosis?.conditions.operator_paused === true) return 'operator'
   if (k.pause_state === 'paused') return 'operator'
   if (k.phase === 'Paused') return 'operator'

--- a/dashboard/src/lib/keeper-runtime-display.ts
+++ b/dashboard/src/lib/keeper-runtime-display.ts
@@ -197,8 +197,45 @@ function diagnosticStateLabel(keeper: Keeper): string | null {
   return health ?? continuity
 }
 
+function transientProviderRuntimeText(value: string | null | undefined): boolean {
+  const text = value?.trim().toLowerCase()
+  if (!text) return false
+  return (
+    text.includes('tls alert')
+    || text.includes('tls_error')
+    || text.includes('handshake failure')
+    || text.includes('network')
+    || text.includes('connection refused')
+    || text.includes('connection reset')
+    || text.includes('dns')
+    || text.includes('timeout')
+    || text.includes('timed out')
+  )
+}
+
+export function isKeeperAutoRecoverPause(keeper: Keeper | null | undefined): boolean {
+  if (!keeper || !isKeeperPaused(keeper)) return false
+  const blockerClass = keeper.runtime_blocker_class
+  if (
+    blockerClass === 'turn_timeout'
+    || blockerClass === 'turn_timeout_after_queue_wait'
+    || blockerClass === 'admission_queue_wait_timeout'
+  ) {
+    return true
+  }
+  if (blockerClass === 'provider_runtime_error') {
+    return (
+      transientProviderRuntimeText(keeper.runtime_blocker_summary)
+      || transientProviderRuntimeText(keeper.last_blocker)
+      || transientProviderRuntimeText(keeper.attention_reason)
+    )
+  }
+  return false
+}
+
 export function keeperPauseDisplay(keeper: Keeper): KeeperPauseDisplay | null {
   if (!isKeeperPaused(keeper)) return null
+  const autoRecover = isKeeperAutoRecoverPause(keeper)
   const trust = keeper.trust
   const blockerLabel = keeperRuntimeBlockerLabel(keeper.runtime_blocker_class)
   const reason =
@@ -221,8 +258,9 @@ export function keeperPauseDisplay(keeper: Keeper): KeeperPauseDisplay | null {
   )
   const diagnostic = diagnosticStateLabel(keeper)
   const detail = [
+    autoRecover ? '상태 자동 재시도 대기' : null,
     `원인 ${reason}`,
-    nextAction ? `다음 ${nextAction}` : null,
+    nextAction ? `다음 ${nextAction}` : autoRecover ? '다음 자동 재시도' : null,
     diagnostic ? `진단 ${diagnostic}` : null,
   ].filter((part): part is string => part !== null).join(' · ')
   const title = [
@@ -459,11 +497,16 @@ export function keeperRuntimeHint(keeper: Keeper | null | undefined): string | n
   // The same file already routes the *summary* and *short* axes through
   // isKeeperPaused (L135, L166); the runtime hint had drifted to raw flag.
   const paused = isKeeperPaused(keeper)
+  const autoRecover = isKeeperAutoRecoverPause(keeper)
   const runtimeBlocker = keeperRuntimeBlockerHint(keeper)
-  if (runtimeBlocker) return paused ? `일시정지 원인 · ${runtimeBlocker}` : runtimeBlocker
+  if (runtimeBlocker) {
+    if (paused && autoRecover) return `자동 재시도 대기 · ${runtimeBlocker}`
+    return paused ? `일시정지 원인 · ${runtimeBlocker}` : runtimeBlocker
+  }
   const socialFallback = socialModelFallbackHint(keeper)
   if (socialFallback) return socialFallback
   const blocker = keeper.last_blocker?.trim()
+  if (paused && autoRecover) return blocker ? `자동 재시도 대기 · ${blocker}` : '자동 재시도 대기'
   if (paused && blocker) return `일시정지 · ${blocker}`
   if (paused && keeper.keepalive_running) return '일시정지 · 하트비트만 유지 중'
   if (paused) return '일시정지됨'

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -32,8 +32,35 @@ let string_contains_substring = String_util.string_contains_substring
 let is_structural_oas_timeout_message message =
   Keeper_oas_timeout_message.is_structural message
 
+let is_transient_internal_runner_error (err : Agent_sdk.Error.sdk_error) : bool =
+  match Keeper_turn_driver.classify_masc_internal_error err with
+  | Some (Keeper_turn_driver.Internal_unhandled_exception { site; exn_repr })
+    when String.equal site "runtime_runner.execute" ->
+    let lower = String.lowercase_ascii exn_repr in
+    string_contains_substring ~needle:"tls alert" lower
+    || string_contains_substring ~needle:"handshake failure" lower
+    || string_contains_substring ~needle:"tls_error" lower
+  | Some
+      ( Keeper_turn_driver.Internal_unhandled_exception _
+      | Keeper_turn_driver.Runtime_exhausted _
+      | Keeper_turn_driver.Capacity_backpressure _
+      | Keeper_turn_driver.Resumable_cli_session _
+      | Keeper_turn_driver.Accept_rejected _
+      | Keeper_turn_driver.Admission_queue_timeout _
+      | Keeper_turn_driver.Admission_queue_rejected _
+      | Keeper_turn_driver.Provider_timeout _
+      | Keeper_turn_driver.Turn_timeout _
+      | Keeper_turn_driver.Max_tokens_ceiling_violation _
+      | Keeper_turn_driver.Ambiguous_post_commit _
+      | Keeper_turn_driver.Retry_admission_denied _
+      | Keeper_turn_driver.Internal_bridge_exception _
+      | Keeper_turn_driver.Internal_contract_rejected _ )
+  | None -> false
+
 let is_transient_network_error (err : Agent_sdk.Error.sdk_error) : bool =
-  match err with
+  if is_transient_internal_runner_error err
+  then true
+  else match err with
   | Agent_sdk.Error.Api (NetworkError _) -> true
   | Agent_sdk.Error.Api (Timeout { message }) ->
       not (is_structural_oas_timeout_message message)

--- a/lib/keeper/keeper_error_classify.mli
+++ b/lib/keeper/keeper_error_classify.mli
@@ -9,6 +9,10 @@
     Uses structured [Agent_sdk.Error.sdk_error] pattern matching. *)
 val is_transient_network_error : Agent_sdk.Error.sdk_error -> bool
 
+(** [true] when a typed internal runner exception preserves a transient
+    transport failure that was raised inside [runtime_runner.execute]. *)
+val is_transient_internal_runner_error : Agent_sdk.Error.sdk_error -> bool
+
 (** [true] when an OAS timeout message describes an execution budget expiry,
     not a transport-level timeout. *)
 val is_structural_oas_timeout_message : string -> bool

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -545,7 +545,7 @@ let sweep_and_recover (ctx : _ context) =
                                   paused so the registry has no entries
                                   to score).  Defaulting to "block" here
                                   is the bug PR #14146 shipped: it turned
-                                  the boot-time race window into a
+           the boot-time race window into a
                                   permanent lockout.  See instructions/
                                   software-development.md anti-pattern
                                   "Unknown -> Permissive Default". *)
@@ -564,7 +564,8 @@ let sweep_and_recover (ctx : _ context) =
            let resume_after_sec =
              Option.value
                ~default:0.0
-               meta.auto_resume_after_sec
+               (Keeper_supervisor_types.paused_meta_effective_auto_resume_after_sec
+                  meta)
            in
            let paused_ts =
              Workspace_resilience.Time.parse_iso8601_opt meta.updated_at

--- a/lib/keeper/keeper_supervisor_types.ml
+++ b/lib/keeper/keeper_supervisor_types.ml
@@ -121,6 +121,49 @@ let paused_meta_requires_reconcile_recovery (meta : keeper_meta) =
   | None -> false
 ;;
 
+let paused_meta_legacy_auto_resume_after_sec (meta : keeper_meta) =
+  match meta.runtime.last_blocker with
+  | Some { klass = Turn_timeout; _ } ->
+    let initial_sec = Env_config.KeeperSupervisor.auto_resume_initial_sec in
+    let max_sec = Env_config.KeeperSupervisor.auto_resume_max_sec in
+    if initial_sec <= 0.0 then None else Some (Float.min max_sec initial_sec)
+  | Some
+      { klass =
+          ( Runtime_exhausted _
+          | Capacity_backpressure
+          | Ambiguous_post_commit_timeout
+          | Ambiguous_post_commit_failure
+          | Autonomous_slot_wait_timeout
+          | Admission_queue_wait_timeout
+          | Turn_timeout_after_queue_wait
+          | Turn_livelock_blocked
+          | Completion_contract_violation
+          | Stay_silent_loop
+          | Fiber_unresolved
+          | Stale_turn_timeout
+          | Stale_fleet_batch
+          | Oas_agent_execution_timeout
+          | Sdk_max_turns_exceeded
+          | Sdk_token_budget_exceeded
+          | Sdk_cost_budget_exceeded
+          | Sdk_unrecognized_stop_reason
+          | Sdk_idle_detected
+          | Sdk_tool_retry_exhausted
+          | Sdk_guardrail_violation
+          | Sdk_tripwire_violation
+          | Sdk_exit_condition_met
+          | Sdk_input_required )
+      ; _
+      }
+  | None -> None
+;;
+
+let paused_meta_effective_auto_resume_after_sec (meta : keeper_meta) =
+  match meta.auto_resume_after_sec with
+  | Some _ as explicit -> explicit
+  | None -> paused_meta_legacy_auto_resume_after_sec meta
+;;
+
 let next_auto_resume_after_sec ~initial_sec ~max_sec previous =
   if initial_sec <= 0.0
   then None
@@ -135,7 +178,7 @@ let paused_meta_auto_resume_due ~now (meta : keeper_meta) =
   if (not meta.paused) || paused_meta_requires_reconcile_recovery meta
   then false
   else
-    match meta.auto_resume_after_sec with
+    match paused_meta_effective_auto_resume_after_sec meta with
     | None -> false
     | Some resume_after_sec ->
       (match Workspace_resilience.Time.parse_iso8601_opt meta.updated_at with

--- a/lib/keeper/keeper_supervisor_types.mli
+++ b/lib/keeper/keeper_supervisor_types.mli
@@ -66,10 +66,18 @@ val paused_meta_requires_reconcile_recovery : keeper_meta -> bool
 val paused_meta_auto_resume_due : now:float -> keeper_meta -> bool
 (** True when [meta] is an auto-paused keeper whose self-healing backoff has
     elapsed.  Intentional/operator pauses and reconcile-gated pauses are
-    excluded.  Only an explicit [auto_resume_after_sec] makes a paused keeper
-    auto-recoverable.  This pure predicate deliberately does not inspect runtime
-    health or approval queues; callers that can see those runtime surfaces must
-    still apply them before mutating state. *)
+    excluded.  Explicit [auto_resume_after_sec] is preferred; legacy
+    [Turn_timeout] blocker metadata without that field uses the current initial
+    auto-resume backoff so old timeout pauses do not become permanent operator
+    pauses.  This predicate deliberately does not inspect runtime health or
+    approval queues; callers that can see those runtime surfaces must still
+    apply them before mutating state. *)
+
+val paused_meta_effective_auto_resume_after_sec : keeper_meta -> float option
+(** Effective auto-resume delay used by supervisor and health JSON.  Returns
+    the persisted value when present, otherwise the implicit legacy timeout
+    delay when the last blocker proves the pause was an auto-recoverable turn
+    timeout. *)
 
 val cohort_key_of_reason : Keeper_registry.failure_reason option -> string
 (** Map a structured failure_reason to a cohort key for self-preservation grouping. *)

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -42,20 +42,26 @@ let pause_kind (meta : Keeper_meta_contract.keeper_meta) =
   if Keeper_supervisor_types.paused_meta_requires_reconcile_recovery meta then
     "reconcile_gated"
   else
-    match meta.auto_resume_after_sec with
+    match Keeper_supervisor_types.paused_meta_effective_auto_resume_after_sec meta with
     | Some _ -> "auto_recoverable"
     | None -> "operator_paused"
 
 let pause_auto_resume_source (meta : Keeper_meta_contract.keeper_meta) =
   match meta.auto_resume_after_sec with
   | Some _ -> Some "explicit"
-  | None -> None
+  | None ->
+    (match Keeper_supervisor_types.paused_meta_effective_auto_resume_after_sec meta with
+     | Some _ -> Some "implicit_turn_timeout"
+     | None -> None)
 
 let paused_keeper_detail_json ~now ~name ~(autoboot_enabled : bool)
     (meta : Keeper_meta_contract.keeper_meta) =
   let elapsed = pause_elapsed_sec now meta in
+  let effective_auto_resume_after_sec =
+    Keeper_supervisor_types.paused_meta_effective_auto_resume_after_sec meta
+  in
   let remaining =
-    match (meta.auto_resume_after_sec, elapsed) with
+    match (effective_auto_resume_after_sec, elapsed) with
     | Some resume_after, Some elapsed -> Some (max 0.0 (resume_after -. elapsed))
     | Some resume_after, None -> Some resume_after
     | None, _ -> None
@@ -65,7 +71,7 @@ let paused_keeper_detail_json ~now ~name ~(autoboot_enabled : bool)
     ("name", `String name);
     ("autoboot_enabled", `Bool autoboot_enabled);
     ("pause_kind", `String (pause_kind meta));
-    ("auto_resume_after_sec", Json_util.float_opt_to_json meta.auto_resume_after_sec);
+    ("auto_resume_after_sec", Json_util.float_opt_to_json effective_auto_resume_after_sec);
     ( "persisted_auto_resume_after_sec"
     , Json_util.float_opt_to_json meta.auto_resume_after_sec );
     ("auto_resume_source", Json_util.string_opt_to_json (pause_auto_resume_source meta));

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -1825,90 +1825,38 @@ let test_operator_pause_not_auto_resumed () =
       check (float 0.001) "metric_keeper_auto_resumed_total NOT incremented"
         baseline_auto_resume after_auto_resume)
 
-let test_turn_timeout_blocker_without_resume_policy_not_auto_resumed () =
-  Eio_main.run @@ fun env ->
-  ensure_fs env;
-  Eio.Switch.run @@ fun sw ->
-  with_config_dir @@ fun config_dir ->
-  let base_dir = temp_dir () in
-  Fun.protect
-    ~finally:(fun () ->
-      Reg.clear ();
-      Masc.Keeper_runtime.reset_test_state base_dir;
-      cleanup_dir base_dir)
-    (fun () ->
-      let config = Masc.Workspace.default_config base_dir in
-      ignore (Masc.Workspace.init config ~agent_name:(Some "supervisor"));
-      let name = "timeout-paused-without-resume-policy" in
-      write_keeper_toml config_dir ~name;
-      let two_hours_ago =
-        let t = Unix.gmtime (Unix.time () -. 7200.0) in
-        Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
-          (t.tm_year + 1900) (t.tm_mon + 1) t.tm_mday
-          t.tm_hour t.tm_min t.tm_sec
-      in
-      let timeout_blocker =
-        Keeper_meta_contract.blocker_info_of_class ~detail:"turn_timeout" Keeper_meta_contract.Turn_timeout
-      in
-      let paused_meta =
-        { (make_meta name) with
-          paused = true;
-          auto_resume_after_sec = None;
-          updated_at = two_hours_ago;
-          runtime =
-            { (make_meta name).runtime with
-              last_blocker = Some timeout_blocker;
-            };
+let test_turn_timeout_blocker_without_resume_policy_auto_recoverable () =
+  let now = Unix.time () in
+  let two_hours_ago =
+    let t = Unix.gmtime (now -. 7200.0) in
+    Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
+      (t.tm_year + 1900) (t.tm_mon + 1) t.tm_mday
+      t.tm_hour t.tm_min t.tm_sec
+  in
+  let timeout_blocker =
+    Keeper_meta_contract.blocker_info_of_class
+      ~detail:"turn_timeout"
+      Keeper_meta_contract.Turn_timeout
+  in
+  let paused_meta =
+    { (make_meta "timeout-paused-without-resume-policy") with
+      paused = true
+    ; auto_resume_after_sec = None
+    ; updated_at = two_hours_ago
+    ; runtime =
+        { (make_meta "timeout-paused-without-resume-policy").runtime with
+          last_blocker = Some timeout_blocker
         }
-      in
-      check bool "timeout blocker without resume policy is not due"
-        false
-        (Masc.Keeper_supervisor_types.paused_meta_auto_resume_due
-           ~now:(Unix.time ())
-           paused_meta);
-      (match Keeper_meta_store.write_meta config paused_meta with
-       | Ok () -> ()
-       | Error err -> fail err);
-      check bool "precondition: timeout pause is not bootable" false
-        (List.mem name (KR.bootable_keeper_names config));
-      let baseline_auto_resume =
-        Masc.Otel_metric_store.metric_total
-          Keeper_metrics.(to_string AutoResumedTotal)
-      in
-      let ctx : _ Keeper_types_profile.context =
-        {
-          config;
-          agent_name = "supervisor";
-          sw;
-          clock = Eio.Stdenv.clock env;
-          proc_mgr = Some (Eio.Stdenv.process_mgr env);
-          net = Some (Eio.Stdenv.net env);
-        }
-      in
-      Sup.sweep_and_recover ctx;
-      (match Keeper_meta_store.read_meta config name with
-       | Ok (Some m) ->
-           check bool "meta.paused stays true without explicit resume policy"
-             true m.paused;
-           check bool "auto_resume_after_sec remains absent"
-             true (Option.is_none m.auto_resume_after_sec);
-           check bool "timeout blocker stays recorded for operator inspection"
-             true
-             (match m.runtime.last_blocker with
-              | Some info -> info.klass = Keeper_meta_contract.Turn_timeout
-              | None -> false)
-       | Ok None -> fail "meta missing"
-       | Error err -> fail ("read_meta failed: " ^ err));
-      check bool "timeout pause remains out of bootable set" false
-        (List.mem name (KR.bootable_keeper_names config));
-      check bool "timeout pause is not reconciled into registry" false
-        (Reg.is_registered ~base_path:config.base_path name);
-      let after_auto_resume =
-        Masc.Otel_metric_store.metric_total
-          Keeper_metrics.(to_string AutoResumedTotal)
-      in
-      check (float 0.001) "metric_keeper_auto_resumed_total NOT incremented"
-        baseline_auto_resume after_auto_resume)
+    }
+  in
+  check bool "timeout blocker without resume policy is due"
+    true
+    (Masc.Keeper_supervisor_types.paused_meta_auto_resume_due ~now paused_meta);
+  check bool "implicit timeout auto-resume delay is present"
+    true
+    (Option.is_some
+       (Masc.Keeper_supervisor_types.paused_meta_effective_auto_resume_after_sec
+          paused_meta))
 
 (* Regression guard for #17063/#17067: [auto_resume_after_sec = None] is the
    manual/operator pause contract.  A [Capacity_backpressure] blocker from old
@@ -2252,8 +2200,8 @@ let () =
         test_sweep_auto_resumes_registered_paused_entry;
       test_case "operator pause (None) is NOT auto-resumed by sweep" `Quick
         test_operator_pause_not_auto_resumed;
-      test_case "turn timeout blocker without resume policy is NOT auto-resumed"
-        `Quick test_turn_timeout_blocker_without_resume_policy_not_auto_resumed;
+      test_case "turn timeout blocker without resume policy is auto-recoverable"
+        `Quick test_turn_timeout_blocker_without_resume_policy_auto_recoverable;
       test_case "capacity blocker without resume policy is NOT auto-resumed"
         `Quick test_capacity_blocker_without_resume_policy_not_auto_resumed;
       test_case "initial delay capped at max_sec when initial > max (regression)" `Quick

--- a/test/test_oas_timeout_budget_strike.ml
+++ b/test/test_oas_timeout_budget_strike.ml
@@ -74,6 +74,13 @@ let provider_timeout_error ~phase =
 let turn_timeout_error () =
   KTD.sdk_error_of_masc_internal_error (KTD.Turn_timeout { elapsed_sec = 600.0 })
 
+let tls_handshake_internal_error () =
+  KTD.sdk_error_of_masc_internal_error
+    (KTD.Internal_unhandled_exception
+       { site = "runtime_runner.execute"
+       ; exn_repr = "TLS alert from peer: handshake failure"
+       })
+
 let test_cycle_failed_log_level_is_policy_aware () =
   Alcotest.(check bool)
     "provider timeout cycle failure is warn"
@@ -84,6 +91,21 @@ let test_cycle_failed_log_level_is_policy_aware () =
     "turn wall-clock timeout remains error"
     false
     (EC.should_warn_keeper_cycle_failed (turn_timeout_error ()))
+
+let test_tls_handshake_internal_error_is_transient () =
+  let err = tls_handshake_internal_error () in
+  Alcotest.(check bool)
+    "runtime_runner TLS handshake failure is a transient runner error"
+    true
+    (EC.is_transient_internal_runner_error err);
+  Alcotest.(check bool)
+    "runtime_runner TLS handshake failure enters transient network retry"
+    true
+    (EC.is_transient_network_error err);
+  Alcotest.(check bool)
+    "runtime_runner TLS handshake failure is auto-recoverable at turn level"
+    true
+    (EC.is_auto_recoverable_turn_error err)
 
 let test_attempt_watchdog_timeout_reclassifies_as_provider_timeout () =
   let budget : KCB.provider_timeout_budget =
@@ -223,6 +245,8 @@ let () =
           test_strike_limit_is_soft_backoff;
         Alcotest.test_case "cycle failure log level is policy-aware" `Quick
           test_cycle_failed_log_level_is_policy_aware;
+        Alcotest.test_case "TLS handshake internal error is transient" `Quick
+          test_tls_handshake_internal_error_is_transient;
         Alcotest.test_case
           "attempt watchdog timeout reclassifies as provider timeout"
           `Quick

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1214,16 +1214,16 @@ let test_health_json_keeps_timeout_pause_without_policy_manual () =
           |> List.find (fun row ->
                row |> member "name" |> to_string = "timeout-without-policy")
         in
-        Alcotest.(check string) "pause kind" "operator_paused"
+        Alcotest.(check string) "pause kind" "auto_recoverable"
           (detail |> member "pause_kind" |> to_string);
-        Alcotest.(check (option (float 0.0001))) "effective auto resume"
-          None
-          (detail |> member "auto_resume_after_sec" |> to_float_option);
+        Alcotest.(check bool) "effective auto resume is present" true
+          (Option.is_some
+             (detail |> member "auto_resume_after_sec" |> to_float_option));
         Alcotest.(check (option (float 0.0001))) "persisted auto resume remains absent"
           None
           (detail |> member "persisted_auto_resume_after_sec" |> to_float_option);
-        Alcotest.(check bool) "auto resume source is absent" true
-          (Yojson.Safe.Util.member "auto_resume_source" detail = `Null);
+        Alcotest.(check string) "auto resume source" "implicit_turn_timeout"
+          (detail |> member "auto_resume_source" |> to_string);
         Alcotest.(check string) "last blocker class" "turn_timeout"
           (detail |> member "last_blocker" |> member "klass" |> to_string)))
 

--- a/test/test_supervisor_start_predicate.ml
+++ b/test/test_supervisor_start_predicate.ml
@@ -210,7 +210,7 @@ let test_operator_paused_only_does_not_start_sweep () =
     check bool "operator pause alone does not start sweep" false
       (KR.should_start_supervisor_sweep ~config ~stats))
 
-let test_turn_timeout_pause_without_explicit_policy_does_not_start_sweep () =
+let test_turn_timeout_pause_without_explicit_policy_starts_sweep () =
   with_temp_masc_dir ~keeper_names:[ "timeout-due" ] (fun config ->
     let now = Unix.time () in
     let timeout_blocker =
@@ -234,9 +234,10 @@ let test_turn_timeout_pause_without_explicit_policy_does_not_start_sweep () =
     in
     check bool "timeout-paused keeper is not bootable yet" false
       (List.mem "timeout-due" (KR.bootable_keeper_names config));
-    check (list string) "timeout pause is not auto-recoverable" []
+    check (list string) "legacy timeout pause is auto-recoverable"
+      [ "timeout-due" ]
       (KR.auto_recoverable_paused_keeper_names ~now config);
-    check bool "timeout pause alone does not start supervisor sweep" false
+    check bool "legacy timeout pause starts supervisor sweep" true
       (KR.should_start_supervisor_sweep ~config ~stats))
 
 let () =
@@ -252,7 +253,7 @@ let () =
         test_due_auto_recoverable_paused_keeper_starts_sweep;
       test_case "operator-paused keeper alone does not start sweep" `Quick
         test_operator_paused_only_does_not_start_sweep;
-      test_case "timeout pause without explicit policy does not start sweep" `Quick
-        test_turn_timeout_pause_without_explicit_policy_does_not_start_sweep;
+      test_case "timeout pause without explicit policy starts sweep" `Quick
+        test_turn_timeout_pause_without_explicit_policy_starts_sweep;
     ];
   ]


### PR DESCRIPTION
## Summary
- Treat legacy paused keeper meta with `last_blocker=turn_timeout` as auto-recoverable using the supervisor initial backoff, while preserving manual/operator pauses.
- Preserve TLS handshake failures wrapped as `internal_unhandled_exception` as transient runner errors so they enter retry/auto-recovery paths.
- Update dashboard paused-state copy to show timeout/TLS transient pauses as automatic retry wait instead of operator pause/offline.

## Verification
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-auto-recover-20260606 dune build --root . test/test_supervisor_start_predicate.exe test/test_oas_timeout_budget_strike.exe test/test_keeper_supervisor.exe test/test_server_runtime_bootstrap.exe`
- `./_build-codex-auto-recover-20260606/default/test/test_supervisor_start_predicate.exe`
- `./_build-codex-auto-recover-20260606/default/test/test_oas_timeout_budget_strike.exe`
- `./_build-codex-auto-recover-20260606/default/test/test_keeper_supervisor.exe`
- `./_build-codex-auto-recover-20260606/default/test/test_server_runtime_bootstrap.exe test bootstrap 22,23`
- `pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/mission-agent-cards.test.ts src/lib/keeper-operational-state.test.ts`
- `pnpm typecheck`