### PR TITLE
fix(keeper): stop wall-clock killing progressing turns

### DIFF
--- a/docs/TIMEOUT-MATRIX.md
+++ b/docs/TIMEOUT-MATRIX.md
@@ -4,16 +4,18 @@ Status: Phase 1 — observability + module stub. Migration of call sites is trac
 
 ## Layer model
 
-MASC timeouts nest innermost-first. Every inner layer's wall cap MUST be
-`<=` its enclosing layer's cap. An inner "hard cap" that exceeds the outer cap
-is effectively advisory.
+MASC timeout policy is progress-first. Tool calls and streaming gaps have
+bounded idle or invocation timeouts, but a keeper turn that is still producing
+stream or tool progress must not be killed only because cumulative wall-clock
+elapsed. `MASC_KEEPER_TURN_TIMEOUT_SEC` is now a retry/admission budget between
+provider attempts, not the hard execution deadline for an active turn.
 
 | Layer | Role | Typical cap | Source of truth |
 |-------|------|-------------|-----------------|
 | `Tool` | per-tool HTTP / shell invocation | 10–60 s | `Env_config_runtime.*`, `lib/tool_local_runtime_http.ml` |
 | `MCP tools/call` | outer per-tool dispatcher cap | 60 s default; board writes 90 s default | `MASC_TOOL_TIMEOUT_DEFAULT_SEC`, `MASC_TOOL_TIMEOUT_BOARD_SEC`, `Mcp_server_eio_call_tool.tool_timeout_sec_opt` |
-| `Oas_bridge` | single OAS `Agent.run` / `Model.call` | 300 s default; provider attempt caps may be lower | `Env_config_keeper.oas_timeout_sec*`, `Keeper_turn_driver.effective_provider_attempt_timeout_s` |
-| `Keeper_turn` | one keeper turn (may issue many OAS calls) | 600 s default/hard ceiling | `MASC_KEEPER_TURN_TIMEOUT_SEC` |
+| `Oas_bridge` | single OAS `Agent.run` / `Model.call` | no cumulative cap on the keeper `run_named` path; stream idle / liveness caps apply | `Env_config_keeper.stream_idle_timeout_sec`, `Keeper_attempt_liveness` |
+| `Keeper_turn` | one keeper turn (may issue many OAS calls) | 600 s default retry/admission budget; not a hard execution kill | `MASC_KEEPER_TURN_TIMEOUT_SEC`, `Keeper_turn_runtime_budget*` |
 | `Keeper_cycle` | full keeper lifecycle | N×turn | cycle supervisor |
 | `Shutdown` | graceful shutdown board flush | 2 s | `bin/main_eio.ml` |
 
@@ -42,14 +44,14 @@ warning preserves the same fields (`layer`, `origin`, `budget`, `actual`,
 ## Operator outcome
 
 Provider timeout failures are not global shutdown signals. A single
-`provider_timeout` is scoped to the provider attempt or keeper turn whose
-provider wait exceeded the active budget. The turn ledger and runtime-trust
+`provider_timeout` is scoped to the provider attempt whose stream idle or
+attempt-liveness budget was exceeded. The turn ledger and runtime-trust
 snapshot must surface provider-owned timeout evidence as provider timeout
-detail, while turn-owned wall-clock exhaustion surfaces as
-`terminal_reason.code = "turn_wall_clock_timeout"` with
-`terminal_reason.next_action = "inspect_turn_timeout"`. The runtime-trust
-snapshot mirrors that as `latest_next_action`, and the runtime surface marks
-the keeper as needing attention with
+detail. Turn-owned retry/admission budget exhaustion may still surface as
+`turn_timeout`, but active stream/tool progress must not become
+`terminal_reason.code = "turn_wall_clock_timeout"` merely because cumulative
+wall time crossed 600 s. The runtime-trust snapshot mirrors the latest
+action, and the runtime surface marks the keeper as needing attention with
 `next_human_action = "inspect_runtime_blocker"` when the keeper is not paused.
 Paused provider-timeout cases keep the paused workflow
 (`attention_reason = "paused"`,
@@ -105,8 +107,9 @@ logs. Candidates:
 ## Non-goals
 
 - This policy module does NOT reimplement OAS retry/budget semantics — OAS
-  owns its own `max_turns` and `max_duration` (see `feedback_no-lifecycle-
-  invasion-from-masc.md`). The MASC-side deadline is the outer hard cap;
-  OAS-side budgets are clamped within it by the caller, not mutated here.
+  owns its own `max_turns` and progress/idle liveness (see `feedback_no-lifecycle-
+  invasion-from-masc.md`). MASC-side retry/admission budgets decide whether a
+  new provider attempt may start; they are not a cumulative hard cap on an
+  active stream.
 - This module does NOT perform forced cancellation. It only makes cooperative
   overshoot observable.

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -332,23 +332,21 @@ module KeeperKeepalive = struct
       ≥600 s can now opt in via env or the upcoming runtime.toml
       override; remote runtimes stay at the global default 600.
 
-      Promotion to 1 800 s requires a follow-up RFC plus one week of
-      [masc_keeper_turns_total{terminated_by="turn_timeout"}] and p95
-      duration data — see RFC-0012 §Out of scope. *)
+      Promotion above 900 s requires a follow-up RFC plus one week of
+      retry-admission and p95 duration data — see RFC-0012 §Out of scope. *)
   let timeout_hard_ceiling_sec = 900.0
 
-  (** Wall-clock timeout in seconds for a single unified turn (including all
-      retries and runtime fallbacks). Prevents indefinite blocking when an
-      upstream LLM hangs at the TCP level.
+  (** Retry/admission budget in seconds for a single unified turn (including all
+      retries and runtime fallbacks). This value no longer kills an active turn
+      solely because cumulative wall-clock elapsed.
       Env: [MASC_KEEPER_TURN_TIMEOUT_SEC]. Default: 600. Range: [60, 900].
 
       The default stays at 600 (the prior hard ceiling) so existing
       remote runtimes keep their budget unchanged; the lifted ceiling
       only fires when an operator opts in via env or runtime override.
-      RFC-0156: post-removal there is no per-provider OAS cap layered
-      below this — [oas_call_timeout_sec] reuses [turn_timeout_sec]
-      directly; runtime rotation is driven by [stream_idle_timeout_sec]
-      + HTTP error + completion contract. *)
+      Active-runaway detection is driven by [stream_idle_timeout_sec],
+      provider-attempt liveness, tool timeouts, OAS max-turn limits, HTTP error,
+      and the optional supervisor stale-turn watchdog. *)
   let turn_timeout_sec =
     Float.max
       60.0
@@ -391,8 +389,7 @@ module KeeperKeepalive = struct
   (** Per-call OAS timeout override in seconds.
 
       Legacy/env override value is clamped to the active keepalive
-      wall-clock cap so this does not extend a single attempt beyond the
-      keeper turn budget. The override is still parsed for observability
+      retry/admission budget. The override is still parsed for observability
       and to preserve compatibility with existing profiles, but it is not
       guaranteed to represent a distinct timeout policy anymore.
 
@@ -447,10 +444,10 @@ module KeeperKeepalive = struct
             (get_int ~default "MASC_KEEPER_OAS_MAX_TURNS_PER_CALL_SCHEDULED_AUTONOMOUS")))
   ;;
 
-  (* RFC-0156: OAS total timeout removed. Resolved OAS-call timeout = override
-     when set, else turn_timeout_sec (wall-clock cap). stream_idle_timeout
-     handles per-stream cap; runtime rotation triggers on stream_idle + HTTP
-     error + completion contract. Historic names
+  (* RFC-0156/RFC-020x: OAS total timeout removed. Resolved OAS-call budget =
+     override when set, else turn_timeout_sec. stream_idle_timeout handles
+     per-stream idle; runtime rotation triggers on stream_idle + HTTP error +
+     completion contract. Historic names
      ([oas_timeout_for_estimated_input_tokens] /
      [oas_timeout_for_estimated_input_tokens_with_turn_budget]) ignored the
      [estimated_input_tokens] and [max_turns] args — function-name-lying. *)

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -466,14 +466,12 @@ let run_turn
                 keeper_oas_visibility_neutral_guardrails ?guardrails ()
               in
               let call_run_named ~initial_messages =
-                let bridge_timeout_s =
-                  Keeper_llm_bridge.with_hitl_approval_headroom timeout_s
-                in
-                Keeper_llm_bridge.run_with_timeout_and_fallback
-                  ~timeout_s:bridge_timeout_s
-                  (fun () ->
-                          Keeper_turn_driver.run_named
-                            ~runtime_id:runtime_id_string
+                (* This path must not impose a cumulative OAS bridge timeout.
+                   Progressing streams are bounded by stream idle and attempt
+                   liveness; completed attempts are bounded before retry by
+                   turn-budget admission. *)
+                Keeper_turn_driver.run_named
+                  ~runtime_id:runtime_id_string
                     ~base_path:config.base_path
                     ~keeper_name:meta.name
                     ?provider_filter
@@ -543,7 +541,7 @@ let run_turn
                     ?oas_checkpoint:resume_oas_checkpoint
                     ?event_bus
                     ?per_provider_timeout_s
-                    ())
+                    ()
               in
               (match call_run_named ~initial_messages:history_messages with
                | Error e -> Error e

--- a/lib/keeper/keeper_runtime_resolved.ml
+++ b/lib/keeper/keeper_runtime_resolved.ml
@@ -110,8 +110,9 @@ let cli_subprocess_idle_sec = cli_subprocess_idle_sec_live
 let oas_timeout_override_sec_live ~turn_timeout_sec =
   match Env_config_core.raw_value_opt "MASC_KEEPER_OAS_TIMEOUT_SEC" with
   | Some raw ->
-      (* DET-OK: env override is parsed at the keeper runtime boundary; malformed
-         values resolve to wall-clock cap for compatibility with previous behavior. *)
+      (* DET-OK: env override is parsed at the keeper runtime boundary;
+         malformed values resolve to the turn budget for compatibility with
+         previous behavior. *)
       (match Float.of_string_opt (String.trim raw) with
        | Some parsed -> Some (Float.max 30.0 (Float.min turn_timeout_sec parsed))
        | None -> Some turn_timeout_sec)
@@ -297,8 +298,9 @@ let stream_idle_timeout_for_total_timeout ~(total_timeout_s : float) =
 let body_timeout_override_sec () =
   (current ()).body_timeout_override_sec.value
 
-(* RFC-0156: OAS total timeout removed — turn_timeout_sec is the wall-clock
-   cap, stream_idle_timeout is the per-stream cap. Kept in lockstep with
+(* RFC-0156/RFC-020x: OAS total timeout removed — turn_timeout_sec is the
+   retry/admission budget, not a cumulative hard kill for active streams.
+   stream_idle_timeout is the per-stream idle cap. Kept in lockstep with
    [Env_config.KeeperKeepalive.oas_call_timeout_sec]. Historic names
    ([oas_timeout_for_estimated_input_tokens] /
    [oas_timeout_for_estimated_input_tokens_with_turn_budget]) ignored their

--- a/lib/keeper/keeper_turn_disposition.ml
+++ b/lib/keeper/keeper_turn_disposition.ml
@@ -40,7 +40,7 @@ let summary = function
   | Input_required -> "agent paused to request human input"
   | External_cancel -> "keeper turn was cancelled before completion"
   | Turn_wall_clock_timeout ->
-    "keeper turn hit the wall-clock timeout"
+    "keeper turn hit a stale/no-progress timeout"
   | Runtime_attempts_exhausted ->
     "runtime attempts exhausted; inspect per-attempt root causes"
   | Post_commit_ambiguous ->
@@ -78,8 +78,8 @@ let to_wire = function
    A runtime cause maps directly to a non-[Provider_error] arm only
    when the runtime classification fully determines the operator
    action. Stale_turn_timeout_* are operator-equivalent to the
-   "wall-clock timeout" disposition; the Ambiguous_partial_commit_* pair both
-   indicate post-commit ambiguity.
+   stale/no-progress timeout disposition; the Ambiguous_partial_commit_* pair
+   both indicate post-commit ambiguity.
    All other runtime causes are wrapped so the typed cause is
    preserved for diagnostics. *)
 let of_termination_code (c : Code.t) : t =

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -165,8 +165,8 @@ let max_execution_time_for_attempt ?per_provider_timeout_s () =
      run_stream call; it cancels healthy active streams even while chunks are
      arriving. Provider-attempt liveness is progress-based instead:
      [stream_idle_timeout_s] catches inter-line stalls, the liveness observer
-     catches no-first-token / inter-chunk gaps, and the keeper turn watchdog is
-     the outer runaway guard. *)
+     catches no-first-token / inter-chunk gaps, and tool/max-turn limits bound
+     finite work. *)
   (match per_provider_timeout_s with
    | Some (_ : float) -> ()
    | None -> ());
@@ -191,7 +191,8 @@ let body_timeout_for_attempt ?per_provider_timeout_s () =
 
     @param ctx Explicit closure context (captures from [run_named]).
     @param resume_checkpoint Checkpoint from a previous failed provider.
-    @param per_provider_timeout_s Per-provider wall-clock timeout.
+    @param per_provider_timeout_s Legacy per-provider budget; not forwarded as
+    a cumulative OAS execution timeout on the keeper path.
     @param candidate The opaque runtime candidate to attempt.
     @return [(result, checkpoint_after, liveness_success_sample)] tuple. The
     sample is not recorded here; the caller records it only after the runtime

--- a/lib/keeper/keeper_turn_runtime_budget.mli
+++ b/lib/keeper/keeper_turn_runtime_budget.mli
@@ -155,14 +155,12 @@ val attempt_watchdog_timeout_sec :
   remaining_turn_budget_s:float ->
   provider_timeout_budget ->
   float
-(** Wall-clock watchdog for a single runtime attempt.
+(** Legacy wall-clock watchdog budget for a single runtime attempt.
 
-    The watchdog fires after the OAS per-attempt budget plus the normal
-    finalization guard, while reserving a small outer-turn margin before the
-    enclosing keeper turn wall-clock timeout. This keeps a hung provider
-    attempt on the structured [provider_timeout] path, where degraded runtime
-    rotation can still run, instead of falling through to terminal
-    [turn_timeout]. *)
+    Off-mode uses this after the OAS per-attempt budget plus the normal
+    finalization guard. Progress-based liveness modes return [None] from
+    [attempt_watchdog_timeout_sec_opt] so healthy active streams are not killed
+    by cumulative wall-clock elapsed. *)
 
 val attempt_watchdog_timeout_sec_opt :
   liveness_mode:Keeper_attempt_liveness_config.mode ->

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -28,9 +28,9 @@ val resolve_bounded_provider_timeout_budget_with_turn_budget
 (** See [Keeper_turn_runtime_budget] for first-attempt retry reserve and
     retry-attempt budget semantics. *)
 
-(** Per-attempt watchdog used around the OAS call. It fires before the
-    enclosing keeper-turn wall-clock timeout so recoverable provider stalls can
-    still rotate through the degraded runtime path. *)
+(** Legacy per-attempt watchdog budget. Progress-based liveness modes return no
+    watchdog so healthy active streams are not killed by cumulative wall time;
+    the budget remains for retry/admission compatibility and off-mode tests. *)
 val attempt_watchdog_timeout_sec
   :  remaining_turn_budget_s:float
   -> provider_timeout_budget

--- a/lib/keeper/keeper_unified_turn_attempt_watchdog.ml
+++ b/lib/keeper/keeper_unified_turn_attempt_watchdog.ml
@@ -9,12 +9,13 @@ let dispatch
      Provider-attempt liveness is progress-based:
        - [stream_idle_timeout_s] catches inter-line stalls
        - [Keeper_attempt_liveness] catches no-first-token / inter-chunk gaps
-       - The keeper turn watchdog ([Eio.Time.with_timeout_exn] in
-         [Keeper_unified_turn_execution]) is the outer runaway guard
+       - tool-level timeouts and OAS max-turn limits bound tool work and
+         finite turn loops
      The former watchdog killed healthy active streams that were making
      progress but slowly, wasting ~570s of productive work per event
-     (~1077 events/24h, 100% at 540-600s latency).  The outer keeper
-     turn timeout still prevents runaway turns. *)
+     (~1077 events/24h, 100% at 540-600s latency). The optional supervisor
+     stale-turn watchdog remains the hard-stop path for real no-progress
+     runaways. *)
   try run () with
   | Eio.Cancel.Cancelled _ as e ->
     on_cancelled ();

--- a/lib/keeper/keeper_unified_turn_attempt_watchdog.mli
+++ b/lib/keeper/keeper_unified_turn_attempt_watchdog.mli
@@ -4,7 +4,8 @@
     Provider-attempt liveness is progress-based:
       - [stream_idle_timeout_s] catches inter-line stalls
       - [Keeper_attempt_liveness] catches no-first-token / inter-chunk gaps
-      - The keeper turn watchdog is the outer runaway guard
+      - tool-level timeouts and OAS max-turn limits bound tool work and
+        finite turn loops
 
     Two outcomes:
 

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -1,8 +1,8 @@
 (** Keeper_unified_turn_execution — Execution body for unified keeper cycles.
 
     Extracted from [Keeper_unified_turn.run_keeper_cycle]. Contains the
-    [do_run] closure, [retry_loop] recursive function, wall-clock timeout
-    wrapper, and cleanup/finalization logic.
+    [do_run] closure, [retry_loop] recursive function, retry/admission
+    budgeting, and cleanup/finalization logic.
 
     @since God file decomposition *)
 
@@ -786,116 +786,21 @@ let run (ctx : ctx)
           mark_terminal_error err;
           Error err)
   in
-  try
-    Eio.Time.with_timeout_exn clock timeout_sec (fun () ->
-      retry_loop
-        { run_meta = meta
-        ; execution = initial_execution
-        ; run_generation = generation
-        ; attempt = 1
-        ; is_retry = false
-        ; allow_degraded_wall_clock_retry_budget = false
-        ; attempted_runtimes =
-            [ initial_execution.runtime_id
-            ]
-        })
-  with
-  | Eio.Time.Timeout ->
-     let msg =
-       Printf.sprintf
-         "Turn wall-clock timeout after %.0fs \
-          (MASC_KEEPER_TURN_TIMEOUT_SEC)"
-         timeout_sec
-     in
-     Log.Keeper.error "%s: %s" meta.name msg;
-     Otel_metric_store.inc_counter
-       Keeper_metrics.(to_string TurnTimeoutCommitted)
-       ~labels:[ "keeper", meta.name ]
-       ();
-     let _ = drain_turn_event_bus ~site:"error_path_drain" () in
-     (match event_bus_integrity_error_snapshot () with
-      | Some integrity_err ->
-        Log.Keeper.error
-          "%s: event-bus order violation during timeout path; \
-           treating turn as failed before retry/reconcile decisions"
-          meta.name;
-        Keeper_registry.set_turn_phase
-          ~base_path:config.base_path
-          meta.name
-          Keeper_registry.(Packed Turn_finalizing);
-        Error integrity_err
-      | None ->
-        let committed_tools = committed_mutating_tools_snapshot () in
-        if
-          committed_tools <> []
-          && Keeper_tool_registry.all_tools_reconcile_safe
-               committed_tools
-        then (
-          Log.Keeper.warn
-            "%s: turn wall-clock timeout after committed \
-             reconcile-safe tool(s) [%s] — auto-recovering \
-             (timeout: %s)"
-            meta.name
-            (String.concat ", " committed_tools)
-            msg;
-          Otel_metric_store.inc_counter
-            Keeper_metrics.(to_string TurnTimeoutCommitted)
-            ~labels:[ "keeper", meta.name ]
-            ();
-          Keeper_registry.set_turn_phase
-            ~base_path:config.base_path
-            meta.name
-            Keeper_registry.(Packed Turn_finalizing);
-          Error (Agent_sdk.Error.Api (Timeout { message = msg })))
-        else if committed_tools <> []
-        then (
-          let timeout_err =
-            Agent_sdk.Error.Api (Timeout { message = msg })
-          in
-          let reclassified, failure_reason =
-            match
-              EC.classify_post_commit_failure
-                ~tool_names:committed_tools
-                ~kind:Keeper_registry.Post_commit_timeout
-                timeout_err
-            with
-            | Some classified -> classified
-            | None ->
-              ( EC.reclassify_error_after_side_effect
-                  ~tool_names:committed_tools
-                  timeout_err
-              , Keeper_registry.Ambiguous_partial_commit
-                  { kind = Keeper_registry.Post_commit_timeout
-                  ; detail =
-                      EC.summarize_post_commit_failure
-                        ~tool_names:committed_tools
-                        ~kind:Keeper_registry.Post_commit_timeout
-                        timeout_err
-                  } )
-          in
-          post_commit_failure_reason := Some failure_reason;
-          Log.Keeper.error
-            "%s: turn wall-clock timeout after committed mutating \
-             tool call(s) [%s] — treating as integrity failure; \
-             evidence recorded for next-turn observation"
-            meta.name
-            (String.concat ", " committed_tools);
-          Otel_metric_store.inc_counter
-            Keeper_metrics.(to_string TurnTimeoutCommitted)
-            ~labels:[ "keeper", meta.name ]
-            ();
-          Keeper_registry.set_turn_phase
-            ~base_path:config.base_path
-            meta.name
-            Keeper_registry.(Packed Turn_finalizing);
-          Error reclassified)
-        else (
-          Keeper_registry.set_turn_phase
-            ~base_path:config.base_path
-            meta.name
-            Keeper_registry.(Packed Turn_finalizing);
-          Error
-            (Keeper_turn_driver.sdk_error_of_masc_internal_error
-               (Keeper_turn_driver.Turn_timeout
-                  { elapsed_sec = timeout_sec }))))
+  (* Do not wrap the full keeper turn in a cumulative wall-clock timeout.
+     Long voice/OAS turns can keep making stream or tool progress beyond the
+     legacy 600s cap. Runaway detection is owned by stream idle, provider
+     attempt liveness, tool-level timeouts, max-turn limits, and the optional
+     supervisor stale-turn watchdog. Retry admission still consults the
+     remaining turn budget between provider attempts. *)
+  retry_loop
+    { run_meta = meta
+    ; execution = initial_execution
+    ; run_generation = generation
+    ; attempt = 1
+    ; is_retry = false
+    ; allow_degraded_wall_clock_retry_budget = false
+    ; attempted_runtimes =
+        [ initial_execution.runtime_id
+        ]
+    }
 )

--- a/lib/keeper_runtime/keeper_attempt_liveness.ml
+++ b/lib/keeper_runtime/keeper_attempt_liveness.ml
@@ -148,8 +148,7 @@ let step ?(recorder = null_recorder) (b : budget) (s : state) (e : event)
 
   (* Streaming × Tick: once the provider has emitted chunks, liveness is
      progress-based. A stream that keeps producing chunks must not be killed
-     only because cumulative wall-clock elapsed; the keeper turn watchdog is
-     the outer runaway guard. *)
+     only because cumulative wall-clock elapsed. *)
   | Streaming { started_at; last_chunk_at }, Tick now ->
       let gap = now -. last_chunk_at in
       if gap >= b.inter_chunk_max then begin

--- a/test/test_oas_timeout_budget_strike.ml
+++ b/test/test_oas_timeout_budget_strike.ml
@@ -89,7 +89,7 @@ let test_cycle_failed_log_level_is_policy_aware () =
     (EC.should_warn_keeper_cycle_failed
        (provider_timeout_error ~phase:"runtime_attempt_watchdog"));
   Alcotest.(check bool)
-    "turn wall-clock timeout remains error"
+    "turn timeout remains error"
     false
     (EC.should_warn_keeper_cycle_failed (turn_timeout_error ()))
 
@@ -260,6 +260,33 @@ let test_concurrent_bumps_do_not_lose_updates () =
       (workers * bumps_per_worker)
       (KK.peek_budget_exhaustion_for_test ~keeper_name:keeper))
 
+let read_file path = In_channel.with_open_text path In_channel.input_all
+
+let contains_substring haystack needle =
+  let haystack_len = String.length haystack in
+  let needle_len = String.length needle in
+  let rec loop index =
+    if needle_len = 0 then true
+    else if index + needle_len > haystack_len then false
+    else if String.sub haystack index needle_len = needle then true
+    else loop (index + 1)
+  in
+  loop 0
+
+let test_keeper_turn_has_no_total_wall_clock_kill () =
+  let source = read_file "lib/keeper/keeper_unified_turn_execution.ml" in
+  Alcotest.(check bool)
+    "no cumulative keeper turn with_timeout"
+    false
+    (contains_substring source "Eio.Time.with_timeout_exn clock timeout_sec")
+
+let test_keeper_oas_path_has_no_bridge_total_timeout () =
+  let source = read_file "lib/keeper/keeper_agent_run.ml" in
+  Alcotest.(check bool)
+    "keeper run_named path is not bridge-timeout wrapped"
+    false
+    (contains_substring source "Keeper_llm_bridge.run_with_timeout_and_fallback")
+
 let () =
   Alcotest.run "provider_timeout_strike"
   [
@@ -300,5 +327,9 @@ let () =
           test_capacity_phase_routes_to_provider_tuning;
         Alcotest.test_case "concurrent bumps do not lose updates" `Quick
           test_concurrent_bumps_do_not_lose_updates;
+        Alcotest.test_case "keeper turn has no total wall-clock kill" `Quick
+          test_keeper_turn_has_no_total_wall_clock_kill;
+        Alcotest.test_case "keeper OAS path has no bridge total timeout" `Quick
+          test_keeper_oas_path_has_no_bridge_total_timeout;
       ] );
   ]


### PR DESCRIPTION
## Summary
- remove the cumulative keeper turn wall-clock timeout wrapper that emitted turn_timeout at 600s even while OAS/voice work was progressing
- stop wrapping the keeper run_named path in the OAS bridge total timeout, leaving stream idle, attempt liveness, tool timeouts, max turns, and retry admission as the active guards
- update timeout SSOT comments/docs and add regression tests for both removed total-timeout wrappers

## Verification
- ocamlformat --check lib/keeper/keeper_unified_turn_execution.ml lib/keeper/keeper_agent_run.ml lib/keeper/keeper_unified_turn_attempt_watchdog.ml lib/keeper/keeper_unified_turn_attempt_watchdog.mli lib/keeper/keeper_turn_driver_try_provider.ml lib/keeper_runtime/keeper_attempt_liveness.ml lib/keeper/keeper_runtime_resolved.ml lib/config/env_config_keeper.ml lib/keeper/keeper_unified_turn.mli lib/keeper/keeper_turn_runtime_budget.mli lib/keeper/keeper_turn_disposition.ml test/test_oas_timeout_budget_strike.ml
- git diff --check
- scripts/dune-local.sh build test/test_oas_timeout_budget_strike.exe (blocked: live bare Dune process detected, exit 75)
- env DUNE_CACHE=disabled DUNE_BUILD_DIR=/private/tmp/masc-dune-keeper-turn-progress-timeout-20260606 dune build --root . test/test_oas_timeout_budget_strike.exe
- env DUNE_CACHE=disabled DUNE_BUILD_DIR=/private/tmp/masc-dune-keeper-turn-progress-timeout-20260606 dune exec --root . test/test_oas_timeout_budget_strike.exe