### PR TITLE
fix(dashboard): improve runtime.toml editor UX

### DIFF
--- a/dashboard/src/components/runtime-toml-editor.test.ts
+++ b/dashboard/src/components/runtime-toml-editor.test.ts
@@ -25,6 +25,24 @@ const baseConfig = {
 
 describe('RuntimeTomlEditor', () => {
   let container: HTMLDivElement
+  const realClipboard = typeof navigator !== 'undefined' ? navigator.clipboard : undefined
+  const realConfirm = window.confirm
+
+  function setClipboard(value: { writeText: (t: string) => Promise<void> } | undefined): void {
+    Object.defineProperty(navigator, 'clipboard', {
+      value,
+      configurable: true,
+      writable: true,
+    })
+  }
+
+  function setConfirm(value: ((message?: string) => boolean) | undefined): void {
+    Object.defineProperty(window, 'confirm', {
+      value,
+      configurable: true,
+      writable: true,
+    })
+  }
 
   beforeEach(() => {
     container = document.createElement('div')
@@ -42,6 +60,9 @@ describe('RuntimeTomlEditor', () => {
   afterEach(() => {
     render(null, container)
     container.remove()
+    setClipboard(realClipboard as unknown as { writeText: (t: string) => Promise<void> } | undefined)
+    setConfirm(realConfirm)
+    vi.restoreAllMocks()
   })
 
   it('loads and displays the full runtime.toml source', async () => {
@@ -58,6 +79,8 @@ describe('RuntimeTomlEditor', () => {
     expect(textarea.value).toBe(baseConfig.source_text)
     expect(saveButton.disabled).toBe(true)
     expect(container.querySelector('[data-testid="runtime-toml-status"]')?.textContent).toContain('saved')
+    expect(container.querySelector('[data-testid="runtime-toml-line-numbers"]')?.textContent).toBe('1\n2\n3')
+    expect(container.querySelector('[data-testid="runtime-toml-stats"]')?.textContent).toContain('3 lines')
   })
 
   it('saves the edited TOML source and clears the dirty state', async () => {
@@ -86,6 +109,135 @@ describe('RuntimeTomlEditor', () => {
     })
     expect(saveButton.disabled).toBe(true)
     expect((container.querySelector('textarea') as HTMLTextAreaElement).value).toBe(nextSource)
+  })
+
+  it('saves from the editor keyboard shortcut', async () => {
+    render(html`<${RuntimeTomlEditor} />`, container)
+
+    await waitFor(() => {
+      expect((container.querySelector('textarea') as HTMLTextAreaElement | null)?.value).toBe(baseConfig.source_text)
+    })
+
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement
+    const nextSource = `${baseConfig.source_text}# keyboard\n`
+    fireEvent.input(textarea, { target: { value: nextSource } })
+    fireEvent.keyDown(textarea, { key: 's', metaKey: true })
+
+    await waitFor(() => {
+      expect(apiMocks.saveRuntimeTomlConfig).toHaveBeenCalledWith(nextSource)
+    })
+  })
+
+  it('inserts two spaces for tab indentation without leaving the editor', async () => {
+    render(html`<${RuntimeTomlEditor} />`, container)
+
+    await waitFor(() => {
+      expect((container.querySelector('textarea') as HTMLTextAreaElement | null)?.value).toBe(baseConfig.source_text)
+    })
+
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement
+    textarea.setSelectionRange('[runtime]\n'.length, '[runtime]\n'.length)
+    fireEvent.keyDown(textarea, { key: 'Tab' })
+
+    await waitFor(() => {
+      expect((container.querySelector('textarea') as HTMLTextAreaElement).value).toBe(
+        '[runtime]\n  default = "runpod_mtp.qwen"\n',
+      )
+    })
+    expect(container.querySelector('[data-testid="runtime-toml-status"]')?.textContent).toContain('modified')
+  })
+
+  it('guards refresh when the draft has unsaved changes', async () => {
+    const confirmSpy = vi.fn(() => false)
+    setConfirm(confirmSpy)
+    render(html`<${RuntimeTomlEditor} />`, container)
+
+    await waitFor(() => {
+      expect((container.querySelector('textarea') as HTMLTextAreaElement | null)?.value).toBe(baseConfig.source_text)
+    })
+
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement
+    fireEvent.input(textarea, { target: { value: `${baseConfig.source_text}# unsaved\n` } })
+    fireEvent.click(container.querySelector('[data-testid="runtime-toml-refresh"]') as HTMLButtonElement)
+
+    expect(confirmSpy).toHaveBeenCalledTimes(1)
+    expect(apiMocks.fetchRuntimeTomlConfig).toHaveBeenCalledTimes(1)
+    expect((container.querySelector('textarea') as HTMLTextAreaElement).value).toBe(`${baseConfig.source_text}# unsaved\n`)
+  })
+
+  it('refreshes a clean draft without prompting for discard confirmation', async () => {
+    const confirmSpy = vi.fn(() => false)
+    setConfirm(confirmSpy)
+    render(html`<${RuntimeTomlEditor} />`, container)
+
+    await waitFor(() => {
+      expect((container.querySelector('textarea') as HTMLTextAreaElement | null)?.value).toBe(baseConfig.source_text)
+    })
+
+    fireEvent.click(container.querySelector('[data-testid="runtime-toml-refresh"]') as HTMLButtonElement)
+
+    await waitFor(() => {
+      expect(apiMocks.fetchRuntimeTomlConfig).toHaveBeenCalledTimes(2)
+    })
+    expect(confirmSpy).not.toHaveBeenCalled()
+  })
+
+  it('resets the draft to the last loaded source without calling save', async () => {
+    render(html`<${RuntimeTomlEditor} />`, container)
+
+    await waitFor(() => {
+      expect((container.querySelector('textarea') as HTMLTextAreaElement | null)?.value).toBe(baseConfig.source_text)
+    })
+
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement
+    fireEvent.input(textarea, { target: { value: `${baseConfig.source_text}# local\n` } })
+    fireEvent.click(container.querySelector('[data-testid="runtime-toml-reset"]') as HTMLButtonElement)
+
+    await waitFor(() => {
+      expect((container.querySelector('textarea') as HTMLTextAreaElement).value).toBe(baseConfig.source_text)
+      expect(container.querySelector('[data-testid="runtime-toml-status"]')?.textContent).toContain('saved')
+    })
+    expect(apiMocks.saveRuntimeTomlConfig).not.toHaveBeenCalled()
+  })
+
+  it('copies the resolved runtime.toml path', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    setClipboard({ writeText })
+    render(html`<${RuntimeTomlEditor} />`, container)
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('/tmp/.masc/config/runtime.toml')
+    })
+
+    fireEvent.click(container.querySelector('[data-testid="runtime-toml-copy-path"]') as HTMLButtonElement)
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith('/tmp/.masc/config/runtime.toml')
+      expect(container.textContent).toContain('경로 복사됨')
+    })
+  })
+
+  it('registers a beforeunload guard only while the draft is dirty', async () => {
+    render(html`<${RuntimeTomlEditor} />`, container)
+
+    await waitFor(() => {
+      expect((container.querySelector('textarea') as HTMLTextAreaElement | null)?.value).toBe(baseConfig.source_text)
+    })
+
+    const cleanEvent = new Event('beforeunload', { cancelable: true })
+    window.dispatchEvent(cleanEvent)
+    expect(cleanEvent.defaultPrevented).toBe(false)
+
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement
+    fireEvent.input(textarea, { target: { value: `${baseConfig.source_text}# dirty\n` } })
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="runtime-toml-status"]')?.textContent).toContain('modified')
+    })
+
+    const dirtyEvent = new Event('beforeunload', { cancelable: true })
+    window.dispatchEvent(dirtyEvent)
+    expect(dirtyEvent.defaultPrevented).toBe(true)
   })
 
   it('shows load errors without losing the editor surface', async () => {

--- a/dashboard/src/components/runtime-toml-editor.ts
+++ b/dashboard/src/components/runtime-toml-editor.ts
@@ -1,5 +1,6 @@
 import { html } from 'htm/preact'
-import { useCallback, useEffect, useState } from 'preact/hooks'
+import { Copy, RefreshCcw, RotateCcw, Save } from 'lucide-preact'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import {
   fetchRuntimeTomlConfig,
   saveRuntimeTomlConfig,
@@ -8,10 +9,16 @@ import {
 import { errorToString } from '../lib/format-string'
 import { ActionButton } from './common/button'
 import { SectionCard } from './common/card'
+import { copyToClipboard } from './common/copyable-code'
 import { ErrorState, LoadingState } from './common/feedback-state'
-import { TextArea } from './common/input'
+import { ringFocusClasses } from './common/ring'
 
 type LoadState = 'idle' | 'loading' | 'loaded'
+
+interface RuntimeTomlDraftStats {
+  readonly lineCount: number
+  readonly charCount: number
+}
 
 function runtimeTomlStatusLabel(
   loadState: LoadState,
@@ -25,7 +32,26 @@ function runtimeTomlStatusLabel(
   return 'idle'
 }
 
+function runtimeTomlDraftStats(sourceText: string): RuntimeTomlDraftStats {
+  return {
+    lineCount: sourceText.length === 0 ? 1 : sourceText.split('\n').length,
+    charCount: sourceText.length,
+  }
+}
+
+function runtimeTomlLineNumbers(lineCount: number): string {
+  return Array.from({ length: lineCount }, (_, index) => String(index + 1)).join('\n')
+}
+
+const editorFocusClasses = ringFocusClasses({
+  tone: 'accent-medium',
+  width: 2,
+  offset: 0,
+})
+
 export function RuntimeTomlEditor() {
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null)
+  const lineGutterRef = useRef<HTMLPreElement | null>(null)
   const [loadState, setLoadState] = useState<LoadState>('loading')
   const [config, setConfig] = useState<RuntimeTomlConfig | null>(null)
   const [draft, setDraft] = useState('')
@@ -54,13 +80,25 @@ export function RuntimeTomlEditor() {
     void refresh()
   }, [refresh])
 
-  async function handleSave() {
-    if (!dirty || saving || loadState === 'loading') return
+  useEffect(() => {
+    if (!dirty || typeof window === 'undefined') return undefined
+    const onBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault()
+      event.returnValue = ''
+    }
+    window.addEventListener('beforeunload', onBeforeUnload)
+    return () => window.removeEventListener('beforeunload', onBeforeUnload)
+  }, [dirty])
+
+  async function handleSave(sourceText?: string) {
+    const nextSourceText = typeof sourceText === 'string' ? sourceText : textareaRef.current?.value ?? draft
+    const nextDirty = config !== null && nextSourceText !== config.source_text
+    if (!nextDirty || saving || loadState === 'loading') return
     setSaving(true)
     setError(null)
     setNotice(null)
     try {
-      const saved = await saveRuntimeTomlConfig(draft)
+      const saved = await saveRuntimeTomlConfig(nextSourceText)
       setConfig(saved)
       setDraft(saved.source_text)
       setNotice('저장됨')
@@ -71,8 +109,73 @@ export function RuntimeTomlEditor() {
     }
   }
 
+  async function handleRefresh() {
+    if (dirty) {
+      const confirmed =
+        typeof window === 'undefined' ||
+        typeof window.confirm !== 'function' ||
+        window.confirm('저장하지 않은 runtime.toml 변경을 버리고 다시 불러올까요?')
+      if (!confirmed) return
+    }
+    await refresh()
+  }
+
+  function handleReset() {
+    if (!config || !dirty || saving) return
+    setDraft(config.source_text)
+    setError(null)
+    setNotice('되돌림')
+  }
+
+  async function handleCopyPath() {
+    const ok = await copyToClipboard(path)
+    if (ok) {
+      setNotice('경로 복사됨')
+      setError(null)
+    } else {
+      setError('경로 복사 실패')
+    }
+  }
+
+  function handleEditorScroll(event: Event) {
+    const gutter = lineGutterRef.current
+    if (!gutter) return
+    gutter.scrollTop = (event.currentTarget as HTMLTextAreaElement).scrollTop
+  }
+
+  function handleEditorInput(event: Event) {
+    setDraft((event.target as HTMLTextAreaElement).value)
+    setNotice(null)
+  }
+
+  function handleEditorKeyDown(event: KeyboardEvent) {
+    if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 's') {
+      event.preventDefault()
+      void handleSave((event.currentTarget as HTMLTextAreaElement).value)
+      return
+    }
+
+    if (event.key !== 'Tab') return
+    event.preventDefault()
+    const textarea = event.currentTarget as HTMLTextAreaElement
+    const start = textarea.selectionStart
+    const end = textarea.selectionEnd
+    const sourceText = textarea.value
+    const next = `${sourceText.slice(0, start)}  ${sourceText.slice(end)}`
+    setDraft(next)
+    setNotice(null)
+    window.setTimeout(() => {
+      textareaRef.current?.setSelectionRange(start + 2, start + 2)
+    }, 0)
+  }
+
   const statusLabel = runtimeTomlStatusLabel(loadState, dirty, saving)
   const path = config?.path ?? 'runtime.toml'
+  const stats = useMemo(() => runtimeTomlDraftStats(draft), [draft])
+  const lineNumbers = useMemo(
+    () => runtimeTomlLineNumbers(stats.lineCount),
+    [stats.lineCount],
+  )
 
   return html`
     <${SectionCard}
@@ -88,42 +191,87 @@ export function RuntimeTomlEditor() {
       `}
     >
       <div class="flex flex-col gap-3">
-        <div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-          <div class="min-w-0">
-            <div class="text-2xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">path</div>
-            <div class="truncate font-mono text-xs text-[var(--color-fg-primary)]" data-testid="runtime-toml-path">
-              ${path}
+        <div class="sticky top-0 z-10 -mx-1 bg-[var(--color-bg-surface)]/95 px-1 py-2 backdrop-blur">
+          <div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+            <div class="min-w-0">
+              <div class="text-2xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">path</div>
+              <div class="truncate font-mono text-xs text-[var(--color-fg-primary)]" data-testid="runtime-toml-path">
+                ${path}
+              </div>
+            </div>
+            <div class="flex shrink-0 flex-wrap items-center gap-2">
+              <${ActionButton}
+                variant="ghost"
+                size="sm"
+                onClick=${handleCopyPath}
+                disabled=${loadState === 'loading'}
+                ariaLabel="runtime.toml 경로 복사"
+                title="경로 복사"
+                testId="runtime-toml-copy-path"
+                class="inline-flex items-center gap-1"
+              >
+                <${Copy} size=${13} strokeWidth=${2.25} aria-hidden="true" />
+                <span>경로</span>
+              <//>
+              <${ActionButton}
+                variant="ghost"
+                size="sm"
+                onClick=${handleReset}
+                disabled=${!dirty || saving}
+                ariaLabel="runtime.toml 변경 되돌리기"
+                title="변경 되돌리기"
+                testId="runtime-toml-reset"
+                class="inline-flex items-center gap-1"
+              >
+                <${RotateCcw} size=${13} strokeWidth=${2.25} aria-hidden="true" />
+                <span>되돌리기</span>
+              <//>
+              <${ActionButton}
+                variant="ghost"
+                size="sm"
+                onClick=${handleRefresh}
+                disabled=${saving || loadState === 'loading'}
+                ariaBusy=${loadState === 'loading'}
+                ariaLabel="runtime.toml 다시 불러오기"
+                title="다시 불러오기"
+                testId="runtime-toml-refresh"
+                class="inline-flex items-center gap-1"
+              >
+                <${RefreshCcw} size=${13} strokeWidth=${2.25} aria-hidden="true" />
+                <span>새로고침</span>
+              <//>
+              <${ActionButton}
+                variant="primary"
+                size="sm"
+                onClick=${handleSave}
+                disabled=${!dirty || saving || loadState === 'loading'}
+                ariaBusy=${saving}
+                ariaLabel="runtime.toml 저장"
+                title="저장"
+                testId="runtime-toml-save"
+                class="inline-flex items-center gap-1"
+              >
+                <${Save} size=${13} strokeWidth=${2.25} aria-hidden="true" />
+                <span>${saving ? '저장 중' : '저장'}</span>
+              <//>
             </div>
           </div>
-          <div class="flex shrink-0 flex-wrap items-center gap-2">
-            <${ActionButton}
-              variant="ghost"
-              size="sm"
-              onClick=${refresh}
-              disabled=${saving || loadState === 'loading'}
-              ariaBusy=${loadState === 'loading'}
-              testId="runtime-toml-refresh"
-            >
-              새로고침
-            <//>
-            <${ActionButton}
-              variant="primary"
-              size="sm"
-              onClick=${handleSave}
-              disabled=${!dirty || saving || loadState === 'loading'}
-              ariaBusy=${saving}
-              testId="runtime-toml-save"
-            >
-              ${saving ? '저장 중' : '저장'}
-            <//>
+          <div
+            class="mt-2 flex flex-wrap items-center gap-2 text-2xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]"
+            data-testid="runtime-toml-stats"
+          >
+            <span>${stats.lineCount} lines</span>
+            <span>${stats.charCount} chars</span>
+            <span>${dirty ? 'unsaved' : 'synced'}</span>
           </div>
         </div>
 
         ${error ? html`<${ErrorState} message=${error} />` : null}
         ${notice ? html`
           <div
-            class="rounded-[var(--r-0)] border border-[var(--ok-30)] bg-[var(--ok-12)] px-3 py-2 text-xs text-[var(--ok-light)]"
+            class="px-1 text-xs text-[var(--color-status-ok)]"
             role="status"
+            data-testid="runtime-toml-notice"
           >
             ${notice}
           </div>
@@ -132,17 +280,33 @@ export function RuntimeTomlEditor() {
         ${loadState === 'loading'
           ? html`<${LoadingState}>runtime.toml 불러오는 중...<//>`
           : html`
-            <${TextArea}
-              ariaLabel="runtime.toml source"
-              value=${draft}
-              rows=${28}
-              class="min-h-[28rem] font-mono text-xs leading-relaxed"
-              disabled=${saving}
-              onInput=${(event: Event) => {
-                setDraft((event.target as HTMLTextAreaElement).value)
-                setNotice(null)
-              }}
-            />
+            <div
+              class="grid min-h-[32rem] max-h-[72vh] grid-cols-[3.5rem_minmax(0,1fr)] overflow-hidden rounded-[var(--r-1)] border border-[var(--input-border)] bg-[var(--input-bg)]"
+              data-testid="runtime-toml-code-frame"
+            >
+              <pre
+                ref=${lineGutterRef}
+                class="select-none overflow-hidden border-r border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-2 py-3 text-right font-mono text-xs leading-relaxed text-[var(--color-fg-disabled)]"
+                aria-hidden="true"
+                data-testid="runtime-toml-line-numbers"
+              >${lineNumbers}</pre>
+              <textarea
+                ref=${textareaRef}
+                class="min-h-[32rem] w-full resize-y overflow-auto border-0 bg-transparent px-3 py-3 font-mono text-xs leading-relaxed text-[var(--color-fg-primary)] outline-none ${editorFocusClasses}"
+                aria-label="runtime.toml source"
+                data-testid="runtime-toml-source"
+                value=${draft}
+                rows=${32}
+                wrap="off"
+                spellcheck=${false}
+                autocapitalize="off"
+                autocorrect="off"
+                disabled=${saving}
+                onInput=${handleEditorInput}
+                onKeyDown=${handleEditorKeyDown}
+                onScroll=${handleEditorScroll}
+              ></textarea>
+            </div>
           `}
       </div>
     <//>


### PR DESCRIPTION
## Summary
- Add a line-numbered runtime.toml editor frame with path copy, reset, sticky actions, and quieter saved feedback.
- Add editor guardrails: dirty refresh confirmation, beforeunload protection, Tab indentation, and Ctrl/Cmd+S save.
- Extend runtime.toml editor tests for keyboard save, tab indent, reset, copy, refresh guard, and unload guard.

## Validation
- pnpm exec vitest run --config vitest.config.ts src/api/dashboard.test.ts src/components/runtime-panel.test.ts src/components/runtime-toml-editor.test.ts --no-file-parallelism --maxWorkers=1
- pnpm run typecheck
- pnpm run build
- git diff --check HEAD~1..HEAD
- Playwright rendered flow: /dashboard/#monitoring?section=runtime&view=config, mocked raw runtime config API, edit + Tab + Ctrl+S save, desktop/mobile screenshots, console errors = 0

## Notes
- Backend/runtime raw config API contract is unchanged.
- ESLint reports only the existing ignored-test-file warning for runtime-toml-editor.test.ts.