### PR TITLE
fix(keeper): remove duplicate state report match

### DIFF
--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -826,5 +826,4 @@ let handle_keeper_task_tool
         ~ok:(Tool_result.is_success transition_result)
         ~message:(Tool_result.message transition_result)
         ())
-    | State_report -> state_report_result_json args
 ;;


### PR DESCRIPTION
## Summary
- remove the duplicate State_report match arm from keeper_task runtime dispatch
- keep the existing state_report_result_json handler as the single implementation

## Verification
- env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_codex_20260606k dune build --root . test/test_keeper_effective_meta_overlay.exe test/test_keeper_tool_name.exe
- _build_codex_20260606k/default/test/test_keeper_tool_name.exe