### PR TITLE
fix(keeper): expose turn slot control signatures

### DIFF
--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -251,6 +251,10 @@ val set_budget_exhaustion_for_test :
 
 type keeper_turn_slot_control = Keeper_turn_slot.keeper_turn_slot_control = {
   is_held : unit -> bool;
+  release_for_retry : unit -> unit;
+  reacquire_after_retry :
+    unit ->
+    (int, [ `Semaphore_wait_timeout of Keeper_turn_slot.semaphore_wait_timeout ]) result;
 }
 
 (** Test-only wrapper around the keeper turn slot acquisition path with

--- a/lib/keeper/keeper_tools_oas_bundle.mli
+++ b/lib/keeper/keeper_tools_oas_bundle.mli
@@ -11,6 +11,7 @@ val make_tool_bundle
   -> ?search_fn:(query:string -> max_results:int -> Yojson.Safe.t)
   -> ?on_tool_called:(string -> unit)
   -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
+  -> ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control
   -> unit
   -> Keeper_tools_oas.tool_bundle
 

--- a/lib/keeper/keeper_tools_oas_handler.mli
+++ b/lib/keeper/keeper_tools_oas_handler.mli
@@ -26,6 +26,7 @@ val make_keeper_tool_handler
   -> ?search_fn:(query:string -> max_results:int -> Yojson.Safe.t)
   -> ?on_tool_called:(string -> unit)
   -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
+  -> ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control
   -> ?translate_input:(Yojson.Safe.t -> Yojson.Safe.t)
   -> failure_counts:Keeper_tools_oas.failure_counts
   -> unit

--- a/lib/keeper/keeper_tools_oas_handler_exec.mli
+++ b/lib/keeper/keeper_tools_oas_handler_exec.mli
@@ -16,6 +16,7 @@ val execute_with_observers
   -> exec_cache:Masc_exec.Exec_cache.t option
   -> ?search_fn:(query:string -> max_results:int -> Yojson.Safe.t)
   -> ?on_tool_called:(string -> unit)
+  -> ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control
   -> failure_counts:Keeper_tools_oas.failure_counts
   -> key:string
   -> input:Yojson.Safe.t

--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -595,6 +595,9 @@ type keeper_turn_slot_state =
 
 type keeper_turn_slot_control =
   { is_held : unit -> bool
+  ; release_for_retry : unit -> unit
+  ; reacquire_after_retry :
+      unit -> (int, [ `Semaphore_wait_timeout of semaphore_wait_timeout ]) result
   }
 
 let make_keeper_turn_slot_state () =
@@ -1293,6 +1296,21 @@ let with_keeper_turn_slot_control ?(runtime_profile = "unknown") ~keeper_name ~c
   in
   let slot_control =
     { is_held = (fun () -> keeper_turn_slot_is_held slot_state)
+    ; release_for_retry =
+        (fun () ->
+           release_keeper_turn_slot_impl
+             ~keeper_name
+             ~stamp_autonomous_completion:false
+             slot_state)
+    ; reacquire_after_retry =
+        (fun () ->
+           if keeper_turn_slot_is_held slot_state
+           then Ok 0
+           else
+             match acquire_all () with
+             | Ok wait_ms -> Ok wait_ms
+             | Error (`Semaphore_wait_timeout timeout) ->
+               Error (`Semaphore_wait_timeout timeout))
     }
   in
   Eio_guard.protect

--- a/lib/keeper/keeper_turn_slot.mli
+++ b/lib/keeper/keeper_turn_slot.mli
@@ -234,6 +234,9 @@ type keeper_turn_slot_state
 
 type keeper_turn_slot_control = {
   is_held : unit -> bool;
+  release_for_retry : unit -> unit;
+  reacquire_after_retry :
+    unit -> (int, [ `Semaphore_wait_timeout of semaphore_wait_timeout ]) result;
 }
 
 val with_keeper_turn_slot_control :

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -92,7 +92,7 @@ let run (ctx : ctx)
       ; keeper_turn_id
       ; turn_id
       ; channel
-      ; turn_slot_control = _
+      ; turn_slot_control
       ; shared_context
       ; base_dir
       ; build_turn_prompt

--- a/test/test_voice_runtime_overlay.ml
+++ b/test/test_voice_runtime_overlay.ml
@@ -230,6 +230,7 @@ let test_keeper_voice_speak_returns_queued_with_root_switch () =
         ~meta
         ~name:"keeper_voice_speak"
         ~args:(`Assoc [ "message", `String "hello from queued voice test" ])
+        ()
     in
     let json = Yojson.Safe.from_string raw in
     check string "queued status" "queued"
@@ -255,11 +256,12 @@ let test_keeper_voice_speak_records_memory_bank_row () =
     let message = "spoken memory should be durable" in
     let raw =
       Masc.Keeper_tool_voice_runtime.handle_voice_tool
-        ~config
-        ~meta
-        ~name:"keeper_voice_speak"
-        ~args:(`Assoc [ "message", `String message; "priority", `Int 3 ])
-    in
+      ~config
+      ~meta
+      ~name:"keeper_voice_speak"
+      ~args:(`Assoc [ "message", `String message; "priority", `Int 3 ])
+      ()
+  in
     let json = Yojson.Safe.from_string raw in
     check bool "memory recorded" true
       Yojson.Safe.Util.(member "memory_recorded" json |> to_bool);
@@ -294,10 +296,11 @@ let test_keeper_voice_speak_text_fallback_records_memory_bank_row () =
   let message = "fallback speech should be durable" in
   let raw =
     Masc.Keeper_tool_voice_runtime.handle_voice_tool
-      ~config
-      ~meta
-      ~name:"keeper_voice_speak"
-      ~args:(`Assoc [ "message", `String message ])
+    ~config
+    ~meta
+    ~name:"keeper_voice_speak"
+    ~args:(`Assoc [ "message", `String message ])
+    ()
   in
   let json = Yojson.Safe.from_string raw in
   check string "text fallback status" "text_fallback"
@@ -341,6 +344,7 @@ let test_keeper_voice_session_start_does_not_store_session_name_as_voice () =
         ~meta
         ~name:"keeper_voice_session_start"
         ~args:(`Assoc [ "session_name", `String session_name ])
+        ()
     in
     let json = Yojson.Safe.from_string raw in
     let voice = Yojson.Safe.Util.(member "voice" json |> to_string) in
@@ -351,7 +355,8 @@ let test_keeper_voice_session_start_does_not_store_session_name_as_voice () =
          ~config
          ~meta
          ~name:"keeper_voice_session_end"
-         ~args:(`Assoc [])))
+         ~args:(`Assoc [])
+         ()))
 ;;
 
 let test_keeper_voice_session_end_discards_queued_speech () =
@@ -370,7 +375,8 @@ let test_keeper_voice_session_end_discards_queued_speech () =
          ~config
          ~meta
          ~name:"keeper_voice_session_start"
-         ~args:(`Assoc [ "session_name", `String "drain regression" ]));
+         ~args:(`Assoc [ "session_name", `String "drain regression" ])
+         ());
     let queued =
       Masc.Voice_bridge.enqueue_agent_speak
         ~sw
@@ -392,6 +398,7 @@ let test_keeper_voice_session_end_discards_queued_speech () =
         ~meta
         ~name:"keeper_voice_session_end"
         ~args:(`Assoc [])
+        ()
     in
     let end_json = Yojson.Safe.from_string end_raw in
     check string "session ended" "ended"


### PR DESCRIPTION
Summary:\n- expose turn_slot_control through OAS handler/bundle interfaces\n- add voice retry release/reacquire operations to keeper_turn_slot_control\n- pass turn_slot_control through unified turn execution\n\nVerification:\n- git diff --check\n- dune build --root . --build-dir _build-codex-turn-slot-fix -j1 bin/main_eio.exe