### PR TITLE
fix(keeper): yield turn semaphore during voice listen I/O

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -104,6 +104,7 @@ let run_turn
       ?(is_retry = false)
       ?shared_context
       ?event_bus
+      ?turn_slot_control
       ()
   : (run_result, Agent_sdk.Error.sdk_error) result
   =
@@ -364,6 +365,7 @@ let run_turn
       ~trajectory_acc
       ~tool_overlay
       ~runtime_manifest_context
+      ?turn_slot_control
       ()
   in
   (* Section 2: prepare runtime tools and hooks. *)

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -109,5 +109,6 @@ val run_turn
   -> ?is_retry:bool
   -> ?shared_context:Agent_sdk.Context.t
   -> ?event_bus:Agent_sdk.Event_bus.t
+  -> ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control
   -> unit
   -> (run_result, Agent_sdk.Error.sdk_error) result

--- a/lib/keeper/keeper_run_tools.mli
+++ b/lib/keeper/keeper_run_tools.mli
@@ -105,5 +105,6 @@ val prepare_agent_setup
   -> tool_overlay:Agent_sdk.Tool_op.t ref option
   -> ?runtime_manifest_context:Keeper_runtime_manifest.turn_context
   -> ?runtime_manifest_append:(Keeper_runtime_manifest.t -> unit)
+  -> ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control
   -> unit
   -> (agent_setup, Agent_sdk.Error.sdk_error) result

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -38,6 +38,7 @@ let prepare_agent_setup
       ~(tool_overlay : Agent_sdk.Tool_op.t ref option)
       ?runtime_manifest_context
       ?runtime_manifest_append
+      ?turn_slot_control
       ()
   : (Keeper_run_tools_hooks.agent_setup, Agent_sdk.Error.sdk_error) result
   =
@@ -127,6 +128,7 @@ let prepare_agent_setup
       ~search_fn:(fun ~query ~max_results -> !local_search_fn_ref ~query ~max_results)
       ~on_tool_called:(fun name ->
         Keeper_discovered_tools.mark_used acc.discovered ~turn:acc.current_turn ~name)
+      ?turn_slot_control
       ()
   in
   let extend_turns_tool = Keeper_extend_turns.make ~agent_ref ~max_turns () in

--- a/lib/keeper/keeper_tool_dispatch_runtime.ml
+++ b/lib/keeper/keeper_tool_dispatch_runtime.ml
@@ -294,6 +294,7 @@ let execute_keeper_tool_call_with_outcome
       ?proc_mgr
       ?net
       ?mcp_session_id
+      ?turn_slot_control
       ~(name : string)
       ~(input : Yojson.Safe.t)
       ()
@@ -410,6 +411,7 @@ let execute_keeper_tool_call_with_outcome
            ; proc_mgr
            ; net
            ; mcp_session_id
+           ; turn_slot_control
            }
        in
        let descriptor_output =
@@ -513,6 +515,7 @@ let execute_keeper_tool_call
       ?turn_sandbox_factory
       ~(exec_cache : Masc_exec.Exec_cache.t option)
       ?search_fn
+      ?turn_slot_control
       ~(name : string)
       ~(input : Yojson.Safe.t)
       ()
@@ -526,6 +529,7 @@ let execute_keeper_tool_call
                   ?turn_sandbox_factory
                   ~exec_cache
       ?search_fn
+      ?turn_slot_control
       ~name
       ~input
       ()

--- a/lib/keeper/keeper_tool_dispatch_runtime.mli
+++ b/lib/keeper/keeper_tool_dispatch_runtime.mli
@@ -156,6 +156,7 @@ val execute_keeper_tool_call_with_outcome
   -> ?proc_mgr:Eio_unix.Process.mgr_ty Eio.Resource.t
   -> ?net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> ?mcp_session_id:string
+  -> ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control
   -> name:string
   -> input:Yojson.Safe.t
   -> unit
@@ -168,6 +169,7 @@ val execute_keeper_tool_call
   -> ?turn_sandbox_factory:Keeper_sandbox_factory.t
   -> exec_cache:Masc_exec.Exec_cache.t option
   -> ?search_fn:(query:string -> max_results:int -> Yojson.Safe.t)
+  -> ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control
   -> name:string
   -> input:Yojson.Safe.t
   -> unit

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -92,8 +92,8 @@ let handle_ide_annotate ~config ~(meta : keeper_meta) ~args =
     ~args
 ;;
 
-let handle_voice ~config ~(meta : keeper_meta) ~name ~args =
-  Keeper_tool_voice_runtime.handle_voice_tool ~config ~meta ~name ~args
+let handle_voice ~config ~(meta : keeper_meta) ~name ~args ?turn_slot_control () =
+  Keeper_tool_voice_runtime.handle_voice_tool ~config ~meta ~name ~args ?turn_slot_control ()
 ;;
 
 let handle_task ~config ~(meta : keeper_meta) ~name ~args =

--- a/lib/keeper/keeper_tool_in_process_runtime.mli
+++ b/lib/keeper/keeper_tool_in_process_runtime.mli
@@ -61,6 +61,8 @@ val handle_voice
   -> meta:keeper_meta
   -> name:string
   -> args:Yojson.Safe.t
+  -> ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control
+  -> unit
   -> string
 
 (** [handle_task] dispatches to [Keeper_tool_task_runtime.handle_keeper_task_tool]

--- a/lib/keeper/keeper_tool_runtime.ml
+++ b/lib/keeper/keeper_tool_runtime.ml
@@ -22,6 +22,7 @@ type context =
   ; proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t option
   ; net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option
   ; mcp_session_id : string option
+  ; turn_slot_control : Keeper_turn_slot.keeper_turn_slot_control option
   }
 
 let descriptor_for_internal internal_name =
@@ -177,7 +178,9 @@ let handle_in_process ctx descriptor args =
          ~config:ctx.config
          ~meta:ctx.meta
          ~name
-         ~args)
+         ~args
+         ?turn_slot_control:ctx.turn_slot_control
+         ())
   | Tool_task_dispatch ->
     Some
       (Keeper_tool_in_process_runtime.handle_task

--- a/lib/keeper/keeper_tool_runtime.mli
+++ b/lib/keeper/keeper_tool_runtime.mli
@@ -21,6 +21,7 @@ type context =
   ; proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t option
   ; net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option
   ; mcp_session_id : string option
+  ; turn_slot_control : Keeper_turn_slot.keeper_turn_slot_control option
   }
 
 val descriptor_for_internal : string -> Keeper_tool_descriptor.t option

--- a/lib/keeper/keeper_tool_voice_runtime.ml
+++ b/lib/keeper/keeper_tool_voice_runtime.ml
@@ -153,22 +153,48 @@ let handle_speak
            (keeper_text_fallback_json ~agent_id:meta.name ~message)
            memory_status))
 
-let handle_listen ~(meta : keeper_meta) ~(args : Yojson.Safe.t) =
-  let timeout_sec = Safe_ops.json_float ~default:15.0 "timeout_seconds" args in
+let handle_listen ~(meta : keeper_meta) ~(args : Yojson.Safe.t) ?turn_slot_control () =
+  let timeout_sec = Safe_ops.json_float ~default:60.0 "timeout_seconds" args in
   let language_code = Safe_ops.json_string_opt "language_code" args in
-  match
-    Voice_bridge.record_and_transcribe
-      ~agent_id:meta.name
-      ~timeout_sec
-      ?language_code
-      ()
-  with
-  | Ok json -> Yojson.Safe.to_string json
-  | Error err ->
-    Tool_args.error_response_with
-      [ "error", `String err
-      ; "agent_id", `String meta.name
-      ]
+  let released =
+    match turn_slot_control with
+    | Some ctrl ->
+      ctrl.Keeper_turn_slot.release_for_retry ();
+      true
+    | None -> false
+  in
+  let result =
+    match
+      Voice_bridge.record_and_transcribe
+        ~agent_id:meta.name
+        ~timeout_sec
+        ?language_code
+        ()
+    with
+    | Ok json -> Yojson.Safe.to_string json
+    | Error err ->
+      Tool_args.error_response_with
+        [ "error", `String err
+        ; "agent_id", `String meta.name
+        ]
+  in
+  if released
+  then (
+    match turn_slot_control with
+    | Some ctrl ->
+      (match ctrl.Keeper_turn_slot.reacquire_after_retry () with
+       | Ok wait_ms ->
+         Log.Keeper.info
+           "%s: reacquired keeper turn slot after voice listen (wait_ms=%d)"
+           meta.name
+           wait_ms
+       | Error (`Semaphore_wait_timeout timeout) ->
+         Log.Keeper.warn
+           "%s: semaphore reacquire timeout after voice listen (waited %.0fs)"
+           meta.name
+           timeout.timeout_wait_sec)
+    | None -> ());
+  result
 
 let handle_agent ~(meta : keeper_meta) =
   match Voice_bridge.get_agent_voice ~agent_id:meta.name with
@@ -218,10 +244,12 @@ let handle
       ~(meta : keeper_meta)
       ~(command : voice_command)
       ~(args : Yojson.Safe.t)
+      ?turn_slot_control
+      ()
   =
   match command with
   | Speak -> handle_speak ~config ~meta ~args
-  | Listen -> handle_listen ~meta ~args
+  | Listen -> handle_listen ~meta ~args ?turn_slot_control ()
   | Agent -> handle_agent ~meta
   | Sessions -> handle_sessions ()
   | Session_start -> handle_session_start ~meta ~args
@@ -232,7 +260,9 @@ let handle_voice_tool
       ~(meta : keeper_meta)
       ~(name : string)
       ~(args : Yojson.Safe.t)
+      ?turn_slot_control
+      ()
   =
   match command_of_string name with
-  | Some command -> handle ~config ~meta ~command ~args
+  | Some command -> handle ~config ~meta ~command ~args ?turn_slot_control ()
   | None -> error_json ~fields:[ "tool", `String name ] "unknown_voice_tool"

--- a/lib/keeper/keeper_tool_voice_runtime.mli
+++ b/lib/keeper/keeper_tool_voice_runtime.mli
@@ -25,4 +25,6 @@ val handle_voice_tool :
   meta:Keeper_meta_contract.keeper_meta ->
   name:string ->
   args:Yojson.Safe.t ->
+  ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control ->
+  unit ->
   string

--- a/lib/keeper/keeper_tools_oas_bundle.ml
+++ b/lib/keeper/keeper_tools_oas_bundle.ml
@@ -32,6 +32,7 @@ let make_tool_bundle
       ?search_fn
       ?on_tool_called
       ?clock
+      ?turn_slot_control
       ()
   : tool_bundle
   =
@@ -113,6 +114,7 @@ let make_tool_bundle
                ?search_fn
                ?on_tool_called
                ?clock
+               ?turn_slot_control
                ~failure_counts
                ()
            in
@@ -167,6 +169,7 @@ let make_tool_bundle
                ?search_fn
                ?on_tool_called
                ?clock
+               ?turn_slot_control
                ~translate_input:descriptor.translate
                ~failure_counts
                ()

--- a/lib/keeper/keeper_tools_oas_handler.ml
+++ b/lib/keeper/keeper_tools_oas_handler.ml
@@ -22,6 +22,7 @@ let make_keeper_tool_handler
       ?search_fn
       ?on_tool_called
       ?clock
+      ?turn_slot_control
       ?(translate_input = fun j -> j)
       ~(failure_counts : failure_counts)
       ()
@@ -135,6 +136,7 @@ let make_keeper_tool_handler
                 ~exec_cache
               ?search_fn
               ?on_tool_called
+              ?turn_slot_control
               ~failure_counts
               ~key
               ~input
@@ -179,6 +181,7 @@ let make_keeper_tool_handler
                     ~exec_cache
                   ?search_fn
                   ?on_tool_called
+                  ?turn_slot_control
                   ~failure_counts
                   ~key
                   ~input

--- a/lib/keeper/keeper_tools_oas_handler_exec.ml
+++ b/lib/keeper/keeper_tools_oas_handler_exec.ml
@@ -93,6 +93,7 @@ let execute_with_observers
       ~(exec_cache : Masc_exec.Exec_cache.t option)
       ?search_fn
       ?on_tool_called
+      ?turn_slot_control
       ~(failure_counts : failure_counts)
       ~(key : string)
       ~(input : Yojson.Safe.t)
@@ -110,6 +111,7 @@ let execute_with_observers
             ?turn_sandbox_factory
             ~exec_cache
           ?search_fn
+          ?turn_slot_control
           ~name
           ~input
           ())

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -207,6 +207,7 @@ let run (ctx : ctx)
                ~is_retry
                ?shared_context
                ?event_bus:(Keeper_event_bus.get ())
+               ?turn_slot_control
                ()))
   in
   let rec retry_loop (input : retry_loop_input) =


### PR DESCRIPTION
## Problem

Voice listen (SoX rec) blocks for 15-60 seconds while holding the keeper turn semaphore. This starves other keepers waiting for turn slots, causing cascading semaphore wait timeouts (observed: 180s+ waits, keeper <tech_glutton> holding semaphore for 250s+).

## Root Cause

The turn semaphore was acquired at turn start and held for the entire duration, including long-blocking I/O operations like voice recording. The existing turn_slot_control interface (release_for_retry / reacquire_after_retry) existed but was only used for retry paths, not for I/O yield.

## Solution

Thread ?turn_slot_control through the full tool dispatch chain (16 files) so voice_listen can:

1. release_for_retry() before starting Voice_bridge.record_and_transcribe
2. Perform the blocking I/O without holding the semaphore
3. reacquire_after_retry() after I/O completes

## Changes

| File | Change |
|---|---|
| keeper_tool_voice_runtime.ml | Yield logic: release -> I/O -> reacquire; timeout 15->60s |
| keeper_tool_voice_runtime.mli | ?turn_slot_control in signature |
| keeper_tool_in_process_runtime.ml/i | Forward ?turn_slot_control |
| keeper_tool_runtime.ml/i | Add turn_slot_control to context record |
| keeper_tool_dispatch_runtime.ml/i | ?turn_slot_control in execute fns |
| keeper_tools_oas_handler_exec.ml | Forward ?turn_slot_control |
| keeper_tools_oas_handler.ml | Forward ?turn_slot_control |
| keeper_tools_oas_bundle.ml | Forward ?turn_slot_control |
| keeper_run_tools_setup.ml | Pass ?turn_slot_control to make_tool_bundle |
| keeper_agent_run.ml/i | ?turn_slot_control in run_turn |
| keeper_unified_turn_execution.ml | Pass turn_slot_control to run_turn |

## Verification

- dune build @check passes (exit 0)

## Related

- Semaphore starvation observed in keeper logs: semaphore_wait_ms=180000+, turn holders >250s

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
