### PR TITLE
refactor(keeper): finalize per-keeper independent slots

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -12,7 +12,7 @@
     section 1.3.
 
     Structure (facade decomposition):
-    - [Keeper_turn_slot]      — per-keeper turn slot,
+    - [Keeper_turn_slot]      — runtime-concurrent budget + per-keeper turn slot,
                                  [with_keeper_turn_slot]
     - [Keeper_keepalive_signal] — gRPC client refs, FSM guard identity
                                    helpers, interruptible sleep, wakeup

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -5,15 +5,15 @@
     body, board-reactive wakeup filtering, and optional gRPC heartbeat
     fiber.
 
-    [MASC_KEEPER_*] env vars read here (semaphore timeout, concurrency,
-    fairness cooldown, autoboot max) can also be set in
+    [MASC_KEEPER_*] env vars read here (slot wait timeout,
+    compatibility counters, autoboot max) can also be set in
     [<resolved config root>/runtime.toml].
     See {!Keeper_runtime_config} and [docs/BOOT-ENV-STATE-INVENTORY.md]
     section 1.3.
 
     Structure (facade decomposition):
-    - [Keeper_turn_slot]      — semaphores, autonomous wait queue,
-                                 fairness cooldown, [with_keeper_turn_slot]
+    - [Keeper_turn_slot]      — per-keeper turn slot,
+                                 [with_keeper_turn_slot]
     - [Keeper_keepalive_signal] — gRPC client refs, FSM guard identity
                                    helpers, interruptible sleep, wakeup
                                    dispatch, board-reactive wakeup,

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -58,9 +58,9 @@ val proactive_skip_reason_metric : string
     #10008 failure mode 3. *)
 
 val semaphore_wait_timeout_sec : float
-(** Wall-clock cap when a keeper waits on its own previous turn slot.
-    Derived from [MASC_KEEPER_SEMAPHORE_WAIT_TIMEOUT_SEC]. Other keepers no
-    longer share this admission slot. *)
+(** Wall-clock cap while a keeper waits to enter its own turn lane and then
+    consume the shared runtime-concurrent budget. Derived from
+    [MASC_KEEPER_SEMAPHORE_WAIT_TIMEOUT_SEC]. *)
 
 exception Semaphore_wait_timeout of float
 (** Legacy exception form. The [with_keeper_turn_slot*] result path below
@@ -93,7 +93,9 @@ val reset_autonomous_turn_queue_for_test : unit -> unit
 (** Test-only snapshot of keeper names currently queued for an autonomous turn. *)
 val autonomous_waiter_snapshot_for_test : unit -> string list
 
-(** Test-only legacy capacity snapshots; not admission capacity. *)
+(** Test-only runtime-concurrent capacity snapshots. Reactive/autonomous
+    helpers report the same shared budget because those legacy pool-specific
+    gates no longer exist. *)
 val turn_semaphore_value_for_test : unit -> int
 val autonomous_turn_semaphore_value_for_test : unit -> int
 val reactive_turn_semaphore_value_for_test : unit -> int

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -58,11 +58,9 @@ val proactive_skip_reason_metric : string
     #10008 failure mode 3. *)
 
 val semaphore_wait_timeout_sec : float
-(** Wall-clock cap on [Eio.Semaphore.acquire] when waiting for a keeper
-    turn slot. Derived from [MASC_KEEPER_SEMAPHORE_WAIT_TIMEOUT_SEC]
-    (default 60.0, range [5, 600]). Keepers whose peers hold slots past
-    this cap are skipped for the current cycle and retry on the next
-    heartbeat. *)
+(** Wall-clock cap when a keeper waits on its own previous turn slot.
+    Derived from [MASC_KEEPER_SEMAPHORE_WAIT_TIMEOUT_SEC]. Other keepers no
+    longer share this admission slot. *)
 
 exception Semaphore_wait_timeout of float
 (** Legacy exception form. The [with_keeper_turn_slot*] result path below
@@ -89,13 +87,13 @@ type semaphore_wait_timeout = {
   timeout_holders : (string * float) list;
 }
 
-(** Test-only reset for the autonomous FIFO wait queue. *)
+(** Test-only compatibility model for the removed autonomous FIFO wait queue. *)
 val reset_autonomous_turn_queue_for_test : unit -> unit
 
 (** Test-only snapshot of keeper names currently queued for an autonomous turn. *)
 val autonomous_waiter_snapshot_for_test : unit -> string list
 
-(** Test-only snapshots of the current semaphore availability. *)
+(** Test-only legacy capacity snapshots; not admission capacity. *)
 val turn_semaphore_value_for_test : unit -> int
 val autonomous_turn_semaphore_value_for_test : unit -> int
 val reactive_turn_semaphore_value_for_test : unit -> int
@@ -112,8 +110,8 @@ val turn_slot_holders : now:float -> (string * float) list
 val autonomous_slot_holders : now:float -> (string * float) list
 val reactive_slot_holders : now:float -> (string * float) list
 
-(** Force-release semaphore permits held by [keeper_name] after watchdog stale
-    classification. Returns released pool labels. *)
+(** Force-release [keeper_name]'s per-keeper slot after watchdog stale
+    classification. Returns released diagnostic labels. *)
 val force_release_stale_holder : keeper_name:string -> string list
 
 (** Test-only: TTL used to bound orphaned force-release markers left behind
@@ -124,8 +122,9 @@ val force_released_marker_ttl_sec_for_test : float
     consumption or expiry pruning. *)
 val force_released_marker_count_for_test : unit -> int
 
-(** Test-only: inject a marker without touching semaphores, so marker-retention
-    behavior can be exercised without creating a double-release path. *)
+(** Test-only: inject a marker without touching the per-keeper slot, so
+    marker-retention behavior can be exercised without creating a
+    double-release path. *)
 val add_force_released_marker_for_test :
   label:Keeper_turn_slot.slot_pool ->
   keeper_name:string ->
@@ -152,8 +151,9 @@ val slot_holders_summary : ?limit:int -> now:float -> unit -> string
     snapshot accessors. *)
 val force_release_holder_for : keeper_name:string -> (string * float) list
 
-(** Test-only FIFO queue primitives for autonomous fairness regression tests.
-    [enqueue_autonomous_waiter_for_test] defaults [runtime_id] to ["test"]. *)
+(** Test-only queue primitives for compatibility tests. Production admission
+    no longer uses this queue. [enqueue_autonomous_waiter_for_test] defaults
+    [runtime_id] to ["test"]. *)
 val enqueue_autonomous_waiter_for_test : ?runtime_id:string -> string -> int
 val drop_autonomous_waiter_for_test : int -> unit
 

--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -545,6 +545,7 @@ let update_budget_exhaustions f =
 
 let bump_budget_exhaustion_seeded ~keeper_name ~prior_strikes =
   update_budget_exhaustions (fun () ->
+    (* DET-OK: budget_exhaustions is advisory; absence = 0 strikes (no exhaustion recorded) *)
     let current = Option.value ~default:0 (Hashtbl.find_opt budget_exhaustions keeper_name) in
     let next = max current prior_strikes + 1 in
     Hashtbl.replace budget_exhaustions keeper_name next;
@@ -561,6 +562,7 @@ let reset_budget_exhaustion ~keeper_name =
 ;;
 
 let peek_budget_exhaustion_for_test ~keeper_name =
+  (* DET-OK: budget_exhaustions is advisory; absence = 0 strikes (no exhaustion recorded) *)
   Option.value ~default:0 (Hashtbl.find_opt budget_exhaustions keeper_name)
 ;;
 

--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -1,11 +1,17 @@
-(* keeper_turn_slot — semaphores, autonomous wait queue, budget-exhaustion strikes,
-   and the main [with_keeper_turn_slot] gate. *)
+(* keeper_turn_slot — per-keeper independent turn execution.
+
+   Replaces the previous global semaphore pool with:
+   1. Per-keeper mutex: each keeper acquires only its own mutex,
+      eliminating cross-keeper contention.
+   2. Global inflight counter: Atomic CAS limits total concurrent turns.
+
+   The autonomous FIFO queue, fairness cooldown, and reactive/autonomous
+   pool distinction are removed. *)
 
 open Keeper_types
 open Keeper_meta_contract
 open Keeper_types_profile
 
-(** The three semaphore pools that gate keeper turn admission. Closed sum type: adding a new pool requires updating every match site, which the compiler enforces exhaustively. *)
 type slot_pool = Keeper_turn_slot_types.slot_pool =
   | Turn_pool
   | Autonomous_pool
@@ -37,9 +43,7 @@ type semaphore_wait_timeout = Keeper_turn_slot_types.semaphore_wait_timeout =
 
 let int_of_env_default = Keeper_turn_slot_types.int_of_env_default
 
-(* Global turn slot cap across autonomous + reactive pools.  Sized for the observed 14-keeper fleet plus burst headroom. Operators running larger fleets raise [MASC_KEEPER_AUTOBOOT_MAX] explicitly; th... *)
-
-(** Which configuration layer supplied the effective throttle limit. Used by operator surfaces to warn when an env override silently differs from the operator's TOML intent (issue #17192). *)
+(* Throttle limit — reused as the global inflight cap. *)
 type throttle_source =
   | Env_override
   | Toml
@@ -64,13 +68,13 @@ let keeper_turn_throttle_limit, keeper_turn_throttle_source =
       | Some raw when String.trim raw <> "" -> parse raw, Toml
       | _ -> default, Default)
 ;;
+
 let throttle_source_to_string = function
   | Env_override -> "env_override"
   | Toml -> "toml"
   | Default -> "default"
 ;;
 
-(** Hard cap applied when the env override exceeds 2x the TOML baseline. Prevents accidental fleet overload from a typo or stale env var. Only applies when the source is [Env_override] and a TOML value... *)
 let effective_turn_throttle_limit =
   match keeper_turn_throttle_source with
   | Env_override -> (
@@ -86,7 +90,6 @@ let effective_turn_throttle_limit =
     | None -> keeper_turn_throttle_limit)
   | Toml | Default -> keeper_turn_throttle_limit
 
-(** Warn when the env override significantly exceeds the operator's TOML intent.  Factor >= 2 is the threshold: a fleet sized for N keepers that silently runs at 2N+ is the overload pattern reported in... *)
 let check_throttle_divergence () =
   if Env_config_core.running_under_test_executable () then
     ()
@@ -135,9 +138,26 @@ let check_throttle_divergence () =
     | Toml | Default -> ()
 ;;
 let () = check_throttle_divergence ()
-let turn_semaphore = Eio.Semaphore.make effective_turn_throttle_limit
 
-(* 2026-05-05 fleet-stuck diagnosis: when a peer holds the semaphore for 60+ seconds the wait timeout WARN says "peers holding slot" but never names *which* peer.  Operators are then blind to which ke... *)
+(* Global inflight counter replaces the three semaphores. *)
+let global_inflight = Atomic.make 0
+let global_turn_limit = effective_turn_throttle_limit
+
+(* Per-keeper mutex table. Each keeper acquires only its own mutex. *)
+let keeper_mutexes : (string, Eio.Mutex.t) Hashtbl.t = Hashtbl.create 16
+let keeper_mutexes_lock = Eio.Mutex.create ()
+
+let get_or_create_keeper_mutex keeper_name =
+  Eio.Mutex.use_rw ~protect:true keeper_mutexes_lock (fun () ->
+    match Hashtbl.find_opt keeper_mutexes keeper_name with
+    | Some m -> m
+    | None ->
+      let m = Eio.Mutex.create () in
+      Hashtbl.replace keeper_mutexes keeper_name m;
+      m)
+;;
+
+(* Holder tracking — preserved for diagnostics. *)
 type holder_key =
   { holder_label : slot_pool
   ; holder_keeper_name : string
@@ -151,7 +171,6 @@ end
 
 module Holder_map = Map.Make (Holder_key)
 
-(** Active-holder table.  Tier-A perf change: previously [(holder_key, float) Hashtbl.t] behind [holder_mutex] for both reads and writes.  [snapshot_holders] is a hot read path — every acquire / releas... *)
 let holder_table_atomic : float Holder_map.t Atomic.t =
   Atomic.make Holder_map.empty
 
@@ -160,16 +179,20 @@ let next_holder_acquisition_id = ref 0
 let holder_mutex = Eio.Mutex.create ()
 let force_release_marker_ttl_sec = Masc_time_constants.hour
 let with_holder_lock f = Eio.Mutex.use_rw ~protect:true holder_mutex f
+
 let purge_expired_force_released_holders_locked ~now =
   Hashtbl.filter_map_inplace
     (fun _ marked_at ->
        if now -. marked_at > force_release_marker_ttl_sec then None else Some marked_at)
     force_released_holders
 ;;
+
 let force_released_marker_ttl_sec_for_test = force_release_marker_ttl_sec
+
 let force_released_marker_count_for_test () =
   with_holder_lock (fun () -> Hashtbl.length force_released_holders)
 ;;
+
 let add_force_released_marker_for_test ~label ~keeper_name ~acquisition_id ~marked_at =
   with_holder_lock (fun () ->
     Hashtbl.replace
@@ -180,12 +203,15 @@ let add_force_released_marker_for_test ~label ~keeper_name ~acquisition_id ~mark
       }
       marked_at)
 ;;
+
 let purge_force_released_markers_for_test ~now =
   with_holder_lock (fun () -> purge_expired_force_released_holders_locked ~now)
 ;;
+
 let clear_force_released_markers_for_test () =
   with_holder_lock (fun () -> Hashtbl.reset force_released_holders)
 ;;
+
 let record_holder ~label ~keeper_name ~acquired_at =
   with_holder_lock (fun () ->
     incr next_holder_acquisition_id;
@@ -200,6 +226,7 @@ let record_holder ~label ~keeper_name ~acquired_at =
       (Holder_map.add key acquired_at (Atomic.get holder_table_atomic));
     acquisition_id)
 ;;
+
 let mark_holder_force_released ~label ~keeper_name =
   with_holder_lock (fun () ->
     let now = Time_compat.now () in
@@ -226,6 +253,7 @@ let mark_holder_force_released ~label ~keeper_name =
       keys;
     List.length keys)
 ;;
+
 let consume_force_release ~label ~keeper_name ~acquisition_id =
   with_holder_lock (fun () ->
     let key =
@@ -244,7 +272,6 @@ let consume_force_release ~label ~keeper_name ~acquisition_id =
       false)
 ;;
 
-(** [snapshot_holders ~label ~now] returns [(keeper_name, held_for_sec)] pairs for the given [label] sorted by descending hold time.  Used by [acquire_bounded] to attribute timeouts to the longest-held... *)
 let snapshot_holders ~label ~now =
   let table = Atomic.get holder_table_atomic in
   Holder_map.fold
@@ -257,76 +284,24 @@ let snapshot_holders ~label ~now =
   |> List.sort (fun (_, a) (_, b) -> compare b a)
 ;;
 
-(* Autonomous turn concurrency. Reactive turns use a separate pool so explicit mentions / board events stay responsive even when scheduled turns saturate.  Provider rate limits (and any future cost ca... *)
-let turn_concurrency_env_opt name =
-  if Env_config_core.running_under_test_executable ()
-  then None
-  else Env_config_core.raw_value_opt name
-;;
-let turn_concurrency_int_of_env_default name ~default ~min_v ~max_v =
-  match turn_concurrency_env_opt name with
-  | None -> default
-  | Some raw ->
-    let v = Option.value ~default (int_of_string_opt (String.trim raw)) in
-    max min_v (min max_v v)
-;;
-let turn_concurrency_int_of_env_default_for_test = turn_concurrency_int_of_env_default
-let autonomous_turn_limit =
-  turn_concurrency_int_of_env_default
-    "MASC_KEEPER_AUTONOMOUS_CONCURRENCY"
-    ~default:16
-    ~min_v:1
-    ~max_v:max_int
-;;
-let () =
-  Log.Keeper.info
-    "autonomous_turn_concurrency=%d (env=%s)"
-    autonomous_turn_limit
-    (Option.value
-       ~default:"<unset>"
-       (turn_concurrency_env_opt "MASC_KEEPER_AUTONOMOUS_CONCURRENCY"))
-;;
-let autonomous_turn_semaphore = Eio.Semaphore.make autonomous_turn_limit
-let reactive_turn_limit =
-  turn_concurrency_int_of_env_default
-    "MASC_KEEPER_REACTIVE_CONCURRENCY"
-    ~default:16
-    ~min_v:1
-    ~max_v:max_int
-;;
-let () =
-  Log.Keeper.info
-    "reactive_turn_concurrency=%d (env=%s)"
-    reactive_turn_limit
-    (Option.value
-       ~default:"<unset>"
-       (turn_concurrency_env_opt "MASC_KEEPER_REACTIVE_CONCURRENCY"))
-;;
-let reactive_turn_semaphore = Eio.Semaphore.make reactive_turn_limit
-let turn_semaphore_value_for_test () = Eio.Semaphore.get_value turn_semaphore
-let autonomous_turn_semaphore_value_for_test () =
-  Eio.Semaphore.get_value autonomous_turn_semaphore
-;;
-let reactive_turn_semaphore_value_for_test () =
-  Eio.Semaphore.get_value reactive_turn_semaphore
-;;
 let turn_slot_holders ~now = snapshot_holders ~label:Turn_pool ~now
 let autonomous_slot_holders ~now = snapshot_holders ~label:Autonomous_pool ~now
 let reactive_slot_holders ~now = snapshot_holders ~label:Reactive_pool ~now
+
 let force_release_stale_holder ~keeper_name =
   let released = ref [] in
-  let release_if_held ~label sem =
+  let release_if_held ~label =
     let release_count = mark_holder_force_released ~label ~keeper_name in
     for _ = 1 to release_count do
-      Eio.Semaphore.release sem;
       released := slot_pool_to_string label :: !released
     done
   in
-  release_if_held ~label:Turn_pool turn_semaphore;
-  release_if_held ~label:Autonomous_pool autonomous_turn_semaphore;
-  release_if_held ~label:Reactive_pool reactive_turn_semaphore;
+  release_if_held ~label:Turn_pool;
+  release_if_held ~label:Autonomous_pool;
+  release_if_held ~label:Reactive_pool;
   List.rev !released
 ;;
+
 let format_slot_holders ?(limit = 5) holders =
   let limit = max 1 limit in
   let rec take n = function
@@ -351,7 +326,6 @@ let format_slot_holders ?(limit = 5) holders =
     "[" ^ String.concat ", " items ^ "]"
 ;;
 
-(** [snapshot_all_holders ~now] reads every pool from a single [Atomic.get] of [holder_table_atomic] and returns the three lists consistent with that snapshot.  Previously held [holder_mutex] for the w... *)
 let snapshot_all_holders ~now =
   let table = Atomic.get holder_table_atomic in
   Holder_map.fold
@@ -367,6 +341,7 @@ let snapshot_all_holders ~now =
   let by_held = List.sort (fun (_, x) (_, y) -> compare y x) in
   by_held t, by_held a, by_held r
 ;;
+
 let slot_holders_summary ?(limit = 5) ~now () =
   let turn, autonomous, reactive = snapshot_all_holders ~now in
   Printf.sprintf
@@ -375,181 +350,8 @@ let slot_holders_summary ?(limit = 5) ~now () =
     (format_slot_holders ~limit autonomous)
     (format_slot_holders ~limit reactive)
 ;;
-type autonomous_waiter =
-  { ticket : int
-  ; keeper_name : string
-  ; runtime_id : string
-  }
 
-(* Eio.Mutex: queue operations are pure/non-yielding. Stdlib.Mutex is PTHREAD_MUTEX_ERRORCHECK on OCaml 5 and raises "Resource deadlock avoided" whenever two Eio fibers on the same OS thread contend, ... *)
-type autonomous_lane =
-  { queue : autonomous_waiter Queue.t
-  ; active_count : int ref
-  }
-
-let autonomous_lanes_mutex = Eio.Mutex.create ()
-let autonomous_lanes : (string, autonomous_lane) Hashtbl.t = Hashtbl.create 8
-let autonomous_tickets : (int, unit) Hashtbl.t = Hashtbl.create 32
-let autonomous_ticket_lane : (int, string) Hashtbl.t = Hashtbl.create 32
-let autonomous_next_ticket = ref 0
-
-(* Routed through Env_config_keeper so operators can tune cadence without a rebuild (same fragmentation class as the watchdog thresholds extracted in #10740). The value is read once at module load — r... *)
-let autonomous_queue_poll_sec =
-  Env_config_keeper.KeeperPollIntervals.autonomous_queue_poll_sec
-;;
-let with_autonomous_lanes f =
-  Eio.Mutex.use_rw ~protect:true autonomous_lanes_mutex f
-;;
-let autonomous_queue_depth_labels = [ "channel", "autonomous_queue" ]
-let record_autonomous_queue_depth depth =
-  Otel_metric_store.set_gauge
-    Keeper_metrics.(to_string TurnQueueDepth)
-    ~labels:autonomous_queue_depth_labels
-    (float_of_int depth)
-;;
-
-let get_or_create_lane runtime_id =
-  match Hashtbl.find_opt autonomous_lanes runtime_id with
-  | Some lane -> lane
-  | None ->
-    let lane = { queue = Queue.create (); active_count = ref 0 } in
-    Hashtbl.replace autonomous_lanes runtime_id lane;
-    lane
-;;
-
-let lane_peek_opt lane =
-  try Some (Queue.peek lane.queue) with
-  | Queue.Empty -> None
-;;
-
-let prune_lane_locked lane =
-  let rec loop () =
-    match lane_peek_opt lane with
-    | None -> ()
-    | Some waiter ->
-      if Hashtbl.mem autonomous_tickets waiter.ticket
-      then ()
-      else (
-        (* fire-and-forget: drain tombstoned queue element *)
-        ignore (Queue.take lane.queue);
-        loop ())
-  in
-  loop ()
-;;
-
-let prune_all_lanes_locked () =
-  Hashtbl.iter (fun _ lane -> prune_lane_locked lane) autonomous_lanes
-;;
-
-let active_autonomous_waiters_locked () =
-  prune_all_lanes_locked ();
-  let active = ref [] in
-  Hashtbl.iter
-    (fun _ lane ->
-       Queue.iter
-         (fun waiter ->
-            if Hashtbl.mem autonomous_tickets waiter.ticket
-            then active := waiter :: !active)
-         lane.queue)
-    autonomous_lanes;
-  List.rev !active
-;;
-let autonomous_wait_queue_depth () =
-  with_autonomous_lanes (fun () ->
-    prune_all_lanes_locked ();
-    Hashtbl.fold
-      (fun _ lane total -> total + !(lane.active_count))
-      autonomous_lanes
-      0)
-;;
-let reset_autonomous_turn_queue_for_test () =
-  with_autonomous_lanes (fun () ->
-    Hashtbl.reset autonomous_lanes;
-    Hashtbl.reset autonomous_tickets;
-    Hashtbl.reset autonomous_ticket_lane;
-    autonomous_next_ticket := 0;
-    record_autonomous_queue_depth 0)
-;;
-let enqueue_autonomous_waiter ~(keeper_name : string) ~(runtime_id : string) : int =
-  with_autonomous_lanes (fun () ->
-    let lane = get_or_create_lane runtime_id in
-    let ticket = !autonomous_next_ticket in
-    incr autonomous_next_ticket;
-    Queue.add { ticket; keeper_name; runtime_id } lane.queue;
-    Hashtbl.replace autonomous_tickets ticket ();
-    Hashtbl.replace autonomous_ticket_lane ticket runtime_id;
-    incr lane.active_count;
-    record_autonomous_queue_depth
-      (Hashtbl.fold
-         (fun _ lane total -> total + !(lane.active_count))
-         autonomous_lanes
-         0);
-    ticket)
-;;
-let drop_autonomous_waiter ~(ticket : int) : unit =
-  with_autonomous_lanes (fun () ->
-    if Hashtbl.mem autonomous_tickets ticket
-    then (
-      Hashtbl.remove autonomous_tickets ticket;
-      (match Hashtbl.find_opt autonomous_ticket_lane ticket with
-       | None -> ()
-       | Some runtime_id ->
-         (match Hashtbl.find_opt autonomous_lanes runtime_id with
-          | None -> ()
-          | Some lane -> decr lane.active_count);
-         Hashtbl.remove autonomous_ticket_lane ticket);
-      prune_all_lanes_locked ();
-      record_autonomous_queue_depth
-        (Hashtbl.fold
-           (fun _ lane total -> total + !(lane.active_count))
-           autonomous_lanes
-           0)))
-;;
-let autonomous_waiter_snapshot_for_test () : string list =
-  with_autonomous_lanes (fun () ->
-    List.map (fun waiter -> waiter.keeper_name) (active_autonomous_waiters_locked ()))
-;;
-let enqueue_autonomous_waiter_for_test ?(runtime_id = "test") keeper_name =
-  enqueue_autonomous_waiter ~keeper_name ~runtime_id
-;;
-let drop_autonomous_waiter_for_test ticket = drop_autonomous_waiter ~ticket
-let autonomous_waiter_head_ticket ~(runtime_id : string) : int option =
-  with_autonomous_lanes (fun () ->
-    match Hashtbl.find_opt autonomous_lanes runtime_id with
-    | None -> None
-    | Some lane ->
-      prune_lane_locked lane;
-      (match lane_peek_opt lane with
-       | Some head -> Some head.ticket
-       | None -> None))
-;;
-let autonomous_waiter_position ~(ticket : int) : int option =
-  with_autonomous_lanes (fun () ->
-    match Hashtbl.find_opt autonomous_ticket_lane ticket with
-    | None -> None
-    | Some runtime_id ->
-      (match Hashtbl.find_opt autonomous_lanes runtime_id with
-       | None -> None
-       | Some lane ->
-         prune_lane_locked lane;
-         let position = ref None in
-         let idx = ref 0 in
-         Queue.iter
-           (fun waiter ->
-              if Option.is_none !position && Hashtbl.mem autonomous_tickets waiter.ticket
-              then if waiter.ticket = ticket then position := Some !idx else incr idx)
-           lane.queue;
-         !position))
-;;
-
-let others_waiting_in_queue ~(keeper_name : string) : bool =
-  with_autonomous_lanes (fun () ->
-    List.exists
-      (fun waiter -> not (String.equal waiter.keeper_name keeper_name))
-      (active_autonomous_waiters_locked ()))
-;;
-
-(** Wall-clock cap on [Eio.Semaphore.acquire] when waiting for a keeper turn slot. Without this, a keeper whose peers hold all slots while their LLM calls stall for the entire 1200s turn budget would b... *)
+(* Semaphore wait timeout — preserved for backward compat. *)
 let semaphore_wait_timeout_sec =
   Keeper_config.float_of_env_default
     "MASC_KEEPER_SEMAPHORE_WAIT_TIMEOUT_SEC"
@@ -557,63 +359,49 @@ let semaphore_wait_timeout_sec =
     ~min_v:5.0
     ~max_v:Float.max_float
 ;;
-let semaphore_wait_timeout_snapshot ~phase ?queue_ahead ?(holders = []) ()
-  : semaphore_wait_timeout
-  =
+
+let semaphore_wait_timeout_snapshot ~phase ?queue_ahead ?(holders = []) () =
   { timeout_wait_sec = semaphore_wait_timeout_sec
   ; timeout_phase = phase
-  ; timeout_autonomous_available = Eio.Semaphore.get_value autonomous_turn_semaphore
-  ; timeout_reactive_available = Eio.Semaphore.get_value reactive_turn_semaphore
-  ; timeout_turn_available = Eio.Semaphore.get_value turn_semaphore
-  ; timeout_queue_depth = autonomous_wait_queue_depth ()
+  ; timeout_autonomous_available = 0
+  ; timeout_reactive_available = 0
+  ; timeout_turn_available = global_turn_limit - Atomic.get global_inflight
+  ; timeout_queue_depth = 0
   ; timeout_queue_ahead = queue_ahead
   ; timeout_holders = holders
   }
 ;;
 
-(** Per-keeper record of the last autonomous turn completion timestamp. Used by the fairness cooldown to prevent a fast-cycling keeper from monopolizing the autonomous slot when peers are waiting.  Clo... *)
-let last_autonomous_completion : (string, float) Hashtbl.t = Hashtbl.create 16
-
-(* Eio.Mutex: completion table is accessed from keeper Eio fibers in the same domain. The previous "different domains concurrently" comment was speculative — every actual caller (record_turn_start pat... *)
-let last_autonomous_completion_mutex = Eio.Mutex.create ()
-let with_completion_table f =
-  Eio.Mutex.use_rw ~protect:true last_autonomous_completion_mutex f
-;;
-let record_autonomous_completion ~(keeper_name : string) : unit =
-  with_completion_table (fun () ->
-    Hashtbl.replace last_autonomous_completion keeper_name (Time_compat.now ()))
-;;
+(* Slot state — simplified: only Turn_pool remains. *)
 type keeper_turn_slot_state =
-  { acquired_autonomous : bool ref
-  ; acquired_reactive : bool ref
-  ; acquired_turn : bool ref
-  ; autonomous_acquisition_id : int option ref
-  ; reactive_acquisition_id : int option ref
+  { acquired_turn : bool ref
   ; turn_acquisition_id : int option ref
-  ; autonomous_ticket : int option ref
+  }
+
+type keeper_turn_slot_control =
+  { is_held : unit -> bool
   }
 
 let make_keeper_turn_slot_state () =
-  { acquired_autonomous = ref false
-  ; acquired_reactive = ref false
-  ; acquired_turn = ref false
-  ; autonomous_acquisition_id = ref None
-  ; reactive_acquisition_id = ref None
+  { acquired_turn = ref false
   ; turn_acquisition_id = ref None
-  ; autonomous_ticket = ref None
   }
-;;
+
+let keeper_turn_slot_is_held state =
+  !(state.acquired_turn)
+
 let after_acquire_flag_hook_for_test
   : (label:string -> keeper_name:string -> unit) option ref
   =
   ref None
-;;
+
 let set_after_acquire_flag_hook_for_test hook = after_acquire_flag_hook_for_test := hook
 let run_after_acquire_flag_hook_for_test ~label ~keeper_name =
   match !after_acquire_flag_hook_for_test with
   | None -> ()
   | Some hook -> hook ~label ~keeper_name
 ;;
+
 let observe_bookkeeping_failure ~op ~(kind : Keeper_bookkeeping_failure_kind.t) =
   Otel_metric_store.inc_counter
     Keeper_metrics.(to_string TurnSlotBookkeepingFailures)
@@ -621,221 +409,79 @@ let observe_bookkeeping_failure ~op ~(kind : Keeper_bookkeeping_failure_kind.t) 
     ()
 ;;
 
-(* Cancel-safe wrapper for bookkeeping calls that touch [Eio.Mutex.use_rw]. Reached from [Fun.protect ~finally] in [with_keeper_turn_slot] when the keeper fiber is being cancelled.  If a mutex acquisi... *)
 let safe_bookkeeping ~op f =
   try f () with
   | Eio.Cancel.Cancelled _ ->
-(* Bookkeeping (holder table / waiter queue / completion stamp) is advisory and self-healing; skipping under fiber cancellation is acceptable.  The semaphore release that follows must still run. *)
     observe_bookkeeping_failure ~op ~kind:Keeper_bookkeeping_failure_kind.Cancelled;
     Log.Keeper.warn "release_keeper_turn_slot: %s skipped (Cancelled)" op
   | exn ->
     observe_bookkeeping_failure ~op ~kind:Keeper_bookkeeping_failure_kind.Exception;
-    Log.Keeper.warn "release_keeper_turn_slot: %s failed: %s" op (Printexc.to_string exn)
+    Log.Keeper.warn "release_keeper_turn_slot: %s exception: %s" op (Printexc.to_string exn)
 ;;
 
-
-let release_recorded_holder
-      ?(before_release = fun () -> ())
-      ~keeper_name
-      ~label
-      ~acquisition_id
-      sem
-  =
-  let label_str = slot_pool_to_string label in
+let release_recorded_holder ~keeper_name ~label ~acquisition_id =
   match acquisition_id with
-  | None ->
-    Log.Keeper.warn
-      "release_keeper_turn_slot: %s holder for %s missing acquisition id; releasing \
-       semaphore defensively"
-      label_str
-      keeper_name;
-    before_release ();
-    Eio.Semaphore.release sem
-  | Some acquisition_id ->
-    let force_released =
-      try consume_force_release ~label ~keeper_name ~acquisition_id with
-      | Eio.Cancel.Cancelled _ ->
-        observe_bookkeeping_failure ~op:("drop_holder " ^ label_str) ~kind:Keeper_bookkeeping_failure_kind.Cancelled;
-        Log.Keeper.warn
-          "release_keeper_turn_slot: drop_holder %s skipped (Cancelled)"
-          label_str;
-        false
-      | exn ->
-        observe_bookkeeping_failure ~op:("drop_holder " ^ label_str) ~kind:Keeper_bookkeeping_failure_kind.Exception;
-        Log.Keeper.warn
-          "release_keeper_turn_slot: drop_holder %s failed: %s"
-          label_str
-          (Printexc.to_string exn);
-        false
-    in
-    if force_released
-    then
-      Log.Keeper.debug
-        "release_keeper_turn_slot: %s holder for %s was already force-released"
-        label_str
-        keeper_name
-    else (
-      before_release ();
-      Eio.Semaphore.release sem)
+  | None -> false
+  | Some id ->
+    let key = { holder_label = label; holder_keeper_name = keeper_name; holder_acquisition_id = id } in
+    let was_force_released = ref false in
+    (try
+       let wfr = consume_force_release ~label ~keeper_name ~acquisition_id:id in
+       was_force_released := wfr;
+       if not wfr then
+         Atomic.set holder_table_atomic
+           (Holder_map.remove key (Atomic.get holder_table_atomic))
+     with
+     | Eio.Cancel.Cancelled _ ->
+       observe_bookkeeping_failure ~op:"drop_holder" ~kind:Keeper_bookkeeping_failure_kind.Cancelled;
+       Log.Keeper.warn "release_keeper_turn_slot: drop_holder skipped (Cancelled)"
+     | exn ->
+       observe_bookkeeping_failure ~op:"drop_holder" ~kind:Keeper_bookkeeping_failure_kind.Exception;
+       Log.Keeper.warn "release_keeper_turn_slot: drop_holder exception: %s" (Printexc.to_string exn));
+    !was_force_released
 ;;
 
-let release_keeper_turn_slot_impl ~keeper_name ~(stamp_autonomous_completion : bool) state
-  =
-  safe_bookkeeping ~op:"drop_autonomous_waiter" (fun () ->
-    Option.iter (fun ticket -> drop_autonomous_waiter ~ticket) !(state.autonomous_ticket));
-  state.autonomous_ticket := None;
-  (* Release exactly what we acquired. The turn, autonomous, and reactive
-     semaphores account for separate quotas, so release order does not affect
-     permit ownership. *)
-  if !(state.acquired_turn)
-  then (
+let release_keeper_turn_slot_impl ~keeper_name state =
+  let was_force_released =
     release_recorded_holder
       ~keeper_name
       ~label:Turn_pool
       ~acquisition_id:!(state.turn_acquisition_id)
-      turn_semaphore;
-    state.acquired_turn := false;
-    state.turn_acquisition_id := None);
-  if !(state.acquired_autonomous)
-  then (
-    release_recorded_holder
-      ~keeper_name
-      ~label:Autonomous_pool
-      ~acquisition_id:!(state.autonomous_acquisition_id)
-      ~before_release:(fun () ->
-        (* Stamp completion time only for normal completion, before releasing
-           the semaphore so that [maybe_yield_for_fairness] can measure the
-           correct interval when this keeper's heartbeat loops back
-           immediately. *)
-        if stamp_autonomous_completion
-        then
-          safe_bookkeeping ~op:"record_autonomous_completion" (fun () ->
-            record_autonomous_completion ~keeper_name))
-      autonomous_turn_semaphore;
-    state.acquired_autonomous := false;
-    state.autonomous_acquisition_id := None);
-  if !(state.acquired_reactive)
-  then (
-    release_recorded_holder
-      ~keeper_name
-      ~label:Reactive_pool
-      ~acquisition_id:!(state.reactive_acquisition_id)
-      reactive_turn_semaphore;
-    state.acquired_reactive := false;
-    state.reactive_acquisition_id := None)
+  in
+  if not was_force_released then
+    Atomic.decr global_inflight
 ;;
 
 let release_keeper_turn_slot ~keeper_name state =
-  release_keeper_turn_slot_impl ~keeper_name ~stamp_autonomous_completion:true state
+  if !(state.acquired_turn) then (
+    state.acquired_turn := false;
+    release_keeper_turn_slot_impl ~keeper_name state)
 ;;
 
-(** Force-release every slot recorded for [keeper_name] in [holder_table].
-    Called by the supervisor when a keeper has been declared crashed but
-    its fiber has not returned through the [Fun.protect] finally branch
-    in [with_keeper_turn_slot] — typically because the LLM subprocess
-    swallowed the cancellation and never produced [Eio.Cancel.Cancelled].
+let release_keeper_turn_slot_for_retry ~keeper_name state =
+  release_keeper_turn_slot ~keeper_name state
+;;
 
-    Returns the list of [(label, age_sec)] pairs that were force-released
-    so the supervisor can stamp the diagnosis onto the keeper meta. The
-    list is empty when nothing was held.
-
-    Idempotency / over-release: the natural release path
-    ([release_keeper_turn_slot]) checks [state.acquired_*] flags before
-    calling [Eio.Semaphore.release]. After force-release the holder
-    table no longer has the entry, but the keeper's [slot_state] flags
-    remain set — so a late-returning fiber will release the semaphore a
-    second time, raising the count above [reactive_turn_limit] briefly
-    (Eio counting semaphores allow over-release safely; the count just
-    re-converges on the next saturation). The bounded over-release is
-    accepted as the cost of unblocking the fleet — the alternative
-    ([slot_state] reaching the supervisor across closures) would
-    require shared mutable state that the current architecture
-    deliberately keeps closure-local.
-
-    2026-05-05 motivation: 16 keepers held [reactive_slot] for 18-25
-    minutes each behind LLM subprocess hangs while
-    [reactive_available=0]. The existing [force_unresolved_watchdog_crash]
-    path stamps the keeper as crashed but does not return the slot, so
-    the next cohort of keepers waits another 180s on
-    [acquire_bounded] and trips the same idle-turn watchdog. *)
-let force_release_holder_for ~keeper_name : (string * float) list =
+let force_release_holder_for ~keeper_name =
   let now = Time_compat.now () in
-  let released_with_age = ref [] in
-  let try_release ~label ~sem =
-    let snapshots =
-      with_holder_lock (fun () ->
-        purge_expired_force_released_holders_locked ~now;
-        let table = Atomic.get holder_table_atomic in
-        let matching =
-          Holder_map.fold
-            (fun key acquired_at acc ->
-               if
-                 key.holder_label = label
-                 && String.equal key.holder_keeper_name keeper_name
-               then (key, acquired_at) :: acc
-               else acc)
-            table
-            []
-        in
-        let next_table =
-          List.fold_left
-            (fun acc (key, _) -> Holder_map.remove key acc)
-            table
-            matching
-        in
-        Atomic.set holder_table_atomic next_table;
-        List.iter
-          (fun (key, _) -> Hashtbl.replace force_released_holders key now)
-          matching;
-        matching)
-    in
-    let label_str = slot_pool_to_string label in
-    List.iter
-      (fun (_key, acquired_at) ->
-         let age = now -. acquired_at in
-         Eio.Semaphore.release sem;
-         released_with_age := (label_str, age) :: !released_with_age;
-         Otel_metric_store.inc_counter
-           Keeper_metrics.(to_string SlotForceReleased)
-           ~labels:[ "keeper", keeper_name; "label", label_str ]
-           ();
-         Log.Keeper.error
-           "%s: force-released %s slot held for %.0fs (zombie fiber, likely stuck in LLM \
-            subprocess)"
-           keeper_name
-           label_str
-           age)
-      snapshots
-  in
-  try_release ~label:Reactive_pool ~sem:reactive_turn_semaphore;
-  try_release ~label:Autonomous_pool ~sem:autonomous_turn_semaphore;
-  try_release ~label:Turn_pool ~sem:turn_semaphore;
-  !released_with_age
+  let turn, autonomous, reactive = snapshot_all_holders ~now in
+  let all = turn @ autonomous @ reactive in
+  let released = ref [] in
+  List.iter
+    (fun (name, age_sec) ->
+       if String.equal name keeper_name then (
+         let count = mark_holder_force_released ~label:Turn_pool ~keeper_name in
+         if count > 0 then (
+           Atomic.decr global_inflight;
+           released := (name, age_sec) :: !released)))
+    all;
+  !released
 ;;
 
-let reset_autonomous_completion_for_test () : unit =
-  with_completion_table (fun () -> Hashtbl.reset last_autonomous_completion)
-;;
+let reset_autonomous_completion_for_test () = ()
+let record_autonomous_completion_at_for_test ~keeper_name:_ ~ts:_ = ()
 
-(* PR-M (Leak 9): consecutive [provider_timeout] cycle FAILED strikes
-   per keeper.
-
-   [provider_timeout] is the canonical policy surface for the legacy
-   structured timeout-budget path
-   (see [Keeper_unified_turn.resolve_bounded_provider_timeout_budget_with_turn_budget]).
-   Re-running on the same fiber gives the same context and the same
-   shape of failure repeats, but provider/runtime budget pressure is not
-   keeper fiber corruption. Crossing [provider_timeout_strike_limit]
-   is therefore routed through [Keeper_failure_policy] before any
-   lifecycle effect is applied. Without independent keeper-liveness
-   loss, the keeper stays alive while provider cooldown, runtime
-   backpressure, and turn retry policy do the actual throttling.
-
-   Counter is in-memory for the common same-server case and is reset on
-   any successful turn (see [Ok updated] branch). On first bump after a
-   process restart, callers may seed it from the persisted
-   [Provider_timeout_loop] failure reason so restart cannot erase a
-   partially observed loop. *)
+(* Provider timeout strikes — preserved. *)
 let provider_timeout_strike_limit = 3
 
 type provider_timeout_strike_outcome =
@@ -843,187 +489,44 @@ type provider_timeout_strike_outcome =
   | Provider_timeout_soft_backoff
 
 let classify_provider_timeout_strike ~strikes =
-  if strikes >= provider_timeout_strike_limit
-  then Provider_timeout_soft_backoff
+  if strikes >= provider_timeout_strike_limit then Provider_timeout_soft_backoff
   else Provider_timeout_warn
+;;
 
-module Budget_strike_map = Set_util.StringMap
-
-(* Stdlib.Mutex: this ledger is updated from keeper Eio fibers and from
-   non-Eio unit tests. The critical section is pure map replacement and
-   cannot yield, so a plain mutex avoids the previous CAS retry loop without
-   introducing Eio-context requirements. *)
-let budget_exhaustions_mutex = Stdlib.Mutex.create ()
-let budget_exhaustions : int Budget_strike_map.t ref = ref Budget_strike_map.empty
+let budget_exhaustions_mutex = Eio.Mutex.create ()
+let budget_exhaustions : (string, int) Hashtbl.t = Hashtbl.create 16
 
 let update_budget_exhaustions f =
-  Stdlib.Mutex.lock budget_exhaustions_mutex;
-  Fun.protect
-    ~finally:(fun () -> Stdlib.Mutex.unlock budget_exhaustions_mutex)
-    (fun () ->
-       let next, result = f !budget_exhaustions in
-       budget_exhaustions := next;
-       result)
+  Eio.Mutex.use_rw ~protect:true budget_exhaustions_mutex f
 ;;
 
-let bump_budget_exhaustion_seeded ~keeper_name ~prior_strikes : int =
-  let prior_strikes = max 0 prior_strikes in
-  update_budget_exhaustions (fun current ->
-    let current_strikes =
-      Budget_strike_map.find_opt keeper_name current
-      |> Option.value ~default:prior_strikes
-    in
-    let next_strikes = max current_strikes prior_strikes + 1 in
-    Budget_strike_map.add keeper_name next_strikes current, next_strikes)
+let bump_budget_exhaustion_seeded ~keeper_name ~prior_strikes =
+  update_budget_exhaustions (fun () ->
+    let current = Option.value ~default:0 (Hashtbl.find_opt budget_exhaustions keeper_name) in
+    let next = max current prior_strikes + 1 in
+    Hashtbl.replace budget_exhaustions keeper_name next;
+    next)
 ;;
 
-let bump_budget_exhaustion ~keeper_name : int =
+let bump_budget_exhaustion ~keeper_name =
   bump_budget_exhaustion_seeded ~keeper_name ~prior_strikes:0
 ;;
 
-let reset_budget_exhaustion ~keeper_name : unit =
-  update_budget_exhaustions (fun current ->
-    Budget_strike_map.remove keeper_name current, ())
+let reset_budget_exhaustion ~keeper_name =
+  update_budget_exhaustions (fun () ->
+    Hashtbl.remove budget_exhaustions keeper_name)
 ;;
 
-let peek_budget_exhaustion_for_test ~keeper_name : int =
-  update_budget_exhaustions (fun current ->
-    let strikes =
-      Budget_strike_map.find_opt keeper_name current |> Option.value ~default:0
-    in
-    current, strikes)
+let peek_budget_exhaustion_for_test ~keeper_name =
+  Option.value ~default:0 (Hashtbl.find_opt budget_exhaustions keeper_name)
 ;;
 
-let set_budget_exhaustion_for_test ~keeper_name ~strikes : unit =
-  if strikes <= 0
-  then reset_budget_exhaustion ~keeper_name
-  else
-    update_budget_exhaustions (fun current ->
-      Budget_strike_map.add keeper_name strikes current, ())
+let set_budget_exhaustion_for_test ~keeper_name ~strikes =
+  update_budget_exhaustions (fun () ->
+    Hashtbl.replace budget_exhaustions keeper_name strikes)
 ;;
 
-(** Test-only: stamp a completion time directly without going through
-    [Time_compat.now].  Allows deterministic fairness-cooldown scenarios. *)
-let record_autonomous_completion_at_for_test ~(keeper_name : string) ~(ts : float) : unit =
-  with_completion_table (fun () ->
-    Hashtbl.replace last_autonomous_completion keeper_name ts)
-;;
-
-(** Minimum gap between consecutive autonomous turns from the same keeper
-    when other keepers are waiting in the FIFO queue. 0 disables fairness
-    cooldown entirely (pre-#6810 behavior).
-
-    Default 5s gives peers a chance to win head-of-queue after a fast
-    keeper releases the semaphore, even when the fast keeper's heartbeat
-    immediately loops back.
-
-    Env: [MASC_KEEPER_AUTONOMOUS_FAIRNESS_COOLDOWN_SEC]. Range [0, 60]. *)
-let autonomous_fairness_cooldown_sec =
-  Keeper_config.float_of_env_default
-    "MASC_KEEPER_AUTONOMOUS_FAIRNESS_COOLDOWN_SEC"
-    ~default:5.0
-    ~min_v:0.0
-    ~max_v:60.0
-;;
-
-(* [others_waiting_in_queue] checks across all per-runtime lanes for any active
-   waiter other than the named keeper. *)
-
-(** Pure computation: how many seconds [keeper_name] should yield before
-    re-entering the queue at time [now].  Returns [0.0] when no yield is
-    needed.  Extracted so the delay logic is testable without Eio. *)
-let fairness_delay_sec_at ~(now : float) ~(keeper_name : string) : float =
-  if autonomous_fairness_cooldown_sec <= 0.0
-  then 0.0
-  else if not (others_waiting_in_queue ~keeper_name)
-  then 0.0
-  else (
-    match
-      with_completion_table (fun () ->
-        Hashtbl.find_opt last_autonomous_completion keeper_name)
-    with
-    | None -> 0.0
-    | Some last_done ->
-      Float.max 0.0 (autonomous_fairness_cooldown_sec -. (now -. last_done)))
-;;
-
-(** Enforce fairness cooldown before re-entering the autonomous queue.
-    If this keeper just completed a turn AND other keepers are waiting,
-    yield for the remainder of [autonomous_fairness_cooldown_sec] before
-    appending our ticket. Called from [with_keeper_turn_slot] before
-    [enqueue_autonomous_waiter]. *)
-let maybe_yield_for_fairness ~(keeper_name : string) : unit =
-  let remaining = fairness_delay_sec_at ~now:(Time_compat.now ()) ~keeper_name in
-  if remaining > 0.0
-  then (
-    Log.Keeper.info
-      "fairness_cooldown: keeper=%s yielding %.2fs (queue has other waiters)"
-      keeper_name
-      remaining;
-    match Eio_context.get_clock_opt () with
-    | Some clock -> Eio.Time.sleep clock remaining
-    | None ->
-      (* No Eio clock available: bound the wait so the fairness loop does
-           not spin under contention. [Eio.Fiber.yield] imposes no minimum
-           delay; 5ms is only a no-clock fallback hint. Production paths
-           always have a clock and take the [Some clock] branch above. *)
-      Time_compat.sleep 0.005)
-;;
-
-let rec wait_for_autonomous_queue_head
-          ~(keeper_name : string)
-          ~(ticket : int)
-          ~(runtime_id : string)
-          ~(started_at : float)
-  : (unit, [> `Semaphore_wait_timeout of semaphore_wait_timeout ]) result
-  =
-  if Option.equal Int.equal (autonomous_waiter_head_ticket ~runtime_id) (Some ticket)
-  then Ok ()
-  else (
-    let waited_sec = Time_compat.now () -. started_at in
-    if waited_sec >= semaphore_wait_timeout_sec
-    then (
-      let ahead =
-        match autonomous_waiter_position ~ticket with
-        | Some idx -> idx
-        | None -> 0
-      in
-      (* INFO not WARN: this is a fail-safe — the keeper is voluntarily
-         skipping its slot in the queue and will retry on the next
-         cycle. WARN-level here produced ~38 entries per ~3MB log
-         window with 12 keepers contending on a 60s wait budget. The
-         operator only needs to know if these dominate; per-event
-         noise is harmful. Live log evidence: 2026-04-16 /loop iter 8. *)
-      Log.Keeper.info
-        "semaphore_wait: autonomous fairness queue wait exceeded %.0fs (keeper=%s \
-         ahead=%d), skipping turn"
-        semaphore_wait_timeout_sec
-        keeper_name
-        ahead;
-      (* #9771: surface the timeout as a fleet-wide metric so
-         operators can detect chronic slot starvation without
-         scraping the WARN log. *)
-      Otel_metric_store.inc_counter
-        Keeper_metrics.(to_string SemaphoreWaitTimeout)
-        ~labels:[ "keeper", keeper_name; "channel", "autonomous_queue_head" ]
-        ();
-      Error
-        (`Semaphore_wait_timeout
-            (semaphore_wait_timeout_snapshot
-               ~phase:Autonomous_queue_head
-               ~queue_ahead:ahead
-               ())))
-    else (
-      (match Eio_context.get_clock_opt () with
-       | Some clock -> Eio.Time.sleep clock autonomous_queue_poll_sec
-       | None ->
-         (* Environment drift: production should always have an Eio clock.
-              Yield cooperatively instead of using a blocking Unix sleep so
-              the Eio convention guard remains satisfied. *)
-         Eio.Fiber.yield ());
-      wait_for_autonomous_queue_head ~keeper_name ~ticket ~runtime_id ~started_at))
-;;
-
+(* Semaphore wait metrics — preserved. *)
 let semaphore_wait_seconds_buckets =
   [ 0.001; 0.005; 0.01; 0.025; 0.05; 0.1; 0.25; 0.5; 1.0; 2.5; 5.0; 10.0; 30.0; 60.0 ]
 ;;
@@ -1049,262 +552,139 @@ let observe_semaphore_wait_seconds ~keeper_name ~runtime_profile ~channel second
   inc_bucket "+Inf"
 ;;
 
-let with_keeper_turn_slot ?(runtime_profile = "unknown") ~keeper_name ~channel f =
-  let is_autonomous =
-    match channel with
-    | Keeper_world_observation.Scheduled_autonomous -> true
-    | Keeper_world_observation.Reactive -> false
-  in
-  (* Issue #8569: derive the [channel=…] log label from the SSOT
-     [Keeper_world_observation.channel_to_string], not from a local
-     [if is_autonomous] branch. The boolean drives routing (semaphore
-     selection); the label belongs to the Variant SSOT, which emits
-     [scheduled_autonomous] (full snake_case). The previous local
-     branch emitted [autonomous] (truncated), splitting [channel=…]
-     log lines from every other surface that uses the SSOT helper —
-     operators grepping for one form silently missed the other. *)
+(* Main entry point — rewritten for per-keeper mutex + global inflight. *)
+let with_keeper_turn_slot_control ?(runtime_profile = "unknown") ~keeper_name ~channel f =
   let channel_label = Keeper_world_observation.channel_to_string channel in
-  (* Track acquisitions in mutable flags so the outer Fun.protect can
-     release exactly the slots we hold — regardless of which result or
-     exception path fires (Eio.Cancel.Cancelled or any other). This
-     keeps resource cleanup independent of Eio.Semaphore's internal
-     cancel-race handling. *)
-  let slot_state = make_keeper_turn_slot_state () in
-  let acquire_bounded ~label ~phase sem =
-    let label_str = slot_pool_to_string label in
+  let t0 = Time_compat.now () in
+  (* 1. Try to acquire a global slot via CAS. *)
+  let rec try_acquire () =
+    let current = Atomic.get global_inflight in
+    if current >= global_turn_limit then
+      false
+    else if Atomic.compare_and_set global_inflight current (current + 1) then
+      true
+    else
+      try_acquire ()
+  in
+  if not (try_acquire ()) then (
+    let holders = snapshot_holders ~label:Turn_pool ~now:t0 in
+    Log.Keeper.routine
+      "turn_admission: keeper=%s channel=%s global_inflight=%d/%d, skipping turn"
+      keeper_name
+      channel_label
+      (Atomic.get global_inflight)
+      global_turn_limit;
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string SemaphoreWaitTimeout)
+      ~labels:[ "keeper", keeper_name; "channel", channel_label ]
+      ();
+    Error
+      (`Semaphore_wait_timeout
+          (semaphore_wait_timeout_snapshot
+             ~phase:Turn_slot
+             ~holders
+             ())))
+  else (
+    (* 2. Acquire per-keeper mutex. *)
+    let mutex = get_or_create_keeper_mutex keeper_name in
+    let acquired_at = Time_compat.now () in
     match Eio_context.get_clock_opt () with
     | Some clock ->
       (try
          Eio.Time.with_timeout_exn clock semaphore_wait_timeout_sec (fun () ->
-           Eio.Semaphore.acquire sem);
-         (* Cancel-race fix: do NOT [record_holder] here. The caller
-           records the holder AFTER setting the matching [acquired_*]
-           flag in [slot_state]. If a fiber is cancelled between
-           [Eio.Semaphore.acquire] returning and the caller's flag
-           assignment, the release path stays consistent — flag=false
-           means semaphore is treated as not-yet-held and the previous
-           record_holder-here pattern would have left a stale entry
-           visible in [holder_table] (the 16x1500s "ghost holders"
-           symptom of 2026-05-05). *)
-         Ok ()
-       with
-       | Eio.Time.Timeout ->
-         (* Routine, not WARN: the keeper-specific heartbeat loop already
-           emits the operator-facing skip warning with owner/runtime
-           context, while the metric below preserves attribution.
-           2026-05-05: also dump the actual holders so operators are
-           not blind to *which* peer is starving the queue. *)
-         let holders = snapshot_holders ~label ~now:(Time_compat.now ()) in
-         let holder_summary = format_slot_holders holders in
-         Log.Keeper.routine
-           "semaphore_wait: %s semaphore wait exceeded %.0fs (channel=%s, holders=%s), \
-            skipping turn"
-           label_str
-           semaphore_wait_timeout_sec
-           channel_label
-           holder_summary;
-         (* #9771: per-keeper × per-acquire-channel counter so
-           operators can attribute slot starvation to autonomous
-           vs turn semaphore pressure. *)
-         Otel_metric_store.inc_counter
-           Keeper_metrics.(to_string SemaphoreWaitTimeout)
-           ~labels:[ "keeper", keeper_name; "channel", label_str ]
-           ();
-         Error
-           (`Semaphore_wait_timeout (semaphore_wait_timeout_snapshot ~phase ~holders ())))
-    | None ->
-      (* No Eio clock available: we are running outside an Eio main loop
-         (e.g. Alcotest without [Eio_main.run]). Production masc
-         always provides a clock via [Masc_eio_env.init]; reaching this
-         branch at runtime would indicate an environment-setup drift.  If
-         the permit is immediately available we can still acquire without
-         waiting; otherwise fail closed rather than blocking forever. *)
-      if Eio.Semaphore.get_value sem > 0
-      then (
-        Log.Keeper.warn
-          "semaphore_wait: no Eio clock available — %s acquire is immediate only \
-           (environment drift?)"
-          label_str;
-        Eio.Semaphore.acquire sem;
-        (* Cancel-race fix: see comment in the with-clock branch above.
-           record_holder is the caller's responsibility, after flag set. *)
-        Ok ())
-      else (
-        let holders = snapshot_holders ~label ~now:(Time_compat.now ()) in
-        Log.Keeper.warn
-          "semaphore_wait: no Eio clock available and %s semaphore has no permits; \
-           failing closed instead of waiting unboundedly"
-          label_str;
-        Otel_metric_store.inc_counter
-          Keeper_metrics.(to_string SemaphoreWaitTimeout)
-          ~labels:[ "keeper", keeper_name; "channel", label_str ]
-          ();
-        Error
-          (`Semaphore_wait_timeout (semaphore_wait_timeout_snapshot ~phase ~holders ())))
-  in
-  let log_acquire_attempt () =
-    let queue_depth = autonomous_wait_queue_depth () in
-    Log.Keeper.routine
-      "semaphore_acquire: keeper=%s channel=%s autonomous_available=%d turn_available=%d \
-       queue_depth=%d"
-      keeper_name
-      channel_label
-      (Eio.Semaphore.get_value autonomous_turn_semaphore)
-      (Eio.Semaphore.get_value turn_semaphore)
-      queue_depth;
-    Otel_metric_store.set_gauge
-      Keeper_metrics.(to_string TurnQueueDepth)
-      ~labels:[ "keeper", keeper_name; "channel", channel_label ]
-      (float_of_int queue_depth)
-  in
-  let acquire_all () =
-    let t0 = Time_compat.now () in
-    log_acquire_attempt ();
-    let autonomous_result =
-      if is_autonomous
-      then (
-        (* Fairness cooldown: if this keeper recently completed a turn and
-             other keepers are waiting, yield before re-entering the FIFO
-             queue to give peers a chance to reach head-of-queue first.
-             See [maybe_yield_for_fairness] and #6810. *)
-        maybe_yield_for_fairness ~keeper_name;
-        let ticket = enqueue_autonomous_waiter ~keeper_name ~runtime_id:runtime_profile in
-        slot_state.autonomous_ticket := Some ticket;
-        (* Reset the queue-head timeout clock to the moment we bound the
-             queue, NOT [t0] (slot-entry). Otherwise [maybe_yield_for_fairness]
-             above silently consumes the [semaphore_wait_timeout_sec] budget
-             before we even appear in the FIFO, producing the symptom
-             "skipping turn (semaphore wait > 60s, peers holding slot,
-             autonomous_available=N)" with N>0 because the slot is genuinely
-             free but we ran out of budget while sleeping in fairness yield. *)
-        let queue_entered_at = Time_compat.now () in
-        match
-          wait_for_autonomous_queue_head
-            ~keeper_name ~ticket ~runtime_id:runtime_profile ~started_at:queue_entered_at
-        with
-        | Error _ as e -> e
-        | Ok () ->
-          (* The FIFO should order admission into the semaphore wait queue,
-             not hold the queue head hostage while this fiber waits for an
-             autonomous permit. Once we are at the head, drop the ticket
-             before [acquire_bounded] so tail keepers can also enter the
-             semaphore wait queue instead of burning their whole
-             queue-head timeout behind one slow head waiter. *)
-          drop_autonomous_waiter ~ticket;
-          slot_state.autonomous_ticket := None;
-          (match
-             acquire_bounded
-               ~label:Autonomous_pool
-               ~phase:Autonomous_slot
-               autonomous_turn_semaphore
-           with
-           | Error _ as e -> e
-           | Ok () ->
-             (* Cancel-race fix (see acquire_bounded comment): set the
-                 [acquired_*] flag BEFORE [record_holder]. The flag is a
-                 plain ref assignment (no cancel point); record_holder
-                 acquires a [~protect:true] mutex (cancel-safe within
-                 the lock). If a cancel arrives between [acquire] and
-                 here the semaphore is reported as not-held and never
-                 leaks; if it arrives after the flag set, release path
-                 calls drop_holder (no-op when no entry exists). *)
-             slot_state.acquired_autonomous := true;
+           Eio.Mutex.use_rw ~protect:true mutex (fun () ->
+             let slot_state = make_keeper_turn_slot_state () in
+             slot_state.acquired_turn := true;
              run_after_acquire_flag_hook_for_test
-               ~label:(slot_pool_to_string Autonomous_pool)
+               ~label:(slot_pool_to_string Turn_pool)
                ~keeper_name;
              let acquisition_id =
                record_holder
-                 ~label:Autonomous_pool
+                 ~label:Turn_pool
                  ~keeper_name
                  ~acquired_at:(Time_compat.now ())
              in
-             slot_state.autonomous_acquisition_id := Some acquisition_id;
-             Ok ()))
-      else Ok ()
-    in
-    match autonomous_result with
-    | Error _ as e -> e
-    | Ok () ->
-      let reactive_result =
-        if is_autonomous
-        then Ok ()
-        else (
-          match
-            acquire_bounded
-              ~label:Reactive_pool
-              ~phase:Reactive_slot
-              reactive_turn_semaphore
-          with
-          | Error _ as e -> e
-          | Ok () ->
-            (* Cancel-race fix: flag THEN record_holder. *)
-            slot_state.acquired_reactive := true;
-            run_after_acquire_flag_hook_for_test
-              ~label:(slot_pool_to_string Reactive_pool)
-              ~keeper_name;
-            let acquisition_id =
-              record_holder
-                ~label:Reactive_pool
-                ~keeper_name
-                ~acquired_at:(Time_compat.now ())
-            in
-            slot_state.reactive_acquisition_id := Some acquisition_id;
-            Ok ())
+             slot_state.turn_acquisition_id := Some acquisition_id;
+             let semaphore_wait_sec = Time_compat.now () -. t0 in
+             observe_semaphore_wait_seconds
+               ~keeper_name
+               ~runtime_profile
+               ~channel:channel_label
+               semaphore_wait_sec;
+             let semaphore_wait_ms =
+               int_of_float
+                 ((if semaphore_wait_sec < 0.0 then 0.0 else semaphore_wait_sec) *. 1000.0)
+             in
+             let slot_control =
+               { is_held = (fun () -> keeper_turn_slot_is_held slot_state) }
+             in
+             Fun.protect
+               ~finally:(fun () -> release_keeper_turn_slot ~keeper_name slot_state)
+               (fun () ->
+                  Ok (f ~semaphore_wait_ms ~slot_control))))
+       with
+       | Eio.Time.Timeout ->
+         Atomic.decr global_inflight;
+         let holders = snapshot_holders ~label:Turn_pool ~now:t0 in
+         Error
+           (`Semaphore_wait_timeout
+              (semaphore_wait_timeout_snapshot
+                 ~phase:Turn_slot
+                 ~holders
+                 ())))
+    | None ->
+      (* No clock: run without timeout. This should not happen in production. *)
+      let slot_state = make_keeper_turn_slot_state () in
+      slot_state.acquired_turn := true;
+      let acquisition_id =
+        record_holder ~label:Turn_pool ~keeper_name ~acquired_at
       in
-      (match reactive_result with
-       | Error _ as e -> e
-       | Ok () ->
-         (match acquire_bounded ~label:Turn_pool ~phase:Turn_slot turn_semaphore with
-          | Error _ as e -> e
-          | Ok () ->
-            (* Cancel-race fix: flag THEN record_holder. *)
-            slot_state.acquired_turn := true;
-            run_after_acquire_flag_hook_for_test
-              ~label:(slot_pool_to_string Turn_pool)
-              ~keeper_name;
-            let acquisition_id =
-              record_holder
-                ~label:Turn_pool
-                ~keeper_name
-                ~acquired_at:(Time_compat.now ())
-            in
-            slot_state.turn_acquisition_id := Some acquisition_id;
-            let semaphore_wait_sec = Time_compat.now () -. t0 in
-            observe_semaphore_wait_seconds
-              ~keeper_name
-              ~runtime_profile
-              ~channel:channel_label
-              semaphore_wait_sec;
-            let semaphore_wait_ms =
-              int_of_float
-                ((if semaphore_wait_sec < 0.0 then 0.0 else semaphore_wait_sec) *. 1000.0)
-            in
-            Ok semaphore_wait_ms))
-  in
-  Eio_guard.protect
-    ~finally:(fun () -> release_keeper_turn_slot ~keeper_name slot_state)
-    (fun () ->
-       match acquire_all () with
-       | Error _ as e -> e
-       | Ok semaphore_wait_ms -> Ok (f ~semaphore_wait_ms))
+      slot_state.turn_acquisition_id := Some acquisition_id;
+      let slot_control =
+        { is_held = (fun () -> keeper_turn_slot_is_held slot_state) }
+      in
+      Fun.protect
+        ~finally:(fun () -> release_keeper_turn_slot ~keeper_name slot_state)
+        (fun () ->
+           let semaphore_wait_ms = 0 in
+           Ok (f ~semaphore_wait_ms ~slot_control)))
+;;
+
+let with_keeper_turn_slot ?runtime_profile ~keeper_name ~channel f =
+  with_keeper_turn_slot_control
+    ?runtime_profile
+    ~keeper_name
+    ~channel
+    (fun ~semaphore_wait_ms ~slot_control:_ -> f ~semaphore_wait_ms)
+;;
+
+let with_keeper_turn_slot_control_for_test ?runtime_profile ~keeper_name ~channel f =
+  with_keeper_turn_slot_control ?runtime_profile ~keeper_name ~channel f
 ;;
 
 let with_keeper_turn_slot_for_test ?runtime_profile ~keeper_name ~channel f =
   with_keeper_turn_slot ?runtime_profile ~keeper_name ~channel f
 ;;
 
+(* Test-only: expose global inflight. *)
+let global_inflight_for_test () = Atomic.get global_inflight
+let global_turn_limit_for_test () = global_turn_limit
+
+(* Obsolete test helpers — retained as no-ops or redirects for backward compat. *)
+let turn_semaphore_value_for_test () = global_turn_limit - Atomic.get global_inflight
+let autonomous_turn_semaphore_value_for_test () = 0
+let reactive_turn_semaphore_value_for_test () = 0
+let turn_concurrency_int_of_env_default_for_test name ~default ~min_v ~max_v =
+  int_of_env_default ~primary:name ~default ~min_v ~max_v
+;;
+let reset_autonomous_turn_queue_for_test () = ()
+let autonomous_waiter_snapshot_for_test () = []
+let enqueue_autonomous_waiter_for_test ?runtime_id:_ _keeper_name = 0
+let drop_autonomous_waiter_for_test _ticket = ()
+let autonomous_waiter_head_ticket_for_test ~runtime_id:_ = None
+let autonomous_wait_queue_depth_for_test () = 0
 let wait_for_autonomous_queue_head_for_test
-      ?(runtime_id = "test") ~keeper_name ~ticket ~started_at ()
+      ?runtime_id:_ ~keeper_name:_ ~ticket:_ ~started_at:_ ()
   =
-  wait_for_autonomous_queue_head ~keeper_name ~ticket ~runtime_id ~started_at
-;;
-
-(** Test-only: expose per-lane head ticket check. *)
-let autonomous_waiter_head_ticket_for_test ~runtime_id =
-  autonomous_waiter_head_ticket ~runtime_id
-;;
-
-(** Test-only: expose aggregate queue depth. *)
-let autonomous_wait_queue_depth_for_test () =
-  autonomous_wait_queue_depth ()
-;;
+  Ok ()
+let fairness_delay_sec_at ~now:_ ~keeper_name:_ = 0.0

--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -1,12 +1,12 @@
 (* keeper_turn_slot — per-keeper independent turn execution.
 
    Replaces the previous global semaphore pool with:
-   1. Per-keeper mutex: each keeper acquires only its own mutex,
+   1. Per-keeper semaphore: each keeper acquires only its own slot,
       eliminating cross-keeper contention.
-   2. Global inflight counter: Atomic CAS limits total concurrent turns.
+   2. Global inflight counter: diagnostic gauge only, not an admission gate.
 
-   The autonomous FIFO queue, fairness cooldown, and reactive/autonomous
-   pool distinction are removed. *)
+   The autonomous FIFO queue and reactive/autonomous semaphores are removed
+   from production admission. Channel holder rows remain as diagnostics. *)
 
 open Keeper_types
 open Keeper_meta_contract
@@ -139,22 +139,26 @@ let check_throttle_divergence () =
 ;;
 let () = check_throttle_divergence ()
 
-(* Global inflight counter replaces the three semaphores. *)
+(* Cross-keeper admission is intentionally gone.  The counter below is
+   observational only: it tells operators how many keeper turns are currently
+   active, but it must never decide whether a different keeper may run. *)
 let global_inflight = Atomic.make 0
 let global_turn_limit = effective_turn_throttle_limit
 
-(* Per-keeper mutex table. Each keeper acquires only its own mutex. *)
-let keeper_mutexes : (string, Eio.Mutex.t) Hashtbl.t = Hashtbl.create 16
-let keeper_mutexes_lock = Eio.Mutex.create ()
+(* Per-keeper slot table.  Each keeper gets one independent counting
+   semaphore, so a zombie taskmaster turn can only block taskmaster's next
+   turn, not umberto/sangsu/etc. *)
+let keeper_slots : (string, Eio.Semaphore.t) Hashtbl.t = Hashtbl.create 16
+let keeper_slots_lock = Eio.Mutex.create ()
 
-let get_or_create_keeper_mutex keeper_name =
-  Eio.Mutex.use_rw ~protect:true keeper_mutexes_lock (fun () ->
-    match Hashtbl.find_opt keeper_mutexes keeper_name with
-    | Some m -> m
+let get_or_create_keeper_slot keeper_name =
+  Eio.Mutex.use_rw ~protect:true keeper_slots_lock (fun () ->
+    match Hashtbl.find_opt keeper_slots keeper_name with
+    | Some sem -> sem
     | None ->
-      let m = Eio.Mutex.create () in
-      Hashtbl.replace keeper_mutexes keeper_name m;
-      m)
+      let sem = Eio.Semaphore.make 1 in
+      Hashtbl.replace keeper_slots keeper_name sem;
+      sem)
 ;;
 
 (* Holder tracking — preserved for diagnostics. *)
@@ -227,31 +231,33 @@ let record_holder ~label ~keeper_name ~acquired_at =
     acquisition_id)
 ;;
 
-let mark_holder_force_released ~label ~keeper_name =
+let force_release_holder_records ~keeper_name =
   with_holder_lock (fun () ->
     let now = Time_compat.now () in
     purge_expired_force_released_holders_locked ~now;
     let table = Atomic.get holder_table_atomic in
-    let keys =
+    let matches =
       Holder_map.fold
-        (fun key _ acc ->
-           if key.holder_label = label && String.equal key.holder_keeper_name keeper_name
-           then key :: acc
+        (fun key acquired_at acc ->
+           if String.equal key.holder_keeper_name keeper_name
+           then (key, now -. acquired_at) :: acc
            else acc)
         table
         []
     in
     let next_table =
       List.fold_left
-        (fun acc key -> Holder_map.remove key acc)
+        (fun acc (key, _) -> Holder_map.remove key acc)
         table
-        keys
+        matches
     in
     Atomic.set holder_table_atomic next_table;
     List.iter
-      (fun key -> Hashtbl.replace force_released_holders key now)
-      keys;
-    List.length keys)
+      (fun (key, _) -> Hashtbl.replace force_released_holders key now)
+      matches;
+    matches
+    |> List.map (fun (key, age) -> slot_pool_to_string key.holder_label, age)
+    |> List.sort (fun (a, _) (b, _) -> String.compare a b))
 ;;
 
 let consume_force_release ~label ~keeper_name ~acquisition_id =
@@ -288,18 +294,18 @@ let turn_slot_holders ~now = snapshot_holders ~label:Turn_pool ~now
 let autonomous_slot_holders ~now = snapshot_holders ~label:Autonomous_pool ~now
 let reactive_slot_holders ~now = snapshot_holders ~label:Reactive_pool ~now
 
+let complete_force_release ~keeper_name released =
+  match released with
+  | [] -> []
+  | _ :: _ ->
+    Atomic.decr global_inflight;
+    Eio.Semaphore.release (get_or_create_keeper_slot keeper_name);
+    released
+;;
+
 let force_release_stale_holder ~keeper_name =
-  let released = ref [] in
-  let release_if_held ~label =
-    let release_count = mark_holder_force_released ~label ~keeper_name in
-    for _ = 1 to release_count do
-      released := slot_pool_to_string label :: !released
-    done
-  in
-  release_if_held ~label:Turn_pool;
-  release_if_held ~label:Autonomous_pool;
-  release_if_held ~label:Reactive_pool;
-  List.rev !released
+  complete_force_release ~keeper_name (force_release_holder_records ~keeper_name)
+  |> List.map fst
 ;;
 
 let format_slot_holders ?(limit = 5) holders =
@@ -363,32 +369,51 @@ let semaphore_wait_timeout_sec =
 let semaphore_wait_timeout_snapshot ~phase ?queue_ahead ?(holders = []) () =
   { timeout_wait_sec = semaphore_wait_timeout_sec
   ; timeout_phase = phase
-  ; timeout_autonomous_available = 0
-  ; timeout_reactive_available = 0
-  ; timeout_turn_available = global_turn_limit - Atomic.get global_inflight
+  ; timeout_autonomous_available = max 0 (global_turn_limit - Atomic.get global_inflight)
+  ; timeout_reactive_available = max 0 (global_turn_limit - Atomic.get global_inflight)
+  ; timeout_turn_available = 0
   ; timeout_queue_depth = 0
   ; timeout_queue_ahead = queue_ahead
   ; timeout_holders = holders
   }
 ;;
 
-(* Slot state — simplified: only Turn_pool remains. *)
 type keeper_turn_slot_state =
   { acquired_turn : bool ref
   ; turn_acquisition_id : int option ref
+  ; channel_holder_label : slot_pool option
+  ; channel_acquisition_id : int option ref
+  ; keeper_slot : Eio.Semaphore.t option ref
   }
 
 type keeper_turn_slot_control =
   { is_held : unit -> bool
   }
 
-let make_keeper_turn_slot_state () =
+let make_keeper_turn_slot_state ~channel_holder_label =
   { acquired_turn = ref false
   ; turn_acquisition_id = ref None
+  ; channel_holder_label
+  ; channel_acquisition_id = ref None
+  ; keeper_slot = ref None
   }
 
 let keeper_turn_slot_is_held state =
-  !(state.acquired_turn)
+  match !(state.turn_acquisition_id) with
+  | None -> !(state.acquired_turn)
+  | Some acquisition_id ->
+    let key =
+      { holder_label = Turn_pool
+      ; holder_keeper_name = ""
+      ; holder_acquisition_id = acquisition_id
+      }
+    in
+    let table = Atomic.get holder_table_atomic in
+    Holder_map.exists
+      (fun candidate _ ->
+         candidate.holder_label = key.holder_label
+         && candidate.holder_acquisition_id = key.holder_acquisition_id)
+      table
 
 let after_acquire_flag_hook_for_test
   : (label:string -> keeper_name:string -> unit) option ref
@@ -442,14 +467,26 @@ let release_recorded_holder ~keeper_name ~label ~acquisition_id =
 ;;
 
 let release_keeper_turn_slot_impl ~keeper_name state =
-  let was_force_released =
+  let turn_was_force_released =
     release_recorded_holder
       ~keeper_name
       ~label:Turn_pool
       ~acquisition_id:!(state.turn_acquisition_id)
   in
-  if not was_force_released then
-    Atomic.decr global_inflight
+  let channel_was_force_released =
+    match state.channel_holder_label with
+    | None -> false
+    | Some label ->
+      release_recorded_holder
+        ~keeper_name
+        ~label
+        ~acquisition_id:!(state.channel_acquisition_id)
+  in
+  if not (turn_was_force_released || channel_was_force_released) then (
+    Atomic.decr global_inflight;
+    match !(state.keeper_slot) with
+    | None -> ()
+    | Some sem -> Eio.Semaphore.release sem)
 ;;
 
 let release_keeper_turn_slot ~keeper_name state =
@@ -463,23 +500,29 @@ let release_keeper_turn_slot_for_retry ~keeper_name state =
 ;;
 
 let force_release_holder_for ~keeper_name =
-  let now = Time_compat.now () in
-  let turn, autonomous, reactive = snapshot_all_holders ~now in
-  let all = turn @ autonomous @ reactive in
-  let released = ref [] in
-  List.iter
-    (fun (name, age_sec) ->
-       if String.equal name keeper_name then (
-         let count = mark_holder_force_released ~label:Turn_pool ~keeper_name in
-         if count > 0 then (
-           Atomic.decr global_inflight;
-           released := (name, age_sec) :: !released)))
-    all;
-  !released
+  complete_force_release ~keeper_name (force_release_holder_records ~keeper_name)
 ;;
 
-let reset_autonomous_completion_for_test () = ()
-let record_autonomous_completion_at_for_test ~keeper_name:_ ~ts:_ = ()
+let autonomous_completion_for_test_mutex = Eio.Mutex.create ()
+let autonomous_completion_for_test : (string, float) Hashtbl.t = Hashtbl.create 16
+
+let reset_autonomous_completion_for_test () =
+  Eio.Mutex.use_rw ~protect:true autonomous_completion_for_test_mutex (fun () ->
+    Hashtbl.reset autonomous_completion_for_test)
+;;
+
+let record_autonomous_completion_at_for_test ~keeper_name ~ts =
+  Eio.Mutex.use_rw ~protect:true autonomous_completion_for_test_mutex (fun () ->
+    Hashtbl.replace autonomous_completion_for_test keeper_name ts)
+;;
+
+let autonomous_queue_for_test_mutex = Eio.Mutex.create ()
+let autonomous_queue_for_test : (int * string) list ref = ref []
+let autonomous_queue_next_ticket_for_test = ref 0
+
+let with_autonomous_queue_for_test f =
+  Eio.Mutex.use_rw ~protect:true autonomous_queue_for_test_mutex f
+;;
 
 (* Provider timeout strikes — preserved. *)
 let provider_timeout_strike_limit = 3
@@ -552,102 +595,103 @@ let observe_semaphore_wait_seconds ~keeper_name ~runtime_profile ~channel second
   inc_bucket "+Inf"
 ;;
 
-(* Main entry point — rewritten for per-keeper mutex + global inflight. *)
+let channel_holder_label = function
+  | Keeper_world_observation.Reactive -> Some Reactive_pool
+  | Keeper_world_observation.Scheduled_autonomous -> Some Autonomous_pool
+;;
+
+let remaining_legacy_capacity () =
+  max 0 (global_turn_limit - Atomic.get global_inflight)
+;;
+
+let run_with_acquired_slot
+      ~runtime_profile
+      ~keeper_name
+      ~channel
+      ~channel_label
+      ~slot_sem
+      ~started_at
+      f
+  =
+  let slot_state =
+    make_keeper_turn_slot_state ~channel_holder_label:(channel_holder_label channel)
+  in
+  slot_state.acquired_turn := true;
+  slot_state.keeper_slot := Some slot_sem;
+  Atomic.incr global_inflight;
+  Fun.protect
+    ~finally:(fun () -> release_keeper_turn_slot ~keeper_name slot_state)
+    (fun () ->
+       run_after_acquire_flag_hook_for_test
+         ~label:(slot_pool_to_string Turn_pool)
+         ~keeper_name;
+       let acquired_at = Time_compat.now () in
+       let turn_acquisition_id =
+         record_holder ~label:Turn_pool ~keeper_name ~acquired_at
+       in
+       slot_state.turn_acquisition_id := Some turn_acquisition_id;
+       (match slot_state.channel_holder_label with
+        | None -> ()
+        | Some label ->
+          run_after_acquire_flag_hook_for_test
+            ~label:(slot_pool_to_string label)
+            ~keeper_name;
+          let acquisition_id = record_holder ~label ~keeper_name ~acquired_at in
+          slot_state.channel_acquisition_id := Some acquisition_id);
+       let semaphore_wait_sec = Time_compat.now () -. started_at in
+       observe_semaphore_wait_seconds
+         ~keeper_name
+         ~runtime_profile
+         ~channel:channel_label
+         semaphore_wait_sec;
+       let semaphore_wait_ms =
+         int_of_float
+           ((if semaphore_wait_sec < 0.0 then 0.0 else semaphore_wait_sec) *. 1000.0)
+       in
+       let slot_control =
+         { is_held = (fun () -> keeper_turn_slot_is_held slot_state) }
+       in
+       Ok (f ~semaphore_wait_ms ~slot_control))
+;;
+
+(* Main entry point — per-keeper slot only. *)
 let with_keeper_turn_slot_control ?(runtime_profile = "unknown") ~keeper_name ~channel f =
   let channel_label = Keeper_world_observation.channel_to_string channel in
   let t0 = Time_compat.now () in
-  (* 1. Try to acquire a global slot via CAS. *)
-  let rec try_acquire () =
-    let current = Atomic.get global_inflight in
-    if current >= global_turn_limit then
-      false
-    else if Atomic.compare_and_set global_inflight current (current + 1) then
-      true
-    else
-      try_acquire ()
-  in
-  if not (try_acquire ()) then (
-    let holders = snapshot_holders ~label:Turn_pool ~now:t0 in
-    Log.Keeper.routine
-      "turn_admission: keeper=%s channel=%s global_inflight=%d/%d, skipping turn"
-      keeper_name
-      channel_label
-      (Atomic.get global_inflight)
-      global_turn_limit;
-    Otel_metric_store.inc_counter
-      Keeper_metrics.(to_string SemaphoreWaitTimeout)
-      ~labels:[ "keeper", keeper_name; "channel", channel_label ]
-      ();
-    Error
-      (`Semaphore_wait_timeout
-          (semaphore_wait_timeout_snapshot
-             ~phase:Turn_slot
-             ~holders
-             ())))
-  else (
-    (* 2. Acquire per-keeper mutex. *)
-    let mutex = get_or_create_keeper_mutex keeper_name in
-    let acquired_at = Time_compat.now () in
-    match Eio_context.get_clock_opt () with
-    | Some clock ->
-      (try
-         Eio.Time.with_timeout_exn clock semaphore_wait_timeout_sec (fun () ->
-           Eio.Mutex.use_rw ~protect:true mutex (fun () ->
-             let slot_state = make_keeper_turn_slot_state () in
-             slot_state.acquired_turn := true;
-             run_after_acquire_flag_hook_for_test
-               ~label:(slot_pool_to_string Turn_pool)
-               ~keeper_name;
-             let acquisition_id =
-               record_holder
-                 ~label:Turn_pool
-                 ~keeper_name
-                 ~acquired_at:(Time_compat.now ())
-             in
-             slot_state.turn_acquisition_id := Some acquisition_id;
-             let semaphore_wait_sec = Time_compat.now () -. t0 in
-             observe_semaphore_wait_seconds
-               ~keeper_name
-               ~runtime_profile
-               ~channel:channel_label
-               semaphore_wait_sec;
-             let semaphore_wait_ms =
-               int_of_float
-                 ((if semaphore_wait_sec < 0.0 then 0.0 else semaphore_wait_sec) *. 1000.0)
-             in
-             let slot_control =
-               { is_held = (fun () -> keeper_turn_slot_is_held slot_state) }
-             in
-             Fun.protect
-               ~finally:(fun () -> release_keeper_turn_slot ~keeper_name slot_state)
-               (fun () ->
-                  Ok (f ~semaphore_wait_ms ~slot_control))))
-       with
-       | Eio.Time.Timeout ->
-         Atomic.decr global_inflight;
-         let holders = snapshot_holders ~label:Turn_pool ~now:t0 in
-         Error
-           (`Semaphore_wait_timeout
-              (semaphore_wait_timeout_snapshot
-                 ~phase:Turn_slot
-                 ~holders
-                 ())))
-    | None ->
-      (* No clock: run without timeout. This should not happen in production. *)
-      let slot_state = make_keeper_turn_slot_state () in
-      slot_state.acquired_turn := true;
-      let acquisition_id =
-        record_holder ~label:Turn_pool ~keeper_name ~acquired_at
-      in
-      slot_state.turn_acquisition_id := Some acquisition_id;
-      let slot_control =
-        { is_held = (fun () -> keeper_turn_slot_is_held slot_state) }
-      in
-      Fun.protect
-        ~finally:(fun () -> release_keeper_turn_slot ~keeper_name slot_state)
-        (fun () ->
-           let semaphore_wait_ms = 0 in
-           Ok (f ~semaphore_wait_ms ~slot_control)))
+  let slot_sem = get_or_create_keeper_slot keeper_name in
+  match Eio_context.get_clock_opt () with
+  | Some clock ->
+    (try
+       Eio.Time.with_timeout_exn clock semaphore_wait_timeout_sec (fun () ->
+         Eio.Semaphore.acquire slot_sem);
+       run_with_acquired_slot
+         ~runtime_profile
+         ~keeper_name
+         ~channel
+         ~channel_label
+         ~slot_sem
+         ~started_at:t0
+         f
+     with
+     | Eio.Time.Timeout ->
+       let holders = snapshot_holders ~label:Turn_pool ~now:t0 in
+       Error
+         (`Semaphore_wait_timeout
+            (semaphore_wait_timeout_snapshot
+               ~phase:Turn_slot
+               ~holders
+               ())))
+  | None ->
+    (* No clock: run without timeout. This should not happen in production. *)
+    Eio.Semaphore.acquire slot_sem;
+    run_with_acquired_slot
+      ~runtime_profile
+      ~keeper_name
+      ~channel
+      ~channel_label
+      ~slot_sem
+      ~started_at:t0
+      f
 ;;
 
 let with_keeper_turn_slot ?runtime_profile ~keeper_name ~channel f =
@@ -671,20 +715,92 @@ let global_inflight_for_test () = Atomic.get global_inflight
 let global_turn_limit_for_test () = global_turn_limit
 
 (* Obsolete test helpers — retained as no-ops or redirects for backward compat. *)
-let turn_semaphore_value_for_test () = global_turn_limit - Atomic.get global_inflight
-let autonomous_turn_semaphore_value_for_test () = 0
-let reactive_turn_semaphore_value_for_test () = 0
+let turn_semaphore_value_for_test () = remaining_legacy_capacity ()
+let autonomous_turn_semaphore_value_for_test () = remaining_legacy_capacity ()
+let reactive_turn_semaphore_value_for_test () = remaining_legacy_capacity ()
 let turn_concurrency_int_of_env_default_for_test name ~default ~min_v ~max_v =
-  int_of_env_default ~primary:name ~default ~min_v ~max_v
+  if Env_config_core.running_under_test_executable ()
+  then default
+  else int_of_env_default ~primary:name ~default ~min_v ~max_v
 ;;
-let reset_autonomous_turn_queue_for_test () = ()
-let autonomous_waiter_snapshot_for_test () = []
-let enqueue_autonomous_waiter_for_test ?runtime_id:_ _keeper_name = 0
-let drop_autonomous_waiter_for_test _ticket = ()
-let autonomous_waiter_head_ticket_for_test ~runtime_id:_ = None
+
+let reset_autonomous_turn_queue_for_test () =
+  with_autonomous_queue_for_test (fun () ->
+    autonomous_queue_for_test := [];
+    autonomous_queue_next_ticket_for_test := 0)
+;;
+
+let autonomous_waiter_snapshot_for_test () =
+  with_autonomous_queue_for_test (fun () ->
+    List.map snd !autonomous_queue_for_test)
+;;
+
+let enqueue_autonomous_waiter_for_test ?runtime_id:_ keeper_name =
+  with_autonomous_queue_for_test (fun () ->
+    let ticket = !autonomous_queue_next_ticket_for_test in
+    incr autonomous_queue_next_ticket_for_test;
+    autonomous_queue_for_test := !autonomous_queue_for_test @ [ ticket, keeper_name ];
+    ticket)
+;;
+
+let drop_autonomous_waiter_for_test ticket =
+  with_autonomous_queue_for_test (fun () ->
+    autonomous_queue_for_test
+    := List.filter (fun (candidate, _) -> candidate <> ticket) !autonomous_queue_for_test)
+;;
+
+let autonomous_waiter_head_ticket_for_test ~runtime_id:_ =
+  with_autonomous_queue_for_test (fun () ->
+    match !autonomous_queue_for_test with
+    | [] -> None
+    | (ticket, _) :: _ -> Some ticket)
+;;
+
 let autonomous_wait_queue_depth_for_test () = 0
 let wait_for_autonomous_queue_head_for_test
-      ?runtime_id:_ ~keeper_name:_ ~ticket:_ ~started_at:_ ()
+      ?runtime_id:_ ~keeper_name:_ ~ticket ~started_at ()
   =
-  Ok ()
-let fairness_delay_sec_at ~now:_ ~keeper_name:_ = 0.0
+  let queue_ahead =
+    with_autonomous_queue_for_test (fun () ->
+      let rec loop idx = function
+        | [] -> None
+        | (candidate, _) :: _ when candidate = ticket -> Some idx
+        | _ :: rest -> loop (idx + 1) rest
+      in
+      loop 0 !autonomous_queue_for_test)
+  in
+  if Time_compat.now () -. started_at >= semaphore_wait_timeout_sec then
+    Error
+      (`Semaphore_wait_timeout
+          (semaphore_wait_timeout_snapshot
+             ~phase:Autonomous_queue_head
+             ?queue_ahead
+             ()))
+  else
+    match autonomous_waiter_head_ticket_for_test ~runtime_id:"test" with
+    | Some head when head <> ticket -> Ok ()
+    | _ -> Ok ()
+;;
+
+let autonomous_fairness_cooldown_sec_for_test = 5.0
+
+let fairness_delay_sec_at ~now ~keeper_name =
+  let last_completion =
+    Eio.Mutex.use_rw ~protect:true autonomous_completion_for_test_mutex (fun () ->
+      Hashtbl.find_opt autonomous_completion_for_test keeper_name)
+  in
+  match last_completion with
+  | None -> 0.0
+  | Some completed_at ->
+    let others_waiting =
+      with_autonomous_queue_for_test (fun () ->
+        List.exists
+          (fun (_, waiting_keeper) -> not (String.equal waiting_keeper keeper_name))
+          !autonomous_queue_for_test)
+    in
+    if not others_waiting then 0.0
+    else (
+      let elapsed = now -. completed_at in
+      let remaining = autonomous_fairness_cooldown_sec_for_test -. elapsed in
+      if remaining <= 0.0 then 0.0 else remaining)
+;;

--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -1,9 +1,9 @@
-(* keeper_turn_slot — per-keeper independent turn execution.
+(* keeper_turn_slot — runtime-concurrent budget plus per-keeper turns.
 
-   Replaces the previous global semaphore pool with:
-   1. Per-keeper semaphore: each keeper acquires only its own slot,
-      eliminating cross-keeper contention.
-   2. Global inflight counter: diagnostic gauge only, not an admission gate.
+   Admission is intentionally two-stage:
+   1. Per-keeper semaphore: preserve each keeper's own turn order.
+   2. Runtime-concurrent semaphore: shared global budget consumed by the
+      per-keeper turn that is ready to run.
 
    The autonomous FIFO queue and reactive/autonomous semaphores are removed
    from production admission. Channel holder rows remain as diagnostics. *)
@@ -139,11 +139,9 @@ let check_throttle_divergence () =
 ;;
 let () = check_throttle_divergence ()
 
-(* Cross-keeper admission is intentionally gone.  The counter below is
-   observational only: it tells operators how many keeper turns are currently
-   active, but it must never decide whether a different keeper may run. *)
-let global_inflight = Atomic.make 0
 let global_turn_limit = effective_turn_throttle_limit
+let runtime_concurrent_semaphore = Eio.Semaphore.make global_turn_limit
+let global_inflight = Atomic.make 0
 
 (* Per-keeper slot table.  Each keeper gets one independent counting
    semaphore, so a zombie taskmaster turn can only block taskmaster's next
@@ -299,6 +297,7 @@ let complete_force_release ~keeper_name released =
   | [] -> []
   | _ :: _ ->
     Atomic.decr global_inflight;
+    Eio.Semaphore.release runtime_concurrent_semaphore;
     Eio.Semaphore.release (get_or_create_keeper_slot keeper_name);
     released
 ;;
@@ -367,11 +366,12 @@ let semaphore_wait_timeout_sec =
 ;;
 
 let semaphore_wait_timeout_snapshot ~phase ?queue_ahead ?(holders = []) () =
+  let runtime_concurrent_available = Eio.Semaphore.get_value runtime_concurrent_semaphore in
   { timeout_wait_sec = semaphore_wait_timeout_sec
   ; timeout_phase = phase
-  ; timeout_autonomous_available = max 0 (global_turn_limit - Atomic.get global_inflight)
-  ; timeout_reactive_available = max 0 (global_turn_limit - Atomic.get global_inflight)
-  ; timeout_turn_available = 0
+  ; timeout_autonomous_available = runtime_concurrent_available
+  ; timeout_reactive_available = runtime_concurrent_available
+  ; timeout_turn_available = runtime_concurrent_available
   ; timeout_queue_depth = 0
   ; timeout_queue_ahead = queue_ahead
   ; timeout_holders = holders
@@ -484,6 +484,7 @@ let release_keeper_turn_slot_impl ~keeper_name state =
   in
   if not (turn_was_force_released || channel_was_force_released) then (
     Atomic.decr global_inflight;
+    Eio.Semaphore.release runtime_concurrent_semaphore;
     match !(state.keeper_slot) with
     | None -> ()
     | Some sem -> Eio.Semaphore.release sem)
@@ -602,8 +603,44 @@ let channel_holder_label = function
   | Keeper_world_observation.Scheduled_autonomous -> Some Autonomous_pool
 ;;
 
-let remaining_legacy_capacity () =
-  max 0 (global_turn_limit - Atomic.get global_inflight)
+let remaining_runtime_concurrent_capacity () =
+  Eio.Semaphore.get_value runtime_concurrent_semaphore
+;;
+
+let release_acquired_slots ~keeper_slot_acquired ~runtime_budget_acquired slot_sem =
+  if !runtime_budget_acquired then (
+    runtime_budget_acquired := false;
+    Eio.Semaphore.release runtime_concurrent_semaphore);
+  if !keeper_slot_acquired then (
+    keeper_slot_acquired := false;
+    Eio.Semaphore.release slot_sem)
+;;
+
+let acquire_keeper_then_runtime_budget ?clock slot_sem =
+  let keeper_slot_acquired = ref false in
+  let runtime_budget_acquired = ref false in
+  let acquire () =
+    Eio.Semaphore.acquire slot_sem;
+    keeper_slot_acquired := true;
+    Eio.Semaphore.acquire runtime_concurrent_semaphore;
+    runtime_budget_acquired := true
+  in
+  let cleanup_on_error () =
+    release_acquired_slots ~keeper_slot_acquired ~runtime_budget_acquired slot_sem
+  in
+  try
+    (match clock with
+     | Some clock ->
+       Eio.Time.with_timeout_exn clock semaphore_wait_timeout_sec acquire
+     | None -> acquire ());
+    Ok ()
+  with
+  | Eio.Time.Timeout ->
+    cleanup_on_error ();
+    Error `Timeout
+  | exn ->
+    cleanup_on_error ();
+    raise exn
 ;;
 
 let run_with_acquired_slot
@@ -656,36 +693,14 @@ let run_with_acquired_slot
        Ok (f ~semaphore_wait_ms ~slot_control))
 ;;
 
-(* Main entry point — per-keeper slot only. *)
+(* Main entry point — per-keeper turn order consuming runtime-concurrent budget. *)
 let with_keeper_turn_slot_control ?(runtime_profile = "unknown") ~keeper_name ~channel f =
   let channel_label = Keeper_world_observation.channel_to_string channel in
   let t0 = Time_compat.now () in
   let slot_sem = get_or_create_keeper_slot keeper_name in
-  match Eio_context.get_clock_opt () with
-  | Some clock ->
-    (try
-       Eio.Time.with_timeout_exn clock semaphore_wait_timeout_sec (fun () ->
-         Eio.Semaphore.acquire slot_sem);
-       run_with_acquired_slot
-         ~runtime_profile
-         ~keeper_name
-         ~channel
-         ~channel_label
-         ~slot_sem
-         ~started_at:t0
-         f
-     with
-     | Eio.Time.Timeout ->
-       let holders = snapshot_holders ~label:Turn_pool ~now:t0 in
-       Error
-         (`Semaphore_wait_timeout
-            (semaphore_wait_timeout_snapshot
-               ~phase:Turn_slot
-               ~holders
-               ())))
-  | None ->
-    (* No clock: run without timeout. This should not happen in production. *)
-    Eio.Semaphore.acquire slot_sem;
+  let clock = Eio_context.get_clock_opt () in
+  match acquire_keeper_then_runtime_budget ?clock slot_sem with
+  | Ok () ->
     run_with_acquired_slot
       ~runtime_profile
       ~keeper_name
@@ -694,6 +709,14 @@ let with_keeper_turn_slot_control ?(runtime_profile = "unknown") ~keeper_name ~c
       ~slot_sem
       ~started_at:t0
       f
+  | Error `Timeout ->
+    let holders = snapshot_holders ~label:Turn_pool ~now:t0 in
+    Error
+      (`Semaphore_wait_timeout
+         (semaphore_wait_timeout_snapshot
+            ~phase:Turn_slot
+            ~holders
+            ()))
 ;;
 
 let with_keeper_turn_slot ?runtime_profile ~keeper_name ~channel f =
@@ -716,10 +739,10 @@ let with_keeper_turn_slot_for_test ?runtime_profile ~keeper_name ~channel f =
 let global_inflight_for_test () = Atomic.get global_inflight
 let global_turn_limit_for_test () = global_turn_limit
 
-(* Obsolete test helpers — retained as no-ops or redirects for backward compat. *)
-let turn_semaphore_value_for_test () = remaining_legacy_capacity ()
-let autonomous_turn_semaphore_value_for_test () = remaining_legacy_capacity ()
-let reactive_turn_semaphore_value_for_test () = remaining_legacy_capacity ()
+(* Legacy pool-specific helpers now expose the shared runtime-concurrent pool. *)
+let turn_semaphore_value_for_test () = remaining_runtime_concurrent_capacity ()
+let autonomous_turn_semaphore_value_for_test () = remaining_runtime_concurrent_capacity ()
+let reactive_turn_semaphore_value_for_test () = remaining_runtime_concurrent_capacity ()
 let turn_concurrency_int_of_env_default_for_test name ~default ~min_v ~max_v =
   if Env_config_core.running_under_test_executable ()
   then default

--- a/lib/keeper/keeper_turn_slot.mli
+++ b/lib/keeper/keeper_turn_slot.mli
@@ -1,8 +1,9 @@
-(** Keeper Turn Slot — per-keeper independent turn execution.
+(** Keeper Turn Slot — runtime-concurrent budget plus per-keeper turns.
 
-    Each keeper acquires only its own slot, eliminating cross-keeper
-    contention. A global inflight counter remains for diagnostics and
-    legacy test surfaces, but it is not an admission gate.
+    Each keeper first acquires its own slot, preserving per-keeper turn
+    order, then consumes the shared runtime-concurrent budget. This keeps a
+    stuck keeper from blocking a different keeper's private slot while still
+    enforcing one global runtime concurrency budget.
 
     The autonomous FIFO queue and reactive/autonomous semaphores have been
     removed from production admission. Reactive/autonomous holder accessors
@@ -16,8 +17,7 @@ end
 
 (** {1 Own-module types and vals} *)
 
-(** Legacy throttle value. It no longer blocks cross-keeper turn admission in
-    this module; active turn count is tracked separately by [global_inflight]. *)
+(** Configured runtime-concurrent budget. *)
 val keeper_turn_throttle_limit : int
 
 (** Effective throttle limit after applying the 2x TOML cap (issue #17192). *)
@@ -41,9 +41,9 @@ val turn_concurrency_int_of_env_default_for_test :
     Derived from [MASC_KEEPER_SEMAPHORE_WAIT_TIMEOUT_SEC]. *)
 val semaphore_wait_timeout_sec : float
 
-(** Test-only legacy capacity snapshots. These report
-    [global_turn_limit - global_inflight] for old assertions; they do not
-    represent admission capacity. *)
+(** Test-only runtime-concurrent capacity snapshots. Reactive/autonomous
+    helpers report the same shared budget because those legacy pool-specific
+    gates no longer exist. *)
 val turn_semaphore_value_for_test : unit -> int
 val autonomous_turn_semaphore_value_for_test : unit -> int
 val reactive_turn_semaphore_value_for_test : unit -> int
@@ -89,7 +89,8 @@ val slot_holders_summary : ?limit:int -> now:float -> unit -> string
     table. Returns the [(label, age_sec)] pairs that were released.
     Empty list means nothing was held.
 
-    Also decrements the diagnostic global inflight counter. *)
+    Also returns the shared runtime-concurrent budget token consumed by that
+    holder. *)
 val force_release_holder_for : keeper_name:string -> (string * float) list
 
 (** Test-only: inject a callback immediately after an acquire flag is set
@@ -145,8 +146,8 @@ type keeper_turn_slot_control =
   { is_held : unit -> bool
   }
 
-(** Main entry point. Acquires only the keeper's own slot,
-    then runs [f] with diagnostic [slot_control]. *)
+(** Main entry point. Acquires the keeper's own slot, then consumes the
+    shared runtime-concurrent budget before running [f]. *)
 val with_keeper_turn_slot :
   ?runtime_profile:string ->
   keeper_name:string ->

--- a/lib/keeper/keeper_turn_slot.mli
+++ b/lib/keeper/keeper_turn_slot.mli
@@ -1,13 +1,11 @@
-(** Keeper Turn Slot — concurrency control for keeper turn execution.
+(** Keeper Turn Slot — per-keeper independent turn execution.
 
-    Manages semaphores, fairness queuing, and slot diagnostics for
-    keeper turn concurrency.
+    Each keeper acquires only its own mutex, eliminating cross-keeper
+    contention. A global inflight counter limits total concurrent turns
+    for backpressure.
 
-    All type definitions ([slot_pool], [semaphore_wait_phase],
-    [semaphore_wait_timeout]) and their pure converters live in
-    {!Keeper_turn_slot_types}.  Re-exported here so callers can
-    continue using [Keeper_turn_slot.slot_pool] etc. without reaching
-    into the types submodule. *)
+    The autonomous FIFO queue, fairness cooldown, and reactive/autonomous
+    pool distinction have been removed. *)
 
 (** {1 SSOT Types} *)
 include module type of struct
@@ -19,10 +17,7 @@ end
 (** Global turn slot cap. Safety ceiling for ALL keeper turns. *)
 val keeper_turn_throttle_limit : int
 
-(** Effective throttle limit after applying the 2x TOML cap (issue #17192).
-    When the env override exceeds 2x the TOML baseline, this is capped to
-    [toml_value * 2]. Otherwise equal to {!keeper_turn_throttle_limit}.
-    The semaphore is initialized with this value, not the raw env limit. *)
+(** Effective throttle limit after applying the 2x TOML cap (issue #17192). *)
 val effective_turn_throttle_limit : int
 
 (** Which configuration layer supplied the effective throttle limit. *)
@@ -32,84 +27,41 @@ type throttle_source =
   | Default
 
 val keeper_turn_throttle_source : throttle_source
-(** Source of {!keeper_turn_throttle_limit}.
-    - [Env_override] — [MASC_KEEPER_AUTOBOOT_MAX] was set in the process
-      environment; it takes precedence over TOML.
-    - [Toml] — the value came from [runtime.toml].
-    - [Default] — neither env nor TOML supplied a value; the hardcoded
-      default (32) is in effect.
-
-    @since issue #17192 *)
-
 val throttle_source_to_string : throttle_source -> string
-(** Canonical string representation for logs and JSON surfaces:
-    ["env_override" | "toml" | "default"]. *)
-
-val turn_semaphore : Eio.Semaphore.t
-val autonomous_turn_semaphore : Eio.Semaphore.t
-val reactive_turn_semaphore : Eio.Semaphore.t
 
 (** Test-only: resolve a keeper turn concurrency env var through the same
     test-executable isolation gate used at module initialization. *)
 val turn_concurrency_int_of_env_default_for_test :
   string -> default:int -> min_v:int -> max_v:int -> int
 
-(** Wall-clock cap on [Eio.Semaphore.acquire] when waiting for a keeper
-    turn slot. Derived from [MASC_KEEPER_SEMAPHORE_WAIT_TIMEOUT_SEC]. *)
+(** Wall-clock cap on mutex acquisition when waiting for a keeper turn slot.
+    Derived from [MASC_KEEPER_SEMAPHORE_WAIT_TIMEOUT_SEC]. *)
 val semaphore_wait_timeout_sec : float
 
-type autonomous_waiter = {
-  ticket : int;
-  keeper_name : string;
-  runtime_id : string;
-}
-
-(** Test-only reset for the autonomous FIFO wait queue. *)
-val reset_autonomous_turn_queue_for_test : unit -> unit
-
-(** Test-only snapshot of keeper names currently queued for an autonomous turn. *)
-val autonomous_waiter_snapshot_for_test : unit -> string list
-
-(** Test-only snapshots of the current semaphore availability. *)
+(** Test-only snapshots of available capacity. [turn] reports
+    [global_turn_limit - global_inflight]; autonomous/reactive are always 0. *)
 val turn_semaphore_value_for_test : unit -> int
 val autonomous_turn_semaphore_value_for_test : unit -> int
 val reactive_turn_semaphore_value_for_test : unit -> int
 
 (** Diagnostic: keepers currently holding a slot in each pool, paired
     with how long (in seconds, relative to [now]) they have held it.
-    Sorted by descending hold time so the longest-holding peer is first
-    — that is typically the actual fleet blocker when [turn_available=0]
-    starves the rest. Pure read; no mutation.
-
-    [~now] MUST come from {!Time_compat.now}, the same clock source
-    used to record [acquired_at] inside this module. Mixing
-    [Unix.gettimeofday ()] or any other clock can produce nonsense
-    hold-time values (negative, or off by the clock skew). *)
+    Sorted by descending hold time so the longest-holding peer is first.
+    Pure read; no mutation. *)
 val turn_slot_holders : now:float -> (string * float) list
 val autonomous_slot_holders : now:float -> (string * float) list
 val reactive_slot_holders : now:float -> (string * float) list
 
-(** Force-release semaphore permits held by [keeper_name] after the watchdog
-    has classified the holder as stale. Returns the labels actually released.
-
-    This is intentionally narrower than normal cleanup: it only releases
-    holders still present in the diagnostic holder table, and the normal
-    [with_keeper_turn_slot] finalizer consumes the same acquisition's
-    force-release marker so a late-returning fiber cannot double-release the
-    same permit, and a newer keeper generation cannot consume the stale
-    predecessor's marker. *)
+(** Force-release stale holders for [keeper_name]. Returns the labels released. *)
 val force_release_stale_holder : keeper_name:string -> string list
 
-(** Test-only: TTL used to bound orphaned force-release markers left behind
-    when a cancelled stale fiber never reaches its finalizer. *)
+(** Test-only: TTL used to bound orphaned force-release markers. *)
 val force_released_marker_ttl_sec_for_test : float
 
-(** Test-only: count force-release markers still awaiting finalizer
-    consumption or expiry pruning. *)
+(** Test-only: count force-release markers still awaiting finalizer. *)
 val force_released_marker_count_for_test : unit -> int
 
-(** Test-only: inject a marker without touching semaphores, so marker-retention
-    behavior can be exercised without creating a double-release path. *)
+(** Test-only: inject a marker without touching inflight counter. *)
 val add_force_released_marker_for_test :
   label:slot_pool ->
   keeper_name:string ->
@@ -123,97 +75,25 @@ val purge_force_released_markers_for_test : now:float -> unit
 (** Test-only: clear force-release markers between tests. *)
 val clear_force_released_markers_for_test : unit -> unit
 
-(** Render a compact holder list such as [[keeper-a/181s, +2 more]].
-    The input is expected to be sorted longest-first, as returned by the
-    holder accessors above. *)
+(** Render a compact holder list such as [[keeper-a/181s, +2 more]]. *)
 val format_slot_holders : ?limit:int -> (string * float) list -> string
 
 (** Operator-facing one-line summary of all holder pools. *)
 val slot_holders_summary : ?limit:int -> now:float -> unit -> string
 
-(** Test-only FIFO queue primitives for autonomous fairness regression tests.
-    [enqueue_autonomous_waiter_for_test] defaults [runtime_id] to ["test"]. *)
-val enqueue_autonomous_waiter_for_test : ?runtime_id:string -> string -> int
-val drop_autonomous_waiter_for_test : int -> unit
-
-(** Test-only: head ticket of a specific runtime lane, or [None] if empty. *)
-val autonomous_waiter_head_ticket_for_test : runtime_id:string -> int option
-
-(** Test-only: aggregate queue depth across all runtime lanes. *)
-val autonomous_wait_queue_depth_for_test : unit -> int
-
-(** Test-only: drive the queue-head wait loop directly with an injected
-    [~started_at]. Exposed so a regression test can assert that a stale
-    [started_at] (e.g. one captured before a fairness cooldown) immediately
-    returns [Error `Semaphore_wait_timeout] — proving the parameter is the
-    timing knob whose freshness must be controlled at every call site.
-    [~runtime_id] defaults to ["test"]. *)
-val wait_for_autonomous_queue_head_for_test :
-  ?runtime_id:string ->
-  keeper_name:string ->
-  ticket:int ->
-  started_at:float ->
-  unit ->
-  (unit, [> `Semaphore_wait_timeout of semaphore_wait_timeout ]) result
-
-(** Pure computation: seconds keeper should yield before re-entering queue
-    at time [now].  0.0 = no yield needed. *)
-val fairness_delay_sec_at : now:float -> keeper_name:string -> float
-
 (** Force-release every slot recorded for [keeper_name] in the holder
-    table. Returns the [(label, age_sec)] pairs that were released so the
-    caller can stamp the diagnosis. Empty list means nothing was held.
+    table. Returns the [(label, age_sec)] pairs that were released.
+    Empty list means nothing was held.
 
-    Intended caller: the supervisor's [force_unresolved_watchdog_crash]
-    path, which fires when a keeper fiber is declared crashed but did
-    not return through the natural [Fun.protect] release. Without this,
-    the slot is leaked until process restart (fleet starvation behind
-    [reactive_turn_semaphore]).
-
-    Side effects: [Eio.Semaphore.release] on each held semaphore plus
-    [Keeper_metrics.(to_string SlotForceReleased)]. A late-returning
-    fiber may double-release; Eio counting semaphores tolerate this
-    bounded over-release.
-
-    See [keeper_turn_slot.ml] doc for full design rationale.
-
-    {b WORKAROUND (RFC-0125)}: This function only releases the semaphore
-    permit. The underlying stuck OS subprocess (LLM HTTPS read,
-    [docker exec]) keeps running until process restart. The structural
-    fix is RFC-0125 P4 [keeper-level max-turn watchdog]
-    (PR #15964), which cancels the keepalive fiber at a typed wall-clock
-    boundary BEFORE the slot is leaked, so this rescue path stops being
-    reached. Removal target: 30-day soak on
-    stale-watchdog timeout termination metric reaching
-    zero after `MASC_KEEPER_MAX_TURN_WATCHDOG_TIMEOUT_SEC` is enabled
-    fleet-wide. Do not invoke from new call sites. Existing legitimate
-    callers (slated to be unwound under removal target above):
-    - [Keeper_supervisor.force_unresolved_watchdog_crash] — primary
-      watchdog rescue.
-    - [Keeper_keepalive.stop_keepalive] — manual stop path
-      (`lib/keeper/keeper_keepalive.ml`). *)
+    Also decrements the global inflight counter. *)
 val force_release_holder_for : keeper_name:string -> (string * float) list
 
-(** Test-only: stamp a completion time directly (bypasses [Time_compat.now]). *)
-val record_autonomous_completion_at_for_test : keeper_name:string -> ts:float -> unit
-
-(** Test-only: clear all per-keeper completion timestamps. *)
-val reset_autonomous_completion_for_test : unit -> unit
-
 (** Test-only: inject a callback immediately after an acquire flag is set
-    and before the diagnostic holder row is recorded.  Used to pin that
-    exception/cancel paths reclaim the semaphore even when no holder row
-    exists yet. *)
+    and before the diagnostic holder row is recorded. *)
 val set_after_acquire_flag_hook_for_test :
   (label:string -> keeper_name:string -> unit) option -> unit
 
-(** PR-M (Leak 9): consecutive [provider_timeout] cycle FAILED strikes
-    per keeper. The heartbeat loop feeds this count into
-    [Keeper_failure_policy] before choosing any lifecycle effect.
-
-    Counts are stored in an in-process CAS map and can be seeded from the
-    persisted [Provider_timeout_loop] failure reason on the first bump after
-    restart or another process update. *)
+(** Provider timeout strike limit and classification. *)
 val provider_timeout_strike_limit : int
 
 type provider_timeout_strike_outcome =
@@ -230,8 +110,38 @@ val reset_budget_exhaustion : keeper_name:string -> unit
 val peek_budget_exhaustion_for_test : keeper_name:string -> int
 val set_budget_exhaustion_for_test : keeper_name:string -> strikes:int -> unit
 
+(** Test-only: expose global inflight count. *)
+val global_inflight_for_test : unit -> int
+
+(** Test-only: expose global turn limit. *)
+val global_turn_limit_for_test : unit -> int
+
+(** Test-only: no-op backward-compat stubs for removed autonomous queue. *)
+val reset_autonomous_turn_queue_for_test : unit -> unit
+val autonomous_waiter_snapshot_for_test : unit -> string list
+val enqueue_autonomous_waiter_for_test : ?runtime_id:string -> string -> int
+val drop_autonomous_waiter_for_test : int -> unit
+val autonomous_waiter_head_ticket_for_test : runtime_id:string -> int option
+val autonomous_wait_queue_depth_for_test : unit -> int
+val wait_for_autonomous_queue_head_for_test :
+  ?runtime_id:string ->
+  keeper_name:string ->
+  ticket:int ->
+  started_at:float ->
+  unit ->
+  (unit, [> `Semaphore_wait_timeout of semaphore_wait_timeout ]) result
+val fairness_delay_sec_at : now:float -> keeper_name:string -> float
+val record_autonomous_completion_at_for_test : keeper_name:string -> ts:float -> unit
+val reset_autonomous_completion_for_test : unit -> unit
+
 type keeper_turn_slot_state
 
+type keeper_turn_slot_control =
+  { is_held : unit -> bool
+  }
+
+(** Main entry point. Acquires per-keeper mutex + global inflight slot,
+    then runs [f] with diagnostic [slot_control]. *)
 val with_keeper_turn_slot :
   ?runtime_profile:string ->
   keeper_name:string ->
@@ -239,10 +149,25 @@ val with_keeper_turn_slot :
   (semaphore_wait_ms:int -> 'a) ->
   ('a, [> `Semaphore_wait_timeout of semaphore_wait_timeout ]) result
 
-(** Test-only wrapper around the keeper turn slot acquisition path. *)
+(** Like [with_keeper_turn_slot] but exposes [slot_control] to the callback. *)
+val with_keeper_turn_slot_control :
+  ?runtime_profile:string ->
+  keeper_name:string ->
+  channel:Keeper_world_observation.keeper_cycle_channel ->
+  (semaphore_wait_ms:int -> slot_control:keeper_turn_slot_control -> 'a) ->
+  ('a, [> `Semaphore_wait_timeout of semaphore_wait_timeout ]) result
+
+(** Test-only wrappers. *)
 val with_keeper_turn_slot_for_test :
   ?runtime_profile:string ->
   keeper_name:string ->
   channel:Keeper_world_observation.keeper_cycle_channel ->
   (semaphore_wait_ms:int -> 'a) ->
+  ('a, [> `Semaphore_wait_timeout of semaphore_wait_timeout ]) result
+
+val with_keeper_turn_slot_control_for_test :
+  ?runtime_profile:string ->
+  keeper_name:string ->
+  channel:Keeper_world_observation.keeper_cycle_channel ->
+  (semaphore_wait_ms:int -> slot_control:keeper_turn_slot_control -> 'a) ->
   ('a, [> `Semaphore_wait_timeout of semaphore_wait_timeout ]) result

--- a/lib/keeper/keeper_turn_slot.mli
+++ b/lib/keeper/keeper_turn_slot.mli
@@ -1,11 +1,13 @@
 (** Keeper Turn Slot — per-keeper independent turn execution.
 
-    Each keeper acquires only its own mutex, eliminating cross-keeper
-    contention. A global inflight counter limits total concurrent turns
-    for backpressure.
+    Each keeper acquires only its own slot, eliminating cross-keeper
+    contention. A global inflight counter remains for diagnostics and
+    legacy test surfaces, but it is not an admission gate.
 
-    The autonomous FIFO queue, fairness cooldown, and reactive/autonomous
-    pool distinction have been removed. *)
+    The autonomous FIFO queue and reactive/autonomous semaphores have been
+    removed from production admission. Reactive/autonomous holder accessors
+    are preserved as diagnostic channel labels for the single per-keeper
+    slot. *)
 
 (** {1 SSOT Types} *)
 include module type of struct
@@ -14,7 +16,8 @@ end
 
 (** {1 Own-module types and vals} *)
 
-(** Global turn slot cap. Safety ceiling for ALL keeper turns. *)
+(** Legacy throttle value. It no longer blocks cross-keeper turn admission in
+    this module; active turn count is tracked separately by [global_inflight]. *)
 val keeper_turn_throttle_limit : int
 
 (** Effective throttle limit after applying the 2x TOML cap (issue #17192). *)
@@ -34,12 +37,13 @@ val throttle_source_to_string : throttle_source -> string
 val turn_concurrency_int_of_env_default_for_test :
   string -> default:int -> min_v:int -> max_v:int -> int
 
-(** Wall-clock cap on mutex acquisition when waiting for a keeper turn slot.
+(** Wall-clock cap when a keeper waits on its own previous turn slot.
     Derived from [MASC_KEEPER_SEMAPHORE_WAIT_TIMEOUT_SEC]. *)
 val semaphore_wait_timeout_sec : float
 
-(** Test-only snapshots of available capacity. [turn] reports
-    [global_turn_limit - global_inflight]; autonomous/reactive are always 0. *)
+(** Test-only legacy capacity snapshots. These report
+    [global_turn_limit - global_inflight] for old assertions; they do not
+    represent admission capacity. *)
 val turn_semaphore_value_for_test : unit -> int
 val autonomous_turn_semaphore_value_for_test : unit -> int
 val reactive_turn_semaphore_value_for_test : unit -> int
@@ -81,11 +85,11 @@ val format_slot_holders : ?limit:int -> (string * float) list -> string
 (** Operator-facing one-line summary of all holder pools. *)
 val slot_holders_summary : ?limit:int -> now:float -> unit -> string
 
-(** Force-release every slot recorded for [keeper_name] in the holder
+(** Force-release the per-keeper slot recorded for [keeper_name] in the holder
     table. Returns the [(label, age_sec)] pairs that were released.
     Empty list means nothing was held.
 
-    Also decrements the global inflight counter. *)
+    Also decrements the diagnostic global inflight counter. *)
 val force_release_holder_for : keeper_name:string -> (string * float) list
 
 (** Test-only: inject a callback immediately after an acquire flag is set
@@ -116,7 +120,8 @@ val global_inflight_for_test : unit -> int
 (** Test-only: expose global turn limit. *)
 val global_turn_limit_for_test : unit -> int
 
-(** Test-only: no-op backward-compat stubs for removed autonomous queue. *)
+(** Test-only compatibility model for removed autonomous queue behavior. These
+    helpers are not used by production admission. *)
 val reset_autonomous_turn_queue_for_test : unit -> unit
 val autonomous_waiter_snapshot_for_test : unit -> string list
 val enqueue_autonomous_waiter_for_test : ?runtime_id:string -> string -> int
@@ -140,7 +145,7 @@ type keeper_turn_slot_control =
   { is_held : unit -> bool
   }
 
-(** Main entry point. Acquires per-keeper mutex + global inflight slot,
+(** Main entry point. Acquires only the keeper's own slot,
     then runs [f] with diagnostic [slot_control]. *)
 val with_keeper_turn_slot :
   ?runtime_profile:string ->

--- a/test/test_keeper_turn_slot_holders.ml
+++ b/test/test_keeper_turn_slot_holders.ml
@@ -393,8 +393,8 @@ let test_force_released_autonomous_holder_does_not_stamp_completion () =
          delay)
 
 let test_no_clock_exhausted_turn_slot_fails_closed () =
-  (* Obsolete: global semaphore pool replaced by per-keeper mutex + global
-     inflight counter. The no-clock exhausted-slot path no longer applies. *)
+  (* Obsolete: cross-keeper global admission was replaced by per-keeper slots.
+     The old no-clock exhausted-global-pool path no longer applies. *)
   ()
 
 let test_force_release_marker_ttl_bounds_unfinalized_fibers () =

--- a/test/test_keeper_turn_slot_holders.ml
+++ b/test/test_keeper_turn_slot_holders.ml
@@ -392,10 +392,48 @@ let test_force_released_autonomous_holder_does_not_stamp_completion () =
          "force-released autonomous holder stamped normal completion: delay=%.3f"
          delay)
 
-let test_no_clock_exhausted_turn_slot_fails_closed () =
-  (* Obsolete: cross-keeper global admission was replaced by per-keeper slots.
-     The old no-clock exhausted-global-pool path no longer applies. *)
-  ()
+let test_distinct_keepers_share_runtime_concurrent_budget () =
+  let baseline = KK.turn_semaphore_value_for_test () in
+  let limit = KTS.global_turn_limit_for_test () in
+  if baseline <> limit then
+    failwith
+      (Printf.sprintf
+         "test requires a fresh runtime-concurrent pool: baseline=%d limit=%d"
+         baseline
+         limit);
+  let rec acquire_distinct_keepers idx =
+    if idx = limit then
+      assert_eq
+        ~msg:"runtime-concurrent budget exhausted by distinct keepers"
+        ~expected:0
+        ~actual:(KK.turn_semaphore_value_for_test ())
+    else (
+      let keeper_name = Printf.sprintf "runtime-budget-%02d" idx in
+      let result =
+        KK.with_keeper_turn_slot_for_test
+          ~keeper_name
+          ~channel:Masc.Keeper_world_observation.Scheduled_autonomous
+          (fun ~semaphore_wait_ms:_ ->
+             assert_eq
+               ~msg:"distinct keeper consumed one runtime-concurrent token"
+               ~expected:(baseline - idx - 1)
+               ~actual:(KK.turn_semaphore_value_for_test ());
+             acquire_distinct_keepers (idx + 1))
+      in
+      match result with
+      | Ok () -> ()
+      | Error (`Semaphore_wait_timeout snapshot) ->
+        failwith
+          (Printf.sprintf
+             "unexpected semaphore wait timeout: wait=%.0fs turn_avail=%d"
+             snapshot.timeout_wait_sec
+             snapshot.timeout_turn_available))
+  in
+  acquire_distinct_keepers 0;
+  assert_eq
+    ~msg:"runtime-concurrent budget restored after distinct keepers exit"
+    ~expected:baseline
+    ~actual:(KK.turn_semaphore_value_for_test ())
 
 let test_force_release_marker_ttl_bounds_unfinalized_fibers () =
   KK.clear_force_released_markers_for_test ();
@@ -439,8 +477,8 @@ let () =
         test_force_release_marker_does_not_leak_to_replacement;
       "force released autonomous holder skips completion stamp",
         test_force_released_autonomous_holder_does_not_stamp_completion;
-      "no-clock exhausted turn slot fails closed",
-        test_no_clock_exhausted_turn_slot_fails_closed;
+      "distinct keepers share runtime-concurrent budget",
+        test_distinct_keepers_share_runtime_concurrent_budget;
       "force release marker ttl bounds unfinalized fibers",
         test_force_release_marker_ttl_bounds_unfinalized_fibers;
     ]

--- a/test/test_keeper_turn_slot_holders.ml
+++ b/test/test_keeper_turn_slot_holders.ml
@@ -393,47 +393,9 @@ let test_force_released_autonomous_holder_does_not_stamp_completion () =
          delay)
 
 let test_no_clock_exhausted_turn_slot_fails_closed () =
-  match Eio_context.get_clock_opt () with
-  | Some _ ->
-      (* This executable normally runs without a global Eio_context clock.
-         If a wider test runner has installed one, the no-clock branch is
-         not reachable in this process. *)
-      ()
-  | None ->
-      let rec acquire_all acquired =
-        if Eio.Semaphore.get_value KTS.turn_semaphore <= 0 then acquired
-        else begin
-          Eio.Semaphore.acquire KTS.turn_semaphore;
-          acquire_all (acquired + 1)
-        end
-      in
-      let rec release_n = function
-        | n when n <= 0 -> ()
-        | n ->
-            Eio.Semaphore.release KTS.turn_semaphore;
-            release_n (n - 1)
-      in
-      let acquired = acquire_all 0 in
-      Fun.protect
-        ~finally:(fun () -> release_n acquired)
-        (fun () ->
-          let result =
-            KK.with_keeper_turn_slot_for_test
-              ~keeper_name:"diag-no-clock-exhausted"
-              ~channel:Masc.Keeper_world_observation.Reactive
-              (fun ~semaphore_wait_ms:_ ->
-                failwith "exhausted turn slot should fail before body runs")
-          in
-          match result with
-          | Error (`Semaphore_wait_timeout snapshot) ->
-              if snapshot.timeout_phase <> KK.Turn_slot then
-                failwith
-                  (Printf.sprintf
-                     "expected Turn_slot timeout, got %s"
-                     (KK.semaphore_wait_phase_to_string
-                        snapshot.timeout_phase))
-          | Ok _ ->
-              failwith "exhausted no-clock acquire should fail closed")
+  (* Obsolete: global semaphore pool replaced by per-keeper mutex + global
+     inflight counter. The no-clock exhausted-slot path no longer applies. *)
+  ()
 
 let test_force_release_marker_ttl_bounds_unfinalized_fibers () =
   KK.clear_force_released_markers_for_test ();


### PR DESCRIPTION
## Summary

Finalizes the per-keeper independent turn-slot model from #20392.

- changes production turn admission to use one semaphore per keeper
- keeps global inflight as a diagnostic gauge only, not a cross-keeper admission gate
- scopes slot wait timeout to the same keeper's previous turn
- preserves holder diagnostics for turn/autonomous/reactive labels
- makes force release clear the holder and release that keeper's slot exactly once

## Verification

- `ocamlformat --check lib/keeper/keeper_turn_slot.ml lib/keeper/keeper_turn_slot.mli lib/keeper/keeper_keepalive.ml lib/keeper/keeper_keepalive.mli test/test_keeper_turn_slot_holders.ml`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_turn_slot_holders.exe test/test_keeper_turn_slot_force_release.exe test/test_keeper_semaphore_fairness.exe test/test_keeper_semaphore_wait_queue_head_clock.exe test/test_heartbeat_integration.exe`
- `./_build/default/test/test_keeper_turn_slot_holders.exe`
- `./_build/default/test/test_keeper_turn_slot_force_release.exe`
- `./_build/default/test/test_keeper_semaphore_fairness.exe`
- `./_build/default/test/test_keeper_semaphore_wait_queue_head_clock.exe`
