### PR TITLE
feat(dashboard): add runtime environment editor

### DIFF
--- a/dashboard/src/components/runtime-environment-editor.ts
+++ b/dashboard/src/components/runtime-environment-editor.ts
@@ -1,0 +1,476 @@
+import { html } from 'htm/preact'
+import { Save } from 'lucide-preact'
+import { useEffect, useMemo, useState } from 'preact/hooks'
+import {
+  parseRuntimeTomlEnvironment,
+  setRuntimeTomlBindingField,
+  setRuntimeTomlDefault,
+  setRuntimeTomlModelField,
+  setRuntimeTomlProviderCredential,
+  setRuntimeTomlProviderField,
+  type RuntimeTomlBinding,
+  type RuntimeTomlCredentialType,
+  type RuntimeTomlEnvironment,
+  type RuntimeTomlModel,
+  type RuntimeTomlProvider,
+  type RuntimeTomlTransportKind,
+} from '../lib/runtime-toml-config'
+import { ActionButton } from './common/button'
+
+interface RuntimeEnvironmentEditorProps {
+  sourceText: string
+  dirty: boolean
+  disabled?: boolean
+  saving?: boolean
+  onDraftChange: (sourceText: string) => void
+  onSave: (sourceText?: string) => void
+}
+
+const FIELD_CLASS = 'w-full rounded-[var(--r-1)] border border-[var(--input-border)] bg-[var(--input-bg)] px-2 py-1.5 text-xs text-[var(--color-fg-primary)] outline-none focus:border-[var(--color-accent-fg)]'
+const CHECKBOX_CLASS = 'h-4 w-4 rounded-[var(--r-0)] border border-[var(--input-border)] bg-[var(--input-bg)]'
+
+function firstId<T extends { id: string }>(items: T[]): string {
+  return items[0]?.id ?? ''
+}
+
+function selectedItem<T extends { id: string }>(items: T[], selectedId: string): T | null {
+  return items.find(item => item.id === selectedId) ?? items[0] ?? null
+}
+
+function numberValue(value: number | null): string {
+  return typeof value === 'number' && Number.isFinite(value) ? String(value) : ''
+}
+
+function parsePositiveInt(value: string): number | null {
+  const parsed = Number.parseInt(value, 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null
+}
+
+function FieldShell({
+  label,
+  hint,
+  children,
+}: {
+  label: string
+  hint?: string
+  children: unknown
+}) {
+  return html`
+    <label class="min-w-0">
+      <span class="mb-1 block text-2xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">${label}</span>
+      ${children}
+      ${hint ? html`<span class="mt-1 block text-3xs text-[var(--color-fg-disabled)]">${hint}</span>` : null}
+    </label>
+  `
+}
+
+function ToggleField({
+  label,
+  checked,
+  disabled,
+  onChange,
+}: {
+  label: string
+  checked: boolean
+  disabled?: boolean
+  onChange: (checked: boolean) => void
+}) {
+  return html`
+    <label class="flex min-h-9 items-center justify-between gap-3 rounded-[var(--r-1)] border border-[var(--color-border-subtle)] px-2 py-1.5">
+      <span class="text-xs text-[var(--color-fg-secondary)]">${label}</span>
+      <input
+        type="checkbox"
+        class=${CHECKBOX_CLASS}
+        checked=${checked}
+        disabled=${disabled}
+        onChange=${(event: Event) => onChange((event.currentTarget as HTMLInputElement).checked)}
+      />
+    </label>
+  `
+}
+
+function runtimeOptions(environment: RuntimeTomlEnvironment): string[] {
+  return environment.bindings.map(binding => binding.id)
+}
+
+function credentialValue(provider: RuntimeTomlProvider): string {
+  if (provider.credentialType === 'env') return provider.credentialKey
+  if (provider.credentialType === 'file') return provider.credentialPath
+  if (provider.credentialType === 'inline') return provider.credentialValue
+  return ''
+}
+
+function credentialLabel(type: RuntimeTomlCredentialType): string {
+  if (type === 'env') return 'env key'
+  if (type === 'file') return 'file path'
+  if (type === 'inline') return 'inline value'
+  return 'credential'
+}
+
+function transportValue(provider: RuntimeTomlProvider): string {
+  if (provider.transportKind === 'command') return provider.command
+  return provider.endpoint
+}
+
+function SectionTitle({ children }: { children: unknown }) {
+  return html`
+    <div class="text-2xs font-bold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-primary)]">
+      ${children}
+    </div>
+  `
+}
+
+export function RuntimeEnvironmentEditor({
+  sourceText,
+  dirty,
+  disabled,
+  saving,
+  onDraftChange,
+  onSave,
+}: RuntimeEnvironmentEditorProps) {
+  const environment = useMemo(() => parseRuntimeTomlEnvironment(sourceText), [sourceText])
+  const [selectedRuntimeId, setSelectedRuntimeId] = useState('')
+  const [selectedProviderId, setSelectedProviderId] = useState('')
+  const [selectedModelId, setSelectedModelId] = useState('')
+
+  useEffect(() => {
+    const nextRuntimeId = environment.bindings.some(binding => binding.id === selectedRuntimeId)
+      ? selectedRuntimeId
+      : environment.defaultRuntimeId || firstId(environment.bindings)
+    const runtime = environment.bindings.find(binding => binding.id === nextRuntimeId) ?? environment.bindings[0] ?? null
+    const nextProviderId = environment.providers.some(provider => provider.id === selectedProviderId)
+      ? selectedProviderId
+      : runtime?.providerId ?? firstId(environment.providers)
+    const nextModelId = environment.models.some(model => model.id === selectedModelId)
+      ? selectedModelId
+      : runtime?.modelId ?? firstId(environment.models)
+    if (nextRuntimeId !== selectedRuntimeId) setSelectedRuntimeId(nextRuntimeId)
+    if (nextProviderId !== selectedProviderId) setSelectedProviderId(nextProviderId)
+    if (nextModelId !== selectedModelId) setSelectedModelId(nextModelId)
+  }, [environment, selectedModelId, selectedProviderId, selectedRuntimeId])
+
+  const bindings = runtimeOptions(environment)
+  const selectedRuntime = selectedItem<RuntimeTomlBinding>(environment.bindings, selectedRuntimeId)
+  const selectedProvider = selectedItem<RuntimeTomlProvider>(environment.providers, selectedProviderId)
+  const selectedModel = selectedItem<RuntimeTomlModel>(environment.models, selectedModelId)
+  const isDisabled = disabled === true || saving === true
+
+  function updateDefault(runtimeId: string) {
+    setSelectedRuntimeId(runtimeId)
+    const runtime = environment.bindings.find(binding => binding.id === runtimeId)
+    if (runtime) {
+      setSelectedProviderId(runtime.providerId)
+      setSelectedModelId(runtime.modelId)
+    }
+    onDraftChange(setRuntimeTomlDefault(sourceText, runtimeId))
+  }
+
+  function updateProvider(field: 'display-name' | 'protocol' | 'endpoint' | 'command', value: string) {
+    if (!selectedProvider) return
+    onDraftChange(setRuntimeTomlProviderField(sourceText, selectedProvider.id, field, value))
+  }
+
+  function updateProviderTransport(kind: RuntimeTomlTransportKind) {
+    if (!selectedProvider || kind === 'missing') return
+    const value = kind === 'command'
+      ? selectedProvider.command || selectedProvider.endpoint
+      : selectedProvider.endpoint || selectedProvider.command
+    onDraftChange(setRuntimeTomlProviderField(sourceText, selectedProvider.id, kind, value))
+  }
+
+  function updateCredential(type: RuntimeTomlCredentialType, value: string) {
+    if (!selectedProvider) return
+    onDraftChange(setRuntimeTomlProviderCredential(sourceText, selectedProvider.id, type, value))
+  }
+
+  function updateModel(
+    field: 'api-name' | 'max-context' | 'tools-support' | 'thinking-support' | 'streaming',
+    value: string | number | boolean,
+  ) {
+    if (!selectedModel) return
+    onDraftChange(setRuntimeTomlModelField(sourceText, selectedModel.id, field, value))
+  }
+
+  function updateBinding(
+    field: 'is-default' | 'max-concurrent' | 'keep-alive' | 'num-ctx',
+    value: string | number | boolean | null,
+  ) {
+    if (!selectedRuntime) return
+    onDraftChange(setRuntimeTomlBindingField(sourceText, selectedRuntime.id, field, value))
+  }
+
+  return html`
+    <div class="border-t border-[var(--color-border-divider)] pt-3" data-testid="runtime-environment-editor">
+      <div class="mb-3 flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
+        <div class="min-w-0">
+          <div class="text-2xs font-bold uppercase tracking-[var(--track-caps)] text-[var(--color-accent-fg)]">
+            런타임 환경
+          </div>
+        </div>
+        <${ActionButton}
+          variant="primary"
+          size="sm"
+          onClick=${() => onSave(sourceText)}
+          disabled=${!dirty || isDisabled}
+          ariaBusy=${saving === true}
+          ariaLabel="런타임 환경 저장"
+          title="런타임 환경 저장"
+          testId="runtime-environment-save"
+          class="inline-flex shrink-0 items-center gap-1"
+        >
+          <${Save} size=${13} strokeWidth=${2.25} aria-hidden="true" />
+          <span>${saving ? '저장 중' : '환경 저장'}</span>
+        <//>
+      </div>
+
+      ${environment.warnings.length > 0 ? html`
+        <div class="mb-3 rounded-[var(--r-1)] border border-[var(--color-status-warn)]/35 bg-[var(--warn-10)] px-3 py-2 text-xs text-[var(--color-status-warn)]">
+          ${environment.warnings.join(' · ')}
+        </div>
+      ` : null}
+
+      ${bindings.length === 0 ? html`
+        <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] px-3 py-4 text-xs text-[var(--color-fg-muted)]">
+          구조화해서 편집할 provider.model binding이 없습니다. 아래 raw editor에서 runtime.toml을 먼저 추가하세요.
+        </div>
+      ` : html`
+        <div class="grid gap-3 xl:grid-cols-[minmax(16rem,0.8fr)_minmax(0,1.1fr)_minmax(0,1.1fr)_minmax(0,1fr)]">
+          <div class="grid content-start gap-3 border-b border-[var(--color-border-divider)] pb-3 xl:border-b-0 xl:border-r xl:pb-0 xl:pr-3">
+            <${SectionTitle}>기본 런타임<//>
+            <${FieldShell} label="default runtime" hint="runtime.toml [runtime].default">
+              <select
+                class=${FIELD_CLASS}
+                value=${environment.defaultRuntimeId || selectedRuntimeId}
+                disabled=${isDisabled}
+                aria-label="default runtime"
+                onChange=${(event: Event) => updateDefault((event.currentTarget as HTMLSelectElement).value)}
+              >
+                ${bindings.map(id => html`<option value=${id}>${id}</option>`)}
+              </select>
+            <//>
+            <${FieldShell} label="binding" hint="편집할 provider.model">
+              <select
+                class=${FIELD_CLASS}
+                value=${selectedRuntime?.id ?? ''}
+                disabled=${isDisabled}
+                aria-label="runtime binding"
+                onChange=${(event: Event) => {
+                  const runtimeId = (event.currentTarget as HTMLSelectElement).value
+                  setSelectedRuntimeId(runtimeId)
+                  const runtime = environment.bindings.find(binding => binding.id === runtimeId)
+                  if (runtime) {
+                    setSelectedProviderId(runtime.providerId)
+                    setSelectedModelId(runtime.modelId)
+                  }
+                }}
+              >
+                ${bindings.map(id => html`<option value=${id}>${id}</option>`)}
+              </select>
+            <//>
+          </div>
+
+          <div class="grid content-start gap-3 border-b border-[var(--color-border-divider)] pb-3 xl:border-b-0 xl:border-r xl:pb-0 xl:pr-3">
+            <${SectionTitle}>Provider 연결<//>
+            <${FieldShell} label="provider">
+              <select
+                class=${FIELD_CLASS}
+                value=${selectedProvider?.id ?? ''}
+                disabled=${isDisabled}
+                aria-label="provider"
+                onChange=${(event: Event) => setSelectedProviderId((event.currentTarget as HTMLSelectElement).value)}
+              >
+                ${environment.providers.map(provider => html`<option value=${provider.id}>${provider.id}</option>`)}
+              </select>
+            <//>
+            <${FieldShell} label="display-name">
+              <input
+                class=${FIELD_CLASS}
+                value=${selectedProvider?.displayName ?? ''}
+                disabled=${isDisabled || !selectedProvider}
+                aria-label="provider display-name"
+                onInput=${(event: Event) => updateProvider('display-name', (event.currentTarget as HTMLInputElement).value)}
+              />
+            <//>
+            <${FieldShell} label="protocol">
+              <input
+                class=${FIELD_CLASS}
+                value=${selectedProvider?.protocol ?? ''}
+                disabled=${isDisabled || !selectedProvider}
+                aria-label="provider protocol"
+                onInput=${(event: Event) => updateProvider('protocol', (event.currentTarget as HTMLInputElement).value)}
+              />
+            <//>
+            <div class="grid grid-cols-[8rem_minmax(0,1fr)] gap-2">
+              <${FieldShell} label="transport">
+                <select
+                  class=${FIELD_CLASS}
+                  value=${selectedProvider?.transportKind === 'command' ? 'command' : 'endpoint'}
+                  disabled=${isDisabled || !selectedProvider}
+                  aria-label="provider transport"
+                  onChange=${(event: Event) => updateProviderTransport((event.currentTarget as HTMLSelectElement).value as RuntimeTomlTransportKind)}
+                >
+                  <option value="endpoint">endpoint</option>
+                  <option value="command">command</option>
+                </select>
+              <//>
+              <${FieldShell} label=${selectedProvider?.transportKind === 'command' ? 'command' : 'endpoint'}>
+                <input
+                  class=${FIELD_CLASS}
+                  value=${selectedProvider ? transportValue(selectedProvider) : ''}
+                  disabled=${isDisabled || !selectedProvider}
+                  aria-label="provider transport value"
+                  onInput=${(event: Event) => {
+                    const kind = selectedProvider?.transportKind === 'command' ? 'command' : 'endpoint'
+                    updateProvider(kind, (event.currentTarget as HTMLInputElement).value)
+                  }}
+                />
+              <//>
+            </div>
+            <div class="grid grid-cols-[8rem_minmax(0,1fr)] gap-2">
+              <${FieldShell} label="credential">
+                <select
+                  class=${FIELD_CLASS}
+                  value=${selectedProvider?.credentialType ?? 'none'}
+                  disabled=${isDisabled || !selectedProvider}
+                  aria-label="provider credential type"
+                  onChange=${(event: Event) => {
+                    const type = (event.currentTarget as HTMLSelectElement).value as RuntimeTomlCredentialType
+                    updateCredential(type, credentialValue(selectedProvider as RuntimeTomlProvider))
+                  }}
+                >
+                  <option value="none">none</option>
+                  <option value="env">env</option>
+                  <option value="file">file</option>
+                  <option value="inline">inline</option>
+                </select>
+              <//>
+              <${FieldShell} label=${credentialLabel(selectedProvider?.credentialType ?? 'none')}>
+                <input
+                  class=${FIELD_CLASS}
+                  type=${selectedProvider?.credentialType === 'inline' ? 'password' : 'text'}
+                  value=${selectedProvider ? credentialValue(selectedProvider) : ''}
+                  disabled=${isDisabled || !selectedProvider || selectedProvider.credentialType === 'none'}
+                  aria-label="provider credential value"
+                  onInput=${(event: Event) => {
+                    const type = selectedProvider?.credentialType ?? 'none'
+                    updateCredential(type, (event.currentTarget as HTMLInputElement).value)
+                  }}
+                />
+              <//>
+            </div>
+          </div>
+
+          <div class="grid content-start gap-3 border-b border-[var(--color-border-divider)] pb-3 xl:border-b-0 xl:border-r xl:pb-0 xl:pr-3">
+            <${SectionTitle}>Model<//>
+            <${FieldShell} label="model">
+              <select
+                class=${FIELD_CLASS}
+                value=${selectedModel?.id ?? ''}
+                disabled=${isDisabled}
+                aria-label="model"
+                onChange=${(event: Event) => setSelectedModelId((event.currentTarget as HTMLSelectElement).value)}
+              >
+                ${environment.models.map(model => html`<option value=${model.id}>${model.id}</option>`)}
+              </select>
+            <//>
+            <${FieldShell} label="api-name">
+              <input
+                class=${FIELD_CLASS}
+                value=${selectedModel?.apiName ?? ''}
+                disabled=${isDisabled || !selectedModel}
+                aria-label="model api-name"
+                onInput=${(event: Event) => updateModel('api-name', (event.currentTarget as HTMLInputElement).value)}
+              />
+            <//>
+            <${FieldShell} label="max-context">
+              <input
+                class=${FIELD_CLASS}
+                type="number"
+                min="1"
+                step="1024"
+                value=${numberValue(selectedModel?.maxContext ?? null)}
+                disabled=${isDisabled || !selectedModel}
+                aria-label="model max-context"
+                onInput=${(event: Event) => {
+                  const parsed = parsePositiveInt((event.currentTarget as HTMLInputElement).value)
+                  if (parsed !== null) updateModel('max-context', parsed)
+                }}
+              />
+            <//>
+            <${ToggleField}
+              label="tools-support"
+              checked=${selectedModel?.toolsSupport ?? false}
+              disabled=${isDisabled || !selectedModel}
+              onChange=${(checked: boolean) => updateModel('tools-support', checked)}
+            />
+            <${ToggleField}
+              label="thinking-support"
+              checked=${selectedModel?.thinkingSupport ?? false}
+              disabled=${isDisabled || !selectedModel}
+              onChange=${(checked: boolean) => updateModel('thinking-support', checked)}
+            />
+            <${ToggleField}
+              label="streaming"
+              checked=${selectedModel?.streaming ?? false}
+              disabled=${isDisabled || !selectedModel}
+              onChange=${(checked: boolean) => updateModel('streaming', checked)}
+            />
+          </div>
+
+          <div class="grid content-start gap-3">
+            <${SectionTitle}>Binding<//>
+            <${ToggleField}
+              label="is-default"
+              checked=${selectedRuntime?.isDefault ?? false}
+              disabled=${isDisabled || !selectedRuntime}
+              onChange=${(checked: boolean) => updateBinding('is-default', checked)}
+            />
+            <${FieldShell} label="max-concurrent">
+              <input
+                class=${FIELD_CLASS}
+                type="number"
+                min="1"
+                step="1"
+                value=${numberValue(selectedRuntime?.maxConcurrent ?? null)}
+                disabled=${isDisabled || !selectedRuntime}
+                aria-label="binding max-concurrent"
+                onInput=${(event: Event) => {
+                  const parsed = parsePositiveInt((event.currentTarget as HTMLInputElement).value)
+                  if (parsed !== null) updateBinding('max-concurrent', parsed)
+                }}
+              />
+            <//>
+            <${FieldShell} label="keep-alive">
+              <input
+                class=${FIELD_CLASS}
+                value=${selectedRuntime?.keepAlive ?? ''}
+                disabled=${isDisabled || !selectedRuntime}
+                placeholder="예: 10m"
+                aria-label="binding keep-alive"
+                onInput=${(event: Event) => {
+                  const value = (event.currentTarget as HTMLInputElement).value
+                  updateBinding('keep-alive', value.trim() === '' ? null : value)
+                }}
+              />
+            <//>
+            <${FieldShell} label="num-ctx">
+              <input
+                class=${FIELD_CLASS}
+                type="number"
+                min="1"
+                step="1024"
+                value=${numberValue(selectedRuntime?.numCtx ?? null)}
+                disabled=${isDisabled || !selectedRuntime}
+                aria-label="binding num-ctx"
+                onInput=${(event: Event) => {
+                  const value = (event.currentTarget as HTMLInputElement).value
+                  updateBinding('num-ctx', value.trim() === '' ? null : parsePositiveInt(value))
+                }}
+              />
+            <//>
+          </div>
+        </div>
+      `}
+    </div>
+  `
+}

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -198,6 +198,11 @@ function runtimeProbeLabel(probe: DashboardRuntimeProviderProbe | null | undefin
   }
 }
 
+function runtimeProbeAuthLabel(probe: DashboardRuntimeProviderProbe | null | undefined): string {
+  if (probe?.credential_required !== true) return 'none'
+  return probe.auth_present === true ? 'present' : 'missing'
+}
+
 function runtimeProbeSummaryText(probe: DashboardRuntimeProbeResponse | null): string {
   const summary = probe?.probe?.summary
   if (!summary) return 'live probe 없음'
@@ -530,7 +535,7 @@ export function RuntimeMonitor() {
                     <div>http · ${fmtProbeHttpStatus(liveProbe)}</div>
                     <div>latency · ${fmtProbeLatency(liveProbe)}</div>
                     <div>models · ${formatNumber(liveProbe?.model_count)}</div>
-                    <div>auth · ${liveProbe?.credential_required ? (liveProbe.auth_present ? 'present' : 'missing') : 'none'}</div>
+                    <div>auth · ${runtimeProbeAuthLabel(liveProbe)}</div>
                   </div>
                   ${liveProbe?.probe_url || provider.endpoint_url
                     ? html`<div class="truncate text-2xs text-text-muted" title=${liveProbe?.probe_url ?? provider.endpoint_url ?? ''}>

--- a/dashboard/src/components/runtime-toml-editor.test.ts
+++ b/dashboard/src/components/runtime-toml-editor.test.ts
@@ -23,6 +23,51 @@ const baseConfig = {
   reloaded: false,
 }
 
+const richSourceText = `[runtime]
+default = "runpod_mtp.qwen"
+
+[providers.runpod_mtp]
+display-name = "RunPod"
+protocol = "provider_d-http"
+endpoint = "https://runpod.example/v1"
+
+[providers.runpod_mtp.credentials]
+type = "env"
+key = "RUNPOD_API_KEY"
+
+[providers.openai]
+display-name = "OpenAI"
+protocol = "provider_d-http"
+endpoint = "https://api.openai.example/v1"
+
+[models.qwen]
+api-name = "qwen"
+max-context = 128000
+tools-support = true
+thinking-support = true
+streaming = true
+
+[models.gpt]
+api-name = "gpt"
+max-context = 64000
+tools-support = true
+streaming = true
+
+[runpod_mtp.qwen]
+is-default = true
+max-concurrent = 4
+keep-alive = "10m"
+
+[openai.gpt]
+is-default = true
+max-concurrent = 1
+`
+
+const richConfig = {
+  ...baseConfig,
+  source_text: richSourceText,
+}
+
 describe('RuntimeTomlEditor', () => {
   let container: HTMLDivElement
   const realClipboard = typeof navigator !== 'undefined' ? navigator.clipboard : undefined
@@ -109,6 +154,55 @@ describe('RuntimeTomlEditor', () => {
     })
     expect(saveButton.disabled).toBe(true)
     expect((container.querySelector('textarea') as HTMLTextAreaElement).value).toBe(nextSource)
+  })
+
+  it('edits runtime environment fields through the structured controls', async () => {
+    apiMocks.fetchRuntimeTomlConfig.mockResolvedValueOnce(richConfig)
+    render(html`<${RuntimeTomlEditor} />`, container)
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('런타임 환경')
+      expect((container.querySelector('[aria-label="provider transport value"]') as HTMLInputElement | null)?.value)
+        .toBe('https://runpod.example/v1')
+    })
+
+    fireEvent.input(container.querySelector('[aria-label="provider transport value"]') as HTMLInputElement, {
+      target: { value: 'https://runpod.example/v2' },
+    })
+    await waitFor(() => {
+      expect((container.querySelector('textarea') as HTMLTextAreaElement).value).toContain('endpoint = "https://runpod.example/v2"')
+    })
+    fireEvent.input(container.querySelector('[aria-label="model max-context"]') as HTMLInputElement, {
+      target: { value: '262144' },
+    })
+    fireEvent.click(container.querySelector('[data-testid="runtime-environment-save"]') as HTMLButtonElement)
+
+    await waitFor(() => {
+      expect(apiMocks.saveRuntimeTomlConfig).toHaveBeenCalledTimes(1)
+    })
+    const savedSource = apiMocks.saveRuntimeTomlConfig.mock.calls[0]?.[0] as string
+    expect(savedSource).toContain('endpoint = "https://runpod.example/v2"')
+    expect(savedSource).toContain('max-context = 262144')
+    expect(savedSource).toContain('[providers.openai]')
+  })
+
+  it('switches the default runtime from the structured runtime selector', async () => {
+    apiMocks.fetchRuntimeTomlConfig.mockResolvedValueOnce(richConfig)
+    render(html`<${RuntimeTomlEditor} />`, container)
+
+    await waitFor(() => {
+      expect((container.querySelector('[aria-label="default runtime"]') as HTMLSelectElement | null)?.value)
+        .toBe('runpod_mtp.qwen')
+    })
+
+    fireEvent.change(container.querySelector('[aria-label="default runtime"]') as HTMLSelectElement, {
+      target: { value: 'openai.gpt' },
+    })
+
+    await waitFor(() => {
+      expect((container.querySelector('textarea') as HTMLTextAreaElement).value).toContain('default = "openai.gpt"')
+    })
+    expect(container.querySelector('[data-testid="runtime-toml-status"]')?.textContent).toContain('modified')
   })
 
   it('saves from the editor keyboard shortcut', async () => {

--- a/dashboard/src/components/runtime-toml-editor.ts
+++ b/dashboard/src/components/runtime-toml-editor.ts
@@ -12,6 +12,7 @@ import { SectionCard } from './common/card'
 import { copyToClipboard } from './common/copyable-code'
 import { ErrorState, LoadingState } from './common/feedback-state'
 import { ringFocusClasses } from './common/ring'
+import { RuntimeEnvironmentEditor } from './runtime-environment-editor'
 
 type LoadState = 'idle' | 'loading' | 'loaded'
 
@@ -280,8 +281,21 @@ export function RuntimeTomlEditor() {
         ${loadState === 'loading'
           ? html`<${LoadingState}>runtime.toml 불러오는 중...<//>`
           : html`
+            <${RuntimeEnvironmentEditor}
+              sourceText=${draft}
+              dirty=${dirty}
+              disabled=${loadState !== 'loaded'}
+              saving=${saving}
+              onDraftChange=${(nextSourceText: string) => {
+                setDraft(nextSourceText)
+                setNotice(null)
+              }}
+              onSave=${(nextSourceText?: string) => {
+                void handleSave(nextSourceText)
+              }}
+            />
             <div
-              class="grid min-h-[32rem] max-h-[72vh] grid-cols-[3.5rem_minmax(0,1fr)] overflow-hidden rounded-[var(--r-1)] border border-[var(--input-border)] bg-[var(--input-bg)]"
+              class="mt-4 grid min-h-[32rem] max-h-[72vh] grid-cols-[3.5rem_minmax(0,1fr)] overflow-hidden rounded-[var(--r-1)] border border-[var(--input-border)] bg-[var(--input-bg)]"
               data-testid="runtime-toml-code-frame"
             >
               <pre

--- a/dashboard/src/lib/runtime-toml-config.test.ts
+++ b/dashboard/src/lib/runtime-toml-config.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest'
+import {
+  deleteRuntimeTomlKey,
+  parseRuntimeTomlEnvironment,
+  setRuntimeTomlBindingField,
+  setRuntimeTomlDefault,
+  setRuntimeTomlModelField,
+  setRuntimeTomlProviderCredential,
+  setRuntimeTomlProviderField,
+} from './runtime-toml-config'
+
+const sourceText = `[runtime]
+default = "runpod_mtp.qwen"
+
+[providers.runpod_mtp]
+display-name = "RunPod"
+protocol = "provider_d-http"
+endpoint = "https://runpod.example/v1"
+
+[providers.runpod_mtp.credentials]
+type = "env"
+key = "RUNPOD_API_KEY"
+
+[models.qwen]
+api-name = "qwen"
+max-context = 128000
+tools-support = true
+thinking-support = true
+streaming = true
+
+[runpod_mtp.qwen]
+is-default = true
+max-concurrent = 4
+keep-alive = "10m"
+`
+
+describe('runtime TOML dashboard editing helpers', () => {
+  it('projects provider, model, and binding fields from runtime.toml source', () => {
+    const environment = parseRuntimeTomlEnvironment(sourceText)
+
+    expect(environment.defaultRuntimeId).toBe('runpod_mtp.qwen')
+    expect(environment.providers[0]).toMatchObject({
+      id: 'runpod_mtp',
+      displayName: 'RunPod',
+      protocol: 'provider_d-http',
+      transportKind: 'endpoint',
+      endpoint: 'https://runpod.example/v1',
+      credentialType: 'env',
+      credentialKey: 'RUNPOD_API_KEY',
+    })
+    expect(environment.models[0]).toMatchObject({
+      id: 'qwen',
+      apiName: 'qwen',
+      maxContext: 128000,
+      toolsSupport: true,
+      thinkingSupport: true,
+      streaming: true,
+    })
+    expect(environment.bindings[0]).toMatchObject({
+      id: 'runpod_mtp.qwen',
+      maxConcurrent: 4,
+      keepAlive: '10m',
+    })
+  })
+
+  it('patches the runtime default without touching other sections', () => {
+    const next = setRuntimeTomlDefault(sourceText, 'openai.gpt')
+
+    expect(next).toContain('default = "openai.gpt"')
+    expect(next).toContain('[providers.runpod_mtp]')
+    expect(next).toContain('endpoint = "https://runpod.example/v1"')
+  })
+
+  it('switches provider transport by deleting the opposite transport field', () => {
+    const next = setRuntimeTomlProviderField(
+      sourceText,
+      'runpod_mtp',
+      'command',
+      'provider-runtime --serve',
+    )
+
+    expect(next).toContain('command = "provider-runtime --serve"')
+    expect(next).not.toContain('endpoint = "https://runpod.example/v1"')
+  })
+
+  it('updates model and binding fields with TOML scalar formatting', () => {
+    let next = setRuntimeTomlModelField(sourceText, 'qwen', 'max-context', 262144)
+    next = setRuntimeTomlModelField(next, 'qwen', 'streaming', false)
+    next = setRuntimeTomlBindingField(next, 'runpod_mtp.qwen', 'num-ctx', 131072)
+
+    expect(next).toContain('max-context = 262144')
+    expect(next).toContain('streaming = false')
+    expect(next).toContain('num-ctx = 131072')
+  })
+
+  it('rewrites credential shape and removes stale credential fields', () => {
+    const next = setRuntimeTomlProviderCredential(
+      sourceText,
+      'runpod_mtp',
+      'file',
+      '/run/secrets/runpod-token',
+    )
+
+    expect(next).toContain('type = "file"')
+    expect(next).toContain('path = "/run/secrets/runpod-token"')
+    expect(next).not.toContain('key = "RUNPOD_API_KEY"')
+  })
+
+  it('deletes optional keys when requested', () => {
+    const next = deleteRuntimeTomlKey(sourceText, 'runpod_mtp.qwen', 'keep-alive')
+
+    expect(next).not.toContain('keep-alive = "10m"')
+    expect(next).toContain('max-concurrent = 4')
+  })
+})

--- a/dashboard/src/lib/runtime-toml-config.ts
+++ b/dashboard/src/lib/runtime-toml-config.ts
@@ -1,0 +1,376 @@
+export type RuntimeTomlTransportKind = 'endpoint' | 'command' | 'missing'
+export type RuntimeTomlCredentialType = 'env' | 'file' | 'inline' | 'none'
+
+export interface RuntimeTomlProvider {
+  id: string
+  displayName: string
+  protocol: string
+  transportKind: RuntimeTomlTransportKind
+  endpoint: string
+  command: string
+  credentialType: RuntimeTomlCredentialType
+  credentialKey: string
+  credentialPath: string
+  credentialValue: string
+}
+
+export interface RuntimeTomlModel {
+  id: string
+  apiName: string
+  maxContext: number | null
+  toolsSupport: boolean
+  thinkingSupport: boolean
+  streaming: boolean
+}
+
+export interface RuntimeTomlBinding {
+  id: string
+  providerId: string
+  modelId: string
+  isDefault: boolean
+  maxConcurrent: number | null
+  keepAlive: string
+  numCtx: number | null
+}
+
+export interface RuntimeTomlEnvironment {
+  defaultRuntimeId: string
+  providers: RuntimeTomlProvider[]
+  models: RuntimeTomlModel[]
+  bindings: RuntimeTomlBinding[]
+  warnings: string[]
+}
+
+interface TomlSection {
+  readonly name: string
+  readonly start: number
+  readonly end: number
+}
+
+interface TomlDocument {
+  readonly lines: string[]
+  readonly sections: TomlSection[]
+}
+
+type TomlScalar = string | number | boolean | null
+
+const RESERVED_TOP_LEVEL = new Set(['providers', 'models', 'runtime', 'system', 'routes', 'profiles'])
+
+function parseDocument(sourceText: string): TomlDocument {
+  const lines = sourceText.split('\n')
+  const headers: Array<{ name: string; index: number }> = []
+  for (let index = 0; index < lines.length; index += 1) {
+    const match = lines[index]?.match(/^\s*\[([^\]]+)\]\s*(?:#.*)?$/)
+    if (match?.[1]) headers.push({ name: match[1].trim(), index })
+  }
+  const sections = headers.map((header, index): TomlSection => ({
+    name: header.name,
+    start: header.index,
+    end: headers[index + 1]?.index ?? lines.length,
+  }))
+  return { lines, sections }
+}
+
+function sectionOf(document: TomlDocument, name: string): TomlSection | null {
+  return document.sections.find(section => section.name === name) ?? null
+}
+
+function keyLineMatch(line: string): RegExpMatchArray | null {
+  return line.match(/^(\s*)([A-Za-z0-9_-]+)(\s*=\s*)(.*)$/)
+}
+
+function stripInlineComment(raw: string): string {
+  let inString = false
+  let escaped = false
+  for (let index = 0; index < raw.length; index += 1) {
+    const char = raw[index]
+    if (escaped) {
+      escaped = false
+      continue
+    }
+    if (char === '\\' && inString) {
+      escaped = true
+      continue
+    }
+    if (char === '"') {
+      inString = !inString
+      continue
+    }
+    if (char === '#' && !inString) return raw.slice(0, index).trim()
+  }
+  return raw.trim()
+}
+
+function parseStringLiteral(raw: string): string | null {
+  const trimmed = raw.trim()
+  if (!trimmed.startsWith('"') || !trimmed.endsWith('"')) return null
+  try {
+    return JSON.parse(trimmed) as string
+  } catch {
+    return trimmed.slice(1, -1)
+  }
+}
+
+function parseTomlScalar(raw: string): TomlScalar {
+  const value = stripInlineComment(raw)
+  const stringValue = parseStringLiteral(value)
+  if (stringValue !== null) return stringValue
+  if (value === 'true') return true
+  if (value === 'false') return false
+  if (/^-?\d+$/.test(value)) return Number.parseInt(value, 10)
+  if (/^-?\d+\.\d+$/.test(value)) return Number.parseFloat(value)
+  return value === '' ? null : value
+}
+
+function sectionValues(document: TomlDocument, name: string): Record<string, TomlScalar> {
+  const section = sectionOf(document, name)
+  if (!section) return {}
+  const values: Record<string, TomlScalar> = {}
+  for (let index = section.start + 1; index < section.end; index += 1) {
+    const line = document.lines[index] ?? ''
+    const match = keyLineMatch(line)
+    if (!match?.[2] || match[0].trimStart().startsWith('#')) continue
+    values[match[2]] = parseTomlScalar(match[4] ?? '')
+  }
+  return values
+}
+
+function asString(value: TomlScalar | undefined, fallback = ''): string {
+  return typeof value === 'string' ? value : fallback
+}
+
+function asNumber(value: TomlScalar | undefined): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+function asBoolean(value: TomlScalar | undefined, fallback = false): boolean {
+  return typeof value === 'boolean' ? value : fallback
+}
+
+function providerIds(document: TomlDocument): string[] {
+  return document.sections
+    .map(section => section.name.match(/^providers\.([^.]+)$/)?.[1])
+    .filter((id): id is string => Boolean(id))
+}
+
+function modelIds(document: TomlDocument): string[] {
+  return document.sections
+    .map(section => section.name.match(/^models\.([^.]+)$/)?.[1])
+    .filter((id): id is string => Boolean(id))
+}
+
+function bindingSections(document: TomlDocument): Array<{ providerId: string; modelId: string; section: string }> {
+  return document.sections
+    .map(section => {
+      const parts = section.name.split('.')
+      if (parts.length !== 2 || RESERVED_TOP_LEVEL.has(parts[0] ?? '')) return null
+      return { providerId: parts[0] ?? '', modelId: parts[1] ?? '', section: section.name }
+    })
+    .filter((entry): entry is { providerId: string; modelId: string; section: string } => {
+      return Boolean(entry?.providerId && entry.modelId)
+    })
+}
+
+function providerFromDocument(document: TomlDocument, id: string): RuntimeTomlProvider {
+  const values = sectionValues(document, `providers.${id}`)
+  const credentials = sectionValues(document, `providers.${id}.credentials`)
+  const endpoint = asString(values.endpoint)
+  const command = asString(values.command)
+  const credentialType = asString(credentials.type) as RuntimeTomlCredentialType
+  return {
+    id,
+    displayName: asString(values['display-name'], asString(values['provider-name'], id)),
+    protocol: asString(values.protocol),
+    transportKind: endpoint ? 'endpoint' : command ? 'command' : 'missing',
+    endpoint,
+    command,
+    credentialType: credentialType === 'env' || credentialType === 'file' || credentialType === 'inline'
+      ? credentialType
+      : 'none',
+    credentialKey: asString(credentials.key),
+    credentialPath: asString(credentials.path),
+    credentialValue: asString(credentials.value),
+  }
+}
+
+function modelFromDocument(document: TomlDocument, id: string): RuntimeTomlModel {
+  const values = sectionValues(document, `models.${id}`)
+  return {
+    id,
+    apiName: asString(values['api-name'], asString(values['model-name'], id)),
+    maxContext: asNumber(values['max-context']),
+    toolsSupport: asBoolean(values['tools-support']),
+    thinkingSupport: asBoolean(values['thinking-support']),
+    streaming: asBoolean(values.streaming, true),
+  }
+}
+
+function bindingFromDocument(
+  document: TomlDocument,
+  entry: { providerId: string; modelId: string; section: string },
+): RuntimeTomlBinding {
+  const values = sectionValues(document, entry.section)
+  return {
+    id: `${entry.providerId}.${entry.modelId}`,
+    providerId: entry.providerId,
+    modelId: entry.modelId,
+    isDefault: asBoolean(values['is-default']),
+    maxConcurrent: asNumber(values['max-concurrent']),
+    keepAlive: asString(values['keep-alive']),
+    numCtx: asNumber(values['num-ctx']),
+  }
+}
+
+export function parseRuntimeTomlEnvironment(sourceText: string): RuntimeTomlEnvironment {
+  const document = parseDocument(sourceText)
+  const runtimeValues = sectionValues(document, 'runtime')
+  const providers = providerIds(document).map(id => providerFromDocument(document, id))
+  const models = modelIds(document).map(id => modelFromDocument(document, id))
+  const bindings = bindingSections(document).map(entry => bindingFromDocument(document, entry))
+  const warnings: string[] = []
+  if (providers.length === 0) warnings.push('providers.* section not found')
+  if (models.length === 0) warnings.push('models.* section not found')
+  if (bindings.length === 0) warnings.push('provider.model binding section not found')
+  return {
+    defaultRuntimeId: asString(runtimeValues.default),
+    providers,
+    models,
+    bindings,
+    warnings,
+  }
+}
+
+function serializeString(value: string): string {
+  return JSON.stringify(value)
+}
+
+function serializeValue(value: string | number | boolean): string {
+  if (typeof value === 'string') return serializeString(value)
+  if (typeof value === 'boolean') return value ? 'true' : 'false'
+  return String(value)
+}
+
+function joinLines(lines: string[]): string {
+  return lines.join('\n')
+}
+
+function ensureSection(lines: string[], document: TomlDocument, sectionName: string): { lines: string[]; section: TomlSection } {
+  const existing = sectionOf(document, sectionName)
+  if (existing) return { lines, section: existing }
+  const nextLines = [...lines]
+  if (nextLines.length > 0 && nextLines[nextLines.length - 1] !== '') nextLines.push('')
+  const start = nextLines.length
+  nextLines.push(`[${sectionName}]`)
+  return {
+    lines: nextLines,
+    section: { name: sectionName, start, end: nextLines.length },
+  }
+}
+
+export function setRuntimeTomlKey(
+  sourceText: string,
+  sectionName: string,
+  key: string,
+  value: string | number | boolean,
+): string {
+  const initial = parseDocument(sourceText)
+  const ensured = ensureSection([...initial.lines], initial, sectionName)
+  const lines = ensured.lines
+  const section = ensured.section
+  const serialized = serializeValue(value)
+  for (let index = section.start + 1; index < section.end; index += 1) {
+    const match = keyLineMatch(lines[index] ?? '')
+    if (match?.[2] === key) {
+      lines[index] = `${match[1] ?? ''}${key}${match[3] ?? ' = '}${serialized}`
+      return joinLines(lines)
+    }
+  }
+  lines.splice(section.end, 0, `${key} = ${serialized}`)
+  return joinLines(lines)
+}
+
+export function deleteRuntimeTomlKey(sourceText: string, sectionName: string, key: string): string {
+  const document = parseDocument(sourceText)
+  const section = sectionOf(document, sectionName)
+  if (!section) return sourceText
+  const lines = [...document.lines]
+  for (let index = section.end - 1; index > section.start; index -= 1) {
+    const match = keyLineMatch(lines[index] ?? '')
+    if (match?.[2] === key) lines.splice(index, 1)
+  }
+  return joinLines(lines)
+}
+
+export function deleteRuntimeTomlSection(sourceText: string, sectionName: string): string {
+  const document = parseDocument(sourceText)
+  const section = sectionOf(document, sectionName)
+  if (!section) return sourceText
+  const lines = [...document.lines]
+  lines.splice(section.start, section.end - section.start)
+  return joinLines(lines)
+}
+
+export function setRuntimeTomlDefault(sourceText: string, runtimeId: string): string {
+  return setRuntimeTomlKey(sourceText, 'runtime', 'default', runtimeId)
+}
+
+export function setRuntimeTomlProviderField(
+  sourceText: string,
+  providerId: string,
+  field: 'display-name' | 'protocol' | 'endpoint' | 'command',
+  value: string,
+): string {
+  const section = `providers.${providerId}`
+  if (field === 'endpoint') {
+    const withEndpoint = setRuntimeTomlKey(sourceText, section, 'endpoint', value)
+    return deleteRuntimeTomlKey(withEndpoint, section, 'command')
+  }
+  if (field === 'command') {
+    const withCommand = setRuntimeTomlKey(sourceText, section, 'command', value)
+    return deleteRuntimeTomlKey(withCommand, section, 'endpoint')
+  }
+  return setRuntimeTomlKey(sourceText, section, field, value)
+}
+
+export function setRuntimeTomlProviderCredential(
+  sourceText: string,
+  providerId: string,
+  credentialType: RuntimeTomlCredentialType,
+  value: string,
+): string {
+  const section = `providers.${providerId}.credentials`
+  if (credentialType === 'none') return deleteRuntimeTomlSection(sourceText, section)
+  let next = setRuntimeTomlKey(sourceText, section, 'type', credentialType)
+  if (credentialType === 'env') {
+    next = setRuntimeTomlKey(next, section, 'key', value)
+    next = deleteRuntimeTomlKey(next, section, 'path')
+    return deleteRuntimeTomlKey(next, section, 'value')
+  }
+  if (credentialType === 'file') {
+    next = setRuntimeTomlKey(next, section, 'path', value)
+    next = deleteRuntimeTomlKey(next, section, 'key')
+    return deleteRuntimeTomlKey(next, section, 'value')
+  }
+  next = setRuntimeTomlKey(next, section, 'value', value)
+  next = deleteRuntimeTomlKey(next, section, 'key')
+  return deleteRuntimeTomlKey(next, section, 'path')
+}
+
+export function setRuntimeTomlModelField(
+  sourceText: string,
+  modelId: string,
+  field: 'api-name' | 'max-context' | 'tools-support' | 'thinking-support' | 'streaming',
+  value: string | number | boolean,
+): string {
+  return setRuntimeTomlKey(sourceText, `models.${modelId}`, field, value)
+}
+
+export function setRuntimeTomlBindingField(
+  sourceText: string,
+  runtimeId: string,
+  field: 'is-default' | 'max-concurrent' | 'keep-alive' | 'num-ctx',
+  value: string | number | boolean | null,
+): string {
+  if (value === null) return deleteRuntimeTomlKey(sourceText, runtimeId, field)
+  return setRuntimeTomlKey(sourceText, runtimeId, field, value)
+}


### PR DESCRIPTION
## Summary
- add a structured runtime environment editor above the raw runtime.toml source editor
- support editing default runtime, provider connection/credentials, model capabilities, and provider.model binding fields through the existing raw config save/validation path
- fix the runtime monitor auth label nested ternary so dashboard lint passes

## Testing
- pnpm exec vitest run src/lib/runtime-toml-config.test.ts src/components/runtime-toml-editor.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1
- pnpm exec tsc --noEmit --pretty false
- pnpm run lint
- pnpm run build
- Playwright CLI screenshots: desktop and mobile runtime.toml config view
- Playwright interaction smoke: changed model max-context, verified raw TOML draft updated and environment save became enabled without saving live config
