### PR TITLE
fix: repair broken sandbox worktree slots

### DIFF
--- a/lib/playground_repo_readiness.ml
+++ b/lib/playground_repo_readiness.ml
@@ -98,6 +98,10 @@ let safe_is_dir path =
   try Sys.file_exists path && Sys.is_directory path with
   | Sys_error _ -> false
 
+let safe_exists path =
+  try Sys.file_exists path with
+  | Sys_error _ -> false
+
 let normalize_path path =
   Keeper_alerting_path.normalize_path_for_check path
   |> Keeper_alerting_path.strip_trailing_slashes
@@ -113,6 +117,7 @@ let git_toplevel path =
 
 let safe_repo_component s =
   s <> "" && s <> "." && s <> ".."
+  && not (String.starts_with ~prefix:"." s)
   && not (String.contains s '/')
   && not (String.contains s '\\')
   && not (String.contains s '\x00')
@@ -552,11 +557,50 @@ let write_file path contents =
     ~finally:(fun () -> close_out_noerr oc)
     (fun () -> output_string oc contents)
 
+let worktree_git_marker_path worktree_path =
+  Filename.concat worktree_path ".git"
+
+let quarantine_candidate path =
+  let rec loop n =
+    let candidate =
+      if n = 0 then path ^ ".broken"
+      else Printf.sprintf "%s.broken-%d" path n
+    in
+    if safe_exists candidate then loop (n + 1) else candidate
+  in
+  loop 0
+
+let quarantine_broken_worktree_slot ~worktree_path =
+  let quarantine = quarantine_candidate worktree_path in
+  try
+    Sys.rename worktree_path quarantine;
+    Ok quarantine
+  with
+  | Sys_error msg ->
+    Error
+      (Printf.sprintf
+         "failed to quarantine broken worktree %s to %s: %s"
+         worktree_path quarantine msg)
+
+let prepare_worktree_path_for_add ~worktree_path =
+  if not (safe_exists worktree_path) then Ok None
+  else if safe_is_dir worktree_path
+          && safe_exists (worktree_git_marker_path worktree_path)
+  then
+    quarantine_broken_worktree_slot ~worktree_path
+    |> Result.map (fun path -> Some path)
+  else
+    Error
+      (Printf.sprintf
+         "worktree path %s already exists but is not a git checkout and has no \
+          .git marker; refusing to overwrite"
+         worktree_path)
+
 let normalize_worktree_gitdir_file ~repo_path ~task_name ~worktree_path =
   if not (is_standard_worktree_path ~repo_path ~task_name ~worktree_path) then
     Ok ()
   else
-    let git_file = Filename.concat worktree_path ".git" in
+    let git_file = worktree_git_marker_path worktree_path in
     if not (Sys.file_exists git_file) then
       Error (Printf.sprintf "worktree %s has no .git file" worktree_path)
     else if Sys.is_directory git_file then Ok ()
@@ -622,7 +666,10 @@ let ensure_worktree_ready
       | Error msg ->
         Error (Printf.sprintf "parent repo %s not usable for worktree: %s" repo_name msg)
       | Ok repo_path -> (
-        match worktree_base_ref ~repo_path with
+        match prepare_worktree_path_for_add ~worktree_path with
+        | Error msg -> Error msg
+        | Ok _quarantined -> (
+          match worktree_base_ref ~repo_path with
         | None ->
           Error
             (Printf.sprintf
@@ -657,7 +704,7 @@ let ensure_worktree_ready
             Error
               (Printf.sprintf
                  "worktree add failed for %s/%s at %s from %s: %s"
-                 repo_name task_name worktree_path base_ref add_result.output))
+                 repo_name task_name worktree_path base_ref add_result.output)))
 
 (** [provision_worktrees_for_task ~config ~agent_name ~task_id ()] scans all
     repos in the keeper's docker playground and creates a worktree for [task_id]
@@ -712,7 +759,13 @@ let provision_worktrees_for_task
                     git checkout (git_toplevel=%s)"
                    repo_name task_id worktree_path top
                | None -> (
-                   match worktree_base_ref ~repo_path with
+                   match prepare_worktree_path_for_add ~worktree_path with
+                   | Error msg ->
+                     Log.Workspace.debug
+                       "provision_worktrees: skipped %s/%s: %s"
+                       repo_name task_id msg
+                   | Ok _quarantined -> (
+                     match worktree_base_ref ~repo_path with
                    | None ->
                      Log.Workspace.debug
                        "provision_worktrees: skipped %s/%s: no base ref found"
@@ -754,7 +807,7 @@ let provision_worktrees_for_task
                      else
                        Log.Workspace.debug
                          "provision_worktrees: skipped %s/%s from %s: %s"
-                         repo_name task_id base_ref add_result.output))
+                         repo_name task_id base_ref add_result.output)))
         entries
 
 (* ── Sandbox repo currency (fetch + work-preserving fast-forward) ──── *)

--- a/test/test_playground_repo_readiness.ml
+++ b/test/test_playground_repo_readiness.ml
@@ -164,6 +164,29 @@ let git_output ~cwd args =
          (String.concat " " args)
          result.output)
 
+let path_exists path =
+  try Sys.file_exists path with
+  | Sys_error _ -> false
+
+let assert_worktree_top ~worktree_path =
+  let worktree_top =
+    git_output ~cwd:worktree_path [ "rev-parse"; "--show-toplevel" ]
+  in
+  check string "worktree top" (normalize_path worktree_path)
+    (normalize_path worktree_top)
+
+let has_quarantined_sibling worktree_path =
+  let parent = Filename.dirname worktree_path in
+  let base = Filename.basename worktree_path in
+  Sys.readdir parent
+  |> Array.exists (fun name -> String.starts_with ~prefix:(base ^ ".broken") name)
+
+let write_stale_worktree_gitdir ~worktree_path ~task_name =
+  mkdir_p worktree_path;
+  write_file
+    (Filename.concat worktree_path ".git")
+    ("gitdir: ../../.git/worktrees/" ^ task_name ^ "\n")
+
 let test_deleted_tracked_files_restore_hint () =
   let clone_path = temp_dir "masc-repo-readiness-status-hint" in
   git_ok ~cwd:clone_path [ "init"; "-q"; "--initial-branch=main" ];
@@ -596,6 +619,45 @@ let test_ensure_worktree_ready_rejects_nested_plain_directory () =
   check string "nested dir toplevel is parent clone" (normalize_path clone_path)
     (normalize_path probe.output)
 
+let test_ensure_worktree_ready_replaces_broken_gitdir_slot () =
+  let base_path = temp_dir "masc-worktree-ready-broken-slot" in
+  let remote = Filename.concat base_path ".remote-masc.git" in
+  git_ok ~cwd:base_path [ "init"; "--bare"; "-q"; "--initial-branch=main"; remote ];
+  let config = Masc.Workspace.default_config base_path in
+  let meta = make_meta "keeper-one" in
+  let clone_path =
+    Masc.Playground_repo_readiness.clone_path ~config ~meta ~repo_name:"masc"
+  in
+  mkdir_p (Filename.dirname clone_path);
+  git_ok ~cwd:base_path [ "clone"; "-q"; remote; clone_path ];
+  git_ok ~cwd:clone_path [ "config"; "user.email"; "test@example.com" ];
+  git_ok ~cwd:clone_path [ "config"; "user.name"; "Test" ];
+  let readme = Filename.concat clone_path "README.md" in
+  write_file readme "# test\n";
+  git_ok ~cwd:clone_path [ "add"; "README.md" ];
+  git_ok ~cwd:clone_path [ "commit"; "-q"; "-m"; "init" ];
+  git_ok ~cwd:clone_path [ "push"; "-q"; "origin"; "main" ];
+  let task_name = "task-broken-gitdir-slot" in
+  let worktree_path = Filename.concat clone_path (".worktrees/" ^ task_name) in
+  write_stale_worktree_gitdir ~worktree_path ~task_name;
+  let broken_probe =
+    Masc.Playground_repo_readiness.run_git
+      ~timeout_sec:Masc.Playground_repo_readiness.read_only_probe_timeout_sec
+      ~clone_path:worktree_path
+      [ "rev-parse"; "--show-toplevel" ]
+  in
+  check bool "fixture starts broken" false broken_probe.ok;
+  let result =
+    Masc.Playground_repo_readiness.ensure_worktree_ready
+      ~config ~meta ~repo_name:"masc" ~task_name ~worktree_path ()
+  in
+  (match result with
+   | Ok () -> ()
+   | Error msg -> fail ("ensure_worktree_ready failed: " ^ msg));
+  check bool "broken slot quarantined" true
+    (has_quarantined_sibling worktree_path);
+  assert_worktree_top ~worktree_path
+
 let test_provision_worktrees_creates_worktrees () =
   (* Set up a docker playground with a repo *)
   let base_path = temp_dir "masc-provision" in
@@ -636,6 +698,62 @@ let test_provision_worktrees_creates_worktrees () =
       [ "rev-parse"; "--show-toplevel" ]
   in
   check bool "worktree is valid git checkout" true probe.ok
+
+let test_provision_worktrees_replaces_broken_gitdir_slot () =
+  let base_path = temp_dir "masc-provision-broken-slot" in
+  let remote = Filename.concat base_path ".remote-masc.git" in
+  git_ok ~cwd:base_path [ "init"; "--bare"; "-q"; "--initial-branch=main"; remote ];
+  let config = Masc.Workspace.default_config base_path in
+  let agent_name = "keeper-provision-broken-slot" in
+  let safe_name = Playground_paths.sanitize_keeper_name agent_name in
+  let repo_dir =
+    Filename.concat base_path
+      (Printf.sprintf ".masc/playground/docker/%s/repos/test-repo" safe_name)
+  in
+  mkdir_p (Filename.dirname repo_dir);
+  git_ok ~cwd:base_path [ "clone"; "-q"; remote; repo_dir ];
+  git_ok ~cwd:repo_dir [ "config"; "user.email"; "test@example.com" ];
+  git_ok ~cwd:repo_dir [ "config"; "user.name"; "Test" ];
+  let readme = Filename.concat repo_dir "README.md" in
+  write_file readme "# test\n";
+  git_ok ~cwd:repo_dir [ "add"; "README.md" ];
+  git_ok ~cwd:repo_dir [ "commit"; "-q"; "-m"; "init" ];
+  git_ok ~cwd:repo_dir [ "push"; "-q"; "origin"; "main" ];
+  let task_id = "task-broken-provision" in
+  let worktree_path =
+    Filename.concat repo_dir (Printf.sprintf ".worktrees/%s" task_id)
+  in
+  write_stale_worktree_gitdir ~worktree_path ~task_name:task_id;
+  Masc.Playground_repo_readiness.provision_worktrees_for_task
+    ~config ~agent_name ~task_id ();
+  check bool "broken provision slot quarantined" true
+    (has_quarantined_sibling worktree_path);
+  assert_worktree_top ~worktree_path
+
+let test_provision_worktrees_rejects_dot_task_id () =
+  let base_path = temp_dir "masc-provision-dot-task" in
+  let remote = Filename.concat base_path ".remote-masc.git" in
+  git_ok ~cwd:base_path [ "init"; "--bare"; "-q"; "--initial-branch=main"; remote ];
+  let config = Masc.Workspace.default_config base_path in
+  let agent_name = "keeper-provision-dot-task" in
+  let safe_name = Playground_paths.sanitize_keeper_name agent_name in
+  let repo_dir =
+    Filename.concat base_path
+      (Printf.sprintf ".masc/playground/docker/%s/repos/test-repo" safe_name)
+  in
+  mkdir_p (Filename.dirname repo_dir);
+  git_ok ~cwd:base_path [ "clone"; "-q"; remote; repo_dir ];
+  git_ok ~cwd:repo_dir [ "config"; "user.email"; "test@example.com" ];
+  git_ok ~cwd:repo_dir [ "config"; "user.name"; "Test" ];
+  let readme = Filename.concat repo_dir "README.md" in
+  write_file readme "# test\n";
+  git_ok ~cwd:repo_dir [ "add"; "README.md" ];
+  git_ok ~cwd:repo_dir [ "commit"; "-q"; "-m"; "init" ];
+  git_ok ~cwd:repo_dir [ "push"; "-q"; "origin"; "main" ];
+  Masc.Playground_repo_readiness.provision_worktrees_for_task
+    ~config ~agent_name ~task_id:".git" ();
+  check bool "reserved dot task did not create hidden worktree" false
+    (path_exists (Filename.concat repo_dir ".worktrees/.git"))
 
 let test_provision_worktrees_uses_origin_base_with_dirty_parent () =
   let base_path = temp_dir "masc-provision-dirty-parent" in
@@ -781,6 +899,8 @@ let () =
           test_ensure_worktree_ready_normalizes_gitdir_pointer;
         test_case "rejects nested plain directory" `Quick
           test_ensure_worktree_ready_rejects_nested_plain_directory;
+        test_case "replaces broken gitdir slot" `Quick
+          test_ensure_worktree_ready_replaces_broken_gitdir_slot;
         test_case "creates worktree from dirty parent clone" `Quick
           test_ensure_worktree_ready_allows_dirty_parent_clone;
       ];
@@ -788,6 +908,10 @@ let () =
       [
         test_case "creates worktrees at claim time" `Quick
           test_provision_worktrees_creates_worktrees;
+        test_case "replaces broken gitdir slot at claim time" `Quick
+          test_provision_worktrees_replaces_broken_gitdir_slot;
+        test_case "rejects reserved dot task id" `Quick
+          test_provision_worktrees_rejects_dot_task_id;
         test_case "creates worktree from origin with dirty parent" `Quick
           test_provision_worktrees_uses_origin_base_with_dirty_parent;
       ];


### PR DESCRIPTION
## Summary
- quarantine stale sandbox task worktree directories that still have a `.git` marker but no valid git metadata
- recreate the task worktree from the fetched origin base ref after quarantine
- reject dot-prefixed repo/task components so reserved paths like `.git` and `.worktrees` cannot become hidden worktree slots

## Root Cause
A sandbox task path such as `repos/masc-mcp/.worktrees/task-670` could be left as a plain directory with a stale `.git` pointer to missing parent metadata. `Execute` correctly rejected that cwd as `sandbox_worktree_not_ready`, but readiness/provisioning tried `git worktree add` into the already-existing broken directory and could not self-heal.

## Validation
- `dune exec --root . test/test_playground_repo_readiness.exe`
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=/private/tmp/masc-dune-sandbox-broken-worktree-20260606 dune build --root . test/test_playground_repo_readiness.exe`
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=/private/tmp/masc-dune-sandbox-broken-worktree-20260606 dune exec --root . test/test_playground_repo_readiness.exe`
- `ocamlformat --check lib/playground_repo_readiness.ml test/test_playground_repo_readiness.ml`
- `scripts/ci/check-determinism-contract.sh --base origin/main --head HEAD`
- `git diff --check`

Note: `scripts/dune-local.sh build test/test_playground_repo_readiness.exe` returned exit 75 because another bare Dune process was already running outside the wrapper, so the focused build/test was rerun with an isolated `DUNE_BUILD_DIR`.
