### PR TITLE
fix(dashboard): keep synthetic idle out of blocker state

### DIFF
--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -155,6 +155,13 @@ let narrative_summary line =
   String_util.utf8_safe ~max_bytes:220 ~suffix:"..." line |> String_util.to_string
 ;;
 
+let snapshot_text_indicates_synthetic_stall text =
+  Keeper_synthetic_marker.contains_marker text
+  && has_any_ci
+       text
+       [ "no visible output"; "belief_summary"; "social_model"; "실제 막힘" ]
+;;
+
 let runtime_blocker_surface_of_progress_snapshot
       (snapshot : Keeper_memory_policy.keeper_state_snapshot)
   =
@@ -214,16 +221,7 @@ let runtime_blocker_surface_of_progress_snapshot
                    ; "manual"
                    ] -> surface "awaiting_operator" line
           | _ ->
-            if
-              Keeper_synthetic_marker.contains_marker text
-              && has_any_ci
-                   text
-                   [ "no visible output"
-                   ; "last output"
-                   ; "belief_summary"
-                   ; "social_model"
-                   ; "실제 막힘"
-                   ]
+            if snapshot_text_indicates_synthetic_stall text
             then
               (* The outer [if lines = [] then None] guard (line 168)
                  already returns early on an empty narrative; the

--- a/test/dune
+++ b/test/dune
@@ -58,6 +58,7 @@
   test_streamable_http_upgrade
   test_mcp_session_id_header
   test_keeper_sdk_error_typed_bridge
+  test_keeper_status_bridge
   test_read_drop_reason
   test_log_ring_encoder
   test_eio_context_fiber_local
@@ -308,6 +309,7 @@
   test_streamable_http_upgrade
   test_mcp_session_id_header
   test_keeper_sdk_error_typed_bridge
+  test_keeper_status_bridge
   test_read_drop_reason
   test_log_ring_encoder
   test_eio_context_fiber_local

--- a/test/test_keeper_status_bridge.ml
+++ b/test/test_keeper_status_bridge.ml
@@ -1,0 +1,58 @@
+open Masc
+
+let meta_with_summary summary =
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+        [
+          ("name", `String "verifier");
+          ("agent_name", `String "keeper-verifier-agent");
+          ("trace_id", `String "trace-verifier");
+          ("runtime_id", `String "ollama_cloud.deepseek-v4-flash");
+        ])
+  with
+  | Ok meta -> { meta with continuity_summary = summary }
+  | Error err -> Alcotest.fail ("meta_of_json_fixture failed: " ^ err)
+;;
+
+let blocker_of_summary summary =
+  let config = Workspace.default_config "/tmp/masc-test-status-bridge" in
+  Keeper_status_bridge.runtime_blocker_surface_opt config (meta_with_summary summary)
+;;
+
+let test_synthetic_idle_last_output_is_not_blocker () =
+  let summary =
+    "Decisions: [SYNTHETIC] Last output: No awaiting_verification tasks. \
+     Board posts are 21-31 days old with no new signals. Pure idle turn."
+  in
+  Alcotest.(check (option string))
+    "idle synthetic last output is not a blocker"
+    None
+    (Option.map (fun b -> b.Keeper_status_bridge.blocker_class) (blocker_of_summary summary))
+;;
+
+let test_synthetic_no_visible_output_remains_blocker () =
+  let summary = "Decisions: [SYNTHETIC] No visible output this generation" in
+  Alcotest.(check (option string))
+    "no visible output remains synthetic_stall"
+    (Some "synthetic_stall")
+    (Option.map (fun b -> b.Keeper_status_bridge.blocker_class) (blocker_of_summary summary))
+;;
+
+let () =
+  Alcotest.run
+    "keeper_status_bridge"
+    [
+      ( "synthetic progress blockers",
+        [
+          Alcotest.test_case
+            "idle synthetic last output is not blocker"
+            `Quick
+            test_synthetic_idle_last_output_is_not_blocker;
+          Alcotest.test_case
+            "no visible synthetic output remains blocker"
+            `Quick
+            test_synthetic_no_visible_output_remains_blocker;
+        ] );
+    ]
+;;


### PR DESCRIPTION
## Summary
- stop treating any synthetic Last output progress snapshot as synthetic_stall
- keep true synthetic stalls such as No visible output this generation classified as synthetic_stall
- add backend regression coverage for the verifier no-work/idle snapshot case

## Why
The live dashboard showed status=idle, paused=false, current_task_id=null, and last_runtime_attempt=null for verifier, but still surfaced runtime_blocker_class=synthetic_stall because the bridge promoted a synthetic Last output: No awaiting_verification tasks ... Pure idle turn line into a current blocker.

## Verification
- env DUNE_CACHE=disabled DUNE_BUILD_DIR=/private/tmp/masc-dune-synthetic-idle-blocker-20260606-rebase dune build --root . test/test_keeper_status_bridge.exe
- env DUNE_CACHE=disabled DUNE_BUILD_DIR=/private/tmp/masc-dune-synthetic-idle-blocker-20260606-rebase dune exec --root . test/test_keeper_status_bridge.exe
- ocamlformat --check lib/keeper/keeper_status_bridge.ml test/test_keeper_status_bridge.ml
- git diff --check HEAD~1..HEAD
- scripts/ci/check-determinism-contract.sh --base origin/main --head HEAD

Note: scripts/dune-local.sh build test/test_keeper_status_bridge.exe was attempted but refused with exit 75 because unrelated bare dune build processes were already running outside the wrapper.
