### PR TITLE
fix(keeper): serialize keeper turns before runtime budget

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop_semaphore_timeout.ml
+++ b/lib/keeper/keeper_heartbeat_loop_semaphore_timeout.ml
@@ -22,7 +22,9 @@ let semaphore_wait_timeout_blocker_class
   match timeout.timeout_phase with
   | Keeper_turn_slot.Autonomous_queue_head -> Keeper_meta_contract.Admission_queue_wait_timeout
   | Keeper_turn_slot.Autonomous_slot -> Keeper_meta_contract.Autonomous_slot_wait_timeout
-  | Keeper_turn_slot.Reactive_slot | Keeper_turn_slot.Turn_slot ->
+  | Keeper_turn_slot.Reactive_slot
+  | Keeper_turn_slot.Keeper_lane_slot
+  | Keeper_turn_slot.Turn_slot ->
     Keeper_meta_contract.Turn_timeout_after_queue_wait
 ;;
 
@@ -70,6 +72,7 @@ let semaphore_wait_timeout_diagnostics
         timeout.timeout_queue_depth
     | Keeper_turn_slot.Autonomous_slot
     | Keeper_turn_slot.Reactive_slot
+    | Keeper_turn_slot.Keeper_lane_slot
     | Keeper_turn_slot.Turn_slot ->
       let holder_text =
         match timeout.timeout_holders with

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -74,6 +74,7 @@ type semaphore_wait_phase =
   | Autonomous_queue_head
   | Autonomous_slot
   | Reactive_slot
+  | Keeper_lane_slot
   | Turn_slot
 
 val semaphore_wait_phase_to_string : semaphore_wait_phase -> string

--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -5,8 +5,11 @@ open Keeper_types
 open Keeper_meta_contract
 open Keeper_types_profile
 
-(** The three semaphore pools that gate keeper turn admission. Closed sum type: adding a new pool requires updating every match site, which the compiler enforces exhaustively. *)
+(** Semaphore pools that gate keeper turn admission. Closed sum type:
+    adding a new pool requires updating every match site, which the compiler
+    enforces exhaustively. *)
 type slot_pool = Keeper_turn_slot_types.slot_pool =
+  | Keeper_pool
   | Turn_pool
   | Autonomous_pool
   | Reactive_pool
@@ -19,6 +22,7 @@ type semaphore_wait_phase = Keeper_turn_slot_types.semaphore_wait_phase =
   | Autonomous_queue_head
   | Autonomous_slot
   | Reactive_slot
+  | Keeper_lane_slot
   | Turn_slot
 
 let semaphore_wait_phase_to_string =
@@ -313,6 +317,29 @@ let reactive_turn_semaphore_value_for_test () =
 let turn_slot_holders ~now = snapshot_holders ~label:Turn_pool ~now
 let autonomous_slot_holders ~now = snapshot_holders ~label:Autonomous_pool ~now
 let reactive_slot_holders ~now = snapshot_holders ~label:Reactive_pool ~now
+
+let keeper_lane_label = slot_pool_to_string Keeper_pool
+
+let keeper_lane_semaphores : (string, Eio.Semaphore.t) Hashtbl.t =
+  Hashtbl.create 32
+
+let keeper_lane_mutex = Eio.Mutex.create ()
+let with_keeper_lane_lock f = Eio.Mutex.use_rw ~protect:true keeper_lane_mutex f
+
+let get_or_create_keeper_lane_semaphore ~keeper_name =
+  with_keeper_lane_lock (fun () ->
+    match Hashtbl.find_opt keeper_lane_semaphores keeper_name with
+    | Some sem -> sem
+    | None ->
+      let sem = Eio.Semaphore.make 1 in
+      Hashtbl.add keeper_lane_semaphores keeper_name sem;
+      sem)
+;;
+
+let find_keeper_lane_semaphore ~keeper_name =
+  with_keeper_lane_lock (fun () -> Hashtbl.find_opt keeper_lane_semaphores keeper_name)
+;;
+
 let force_release_stale_holder ~keeper_name =
   let released = ref [] in
   let release_if_held ~label sem =
@@ -322,6 +349,17 @@ let force_release_stale_holder ~keeper_name =
       released := slot_pool_to_string label :: !released
     done
   in
+  let release_keeper_lane_if_held () =
+    let release_count = mark_holder_force_released ~label:Keeper_pool ~keeper_name in
+    if release_count > 0
+    then (
+      let sem = get_or_create_keeper_lane_semaphore ~keeper_name in
+      for _ = 1 to release_count do
+        Eio.Semaphore.release sem;
+        released := slot_pool_to_string Keeper_pool :: !released
+      done)
+  in
+  release_keeper_lane_if_held ();
   release_if_held ~label:Turn_pool turn_semaphore;
   release_if_held ~label:Autonomous_pool autonomous_turn_semaphore;
   release_if_held ~label:Reactive_pool reactive_turn_semaphore;
@@ -358,6 +396,7 @@ let snapshot_all_holders ~now =
     (fun key ts (turn, auto, reactive) ->
        let held = now -. ts in
        match key.holder_label with
+       | Keeper_pool -> turn, auto, reactive
        | Turn_pool -> (key.holder_keeper_name, held) :: turn, auto, reactive
        | Autonomous_pool -> turn, (key.holder_keeper_name, held) :: auto, reactive
        | Reactive_pool -> turn, auto, (key.holder_keeper_name, held) :: reactive)
@@ -584,22 +623,28 @@ let record_autonomous_completion ~(keeper_name : string) : unit =
     Hashtbl.replace last_autonomous_completion keeper_name (Time_compat.now ()))
 ;;
 type keeper_turn_slot_state =
-  { acquired_autonomous : bool ref
+  { acquired_keeper_lane : bool ref
+  ; acquired_autonomous : bool ref
   ; acquired_reactive : bool ref
   ; acquired_turn : bool ref
+  ; keeper_lane_acquisition_id : int option ref
   ; autonomous_acquisition_id : int option ref
   ; reactive_acquisition_id : int option ref
   ; turn_acquisition_id : int option ref
+  ; keeper_lane_semaphore : Eio.Semaphore.t option ref
   ; autonomous_ticket : int option ref
   }
 
 let make_keeper_turn_slot_state () =
-  { acquired_autonomous = ref false
+  { acquired_keeper_lane = ref false
+  ; acquired_autonomous = ref false
   ; acquired_reactive = ref false
   ; acquired_turn = ref false
+  ; keeper_lane_acquisition_id = ref None
   ; autonomous_acquisition_id = ref None
   ; reactive_acquisition_id = ref None
   ; turn_acquisition_id = ref None
+  ; keeper_lane_semaphore = ref None
   ; autonomous_ticket = ref None
   }
 ;;
@@ -722,7 +767,24 @@ let release_keeper_turn_slot_impl ~keeper_name ~(stamp_autonomous_completion : b
       ~acquisition_id:!(state.reactive_acquisition_id)
       reactive_turn_semaphore;
     state.acquired_reactive := false;
-    state.reactive_acquisition_id := None)
+    state.reactive_acquisition_id := None);
+  if !(state.acquired_keeper_lane)
+  then (
+    (match !(state.keeper_lane_semaphore) with
+     | None ->
+       Log.Keeper.warn
+         "release_keeper_turn_slot: %s holder for %s missing semaphore"
+         keeper_lane_label
+         keeper_name
+     | Some sem ->
+       release_recorded_holder
+         ~keeper_name
+         ~label:Keeper_pool
+         ~acquisition_id:!(state.keeper_lane_acquisition_id)
+         sem);
+    state.acquired_keeper_lane := false;
+    state.keeper_lane_acquisition_id := None;
+    state.keeper_lane_semaphore := None)
 ;;
 
 let release_keeper_turn_slot ~keeper_name state =
@@ -807,6 +869,9 @@ let force_release_holder_for ~keeper_name : (string * float) list =
            age)
       snapshots
   in
+  Option.iter
+    (fun sem -> try_release ~label:Keeper_pool ~sem)
+    (find_keeper_lane_semaphore ~keeper_name);
   try_release ~label:Reactive_pool ~sem:reactive_turn_semaphore;
   try_release ~label:Autonomous_pool ~sem:autonomous_turn_semaphore;
   try_release ~label:Turn_pool ~sem:turn_semaphore;
@@ -1142,6 +1207,57 @@ let with_keeper_turn_slot ?(runtime_profile = "unknown") ~keeper_name ~channel f
         Error
           (`Semaphore_wait_timeout (semaphore_wait_timeout_snapshot ~phase ~holders ())))
   in
+  let acquire_keeper_lane_bounded () =
+    let sem = get_or_create_keeper_lane_semaphore ~keeper_name in
+    slot_state.keeper_lane_semaphore := Some sem;
+    let timeout_snapshot () =
+      let holders = snapshot_holders ~label:Keeper_pool ~now:(Time_compat.now ()) in
+      `Semaphore_wait_timeout
+        (semaphore_wait_timeout_snapshot ~phase:Keeper_lane_slot ~holders ())
+    in
+    match Eio_context.get_clock_opt () with
+    | Some clock ->
+      (try
+         Eio.Time.with_timeout_exn clock semaphore_wait_timeout_sec (fun () ->
+           Eio.Semaphore.acquire sem);
+         Ok ()
+       with
+       | Eio.Time.Timeout ->
+         let holders = snapshot_holders ~label:Keeper_pool ~now:(Time_compat.now ()) in
+         let holder_summary = format_slot_holders holders in
+         Log.Keeper.routine
+           "semaphore_wait: %s wait exceeded %.0fs (keeper=%s channel=%s holders=%s), \
+            skipping turn"
+           keeper_lane_label
+           semaphore_wait_timeout_sec
+           keeper_name
+           channel_label
+           holder_summary;
+         Otel_metric_store.inc_counter
+           Keeper_metrics.(to_string SemaphoreWaitTimeout)
+           ~labels:[ "keeper", keeper_name; "channel", keeper_lane_label ]
+           ();
+         Error (timeout_snapshot ()))
+    | None ->
+      if Eio.Semaphore.get_value sem > 0
+      then (
+        Log.Keeper.warn
+          "semaphore_wait: no Eio clock available — %s acquire is immediate only \
+           (environment drift?)"
+          keeper_lane_label;
+        Eio.Semaphore.acquire sem;
+        Ok ())
+      else (
+        Log.Keeper.warn
+          "semaphore_wait: no Eio clock available and %s has no permits; failing \
+           closed instead of waiting unboundedly"
+          keeper_lane_label;
+        Otel_metric_store.inc_counter
+          Keeper_metrics.(to_string SemaphoreWaitTimeout)
+          ~labels:[ "keeper", keeper_name; "channel", keeper_lane_label ]
+          ();
+        Error (timeout_snapshot ()))
+  in
   let log_acquire_attempt () =
     let queue_depth = autonomous_wait_queue_depth () in
     Log.Keeper.routine
@@ -1160,7 +1276,25 @@ let with_keeper_turn_slot ?(runtime_profile = "unknown") ~keeper_name ~channel f
   let acquire_all () =
     let t0 = Time_compat.now () in
     log_acquire_attempt ();
+    let keeper_lane_result =
+      match acquire_keeper_lane_bounded () with
+      | Error _ as e -> e
+      | Ok () ->
+        slot_state.acquired_keeper_lane := true;
+        run_after_acquire_flag_hook_for_test ~label:keeper_lane_label ~keeper_name;
+        let acquisition_id =
+          record_holder
+            ~label:Keeper_pool
+            ~keeper_name
+            ~acquired_at:(Time_compat.now ())
+        in
+        slot_state.keeper_lane_acquisition_id := Some acquisition_id;
+        Ok ()
+    in
     let autonomous_result =
+      match keeper_lane_result with
+      | Error _ as e -> e
+      | Ok () ->
       if is_autonomous
       then (
         (* Fairness cooldown: if this keeper recently completed a turn and

--- a/lib/keeper_contract/keeper_turn_slot_types.ml
+++ b/lib/keeper_contract/keeper_turn_slot_types.ml
@@ -11,11 +11,13 @@
     patterns continue to match. *)
 
 type slot_pool =
+  | Keeper_pool
   | Turn_pool
   | Autonomous_pool
   | Reactive_pool
 
 let slot_pool_to_string = function
+  | Keeper_pool -> "keeper_lane"
   | Turn_pool -> "turn"
   | Autonomous_pool -> "autonomous"
   | Reactive_pool -> "reactive"
@@ -27,12 +29,14 @@ type semaphore_wait_phase =
   | Autonomous_queue_head
   | Autonomous_slot
   | Reactive_slot
+  | Keeper_lane_slot
   | Turn_slot
 
 let semaphore_wait_phase_to_string = function
   | Autonomous_queue_head -> "autonomous_queue_head"
   | Autonomous_slot -> "autonomous_slot"
   | Reactive_slot -> "reactive_slot"
+  | Keeper_lane_slot -> "keeper_lane_slot"
   | Turn_slot -> "turn_slot"
 ;;
 

--- a/lib/keeper_contract/keeper_turn_slot_types.mli
+++ b/lib/keeper_contract/keeper_turn_slot_types.mli
@@ -1,6 +1,7 @@
 (** Slot/pool/phase variants + wait-timeout payload for keeper turn slots. *)
 
 type slot_pool =
+  | Keeper_pool
   | Turn_pool
   | Autonomous_pool
   | Reactive_pool
@@ -13,6 +14,7 @@ type semaphore_wait_phase =
   | Autonomous_queue_head
   | Autonomous_slot
   | Reactive_slot
+  | Keeper_lane_slot
   | Turn_slot
 
 val semaphore_wait_phase_to_string : semaphore_wait_phase -> string

--- a/test/test_keeper_turn_slot_holders.ml
+++ b/test/test_keeper_turn_slot_holders.ml
@@ -13,13 +13,26 @@ module KTS = Masc.Keeper_turn_slot
 
 exception After_flag_injected
 
+let current_test_clock = ref None
+let current_test_net = ref None
+let current_test_mono_clock = ref None
+
 let with_fresh_state body () =
-  Eio_main.run @@ fun _env ->
-    KK.set_after_acquire_flag_hook_for_test None;
-    KK.clear_force_released_markers_for_test ();
-    KK.reset_autonomous_completion_for_test ();
-    KK.reset_autonomous_turn_queue_for_test ();
-    body ()
+  Eio_main.run @@ fun env ->
+    current_test_clock := Some (Eio.Stdenv.clock env);
+    current_test_net := Some (Eio.Stdenv.net env);
+    current_test_mono_clock := Some (Eio.Stdenv.mono_clock env);
+    Fun.protect
+      ~finally:(fun () ->
+        current_test_clock := None;
+        current_test_net := None;
+        current_test_mono_clock := None)
+      (fun () ->
+        KK.set_after_acquire_flag_hook_for_test None;
+        KK.clear_force_released_markers_for_test ();
+        KK.reset_autonomous_completion_for_test ();
+        KK.reset_autonomous_turn_queue_for_test ();
+        body ())
 
 let assert_eq ~msg ~expected ~actual =
   if expected <> actual then
@@ -435,6 +448,129 @@ let test_no_clock_exhausted_turn_slot_fails_closed () =
           | Ok _ ->
               failwith "exhausted no-clock acquire should fail closed")
 
+let eio_clock_or_fail () =
+  match !current_test_clock with
+  | Some clock -> clock
+  | None -> failwith "expected Eio clock in keeper turn-slot concurrency test"
+
+let with_current_test_eio_context f =
+  match !current_test_net, !current_test_clock, !current_test_mono_clock with
+  | Some net, Some clock, Some mono_clock ->
+    Eio.Switch.run @@ fun sw ->
+    Eio_context.with_test_env ~net ~clock ~mono_clock ~sw f
+  | _ -> failwith "expected Eio env in keeper turn-slot concurrency test"
+
+let await_with_timeout ~clock ~seconds promise ~msg =
+  try Eio.Time.with_timeout_exn clock seconds (fun () -> Eio.Promise.await promise)
+  with Eio.Time.Timeout -> failwith msg
+
+let test_same_keeper_lane_serializes_turns () =
+  with_current_test_eio_context @@ fun () ->
+  let clock = eio_clock_or_fail () in
+  Eio.Switch.run @@ fun sw ->
+  let first_entered, notify_first_entered = Eio.Promise.create () in
+  let release_first, notify_release_first = Eio.Promise.create () in
+  let second_entered, notify_second_entered = Eio.Promise.create () in
+  let second_done, notify_second_done = Eio.Promise.create () in
+  let keeper_name = "diag-same-keeper-lane" in
+  Eio.Fiber.fork ~sw (fun () ->
+    match
+      KK.with_keeper_turn_slot_for_test
+        ~keeper_name
+        ~channel:Masc.Keeper_world_observation.Reactive
+        (fun ~semaphore_wait_ms:_ ->
+          Eio.Promise.resolve notify_first_entered ();
+          Eio.Promise.await release_first)
+    with
+    | Ok () -> ()
+    | Error (`Semaphore_wait_timeout _) ->
+        failwith "first same-keeper lane turn timed out");
+  await_with_timeout
+    ~clock
+    ~seconds:1.0
+    first_entered
+    ~msg:"first same-keeper lane turn did not enter";
+  Eio.Fiber.fork ~sw (fun () ->
+    match
+      KK.with_keeper_turn_slot_for_test
+        ~keeper_name
+        ~channel:Masc.Keeper_world_observation.Reactive
+        (fun ~semaphore_wait_ms:_ ->
+          Eio.Promise.resolve notify_second_entered ())
+    with
+    | Ok () -> Eio.Promise.resolve notify_second_done ()
+    | Error (`Semaphore_wait_timeout _) ->
+        failwith "second same-keeper lane turn timed out");
+  Eio.Time.sleep clock 0.05;
+  (match Eio.Promise.peek second_entered with
+   | Some () -> failwith "same keeper re-entered before its lane was released"
+   | None -> ());
+  Eio.Promise.resolve notify_release_first ();
+  await_with_timeout
+    ~clock
+    ~seconds:1.0
+    second_entered
+    ~msg:"second same-keeper lane turn did not enter after release";
+  await_with_timeout
+    ~clock
+    ~seconds:1.0
+    second_done
+    ~msg:"second same-keeper lane turn did not finish"
+
+let test_distinct_keeper_lanes_share_runtime_concurrent_budget () =
+  with_current_test_eio_context @@ fun () ->
+  let clock = eio_clock_or_fail () in
+  Eio.Switch.run @@ fun sw ->
+  let first_entered, notify_first_entered = Eio.Promise.create () in
+  let release_first, notify_release_first = Eio.Promise.create () in
+  let first_done, notify_first_done = Eio.Promise.create () in
+  let second_entered, notify_second_entered = Eio.Promise.create () in
+  let second_done, notify_second_done = Eio.Promise.create () in
+  Eio.Fiber.fork ~sw (fun () ->
+    match
+      KK.with_keeper_turn_slot_for_test
+        ~keeper_name:"diag-lane-a"
+        ~channel:Masc.Keeper_world_observation.Reactive
+        (fun ~semaphore_wait_ms:_ ->
+          Eio.Promise.resolve notify_first_entered ();
+          Eio.Promise.await release_first)
+    with
+    | Ok () -> Eio.Promise.resolve notify_first_done ()
+    | Error (`Semaphore_wait_timeout _) ->
+        failwith "first distinct-keeper lane turn timed out");
+  await_with_timeout
+    ~clock
+    ~seconds:1.0
+    first_entered
+    ~msg:"first distinct-keeper lane turn did not enter";
+  Eio.Fiber.fork ~sw (fun () ->
+    match
+      KK.with_keeper_turn_slot_for_test
+        ~keeper_name:"diag-lane-b"
+        ~channel:Masc.Keeper_world_observation.Reactive
+        (fun ~semaphore_wait_ms:_ ->
+          Eio.Promise.resolve notify_second_entered ())
+    with
+    | Ok () -> Eio.Promise.resolve notify_second_done ()
+    | Error (`Semaphore_wait_timeout _) ->
+        failwith "second distinct-keeper lane turn timed out");
+  await_with_timeout
+    ~clock
+    ~seconds:1.0
+    second_entered
+    ~msg:"distinct keeper did not enter while another keeper held its own lane";
+  await_with_timeout
+    ~clock
+    ~seconds:1.0
+    second_done
+    ~msg:"second distinct-keeper lane turn did not finish";
+  Eio.Promise.resolve notify_release_first ();
+  await_with_timeout
+    ~clock
+    ~seconds:1.0
+    first_done
+    ~msg:"first distinct-keeper lane turn did not finish"
+
 let test_force_release_marker_ttl_bounds_unfinalized_fibers () =
   KK.clear_force_released_markers_for_test ();
   let marked_at = 1_000.0 in
@@ -479,6 +615,10 @@ let () =
         test_force_released_autonomous_holder_does_not_stamp_completion;
       "no-clock exhausted turn slot fails closed",
         test_no_clock_exhausted_turn_slot_fails_closed;
+      "same keeper lane serializes turns",
+        test_same_keeper_lane_serializes_turns;
+      "distinct keeper lanes share runtime concurrent budget",
+        test_distinct_keeper_lanes_share_runtime_concurrent_budget;
       "force release marker ttl bounds unfinalized fibers",
         test_force_release_marker_ttl_bounds_unfinalized_fibers;
     ]


### PR DESCRIPTION
## Summary
- add a per-keeper admission lane before the existing global turn semaphore
- keep the existing runtime concurrent budget (turn_semaphore) as the shared fleet budget
- route keeper-lane timeout and force-release through the existing holder marker machinery

## Verification
- scripts/dune-local.sh build test/test_keeper_turn_slot_holders.exe test/test_keeper_turn_slot_force_release.exe test/test_keeper_turn_slot_lane_isolation.exe test/test_keeper_semaphore_fairness.exe test/test_keeper_semaphore_wait_queue_head_clock.exe
- _build/default/test/test_keeper_turn_slot_holders.exe
- _build/default/test/test_keeper_turn_slot_force_release.exe
- _build/default/test/test_keeper_turn_slot_lane_isolation.exe
- _build/default/test/test_keeper_semaphore_fairness.exe
- _build/default/test/test_keeper_semaphore_wait_queue_head_clock.exe