### PR TITLE
fix(keeper): remove turn slot retry reacquire residue

### DIFF
--- a/lib/keeper/keeper_tool_voice_runtime.ml
+++ b/lib/keeper/keeper_tool_voice_runtime.ml
@@ -153,48 +153,22 @@ let handle_speak
            (keeper_text_fallback_json ~agent_id:meta.name ~message)
            memory_status))
 
-let handle_listen ~(meta : keeper_meta) ~(args : Yojson.Safe.t) ?turn_slot_control () =
+let handle_listen ~(meta : keeper_meta) ~(args : Yojson.Safe.t) ?turn_slot_control:_ () =
   let timeout_sec = Safe_ops.json_float ~default:60.0 "timeout_seconds" args in
   let language_code = Safe_ops.json_string_opt "language_code" args in
-  let released =
-    match turn_slot_control with
-    | Some ctrl ->
-      ctrl.Keeper_turn_slot.release_for_retry ();
-      true
-    | None -> false
-  in
-  let result =
-    match
-      Voice_bridge.record_and_transcribe
-        ~agent_id:meta.name
-        ~timeout_sec
-        ?language_code
-        ()
-    with
-    | Ok json -> Yojson.Safe.to_string json
-    | Error err ->
-      Tool_args.error_response_with
-        [ "error", `String err
-        ; "agent_id", `String meta.name
-        ]
-  in
-  if released
-  then (
-    match turn_slot_control with
-    | Some ctrl ->
-      (match ctrl.Keeper_turn_slot.reacquire_after_retry () with
-       | Ok wait_ms ->
-         Log.Keeper.info
-           "%s: reacquired keeper turn slot after voice listen (wait_ms=%d)"
-           meta.name
-           wait_ms
-       | Error (`Semaphore_wait_timeout timeout) ->
-         Log.Keeper.warn
-           "%s: semaphore reacquire timeout after voice listen (waited %.0fs)"
-           meta.name
-           timeout.timeout_wait_sec)
-    | None -> ());
-  result
+  match
+    Voice_bridge.record_and_transcribe
+      ~agent_id:meta.name
+      ~timeout_sec
+      ?language_code
+      ()
+  with
+  | Ok json -> Yojson.Safe.to_string json
+  | Error err ->
+    Tool_args.error_response_with
+      [ "error", `String err
+      ; "agent_id", `String meta.name
+      ]
 
 let handle_agent ~(meta : keeper_meta) =
   match Voice_bridge.get_agent_voice ~agent_id:meta.name with

--- a/lib/keeper/keeper_tools_oas_bundle.ml
+++ b/lib/keeper/keeper_tools_oas_bundle.ml
@@ -203,9 +203,18 @@ let make_tools
       ?search_fn
       ?on_tool_called
       ?clock
+      ?turn_slot_control
       ()
   : Agent_sdk.Tool.t list
   =
-  (make_tool_bundle ~config ~meta ~ctx_snapshot ?search_fn ?on_tool_called ?clock ())
+  (make_tool_bundle
+     ~config
+     ~meta
+     ~ctx_snapshot
+     ?search_fn
+     ?on_tool_called
+     ?clock
+     ?turn_slot_control
+     ())
     .tools
 ;;

--- a/lib/keeper/keeper_tools_oas_bundle.mli
+++ b/lib/keeper/keeper_tools_oas_bundle.mli
@@ -11,6 +11,7 @@ val make_tool_bundle
   -> ?search_fn:(query:string -> max_results:int -> Yojson.Safe.t)
   -> ?on_tool_called:(string -> unit)
   -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
+  -> ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control
   -> unit
   -> Keeper_tools_oas.tool_bundle
 
@@ -22,5 +23,6 @@ val make_tools
   -> ?search_fn:(query:string -> max_results:int -> Yojson.Safe.t)
   -> ?on_tool_called:(string -> unit)
   -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
+  -> ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control
   -> unit
   -> Agent_sdk.Tool.t list

--- a/lib/keeper/keeper_tools_oas_handler.mli
+++ b/lib/keeper/keeper_tools_oas_handler.mli
@@ -26,6 +26,7 @@ val make_keeper_tool_handler
   -> ?search_fn:(query:string -> max_results:int -> Yojson.Safe.t)
   -> ?on_tool_called:(string -> unit)
   -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
+  -> ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control
   -> ?translate_input:(Yojson.Safe.t -> Yojson.Safe.t)
   -> failure_counts:Keeper_tools_oas.failure_counts
   -> unit

--- a/lib/keeper/keeper_tools_oas_handler_exec.mli
+++ b/lib/keeper/keeper_tools_oas_handler_exec.mli
@@ -16,6 +16,7 @@ val execute_with_observers
   -> exec_cache:Masc_exec.Exec_cache.t option
   -> ?search_fn:(query:string -> max_results:int -> Yojson.Safe.t)
   -> ?on_tool_called:(string -> unit)
+  -> ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control
   -> failure_counts:Keeper_tools_oas.failure_counts
   -> key:string
   -> input:Yojson.Safe.t

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -92,7 +92,7 @@ let run (ctx : ctx)
       ; keeper_turn_id
       ; turn_id
       ; channel
-      ; turn_slot_control = _
+      ; turn_slot_control
       ; shared_context
       ; base_dir
       ; build_turn_prompt

--- a/test/test_voice_runtime_overlay.ml
+++ b/test/test_voice_runtime_overlay.ml
@@ -230,6 +230,7 @@ let test_keeper_voice_speak_returns_queued_with_root_switch () =
         ~meta
         ~name:"keeper_voice_speak"
         ~args:(`Assoc [ "message", `String "hello from queued voice test" ])
+        ()
     in
     let json = Yojson.Safe.from_string raw in
     check string "queued status" "queued"
@@ -259,6 +260,7 @@ let test_keeper_voice_speak_records_memory_bank_row () =
         ~meta
         ~name:"keeper_voice_speak"
         ~args:(`Assoc [ "message", `String message; "priority", `Int 3 ])
+        ()
     in
     let json = Yojson.Safe.from_string raw in
     check bool "memory recorded" true
@@ -298,6 +300,7 @@ let test_keeper_voice_speak_text_fallback_records_memory_bank_row () =
       ~meta
       ~name:"keeper_voice_speak"
       ~args:(`Assoc [ "message", `String message ])
+      ()
   in
   let json = Yojson.Safe.from_string raw in
   check string "text fallback status" "text_fallback"
@@ -341,6 +344,7 @@ let test_keeper_voice_session_start_does_not_store_session_name_as_voice () =
         ~meta
         ~name:"keeper_voice_session_start"
         ~args:(`Assoc [ "session_name", `String session_name ])
+        ()
     in
     let json = Yojson.Safe.from_string raw in
     let voice = Yojson.Safe.Util.(member "voice" json |> to_string) in
@@ -351,7 +355,8 @@ let test_keeper_voice_session_start_does_not_store_session_name_as_voice () =
          ~config
          ~meta
          ~name:"keeper_voice_session_end"
-         ~args:(`Assoc [])))
+         ~args:(`Assoc [])
+         ()))
 ;;
 
 let test_keeper_voice_session_end_discards_queued_speech () =
@@ -370,7 +375,8 @@ let test_keeper_voice_session_end_discards_queued_speech () =
          ~config
          ~meta
          ~name:"keeper_voice_session_start"
-         ~args:(`Assoc [ "session_name", `String "drain regression" ]));
+         ~args:(`Assoc [ "session_name", `String "drain regression" ])
+         ());
     let queued =
       Masc.Voice_bridge.enqueue_agent_speak
         ~sw
@@ -392,6 +398,7 @@ let test_keeper_voice_session_end_discards_queued_speech () =
         ~meta
         ~name:"keeper_voice_session_end"
         ~args:(`Assoc [])
+        ()
     in
     let end_json = Yojson.Safe.from_string end_raw in
     check string "session ended" "ended"


### PR DESCRIPTION
## Summary
- keep timeout/retry boundaries inside the original keeper turn slot instead of exposing release/reacquire controls again
- align OAS handler signatures for the remaining observation-only turn slot control
- fix voice runtime tests now that handle_voice_tool has a final unit argument

## Validation
- ocamlformat --check lib/keeper/keeper_tool_voice_runtime.ml lib/keeper/keeper_tools_oas_bundle.ml lib/keeper/keeper_tools_oas_bundle.mli lib/keeper/keeper_tools_oas_handler.mli lib/keeper/keeper_tools_oas_handler_exec.mli lib/keeper/keeper_unified_turn_execution.ml test/test_voice_runtime_overlay.ml
- git diff --check
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build --cache=disabled lib/masc.cma test/test_voice_runtime_overlay.exe test/test_keeper_turn_slot_holders.exe
- _build/default/test/test_keeper_turn_slot_holders.exe
- _build/default/test/test_voice_runtime_overlay.exe