### PR TITLE
fix(keeper): make workflow rejection advisory instead of blocking

### DIFF
--- a/lib/keeper/keeper_tools_oas_workflow.ml
+++ b/lib/keeper/keeper_tools_oas_workflow.ml
@@ -262,8 +262,8 @@ let workflow_rejection_recovery_instruction ~tool_name ~count (info : workflow_r
       next_tool
   | Some next_tool ->
     Printf.sprintf
-      "Do not retry this %s call. Call %s next and follow the hint/alternatives \
-       in detail."
+      "Revise your approach and retry this %s call, or call %s next and follow \
+       the hint/alternatives in detail."
       tool_name
       next_tool
   | None when count >= 2 ->
@@ -273,7 +273,7 @@ let workflow_rejection_recovery_instruction ~tool_name ~count (info : workflow_r
       tool_name
   | None ->
     Printf.sprintf
-      "Do not retry this %s call. Use the hint/alternatives in detail."
+      "Revise your approach and retry this %s call. Use the hint/alternatives in detail."
       tool_name
 ;;
 
@@ -297,7 +297,6 @@ let workflow_rejection_recovery_fields ~tool_name ~count raw =
         ]
     in
     [ "self_correction_required", `Bool true
-    ; "do_not_retry_tool", `String tool_name
     ; "workflow_rejection_recovery", `Assoc recovery
     ]
     @ optional_string "required_next_tool" info.tool_suggestion


### PR DESCRIPTION
Workflow rejection previously told keepers 'Do not retry' and set do_not_retry_tool, causing keepers to stall on tasks (e.g., task-676 ramarama anti-rationalization gate). Change instruction to 'Revise and retry' and remove do_not_retry_tool. Keep count>=2 'Stop retrying' as infinite loop guard. Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>