### PR TITLE
Reject blank runtime credentials

### DIFF
--- a/dashboard/src/lib/runtime-toml-config.test.ts
+++ b/dashboard/src/lib/runtime-toml-config.test.ts
@@ -106,6 +106,24 @@ describe('runtime TOML dashboard editing helpers', () => {
     expect(next).not.toContain('key = "RUNPOD_API_KEY"')
   })
 
+  it('deletes credential sections instead of writing blank credential values', () => {
+    const next = setRuntimeTomlProviderCredential(sourceText, 'runpod_mtp', 'env', '   ')
+
+    expect(next).not.toContain('[providers.runpod_mtp.credentials]')
+    expect(next).not.toContain('key = ""')
+  })
+
+  it('trims env credential names before writing them', () => {
+    const next = setRuntimeTomlProviderCredential(
+      sourceText,
+      'runpod_mtp',
+      'env',
+      ' OLLAMA_CLOUD_API_KEY ',
+    )
+
+    expect(next).toContain('key = "OLLAMA_CLOUD_API_KEY"')
+  })
+
   it('deletes optional keys when requested', () => {
     const next = deleteRuntimeTomlKey(sourceText, 'runpod_mtp.qwen', 'keep-alive')
 

--- a/dashboard/src/lib/runtime-toml-config.ts
+++ b/dashboard/src/lib/runtime-toml-config.ts
@@ -340,14 +340,16 @@ export function setRuntimeTomlProviderCredential(
 ): string {
   const section = `providers.${providerId}.credentials`
   if (credentialType === 'none') return deleteRuntimeTomlSection(sourceText, section)
+  const normalizedValue = value.trim()
+  if (!normalizedValue) return deleteRuntimeTomlSection(sourceText, section)
   let next = setRuntimeTomlKey(sourceText, section, 'type', credentialType)
   if (credentialType === 'env') {
-    next = setRuntimeTomlKey(next, section, 'key', value)
+    next = setRuntimeTomlKey(next, section, 'key', normalizedValue)
     next = deleteRuntimeTomlKey(next, section, 'path')
     return deleteRuntimeTomlKey(next, section, 'value')
   }
   if (credentialType === 'file') {
-    next = setRuntimeTomlKey(next, section, 'path', value)
+    next = setRuntimeTomlKey(next, section, 'path', normalizedValue)
     next = deleteRuntimeTomlKey(next, section, 'key')
     return deleteRuntimeTomlKey(next, section, 'value')
   }

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -23,6 +23,20 @@ type parse_error =
 
 let error path message = [ { path; message } ]
 
+let required_non_empty_string
+      ?(trim_result = false)
+      (tbl : Otoml.t)
+      ~(path : string)
+      ~(key : string)
+      ~(message : string)
+  : (string, parse_error list) result
+  =
+  match Otoml.find_opt tbl Otoml.get_string [ key ] with
+  | Some value when String.trim value <> "" ->
+    Ok (if trim_result then String.trim value else value)
+  | Some _ | None -> Error (error (path ^ "." ^ key) message)
+;;
+
 (* Partition a list of per-entry parse results into a single
    collected result. Either every entry parsed (return [Ok all]),
    or at least one entry failed (return [Error] with every error
@@ -85,21 +99,44 @@ let transport_of_provider (tbl : Otoml.t) (id : string)
 let parse_credential (tbl : Otoml.t) (path : string)
   : (Runtime_schema.credential, parse_error list) result
   =
-  let cred_type = Otoml.find tbl Otoml.get_string [ "type" ] in
-  match cred_type with
-  | "env" ->
-    (match Otoml.find_opt tbl Otoml.get_string [ "key" ] with
-     | Some key -> Ok (Runtime_schema.Env key)
-     | None -> Error (error (path ^ ".key") "credential type 'env' requires 'key'"))
-  | "file" ->
-    (match Otoml.find_opt tbl Otoml.get_string [ "path" ] with
-     | Some p -> Ok (Runtime_schema.File p)
-     | None -> Error (error (path ^ ".path") "credential type 'file' requires 'path'"))
-  | "inline" ->
-    (match Otoml.find_opt tbl Otoml.get_string [ "value" ] with
-     | Some v -> Ok (Runtime_schema.Inline v)
-     | None -> Error (error (path ^ ".value") "credential type 'inline' requires 'value'"))
-  | t -> Error (error (path ^ ".type") (Printf.sprintf "unknown credential type %S" t))
+  match
+    required_non_empty_string
+      ~trim_result:true
+      tbl
+      ~path
+      ~key:"type"
+      ~message:"credential requires non-empty 'type'"
+  with
+  | Error errs -> Error errs
+  | Ok cred_type ->
+    (match cred_type with
+     | "env" ->
+       Result.map
+         (fun key -> Runtime_schema.Env key)
+         (required_non_empty_string
+            ~trim_result:true
+            tbl
+            ~path
+            ~key:"key"
+            ~message:"credential type 'env' requires non-empty 'key'")
+     | "file" ->
+       Result.map
+         (fun path -> Runtime_schema.File path)
+         (required_non_empty_string
+            ~trim_result:true
+            tbl
+            ~path
+            ~key:"path"
+            ~message:"credential type 'file' requires non-empty 'path'")
+     | "inline" ->
+       Result.map
+         (fun value -> Runtime_schema.Inline value)
+         (required_non_empty_string
+            tbl
+            ~path
+            ~key:"value"
+            ~message:"credential type 'inline' requires non-empty 'value'")
+     | t -> Error (error (path ^ ".type") (Printf.sprintf "unknown credential type %S" t)))
 ;;
 
 let parse_capabilities ~(path : string) (tbl : Otoml.t) : Runtime_schema.capabilities =
@@ -206,50 +243,39 @@ let parse_provider (id : string) (tbl : Otoml.t)
     let is_non_interactive =
       Otoml.find_or ~default:false tbl Otoml.get_boolean [ "is-non-interactive" ]
     in
-    let credentials =
+    let credentials_result =
       match Otoml.find_opt tbl Fun.id [ "credentials" ] with
       | Some cred_tbl ->
-        (match parse_credential cred_tbl (path ^ ".credentials") with
-         | Ok c -> Some c
-         | Error errs ->
-           (* [parse_credential] always wraps its single failure through
-              the [error] helper which builds a 1-element list, so the
-              [[]] branch is unreachable.  Typed for exhaustiveness so a
-              future change to the error-shape contract does not silently
-              lose the diagnostic. *)
-           let detail =
-             match errs with
-             | [] -> "<empty error list>"
-             | e :: _ -> Printf.sprintf "%s: %s" e.path e.message
-           in
-           Log.Runtime.warn "runtime_toml: %s" detail;
-           None)
-      | None -> None
+        Result.map Option.some (parse_credential cred_tbl (path ^ ".credentials"))
+      | None -> Ok None
     in
-    let capabilities =
-      Otoml.find_opt tbl Fun.id [ "capabilities" ]
-      |> Option.map (parse_capabilities ~path)
-    in
-    (* [providers.<id>.log] and [providers.<id>.healthcheck] sub-tables are
-       parse-and-ignore: their fields were dropped from
-       {!Runtime_schema.provider}, so they are neither read nor populated.
-       Leaving them in a TOML file is not an error. *)
-    let headers =
-      match Otoml.find_opt tbl Fun.id [ "headers" ] with
-      | None -> None
-      | Some h_tbl -> Some (parse_headers h_tbl (path ^ ".headers"))
-    in
-    Ok
-      { Runtime_schema.id
-      ; display_name
-      ; protocol
-      ; api_format
-      ; transport
-      ; is_non_interactive
-      ; credentials
-      ; capabilities
-      ; headers
-      }
+    (match credentials_result with
+     | Error errs -> Error errs
+     | Ok credentials ->
+       let capabilities =
+         Otoml.find_opt tbl Fun.id [ "capabilities" ]
+         |> Option.map (parse_capabilities ~path)
+       in
+       (* [providers.<id>.log] and [providers.<id>.healthcheck] sub-tables are
+          parse-and-ignore: their fields were dropped from
+          {!Runtime_schema.provider}, so they are neither read nor populated.
+          Leaving them in a TOML file is not an error. *)
+       let headers =
+         match Otoml.find_opt tbl Fun.id [ "headers" ] with
+         | None -> None
+         | Some h_tbl -> Some (parse_headers h_tbl (path ^ ".headers"))
+       in
+       Ok
+         { Runtime_schema.id
+         ; display_name
+         ; protocol
+         ; api_format
+         ; transport
+         ; is_non_interactive
+         ; credentials
+         ; capabilities
+         ; headers
+         })
 ;;
 
 let parse_providers (toml : Otoml.t)

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -53,6 +53,94 @@ let runpod_binding =
   ; num_ctx = None
   }
 
+let runtime_toml_with_credentials credentials =
+  Printf.sprintf
+    {|
+[runtime]
+default = "runpod_mtp.qwen"
+
+[providers.runpod_mtp]
+display-name = "RunPod"
+protocol = "provider_d-http"
+endpoint = "https://example-runpod.proxy.runpod.net/v1"
+
+%s
+
+[models.qwen]
+api-name = "qwen"
+max-context = 160000
+tools-support = true
+
+[runpod_mtp.qwen]
+is-default = true
+max-concurrent = 4
+|}
+    credentials
+
+let check_parse_error errors expected_path expected_message =
+  let matches =
+    List.exists
+      (fun (err : Runtime_toml.parse_error) ->
+         String.equal err.path expected_path
+         && String.equal err.message expected_message)
+      errors
+  in
+  check bool "expected parse error" true matches
+
+let test_runtime_toml_rejects_blank_env_credential_key () =
+  let content =
+    runtime_toml_with_credentials
+      {|
+[providers.runpod_mtp.credentials]
+type = "env"
+key = ""
+|}
+  in
+  match Runtime_toml.parse_string content with
+  | Ok _ -> fail "expected runtime TOML credential parse error"
+  | Error errors ->
+    check_parse_error
+      errors
+      "providers.runpod_mtp.credentials.key"
+      "credential type 'env' requires non-empty 'key'"
+
+let test_runtime_toml_rejects_missing_env_credential_key () =
+  let content =
+    runtime_toml_with_credentials
+      {|
+[providers.runpod_mtp.credentials]
+type = "env"
+|}
+  in
+  match Runtime_toml.parse_string content with
+  | Ok _ -> fail "expected runtime TOML credential parse error"
+  | Error errors ->
+    check_parse_error
+      errors
+      "providers.runpod_mtp.credentials.key"
+      "credential type 'env' requires non-empty 'key'"
+
+let test_runtime_toml_trims_env_credential_key () =
+  let content =
+    runtime_toml_with_credentials
+      {|
+[providers.runpod_mtp.credentials]
+type = "env"
+key = " OLLAMA_CLOUD_API_KEY "
+|}
+  in
+  match Runtime_toml.parse_string content with
+  | Error _ -> fail "expected runtime TOML to parse"
+  | Ok config ->
+    (match config.providers with
+     | [ provider ] ->
+       (match provider.credentials with
+        | Some (Runtime_schema.Env key) ->
+          check string "trimmed env key" "OLLAMA_CLOUD_API_KEY" key
+        | Some _ -> fail "expected env credential"
+        | None -> fail "expected credential")
+     | _ -> fail "expected one provider")
+
 let test_runtime_adapter_keeps_auth_out_of_headers () =
   let cfg =
     { Runtime_schema.providers = [ runpod_provider ]
@@ -296,6 +384,18 @@ let () =
             "runtime adapter filters TOML auth headers"
             `Quick
             test_runtime_adapter_filters_toml_auth_headers
+        ; test_case
+            "runtime TOML rejects blank env credential key"
+            `Quick
+            test_runtime_toml_rejects_blank_env_credential_key
+        ; test_case
+            "runtime TOML rejects missing env credential key"
+            `Quick
+            test_runtime_toml_rejects_missing_env_credential_key
+        ; test_case
+            "runtime TOML trims env credential key"
+            `Quick
+            test_runtime_toml_trims_env_credential_key
         ; test_case
             "runtime agent terminal observation carries model identity"
             `Quick


### PR DESCRIPTION
## Summary
- reject blank or missing runtime credential fields while parsing runtime.toml
- trim env credential keys and file paths before runtime auth resolution
- prevent the dashboard runtime editor from writing blank credential values

## Verification
- `pnpm exec vitest run --config vitest.config.ts src/lib/runtime-toml-config.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm typecheck`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_runtime_provider_auth_headers.exe`
- `./_build/default/test/test_runtime_provider_auth_headers.exe`