### PR TITLE
fix(otel): drop pseudo status attribute from tool spans

### DIFF
--- a/lib/otel_dispatch_hook/otel_dispatch_hook.ml
+++ b/lib/otel_dispatch_hook/otel_dispatch_hook.ml
@@ -91,10 +91,9 @@ let tool_failure_class_attrs (result : Tool_result.result) =
 let tool_span_attrs (result : Tool_result.result) =
   let status_attrs =
     if Tool_result.is_success result
-    then [ "otel.status_code", `String "OK" ]
+    then []
     else
-      [ "otel.status_code", `String "ERROR"
-      ; ( Otel_genai.Mcp_attr_key.error_type
+      [ ( Otel_genai.Mcp_attr_key.error_type
         , `String Otel_genai.Mcp_value.tool_error_type )
       ]
       @ tool_failure_class_attrs result

--- a/test/test_otel_dispatch_hook.ml
+++ b/test/test_otel_dispatch_hook.ml
@@ -16,6 +16,13 @@ let assoc_string key attrs =
   | None -> Alcotest.failf "missing attr %s" key
 ;;
 
+let check_no_attr key attrs =
+  Alcotest.(check bool)
+    (key ^ " absent")
+    true
+    (List.assoc_opt key attrs |> Option.is_none)
+;;
+
 let capture f =
   let captured = ref None in
   let emit_span ~name ~attrs ~kind ~status =
@@ -63,10 +70,7 @@ let test_success_span_uses_mcp_tool_call_semconv () =
     "mcp.method.name"
     "tools/call"
     (assoc_string Genai.Mcp_attr_key.mcp_method_name span.attrs);
-  Alcotest.(check string)
-    "otel.status_code"
-    "OK"
-    (assoc_string "otel.status_code" span.attrs)
+  check_no_attr "otel.status_code" span.attrs
 ;;
 
 let test_failure_span_records_typed_error_status () =
@@ -93,10 +97,7 @@ let test_failure_span_records_typed_error_status () =
     "masc.mcp.tool.failure_class"
     "policy_rejection"
     (assoc_string Genai.Mcp_attr_key.masc_mcp_tool_failure_class span.attrs);
-  Alcotest.(check string)
-    "otel.status_code"
-    "ERROR"
-    (assoc_string "otel.status_code" span.attrs);
+  check_no_attr "otel.status_code" span.attrs;
   match span.status with
   | None -> Alcotest.fail "failed tool call should set ERROR span status"
   | Some status ->


### PR DESCRIPTION
## Summary
- stop emitting non-semconv `otel.status_code` as a span attribute on MCP tool-call spans
- keep success spans status-unset and failed tool payload spans with real OTel span status ERROR
- update focused dispatch-hook tests to assert the pseudo attribute stays absent

## Evidence
- OTel MCP semconv describes status as span status (`UNSET`/`ERROR`) and separately requires `error.type` only on failures (checked 2026-06-06)

## Verification
- `ocamlformat --check lib/otel_dispatch_hook/otel_dispatch_hook.ml test/test_otel_dispatch_hook.ml`
- `git diff --check`
- `env MASC_DUNE_THROTTLE=0 MASC_OPAM_LOCK=0 MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_BUILD_DIR=/private/tmp/masc-mcp-otel-drop-status-attr-20260606 scripts/dune-local.sh build test/test_otel_dispatch_hook.exe --display=quiet`
- `/private/tmp/masc-mcp-otel-drop-status-attr-20260606/default/test/test_otel_dispatch_hook.exe`