### PR TITLE
fix(discord): preserve queued chat connector context

### DIFF
--- a/lib/keeper/keeper_chat_queue.mli
+++ b/lib/keeper/keeper_chat_queue.mli
@@ -6,15 +6,11 @@
 
     The queue is transient (not persisted).  Lost on server restart.
 
-    NOTE: Queue drain is currently coupled to the HTTP request
-    lifecycle in [Server_routes_http_keeper_stream].  External
-    connectors (Discord, Slack, etc.) that enqueue messages here
-    will not see them auto-drained unless a Dashboard HTTP request
-    also arrives for the same keeper.  See RFC-0217 §Future Work.
-
-    TODO: Add [source] field to [queued_message] for multi-channel
-    delivery, and extract the consumer from the HTTP handler into a
-    standalone polling fiber.
+    Queue drain is handled by [Keeper_chat_consumer], started from
+    server bootstrap.  The [source] field preserves connector context
+    so queued dashboard, Discord, and Slack messages can be projected
+    into the same keeper-chat execution path without losing reply
+    routing metadata.
 
     @since 2.145.0 *)
 

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -106,9 +106,81 @@ let board_sse_event_params event =
       ]
 ;;
 
+type queued_chat_projection = {
+  payload_channel : string;
+  payload_channel_user_id : string;
+  payload_channel_user_name : string;
+  payload_channel_workspace_id : string;
+  agent_name : string;
+}
+
+let discord_channel_label = "discord"
+
+let queued_chat_projection (queued_message : Keeper_chat_queue.queued_message) =
+  match queued_message.source with
+  | Keeper_chat_queue.Dashboard ->
+    {
+      payload_channel = "";
+      payload_channel_user_id = "";
+      payload_channel_user_name = "";
+      payload_channel_workspace_id = "";
+      agent_name = "dashboard";
+    }
+  | Keeper_chat_queue.Discord { channel_id; user_id } ->
+    {
+      payload_channel = discord_channel_label;
+      payload_channel_user_id = user_id;
+      payload_channel_user_name = "";
+      payload_channel_workspace_id = channel_id;
+      agent_name =
+        Gate_keeper_backend.agent_name_for_channel_actor
+          ~channel:discord_channel_label
+          ~channel_workspace_id:channel_id
+          ~channel_user_id:user_id;
+    }
+  | Keeper_chat_queue.Slack { channel; user_id } ->
+    {
+      payload_channel = channel;
+      payload_channel_user_id = user_id;
+      payload_channel_user_name = "";
+      payload_channel_workspace_id = "";
+      agent_name =
+        Gate_keeper_backend.agent_name_for_channel_actor
+          ~channel
+          ~channel_workspace_id:""
+          ~channel_user_id:user_id;
+    }
+
+let trimmed_env_opt name =
+  match Sys.getenv_opt name with
+  | None -> None
+  | Some raw ->
+    let trimmed = String.trim raw in
+    if String.equal trimmed "" then None else Some trimmed
+
+let discord_bot_token_opt () = trimmed_env_opt "DISCORD_BOT_TOKEN"
+
 module For_testing = struct
+  type queued_chat_projection = {
+    payload_channel : string;
+    payload_channel_user_id : string;
+    payload_channel_user_name : string;
+    payload_channel_workspace_id : string;
+    agent_name : string;
+  }
+
   let autoboot_proactive_warmup_sec = autoboot_proactive_warmup_sec
   let board_sse_event_params = board_sse_event_params
+
+  let queued_chat_projection queued_message : queued_chat_projection =
+    let projection = queued_chat_projection queued_message in
+    {
+      payload_channel = projection.payload_channel;
+      payload_channel_user_id = projection.payload_channel_user_id;
+      payload_channel_user_name = projection.payload_channel_user_name;
+      payload_channel_workspace_id = projection.payload_channel_workspace_id;
+      agent_name = projection.agent_name;
+    }
 end
 
 let fork_logged_fiber = Server_bootstrap_loops_fiber.fork_logged_fiber
@@ -873,41 +945,20 @@ let start_keeper_loops
                Printf.sprintf "keeper-consumer-msg-%d"
                  (int_of_float ((now +. 0.001) *. 1000.0))
              in
+             let projection = queued_chat_projection queued_message in
              let payload =
                {
                  name = keeper_name;
                  message = queued_message.content;
                  timeout_sec = None;
-                 channel =
-                   (match queued_message.source with
-                    | Keeper_chat_queue.Dashboard -> ""
-                    | Keeper_chat_queue.Discord { channel_id; _ } ->
-                        channel_id
-                    | Keeper_chat_queue.Slack { channel; _ } -> channel);
-                 channel_user_id =
-                   (match queued_message.source with
-                    | Keeper_chat_queue.Dashboard -> ""
-                    | Keeper_chat_queue.Discord { user_id; _ } -> user_id
-                    | Keeper_chat_queue.Slack { user_id; _ } -> user_id);
-                 channel_user_name = "";
-                 channel_workspace_id = "";
+                 channel = projection.payload_channel;
+                 channel_user_id = projection.payload_channel_user_id;
+                 channel_user_name = projection.payload_channel_user_name;
+                 channel_workspace_id = projection.payload_channel_workspace_id;
                  attachments = queued_message.attachments;
                }
              in
-             let agent_name =
-               match queued_message.source with
-               | Keeper_chat_queue.Dashboard -> "dashboard"
-               | Keeper_chat_queue.Discord { channel_id; user_id } ->
-                   Gate_keeper_backend.agent_name_for_channel_actor
-                     ~channel:channel_id
-                     ~channel_workspace_id:""
-                     ~channel_user_id:user_id
-               | Keeper_chat_queue.Slack { channel; user_id } ->
-                   Gate_keeper_backend.agent_name_for_channel_actor
-                     ~channel
-                     ~channel_workspace_id:""
-                     ~channel_user_id:user_id
-             in
+             let agent_name = projection.agent_name in
              let events = Keeper_chat_events.create () in
              let closed = ref false in
              let thread_id = "keeper-consumer:" ^ keeper_name in
@@ -922,7 +973,7 @@ let start_keeper_loops
                     "keeper_chat_consumer: forking Discord adapter \
                      for keeper=%s"
                     keeper_name;
-                  (match Sys.getenv_opt "MASC_DISCORD_BOT_TOKEN" with
+                  (match discord_bot_token_opt () with
                    | Some token ->
                        Eio.Fiber.fork ~sw (fun () ->
                          Keeper_chat_discord.adapter_loop ~token
@@ -930,7 +981,7 @@ let start_keeper_loops
                    | None ->
                        Log.Keeper.warn
                          "keeper_chat_consumer: \
-                          MASC_DISCORD_BOT_TOKEN not set, \
+                          DISCORD_BOT_TOKEN not set, \
                           skipping Discord delivery for keeper=%s"
                          keeper_name)
               | Keeper_chat_queue.Slack { channel; _ } ->

--- a/lib/server/server_bootstrap_loops.mli
+++ b/lib/server/server_bootstrap_loops.mli
@@ -25,10 +25,21 @@ val start_keeper_loops :
     shutdown cancels them in order. *)
 
 module For_testing : sig
+  type queued_chat_projection = {
+    payload_channel : string;
+    payload_channel_user_id : string;
+    payload_channel_user_name : string;
+    payload_channel_workspace_id : string;
+    agent_name : string;
+  }
+
   val autoboot_proactive_warmup_sec :
     base_warmup:int -> stagger_window_sec:int -> keeper_name:string -> int
 
   val board_sse_event_params : Board_dispatch.board_sse_event -> Yojson.Safe.t
+
+  val queued_chat_projection :
+    Keeper_chat_queue.queued_message -> queued_chat_projection
 end
 
 val start_background_maintenance :

--- a/test/test_env_config_keeper_bootstrap_intervals.ml
+++ b/test/test_env_config_keeper_bootstrap_intervals.ml
@@ -25,6 +25,7 @@ open Alcotest
 
 module KB = Env_config_keeper.KeeperBootstrap
 module Boot = Server_bootstrap_loops.For_testing
+module Chat_queue = Masc.Keeper_chat_queue
 
 let approx = float 0.001
 
@@ -161,6 +162,26 @@ let test_autoboot_warmup_is_order_independent () =
   check bool "stagger produces ≥3 distinct warmups across 10 names" true
     (distinct >= 3)
 
+let test_discord_queue_projection_matches_gateway_context () =
+  let queued : Chat_queue.queued_message =
+    {
+      content = "hello";
+      attachments = [];
+      timestamp = 0.0;
+      source =
+        Chat_queue.Discord
+          { channel_id = "discord-channel-1"; user_id = "discord-user-9" };
+    }
+  in
+  let projection = Boot.queued_chat_projection queued in
+  check string "connector label" "discord" projection.payload_channel;
+  check string "actor id" "discord-user-9" projection.payload_channel_user_id;
+  check string "workspace id uses Discord channel id" "discord-channel-1"
+    projection.payload_channel_workspace_id;
+  check string "agent identity matches gate channel actor"
+    "gate:discord:discord-channel-1:discord-user-9"
+    projection.agent_name
+
 let () =
   run "env_config_keeper_bootstrap_intervals"
     [
@@ -191,5 +212,10 @@ let () =
             test_autoboot_warmup_is_order_independent;
           test_case "Int32 hash pinned cross-platform (#13155 §L)" `Quick
             test_warmup_hash_pinned_cross_platform;
+        ] );
+      ( "queued chat projection",
+        [
+          test_case "Discord queue source keeps connector context" `Quick
+            test_discord_queue_projection_matches_gateway_context;
         ] );
     ]


### PR DESCRIPTION
## Summary
- Preserve Discord connector/channel context when queued keeper chat messages are projected into masc_keeper_msg.
- Align queued Discord delivery token lookup with the in-process gateway by using DISCORD_BOT_TOKEN.
- Add a regression test pinning Discord queue projection to gate:discord:<channel>:<user> identity.

## Tests
- env MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_env_config_keeper_bootstrap_intervals.exe test/test_channel_gate_discord_state_in_process.exe
- env MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh exec ./test/test_env_config_keeper_bootstrap_intervals.exe
- env MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh exec ./test/test_channel_gate_discord_state_in_process.exe