### PR TITLE
[codex] Make keeper detail immersive

### DIFF
--- a/dashboard/src/app.test.ts
+++ b/dashboard/src/app.test.ts
@@ -1,0 +1,21 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from 'vitest'
+import { shouldUseCompactDashboardChrome } from './app'
+
+describe('shouldUseCompactDashboardChrome', () => {
+  it('uses compact chrome for keeper detail routes', () => {
+    expect(shouldUseCompactDashboardChrome({
+      widgetSoloMode: false,
+      focusMode: false,
+      keeperDetailMode: true,
+    })).toBe(true)
+  })
+
+  it('keeps the standard shell for normal dashboard routes', () => {
+    expect(shouldUseCompactDashboardChrome({
+      widgetSoloMode: false,
+      focusMode: false,
+      keeperDetailMode: false,
+    })).toBe(false)
+  })
+})

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -30,6 +30,7 @@ import {
   DashboardHealthStrip,
   DashboardMain,
   ErrorCounterBadge,
+  isKeeperDetailDashboardRoute,
   SideRail,
 } from './components/dashboard-shell'
 import { ThemeSwitch } from './components/theme-switch'
@@ -100,6 +101,18 @@ function refreshCurrentRoute(options?: { recordVisit?: boolean }): void {
     .catch(err => {
       console.warn('[app] route refresh unavailable', err instanceof Error ? err.message : err)
     })
+}
+
+export function shouldUseCompactDashboardChrome({
+  widgetSoloMode,
+  focusMode,
+  keeperDetailMode,
+}: {
+  widgetSoloMode: boolean
+  focusMode: boolean
+  keeperDetailMode: boolean
+}): boolean {
+  return widgetSoloMode || focusMode || keeperDetailMode
 }
 
 export function App() {
@@ -235,14 +248,20 @@ export function App() {
   const currentSection = currentSectionForRoute(route.value)
   const isCodeSurface = currentTab === 'code'
   const widgetSoloMode = isWidgetSoloRoute(route.value)
+  const keeperDetailMode = isKeeperDetailDashboardRoute(route.value)
   const focusMode = dashboardFocusMode.value
-  const compactChromeMode = widgetSoloMode || focusMode
+  const compactChromeMode = shouldUseCompactDashboardChrome({
+    widgetSoloMode,
+    focusMode,
+    keeperDetailMode,
+  })
 
   return html`
     <div
       class="flex min-h-screen h-screen flex-col overflow-hidden bg-[var(--color-bg-page)] text-[var(--color-fg-primary)]"
       data-widget-solo=${widgetSoloMode ? 'true' : 'false'}
       data-focus-mode=${focusMode ? 'true' : 'false'}
+      data-keeper-detail-mode=${keeperDetailMode ? 'true' : 'false'}
     >
       <${SkipLink} />
       <header class="${compactChromeMode ? 'hidden' : 'relative'} z-10 shrink-0 border-b border-[var(--color-border-default)] bg-[var(--shell-header-bg)] px-3 py-1.5 backdrop-blur-xl">
@@ -312,7 +331,7 @@ export function App() {
           </div>
         `
         : null}
-      ${focusMode ? null : html`
+      ${focusMode || keeperDetailMode ? null : html`
         <${Suspense} fallback=${null}>
           <${LazyRemoteWarningBanner} />
         <//>
@@ -341,8 +360,10 @@ export function App() {
       ${selectedTask.value
         ? html`<${Suspense} fallback=${null}><${LazyTaskDetailOverlay} /><//>`
         : null}
-      <${DashboardStatusTray} sideRailCollapsed=${sidebarCollapsed.value} />
-      <${DashboardFocusModeToggle} />
+      ${keeperDetailMode ? null : html`
+        <${DashboardStatusTray} sideRailCollapsed=${sidebarCollapsed.value} />
+        <${DashboardFocusModeToggle} />
+      `}
       <${ToastContainer} />
       <${ConfirmDialogOverlay} />
       <${Suspense} fallback=${null}>

--- a/dashboard/src/components/keeper-detail-shell.ts
+++ b/dashboard/src/components/keeper-detail-shell.ts
@@ -201,7 +201,7 @@ export function KeeperDetailSection({
     ? 'scroll-mt-24 rounded-[var(--r-2)] bg-transparent shadow-none'
     : 'scroll-mt-24 rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] shadow-none'
   const headerClass = variant === 'primary'
-    ? 'flex w-full items-center justify-between gap-3 px-0 pb-2 pt-1 text-left'
+    ? 'sr-only'
     : 'flex w-full items-center justify-between gap-3 border-b border-[var(--color-border-default)] px-4 py-3 text-left transition-colors hover:bg-[var(--color-bg-hover)] sm:px-5'
   const headerContent = html`
     <div class="min-w-0">


### PR DESCRIPTION
## Summary
- Treat monitor keeper detail routes as an immersive dashboard surface so the global header, health strip, sidebar, status tray, and focus button no longer crowd the chat canvas.
- Visually collapse the primary keeper chat section heading so the direct conversation toolbar starts immediately below the keeper header.
- Add a focused pure test for compact chrome selection.

## Validation
- pnpm -C dashboard typecheck
- pnpm -C dashboard lint
- pnpm -C dashboard exec vitest run --config vitest.config.ts src/app.test.ts src/components/dashboard-shell.test.ts src/components/keeper-detail-shell.test.ts src/components/keeper-detail.test.ts src/components/keeper-shared.test.ts src/components/chat/primitives.test.ts --no-file-parallelism --maxWorkers=1
- git diff --check
- Playwright smoke at http://127.0.0.1:5177/dashboard/#monitoring?section=agents&keeper=sangsu
  - desktop chat top: 263px before this slice baseline -> 106px
  - mobile chat top: 636px before this slice baseline -> 185px
  - no horizontal overflow; header/health/sidebar/status tray hidden only for keeper detail mode

## Screenshots
- /tmp/keeper-roomier-polished-desktop.png
- /tmp/keeper-roomier-polished-mobile.png