### PR TITLE
fix(keeper): avoid autonomous fifo head blocking

### DIFF
--- a/docs/BOOT-ENV-STATE-INVENTORY.md
+++ b/docs/BOOT-ENV-STATE-INVENTORY.md
@@ -142,7 +142,7 @@ canonical process env var is already set.
 ```toml
 [autonomous]
 max_turns_per_call = 7           # default: 2
-semaphore_wait_timeout_sec = 150 # default: 60
+semaphore_wait_timeout_sec = 150 # default: 180
 
 [reactive]
 max_turns_per_call = 15

--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -575,6 +575,14 @@ let with_keeper_turn_slot_control ?(runtime_profile = "unknown") ~keeper_name ~c
         with
         | Error _ as e -> e
         | Ok () ->
+          (* The FIFO should order admission into the semaphore wait queue,
+             not hold the queue head hostage while this fiber waits for an
+             autonomous permit. Once we are at the head, drop the ticket
+             before [acquire_bounded] so tail keepers can also enter the
+             semaphore wait queue instead of burning their whole
+             queue-head timeout behind one slow head waiter. *)
+          drop_autonomous_waiter ~ticket;
+          slot_state.autonomous_ticket := None;
           (match
              acquire_bounded
                ~label:Autonomous_pool
@@ -602,8 +610,6 @@ let with_keeper_turn_slot_control ?(runtime_profile = "unknown") ~keeper_name ~c
                  ~acquired_at:(Time_compat.now ())
              in
              slot_state.autonomous_acquisition_id := Some acquisition_id;
-             drop_autonomous_waiter ~ticket;
-             slot_state.autonomous_ticket := None;
              Ok ()))
       else Ok ()
     in

--- a/lib/keeper_runtime/keeper_runtime_config.mli
+++ b/lib/keeper_runtime/keeper_runtime_config.mli
@@ -61,7 +61,7 @@ val resolve_overrides :
     {[
       [autonomous]
       max_turns_per_call          = 7
-      semaphore_wait_timeout_sec  = 60
+      semaphore_wait_timeout_sec  = 180
       concurrency                 = 3
 
       [reactive]

--- a/test/test_keeper_semaphore_wait_queue_head_clock.ml
+++ b/test/test_keeper_semaphore_wait_queue_head_clock.ml
@@ -95,6 +95,36 @@ let test_fresh_started_at_at_head_returns_ok () =
         Alcotest.fail
           "expected Ok when this is the only waiter and clock is fresh")
 
+let test_autonomous_ticket_dropped_before_semaphore_acquire_hook () =
+  Eio_main.run @@ fun _env ->
+  Keeper_turn_slot.reset_autonomous_turn_queue_for_test ();
+  let observed_queue = ref None in
+  Keeper_turn_slot.set_after_acquire_flag_hook_for_test
+    (Some
+       (fun ~label ~keeper_name ->
+          if String.equal label "autonomous" && String.equal keeper_name "ours"
+          then
+            observed_queue
+            := Some (Keeper_turn_slot.autonomous_waiter_snapshot_for_test ())));
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_turn_slot.set_after_acquire_flag_hook_for_test None;
+      Keeper_turn_slot.reset_autonomous_turn_queue_for_test ())
+    (fun () ->
+       (match
+          Keeper_turn_slot.with_keeper_turn_slot_control_for_test
+            ~keeper_name:"ours"
+            ~channel:Keeper_world_observation.Scheduled_autonomous
+            (fun ~semaphore_wait_ms:_ ~slot_control:_ -> ())
+        with
+        | Ok () -> ()
+        | Error (`Semaphore_wait_timeout _) ->
+          Alcotest.fail "unexpected semaphore wait timeout");
+       Alcotest.(check (option (list string)))
+         "ticket is no longer in FIFO by autonomous acquire hook"
+         (Some [])
+         !observed_queue)
+
 let () =
   Alcotest.run
     "keeper_semaphore_wait_queue_head_clock"
@@ -107,6 +137,10 @@ let () =
             "fresh started_at at head returns Ok"
             `Quick
             test_fresh_started_at_at_head_returns_ok
+        ; Alcotest.test_case
+            "autonomous FIFO only gates entry into semaphore wait"
+            `Quick
+            test_autonomous_ticket_dropped_before_semaphore_acquire_hook
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- Drop autonomous FIFO ticket immediately after reaching queue head, before waiting on the autonomous semaphore
- Add regression coverage proving the FIFO no longer stays populated during semaphore acquire
- Align stale 60s docs/examples with the current 180s default

## Tests
- ocamlformat --enable-outside-detected-project --check lib/keeper/keeper_turn_slot.ml lib/keeper_runtime/keeper_runtime_config.mli test/test_keeper_semaphore_wait_queue_head_clock.ml
- git diff --check
- env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-fifo-hol dune build --root . test/test_keeper_semaphore_wait_queue_head_clock.exe --display=short -j 1
- _build-codex-fifo-hol/default/test/test_keeper_semaphore_wait_queue_head_clock.exe

Note: scripts/dune-local.sh build test/test_keeper_semaphore_wait_queue_head_clock.exe returned exit 75 because other bare Dune processes were already running; the focused Dune build above used an isolated build dir.