### PR TITLE
[codex] Make keeper detail an airy chat canvas

### DIFF
--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -115,6 +115,9 @@ describe('ChatTranscript', () => {
     const transcript = container.querySelector('[data-chat-variant="messenger"]')
     expect(transcript?.classList.contains('min-h-[18rem]')).toBe(true)
     expect(transcript?.classList.contains('max-h-[42vh]')).toBe(true)
+    expect(transcript?.classList.contains('sm:min-h-[28rem]')).toBe(true)
+    expect(transcript?.classList.contains('sm:max-h-[54vh]')).toBe(true)
+    expect(transcript?.classList.contains('chat-transcript-airy')).toBe(true)
   })
 
   it('renders attachments even when metadata is hidden', () => {

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -429,14 +429,17 @@ export function ChatTranscript({
     el.scrollTop = el.scrollHeight
   }, [lastSignature])
 
-  const heightClass = size === 'primary'
-    ? 'min-h-[18rem] max-h-[42vh] xl:max-h-[46vh]'
+  const isPrimary = size === 'primary'
+  const heightClass = isPrimary
+    ? 'min-h-[18rem] max-h-[42vh] sm:min-h-[28rem] sm:max-h-[54vh] xl:max-h-[58vh]'
     : 'min-h-75 max-h-130'
 
   return html`
     <div
-      class=${`chat-transcript flex ${heightClass} flex-col overflow-y-auto border border-[var(--color-border-default)] shadow-[inset_0_1px_0_var(--color-border-default)] ${
-        variant === 'messenger'
+      class=${`chat-transcript ${isPrimary ? 'chat-transcript-airy' : ''} flex ${heightClass} flex-col overflow-y-auto ${
+        isPrimary
+          ? 'gap-5 rounded-[var(--r-2)] border border-transparent px-0 py-2 shadow-none'
+          : variant === 'messenger'
           ? 'gap-4 rounded-[var(--radius-xl)] px-4 py-5 sm:px-5'
           : 'gap-3 rounded-[var(--radius-xl)] px-3 py-4'
       }`}
@@ -464,6 +467,7 @@ export function ChatComposer({
   onDraftChange,
   onSend,
   onAbort,
+  layout = 'default',
 }: {
   draft: string
   placeholder: string
@@ -473,6 +477,7 @@ export function ChatComposer({
   onDraftChange: (value: string) => void
   onSend: () => void
   onAbort?: () => void
+  layout?: 'default' | 'primary'
 }) {
   const [elapsed, setElapsed] = useState(0)
 
@@ -492,14 +497,20 @@ export function ChatComposer({
     : '보내기'
   const isStreamWarning = streaming && elapsed > 60
 
+  const isPrimary = layout === 'primary'
+
   return html`
     <div class="chat-composer flex flex-col gap-3">
-      <div class="flex flex-wrap items-center justify-between gap-2">
-        <div class="text-2xs font-semibold uppercase tracking-4 text-[var(--color-fg-muted)]">메시지</div>
-        <div class="text-2xs text-[var(--color-fg-muted)]">Enter로 전송, Shift+Enter로 줄바꿈</div>
-      </div>
+      ${isPrimary ? null : html`
+        <div class="flex flex-wrap items-center justify-between gap-2">
+          <div class="text-2xs font-semibold uppercase tracking-4 text-[var(--color-fg-muted)]">메시지</div>
+          <div class="text-2xs text-[var(--color-fg-muted)]">Enter로 전송, Shift+Enter로 줄바꿈</div>
+        </div>
+      `}
       <textarea
-        class="control-textarea min-h-24 rounded-card border border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] px-3 py-3 text-base leading-loose"
+        class=${isPrimary
+          ? 'control-textarea min-h-30 rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-4 py-4 text-base leading-loose'
+          : 'control-textarea min-h-24 rounded-card border border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] px-3 py-3 text-base leading-loose'}
         placeholder=${placeholder}
         aria-label="메시지 입력"
         value=${draft}

--- a/dashboard/src/components/dashboard-shell.test.ts
+++ b/dashboard/src/components/dashboard-shell.test.ts
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { h, render } from 'preact'
 import { waitFor } from '@testing-library/preact'
-import { DashboardMain, dashboardHealthChips } from './dashboard-shell'
+import { DashboardMain, dashboardHealthChips, isKeeperDetailDashboardRoute } from './dashboard-shell'
 import { route } from '../router'
 import { connected } from '../sse'
 import { dashboardLoading } from '../store'
@@ -43,6 +43,24 @@ describe('DashboardMain solo mode', () => {
     await waitFor(() => expect(document.title).toBe('MASC · Runtime'))
     expect(container.querySelector('[data-testid="dashboard-widget-solo-bar"]')).not.toBeNull()
     expect(container.querySelector('[aria-label="Active observability filters"]')).not.toBeNull()
+  })
+})
+
+describe('isKeeperDetailDashboardRoute', () => {
+  it('detects monitor keeper detail drilldowns', () => {
+    expect(isKeeperDetailDashboardRoute({
+      tab: 'monitoring',
+      params: { section: 'agents', keeper: 'sangsu' },
+      postId: null,
+    })).toBe(true)
+  })
+
+  it('does not treat the fleet list as keeper detail', () => {
+    expect(isKeeperDetailDashboardRoute({
+      tab: 'monitoring',
+      params: { section: 'agents' },
+      postId: null,
+    })).toBe(false)
   })
 })
 

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -1160,6 +1160,13 @@ function useSurfaceDocumentTitle(): void {
   }, [currentView?.label, currentSection?.label])
 }
 
+export function isKeeperDetailDashboardRoute(routeState: RouteState): boolean {
+  return routeState.tab === 'monitoring'
+    && routeState.params.section === 'agents'
+    && typeof routeState.params.keeper === 'string'
+    && routeState.params.keeper.trim() !== ''
+}
+
 function SurfaceLead() {
   const currentTab = route.value.tab
   const currentView = DASHBOARD_NAV_ITEMS.find(item => item.id === currentTab)
@@ -1225,6 +1232,7 @@ export function DashboardMain() {
   const routeLabel = dashboardRouteBoundaryKey(route.value)
   const soloMode = isWidgetSoloRoute(route.value)
   const immersiveSurface = route.value.tab === 'code'
+  const keeperDetailRoute = isKeeperDetailDashboardRoute(route.value)
   const warmingBanner = namespaceTruthInitializing.value ? html`
     <div class=${immersiveSurface
       ? 'shrink-0 border-b border-solid border-[var(--warn-20)] bg-[var(--warn-10)] px-4 py-1.5 text-center text-xs text-[var(--color-status-warn)]'
@@ -1269,8 +1277,8 @@ export function DashboardMain() {
 
   return html`
     ${warmingBanner}
-    <${SurfaceLead} />
-    <${ObservatoryFilterBar} />
+    ${keeperDetailRoute ? null : html`<${SurfaceLead} />`}
+    ${keeperDetailRoute ? null : html`<${ObservatoryFilterBar} />`}
     <${ErrorBoundary} key=${routeLabel} label=${routeLabel || 'dashboard'}>
       <div class="animate-in fade-in slide-in-from-bottom-2 duration-[var(--t-slow)] fill-mode-both">
         <${TabContent} />

--- a/dashboard/src/components/keeper-detail-body.ts
+++ b/dashboard/src/components/keeper-detail-body.ts
@@ -101,10 +101,7 @@ export function KeeperDetailBody({
   onSocialSweep,
 }: KeeperDetailBodyProps) {
   return html`
-    <div class="flex flex-col gap-4">
-        <${KeeperRuntimeAlertStrip} keeper=${keeper} />
-        <${KeeperDetailSectionRail} />
-
+    <div class="mx-auto flex w-full max-w-[1180px] flex-col gap-5">
         <${KeeperDetailSection}
           id="keeper-comms"
           eyebrow="대화 & 세션"
@@ -117,6 +114,9 @@ export function KeeperDetailBody({
             <${SessionTraceView} agentName=${keeper.name} isKeeper=${true} keeperStatus=${keeper.status} keeperGeneration=${keeper.generation} />
           <//>
         <//>
+
+        <${KeeperRuntimeAlertStrip} keeper=${keeper} />
+        <${KeeperDetailSectionRail} />
 
         <${KeeperDetailSection}
           id="keeper-summary"

--- a/dashboard/src/components/keeper-detail-page.ts
+++ b/dashboard/src/components/keeper-detail-page.ts
@@ -192,9 +192,9 @@ export function KeeperDetailPage() {
   }
 
   return html`
-    <div class="mx-auto flex w-full max-w-[1720px] flex-col gap-4 pb-6" data-route-focused-keeper=${keeper.name}>
-      <div class="sticky top-0 z-20 overflow-hidden rounded-[var(--r-3)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] shadow-[var(--shadow-raised)] backdrop-blur-xl">
-        <div class="flex flex-col items-stretch justify-between gap-3 px-4 py-3 sm:flex-row sm:items-center sm:px-5">
+    <div class="mx-auto flex w-full max-w-[1380px] flex-col gap-5 pb-8" data-route-focused-keeper=${keeper.name}>
+      <div class="sticky top-0 z-20 mx-auto w-full max-w-[1180px] overflow-hidden rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] shadow-none backdrop-blur-xl">
+        <div class="flex flex-col items-stretch justify-between gap-3 px-4 py-2.5 sm:flex-row sm:items-center sm:px-5">
           <${KeeperDetailHeaderInfo}
             keeper=${keeper}
             titleId=${titleId}

--- a/dashboard/src/components/keeper-detail-shell.test.ts
+++ b/dashboard/src/components/keeper-detail-shell.test.ts
@@ -64,7 +64,8 @@ describe('KeeperDetailSection', () => {
 
     const section = container.querySelector('section')
     expect(section?.classList.contains('scroll-mt-24')).toBe(true)
-    expect(section?.classList.contains('rounded-[var(--r-3)]')).toBe(true)
+    expect(section?.classList.contains('rounded-[var(--r-2)]')).toBe(true)
+    expect(section?.classList.contains('shadow-none')).toBe(true)
   })
 
   it('keeps locked-open primary sections visible without a collapse button', () => {
@@ -84,7 +85,8 @@ describe('KeeperDetailSection', () => {
 
     expect(container.querySelector('[data-testid="chat-child"]')).not.toBeNull()
     expect(container.querySelector('button[aria-expanded]')).toBeNull()
-    expect(container.textContent).toContain('기본')
+    expect(container.textContent).not.toContain('기본')
+    expect(container.querySelector('section')?.classList.contains('bg-transparent')).toBe(true)
   })
 })
 

--- a/dashboard/src/components/keeper-detail-shell.ts
+++ b/dashboard/src/components/keeper-detail-shell.ts
@@ -74,20 +74,19 @@ export function KeeperDetailHeaderInfo({
   onClose: () => void
 }) {
   return html`
-    <div class="flex min-w-0 flex-wrap items-start gap-4">
+    <div class="flex min-w-0 flex-wrap items-center gap-3">
       <button
         type="button"
         onClick=${onClose}
-        class="inline-flex shrink-0 items-center gap-2 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-3 py-1.5 text-xs font-semibold text-[var(--color-fg-primary)] transition-colors hover:bg-[var(--color-bg-hover)]"
+        class="inline-flex shrink-0 items-center gap-2 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-1.5 text-xs font-semibold text-[var(--color-fg-primary)] transition-colors hover:bg-[var(--color-bg-hover)]"
       >
         <span aria-hidden="true">←</span>
         목록
       </button>
-      <div class="size-10 shrink-0 rounded-[var(--r-1)] bg-[var(--color-bg-elevated)] border border-[var(--color-border-default)] flex items-center justify-center text-xl">${keeper.emoji}</div>
+      <div class="size-9 shrink-0 rounded-[var(--r-1)] bg-[var(--color-bg-surface)] border border-[var(--color-border-default)] flex items-center justify-center text-lg">${keeper.emoji}</div>
       <div class="flex min-w-[12rem] flex-1 flex-col gap-0.5">
-        <${SectionLabel}>모니터링 / 에이전트 / 키퍼 상세</${SectionLabel}>
-        <div class="mt-1 flex flex-wrap items-center gap-2.5">
-          <h2 id=${titleId} class="m-0 text-lg font-semibold text-[var(--color-fg-primary)]">${keeper.name}</h2>
+        <div class="flex flex-wrap items-center gap-2.5">
+          <h2 id=${titleId} class="m-0 text-xl font-semibold text-[var(--color-fg-primary)]">${keeper.name}</h2>
           <${KeeperPhaseAndStage}
             phase=${keeper.lifecycle_phase ?? keeper.phase}
             pipelineStage=${keeper.pipeline_stage}
@@ -153,15 +152,14 @@ function scrollToKeeperDetailSection(sectionId: KeeperDetailSectionId): void {
 export function KeeperDetailSectionRail() {
   return html`
     <nav
-      class="sticky top-[76px] z-10 overflow-x-auto rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] p-1 shadow-[var(--shadow-panel)]"
+      class="sticky top-[64px] z-10 overflow-x-auto border-b border-[var(--color-border-default)] bg-[var(--color-bg-page)] py-1.5"
       aria-label="키퍼 상세 섹션"
     >
-      <div class="flex min-w-max items-center gap-1">
-        <span class="shrink-0 px-2 text-3xs font-semibold uppercase tracking-[var(--track-label)] text-[var(--color-fg-disabled)]">섹션</span>
+      <div class="flex min-w-max items-center gap-1.5 px-1">
         ${KEEPER_DETAIL_SECTIONS.map((section) => html`
           <button
             type="button"
-            class="h-8 shrink-0 rounded-[var(--r-1)] border border-transparent px-3 text-2xs font-semibold text-[var(--color-fg-muted)] transition-colors hover:border-[var(--color-border-default)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-primary)]"
+            class="h-8 shrink-0 rounded-[var(--r-1)] border border-transparent px-3 text-2xs font-semibold text-[var(--color-fg-muted)] transition-colors hover:border-[var(--color-border-default)] hover:bg-[var(--color-bg-surface)] hover:text-[var(--color-fg-primary)]"
             onClick=${() => scrollToKeeperDetailSection(section.id)}
           >
             ${section.label}
@@ -200,18 +198,20 @@ export function KeeperDetailSection({
   const isCollapsed = lockedOpen ? false : collapsed
   const bodyId = `${id}-body`
   const sectionClass = variant === 'primary'
-    ? 'scroll-mt-24 rounded-[var(--r-3)] border border-[var(--accent-20)] bg-[var(--color-bg-surface)] shadow-[var(--shadow-raised)]'
-    : 'scroll-mt-24 rounded-[var(--r-3)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] shadow-[var(--shadow-raised)]'
+    ? 'scroll-mt-24 rounded-[var(--r-2)] bg-transparent shadow-none'
+    : 'scroll-mt-24 rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] shadow-none'
   const headerClass = variant === 'primary'
-    ? 'flex w-full items-center justify-between gap-3 border-b border-[var(--accent-20)] px-5 py-4 text-left sm:px-6'
-    : 'flex w-full items-center justify-between gap-3 border-b border-[var(--color-border-default)] px-5 py-4 text-left transition-colors hover:bg-[var(--color-bg-hover)] sm:px-6'
+    ? 'flex w-full items-center justify-between gap-3 px-0 pb-2 pt-1 text-left'
+    : 'flex w-full items-center justify-between gap-3 border-b border-[var(--color-border-default)] px-4 py-3 text-left transition-colors hover:bg-[var(--color-bg-hover)] sm:px-5'
   const headerContent = html`
     <div class="min-w-0">
       <div class="text-3xs font-semibold uppercase tracking-[var(--track-brand)] text-[var(--color-fg-muted)]">${eyebrow}</div>
       <h3 class="m-0 mt-1 text-lg font-semibold text-[var(--color-fg-primary)]">${title}</h3>
     </div>
-    ${lockedOpen
+    ${lockedOpen && variant !== 'primary'
       ? html`<span class="shrink-0 rounded-[var(--r-0)] border border-[var(--accent-20)] bg-[var(--accent-10)] px-2 py-1 text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-accent-fg)]">기본</span>`
+      : lockedOpen
+        ? null
       : html`
         <span
           aria-hidden="true"
@@ -239,7 +239,7 @@ export function KeeperDetailSection({
           </button>
         `}
       ${isCollapsed ? null : html`
-        <div id=${bodyId} class="flex flex-col gap-4 px-5 py-5 sm:px-6">
+        <div id=${bodyId} class=${variant === 'primary' ? 'flex flex-col gap-4 px-0 py-0' : 'flex flex-col gap-4 px-4 py-4 sm:px-5'}>
           ${children}
         </div>
       `}

--- a/dashboard/src/components/keeper-shared.test.ts
+++ b/dashboard/src/components/keeper-shared.test.ts
@@ -148,6 +148,38 @@ describe('KeeperConversationPanel', () => {
     expect(hydrateKeeperStatus).not.toHaveBeenCalled()
   })
 
+  it('renders the primary conversation layout as an airy canvas', async () => {
+    keeperThreads.value = {
+      sangsu: [
+        {
+          id: 'direct-user',
+          role: 'user',
+          source: 'direct_user',
+          label: '사용자',
+          text: '넓게 보여줘',
+          rawText: '넓게 보여줘',
+          timestamp: '2026-03-24T00:01:00.000Z',
+          delivery: 'history',
+          streamState: null,
+          details: null,
+          error: null,
+        },
+      ],
+    }
+
+    render(
+      html`<${KeeperConversationPanel} keeperName="sangsu" placeholder="메시지 입력..." layout="primary" />`,
+      container,
+    )
+    await Promise.resolve()
+
+    expect(container.querySelector('[data-keeper-chat-layout="primary"]')).not.toBeNull()
+    expect(container.querySelector('.chat-transcript-airy')).not.toBeNull()
+    expect(container.querySelector('.min-h-30')).not.toBeNull()
+    expect(container.textContent).toContain('@sangsu')
+    expect(container.textContent).not.toContain('Enter로 전송')
+  })
+
   it('renders probe and recover buttons in RuntimeActions', async () => {
     const keeper = { name: 'sangsu', status: 'running' } as any
 

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -316,6 +316,87 @@ export function KeeperConversationPanel({
     }
   }
 
+  if (layout === 'primary') {
+    return html`
+      <div class="flex flex-col gap-4" data-keeper-chat-layout="primary">
+        <div class="flex flex-wrap items-center justify-between gap-3 border-b border-[var(--color-border-default)] pb-3">
+          <div class="min-w-0">
+            <div class="text-2xs font-semibold uppercase tracking-5 text-[var(--color-fg-muted)]">직접 대화</div>
+            <div class="mt-1.5 flex flex-wrap items-center gap-2">
+              <div class="text-lg font-semibold text-[var(--color-fg-primary)]">@${keeperName}</div>
+              <span class=${`inline-flex items-center rounded-[var(--r-0)] border px-2.5 py-1 text-3xs font-medium uppercase tracking-2 ${conversationStateClass(sending, hydrating)}`}>
+                ${conversationStateLabel(sending, hydrating)}
+              </span>
+            </div>
+          </div>
+          <div class="flex flex-wrap items-center justify-end gap-2">
+            <${GhostButton} onClick=${toggleMetadata} ariaExpanded=${showMetadata}>
+              ${showMetadata ? '메타데이터 숨김' : '메타데이터 표시'}
+            <//>
+            <${GhostButton}
+              onClick=${toggleInternal}
+              ariaExpanded=${showInternal}
+              class=${showInternal ? 'border-[var(--info-border)] text-[var(--info-fg)]' : ''}
+            >
+              ${showInternal ? '내부 메시지 숨김' : '내부 메시지 표시'}
+            </${GhostButton}>
+            ${!historyExpanded
+              ? html`
+                  <${GhostButton} disabled=${hydrating} onClick=${() => { void expandHistory() }}>
+                    ${hydrating
+                      ? '불러오는 중...'
+                      : rawThread.length === 0
+                        ? '이력 불러오기'
+                        : `전체 이력 (${thread.length})`}
+                  </button>
+                `
+              : null}
+          </div>
+        </div>
+
+        ${chatAccess.message
+          ? html`
+              <div class="rounded-[var(--r-2)] border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2.5 text-xs leading-loose text-[var(--warn-bright)]">
+                ${chatAccess.message}
+              </div>
+            `
+          : null}
+
+        <${ChatTranscript}
+          entries=${thread}
+          emptyText="아직 표시할 대화가 없습니다. 내부 메시지와 도구 호출은 토글로 전환할 수 있습니다."
+          showMetadata=${showMetadata}
+          variant="messenger"
+          size="primary"
+        />
+
+        ${!showInternal && hiddenCount > 0
+          ? html`
+              <div class="rounded-[var(--r-2)] border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2 text-2xs leading-paragraph text-[var(--warn-bright)]">
+                ${hiddenCount}개의 내부 메시지가 숨겨져 있습니다. "내부 메시지 표시"로 볼 수 있습니다.
+              </div>
+            `
+          : null}
+
+        <div class="rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-4 py-4 shadow-none">
+          <${ChatComposer}
+            draft=${draft}
+            placeholder=${chatAccess.blocked ? '현재 actor는 direct keeper chat 권한이 없습니다' : placeholder}
+            disabled=${composerDisabled}
+            streaming=${sending}
+            streamStartedAt=${keeperStreamStartedAt.value[keeperName] ?? null}
+            onDraftChange=${setDraft}
+            onSend=${() => { void submit() }}
+            onAbort=${() => { abortKeeperThreadMessage(keeperName) }}
+            layout="primary"
+          />
+        </div>
+
+        ${error ? html`<div class="text-xs text-[var(--bad-light)] leading-relaxed">${error}</div>` : null}
+      </div>
+    `
+  }
+
   return html`
     <div class="flex flex-col gap-3">
       <div class="overflow-hidden rounded-[var(--radius-xl)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] shadow-[var(--shadow-raised)]">
@@ -367,7 +448,7 @@ export function KeeperConversationPanel({
             emptyText="아직 표시할 대화가 없습니다. 내부 메시지와 도구 호출은 토글로 전환할 수 있습니다."
             showMetadata=${showMetadata}
             variant="messenger"
-            size=${layout === 'primary' ? 'primary' : 'default'}
+            size="default"
           />
         </div>
 

--- a/dashboard/src/styles/chat.css
+++ b/dashboard/src/styles/chat.css
@@ -8,6 +8,10 @@
     var(--color-bg-page);
 }
 
+@utility chat-transcript-airy {
+  background: transparent;
+}
+
 @utility chat-bubble {
   box-shadow: var(--elev-4-shadow);
   &.user {


### PR DESCRIPTION
## Summary

- Suppress the generic Keeper Fleet surface lead and observability filter bar on keeper detail drilldowns so selecting a keeper opens directly into the detail experience.
- Reorder keeper detail content so the primary conversation canvas renders before runtime alerts, section rail, status, diagnostics, identity, config, and debug panels.
- Add an airy primary chat layout: flat toolbar, transparent transcript canvas, responsive transcript height, and larger composer without shortcut copy.

## Validation

- `pnpm -C dashboard typecheck`
- `pnpm -C dashboard exec vitest run --config vitest.config.ts src/components/chat/primitives.test.ts src/components/keeper-detail.test.ts src/components/keeper-shared.test.ts src/components/dashboard-shell.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm -C dashboard exec vitest run --config vitest.config.ts src/components/keeper-detail-shell.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm -C dashboard exec eslint src/components/keeper-detail-shell.ts src/components/keeper-detail-body.ts src/components/keeper-detail-page.ts src/components/keeper-shared.ts src/components/chat/primitives.ts src/components/dashboard-shell.ts`
- `git diff --check`
- Playwright rendered smoke at `http://127.0.0.1:5176/dashboard/#monitoring?section=agents&keeper=sangsu`: primary chat present, airy transcript present, composer present, chat before status, generic surface lead/filter hidden, old section label/default badge/shortcut copy absent, status initially collapsed, no console errors on desktop or mobile.