### PR TITLE
feat(dashboard): render AG-UI tool call events in keeper chat

### DIFF
--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -202,6 +202,9 @@ export interface KeeperChatStreamEvent {
   name?: string
   value?: unknown
   timestamp?: number
+  // AG-UI tool call fields (TOOL_CALL_START / TOOL_CALL_ARGS / TOOL_CALL_END)
+  toolCallId?: string
+  toolCallName?: string
 }
 
 // --- Direct and operator-mediated messaging ---

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -51,6 +51,7 @@ function bubbleTone(entry: KeeperConversationEntry): string {
   if (entry.delivery === 'error' || entry.delivery === 'timeout') return 'error'
   if (entry.role === 'user') return 'user'
   if (entry.role === 'assistant') return 'assistant'
+  if (entry.role === 'tool') return 'tool'
   return 'system'
 }
 
@@ -435,6 +436,57 @@ function ChatMessageBubble({
   `
 }
 
+// Compact collapsible card for tool call entries in the chat transcript.
+function ToolCallBubble({ entry }: { entry: KeeperConversationEntry }) {
+  const [expanded, setExpanded] = useState(false)
+  const timestamp = timeLabel(entry.timestamp)
+  const toolName = entry.label || 'tool'
+  const argsText = entry.text || ''
+  const isJson = argsText.trimStart().startsWith('{') || argsText.trimStart().startsWith('[')
+  let displayText = argsText
+  if (isJson) {
+    try {
+      displayText = JSON.stringify(JSON.parse(argsText), null, 2)
+    } catch {
+      // keep original
+    }
+  }
+  const preview = displayText.length > 120 ? displayText.slice(0, 120) + '...' : displayText
+
+  return html`
+    <article
+      class="chat-bubble tool flex w-full flex-col rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]"
+      data-chat-variant="tool-call"
+    >
+      <button
+        type="button"
+        class="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-[var(--color-bg-hover)] transition-colors"
+        onClick=${() => { setExpanded(!expanded) }}
+        aria-expanded=${expanded}
+      >
+        <span class="inline-flex size-5 shrink-0 items-center justify-center rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] text-3xs font-mono font-bold text-[var(--color-fg-muted)]">T</span>
+        <span class="font-mono text-xs font-medium text-[var(--color-accent-fg)] truncate">${toolName}</span>
+        ${timestamp
+          ? html`<span class="ml-auto text-2xs tabular-nums text-[var(--color-fg-muted)]">${timestamp}</span>`
+          : null}
+        <span class="ml-1 text-xs text-[var(--color-fg-muted)]">${expanded ? '▾' : '▸'}</span>
+      </button>
+      ${expanded
+        ? html`
+            <div class="border-t border-[var(--color-border-default)] px-3 py-2">
+              <pre class="text-2xs font-mono whitespace-pre-wrap break-all text-[var(--color-fg-secondary)] max-h-64 overflow-y-auto">${displayText}</pre>
+            </div>
+          `
+        : html`
+            <div class="px-3 pb-2">
+              <div class="truncate text-2xs font-mono text-[var(--color-fg-muted)]">${preview}</div>
+            </div>
+          `
+      }
+    </article>
+  `
+}
+
 export function ChatTranscript({
   entries,
   emptyText,
@@ -485,7 +537,10 @@ export function ChatTranscript({
               <div class="mt-3 max-w-[34rem] text-sm leading-airy text-[var(--color-fg-secondary)]">${emptyText}</div>
             </div>
           `
-        : entries.map(entry => html`<${ChatMessageBubble} key=${entry.id} entry=${entry} showMetadata=${showMetadata !== false} variant=${variant} />`)}
+        : entries.map(entry => entry.role === 'tool'
+            ? html`<${ToolCallBubble} key=${entry.id} entry=${entry} />`
+            : html`<${ChatMessageBubble} key=${entry.id} entry=${entry} showMetadata=${showMetadata !== false} variant=${variant} />`
+        )}
     </div>
   `
 }

--- a/dashboard/src/components/keeper-chat-panel.ts
+++ b/dashboard/src/components/keeper-chat-panel.ts
@@ -301,6 +301,23 @@ export function KeeperChatPanel({ name }: { name: string }) {
 
     // Track pending tool call args during streaming (keyed by toolCallId)
     const pendingToolArgs = new Map<string, { name: string; args: string }>()
+    // Insertion-order key list for fallback lookup when toolCallId is absent
+    const pendingOrder: string[] = []
+
+    function resolvePending(toolCallId?: string): { id: string; entry: { name: string; args: string } } | null {
+      if (toolCallId) {
+        const entry = pendingToolArgs.get(toolCallId)
+        return entry ? { id: toolCallId, entry } : null
+      }
+      // Fallback: most recently inserted pending tool call
+      while (pendingOrder.length > 0) {
+        const lastId = pendingOrder[pendingOrder.length - 1]
+        const entry = pendingToolArgs.get(lastId)
+        if (entry) return { id: lastId, entry }
+        pendingOrder.pop()
+      }
+      return null
+    }
 
     try {
       await streamKeeperMessage(keeperName, text, {
@@ -313,27 +330,26 @@ export function KeeperChatPanel({ name }: { name: string }) {
             const tcId = event.toolCallId ?? `tc-${Date.now()}`
             const tcName = event.toolCallName ?? event.name ?? 'unknown'
             pendingToolArgs.set(tcId, { name: tcName, args: '' })
+            pendingOrder.push(tcId)
           } else if (event.type === 'TOOL_CALL_ARGS') {
-            const tcId = event.toolCallId ?? ''
-            const entry = tcId ? pendingToolArgs.get(tcId) : undefined
-            if (entry && typeof event.delta === 'string') {
-              entry.args += event.delta
+            const resolved = resolvePending(event.toolCallId)
+            if (resolved && typeof event.delta === 'string') {
+              resolved.entry.args += event.delta
             }
           } else if (event.type === 'TOOL_CALL_END') {
-            const tcId = event.toolCallId ?? ''
-            const entry = tcId ? pendingToolArgs.get(tcId) : undefined
-            if (entry) {
+            const resolved = resolvePending(event.toolCallId)
+            if (resolved) {
               const toolMsg: ChatMessage = {
                 role: 'tool',
-                content: entry.args || '(no args)',
+                content: resolved.entry.args || '(no args)',
                 timestamp: Date.now(),
                 source: 'dashboard',
-                toolCallId: tcId,
-                toolCallName: entry.name,
+                toolCallId: resolved.id,
+                toolCallName: resolved.entry.name,
               }
               appendChatMessage(keeperName, toolMsg)
               chatMessages.value = getChatMessageBuffer(keeperName)
-              pendingToolArgs.delete(tcId)
+              pendingToolArgs.delete(resolved.id)
             }
           } else if (event.type === 'RUN_FINISHED') {
             const finalText = streamBuffer.value.trim() || '(no response)'

--- a/dashboard/src/components/keeper-chat-panel.ts
+++ b/dashboard/src/components/keeper-chat-panel.ts
@@ -107,6 +107,20 @@ function toConversationEntry(
   msg: ChatMessage,
   index: number,
 ): KeeperConversationEntry {
+  if (msg.role === 'tool') {
+    return {
+      id: `${msg.role}-${msg.timestamp}-${index}`,
+      role: 'tool',
+      source: 'tool_result',
+      label: msg.toolCallName ?? 'tool',
+      text: msg.content,
+      rawText: msg.content,
+      timestamp: new Date(msg.timestamp).toISOString(),
+      delivery: 'delivered',
+      streamState: null,
+      details: null,
+    }
+  }
   const source = msg.role === 'user' ? 'direct_user' : 'direct_assistant'
   return {
     id: `${msg.role}-${msg.timestamp}-${index}`,
@@ -285,6 +299,9 @@ export function KeeperChatPanel({ name }: { name: string }) {
         data: att.data,
       }))
 
+    // Track pending tool call args during streaming (keyed by toolCallId)
+    const pendingToolArgs = new Map<string, { name: string; args: string }>()
+
     try {
       await streamKeeperMessage(keeperName, text, {
         signal: activeAbortRef.current.signal,
@@ -292,6 +309,32 @@ export function KeeperChatPanel({ name }: { name: string }) {
         onEvent: (event: KeeperChatStreamEvent) => {
           if (isKeeperTextContentEvent(event) && typeof event.delta === 'string') {
             streamBuffer.value += event.delta
+          } else if (event.type === 'TOOL_CALL_START') {
+            const tcId = event.toolCallId ?? `tc-${Date.now()}`
+            const tcName = event.toolCallName ?? event.name ?? 'unknown'
+            pendingToolArgs.set(tcId, { name: tcName, args: '' })
+          } else if (event.type === 'TOOL_CALL_ARGS') {
+            const tcId = event.toolCallId ?? ''
+            const entry = tcId ? pendingToolArgs.get(tcId) : undefined
+            if (entry && typeof event.delta === 'string') {
+              entry.args += event.delta
+            }
+          } else if (event.type === 'TOOL_CALL_END') {
+            const tcId = event.toolCallId ?? ''
+            const entry = tcId ? pendingToolArgs.get(tcId) : undefined
+            if (entry) {
+              const toolMsg: ChatMessage = {
+                role: 'tool',
+                content: entry.args || '(no args)',
+                timestamp: Date.now(),
+                source: 'dashboard',
+                toolCallId: tcId,
+                toolCallName: entry.name,
+              }
+              appendChatMessage(keeperName, toolMsg)
+              chatMessages.value = getChatMessageBuffer(keeperName)
+              pendingToolArgs.delete(tcId)
+            }
           } else if (event.type === 'RUN_FINISHED') {
             const finalText = streamBuffer.value.trim() || '(no response)'
             const assistantMsg: ChatMessage = { role: 'assistant', content: finalText, timestamp: Date.now(), source: 'dashboard' }

--- a/dashboard/src/keeper-chat-store.ts
+++ b/dashboard/src/keeper-chat-store.ts
@@ -10,7 +10,7 @@
 // - useEffect: not used for data init.  External system sync only.
 // - Component unmount: messages are preserved, not cleared.
 
-export type ChatMessageRole = 'user' | 'assistant'
+export type ChatMessageRole = 'user' | 'assistant' | 'tool'
 export type ChatMessageSource = 'dashboard' | 'discord' | 'slack' | 'api'
 
 export interface Attachment {
@@ -28,6 +28,9 @@ export interface ChatMessage {
   timestamp: number
   source?: ChatMessageSource
   attachments?: Attachment[]
+  // Tool call fields (role === 'tool')
+  toolCallId?: string
+  toolCallName?: string
 }
 
 interface StoredSession {


### PR DESCRIPTION
Keeper chat panel silently dropped AG-UI tool call events. Now handles TOOL_CALL_START/ARGS/END and renders as collapsible cards. 4 files, +106/-2 lines. Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>