### PR TITLE
fix(keeper): treat provider timeouts as liveness signals

### DIFF
--- a/lib/keeper/keeper_error_classify.mli
+++ b/lib/keeper/keeper_error_classify.mli
@@ -55,6 +55,14 @@ val post_commit_failure_kind_of_error :
     mutating tool call succeeded but the turn failed before a clean result. *)
 val is_ambiguous_side_effect_error : Agent_sdk.Error.sdk_error -> bool
 
+val ambiguous_side_effect_commit_tools :
+  tool_names:string list ->
+  Agent_sdk.Error.sdk_error -> string list
+
+val has_ambiguous_side_effect_commit :
+  tool_names:string list ->
+  Agent_sdk.Error.sdk_error -> bool
+
 (** [true] when a structured error indicates context overflow. *)
 val is_context_overflow : Agent_sdk.Error.sdk_error -> bool
 

--- a/lib/keeper/keeper_error_classify_post_commit.ml
+++ b/lib/keeper/keeper_error_classify_post_commit.ml
@@ -56,6 +56,37 @@ let is_ambiguous_side_effect_error (err : Agent_sdk.Error.sdk_error) : bool =
   | Some (Keeper_turn_driver.Internal_contract_rejected _) ->
       false
 
+let ambiguous_side_effect_error_tools (err : Agent_sdk.Error.sdk_error) =
+  match Keeper_turn_driver.classify_masc_internal_error err with
+  | Some (Keeper_turn_driver.Ambiguous_post_commit { tools; _ }) ->
+      committed_mutating_tools tools
+  | Some
+      ( Keeper_turn_driver.Runtime_exhausted _
+      | Keeper_turn_driver.Capacity_backpressure _
+      | Keeper_turn_driver.Accept_rejected _
+      | Keeper_turn_driver.Resumable_cli_session _
+      | Keeper_turn_driver.Admission_queue_rejected _
+      | Keeper_turn_driver.Admission_queue_timeout _
+      | Keeper_turn_driver.Turn_timeout _
+      | Keeper_turn_driver.Provider_timeout _
+      | Keeper_turn_driver.Max_tokens_ceiling_violation _
+      | Keeper_turn_driver.Retry_admission_denied _
+      | Keeper_turn_driver.Internal_unhandled_exception _
+      | Keeper_turn_driver.Internal_bridge_exception _
+      | Keeper_turn_driver.Internal_contract_rejected _ )
+  | None ->
+      []
+
+let ambiguous_side_effect_commit_tools ~(tool_names : string list)
+    (err : Agent_sdk.Error.sdk_error) : string list =
+  if not (is_ambiguous_side_effect_error err)
+  then []
+  else committed_mutating_tools (tool_names @ ambiguous_side_effect_error_tools err)
+
+let has_ambiguous_side_effect_commit ~(tool_names : string list)
+    (err : Agent_sdk.Error.sdk_error) : bool =
+  ambiguous_side_effect_commit_tools ~tool_names err <> []
+
 let reclassify_error_after_side_effect
     ~(tool_names : string list)
     (err : Agent_sdk.Error.sdk_error) : Agent_sdk.Error.sdk_error =

--- a/lib/keeper/keeper_error_classify_post_commit.mli
+++ b/lib/keeper/keeper_error_classify_post_commit.mli
@@ -4,6 +4,14 @@ val committed_mutating_tools : string list -> string list
 
 val is_ambiguous_side_effect_error : Agent_sdk.Error.sdk_error -> bool
 
+val ambiguous_side_effect_commit_tools :
+  tool_names:string list ->
+  Agent_sdk.Error.sdk_error -> string list
+
+val has_ambiguous_side_effect_commit :
+  tool_names:string list ->
+  Agent_sdk.Error.sdk_error -> bool
+
 val reclassify_error_after_side_effect :
   tool_names:string list ->
   Agent_sdk.Error.sdk_error -> Agent_sdk.Error.sdk_error

--- a/lib/keeper/keeper_status_bridge_blocker.ml
+++ b/lib/keeper/keeper_status_bridge_blocker.ml
@@ -42,7 +42,7 @@ let blocker_class_of_sdk_error (err : Agent_sdk.Error.sdk_error) : blocker_class
   | Some (Keeper_turn_driver.Admission_queue_timeout _) ->
     Some Admission_queue_wait_timeout
   | Some (Keeper_turn_driver.Admission_queue_rejected _) -> None
-  | Some (Keeper_turn_driver.Provider_timeout _) -> Some Turn_timeout
+  | Some (Keeper_turn_driver.Provider_timeout _) -> None
   | Some (Keeper_turn_driver.Max_tokens_ceiling_violation _) -> None
   | Some (Keeper_turn_driver.Turn_timeout _) -> Some Turn_timeout
   | Some (Keeper_turn_driver.Ambiguous_post_commit { is_timeout; _ }) ->

--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -114,6 +114,60 @@ let resolve_task_create_goal_id ~config ~(meta : keeper_meta) args =
        | _ :: _ :: _ -> Ok None)
 ;;
 
+let keeper_state_report_json ~(config : Workspace.config) ~(meta : keeper_meta) args =
+  match Keeper_memory_policy.keeper_state_snapshot_of_json args with
+  | None ->
+    Yojson.Safe.to_string
+      (`Assoc
+         [ "ok", `Bool true
+         ; "saved", `Bool false
+         ; "result", `String "No keeper state fields supplied."
+         ; "source", `String "keeper_report_state"
+         ])
+  | Some snapshot ->
+    let snapshot = Keeper_memory_policy.cap_snapshot snapshot in
+    let progress_snapshot = Keeper_memory_policy.forward_looking_snapshot snapshot in
+    let progress_path = Keeper_types_support.keeper_progress_path config meta.name in
+    (match
+       Keeper_memory_policy.write_progress_snapshot_path
+         ~path:progress_path
+         ~generation:meta.runtime.generation
+         ~updated_at:(now_iso ())
+         progress_snapshot
+     with
+     | Ok () ->
+       Yojson.Safe.to_string
+         (`Assoc
+            [ "ok", `Bool true
+            ; "saved", `Bool true
+            ; "source", `String "keeper_report_state"
+            ; ( "state_snapshot"
+              , Keeper_memory_policy.keeper_state_snapshot_to_json snapshot )
+            ; ( "progress_snapshot"
+              , Keeper_memory_policy.keeper_state_snapshot_to_json progress_snapshot )
+            ; "result", `String "State report saved."
+            ])
+     | Error err ->
+       Log.Keeper.warn
+         "keeper:%s report_state progress snapshot write failed: %s"
+         meta.name err;
+       Otel_metric_store.inc_counter
+         Keeper_metrics.(to_string SnapshotWriteFailures)
+         ~labels:[("keeper", meta.name)]
+         ();
+       error_json
+         ~fields:
+           [ "ok", `Bool false
+           ; "saved", `Bool false
+           ; "source", `String "keeper_report_state"
+           ; ( "failure_class"
+             , `String
+                 (Tool_result.tool_failure_class_to_string Tool_result.Runtime_failure)
+             )
+           ]
+         "State report save failed.")
+;;
+
 (* RFC-0034.v2: per-goal task creation cap moved to
    [Workspace_task_capacity] so all 5 task creation entrypoints share the
    same guard. Pre-RFC-0034.v2, these helpers (and the constant
@@ -489,6 +543,7 @@ let handle_keeper_task_tool
            ; "broadcast", `String message
            ; "typed_outcome", Keeper_tool_outcome.to_json Keeper_tool_outcome.Progress
            ]))
+    | State_report -> keeper_state_report_json ~config ~meta args
     | Task_create ->
     let title = Safe_ops.json_string ~default:"" "title" args |> String.trim in
     let description = Safe_ops.json_string ~default:"" "description" args |> String.trim in

--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -114,60 +114,6 @@ let resolve_task_create_goal_id ~config ~(meta : keeper_meta) args =
        | _ :: _ :: _ -> Ok None)
 ;;
 
-let keeper_state_report_json ~(config : Workspace.config) ~(meta : keeper_meta) args =
-  match Keeper_memory_policy.keeper_state_snapshot_of_json args with
-  | None ->
-    Yojson.Safe.to_string
-      (`Assoc
-         [ "ok", `Bool true
-         ; "saved", `Bool false
-         ; "result", `String "No keeper state fields supplied."
-         ; "source", `String "keeper_report_state"
-         ])
-  | Some snapshot ->
-    let snapshot = Keeper_memory_policy.cap_snapshot snapshot in
-    let progress_snapshot = Keeper_memory_policy.forward_looking_snapshot snapshot in
-    let progress_path = Keeper_types_support.keeper_progress_path config meta.name in
-    (match
-       Keeper_memory_policy.write_progress_snapshot_path
-         ~path:progress_path
-         ~generation:meta.runtime.generation
-         ~updated_at:(now_iso ())
-         progress_snapshot
-     with
-     | Ok () ->
-       Yojson.Safe.to_string
-         (`Assoc
-            [ "ok", `Bool true
-            ; "saved", `Bool true
-            ; "source", `String "keeper_report_state"
-            ; ( "state_snapshot"
-              , Keeper_memory_policy.keeper_state_snapshot_to_json snapshot )
-            ; ( "progress_snapshot"
-              , Keeper_memory_policy.keeper_state_snapshot_to_json progress_snapshot )
-            ; "result", `String "State report saved."
-            ])
-     | Error err ->
-       Log.Keeper.warn
-         "keeper:%s report_state progress snapshot write failed: %s"
-         meta.name err;
-       Otel_metric_store.inc_counter
-         Keeper_metrics.(to_string SnapshotWriteFailures)
-         ~labels:[("keeper", meta.name)]
-         ();
-       error_json
-         ~fields:
-           [ "ok", `Bool false
-           ; "saved", `Bool false
-           ; "source", `String "keeper_report_state"
-           ; ( "failure_class"
-             , `String
-                 (Tool_result.tool_failure_class_to_string Tool_result.Runtime_failure)
-             )
-           ]
-         "State report save failed.")
-;;
-
 (* RFC-0034.v2: per-goal task creation cap moved to
    [Workspace_task_capacity] so all 5 task creation entrypoints share the
    same guard. Pre-RFC-0034.v2, these helpers (and the constant
@@ -399,17 +345,44 @@ let task_op_of_name name =
   | None -> None
 ;;
 
-let state_report_result_json args =
-  let snapshot =
+let state_report_result_json ~(config : Workspace.config) ~(meta : keeper_meta) args =
+  let snapshot, has_state =
     match Keeper_memory_policy.structured_state_snapshot_schema.parse args with
-    | Ok snapshot -> snapshot
-    | Error _ -> Keeper_memory_policy.empty_keeper_state_snapshot
+    | Ok snapshot -> Keeper_memory_policy.cap_snapshot snapshot, true
+    | Error _ -> Keeper_memory_policy.empty_keeper_state_snapshot, false
+  in
+  let progress_snapshot = Keeper_memory_policy.forward_looking_snapshot snapshot in
+  let progress_snapshot_saved =
+    if not has_state
+    then false
+    else (
+      let progress_path = Keeper_types_support.keeper_progress_path config meta.name in
+      match
+        Keeper_memory_policy.write_progress_snapshot_path
+          ~path:progress_path
+          ~generation:meta.runtime.generation
+          ~updated_at:(now_iso ())
+          progress_snapshot
+      with
+      | Ok () -> true
+      | Error err ->
+        Log.Keeper.warn
+          "keeper:%s report_state progress snapshot write failed: %s"
+          meta.name err;
+        Otel_metric_store.inc_counter
+          Keeper_metrics.(to_string SnapshotWriteFailures)
+          ~labels:[("keeper", meta.name)]
+          ();
+        false)
   in
   Yojson.Safe.to_string
     (`Assoc
        [ "ok", `Bool true
        ; ( "state_snapshot"
          , Keeper_memory_policy.keeper_state_snapshot_to_json snapshot )
+       ; ( "progress_snapshot"
+         , Keeper_memory_policy.keeper_state_snapshot_to_json progress_snapshot )
+       ; "progress_snapshot_saved", `Bool progress_snapshot_saved
        ; "state_block", `String (Keeper_memory_policy.render_state_block snapshot)
        ; "typed_outcome", Keeper_tool_outcome.to_json Keeper_tool_outcome.Progress
        ])
@@ -543,7 +516,6 @@ let handle_keeper_task_tool
            ; "broadcast", `String message
            ; "typed_outcome", Keeper_tool_outcome.to_json Keeper_tool_outcome.Progress
            ]))
-    | State_report -> keeper_state_report_json ~config ~meta args
     | Task_create ->
     let title = Safe_ops.json_string ~default:"" "title" args |> String.trim in
     let description = Safe_ops.json_string ~default:"" "description" args |> String.trim in
@@ -791,7 +763,7 @@ let handle_keeper_task_tool
          match accountability_warning with
          | Some warning -> [ ("routing_warning", `String warning) ]
          | None -> []))
-    | State_report -> state_report_result_json args
+    | State_report -> state_report_result_json ~config ~meta args
     | Task_done ->
     let task_id = Safe_ops.json_string ~default:"" "task_id" args |> String.trim in
     let result_text = Safe_ops.json_string ~default:"" "result" args |> String.trim in

--- a/lib/keeper/keeper_turn_terminal.ml
+++ b/lib/keeper/keeper_turn_terminal.ml
@@ -78,7 +78,8 @@ let of_failure ?(post_commit_ambiguous = false) ?(tool_call_count = 0) ~raw_erro
     | Some (Keeper_turn_driver.Provider_timeout _) ->
       of_disposition
         ~source:"typed_error"
-        Keeper_turn_disposition.Turn_wall_clock_timeout
+        (Keeper_turn_disposition.Provider_error
+           (Keeper_turn_terminal_code.Provider_runtime_error "provider_timeout"))
     | Some (Keeper_turn_driver.Capacity_backpressure _) ->
       make ~source:"typed_error" "capacity_backpressure"
     | Some (Keeper_turn_driver.Runtime_exhausted _) ->

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -615,7 +615,12 @@ let run_keeper_cycle
                       | _ -> ()));
                   let is_server_parse_rejection = EC.is_server_rejected_parse_error err in
                   let is_auto_recoverable = EC.is_auto_recoverable_turn_error err in
-                  let is_ambiguous_partial = EC.is_ambiguous_side_effect_error err in
+                  let ambiguous_commit_tools =
+                    EC.ambiguous_side_effect_commit_tools
+                      ~tool_names:(committed_mutating_tools_snapshot ())
+                      err
+                  in
+                  let is_ambiguous_partial = ambiguous_commit_tools <> [] in
                   Otel_metric_store.inc_counter
                     Keeper_metrics.(to_string Turns)
                     ~labels:[ "keeper_name", meta.name; "outcome", "failure" ]
@@ -709,7 +714,7 @@ let run_keeper_cycle
                  The keeper is paused and an explicit continue gate is
                  raised for the operator. Approving the gate auto-resumes
                  the keeper; rejecting it leaves the keeper paused. *)
-                      let committed_tools = committed_mutating_tools_snapshot () in
+                      let committed_tools = ambiguous_commit_tools in
                       let turn_event_summary = turn_event_bus in
                       let failure_reason =
                         Option.value
@@ -856,7 +861,7 @@ dominant source of the observed CAS race exhaustion after
                       ~base_path:config.base_path
                       meta.name
                       (Some failure_reason);
-                    let committed_tools = committed_mutating_tools_snapshot () in
+                    let committed_tools = ambiguous_commit_tools in
                     let turn_event_summary = turn_event_bus in
                     Log.Keeper.info
                       "%s: reconcile-required failure latched as %s after \

--- a/test/test_blocker_class_exhaustiveness.ml
+++ b/test/test_blocker_class_exhaustiveness.ml
@@ -134,6 +134,7 @@ let test_variant_count () =
 module SdkE = Agent_sdk.Error
 module SdkRetry = Agent_sdk.Retry
 module KSB = Masc.Keeper_status_bridge_blocker
+module KTD = Masc.Keeper_turn_driver
 module Reg = Masc.Keeper_registry
 
 (** Every [Agent_sdk.Error.Agent _] sub-variant must map to a [Some blocker_class]
@@ -238,6 +239,27 @@ let test_structural_timeout_maps_to_oas_timeout () =
   | None -> fail "structural timeout should map to Some blocker_class"
 ;;
 
+let test_provider_timeout_is_not_runtime_blocker () =
+  let provider_timeout =
+    KTD.sdk_error_of_masc_internal_error
+      (KTD.Provider_timeout
+         { budget_sec = 555.0
+         ; keeper_turn_timeout_sec = 600.0
+         ; estimated_input_tokens = 4302
+         ; source = "first_attempt_limited_by_turn_budget"
+         ; remaining_turn_budget_sec = Some 45.0
+         ; min_required_sec = 15.0
+         ; phase = "runtime_attempt_watchdog"
+         })
+  in
+  match KSB.blocker_class_of_sdk_error provider_timeout with
+  | None -> ()
+  | Some klass ->
+    failf
+      "provider timeout should remain a provider liveness signal, got blocker_class %S"
+      (blocker_class_to_string klass)
+;;
+
 (* ── Provider runtime record classification ────────────────────── *)
 
 let provider_runtime_surface_exn
@@ -330,6 +352,8 @@ let () =
         ; test_case "Agent variant count pin" `Quick test_agent_variant_count_pin
         ; test_case "structural timeout → oas_agent_execution_timeout" `Quick
             test_structural_timeout_maps_to_oas_timeout
+        ; test_case "provider timeout is not a runtime blocker" `Quick
+            test_provider_timeout_is_not_runtime_blocker
         ] )
     ; ( "provider_runtime_record"
       , [ test_case "typed reason falls through" `Quick

--- a/test/test_keeper_turn_disposition.ml
+++ b/test/test_keeper_turn_disposition.ml
@@ -22,6 +22,7 @@
 module D = Masc.Keeper_turn_disposition
 module Code = Masc.Keeper_turn_terminal_code
 module Legacy = Masc.Keeper_turn_terminal
+module KTD = Masc.Keeper_turn_driver
 module Registry = Masc.Keeper_registry
 module Unified_types = Masc.Keeper_unified_turn_types
 
@@ -242,6 +243,34 @@ let test_projection () =
     runtime_codes_to_projection
 ;;
 
+let test_provider_timeout_terminal_is_provider_error () =
+  let err =
+    KTD.sdk_error_of_masc_internal_error
+      (KTD.Provider_timeout
+         { budget_sec = 555.0
+         ; keeper_turn_timeout_sec = 600.0
+         ; estimated_input_tokens = 4302
+         ; source = "first_attempt_limited_by_turn_budget"
+         ; remaining_turn_budget_sec = Some 45.0
+         ; min_required_sec = 15.0
+         ; phase = "runtime_attempt_watchdog"
+         })
+  in
+  let terminal =
+    Legacy.of_failure
+      ~raw_error:(Agent_sdk.Error.to_string err)
+      err
+  in
+  Alcotest.(check string)
+    "provider timeout terminal code"
+    "provider_timeout"
+    (Legacy.code terminal);
+  Alcotest.(check string)
+    "provider timeout disposition"
+    "provider_timeout"
+    (D.to_wire terminal.disposition)
+;;
+
 let check_runtime_failure_reason raw_error expected_code =
   let terminal = Legacy.of_code raw_error in
   match Unified_types.registry_failure_reason_of_terminal_reason terminal ~raw_error with
@@ -317,6 +346,10 @@ let () =
             "every runtime variant projects deterministically"
             `Quick
             test_projection
+        ; Alcotest.test_case
+            "provider timeout is provider error, not turn wall-clock"
+            `Quick
+            test_provider_timeout_terminal_is_provider_error
         ] )
     ; ( "registry failure reason"
       , [ Alcotest.test_case

--- a/test/test_oas_timeout_budget_strike.ml
+++ b/test/test_oas_timeout_budget_strike.ml
@@ -75,6 +75,19 @@ let provider_timeout_error ~phase =
 let turn_timeout_error () =
   KTD.sdk_error_of_masc_internal_error (KTD.Turn_timeout { elapsed_sec = 600.0 })
 
+let ambiguous_post_commit_error () =
+  KTD.sdk_error_of_masc_internal_error
+    (KTD.Ambiguous_post_commit
+       { is_timeout = true
+       ; tools = [ "keeper_board_post" ]
+       ; original_error = "provider timeout after board post"
+       })
+
+let legacy_ambiguous_internal_error () =
+  Agent_sdk.Error.Internal
+    "turn outcome ambiguous after committed mutating tool call(s): []; \
+     original_error=provider_timeout"
+
 let tls_handshake_internal_error () =
   KTD.sdk_error_of_masc_internal_error
     (KTD.Internal_unhandled_exception
@@ -191,6 +204,26 @@ let test_provider_timeout_is_not_ambiguous_side_effect () =
     (EC.is_ambiguous_side_effect_error
        (provider_timeout_error ~phase:"runtime_attempt_watchdog"))
 
+let test_ambiguous_gate_requires_committed_tool_evidence () =
+  Alcotest.(check bool)
+    "provider timeout has no ambiguous commit evidence"
+    false
+    (EC.has_ambiguous_side_effect_commit
+       ~tool_names:[]
+       (provider_timeout_error ~phase:"runtime_attempt_watchdog"));
+  Alcotest.(check bool)
+    "legacy ambiguous string without committed tools has no gate evidence"
+    false
+    (EC.has_ambiguous_side_effect_commit
+       ~tool_names:[]
+       (legacy_ambiguous_internal_error ()));
+  Alcotest.(check (list string))
+    "structured ambiguous error carries mutating tool evidence"
+    [ "keeper_board_post" ]
+    (EC.ambiguous_side_effect_commit_tools
+       ~tool_names:[]
+       (ambiguous_post_commit_error ()))
+
 let test_turn_timeout_is_not_ambiguous_side_effect () =
   Alcotest.(check bool)
     "turn timeout is not ambiguous without committed tools"
@@ -290,6 +323,10 @@ let () =
           "provider timeout is not ambiguous partial commit"
           `Quick
           test_provider_timeout_is_not_ambiguous_side_effect;
+        Alcotest.test_case
+          "ambiguous gate requires committed tool evidence"
+          `Quick
+          test_ambiguous_gate_requires_committed_tool_evidence;
         Alcotest.test_case
           "turn timeout is not ambiguous partial commit"
           `Quick


### PR DESCRIPTION
Supersedes closed/unmerged #20296.

## Summary

- wire `keeper_report_state` through the runtime task surface
- classify provider timeouts as provider/runtime liveness, not turn wall-clock failure
- make report-state cache writes nonfatal so reporting cannot block turn progress

## Verification

Post-rebase on `origin/main` at `ece28a2c77`:

- `git diff --check origin/main...HEAD`
- `ocamlformat --enable-outside-detected-project --check lib/keeper/keeper_error_classify.mli lib/keeper/keeper_error_classify_post_commit.ml lib/keeper/keeper_error_classify_post_commit.mli lib/keeper/keeper_status_bridge_blocker.ml lib/keeper/keeper_tool_task_runtime.ml lib/keeper/keeper_turn_terminal.ml lib/keeper/keeper_unified_turn.ml test/test_blocker_class_exhaustiveness.ml test/test_keeper_turn_disposition.ml test/test_oas_timeout_budget_strike.ml`

Local Dune status:

- `scripts/dune-local.sh build test/test_blocker_class_exhaustiveness.exe test/test_keeper_turn_disposition.exe test/test_oas_timeout_budget_strike.exe` was blocked by an existing bare `dune build --root .` process (`dune-local` exit 75).
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-pr20318-rebase dune build --root . test/test_blocker_class_exhaustiveness.exe test/test_keeper_turn_disposition.exe test/test_oas_timeout_budget_strike.exe --display=short -j 1` was attempted after rebase, but local opam/CMI state failed with repeated `Agent_sdk_base__Types` interface mismatch between local build artifacts and `/Users/dancer/.opam/5.4.1/lib/agent_sdk/agent_sdk.cmi`.

GitHub CI is the authoritative post-push build surface for head `92bf9ff258`.
