### PR TITLE
kill shadow match in sandbox_root binding

### DIFF
--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -539,11 +539,7 @@ let log_call
         | Some _ -> generation
         | None -> ctx.generation
       in
-      let sandbox_root =
-        match sandbox_root with
-        | Some _ -> sandbox_root
-        | None -> ctx.sandbox_root
-      in
+      let sandbox_root = Option.first_some sandbox_root ctx.sandbox_root in
       let allowed_paths =
         match allowed_paths with
         | Some _ -> allowed_paths


### PR DESCRIPTION
Remove self-shadowing pattern in sandbox_root binding. Replace match-expression with Option.first_some. No behavioral change.