### PR TITLE
feat(keeper): autonomous goal validation and ghost-goal cleanup

### DIFF
--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -442,6 +442,17 @@ let apply_post_turn_lifecycle_with_resilience_handles
             };
         }
     | Some snapshot ->
+        (* Gen7: sanitize snapshot goal against validated active_goal_ids.
+           Prevents ghost goals from persisting into progress.md. *)
+        let snapshot =
+          match snapshot.goal with
+          | Some goal_id when not (List.mem goal_id meta.active_goal_ids) ->
+              Log.Keeper.warn
+                "keeper:%s snapshot goal %s not in active_goal_ids, clearing"
+                meta.name goal_id;
+              { snapshot with goal = None }
+          | _ -> snapshot
+        in
         (* Gen7: cap snapshot size before rendering + persisting.
            Bounds string prose and list items so meta.continuity_summary
            cannot grow unboundedly even when the LLM produces a longer

--- a/lib/keeper/keeper_run_context.ml
+++ b/lib/keeper/keeper_run_context.ml
@@ -49,6 +49,15 @@ let prepare_run_context
   =
   let receipt_started_at = Masc_domain.now_iso () in
   let meta = Keeper_agent_tool_surface.sync_current_task_id_from_backlog ~config meta in
+  let validated_goal_ids =
+    Keeper_runtime_contract.validate_active_goal_ids ~config ~meta ()
+  in
+  let meta =
+    if List.length validated_goal_ids <> List.length meta.active_goal_ids then
+      { meta with active_goal_ids = validated_goal_ids }
+    else
+      meta
+  in
   let profile_defaults = Keeper_types_profile.load_keeper_profile_defaults meta.name in
   (* 0. Resolve inference parameters via Runtime_inference *)
   let temperature =

--- a/lib/keeper/keeper_runtime_contract.ml
+++ b/lib/keeper/keeper_runtime_contract.ml
@@ -10,6 +10,22 @@ let primary_goal_id_opt (meta : keeper_meta) =
   | goal_id :: _ -> Some goal_id
   | [] -> None
 
+(** Cross-check [meta.active_goal_ids] against the live MASC goal store.
+    Returns only goal IDs that actually exist. Logs pruned IDs at warn level. *)
+let validate_active_goal_ids ~(config : Workspace.config) ~(meta : keeper_meta) () =
+  let valid_goal_ids, invalid_goal_ids =
+    List.partition
+      (fun goal_id -> Option.is_some (Goal_store.get_goal config ~goal_id))
+      meta.active_goal_ids
+  in
+  if invalid_goal_ids <> [] then
+    Log.Keeper.warn
+      "keeper:%s pruned %d invalid goal_ids from active_goal_ids: %s"
+      meta.name
+      (List.length invalid_goal_ids)
+      (String.concat ", " invalid_goal_ids);
+  valid_goal_ids
+
 let backend_of_meta (meta : keeper_meta) =
   match meta.sandbox_profile with
   | Docker -> "docker"

--- a/lib/keeper/keeper_runtime_contract.mli
+++ b/lib/keeper/keeper_runtime_contract.mli
@@ -1,5 +1,14 @@
 val current_task_id_opt : Keeper_meta_contract.keeper_meta -> string option
 val primary_goal_id_opt : Keeper_meta_contract.keeper_meta -> string option
+
+val validate_active_goal_ids :
+  config:Workspace.config ->
+  meta:Keeper_meta_contract.keeper_meta ->
+  unit ->
+  string list
+(** Cross-check [meta.active_goal_ids] against the live MASC goal store.
+    Returns only goal IDs that actually exist. Logs pruned IDs at warn level. *)
+
 val backend_of_meta : Keeper_meta_contract.keeper_meta -> string
 val task_is_linked_to_keeper_goals :
   string list -> Masc_domain.task -> bool

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -467,9 +467,14 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
     else Printf.sprintf "\nInstructions:\n%s\n" instructions
   in
   let goal_lines =
+    let has_valid_primary_goal =
+      Option.is_some (Keeper_runtime_contract.primary_goal_id_opt meta)
+    in
     String.concat ""
       [
-        line_block "Primary goal" meta.goal;
+        line_block "Primary goal"
+          (if has_valid_primary_goal then meta.goal
+           else "(no valid active goal — awaiting assignment)");
         (if meta.short_goal <> "" && meta.short_goal <> meta.goal then
            line_block "Short-term goal" meta.short_goal
          else "");


### PR DESCRIPTION
## Summary

Keeper가 MASC goal store와 교차 검증 없이 `active_goal_ids`를 유지하여, 존재하지 않는 goal(ghost goal)을 계속 참조하며 idle loop를 도는 문제를 해결합니다.

- `keeper_runtime_contract.ml`: `validate_active_goal_ids` 추가 — `Goal_store.get_goal`으로 유효성 검증
- `keeper_run_context.ml`: `prepare_run_context`에서 meta의 `active_goal_ids`를 필터링
- `keeper_post_turn.ml`: `progress.md` 기록 전 `snapshot.goal`이 유효한지 검증
- `keeper_unified_prompt.ml`: 유효한 primary goal이 없을 때 prompt에 advisory 표시

## Test plan

- [ ] sangsu keeper의 `active_goal_ids`에 ghost goal이 있을 때 다음 턴에서 제거되는지 확인
- [ ] `Log.Keeper.warn "pruned %d invalid goal_ids..."` 로그 출력 확인
- [ ] `progress.md`에 ghost goal이 더 이상 기록되지 않는지 확인
- [ ] prompt에 `"(no valid active goal — awaiting assignment)"` 표시 확인
- [ ] dune build @check 통과 (pre-existing Shell_ir/Cargo 에러 제외)

🤖 Generated with [Claude Code](https://claude.com/claude-code)