### PR TITLE
[codex] Show live keeper reply placeholder

### DIFF
--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -75,7 +75,7 @@ describe('ChatTranscript', () => {
     expect(container.querySelector('[data-chat-delivery="live"]')).not.toBeNull()
   })
 
-  it('does not render an ellipsis for empty streaming text', () => {
+  it('renders a live placeholder for empty streaming text', () => {
     render(
       html`<${ChatTranscript}
         entries=${[
@@ -96,9 +96,10 @@ describe('ChatTranscript', () => {
       container,
     )
 
-    const bodies = [...container.querySelectorAll('.whitespace-pre-wrap')]
-    const latestBody = (bodies[bodies.length - 1]?.textContent ?? '').trim()
-    expect(latestBody).toBe('')
+    const placeholder = container.querySelector('[data-chat-stream-placeholder]')
+    expect(placeholder).not.toBeNull()
+    expect(placeholder?.textContent).toContain('응답 작성 중...')
+    expect(container.querySelector('[data-chat-delivery="live"]')).not.toBeNull()
   })
 
   it('uses a parent-bounded flexible transcript in primary mode', () => {

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -37,6 +37,16 @@ function deliveryLabel(entry: KeeperConversationEntry): string {
   }
 }
 
+function liveMessageLabel(entry: KeeperConversationEntry): string | null {
+  if (entry.text.trim()) return null
+  if (entry.delivery === 'streaming') {
+    return entry.streamState === 'finalizing' ? '응답 마무리 중...' : '응답 작성 중...'
+  }
+  if (entry.delivery === 'sending') return '응답 연결 중...'
+  if (entry.delivery === 'queued') return '응답 대기 중...'
+  return null
+}
+
 function bubbleTone(entry: KeeperConversationEntry): string {
   if (entry.delivery === 'error' || entry.delivery === 'timeout') return 'error'
   if (entry.role === 'user') return 'user'
@@ -130,6 +140,22 @@ function attachmentMeta(attachment: KeeperConversationAttachment): string {
   return [attachment.mimeType, formatAttachmentSize(attachment.size)].filter(Boolean).join(' · ')
 }
 
+function LiveMessagePlaceholder({ label }: { label: string }) {
+  return html`
+    <div
+      class="flex items-center gap-2 text-base leading-airy text-[var(--color-fg-secondary)]"
+      data-chat-stream-placeholder
+    >
+      <span>${label}</span>
+      <span class="inline-flex items-center gap-1" aria-hidden="true">
+        <span class="h-1.5 w-1.5 rounded-full bg-[var(--color-fg-muted)] animate-pulse"></span>
+        <span class="h-1.5 w-1.5 rounded-full bg-[var(--color-fg-muted)] animate-pulse"></span>
+        <span class="h-1.5 w-1.5 rounded-full bg-[var(--color-fg-muted)] animate-pulse"></span>
+      </span>
+    </div>
+  `
+}
+
 function renderAttachmentCard(attachment: KeeperConversationAttachment) {
   const canLink = isSafeAttachmentHref(attachment)
   const meta = attachmentMeta(attachment)
@@ -194,7 +220,8 @@ function ChatMessageBubble({
   const [messageCollapsed, setMessageCollapsed] = useState(true)
   const expanded = showMetadata && expandedRaw
   const rawExpanded = showMetadata && rawExpandedRaw
-  const messageText = entry.text || (entry.delivery === 'streaming' || entry.delivery === 'queued' ? '' : '(empty reply)')
+  const liveLabel = liveMessageLabel(entry)
+  const messageText = liveLabel ? '' : entry.text || '(empty reply)'
   const messageLength = messageText.length
   const collapseThreshold = 1200
   const isCollapsible = messageLength > collapseThreshold
@@ -305,15 +332,19 @@ function ChatMessageBubble({
           </div>`
         : null}
 
-      <div
-        class=${`markdown-body whitespace-pre-wrap break-words text-base leading-airy text-[var(--color-fg-primary)] ${isCollapsible && messageCollapsed ? 'max-h-96 overflow-hidden' : ''}`}
-        dangerouslySetInnerHTML=${{
-          __html: DOMPurify.sanitize(
-            marked.parse(messageText) as string,
-            { ALLOWED_TAGS: ['p', 'br', 'strong', 'em', 'code', 'pre', 'ul', 'ol', 'li', 'h1', 'h2', 'h3', 'h4', 'blockquote', 'a', 'hr'] }
-          )
-        }}
-      />
+      ${liveLabel
+        ? html`<${LiveMessagePlaceholder} label=${liveLabel} />`
+        : html`
+            <div
+              class=${`markdown-body whitespace-pre-wrap break-words text-base leading-airy text-[var(--color-fg-primary)] ${isCollapsible && messageCollapsed ? 'max-h-96 overflow-hidden' : ''}`}
+              dangerouslySetInnerHTML=${{
+                __html: DOMPurify.sanitize(
+                  marked.parse(messageText) as string,
+                  { ALLOWED_TAGS: ['p', 'br', 'strong', 'em', 'code', 'pre', 'ul', 'ol', 'li', 'h1', 'h2', 'h3', 'h4', 'blockquote', 'a', 'hr'] }
+                )
+              }}
+            />
+          `}
       ${isCollapsible
         ? html`
             <button
@@ -419,7 +450,7 @@ export function ChatTranscript({
 }) {
   const scrollerRef = useRef<HTMLDivElement | null>(null)
   const lastSignature = useMemo(
-    () => entries.map(entry => `${entry.id}:${entry.text.length}:${entry.delivery}`).join('|'),
+    () => entries.map(entry => `${entry.id}:${entry.text.length}:${entry.delivery}:${entry.streamState ?? ''}`).join('|'),
     [entries],
   )
 

--- a/dashboard/src/components/keeper-shared.test.ts
+++ b/dashboard/src/components/keeper-shared.test.ts
@@ -184,6 +184,38 @@ describe('KeeperConversationPanel', () => {
     expect(container.textContent).not.toContain('Enter로 전송')
   })
 
+  it('shows a live assistant placeholder while streaming without a reply entry', async () => {
+    keeperThreads.value = {
+      echo: [
+        {
+          id: 'direct-user',
+          role: 'user',
+          source: 'direct_user',
+          label: '사용자',
+          text: '왜 PR 안함?',
+          rawText: '왜 PR 안함?',
+          timestamp: '2026-03-24T00:01:00.000Z',
+          delivery: 'history',
+          streamState: null,
+          details: null,
+          error: null,
+        },
+      ],
+    }
+    keeperSending.value = { echo: true }
+
+    render(
+      html`<${KeeperConversationPanel} keeperName="echo" placeholder="메시지 입력..." layout="primary" />`,
+      container,
+    )
+    await Promise.resolve()
+
+    const placeholder = container.querySelector('[data-chat-stream-placeholder]')
+    expect(placeholder).not.toBeNull()
+    expect(placeholder?.textContent).toContain('응답 작성 중...')
+    expect(container.querySelector('[data-chat-delivery="live"]')).not.toBeNull()
+  })
+
   it('renders probe and recover buttons in RuntimeActions', async () => {
     const keeper = { name: 'sangsu', status: 'running' } as any
 

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -5,7 +5,7 @@ import { useState } from 'preact/hooks'
 import { keeperDirectChatAccess } from '../lib/keeper-chat-access'
 import { relativeTime, NO_TIME_INFO } from '../lib/format-time'
 import { isAbortError } from '../lib/async-state'
-import type { Keeper, KeeperDiagnostic } from '../types'
+import type { Keeper, KeeperConversationEntry, KeeperDiagnostic } from '../types'
 import {
   abortKeeperThreadMessage,
   hydrateKeeperStatus,
@@ -169,6 +169,30 @@ function conversationStateClass(sending: boolean, hydrating: boolean): string {
   return 'border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] text-[var(--color-fg-primary)]'
 }
 
+function isActiveAssistantEntry(entry: KeeperConversationEntry): boolean {
+  return (
+    entry.role === 'assistant'
+    && entry.source === 'direct_assistant'
+    && (entry.delivery === 'sending' || entry.delivery === 'streaming' || entry.delivery === 'queued')
+  )
+}
+
+function liveAssistantPlaceholder(keeperName: string): KeeperConversationEntry {
+  return {
+    id: `live-assistant-placeholder-${keeperName}`,
+    role: 'assistant',
+    source: 'direct_assistant',
+    label: keeperName,
+    text: '',
+    rawText: '',
+    timestamp: null,
+    delivery: 'streaming',
+    streamState: 'streaming',
+    details: null,
+    error: null,
+  }
+}
+
 function effectiveDiagnostic(keeper: Keeper | null | undefined): KeeperDiagnostic | null {
   if (!keeper) return null
   const detail = keeperStatusDetails.value[keeper.name]
@@ -289,6 +313,10 @@ export function KeeperConversationPanel({
   const thread = showInternal ? rawThread : rawThread.filter(isVisibleDirectConversationEntry)
   const hiddenCount = rawThread.length - thread.length
   const sending = keeperSending.value[keeperName] ?? false
+  const visibleThread =
+    sending && !thread.some(isActiveAssistantEntry)
+      ? [...thread, liveAssistantPlaceholder(keeperName)]
+      : thread
   const hydrating = keeperHydrating.value[keeperName] ?? false
   const error = keeperActionErrors.value[keeperName]
   const chatAccess = keeperDirectChatAccess(shellAuthSummary.value)
@@ -366,7 +394,7 @@ export function KeeperConversationPanel({
           : null}
 
         <${ChatTranscript}
-          entries=${thread}
+          entries=${visibleThread}
           emptyText="아직 표시할 대화가 없습니다. 내부 메시지와 도구 호출은 토글로 전환할 수 있습니다."
           showMetadata=${showMetadata}
           variant="messenger"
@@ -447,7 +475,7 @@ export function KeeperConversationPanel({
               `
             : null}
           <${ChatTranscript}
-            entries=${thread}
+            entries=${visibleThread}
             emptyText="아직 표시할 대화가 없습니다. 내부 메시지와 도구 호출은 토글로 전환할 수 있습니다."
             showMetadata=${showMetadata}
             variant="messenger"


### PR DESCRIPTION
## Summary
- Show a visible live placeholder inside the keeper direct-chat transcript when an assistant reply is streaming but has no text yet.
- Add a synthetic live assistant transcript entry when the panel knows a keeper is sending but the reply entry has not been hydrated yet.

## Root cause
The header badge and composer showed the streaming state, but the transcript bubble rendered an empty markdown body for blank `sending` / `streaming` / `queued` assistant entries. In some live states, the panel could also know `keeperSending=true` before an assistant reply entry was present, leaving no in-transcript indicator.

## Validation
- `pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/chat/primitives.test.ts src/components/keeper-shared.test.ts`
- `pnpm run typecheck`
- `pnpm exec eslint src/components/chat/primitives.ts src/components/keeper-shared.ts`
- Playwright rendered check against `http://127.0.0.1:5188/dashboard/#monitoring?section=agents&keeper=echo` for desktop `1440x1000` and mobile `390x844`, with fixture state injected into the Vite module singleton. Confirmed `응답 작성 중...` and `LIVE` badge visible in both viewports.