### PR TITLE
fix(keeper): restore shell ir typed build

### DIFF
--- a/lib/exec/shell_ir_typed.ml
+++ b/lib/exec/shell_ir_typed.ml
@@ -744,6 +744,8 @@ let path_args : wrapped -> string list = function
   | W (Ruff _) -> []
   | W (Pyright _) -> []
   | W (Tsc _) -> []
+  | W (Cargo _) -> []
+  | W (Go _) -> []
   | W (Ocamlfind _) -> []
   | W (Rustc _) -> []
   | W (Gofmt _) -> []

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -285,7 +285,7 @@ let glob_literal_failure_fields ~input ~status ~stderr =
    failure. Pipeline path validation is deferred. *)
 let pre_dispatch_path_missing ~cwd ir =
   match ir with
-  | Shell_ir.Simple s ->
+  | Masc_exec.Shell_ir.Simple s ->
     let typed = Masc_exec.Shell_ir_typed.of_simple s in
     (match Masc_exec.Shell_ir_typed.risk typed with
      | `Safe ->
@@ -297,7 +297,7 @@ let pre_dispatch_path_missing ~cwd ir =
          try not (Sys.file_exists resolved) with _ -> true
        ) args
      | `Audited | `Privileged -> None)
-  | Shell_ir.Pipeline _ -> None
+  | Masc_exec.Shell_ir.Pipeline _ -> None
 ;;
 
 let sandbox_extra_uses_docker sandbox_extra_fields =


### PR DESCRIPTION
## Summary
- add missing Cargo/Go arms to Shell_ir_typed.path_args exhaustive match
- qualify Shell_ir pattern matches through Masc_exec in keeper execute runtime

## Why
Current main fails dune build after typed Shell IR changes because the path extractor did not account for newly added typed constructors and one new call site referenced an unopened Shell_ir module.

## Verification
- opam exec -- dune build --root . lib/exec/shell_ir_typed.ml lib/keeper/keeper_tool_execute_runtime.ml -j 1 --display=short
- opam exec -- dune build --root . lib/masc.cma -j 1 --display=short
- git diff --check

Note: attempted full `opam exec -- dune build --root . . -j 1 --display=quiet`; after the reported exhaustive-match errors were fixed, it produced no further output for several minutes and was stopped. CI should exercise the full suite.
