### PR TITLE
fix(keeper): align keeper_up sandbox profile guard

### DIFF
--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -201,14 +201,13 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) 
     let instructions_arg = get_string_opt args "instructions" in
     let profile_defaults = load_keeper_profile_defaults name in
     let sandbox_profile_error =
-      match profile_defaults.sandbox_profile, profile_defaults.manifest_path with
-      | None, Some _ ->
+      match profile_defaults.sandbox_profile with
+      | None ->
         Some
           (missing_required_sandbox_profile_error
              ~keeper_name:name
              profile_defaults)
-      | Some _, _
-      | None, None -> None
+      | Some _ -> None
     in
     (* The previous implementation read [<base>/memory/souls/<name>/SOUL.md]
        on every keeper turn-up and wrapped the resulting (or "not found")

--- a/test/test_keeper_effective_meta_overlay.ml
+++ b/test/test_keeper_effective_meta_overlay.ml
@@ -270,6 +270,33 @@ goal = "missing sandbox profile"
        ~needle:"sandbox_profile is required"
        (Profile.tool_result_body result))
 
+let test_keeper_up_rejects_missing_profile_source () =
+  with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir:_ ->
+  let name = "nosourceup" in
+  let config = Workspace.default_config base in
+  ignore (seed_runtime_meta config name : Masc.Keeper_meta_contract.keeper_meta);
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let ctx : _ Profile.context =
+    {
+      config;
+      agent_name = "test-agent";
+      sw;
+      clock = Eio.Stdenv.clock env;
+      proc_mgr = None;
+      net = None;
+    }
+  in
+  let result = Turn.handle_keeper_up ctx (`Assoc [ ("name", `String name) ]) in
+  if Profile.tool_result_success result then
+    Alcotest.fail "keeper_up should reject missing TOML/persona source";
+  Alcotest.(check bool)
+    "keeper_up missing source error names sandbox_profile"
+    true
+    (contains_substring
+       ~needle:"sandbox_profile is required"
+       (Profile.tool_result_body result))
+
 let test_missing_profile_source_fails_loud () =
   with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir:_ ->
   let name = "nosource" in
@@ -426,6 +453,8 @@ let () =
           Alcotest.test_case
             "keeper_up rejects profile source without sandbox_profile"
             `Quick test_keeper_up_rejects_profile_source_without_sandbox_profile;
+          Alcotest.test_case "keeper_up rejects missing profile source" `Quick
+            test_keeper_up_rejects_missing_profile_source;
           Alcotest.test_case
             "missing profile source fails loudly"
             `Quick test_missing_profile_source_fails_loud;


### PR DESCRIPTION
## Summary
- reject keeper_up when effective profile defaults have no sandbox_profile, matching runtime reconcile
- cover missing TOML/persona source, not only TOML-present missing sandbox_profile
- add focused regression for keeper_up missing profile source

## Verification
- git diff --check
- env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_codex_20260606b dune build --root . test/test_keeper_effective_meta_overlay.exe
- _build_codex_20260606b/default/test/test_keeper_effective_meta_overlay.exe

## Notes
- Follow-up to #20278. That PR blocked TOML-present missing sandbox_profile. This closes the remaining persona/missing-source path that live logs can hit for keepers like imseonghan.