### PR TITLE
fix(dashboard): keep synthetic stall diagnostic non-blocking

### DIFF
--- a/dashboard/src/components/agent-roster.test.ts
+++ b/dashboard/src/components/agent-roster.test.ts
@@ -81,15 +81,15 @@ describe('rosterStateNote — RFC-0135 §1.1 typed-state conditioning', () => {
     }
   }
 
-  it('returns "현재 차단" when blocker is set and no composite is available', () => {
+  it('returns "상태 추정" for synthetic_stall when no composite is available', () => {
     const note = rosterStateNote(
-      k({ runtime_blocker_class: 'synthetic_stall', runtime_blocker_summary: '실제 막힘' }),
+      k({ runtime_blocker_class: 'synthetic_stall', runtime_blocker_summary: '합성 상태 정체' }),
       null,
       null,
     )
     expect(note).toEqual({
-      label: '현재 차단',
-      text: '실제 막힘',
+      label: '상태 추정',
+      text: '합성 상태 정체',
       kind: 'synthetic_stall',
     })
   })

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -128,6 +128,7 @@ function rosterContextMeta(
  * Display rules per typed state:
  *  - stuck             → `현재 차단`  (text: backend summary or typed reason)
  *  - running + staleBlocker → `이전 차단` (informational; not a headline)
+ *  - running + synthetic_stall → `상태 추정` (diagnostic; not a blocker)
  *  - running           → fallback to diagnostic error / monitoring hint
  *  - paused           → pause cause when available, because it explains the
  *                       resume gate.
@@ -191,6 +192,15 @@ export function rosterStateNote(
       label: '이전 차단',
       text: `이전 턴 차단 (${state.staleBlocker}) — 현재는 실행 중`,
       kind: state.staleBlocker,
+    }
+  }
+
+  if (state.kind === 'running' && keeper.runtime_blocker_class === 'synthetic_stall') {
+    const summary = keeper.runtime_blocker_summary?.trim()
+    return {
+      label: '상태 추정',
+      text: summary || '실제 STATE 없이 합성된 진행 기록만 남아 최근 턴 산출물 재확인이 필요합니다.',
+      kind: 'synthetic_stall',
     }
   }
 

--- a/dashboard/src/lib/keeper-operational-state.test.ts
+++ b/dashboard/src/lib/keeper-operational-state.test.ts
@@ -207,7 +207,7 @@ describe('deriveKeeperOperationalState — offline branch', () => {
 })
 
 describe('deriveKeeperOperationalState — stuck branch (RFC-0135 §1.1 root)', () => {
-  it('blocker without composite ⇒ stuck reason=blocker_class', () => {
+  it('synthetic_stall without composite ⇒ running because it is diagnostic-only', () => {
     const state = deriveKeeperOperationalState({
       keeper: makeKeeper({
         runtime_blocker_class: 'synthetic_stall',
@@ -215,8 +215,24 @@ describe('deriveKeeperOperationalState — stuck branch (RFC-0135 §1.1 root)', 
       composite: null,
     })
     expect(state).toMatchObject({
-      kind: 'stuck',
+      kind: 'running',
       attention: 'clean',
+      staleBlocker: null,
+    })
+  })
+
+  it('synthetic_stall with blocked runtime_attention ⇒ stuck', () => {
+    const state = deriveKeeperOperationalState({
+      keeper: makeKeeper({
+        runtime_blocker_class: 'synthetic_stall',
+      }),
+      composite: makeComposite({
+        runtime_attention: attention({ execution_current: true, blocked: true }),
+      }),
+    })
+    expect(state).toMatchObject({
+      kind: 'stuck',
+      attention: 'blocked',
       reason: 'synthetic_stall',
     })
   })
@@ -276,7 +292,9 @@ describe('deriveKeeperOperationalState — stuck branch (RFC-0135 §1.1 root)', 
     for (const cls of KEEPER_RUNTIME_BLOCKER_CLASSES) {
       const state = deriveKeeperOperationalState({
         keeper: makeKeeper({ runtime_blocker_class: cls as KeeperRuntimeBlockerClass }),
-        composite: null,
+        composite: cls === 'synthetic_stall'
+          ? makeComposite({ runtime_attention: attention({ execution_current: true, blocked: true }) })
+          : null,
       })
       expect(state.kind === 'stuck' && state.reason === cls).toBe(true)
     }

--- a/dashboard/src/lib/keeper-operational-state.ts
+++ b/dashboard/src/lib/keeper-operational-state.ts
@@ -27,11 +27,14 @@
 //   paused   ⇐ keeper.paused | phase==='Paused' | pause_state==='paused'
 //   offline  ⇐ phase ∈ Offline/Stopped/Dead/Crashed/Zombie  OR
 //              status ∈ offline/inactive/unbooted
-//   stuck    ⇐ (runtime_blocker_class set AND NOT explicitlyStale)
+//   stuck    ⇐ (runtime_blocker_class set AND NOT explicitlyStale
+//                 AND class is execution-blocking)
 //              OR composite reports fiber_alive === false
 //   running  ⇐ otherwise. When the blocker_class is set but the receipt
 //              is explicitly stale, the blocker is recorded as
 //              `staleBlocker` for display but does NOT drive the headline.
+//              Diagnostic-only classes such as `synthetic_stall` remain
+//              running unless runtime_attention.blocked attests a live block.
 //
 // catch-all `default:` is forbidden — see RFC-0135 §9 (PR-9 CI guard).
 
@@ -120,6 +123,16 @@ function canonicalRuntimeBlockerClass(
   return blockerClass
 }
 
+function runtimeBlockerDrivesStuck(
+  blockerClass: KeeperRuntimeBlockerClass,
+  attention: KeeperCompositeSnapshot['runtime_attention'] | null,
+): boolean {
+  if (blockerClass === 'synthetic_stall') {
+    return attention?.blocked === true
+  }
+  return true
+}
+
 export function deriveKeeperOperationalState(
   { keeper, composite }: DeriveInputs,
 ): KeeperOperationalState {
@@ -143,7 +156,11 @@ export function deriveKeeperOperationalState(
     attention?.execution_current === false
     || attention?.stale_execution_receipt === true
 
-  if (blockerClass !== null && !explicitlyStale) {
+  if (
+    blockerClass !== null
+    && !explicitlyStale
+    && runtimeBlockerDrivesStuck(blockerClass, attention)
+  ) {
     return { kind: 'stuck', ...axes, reason: blockerClass }
   }
 


### PR DESCRIPTION
Summary:
- Treat synthetic_stall as diagnostic-only unless runtime_attention.blocked attests a live block.
- Show synthetic_stall on roster as 상태 추정 instead of 현재 차단.
- Update operational-state and roster tests for the non-blocking synthetic path.

Validation:
- pnpm exec vitest run --config vitest.config.ts src/lib/keeper-operational-state.test.ts src/components/agent-roster.test.ts src/components/keeper-detail-runtime.test.ts src/lib/keeper-predicates.test.ts src/lib/keeper-runtime-display.test.ts --no-file-parallelism --maxWorkers=1
- pnpm exec tsc --noEmit --pretty false
- git diff --check