### PR TITLE
fix(keeper): persist voice speak output to memory

### DIFF
--- a/lib/keeper/keeper_memory_bank.ml
+++ b/lib/keeper/keeper_memory_bank.ml
@@ -854,6 +854,54 @@ let append_memory_notes_from_tool_results
       results);
   !written
 
+let append_voice_output
+    (config : Workspace.config)
+    (meta : keeper_meta)
+    ?provider
+    ~(execution : string)
+    ~(voice_priority : int)
+    ~(turn : int)
+    ~(message : string)
+    () : (int, string) result =
+  let text = String.trim message in
+  if text = "" || not (is_meaningful_memory_text text)
+  then Ok 0
+  else (
+    let kind = "progress" in
+    let now_ts = Time_compat.now () in
+    let path = Keeper_types_support.keeper_memory_bank_path config meta.name in
+    let optional_provider =
+      match provider |> Option.map String.trim with
+      | Some value when value <> "" -> [ "provider", `String value ]
+      | _ -> []
+    in
+    let fields =
+      [ "ts", `String (now_iso ())
+      ; "ts_unix", `Float now_ts
+      ; "name", `String meta.name
+      ; "trace_id", `String (Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+      ; "generation", `Int meta.runtime.generation
+      ; "turn", `Int turn
+      ; "kind", `String kind
+      ; "horizon", `String short_term_horizon
+      ; "source", `String "voice_output"
+      ; "schema_version", `Int keeper_memory_schema_version
+      ; "priority", `Int (tuned_priority_for_candidate ~kind ~text)
+      ; "text", `String text
+      ; "tool", `String "keeper_voice_speak"
+      ; "execution", `String execution
+      ; "voice_priority", `Int (max 1 voice_priority)
+      ]
+      @ optional_provider
+    in
+    try
+      with_memory_bank_lock path (fun () ->
+        Keeper_types_support.append_jsonl_line path (`Assoc fields));
+      Ok 1
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn -> Error (Printexc.to_string exn))
+
 let summarize_memory_bank_lines
     (lines : string list)
     ~(recent_limit : int) : keeper_memory_summary =

--- a/lib/keeper/keeper_memory_bank.mli
+++ b/lib/keeper/keeper_memory_bank.mli
@@ -354,6 +354,20 @@ val append_memory_notes_from_tool_results :
   results:Yojson.Safe.t list ->
   int
 
+val append_voice_output :
+  Workspace.config ->
+  Keeper_meta_contract.keeper_meta ->
+  ?provider:string ->
+  execution:string ->
+  voice_priority:int ->
+  turn:int ->
+  message:string ->
+  unit ->
+  (int, string) result
+(** Persist a keeper voice output event as a short-term progress memory row.
+    Returns [Ok 1] when a row is written, [Ok 0] when the message is empty or
+    filtered as non-meaningful, and [Error _] on persistence failure. *)
+
 (** {1 Summary} *)
 
 val summarize_memory_bank_lines :

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -92,8 +92,8 @@ let handle_ide_annotate ~config ~(meta : keeper_meta) ~args =
     ~args
 ;;
 
-let handle_voice ~(meta : keeper_meta) ~name ~args =
-  Keeper_tool_voice_runtime.handle_voice_tool ~meta ~name ~args
+let handle_voice ~config ~(meta : keeper_meta) ~name ~args =
+  Keeper_tool_voice_runtime.handle_voice_tool ~config ~meta ~name ~args
 ;;
 
 let handle_task ~config ~(meta : keeper_meta) ~name ~args =

--- a/lib/keeper/keeper_tool_in_process_runtime.mli
+++ b/lib/keeper/keeper_tool_in_process_runtime.mli
@@ -57,7 +57,8 @@ val handle_ide_annotate
 (** [handle_voice] dispatches to [Keeper_tool_voice_runtime.handle_voice_tool]
     by [name]. Caller must pass a name in the voice cluster. *)
 val handle_voice
-  :  meta:keeper_meta
+  :  config:Workspace.config
+  -> meta:keeper_meta
   -> name:string
   -> args:Yojson.Safe.t
   -> string

--- a/lib/keeper/keeper_tool_runtime.ml
+++ b/lib/keeper/keeper_tool_runtime.ml
@@ -173,7 +173,11 @@ let handle_in_process ctx descriptor args =
          ~args)
   | Tool_voice_dispatch ->
     Some
-      (Keeper_tool_in_process_runtime.handle_voice ~meta:ctx.meta ~name ~args)
+      (Keeper_tool_in_process_runtime.handle_voice
+         ~config:ctx.config
+         ~meta:ctx.meta
+         ~name
+         ~args)
   | Tool_task_dispatch ->
     Some
       (Keeper_tool_in_process_runtime.handle_task

--- a/lib/keeper/keeper_tool_voice_runtime.ml
+++ b/lib/keeper/keeper_tool_voice_runtime.ml
@@ -42,7 +42,57 @@ let command_to_string = function
 let command_of_string (s : string) : voice_command option =
   List.find_opt (fun c -> String.equal (command_to_string c) s) all_commands
 
-let handle_speak ~(meta : keeper_meta) ~(args : Yojson.Safe.t) =
+type voice_memory_status =
+  { recorded : bool
+  ; rows_written : int
+  ; error : string option
+  }
+
+let record_voice_output
+      ~(config : Workspace.config)
+      ~(meta : keeper_meta)
+      ~(provider : string option)
+      ~priority
+      ~execution
+      ~message
+  =
+  match
+    Keeper_memory_bank.append_voice_output
+      config
+      meta
+      ?provider
+      ~execution
+      ~voice_priority:priority
+      ~turn:meta.runtime.usage.total_turns
+      ~message
+      ()
+  with
+  | Ok rows_written ->
+    { recorded = rows_written > 0; rows_written; error = None }
+  | Error err ->
+    Log.Keeper.warn
+      ~keeper_name:meta.name
+      "keeper_voice_speak memory write failed: %s"
+      err;
+    { recorded = false; rows_written = 0; error = Some err }
+
+let memory_status_fields status =
+  [ "memory_recorded", `Bool status.recorded
+  ; "memory_rows_written", `Int status.rows_written
+  ; "memory_source", `String "voice_output"
+  ; "memory_error", Json_util.string_opt_to_json status.error
+  ]
+
+let attach_memory_status json status =
+  match json with
+  | `Assoc fields -> `Assoc (fields @ memory_status_fields status)
+  | other -> `Assoc (("result", other) :: memory_status_fields status)
+
+let handle_speak
+      ~(config : Workspace.config)
+      ~(meta : keeper_meta)
+      ~(args : Yojson.Safe.t)
+  =
   let message = Safe_ops.json_string ~default:"" "message" args |> String.trim in
   let provider =
     Safe_ops.json_string_opt "provider" args
@@ -72,14 +122,36 @@ let handle_speak ~(meta : keeper_meta) ~(args : Yojson.Safe.t) =
            ~priority
            ()
        with
-       | Ok json -> Yojson.Safe.to_string json
+       | Ok json ->
+         let memory_status =
+             record_voice_output
+               ~config
+               ~meta
+               ~provider
+               ~priority
+               ~execution:"background_voice_queue"
+               ~message
+         in
+         Yojson.Safe.to_string (attach_memory_status json memory_status)
        | Error err ->
          Tool_args.error_response_with
            [ "agent_id", `String meta.name
            ; "message", `String err
            ])
     | _ ->
-      Yojson.Safe.to_string (keeper_text_fallback_json ~agent_id:meta.name ~message))
+      let memory_status =
+        record_voice_output
+          ~config
+          ~meta
+          ~provider
+          ~priority
+          ~execution:"text_fallback"
+          ~message
+      in
+      Yojson.Safe.to_string
+        (attach_memory_status
+           (keeper_text_fallback_json ~agent_id:meta.name ~message)
+           memory_status))
 
 let handle_listen ~(meta : keeper_meta) ~(args : Yojson.Safe.t) =
   let timeout_sec = Safe_ops.json_float ~default:15.0 "timeout_seconds" args in
@@ -141,9 +213,14 @@ let handle_session_end ~(meta : keeper_meta) =
         ; "discarded_voice_queue_jobs", `Int discarded_voice_queue_jobs
         ])
 
-let handle ~(meta : keeper_meta) ~(command : voice_command) ~(args : Yojson.Safe.t) =
+let handle
+      ~(config : Workspace.config)
+      ~(meta : keeper_meta)
+      ~(command : voice_command)
+      ~(args : Yojson.Safe.t)
+  =
   match command with
-  | Speak -> handle_speak ~meta ~args
+  | Speak -> handle_speak ~config ~meta ~args
   | Listen -> handle_listen ~meta ~args
   | Agent -> handle_agent ~meta
   | Sessions -> handle_sessions ()
@@ -151,10 +228,11 @@ let handle ~(meta : keeper_meta) ~(command : voice_command) ~(args : Yojson.Safe
   | Session_end -> handle_session_end ~meta
 
 let handle_voice_tool
+      ~(config : Workspace.config)
       ~(meta : keeper_meta)
       ~(name : string)
       ~(args : Yojson.Safe.t)
   =
   match command_of_string name with
-  | Some command -> handle ~meta ~command ~args
+  | Some command -> handle ~config ~meta ~command ~args
   | None -> error_json ~fields:[ "tool", `String name ] "unknown_voice_tool"

--- a/lib/keeper/keeper_tool_voice_runtime.mli
+++ b/lib/keeper/keeper_tool_voice_runtime.mli
@@ -21,6 +21,7 @@ val command_to_string : voice_command -> string
 val command_of_string : string -> voice_command option
 
 val handle_voice_tool :
+  config:Workspace.config ->
   meta:Keeper_meta_contract.keeper_meta ->
   name:string ->
   args:Yojson.Safe.t ->

--- a/test/test_voice_runtime_overlay.ml
+++ b/test/test_voice_runtime_overlay.ml
@@ -36,6 +36,26 @@ let () =
   at_exit (fun () -> rm_rf voice_session_test_base)
 ;;
 
+let test_config () = Masc.Workspace.default_config voice_session_test_base
+
+let read_lines path =
+  if not (Sys.file_exists path)
+  then []
+  else (
+    let ic = open_in path in
+    let rec loop acc =
+      match input_line ic with
+      | line -> loop (line :: acc)
+      | exception End_of_file ->
+        close_in ic;
+        List.rev acc
+      | exception exn ->
+        close_in_noerr ic;
+        raise exn
+    in
+    loop [])
+;;
+
 let test_resolve_voice_aliases () =
   let elevenlabs = Option.get (Voice.resolve_adapter "elevenlabs") in
   check string "elevenlabs alias" "elevenlabs-direct" elevenlabs.canonical_name;
@@ -202,9 +222,11 @@ let test_keeper_voice_speak_returns_queued_with_root_switch () =
   let clock = Eio.Stdenv.clock env in
   let mono_clock = Eio.Stdenv.mono_clock env in
   Eio_context.with_test_env ~net ~clock ~mono_clock ~sw (fun () ->
+    let config = test_config () in
     let meta = make_keeper_meta "voice-queue-keeper" in
     let raw =
       Masc.Keeper_tool_voice_runtime.handle_voice_tool
+        ~config
         ~meta
         ~name:"keeper_voice_speak"
         ~args:(`Assoc [ "message", `String "hello from queued voice test" ])
@@ -214,7 +236,91 @@ let test_keeper_voice_speak_returns_queued_with_root_switch () =
       Yojson.Safe.Util.(member "status" json |> to_string);
     check string "background execution" "background_voice_queue"
       Yojson.Safe.Util.(member "execution" json |> to_string);
+    check bool "memory recorded" true
+      Yojson.Safe.Util.(member "memory_recorded" json |> to_bool);
     ignore (Masc.Voice_bridge.discard_queued_agent_speak ~agent_id:meta.name))
+;;
+
+let test_keeper_voice_speak_records_memory_bank_row () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let net = Eio.Stdenv.net env in
+  let clock = Eio.Stdenv.clock env in
+  let mono_clock = Eio.Stdenv.mono_clock env in
+  Eio_context.with_test_env ~net ~clock ~mono_clock ~sw (fun () ->
+    let config = test_config () in
+    let meta = make_keeper_meta "voice-memory-keeper" in
+    let message = "spoken memory should be durable" in
+    let raw =
+      Masc.Keeper_tool_voice_runtime.handle_voice_tool
+        ~config
+        ~meta
+        ~name:"keeper_voice_speak"
+        ~args:(`Assoc [ "message", `String message; "priority", `Int 3 ])
+    in
+    let json = Yojson.Safe.from_string raw in
+    check bool "memory recorded" true
+      Yojson.Safe.Util.(member "memory_recorded" json |> to_bool);
+    check int "memory rows written" 1
+      Yojson.Safe.Util.(member "memory_rows_written" json |> to_int);
+    let memory_path = Masc.Keeper_types_support.keeper_memory_bank_path config meta.name in
+    let rows =
+      read_lines memory_path
+      |> List.filter_map Masc.Keeper_memory_bank.parse_memory_bank_row
+    in
+    let row =
+      rows
+      |> List.find_opt (fun row ->
+        String.equal row.Masc.Keeper_memory_bank.source "voice_output"
+        && String.equal row.kind "progress"
+        && String.equal row.text message)
+    in
+    (match row with
+     | Some row ->
+       check string "voice memory horizon" "short_term" row.horizon;
+       check string "voice memory execution" "background_voice_queue"
+         Yojson.Safe.Util.(member "execution" row.json |> to_string);
+       check int "voice priority metadata" 3
+         Yojson.Safe.Util.(member "voice_priority" row.json |> to_int)
+     | None -> fail "expected voice_output progress memory row");
+    ignore (Masc.Voice_bridge.discard_queued_agent_speak ~agent_id:meta.name))
+;;
+
+let test_keeper_voice_speak_text_fallback_records_memory_bank_row () =
+  let config = test_config () in
+  let meta = make_keeper_meta "voice-fallback-memory-keeper" in
+  let message = "fallback speech should be durable" in
+  let raw =
+    Masc.Keeper_tool_voice_runtime.handle_voice_tool
+      ~config
+      ~meta
+      ~name:"keeper_voice_speak"
+      ~args:(`Assoc [ "message", `String message ])
+  in
+  let json = Yojson.Safe.from_string raw in
+  check string "text fallback status" "text_fallback"
+    Yojson.Safe.Util.(member "status" json |> to_string);
+  check bool "fallback memory recorded" true
+    Yojson.Safe.Util.(member "memory_recorded" json |> to_bool);
+  let memory_path = Masc.Keeper_types_support.keeper_memory_bank_path config meta.name in
+  let rows =
+    read_lines memory_path
+    |> List.filter_map Masc.Keeper_memory_bank.parse_memory_bank_row
+  in
+  let row =
+    rows
+    |> List.find_opt (fun row ->
+      String.equal row.Masc.Keeper_memory_bank.source "voice_output"
+      && String.equal row.kind "progress"
+      && String.equal row.text message)
+  in
+  match row with
+  | Some row ->
+    check string "fallback memory execution" "text_fallback"
+      Yojson.Safe.Util.(member "execution" row.json |> to_string)
+  | None -> fail "expected fallback voice_output progress memory row"
 ;;
 
 let test_keeper_voice_session_start_does_not_store_session_name_as_voice () =
@@ -226,10 +332,12 @@ let test_keeper_voice_session_start_does_not_store_session_name_as_voice () =
   let clock = Eio.Stdenv.clock env in
   let mono_clock = Eio.Stdenv.mono_clock env in
   Eio_context.with_test_env ~net ~clock ~mono_clock ~sw (fun () ->
+    let config = test_config () in
     let meta = make_keeper_meta "voice-session-name-regression" in
     let session_name = "shutup-shutup-shutup" in
     let raw =
       Masc.Keeper_tool_voice_runtime.handle_voice_tool
+        ~config
         ~meta
         ~name:"keeper_voice_session_start"
         ~args:(`Assoc [ "session_name", `String session_name ])
@@ -240,6 +348,7 @@ let test_keeper_voice_session_start_does_not_store_session_name_as_voice () =
       (not (String.equal session_name voice));
     ignore
       (Masc.Keeper_tool_voice_runtime.handle_voice_tool
+         ~config
          ~meta
          ~name:"keeper_voice_session_end"
          ~args:(`Assoc [])))
@@ -254,9 +363,11 @@ let test_keeper_voice_session_end_discards_queued_speech () =
   let clock = Eio.Stdenv.clock env in
   let mono_clock = Eio.Stdenv.mono_clock env in
   Eio_context.with_test_env ~net ~clock ~mono_clock ~sw (fun () ->
+    let config = test_config () in
     let meta = make_keeper_meta "voice-session-drain-keeper" in
     ignore
       (Masc.Keeper_tool_voice_runtime.handle_voice_tool
+         ~config
          ~meta
          ~name:"keeper_voice_session_start"
          ~args:(`Assoc [ "session_name", `String "drain regression" ]));
@@ -277,6 +388,7 @@ let test_keeper_voice_session_end_discards_queued_speech () =
      | Error err -> fail ("expected queued speech, got error: " ^ err));
     let end_raw =
       Masc.Keeper_tool_voice_runtime.handle_voice_tool
+        ~config
         ~meta
         ~name:"keeper_voice_session_end"
         ~args:(`Assoc [])
@@ -316,6 +428,14 @@ let () =
             "keeper_voice_speak queues on root switch"
             `Quick
             test_keeper_voice_speak_returns_queued_with_root_switch
+        ; test_case
+            "keeper_voice_speak records memory"
+            `Quick
+            test_keeper_voice_speak_records_memory_bank_row
+        ; test_case
+            "keeper_voice_speak fallback records memory"
+            `Quick
+            test_keeper_voice_speak_text_fallback_records_memory_bank_row
         ; test_case
             "session_start does not store session_name as voice"
             `Quick


### PR DESCRIPTION
## Summary

- pass workspace config into keeper voice tool dispatch so voice memory writes use the correct base path
- persist `keeper_voice_speak` output as `source=voice_output` progress rows in the keeper memory bank
- expose `memory_recorded`, `memory_rows_written`, and `memory_error` in voice speak results

## Product impact

Voice output from keepers is now captured in durable keeper memory, including the text fallback path. Operators can also see whether a voice speak result recorded memory from the tool response JSON.

## Evidence

- `ocamlformat --check lib/keeper/keeper_memory_bank.ml lib/keeper/keeper_memory_bank.mli lib/keeper/keeper_tool_in_process_runtime.ml lib/keeper/keeper_tool_in_process_runtime.mli lib/keeper/keeper_tool_runtime.ml lib/keeper/keeper_tool_voice_runtime.ml lib/keeper/keeper_tool_voice_runtime.mli test/test_voice_runtime_overlay.ml`
- `git diff --check`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_voice_runtime_overlay.exe`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-voice-output-memory test/test_voice_runtime_overlay.exe`
- `_build/default/test/test_voice_runtime_overlay.exe`

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 5/5
provenance: direct
stages:
  - name: ocamlformat
    command: ocamlformat --check lib/keeper/keeper_memory_bank.ml lib/keeper/keeper_memory_bank.mli lib/keeper/keeper_tool_in_process_runtime.ml lib/keeper/keeper_tool_in_process_runtime.mli lib/keeper/keeper_tool_runtime.ml lib/keeper/keeper_tool_voice_runtime.ml lib/keeper/keeper_tool_voice_runtime.mli test/test_voice_runtime_overlay.ml
    result: pass
  - name: diff-check
    command: git diff --check
    result: pass
  - name: focused-wrapper-build
    command: env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_voice_runtime_overlay.exe
    result: pass
  - name: focused-direct-build
    command: dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-voice-output-memory test/test_voice_runtime_overlay.exe
    result: pass
  - name: focused-test
    command: _build/default/test/test_voice_runtime_overlay.exe
    result: pass
```

- `test/test_voice_runtime_overlay.exe`: 12 tests run, all passing.
- New coverage asserts both queued voice speak and text fallback write `source=voice_output` rows to `<keeper>.memory.jsonl`.

## Review evidence

- Local self-review of the dispatch boundary: memory persistence is wired through keeper tool runtime with `Workspace.config`, not through the generic voice bridge.

## Linked issue

- Operator report: voice-spoken content was not remembered, causing repeated conversation context.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`fix/voice-output-memory` → `main` · 1 commit(s) · synced 2026-06-06T10:44:02Z

| sha | subject | date |
|---|---|---|
| `05746f2cd` | fix(keeper): persist voice speak output to memory | 2026-06-06 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->