### PR TITLE
[codex] Remove retry slot reacquire timeout state

### DIFF
--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -250,15 +250,11 @@ val set_budget_exhaustion_for_test :
     to [reset_budget_exhaustion]. *)
 
 type keeper_turn_slot_control = Keeper_turn_slot.keeper_turn_slot_control = {
-  release_for_retry : unit -> unit;
-  reacquire_after_retry :
-    unit ->
-    (int, [ `Semaphore_wait_timeout of Keeper_turn_slot.semaphore_wait_timeout ])
-      result;
+  is_held : unit -> bool;
 }
 
 (** Test-only wrapper around the keeper turn slot acquisition path with
-    explicit in-turn release/reacquire controls. *)
+    in-turn slot ownership observation. *)
 val with_keeper_turn_slot_control_for_test :
   ?runtime_profile:string ->
   keeper_name:string ->

--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -594,9 +594,7 @@ type keeper_turn_slot_state =
   }
 
 type keeper_turn_slot_control =
-  { release_for_retry : unit -> unit
-  ; reacquire_after_retry :
-      unit -> (int, [ `Semaphore_wait_timeout of semaphore_wait_timeout ]) result
+  { is_held : unit -> bool
   }
 
 let make_keeper_turn_slot_state () =
@@ -739,10 +737,6 @@ let release_keeper_turn_slot_impl ~keeper_name ~(stamp_autonomous_completion : b
 
 let release_keeper_turn_slot ~keeper_name state =
   release_keeper_turn_slot_impl ~keeper_name ~stamp_autonomous_completion:true state
-;;
-
-let release_keeper_turn_slot_for_retry ~keeper_name state =
-  release_keeper_turn_slot_impl ~keeper_name ~stamp_autonomous_completion:false state
 ;;
 
 (** Force-release every slot recorded for [keeper_name] in [holder_table].
@@ -1298,24 +1292,7 @@ let with_keeper_turn_slot_control ?(runtime_profile = "unknown") ~keeper_name ~c
             Ok semaphore_wait_ms))
   in
   let slot_control =
-    { release_for_retry =
-        (fun () ->
-          if keeper_turn_slot_is_held slot_state
-          then (
-            Log.Keeper.info
-              "%s: releasing keeper turn slot before degraded retry"
-              keeper_name;
-            release_keeper_turn_slot_for_retry ~keeper_name slot_state))
-    ; reacquire_after_retry =
-        (fun () ->
-          if keeper_turn_slot_is_held slot_state
-          then (
-            Log.Keeper.warn
-              "%s: retry slot reacquire requested while a slot is still held; releasing \
-               first"
-              keeper_name;
-            release_keeper_turn_slot_for_retry ~keeper_name slot_state);
-          acquire_all ())
+    { is_held = (fun () -> keeper_turn_slot_is_held slot_state)
     }
   in
   Eio_guard.protect

--- a/lib/keeper/keeper_turn_slot.mli
+++ b/lib/keeper/keeper_turn_slot.mli
@@ -233,10 +233,7 @@ val set_budget_exhaustion_for_test : keeper_name:string -> strikes:int -> unit
 type keeper_turn_slot_state
 
 type keeper_turn_slot_control = {
-  release_for_retry : unit -> unit;
-  reacquire_after_retry :
-    unit ->
-    (int, [ `Semaphore_wait_timeout of semaphore_wait_timeout ]) result;
+  is_held : unit -> bool;
 }
 
 val with_keeper_turn_slot_control :
@@ -254,7 +251,7 @@ val with_keeper_turn_slot :
   ('a, [> `Semaphore_wait_timeout of semaphore_wait_timeout ]) result
 
 (** Test-only wrapper around the keeper turn slot acquisition path with
-    explicit in-turn release/reacquire controls. *)
+    in-turn slot ownership observation. *)
 val with_keeper_turn_slot_control_for_test :
   ?runtime_profile:string ->
   keeper_name:string ->

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -92,7 +92,7 @@ let run (ctx : ctx)
       ; keeper_turn_id
       ; turn_id
       ; channel
-      ; turn_slot_control
+      ; turn_slot_control = _
       ; shared_context
       ; base_dir
       ; build_turn_prompt
@@ -531,15 +531,7 @@ let run (ctx : ctx)
              let productive_phase_elapsed_ms, retry_phase_elapsed_ms =
                current_turn_phase_elapsed_ms ()
              in
-             let slot_release_at_phase =
-               match turn_slot_control with
-               | Some slot_control ->
-                 slot_control.Keeper_turn_slot.release_for_retry ();
-                 Some Keeper_execution_receipt.Retry_scheduled
-               | None -> None
-             in
              record_runtime_rotation_attempt
-               ?slot_release_at_phase
                ~productive_phase_elapsed_ms
                ?retry_phase_elapsed_ms
                ~from_runtime:execution.runtime_id
@@ -569,49 +561,16 @@ let run (ctx : ctx)
                 | None -> "none")
                (short_preview (Agent_sdk.Error.to_string err));
              Eio.Fiber.yield ();
-             let run_retry_after_reacquire () =
-               retry_loop
-                 { run_meta
-                 ; execution = next_execution
-                 ; run_generation
-                 ; attempt = 1
-                 ; is_retry = true
-                 ; allow_degraded_wall_clock_retry_budget = true
-                 ; attempted_runtimes =
-                     next_execution_runtime_id :: attempted_runtimes
-                 }
-             in
-             (match turn_slot_control with
-              | None -> run_retry_after_reacquire ()
-              | Some slot_control ->
-                (match
-                   slot_control
-                     .Keeper_turn_slot.reacquire_after_retry
-                     ()
-                 with
-                 | Ok retry_semaphore_wait_ms ->
-                   Log.Keeper.info
-                     "%s: reacquired keeper turn slot for degraded \
-                      retry on runtime=%s wait_ms=%d"
-                     meta.name
-                     next_execution_runtime_id
-                     retry_semaphore_wait_ms;
-                   run_retry_after_reacquire ()
-                 | Error (`Semaphore_wait_timeout timeout) ->
-                   let slot_err =
-                     sdk_error_of_retry_slot_reacquire_timeout
-                       ~keeper_name:meta.name
-                       timeout
-                   in
-                   Log.Keeper.warn
-                     "%s: degraded retry to %s skipped because turn \
-                      slot reacquire timed out: %s"
-                     meta.name
-                     next_execution_runtime_id
-                     (short_preview
-                        (Agent_sdk.Error.to_string slot_err));
-                   mark_terminal_error slot_err;
-                   Error slot_err)))
+             retry_loop
+               { run_meta
+               ; execution = next_execution
+               ; run_generation
+               ; attempt = 1
+               ; is_retry = true
+               ; allow_degraded_wall_clock_retry_budget = true
+               ; attempted_runtimes =
+                   next_execution_runtime_id :: attempted_runtimes
+               })
         | Degraded_retry_budget_exhausted degraded_retry ->
           let productive_phase_elapsed_ms, retry_phase_elapsed_ms =
             current_turn_phase_elapsed_ms ()
@@ -698,55 +657,20 @@ let run (ctx : ctx)
               ; "phase", Keeper_oas_execution_error_phase.(to_label Recoverable_runtime_transient)
               ]
             ();
-          (* Release the outer turn slot for the duration of the transient
-             backoff so a stalled/retrying keeper does not hold a concurrency
-             slot it is not actively using. This matches the degraded-retry
-             path above (release_for_retry before the gap,
-             reacquire_after_retry before recursing). *)
-          (match turn_slot_control with
-           | Some slot_control ->
-             slot_control.Keeper_turn_slot.release_for_retry ()
-           | None -> ());
+          (* Retry backoff remains inside the same keeper turn slot.  The
+             delay is an observation, not an admission state that can produce
+             a second semaphore timeout while the original turn is still
+             logically active. *)
           Eio.Time.sleep clock delay;
-          let run_retry () =
-            retry_loop
-              { run_meta
-              ; execution
-              ; run_generation
-              ; attempt = attempt + 1
-              ; is_retry = true
-              ; allow_degraded_wall_clock_retry_budget = false
-              ; attempted_runtimes
-              }
-          in
-          (match turn_slot_control with
-           | None -> run_retry ()
-           | Some slot_control ->
-             (match
-                slot_control.Keeper_turn_slot.reacquire_after_retry ()
-              with
-              | Ok wait_ms ->
-                Log.Keeper.info
-                  "%s: reacquired keeper turn slot for transient retry on \
-                   runtime=%s wait_ms=%d"
-                  meta.name
-                  execution_runtime_id
-                  wait_ms;
-                run_retry ()
-              | Error (`Semaphore_wait_timeout timeout) ->
-                let slot_err =
-                  sdk_error_of_retry_slot_reacquire_timeout
-                    ~keeper_name:meta.name
-                    timeout
-                in
-                Log.Keeper.warn
-                  "%s: transient retry on runtime=%s skipped because turn \
-                   slot reacquire timed out: %s"
-                  meta.name
-                  execution_runtime_id
-                  (short_preview (Agent_sdk.Error.to_string slot_err));
-                mark_terminal_error slot_err;
-                Error slot_err))
+          retry_loop
+            { run_meta
+            ; execution
+            ; run_generation
+            ; attempt = attempt + 1
+            ; is_retry = true
+            ; allow_degraded_wall_clock_retry_budget = false
+            ; attempted_runtimes
+            }
         | No_degraded_retry when EC.is_context_overflow err ->
           let current_turn_event_bus =
             drain_turn_event_bus ~site:"context_overflow_capture" ()
@@ -790,7 +714,7 @@ let run (ctx : ctx)
      Long voice/OAS turns can keep making stream or tool progress beyond the
      legacy 600s cap. Runaway detection is owned by stream idle, provider
      attempt liveness, tool-level timeouts, max-turn limits, and the optional
-     supervisor stale-turn watchdog. Retry admission still consults the
+     supervisor stale-turn watchdog. Retry budgeting still consults the
      remaining turn budget between provider attempts. *)
   retry_loop
     { run_meta = meta

--- a/lib/keeper/keeper_unified_turn_types.ml
+++ b/lib/keeper/keeper_unified_turn_types.ml
@@ -45,26 +45,6 @@ let turn_event_bus_manifest_decision
     ]
 ;;
 
-(* Pure constructor for the SDK retry-timeout error wire shape. *)
-let sdk_error_of_retry_slot_reacquire_timeout
-      ~(keeper_name : string)
-      (timeout : Keeper_turn_slot.semaphore_wait_timeout)
-  =
-  let phase = Keeper_turn_slot.semaphore_wait_phase_to_string timeout.timeout_phase in
-  let holder_summary = Keeper_turn_slot.format_slot_holders timeout.timeout_holders in
-  Agent_sdk.Error.Api
-    (Agent_sdk.Retry.Timeout
-       { message =
-           Printf.sprintf
-             "keeper turn slot reacquire timed out after degraded retry (keeper=%s \
-              phase=%s wait=%.0fs holders=%s)"
-             keeper_name
-             phase
-             timeout.timeout_wait_sec
-             holder_summary
-       })
-;;
-
 let runtime_exhaustion_detail_code detail =
   let contains needle = String_util.contains_substring_ci detail needle in
   if contains "no_first_token"

--- a/lib/keeper/keeper_unified_turn_types.mli
+++ b/lib/keeper/keeper_unified_turn_types.mli
@@ -9,11 +9,6 @@
 val turn_event_bus_manifest_decision :
   Keeper_turn_runtime_budget.turn_event_bus_summary -> Yojson.Safe.t
 
-val sdk_error_of_retry_slot_reacquire_timeout :
-  keeper_name:string ->
-  Keeper_turn_slot.semaphore_wait_timeout ->
-  Agent_sdk.Error.sdk_error
-
 (** [registry_failure_reason_of_terminal_reason terminal ~raw_error]
     maps a [Keeper_turn_terminal.t] disposition to the corresponding
     [Keeper_registry.failure_reason], or [None] for benign terminals

--- a/test/test_keeper_turn_slot_holders.ml
+++ b/test/test_keeper_turn_slot_holders.ml
@@ -392,7 +392,7 @@ let test_force_released_autonomous_holder_does_not_stamp_completion () =
          "force-released autonomous holder stamped normal completion: delay=%.3f"
          delay)
 
-let test_retry_control_releases_and_reacquires_reactive_slot () =
+let test_retry_control_keeps_reactive_slot_in_same_turn () =
   let keeper_name = "diag-retry-reactive" in
   let turn_before = KK.turn_semaphore_value_for_test () in
   let reactive_before = KK.reactive_turn_semaphore_value_for_test () in
@@ -401,44 +401,30 @@ let test_retry_control_releases_and_reacquires_reactive_slot () =
       ~keeper_name
       ~channel:Masc.Keeper_world_observation.Reactive
       (fun ~semaphore_wait_ms:_ ~slot_control ->
-         assert_eq ~msg:"turn acquired before retry release"
+         assert_eq ~msg:"turn acquired before retry boundary"
            ~expected:(turn_before - 1)
            ~actual:(KK.turn_semaphore_value_for_test ());
-         assert_eq ~msg:"reactive acquired before retry release"
+         assert_eq ~msg:"reactive acquired before retry boundary"
            ~expected:(reactive_before - 1)
            ~actual:(KK.reactive_turn_semaphore_value_for_test ());
-         slot_control.release_for_retry ();
-         assert_eq ~msg:"turn restored during retry release"
-           ~expected:turn_before
+         if not (slot_control.is_held ()) then
+           failwith "retry control reported no held slot during active turn";
+         Eio.Fiber.yield ();
+         assert_eq ~msg:"turn remains held across retry boundary"
+           ~expected:(turn_before - 1)
            ~actual:(KK.turn_semaphore_value_for_test ());
-         assert_eq ~msg:"reactive restored during retry release"
-           ~expected:reactive_before
+         assert_eq ~msg:"reactive remains held across retry boundary"
+           ~expected:(reactive_before - 1)
            ~actual:(KK.reactive_turn_semaphore_value_for_test ());
          let names =
            List.map fst (KK.reactive_slot_holders ~now:(Time_compat.now ()))
          in
-         if List.mem keeper_name names then
-           failwith "reactive holder remained after retry release";
-         let nested =
-           KK.with_keeper_turn_slot_for_test
-             ~keeper_name:"diag-retry-reactive-peer"
-             ~channel:Masc.Keeper_world_observation.Reactive
-             (fun ~semaphore_wait_ms:_ -> ())
-         in
-         (match nested with
-          | Ok () -> ()
-          | Error (`Semaphore_wait_timeout _) ->
-              failwith "nested keeper could not acquire released slot");
-         (match slot_control.reacquire_after_retry () with
-          | Error (`Semaphore_wait_timeout _) ->
-              failwith "retry reacquire unexpectedly timed out"
-          | Ok retry_wait_ms when retry_wait_ms < 0 ->
-              failwith "retry reacquire returned negative wait"
-          | Ok _ -> ());
-         assert_eq ~msg:"turn reacquired after retry release"
+         if not (List.mem keeper_name names) then
+           failwith "reactive holder missing across retry boundary";
+         assert_eq ~msg:"turn still held before finalizer"
            ~expected:(turn_before - 1)
            ~actual:(KK.turn_semaphore_value_for_test ());
-         assert_eq ~msg:"reactive reacquired after retry release"
+         assert_eq ~msg:"reactive still held before finalizer"
            ~expected:(reactive_before - 1)
            ~actual:(KK.reactive_turn_semaphore_value_for_test ()))
   in
@@ -446,14 +432,14 @@ let test_retry_control_releases_and_reacquires_reactive_slot () =
    | Ok () -> ()
    | Error (`Semaphore_wait_timeout _) ->
        failwith "unexpected semaphore wait timeout in test");
-  assert_eq ~msg:"turn baseline after retry control finalizer"
+  assert_eq ~msg:"turn baseline after retry observation finalizer"
     ~expected:turn_before
     ~actual:(KK.turn_semaphore_value_for_test ());
-  assert_eq ~msg:"reactive baseline after retry control finalizer"
+  assert_eq ~msg:"reactive baseline after retry observation finalizer"
     ~expected:reactive_before
     ~actual:(KK.reactive_turn_semaphore_value_for_test ())
 
-let test_retry_control_autonomous_release_skips_completion_stamp () =
+let test_retry_control_keeps_autonomous_slot_in_same_turn () =
   let keeper_name = "diag-retry-autonomous" in
   let turn_before = KK.turn_semaphore_value_for_test () in
   let autonomous_before = KK.autonomous_turn_semaphore_value_for_test () in
@@ -462,18 +448,20 @@ let test_retry_control_autonomous_release_skips_completion_stamp () =
       ~keeper_name
       ~channel:Masc.Keeper_world_observation.Scheduled_autonomous
       (fun ~semaphore_wait_ms:_ ~slot_control ->
-         assert_eq ~msg:"turn acquired before autonomous retry release"
+         assert_eq ~msg:"turn acquired before autonomous retry boundary"
            ~expected:(turn_before - 1)
            ~actual:(KK.turn_semaphore_value_for_test ());
-         assert_eq ~msg:"autonomous acquired before retry release"
+         assert_eq ~msg:"autonomous acquired before retry boundary"
            ~expected:(autonomous_before - 1)
            ~actual:(KK.autonomous_turn_semaphore_value_for_test ());
-         slot_control.release_for_retry ();
-         assert_eq ~msg:"turn restored by autonomous retry release"
-           ~expected:turn_before
+         if not (slot_control.is_held ()) then
+           failwith "retry control reported no held autonomous slot";
+         Eio.Fiber.yield ();
+         assert_eq ~msg:"turn remains held across autonomous retry boundary"
+           ~expected:(turn_before - 1)
            ~actual:(KK.turn_semaphore_value_for_test ());
-         assert_eq ~msg:"autonomous restored by retry release"
-           ~expected:autonomous_before
+         assert_eq ~msg:"autonomous remains held across retry boundary"
+           ~expected:(autonomous_before - 1)
            ~actual:(KK.autonomous_turn_semaphore_value_for_test ());
          let delay =
            let ticket =
@@ -488,16 +476,12 @@ let test_retry_control_autonomous_release_skips_completion_stamp () =
          if delay <> 0.0 then
            failwith
              (Printf.sprintf
-                "retry release stamped normal autonomous completion: delay=%.3f"
+                "retry boundary stamped normal autonomous completion: delay=%.3f"
                 delay);
-         (match slot_control.reacquire_after_retry () with
-          | Error (`Semaphore_wait_timeout _) ->
-              failwith "autonomous retry reacquire unexpectedly timed out"
-          | Ok _ -> ());
-         assert_eq ~msg:"turn reacquired after autonomous retry release"
+         assert_eq ~msg:"turn still held before autonomous finalizer"
            ~expected:(turn_before - 1)
            ~actual:(KK.turn_semaphore_value_for_test ());
-         assert_eq ~msg:"autonomous reacquired after retry release"
+         assert_eq ~msg:"autonomous still held before finalizer"
            ~expected:(autonomous_before - 1)
            ~actual:(KK.autonomous_turn_semaphore_value_for_test ()))
   in
@@ -505,10 +489,10 @@ let test_retry_control_autonomous_release_skips_completion_stamp () =
    | Ok () -> ()
    | Error (`Semaphore_wait_timeout _) ->
        failwith "unexpected semaphore wait timeout in test");
-  assert_eq ~msg:"turn baseline after autonomous retry control"
+  assert_eq ~msg:"turn baseline after autonomous retry observation"
     ~expected:turn_before
     ~actual:(KK.turn_semaphore_value_for_test ());
-  assert_eq ~msg:"autonomous baseline after retry control"
+  assert_eq ~msg:"autonomous baseline after retry observation"
     ~expected:autonomous_before
     ~actual:(KK.autonomous_turn_semaphore_value_for_test ())
 
@@ -597,10 +581,10 @@ let () =
         test_force_release_marker_does_not_leak_to_replacement;
       "force released autonomous holder skips completion stamp",
         test_force_released_autonomous_holder_does_not_stamp_completion;
-      "retry control releases and reacquires reactive slot",
-        test_retry_control_releases_and_reacquires_reactive_slot;
-      "retry control autonomous release skips completion stamp",
-        test_retry_control_autonomous_release_skips_completion_stamp;
+      "retry control keeps reactive slot in same turn",
+        test_retry_control_keeps_reactive_slot_in_same_turn;
+      "retry control keeps autonomous slot in same turn",
+        test_retry_control_keeps_autonomous_slot_in_same_turn;
       "no-clock exhausted turn slot fails closed",
         test_no_clock_exhausted_turn_slot_fails_closed;
       "force release marker ttl bounds unfinalized fibers",


### PR DESCRIPTION
## Summary

- Remove retry-time release/reacquire controls from keeper turn slots.
- Keep degraded and transient retries inside the original keeper turn slot instead of creating a second semaphore admission point.
- Replace retry slot-control tests with assertions that retry boundaries preserve the active slot and only expose ownership observation.

## Why

A retry slot reacquire timeout was being surfaced as `api_error_timeout`, which made capacity pressure look like a provider/auth/DNS/runtime failure. Timeout should remain an observation, not a derived keeper/provider state transition.

## Validation

- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build --cache=disabled test/test_keeper_turn_slot_holders.exe`
- `_build/default/test/test_keeper_turn_slot_holders.exe`
- `git diff --check`