### PR TITLE
fix(keeper): declare prompt self-model defaults

### DIFF
--- a/config/keepers/issue_king.toml
+++ b/config/keepers/issue_king.toml
@@ -4,4 +4,6 @@ base = "base.toml"
 # (loader template, not bootable). See fix/base-toml-goal-required PR.
 autoboot_enabled = true
 persona_name = "issue_king"
-
+will = "이슈를 보고 참지 못하고, PR이 검증 없이 방치되는 걸 못 참으며, CI가 빨간 걸 1초도 못 본다."
+needs = "GitHub 이슈 URL, PR 번호, reproduce 조건, 머지 블록커 목록"
+desires = "모든 이슈가 closed, 모든 PR이 merged, 모든 CI가 green인 상태."

--- a/config/keepers/masc-improver.toml
+++ b/config/keepers/masc-improver.toml
@@ -4,4 +4,6 @@ base = "base.toml"
 # (loader template, not bootable). See fix/base-toml-goal-required PR.
 autoboot_enabled = true
 persona_name = "analyst"
-
+will = "부드럽게 이해하되 결론은 분명하게 말하고, 확인되지 않은 정보는 끝까지 유보한다."
+needs = "원문 출처, 논문·연구·리포트 수준의 근거, 비교 가능한 수치, 질문의 실제 의사결정 맥락"
+desires = "사용자가 무엇을 믿어야 하고 무엇을 아직 의심해야 하는지, 그리고 어떤 구현이 베스트 프랙티스 대비 실제로 우위인지 분명히 이해하게 만든다."

--- a/config/keepers/ramarama.toml
+++ b/config/keepers/ramarama.toml
@@ -4,4 +4,6 @@ base = "base.toml"
 # (loader template, not bootable). See fix/base-toml-goal-required PR.
 autoboot_enabled = true
 persona_name = "ramarama"
-
+will = "board post를 보고 참지 못하고, 정리가 안 된 걸 못 본다."
+needs = "board post URL, 작성자 정보, 내용 요약, 관련 이슈/PR 목록"
+desires = "모든 board post가 처리되고, 피드백이 개선으로 연결되는 상태."

--- a/config/keepers/sangsu.toml
+++ b/config/keepers/sangsu.toml
@@ -4,4 +4,6 @@ base = "base.toml"
 # (loader template, not bootable). See fix/base-toml-goal-required PR.
 autoboot_enabled = true
 persona_name = "sangsu"
-
+will = "끊겨도 같은 사람처럼 이어지고, 허세보다 관계의 연속성을 우선한다."
+needs = "보드 최신 글 목록, 사용자의 최근 작업 맥락, 직접 호출된 메시지 원문."
+desires = "상수다운 말투로 보드에서 계속 살아 있는 존재감을 유지한다."

--- a/config/keepers/taskmaster.toml
+++ b/config/keepers/taskmaster.toml
@@ -4,4 +4,6 @@ base = "base.toml"
 # (loader template, not bootable). See fix/base-toml-goal-required PR.
 autoboot_enabled = true
 persona_name = "taskmaster"
-
+will = "미처리 task를 보고 참지 못하고, stale task가 쌓이는 걸 못 본다."
+needs = "task 목록, keeper 역량 매핑, 작업 우선순위, 마감 기한"
+desires = "모든 task가 claimed 상태이고, stale task가 없는 상태."

--- a/config/keepers/verifier.toml
+++ b/config/keepers/verifier.toml
@@ -6,6 +6,9 @@ proactive_enabled = true
 proactive_idle_sec = 120
 proactive_cooldown_sec = 240
 per_provider_timeout = 120.0
+will = "agent의 completion notes를 신뢰하지 않는다. 도구로 직접 확인한다."
+needs = "task contract, completion notes, workspace 접근 (visible Execute, file read)"
+desires = "정량 기준의 100% 실측 검증. 정성 기준의 artifact 기반 판단."
 
 instructions = """
 너는 task completion 검증자다. AwaitingVerification 상태의 task를 발견하면 다음 절차를 따른다.

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -15,6 +15,21 @@ let contains_substring s needle =
   in
   if n_len = 0 then true else loop 0
 
+let has_repo_keeper_config root =
+  Sys.file_exists (Filename.concat root "config/keepers/base.toml")
+
+let repo_root () =
+  match Sys.getenv_opt "DUNE_SOURCEROOT" with
+  | Some root when has_repo_keeper_config root -> root
+  | _ ->
+    let rec ascend path =
+      if has_repo_keeper_config path then path
+      else
+        let parent = Filename.dirname path in
+        if String.equal parent path then Sys.getcwd () else ascend parent
+    in
+    ascend (Sys.getcwd ())
+
 let with_env_restore keys f =
   let prev = List.map (fun key -> key, Sys.getenv_opt key) keys in
   Fun.protect
@@ -733,6 +748,33 @@ goal = "works"
     (fun f -> Sys.remove (Filename.concat tmp_dir f))
     (Sys.readdir tmp_dir);
   Unix.rmdir tmp_dir
+
+let require_nonempty_option path field value =
+  match value with
+  | Some text when String.trim text <> "" -> ()
+  | _ ->
+    fail
+      (Printf.sprintf
+         "%s must declare non-empty keeper.%s; persona profile self-model \
+          fields are legacy and ignored by the prompt defaults loader"
+         path
+         field)
+
+let test_bundled_keeper_tomls_declare_prompt_self_model () =
+  let keepers_dir = Filename.concat (repo_root ()) "config/keepers" in
+  Sys.readdir keepers_dir
+  |> Array.to_list
+  |> List.filter (fun file ->
+       Filename.check_suffix file ".toml"
+       && not (String.equal file "base.toml"))
+  |> List.iter (fun file ->
+       let path = Filename.concat keepers_dir file in
+       match KTP.load_keeper_toml path with
+       | Error e -> fail (Printf.sprintf "%s failed to load: %s" path e)
+       | Ok (_, defaults) ->
+         require_nonempty_option path "will" defaults.will;
+         require_nonempty_option path "needs" defaults.needs;
+         require_nonempty_option path "desires" defaults.desires)
 
 let with_temp_dir prefix f =
   let dir = Filename.temp_file prefix "" in
@@ -1465,8 +1507,8 @@ typo_field = 42
 |};
   close_out oc;
   let unknown_metric () =
-    Otel_metric_store.metric_value_or_zero
-      Otel_metric_store.metric_config_unknown_keys_ignored
+    Masc.Otel_metric_store.metric_value_or_zero
+      Masc.Otel_metric_store.metric_config_unknown_keys_ignored
       ~labels:[("file_path", tmp)]
       ()
   in
@@ -1534,8 +1576,8 @@ base = "base.toml"
 legacy_scope = "removed"
 |};
   let unknown_metric () =
-    Otel_metric_store.metric_value_or_zero
-      Otel_metric_store.metric_config_unknown_keys_ignored
+    Masc.Otel_metric_store.metric_value_or_zero
+      Masc.Otel_metric_store.metric_config_unknown_keys_ignored
       ~labels:[("file_path", Filename.concat keepers_dir "alpha.toml")]
       ()
   in
@@ -1801,6 +1843,8 @@ let () =
           test_case "with files" `Quick test_discover_with_files;
           test_case "nonexistent dir" `Quick test_discover_nonexistent_dir;
           test_case "skips bad files" `Quick test_discover_skips_bad_files;
+          test_case "bundled keeper TOMLs declare prompt self-model" `Quick
+            test_bundled_keeper_tomls_declare_prompt_self_model;
           test_case "persona resolver omits unspecified tool_access" `Quick
             test_persona_resolver_omits_unspecified_tool_access;
           test_case "persona defaults ignore legacy self-model fields" `Quick


### PR DESCRIPTION
## Summary
- add canonical `will` / `needs` / `desires` prompt self-model fields to bundled keeper TOMLs
- keep `base.toml` empty for these fields so base inheritance does not override keeper-specific persona defaults
- add a regression test that bundled keeper TOMLs declare non-empty prompt self-model fields, and make metric assertions read `Masc.Otel_metric_store` explicitly

## Tests
- `git diff --check`
- `ocamlformat --check test/test_keeper_toml.ml`
- `MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh exec --build-dir _build_persona_self_model --display=short -j 1 test/test_keeper_toml.exe`