### PR TITLE
fix(keeper): prune stale active goal scopes

### DIFF
--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -279,7 +279,7 @@ spawn 시 인자로 직접 설정하는 필드.
 | `verify` | bool | `false` | 저비용 모델로 action 검증 | `masc_keeper_up`의 `verify` 인자 |
 | `sandbox_profile` | string | `local` | 실행 샌드박스 프로필 (`local`, `docker`). hard mode에서는 `docker`만 허용된다. | `masc_keeper_up`의 `sandbox_profile` 인자 |
 | `network_mode` | string | `inherit` 또는 `none` | 샌드박스 네트워크 정책. `docker`는 기본 `none`이고 hard mode에서는 `none`만 허용된다. | `masc_keeper_up`의 `network_mode` 인자 |
-| `active_goal_ids` | string[] | 없음 | 설정 시 `keeper_task_claim`이 goal-linked task만 claim. scoped pool에 현재 capability로 claim 가능한 task가 없으면 claim을 멈춘다. 전체 claimable task fallback은 없다. | `keeper.toml` 선언 |
+| `active_goal_ids` | string[] | 없음 | 설정 시 `keeper_task_claim`이 goal-linked task만 claim. scoped pool에 현재 capability로 claim 가능한 task가 없으면 claim을 멈춘다. 전체 claimable task fallback은 없다. 부트스트랩 reconcile은 goal store에 없는 stale id를 자동 제거한다. | `keeper.toml` 선언 |
 
 ### 3.1.1 Sandbox Core V1 사용법
 

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -125,6 +125,24 @@ let canonicalize_if_keeper config name =
     [Some v] from TOML overrides; [None] keeps the current runtime value. *)
 let apply_default opt current = match opt with Some v -> v | None -> current
 
+let prune_unknown_active_goal_ids config ~keeper_name active_goal_ids =
+  match active_goal_ids with
+  | [] -> []
+  | ids ->
+    let known_goal_ids =
+      Goal_store.list_goals config ()
+      |> List.map (fun (goal : Goal_store.goal) -> goal.id)
+    in
+    let kept, missing =
+      List.partition (fun goal_id -> List.mem goal_id known_goal_ids) ids
+    in
+    if missing <> [] then
+      Log.Keeper.warn
+        "ensure_keeper_meta: pruning unknown active_goal_ids for %s: %s"
+        keeper_name
+        (String.concat ", " missing);
+    kept
+
 (** Same as [apply_default] but both TOML and meta are option-typed. *)
 let apply_default_opt opt current = match opt with Some _ -> opt | None -> current
 
@@ -200,7 +218,9 @@ let ensure_keeper_meta config name =
     let target_mention_targets =
       match defaults.mention_targets with [] -> meta.mention_targets | xs -> xs in
     let target_active_goal_ids =
-      apply_default defaults.active_goal_ids meta.active_goal_ids in
+      apply_default defaults.active_goal_ids meta.active_goal_ids
+      |> prune_unknown_active_goal_ids config ~keeper_name:meta.name
+    in
     (* Defense-in-depth (#11080 sibling): keeper sandbox_profile MUST be
        declared. The previous behaviour silently fell through to
        [default_sandbox_profile = Local] when TOML omitted the key,

--- a/lib/keeper/keeper_tools_oas_bundle.ml
+++ b/lib/keeper/keeper_tools_oas_bundle.ml
@@ -203,9 +203,18 @@ let make_tools
       ?search_fn
       ?on_tool_called
       ?clock
+      ?turn_slot_control
       ()
   : Agent_sdk.Tool.t list
   =
-  (make_tool_bundle ~config ~meta ~ctx_snapshot ?search_fn ?on_tool_called ?clock ())
+  (make_tool_bundle
+     ~config
+     ~meta
+     ~ctx_snapshot
+     ?search_fn
+     ?on_tool_called
+     ?clock
+     ?turn_slot_control
+     ())
     .tools
 ;;

--- a/lib/keeper/keeper_tools_oas_bundle.mli
+++ b/lib/keeper/keeper_tools_oas_bundle.mli
@@ -11,6 +11,7 @@ val make_tool_bundle
   -> ?search_fn:(query:string -> max_results:int -> Yojson.Safe.t)
   -> ?on_tool_called:(string -> unit)
   -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
+  -> ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control
   -> unit
   -> Keeper_tools_oas.tool_bundle
 
@@ -22,5 +23,6 @@ val make_tools
   -> ?search_fn:(query:string -> max_results:int -> Yojson.Safe.t)
   -> ?on_tool_called:(string -> unit)
   -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
+  -> ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control
   -> unit
   -> Agent_sdk.Tool.t list

--- a/lib/keeper/keeper_tools_oas_handler.mli
+++ b/lib/keeper/keeper_tools_oas_handler.mli
@@ -26,6 +26,7 @@ val make_keeper_tool_handler
   -> ?search_fn:(query:string -> max_results:int -> Yojson.Safe.t)
   -> ?on_tool_called:(string -> unit)
   -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
+  -> ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control
   -> ?translate_input:(Yojson.Safe.t -> Yojson.Safe.t)
   -> failure_counts:Keeper_tools_oas.failure_counts
   -> unit

--- a/lib/keeper/keeper_tools_oas_handler_exec.mli
+++ b/lib/keeper/keeper_tools_oas_handler_exec.mli
@@ -16,6 +16,7 @@ val execute_with_observers
   -> exec_cache:Masc_exec.Exec_cache.t option
   -> ?search_fn:(query:string -> max_results:int -> Yojson.Safe.t)
   -> ?on_tool_called:(string -> unit)
+  -> ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control
   -> failure_counts:Keeper_tools_oas.failure_counts
   -> key:string
   -> input:Yojson.Safe.t

--- a/test/test_keeper_runtime_denylist.ml
+++ b/test/test_keeper_runtime_denylist.ml
@@ -140,7 +140,7 @@ tool_denylist = ["toml-tool-x", "toml-tool-y"]
           check int "no TOML-only write bump" (initial_meta.meta_version + 1)
             persisted.Keeper_meta_contract.meta_version))
 
-let test_ensure_keeper_meta_persists_active_goal_ids () =
+let test_ensure_keeper_meta_prunes_unknown_active_goal_ids () =
   with_runtime_default @@ fun () ->
   with_temp_dir "keeper-runtime-active-goal-workspace" @@ fun workspace_dir ->
   with_config_dir @@ fun config_dir ->
@@ -155,9 +155,12 @@ let test_ensure_keeper_meta_persists_active_goal_ids () =
     {|[keeper]
 goal = "Test active goal resync"
 sandbox_profile = "local"
-active_goal_ids = ["goal-runtime"]
+active_goal_ids = ["goal-runtime", "goal-ghost"]
 |};
   let config = Workspace.default_config workspace_dir in
+  (match Goal_store.upsert_goal config ~id:"goal-runtime" ~title:"Runtime goal" () with
+  | Ok _ -> ()
+  | Error e -> fail ("upsert_goal failed: " ^ e));
   let initial_meta =
     match
       Masc_test_deps.meta_of_json_fixture
@@ -179,7 +182,7 @@ active_goal_ids = ["goal-runtime"]
   | Ok updated ->
       check
         (list string)
-        "returned meta active_goal_ids overlaid from TOML"
+        "returned meta active_goal_ids pruned to known TOML goals"
         [ "goal-runtime" ]
         updated.Keeper_meta_contract.active_goal_ids;
       (match Keeper_meta_store.read_meta config keeper_name with
@@ -188,7 +191,7 @@ active_goal_ids = ["goal-runtime"]
       | Ok (Some persisted) ->
           check
             (list string)
-            "persisted meta keeps active_goal_ids"
+            "persisted meta prunes unknown active_goal_ids"
             [ "goal-runtime" ]
             persisted.Keeper_meta_contract.active_goal_ids;
           check int "persisted write bumps meta_version"
@@ -205,8 +208,8 @@ let () =
             `Quick
             test_ensure_keeper_meta_overlays_denylist_from_toml;
           test_case
-            "persists active_goal_ids from TOML on bootstrap"
+            "prunes unknown active_goal_ids from TOML on bootstrap"
             `Quick
-            test_ensure_keeper_meta_persists_active_goal_ids;
+            test_ensure_keeper_meta_prunes_unknown_active_goal_ids;
         ] );
     ]


### PR DESCRIPTION
## Summary

- prune stale `active_goal_ids` during `ensure_keeper_meta` reconcile when the goal id no longer exists in `Goal_store`
- keep explicit `keeper_up active_goal_ids` strict validation unchanged, while preventing persisted/TOML ghost ids from re-entering the claim gate on bootstrap
- update keeper docs for bootstrap reconcile behavior
- fix latest-main OAS tool signature drift by threading `?turn_slot_control` through the public `.mli` surfaces and `make_tools`

## Why

Ghost `active_goal_ids` can hard-block keeper task claiming even after the referenced goal has been removed from the goal store. Manual live JSON/TOML cleanup works as an emergency recovery, but the runtime should not require operator edits for stale persisted state.

The deterministic cleanup point is `ensure_keeper_meta`, because that is where TOML defaults and persisted keeper meta are reconciled before the claim gate reads `meta.active_goal_ids`. `Goal_store` remains the SSOT: ids not present there are stale references and are pruned with a keeper warning.

## Verification

- `ocamlformat --check lib/keeper/keeper_runtime.ml test/test_keeper_runtime_denylist.ml lib/keeper/keeper_tools_oas_handler_exec.mli lib/keeper/keeper_tools_oas_handler.mli lib/keeper/keeper_tools_oas_bundle.mli lib/keeper/keeper_tools_oas_bundle.ml`
- `git diff --check origin/main...HEAD`
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=/private/tmp/masc-dune-active-goal-ghost-rebase-20260606c dune build --root . test/test_keeper_runtime_denylist.exe`
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=/private/tmp/masc-dune-active-goal-ghost-rebase-20260606c dune exec --root . test/test_keeper_runtime_denylist.exe`
