### PR TITLE
[codex] Add sidecar connector interfaces

### DIFF
--- a/lib/gate/channel_gate_slack_state.mli
+++ b/lib/gate/channel_gate_slack_state.mli
@@ -1,0 +1,1 @@
+include Channel_gate_connector.S

--- a/lib/gate/channel_gate_telegram_state.mli
+++ b/lib/gate/channel_gate_telegram_state.mli
@@ -1,0 +1,1 @@
+include Channel_gate_connector.S


### PR DESCRIPTION
## What changed

- Adds `.mli` interfaces for `Channel_gate_slack_state` and `Channel_gate_telegram_state`.

## Why

PR #20346 added the Slack/Telegram connector implementations, but the public `lib/gate` modules were missing interfaces. The OCaml structure ratchet flagged this as `lib_other_mli_missing`.

## Validation

- `scripts/ocaml-structure-ratchet.sh`
- `git diff --check HEAD~1..HEAD`

Note: I attempted the focused Dune build after rebasing on latest `origin/main`, but it was blocked by a long-running global `dune-local` lock from another worktree. The same interface addition was already build/test verified before the follow-up branch was split out.