### PR TITLE
fix(shutdown): justify hook timing boundary

### DIFF
--- a/lib/shutdown_hooks.ml
+++ b/lib/shutdown_hooks.ml
@@ -61,11 +61,13 @@ let run_all () =
     ws_count
     (Unix.gettimeofday () -. t_ws)
     remaining_ws;
+  (* NDT-OK: shutdown hook elapsed timing is operator telemetry only; cleanup
+     ordering remains priority-driven and does not branch on wall-clock time. *)
   let t_registered = Unix.gettimeofday () in
   Shutdown.run_registered_hooks ();
-  Log.Server.info
-    "[Shutdown] registered hooks completed (%.2fs)"
-    (Unix.gettimeofday () -. t_registered);
+  (* NDT-OK: second wall-clock read closes the elapsed telemetry span above. *)
+  let registered_elapsed_s = Unix.gettimeofday () -. t_registered in
+  Log.Server.info "[Shutdown] registered hooks completed (%.2fs)" registered_elapsed_s;
   (* Clear transient A2A state to free memory *)
   (* Clear session identity caches *)
   Client_registry_eio.clear_session_caches ();


### PR DESCRIPTION
## Summary
- add NDT-OK rationale for the shutdown registered-hook elapsed timing reads merged in #20360
- keep hook execution unchanged; this only documents the wall-clock telemetry boundary for Meta Guards

## Verification
- scripts/ci/check-determinism-contract.sh --base origin/main --head HEAD
- git diff --check