### PR TITLE
[RFC-0217 Phase 4+5] Discord and Slack delivery adapters

### DIFF
--- a/lib/keeper/keeper_chat_consumer.ml
+++ b/lib/keeper/keeper_chat_consumer.ml
@@ -14,7 +14,7 @@ let start ~sw ~clock ~handle_turn =
          match Keeper_chat_queue.dequeue ~keeper_name with
          | None -> ()
          | Some queued ->
-             (try handle_turn ~keeper_name ~queued_message:queued with
+             (try handle_turn ~sw ~keeper_name ~queued_message:queued with
               | Eio.Cancel.Cancelled _ as e -> raise e
               | exn ->
                   Log.Keeper.warn

--- a/lib/keeper/keeper_chat_consumer.mli
+++ b/lib/keeper/keeper_chat_consumer.mli
@@ -21,5 +21,5 @@
 val start :
   sw:Eio.Switch.t ->
   clock:_ Eio.Time.clock ->
-  handle_turn:(keeper_name:string -> queued_message:Keeper_chat_queue.queued_message -> unit) ->
+  handle_turn:(sw:Eio.Switch.t -> keeper_name:string -> queued_message:Keeper_chat_queue.queued_message -> unit) ->
   unit

--- a/lib/keeper/keeper_chat_discord.ml
+++ b/lib/keeper/keeper_chat_discord.ml
@@ -1,0 +1,46 @@
+(** Keeper_chat_discord — Discord delivery adapter for keeper chat events. *)
+
+let discord_message_limit = 2000
+
+let send_message ~token ~channel_id ~content =
+  let truncated =
+    if String.length content > discord_message_limit then
+      String.sub content 0 discord_message_limit
+    else content
+  in
+  match Discord_rest_client.send_message ~token ~channel_id ~content:truncated with
+  | Ok _msg_id -> ()
+  | Error err ->
+      let err_str =
+        Format.asprintf "%a" Discord_rest_client.pp_error err
+      in
+      Log.Keeper.warn
+        "keeper_chat_discord: send_message failed: %s" err_str
+
+let adapter_loop ~token ~channel_id ~events =
+  let rec loop ~acc_text ~run_id_opt =
+    match Keeper_chat_events.subscribe events with
+    | Text_delta text ->
+        loop ~acc_text:(acc_text ^ text) ~run_id_opt
+    | Text_message_end ->
+        loop ~acc_text ~run_id_opt
+    | Run_finished { run_id = _ } ->
+        if String.length acc_text > 0 then
+          send_message ~token ~channel_id ~content:acc_text;
+        (* Loop exits after one turn. *)
+        ()
+    | Error { message } ->
+        send_message ~token ~channel_id
+          ~content:("Keeper error: " ^ message);
+        (* Loop exits after error. *)
+        ()
+    | Run_started { run_id; thread_id = _ } ->
+        loop ~acc_text:"" ~run_id_opt:(Some run_id)
+    | Text_message_start { message_id = _; role = _ } ->
+        loop ~acc_text ~run_id_opt
+    | Custom { name; value = _ } ->
+        Log.Keeper.debug
+          "keeper_chat_discord: custom event %s" name;
+        loop ~acc_text ~run_id_opt
+  in
+  loop ~acc_text:"" ~run_id_opt:None

--- a/lib/keeper/keeper_chat_discord.ml
+++ b/lib/keeper/keeper_chat_discord.ml
@@ -29,7 +29,7 @@ let adapter_loop ~token ~channel_id ~events =
           send_message ~token ~channel_id ~content:acc_text;
         (* Loop exits after one turn. *)
         ()
-    | Error { message } ->
+    | Event_error { message } ->
         send_message ~token ~channel_id
           ~content:("Keeper error: " ^ message);
         (* Loop exits after error. *)

--- a/lib/keeper/keeper_chat_discord.mli
+++ b/lib/keeper/keeper_chat_discord.mli
@@ -1,0 +1,25 @@
+(** Keeper_chat_discord — Discord delivery adapter for keeper chat events.
+
+    Subscribes to a [Keeper_chat_events] stream, accumulates assistant
+    text deltas, and sends the final reply to a Discord channel via the
+    REST API when the run finishes.
+
+    @since 2.145.0 *)
+
+val send_message :
+  token:string -> channel_id:string -> content:string -> unit
+(** [send_message ~token ~channel_id ~content] posts to Discord.
+    Errors are logged as warnings but never raised.
+    The content is truncated to Discord's 2000-character limit. *)
+
+val adapter_loop :
+  token:string ->
+  channel_id:string ->
+  events:Keeper_chat_events.keeper_chat_event Eio.Stream.t ->
+  unit
+(** [adapter_loop ~token ~channel_id ~events] blocks on the event
+    stream until [Run_finished] or [Error], then sends the accumulated
+    text (or error message) to the given Discord channel.
+
+    The loop exits after one turn; the caller must restart it for
+    subsequent turns. *)

--- a/lib/keeper/keeper_chat_events.ml
+++ b/lib/keeper/keeper_chat_events.ml
@@ -6,7 +6,7 @@ type keeper_chat_event =
   | Text_delta of string
   | Text_message_end
   | Run_finished of { run_id : string }
-  | Error of { message : string }
+  | Event_error of { message : string }
   | Custom of { name : string; value : Yojson.Safe.t }
 
 let create () = Eio.Stream.create 512

--- a/lib/keeper/keeper_chat_events.mli
+++ b/lib/keeper/keeper_chat_events.mli
@@ -16,7 +16,7 @@ type keeper_chat_event =
   | Text_delta of string
   | Text_message_end
   | Run_finished of { run_id : string }
-  | Error of { message : string }
+  | Event_error of { message : string }
   | Custom of { name : string; value : Yojson.Safe.t }
 
 (** {1 Stream operations} *)

--- a/lib/keeper/keeper_chat_slack.ml
+++ b/lib/keeper/keeper_chat_slack.ml
@@ -1,0 +1,86 @@
+(** Keeper_chat_slack — Slack delivery adapter for keeper chat events. *)
+
+type error =
+  | Network of string
+  | Http_status of { code : int; body : string }
+  | Slack_api of { error : string }
+  | Other of string
+
+let pp_error fmt = function
+  | Network msg -> Format.fprintf fmt "Network: %s" msg
+  | Http_status { code; body } ->
+      Format.fprintf fmt "HTTP %d: %s" code body
+  | Slack_api { error } ->
+      Format.fprintf fmt "Slack API error: %s" error
+  | Other msg -> Format.fprintf fmt "Other: %s" msg
+
+let slack_message_limit = 4000
+
+let send_message ~token ~channel ~content =
+  let truncated =
+    if String.length content > slack_message_limit then
+      String.sub content 0 slack_message_limit
+    else content
+  in
+  let body_json =
+    `Assoc
+      [ ("channel", `String channel);
+        ("text", `String truncated) ]
+    |> Yojson.Safe.to_string
+  in
+  match
+    Masc_http_client.post_sync ~url:"https://slack.com/api/chat.postMessage"
+      ~headers:
+        [
+          ("Authorization", "Bearer " ^ token);
+          ("Content-Type", "application/json");
+        ]
+      ~body:body_json ()
+  with
+  | Error err ->
+      Log.Keeper.warn "keeper_chat_slack: post failed: %s" err
+  | Ok (code, response_body) -> (
+      if code < 200 || code >= 300 then
+        Log.Keeper.warn "keeper_chat_slack: HTTP %d: %s" code response_body
+      else
+        try
+          let json = Yojson.Safe.from_string response_body in
+          match Json_util.get_bool json "ok" with
+          | Some true -> ()
+          | Some false -> (
+              match Json_util.get_string json "error" with
+              | Some err ->
+                  Log.Keeper.warn "keeper_chat_slack: Slack API error: %s" err
+              | None ->
+                  Log.Keeper.warn "keeper_chat_slack: Slack ok=false")
+          | None ->
+              Log.Keeper.warn "keeper_chat_slack: missing ok in response"
+        with
+        | Yojson.Json_error msg ->
+            Log.Keeper.warn "keeper_chat_slack: JSON parse error: %s" msg)
+
+let adapter_loop ~token ~channel ~events =
+  let rec loop ~acc_text ~run_id_opt =
+    match Keeper_chat_events.subscribe events with
+    | Text_delta text ->
+        loop ~acc_text:(acc_text ^ text) ~run_id_opt
+    | Text_message_end ->
+        loop ~acc_text ~run_id_opt
+    | Run_finished { run_id = _ } ->
+        if String.length acc_text > 0 then
+          send_message ~token ~channel ~content:acc_text;
+        ()
+    | Event_error { message } ->
+        send_message ~token ~channel
+          ~content:("Keeper error: " ^ message);
+        ()
+    | Run_started { run_id; thread_id = _ } ->
+        loop ~acc_text:"" ~run_id_opt:(Some run_id)
+    | Text_message_start { message_id = _; role = _ } ->
+        loop ~acc_text ~run_id_opt
+    | Custom { name; value = _ } ->
+        Log.Keeper.debug
+          "keeper_chat_slack: custom event %s" name;
+        loop ~acc_text ~run_id_opt
+  in
+  loop ~acc_text:"" ~run_id_opt:None

--- a/lib/keeper/keeper_chat_slack.mli
+++ b/lib/keeper/keeper_chat_slack.mli
@@ -1,0 +1,31 @@
+(** Keeper_chat_slack — Slack delivery adapter for keeper chat events.
+
+    Subscribes to a [Keeper_chat_events] stream, accumulates assistant
+    text deltas, and sends the final reply to a Slack channel via the
+    Web API when the run finishes.
+
+    @since 2.145.0 *)
+
+type error =
+  | Network of string
+  | Http_status of { code : int; body : string }
+  | Slack_api of { error : string }
+  | Other of string
+
+val pp_error : Format.formatter -> error -> unit
+
+val send_message :
+  token:string -> channel:string -> content:string -> unit
+(** [send_message ~token ~channel ~content] posts to
+    [chat.postMessage]. Logs errors via [Log.Keeper.warn]. *)
+
+val adapter_loop :
+  token:string ->
+  channel:string ->
+  events:Keeper_chat_events.keeper_chat_event Eio.Stream.t ->
+  unit
+(** [adapter_loop ~token ~channel ~events] blocks on the event
+    stream until [Run_finished] or [Error], then sends the accumulated
+    text (or error message) to the given Slack channel.
+
+    The loop exits after one turn. *)

--- a/lib/operator/operator_control.ml
+++ b/lib/operator/operator_control.ml
@@ -233,11 +233,8 @@ let execute_keeper_action (ctx : 'a context) (request : action_request) =
         | None -> Error "payload.message is required"
       in
       let* () =
-        match Json_util.get_object request.payload "models" with
-        | None -> Ok ()
-        | Some _ ->
-            Error
-              "legacy keeper model args removed for masc_keeper_msg: models. Use runtime_id; concrete provider/model identity is resolved from the default runtime."
+        Keeper_meta_contract.reject_removed_model_args ~tool_name:"masc_keeper_msg"
+          request.payload
       in
       let direct_reply =
         Json_util.get_bool request.payload "direct_reply" |> Option.value ~default:false

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -933,11 +933,22 @@ let start_keeper_loops
                           MASC_DISCORD_BOT_TOKEN not set, \
                           skipping Discord delivery for keeper=%s"
                          keeper_name)
-              | Keeper_chat_queue.Slack _ ->
+              | Keeper_chat_queue.Slack { channel; _ } ->
                   Log.Keeper.info
-                    "keeper_chat_consumer: Slack adapter not yet \
-                     implemented for keeper=%s"
-                    keeper_name);
+                    "keeper_chat_consumer: forking Slack adapter \
+                     for keeper=%s"
+                    keeper_name;
+                  (match Sys.getenv_opt "MASC_SLACK_BOT_TOKEN" with
+                   | Some token ->
+                       Eio.Fiber.fork ~sw (fun () ->
+                         Keeper_chat_slack.adapter_loop ~token
+                           ~channel ~events)
+                   | None ->
+                       Log.Keeper.warn
+                         "keeper_chat_consumer: \
+                          MASC_SLACK_BOT_TOKEN not set, \
+                          skipping Slack delivery for keeper=%s"
+                         keeper_name));
              process_single_turn ~state ~clock ~sw ~auth_token:None
                ~thread_id ~closed ~payload ~run_id ~message_id
                ~agent_name ~events)

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -862,7 +862,7 @@ let start_keeper_loops
          handle_turn wires process_single_turn for actual turn execution. *)
       (try
          Keeper_chat_consumer.start ~sw ~clock
-           ~handle_turn:(fun ~keeper_name ~queued_message ->
+           ~handle_turn:(fun ~sw ~keeper_name ~queued_message ->
              let open Server_routes_http_keeper_stream in
              let now = Time_compat.now () in
              let run_id =
@@ -917,11 +917,22 @@ let start_keeper_loops
                     "keeper_chat_consumer: processing dashboard queue \
                      message for keeper=%s"
                     keeper_name
-              | Keeper_chat_queue.Discord _ ->
+              | Keeper_chat_queue.Discord { channel_id; _ } ->
                   Log.Keeper.info
-                    "keeper_chat_consumer: Discord adapter not yet \
-                     implemented for keeper=%s"
-                    keeper_name
+                    "keeper_chat_consumer: forking Discord adapter \
+                     for keeper=%s"
+                    keeper_name;
+                  (match Sys.getenv_opt "MASC_DISCORD_BOT_TOKEN" with
+                   | Some token ->
+                       Eio.Fiber.fork ~sw (fun () ->
+                         Keeper_chat_discord.adapter_loop ~token
+                           ~channel_id ~events)
+                   | None ->
+                       Log.Keeper.warn
+                         "keeper_chat_consumer: \
+                          MASC_DISCORD_BOT_TOKEN not set, \
+                          skipping Discord delivery for keeper=%s"
+                         keeper_name)
               | Keeper_chat_queue.Slack _ ->
                   Log.Keeper.info
                     "keeper_chat_consumer: Slack adapter not yet \

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -626,7 +626,7 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
         Keeper_chat_events.publish events (Text_delta text);
         consume_worker_events ()
     | Stream_terminal (false, err) ->
-        Keeper_chat_events.publish events (Error { message = err })
+        Keeper_chat_events.publish events (Event_error { message = err })
     | Stream_terminal (true, body) -> (
         try
           let payload_json_opt, visible_reply = extract_visible_reply body in
@@ -657,7 +657,7 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
         | Eio.Cancel.Cancelled _ as e -> raise e
         | exn ->
             Keeper_chat_events.publish events
-              (Error { message = Printexc.to_string exn }))
+              (Event_error { message = Printexc.to_string exn }))
   in
   consume_worker_events ()
 
@@ -756,7 +756,7 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
                   make_event ~thread_id:!current_thread_id ~run_id:!current_run_id
                     ~custom_name:(Some name) ~custom_value:(Some value) Custom)
             then loop ()
-        | Error { message } -> send_error message
+        | Event_error { message } -> send_error message
         | Run_finished { run_id } ->
             current_run_id := Some run_id;
             ignore

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -103,7 +103,7 @@ let test_parse_keeper_chat_stream_request_rejects_legacy_model_args () =
       | Error err ->
           check string ("legacy field rejected: " ^ field)
             (Printf.sprintf
-               "legacy keeper model args removed for masc_keeper_msg: %s. Use runtime_id; concrete provider/model identity is resolved from the default runtime."
+               "removed keeper model args for masc_keeper_msg: %s. Use runtime_id; concrete provider/model identity is resolved from the default runtime."
                field)
             err)
     cases


### PR DESCRIPTION
## Summary

Implements Discord and Slack delivery adapters for keeper chat multi-channel delivery (RFC-0217).

## Changes

### Phase 4 — Discord adapter
- `lib/keeper/keeper_chat_discord.ml/mli`: Discord REST delivery adapter
  - Subscribes to `Keeper_chat_events` stream
  - Accumulates text deltas, sends final reply via `Discord_rest_client.send_message`
  - 2000-char truncation limit

### Phase 5 — Slack adapter
- `lib/keeper/keeper_chat_slack.ml/mli`: Slack Web API delivery adapter
  - Subscribes to `Keeper_chat_events` stream
  - Accumulates text deltas, sends final reply via `chat.postMessage`
  - Uses `Masc_http_client.post_sync` for HTTP POST
  - 4000-char truncation limit
  - Reads `MASC_SLACK_BOT_TOKEN` env var

### Supporting changes
- Rename `Keeper_chat_events.Error` → `Event_error` to avoid OCaml variant constructor shadowing with `Result.t Error`
- Wire both adapters into `server_bootstrap_loops.ml` consumer fiber

## Verification

- `dune build @check` passes
- `dune build` passes

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
