### PR TITLE
fix(keeper): remove stale turn slot control passthrough

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -104,7 +104,6 @@ let run_turn
       ?(is_retry = false)
       ?shared_context
       ?event_bus
-      ?turn_slot_control
       ()
   : (run_result, Agent_sdk.Error.sdk_error) result
   =
@@ -365,7 +364,6 @@ let run_turn
       ~trajectory_acc
       ~tool_overlay
       ~runtime_manifest_context
-      ?turn_slot_control
       ()
   in
   (* Section 2: prepare runtime tools and hooks. *)

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -109,6 +109,5 @@ val run_turn
   -> ?is_retry:bool
   -> ?shared_context:Agent_sdk.Context.t
   -> ?event_bus:Agent_sdk.Event_bus.t
-  -> ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control
   -> unit
   -> (run_result, Agent_sdk.Error.sdk_error) result

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -379,11 +379,11 @@ let run_keepalive_unified_turn
           ~kind:Semaphore_wait_pending
           ();
         match
-          Keeper_turn_slot.with_keeper_turn_slot_control
+          Keeper_turn_slot.with_keeper_turn_slot
             ~runtime_profile:(runtime_id_of_meta meta_after_triage)
             ~keeper_name:meta_after_triage.name
             ~channel:turn_decision.channel
-            (fun ~semaphore_wait_ms ~slot_control ->
+            (fun ~semaphore_wait_ms ->
                run_keeper_cycle_with_slot
                  ~ctx
                  ~meta_after_cursor_persist
@@ -392,7 +392,6 @@ let run_keepalive_unified_turn
                  ~turn_decision
                  ~shared_context
                  ~semaphore_wait_ms
-                 ~slot_control
                  ())
         with
         | Ok meta -> meta

--- a/lib/keeper/keeper_heartbeat_loop_cycle_with_slot.ml
+++ b/lib/keeper/keeper_heartbeat_loop_cycle_with_slot.ml
@@ -47,7 +47,6 @@ let run_keeper_cycle_with_slot
       ~(turn_decision : Keeper_world_observation.keeper_cycle_decision)
       ~shared_context
       ~semaphore_wait_ms
-      ~slot_control
       ()
   =
   match
@@ -59,7 +58,6 @@ let run_keeper_cycle_with_slot
         ~generation:meta_after_cursor_persist.runtime.generation
         ~channel:turn_decision.channel
         ~semaphore_wait_ms
-        ~turn_slot_control:slot_control
         ~shared_context
         ())
   with

--- a/lib/keeper/keeper_heartbeat_loop_cycle_with_slot.mli
+++ b/lib/keeper/keeper_heartbeat_loop_cycle_with_slot.mli
@@ -8,6 +8,5 @@ val run_keeper_cycle_with_slot
   -> turn_decision:Keeper_world_observation.keeper_cycle_decision
   -> shared_context:Agent_sdk.Context.t
   -> semaphore_wait_ms:int
-  -> slot_control:Keeper_turn_slot.keeper_turn_slot_control
   -> unit
   -> Keeper_meta_contract.keeper_meta

--- a/lib/keeper/keeper_run_tools.mli
+++ b/lib/keeper/keeper_run_tools.mli
@@ -105,6 +105,5 @@ val prepare_agent_setup
   -> tool_overlay:Agent_sdk.Tool_op.t ref option
   -> ?runtime_manifest_context:Keeper_runtime_manifest.turn_context
   -> ?runtime_manifest_append:(Keeper_runtime_manifest.t -> unit)
-  -> ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control
   -> unit
   -> (agent_setup, Agent_sdk.Error.sdk_error) result

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -38,7 +38,6 @@ let prepare_agent_setup
       ~(tool_overlay : Agent_sdk.Tool_op.t ref option)
       ?runtime_manifest_context
       ?runtime_manifest_append
-      ?turn_slot_control
       ()
   : (Keeper_run_tools_hooks.agent_setup, Agent_sdk.Error.sdk_error) result
   =
@@ -128,7 +127,6 @@ let prepare_agent_setup
       ~search_fn:(fun ~query ~max_results -> !local_search_fn_ref ~query ~max_results)
       ~on_tool_called:(fun name ->
         Keeper_discovered_tools.mark_used acc.discovered ~turn:acc.current_turn ~name)
-      ?turn_slot_control
       ()
   in
   let extend_turns_tool = Keeper_extend_turns.make ~agent_ref ~max_turns () in

--- a/lib/keeper/keeper_tool_dispatch_runtime.ml
+++ b/lib/keeper/keeper_tool_dispatch_runtime.ml
@@ -294,7 +294,6 @@ let execute_keeper_tool_call_with_outcome
       ?proc_mgr
       ?net
       ?mcp_session_id
-      ?turn_slot_control
       ~(name : string)
       ~(input : Yojson.Safe.t)
       ()
@@ -411,7 +410,6 @@ let execute_keeper_tool_call_with_outcome
            ; proc_mgr
            ; net
            ; mcp_session_id
-           ; turn_slot_control
            }
        in
        let descriptor_output =
@@ -515,7 +513,6 @@ let execute_keeper_tool_call
       ?turn_sandbox_factory
       ~(exec_cache : Masc_exec.Exec_cache.t option)
       ?search_fn
-      ?turn_slot_control
       ~(name : string)
       ~(input : Yojson.Safe.t)
       ()
@@ -529,7 +526,6 @@ let execute_keeper_tool_call
                   ?turn_sandbox_factory
                   ~exec_cache
       ?search_fn
-      ?turn_slot_control
       ~name
       ~input
       ()

--- a/lib/keeper/keeper_tool_dispatch_runtime.mli
+++ b/lib/keeper/keeper_tool_dispatch_runtime.mli
@@ -156,7 +156,6 @@ val execute_keeper_tool_call_with_outcome
   -> ?proc_mgr:Eio_unix.Process.mgr_ty Eio.Resource.t
   -> ?net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> ?mcp_session_id:string
-  -> ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control
   -> name:string
   -> input:Yojson.Safe.t
   -> unit
@@ -169,7 +168,6 @@ val execute_keeper_tool_call
   -> ?turn_sandbox_factory:Keeper_sandbox_factory.t
   -> exec_cache:Masc_exec.Exec_cache.t option
   -> ?search_fn:(query:string -> max_results:int -> Yojson.Safe.t)
-  -> ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control
   -> name:string
   -> input:Yojson.Safe.t
   -> unit

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -92,8 +92,8 @@ let handle_ide_annotate ~config ~(meta : keeper_meta) ~args =
     ~args
 ;;
 
-let handle_voice ~config ~(meta : keeper_meta) ~name ~args ?turn_slot_control () =
-  Keeper_tool_voice_runtime.handle_voice_tool ~config ~meta ~name ~args ?turn_slot_control ()
+let handle_voice ~config ~(meta : keeper_meta) ~name ~args () =
+  Keeper_tool_voice_runtime.handle_voice_tool ~config ~meta ~name ~args ()
 ;;
 
 let handle_task ~config ~(meta : keeper_meta) ~name ~args =

--- a/lib/keeper/keeper_tool_in_process_runtime.mli
+++ b/lib/keeper/keeper_tool_in_process_runtime.mli
@@ -61,7 +61,6 @@ val handle_voice
   -> meta:keeper_meta
   -> name:string
   -> args:Yojson.Safe.t
-  -> ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control
   -> unit
   -> string
 

--- a/lib/keeper/keeper_tool_runtime.ml
+++ b/lib/keeper/keeper_tool_runtime.ml
@@ -22,7 +22,6 @@ type context =
   ; proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t option
   ; net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option
   ; mcp_session_id : string option
-  ; turn_slot_control : Keeper_turn_slot.keeper_turn_slot_control option
   }
 
 let descriptor_for_internal internal_name =
@@ -179,7 +178,6 @@ let handle_in_process ctx descriptor args =
          ~meta:ctx.meta
          ~name
          ~args
-         ?turn_slot_control:ctx.turn_slot_control
          ())
   | Tool_task_dispatch ->
     Some

--- a/lib/keeper/keeper_tool_runtime.mli
+++ b/lib/keeper/keeper_tool_runtime.mli
@@ -21,7 +21,6 @@ type context =
   ; proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t option
   ; net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option
   ; mcp_session_id : string option
-  ; turn_slot_control : Keeper_turn_slot.keeper_turn_slot_control option
   }
 
 val descriptor_for_internal : string -> Keeper_tool_descriptor.t option

--- a/lib/keeper/keeper_tool_voice_runtime.ml
+++ b/lib/keeper/keeper_tool_voice_runtime.ml
@@ -153,48 +153,22 @@ let handle_speak
            (keeper_text_fallback_json ~agent_id:meta.name ~message)
            memory_status))
 
-let handle_listen ~(meta : keeper_meta) ~(args : Yojson.Safe.t) ?turn_slot_control () =
+let handle_listen ~(meta : keeper_meta) ~(args : Yojson.Safe.t) () =
   let timeout_sec = Safe_ops.json_float ~default:60.0 "timeout_seconds" args in
   let language_code = Safe_ops.json_string_opt "language_code" args in
-  let released =
-    match turn_slot_control with
-    | Some ctrl ->
-      ctrl.Keeper_turn_slot.release_for_retry ();
-      true
-    | None -> false
-  in
-  let result =
-    match
-      Voice_bridge.record_and_transcribe
-        ~agent_id:meta.name
-        ~timeout_sec
-        ?language_code
-        ()
-    with
-    | Ok json -> Yojson.Safe.to_string json
-    | Error err ->
-      Tool_args.error_response_with
-        [ "error", `String err
-        ; "agent_id", `String meta.name
-        ]
-  in
-  if released
-  then (
-    match turn_slot_control with
-    | Some ctrl ->
-      (match ctrl.Keeper_turn_slot.reacquire_after_retry () with
-       | Ok wait_ms ->
-         Log.Keeper.info
-           "%s: reacquired keeper turn slot after voice listen (wait_ms=%d)"
-           meta.name
-           wait_ms
-       | Error (`Semaphore_wait_timeout timeout) ->
-         Log.Keeper.warn
-           "%s: semaphore reacquire timeout after voice listen (waited %.0fs)"
-           meta.name
-           timeout.timeout_wait_sec)
-    | None -> ());
-  result
+  match
+    Voice_bridge.record_and_transcribe
+      ~agent_id:meta.name
+      ~timeout_sec
+      ?language_code
+      ()
+  with
+  | Ok json -> Yojson.Safe.to_string json
+  | Error err ->
+    Tool_args.error_response_with
+      [ "error", `String err
+      ; "agent_id", `String meta.name
+      ]
 
 let handle_agent ~(meta : keeper_meta) =
   match Voice_bridge.get_agent_voice ~agent_id:meta.name with
@@ -244,12 +218,11 @@ let handle
       ~(meta : keeper_meta)
       ~(command : voice_command)
       ~(args : Yojson.Safe.t)
-      ?turn_slot_control
       ()
   =
   match command with
   | Speak -> handle_speak ~config ~meta ~args
-  | Listen -> handle_listen ~meta ~args ?turn_slot_control ()
+  | Listen -> handle_listen ~meta ~args ()
   | Agent -> handle_agent ~meta
   | Sessions -> handle_sessions ()
   | Session_start -> handle_session_start ~meta ~args
@@ -260,9 +233,8 @@ let handle_voice_tool
       ~(meta : keeper_meta)
       ~(name : string)
       ~(args : Yojson.Safe.t)
-      ?turn_slot_control
       ()
   =
   match command_of_string name with
-  | Some command -> handle ~config ~meta ~command ~args ?turn_slot_control ()
+  | Some command -> handle ~config ~meta ~command ~args ()
   | None -> error_json ~fields:[ "tool", `String name ] "unknown_voice_tool"

--- a/lib/keeper/keeper_tool_voice_runtime.mli
+++ b/lib/keeper/keeper_tool_voice_runtime.mli
@@ -25,6 +25,5 @@ val handle_voice_tool :
   meta:Keeper_meta_contract.keeper_meta ->
   name:string ->
   args:Yojson.Safe.t ->
-  ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control ->
   unit ->
   string

--- a/lib/keeper/keeper_tools_oas_bundle.ml
+++ b/lib/keeper/keeper_tools_oas_bundle.ml
@@ -32,7 +32,6 @@ let make_tool_bundle
       ?search_fn
       ?on_tool_called
       ?clock
-      ?turn_slot_control
       ()
   : tool_bundle
   =
@@ -114,7 +113,6 @@ let make_tool_bundle
                ?search_fn
                ?on_tool_called
                ?clock
-               ?turn_slot_control
                ~failure_counts
                ()
            in
@@ -169,7 +167,6 @@ let make_tool_bundle
                ?search_fn
                ?on_tool_called
                ?clock
-               ?turn_slot_control
                ~translate_input:descriptor.translate
                ~failure_counts
                ()

--- a/lib/keeper/keeper_tools_oas_handler.ml
+++ b/lib/keeper/keeper_tools_oas_handler.ml
@@ -22,7 +22,6 @@ let make_keeper_tool_handler
       ?search_fn
       ?on_tool_called
       ?clock
-      ?turn_slot_control
       ?(translate_input = fun j -> j)
       ~(failure_counts : failure_counts)
       ()
@@ -136,7 +135,6 @@ let make_keeper_tool_handler
                 ~exec_cache
               ?search_fn
               ?on_tool_called
-              ?turn_slot_control
               ~failure_counts
               ~key
               ~input
@@ -181,7 +179,6 @@ let make_keeper_tool_handler
                     ~exec_cache
                   ?search_fn
                   ?on_tool_called
-                  ?turn_slot_control
                   ~failure_counts
                   ~key
                   ~input

--- a/lib/keeper/keeper_tools_oas_handler_exec.ml
+++ b/lib/keeper/keeper_tools_oas_handler_exec.ml
@@ -93,7 +93,6 @@ let execute_with_observers
       ~(exec_cache : Masc_exec.Exec_cache.t option)
       ?search_fn
       ?on_tool_called
-      ?turn_slot_control
       ~(failure_counts : failure_counts)
       ~(key : string)
       ~(input : Yojson.Safe.t)
@@ -111,7 +110,6 @@ let execute_with_observers
             ?turn_sandbox_factory
             ~exec_cache
           ?search_fn
-          ?turn_slot_control
           ~name
           ~input
           ())

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -28,7 +28,6 @@ let run_keeper_cycle
       ~(generation : int)
       ?(channel : Keeper_world_observation.keeper_cycle_channel = Scheduled_autonomous)
       ?(semaphore_wait_ms = 0)
-      ?turn_slot_control
       ?shared_context
       ()
   : (keeper_meta, Agent_sdk.Error.sdk_error) result
@@ -484,7 +483,6 @@ let run_keeper_cycle
                           ; trajectory_acc
                           ; turn_affordances
                           ; turn_id = keeper_turn_id
-                          ; turn_slot_control
                           }
                           ~initial_execution
                           ~timeout_sec

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -228,7 +228,6 @@ val run_keeper_cycle
   -> generation:int
   -> ?channel:Keeper_world_observation.keeper_cycle_channel
   -> ?semaphore_wait_ms:int
-  -> ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control
   -> ?shared_context:Agent_sdk.Context.t
   -> unit
   -> (Keeper_meta_contract.keeper_meta, Agent_sdk.Error.sdk_error) result

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -65,7 +65,6 @@ type ctx =
   ; trajectory_acc : Trajectory.accumulator
   ; turn_affordances : string list
   ; turn_id : int
-  ; turn_slot_control : Keeper_turn_slot.keeper_turn_slot_control option
   }
 
 let run (ctx : ctx)
@@ -92,7 +91,6 @@ let run (ctx : ctx)
       ; keeper_turn_id
       ; turn_id
       ; channel
-      ; turn_slot_control = _
       ; shared_context
       ; base_dir
       ; build_turn_prompt
@@ -207,7 +205,6 @@ let run (ctx : ctx)
                ~is_retry
                ?shared_context
                ?event_bus:(Keeper_event_bus.get ())
-               ?turn_slot_control
                ()))
   in
   let rec retry_loop (input : retry_loop_input) =

--- a/test/test_voice_runtime_overlay.ml
+++ b/test/test_voice_runtime_overlay.ml
@@ -230,6 +230,7 @@ let test_keeper_voice_speak_returns_queued_with_root_switch () =
         ~meta
         ~name:"keeper_voice_speak"
         ~args:(`Assoc [ "message", `String "hello from queued voice test" ])
+        ()
     in
     let json = Yojson.Safe.from_string raw in
     check string "queued status" "queued"
@@ -259,6 +260,7 @@ let test_keeper_voice_speak_records_memory_bank_row () =
         ~meta
         ~name:"keeper_voice_speak"
         ~args:(`Assoc [ "message", `String message; "priority", `Int 3 ])
+        ()
     in
     let json = Yojson.Safe.from_string raw in
     check bool "memory recorded" true
@@ -298,6 +300,7 @@ let test_keeper_voice_speak_text_fallback_records_memory_bank_row () =
       ~meta
       ~name:"keeper_voice_speak"
       ~args:(`Assoc [ "message", `String message ])
+      ()
   in
   let json = Yojson.Safe.from_string raw in
   check string "text fallback status" "text_fallback"
@@ -341,6 +344,7 @@ let test_keeper_voice_session_start_does_not_store_session_name_as_voice () =
         ~meta
         ~name:"keeper_voice_session_start"
         ~args:(`Assoc [ "session_name", `String session_name ])
+        ()
     in
     let json = Yojson.Safe.from_string raw in
     let voice = Yojson.Safe.Util.(member "voice" json |> to_string) in
@@ -351,7 +355,8 @@ let test_keeper_voice_session_start_does_not_store_session_name_as_voice () =
          ~config
          ~meta
          ~name:"keeper_voice_session_end"
-         ~args:(`Assoc [])))
+         ~args:(`Assoc [])
+         ()))
 ;;
 
 let test_keeper_voice_session_end_discards_queued_speech () =
@@ -370,7 +375,8 @@ let test_keeper_voice_session_end_discards_queued_speech () =
          ~config
          ~meta
          ~name:"keeper_voice_session_start"
-         ~args:(`Assoc [ "session_name", `String "drain regression" ]));
+         ~args:(`Assoc [ "session_name", `String "drain regression" ])
+         ());
     let queued =
       Masc.Voice_bridge.enqueue_agent_speak
         ~sw
@@ -392,6 +398,7 @@ let test_keeper_voice_session_end_discards_queued_speech () =
         ~meta
         ~name:"keeper_voice_session_end"
         ~args:(`Assoc [])
+        ()
     in
     let end_json = Yojson.Safe.from_string end_raw in
     check string "session ended" "ended"


### PR DESCRIPTION
## Summary
- remove stale turn_slot_control passthrough from keeper OAS/tool execution paths
- stop voice listen from calling removed release/reacquire hooks
- update voice runtime tests for the remaining explicit unit call boundary

## Why
main was failing to build after the turn-slot gate cleanup because some call sites still carried the removed retry-release control surface. That control path is not recoverable behavior anymore and should not be threaded into tool execution.

## Verification
- opam exec -- dune build --root . . -j 1 --display=quiet
- ./_build/default/test/test_voice_runtime_overlay.exe
- rg -n "\?turn_slot_control|turn_slot_control:|release_for_retry|reacquire_after_retry" lib/keeper test
- git diff --check origin/main..HEAD