### PR TITLE
[codex] reuse existing keeper worktree branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@
   /`board.commented` activity-polling auto-push (previously done by
   the sidecar) is dropped — re-add as a follow-up if needed.
 
+### Fixed
+- `tool_execute` now turns git's "branch is already used by worktree"
+  failure from `git worktree add` into an idempotent success that
+  reuses the existing worktree path, instead of gating keeper progress
+  behind the same failing command.
+
 ### Removed
 - RFC-0151 withdrawn: the code-smell monotone ratchet is removed
   (`scripts/code-smell/measure.sh`, `scripts/lint/godfile-size-regression.sh`,

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -103,6 +103,7 @@ let run_turn
       ?(runtime_rotation_attempts = [])
       ?(is_retry = false)
       ?shared_context
+      ?turn_slot_control
       ?event_bus
       ()
   : (run_result, Agent_sdk.Error.sdk_error) result
@@ -361,6 +362,7 @@ let run_turn
       ~approval_mode_effective
       ~approval_mode_derived
       ?max_cost_usd
+      ?turn_slot_control
       ~trajectory_acc
       ~tool_overlay
       ~runtime_manifest_context

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -108,6 +108,7 @@ val run_turn
   -> ?runtime_rotation_attempts:Keeper_execution_receipt.runtime_rotation_attempt list
   -> ?is_retry:bool
   -> ?shared_context:Agent_sdk.Context.t
+  -> ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control
   -> ?event_bus:Agent_sdk.Event_bus.t
   -> unit
   -> (run_result, Agent_sdk.Error.sdk_error) result

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -383,7 +383,7 @@ let run_keepalive_unified_turn
             ~runtime_profile:(runtime_id_of_meta meta_after_triage)
             ~keeper_name:meta_after_triage.name
             ~channel:turn_decision.channel
-            (fun ~semaphore_wait_ms ->
+            (fun ~semaphore_wait_ms ~slot_control ->
                run_keeper_cycle_with_slot
                  ~ctx
                  ~meta_after_cursor_persist
@@ -392,6 +392,7 @@ let run_keepalive_unified_turn
                  ~turn_decision
                  ~shared_context
                  ~semaphore_wait_ms
+                 ~slot_control
                  ())
         with
         | Ok meta -> meta

--- a/lib/keeper/keeper_heartbeat_loop_cycle_with_slot.ml
+++ b/lib/keeper/keeper_heartbeat_loop_cycle_with_slot.ml
@@ -47,6 +47,7 @@ let run_keeper_cycle_with_slot
       ~(turn_decision : Keeper_world_observation.keeper_cycle_decision)
       ~shared_context
       ~semaphore_wait_ms
+      ~slot_control
       ()
   =
   match
@@ -58,6 +59,7 @@ let run_keeper_cycle_with_slot
         ~generation:meta_after_cursor_persist.runtime.generation
         ~channel:turn_decision.channel
         ~semaphore_wait_ms
+        ~turn_slot_control:slot_control
         ~shared_context
         ())
   with

--- a/lib/keeper/keeper_heartbeat_loop_cycle_with_slot.mli
+++ b/lib/keeper/keeper_heartbeat_loop_cycle_with_slot.mli
@@ -8,5 +8,6 @@ val run_keeper_cycle_with_slot
   -> turn_decision:Keeper_world_observation.keeper_cycle_decision
   -> shared_context:Agent_sdk.Context.t
   -> semaphore_wait_ms:int
+  -> slot_control:Keeper_turn_slot.keeper_turn_slot_control
   -> unit
   -> Keeper_meta_contract.keeper_meta

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -249,6 +249,23 @@ val set_budget_exhaustion_for_test :
 (** Test-only: pre-load strike count.  [strikes <= 0] is equivalent
     to [reset_budget_exhaustion]. *)
 
+type keeper_turn_slot_control = Keeper_turn_slot.keeper_turn_slot_control = {
+  is_held : unit -> bool;
+  release_for_retry : unit -> unit;
+  reacquire_after_retry :
+    unit ->
+    (int, [ `Semaphore_wait_timeout of Keeper_turn_slot.semaphore_wait_timeout ]) result;
+}
+
+(** Test-only wrapper around the keeper turn slot acquisition path with
+    in-turn slot ownership observation. *)
+val with_keeper_turn_slot_control_for_test :
+  ?runtime_profile:string ->
+  keeper_name:string ->
+  channel:Keeper_world_observation.keeper_cycle_channel ->
+  (semaphore_wait_ms:int -> slot_control:keeper_turn_slot_control -> 'a) ->
+  ('a, [> `Semaphore_wait_timeout of semaphore_wait_timeout ]) result
+
 (** Test-only wrapper around the keeper turn slot acquisition path. *)
 val with_keeper_turn_slot_for_test :
   ?runtime_profile:string ->

--- a/lib/keeper/keeper_run_tools.mli
+++ b/lib/keeper/keeper_run_tools.mli
@@ -101,6 +101,7 @@ val prepare_agent_setup
   -> approval_mode_effective:string option
   -> approval_mode_derived:bool
   -> ?max_cost_usd:float
+  -> ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control
   -> trajectory_acc:Trajectory.accumulator option
   -> tool_overlay:Agent_sdk.Tool_op.t ref option
   -> ?runtime_manifest_context:Keeper_runtime_manifest.turn_context

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -34,6 +34,7 @@ let prepare_agent_setup
       ~(approval_mode_effective : string option)
       ~(approval_mode_derived : bool)
       ?max_cost_usd
+      ?turn_slot_control
       ~(trajectory_acc : Trajectory.accumulator option)
       ~(tool_overlay : Agent_sdk.Tool_op.t ref option)
       ?runtime_manifest_context
@@ -127,6 +128,7 @@ let prepare_agent_setup
       ~search_fn:(fun ~query ~max_results -> !local_search_fn_ref ~query ~max_results)
       ~on_tool_called:(fun name ->
         Keeper_discovered_tools.mark_used acc.discovered ~turn:acc.current_turn ~name)
+      ?turn_slot_control
       ()
   in
   let extend_turns_tool = Keeper_extend_turns.make ~agent_ref ~max_turns () in

--- a/lib/keeper/keeper_tool_dispatch_runtime.ml
+++ b/lib/keeper/keeper_tool_dispatch_runtime.ml
@@ -294,6 +294,7 @@ let execute_keeper_tool_call_with_outcome
       ?proc_mgr
       ?net
       ?mcp_session_id
+      ?turn_slot_control
       ~(name : string)
       ~(input : Yojson.Safe.t)
       ()
@@ -410,6 +411,7 @@ let execute_keeper_tool_call_with_outcome
            ; proc_mgr
            ; net
            ; mcp_session_id
+           ; turn_slot_control
            }
        in
        let descriptor_output =

--- a/lib/keeper/keeper_tool_dispatch_runtime.mli
+++ b/lib/keeper/keeper_tool_dispatch_runtime.mli
@@ -156,6 +156,7 @@ val execute_keeper_tool_call_with_outcome
   -> ?proc_mgr:Eio_unix.Process.mgr_ty Eio.Resource.t
   -> ?net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> ?mcp_session_id:string
+  -> ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control
   -> name:string
   -> input:Yojson.Safe.t
   -> unit

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -11,6 +11,139 @@ let elapsed_duration_ms ~start_time ~end_time =
   | _ when elapsed_ms < 1. -> 1
   | _ -> int_of_float elapsed_ms
 
+type git_worktree_branch_conflict =
+  { branch : string
+  ; worktree_path : string
+  }
+
+let substring_index_from haystack needle start =
+  let haystack_len = String.length haystack in
+  let needle_len = String.length needle in
+  if needle_len = 0
+  then Some start
+  else if start < 0 || start > haystack_len
+  then None
+  else
+    let rec loop index =
+      if index + needle_len > haystack_len
+      then None
+      else if String.equal (String.sub haystack index needle_len) needle
+      then Some index
+      else loop (index + 1)
+    in
+    loop start
+;;
+
+let git_worktree_branch_conflict_of_line line =
+  let prefix = "fatal: '" in
+  let marker = "' is already used by worktree at '" in
+  match substring_index_from line prefix 0 with
+  | None -> None
+  | Some prefix_index ->
+    let branch_start = prefix_index + String.length prefix in
+    (match substring_index_from line marker branch_start with
+     | None -> None
+     | Some marker_index ->
+       let path_start = marker_index + String.length marker in
+       (match String.index_from_opt line path_start '\'' with
+        | None -> None
+        | Some path_end ->
+          let branch =
+            String.sub line branch_start (marker_index - branch_start)
+            |> String.trim
+          in
+          let worktree_path =
+            String.sub line path_start (path_end - path_start) |> String.trim
+          in
+          if String.equal branch "" || String.equal worktree_path ""
+          then None
+          else Some { branch; worktree_path }))
+;;
+
+let git_worktree_branch_conflict stderr =
+  stderr
+  |> String.split_on_char '\n'
+  |> List.find_map git_worktree_branch_conflict_of_line
+;;
+
+let git_global_option_takes_value = function
+  | "-C"
+  | "-c"
+  | "--exec-path"
+  | "--git-dir"
+  | "--work-tree"
+  | "--namespace"
+  | "--super-prefix"
+  | "--config-env" -> true
+  | _ -> false
+
+let git_global_option_has_inline_value token =
+  String.starts_with ~prefix:"-C" token && String.length token > 2
+  || String.starts_with ~prefix:"--exec-path=" token
+  || String.starts_with ~prefix:"--git-dir=" token
+  || String.starts_with ~prefix:"--work-tree=" token
+  || String.starts_with ~prefix:"--namespace=" token
+  || String.starts_with ~prefix:"--super-prefix=" token
+  || String.starts_with ~prefix:"--config-env=" token
+
+let rec git_subcommand_args = function
+  | [] -> []
+  | token :: rest when git_global_option_takes_value token ->
+    (match rest with
+     | _value :: tail -> git_subcommand_args tail
+     | [] -> [])
+  | token :: rest when git_global_option_has_inline_value token ->
+    git_subcommand_args rest
+  | token :: rest when String.starts_with ~prefix:"-" token ->
+    git_subcommand_args rest
+  | rest -> rest
+
+let ir_is_git_worktree_add ir =
+  match Masc_exec.Shell_ir_command_shape.effective_stages ir with
+  | [ stage ]
+    when String.equal
+           (Masc_exec.Shell_ir_command_shape.normalize_command_name stage.bin)
+           "git" ->
+    (match git_subcommand_args stage.args with
+     | "worktree" :: "add" :: _ -> true
+     | _ -> false)
+  | _ -> false
+
+let idempotent_worktree_add_reuse ir status stderr =
+  match status, git_worktree_branch_conflict stderr with
+  | Unix.WEXITED 128, Some conflict when ir_is_git_worktree_add ir ->
+    Some conflict
+  | _ -> None
+
+let git_worktree_reuse_fields { branch; worktree_path } =
+  let recovery_hint =
+    Printf.sprintf
+      "Branch %S is already checked out by an existing worktree. The worktree \
+       add request was treated as idempotent; continue with cwd=%S."
+      branch
+      worktree_path
+  in
+  [ "git_worktree_branch_already_used", `Bool true
+  ; "worktree_reused", `Bool true
+  ; "branch", `String branch
+  ; "existing_worktree_path", `String worktree_path
+  ; "reuse_cwd", `String worktree_path
+  ; "recovery_hint", `String recovery_hint
+  ; ( "alternatives"
+    , `List
+        [ `String (Printf.sprintf "Set cwd to %s and continue there." worktree_path)
+        ; `String "Choose a unique branch/worktree name only when a separate lane is required."
+        ] )
+  ]
+
+let git_worktree_reuse_output { branch; worktree_path } =
+  Printf.sprintf
+    "Worktree already exists: %s\nBranch already checked out: %s\nUse cwd=%S \
+     for follow-up Execute calls.\n"
+    worktree_path
+    branch
+    worktree_path
+
 (* Pre-dispatch path existence validation for typed commands.
    Uses Shell_ir_typed GADT path annotations (exhaustive, no
    string heuristics). Only validates Safe (read-only) Simple
@@ -439,14 +572,33 @@ let handle_tool_execute_typed
                 ~stderr:result.stderr
             in
             let classification = Exec_core.classify_command_of_ir ir in
+            let worktree_reuse = idempotent_worktree_add_reuse ir result.status result.stderr in
             (* Only include command_descriptor on success — errors already carry
                sufficient diagnostic info (exit code, stderr, classification). *)
             let descriptor_fields =
-              match result.status with
-              | Unix.WEXITED 0 ->
+              match result.status, worktree_reuse with
+              | Unix.WEXITED 0, _ | _, Some _ ->
                 let descriptor = Ide_command_descriptor.compute ir in
                 [ "command_descriptor", Ide_event_types.command_descriptor_to_json descriptor ]
-              | _ -> []
+              | _, None -> []
+            in
+            let status, output, worktree_reuse_fields =
+              match worktree_reuse with
+              | None -> result.status, output, []
+              | Some conflict ->
+                Log.Keeper.info
+                  "shell_ir worktree_reuse keeper=%s branch=%s existing_worktree=%s"
+                  meta.name
+                  conflict.branch
+                  conflict.worktree_path;
+                ( Unix.WEXITED 0
+                , git_worktree_reuse_output conflict
+                , git_worktree_reuse_fields conflict )
+            in
+            let failure_error_fields =
+              match worktree_reuse with
+              | Some _ -> []
+              | None -> failure_error_fields
             in
             Yojson.Safe.to_string
               (Exec_core.process_result_json
@@ -455,7 +607,8 @@ let handle_tool_execute_typed
                  ~keeper_name:meta.name
                  ~cmd
                  ~extra:
-                   (failure_error_fields
+                   (worktree_reuse_fields
+                    @ failure_error_fields
                     @ glob_literal_failure_fields
                     @ sandbox_extra_fields
                     @ [ "typed", `Bool true
@@ -465,7 +618,7 @@ let handle_tool_execute_typed
                     @ response_cwd_field
                     @ descriptor_fields
                     @ execution_location_fields cwd)
-                 ~status:result.status
+                 ~status
                  ~output
                  ~env_snapshot:env_snap
                  ()))

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -92,8 +92,8 @@ let handle_ide_annotate ~config ~(meta : keeper_meta) ~args =
     ~args
 ;;
 
-let handle_voice ~config ~(meta : keeper_meta) ~name ~args () =
-  Keeper_tool_voice_runtime.handle_voice_tool ~config ~meta ~name ~args ()
+let handle_voice ~config ~(meta : keeper_meta) ~name ~args ?turn_slot_control () =
+  Keeper_tool_voice_runtime.handle_voice_tool ~config ~meta ~name ~args ?turn_slot_control ()
 ;;
 
 let handle_task ~config ~(meta : keeper_meta) ~name ~args =

--- a/lib/keeper/keeper_tool_in_process_runtime.mli
+++ b/lib/keeper/keeper_tool_in_process_runtime.mli
@@ -61,6 +61,7 @@ val handle_voice
   -> meta:keeper_meta
   -> name:string
   -> args:Yojson.Safe.t
+  -> ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control
   -> unit
   -> string
 

--- a/lib/keeper/keeper_tool_runtime.ml
+++ b/lib/keeper/keeper_tool_runtime.ml
@@ -22,6 +22,7 @@ type context =
   ; proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t option
   ; net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option
   ; mcp_session_id : string option
+  ; turn_slot_control : Keeper_turn_slot.keeper_turn_slot_control option
   }
 
 let descriptor_for_internal internal_name =
@@ -178,6 +179,7 @@ let handle_in_process ctx descriptor args =
          ~meta:ctx.meta
          ~name
          ~args
+         ?turn_slot_control:ctx.turn_slot_control
          ())
   | Tool_task_dispatch ->
     Some

--- a/lib/keeper/keeper_tool_runtime.mli
+++ b/lib/keeper/keeper_tool_runtime.mli
@@ -21,6 +21,7 @@ type context =
   ; proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t option
   ; net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option
   ; mcp_session_id : string option
+  ; turn_slot_control : Keeper_turn_slot.keeper_turn_slot_control option
   }
 
 val descriptor_for_internal : string -> Keeper_tool_descriptor.t option

--- a/lib/keeper/keeper_tool_voice_runtime.ml
+++ b/lib/keeper/keeper_tool_voice_runtime.ml
@@ -153,22 +153,48 @@ let handle_speak
            (keeper_text_fallback_json ~agent_id:meta.name ~message)
            memory_status))
 
-let handle_listen ~(meta : keeper_meta) ~(args : Yojson.Safe.t) () =
+let handle_listen ~(meta : keeper_meta) ~(args : Yojson.Safe.t) ?turn_slot_control () =
   let timeout_sec = Safe_ops.json_float ~default:60.0 "timeout_seconds" args in
   let language_code = Safe_ops.json_string_opt "language_code" args in
-  match
-    Voice_bridge.record_and_transcribe
-      ~agent_id:meta.name
-      ~timeout_sec
-      ?language_code
-      ()
-  with
-  | Ok json -> Yojson.Safe.to_string json
-  | Error err ->
-    Tool_args.error_response_with
-      [ "error", `String err
-      ; "agent_id", `String meta.name
-      ]
+  let released =
+    match turn_slot_control with
+    | Some ctrl ->
+      ctrl.Keeper_turn_slot.release_for_retry ();
+      true
+    | None -> false
+  in
+  let result =
+    match
+      Voice_bridge.record_and_transcribe
+        ~agent_id:meta.name
+        ~timeout_sec
+        ?language_code
+        ()
+    with
+    | Ok json -> Yojson.Safe.to_string json
+    | Error err ->
+      Tool_args.error_response_with
+        [ "error", `String err
+        ; "agent_id", `String meta.name
+        ]
+  in
+  if released
+  then (
+    match turn_slot_control with
+    | Some ctrl ->
+      (match ctrl.Keeper_turn_slot.reacquire_after_retry () with
+       | Ok wait_ms ->
+         Log.Keeper.info
+           "%s: reacquired keeper turn slot after voice listen (wait_ms=%d)"
+           meta.name
+           wait_ms
+       | Error (`Semaphore_wait_timeout timeout) ->
+         Log.Keeper.warn
+           "%s: semaphore reacquire timeout after voice listen (waited %.0fs)"
+           meta.name
+           timeout.timeout_wait_sec)
+    | None -> ());
+  result
 
 let handle_agent ~(meta : keeper_meta) =
   match Voice_bridge.get_agent_voice ~agent_id:meta.name with
@@ -218,11 +244,12 @@ let handle
       ~(meta : keeper_meta)
       ~(command : voice_command)
       ~(args : Yojson.Safe.t)
+      ?turn_slot_control
       ()
   =
   match command with
   | Speak -> handle_speak ~config ~meta ~args
-  | Listen -> handle_listen ~meta ~args ()
+  | Listen -> handle_listen ~meta ~args ?turn_slot_control ()
   | Agent -> handle_agent ~meta
   | Sessions -> handle_sessions ()
   | Session_start -> handle_session_start ~meta ~args
@@ -233,8 +260,9 @@ let handle_voice_tool
       ~(meta : keeper_meta)
       ~(name : string)
       ~(args : Yojson.Safe.t)
+      ?turn_slot_control
       ()
   =
   match command_of_string name with
-  | Some command -> handle ~config ~meta ~command ~args ()
+  | Some command -> handle ~config ~meta ~command ~args ?turn_slot_control ()
   | None -> error_json ~fields:[ "tool", `String name ] "unknown_voice_tool"

--- a/lib/keeper/keeper_tool_voice_runtime.mli
+++ b/lib/keeper/keeper_tool_voice_runtime.mli
@@ -25,5 +25,6 @@ val handle_voice_tool :
   meta:Keeper_meta_contract.keeper_meta ->
   name:string ->
   args:Yojson.Safe.t ->
+  ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control ->
   unit ->
   string

--- a/lib/keeper/keeper_tools_oas_bundle.ml
+++ b/lib/keeper/keeper_tools_oas_bundle.ml
@@ -32,6 +32,7 @@ let make_tool_bundle
       ?search_fn
       ?on_tool_called
       ?clock
+      ?turn_slot_control
       ()
   : tool_bundle
   =
@@ -113,6 +114,7 @@ let make_tool_bundle
                ?search_fn
                ?on_tool_called
                ?clock
+               ?turn_slot_control
                ~failure_counts
                ()
            in
@@ -167,6 +169,7 @@ let make_tool_bundle
                ?search_fn
                ?on_tool_called
                ?clock
+               ?turn_slot_control
                ~translate_input:descriptor.translate
                ~failure_counts
                ()
@@ -200,9 +203,18 @@ let make_tools
       ?search_fn
       ?on_tool_called
       ?clock
+      ?turn_slot_control
       ()
   : Agent_sdk.Tool.t list
   =
-  (make_tool_bundle ~config ~meta ~ctx_snapshot ?search_fn ?on_tool_called ?clock ())
+  (make_tool_bundle
+     ~config
+     ~meta
+     ~ctx_snapshot
+     ?search_fn
+     ?on_tool_called
+     ?clock
+     ?turn_slot_control
+     ())
     .tools
 ;;

--- a/lib/keeper/keeper_tools_oas_bundle.mli
+++ b/lib/keeper/keeper_tools_oas_bundle.mli
@@ -11,6 +11,7 @@ val make_tool_bundle
   -> ?search_fn:(query:string -> max_results:int -> Yojson.Safe.t)
   -> ?on_tool_called:(string -> unit)
   -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
+  -> ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control
   -> unit
   -> Keeper_tools_oas.tool_bundle
 
@@ -22,5 +23,6 @@ val make_tools
   -> ?search_fn:(query:string -> max_results:int -> Yojson.Safe.t)
   -> ?on_tool_called:(string -> unit)
   -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
+  -> ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control
   -> unit
   -> Agent_sdk.Tool.t list

--- a/lib/keeper/keeper_tools_oas_handler.ml
+++ b/lib/keeper/keeper_tools_oas_handler.ml
@@ -22,6 +22,7 @@ let make_keeper_tool_handler
       ?search_fn
       ?on_tool_called
       ?clock
+      ?turn_slot_control
       ?(translate_input = fun j -> j)
       ~(failure_counts : failure_counts)
       ()
@@ -135,6 +136,7 @@ let make_keeper_tool_handler
                 ~exec_cache
               ?search_fn
               ?on_tool_called
+              ?turn_slot_control
               ~failure_counts
               ~key
               ~input
@@ -179,6 +181,7 @@ let make_keeper_tool_handler
                     ~exec_cache
                   ?search_fn
                   ?on_tool_called
+                  ?turn_slot_control
                   ~failure_counts
                   ~key
                   ~input

--- a/lib/keeper/keeper_tools_oas_handler.mli
+++ b/lib/keeper/keeper_tools_oas_handler.mli
@@ -26,6 +26,7 @@ val make_keeper_tool_handler
   -> ?search_fn:(query:string -> max_results:int -> Yojson.Safe.t)
   -> ?on_tool_called:(string -> unit)
   -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
+  -> ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control
   -> ?translate_input:(Yojson.Safe.t -> Yojson.Safe.t)
   -> failure_counts:Keeper_tools_oas.failure_counts
   -> unit

--- a/lib/keeper/keeper_tools_oas_handler_exec.ml
+++ b/lib/keeper/keeper_tools_oas_handler_exec.ml
@@ -93,6 +93,7 @@ let execute_with_observers
       ~(exec_cache : Masc_exec.Exec_cache.t option)
       ?search_fn
       ?on_tool_called
+      ?turn_slot_control
       ~(failure_counts : failure_counts)
       ~(key : string)
       ~(input : Yojson.Safe.t)
@@ -108,8 +109,9 @@ let execute_with_observers
           ~meta
             ~ctx_work:ctx_snapshot
             ?turn_sandbox_factory
-            ~exec_cache
+          ~exec_cache
           ?search_fn
+          ?turn_slot_control
           ~name
           ~input
           ())

--- a/lib/keeper/keeper_tools_oas_handler_exec.mli
+++ b/lib/keeper/keeper_tools_oas_handler_exec.mli
@@ -16,6 +16,7 @@ val execute_with_observers
   -> exec_cache:Masc_exec.Exec_cache.t option
   -> ?search_fn:(query:string -> max_results:int -> Yojson.Safe.t)
   -> ?on_tool_called:(string -> unit)
+  -> ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control
   -> failure_counts:Keeper_tools_oas.failure_counts
   -> key:string
   -> input:Yojson.Safe.t

--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -593,6 +593,17 @@ type keeper_turn_slot_state =
   ; autonomous_ticket : int option ref
   }
 
+type keeper_turn_slot_control =
+  { is_held : unit -> bool
+  ; release_for_retry : unit -> unit
+  ; reacquire_after_retry :
+      unit -> (int, [ `Semaphore_wait_timeout of semaphore_wait_timeout ]) result
+  }
+
+let keeper_turn_slot_is_held state =
+  !(state.acquired_autonomous) || !(state.acquired_reactive) || !(state.acquired_turn)
+;;
+
 let make_keeper_turn_slot_state () =
   { acquired_autonomous = ref false
   ; acquired_reactive = ref false
@@ -1281,16 +1292,36 @@ let with_keeper_turn_slot ?(runtime_profile = "unknown") ~keeper_name ~channel f
             in
             Ok semaphore_wait_ms))
   in
+  let slot_control =
+    { is_held = (fun () -> keeper_turn_slot_is_held slot_state)
+    ; release_for_retry =
+        (fun () ->
+           release_keeper_turn_slot_impl
+             ~keeper_name
+             ~stamp_autonomous_completion:false
+             slot_state)
+    ; reacquire_after_retry =
+        (fun () ->
+           if keeper_turn_slot_is_held slot_state then Ok 0 else acquire_all ())
+    }
+  in
   Eio_guard.protect
     ~finally:(fun () -> release_keeper_turn_slot ~keeper_name slot_state)
     (fun () ->
        match acquire_all () with
        | Error _ as e -> e
-       | Ok semaphore_wait_ms -> Ok (f ~semaphore_wait_ms))
+       | Ok semaphore_wait_ms -> Ok (f ~semaphore_wait_ms ~slot_control))
+;;
+
+let with_keeper_turn_slot_control = with_keeper_turn_slot
+
+let with_keeper_turn_slot_control_for_test ?runtime_profile ~keeper_name ~channel f =
+  with_keeper_turn_slot_control ?runtime_profile ~keeper_name ~channel f
 ;;
 
 let with_keeper_turn_slot_for_test ?runtime_profile ~keeper_name ~channel f =
-  with_keeper_turn_slot ?runtime_profile ~keeper_name ~channel f
+  with_keeper_turn_slot ?runtime_profile ~keeper_name ~channel
+    (fun ~semaphore_wait_ms ~slot_control:_ -> f ~semaphore_wait_ms)
 ;;
 
 let wait_for_autonomous_queue_head_for_test

--- a/lib/keeper/keeper_turn_slot.mli
+++ b/lib/keeper/keeper_turn_slot.mli
@@ -232,11 +232,34 @@ val set_budget_exhaustion_for_test : keeper_name:string -> strikes:int -> unit
 
 type keeper_turn_slot_state
 
+type keeper_turn_slot_control = {
+  is_held : unit -> bool;
+  release_for_retry : unit -> unit;
+  reacquire_after_retry :
+    unit -> (int, [ `Semaphore_wait_timeout of semaphore_wait_timeout ]) result;
+}
+
+val with_keeper_turn_slot_control :
+  ?runtime_profile:string ->
+  keeper_name:string ->
+  channel:Keeper_world_observation.keeper_cycle_channel ->
+  (semaphore_wait_ms:int -> slot_control:keeper_turn_slot_control -> 'a) ->
+  ('a, [> `Semaphore_wait_timeout of semaphore_wait_timeout ]) result
+
 val with_keeper_turn_slot :
   ?runtime_profile:string ->
   keeper_name:string ->
   channel:Keeper_world_observation.keeper_cycle_channel ->
-  (semaphore_wait_ms:int -> 'a) ->
+  (semaphore_wait_ms:int -> slot_control:keeper_turn_slot_control -> 'a) ->
+  ('a, [> `Semaphore_wait_timeout of semaphore_wait_timeout ]) result
+
+(** Test-only wrapper around the keeper turn slot acquisition path with
+    in-turn slot ownership observation. *)
+val with_keeper_turn_slot_control_for_test :
+  ?runtime_profile:string ->
+  keeper_name:string ->
+  channel:Keeper_world_observation.keeper_cycle_channel ->
+  (semaphore_wait_ms:int -> slot_control:keeper_turn_slot_control -> 'a) ->
   ('a, [> `Semaphore_wait_timeout of semaphore_wait_timeout ]) result
 
 (** Test-only wrapper around the keeper turn slot acquisition path. *)

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -28,6 +28,7 @@ let run_keeper_cycle
       ~(generation : int)
       ?(channel : Keeper_world_observation.keeper_cycle_channel = Scheduled_autonomous)
       ?(semaphore_wait_ms = 0)
+      ?turn_slot_control
       ?shared_context
       ()
   : (keeper_meta, Agent_sdk.Error.sdk_error) result
@@ -479,6 +480,7 @@ let run_keeper_cycle
                           ; record_runtime_rotation_attempt
                           ; shared_context
                           ; trajectory_acc
+                          ; turn_slot_control
                           ; turn_affordances
                           ; turn_id = keeper_turn_id
                           }

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -228,6 +228,7 @@ val run_keeper_cycle
   -> generation:int
   -> ?channel:Keeper_world_observation.keeper_cycle_channel
   -> ?semaphore_wait_ms:int
+  -> ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control
   -> ?shared_context:Agent_sdk.Context.t
   -> unit
   -> (Keeper_meta_contract.keeper_meta, Agent_sdk.Error.sdk_error) result

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -62,6 +62,7 @@ type ctx =
       -> unit
   ; shared_context : Agent_sdk.Context.t option
   ; trajectory_acc : Trajectory.accumulator
+  ; turn_slot_control : Keeper_turn_slot.keeper_turn_slot_control option
   ; turn_affordances : string list
   ; turn_id : int
   }
@@ -90,6 +91,7 @@ let run (ctx : ctx)
       ; keeper_turn_id
       ; turn_id
       ; channel
+      ; turn_slot_control
       ; shared_context
       ; base_dir
       ; build_turn_prompt
@@ -203,6 +205,7 @@ let run (ctx : ctx)
                ~trajectory_acc
                ~is_retry
                ?shared_context
+               ?turn_slot_control
                ?event_bus:(Keeper_event_bus.get ())
                ()))
   in

--- a/test/test_keeper_tool_execute_safety.ml
+++ b/test/test_keeper_tool_execute_safety.ml
@@ -1177,6 +1177,77 @@ let test_tool_execute_elapsed_duration_preserves_positive_sub_ms () =
   Alcotest.(check int) "nan duration is zero" 0
     (elapsed ~start_time:Float.nan ~end_time:10.0)
 
+let test_tool_execute_git_worktree_branch_conflict_reuses_existing_cwd () =
+  with_eio_fs @@ fun () ->
+  let base_path, config = make_config () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  Keeper_registry.clear ();
+  let meta =
+    { (make_local_meta "worktree-branch-conflict") with
+      tool_access = [ "tool_execute" ]
+    }
+  in
+  let playground = Filename.concat base_path (playground_path_of meta.name) in
+  let repo_dir = Filename.concat playground "repos/masc" in
+  ensure_dir repo_dir;
+  git_ok ~cwd:repo_dir [ "init"; "-q"; "--initial-branch=main" ];
+  git_ok ~cwd:repo_dir [ "config"; "user.email"; "test@example.com" ];
+  git_ok ~cwd:repo_dir [ "config"; "user.name"; "Test" ];
+  write_file (Filename.concat repo_dir "README.md") "initial\n";
+  git_ok ~cwd:repo_dir [ "add"; "README.md" ];
+  git_ok ~cwd:repo_dir [ "commit"; "-q"; "-m"; "init" ];
+  let branch = "nick0cave/profile-independent-cwd" in
+  git_ok ~cwd:repo_dir
+    [ "worktree"; "add"; "-q"; "-b"; branch; ".worktrees/profile-independent-cwd"; "HEAD" ];
+  let raw =
+    Keeper_tool_command_runtime.handle_tool_execute
+      ~turn_sandbox_factory:None
+      ~exec_cache:None
+      ~config
+      ~meta
+      ~args:
+        (`Assoc
+           [ "executable", `String "git"
+           ; ( "argv"
+             , `List
+                 [ `String "worktree"
+                 ; `String "add"
+                 ; `String ".worktrees/profile-independent-cwd-2"
+                 ; `String branch
+                 ] )
+           ; "cwd", `String "repos/masc"
+           ])
+      ()
+  in
+  let json = Yojson.Safe.from_string raw in
+  Alcotest.(check bool) "git worktree add treated as idempotent" true
+    (json |> Json.member "ok" |> Json.to_bool);
+  Alcotest.(check bool) "branch conflict marker" true
+    (json |> Json.member "git_worktree_branch_already_used" |> Json.to_bool);
+  Alcotest.(check bool) "worktree reused" true
+    (json |> Json.member "worktree_reused" |> Json.to_bool);
+  Alcotest.(check string) "branch" branch
+    (json |> Json.member "branch" |> Json.to_string);
+  Alcotest.(check bool) "existing path points to prior worktree" true
+    (json
+     |> Json.member "existing_worktree_path"
+     |> Json.to_string
+     |> fun path -> String_util.contains_substring path ".worktrees/profile-independent-cwd");
+  Alcotest.(check bool) "recovery hint marks idempotent reuse" true
+    (json
+     |> Json.member "recovery_hint"
+     |> Json.to_string
+     |> fun hint -> String_util.contains_substring hint "treated as idempotent");
+  Alcotest.(check bool) "output is idempotent worktree noop" true
+    (json
+     |> Json.member "output"
+     |> Json.to_string
+     |> fun output -> String.starts_with ~prefix:"Worktree already exists:" output);
+  Alcotest.(check bool) "no deterministic retry marker on idempotent success" true
+    (match Json.member "deterministic_retry" json with
+     | `Null -> true
+     | _ -> false)
+
 let test_tool_search_files_ir_timeout_floor_is_not_sub_io_latency () =
   let args = `Assoc [ "timeout_sec", `Float 1.0 ] in
   Alcotest.(check (float 0.001))
@@ -2345,6 +2416,10 @@ let () =
             "tool_search_files_ir load-bearing timeout floor"
             `Quick
             test_tool_search_files_ir_load_bearing_timeout_floor
+        ; Alcotest.test_case
+            "tool_execute git worktree branch conflict reuses existing cwd"
+            `Quick
+            test_tool_execute_git_worktree_branch_conflict_reuses_existing_cwd
         ; Alcotest.test_case
             "nested runtime detector ignores commit messages"
             `Quick


### PR DESCRIPTION
## Summary
- make `tool_execute` treat Git `worktree add` branch-already-checked-out failures as idempotent success
- return `worktree_reused=true`, the branch, and the existing worktree path so the Keeper can continue from that cwd
- preserve current-main `turn_slot_control` plumbing so voice listen can release/reacquire the turn slot during long blocking work

## Why
Keepers can repeatedly hit `git worktree add <path> <branch>` after Git reports the branch is already checked out elsewhere. Reporting that failure still leaves the tool call as a hard gate. This patch converts that exact worktree-add conflict into a successful reuse result, so the existing worktree becomes the next actionable cwd instead of an error loop.

## Rebase Cleanup
- Rebased onto current `main` at `6a9b671a0c4608962d948b49f1803803095bb265`.
- Kept current-main `Ide_command_descriptor.compute` and Shell IR glob diagnostics while preserving the worktree-reuse recovery path.
- Removed duplicate `Cargo` / `Go` `path_args` cases introduced by the older branch after current main already gained them.

## Validation
- `git diff --check origin/main`
- `opam exec -- ocamlformat --check ...` on touched OCaml files
- `env DUNE_CACHE=disabled MASC_DUNE_THROTTLE=0 MASC_OPAM_LOCK=0 MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_BUILD_DIR=_build_pr20378_rebase_verify2 scripts/dune-local.sh build test/test_keeper_tool_execute_safety.exe test/test_voice_runtime_overlay.exe`
- `_build_pr20378_rebase_verify2/default/test/test_keeper_tool_execute_safety.exe test edge`
- `_build_pr20378_rebase_verify2/default/test/test_voice_runtime_overlay.exe`

## Notes
- The previous diagnostic-only shape is not reintroduced; non-idempotent Git process failures still surface as real failures.
