### PR TITLE
fix(dashboard): surface runtime provider reachability

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -1815,8 +1815,46 @@ interface DashboardRuntimeProbeAssessment {
   limitation?: string | null
 }
 
-interface DashboardRuntimeProbePayload {
+export interface DashboardRuntimeProviderProbe {
+  runtime_id?: string | null
+  provider_id?: string | null
+  provider_display_name?: string | null
+  model_id?: string | null
+  model_api_name?: string | null
+  protocol?: string | null
+  runtime_kind?: string | null
+  transport?: string | null
+  auth_kind?: string | null
+  credential_required?: boolean | null
+  auth_present?: boolean | null
+  status?: string | null
+  reachable?: boolean | null
+  http_status?: number | null
+  latency_ms?: number | null
+  model_count?: number | null
+  content_type?: string | null
+  downloaded_bytes?: number | null
+  endpoint_url?: string | null
+  probe_url?: string | null
+  error?: string | null
+  checked_at?: string | null
+}
+
+export interface DashboardRuntimeProviderProbeSummary {
+  runtimes?: number
+  probed?: number
+  reachable?: number
+  failed?: number
+  skipped?: number
+  default_runtime_id?: string | null
+}
+
+export interface DashboardRuntimeProbePayload {
   source?: string
+  status?: string | null
+  checked_at?: string | null
+  summary?: DashboardRuntimeProviderProbeSummary | null
+  providers?: DashboardRuntimeProviderProbe[]
   server_url?: string
   ps_endpoint?: string
   generate_endpoint?: string

--- a/dashboard/src/components/runtime-monitor.test.ts
+++ b/dashboard/src/components/runtime-monitor.test.ts
@@ -4,6 +4,7 @@ import { render } from 'preact'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const apiMocks = vi.hoisted(() => ({
+  fetchDashboardRuntimeProbe: vi.fn(),
   fetchRuntimeProviders: vi.fn(),
   fetchRuntimeModelMetrics: vi.fn(),
 }))
@@ -75,6 +76,43 @@ describe('RuntimeMonitor', () => {
       latency_buckets: [],
       models: [],
     })
+    apiMocks.fetchDashboardRuntimeProbe.mockReset().mockResolvedValue({
+      generated_at: '2026-06-06T02:47:31Z',
+      refreshed_at_unix: 1780714051,
+      cache_ttl_sec: 30,
+      cache_age_sec: 0,
+      cache_hit: false,
+      probe: {
+        source: 'runtime.toml',
+        status: 'reachable',
+        checked_at: '2026-06-06T02:47:31Z',
+        probe_ok: true,
+        summary: {
+          runtimes: 1,
+          probed: 1,
+          reachable: 1,
+          failed: 0,
+          skipped: 0,
+          default_runtime_id: 'runpod_mtp.qwen',
+        },
+        providers: [
+          {
+            runtime_id: 'runpod_mtp.qwen',
+            provider_id: 'runpod_mtp',
+            model_api_name: 'Qwen/Qwen3-32B',
+            status: 'reachable',
+            reachable: true,
+            http_status: 200,
+            latency_ms: 42.5,
+            model_count: 1,
+            credential_required: true,
+            auth_present: true,
+            probe_url: 'https://example.invalid/v1/models',
+          },
+        ],
+        errors: [],
+      },
+    })
     container = document.createElement('div')
     document.body.appendChild(container)
   })
@@ -96,5 +134,22 @@ describe('RuntimeMonitor', () => {
     expect(container.textContent).toContain('runpod_mtp.qwen')
     expect(container.textContent).toContain('runpod_mtp')
     expect(container.textContent).toContain('Qwen/Qwen3-32B')
+  })
+
+  it('separates configured inventory from live provider reachability', async () => {
+    const { RuntimeMonitor } = await import('./runtime-monitor')
+
+    render(h(RuntimeMonitor, {}), container)
+    await waitFor(
+      () => container.textContent?.includes('runpod_mtp.qwen') ?? false,
+      'live reachability summary',
+    )
+
+    expect(container.textContent).toContain('available')
+    expect(container.textContent).toContain('live reachable')
+    expect(container.textContent).toContain('http · 200')
+    expect(container.textContent).toContain('latency · 42.5 ms')
+    expect(container.textContent).toContain('models · 1')
+    expect(container.textContent).toContain('auth · present')
   })
 })

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -2,10 +2,13 @@ import { html } from 'htm/preact'
 import { useEffect } from 'preact/hooks'
 import { useSignal } from '@preact/signals'
 import {
+  fetchDashboardRuntimeProbe,
   fetchRuntimeModelMetrics,
   fetchRuntimeProviders,
+  type DashboardRuntimeProbeResponse,
   type DashboardRuntimeModelMetric,
   type DashboardRuntimeModelMetricsResponse,
+  type DashboardRuntimeProviderProbe,
   type DashboardRuntimeProviderSnapshot,
   type DashboardRuntimeProvidersResponse,
 } from '../api/dashboard'
@@ -21,7 +24,7 @@ import { Table, type TableColumn } from './common/table'
 import type { ManagedAsyncResource } from '../lib/async-state'
 import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
 import { formatCost, formatNumber, formatPct1 } from '../lib/format-number'
-import { MISSING_DATA_DASH } from '../lib/format-string'
+import { errorToString, MISSING_DATA_DASH } from '../lib/format-string'
 import { formatTimeHms } from '../lib/format-time'
 
 /**
@@ -72,6 +75,8 @@ function sortModelMetricsByUrgency(
 interface RuntimeData {
   providers: DashboardRuntimeProvidersResponse | null
   metrics: DashboardRuntimeModelMetricsResponse | null
+  probe: DashboardRuntimeProbeResponse | null
+  probeError: string | null
 }
 
 const COVERAGE_PRIORITY: Record<string, number> = {
@@ -105,13 +110,21 @@ const COVERAGE_STAGE_LABELS: Record<string, string> = {
   unknown: 'unknown stage',
 }
 
-async function loadRuntimeData(resource: ManagedAsyncResource<RuntimeData>, windowMinutes: number) {
+async function loadRuntimeData(
+  resource: ManagedAsyncResource<RuntimeData>,
+  windowMinutes: number,
+  forceProbe = false,
+) {
   await resource.load(async (signal) => {
-    const [providers, metrics] = await Promise.all([
+    const probeResult = fetchDashboardRuntimeProbe(forceProbe, { signal })
+      .then(probe => ({ probe, probeError: null }))
+      .catch(error => ({ probe: null, probeError: errorToString(error) }))
+    const [providers, metrics, probe] = await Promise.all([
       fetchRuntimeProviders({ signal }),
       fetchRuntimeModelMetrics(windowMinutes, 5, { signal }),
+      probeResult,
     ])
-    return { providers, metrics }
+    return { providers, metrics, probe: probe.probe, probeError: probe.probeError }
   })
 }
 
@@ -141,6 +154,72 @@ function runtimeStatusLabel(provider: DashboardRuntimeProviderSnapshot): string 
   if (provider.available === true) return 'available'
   if (provider.available === false) return 'unavailable'
   return provider.discovery?.healthy === false ? 'degraded' : 'unknown'
+}
+
+function providerProbeKey(probe: DashboardRuntimeProviderProbe): string | null {
+  return probe.runtime_id ?? null
+}
+
+function providerRuntimeKey(provider: DashboardRuntimeProviderSnapshot): string {
+  return provider.runtime_id ?? provider.provider
+}
+
+function runtimeProbeTone(probe: DashboardRuntimeProviderProbe | null | undefined): string {
+  if (!probe) return 'neutral'
+  if (probe.reachable === true) return 'ok'
+  if (probe.status === 'skipped_cli') return 'neutral'
+  if (probe.status === 'missing_auth' || probe.status === 'auth_failed') return 'bad'
+  if (probe.status === 'network_error' || probe.status === 'server_error') return 'bad'
+  if (probe.reachable === false) return 'bad'
+  return 'warn'
+}
+
+function runtimeProbeLabel(probe: DashboardRuntimeProviderProbe | null | undefined): string {
+  if (!probe) return 'not probed'
+  switch (probe.status) {
+    case 'reachable':
+      return 'reachable'
+    case 'missing_auth':
+      return 'missing auth'
+    case 'auth_failed':
+      return 'auth failed'
+    case 'network_error':
+      return 'network error'
+    case 'server_error':
+      return 'server error'
+    case 'endpoint_not_found':
+      return 'not found'
+    case 'skipped_cli':
+      return 'cli skipped'
+    case 'invalid_endpoint':
+      return 'bad endpoint'
+    default:
+      return probe.status ?? 'unknown'
+  }
+}
+
+function runtimeProbeSummaryText(probe: DashboardRuntimeProbeResponse | null): string {
+  const summary = probe?.probe?.summary
+  if (!summary) return 'live probe 없음'
+  return `Reachable ${summary.reachable ?? 0} · Failed ${summary.failed ?? 0} · Skipped ${summary.skipped ?? 0}`
+}
+
+function providerProbeMap(probe: DashboardRuntimeProbeResponse | null): Map<string, DashboardRuntimeProviderProbe> {
+  const map = new Map<string, DashboardRuntimeProviderProbe>()
+  for (const item of probe?.probe?.providers ?? []) {
+    const key = providerProbeKey(item)
+    if (key) map.set(key, item)
+  }
+  return map
+}
+
+function fmtProbeLatency(probe: DashboardRuntimeProviderProbe | null | undefined): string {
+  if (!probe || probe.latency_ms == null) return MISSING_DATA_DASH
+  return `${formatNumber(probe.latency_ms, 1)} ms`
+}
+
+function fmtProbeHttpStatus(probe: DashboardRuntimeProviderProbe | null | undefined): string {
+  return probe?.http_status == null ? MISSING_DATA_DASH : String(probe.http_status)
 }
 
 function modelMetricTone(metric: DashboardRuntimeModelMetric): string {
@@ -356,7 +435,7 @@ export function RuntimeMonitor() {
   const expandedModel = useSignal<string | null>(null)
   const modelSearch = useSignal('')
 
-  const load = () => loadRuntimeData(resource, windowMinutes.value)
+  const load = (forceProbe = false) => loadRuntimeData(resource, windowMinutes.value, forceProbe)
 
   useEffect(() => {
     void loadRuntimeData(resource, windowMinutes.value)
@@ -368,6 +447,9 @@ export function RuntimeMonitor() {
   const current = resource.state.value
   const providers = current.data?.providers ?? null
   const metrics = current.data?.metrics ?? null
+  const probe = current.data?.probe ?? null
+  const probeError = current.data?.probeError ?? null
+  const providerProbes = providerProbeMap(probe)
 
   return html`
     <div class="flex flex-col gap-4">
@@ -388,7 +470,7 @@ export function RuntimeMonitor() {
           variant="ghost"
           size="sm"
           ariaLabel="runtime snapshot 새로고침"
-          onClick=${() => void load()}
+          onClick=${() => void load(true)}
         >새로고침<//>
         ${current.loading ? html`<span class="text-xs text-[var(--color-fg-muted)]" role="status">로딩 중...</span>` : null}
       </div>
@@ -402,7 +484,12 @@ export function RuntimeMonitor() {
         : null}
 
       <${SectionCard} label="런타임 상태">
-        <div class="grid grid-cols-2 gap-3 mb-4">
+        ${probeError
+          ? html`<div class="mb-3 rounded-[var(--r-1)] border border-[var(--status-warn)] bg-[var(--status-warn)]/5 px-3 py-2 text-xs text-[var(--status-warn)]">
+              live probe 실패 · ${probeError}
+            </div>`
+          : null}
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-3 mb-4">
           <${StatTile}
             label="런타임"
             value=${String(providers?.summary?.runtimes ?? providers?.providers.length ?? 0)}
@@ -413,27 +500,46 @@ export function RuntimeMonitor() {
             value=${String(providers?.summary?.local_models ?? 0)}
             delta=${{ direction: 'flat', text: `Cloud ${providers?.summary?.cloud_models ?? 0} · CLI ${providers?.summary?.cli_models ?? 0}` }}
           />
+          <${StatTile}
+            label="Live reachability"
+            value=${String(probe?.probe?.summary?.reachable ?? 0)}
+            delta=${{ direction: probe?.probe?.summary?.failed ? 'down' : 'flat', text: runtimeProbeSummaryText(probe) }}
+          />
         </div>
         <div class="flex flex-col gap-3">
           ${(providers?.providers ?? []).length > 0
-            ? providers?.providers.map(provider => html`
+            ? providers?.providers.map(provider => {
+                const liveProbe = providerProbes.get(providerRuntimeKey(provider)) ?? null
+                return html`
                 <article class="p-4 rounded-[var(--r-1)] border border-card-border bg-card/40 backdrop-blur-sm shadow-[var(--shadow-1)] flex flex-col gap-2">
                   <div class="flex justify-between gap-3 items-start flex-wrap">
                     <div class="grid gap-1">
                       <strong class="text-sm text-text-strong">${provider.runtime_id ?? provider.provider}</strong>
                       <span class="text-xs text-text-muted">${provider.provider_id ?? '(unknown provider)'}</span>
                     </div>
-                    <${StatusChip}
-                      label=${runtimeStatusLabel(provider)}
-                      tone=${runtimeProviderTone(provider)}
-                    />
+                    <div class="flex items-center gap-2 flex-wrap justify-end">
+                      <${StatusChip} tone=${runtimeProviderTone(provider)}>${runtimeStatusLabel(provider)}<//>
+                      <${StatusChip} tone=${runtimeProbeTone(liveProbe)} uppercase=${false}>live ${runtimeProbeLabel(liveProbe)}<//>
+                    </div>
                   </div>
                   <div class="grid grid-cols-2 gap-3 text-xs text-text-body">
                     <div>model · ${provider.model_api_name ?? provider.model_id ?? '-'}</div>
                     <div>default · ${provider.is_default_runtime ? 'yes' : 'no'}</div>
                     <div>transport · ${provider.runtime_kind ?? provider.transport ?? '-'}</div>
                     <div>ctx · ${formatNumber(provider.max_context)}</div>
+                    <div>http · ${fmtProbeHttpStatus(liveProbe)}</div>
+                    <div>latency · ${fmtProbeLatency(liveProbe)}</div>
+                    <div>models · ${formatNumber(liveProbe?.model_count)}</div>
+                    <div>auth · ${liveProbe?.credential_required ? (liveProbe.auth_present ? 'present' : 'missing') : 'none'}</div>
                   </div>
+                  ${liveProbe?.probe_url || provider.endpoint_url
+                    ? html`<div class="truncate text-2xs text-text-muted" title=${liveProbe?.probe_url ?? provider.endpoint_url ?? ''}>
+                        probe · ${liveProbe?.probe_url ?? provider.endpoint_url}
+                      </div>`
+                    : null}
+                  ${liveProbe?.error
+                    ? html`<div class="text-2xs text-[var(--status-bad)]">${liveProbe.error}</div>`
+                    : null}
                   ${provider.discovery
                     ? html`<div class="grid grid-cols-2 gap-3 text-xs text-text-body pt-2 border-t border-card-border/50">
                         <div>discovery · ${provider.discovery.healthy ? 'healthy' : 'degraded'}</div>
@@ -442,7 +548,7 @@ export function RuntimeMonitor() {
                       </div>`
                     : null}
                 </article>
-              `)
+              `})
             : html`<${EmptyState} message="runtime snapshot이 없습니다." compact />`}
         </div>
       <//>

--- a/dashboard/src/components/tools/config-resolution-panel.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.ts
@@ -320,6 +320,33 @@ function probeSignalLabel(signal: string | null | undefined): string {
   }
 }
 
+function providerProbeTone(status: string | null | undefined, reachable: boolean | null | undefined): string {
+  if (reachable === true) return 'ok'
+  if (status === 'skipped_cli') return 'neutral'
+  if (reachable === false) return 'bad'
+  return 'neutral'
+}
+
+function providerProbeLabel(status: string | null | undefined, reachable: boolean | null | undefined): string {
+  if (reachable === true) return 'reachable'
+  switch (status) {
+    case 'missing_auth':
+      return 'missing auth'
+    case 'auth_failed':
+      return 'auth failed'
+    case 'network_error':
+      return 'network error'
+    case 'server_error':
+      return 'server error'
+    case 'endpoint_not_found':
+      return 'not found'
+    case 'skipped_cli':
+      return 'cli skipped'
+    default:
+      return status ?? 'unknown'
+  }
+}
+
 const KEEPER_RUNTIME_ROWS: Array<{
   key: keyof KeeperRuntimeResolved
   label: string
@@ -453,12 +480,19 @@ function RuntimeProbePanel() {
   const firstRun = probe?.runs?.[0] ?? null
   const assessment = probe?.kv_cache_assessment ?? null
   const signal = assessment?.signal ?? null
+  const providerProbes = probe?.providers ?? []
+  const providerSummary = probe?.summary ?? null
+  const isProviderProbe = providerProbes.length > 0
 
   return html`
     <${ConfigCard} class="mt-4 px-4 py-4">
       <div class="mb-3 flex flex-wrap items-center gap-2">
-        <div class="text-2xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">ollama warm / kv probe</div>
-        <${StatusChip} tone=${probeTone(signal, probe?.probe_ok)}>${probeSignalLabel(signal)}<//>
+        <div class="text-2xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">
+          ${isProviderProbe ? 'provider reachability' : 'ollama warm / kv probe'}
+        </div>
+        <${StatusChip} tone=${isProviderProbe ? (probe?.probe_ok === false ? 'bad' : 'ok') : probeTone(signal, probe?.probe_ok)}>
+          ${isProviderProbe ? (probe?.status ?? 'provider probe') : probeSignalLabel(signal)}
+        <//>
         ${state.value.data?.cache_hit !== undefined
           ? html`
               <${StatusChip} tone="neutral" uppercase=${false}>${state.value.data.cache_hit ? 'cached' : 'fresh'} · age ${formatNumber(state.value.data.cache_age_sec, 1)}s<//>
@@ -491,33 +525,65 @@ function RuntimeProbePanel() {
 
       ${probe
         ? html`
-            <div class="grid gap-3 md:grid-cols-2">
-              <${RuntimeMetaRow} label="effective model" value=${probe.effective_model ?? MISSING_DATA_DASH} />
-              <${RuntimeMetaRow} label="server" value=${probe.server_url ?? MISSING_DATA_DASH} />
-              <${RuntimeMetaRow} label="loaded before/after" value=${`${fmtBoolean(probe.model_loaded_before_probe)} / ${fmtBoolean(probe.model_loaded_after_probe)}`} />
-              <${RuntimeMetaRow}
-                label="first run load"
-                value=${`${formatNumber(firstRun?.load_duration_ms, 1)} ms`}
-              />
-              <${RuntimeMetaRow}
-                label="prompt tok/s"
-                value=${`${formatNumber(firstRun?.prompt_tokens_per_second, 1)} tok/s`}
-              />
-              <${RuntimeMetaRow}
-                label="generation tok/s"
-                value=${`${formatNumber(firstRun?.generation_tokens_per_second, 1)} tok/s`}
-              />
-              <${RuntimeMetaRow}
-                label="prompt eval delta"
-                value=${assessment?.prompt_eval_duration_reduction_ratio != null
-                  ? `${formatNumber(assessment.prompt_eval_duration_reduction_ratio * 100, 1)}%`
-                  : MISSING_DATA_DASH}
-              />
-              <${RuntimeMetaRow}
-                label="loaded models"
-                value=${String(probe.loaded_models_after?.length ?? probe.loaded_models_before?.length ?? 0)}
-              />
-            </div>
+            ${isProviderProbe
+              ? html`
+                  <div class="grid gap-3 md:grid-cols-2">
+                    <${RuntimeMetaRow} label="status" value=${probe.status ?? MISSING_DATA_DASH} />
+                    <${RuntimeMetaRow} label="checked at" value=${probe.checked_at ?? MISSING_DATA_DASH} />
+                    <${RuntimeMetaRow} label="reachable" value=${String(providerSummary?.reachable ?? 0)} />
+                    <${RuntimeMetaRow} label="failed" value=${String(providerSummary?.failed ?? 0)} />
+                    <${RuntimeMetaRow} label="skipped" value=${String(providerSummary?.skipped ?? 0)} />
+                    <${RuntimeMetaRow} label="default runtime" value=${providerSummary?.default_runtime_id ?? MISSING_DATA_DASH} />
+                  </div>
+                  <div class="mt-3 flex flex-col gap-2">
+                    ${providerProbes.map(item => html`
+                      <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-hover)] px-3 py-2">
+                        <div class="flex flex-wrap items-center justify-between gap-2">
+                          <div class="min-w-0">
+                            <div class="truncate text-xs font-medium text-[var(--color-fg-primary)]">${item.runtime_id ?? item.provider_id ?? '(unknown runtime)'}</div>
+                            <div class="truncate text-2xs text-[var(--color-fg-muted)]">${item.probe_url ?? item.endpoint_url ?? MISSING_DATA_DASH}</div>
+                          </div>
+                          <div class="flex items-center gap-2">
+                            <${StatusChip} tone=${providerProbeTone(item.status, item.reachable)} uppercase=${false}>${providerProbeLabel(item.status, item.reachable)}<//>
+                            <span class="font-mono text-2xs text-[var(--color-fg-muted)]">${item.http_status ?? MISSING_DATA_DASH} · ${item.latency_ms == null ? MISSING_DATA_DASH : `${formatNumber(item.latency_ms, 1)}ms`}</span>
+                          </div>
+                        </div>
+                        ${item.error
+                          ? html`<div class="mt-2 text-2xs text-[var(--rose-fg)]">${item.error}</div>`
+                          : null}
+                      </div>
+                    `)}
+                  </div>
+                `
+              : html`
+                  <div class="grid gap-3 md:grid-cols-2">
+                    <${RuntimeMetaRow} label="effective model" value=${probe.effective_model ?? MISSING_DATA_DASH} />
+                    <${RuntimeMetaRow} label="server" value=${probe.server_url ?? MISSING_DATA_DASH} />
+                    <${RuntimeMetaRow} label="loaded before/after" value=${`${fmtBoolean(probe.model_loaded_before_probe)} / ${fmtBoolean(probe.model_loaded_after_probe)}`} />
+                    <${RuntimeMetaRow}
+                      label="first run load"
+                      value=${`${formatNumber(firstRun?.load_duration_ms, 1)} ms`}
+                    />
+                    <${RuntimeMetaRow}
+                      label="prompt tok/s"
+                      value=${`${formatNumber(firstRun?.prompt_tokens_per_second, 1)} tok/s`}
+                    />
+                    <${RuntimeMetaRow}
+                      label="generation tok/s"
+                      value=${`${formatNumber(firstRun?.generation_tokens_per_second, 1)} tok/s`}
+                    />
+                    <${RuntimeMetaRow}
+                      label="prompt eval delta"
+                      value=${assessment?.prompt_eval_duration_reduction_ratio != null
+                        ? `${formatNumber(assessment.prompt_eval_duration_reduction_ratio * 100, 1)}%`
+                        : MISSING_DATA_DASH}
+                    />
+                    <${RuntimeMetaRow}
+                      label="loaded models"
+                      value=${String(probe.loaded_models_after?.length ?? probe.loaded_models_before?.length ?? 0)}
+                    />
+                  </div>
+                `}
 
             ${assessment?.note
               ? html`

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -22,12 +22,31 @@ let dashboard_runtime_probe_runner_hook : (unit -> Yojson.Safe.t) option Atomic.
   Atomic.make None
 ;;
 
+let dashboard_runtime_provider_http_get_hook :
+  (url:string ->
+   headers:(string * string) list ->
+   timeout_sec:float ->
+   (int * (string * string) list * string, string) result)
+    option
+    Atomic.t
+  =
+  Atomic.make None
+;;
+
 let set_dashboard_runtime_probe_runner_for_tests hook =
   Atomic.set dashboard_runtime_probe_runner_hook (Some hook)
 ;;
 
 let clear_dashboard_runtime_probe_runner_for_tests () =
   Atomic.set dashboard_runtime_probe_runner_hook None
+;;
+
+let set_dashboard_runtime_provider_http_get_for_tests hook =
+  Atomic.set dashboard_runtime_provider_http_get_hook (Some hook)
+;;
+
+let clear_dashboard_runtime_provider_http_get_for_tests () =
+  Atomic.set dashboard_runtime_provider_http_get_hook None
 ;;
 
 let clear_dashboard_runtime_probe_cache_for_tests () =
@@ -703,16 +722,386 @@ let runtime_diagnostics_json () =
   `List diagnostics, count "external_signal", count "state_repair", count "agent_state"
 ;;
 
+type dashboard_runtime_provider_probe =
+  { json : Yojson.Safe.t
+  ; status : string
+  ; reachable : bool option
+  ; skipped : bool
+  }
+
+let runtime_inventory_source = "runtime.toml"
+
+let dashboard_runtime_probe_timeout_sec_float =
+  Float.of_int dashboard_runtime_probe_timeout_sec
+;;
+
+let dashboard_runtime_trim_trailing_slashes raw =
+  let raw = String.trim raw in
+  let rec loop idx =
+    if idx < 0
+    then ""
+    else if Char.equal raw.[idx] '/'
+    then loop (idx - 1)
+    else String.sub raw 0 (idx + 1)
+  in
+  loop (String.length raw - 1)
+;;
+
+let dashboard_runtime_append_probe_path base ~suffix =
+  let base = dashboard_runtime_trim_trailing_slashes base in
+  if String.equal base "" || String.ends_with ~suffix base
+  then base
+  else base ^ suffix
+;;
+
+let dashboard_runtime_probe_url ~(api_format : Runtime_schema.api_format) base_url =
+  match api_format with
+  | Runtime_schema.Ollama_api ->
+    let base = dashboard_runtime_trim_trailing_slashes base_url in
+    if String.ends_with ~suffix:"/api/tags" base
+    then base
+    else if String.ends_with ~suffix:"/api" base
+    then base ^ "/tags"
+    else base ^ "/api/tags"
+  | Runtime_schema.Messages_api | Runtime_schema.Chat_completions_api ->
+      dashboard_runtime_append_probe_path base_url ~suffix:"/models"
+;;
+
+let dashboard_runtime_url_for_json raw =
+  let uri = Uri.of_string raw in
+  Uri.with_uri ~userinfo:None ~query:None ~fragment:None uri |> Uri.to_string
+;;
+
+let dashboard_runtime_http_url_valid url =
+  let uri = Uri.of_string url in
+  match Option.map String.lowercase_ascii (Uri.scheme uri), Uri.host uri with
+  | Some ("http" | "https"), Some host when String.trim host <> "" -> true
+  | _ -> false
+;;
+
+let dashboard_runtime_provider_auth_kind = function
+  | None -> "none"
+  | Some (Runtime_schema.Env key) -> "env:" ^ key
+  | Some (Runtime_schema.File path) -> "file:" ^ path
+  | Some (Runtime_schema.Inline _) -> "inline"
+;;
+
+let dashboard_runtime_header_is_auth name =
+  match String.lowercase_ascii (String.trim name) with
+  | "authorization" | "x-api-key" | "api-key" | "x-auth-token" -> true
+  | _ -> false
+;;
+
+let dashboard_runtime_non_auth_headers (provider : Runtime_schema.provider) =
+  provider.headers
+  |> Option.value ~default:[]
+  |> List.filter (fun (name, _) -> not (dashboard_runtime_header_is_auth name))
+;;
+
+let dashboard_runtime_credential_value = function
+  | Runtime_schema.Env key ->
+    (match Option.bind (Sys.getenv_opt key) String_util.trim_to_option with
+     | Some value -> Ok value
+     | None -> Error (Printf.sprintf "env credential %s is empty or unset" key))
+  | Runtime_schema.File path ->
+    (try
+       match Fs_compat.load_file path |> String_util.trim_to_option with
+       | Some value -> Ok value
+       | None -> Error (Printf.sprintf "credential file %s is empty" path)
+     with
+     | Eio.Cancel.Cancelled _ as e -> raise e
+     | exn -> Error (Printf.sprintf "credential file %s: %s" path (Printexc.to_string exn)))
+  | Runtime_schema.Inline value ->
+    (match String_util.trim_to_option value with
+     | Some value -> Ok value
+     | None -> Error "inline credential is empty")
+;;
+
+let dashboard_runtime_probe_headers (provider : Runtime_schema.provider) =
+  let base_headers =
+    [ "Accept", "application/json" ] @ dashboard_runtime_non_auth_headers provider
+  in
+  match provider.credentials with
+  | None -> Ok (false, base_headers)
+  | Some credential ->
+    (match dashboard_runtime_credential_value credential with
+     | Ok value -> Ok (true, ("Authorization", "Bearer " ^ value) :: base_headers)
+     | Error _ as error -> error)
+;;
+
+let dashboard_runtime_probe_transport_kind = function
+  | Runtime_schema.Cli _ -> "cli"
+  | Runtime_schema.Http url
+    when Uri.of_string url |> Uri.host |> Masc_network_defaults.is_loopback_host_opt ->
+    "local"
+  | Runtime_schema.Http _ -> "http"
+;;
+
+let dashboard_runtime_probe_http_get ~url ~headers ~timeout_sec =
+  match Atomic.get dashboard_runtime_provider_http_get_hook with
+  | Some hook -> hook ~url ~headers ~timeout_sec
+  | None ->
+    let clock = Eio_context.get_clock_opt () in
+    (match Masc_http_client.get_response_sync ?clock ~timeout_sec ~url ~headers () with
+     | Ok response -> Ok (response.status, response.headers, response.body)
+     | Error _ as error -> error)
+;;
+
+let dashboard_runtime_header_value name headers =
+  let name = String.lowercase_ascii name in
+  headers
+  |> List.find_map (fun (k, v) ->
+    if String.equal name (String.lowercase_ascii k) then Some v else None)
+;;
+
+let dashboard_runtime_list_member_len key json =
+  match Json_util.assoc_member_opt key json with
+  | Some (`List items) -> Some (List.length items)
+  | _ -> None
+;;
+
+let dashboard_runtime_model_count_of_body ~(api_format : Runtime_schema.api_format) body =
+  try
+    let json = Yojson.Safe.from_string body in
+    match api_format with
+    | Runtime_schema.Ollama_api -> dashboard_runtime_list_member_len "models" json
+    | Runtime_schema.Messages_api | Runtime_schema.Chat_completions_api ->
+      (match dashboard_runtime_list_member_len "data" json with
+       | Some _ as value -> value
+       | None -> dashboard_runtime_list_member_len "models" json)
+  with
+  | Yojson.Json_error _ -> None
+;;
+
+let dashboard_runtime_status_of_http_status = function
+  | Some code when code >= 200 && code < 300 -> "reachable"
+  | Some 401 | Some 403 -> "auth_failed"
+  | Some 404 -> "endpoint_not_found"
+  | Some code when code >= 500 -> "server_error"
+  | Some _ -> "http_error"
+  | None -> "unknown_http_status"
+;;
+
+let dashboard_runtime_provider_probe_json
+    ?(http_get = dashboard_runtime_probe_http_get)
+    (rt : Runtime.t)
+  =
+  let runtime_kind = dashboard_runtime_probe_transport_kind rt.provider.transport in
+  let auth_kind = dashboard_runtime_provider_auth_kind rt.provider.credentials in
+  let credential_required = Option.is_some rt.provider.credentials in
+  let endpoint_url =
+    match rt.provider.transport with
+    | Runtime_schema.Http url -> Some (dashboard_runtime_url_for_json url)
+    | Runtime_schema.Cli _ -> None
+  in
+  let base_fields
+        ?probe_url
+        ?http_status
+        ?latency_ms
+        ?model_count
+        ?content_type
+        ?downloaded_bytes
+        ?error
+        ~auth_present
+        ~status
+        ~reachable
+        ()
+    =
+    [ "runtime_id", `String rt.id
+    ; "provider_id", `String rt.provider.id
+    ; "provider_display_name", `String rt.provider.display_name
+    ; "model_id", `String rt.model.id
+    ; "model_api_name", `String rt.model.api_name
+    ; "protocol", `String rt.provider.protocol
+    ; "runtime_kind", `String runtime_kind
+    ; "transport", `String (match rt.provider.transport with Runtime_schema.Http _ -> "http" | Runtime_schema.Cli _ -> "cli")
+    ; "auth_kind", `String auth_kind
+    ; "credential_required", `Bool credential_required
+    ; "auth_present", `Bool auth_present
+    ; "status", `String status
+    ; "reachable", (match reachable with Some value -> `Bool value | None -> `Null)
+    ; "http_status", Json_util.int_opt_to_json http_status
+    ; "latency_ms", Json_util.float_opt_to_json latency_ms
+    ; "model_count", Json_util.int_opt_to_json model_count
+    ; "content_type", Json_util.string_opt_to_json content_type
+    ; "downloaded_bytes", Json_util.int_opt_to_json downloaded_bytes
+    ; "endpoint_url", Json_util.string_opt_to_json endpoint_url
+    ; "probe_url", Json_util.string_opt_to_json probe_url
+    ; "error", Json_util.string_opt_to_json error
+    ; "checked_at", `String (Masc_domain.now_iso ())
+    ]
+  in
+  let make ?probe_url ?http_status ?latency_ms ?model_count ?content_type
+      ?downloaded_bytes ?error ~auth_present ~status ~reachable ~skipped () =
+    { json =
+        `Assoc
+          (base_fields
+             ?probe_url
+             ?http_status
+             ?latency_ms
+             ?model_count
+             ?content_type
+             ?downloaded_bytes
+             ?error
+             ~auth_present
+             ~status
+             ~reachable
+             ())
+    ; status
+    ; reachable
+    ; skipped
+    }
+  in
+  match rt.provider.transport with
+  | Runtime_schema.Cli _ ->
+    make
+      ~auth_present:false
+      ~status:"skipped_cli"
+      ~reachable:None
+      ~skipped:true
+      ~error:"CLI runtimes do not expose an HTTP reachability endpoint"
+      ()
+  | Runtime_schema.Http endpoint_url ->
+    let probe_url = dashboard_runtime_probe_url ~api_format:rt.provider.api_format endpoint_url in
+    let probe_url_json = dashboard_runtime_url_for_json probe_url in
+    if not (dashboard_runtime_http_url_valid probe_url)
+    then
+      make
+        ~probe_url:probe_url_json
+        ~auth_present:false
+        ~status:"invalid_endpoint"
+        ~reachable:(Some false)
+        ~skipped:false
+        ~error:"runtime endpoint is not an absolute http(s) URL"
+        ()
+    else (
+      match dashboard_runtime_probe_headers rt.provider with
+      | Error error ->
+        make
+          ~probe_url:probe_url_json
+          ~auth_present:false
+          ~status:"missing_auth"
+          ~reachable:(Some false)
+          ~skipped:false
+          ~error
+          ()
+      | Ok (auth_present, headers) ->
+        let started_at = Time_compat.now () in
+        (match
+           http_get ~url:probe_url ~headers
+             ~timeout_sec:dashboard_runtime_probe_timeout_sec_float
+         with
+         | Ok (http_status, response_headers, body) ->
+           let latency_ms = (Time_compat.now () -. started_at) *. 1000.0 in
+           let status = dashboard_runtime_status_of_http_status (Some http_status) in
+           let reachable = http_status >= 200 && http_status < 300 in
+           let model_count =
+             if reachable
+             then dashboard_runtime_model_count_of_body ~api_format:rt.provider.api_format body
+             else None
+           in
+           make
+             ~probe_url:probe_url_json
+             ~http_status
+             ~latency_ms
+             ?model_count
+             ?content_type:(dashboard_runtime_header_value "content-type" response_headers)
+             ?downloaded_bytes:(Some (String.length body))
+             ~auth_present
+             ~status
+             ~reachable:(Some reachable)
+             ~skipped:false
+             ()
+         | Error error ->
+           let latency_ms = (Time_compat.now () -. started_at) *. 1000.0 in
+           make
+             ~probe_url:probe_url_json
+             ~latency_ms
+             ~auth_present
+             ~status:"network_error"
+             ~reachable:(Some false)
+             ~skipped:false
+             ~error
+             ()))
+;;
+
+let dashboard_runtime_probe_payload_json_of_runtimes ?default_id runtimes =
+  let probes = List.map dashboard_runtime_provider_probe_json runtimes in
+  let count pred = probes |> List.filter pred |> List.length in
+  let skipped = count (fun p -> p.skipped) in
+  let reachable = count (fun p -> Option.equal Bool.equal p.reachable (Some true)) in
+  let failed = count (fun p -> Option.equal Bool.equal p.reachable (Some false)) in
+  let probed = List.length probes - skipped in
+  let status =
+    if failed = 0 && probed > 0
+    then "reachable"
+    else if failed = 0
+    then "no_http_runtimes"
+    else if reachable > 0
+    then "degraded"
+    else "unreachable"
+  in
+  let errors =
+    probes
+    |> List.filter_map (fun probe ->
+      match probe.reachable with
+      | Some false ->
+        (match probe.json with
+         | `Assoc fields ->
+           let runtime_id =
+             match List.assoc_opt "runtime_id" fields with
+             | Some (`String value) -> value
+             | _ -> "(unknown runtime)"
+           in
+           Some (Printf.sprintf "%s: %s" runtime_id probe.status)
+         | _ -> Some probe.status)
+      | _ -> None)
+  in
+  `Assoc
+    [ "source", `String runtime_inventory_source
+    ; "status", `String status
+    ; "probe_ok", `Bool (failed = 0)
+    ; "checked_at", `String (Masc_domain.now_iso ())
+    ; ( "summary"
+      , `Assoc
+          [ "runtimes", `Int (List.length runtimes)
+          ; "probed", `Int probed
+          ; "reachable", `Int reachable
+          ; "failed", `Int failed
+          ; "skipped", `Int skipped
+          ; "default_runtime_id", Json_util.string_opt_to_json default_id
+          ] )
+    ; "providers", `List (List.map (fun p -> p.json) probes)
+    ; "errors", Json_util.json_string_list errors
+    ; ( "observations"
+      , Json_util.json_string_list
+          [ Printf.sprintf
+              "runtime.toml provider reachability: %d reachable, %d failed, %d skipped"
+              reachable
+              failed
+              skipped
+          ] )
+    ; "limitations"
+      , Json_util.json_string_list
+          [ "Probe checks provider metadata endpoints only; it does not send a completion request."
+          ; "CLI runtimes are listed but not executed by the dashboard probe."
+          ]
+    ]
+;;
+
+let dashboard_runtime_probe_payload_json_for_tests ?default_id runtimes =
+  dashboard_runtime_probe_payload_json_of_runtimes ?default_id runtimes
+;;
+
 let run_dashboard_runtime_probe () =
   match Atomic.get dashboard_runtime_probe_runner_hook with
   | Some hook -> hook ()
   | None ->
-    `Assoc
-      [ "source", `String "runtime"
-      ; "probe_ok", `Null
-      ; "status", `String "oas_owned"
-      ; "detail", `String "Concrete provider probes are owned by OAS."
-      ]
+    let runtimes = Runtime.get_runtimes () in
+    let default_id =
+      Runtime.get_default_runtime () |> Option.map (fun (rt : Runtime.t) -> rt.id)
+    in
+    dashboard_runtime_probe_payload_json_of_runtimes ?default_id runtimes
 ;;
 
 let dashboard_runtime_probe_cached_value () =
@@ -791,8 +1180,6 @@ let dashboard_runtime_probe_http_json ?(force = false) () =
     ; "probe", probe
     ]
 ;;
-
-let runtime_inventory_source = "runtime.toml"
 
 let runtime_endpoint_url_of_transport = function
   | Runtime_schema.Http url -> Some url

--- a/lib/server/server_dashboard_http_runtime_info.mli
+++ b/lib/server/server_dashboard_http_runtime_info.mli
@@ -13,15 +13,20 @@
     a [module Runtime = ...] alias inside
     [test/test_dashboard_cache].
 
-    External surface (15 entries + one test record type):
+    External surface:
     - {b runtime resolution + HTTP routes}
       ({!runtime_resolution_json},
+      {!light_runtime_resolution_json},
       {!dashboard_runtime_probe_http_json},
+      {!runtime_inventory_json},
       {!dashboard_perf_http_json},
       {!dashboard_tools_http_json}).
     - {b runtime probe test seams}
       ({!set_dashboard_runtime_probe_runner_for_tests},
       {!clear_dashboard_runtime_probe_runner_for_tests},
+      {!dashboard_runtime_probe_payload_json_for_tests},
+      {!set_dashboard_runtime_provider_http_get_for_tests},
+      {!clear_dashboard_runtime_provider_http_get_for_tests},
       {!clear_dashboard_runtime_probe_cache_for_tests}).
     - {b git rev-parse short test seams}
       ({!git_rev_parse_short},
@@ -70,6 +75,12 @@ val dashboard_runtime_probe_http_json :
     includes a [cache_hit] flag so dashboards can show
     the freshness state. *)
 
+val dashboard_runtime_probe_payload_json_for_tests :
+  ?default_id:string -> Runtime.t list -> Yojson.Safe.t
+(** Test-only pure projection for the production runtime reachability payload.
+    HTTP execution is supplied through
+    {!set_dashboard_runtime_provider_http_get_for_tests}. *)
+
 val runtime_inventory_json : unit -> Yojson.Safe.t
 (** Returns the materialized runtime.toml inventory loaded by
     {!Runtime.init_default}. This is the dashboard-compatible projection for
@@ -105,6 +116,21 @@ val clear_dashboard_runtime_probe_runner_for_tests :
   unit -> unit
 (** Removes the test runner installed by
     {!set_dashboard_runtime_probe_runner_for_tests}. *)
+
+val set_dashboard_runtime_provider_http_get_for_tests :
+  (url:string ->
+   headers:(string * string) list ->
+   timeout_sec:float ->
+   (int * (string * string) list * string, string) result) ->
+  unit
+(** Installs a deterministic HTTP GET hook used by the provider reachability
+    probe.  The hook receives the final probe URL and in-memory headers; callers
+    must not persist header values in assertion failure messages. *)
+
+val clear_dashboard_runtime_provider_http_get_for_tests :
+  unit -> unit
+(** Removes the provider HTTP GET hook installed by
+    {!set_dashboard_runtime_provider_http_get_for_tests}. *)
 
 val clear_dashboard_runtime_probe_cache_for_tests :
   unit -> unit

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -125,6 +125,132 @@ let provider_cfg () =
   | Ok provider_cfg -> provider_cfg
   | Error msg -> failf "unexpected adapter error: %s" msg
 
+let runtime_or_fail ?(provider = runpod_provider) () =
+  let cfg =
+    { Runtime_schema.providers = [ provider ]
+    ; models = [ qwen_model ]
+    ; bindings = [ runpod_binding ]
+    ; default_runtime_id = Some "runpod_mtp.qwen"
+    ; keeper_assignments = []
+    }
+  in
+  match Runtime.of_binding cfg runpod_binding with
+  | Some runtime -> runtime
+  | None -> fail "expected runtime binding to materialize"
+
+let with_dashboard_probe_http_get hook f =
+  Server_dashboard_http_runtime_info.set_dashboard_runtime_provider_http_get_for_tests
+    hook;
+  Fun.protect
+    ~finally:(fun () ->
+      Server_dashboard_http_runtime_info.clear_dashboard_runtime_provider_http_get_for_tests ())
+    f
+
+let first_provider_probe json =
+  match Yojson.Safe.Util.(member "providers" json |> to_list) with
+  | provider :: _ -> provider
+  | [] -> fail "expected at least one provider probe"
+
+let dashboard_probe_missing_auth_calls = ref 0
+
+let assert_dashboard_runtime_probe_reachable runtime =
+  let reachable_json =
+    with_dashboard_probe_http_get
+      (fun ~url ~headers ~timeout_sec:_ ->
+         check string "models probe URL"
+           "https://example-runpod.proxy.runpod.net/v1/models"
+           url;
+         check bool "auth header present" true
+           (Option.is_some (normalized_header_value "authorization" headers));
+         check bool "auth header is bearer" true
+           (match normalized_header_value "authorization" headers with
+            | Some value -> String.starts_with ~prefix:"Bearer " value
+            | None -> false);
+         Ok
+           ( 200
+           , [ "content-type", "application/json" ]
+           , {|{"data":[{"id":"qwen"}]}|} ))
+      (fun () ->
+         Server_dashboard_http_runtime_info.dashboard_runtime_probe_payload_json_for_tests
+           ~default_id:"runpod_mtp.qwen" [ runtime ])
+  in
+  let reachable_provider = first_provider_probe reachable_json in
+  check string "provider status" "reachable"
+    Yojson.Safe.Util.(member "status" reachable_provider |> to_string);
+  check int "http status" 200
+    Yojson.Safe.Util.(member "http_status" reachable_provider |> to_int);
+  check int "model count" 1
+    Yojson.Safe.Util.(member "model_count" reachable_provider |> to_int);
+  let () =
+    check bool "payload redacts inline token" false
+      (String_util.contains_substring
+         (Yojson.Safe.to_string reachable_json)
+         "rp-test-token")
+  in
+  ()
+
+let assert_dashboard_runtime_probe_missing_auth runtime =
+  dashboard_probe_missing_auth_calls := 0;
+  Server_dashboard_http_runtime_info.set_dashboard_runtime_provider_http_get_for_tests
+    (fun ~url:_ ~headers:_ ~timeout_sec:_ ->
+       incr dashboard_probe_missing_auth_calls;
+       Ok (200, [], {|{"data":[]}|}));
+  let json =
+    Fun.protect
+      ~finally:(fun () ->
+        Server_dashboard_http_runtime_info.clear_dashboard_runtime_provider_http_get_for_tests ())
+      (fun () ->
+         Server_dashboard_http_runtime_info.dashboard_runtime_probe_payload_json_for_tests
+           ~default_id:"runpod_mtp.qwen" [ runtime ])
+  in
+  let provider = first_provider_probe json in
+  check int "missing auth does not execute HTTP" 0
+    !dashboard_probe_missing_auth_calls;
+  check string "provider status" "missing_auth"
+    (Yojson.Safe.Util.(member "status" provider |> to_string));
+  check bool "provider not reachable" false
+    (Yojson.Safe.Util.(member "reachable" provider |> to_bool));
+  let () =
+    check bool "probe not ok" false
+      (Yojson.Safe.Util.(member "probe_ok" json |> to_bool))
+  in
+  ()
+
+let assert_dashboard_runtime_probe_redacts_url_credentials () =
+  let provider =
+    { runpod_provider with
+      transport =
+        Runtime_schema.Http
+          "https://user:secret@example-runpod.proxy.runpod.net/v1?token=secret#frag"
+    }
+  in
+  let runtime = runtime_or_fail ~provider () in
+  let json =
+    with_dashboard_probe_http_get
+      (fun ~url:_ ~headers:_ ~timeout_sec:_ -> Ok (200, [], {|{"data":[]}|}))
+      (fun () ->
+         Server_dashboard_http_runtime_info.dashboard_runtime_probe_payload_json_for_tests
+           ~default_id:"runpod_mtp.qwen" [ runtime ])
+  in
+  let provider = first_provider_probe json in
+  check bool "payload redacts URL secrets" false
+    (String_util.contains_substring (Yojson.Safe.to_string provider) "secret");
+  check string "redacted endpoint URL"
+    "https://example-runpod.proxy.runpod.net/v1"
+    (Yojson.Safe.Util.(member "endpoint_url" provider |> to_string))
+
+let test_dashboard_runtime_probe_reachability_contracts () =
+  let runtime = runtime_or_fail () in
+  assert_dashboard_runtime_probe_reachable runtime;
+  assert_dashboard_runtime_probe_redacts_url_credentials ();
+  let env_key = "MASC_TEST_RUNTIME_PROBE_TOKEN_MISSING_6F4C1D7A" in
+  Unix.putenv env_key "";
+  let provider =
+    { runpod_provider with credentials = Some (Runtime_schema.Env env_key) }
+  in
+  let runtime = runtime_or_fail ~provider () in
+  assert_dashboard_runtime_probe_missing_auth runtime
+
 let test_runtime_agent_terminal_observation_uses_runtime_identity () =
   let config =
     Runtime_agent.default_config
@@ -178,5 +304,9 @@ let () =
             "max turns is continuation checkpoint"
             `Quick
             test_runtime_agent_max_turns_is_continuation_checkpoint
+        ; test_case
+            "dashboard runtime provider reachability contracts"
+            `Quick
+            test_dashboard_runtime_probe_reachability_contracts
         ] )
     ]


### PR DESCRIPTION
## Summary
- replace the dashboard runtime-probe stub with runtime.toml provider reachability probes
- surface configured vs live reachability in the Runtime Monitor and config-resolution runtime probe panel
- keep provider auth in memory only, filter auth-like TOML headers, and redact URL userinfo/query/fragment in probe JSON

## Tests
- env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_runtime_reachability dune build --root . test/test_runtime_provider_auth_headers.exe
- _build_runtime_reachability/default/test/test_runtime_provider_auth_headers.exe
- pnpm --dir dashboard exec tsc --noEmit --pretty false
- pnpm --dir dashboard exec vitest run src/components/runtime-monitor.test.ts src/components/tools/config-resolution-panel.test.ts src/api/dashboard.test.ts --no-file-parallelism --maxWorkers=1
- Playwright rendered QA against Vite with mocked provider/probe APIs: checked Live reachability, live reachable, live missing auth, probe URL, and secret redaction