### PR TITLE
fix(ide): remove masc repo prioritization, add self-healing for unreachable repos

### DIFF
--- a/dashboard/src/components/ide/ide-data-workspace-store.test.ts
+++ b/dashboard/src/components/ide/ide-data-workspace-store.test.ts
@@ -22,58 +22,132 @@ function repo(
 }
 
 describe('selectPreferredIdeRepositoryId', () => {
+  // ── Current selection persistence ────────────────────────────
+
   it('keeps the current repository when it is still present', () => {
     const repositories = [
-      repo('masc', '/Users/dancer/me/workspace/yousleepwhen/masc'),
-      repo('oas', '.masc/repos/oas'),
+      repo('repo-a', '/Users/dancer/me/workspace/repo-a'),
+      repo('repo-b', '.masc/repos/repo-b'),
     ]
 
-    expect(selectPreferredIdeRepositoryId(repositories, 'oas')).toBe('oas')
+    expect(selectPreferredIdeRepositoryId(repositories, 'repo-b')).toBe('repo-b')
   })
 
-  it('prefers the actual masc workspace over managed mirrors', () => {
+  // ── Workspace repo priority (absolute paths, not mirrors) ───
+
+  it('prefers a workspace repo over managed mirrors', () => {
     const repositories = [
-      repo('masc', '.masc/repos/masc'),
-      repo('oas', '.masc/repos/oas'),
-      repo('masc', '/Users/dancer/me/workspace/yousleepwhen/masc'),
+      repo('managed-a', '.masc/repos/managed-a'),
+      repo('managed-b', '.masc/repos/managed-b'),
+      repo('workspace-a', '/Users/dancer/me/workspace/project-a'),
     ]
 
-    expect(selectPreferredIdeRepositoryId(repositories, null)).toBe('masc')
+    expect(selectPreferredIdeRepositoryId(repositories, null)).toBe('workspace-a')
   })
 
-  it('prefers a masc workspace when a same-name mirror appears first', () => {
+  it('selects the first workspace repo when multiple exist', () => {
     const repositories = [
-      repo('mirror-masc', '.masc/repos/mirror-masc', 'masc'),
-      repo('workspace-masc', '/Users/dancer/me/workspace/yousleepwhen/masc', 'masc'),
+      repo('managed-a', '.masc/repos/managed-a'),
+      repo('workspace-alpha', '/Users/dancer/me/workspace/alpha'),
+      repo('workspace-beta', '/Users/dancer/me/workspace/beta'),
     ]
 
-    expect(selectPreferredIdeRepositoryId(repositories, null)).toBe('workspace-masc')
+    expect(selectPreferredIdeRepositoryId(repositories, null)).toBe('workspace-alpha')
   })
 
   it('does not treat absolute .masc/repos mirrors as workspace checkouts', () => {
     const repositories = [
-      repo('mirror-masc', '/Users/dancer/me/.masc/repos/mirror-masc', 'masc'),
-      repo('workspace-oas', '/Users/dancer/me/workspace/yousleepwhen/oas', 'oas'),
+      repo('mirror-a', '/Users/dancer/me/.masc/repos/mirror-a'),
+      repo('workspace-b', '/Users/dancer/me/workspace/project-b'),
     ]
 
-    expect(selectPreferredIdeRepositoryId(repositories, null)).toBe('workspace-oas')
+    expect(selectPreferredIdeRepositoryId(repositories, null)).toBe('workspace-b')
   })
 
-  it('falls back to the first visible absolute workspace repository', () => {
+  // ── Mirror-only fallback ─────────────────────────────────────
+
+  it('falls back to the first non-mirror repository when only mirrors exist', () => {
     const repositories = [
-      repo('masc', '.masc/repos/masc'),
-      repo('kidsnote-shop', '/Users/dancer/me/workspace/kidsnote/kidsnote-shop'),
+      repo('managed-a', '.masc/repos/managed-a'),
+      repo('managed-b', '.masc/repos/managed-b'),
     ]
 
-    expect(selectPreferredIdeRepositoryId(repositories, null)).toBe('kidsnote-shop')
+    expect(selectPreferredIdeRepositoryId(repositories, null)).toBe('managed-a')
   })
 
-  it('falls back to the first repository when only mirrors exist', () => {
+  it('returns null for an empty repository list', () => {
+    expect(selectPreferredIdeRepositoryId([], null)).toBeNull()
+  })
+
+  // ── excludeIds: self-healing after unreachable repo ──────────
+
+  it('skips excluded repo IDs and selects the next workspace repo', () => {
     const repositories = [
-      repo('masc', '.masc/repos/masc'),
-      repo('oas', '.masc/repos/oas'),
+      repo('managed-a', '.masc/repos/managed-a'),
+      repo('broken-cache', '/Users/dancer/me/.cache/some-tool'),
+      repo('workspace-a', '/Users/dancer/me/workspace/project-a'),
     ]
 
-    expect(selectPreferredIdeRepositoryId(repositories, null)).toBe('masc')
+    const excluded = new Set(['broken-cache'])
+    expect(selectPreferredIdeRepositoryId(repositories, null, excluded)).toBe('workspace-a')
+  })
+
+  it('drops current if it is in the exclude set', () => {
+    const repositories = [
+      repo('managed-a', '.masc/repos/managed-a'),
+      repo('broken-cache', '/Users/dancer/me/.cache/some-tool'),
+      repo('workspace-a', '/Users/dancer/me/workspace/project-a'),
+    ]
+
+    const excluded = new Set(['broken-cache'])
+    expect(selectPreferredIdeRepositoryId(repositories, 'broken-cache', excluded)).toBe('workspace-a')
+  })
+
+  it('skips multiple excluded repos', () => {
+    const repositories = [
+      repo('broken-a', '/Users/dancer/me/.cache/a'),
+      repo('broken-b', '/Users/dancer/me/.cache/b'),
+      repo('workspace-c', '/Users/dancer/me/workspace/c'),
+    ]
+
+    const excluded = new Set(['broken-a', 'broken-b'])
+    expect(selectPreferredIdeRepositoryId(repositories, null, excluded)).toBe('workspace-c')
+  })
+
+  it('returns null when all repos are excluded', () => {
+    const repositories = [
+      repo('managed-a', '.masc/repos/managed-a'),
+      repo('managed-b', '.masc/repos/managed-b'),
+    ]
+
+    const excluded = new Set(['managed-a', 'managed-b'])
+    expect(selectPreferredIdeRepositoryId(repositories, null, excluded)).toBeNull()
+  })
+
+  // ── Reported bug: cache dir picked as first workspace repo ──
+
+  it('selects first workspace repo initially, even if it is a cache dir', () => {
+    const repositories = [
+      repo('managed-a', '.masc/repos/managed-a'),
+      repo('llama-cpp', '/Users/dancer/me/.cache/llama.cpp'),
+      repo('workspace-a', '/Users/dancer/me/workspace/project-a'),
+    ]
+
+    // Initial selection: llama-cpp is the first workspace repo.
+    // The self-healing in createIdeDataWorkspaceStore handles the
+    // auto-switch when workspace tree returns repository_missing.
+    expect(selectPreferredIdeRepositoryId(repositories, null)).toBe('llama-cpp')
+  })
+
+  it('self-heals by excluding broken cache and selecting next workspace repo', () => {
+    const repositories = [
+      repo('managed-a', '.masc/repos/managed-a'),
+      repo('llama-cpp', '/Users/dancer/me/.cache/llama.cpp'),
+      repo('workspace-a', '/Users/dancer/me/workspace/project-a'),
+    ]
+
+    // After self-healing excludes llama-cpp:
+    const excluded = new Set(['llama-cpp'])
+    expect(selectPreferredIdeRepositoryId(repositories, null, excluded)).toBe('workspace-a')
   })
 })

--- a/dashboard/src/components/ide/ide-data-workspace-store.ts
+++ b/dashboard/src/components/ide/ide-data-workspace-store.ts
@@ -80,23 +80,28 @@ function isWorkspaceRepository(repository: Repository): boolean {
   return isAbsolute && !localPath.includes('/.masc/')
 }
 
-function isMascMcpRepository(repository: Repository): boolean {
-  return repository.id === 'masc' || repository.name === 'masc'
-}
+/** Repo is not reachable — server reported it as missing or unknown. */
+const UNREACHABLE_WORKSPACE_SOURCES: ReadonlySet<string> = new Set([
+  'repository_missing',
+  'repository_unknown',
+])
 
 export function selectPreferredIdeRepositoryId(
   repositories: ReadonlyArray<Repository>,
   current: string | null,
+  excludeIds?: ReadonlySet<string>,
 ): string | null {
-  if (current && repositories.some(repository => repository.id === current)) {
+  if (current && !excludeIds?.has(current) && repositories.some(repository => repository.id === current)) {
     return current
   }
 
-  return repositories.find(repository => isMascMcpRepository(repository) && isWorkspaceRepository(repository))?.id
-    ?? repositories.find(isWorkspaceRepository)?.id
-    ?? repositories.find(isMascMcpRepository)?.id
-    ?? repositories.find(repository => !isManagedMirrorRepository(repository))?.id
-    ?? repositories[0]?.id
+  const candidates = excludeIds && excludeIds.size > 0
+    ? repositories.filter(r => !excludeIds.has(r.id))
+    : repositories
+
+  return candidates.find(isWorkspaceRepository)?.id
+    ?? candidates.find(repository => !isManagedMirrorRepository(repository))?.id
+    ?? candidates[0]?.id
     ?? null
 }
 
@@ -115,11 +120,14 @@ export function createIdeDataWorkspaceStore(): IdeDataWorkspaceStore {
   const activeRepositoryIdSignal = signal<string | null>(null)
   const annotationsSignal = signal<ReadonlyArray<IdeAnnotation>>([])
 
+  /** Track repo IDs that returned unreachable workspace sources, to avoid re-selecting them. */
+  const unreachableRepoIds = new Set<string>()
+
   let abortController = new AbortController()
 
   const applyRepositories = (repositories: ReadonlyArray<Repository>): void => {
     const current = activeRepositoryIdSignal.value
-    activeRepositoryIdSignal.value = selectPreferredIdeRepositoryId(repositories, current)
+    activeRepositoryIdSignal.value = selectPreferredIdeRepositoryId(repositories, current, unreachableRepoIds)
     repositoriesSignal.value = repositories
   }
 
@@ -162,6 +170,20 @@ export function createIdeDataWorkspaceStore(): IdeDataWorkspaceStore {
       if (signal.aborted) return
       fileTreeStore.seed(nodes)
       workspaceSourceSignal.value = source
+
+      // Self-healing: if the selected repo is unreachable (missing .git,
+      // path does not exist, etc.), exclude it and auto-switch to the next
+      // preferred repo so the IDE does not land on a blank screen.
+      if (repoId && UNREACHABLE_WORKSPACE_SOURCES.has(source.kind)) {
+        unreachableRepoIds.add(repoId)
+        const repos = repositoriesSignal.value
+        const nextId = selectPreferredIdeRepositoryId(repos, null, unreachableRepoIds)
+        if (nextId && nextId !== repoId) {
+          activeRepositoryIdSignal.value = nextId
+          return  // effect will re-fire with the new repoId
+        }
+      }
+
       const hasCurrentFile =
         filePath !== null && nodes.some(node => node.path === filePath && !node.hasChildren)
       const nextFile = hasCurrentFile ? null : firstFilePath(nodes)


### PR DESCRIPTION
## 문제

IDE 대시보드를 열면 `llama-cpp` (캐시 디렉토리, `.git` 없음)가 기본 repo로 선택되어 빈 화면이 렌더링됨.

### 원인

1. `isMascMcpRepository`가 `id === 'masc'`만 매칭 → 실제 repo id `masc-mcp`는 매칭 실패
2. `llama-cpp`가 절대경로 + mirror 아닌 첫 번째 repo로 선택됨
3. 선택 로직에 repo 유효성 검증 없음

### 근본 문제

`isMascMcpRepository` 자체가 설계 결함. **masc는 멀티 에이전트 도구이고 IDE는 그 기능 중 하나**. 특정 프로젝트 repo를 하드코딩으로 우대하는 건 범용 도구에 어울리지 않음.

## 변경

| 항목 | 내용 |
|------|------|
| `isMascMcpRepository` 삭제 | 프로젝트 특화 하드코딩 제거 |
| 선택 우선순위 단순화 | workspace repo → non-mirror → `[0]` → `null` |
| `excludeIds` 파라미터 | self-healing용 unreachable repo 추적 |
| workspace tree 콜백에 자가 복구 | `repository_missing`/`repository_unknown` 시 다음 repo로 자동 전환 |
| 테스트 재작성 | 범용 repo명, self-healing 시나리오 5개 추가 |

## 동작 흐름

```
IDE 열림 → 첫 workspace repo = llama-cpp 선택 (cache dir)
  → workspace tree fetch → source.kind = "repository_missing"
  → unreachableRepoIds = {"llama-cpp"}
  → 다음 workspace repo = kidsnote-shop 선택
  → workspace tree fetch → source.kind = "repository" ✅
  → 정상 동작
```

## 테스트

```
 ✓ 12 passed (12)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
