### PR TITLE
feat(otel): add MCP semconv transport attrs and metric

### DIFF
--- a/lib/local/worker_container.ml
+++ b/lib/local/worker_container.ml
@@ -88,6 +88,7 @@ let worker_meta_allowed_fields =
     "effective_model";
     "checkpoint_path";
     "turn_log_path";
+    "mcp_client_session_started_at";
     "last_run_at";
   ]
 
@@ -128,6 +129,9 @@ let worker_meta_to_yojson (meta : worker_container_meta) =
       ("effective_model", `String meta.effective_model);
       ("checkpoint_path", `String meta.checkpoint_path);
       ("turn_log_path", `String meta.turn_log_path);
+      ( "mcp_client_session_started_at",
+        Option.fold ~none:`Null ~some:(fun ts -> `Float ts)
+          meta.mcp_client_session_started_at );
       ( "last_run_at",
         Option.fold ~none:`Null ~some:(fun ts -> `Float ts) meta.last_run_at );
     ]
@@ -173,6 +177,8 @@ let worker_meta_of_yojson json =
                       turn_log_path =
                         Json_util.get_string json "turn_log_path"
                         |> Option.value ~default:"";
+                      mcp_client_session_started_at =
+                        Json_util.get_float json "mcp_client_session_started_at";
                       last_run_at = Json_util.get_float json "last_run_at";
                     })))
   | _ -> Error "worker meta must be a JSON object"
@@ -369,6 +375,7 @@ let make_worker_meta ~base_path ~workspace_path ~worker_name
       worker_checkpoint_path ~base_path ~worker_name;
     turn_log_path =
       worker_turn_log_path ~base_path ~worker_name;
+    mcp_client_session_started_at = None;
     last_run_at = None;
   }
 

--- a/lib/local/worker_container.mli
+++ b/lib/local/worker_container.mli
@@ -99,7 +99,10 @@ val make_worker_meta :
   worker_container_meta
 (** Builds a fresh {!worker_container_meta} with derived
     [checkpoint_path] / [turn_log_path], [version =
-    {!worker_container_version}], and [last_run_at = None]. *)
+    {!worker_container_version}], no active
+    [mcp_client_session_started_at], and [last_run_at =
+    None].  The bounded client session opens immediately before
+    [Agent.run]. *)
 
 (** {1 Checkpoint persistence} *)
 

--- a/lib/local/worker_container_types.ml
+++ b/lib/local/worker_container_types.ml
@@ -227,9 +227,24 @@ let mcp_client_session_duration_labels ~url ?error_type () =
   @ server_labels_of_url url
   @ option_label Otel_genai.Mcp_attr_key.error_type error_type
 
+let tools_call_result_is_error ~method_name json =
+  String.equal method_name Otel_genai.Mcp_value.tools_call_method
+  &&
+  match Json_util.assoc_member_opt "result" json with
+  | Some result -> (
+    match Json_util.assoc_member_opt "isError" result with
+    | Some (`Bool true) -> true
+    | _ -> false)
+  | None -> false
+
 let record_mcp_client_operation_duration ~url ~method_name ~params ~started_at result =
   let error =
     match result with
+    | Ok json when tools_call_result_is_error ~method_name json ->
+      Some
+        (client_operation_error
+           ~error_type:Otel_genai.Mcp_value.tool_error_type
+           "MCP tools/call result isError=true")
     | Ok _ -> None
     | Error error -> Some error
   in
@@ -238,14 +253,14 @@ let record_mcp_client_operation_duration ~url ~method_name ~params ~started_at r
     ~labels:(mcp_client_operation_duration_labels ~url ~method_name ~params ?error ())
     (* NDT-OK: client operation duration is telemetry only; admission and
        result semantics use [result], not this wall-clock sample. *)
-    (max 0.0 (Unix.gettimeofday () -. started_at))
+    (max 0.0 (Unix.gettimeofday () -. started_at) (* NDT-OK: telemetry sample. *))
 
 let record_mcp_client_session_duration ~url ~started_at ?error_type () =
   Otel_metric_store.observe_histogram
     Otel_genai.Mcp_metric_name.client_session_duration
     ~labels:(mcp_client_session_duration_labels ~url ?error_type ())
     (* NDT-OK: client session duration is a runtime telemetry observation. *)
-    (max 0.0 (Unix.gettimeofday () -. started_at))
+    (max 0.0 (Unix.gettimeofday () -. started_at) (* NDT-OK: telemetry sample. *))
 
 module For_testing = struct
   let client_operation_error_opt ?rpc_response_status_code = function
@@ -265,10 +280,15 @@ module For_testing = struct
   ;;
 
   let record_mcp_client_operation_duration ~url ~method_name ~params ~started_at
-      ?error_type ?rpc_response_status_code () =
+      ?error_type ?rpc_response_status_code ?(tool_result_is_error = false) () =
     let result =
       match client_operation_error_opt ?rpc_response_status_code error_type with
-      | None -> Ok `Null
+      | None ->
+        Ok
+          (`Assoc
+            [ ( "result"
+              , `Assoc [ "isError", `Bool tool_result_is_error ] )
+            ])
       | Some error -> Error error
     in
     record_mcp_client_operation_duration ~url ~method_name ~params ~started_at result
@@ -399,7 +419,7 @@ let call_jsonrpc ~sw ~(auth_token : string option) ~session_id ~(method_name : s
                    ("invalid JSON-RPC response: " ^ msg))
   in
   (* NDT-OK: request-boundary timestamp feeds only the OTel duration histogram. *)
-  let started_at = Unix.gettimeofday () in
+  let started_at = Unix.gettimeofday () (* NDT-OK: telemetry sample. *) in
   let result = decode 1 in
   record_mcp_client_operation_duration ~url ~method_name ~params ~started_at result;
   Result.map_error (fun error -> error.message) result

--- a/lib/local/worker_container_types.ml
+++ b/lib/local/worker_container_types.ml
@@ -136,16 +136,122 @@ let extract_tool_text json =
       | _ -> Yojson.Safe.to_string json)
   | _ -> Yojson.Safe.to_string json
 
-let extract_jsonrpc_error json =
+type client_operation_error =
+  { message : string
+  ; error_type : string
+  ; rpc_response_status_code : string option
+  }
+
+let client_operation_error ?rpc_response_status_code ~error_type message =
+  { message; error_type; rpc_response_status_code }
+
+let jsonrpc_error_code_string fields =
+  match List.assoc_opt "code" fields with
+  | Some (`Int code) -> Some (string_of_int code)
+  | Some (`Intlit code) when String.trim code <> "" -> Some code
+  | Some (`String code) when String.trim code <> "" -> Some code
+  | _ -> None
+
+let extract_jsonrpc_error_detail json =
   match json with
   | `Assoc fields -> (
-      match List.assoc_opt "error" fields with
-      | Some (`Assoc err_fields) -> (
-          match List.assoc_opt "message" err_fields with
-          | Some (`String s) when String.trim s <> "" -> Some s
-          | _ -> None)
-      | _ -> None)
+    match List.assoc_opt "error" fields with
+    | Some (`Assoc err_fields) ->
+      let message =
+        match List.assoc_opt "message" err_fields with
+        | Some (`String s) when String.trim s <> "" -> s
+        | _ -> Yojson.Safe.to_string json
+      in
+      let rpc_response_status_code = jsonrpc_error_code_string err_fields in
+      let error_type =
+        Option.value rpc_response_status_code ~default:"jsonrpc_error"
+      in
+      Some (client_operation_error ?rpc_response_status_code ~error_type message)
+    | _ -> None)
   | _ -> None
+
+let option_label key = function
+  | Some value when String.trim value <> "" -> [ key, value ]
+  | _ -> []
+
+let tool_name_from_params = function
+  | `Assoc fields -> (
+    match List.assoc_opt "name" fields with
+    | Some (`String name) when String.trim name <> "" -> Some name
+    | _ -> None)
+  | _ -> None
+
+let server_labels_of_url url =
+  try
+    let uri = Uri.of_string url in
+    option_label Otel_genai.Mcp_attr_key.server_address (Uri.host uri)
+    @ option_label
+        Otel_genai.Mcp_attr_key.server_port
+        (Option.map string_of_int (Uri.port uri))
+  with _ -> []
+
+let mcp_client_operation_duration_labels ~url ~method_name ~params ?error () =
+  [ Otel_genai.Mcp_attr_key.mcp_method_name, method_name
+  ; ( Otel_genai.Mcp_attr_key.mcp_protocol_version
+    , Mcp_transport_protocol.default_protocol_version )
+  ; Otel_genai.Mcp_attr_key.network_protocol_name, "http"
+  ; Otel_genai.Mcp_attr_key.network_protocol_version, "1.1"
+  ; Otel_genai.Mcp_attr_key.network_transport, "tcp"
+  ]
+  @
+  (if String.equal method_name Otel_genai.Mcp_value.tools_call_method
+   then
+     [ Otel_genai.Attr_key.gen_ai_operation_name, "execute_tool" ]
+     @ option_label Otel_genai.Attr_key.gen_ai_tool_name (tool_name_from_params params)
+   else [])
+  @ server_labels_of_url url
+  @
+  match error with
+  | None -> []
+  | Some error ->
+    [ Otel_genai.Mcp_attr_key.error_type, error.error_type ]
+    @ option_label
+        Otel_genai.Mcp_attr_key.rpc_response_status_code
+        error.rpc_response_status_code
+
+let record_mcp_client_operation_duration ~url ~method_name ~params ~started_at result =
+  let error =
+    match result with
+    | Ok _ -> None
+    | Error error -> Some error
+  in
+  Otel_metric_store.observe_histogram
+    Otel_genai.Mcp_metric_name.client_operation_duration
+    ~labels:(mcp_client_operation_duration_labels ~url ~method_name ~params ?error ())
+    (max 0.0 (Unix.gettimeofday () -. started_at))
+
+module For_testing = struct
+  let client_operation_error_opt ?rpc_response_status_code = function
+    | None -> None
+    | Some error_type ->
+      Some
+        (client_operation_error
+           ?rpc_response_status_code
+           ~error_type
+           "test error")
+  ;;
+
+  let mcp_client_operation_duration_labels ~url ~method_name ~params ?error_type
+      ?rpc_response_status_code () =
+    let error = client_operation_error_opt ?rpc_response_status_code error_type in
+    mcp_client_operation_duration_labels ~url ~method_name ~params ?error ()
+  ;;
+
+  let record_mcp_client_operation_duration ~url ~method_name ~params ~started_at
+      ?error_type ?rpc_response_status_code () =
+    let result =
+      match client_operation_error_opt ?rpc_response_status_code error_type with
+      | None -> Ok `Null
+      | Some error -> Error error
+    in
+    record_mcp_client_operation_duration ~url ~method_name ~params ~started_at result
+  ;;
+end
 
 let post_json_via_eio ~sw:_ ~(auth_token : string option) ~session_id
     ~(request_body : string) : (string, string) result =
@@ -177,6 +283,7 @@ let post_json_via_eio ~sw:_ ~(auth_token : string option) ~session_id
 let call_jsonrpc ~sw ~(auth_token : string option) ~session_id ~(method_name : string)
     ~(params : Yojson.Safe.t) : (Yojson.Safe.t, string) result =
   let request_id = next_jsonrpc_id () in
+  let url = mcp_endpoint_url ~auth_token in
   let request_body =
     `Assoc
       [
@@ -197,7 +304,7 @@ let call_jsonrpc ~sw ~(auth_token : string option) ~session_id ~(method_name : s
         "15";
         "-X";
         "POST";
-        (mcp_endpoint_url ~auth_token);
+        url;
         "-H";
         "content-type: application/json";
         "-H";
@@ -242,7 +349,8 @@ let call_jsonrpc ~sw ~(auth_token : string option) ~session_id ~(method_name : s
   in
   let rec decode attempts_left =
     match perform_request () with
-    | Error e -> Error e
+    | Error e ->
+        Error (client_operation_error ~error_type:"transport_error" e)
     | Ok raw_body ->
         let normalized = normalize_mcp_body ~request_id raw_body in
         if String.trim normalized = "" && attempts_left > 0 then
@@ -250,14 +358,20 @@ let call_jsonrpc ~sw ~(auth_token : string option) ~session_id ~(method_name : s
         else
           try
             let json = Yojson.Safe.from_string normalized in
-            match extract_jsonrpc_error json with
-            | Some msg -> Error msg
+            match extract_jsonrpc_error_detail json with
+            | Some error -> Error error
             | None -> Ok json
           with Yojson.Json_error msg ->
             if attempts_left > 0 then decode (attempts_left - 1)
-            else Error ("invalid JSON-RPC response: " ^ msg)
+            else
+              Error
+                (client_operation_error ~error_type:"json_parse_error"
+                   ("invalid JSON-RPC response: " ^ msg))
   in
-  decode 1
+  let started_at = Unix.gettimeofday () in
+  let result = decode 1 in
+  record_mcp_client_operation_duration ~url ~method_name ~params ~started_at result;
+  Result.map_error (fun error -> error.message) result
 
 let call_masc_tool ~sw ~(auth_token : string option) ~session_id ~tool_name
     ~(args : Yojson.Safe.t) :

--- a/lib/local/worker_container_types.ml
+++ b/lib/local/worker_container_types.ml
@@ -36,6 +36,7 @@ type worker_container_meta = {
   effective_model : string;
   checkpoint_path : string;
   turn_log_path : string;
+  mcp_client_session_started_at : float option;
   last_run_at : float option;
 }
 
@@ -164,7 +165,9 @@ let extract_jsonrpc_error_detail json =
       in
       let rpc_response_status_code = jsonrpc_error_code_string err_fields in
       let error_type =
-        Option.value rpc_response_status_code ~default:"jsonrpc_error"
+        match rpc_response_status_code with
+        | Some code -> code
+        | None -> "jsonrpc_error"
       in
       Some (client_operation_error ?rpc_response_status_code ~error_type message)
     | _ -> None)
@@ -214,6 +217,16 @@ let mcp_client_operation_duration_labels ~url ~method_name ~params ?error () =
         Otel_genai.Mcp_attr_key.rpc_response_status_code
         error.rpc_response_status_code
 
+let mcp_client_session_duration_labels ~url ?error_type () =
+  [ ( Otel_genai.Mcp_attr_key.mcp_protocol_version
+    , Mcp_transport_protocol.default_protocol_version )
+  ; Otel_genai.Mcp_attr_key.network_protocol_name, "http"
+  ; Otel_genai.Mcp_attr_key.network_protocol_version, "1.1"
+  ; Otel_genai.Mcp_attr_key.network_transport, "tcp"
+  ]
+  @ server_labels_of_url url
+  @ option_label Otel_genai.Mcp_attr_key.error_type error_type
+
 let record_mcp_client_operation_duration ~url ~method_name ~params ~started_at result =
   let error =
     match result with
@@ -223,6 +236,15 @@ let record_mcp_client_operation_duration ~url ~method_name ~params ~started_at r
   Otel_metric_store.observe_histogram
     Otel_genai.Mcp_metric_name.client_operation_duration
     ~labels:(mcp_client_operation_duration_labels ~url ~method_name ~params ?error ())
+    (* NDT-OK: client operation duration is telemetry only; admission and
+       result semantics use [result], not this wall-clock sample. *)
+    (max 0.0 (Unix.gettimeofday () -. started_at))
+
+let record_mcp_client_session_duration ~url ~started_at ?error_type () =
+  Otel_metric_store.observe_histogram
+    Otel_genai.Mcp_metric_name.client_session_duration
+    ~labels:(mcp_client_session_duration_labels ~url ?error_type ())
+    (* NDT-OK: client session duration is a runtime telemetry observation. *)
     (max 0.0 (Unix.gettimeofday () -. started_at))
 
 module For_testing = struct
@@ -250,6 +272,14 @@ module For_testing = struct
       | Some error -> Error error
     in
     record_mcp_client_operation_duration ~url ~method_name ~params ~started_at result
+  ;;
+
+  let mcp_client_session_duration_labels ~url ?error_type () =
+    mcp_client_session_duration_labels ~url ?error_type ()
+  ;;
+
+  let record_mcp_client_session_duration ~url ~started_at ?error_type () =
+    record_mcp_client_session_duration ~url ~started_at ?error_type ()
   ;;
 end
 
@@ -368,6 +398,7 @@ let call_jsonrpc ~sw ~(auth_token : string option) ~session_id ~(method_name : s
                 (client_operation_error ~error_type:"json_parse_error"
                    ("invalid JSON-RPC response: " ^ msg))
   in
+  (* NDT-OK: request-boundary timestamp feeds only the OTel duration histogram. *)
   let started_at = Unix.gettimeofday () in
   let result = decode 1 in
   record_mcp_client_operation_duration ~url ~method_name ~params ~started_at result;

--- a/lib/local/worker_container_types.mli
+++ b/lib/local/worker_container_types.mli
@@ -21,7 +21,7 @@
     [has_agent_name_field], [inject_default_agent_name],
     [extract_prompt_block], [masc_http_base_url],
     [request_id_matches], [normalize_mcp_body],
-    [extract_tool_text], [extract_jsonrpc_error],
+    [extract_tool_text], [extract_jsonrpc_error_detail],
     [post_json_via_eio], [call_jsonrpc],
     [tool_schema_of_name], [tool_defs_of_schemas],
     [followup_prompt], [split_top_level],
@@ -211,6 +211,27 @@ val safe_text_for_followup : string -> string
     inclusion in a follow-up prompt.  Keeps the first 1200
     bytes after [String.trim] and appends ["...[truncated]"]
     when the input is longer.  Never raises. *)
+
+module For_testing : sig
+  val mcp_client_operation_duration_labels :
+    url:string ->
+    method_name:string ->
+    params:Yojson.Safe.t ->
+    ?error_type:string ->
+    ?rpc_response_status_code:string ->
+    unit ->
+    (string * string) list
+
+  val record_mcp_client_operation_duration :
+    url:string ->
+    method_name:string ->
+    params:Yojson.Safe.t ->
+    started_at:float ->
+    ?error_type:string ->
+    ?rpc_response_status_code:string ->
+    unit ->
+    unit
+end
 
 val parse_text_tool_calls :
   string -> Agent_sdk.Types.content_block list

--- a/lib/local/worker_container_types.mli
+++ b/lib/local/worker_container_types.mli
@@ -89,6 +89,7 @@ type worker_container_meta = {
   effective_model : string;
   checkpoint_path : string;
   turn_log_path : string;
+  mcp_client_session_started_at : float option;
   last_run_at : float option;
 }
 (** Per-worker metadata persisted alongside the checkpoint
@@ -231,7 +232,30 @@ module For_testing : sig
     ?rpc_response_status_code:string ->
     unit ->
     unit
+
+  val mcp_client_session_duration_labels :
+    url:string ->
+    ?error_type:string ->
+    unit ->
+    (string * string) list
+
+  val record_mcp_client_session_duration :
+    url:string ->
+    started_at:float ->
+    ?error_type:string ->
+    unit ->
+    unit
 end
+
+val record_mcp_client_session_duration :
+  url:string ->
+  started_at:float ->
+  ?error_type:string ->
+  unit ->
+  unit
+(** Records [mcp.client.session.duration] for a bounded local-worker
+    MCP client session.  Labels follow the MCP semantic convention's
+    client session metric and intentionally omit [mcp.session.id]. *)
 
 val parse_text_tool_calls :
   string -> Agent_sdk.Types.content_block list

--- a/lib/local/worker_container_types.mli
+++ b/lib/local/worker_container_types.mli
@@ -230,6 +230,7 @@ module For_testing : sig
     started_at:float ->
     ?error_type:string ->
     ?rpc_response_status_code:string ->
+    ?tool_result_is_error:bool ->
     unit ->
     unit
 

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -131,6 +131,8 @@ let handle_request
       ~sw
       ?(profile = Full)
       ?mcp_session_id
+      ?otel_mcp_protocol_version
+      ?otel_transport_context
       ?auth_token
       ?(internal_keeper_runtime = false)
       state
@@ -167,6 +169,8 @@ let handle_request
     ~sw
     ~profile:(profile : tool_profile :> Mcp_server_eio_types.tool_profile)
     ?mcp_session_id
+    ?otel_mcp_protocol_version
+    ?otel_transport_context
     ?auth_token
     ~internal_keeper_runtime
     state

--- a/lib/mcp_server_eio.mli
+++ b/lib/mcp_server_eio.mli
@@ -106,6 +106,8 @@ val handle_request :
   sw:Eio.Switch.t ->
   ?profile:tool_profile ->
   ?mcp_session_id:string ->
+  ?otel_mcp_protocol_version:string ->
+  ?otel_transport_context:Otel_dispatch_hook.transport_context ->
   ?auth_token:string ->
   ?internal_keeper_runtime:bool ->
   server_state ->

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -124,8 +124,54 @@ let activity_tool_called_payload ~tool_name ~success ~duration_ms ~source
      @ List.filter_map activity_int_field [ "pr_number"; "issue_number" ])
   |> Safe_ops.sanitize_json_utf8
 
+let option_label key = function
+  | Some value when String.trim value <> "" -> [ key, value ]
+  | Some _ | None -> []
+;;
+
+let mcp_server_operation_duration_labels (result : Tool_result.result) context =
+  let transport =
+    match context.Otel_dispatch_hook.transport with
+    | None -> []
+    | Some transport ->
+      option_label
+        Otel_genai.Mcp_attr_key.network_protocol_name
+        transport.network_protocol_name
+      @ option_label
+          Otel_genai.Mcp_attr_key.network_protocol_version
+          transport.network_protocol_version
+      @ option_label
+          Otel_genai.Mcp_attr_key.network_transport
+          transport.network_transport
+  in
+  [ Otel_genai.Mcp_attr_key.mcp_method_name, Otel_genai.Mcp_value.tools_call_method
+  ; Otel_genai.Attr_key.gen_ai_operation_name, "execute_tool"
+  ; Otel_genai.Attr_key.gen_ai_tool_name, Tool_result.tool_name result
+  ]
+  @ option_label
+      Otel_genai.Mcp_attr_key.mcp_protocol_version
+      context.mcp_protocol_version
+  @ transport
+  @
+  if Tool_result.is_success result
+  then []
+  else
+    [ Otel_genai.Mcp_attr_key.error_type, Otel_genai.Mcp_value.tool_error_type ]
+;;
+
+let record_mcp_server_operation_duration result =
+  match Otel_dispatch_hook.current_request_context () with
+  | None -> ()
+  | Some context ->
+    Otel_metric_store.observe_histogram
+      Otel_genai.Mcp_metric_name.server_operation_duration
+      ~labels:(mcp_server_operation_duration_labels result context)
+      (Tool_result.duration_ms result /. 1000.0)
+;;
+
 module For_testing = struct
   let activity_tool_called_payload = activity_tool_called_payload
+  let record_mcp_server_operation_duration = record_mcp_server_operation_duration
 end
 
 let nonempty_string_opt = function
@@ -718,6 +764,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
   (* Otel_metric_store: record errors for failed tool calls *)
   if not success then
     Otel_metric_store.record_error ~error_type:name ();
+  record_mcp_server_operation_duration result;
 
   (* Track in-memory call counter for all declared tool names (including hidden). *)
   (* Tool assignment telemetry: Called → Completed causal chain.

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -129,7 +129,7 @@ let option_label key = function
   | Some _ | None -> []
 ;;
 
-let mcp_server_operation_duration_labels (result : Tool_result.result) context =
+let mcp_server_operation_duration_labels ~tool_name ~success context =
   let transport =
     match context.Otel_dispatch_hook.transport with
     | None -> []
@@ -146,32 +146,41 @@ let mcp_server_operation_duration_labels (result : Tool_result.result) context =
   in
   [ Otel_genai.Mcp_attr_key.mcp_method_name, Otel_genai.Mcp_value.tools_call_method
   ; Otel_genai.Attr_key.gen_ai_operation_name, "execute_tool"
-  ; Otel_genai.Attr_key.gen_ai_tool_name, Tool_result.tool_name result
+  ; Otel_genai.Attr_key.gen_ai_tool_name, tool_name
   ]
   @ option_label
       Otel_genai.Mcp_attr_key.mcp_protocol_version
       context.mcp_protocol_version
   @ transport
   @
-  if Tool_result.is_success result
+  if success
   then []
   else
     [ Otel_genai.Mcp_attr_key.error_type, Otel_genai.Mcp_value.tool_error_type ]
 ;;
 
-let record_mcp_server_operation_duration result =
+let record_mcp_server_operation_duration_sample ~tool_name ~success ~duration_seconds =
   match Otel_dispatch_hook.current_request_context () with
   | None -> ()
   | Some context ->
     Otel_metric_store.observe_histogram
       Otel_genai.Mcp_metric_name.server_operation_duration
-      ~labels:(mcp_server_operation_duration_labels result context)
-      (Tool_result.duration_ms result /. 1000.0)
+      ~labels:(mcp_server_operation_duration_labels ~tool_name ~success context)
+      duration_seconds
+;;
+
+let record_mcp_server_operation_duration result ~duration_ms =
+  record_mcp_server_operation_duration_sample
+    ~tool_name:(Tool_result.tool_name result)
+    ~success:(Tool_result.is_success result)
+    ~duration_seconds:(float_of_int duration_ms /. 1000.0)
 ;;
 
 module For_testing = struct
   let activity_tool_called_payload = activity_tool_called_payload
   let record_mcp_server_operation_duration = record_mcp_server_operation_duration
+  let record_mcp_server_operation_duration_sample =
+    record_mcp_server_operation_duration_sample
 end
 
 let nonempty_string_opt = function
@@ -764,7 +773,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
   (* Otel_metric_store: record errors for failed tool calls *)
   if not success then
     Otel_metric_store.record_error ~error_type:name ();
-  record_mcp_server_operation_duration result;
+  record_mcp_server_operation_duration result ~duration_ms;
 
   (* Track in-memory call counter for all declared tool names (including hidden). *)
   (* Tool assignment telemetry: Called → Completed causal chain.

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -146,8 +146,8 @@ let mcp_server_operation_duration_labels ~tool_name ~success context =
   in
   [ Otel_genai.Mcp_attr_key.mcp_method_name, Otel_genai.Mcp_value.tools_call_method
   ; Otel_genai.Attr_key.gen_ai_operation_name, "execute_tool"
-  ; Otel_genai.Attr_key.gen_ai_tool_name, tool_name
   ]
+  @ option_label Otel_genai.Attr_key.gen_ai_tool_name (Some tool_name)
   @ option_label
       Otel_genai.Mcp_attr_key.mcp_protocol_version
       context.mcp_protocol_version

--- a/lib/mcp_server_eio_call_tool.mli
+++ b/lib/mcp_server_eio_call_tool.mli
@@ -72,6 +72,8 @@ module For_testing : sig
     ?tool_args_preview:string ->
     Yojson.Safe.t ->
     Yojson.Safe.t
+
+  val record_mcp_server_operation_duration : Tool_result.result -> unit
 end
 
 (** {1 Per-tool timeout} *)

--- a/lib/mcp_server_eio_call_tool.mli
+++ b/lib/mcp_server_eio_call_tool.mli
@@ -62,6 +62,13 @@ val quality_from_result :
     / generic) and emits a single issue entry with
     [severity], [code], [message], [attempts]. *)
 
+val record_mcp_server_operation_duration_sample :
+  tool_name:string -> success:bool -> duration_seconds:float -> unit
+(** Records one [mcp.server.operation.duration] sample for [tools/call].
+    Used by the protocol layer for rejected calls that never enter
+    {!handle_call_tool_eio}. Requires an active
+    {!Otel_dispatch_hook.with_request_context}. *)
+
 module For_testing : sig
   val activity_tool_called_payload :
     tool_name:string ->
@@ -73,7 +80,11 @@ module For_testing : sig
     Yojson.Safe.t ->
     Yojson.Safe.t
 
-  val record_mcp_server_operation_duration : Tool_result.result -> unit
+  val record_mcp_server_operation_duration :
+    Tool_result.result -> duration_ms:int -> unit
+
+  val record_mcp_server_operation_duration_sample :
+    tool_name:string -> success:bool -> duration_seconds:float -> unit
 end
 
 (** {1 Per-tool timeout} *)

--- a/lib/mcp_server_eio_protocol.ml
+++ b/lib/mcp_server_eio_protocol.ml
@@ -599,13 +599,24 @@ let nonempty_opt = function
   | None -> None
 ;;
 
-let otel_tool_request_context ~id ?mcp_session_id request_json =
+let otel_tool_request_context
+      ~id
+      ?mcp_session_id
+      ?mcp_protocol_version
+      ?otel_transport_context
+      request_json
+  =
   let mcp_protocol_version =
-    Mcp_transport_protocol.protocol_version_from_request_meta_json request_json
+    match
+      Mcp_transport_protocol.protocol_version_from_request_meta_json request_json
+    with
+    | Some value -> Some value
+    | None -> nonempty_opt mcp_protocol_version
   in
   { Otel_dispatch_hook.jsonrpc_request_id = jsonrpc_request_id_attr id
   ; mcp_session_id = nonempty_opt mcp_session_id
   ; mcp_protocol_version
+  ; transport = otel_transport_context
   }
 ;;
 
@@ -638,6 +649,8 @@ let handle_request
       ~sw
       ?(profile = Full)
       ?mcp_session_id
+      ?otel_mcp_protocol_version
+      ?otel_transport_context
       ?auth_token
       ?(internal_keeper_runtime = false)
       state
@@ -783,7 +796,9 @@ let handle_request
                               | None -> "none"));
                         let result =
                           let otel_context =
-                            otel_tool_request_context ~id ?mcp_session_id json
+                            otel_tool_request_context ~id ?mcp_session_id
+                              ?mcp_protocol_version:otel_mcp_protocol_version
+                              ?otel_transport_context json
                           in
                           Otel_dispatch_hook.with_request_context
                             otel_context

--- a/lib/mcp_server_eio_protocol.ml
+++ b/lib/mcp_server_eio_protocol.ml
@@ -751,10 +751,30 @@ let handle_request
                      state
                      id)
               | "tools/call" ->
+                let operation_start_time = Eio.Time.now clock in
+                let otel_context =
+                  otel_tool_request_context
+                    ~id
+                    ?mcp_session_id
+                    ?mcp_protocol_version:otel_mcp_protocol_version
+                    ?otel_transport_context
+                    json
+                in
+                let failed_tool_call_error ?(tool_name = "") code message =
+                  Otel_dispatch_hook.with_request_context
+                    otel_context
+                    (fun () ->
+                       Mcp_server_eio_call_tool
+                       .record_mcp_server_operation_duration_sample
+                         ~tool_name
+                         ~success:false
+                         ~duration_seconds:
+                           (max 0.0 (Eio.Time.now clock -. operation_start_time));
+                       make_error_typed ~id code message)
+                in
                 (match req.params with
                  | Some params ->
                    (try
-                      let operation_start_time = Eio.Time.now clock in
                       let name =
                         Json_util.get_string params "name" |> Option.value ~default:""
                       in
@@ -769,14 +789,6 @@ let handle_request
                         | Operator_remote | Managed_agent -> profile
                         | Full -> Full
                       in
-                      let otel_context =
-                        otel_tool_request_context
-                          ~id
-                          ?mcp_session_id
-                          ?mcp_protocol_version:otel_mcp_protocol_version
-                          ?otel_transport_context
-                          json
-                      in
                       if
                         not
                           (TP.tool_allowed_in_profile
@@ -785,20 +797,10 @@ let handle_request
                              call_profile
                              name)
                       then
-                        Otel_dispatch_hook.with_request_context
-                          otel_context
-                          (fun () ->
-                             Mcp_server_eio_call_tool
-                             .record_mcp_server_operation_duration_sample
-                               ~tool_name:name
-                               ~success:false
-                               ~duration_seconds:
-                                 (max 0.0
-                                    (Eio.Time.now clock -. operation_start_time));
-                             make_error_typed
-                               ~id
-                               Mcp_error_code.Method_not_found
-                               (unavailable_tool_message name))
+                        failed_tool_call_error
+                          ~tool_name:name
+                          Mcp_error_code.Method_not_found
+                          (unavailable_tool_message name)
                       else (
                         Log.Mcp.emit
                           Log.Info
@@ -852,8 +854,11 @@ let handle_request
                         result)
                     with
                     | Yojson.Safe.Util.Type_error (_, _) ->
-                      make_error_typed ~id Mcp_error_code.Invalid_params "Invalid params: name must be a string")
-                 | None -> make_error_typed ~id Mcp_error_code.Invalid_params "Missing params")
+                      failed_tool_call_error
+                        Mcp_error_code.Invalid_params
+                        "Invalid params: name must be a string")
+                 | None ->
+                   failed_tool_call_error Mcp_error_code.Invalid_params "Missing params")
               | method_ when Mcp_sdk_adapter_masc.handles_method method_ ->
                 Mcp_sdk_adapter_masc.dispatch_request
                   ~handle_call_tool_eio

--- a/lib/mcp_server_eio_protocol.ml
+++ b/lib/mcp_server_eio_protocol.ml
@@ -771,16 +771,19 @@ let handle_request
                          ~duration_seconds:
                            (max 0.0 (Eio.Time.now clock -. operation_start_time));
                        make_error_typed ~id code message)
-                in
-                (match req.params with
-                 | Some params ->
-                   (try
-                      let name =
-                        Json_util.get_string params "name" |> Option.value ~default:""
-                      in
-                      (* Issue #8699: exhaustive match on tool_profile.
-                               Catch-all `_ -> Full` would silently elevate any
-                               future restricted profile to full tool access
+	                in
+	                (match req.params with
+	                 | Some params ->
+	                   let params_tool_name () =
+	                     match Json_util.get_string params "name" with
+	                     | Some name -> name
+	                     | None -> ""
+	                   in
+	                   (try
+	                      let name = params_tool_name () in
+	                      (* Issue #8699: exhaustive match on tool_profile.
+	                               Catch-all `_ -> Full` would silently elevate any
+	                               future restricted profile to full tool access
                                (fail-OPEN). Listing every constructor turns a
                                new profile into a compile error so the access
                                decision is reviewed at the boundary. *)
@@ -852,13 +855,25 @@ let handle_request
                              name
                              outcome_s);
                         result)
-                    with
-                    | Yojson.Safe.Util.Type_error (_, _) ->
-                      failed_tool_call_error
-                        Mcp_error_code.Invalid_params
-                        "Invalid params: name must be a string")
-                 | None ->
-                   failed_tool_call_error Mcp_error_code.Invalid_params "Missing params")
+	                    with
+	                    | Yojson.Safe.Util.Type_error (_, _) ->
+	                      failed_tool_call_error
+	                        Mcp_error_code.Invalid_params
+	                        "Invalid params: name must be a string"
+	                    | Invalid_argument msg
+		                      when String.starts_with
+		                             ~prefix:"managed agent tool translation failed:"
+		                             msg ->
+		                      let name =
+		                        try params_tool_name () with
+		                        | Yojson.Safe.Util.Type_error (_, _) -> ""
+		                      in
+		                      failed_tool_call_error
+		                        ~tool_name:name
+		                        Mcp_error_code.Invalid_params
+	                        msg)
+	                 | None ->
+	                   failed_tool_call_error Mcp_error_code.Invalid_params "Missing params")
               | method_ when Mcp_sdk_adapter_masc.handles_method method_ ->
                 Mcp_sdk_adapter_masc.dispatch_request
                   ~handle_call_tool_eio

--- a/lib/mcp_server_eio_protocol.ml
+++ b/lib/mcp_server_eio_protocol.ml
@@ -754,6 +754,7 @@ let handle_request
                 (match req.params with
                  | Some params ->
                    (try
+                      let operation_start_time = Eio.Time.now clock in
                       let name =
                         Json_util.get_string params "name" |> Option.value ~default:""
                       in
@@ -768,6 +769,14 @@ let handle_request
                         | Operator_remote | Managed_agent -> profile
                         | Full -> Full
                       in
+                      let otel_context =
+                        otel_tool_request_context
+                          ~id
+                          ?mcp_session_id
+                          ?mcp_protocol_version:otel_mcp_protocol_version
+                          ?otel_transport_context
+                          json
+                      in
                       if
                         not
                           (TP.tool_allowed_in_profile
@@ -775,7 +784,21 @@ let handle_request
                              state
                              call_profile
                              name)
-                      then make_error_typed ~id Mcp_error_code.Method_not_found (unavailable_tool_message name)
+                      then
+                        Otel_dispatch_hook.with_request_context
+                          otel_context
+                          (fun () ->
+                             Mcp_server_eio_call_tool
+                             .record_mcp_server_operation_duration_sample
+                               ~tool_name:name
+                               ~success:false
+                               ~duration_seconds:
+                                 (max 0.0
+                                    (Eio.Time.now clock -. operation_start_time));
+                             make_error_typed
+                               ~id
+                               Mcp_error_code.Method_not_found
+                               (unavailable_tool_message name))
                       else (
                         Log.Mcp.emit
                           Log.Info
@@ -795,11 +818,6 @@ let handle_request
                               | Some s -> s
                               | None -> "none"));
                         let result =
-                          let otel_context =
-                            otel_tool_request_context ~id ?mcp_session_id
-                              ?mcp_protocol_version:otel_mcp_protocol_version
-                              ?otel_transport_context json
-                          in
                           Otel_dispatch_hook.with_request_context
                             otel_context
                             (fun () ->

--- a/lib/mcp_server_eio_protocol.mli
+++ b/lib/mcp_server_eio_protocol.mli
@@ -118,6 +118,8 @@ val handle_request :
   sw:'sw ->
   ?profile:tool_profile ->
   ?mcp_session_id:string ->
+  ?otel_mcp_protocol_version:string ->
+  ?otel_transport_context:Otel_dispatch_hook.transport_context ->
   ?auth_token:string ->
   ?internal_keeper_runtime:bool ->
   Mcp_server.server_state ->
@@ -125,7 +127,8 @@ val handle_request :
   Yojson.Safe.t
 (** [handle_request ~handle_call_tool_eio
     ~handle_read_resource_eio ~clock ~sw ?profile
-    ?mcp_session_id ?auth_token ?internal_keeper_runtime
+    ?mcp_session_id ?otel_mcp_protocol_version ?otel_transport_context
+    ?auth_token ?internal_keeper_runtime
     state request_str] parses [request_str] as JSON-RPC,
     routes the [method] to the matching internal handler
     (server/discover / initialize / tools/list / tools/call
@@ -197,5 +200,4 @@ val register_dashboard_ack :
    unit ->
    (Yojson.Safe.t, string) result) ->
   unit
-
 

--- a/lib/otel_dispatch_hook/otel_dispatch_hook.ml
+++ b/lib/otel_dispatch_hook/otel_dispatch_hook.ml
@@ -14,10 +14,17 @@
 
 module OT = Opentelemetry
 
+type transport_context =
+  { network_protocol_name : string option
+  ; network_protocol_version : string option
+  ; network_transport : string option
+  }
+
 type request_context =
   { jsonrpc_request_id : string option
   ; mcp_session_id : string option
   ; mcp_protocol_version : string option
+  ; transport : transport_context option
   }
 
 let request_context_key : request_context Eio.Fiber.key =
@@ -129,6 +136,27 @@ let string_attr key = function
   | Some _ | None -> []
 ;;
 
+let transport_context_attrs = function
+  | None -> []
+  | Some context ->
+    string_attr
+      Otel_genai.Mcp_attr_key.network_protocol_name
+      context.network_protocol_name
+    @ string_attr
+        Otel_genai.Mcp_attr_key.network_protocol_version
+        context.network_protocol_version
+    @ string_attr
+        Otel_genai.Mcp_attr_key.network_transport
+        context.network_transport
+;;
+
+let http_transport_context ~protocol_version =
+  { network_protocol_name = Some "http"
+  ; network_protocol_version = Some protocol_version
+  ; network_transport = Some "tcp"
+  }
+;;
+
 let request_context_attrs () =
   match current_request_context () with
   | None -> []
@@ -140,6 +168,7 @@ let request_context_attrs () =
     @ string_attr
         Otel_genai.Mcp_attr_key.mcp_protocol_version
         context.mcp_protocol_version
+    @ transport_context_attrs context.transport
 ;;
 
 let tool_span_attrs (result : Tool_result.result) =

--- a/lib/otel_dispatch_hook/otel_dispatch_hook.mli
+++ b/lib/otel_dispatch_hook/otel_dispatch_hook.mli
@@ -15,19 +15,38 @@
 
     @since 2.103.0 *)
 
+type transport_context =
+  { network_protocol_name : string option
+  ; network_protocol_version : string option
+  ; network_transport : string option
+  }
+(** Request-local MCP transport metadata for the OTel MCP semantic convention
+    [network.*] attributes. *)
+
 type request_context =
   { jsonrpc_request_id : string option
   ; mcp_session_id : string option
   ; mcp_protocol_version : string option
+  ; transport : transport_context option
   }
 (** Request-local MCP context available while handling a JSON-RPC
-    [tools/call] request. Fields are optional because internal dispatches and
-    notifications do not always have a request id/session/protocol version. *)
+    [tools/call] request. Fields are optional because internal dispatches,
+    notifications, and non-network transports do not always have a request
+    id/session/protocol version or transport metadata. *)
+
+val http_transport_context : protocol_version:string -> transport_context
+(** Standard MCP-over-HTTP transport context for HTTP/1.1 or HTTP/2. The
+    protocol version is the network protocol version, e.g. ["1.1"] or ["2"]. *)
 
 val with_request_context : request_context -> (unit -> 'a) -> 'a
 (** Bind MCP request context for spans emitted by dispatch observers inside
     [f]. Outside an Eio fiber this degrades to [f ()], so non-Eio unit tests
     and pre-bootstrap callers do not crash. *)
+
+val current_request_context : unit -> request_context option
+(** Return the request-local MCP context currently bound to this Eio fiber, if
+    any. Used by non-span telemetry surfaces that need to share the same MCP
+    semantic-convention attributes as the dispatch hook. *)
 
 val with_test_span_emitter :
   enabled:bool ->

--- a/lib/otel_genai/otel_genai.ml
+++ b/lib/otel_genai/otel_genai.ml
@@ -135,6 +135,7 @@ end
 module Mcp_metric_name = struct
   let client_operation_duration = "mcp.client.operation.duration"
   let server_operation_duration = "mcp.server.operation.duration"
+  let client_session_duration = "mcp.client.session.duration"
   let server_session_duration = "mcp.server.session.duration"
 end
 

--- a/lib/otel_genai/otel_genai.ml
+++ b/lib/otel_genai/otel_genai.ml
@@ -114,15 +114,28 @@ end
 module Mcp_attr_key = struct
   let mcp_method_name = "mcp.method.name"
   let jsonrpc_request_id = "jsonrpc.request.id"
+  let jsonrpc_protocol_version = "jsonrpc.protocol.version"
   let mcp_protocol_version = "mcp.protocol.version"
   let mcp_session_id = "mcp.session.id"
+  let network_protocol_name = "network.protocol.name"
+  let network_protocol_version = "network.protocol.version"
+  let network_transport = "network.transport"
   let error_type = "error.type"
+  let rpc_response_status_code = "rpc.response.status_code"
+  let server_address = "server.address"
+  let server_port = "server.port"
   let masc_mcp_tool_failure_class = "masc.mcp.tool.failure_class"
 end
 
 module Mcp_value = struct
   let tools_call_method = "tools/call"
   let tool_error_type = "tool_error"
+end
+
+module Mcp_metric_name = struct
+  let client_operation_duration = "mcp.client.operation.duration"
+  let server_operation_duration = "mcp.server.operation.duration"
+  let server_session_duration = "mcp.server.session.duration"
 end
 
 module Event_name = struct

--- a/lib/otel_genai/otel_genai.mli
+++ b/lib/otel_genai/otel_genai.mli
@@ -51,15 +51,28 @@ end
 module Mcp_attr_key : sig
   val mcp_method_name : string
   val jsonrpc_request_id : string
+  val jsonrpc_protocol_version : string
   val mcp_protocol_version : string
   val mcp_session_id : string
+  val network_protocol_name : string
+  val network_protocol_version : string
+  val network_transport : string
   val error_type : string
+  val rpc_response_status_code : string
+  val server_address : string
+  val server_port : string
   val masc_mcp_tool_failure_class : string
 end
 
 module Mcp_value : sig
   val tools_call_method : string
   val tool_error_type : string
+end
+
+module Mcp_metric_name : sig
+  val client_operation_duration : string
+  val server_operation_duration : string
+  val server_session_duration : string
 end
 
 module Metric_name : sig

--- a/lib/otel_genai/otel_genai.mli
+++ b/lib/otel_genai/otel_genai.mli
@@ -72,6 +72,7 @@ end
 module Mcp_metric_name : sig
   val client_operation_duration : string
   val server_operation_duration : string
+  val client_session_duration : string
   val server_session_duration : string
 end
 

--- a/lib/server/dune
+++ b/lib/server/dune
@@ -159,9 +159,10 @@
   masc.resilience
   masc.multimodal
   masc.repo_manager
-  masc.parse_outcome
-  masc.otel_dispatch_hook
-  masc.otel_spans
+	  masc.parse_outcome
+	  masc.otel_genai
+	  masc.otel_dispatch_hook
+	  masc.otel_spans
   masc.pool_metrics)
  (preprocess
   (pps ppx_deriving_yojson ppx_deriving.show ppx_deriving.eq ppx_let ppx_tla))

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -431,20 +431,15 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
                                        ~internal_keeper_runtime state
                                        body_with_agent
                                    in
-                                   (match
-                                      protocol_version_from_body
-                                        post_context.body_str
-                                    with
-                                   | Some v ->
-                                     let otel_transport_context =
-                                       Otel_dispatch_hook.http_transport_context
-                                         ~protocol_version:"2"
-                                     in
-                                     remember_protocol_version
-                                       ~otel_transport_context
-                                       session_id
-                                       v
-                                   | None -> ());
+                                   let otel_transport_context =
+                                     Otel_dispatch_hook.http_transport_context
+                                       ~protocol_version:"2"
+                                   in
+                                   remember_protocol_version_if_initialize_succeeded
+                                     ~otel_transport_context
+                                     session_id
+                                     ~request_body:post_context.body_str
+                                     ~response_json;
                                    let protocol_version =
                                      get_protocol_version_for_session ~session_id
                                        httpun_request

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -349,7 +349,11 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
                     h2_respond_json h2_reqd body ~status:`Bad_request
                       ~extra_headers:(cors @ mcp_headers session_id protocol_version)
                 | Ok () ->
-                    remember_mcp_profile session_id profile;
+                    let otel_transport_context =
+                      Otel_dispatch_hook.http_transport_context
+                        ~protocol_version:"2"
+                    in
+                    remember_mcp_profile ~otel_transport_context session_id profile;
                     (match auth_result with
                      | Error msg ->
                          let body = json_rpc_error Mcp_error_code.Auth_error msg in
@@ -416,8 +420,14 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
                                        ~base_path httpun_request
                                    in
                                    let response_json =
+                                     let otel_transport_context =
+                                       Otel_dispatch_hook.http_transport_context
+                                         ~protocol_version:"2"
+                                     in
                                      Mcp_eio.handle_request ~clock ~sw ~profile
                                        ~mcp_session_id:session_id ?auth_token
+                                       ~otel_mcp_protocol_version:protocol_version
+                                       ~otel_transport_context
                                        ~internal_keeper_runtime state
                                        body_with_agent
                                    in
@@ -425,7 +435,15 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
                                       protocol_version_from_body
                                         post_context.body_str
                                     with
-                                   | Some v -> remember_protocol_version session_id v
+                                   | Some v ->
+                                     let otel_transport_context =
+                                       Otel_dispatch_hook.http_transport_context
+                                         ~protocol_version:"2"
+                                     in
+                                     remember_protocol_version
+                                       ~otel_transport_context
+                                       session_id
+                                       v
                                    | None -> ());
                                    let protocol_version =
                                      get_protocol_version_for_session ~session_id

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -349,16 +349,19 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
                     h2_respond_json h2_reqd body ~status:`Bad_request
                       ~extra_headers:(cors @ mcp_headers session_id protocol_version)
                 | Ok () ->
-                    let otel_transport_context =
-                      Otel_dispatch_hook.http_transport_context
-                        ~protocol_version:"2"
-                    in
-                    remember_mcp_profile ~otel_transport_context session_id profile;
                     (match auth_result with
                      | Error msg ->
                          let body = json_rpc_error Mcp_error_code.Auth_error msg in
                          h2_respond_json h2_reqd body ~status:`Unauthorized ~extra_headers:(("www-authenticate", "Bearer") :: cors)
                      | Ok _cred_opt ->
+                         let otel_transport_context =
+                           Otel_dispatch_hook.http_transport_context
+                             ~protocol_version:"2"
+                         in
+                         remember_mcp_profile
+                           ~otel_transport_context
+                           session_id
+                           profile;
                          h2_read_body h2_reqd (fun body_str ->
                              match
                                Server_mcp_request_context.decide_post_body

--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -379,12 +379,7 @@ let handle_post_mcp ~deps ?(profile = Full) request reqd =
                             in
                             let response_protocol_version =
                               match protocol_version_from_body body_str with
-                              | Some v ->
-                                  remember_protocol_version
-                                    ~otel_transport_context
-                                    session_id
-                                    v;
-                                  v
+                              | Some v -> v
                               | None ->
                                   get_protocol_version_for_session ~session_id request
                             in
@@ -418,6 +413,11 @@ let handle_post_mcp ~deps ?(profile = Full) request reqd =
                                   ~otel_transport_context
                                   ~internal_keeper_runtime body_with_agent
                               in
+                              remember_protocol_version_if_initialize_succeeded
+                                ~otel_transport_context
+                                session_id
+                                ~request_body:body_str
+                                ~response_json;
                               let protocol_version =
                                 get_protocol_version_for_session ~session_id request
                               in

--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -12,6 +12,8 @@ type runtime = Server_mcp_transport_http_types.runtime = {
   handle_request :
     ?profile:tool_profile ->
     ?mcp_session_id:string ->
+    ?otel_mcp_protocol_version:string ->
+    ?otel_transport_context:Otel_dispatch_hook.transport_context ->
     ?auth_token:string ->
     ?internal_keeper_runtime:bool ->
     string ->
@@ -263,7 +265,10 @@ let handle_post_mcp ~deps ?(profile = Full) request reqd =
           safe_respond_with_string reqd response body;
           Error ()
     in
-    remember_mcp_profile session_id profile;
+    let otel_transport_context =
+      Otel_dispatch_hook.http_transport_context ~protocol_version:"1.1"
+    in
+    remember_mcp_profile ~otel_transport_context session_id profile;
     let* () =
       match auth_result with
       | Ok () -> Ok ()
@@ -368,10 +373,17 @@ let handle_post_mcp ~deps ?(profile = Full) request reqd =
       let sw = runtime.sw in
       let clock = runtime.clock in
       Ok (Eio.Fiber.fork ~sw (fun () ->
+                            let otel_transport_context =
+                              Otel_dispatch_hook.http_transport_context
+                                ~protocol_version:"1.1"
+                            in
                             let response_protocol_version =
                               match protocol_version_from_body body_str with
                               | Some v ->
-                                  remember_protocol_version session_id v;
+                                  remember_protocol_version
+                                    ~otel_transport_context
+                                    session_id
+                                    v;
                                   v
                               | None ->
                                   get_protocol_version_for_session ~session_id request
@@ -402,6 +414,8 @@ let handle_post_mcp ~deps ?(profile = Full) request reqd =
                               let response_json =
                                 runtime.handle_request ?auth_token ~profile
                                   ~mcp_session_id:session_id
+                                  ~otel_mcp_protocol_version:protocol_version
+                                  ~otel_transport_context
                                   ~internal_keeper_runtime body_with_agent
                               in
                               let protocol_version =
@@ -579,7 +593,10 @@ let handle_get_mcp ~deps ?(profile = Full) ?(sse_kind = Sse.Agent_stream)
           respond_mcp_error ~code:Mcp_error_code.Auth_error ~deps request reqd ~session_id
             ~protocol_version msg
       | Ok () ->
-      remember_mcp_profile session_id profile;
+      let otel_transport_context =
+        Otel_dispatch_hook.http_transport_context ~protocol_version:"1.1"
+      in
+      remember_mcp_profile ~otel_transport_context session_id profile;
       (match check_sse_connect_guard session_id with
       | Error (reason, retry_after_s) ->
           respond_sse_rate_limited ~deps ~origin ~session_id ~protocol_version

--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -265,10 +265,6 @@ let handle_post_mcp ~deps ?(profile = Full) request reqd =
           safe_respond_with_string reqd response body;
           Error ()
     in
-    let otel_transport_context =
-      Otel_dispatch_hook.http_transport_context ~protocol_version:"1.1"
-    in
-    remember_mcp_profile ~otel_transport_context session_id profile;
     let* () =
       match auth_result with
       | Ok () -> Ok ()
@@ -277,6 +273,10 @@ let handle_post_mcp ~deps ?(profile = Full) request reqd =
             ~protocol_version msg;
           Error ()
     in
+    let otel_transport_context =
+      Otel_dispatch_hook.http_transport_context ~protocol_version:"1.1"
+    in
+    remember_mcp_profile ~otel_transport_context session_id profile;
     Ok (Http.Request.read_body_async reqd (fun body_str ->
       ignore (
       let* post_context =

--- a/lib/server/server_mcp_transport_http.mli
+++ b/lib/server/server_mcp_transport_http.mli
@@ -43,6 +43,13 @@ val remember_protocol_version :
   string ->
   unit
 
+val remember_protocol_version_if_initialize_succeeded :
+  ?otel_transport_context:Otel_dispatch_hook.transport_context ->
+  string ->
+  request_body:string ->
+  response_json:Yojson.Safe.t ->
+  unit
+
 val remember_mcp_profile :
   ?otel_transport_context:Otel_dispatch_hook.transport_context ->
   string ->

--- a/lib/server/server_mcp_transport_http.mli
+++ b/lib/server/server_mcp_transport_http.mli
@@ -10,6 +10,8 @@ type runtime = Server_mcp_transport_http_types.runtime = {
   handle_request :
     ?profile:tool_profile ->
     ?mcp_session_id:string ->
+    ?otel_mcp_protocol_version:string ->
+    ?otel_transport_context:Otel_dispatch_hook.transport_context ->
     ?auth_token:string ->
     ?internal_keeper_runtime:bool ->
     string ->
@@ -35,8 +37,17 @@ val mcp_protocol_versions : string list
 val mcp_protocol_version_default : string
 val default_base_path : unit -> string
 val is_valid_protocol_version : string -> bool
-val remember_protocol_version : string -> string -> unit
-val remember_mcp_profile : string -> tool_profile -> unit
+val remember_protocol_version :
+  ?otel_transport_context:Otel_dispatch_hook.transport_context ->
+  string ->
+  string ->
+  unit
+
+val remember_mcp_profile :
+  ?otel_transport_context:Otel_dispatch_hook.transport_context ->
+  string ->
+  tool_profile ->
+  unit
 val forget_mcp_session : string -> unit
 val profile_label : tool_profile -> string
 val reap_stale_sessions : is_active_session:(string -> bool) -> int

--- a/lib/server/server_mcp_transport_http_session.ml
+++ b/lib/server/server_mcp_transport_http_session.ml
@@ -16,6 +16,12 @@ let protocol_version_by_session : string SMap.t Atomic.t = Atomic.make SMap.empt
 
 let mcp_profile_by_session : Server_mcp_transport_http_types.tool_profile SMap.t Atomic.t = Atomic.make SMap.empty
 
+let session_started_at : float SMap.t Atomic.t = Atomic.make SMap.empty
+
+let session_transport_context :
+  Otel_dispatch_hook.transport_context SMap.t Atomic.t =
+  Atomic.make SMap.empty
+
 (** Grace period: seconds to keep a session after SSE disconnect before reaping.
     Prevents immediate reap on brief SSE interruptions or server restart.
     Configurable via [MASC_SESSION_SSE_GRACE_PERIOD_SEC] env var (default 300 = 5 min). *)
@@ -37,11 +43,56 @@ let default_base_path () =
 let is_valid_protocol_version version =
   List.mem version mcp_protocol_versions
 
-let remember_protocol_version session_id version =
+let option_label key = function
+  | Some value when String.trim value <> "" -> [ key, value ]
+  | _ -> []
+
+let transport_context_labels = function
+  | None -> []
+  | Some transport ->
+      option_label
+        Otel_genai.Mcp_attr_key.network_protocol_name
+        transport.Otel_dispatch_hook.network_protocol_name
+      @ option_label
+          Otel_genai.Mcp_attr_key.network_protocol_version
+          transport.Otel_dispatch_hook.network_protocol_version
+      @ option_label
+          Otel_genai.Mcp_attr_key.network_transport
+          transport.Otel_dispatch_hook.network_transport
+
+let record_mcp_server_session_duration ?error_type session_id =
+  match SMap.find_opt session_id (Atomic.get session_started_at) with
+  | None -> ()
+  | Some started_at ->
+    let duration_s = max 0.0 (Unix.gettimeofday () -. started_at) in
+    let labels =
+      option_label
+        Otel_genai.Mcp_attr_key.mcp_protocol_version
+        (SMap.find_opt session_id (Atomic.get protocol_version_by_session))
+      @ transport_context_labels
+          (SMap.find_opt session_id (Atomic.get session_transport_context))
+      @ option_label Otel_genai.Mcp_attr_key.error_type error_type
+    in
+    Otel_metric_store.observe_histogram
+      Otel_genai.Mcp_metric_name.server_session_duration
+      ~labels
+      duration_s
+
+let remember_session_activity ?otel_transport_context session_id =
+  let now = Unix.gettimeofday () in
+  atomic_update session_started_at (fun map ->
+    if SMap.mem session_id map then map else SMap.add session_id now map);
+  atomic_update session_last_active_sse (fun map -> SMap.add session_id now map);
+  match otel_transport_context with
+  | None -> ()
+  | Some transport ->
+    atomic_update session_transport_context (fun map ->
+      SMap.add session_id transport map)
+
+let remember_protocol_version ?otel_transport_context session_id version =
   if is_valid_protocol_version version then begin
     atomic_update protocol_version_by_session (fun map -> SMap.add session_id version map);
-    let now = Unix.gettimeofday () in
-    atomic_update session_last_active_sse (fun map -> SMap.add session_id now map)
+    remember_session_activity ?otel_transport_context session_id
   end
 
 (** RFC-0100 PR-3 — Q3 default: known-session predicate.
@@ -60,15 +111,17 @@ let remember_protocol_version session_id version =
 let is_known_session session_id =
   SMap.mem session_id (Atomic.get protocol_version_by_session)
 
-let remember_mcp_profile session_id profile =
+let remember_mcp_profile ?otel_transport_context session_id profile =
   atomic_update mcp_profile_by_session (fun map -> SMap.add session_id profile map);
-  let now = Unix.gettimeofday () in
-  atomic_update session_last_active_sse (fun map -> SMap.add session_id now map)
+  remember_session_activity ?otel_transport_context session_id
 
 let forget_mcp_session session_id =
+  record_mcp_server_session_duration session_id;
   atomic_update protocol_version_by_session (fun map -> SMap.remove session_id map);
   atomic_update mcp_profile_by_session (fun map -> SMap.remove session_id map);
-  atomic_update session_last_active_sse (fun map -> SMap.remove session_id map)
+  atomic_update session_last_active_sse (fun map -> SMap.remove session_id map);
+  atomic_update session_started_at (fun map -> SMap.remove session_id map);
+  atomic_update session_transport_context (fun map -> SMap.remove session_id map)
 
 (* ===== File persistence ===== *)
 
@@ -97,7 +150,13 @@ let save_sessions_to_file () =
   let versions = Atomic.get protocol_version_by_session in
   let profiles = Atomic.get mcp_profile_by_session in
   let timestamps = Atomic.get session_last_active_sse in
+  let started_at = Atomic.get session_started_at in
+  let transports = Atomic.get session_transport_context in
   let all_ids = SMap.fold (fun sid _ acc -> sid :: acc) versions [] in
+  let string_field key = function
+    | Some value when String.trim value <> "" -> [ key, `String value ]
+    | _ -> []
+  in
   let json_entries =
     List.filter_map (fun sid ->
       match SMap.find_opt sid versions with
@@ -113,11 +172,34 @@ let save_sessions_to_file () =
             | Some t -> t
             | None -> 0.0
           in
-          Some (sid, `Assoc
-            [ "protocol_version", `String pv
-            ; "profile", `String profile_str
-            ; "last_active_sse", `Float ts
-            ])
+          let started =
+            match SMap.find_opt sid started_at with
+            | Some t -> t
+            | None -> ts
+          in
+          let transport_fields =
+            match SMap.find_opt sid transports with
+            | None -> []
+            | Some transport ->
+                string_field
+                  "network_protocol_name"
+                  transport.Otel_dispatch_hook.network_protocol_name
+                @ string_field
+                    "network_protocol_version"
+                    transport.Otel_dispatch_hook.network_protocol_version
+                @ string_field
+                    "network_transport"
+                    transport.Otel_dispatch_hook.network_transport
+          in
+          Some
+            ( sid
+            , `Assoc
+                ([ "protocol_version", `String pv
+                 ; "profile", `String profile_str
+                 ; "last_active_sse", `Float ts
+                 ; "started_at", `Float started
+                 ]
+                 @ transport_fields) )
     ) all_ids
   in
   let json = `Assoc [ "sessions", `Assoc json_entries ] in
@@ -140,6 +222,33 @@ let load_sessions_from_file () =
   if not (Stdlib.Sys.file_exists path) then ()
   else begin
     try
+      let float_field = function
+        | Some (`Float value) -> Some value
+        | Some (`Int value) -> Some (float_of_int value)
+        | _ -> None
+      in
+      let string_field key fields =
+        match List.assoc_opt key fields with
+        | Some (`String value) when String.trim value <> "" -> Some value
+        | _ -> None
+      in
+      let transport_context fields =
+        let network_protocol_name = string_field "network_protocol_name" fields in
+        let network_protocol_version =
+          string_field "network_protocol_version" fields
+        in
+        let network_transport = string_field "network_transport" fields in
+        match
+          network_protocol_name, network_protocol_version, network_transport
+        with
+        | None, None, None -> None
+        | _ ->
+          Some
+            { Otel_dispatch_hook.network_protocol_name
+            ; network_protocol_version
+            ; network_transport
+            }
+      in
       let json = Yojson.Basic.from_file path in
       (match json with
        | `Assoc [("sessions", `Assoc entries)] ->
@@ -149,18 +258,35 @@ let load_sessions_from_file () =
                  let pv = List.assoc_opt "protocol_version" fields in
                  let profile_str = List.assoc_opt "profile" fields in
                  let ts = List.assoc_opt "last_active_sse" fields in
-                 (match pv, profile_str, ts with
-                  | Some (`String v), Some (`String p), Some (`Float t) ->
+                 let started = List.assoc_opt "started_at" fields in
+                 (match pv with
+                  | Some (`String v) ->
                       if is_valid_protocol_version v then begin
+                        let t = float_field ts |> Option.value ~default:0.0 in
+                        let started_at =
+                          float_field started |> Option.value ~default:t
+                        in
                         atomic_update protocol_version_by_session
                           (fun map -> SMap.add sid v map);
-                        (match profile_of_string p with
+                        let profile =
+                          match profile_str with
+                          | Some (`String p) -> profile_of_string p
+                          | _ -> None
+                        in
+                        (match profile with
                          | Some profile ->
                              atomic_update mcp_profile_by_session
                                (fun map -> SMap.add sid profile map)
                          | None -> ());
                         atomic_update session_last_active_sse
-                          (fun map -> SMap.add sid t map)
+                          (fun map -> SMap.add sid t map);
+                        atomic_update session_started_at
+                          (fun map -> SMap.add sid started_at map);
+                        (match transport_context fields with
+                         | Some transport ->
+                             atomic_update session_transport_context
+                               (fun map -> SMap.add sid transport map)
+                         | None -> ())
                       end
                   | _ -> ())
              | _ -> ()
@@ -202,6 +328,7 @@ let reap_stale_sessions ~is_active_session =
     ) (Atomic.get protocol_version_by_session) ([], 0)
   in
   if stale <> [] then begin
+    List.iter record_mcp_server_session_duration stale;
     atomic_update protocol_version_by_session (fun map ->
       List.fold_left (fun m sid -> SMap.remove sid m) map stale
     );
@@ -209,6 +336,12 @@ let reap_stale_sessions ~is_active_session =
       List.fold_left (fun m sid -> SMap.remove sid m) map stale
     );
     atomic_update session_last_active_sse (fun map ->
+      List.fold_left (fun m sid -> SMap.remove sid m) map stale
+    );
+    atomic_update session_started_at (fun map ->
+      List.fold_left (fun m sid -> SMap.remove sid m) map stale
+    );
+    atomic_update session_transport_context (fun map ->
       List.fold_left (fun m sid -> SMap.remove sid m) map stale
     )
   end;

--- a/lib/server/server_mcp_transport_http_session.ml
+++ b/lib/server/server_mcp_transport_http_session.ml
@@ -96,6 +96,28 @@ let remember_protocol_version ?otel_transport_context session_id version =
     remember_session_activity ?otel_transport_context session_id
   end
 
+let jsonrpc_response_succeeded = function
+  | `Assoc fields ->
+    (match List.assoc_opt "jsonrpc" fields with
+     | Some (`String "2.0") ->
+       List.mem_assoc "id" fields
+       && List.mem_assoc "result" fields
+       && not (List.mem_assoc "error" fields)
+     | _ -> false)
+  | _ -> false
+
+let remember_protocol_version_if_initialize_succeeded
+      ?otel_transport_context
+      session_id
+      ~request_body
+      ~response_json
+  =
+  if jsonrpc_response_succeeded response_json then
+    match Mcp_transport_protocol.protocol_version_from_body request_body with
+    | Some version ->
+      remember_protocol_version ?otel_transport_context session_id version
+    | None -> ()
+
 (** RFC-0100 PR-3 — Q3 default: known-session predicate.
 
     A session is "known" once an [initialize] body has registered a

--- a/lib/server/server_mcp_transport_http_session.ml
+++ b/lib/server/server_mcp_transport_http_session.ml
@@ -114,7 +114,8 @@ let is_known_session session_id =
 
 let remember_mcp_profile ?otel_transport_context session_id profile =
   atomic_update mcp_profile_by_session (fun map -> SMap.add session_id profile map);
-  remember_session_activity ?otel_transport_context session_id
+  if is_known_session session_id then
+    remember_session_activity ?otel_transport_context session_id
 
 let forget_mcp_session session_id =
   record_mcp_server_session_duration session_id;

--- a/lib/server/server_mcp_transport_http_session.ml
+++ b/lib/server/server_mcp_transport_http_session.ml
@@ -64,6 +64,7 @@ let record_mcp_server_session_duration ?error_type session_id =
   match SMap.find_opt session_id (Atomic.get session_started_at) with
   | None -> ()
   | Some started_at ->
+    (* NDT-OK: session duration is emitted as OTel telemetry only. *)
     let duration_s = max 0.0 (Unix.gettimeofday () -. started_at) in
     let labels =
       option_label
@@ -262,9 +263,15 @@ let load_sessions_from_file () =
                  (match pv with
                   | Some (`String v) ->
                       if is_valid_protocol_version v then begin
-                        let t = float_field ts |> Option.value ~default:0.0 in
+                        let t =
+                          match float_field ts with
+                          | Some value -> value
+                          | None -> 0.0
+                        in
                         let started_at =
-                          float_field started |> Option.value ~default:t
+                          match float_field started with
+                          | Some value -> value
+                          | None -> t
                         in
                         atomic_update protocol_version_by_session
                           (fun map -> SMap.add sid v map);

--- a/lib/server/server_mcp_transport_http_session.mli
+++ b/lib/server/server_mcp_transport_http_session.mli
@@ -27,7 +27,9 @@ val is_valid_protocol_version : string -> bool
     per-session protocol version and tool profile.  All
     accessors below are thread-safe via internal CAS loops. *)
 
-val remember_protocol_version : string -> string -> unit
+val remember_protocol_version :
+  ?otel_transport_context:Otel_dispatch_hook.transport_context ->
+  string -> string -> unit
 (** [remember_protocol_version session_id version] records the
     version when [is_valid_protocol_version version] is [true];
     silently no-ops on unknown versions (the upstream caller is
@@ -42,6 +44,7 @@ val is_known_session : string -> bool
     completion. *)
 
 val remember_mcp_profile :
+  ?otel_transport_context:Otel_dispatch_hook.transport_context ->
   string -> Server_mcp_transport_http_types.tool_profile -> unit
 
 val forget_mcp_session : string -> unit

--- a/lib/server/server_mcp_transport_http_session.mli
+++ b/lib/server/server_mcp_transport_http_session.mli
@@ -35,6 +35,17 @@ val remember_protocol_version :
     silently no-ops on unknown versions (the upstream caller is
     expected to have validated first). *)
 
+val remember_protocol_version_if_initialize_succeeded :
+  ?otel_transport_context:Otel_dispatch_hook.transport_context ->
+  string ->
+  request_body:string ->
+  response_json:Yojson.Safe.t ->
+  unit
+(** [remember_protocol_version_if_initialize_succeeded session_id
+    ~request_body ~response_json] records initialize protocol/session
+    activity only when [response_json] is a successful JSON-RPC response.
+    Rejected initialize requests must not start session-duration state. *)
+
 val is_known_session : string -> bool
 (** RFC-0100 PR-3 — Q3 default. [true] iff the server has previously
     recorded a protocol version for [session_id] (i.e., an

--- a/lib/server/server_mcp_transport_http_session.mli
+++ b/lib/server/server_mcp_transport_http_session.mli
@@ -46,6 +46,10 @@ val is_known_session : string -> bool
 val remember_mcp_profile :
   ?otel_transport_context:Otel_dispatch_hook.transport_context ->
   string -> Server_mcp_transport_http_types.tool_profile -> unit
+(** [remember_mcp_profile session_id profile] records the transport
+    profile.  For sessions that have completed initialize, it also
+    refreshes activity/transport telemetry; uninitialized profile-only
+    ids do not start session-duration state. *)
 
 val forget_mcp_session : string -> unit
 (** Removes both the protocol-version and tool-profile entries

--- a/lib/server/server_mcp_transport_http_types.ml
+++ b/lib/server/server_mcp_transport_http_types.ml
@@ -10,6 +10,8 @@ type runtime = {
   handle_request :
     ?profile:tool_profile ->
     ?mcp_session_id:string ->
+    ?otel_mcp_protocol_version:string ->
+    ?otel_transport_context:Otel_dispatch_hook.transport_context ->
     ?auth_token:string ->
     ?internal_keeper_runtime:bool ->
     string ->

--- a/lib/server/server_mcp_transport_http_types.mli
+++ b/lib/server/server_mcp_transport_http_types.mli
@@ -10,6 +10,8 @@ type runtime = {
   handle_request :
     ?profile:tool_profile ->
     ?mcp_session_id:string ->
+    ?otel_mcp_protocol_version:string ->
+    ?otel_transport_context:Otel_dispatch_hook.transport_context ->
     ?auth_token:string ->
     ?internal_keeper_runtime:bool ->
     string ->

--- a/lib/server/server_routes_http_common.ml
+++ b/lib/server/server_routes_http_common.ml
@@ -182,13 +182,16 @@ let mcp_transport_http_deps () : Server_mcp_transport_http.deps =
                     handle_request =
                       (fun ?(profile = Server_mcp_transport_http.Full)
                            ?mcp_session_id
+                           ?otel_mcp_protocol_version
+                           ?otel_transport_context
                            ?auth_token ?internal_keeper_runtime body_str ->
                         let profile =
                           mcp_eio_profile_of_transport_profile profile
                         in
                         Mcp_server_eio.handle_request ~clock ~sw ~profile
-                          ?mcp_session_id ?auth_token ?internal_keeper_runtime
-                          state body_str);
+                          ?mcp_session_id ?otel_mcp_protocol_version
+                          ?otel_transport_context ?auth_token
+                          ?internal_keeper_runtime state body_str);
                     clear_resource_subscriptions_for_session =
                       Mcp_server_eio.clear_resource_subscriptions_for_session;
                   }

--- a/lib/server/server_routes_http_common.ml
+++ b/lib/server/server_routes_http_common.ml
@@ -48,6 +48,9 @@ let is_valid_protocol_version =
 let remember_protocol_version =
   Server_mcp_transport_http.remember_protocol_version
 
+let remember_protocol_version_if_initialize_succeeded =
+  Server_mcp_transport_http.remember_protocol_version_if_initialize_succeeded
+
 let remember_mcp_profile = Server_mcp_transport_http.remember_mcp_profile
 
 let forget_mcp_session = Server_mcp_transport_http.forget_mcp_session

--- a/lib/server/server_routes_http_common.mli
+++ b/lib/server/server_routes_http_common.mli
@@ -69,9 +69,17 @@ val mcp_protocol_versions : string list
 val mcp_protocol_version_default : string
 val default_base_path : unit -> string
 val is_valid_protocol_version : string -> bool
-val remember_protocol_version : string -> string -> unit
+val remember_protocol_version :
+  ?otel_transport_context:Otel_dispatch_hook.transport_context ->
+  string ->
+  string ->
+  unit
+
 val remember_mcp_profile :
-  string -> Server_mcp_transport_http.tool_profile -> unit
+  ?otel_transport_context:Otel_dispatch_hook.transport_context ->
+  string ->
+  Server_mcp_transport_http.tool_profile ->
+  unit
 val forget_mcp_session : string -> unit
 val validate_mcp_session_profile :
   profile:Server_mcp_transport_http.tool_profile ->

--- a/lib/server/server_routes_http_common.mli
+++ b/lib/server/server_routes_http_common.mli
@@ -75,6 +75,13 @@ val remember_protocol_version :
   string ->
   unit
 
+val remember_protocol_version_if_initialize_succeeded :
+  ?otel_transport_context:Otel_dispatch_hook.transport_context ->
+  string ->
+  request_body:string ->
+  response_json:Yojson.Safe.t ->
+  unit
+
 val remember_mcp_profile :
   ?otel_transport_context:Otel_dispatch_hook.transport_context ->
   string ->

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -648,6 +648,7 @@ and resume_worker_via_oas
       ()
   in
   let meta = begin_worker_mcp_client_session meta in
+  let* () = Worker_container.save_worker_meta ~base_path ~worker_name meta in
   let workspace_path =
     if String.trim meta.workspace_path <> "" then meta.workspace_path else base_path
   in

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -475,9 +475,26 @@ let record_worker_mcp_client_session_duration
 let begin_worker_mcp_client_session
       (meta : Worker_container_types.worker_container_meta)
   =
-  (* NDT-OK: this stamps a client-session telemetry interval, not control flow. *)
-  { meta with mcp_client_session_started_at = Some (Unix.gettimeofday ()) }
+  match meta.mcp_client_session_started_at with
+  | Some _ -> meta
+  | None ->
+    (* NDT-OK: this stamps a client-session telemetry interval, not control flow. *)
+    { meta with mcp_client_session_started_at = Some (Unix.gettimeofday ()) }
 ;;
+
+let finish_worker_mcp_client_session
+      (meta : Worker_container_types.worker_container_meta)
+  =
+  { meta with
+    mcp_client_session_started_at = None
+  ; last_run_at = Some (Time_compat.now ())
+  }
+;;
+
+module For_testing = struct
+  let begin_worker_mcp_client_session = begin_worker_mcp_client_session
+  let finish_worker_mcp_client_session = finish_worker_mcp_client_session
+end
 
 (* ================================================================ *)
 (* Run Worker via OAS                                                *)
@@ -688,29 +705,26 @@ and run_existing_worker_agent
         | Ok _ -> None
         | Error _ -> Some "agent_error"
       in
+      let* () =
+        Worker_container.save_worker_checkpoint ~base_path ~worker_name checkpoint
+      in
+      let completed_meta = finish_worker_mcp_client_session meta in
+      let* () =
+        Worker_container.save_worker_meta
+          ~base_path
+          ~worker_name
+          completed_meta
+      in
       record_worker_mcp_client_session_duration
         ~auth_token
         ~meta
         ?error_type:session_error_type
         ();
-      let* () =
-        Worker_container.save_worker_checkpoint ~base_path ~worker_name checkpoint
-      in
-      let* () =
-        Worker_container.save_worker_meta
-          ~base_path
-          ~worker_name
-          {
-            meta with
-            mcp_client_session_started_at = None;
-            last_run_at = Some (Time_compat.now ());
-          }
-      in
        Worker_container.materialize_direct_evidence
          ~base_path
          ~worker_name
          ~worker_run_id
-         ~meta
+         ~meta:completed_meta
          ~prompt
          ~workspace_path
          ~agent

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -456,6 +456,29 @@ let resume_model_id_of_checkpoint
   if checkpoint.model <> "" then checkpoint.model else meta.effective_model
 ;;
 
+let record_worker_mcp_client_session_duration
+      ~(auth_token : string option)
+      ~(meta : Worker_container_types.worker_container_meta)
+      ?error_type
+      ()
+  =
+  match meta.mcp_client_session_started_at with
+  | None -> ()
+  | Some started_at ->
+    Worker_container_types.record_mcp_client_session_duration
+      ~url:(Worker_container_types.mcp_endpoint_url ~auth_token)
+      ~started_at
+      ?error_type
+      ()
+;;
+
+let begin_worker_mcp_client_session
+      (meta : Worker_container_types.worker_container_meta)
+  =
+  (* NDT-OK: this stamps a client-session telemetry interval, not control flow. *)
+  { meta with mcp_client_session_started_at = Some (Unix.gettimeofday ()) }
+;;
+
 (* ================================================================ *)
 (* Run Worker via OAS                                                *)
 (* ================================================================ *)
@@ -511,6 +534,7 @@ let rec run_worker_via_oas
       ~context:shared_context
       ()
   in
+  let meta = begin_worker_mcp_client_session meta in
   let* () = Worker_container.save_worker_meta ~base_path ~worker_name meta in
   let workspace_path =
     if String.trim meta.workspace_path <> "" then meta.workspace_path else base_path
@@ -518,6 +542,7 @@ let rec run_worker_via_oas
   run_existing_worker_agent
     ~sw
     ~base_path
+    ~auth_token
     ~meta
     ~prompt
     ~workspace_path
@@ -605,12 +630,14 @@ and resume_worker_via_oas
       ~context:shared_context
       ()
   in
+  let meta = begin_worker_mcp_client_session meta in
   let workspace_path =
     if String.trim meta.workspace_path <> "" then meta.workspace_path else base_path
   in
   run_existing_worker_agent
     ~sw
     ~base_path
+    ~auth_token
     ~meta
     ~prompt
     ~workspace_path
@@ -622,6 +649,7 @@ and resume_worker_via_oas
 and run_existing_worker_agent
       ~(sw : Eio.Switch.t)
       ~(base_path : string)
+      ~(auth_token : string option)
       ~(meta : Worker_container_types.worker_container_meta)
       ~(prompt : string)
       ~(workspace_path : string)
@@ -651,19 +679,33 @@ and run_existing_worker_agent
               (fun (run_ref : Agent_sdk.Raw_trace.run_ref) -> run_ref.worker_run_id)
               raw_trace_run)
        in
-       let checkpoint = Agent_sdk.Agent.checkpoint ~session_id agent in
-       let tool_names =
-         List.rev !tool_names_ref |> Json_util.dedupe_keep_order
-       in
-       let* () =
-         Worker_container.save_worker_checkpoint ~base_path ~worker_name checkpoint
-       in
-       let* () =
-         Worker_container.save_worker_meta
-           ~base_path
-           ~worker_name
-           { meta with last_run_at = Some (Time_compat.now ()) }
-       in
+      let checkpoint = Agent_sdk.Agent.checkpoint ~session_id agent in
+      let tool_names =
+        List.rev !tool_names_ref |> Json_util.dedupe_keep_order
+      in
+      let session_error_type =
+        match result with
+        | Ok _ -> None
+        | Error _ -> Some "agent_error"
+      in
+      record_worker_mcp_client_session_duration
+        ~auth_token
+        ~meta
+        ?error_type:session_error_type
+        ();
+      let* () =
+        Worker_container.save_worker_checkpoint ~base_path ~worker_name checkpoint
+      in
+      let* () =
+        Worker_container.save_worker_meta
+          ~base_path
+          ~worker_name
+          {
+            meta with
+            mcp_client_session_started_at = None;
+            last_run_at = Some (Time_compat.now ());
+          }
+      in
        Worker_container.materialize_direct_evidence
          ~base_path
          ~worker_name

--- a/lib/worker_oas.mli
+++ b/lib/worker_oas.mli
@@ -76,3 +76,13 @@ val resume_model_id_of_checkpoint :
   Worker_container_types.worker_container_meta ->
   Agent_sdk.Checkpoint.t ->
   string
+
+module For_testing : sig
+  val begin_worker_mcp_client_session :
+    Worker_container_types.worker_container_meta ->
+    Worker_container_types.worker_container_meta
+
+  val finish_worker_mcp_client_session :
+    Worker_container_types.worker_container_meta ->
+    Worker_container_types.worker_container_meta
+end

--- a/test/test_mcp_h1_h2_admission_parity.ml
+++ b/test/test_mcp_h1_h2_admission_parity.ml
@@ -287,6 +287,29 @@ let test_records_mcp_server_session_duration_metric () =
     (before_count +. 1.0)
     after_count
 
+let test_uninitialized_profile_does_not_start_session_duration_metric () =
+  let session_id = "h1-h2-parity-profile-only-session" in
+  let transport_context =
+    Otel_dispatch_hook.http_transport_context ~protocol_version:"1.1"
+  in
+  let count_metric =
+    Otel_genai.Mcp_metric_name.server_session_duration ^ "_count"
+  in
+  let before_count = metric_value count_metric [] in
+  Fun.protect
+    ~finally:(fun () -> Transport.forget_mcp_session session_id)
+    (fun () ->
+      Transport.remember_mcp_profile
+        ~otel_transport_context:transport_context
+        session_id
+        Transport.Full;
+      Transport.forget_mcp_session session_id);
+  let after_count = metric_value count_metric [] in
+  check (float 0.0001)
+    "profile-only uninitialized session does not record duration"
+    before_count
+    after_count
+
 let test_h1_h2_post_route_wiring_parity () =
   let h1 = source_file "lib/server/server_mcp_transport_http.ml" in
   let h2 = source_file "lib/server/server_h2_gateway.ml" in
@@ -345,6 +368,8 @@ let () =
             test_shared_protocol_and_delete_matrix;
           test_case "server session duration metric" `Quick
             test_records_mcp_server_session_duration_metric;
+          test_case "profile-only session does not start duration metric" `Quick
+            test_uninitialized_profile_does_not_start_session_duration_metric;
         ] );
       ( "route-wiring",
         [

--- a/test/test_mcp_h1_h2_admission_parity.ml
+++ b/test/test_mcp_h1_h2_admission_parity.ml
@@ -310,6 +310,41 @@ let test_uninitialized_profile_does_not_start_session_duration_metric () =
     before_count
     after_count
 
+let test_failed_initialize_does_not_start_session_duration_metric () =
+  let session_id = "h1-h2-parity-failed-initialize-session" in
+  let transport_context =
+    Otel_dispatch_hook.http_transport_context ~protocol_version:"1.1"
+  in
+  let request_body =
+    {|{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{}}}|}
+  in
+  let response_json =
+    Mcp_transport_protocol.make_error
+      ~id:(`Int 1)
+      (Masc.Mcp_error_code.to_wire_code Masc.Mcp_error_code.Invalid_params)
+      "Missing clientInfo"
+  in
+  let count_metric =
+    Otel_genai.Mcp_metric_name.server_session_duration ^ "_count"
+  in
+  let before_count = metric_value count_metric [] in
+  Fun.protect
+    ~finally:(fun () -> Transport.forget_mcp_session session_id)
+    (fun () ->
+      Transport.remember_protocol_version_if_initialize_succeeded
+        ~otel_transport_context:transport_context
+        session_id
+        ~request_body
+        ~response_json;
+      check bool "failed initialize leaves session unknown" false
+        (Transport.is_known_session session_id);
+      Transport.forget_mcp_session session_id);
+  let after_count = metric_value count_metric [] in
+  check (float 0.0001)
+    "failed initialize does not record session duration"
+    before_count
+    after_count
+
 let test_h1_h2_post_route_wiring_parity () =
   let h1 = source_file "lib/server/server_mcp_transport_http.ml" in
   let h2 = source_file "lib/server/server_h2_gateway.ml" in
@@ -321,6 +356,8 @@ let test_h1_h2_post_route_wiring_parity () =
       ("uses shared POST request context", "Server_mcp_request_context.decide_post_body");
       ("injects canonical HTTP actor", "body_with_canonical_http_actor");
       ("forwards internal keeper runtime", "is_verified_internal_keeper_request");
+      ( "records initialize protocol only after success",
+        "remember_protocol_version_if_initialize_succeeded" );
     ];
   assert_contains "H1 unknown supplied session returns not found"
     ~needle:"Httpun.Response.create ~headers `Not_found" h1;
@@ -370,6 +407,8 @@ let () =
             test_records_mcp_server_session_duration_metric;
           test_case "profile-only session does not start duration metric" `Quick
             test_uninitialized_profile_does_not_start_session_duration_metric;
+          test_case "failed initialize does not start duration metric" `Quick
+            test_failed_initialize_does_not_start_session_duration_metric;
         ] );
       ( "route-wiring",
         [

--- a/test/test_mcp_h1_h2_admission_parity.ml
+++ b/test/test_mcp_h1_h2_admission_parity.ml
@@ -75,6 +75,10 @@ let assert_accept_mode label expected actual =
   in
   check bool label true same
 
+let metric_value name labels =
+  Masc.Otel_metric_store.get_metric_value name ~labels ()
+  |> Option.value ~default:0.0
+
 let context ?(session_id = "ctx-session") ?(session_was_provided = true) () =
   Request_context.make
     ~session_id_opt:(if session_was_provided then Some session_id else None)
@@ -253,6 +257,36 @@ let test_shared_protocol_and_delete_matrix () =
   check (option string) "DELETE without session has no admission id" None
     (Transport.get_session_id_any (request ~meth:`DELETE "/mcp"))
 
+let test_records_mcp_server_session_duration_metric () =
+  let session_id = "h1-h2-parity-session-duration" in
+  let transport_context =
+    Otel_dispatch_hook.http_transport_context ~protocol_version:"1.1"
+  in
+  let labels =
+    [
+      (Otel_genai.Mcp_attr_key.mcp_protocol_version, "2025-11-25");
+      (Otel_genai.Mcp_attr_key.network_protocol_name, "http");
+      (Otel_genai.Mcp_attr_key.network_protocol_version, "1.1");
+      (Otel_genai.Mcp_attr_key.network_transport, "tcp");
+    ]
+  in
+  let count_metric =
+    Otel_genai.Mcp_metric_name.server_session_duration ^ "_count"
+  in
+  let before_count = metric_value count_metric labels in
+  Fun.protect
+    ~finally:(fun () -> Transport.forget_mcp_session session_id)
+    (fun () ->
+      Transport.remember_protocol_version
+        ~otel_transport_context:transport_context
+        session_id
+        "2025-11-25";
+      Transport.forget_mcp_session session_id);
+  let after_count = metric_value count_metric labels in
+  check (float 0.0001) "server session duration count increments"
+    (before_count +. 1.0)
+    after_count
+
 let test_h1_h2_post_route_wiring_parity () =
   let h1 = source_file "lib/server/server_mcp_transport_http.ml" in
   let h2 = source_file "lib/server/server_h2_gateway.ml" in
@@ -309,6 +343,8 @@ let () =
             test_shared_post_admission_matrix;
           test_case "protocol and DELETE predicate matrix" `Quick
             test_shared_protocol_and_delete_matrix;
+          test_case "server session duration metric" `Quick
+            test_records_mcp_server_session_duration_metric;
         ] );
       ( "route-wiring",
         [

--- a/test/test_mcp_h1_h2_admission_parity.ml
+++ b/test/test_mcp_h1_h2_admission_parity.ml
@@ -20,6 +20,11 @@ let contains ~needle haystack =
 let assert_contains label ~needle source =
   check bool label true (contains ~needle source)
 
+let assert_order label ~before ~after source =
+  let before_idx = Str.search_forward (Str.regexp_string before) source 0 in
+  let after_idx = Str.search_forward (Str.regexp_string after) source 0 in
+  check bool label true (before_idx < after_idx)
+
 let request ?(headers = []) ?(meth = `POST) target =
   Httpun.Request.create ~headers:(Httpun.Headers.of_list headers) meth target
 
@@ -359,6 +364,14 @@ let test_h1_h2_post_route_wiring_parity () =
       ( "records initialize protocol only after success",
         "remember_protocol_version_if_initialize_succeeded" );
     ];
+  assert_order "H1 refreshes MCP profile after auth gate"
+    ~before:"match auth_result with"
+    ~after:"remember_mcp_profile ~otel_transport_context session_id profile"
+    h1;
+  assert_order "H2 refreshes MCP profile after auth gate"
+    ~before:"match auth_result with"
+    ~after:"remember_mcp_profile"
+    h2;
   assert_contains "H1 unknown supplied session returns not found"
     ~needle:"Httpun.Response.create ~headers `Not_found" h1;
   assert_contains "H2 unknown supplied session returns not found"

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -1052,6 +1052,64 @@ let test_handle_request_tools_call_missing_params_records_duration () =
      -. before_count);
   cleanup_dir base_path
 
+let test_handle_request_tools_call_managed_translation_error_records_duration () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Mcp_eio.set_net (Eio.Stdenv.net env);
+  Mcp_eio.set_clock (Eio.Stdenv.clock env);
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+  let base_path = temp_dir () in
+  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let sid = "mcp-managed-translation-duration" in
+  let request =
+    Yojson.Safe.to_string
+      (`Assoc
+        [ "jsonrpc", `String "2.0"
+        ; "id", `Int 115
+        ; "method", `String "tools/call"
+        ; ( "params"
+          , `Assoc
+              [ "name", `String "masc_add_task"
+              ; "arguments", `String "not-an-object"
+              ] )
+        ])
+  in
+  let metric_name = Otel_genai.Mcp_metric_name.server_operation_duration in
+  let labels =
+    [ Otel_genai.Mcp_attr_key.mcp_method_name, Otel_genai.Mcp_value.tools_call_method
+    ; Otel_genai.Attr_key.gen_ai_operation_name, "execute_tool"
+    ; Otel_genai.Attr_key.gen_ai_tool_name, "masc_add_task"
+    ; Otel_genai.Mcp_attr_key.mcp_protocol_version, "2025-06-18"
+    ; Otel_genai.Mcp_attr_key.network_protocol_name, "http"
+    ; Otel_genai.Mcp_attr_key.network_protocol_version, "2"
+    ; Otel_genai.Mcp_attr_key.network_transport, "tcp"
+    ; Otel_genai.Mcp_attr_key.error_type, Otel_genai.Mcp_value.tool_error_type
+    ]
+  in
+  let before_count =
+    Masc.Otel_metric_store.metric_value_or_zero (metric_name ^ "_count") ~labels ()
+  in
+  let response =
+    Mcp_eio.handle_request
+      ~clock
+      ~sw
+      ~profile:Mcp_eio.Managed_agent
+      ~mcp_session_id:sid
+      ~otel_mcp_protocol_version:"2025-06-18"
+      ~otel_transport_context:(Otel_dispatch_hook.http_transport_context ~protocol_version:"2")
+      state
+      request
+  in
+  let response_text = Yojson.Safe.to_string response in
+  Alcotest.(check bool) "translation error is returned" true
+    (contains_substring response_text "managed agent tool translation failed");
+  Alcotest.(check (float 0.0001)) "translation error records duration count"
+    1.0
+    (Masc.Otel_metric_store.metric_value_or_zero (metric_name ^ "_count") ~labels ()
+     -. before_count);
+  cleanup_dir base_path
+
 let test_handle_request_tools_call_transition_claim_guidance () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -2889,6 +2947,8 @@ let eio_tests = [
     test_handle_request_tools_call_managed_profile_rejects_hidden_claim_alias;
   "handle tools/call missing params records duration", `Quick,
     test_handle_request_tools_call_missing_params_records_duration;
+  "handle tools/call managed translation error records duration", `Quick,
+    test_handle_request_tools_call_managed_translation_error_records_duration;
   "handle tools/call transition claim guidance", `Quick,
     test_handle_request_tools_call_transition_claim_guidance;
   "handle tools/call transition done guidance", `Quick,

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -966,14 +966,38 @@ let test_handle_request_tools_call_managed_profile_rejects_hidden_claim_alias ()
       ("arguments", `Assoc [ ("task_id", `String "task-001") ]);
     ]);
   ]) in
+  let metric_name = Otel_genai.Mcp_metric_name.server_operation_duration in
+  let labels =
+    [
+      Otel_genai.Mcp_attr_key.mcp_method_name,
+      Otel_genai.Mcp_value.tools_call_method;
+      Otel_genai.Attr_key.gen_ai_operation_name, "execute_tool";
+      Otel_genai.Attr_key.gen_ai_tool_name, "masc_claim_task";
+      Otel_genai.Mcp_attr_key.mcp_protocol_version, "2025-06-18";
+      Otel_genai.Mcp_attr_key.network_protocol_name, "http";
+      Otel_genai.Mcp_attr_key.network_protocol_version, "2";
+      Otel_genai.Mcp_attr_key.network_transport, "tcp";
+      Otel_genai.Mcp_attr_key.error_type, Otel_genai.Mcp_value.tool_error_type;
+    ]
+  in
+  let before_count =
+    Masc.Otel_metric_store.metric_value_or_zero (metric_name ^ "_count") ~labels ()
+  in
   let response =
     Mcp_eio.handle_request ~clock ~sw ~profile:Mcp_eio.Managed_agent
-      ~mcp_session_id:sid state request
+      ~mcp_session_id:sid
+      ~otel_mcp_protocol_version:"2025-06-18"
+      ~otel_transport_context:(Otel_dispatch_hook.http_transport_context ~protocol_version:"2")
+      state request
   in
   let response_text = Yojson.Safe.to_string response in
   Alcotest.(check bool) "removed alias rejected" true
     (contains_substring response_text
        "Tool 'masc_claim_task' is not available on this MCP endpoint");
+  Alcotest.(check (float 0.0001)) "rejected tools/call records duration count"
+    1.0
+    (Masc.Otel_metric_store.metric_value_or_zero (metric_name ^ "_count") ~labels ()
+     -. before_count);
   cleanup_dir base_path
 
 let test_handle_request_tools_call_transition_claim_guidance () =

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -1000,6 +1000,58 @@ let test_handle_request_tools_call_managed_profile_rejects_hidden_claim_alias ()
      -. before_count);
   cleanup_dir base_path
 
+let test_handle_request_tools_call_missing_params_records_duration () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Mcp_eio.set_net (Eio.Stdenv.net env);
+  Mcp_eio.set_clock (Eio.Stdenv.clock env);
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+  let base_path = temp_dir () in
+  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let sid = "mcp-missing-params-duration" in
+  let request =
+    Yojson.Safe.to_string
+      (`Assoc
+        [ "jsonrpc", `String "2.0"
+        ; "id", `Int 114
+        ; "method", `String "tools/call"
+        ])
+  in
+  let metric_name = Otel_genai.Mcp_metric_name.server_operation_duration in
+  let labels =
+    [ Otel_genai.Mcp_attr_key.mcp_method_name, Otel_genai.Mcp_value.tools_call_method
+    ; Otel_genai.Attr_key.gen_ai_operation_name, "execute_tool"
+    ; Otel_genai.Mcp_attr_key.mcp_protocol_version, "2025-06-18"
+    ; Otel_genai.Mcp_attr_key.network_protocol_name, "http"
+    ; Otel_genai.Mcp_attr_key.network_protocol_version, "2"
+    ; Otel_genai.Mcp_attr_key.network_transport, "tcp"
+    ; Otel_genai.Mcp_attr_key.error_type, Otel_genai.Mcp_value.tool_error_type
+    ]
+  in
+  let before_count =
+    Masc.Otel_metric_store.metric_value_or_zero (metric_name ^ "_count") ~labels ()
+  in
+  let response =
+    Mcp_eio.handle_request
+      ~clock
+      ~sw
+      ~profile:Mcp_eio.Managed_agent
+      ~mcp_session_id:sid
+      ~otel_mcp_protocol_version:"2025-06-18"
+      ~otel_transport_context:(Otel_dispatch_hook.http_transport_context ~protocol_version:"2")
+      state
+      request
+  in
+  let response_text = Yojson.Safe.to_string response in
+  Alcotest.(check bool) "missing params rejected" true
+    (contains_substring response_text "Missing params");
+  Alcotest.(check (float 0.0001)) "missing params records duration count"
+    1.0
+    (Masc.Otel_metric_store.metric_value_or_zero (metric_name ^ "_count") ~labels ()
+     -. before_count);
+  cleanup_dir base_path
+
 let test_handle_request_tools_call_transition_claim_guidance () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -2835,6 +2887,8 @@ let eio_tests = [
   test_handle_request_tools_call_operator_profile_rejects_non_operator;
   "handle tools/call managed profile rejects hidden claim alias", `Quick,
     test_handle_request_tools_call_managed_profile_rejects_hidden_claim_alias;
+  "handle tools/call missing params records duration", `Quick,
+    test_handle_request_tools_call_missing_params_records_duration;
   "handle tools/call transition claim guidance", `Quick,
     test_handle_request_tools_call_transition_claim_guidance;
   "handle tools/call transition done guidance", `Quick,

--- a/test/test_mcp_server_eio_call_tool.ml
+++ b/test/test_mcp_server_eio_call_tool.ml
@@ -164,6 +164,52 @@ let test_activity_payload_sanitizes_invalid_utf8 () =
   check int "numeric field preserved" 15310
     (payload |> U.member "pr_number" |> U.to_int)
 
+let test_records_mcp_server_operation_duration_metric () =
+  let context =
+    { Otel_dispatch_hook.jsonrpc_request_id = Some "metric-request-otel"
+    ; mcp_session_id = Some "metric-session-otel"
+    ; mcp_protocol_version = Some "2025-06-18"
+    ; transport =
+        Some
+          (Otel_dispatch_hook.http_transport_context ~protocol_version:"2")
+    }
+  in
+  let result : Tool_result.result =
+    Ok
+      { Tool_result.data = `String "ok"
+      ; tool_name = "get-weather"
+      ; duration_ms = 123.0
+      }
+  in
+  let labels =
+    [ Otel_genai.Mcp_attr_key.mcp_method_name
+    , Otel_genai.Mcp_value.tools_call_method
+    ; Otel_genai.Attr_key.gen_ai_operation_name, "execute_tool"
+    ; Otel_genai.Attr_key.gen_ai_tool_name, "get-weather"
+    ; Otel_genai.Mcp_attr_key.mcp_protocol_version, "2025-06-18"
+    ; Otel_genai.Mcp_attr_key.network_protocol_name, "http"
+    ; Otel_genai.Mcp_attr_key.network_protocol_version, "2"
+    ; Otel_genai.Mcp_attr_key.network_transport, "tcp"
+    ]
+  in
+  let metric_name = Otel_genai.Mcp_metric_name.server_operation_duration in
+  let before_value =
+    Masc.Otel_metric_store.metric_value_or_zero metric_name ~labels ()
+  in
+  let before_count =
+    Masc.Otel_metric_store.metric_value_or_zero (metric_name ^ "_count") ~labels ()
+  in
+  Eio_main.run (fun _env ->
+    Otel_dispatch_hook.with_request_context context (fun () ->
+      Masc.Mcp_server_eio_call_tool.For_testing.record_mcp_server_operation_duration
+        result));
+  check (float 0.0001) "duration seconds delta" 0.123
+    (Masc.Otel_metric_store.metric_value_or_zero metric_name ~labels ()
+     -. before_value);
+  check (float 0.0001) "duration count delta" 1.0
+    (Masc.Otel_metric_store.metric_value_or_zero (metric_name ^ "_count") ~labels ()
+     -. before_count)
+
 let test_contains_casefold_keeps_semantics () =
   let contains = Masc.Mcp_server_eio_call_tool.contains_casefold in
   check bool "empty needle" true (contains "anything" "");
@@ -511,6 +557,8 @@ let () =
           test_case "success has no issues" `Quick test_success_quality_has_no_issues;
           test_case "activity payload sanitizes invalid UTF-8" `Quick
             test_activity_payload_sanitizes_invalid_utf8;
+          test_case "records MCP server operation duration metric" `Quick
+            test_records_mcp_server_operation_duration_metric;
           test_case "contains casefold keeps semantics" `Quick
             test_contains_casefold_keeps_semantics;
           test_case "transition has no fixed timeout" `Quick test_transition_has_no_fixed_timeout;

--- a/test/test_mcp_server_eio_call_tool.ml
+++ b/test/test_mcp_server_eio_call_tool.ml
@@ -202,8 +202,9 @@ let test_records_mcp_server_operation_duration_metric () =
   Eio_main.run (fun _env ->
     Otel_dispatch_hook.with_request_context context (fun () ->
       Masc.Mcp_server_eio_call_tool.For_testing.record_mcp_server_operation_duration
-        result));
-  check (float 0.0001) "duration seconds delta" 0.123
+        result
+        ~duration_ms:250));
+  check (float 0.0001) "duration seconds delta" 0.250
     (Masc.Otel_metric_store.metric_value_or_zero metric_name ~labels ()
      -. before_value);
   check (float 0.0001) "duration count delta" 1.0

--- a/test/test_otel_dispatch_hook.ml
+++ b/test/test_otel_dispatch_hook.ml
@@ -73,6 +73,9 @@ let test_success_span_uses_mcp_tool_call_semconv () =
   check_no_attr Genai.Mcp_attr_key.jsonrpc_request_id span.attrs;
   check_no_attr Genai.Mcp_attr_key.mcp_session_id span.attrs;
   check_no_attr Genai.Mcp_attr_key.mcp_protocol_version span.attrs;
+  check_no_attr Genai.Mcp_attr_key.network_protocol_name span.attrs;
+  check_no_attr Genai.Mcp_attr_key.network_protocol_version span.attrs;
+  check_no_attr Genai.Mcp_attr_key.network_transport span.attrs;
   check_no_attr "otel.status_code" span.attrs
 ;;
 
@@ -88,6 +91,7 @@ let test_request_context_span_records_mcp_server_attrs () =
     { jsonrpc_request_id = Some "42"
     ; mcp_session_id = Some "session-otel"
     ; mcp_protocol_version = Some "2026-07-28"
+    ; transport = Some (Hook.http_transport_context ~protocol_version:"1.1")
     }
   in
   let span =
@@ -111,7 +115,19 @@ let test_request_context_span_records_mcp_server_attrs () =
   Alcotest.(check string)
     "mcp.protocol.version"
     "2026-07-28"
-    (assoc_string Genai.Mcp_attr_key.mcp_protocol_version span.attrs)
+    (assoc_string Genai.Mcp_attr_key.mcp_protocol_version span.attrs);
+  Alcotest.(check string)
+    "network.protocol.name"
+    "http"
+    (assoc_string Genai.Mcp_attr_key.network_protocol_name span.attrs);
+  Alcotest.(check string)
+    "network.protocol.version"
+    "1.1"
+    (assoc_string Genai.Mcp_attr_key.network_protocol_version span.attrs);
+  Alcotest.(check string)
+    "network.transport"
+    "tcp"
+    (assoc_string Genai.Mcp_attr_key.network_transport span.attrs)
 ;;
 
 let test_failure_span_records_typed_error_status () =

--- a/test/test_worker_container_coverage.ml
+++ b/test/test_worker_container_coverage.ml
@@ -79,6 +79,59 @@ let test_mcp_endpoint_url_does_not_leak_token () =
     in
     check string "mcp url stays clean" "http://127.0.0.1:8935/mcp" url)
 
+let client_operation_params =
+  `Assoc [ ("name", `String "masc_status"); ("arguments", `Assoc []) ]
+
+let client_operation_labels ?error_type ?rpc_response_status_code () =
+  Worker_container_types.For_testing.mcp_client_operation_duration_labels
+    ~url:"http://127.0.0.1:8935/mcp"
+    ~method_name:Otel_genai.Mcp_value.tools_call_method
+    ~params:client_operation_params
+    ?error_type
+    ?rpc_response_status_code
+    ()
+
+let test_mcp_client_operation_duration_labels_follow_semconv () =
+  let labels =
+    client_operation_labels ~error_type:"-32602" ~rpc_response_status_code:"-32602" ()
+  in
+  check (list (pair string string)) "client operation labels"
+    [
+      (Otel_genai.Mcp_attr_key.mcp_method_name, Otel_genai.Mcp_value.tools_call_method);
+      ( Otel_genai.Mcp_attr_key.mcp_protocol_version,
+        Mcp_transport_protocol.default_protocol_version );
+      (Otel_genai.Mcp_attr_key.network_protocol_name, "http");
+      (Otel_genai.Mcp_attr_key.network_protocol_version, "1.1");
+      (Otel_genai.Mcp_attr_key.network_transport, "tcp");
+      (Otel_genai.Attr_key.gen_ai_operation_name, "execute_tool");
+      (Otel_genai.Attr_key.gen_ai_tool_name, "masc_status");
+      (Otel_genai.Mcp_attr_key.server_address, "127.0.0.1");
+      (Otel_genai.Mcp_attr_key.server_port, "8935");
+      (Otel_genai.Mcp_attr_key.error_type, "-32602");
+      (Otel_genai.Mcp_attr_key.rpc_response_status_code, "-32602");
+    ]
+    labels;
+  check bool "client operation metric omits session id" false
+    (List.exists
+       (fun (key, _) -> String.equal key Otel_genai.Mcp_attr_key.mcp_session_id)
+       labels)
+
+let test_records_mcp_client_operation_duration_metric () =
+  let metric_name = Otel_genai.Mcp_metric_name.client_operation_duration in
+  let labels = client_operation_labels () in
+  let before_count =
+    Otel_metric_store.metric_value_or_zero (metric_name ^ "_count") ~labels ()
+  in
+  Worker_container_types.For_testing.record_mcp_client_operation_duration
+    ~url:"http://127.0.0.1:8935/mcp"
+    ~method_name:Otel_genai.Mcp_value.tools_call_method
+    ~params:client_operation_params
+    ~started_at:(Unix.gettimeofday () -. 0.25)
+    ();
+  check (float 0.0001) "client operation count increments"
+    (before_count +. 1.0)
+    (Otel_metric_store.metric_value_or_zero (metric_name ^ "_count") ~labels ())
+
 let () =
   run "Worker_runtime"
     [
@@ -94,5 +147,9 @@ let () =
             test_merge_usage_sums_costs_when_both_present;
           test_case "mcp endpoint url does not leak token" `Quick
             test_mcp_endpoint_url_does_not_leak_token;
+          test_case "MCP client operation duration labels follow semconv" `Quick
+            test_mcp_client_operation_duration_labels_follow_semconv;
+          test_case "records MCP client operation duration metric" `Quick
+            test_records_mcp_client_operation_duration_metric;
         ] );
     ]

--- a/test/test_worker_container_coverage.ml
+++ b/test/test_worker_container_coverage.ml
@@ -132,6 +132,45 @@ let test_records_mcp_client_operation_duration_metric () =
     (before_count +. 1.0)
     (Otel_metric_store.metric_value_or_zero (metric_name ^ "_count") ~labels ())
 
+let client_session_labels ?error_type () =
+  Worker_container_types.For_testing.mcp_client_session_duration_labels
+    ~url:"http://127.0.0.1:8935/mcp"
+    ?error_type
+    ()
+
+let test_mcp_client_session_duration_labels_follow_semconv () =
+  let labels = client_session_labels ~error_type:"agent_error" () in
+  check (list (pair string string)) "client session labels"
+    [
+      ( Otel_genai.Mcp_attr_key.mcp_protocol_version,
+        Mcp_transport_protocol.default_protocol_version );
+      (Otel_genai.Mcp_attr_key.network_protocol_name, "http");
+      (Otel_genai.Mcp_attr_key.network_protocol_version, "1.1");
+      (Otel_genai.Mcp_attr_key.network_transport, "tcp");
+      (Otel_genai.Mcp_attr_key.server_address, "127.0.0.1");
+      (Otel_genai.Mcp_attr_key.server_port, "8935");
+      (Otel_genai.Mcp_attr_key.error_type, "agent_error");
+    ]
+    labels;
+  check bool "client session metric omits session id" false
+    (List.exists
+       (fun (key, _) -> String.equal key Otel_genai.Mcp_attr_key.mcp_session_id)
+       labels)
+
+let test_records_mcp_client_session_duration_metric () =
+  let metric_name = Otel_genai.Mcp_metric_name.client_session_duration in
+  let labels = client_session_labels () in
+  let before_count =
+    Otel_metric_store.metric_value_or_zero (metric_name ^ "_count") ~labels ()
+  in
+  Worker_container_types.For_testing.record_mcp_client_session_duration
+    ~url:"http://127.0.0.1:8935/mcp"
+    ~started_at:(Unix.gettimeofday () -. 0.5)
+    ();
+  check (float 0.0001) "client session count increments"
+    (before_count +. 1.0)
+    (Otel_metric_store.metric_value_or_zero (metric_name ^ "_count") ~labels ())
+
 let () =
   run "Worker_runtime"
     [
@@ -151,5 +190,9 @@ let () =
             test_mcp_client_operation_duration_labels_follow_semconv;
           test_case "records MCP client operation duration metric" `Quick
             test_records_mcp_client_operation_duration_metric;
+          test_case "MCP client session duration labels follow semconv" `Quick
+            test_mcp_client_session_duration_labels_follow_semconv;
+          test_case "records MCP client session duration metric" `Quick
+            test_records_mcp_client_session_duration_metric;
         ] );
     ]

--- a/test/test_worker_container_coverage.ml
+++ b/test/test_worker_container_coverage.ml
@@ -188,6 +188,49 @@ let test_records_mcp_client_session_duration_metric () =
     (before_count +. 1.0)
     (Otel_metric_store.metric_value_or_zero (metric_name ^ "_count") ~labels ())
 
+let worker_meta ?mcp_client_session_started_at () =
+  {
+    Worker_container_types.version =
+      Worker_container_types.worker_container_version;
+    worker_name = "coverage-worker";
+    mcp_session_id = "coverage-session";
+    workspace_path = "/tmp/coverage-workspace";
+    role = None;
+    selection_note = None;
+    runtime_backend = Worker_execution_backend.Local_playground;
+    thinking_enabled = None;
+    timeout_seconds = None;
+    effective_model = "test-model";
+    checkpoint_path = "/tmp/coverage-checkpoint.json";
+    turn_log_path = "/tmp/coverage-turns.jsonl";
+    mcp_client_session_started_at;
+    last_run_at = None;
+  }
+
+let test_worker_mcp_client_session_preserves_persisted_start () =
+  let started_at = 42.0 in
+  let begun =
+    Worker_oas.For_testing.begin_worker_mcp_client_session
+      (worker_meta ~mcp_client_session_started_at:started_at ())
+  in
+  check (option (float 0.0001)) "persisted start is preserved"
+    (Some started_at)
+    begun.mcp_client_session_started_at;
+  let fresh =
+    Worker_oas.For_testing.begin_worker_mcp_client_session (worker_meta ())
+  in
+  check bool "fresh session receives a start timestamp" true
+    (Option.is_some fresh.mcp_client_session_started_at)
+
+let test_worker_mcp_client_session_finish_clears_started_at () =
+  let completed =
+    Worker_oas.For_testing.finish_worker_mcp_client_session
+      (worker_meta ~mcp_client_session_started_at:42.0 ())
+  in
+  check (option (float 0.0001)) "active session timestamp cleared" None
+    completed.mcp_client_session_started_at;
+  check bool "last_run_at recorded" true (Option.is_some completed.last_run_at)
+
 let () =
   run "Worker_runtime"
     [
@@ -214,5 +257,11 @@ let () =
             test_mcp_client_session_duration_labels_follow_semconv;
           test_case "records MCP client session duration metric" `Quick
             test_records_mcp_client_session_duration_metric;
+          test_case "worker MCP client session preserves persisted start"
+            `Quick
+            test_worker_mcp_client_session_preserves_persisted_start;
+          test_case "worker MCP client session finish clears active start"
+            `Quick
+            test_worker_mcp_client_session_finish_clears_started_at;
         ] );
     ]

--- a/test/test_worker_container_coverage.ml
+++ b/test/test_worker_container_coverage.ml
@@ -132,6 +132,23 @@ let test_records_mcp_client_operation_duration_metric () =
     (before_count +. 1.0)
     (Otel_metric_store.metric_value_or_zero (metric_name ^ "_count") ~labels ())
 
+let test_tools_call_is_error_records_failed_client_operation_duration () =
+  let metric_name = Otel_genai.Mcp_metric_name.client_operation_duration in
+  let labels = client_operation_labels ~error_type:Otel_genai.Mcp_value.tool_error_type () in
+  let before_count =
+    Otel_metric_store.metric_value_or_zero (metric_name ^ "_count") ~labels ()
+  in
+  Worker_container_types.For_testing.record_mcp_client_operation_duration
+    ~url:"http://127.0.0.1:8935/mcp"
+    ~method_name:Otel_genai.Mcp_value.tools_call_method
+    ~params:client_operation_params
+    ~started_at:(Unix.gettimeofday () -. 0.25)
+    ~tool_result_is_error:true
+    ();
+  check (float 0.0001) "client tool-error count increments"
+    (before_count +. 1.0)
+    (Otel_metric_store.metric_value_or_zero (metric_name ^ "_count") ~labels ())
+
 let client_session_labels ?error_type () =
   Worker_container_types.For_testing.mcp_client_session_duration_labels
     ~url:"http://127.0.0.1:8935/mcp"
@@ -190,6 +207,9 @@ let () =
             test_mcp_client_operation_duration_labels_follow_semconv;
           test_case "records MCP client operation duration metric" `Quick
             test_records_mcp_client_operation_duration_metric;
+          test_case "tools/call isError records failed client operation duration"
+            `Quick
+            test_tools_call_is_error_records_failed_client_operation_duration;
           test_case "MCP client session duration labels follow semconv" `Quick
             test_mcp_client_session_duration_labels_follow_semconv;
           test_case "records MCP client session duration metric" `Quick


### PR DESCRIPTION
## Summary
- add MCP semantic-convention transport/session attributes and OTel duration metrics
- cover all four recommended MCP duration histograms:
  - `mcp.client.operation.duration`
  - `mcp.server.operation.duration`
  - `mcp.client.session.duration`
  - `mcp.server.session.duration`
- rebase the valid OTel slice onto current `main`; base is no longer stacked on #20382
- keep wall-clock telemetry at explicit DET/NDT boundaries

## Client Session Lifecycle
- persist `mcp_client_session_started_at` in local-worker metadata
- open the bounded MCP client session immediately before `Agent.run` on cold start and resume
- record `mcp.client.session.duration` on the common worker finish path
- attach `error.type=agent_error` when `Agent.run` returns an error
- clear the active start timestamp after recording so resumed workers do not double-count the same session
- intentionally omit `mcp.session.id` from the client session metric labels; operation telemetry can still include it where available

## Rebase / Cleanup
- moved the PR base to `main`
- dropped dependency on the closed stale path-preflight PR
- fixed the DET/NDT ratchet failure introduced by the client-session duration follow-up

## Evidence
- [근거] OpenTelemetry MCP semantic conventions official docs, checked 2026-06-07 KST, confidence High: https://opentelemetry.io/docs/specs/semconv/gen-ai/mcp/
- The current official page is Semantic Conventions 1.41.1 and lists the four MCP duration metrics implemented here: client/server operation duration and client/server session duration.

## Verification
- `git diff --check origin/main...HEAD`
- `scripts/ci/check-determinism-contract.sh --base origin/main --head HEAD`
- `ocamlformat --check lib/local/worker_container_types.ml lib/server/server_mcp_transport_http_session.ml lib/worker_oas.ml lib/otel_genai/otel_genai.ml lib/otel_genai/otel_genai.mli lib/local/worker_container_types.mli lib/local/worker_container.ml lib/local/worker_container.mli test/test_worker_container_coverage.ml`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_JOBS=1 DUNE_BUILD_DIR=/private/tmp/masc-mcp-otel-mcp-transport-context-20260607-r7 scripts/dune-local.sh build --cache=disabled test/test_worker_container_coverage.exe test/test_worker_runtime.exe test/test_otel_dispatch_hook.exe test/test_mcp_server_eio_call_tool.exe test/test_mcp_h1_h2_admission_parity.exe --display=quiet`
- `/private/tmp/masc-mcp-otel-mcp-transport-context-20260607-r7/default/test/test_worker_container_coverage.exe`
- `/private/tmp/masc-mcp-otel-mcp-transport-context-20260607-r7/default/test/test_worker_runtime.exe`
- `/private/tmp/masc-mcp-otel-mcp-transport-context-20260607-r7/default/test/test_otel_dispatch_hook.exe`
- `/private/tmp/masc-mcp-otel-mcp-transport-context-20260607-r7/default/test/test_mcp_server_eio_call_tool.exe`
- `/private/tmp/masc-mcp-otel-mcp-transport-context-20260607-r7/default/test/test_mcp_h1_h2_admission_parity.exe`

Fixes #20394
