### PR TITLE
fix(dashboard): stabilize keeper detail chat scroll

### DIFF
--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -101,7 +101,7 @@ describe('ChatTranscript', () => {
     expect(latestBody).toBe('')
   })
 
-  it('uses a viewport-bounded transcript height in primary mode', () => {
+  it('uses a parent-bounded flexible transcript in primary mode', () => {
     render(
       html`<${ChatTranscript}
         entries=${[entry({ id: 'u1', text: 'ping' })]}
@@ -113,10 +113,10 @@ describe('ChatTranscript', () => {
     )
 
     const transcript = container.querySelector('[data-chat-variant="messenger"]')
-    expect(transcript?.classList.contains('min-h-[18rem]')).toBe(true)
-    expect(transcript?.classList.contains('max-h-[42vh]')).toBe(true)
-    expect(transcript?.classList.contains('sm:min-h-[28rem]')).toBe(true)
-    expect(transcript?.classList.contains('sm:max-h-[54vh]')).toBe(true)
+    expect(transcript?.getAttribute('data-chat-size')).toBe('primary')
+    expect(transcript?.classList.contains('min-h-0')).toBe(true)
+    expect(transcript?.classList.contains('flex-1')).toBe(true)
+    expect(transcript?.classList.contains('max-h-[42vh]')).toBe(false)
     expect(transcript?.classList.contains('chat-transcript-airy')).toBe(true)
   })
 

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -431,7 +431,7 @@ export function ChatTranscript({
 
   const isPrimary = size === 'primary'
   const heightClass = isPrimary
-    ? 'min-h-[18rem] max-h-[42vh] sm:min-h-[28rem] sm:max-h-[54vh] xl:max-h-[58vh]'
+    ? 'min-h-0 flex-1'
     : 'min-h-75 max-h-130'
 
   return html`
@@ -444,6 +444,7 @@ export function ChatTranscript({
           : 'gap-3 rounded-[var(--radius-xl)] px-3 py-4'
       }`}
       data-chat-variant=${variant}
+      data-chat-size=${size}
       ref=${scrollerRef}
     >
       ${entries.length === 0

--- a/dashboard/src/components/keeper-shared.test.ts
+++ b/dashboard/src/components/keeper-shared.test.ts
@@ -173,8 +173,12 @@ describe('KeeperConversationPanel', () => {
     )
     await Promise.resolve()
 
-    expect(container.querySelector('[data-keeper-chat-layout="primary"]')).not.toBeNull()
+    const shell = container.querySelector('[data-keeper-chat-layout="primary"]')
+    expect(shell).not.toBeNull()
+    expect(shell?.classList.contains('overflow-hidden')).toBe(true)
+    expect(shell?.classList.contains('h-[clamp(30rem,calc(100svh-13rem),52rem)]')).toBe(true)
     expect(container.querySelector('.chat-transcript-airy')).not.toBeNull()
+    expect(container.querySelector('.chat-transcript-airy')?.classList.contains('flex-1')).toBe(true)
     expect(container.querySelector('.min-h-30')).not.toBeNull()
     expect(container.textContent).toContain('@sangsu')
     expect(container.textContent).not.toContain('Enter로 전송')

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -318,8 +318,11 @@ export function KeeperConversationPanel({
 
   if (layout === 'primary') {
     return html`
-      <div class="flex flex-col gap-4" data-keeper-chat-layout="primary">
-        <div class="flex flex-wrap items-center justify-between gap-3 border-b border-[var(--color-border-default)] pb-3">
+      <div
+        class="flex h-[clamp(30rem,calc(100svh-13rem),52rem)] min-h-0 flex-col gap-4 overflow-hidden rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-4 shadow-none"
+        data-keeper-chat-layout="primary"
+      >
+        <div class="shrink-0 flex flex-wrap items-center justify-between gap-3 border-b border-[var(--color-border-default)] pb-3">
           <div class="min-w-0">
             <div class="text-2xs font-semibold uppercase tracking-5 text-[var(--color-fg-muted)]">직접 대화</div>
             <div class="mt-1.5 flex flex-wrap items-center gap-2">
@@ -356,7 +359,7 @@ export function KeeperConversationPanel({
 
         ${chatAccess.message
           ? html`
-              <div class="rounded-[var(--r-2)] border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2.5 text-xs leading-loose text-[var(--warn-bright)]">
+              <div class="shrink-0 rounded-[var(--r-2)] border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2.5 text-xs leading-loose text-[var(--warn-bright)]">
                 ${chatAccess.message}
               </div>
             `
@@ -372,13 +375,13 @@ export function KeeperConversationPanel({
 
         ${!showInternal && hiddenCount > 0
           ? html`
-              <div class="rounded-[var(--r-2)] border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2 text-2xs leading-paragraph text-[var(--warn-bright)]">
+              <div class="shrink-0 rounded-[var(--r-2)] border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2 text-2xs leading-paragraph text-[var(--warn-bright)]">
                 ${hiddenCount}개의 내부 메시지가 숨겨져 있습니다. "내부 메시지 표시"로 볼 수 있습니다.
               </div>
             `
           : null}
 
-        <div class="rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-4 py-4 shadow-none">
+        <div class="shrink-0 rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-4 py-4 shadow-none">
           <${ChatComposer}
             draft=${draft}
             placeholder=${chatAccess.blocked ? '현재 actor는 direct keeper chat 권한이 없습니다' : placeholder}
@@ -392,7 +395,7 @@ export function KeeperConversationPanel({
           />
         </div>
 
-        ${error ? html`<div class="text-xs text-[var(--bad-light)] leading-relaxed">${error}</div>` : null}
+        ${error ? html`<div class="shrink-0 text-xs text-[var(--bad-light)] leading-relaxed">${error}</div>` : null}
       </div>
     `
   }


### PR DESCRIPTION
## Summary

Fixes the Keeper detail chat panel so the conversation view no longer creates a viewport-height nested scroll region that fights the page layout.

- Make the primary chat transcript fill the remaining panel height with `min-h-0 flex-1`.
- Bound the primary Keeper conversation shell with a viewport-aware clamp and `overflow-hidden`.
- Keep header/actions/composer as non-shrinking siblings so only the transcript scrolls.
- Update focused component tests for the new primary layout contract.

## Root Cause

The primary transcript was using fixed `min-h` plus viewport `max-h` classes while its parent did not define a bounded flex height. On Keeper detail pages this allowed the chat area to become its own viewport-sized scroll block, pushing the composer and surrounding detail content into confusing scroll behavior.

## User Impact

Keeper detail now presents the direct chat area as one bounded panel:

- the outer chat shell stays fixed within the available viewport band
- the transcript is the only scrollable message region
- the composer remains visible inside the same panel on desktop and mobile

## Evidence

[근거] Local commands, 2026-06-06 Asia/Seoul, High:

- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/chat/primitives.test.ts src/components/keeper-shared.test.ts --no-file-parallelism --maxWorkers=1`
  - 2 files passed, 10 tests passed
- `pnpm --dir dashboard exec eslint src/components/chat/primitives.ts src/components/keeper-shared.ts`
  - passed
- `pnpm --dir dashboard exec tsc --noEmit --pretty false`
  - passed
- `pnpm --dir dashboard build`
  - passed; existing Vite chunk/dynamic import warnings only
- `git diff --check HEAD~1..HEAD`
  - passed

[근거] Playwright layout probe against local dashboard `http://127.0.0.1:5178/dashboard/#monitoring?section=agents&keeper=sangsu`, 2026-06-06 Asia/Seoul, High:

- Desktop 1440x900:
  - shell `overflowY=hidden`, height 692
  - transcript `overflowY=auto`, height 364
  - composer contained by shell: true
  - screenshot: `/tmp/keeper-chat-scroll-after-desktop-final.png`
- Mobile 390x844:
  - shell `overflowY=hidden`, height 636
  - transcript `overflowY=auto`, height 185
  - composer contained by shell: true
  - screenshot: `/tmp/keeper-chat-scroll-after-mobile-final.png`

Observed console warnings during the probe were existing SSE/composite schema-drift warnings and were unrelated to this layout change.