### PR TITLE
fix(dashboard): guard keeper chat tool call fallback id

### DIFF
--- a/dashboard/src/components/keeper-chat-panel.ts
+++ b/dashboard/src/components/keeper-chat-panel.ts
@@ -312,6 +312,10 @@ export function KeeperChatPanel({ name }: { name: string }) {
       // Fallback: most recently inserted pending tool call
       while (pendingOrder.length > 0) {
         const lastId = pendingOrder[pendingOrder.length - 1]
+        if (lastId == null) {
+          pendingOrder.pop()
+          continue
+        }
         const entry = pendingToolArgs.get(lastId)
         if (entry) return { id: lastId, entry }
         pendingOrder.pop()


### PR DESCRIPTION
Summary:
- Fix main Dashboard typecheck failure in keeper-chat-panel.ts.
- Add an explicit undefined guard for the fallback pending tool-call id under noUncheckedIndexedAccess.
- Preserve fallback behavior by only popping stale or missing entries.

Root cause:
- main CI Dashboard failed with TS2345/TS2322 at dashboard/src/components/keeper-chat-panel.ts:315-316 because pendingOrder[index] is string | undefined.

Tests:
- pnpm install --frozen-lockfile
- pnpm run typecheck
- pnpm run lint
- git diff --check origin/main...HEAD