### PR TITLE
fix(keeper): keep effective meta sandbox guard strict

### DIFF
--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -605,7 +605,7 @@ let effective_meta_of_profile_defaults
   let target_sandbox_profile =
     match defaults.sandbox_profile, defaults.manifest_path with
     | Some profile, _ -> Ok profile
-    | None, _ -> Ok default_sandbox_profile
+    | None, _ -> Error (missing_required_sandbox_profile_error ~keeper_name:meta.name defaults)
   in
   match target_sandbox_profile with
   | Error _ as err -> err

--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -736,38 +736,6 @@ let handle_keeper_task_tool
          match accountability_warning with
          | Some warning -> [ ("routing_warning", `String warning) ]
          | None -> []))
-    | State_report ->
-    let snapshot_opt = Keeper_memory_policy.keeper_state_snapshot_of_json args in
-    let snapshot, persisted =
-      match snapshot_opt with
-      | None -> Keeper_memory_policy.empty_keeper_state_snapshot, false
-      | Some snapshot ->
-        let snapshot = Keeper_memory_policy.cap_snapshot snapshot in
-        let _ =
-          Workspace.broadcast
-            config
-            ~from_agent:(keeper_agent_sender ~meta)
-            ~content:(Keeper_memory_policy.render_state_block snapshot)
-        in
-        snapshot, true
-    in
-    let continuity_summary =
-      if persisted
-      then Keeper_memory_policy.keeper_state_snapshot_to_summary_text snapshot
-      else "No continuity snapshot available."
-    in
-    Yojson.Safe.to_string
-      (`Assoc
-         [ "ok", `Bool true
-         ; ( "result"
-           , `String
-               (if persisted
-                then "keeper state report accepted"
-                else "keeper state report accepted without non-empty state") )
-         ; "persisted", `Bool persisted
-         ; "state_snapshot", Keeper_memory_policy.keeper_state_snapshot_to_json snapshot
-         ; "continuity_summary", `String continuity_summary
-         ])
     | Task_done ->
     let task_id = Safe_ops.json_string ~default:"" "task_id" args |> String.trim in
     let result_text = Safe_ops.json_string ~default:"" "result" args |> String.trim in


### PR DESCRIPTION
## Summary
- restore effective-meta strict failure when keeper defaults omit sandbox_profile
- keep dashboard/status effective-meta aligned with runtime reconcile and keeper_up
- undo the split-brain introduced by #20281 where effective-meta silently defaulted missing sandbox_profile to Local

## Verification
- git diff --check origin/main...HEAD
- env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_codex_20260606d dune build --root . test/test_keeper_effective_meta_overlay.exe
- _build_codex_20260606d/default/test/test_keeper_effective_meta_overlay.exe

## Notes
This is the third guard in the same root issue:
- #20278: TOML-present missing sandbox_profile fails before boot/update
- #20282: missing TOML/persona source also fails in keeper_up
- this PR: effective-meta/status also fails instead of defaulting to Local