### PR TITLE
[codex] Guide typed glob Execute failures

### DIFF
--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -207,6 +207,88 @@ let deterministic_retry_fields_for_process_result
   | _ -> []
 ;;
 
+let token_looks_like_shell_glob token =
+  String.exists
+    (function
+      | '*' | '?' -> true
+      | _ -> false)
+    token
+  ||
+  (String.contains token '[' && String.contains token ']')
+;;
+
+let path_not_found_output text =
+  String_util.contains_substring text "No such file or directory"
+  || String_util.contains_substring text "cannot access"
+;;
+
+let glob_prone_file_command executable =
+  match String.trim executable with
+  | "ls" | "cat" | "head" | "tail" | "wc" | "stat" -> true
+  | _ -> false
+;;
+
+let directory_and_pattern_of_glob_token token =
+  match String.rindex_opt token '/' with
+  | None -> ".", token
+  | Some 0 -> "/", String.sub token 1 (String.length token - 1)
+  | Some idx ->
+    ( String.sub token 0 idx
+    , String.sub token (idx + 1) (String.length token - idx - 1) )
+;;
+
+let glob_literal_failure_fields ~input ~status ~stderr =
+  match status, String.trim stderr with
+  | Unix.WEXITED 0, _ | _, "" -> []
+  | _, stderr when not (path_not_found_output stderr) -> []
+  | _ ->
+    let matching_stage =
+      let stage executable argv =
+        if glob_prone_file_command executable
+        then
+          match List.find_opt token_looks_like_shell_glob argv with
+          | Some token -> Some (executable, token)
+          | None -> None
+        else None
+      in
+      match input with
+      | Keeper_tool_execute_typed_input.Exec { executable; argv; _ } ->
+        stage executable argv
+      | Keeper_tool_execute_typed_input.Pipeline { stages; _ } ->
+        List.find_map
+          (fun { Keeper_tool_execute_typed_input.executable; argv } ->
+             stage executable argv)
+          stages
+    in
+    (match matching_stage with
+     | None -> []
+     | Some (_, token) ->
+       let dir, pattern = directory_and_pattern_of_glob_token token in
+       let hint =
+         "Typed Execute uses execve-style argv; shell glob characters in argv \
+          are passed literally and are not shell-expanded. For wildcard file \
+          discovery, run find with -name or rg --files with -g."
+       in
+       let find_alt =
+         Printf.sprintf
+           "Use executable=\"find\" argv=[%S, \"-name\", %S]."
+           dir
+           pattern
+       in
+       let rg_alt =
+         Printf.sprintf
+           "Use executable=\"rg\" argv=[\"--files\", %S, \"-g\", %S]."
+           dir
+           pattern
+       in
+       [ "execution_hint", `String hint
+       ; "shell_ir_hint", `String hint
+       ; "typed_glob_not_expanded", `Bool true
+       ; "literal_glob_token", `String token
+       ; "alternatives", `List [ `String find_alt; `String rg_alt ]
+       ])
+;;
+
 let sandbox_extra_uses_docker sandbox_extra_fields =
   List.exists
     (function
@@ -621,6 +703,12 @@ let handle_tool_execute_typed
               | Unix.WEXITED 0, _ | _, "" -> []
               | _, stderr -> [ "error", `String stderr; "stderr", `String stderr ]
             in
+            let glob_literal_failure_fields =
+              glob_literal_failure_fields
+                ~input
+                ~status:result.status
+                ~stderr:result.stderr
+            in
             let classification = Exec_core.classify_command_of_ir ir in
             let deterministic_retry_fields =
               deterministic_retry_fields_for_process_result
@@ -645,6 +733,7 @@ let handle_tool_execute_typed
                  ~extra:
                    (deterministic_retry_fields
                     @ failure_error_fields
+                    @ glob_literal_failure_fields
                     @ sandbox_extra_fields
                     @ [ "typed", `Bool true
                       ; "execution_time_ms", `Int elapsed_ms

--- a/test/test_keeper_tool_execute_safety.ml
+++ b/test/test_keeper_tool_execute_safety.ml
@@ -1631,6 +1631,75 @@ let test_tool_execute_typed_failure_error_prefers_stderr () =
        normalized_error
        "Keeper_sandbox contract fixture")
 
+let test_tool_execute_typed_literal_glob_failure_guides_retry () =
+  with_eio_fs @@ fun () ->
+  let base_path, config = make_config () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  Keeper_registry.clear ();
+  let meta = make_readonly_meta "typed-literal-glob-failure" in
+  let playground = Filename.concat base_path (playground_path_of meta.name) in
+  ensure_dir playground;
+  let raw =
+    Keeper_tool_command_runtime.handle_tool_execute
+      ~turn_sandbox_factory:None
+      ~exec_cache:None
+      ~config
+      ~meta
+      ~args:
+        (`Assoc
+           [ "executable", `String "ls"
+           ; "argv", `List [ `String "keeper_execution_receipt*" ]
+           ; "cwd", `String playground
+           ])
+      ()
+  in
+  let json = Yojson.Safe.from_string raw in
+  Alcotest.(check bool) "glob literal failure is not ok" false
+    (json |> Json.member "ok" |> Json.to_bool);
+  let err = json |> Json.member "error" |> Json.to_string in
+  Alcotest.(check bool)
+    "top-level error keeps stderr"
+    true
+    (String_util.contains_substring err "No such file or directory");
+  let hint = json |> Json.member "execution_hint" |> Json.to_string in
+  Alcotest.(check bool)
+    "hint explains glob is literal"
+    true
+    (String_util.contains_substring hint "not shell-expanded");
+  Alcotest.(check bool) "glob marker is structured" true
+    (json |> Json.member "typed_glob_not_expanded" |> Json.to_bool);
+  Alcotest.(check string)
+    "literal token preserved"
+    "keeper_execution_receipt*"
+    (json |> Json.member "literal_glob_token" |> Json.to_string);
+  let alternatives =
+    json
+    |> Json.member "alternatives"
+    |> Json.to_list
+    |> List.map Json.to_string
+    |> String.concat "\n"
+  in
+  Alcotest.(check bool)
+    "find alternative is present"
+    true
+    (String_util.contains_substring alternatives "executable=\"find\"");
+  Alcotest.(check bool)
+    "rg alternative is present"
+    true
+    (String_util.contains_substring alternatives "executable=\"rg\"");
+  let normalized =
+    Masc.Keeper_tools_oas.normalize_tool_result ~success:false raw
+    |> Yojson.Safe.from_string
+  in
+  Alcotest.(check bool)
+    "OAS-normalized result preserves execution hint"
+    true
+    (normalized
+     |> Json.member "execution_hint"
+     |> Json.to_string
+     |> fun normalized_hint ->
+     String_util.contains_substring normalized_hint "not shell-expanded")
+
 let test_tool_execute_typed_pipeline_runs_via_shell_ir () =
   with_eio_fs @@ fun () ->
   let base_path, config = make_config () in
@@ -2274,6 +2343,10 @@ let () =
             "typed failure top-level error prefers stderr"
             `Quick
             test_tool_execute_typed_failure_error_prefers_stderr
+        ; Alcotest.test_case
+            "typed literal glob failure guides retry"
+            `Quick
+            test_tool_execute_typed_literal_glob_failure_guides_retry
         ; Alcotest.test_case
             "typed pipeline runs via Shell IR"
             `Quick


### PR DESCRIPTION
Summary: Adds structured execution hints when typed Execute passes glob-looking argv literally and file commands fail with path-not-found; preserves duplicate argv0 fail-fast behavior. Tests: env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_shell_ir_glob_hint dune build --root . test/test_keeper_tool_execute_safety.exe; _build_shell_ir_glob_hint/default/test/test_keeper_tool_execute_safety.exe