### PR TITLE
fix(otel): separate MCP tool error type

### DIFF
--- a/docs/rfc/RFC-0214-otel-genai-dual-emission.md
+++ b/docs/rfc/RFC-0214-otel-genai-dual-emission.md
@@ -36,8 +36,9 @@ Implementation status as of 2026-06-06:
 - MCP tool-call spans emitted by `lib/otel_dispatch_hook.ml` use
   `tools/call <tool-name>` span names, `mcp.method.name=tools/call`, and
   `gen_ai.tool.name=<tool-name>`. Failed tool results set span status ERROR
-  and use the typed `Tool_result.tool_failure_class` string as low-cardinality
-  `error.type`.
+  and use OTel/MCP `error.type=tool_error` for `CallToolResult.isError=true`.
+  The typed `Tool_result.tool_failure_class` string remains available under the
+  MASC-owned `masc.mcp.tool.failure_class` attribute.
 
 ### 2.1 Legacy Metric Names
 
@@ -154,12 +155,12 @@ Why OTel-backed migration:
 | File | Change |
 |------|--------|
 | `lib/otel_genai/otel_genai.ml` | Centralized GenAI metric, event, and attribute names including usage detail attributes. |
-| `lib/otel_dispatch_hook/otel_dispatch_hook.ml` | Emits MCP tool-call spans with `tools/call <tool-name>` names, `mcp.method.name=tools/call`, `gen_ai.tool.name`, CLIENT span kind, and typed `error.type`/ERROR status for failed tool results. |
+| `lib/otel_dispatch_hook/otel_dispatch_hook.ml` | Emits MCP tool-call spans with `tools/call <tool-name>` names, `mcp.method.name=tools/call`, `gen_ai.tool.name`, CLIENT span kind, OTel/MCP `error.type=tool_error`, MASC `masc.mcp.tool.failure_class`, and ERROR status for failed tool results. |
 | `lib/otel_spans/otel_spans.ml` | Added testable span attribute/status hooks and GenAI exception recording. |
 | `lib/llm_metric_bridge.ml` | Emits standard GenAI client metrics, operation-details events, usage attributes, streaming timings, and bounded error status. |
 | `lib/keeper/keeper_hooks_oas.ml` | Projects trusted cache/reasoning token details into GenAI usage attributes without inventing extra `gen_ai.token.type` values. |
 | `test/test_llm_metric_bridge.ml` | Covers standard metric names, event names, span attrs/status, and the cache/reasoning token-type guardrail. |
-| `test/test_otel_dispatch_hook.ml` | Covers MCP tool-call span name, `gen_ai.tool.name`, `mcp.method.name`, CLIENT kind, and typed failure status/error attributes. |
+| `test/test_otel_dispatch_hook.ml` | Covers MCP tool-call span name, `gen_ai.tool.name`, `mcp.method.name`, CLIENT kind, OTel/MCP `tool_error`, and MASC typed failure-class preservation. |
 
 ## 5. Remaining Migration Work
 

--- a/lib/otel_dispatch_hook/otel_dispatch_hook.ml
+++ b/lib/otel_dispatch_hook/otel_dispatch_hook.ml
@@ -5,7 +5,10 @@
     Span attributes use OpenTelemetry GenAI + MCP semantic-convention keys
     ([gen_ai.tool.name], [gen_ai.operation.name], [mcp.method.name]) so vendors
     that auto-categorise on [gen_ai.*] classify these spans as AI/LLM activity
-    while still seeing the underlying MCP [tools/call] method.
+    while still seeing the underlying MCP [tools/call] method. MCP
+    CallToolResult payload failures use [error.type=tool_error]; the MASC
+    failure taxonomy is preserved separately under
+    [masc.mcp.tool.failure_class].
 
     @since 2.103.0 *)
 
@@ -76,25 +79,25 @@ let tool_call_span_name ~tool_name =
   Otel_genai.Mcp_value.tools_call_method ^ " " ^ tool_name
 ;;
 
-let tool_error_type (result : Tool_result.result) =
+let tool_failure_class_attrs (result : Tool_result.result) =
   match Tool_result.failure_class result with
-  | None -> None
-  | Some class_ -> Some (Tool_result.tool_failure_class_to_string class_)
+  | None -> []
+  | Some class_ ->
+    [ ( Otel_genai.Mcp_attr_key.masc_mcp_tool_failure_class
+      , `String (Tool_result.tool_failure_class_to_string class_) )
+    ]
 ;;
 
 let tool_span_attrs (result : Tool_result.result) =
   let status_attrs =
     if Tool_result.is_success result
     then [ "otel.status_code", `String "OK" ]
-    else (
-      let error_type =
-        match tool_error_type result with
-        | Some value -> value
-        | None -> "unknown"
-      in
+    else
       [ "otel.status_code", `String "ERROR"
-      ; Otel_genai.Mcp_attr_key.error_type, `String error_type
-      ])
+      ; ( Otel_genai.Mcp_attr_key.error_type
+        , `String Otel_genai.Mcp_value.tool_error_type )
+      ]
+      @ tool_failure_class_attrs result
   in
   (* OpenTelemetry GenAI semantic conventions
      (https://opentelemetry.io/docs/specs/semconv/gen-ai/). Tool execution
@@ -115,9 +118,9 @@ let on_tool_result (result : Tool_result.result) : unit =
   if enabled ()
   then (
     let status =
-      match tool_error_type result with
-      | None -> None
-      | Some _ ->
+      if Tool_result.is_success result
+      then None
+      else
         Some
           (OT.Span_status.make
              ~message:(Tool_result.message result)

--- a/lib/otel_dispatch_hook/otel_dispatch_hook.mli
+++ b/lib/otel_dispatch_hook/otel_dispatch_hook.mli
@@ -5,7 +5,9 @@
     Span attributes use OpenTelemetry GenAI + MCP semantic-convention keys
     ([gen_ai.tool.name], [gen_ai.operation.name], [mcp.method.name]) so Datadog
     v1.37+/Grafana auto-categorise these spans as AI/LLM activity while still
-    seeing the underlying MCP [tools/call] method.
+    seeing the underlying MCP [tools/call] method. Payload-level MCP tool
+    failures use [error.type=tool_error]; the MASC failure taxonomy is kept in
+    [masc.mcp.tool.failure_class].
 
     Internal helper [on_tool_result] is intentionally hidden — the
     hook is registered through {!install} once at startup, after

--- a/lib/otel_genai/otel_genai.ml
+++ b/lib/otel_genai/otel_genai.ml
@@ -114,10 +114,12 @@ end
 module Mcp_attr_key = struct
   let mcp_method_name = "mcp.method.name"
   let error_type = "error.type"
+  let masc_mcp_tool_failure_class = "masc.mcp.tool.failure_class"
 end
 
 module Mcp_value = struct
   let tools_call_method = "tools/call"
+  let tool_error_type = "tool_error"
 end
 
 module Event_name = struct

--- a/lib/otel_genai/otel_genai.mli
+++ b/lib/otel_genai/otel_genai.mli
@@ -51,10 +51,12 @@ end
 module Mcp_attr_key : sig
   val mcp_method_name : string
   val error_type : string
+  val masc_mcp_tool_failure_class : string
 end
 
 module Mcp_value : sig
   val tools_call_method : string
+  val tool_error_type : string
 end
 
 module Metric_name : sig

--- a/test/test_otel_dispatch_hook.ml
+++ b/test/test_otel_dispatch_hook.ml
@@ -87,8 +87,12 @@ let test_failure_span_records_typed_error_status () =
     span.name;
   Alcotest.(check string)
     "error.type"
-    "policy_rejection"
+    "tool_error"
     (assoc_string Genai.Mcp_attr_key.error_type span.attrs);
+  Alcotest.(check string)
+    "masc.mcp.tool.failure_class"
+    "policy_rejection"
+    (assoc_string Genai.Mcp_attr_key.masc_mcp_tool_failure_class span.attrs);
   Alcotest.(check string)
     "otel.status_code"
     "ERROR"


### PR DESCRIPTION
## Summary
- emit OTel/MCP `error.type=tool_error` for failed MCP tool-call spans
- preserve MASC typed `Tool_result.tool_failure_class` under `masc.mcp.tool.failure_class`
- update RFC-0214 and focused dispatch-hook coverage

## Evidence
- OTel MCP semconv says `CallToolResult.isError=true` should use `error.type=tool_error` (checked 2026-06-06)

## Verification
- `ocamlformat --check lib/otel_genai/otel_genai.mli lib/otel_genai/otel_genai.ml lib/otel_dispatch_hook/otel_dispatch_hook.mli lib/otel_dispatch_hook/otel_dispatch_hook.ml test/test_otel_dispatch_hook.ml`
- `git diff --check`
- `python3 scripts/rfc_enforcer.py --check-numbering --base-ref origin/main --head-ref HEAD`
- `env MASC_DUNE_THROTTLE=0 MASC_OPAM_LOCK=0 MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_BUILD_DIR=/private/tmp/masc-mcp-otel-mcp-tool-error-20260606 scripts/dune-local.sh build test/test_otel_dispatch_hook.exe --display=quiet`
- `/private/tmp/masc-mcp-otel-mcp-tool-error-20260606/default/test/test_otel_dispatch_hook.exe`