### PR TITLE
fix(keeper): default sandbox_profile to Local when TOML omits it

### DIFF
--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -605,10 +605,7 @@ let effective_meta_of_profile_defaults
   let target_sandbox_profile =
     match defaults.sandbox_profile, defaults.manifest_path with
     | Some profile, _ -> Ok profile
-    | None, _ ->
-        Error
-          (missing_required_sandbox_profile_error ~keeper_name:meta.name
-             defaults)
+    | None, _ -> Ok default_sandbox_profile
   in
   match target_sandbox_profile with
   | Error _ as err -> err


### PR DESCRIPTION
keeper_meta_contract.ml required sandbox_profile in TOML, but keeper_meta_json_parse.ml already defaulted to Local on missing key. Align the two code paths. Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>