### PR TITLE
fix(keeper): allow multiline typed argv literals

### DIFF
--- a/docs/rfc/RFC-0198-execute-typed-redirection.md
+++ b/docs/rfc/RFC-0198-execute-typed-redirection.md
@@ -52,7 +52,7 @@ Issue #18892 (sandbox playground missing-file ENOENT, 15 ERROR/day) 와 같은 *
 
 **Principle**: RFC-0194 §1 (typed SSOT 가 *control-flow gate* 에 위치).
 
-`shell_metachar_in_token` (`lib/keeper/agent_tool_execute_typed_input.ml:223-228`) 의 현재 형태는 *NUL/CR/LF* 만 거부. 본 Phase 는 *redirection-shape pattern* 을 추가 거부:
+`shell_metachar_in_token` (`lib/keeper/keeper_tool_execute_typed_input.ml`) 의 현재 형태는 *NUL* 만 거부. LF/CR 과 shell metacharacter 는 execve argv literal data 이다. 본 Phase 는 *redirection-shape pattern* 을 추가 거부:
 
 | 거부 token shape | 예시 |
 |---|---|

--- a/lib/keeper/keeper_tool_execute_typed_input.ml
+++ b/lib/keeper/keeper_tool_execute_typed_input.ml
@@ -287,14 +287,13 @@ let of_json (json : Yojson.Safe.t) =
 ;;
 
 (* Execve-style: argv tokens pass verbatim to the child process, so
-   shell metacharacters ([;|&><`$*?]) are literal data, not operators.
-   Only control characters that cannot survive process-boundary
-   serialization are rejected.  See .mli "Design constraints" for the
-   rationale. *)
+   shell metacharacters ([;|&><`$*?]) and line breaks are literal data, not
+   operators.  NUL is the only byte that cannot be represented inside an argv
+   string.  See .mli "Design constraints" for the rationale. *)
 let shell_metachar_in_token token =
   String.exists
     (function
-      | '\000' | '\n' | '\r' -> true
+      | '\000' -> true
       | _ -> false)
     token
 ;;
@@ -656,8 +655,8 @@ let pp_validation_error ppf = function
   | Argv_contains_shell_metachar { executable; index; token } ->
     Format.fprintf
       ppf
-      "executable %S argv[%d]=%S contains shell metacharacter; \
-       split into Pipeline stages instead"
+      "executable %S argv[%d]=%S contains NUL; typed Execute argv strings \
+       cannot contain NUL bytes"
       executable
       index
       token
@@ -697,7 +696,7 @@ let pp_validation_error ppf = function
 let validation_error_alternatives : validation_error -> string list = function
   | Executable_not_allowlisted { name; mode } ->
     executable_not_allowlisted_alternatives ~name ~mode
-  | Argv_contains_shell_metachar _ -> [ "Pipeline" ]
+  | Argv_contains_shell_metachar _ -> []
   | Argv_contains_shell_redirection _ ->
     [ "discard_stderr"; "discard_stdout"; "Pipeline" ]
   | _ -> []

--- a/lib/keeper/keeper_tool_execute_typed_input.mli
+++ b/lib/keeper/keeper_tool_execute_typed_input.mli
@@ -14,17 +14,17 @@
       verbatim to the child process; the implementation invokes the
       executable directly (no [/bin/sh -c "..."] wrapping).  Therefore
       shell metacharacters like [*], [?], [|], [&], [;], [>], [<],
-      [`], [$] inside an argv token are *literal characters*, not
-      shell operators.  For example, the typed schema accepts
-      [find . -name *.ml] because [*.ml] is a [find]-internal pattern,
-      not a shell glob.
+      [`], [$], [\n], and [\r] inside an argv token are *literal
+      characters*, not shell operators.  For example, the typed schema accepts
+      [find . -name *.ml] because [*.ml] is a [find]-internal pattern, not a
+      shell glob; it also accepts multiline `gh --body` text because the
+      argument is passed directly to [gh].
     - **Pipelines are explicit**.  [Pipeline.stages] enumerates each
       [exec_stage] separately; [|]-delimited strings are never parsed.
-    - **Forbidden in argv tokens**: only control characters that
-      cannot survive process boundary serialization
-      ([NUL], [\n], [\r]).  The validator rejects them via
-      {!Argv_contains_shell_metachar} (name kept for log continuity;
-      semantics narrowed in PR-1 follow-up commit).
+    - **Forbidden in argv tokens**: only [NUL], which cannot be represented in
+      an execve argv string.  The validator rejects it via
+      {!Argv_contains_shell_metachar}; the variant name is kept for log
+      continuity, but the semantics are NUL-only.
     - **Cwd is a string for now**.  Path SSOT does not yet expose a
       [Path.t] type (RFC-0091 §2.3 mis-cited [Host_config.cwd_for_keeper]
       which does not exist).  Absolute-path enforcement happens in

--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -736,38 +736,6 @@ let handle_keeper_task_tool
          match accountability_warning with
          | Some warning -> [ ("routing_warning", `String warning) ]
          | None -> []))
-    | State_report ->
-    let snapshot_opt = Keeper_memory_policy.keeper_state_snapshot_of_json args in
-    let snapshot, persisted =
-      match snapshot_opt with
-      | None -> Keeper_memory_policy.empty_keeper_state_snapshot, false
-      | Some snapshot ->
-        let snapshot = Keeper_memory_policy.cap_snapshot snapshot in
-        let _ =
-          Workspace.broadcast
-            config
-            ~from_agent:(keeper_agent_sender ~meta)
-            ~content:(Keeper_memory_policy.render_state_block snapshot)
-        in
-        snapshot, true
-    in
-    let continuity_summary =
-      if persisted
-      then Keeper_memory_policy.keeper_state_snapshot_to_summary_text snapshot
-      else "No continuity snapshot available."
-    in
-    Yojson.Safe.to_string
-      (`Assoc
-         [ "ok", `Bool true
-         ; ( "result"
-           , `String
-               (if persisted
-                then "keeper state report accepted"
-                else "keeper state report accepted without non-empty state") )
-         ; "persisted", `Bool persisted
-         ; "state_snapshot", Keeper_memory_policy.keeper_state_snapshot_to_json snapshot
-         ; "continuity_summary", `String continuity_summary
-         ])
     | Task_done ->
     let task_id = Safe_ops.json_string ~default:"" "task_id" args |> String.trim in
     let result_text = Safe_ops.json_string ~default:"" "result" args |> String.trim in

--- a/test/test_keeper_tool_execute_typed_input.ml
+++ b/test/test_keeper_tool_execute_typed_input.ml
@@ -121,6 +121,25 @@ let cases : case list =
         "NUL in argv token cannot survive process-boundary \
          serialization; typed schema rejects via shell_metachar_in_token"
     }
+  ; { name = "argv_with_newlines"
+    ; sample_cmd = "gh pr create --body '<multiline markdown>'"
+    ; typed =
+        mk_exec
+          "gh"
+          [ "pr"
+          ; "create"
+          ; "--body"
+          ; "Replace self-shadowing `match sandbox_root with | Some _ -> \
+             sandbox_root | ...` with `Option.first_some sandbox_root \
+             ctx.sandbox_root`.\n\
+             \n\
+             No behavioral change. Single commit."
+          ]
+    ; expect_typed = true
+    ; rationale =
+        "execve-style argv: markdown backticks, pipe characters, and newlines \
+         inside a gh body are literal argument data"
+    }
   ]
 ;;
 
@@ -823,6 +842,41 @@ let test_pipe_character_in_exec_argv_is_literal () =
     Alcotest.fail "literal pipe argv token must not create Shell_ir.Pipeline"
 ;;
 
+let test_gh_multiline_body_lowers_to_literal_argv () =
+  let body =
+    "Replace self-shadowing `match sandbox_root with | Some _ -> sandbox_root \
+     | ...` with `Option.first_some sandbox_root ctx.sandbox_root`.\n\
+     \n\
+     No behavioral change. Single commit."
+  in
+  let input =
+    Execute_input.Exec
+      { executable = "gh"
+      ; argv = [ "pr"; "create"; "--body"; body ]
+      ; cwd = None
+      ; env = []
+      ; stdin = Execute_input.Inherit
+      ; stdout = Execute_input.Inherit
+      ; stderr = Execute_input.Inherit
+      }
+  in
+  match to_shell_ir_exn input with
+  | Masc_exec.Shell_ir.Simple simple ->
+    let argv =
+      List.filter_map
+        (function
+          | Masc_exec.Shell_ir.Lit (value, _) -> Some value
+          | Masc_exec.Shell_ir.Concat _ | Masc_exec.Shell_ir.Var _ -> None)
+        simple.args
+    in
+    Alcotest.(check (list string))
+      "gh argv preserved"
+      [ "pr"; "create"; "--body"; body ]
+      argv
+  | Masc_exec.Shell_ir.Pipeline _ ->
+    Alcotest.fail "multiline gh body must not create Shell_ir.Pipeline"
+;;
+
 let test_cwd_not_absolute () =
   let input =
     Execute_input.Exec
@@ -946,6 +1000,8 @@ let test_legitimate_metachar_still_allowed () =
     ; "find-name with literal '&' inside payload", [ "."; "-name"; "a&b" ]
     ; "find-name with '>foo' (no leading fd, but path payload-looking)", [ "."; "-name"; "X>foo" ]
     ; "ampersand by itself is execve-literal", [ "."; "-name"; "&" ]
+    ; "newline is execve-literal payload", [ "."; "-name"; "foo\nbar" ]
+    ; "carriage return is execve-literal payload", [ "."; "-name"; "foo\rbar" ]
     ]
 ;;
 
@@ -1011,7 +1067,7 @@ let test_validation_error_alternatives () =
     ~name:"Argv_contains_shell_metachar alternatives"
     (Execute_input.Argv_contains_shell_metachar
        { executable = "find"; index = 3; token = "foo\nbar" })
-    [ "Pipeline" ];
+    [];
   check_alts
     ~name:"Executable_not_allowlisted rm has no alternatives"
     (Execute_input.Executable_not_allowlisted { name = "rm"; mode = Execute_input.Dev_full })
@@ -1318,6 +1374,10 @@ let suite =
           "pipe_character_in_exec_argv_is_literal"
           `Quick
           test_pipe_character_in_exec_argv_is_literal
+      ; Alcotest.test_case
+          "gh_multiline_body_lowers_to_literal_argv"
+          `Quick
+          test_gh_multiline_body_lowers_to_literal_argv
       ; Alcotest.test_case "cwd_not_absolute" `Quick test_cwd_not_absolute
       ; Alcotest.test_case "env_key_invalid" `Quick test_env_key_invalid
       ; Alcotest.test_case


### PR DESCRIPTION
## Summary

- allow LF/CR inside typed `Execute` argv tokens; only NUL remains rejected
- stop diagnosing literal multiline argv payloads as shell metacharacters or suggesting `Pipeline`
- add regression coverage for multiline `gh --body` markdown containing backticks and pipe characters

## Rebase note

- dropped the earlier keeper report-state compile-repair commit during rebase because #20293/#20295 landed those fixes on `main`

## Verification

- `opam exec -- ocamlformat --check lib/keeper/keeper_tool_execute_typed_input.ml lib/keeper/keeper_tool_execute_typed_input.mli test/test_keeper_tool_execute_typed_input.ml`
- `git diff --check origin/main...HEAD`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-typed-argv-literal scripts/dune-local.sh build test/test_keeper_tool_execute_typed_input.exe test/test_keeper_tool_dispatch_runtime.exe`
- `./_build-codex-typed-argv-literal/default/test/test_keeper_tool_execute_typed_input.exe`
- `./_build-codex-typed-argv-literal/default/test/test_keeper_tool_dispatch_runtime.exe`
- `bash scripts/lint-spawn-bounded.sh`
- `scripts/audit-shell-ir-consumption.sh --baseline scripts/shell-ir-consumption-baseline.json`
