### PR TITLE
fix(keeper): repair state report main build

### DIFF
--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -732,10 +732,9 @@ let handle_keeper_task_tool
             | None -> [])
          @ claimed_task_fields
          @ wip_admission_result_fields wip_rejections
-         @
-         match accountability_warning with
-         | Some warning -> [ ("routing_warning", `String warning) ]
-         | None -> []))
+         @ (match accountability_warning with
+            | Some warning -> [ ("routing_warning", `String warning) ]
+            | None -> [])))
     | State_report -> state_report_result_json args
     | Task_done ->
     let task_id = Safe_ops.json_string ~default:"" "task_id" args |> String.trim in
@@ -795,5 +794,4 @@ let handle_keeper_task_tool
         ~ok:(Tool_result.is_success transition_result)
         ~message:(Tool_result.message transition_result)
         ())
-    | State_report -> state_report_result_json args
 ;;

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -539,7 +539,11 @@ let log_call
         | Some _ -> generation
         | None -> ctx.generation
       in
-      let sandbox_root = Option.first_some sandbox_root ctx.sandbox_root in
+      let sandbox_root =
+        match sandbox_root with
+        | Some _ -> sandbox_root
+        | None -> ctx.sandbox_root
+      in
       let allowed_paths =
         match allowed_paths with
         | Some _ -> allowed_paths


### PR DESCRIPTION
## Summary
- keep exactly one State_report dispatch in keeper_task runtime so the closed task_op match is exhaustive without a redundant case
- replace non-existent Option.first_some with the local explicit fallback pattern

## Tests
- env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-state-report-match dune build --root . test/test_keeper_state_snapshot_json.exe
- env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-state-report-match dune exec --root . test/test_keeper_state_snapshot_json.exe