### PR TITLE
fix(keeper): let OAS stream liveness own attempts

### DIFF
--- a/lib/keeper/keeper_turn_runtime_budget.ml
+++ b/lib/keeper/keeper_turn_runtime_budget.ml
@@ -239,6 +239,25 @@ let attempt_watchdog_timeout_sec
   in
   Float.max floor (Float.min desired cap_before_outer_timeout)
 
+let attempt_watchdog_timeout_sec_opt
+    ~(liveness_mode : Keeper_attempt_liveness_config.mode)
+    ~(remaining_turn_budget_s : float)
+    (provider_timeout_budget : provider_timeout_budget) : float option =
+  let legacy_watchdog_s =
+    attempt_watchdog_timeout_sec ~remaining_turn_budget_s provider_timeout_budget
+  in
+  let observer_attached =
+    match liveness_mode with
+    | Keeper_attempt_liveness_config.Off -> false
+    | Keeper_attempt_liveness_config.Observe
+    | Keeper_attempt_liveness_config.Enforce -> true
+  in
+  Keeper_attempt_liveness_config.outer_wall_for_attempt
+    ~mode:liveness_mode
+    ~observer_attached
+    ~per_provider_timeout_s:(Some legacy_watchdog_s)
+    ~candidate_key:Keeper_attempt_liveness_config.runtime_candidate_key
+
 type degraded_retry_budget_decision =
   | No_degraded_retry
   | Degraded_retry_slot_phase_exhausted of EC.degraded_retry

--- a/lib/keeper/keeper_turn_runtime_budget.mli
+++ b/lib/keeper/keeper_turn_runtime_budget.mli
@@ -164,6 +164,18 @@ val attempt_watchdog_timeout_sec :
     rotation can still run, instead of falling through to terminal
     [turn_timeout]. *)
 
+val attempt_watchdog_timeout_sec_opt :
+  liveness_mode:Keeper_attempt_liveness_config.mode ->
+  remaining_turn_budget_s:float ->
+  provider_timeout_budget ->
+  float option
+(** Runtime-attempt wall-clock watchdog selected for the active streaming
+    liveness mode.
+
+    [Observe] and [Enforce] return [None] so OAS [run_stream] progress,
+    [stream_idle_timeout_s], and the attempt-liveness observer own stream
+    liveness. [Off] preserves the legacy per-attempt watchdog. *)
+
 type degraded_retry_budget_decision =
   | No_degraded_retry
   | Degraded_retry_slot_phase_exhausted of EC.degraded_retry

--- a/lib/keeper/keeper_unified_turn_attempt_watchdog.ml
+++ b/lib/keeper/keeper_unified_turn_attempt_watchdog.ml
@@ -5,6 +5,9 @@ let dispatch
       ~on_cancelled
       ~run
   =
+  match attempt_watchdog_s with
+  | None -> run ()
+  | Some attempt_watchdog_s ->
   try Eio.Time.with_timeout_exn clock attempt_watchdog_s run with
   | Eio.Cancel.Cancelled _ as e ->
     on_cancelled ();

--- a/lib/keeper/keeper_unified_turn_attempt_watchdog.mli
+++ b/lib/keeper/keeper_unified_turn_attempt_watchdog.mli
@@ -1,11 +1,13 @@
-(** RFC-0136 PR-4-c: wrap [Eio.Time.with_timeout_exn] + the
+(** RFC-0136 PR-4-c: optionally wrap [Eio.Time.with_timeout_exn] + the
     [Eio.Cancel.Cancelled] / [Eio.Time.Timeout] handling for a single
-    keeper turn runtime attempt.  Extracted from
+    keeper turn runtime attempt. Extracted from
     [keeper_unified_turn.ml] do_run closure (L490-L577).
 
     Three outcomes:
 
-    - normal completion: pass-through of [run]'s [result]
+    - no attempt watchdog ([attempt_watchdog_s = None]): pass-through of [run]'s
+      [result]
+    - normal completion under a watchdog: pass-through of [run]'s [result]
     - [Eio.Cancel.Cancelled]: invoke [on_cancelled] for the terminal
       receipt + FSM transition, then re-raise so the outer cleanup
       handler observes the cancellation
@@ -21,7 +23,7 @@
     timeline.  Cycle 1b-iv. *)
 val dispatch
   :  clock:_ Eio.Time.clock
-  -> attempt_watchdog_s:float
+  -> attempt_watchdog_s:float option
   -> oas_timeout_s:float
   -> on_cancelled:(unit -> unit)
   -> run:(unit -> ('a, Agent_sdk.Error.sdk_error) result)

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -346,7 +346,8 @@ let run (ctx : ctx)
         attempt_provider_timeout_budget := Some provider_timeout_budget;
         last_provider_timeout_budget := Some provider_timeout_budget;
         let attempt_watchdog_s =
-          attempt_watchdog_timeout_sec
+          attempt_watchdog_timeout_sec_opt
+            ~liveness_mode:(Keeper_attempt_liveness_config.current_mode ())
             ~remaining_turn_budget_s:(remaining_turn_budget_s ())
             provider_timeout_budget
         in

--- a/test/stanzas/test_oas_timeout_budget_strike.inc
+++ b/test/stanzas/test_oas_timeout_budget_strike.inc
@@ -1,4 +1,4 @@
 (test
  (name test_oas_timeout_budget_strike)
  (modules test_oas_timeout_budget_strike)
- (libraries masc masc.keeper_failure_policy alcotest eio eio_main agent_sdk))
+ (libraries masc masc.keeper_failure_policy masc.keeper_runtime alcotest eio eio_main agent_sdk))

--- a/test/test_oas_timeout_budget_strike.ml
+++ b/test/test_oas_timeout_budget_strike.ml
@@ -4,6 +4,7 @@ module KH = Keeper_heartbeat_loop
 module KFP = Keeper_failure_policy
 module KK = Keeper_keepalive
 module KCB = Keeper_turn_runtime_budget
+module KAL = Keeper_attempt_liveness_config
 module KTD = Keeper_turn_driver
 module EC = Keeper_error_classify
 
@@ -153,6 +154,36 @@ let test_attempt_watchdog_timeout_reclassifies_as_provider_timeout () =
     true
     (EC.should_warn_keeper_cycle_failed reclassified)
 
+let test_stream_liveness_disables_outer_attempt_watchdog () =
+  let budget : KCB.provider_timeout_budget =
+    { effective_timeout_sec = 555.0
+    ; adaptive_timeout_sec = 600.0
+    ; keeper_turn_timeout_sec = 600.0
+    ; remaining_turn_budget_sec = 571.0
+    ; estimated_input_tokens = 10_000
+    ; max_turns = 6
+    ; source = "turn_budget_capped"
+    }
+  in
+  let select mode =
+    KCB.attempt_watchdog_timeout_sec_opt
+      ~liveness_mode:mode
+      ~remaining_turn_budget_s:571.0
+      budget
+  in
+  (match select KAL.Off with
+   | Some actual ->
+     Alcotest.(check (float 0.001)) "legacy off-mode watchdog" 570.0 actual
+   | None -> Alcotest.fail "off mode should preserve the legacy watchdog");
+  Alcotest.(check bool)
+    "observe mode lets stream liveness own the attempt"
+    true
+    (Option.is_none (select KAL.Observe));
+  Alcotest.(check bool)
+    "enforce mode lets stream liveness own the attempt"
+    true
+    (Option.is_none (select KAL.Enforce))
+
 let test_provider_timeout_is_not_ambiguous_side_effect () =
   Alcotest.(check bool)
     "provider timeout is not ambiguous without committed tools"
@@ -251,6 +282,10 @@ let () =
           "attempt watchdog timeout reclassifies as provider timeout"
           `Quick
           test_attempt_watchdog_timeout_reclassifies_as_provider_timeout;
+        Alcotest.test_case
+          "stream liveness disables outer attempt watchdog"
+          `Quick
+          test_stream_liveness_disables_outer_attempt_watchdog;
         Alcotest.test_case
           "provider timeout is not ambiguous partial commit"
           `Quick


### PR DESCRIPTION
## Summary
- disable the outer provider-budget attempt watchdog when runtime attempt liveness is observe/enforce
- keep the legacy watchdog when liveness is explicitly off
- add a regression test pinning that stream liveness owns active OAS attempts

## Verification
- ocamlformat --check lib/keeper/keeper_unified_turn_attempt_watchdog.ml lib/keeper/keeper_unified_turn_attempt_watchdog.mli lib/keeper/keeper_turn_runtime_budget.ml lib/keeper/keeper_turn_runtime_budget.mli lib/keeper/keeper_unified_turn_execution.ml test/test_oas_timeout_budget_strike.ml
- git diff --check HEAD~1..HEAD
- env DUNE_CACHE=disabled DUNE_BUILD_DIR=/private/tmp/masc-dune-oas-streaming-liveness-20260606-pr20314 dune build --root . .
- env DUNE_CACHE=disabled DUNE_BUILD_DIR=/private/tmp/masc-dune-oas-streaming-liveness-20260606-final dune build --root . test/test_oas_timeout_budget_strike.exe
- /private/tmp/masc-dune-oas-streaming-liveness-20260606-final/default/test/test_oas_timeout_budget_strike.exe