### PR TITLE
fix(dashboard): reinit stale MCP sessions

### DIFF
--- a/dashboard/src/api/mcp.test.ts
+++ b/dashboard/src/api/mcp.test.ts
@@ -409,6 +409,67 @@ describe('callMcpTool', () => {
     )
   })
 
+  it('reinitializes and retries once when the server rejects a stale MCP session', async () => {
+    fetchWithTimeout
+      .mockResolvedValueOnce(
+        new Response('{}', {
+          status: 200,
+          headers: { 'Mcp-Session-Id': 'sess-stale' },
+        }),
+      )
+      .mockResolvedValueOnce(new Response('', { status: 202 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            error: {
+              code: -32600,
+              message: 'Unknown Mcp-Session-Id. Re-initialize to obtain a fresh session.',
+            },
+            id: null,
+          }),
+          {
+            status: 404,
+            statusText: 'Not Found',
+            headers: { 'Mcp-Session-Id': 'sess-uninitialized' },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response('{}', {
+          status: 200,
+          headers: { 'Mcp-Session-Id': 'sess-fresh' },
+        }),
+      )
+      .mockResolvedValueOnce(new Response('', { status: 202 }))
+      .mockResolvedValueOnce(
+        new Response('data: {"result":{"content":[{"type":"text","text":"ok"}]}}\n', { status: 200 }),
+      )
+
+    const { callMcpTool } = await import('./mcp')
+    await expect(callMcpTool('masc_status', {})).resolves.toBe('ok')
+
+    const calls = fetchWithTimeout.mock.calls as Array<[string, RequestInit, number]>
+    const callsByMethod = (method: string) =>
+      calls.filter(([, init]) => {
+        const body = init.body
+        if (typeof body !== 'string') return false
+        try { return JSON.parse(body).method === method }
+        catch { return false }
+      })
+    const initCalls = callsByMethod('initialize')
+    const toolCalls = callsByMethod('tools/call')
+
+    expect(initCalls).toHaveLength(2)
+    expect(toolCalls).toHaveLength(2)
+    expect((toolCalls[0]![1].headers as Record<string, string>)['Mcp-Session-Id'])
+      .toBe('sess-stale')
+    expect((initCalls[1]![1].headers as Record<string, string>)['Mcp-Session-Id'])
+      .toBeUndefined()
+    expect((toolCalls[1]![1].headers as Record<string, string>)['Mcp-Session-Id'])
+      .toBe('sess-fresh')
+  })
+
   it('blocks subsequent calls after tools/call returns 403', async () => {
     fetchWithTimeout
       .mockResolvedValueOnce(

--- a/dashboard/src/api/mcp.ts
+++ b/dashboard/src/api/mcp.ts
@@ -23,6 +23,7 @@ import { errorToString } from '../lib/format-string'
 
 const MCP_BLOCKED_MESSAGE = 'MCP 연결이 차단되었습니다.'
 const MCP_SESSION_BLOCKED = '__blocked__'
+const MCP_UNKNOWN_SESSION_MESSAGE = 'Unknown Mcp-Session-Id'
 
 let mcpSessionId: string | null = null
 let initPromise: Promise<void> | null = null
@@ -113,26 +114,72 @@ function mcpHeadersForActor(
   return headers
 }
 
+function resetMcpSessionOnly(): void {
+  mcpSessionId = null
+  initPromise = null
+  if (initCooldownTimer) {
+    clearTimeout(initCooldownTimer)
+    initCooldownTimer = null
+  }
+}
+
+function mcpBodyMethod(body: unknown): string | null {
+  if (typeof body !== 'object' || body === null) return null
+  const method = (body as Record<string, unknown>).method
+  return typeof method === 'string' ? method : null
+}
+
+function canRetryUnknownSession(body: unknown): boolean {
+  const method = mcpBodyMethod(body)
+  return method !== 'initialize'
+    && method !== 'notifications/initialized'
+    && method !== 'ping'
+    && method !== 'server/discover'
+}
+
+async function responseTextSnippet(res: Response): Promise<string> {
+  try {
+    return await res.clone().text()
+  } catch {
+    return ''
+  }
+}
+
 async function mcpPost(
   body: unknown,
   timeoutMs = DEFAULT_MCP_TIMEOUT_MS,
   actorName?: string | null,
+  retryUnknownSession = true,
 ): Promise<string> {
   const res = await fetchWithTimeout('/mcp', {
     method: 'POST',
     headers: mcpHeadersForActor(actorName),
     body: JSON.stringify(body),
   }, timeoutMs)
-  // Capture session ID from response
-  const sid = res.headers.get('Mcp-Session-Id')
-  if (sid) mcpSessionId = sid
   if (!res.ok) {
     if (res.status === 403) {
       mcpSessionId = MCP_SESSION_BLOCKED
       throw new Error(MCP_BLOCKED_MESSAGE)
     }
-    throw await apiRequestErrorFromResponse('POST', '/mcp', res)
+    const bodyText = res.status === 404 ? await responseTextSnippet(res) : ''
+    const err = await apiRequestErrorFromResponse('POST', '/mcp', res)
+    const message = `${bodyText}\n${errorToString(err)}`
+    if (
+      retryUnknownSession
+      && res.status === 404
+      && canRetryUnknownSession(body)
+      && message.includes(MCP_UNKNOWN_SESSION_MESSAGE)
+    ) {
+      resetMcpSessionOnly()
+      await ensureSession()
+      return mcpPost(body, timeoutMs, actorName, false)
+    }
+    throw err
   }
+  // Capture session ID only after successful responses. A stale-session 404
+  // may include a fresh header, but that header is not initialized yet.
+  const sid = res.headers.get('Mcp-Session-Id')
+  if (sid) mcpSessionId = sid
   return res.text()
 }
 
@@ -207,13 +254,8 @@ async function ensureSession(): Promise<void> {
 }
 
 export function resetMcpClientState(): void {
-  mcpSessionId = null
-  initPromise = null
+  resetMcpSessionOnly()
   resetDevTokenBootstrap()
-  if (initCooldownTimer) {
-    clearTimeout(initCooldownTimer)
-    initCooldownTimer = null
-  }
 }
 
 // --- MCP over HTTP helper ---


### PR DESCRIPTION
## What changed
- Reset the dashboard MCP client session when `/mcp` returns `Unknown Mcp-Session-Id` for a non-handshake request.
- Re-run `initialize` and retry the original MCP request once.
- Avoid storing a session id from failed stale-session responses because that id has not been initialized yet.

## Why
After a backend restart or stale session reap, the dashboard could keep posting with an old `Mcp-Session-Id`, surfacing the resume failure toast instead of recovering.

## Validation
- `pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/api/mcp.test.ts`
- `pnpm run typecheck`
- `pnpm run lint`