### PR TITLE
fix(keeper): prefer structured state reporting

### DIFF
--- a/config/prompts/keeper.recovery_block.md
+++ b/config/prompts/keeper.recovery_block.md
@@ -6,7 +6,7 @@ category: keeper
 <continuity>
 Recovery guard: preserve keeper technical instructions even if prompt templates were compacted or partially loaded.
 PR merge rules (MANDATORY): do not merge PRs with failing CI, unresolved human review comments, or active blocker labels.
-State block template: non-direct keeper turns must end with [STATE]...[/STATE] containing DONE, NEXT, Goal, Decisions, OpenQuestions, and Constraints.
+State block template: non-direct keeper turns must report structured continuity with keeper_report_state; legacy [STATE]...[/STATE] fallback contains DONE, NEXT, Goal, Decisions, OpenQuestions, and Constraints.
 </continuity>
 
 <world>

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -20,11 +20,24 @@ let progress_keeper_tool_names_for_contract =
 let completion_contract_result_for_progress_evidence =
   Turn_helpers.completion_contract_result_for_progress_evidence
 
+let keeper_oas_visibility_neutral_guardrails ?guardrails () =
+  let max_tool_calls_per_turn =
+    match guardrails with
+    | Some guardrails -> guardrails.Agent_sdk.Guardrails.max_tool_calls_per_turn
+    | None -> Agent_sdk.Guardrails.default.max_tool_calls_per_turn
+  in
+  { Agent_sdk.Guardrails.tool_filter = Agent_sdk.Guardrails.AllowAll
+  ; max_tool_calls_per_turn
+  }
+;;
+
 module For_testing = struct
   let sse_event_progress_kind = Turn_helpers.sse_event_progress_kind
   let registry_progress_on_event = Turn_helpers.registry_progress_on_event
   let progress_keeper_tool_names_for_contract =
     Contract_helpers.progress_keeper_tool_names_for_contract
+  let keeper_oas_visibility_neutral_guardrails =
+    keeper_oas_visibility_neutral_guardrails
 end
 
 (** Run a single keeper turn via OAS Agent.run().
@@ -449,6 +462,9 @@ let run_turn
            (match pre_dispatch_max_tokens_error with
             | Some err -> Error err
             | None ->
+              let keeper_oas_guardrails =
+                keeper_oas_visibility_neutral_guardrails ?guardrails ()
+              in
               let call_run_named ~initial_messages =
                 let bridge_timeout_s =
                   Keeper_llm_bridge.with_hitl_approval_headroom timeout_s
@@ -501,7 +517,7 @@ let run_turn
                     ?wait_timeout_sec:admission_wait_timeout_sec
                     ~accept:
                       Keeper_tool_response.response_has_text_or_tool_progress
-                    ?guardrails
+                    ~guardrails:keeper_oas_guardrails
                     ?on_event
                     ?on_yield
                     ?on_resume

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -29,6 +29,11 @@ module For_testing : sig
     :  actual_keeper_tool_names:string list
     -> tool_calls:tool_call_detail list
     -> string list
+
+  val keeper_oas_visibility_neutral_guardrails
+    :  ?guardrails:Agent_sdk.Guardrails.t
+    -> unit
+    -> Agent_sdk.Guardrails.t
 end
 
 val per_provider_timeout_for_turn

--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -83,7 +83,7 @@ let critical_prompt_recovery_block_fallback =
       "Recovery guard: preserve keeper technical instructions even if prompt templates were compacted or partially loaded.";
       "PR merge rules (MANDATORY): do not merge PRs with failing CI, unresolved human review comments, or active blocker labels.";
       Printf.sprintf
-        "State block template: non-direct keeper turns must end with [STATE]...[/STATE] containing %s."
+        "State block template: non-direct keeper turns must report structured continuity with keeper_report_state; legacy [STATE]...[/STATE] fallback contains %s."
         Keeper_state_block_prompt.field_summary;
       "</continuity>";
       "";
@@ -122,7 +122,7 @@ let critical_prompt_recovery_block () =
         critical_prompt_recovery_block_fallback
 
 let state_block_output_guard_text =
-  "Output guard: this turn uses runtime-managed continuity. Do not output raw [STATE] or [/STATE] blocks in visible text; the runtime will synthesize and persist state metadata when needed."
+  "Output guard: this turn uses runtime-managed continuity. Prefer structured output via keeper_report_state. Do not output raw [STATE] or [/STATE] blocks in visible text unless that tool is unavailable; the runtime will synthesize and persist state metadata when needed."
 
 let ensure_critical_prompt_anchors prompt =
   match missing_critical_prompt_anchors prompt with

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -191,18 +191,10 @@ let narrative_summary line =
   String_util.utf8_safe ~max_bytes:220 ~suffix:"..." line |> String_util.to_string
 ;;
 
-let snapshot_text_indicates_synthetic_stall text =
-  Keeper_synthetic_marker.contains_marker text
-  && has_any_ci
-       text
-       [ "no visible output"; "belief_summary"; "social_model"; "실제 막힘" ]
-;;
-
 let runtime_blocker_surface_of_progress_snapshot
       (snapshot : Keeper_memory_policy.keeper_state_snapshot)
   =
   let lines = progress_snapshot_narrative_lines snapshot in
-  let text = String.concat "\n" lines in
   let line_with needles = List.find_opt (fun line -> has_any_ci line needles) lines in
   let surface blocker_class line =
     Some { blocker_class; summary = narrative_summary line; continue_gate = false }
@@ -257,36 +249,18 @@ let runtime_blocker_surface_of_progress_snapshot
                    ; "manual"
                    ] -> surface "awaiting_operator" line
           | _ ->
-            if snapshot_text_indicates_synthetic_stall text
-            then
-              (* The outer [if lines = [] then None] guard (line 168)
-                 already returns early on an empty narrative; the
-                 [[]] arm below is unreachable here but typed for
-                 exhaustiveness so a future refactor that drops the
-                 outer guard does not silently fall through to a
-                 Sys_error from [List.hd]. *)
-              let first_line =
-                match lines with
-                | [] -> ""
-                | h :: _ -> h
-              in
-              surface
-                "synthetic_stall"
-                (line_with [ Keeper_synthetic_marker.marker_prefix ]
-                 |> Option.value ~default:first_line)
-            else (
-              match
-                line_with
-                  [ "watching"
-                  ; "monitor"
-                  ; "no action"
-                  ; "no next action"
-                  ; "자체 action 부재"
-                  ; "감시"
-                  ]
-              with
-              | Some line -> surface "self_imposed_idle" line
-              | None -> None))))
+            (match
+               line_with
+                 [ "watching"
+                 ; "monitor"
+                 ; "no action"
+                 ; "no next action"
+                 ; "자체 action 부재"
+                 ; "감시"
+                 ]
+             with
+             | Some line -> surface "self_imposed_idle" line
+             | None -> None))))
 ;;
 
 let runtime_blocker_surface_of_progress_narrative config (meta : keeper_meta) =

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -44,7 +44,7 @@ let keeper_voice_tool_schemas =
 let core_always_tools =
   List.map
     Keeper_tool_name.to_string
-    Keeper_tool_name.[ Context_status; Stay_silent; Tool_search ]
+    Keeper_tool_name.[ Context_status; Stay_silent; Tool_search; State_report ]
   @ [ "extend_turns" ]
 ;;
 

--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -34,7 +34,7 @@ let workflow_rejection_error_json
      candidates. *)
   Task.Payloads.workflow_rejection_payload_json
     ~rule_id
-    ~scope_policy:"block_scope"
+    ~scope_policy:"observe"
     ~alternatives
     message
 ;;

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -71,8 +71,6 @@ let recent_tools_for_keeper ?(limit = 5) keeper_name : string list =
     reading a non-existent file 400+ times). *)
 let max_consecutive_failures = Env_config.KeeperToolExec.max_consecutive_tool_failures
 
-type workflow_rejection_block = Keeper_tools_oas_workflow.workflow_rejection_block
-
 type workflow_rejection_info = Keeper_tools_oas_workflow.workflow_rejection_info
 
 (* TTL for per-(tool, args_hash) failure counters (#18501).
@@ -84,7 +82,6 @@ type failure_counts =
   { table : (string, int) Hashtbl.t
   ; failure_timestamps : (string, float) Hashtbl.t
   ; workflow_table : (string, int) Hashtbl.t
-  ; workflow_block_table : (string, workflow_rejection_block) Hashtbl.t
   ; mutex : Mutex.t
   }
 
@@ -92,7 +89,6 @@ let create_failure_counts () =
   { table = Hashtbl.create 16
   ; failure_timestamps = Hashtbl.create 16
   ; workflow_table = Hashtbl.create 16
-  ; workflow_block_table = Hashtbl.create 16
   ; mutex = Mutex.create ()
   }
 ;;
@@ -143,12 +139,6 @@ let failure_count_jump_to counts key ~target =
     target)
 ;;
 
-(* TTL for workflow rejection scope blocks (#18500).
-   After this many seconds, a scope block expires and the agent may
-   retry the same (tool, task, action) scope — e.g. after creating a PR
-   externally and re-submitting for verification. *)
-let workflow_block_ttl_seconds = 1800.
-
 let workflow_rejection_count_record counts key =
   Mutex.protect counts.mutex (fun () ->
     let next =
@@ -164,38 +154,6 @@ let workflow_rejection_count_reset counts =
   Mutex.protect counts.mutex (fun () -> Hashtbl.clear counts.workflow_table)
 ;;
 
-let workflow_rejection_scope_block_get counts key =
-  Mutex.protect counts.mutex (fun () ->
-    match Hashtbl.find_opt counts.workflow_block_table key with
-    | None -> None
-    | Some block ->
-      let age = Time_compat.now () -. block.blocked_at in
-      if age > workflow_block_ttl_seconds then begin
-        Hashtbl.remove counts.workflow_block_table key;
-        None
-      end else
-        Some block)
-;;
-
-let workflow_rejection_scope_block_record counts key (info : Keeper_tools_oas_workflow.workflow_rejection_info) =
-  Mutex.protect counts.mutex (fun () ->
-    let previous_count =
-      match Hashtbl.find_opt counts.workflow_block_table key with
-      | Some block -> block.Keeper_tools_oas_workflow.count
-      | None -> 0
-    in
-    let block : Keeper_tools_oas_workflow.workflow_rejection_block =
-      { count = previous_count + 1
-      ; rule_id = info.rule_id
-      ; tool_suggestion = info.tool_suggestion
-      ; hint = info.hint
-      ; blocked_at = Time_compat.now ()
-      }
-    in
-    Hashtbl.replace counts.workflow_block_table key block;
-    block.Keeper_tools_oas_workflow.count)
-;;
-
 (* Test-only: inject a failure counter with a stale timestamp so the
    TTL expiry path in [failure_count_get] can be exercised. *)
 let inject_stale_failure_count_for_test counts key count =
@@ -205,21 +163,6 @@ let inject_stale_failure_count_for_test counts key count =
       (Time_compat.now () -. (failure_count_ttl_seconds +. 60.)))
 ;;
 
-(* Test-only: inject a scope block with a stale [blocked_at] timestamp
-   so the TTL expiry path in [workflow_rejection_scope_block_get]
-   can be exercised without sleeping. *)
-let inject_stale_workflow_block_for_test counts key =
-  let block : Keeper_tools_oas_workflow.workflow_rejection_block =
-    { count = 1
-    ; rule_id = None
-    ; tool_suggestion = None
-    ; hint = None
-    ; blocked_at = Time_compat.now () -. (workflow_block_ttl_seconds +. 60.)
-    }
-  in
-  Mutex.protect counts.mutex (fun () ->
-    Hashtbl.replace counts.workflow_block_table key block)
-;;
 open Keeper_tools_oas_workflow
 open Keeper_tools_oas_deterministic_error
 

--- a/lib/keeper/keeper_tools_oas.mli
+++ b/lib/keeper/keeper_tools_oas.mli
@@ -41,8 +41,6 @@ val max_consecutive_failures : int
 
 (** Thread-safe per-tool consecutive-failure counters shared by the
     handler closures in one tool bundle. *)
-type workflow_rejection_block = Keeper_tools_oas_workflow.workflow_rejection_block
-
 type workflow_rejection_info = Keeper_tools_oas_workflow.workflow_rejection_info
 
 type failure_counts
@@ -61,17 +59,6 @@ val workflow_rejection_count_record : failure_counts -> string -> int
 
 val workflow_rejection_count_reset : failure_counts -> unit
 
-val workflow_rejection_scope_block_get
-  :  failure_counts
-  -> string
-  -> Keeper_tools_oas_workflow.workflow_rejection_block option
-
-val workflow_rejection_scope_block_record
-  :  failure_counts
-  -> string
-  -> Keeper_tools_oas_workflow.workflow_rejection_info
-  -> int
-
 (** Test-only: inject a failure counter with [blocked_at] set to
     [failure_count_ttl_seconds + 60] seconds in the past.
     The next [failure_count_get] call for [key] will treat it as
@@ -82,12 +69,6 @@ val inject_stale_failure_count_for_test : failure_counts -> string -> int -> uni
     for suites that assert the first occurrence of a tool failure emits
     at ERROR. *)
 val reset_tool_retry_dedupe_for_testing : unit -> unit
-
-(** Test-only: inject a scope block with [blocked_at] set to
-    [workflow_block_ttl_seconds + 60] seconds in the past.
-    The next [workflow_rejection_scope_block_get] call for [key]
-    will treat it as expired and return [None]. *)
-val inject_stale_workflow_block_for_test : failure_counts -> string -> unit
 
 (** Normalize a raw tool result string into the canonical JSON
     envelope. Success → [{"ok":true,"result":...}]; failure →

--- a/lib/keeper/keeper_tools_oas_handler.ml
+++ b/lib/keeper/keeper_tools_oas_handler.ml
@@ -1,14 +1,13 @@
 (** Keeper_tools_oas_handler — Tool handler factory for Agent.run().
 
-    Skeleton module: validation, circuit-breaking, workflow-rejection
-    gating, and resource-gate wrapping.  The heavy execution body lives
+    Skeleton module: validation, repeated-failure circuit-breaking,
+    and resource-gate wrapping.  The heavy execution body lives
     in [Keeper_tools_oas_handler_exec]; telemetry helpers live in
     [Keeper_tools_oas_handler_telemetry].
 
     @since P1 extraction *)
 
 open Keeper_tools_oas
-open Keeper_tools_oas_workflow
 open Keeper_tools_oas_deterministic_error
 open Keeper_tools_oas_handler_telemetry
 
@@ -120,42 +119,6 @@ let make_keeper_tool_handler
           ~start_time:t0
           output_text)
       else (
-        match
-          Option.bind
-            (workflow_scope_key_of_input ~tool_name:name input)
-            (workflow_rejection_scope_block_get failure_counts)
-        with
-        | Some block ->
-          Otel_metric_store.inc_counter
-            Keeper_metrics.(to_string ToolsOasFailures)
-            ~labels:[ "tool", name; "site", "workflow_scope_blocked" ]
-            ();
-          record_deterministic_tool_failure_metric
-            ~tool_name:name
-            Keeper_tool_deterministic_error.Workflow_rejection_blocked;
-          Log.Keeper.warn
-            "tool %s workflow rejection retry skipped for same task/action scope"
-            name;
-          let raw_result =
-            workflow_rejection_payload_json
-              ~scope_policy:Block_scope
-              ~error_class:Workflow_error_deterministic
-              ~recoverability:Workflow_unrecoverable
-              "workflow_rejection_open_loop_blocked"
-          in
-          let output_text =
-            normalize_tool_result
-              ~workflow_rejection_recovery_fields:
-                (workflow_rejection_scope_block_fields ~tool_name:name block)
-              ~success:false
-              raw_result
-          in
-          Tool_result.error
-            ~failure_class:(Some Tool_result.Workflow_rejection)
-            ~tool_name:name
-            ~start_time:t0
-            output_text
-        | None ->
           let gate_clock =
             match clock with
             | Some clock -> Some clock

--- a/lib/keeper/keeper_tools_oas_handler_exec.ml
+++ b/lib/keeper/keeper_tools_oas_handler_exec.ml
@@ -145,16 +145,10 @@ let execute_with_observers
           | Some info ->
             let family_key = workflow_rejection_family_key ~tool_name:name info in
             let count = workflow_rejection_count_record failure_counts family_key in
-            if workflow_rejection_should_scope_block info
-            then (
-              match workflow_scope_key_of_input ~tool_name:name input with
-              | Some scope_key ->
-                ignore
-                  (workflow_rejection_scope_block_record
-                     failure_counts
-                     scope_key
-                     info)
-              | None -> ());
+            (* Workflow rejections are recovery guidance, not an execution
+               ban.  The former scope-block table turned a normal
+               self-correction hint into a 30-minute pre-dispatch gate for
+               the same task/action scope. *)
             workflow_rejection_recovery_fields ~tool_name:name ~count raw_result
           | None -> [])
         else []

--- a/lib/keeper/keeper_tools_oas_workflow.ml
+++ b/lib/keeper/keeper_tools_oas_workflow.ml
@@ -7,6 +7,8 @@
 
 type workflow_rejection_scope_policy =
   | Observe_scope
+  (* Legacy diagnostic value accepted for compatibility with older
+     payloads. Runtime scope blocking is not driven by this field. *)
   | Block_scope
 
 let workflow_rejection_scope_policy_to_string = function
@@ -27,14 +29,6 @@ type workflow_rejection_info =
   ; tool_suggestion : string option
   ; hint : string option
   ; scope_policy : workflow_rejection_scope_policy
-  }
-
-type workflow_rejection_block =
-  { count : int
-  ; rule_id : string option
-  ; tool_suggestion : string option
-  ; hint : string option
-  ; blocked_at : float
   }
 
 let json_assoc_field_opt = Json_util.assoc_member_opt
@@ -237,12 +231,6 @@ let workflow_rejection_info_of_raw raw =
   | Yojson.Json_error _ -> None
 ;;
 
-let workflow_rejection_should_scope_block (info : workflow_rejection_info) =
-  match info.scope_policy with
-  | Block_scope -> true
-  | Observe_scope -> false
-;;
-
 let workflow_rejection_family_key ~tool_name (info : workflow_rejection_info) =
   Printf.sprintf
     "%s:%s:%s:%s"
@@ -329,73 +317,4 @@ let workflow_submit_evidence_marker json =
      || json_has_nonempty_evidence_refs json
   then "has_evidence"
   else "missing_evidence"
-;;
-
-let workflow_scope_key_of_input ~tool_name input =
-  let task_id_part json = json_nonempty_string_opt "task_id" json in
-  match input with
-  | `Assoc _ as json ->
-    (match tool_name with
-     | "masc_transition" ->
-       (match json_nonempty_string_opt "action" json, task_id_part json with
-        | None, _ | _, None -> None
-        | Some action, Some task_id ->
-          let correction_marker =
-            if String.equal action "submit_for_verification"
-            then ":" ^ workflow_submit_evidence_marker json
-            else ""
-          in
-          Some
-            (Printf.sprintf
-               "%s:action=%s:task=%s%s"
-               tool_name
-               action
-               task_id
-               correction_marker))
-     | "keeper_task_done" ->
-       (match task_id_part json with
-        | None -> None
-        | Some task_id ->
-          Some (Printf.sprintf "%s:task=%s" tool_name task_id))
-     | "keeper_task_claim" -> Some "keeper_task_claim"
-     | _ -> None)
-  | _ -> None
-;;
-
-let workflow_rejection_scope_block_fields ~tool_name block =
-  let optional_string key = function
-    | Some value -> [ key, `String value ]
-    | None -> []
-  in
-  let recovery =
-    [ "count", `Int (block.count + 1)
-    ; "instruction"
-      , `String
-          (workflow_rejection_recovery_instruction
-             ~tool_name
-             ~count:(block.count + 1)
-             ({ task_id = None
-              ; rule_id = block.rule_id
-              ; tool_suggestion = block.tool_suggestion
-              ; hint = block.hint
-              ; scope_policy = Block_scope
-              } : workflow_rejection_info)
-             )
-    ]
-    @ optional_string "rule_id" block.rule_id
-    @ optional_string "tool_suggestion" block.tool_suggestion
-    @ optional_string "hint" block.hint
-    @ [ "scope_policy", `String (workflow_rejection_scope_policy_to_string Block_scope) ]
-  in
-  [ "self_correction_required", `Bool true
-  ; "do_not_retry_tool", `String tool_name
-  ; "workflow_rejection_recovery", `Assoc recovery
-  ; "workflow_rejection_loop", `Bool true
-  ; "retry_skipped", `Bool true
-  ; "retry_skipped_reason", `String "deterministic_workflow_scope_blocked"
-  ; ( "retry_skipped_explanation"
-    , `String
-        "previous workflow_rejection for this task/action scope requires a different next step" )
-  ]
-  @ optional_string "required_next_tool" block.tool_suggestion
 ;;

--- a/lib/keeper/keeper_tools_oas_workflow.mli
+++ b/lib/keeper/keeper_tools_oas_workflow.mli
@@ -8,6 +8,8 @@
     before execution. Missing policy is deliberately observe-only. *)
 type workflow_rejection_scope_policy =
   | Observe_scope
+  (** Legacy diagnostic value accepted for compatibility with older
+      payloads. Runtime scope blocking is not driven by this field. *)
   | Block_scope
 
 val workflow_rejection_scope_policy_to_string :
@@ -89,9 +91,6 @@ val workflow_rejection_payload_json
 (** Extract [workflow_rejection_info] from a raw JSON string. *)
 val workflow_rejection_info_of_raw : string -> workflow_rejection_info option
 
-(** True only when the producing tool explicitly requested a scope block. *)
-val workflow_rejection_should_scope_block : workflow_rejection_info -> bool
-
 (** Build a stable family key for deduplication. *)
 val workflow_rejection_family_key
   :  tool_name:string
@@ -120,25 +119,3 @@ val json_has_nonempty_evidence_refs : Yojson.Safe.t -> bool
 
 (** Build a workflow-submit evidence marker string. *)
 val workflow_submit_evidence_marker : Yojson.Safe.t -> string
-
-(** Build a scope key from tool input for workflow rejection dedup. *)
-val workflow_scope_key_of_input
-  :  tool_name:string
-  -> Yojson.Safe.t
-  -> string option
-
-(** Block record stored in [failure_counts.workflow_block_table].
-    Defined here because [workflow_rejection_scope_block_fields] uses it. *)
-type workflow_rejection_block =
-  { count : int
-  ; rule_id : string option
-  ; tool_suggestion : string option
-  ; hint : string option
-  ; blocked_at : float
-  }
-
-(** Build structured recovery fields from a workflow rejection block. *)
-val workflow_rejection_scope_block_fields
-  :  tool_name:string
-  -> workflow_rejection_block
-  -> (string * Yojson.Safe.t) list

--- a/lib/keeper_registry/keeper_state_block_prompt.ml
+++ b/lib/keeper_registry/keeper_state_block_prompt.ml
@@ -16,9 +16,9 @@ let template_text =
 let instruction_text =
   String.concat "\n"
     [
-      "For non-direct keeper turns, call the keeper_report_state tool at the end of your response to report your turn state for continuity. This is MANDATORY — do not skip it.";
+      "For non-direct keeper turns, report continuity through structured output: call the keeper_report_state tool at the end of your response. This is MANDATORY — do not skip it.";
       "The tool accepts: goal, progress, done_summary, next_summary, next_items, decisions, open_questions, constraints. All fields are optional but provide as many as you can.";
       Printf.sprintf "State block template: fields correspond to the legacy [STATE] block: %s." field_summary;
-      "If the tool is unavailable for any reason, fall back to a [STATE]...[/STATE] text block:";
+      "Only if keeper_report_state is unavailable, use the compatibility fallback [STATE]...[/STATE] text block:";
       template_text;
     ]

--- a/lib/task/tool_task.ml
+++ b/lib/task/tool_task.ml
@@ -320,7 +320,7 @@ and handle_transition ~tool_name ~start_time ctx args =
       (workflow_rejection_payload_json
          ~rule_id
          ~hint
-         ~scope_policy:"block_scope"
+         ~scope_policy:"observe"
          ~extra_fields
          reason)
   | Workspace_hooks.Pass ->

--- a/lib/task/workflow_rejection_payload.ml
+++ b/lib/task/workflow_rejection_payload.ml
@@ -2,6 +2,8 @@
 
 type scope_policy =
   | Observe_scope
+  (* Legacy diagnostic value accepted for compatibility with older
+     payloads. Runtime scope blocking is not driven by this field. *)
   | Block_scope
 
 let scope_policy_to_string = function

--- a/test/test_keeper_prompt_metrics.ml
+++ b/test/test_keeper_prompt_metrics.ml
@@ -268,6 +268,10 @@ let test_state_block_guard_is_runtime_managed_not_absolute_never () =
   let guard = KP.state_block_output_guard_text in
   check bool "guard mentions runtime-managed continuity" true
     (has_in guard "runtime-managed continuity");
+  check bool "guard prefers structured output" true
+    (has_in guard "structured output");
+  check bool "guard names keeper_report_state" true
+    (has_in guard "keeper_report_state");
   check bool "guard avoids absolute NEVER state wording" false
     (has_in guard ("NEVER output " ^ "[STATE]"));
   check bool "guard names raw state markers" true
@@ -279,10 +283,12 @@ let test_unified_state_instruction_respects_turn_level_guard () =
   let text = KUP.state_block_instruction_text in
   check bool "instruction is scoped to non-direct turns" true
     (has_in text "For non-direct keeper turns");
-  check bool "instruction names turn-level override" true
-    (has_in text "turn-level output guard");
-  check bool "instruction mentions runtime-managed continuity" true
-    (has_in text "runtime-managed");
+  check bool "instruction prefers structured output" true
+    (has_in text "structured output");
+  check bool "instruction names keeper_report_state" true
+    (has_in text "keeper_report_state");
+  check bool "instruction keeps raw state fallback scoped" true
+    (has_in text "Only if keeper_report_state is unavailable");
   check bool "instruction avoids old unconditional wording" false
     (has_in text
        ("End every response with a "
@@ -330,6 +336,26 @@ let test_prompt_mentions_runtime_operator_approval_for_risky_actions () =
   check bool "does not claim no permission is needed" false
     (has_in prompt "You do not need permission to act")
 
+let test_keeper_oas_guardrails_are_visibility_neutral () =
+  let source_guardrails =
+    { Agent_sdk.Guardrails.tool_filter =
+        Agent_sdk.Guardrails.AllowList [ "keeper_report_state" ]
+    ; max_tool_calls_per_turn = Some 7
+    }
+  in
+  let guardrails =
+    KAR.For_testing.keeper_oas_visibility_neutral_guardrails
+      ~guardrails:source_guardrails
+      ()
+  in
+  check bool "OAS base guardrails allow all tools" true
+    (match guardrails.Agent_sdk.Guardrails.tool_filter with
+     | Agent_sdk.Guardrails.AllowAll -> true
+     | Agent_sdk.Guardrails.AllowList _
+     | Agent_sdk.Guardrails.DenyList _
+     | Agent_sdk.Guardrails.Custom _ -> false);
+  check (option int) "max tool call cap is preserved" (Some 7)
+    guardrails.Agent_sdk.Guardrails.max_tool_calls_per_turn
 
 let test_user_message_sanitizer_preserves_normal_text () =
   let text = "Please inspect the current board status." in
@@ -513,6 +539,8 @@ let () =
             test_state_block_schema_is_canonical_six_field_shape;
           test_case "constitution uses canonical state instruction" `Quick
             test_constitution_uses_canonical_state_instruction;
+          test_case "keeper OAS base guardrails are visibility-neutral" `Quick
+            test_keeper_oas_guardrails_are_visibility_neutral;
           test_case "prompt mentions runtime operator approval for risky actions" `Quick
             test_prompt_mentions_runtime_operator_approval_for_risky_actions;
           test_case "user message sanitizer preserves normal text" `Quick

--- a/test/test_keeper_status_bridge.ml
+++ b/test/test_keeper_status_bridge.ml
@@ -68,11 +68,11 @@ let test_synthetic_idle_last_output_is_not_blocker () =
     (Option.map (fun b -> b.Keeper_status_bridge.blocker_class) (blocker_of_summary summary))
 ;;
 
-let test_synthetic_no_visible_output_remains_blocker () =
+let test_synthetic_no_visible_output_is_not_blocker () =
   let summary = "Decisions: [SYNTHETIC] No visible output this generation" in
   Alcotest.(check (option string))
-    "no visible output remains synthetic_stall"
-    (Some "synthetic_stall")
+    "synthetic fallback output is not a blocker"
+    None
     (Option.map (fun b -> b.Keeper_status_bridge.blocker_class) (blocker_of_summary summary))
 ;;
 
@@ -139,9 +139,9 @@ let () =
             `Quick
             test_synthetic_idle_last_output_is_not_blocker;
           Alcotest.test_case
-            "no visible synthetic output remains blocker"
+            "no visible synthetic output is not blocker"
             `Quick
-            test_synthetic_no_visible_output_remains_blocker;
+            test_synthetic_no_visible_output_is_not_blocker;
         ] );
       ( "profile default override provenance",
         [

--- a/test/test_keeper_tool_resolution.ml
+++ b/test/test_keeper_tool_resolution.ml
@@ -72,6 +72,24 @@ let test_extend_turns_resolved () =
       fail (Printf.sprintf "extend_turns should resolve, got Unknown (tried: %s)"
               (TR.string_of_tried tried))
 
+let test_keeper_report_state_core_always () =
+  check bool
+    "keeper_report_state is core always"
+    true
+    (Masc.Keeper_tool_registry.is_core_always_tool "keeper_report_state");
+  match TR.resolve "keeper_report_state" with
+  | TR.Resolved { via = TR.Registry_core_tools; _ } -> ()
+  | TR.Resolved { via; _ } | TR.Alias_to { via; _ } ->
+      fail
+        (Printf.sprintf
+           "keeper_report_state should resolve via Registry_core_tools, got via %s"
+           (TR.string_of_tried_source via))
+  | TR.Unknown { tried; _ } ->
+      fail
+        (Printf.sprintf
+           "keeper_report_state should resolve, got Unknown (tried: %s)"
+           (TR.string_of_tried tried))
+
 let test_tool_execute_resolves () =
   (* Was "resolves via surface"; the per-actor Surface source was removed in
      the surface-cut refactor. tool_execute now resolves via an earlier source
@@ -299,6 +317,7 @@ let () =
         test_case "mcp prefix stripped and resolved" `Quick test_mcp_prefix_stripped;
         test_case "unknown returns tried list" `Quick test_unknown_returns_tried_list;
         test_case "extend_turns resolves" `Quick test_extend_turns_resolved;
+        test_case "keeper_report_state is core-always structured state tool" `Quick test_keeper_report_state_core_always;
         test_case "tool_execute resolves" `Quick test_tool_execute_resolves;
         test_case "masc_keeper_* cluster resolves via descriptor registry (boot guard)" `Quick test_descriptor_registry_admits_masc_keeper_cluster;
         test_case "masc_board_post resolves" `Quick test_masc_board_post_resolves;


### PR DESCRIPTION
## Summary
- prefer structured keeper state continuity through keeper_report_state while keeping raw [STATE] parsing as compatibility fallback
- stop promoting synthetic no-visible-output summaries into dashboard blockers
- remove workflow-rejection scope-block pre-dispatch gate and stale scope-block state, leaving rejection recovery as observe/self-correction guidance
- make Keeper's base OAS guardrails visibility-neutral so MASC turn-level tool surface remains the authoritative filter

## Tests
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_status_bridge.exe test/test_keeper_tool_resolution.exe test/test_keeper_prompt_metrics.exe test/test_tool_result.exe test/test_keeper_tool_dispatch_runtime.exe test/test_tool_task_coverage.exe
- _build/default/test/test_keeper_status_bridge.exe
- _build/default/test/test_keeper_tool_resolution.exe
- _build/default/test/test_keeper_prompt_metrics.exe
- _build/default/test/test_tool_result.exe
- _build/default/test/test_keeper_tool_dispatch_runtime.exe
- _build/default/test/test_tool_task_coverage.exe