### PR TITLE
fix(shutdown): run registered hooks inline

### DIFF
--- a/lib/shutdown.ml
+++ b/lib/shutdown.ml
@@ -111,6 +111,22 @@ let register ~name ?(priority = 50) action =
 let sorted_hooks () =
   List.sort (fun a b -> compare a.priority b.priority) !hooks
 
+let run_registered_hooks () =
+  let all_hooks = sorted_hooks () in
+  List.iter
+    (fun hook ->
+      try
+        hook.action ();
+        Log.Server.debug "[Shutdown] hook '%s' completed" hook.name
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | exn ->
+        Log.Server.warn
+          "[Shutdown] hook '%s' failed: %s"
+          hook.name
+          (Printexc.to_string exn))
+    all_hooks
+
 (** {1 Phase Execution} *)
 
 (** Execute notify phase: broadcast shutdown to clients. *)
@@ -144,14 +160,7 @@ let phase_cleanup state ~clock =
   Log.Server.info "[Shutdown] Phase 3/4: CLEANUP (%d hooks, timeout=%.1fs)"
     (List.length all_hooks) state.config.cleanup_timeout_s;
   (try
-    Eio.Time.with_timeout_exn clock state.config.cleanup_timeout_s (fun () ->
-      List.iter (fun hook ->
-        try
-          hook.action ();
-          Log.Server.debug "[Shutdown] hook '%s' completed" hook.name
-        with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-          Log.Server.warn "[Shutdown] hook '%s' failed: %s" hook.name (Printexc.to_string exn)
-      ) all_hooks)
+    Eio.Time.with_timeout_exn clock state.config.cleanup_timeout_s run_registered_hooks
   with Eio.Time.Timeout ->
     Log.Server.warn "[Shutdown] cleanup timeout (%.1fs) exceeded, proceeding"
       state.config.cleanup_timeout_s)

--- a/lib/shutdown.mli
+++ b/lib/shutdown.mli
@@ -46,6 +46,12 @@ type hook = {
 
 val register : name:string -> ?priority:int -> (unit -> unit) -> unit
 val sorted_hooks : unit -> hook list
+val run_registered_hooks : unit -> unit
+(** Run every hook registered with {!register}, in priority order.
+
+    This is the cleanup core used by {!initiate}'s cleanup phase and by the
+    inline server shutdown path in {!Shutdown_hooks}. Hook exceptions are logged
+    and swallowed except for [Eio.Cancel.Cancelled], which is re-raised. *)
 
 (** {1 Global Shutdown Flag} *)
 

--- a/lib/shutdown_hooks.ml
+++ b/lib/shutdown_hooks.ml
@@ -61,6 +61,11 @@ let run_all () =
     ws_count
     (Unix.gettimeofday () -. t_ws)
     remaining_ws;
+  let t_registered = Unix.gettimeofday () in
+  Shutdown.run_registered_hooks ();
+  Log.Server.info
+    "[Shutdown] registered hooks completed (%.2fs)"
+    (Unix.gettimeofday () -. t_registered);
   (* Clear transient A2A state to free memory *)
   (* Clear session identity caches *)
   Client_registry_eio.clear_session_caches ();

--- a/test/test_lifecycle.ml
+++ b/test/test_lifecycle.ml
@@ -87,6 +87,14 @@ let () = test "shutdown ignores duplicate initiate" (fun () ->
   assert (!count = 1)
 )
 
+let () = test "inline shutdown hooks run registered cleanup hooks" (fun () ->
+  Eio_main.run @@ fun _env ->
+  let called = ref false in
+  Shutdown.register ~name:"inline-run-all-test" ~priority:99 (fun () ->
+    called := true);
+  Shutdown_hooks.run_all ();
+  assert !called)
+
 (* ══════════════════════════════════════════════════════════════
    Supervisor tests
    ══════════════════════════════════════════════════════════════ *)


### PR DESCRIPTION
## Summary
- share Shutdown.register cleanup hook execution between Shutdown.initiate and inline Shutdown_hooks.run_all
- ensure inline SIGINT/SIGTERM shutdown runs registered otel/metrics/tool-log cleanup hooks
- add lifecycle regression coverage for inline registered hooks

## Verification
- env DUNE_CACHE=disabled MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build --build-dir _build_verify_wrapper --cache=disabled -j1 test/test_lifecycle.exe test/test_otel_tick_poison_source.exe
- _build_verify_wrapper/default/test/test_lifecycle.exe
- _build_verify_wrapper/default/test/test_otel_tick_poison_source.exe
- git diff --check HEAD

Note: after rebasing onto the latest origin/main, a second local Dune run was attempted but cancelled due repeated Dune lock starvation from parallel PR work. The branch rebased cleanly and CI should run the final target set.