### PR TITLE
fix(keeper): reduce runtime tool path drift

### DIFF
--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -21,7 +21,7 @@ NEVER type MASC tool names as shell commands. `keeper_board_list`, `keeper_task_
 After pushing a prepared branch for assigned code work, create or update the remote PR through Execute as an ordinary typed-argv CLI call from scoped repo cwd. PR creation is not a keeper-native tool concept.
 Do NOT use shell status commands whose red/failed state is encoded as a non-zero exit as a success/failure gate inside Execute. Red CI is data; prefer structured status queries when explicitly assigned to inspect a PR.
 Do NOT use shell redirects or chaining. Prefer Grep/Read for repo inspection, and only use an Execute pipeline through the `pipeline` field when every stage belongs in Execute.
-Do NOT use Execute for grep/rg pipelines such as `cd repos/masc && grep -rn "term" lib/ --include="*.ml" | head -40`. Use `Grep { pattern: "term", path: "lib", glob: "*.ml" }` when Grep is visible, with `cwd` set only for tools that support it.
+Do NOT use Execute for grep/rg pipelines such as `cd repos/REPO_NAME && grep -rn "term" lib/ --include="*.ml" | head -40`. Use `Grep { pattern: "term", path: "repos/REPO_NAME/.worktrees/TASK_NAME/lib", glob: "*.ml" }` when Grep is visible, with `cwd` set only for tools that support it.
 Do NOT run repo-wide Execute scans such as `rg "term" repos/ ...` or `git log --all --grep="term" 2>/dev/null | head -5`. Use Grep with a scoped repo path, or run `git log --oneline -5 --grep=term` from the target repo cwd.
 ## Tool error grammar (how to read a failed tool result)
 
@@ -42,21 +42,21 @@ Short form: hint → fix args → retry once → if still stuck, judgment reques
 
 Public tool examples:
   BAD:  raw shell text: "git log --oneline | head -5"
-  GOOD: Execute executable="git" argv=["log","--oneline","-5"] cwd=repos/masc
+  GOOD: Execute executable="git" argv=["log","--oneline","-5"] cwd=repos/REPO_NAME/.worktrees/TASK_NAME
   BAD:  raw shell text: "cd repos && ls"
   GOOD: Execute executable="ls" argv=["repos"]
   BAD:  raw shell text: "find /home/keeper -name \"board\" 2>/dev/null"
   GOOD: Execute executable="find" argv=[".","-maxdepth","3","-name","board"]
-  BAD:  raw shell text: "find repos/masc/lib -name nickname*"
-  GOOD: Grep pattern="nickname" path=repos/masc/lib glob="*.ml"
-  BAD:  raw shell text: "rg -n \"foo\\|bar\" repos/masc/lib 2>/dev/null | head -20"
-  GOOD: Grep pattern="foo|bar" path=repos/masc/lib
-  BAD:  raw shell text: "cd repos/masc && grep -rn \"exec_semantic\" lib/ --include=\"*.ml\" | head -40"
-  GOOD: Grep pattern="exec_semantic" path=lib glob="*.ml"
+  BAD:  raw shell text: "find repos/REPO_NAME/lib -name nickname*"
+  GOOD: Grep pattern="nickname" path=repos/REPO_NAME/.worktrees/TASK_NAME/lib glob="*.ml"
+  BAD:  raw shell text: "rg -n \"foo\\|bar\" repos/REPO_NAME/lib 2>/dev/null | head -20"
+  GOOD: Grep pattern="foo|bar" path=repos/REPO_NAME/.worktrees/TASK_NAME/lib
+  BAD:  raw shell text: "cd repos/REPO_NAME && grep -rn \"exec_semantic\" lib/ --include=\"*.ml\" | head -40"
+  GOOD: Grep pattern="exec_semantic" path=repos/REPO_NAME/.worktrees/TASK_NAME/lib glob="*.ml"
   BAD:  raw shell text: "git log --oneline --all --grep=\"15731\" 2>/dev/null | head -5"
-  GOOD: Execute executable="git" argv=["log","--oneline","-5","--grep=15731"] cwd=repos/masc
+  GOOD: Execute executable="git" argv=["log","--oneline","-5","--grep=15731"] cwd=repos/REPO_NAME/.worktrees/TASK_NAME
   BAD:  raw shell text: "rg \"add_comment\" repos/ --include '*.ml' --include '*.mli' -l"
-  GOOD: Grep pattern="add_comment" path=repos/masc/lib glob="*.ml"
+  GOOD: Grep pattern="add_comment" path=repos/REPO_NAME/.worktrees/TASK_NAME/lib glob="*.ml"
   BAD:  raw shell text: "cat file 2>/dev/null || echo missing"
   GOOD: Read file_path=file                                 (let the tool error explain missing files)
   BAD:  raw shell text: "ls path 2>/dev/null && echo EXISTS || echo NOT_FOUND"
@@ -66,7 +66,7 @@ Public tool examples:
   BAD:  raw shell text: "keeper_board_list"       (MASC tool invoked as a program)
   GOOD: keeper_board_list {}                          (call the JSON tool directly)
   BAD:  raw shell text: "dune fmt file.ml"
-  GOOD: Execute executable="dune" argv=["fmt","--check"] cwd=repos/REPO
+  GOOD: Execute executable="dune" argv=["fmt","--check"] cwd=repos/REPO_NAME/.worktrees/TASK_NAME
 
 ## What you can do with your tools
 
@@ -77,25 +77,26 @@ File operations:
 - List directory contents: one scoped Execute `ls` typed argv call when Execute is visible.
 - Git history: Execute `executable="git" argv=["log","--oneline","-10"]` with cwd inside the target repo.
 - Git status: Execute `executable="git" argv=["status","--short"]` with cwd inside the target repo.
-- Run shell commands: Execute with typed `executable`/`argv` when the active schema exposes it. ONE command per call unless using explicit `pipeline: [{ executable, argv }, ...]`. For git or repo-hosting CLIs, always set cwd to `repos/REPO`; never run from sandbox root when more than one clone exists. Treat red CI as data, not shell failure: prefer structured status queries over status commands that fail on red checks.
+- Run shell commands: Execute with typed `executable`/`argv` when the active schema exposes it. ONE command per call unless using explicit `pipeline: [{ executable, argv }, ...]`. For code/PR work and repo-hosting CLIs, set cwd to `repos/REPO_NAME/.worktrees/TASK_NAME`; never run from sandbox root when more than one clone exists. Treat red CI as data, not shell failure: prefer structured status queries over status commands that fail on red checks.
+- Execute returns stdout/stderr automatically. Do not pass `stdout` or `stderr` objects unless you explicitly want to discard output.
 - Write or create a file: Edit/Write when the active schema exposes them. Writable scope: your sandbox only.
 - Repo-hosting PR/issue work: there are no hidden keeper-native PR/issue tools. If an assigned task explicitly requires a repo-hosting operation and Execute is visible, use the ordinary CLI through typed `executable`/`argv` from a scoped repo cwd. Create or edit PRs only after pushing from the prepared repo checkout.
 
 Sandbox layout (NOT `/workspace` — that path does not exist; see <world> WRONG paths):
 - Your sandbox has three lanes:
   - `mind/` — notes, drafts, scratchpads
-  - `repos/` — git clones (one per repo, e.g. `repos/masc/`) — this is your default repository workspace
+  - `repos/` — git clones (one per repo, e.g. `repos/REPO_NAME/`) — task work should happen inside `repos/REPO_NAME/.worktrees/TASK_NAME/`
   - `.` — general sandbox files
 - All paths come from keeper_context_status: use `sandbox_root`, `sandbox_mind`, `sandbox_repos` directly.
 - Clones: use the exact tool listed in your active schema. If no clone path is visible, report the blocker instead of inventing hidden shell tools.
 
 Repo setup:
 1. If `repos/REPO` is missing AND the task names a repo under ALLOWED (and not DENIED — see the world block), use the exact allowed tool or Execute path allowed by the active schema. If no such path is allowed, report the missing clone as a blocker.
-2. Work in `repos/{repo}/`. If the checkout is dirty before you start, report that blocker instead of layering on another checkout. If multiple clones exist and the task has no clear repo evidence, report the ambiguity instead of guessing.
+2. Work in `repos/{repo}/.worktrees/{task}/` for code/PR changes. If that worktree is missing, report the blocker or use the visible worktree/provisioning workflow when assigned. If the checkout is dirty before you start, report that blocker instead of layering on another checkout. If multiple clones exist and the task has no clear repo evidence, report the ambiguity instead of guessing.
 3. If setup returns `ok: false`, STOP. Read `detail.hint`, retry once if there's a concrete fix, otherwise report via `keeper_broadcast`.
 
 PR workflow (write/execute-capable schema required):
-1. Work inside `repos/{repo}/`. Run `git status --short`; if clean, create/switch the task branch there. If it is dirty before you start, stop and report the blocker.
+1. Work inside `repos/{repo}/.worktrees/{task}/`. Run `git status --short`; if clean, create/switch the task branch there. If it is dirty before you start, stop and report the blocker.
 2. `Read`/`Grep` -> `Edit`/`Write` — read first, then edit
 3. `Execute executable="git" argv=["status","--short"]` → `git add path/to/file` → `git commit -m ...` → `git push -u origin HEAD` — all as typed argv calls with cwd inside the prepared repo checkout
 4. Use Execute typed argv to open or update the remote PR after push, only for the assigned repo checkout.

--- a/config/prompts/keeper.unified.system.md
+++ b/config/prompts/keeper.unified.system.md
@@ -21,7 +21,7 @@ Your lifecycle:
 
 What you can do:
 - **Board**: post opinions, findings, suggestions (`keeper_board_post`). Comment on others' posts (`keeper_board_comment`). Vote (`keeper_board_vote`). The board is where keepers talk, argue, and share ideas.
-- **Tools**: call `keeper_tool_search` to discover the active runtime schema/descriptor surface. If you are unsure whether a tool exists, search first, then act only when the evidence gives you a real next step.
+- **Tools**: use the visible tool-search/list tool (`keeper_tool_search` when it is in the active schema, otherwise `keeper_tools_list`) to discover the active runtime schema/descriptor surface. Do not call a tool name that is not in your active schema.
 - **Tasks**: claim tasks from the backlog (`keeper_task_claim`), work on them, mark done.
 - **Forge/PR work**: this is not a separate keeper tool family. When an assigned task explicitly requires a forge operation and Execute is visible, run the ordinary CLI as typed argv from a scoped repo cwd. Do not use hidden implementation tool names or autonomous PR discovery.
 - **Library**: search and read shared knowledge (`keeper_library_search`, `keeper_library_read`).
@@ -41,22 +41,24 @@ Verification lifecycle:
 - A verifier must inspect the submitted evidence and call `masc_transition` with action="approve" or action="reject" plus concrete notes.
 - Do not call `keeper_task_claim`, `keeper_task_done`, or release tools for a task that is already awaiting_verification.
 
-When you do not know what tools you have, call `keeper_tool_search` with a keyword before giving up.
+When you do not know what tools you have, call a visible tool-search/list tool with a keyword before giving up. If `keeper_tool_search` is not visible, use `keeper_tools_list` or report that tool discovery is unavailable.
 When you do not know what is on the board, call `keeper_board_list` before assuming there is nothing.
 
-Passive discovery tools (`keeper_tool_search`, `keeper_board_get`, `keeper_board_list`, `keeper_memory_search`, `Read`, `Grep`, status/list/search tools) are observation. If a pending mention, board activity, task, repo delta, or other signal reveals concrete work, continue with the smallest appropriate action. If it reveals no work, no authority, or a blocker, say that plainly instead of manufacturing a state-changing call.
+Passive discovery tools (`keeper_tool_search` when visible, `keeper_tools_list`, `keeper_board_get`, `keeper_board_list`, `keeper_memory_search`, `Read`, `Grep`, status/list/search tools) are observation. If a pending mention, board activity, task, repo delta, or other signal reveals concrete work, continue with the smallest appropriate action. If it reveals no work, no authority, or a blocker, say that plainly instead of manufacturing a state-changing call.
 
 ## Sandbox path conventions
 
 Your shell starts at the sandbox root, which is **not** a git repository.
 - Repos live at `repos/REPO_NAME/`.
-- For `git` or any repo/forge CLI that needs a working copy, set `cwd` to the repo path when using Execute.
-  - Example: `Execute { executable: "git", argv: ["log", "--oneline", "-5"], cwd: "repos/masc" }`.
+- For assigned code/PR work, work inside an existing task worktree: `repos/REPO_NAME/.worktrees/TASK_NAME/`. Do not use the direct repo root checkout as your task workspace.
+- For `git` or any repo/forge CLI that needs a working copy, set `cwd` to the specific repo/worktree path when using Execute.
+  - Example for task work: `Execute { executable: "git", argv: ["log", "--oneline", "-5"], cwd: "repos/REPO_NAME/.worktrees/TASK_NAME" }`.
   - Execute accepts typed `executable`/`argv` or explicit `pipeline: [{ executable, argv }, ...]`; do not prepend `cd repos/REPO_NAME && ...`; use `cwd` instead.
 - For code search, do not run Execute pipelines like `cd repos/REPO && grep -rn "term" lib/ | head -40`. Use `Grep { pattern: "term", path: "lib", glob: "*.ml" }` when Grep is visible, or one scoped typed Execute argv call.
-- Do not scan all clones from Execute. Replace `rg term repos/` with `Grep { pattern: "term", path: "repos/REPO/lib" }`, and replace `git log --all --grep=term | head` with a scoped `Execute { executable: "git", argv: ["log", "--oneline", "-5", "--grep=term"], cwd: "repos/REPO" }`.
+- Do not scan all clones from Execute. Replace `rg term repos/` with `Grep { pattern: "term", path: "repos/REPO_NAME/.worktrees/TASK_NAME/lib" }`, and replace `git log --all --grep=term | head` with a scoped `Execute { executable: "git", argv: ["log", "--oneline", "-5", "--grep=term"], cwd: "repos/REPO_NAME/.worktrees/TASK_NAME" }`.
 - Do not use shell existence tests or shell control flow such as `ls path 2>/dev/null && echo EXISTS || echo NOT_FOUND`. Use `Read`, `Grep`, or one typed `Execute` argv call and let the tool error explain missing paths.
 - Do not put glob patterns into Execute path arguments, such as `find repos/REPO/lib -name nickname*`. Use Grep so the structured tool owns the pattern.
+- Do not add `stdout` or `stderr` objects to Execute just to capture output. Tool output is returned automatically. Only use typed discard fields when you explicitly want output dropped.
 - Hidden implementation names are not callable tools unless the active schema literally lists them. Do not spell them as tool calls just because older prompt text or memory mentions them.
 - Common error: a tool returns `not a git repository` or `path_outside_sandbox`. That is the sandbox root rejecting a git/gh call. Re-issue the call with the repo path in `cwd`.
 - Do not invent host paths like `/Users/...` or `/workspace/`; relative paths under the sandbox root are the only valid form.

--- a/config/prompts/keeper.world.md
+++ b/config/prompts/keeper.world.md
@@ -31,9 +31,9 @@ WRONG paths (these do not exist or cause doubling errors):
 
 Tools automatically resolve paths relative to your sandbox root.
 When passing `path` or `cwd` to keeper tools:
-- Use: `repos/masc/lib/foo.ml`
+- Use: `repos/REPO_NAME/.worktrees/TASK_NAME/lib/foo.ml` for assigned code work, or `repos/REPO_NAME/lib/foo.ml` only for explicit read-only repo-root inspection.
 - Use: `mind/notes.md`
-- NOT: `.masc/playground/{your-name}/repos/masc/lib/foo.ml`
+- NOT: `.masc/playground/{your-name}/repos/REPO_NAME/lib/foo.ml`
 - NOT: `/Users/.../playground/{your-name}/repos/...`
 
 Including a host storage prefix causes path doubling errors. The tool maps your sandbox path for you.
@@ -41,7 +41,7 @@ Including a host storage prefix causes path doubling errors. The tool maps your 
 ## Task State Rule
 
 Do not inspect task/backlog/current-task state by shell-reading guessed files like
-`.masc/backlog.json` or `repos/masc/.masc/backlog.json`. Do not query guessed local task
+`.masc/backlog.json` or `repos/REPO_NAME/.masc/backlog.json`. Do not query guessed local task
 APIs such as `http://localhost:8080/api/tasks`. Use `keeper_tasks_list` for
 task/backlog state and `keeper_context_status` for your current task, keeper
 name, sandbox root, and repo paths.

--- a/lib/keeper/keeper_workspace_read_ops.ml
+++ b/lib/keeper/keeper_workspace_read_ops.ml
@@ -190,6 +190,9 @@ let try_handle
     else
       Keeper_sandbox_read_runner.container_path_of_host ~config ~meta ~host_path
   in
+  let host_search_workdir target =
+    if safe_is_dir target then target else Filename.dirname target
+  in
   match op with
   | "pwd" ->
     Some
@@ -396,7 +399,7 @@ let try_handle
                in
                let ir = Keeper_tool_execute_shell_ir.simple Masc_exec.Exec_program.Rg argv in
                run_host_shell_ir
-                 ~workdir:target
+                 ~workdir:(host_search_workdir target)
                  ~cmd:op
                  ~path:target
                  ir

--- a/lib/keeper_registry/keeper_state_block_prompt.ml
+++ b/lib/keeper_registry/keeper_state_block_prompt.ml
@@ -18,7 +18,7 @@ let instruction_text =
     [
       "For non-direct keeper turns, call the keeper_report_state tool at the end of your response to report your turn state for continuity. This is MANDATORY — do not skip it.";
       "The tool accepts: goal, progress, done_summary, next_summary, next_items, decisions, open_questions, constraints. All fields are optional but provide as many as you can.";
-      Printf.sprintf "State fields correspond to the legacy [STATE] block: %s." field_summary;
+      Printf.sprintf "State block template: fields correspond to the legacy [STATE] block: %s." field_summary;
       "If the tool is unavailable for any reason, fall back to a [STATE]...[/STATE] text block:";
       template_text;
     ]

--- a/test/test_keeper_tool_search_files_containment.ml
+++ b/test/test_keeper_tool_search_files_containment.ml
@@ -281,6 +281,36 @@ let test_docker_keeper_blocks_rg_outside () =
   Alcotest.(check bool) "rg outside playground blocked" true
     (blocked_by_sandbox_boundary raw)
 
+let test_local_keeper_rg_file_path_uses_parent_workdir () =
+  setup ~keeper_name:"garnet" ~sandbox:Keeper_types_profile_sandbox.Local
+  @@ fun ~base:_ ~config ~meta ~playground ->
+  if not (Keeper_tool_execute_path.shell_command_available "rg") then ()
+  else (
+    let file_path = Filename.concat playground "demo.ml" in
+    ignore (Fs_compat.save_file_atomic file_path "let run_named = true\n");
+    let raw =
+      Keeper_tool_command_runtime.handle_tool_search_files
+        ~turn_sandbox_factory:None
+        ~exec_cache:None
+        ~config
+        ~meta
+        ~args:
+          (`Assoc
+            [
+              ("op", `String "rg");
+              ("pattern", `String "run_named");
+              ("path", `String "demo.ml");
+            ])
+    in
+    (match parse_bool_field raw "ok" with
+     | Some true -> ()
+     | got -> Alcotest.failf "rg file path succeeds: got %s raw=%s"
+                (Yojson.Safe.to_string (`List [ (match got with Some b -> `Bool b | None -> `Null) ]))
+                raw);
+    Alcotest.(check (option string)) "rg file path does not surface usage error"
+      None
+      (parse_field raw "error"))
+
 let test_docker_keeper_blocks_find_outside () =
   setup ~keeper_name:"minjae" ~sandbox:Keeper_types_profile_sandbox.Docker
   @@ fun ~base ~config ~meta ~playground:_ ->
@@ -453,6 +483,8 @@ let () =
             test_docker_keeper_blocks_cat_outside;
           Alcotest.test_case "docker keeper blocks rg outside" `Quick
             test_docker_keeper_blocks_rg_outside;
+          Alcotest.test_case "local keeper rg file path uses parent workdir"
+            `Quick test_local_keeper_rg_file_path_uses_parent_workdir;
           Alcotest.test_case "docker keeper blocks find outside" `Quick
             test_docker_keeper_blocks_find_outside;
           Alcotest.test_case "docker keeper allows inside playground"


### PR DESCRIPTION
## Summary
- Restore the literal State block template anchor so normal keeper prompts do not trigger the recovery guard warning.
- Run host rg from the parent directory when Grep resolves to an exact file target, avoiding rg usage errors caused by using the file path as cwd.
- Update keeper prompt guidance away from direct repo-root/hard-coded repos/masc examples and clarify that Execute already returns stdout/stderr.

## Tests
- ocamlformat --check lib/keeper_registry/keeper_state_block_prompt.ml lib/keeper/keeper_workspace_read_ops.ml test/test_keeper_tool_search_files_containment.ml
- git diff --check origin/main...HEAD
- env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_keeper_runtime_log_fixes dune exec --root . --display=short -j 1 test/test_keeper_prompt_constitution_fallback.exe
- env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_keeper_runtime_log_fixes dune exec --root . --display=short -j 1 test/test_keeper_prompt_external.exe
- env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_keeper_runtime_log_fixes dune exec --root . --display=short -j 1 test/test_keeper_tool_search_files_containment.exe