### PR TITLE
fix(keeper): close report-state compile gaps

### DIFF
--- a/lib/config/env_config_runtime.mli
+++ b/lib/config/env_config_runtime.mli
@@ -30,6 +30,7 @@ end
 module Session : sig
   val max_age_seconds : float
   val rate_limit_window_seconds : float
+  val sse_grace_period_seconds : float
 end
 
 (** {1 Tempo (polling interval)} *)

--- a/lib/governance_pipeline_risk.ml
+++ b/lib/governance_pipeline_risk.ml
@@ -141,8 +141,8 @@ let risk_of_keeper (k : Keeper_tool_name.t) : risk_level =
   | Board_sub_board_get | Board_sub_board_list | Board_vote | Broadcast
   | Context_status | Handoff | Library_read | Library_search | Memory_search
   | Memory_write | Search_files | Stay_silent | Tasks_audit | Tasks_list | Time_now
-  | Tool_search | Tools_list | Voice_agent | Voice_listen | Voice_session_end
-  | Voice_session_start | Voice_sessions | Voice_speak -> Low
+  | Tool_search | Tools_list | State_report | Voice_agent | Voice_listen
+  | Voice_session_end | Voice_session_start | Voice_sessions | Voice_speak -> Low
   | Board_sub_board_create | Board_sub_board_update | Task_claim | Task_create | Task_done
     -> Medium
   | Fs_edit | Fs_write | Fs_read | Ide_annotate -> High

--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -714,6 +714,38 @@ let handle_keeper_task_tool
          match accountability_warning with
          | Some warning -> [ ("routing_warning", `String warning) ]
          | None -> []))
+    | State_report ->
+    let snapshot_opt = Keeper_memory_policy.keeper_state_snapshot_of_json args in
+    let snapshot, persisted =
+      match snapshot_opt with
+      | None -> Keeper_memory_policy.empty_keeper_state_snapshot, false
+      | Some snapshot ->
+        let snapshot = Keeper_memory_policy.cap_snapshot snapshot in
+        let _ =
+          Workspace.broadcast
+            config
+            ~from_agent:(keeper_agent_sender ~meta)
+            ~content:(Keeper_memory_policy.render_state_block snapshot)
+        in
+        snapshot, true
+    in
+    let continuity_summary =
+      if persisted
+      then Keeper_memory_policy.keeper_state_snapshot_to_summary_text snapshot
+      else "No continuity snapshot available."
+    in
+    Yojson.Safe.to_string
+      (`Assoc
+         [ "ok", `Bool true
+         ; ( "result"
+           , `String
+               (if persisted
+                then "keeper state report accepted"
+                else "keeper state report accepted without non-empty state") )
+         ; "persisted", `Bool persisted
+         ; "state_snapshot", Keeper_memory_policy.keeper_state_snapshot_to_json snapshot
+         ; "continuity_summary", `String continuity_summary
+         ])
     | Task_done ->
     let task_id = Safe_ops.json_string ~default:"" "task_id" args |> String.trim in
     let result_text = Safe_ops.json_string ~default:"" "result" args |> String.trim in

--- a/lib/keeper_tooling/keeper_tool_name.mli
+++ b/lib/keeper_tooling/keeper_tool_name.mli
@@ -45,6 +45,7 @@ type t =
   | Time_now
   | Tool_search
   | Tools_list
+  | State_report
   | Voice_agent
   | Voice_listen
   | Voice_session_end

--- a/test/test_keeper_validation_breaker_exempt.ml
+++ b/test/test_keeper_validation_breaker_exempt.ml
@@ -112,6 +112,43 @@ let test_task_create_multi_active_goals_without_goal_id_is_unscoped () =
        | tasks ->
            failf "expected exactly one persisted task, got %d" (List.length tasks))
 
+let test_keeper_report_state_persists_state_block () =
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
+       let config = Masc.Workspace.default_config base_path in
+       ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
+       let meta = meta_with_active_goals [] in
+       let payload =
+         Task.handle_keeper_task_tool
+           ~config
+           ~meta
+           ~name:"keeper_report_state"
+           ~args:
+             (`Assoc
+               [ "goal", `String "Keep runtime visible"
+               ; "next_items", `List [ `String "Check main CI" ]
+               ; "constraints", `List [ `String "Use worktrees" ]
+               ])
+       in
+       let json = Yojson.Safe.from_string payload in
+       check bool "state report succeeds" true (json |> U.member "ok" |> U.to_bool);
+       check bool "state report persists non-empty state" true
+         (json |> U.member "persisted" |> U.to_bool);
+       check string "state report summary includes goal"
+         "Goal: Keep runtime visible\nNext: Check main CI\nConstraints: Use worktrees"
+         (json |> U.member "continuity_summary" |> U.to_string);
+       let messages = Masc.Workspace.get_messages_raw config ~since_seq:0 ~limit:20 in
+       check bool "workspace history includes state block" true
+         (List.exists
+            (fun (message : Masc_domain.message) ->
+               String.equal message.from_agent "keeper-task-create-test"
+               && String.contains message.content '['
+               && String.contains message.content ']'
+               && String.starts_with ~prefix:"[STATE]" message.content)
+            messages))
+
 let () =
   run "keeper validation breaker exemption"
     [ ( "validation_failure_class"
@@ -125,5 +162,7 @@ let () =
             "keeper_task_create treats ambiguous active_goal_ids as advisory"
             `Quick
             test_task_create_multi_active_goals_without_goal_id_is_unscoped
+        ; test_case "keeper_report_state persists state block" `Quick
+            test_keeper_report_state_persists_state_block
         ] )
     ]


### PR DESCRIPTION
## Summary
- expose keeper_report_state in the keeper tool-name interface and classify it as low-risk
- implement keeper_report_state runtime handling by normalizing the snapshot and persisting a [STATE] block through workspace history
- expose the SSE grace-period runtime knob in Env_config_runtime.mli

## Verification
- env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-ci-fix-20260606 dune build --root . @test/runtest-test_keeper_validation_breaker_exempt
- env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-ci-fix-20260606 dune build --root . @install --force
- git diff --check

## CI failure addressed
Latest main CI 27054532838 failed in Build/Lint with keeper_tool_name.ml/.mli State_report mismatch and missing Env_config_runtime.Session.sse_grace_period_seconds interface exposure.