### PR TITLE
[codex] Wire Slack and Telegram sidecar connectors

### DIFF
--- a/lib/gate/channel_gate_sidecar_state.ml
+++ b/lib/gate/channel_gate_sidecar_state.ml
@@ -1,0 +1,480 @@
+(** Generic file-backed Channel Gate connector state for Python sidecars. *)
+
+module U = Yojson.Safe.Util
+
+module type Config = sig
+  val connector_id : string
+  val display_name : string
+  val channel : string
+  val default_status_path : string
+  val default_binding_store_path : string
+  val default_binding_audit_path : string
+  val status_path_env_names : string list
+  val binding_store_path_env_names : string list
+  val binding_audit_path_env_names : string list
+  val stale_after_env_name : string
+end
+
+module Make (Config : Config) = struct
+  type binding = {
+    channel_id : string;
+    keeper_name : string;
+  }
+
+  type audit_event = {
+    timestamp : string;
+    action : string;
+    channel_id : string;
+    keeper_name : string;
+    actor_id : string;
+    actor_name : string;
+    previous_keeper : string;
+  }
+
+  let connector_id = Config.connector_id
+  let display_name = Config.display_name
+  let channel = Config.channel
+
+  let stale_after_sec () =
+    Env_config_core.get_int ~default:30 Config.stale_after_env_name
+
+  let resolve_path raw_path =
+    if Filename.is_relative raw_path then
+      Filename.concat (Env_config_core.base_path ()) raw_path
+    else
+      raw_path
+
+  let configured_write_path env_names ~default =
+    env_names
+    |> List.find_map (fun name ->
+           Sys.getenv_opt name |> Env_config_core.trim_opt)
+    |> Option.value ~default
+    |> resolve_path
+
+  let status_path () =
+    configured_write_path Config.status_path_env_names
+      ~default:Config.default_status_path
+
+  let binding_store_path () =
+    configured_write_path Config.binding_store_path_env_names
+      ~default:Config.default_binding_store_path
+
+  let binding_store_read_path = binding_store_path
+
+  let binding_audit_path () =
+    configured_write_path Config.binding_audit_path_env_names
+      ~default:Config.default_binding_audit_path
+
+  let binding_audit_read_path = binding_audit_path
+
+  let read_json_file_opt path =
+    try Some (Yojson.Safe.from_file path) with
+    | Sys_error _ | Yojson.Json_error _ -> None
+
+  let normalize_bindings_json (json : Yojson.Safe.t) : binding list =
+    match json with
+    | `Assoc items ->
+        items
+        |> List.filter_map (fun (raw_channel_id, raw_keeper_name) ->
+               let channel_id = String.trim raw_channel_id in
+               let keeper_name =
+                 match raw_keeper_name with
+                 | `String value -> String.trim value
+                 | _ -> ""
+               in
+               if channel_id = "" || keeper_name = "" then None
+               else Some ({ channel_id; keeper_name } : binding))
+        |> List.sort (fun (a : binding) (b : binding) ->
+               String.compare a.channel_id b.channel_id)
+    | _ -> []
+
+  let read_bindings () : binding list =
+    match read_json_file_opt (binding_store_read_path ()) with
+    | Some json -> normalize_bindings_json json
+    | None -> []
+
+  let binding_json (binding : binding) =
+    `Assoc
+      [
+        ("channel_id", `String binding.channel_id);
+        ("keeper_name", `String binding.keeper_name);
+      ]
+
+  let save_bindings (bindings : binding list) =
+    let path = binding_store_path () in
+    let normalized =
+      bindings
+      |> List.sort (fun (a : binding) (b : binding) ->
+             String.compare a.channel_id b.channel_id)
+      |> List.fold_left
+           (fun acc (binding : binding) ->
+             (binding.channel_id, `String binding.keeper_name) :: acc)
+           []
+      |> List.rev
+      |> fun items -> `Assoc items
+    in
+    let dir = Filename.dirname path in
+    Fs_compat.mkdir_p dir;
+    let tmp = path ^ ".tmp" in
+    let oc = open_out_bin tmp in
+    Fun.protect
+      ~finally:(fun () -> close_out_noerr oc)
+      (fun () -> output_string oc (Yojson.Safe.pretty_to_string normalized ^ "\n"));
+    Sys.rename tmp path
+
+  let audit_event_json event =
+    `Assoc
+      [
+        ("timestamp", `String event.timestamp);
+        ("action", `String event.action);
+        ("guild_id", `String "");
+        ("channel_id", `String event.channel_id);
+        ("keeper_name", `String event.keeper_name);
+        ("actor_id", `String event.actor_id);
+        ("actor_name", `String event.actor_name);
+        ("previous_keeper", `String event.previous_keeper);
+      ]
+
+  let append_audit_event event =
+    let path = binding_audit_path () in
+    let dir = Filename.dirname path in
+    Fs_compat.mkdir_p dir;
+    let oc =
+      open_out_gen [ Open_creat; Open_wronly; Open_append; Open_binary ] 0o644
+        path
+    in
+    Fun.protect
+      ~finally:(fun () -> close_out_noerr oc)
+      (fun () ->
+        output_string oc (Yojson.Safe.to_string (audit_event_json event));
+        output_char oc '\n';
+        flush oc;
+        Unix.fsync (Unix.descr_of_out_channel oc))
+
+  let rec drop_left n xs =
+    if n <= 0 then xs
+    else
+      match xs with
+      | [] -> []
+      | _ :: tl -> drop_left (n - 1) tl
+
+  let read_recent_audit ~limit =
+    let path = binding_audit_read_path () in
+    if limit <= 0 || not (Sys.file_exists path) then
+      []
+    else
+      let ic = open_in_bin path in
+      Fun.protect
+        ~finally:(fun () -> close_in_noerr ic)
+        (fun () ->
+          let rec loop acc =
+            match input_line ic with
+            | line -> loop (line :: acc)
+            | exception End_of_file -> acc
+          in
+          loop []
+          |> List.filter_map (fun line ->
+                 let trimmed = String.trim line in
+                 if trimmed = "" then None
+                 else
+                   try Some (Yojson.Safe.from_string trimmed) with
+                   | Yojson.Json_error _ -> None)
+          |> List.rev
+          |> fun rows ->
+          let total = List.length rows in
+          if total <= limit then List.rev rows
+          else rows |> drop_left (total - limit) |> List.rev)
+
+  let string_member json key =
+    Json_util.get_string_with_default json ~key ~default:""
+
+  let int_member json key =
+    Json_util.get_int json key |> Option.value ~default:0
+
+  let float_member json key =
+    Json_util.get_float json key |> Option.value ~default:0.0
+
+  let bool_member json key =
+    Json_util.get_bool json key |> Option.value ~default:false
+
+  let bool_option_member json key = Json_util.get_bool json key
+
+  let stale_of_updated_at updated_at =
+    match Gate_time_util.parse_iso8601_opt updated_at with
+    | Some ts -> Unix.gettimeofday () -. ts > float_of_int (stale_after_sec ())
+    | None -> true
+
+  let connector_state_label ~available ~connected ~stale =
+    if not available then "offline"
+    else if stale then "stale"
+    else if connected then "connected"
+    else "disconnected"
+
+  let status_json ?(audit_limit = 10) () =
+    let status_path = status_path () in
+    let live_status = read_json_file_opt status_path in
+    let binding_store_path = binding_store_read_path () in
+    let audit_path = binding_audit_read_path () in
+    let configured_bindings = read_bindings () in
+    let recent_audit = read_recent_audit ~limit:audit_limit in
+    let available = Option.is_some live_status in
+    let updated_at =
+      match live_status with
+      | Some json -> string_member json "updated_at"
+      | None -> ""
+    in
+    let stale = if not available then true else stale_of_updated_at updated_at in
+    let connected =
+      match live_status with
+      | Some json -> bool_member json "connected" && not stale
+      | None -> false
+    in
+    let error = if available then "" else "connector status file not found" in
+    let status_field key f default =
+      match live_status with
+      | Some json -> f json key
+      | None -> default
+    in
+    `Assoc
+      [
+        ("channel", `String channel);
+        ("available", `Bool available);
+        ("connected", `Bool connected);
+        ("stale", `Bool stale);
+        ("stale_after_sec", `Int (stale_after_sec ()));
+        ("status", `String (connector_state_label ~available ~connected ~stale));
+        ("error", `String error);
+        ("status_path", `String status_path);
+        ("binding_store_path", `String binding_store_path);
+        ("audit_path", `String audit_path);
+        ("updated_at", `String updated_at);
+        ("last_message_at", `String (status_field "last_message_at" string_member ""));
+        ( "messages_processed",
+          `Int (status_field "messages_processed" int_member 0) );
+        ("messages_failed", `Int (status_field "messages_failed" int_member 0));
+        ( "poll_interval_sec",
+          `Float (status_field "poll_interval_sec" float_member 0.0) );
+        ("gate_base_url", `String (status_field "gate_base_url" string_member ""));
+        ( "gate_healthy",
+          Option.value ~default:`Null
+            (Option.map (fun value -> `Bool value)
+               (match live_status with
+                | Some json -> bool_option_member json "gate_healthy"
+                | None -> None)) );
+        ( "gate_health_checked_at",
+          `String (status_field "gate_health_checked_at" string_member "") );
+        ("pid", `Int (status_field "pid" int_member 0));
+        ( "binding_source",
+          `String (status_field "binding_source" string_member "persisted") );
+        ( "runtime_bindings_count",
+          `Int
+            (status_field "runtime_bindings_count" int_member
+               (List.length configured_bindings)) );
+        ("configured_bindings", `List (List.map binding_json configured_bindings));
+        ("recent_audit", `List recent_audit);
+      ]
+
+  let list_assoc_field key = function
+    | `Assoc fields -> List.assoc_opt key fields
+    | _ -> None
+
+  let find_assoc_by_string_field ~field ~value = function
+    | `List rows ->
+        List.find_map
+          (function
+            | (`Assoc _ as row) -> (
+                match list_assoc_field field row with
+                | Some (`String candidate) when String.equal candidate value -> Some row
+                | _ -> None)
+            | _ -> None)
+          rows
+    | _ -> None
+
+  let connector_json ?gate_status_json ?(audit_limit = 10) () =
+    let status = status_json ~audit_limit () in
+    let observed_channel =
+      match gate_status_json with
+      | None -> `Null
+      | Some json -> (
+          match list_assoc_field "channels" json with
+          | Some channels -> (
+              match find_assoc_by_string_field ~field:"channel" ~value:channel channels with
+              | Some row -> row
+              | None -> `Null)
+          | None -> `Null)
+    in
+    let storage_paths =
+      `Assoc
+        [
+          ("status_path", `String (string_member status "status_path"));
+          ( "binding_store_path",
+            `String (string_member status "binding_store_path") );
+          ("audit_path", `String (string_member status "audit_path"));
+          ("names_path", `String "");
+        ]
+    in
+    let runtime_summary =
+      `Assoc
+        [
+          ("available", `Bool (bool_member status "available"));
+          ("connected", `Bool (bool_member status "connected"));
+          ("stale", `Bool (bool_member status "stale"));
+          ("stale_after_sec", `Int (int_member status "stale_after_sec"));
+          ("status", `String (string_member status "status"));
+          ("error", `String (string_member status "error"));
+          ("updated_at", `String (string_member status "updated_at"));
+          ("last_message_at", `String (string_member status "last_message_at"));
+          ("gate_base_url", `String (string_member status "gate_base_url"));
+          ( "gate_healthy",
+            Option.value ~default:`Null
+              (Option.map (fun value -> `Bool value)
+                 (bool_option_member status "gate_healthy")) );
+          ( "gate_health_checked_at",
+            `String (string_member status "gate_health_checked_at") );
+          ("pid", `Int (int_member status "pid"));
+        ]
+    in
+    let configured_bindings =
+      match status |> U.member "configured_bindings" with
+      | `List rows -> rows
+      | _ -> []
+    in
+    let binding_summary =
+      `Assoc
+        [
+          ("binding_source", `String (string_member status "binding_source"));
+          ( "runtime_bindings_count",
+            `Int (int_member status "runtime_bindings_count") );
+          ("configured_bindings_count", `Int (List.length configured_bindings));
+        ]
+    in
+    `Assoc
+      [
+        ("connector_id", `String connector_id);
+        ("display_name", `String display_name);
+        ("channel", `String channel);
+        ( "capabilities",
+          `List [ `String "runtime_status"; `String "bindings"; `String "audit" ]
+        );
+        ("status", `String (string_member status "status"));
+        ("available", `Bool (bool_member status "available"));
+        ("connected", `Bool (bool_member status "connected"));
+        ("stale", `Bool (bool_member status "stale"));
+        ("stale_after_sec", `Int (int_member status "stale_after_sec"));
+        ("error", `String (string_member status "error"));
+        ("status_path", `String (string_member status "status_path"));
+        ("binding_store_path", `String (string_member status "binding_store_path"));
+        ("audit_path", `String (string_member status "audit_path"));
+        ("updated_at", `String (string_member status "updated_at"));
+        ("last_message_at", `String (string_member status "last_message_at"));
+        ("messages_processed", `Int (int_member status "messages_processed"));
+        ("messages_failed", `Int (int_member status "messages_failed"));
+        ("poll_interval_sec", status |> U.member "poll_interval_sec");
+        ("gate_base_url", `String (string_member status "gate_base_url"));
+        ( "gate_healthy",
+          Option.value ~default:`Null
+            (Option.map (fun value -> `Bool value)
+               (bool_option_member status "gate_healthy")) );
+        ( "gate_health_checked_at",
+          `String (string_member status "gate_health_checked_at") );
+        ("binding_source", `String (string_member status "binding_source"));
+        ("runtime_bindings_count", `Int (int_member status "runtime_bindings_count"));
+        ("pid", `Int (int_member status "pid"));
+        ("configured_bindings", status |> U.member "configured_bindings");
+        ("recent_audit", status |> U.member "recent_audit");
+        ("storage_paths", storage_paths);
+        ("runtime_summary", runtime_summary);
+        ("binding_summary", binding_summary);
+        ("observed_channel", observed_channel);
+        ( "names",
+          `Assoc
+            [
+              ("guild_names", `Assoc []);
+              ("channel_names", `Assoc []);
+              ("channel_to_guild", `Assoc []);
+              ("updated_at", `String "");
+            ] );
+      ]
+
+  let rollback_bindings original_bindings =
+    try save_bindings original_bindings with
+    | Sys_error _ -> ()
+
+  let bind ~channel_id ~keeper_name ~actor_name =
+    let channel_id = String.trim channel_id in
+    let keeper_name = String.trim keeper_name in
+    if channel_id = "" then Error "channel_id is required"
+    else if keeper_name = "" then Error "keeper_name is required"
+    else
+      let original_bindings = read_bindings () in
+      let previous_keeper =
+        original_bindings
+        |> List.find_map (fun (binding : binding) ->
+               if String.equal binding.channel_id channel_id then
+                 Some binding.keeper_name
+               else None)
+        |> Option.value ~default:""
+      in
+      let updated_bindings =
+        ({ channel_id; keeper_name } : binding)
+        :: List.filter
+             (fun (binding : binding) ->
+               not (String.equal binding.channel_id channel_id))
+             original_bindings
+        |> List.sort (fun (a : binding) (b : binding) ->
+               String.compare a.channel_id b.channel_id)
+      in
+      try
+        save_bindings updated_bindings;
+        append_audit_event
+          {
+            timestamp = Gate_time_util.iso8601_of_unix (Unix.gettimeofday ());
+            action = "bind";
+            channel_id;
+            keeper_name;
+            actor_id = actor_name;
+            actor_name;
+            previous_keeper;
+          };
+        Ok (status_json ())
+      with
+      | Sys_error msg ->
+          rollback_bindings original_bindings;
+          Error msg
+
+  let unbind ~channel_id ~actor_name =
+    let channel_id = String.trim channel_id in
+    if channel_id = "" then Error "channel_id is required"
+    else
+      let original_bindings = read_bindings () in
+      match
+        List.find_opt
+          (fun (binding : binding) -> String.equal binding.channel_id channel_id)
+          original_bindings
+      with
+      | None -> Error "binding not found"
+      | Some previous ->
+          let updated_bindings =
+            List.filter
+              (fun (binding : binding) ->
+                not (String.equal binding.channel_id channel_id))
+              original_bindings
+          in
+          try
+            save_bindings updated_bindings;
+            append_audit_event
+              {
+                timestamp = Gate_time_util.iso8601_of_unix (Unix.gettimeofday ());
+                action = "unbind";
+                channel_id;
+                keeper_name = previous.keeper_name;
+                actor_id = actor_name;
+                actor_name;
+                previous_keeper = previous.keeper_name;
+              };
+            Ok (status_json ())
+          with
+          | Sys_error msg ->
+              rollback_bindings original_bindings;
+              Error msg
+end

--- a/lib/gate/channel_gate_sidecar_state.mli
+++ b/lib/gate/channel_gate_sidecar_state.mli
@@ -1,0 +1,20 @@
+(** Generic file-backed Channel Gate connector state for Python sidecars.
+
+    Slack and Telegram sidecars already read [bindings.json] from
+    [.gate/runtime/<connector>/]. This functor wires those sidecars into the
+    same dashboard bind/unbind and connector status API as Discord/iMessage. *)
+
+module type Config = sig
+  val connector_id : string
+  val display_name : string
+  val channel : string
+  val default_status_path : string
+  val default_binding_store_path : string
+  val default_binding_audit_path : string
+  val status_path_env_names : string list
+  val binding_store_path_env_names : string list
+  val binding_audit_path_env_names : string list
+  val stale_after_env_name : string
+end
+
+module Make (_ : Config) : Channel_gate_connector.S

--- a/lib/gate/channel_gate_slack_state.ml
+++ b/lib/gate/channel_gate_slack_state.ml
@@ -1,0 +1,17 @@
+include
+  Channel_gate_sidecar_state.Make
+    (struct
+      let connector_id = "slack"
+      let display_name = "Slack"
+      let channel = "slack"
+      let default_status_path = ".gate/runtime/slack/status.json"
+      let default_binding_store_path = ".gate/runtime/slack/bindings.json"
+      let default_binding_audit_path = ".gate/runtime/slack/binding_audit.jsonl"
+      let status_path_env_names =
+        [ "SLACK_STATUS_PATH"; "MASC_SLACK_STATUS_PATH" ]
+      let binding_store_path_env_names =
+        [ "SLACK_BINDING_STORE_PATH"; "MASC_SLACK_BINDING_STORE_PATH" ]
+      let binding_audit_path_env_names =
+        [ "SLACK_BINDING_AUDIT_PATH"; "MASC_SLACK_BINDING_AUDIT_PATH" ]
+      let stale_after_env_name = "MASC_SLACK_STATUS_STALE_SEC"
+    end)

--- a/lib/gate/channel_gate_telegram_state.ml
+++ b/lib/gate/channel_gate_telegram_state.ml
@@ -1,0 +1,17 @@
+include
+  Channel_gate_sidecar_state.Make
+    (struct
+      let connector_id = "telegram"
+      let display_name = "Telegram"
+      let channel = "telegram"
+      let default_status_path = ".gate/runtime/telegram/status.json"
+      let default_binding_store_path = ".gate/runtime/telegram/bindings.json"
+      let default_binding_audit_path = ".gate/runtime/telegram/binding_audit.jsonl"
+      let status_path_env_names =
+        [ "TELEGRAM_STATUS_PATH"; "MASC_TELEGRAM_STATUS_PATH" ]
+      let binding_store_path_env_names =
+        [ "TELEGRAM_BINDING_STORE_PATH"; "MASC_TELEGRAM_BINDING_STORE_PATH" ]
+      let binding_audit_path_env_names =
+        [ "TELEGRAM_BINDING_AUDIT_PATH"; "MASC_TELEGRAM_BINDING_AUDIT_PATH" ]
+      let stale_after_env_name = "MASC_TELEGRAM_STATUS_STALE_SEC"
+    end)

--- a/lib/gate/dune
+++ b/lib/gate/dune
@@ -10,6 +10,9 @@
   channel_gate_discord_names
   channel_gate_discord_state
   channel_gate_imessage_state
+  channel_gate_sidecar_state
+  channel_gate_slack_state
+  channel_gate_telegram_state
   channel_gate_metrics
   discord_gateway_client
   discord_gateway_state

--- a/lib/gate/gate_time_util.ml
+++ b/lib/gate/gate_time_util.ml
@@ -13,10 +13,46 @@ let iso8601_of_unix ts =
     (tm.tm_year + 1900) (tm.tm_mon + 1) tm.tm_mday
     tm.tm_hour tm.tm_min tm.tm_sec
 
-(** Parse ISO8601 "YYYY-MM-DDTHH:MM:SSZ" to Unix float (UTC). Duplicated
-    locally from [Masc_domain.parse_iso8601_opt] to sever the dependency on
-    [masc_types]. Behavior byte-identical to the original. *)
+(** Parse UTC ISO8601 timestamps to Unix float. Accepts the compact [Z] form
+    emitted by OCaml code and Python's [datetime.isoformat] UTC form with
+    fractional seconds and [+00:00]. *)
+let has_suffix s suffix =
+  let s_len = String.length s in
+  let suffix_len = String.length suffix in
+  s_len >= suffix_len
+  && String.equal
+       (String.sub s (s_len - suffix_len) suffix_len)
+       suffix
+
+let drop_suffix s suffix =
+  String.sub s 0 (String.length s - String.length suffix)
+
+let strip_fractional_seconds s =
+  match String.index_opt s '.' with
+  | None -> s
+  | Some dot ->
+      let len = String.length s in
+      let rec find_suffix i =
+        if i >= len then len
+        else
+          match s.[i] with
+          | 'Z' | '+' | '-' -> i
+          | _ -> find_suffix (i + 1)
+      in
+      let suffix_start = find_suffix (dot + 1) in
+      String.sub s 0 dot ^ String.sub s suffix_start (len - suffix_start)
+
+let normalize_utc_iso8601 s =
+  let s = s |> String.trim |> strip_fractional_seconds in
+  if has_suffix s "Z" then Some s
+  else if has_suffix s "+00:00" then Some (drop_suffix s "+00:00" ^ "Z")
+  else if has_suffix s "-00:00" then Some (drop_suffix s "-00:00" ^ "Z")
+  else None
+
 let parse_iso8601_opt s =
+  match normalize_utc_iso8601 s with
+  | None -> None
+  | Some s -> (
   try
     Scanf.sscanf s "%04d-%02d-%02dT%02d:%02d:%02dZ"
       (fun year mon day hour min sec ->
@@ -30,4 +66,4 @@ let parse_iso8601_opt s =
         let utc_as_local, _ = Unix.mktime utc_of_local in
         let tz_offset = local_epoch -. utc_as_local in
         Some (local_epoch +. tz_offset))
-  with Scanf.Scan_failure _ | Failure _ | End_of_file -> None
+  with Scanf.Scan_failure _ | Failure _ | End_of_file -> None)

--- a/lib/server/server_routes_http.ml
+++ b/lib/server/server_routes_http.ml
@@ -10,6 +10,8 @@ let make_routes ~port ~host ~sw ~clock =
   (* Register connectors before routes are wired up *)
   Channel_gate_connector.register (module Channel_gate_discord_state);
   Channel_gate_connector.register (module Channel_gate_imessage_state);
+  Channel_gate_connector.register (module Channel_gate_slack_state);
+  Channel_gate_connector.register (module Channel_gate_telegram_state);
   (* Tier K1: bind the multimodal workspace getter so the dashboard
      reads the live keeper-side workspace instead of [Workspace.empty].
      Idempotent — calling [bind_workspace_getter] twice just replaces

--- a/sidecars/shared/gate_shared/bindings_store.py
+++ b/sidecars/shared/gate_shared/bindings_store.py
@@ -13,6 +13,16 @@ import os
 from pathlib import Path
 
 
+def resolve_runtime_path(path: str | Path) -> Path:
+    target = Path(path).expanduser()
+    if target.is_absolute():
+        return target
+    raw_base = os.getenv("MASC_BASE_PATH", "").strip()
+    if raw_base:
+        return Path(raw_base).expanduser() / target
+    return target
+
+
 def load_bindings(
     default_path: str | Path,
     *,
@@ -25,7 +35,7 @@ def load_bindings(
     preserve the `str -> str` contract.
     """
     log = logger or logging.getLogger(__name__)
-    path = Path(default_path)
+    path = resolve_runtime_path(default_path)
     if not path.exists():
         return {}
     try:
@@ -35,9 +45,7 @@ def load_bindings(
         return {}
     if not isinstance(data, dict):
         return {}
-    bindings = {
-        str(k): str(v) for k, v in data.items() if isinstance(v, str)
-    }
+    bindings = {str(k): str(v) for k, v in data.items() if isinstance(v, str)}
     log.info("Loaded %d binding(s)", len(bindings))
     return bindings
 
@@ -50,7 +58,7 @@ def save_bindings(
 ) -> None:
     """Persist bindings atomically via a hidden tempfile + os.replace."""
     log = logger or logging.getLogger(__name__)
-    target = Path(path)
+    target = resolve_runtime_path(path)
     target.parent.mkdir(parents=True, exist_ok=True)
     tmp = target.with_name(f".{target.name}.tmp")
     try:

--- a/sidecars/shared/gate_shared/status_store.py
+++ b/sidecars/shared/gate_shared/status_store.py
@@ -1,0 +1,58 @@
+"""Shared runtime status writer for Channel Gate sidecars."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True, slots=True)
+class ConnectorRuntimeStatus:
+    """One connector runtime snapshot for dashboard consumption."""
+
+    updated_at: str
+    connected: bool
+    gate_base_url: str
+    gate_healthy: bool | None
+    gate_health_checked_at: str
+    last_message_at: str
+    messages_processed: int
+    messages_failed: int
+    pid: int
+    binding_source: str = "persisted"
+    runtime_bindings_count: int = 0
+    poll_interval_sec: float = 10.0
+    default_keeper: str = ""
+
+
+def resolve_runtime_path(path: str | Path) -> Path:
+    target = Path(path).expanduser()
+    if target.is_absolute():
+        return target
+    raw_base = os.getenv("MASC_BASE_PATH", "").strip()
+    if raw_base:
+        return Path(raw_base).expanduser() / target
+    return target
+
+
+class StatusStore:
+    """Persist connector runtime snapshots atomically."""
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = resolve_runtime_path(path)
+
+    def write(self, status: ConnectorRuntimeStatus) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = self.path.with_name(f".{self.path.name}.tmp")
+        payload = json.dumps(asdict(status), indent=2, sort_keys=True)
+        try:
+            tmp_path.write_text(f"{payload}\n", encoding="utf-8")
+            os.replace(tmp_path, self.path)
+        except OSError:
+            try:
+                tmp_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+            raise

--- a/sidecars/shared/tests/test_status_store.py
+++ b/sidecars/shared/tests/test_status_store.py
@@ -1,0 +1,76 @@
+"""Tests for shared connector runtime status persistence."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from gate_shared.bindings_store import load_bindings, save_bindings
+from gate_shared.status_store import ConnectorRuntimeStatus, StatusStore
+
+
+def test_status_store_writes_runtime_snapshot(tmp_path: Path) -> None:
+    path = tmp_path / "status.json"
+    store = StatusStore(path)
+
+    store.write(
+        ConnectorRuntimeStatus(
+            updated_at="2026-06-06T00:00:00Z",
+            connected=True,
+            gate_base_url="http://127.0.0.1:8935",
+            gate_healthy=True,
+            gate_health_checked_at="2026-06-06T00:00:01Z",
+            last_message_at="2026-06-06T00:00:02Z",
+            messages_processed=3,
+            messages_failed=1,
+            pid=4242,
+            runtime_bindings_count=2,
+            default_keeper="sangsu",
+        )
+    )
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["connected"] is True
+    assert payload["gate_healthy"] is True
+    assert payload["messages_processed"] == 3
+    assert payload["messages_failed"] == 1
+    assert payload["runtime_bindings_count"] == 2
+    assert payload["binding_source"] == "persisted"
+    assert payload["default_keeper"] == "sangsu"
+
+
+def test_status_store_resolves_relative_path_against_base_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("MASC_BASE_PATH", str(tmp_path))
+    store = StatusStore(".gate/runtime/slack/status.json")
+
+    store.write(
+        ConnectorRuntimeStatus(
+            updated_at="2026-06-06T00:00:00Z",
+            connected=True,
+            gate_base_url="http://127.0.0.1:8935",
+            gate_healthy=None,
+            gate_health_checked_at="",
+            last_message_at="",
+            messages_processed=0,
+            messages_failed=0,
+            pid=4242,
+        )
+    )
+
+    assert (tmp_path / ".gate/runtime/slack/status.json").exists()
+
+
+def test_bindings_store_resolves_relative_path_against_base_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("MASC_BASE_PATH", str(tmp_path))
+    path = ".gate/runtime/slack/bindings.json"
+
+    save_bindings(path, {"C123": "luna"})
+
+    assert (tmp_path / ".gate/runtime/slack/bindings.json").exists()
+    assert load_bindings(path) == {"C123": "luna"}

--- a/sidecars/slack-bot/src/bot.py
+++ b/sidecars/slack-bot/src/bot.py
@@ -14,16 +14,20 @@ Supports:
 from __future__ import annotations
 
 import logging
+import os
+import threading
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 
 from gate_shared.bindings_store import load_bindings, save_bindings
+from gate_shared.status_store import ConnectorRuntimeStatus, StatusStore
 
 from slack_bolt import App
 from slack_bolt.adapter.socket_mode import SocketModeHandler
 
 from .config import get_config
-from .formatters import chunk_text, response_blocks, strip_state_blocks
+from .formatters import response_blocks, strip_state_blocks
 from .gate_client import GateClient, GateResponse
 
 logging.basicConfig(
@@ -42,6 +46,10 @@ class SlackGateBot:
         self._bindings: dict[str, str] = {}  # channel_id -> keeper_name
         self._messages_processed = 0
         self._messages_failed = 0
+        self._last_message_at = ""
+        self.status_store = StatusStore(Path(self.cfg.status_path))
+        self._status_stop = threading.Event()
+        self._status_thread: threading.Thread | None = None
 
     def _load_bindings(self) -> None:
         self._bindings = load_bindings(
@@ -54,6 +62,51 @@ class SlackGateBot:
 
     def _resolve_keeper(self, channel_id: str) -> str:
         return self._bindings.get(channel_id, self.cfg.default_keeper)
+
+    def _write_status(self) -> None:
+        self.status_store.write(
+            ConnectorRuntimeStatus(
+                updated_at=datetime.now(tz=timezone.utc).isoformat(),
+                connected=True,
+                gate_base_url=self.cfg.gate_base_url,
+                gate_healthy=None,
+                gate_health_checked_at="",
+                last_message_at=self._last_message_at,
+                messages_processed=self._messages_processed,
+                messages_failed=self._messages_failed,
+                pid=os.getpid(),
+                runtime_bindings_count=len(self._bindings),
+                default_keeper=self.cfg.default_keeper,
+            )
+        )
+
+    def _status_loop(self) -> None:
+        while not self._status_stop.is_set():
+            try:
+                self._write_status()
+            except Exception as exc:
+                logger.warning("Status write error: %s", exc)
+            self._status_stop.wait(10.0)
+
+    def start_status_heartbeat(self) -> None:
+        if self._status_thread is not None and self._status_thread.is_alive():
+            return
+        self._status_stop.clear()
+        self._status_thread = threading.Thread(
+            target=self._status_loop,
+            name="slack-status-heartbeat",
+            daemon=True,
+        )
+        self._status_thread.start()
+
+    def stop_status_heartbeat(self) -> None:
+        self._status_stop.set()
+        if self._status_thread is not None:
+            self._status_thread.join(timeout=2.0)
+        try:
+            self._write_status()
+        except Exception as exc:
+            logger.warning("Final status write error: %s", exc)
 
     def register_handlers(self, app: App) -> None:
         """Register all Slack event and command handlers."""
@@ -193,10 +246,7 @@ class SlackGateBot:
             model = status.get("last_model_used", "?")
             turns = status.get("total_turns", 0)
             mark = ":white_check_mark:" if alive else ":x:"
-            respond(
-                f"{mark} *{keeper}*: {state}\n"
-                f"Model: `{model}` | Turns: {turns}"
-            )
+            respond(f"{mark} *{keeper}*: {state}\nModel: `{model}` | Turns: {turns}")
 
     def _handle_response(
         self,
@@ -229,6 +279,7 @@ class SlackGateBot:
             else:
                 say(text=reply, blocks=blocks)
             self._messages_processed += 1
+            self._last_message_at = datetime.now(tz=timezone.utc).isoformat()
         elif response.error:
             error_text = f":warning: {response.error}"
             if thinking_ts:
@@ -243,6 +294,7 @@ class SlackGateBot:
             else:
                 say(error_text)
             self._messages_failed += 1
+            self._last_message_at = datetime.now(tz=timezone.utc).isoformat()
         else:
             if thinking_ts:
                 try:
@@ -253,6 +305,8 @@ class SlackGateBot:
                     )
                 except Exception:
                     pass
+            self._messages_processed += 1
+            self._last_message_at = datetime.now(tz=timezone.utc).isoformat()
 
 
 def main() -> None:
@@ -260,15 +314,19 @@ def main() -> None:
     cfg = get_config()
     bot = SlackGateBot()
     bot._load_bindings()
+    bot.start_status_heartbeat()
 
-    app = App(token=cfg.slack_bot_token)
-    bot.register_handlers(app)
+    try:
+        app = App(token=cfg.slack_bot_token)
+        bot.register_handlers(app)
 
-    logger.info(
-        "Slack bot starting (gate=%s, default_keeper=%s, socket_mode=true)",
-        cfg.gate_base_url,
-        cfg.default_keeper,
-    )
+        logger.info(
+            "Slack bot starting (gate=%s, default_keeper=%s, socket_mode=true)",
+            cfg.gate_base_url,
+            cfg.default_keeper,
+        )
 
-    handler = SocketModeHandler(app, cfg.slack_app_token)
-    handler.start()
+        handler = SocketModeHandler(app, cfg.slack_app_token)
+        handler.start()
+    finally:
+        bot.stop_status_heartbeat()

--- a/sidecars/telegram-bot/src/bot.py
+++ b/sidecars/telegram-bot/src/bot.py
@@ -12,11 +12,15 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import signal
 import time
+from contextlib import suppress
 from datetime import datetime, timezone
+from pathlib import Path
 
 from gate_shared.bindings_store import load_bindings, save_bindings
+from gate_shared.status_store import ConnectorRuntimeStatus, StatusStore
 
 from telegram import Message, Update
 from telegram.ext import (
@@ -29,7 +33,7 @@ from telegram.ext import (
 
 from .config import get_config
 from .formatters import chunk_text, format_footer, strip_state_blocks
-from .gate_client import GateClient, GateResponse
+from .gate_client import GateClient
 
 logging.basicConfig(
     level=logging.INFO,
@@ -49,6 +53,8 @@ class TelegramGateBot:
         self._messages_processed = 0
         self._messages_failed = 0
         self._last_message_at = ""
+        self._running = False
+        self.status_store = StatusStore(Path(self.cfg.status_path))
 
     def _load_bindings(self) -> None:
         self._bindings = load_bindings(
@@ -69,9 +75,45 @@ class TelegramGateBot:
             return True  # no admin restriction configured
         return user_id is not None and user_id in self._admin_ids
 
+    async def _write_status(self) -> None:
+        """Persist current status for dashboard consumption."""
+        gate_healthy: bool | None = None
+        gate_health_checked_at = ""
+        try:
+            gate_healthy = await self.gate.health_check()
+            gate_health_checked_at = datetime.now(tz=timezone.utc).isoformat()
+        except Exception:
+            gate_healthy = False
+
+        self.status_store.write(
+            ConnectorRuntimeStatus(
+                updated_at=datetime.now(tz=timezone.utc).isoformat(),
+                connected=True,
+                gate_base_url=self.cfg.gate_base_url,
+                gate_healthy=gate_healthy,
+                gate_health_checked_at=gate_health_checked_at,
+                last_message_at=self._last_message_at,
+                messages_processed=self._messages_processed,
+                messages_failed=self._messages_failed,
+                pid=os.getpid(),
+                runtime_bindings_count=len(self._bindings),
+                default_keeper=self.cfg.default_keeper,
+            )
+        )
+
+    async def status_loop(self) -> None:
+        while self._running:
+            try:
+                await self._write_status()
+            except Exception as exc:
+                logger.warning("Status write error: %s", exc)
+            await asyncio.sleep(10.0)
+
     # ── Command Handlers ───────────────────────────────────
 
-    async def cmd_start(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    async def cmd_start(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ) -> None:
         """Handle /start command."""
         if update.effective_chat is None:
             return
@@ -88,13 +130,17 @@ class TelegramGateBot:
             parse_mode="Markdown",
         )
 
-    async def cmd_keepers(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    async def cmd_keepers(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ) -> None:
         """Handle /keepers command -- list available keepers."""
         if update.effective_chat is None:
             return
         names = await self.gate.list_keepers()
         if not names:
-            await update.effective_chat.send_message("No keepers available or gate unreachable.")
+            await update.effective_chat.send_message(
+                "No keepers available or gate unreachable."
+            )
             return
         lines = [f"- `{name}`" for name in sorted(names)]
         await update.effective_chat.send_message(
@@ -102,7 +148,9 @@ class TelegramGateBot:
             parse_mode="Markdown",
         )
 
-    async def cmd_bind(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    async def cmd_bind(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ) -> None:
         """Handle /bind <keeper> -- bind this chat to a keeper."""
         if update.effective_chat is None or update.effective_user is None:
             return
@@ -136,7 +184,9 @@ class TelegramGateBot:
             update.effective_user.id,
         )
 
-    async def cmd_unbind(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    async def cmd_unbind(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ) -> None:
         """Handle /unbind -- unbind this chat from a keeper."""
         if update.effective_chat is None or update.effective_user is None:
             return
@@ -158,7 +208,9 @@ class TelegramGateBot:
                 parse_mode="Markdown",
             )
 
-    async def cmd_status(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    async def cmd_status(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ) -> None:
         """Handle /status -- show keeper status."""
         if update.effective_chat is None:
             return
@@ -226,7 +278,10 @@ class TelegramGateBot:
                 streamed_any = True
                 now = time.monotonic()
                 new_chars = len(accumulated) - last_edit_len
-                if now - last_edit_time >= edit_interval and new_chars >= char_threshold:
+                if (
+                    now - last_edit_time >= edit_interval
+                    and new_chars >= char_threshold
+                ):
                     display = strip_state_blocks(accumulated)
                     if display:
                         try:
@@ -259,7 +314,9 @@ class TelegramGateBot:
 
         return True
 
-    async def handle_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    async def handle_message(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ) -> None:
         """Handle incoming text messages -- route to keeper.
 
         Tries SSE streaming first for real-time response display.
@@ -369,22 +426,35 @@ async def main() -> None:
     else:
         logger.warning("Gate health check failed at %s", cfg.gate_base_url)
 
+    bot._running = True
+    status_task = asyncio.create_task(bot.status_loop())
+
     # Run with polling (simpler than webhooks for local dev)
-    async with app:
-        await app.start()
-        await app.updater.start_polling(drop_pending_updates=True)  # type: ignore[union-attr]
-        logger.info("Telegram bot running. Press Ctrl+C to stop.")
+    try:
+        async with app:
+            await app.start()
+            await app.updater.start_polling(drop_pending_updates=True)  # type: ignore[union-attr]
+            logger.info("Telegram bot running. Press Ctrl+C to stop.")
 
-        # Block until stopped
-        stop_event = asyncio.Event()
-        loop = asyncio.get_event_loop()
-        for sig in (signal.SIGINT, signal.SIGTERM):
-            loop.add_signal_handler(sig, stop_event.set)
+            # Block until stopped
+            stop_event = asyncio.Event()
+            loop = asyncio.get_event_loop()
+            for sig in (signal.SIGINT, signal.SIGTERM):
+                loop.add_signal_handler(sig, stop_event.set)
 
-        await stop_event.wait()
+            await stop_event.wait()
 
-        await app.updater.stop()  # type: ignore[union-attr]
-        await app.stop()
+            await app.updater.stop()  # type: ignore[union-attr]
+            await app.stop()
+    finally:
+        bot._running = False
+        status_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await status_task
+        try:
+            await bot._write_status()
+        except Exception as exc:
+            logger.warning("Final status write error: %s", exc)
 
     await bot.gate.aclose()
     logger.info(

--- a/test/test_channel_gate_connector_routes.ml
+++ b/test/test_channel_gate_connector_routes.ml
@@ -1,6 +1,54 @@
 open Alcotest
 
 module Routes = Server_routes_http_routes_channel_gate
+module U = Yojson.Safe.Util
+
+let with_env name value f =
+  let previous = Sys.getenv_opt name in
+  (match value with
+   | Some v -> Unix.putenv name v
+   | None -> Unix.putenv name "");
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some v -> Unix.putenv name v
+      | None -> Unix.putenv name "")
+    f
+
+let temp_dir_counter = ref 0
+
+let with_temp_dir f =
+  incr temp_dir_counter;
+  let base =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "sidecar-state-%d-%06d" (Unix.getpid ()) !temp_dir_counter)
+  in
+  Unix.mkdir base 0o755;
+  Fun.protect
+    ~finally:(fun () ->
+      let rec rm_rf path =
+        if Sys.file_exists path then
+          if Sys.is_directory path then (
+            Sys.readdir path
+            |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+            Unix.rmdir path
+          ) else Sys.remove path
+      in
+      rm_rf base)
+    (fun () -> f base)
+
+let with_sidecar_paths prefix dir f =
+  let status_path = Filename.concat dir (prefix ^ "-status.json") in
+  let binding_path = Filename.concat dir (prefix ^ "-bindings.json") in
+  let audit_path = Filename.concat dir (prefix ^ "-audit.jsonl") in
+  with_env (String.uppercase_ascii prefix ^ "_STATUS_PATH") (Some status_path)
+    (fun () ->
+      with_env
+        (String.uppercase_ascii prefix ^ "_BINDING_STORE_PATH")
+        (Some binding_path) (fun () ->
+          with_env
+            (String.uppercase_ascii prefix ^ "_BINDING_AUDIT_PATH")
+            (Some audit_path) f))
 
 let test_resolve_connector_status_name_prefers_explicit_name () =
   check (option string) "name wins and normalizes" (Some "discord")
@@ -15,6 +63,68 @@ let test_resolve_connector_status_name_ignores_blank_inputs () =
   check (option string) "blank query params ignored" None
     (Routes.resolve_connector_status_name ~name:"   " ~channel:"   " ())
 
+let python_utc_iso_now () =
+  let z = Gate_time_util.iso8601_of_unix (Unix.gettimeofday ()) in
+  String.sub z 0 (String.length z - 1) ^ ".123456+00:00"
+
+let test_gate_time_parser_accepts_python_utc_isoformat () =
+  check bool "python UTC isoformat parsed" true
+    (Option.is_some (Gate_time_util.parse_iso8601_opt (python_utc_iso_now ())));
+  check bool "non-UTC offset remains rejected" true
+    (Option.is_none
+       (Gate_time_util.parse_iso8601_opt "2026-06-06T00:00:00+09:00"))
+
+let test_slack_bind_persists_binding_and_audit () =
+  with_temp_dir @@ fun dir ->
+  with_sidecar_paths "slack" dir (fun () ->
+    match
+      Channel_gate_slack_state.bind ~channel_id:"C123" ~keeper_name:"luna"
+        ~actor_name:"dashboard"
+    with
+    | Error err -> fail err
+    | Ok json ->
+        check string "channel" "slack" (json |> U.member "channel" |> U.to_string);
+        let bindings = json |> U.member "configured_bindings" |> U.to_list in
+        check int "one configured binding" 1 (List.length bindings);
+        check string "keeper persisted" "luna"
+          (List.hd bindings |> U.member "keeper_name" |> U.to_string);
+        let audit = json |> U.member "recent_audit" |> U.to_list in
+        check int "one audit event" 1 (List.length audit);
+        check string "audit actor" "dashboard"
+          (List.hd audit |> U.member "actor_name" |> U.to_string))
+
+let test_telegram_connector_json_reads_runtime_status () =
+  with_temp_dir @@ fun dir ->
+  with_sidecar_paths "telegram" dir (fun () ->
+    ignore
+      (Channel_gate_telegram_state.bind ~channel_id:"12345" ~keeper_name:"luna"
+         ~actor_name:"dashboard");
+    let status_path = Filename.concat dir "telegram-status.json" in
+    Yojson.Safe.to_file status_path
+      (`Assoc
+        [
+          ("updated_at", `String (python_utc_iso_now ()));
+          ("connected", `Bool true);
+          ("gate_base_url", `String "http://127.0.0.1:8935");
+          ("gate_healthy", `Bool true);
+          ("gate_health_checked_at", `String (python_utc_iso_now ()));
+          ("last_message_at", `String "2026-06-06T00:00:00Z");
+          ("messages_processed", `Int 7);
+          ("messages_failed", `Int 1);
+          ("binding_source", `String "persisted");
+          ("runtime_bindings_count", `Int 1);
+          ("pid", `Int 4242);
+        ]);
+    let json = Channel_gate_telegram_state.connector_json () in
+    check string "connector id" "telegram"
+      (json |> U.member "connector_id" |> U.to_string);
+    check bool "available" true (json |> U.member "available" |> U.to_bool);
+    check bool "connected" true (json |> U.member "connected" |> U.to_bool);
+    check int "messages processed" 7
+      (json |> U.member "messages_processed" |> U.to_int);
+    check int "configured bindings count" 1
+      (json |> U.member "configured_bindings" |> U.to_list |> List.length))
+
 let () =
   run "channel_gate_connector_routes"
     [
@@ -26,5 +136,14 @@ let () =
             test_resolve_connector_status_name_normalizes_legacy_channel;
           test_case "ignores blank inputs" `Quick
             test_resolve_connector_status_name_ignores_blank_inputs;
+        ] );
+      ( "sidecar_connector_state",
+        [
+          test_case "gate time parses python UTC isoformat" `Quick
+            test_gate_time_parser_accepts_python_utc_isoformat;
+          test_case "slack bind persists binding and audit" `Quick
+            test_slack_bind_persists_binding_and_audit;
+          test_case "telegram connector json reads runtime status" `Quick
+            test_telegram_connector_json_reads_runtime_status;
         ] );
     ]


### PR DESCRIPTION
## What changed

- Registered Slack and Telegram as Channel Gate connectors so dashboard bind/status calls no longer hit `unknown connector`.
- Added a reusable file-backed sidecar connector state module for sidecars that share `bindings.json`, `status.json`, and audit files.
- Added Slack and Telegram runtime status heartbeat writes for dashboard connector cards.
- Made shared sidecar status/bindings stores resolve relative runtime paths under `MASC_BASE_PATH`.
- Extended Gate UTC timestamp parsing to accept Python `datetime.isoformat()` output with fractional seconds and `+00:00`.

## Root cause

Dashboard and sidecar lifecycle code already knew about Slack and Telegram, and the sidecars already sent messages through Gate, but the server connector registry only registered Discord and iMessage. Slack/Telegram also did not write `status.json`, so the dashboard had no live runtime status file to read.

## Validation

- `env MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_channel_gate_connector_routes.exe bin/main_eio.exe`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh exec ./test/test_channel_gate_connector_routes.exe`
- `PYTHONPATH=sidecars/shared python3 -m pytest sidecars/shared/tests`
- `ruff check sidecars/shared/gate_shared/status_store.py sidecars/shared/gate_shared/bindings_store.py sidecars/slack-bot/src/bot.py sidecars/telegram-bot/src/bot.py sidecars/shared/tests/test_status_store.py`
- `ruff format --check sidecars/shared/gate_shared/status_store.py sidecars/shared/gate_shared/bindings_store.py sidecars/slack-bot/src/bot.py sidecars/telegram-bot/src/bot.py sidecars/shared/tests/test_status_store.py`
- `git diff --check`