### PR TITLE
[codex] Make keeper detail chat first

### DIFF
--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -101,6 +101,22 @@ describe('ChatTranscript', () => {
     expect(latestBody).toBe('')
   })
 
+  it('uses a viewport-bounded transcript height in primary mode', () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[entry({ id: 'u1', text: 'ping' })]}
+        emptyText="empty"
+        variant="messenger"
+        size="primary"
+      />`,
+      container,
+    )
+
+    const transcript = container.querySelector('[data-chat-variant="messenger"]')
+    expect(transcript?.classList.contains('min-h-[18rem]')).toBe(true)
+    expect(transcript?.classList.contains('max-h-[42vh]')).toBe(true)
+  })
+
   it('renders attachments even when metadata is hidden', () => {
     render(
       html`<${ChatTranscript}

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -9,6 +9,7 @@ import { formatCost } from '../../lib/format-number'
 import type { KeeperConversationAttachment, KeeperConversationDetails, KeeperConversationEntry } from '../../types'
 
 type ChatTranscriptVariant = 'default' | 'messenger'
+type ChatTranscriptSize = 'default' | 'primary'
 
 function timeLabel(timestamp?: string | null): string | null {
   if (!timestamp) return null
@@ -408,11 +409,13 @@ export function ChatTranscript({
   emptyText,
   showMetadata,
   variant = 'default',
+  size = 'default',
 }: {
   entries: KeeperConversationEntry[]
   emptyText: string
   showMetadata?: boolean
   variant?: ChatTranscriptVariant
+  size?: ChatTranscriptSize
 }) {
   const scrollerRef = useRef<HTMLDivElement | null>(null)
   const lastSignature = useMemo(
@@ -426,9 +429,13 @@ export function ChatTranscript({
     el.scrollTop = el.scrollHeight
   }, [lastSignature])
 
+  const heightClass = size === 'primary'
+    ? 'min-h-[18rem] max-h-[42vh] xl:max-h-[46vh]'
+    : 'min-h-75 max-h-130'
+
   return html`
     <div
-      class=${`chat-transcript flex min-h-75 max-h-130 flex-col overflow-y-auto border border-[var(--color-border-default)] shadow-[inset_0_1px_0_var(--color-border-default)] ${
+      class=${`chat-transcript flex ${heightClass} flex-col overflow-y-auto border border-[var(--color-border-default)] shadow-[inset_0_1px_0_var(--color-border-default)] ${
         variant === 'messenger'
           ? 'gap-4 rounded-[var(--radius-xl)] px-4 py-5 sm:px-5'
           : 'gap-3 rounded-[var(--radius-xl)] px-3 py-4'

--- a/dashboard/src/components/keeper-detail-body.ts
+++ b/dashboard/src/components/keeper-detail-body.ts
@@ -28,7 +28,7 @@ import {
   KeeperNeighborhood,
 } from './keeper-detail-runtime'
 import {
-  KeeperDetailOverviewSidebar,
+  KeeperDetailSectionRail,
   KeeperDetailSection,
 } from './keeper-detail-shell'
 import {
@@ -101,16 +101,28 @@ export function KeeperDetailBody({
   onSocialSweep,
 }: KeeperDetailBodyProps) {
   return html`
-    <div class="grid gap-5 xl:grid-cols-[280px_minmax(0,1fr)]">
-      <${KeeperDetailOverviewSidebar} />
-
-      <div class="order-1 xl:order-2 flex flex-col gap-5">
+    <div class="flex flex-col gap-4">
         <${KeeperRuntimeAlertStrip} keeper=${keeper} />
+        <${KeeperDetailSectionRail} />
+
+        <${KeeperDetailSection}
+          id="keeper-comms"
+          eyebrow="대화 & 세션"
+          title="대화 / 세션"
+          lockedOpen=${true}
+          variant="primary"
+        >
+          <${KeeperCommsPanel} keeper=${keeper} />
+          <${CollapsibleSection} title="세션 활동 로그" open=${false} mountWhenOpen=${true}>
+            <${SessionTraceView} agentName=${keeper.name} isKeeper=${true} keeperStatus=${keeper.status} keeperGeneration=${keeper.generation} />
+          <//>
+        <//>
 
         <${KeeperDetailSection}
           id="keeper-summary"
           eyebrow="상태 개요"
           title="운영 상태 개요"
+          defaultCollapsed=${true}
         >
       ${'' /* KeeperLiveTruthPanel (derived "Live truth / 런타임 / 현재 턴 / 최신 증거 / 차단" composite) moved to the 진단 / 운영 section as a default-closed CollapsibleSection. It is a derived synthesis on top of composite + keeper + runtime_trace + linked_state and lives below the raw-state alert-strip in information hierarchy. */}
       ${'' /* RFC-0046: 6-axis composite snapshot (KSM/KTC/KDP/KCL/KMC/breaker) — SSOT for keeper FSM state */}
@@ -157,18 +169,6 @@ export function KeeperDetailBody({
 
       ${'' /* ── Inference Telemetry (tok/s, cache, reasoning) ── */}
       <${InferenceTelemetryPanel} keeper=${keeper} />
-        <//>
-
-        <${KeeperDetailSection}
-          id="keeper-comms"
-          eyebrow="대화 & 세션"
-          title="대화 / 활동 흐름"
-          defaultCollapsed=${true}
-        >
-          <${KeeperCommsPanel} keeper=${keeper} />
-          <${PanelCard} title="세션 활동 로그">
-            <${SessionTraceView} agentName=${keeper.name} isKeeper=${true} keeperStatus=${keeper.status} keeperGeneration=${keeper.generation} />
-          <//>
         <//>
 
         <${KeeperDetailSection}
@@ -338,7 +338,6 @@ export function KeeperDetailBody({
         onPreserveToggle=${onPreserveToggle}
         onSubmit=${onClearSubmit}
       />
-      </div>
     </div>
   `
 }

--- a/dashboard/src/components/keeper-detail-comms.ts
+++ b/dashboard/src/components/keeper-detail-comms.ts
@@ -14,11 +14,9 @@ export function KeeperCommsPanel({ keeper }: { keeper: Keeper }) {
   const isOffline = isKeeperOffline(keeper)
 
   return html`
-    <div class="border-t border-[var(--color-border-divider)] pt-5">
-      <h3 class="m-0 mb-3 text-sm font-semibold text-[var(--color-fg-secondary)] uppercase tracking-[var(--track-sub)]">직접 통신</h3>
-
+    <div class="flex flex-col gap-3">
       ${isOffline ? html`
-        <div class="px-4 py-3 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] text-sm text-[var(--color-fg-muted)]">
+        <div class="px-4 py-3 rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] text-sm text-[var(--color-fg-muted)]">
           이 키퍼는 현재 비활동 상태입니다. 기동 후 메시지를 볼 수 있습니다.
         </div>
       ` : html`
@@ -26,6 +24,7 @@ export function KeeperCommsPanel({ keeper }: { keeper: Keeper }) {
           <${KeeperConversationPanel}
             keeperName=${keeper.name}
             placeholder=${'이 키퍼에게 직접 프롬프트 전송'}
+            layout="primary"
           />
         </div>
       `}

--- a/dashboard/src/components/keeper-detail-page.ts
+++ b/dashboard/src/components/keeper-detail-page.ts
@@ -192,9 +192,9 @@ export function KeeperDetailPage() {
   }
 
   return html`
-    <div class="mx-auto flex w-full max-w-[1600px] flex-col gap-5 pb-8" data-route-focused-keeper=${keeper.name}>
-      <div class="sticky top-0 z-20 overflow-hidden rounded-[var(--r-6)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] shadow-[var(--shadow-raised)] backdrop-blur-xl">
-        <div class="flex flex-col items-stretch justify-between gap-4 border-b border-[var(--color-border-default)] px-5 py-4 sm:flex-row sm:items-center sm:px-6">
+    <div class="mx-auto flex w-full max-w-[1720px] flex-col gap-4 pb-6" data-route-focused-keeper=${keeper.name}>
+      <div class="sticky top-0 z-20 overflow-hidden rounded-[var(--r-3)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] shadow-[var(--shadow-raised)] backdrop-blur-xl">
+        <div class="flex flex-col items-stretch justify-between gap-3 px-4 py-3 sm:flex-row sm:items-center sm:px-5">
           <${KeeperDetailHeaderInfo}
             keeper=${keeper}
             titleId=${titleId}

--- a/dashboard/src/components/keeper-detail-shell.test.ts
+++ b/dashboard/src/components/keeper-detail-shell.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { html } from 'htm/preact'
 import { render } from 'preact'
-import { KeeperDetailSection } from './keeper-detail-shell'
+import { KeeperDetailSection, KeeperDetailSectionRail } from './keeper-detail-shell'
 
 describe('KeeperDetailSection', () => {
   let container: HTMLDivElement
@@ -50,7 +50,7 @@ describe('KeeperDetailSection', () => {
     expect(section?.getAttribute('aria-label')).toBe('Debug')
   })
 
-  it('applies scroll margin and rounded-[var(--r-1)] styling', () => {
+  it('applies scroll margin and compact section styling', () => {
     render(
       html`<${KeeperDetailSection}
         id="keeper-config"
@@ -64,6 +64,55 @@ describe('KeeperDetailSection', () => {
 
     const section = container.querySelector('section')
     expect(section?.classList.contains('scroll-mt-24')).toBe(true)
-    expect(section?.classList.contains('rounded-[var(--r-6)]')).toBe(true)
+    expect(section?.classList.contains('rounded-[var(--r-3)]')).toBe(true)
+  })
+
+  it('keeps locked-open primary sections visible without a collapse button', () => {
+    render(
+      html`<${KeeperDetailSection}
+        id="keeper-comms"
+        eyebrow="CHAT"
+        title="Conversation"
+        defaultCollapsed=${true}
+        lockedOpen=${true}
+        variant="primary"
+      >
+        <div data-testid="chat-child">Chat child</div>
+      <//>`,
+      container,
+    )
+
+    expect(container.querySelector('[data-testid="chat-child"]')).not.toBeNull()
+    expect(container.querySelector('button[aria-expanded]')).toBeNull()
+    expect(container.textContent).toContain('기본')
+  })
+})
+
+describe('KeeperDetailSectionRail', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+  })
+
+  it('renders compact section navigation without long summary copy', () => {
+    render(html`<${KeeperDetailSectionRail} />`, container)
+
+    const nav = container.querySelector('nav[aria-label="키퍼 상세 섹션"]')
+    expect(nav).not.toBeNull()
+    expect(container.textContent).toContain('대화')
+    expect(container.textContent).toContain('상태')
+    expect(container.textContent).toContain('진단')
+    expect(container.textContent).toContain('정체성')
+    expect(container.textContent).toContain('설정')
+    expect(container.textContent).toContain('디버그')
+    expect(container.textContent).not.toContain('상태 기계, KPI')
+    expect(container.textContent).not.toContain('실시간 대화와 세션 이벤트')
   })
 })

--- a/dashboard/src/components/keeper-detail-shell.ts
+++ b/dashboard/src/components/keeper-detail-shell.ts
@@ -78,12 +78,12 @@ export function KeeperDetailHeaderInfo({
       <button
         type="button"
         onClick=${onClose}
-        class="inline-flex shrink-0 items-center gap-2 rounded-full border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-3.5 py-2 text-sm font-medium text-[var(--color-fg-primary)] transition-colors hover:bg-[var(--color-bg-hover)]"
+        class="inline-flex shrink-0 items-center gap-2 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-3 py-1.5 text-xs font-semibold text-[var(--color-fg-primary)] transition-colors hover:bg-[var(--color-bg-hover)]"
       >
         <span aria-hidden="true">←</span>
         목록
       </button>
-      <div class="size-12 shrink-0 rounded-[var(--r-1)] bg-[var(--color-bg-elevated)] border border-[var(--color-border-default)] flex items-center justify-center text-2xl">${keeper.emoji}</div>
+      <div class="size-10 shrink-0 rounded-[var(--r-1)] bg-[var(--color-bg-elevated)] border border-[var(--color-border-default)] flex items-center justify-center text-xl">${keeper.emoji}</div>
       <div class="flex min-w-[12rem] flex-1 flex-col gap-0.5">
         <${SectionLabel}>모니터링 / 에이전트 / 키퍼 상세</${SectionLabel}>
         <div class="mt-1 flex flex-wrap items-center gap-2.5">
@@ -119,37 +119,30 @@ type KeeperDetailSectionId =
 const KEEPER_DETAIL_SECTIONS: Array<{
   id: KeeperDetailSectionId
   label: string
-  summary: string
 }> = [
   {
-    id: 'keeper-summary',
-    label: '상태 개요',
-    summary: '상태 기계, KPI, 메모리/추론 지표를 먼저 봅니다.',
+    id: 'keeper-comms',
+    label: '대화',
   },
   {
-    id: 'keeper-comms',
-    label: '대화 / 세션',
-    summary: '실시간 대화와 세션 이벤트를 함께 봅니다.',
+    id: 'keeper-summary',
+    label: '상태',
   },
   {
     id: 'keeper-runtime',
-    label: '진단 / 운영',
-    summary: 'runtime action, eval, supervisor, 품질 시그널을 모았습니다.',
+    label: '진단',
   },
   {
     id: 'keeper-identity',
-    label: '정체성 / 세대',
-    summary: '프로필, 관계, generation lineage, checkpoint를 함께 봅니다.',
+    label: '정체성',
   },
   {
     id: 'keeper-config',
-    label: '설정 / 작업 방식',
-    summary: '허용 도구, repos, config를 한 곳에서 조정합니다.',
+    label: '설정',
   },
   {
     id: 'keeper-debug',
     label: '디버그',
-    summary: '저널과 원시 데이터를 마지막에 몰아 둡니다.',
   },
 ]
 
@@ -157,33 +150,25 @@ function scrollToKeeperDetailSection(sectionId: KeeperDetailSectionId): void {
   document.getElementById(sectionId)?.scrollIntoView({ behavior: 'smooth', block: 'start' })
 }
 
-// `KeeperDetailOverviewSidebar` previously rendered a 4-cell QuickFact
-// grid (상태 / 컨텍스트 / 런타임 / 최근 활동) above the navigation. Each
-// cell duplicated information shown elsewhere on the page (page header
-// status chip, KpiGrid context ratio, hardcoded placeholder
-// '런타임 runtime', page header activity subtitle). The grid was removed
-// 2026-05-19 as part of the SSOT reconciliation plan (Phase 5). What
-// remains is the sticky scroll navigation — the only piece that was
-// providing unique value.
-export function KeeperDetailOverviewSidebar() {
+export function KeeperDetailSectionRail() {
   return html`
-    <aside class="order-2 xl:order-1 xl:sticky xl:top-[104px] xl:self-start" aria-label="키퍼 프로필 요약">
-      <div class="rounded-[var(--r-5)] border border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] p-3.5 shadow-[var(--shadow-panel)]">
-        <${SectionLabel}>빠른 이동</${SectionLabel}>
-        <div class="mt-3 flex flex-col gap-2">
-          ${KEEPER_DETAIL_SECTIONS.map((section) => html`
-            <button
-              type="button"
-              class="rounded-[var(--r-5)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2 text-left transition-colors hover:bg-[var(--color-bg-hover)]"
-              onClick=${() => scrollToKeeperDetailSection(section.id)}
-            >
-              <div class="text-sm font-medium text-[var(--color-fg-primary)]">${section.label}</div>
-              <div class="mt-1 text-2xs leading-relaxed text-[var(--color-fg-muted)]">${section.summary}</div>
-            </button>
-          `)}
-        </div>
+    <nav
+      class="sticky top-[76px] z-10 overflow-x-auto rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] p-1 shadow-[var(--shadow-panel)]"
+      aria-label="키퍼 상세 섹션"
+    >
+      <div class="flex min-w-max items-center gap-1">
+        <span class="shrink-0 px-2 text-3xs font-semibold uppercase tracking-[var(--track-label)] text-[var(--color-fg-disabled)]">섹션</span>
+        ${KEEPER_DETAIL_SECTIONS.map((section) => html`
+          <button
+            type="button"
+            class="h-8 shrink-0 rounded-[var(--r-1)] border border-transparent px-3 text-2xs font-semibold text-[var(--color-fg-muted)] transition-colors hover:border-[var(--color-border-default)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-primary)]"
+            onClick=${() => scrollToKeeperDetailSection(section.id)}
+          >
+            ${section.label}
+          </button>
+        `)}
       </div>
-    </aside>
+    </nav>
   `
 }
 
@@ -192,6 +177,8 @@ export function KeeperDetailSection({
   eyebrow,
   title,
   defaultCollapsed = false,
+  lockedOpen = false,
+  variant = 'default',
   children,
 }: {
   id: KeeperDetailSectionId
@@ -203,33 +190,55 @@ export function KeeperDetailSection({
    *  that do not opt in. Quick-jump links via [scrollToKeeperDetailSection]
    *  still resolve to the header anchor regardless of the body state. */
   defaultCollapsed?: boolean
+  /** Primary sections, such as the chat lane, stay open and do not expose
+   *  collapse controls. */
+  lockedOpen?: boolean
+  variant?: 'default' | 'primary'
   children: ComponentChildren
 }) {
-  const [collapsed, setCollapsed] = useState(defaultCollapsed)
+  const [collapsed, setCollapsed] = useState(lockedOpen ? false : defaultCollapsed)
+  const isCollapsed = lockedOpen ? false : collapsed
   const bodyId = `${id}-body`
+  const sectionClass = variant === 'primary'
+    ? 'scroll-mt-24 rounded-[var(--r-3)] border border-[var(--accent-20)] bg-[var(--color-bg-surface)] shadow-[var(--shadow-raised)]'
+    : 'scroll-mt-24 rounded-[var(--r-3)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] shadow-[var(--shadow-raised)]'
+  const headerClass = variant === 'primary'
+    ? 'flex w-full items-center justify-between gap-3 border-b border-[var(--accent-20)] px-5 py-4 text-left sm:px-6'
+    : 'flex w-full items-center justify-between gap-3 border-b border-[var(--color-border-default)] px-5 py-4 text-left transition-colors hover:bg-[var(--color-bg-hover)] sm:px-6'
+  const headerContent = html`
+    <div class="min-w-0">
+      <div class="text-3xs font-semibold uppercase tracking-[var(--track-brand)] text-[var(--color-fg-muted)]">${eyebrow}</div>
+      <h3 class="m-0 mt-1 text-lg font-semibold text-[var(--color-fg-primary)]">${title}</h3>
+    </div>
+    ${lockedOpen
+      ? html`<span class="shrink-0 rounded-[var(--r-0)] border border-[var(--accent-20)] bg-[var(--accent-10)] px-2 py-1 text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-accent-fg)]">기본</span>`
+      : html`
+        <span
+          aria-hidden="true"
+          class=${`shrink-0 text-[var(--color-fg-muted)] transition-transform duration-[var(--t-med)] ${isCollapsed ? '' : 'rotate-180'}`}
+        >▾</span>
+      `}
+  `
   return html`
     <section
       id=${id}
-      class="scroll-mt-24 rounded-[var(--r-6)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] shadow-[var(--shadow-raised)]"
+      class=${sectionClass}
       aria-label=${title}
     >
-      <button
-        type="button"
-        class="flex w-full items-center justify-between gap-3 border-b border-[var(--color-border-default)] px-5 py-4 text-left transition-colors hover:bg-[var(--color-bg-hover)] sm:px-6"
-        aria-expanded=${!collapsed}
-        aria-controls=${bodyId}
-        onClick=${() => setCollapsed((c: boolean) => !c)}
-      >
-        <div class="min-w-0">
-          <div class="text-3xs font-semibold uppercase tracking-[var(--track-brand)] text-[var(--color-fg-muted)]">${eyebrow}</div>
-          <h3 class="m-0 mt-1 text-lg font-semibold text-[var(--color-fg-primary)]">${title}</h3>
-        </div>
-        <span
-          aria-hidden="true"
-          class=${`shrink-0 text-[var(--color-fg-muted)] transition-transform duration-[var(--t-med)] ${collapsed ? '' : 'rotate-180'}`}
-        >▾</span>
-      </button>
-      ${collapsed ? null : html`
+      ${lockedOpen
+        ? html`<div class=${headerClass}>${headerContent}</div>`
+        : html`
+          <button
+            type="button"
+            class=${headerClass}
+            aria-expanded=${!isCollapsed}
+            aria-controls=${bodyId}
+            onClick=${() => setCollapsed((c: boolean) => !c)}
+          >
+            ${headerContent}
+          </button>
+        `}
+      ${isCollapsed ? null : html`
         <div id=${bodyId} class="flex flex-col gap-4 px-5 py-5 sm:px-6">
           ${children}
         </div>

--- a/dashboard/src/components/keeper-detail.test.ts
+++ b/dashboard/src/components/keeper-detail.test.ts
@@ -117,7 +117,7 @@ vi.mock('./agent-detail-journal', () => ({
 }))
 
 vi.mock('./keeper-shared', () => ({
-  KeeperConversationPanel: () => null,
+  KeeperConversationPanel: ({ keeperName }: { keeperName: string }) => `direct chat ${keeperName}`,
   KeeperDiagnosticSummary: () => null,
   KeeperRuntimeActions: () => null,
 }))
@@ -327,8 +327,13 @@ describe('KeeperDetailPage', () => {
     } as unknown as Keeper
     keepers.value = [analyst]
 
-    render(html`<${KeeperDetailPage} />`)
+    const { container } = render(html`<${KeeperDetailPage} />`)
     expect(screen.getByText('analyst')).toBeTruthy()
+    expect(screen.getByText('direct chat analyst')).toBeTruthy()
+    expect(screen.queryByText('FSM Hub (6축 상태 머신)')).toBeNull()
+    const pageText = container.textContent ?? ''
+    expect(pageText.indexOf('대화 / 세션')).toBeGreaterThanOrEqual(0)
+    expect(pageText.indexOf('운영 상태 개요')).toBeGreaterThan(pageText.indexOf('대화 / 세션'))
     expect(mocks.selectKeeper).toHaveBeenCalledWith('analyst')
   })
 

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -259,9 +259,11 @@ export function KeeperDiagnosticSummary({
 export function KeeperConversationPanel({
   keeperName,
   placeholder,
+  layout = 'default',
 }: {
   keeperName: string
   placeholder: string
+  layout?: 'default' | 'primary'
 }) {
   const [draft, setDraft] = useState('')
   const [showMetadata, setShowMetadata] = useState(readKeeperChatMetadataVisible())
@@ -365,6 +367,7 @@ export function KeeperConversationPanel({
             emptyText="아직 표시할 대화가 없습니다. 내부 메시지와 도구 호출은 토글로 전환할 수 있습니다."
             showMetadata=${showMetadata}
             variant="messenger"
+            size=${layout === 'primary' ? 'primary' : 'default'}
           />
         </div>
 


### PR DESCRIPTION
## Summary

- Make the keeper detail route open into the conversation/session lane by default.
- Replace the wide quick-navigation sidebar with a compact sticky section rail.
- Collapse the status overview by default so FSM/KPI/telemetry panels are available but no longer dominate the first viewport.
- Add a primary transcript size mode for the chat lane so the composer remains reachable in the detail layout.

## Why

The previous quick navigation consumed too much horizontal space and pushed the detail body into a cramped layout. Operators selecting a keeper primarily need the conversation surface first; status, diagnostics, identity, config, and debug are secondary drill-down sections.

## Validation

- `pnpm -C dashboard typecheck`
- `pnpm -C dashboard exec vitest run --config vitest.config.ts src/components/keeper-detail-shell.test.ts src/components/chat/primitives.test.ts src/components/keeper-detail.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm -C dashboard exec eslint src/components/keeper-detail-shell.ts src/components/keeper-detail-body.ts src/components/keeper-detail-comms.ts src/components/keeper-detail-page.ts src/components/keeper-shared.ts src/components/chat/primitives.ts`
- `git diff --check`
- Playwright rendered smoke at `http://127.0.0.1:5175/dashboard/#monitoring?section=agents&keeper=sangsu`: chat-first ordering true, old quick summary absent, status body initially collapsed, console errors empty.
