### PR TITLE
docs(masc): clarify OAS body timeout scope

### DIFF
--- a/docs/rfc/RFC-0129-http-idle-timeout-and-streaming-progress.md
+++ b/docs/rfc/RFC-0129-http-idle-timeout-and-streaming-progress.md
@@ -149,8 +149,8 @@ A single, narrow change scope:
 2. **Update** the stale comment block to reflect the cap chain that
    now exists end-to-end.
 3. **Keep** the streaming-progress wiring: `with_stream_idle_timeout`
-   continues to bound inter-line silence; OAS `body_timeout_s` remains
-   opt-in for explicit non-streaming body ceilings.
+   continues to bound inter-line silence; OAS `body_timeout_s` is
+   sync-only and remains opt-in for explicit non-streaming body ceilings.
 
 Two related-but-non-gating tracks are explicitly separated below
 (§4.2, §4.3) so they cannot stall the fleet fix.
@@ -263,8 +263,10 @@ Expected:
 - Self-admitting comment at
   `lib/keeper/keeper_turn_runtime_budget.ml:173-174` (replaced by
   PR-2).
-- OAS `body_timeout_s` since 0.195.0, `complete.ml:656-686`.
-- OAS streaming `idle_timeout` at `http_client.mli:204-243`.
+- OAS `body_timeout_s` on the non-streaming `Complete.complete` path since
+  0.195.0, `complete.ml:656-686`.
+- OAS streaming `idle_timeout` at `http_client.mli:204-243`; streaming has
+  no total body-duration cap.
 - masc `stream_idle_timeout_s` wiring at
   `runtime_agent_context.ml:174-180`.
 

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -129,7 +129,7 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_AUTONOMOUS_QUEUE_POLL_SEC` | typed:float | unclassified | unclassified | 172 | Autonomous-turn semaphore queue poll interval in seconds. Polled inside the autonomous-turn admission loop in {!Keepe... |
 | `MASC_KEEPER_AUTONOMOUS_SLOT_WAIT_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 388 | Maximum time a scheduled autonomous keeper will wait for the local keeper turn gate before skipping the cycle. Reacti... |
 | `MASC_KEEPER_BOARD_DEBOUNCE_SEC` | typed:float | unclassified | unclassified | 286 | Board-reactive wakeup debounce in seconds. Prevents rapid repeated wakeups from the same board post. Default: 60.0. R... |
-| `MASC_KEEPER_BODY_TIMEOUT_SEC` | string_literal | n/a | n/a | 488 | Total HTTP body-consumption deadline for one OAS streaming call. Wraps the body callback in [Eio.Time.with_timeout_ex... |
+| `MASC_KEEPER_BODY_TIMEOUT_SEC` | string_literal | n/a | n/a | 488 | Total HTTP body-consumption deadline for non-streaming OAS completion calls. Streaming paths ignore this knob and rely... |
 | `MASC_KEEPER_BOOTSTRAP_ENABLED` | feature_flag | n/a | n/a | 20 | Enable startup keeper bootstrap scan |
 | `MASC_KEEPER_BOOTSTRAP_LAZY_STARTUP_POLL_INTERVAL_SEC` | typed:float | unclassified | unclassified | 46 | Polling interval (seconds) for the lazy-startup wait loop in [server_bootstrap_loops.ml]. The autoboot fiber wakes up... |
 | `MASC_KEEPER_BOOTSTRAP_LISTENER_RETRY_INTERVAL_SEC` | typed:float | unclassified | unclassified | 58 | Polling interval (seconds) for the keeper-lifecycle listener retry loop in [server_bootstrap_loops.ml]. After a liste... |

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -469,18 +469,15 @@ module KeeperKeepalive = struct
       (Float.min 600.0 (get_float ~default:120.0 "MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC"))
   ;;
 
-  (** Total HTTP body-consumption deadline for one OAS streaming call.
-      Wraps the body callback in [Eio.Time.with_timeout_exn] in agent_sdk;
-      on expiry [Retry.Timeout] surfaces and runtime falls forward to the
-      next provider at the attempt boundary. Complements
-      [stream_idle_timeout_sec] (which only caps inter-line silence):
-      this catches the case where a single bulk read hangs without
-      producing line breaks.
+  (** Total HTTP body-consumption deadline for non-streaming OAS completion
+      calls. In agent_sdk this wraps [Complete.complete]'s synchronous HTTP
+      body read; streaming calls deliberately ignore the knob so active
+      long streams are not killed by total duration. Streaming liveness is
+      handled by [stream_idle_timeout_sec] and the attempt liveness observer.
 
       Opt-in: unset env leaves [None] so {!Runtime_agent_context} skips
-      the builder wiring. Set to a value strictly less than the effective
-      OAS attempt cap for attempt-level fall-forward; set
-      [<= stream_idle_timeout_sec] for a strict overall cap.
+      the builder wiring. Set only for sync completion callers that need a
+      body-read ceiling before the outer turn cap.
 
       Env: [MASC_KEEPER_BODY_TIMEOUT_SEC]. Default: unset → [None].
       Range when set: [10, 600]. *)

--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -131,12 +131,11 @@ module KeeperKeepalive : sig
   val stream_idle_timeout_sec : float
 
   val body_timeout_sec_override : float option
-  (** Total HTTP body-consumption deadline for one OAS streaming call.
-      [None] (env unset) leaves the runtime builder wire untouched.
-      [Some s] forwards to [Builder.with_body_timeout]; on expiry
-      [Retry.Timeout] surfaces at the attempt boundary so runtime falls
-      forward to the next provider. Complements {!stream_idle_timeout_sec}
-      (inter-line silence cap) and [max_execution_time_s] (turn-total cap).
+  (** Total HTTP body-consumption deadline for non-streaming OAS completion
+      calls. [None] (env unset) leaves the runtime builder wire untouched.
+      [Some s] forwards to [Builder.with_body_timeout] for sync completion
+      paths. Streaming paths ignore it and rely on {!stream_idle_timeout_sec}
+      plus attempt liveness observation.
 
       Env: [MASC_KEEPER_BODY_TIMEOUT_SEC]. Clamp range: [10, 600] s. *)
 

--- a/lib/keeper/keeper_runtime_resolved.ml
+++ b/lib/keeper/keeper_runtime_resolved.ml
@@ -120,8 +120,9 @@ let oas_timeout_override_sec_live ~turn_timeout_sec =
 (* SSOT: Env_config_keeper.KeeperKeepalive.body_timeout_sec_override
    (same env var, same clamp [10, 600]). Mirrors the
    [oas_timeout_override_sec_live] / [stream_idle_timeout_sec_live]
-   idiom: read raw env, clamp, return option. Opt-in: unset → None
-   → runtime falls back to the per-attempt max_execution_time. *)
+   idiom: read raw env, clamp, return option. Opt-in: unset → None.
+   OAS applies this only to non-streaming sync body reads; streaming
+   liveness is progress-based. *)
 let body_timeout_override_sec_live () =
   match Env_config_core.raw_value_opt "MASC_KEEPER_BODY_TIMEOUT_SEC" with
   | Some raw ->

--- a/lib/keeper/keeper_runtime_resolved.mli
+++ b/lib/keeper/keeper_runtime_resolved.mli
@@ -53,12 +53,11 @@ val admission_wait_timeout_sec : unit -> float
 val stream_idle_timeout_sec : unit -> float
 val stream_idle_timeout_for_total_timeout : total_timeout_s:float -> float
 
-(** Total HTTP body-consumption deadline override.
-    [None] (env unset) lets the runtime attempt fall back to the per-
-    attempt [max_execution_time]. [Some s] is forwarded to
-    [Runtime_agent_context.body_timeout_s] -> [Builder.with_body_timeout],
-    surfacing [Retry.Timeout] before the turn cap so runtime falls
-    forward at the attempt boundary.
+(** Non-streaming HTTP body-consumption deadline override.
+    [None] (env unset) skips [Builder.with_body_timeout]. [Some s] is
+    forwarded through [Runtime_agent_context.body_timeout_s] for OAS sync
+    completion paths. Streaming paths ignore this knob and rely on
+    [stream_idle_timeout_sec] plus the attempt liveness observer.
 
     SSOT: {!Env_config_keeper.KeeperKeepalive.body_timeout_sec_override}. *)
 val body_timeout_override_sec : unit -> float option

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -258,10 +258,11 @@ let run_try_provider
               max_execution_time_for_attempt ?per_provider_timeout_s ()
           ; body_timeout_s =
               (* SSOT: Keeper_runtime_resolved.body_timeout_override_sec
-                 (driven by MASC_KEEPER_BODY_TIMEOUT_SEC). When unset, do not
-                 inherit [per_provider_timeout_s]: a cumulative body deadline
-                 is another mid-stream killer for healthy reasoning bursts.
-                 Stall detection is handled by [stream_idle_timeout_s]. *)
+                 (driven by MASC_KEEPER_BODY_TIMEOUT_SEC). OAS applies this
+                 only to non-streaming sync body reads; streaming attempts
+                 deliberately rely on [stream_idle_timeout_s] plus liveness
+                 observation so healthy reasoning bursts are not killed by
+                 total duration. *)
               body_timeout_for_attempt ?per_provider_timeout_s ()
           ; temperature = ctx.temperature
           ; max_idle_turns = ctx.max_idle_turns

--- a/lib/runtime/runtime_agent_context.ml
+++ b/lib/runtime/runtime_agent_context.ml
@@ -39,10 +39,11 @@ type config =
           Default [None] preserves the historical behaviour
           (block indefinitely on stream-parser hang). *)
   ; body_timeout_s : float option
-    (** Total HTTP streaming body-consumption ceiling. This is forwarded to
-        OAS's [with_body_timeout] and complements [stream_idle_timeout_s]:
-        idle timeout catches inter-line silence, while body timeout bounds
-        the whole response body callback. Non-HTTP transports ignore it. *)
+    (** Total HTTP body-consumption ceiling for non-streaming OAS completion
+        paths. Streaming paths deliberately ignore this knob so active long
+        streams are not killed by total duration; streaming liveness is
+        owned by [stream_idle_timeout_s] plus attempt observation. Non-HTTP
+        transports ignore it. *)
   ; max_tokens : int
   ; max_input_tokens : int option
   ; max_cost_usd : float option

--- a/lib/runtime/runtime_agent_context.mli
+++ b/lib/runtime/runtime_agent_context.mli
@@ -45,11 +45,12 @@ type config = {
           [Retry.Timeout] after [s] seconds. Default [None] preserves
           historical block-on-hang behaviour. *)
   body_timeout_s : float option;
-      (** Total HTTP streaming body-consumption ceiling forwarded to
-          OAS [Builder.with_body_timeout]. Complements
-          [stream_idle_timeout_s]: idle timeout catches inter-line
-          silence, body timeout bounds the whole body callback.
-          Non-HTTP transports ignore it. *)
+      (** Total HTTP body-consumption ceiling forwarded to OAS
+          [Builder.with_body_timeout] for non-streaming completion paths.
+          Streaming paths deliberately ignore this knob so active long
+          streams are not killed by total duration; streaming liveness is
+          owned by [stream_idle_timeout_s] and the attempt liveness
+          observer. Non-HTTP transports ignore it. *)
   max_tokens : int;
   max_input_tokens : int option;
   max_cost_usd : float option;


### PR DESCRIPTION
## Summary
- Update runtime comments and docs so `MASC_KEEPER_BODY_TIMEOUT_SEC` is sync-only OAS body timeout.
- Clarify streaming uses `stream_idle_timeout_s` and the liveness observer, not total body duration.

## Verification
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_BUILD_DIR=_build-codex-stream-timeout-docs scripts/dune-local.sh build lib/masc.cmxa`
- `git diff --check`