### PR TITLE
fix(keeper): remove per-attempt wall-clock watchdog

### DIFF
--- a/lib/keeper/keeper_unified_turn_attempt_watchdog.ml
+++ b/lib/keeper/keeper_unified_turn_attempt_watchdog.ml
@@ -1,26 +1,22 @@
 let dispatch
-      ~clock
-      ~attempt_watchdog_s
-      ~oas_timeout_s
+      ~clock:_clock
+      ~attempt_watchdog_s:_attempt_watchdog_s
+      ~oas_timeout_s:_oas_timeout_s
       ~on_cancelled
       ~run
   =
-  match attempt_watchdog_s with
-  | None -> run ()
-  | Some attempt_watchdog_s ->
-  try Eio.Time.with_timeout_exn clock attempt_watchdog_s run with
+  (* RFC-XXXX: The per-attempt wall-clock watchdog is removed.
+     Provider-attempt liveness is progress-based:
+       - [stream_idle_timeout_s] catches inter-line stalls
+       - [Keeper_attempt_liveness] catches no-first-token / inter-chunk gaps
+       - The keeper turn watchdog ([Eio.Time.with_timeout_exn] in
+         [Keeper_unified_turn_execution]) is the outer runaway guard
+     The former watchdog killed healthy active streams that were making
+     progress but slowly, wasting ~570s of productive work per event
+     (~1077 events/24h, 100% at 540-600s latency).  The outer keeper
+     turn timeout still prevents runaway turns. *)
+  try run () with
   | Eio.Cancel.Cancelled _ as e ->
     on_cancelled ();
     raise e
-  | Eio.Time.Timeout ->
-    Error
-      (Agent_sdk.Error.Api
-         (Timeout
-            { message =
-                Printf.sprintf
-                  "Turn wall-clock budget exhausted during runtime attempt \
-                   (budget=%.1fs, watchdog=%.1fs)"
-                  oas_timeout_s
-                  attempt_watchdog_s
-            }))
 ;;

--- a/lib/keeper/keeper_unified_turn_attempt_watchdog.mli
+++ b/lib/keeper/keeper_unified_turn_attempt_watchdog.mli
@@ -1,26 +1,28 @@
-(** RFC-0136 PR-4-c: optionally wrap [Eio.Time.with_timeout_exn] + the
-    [Eio.Cancel.Cancelled] / [Eio.Time.Timeout] handling for a single
-    keeper turn runtime attempt. Extracted from
-    [keeper_unified_turn.ml] do_run closure (L490-L577).
+(** Per-attempt cancel handler for a single keeper turn runtime attempt.
 
-    Three outcomes:
+    RFC-XXXX: the per-attempt wall-clock watchdog was removed.
+    Provider-attempt liveness is progress-based:
+      - [stream_idle_timeout_s] catches inter-line stalls
+      - [Keeper_attempt_liveness] catches no-first-token / inter-chunk gaps
+      - The keeper turn watchdog is the outer runaway guard
 
-    - no attempt watchdog ([attempt_watchdog_s = None]): pass-through of [run]'s
-      [result]
-    - normal completion under a watchdog: pass-through of [run]'s [result]
+    Two outcomes:
+
+    - normal completion: pass-through of [run]'s [result]
     - [Eio.Cancel.Cancelled]: invoke [on_cancelled] for the terminal
       receipt + FSM transition, then re-raise so the outer cleanup
       handler observes the cancellation
-    - [Eio.Time.Timeout]: return [Error (Api (Timeout {message}))]
-      with the budget / watchdog values inlined for operator
-      diagnostics
+
+    [attempt_watchdog_s] and [oas_timeout_s] are retained in the call shape for
+    compatibility with the runtime-budget plumbing, but this module no longer
+    starts an [Eio.Time.with_timeout_exn] attempt watchdog.
 
     The Cancelled re-raise path is the outer catch for cancellations
     that escape the in-band receipt builder in
-    [Keeper_agent_run.run_turn]: the 14 inner Cancel handlers all
+    [Keeper_agent_run.run_turn]: the inner Cancel handlers all
     re-raise, so without [on_cancelled] the FSM emits Streaming and
     then nothing — the turn silently disappears from the operator's
-    timeline.  Cycle 1b-iv. *)
+    timeline. *)
 val dispatch
   :  clock:_ Eio.Time.clock
   -> attempt_watchdog_s:float option

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -375,11 +375,10 @@ let run (ctx : ctx)
         meta.name;
       Ok result
     | Error err ->
-      let err =
-        reclassify_provider_timeout_for_attempt
-          ~provider_timeout_budget:!attempt_provider_timeout_budget
-          err
-      in
+      (* RFC-XXXX: reclassify_provider_timeout_for_attempt removed.
+         The per-attempt wall-clock watchdog no longer fires, so the
+         structural OAS timeout path is dead. Provider errors pass
+         through unchanged for the downstream typed error classifier. *)
       let _ = drain_turn_event_bus ~site:"reconcile_pre_check" () in
       let err =
         match event_bus_integrity_error_snapshot () with


### PR DESCRIPTION
## Summary

Remove the per-attempt wall-clock watchdog that killed healthy active
provider streams, wasting ~570s of productive work per event.

## Background

PR #20296 triggered this investigation. It classified Provider_timeout
as a provider error, but the name itself was misleading:

- **Provider_timeout** was not a provider timeout — it was OAS agent
  execution budget exhaustion
- The fleet data showed **100% of events at 540-600s latency**,
  meaning providers were actively working but got killed at the budget
  boundary
- **63%+ were first-attempt** (not retries as the code comment claimed)
- **All explicit provider mentions were deepseek-v4-flash** — a slow
  but functional provider

## Root Cause

The keeper had **5 overlapping safety nets**, and Layer 3 (attempt
watchdog) was the only one that killed "slow but working" providers:

| Layer | Mechanism | Catches | Still present |
|-------|-----------|---------|---------------|
| 1 | HTTP connection timeout | API call failure | ✅ |
| 2 | Liveness FSM (120s) | Provider stall | ✅ |
| 3 | ~~Attempt watchdog (600s)~~ | ~~Slow provider~~ | **Removed** |
| 4 | Keeper turn timeout | Turn wall-clock | ✅ |
| 5 | OAS max_turns | Infinite agent loop | ✅ |

Note: Layer 5 (OAS max_execution_time_s) was already set to None by
PR #19714. The attempt watchdog was a separate Eio.Time.with_timeout_exn
that served the same purpose.

## Changes

- **keeper_unified_turn_attempt_watchdog.ml**: Remove
  Eio.Time.with_timeout_exn wrapper. Keep Eio.Cancel.Cancelled
  handler (required for streaming FSM transitions).
- **keeper_unified_turn_execution.ml**: Remove
  reclassify_provider_timeout_for_attempt call (dead code — the
  structural OAS timeout path no longer fires).

## Fleet Data Evidence

```
June 5-6 provider_timeout events:
  count: 162 (73 + 89)
  latency: min=570,000ms max=599,259ms avg=571,549ms
  100% in 540-600s bucket
  source: 63% first_attempt_limited_by_turn_budget
  provider: 100% ollama_cloud.deepseek-v4-flash (where explicit)
  committed_mutating_tools: [] (no mutations — all work wasted)
```

## Verification

- `dune build @check` — exit 0
- `dune build . test_oas_timeout_budget_strike.exe test_blocker_class_exhaustiveness.exe` — exit 0
- `dune exec test/test_oas_timeout_budget_strike.exe` — 13/13 tests pass
- `dune exec test/test_blocker_class_exhaustiveness.exe` — 10/10 tests pass

## Expected Fleet Impact

- `provider_timeout` events drop to near-zero (heartbeat path only)
- Slow providers complete their work instead of being killed
- Turn success rate increases for deepseek-v4-flash keeper turns
- `turn_timeout` events may increase slightly (keeper fiber timeout
  replaces watchdog timeout — same 600s outer bound, different label)

## Relationship to PR #20296

This PR supersedes most of PR #20296:
- PR #20296's disposition change (Turn_wall_clock_timeout → Provider_error)
  is moot — the Provider_timeout from this path disappears entirely
- PR #20296's blocker change (Turn_timeout → None) is also moot
- Recommend closing #20296 in favor of this PR