### PR TITLE
fix(keeper): purge worktree reuse progress policy

### DIFF
--- a/lib/keeper/keeper_tool_progress.ml
+++ b/lib/keeper/keeper_tool_progress.ml
@@ -197,14 +197,7 @@ let result_text_for_progress_check output_text =
   | Tool_output.Inline value -> value
 ;;
 
-let tool_result_has_material_progress ~(tool_name : string) ~(output_text : string)
-  : bool
-  =
-  let tool_name = Keeper_tool_resolution.canonical_tool_name tool_name in
+let tool_result_has_material_progress ~tool_name:_ ~(output_text : string) : bool =
   let output_text = result_text_for_progress_check output_text |> String.trim in
-  let idempotent_worktree_noop =
-    String.equal tool_name "tool_execute"
-    && String.starts_with ~prefix:"Worktree already exists:" output_text
-  in
-  (not (String.equal output_text "")) && not idempotent_worktree_noop
+  not (String.equal output_text "")
 ;;

--- a/test/test_keeper_unified_claim_progress.ml
+++ b/test/test_keeper_unified_claim_progress.ml
@@ -127,6 +127,25 @@ let test_contract_progress_filters_no_progress_tool_results () =
          ])
 ;;
 
+let test_material_progress_does_not_special_case_worktree_reuse_text () =
+  check
+    bool
+    "empty output has no material progress"
+    false
+    (KTP.tool_result_has_material_progress
+       ~tool_name:"tool_execute"
+       ~output_text:"");
+  check
+    bool
+    "worktree reuse text is just tool output"
+    true
+    (KTP.tool_result_has_material_progress
+       ~tool_name:"tool_execute"
+       ~output_text:
+         "Worktree already exists: /tmp/repo/.worktrees/task\n\
+          Branch already checked out: feature/task\n")
+;;
+
 let () =
   run
     "keeper_unified_claim_progress"
@@ -151,6 +170,10 @@ let () =
             "contract progress filters no-progress tool results"
             `Quick
             test_contract_progress_filters_no_progress_tool_results
+        ; test_case
+            "material progress does not special-case worktree reuse text"
+            `Quick
+            test_material_progress_does_not_special_case_worktree_reuse_text
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- Remove the string-based `Worktree already exists:` no-op exception from keeper material-progress detection.
- Treat worktree reuse text as ordinary tool output instead of keeper policy.
- Add a regression test that branch/worktree reuse diagnostics remain tool-result text, not a progress-policy decision.

## Tests
- `ocamlformat --enable-outside-detected-project --check lib/keeper/keeper_tool_progress.ml test/test_keeper_unified_claim_progress.ml`
- `git diff --check`
- `scripts/dune-local.sh build test/test_keeper_unified_claim_progress.exe`
- `./_build/default/test/test_keeper_unified_claim_progress.exe`