### PR TITLE
fix(keeper): split voice blocking I/O slot yield from retry state

### DIFF
--- a/lib/exec/shell_ir_typed.ml
+++ b/lib/exec/shell_ir_typed.ml
@@ -752,6 +752,7 @@ let path_args : wrapped -> string list = function
   | W (Java _) -> []
   | W (Javac _) -> []
   | W (Mvn _) -> []
+  | W (Cargo _) -> []
   | W (Cmake _) -> []
   | W (Dune_local_sh _) -> []
   | W (Osascript _) -> []

--- a/lib/exec/shell_ir_typed.ml
+++ b/lib/exec/shell_ir_typed.ml
@@ -746,6 +746,7 @@ let path_args : wrapped -> string list = function
   | W (Tsc _) -> []
   | W (Ocamlfind _) -> []
   | W (Rustc _) -> []
+  | W (Go _) -> []
   | W (Gofmt _) -> []
   | W (Gradle _) -> []
   | W (Ninja _) -> []

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -80,6 +80,7 @@ let run_turn
       ~(runtime_id : string)
       ?world_observation
       ?(turn_affordances = [])
+      ?turn_slot_control
       ?provider_filter
       ~(generation : int)
       ?(max_turns : int = Keeper_runtime_resolved.reactive_max_turns_per_call ())
@@ -363,6 +364,7 @@ let run_turn
       ?max_cost_usd
       ~trajectory_acc
       ~tool_overlay
+      ?turn_slot_control
       ~runtime_manifest_context
       ()
   in

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -86,6 +86,7 @@ val run_turn
   -> runtime_id:string
   -> ?world_observation:Keeper_world_observation.world_observation
   -> ?turn_affordances:string list
+  -> ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control
   -> ?provider_filter:string list
   -> generation:int
   -> ?max_turns:int

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -379,11 +379,11 @@ let run_keepalive_unified_turn
           ~kind:Semaphore_wait_pending
           ();
         match
-          Keeper_turn_slot.with_keeper_turn_slot
+          Keeper_turn_slot.with_keeper_turn_slot_control
             ~runtime_profile:(runtime_id_of_meta meta_after_triage)
             ~keeper_name:meta_after_triage.name
             ~channel:turn_decision.channel
-            (fun ~semaphore_wait_ms ->
+            (fun ~semaphore_wait_ms ~slot_control ->
                run_keeper_cycle_with_slot
                  ~ctx
                  ~meta_after_cursor_persist
@@ -392,6 +392,7 @@ let run_keepalive_unified_turn
                  ~turn_decision
                  ~shared_context
                  ~semaphore_wait_ms
+                 ~turn_slot_control:slot_control
                  ())
         with
         | Ok meta -> meta

--- a/lib/keeper/keeper_heartbeat_loop_cycle_with_slot.ml
+++ b/lib/keeper/keeper_heartbeat_loop_cycle_with_slot.ml
@@ -47,6 +47,7 @@ let run_keeper_cycle_with_slot
       ~(turn_decision : Keeper_world_observation.keeper_cycle_decision)
       ~shared_context
       ~semaphore_wait_ms
+      ?turn_slot_control
       ()
   =
   match
@@ -58,6 +59,7 @@ let run_keeper_cycle_with_slot
         ~generation:meta_after_cursor_persist.runtime.generation
         ~channel:turn_decision.channel
         ~semaphore_wait_ms
+        ?turn_slot_control
         ~shared_context
         ())
   with

--- a/lib/keeper/keeper_heartbeat_loop_cycle_with_slot.mli
+++ b/lib/keeper/keeper_heartbeat_loop_cycle_with_slot.mli
@@ -8,5 +8,6 @@ val run_keeper_cycle_with_slot
   -> turn_decision:Keeper_world_observation.keeper_cycle_decision
   -> shared_context:Agent_sdk.Context.t
   -> semaphore_wait_ms:int
+  -> ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control
   -> unit
   -> Keeper_meta_contract.keeper_meta

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -249,6 +249,24 @@ val set_budget_exhaustion_for_test :
 (** Test-only: pre-load strike count.  [strikes <= 0] is equivalent
     to [reset_budget_exhaustion]. *)
 
+type keeper_turn_slot_control = Keeper_turn_slot.keeper_turn_slot_control = {
+  is_held : unit -> bool;
+  release_for_blocking_io : unit -> unit;
+  reacquire_after_blocking_io :
+    unit ->
+    (int, [ `Semaphore_wait_timeout of Keeper_turn_slot.semaphore_wait_timeout ])
+      result;
+}
+
+(** Test-only wrapper around the keeper turn slot acquisition path with
+    in-turn slot ownership observation. *)
+val with_keeper_turn_slot_control_for_test :
+  ?runtime_profile:string ->
+  keeper_name:string ->
+  channel:Keeper_world_observation.keeper_cycle_channel ->
+  (semaphore_wait_ms:int -> slot_control:keeper_turn_slot_control -> 'a) ->
+  ('a, [> `Semaphore_wait_timeout of semaphore_wait_timeout ]) result
+
 (** Test-only wrapper around the keeper turn slot acquisition path. *)
 val with_keeper_turn_slot_for_test :
   ?runtime_profile:string ->

--- a/lib/keeper/keeper_run_tools.mli
+++ b/lib/keeper/keeper_run_tools.mli
@@ -95,6 +95,7 @@ val prepare_agent_setup
   -> runtime_id:string
   -> is_retry:bool
   -> turn_affordances:string list
+  -> ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control
   -> config_root:string
   -> runtime_config_path:string option
   -> gemini_mcp_disabled:bool

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -28,6 +28,7 @@ let prepare_agent_setup
       ~(runtime_id : string)
       ~(is_retry : bool)
       ~(turn_affordances : string list)
+      ?turn_slot_control
       ~(config_root : string)
       ~(runtime_config_path : string option)
       ~(gemini_mcp_disabled : bool)
@@ -127,6 +128,7 @@ let prepare_agent_setup
       ~search_fn:(fun ~query ~max_results -> !local_search_fn_ref ~query ~max_results)
       ~on_tool_called:(fun name ->
         Keeper_discovered_tools.mark_used acc.discovered ~turn:acc.current_turn ~name)
+      ?turn_slot_control
       ()
   in
   let extend_turns_tool = Keeper_extend_turns.make ~agent_ref ~max_turns () in

--- a/lib/keeper/keeper_tool_dispatch_runtime.ml
+++ b/lib/keeper/keeper_tool_dispatch_runtime.ml
@@ -287,6 +287,7 @@ let execute_keeper_tool_call_with_outcome
       ?turn_sandbox_factory
       ~(exec_cache : Masc_exec.Exec_cache.t option)
       ?search_fn
+      ?turn_slot_control
       (* RFC-0182 Phase 5 PR-A.2: optional Eio resources threaded to
          Keeper_tool_runtime.context for Eio-bound descriptor handlers. *)
       ?sw
@@ -400,8 +401,9 @@ let execute_keeper_tool_call_with_outcome
                        ; meta
                        ; ctx_work
                        ; turn_sandbox_factory
-                       ; exec_cache
+           ; exec_cache
            ; search_fn = effective_search_fn
+           ; turn_slot_control
            ; (* RFC-0182 Phase 5 PR-A.2: Eio resources threaded from
                 caller via labeled ? params.  Callers without Eio
                 context (OAS handler, tests) leave them unset. *)

--- a/lib/keeper/keeper_tool_dispatch_runtime.mli
+++ b/lib/keeper/keeper_tool_dispatch_runtime.mli
@@ -151,6 +151,7 @@ val execute_keeper_tool_call_with_outcome
   -> ?turn_sandbox_factory:Keeper_sandbox_factory.t
   -> exec_cache:Masc_exec.Exec_cache.t option
   -> ?search_fn:(query:string -> max_results:int -> Yojson.Safe.t)
+  -> ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control
   -> ?sw:Eio.Switch.t
   -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
   -> ?proc_mgr:Eio_unix.Process.mgr_ty Eio.Resource.t

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -285,7 +285,7 @@ let glob_literal_failure_fields ~input ~status ~stderr =
    failure. Pipeline path validation is deferred. *)
 let pre_dispatch_path_missing ~cwd ir =
   match ir with
-  | Shell_ir.Simple s ->
+  | Masc_exec.Shell_ir.Simple s ->
     let typed = Masc_exec.Shell_ir_typed.of_simple s in
     (match Masc_exec.Shell_ir_typed.risk typed with
      | `Safe ->
@@ -297,7 +297,7 @@ let pre_dispatch_path_missing ~cwd ir =
          try not (Sys.file_exists resolved) with _ -> true
        ) args
      | `Audited | `Privileged -> None)
-  | Shell_ir.Pipeline _ -> None
+  | Masc_exec.Shell_ir.Pipeline _ -> None
 ;;
 
 let sandbox_extra_uses_docker sandbox_extra_fields =

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -92,8 +92,14 @@ let handle_ide_annotate ~config ~(meta : keeper_meta) ~args =
     ~args
 ;;
 
-let handle_voice ~config ~(meta : keeper_meta) ~name ~args () =
-  Keeper_tool_voice_runtime.handle_voice_tool ~config ~meta ~name ~args ()
+let handle_voice ~config ~(meta : keeper_meta) ~name ~args ?turn_slot_control () =
+  Keeper_tool_voice_runtime.handle_voice_tool
+    ~config
+    ~meta
+    ~name
+    ~args
+    ?turn_slot_control
+    ()
 ;;
 
 let handle_task ~config ~(meta : keeper_meta) ~name ~args =

--- a/lib/keeper/keeper_tool_in_process_runtime.mli
+++ b/lib/keeper/keeper_tool_in_process_runtime.mli
@@ -61,6 +61,7 @@ val handle_voice
   -> meta:keeper_meta
   -> name:string
   -> args:Yojson.Safe.t
+  -> ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control
   -> unit
   -> string
 

--- a/lib/keeper/keeper_tool_runtime.ml
+++ b/lib/keeper/keeper_tool_runtime.ml
@@ -17,6 +17,7 @@ type context =
   ; turn_sandbox_factory : Keeper_sandbox_factory.t option
   ; exec_cache : Masc_exec.Exec_cache.t option
   ; search_fn : query:string -> max_results:int -> Yojson.Safe.t
+  ; turn_slot_control : Keeper_turn_slot.keeper_turn_slot_control option
   ; sw : Eio.Switch.t option
   ; clock : float Eio.Time.clock_ty Eio.Resource.t option
   ; proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t option
@@ -178,6 +179,7 @@ let handle_in_process ctx descriptor args =
          ~meta:ctx.meta
          ~name
          ~args
+         ?turn_slot_control:ctx.turn_slot_control
          ())
   | Tool_task_dispatch ->
     Some

--- a/lib/keeper/keeper_tool_runtime.mli
+++ b/lib/keeper/keeper_tool_runtime.mli
@@ -16,6 +16,7 @@ type context =
   ; turn_sandbox_factory : Keeper_sandbox_factory.t option
   ; exec_cache : Masc_exec.Exec_cache.t option
   ; search_fn : query:string -> max_results:int -> Yojson.Safe.t
+  ; turn_slot_control : Keeper_turn_slot.keeper_turn_slot_control option
   ; sw : Eio.Switch.t option
   ; clock : float Eio.Time.clock_ty Eio.Resource.t option
   ; proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t option

--- a/lib/keeper/keeper_tool_voice_runtime.ml
+++ b/lib/keeper/keeper_tool_voice_runtime.ml
@@ -153,22 +153,42 @@ let handle_speak
            (keeper_text_fallback_json ~agent_id:meta.name ~message)
            memory_status))
 
-let handle_listen ~(meta : keeper_meta) ~(args : Yojson.Safe.t) () =
+let handle_listen ~(meta : keeper_meta) ~(args : Yojson.Safe.t) ?turn_slot_control () =
   let timeout_sec = Safe_ops.json_float ~default:60.0 "timeout_seconds" args in
   let language_code = Safe_ops.json_string_opt "language_code" args in
-  match
-    Voice_bridge.record_and_transcribe
-      ~agent_id:meta.name
-      ~timeout_sec
-      ?language_code
-      ()
-  with
-  | Ok json -> Yojson.Safe.to_string json
-  | Error err ->
-    Tool_args.error_response_with
-      [ "error", `String err
-      ; "agent_id", `String meta.name
-      ]
+  let record () =
+    match
+      Voice_bridge.record_and_transcribe
+        ~agent_id:meta.name
+        ~timeout_sec
+        ?language_code
+        ()
+    with
+    | Ok json -> Yojson.Safe.to_string json
+    | Error err ->
+      Tool_args.error_response_with
+        [ "error", `String err
+        ; "agent_id", `String meta.name
+        ]
+  in
+  let reacquire ctrl =
+    match ctrl.Keeper_turn_slot.reacquire_after_blocking_io () with
+    | Ok wait_ms ->
+      Log.Keeper.info
+        "%s: reacquired keeper turn slot after voice listen (wait_ms=%d)"
+        meta.name
+        wait_ms
+    | Error (`Semaphore_wait_timeout timeout) ->
+      Log.Keeper.warn
+        "%s: semaphore reacquire timeout after voice listen (waited %.0fs)"
+        meta.name
+        timeout.timeout_wait_sec
+  in
+  match turn_slot_control with
+  | Some ctrl when ctrl.Keeper_turn_slot.is_held () ->
+    ctrl.Keeper_turn_slot.release_for_blocking_io ();
+    Eio_guard.protect ~finally:(fun () -> reacquire ctrl) record
+  | _ -> record ()
 
 let handle_agent ~(meta : keeper_meta) =
   match Voice_bridge.get_agent_voice ~agent_id:meta.name with
@@ -218,11 +238,12 @@ let handle
       ~(meta : keeper_meta)
       ~(command : voice_command)
       ~(args : Yojson.Safe.t)
+      ?turn_slot_control
       ()
   =
   match command with
   | Speak -> handle_speak ~config ~meta ~args
-  | Listen -> handle_listen ~meta ~args ()
+  | Listen -> handle_listen ~meta ~args ?turn_slot_control ()
   | Agent -> handle_agent ~meta
   | Sessions -> handle_sessions ()
   | Session_start -> handle_session_start ~meta ~args
@@ -233,8 +254,9 @@ let handle_voice_tool
       ~(meta : keeper_meta)
       ~(name : string)
       ~(args : Yojson.Safe.t)
+      ?turn_slot_control
       ()
   =
   match command_of_string name with
-  | Some command -> handle ~config ~meta ~command ~args ()
+  | Some command -> handle ~config ~meta ~command ~args ?turn_slot_control ()
   | None -> error_json ~fields:[ "tool", `String name ] "unknown_voice_tool"

--- a/lib/keeper/keeper_tool_voice_runtime.mli
+++ b/lib/keeper/keeper_tool_voice_runtime.mli
@@ -25,5 +25,6 @@ val handle_voice_tool :
   meta:Keeper_meta_contract.keeper_meta ->
   name:string ->
   args:Yojson.Safe.t ->
+  ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control ->
   unit ->
   string

--- a/lib/keeper/keeper_tools_oas_bundle.ml
+++ b/lib/keeper/keeper_tools_oas_bundle.ml
@@ -32,6 +32,7 @@ let make_tool_bundle
       ?search_fn
       ?on_tool_called
       ?clock
+      ?turn_slot_control
       ()
   : tool_bundle
   =
@@ -113,6 +114,7 @@ let make_tool_bundle
                ?search_fn
                ?on_tool_called
                ?clock
+               ?turn_slot_control
                ~failure_counts
                ()
            in
@@ -164,11 +166,12 @@ let make_tool_bundle
                  ~ctx_snapshot
                  ?turn_sandbox_factory
                  ~exec_cache
-               ?search_fn
-               ?on_tool_called
-               ?clock
-               ~translate_input:descriptor.translate
-               ~failure_counts
+              ?search_fn
+              ?on_tool_called
+              ?clock
+              ?turn_slot_control
+              ~translate_input:descriptor.translate
+              ~failure_counts
                ()
            in
            Keeper_tool_descriptor.public_names_of_descriptor descriptor
@@ -203,6 +206,13 @@ let make_tools
       ()
   : Agent_sdk.Tool.t list
   =
-  (make_tool_bundle ~config ~meta ~ctx_snapshot ?search_fn ?on_tool_called ?clock ())
+  (make_tool_bundle
+     ~config
+     ~meta
+     ~ctx_snapshot
+     ?search_fn
+     ?on_tool_called
+     ?clock
+     ())
     .tools
 ;;

--- a/lib/keeper/keeper_tools_oas_bundle.mli
+++ b/lib/keeper/keeper_tools_oas_bundle.mli
@@ -11,6 +11,7 @@ val make_tool_bundle
   -> ?search_fn:(query:string -> max_results:int -> Yojson.Safe.t)
   -> ?on_tool_called:(string -> unit)
   -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
+  -> ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control
   -> unit
   -> Keeper_tools_oas.tool_bundle
 

--- a/lib/keeper/keeper_tools_oas_handler.ml
+++ b/lib/keeper/keeper_tools_oas_handler.ml
@@ -22,6 +22,7 @@ let make_keeper_tool_handler
       ?search_fn
       ?on_tool_called
       ?clock
+      ?turn_slot_control
       ?(translate_input = fun j -> j)
       ~(failure_counts : failure_counts)
       ()
@@ -135,6 +136,7 @@ let make_keeper_tool_handler
                 ~exec_cache
               ?search_fn
               ?on_tool_called
+              ?turn_slot_control
               ~failure_counts
               ~key
               ~input
@@ -179,6 +181,7 @@ let make_keeper_tool_handler
                     ~exec_cache
                   ?search_fn
                   ?on_tool_called
+                  ?turn_slot_control
                   ~failure_counts
                   ~key
                   ~input

--- a/lib/keeper/keeper_tools_oas_handler.mli
+++ b/lib/keeper/keeper_tools_oas_handler.mli
@@ -26,6 +26,7 @@ val make_keeper_tool_handler
   -> ?search_fn:(query:string -> max_results:int -> Yojson.Safe.t)
   -> ?on_tool_called:(string -> unit)
   -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
+  -> ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control
   -> ?translate_input:(Yojson.Safe.t -> Yojson.Safe.t)
   -> failure_counts:Keeper_tools_oas.failure_counts
   -> unit

--- a/lib/keeper/keeper_tools_oas_handler_exec.ml
+++ b/lib/keeper/keeper_tools_oas_handler_exec.ml
@@ -93,6 +93,7 @@ let execute_with_observers
       ~(exec_cache : Masc_exec.Exec_cache.t option)
       ?search_fn
       ?on_tool_called
+      ?turn_slot_control
       ~(failure_counts : failure_counts)
       ~(key : string)
       ~(input : Yojson.Safe.t)
@@ -110,6 +111,7 @@ let execute_with_observers
             ?turn_sandbox_factory
             ~exec_cache
           ?search_fn
+          ?turn_slot_control
           ~name
           ~input
           ())

--- a/lib/keeper/keeper_tools_oas_handler_exec.mli
+++ b/lib/keeper/keeper_tools_oas_handler_exec.mli
@@ -16,6 +16,7 @@ val execute_with_observers
   -> exec_cache:Masc_exec.Exec_cache.t option
   -> ?search_fn:(query:string -> max_results:int -> Yojson.Safe.t)
   -> ?on_tool_called:(string -> unit)
+  -> ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control
   -> failure_counts:Keeper_tools_oas.failure_counts
   -> key:string
   -> input:Yojson.Safe.t

--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -593,6 +593,13 @@ type keeper_turn_slot_state =
   ; autonomous_ticket : int option ref
   }
 
+type keeper_turn_slot_control =
+  { is_held : unit -> bool
+  ; release_for_blocking_io : unit -> unit
+  ; reacquire_after_blocking_io :
+      unit -> (int, [ `Semaphore_wait_timeout of semaphore_wait_timeout ]) result
+  }
+
 let make_keeper_turn_slot_state () =
   { acquired_autonomous = ref false
   ; acquired_reactive = ref false
@@ -727,6 +734,10 @@ let release_keeper_turn_slot_impl ~keeper_name ~(stamp_autonomous_completion : b
 
 let release_keeper_turn_slot ~keeper_name state =
   release_keeper_turn_slot_impl ~keeper_name ~stamp_autonomous_completion:true state
+;;
+
+let release_keeper_turn_slot_for_blocking_io ~keeper_name state =
+  release_keeper_turn_slot_impl ~keeper_name ~stamp_autonomous_completion:false state
 ;;
 
 (** Force-release every slot recorded for [keeper_name] in [holder_table].
@@ -1049,7 +1060,7 @@ let observe_semaphore_wait_seconds ~keeper_name ~runtime_profile ~channel second
   inc_bucket "+Inf"
 ;;
 
-let with_keeper_turn_slot ?(runtime_profile = "unknown") ~keeper_name ~channel f =
+let with_keeper_turn_slot_control ?(runtime_profile = "unknown") ~keeper_name ~channel f =
   let is_autonomous =
     match channel with
     | Keeper_world_observation.Scheduled_autonomous -> true
@@ -1281,12 +1292,46 @@ let with_keeper_turn_slot ?(runtime_profile = "unknown") ~keeper_name ~channel f
             in
             Ok semaphore_wait_ms))
   in
+  let slot_control =
+    { is_held = (fun () -> keeper_turn_slot_is_held slot_state)
+    ; release_for_blocking_io =
+        (fun () ->
+          if keeper_turn_slot_is_held slot_state
+          then (
+            Log.Keeper.info
+              "%s: releasing keeper turn slot before blocking I/O"
+              keeper_name;
+            release_keeper_turn_slot_for_blocking_io ~keeper_name slot_state))
+    ; reacquire_after_blocking_io =
+        (fun () ->
+          if keeper_turn_slot_is_held slot_state
+          then (
+            Log.Keeper.warn
+              "%s: blocking I/O slot reacquire requested while a slot is still held; \
+               releasing first"
+              keeper_name;
+            release_keeper_turn_slot_for_blocking_io ~keeper_name slot_state);
+          acquire_all ())
+    }
+  in
   Eio_guard.protect
     ~finally:(fun () -> release_keeper_turn_slot ~keeper_name slot_state)
     (fun () ->
        match acquire_all () with
        | Error _ as e -> e
-       | Ok semaphore_wait_ms -> Ok (f ~semaphore_wait_ms))
+       | Ok semaphore_wait_ms -> Ok (f ~semaphore_wait_ms ~slot_control))
+;;
+
+let with_keeper_turn_slot ?runtime_profile ~keeper_name ~channel f =
+  with_keeper_turn_slot_control
+    ?runtime_profile
+    ~keeper_name
+    ~channel
+    (fun ~semaphore_wait_ms ~slot_control:_ -> f ~semaphore_wait_ms)
+;;
+
+let with_keeper_turn_slot_control_for_test ?runtime_profile ~keeper_name ~channel f =
+  with_keeper_turn_slot_control ?runtime_profile ~keeper_name ~channel f
 ;;
 
 let with_keeper_turn_slot_for_test ?runtime_profile ~keeper_name ~channel f =

--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -610,6 +610,14 @@ let make_keeper_turn_slot_state () =
   ; autonomous_ticket = ref None
   }
 ;;
+
+let keeper_turn_slot_is_held state =
+  !(state.acquired_autonomous)
+  || !(state.acquired_reactive)
+  || !(state.acquired_turn)
+  || Option.is_some !(state.autonomous_ticket)
+;;
+
 let after_acquire_flag_hook_for_test
   : (label:string -> keeper_name:string -> unit) option ref
   =

--- a/lib/keeper/keeper_turn_slot.mli
+++ b/lib/keeper/keeper_turn_slot.mli
@@ -232,6 +232,21 @@ val set_budget_exhaustion_for_test : keeper_name:string -> strikes:int -> unit
 
 type keeper_turn_slot_state
 
+type keeper_turn_slot_control = {
+  is_held : unit -> bool;
+  release_for_blocking_io : unit -> unit;
+  reacquire_after_blocking_io :
+    unit ->
+    (int, [ `Semaphore_wait_timeout of semaphore_wait_timeout ]) result;
+}
+
+val with_keeper_turn_slot_control :
+  ?runtime_profile:string ->
+  keeper_name:string ->
+  channel:Keeper_world_observation.keeper_cycle_channel ->
+  (semaphore_wait_ms:int -> slot_control:keeper_turn_slot_control -> 'a) ->
+  ('a, [> `Semaphore_wait_timeout of semaphore_wait_timeout ]) result
+
 val with_keeper_turn_slot :
   ?runtime_profile:string ->
   keeper_name:string ->

--- a/lib/keeper/keeper_turn_slot.mli
+++ b/lib/keeper/keeper_turn_slot.mli
@@ -254,6 +254,15 @@ val with_keeper_turn_slot :
   (semaphore_wait_ms:int -> 'a) ->
   ('a, [> `Semaphore_wait_timeout of semaphore_wait_timeout ]) result
 
+(** Test-only wrapper around the keeper turn slot acquisition path with
+    in-turn slot ownership observation. *)
+val with_keeper_turn_slot_control_for_test :
+  ?runtime_profile:string ->
+  keeper_name:string ->
+  channel:Keeper_world_observation.keeper_cycle_channel ->
+  (semaphore_wait_ms:int -> slot_control:keeper_turn_slot_control -> 'a) ->
+  ('a, [> `Semaphore_wait_timeout of semaphore_wait_timeout ]) result
+
 (** Test-only wrapper around the keeper turn slot acquisition path. *)
 val with_keeper_turn_slot_for_test :
   ?runtime_profile:string ->

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -28,6 +28,7 @@ let run_keeper_cycle
       ~(generation : int)
       ?(channel : Keeper_world_observation.keeper_cycle_channel = Scheduled_autonomous)
       ?(semaphore_wait_ms = 0)
+      ?turn_slot_control
       ?shared_context
       ()
   : (keeper_meta, Agent_sdk.Error.sdk_error) result
@@ -479,6 +480,7 @@ let run_keeper_cycle
                           ; record_runtime_rotation_attempt
                           ; shared_context
                           ; trajectory_acc
+                          ; turn_slot_control
                           ; turn_affordances
                           ; turn_id = keeper_turn_id
                           }

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -228,6 +228,7 @@ val run_keeper_cycle
   -> generation:int
   -> ?channel:Keeper_world_observation.keeper_cycle_channel
   -> ?semaphore_wait_ms:int
+  -> ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control
   -> ?shared_context:Agent_sdk.Context.t
   -> unit
   -> (Keeper_meta_contract.keeper_meta, Agent_sdk.Error.sdk_error) result

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -62,6 +62,7 @@ type ctx =
       -> unit
   ; shared_context : Agent_sdk.Context.t option
   ; trajectory_acc : Trajectory.accumulator
+  ; turn_slot_control : Keeper_turn_slot.keeper_turn_slot_control option
   ; turn_affordances : string list
   ; turn_id : int
   }

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -90,6 +90,7 @@ let run (ctx : ctx)
       ; keeper_turn_id
       ; turn_id
       ; channel
+      ; turn_slot_control
       ; shared_context
       ; base_dir
       ; build_turn_prompt

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -175,6 +175,7 @@ let run (ctx : ctx)
                ~runtime_id:execution.runtime_id
                ~world_observation:observation
                ~turn_affordances
+               ?turn_slot_control
                ?provider_filter:
                  (Env_config_keeper.KeeperRuntimeProviderFilter.provider_allowlist ())
                ~generation:run_generation

--- a/test/test_keeper_turn_slot_holders.ml
+++ b/test/test_keeper_turn_slot_holders.ml
@@ -392,6 +392,224 @@ let test_force_released_autonomous_holder_does_not_stamp_completion () =
          "force-released autonomous holder stamped normal completion: delay=%.3f"
          delay)
 
+let test_retry_control_keeps_reactive_slot_in_same_turn () =
+  let keeper_name = "diag-retry-reactive" in
+  let turn_before = KK.turn_semaphore_value_for_test () in
+  let reactive_before = KK.reactive_turn_semaphore_value_for_test () in
+  let result =
+    KK.with_keeper_turn_slot_control_for_test
+      ~keeper_name
+      ~channel:Masc.Keeper_world_observation.Reactive
+      (fun ~semaphore_wait_ms:_ ~slot_control ->
+         assert_eq ~msg:"turn acquired before retry boundary"
+           ~expected:(turn_before - 1)
+           ~actual:(KK.turn_semaphore_value_for_test ());
+         assert_eq ~msg:"reactive acquired before retry boundary"
+           ~expected:(reactive_before - 1)
+           ~actual:(KK.reactive_turn_semaphore_value_for_test ());
+         if not (slot_control.is_held ()) then
+           failwith "retry control reported no held slot during active turn";
+         Eio.Fiber.yield ();
+         assert_eq ~msg:"turn remains held across retry boundary"
+           ~expected:(turn_before - 1)
+           ~actual:(KK.turn_semaphore_value_for_test ());
+         assert_eq ~msg:"reactive remains held across retry boundary"
+           ~expected:(reactive_before - 1)
+           ~actual:(KK.reactive_turn_semaphore_value_for_test ());
+         let names =
+           List.map fst (KK.reactive_slot_holders ~now:(Time_compat.now ()))
+         in
+         if not (List.mem keeper_name names) then
+           failwith "reactive holder missing across retry boundary";
+         assert_eq ~msg:"turn still held before finalizer"
+           ~expected:(turn_before - 1)
+           ~actual:(KK.turn_semaphore_value_for_test ());
+         assert_eq ~msg:"reactive still held before finalizer"
+           ~expected:(reactive_before - 1)
+           ~actual:(KK.reactive_turn_semaphore_value_for_test ()))
+  in
+  (match result with
+   | Ok () -> ()
+   | Error (`Semaphore_wait_timeout _) ->
+       failwith "unexpected semaphore wait timeout in test");
+  assert_eq ~msg:"turn baseline after retry observation finalizer"
+    ~expected:turn_before
+    ~actual:(KK.turn_semaphore_value_for_test ());
+  assert_eq ~msg:"reactive baseline after retry observation finalizer"
+    ~expected:reactive_before
+    ~actual:(KK.reactive_turn_semaphore_value_for_test ())
+
+let test_retry_control_keeps_autonomous_slot_in_same_turn () =
+  let keeper_name = "diag-retry-autonomous" in
+  let turn_before = KK.turn_semaphore_value_for_test () in
+  let autonomous_before = KK.autonomous_turn_semaphore_value_for_test () in
+  let result =
+    KK.with_keeper_turn_slot_control_for_test
+      ~keeper_name
+      ~channel:Masc.Keeper_world_observation.Scheduled_autonomous
+      (fun ~semaphore_wait_ms:_ ~slot_control ->
+         assert_eq ~msg:"turn acquired before autonomous retry boundary"
+           ~expected:(turn_before - 1)
+           ~actual:(KK.turn_semaphore_value_for_test ());
+         assert_eq ~msg:"autonomous acquired before retry boundary"
+           ~expected:(autonomous_before - 1)
+           ~actual:(KK.autonomous_turn_semaphore_value_for_test ());
+         if not (slot_control.is_held ()) then
+           failwith "retry control reported no held autonomous slot";
+         Eio.Fiber.yield ();
+         assert_eq ~msg:"turn remains held across autonomous retry boundary"
+           ~expected:(turn_before - 1)
+           ~actual:(KK.turn_semaphore_value_for_test ());
+         assert_eq ~msg:"autonomous remains held across retry boundary"
+           ~expected:(autonomous_before - 1)
+           ~actual:(KK.autonomous_turn_semaphore_value_for_test ());
+         let delay =
+           let ticket =
+             KK.enqueue_autonomous_waiter_for_test "diag-retry-waiting-peer"
+           in
+           Fun.protect
+             ~finally:(fun () -> KK.drop_autonomous_waiter_for_test ticket)
+             (fun () ->
+                KK.fairness_delay_sec_at
+                  ~keeper_name ~now:(Time_compat.now ()))
+         in
+         if delay <> 0.0 then
+           failwith
+             (Printf.sprintf
+                "retry boundary stamped normal autonomous completion: delay=%.3f"
+                delay);
+         assert_eq ~msg:"turn still held before autonomous finalizer"
+           ~expected:(turn_before - 1)
+           ~actual:(KK.turn_semaphore_value_for_test ());
+         assert_eq ~msg:"autonomous still held before finalizer"
+           ~expected:(autonomous_before - 1)
+           ~actual:(KK.autonomous_turn_semaphore_value_for_test ()))
+  in
+  (match result with
+   | Ok () -> ()
+   | Error (`Semaphore_wait_timeout _) ->
+       failwith "unexpected semaphore wait timeout in test");
+  assert_eq ~msg:"turn baseline after autonomous retry observation"
+    ~expected:turn_before
+    ~actual:(KK.turn_semaphore_value_for_test ());
+  assert_eq ~msg:"autonomous baseline after retry observation"
+    ~expected:autonomous_before
+    ~actual:(KK.autonomous_turn_semaphore_value_for_test ())
+
+let test_blocking_io_control_releases_and_reacquires_reactive_slot () =
+  let keeper_name = "diag-blocking-io-reactive" in
+  let turn_before = KK.turn_semaphore_value_for_test () in
+  let reactive_before = KK.reactive_turn_semaphore_value_for_test () in
+  let result =
+    KK.with_keeper_turn_slot_control_for_test
+      ~keeper_name
+      ~channel:Masc.Keeper_world_observation.Reactive
+      (fun ~semaphore_wait_ms:_ ~slot_control ->
+         assert_eq ~msg:"turn acquired before blocking I/O release"
+           ~expected:(turn_before - 1)
+           ~actual:(KK.turn_semaphore_value_for_test ());
+         assert_eq ~msg:"reactive acquired before blocking I/O release"
+           ~expected:(reactive_before - 1)
+           ~actual:(KK.reactive_turn_semaphore_value_for_test ());
+         slot_control.release_for_blocking_io ();
+         assert_eq ~msg:"turn restored during blocking I/O"
+           ~expected:turn_before
+           ~actual:(KK.turn_semaphore_value_for_test ());
+         assert_eq ~msg:"reactive restored during blocking I/O"
+           ~expected:reactive_before
+           ~actual:(KK.reactive_turn_semaphore_value_for_test ());
+         let peer =
+           KK.with_keeper_turn_slot_for_test
+             ~keeper_name:"diag-blocking-io-reactive-peer"
+             ~channel:Masc.Keeper_world_observation.Reactive
+             (fun ~semaphore_wait_ms:_ -> ())
+         in
+         (match peer with
+          | Ok () -> ()
+          | Error (`Semaphore_wait_timeout _) ->
+            failwith "peer could not acquire released blocking I/O slot");
+         (match slot_control.reacquire_after_blocking_io () with
+          | Ok wait_ms when wait_ms >= 0 -> ()
+          | Ok _ -> failwith "blocking I/O reacquire returned negative wait"
+          | Error (`Semaphore_wait_timeout _) ->
+            failwith "blocking I/O reacquire unexpectedly timed out");
+         assert_eq ~msg:"turn reacquired after blocking I/O"
+           ~expected:(turn_before - 1)
+           ~actual:(KK.turn_semaphore_value_for_test ());
+         assert_eq ~msg:"reactive reacquired after blocking I/O"
+           ~expected:(reactive_before - 1)
+           ~actual:(KK.reactive_turn_semaphore_value_for_test ()))
+  in
+  (match result with
+   | Ok () -> ()
+   | Error (`Semaphore_wait_timeout _) ->
+     failwith "unexpected semaphore wait timeout in test");
+  assert_eq ~msg:"turn baseline after blocking I/O finalizer"
+    ~expected:turn_before
+    ~actual:(KK.turn_semaphore_value_for_test ());
+  assert_eq ~msg:"reactive baseline after blocking I/O finalizer"
+    ~expected:reactive_before
+    ~actual:(KK.reactive_turn_semaphore_value_for_test ())
+
+let test_blocking_io_control_autonomous_release_skips_completion_stamp () =
+  let keeper_name = "diag-blocking-io-autonomous" in
+  let turn_before = KK.turn_semaphore_value_for_test () in
+  let autonomous_before = KK.autonomous_turn_semaphore_value_for_test () in
+  let result =
+    KK.with_keeper_turn_slot_control_for_test
+      ~keeper_name
+      ~channel:Masc.Keeper_world_observation.Scheduled_autonomous
+      (fun ~semaphore_wait_ms:_ ~slot_control ->
+         assert_eq ~msg:"turn acquired before autonomous blocking I/O release"
+           ~expected:(turn_before - 1)
+           ~actual:(KK.turn_semaphore_value_for_test ());
+         assert_eq ~msg:"autonomous acquired before blocking I/O release"
+           ~expected:(autonomous_before - 1)
+           ~actual:(KK.autonomous_turn_semaphore_value_for_test ());
+         slot_control.release_for_blocking_io ();
+         assert_eq ~msg:"turn restored by autonomous blocking I/O release"
+           ~expected:turn_before
+           ~actual:(KK.turn_semaphore_value_for_test ());
+         assert_eq ~msg:"autonomous restored by blocking I/O release"
+           ~expected:autonomous_before
+           ~actual:(KK.autonomous_turn_semaphore_value_for_test ());
+         let delay =
+           let ticket =
+             KK.enqueue_autonomous_waiter_for_test "diag-blocking-io-waiting-peer"
+           in
+           Fun.protect
+             ~finally:(fun () -> KK.drop_autonomous_waiter_for_test ticket)
+             (fun () ->
+                KK.fairness_delay_sec_at
+                  ~keeper_name ~now:(Time_compat.now ()))
+         in
+         if delay <> 0.0 then
+           failwith
+             (Printf.sprintf
+                "blocking I/O release stamped normal autonomous completion: delay=%.3f"
+                delay);
+         (match slot_control.reacquire_after_blocking_io () with
+          | Ok _ -> ()
+          | Error (`Semaphore_wait_timeout _) ->
+            failwith "autonomous blocking I/O reacquire unexpectedly timed out");
+         assert_eq ~msg:"turn reacquired after autonomous blocking I/O"
+           ~expected:(turn_before - 1)
+           ~actual:(KK.turn_semaphore_value_for_test ());
+         assert_eq ~msg:"autonomous reacquired after blocking I/O"
+           ~expected:(autonomous_before - 1)
+           ~actual:(KK.autonomous_turn_semaphore_value_for_test ()))
+  in
+  (match result with
+   | Ok () -> ()
+   | Error (`Semaphore_wait_timeout _) ->
+     failwith "unexpected semaphore wait timeout in test");
+  assert_eq ~msg:"turn baseline after autonomous blocking I/O control"
+    ~expected:turn_before
+    ~actual:(KK.turn_semaphore_value_for_test ());
+  assert_eq ~msg:"autonomous baseline after blocking I/O control"
+    ~expected:autonomous_before
+    ~actual:(KK.autonomous_turn_semaphore_value_for_test ())
+
 let test_no_clock_exhausted_turn_slot_fails_closed () =
   match Eio_context.get_clock_opt () with
   | Some _ ->
@@ -477,6 +695,14 @@ let () =
         test_force_release_marker_does_not_leak_to_replacement;
       "force released autonomous holder skips completion stamp",
         test_force_released_autonomous_holder_does_not_stamp_completion;
+      "retry control keeps reactive slot in same turn",
+        test_retry_control_keeps_reactive_slot_in_same_turn;
+      "retry control keeps autonomous slot in same turn",
+        test_retry_control_keeps_autonomous_slot_in_same_turn;
+      "blocking I/O control releases and reacquires reactive slot",
+        test_blocking_io_control_releases_and_reacquires_reactive_slot;
+      "blocking I/O control autonomous release skips completion stamp",
+        test_blocking_io_control_autonomous_release_skips_completion_stamp;
       "no-clock exhausted turn slot fails closed",
         test_no_clock_exhausted_turn_slot_fails_closed;
       "force release marker ttl bounds unfinalized fibers",


### PR DESCRIPTION
## Summary
- reconcile the merged voice-listen semaphore yield with retry-state cleanup by using explicit blocking I/O turn-slot controls
- thread `turn_slot_control` through the current unified-turn and typed tool-runtime call chain after rebasing onto latest `origin/main`
- fix the typed Shell IR path match drift exposed by the latest main branch (`Go`/`Cargo` constructors)

## Verification
- ocamlformat --check on all changed OCaml files
- git diff --check origin/main...HEAD
- env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_CACHE=disabled scripts/dune-local.sh build @test/runtest-test_keeper_turn_slot_holders @test/runtest-test_voice_runtime_overlay --display=quiet -j 2

## PR state
- rebased on latest origin/main
- mergeable: MERGEABLE
- PR Sync Check: passed