### PR TITLE
fix(otel): emit GenAI client metrics and span details

### DIFF
--- a/docs/rfc/RFC-0214-otel-genai-dual-emission.md
+++ b/docs/rfc/RFC-0214-otel-genai-dual-emission.md
@@ -2,9 +2,10 @@
 
 | | |
 |---|---|
-| **Status** | Draft |
+| **Status** | Implemented |
 | **Author** | Claude Opus 4.8 |
 | **Date** | 2026-06-04 |
+| **Last Updated** | 2026-06-06 |
 | **Supersedes** | — |
 
 ## 1. Problem
@@ -16,6 +17,22 @@ masc-mcp의 LLM 텔레메트리는 이전에 **legacy backend 전용 커스텀 �
 3. span attributes와 metric labels 간 불일치
 
 ## 2. Current State
+
+Implementation status as of 2026-06-06:
+
+- Legacy `masc_llm_provider_*` metrics remain emitted from `Otel_metric_store`
+  for existing dashboards.
+- `lib/llm_metric_bridge.ml` now also emits standard GenAI OTel client metrics:
+  `gen_ai.client.token.usage`,
+  `gen_ai.client.operation.duration`,
+  `gen_ai.client.operation.time_to_first_chunk`, and
+  `gen_ai.client.operation.time_per_output_chunk`.
+- Token usage, cache details, reasoning-token details, streaming timing, and
+  bounded error classification are projected to GenAI span attributes/events.
+- `tool.name` telemetry used by tool-input validation remains a separate
+  historical tool telemetry surface. It is not the same as the GenAI/MCP
+  semantic-convention `gen_ai.tool.name` attribute used for model/tool-call
+  spans.
 
 ### 2.1 Legacy Metric Names
 
@@ -35,21 +52,23 @@ masc-mcp의 LLM 텔레메트리는 이전에 **legacy backend 전용 커스텀 �
 | `masc_llm_provider_cache_misses_total` | counter | provider, model |
 | `masc_llm_provider_circuit_state` | gauge | provider, model |
 
-### 2.2 OTel Span Events (Partial)
+### 2.2 OTel Span Events And Attributes
 
-Only streaming events emit OTel span attributes:
-
-| Span Event | Attributes |
-|------------|------------|
-| `ttfrc.received` | `gen_ai.provider.name`, `gen_ai.request.model`, `masc.gen_ai.streaming.ttfrc_ms` |
+| Surface | Attributes |
+|---------|------------|
+| `gen_ai.client.inference.operation.details` | `gen_ai.operation.name`, `gen_ai.provider.name`, `gen_ai.request.model`, `gen_ai.response.model`, usage token attributes |
+| `gen_ai.client.operation.exception` | `exception.message`, `exception.type`, plus low-cardinality `error.type` on the span |
+| `ttfrc.received` | `gen_ai.provider.name`, `gen_ai.request.model`, `gen_ai.response.time_to_first_chunk`, `masc.gen_ai.streaming.ttfrc_ms` |
 | `streaming.chunk` | `gen_ai.provider.name`, `gen_ai.request.model`, `masc.gen_ai.streaming.chunk_index`, `masc.gen_ai.streaming.inter_chunk_ms` |
 
-### 2.3 Missing OTel Integration
+### 2.3 Remaining Constraints
 
-- Token usage → NOT as OTel metric or span attribute
-- Error events → NOT as OTel span status
-- Cache metrics → NOT in OTel
-- Request duration → NOT as OTel metric
+- The standard `gen_ai.client.token.usage` metric only uses
+  `gen_ai.token.type=input|output`. Cache and reasoning tokens are represented
+  as usage detail attributes, not as additional token-type label values.
+- The current bridge intentionally does not record opt-in prompt/response
+  content attributes such as `gen_ai.input.messages` or
+  `gen_ai.output.messages`.
 
 ## 3. Target State (OTel GenAI Semconv)
 
@@ -57,15 +76,17 @@ Reference: [OTel GenAI Semantic Conventions](https://opentelemetry.io/docs/specs
 
 ### 3.1 OTel Metric: `gen_ai.client.token.usage`
 
-Counter with `gen_ai.token.type` attribute:
+Histogram with `gen_ai.token.type` attribute:
 
 | `gen_ai.token.type` value | Source |
 |--------------------------|--------|
 | `input` | `masc_llm_provider_input_tokens_total` |
 | `output` | `masc_llm_provider_output_tokens_total` |
-| `cache_read` | `masc_llm_provider_cache_read_tokens_total` |
-| `cache_creation` | `masc_llm_provider_cache_creation_tokens_total` |
-| `reasoning` | `masc_llm_provider_reasoning_tokens_total` |
+
+Do not encode `cache_read`, `cache_creation`, or `reasoning` as
+`gen_ai.token.type` values. The OpenTelemetry well-known values are
+`input` and `output`; provider cache/reasoning details belong on the
+`gen_ai.usage.*` attributes below.
 
 ### 3.2 OTel Span Event: `gen_ai.client.inference.operation.details`
 
@@ -88,9 +109,11 @@ Attributes to add per-inference:
 
 Emit OTel metrics/attributes directly.
 
-Why OTel-only migration:
+Why OTel-backed migration:
 - legacy backend was removed by RFC-0217 / PR #20189
-- The compatibility target is now OTel metric store + OTLP, not dual emission
+- The compatibility target is now OTel metric store + OTLP
+- Existing `masc_llm_provider_*` metric names remain in the OTel metric store
+  until dashboard consumers migrate to `gen_ai.*`
 - OTLP-enabled environments get automatic LLM dashboards
 - OTel is the primary metric backend
 
@@ -115,63 +138,31 @@ Why OTel-only migration:
               └────────────┘  └──────────────┘
 ```
 
-### 4.3 Code Changes
+### 4.3 Implemented Changes
 
-#### Phase A: Span Attributes (Low risk)
+| File | Change |
+|------|--------|
+| `lib/otel_genai/otel_genai.ml` | Centralized GenAI metric, event, and attribute names including usage detail attributes. |
+| `lib/otel_spans/otel_spans.ml` | Added testable span attribute/status hooks and GenAI exception recording. |
+| `lib/llm_metric_bridge.ml` | Emits standard GenAI client metrics, operation-details events, usage attributes, streaming timings, and bounded error status. |
+| `lib/keeper/keeper_hooks_oas.ml` | Projects trusted cache/reasoning token details into GenAI usage attributes without inventing extra `gen_ai.token.type` values. |
+| `test/test_llm_metric_bridge.ml` | Covers standard metric names, event names, span attrs/status, and the cache/reasoning token-type guardrail. |
 
-In `lib/llm_metric_bridge.ml`, add OTel span attributes to `emit_token_usage`:
+## 5. Remaining Migration Work
 
-```ocaml
-let emit_token_usage ~provider ~model_id ~input_tokens ~output_tokens =
-  (* OTel metric store counters *)
-  Otel_metric_store.inc_counter input_token_metric ...;
-  Otel_metric_store.inc_counter output_token_metric ...;
-  (* OTel span attributes *)
-  Otel_spans.add_event
-    ~name:"gen_ai.client.token.usage"
-    ~attrs:
-      [ "gen_ai.provider.name", `String provider
-      ; "gen_ai.request.model", `String model_id
-      ; "gen_ai.usage.input_tokens", `Int input_tokens
-      ; "gen_ai.usage.output_tokens", `Int output_tokens
-      ]
-    ()
-```
-
-Similarly for `emit_error` (span status), `emit_streaming_first_chunk` (already partially done).
-
-#### Phase B: OTel Metric Export (Medium risk)
-
-Add a thin OTel metric exporter in the bridge:
-
-```ocaml
-(* OTel emission helper *)
-let emit_metric_otel ~name ~value ~attrs =
-  Otel_metrics.record ~name ~value ~attrs
-```
-
-This requires the `opentelemetry` OCaml library (already in dune-project).
-
-#### Phase C: Custom→Standard Migration (Future)
-
-After Phase B is validated:
-1. Add legacy → OTel name mapping table where compatibility is still needed
-2. Grafana dashboards use OTel metric names
-3. Deprecate legacy `masc_llm_provider_*` names once dashboard consumers are updated
-
-## 5. Scope & Effort
-
-| Phase | Files | Effort | Risk |
-|-------|-------|--------|------|
-| A: Span attributes | `llm_metric_bridge.ml`, `keeper_hooks_oas.ml` | ~50 lines | Low |
-| B: OTel metric export | `llm_metric_bridge.ml`, new `otel_llm_metrics.ml` | ~200 lines | Medium |
-| C: Deprecation | Dashboard, alert configs | ~100 files | High |
+| Area | Status |
+|------|--------|
+| Dashboard queries | Can migrate from `masc_llm_provider_*` to `gen_ai.*`; legacy names remain available for now. |
+| Prompt/response content events | Intentionally not emitted by default because `gen_ai.input.messages` and `gen_ai.output.messages` are opt-in and can contain sensitive data. |
+| MCP tool-call semantic convention | Separate from LLM GenAI client metrics. Use `gen_ai.tool.name` / `mcp.*` only when instrumenting MCP tool-call spans. |
 
 ## 6. Decision Points
 
-1. **Dual emission vs replacement?** — Replacement. RFC-0217 / PR #20189 retired the legacy backend.
+1. **Dual emission vs replacement?** — Dual metric names in the OTel metric
+   store for compatibility; no restoration of the retired legacy backend.
 2. **OTLP endpoint configuration?** — Use existing `opentelemetry` lib config (env vars).
-3. **Custom attributes (`masc.gen_ai.*`) migration?** — Phase C, with deprecation period.
+3. **Custom attributes (`masc.gen_ai.*`) migration?** — Keep as MASC-owned
+   extensions where no current GenAI convention exists.
 
 ## 7. Non-Goals
 
@@ -181,8 +172,12 @@ After Phase B is validated:
 
 ## 8. References
 
-- [OTel GenAI Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/)
-- [OTel GenAI Metrics](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics/)
+- [OTel GenAI Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/) — checked 2026-06-06, confidence High.
+- [OTel GenAI Metrics](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics/) — checked 2026-06-06, confidence High.
+- [OTel GenAI Events](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-events/) — checked 2026-06-06, confidence High.
+- [OTel GenAI Exceptions](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-exceptions/) — checked 2026-06-06, confidence High.
+- [OTel GenAI Attribute Registry](https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/) — checked 2026-06-06, confidence High.
+- [OTel MCP Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/mcp/) — checked 2026-06-06, confidence High.
 - PR #19957 — Telemetry pipeline gap fixes (error/retry JSONL, cache_creation pipeline)
-- `lib/llm_metric_bridge.ml` — Bridge layer with partial OTel span events
+- `lib/llm_metric_bridge.ml` — Bridge layer with GenAI client metric/span/event emission
 - `lib/opentelemetry_client_cohttp_eio.ml` — OTLP exporter (Eio transport)

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -338,40 +338,53 @@ let make_hooks
             Llm_provider.Provider_kind.to_string pk
           | _ -> runtime_lane_label
         in
+        let cache_creation_input_tokens, cache_read_input_tokens =
+          match response.usage with
+          | Some u when usage_trusted ->
+              u.cache_creation_input_tokens, u.cache_read_input_tokens
+          | Some _ | None -> 0, 0
+        in
+        let reasoning_output_tokens =
+          match response.telemetry with
+          | Some { reasoning_tokens = Some rt; _ } when usage_trusted && rt > 0 -> rt
+          | _ -> 0
+        in
         (* Cache-token tracking uses OAS-reported counters only. *)
-        (match response.usage with
-         | Some u when usage_trusted ->
-           let cc = u.cache_creation_input_tokens in
-           let cr = u.cache_read_input_tokens in
-           if cc > 0 then
+        let cc = cache_creation_input_tokens in
+        let cr = cache_read_input_tokens in
+        if cc > 0 then
              Otel_metric_store.inc_counter
                Otel_metric_store.metric_provider_prefix_cache_creation_tokens
                ~delta:(Float.of_int cc) ();
-           if cr > 0 then begin
-             Otel_metric_store.inc_counter
-               Otel_metric_store.metric_provider_prefix_cache_read_tokens
-               ~delta:(Float.of_int cr) ();
-             (* Per-provider/model cache-read counter for Otel_metric_store
-                dashboards.  The legacy unlabelled counter above
-                remains for backward compatibility. *)
-             Otel_metric_store.inc_counter
-               Otel_metric_store.metric_llm_provider_cache_read_tokens
-               ~labels:[ ("provider", provider_label); ("model", model) ]
-               ~delta:(Float.of_int cr)
-               ()
-           end
-         | Some _ | None -> ());
+        if cr > 0 then begin
+          Otel_metric_store.inc_counter
+            Otel_metric_store.metric_provider_prefix_cache_read_tokens
+            ~delta:(Float.of_int cr) ();
+          (* Per-provider/model cache-read counter for Otel_metric_store
+             dashboards.  The legacy unlabelled counter above
+             remains for backward compatibility. *)
+          Otel_metric_store.inc_counter
+            Otel_metric_store.metric_llm_provider_cache_read_tokens
+            ~labels:[ ("provider", provider_label); ("model", model) ]
+            ~delta:(Float.of_int cr)
+            ()
+        end;
         (* Per-provider/model reasoning-token counter.  Available via
            [inference_telemetry.reasoning_tokens] on select providers
            (Anthropic extended thinking, DeepSeek, etc.). *)
-        (match response.telemetry with
-         | Some { reasoning_tokens = Some rt; _ } when usage_trusted && rt > 0 ->
+        if reasoning_output_tokens > 0 then
            Otel_metric_store.inc_counter
              Otel_metric_store.metric_llm_provider_reasoning_tokens
              ~labels:[ ("provider", provider_label); ("model", model) ]
-             ~delta:(Float.of_int rt)
-             ()
-         | _ -> ());
+             ~delta:(Float.of_int reasoning_output_tokens)
+             ();
+        Llm_metric_bridge.emit_usage_details
+          ~provider:provider_label
+          ~model_id:model
+          ~cache_creation_input_tokens
+          ~cache_read_input_tokens
+          ~reasoning_output_tokens
+          ();
         (* Inference latency histogram for telemetry export.
            Missing telemetry stays a separate counter; zero/negative latency
            increments the zero-latency counter and observes a 1ms floor so the

--- a/lib/llm_metric_bridge.ml
+++ b/lib/llm_metric_bridge.ml
@@ -36,6 +36,25 @@ let provider_seen_for_model ~model_id =
 let model_labels ~model_id = [ ("model", model_id) ]
 let provider_model_labels ~provider ~model_id = [ ("provider", provider); ("model", model_id) ]
 
+let genai_operation_name = "chat"
+
+let genai_provider_for_model ~model_id =
+  if String.equal model_id "" then "unknown"
+  else provider_seen_for_model ~model_id |> Option.value ~default:"unknown"
+;;
+
+let genai_base_labels ~provider ~model_id =
+  [ Otel_genai.Attr_key.gen_ai_operation_name, genai_operation_name
+  ; Otel_genai.Attr_key.gen_ai_provider_name, provider
+  ; Otel_genai.Attr_key.gen_ai_request_model, model_id
+  ]
+;;
+
+let genai_token_labels ~provider ~model_id ~token_type =
+  genai_base_labels ~provider ~model_id
+  @ [ Otel_genai.Attr_key.gen_ai_token_type, token_type ]
+;;
+
 let inc_counter ?(delta = 1.0) name ~labels =
   Otel_metric_store.inc_counter name ~labels ~delta ()
 ;;
@@ -44,6 +63,74 @@ let set_gauge name ~labels value = Otel_metric_store.set_gauge name ~labels valu
 
 let observe_seconds name ~labels seconds =
   Otel_metric_store.observe_histogram name ~labels seconds
+;;
+
+let observe_genai_seconds name ~provider ~model_id seconds =
+  observe_seconds name ~labels:(genai_base_labels ~provider ~model_id) seconds
+;;
+
+let observe_genai_tokens ~provider ~model_id ~token_type tokens =
+  Otel_metric_store.observe_histogram
+    Otel_genai.Metric_name.client_token_usage
+    ~labels:(genai_token_labels ~provider ~model_id ~token_type)
+    (float_of_int tokens)
+;;
+
+let add_genai_attrs attrs =
+  Otel_spans.add_attrs
+    ~attrs:
+      ((Otel_genai.Attr_key.gen_ai_operation_name, `String genai_operation_name)
+       :: attrs)
+    ()
+;;
+
+let positive_int_attrs attrs =
+  attrs
+  |> List.filter_map (fun (key, value_opt) ->
+    match value_opt with
+    | Some value when value > 0 -> Some (key, `Int value)
+    | Some _ | None -> None)
+;;
+
+let emit_usage_details
+      ?input_tokens
+      ?output_tokens
+      ?cache_creation_input_tokens
+      ?cache_read_input_tokens
+      ?reasoning_output_tokens
+      ~provider
+      ~model_id
+      ()
+  =
+  let detail_attrs =
+    positive_int_attrs
+      [ Otel_genai.Attr_key.gen_ai_usage_input_tokens, input_tokens
+      ; Otel_genai.Attr_key.gen_ai_usage_output_tokens, output_tokens
+      ; ( Otel_genai.Attr_key.gen_ai_usage_cache_creation_input_tokens
+        , cache_creation_input_tokens )
+      ; Otel_genai.Attr_key.gen_ai_usage_cache_read_input_tokens, cache_read_input_tokens
+      ; ( Otel_genai.Attr_key.gen_ai_usage_reasoning_output_tokens
+        , reasoning_output_tokens )
+      ]
+  in
+  match detail_attrs with
+  | [] -> ()
+  | _ ->
+    note_provider ~model_id ~provider;
+    let attrs =
+      [ Otel_genai.Attr_key.gen_ai_provider_name, `String provider
+      ; Otel_genai.Attr_key.gen_ai_request_model, `String model_id
+      ; Otel_genai.Attr_key.gen_ai_response_model, `String model_id
+      ]
+      @ detail_attrs
+    in
+    add_genai_attrs attrs;
+    Otel_spans.add_event
+      ~name:Otel_genai.Event_name.client_inference_operation_details
+      ~attrs:
+        ((Otel_genai.Attr_key.gen_ai_operation_name, `String genai_operation_name)
+         :: attrs)
+      ()
 ;;
 
 let emit_http_status ~provider ~model_id ~status =
@@ -92,6 +179,11 @@ let emit_request_latency ?provider ~model_id ~latency_ms () =
   observe_seconds
     Otel_metric_store.metric_llm_provider_request_latency
     ~labels:(provider_model_labels ~provider ~model_id)
+    seconds;
+  observe_genai_seconds
+    Otel_genai.Metric_name.client_operation_duration
+    ~provider
+    ~model_id
     seconds
 ;;
 
@@ -132,12 +224,23 @@ let error_reason error =
 ;;
 
 let emit_error ~model_id ~error =
+  let reason = error_reason error in
+  let provider = genai_provider_for_model ~model_id in
   inc_counter
     Otel_metric_store.metric_llm_provider_errors
     ~labels:(model_labels ~model_id);
   inc_counter
     Otel_metric_store.metric_llm_provider_errors_by_reason
-    ~labels:[ ("model", model_id); ("error_reason", error_reason error) ]
+    ~labels:[ ("model", model_id); ("error_reason", reason) ];
+  Otel_spans.record_error
+    ~message:error
+    ~error_type:reason
+    ~attrs:
+      [ Otel_genai.Attr_key.gen_ai_operation_name, `String genai_operation_name
+      ; Otel_genai.Attr_key.gen_ai_provider_name, `String provider
+      ; Otel_genai.Attr_key.gen_ai_request_model, `String model_id
+      ]
+    ()
 ;;
 
 let emit_retry ~provider ~model_id ~attempt =
@@ -173,7 +276,10 @@ let emit_token_usage ~provider ~model_id ~input_tokens ~output_tokens =
   inc_counter
     Otel_metric_store.metric_llm_provider_output_tokens
     ~labels
-    ~delta:(float_of_int output_tokens)
+    ~delta:(float_of_int output_tokens);
+  observe_genai_tokens ~provider ~model_id ~token_type:"input" input_tokens;
+  observe_genai_tokens ~provider ~model_id ~token_type:"output" output_tokens;
+  emit_usage_details ~provider ~model_id ~input_tokens ~output_tokens ()
 ;;
 
 let emit_tool_calls ~provider ~model_id ~count =
@@ -211,6 +317,17 @@ let emit_streaming_first_chunk ~provider ~model_id ~ttfrc_ms =
       Otel_metric_store.metric_llm_provider_streaming_first_chunk
       ~labels:(provider_model_labels ~provider ~model_id)
       (ttfrc_ms /. 1000.0);
+    observe_genai_seconds
+      Otel_genai.Metric_name.client_operation_time_to_first_chunk
+      ~provider
+      ~model_id
+      (ttfrc_ms /. 1000.0);
+    add_genai_attrs
+      [ Otel_genai.Attr_key.gen_ai_provider_name, `String provider
+      ; Otel_genai.Attr_key.gen_ai_request_model, `String model_id
+      ; Otel_genai.Attr_key.gen_ai_response_time_to_first_chunk
+        , `Float (ttfrc_ms /. 1000.0)
+      ];
     Otel_spans.add_event
       ~name:"ttfrc.received"
       ~attrs:
@@ -232,6 +349,11 @@ let emit_streaming_chunk ~provider ~model_id ~chunk_index ~inter_chunk_ms =
     observe_seconds
       Otel_metric_store.metric_llm_provider_streaming_inter_chunk
       ~labels:(provider_model_labels ~provider ~model_id)
+      (inter_chunk_ms /. 1000.0);
+    observe_genai_seconds
+      Otel_genai.Metric_name.client_operation_time_per_output_chunk
+      ~provider
+      ~model_id
       (inter_chunk_ms /. 1000.0);
     Otel_spans.add_event
       ~name:"streaming.chunk"

--- a/lib/llm_metric_bridge.mli
+++ b/lib/llm_metric_bridge.mli
@@ -41,6 +41,17 @@ val emit_token_usage
   -> output_tokens:int
   -> unit
 
+val emit_usage_details
+  :  ?input_tokens:int
+  -> ?output_tokens:int
+  -> ?cache_creation_input_tokens:int
+  -> ?cache_read_input_tokens:int
+  -> ?reasoning_output_tokens:int
+  -> provider:string
+  -> model_id:string
+  -> unit
+  -> unit
+
 val emit_tool_calls
   :  provider:string
   -> model_id:string

--- a/lib/otel_genai/otel_genai.ml
+++ b/lib/otel_genai/otel_genai.ml
@@ -31,6 +31,32 @@ module Attr_key = struct
   ;;
 
   let gen_ai_tool_name = register Official_gen_ai "gen_ai.tool.name"
+  let gen_ai_request_model = register Official_gen_ai "gen_ai.request.model"
+  let gen_ai_response_model = register Official_gen_ai "gen_ai.response.model"
+  let gen_ai_token_type = register Official_gen_ai "gen_ai.token.type"
+  let gen_ai_usage_input_tokens =
+    register Official_gen_ai "gen_ai.usage.input_tokens"
+  ;;
+
+  let gen_ai_usage_output_tokens =
+    register Official_gen_ai "gen_ai.usage.output_tokens"
+  ;;
+
+  let gen_ai_usage_cache_creation_input_tokens =
+    register Official_gen_ai "gen_ai.usage.cache_creation.input_tokens"
+  ;;
+
+  let gen_ai_usage_cache_read_input_tokens =
+    register Official_gen_ai "gen_ai.usage.cache_read.input_tokens"
+  ;;
+
+  let gen_ai_usage_reasoning_output_tokens =
+    register Official_gen_ai "gen_ai.usage.reasoning.output_tokens"
+  ;;
+
+  let gen_ai_response_time_to_first_chunk =
+    register Official_gen_ai "gen_ai.response.time_to_first_chunk"
+  ;;
 
   let masc_gen_ai_keeper_name =
     register Masc_extension "masc.gen_ai.keeper.name"
@@ -66,6 +92,26 @@ module Attr_key = struct
 
   let is_official_gen_ai key = List.mem key official_gen_ai
   let is_masc_extension key = List.mem key masc_extensions
+end
+
+module Metric_name = struct
+  let client_token_usage = "gen_ai.client.token.usage"
+  let client_operation_duration = "gen_ai.client.operation.duration"
+  let client_operation_time_to_first_chunk =
+    "gen_ai.client.operation.time_to_first_chunk"
+  ;;
+
+  let client_operation_time_per_output_chunk =
+    "gen_ai.client.operation.time_per_output_chunk"
+  ;;
+end
+
+module Event_name = struct
+  let client_inference_operation_details =
+    "gen_ai.client.inference.operation.details"
+  ;;
+
+  let client_operation_exception = "gen_ai.client.operation.exception"
 end
 
 let keeper_turn_span_name ~keeper_name = "invoke_agent " ^ keeper_name

--- a/lib/otel_genai/otel_genai.mli
+++ b/lib/otel_genai/otel_genai.mli
@@ -9,6 +9,15 @@ module Attr_key : sig
   val gen_ai_agent_id : string
   val gen_ai_conversation_id : string
   val gen_ai_tool_name : string
+  val gen_ai_request_model : string
+  val gen_ai_response_model : string
+  val gen_ai_token_type : string
+  val gen_ai_usage_input_tokens : string
+  val gen_ai_usage_output_tokens : string
+  val gen_ai_usage_cache_creation_input_tokens : string
+  val gen_ai_usage_cache_read_input_tokens : string
+  val gen_ai_usage_reasoning_output_tokens : string
+  val gen_ai_response_time_to_first_chunk : string
   val masc_gen_ai_keeper_name : string
   val masc_gen_ai_runtime_id : string
   val keeper_name : string
@@ -35,6 +44,18 @@ module Attr_key : sig
   val legacy : string list
   val is_official_gen_ai : string -> bool
   val is_masc_extension : string -> bool
+end
+
+module Metric_name : sig
+  val client_token_usage : string
+  val client_operation_duration : string
+  val client_operation_time_to_first_chunk : string
+  val client_operation_time_per_output_chunk : string
+end
+
+module Event_name : sig
+  val client_inference_operation_details : string
+  val client_operation_exception : string
 end
 
 val keeper_turn_span_name : keeper_name:string -> string

--- a/lib/otel_spans/otel_spans.ml
+++ b/lib/otel_spans/otel_spans.ml
@@ -20,6 +20,12 @@ let event_emitter_override
   ref None
 ;;
 
+let attrs_emitter_override : (attrs:OT.key_value list -> unit) option ref =
+  ref None
+;;
+
+let status_emitter_override : (OT.Span_status.t -> unit) option ref = ref None
+
 let enabled () =
   match !enabled_override with
   | Some value -> value
@@ -193,15 +199,65 @@ let add_event ~name ?(attrs = []) () =
        | None -> ())
 ;;
 
-let with_test_event_emitter ~enabled:enabled_value ~emit_event f =
+let add_attrs ?(attrs = []) () =
+  if enabled ()
+  then
+    match !attrs_emitter_override with
+    | Some emit -> emit ~attrs
+    | None ->
+      (match OT.Scope.get_ambient_scope () with
+       | Some scope -> OT.Scope.add_attrs scope (fun () -> attrs)
+       | None -> ())
+;;
+
+let set_status status =
+  if enabled ()
+  then
+    match !status_emitter_override with
+    | Some emit -> emit status
+    | None ->
+      (match OT.Scope.get_ambient_scope () with
+       | Some scope -> OT.Scope.set_status scope status
+       | None -> ())
+;;
+
+let record_error ?(attrs = []) ~message ~error_type () =
+  let status =
+    OT.Span_status.make ~message ~code:OT.Span_status.Status_code_error
+  in
+  let span_attrs = ("error.type", `String error_type) :: attrs in
+  set_status status;
+  add_attrs ~attrs:span_attrs ();
+  add_event
+    ~name:"gen_ai.client.operation.exception"
+    ~attrs:
+      [ "exception.message", `String message
+      ; "exception.type", `String error_type
+      ]
+    ()
+;;
+
+let with_test_event_emitter
+      ~enabled:enabled_value
+      ~emit_event
+      ?emit_attrs
+      ?set_status:set_status_hook
+      f
+  =
   let prev_enabled = !enabled_override in
   let prev_emitter = !event_emitter_override in
+  let prev_attrs_emitter = !attrs_emitter_override in
+  let prev_status_emitter = !status_emitter_override in
   enabled_override := Some enabled_value;
   event_emitter_override := Some emit_event;
+  attrs_emitter_override := emit_attrs;
+  status_emitter_override := set_status_hook;
   Eio_guard.protect
     ~finally:(fun () ->
       enabled_override := prev_enabled;
-      event_emitter_override := prev_emitter)
+      event_emitter_override := prev_emitter;
+      attrs_emitter_override := prev_attrs_emitter;
+      status_emitter_override := prev_status_emitter)
     f
 ;;
 

--- a/lib/otel_spans/otel_spans.mli
+++ b/lib/otel_spans/otel_spans.mli
@@ -56,10 +56,29 @@ val with_span :
 val add_event :
   name:string -> ?attrs:Opentelemetry.key_value list -> unit -> unit
 
+(** [add_attrs ~attrs ()] appends attributes to the active OTel span.
+    No-op when OTel is disabled or when no ambient span exists. *)
+val add_attrs : ?attrs:Opentelemetry.key_value list -> unit -> unit
+
+(** [set_status status] sets the active span status.
+    No-op when OTel is disabled or when no ambient span exists. *)
+val set_status : Opentelemetry.Span_status.t -> unit
+
+(** [record_error ~message ~error_type] marks the active span as errored and
+    emits the GenAI exception event. *)
+val record_error :
+  ?attrs:Opentelemetry.key_value list ->
+  message:string ->
+  error_type:string ->
+  unit ->
+  unit
+
 (** Temporarily override event emission for focused tests. *)
 val with_test_event_emitter :
   enabled:bool ->
   emit_event:(name:string -> attrs:Opentelemetry.key_value list -> unit) ->
+  ?emit_attrs:(attrs:Opentelemetry.key_value list -> unit) ->
+  ?set_status:(Opentelemetry.Span_status.t -> unit) ->
   (unit -> 'a) ->
   'a
 

--- a/test/deps/dune
+++ b/test/deps/dune
@@ -40,6 +40,7 @@
   (re_export masc.worker_execution_backend)
   (re_export masc.worker_execution_spec)
   (re_export masc.worker_runtime_config)
+  (re_export masc.otel_genai)
   (re_export masc.otel_metrics)
   (re_export masc.otel_spans)
   (re_export otel_metric_test_store)
@@ -178,6 +179,7 @@
   (re_export multimodal)
   (re_export ocaml-protoc-plugin)
   (re_export ocaml-webrtc)
+  (re_export opentelemetry)
   ; RFC-0129 — Pool.For_testing.read_body_with_idle tests build a mock
   ; Piaf.Body via Piaf.Stream.create + Piaf.Body.of_string_stream.
   (re_export piaf)

--- a/test/test_llm_metric_bridge.ml
+++ b/test/test_llm_metric_bridge.ml
@@ -340,6 +340,229 @@ let assoc_int key attrs =
   | Some _ -> Alcotest.failf "expected int attr %s" key
   | None -> Alcotest.failf "missing attr %s" key
 
+let genai_base_labels ~provider ~model_id =
+  [ (Otel_genai.Attr_key.gen_ai_operation_name, "chat")
+  ; (Otel_genai.Attr_key.gen_ai_provider_name, provider)
+  ; (Otel_genai.Attr_key.gen_ai_request_model, model_id)
+  ]
+
+let genai_token_labels ~provider ~model_id ~token_type =
+  genai_base_labels ~provider ~model_id
+  @ [ (Otel_genai.Attr_key.gen_ai_token_type, token_type) ]
+
+let test_token_usage_emits_genai_otel_surface () =
+  let events = ref [] in
+  let span_attrs = ref [] in
+  let provider = "bridge-genai-provider" in
+  let model_id = Printf.sprintf "bridge-genai-token-%d" (Unix.getpid ()) in
+  let input_labels = genai_token_labels ~provider ~model_id ~token_type:"input" in
+  let output_labels = genai_token_labels ~provider ~model_id ~token_type:"output" in
+  let before_input =
+    metric Otel_genai.Metric_name.client_token_usage ~labels:input_labels
+  in
+  let before_output =
+    metric Otel_genai.Metric_name.client_token_usage ~labels:output_labels
+  in
+  Otel_spans.with_test_event_emitter ~enabled:true
+    ~emit_event:(fun ~name ~attrs -> events := (name, attrs) :: !events)
+    ~emit_attrs:(fun ~attrs -> span_attrs := attrs @ !span_attrs)
+    (fun () ->
+       Bridge.emit_token_usage
+         ~provider
+         ~model_id
+         ~input_tokens:17
+         ~output_tokens:23);
+  check_metric_delta "genai input token usage +17"
+    Otel_genai.Metric_name.client_token_usage
+    ~labels:input_labels
+    ~before:before_input
+    ~delta:17.0;
+  check_metric_delta "genai output token usage +23"
+    Otel_genai.Metric_name.client_token_usage
+    ~labels:output_labels
+    ~before:before_output
+    ~delta:23.0;
+  (match find_otel_sample Otel_genai.Metric_name.client_token_usage ~labels:input_labels with
+   | Some { kind = Otel_metrics.Histogram; _ } -> ()
+   | Some _ -> Alcotest.fail "genai token usage must export as OTel histogram"
+   | None -> Alcotest.fail "missing genai token usage sample");
+  Alcotest.(check int)
+    "span attr input tokens"
+    17
+    (assoc_int Otel_genai.Attr_key.gen_ai_usage_input_tokens !span_attrs);
+  Alcotest.(check int)
+    "span attr output tokens"
+    23
+    (assoc_int Otel_genai.Attr_key.gen_ai_usage_output_tokens !span_attrs);
+  Alcotest.(check string)
+    "span attr provider"
+    provider
+    (assoc_string Otel_genai.Attr_key.gen_ai_provider_name !span_attrs);
+  (match List.rev !events with
+   | [ name, attrs ] ->
+     Alcotest.(check string)
+       "operation details event"
+       Otel_genai.Event_name.client_inference_operation_details
+       name;
+     Alcotest.(check int)
+       "event input tokens"
+       17
+       (assoc_int Otel_genai.Attr_key.gen_ai_usage_input_tokens attrs)
+   | other ->
+     Alcotest.failf "expected one token usage OTel event, got %d"
+       (List.length other))
+
+let test_usage_details_emit_cache_reasoning_attrs_without_token_type_aliases () =
+  let events = ref [] in
+  let span_attrs = ref [] in
+  let provider = "bridge-genai-detail-provider" in
+  let model_id = Printf.sprintf "bridge-genai-detail-%d" (Unix.getpid ()) in
+  let cache_read_labels =
+    genai_token_labels ~provider ~model_id ~token_type:"cache_read"
+  in
+  let reasoning_labels =
+    genai_token_labels ~provider ~model_id ~token_type:"reasoning"
+  in
+  let before_cache_read =
+    metric Otel_genai.Metric_name.client_token_usage ~labels:cache_read_labels
+  in
+  let before_reasoning =
+    metric Otel_genai.Metric_name.client_token_usage ~labels:reasoning_labels
+  in
+  Otel_spans.with_test_event_emitter ~enabled:true
+    ~emit_event:(fun ~name ~attrs -> events := (name, attrs) :: !events)
+    ~emit_attrs:(fun ~attrs -> span_attrs := attrs @ !span_attrs)
+    (fun () ->
+       Bridge.emit_usage_details
+         ~provider
+         ~model_id
+         ~cache_creation_input_tokens:5
+         ~cache_read_input_tokens:7
+         ~reasoning_output_tokens:11
+         ());
+  check_metric_delta "cache_read is not a gen_ai.token.type alias"
+    Otel_genai.Metric_name.client_token_usage
+    ~labels:cache_read_labels
+    ~before:before_cache_read
+    ~delta:0.0;
+  check_metric_delta "reasoning is not a gen_ai.token.type alias"
+    Otel_genai.Metric_name.client_token_usage
+    ~labels:reasoning_labels
+    ~before:before_reasoning
+    ~delta:0.0;
+  Alcotest.(check int)
+    "span cache creation tokens"
+    5
+    (assoc_int
+       Otel_genai.Attr_key.gen_ai_usage_cache_creation_input_tokens
+       !span_attrs);
+  Alcotest.(check int)
+    "span cache read tokens"
+    7
+    (assoc_int
+       Otel_genai.Attr_key.gen_ai_usage_cache_read_input_tokens
+       !span_attrs);
+  Alcotest.(check int)
+    "span reasoning tokens"
+    11
+    (assoc_int
+       Otel_genai.Attr_key.gen_ai_usage_reasoning_output_tokens
+       !span_attrs);
+  (match List.rev !events with
+   | [ name, attrs ] ->
+     Alcotest.(check string)
+       "operation details event"
+       Otel_genai.Event_name.client_inference_operation_details
+       name;
+     Alcotest.(check int)
+       "event cache read tokens"
+       7
+       (assoc_int Otel_genai.Attr_key.gen_ai_usage_cache_read_input_tokens attrs)
+   | other ->
+     Alcotest.failf "expected one GenAI usage-details event, got %d"
+       (List.length other))
+
+let test_latency_and_streaming_emit_genai_metrics () =
+  let provider = "bridge-genai-latency-provider" in
+  let model_id = Printf.sprintf "bridge-genai-latency-%d" (Unix.getpid ()) in
+  let labels = genai_base_labels ~provider ~model_id in
+  let before_duration =
+    metric Otel_genai.Metric_name.client_operation_duration ~labels
+  in
+  let before_ttf =
+    metric Otel_genai.Metric_name.client_operation_time_to_first_chunk ~labels
+  in
+  let before_chunk =
+    metric Otel_genai.Metric_name.client_operation_time_per_output_chunk ~labels
+  in
+  Bridge.emit_request_latency ~provider ~model_id ~latency_ms:125 ();
+  Bridge.emit_streaming_first_chunk ~provider ~model_id ~ttfrc_ms:25.0;
+  Bridge.emit_streaming_chunk
+    ~provider
+    ~model_id
+    ~chunk_index:3
+    ~inter_chunk_ms:7.5;
+  check_metric_delta "genai operation duration +0.125s"
+    Otel_genai.Metric_name.client_operation_duration
+    ~labels
+    ~before:before_duration
+    ~delta:0.125;
+  check_metric_delta "genai time to first chunk +0.025s"
+    Otel_genai.Metric_name.client_operation_time_to_first_chunk
+    ~labels
+    ~before:before_ttf
+    ~delta:0.025;
+  check_metric_delta "genai time per output chunk +0.0075s"
+    Otel_genai.Metric_name.client_operation_time_per_output_chunk
+    ~labels
+    ~before:before_chunk
+    ~delta:0.0075
+
+let test_error_records_genai_exception_span_signal () =
+  let events = ref [] in
+  let span_attrs = ref [] in
+  let span_status = ref None in
+  let provider = "bridge-genai-error-provider" in
+  let model_id = Printf.sprintf "bridge-genai-error-%d" (Unix.getpid ()) in
+  Bridge.emit_http_status ~provider ~model_id ~status:200;
+  Otel_spans.with_test_event_emitter ~enabled:true
+    ~emit_event:(fun ~name ~attrs -> events := (name, attrs) :: !events)
+    ~emit_attrs:(fun ~attrs -> span_attrs := attrs @ !span_attrs)
+    ~set_status:(fun status -> span_status := Some status)
+    (fun () -> Bridge.emit_error ~model_id ~error:"deadline exceeded after 30s");
+  (match !span_status with
+   | Some { Opentelemetry.Span_status.message; code } ->
+     Alcotest.(check string)
+       "span status message"
+       "deadline exceeded after 30s"
+       message;
+     Alcotest.(check bool)
+       "span status error code"
+       true
+       (code = Opentelemetry.Span_status.Status_code_error)
+   | None -> Alcotest.fail "missing GenAI error span status");
+  Alcotest.(check string)
+    "span error.type"
+    "timeout"
+    (assoc_string "error.type" !span_attrs);
+  Alcotest.(check string)
+    "span provider"
+    provider
+    (assoc_string Otel_genai.Attr_key.gen_ai_provider_name !span_attrs);
+  (match List.rev !events with
+   | [ name, attrs ] ->
+     Alcotest.(check string)
+       "exception event name"
+       "gen_ai.client.operation.exception"
+       name;
+     Alcotest.(check string)
+       "exception type"
+       "timeout"
+       (assoc_string "exception.type" attrs)
+   | other ->
+     Alcotest.failf "expected one GenAI exception event, got %d"
+       (List.length other))
+
 let test_streaming_callbacks_emit_otel_events () =
   let events = ref [] in
   let provider = "bridge-otel-provider" in
@@ -501,6 +724,18 @@ let () =
           Alcotest.test_case
             "request latency no model_id increments typed clamp reason" `Quick
             test_request_latency_no_model_id_clamped_counter;
+          Alcotest.test_case
+            "token usage emits GenAI OTel surface" `Quick
+            test_token_usage_emits_genai_otel_surface;
+          Alcotest.test_case
+            "usage details keep cache and reasoning out of token.type" `Quick
+            test_usage_details_emit_cache_reasoning_attrs_without_token_type_aliases;
+          Alcotest.test_case
+            "latency and streaming emit GenAI metrics" `Quick
+            test_latency_and_streaming_emit_genai_metrics;
+          Alcotest.test_case
+            "error records GenAI exception span signal" `Quick
+            test_error_records_genai_exception_span_signal;
           Alcotest.test_case "streaming callbacks emit OTel events" `Quick
             test_streaming_callbacks_emit_otel_events;
           Alcotest.test_case "request latency floors zero ms" `Quick


### PR DESCRIPTION
## Summary

- emit standard GenAI OTel client metrics from the LLM metric bridge:
  `gen_ai.client.token.usage`, operation duration, time-to-first-chunk, and per-output-chunk timing
- add span attr/status hooks plus GenAI operation-details and exception events for token usage, cache/reasoning details, streaming timing, and bounded errors
- keep cache/reasoning out of `gen_ai.token.type`; emit them as `gen_ai.usage.*` attributes instead
- update RFC-0214 to reflect the implemented support and the `tool.name` vs `gen_ai.tool.name` naming boundary

## Verification

- `ocamlformat --check lib/otel_spans/otel_spans.ml lib/otel_spans/otel_spans.mli lib/otel_genai/otel_genai.ml lib/otel_genai/otel_genai.mli lib/llm_metric_bridge.ml lib/llm_metric_bridge.mli lib/keeper/keeper_hooks_oas.ml test/test_llm_metric_bridge.ml`
- `git diff --check`
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=/private/tmp/masc-mcp-otel-complete-20260606 dune build --root . test/test_llm_metric_bridge.exe test/test_otel_tick_poison_source.exe test/test_otel_trace_context.exe test/test_otel_otlp_export_e2e.exe test/test_tool_input_validation.exe --display=quiet -j 1`
- `/private/tmp/masc-mcp-otel-complete-20260606/default/test/test_llm_metric_bridge.exe`
- `/private/tmp/masc-mcp-otel-complete-20260606/default/test/test_otel_tick_poison_source.exe`
- `/private/tmp/masc-mcp-otel-complete-20260606/default/test/test_otel_trace_context.exe`
- `/private/tmp/masc-mcp-otel-complete-20260606/default/test/test_tool_input_validation.exe`
- `/private/tmp/masc-mcp-otel-complete-20260606/default/test/test_otel_otlp_export_e2e.exe` outside sandbox because local bind is denied in sandbox

After the final `origin/main` rebase, `ocamlformat --check` and `git diff --check origin/main...HEAD` were re-run successfully. A final focused Dune rebuild was attempted but the local Dune process stayed in root-lock sleep; CI should provide the post-rebase build signal.

## References

- OpenTelemetry GenAI metrics: https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics/
- OpenTelemetry GenAI events: https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-events/
- OpenTelemetry GenAI exceptions: https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-exceptions/
- OpenTelemetry GenAI attribute registry: https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/
- OpenTelemetry MCP semantic conventions: https://opentelemetry.io/docs/specs/semconv/gen-ai/mcp/
