### PR TITLE
fix(keeper): preserve effective meta during recovery

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop_cycle_with_slot.ml
+++ b/lib/keeper/keeper_heartbeat_loop_cycle_with_slot.ml
@@ -92,11 +92,11 @@ let run_keeper_cycle_with_slot
         "%s: provider_timeout observed; preserving original turn \
          failure without Provider_timeout_loop latch"
         keeper_name);
-    (match read_meta ctx.config meta_after_cursor_persist.name with
+    (match read_effective_meta ctx.config meta_after_cursor_persist.name with
      | Ok (Some latest) -> latest
      | Ok None ->
        Log.Keeper.error
-         "keeper:%s read_meta returned None after turn failure, using stale meta"
+         "keeper:%s read_effective_meta returned None after turn failure, using stale meta"
          meta_after_cursor_persist.name;
        Otel_metric_store.inc_counter
          Keeper_metrics.(to_string MetaReadFailures)
@@ -106,7 +106,7 @@ let run_keeper_cycle_with_slot
        meta_after_cursor_persist
      | Error e ->
        Log.Keeper.error
-         "keeper:%s read_meta failed after turn failure (%s), using stale meta"
+         "keeper:%s read_effective_meta failed after turn failure (%s), using stale meta"
          meta_after_cursor_persist.name
          e;
        Otel_metric_store.inc_counter

--- a/lib/keeper/keeper_heartbeat_loop_presence.ml
+++ b/lib/keeper/keeper_heartbeat_loop_presence.ml
@@ -21,12 +21,22 @@ let effective_keepalive_meta
       ~(disk_meta_opt : keeper_meta option)
   : keeper_meta
   =
-  match disk_meta_opt with
+  let selected =
+    match disk_meta_opt with
   | Some latest -> latest
   | None ->
     (match Keeper_registry.get ~base_path fallback.name with
      | Some entry -> entry.meta
      | None -> fallback)
+  in
+  match Keeper_meta_contract.effective_meta_result selected with
+  | Ok effective -> effective
+  | Error msg ->
+    Log.Keeper.warn
+      "effective_keepalive_meta: failed to overlay TOML profile for %s: %s"
+      selected.name
+      msg;
+    selected
 ;;
 
 let repair_identity_drift_for_keepalive ~(ctx : _ context) (meta : keeper_meta)

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -384,7 +384,7 @@ let sweep_and_recover (ctx : _ context) =
          Keeper_metrics.(to_string RestartAttempts)
          ~labels:[ "keeper", old_entry.name ]
          ();
-       match read_meta ctx.config old_entry.name with
+       match read_effective_meta ctx.config old_entry.name with
        | Ok (Some meta) ->
          (* RFC-0002: dispatch restart attempt event *)
          Keeper_registry.dispatch_event_unit

--- a/lib/keeper/keeper_supervisor_reconcile_keepalive.ml
+++ b/lib/keeper/keeper_supervisor_reconcile_keepalive.ml
@@ -23,7 +23,7 @@ let reconcile_keepalive_keepers
   let reconcile_ym = Eio_guard.create_yield_meter () in
   List.iter
     (fun name ->
-       (match read_meta ctx.config name with
+       (match read_effective_meta ctx.config name with
         | Ok (Some meta) when not meta.paused ->
           let dominated_by_sweep =
             match Keeper_registry.get ~base_path meta.name with
@@ -69,7 +69,7 @@ let reconcile_keepalive_keepers
               [ ("operation", Runtime_observation_query_operation.(to_label Reconcile_read_meta))
               ]
             ();
-          Log.Keeper.warn "reconcile: read_meta failed for %s: %s" name err);
+          Log.Keeper.warn "reconcile: read_effective_meta failed for %s: %s" name err);
        Eio_guard.yield_step reconcile_ym)
     names;
   Log.Keeper.debug

--- a/test/test_keeper_effective_meta_overlay.ml
+++ b/test/test_keeper_effective_meta_overlay.ml
@@ -6,6 +6,7 @@ module Turn_setup = Masc.Keeper_turn_setup
 module Turn = Masc.Keeper_turn
 module Keeper_tool_surface = Masc.Keeper_tool_surface
 module Keeper_tool_surface_ops = Masc.Keeper_tool_surface_ops
+module Heartbeat_presence = Masc.Keeper_heartbeat_loop_presence
 
 let temp_dir () =
   let path = Filename.temp_file "keeper-effective-meta-" "" in
@@ -219,6 +220,36 @@ tool_access = ["tool_search_files", "tool_read_file"]
         "turn setup sees TOML tool overlay"
         [ "tool_search_files"; "tool_read_file" ]
         meta.tool_access
+
+let test_keepalive_meta_selection_overlays_disk_meta () =
+  with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir ->
+  let name = "taskmaster" in
+  write_file
+    (Filename.concat keepers_dir (name ^ ".toml"))
+    {|[keeper]
+sandbox_profile = "docker"
+network_mode = "inherit"
+|};
+  let config = Workspace.default_config base in
+  let raw_meta = seed_runtime_meta config name in
+  Alcotest.(check string)
+    "fixture raw meta starts from persisted/default sandbox"
+    "local"
+    (Profile.sandbox_profile_to_string raw_meta.sandbox_profile);
+  let effective =
+    Heartbeat_presence.effective_keepalive_meta
+      ~base_path:config.base_path
+      ~fallback:raw_meta
+      ~disk_meta_opt:(Some raw_meta)
+  in
+  Alcotest.(check string)
+    "keepalive disk meta selection applies TOML sandbox overlay"
+    "docker"
+    (Profile.sandbox_profile_to_string effective.sandbox_profile);
+  Alcotest.(check string)
+    "keepalive disk meta selection applies TOML network overlay"
+    "inherit"
+    (Profile.network_mode_to_string effective.network_mode)
 
 let test_missing_sandbox_profile_fails_loud_for_profile_source () =
   with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir ->
@@ -447,6 +478,9 @@ let () =
             `Quick test_toml_overlay_reaches_effective_meta;
           Alcotest.test_case "turn setup uses effective meta" `Quick
             test_turn_setup_uses_effective_meta;
+          Alcotest.test_case
+            "keepalive meta selection overlays disk meta"
+            `Quick test_keepalive_meta_selection_overlays_disk_meta;
           Alcotest.test_case
             "profile source without sandbox_profile fails loudly"
             `Quick test_missing_sandbox_profile_fails_loud_for_profile_source;


### PR DESCRIPTION
## Summary
- apply TOML effective-meta overlay when keepalive selects disk/registry/fallback meta
- use effective meta after turn failure and when supervisor restarts/reconciles durable keepers
- add regression coverage for raw disk meta resolving back to docker keepalive meta

## Verification
- ocamlformat --check lib/keeper/keeper_heartbeat_loop_presence.ml lib/keeper/keeper_heartbeat_loop_cycle_with_slot.ml lib/keeper/keeper_supervisor_reconcile_keepalive.ml lib/keeper/keeper_supervisor.ml test/test_keeper_effective_meta_overlay.ml
- env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-effective-meta dune build --root . @test/runtest-test_keeper_effective_meta_overlay @test/runtest-test_oas_timeout_budget_strike --display=quiet -j 2