### PR TITLE
fix(keeper): reject incomplete declarative sandbox profiles

### DIFF
--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -378,6 +378,13 @@ val effective_meta_of_profile_defaults :
   keeper_meta ->
   (keeper_meta, string) result
 
+val missing_required_sandbox_profile_error :
+  keeper_name:string ->
+  Keeper_types_profile.keeper_profile_defaults ->
+  string
+(** Error text shared by effective-meta reconcile and keeper-up parsing when a
+    declarative keeper profile omits the required [sandbox_profile]. *)
+
 val runtime_id_of_meta : keeper_meta -> string
 (** Runtime id selected for keeper dispatch. Uses the keeper profile [model]
     when present; otherwise falls back to the configured default runtime id. *)

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -200,6 +200,16 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) 
     let handoff_cooldown_sec_opt = Safe_ops.json_int_opt "handoff_cooldown_sec" args in
     let instructions_arg = get_string_opt args "instructions" in
     let profile_defaults = load_keeper_profile_defaults name in
+    let sandbox_profile_error =
+      match profile_defaults.sandbox_profile, profile_defaults.manifest_path with
+      | None, Some _ ->
+        Some
+          (missing_required_sandbox_profile_error
+             ~keeper_name:name
+             profile_defaults)
+      | Some _, _
+      | None, None -> None
+    in
     (* The previous implementation read [<base>/memory/souls/<name>/SOUL.md]
        on every keeper turn-up and wrapped the resulting (or "not found")
        text into a "[SYSTEM: SOUL INFUSION]" block prepended to the
@@ -217,9 +227,10 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) 
     let will_opt = parse_self_model_opt args "will" in
     let needs_opt = parse_self_model_opt args "needs" in
     let desires_opt = parse_self_model_opt args "desires" in
-    match tool_denylist_opt_res with
-    | Error msg -> Error (tool_result_error msg)
-    | Ok tool_denylist_opt ->
+    match sandbox_profile_error, tool_denylist_opt_res with
+    | Some msg, _ -> Error (tool_result_error msg)
+    | None, Error msg -> Error (tool_result_error msg)
+    | None, Ok tool_denylist_opt ->
     Ok {
       name;
       compaction_profile_opt;

--- a/test/test_keeper_effective_meta_overlay.ml
+++ b/test/test_keeper_effective_meta_overlay.ml
@@ -3,6 +3,7 @@ module Store = Masc.Keeper_meta_store
 module Profile = Masc.Keeper_types_profile
 module Status_detail = Masc.Keeper_status_detail
 module Turn_setup = Masc.Keeper_turn_setup
+module Turn = Masc.Keeper_turn
 module Keeper_tool_surface = Masc.Keeper_tool_surface
 module Keeper_tool_surface_ops = Masc.Keeper_tool_surface_ops
 
@@ -237,6 +238,38 @@ goal = "missing sandbox profile"
         true
         (contains_substring ~needle:"sandbox_profile is required" err)
 
+let test_keeper_up_rejects_profile_source_without_sandbox_profile () =
+  with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir ->
+  let name = "nosandboxup" in
+  write_file
+    (Filename.concat keepers_dir (name ^ ".toml"))
+    {|[keeper]
+goal = "missing sandbox profile"
+|};
+  let config = Workspace.default_config base in
+  ignore (seed_runtime_meta config name : Masc.Keeper_meta_contract.keeper_meta);
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let ctx : _ Profile.context =
+    {
+      config;
+      agent_name = "test-agent";
+      sw;
+      clock = Eio.Stdenv.clock env;
+      proc_mgr = None;
+      net = None;
+    }
+  in
+  let result = Turn.handle_keeper_up ctx (`Assoc [ ("name", `String name) ]) in
+  if Profile.tool_result_success result then
+    Alcotest.fail "keeper_up should reject TOML profile without sandbox_profile";
+  Alcotest.(check bool)
+    "keeper_up error names missing sandbox_profile"
+    true
+    (contains_substring
+       ~needle:"sandbox_profile is required"
+       (Profile.tool_result_body result))
+
 let test_missing_profile_source_fails_loud () =
   with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir:_ ->
   let name = "nosource" in
@@ -390,6 +423,9 @@ let () =
           Alcotest.test_case
             "profile source without sandbox_profile fails loudly"
             `Quick test_missing_sandbox_profile_fails_loud_for_profile_source;
+          Alcotest.test_case
+            "keeper_up rejects profile source without sandbox_profile"
+            `Quick test_keeper_up_rejects_profile_source_without_sandbox_profile;
           Alcotest.test_case
             "missing profile source fails loudly"
             `Quick test_missing_profile_source_fails_loud;


### PR DESCRIPTION
## Summary
- reject masc_keeper_up when a declarative keeper profile exists but omits sandbox_profile
- reuse the effective-meta sandbox_profile error text for keeper_up parsing
- add a regression test so boot/update cannot silently start from stale runtime meta when TOML is incomplete

## Verification
- env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_codex_20260606 dune build --root . test/test_keeper_effective_meta_overlay.exe
- _build_codex_20260606/default/test/test_keeper_effective_meta_overlay.exe