### PR TITLE
fix(exec): restore Execute allowlist and repo readiness gates

### DIFF
--- a/lib/exec/command_gate/shell_command_gate.ml
+++ b/lib/exec/command_gate/shell_command_gate.ml
@@ -46,6 +46,7 @@ type verdict =
 
 type allowlist_policy = {
   redirect_allowed : bool;
+  allowed_commands : string list;
   allow_pipes : bool;
 }
 
@@ -374,13 +375,23 @@ type stage_block =
   | Stage_not_allowed of { stage : int; bin : string }
   | Stage_unreducible of { stage : int; wrapper : string; detail : string }
 
-let first_blocked_stage (stages : SI.simple list)
+let first_blocked_stage ~allowed_commands (stages : SI.simple list)
   : stage_block option
   =
-  (* RFC-0219: allowlist check removed. Safety is provided by Shell IR
-     risk classification (destructive/R0/R1/R2) and the destructive +
-     write operation gates in keeper_tool_execute_runtime.ml. *)
-  None
+  let rec scan idx = function
+    | [] -> None
+    | s :: rest ->
+      (match effective_bin_of_stage s with
+       | Unreducible detail ->
+         Some
+           (Stage_unreducible
+              { stage = idx; wrapper = BIN.to_string s.SI.bin; detail })
+       | Bin bin ->
+         if bin_allowed ~allowed_commands bin
+         then scan (idx + 1) rest
+         else Some (Stage_not_allowed { stage = idx; bin }))
+  in
+  scan 1 stages
 ;;
 
 let stage_has_redirect (simple : SI.simple) : bool =
@@ -466,7 +477,35 @@ let apply_policy ~(allowlist : allowlist_policy) ~(path_policy : path_policy)
         ; diagnostic
         }
     else
-    match first_path_failure ~path_policy stages with
+      (match
+         first_blocked_stage ~allowed_commands:allowlist.allowed_commands stages
+       with
+       | Some (Stage_not_allowed { stage = stage_idx; bin }) ->
+         let reason, diagnostic =
+           if stage_n = 1 then
+             ( Command_not_in_allowlist { bin }
+             , Printf.sprintf "%s not in shell command allowlist" bin )
+           else
+             ( Pipeline_segment_disallowed { stage = stage_idx; bin }
+             , Printf.sprintf
+                 "pipeline stage %d command %s not in shell command allowlist"
+                 stage_idx
+                 bin )
+         in
+         Reject { context; reason; diagnostic }
+       | Some (Stage_unreducible { stage = stage_idx; wrapper; detail }) ->
+         Reject
+           { context
+           ; reason = Wrapper_unreducible { stage = stage_idx; wrapper; detail }
+           ; diagnostic =
+               Printf.sprintf
+                 "stage %d: %s wrapper cannot be statically authorized (%s)"
+                 stage_idx
+                 wrapper
+                 detail
+           }
+       | None ->
+         (match first_path_failure ~path_policy stages with
           | Some (stage_idx, raw_path, diagnostic) ->
             Reject
               { context
@@ -484,7 +523,7 @@ let apply_policy ~(allowlist : allowlist_policy) ~(path_policy : path_policy)
                      Printf.sprintf "pipeline stage %d carries a redirect" stage
                  }
              | None -> Allow context
-             | Some _ -> Allow context)
+             | Some _ -> Allow context)))
 ;;
 
 let parse_only_to_stages (parsed : SI.t PD.t) :

--- a/lib/exec/command_gate/shell_command_gate.mli
+++ b/lib/exec/command_gate/shell_command_gate.mli
@@ -106,6 +106,7 @@ type verdict =
     syntax, including fd-to-fd redirects such as [2>&1]. *)
 type allowlist_policy = {
   redirect_allowed : bool;
+  allowed_commands : string list;
   allow_pipes : bool;
 }
 

--- a/lib/exec/test/test_exec_gate_env_wrapper.ml
+++ b/lib/exec/test/test_exec_gate_env_wrapper.ml
@@ -17,7 +17,7 @@ let dev = [ "env"; "cat"; "ls"; "npm" ]
 let readonly = [ "env"; "cat"; "ls" ]
 
 let policy allowed =
-  { Gate.redirect_allowed = true;  allow_pipes = true }
+  { Gate.redirect_allowed = true; allowed_commands = allowed; allow_pipes = true }
 ;;
 
 let sandbox = { Gate.target = Sandbox_target.host () }

--- a/lib/exec_policy/exec_policy.ml
+++ b/lib/exec_policy/exec_policy.ml
@@ -232,13 +232,13 @@ let validate_command_name_with_allowlist ~allowed_commands = function
   | Some name -> Error (Command_not_allowed name)
 ;;
 
-let strict_allowlist_policy : Exec_shell_gate.allowlist_policy =
-  { allow_pipes = false; redirect_allowed = false }
+let strict_allowlist_policy ~allowed_commands : Exec_shell_gate.allowlist_policy =
+  { allowed_commands; allow_pipes = false; redirect_allowed = false }
 ;;
 
-let tool_execute_allowlist_policy ?(allow_pipes = true) ()
+let tool_execute_allowlist_policy ?(allow_pipes = true) ~allowed_commands ()
   : Exec_shell_gate.allowlist_policy =
-  { allow_pipes; redirect_allowed = false }
+  { allowed_commands; allow_pipes; redirect_allowed = false }
 ;;
 
 let rec shell_ir_literal_text = function
@@ -404,7 +404,7 @@ let command_context_with_allowlist ~allowed_commands ir =
   let verdict =
     Exec_shell_gate.gate_typed
       ~ir
-      ~allowlist:strict_allowlist_policy
+      ~allowlist:(strict_allowlist_policy ~allowed_commands)
       ~path_policy:Exec_shell_gate.allow_all_paths
       ~sandbox:Exec_shell_gate.host_sandbox
       ()
@@ -446,7 +446,7 @@ let command_context_tool_execute_with_allowlist
   let verdict =
     Exec_shell_gate.gate_typed
       ~ir
-      ~allowlist:(tool_execute_allowlist_policy ~allow_pipes ())
+      ~allowlist:(tool_execute_allowlist_policy ~allow_pipes ~allowed_commands ())
       ~path_policy:Exec_shell_gate.allow_all_paths
       ~sandbox:Exec_shell_gate.host_sandbox
       ()

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -601,6 +601,27 @@ let handle_tool_execute_typed
               ]
             ()
         else
+          let repo_sync_policy =
+            if write_enabled
+            then Keeper_sandbox_repo_lifecycle.Allow_repo_sync
+            else Keeper_sandbox_repo_lifecycle.Reject_repo_sync
+          in
+          let allow_stale_preserved_repo_context =
+            is_git_diagnostic_command || is_direct_repo_git_recovery
+          in
+          match
+            Keeper_sandbox_repo_lifecycle.validate_cwd_ready
+              ~repo_sync_policy
+              ~config
+              ~meta
+              ~cwd
+              ~allow_stale_preserved_repo_context
+          with
+          | Error e ->
+            error_json
+              ~fields:(("blocked_cmd", `String cmd_for_log) :: typed_error_fields)
+              e
+          | Ok () ->
           let allowed_commands =
             match mode with
             | Keeper_tool_execute_typed_input.Dev_full -> Exec_policy.dev_allowed_commands
@@ -617,6 +638,11 @@ let handle_tool_execute_typed
           let t0 = Unix.gettimeofday () in
           let dispatch_result =
             Keeper_tool_execute_shell_ir.dispatch_classified
+              ~before_path_validation:
+                (Keeper_sandbox_repo_lifecycle.validate_path_args_ready
+                   ~config
+                   ~meta
+                   ~cwd)
               ~allowed_commands
               ~keeper_id:meta.name
               ~base_path:root

--- a/lib/keeper_tooling/keeper_tool_execute_shell_ir.ml
+++ b/lib/keeper_tooling/keeper_tool_execute_shell_ir.ml
@@ -115,7 +115,7 @@ let dispatch_classified
   let gate_verdict =
     Shell_gate.gate_typed
       ~ir
-      ~allowlist:{ allow_pipes; redirect_allowed }
+      ~allowlist:{ allow_pipes; allowed_commands; redirect_allowed }
       ~path_policy:Shell_gate.forbid_masc_internal_state_paths
       ~sandbox:{ target = sandbox }
       ()

--- a/test/test_exec_shell_command_gate.ml
+++ b/test/test_exec_shell_command_gate.ml
@@ -25,7 +25,7 @@ let allowed = [ "rg"; "sort"; "head"; "wc"; "cat"; "git"; "ls" ]
 let gate_from_raw ~raw ~allowlist ~path_policy ~sandbox () =
   Gate.gate_raw ~text:raw ~allowlist ~path_policy ~sandbox ()
 let allowlist : Gate.allowlist_policy =
-  { redirect_allowed = false; allow_pipes = true }
+  { redirect_allowed = false; allowed_commands = allowed; allow_pipes = true }
 ;;
 
 (* {1 Baseline corpus} *)
@@ -282,7 +282,7 @@ let test_pipeline_segment_rejection_carries_stage_index () =
 
 let test_pipes_disabled () =
   let policy : Gate.allowlist_policy =
-    { redirect_allowed = false; allow_pipes = false }
+    { redirect_allowed = false; allowed_commands = allowed; allow_pipes = false }
   in
   match
     gate_from_raw


### PR DESCRIPTION
## Summary
- restore Shell_command_gate allowed_commands enforcement so Execute blocks non-allowlisted commands and disallowed pipeline stages again
- pass allowed_commands through Exec_policy and typed Shell IR dispatch
- run repo cwd readiness and repo path-arg readiness before Execute dispatch so stale/missing sandbox repo paths do not fall through to runtime

## Verification
- opam exec -- ocamlformat --check lib/exec/command_gate/shell_command_gate.ml lib/exec/command_gate/shell_command_gate.mli lib/exec/test/test_exec_gate_env_wrapper.ml lib/exec_policy/exec_policy.ml lib/keeper/keeper_tool_execute_runtime.ml lib/keeper_tooling/keeper_tool_execute_shell_ir.ml test/test_exec_shell_command_gate.ml
- opam exec -- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/add-dune-to-allowlist --build-dir _build-codex-add-dune-pr-direct --cache=disabled -j1 test/test_exec_shell_command_gate.exe test/test_keeper_tool_execute_safety.exe lib/exec/test/test_exec_gate_env_wrapper.exe
- ./_build-codex-add-dune-pr-direct/default/test/test_exec_shell_command_gate.exe
- ./_build-codex-add-dune-pr-direct/default/test/test_keeper_tool_execute_safety.exe
- ./_build-codex-add-dune-pr-direct/default/lib/exec/test/test_exec_gate_env_wrapper.exe