### PR TITLE
fix(keeper): keep git process failures recoverable

### DIFF
--- a/lib/keeper/keeper_tool_command_runtime.ml
+++ b/lib/keeper/keeper_tool_command_runtime.ml
@@ -38,6 +38,4 @@ include Keeper_workspace_ops
 
 module For_testing = struct
   let elapsed_duration_ms = Keeper_tool_execute_runtime.For_testing.elapsed_duration_ms
-  let deterministic_retry_fields_for_process_result =
-    Keeper_tool_execute_runtime.For_testing.deterministic_retry_fields_for_process_result
 end

--- a/lib/keeper/keeper_tool_command_runtime.mli
+++ b/lib/keeper/keeper_tool_command_runtime.mli
@@ -71,10 +71,6 @@ val handle_tool_execute :
 
 module For_testing : sig
   val elapsed_duration_ms : start_time:float -> end_time:float -> int
-  val deterministic_retry_fields_for_process_result :
-    classification:Exec_core.classification ->
-    status:Unix.process_status ->
-    (string * Yojson.Safe.t) list
 end
 
 val handle_tool_search_files :

--- a/lib/keeper/keeper_tool_deterministic_error.ml
+++ b/lib/keeper/keeper_tool_deterministic_error.ml
@@ -12,7 +12,6 @@ type deterministic_reason =
   | Completion_contract_violation
   | Structured_tool_payload
   | Workflow_rejection_blocked
-  | Git_precondition_failed
 
 type classification_source =
   | Deterministic_retry_marker
@@ -45,7 +44,6 @@ let to_telemetry_key = function
     "deterministic_error_completion_contract_violation"
   | Structured_tool_payload -> "deterministic_error_structured_tool_payload"
   | Workflow_rejection_blocked -> "deterministic_error_workflow_rejection_blocked"
-  | Git_precondition_failed -> "deterministic_error_git_precondition_failed"
 ;;
 
 let to_string = function
@@ -68,8 +66,6 @@ let to_string = function
     "raw shell rejected; caller must use the visible structured tool from the recovery plan"
   | Workflow_rejection_blocked ->
     "workflow rejection explicitly marked deterministic and unrecoverable"
-  | Git_precondition_failed ->
-    "git command failed a process precondition; inspect repository/ref state or change the command"
 ;;
 
 (* ── JSON helpers ─────────────────────────────────────────────── *)
@@ -107,7 +103,6 @@ let reason_to_wire = function
   | Completion_contract_violation -> "completion_contract_violation"
   | Structured_tool_payload -> "structured_tool_payload"
   | Workflow_rejection_blocked -> "workflow_rejection_blocked"
-  | Git_precondition_failed -> "git_precondition_failed"
 ;;
 
 let reason_of_wire = function
@@ -122,7 +117,6 @@ let reason_of_wire = function
   | "completion_contract_violation" -> Some Completion_contract_violation
   | "structured_tool_payload" -> Some Structured_tool_payload
   | "workflow_rejection_blocked" -> Some Workflow_rejection_blocked
-  | "git_precondition_failed" -> Some Git_precondition_failed
   | _ -> None
 ;;
 
@@ -203,10 +197,9 @@ let classify_with_source (json : Yojson.Safe.t) : classification option =
      dedicated counter in [Keeper_tools_oas]). Once observed, it must
      not fall through to [error] string fallbacks; only explicit
      deterministic workflow markers may short-circuit retry. Path
-     checks have their own typed surface. Generic [error] codes and
-     retryability-only fields are observational metadata, not a
-     deterministic reason. Git process failures must be marked by
-     their typed producer instead of re-parsed from stderr here. *)
+     checks have their own typed surface. Generic [error] codes,
+     retryability-only fields, and git process failures are
+     observational metadata, not a deterministic reason. *)
   match classify_deterministic_retry json with
   | Some reason -> Some { reason; source = Deterministic_retry_marker }
   | None ->

--- a/lib/keeper/keeper_tool_deterministic_error.mli
+++ b/lib/keeper/keeper_tool_deterministic_error.mli
@@ -49,12 +49,6 @@ type deterministic_reason =
           separate counter in [Keeper_tools_oas]. It is considered
           deterministic only when the payload explicitly carries
           [error_class="deterministic"] and [recoverable=false]. *)
-  | Git_precondition_failed
-      (** git process precondition failed. Typed shell producers may
-          emit this for git exit 128 from structured command
-          classification plus process status; the deterministic
-          classifier intentionally does not re-parse stderr/output to
-          split missing refs from command usage. *)
 
 type classification_source =
   | Deterministic_retry_marker
@@ -80,8 +74,10 @@ type classification =
 
     There is no [error] string fallback and no [_ ->] catch-all that
     admits new prefixes silently. Producers that know same-argument
-    retry cannot succeed, including typed shell producers handling git
-    process failures, must emit [deterministic_retry_fields]. *)
+    retry cannot succeed must emit [deterministic_retry_fields]. Plain
+    git process failures intentionally stay outside this deterministic
+    surface so sandbox/worktree recovery can adapt with different refs,
+    paths, or branch names. *)
 val classify : Yojson.Safe.t -> deterministic_reason option
 
 val classify_with_source : Yojson.Safe.t -> classification option

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -196,17 +196,6 @@ let elapsed_duration_ms ~start_time ~end_time =
   | _ when elapsed_ms < 1. -> 1
   | _ -> int_of_float elapsed_ms
 
-let deterministic_retry_fields_for_process_result
-      ~(classification : Exec_core.classification)
-      ~status
-  =
-  match status, classification.Exec_core.family with
-  | Unix.WEXITED 128, (Exec_core.Git_read | Exec_core.Git_write) ->
-    Keeper_tool_deterministic_error.deterministic_retry_fields
-      Keeper_tool_deterministic_error.Git_precondition_failed
-  | _ -> []
-;;
-
 let token_looks_like_shell_glob token =
   String.exists
     (function
@@ -315,8 +304,6 @@ let typed_execute_response_cwd_json
 
 module For_testing = struct
   let elapsed_duration_ms = elapsed_duration_ms
-  let deterministic_retry_fields_for_process_result =
-    deterministic_retry_fields_for_process_result
   let compute_command_descriptor = compute_command_descriptor
   let typed_execute_response_cwd_json = typed_execute_response_cwd_json
 end
@@ -688,11 +675,6 @@ let handle_tool_execute_typed
                 ~stderr:result.stderr
             in
             let classification = Exec_core.classify_command_of_ir ir in
-            let deterministic_retry_fields =
-              deterministic_retry_fields_for_process_result
-                ~classification
-                ~status:result.status
-            in
             (* Only include command_descriptor on success — errors already carry
                sufficient diagnostic info (exit code, stderr, classification). *)
             let descriptor_fields =
@@ -709,8 +691,7 @@ let handle_tool_execute_typed
                  ~keeper_name:meta.name
                  ~cmd
                  ~extra:
-                   (deterministic_retry_fields
-                    @ failure_error_fields
+                   (failure_error_fields
                     @ glob_literal_failure_fields
                     @ sandbox_extra_fields
                     @ [ "typed", `Bool true

--- a/lib/keeper/keeper_tool_execute_runtime.mli
+++ b/lib/keeper/keeper_tool_execute_runtime.mli
@@ -14,10 +14,6 @@ val handle_tool_execute :
 
 module For_testing : sig
   val elapsed_duration_ms : start_time:float -> end_time:float -> int
-  val deterministic_retry_fields_for_process_result :
-    classification:Exec_core.classification ->
-    status:Unix.process_status ->
-    (string * Yojson.Safe.t) list
   val compute_command_descriptor : Masc_exec.Shell_ir.t -> Ide_event_types.command_descriptor
   val typed_execute_response_cwd_json :
     turn_sandbox_factory:Keeper_sandbox_factory.t option ->

--- a/test/test_keeper_tool_execute_retry_deterministic_close.ml
+++ b/test/test_keeper_tool_execute_retry_deterministic_close.ml
@@ -270,30 +270,15 @@ let test_workflow_rejection_nested_under_detail () =
     raw
 ;;
 
-(* ── Deterministic — typed git process markers ────────────────── *)
+(* ── Git process failures stay recoverable ────────────────────── *)
 
-let test_git_precondition_marker_is_deterministic () =
+let test_retired_git_precondition_marker_is_observed_only () =
   let raw =
-    deterministic_marker_raw
-      ~error:"git_exit_128"
-      D.Git_precondition_failed
+    {|{"ok":false,"error":"git_exit_128","deterministic_retry":{"reason":"git_precondition_failed","retry_same_args":false}}|}
   in
   check_classify
-    ~name:"git precondition marker"
-    ~expected:(Some D.Git_precondition_failed)
-    raw
-;;
-
-let test_git_precondition_marker_reports_source () =
-  let raw =
-    deterministic_marker_raw
-      ~error:"git_exit_128"
-      D.Git_precondition_failed
-  in
-  check_classify_source
-    ~name:"git precondition marker source"
-    ~expected_reason:D.Git_precondition_failed
-    ~expected_source:D.Deterministic_retry_marker
+    ~name:"retired git precondition marker"
+    ~expected:None
     raw
 ;;
 
@@ -374,7 +359,6 @@ let test_to_string_non_empty_for_every_variant () =
     ; D.Completion_contract_violation
     ; D.Structured_tool_payload
     ; D.Workflow_rejection_blocked
-    ; D.Git_precondition_failed
     ]
   in
   List.iter
@@ -472,13 +456,9 @@ let () =
         ] )
     ; ( "classify_git_markers"
       , [ Alcotest.test_case
-            "git_precondition_marker"
+            "retired_git_precondition_marker_observed_only"
             `Quick
-            test_git_precondition_marker_is_deterministic
-        ; Alcotest.test_case
-            "git_precondition_marker_reports_source"
-            `Quick
-            test_git_precondition_marker_reports_source
+            test_retired_git_precondition_marker_is_observed_only
         ; Alcotest.test_case
             "plain_git_exit_128_observed_only"
             `Quick

--- a/test/test_keeper_tool_execute_safety.ml
+++ b/test/test_keeper_tool_execute_safety.ml
@@ -1217,39 +1217,6 @@ let test_tool_execute_elapsed_duration_preserves_positive_sub_ms () =
   Alcotest.(check int) "nan duration is zero" 0
     (elapsed ~start_time:Float.nan ~end_time:10.0)
 
-let classification family =
-  { Exec_core.family = family
-  ; reversibility = Exec_core.Read_only
-  ; risk = Exec_core.Low
-  ; risk_class = Masc_exec.Shell_ir_risk.R0_Read
-  }
-;;
-
-let test_git_exit_128_emits_typed_deterministic_retry_marker () =
-  let fields =
-    Keeper_tool_command_runtime.For_testing.deterministic_retry_fields_for_process_result
-      ~classification:(classification Exec_core.Git_read)
-      ~status:(Unix.WEXITED 128)
-  in
-  let json = `Assoc fields in
-  let marker = json |> Json.member "deterministic_retry" in
-  Alcotest.(check string)
-    "reason"
-    "git_precondition_failed"
-    (marker |> Json.member "reason" |> Json.to_string);
-  Alcotest.(check bool)
-    "retry_same_args=false"
-    false
-    (marker |> Json.member "retry_same_args" |> Json.to_bool)
-
-let test_non_git_exit_128_has_no_deterministic_retry_marker () =
-  let fields =
-    Keeper_tool_command_runtime.For_testing.deterministic_retry_fields_for_process_result
-      ~classification:(classification Exec_core.Build)
-      ~status:(Unix.WEXITED 128)
-  in
-  Alcotest.(check int) "no fields" 0 (List.length fields)
-
 let test_tool_search_files_ir_timeout_floor_is_not_sub_io_latency () =
   let args = `Assoc [ "timeout_sec", `Float 1.0 ] in
   Alcotest.(check (float 0.001))
@@ -2363,14 +2330,6 @@ let () =
             "tool_search_files_ir load-bearing timeout floor"
             `Quick
             test_tool_search_files_ir_load_bearing_timeout_floor
-        ; Alcotest.test_case
-            "git exit 128 emits typed deterministic retry marker"
-            `Quick
-            test_git_exit_128_emits_typed_deterministic_retry_marker
-        ; Alcotest.test_case
-            "non-git exit 128 has no deterministic retry marker"
-            `Quick
-            test_non_git_exit_128_has_no_deterministic_retry_marker
         ; Alcotest.test_case
             "nested runtime detector ignores commit messages"
             `Quick


### PR DESCRIPTION
## Summary
- remove the typed Execute producer gate that marked git exit 128 as deterministic retry-skip
- retire git_precondition_failed from the deterministic error classifier so branch/worktree conflicts stay recoverable
- remove the earlier missing-path candidate heuristic; typed process failures now stay observational unless a true policy/shape/path-check gate emits a deterministic marker

## Why
Branch/worktree conflicts such as git_worktree_branch_conflict are not deterministic terminal failures for a keeper. The sandbox can recover by choosing a different branch/worktree name or repairing local sandbox state, so the OAS retry boundary should not close on git exit 128.

## Verification
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_tool_execute_safety.exe test/test_keeper_tool_execute_retry_deterministic_close.exe
- ./_build/default/test/test_keeper_tool_execute_retry_deterministic_close.exe test classify_git_markers
- ./_build/default/test/test_keeper_tool_execute_retry_deterministic_close.exe
- ./_build/default/test/test_keeper_tool_execute_safety.exe test typed_shell_ir 6