### PR TITLE
[codex] make cost thresholds non-gating

### DIFF
--- a/docs/BOOT-ENV-STATE-INVENTORY.md
+++ b/docs/BOOT-ENV-STATE-INVENTORY.md
@@ -166,7 +166,8 @@ stale_sec = 600
 grace_sec = 900
 ```
 
-`tool_cost_max_usd = 0` means unlimited and disables the keeper cost gate.
+`tool_cost_max_usd = 0` leaves the advisory cost threshold unset. Cost
+thresholds are telemetry only and never gate keeper tool execution.
 
 **Implementation**: `lib/keeper/keeper_runtime_config.ml` maintains a
 `key_to_env` table mapping TOML dotted keys to env var names. Values

--- a/docs/KEEPER-CAPABILITY-MATRIX.md
+++ b/docs/KEEPER-CAPABILITY-MATRIX.md
@@ -108,7 +108,7 @@ surfaces.
 
 | Gate | Description | Config |
 |------|-------------|--------|
-| Cost budget | Per-session limit | `max_cost_usd` (default: $0.50) |
+| Cost telemetry | Advisory threshold only; never gates tool execution | `max_cost_usd` (default: $0.50) |
 | Turn limit | Max tool calls per turn | `max_tool_calls_per_turn` (default: 10) |
 | Entropy | Consecutive same-tool detection | `entropy_threshold` (default: 3) |
 | Destructive | Pattern-match on bash/edit commands | 19 patterns, substring match |

--- a/docs/spec/05-keeper-agent.md
+++ b/docs/spec/05-keeper-agent.md
@@ -384,9 +384,9 @@ OAS Agent.run의 hook lifecycle에 keeper 동작을 주입:
 
 | 검사 | 동작 |
 |------|------|
-| Cost budget | 누적 cost가 한도 초과 시 tool call 거부 |
 | Destructive pattern | `rm -rf`, `drop table`, `force push` 등 위험 패턴 감지 시 거부 |
 | Autonomy filter | autonomy_level에 따라 허용 tool 목록 필터링 |
+| Cost telemetry | 비용은 ledger/dashboard에 기록한다. Cost threshold는 tool call 거부 사유가 아니다. |
 
 Destructive check 대상 도구: `tool_execute`, `tool_edit_file`, `keeper_edit`
 

--- a/docs/spec/15-testing.md
+++ b/docs/spec/15-testing.md
@@ -120,19 +120,21 @@ rg -n '^\((test|tests|executable)\b|^\s+\((name|names|modules)\b' test/dune test
 Keeper tool call의 사전/사후 실행 게이트. Swiss Cheese Model (다중 방어층).
 
 ```
-Tool call -> Cost budget check
-          -> Destructive pattern detection
+Tool call -> Destructive pattern detection
           -> Tool allowlist check
           -> Entropy check (동일 도구 N회 연속 호출)
           -> [모두 Pass] -> 실행 허용
           -> [하나라도 Reject] -> 실행 차단
 ```
 
+Current-source overlay: `max_cost_usd` is advisory telemetry only and is not a
+pre-execution gate.
+
 **gate_config 기본값**:
 
 | 파라미터 | 기본값 | 설명 |
 |---------|--------|------|
-| `max_cost_usd` | 0 | 세션 비용 한도 (`0`이면 비활성) |
+| `max_cost_usd` | 0 | Advisory cost threshold. Cost never gates execution. |
 | `max_tool_calls_per_turn` | 10 | 턴당 도구 호출 상한 |
 | `entropy_threshold` | 3 | 동일 도구 연속 호출 임계값 |
 | `destructive_check_enabled` | true | 파괴적 명령 탐지 |
@@ -305,7 +307,7 @@ bisect-ppx-report html --coverage-path _coverage
 - **INV-T4**: `trajectory.tool_call_entry`의 `gate_decision`이 `Reject`이면 `result`는 반드시 `None`이다.
 - **INV-T5**: `anti_fake` penalty 패턴에 매칭되는 테스트 파일은 `quality_tier`에서 경고 또는 위험으로 분류된다.
 - **INV-T6**: Contract harness는 외부 서버에 의존하지 않는다. Hermetic bootstrap 경로만 사용한다.
-- **INV-T7**: `eval_harness` 시나리오의 `max_cost_usd`를 초과하면 `trajectory_outcome`은 `CostExceeded`이다.
+- **INV-T7**: `eval_harness` 시나리오의 `max_cost_usd` 초과는 telemetry/warning only이다. Cost만으로 `trajectory_outcome`을 `CostExceeded`, `Gated`, `Failed`, 또는 `Timeout`으로 바꾸면 안 된다.
 
 ---
 

--- a/lib/eval_gate.ml
+++ b/lib/eval_gate.ml
@@ -1,10 +1,11 @@
 (** Eval_gate — Pre/Post execution gates for Keeper tool calls.
 
     Multi-layer defense (Swiss Cheese Model):
-    1. Cost budget check — reject if accumulated cost exceeds limit
-    2. Destructive operation detection — reject bash commands with rm/drop/etc.
-    3. Tool allowlist — reject tools not in keeper's permitted set
-    4. Entropy check — reject if same tool called N+ times consecutively
+    1. Destructive operation detection — reject bash commands with rm/drop/etc.
+    2. Tool allowlist — reject tools not in keeper's permitted set
+    3. Entropy check — reject if same tool called N+ times consecutively
+
+    Cost thresholds are advisory telemetry only and must not reject execution.
 
     Each gate check is independent: any single rejection blocks execution.
     This prevents a failure in one layer from being masked by another.
@@ -20,11 +21,11 @@ let eval_cost_warn_ratio = 0.8
 
 type gate_config = {
   max_cost_usd : float;
-  (** Per-session cost limit.
+  (** Per-session advisory cost threshold.
       Default 0.50 USD. Based on observed MASC keeper sessions averaging
       $0.02-0.15 per session (local llama + GLM fallback). 0.50 is ~3x the
-      worst-case observed session cost, providing headroom without allowing
-      runaway spending. Adjust upward if using expensive cloud models directly. *)
+      worst-case observed session cost. This value may drive warnings and
+      reporting, but never gates tool execution. *)
 
   max_tool_calls_per_turn : int;
   (** Max tool calls in a single LLM turn (before yielding control).
@@ -230,10 +231,11 @@ let detect_destructive (command : string) : (string * string) option =
     The checks run in order of cheapest-to-evaluate first:
     1. Deny list (O(n) string compare)
     2. Allowlist (O(n) string compare)
-    3. Cost budget (float compare)
-    4. Turn call limit (int compare)
-    5. Entropy (list scan)
-    6. Destructive pattern (string scan, only for bash tools)
+    3. Turn call limit (int compare)
+    4. Entropy (list scan)
+    5. Destructive pattern (string scan, only for bash tools)
+
+    Cost is telemetry-only and is intentionally not checked here.
 
     First rejection wins — remaining checks are skipped. *)
 
@@ -254,7 +256,8 @@ let pre_check
     ~(trajectory_acc : Trajectory.accumulator option)
     ~(tool_name : string)
     ~(args_json : string)
-    : Trajectory.gate_decision =
+  : Trajectory.gate_decision =
+  ignore accumulated_cost;
 
   let tool_policy = tool_policy_of_config config in
   let deny_hit =
@@ -270,12 +273,7 @@ let pre_check
   else if not allow_hit then
     Trajectory.Reject (Printf.sprintf "tool '%s' not in allowlist" tool_name)
 
-  (* 3. Cost budget *)
-  else if accumulated_cost >= config.max_cost_usd then
-    Trajectory.Reject (Printf.sprintf "cost budget exceeded: $%.4f >= $%.4f limit"
-      accumulated_cost config.max_cost_usd)
-
-  (* 4. Turn call limit *)
+  (* 2. Turn call limit *)
   else begin
     match trajectory_acc with
     | Some acc ->
@@ -394,17 +392,19 @@ let post_eval
     else None
   in
 
-  (* Warn if approaching cost limit.
+  (* Warn if approaching advisory cost threshold.
      80%% threshold: standard practice from capacity planning (e.g., disk usage
      alerts at 80%%). Gives ~20%% remaining budget for the agent to wrap up
-     gracefully rather than hitting a hard wall mid-operation. *)
+     gracefully. This is not a hard wall. *)
   let new_cost = accumulated_cost +. cost in
   let cost_warn_ratio = eval_cost_warn_ratio in
-  let approaching_limit = new_cost >= config.max_cost_usd *. cost_warn_ratio in
+  let approaching_limit =
+    config.max_cost_usd > 0.0 && new_cost >= config.max_cost_usd *. cost_warn_ratio
+  in
   let should_warn = approaching_limit in
   let warning =
     if approaching_limit then
-      Some (Printf.sprintf "approaching cost limit: $%.4f / $%.4f (%.0f%%)"
+      Some (Printf.sprintf "approaching advisory cost threshold: $%.4f / $%.4f (%.0f%%)"
         new_cost config.max_cost_usd (new_cost /. config.max_cost_usd *. 100.0))
     else None
   in

--- a/lib/eval_gate.mli
+++ b/lib/eval_gate.mli
@@ -1,15 +1,17 @@
 (** Eval_gate — Pre/Post execution gates for Keeper tool calls.
 
     Multi-layer defense (Swiss Cheese Model):
-    1. Cost budget check
-    2. Destructive operation detection
-    3. Tool allowlist
-    4. Entropy check *)
+    1. Destructive operation detection
+    2. Tool allowlist
+    3. Entropy check
+
+    Cost thresholds are advisory telemetry only and must not reject execution. *)
 
 (** {1 Configuration} *)
 
 type gate_config = {
   max_cost_usd : float;
+  (** Advisory cost threshold used for reporting/warnings only. *)
   max_tool_calls_per_turn : int;
   entropy_threshold : int;
   destructive_check_enabled : bool;

--- a/lib/eval_harness.ml
+++ b/lib/eval_harness.ml
@@ -63,7 +63,7 @@ type scenario = {
   tool_expectations : tool_expectation list;
   graders : grader list;
   max_turns : int;                    (** Max turns before timeout *)
-  max_cost_usd : float;              (** Cost budget for this scenario *)
+  max_cost_usd : float;              (** Advisory cost threshold for this scenario *)
   tags : string list;                 (** Filtering tags: "regression", "smoke", etc. *)
 }
 

--- a/lib/governance_registry.ml
+++ b/lib/governance_registry.ml
@@ -234,10 +234,10 @@ let dashboard_agent_stuck_threshold_sec =
 
 (* ── cost_policy surface ──────────────────────────────────────── *)
 
-(** Per-session cost ceiling in USD.
+(** Per-session advisory cost threshold in USD.
     Default 0.50: based on observed keeper sessions averaging $0.02-0.15
     (local llama + GLM fallback). 0.50 is ~3x worst-case observed session cost.
-    Governs Eval_gate.max_cost_usd pre-execution gating. *)
+    Used for reporting/warnings only; it must not gate execution. *)
 let _cost_max_session_usd =
   register_float
     ~key:"cost.max_session_usd"

--- a/lib/keeper/keeper_deliberation.ml
+++ b/lib/keeper/keeper_deliberation.ml
@@ -295,10 +295,13 @@ let deterministic_baseline_action (obs : world_observation) : deliberation_actio
 let daily_budget_usd () : float =
   Env_config.KeeperRuntime.deliberation_daily_budget_usd ()
 
-(** Check whether the keeper has remaining budget for another deliberation call.
-    Returns [true] if [cost_today_usd < daily_budget_usd]. *)
+(** Advisory cost telemetry for deliberation.
+
+    Deliberation must not be blocked by a daily cost threshold. *)
 let deliberation_budget_check ~daily_budget_usd ~cost_today_usd : bool =
-  cost_today_usd < daily_budget_usd
+  ignore daily_budget_usd;
+  ignore cost_today_usd;
+  true
 
 (* ---------- Prompt builder ---------- *)
 

--- a/lib/keeper/keeper_deliberation.mli
+++ b/lib/keeper/keeper_deliberation.mli
@@ -138,8 +138,9 @@ val deterministic_baseline_action : world_observation -> deliberation_action
     ([MASC_KEEPER_DELIBERATION_DAILY_BUDGET_USD], default: 0.10). *)
 val daily_budget_usd : unit -> float
 
-(** Check whether the keeper has remaining budget for deliberation.
-    Returns [true] when [cost_today_usd < daily_budget_usd]. *)
+(** Advisory cost telemetry for deliberation.
+
+    Always returns [true]; daily cost thresholds must not gate deliberation. *)
 val deliberation_budget_check :
   daily_budget_usd:float -> cost_today_usd:float -> bool
 

--- a/lib/keeper/keeper_guards.ml
+++ b/lib/keeper/keeper_guards.ml
@@ -228,7 +228,7 @@ let planner_alternative_for_gate ~stage ~tool_name =
   | "keeper_deny" ->
     "planner_alternative=\"choose an allowed replacement tool, change plan, or request operator approval\""
   | "cost_gate" ->
-    "planner_alternative=\"stop tool use, summarize progress, or request a budget increase before retrying\""
+    "planner_alternative=\"cost telemetry is advisory; inspect the real gate before changing plan\""
   | "destructive_guard" ->
     "planner_alternative=\"use a safe read-only command, narrow the path, or request operator approval\""
   | _ ->
@@ -609,52 +609,18 @@ let deny_guard
       else Agent_sdk.Hooks.Continue
     | _ -> Agent_sdk.Hooks.Continue)
 
-(** Cost budget gate: reject when the running cost meets or exceeds
-    [limit]. No-op when [max_cost_usd] is [None]. *)
+(** Cost telemetry passthrough.
+
+    [max_cost_usd] is advisory only and must never reject tool execution. *)
 let cost_guard
     ~(meta_ref : Keeper_meta_contract.keeper_meta ref)
     ~on_gate_decision
     ~(max_cost_usd : float option)
   : Agent_sdk.Hooks.hooks =
-  hooks_of_pre_tool_use (fun event ->
-    match event with
-    | Agent_sdk.Hooks.PreToolUse
-        { tool_name; input; accumulated_cost_usd; turn; _ } ->
-      let t0 = Time_compat.now () in
-      let keeper_name = (!meta_ref).name in
-      (match max_cost_usd with
-       | Some limit when accumulated_cost_usd >= limit ->
-         let reason_text =
-           Printf.sprintf
-             "accumulated_cost_usd=%.4f exceeded limit=%.4f"
-             accumulated_cost_usd limit
-         in
-         let latency_ms = (Time_compat.now () -. t0) *. 1000.0 in
-         Otel_metric_store.inc_counter
-           Keeper_metrics.(to_string GuardsFailures)
-           ~labels:[("keeper", keeper_name); ("site", "cost_gate")]
-           ();
-         log_gate_rejection
-           ~keeper_name ~stage:"cost_gate" ~tool_name
-           ~reason_code:"cost_gate"
-           "keeper:%s cost gate: $%.4f >= $%.4f limit, skipping %s"
-           keeper_name accumulated_cost_usd limit tool_name;
-         broadcast_tool_skipped
-           ~keeper_name ~tool_name ~reason_code:"cost_gate";
-         let source_path = keeper_guards_source_path in
-         let source_line = __LINE__ in
-         report_gate_decision on_gate_decision
-           ~source_path:(Some source_path) ~source_line:(Some source_line)
-           ~stage:"cost_gate" ~decision:Gate_override
-           ~reason_code:"cost_gate" ~reason_text
-           ~tool_name ~keeper_name ~input ~turn ~accumulated_cost_usd
-           ~stage_latency_ms:latency_ms;
-         Agent_sdk.Hooks.Override
-           (render_inline_skip_reason_with_source
-              ~source_path ~source_line
-              ~tool_name ~reason_code:"cost_gate" ~reason_text)
-       | _ -> Agent_sdk.Hooks.Continue)
-    | _ -> Agent_sdk.Hooks.Continue)
+  ignore meta_ref;
+  ignore on_gate_decision;
+  ignore max_cost_usd;
+  hooks_of_pre_tool_use (fun _event -> Agent_sdk.Hooks.Continue)
 
 (** Destructive pattern detection for bash/edit style tools.
     Only applies when [enabled] is [true] and descriptor/catalog capability
@@ -761,7 +727,7 @@ let governance_approval_guard
     Order matters: the first guard to return a non-[Continue]
     decision wins (short-circuit via [Hooks.compose]). Preserves the
     ordering of the previous monolithic implementation:
-      timing -> custom -> streak -> deny -> cost -> destructive ->
+      timing -> custom -> streak -> deny -> cost telemetry passthrough -> destructive ->
       governance_approval *)
 let build_chain
     ~(meta_ref : Keeper_meta_contract.keeper_meta ref)

--- a/lib/keeper/keeper_guards.mli
+++ b/lib/keeper/keeper_guards.mli
@@ -175,8 +175,9 @@ val deny_guard :
   denied:string list ->
   Agent_sdk.Hooks.hooks
 
-(** Reject when the running cost meets or exceeds [max_cost_usd].
-    No-op when [None]. *)
+(** Cost telemetry passthrough.
+
+    [max_cost_usd] is advisory only and must never reject tool execution. *)
 val cost_guard :
   meta_ref:Keeper_meta_contract.keeper_meta ref ->
   on_gate_decision:(gate_decision_event -> unit) ->

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -4,9 +4,10 @@
     safety gates) to OAS hook events.
 
     Safety checks in [pre_tool_use]:
-    - Cost budget: reject tool calls when accumulated cost exceeds limit
     - Destructive patterns: reject bash/edit tools with dangerous commands
       (rm -rf, drop table, force push, etc.)
+
+    Cost is telemetry-only and must not reject tool calls.
 
     These checks were previously in [Eval_gate.guarded_execute] and are
     now natively integrated into the Agent.run() hook lifecycle.
@@ -194,13 +195,13 @@ include Keeper_hooks_oas_cost_events
 
     All keepers receive the full tool set unconditionally.
     Safety is enforced through eval_gate deny lists and these hooks:
-    1. Cost budget — reject when accumulated cost exceeds limit
-    2. Destructive pattern detection — reject dangerous bash/edit commands
-    3. Cost event emission — auto-emit per-turn cost to .masc/costs.jsonl
+    1. Destructive pattern detection — reject dangerous bash/edit commands
+    2. Cost event emission — auto-emit per-turn cost to .masc/costs.jsonl
+    3. Advisory cost threshold reporting — never rejects tool calls
 
     @param meta_ref Mutable ref to keeper metadata
     @param generation Current generation counter
-    @param max_cost_usd Optional cost budget (rejects tool calls above limit)
+    @param max_cost_usd Optional advisory cost threshold; never rejects tool calls
     @param destructive_check Enable destructive pattern detection (default true)
     @param pre_tool_use_guard Optional callback that can short-circuit a tool
            before execution by returning an inline override response.

--- a/lib/keeper/keeper_hooks_oas.mli
+++ b/lib/keeper/keeper_hooks_oas.mli
@@ -182,7 +182,7 @@ val make_hooks :
   ?trajectory_acc:Trajectory.accumulator ->
   unit -> Agent_sdk.Hooks.hooks
 (** Build the [Agent_sdk.Hooks.hooks] record used by the keeper turn loop:
-    pre-tool gate, post-tool accounting, idle-detection, cost guard,
+    pre-tool gate, post-tool accounting, idle-detection, cost telemetry,
     and trajectory hooks all wired together. *)
 
 val hook_introspection_json :

--- a/lib/keeper/keeper_hooks_oas_introspection.ml
+++ b/lib/keeper/keeper_hooks_oas_introspection.ml
@@ -72,9 +72,14 @@ let hook_introspection_json ~denied_tools ?(max_cost_usd : float option)
             "custom_guard";
             "streak_gate";
             "keeper_deny_list";
-            (if Option.is_some max_cost_usd then "cost_budget" else "cost_budget_off");
             (if destructive_check then "destructive_pattern" else "destructive_pattern_off");
             "governance_approval";
+          ]
+        ~features:
+          [
+            (if Option.is_some max_cost_usd
+             then "cost_telemetry_threshold"
+             else "cost_telemetry_threshold_off");
           ]
         "pre_tool_use";
       slot
@@ -157,9 +162,11 @@ let hook_introspection_json ~denied_tools ?(max_cost_usd : float option)
       ("deny_list", denied_json);
       (key_deny_list_count, `Int (List.length denied_tools));
       ("destructive_check_tools", destructive_json);
-      ( "cost_budget",
+      ( "cost_telemetry",
         match max_cost_usd with
-        | Some v -> `Assoc [ (key_max_cost_usd, `Float v); (key_active, `Bool true) ]
-        | None -> `Assoc [ (key_active, `Bool false) ] );
+        | Some v ->
+          `Assoc
+            [ (key_max_cost_usd, `Float v); (key_active, `Bool true); ("enforced", `Bool false) ]
+        | None -> `Assoc [ (key_active, `Bool false); ("enforced", `Bool false) ] );
     ]
 ;;

--- a/lib/trajectory/trajectory.mli
+++ b/lib/trajectory/trajectory.mli
@@ -1,6 +1,6 @@
-(** Trajectory — Tool call recording and cost/entropy gates for keeper sessions.
+(** Trajectory — Tool call recording, cost telemetry, and entropy gates for keeper sessions.
 
-    Tracks tool calls per turn, accumulated cost, and detects stuck loops
+    Tracks tool calls per turn, accumulated cost telemetry, and detects stuck loops
     via entropy checking. Persists trajectory data as JSONL for post-hoc analysis. *)
 
 (** {1 Types} *)

--- a/lib/verifier_oas.ml
+++ b/lib/verifier_oas.ml
@@ -297,7 +297,7 @@ let read_only_predicate (schema : Agent_sdk.Types.tool_schema) : bool =
     - Both enabled -> AllowList (stricter; deny is redundant)
     - Neither -> AllowAll
 
-    Dynamic runtime checks (cost budget, entropy, destructive patterns)
+    Dynamic runtime checks (cost telemetry, entropy, destructive patterns)
     remain in Eval_gate. OAS Guardrails handles static pre-filtering;
     Eval_gate handles stateful per-call checks. Together they form
     defense-in-depth.

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -298,11 +298,12 @@ let render_worker_skip_reason ~tool_name ~reason_code ~reason_text =
 
 (** Build pre_tool_use hook with optional safety gates.
 
-    When [gate_config] is provided, adds 3-gate defense-in-depth
+    When [gate_config] is provided, adds safety defense-in-depth
     (same pattern as keeper_hooks_oas.ml):
     - Gate 0: Deny list — reject tools in [gate_config.denied_tools]
-    - Gate 1: Cost budget — reject when [accumulated_cost_usd >= max_cost_usd]
-    - Gate 2: Destructive pattern detection — reject dangerous shell commands
+    - Gate 1: Destructive pattern detection — reject dangerous shell commands
+
+    [gate_config.max_cost_usd] is advisory telemetry only and must not reject.
 
     When [gate_config] is None, only name tracking is performed (backward compat).
 
@@ -315,7 +316,7 @@ let make_tool_tracking_hooks ?gate_config ?context () =
         Some
           (fun event ->
             match event with
-            | Agent_sdk.Hooks.PreToolUse { tool_name; input; accumulated_cost_usd; _ } ->
+            | Agent_sdk.Hooks.PreToolUse { tool_name; input; _ } ->
               (* Always track tool names *)
               tool_names_ref := tool_name :: !tool_names_ref;
               (* Safety gates (when gate_config is provided) *)
@@ -335,27 +336,7 @@ let make_tool_tracking_hooks ?gate_config ?context () =
                         ~reason_code:"worker_deny"
                         ~reason_text:"tool is on the worker deny list"))
                  else if
-                   (* Gate 1: Cost budget *)
-                   accumulated_cost_usd >= gate.max_cost_usd
-                 then (
-                   let reason_text =
-                     Printf.sprintf
-                       "accumulated_cost_usd=%.4f exceeded limit=%.4f"
-                       accumulated_cost_usd
-                       gate.max_cost_usd
-                   in
-                   Log.LocalWorker.warn
-                     "worker cost gate: $%.4f >= $%.4f limit, skipping %s"
-                     accumulated_cost_usd
-                     gate.max_cost_usd
-                     tool_name;
-                   Agent_sdk.Hooks.Override
-                     (render_worker_skip_reason
-                        ~tool_name
-                        ~reason_code:"cost_gate"
-                        ~reason_text))
-                 else if
-                   (* Gate 2: Destructive pattern detection *)
+                   (* Gate 1: Destructive pattern detection *)
                    gate.destructive_check_enabled
                    && Tool_capability.has Tool_capability.Destructive tool_name
                  then (

--- a/test/test_cost_token_decouple.ml
+++ b/test/test_cost_token_decouple.ml
@@ -4,7 +4,7 @@
     [zero_token_usage_reported]) forced the accounted [cost_usd] to 0.0 and the
     source label to [usage_untrusted], even when the provider reported a positive
     authoritative cost. Empirically this had never suppressed a real dollar (all
-    untrusted ledger rows carried raw_cost_usd=0.0), so the gate was a no-op that
+    untrusted ledger rows carried raw_cost_usd=0.0), so the coupling was a no-op that
     carried a latent footgun: a future provider reporting 0 tokens + nonzero
     cost_usd would have real spend silently dropped from accounting.
 

--- a/test/test_cost_usd_source_attribution_10318.ml
+++ b/test/test_cost_usd_source_attribution_10318.ml
@@ -25,7 +25,7 @@
 
     Precedence is fixed (top-down) so a missing-usage call on a
     pricing-known model still labels [missing_usage], not
-    [oas_cost_unreported] — the upstream gate is the more
+    [oas_cost_unreported] — the upstream signal is the more
     actionable failure mode. *)
 
 open Alcotest

--- a/test/test_eval_gate.ml
+++ b/test/test_eval_gate.ml
@@ -100,7 +100,7 @@ let test_pre_allowlist_pass () =
   | Trajectory.Reject r -> Alcotest.fail (Printf.sprintf "Should pass: %s" r)
 
 (* ================================================================ *)
-(* Test: pre_check — cost budget                                     *)
+(* Test: pre_check — advisory cost threshold                         *)
 (* ================================================================ *)
 
 let test_pre_cost_exceeded () =
@@ -108,12 +108,9 @@ let test_pre_cost_exceeded () =
     ~config:default_config ~accumulated_cost:0.60 ~trajectory_acc:None
     ~tool_name:"tool_execute" ~args_json:"{\"command\": \"echo hi\"}" in
   match decision with
-  | Trajectory.Reject reason ->
-      Alcotest.(check bool) "cost exceeded reason" true
-        (let r = String.lowercase_ascii reason in
-         try ignore (Str.search_forward (Str.regexp_string "cost") r 0); true
-         with Not_found -> false)
-  | Trajectory.Pass -> Alcotest.fail "Should reject when cost exceeded"
+  | Trajectory.Pass -> ()
+  | Trajectory.Reject r ->
+      Alcotest.fail (Printf.sprintf "Cost threshold must be advisory: %s" r)
 
 let test_pre_cost_within_budget () =
   let decision = Eval_gate.pre_check
@@ -382,7 +379,7 @@ let () =
       Alcotest.test_case "deny list" `Quick test_pre_deny_list;
       Alcotest.test_case "allowlist reject" `Quick test_pre_allowlist_reject;
       Alcotest.test_case "allowlist pass" `Quick test_pre_allowlist_pass;
-      Alcotest.test_case "cost exceeded" `Quick test_pre_cost_exceeded;
+      Alcotest.test_case "cost threshold is advisory" `Quick test_pre_cost_exceeded;
       Alcotest.test_case "cost within budget" `Quick test_pre_cost_within_budget;
       Alcotest.test_case "destructive bash" `Quick test_pre_destructive_bash;
       Alcotest.test_case "safe bash" `Quick test_pre_safe_bash;

--- a/test/test_keeper_deliberation.ml
+++ b/test/test_keeper_deliberation.ml
@@ -582,15 +582,15 @@ let test_budget_check_under_budget () =
     (D.deliberation_budget_check ~daily_budget_usd:0.10 ~cost_today_usd:0.05)
 
 let test_budget_check_at_budget () =
-  check bool "at budget (should fail)" false
+  check bool "at budget remains advisory" true
     (D.deliberation_budget_check ~daily_budget_usd:0.10 ~cost_today_usd:0.10)
 
 let test_budget_check_over_budget () =
-  check bool "over budget" false
+  check bool "over budget remains advisory" true
     (D.deliberation_budget_check ~daily_budget_usd:0.10 ~cost_today_usd:0.15)
 
 let test_budget_check_zero_budget () =
-  check bool "zero budget always fails" false
+  check bool "zero budget remains advisory" true
     (D.deliberation_budget_check ~daily_budget_usd:0.0 ~cost_today_usd:0.0)
 
 let test_budget_check_zero_cost () =
@@ -1135,11 +1135,11 @@ let () =
         [
           test_case "under budget returns true" `Quick
             test_budget_check_under_budget;
-          test_case "at budget returns false" `Quick
+          test_case "at budget remains advisory" `Quick
             test_budget_check_at_budget;
-          test_case "over budget returns false" `Quick
+          test_case "over budget remains advisory" `Quick
             test_budget_check_over_budget;
-          test_case "zero budget always false" `Quick
+          test_case "zero budget remains advisory" `Quick
             test_budget_check_zero_budget;
           test_case "zero cost under positive budget" `Quick
             test_budget_check_zero_cost;

--- a/test/test_keeper_guards.ml
+++ b/test/test_keeper_guards.ml
@@ -301,7 +301,7 @@ let test_deny_guard_continues () =
   let d = invoke hook (pre_tool_use_event ~tool_name:"allowed_tool" ()) in
   check string "allowed tool -> Continue" "Continue" (decision_kind d)
 
-let test_cost_guard_blocks () =
+let test_cost_guard_over_limit_continues () =
   let meta_ref = make_meta_ref "test_keeper" in
   let hook =
     KG.cost_guard ~meta_ref ~on_gate_decision:no_gate_observer
@@ -310,7 +310,7 @@ let test_cost_guard_blocks () =
   let d = invoke hook
     (pre_tool_use_event ~tool_name:"expensive" ~accumulated_cost_usd:0.15 ())
   in
-  check string "over limit -> Override" "Override" (decision_kind d)
+  check string "over advisory threshold -> Continue" "Continue" (decision_kind d)
 
 let test_cost_guard_under_limit () =
   let meta_ref = make_meta_ref "test_keeper" in
@@ -489,7 +489,7 @@ let test_compose_all_short_circuits_at_first_override () =
   in
   check string "first Override wins" "Override" (decision_kind d);
   let text = override_text d in
-  (* The reason should be from deny_guard, not cost_gate *)
+  (* The reason should be from deny_guard. Cost telemetry never overrides. *)
   check bool "short-circuit preserves first reason" true
     (contains_substring text "code=keeper_deny")
 
@@ -554,7 +554,8 @@ let () = run "Keeper_guards" [
     test_case "continues for allowed tool" `Quick test_deny_guard_continues;
   ];
   "cost_guard", [
-    test_case "blocks over limit" `Quick test_cost_guard_blocks;
+    test_case "continues over advisory threshold" `Quick
+      test_cost_guard_over_limit_continues;
     test_case "continues under limit" `Quick test_cost_guard_under_limit;
     test_case "no budget -> continue" `Quick test_cost_guard_disabled;
   ];

--- a/test/test_keeper_unified_inline_skip.ml
+++ b/test/test_keeper_unified_inline_skip.ml
@@ -24,16 +24,16 @@ let test_render_inline_skip_reason_deny () =
   check bool "reason encoded" true (str_contains result "reason=tool%20is%20on")
 ;;
 
-let test_render_inline_skip_reason_cost () =
+let test_render_inline_skip_reason_policy () =
   let result =
     KG.render_inline_skip_reason
       ~tool_name:"tool_execute"
-      ~reason_code:"cost_gate"
-      ~reason_text:"accumulated_cost_usd=0.5100 exceeded limit=0.5000"
+      ~reason_code:"policy_gate"
+      ~reason_text:"policy gate sample"
   in
   check bool "prefix" true (String.starts_with ~prefix:"[tool_skipped]" result);
-  check bool "code" true (str_contains result "code=cost_gate");
-  check bool "reason encoded equals" true (str_contains result "0.5100%20exceeded")
+  check bool "code" true (str_contains result "code=policy_gate");
+  check bool "reason encoded equals" true (str_contains result "policy%20gate")
 ;;
 
 let test_render_inline_skip_reason_destructive () =
@@ -80,9 +80,9 @@ let () =
             `Quick
             test_render_inline_skip_reason_deny
         ; test_case
-            "render inline skip cost"
+            "render inline skip policy"
             `Quick
-            test_render_inline_skip_reason_cost
+            test_render_inline_skip_reason_policy
         ; test_case
             "render inline skip destructive"
             `Quick

--- a/test/test_runtime_toml_overrides.ml
+++ b/test/test_runtime_toml_overrides.ml
@@ -65,13 +65,13 @@ let test_missing_file_returns_zero () =
   | Ok n -> failf "expected 0 overrides, got %d" n
   | Error msg -> failf "unexpected error: %s" msg
 
-let test_missing_file_keeps_cost_gate_disabled_by_default () =
+let test_missing_file_keeps_cost_threshold_unset_by_default () =
   with_clean_boot_overrides @@ fun () ->
   with_base_path @@ fun base_path ->
   match Keeper_runtime_config.load_and_apply ~base_path with
   | Error msg -> failf "unexpected error: %s" msg
   | Ok _ ->
-    check (option (float 0.0001)) "cost gate disabled by default"
+    check (option (float 0.0001)) "cost threshold unset by default"
       None
       (Keeper_config.keeper_tool_cost_max_usd ())
 
@@ -372,7 +372,7 @@ let test_load_and_apply_records_disabled_turn_cost_override () =
     check (option string) "boot override stored"
       (Some "0")
       (Config_boot_overrides.get_opt "MASC_KEEPER_TOOL_COST_MAX_USD");
-    check (option (float 0.0001)) "cost gate disabled"
+    check (option (float 0.0001)) "cost threshold unset"
       None
       (Keeper_config.keeper_tool_cost_max_usd ())
 
@@ -587,7 +587,8 @@ let () =
   run "runtime_toml_overrides"
     [ ( "resolve_overrides"
       , [ test_case "missing file returns 0 overrides" `Quick test_missing_file_returns_zero
-        ; test_case "missing file keeps cost gate disabled by default" `Quick test_missing_file_keeps_cost_gate_disabled_by_default
+        ; test_case "missing file keeps cost threshold unset by default" `Quick
+            test_missing_file_keeps_cost_threshold_unset_by_default
         ; test_case "applies autonomous max_turns_per_call" `Quick test_applies_autonomous_max_turns
         ; test_case "applies multiple overrides" `Quick test_applies_multiple_overrides
         ; test_case "applies sleep/throttle overrides" `Quick test_applies_sleep_and_throttle_overrides

--- a/test/test_worker_safety_gates.ml
+++ b/test/test_worker_safety_gates.ml
@@ -1,9 +1,9 @@
 (** Tests for Worker safety gates in pre_tool_use hook.
 
-    Verifies the 3-gate defense-in-depth:
+    Verifies safety defense-in-depth:
     - Gate 0: Deny list
-    - Gate 1: Cost budget
-    - Gate 2: Destructive pattern detection
+    - Gate 1: Destructive pattern detection
+    - Advisory cost thresholds never gate execution
 
     Uses Masc.Worker_oas.make_tool_tracking_hooks with gate_config. *)
 
@@ -96,9 +96,9 @@ let test_deny_list_allows_non_denied () =
   check bool "continues" true
     (result = Agent_sdk.Hooks.Continue)
 
-(* ── Test: Gate 1 — Cost budget ──────────────── *)
+(* ── Test: Advisory cost telemetry ───────────── *)
 
-let test_cost_gate_blocks_over_budget () =
+let test_cost_threshold_allows_over_budget () =
   let gate_config = default_gate ~max_cost_usd:0.50 () in
   let _ref, hooks = WO.make_tool_tracking_hooks ~gate_config () in
   let result =
@@ -107,13 +107,10 @@ let test_cost_gate_blocks_over_budget () =
       ~input:`Null
       ~accumulated_cost_usd:0.55
   in
-  (match result with
-   | Agent_sdk.Hooks.Override msg ->
-     check bool "contains cost_gate" true
-       (Astring.String.is_infix ~affix:"cost_gate" msg)
-   | _ -> fail "expected Override for cost budget exceeded")
+  check bool "continues over advisory threshold" true
+    (result = Agent_sdk.Hooks.Continue)
 
-let test_cost_gate_blocks_at_exact_limit () =
+let test_cost_threshold_allows_at_exact_limit () =
   let gate_config = default_gate ~max_cost_usd:0.50 () in
   let _ref, hooks = WO.make_tool_tracking_hooks ~gate_config () in
   let result =
@@ -122,13 +119,10 @@ let test_cost_gate_blocks_at_exact_limit () =
       ~input:`Null
       ~accumulated_cost_usd:0.50
   in
-  (match result with
-   | Agent_sdk.Hooks.Override msg ->
-     check bool "contains cost_gate" true
-       (Astring.String.is_infix ~affix:"cost_gate" msg)
-   | _ -> fail "expected Override at exact budget limit")
+  check bool "continues at advisory threshold" true
+    (result = Agent_sdk.Hooks.Continue)
 
-let test_cost_gate_allows_under_budget () =
+let test_cost_threshold_allows_under_budget () =
   let gate_config = default_gate ~max_cost_usd:1.0 () in
   let _ref, hooks = WO.make_tool_tracking_hooks ~gate_config () in
   let result =
@@ -197,7 +191,7 @@ let test_destructive_disabled () =
   check bool "continues (destructive check disabled)" true
     (result = Agent_sdk.Hooks.Continue)
 
-(* ── Test: Gate priority (deny > cost > destructive) ── *)
+(* ── Test: Gate priority (deny > destructive; cost is advisory) ── *)
 
 let test_deny_takes_priority_over_cost () =
   let gate_config =
@@ -212,7 +206,7 @@ let test_deny_takes_priority_over_cost () =
   in
   (match result with
    | Agent_sdk.Hooks.Override msg ->
-     (* Should be denied by deny list, not cost gate *)
+     (* Should be denied by deny list. Cost telemetry never overrides. *)
      check bool "deny list first" true
        (Astring.String.is_infix ~affix:"worker_deny" msg)
    | _ -> fail "expected Override")
@@ -232,14 +226,14 @@ let () =
           test_case "allows non-denied tool" `Quick
             test_deny_list_allows_non_denied;
         ] );
-      ( "cost_gate",
+      ( "cost_telemetry",
         [
-          test_case "blocks over budget" `Quick
-            test_cost_gate_blocks_over_budget;
-          test_case "blocks at exact limit" `Quick
-            test_cost_gate_blocks_at_exact_limit;
-          test_case "allows under budget" `Quick
-            test_cost_gate_allows_under_budget;
+          test_case "allows over advisory threshold" `Quick
+            test_cost_threshold_allows_over_budget;
+          test_case "allows at advisory threshold" `Quick
+            test_cost_threshold_allows_at_exact_limit;
+          test_case "allows under advisory threshold" `Quick
+            test_cost_threshold_allows_under_budget;
         ] );
       ( "destructive",
         [
@@ -252,7 +246,7 @@ let () =
         ] );
       ( "priority",
         [
-          test_case "deny > cost > destructive" `Quick
+          test_case "deny before destructive; cost advisory" `Quick
             test_deny_takes_priority_over_cost;
         ] );
     ]


### PR DESCRIPTION
## Summary

Make MASC cost thresholds advisory telemetry instead of gates.

- `keeper_guards.cost_guard` is now a passthrough compatibility hook.
- `Eval_gate.pre_check` no longer rejects on `max_cost_usd`; post-eval warning remains advisory.
- Worker OAS hooks no longer emit `cost_gate` overrides.
- Keeper deliberation budget check always allows deliberation; the daily threshold is telemetry only.
- Hook introspection reports `cost_telemetry.enforced=false`.
- Repo-local docs and tests were updated to stop presenting cost as a blocker.

## Why

Cost budget gates were creating confusing false blockers and could mask the real error path. Cost should explain spend, not decide admission or tool execution.

## Validation

- `git diff --check`
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_costbudget dune build --root . test/test_keeper_guards.exe test/test_eval_gate.exe test/test_worker_safety_gates.exe test/test_keeper_deliberation.exe test/test_keeper_unified_inline_skip.exe test/test_runtime_toml_overrides.exe`
- `./_build_costbudget/default/test/test_keeper_guards.exe`
- `./_build_costbudget/default/test/test_eval_gate.exe`
- `./_build_costbudget/default/test/test_worker_safety_gates.exe`
- `./_build_costbudget/default/test/test_keeper_deliberation.exe test deliberation_budget`
- `./_build_costbudget/default/test/test_keeper_unified_inline_skip.exe`
- `./_build_costbudget/default/test/test_runtime_toml_overrides.exe`

## Out Of Scope

While validating, unrelated existing failures were recorded separately:

- #20331
- #20332
