### PR TITLE
fix: resolve two build errors

### DIFF
--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -795,5 +795,4 @@ let handle_keeper_task_tool
         ~ok:(Tool_result.is_success transition_result)
         ~message:(Tool_result.message transition_result)
         ())
-    | State_report -> state_report_result_json args
 ;;

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -539,7 +539,11 @@ let log_call
         | Some _ -> generation
         | None -> ctx.generation
       in
-      let sandbox_root = Option.first_some sandbox_root ctx.sandbox_root in
+      let sandbox_root =
+        match sandbox_root with
+        | Some _ -> sandbox_root
+        | None -> ctx.sandbox_root
+      in
       let allowed_paths =
         match allowed_paths with
         | Some _ -> allowed_paths


### PR DESCRIPTION
## Changes

- **keeper_tool_call_log.ml**: Replace unbound `Option.first_some` with match pattern consistent with surrounding code
- **keeper_tool_task_runtime.ml**: Remove redundant `State_report` match case (duplicate of L739, warning 11)

## Verification

`dune build --root .` exits 0 in worktree.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
