### PR TITLE
feat(keeper): per-runtime autonomous queue lanes

### DIFF
--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -152,9 +152,16 @@ val slot_holders_summary : ?limit:int -> now:float -> unit -> string
     snapshot accessors. *)
 val force_release_holder_for : keeper_name:string -> (string * float) list
 
-(** Test-only FIFO queue primitives for autonomous fairness regression tests. *)
-val enqueue_autonomous_waiter_for_test : string -> int
+(** Test-only FIFO queue primitives for autonomous fairness regression tests.
+    [enqueue_autonomous_waiter_for_test] defaults [runtime_id] to ["test"]. *)
+val enqueue_autonomous_waiter_for_test : ?runtime_id:string -> string -> int
 val drop_autonomous_waiter_for_test : int -> unit
+
+(** Test-only: head ticket of a specific runtime lane. *)
+val autonomous_waiter_head_ticket_for_test : runtime_id:string -> int option
+
+(** Test-only: aggregate queue depth across all runtime lanes. *)
+val autonomous_wait_queue_depth_for_test : unit -> int
 
 (** Pure computation: seconds keeper should yield before re-entering queue
     at time [now].  0.0 = no yield needed.  Exposed for unit testing. *)

--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -430,6 +430,7 @@ let prune_lane_locked lane =
       if Hashtbl.mem autonomous_tickets waiter.ticket
       then ()
       else (
+        (* fire-and-forget: drain tombstoned queue element *)
         ignore (Queue.take lane.queue);
         loop ())
   in

--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -378,23 +378,27 @@ let slot_holders_summary ?(limit = 5) ~now () =
 type autonomous_waiter =
   { ticket : int
   ; keeper_name : string
+  ; runtime_id : string
   }
 
 (* Eio.Mutex: queue operations are pure/non-yielding. Stdlib.Mutex is PTHREAD_MUTEX_ERRORCHECK on OCaml 5 and raises "Resource deadlock avoided" whenever two Eio fibers on the same OS thread contend, ... *)
-let autonomous_wait_queue_mutex = Eio.Mutex.create ()
+type autonomous_lane =
+  { queue : autonomous_waiter Queue.t
+  ; active_count : int ref
+  }
 
-(* FIFO waiters use an append-only queue plus an active-ticket table. Removing a middle waiter only tombstones its ticket; the physical queue is pruned lazily from the head. This keeps enqueue/drop O(... *)
-let autonomous_wait_queue : autonomous_waiter Queue.t = Queue.create ()
-let autonomous_wait_queue_active_tickets : (int, unit) Hashtbl.t = Hashtbl.create 32
-let autonomous_wait_queue_active_count = ref 0
-let autonomous_wait_queue_next_ticket = ref 0
+let autonomous_lanes_mutex = Eio.Mutex.create ()
+let autonomous_lanes : (string, autonomous_lane) Hashtbl.t = Hashtbl.create 8
+let autonomous_tickets : (int, unit) Hashtbl.t = Hashtbl.create 32
+let autonomous_ticket_lane : (int, string) Hashtbl.t = Hashtbl.create 32
+let autonomous_next_ticket = ref 0
 
 (* Routed through Env_config_keeper so operators can tune cadence without a rebuild (same fragmentation class as the watchdog thresholds extracted in #10740). The value is read once at module load — r... *)
 let autonomous_queue_poll_sec =
   Env_config_keeper.KeeperPollIntervals.autonomous_queue_poll_sec
 ;;
-let with_autonomous_wait_queue f =
-  Eio.Mutex.use_rw ~protect:true autonomous_wait_queue_mutex f
+let with_autonomous_lanes f =
+  Eio.Mutex.use_rw ~protect:true autonomous_lanes_mutex f
 ;;
 let autonomous_queue_depth_labels = [ "channel", "autonomous_queue" ]
 let record_autonomous_queue_depth depth =
@@ -403,94 +407,145 @@ let record_autonomous_queue_depth depth =
     ~labels:autonomous_queue_depth_labels
     (float_of_int depth)
 ;;
-let autonomous_queue_peek_opt () =
-  try Some (Queue.peek autonomous_wait_queue) with
+
+let get_or_create_lane runtime_id =
+  match Hashtbl.find_opt autonomous_lanes runtime_id with
+  | Some lane -> lane
+  | None ->
+    let lane = { queue = Queue.create (); active_count = ref 0 } in
+    Hashtbl.replace autonomous_lanes runtime_id lane;
+    lane
+;;
+
+let lane_peek_opt lane =
+  try Some (Queue.peek lane.queue) with
   | Queue.Empty -> None
 ;;
-let prune_autonomous_wait_queue_locked () =
+
+let prune_lane_locked lane =
   let rec loop () =
-    match autonomous_queue_peek_opt () with
+    match lane_peek_opt lane with
     | None -> ()
     | Some waiter ->
-      if Hashtbl.mem autonomous_wait_queue_active_tickets waiter.ticket
+      if Hashtbl.mem autonomous_tickets waiter.ticket
       then ()
       else (
-        (* fire-and-forget: drain queue element *)
-        ignore (Queue.take autonomous_wait_queue);
+        ignore (Queue.take lane.queue);
         loop ())
   in
   loop ()
 ;;
+
+let prune_all_lanes_locked () =
+  Hashtbl.iter (fun _ lane -> prune_lane_locked lane) autonomous_lanes
+;;
+
 let active_autonomous_waiters_locked () =
-  prune_autonomous_wait_queue_locked ();
+  prune_all_lanes_locked ();
   let active = ref [] in
-  Queue.iter
-    (fun waiter ->
-       if Hashtbl.mem autonomous_wait_queue_active_tickets waiter.ticket
-       then active := waiter :: !active)
-    autonomous_wait_queue;
+  Hashtbl.iter
+    (fun _ lane ->
+       Queue.iter
+         (fun waiter ->
+            if Hashtbl.mem autonomous_tickets waiter.ticket
+            then active := waiter :: !active)
+         lane.queue)
+    autonomous_lanes;
   List.rev !active
 ;;
 let autonomous_wait_queue_depth () =
-  with_autonomous_wait_queue (fun () ->
-    prune_autonomous_wait_queue_locked ();
-    !autonomous_wait_queue_active_count)
+  with_autonomous_lanes (fun () ->
+    prune_all_lanes_locked ();
+    Hashtbl.fold
+      (fun _ lane total -> total + !(lane.active_count))
+      autonomous_lanes
+      0)
 ;;
 let reset_autonomous_turn_queue_for_test () =
-  with_autonomous_wait_queue (fun () ->
-    Queue.clear autonomous_wait_queue;
-    Hashtbl.reset autonomous_wait_queue_active_tickets;
-    autonomous_wait_queue_active_count := 0;
-    autonomous_wait_queue_next_ticket := 0;
+  with_autonomous_lanes (fun () ->
+    Hashtbl.reset autonomous_lanes;
+    Hashtbl.reset autonomous_tickets;
+    Hashtbl.reset autonomous_ticket_lane;
+    autonomous_next_ticket := 0;
     record_autonomous_queue_depth 0)
 ;;
-let enqueue_autonomous_waiter ~(keeper_name : string) : int =
-  with_autonomous_wait_queue (fun () ->
-    let ticket = !autonomous_wait_queue_next_ticket in
-    incr autonomous_wait_queue_next_ticket;
-    Queue.add { ticket; keeper_name } autonomous_wait_queue;
-    Hashtbl.replace autonomous_wait_queue_active_tickets ticket ();
-    incr autonomous_wait_queue_active_count;
-    record_autonomous_queue_depth !autonomous_wait_queue_active_count;
+let enqueue_autonomous_waiter ~(keeper_name : string) ~(runtime_id : string) : int =
+  with_autonomous_lanes (fun () ->
+    let lane = get_or_create_lane runtime_id in
+    let ticket = !autonomous_next_ticket in
+    incr autonomous_next_ticket;
+    Queue.add { ticket; keeper_name; runtime_id } lane.queue;
+    Hashtbl.replace autonomous_tickets ticket ();
+    Hashtbl.replace autonomous_ticket_lane ticket runtime_id;
+    incr lane.active_count;
+    record_autonomous_queue_depth
+      (Hashtbl.fold
+         (fun _ lane total -> total + !(lane.active_count))
+         autonomous_lanes
+         0);
     ticket)
 ;;
 let drop_autonomous_waiter ~(ticket : int) : unit =
-  with_autonomous_wait_queue (fun () ->
-    if Hashtbl.mem autonomous_wait_queue_active_tickets ticket
+  with_autonomous_lanes (fun () ->
+    if Hashtbl.mem autonomous_tickets ticket
     then (
-      Hashtbl.remove autonomous_wait_queue_active_tickets ticket;
-      decr autonomous_wait_queue_active_count);
-    prune_autonomous_wait_queue_locked ();
-    record_autonomous_queue_depth !autonomous_wait_queue_active_count)
+      Hashtbl.remove autonomous_tickets ticket;
+      (match Hashtbl.find_opt autonomous_ticket_lane ticket with
+       | None -> ()
+       | Some runtime_id ->
+         (match Hashtbl.find_opt autonomous_lanes runtime_id with
+          | None -> ()
+          | Some lane -> decr lane.active_count);
+         Hashtbl.remove autonomous_ticket_lane ticket);
+      prune_all_lanes_locked ();
+      record_autonomous_queue_depth
+        (Hashtbl.fold
+           (fun _ lane total -> total + !(lane.active_count))
+           autonomous_lanes
+           0)))
 ;;
 let autonomous_waiter_snapshot_for_test () : string list =
-  with_autonomous_wait_queue (fun () ->
+  with_autonomous_lanes (fun () ->
     List.map (fun waiter -> waiter.keeper_name) (active_autonomous_waiters_locked ()))
 ;;
-let enqueue_autonomous_waiter_for_test keeper_name =
-  enqueue_autonomous_waiter ~keeper_name
+let enqueue_autonomous_waiter_for_test ?(runtime_id = "test") keeper_name =
+  enqueue_autonomous_waiter ~keeper_name ~runtime_id
 ;;
 let drop_autonomous_waiter_for_test ticket = drop_autonomous_waiter ~ticket
-let autonomous_waiter_head_ticket () : int option =
-  with_autonomous_wait_queue (fun () ->
-    prune_autonomous_wait_queue_locked ();
-    match autonomous_queue_peek_opt () with
-    | Some head -> Some head.ticket
-    | None -> None)
+let autonomous_waiter_head_ticket ~(runtime_id : string) : int option =
+  with_autonomous_lanes (fun () ->
+    match Hashtbl.find_opt autonomous_lanes runtime_id with
+    | None -> None
+    | Some lane ->
+      prune_lane_locked lane;
+      (match lane_peek_opt lane with
+       | Some head -> Some head.ticket
+       | None -> None))
 ;;
 let autonomous_waiter_position ~(ticket : int) : int option =
-  with_autonomous_wait_queue (fun () ->
-    prune_autonomous_wait_queue_locked ();
-    let position = ref None in
-    let idx = ref 0 in
-    Queue.iter
-      (fun waiter ->
-         if
-           Option.is_none !position
-           && Hashtbl.mem autonomous_wait_queue_active_tickets waiter.ticket
-         then if waiter.ticket = ticket then position := Some !idx else incr idx)
-      autonomous_wait_queue;
-    !position)
+  with_autonomous_lanes (fun () ->
+    match Hashtbl.find_opt autonomous_ticket_lane ticket with
+    | None -> None
+    | Some runtime_id ->
+      (match Hashtbl.find_opt autonomous_lanes runtime_id with
+       | None -> None
+       | Some lane ->
+         prune_lane_locked lane;
+         let position = ref None in
+         let idx = ref 0 in
+         Queue.iter
+           (fun waiter ->
+              if Option.is_none !position && Hashtbl.mem autonomous_tickets waiter.ticket
+              then if waiter.ticket = ticket then position := Some !idx else incr idx)
+           lane.queue;
+         !position))
+;;
+
+let others_waiting_in_queue ~(keeper_name : string) : bool =
+  with_autonomous_lanes (fun () ->
+    List.exists
+      (fun waiter -> not (String.equal waiter.keeper_name keeper_name))
+      (active_autonomous_waiters_locked ()))
 ;;
 
 (** Wall-clock cap on [Eio.Semaphore.acquire] when waiting for a keeper turn slot. Without this, a keeper whose peers hold all slots while their LLM calls stall for the entire 1200s turn budget would b... *)
@@ -886,20 +941,8 @@ let autonomous_fairness_cooldown_sec =
     ~max_v:60.0
 ;;
 
-let others_waiting_in_queue ~(keeper_name : string) : bool =
-  with_autonomous_wait_queue (fun () ->
-    prune_autonomous_wait_queue_locked ();
-    let found = ref false in
-    Queue.iter
-      (fun w ->
-         if
-           (not !found)
-           && Hashtbl.mem autonomous_wait_queue_active_tickets w.ticket
-           && w.keeper_name <> keeper_name
-         then found := true)
-      autonomous_wait_queue;
-    !found)
-;;
+(* [others_waiting_in_queue] checks across all per-runtime lanes for any active
+   waiter other than the named keeper. *)
 
 (** Pure computation: how many seconds [keeper_name] should yield before
     re-entering the queue at time [now].  Returns [0.0] when no yield is
@@ -945,10 +988,11 @@ let maybe_yield_for_fairness ~(keeper_name : string) : unit =
 let rec wait_for_autonomous_queue_head
           ~(keeper_name : string)
           ~(ticket : int)
+          ~(runtime_id : string)
           ~(started_at : float)
   : (unit, [> `Semaphore_wait_timeout of semaphore_wait_timeout ]) result
   =
-  if Option.equal Int.equal (autonomous_waiter_head_ticket ()) (Some ticket)
+  if Option.equal Int.equal (autonomous_waiter_head_ticket ~runtime_id) (Some ticket)
   then Ok ()
   else (
     let waited_sec = Time_compat.now () -. started_at in
@@ -992,7 +1036,7 @@ let rec wait_for_autonomous_queue_head
               Yield cooperatively instead of using a blocking Unix sleep so
               the Eio convention guard remains satisfied. *)
          Eio.Fiber.yield ());
-      wait_for_autonomous_queue_head ~keeper_name ~ticket ~started_at))
+      wait_for_autonomous_queue_head ~keeper_name ~ticket ~runtime_id ~started_at))
 ;;
 
 let semaphore_wait_seconds_buckets =
@@ -1139,7 +1183,7 @@ let with_keeper_turn_slot_control ?(runtime_profile = "unknown") ~keeper_name ~c
              queue to give peers a chance to reach head-of-queue first.
              See [maybe_yield_for_fairness] and #6810. *)
         maybe_yield_for_fairness ~keeper_name;
-        let ticket = enqueue_autonomous_waiter ~keeper_name in
+        let ticket = enqueue_autonomous_waiter ~keeper_name ~runtime_id:runtime_profile in
         slot_state.autonomous_ticket := Some ticket;
         (* Reset the queue-head timeout clock to the moment we bound the
              queue, NOT [t0] (slot-entry). Otherwise [maybe_yield_for_fairness]
@@ -1150,7 +1194,8 @@ let with_keeper_turn_slot_control ?(runtime_profile = "unknown") ~keeper_name ~c
              free but we ran out of budget while sleeping in fairness yield. *)
         let queue_entered_at = Time_compat.now () in
         match
-          wait_for_autonomous_queue_head ~keeper_name ~ticket ~started_at:queue_entered_at
+          wait_for_autonomous_queue_head
+            ~keeper_name ~ticket ~runtime_id:runtime_profile ~started_at:queue_entered_at
         with
         | Error _ as e -> e
         | Ok () ->
@@ -1296,6 +1341,18 @@ let with_keeper_turn_slot_for_test ?runtime_profile ~keeper_name ~channel f =
   with_keeper_turn_slot ?runtime_profile ~keeper_name ~channel f
 ;;
 
-let wait_for_autonomous_queue_head_for_test ~keeper_name ~ticket ~started_at =
-  wait_for_autonomous_queue_head ~keeper_name ~ticket ~started_at
+let wait_for_autonomous_queue_head_for_test
+      ?(runtime_id = "test") ~keeper_name ~ticket ~started_at ()
+  =
+  wait_for_autonomous_queue_head ~keeper_name ~ticket ~runtime_id ~started_at
+;;
+
+(** Test-only: expose per-lane head ticket check. *)
+let autonomous_waiter_head_ticket_for_test ~runtime_id =
+  autonomous_waiter_head_ticket ~runtime_id
+;;
+
+(** Test-only: expose aggregate queue depth. *)
+let autonomous_wait_queue_depth_for_test () =
+  autonomous_wait_queue_depth ()
 ;;

--- a/lib/keeper/keeper_turn_slot.mli
+++ b/lib/keeper/keeper_turn_slot.mli
@@ -61,6 +61,7 @@ val semaphore_wait_timeout_sec : float
 type autonomous_waiter = {
   ticket : int;
   keeper_name : string;
+  runtime_id : string;
 }
 
 (** Test-only reset for the autonomous FIFO wait queue. *)
@@ -130,19 +131,29 @@ val format_slot_holders : ?limit:int -> (string * float) list -> string
 (** Operator-facing one-line summary of all holder pools. *)
 val slot_holders_summary : ?limit:int -> now:float -> unit -> string
 
-(** Test-only FIFO queue primitives for autonomous fairness regression tests. *)
-val enqueue_autonomous_waiter_for_test : string -> int
+(** Test-only FIFO queue primitives for autonomous fairness regression tests.
+    [enqueue_autonomous_waiter_for_test] defaults [runtime_id] to ["test"]. *)
+val enqueue_autonomous_waiter_for_test : ?runtime_id:string -> string -> int
 val drop_autonomous_waiter_for_test : int -> unit
+
+(** Test-only: head ticket of a specific runtime lane, or [None] if empty. *)
+val autonomous_waiter_head_ticket_for_test : runtime_id:string -> int option
+
+(** Test-only: aggregate queue depth across all runtime lanes. *)
+val autonomous_wait_queue_depth_for_test : unit -> int
 
 (** Test-only: drive the queue-head wait loop directly with an injected
     [~started_at]. Exposed so a regression test can assert that a stale
     [started_at] (e.g. one captured before a fairness cooldown) immediately
     returns [Error `Semaphore_wait_timeout] — proving the parameter is the
-    timing knob whose freshness must be controlled at every call site. *)
+    timing knob whose freshness must be controlled at every call site.
+    [~runtime_id] defaults to ["test"]. *)
 val wait_for_autonomous_queue_head_for_test :
+  ?runtime_id:string ->
   keeper_name:string ->
   ticket:int ->
   started_at:float ->
+  unit ->
   (unit, [> `Semaphore_wait_timeout of semaphore_wait_timeout ]) result
 
 (** Pure computation: seconds keeper should yield before re-entering queue

--- a/test/dune
+++ b/test/dune
@@ -1442,6 +1442,7 @@
 
 (include stanzas/test_keeper_semaphore_fairness.inc)
 
+(include stanzas/test_keeper_turn_slot_lane_isolation.inc)
 
 (include stanzas/test_keeper_sandbox_docker_cwd_response.inc)
 

--- a/test/stanzas/test_keeper_turn_slot_lane_isolation.inc
+++ b/test/stanzas/test_keeper_turn_slot_lane_isolation.inc
@@ -1,0 +1,6 @@
+; Per-runtime autonomous queue lane isolation
+
+(test
+ (name test_keeper_turn_slot_lane_isolation)
+ (modules test_keeper_turn_slot_lane_isolation)
+ (libraries masc_test_deps))

--- a/test/test_keeper_semaphore_wait_queue_head_clock.ml
+++ b/test/test_keeper_semaphore_wait_queue_head_clock.ml
@@ -51,6 +51,7 @@ let test_stale_started_at_times_out_immediately () =
           ~keeper_name:"ours"
           ~ticket:ours
           ~started_at:stale_started_at
+          ()
       with
       | Error (`Semaphore_wait_timeout timeout) ->
         Alcotest.(check (float 0.001))
@@ -85,6 +86,7 @@ let test_fresh_started_at_at_head_returns_ok () =
           ~keeper_name:"ours"
           ~ticket:ours
           ~started_at:fresh
+          ()
       with
       | Ok () ->
         Alcotest.(check pass)

--- a/test/test_keeper_turn_slot_lane_isolation.ml
+++ b/test/test_keeper_turn_slot_lane_isolation.ml
@@ -1,0 +1,233 @@
+(** Regression tests for per-runtime autonomous queue lane isolation.
+
+    Background: the autonomous FIFO wait queue was a single global structure.
+    When a slow runtime (deepseek-v4-flash, ~900s turns) held the head,
+    all keepers behind it—including fast runtimes (GLM, ~180s)—timed out
+    at the 180s semaphore_wait_timeout. This is classic head-of-line blocking.
+
+    Fix: per-runtime FIFO lanes keyed by runtime_id string. Each runtime
+    gets its own queue; a slow head no longer blocks fast runtimes in
+    other lanes. The shared autonomous_turn_semaphore (16 permits) still
+    provides global concurrency control.
+
+    These tests exercise:
+    - Lane isolation: fast lane not blocked by slow lane head
+    - FIFO within lane: ordering preserved within the same runtime
+    - Depth aggregation: global depth sums across all lanes
+    - Cross-lane drop: ticket_lane reverse index works correctly
+    - Runtime ID in waiter record: preserved through enqueue/drop *)
+
+module KK = Masc.Keeper_keepalive
+
+(** Reset all lane state between tests. *)
+let with_fresh_lanes test_body () =
+  Eio_main.run @@ fun _env ->
+    KK.reset_autonomous_turn_queue_for_test ();
+    test_body ()
+;;
+
+(* --------------------------------------------------------------------------
+   Lane isolation: slow lane does not block fast lane
+   -------------------------------------------------------------------------- *)
+
+let test_slow_lane_does_not_block_fast_lane () =
+  (* Enqueue a "slow-runtime" keeper, then a "fast-runtime" keeper.
+     The fast keeper is immediately at the head of its own lane —
+     it does NOT wait behind the slow keeper. *)
+  let _slow_ticket =
+    KK.enqueue_autonomous_waiter_for_test ~runtime_id:"deepseek" "slow-keeper"
+  in
+  let fast_ticket =
+    KK.enqueue_autonomous_waiter_for_test ~runtime_id:"glm" "fast-keeper"
+  in
+  (* Fast keeper is head of the "glm" lane immediately. *)
+  let fast_head =
+    match KK.autonomous_waiter_head_ticket_for_test ~runtime_id:"glm" with
+    | Some t -> t
+    | None -> Alcotest.fail "fast lane should have a head"
+  in
+  Alcotest.(check int) "fast lane head = fast_ticket" fast_ticket fast_head;
+  (* Slow keeper is head of the "deepseek" lane. *)
+  let slow_head =
+    match KK.autonomous_waiter_head_ticket_for_test ~runtime_id:"deepseek" with
+    | Some t -> t
+    | None -> Alcotest.fail "slow lane should have a head"
+  in
+  Alcotest.(check bool) "slow head != fast head" true (slow_head <> fast_head);
+  (* Cleanup. *)
+  KK.drop_autonomous_waiter_for_test _slow_ticket;
+  KK.drop_autonomous_waiter_for_test fast_ticket
+;;
+
+(* --------------------------------------------------------------------------
+   FIFO within lane: ordering preserved
+   -------------------------------------------------------------------------- *)
+
+let test_fifo_ordering_within_lane () =
+  let t1 =
+    KK.enqueue_autonomous_waiter_for_test ~runtime_id:"glm" "keeper-a"
+  in
+  let t2 =
+    KK.enqueue_autonomous_waiter_for_test ~runtime_id:"glm" "keeper-b"
+  in
+  let t3 =
+    KK.enqueue_autonomous_waiter_for_test ~runtime_id:"glm" "keeper-c"
+  in
+  (* Head of "glm" lane is the first enqueued. *)
+  (match KK.autonomous_waiter_head_ticket_for_test ~runtime_id:"glm" with
+   | Some h -> Alcotest.(check int) "head = t1" t1 h
+   | None -> Alcotest.fail "glm lane should have a head");
+  (* Drop t1, head advances to t2. *)
+  KK.drop_autonomous_waiter_for_test t1;
+  (match KK.autonomous_waiter_head_ticket_for_test ~runtime_id:"glm" with
+   | Some h -> Alcotest.(check int) "head = t2 after drop t1" t2 h
+   | None -> Alcotest.fail "glm lane should still have a head after drop");
+  (* Drop t2, head advances to t3. *)
+  KK.drop_autonomous_waiter_for_test t2;
+  (match KK.autonomous_waiter_head_ticket_for_test ~runtime_id:"glm" with
+   | Some h -> Alcotest.(check int) "head = t3 after drop t2" t3 h
+   | None -> Alcotest.fail "glm lane should still have a head after drop t2");
+  KK.drop_autonomous_waiter_for_test t3
+;;
+
+(* --------------------------------------------------------------------------
+   Tombstone pruning within lane
+   -------------------------------------------------------------------------- *)
+
+let test_tombstone_does_not_block_lane_head () =
+  let t1 =
+    KK.enqueue_autonomous_waiter_for_test ~runtime_id:"glm" "keeper-a"
+  in
+  let t2 =
+    KK.enqueue_autonomous_waiter_for_test ~runtime_id:"glm" "keeper-b"
+  in
+  (* Tombstone t1 (middle dequeue). *)
+  KK.drop_autonomous_waiter_for_test t1;
+  (* Head should advance to t2 after pruning. *)
+  (match KK.autonomous_waiter_head_ticket_for_test ~runtime_id:"glm" with
+   | Some h -> Alcotest.(check int) "head = t2 after tombstone t1" t2 h
+   | None -> Alcotest.fail "glm lane should have t2 as head after tombstone");
+  KK.drop_autonomous_waiter_for_test t2
+;;
+
+(* --------------------------------------------------------------------------
+   Depth aggregation across lanes
+   -------------------------------------------------------------------------- *)
+
+let test_depth_aggregation () =
+  Alcotest.(check int) "empty depth" 0 (KK.autonomous_wait_queue_depth_for_test ());
+  let t1 =
+    KK.enqueue_autonomous_waiter_for_test ~runtime_id:"glm" "glm-keeper"
+  in
+  Alcotest.(check int) "depth=1 after one enqueue" 1
+    (KK.autonomous_wait_queue_depth_for_test ());
+  let t2 =
+    KK.enqueue_autonomous_waiter_for_test ~runtime_id:"deepseek" "deepseek-keeper"
+  in
+  Alcotest.(check int) "depth=2 after two lanes" 2
+    (KK.autonomous_wait_queue_depth_for_test ());
+  let t3 =
+    KK.enqueue_autonomous_waiter_for_test ~runtime_id:"glm" "glm-keeper-2"
+  in
+  Alcotest.(check int) "depth=3 after second glm enqueue" 3
+    (KK.autonomous_wait_queue_depth_for_test ());
+  KK.drop_autonomous_waiter_for_test t1;
+  Alcotest.(check int) "depth=2 after drop" 2
+    (KK.autonomous_wait_queue_depth_for_test ());
+  KK.drop_autonomous_waiter_for_test t2;
+  KK.drop_autonomous_waiter_for_test t3;
+  Alcotest.(check int) "depth=0 after all drops" 0
+    (KK.autonomous_wait_queue_depth_for_test ())
+;;
+
+(* --------------------------------------------------------------------------
+   Cross-lane drop via ticket_lane reverse index
+   -------------------------------------------------------------------------- *)
+
+let test_cross_lane_drop () =
+  let t_slow =
+    KK.enqueue_autonomous_waiter_for_test ~runtime_id:"deepseek" "slow-keeper"
+  in
+  let t_fast =
+    KK.enqueue_autonomous_waiter_for_test ~runtime_id:"glm" "fast-keeper"
+  in
+  (* Drop the slow keeper — should use ticket_lane to find "deepseek" lane. *)
+  KK.drop_autonomous_waiter_for_test t_slow;
+  (* "deepseek" lane should be empty now. *)
+  (match KK.autonomous_waiter_head_ticket_for_test ~runtime_id:"deepseek" with
+   | None -> ()
+   | Some _ -> Alcotest.fail "deepseek lane should be empty after drop");
+  (* "glm" lane should still have the fast keeper. *)
+  (match KK.autonomous_waiter_head_ticket_for_test ~runtime_id:"glm" with
+   | Some h -> Alcotest.(check int) "glm head intact" t_fast h
+   | None -> Alcotest.fail "glm lane should still have fast-keeper");
+  KK.drop_autonomous_waiter_for_test t_fast
+;;
+
+(* --------------------------------------------------------------------------
+   Empty lane returns None for head
+   -------------------------------------------------------------------------- *)
+
+let test_empty_lane_head_is_none () =
+  (match KK.autonomous_waiter_head_ticket_for_test ~runtime_id:"nonexistent" with
+   | None -> ()
+   | Some _ -> Alcotest.fail "nonexistent lane should have no head")
+;;
+
+(* --------------------------------------------------------------------------
+   Waiter snapshot aggregates across lanes
+   -------------------------------------------------------------------------- *)
+
+let test_snapshot_cross_lane () =
+  let _t1 =
+    KK.enqueue_autonomous_waiter_for_test ~runtime_id:"deepseek" "slow-keeper"
+  in
+  let _t2 =
+    KK.enqueue_autonomous_waiter_for_test ~runtime_id:"glm" "fast-keeper"
+  in
+  let snapshot = KK.autonomous_waiter_snapshot_for_test () in
+  (* Snapshot should contain both keepers, order is lane-iteration order. *)
+  let has_slow = List.exists (fun n -> String.equal n "slow-keeper") snapshot in
+  let has_fast = List.exists (fun n -> String.equal n "fast-keeper") snapshot in
+  Alcotest.(check bool) "snapshot has slow-keeper" true has_slow;
+  Alcotest.(check bool) "snapshot has fast-keeper" true has_fast;
+  Alcotest.(check int) "snapshot length = 2" 2 (List.length snapshot)
+;;
+
+(* --------------------------------------------------------------------------
+   Suite
+   -------------------------------------------------------------------------- *)
+
+let () =
+  Alcotest.run
+    "keeper_turn_slot_lane_isolation"
+    [ ( "lane_isolation"
+      , [ Alcotest.test_case "slow does not block fast" `Quick
+             (with_fresh_lanes test_slow_lane_does_not_block_fast_lane)
+        ] )
+    ; ( "fifo_within_lane"
+      , [ Alcotest.test_case "ordering preserved" `Quick
+             (with_fresh_lanes test_fifo_ordering_within_lane)
+        ] )
+    ; ( "tombstone"
+      , [ Alcotest.test_case "tombstone pruning" `Quick
+             (with_fresh_lanes test_tombstone_does_not_block_lane_head)
+        ] )
+    ; ( "depth"
+      , [ Alcotest.test_case "aggregation across lanes" `Quick
+             (with_fresh_lanes test_depth_aggregation)
+        ] )
+    ; ( "cross_lane_drop"
+      , [ Alcotest.test_case "ticket reverse index" `Quick
+             (with_fresh_lanes test_cross_lane_drop)
+        ] )
+    ; ( "empty_lane"
+      , [ Alcotest.test_case "head is None" `Quick
+             (with_fresh_lanes test_empty_lane_head_is_none)
+        ] )
+    ; ( "snapshot"
+      , [ Alcotest.test_case "cross-lane aggregation" `Quick
+             (with_fresh_lanes test_snapshot_cross_lane)
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Problem

Autonomous keeper turn admission used one global FIFO queue. When a slow runtime sits at the autonomous queue head, faster runtimes behind it can spend their whole queue-head budget waiting for an unrelated runtime lane.

```text
qa-king: skipping turn (skipped: semaphore wait > 180s
  phase=autonomous_queue_head
  runtime=ollama_cloud.deepseek-v4-flash
  queue_blocker=autonomous_fifo queue_ahead=1 queue_depth=6)
```

## Solution

Keep `Keeper_turn_slot_acquire` deleted and move the autonomous queue state in `keeper_turn_slot.ml` from a single FIFO queue to per-runtime FIFO lanes:

```text
Before: [deepseek-A] -> [glm-B] -> [glm-C] -> [qa-king]
After:  deepseek lane: [deepseek-A]
        glm lane:      [glm-B] -> [glm-C]
        qa lane:       [qa-king]
```

Each `runtime_profile` becomes the lane key passed through enqueue and queue-head wait paths. FIFO ordering remains preserved inside a runtime lane, while unrelated runtime lanes no longer block each other at the queue-head check.

## Changes

- `lib/keeper/keeper_turn_slot.ml`: replace global autonomous waiter queue with `autonomous_lanes`, active ticket tombstones, and ticket-to-lane reverse index.
- `lib/keeper/keeper_turn_slot.ml`: thread `runtime_id` through enqueue and queue-head wait paths.
- `lib/keeper/keeper_turn_slot.mli`, `lib/keeper/keeper_keepalive.mli`: update test helper interfaces.
- `test/test_keeper_turn_slot_lane_isolation.ml`: add lane isolation, per-lane FIFO, tombstone, aggregate depth, cross-lane drop, empty-lane, and snapshot coverage.

## Local Verification

- `git diff --check origin/main...HEAD`
- `rg -n "Keeper_turn_slot_acquire|keeper_turn_slot_acquire|turn_slot_acquire" lib test dune-project dune` -> no matches
- `ocamlformat --enable-outside-detected-project --check lib/keeper/keeper_keepalive.mli lib/keeper/keeper_turn_slot.ml lib/keeper/keeper_turn_slot.mli test/test_keeper_semaphore_wait_queue_head_clock.ml test/test_keeper_turn_slot_lane_isolation.ml`
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-pr20345 dune build --root . test/test_keeper_turn_slot_lane_isolation.exe test/test_keeper_semaphore_wait_queue_head_clock.exe test/test_keeper_turn_slot_holders.exe test/test_keeper_turn_slot_force_release.exe test/test_keeper_turn_slot_release_cancel_safe.exe test/test_work_as_heartbeat.exe --display=short -j 1`
- `dune exec ... test/test_keeper_turn_slot_lane_isolation.exe` -> 7 tests pass
- `dune exec ... test/test_keeper_semaphore_wait_queue_head_clock.exe` -> 3 tests pass
- `dune exec ... test/test_keeper_turn_slot_holders.exe` -> 16 checks pass
- `dune exec ... test/test_keeper_turn_slot_force_release.exe` -> 4 tests pass
- `dune exec ... test/test_keeper_turn_slot_release_cancel_safe.exe` -> OK
- `dune exec ... test/test_work_as_heartbeat.exe` -> 43 tests pass

## GitHub Checks

Force-pushed onto current `origin/main` (`416a71bb4b`). PR remains draft; the draft auto-merge guard is expected to block until the PR is approved and marked ready.
