### PR TITLE
fix(keeper): clarify empty tool argument failures

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -96,12 +96,18 @@ let json_value_shape_for_log = function
   | `Null -> "null"
 
 let tool_input_shape_for_log = function
+  | `Assoc [] -> "object:0"
   | `Assoc fields ->
     fields
     |> List.sort (fun (left, _) (right, _) -> String.compare left right)
     |> List.map (fun (key, value) -> key ^ "=" ^ json_value_shape_for_log value)
     |> String.concat ","
   | other -> json_value_shape_for_log other
+
+let tool_input_keys_for_log = function
+  | `Assoc [] -> "-"
+  | `Assoc pairs -> String.concat "," (List.map fst pairs)
+  | _ -> "-"
 
 let one_line_preview_for_log text =
   text
@@ -503,10 +509,7 @@ let make_hooks
              | exception _ -> (content, None))
           | Error { Agent_sdk.Types.message; _ } -> (message, None)
         in
-        let input_keys = match input with
-          | `Assoc pairs -> String.concat "," (List.map fst pairs)
-          | _ -> "-"
-        in
+        let input_keys = tool_input_keys_for_log input in
         let outcome, out_len = match output with
           | Ok { Agent_sdk.Types.content; _ } -> Tool_result.Ok, String.length content
           | Error { Agent_sdk.Types.message; _ } -> Tool_result.Error, String.length message
@@ -840,3 +843,8 @@ let hook_introspection_json
     ?max_cost_usd
     ~destructive_check
     ()
+
+module For_testing = struct
+  let tool_input_shape_for_log = tool_input_shape_for_log
+  let tool_input_keys_for_log = tool_input_keys_for_log
+end

--- a/lib/keeper/keeper_hooks_oas.mli
+++ b/lib/keeper/keeper_hooks_oas.mli
@@ -189,3 +189,8 @@ val hook_introspection_json :
   ?max_cost_usd:float -> ?destructive_check:bool -> unit -> Yojson.Safe.t
 (** JSON snapshot describing which hooks are active for the dashboard
     diagnostics surface. *)
+
+module For_testing : sig
+  val tool_input_shape_for_log : Yojson.Safe.t -> string
+  val tool_input_keys_for_log : Yojson.Safe.t -> string
+end

--- a/lib/tool_input_validation.ml
+++ b/lib/tool_input_validation.ml
@@ -312,6 +312,10 @@ let reject_validation ~name ~reason ~message =
              [ "error", `String message
              ; "validation", `String "oas_tool_middleware"
              ; "reason", `String reason
+             ; ( "failure_class"
+               , `String
+                   (Tool_result.tool_failure_class_to_string
+                      Tool_result.Policy_rejection) )
              ]
        ; tool_name = name
        ; duration_ms = 0.0
@@ -443,6 +447,11 @@ let validation_action ?schema ~name ~args () : Tool_dispatch.pre_hook_action =
                `Assoc
                  [ "error", `String message
                  ; "validation", `String "oas_tool_middleware"
+                 ; "reason", `String "invalid_args"
+                 ; ( "failure_class"
+                   , `String
+                       (Tool_result.tool_failure_class_to_string
+                          Tool_result.Policy_rejection) )
                  ]
            ; tool_name = name
            ; duration_ms = 0.0

--- a/test/dune
+++ b/test/dune
@@ -101,6 +101,7 @@
   test_reward_advice_artifact
   test_masc_oas_bridge_timeout_guard
   test_keeper_llm_bridge
+  test_keeper_hooks_oas_log_shape
   test_keeper_tool_use_failure_counter
   test_keeper_compaction_outcome_counter
   test_keeper_usage_trust_counter
@@ -350,6 +351,7 @@
   test_reward_advice_artifact
   test_masc_oas_bridge_timeout_guard
   test_keeper_llm_bridge
+  test_keeper_hooks_oas_log_shape
   test_keeper_tool_use_failure_counter
   test_keeper_compaction_outcome_counter
   test_keeper_usage_trust_counter

--- a/test/test_keeper_hooks_oas_log_shape.ml
+++ b/test/test_keeper_hooks_oas_log_shape.ml
@@ -1,0 +1,32 @@
+open Alcotest
+
+module Under_test = Masc.Keeper_hooks_oas.For_testing
+
+let test_empty_tool_args_are_explicit_object_shape () =
+  check string "empty object shape" "object:0"
+    (Under_test.tool_input_shape_for_log (`Assoc []));
+  check string "empty object keys" "-"
+    (Under_test.tool_input_keys_for_log (`Assoc []))
+
+let test_tool_arg_shapes_keep_field_names () =
+  let input =
+    `Assoc
+      [ "argv", `List [ `String "status"; `String "--short" ]
+      ; "cwd", `String "repos/masc-mcp"
+      ; "executable", `String "git"
+      ]
+  in
+  check string "shape" "argv=array:2,cwd=string:14,executable=string:3"
+    (Under_test.tool_input_shape_for_log input);
+  check string "keys preserve input order" "argv,cwd,executable"
+    (Under_test.tool_input_keys_for_log input)
+
+let () =
+  run "keeper_hooks_oas_log_shape"
+    [ ( "tool-input-log-shape"
+      , [ test_case "empty args are object:0" `Quick
+            test_empty_tool_args_are_explicit_object_shape
+        ; test_case "field shapes are explicit" `Quick
+            test_tool_arg_shapes_keep_field_names
+        ] )
+    ]

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -460,6 +460,21 @@ let assoc_string key json =
   | `String value -> value
   | _ -> failwith ("expected string field: " ^ key)
 
+let assert_policy_validation_payload ~label result =
+  let data = Tool_result.data result in
+  Alcotest.(check string)
+    (label ^ " reason")
+    "invalid_args"
+    (assoc_string "reason" data);
+  Alcotest.(check string)
+    (label ^ " failure_class payload")
+    "policy_rejection"
+    (assoc_string "failure_class" data);
+  Alcotest.(check bool)
+    (label ^ " typed failure_class")
+    true
+    (Tool_result.failure_class result = Some Tool_result.Policy_rejection)
+
 let test_registered_hook_tool_edit_file_patch_args () =
   let args =
     `Assoc
@@ -574,6 +589,27 @@ let test_tool_execute_schema_exposes_typed_boundary () =
     true
     (Option.is_none (param_by_name legacy_background_flag_name params))
 
+let test_validate_args_tool_execute_rejects_empty_object_with_policy_class () =
+  let args = `Assoc [] in
+  match
+    Tool_input_validation.validate_args
+      ~schema:tool_execute_schema
+      ~name:"tool_execute"
+      ~args
+      ()
+  with
+  | Error result ->
+    let msg = Yojson.Safe.to_string (Tool_result.data result) in
+    Alcotest.(check bool)
+      "empty Execute mentions exact-one-of"
+      true
+      (string_contains msg "exactly one of");
+    assert_policy_validation_payload ~label:"empty Execute" result
+  | Ok forwarded ->
+    Alcotest.failf
+      "expected empty tool_execute args to fail, got %s"
+      (Yojson.Safe.to_string forwarded)
+
 let test_validate_args_tool_execute_rejects_cmd_string () =
   let args = `Assoc [ "cmd", `String "pwd" ] in
   match
@@ -590,6 +626,7 @@ let test_validate_args_tool_execute_rejects_cmd_string () =
       "validation error returned"
       true
       (String.length msg > 0);
+    assert_policy_validation_payload ~label:"cmd string" result;
     Alcotest.(check bool)
       "validation error points to typed argv"
       true
@@ -1535,6 +1572,8 @@ let () =
         test_registered_hook_keeper_board_post_accepts_sources_array;
       Alcotest.test_case "tool_execute exposes typed boundary" `Quick
         test_tool_execute_schema_exposes_typed_boundary;
+      Alcotest.test_case "tool_execute rejects empty args with class" `Quick
+        test_validate_args_tool_execute_rejects_empty_object_with_policy_class;
       Alcotest.test_case "tool_execute rejects cmd string" `Quick
         test_validate_args_tool_execute_rejects_cmd_string;
       Alcotest.test_case "tool_execute rejects command string" `Quick


### PR DESCRIPTION
## Summary
- Make empty keeper tool-call args log as an explicit object shape (`object:0`) instead of an empty-looking shape.
- Include `reason=invalid_args` and `failure_class=policy_rejection` in OAS middleware validation reject payloads.
- Add regression coverage for empty `Execute` args and keeper hook log shape rendering.

## Product impact
Operators can distinguish an LLM malformed empty `Execute` call from runtime/cwd/Docker execution failures. Dashboard and failure classifiers get a typed policy-rejection payload instead of relying on string inference.

## Evidence
- `scripts/dune-local.sh build test/test_tool_input_validation.exe test/test_keeper_hooks_oas_log_shape.exe`
- `./_build/default/test/test_tool_input_validation.exe`
- `./_build/default/test/test_keeper_hooks_oas_log_shape.exe`
- `opam exec -- ocamlformat --check lib/keeper/keeper_hooks_oas.ml lib/keeper/keeper_hooks_oas.mli lib/tool_input_validation.ml test/test_tool_input_validation.ml test/test_keeper_hooks_oas_log_shape.ml`
- `git diff --check`

## Direct evidence
```yaml
schema_version: 1
local_checks:
  dune_build: pass
  test_tool_input_validation: pass_64_tests
  test_keeper_hooks_oas_log_shape: pass_2_tests
  ocamlformat_changed_files: pass
  diff_check: pass
```

## Review evidence
Not requested.

## Linked issue
None.