### PR TITLE
fix(keeper): accept structured state output

### DIFF
--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -9,6 +9,40 @@ open Keeper_meta_contract
 open Keeper_types_profile
 open Keeper_agent_result
 
+let reported_state_snapshot_from_checkpoint
+    (checkpoint : Agent_sdk.Checkpoint.t option)
+  : Keeper_memory_policy.keeper_state_snapshot option =
+  let snapshot_of_content = function
+    | Agent_sdk.Types.ToolUse { name; input; _ }
+      when String.equal name
+             (Keeper_tool_name.to_string Keeper_tool_name.State_report) ->
+      (match Keeper_memory_policy.structured_state_snapshot_schema.parse input with
+       | Ok snapshot -> Some snapshot
+       | Error detail ->
+         Log.Keeper.warn
+           "keeper_report_state input ignored: invalid structured state: %s"
+           detail;
+         None)
+    | Agent_sdk.Types.Text _
+    | Agent_sdk.Types.Thinking _
+    | Agent_sdk.Types.RedactedThinking _
+    | Agent_sdk.Types.Image _
+    | Agent_sdk.Types.Document _
+    | Agent_sdk.Types.Audio _
+    | Agent_sdk.Types.ToolUse _
+    | Agent_sdk.Types.ToolResult _ -> None
+  in
+  let rec messages_loop = function
+    | [] -> None
+    | (msg : Agent_sdk.Types.message) :: rest ->
+      (match List.find_map snapshot_of_content msg.content with
+       | Some _ as snapshot -> snapshot
+       | None -> messages_loop rest)
+  in
+  match checkpoint with
+  | None -> None
+  | Some checkpoint -> messages_loop (List.rev checkpoint.messages)
+
 let finalize
     ~config
     ~meta
@@ -36,29 +70,29 @@ let finalize
     ~pre_dispatch_compaction_after_tokens
     ~raw_response_text
     () =
+  let reported_state_snapshot =
+    reported_state_snapshot_from_checkpoint result.checkpoint
+  in
   let
-    { Keeper_agent_run_response_text.state_snapshot; response_text }
+    { Keeper_agent_run_response_text.state_snapshot
+    ; state_snapshot_source
+    ; response_text
+    }
     =
     Keeper_agent_run_response_text.finalize
+      ~reported_state_snapshot
       ~keeper_name:meta.name
       ~goal:meta.goal
       ~actual_keeper_tool_names
       ~stop_reason:result.stop_reason
       ~raw_response_text
-  in
-  let state_snapshot_source =
-    if
-      Option.is_some
-        (Keeper_memory_policy.parse_state_snapshot_from_reply
-           raw_response_text)
-    then "model_state_block"
-    else "synthesized"
+      ()
   in
   (* Gate the working-state resume merge (ResumeFromDigest) to turns where active
      loops can be silently lost: a pre-dispatch compaction may have dropped the
-     reminder, or the model emitted no [STATE] block at all (synthesized). On a
-     normal model_state_block turn the snapshot is authoritative, so a dropped
-     loop still clears. *)
+     reminder, or the model emitted no structured state at all (synthesized). On
+     a normal model-authored state turn the snapshot is authoritative, so a
+     dropped loop still clears. *)
   let is_budget_exhausted = function
     | Runtime_agent.TurnBudgetExhausted _ -> true
     | _ -> false

--- a/lib/keeper/keeper_agent_run_response_text.ml
+++ b/lib/keeper/keeper_agent_run_response_text.ml
@@ -2,6 +2,7 @@
 
 type finalized = {
   state_snapshot : Keeper_memory_policy.keeper_state_snapshot;
+  state_snapshot_source : string;
   response_text : string;
 }
 
@@ -14,48 +15,73 @@ let stop_reason_label = function
      | None -> "mutation_boundary")
 ;;
 
-let state_snapshot ~keeper_name ~goal ~actual_keeper_tool_names
+let state_snapshot ~reported_state_snapshot ~keeper_name ~goal ~actual_keeper_tool_names
       ~stop_reason ~raw_response_text
+      ()
   =
-  match Keeper_memory_policy.parse_state_snapshot_from_reply raw_response_text with
-  | Some snapshot -> snapshot
+  match reported_state_snapshot with
+  | Some snapshot -> (snapshot, "model_structured_state_tool")
   | None ->
-    let stop_reason_str = stop_reason_label stop_reason in
-    let synth =
-      Keeper_memory_policy.synthesize_state_from_run_result
-        ~goal
-        ~tools_used:actual_keeper_tool_names
-        ~stop_reason:stop_reason_str
-        ~response_text:raw_response_text
-    in
-    Log.Keeper.info
-      "keeper:%s [STATE] missing, synthesized from %d tools (stop=%s)"
-      keeper_name
-      (List.length actual_keeper_tool_names)
-      stop_reason_str;
-    synth
+    (match
+       Keeper_memory_policy.parse_structured_state_snapshot_from_reply
+         raw_response_text
+     with
+     | Some snapshot -> (snapshot, "model_structured_state")
+     | None ->
+       (match Keeper_memory_policy.parse_state_snapshot_from_reply raw_response_text with
+        | Some snapshot -> (snapshot, "model_state_block")
+        | None ->
+          let stop_reason_str = stop_reason_label stop_reason in
+          let synth =
+            Keeper_memory_policy.synthesize_state_from_run_result
+              ~goal
+              ~tools_used:actual_keeper_tool_names
+              ~stop_reason:stop_reason_str
+              ~response_text:raw_response_text
+          in
+          Log.Keeper.info
+            "keeper:%s state metadata missing, synthesized from %d tools (stop=%s)"
+            keeper_name
+            (List.length actual_keeper_tool_names)
+            stop_reason_str;
+          (synth, "synthesized")))
 ;;
 
-let response_text ~state_snapshot ~raw_response_text =
-  match
-    Keeper_text_processing.state_snapshot_reply_fallback (Some state_snapshot)
-  with
-  | Some fallback ->
-    Keeper_text_processing.user_visible_reply_text ~fallback raw_response_text
-  | None -> Keeper_text_processing.user_visible_reply_text raw_response_text
+let response_text ~state_snapshot ~state_snapshot_source ~raw_response_text =
+  let fallback =
+    match
+      Keeper_text_processing.state_snapshot_reply_fallback (Some state_snapshot)
+    with
+    | Some _ as fallback -> fallback
+    | None when String.equal state_snapshot_source "model_structured_state" ->
+      Some "State updated."
+    | None -> None
+  in
+  if String.equal state_snapshot_source "model_structured_state" then
+    Keeper_text_processing.user_visible_reply_text ?fallback ""
+  else
+    match fallback with
+    | Some fallback ->
+      Keeper_text_processing.user_visible_reply_text ~fallback raw_response_text
+    | None -> Keeper_text_processing.user_visible_reply_text raw_response_text
 ;;
 
-let finalize ~keeper_name ~goal ~actual_keeper_tool_names
+let finalize ~reported_state_snapshot ~keeper_name ~goal ~actual_keeper_tool_names
       ~stop_reason ~raw_response_text
+      ()
   =
-  let state_snapshot =
+  let state_snapshot, state_snapshot_source =
     state_snapshot
+      ~reported_state_snapshot
       ~keeper_name
       ~goal
       ~actual_keeper_tool_names
       ~stop_reason
       ~raw_response_text
+      ()
   in
-  let response_text = response_text ~state_snapshot ~raw_response_text in
-  { state_snapshot; response_text }
+  let response_text =
+    response_text ~state_snapshot ~state_snapshot_source ~raw_response_text
+  in
+  { state_snapshot; state_snapshot_source; response_text }
 ;;

--- a/lib/keeper/keeper_agent_run_response_text.mli
+++ b/lib/keeper/keeper_agent_run_response_text.mli
@@ -2,15 +2,18 @@
 
 type finalized = {
   state_snapshot : Keeper_memory_policy.keeper_state_snapshot;
+  state_snapshot_source : string;
   response_text : string;
 }
 
 val stop_reason_label : Runtime_agent.stop_reason -> string
 
 val finalize :
+  reported_state_snapshot:Keeper_memory_policy.keeper_state_snapshot option ->
   keeper_name:string ->
   goal:string ->
   actual_keeper_tool_names:string list ->
   stop_reason:Runtime_agent.stop_reason ->
   raw_response_text:string ->
+  unit ->
   finalized

--- a/lib/keeper/keeper_memory_policy.ml
+++ b/lib/keeper/keeper_memory_policy.ml
@@ -729,6 +729,99 @@ let snapshot_of_structured_working_context
             | None -> None)
        | _ -> None)
 
+let structured_state_snapshot_of_json
+    (json : Yojson.Safe.t) : keeper_state_snapshot option =
+  match snapshot_of_structured_working_context json with
+  | Some _ as snapshot -> snapshot
+  | None -> keeper_state_snapshot_of_json json
+
+let structured_param ~name ~description ~param_type ~required =
+  { Agent_sdk.Types.name = name; description; param_type; required }
+
+let structured_state_snapshot_schema :
+    keeper_state_snapshot Agent_sdk.Structured.schema =
+  { Agent_sdk.Structured.name = "keeper_state_snapshot";
+    description =
+      "Structured keeper continuity state for the completed turn. Return only \
+       this JSON object when the runtime requests structured state.";
+    params =
+      [ structured_param
+          ~name:"goal"
+          ~description:"Current keeper goal, if still relevant."
+          ~param_type:Agent_sdk.Types.String
+          ~required:false
+      ; structured_param
+          ~name:"progress"
+          ~description:"Short factual progress summary for this generation."
+          ~param_type:Agent_sdk.Types.String
+          ~required:false
+      ; structured_param
+          ~name:"done_summary"
+          ~description:"What was completed this generation."
+          ~param_type:Agent_sdk.Types.String
+          ~required:false
+      ; structured_param
+          ~name:"next_summary"
+          ~description:"What the next generation should do or inspect first."
+          ~param_type:Agent_sdk.Types.String
+          ~required:false
+      ; structured_param
+          ~name:"next_items"
+          ~description:"Concrete next items as strings."
+          ~param_type:Agent_sdk.Types.Array
+          ~required:false
+      ; structured_param
+          ~name:"decisions"
+          ~description:"Model-authored decisions from this generation."
+          ~param_type:Agent_sdk.Types.Array
+          ~required:false
+      ; structured_param
+          ~name:"open_questions"
+          ~description:"Unresolved questions as strings."
+          ~param_type:Agent_sdk.Types.Array
+          ~required:false
+      ; structured_param
+          ~name:"constraints"
+          ~description:"Active constraints as strings."
+          ~param_type:Agent_sdk.Types.Array
+          ~required:false
+      ];
+    parse =
+      (fun json ->
+        match structured_state_snapshot_of_json json with
+        | Some snapshot -> Ok snapshot
+        | None ->
+            Error
+              "structured keeper state is empty or does not match the snapshot \
+               schema");
+  }
+
+let strip_json_markdown_fences (text : string) : string =
+  let trimmed = String.trim text in
+  if not (String.starts_with ~prefix:"```" trimmed) then trimmed
+  else
+    match String.split_on_char '\n' trimmed with
+    | first :: body when String.starts_with ~prefix:"```" (String.trim first) ->
+        let body =
+          match List.rev body with
+          | last :: rest when String.starts_with ~prefix:"```" (String.trim last) ->
+              List.rev rest
+          | _ -> body
+        in
+        String.concat "\n" body |> String.trim
+    | _ -> trimmed
+
+let parse_structured_state_snapshot_from_reply
+    (reply : string) : keeper_state_snapshot option =
+  let text = strip_json_markdown_fences reply in
+  if String.trim text = "" then None
+  else
+    try
+      Yojson.Safe.from_string text
+      |> structured_state_snapshot_of_json
+    with
+    | Yojson.Json_error _ -> None
+
 let latest_state_snapshot_from_messages (messages : Agent_sdk.Types.message list) :
     keeper_state_snapshot option =
   let rec loop (msgs : Agent_sdk.Types.message list) =

--- a/lib/keeper/keeper_memory_policy.mli
+++ b/lib/keeper/keeper_memory_policy.mli
@@ -173,6 +173,16 @@ val parse_state_snapshot_from_reply : string -> keeper_state_snapshot option
 (** Convenience: locate the [STATE] block in a full assistant reply
     and parse it. *)
 
+val structured_state_snapshot_schema :
+  keeper_state_snapshot Agent_sdk.Structured.schema
+(** Provider-native structured-output schema for keeper state snapshots. *)
+
+val parse_structured_state_snapshot_from_reply :
+  string -> keeper_state_snapshot option
+(** Parse a full assistant reply that is itself structured JSON.  Accepts
+    raw snapshot JSON, the versioned [state_snapshot] envelope, or replay
+    metadata. *)
+
 val state_snapshot_of_summary_text : string -> keeper_state_snapshot option
 (** Re-parse the rendered summary text back into a snapshot.  Inverse
     of [keeper_state_snapshot_to_summary_text]. *)

--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -736,38 +736,6 @@ let handle_keeper_task_tool
          match accountability_warning with
          | Some warning -> [ ("routing_warning", `String warning) ]
          | None -> []))
-    | State_report ->
-    let snapshot_opt = Keeper_memory_policy.keeper_state_snapshot_of_json args in
-    let snapshot, persisted =
-      match snapshot_opt with
-      | None -> Keeper_memory_policy.empty_keeper_state_snapshot, false
-      | Some snapshot ->
-        let snapshot = Keeper_memory_policy.cap_snapshot snapshot in
-        let _ =
-          Workspace.broadcast
-            config
-            ~from_agent:(keeper_agent_sender ~meta)
-            ~content:(Keeper_memory_policy.render_state_block snapshot)
-        in
-        snapshot, true
-    in
-    let continuity_summary =
-      if persisted
-      then Keeper_memory_policy.keeper_state_snapshot_to_summary_text snapshot
-      else "No continuity snapshot available."
-    in
-    Yojson.Safe.to_string
-      (`Assoc
-         [ "ok", `Bool true
-         ; ( "result"
-           , `String
-               (if persisted
-                then "keeper state report accepted"
-                else "keeper state report accepted without non-empty state") )
-         ; "persisted", `Bool persisted
-         ; "state_snapshot", Keeper_memory_policy.keeper_state_snapshot_to_json snapshot
-         ; "continuity_summary", `String continuity_summary
-         ])
     | Task_done ->
     let task_id = Safe_ops.json_string ~default:"" "task_id" args |> String.trim in
     let result_text = Safe_ops.json_string ~default:"" "result" args |> String.trim in

--- a/test/test_keeper_state_snapshot_json.ml
+++ b/test/test_keeper_state_snapshot_json.ml
@@ -10,6 +10,7 @@
 
 module KMP = Masc.Keeper_memory_policy
 module KCC = Masc.Keeper_context_core
+module KRT = Masc.Keeper_agent_run_response_text
 
 let contains_substring text needle =
   let text_len = String.length text in
@@ -117,6 +118,148 @@ let test_envelope_empty_snapshot_returns_none () =
   ] in
   let restored = KMP.snapshot_of_structured_working_context json in
   Alcotest.(check bool) "empty snapshot in envelope -> None" true (restored = None)
+
+let test_structured_state_schema_parse_raw_snapshot_json () =
+  let json =
+    `Assoc
+      [ ("progress", `String "Structured progress")
+      ; ("decisions", `List [ `String "No blocker" ])
+      ]
+  in
+  match KMP.structured_state_snapshot_schema.parse json with
+  | Error msg -> Alcotest.fail ("schema parse returned Error: " ^ msg)
+  | Ok snap ->
+      Alcotest.(check (option string))
+        "progress"
+        (Some "Structured progress")
+        snap.progress;
+      Alcotest.(check (list string))
+        "decisions"
+        [ "No blocker" ]
+        snap.decisions
+
+let test_parse_structured_reply_accepts_envelope_json_fence () =
+  let original =
+    make_snapshot
+      ~goal:(Some "Structured goal")
+      ~progress:(Some "Parsed from fenced envelope")
+      ~done_summary:None
+      ~next_summary:None
+      ~next_items:[]
+      ~decisions:[]
+      ~open_questions:[]
+      ~constraints:[]
+      ()
+  in
+  let raw =
+    "```json\n"
+    ^ Yojson.Safe.to_string (KMP.structured_working_context_of_snapshot original)
+    ^ "\n```"
+  in
+  match KMP.parse_structured_state_snapshot_from_reply raw with
+  | None -> Alcotest.fail "structured reply parse returned None"
+  | Some snap ->
+      Alcotest.(check (option string))
+        "goal"
+        (Some "Structured goal")
+        snap.goal;
+      Alcotest.(check (option string))
+        "progress"
+        (Some "Parsed from fenced envelope")
+        snap.progress
+
+let test_finalizer_uses_structured_state_source () =
+  let raw =
+    {|{"progress":"Structured progress","decisions":["No blocker"]}|}
+  in
+  let finalized =
+    KRT.finalize
+      ~reported_state_snapshot:None
+      ~keeper_name:"test"
+      ~goal:"Fix structured state"
+      ~actual_keeper_tool_names:[ "masc_tasks" ]
+      ~stop_reason:Runtime_agent.Completed
+      ~raw_response_text:raw
+      ()
+  in
+  let
+    { KRT.state_snapshot
+    ; state_snapshot_source
+    ; response_text
+    }
+    =
+    finalized
+  in
+  Alcotest.(check string)
+    "source"
+    "model_structured_state"
+    state_snapshot_source;
+  Alcotest.(check (option string))
+    "progress"
+    (Some "Structured progress")
+    state_snapshot.progress;
+  Alcotest.(check string)
+    "visible response"
+    "Structured progress"
+    response_text;
+  Alcotest.(check (list string))
+    "decisions"
+    [ "No blocker" ]
+    state_snapshot.decisions;
+  Alcotest.(check bool)
+    "no synthetic marker"
+    false
+    (List.exists
+       (fun text -> contains_substring text "[SYNTHETIC]")
+       state_snapshot.decisions)
+
+let test_finalizer_prefers_reported_state_snapshot () =
+  let reported_state_snapshot =
+    make_snapshot
+      ~goal:(Some "Tool state goal")
+      ~progress:(Some "Reported through keeper_report_state")
+      ~done_summary:None
+      ~next_summary:None
+      ~next_items:[]
+      ~decisions:[ "Tool state wins" ]
+      ~open_questions:[]
+      ~constraints:[]
+      ()
+  in
+  let finalized =
+    KRT.finalize
+      ~reported_state_snapshot:(Some reported_state_snapshot)
+      ~keeper_name:"test"
+      ~goal:"Fallback goal"
+      ~actual_keeper_tool_names:[ "keeper_report_state" ]
+      ~stop_reason:Runtime_agent.Completed
+      ~raw_response_text:"Visible reply"
+      ()
+  in
+  let
+    { KRT.state_snapshot
+    ; state_snapshot_source
+    ; response_text
+    }
+    =
+    finalized
+  in
+  Alcotest.(check string)
+    "source"
+    "model_structured_state_tool"
+    state_snapshot_source;
+  Alcotest.(check (option string))
+    "progress"
+    (Some "Reported through keeper_report_state")
+    state_snapshot.progress;
+  Alcotest.(check string)
+    "visible response"
+    "Visible reply"
+    response_text;
+  Alcotest.(check (list string))
+    "decisions"
+    [ "Tool state wins" ]
+    state_snapshot.decisions
 
 (* ── patch_checkpoint_last_assistant tests ────────────────────────── *)
 
@@ -300,6 +443,22 @@ let () =
           Alcotest.test_case "wrong version -> None" `Quick test_envelope_wrong_version_returns_none;
           Alcotest.test_case "missing version -> None" `Quick test_envelope_missing_version_returns_none;
           Alcotest.test_case "empty in envelope -> None" `Quick test_envelope_empty_snapshot_returns_none;
+          Alcotest.test_case
+            "schema parses raw snapshot json"
+            `Quick
+            test_structured_state_schema_parse_raw_snapshot_json;
+          Alcotest.test_case
+            "reply parser accepts fenced envelope"
+            `Quick
+            test_parse_structured_reply_accepts_envelope_json_fence;
+          Alcotest.test_case
+            "finalizer keeps structured source"
+            `Quick
+            test_finalizer_uses_structured_state_source;
+          Alcotest.test_case
+            "finalizer prefers reported state"
+            `Quick
+            test_finalizer_prefers_reported_state_snapshot;
         ] );
       ( "patch_checkpoint",
         [


### PR DESCRIPTION
## Summary
- add a structured keeper state snapshot schema and parser for raw/enveloped/fenced JSON state output
- prefer keeper_report_state tool input from the checkpoint as the authoritative state snapshot source
- keep legacy [STATE] and synthesized fallback paths, but mark structured sources explicitly
- remove the duplicate State_report task handler left by overlapping main PRs

## Tests
- env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-structured-state dune build --root . test/test_keeper_state_snapshot_json.exe
- env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-structured-state dune exec --root . test/test_keeper_state_snapshot_json.exe