### PR TITLE
fix(keeper): exempt git diagnostics from readonly write gate

### DIFF
--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -77,6 +77,7 @@ File operations:
 - List directory contents: one scoped Execute `ls` typed argv call when Execute is visible.
 - Git history: Execute `executable="git" argv=["log","--oneline","-10"]` with cwd inside the target repo.
 - Git status: Execute `executable="git" argv=["status","--short"]` with cwd inside the target repo.
+- Read-only branch/worktree inspection: use `git status --short --branch`, `git branch --show-current`, or `git worktree list`. Never run `git checkout main`, `git switch main`, `git add`, `git commit`, `git push`, or `git worktree add` unless the active schema explicitly exposes write-capable Execute and the task is assigned code work.
 - Run shell commands: Execute with typed `executable`/`argv` when the active schema exposes it. ONE command per call unless using explicit `pipeline: [{ executable, argv }, ...]`. For code/PR work and repo-hosting CLIs, set cwd to `repos/REPO_NAME/.worktrees/TASK_NAME`; never run from sandbox root when more than one clone exists. Treat red CI as data, not shell failure: prefer structured status queries over status commands that fail on red checks.
 - Execute returns stdout/stderr automatically. Do not pass `stdout` or `stderr` objects unless you explicitly want to discard output.
 - Write or create a file: Edit/Write when the active schema exposes them. Writable scope: your sandbox only.

--- a/config/prompts/keeper.unified.system.md
+++ b/config/prompts/keeper.unified.system.md
@@ -56,6 +56,7 @@ Your shell starts at the sandbox root, which is **not** a git repository.
   - Execute accepts typed `executable`/`argv` or explicit `pipeline: [{ executable, argv }, ...]`; do not prepend `cd repos/REPO_NAME && ...`; use `cwd` instead.
 - For code search, do not run Execute pipelines like `cd repos/REPO && grep -rn "term" lib/ | head -40`. Use `Grep { pattern: "term", path: "lib", glob: "*.ml" }` when Grep is visible, or one scoped typed Execute argv call.
 - Do not scan all clones from Execute. Replace `rg term repos/` with `Grep { pattern: "term", path: "repos/REPO_NAME/.worktrees/TASK_NAME/lib" }`, and replace `git log --all --grep=term | head` with a scoped `Execute { executable: "git", argv: ["log", "--oneline", "-5", "--grep=term"], cwd: "repos/REPO_NAME/.worktrees/TASK_NAME" }`.
+- Read-only Execute cannot change repo state. For branch checks, use `git status --short --branch`, `git branch --show-current`, or `git worktree list`; do not run `git checkout main` or `git switch main` as a probe.
 - Do not use shell existence tests or shell control flow such as `ls path 2>/dev/null && echo EXISTS || echo NOT_FOUND`. Use `Read`, `Grep`, or one typed `Execute` argv call and let the tool error explain missing paths.
 - Do not put glob patterns into Execute path arguments, such as `find repos/REPO/lib -name nickname*`. Use Grep so the structured tool owns the pattern.
 - Do not add `stdout` or `stderr` objects to Execute just to capture output. Tool output is returned automatically. Only use typed discard fields when you explicitly want output dropped.

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -588,7 +588,11 @@ let handle_tool_execute_typed
           || Masc_exec.Shell_ir_risk.is_r1 envelope
           || Masc_exec.Shell_ir_risk.is_r2 envelope
         in
-        if (not write_enabled) && readonly_write_like && not is_direct_repo_git_recovery
+        if
+          (not write_enabled)
+          && readonly_write_like
+          && not is_git_diagnostic_command
+          && not is_direct_repo_git_recovery
         then
           blocked_result
             ~deterministic_reason:Keeper_tool_deterministic_error.Write_operation_gated

--- a/test/test_keeper_tool_execute_safety.ml
+++ b/test/test_keeper_tool_execute_safety.ml
@@ -942,6 +942,35 @@ let test_tool_execute_allows_preserved_direct_repo_git_status () =
   Alcotest.(check bool) "stale gate did not block diagnostic" false
     (String_util.contains_substring raw "sandbox_repo_stale")
 
+let test_tool_execute_allows_preserved_direct_repo_git_worktree_list () =
+  with_eio_fs @@ fun () ->
+  let base_path, config, meta, _repo_dir =
+    setup_preserved_sandbox_repo ~keeper_name:"stale-direct-git-worktree-list"
+  in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  Keeper_registry.clear ();
+  let raw =
+    Keeper_tool_command_runtime.handle_tool_execute
+      ~turn_sandbox_factory:None
+      ~exec_cache:None
+      ~config
+      ~meta
+      ~args:
+        (`Assoc
+           [ "executable", `String "git"
+           ; "argv", `List [ `String "worktree"; `String "list" ]
+           ; "cwd", `String "repos/masc"
+           ])
+      ()
+  in
+  let json = Yojson.Safe.from_string raw in
+  Alcotest.(check bool) "diagnostic git worktree list succeeds" true
+    (json |> Json.member "ok" |> Json.to_bool);
+  Alcotest.(check bool) "write gate did not block diagnostic" false
+    (String_util.contains_substring raw "write_operation_gated");
+  Alcotest.(check bool) "stale gate did not block diagnostic" false
+    (String_util.contains_substring raw "sandbox_repo_stale")
+
 let test_tool_execute_allows_preserved_direct_repo_git_checkout_head_restore () =
   with_eio_fs @@ fun () ->
   let base_path, config, meta, repo_dir =
@@ -2259,6 +2288,10 @@ let () =
             "preserved direct repo root allows git status"
             `Quick
             test_tool_execute_allows_preserved_direct_repo_git_status
+        ; Alcotest.test_case
+            "preserved direct repo root allows git worktree list"
+            `Quick
+            test_tool_execute_allows_preserved_direct_repo_git_worktree_list
         ; Alcotest.test_case
             "preserved direct repo root allows git checkout HEAD restore"
             `Quick


### PR DESCRIPTION
## Summary
- Exempt Shell IR git diagnostic commands from the readonly write-operation gate after risk classification.
- Add a regression test for typed `git worktree list` in preserved direct repo roots.
- Clarify keeper prompts to use read-only branch/worktree inspection instead of `git checkout main` probes.

## Tests
- `ocamlformat --check lib/keeper/keeper_tool_execute_runtime.ml test/test_keeper_tool_execute_safety.ml`
- `git diff --check origin/main`
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_readonly_gate dune exec --root . --display=short -j 1 test/test_keeper_tool_execute_safety.exe` (66 tests)

Note: `git checkout main` remains blocked in read-only Execute; this PR fixes false-positive blocking for diagnostic git commands.