### PR TITLE
Dashboard: surface runtime health snapshot

### DIFF
--- a/dashboard/src/components/runtime-health-snapshot.test.ts
+++ b/dashboard/src/components/runtime-health-snapshot.test.ts
@@ -1,0 +1,198 @@
+// @vitest-environment happy-dom
+import { h } from 'preact'
+import { render } from 'preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const apiMocks = vi.hoisted(() => ({
+  fetchDashboardRuntimeProbe: vi.fn(),
+  fetchRuntimeProviders: vi.fn(),
+}))
+
+vi.mock('../api/dashboard', () => apiMocks)
+
+async function waitFor(assertion: () => boolean, label: string): Promise<void> {
+  for (let i = 0; i < 30; i += 1) {
+    if (assertion()) return
+    await new Promise(resolve => setTimeout(resolve, 0))
+  }
+  throw new Error(`Timed out waiting for ${label}`)
+}
+
+function providerPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    updated_at: '2026-06-06T07:24:08Z',
+    summary: {
+      providers: 1,
+      runtimes: 1,
+      local_models: 0,
+      cloud_models: 1,
+      cli_models: 0,
+      default_runtime_id: 'runpod_mtp.qwen',
+    },
+    providers: [
+      {
+        provider: 'runpod_mtp.qwen',
+        runtime_id: 'runpod_mtp.qwen',
+        provider_id: 'runpod_mtp',
+        model_api_name: 'Qwen/Qwen3-32B',
+        transport: 'http',
+        runtime_kind: 'http',
+        status: 'configured',
+        available: true,
+        is_default_runtime: true,
+        models: ['Qwen/Qwen3-32B'],
+        endpoint_url: 'https://runpod.example/v1',
+        ...overrides,
+      },
+    ],
+  }
+}
+
+function probePayload(overrides: Record<string, unknown> = {}) {
+  return {
+    generated_at: '2026-06-06T07:24:08Z',
+    cache_hit: false,
+    probe: {
+      source: 'runtime.toml',
+      status: 'reachable',
+      checked_at: '2026-06-06T07:24:08Z',
+      probe_ok: true,
+      server_url: 'https://runpod.example/v1',
+      ps_endpoint: 'https://runpod.example/v1/models',
+      generate_endpoint: 'https://runpod.example/v1/chat/completions',
+      summary: {
+        runtimes: 1,
+        probed: 1,
+        reachable: 1,
+        failed: 0,
+        skipped: 0,
+        default_runtime_id: 'runpod_mtp.qwen',
+      },
+      providers: [
+        {
+          runtime_id: 'runpod_mtp.qwen',
+          provider_id: 'runpod_mtp',
+          model_api_name: 'Qwen/Qwen3-32B',
+          status: 'reachable',
+          reachable: true,
+          http_status: 200,
+          latency_ms: 42,
+          credential_required: true,
+          auth_present: true,
+          probe_url: 'https://runpod.example/v1/models',
+        },
+      ],
+      ...overrides,
+    },
+  }
+}
+
+describe('RuntimeHealthSnapshot', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    vi.resetModules()
+    apiMocks.fetchRuntimeProviders.mockReset().mockResolvedValue(providerPayload())
+    apiMocks.fetchDashboardRuntimeProbe.mockReset().mockResolvedValue(probePayload())
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+    vi.clearAllMocks()
+  })
+
+  it('surfaces live reachability, default runtime, and probe endpoints on the first screen', async () => {
+    const { RuntimeHealthSnapshot } = await import('./runtime-health-snapshot')
+
+    render(h(RuntimeHealthSnapshot, {}), container)
+    await waitFor(
+      () => container.textContent?.includes('runpod_mtp.qwen') ?? false,
+      'default runtime',
+    )
+
+    expect(container.textContent).toContain('런타임 상태 체크')
+    expect(container.textContent).toContain('1 reachable')
+    expect(container.textContent).toContain('default runtime')
+    expect(container.textContent).toContain('ready')
+    expect(container.textContent).toContain('https://runpod.example/v1')
+    expect(container.textContent).toContain('provider details')
+    expect(container.textContent).toContain('runtime.toml')
+    expect(container.textContent).toContain('transport health')
+  })
+
+  it('does not hide failed live probe details behind the full runtime monitor', async () => {
+    apiMocks.fetchDashboardRuntimeProbe.mockResolvedValueOnce(probePayload({
+      status: 'network_error',
+      probe_ok: false,
+      summary: {
+        runtimes: 1,
+        probed: 1,
+        reachable: 0,
+        failed: 1,
+        skipped: 0,
+        default_runtime_id: 'runpod_mtp.qwen',
+      },
+      providers: [
+        {
+          runtime_id: 'runpod_mtp.qwen',
+          provider_id: 'runpod_mtp',
+          status: 'network_error',
+          reachable: false,
+          credential_required: true,
+          auth_present: true,
+          error: 'connect ECONNREFUSED 127.0.0.1:3000',
+          probe_url: 'https://runpod.example/v1/models',
+        },
+      ],
+    }))
+    const { RuntimeHealthSnapshot } = await import('./runtime-health-snapshot')
+
+    render(h(RuntimeHealthSnapshot, {}), container)
+    await waitFor(
+      () => container.textContent?.includes('1 failing') ?? false,
+      'failed probe summary',
+    )
+
+    expect(container.textContent).toContain('needs attention')
+    expect(container.textContent).toContain('network_error')
+    expect(container.textContent).toContain('connect ECONNREFUSED 127.0.0.1:3000')
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain('runpod_mtp.qwen')
+  })
+
+  it('keeps provider config visible when the live probe request itself fails', async () => {
+    apiMocks.fetchDashboardRuntimeProbe.mockRejectedValueOnce(new Error('500 Internal Server Error: Eio mutex poisoned'))
+    const { RuntimeHealthSnapshot } = await import('./runtime-health-snapshot')
+
+    render(h(RuntimeHealthSnapshot, {}), container)
+    await waitFor(
+      () => container.textContent?.includes('live probe request failed') ?? false,
+      'probe request failure',
+    )
+
+    expect(container.textContent).toContain('runpod_mtp.qwen')
+    expect(container.textContent).toContain('needs attention')
+    expect(container.textContent).toContain('500 Internal Server Error: Eio mutex poisoned')
+  })
+
+  it('uses force=1 when the operator clicks Live probe', async () => {
+    const { RuntimeHealthSnapshot } = await import('./runtime-health-snapshot')
+
+    render(h(RuntimeHealthSnapshot, {}), container)
+    await waitFor(
+      () => apiMocks.fetchDashboardRuntimeProbe.mock.calls[0]?.[0] === false,
+      'initial unforced probe',
+    )
+
+    container.querySelector('button')?.click()
+    await waitFor(
+      () => apiMocks.fetchDashboardRuntimeProbe.mock.calls.length >= 2,
+      'forced refresh',
+    )
+
+    expect(apiMocks.fetchDashboardRuntimeProbe.mock.calls[0]?.[0]).toBe(false)
+    expect(apiMocks.fetchDashboardRuntimeProbe.mock.calls.at(-1)?.[0]).toBe(true)
+  })
+})

--- a/dashboard/src/components/runtime-health-snapshot.ts
+++ b/dashboard/src/components/runtime-health-snapshot.ts
@@ -1,0 +1,298 @@
+import { html } from 'htm/preact'
+import { useEffect } from 'preact/hooks'
+import {
+  fetchDashboardRuntimeProbe,
+  fetchRuntimeProviders,
+  type DashboardRuntimeProbeResponse,
+  type DashboardRuntimeProviderProbe,
+  type DashboardRuntimeProviderSnapshot,
+  type DashboardRuntimeProvidersResponse,
+} from '../api/dashboard'
+import { errorToString, MISSING_DATA_DASH } from '../lib/format-string'
+import { formatNumber } from '../lib/format-number'
+import { formatRelativeAgeMs } from '../lib/format-time'
+import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
+import { ActionButton } from './common/button'
+import { SectionCard } from './common/card'
+import { ErrorState, LoadingState } from './common/feedback-state'
+import { RouteLink } from './common/route-link'
+import { StatTile } from './common/stat-tile'
+import { StatusChip } from './common/status-chip'
+
+interface RuntimeHealthSnapshotData {
+  providers: DashboardRuntimeProvidersResponse | null
+  probe: DashboardRuntimeProbeResponse | null
+  probeError: string | null
+}
+
+async function loadSnapshot(forceProbe = false, signal?: AbortSignal): Promise<RuntimeHealthSnapshotData> {
+  const probeResult = fetchDashboardRuntimeProbe(forceProbe, { signal })
+    .then(probe => ({ probe, probeError: null }))
+    .catch(error => ({ probe: null, probeError: errorToString(error) }))
+  const [providers, probe] = await Promise.all([
+    fetchRuntimeProviders({ signal }),
+    probeResult,
+  ])
+  return {
+    providers,
+    probe: probe.probe,
+    probeError: probe.probeError,
+  }
+}
+
+function runtimeKey(provider: DashboardRuntimeProviderSnapshot): string {
+  return provider.runtime_id ?? provider.provider
+}
+
+function providerProbeMap(probe: DashboardRuntimeProbeResponse | null): Map<string, DashboardRuntimeProviderProbe> {
+  const map = new Map<string, DashboardRuntimeProviderProbe>()
+  for (const item of probe?.probe?.providers ?? []) {
+    const key = item.runtime_id ?? null
+    if (key) map.set(key, item)
+  }
+  return map
+}
+
+function configuredDefaultRuntime(providers: DashboardRuntimeProvidersResponse | null): string | null {
+  return providers?.summary?.default_runtime_id
+    ?? providers?.providers.find(provider => provider.is_default_runtime === true)?.runtime_id
+    ?? providers?.providers.find(provider => provider.is_default_runtime === true)?.provider
+    ?? null
+}
+
+function probeDefaultRuntime(probe: DashboardRuntimeProbeResponse | null): string | null {
+  return probe?.probe?.summary?.default_runtime_id
+    ?? probe?.probe?.configured_default_model
+    ?? probe?.probe?.effective_model
+    ?? null
+}
+
+function countProviderStatus(
+  providers: DashboardRuntimeProvidersResponse | null,
+  probe: DashboardRuntimeProbeResponse | null,
+) {
+  const probeItems = probe?.probe?.providers ?? []
+  const reachable = probe?.probe?.summary?.reachable
+    ?? probeItems.filter(item => item.reachable === true).length
+  const failed = probe?.probe?.summary?.failed
+    ?? probeItems.filter(item => item.reachable === false).length
+  const skipped = probe?.probe?.summary?.skipped
+    ?? probeItems.filter(item => item.status === 'skipped_cli').length
+  const missingAuth =
+    probeItems.filter(item => item.status === 'missing_auth' || item.status === 'auth_failed').length
+    + (providers?.providers ?? []).filter(provider => provider.status === 'missing_auth').length
+  return {
+    reachable,
+    failed,
+    skipped,
+    missingAuth,
+    total: providers?.summary?.runtimes ?? providers?.providers.length ?? probe?.probe?.summary?.runtimes ?? 0,
+  }
+}
+
+function snapshotStatus(counts: ReturnType<typeof countProviderStatus>, probeError: string | null): 'ok' | 'warn' | 'crit' {
+  if (probeError || counts.failed > 0 || counts.missingAuth > 0) return 'crit'
+  if (counts.skipped > 0 || counts.reachable === 0) return 'warn'
+  return 'ok'
+}
+
+function snapshotTone(status: 'ok' | 'warn' | 'crit'): 'ok' | 'warn' | 'bad' {
+  return status === 'crit' ? 'bad' : status
+}
+
+function shortUrl(value: string | null | undefined): string {
+  if (!value) return MISSING_DATA_DASH
+  if (value.length <= 52) return value
+  return `${value.slice(0, 32)}...${value.slice(-16)}`
+}
+
+function formatCheckedAt(probe: DashboardRuntimeProbeResponse | null): string {
+  const ts = probe?.probe?.checked_at ?? probe?.generated_at
+  if (!ts) return 'probe time unknown'
+  const ms = Date.parse(ts)
+  if (!Number.isFinite(ms)) return ts
+  return formatRelativeAgeMs(Date.now() - ms)
+}
+
+function firstProblem(
+  providers: DashboardRuntimeProvidersResponse | null,
+  probe: DashboardRuntimeProbeResponse | null,
+): { id: string; message: string; detail: string | null } | null {
+  const probeProblem = (probe?.probe?.providers ?? []).find(item =>
+    item.reachable === false
+    || item.status === 'missing_auth'
+    || item.status === 'auth_failed'
+    || item.status === 'network_error'
+    || item.status === 'server_error'
+  )
+  if (probeProblem) {
+    return {
+      id: probeProblem.runtime_id ?? probeProblem.provider_id ?? 'runtime',
+      message: probeProblem.status ?? 'probe failed',
+      detail: probeProblem.error ?? probeProblem.probe_url ?? probeProblem.endpoint_url ?? null,
+    }
+  }
+  const providerProblem = (providers?.providers ?? []).find(provider =>
+    provider.available === false
+    || provider.status === 'missing_auth'
+    || provider.status === 'unsupported'
+    || provider.status === 'offline'
+  )
+  if (!providerProblem) return null
+  return {
+    id: runtimeKey(providerProblem),
+    message: providerProblem.status ?? 'unavailable',
+    detail: providerProblem.note ?? providerProblem.endpoint_url ?? null,
+  }
+}
+
+function endpointRows(probe: DashboardRuntimeProbeResponse | null): Array<{ label: string; value: string | null | undefined }> {
+  return [
+    { label: 'server', value: probe?.probe?.server_url },
+    { label: 'models', value: probe?.probe?.ps_endpoint },
+    { label: 'generate', value: probe?.probe?.generate_endpoint },
+  ].filter(row => Boolean(row.value))
+}
+
+export function RuntimeHealthSnapshot() {
+  const resource = useManagedAsyncResource<RuntimeHealthSnapshotData>()
+
+  const load = (forceProbe = false) => {
+    void resource.load(signal => loadSnapshot(forceProbe, signal))
+  }
+
+  useEffect(() => {
+    load(false)
+    return () => {
+      resource.cancel()
+    }
+  }, [resource])
+
+  const state = resource.state.value
+  const data = state.data
+  const providers = data?.providers ?? null
+  const probe = data?.probe ?? null
+  const probeError = data?.probeError ?? null
+  const counts = countProviderStatus(providers, probe)
+  const status = snapshotStatus(counts, probeError)
+  const problem = firstProblem(providers, probe)
+  const providerProbes = providerProbeMap(probe)
+  const defaultRuntime = configuredDefaultRuntime(providers) ?? probeDefaultRuntime(probe)
+  const defaultProbe = defaultRuntime ? providerProbes.get(defaultRuntime) ?? null : null
+  const defaultProvider = defaultRuntime
+    ? providers?.providers.find(provider => runtimeKey(provider) === defaultRuntime) ?? null
+    : null
+  const endpoints = endpointRows(probe)
+
+  return html`
+    <${SectionCard}
+      label="런타임 상태 체크"
+      status=${status}
+      right=${html`
+        <${ActionButton}
+          variant="ghost"
+          size="sm"
+          ariaLabel="runtime live probe 강제 새로고침"
+          ariaBusy=${state.loading}
+          disabled=${state.loading}
+          onClick=${() => load(true)}
+        >
+          ${state.loading ? '확인 중' : 'Live probe'}
+        <//>
+      `}
+    >
+      ${state.loading && !data ? html`
+        <${LoadingState}>runtime 상태 확인 중...<//>
+      ` : null}
+      ${state.error ? html`<${ErrorState} message=${state.error} />` : null}
+
+      <div class="grid grid-cols-1 gap-3 md:grid-cols-4" data-testid="runtime-health-snapshot">
+        <${StatTile}
+          label="live probe"
+          value=${counts.failed > 0 ? `${counts.failed} failing` : `${counts.reachable} reachable`}
+          status=${status}
+          delta=${{
+            direction: status === 'crit' ? 'down' : status === 'ok' ? 'up' : 'flat',
+            text: `total ${formatNumber(counts.total)} · skipped ${formatNumber(counts.skipped)}`,
+          }}
+        />
+        <${StatTile}
+          label="default runtime"
+          value=${defaultRuntime ?? MISSING_DATA_DASH}
+          status=${defaultProbe?.reachable === false || defaultProvider?.available === false ? 'crit' : defaultRuntime ? 'ok' : 'warn'}
+          delta=${{
+            direction: defaultProbe?.reachable === false || defaultProvider?.available === false ? 'down' : 'flat',
+            text: defaultProbe?.status ?? defaultProvider?.status ?? 'configured',
+          }}
+        />
+        <${StatTile}
+          label="auth"
+          value=${counts.missingAuth > 0 ? `${counts.missingAuth} missing` : 'ready'}
+          status=${counts.missingAuth > 0 ? 'crit' : 'ok'}
+          delta=${{ direction: counts.missingAuth > 0 ? 'down' : 'flat', text: 'runtime credentials' }}
+        />
+        <${StatTile}
+          label="checked"
+          value=${formatCheckedAt(probe)}
+          status=${probeError ? 'crit' : probe ? 'ok' : 'warn'}
+          delta=${{ direction: probeError ? 'down' : 'flat', text: probe?.cache_hit ? 'cache hit' : 'fresh probe' }}
+        />
+      </div>
+
+      ${probeError ? html`
+        <div class="mt-3 rounded-[var(--r-1)] border border-[var(--status-bad)] bg-[var(--status-bad)]/5 px-3 py-2 text-xs text-[var(--status-bad)]" role="alert">
+          live probe request failed · ${probeError}
+        </div>
+      ` : null}
+
+      ${problem ? html`
+        <div class="mt-3 rounded-[var(--r-1)] border border-[var(--status-bad)] bg-[var(--status-bad)]/5 px-3 py-2 text-xs text-[var(--status-bad)]" role="alert">
+          <span class="font-mono">${problem.id}</span>
+          <span class="mx-1">·</span>
+          <span>${problem.message}</span>
+          ${problem.detail ? html`<div class="mt-1 truncate text-2xs" title=${problem.detail}>${problem.detail}</div>` : null}
+        </div>
+      ` : null}
+
+      ${endpoints.length > 0 ? html`
+        <div class="mt-3 grid gap-2 md:grid-cols-3" data-testid="runtime-health-endpoints">
+          ${endpoints.map(row => html`
+            <div class="min-w-0 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2">
+              <div class="text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">${row.label}</div>
+              <div class="mt-1 truncate font-mono text-2xs text-[var(--color-fg-secondary)]" title=${row.value ?? ''}>
+                ${shortUrl(row.value)}
+              </div>
+            </div>
+          `)}
+        </div>
+      ` : null}
+
+      <div class="mt-3 flex flex-wrap items-center gap-2 text-2xs">
+        <${StatusChip} tone=${snapshotTone(status)} uppercase=${false}>
+          ${status === 'crit' ? 'needs attention' : status === 'ok' ? 'runtime reachable' : 'probe incomplete'}
+        <//>
+        <${RouteLink}
+          tab="monitoring"
+          params=${{ section: 'runtime', view: 'providers' }}
+          class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-1 text-[var(--color-fg-secondary)] hover:bg-[var(--color-bg-hover)]"
+        >
+          provider details
+        <//>
+        <${RouteLink}
+          tab="monitoring"
+          params=${{ section: 'runtime', view: 'config' }}
+          class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-1 text-[var(--color-fg-secondary)] hover:bg-[var(--color-bg-hover)]"
+        >
+          runtime.toml
+        <//>
+        <${RouteLink}
+          tab="monitoring"
+          params=${{ section: 'transport-health' }}
+          class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-1 text-[var(--color-fg-secondary)] hover:bg-[var(--color-bg-hover)]"
+        >
+          transport health
+        <//>
+      </div>
+    <//>
+  `
+}

--- a/dashboard/src/components/runtime-panel.test.ts
+++ b/dashboard/src/components/runtime-panel.test.ts
@@ -18,6 +18,9 @@ async function loadRuntimePanel() {
   vi.doMock('./runtime-monitor', () => ({
     RuntimeMonitor: () => html`<div data-testid="runtime-monitor">RuntimeMonitor</div>`,
   }))
+  vi.doMock('./runtime-health-snapshot', () => ({
+    RuntimeHealthSnapshot: () => html`<div data-testid="runtime-health-snapshot">RuntimeHealthSnapshot</div>`,
+  }))
   vi.doMock('./runtime-toml-editor', () => ({
     RuntimeTomlEditor: () => html`<div data-testid="runtime-toml-editor">RuntimeTomlEditor</div>`,
   }))
@@ -62,6 +65,7 @@ describe('RuntimePanel', () => {
     vi.doUnmock('../router')
     vi.doUnmock('./oas-health-chip')
     vi.doUnmock('./runtime-monitor')
+    vi.doUnmock('./runtime-health-snapshot')
     vi.doUnmock('./runtime-toml-editor')
     vi.doUnmock('./verification-specs-panel')
     vi.doUnmock('./cost-dashboard')
@@ -69,13 +73,17 @@ describe('RuntimePanel', () => {
     vi.doUnmock('./common/route-link')
   })
 
-  it('renders runtime panels and diagnostics links by default', async () => {
+  it('renders first-screen runtime snapshot and diagnostics links by default', async () => {
     route.value.params = {}
     const { RuntimePanel } = await loadRuntimePanel()
     render(html`<${RuntimePanel} />`, container)
     await flushUi()
 
     expect(container.textContent).toContain('OasHealthChip')
+    expect(container.textContent).toContain('RuntimeHealthSnapshot')
+    expect(container.textContent?.indexOf('RuntimeHealthSnapshot')).toBeLessThan(
+      container.textContent?.indexOf('OasHealthChip') ?? Number.POSITIVE_INFINITY,
+    )
     const routeLinks = Array.from(container.querySelectorAll('[data-testid="route-link"]'))
       .map(link => link.getAttribute('data-section'))
     expect(routeLinks).toEqual([
@@ -85,7 +93,7 @@ describe('RuntimePanel', () => {
     expect(container.textContent).toContain('Diagnostics')
     expect(container.textContent).toContain('Transport diagnostics')
     expect(container.textContent).toContain('Feature cleanup')
-    expect(container.textContent).toContain('RuntimeMonitor')
+    expect(container.textContent).not.toContain('RuntimeMonitor')
     expect(container.textContent).toContain('VerificationSpecsPanel')
   })
 
@@ -109,6 +117,8 @@ describe('RuntimePanel', () => {
       expect(el?.tagName.toLowerCase()).toBe('details')
       expect((el as HTMLDetailsElement).open).toBe(false)
     }
+    expect(container.textContent).toContain('RuntimeHealthSnapshot')
+    expect(container.textContent).not.toContain('RuntimeMonitor')
   })
 
   it('explicit drill-down views bypass progressive disclosure', async () => {
@@ -122,12 +132,13 @@ describe('RuntimePanel', () => {
     expect(specs?.closest('details')).toBeNull()
   })
 
-  it('renders only OasHealthChip and RuntimeMonitor for providers view', async () => {
+  it('renders snapshot, OasHealthChip, and RuntimeMonitor for providers view', async () => {
     route.value.params = { view: 'providers' }
     const { RuntimePanel } = await loadRuntimePanel()
     render(html`<${RuntimePanel} />`, container)
     await flushUi()
 
+    expect(container.textContent).toContain('RuntimeHealthSnapshot')
     expect(container.textContent).toContain('OasHealthChip')
     expect(container.textContent).toContain('RuntimeMonitor')
   })
@@ -139,6 +150,7 @@ describe('RuntimePanel', () => {
     await flushUi()
 
     expect(container.textContent).toContain('RuntimeTomlEditor')
+    expect(container.textContent).not.toContain('RuntimeHealthSnapshot')
     expect(container.textContent).not.toContain('OasHealthChip')
     expect(container.textContent).not.toContain('RuntimeMonitor')
   })
@@ -183,7 +195,8 @@ describe('RuntimePanel', () => {
     await flushUi()
 
     expect(container.textContent).toContain('OasHealthChip')
-    expect(container.textContent).toContain('RuntimeMonitor')
+    expect(container.textContent).toContain('RuntimeHealthSnapshot')
+    expect(container.textContent).not.toContain('RuntimeMonitor')
   })
 
   it('passes current view value to FilterChips', async () => {

--- a/dashboard/src/components/runtime-panel.ts
+++ b/dashboard/src/components/runtime-panel.ts
@@ -4,7 +4,7 @@
 // TelemetryPanel (cost / audit / stress).
 //
 // Progressive-disclosure default view (density reduction, 2026-04):
-//   Signal layer     — OasHealthChip always expanded (summary StatCells)
+//   Signal layer     — RuntimeHealthSnapshot first, OasHealthChip below
 //   Diagnostic layer — Runtime lanes via CollapsibleSection (closed)
 //   Raw layer        — Formal specs via CollapsibleSection (closed)
 // NN/g progressive disclosure: respect working-memory limits, defer detail.
@@ -29,6 +29,7 @@ import { replaceRoute, route } from '../router'
 import { FilterChips } from './common/filter-chips'
 import { CollapsibleSection } from './common/collapsible'
 import { OasHealthChip } from './oas-health-chip'
+import { RuntimeHealthSnapshot } from './runtime-health-snapshot'
 import { RuntimeMonitor } from './runtime-monitor'
 import { RuntimeTomlEditor } from './runtime-toml-editor'
 import { VerificationSpecsPanel } from './verification-specs-panel'
@@ -160,6 +161,7 @@ export function RuntimePanel() {
       <div class="grid gap-4">
         ${view === 'providers'
           ? html`
+            <${RuntimeHealthSnapshot} />
             <${OasHealthChip} />
             <${RuntimeMonitor} />
           `
@@ -170,9 +172,14 @@ export function RuntimePanel() {
         : view === 'verification'
           ? html`<${VerificationSpecsPanel} />`
         : html`
+            <${RuntimeHealthSnapshot} />
             <${OasHealthChip} />
             <${HiddenDiagnosticsLinks} />
-            <${CollapsibleSection} id="runtime-details-providers" title="런타임">
+            <${CollapsibleSection}
+              id="runtime-details-providers"
+              title="런타임 상세"
+              mountWhenOpen=${true}
+            >
               <${RuntimeMonitor} />
             <//>
             <${CollapsibleSection} id="runtime-details-verification" title="형식검증">


### PR DESCRIPTION
## Summary
- add a first-screen RuntimeHealthSnapshot using runtime provider config plus live runtime probe data
- show default runtime, reachability, auth, checked time, endpoint links, and probe failures without opening the full RuntimeMonitor
- keep the detailed RuntimeMonitor mounted only after the runtime details accordion opens on the default view

## Verification
- pnpm exec vitest run --config vitest.config.ts src/components/runtime-health-snapshot.test.ts src/components/runtime-panel.test.ts --no-file-parallelism --maxWorkers=1
- pnpm exec tsc --noEmit --pretty false
- pnpm run lint
- pnpm run build
- Playwright screenshots: /tmp/masc-runtime-snapshot-desktop-3.png, /tmp/masc-runtime-snapshot-mobile-3.png