### PR TITLE
feat(keeper): ghost-goal cleanup + active self-assignment (follow-up to #20386)

### DIFF
--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -475,6 +475,14 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
         line_block "Primary goal"
           (if has_valid_primary_goal then meta.goal
            else "(no valid active goal — awaiting assignment)");
+        (if not has_valid_primary_goal then
+           "\n\
+            You have no active goal. Pick ONE action this turn to self-assign a purpose:\n\
+            - Scan the backlog with keeper_tasks_list and claim a matching task.\n\
+            - Read the board with keeper_board_list and join an active discussion.\n\
+            - Post your intended focus to the board so other keepers can align.\n\
+            Do not stay silent when you have no goal.\n"
+         else "");
         (if meta.short_goal <> "" && meta.short_goal <> meta.goal then
            line_block "Short-term goal" meta.short_goal
          else "");


### PR DESCRIPTION
## Summary
When a keeper's active goals are all pruned as invalid (ghost goals), the unified prompt now injects an explicit instruction telling the keeper to self-assign a purpose for the current turn.

## Context
#20386 added runtime validation that cross-checks `keeper_meta.active_goal_ids` against the live MASC goal store and prunes stale references. After pruning, a keeper may end up with zero valid goals and fall into a silent idle loop. This PR closes that gap at the prompt level.

## Changes
- **keeper_unified_prompt.ml**: When `primary_goal_id_opt` returns `None`, append an active instruction block to the prompt:
  - Scan the backlog and claim a matching task.
  - Read the board and join an active discussion.
  - Post an intended focus so other keepers can align.

## Verification
- `dune build @check` passes (pre-existing `Shell_ir` / `Cargo` errors unrelated).

## Related
- #20386 (runtime validation + snapshot sanitization — already merged)