### PR TITLE
Remove narrative blocker inference from status bridge

### DIFF
--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -156,148 +156,17 @@ let runtime_keepalive_started_at (config : Workspace_utils.config) (meta : keepe
 include Keeper_status_bridge_blocker
 
 
-let has_any_ci text needles = List.exists (String_util.contains_substring_ci text) needles
-
-let first_nonempty_line label values =
-  values
-  |> List.map String.trim
-  |> List.find_map (fun value ->
-    if String.equal value "" then None else Some (Printf.sprintf "%s: %s" label value))
-;;
-
-let progress_snapshot_narrative_lines
-      (snapshot : Keeper_memory_policy.keeper_state_snapshot)
-  =
-  [ (match snapshot.progress with
-     | Some progress -> Some ("Progress: " ^ String.trim progress)
-     | None -> None)
-  ; (match snapshot.done_summary with
-     | Some done_summary -> Some ("Done: " ^ String.trim done_summary)
-     | None -> None)
-  ; (match snapshot.next_summary with
-     | Some next_summary -> Some ("Next plan: " ^ String.trim next_summary)
-     | None -> None)
-  ; first_nonempty_line "Next" snapshot.next_items
-  ; first_nonempty_line "Decisions" snapshot.decisions
-  ; first_nonempty_line "OpenQuestions" snapshot.open_questions
-  ; first_nonempty_line "Constraints" snapshot.constraints
-  ]
-  |> List.filter_map (function
-    | Some line when not (String.equal (String.trim line) "") -> Some line
-    | _ -> None)
-;;
-
-let narrative_summary line =
-  String_util.utf8_safe ~max_bytes:220 ~suffix:"..." line |> String_util.to_string
-;;
-
-let runtime_blocker_surface_of_progress_snapshot
-      (snapshot : Keeper_memory_policy.keeper_state_snapshot)
-  =
-  let lines = progress_snapshot_narrative_lines snapshot in
-  let line_with needles = List.find_opt (fun line -> has_any_ci line needles) lines in
-  let surface blocker_class line =
-    Some { blocker_class; summary = narrative_summary line; continue_gate = false }
-  in
-  if lines = []
-  then None
-  else (
-    match
-      line_with
-        [ "sandbox egress"
-        ; "push egress"
-        ; "github.com push"
-        ; "github push"
-        ; "network egress"
-        ; "sandbox"
-        ]
-    with
-    | Some line when has_any_ci line [ "egress"; "push"; "github.com"; "network" ] ->
-      surface "awaiting_sandbox_egress" line
-    | _ ->
-      (match line_with [ "supervisor"; "supervisor가" ] with
-       | Some line when has_any_ci line [ "pause"; "paused"; "unpause"; "의도" ] ->
-         surface "supervisor_paused" line
-       | _ ->
-         (match
-            line_with
-              [ "push gate"
-              ; "operator"
-              ; "human"
-              ; "approval"
-              ; "approve"
-              ; "decision tree"
-              ; "4-gate"
-              ; "4 gate"
-              ; "unblock"
-              ; "manual"
-              ]
-          with
-          | Some line
-            when has_any_ci
-                   line
-                   [ "waiting"
-                   ; "await"
-                   ; "blocked"
-                   ; "respond"
-                   ; "resolved"
-                   ; "gate"
-                   ; "decision"
-                   ; "approval"
-                   ; "approve"
-                   ; "unblock"
-                   ; "manual"
-                   ] -> surface "awaiting_operator" line
-          | _ ->
-            (match
-               line_with
-                 [ "watching"
-                 ; "monitor"
-                 ; "no action"
-                 ; "no next action"
-                 ; "자체 action 부재"
-                 ; "감시"
-                 ]
-             with
-             | Some line -> surface "self_imposed_idle" line
-             | None -> None))))
-;;
-
-let runtime_blocker_surface_of_progress_narrative config (meta : keeper_meta) =
-  let from_continuity_summary =
-    match
-      Keeper_memory_policy.progress_snapshot_cache_of_text meta.continuity_summary
-    with
-    | Some cache -> runtime_blocker_surface_of_progress_snapshot cache.snapshot
-    | None -> None
-  in
-  match from_continuity_summary with
-  | Some _ as blocker -> blocker
-  | None ->
-    (match Keeper_memory_policy.read_progress_snapshot ~config ~name:meta.name with
-     | Some snapshot -> runtime_blocker_surface_of_progress_snapshot snapshot
-     | None -> None)
-;;
-
 let runtime_blocker_surface_opt (config : Workspace_utils.config) (meta : keeper_meta) =
-  let derived =
-    match meta.runtime.last_blocker with
-    | Some info ->
-      Some (runtime_blocker_surface_of_typed_class ~summary:info.detail info.klass)
-    | None ->
-      (match runtime_registry_entry config meta.name with
-       | Some entry ->
-         (match entry.last_failure_reason with
-          | Some reason -> runtime_blocker_surface_of_failure_reason reason
-          | None -> None)
-       | None -> None)
-  in
-  let derived =
-    match derived with
-    | Some blocker -> Some blocker
-    | None -> runtime_blocker_surface_of_progress_narrative config meta
-  in
-  derived
+  match meta.runtime.last_blocker with
+  | Some info ->
+    Some (runtime_blocker_surface_of_typed_class ~summary:info.detail info.klass)
+  | None ->
+    (match runtime_registry_entry config meta.name with
+     | Some entry ->
+       (match entry.last_failure_reason with
+        | Some reason -> runtime_blocker_surface_of_failure_reason reason
+        | None -> None)
+     | None -> None)
 ;;
 
 let runtime_attempt_outcome_json = function

--- a/test/test_keeper_status_bridge.ml
+++ b/test/test_keeper_status_bridge.ml
@@ -57,21 +57,21 @@ let init_runtime_default_for_tests () =
   | Error e -> Alcotest.failf "Runtime.init_default failed: %s" e
 ;;
 
-let test_synthetic_idle_last_output_is_not_blocker () =
+let test_progress_narrative_is_not_runtime_blocker_source () =
   let summary =
-    "Decisions: [SYNTHETIC] Last output: No awaiting_verification tasks. \
-     Board posts are 21-31 days old with no new signals. Pure idle turn."
+    "Progress: waiting on sandbox egress for github.com push\n\
+     Next: ask operator to approve the manual 4-gate unblock"
   in
   Alcotest.(check (option string))
-    "idle synthetic last output is not a blocker"
+    "progress text never creates runtime blocker class"
     None
     (Option.map (fun b -> b.Keeper_status_bridge.blocker_class) (blocker_of_summary summary))
 ;;
 
-let test_synthetic_no_visible_output_is_not_blocker () =
+let test_synthetic_narrative_is_not_runtime_blocker_source () =
   let summary = "Decisions: [SYNTHETIC] No visible output this generation" in
   Alcotest.(check (option string))
-    "synthetic fallback output is not a blocker"
+    "synthetic text never creates runtime blocker class"
     None
     (Option.map (fun b -> b.Keeper_status_bridge.blocker_class) (blocker_of_summary summary))
 ;;
@@ -132,16 +132,16 @@ let () =
   Alcotest.run
     "keeper_status_bridge"
     [
-      ( "synthetic progress blockers",
+      ( "progress narrative provenance",
         [
           Alcotest.test_case
-            "idle synthetic last output is not blocker"
+            "progress narrative is not blocker source"
             `Quick
-            test_synthetic_idle_last_output_is_not_blocker;
+            test_progress_narrative_is_not_runtime_blocker_source;
           Alcotest.test_case
-            "no visible synthetic output is not blocker"
+            "synthetic narrative is not blocker source"
             `Quick
-            test_synthetic_no_visible_output_is_not_blocker;
+            test_synthetic_narrative_is_not_runtime_blocker_source;
         ] );
       ( "profile default override provenance",
         [


### PR DESCRIPTION
## Summary
- remove progress/continuity narrative substring classification from `Keeper_status_bridge.runtime_blocker_surface_opt`
- keep runtime blocker classes sourced only from typed keeper metadata or registry failure reasons
- update status bridge tests so progress/synthetic narrative text cannot create a runtime blocker class

## Verification
- `ocamlformat --check lib/keeper/keeper_status_bridge.ml test/test_keeper_status_bridge.ml`
- `git diff --check`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_status_bridge.exe`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_keeper_status_bridge.exe` (after another session temporarily changed the opam pin guard state)
- `./_build/default/test/test_keeper_status_bridge.exe`