### PR TITLE
fix(ci): refresh keeper boundary matrix path

### DIFF
--- a/docs/design/keeper-tool-boundary-matrix.md
+++ b/docs/design/keeper-tool-boundary-matrix.md
@@ -128,8 +128,8 @@ Each path below must appear exactly once and use one owner from the table above.
 - `lib/keeper_tool_execute_shell_ir/keeper_tool_execute_shell_ir.mli` - shell-surface
 - `lib/keeper/keeper_tool_execute_path.ml` - shell-surface
 - `lib/keeper/keeper_tool_execute_path.mli` - shell-surface
-- `lib/keeper/keeper_tool_execute_repo_readiness.ml` - shell-surface
-- `lib/keeper/keeper_tool_execute_repo_readiness.mli` - shell-surface
+- `lib/keeper/keeper_sandbox_repo_lifecycle.ml` - shell-surface
+- `lib/keeper/keeper_sandbox_repo_lifecycle.mli` - shell-surface
 - `lib/keeper/keeper_tool_execute_readonly_policy.ml` - shell-surface
 - `lib/keeper/keeper_tool_execute_readonly_policy.mli` - shell-surface
 - `lib/keeper/keeper_tool_execute_runtime_paths.ml` - shell-surface


### PR DESCRIPTION
## Summary

- Refresh `docs/design/keeper-tool-boundary-matrix.md` after the repo-readiness module rename.
- Replace stale `keeper_tool_execute_repo_readiness.{ml,mli}` entries with `keeper_sandbox_repo_lifecycle.{ml,mli}`.

## Validation

- `scripts/audit-keeper-tool-boundary-matrix.sh`
- `git diff --check origin/main..HEAD`
