### PR TITLE
feat(otel): wire metric bridge and degraded health

### DIFF
--- a/lib/llm_metric_bridge.ml
+++ b/lib/llm_metric_bridge.ml
@@ -1,45 +1,276 @@
-let http_status_metric = "retired_otel_metric_store_llm_provider_http_status_total"
-let fallback_triggered_metric = "retired_otel_metric_store_fallback_triggered_total"
+module Metrics = Llm_provider.Metrics
 
-let emit_http_status ~provider:_ ~model_id:_ ~status:_ = ()
-let emit_request_latency ?provider:_ ~model_id:_ ~latency_ms:_ () = ()
-let emit_capability_drop ~model_id:_ ~field:_ = ()
-let emit_cache_hit ~model_id:_ = ()
-let emit_cache_miss ~model_id:_ = ()
-let emit_request_start ~model_id:_ = ()
-let emit_error ~model_id:_ ~error:_ = ()
-let emit_retry ~provider:_ ~model_id:_ ~attempt:_ = ()
+let http_status_metric = Otel_metric_store.metric_llm_provider_http_status
+let fallback_triggered_metric = Otel_metric_store.metric_fallback_triggered
 
-let emit_circuit_state
-      ~provider:_
-      ~model_id:_
-      ~provider_key:_
-      ~state:_
-  =
-  ()
+let provider_cache : (string, string) Hashtbl.t = Hashtbl.create 64
+let provider_cache_mu = Stdlib.Mutex.create ()
+
+let with_provider_cache_lock f =
+  Stdlib.Mutex.lock provider_cache_mu;
+  Fun.protect ~finally:(fun () -> Stdlib.Mutex.unlock provider_cache_mu) f
 ;;
 
-let emit_token_usage ~provider:_ ~model_id:_ ~input_tokens:_ ~output_tokens:_ =
-  ()
+let contains_substring haystack needle =
+  let haystack_len = String.length haystack in
+  let needle_len = String.length needle in
+  if needle_len = 0 then true
+  else
+    let rec loop i =
+      i + needle_len <= haystack_len
+      && (String.equal (String.sub haystack i needle_len) needle || loop (i + 1))
+    in
+    loop 0
 ;;
 
-let emit_tool_calls ~provider:_ ~model_id:_ ~count:_ = ()
-
-let emit_streaming_first_chunk ~provider:_ ~model_id:_ ~ttfrc_ms:_ = ()
-
-let emit_streaming_chunk
-      ~provider:_
-      ~model_id:_
-      ~chunk_index:_
-      ~inter_chunk_ms:_
-  =
-  ()
+let note_provider ~model_id ~provider =
+  if (not (String.equal model_id "")) && not (String.equal provider "") then
+    with_provider_cache_lock (fun () ->
+      Hashtbl.replace provider_cache model_id provider)
 ;;
 
-let emit_fallback_triggered ~kind:_ ~detail:_ = ()
+let provider_seen_for_model ~model_id =
+  with_provider_cache_lock (fun () -> Hashtbl.find_opt provider_cache model_id)
+;;
 
-let make_sink () : Llm_provider.Metrics.t = Llm_provider.Metrics.noop
+let model_labels ~model_id = [ ("model", model_id) ]
+let provider_model_labels ~provider ~model_id = [ ("provider", provider); ("model", model_id) ]
+
+let inc_counter ?(delta = 1.0) name ~labels =
+  Otel_metric_store.inc_counter name ~labels ~delta ()
+;;
+
+let set_gauge name ~labels value = Otel_metric_store.set_gauge name ~labels value
+
+let observe_seconds name ~labels seconds =
+  Otel_metric_store.observe_histogram name ~labels seconds
+;;
+
+let emit_http_status ~provider ~model_id ~status =
+  note_provider ~model_id ~provider;
+  inc_counter
+    http_status_metric
+    ~labels:
+      [ ("provider", provider)
+      ; ("model", model_id)
+      ; ("status", string_of_int status)
+      ]
+;;
+
+let provider_for_latency provider_opt ~model_id =
+  match provider_opt with
+  | Some provider when not (String.equal provider "") ->
+    note_provider ~model_id ~provider;
+    provider, None
+  | _ ->
+    if String.equal model_id ""
+    then "unknown", Some "provider_unknown_no_model_id"
+    else (
+      match provider_seen_for_model ~model_id with
+      | Some provider -> provider, None
+      | None -> "unknown", Some "provider_unknown_cache_miss")
+;;
+
+let emit_latency_clamp ~provider ~model_id ~reason =
+  inc_counter
+    Otel_metric_store.metric_llm_provider_request_latency_clamped
+    ~labels:[ ("provider", provider); ("model", model_id); ("reason", reason) ]
+;;
+
+let emit_request_latency ?provider ~model_id ~latency_ms () =
+  let provider, provider_reason = provider_for_latency provider ~model_id in
+  Option.iter
+    (fun reason -> emit_latency_clamp ~provider ~model_id ~reason)
+    provider_reason;
+  let seconds =
+    if latency_ms <= 0
+    then (
+      emit_latency_clamp ~provider ~model_id ~reason:"non_positive_latency_ms";
+      0.001)
+    else float_of_int latency_ms /. 1000.0
+  in
+  observe_seconds
+    Otel_metric_store.metric_llm_provider_request_latency
+    ~labels:(provider_model_labels ~provider ~model_id)
+    seconds
+;;
+
+let emit_capability_drop ~model_id ~field =
+  inc_counter
+    Otel_metric_store.metric_llm_provider_capability_drops
+    ~labels:[ ("model", model_id); ("field", field) ]
+;;
+
+let emit_cache_hit ~model_id =
+  inc_counter
+    Otel_metric_store.metric_llm_provider_cache_hits
+    ~labels:(model_labels ~model_id)
+;;
+
+let emit_cache_miss ~model_id =
+  inc_counter
+    Otel_metric_store.metric_llm_provider_cache_misses
+    ~labels:(model_labels ~model_id)
+;;
+
+let emit_request_start ~model_id =
+  inc_counter
+    Otel_metric_store.metric_llm_provider_requests_started
+    ~labels:(model_labels ~model_id)
+;;
+
+let error_reason error =
+  let error = String.lowercase_ascii error in
+  if contains_substring error "429" || contains_substring error "rate limit"
+  then "rate_limit"
+  else if
+    contains_substring error "timeout"
+    || contains_substring error "timed out"
+    || contains_substring error "deadline"
+  then "timeout"
+  else "unknown"
+;;
+
+let emit_error ~model_id ~error =
+  inc_counter
+    Otel_metric_store.metric_llm_provider_errors
+    ~labels:(model_labels ~model_id);
+  inc_counter
+    Otel_metric_store.metric_llm_provider_errors_by_reason
+    ~labels:[ ("model", model_id); ("error_reason", error_reason error) ]
+;;
+
+let emit_retry ~provider ~model_id ~attempt =
+  note_provider ~model_id ~provider;
+  inc_counter
+    Otel_metric_store.metric_llm_provider_retries
+    ~labels:
+      [ ("provider", provider)
+      ; ("model", model_id)
+      ; ("attempt", string_of_int attempt)
+      ]
+;;
+
+let emit_circuit_state ~provider ~model_id ~provider_key ~state =
+  note_provider ~model_id ~provider;
+  set_gauge
+    Otel_metric_store.metric_llm_provider_circuit_state
+    ~labels:
+      [ ("provider", provider)
+      ; ("model", model_id)
+      ; ("provider_key", provider_key)
+      ]
+    (float_of_int (Metrics.circuit_state_to_int state))
+;;
+
+let emit_token_usage ~provider ~model_id ~input_tokens ~output_tokens =
+  note_provider ~model_id ~provider;
+  let labels = provider_model_labels ~provider ~model_id in
+  inc_counter
+    Otel_metric_store.metric_llm_provider_input_tokens
+    ~labels
+    ~delta:(float_of_int input_tokens);
+  inc_counter
+    Otel_metric_store.metric_llm_provider_output_tokens
+    ~labels
+    ~delta:(float_of_int output_tokens)
+;;
+
+let emit_tool_calls ~provider ~model_id ~count =
+  note_provider ~model_id ~provider;
+  if count > 0 then
+    inc_counter
+      Otel_metric_store.metric_llm_provider_tool_calls
+      ~labels:(provider_model_labels ~provider ~model_id)
+      ~delta:(float_of_int count)
+;;
+
+let invalid_ms_reason value =
+  match classify_float value with
+  | FP_nan | FP_infinite -> Some "not_finite"
+  | _ when value <= 0.0 -> Some "non_positive"
+  | _ -> None
+;;
+
+let streaming_attrs ~provider ~model_id extra =
+  [ Otel_genai.Attr_key.gen_ai_provider_name, `String provider
+  ; "gen_ai.request.model", `String model_id
+  ]
+  @ extra
+;;
+
+let emit_streaming_first_chunk ~provider ~model_id ~ttfrc_ms =
+  note_provider ~model_id ~provider;
+  match invalid_ms_reason ttfrc_ms with
+  | Some reason ->
+    inc_counter
+      Otel_metric_store.metric_llm_provider_streaming_first_chunk_invalid
+      ~labels:[ ("provider", provider); ("model", model_id); ("reason", reason) ]
+  | None ->
+    observe_seconds
+      Otel_metric_store.metric_llm_provider_streaming_first_chunk
+      ~labels:(provider_model_labels ~provider ~model_id)
+      (ttfrc_ms /. 1000.0);
+    Otel_spans.add_event
+      ~name:"ttfrc.received"
+      ~attrs:
+        (streaming_attrs
+           ~provider
+           ~model_id
+           [ "masc.gen_ai.streaming.ttfrc_ms", `Float ttfrc_ms ])
+      ()
+;;
+
+let emit_streaming_chunk ~provider ~model_id ~chunk_index ~inter_chunk_ms =
+  note_provider ~model_id ~provider;
+  match invalid_ms_reason inter_chunk_ms with
+  | Some reason ->
+    inc_counter
+      Otel_metric_store.metric_llm_provider_streaming_inter_chunk_invalid
+      ~labels:[ ("provider", provider); ("model", model_id); ("reason", reason) ]
+  | None ->
+    observe_seconds
+      Otel_metric_store.metric_llm_provider_streaming_inter_chunk
+      ~labels:(provider_model_labels ~provider ~model_id)
+      (inter_chunk_ms /. 1000.0);
+    Otel_spans.add_event
+      ~name:"streaming.chunk"
+      ~attrs:
+        (streaming_attrs
+           ~provider
+           ~model_id
+           [ "masc.gen_ai.streaming.chunk_index", `Int chunk_index
+           ; "masc.gen_ai.streaming.inter_chunk_ms", `Float inter_chunk_ms
+           ])
+      ()
+;;
+
+let emit_fallback_triggered ~kind ~detail =
+  inc_counter fallback_triggered_metric ~labels:[ ("kind", kind); ("detail", detail) ]
+;;
+
+let make_sink () : Metrics.t =
+  { Metrics.
+    on_cache_hit = emit_cache_hit
+  ; on_cache_miss = emit_cache_miss
+  ; on_request_start = emit_request_start
+  ; on_request_end =
+      (fun ~model_id ~latency_ms ->
+        match latency_ms with
+        | Some latency_ms -> emit_request_latency ~model_id ~latency_ms ()
+        | None -> ())
+  ; on_error = emit_error
+  ; on_http_status = emit_http_status
+  ; on_circuit_state = emit_circuit_state
+  ; on_capability_drop = emit_capability_drop
+  ; on_retry = emit_retry
+  ; on_token_usage = emit_token_usage
+  ; on_tool_calls = emit_tool_calls
+  ; on_streaming_first_chunk = emit_streaming_first_chunk
+  ; on_streaming_chunk = emit_streaming_chunk
+  }
+;;
 
 let init ~base_path:_ = ()
 
-let install () = Llm_provider.Metrics.set_global (make_sink ())
+let install () = Metrics.set_global (make_sink ())

--- a/lib/llm_metric_bridge.mli
+++ b/lib/llm_metric_bridge.mli
@@ -1,8 +1,8 @@
-(** Retired Otel_metric_store bridge for OAS [Llm_provider.Metrics.t].
+(** Otel_metric_store-backed bridge for OAS [Llm_provider.Metrics.t].
 
-    The process-wide sink remains installable so callers keep their
-    initialization order, but callbacks are intentionally no-op until the OTel
-    replacement owns this boundary. *)
+    The process-wide sink is installed early during server bootstrap so OAS
+    provider callbacks update the in-process metric store. The store is then
+    exported through the OTel metrics bridge. *)
 
 val http_status_metric : string
 val fallback_triggered_metric : string

--- a/lib/otel_metric_store.ml
+++ b/lib/otel_metric_store.ml
@@ -1,8 +1,8 @@
-(** Retired Otel_metric_store facade.
+(** Otel_metric_store facade.
 
-    The Otel_metric_store exporter/registration stack was hard-cut; this module keeps
-    the historical metric-name and in-process counter API as a compatibility
-    boundary while callers are removed in follow-up slices. *)
+    Keeps the historical metric-name and in-process counter API as the local
+    accumulator, and exposes the same snapshot as an OpenTelemetry metric source
+    during server bootstrap. *)
 
 include Otel_metric_store_core
 include Otel_metric_names
@@ -13,6 +13,32 @@ include Otel_core_metric_names
 include Otel_policy_metric_names
 include Otel_identity_metric_names
 include Otel_transport_metric_names
+
+let otel_kind_of_metric_type = function
+  | Counter -> Otel_metrics.Counter
+  | Gauge -> Otel_metrics.Gauge
+  | Histogram -> Otel_metrics.Histogram
+;;
+
+let otel_samples () =
+  snapshot ()
+  |> List.map (fun (metric : Otel_metric_store_core.metric) ->
+    { Otel_metrics.name = metric.name
+    ; value = metric.value
+    ; labels = metric.labels
+    ; kind = otel_kind_of_metric_type metric.metric_type
+    })
+;;
+
+let otel_source_registered = Atomic.make false
+
+let register_otel_source_once () =
+  if not (Atomic.exchange otel_source_registered true) then
+    Otel_metrics.register_source otel_samples
+;;
+
+let otel_source_registered_for_test () = Atomic.get otel_source_registered
+let otel_samples_for_test () = otel_samples ()
 
 let set_tool_schema_stats ~count ~approx_tokens =
   set_gauge metric_mcp_tool_schema_count (Float.of_int count);

--- a/lib/otel_spans/opentelemetry_client_cohttp_eio.ml
+++ b/lib/otel_spans/opentelemetry_client_cohttp_eio.ml
@@ -462,8 +462,21 @@ module Backend (Emitter : EMITTER) : Opentelemetry.Collector.BACKEND = struct
   let set_on_tick_callbacks = Emitter.set_on_tick_callbacks
 end
 
+let tick_degraded_state = Atomic.make false
+let last_tick_poisoned_error_state : string option Atomic.t = Atomic.make None
+
+let tick_degraded () = Atomic.get tick_degraded_state
+let last_tick_poisoned_error () = Atomic.get last_tick_poisoned_error_state
+
+let reset_tick_health () =
+  Atomic.set tick_degraded_state false;
+  Atomic.set last_tick_poisoned_error_state None
+;;
+
 let stop_tick_after_poisoned_mutex ~stop cause =
   Atomic.set stop true;
+  Atomic.set tick_degraded_state true;
+  Atomic.set last_tick_poisoned_error_state (Some (Printexc.to_string cause));
   Log.Telemetry.error
     "otel tick failed with Eio.Mutex.Poisoned; stopping tick fiber; OTEL metrics \
      export degraded until backend restart; underlying cause: %s"
@@ -487,6 +500,7 @@ let create_backend ~sw ?(stop = Atomic.make false) ?(config = Config.make ()) en
 ;;
 
 let setup_ ~sw ?stop ?config env : unit =
+  reset_tick_health ();
   let backend = create_backend ?stop ?config ~sw env in
   OT.Collector.set_backend backend
 ;;
@@ -495,7 +509,10 @@ let setup ?stop ?config ?(enable = true) ~sw env =
   if enable then setup_ ~sw ?stop ?config env
 ;;
 
-let remove_backend () = OT.Collector.remove_backend ~on_done:ignore ()
+let remove_backend () =
+  reset_tick_health ();
+  OT.Collector.remove_backend ~on_done:ignore ()
+;;
 
 let with_setup ?stop ?config ?(enable = true) f env =
   if enable

--- a/lib/otel_spans/opentelemetry_client_cohttp_eio.mli
+++ b/lib/otel_spans/opentelemetry_client_cohttp_eio.mli
@@ -2,15 +2,13 @@
     exporter (cohttp-eio backend) wrapped behind a tiny
     pinned surface.
 
-    The .ml is 475 lines: the bulk of it implements the
+    The .ml is intentionally private-heavy: the bulk of it implements the
     full {!Opentelemetry.Collector.BACKEND} module
     (Httpc client, Batch / Signal helpers, GC metrics
-    sampler, custom emitter pipeline).  External callers
-    reach exactly three entry points — [Config], [setup],
-    and [remove_backend] — through {!Otel_spans.start} and
-    {!Otel_spans.shutdown}.  Pinning that minimal surface
-    lets the BACKEND machinery evolve internally without
-    contract churn.
+    sampler, custom emitter pipeline). External callers get only backend
+    lifecycle entry points plus the small tick-health accessors that
+    {!Otel_spans} surfaces in [/health]. Pinning that minimal surface lets the
+    BACKEND machinery evolve internally without contract churn.
 
     Internal helpers stay private at this boundary
     (the [OT] / [Signal] / [Batch] aliases, the
@@ -21,8 +19,8 @@
     [sample_gc_metrics_if_needed], [error] type, the
     [n_errors] / [n_dropped] counters, [report_err_],
     the {!Httpc} module, the {!EMITTER} module type,
-    [mk_emitter], the {!Backend} functor, [create_backend],
-    [setup_], [with_setup]). *)
+    [mk_emitter], the {!Backend} functor, [create_backend], [setup_],
+    [with_setup]). *)
 
 module Config : sig
   type t
@@ -69,6 +67,16 @@ val setup :
     short-circuits the install when set to [false] so
     callers can keep a single boot path while toggling
     OTel via configuration. *)
+
+val tick_degraded : unit -> bool
+(** [true] once the exporter tick fiber has stopped after
+    [Eio.Mutex.Poisoned]. The backend must be restarted to clear this state. *)
+
+val last_tick_poisoned_error : unit -> string option
+(** Last poison cause captured by the tick fiber, if any. *)
+
+val reset_tick_health : unit -> unit
+(** Clear tick degraded state before installing a fresh backend. *)
 
 val remove_backend : unit -> unit
 (** Uninstalls the active backend (counterpart to

--- a/lib/otel_spans/otel_spans.ml
+++ b/lib/otel_spans/otel_spans.ml
@@ -39,12 +39,19 @@ let init () =
     metrics, and logs to the configured OTLP collector via HTTP/protobuf.
     Internally forks a 500ms tick fiber under [sw] for periodic batch flush.
     No-op when OTel is explicitly disabled. *)
-let is_exporter_active () = Atomic.get exporter_active
+let is_exporter_degraded () = Opentelemetry_client_cohttp_eio.tick_degraded ()
+let last_degradation_error () = Opentelemetry_client_cohttp_eio.last_tick_poisoned_error ()
+
+let is_exporter_active () =
+  Atomic.get exporter_active && not (is_exporter_degraded ())
+;;
+
 let last_successful_export () = Atomic.get _last_successful_export
 let consecutive_failures () = Atomic.get _consecutive_failures
 
 let setup_exporter_with ?(enabled = Otel_config.enabled) ~endpoint ~setup () =
   if enabled then begin
+    Opentelemetry_client_cohttp_eio.reset_tick_health ();
     init ();
     try
       setup ();
@@ -83,6 +90,7 @@ let probe_endpoint ~(env : Eio_unix.Stdenv.base) endpoint =
 let setup_exporter ~sw (env : Eio_unix.Stdenv.base) =
   let endpoint = Otel_config.endpoint in
   let clock = Eio.Stdenv.clock env in
+  Opentelemetry_client_cohttp_eio.reset_tick_health ();
   let rec try_setup attempt =
     if not (enabled ()) then ()
     else begin
@@ -155,6 +163,7 @@ let shutdown ?(enabled = Otel_config.enabled) () =
     Opentelemetry_client_cohttp_eio.remove_backend ();
     Log.Otel.info "OTLP exporter stopped"
   end;
+  Opentelemetry_client_cohttp_eio.reset_tick_health ();
   Atomic.set exporter_active false;
   Atomic.set initialized false;
   Atomic.set _last_successful_export None;

--- a/lib/otel_spans/otel_spans.mli
+++ b/lib/otel_spans/otel_spans.mli
@@ -12,6 +12,13 @@ val init : unit -> unit
 (** [is_exporter_active ()] reports whether an OTLP exporter backend is registered. *)
 val is_exporter_active : unit -> bool
 
+(** [is_exporter_degraded ()] reports whether the exporter backend exists but
+    its tick fiber stopped after an unrecoverable internal error. *)
+val is_exporter_degraded : unit -> bool
+
+(** [last_degradation_error ()] returns the last exporter degradation cause. *)
+val last_degradation_error : unit -> string option
+
 (** [last_successful_export ()] returns the Unix timestamp of the last
     successful export, or [None] if the exporter has never been active. *)
 val last_successful_export : unit -> float option

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -81,6 +81,7 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
      Without this call [guarded_dispatch] runs with the identity wrapper (no
      span / no [tool_dispatch_total] metric). *)
   Tool_dispatch.set_span_wrapper Tool_telemetry.with_span;
+  Otel_metric_store.register_otel_source_once ();
   Otel_spans.setup_exporter ~sw env;
   Shutdown.register ~name:"otel_exporter" ~priority:20 Otel_spans.shutdown;
   (* Board_listener removed: filesystem-first principle.

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -201,6 +201,34 @@ let internal_mcp_auth_json ~base_path =
     ; "operator_next_action", `String operator_next_action
     ]
 
+let otel_health_json () =
+  let enabled = Otel_config.enabled in
+  let degraded = Otel_spans.is_exporter_degraded () in
+  let exporter_active = Otel_spans.is_exporter_active () in
+  let status =
+    if not enabled
+    then "disabled"
+    else if degraded
+    then "degraded"
+    else if exporter_active
+    then "ok"
+    else "inactive"
+  in
+  `Assoc
+    [ "enabled", `Bool enabled
+    ; "status", `String status
+    ; "endpoint", `String Otel_config.endpoint
+    ; "service_name", `String Otel_config.service_name
+    ; "exporter_active", `Bool exporter_active
+    ; "exporter_degraded", `Bool degraded
+    ; "consecutive_failures", `Int (Otel_spans.consecutive_failures ())
+    ; ( "last_successful_export_unix",
+        Json_util.float_opt_to_json (Otel_spans.last_successful_export ()) )
+    ; ( "last_degradation_error",
+        Json_util.string_opt_to_json (Otel_spans.last_degradation_error ()) )
+    ]
+;;
+
 let make_health_probe_fields ?(listener = "http/1.1") ?full_health_url
     ?(health_detail = "probe") request =
   let uptime_secs = health_uptime_secs () in
@@ -226,6 +254,7 @@ let make_health_probe_fields ?(listener = "http/1.1") ?full_health_url
       ("paths", Server_base_path_diagnostics.to_yojson path_diagnostics);
       ( "internal_mcp_auth"
       , internal_mcp_auth_json ~base_path:path_diagnostics.effective_base_path );
+      ("otel", otel_health_json ());
       ("uptime", `String (health_uptime_string uptime_secs));
       ("sse_clients", `Int (Sse.client_count ()));
       ("startup", Server_startup_state.to_yojson ());
@@ -389,6 +418,7 @@ let make_health_json ?(listener = "http/1.1") ?section_timings_ref request =
     ("paths", Server_base_path_diagnostics.to_yojson path_diagnostics);
     ( "internal_mcp_auth"
     , internal_mcp_auth_json ~base_path:path_diagnostics.effective_base_path );
+    ("otel", otel_health_json ());
     ( "runtime_truth"
     , runtime_truth_json ~build ~path_diagnostics ~keeper_fibers
         ~fd_accountant:fd_accountant_json );

--- a/test/deps/dune
+++ b/test/deps/dune
@@ -40,6 +40,7 @@
   (re_export masc.worker_execution_backend)
   (re_export masc.worker_execution_spec)
   (re_export masc.worker_runtime_config)
+  (re_export masc.otel_metrics)
   (re_export masc.otel_spans)
   (re_export otel_metric_test_store)
   (re_export masc.telemetry_coverage_gap)

--- a/test/test_llm_metric_bridge.ml
+++ b/test/test_llm_metric_bridge.ml
@@ -1,5 +1,5 @@
 module Bridge = Masc.Llm_metric_bridge
-module Prom = Otel_metric_store
+module Prom = Masc.Otel_metric_store
 
 let metric name ~labels =
   Prom.metric_value_or_zero name ~labels ()
@@ -9,6 +9,16 @@ let check_metric_delta label name ~labels ~before ~delta =
     label
     (before +. delta)
     (metric name ~labels)
+
+let same_labels expected actual =
+  List.sort compare expected = List.sort compare actual
+;;
+
+let find_otel_sample name ~labels =
+  Prom.otel_samples_for_test ()
+  |> List.find_opt (fun (sample : Otel_metrics.sample) ->
+    String.equal sample.name name && same_labels labels sample.labels)
+;;
 
 let test_metric_names_stable () =
   Alcotest.(check string)
@@ -63,6 +73,38 @@ let test_metric_names_stable () =
     "streaming inter chunk metric"
     "masc_llm_provider_streaming_inter_chunk_seconds"
     Prom.metric_llm_provider_streaming_inter_chunk
+
+let test_metric_store_exports_otel_samples () =
+  let model_id = Printf.sprintf "bridge-otel-sample-%d" (Unix.getpid ()) in
+  let labels = [ ("model", model_id) ] in
+  let before = metric Prom.metric_llm_provider_cache_hits ~labels in
+  Bridge.emit_cache_hit ~model_id;
+  match find_otel_sample Prom.metric_llm_provider_cache_hits ~labels with
+  | None -> Alcotest.fail "missing cache hit metric in OTel sample snapshot"
+  | Some sample ->
+    Alcotest.(check (float 0.0001))
+      "sample value reflects metric store"
+      (before +. 1.0)
+      sample.value;
+    (match sample.kind with
+     | Otel_metrics.Counter -> ()
+     | _ -> Alcotest.fail "cache hit metric must export as OTel counter")
+
+let test_metric_store_registers_otel_source_once () =
+  Alcotest.(check bool)
+    "source starts unregistered in this test process"
+    false
+    (Prom.otel_source_registered_for_test ());
+  Prom.register_otel_source_once ();
+  Alcotest.(check bool)
+    "source is marked registered"
+    true
+    (Prom.otel_source_registered_for_test ());
+  Prom.register_otel_source_once ();
+  Alcotest.(check bool)
+    "second registration stays registered"
+    true
+    (Prom.otel_source_registered_for_test ())
 
 let test_sink_records_oas_callbacks () =
   let sink : Llm_provider.Metrics.t = Bridge.make_sink () in
@@ -438,6 +480,10 @@ let () =
         [
           Alcotest.test_case "metric names are stable" `Quick
             test_metric_names_stable;
+          Alcotest.test_case "metric store exports OTel samples" `Quick
+            test_metric_store_exports_otel_samples;
+          Alcotest.test_case "metric store registers OTel source once" `Quick
+            test_metric_store_registers_otel_source_once;
           Alcotest.test_case "sink records OAS callbacks" `Quick
             test_sink_records_oas_callbacks;
           Alcotest.test_case "streaming metrics ignore invalid ms" `Quick

--- a/test/test_otel_tick_poison_source.ml
+++ b/test/test_otel_tick_poison_source.ml
@@ -66,6 +66,8 @@ let () =
   let src = source () in
   let helper = "let stop_tick_after_poisoned_mutex ~stop cause =" in
   let stop_flag = "Atomic.set stop true" in
+  let degraded_state = "Atomic.set tick_degraded_state true" in
+  let degradation_error = "Atomic.set last_tick_poisoned_error_state" in
   let degraded_log_prefix = "OTEL metrics \\" in
   let degraded_log_suffix = "export degraded until backend restart" in
   let poison_catch =
@@ -75,6 +77,8 @@ let () =
   let global_pool_post = "Masc_http_client.post_sync" in
   assert_contains ~label:"poison helper" src helper;
   assert_contains ~label:"poison helper stops tick loop" src stop_flag;
+  assert_contains ~label:"poison helper records degraded state" src degraded_state;
+  assert_contains ~label:"poison helper records degradation cause" src degradation_error;
   assert_contains ~label:"poison log explains degradation prefix" src degraded_log_prefix;
   assert_contains ~label:"poison log explains degradation suffix" src degraded_log_suffix;
   assert_contains ~label:"tick catch delegates to poison helper" src poison_catch;

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1493,6 +1493,23 @@ let test_health_json_surfaces_internal_mcp_auth_diagnostics () =
   Alcotest.(check bool) "mismatch reason is explicit" true
     (List.mem "token_hash_mismatch" (missing_names mismatch))
 
+let check_otel_health_shape label json =
+  let open Yojson.Safe.Util in
+  let otel = json |> member "otel" in
+  Alcotest.(check bool) (label ^ " otel object") true
+    (match otel with `Assoc _ -> true | _ -> false);
+  ignore (otel |> member "enabled" |> to_bool);
+  Alcotest.(check bool) (label ^ " otel status bounded") true
+    (List.mem
+       (otel |> member "status" |> to_string)
+       [ "ok"; "inactive"; "degraded"; "disabled" ]);
+  ignore (otel |> member "endpoint" |> to_string);
+  ignore (otel |> member "service_name" |> to_string);
+  ignore (otel |> member "exporter_active" |> to_bool);
+  ignore (otel |> member "exporter_degraded" |> to_bool);
+  ignore (otel |> member "consecutive_failures" |> to_int)
+;;
+
 let test_health_response_default_is_light_probe () =
   let request = Httpun.Request.create `GET "/health" in
   let json = Server_routes_http_runtime.make_health_response_json request in
@@ -1507,6 +1524,7 @@ let test_health_response_default_is_light_probe () =
     (match json |> member "paths" with `Assoc _ -> true | _ -> false);
   Alcotest.(check bool) "internal mcp auth stays on default health" true
     (match json |> member "internal_mcp_auth" with `Assoc _ -> true | _ -> false);
+  check_otel_health_shape "default health" json;
   Alcotest.(check bool) "default health skips reaction ledger" true
     (json |> member "keeper_reaction_ledger" = `Null);
   Alcotest.(check bool) "default health skips cdal snapshot" true
@@ -1534,6 +1552,7 @@ let test_health_response_full_query_uses_snapshot_cache () =
           let open Yojson.Safe.Util in
           Alcotest.(check string) "full health detail" "full"
             (first |> member "health_detail" |> to_string);
+          check_otel_health_shape "full health" first;
           Alcotest.(check bool) "full health includes snapshot metadata" true
             (match first |> member "full_health_snapshot" with
              | `Assoc _ -> true


### PR DESCRIPTION
## Summary

- Wire `Llm_metric_bridge` back to `Otel_metric_store` instead of the retired no-op bridge.
- Export `Otel_metric_store` snapshots through `Otel_metrics.register_source` during server bootstrap.
- Surface OTel exporter health in `/health`, including degraded tick state and last poison cause.
- Stop the OTel tick fiber after `Eio.Mutex.Poisoned` so the log does not repeat every tick.

## Validation

- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=/private/tmp/masc-mcp-otel-complete-20260606 dune build --root . test/test_llm_metric_bridge.exe test/test_otel_tick_poison_source.exe test/test_otel_trace_context.exe test/test_server_runtime_bootstrap.exe --display=short -j 1`
- `/private/tmp/masc-mcp-otel-complete-20260606/default/test/test_llm_metric_bridge.exe`
- `/private/tmp/masc-mcp-otel-complete-20260606/default/test/test_otel_tick_poison_source.exe`
- `/private/tmp/masc-mcp-otel-complete-20260606/default/test/test_otel_trace_context.exe`
- `/private/tmp/masc-mcp-otel-complete-20260606/default/test/test_server_runtime_bootstrap.exe test bootstrap 17,29,30,31`
- `git diff --cached --check`
- `git diff --check`
- `rg -n "<<<<<<<|=======|>>>>>>>|\\|\\|\\|\\|\\|\\|\\|" test/test_server_runtime_bootstrap.ml test/test_llm_metric_bridge.ml`
