### PR TITLE
feat(session): MCP transport session grace period + file persistence + keeper_report_state

### DIFF
--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -36,6 +36,11 @@ module Session = struct
   (** Rate limit window (seconds) *)
   let rate_limit_window_seconds =
     get_float ~default:60.0 "MASC_SESSION_RATE_LIMIT_WINDOW_SEC"
+
+  (** Grace period after SSE disconnect before reaping transport session (seconds).
+      Prevents "Unknown Mcp-Session-Id" errors on brief SSE interruptions. *)
+  let sse_grace_period_seconds =
+    get_float ~default:300.0 "MASC_SESSION_SSE_GRACE_PERIOD_SEC"
 end
 
 (** {1 Tempo (Polling Interval) Configuration} *)

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -683,6 +683,8 @@ let session_entries =
       "Maximum session age before cleanup (seconds, 1 hour)";
     entry ~default:"60.0" "MASC_SESSION_RATE_LIMIT_WINDOW_SEC"
       "Rate limit window (seconds)";
+    entry ~default:"300.0" "MASC_SESSION_SSE_GRACE_PERIOD_SEC"
+      "Grace period after SSE disconnect before reaping transport session (seconds, 5 min)";
   ]
 
 let shutdown_entries =

--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -324,6 +324,7 @@ type task_op =
   | Task_create
   | Task_claim
   | Task_done
+  | State_report
 
 let task_op_of_name = function
   | "keeper_tasks_list" -> Some Tasks_list
@@ -334,6 +335,7 @@ let task_op_of_name = function
   | "keeper_task_create" -> Some Task_create
   | "keeper_task_claim" -> Some Task_claim
   | "keeper_task_done" -> Some Task_done
+  | "keeper_report_state" -> Some State_report
   | _ -> None
 ;;
 

--- a/lib/keeper_registry/keeper_state_block_prompt.ml
+++ b/lib/keeper_registry/keeper_state_block_prompt.ml
@@ -16,7 +16,9 @@ let template_text =
 let instruction_text =
   String.concat "\n"
     [
-      "For non-direct keeper turns, end every response with a [STATE]...[/STATE] block unless a more specific turn-level output guard says continuity is runtime-managed:";
-      Printf.sprintf "State block template: %s." field_summary;
+      "For non-direct keeper turns, call the keeper_report_state tool at the end of your response to report your turn state for continuity. This is MANDATORY — do not skip it.";
+      "The tool accepts: goal, progress, done_summary, next_summary, next_items, decisions, open_questions, constraints. All fields are optional but provide as many as you can.";
+      Printf.sprintf "State fields correspond to the legacy [STATE] block: %s." field_summary;
+      "If the tool is unavailable for any reason, fall back to a [STATE]...[/STATE] text block:";
       template_text;
     ]

--- a/lib/keeper_tooling/keeper_tool_name.ml
+++ b/lib/keeper_tooling/keeper_tool_name.ml
@@ -47,6 +47,7 @@ type t =
   | Time_now
   | Tool_search
   | Tools_list
+  | State_report
   | Voice_agent
   | Voice_listen
   | Voice_session_end
@@ -94,6 +95,7 @@ let to_string = function
   | Time_now -> "keeper_time_now"
   | Tool_search -> "keeper_tool_search"
   | Tools_list -> "keeper_tools_list"
+  | State_report -> "keeper_report_state"
   | Voice_agent -> "keeper_voice_agent"
   | Voice_listen -> "keeper_voice_listen"
   | Voice_session_end -> "keeper_voice_session_end"
@@ -142,6 +144,7 @@ let of_string = function
   | "keeper_time_now" -> Some Time_now
   | "keeper_tool_search" -> Some Tool_search
   | "keeper_tools_list" -> Some Tools_list
+  | "keeper_report_state" -> Some State_report
   | "keeper_voice_agent" -> Some Voice_agent
   | "keeper_voice_listen" -> Some Voice_listen
   | "keeper_voice_session_end" -> Some Voice_session_end
@@ -210,6 +213,7 @@ let is_keeper_board_tool = function
   | Time_now
   | Tool_search
   | Tools_list
+  | State_report
   | Voice_agent
   | Voice_listen
   | Voice_session_end

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -92,6 +92,12 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
     ~on_error:(log_server_fiber_crash "maintenance_cleanup")
     (fun () ->
     let last_prune = ref (Unix.gettimeofday ()) in
+    (* Restore MCP transport sessions from disk before first cleanup cycle.
+       Grace period timestamps survive server restart, so recently-active
+       clients can reconnect without "Unknown Mcp-Session-Id" errors. *)
+    (try Server_mcp_transport_http_session.load_sessions_from_file ()
+     with exn ->
+       Log.Server.warn "session restore failed: %s" (Printexc.to_string exn));
     let rec loop () =
       Eio.Time.sleep clock Env_config_runtime.InternalTimers.janitor_interval_sec;
       (try

--- a/lib/server/server_mcp_transport_http_session.ml
+++ b/lib/server/server_mcp_transport_http_session.ml
@@ -16,6 +16,16 @@ let protocol_version_by_session : string SMap.t Atomic.t = Atomic.make SMap.empt
 
 let mcp_profile_by_session : Server_mcp_transport_http_types.tool_profile SMap.t Atomic.t = Atomic.make SMap.empty
 
+(** Grace period: seconds to keep a session after SSE disconnect before reaping.
+    Prevents immediate reap on brief SSE interruptions or server restart.
+    Configurable via [MASC_SESSION_SSE_GRACE_PERIOD_SEC] env var (default 300 = 5 min). *)
+let grace_period_seconds = Env_config_runtime.Session.sse_grace_period_seconds
+
+(** Per-session timestamp of last active SSE connection.
+    Used by [reap_stale_sessions] to implement the grace period:
+    sessions without active SSE are kept until [now - last_active > grace_period]. *)
+let session_last_active_sse : float SMap.t Atomic.t = Atomic.make SMap.empty
+
 let default_base_path () =
   (* Match the launcher guard: a direct binary launch from a checkout with its
      own .masc must not silently inherit a stale parent MASC_BASE_PATH.
@@ -28,8 +38,11 @@ let is_valid_protocol_version version =
   List.mem version mcp_protocol_versions
 
 let remember_protocol_version session_id version =
-  if is_valid_protocol_version version then
-    atomic_update protocol_version_by_session (fun map -> SMap.add session_id version map)
+  if is_valid_protocol_version version then begin
+    atomic_update protocol_version_by_session (fun map -> SMap.add session_id version map);
+    let now = Unix.gettimeofday () in
+    atomic_update session_last_active_sse (fun map -> SMap.add session_id now map)
+  end
 
 (** RFC-0100 PR-3 — Q3 default: known-session predicate.
 
@@ -48,20 +61,145 @@ let is_known_session session_id =
   SMap.mem session_id (Atomic.get protocol_version_by_session)
 
 let remember_mcp_profile session_id profile =
-  atomic_update mcp_profile_by_session (fun map -> SMap.add session_id profile map)
+  atomic_update mcp_profile_by_session (fun map -> SMap.add session_id profile map);
+  let now = Unix.gettimeofday () in
+  atomic_update session_last_active_sse (fun map -> SMap.add session_id now map)
 
 let forget_mcp_session session_id =
   atomic_update protocol_version_by_session (fun map -> SMap.remove session_id map);
-  atomic_update mcp_profile_by_session (fun map -> SMap.remove session_id map)
+  atomic_update mcp_profile_by_session (fun map -> SMap.remove session_id map);
+  atomic_update session_last_active_sse (fun map -> SMap.remove session_id map)
 
-(** Reap session entries whose session_id has no active SSE connection.
+(* ===== File persistence ===== *)
+
+let profile_to_string = function
+  | Server_mcp_transport_http_types.Full -> "full"
+  | Server_mcp_transport_http_types.Managed_agent -> "managed_agent"
+  | Server_mcp_transport_http_types.Operator_remote -> "operator_remote"
+
+let profile_of_string = function
+  | "full" -> Some Server_mcp_transport_http_types.Full
+  | "managed_agent" -> Some Server_mcp_transport_http_types.Managed_agent
+  | "operator_remote" -> Some Server_mcp_transport_http_types.Operator_remote
+  | _ -> None
+
+let sessions_file_path () =
+  let base = default_base_path () in
+  Filename.concat (Filename.concat base ".masc") "mcp_transport_sessions.json"
+
+(** Serialize current session state to JSON and write to disk atomically.
+    Uses write-then-rename to avoid partial writes on crash. *)
+let save_sessions_to_file () =
+  let path = sessions_file_path () in
+  let dir = Filename.dirname path in
+  if not (Stdlib.Sys.file_exists dir) then
+    try Unix.mkdir dir 0o755 with Unix.Unix_error _ -> ();
+  let versions = Atomic.get protocol_version_by_session in
+  let profiles = Atomic.get mcp_profile_by_session in
+  let timestamps = Atomic.get session_last_active_sse in
+  let all_ids = SMap.fold (fun sid _ acc -> sid :: acc) versions [] in
+  let json_entries =
+    List.filter_map (fun sid ->
+      match SMap.find_opt sid versions with
+      | None -> None
+      | Some pv ->
+          let profile_str =
+            match SMap.find_opt sid profiles with
+            | Some p -> profile_to_string p
+            | None -> "full"
+          in
+          let ts =
+            match SMap.find_opt sid timestamps with
+            | Some t -> t
+            | None -> 0.0
+          in
+          Some (sid, `Assoc
+            [ "protocol_version", `String pv
+            ; "profile", `String profile_str
+            ; "last_active_sse", `Float ts
+            ])
+    ) all_ids
+  in
+  let json = `Assoc [ "sessions", `Assoc json_entries ] in
+  let tmp_path = path ^ ".tmp" in
+  let oc = open_out tmp_path in
+  output_string oc (Yojson.Basic.to_string json);
+  output_char oc '\n';
+  close_out oc;
+  Unix.rename tmp_path path
+
+(** Load session state from disk. Restores protocol versions, profiles,
+    and last-active timestamps so the grace period applies correctly
+    after a server restart.
+
+    Errors (missing file, corrupt JSON) are silently ignored — the
+    server starts with a clean slate, which is safe but means clients
+    must re-handshake. *)
+let load_sessions_from_file () =
+  let path = sessions_file_path () in
+  if not (Stdlib.Sys.file_exists path) then ()
+  else begin
+    try
+      let json = Yojson.Basic.from_file path in
+      (match json with
+       | `Assoc [("sessions", `Assoc entries)] ->
+           List.iter (fun (sid, entry) ->
+             match entry with
+             | `Assoc fields ->
+                 let pv = List.assoc_opt "protocol_version" fields in
+                 let profile_str = List.assoc_opt "profile" fields in
+                 let ts = List.assoc_opt "last_active_sse" fields in
+                 (match pv, profile_str, ts with
+                  | Some (`String v), Some (`String p), Some (`Float t) ->
+                      if is_valid_protocol_version v then begin
+                        atomic_update protocol_version_by_session
+                          (fun map -> SMap.add sid v map);
+                        (match profile_of_string p with
+                         | Some profile ->
+                             atomic_update mcp_profile_by_session
+                               (fun map -> SMap.add sid profile map)
+                         | None -> ());
+                        atomic_update session_last_active_sse
+                          (fun map -> SMap.add sid t map)
+                      end
+                  | _ -> ())
+             | _ -> ()
+           ) entries
+       | _ -> ())
+    with
+    | Stdlib.Sys_error _ -> ()
+    | Yojson.Json_error _ -> ()
+  end
+
+(** Reap session entries whose session_id has no active SSE connection
+    AND whose grace period has expired.
+
+    Grace period logic: when a session's SSE goes inactive, we record the
+    timestamp in [session_last_active_sse]. The session is kept for
+    [grace_period_seconds] after that point, giving the client time to
+    reconnect without triggering "Unknown Mcp-Session-Id" errors.
+
     Call periodically from the cleanup loop. Returns number of reaped entries. *)
 let reap_stale_sessions ~is_active_session =
-  let stale =
-    SMap.fold (fun sid _ acc ->
-      if not (is_active_session sid) then sid :: acc
-      else acc
-    ) (Atomic.get protocol_version_by_session) []
+  let now = Unix.gettimeofday () in
+  let stale, kept_by_grace =
+    SMap.fold (fun sid _ (stale_acc, grace_acc) ->
+      if is_active_session sid then begin
+        (* Active right now — refresh timestamp, keep session *)
+        atomic_update session_last_active_sse
+          (fun map -> SMap.add sid now map);
+        (stale_acc, grace_acc)
+      end else begin
+        (* Not active — check grace period *)
+        match SMap.find_opt sid (Atomic.get session_last_active_sse) with
+        | Some last_active when now -. last_active < grace_period_seconds ->
+            (* Within grace period — keep *)
+            (stale_acc, grace_acc + 1)
+        | _ ->
+            (* Grace expired or never tracked — reap *)
+            (sid :: stale_acc, grace_acc)
+      end
+    ) (Atomic.get protocol_version_by_session) ([], 0)
   in
   if stale <> [] then begin
     atomic_update protocol_version_by_session (fun map ->
@@ -69,8 +207,18 @@ let reap_stale_sessions ~is_active_session =
     );
     atomic_update mcp_profile_by_session (fun map ->
       List.fold_left (fun m sid -> SMap.remove sid m) map stale
+    );
+    atomic_update session_last_active_sse (fun map ->
+      List.fold_left (fun m sid -> SMap.remove sid m) map stale
     )
   end;
+  if kept_by_grace > 0 then
+    Log.Server.info "session grace: %d sessions kept (inactive but within %.0fs grace)"
+      kept_by_grace grace_period_seconds;
+  (* Persist session state after each reap cycle so file stays current. *)
+  (try save_sessions_to_file ()
+   with Stdlib.Sys_error msg ->
+     Log.Server.warn "session persist failed: %s" msg);
   List.length stale
 
 let profile_label = function

--- a/lib/server/server_mcp_transport_http_session.mli
+++ b/lib/server/server_mcp_transport_http_session.mli
@@ -48,6 +48,37 @@ val forget_mcp_session : string -> unit
 (** Removes both the protocol-version and tool-profile entries
     for [session_id]. *)
 
+(** {1 Grace period}
+
+    Sessions whose SSE connection drops are kept for a configurable
+    grace period before reaping.  This prevents "Unknown Mcp-Session-Id"
+    errors when clients briefly disconnect and reconnect. *)
+
+val grace_period_seconds : float
+(** Seconds to keep a session after SSE disconnect.  Default 300 (5 min).
+    Configurable via [MASC_SESSION_SSE_GRACE_PERIOD_SEC] env var. *)
+
+(** {1 File persistence}
+
+    Session state (protocol version, profile, last-active timestamp)
+    is persisted to [\<base_path\>/.masc/mcp_transport_sessions.json].
+    On restart, [load_sessions_from_file] restores the state so the
+    grace period applies to recently-active sessions. *)
+
+val sessions_file_path : unit -> string
+(** Returns the path to the persistence file.  Exposed for testing. *)
+
+val save_sessions_to_file : unit -> unit
+(** Serialize current session state and write atomically to disk.
+    Called automatically by [reap_stale_sessions] after each cleanup.
+    Safe to call at any time — uses write-then-rename. *)
+
+val load_sessions_from_file : unit -> unit
+(** Load session state from disk into the in-memory registries.
+    Call once during server startup, before the MCP handler accepts
+    requests.  Errors (missing file, corrupt JSON) are silently
+    ignored — the server starts clean. *)
+
 val profile_label : Server_mcp_transport_http_types.tool_profile -> string
 (** Stable label for the MCP HTTP surface a session belongs to.
     Used in profile-mismatch errors and termination logs. *)

--- a/lib/tool_surface/tool_shard_types_schemas_taskboard.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_taskboard.ml
@@ -269,5 +269,79 @@ let taskboard_tools : Masc_domain.tool_schema list =
           ; "required", `List [ `String "title"; `String "description" ]
           ]
     }
+  ; { name = "keeper_report_state"
+    ; description =
+        "Report your current turn state for continuity across cycles. \
+         Call this at the end of every non-direct keeper turn. Provides \
+         structured state (goal, progress, next steps, decisions, open \
+         questions, constraints) that survives cycle boundaries."
+    ; input_schema =
+        `Assoc
+          [ "type", `String "object"
+          ; ( "properties"
+            , `Assoc
+                [ ( "goal"
+                  , `Assoc
+                      [ "type", `String "string"
+                      ; ( "description"
+                        , `String "Current active goal (one sentence)" )
+                      ] )
+                ; ( "progress"
+                  , `Assoc
+                      [ "type", `String "string"
+                      ; ( "description"
+                        , `String
+                            "Summary of what was accomplished this turn" )
+                      ] )
+                ; ( "done_summary"
+                  , `Assoc
+                      [ "type", `String "string"
+                      ; ( "description"
+                        , `String
+                            "Detailed summary of completed work this turn" )
+                      ] )
+                ; ( "next_summary"
+                  , `Assoc
+                      [ "type", `String "string"
+                      ; ( "description"
+                        , `String
+                            "What the next turn should focus on" )
+                      ] )
+                ; ( "next_items"
+                  , `Assoc
+                      [ "type", `String "array"
+                      ; "items", `Assoc [ "type", `String "string" ]
+                      ; ( "description"
+                        , `String
+                            "Specific action items for the next turn" )
+                      ] )
+                ; ( "decisions"
+                  , `Assoc
+                      [ "type", `String "array"
+                      ; "items", `Assoc [ "type", `String "string" ]
+                      ; ( "description"
+                        , `String
+                            "Key decisions made this turn" )
+                      ] )
+                ; ( "open_questions"
+                  , `Assoc
+                      [ "type", `String "array"
+                      ; "items", `Assoc [ "type", `String "string" ]
+                      ; ( "description"
+                        , `String
+                            "Unresolved questions or blockers" )
+                      ] )
+                ; ( "constraints"
+                  , `Assoc
+                      [ "type", `String "array"
+                      ; "items", `Assoc [ "type", `String "string" ]
+                      ; ( "description"
+                        , `String
+                            "Active constraints or limitations" )
+                      ] )
+                ] )
+          ; "required", `List []
+          ]
+    }
   ]
 ;;


### PR DESCRIPTION
## Summary

Prevents repeated "Unknown Mcp-Session-Id" errors when keepers lose SSE connectivity. Two root-cause fixes:

### 1. Grace Period (MASC_SESSION_SSE_GRACE_PERIOD_SEC, default 300s)
- Per-session last-active-SSE timestamp tracking
- Inactive sessions kept within grace period instead of immediate removal
- Active sessions get timestamp refreshed each cleanup cycle

### 2. File Persistence (<base>/.masc/mcp_transport_sessions.json)
- Session state serialized to disk after each cleanup (atomic write-then-rename)
- Restored on startup so recently-active clients can reconnect
- Grace period timestamps survive restart

### 3. keeper_report_state Tool
- Structured state reporting replaces text-based [STATE]...[/STATE] blocks
- Schema: goal, progress, done_summary, next_summary, next_items, decisions, open_questions, constraints

## Root Cause
Server reaps sessions when SSE disconnects (no grace period) + client doesn't re-handshake on 404 + ephemeral in-memory state lost on restart.

Fix: don't lose state unnecessarily (grace period) + persist across restarts (file).

## Files (9 changed, +286/-12)
- server_mcp_transport_http_session.ml/mli — grace period + persistence
- server_bootstrap_maintenance.ml — load on startup
- env_config_runtime.ml, env_config_snapshot.ml — config
- keeper_tool_name.ml, keeper_tool_task_runtime.ml — State_report variant
- keeper_state_block_prompt.ml — tool-based prompt
- tool_shard_types_schemas_taskboard.ml — JSON schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)