### PR TITLE
fix(otel): expose streaming and finish reason details

### DIFF
--- a/docs/rfc/RFC-0214-otel-genai-dual-emission.md
+++ b/docs/rfc/RFC-0214-otel-genai-dual-emission.md
@@ -105,8 +105,14 @@ Attributes to add per-inference:
 | `gen_ai.usage.cache_creation.input_tokens` | `response.usage.cache_creation_input_tokens` |
 | `gen_ai.usage.reasoning.output_tokens` | `response.telemetry.reasoning_tokens` |
 | `gen_ai.response.time_to_first_chunk` | `streaming_ttfrc_ms / 1000` |
-| `gen_ai.response.finish_reasons` | `stop_reason` |
+| `gen_ai.request.stream` | `true` on streaming callbacks |
+| `masc.gen_ai.response.finish_reason` | `stop_reason` |
 | `gen_ai.response.model` | `resolved_model_id` |
+
+`gen_ai.response.finish_reasons` is the upstream OpenTelemetry key, but it is a
+`string[]` attribute. The current opentelemetry-ocaml `key_value` type only
+supports scalar values, so MASC emits the scalar stop reason under the
+MASC-owned extension above instead of string-encoding the official array key.
 
 ## 4. Approach: OTel Migration
 

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -349,6 +349,11 @@ let make_hooks
           | Some { reasoning_tokens = Some rt; _ } when usage_trusted && rt > 0 -> rt
           | _ -> 0
         in
+        let request_stream =
+          match response.telemetry with
+          | Some { ttfrc_ms = Some _; _ } -> Some true
+          | _ -> None
+        in
         (* Cache-token tracking uses OAS-reported counters only. *)
         let cc = cache_creation_input_tokens in
         let cr = cache_read_input_tokens in
@@ -384,6 +389,8 @@ let make_hooks
           ~cache_creation_input_tokens
           ~cache_read_input_tokens
           ~reasoning_output_tokens
+          ?request_stream
+          ~finish_reason:(stop_reason_to_label response.stop_reason)
           ();
         (* Inference latency histogram for telemetry export.
            Missing telemetry stays a separate counter; zero/negative latency

--- a/lib/llm_metric_bridge.ml
+++ b/lib/llm_metric_bridge.ml
@@ -95,12 +95,24 @@ let positive_int_attrs attrs =
     | Some _ | None -> None)
 ;;
 
+let non_empty_string_attr key = function
+  | Some value when not (String.equal value "") -> [ key, `String value ]
+  | Some _ | None -> []
+;;
+
+let bool_attr key = function
+  | Some value -> [ key, `Bool value ]
+  | None -> []
+;;
+
 let emit_usage_details
       ?input_tokens
       ?output_tokens
       ?cache_creation_input_tokens
       ?cache_read_input_tokens
       ?reasoning_output_tokens
+      ?request_stream
+      ?finish_reason
       ~provider
       ~model_id
       ()
@@ -116,8 +128,16 @@ let emit_usage_details
         , reasoning_output_tokens )
       ]
   in
-  match detail_attrs with
-  | [] -> ()
+  let finish_attrs =
+    non_empty_string_attr
+      Otel_genai.Attr_key.masc_gen_ai_response_finish_reason
+      finish_reason
+  in
+  let request_stream_attrs =
+    bool_attr Otel_genai.Attr_key.gen_ai_request_stream request_stream
+  in
+  match detail_attrs, finish_attrs, request_stream_attrs with
+  | [], [], [] -> ()
   | _ ->
     note_provider ~model_id ~provider;
     let attrs =
@@ -126,6 +146,8 @@ let emit_usage_details
       ; Otel_genai.Attr_key.gen_ai_response_model, `String model_id
       ]
       @ detail_attrs
+      @ finish_attrs
+      @ request_stream_attrs
     in
     add_genai_attrs attrs;
     Otel_spans.add_event
@@ -303,7 +325,8 @@ let invalid_ms_reason value =
 
 let streaming_attrs ~provider ~model_id extra =
   [ Otel_genai.Attr_key.gen_ai_provider_name, `String provider
-  ; "gen_ai.request.model", `String model_id
+  ; Otel_genai.Attr_key.gen_ai_request_model, `String model_id
+  ; Otel_genai.Attr_key.gen_ai_request_stream, `Bool true
   ]
   @ extra
 ;;
@@ -328,6 +351,7 @@ let emit_streaming_first_chunk ~provider ~model_id ~ttfrc_ms =
     add_genai_attrs
       [ Otel_genai.Attr_key.gen_ai_provider_name, `String provider
       ; Otel_genai.Attr_key.gen_ai_request_model, `String model_id
+      ; Otel_genai.Attr_key.gen_ai_request_stream, `Bool true
       ; Otel_genai.Attr_key.gen_ai_response_time_to_first_chunk
         , `Float (ttfrc_ms /. 1000.0)
       ];

--- a/lib/llm_metric_bridge.mli
+++ b/lib/llm_metric_bridge.mli
@@ -47,6 +47,8 @@ val emit_usage_details
   -> ?cache_creation_input_tokens:int
   -> ?cache_read_input_tokens:int
   -> ?reasoning_output_tokens:int
+  -> ?request_stream:bool
+  -> ?finish_reason:string
   -> provider:string
   -> model_id:string
   -> unit

--- a/lib/otel_genai/otel_genai.ml
+++ b/lib/otel_genai/otel_genai.ml
@@ -32,6 +32,7 @@ module Attr_key = struct
 
   let gen_ai_tool_name = register Official_gen_ai "gen_ai.tool.name"
   let gen_ai_request_model = register Official_gen_ai "gen_ai.request.model"
+  let gen_ai_request_stream = register Official_gen_ai "gen_ai.request.stream"
   let gen_ai_response_model = register Official_gen_ai "gen_ai.response.model"
   let gen_ai_token_type = register Official_gen_ai "gen_ai.token.type"
   let gen_ai_usage_input_tokens =
@@ -64,6 +65,10 @@ module Attr_key = struct
 
   let masc_gen_ai_runtime_id =
     register Masc_extension "masc.gen_ai.runtime_id"
+  ;;
+
+  let masc_gen_ai_response_finish_reason =
+    register Masc_extension "masc.gen_ai.response.finish_reason"
   ;;
 
   let keeper_name = register Legacy "keeper.name"

--- a/lib/otel_genai/otel_genai.mli
+++ b/lib/otel_genai/otel_genai.mli
@@ -10,6 +10,7 @@ module Attr_key : sig
   val gen_ai_conversation_id : string
   val gen_ai_tool_name : string
   val gen_ai_request_model : string
+  val gen_ai_request_stream : string
   val gen_ai_response_model : string
   val gen_ai_token_type : string
   val gen_ai_usage_input_tokens : string
@@ -20,6 +21,7 @@ module Attr_key : sig
   val gen_ai_response_time_to_first_chunk : string
   val masc_gen_ai_keeper_name : string
   val masc_gen_ai_runtime_id : string
+  val masc_gen_ai_response_finish_reason : string
   val keeper_name : string
   val keeper_agent_name : string
   val keeper_trace_id : string

--- a/test/test_llm_metric_bridge.ml
+++ b/test/test_llm_metric_bridge.ml
@@ -340,6 +340,12 @@ let assoc_int key attrs =
   | Some _ -> Alcotest.failf "expected int attr %s" key
   | None -> Alcotest.failf "missing attr %s" key
 
+let assoc_bool key attrs =
+  match List.assoc_opt key attrs with
+  | Some (`Bool value) -> value
+  | Some _ -> Alcotest.failf "expected bool attr %s" key
+  | None -> Alcotest.failf "missing attr %s" key
+
 let genai_base_labels ~provider ~model_id =
   [ (Otel_genai.Attr_key.gen_ai_operation_name, "chat")
   ; (Otel_genai.Attr_key.gen_ai_provider_name, provider)
@@ -478,8 +484,57 @@ let test_usage_details_emit_cache_reasoning_attrs_without_token_type_aliases () 
        "event cache read tokens"
        7
        (assoc_int Otel_genai.Attr_key.gen_ai_usage_cache_read_input_tokens attrs)
-   | other ->
+  | other ->
      Alcotest.failf "expected one GenAI usage-details event, got %d"
+       (List.length other))
+
+let test_usage_details_emit_masc_finish_reason_extension () =
+  let events = ref [] in
+  let span_attrs = ref [] in
+  let provider = "bridge-genai-finish-provider" in
+  let model_id = Printf.sprintf "bridge-genai-finish-%d" (Unix.getpid ()) in
+  Otel_spans.with_test_event_emitter ~enabled:true
+    ~emit_event:(fun ~name ~attrs -> events := (name, attrs) :: !events)
+    ~emit_attrs:(fun ~attrs -> span_attrs := attrs @ !span_attrs)
+    (fun () ->
+       Bridge.emit_usage_details
+         ~provider
+         ~model_id
+         ~request_stream:true
+         ~finish_reason:"end_turn"
+         ());
+  Alcotest.(check string)
+    "span finish reason extension"
+    "end_turn"
+    (assoc_string
+       Otel_genai.Attr_key.masc_gen_ai_response_finish_reason
+       !span_attrs);
+  Alcotest.(check bool)
+    "official finish_reasons is not string-encoded"
+    false
+    (List.mem_assoc "gen_ai.response.finish_reasons" !span_attrs);
+  Alcotest.(check bool)
+    "span request stream"
+    true
+    (assoc_bool Otel_genai.Attr_key.gen_ai_request_stream !span_attrs);
+  (match List.rev !events with
+   | [ name, attrs ] ->
+     Alcotest.(check string)
+       "operation details event"
+       Otel_genai.Event_name.client_inference_operation_details
+       name;
+     Alcotest.(check string)
+       "event finish reason extension"
+       "end_turn"
+       (assoc_string
+          Otel_genai.Attr_key.masc_gen_ai_response_finish_reason
+          attrs);
+     Alcotest.(check bool)
+       "event request stream"
+       true
+       (assoc_bool Otel_genai.Attr_key.gen_ai_request_stream attrs)
+   | other ->
+     Alcotest.failf "expected one GenAI finish-reason event, got %d"
        (List.length other))
 
 let test_latency_and_streaming_emit_genai_metrics () =
@@ -585,6 +640,10 @@ let test_streaming_callbacks_emit_otel_events () =
       "first model"
       model_id
       (assoc_string "gen_ai.request.model" first_attrs);
+    Alcotest.(check bool)
+      "first stream attr"
+      true
+      (assoc_bool Otel_genai.Attr_key.gen_ai_request_stream first_attrs);
     Alcotest.(check (float 0.0001))
       "ttfrc ms"
       25.0
@@ -601,6 +660,10 @@ let test_streaming_callbacks_emit_otel_events () =
       "chunk model"
       model_id
       (assoc_string "gen_ai.request.model" chunk_attrs);
+    Alcotest.(check bool)
+      "chunk stream attr"
+      true
+      (assoc_bool Otel_genai.Attr_key.gen_ai_request_stream chunk_attrs);
     Alcotest.(check (float 0.0001))
       "inter chunk ms"
       7.5
@@ -730,6 +793,9 @@ let () =
           Alcotest.test_case
             "usage details keep cache and reasoning out of token.type" `Quick
             test_usage_details_emit_cache_reasoning_attrs_without_token_type_aliases;
+          Alcotest.test_case
+            "usage details emit MASC finish reason extension" `Quick
+            test_usage_details_emit_masc_finish_reason_extension;
           Alcotest.test_case
             "latency and streaming emit GenAI metrics" `Quick
             test_latency_and_streaming_emit_genai_metrics;


### PR DESCRIPTION
Summary
- add official `gen_ai.request.stream=true` attributes on streaming GenAI span/events and operation details when TTFC telemetry proves streaming
- expose stop reason as MASC-owned `masc.gen_ai.response.finish_reason` instead of mis-encoding official `gen_ai.response.finish_reasons` string[] as a scalar
- document the opentelemetry-ocaml scalar key_value limitation and add regression coverage

Tests
- `ocamlformat --check lib/otel_genai/otel_genai.mli lib/otel_genai/otel_genai.ml lib/llm_metric_bridge.mli lib/llm_metric_bridge.ml lib/keeper/keeper_hooks_oas.ml test/test_llm_metric_bridge.ml`
- `git diff --check`
- `python3 scripts/rfc_enforcer.py --check-numbering --base-ref origin/main --head-ref HEAD`
- `env MASC_DUNE_THROTTLE=0 MASC_OPAM_LOCK=0 MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_BUILD_DIR=/private/tmp/masc-mcp-otel-finish-reasons-20260606-rebase scripts/dune-local.sh build test/test_llm_metric_bridge.exe test/test_otel_dispatch_hook.exe --display=quiet`
- `/private/tmp/masc-mcp-otel-finish-reasons-20260606-rebase/default/test/test_llm_metric_bridge.exe`
- `/private/tmp/masc-mcp-otel-finish-reasons-20260606-rebase/default/test/test_otel_dispatch_hook.exe`