### PR TITLE
feat(keeper): remove sandbox repo patrol gates (RFC-0219)

### DIFF
--- a/docs/rfc/RFC-0219-remove-sandbox-repo-gates.md
+++ b/docs/rfc/RFC-0219-remove-sandbox-repo-gates.md
@@ -1,0 +1,95 @@
+# RFC-0219: Remove Sandbox Repo Patrol Gates
+
+**Status**: Draft
+**Date**: 2026-06-06
+**Author**: Vincent + Claude
+**Subsystem**: `lib/keeper/keeper_sandbox_repo_lifecycle.ml`, `lib/keeper/keeper_tool_execute_runtime.ml`
+
+## Problem
+
+Keeper Execute pipeline has a set of "repo patrol" gates that pre-emptively
+block commands when the sandbox repo checkout is not in an ideal state. These
+gates cause deadlocks: the keeper cannot fix the problem because the fix
+itself (e.g. `git pull`) requires Execute, which is blocked.
+
+Observed failure (keeper:garnet 2026-06-06):
+- Sandbox repo `repos/masc` was 445 commits behind `origin/main`
+- `ensure_current` returned `Preserved "uncommitted changes in the working tree"`
+  (false positive — repo was actually clean, just behind)
+- Every Execute was blocked with `sandbox_repo_stale`
+- 5 identical retries → threshold-silence → circuit breaker trip
+- Keeper fully paralyzed; required manual `git pull` by operator
+
+## Gates to Remove
+
+### 1. `sandbox_repo_stale` (validate_cwd_sync_ready)
+
+**File**: `keeper_sandbox_repo_lifecycle.ml:198-234`
+
+Checks if sandbox repo is current with origin. Blocks Execute when:
+- Behind (uncommitted changes, even if false positive)
+- On task branch (not default branch)
+- Detached HEAD
+- Diverged
+- Fast-forward refused
+
+**Why remove**: Keeper can `git pull` / `git checkout main` / `git rebase`
+itself. The gate creates a deadlock where the keeper cannot self-heal.
+
+### 2. `sandbox_repo_sync_disabled` (Reject_repo_sync path)
+
+**File**: `keeper_sandbox_repo_lifecycle.ml:89-98`
+
+When keeper is readonly, refuses to even fetch/fast-forward the sandbox.
+
+**Why remove**: Readonly keepers still need current code to read. `git fetch`
++ `git ff-only` is a read operation.
+
+### 3. `sandbox_repo_not_ready` / `sandbox_worktree_not_ready` (validate_repo_path_ready)
+
+**File**: `keeper_sandbox_repo_lifecycle.ml:119-196`
+
+Pre-validates that cwd/path args are valid git checkouts.
+
+**Why remove**: The command itself will fail with a clear git error if the
+path isn't a checkout. Pre-validation adds latency and false positives
+without adding safety — the failure mode is identical either way.
+
+## Gates to Keep
+
+| Gate | Reason |
+|------|--------|
+| **Destructive operation** (`is_destructive`) | Prevents `rm -rf`, force-push, etc. |
+| **Write operation gated** (`write_enabled`) | Policy: readonly vs write-capable surfaces |
+
+These are safety-critical and do not cause deadlocks.
+
+## Proposed Change
+
+Remove the `before_path_validation` callback that calls
+`validate_cwd_ready` and `validate_path_args_ready`. The callback is the
+sole call site for repo patrol gates.
+
+Keep `Playground_repo_readiness.ensure_current` available as a utility
+for future "keeper self-sync" tools, but do not gate Execute on it.
+
+### Files Changed
+
+- `lib/keeper/keeper_tool_execute_runtime.ml` — remove `before_path_validation` callback
+- `lib/keeper/keeper_sandbox_repo_lifecycle.ml` — remove error constructors, keep types for backward compat
+- `lib/playground_repo_readiness.ml` — keep `ensure_current` (may be used by future keeper self-sync)
+
+### Migration
+
+No migration needed. The gates produce Error results that block Execute;
+removing them simply lets commands through to run (and fail naturally if
+the repo is genuinely broken).
+
+## Impact
+
+- **Keeper autonomy**: Keepers can self-heal stale repos via `git pull`
+- **Reduced operator burden**: No more manual sandbox sync
+- **Risk**: A keeper might work against stale code briefly before noticing.
+  This is acceptable — the keeper will detect version mismatch from error
+  messages or test failures and pull.
+- **Latency**: Removes 2-3 git probe subprocess calls per Execute invocation

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -580,9 +580,6 @@ let handle_tool_execute_typed
         let is_direct_repo_git_recovery =
           is_direct_sandbox_repo_root && is_git_recovery_command
         in
-        let allow_stale_preserved_repo_context =
-          is_git_diagnostic_command || is_direct_repo_git_recovery
-        in
         let readonly_write_like =
           is_git_recovery_command
           || Masc_exec.Shell_ir_risk.is_r1 envelope
@@ -620,29 +617,6 @@ let handle_tool_execute_typed
           let t0 = Unix.gettimeofday () in
           let dispatch_result =
             Keeper_tool_execute_shell_ir.dispatch_classified
-              ~before_path_validation:(fun ir ->
-                let repo_sync_policy =
-                  if write_enabled
-                  then
-                    Keeper_sandbox_repo_lifecycle.Allow_repo_sync
-                  else
-                    Keeper_sandbox_repo_lifecycle.Reject_repo_sync
-                in
-                match
-                  Keeper_sandbox_repo_lifecycle.validate_cwd_ready
-                    ~config
-                    ~meta
-                    ~cwd
-                    ~repo_sync_policy
-                    ~allow_stale_preserved_repo_context
-                with
-                | Error _ as err -> err
-                | Ok () ->
-                  Keeper_sandbox_repo_lifecycle.validate_path_args_ready
-                    ~config
-                    ~meta
-                    ~cwd
-                    ir)
               ~allowed_commands
               ~keeper_id:meta.name
               ~base_path:root


### PR DESCRIPTION
## RFC-0219: Remove Sandbox Repo Patrol Gates

### Problem

Keeper Execute pipeline has "repo patrol" gates that pre-emptively block commands when the sandbox repo is behind, on a task branch, or has uncommitted changes. These gates cause deadlocks: the keeper cannot self-heal because the fix (e.g. `git pull`) also requires Execute.

Observed: keeper:garnet fully paralyzed by `sandbox_repo_stale` → 5 retries → threshold-silence → circuit breaker trip. Required manual `git pull` by operator.

### Change

Remove `before_path_validation` callback from Execute dispatch. This was the sole call site for:

- `sandbox_repo_stale` — repo behind/preserved
- `sandbox_repo_sync_disabled` — readonly keeper fetch blocked
- `sandbox_repo_not_ready` — path not valid git checkout
- `sandbox_worktree_not_ready` — worktree path invalid

### Kept

- **Destructive operation gate** (`is_destructive`) — blocks `rm -rf` etc.
- **Write operation gate** (`write_enabled`) — readonly vs write-capable policy

### Reasoning

Keepers are autonomous agents. They can `git pull`, `git checkout main`, `git rebase` themselves. Pre-emptive gating that blocks the very tool needed for self-repair creates deadlocks, not safety.

If the repo is genuinely broken, the git command will fail with a clear error — identical failure mode with or without the gate.

### Files

- `lib/keeper/keeper_tool_execute_runtime.ml` — 26 lines removed (callback + unused variable)
- `docs/rfc/RFC-0219-remove-sandbox-repo-gates.md` — RFC document

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
