### PR TITLE
fix(keeper): avoid invalid path recovery hints

### DIFF
--- a/lib/keeper/keeper_failure_circuit_breaker.ml
+++ b/lib/keeper/keeper_failure_circuit_breaker.ml
@@ -224,10 +224,10 @@ and corrective_hint cls keeper_name =
     | Path_not_found ->
       Printf.sprintf
         "- The file you are looking for does NOT exist. Do NOT guess paths.\n\
-         - Use Execute executable='ls' argv=['.'] on your playground root first to see what actually exists, or use a visible file-listing tool if one is present.\n\
+         - Inspect visible paths with the currently exposed read/listing tools before retrying.\n\
          - Your playground: .masc/playground/%s/\n\
          - Your repos: .masc/playground/%s/repos/ (clone a repo first if empty)\n\
-         - NEVER fabricate file paths like lib/ocaml/... — check with ls first."
+         - NEVER fabricate file paths like lib/ocaml/... — confirm the path exists first."
         keeper_name keeper_name
     | Path_not_allowed ->
       Printf.sprintf
@@ -237,7 +237,7 @@ and corrective_hint cls keeper_name =
          - Run `keeper_context_status` to see your allowed paths."
         keeper_name
     | Cwd_not_directory ->
-      "- The cwd you specified is not a directory. Use Execute executable='ls' argv=['.'] to find valid directories, or use a visible file-listing tool if one is present.\n\
+      "- The cwd you specified is not a directory. Inspect visible paths with the currently exposed read/listing tools before retrying.\n\
        - Leave the cwd parameter empty to use your default playground root."
     | Shell_exit_nonzero ->
       "- Your shell command is failing repeatedly. Check the command syntax.\n\

--- a/lib/keeper/keeper_runtime_contract.ml
+++ b/lib/keeper/keeper_runtime_contract.ml
@@ -160,9 +160,9 @@ let path_resolution_contract_json =
            Execute cwd implicitly." )
     ; ( "discover_before_read"
       , `String
-          "When unsure, use Grep or Execute ls to discover concrete paths before Read. \
-           For repo files, use cwd=\"repos/<repo>\" plus file_path=\"lib/...\", or use \
-           file_path=\"repos/<repo>/lib/...\"."
+          "When unsure, inspect visible paths with the currently exposed read/listing \
+           tools before Read. For repo files, use cwd=\"repos/<repo>\" plus \
+           file_path=\"lib/...\", or use file_path=\"repos/<repo>/lib/...\"."
       )
     ]
 

--- a/lib/keeper/keeper_sandbox_read_backend.ml
+++ b/lib/keeper/keeper_sandbox_read_backend.ml
@@ -212,8 +212,8 @@ let read_file ?turn_sandbox_factory ~config ~(meta : keeper_meta) ~host_path
       Error
         (Printf.sprintf
            "docker_cat_failed: path_is_directory: %s (Read requires a file, \
-            not a directory; use Execute executable='ls' argv=['<path>'] or a visible file-listing \
-            tool for directory listings)"
+            not a directory; use the currently exposed read/listing tools for directory \
+            listings)"
            host_path)
     else
       run_command ?turn_sandbox_factory ~config ~meta

--- a/lib/keeper/keeper_tool_shared_runtime.ml
+++ b/lib/keeper/keeper_tool_shared_runtime.ml
@@ -60,8 +60,9 @@ let actionable_path_action_for_class
     match cls with
     | Path_not_found ->
       Printf.sprintf
-        "File does not exist. Use Execute executable='ls' argv=['%s'] first to see available \
-         files, or use a visible file-listing tool if one is present."
+        "File does not exist under %s. Inspect visible paths with the currently \
+         exposed read/listing tools before retrying. Use keeper task/context tools \
+         for .masc state."
         playground
     | Path_not_allowed ->
       Printf.sprintf
@@ -137,43 +138,24 @@ let missing_file_recovery_examples ~(raw_path : string option) ~(repo_hint : str
   | None -> `Assoc []
   | Some raw ->
     let parent = dirname_opt raw |> Option.value ~default:"." in
-    let grep_filename =
-      Filename.basename raw
-      |> fun name ->
-      let path =
-        match split_repo_relative raw, repo_hint with
-        | Some _, _ | _, None -> parent
-        | None, Some repo -> Filename.concat ("repos/" ^ repo) parent
-      in
-      `Assoc [ "tool", `String "Grep"; "pattern", `String name; "path", `String path ]
-    in
-    let list_parent =
+    let parent_path_hint =
       match split_repo_relative raw with
       | Some (repo, rel) ->
         let repo_parent = dirname_opt rel |> Option.value ~default:"." in
-        `Assoc
-          [ "tool", `String "Execute"
-          ; "cwd", `String ("repos/" ^ repo)
-          ; "executable", `String "ls"
-          ; "argv", `List [ `String repo_parent ]
-          ]
+        Filename.concat ("repos/" ^ repo) repo_parent
       | None ->
         (match repo_hint with
-         | Some repo ->
-           `Assoc
-             [ "tool", `String "Execute"
-             ; "cwd", `String ("repos/" ^ repo)
-             ; "executable", `String "ls"
-             ; "argv", `List [ `String parent ]
-             ]
-         | None ->
-           `Assoc
-             [ "tool", `String "Execute"
-             ; "executable", `String "ls"
-             ; "argv", `List [ `String parent ]
-             ])
+         | Some repo -> Filename.concat ("repos/" ^ repo) parent
+         | None -> parent)
     in
-    `Assoc [ "grep_filename", grep_filename; "list_parent", list_parent ]
+    `Assoc
+      [ "basename_hint", `String (Filename.basename raw)
+      ; "parent_path_hint", `String parent_path_hint
+      ; ( "instruction"
+        , `String
+            "Use the currently exposed read/listing tools and their visible schema to \
+             confirm this parent path before retrying." )
+      ]
 ;;
 
 let visible_repo_hint = function
@@ -228,15 +210,16 @@ let missing_file_error_json
     | Some path, Some repo when Option.is_none (split_repo_relative path) ->
       Printf.sprintf
         "A single sandbox repo is available. Retry with cwd=\"repos/%s\" and \
-         file_path=%S, or use file_path=%S. Use Grep or Execute ls first when \
-         the exact path is unclear."
+         file_path=%S, or use file_path=%S. Inspect visible paths with the \
+         currently exposed read/listing tools first when the exact path is unclear."
         repo
         path
         (Filename.concat ("repos/" ^ repo) path)
     | _ ->
       "For repo-relative files, pass cwd=\"repos/<repo>\" with \
        file_path=\"lib/...\", or pass file_path=\"repos/<repo>/lib/...\". \
-       Use Grep or Execute ls first when the exact path is unclear."
+       Inspect visible paths with the currently exposed read/listing tools first \
+       when the exact path is unclear."
   in
   Yojson.Safe.to_string
     (`Assoc
@@ -264,8 +247,8 @@ let missing_file_error_json
               ; "next_action", `String next_action
               ; ( "retry_policy"
                 , `String
-                    "Do not retry Read with the same file_path until Grep or Execute ls \
-                     confirms the file exists." )
+                    "Do not retry Read with the same file_path until a visible \
+                     read/listing tool confirms the file exists." )
               ; "recovery_examples", missing_file_recovery_examples ~raw_path ~repo_hint
               ] )
         ])

--- a/test/test_actionable_path_action.ml
+++ b/test/test_actionable_path_action.ml
@@ -19,10 +19,20 @@ let test_path_not_found () =
     actionable_path_action_for_class
       ~playground:pg ~raw_path:"missing.ml" CB.Path_not_found
   in
-  Alcotest.(check bool) "mentions ls hint" true
+  Alcotest.(check bool) "mentions visible path inspection" true
     (try
-       Str.search_forward (Str.regexp_string "Execute executable='ls'") action 0
-       >= 0
+       ignore (Str.search_forward (Str.regexp_string "Inspect visible paths") action 0);
+       true
+     with Not_found -> false);
+  Alcotest.(check bool) "does not mention Execute" false
+    (try
+       ignore (Str.search_forward (Str.regexp_string "Execute") action 0);
+       true
+     with Not_found -> false);
+  Alcotest.(check bool) "does not invent Grep op syntax" false
+    (try
+       ignore (Str.search_forward (Str.regexp_string "Grep op=") action 0);
+       true
      with Not_found -> false);
   Alcotest.(check bool) "mentions playground" true
     (try

--- a/test/test_circuit_breaker.ml
+++ b/test/test_circuit_breaker.ml
@@ -1,6 +1,7 @@
 open Alcotest
 
 module CB = Masc.Keeper_failure_circuit_breaker
+module KSR = Masc.Keeper_tool_shared_runtime
 module KAP = Masc.Keeper_alerting_path
 module PCE = Keeper_path_check_error
 
@@ -76,8 +77,24 @@ let test_hint_at_threshold () =
   let r3 = CB.maybe_enrich_error ~keeper_name:"t2" ~error_msg:(path_not_found_msg "/c") in
   check bool "3rd: HAS hint" true (contains r3 "CIRCUIT BREAKER");
   check bool "mentions playground" true (contains r3 "playground");
-  check bool "mentions typed public Execute ls" true
-    (contains r3 "Execute executable='ls' argv=['.']")
+  check bool "mentions visible path inspection" true
+    (contains r3 "Inspect visible paths");
+  check bool "does not mention Execute" false (contains r3 "Execute");
+  check bool "does not invent Grep op syntax" false (contains r3 "Grep op=")
+
+let test_actionable_path_not_found_hint () =
+  let action =
+    KSR.actionable_path_action_for_class
+      ~playground:".masc/playground/taskmaster/"
+      ~raw_path:"repos/masc/.worktrees/task-676/lib"
+      CB.Path_not_found
+  in
+  check bool "mentions visible path inspection" true
+    (contains action "Inspect visible paths");
+  check bool "mentions task/context tools for .masc" true
+    (contains action "keeper task/context tools");
+  check bool "does not mention Execute" false (contains action "Execute");
+  check bool "does not invent Grep op syntax" false (contains action "Grep op=")
 
 let test_reset_on_success () =
   CB.record_success ~keeper_name:"t3";
@@ -406,6 +423,8 @@ let () =
     "threshold", [
       test_case "no hint under threshold" `Quick test_no_hint_under_threshold;
       test_case "hint at threshold" `Quick test_hint_at_threshold;
+      test_case "actionable path hint uses visible listing"
+        `Quick test_actionable_path_not_found_hint;
       test_case "reset on success" `Quick test_reset_on_success;
       test_case "class change resets" `Quick test_class_change_resets;
     ];

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -406,17 +406,15 @@ let test_execute_with_outcome_missing_file_is_failure () =
         (contains_substring
            Yojson.Safe.Util.(member "retry_policy" path_resolution |> to_string)
            "Do not retry Read");
-      check string "list recovery cwd" "repos/masc-mcp"
+      check string "recovery parent path" "repos/masc-mcp/config"
         Yojson.Safe.Util.(
           member "recovery_examples" path_resolution
-          |> member "list_parent"
-          |> member "cwd"
+          |> member "parent_path_hint"
           |> to_string);
-      check string "grep recovery example" "Grep"
+      check string "recovery basename hint" "tool_policy.toml"
         Yojson.Safe.Util.(
           member "recovery_examples" path_resolution
-          |> member "grep_filename"
-          |> member "tool"
+          |> member "basename_hint"
           |> to_string))
 
 let test_execute_with_outcome_bad_query_is_failure () =


### PR DESCRIPTION
## Summary
- replace path recovery hints that suggested blocked or invalid listing calls with schema-neutral visible-path guidance
- remove tool-shaped Execute/Grep recovery examples from missing-file payloads
- keep task-state recovery pointed at keeper task/context tools instead of .masc filesystem probes

## Verification
- env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-path-hints dune build --root . @test/runtest-test_circuit_breaker --display=quiet -j 2
- env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-path-hints dune build --root . @test/runtest-test_keeper_tool_dispatch_runtime --display=quiet -j 2

## Notes
The live failure was a stale path under repos/masc/.worktrees/task-676, but the recovery hint compounded it by steering the keeper toward invalid or blocked path-discovery syntax. This PR keeps the sandbox rejection intact and fixes the hint surface.