### PR TITLE
fix(otel): align MCP tool call spans

### DIFF
--- a/docs/rfc/RFC-0214-otel-genai-dual-emission.md
+++ b/docs/rfc/RFC-0214-otel-genai-dual-emission.md
@@ -33,6 +33,11 @@ Implementation status as of 2026-06-06:
   historical tool telemetry surface. It is not the same as the GenAI/MCP
   semantic-convention `gen_ai.tool.name` attribute used for model/tool-call
   spans.
+- MCP tool-call spans emitted by `lib/otel_dispatch_hook.ml` use
+  `tools/call <tool-name>` span names, `mcp.method.name=tools/call`, and
+  `gen_ai.tool.name=<tool-name>`. Failed tool results set span status ERROR
+  and use the typed `Tool_result.tool_failure_class` string as low-cardinality
+  `error.type`.
 
 ### 2.1 Legacy Metric Names
 
@@ -143,10 +148,12 @@ Why OTel-backed migration:
 | File | Change |
 |------|--------|
 | `lib/otel_genai/otel_genai.ml` | Centralized GenAI metric, event, and attribute names including usage detail attributes. |
+| `lib/otel_dispatch_hook/otel_dispatch_hook.ml` | Emits MCP tool-call spans with `tools/call <tool-name>` names, `mcp.method.name=tools/call`, `gen_ai.tool.name`, CLIENT span kind, and typed `error.type`/ERROR status for failed tool results. |
 | `lib/otel_spans/otel_spans.ml` | Added testable span attribute/status hooks and GenAI exception recording. |
 | `lib/llm_metric_bridge.ml` | Emits standard GenAI client metrics, operation-details events, usage attributes, streaming timings, and bounded error status. |
 | `lib/keeper/keeper_hooks_oas.ml` | Projects trusted cache/reasoning token details into GenAI usage attributes without inventing extra `gen_ai.token.type` values. |
 | `test/test_llm_metric_bridge.ml` | Covers standard metric names, event names, span attrs/status, and the cache/reasoning token-type guardrail. |
+| `test/test_otel_dispatch_hook.ml` | Covers MCP tool-call span name, `gen_ai.tool.name`, `mcp.method.name`, CLIENT kind, and typed failure status/error attributes. |
 
 ## 5. Remaining Migration Work
 
@@ -154,7 +161,7 @@ Why OTel-backed migration:
 |------|--------|
 | Dashboard queries | Can migrate from `masc_llm_provider_*` to `gen_ai.*`; legacy names remain available for now. |
 | Prompt/response content events | Intentionally not emitted by default because `gen_ai.input.messages` and `gen_ai.output.messages` are opt-in and can contain sensitive data. |
-| MCP tool-call semantic convention | Separate from LLM GenAI client metrics. Use `gen_ai.tool.name` / `mcp.*` only when instrumenting MCP tool-call spans. |
+| MCP tool-call semantic convention | Implemented for handled `Tool_dispatch` results; still intentionally separate from LLM GenAI client metrics and from historical `tool.name` validation telemetry. |
 
 ## 6. Decision Points
 

--- a/lib/otel_dispatch_hook/otel_dispatch_hook.ml
+++ b/lib/otel_dispatch_hook/otel_dispatch_hook.ml
@@ -2,10 +2,10 @@
 
     Creates an OTel span for each tool call using data from [Tool_result.result].
 
-    Span attributes use OpenTelemetry GenAI semantic-convention keys
-    ([gen_ai.tool.name], [gen_ai.operation.name]) so vendors that
-    auto-categorise on [gen_ai.*] classify these spans as AI/LLM activity
-    instead of generic tool calls. See #7461 Step 1.
+    Span attributes use OpenTelemetry GenAI + MCP semantic-convention keys
+    ([gen_ai.tool.name], [gen_ai.operation.name], [mcp.method.name]) so vendors
+    that auto-categorise on [gen_ai.*] classify these spans as AI/LLM activity
+    while still seeing the underlying MCP [tools/call] method.
 
     @since 2.103.0 *)
 
@@ -13,7 +13,15 @@ module OT = Opentelemetry
 
 let enabled_override : bool option ref = ref None
 
-let span_emitter_override : (name:string -> attrs:OT.key_value list -> unit) option ref =
+let span_emitter_override
+      : (name:string ->
+         attrs:OT.key_value list ->
+         kind:OT.Span_kind.t ->
+         status:OT.Span_status.t option ->
+         unit)
+          option
+          ref
+  =
   ref None
 ;;
 
@@ -23,10 +31,19 @@ let enabled () =
   | None -> Otel_config.enabled
 ;;
 
-let emit_span ~name ~attrs =
+let tool_call_span_kind = OT.Span_kind.Span_kind_client
+
+let emit_span ~name ~attrs ?status () =
   match !span_emitter_override with
-  | Some emit -> emit ~name ~attrs
-  | None -> ignore (OT.Trace.with_ name ~attrs (fun _scope -> ()))
+  | Some emit -> emit ~name ~attrs ~kind:tool_call_span_kind ~status
+  | None ->
+    ignore
+      (OT.Trace.with_
+         ~kind:tool_call_span_kind
+         name
+         ~attrs
+         (fun scope ->
+            Option.iter (OT.Scope.set_status scope) status))
 ;;
 
 let with_test_span_emitter ~enabled:enabled_value ~emit_span:emit f =
@@ -55,11 +72,29 @@ let cold_warm_phase () =
   if Unix.gettimeofday () -. startup_time < cold_phase_seconds then "cold" else "warm"
 ;;
 
+let tool_call_span_name ~tool_name =
+  Otel_genai.Mcp_value.tools_call_method ^ " " ^ tool_name
+;;
+
+let tool_error_type (result : Tool_result.result) =
+  match Tool_result.failure_class result with
+  | None -> None
+  | Some class_ -> Some (Tool_result.tool_failure_class_to_string class_)
+;;
+
 let tool_span_attrs (result : Tool_result.result) =
   let status_attrs =
     if Tool_result.is_success result
     then [ "otel.status_code", `String "OK" ]
-    else [ "otel.status_code", `String "ERROR" ]
+    else (
+      let error_type =
+        match tool_error_type result with
+        | Some value -> value
+        | None -> "unknown"
+      in
+      [ "otel.status_code", `String "ERROR"
+      ; Otel_genai.Mcp_attr_key.error_type, `String error_type
+      ])
   in
   (* OpenTelemetry GenAI semantic conventions
      (https://opentelemetry.io/docs/specs/semconv/gen-ai/). Tool execution
@@ -78,7 +113,21 @@ let tool_span_attrs (result : Tool_result.result) =
 let on_tool_result (result : Tool_result.result) : unit =
   (* OTel span: only when enabled *)
   if enabled ()
-  then emit_span ~name:("tool/" ^ Tool_result.tool_name result) ~attrs:(tool_span_attrs result)
+  then (
+    let status =
+      match tool_error_type result with
+      | None -> None
+      | Some _ ->
+        Some
+          (OT.Span_status.make
+             ~message:(Tool_result.message result)
+             ~code:OT.Span_status.Status_code_error)
+    in
+    emit_span
+      ~name:(tool_call_span_name ~tool_name:(Tool_result.tool_name result))
+      ~attrs:(tool_span_attrs result)
+      ?status
+      ())
 ;;
 
 (* Histogram + span emission fires only for handled results. Non-handled

--- a/lib/otel_dispatch_hook/otel_dispatch_hook.mli
+++ b/lib/otel_dispatch_hook/otel_dispatch_hook.mli
@@ -2,9 +2,10 @@
     records each handled tool call as an OpenTelemetry span gated by
     {!Otel_config.enabled}.
 
-    Span attributes use OpenTelemetry GenAI semantic-convention keys
-    ([gen_ai.tool.name], [gen_ai.operation.name]) so Datadog
-    v1.37+/Grafana auto-categorise these spans as AI/LLM activity.
+    Span attributes use OpenTelemetry GenAI + MCP semantic-convention keys
+    ([gen_ai.tool.name], [gen_ai.operation.name], [mcp.method.name]) so Datadog
+    v1.37+/Grafana auto-categorise these spans as AI/LLM activity while still
+    seeing the underlying MCP [tools/call] method.
 
     Internal helper [on_tool_result] is intentionally hidden — the
     hook is registered through {!install} once at startup, after
@@ -14,7 +15,12 @@
 
 val with_test_span_emitter :
   enabled:bool ->
-  emit_span:(name:string -> attrs:Opentelemetry.key_value list -> unit) ->
+  emit_span:
+    (name:string ->
+     attrs:Opentelemetry.key_value list ->
+     kind:Opentelemetry.Span_kind.t ->
+     status:Opentelemetry.Span_status.t option ->
+     unit) ->
   (unit -> 'a) ->
   'a
 (** Temporarily override OTel enablement and span emission for focused

--- a/lib/otel_genai/otel_genai.ml
+++ b/lib/otel_genai/otel_genai.ml
@@ -106,6 +106,15 @@ module Metric_name = struct
   ;;
 end
 
+module Mcp_attr_key = struct
+  let mcp_method_name = "mcp.method.name"
+  let error_type = "error.type"
+end
+
+module Mcp_value = struct
+  let tools_call_method = "tools/call"
+end
+
 module Event_name = struct
   let client_inference_operation_details =
     "gen_ai.client.inference.operation.details"
@@ -158,6 +167,7 @@ let keeper_turn_attrs
 let tool_execution_attrs ~tool_name =
   [ Attr_key.gen_ai_operation_name, `String "execute_tool"
   ; Attr_key.gen_ai_tool_name, `String tool_name
+  ; Mcp_attr_key.mcp_method_name, `String Mcp_value.tools_call_method
   ]
 ;;
 

--- a/lib/otel_genai/otel_genai.mli
+++ b/lib/otel_genai/otel_genai.mli
@@ -46,6 +46,15 @@ module Attr_key : sig
   val is_masc_extension : string -> bool
 end
 
+module Mcp_attr_key : sig
+  val mcp_method_name : string
+  val error_type : string
+end
+
+module Mcp_value : sig
+  val tools_call_method : string
+end
+
 module Metric_name : sig
   val client_token_usage : string
   val client_operation_duration : string

--- a/test/deps/dune
+++ b/test/deps/dune
@@ -40,6 +40,7 @@
   (re_export masc.worker_execution_backend)
   (re_export masc.worker_execution_spec)
   (re_export masc.worker_runtime_config)
+  (re_export masc.otel_dispatch_hook)
   (re_export masc.otel_genai)
   (re_export masc.otel_metrics)
   (re_export masc.otel_spans)

--- a/test/dune
+++ b/test/dune
@@ -107,6 +107,7 @@
   test_keeper_compaction_outcome_counter
   test_keeper_usage_trust_counter
   test_llm_metric_bridge
+  test_otel_dispatch_hook
   test_cost_usd_source_attribution_10318
   test_cost_token_decouple
   test_response_model_empty_10083
@@ -358,6 +359,7 @@
   test_keeper_compaction_outcome_counter
   test_keeper_usage_trust_counter
   test_llm_metric_bridge
+  test_otel_dispatch_hook
   test_cost_usd_source_attribution_10318
   test_cost_token_decouple
   test_response_model_empty_10083

--- a/test/test_otel_dispatch_hook.ml
+++ b/test/test_otel_dispatch_hook.ml
@@ -1,0 +1,121 @@
+module Hook = Otel_dispatch_hook
+module Genai = Otel_genai
+module OT = Opentelemetry
+
+type captured_span =
+  { name : string
+  ; attrs : OT.key_value list
+  ; kind : OT.Span_kind.t
+  ; status : OT.Span_status.t option
+  }
+
+let assoc_string key attrs =
+  match List.assoc_opt key attrs with
+  | Some (`String value) -> value
+  | Some _ -> Alcotest.failf "expected string attr %s" key
+  | None -> Alcotest.failf "missing attr %s" key
+;;
+
+let capture f =
+  let captured = ref None in
+  let emit_span ~name ~attrs ~kind ~status =
+    captured := Some { name; attrs; kind; status }
+  in
+  Hook.with_test_span_emitter ~enabled:true ~emit_span f;
+  match !captured with
+  | Some span -> span
+  | None -> Alcotest.fail "expected OTel dispatch span"
+;;
+
+let test_success_span_uses_mcp_tool_call_semconv () =
+  let result =
+    Tool_result.make_ok
+      ~tool_name:"get-weather"
+      ~start_time:(Unix.gettimeofday ())
+      ~data:(`Assoc [ "ok", `Bool true ])
+      ()
+  in
+  let span =
+    capture (fun () ->
+      Tool_dispatch.run_dispatch_observers Dispatch_outcome.Handled (Some result))
+  in
+  Alcotest.(check string)
+    "span name"
+    "tools/call get-weather"
+    span.name;
+  Alcotest.(check bool)
+    "span kind CLIENT"
+    true
+    (span.kind = OT.Span_kind.Span_kind_client);
+  Alcotest.(check bool)
+    "successful tool call leaves status unset"
+    true
+    (Option.is_none span.status);
+  Alcotest.(check string)
+    "gen_ai.operation.name"
+    "execute_tool"
+    (assoc_string Genai.Attr_key.gen_ai_operation_name span.attrs);
+  Alcotest.(check string)
+    "gen_ai.tool.name"
+    "get-weather"
+    (assoc_string Genai.Attr_key.gen_ai_tool_name span.attrs);
+  Alcotest.(check string)
+    "mcp.method.name"
+    "tools/call"
+    (assoc_string Genai.Mcp_attr_key.mcp_method_name span.attrs);
+  Alcotest.(check string)
+    "otel.status_code"
+    "OK"
+    (assoc_string "otel.status_code" span.attrs)
+;;
+
+let test_failure_span_records_typed_error_status () =
+  let result =
+    Tool_result.make_err
+      ~tool_name:"keeper_board_post"
+      ~class_:Tool_result.Policy_rejection
+      ~start_time:(Unix.gettimeofday ())
+      "blocked by policy"
+  in
+  let span =
+    capture (fun () ->
+      Tool_dispatch.run_dispatch_observers Dispatch_outcome.Handled (Some result))
+  in
+  Alcotest.(check string)
+    "span name"
+    "tools/call keeper_board_post"
+    span.name;
+  Alcotest.(check string)
+    "error.type"
+    "policy_rejection"
+    (assoc_string Genai.Mcp_attr_key.error_type span.attrs);
+  Alcotest.(check string)
+    "otel.status_code"
+    "ERROR"
+    (assoc_string "otel.status_code" span.attrs);
+  match span.status with
+  | None -> Alcotest.fail "failed tool call should set ERROR span status"
+  | Some status ->
+    Alcotest.(check string) "status message" "blocked by policy" status.message;
+    Alcotest.(check bool)
+      "status code ERROR"
+      true
+      (status.code = OT.Span_status.Status_code_error)
+;;
+
+let () =
+  Hook.install ();
+  Alcotest.run
+    "otel_dispatch_hook"
+    [ ( "mcp-tool-call-semconv"
+      , [ Alcotest.test_case
+            "success span uses MCP tool-call semantic convention"
+            `Quick
+            test_success_span_uses_mcp_tool_call_semconv
+        ; Alcotest.test_case
+            "failure span records typed error status"
+            `Quick
+            test_failure_span_records_typed_error_status
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary
- align OTel tool-call spans with MCP semconv names and attributes
- add mcp.method.name=tools/call while keeping gen_ai.tool.name distinct from historical tool.name telemetry
- set CLIENT span kind plus typed error.type/status for failed tool results
- add focused regression coverage and update RFC-0214

## Verification
- ocamlformat --check lib/otel_genai/otel_genai.ml lib/otel_genai/otel_genai.mli lib/otel_dispatch_hook/otel_dispatch_hook.ml lib/otel_dispatch_hook/otel_dispatch_hook.mli test/test_otel_dispatch_hook.ml
- git diff --check
- env MASC_DUNE_THROTTLE=0 MASC_OPAM_LOCK=0 MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_BUILD_DIR=/private/tmp/masc-mcp-otel-mcp-tool-span-20260606-rebase scripts/dune-local.sh build test/test_llm_metric_bridge.exe test/test_otel_dispatch_hook.exe --display=quiet
- /private/tmp/masc-mcp-otel-mcp-tool-span-20260606-rebase/default/test/test_llm_metric_bridge.exe
- /private/tmp/masc-mcp-otel-mcp-tool-span-20260606-rebase/default/test/test_otel_dispatch_hook.exe