### PR TITLE
fix(otel): attach MCP request context to tool spans

### DIFF
--- a/docs/rfc/RFC-0214-otel-genai-dual-emission.md
+++ b/docs/rfc/RFC-0214-otel-genai-dual-emission.md
@@ -39,6 +39,10 @@ Implementation status as of 2026-06-06:
   and use OTel/MCP `error.type=tool_error` for `CallToolResult.isError=true`.
   The typed `Tool_result.tool_failure_class` string remains available under the
   MASC-owned `masc.mcp.tool.failure_class` attribute.
+  When a JSON-RPC `tools/call` request context is available, spans also carry
+  `jsonrpc.request.id`, `mcp.session.id`, `mcp.protocol.version`, and SERVER
+  kind. Internal dispatch spans without MCP request context keep CLIENT kind and
+  omit request/session attrs.
 
 ### 2.1 Legacy Metric Names
 
@@ -155,12 +159,12 @@ Why OTel-backed migration:
 | File | Change |
 |------|--------|
 | `lib/otel_genai/otel_genai.ml` | Centralized GenAI metric, event, and attribute names including usage detail attributes. |
-| `lib/otel_dispatch_hook/otel_dispatch_hook.ml` | Emits MCP tool-call spans with `tools/call <tool-name>` names, `mcp.method.name=tools/call`, `gen_ai.tool.name`, CLIENT span kind, OTel/MCP `error.type=tool_error`, MASC `masc.mcp.tool.failure_class`, and ERROR status for failed tool results. |
+| `lib/otel_dispatch_hook/otel_dispatch_hook.ml` | Emits MCP tool-call spans with `tools/call <tool-name>` names, `mcp.method.name=tools/call`, `gen_ai.tool.name`, context-aware CLIENT/SERVER span kind, request/session/protocol attrs when a JSON-RPC `tools/call` request context is present, OTel/MCP `error.type=tool_error`, MASC `masc.mcp.tool.failure_class`, and ERROR status for failed tool results. |
 | `lib/otel_spans/otel_spans.ml` | Added testable span attribute/status hooks and GenAI exception recording. |
 | `lib/llm_metric_bridge.ml` | Emits standard GenAI client metrics, operation-details events, usage attributes, streaming timings, and bounded error status. |
 | `lib/keeper/keeper_hooks_oas.ml` | Projects trusted cache/reasoning token details into GenAI usage attributes without inventing extra `gen_ai.token.type` values. |
 | `test/test_llm_metric_bridge.ml` | Covers standard metric names, event names, span attrs/status, and the cache/reasoning token-type guardrail. |
-| `test/test_otel_dispatch_hook.ml` | Covers MCP tool-call span name, `gen_ai.tool.name`, `mcp.method.name`, CLIENT kind, OTel/MCP `tool_error`, and MASC typed failure-class preservation. |
+| `test/test_otel_dispatch_hook.ml` | Covers MCP tool-call span name, `gen_ai.tool.name`, `mcp.method.name`, internal CLIENT kind, request-context SERVER kind, `jsonrpc.request.id`, `mcp.session.id`, `mcp.protocol.version`, OTel/MCP `tool_error`, and MASC typed failure-class preservation. |
 
 ## 5. Remaining Migration Work
 

--- a/lib/mcp_server_eio_protocol.ml
+++ b/lib/mcp_server_eio_protocol.ml
@@ -579,6 +579,36 @@ let jsonrpc_id_label = function
   | _ -> "?"
 ;;
 
+let jsonrpc_request_id_attr = function
+  | `String s ->
+    let s = String.trim s in
+    if s = "" then None else Some s
+  | `Int i -> Some (string_of_int i)
+  | `Intlit s ->
+    let s = String.trim s in
+    if s = "" then None else Some s
+  | `Float f -> Some (Printf.sprintf "%0.0f" f)
+  | `Null -> None
+  | _ -> None
+;;
+
+let nonempty_opt = function
+  | Some value ->
+    let trimmed = String.trim value in
+    if trimmed = "" then None else Some trimmed
+  | None -> None
+;;
+
+let otel_tool_request_context ~id ?mcp_session_id request_json =
+  let mcp_protocol_version =
+    Mcp_transport_protocol.protocol_version_from_request_meta_json request_json
+  in
+  { Otel_dispatch_hook.jsonrpc_request_id = jsonrpc_request_id_attr id
+  ; mcp_session_id = nonempty_opt mcp_session_id
+  ; mcp_protocol_version
+  }
+;;
+
 let tool_profile_label = function
   | Full -> "full"
   | Managed_agent -> "managed_agent"
@@ -752,16 +782,22 @@ let handle_request
                               | Some s -> s
                               | None -> "none"));
                         let result =
-                          handle_call_tool_eio
-                            ~sw
-                            ~clock
-                            ~profile
-                            ?mcp_session_id
-                            ?auth_token
-                            ~internal_keeper_runtime
-                            state
-                            id
-                            params
+                          let otel_context =
+                            otel_tool_request_context ~id ?mcp_session_id json
+                          in
+                          Otel_dispatch_hook.with_request_context
+                            otel_context
+                            (fun () ->
+                               handle_call_tool_eio
+                                 ~sw
+                                 ~clock
+                                 ~profile
+                                 ?mcp_session_id
+                                 ?auth_token
+                                 ~internal_keeper_runtime
+                                 state
+                                 id
+                                 params)
                         in
                         let outcome = tool_call_outcome result in
                         let outcome_s = Tool_result.string_of_tool_call_outcome outcome in

--- a/lib/otel_dispatch_hook/dune
+++ b/lib/otel_dispatch_hook/dune
@@ -6,6 +6,7 @@
  (wrapped false)
  (modules otel_dispatch_hook)
  (libraries
+  eio
   opentelemetry
   unix
   masc.masc_core

--- a/lib/otel_dispatch_hook/otel_dispatch_hook.ml
+++ b/lib/otel_dispatch_hook/otel_dispatch_hook.ml
@@ -14,6 +14,16 @@
 
 module OT = Opentelemetry
 
+type request_context =
+  { jsonrpc_request_id : string option
+  ; mcp_session_id : string option
+  ; mcp_protocol_version : string option
+  }
+
+let request_context_key : request_context Eio.Fiber.key =
+  Eio.Fiber.create_key ()
+;;
+
 let enabled_override : bool option ref = ref None
 
 let span_emitter_override
@@ -34,15 +44,41 @@ let enabled () =
   | None -> Otel_config.enabled
 ;;
 
-let tool_call_span_kind = OT.Span_kind.Span_kind_client
+let current_request_context () =
+  try Eio.Fiber.get request_context_key with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | _ -> None
+;;
+
+let in_eio_fiber_context () =
+  try
+    ignore (Eio.Fiber.get request_context_key);
+    true
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | _ -> false
+;;
+
+let with_request_context context f =
+  if in_eio_fiber_context ()
+  then Eio.Fiber.with_binding request_context_key context f
+  else f ()
+;;
+
+let tool_call_span_kind () =
+  match current_request_context () with
+  | Some _ -> OT.Span_kind.Span_kind_server
+  | None -> OT.Span_kind.Span_kind_client
+;;
 
 let emit_span ~name ~attrs ?status () =
+  let kind = tool_call_span_kind () in
   match !span_emitter_override with
-  | Some emit -> emit ~name ~attrs ~kind:tool_call_span_kind ~status
+  | Some emit -> emit ~name ~attrs ~kind ~status
   | None ->
     ignore
       (OT.Trace.with_
-         ~kind:tool_call_span_kind
+         ~kind
          name
          ~attrs
          (fun scope ->
@@ -88,6 +124,24 @@ let tool_failure_class_attrs (result : Tool_result.result) =
     ]
 ;;
 
+let string_attr key = function
+  | Some value when String.trim value <> "" -> [ key, `String value ]
+  | Some _ | None -> []
+;;
+
+let request_context_attrs () =
+  match current_request_context () with
+  | None -> []
+  | Some context ->
+    string_attr
+      Otel_genai.Mcp_attr_key.jsonrpc_request_id
+      context.jsonrpc_request_id
+    @ string_attr Otel_genai.Mcp_attr_key.mcp_session_id context.mcp_session_id
+    @ string_attr
+        Otel_genai.Mcp_attr_key.mcp_protocol_version
+        context.mcp_protocol_version
+;;
+
 let tool_span_attrs (result : Tool_result.result) =
   let status_attrs =
     if Tool_result.is_success result
@@ -108,7 +162,7 @@ let tool_span_attrs (result : Tool_result.result) =
     Otel_genai.tool_execution_attrs ~tool_name:(Tool_result.tool_name result)
     |> List.map (fun (key, value) -> key, (value :> OT.value))
   in
-  gen_ai_attrs @ status_attrs
+  gen_ai_attrs @ request_context_attrs () @ status_attrs
 ;;
 
 (** Record a tool call as an OTel span. *)

--- a/lib/otel_dispatch_hook/otel_dispatch_hook.mli
+++ b/lib/otel_dispatch_hook/otel_dispatch_hook.mli
@@ -15,6 +15,20 @@
 
     @since 2.103.0 *)
 
+type request_context =
+  { jsonrpc_request_id : string option
+  ; mcp_session_id : string option
+  ; mcp_protocol_version : string option
+  }
+(** Request-local MCP context available while handling a JSON-RPC
+    [tools/call] request. Fields are optional because internal dispatches and
+    notifications do not always have a request id/session/protocol version. *)
+
+val with_request_context : request_context -> (unit -> 'a) -> 'a
+(** Bind MCP request context for spans emitted by dispatch observers inside
+    [f]. Outside an Eio fiber this degrades to [f ()], so non-Eio unit tests
+    and pre-bootstrap callers do not crash. *)
+
 val with_test_span_emitter :
   enabled:bool ->
   emit_span:

--- a/lib/otel_genai/otel_genai.ml
+++ b/lib/otel_genai/otel_genai.ml
@@ -113,6 +113,9 @@ end
 
 module Mcp_attr_key = struct
   let mcp_method_name = "mcp.method.name"
+  let jsonrpc_request_id = "jsonrpc.request.id"
+  let mcp_protocol_version = "mcp.protocol.version"
+  let mcp_session_id = "mcp.session.id"
   let error_type = "error.type"
   let masc_mcp_tool_failure_class = "masc.mcp.tool.failure_class"
 end

--- a/lib/otel_genai/otel_genai.mli
+++ b/lib/otel_genai/otel_genai.mli
@@ -50,6 +50,9 @@ end
 
 module Mcp_attr_key : sig
   val mcp_method_name : string
+  val jsonrpc_request_id : string
+  val mcp_protocol_version : string
+  val mcp_session_id : string
   val error_type : string
   val masc_mcp_tool_failure_class : string
 end

--- a/test/test_otel_dispatch_hook.ml
+++ b/test/test_otel_dispatch_hook.ml
@@ -70,7 +70,48 @@ let test_success_span_uses_mcp_tool_call_semconv () =
     "mcp.method.name"
     "tools/call"
     (assoc_string Genai.Mcp_attr_key.mcp_method_name span.attrs);
+  check_no_attr Genai.Mcp_attr_key.jsonrpc_request_id span.attrs;
+  check_no_attr Genai.Mcp_attr_key.mcp_session_id span.attrs;
+  check_no_attr Genai.Mcp_attr_key.mcp_protocol_version span.attrs;
   check_no_attr "otel.status_code" span.attrs
+;;
+
+let test_request_context_span_records_mcp_server_attrs () =
+  let result =
+    Tool_result.make_ok
+      ~tool_name:"get-weather"
+      ~start_time:(Unix.gettimeofday ())
+      ~data:(`Assoc [ "ok", `Bool true ])
+      ()
+  in
+  let context : Hook.request_context =
+    { jsonrpc_request_id = Some "42"
+    ; mcp_session_id = Some "session-otel"
+    ; mcp_protocol_version = Some "2026-07-28"
+    }
+  in
+  let span =
+    Eio_main.run (fun _env ->
+      capture (fun () ->
+        Hook.with_request_context context (fun () ->
+          Tool_dispatch.run_dispatch_observers Dispatch_outcome.Handled (Some result))))
+  in
+  Alcotest.(check bool)
+    "MCP request tool call span kind SERVER"
+    true
+    (span.kind = OT.Span_kind.Span_kind_server);
+  Alcotest.(check string)
+    "jsonrpc.request.id"
+    "42"
+    (assoc_string Genai.Mcp_attr_key.jsonrpc_request_id span.attrs);
+  Alcotest.(check string)
+    "mcp.session.id"
+    "session-otel"
+    (assoc_string Genai.Mcp_attr_key.mcp_session_id span.attrs);
+  Alcotest.(check string)
+    "mcp.protocol.version"
+    "2026-07-28"
+    (assoc_string Genai.Mcp_attr_key.mcp_protocol_version span.attrs)
 ;;
 
 let test_failure_span_records_typed_error_status () =
@@ -117,6 +158,10 @@ let () =
             "success span uses MCP tool-call semantic convention"
             `Quick
             test_success_span_uses_mcp_tool_call_semconv
+        ; Alcotest.test_case
+            "request context records MCP server attributes"
+            `Quick
+            test_request_context_span_records_mcp_server_attrs
         ; Alcotest.test_case
             "failure span records typed error status"
             `Quick


### PR DESCRIPTION
## Summary
- bind request-local MCP context around JSON-RPC `tools/call` dispatch
- add `jsonrpc.request.id`, `mcp.session.id`, and `mcp.protocol.version` attrs when that context is present
- use SERVER span kind for MCP request-context tool spans while preserving CLIENT kind for internal dispatch spans
- update RFC-0214 and dispatch-hook coverage

## Evidence
- OTel MCP semantic conventions define MCP server spans with `mcp.method.name`, optional `mcp.protocol.version`, `mcp.session.id`, and `jsonrpc.request.id` when the request id is not null/omitted. Checked 2026-06-06.

## Verification
- `ocamlformat --check lib/otel_genai/otel_genai.ml lib/otel_genai/otel_genai.mli lib/otel_dispatch_hook/otel_dispatch_hook.ml lib/otel_dispatch_hook/otel_dispatch_hook.mli lib/mcp_server_eio_protocol.ml test/test_otel_dispatch_hook.ml`
- `git diff --check`
- `env MASC_DUNE_THROTTLE=0 MASC_OPAM_LOCK=0 MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_BUILD_DIR=/private/tmp/masc-mcp-otel-mcp-request-context-20260606-r2 scripts/dune-local.sh build test/test_otel_dispatch_hook.exe --display=quiet`
- `/private/tmp/masc-mcp-otel-mcp-request-context-20260606-r2/default/test/test_otel_dispatch_hook.exe`
