### PR TITLE
[codex] fix keeper report state tool surface

### DIFF
--- a/lib/config/env_config_runtime.mli
+++ b/lib/config/env_config_runtime.mli
@@ -30,6 +30,7 @@ end
 module Session : sig
   val max_age_seconds : float
   val rate_limit_window_seconds : float
+  val sse_grace_period_seconds : float
 end
 
 (** {1 Tempo (polling interval)} *)

--- a/lib/governance_pipeline_risk.ml
+++ b/lib/governance_pipeline_risk.ml
@@ -141,8 +141,8 @@ let risk_of_keeper (k : Keeper_tool_name.t) : risk_level =
   | Board_sub_board_get | Board_sub_board_list | Board_vote | Broadcast
   | Context_status | Handoff | Library_read | Library_search | Memory_search
   | Memory_write | Search_files | Stay_silent | Tasks_audit | Tasks_list | Time_now
-  | Tool_search | Tools_list | Voice_agent | Voice_listen | Voice_session_end
-  | Voice_session_start | Voice_sessions | Voice_speak -> Low
+  | Tool_search | Tools_list | State_report | Voice_agent | Voice_listen
+  | Voice_session_end | Voice_session_start | Voice_sessions | Voice_speak -> Low
   | Board_sub_board_create | Board_sub_board_update | Task_claim | Task_create | Task_done
     -> Medium
   | Fs_edit | Fs_write | Fs_read | Ide_annotate -> High

--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -326,17 +326,39 @@ type task_op =
   | Task_done
   | State_report
 
-let task_op_of_name = function
-  | "keeper_tasks_list" -> Some Tasks_list
-  | "keeper_tasks_audit" -> Some Tasks_audit
-  | "keeper_task_force_release" -> Some Task_force_release
-  | "keeper_task_force_done" -> Some Task_force_done
-  | "keeper_broadcast" -> Some Broadcast
-  | "keeper_task_create" -> Some Task_create
-  | "keeper_task_claim" -> Some Task_claim
-  | "keeper_task_done" -> Some Task_done
-  | "keeper_report_state" -> Some State_report
+let task_op_of_keeper_tool = function
+  | Keeper_tool_name.Tasks_list -> Some Tasks_list
+  | Keeper_tool_name.Tasks_audit -> Some Tasks_audit
+  | Keeper_tool_name.Task_force_release -> Some Task_force_release
+  | Keeper_tool_name.Task_force_done -> Some Task_force_done
+  | Keeper_tool_name.Broadcast -> Some Broadcast
+  | Keeper_tool_name.Task_create -> Some Task_create
+  | Keeper_tool_name.Task_claim -> Some Task_claim
+  | Keeper_tool_name.Task_done -> Some Task_done
+  | Keeper_tool_name.State_report -> Some State_report
   | _ -> None
+;;
+
+let task_op_of_name name =
+  match Keeper_tool_name.of_string name with
+  | Some tool -> task_op_of_keeper_tool tool
+  | None -> None
+;;
+
+let state_report_result_json args =
+  let snapshot =
+    match Keeper_memory_policy.keeper_state_snapshot_of_json args with
+    | Some snapshot -> snapshot
+    | None -> Keeper_memory_policy.empty_keeper_state_snapshot
+  in
+  Yojson.Safe.to_string
+    (`Assoc
+       [ "ok", `Bool true
+       ; ( "state_snapshot"
+         , Keeper_memory_policy.keeper_state_snapshot_to_json snapshot )
+       ; "state_block", `String (Keeper_memory_policy.render_state_block snapshot)
+       ; "typed_outcome", Keeper_tool_outcome.to_json Keeper_tool_outcome.Progress
+       ])
 ;;
 
 let handle_keeper_task_tool
@@ -772,4 +794,5 @@ let handle_keeper_task_tool
         ~ok:(Tool_result.is_success transition_result)
         ~message:(Tool_result.message transition_result)
         ())
+    | State_report -> state_report_result_json args
 ;;

--- a/lib/keeper_tooling/keeper_tool_name.mli
+++ b/lib/keeper_tooling/keeper_tool_name.mli
@@ -45,6 +45,7 @@ type t =
   | Time_now
   | Tool_search
   | Tools_list
+  | State_report
   | Voice_agent
   | Voice_listen
   | Voice_session_end

--- a/test/test_keeper_tool_name.ml
+++ b/test/test_keeper_tool_name.ml
@@ -33,6 +33,24 @@ let test_non_write_board_surface_names () =
     ]
 ;;
 
+let test_state_report_name_round_trips () =
+  check
+    (option (testable Keeper_tool_name.pp ( = )))
+    "of_string"
+    (Some Keeper_tool_name.State_report)
+    (Keeper_tool_name.of_string "keeper_report_state");
+  check
+    string
+    "to_string"
+    "keeper_report_state"
+    (Keeper_tool_name.to_string Keeper_tool_name.State_report);
+  check
+    bool
+    "not board write"
+    false
+    (Keeper_tool_name.is_board_write_surface_name "keeper_report_state")
+;;
+
 let () =
   run
     "Keeper_tool_name"
@@ -42,6 +60,10 @@ let () =
             "rejects non-write and unknown surfaces"
             `Quick
             test_non_write_board_surface_names
+        ; test_case
+            "state report name round-trips"
+            `Quick
+            test_state_report_name_round_trips
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary

- Export the new `State_report` keeper tool-name constructor through `keeper_tool_name.mli`.
- Route taskboard tool dispatch through `Keeper_tool_name.of_string` and add a callable `keeper_report_state` handler that returns the normalized state snapshot payload.
- Classify `State_report` as low governance risk and export `Session.sse_grace_period_seconds`, which the session transport already used.
- Add a round-trip test for `keeper_report_state`.

## Root Cause

`keeper_report_state` was added to the schema/runtime surface but the typed keeper tool-name interface and exhaustive typed consumers were not updated. After that was fixed, `dune build .` exposed a second interface drift: `Env_config_runtime.Session.sse_grace_period_seconds` existed in the implementation but not in the `.mli`.

## Validation

- `git diff --check`
- `env DUNE_CACHE=disabled dune build --build-dir _build_codex_state_report --root . lib/masc.cmxa`
- `./_build_codex_state_report/default/test/test_keeper_tool_name.exe`
- `env DUNE_CACHE=disabled dune build --build-dir _build_codex_state_report --root . .`