### PR TITLE
fix(keeper): keep state report dispatch singular

### DIFF
--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -795,5 +795,4 @@ let handle_keeper_task_tool
         ~ok:(Tool_result.is_success transition_result)
         ~message:(Tool_result.message transition_result)
         ())
-    | State_report -> state_report_result_json args
 ;;

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -539,7 +539,11 @@ let log_call
         | Some _ -> generation
         | None -> ctx.generation
       in
-      let sandbox_root = Option.first_some sandbox_root ctx.sandbox_root in
+      let sandbox_root =
+        match sandbox_root with
+        | Some _ -> sandbox_root
+        | None -> ctx.sandbox_root
+      in
       let allowed_paths =
         match allowed_paths with
         | Some _ -> allowed_paths


### PR DESCRIPTION
## Summary
- keep only one keeper_report_state dispatch arm so warning-as-error does not see a redundant State_report case
- replace Option.first_some from #20302 with the existing explicit option fallback pattern for OCaml compatibility

## Verification
- git diff --check
- env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_codex_20260606m dune build --root . test/test_keeper_validation_breaker_exempt.exe test/test_keeper_tool_name.exe test/test_keeper_state_snapshot_json.exe test/test_keeper_effective_meta_overlay.exe
- _build_codex_20260606m/default/test/test_keeper_validation_breaker_exempt.exe
- _build_codex_20260606m/default/test/test_keeper_tool_name.exe
- _build_codex_20260606m/default/test/test_keeper_state_snapshot_json.exe
- _build_codex_20260606m/default/test/test_keeper_effective_meta_overlay.exe