### PR TITLE
refactor(exec): remove allowlist gate from Execute pipeline (RFC-0219)

### DIFF
--- a/lib/exec/command_gate/shell_command_gate.ml
+++ b/lib/exec/command_gate/shell_command_gate.ml
@@ -46,9 +46,7 @@ type verdict =
 
 type allowlist_policy = {
   redirect_allowed : bool;
-  allowed_commands : string list;
   allow_pipes : bool;
-  
 }
 
 type path_policy = {
@@ -376,7 +374,7 @@ type stage_block =
   | Stage_not_allowed of { stage : int; bin : string }
   | Stage_unreducible of { stage : int; wrapper : string; detail : string }
 
-let first_blocked_stage ~allowed_commands (stages : SI.simple list)
+let first_blocked_stage (stages : SI.simple list)
   : stage_block option
   =
   (* RFC-0219: allowlist check removed. Safety is provided by Shell IR
@@ -468,35 +466,7 @@ let apply_policy ~(allowlist : allowlist_policy) ~(path_policy : path_policy)
         ; diagnostic
         }
     else
-      (match
-         first_blocked_stage ~allowed_commands:allowlist.allowed_commands stages
-       with
-       | Some (Stage_not_allowed { stage = stage_idx; bin }) ->
-         let reason, diagnostic =
-           if stage_n = 1 then
-             ( Command_not_in_allowlist { bin }
-             , Printf.sprintf "%s not in shell command allowlist" bin )
-           else
-             ( Pipeline_segment_disallowed { stage = stage_idx; bin }
-             , Printf.sprintf
-                 "pipeline stage %d command %s not in shell command allowlist"
-                 stage_idx
-                 bin )
-         in
-         Reject { context; reason; diagnostic }
-       | Some (Stage_unreducible { stage = stage_idx; wrapper; detail }) ->
-         Reject
-           { context
-           ; reason = Wrapper_unreducible { stage = stage_idx; wrapper; detail }
-           ; diagnostic =
-               Printf.sprintf
-                 "stage %d: %s wrapper cannot be statically authorized (%s)"
-                 stage_idx
-                 wrapper
-                 detail
-           }
-       | None ->
-         (match first_path_failure ~path_policy stages with
+    match first_path_failure ~path_policy stages with
           | Some (stage_idx, raw_path, diagnostic) ->
             Reject
               { context
@@ -514,7 +484,7 @@ let apply_policy ~(allowlist : allowlist_policy) ~(path_policy : path_policy)
                      Printf.sprintf "pipeline stage %d carries a redirect" stage
                  }
              | None -> Allow context
-             | Some _ -> Allow context)))
+             | Some _ -> Allow context)
 ;;
 
 let parse_only_to_stages (parsed : SI.t PD.t) :

--- a/lib/exec/command_gate/shell_command_gate.ml
+++ b/lib/exec/command_gate/shell_command_gate.ml
@@ -379,20 +379,10 @@ type stage_block =
 let first_blocked_stage ~allowed_commands (stages : SI.simple list)
   : stage_block option
   =
-  let rec scan idx = function
-    | [] -> None
-    | s :: rest ->
-      (match effective_bin_of_stage s with
-       | Unreducible detail ->
-         Some
-           (Stage_unreducible
-              { stage = idx; wrapper = BIN.to_string s.SI.bin; detail })
-       | Bin bin ->
-         if bin_allowed ~allowed_commands bin
-         then scan (idx + 1) rest
-         else Some (Stage_not_allowed { stage = idx; bin }))
-  in
-  scan 1 stages
+  (* RFC-0219: allowlist check removed. Safety is provided by Shell IR
+     risk classification (destructive/R0/R1/R2) and the destructive +
+     write operation gates in keeper_tool_execute_runtime.ml. *)
+  None
 ;;
 
 let stage_has_redirect (simple : SI.simple) : bool =

--- a/lib/exec/command_gate/shell_command_gate.mli
+++ b/lib/exec/command_gate/shell_command_gate.mli
@@ -106,9 +106,7 @@ type verdict =
     syntax, including fd-to-fd redirects such as [2>&1]. *)
 type allowlist_policy = {
   redirect_allowed : bool;
-  allowed_commands : string list;
   allow_pipes : bool;
-  
 }
 
 (** Path policy applied to literal path arguments and file redirect

--- a/lib/exec/test/test_exec_gate_env_wrapper.ml
+++ b/lib/exec/test/test_exec_gate_env_wrapper.ml
@@ -17,7 +17,7 @@ let dev = [ "env"; "cat"; "ls"; "npm" ]
 let readonly = [ "env"; "cat"; "ls" ]
 
 let policy allowed =
-  { Gate.redirect_allowed = true; allowed_commands = allowed; allow_pipes = true }
+  { Gate.redirect_allowed = true;  allow_pipes = true }
 ;;
 
 let sandbox = { Gate.target = Sandbox_target.host () }

--- a/lib/exec_policy/exec_policy.ml
+++ b/lib/exec_policy/exec_policy.ml
@@ -232,13 +232,13 @@ let validate_command_name_with_allowlist ~allowed_commands = function
   | Some name -> Error (Command_not_allowed name)
 ;;
 
-let strict_allowlist_policy ~allowed_commands : Exec_shell_gate.allowlist_policy =
-  { allowed_commands; allow_pipes = false; redirect_allowed = false }
+let strict_allowlist_policy : Exec_shell_gate.allowlist_policy =
+  { allow_pipes = false; redirect_allowed = false }
 ;;
 
-let tool_execute_allowlist_policy ?(allow_pipes = true) ~allowed_commands ()
+let tool_execute_allowlist_policy ?(allow_pipes = true) ()
   : Exec_shell_gate.allowlist_policy =
-  { allowed_commands; allow_pipes; redirect_allowed = false }
+  { allow_pipes; redirect_allowed = false }
 ;;
 
 let rec shell_ir_literal_text = function
@@ -404,7 +404,7 @@ let command_context_with_allowlist ~allowed_commands ir =
   let verdict =
     Exec_shell_gate.gate_typed
       ~ir
-      ~allowlist:(strict_allowlist_policy ~allowed_commands)
+      ~allowlist:strict_allowlist_policy
       ~path_policy:Exec_shell_gate.allow_all_paths
       ~sandbox:Exec_shell_gate.host_sandbox
       ()
@@ -446,7 +446,7 @@ let command_context_tool_execute_with_allowlist
   let verdict =
     Exec_shell_gate.gate_typed
       ~ir
-      ~allowlist:(tool_execute_allowlist_policy ~allow_pipes ~allowed_commands ())
+      ~allowlist:(tool_execute_allowlist_policy ~allow_pipes ())
       ~path_policy:Exec_shell_gate.allow_all_paths
       ~sandbox:Exec_shell_gate.host_sandbox
       ()

--- a/lib/keeper_tooling/keeper_tool_execute_shell_ir.ml
+++ b/lib/keeper_tooling/keeper_tool_execute_shell_ir.ml
@@ -115,7 +115,7 @@ let dispatch_classified
   let gate_verdict =
     Shell_gate.gate_typed
       ~ir
-      ~allowlist:{ allowed_commands; allow_pipes; redirect_allowed }
+      ~allowlist:{ allow_pipes; redirect_allowed }
       ~path_policy:Shell_gate.forbid_masc_internal_state_paths
       ~sandbox:{ target = sandbox }
       ()

--- a/test/test_exec_shell_command_gate.ml
+++ b/test/test_exec_shell_command_gate.ml
@@ -25,7 +25,7 @@ let allowed = [ "rg"; "sort"; "head"; "wc"; "cat"; "git"; "ls" ]
 let gate_from_raw ~raw ~allowlist ~path_policy ~sandbox () =
   Gate.gate_raw ~text:raw ~allowlist ~path_policy ~sandbox ()
 let allowlist : Gate.allowlist_policy =
-  { redirect_allowed = false; allowed_commands = allowed; allow_pipes = true }
+  { redirect_allowed = false; allow_pipes = true }
 ;;
 
 (* {1 Baseline corpus} *)
@@ -282,7 +282,7 @@ let test_pipeline_segment_rejection_carries_stage_index () =
 
 let test_pipes_disabled () =
   let policy : Gate.allowlist_policy =
-    { redirect_allowed = false; allowed_commands = allowed; allow_pipes = false }
+    { redirect_allowed = false; allow_pipes = false }
   in
   match
     gate_from_raw


### PR DESCRIPTION
## Summary

Removes the `allowed_commands` field from `allowlist_policy` type and all call sites across 6 files. (-45 lines)

`first_blocked_stage` now always returns `None` — all commands pass through. Safety is provided by Shell IR risk classification (destructive/R0/R1/R2) and the destructive + write operation gates.

## Files

- `shell_command_gate.ml` — removed allowlist check block
- `shell_command_gate.mli` — removed `allowed_commands` from type
- `exec_policy.ml` — removed from policy constructors
- `keeper_tool_execute_shell_ir.ml` — removed from record literal
- 2 test files — removed from test fixtures

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
