### PR TITLE
Revert status bridge narrative blocker inference removal

### DIFF
--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -156,17 +156,148 @@ let runtime_keepalive_started_at (config : Workspace_utils.config) (meta : keepe
 include Keeper_status_bridge_blocker
 
 
-let runtime_blocker_surface_opt (config : Workspace_utils.config) (meta : keeper_meta) =
-  match meta.runtime.last_blocker with
-  | Some info ->
-    Some (runtime_blocker_surface_of_typed_class ~summary:info.detail info.klass)
-  | None ->
-    (match runtime_registry_entry config meta.name with
-     | Some entry ->
-       (match entry.last_failure_reason with
-        | Some reason -> runtime_blocker_surface_of_failure_reason reason
-        | None -> None)
+let has_any_ci text needles = List.exists (String_util.contains_substring_ci text) needles
+
+let first_nonempty_line label values =
+  values
+  |> List.map String.trim
+  |> List.find_map (fun value ->
+    if String.equal value "" then None else Some (Printf.sprintf "%s: %s" label value))
+;;
+
+let progress_snapshot_narrative_lines
+      (snapshot : Keeper_memory_policy.keeper_state_snapshot)
+  =
+  [ (match snapshot.progress with
+     | Some progress -> Some ("Progress: " ^ String.trim progress)
      | None -> None)
+  ; (match snapshot.done_summary with
+     | Some done_summary -> Some ("Done: " ^ String.trim done_summary)
+     | None -> None)
+  ; (match snapshot.next_summary with
+     | Some next_summary -> Some ("Next plan: " ^ String.trim next_summary)
+     | None -> None)
+  ; first_nonempty_line "Next" snapshot.next_items
+  ; first_nonempty_line "Decisions" snapshot.decisions
+  ; first_nonempty_line "OpenQuestions" snapshot.open_questions
+  ; first_nonempty_line "Constraints" snapshot.constraints
+  ]
+  |> List.filter_map (function
+    | Some line when not (String.equal (String.trim line) "") -> Some line
+    | _ -> None)
+;;
+
+let narrative_summary line =
+  String_util.utf8_safe ~max_bytes:220 ~suffix:"..." line |> String_util.to_string
+;;
+
+let runtime_blocker_surface_of_progress_snapshot
+      (snapshot : Keeper_memory_policy.keeper_state_snapshot)
+  =
+  let lines = progress_snapshot_narrative_lines snapshot in
+  let line_with needles = List.find_opt (fun line -> has_any_ci line needles) lines in
+  let surface blocker_class line =
+    Some { blocker_class; summary = narrative_summary line; continue_gate = false }
+  in
+  if lines = []
+  then None
+  else (
+    match
+      line_with
+        [ "sandbox egress"
+        ; "push egress"
+        ; "github.com push"
+        ; "github push"
+        ; "network egress"
+        ; "sandbox"
+        ]
+    with
+    | Some line when has_any_ci line [ "egress"; "push"; "github.com"; "network" ] ->
+      surface "awaiting_sandbox_egress" line
+    | _ ->
+      (match line_with [ "supervisor"; "supervisor가" ] with
+       | Some line when has_any_ci line [ "pause"; "paused"; "unpause"; "의도" ] ->
+         surface "supervisor_paused" line
+       | _ ->
+         (match
+            line_with
+              [ "push gate"
+              ; "operator"
+              ; "human"
+              ; "approval"
+              ; "approve"
+              ; "decision tree"
+              ; "4-gate"
+              ; "4 gate"
+              ; "unblock"
+              ; "manual"
+              ]
+          with
+          | Some line
+            when has_any_ci
+                   line
+                   [ "waiting"
+                   ; "await"
+                   ; "blocked"
+                   ; "respond"
+                   ; "resolved"
+                   ; "gate"
+                   ; "decision"
+                   ; "approval"
+                   ; "approve"
+                   ; "unblock"
+                   ; "manual"
+                   ] -> surface "awaiting_operator" line
+          | _ ->
+            (match
+               line_with
+                 [ "watching"
+                 ; "monitor"
+                 ; "no action"
+                 ; "no next action"
+                 ; "자체 action 부재"
+                 ; "감시"
+                 ]
+             with
+             | Some line -> surface "self_imposed_idle" line
+             | None -> None))))
+;;
+
+let runtime_blocker_surface_of_progress_narrative config (meta : keeper_meta) =
+  let from_continuity_summary =
+    match
+      Keeper_memory_policy.progress_snapshot_cache_of_text meta.continuity_summary
+    with
+    | Some cache -> runtime_blocker_surface_of_progress_snapshot cache.snapshot
+    | None -> None
+  in
+  match from_continuity_summary with
+  | Some _ as blocker -> blocker
+  | None ->
+    (match Keeper_memory_policy.read_progress_snapshot ~config ~name:meta.name with
+     | Some snapshot -> runtime_blocker_surface_of_progress_snapshot snapshot
+     | None -> None)
+;;
+
+let runtime_blocker_surface_opt (config : Workspace_utils.config) (meta : keeper_meta) =
+  let derived =
+    match meta.runtime.last_blocker with
+    | Some info ->
+      Some (runtime_blocker_surface_of_typed_class ~summary:info.detail info.klass)
+    | None ->
+      (match runtime_registry_entry config meta.name with
+       | Some entry ->
+         (match entry.last_failure_reason with
+          | Some reason -> runtime_blocker_surface_of_failure_reason reason
+          | None -> None)
+       | None -> None)
+  in
+  let derived =
+    match derived with
+    | Some blocker -> Some blocker
+    | None -> runtime_blocker_surface_of_progress_narrative config meta
+  in
+  derived
 ;;
 
 let runtime_attempt_outcome_json = function

--- a/test/test_keeper_status_bridge.ml
+++ b/test/test_keeper_status_bridge.ml
@@ -57,21 +57,21 @@ let init_runtime_default_for_tests () =
   | Error e -> Alcotest.failf "Runtime.init_default failed: %s" e
 ;;
 
-let test_progress_narrative_is_not_runtime_blocker_source () =
+let test_synthetic_idle_last_output_is_not_blocker () =
   let summary =
-    "Progress: waiting on sandbox egress for github.com push\n\
-     Next: ask operator to approve the manual 4-gate unblock"
+    "Decisions: [SYNTHETIC] Last output: No awaiting_verification tasks. \
+     Board posts are 21-31 days old with no new signals. Pure idle turn."
   in
   Alcotest.(check (option string))
-    "progress text never creates runtime blocker class"
+    "idle synthetic last output is not a blocker"
     None
     (Option.map (fun b -> b.Keeper_status_bridge.blocker_class) (blocker_of_summary summary))
 ;;
 
-let test_synthetic_narrative_is_not_runtime_blocker_source () =
+let test_synthetic_no_visible_output_is_not_blocker () =
   let summary = "Decisions: [SYNTHETIC] No visible output this generation" in
   Alcotest.(check (option string))
-    "synthetic text never creates runtime blocker class"
+    "synthetic fallback output is not a blocker"
     None
     (Option.map (fun b -> b.Keeper_status_bridge.blocker_class) (blocker_of_summary summary))
 ;;
@@ -132,16 +132,16 @@ let () =
   Alcotest.run
     "keeper_status_bridge"
     [
-      ( "progress narrative provenance",
+      ( "synthetic progress blockers",
         [
           Alcotest.test_case
-            "progress narrative is not blocker source"
+            "idle synthetic last output is not blocker"
             `Quick
-            test_progress_narrative_is_not_runtime_blocker_source;
+            test_synthetic_idle_last_output_is_not_blocker;
           Alcotest.test_case
-            "synthetic narrative is not blocker source"
+            "no visible synthetic output is not blocker"
             `Quick
-            test_synthetic_narrative_is_not_runtime_blocker_source;
+            test_synthetic_no_visible_output_is_not_blocker;
         ] );
       ( "profile default override provenance",
         [


### PR DESCRIPTION
## Summary

Reverts #20344 (`Remove narrative blocker inference from status bridge`).

This removes the already-merged status bridge change from `main` so the work can be reopened as a fresh PR instead of staying landed from the accidental/too-fast merge path.

Also adds the missing public `.mli` files for the Slack and Telegram Channel Gate state modules. Those modules are already referenced from server/tests, so they need explicit public interfaces for the OCaml structure ratchet.

## Validation

- `ocamlformat --check lib/gate/channel_gate_slack_state.mli lib/gate/channel_gate_telegram_state.mli lib/keeper/keeper_status_bridge.ml test/test_keeper_status_bridge.ml`
- `scripts/ocaml-structure-ratchet.sh`
- `git diff --check`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_status_bridge.exe` (passed before the conflict-free rebase)
- `./_build/default/test/test_keeper_status_bridge.exe` (passed before the conflict-free rebase)

Note: a post-amend focused build including `test/test_channel_gate_connector_routes.exe` was queued behind unrelated repo-wide Dune locks and was stopped; CI will validate the pushed head.
