### PR TITLE
fix(keeper): apply prompt profile defaults to blank live meta

### DIFF
--- a/lib/dashboard/dashboard_http_keeper_snapshot.ml
+++ b/lib/dashboard/dashboard_http_keeper_snapshot.ml
@@ -173,6 +173,25 @@ let keeper_config_json (config : Workspace.config) (name : string)
                | None -> None)
           m.active_goal_ids
       in
+      let default_prompt_string default live =
+        match default with
+        | Some value when String.trim live = "" -> value
+        | _ -> live
+      in
+      let prompt_goal = default_prompt_string defaults.goal m.goal in
+      let prompt_short_goal =
+        default_prompt_string defaults.short_goal m.short_goal
+      in
+      let prompt_mid_goal = default_prompt_string defaults.mid_goal m.mid_goal in
+      let prompt_long_goal =
+        default_prompt_string defaults.long_goal m.long_goal
+      in
+      let prompt_will = default_prompt_string defaults.will m.will in
+      let prompt_needs = default_prompt_string defaults.needs m.needs in
+      let prompt_desires = default_prompt_string defaults.desires m.desires in
+      let prompt_instructions =
+        default_prompt_string defaults.instructions m.instructions
+      in
       let active_goal_ids_json =
         `List (List.map (fun goal_id -> `String goal_id) m.active_goal_ids)
       in
@@ -217,23 +236,28 @@ let keeper_config_json (config : Workspace.config) (name : string)
       in
       let effective_system_prompt =
         Keeper_prompt.build_keeper_system_prompt
-          ~goal:m.goal ~short_goal:m.short_goal ~mid_goal:m.mid_goal
-          ~long_goal:m.long_goal ~will:m.will
-          ~needs:m.needs ~desires:m.desires ~instructions:m.instructions
+          ~goal:prompt_goal
+          ~short_goal:prompt_short_goal
+          ~mid_goal:prompt_mid_goal
+          ~long_goal:prompt_long_goal
+          ~will:prompt_will
+          ~needs:prompt_needs
+          ~desires:prompt_desires
+          ~instructions:prompt_instructions
           ~persona_extended ~keeper_name:m.name
           ~active_goals
           ()
       in
       let prompt =
         `Assoc [
-          ("goal", `String m.goal);
-          ("short_goal", `String m.short_goal);
-          ("mid_goal", `String m.mid_goal);
-          ("long_goal", `String m.long_goal);
-          ("will", `String m.will);
-          ("needs", `String m.needs);
-          ("desires", `String m.desires);
-          ("instructions", `String m.instructions);
+          ("goal", `String prompt_goal);
+          ("short_goal", `String prompt_short_goal);
+          ("mid_goal", `String prompt_mid_goal);
+          ("long_goal", `String prompt_long_goal);
+          ("will", `String prompt_will);
+          ("needs", `String prompt_needs);
+          ("desires", `String prompt_desires);
+          ("instructions", `String prompt_instructions);
           ( "system_prompt_blocks",
             `Assoc
               [

--- a/lib/keeper/keeper_run_context.ml
+++ b/lib/keeper/keeper_run_context.ml
@@ -141,10 +141,10 @@ let prepare_run_context
   in
   let base_system_prompt =
     Keeper_prompt.build_keeper_system_prompt
-      ~goal:meta.goal
-      ~short_goal:meta.short_goal
-      ~mid_goal:meta.mid_goal
-      ~long_goal:meta.long_goal
+      ~goal:(Option.value profile_defaults.goal ~default:meta.goal)
+      ~short_goal:(Option.value profile_defaults.short_goal ~default:meta.short_goal)
+      ~mid_goal:(Option.value profile_defaults.mid_goal ~default:meta.mid_goal)
+      ~long_goal:(Option.value profile_defaults.long_goal ~default:meta.long_goal)
       ~will:(Option.value profile_defaults.will ~default:meta.will)
       ~needs:(Option.value profile_defaults.needs ~default:meta.needs)
       ~desires:(Option.value profile_defaults.desires ~default:meta.desires)

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -54,28 +54,64 @@ let maybe_string_option_override =
 let live_override_details (meta : keeper_meta) (defaults : keeper_profile_defaults)
   : override_field_detail list
   =
+  let default_string default live =
+    match default with
+    | Some value when String.trim live = "" -> value
+    | _ -> live
+  in
+  let default_string_list default live =
+    match default, live with
+    | Some values, [] -> values
+    | _, values -> values
+  in
+  let default_nonempty_string_list default live =
+    match default, live with
+    | values, [] when values <> [] -> values
+    | _, values -> values
+  in
   let effective_runtime_id = effective_declarative_runtime_id defaults meta in
   []
   |> maybe_string_override
        "prompt.goal"
        ~normalize:normalize_goal_horizon_text
        defaults.goal
-       meta.goal
-  |> maybe_string_override "prompt.short_goal" defaults.short_goal meta.short_goal
-  |> maybe_string_override "prompt.mid_goal" defaults.mid_goal meta.mid_goal
-  |> maybe_string_override "prompt.long_goal" defaults.long_goal meta.long_goal
-  |> maybe_string_override "prompt.will" defaults.will meta.will
-  |> maybe_string_override "prompt.needs" defaults.needs meta.needs
-  |> maybe_string_override "prompt.desires" defaults.desires meta.desires
-  |> maybe_string_override "prompt.instructions" defaults.instructions meta.instructions
+       (default_string defaults.goal meta.goal)
+  |> maybe_string_override
+       "prompt.short_goal"
+       defaults.short_goal
+       (default_string defaults.short_goal meta.short_goal)
+  |> maybe_string_override
+       "prompt.mid_goal"
+       defaults.mid_goal
+       (default_string defaults.mid_goal meta.mid_goal)
+  |> maybe_string_override
+       "prompt.long_goal"
+       defaults.long_goal
+       (default_string defaults.long_goal meta.long_goal)
+  |> maybe_string_override
+       "prompt.will"
+       defaults.will
+       (default_string defaults.will meta.will)
+  |> maybe_string_override
+       "prompt.needs"
+       defaults.needs
+       (default_string defaults.needs meta.needs)
+  |> maybe_string_override
+       "prompt.desires"
+       defaults.desires
+       (default_string defaults.desires meta.desires)
+  |> maybe_string_override
+       "prompt.instructions"
+       defaults.instructions
+       (default_string defaults.instructions meta.instructions)
   |> nonempty_string_list_override
        "workspace.mention_targets"
        defaults.mention_targets
-       meta.mention_targets
+       (default_nonempty_string_list defaults.mention_targets meta.mention_targets)
   |> maybe_string_list_override
        "tools.tool_denylist"
        defaults.tool_denylist
-       meta.tool_denylist
+       (default_string_list defaults.tool_denylist meta.tool_denylist)
   |> (fun acc ->
   let runtime_id = runtime_id_of_meta meta in
   if effective_runtime_id <> runtime_id

--- a/test/test_keeper_status_bridge.ml
+++ b/test/test_keeper_status_bridge.ml
@@ -20,6 +20,43 @@ let blocker_of_summary summary =
   Keeper_status_bridge.runtime_blocker_surface_opt config (meta_with_summary summary)
 ;;
 
+let write_file path content =
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc content)
+;;
+
+let runtime_toml =
+  {|
+[runtime]
+default = "test_provider.test_model"
+
+[providers.test_provider]
+display-name = "Test Provider"
+protocol = "provider_d-http"
+endpoint = "http://127.0.0.1:1"
+
+[models.test_model]
+api-name = "test-model"
+max-context = 8192
+tools-support = true
+streaming = true
+
+[test_provider.test_model]
+is-default = true
+max-concurrent = 1
+|}
+;;
+
+let init_runtime_default_for_tests () =
+  let path = Filename.temp_file "keeper_status_bridge_runtime_" ".toml" in
+  write_file path runtime_toml;
+  match Runtime.init_default ~config_path:path with
+  | Ok () -> ()
+  | Error e -> Alcotest.failf "Runtime.init_default failed: %s" e
+;;
+
 let test_synthetic_idle_last_output_is_not_blocker () =
   let summary =
     "Decisions: [SYNTHETIC] Last output: No awaiting_verification tasks. \
@@ -39,6 +76,58 @@ let test_synthetic_no_visible_output_remains_blocker () =
     (Option.map (fun b -> b.Keeper_status_bridge.blocker_class) (blocker_of_summary summary))
 ;;
 
+let defaults_with_prompt_fields =
+  { Keeper_types_profile.empty_keeper_profile_defaults with
+    manifest_path = Some "/tmp/keeper.toml";
+    sandbox_profile = Some Keeper_types_profile_sandbox.Local;
+    goal = Some "toml goal";
+    short_goal = Some "toml short";
+    mid_goal = Some "toml mid";
+    long_goal = Some "toml long";
+    will = Some "toml will";
+    needs = Some "toml needs";
+    desires = Some "toml desires";
+    instructions = Some "toml instructions";
+    mention_targets = [ "toml-target" ];
+  }
+;;
+
+let test_empty_live_meta_does_not_mask_profile_defaults_as_overrides () =
+  init_runtime_default_for_tests ();
+  let meta =
+    { (meta_with_summary "") with
+      goal = "";
+      short_goal = "";
+      mid_goal = "";
+      long_goal = "";
+      will = "";
+      needs = "";
+      desires = "";
+      instructions = "";
+      mention_targets = [];
+    }
+  in
+  Alcotest.(check (list string))
+    "empty live prompt fields inherit TOML defaults without override drift"
+    []
+    (Keeper_status_bridge.live_override_fields meta defaults_with_prompt_fields)
+;;
+
+let test_nonempty_live_meta_still_reports_profile_override () =
+  init_runtime_default_for_tests ();
+  let meta =
+    { (meta_with_summary "") with
+      goal = "live goal";
+      will = "live will";
+      mention_targets = [ "live-target" ];
+    }
+  in
+  Alcotest.(check (list string))
+    "non-empty live prompt fields still surface as overrides"
+    [ "prompt.goal"; "prompt.will"; "workspace.mention_targets" ]
+    (Keeper_status_bridge.live_override_fields meta defaults_with_prompt_fields)
+;;
+
 let () =
   Alcotest.run
     "keeper_status_bridge"
@@ -53,6 +142,17 @@ let () =
             "no visible synthetic output remains blocker"
             `Quick
             test_synthetic_no_visible_output_remains_blocker;
+        ] );
+      ( "profile default override provenance",
+        [
+          Alcotest.test_case
+            "empty live self-model inherits TOML without drift"
+            `Quick
+            test_empty_live_meta_does_not_mask_profile_defaults_as_overrides;
+          Alcotest.test_case
+            "non-empty live self-model still reports override"
+            `Quick
+            test_nonempty_live_meta_still_reports_profile_override;
         ] );
     ]
 ;;


### PR DESCRIPTION
## Summary
- apply keeper profile defaults to goal horizons when building runtime system prompts
- show dashboard keeper config prompts using TOML defaults when persisted live meta fields are blank
- stop status provenance from treating blank live self-model fields as real overrides while preserving non-empty live override reporting

## Verification
- env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_codex_prompt_defaults dune build --root . test/test_keeper_status_bridge.exe
- ./_build_codex_prompt_defaults/default/test/test_keeper_status_bridge.exe
- env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_codex_prompt_defaults dune build --root . test/test_keeper_prompt_constitution_fallback.exe test/test_keeper_prompt_external.exe
- ./_build_codex_prompt_defaults/default/test/test_keeper_prompt_constitution_fallback.exe
- ./_build_codex_prompt_defaults/default/test/test_keeper_prompt_external.exe