### PR TITLE
fix(keeper): reject pipe operators in execute argv

### DIFF
--- a/lib/keeper/keeper_tool_execute_typed_input.ml
+++ b/lib/keeper/keeper_tool_execute_typed_input.ml
@@ -44,6 +44,11 @@ type validation_error =
       index : int;
       token : string;
     }
+  | Argv_contains_shell_pipeline_operator of {
+      executable : string;
+      index : int;
+      token : string;
+    }
   | Argv_contains_shell_redirection of {
       executable : string;
       index : int;
@@ -286,16 +291,27 @@ let of_json (json : Yojson.Safe.t) =
   | false, None -> Error "$.executable or $.pipeline is required"
 ;;
 
-(* Execve-style: argv tokens pass verbatim to the child process, so
-   shell metacharacters ([;|&><`$*?]) and line breaks are literal data, not
-   operators.  NUL is the only byte that cannot be represented inside an argv
-   string.  See .mli "Design constraints" for the rationale. *)
+(* Execve-style: argv tokens pass verbatim to the child process, so shell
+   metacharacters ([;|&><`$*?]) and line breaks inside a payload token are
+   literal data, not operators.  NUL is the only byte that cannot be
+   represented inside an argv string.  See .mli "Design constraints" for the
+   rationale. *)
 let shell_metachar_in_token token =
   String.exists
     (function
       | '\000' -> true
       | _ -> false)
     token
+;;
+
+(* A standalone pipe token is almost always a caller attempting shell syntax
+   inside direct Exec.argv.  Unlike payload tokens such as [foo|bar], ["|"]
+   cannot create a pipe in execve argv and commonly becomes a bogus filename
+   ([tail: |: No such file or directory]).  Keep this narrow: [;] is a valid
+   argv sentinel for find -exec, and [&] can be payload data. *)
+let looks_like_shell_pipeline_operator = function
+  | "|" | "|&" -> true
+  | _ -> false
 ;;
 
 (* RFC-0198 Phase A.  Detects argv tokens whose entire shape matches a
@@ -354,6 +370,9 @@ let check_argv ~executable argv =
     | [] -> Ok ()
     | token :: _ when shell_metachar_in_token token ->
       Error (Argv_contains_shell_metachar { executable; index = i; token })
+    | token :: _ when looks_like_shell_pipeline_operator token ->
+      Error
+        (Argv_contains_shell_pipeline_operator { executable; index = i; token })
     | token :: _ when looks_like_shell_redirection token ->
       Error (Argv_contains_shell_redirection { executable; index = i; token })
     | _ :: rest -> loop (i + 1) rest
@@ -660,6 +679,15 @@ let pp_validation_error ppf = function
       executable
       index
       token
+  | Argv_contains_shell_pipeline_operator { executable; index; token } ->
+    Format.fprintf
+      ppf
+      "executable %S argv[%d]=%S is a shell pipeline operator; argv tokens \
+       are passed verbatim to execve and never create pipelines. Split the \
+       command into typed Pipeline.stages instead."
+      executable
+      index
+      token
   | Argv_contains_shell_redirection { executable; index; token } ->
     Format.fprintf
       ppf
@@ -697,6 +725,7 @@ let validation_error_alternatives : validation_error -> string list = function
   | Executable_not_allowlisted { name; mode } ->
     executable_not_allowlisted_alternatives ~name ~mode
   | Argv_contains_shell_metachar _ -> []
+  | Argv_contains_shell_pipeline_operator _ -> [ "Pipeline" ]
   | Argv_contains_shell_redirection _ ->
     [ "discard_stderr"; "discard_stdout"; "Pipeline" ]
   | _ -> []

--- a/lib/keeper/keeper_tool_execute_typed_input.mli
+++ b/lib/keeper/keeper_tool_execute_typed_input.mli
@@ -14,17 +14,21 @@
       verbatim to the child process; the implementation invokes the
       executable directly (no [/bin/sh -c "..."] wrapping).  Therefore
       shell metacharacters like [*], [?], [|], [&], [;], [>], [<],
-      [`], [$], [\n], and [\r] inside an argv token are *literal
+      [`], [$], [\n], and [\r] inside a payload argv token are *literal
       characters*, not shell operators.  For example, the typed schema accepts
       [find . -name *.ml] because [*.ml] is a [find]-internal pattern, not a
       shell glob; it also accepts multiline `gh --body` text because the
       argument is passed directly to [gh].
     - **Pipelines are explicit**.  [Pipeline.stages] enumerates each
-      [exec_stage] separately; [|]-delimited strings are never parsed.
-    - **Forbidden in argv tokens**: only [NUL], which cannot be represented in
-      an execve argv string.  The validator rejects it via
-      {!Argv_contains_shell_metachar}; the variant name is kept for log
-      continuity, but the semantics are NUL-only.
+      [exec_stage] separately; [|]-delimited strings are never parsed.  A
+      standalone pipe operator token (["|"] / ["|&"]) in direct [Exec.argv] is
+      rejected because it can only become bogus argv data (for example
+      [tail: |: No such file or directory]); use [Pipeline] instead.
+    - **Forbidden argv shapes**: [NUL], standalone pipe operator tokens, and
+      shell redirection operator tokens.  [NUL] cannot be represented in an
+      execve argv string.  Pipe/redirection operator tokens are rejected as
+      command-shape mistakes while payload tokens that merely contain those
+      characters remain allowed.
     - **Cwd is a string for now**.  Path SSOT does not yet expose a
       [Path.t] type (RFC-0091 §2.3 mis-cited [Host_config.cwd_for_keeper]
       which does not exist).  Absolute-path enforcement happens in
@@ -91,6 +95,16 @@ type validation_error =
       index : int;
       token : string;
     }
+  | Argv_contains_shell_pipeline_operator of {
+      executable : string;
+      index : int;
+      token : string;
+    }
+      (** Standalone shell pipeline operator token (["|"] or ["|&"]) in
+          [Exec.argv].  These tokens are never interpreted as pipelines by
+          execve and commonly become bogus filenames/arguments.  Use
+          [Pipeline.stages]; payload tokens containing pipe characters (for
+          example ["foo|bar"] or multiline markdown bodies) remain valid. *)
   | Argv_contains_shell_redirection of {
       executable : string;
       index : int;
@@ -148,12 +162,13 @@ val to_shell_ir :
   execute_input ->
   (Masc_exec.Shell_ir.t, validation_error) result
 (** Validate and lower [input] into {!Masc_exec.Shell_ir.t}.  [Pipeline]
-    inputs become an explicit {!Masc_exec.Shell_ir.Pipeline}; literal ["|"]
-    argv tokens remain ordinary argument data and never create a pipeline.
-    [Exec] argv is passed through as authored after validation; duplicated
-    executable tokens at [argv[0]] are rejected rather than silently stripped.
-    [sandbox] defaults to host execution; keeper callers may provide Docker
-    runtime targets after sandbox/profile resolution. *)
+    inputs become an explicit {!Masc_exec.Shell_ir.Pipeline}; embedded pipe
+    characters inside payload argv tokens remain ordinary argument data, while
+    standalone pipe operator argv tokens are rejected before lowering.  [Exec]
+    argv is passed through as authored after validation; duplicated executable
+    tokens at [argv[0]] are rejected rather than silently stripped.  [sandbox]
+    defaults to host execution; keeper callers may provide Docker runtime
+    targets after sandbox/profile resolution. *)
 
 val pp_validation_error : Format.formatter -> validation_error -> unit
 (** Human-readable formatter for {!validation_error}.  Stable across

--- a/test/test_keeper_tool_execute_typed_input.ml
+++ b/test/test_keeper_tool_execute_typed_input.ml
@@ -842,6 +842,51 @@ let test_pipe_character_in_exec_argv_is_literal () =
     Alcotest.fail "literal pipe argv token must not create Shell_ir.Pipeline"
 ;;
 
+let test_standalone_pipe_operator_in_exec_argv_rejected () =
+  let check_case ~name ~token ~index argv =
+    let input =
+      Execute_input.Exec
+        { executable = "tail"
+        ; argv
+        ; cwd = None
+        ; env = []
+        ; stdin = Execute_input.Inherit
+        ; stdout = Execute_input.Inherit
+        ; stderr = Execute_input.Inherit
+        }
+    in
+    match Execute_input.validate ~mode:Execute_input.Readonly input with
+    | Error
+        (Execute_input.Argv_contains_shell_pipeline_operator
+          { executable; index = actual_index; token = actual_token } as err) ->
+      Alcotest.(check string) (name ^ " executable") "tail" executable;
+      Alcotest.(check int) (name ^ " index") index actual_index;
+      Alcotest.(check string) (name ^ " token") token actual_token;
+      let msg = Format.asprintf "%a" Execute_input.pp_validation_error err in
+      Alcotest.(check bool)
+        (name ^ " message points to Pipeline.stages")
+        true
+        (String_util.contains_substring_ci msg "Pipeline.stages")
+    | Error other ->
+      Alcotest.failf
+        "%s: expected Argv_contains_shell_pipeline_operator, got %a"
+        name
+        Execute_input.pp_validation_error
+        other
+    | Ok () -> Alcotest.failf "%s: expected standalone %S to be rejected" name token
+  in
+  check_case
+    ~name:"tail_pipe_head_log_shape"
+    ~token:"|"
+    ~index:3
+    [ "-n"; "200"; "/tmp/keeper.log"; "|"; "head"; "-80" ];
+  check_case
+    ~name:"stderr_pipe_operator"
+    ~token:"|&"
+    ~index:2
+    [ "-f"; "/tmp/keeper.log"; "|&"; "head"; "-80" ]
+;;
+
 let test_gh_multiline_body_lowers_to_literal_argv () =
   let body =
     "Replace self-shadowing `match sandbox_root with | Some _ -> sandbox_root \
@@ -1068,6 +1113,11 @@ let test_validation_error_alternatives () =
     (Execute_input.Argv_contains_shell_metachar
        { executable = "find"; index = 3; token = "foo\nbar" })
     [];
+  check_alts
+    ~name:"Argv_contains_shell_pipeline_operator alternatives"
+    (Execute_input.Argv_contains_shell_pipeline_operator
+       { executable = "tail"; index = 3; token = "|" })
+    [ "Pipeline" ];
   check_alts
     ~name:"Executable_not_allowlisted rm has no alternatives"
     (Execute_input.Executable_not_allowlisted { name = "rm"; mode = Execute_input.Dev_full })
@@ -1374,6 +1424,10 @@ let suite =
           "pipe_character_in_exec_argv_is_literal"
           `Quick
           test_pipe_character_in_exec_argv_is_literal
+      ; Alcotest.test_case
+          "standalone_pipe_operator_in_exec_argv_rejected"
+          `Quick
+          test_standalone_pipe_operator_in_exec_argv_rejected
       ; Alcotest.test_case
           "gh_multiline_body_lowers_to_literal_argv"
           `Quick


### PR DESCRIPTION
Summary:
- Reject standalone pipe operator tokens in typed Execute argv before dispatch.
- Preserve payload pipe characters such as foo|bar and gh multiline bodies.
- Add regression coverage for the tail ... | head argv shape and Pipeline alternative hints.

Tests:
- opam exec -- ocamlformat --check lib/keeper/keeper_tool_execute_typed_input.ml lib/keeper/keeper_tool_execute_typed_input.mli test/test_keeper_tool_execute_typed_input.ml
- git diff --check origin/main...HEAD
- scripts/lint-spawn-bounded.sh
- scripts/audit-shell-ir-consumption.sh --baseline scripts/shell-ir-consumption-baseline.json
- env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-shell-ir-pipe-3 scripts/dune-local.sh build test/test_keeper_tool_execute_typed_input.exe
- ./_build-codex-shell-ir-pipe-3/default/test/test_keeper_tool_execute_typed_input.exe (55 tests)

Note: I repaired the local agent_sdk pin with scripts/opam-pin-external-deps.sh --install before the focused dune run. After rebasing onto latest origin/main, post-rebase quick checks passed; a second focused dune run was stopped while queued behind another worktree's repo-wide dune lock.