### PR TITLE
fix(keeper): remove retry wall-clock admission budget

### DIFF
--- a/lib/keeper/keeper_runtime_resolved.ml
+++ b/lib/keeper/keeper_runtime_resolved.ml
@@ -299,7 +299,8 @@ let body_timeout_override_sec () =
   (current ()).body_timeout_override_sec.value
 
 (* RFC-0156/RFC-020x: OAS total timeout removed — turn_timeout_sec is the
-   retry/admission budget, not a cumulative hard kill for active streams.
+   default provider-attempt timeout and first-attempt admission input, not a
+   cumulative hard kill for active streams or retry admission.
    stream_idle_timeout is the per-stream idle cap. Kept in lockstep with
    [Env_config.KeeperKeepalive.oas_call_timeout_sec]. Historic names
    ([oas_timeout_for_estimated_input_tokens] /

--- a/lib/keeper/keeper_turn_runtime_budget.ml
+++ b/lib/keeper/keeper_turn_runtime_budget.ml
@@ -87,49 +87,13 @@ let decide_retry_admission_for_turn
     ~(allow_wall_clock_retry_budget : bool)
     ~(estimated_input_tokens : int)
     ~(max_turns : int) : (unit, retry_admission_denial) result =
-  let runtime = Keeper_runtime_resolved.current () in
-  let adaptive_timeout_sec = Keeper_runtime_resolved.oas_call_timeout_sec () in
   let is_retry = attempt_kind_is_retry attempt_kind in
   if is_retry then
-    let time_spent_in_turn =
-      runtime.turn_timeout_sec.value -. remaining_turn_budget_s
-    in
-    let usable_retry_budget = adaptive_timeout_sec -. time_spent_in_turn in
-    let usable_wall_clock_budget =
-      remaining_turn_budget_s -. provider_timeout_guard_sec
-    in
-    let projected_usable_budget_s =
-      if usable_retry_budget >= min_provider_timeout_budget_sec then
-        usable_retry_budget
-      else if allow_wall_clock_retry_budget then usable_wall_clock_budget
-      else usable_retry_budget
-    in
-    if remaining_turn_budget_s <= 0.0 then
-      Error
-        (Retry_budget_below_min
-           {
-             projected_usable_budget_s;
-             min_required_s = min_provider_timeout_budget_sec;
-             remaining_turn_budget_s;
-             adaptive_timeout_s = adaptive_timeout_sec;
-             allow_wall_clock_retry_budget;
-           })
-    else if usable_retry_budget >= min_provider_timeout_budget_sec then Ok ()
-    else if
-      allow_wall_clock_retry_budget
-      && usable_wall_clock_budget >= min_provider_timeout_budget_sec
-    then Ok ()
-    else
-      Error
-        (Retry_budget_below_min
-           {
-             projected_usable_budget_s;
-             min_required_s = min_provider_timeout_budget_sec;
-             remaining_turn_budget_s;
-             adaptive_timeout_s = adaptive_timeout_sec;
-             allow_wall_clock_retry_budget;
-           })
+    Ok ()
   else
+    let _ = allow_wall_clock_retry_budget in
+    let _ = estimated_input_tokens in
+    let _ = max_turns in
     let usable_budget = remaining_turn_budget_s -. provider_timeout_guard_sec in
     if usable_budget >= min_provider_timeout_budget_sec then Ok ()
     else

--- a/lib/keeper/keeper_turn_runtime_budget.mli
+++ b/lib/keeper/keeper_turn_runtime_budget.mli
@@ -30,15 +30,15 @@ val next_fail_open_runtime_for_turn :
 val sdk_error_kind : Agent_sdk.Error.sdk_error -> string
 
 val provider_timeout_guard_sec : float
-(** Retry guard floor (seconds). *)
+(** First-attempt provider startup guard floor (seconds). *)
 
 val min_provider_timeout_budget_sec : float
 (** Minimum provider timeout budget (seconds). *)
 
 val first_attempt_degraded_retry_reserve_sec : float
-(** Wall-clock reserve kept from non-retry attempts so one degraded
-    retry can still satisfy [provider_timeout_guard_sec] +
-    [min_provider_timeout_budget_sec]. *)
+(** Conservative wall-clock reserve kept from non-retry attempts before
+    provider dispatch. Retry attempts do not consume this outer
+    wall-clock reserve as admission budget. *)
 
 val sdk_error_kind : Agent_sdk.Error.sdk_error -> string
 
@@ -64,8 +64,9 @@ val resolve_bounded_provider_timeout_budget_with_turn_budget :
   provider_timeout_budget option
 (** Resolves the per-provider timeout inside the outer keeper turn
     budget. Non-retry attempts keep a small degraded-retry reserve when
-    the remaining wall-clock budget is large enough; retry attempts use
-    the remaining per-attempt or one-shot degraded wall-clock budget. *)
+    the remaining wall-clock budget is large enough. Retry attempts use
+    the resolved adaptive provider timeout directly; provider liveness,
+    stream idle, and max-turn limits own retry termination. *)
 
 val allow_wall_clock_retry_budget_for_attempt :
   is_retry:bool ->

--- a/lib/keeper/keeper_turn_runtime_budget_provider_timeout.ml
+++ b/lib/keeper/keeper_turn_runtime_budget_provider_timeout.ml
@@ -6,16 +6,11 @@
 
     @since God file decomposition *)
 
-(* Retry guard floor: relaxed 30->15 (2026-04-27).
-   Original 60s threshold (guard 30 + min 30) caused keeper cycle FAILED when
-   remaining turn budget fell into the 30-60s band, increasing noop count and
-   eventually fleet auto-pause. Field evidence (post v0.18.4): keepers hung on
-   cohttp-eio bulk read for ~600s and arrived at the retry branch with <60s
-   remaining -> guarded out -> cycle terminal.
-
-   New threshold (15+15=30s) accommodates small-tail retries:
-   - cohttp connect 1s + first-token 2-5s = ~6s baseline
-   - 30s leaves ~9-12s headroom for actual response
+(* First-attempt guard floor. Retry attempts no longer consume the outer
+   keeper-turn wall clock as an admission budget: a provider/liveness failure
+   can spend the old turn cap before producing a first token, and denying the
+   follow-up retry with [retry_budget_below_min] only converts the real
+   provider failure into a synthetic turn-budget failure.
 
    RFC-0129 (2026-05-18): the prior reserve_fraction band-aid below
    was removed. The current live-stream cap chain is progress-based:
@@ -67,40 +62,17 @@ let resolve_bounded_provider_timeout_budget_with_turn_budget
   let runtime = Keeper_runtime_resolved.current () in
   let adaptive_timeout_sec = Keeper_runtime_resolved.oas_call_timeout_sec () in
   if is_retry then begin
-    let time_spent_in_turn = runtime.turn_timeout_sec.value -. remaining_turn_budget_s in
-    let usable_retry_budget = adaptive_timeout_sec -. time_spent_in_turn in
-    let wall_clock_retry_budget =
-      let usable_budget = remaining_turn_budget_s -. provider_timeout_guard_sec in
-      if usable_budget < min_provider_timeout_budget_sec
-      then None
-      else Some (Float.min adaptive_timeout_sec usable_budget)
-    in
-    let retry_budget =
-      if remaining_turn_budget_s <= 0.0 then None
-      else if usable_retry_budget >= min_provider_timeout_budget_sec then
-        Some (usable_retry_budget, false)
-      else if allow_wall_clock_retry_budget then
-        Option.map (fun timeout -> (timeout, true)) wall_clock_retry_budget
-      else None
-    in
-    match retry_budget with
-    | None -> None
-    | Some (effective_timeout_sec, used_wall_clock_retry_budget) ->
-      let source =
-        if used_wall_clock_retry_budget
-        then "retry_wall_clock_limited"
-        else "retry_per_attempt_limited"
-      in
-      Some
-        {
-          effective_timeout_sec;
-          adaptive_timeout_sec;
-          keeper_turn_timeout_sec = runtime.turn_timeout_sec.value;
-          remaining_turn_budget_sec = remaining_turn_budget_s;
-          estimated_input_tokens = max 0 estimated_input_tokens;
-          max_turns;
-          source;
-        }
+    ignore allow_wall_clock_retry_budget;
+    Some
+      {
+        effective_timeout_sec = adaptive_timeout_sec;
+        adaptive_timeout_sec;
+        keeper_turn_timeout_sec = runtime.turn_timeout_sec.value;
+        remaining_turn_budget_sec = remaining_turn_budget_s;
+        estimated_input_tokens = max 0 estimated_input_tokens;
+        max_turns;
+        source = "retry_adaptive_timeout";
+      }
   end else begin
     let usable_budget = remaining_turn_budget_s -. provider_timeout_guard_sec in
     if usable_budget < min_provider_timeout_budget_sec

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -580,15 +580,14 @@ let run (ctx : ctx)
             err;
           Log.Keeper.warn
             "%s: recoverable runtime failure in %s suggested \
-             degraded retry to %s (reason=%s), but remaining turn \
-             budget %.1fs is below the OAS retry guard/minimum; \
+             degraded retry to %s (reason=%s), but retry provider \
+             timeout admission was unavailable; \
              ending this cycle: %s"
             meta.name
             execution_runtime_id
             degraded_retry.next_runtime
             (EC.degraded_retry_reason_to_string
                degraded_retry.fallback_reason)
-            (remaining_turn_budget_s ())
             (short_preview (Agent_sdk.Error.to_string err));
           mark_terminal_error err;
           Error err
@@ -705,8 +704,8 @@ let run (ctx : ctx)
      Long voice/OAS turns can keep making stream or tool progress beyond the
      legacy 600s cap. Runaway detection is owned by stream idle, provider
      attempt liveness, tool-level timeouts, max-turn limits, and the optional
-     supervisor stale-turn watchdog. Retry budgeting still consults the
-     remaining turn budget between provider attempts. *)
+     supervisor stale-turn watchdog. Retry admission must not reintroduce the
+     cumulative wall-clock cap between provider attempts. *)
   retry_loop
     { run_meta = meta
     ; execution = initial_execution

--- a/test/test_d7_retry_admission_gate.ml
+++ b/test/test_d7_retry_admission_gate.ml
@@ -3,12 +3,11 @@
     Verifies that
     [Keeper_turn_runtime_budget.decide_retry_admission_for_turn]
     returns:
-      - [Ok ()] when remaining turn budget is well above the
-        per-attempt floor ([provider_timeout_guard_sec +
-        min_provider_timeout_budget_sec] = 30s) for a retry without
-        wall-clock fallback.
-      - [Error (Retry_budget_below_min _)] when the projected
-        wall-clock budget falls below the min floor (15s).
+      - [Ok ()] for retries even when the outer keeper-turn wall clock
+        is exhausted. Provider liveness, stream idle, and max-turn
+        limits own retry termination.
+      - [Error (First_attempt_budget_below_min _)] when a first
+        attempt does not have enough startup budget.
 
     The min floor is a typed boundary: the gate's reason field is a
     closed-sum reason record, not a substring or counter — see
@@ -42,34 +41,32 @@ let decision_testable =
       Error (KCB.First_attempt_budget_below_min _) -> true
     | _ -> false)
 
-let test_retry_with_sufficient_wall_clock_budget_admits () =
-  (* remaining_turn_budget_s = 120s; wall-clock fallback enabled.
-     wall_clock = 120 - 15 = 105 >= 15 → Ok. *)
+let test_retry_ignores_expired_outer_turn_budget () =
+  (* Retry admission intentionally ignores the cumulative outer turn
+     wall-clock cap. A no-first-token liveness guard can spend the old
+     cap before the retry branch; denying here would turn the real
+     provider failure into synthetic [retry_budget_below_min]. *)
   let result =
     KCB.decide_retry_admission_for_turn
-      ~remaining_turn_budget_s:120.0
+      ~remaining_turn_budget_s:0.0
       ~attempt_kind:KCB.Retry_attempt
-      ~allow_wall_clock_retry_budget:true
+      ~allow_wall_clock_retry_budget:false
       ~estimated_input_tokens:1000
       ~max_turns:6
   in
   Alcotest.check decision_testable
-    "retry with 120s remaining + wall-clock should admit"
+    "retry with 0s remaining should admit"
     (Ok ()) result
 
-let test_retry_below_min_denies_with_typed_reason () =
-  (* remaining_turn_budget_s = 20s; wall-clock fallback off
-     (i.e. usable_retry_budget alone must clear 15s).
-     adaptive_timeout default = min(turn_timeout, 300). Since the
-     freeze gives us a known turn_timeout_sec, and
-     time_spent_in_turn = turn_timeout - 20, usable_retry_budget
-     can be small / negative. We avoid asserting the exact
-     [projected_usable_budget_s] value; we only assert the
-     constructor + min_required_s + that the gate said NO. *)
+let test_first_attempt_below_min_denies_with_typed_reason () =
+  (* First attempts still need enough startup room for the provider
+     guard plus minimum attempt budget. This keeps genuinely stale
+     turn-start attempts from starting, without blocking retries after
+     a provider/liveness failure. *)
   let result =
     KCB.decide_retry_admission_for_turn
       ~remaining_turn_budget_s:20.0
-      ~attempt_kind:KCB.Retry_attempt
+      ~attempt_kind:KCB.First_attempt
       ~allow_wall_clock_retry_budget:false
       ~estimated_input_tokens:1000
       ~max_turns:6
@@ -77,21 +74,16 @@ let test_retry_below_min_denies_with_typed_reason () =
   match result with
   | Ok () ->
     Alcotest.failf
-      "expected admission denial with 20s remaining and no \
-       wall-clock fallback, got Ok"
-  | Error (KCB.First_attempt_budget_below_min _) ->
+      "expected first-attempt admission denial with 20s remaining, got Ok"
+  | Error (KCB.Retry_budget_below_min _) ->
     Alcotest.failf
-      "expected Retry_budget_below_min, got \
-       First_attempt_budget_below_min"
-  | Error (KCB.Retry_budget_below_min r) ->
+      "expected First_attempt_budget_below_min, got Retry_budget_below_min"
+  | Error (KCB.First_attempt_budget_below_min r) ->
     Alcotest.(check (float 0.001))
       "min_required_s is 15.0" 15.0 r.min_required_s;
     Alcotest.(check (float 0.001))
       "remaining_turn_budget_s echoed back" 20.0
-      r.remaining_turn_budget_s;
-    Alcotest.(check bool)
-      "wall-clock flag echoed back" false
-      r.allow_wall_clock_retry_budget
+      r.remaining_turn_budget_s
 
 let () =
   Alcotest.run "d7_retry_admission_gate"
@@ -99,12 +91,12 @@ let () =
       ( "decide_retry_admission_for_turn",
         [
           Alcotest.test_case
-            "retry with sufficient wall-clock budget admits"
+            "retry ignores expired outer turn budget"
             `Quick
-            test_retry_with_sufficient_wall_clock_budget_admits;
+            test_retry_ignores_expired_outer_turn_budget;
           Alcotest.test_case
-            "retry below min denies with typed Retry_budget_below_min"
+            "first attempt below min denies with typed First_attempt_budget_below_min"
             `Quick
-            test_retry_below_min_denies_with_typed_reason;
+            test_first_attempt_below_min_denies_with_typed_reason;
         ] );
     ]

--- a/test/test_oas_timeout_budget_strike.ml
+++ b/test/test_oas_timeout_budget_strike.ml
@@ -226,6 +226,32 @@ let test_stream_liveness_disables_outer_attempt_watchdog () =
     true
     (Option.is_none (select KAL.Enforce))
 
+let test_retry_timeout_budget_ignores_expired_outer_turn_budget () =
+  match
+    KCB.resolve_bounded_provider_timeout_budget_with_turn_budget
+      ~allow_wall_clock_retry_budget:false
+      ~is_retry:true
+      ~estimated_input_tokens:10_000
+      ~max_turns:6
+      ~remaining_turn_budget_s:0.0
+  with
+  | None ->
+    Alcotest.fail
+      "retry attempts should not be denied by exhausted outer turn wall clock"
+  | Some budget ->
+    Alcotest.(check string)
+      "retry source"
+      "retry_adaptive_timeout"
+      budget.source;
+    Alcotest.(check bool)
+      "retry keeps an actionable provider timeout"
+      true
+      (budget.effective_timeout_sec >= KCB.min_provider_timeout_budget_sec);
+    Alcotest.(check (float 0.001))
+      "remaining turn budget is telemetry only"
+      0.0
+      budget.remaining_turn_budget_sec
+
 let test_provider_timeout_is_not_ambiguous_side_effect () =
   Alcotest.(check bool)
     "provider timeout is not ambiguous without committed tools"
@@ -379,6 +405,10 @@ let () =
           "stream liveness disables outer attempt watchdog"
           `Quick
           test_stream_liveness_disables_outer_attempt_watchdog;
+        Alcotest.test_case
+          "retry timeout budget ignores expired outer turn budget"
+          `Quick
+          test_retry_timeout_budget_ignores_expired_outer_turn_budget;
         Alcotest.test_case
           "provider timeout is not ambiguous partial commit"
           `Quick


### PR DESCRIPTION
## Summary
- stop denying retry attempts when the outer keeper-turn wall-clock budget is exhausted
- make retry provider timeout resolution use the adaptive provider timeout directly
- keep the first-attempt startup floor and update focused regression coverage

## Tests
- ocamlformat --enable-outside-detected-project --check lib/keeper/keeper_runtime_resolved.ml lib/keeper/keeper_turn_runtime_budget_provider_timeout.ml lib/keeper/keeper_turn_runtime_budget.ml lib/keeper/keeper_turn_runtime_budget.mli lib/keeper/keeper_unified_turn_execution.ml test/test_d7_retry_admission_gate.ml test/test_oas_timeout_budget_strike.ml
- git diff --check
- scripts/dune-local.sh build --cache=disabled test/test_d7_retry_admission_gate.exe test/test_oas_timeout_budget_strike.exe
- ./_build/default/test/test_d7_retry_admission_gate.exe
- ./_build/default/test/test_oas_timeout_budget_strike.exe