### PR TITLE
fix(dashboard): keep board refresh HTTP-owned

### DIFF
--- a/dashboard/src/dashboard-ws.test.ts
+++ b/dashboard/src/dashboard-ws.test.ts
@@ -215,9 +215,13 @@ describe('dashboardSlicesForRoute', () => {
     })).toContain('execution')
   })
 
-  it('subscribes route-local dashboard slices for board, goals, and fleet FSM routes', () => {
+  it('keeps board route snapshots HTTP-owned while subscribing goals and fleet FSM slices', () => {
     expect(dashboardSlicesForRoute({ tab: 'workspace', params: { section: 'board' } }))
-      .toContain('board')
+      .toEqual([
+        'namespace',
+        'shell',
+        'transport',
+      ])
     expect(dashboardSlicesForRoute({ tab: 'workspace', params: { section: 'planning' } }))
       .toContain('goals')
     expect(dashboardSlicesForRoute({ tab: 'monitoring', params: { section: 'agents' } }))
@@ -408,7 +412,11 @@ describe('dashboard websocket route subscriptions', () => {
     const subscribe = parseRpc(socket, 1)
     expect(subscribe.method).toBe('dashboard/subscribe')
     expect(subscribe.params.route).toBe('workspace:board::')
-    expect(subscribe.params.slices).toEqual(expect.arrayContaining(['board']))
+    expect(subscribe.params.slices).toEqual([
+      'namespace',
+      'shell',
+      'transport',
+    ])
 
     socket.receive({
       jsonrpc: '2.0',
@@ -750,7 +758,7 @@ describe('dashboard websocket route subscriptions', () => {
     expect(dashboardWsLastSeq.value).toBe(1)
   })
 
-  it('ignores dashboard slice deltas outside the latest route subscription', async () => {
+  it('ignores board slice snapshots and deltas because the board list is HTTP-owned', async () => {
     installWebSocketMocks()
 
     await connectDashboardWS({ tab: 'workspace', params: { section: 'board' } })
@@ -774,11 +782,7 @@ describe('dashboard websocket route subscriptions', () => {
       method: 'dashboard/delta',
       params: { seq: 2, slice: 'board', payload: { posts: [] } },
     })
-    expect(sseStoreMocks.hydrateDashboardSlice).toHaveBeenCalledWith(
-      'board',
-      { posts: [] },
-      undefined,
-    )
+    expect(sseStoreMocks.hydrateDashboardSlice).not.toHaveBeenCalled()
     sseStoreMocks.hydrateDashboardSlice.mockClear()
 
     const switchPromise = subscribeDashboardRoute({

--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -206,9 +206,12 @@ export function dashboardSlicesForRoute(routeState: DashboardRouteState): string
     slices.add('execution')
     slices.add('goals')
   }
-  if (routeState.tab === 'workspace' && routeState.params.section === 'board') {
-    slices.add('board')
-  }
+  // Board rows are actor/filter scoped (`voter`, blind-vote policy, author and
+  // hearth filters) and are loaded through refreshBoard's HTTP query. The WS
+  // snapshot provider is route-scoped only, so subscribing the board slice here
+  // can hydrate the list with a different query immediately after the route HTTP
+  // refresh. Raw board SSE events still reach the client and schedule/increment
+  // board refreshes through sse-store.
   if (routeState.tab === 'monitoring') {
     const section = routeState.params.section
     if (section === 'observatory' || section === 'journey' || section === 'agents' || section === 'cognition') {


### PR DESCRIPTION
## Summary

- Stop subscribing the workspace board route to the route-scoped `board` WebSocket snapshot.
- Keep board list hydration owned by `refreshBoard()` / `/api/v1/dashboard/board`, while raw board SSE/WS events still schedule or incrementally hydrate board updates.
- Update WebSocket route tests so board snapshots/deltas are ignored for the board route.

## Product impact

- User-visible change: refreshing Workspace / Board no longer races an HTTP board list against a differently-shaped WS board snapshot.
- The board list keeps the actor/filter scoped query shape, including `voter` and `blind_votes=true`.

## Evidence

- Live drift check: `curl http://127.0.0.1:8935/api/v1/dashboard/board?...&blind_votes=true` returned `vote_blind=true`, while the WS-provider-equivalent query without `blind_votes=true` returned `vote_blind=false` for the same post.
- `pnpm exec vitest run src/dashboard-ws.test.ts src/sse-store.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec eslint src/dashboard-ws.ts src/dashboard-ws.test.ts`
- `pnpm run build`
- Patched dev smoke: `http://127.0.0.1:5174/dashboard/#workspace?section=board` rendered board posts; HAR showed `/api/v1/dashboard/board?...voter=dashboard&blind_votes=true&exclude_system=true`.

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 6/6
provenance: direct
stages:
  - live-query-drift-check
  - focused-vitest
  - typecheck
  - eslint
  - production-build
  - patched-dev-smoke
```

## GOAL LOOP ACT checklist

- [x] Observe — live board queries showed different vote/blind fields for the same post.
- [x] Orient — the race mapped to route refresh HTTP ownership versus WS route snapshot ownership.
- [x] Decide — removed only the board route WS snapshot subscription; kept other route-local slices intact.
- [x] Act — changed `dashboardSlicesForRoute` and the focused WS tests.
- [x] Verify — focused tests, typecheck, eslint, build, and patched dashboard smoke passed.
- [x] Loop — no follow-up required for this scoped fix.

## Review evidence

- Not run; this is a narrow dashboard route ownership fix with focused regression coverage.

## Linked issue

- Closes #
- Relates #

## Variant addition checklist

- [ ] **OCaml** — N/A; no OCaml variants changed.
- [ ] **TypeScript** — N/A; no union members changed.
- [ ] **TLA+ spec** — N/A; no TLA+ literals changed.
- [ ] **Event / JSON schema** — N/A; no event or JSON schema enum changed.
- [ ] **`make check-variants` passes** — N/A; no variants changed.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`fix/dashboard-board-refresh-ssot` → `main` · 1 commit(s) · synced 2026-06-06T10:02:16Z

| sha | subject | date |
|---|---|---|
| `afbbe3f5e` | fix(dashboard): keep board refresh HTTP-owned | 2026-06-06 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->