### PR TITLE
fix(ide): surface bridge events in dashboard

### DIFF
--- a/dashboard/src/api/execute-output.test.ts
+++ b/dashboard/src/api/execute-output.test.ts
@@ -14,6 +14,24 @@ describe('Execute output SSE parsing', () => {
     })
   })
 
+  it('parses structured line frames', () => {
+    const event = parseExecuteOutputSseFrame(
+      'event: output\ndata: {"type":"line","kind":"line","keeper_id":"sangsu","keeper":"sangsu","line":{"ts_ms":1000,"stream":"stdout","text":"ok","ansi":false}}',
+    )
+
+    expect(event).toMatchObject({
+      type: 'line',
+      keeper: 'sangsu',
+      keeper_id: 'sangsu',
+      line: {
+        ts_ms: 1000,
+        stream: 'stdout',
+        text: 'ok',
+        ansi: false,
+      },
+    })
+  })
+
   it('ignores malformed frames', () => {
     expect(parseExecuteOutputSseFrame('event: output\ndata: {')).toBeNull()
   })

--- a/dashboard/src/api/execute-output.ts
+++ b/dashboard/src/api/execute-output.ts
@@ -1,10 +1,21 @@
 import { authHeaders } from './core'
 
+export interface ExecuteOutputLine {
+  ts_ms?: number
+  stream: 'stdout' | 'stderr' | 'cmd' | 'system' | string
+  text: string
+  ansi?: boolean
+}
+
 export interface ExecuteOutputStreamEvent {
   type: 'snapshot' | 'no_task' | 'error' | string
+  kind?: string
   keeper: string
+  keeper_id?: string
   task_id?: string | null
   task_count?: number
+  lines?: ExecuteOutputLine[]
+  line?: ExecuteOutputLine
   since_stdout?: number
   since_stderr?: number
   stdout_since?: string

--- a/dashboard/src/api/ide.test.ts
+++ b/dashboard/src/api/ide.test.ts
@@ -3,6 +3,8 @@ import {
   createIdeAnnotation,
   deleteIdeAnnotation,
   fetchIdeAnnotations,
+  fetchIdeCursors,
+  fetchIdeEvents,
   fetchIdeRegions,
 } from './ide'
 
@@ -103,5 +105,90 @@ describe('ide API', () => {
     expect(url).toContain('/api/v1/ide/annotations/ann-1?')
     expect(url).toContain('keeper_id=sangsu')
     expect(url).toContain('repo_id=masc')
+  })
+
+  it('fetchIdeEvents appends event filters and parses bridge events', async () => {
+    stubFetch({
+      ok: true,
+      data: {
+        events: [{
+          type: 'tool',
+          tool_name: 'execute',
+          keeper_id: 'sangsu',
+          turn_id: 'turn-1',
+          outcome: 'success',
+          typed_outcome: 'progress',
+          latency_ms: 50,
+          summary: 'ran command',
+          file_path: 'lib/a.ml',
+          command_descriptor: null,
+          timestamp_ms: '1717400000000',
+        }],
+      },
+    })
+
+    const events = await fetchIdeEvents({
+      kind: 'tool',
+      keeperId: 'sangsu',
+      repoId: 'masc',
+      limit: 25,
+    })
+
+    const url = String(mockFetch.mock.calls[0]![0])
+    expect(url).toContain('/api/v1/ide/events?')
+    expect(url).toContain('kind=tool')
+    expect(url).toContain('keeper_id=sangsu')
+    expect(url).toContain('repo_id=masc')
+    expect(url).toContain('limit=25')
+    expect(events).toEqual([expect.objectContaining({
+      type: 'tool',
+      tool_name: 'execute',
+      keeper_id: 'sangsu',
+      turn_id: 'turn-1',
+      timestamp_ms: 1717400000000,
+    })])
+  })
+
+  it('fetchIdeCursors appends cursor filters and parses valid cursor rows', async () => {
+    stubFetch({
+      ok: true,
+      data: {
+        runtime_id: 'masc-runtime',
+        branch: 'main',
+        connected: true,
+        cursors: [{
+          keeper_id: 'sangsu',
+          file_path: 'lib/a.ml',
+          line: 12,
+          column: 3,
+          selection_end: { line: 14, column: 3 },
+          focus_mode: 'editing',
+          last_update: '1717400000000',
+          tool_name: 'keeper_ide_annotate',
+          turn: 7,
+        }],
+      },
+    })
+
+    const snapshot = await fetchIdeCursors({
+      keeperId: 'sangsu',
+      filePath: 'lib/a.ml',
+      repoId: 'masc',
+      limit: 10,
+    })
+
+    const url = String(mockFetch.mock.calls[0]![0])
+    expect(url).toContain('/api/v1/ide/cursors?')
+    expect(url).toContain('keeper_id=sangsu')
+    expect(url).toContain('file_path=lib%2Fa.ml')
+    expect(url).toContain('repo_id=masc')
+    expect(url).toContain('limit=10')
+    expect(snapshot?.cursors).toEqual([expect.objectContaining({
+      keeper_id: 'sangsu',
+      file_path: 'lib/a.ml',
+      line: 12,
+      focus_mode: 'editing',
+      turn: 7,
+    })])
   })
 })

--- a/dashboard/src/api/ide.ts
+++ b/dashboard/src/api/ide.ts
@@ -6,6 +6,7 @@ import {
   type IdeCodeRegion,
   type AnnotationKind,
 } from './schemas/ide-annotations'
+import { isRecord } from '../lib/type-guards'
 
 export type { IdeAnnotation, IdeCodeRegion, AnnotationKind } from './schemas/ide-annotations'
 
@@ -13,6 +14,84 @@ export interface IdeApiOptions extends GetOptions {
   readonly keeper?: string
   readonly repoId?: string | null
 }
+
+export type IdeEventKind = 'tool' | 'turn' | 'pr'
+
+export interface IdeEventsOptions extends IdeApiOptions {
+  readonly kind?: IdeEventKind | 'all'
+  readonly keeperId?: string
+  readonly limit?: number
+  readonly offset?: number
+}
+
+export type IdeCursorFocusMode = 'reading' | 'editing' | 'reviewing' | 'planning'
+
+export interface IdeCursorEntry {
+  readonly keeper_id: string
+  readonly file_path: string
+  readonly line: number
+  readonly column: number
+  readonly selection_end?: { readonly line: number; readonly column: number }
+  readonly focus_mode: IdeCursorFocusMode
+  readonly last_update: number
+  readonly tool_name?: string
+  readonly turn?: number
+  readonly turn_id?: string
+}
+
+export interface IdeCursorSnapshot {
+  readonly runtime_id: string
+  readonly branch?: string
+  readonly connected: boolean
+  readonly cursors: ReadonlyArray<IdeCursorEntry>
+}
+
+export interface IdeCursorOptions extends IdeApiOptions {
+  readonly keeperId?: string
+  readonly filePath?: string
+  readonly limit?: number
+  readonly offset?: number
+}
+
+interface IdeBridgeEventBase {
+  readonly type: IdeEventKind
+  readonly keeper_id: string
+  readonly turn_id: string
+  readonly timestamp_ms: number
+}
+
+export interface IdeToolEvent extends IdeBridgeEventBase {
+  readonly type: 'tool'
+  readonly tool_name: string
+  readonly outcome: string
+  readonly typed_outcome: string
+  readonly latency_ms: number
+  readonly summary: string
+  readonly file_path: string | null
+  readonly command_descriptor: unknown
+}
+
+export interface IdeTurnEvent extends IdeBridgeEventBase {
+  readonly type: 'turn'
+  readonly phase: string
+  readonly model_used: string | null
+  readonly tools_used: ReadonlyArray<string>
+  readonly stop_reason: string | null
+  readonly duration_ms: number | null
+}
+
+export interface IdePrEvent extends IdeBridgeEventBase {
+  readonly type: 'pr'
+  readonly pr_number: number
+  readonly pull_request_url: string
+  readonly pr_title: string
+  readonly pr_state: string
+  readonly repo: string
+  readonly comment_count: number
+  readonly review_status: string | null
+}
+
+export type IdeBridgeEvent = IdeToolEvent | IdeTurnEvent | IdePrEvent
 
 export interface IdeAnnotationFilter {
   readonly file_path?: string
@@ -122,4 +201,200 @@ export async function fetchIdePresence(
   return raw.data
 }
 
-import { isRecord } from '../lib/type-guards'
+export async function fetchIdeCursors(
+  opts: IdeCursorOptions = {},
+): Promise<IdeCursorSnapshot | null> {
+  const params = new URLSearchParams()
+  appendWorkspaceParams(params, opts)
+  if (opts.keeperId) params.set('keeper_id', opts.keeperId)
+  if (opts.filePath) params.set('file_path', opts.filePath)
+  if (opts.limit !== undefined) params.set('limit', String(opts.limit))
+  if (opts.offset !== undefined) params.set('offset', String(opts.offset))
+  const query = params.size > 0 ? `?${params.toString()}` : ''
+  const raw = await get<unknown>(`/api/v1/ide/cursors${query}`, opts)
+  if (!isRecord(raw) || raw.ok !== true) return null
+  return parseIdeCursorSnapshot(raw.data)
+}
+
+export async function fetchIdeEvents(
+  opts: IdeEventsOptions = {},
+): Promise<ReadonlyArray<IdeBridgeEvent>> {
+  const params = new URLSearchParams()
+  appendWorkspaceParams(params, opts)
+  if (opts.kind && opts.kind !== 'all') params.set('kind', opts.kind)
+  if (opts.keeperId) params.set('keeper_id', opts.keeperId)
+  if (opts.limit !== undefined) params.set('limit', String(opts.limit))
+  if (opts.offset !== undefined) params.set('offset', String(opts.offset))
+  const query = params.size > 0 ? `?${params.toString()}` : ''
+  const raw = await get<unknown>(`/api/v1/ide/events${query}`, opts)
+  if (!isRecord(raw) || raw.ok !== true || !isRecord(raw.data)) return []
+  const events = raw.data.events
+  return Array.isArray(events) ? events.map(parseIdeBridgeEvent).filter(isIdeBridgeEvent) : []
+}
+
+function parseIdeBridgeEvent(raw: unknown): IdeBridgeEvent | null {
+  if (!isRecord(raw)) return null
+  const type = stringField(raw, 'type')
+  const keeperId = stringField(raw, 'keeper_id')
+  const turnId = stringField(raw, 'turn_id')
+  const timestampMs = numberField(raw, 'timestamp_ms')
+  if (!isIdeEventKind(type) || !keeperId || !turnId || timestampMs === null) return null
+
+  if (type === 'tool') {
+    const toolName = stringField(raw, 'tool_name')
+    const outcome = stringField(raw, 'outcome')
+    const typedOutcome = stringField(raw, 'typed_outcome')
+    const latencyMs = numberField(raw, 'latency_ms')
+    const summary = stringField(raw, 'summary')
+    if (!toolName || !outcome || !typedOutcome || latencyMs === null || !summary) return null
+    return {
+      type,
+      keeper_id: keeperId,
+      turn_id: turnId,
+      timestamp_ms: timestampMs,
+      tool_name: toolName,
+      outcome,
+      typed_outcome: typedOutcome,
+      latency_ms: latencyMs,
+      summary,
+      file_path: stringField(raw, 'file_path'),
+      command_descriptor: raw.command_descriptor ?? null,
+    }
+  }
+
+  if (type === 'turn') {
+    const phase = stringField(raw, 'phase')
+    if (!phase) return null
+    return {
+      type,
+      keeper_id: keeperId,
+      turn_id: turnId,
+      timestamp_ms: timestampMs,
+      phase,
+      model_used: stringField(raw, 'model_used'),
+      tools_used: stringArrayField(raw, 'tools_used'),
+      stop_reason: stringField(raw, 'stop_reason'),
+      duration_ms: numberField(raw, 'duration_ms'),
+    }
+  }
+
+  const prNumber = numberField(raw, 'pr_number')
+  const pullRequestUrl = stringField(raw, 'pull_request_url') ?? ''
+  const prTitle = stringField(raw, 'pr_title') ?? ''
+  const prState = stringField(raw, 'pr_state') ?? ''
+  const repo = stringField(raw, 'repo') ?? ''
+  const commentCount = numberField(raw, 'comment_count')
+  if (prNumber === null || commentCount === null) return null
+  return {
+    type,
+    keeper_id: keeperId,
+    turn_id: turnId,
+    timestamp_ms: timestampMs,
+    pr_number: prNumber,
+    pull_request_url: pullRequestUrl,
+    pr_title: prTitle,
+    pr_state: prState,
+    repo,
+    comment_count: commentCount,
+    review_status: stringField(raw, 'review_status'),
+  }
+}
+
+function isIdeBridgeEvent(value: IdeBridgeEvent | null): value is IdeBridgeEvent {
+  return value !== null
+}
+
+function isIdeEventKind(value: string | null): value is IdeEventKind {
+  return value === 'tool' || value === 'turn' || value === 'pr'
+}
+
+function stringField(record: Record<string, unknown>, key: string): string | null {
+  const value = record[key]
+  return typeof value === 'string' && value.trim() !== '' ? value.trim() : null
+}
+
+function numberField(record: Record<string, unknown>, key: string): number | null {
+  const value = record[key]
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : null
+  }
+  return null
+}
+
+function stringArrayField(record: Record<string, unknown>, key: string): ReadonlyArray<string> {
+  const value = record[key]
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : []
+}
+
+function parseIdeCursorSnapshot(raw: unknown): IdeCursorSnapshot | null {
+  if (!isRecord(raw)) return null
+  const runtimeId = stringField(raw, 'runtime_id')
+  if (!runtimeId) return null
+  const cursorsRaw = Array.isArray(raw.cursors) ? raw.cursors : []
+  const cursors = cursorsRaw.map(parseIdeCursorEntry).filter(isIdeCursorEntry)
+  const branch = stringField(raw, 'branch')
+  return {
+    runtime_id: runtimeId,
+    connected: raw.connected === true,
+    cursors,
+    ...(branch ? { branch } : {}),
+  }
+}
+
+function parseIdeCursorEntry(raw: unknown): IdeCursorEntry | null {
+  if (!isRecord(raw)) return null
+  const keeperId = stringField(raw, 'keeper_id')
+  const filePath = stringField(raw, 'file_path')
+  const line = numberField(raw, 'line')
+  const column = numberField(raw, 'column')
+  const focusMode = stringField(raw, 'focus_mode')
+  const lastUpdate = numberField(raw, 'last_update')
+  if (
+    !keeperId
+    || !filePath
+    || line === null
+    || line < 1
+    || column === null
+    || column < 0
+    || !isIdeCursorFocusMode(focusMode)
+    || lastUpdate === null
+  ) return null
+
+  const selectionEnd = parseSelectionEnd(raw.selection_end)
+  const toolName = stringField(raw, 'tool_name')
+  const turn = numberField(raw, 'turn')
+  const turnId = stringField(raw, 'turn_id')
+  return {
+    keeper_id: keeperId,
+    file_path: filePath,
+    line,
+    column,
+    ...(selectionEnd ? { selection_end: selectionEnd } : {}),
+    focus_mode: focusMode,
+    last_update: lastUpdate,
+    ...(toolName ? { tool_name: toolName } : {}),
+    ...(turn !== null ? { turn } : {}),
+    ...(turnId ? { turn_id: turnId } : {}),
+  }
+}
+
+function isIdeCursorEntry(value: IdeCursorEntry | null): value is IdeCursorEntry {
+  return value !== null
+}
+
+function parseSelectionEnd(raw: unknown): { readonly line: number; readonly column: number } | null {
+  if (!isRecord(raw)) return null
+  const line = numberField(raw, 'line')
+  const column = numberField(raw, 'column')
+  if (line === null || line < 1 || column === null || column < 0) return null
+  return { line, column }
+}
+
+function isIdeCursorFocusMode(value: string | null): value is IdeCursorFocusMode {
+  return value === 'reading'
+    || value === 'editing'
+    || value === 'reviewing'
+    || value === 'planning'
+}

--- a/dashboard/src/components/ide/execute-output-drawer.test.ts
+++ b/dashboard/src/components/ide/execute-output-drawer.test.ts
@@ -41,6 +41,41 @@ describe('ExecuteOutputDrawer event mapping', () => {
     expect(lines.map(line => line.stream)).toEqual(['stdout', 'stdout', 'stderr'])
   })
 
+  it('prefers structured snapshot lines over byte chunks', () => {
+    const lines = linesFromExecuteOutputEvent({
+      type: 'snapshot',
+      keeper: 'sangsu',
+      stdout_since: 'duplicate\n',
+      lines: [
+        { ts_ms: 1000, stream: 'stdout', text: 'one', ansi: false },
+        { ts_ms: 1001, stream: 'stderr', text: 'warn', ansi: false },
+        { ts_ms: 1002, stream: 'system', text: 'closed', ansi: false },
+      ],
+      closed: false,
+    })
+
+    expect(lines).toEqual([
+      { text: 'one', stream: 'stdout' },
+      { text: 'warn', stream: 'stderr' },
+      { text: 'closed', stream: 'meta' },
+    ])
+  })
+
+  it('maps live line and task close events', () => {
+    expect(linesFromExecuteOutputEvent({
+      type: 'line',
+      keeper: 'sangsu',
+      line: { ts_ms: 1000, stream: 'stdout', text: 'fresh', ansi: false },
+      closed: false,
+    })).toEqual([{ text: 'fresh', stream: 'stdout' }])
+
+    expect(linesFromExecuteOutputEvent({
+      type: 'task_closed',
+      keeper: 'sangsu',
+      closed: true,
+    })).toEqual([{ text: 'Execute output task closed', stream: 'meta' }])
+  })
+
   it('surfaces dropped byte evidence as a meta line', () => {
     const lines = linesFromExecuteOutputEvent({
       type: 'snapshot',

--- a/dashboard/src/components/ide/execute-output-drawer.ts
+++ b/dashboard/src/components/ide/execute-output-drawer.ts
@@ -2,6 +2,7 @@ import { html } from 'htm/preact'
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import {
   streamExecuteOutput,
+  type ExecuteOutputLine,
   type ExecuteOutputStreamEvent,
 } from '../../api/execute-output'
 import { tasks } from '../../store'
@@ -55,6 +56,12 @@ function splitChunkLines(chunk: string): string[] {
   return lines
 }
 
+function outputLineFromExecuteLine(line: ExecuteOutputLine): OutputLine {
+  if (line.stream === 'stderr') return { text: line.text, stream: 'stderr' }
+  if (line.stream === 'stdout') return { text: line.text, stream: 'stdout' }
+  return { text: line.text, stream: 'meta' }
+}
+
 export function linesFromExecuteOutputEvent(event: ExecuteOutputStreamEvent): OutputLine[] {
   if (event.type === 'error') {
     return [{ text: event.message ?? 'Execute output stream error', stream: 'stderr' }]
@@ -64,11 +71,22 @@ export function linesFromExecuteOutputEvent(event: ExecuteOutputStreamEvent): Ou
   }
 
   const lines: OutputLine[] = []
-  for (const line of splitChunkLines(event.stdout_since ?? '')) {
-    lines.push({ text: line, stream: 'stdout' })
+  let usedStructuredLines = false
+  if (event.line) {
+    usedStructuredLines = true
+    lines.push(outputLineFromExecuteLine(event.line))
   }
-  for (const line of splitChunkLines(event.stderr_since ?? '')) {
-    lines.push({ text: line, stream: 'stderr' })
+  if (Array.isArray(event.lines)) {
+    usedStructuredLines = true
+    for (const line of event.lines) lines.push(outputLineFromExecuteLine(line))
+  }
+  if (!usedStructuredLines) {
+    for (const line of splitChunkLines(event.stdout_since ?? '')) {
+      lines.push({ text: line, stream: 'stdout' })
+    }
+    for (const line of splitChunkLines(event.stderr_since ?? '')) {
+      lines.push({ text: line, stream: 'stderr' })
+    }
   }
   const dropped =
     (event.bytes_dropped_stdout ?? 0) + (event.bytes_dropped_stderr ?? 0)

--- a/dashboard/src/components/ide/ide-activity-panel.test.ts
+++ b/dashboard/src/components/ide/ide-activity-panel.test.ts
@@ -252,6 +252,56 @@ describe('IdeActivityPanel', () => {
     })]))
   })
 
+  it('merges IDE bridge events into the activity timeline', async () => {
+    vi.stubGlobal('fetch', vi.fn(async input => {
+      const url = String(input)
+      if (url.includes('/api/v1/ide/events')) {
+        return new Response(JSON.stringify({
+          ok: true,
+          data: {
+            events: [{
+              type: 'tool',
+              tool_name: 'execute',
+              keeper_id: 'sangsu',
+              turn_id: 'turn-bridge',
+              outcome: 'success',
+              typed_outcome: 'progress',
+              latency_ms: 50,
+              summary: 'opened PR',
+              file_path: 'lib/runtime.ml',
+              command_descriptor: { kind: 'gh_pr_comment', pr_number: 20402 },
+              timestamp_ms: 500,
+            }],
+          },
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+      }
+      return new Response(JSON.stringify({ events: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }))
+
+    const container = document.createElement('div')
+    render(h(IdeActivityPanel, { activeFile: 'lib/runtime.ml' }), container)
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('tool:execute')
+      expect(container.textContent).toContain('progress: opened PR')
+      expect(container.textContent).toContain('1/1 linked')
+      expect(container.textContent).toContain('PR 20402')
+    })
+
+    const jump = container.querySelector<HTMLButtonElement>('.ide-activity-context-jump')
+    expect(jump?.textContent).toContain('runtime.ml')
+    fireEvent.click(jump!)
+    expect(ideContextFocus.value).toMatchObject({
+      file_path: 'lib/runtime.ml',
+      surface: 'PR',
+      keeper_id: 'sangsu',
+      source_id: 'ide-tool-turn-bridge-500-0',
+    })
+  })
+
   it('shows linked context coverage for mixed activity events', async () => {
     vi.stubGlobal('fetch', vi.fn(async () =>
       new Response(JSON.stringify({
@@ -367,8 +417,8 @@ describe('IdeActivityPanel', () => {
 
   it('refreshes activity events when polling is enabled', async () => {
     vi.useFakeTimers()
-    const fetchMock = vi.fn()
-      .mockResolvedValueOnce(new Response(JSON.stringify({
+    const activityResponses = [
+      {
         events: [{
           seq: 1,
           ts_ms: 100,
@@ -384,8 +434,8 @@ describe('IdeActivityPanel', () => {
           },
           tags: [],
         }],
-      }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
-      .mockResolvedValueOnce(new Response(JSON.stringify({
+      },
+      {
         events: [{
           seq: 2,
           ts_ms: 200,
@@ -402,7 +452,24 @@ describe('IdeActivityPanel', () => {
           },
           tags: [],
         }],
-      }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+      },
+    ]
+    let activityIndex = 0
+    const fetchMock = vi.fn(async input => {
+      const url = String(input)
+      if (url.includes('/api/v1/ide/events')) {
+        return new Response(JSON.stringify({ ok: true, data: { events: [] } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+      const body = activityResponses[Math.min(activityIndex, activityResponses.length - 1)]
+      activityIndex += 1
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    })
     vi.stubGlobal('fetch', fetchMock)
 
     const container = document.createElement('div')
@@ -411,13 +478,13 @@ describe('IdeActivityPanel', () => {
     await vi.waitFor(() => {
       expect(container.textContent).toContain('turn-1')
     })
-    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
 
     await vi.advanceTimersByTimeAsync(1_000)
     await vi.waitFor(() => {
       expect(container.textContent).toContain('goal goal-refresh')
     })
-    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock).toHaveBeenCalledTimes(4)
     expect(container.textContent).toContain('turn-2')
     expect(container.textContent).not.toContain('turn-1')
 
@@ -427,8 +494,18 @@ describe('IdeActivityPanel', () => {
   it('keeps the last activity snapshot when a refresh fails', async () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-05-05T10:00:00Z'))
-    const fetchMock = vi.fn()
-      .mockResolvedValueOnce(new Response(JSON.stringify({
+    let activityCalls = 0
+    const fetchMock = vi.fn(async input => {
+      const url = String(input)
+      if (url.includes('/api/v1/ide/events')) {
+        return new Response(JSON.stringify({ ok: true, data: { events: [] } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+      activityCalls += 1
+      if (activityCalls === 1) {
+        return new Response(JSON.stringify({
         events: [{
           seq: 1,
           ts_ms: 100,
@@ -444,8 +521,10 @@ describe('IdeActivityPanel', () => {
           },
           tags: [],
         }],
-      }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
-      .mockResolvedValueOnce(new Response('unavailable', { status: 503 }))
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+      }
+      return new Response('unavailable', { status: 503 })
+    })
     vi.stubGlobal('fetch', fetchMock)
 
     const container = document.createElement('div')
@@ -459,7 +538,7 @@ describe('IdeActivityPanel', () => {
     vi.setSystemTime(new Date('2026-05-05T10:00:10Z'))
     await vi.advanceTimersByTimeAsync(1_000)
     await vi.waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledTimes(2)
+      expect(fetchMock).toHaveBeenCalledTimes(4)
     })
 
     expect(container.textContent).toContain('turn-stable')

--- a/dashboard/src/components/ide/ide-activity-panel.ts
+++ b/dashboard/src/components/ide/ide-activity-panel.ts
@@ -1,6 +1,7 @@
 import { html } from 'htm/preact'
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import { get } from '../../api/core'
+import { fetchIdeEvents, type IdeBridgeEvent } from '../../api/ide'
 import { asRecord, isPositiveSafeInteger } from '../common/normalize'
 import { keeperHueIndex } from '../../../design-system/headless-core/keeper-line-ownership'
 import type { IdeAnnotation } from '../../api/schemas/ide-annotations'
@@ -196,6 +197,15 @@ function mapApiEvent(event: ApiActivityEvent, workspaceId: string): RunActivityE
 }
 
 async function fetchActivityEvents(): Promise<ActivityFetchResult> {
+  const graph = await fetchActivityGraphEvents()
+  const bridgeEvents = await fetchIdeBridgeRunActivityEvents(graph.workspaceId)
+  return {
+    ...graph,
+    events: mergeRunActivityEvents(graph.events, bridgeEvents),
+  }
+}
+
+async function fetchActivityGraphEvents(): Promise<ActivityFetchResult> {
   try {
     const data = await get<ApiActivityResponse>('/api/v1/activity/events?limit=50')
     const rawEvents = data.events
@@ -208,6 +218,88 @@ async function fetchActivityEvents(): Promise<ActivityFetchResult> {
   } catch {
     return { events: EMPTY_ACTIVITY, workspaceId: DEFAULT_WORKSPACE_ID, ok: false }
   }
+}
+
+async function fetchIdeBridgeRunActivityEvents(
+  workspaceId: string,
+): Promise<ReadonlyArray<RunActivityEvent>> {
+  try {
+    const events = await fetchIdeEvents({ limit: 50 })
+    return events.map((event, index) => mapIdeBridgeEvent(event, workspaceId, index))
+  } catch {
+    return EMPTY_ACTIVITY
+  }
+}
+
+function mergeRunActivityEvents(
+  graphEvents: ReadonlyArray<RunActivityEvent>,
+  bridgeEvents: ReadonlyArray<RunActivityEvent>,
+): ReadonlyArray<RunActivityEvent> {
+  if (bridgeEvents.length === 0) return graphEvents
+  if (graphEvents.length === 0) return bridgeEvents
+  return [...graphEvents, ...bridgeEvents].sort(compareRunActivityEvents)
+}
+
+function mapIdeBridgeEvent(
+  event: IdeBridgeEvent,
+  workspaceId: string,
+  index: number,
+): RunActivityEvent {
+  return {
+    id: `ide-${event.type}-${event.turn_id}-${event.timestamp_ms}-${index}`,
+    run_id: workspaceId,
+    timestamp_ms: event.timestamp_ms,
+    keeper_id: event.keeper_id,
+    verb: 'noted',
+    target: bridgeEventTarget(event),
+    detail: bridgeEventDetail(event),
+    kind: `ide.bridge.${event.type}`,
+    tags: [`ide:${event.type}`, `turn:${event.turn_id}`],
+    context: bridgeEventContext(event),
+  }
+}
+
+function bridgeEventTarget(event: IdeBridgeEvent): string {
+  if (event.type === 'tool') return `tool:${event.tool_name}`
+  if (event.type === 'turn') return `turn:${event.phase}`
+  return `pr:${event.pr_number}`
+}
+
+function bridgeEventDetail(event: IdeBridgeEvent): string {
+  if (event.type === 'tool') {
+    const outcome = event.typed_outcome || event.outcome
+    return `${outcome}: ${event.summary}`
+  }
+  if (event.type === 'turn') {
+    return [event.phase, event.model_used, event.stop_reason]
+      .filter((item): item is string => typeof item === 'string' && item.trim() !== '')
+      .join(' · ') || event.phase
+  }
+  return event.pr_title || event.pull_request_url || event.pr_state || `PR ${event.pr_number}`
+}
+
+function bridgeEventContext(event: IdeBridgeEvent): RunActivityContext | undefined {
+  const context: MutableRunActivityContext = {}
+  if (event.turn_id) context.log_id = event.turn_id
+  if (event.type === 'tool') {
+    const filePath = event.file_path ? normalizeIdeContextFilePath(event.file_path) : null
+    if (filePath) context.file_path = filePath
+    mergeCommandDescriptorContext(context, event.command_descriptor)
+  } else if (event.type === 'pr') {
+    if (event.pr_number > 0) context.pr_id = String(event.pr_number)
+  }
+  return Object.keys(context).length === 0 ? undefined : context
+}
+
+function mergeCommandDescriptorContext(
+  context: MutableRunActivityContext,
+  descriptor: unknown,
+): void {
+  if (!isRecord(descriptor)) return
+  const prNumber = positiveInteger(descriptor.pr_number)
+  if (prNumber !== undefined) context.pr_id = String(prNumber)
+  const branch = stringValue(descriptor.branch)
+  if (branch) context.git_ref = branch
 }
 
 function contextFromPayloadAndTags(
@@ -769,6 +861,11 @@ function latestRunActivityEvent(events: ReadonlyArray<RunActivityEvent>): RunAct
 function isLaterRunActivityEvent(candidate: RunActivityEvent, current: RunActivityEvent): boolean {
   return candidate.timestamp_ms > current.timestamp_ms
     || (candidate.timestamp_ms === current.timestamp_ms && candidate.id > current.id)
+}
+
+function compareRunActivityEvents(left: RunActivityEvent, right: RunActivityEvent): number {
+  if (left.timestamp_ms !== right.timestamp_ms) return right.timestamp_ms - left.timestamp_ms
+  return left.id.localeCompare(right.id)
 }
 
 function activityRouteLinks(item: RunActivityEvent): ReadonlyArray<IdeContextRouteLink> {

--- a/dashboard/src/components/ide/keeper-cursor-overlay.test.ts
+++ b/dashboard/src/components/ide/keeper-cursor-overlay.test.ts
@@ -1,6 +1,14 @@
 // @vitest-environment happy-dom
-import { describe, expect, it } from 'vitest'
-import { getKeeperColor } from './keeper-cursor-overlay'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  connectKeeperCursorStream,
+  getKeeperColor,
+  normalizeKeeperCursorSnapshot,
+} from './keeper-cursor-overlay'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
 
 describe('getKeeperColor', () => {
   it('maps explicit indexes to design-system keeper token slots', () => {
@@ -22,5 +30,70 @@ describe('getKeeperColor', () => {
     expect(color.cursor).toMatch(/^var\(--color-keeper-\d+\)$/)
     expect(color.selection).toMatch(/^rgb\(var\(--color-keeper-\d+-glow\) \/ 0\.22\)$/)
     expect(`${color.cursor} ${color.selection} ${color.shadow}`).not.toMatch(/#[0-9a-fA-F]{3,8}|rgba\(/)
+  })
+
+  it('ignores presence-only snapshots without cursor fields', () => {
+    const overlay = normalizeKeeperCursorSnapshot({
+      runtime_id: 'masc-runtime',
+      entries: [{
+        keeper_id: 'sangsu',
+        workspace_label: 'masc-mcp',
+        branch: 'main',
+        role: 'keeper',
+        status: 'active',
+        last_seen_ms: Date.now(),
+      }],
+    })
+
+    expect(overlay.cursors.size).toBe(0)
+    expect(overlay.active_file).toBeNull()
+  })
+
+  it('normalizes cursor snapshots with positive line positions', () => {
+    const overlay = normalizeKeeperCursorSnapshot({
+      runtime_id: 'masc-runtime',
+      cursors: [{
+        keeper_id: 'sangsu',
+        file_path: 'lib/a.ml',
+        line: 24,
+        column: 2,
+        focus_mode: 'editing',
+        last_update: Date.now(),
+        tool_name: 'keeper_ide_annotate',
+        turn: 7,
+      }],
+    })
+
+    expect(overlay.active_file).toBe('lib/a.ml')
+    expect(overlay.cursors.get('sangsu')).toMatchObject({
+      file_path: 'lib/a.ml',
+      line: 24,
+      focus_mode: 'editing',
+      tool_name: 'keeper_ide_annotate',
+      turn: 7,
+    })
+  })
+
+  it('connects to the dedicated cursor stream endpoint', () => {
+    const instances: Array<{ readonly url: string; close: () => void }> = []
+    class MockEventSource {
+      onmessage: ((event: MessageEvent) => void) | null = null
+      onerror: ((event: Event) => void) | null = null
+      readonly url: string
+
+      constructor(url: string) {
+        this.url = url
+        instances.push(this)
+      }
+
+      close = vi.fn()
+    }
+    vi.stubGlobal('EventSource', MockEventSource)
+
+    const cleanup = connectKeeperCursorStream('http://localhost:8935', () => {})
+
+    expect(instances[0]?.url).toBe('http://localhost:8935/api/v1/ide/cursors/stream')
+    cleanup()
+    expect(instances[0]?.close).toHaveBeenCalled()
   })
 })

--- a/dashboard/src/components/ide/keeper-cursor-overlay.ts
+++ b/dashboard/src/components/ide/keeper-cursor-overlay.ts
@@ -307,48 +307,111 @@ export function ActiveFileIndicator({ activeFile, keeperCount }: ActiveFileIndic
 
 // ── SSE Stream Integration ───────────────────────────────────────
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function stringField(record: Record<string, unknown>, key: string): string | null {
+  const value = record[key]
+  return typeof value === 'string' && value.trim() !== '' ? value.trim() : null
+}
+
+function numberField(record: Record<string, unknown>, key: string): number | null {
+  const value = record[key]
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : null
+  }
+  return null
+}
+
+function focusModeField(record: Record<string, unknown>): KeeperCursor['focus_mode'] | null {
+  const value = stringField(record, 'focus_mode')
+  if (value === 'reading' || value === 'editing' || value === 'reviewing' || value === 'planning') {
+    return value
+  }
+  return null
+}
+
+function parseSelectionEnd(raw: unknown): KeeperCursor['selection_end'] | null {
+  if (!isRecord(raw)) return null
+  const line = numberField(raw, 'line')
+  const column = numberField(raw, 'column')
+  if (line === null || line < 1 || column === null || column < 0) return null
+  return { line, column }
+}
+
+function parseCursorEntry(raw: unknown): KeeperCursor | null {
+  if (!isRecord(raw)) return null
+  const keeperId = stringField(raw, 'keeper_id')
+  const filePath = stringField(raw, 'file_path')
+  const line = numberField(raw, 'line')
+  const column = numberField(raw, 'column')
+  const focusMode = focusModeField(raw)
+  const lastUpdate = numberField(raw, 'last_update')
+  if (
+    !keeperId
+    || !filePath
+    || line === null
+    || line < 1
+    || column === null
+    || column < 0
+    || focusMode === null
+    || lastUpdate === null
+  ) return null
+
+  const selectionEnd = parseSelectionEnd(raw.selection_end)
+  const toolName = stringField(raw, 'tool_name')
+  const turn = numberField(raw, 'turn')
+  return {
+    keeper_id: keeperId,
+    file_path: filePath,
+    line,
+    column,
+    ...(selectionEnd ? { selection_end: selectionEnd } : {}),
+    focus_mode: focusMode,
+    last_update: lastUpdate,
+    ...(toolName ? { tool_name: toolName } : {}),
+    ...(turn !== null ? { turn } : {}),
+  }
+}
+
+export function normalizeKeeperCursorSnapshot(snapshot: unknown): KeeperCursorOverlay {
+  const entries =
+    isRecord(snapshot) && Array.isArray(snapshot.cursors)
+      ? snapshot.cursors
+      : isRecord(snapshot) && Array.isArray(snapshot.entries)
+        ? snapshot.entries
+        : []
+  const cursors = new Map<string, KeeperCursor>()
+  let activeFilePath: string | null = null
+
+  for (const raw of entries) {
+    const cursor = parseCursorEntry(raw)
+    if (cursor === null) continue
+    if (!activeFilePath) activeFilePath = cursor.file_path
+    cursors.set(cursor.keeper_id, cursor)
+  }
+
+  return {
+    cursors,
+    heatmap: calculateHeatmap(cursors.values()),
+    collisions: detectCollisions(cursors.values()),
+    active_file: activeFilePath,
+  }
+}
+
 export function connectKeeperCursorStream(
   baseUrl: string,
   onUpdate: (overlay: KeeperCursorOverlay) => void,
 ): () => void {
-  const eventSource = new EventSource(`${baseUrl}/api/v1/ide/presence/stream`)
+  const eventSource = new EventSource(`${baseUrl}/api/v1/ide/cursors/stream`)
   
   eventSource.onmessage = (event) => {
     try {
       const data = JSON.parse(event.data)
-      const entries = data.entries || []
-      
-      const cursors = new Map<string, KeeperCursor>()
-      let activeFilePath: string | null = null
-      
-      for (const entry of entries) {
-        // Extract file path from workspace_label or branch info
-        const filePath = entry.file_path || ''
-        if (filePath && !activeFilePath) {
-          activeFilePath = filePath
-        }
-        
-        cursors.set(entry.keeper_id, {
-          keeper_id: entry.keeper_id,
-          file_path: filePath,
-          line: entry.line || 0,
-          column: entry.column || 0,
-          focus_mode: entry.focus_mode || '(unknown focus_mode)',
-          last_update: entry.last_seen_ms,
-          tool_name: entry.tool_name,
-          turn: entry.turn,
-        })
-      }
-      
-      const collisionArray = detectCollisions(cursors.values())
-      const heatmapMap = calculateHeatmap(cursors.values())
-      
-      onUpdate({ 
-        cursors, 
-        heatmap: heatmapMap, 
-        collisions: collisionArray,
-        active_file: activeFilePath,
-      })
+      onUpdate(normalizeKeeperCursorSnapshot(data))
     } catch (err) {
       console.error('Keeper cursor stream parse error:', err)
     }

--- a/lib/dashboard/dashboard_execute_output.ml
+++ b/lib/dashboard/dashboard_execute_output.ml
@@ -1,0 +1,402 @@
+(** See [Dashboard_execute_output.mli]. *)
+
+type entry = {
+  task_id : string option;
+  stdout : string;
+  stderr : string;
+  status : Yojson.Safe.t;
+  generated_at : float;
+}
+
+type output_line = {
+  ts_ms : int;
+  stream : string;
+  text : string;
+  ansi : bool;
+}
+
+type snapshot = {
+  keeper : string;
+  task_id : string option;
+  task_count : int;
+  lines : output_line list;
+  stdout_since : string;
+  stderr_since : string;
+  since_stdout : int;
+  since_stderr : int;
+  bytes_dropped_stdout : int;
+  bytes_dropped_stderr : int;
+  closed : bool;
+  status : Yojson.Safe.t option;
+  generated_at : float;
+}
+
+type stream_event =
+  | Line_event of {
+      keeper : string;
+      task_id : string option;
+      line : output_line;
+      generated_at : float;
+    }
+  | Task_closed_event of {
+      keeper : string;
+      task_id : string option;
+      status : Yojson.Safe.t;
+      generated_at : float;
+    }
+
+type subscriber = {
+  id : int;
+  keeper : string;
+  events : stream_event Eio.Stream.t;
+}
+
+let per_keeper_cap = 50
+let retained_stream_bytes = 256 * 1024
+let line_ring_cap = 5000
+let subscriber_capacity = 256
+let max_line_bytes = 4096
+
+(* Stdlib.Mutex: producer callbacks can run outside an Eio context, and the
+   critical section only mutates or snapshots small queues. *)
+let mu = Mutex.create ()
+let table : (string, entry Queue.t) Hashtbl.t = Hashtbl.create 16
+let line_table : (string, output_line Queue.t) Hashtbl.t = Hashtbl.create 16
+let subscribers : (string, subscriber list) Hashtbl.t = Hashtbl.create 16
+let next_subscriber_id = ref 0
+
+let normalize_keeper keeper_name =
+  keeper_name |> String.trim |> String.lowercase_ascii
+
+let now_unix () =
+  (* NDT-OK: runtime freshness timestamp only; not a deterministic input. *)
+  Unix.gettimeofday ()
+
+let with_lock f =
+  Mutex.lock mu;
+  Fun.protect ~finally:(fun () -> Mutex.unlock mu) f
+
+let queue_to_list q =
+  Queue.fold (fun acc value -> value :: acc) [] q |> List.rev
+
+let ts_ms_of_unix ts = int_of_float (ts *. 1000.0)
+
+let strip_trailing_cr line =
+  let len = String.length line in
+  if len > 0 && Char.equal line.[len - 1] '\r'
+  then String.sub line 0 (len - 1)
+  else line
+
+let split_chunk_lines chunk =
+  if String.equal chunk ""
+  then []
+  else (
+    let lines = String.split_on_char '\n' chunk in
+    let rec drop_last = function
+      | [] -> []
+      | [ _ ] -> []
+      | head :: tail -> head :: drop_last tail
+    in
+    let lines =
+      if String.ends_with ~suffix:"\n" chunk then drop_last lines else lines
+    in
+    List.map strip_trailing_cr lines)
+
+let output_lines_for_chunk ~ts_ms ~stream chunk =
+  split_chunk_lines chunk
+  |> List.map (fun text ->
+    { ts_ms
+    ; stream
+    ; text = Masc_exec.Exec_buffer.utf8_truncate text max_line_bytes
+    ; ansi = false
+    })
+
+let output_lines_for_entry (entry : entry) =
+  let ts_ms = ts_ms_of_unix entry.generated_at in
+  output_lines_for_chunk ~ts_ms ~stream:"stdout" entry.stdout
+  @ output_lines_for_chunk ~ts_ms ~stream:"stderr" entry.stderr
+
+let append_bounded q cap value =
+  Queue.push value q;
+  while Queue.length q > cap do
+    let _dropped = Queue.pop q in
+    ()
+  done
+
+let append_completed_locked ~keeper (entry : entry) lines =
+  let q =
+    match Hashtbl.find_opt table keeper with
+    | Some q -> q
+    | None ->
+      let q = Queue.create () in
+      Hashtbl.add table keeper q;
+      q
+  in
+  append_bounded q per_keeper_cap entry;
+  let line_q =
+    match Hashtbl.find_opt line_table keeper with
+    | Some q -> q
+    | None ->
+      let q = Queue.create () in
+      Hashtbl.add line_table keeper q;
+      q
+  in
+  List.iter (append_bounded line_q line_ring_cap) lines;
+  (* DET-OK: missing subscriber list means no live clients for this keeper. *)
+  Hashtbl.find_opt subscribers keeper |> Option.value ~default:[]
+
+let enqueue_subscriber_event subscriber event =
+  while Eio.Stream.length subscriber.events >= subscriber_capacity do
+    match Eio.Stream.take_nonblocking subscriber.events with
+    | Some _ -> ()
+    | None -> ()
+  done;
+  Eio.Stream.add subscriber.events event
+
+let broadcast_events subscribers events =
+  List.iter
+    (fun event ->
+       List.iter
+         (fun subscriber ->
+            try enqueue_subscriber_event subscriber event with
+            | Eio.Cancel.Cancelled _ as e -> raise e
+            | exn ->
+              Log.Dashboard.warn
+                "dashboard execute output subscriber enqueue failed: %s"
+                (Printexc.to_string exn))
+         subscribers)
+    events
+
+let append_completed ~keeper_name (entry : entry) =
+  let keeper = normalize_keeper keeper_name in
+  if keeper = ""
+  then ()
+  else (
+    let lines = output_lines_for_entry entry in
+    let current_subscribers =
+      with_lock (fun () -> append_completed_locked ~keeper entry lines)
+    in
+    let events =
+      List.map
+        (fun line ->
+           Line_event { keeper; task_id = entry.task_id; line; generated_at = entry.generated_at })
+        lines
+      @ [ Task_closed_event
+            { keeper
+            ; task_id = entry.task_id
+            ; status = entry.status
+            ; generated_at = entry.generated_at
+            }
+        ]
+    in
+    broadcast_events current_subscribers events)
+
+let record_failure exn =
+  Log.Dashboard.warn
+    "dashboard execute output collector failed: %s"
+    (Printexc.to_string exn)
+
+let record_completed ~keeper_name ~task_id ~stdout ~stderr ~status =
+  let entry =
+    { task_id; stdout; stderr; status; generated_at = now_unix () }
+  in
+  try append_completed ~keeper_name entry with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn -> record_failure exn
+
+let snapshot_state keeper_name =
+  let keeper = normalize_keeper keeper_name in
+  if keeper = ""
+  then "", [], []
+  else
+    with_lock (fun () ->
+      let entries =
+        match Hashtbl.find_opt table keeper with
+        | None -> []
+        | Some q -> queue_to_list q
+      in
+      let lines =
+        match Hashtbl.find_opt line_table keeper with
+        | None -> []
+        | Some q -> queue_to_list q
+      in
+      keeper, entries, lines)
+
+let add_stream_chunks entries select =
+  let buffer =
+    Masc_exec.Exec_buffer.create ~head_cap:0 ~tail_cap:retained_stream_bytes
+  in
+  List.iter
+    (fun entry -> Masc_exec.Exec_buffer.add_string buffer (select entry))
+    entries;
+  ( Masc_exec.Exec_buffer.tail buffer
+  , Masc_exec.Exec_buffer.total_bytes buffer
+  , Masc_exec.Exec_buffer.bytes_dropped buffer )
+
+let snapshot ~keeper_name =
+  let keeper, entries, lines = snapshot_state keeper_name in
+  match List.rev entries with
+  | [] -> None
+  | latest :: _ ->
+    let stdout_since, since_stdout, bytes_dropped_stdout =
+      add_stream_chunks entries (fun entry -> entry.stdout)
+    in
+    let stderr_since, since_stderr, bytes_dropped_stderr =
+      add_stream_chunks entries (fun entry -> entry.stderr)
+    in
+    Some
+      { keeper
+      ; task_id = latest.task_id
+      ; task_count = List.length entries
+      ; lines
+      ; stdout_since
+      ; stderr_since
+      ; since_stdout
+      ; since_stderr
+      ; bytes_dropped_stdout
+      ; bytes_dropped_stderr
+      ; closed = true
+      ; status = Some latest.status
+      ; generated_at = latest.generated_at
+      }
+
+let option_json f = function
+  | Some value -> f value
+  | None -> `Null
+
+let output_line_json line =
+  `Assoc
+    [ "ts_ms", `Int line.ts_ms
+    ; "stream", `String line.stream
+    ; "text", `String line.text
+    ; "ansi", `Bool line.ansi
+    ]
+
+let snapshot_json (s : snapshot) =
+  `Assoc
+    [ "type", `String "snapshot"
+    ; "kind", `String "snapshot"
+    ; "keeper", `String s.keeper
+    ; "keeper_id", `String s.keeper
+    ; "task_id", option_json (fun value -> `String value) s.task_id
+    ; "task_count", `Int s.task_count
+    ; "lines", `List (List.map output_line_json s.lines)
+    ; "since_stdout", `Int s.since_stdout
+    ; "since_stderr", `Int s.since_stderr
+    ; "stdout_since", `String s.stdout_since
+    ; "stderr_since", `String s.stderr_since
+    ; "closed", `Bool s.closed
+    ; "status", option_json (fun value -> value) s.status
+    ; "bytes_dropped_stdout", `Int s.bytes_dropped_stdout
+    ; "bytes_dropped_stderr", `Int s.bytes_dropped_stderr
+    ; "generated_at", `Float s.generated_at
+    ]
+
+let no_task_json keeper_name =
+  `Assoc
+    [ "type", `String "no_task"
+    ; "kind", `String "no_task"
+    ; "keeper", `String (normalize_keeper keeper_name)
+    ; "keeper_id", `String (normalize_keeper keeper_name)
+    ; "task_count", `Int 0
+    ; "lines", `List []
+    ; "closed", `Bool true
+    ; "generated_at", `Float (now_unix ())
+    ]
+
+let event_json ~keeper_name =
+  match snapshot ~keeper_name with
+  | Some s -> snapshot_json s
+  | None -> no_task_json keeper_name
+
+let stream_event_json = function
+  | Line_event { keeper; task_id; line; generated_at } ->
+    `Assoc
+      [ "type", `String "line"
+      ; "kind", `String "line"
+      ; "keeper", `String keeper
+      ; "keeper_id", `String keeper
+      ; "task_id", option_json (fun value -> `String value) task_id
+      ; "line", output_line_json line
+      ; "closed", `Bool false
+      ; "generated_at", `Float generated_at
+      ]
+  | Task_closed_event { keeper; task_id; status; generated_at } ->
+    `Assoc
+      [ "type", `String "task_closed"
+      ; "kind", `String "task_closed"
+      ; "keeper", `String keeper
+      ; "keeper_id", `String keeper
+      ; "task_id", option_json (fun value -> `String value) task_id
+      ; "closed", `Bool true
+      ; "status", status
+      ; "generated_at", `Float generated_at
+      ]
+
+let sse_frame json =
+  Printf.sprintf "event: output\ndata: %s\n\n" (Yojson.Safe.to_string json)
+
+let subscribe ~keeper_name =
+  let keeper = normalize_keeper keeper_name in
+  if String.equal keeper ""
+  then None
+  else
+    let events = Eio.Stream.create subscriber_capacity in
+    with_lock (fun () ->
+      let id = !next_subscriber_id in
+      incr next_subscriber_id;
+      let subscriber = { id; keeper; events } in
+      let current =
+        (* DET-OK: missing subscriber list means this is the first client. *)
+        Hashtbl.find_opt subscribers keeper |> Option.value ~default:[]
+      in
+      Hashtbl.replace subscribers keeper (subscriber :: current);
+      Some subscriber)
+
+let unsubscribe subscriber =
+  with_lock (fun () ->
+    match Hashtbl.find_opt subscribers subscriber.keeper with
+    | None -> ()
+    | Some current ->
+      let remaining =
+        List.filter (fun candidate -> candidate.id <> subscriber.id) current
+      in
+      if remaining = []
+      then Hashtbl.remove subscribers subscriber.keeper
+      else Hashtbl.replace subscribers subscriber.keeper remaining)
+
+let take_event subscriber = Eio.Stream.take subscriber.events
+
+let reset_for_testing () =
+  with_lock (fun () ->
+    Hashtbl.clear table;
+    Hashtbl.clear line_table;
+    Hashtbl.clear subscribers;
+    next_subscriber_id := 0)
+
+let output_lines_for_testing ~keeper_name =
+  let keeper = normalize_keeper keeper_name in
+  if keeper = ""
+  then []
+  else
+    with_lock (fun () ->
+      match Hashtbl.find_opt line_table keeper with
+      | None -> []
+      | Some q -> queue_to_list q)
+
+let inject_for_testing
+      ~keeper_name
+      ?task_id
+      ?(generated_at = now_unix ())
+      ~stdout
+      ~stderr
+      ~status
+      ()
+  =
+  append_completed ~keeper_name { task_id; stdout; stderr; status; generated_at }
+
+let () =
+  Keeper_keepalive_signal.register_record_execute_output
+    (fun ~keeper_name ~task_id ~stdout ~stderr ~status ->
+       record_completed ~keeper_name ~task_id ~stdout ~stderr ~status)
+;;

--- a/lib/dashboard/dashboard_execute_output.mli
+++ b/lib/dashboard/dashboard_execute_output.mli
@@ -1,0 +1,79 @@
+(** Execute output collector for the Code IDE terminal drawer.
+
+    The collector stores completed Execute output per keeper in bounded,
+    in-process rings. HTTP routes serialize an initial snapshot and can then
+    keep an SSE tail open for later line events. *)
+
+type output_line = {
+  ts_ms : int;
+  stream : string;
+  text : string;
+  ansi : bool;
+}
+
+type snapshot = {
+  keeper : string;
+  task_id : string option;
+  task_count : int;
+  lines : output_line list;
+  stdout_since : string;
+  stderr_since : string;
+  since_stdout : int;
+  since_stderr : int;
+  bytes_dropped_stdout : int;
+  bytes_dropped_stderr : int;
+  closed : bool;
+  status : Yojson.Safe.t option;
+  generated_at : float;
+}
+
+type stream_event
+type subscriber
+
+val record_completed :
+  keeper_name:string ->
+  task_id:string option ->
+  stdout:string ->
+  stderr:string ->
+  status:Yojson.Safe.t ->
+  unit
+(** Record a completed Execute invocation. Non-cancellation failures are logged
+    and swallowed by the implementation because this path is observational. *)
+
+val snapshot : keeper_name:string -> snapshot option
+(** Latest retained Execute output for [keeper_name], if any. *)
+
+val event_json : keeper_name:string -> Yojson.Safe.t
+(** Build the SSE payload. Returns a [no_task] event when the keeper has no
+    retained Execute output. *)
+
+val stream_event_json : stream_event -> Yojson.Safe.t
+(** Build an SSE payload for a live tail event. *)
+
+val sse_frame : Yojson.Safe.t -> string
+(** Serialize one [event: output] SSE frame. *)
+
+val subscribe : keeper_name:string -> subscriber option
+(** Subscribe to future line events for [keeper_name]. Returns [None] when the
+    keeper name is empty after normalization. *)
+
+val unsubscribe : subscriber -> unit
+
+val take_event : subscriber -> stream_event
+(** Block until the next live tail event for this subscriber. *)
+
+(** {1 Test hooks} *)
+
+val reset_for_testing : unit -> unit
+
+val output_lines_for_testing : keeper_name:string -> output_line list
+
+val inject_for_testing :
+  keeper_name:string ->
+  ?task_id:string ->
+  ?generated_at:float ->
+  stdout:string ->
+  stderr:string ->
+  status:Yojson.Safe.t ->
+  unit ->
+  unit

--- a/lib/ide/ide_bridge.ml
+++ b/lib/ide/ide_bridge.ml
@@ -5,15 +5,42 @@ open Ide_event_types
 
 let default_partition = Ide_paths.Orphan
 
+type event_kind =
+  | Tool
+  | Turn
+  | Pr
+
+let event_kind_to_string = function
+  | Tool -> "tool"
+  | Turn -> "turn"
+  | Pr -> "pr"
+;;
+
+let event_kind_of_string = function
+  | "tool" -> Some Tool
+  | "turn" -> Some Turn
+  | "pr" -> Some Pr
+  | _ -> None
+;;
+
+let event_file_name = function
+  | Tool -> "tool_events.jsonl"
+  | Turn -> "turn_events.jsonl"
+  | Pr -> "pr_events.jsonl"
+;;
+
+let cursor_file_name = "cursor_events.jsonl"
+
+let event_kind_of_event = function
+  | Tool_event _ -> Tool
+  | Turn_event _ -> Turn
+  | Pr_event _ -> Pr
+;;
+
 let append_event ~base_dir ~partition ~(event : ide_event) =
   let dir = Ide_paths.partition_store_dir ~base_dir partition in
   Fs_compat.mkdir_p dir;
-  let file_name =
-    match event with
-    | Tool_event _ -> "tool_events.jsonl"
-    | Turn_event _ -> "turn_events.jsonl"
-    | Pr_event _ -> "pr_events.jsonl"
-  in
+  let file_name = event_file_name (event_kind_of_event event) in
   let path = Filename.concat dir file_name in
   let json = ide_event_to_json event in
   (* Use Fs_compat.append_jsonl for per-path mutex protection.
@@ -22,6 +49,217 @@ let append_event ~base_dir ~partition ~(event : ide_event) =
      so writes to the same file are serialized; writes to different files
      can proceed concurrently. *)
   Fs_compat.append_jsonl path json
+
+let append_cursor ~base_dir ~partition json =
+  let dir = Ide_paths.partition_store_dir ~base_dir partition in
+  Fs_compat.mkdir_p dir;
+  let path = Filename.concat dir cursor_file_name in
+  Fs_compat.append_jsonl path json
+
+let string_field key = function
+  | `Assoc fields ->
+    (match List.assoc_opt key fields with
+     | Some (`String s) when s <> "" -> Some s
+     | _ -> None)
+  | _ -> None
+;;
+
+let int64_field key = function
+  | `Assoc fields ->
+    (match List.assoc_opt key fields with
+     | Some (`Int i) -> Some (Int64.of_int i)
+     | Some (`Intlit s) -> Int64.of_string_opt s
+     | _ -> None)
+  | _ -> None
+;;
+
+let int_field key = function
+  | `Assoc fields ->
+    (match List.assoc_opt key fields with
+     | Some (`Int i) -> Some i
+     | Some (`Intlit s) -> int_of_string_opt s
+     | Some (`String s) -> int_of_string_opt (String.trim s)
+     | _ -> None)
+  | _ -> None
+;;
+
+let event_timestamp_ms json =
+  match int64_field "timestamp_ms" json with
+  | Some ts -> ts
+  | None ->
+    (* DET-OK: malformed or historical bridge rows without timestamps sort last;
+       the reader does not synthesize event identity or mutate the stored row. *)
+    0L
+;;
+
+let event_matches_kind kind json =
+  match string_field "type" json with
+  | Some wire_kind -> String.equal wire_kind (event_kind_to_string kind)
+  | None -> false
+;;
+
+let event_matches_keeper keeper_id json =
+  match keeper_id with
+  | None -> true
+  | Some expected ->
+    (match string_field "keeper_id" json with
+     | Some actual -> String.equal actual expected
+     | None -> false)
+;;
+
+let cursor_matches_file file_path json =
+  match file_path with
+  | None -> true
+  | Some expected ->
+    (match string_field "file_path" json with
+     | Some actual -> String.equal actual expected
+     | None -> false)
+;;
+
+let valid_focus_mode = function
+  | "reading" | "editing" | "reviewing" | "planning" -> true
+  | _ -> false
+;;
+
+let cursor_is_valid json =
+  match
+    ( string_field "keeper_id" json
+    , string_field "file_path" json
+    , int_field "line" json
+    , int_field "column" json
+    , string_field "focus_mode" json )
+  with
+  | Some _, Some file_path, Some line, Some column, Some focus_mode ->
+    String.trim file_path <> "" && line >= 1 && column >= 0 && valid_focus_mode focus_mode
+  | _ -> false
+;;
+
+let cursor_timestamp_ms json =
+  match int64_field "last_update" json with
+  | Some ts -> ts
+  | None ->
+    (match int64_field "timestamp_ms" json with
+     | Some ts -> ts
+     | None -> 0L)
+;;
+
+let compare_cursor_json left right =
+  let by_time = Int64.compare (cursor_timestamp_ms right) (cursor_timestamp_ms left) in
+  if by_time <> 0 then by_time else compare left right
+;;
+
+let normalize_limit = function
+  | Some n when n > 0 -> min n 200
+  | _ -> 50
+;;
+
+let normalize_offset = function
+  | Some n when n > 0 -> n
+  | _ -> 0
+;;
+
+let drop n items =
+  let rec loop remaining = function
+    | [] -> []
+    | rest when remaining <= 0 -> rest
+    | _ :: rest -> loop (remaining - 1) rest
+  in
+  loop n items
+;;
+
+let take n items =
+  let rec loop remaining acc = function
+    | [] -> List.rev acc
+    | _ when remaining <= 0 -> List.rev acc
+    | item :: rest -> loop (remaining - 1) (item :: acc) rest
+  in
+  loop n [] items
+;;
+
+let compare_event_json left right =
+  let by_time = Int64.compare (event_timestamp_ms right) (event_timestamp_ms left) in
+  if by_time <> 0 then by_time else compare left right
+;;
+
+let now_ms () =
+  (* NDT-OK: IDE bridge timestamps are runtime telemetry for operator ordering;
+     they are not used to make deterministic build or scheduling decisions. *)
+  Int64.of_float (Unix.gettimeofday () *. 1000.0)
+;;
+
+let list_kind_events ~base_path ~partition ~kind ?keeper_id () =
+  let dir = Ide_paths.partition_store_dir ~base_dir:base_path partition in
+  let path = Filename.concat dir (event_file_name kind) in
+  Fs_compat.fold_jsonl_lines
+    ~init:[]
+    ~f:(fun acc ~line_no:_ json ->
+      if event_matches_kind kind json && event_matches_keeper keeper_id json
+      then json :: acc
+      else acc)
+    path
+;;
+
+let latest_cursor_per_keeper cursors =
+  let seen = Hashtbl.create 8 in
+  let acc = ref [] in
+  List.iter
+    (fun json ->
+       match string_field "keeper_id" json with
+       | Some keeper_id when not (Hashtbl.mem seen keeper_id) ->
+         Hashtbl.add seen keeper_id ();
+         acc := json :: !acc
+       | _ -> ())
+    cursors;
+  List.rev !acc
+;;
+
+let list_cursors
+    ~base_path
+    ?(partition = default_partition)
+    ?keeper_id
+    ?file_path
+    ?limit
+    ?offset
+    ()
+  =
+  let dir = Ide_paths.partition_store_dir ~base_dir:base_path partition in
+  let path = Filename.concat dir cursor_file_name in
+  let cursors =
+    Fs_compat.fold_jsonl_lines
+      ~init:[]
+      ~f:(fun acc ~line_no:_ json ->
+        if cursor_is_valid json
+           && event_matches_keeper keeper_id json
+           && cursor_matches_file file_path json
+        then json :: acc
+        else acc)
+      path
+    |> List.sort compare_cursor_json
+    |> latest_cursor_per_keeper
+  in
+  cursors |> drop (normalize_offset offset) |> take (normalize_limit limit)
+
+let list_events
+    ~base_path
+    ?(partition = default_partition)
+    ?kind
+    ?keeper_id
+    ?limit
+    ?offset
+    ()
+  =
+  let kinds =
+    match kind with
+    | Some k -> [ k ]
+    | None -> [ Tool; Turn; Pr ]
+  in
+  let events =
+    List.concat_map
+      (fun kind -> list_kind_events ~base_path ~partition ~kind ?keeper_id ())
+      kinds
+    |> List.sort compare_event_json
+  in
+  events |> drop (normalize_offset offset) |> take (normalize_limit limit)
 
 let ingest_tool_event
     ~base_path
@@ -182,6 +420,145 @@ let extract_descriptor_from_output (output_text : string) : Ide_event_types.comm
     | _ -> None
   with _ -> None
 
+let string_contains s needle =
+  let s_len = String.length s in
+  let needle_len = String.length needle in
+  let rec loop i =
+    if needle_len = 0 then true
+    else if i + needle_len > s_len then false
+    else if String.sub s i needle_len = needle then true
+    else loop (i + 1)
+  in
+  loop 0
+;;
+
+let cursor_file_path_of_input input =
+  let non_empty = function
+    | Some s ->
+      let trimmed = String.trim s in
+      if trimmed = "" then None else Some trimmed
+    | None -> None
+  in
+  match non_empty (string_field "file_path" input) with
+  | Some _ as path -> path
+  | None -> non_empty (string_field "path" input)
+;;
+
+let cursor_line_of_input input =
+  match int_field "line" input with
+  | Some n -> Some n
+  | None -> int_field "line_start" input
+;;
+
+let focus_mode_of_tool_input ~tool_name input =
+  match string_field "focus_mode" input with
+  | Some mode when valid_focus_mode mode -> mode
+  | _ ->
+    let lowered = String.lowercase_ascii tool_name in
+    if string_contains lowered "review"
+    then "reviewing"
+    else if string_contains lowered "read" || string_contains lowered "search"
+    then "reading"
+    else if string_contains lowered "write"
+            || string_contains lowered "edit"
+            || string_contains lowered "patch"
+            || string_contains lowered "annotate"
+    then "editing"
+    else "planning"
+;;
+
+let turn_number_of_id turn_id =
+  let digits = Buffer.create (String.length turn_id) in
+  String.iter
+    (fun c -> if c >= '0' && c <= '9' then Buffer.add_char digits c)
+    turn_id;
+  let raw = Buffer.contents digits in
+  if raw = "" then None else int_of_string_opt raw
+;;
+
+let cursor_event_json
+    ~keeper_id
+    ~file_path
+    ~line
+    ~column
+    ?selection_end
+    ~focus_mode
+    ~last_update
+    ~tool_name
+    ?turn
+    ~turn_id
+    ()
+  =
+  let fields =
+    [ "keeper_id", `String keeper_id
+    ; "file_path", `String file_path
+    ; "line", `Int line
+    ; "column", `Int column
+    ; "focus_mode", `String focus_mode
+    ; "last_update", `Intlit (Int64.to_string last_update)
+    ; "timestamp_ms", `Intlit (Int64.to_string last_update)
+    ; "tool_name", `String tool_name
+    ; "turn_id", `String turn_id
+    ]
+  in
+  let fields =
+    match selection_end with
+    | Some (line, column) ->
+      ( "selection_end"
+      , `Assoc [ "line", `Int line; "column", `Int column ] )
+      :: fields
+    | None -> fields
+  in
+  let fields =
+    match turn with
+    | Some turn -> ("turn", `Int turn) :: fields
+    | None -> fields
+  in
+  `Assoc (List.rev fields)
+;;
+
+let ingest_cursor_event_from_hook
+    ~base_path
+    ~tool_name
+    ~keeper_id
+    ~turn_id
+    ~timestamp_ms
+    ~(input : Yojson.Safe.t)
+  =
+  match cursor_file_path_of_input input, cursor_line_of_input input with
+  | Some file_path, Some line when line >= 1 ->
+    let column =
+      match int_field "column" input with
+      | Some n when n >= 0 -> n
+      | _ -> 0
+    in
+    let selection_end =
+      match int_field "line_end" input with
+      | Some line_end when line_end > line -> Some (line_end, column)
+      | _ -> None
+    in
+    let json =
+      cursor_event_json
+        ~keeper_id
+        ~file_path
+        ~line
+        ~column
+        ?selection_end
+        ~focus_mode:(focus_mode_of_tool_input ~tool_name input)
+        ~last_update:timestamp_ms
+        ~tool_name
+        ?turn:(turn_number_of_id turn_id)
+        ~turn_id
+        ()
+    in
+    (try append_cursor ~base_dir:base_path ~partition:default_partition json
+     with exn ->
+       Printf.eprintf
+         "Ide_bridge.ingest_cursor_event_from_hook error: %s\n%!"
+         (Printexc.to_string exn))
+  | _ -> ()
+;;
+
 (** Extract tool event parameters from raw hook data and ingest.
     This is the function called from [keeper_run_tools_hooks.on_tool_executed].
     Separated for direct testability. *)
@@ -209,6 +586,7 @@ let ingest_tool_event_from_hook
     else output_text
   in
   let command_descriptor = extract_descriptor_from_output output_text in
+  let timestamp_ms = now_ms () in
   ingest_tool_event
     ~base_path
     ~tool_name
@@ -220,8 +598,15 @@ let ingest_tool_event_from_hook
     ~summary
     ~file_path
     ?command_descriptor
-    ~timestamp_ms:(Int64.of_float (Unix.gettimeofday () *. 1000.0))
-    ()
+    ~timestamp_ms
+    ();
+  ingest_cursor_event_from_hook
+    ~base_path
+    ~tool_name
+    ~keeper_id
+    ~turn_id
+    ~timestamp_ms
+    ~input
 
 let parse_pull_request_link_from_output (output : string) : (int * string) option =
   let prefix = "https://github.com/" in
@@ -284,37 +669,37 @@ let ingest_pr_event_from_descriptor
         ~base_path ~pr_number ~pull_request_url ~pr_title:title
         ~pr_state:"open" ~repo:"" ~keeper_id ~turn_id
         ~comment_count:0 ~review_status:None
-        ~timestamp_ms:(Int64.of_float (Unix.gettimeofday () *. 1000.0))
+        ~timestamp_ms:(now_ms ())
     | Some (Ide_event_types.Gh_pr_merge { pr_number; squash = _ }) ->
       ingest_pr_event
         ~base_path ~pr_number ~pull_request_url:"" ~pr_title:""
         ~pr_state:"merged" ~repo:"" ~keeper_id ~turn_id
         ~comment_count:0 ~review_status:None
-        ~timestamp_ms:(Int64.of_float (Unix.gettimeofday () *. 1000.0))
+        ~timestamp_ms:(now_ms ())
     | Some (Ide_event_types.Gh_pr_close { pr_number }) ->
       ingest_pr_event
         ~base_path ~pr_number ~pull_request_url:"" ~pr_title:""
         ~pr_state:"closed" ~repo:"" ~keeper_id ~turn_id
         ~comment_count:0 ~review_status:None
-        ~timestamp_ms:(Int64.of_float (Unix.gettimeofday () *. 1000.0))
+        ~timestamp_ms:(now_ms ())
     | Some (Ide_event_types.Gh_pr_comment { pr_number; body = _ }) ->
       ingest_pr_event
         ~base_path ~pr_number ~pull_request_url:"" ~pr_title:""
         ~pr_state:"open" ~repo:"" ~keeper_id ~turn_id
         ~comment_count:1 ~review_status:None
-        ~timestamp_ms:(Int64.of_float (Unix.gettimeofday () *. 1000.0))
+        ~timestamp_ms:(now_ms ())
     | Some (Ide_event_types.Gh_pr_edit { pr_number; title = _ }) ->
       ingest_pr_event
         ~base_path ~pr_number ~pull_request_url:"" ~pr_title:""
         ~pr_state:"open" ~repo:"" ~keeper_id ~turn_id
         ~comment_count:0 ~review_status:None
-        ~timestamp_ms:(Int64.of_float (Unix.gettimeofday () *. 1000.0))
+        ~timestamp_ms:(now_ms ())
     | Some (Ide_event_types.Gh_pr_review { pr_number }) ->
       ingest_pr_event
         ~base_path ~pr_number ~pull_request_url:"" ~pr_title:""
         ~pr_state:"open" ~repo:"" ~keeper_id ~turn_id
         ~comment_count:0 ~review_status:None
-        ~timestamp_ms:(Int64.of_float (Unix.gettimeofday () *. 1000.0))
+        ~timestamp_ms:(now_ms ())
     | Some (Ide_event_types.Gh_api_pr_create { repo; title; base = _ }) ->
       let pr_number, pull_request_url = match parse_pull_request_link_from_output output_text with
         | Some (n, url) -> (n, url)
@@ -324,19 +709,19 @@ let ingest_pr_event_from_descriptor
         ~base_path ~pr_number ~pull_request_url ~pr_title:title
         ~pr_state:"open" ~repo ~keeper_id ~turn_id
         ~comment_count:0 ~review_status:None
-        ~timestamp_ms:(Int64.of_float (Unix.gettimeofday () *. 1000.0))
+        ~timestamp_ms:(now_ms ())
     | Some (Ide_event_types.Gh_api_pr_merge { repo; pr_number }) ->
       ingest_pr_event
         ~base_path ~pr_number ~pull_request_url:"" ~pr_title:""
         ~pr_state:"merged" ~repo ~keeper_id ~turn_id
         ~comment_count:0 ~review_status:None
-        ~timestamp_ms:(Int64.of_float (Unix.gettimeofday () *. 1000.0))
+        ~timestamp_ms:(now_ms ())
     | Some (Ide_event_types.Gh_api_pr_comment { repo; pr_number; body = _ }) ->
       ingest_pr_event
         ~base_path ~pr_number ~pull_request_url:"" ~pr_title:""
         ~pr_state:"open" ~repo ~keeper_id ~turn_id
         ~comment_count:1 ~review_status:None
-        ~timestamp_ms:(Int64.of_float (Unix.gettimeofday () *. 1000.0))
+        ~timestamp_ms:(now_ms ())
     | Some (Ide_event_types.Gh_issue_create _ | Ide_event_types.Gh_issue_close _ | Ide_event_types.Git_push _ | Ide_event_types.Git_commit _ | Ide_event_types.Pipe_chain _ | Ide_event_types.Generic)
     | None ->
       (* Not a PR operation — fall back to heuristic output parsing *)
@@ -359,7 +744,7 @@ let ingest_pr_event_from_descriptor
             ~base_path ~pr_number ~pull_request_url ~pr_title:""
             ~pr_state:"open" ~repo ~keeper_id ~turn_id
             ~comment_count:0 ~review_status:None
-            ~timestamp_ms:(Int64.of_float (Unix.gettimeofday () *. 1000.0))
+            ~timestamp_ms:(now_ms ())
         | None -> ()
 
 (** Try to detect PR creation from Execute tool output and ingest a PR event.
@@ -403,5 +788,5 @@ let ingest_pr_event_from_hook
         ~turn_id
         ~comment_count:0
         ~review_status:None
-        ~timestamp_ms:(Int64.of_float (Unix.gettimeofday () *. 1000.0))
+        ~timestamp_ms:(now_ms ())
     | None -> ()

--- a/lib/ide/ide_bridge.mli
+++ b/lib/ide/ide_bridge.mli
@@ -3,6 +3,37 @@
 
 open Ide_event_types
 
+type event_kind =
+  | Tool
+  | Turn
+  | Pr
+
+val event_kind_of_string : string -> event_kind option
+val event_kind_to_string : event_kind -> string
+
+val list_events :
+  base_path:string ->
+  ?partition:Ide_paths.partition ->
+  ?kind:event_kind ->
+  ?keeper_id:string ->
+  ?limit:int ->
+  ?offset:int ->
+  unit ->
+  Yojson.Safe.t list
+
+val list_cursors :
+  base_path:string ->
+  ?partition:Ide_paths.partition ->
+  ?keeper_id:string ->
+  ?file_path:string ->
+  ?limit:int ->
+  ?offset:int ->
+  unit ->
+  Yojson.Safe.t list
+(** Return latest valid cursor records, newest first. Cursor records are
+    produced from tool hooks only when the hook input contains a non-empty
+    file path and a positive line number. *)
+
 val ingest_tool_event :
   base_path:string ->
   tool_name:string ->

--- a/lib/keeper/keeper_keepalive_signal.ml
+++ b/lib/keeper/keeper_keepalive_signal.ml
@@ -39,6 +39,22 @@ let register_record_tool_skipped (f : (keeper_name:string -> tool_name:string ->
   record_tool_skipped_callback := f
 ;;
 
+let record_execute_output_callback
+  : (keeper_name:string ->
+     task_id:string option ->
+     stdout:string ->
+     stderr:string ->
+     status:Yojson.Safe.t ->
+     unit)
+      ref
+  =
+  ref
+    (fun ~keeper_name:_ ~task_id:_ ~stdout:_ ~stderr:_ ~status:_ -> ())
+
+let register_record_execute_output f =
+  record_execute_output_callback := f
+;;
+
 (* Skip log throttle removed with manual_reconcile blocker — no more
    sticky reconcile state means no flood of "reconcile pending" skip logs. *)
 

--- a/lib/keeper/keeper_keepalive_signal.mli
+++ b/lib/keeper/keeper_keepalive_signal.mli
@@ -50,6 +50,24 @@ val register_record_tool_skipped :
   (keeper_name:string -> tool_name:string -> reason_code:string -> unit) ->
   unit
 
+val record_execute_output_callback :
+  (keeper_name:string ->
+   task_id:string option ->
+   stdout:string ->
+   stderr:string ->
+   status:Yojson.Safe.t ->
+   unit)
+    ref
+
+val register_record_execute_output :
+  (keeper_name:string ->
+   task_id:string option ->
+   stdout:string ->
+   stderr:string ->
+   status:Yojson.Safe.t ->
+   unit) ->
+  unit
+
 
 
 

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -427,6 +427,21 @@ let handle_tool_execute_typed
               then result.stdout
               else result.stdout ^ result.stderr
             in
+            (try
+               !Keeper_keepalive_signal.record_execute_output_callback
+                 ~keeper_name:meta.name
+                 ~task_id:
+                   (Option.map Keeper_id.Task_id.to_string meta.current_task_id)
+                 ~stdout:result.stdout
+                 ~stderr:result.stderr
+                 ~status:(Keeper_alerting_path.process_status_to_json result.status)
+             with
+             | Eio.Cancel.Cancelled _ as e -> raise e
+             | exn ->
+               Log.Dashboard.warn
+                 "execute output callback failed keeper=%s: %s"
+                 meta.name
+                 (Printexc.to_string exn));
             let failure_error_fields =
               match result.status, String.trim result.stderr with
               | Unix.WEXITED 0, _ | _, "" -> []

--- a/lib/server/server_ide_http.ml
+++ b/lib/server/server_ide_http.ml
@@ -71,7 +71,52 @@ let resolve_partition_for_query ~state ~uri =
 let json_error message = `Assoc [ "ok", `Bool false; "error", `String message ]
 let json_ok data = `Assoc [ "ok", `Bool true; "data", data ]
 
-let build_presence_snapshot state =
+let parse_positive_int_query ?(default = 50) ?(max_value = 200) uri name =
+  match Uri.get_query_param uri name with
+  | Some s ->
+    (match int_of_string_opt s with
+     | Some n when n > 0 -> min n max_value
+     | _ -> default)
+  | None -> default
+;;
+
+let parse_non_negative_int_query ?(default = 0) uri name =
+  match Uri.get_query_param uri name with
+  | Some s ->
+    (match int_of_string_opt s with
+     | Some n when n > 0 -> n
+     | _ -> default)
+  | None -> default
+;;
+
+let event_kind_param uri =
+  match Uri.get_query_param uri "kind" with
+  | None -> Ok None
+  | Some raw ->
+    (match String.trim raw with
+     | "" | "all" -> Ok None
+     | kind ->
+       (match Ide_bridge.event_kind_of_string kind with
+        | Some parsed -> Ok (Some parsed)
+        | None -> Error "kind must be one of tool, turn, pr, all"))
+;;
+
+let keeper_id_param uri =
+  match Uri.get_query_param uri "keeper_id" with
+  | Some k when String.trim k <> "" -> Some (String.trim k)
+  | _ ->
+    (match Uri.get_query_param uri "keeper" with
+     | Some k when String.trim k <> "" -> Some (String.trim k)
+     | _ -> None)
+;;
+
+let file_path_param uri =
+  match Uri.get_query_param uri "file_path" with
+  | Some p when String.trim p <> "" -> Some (String.trim p)
+  | _ -> None
+;;
+
+let runtime_id_and_branch state =
   let base = base_path_of_state state in
   let runtime_id =
     let base_name = Filename.basename base in
@@ -99,6 +144,12 @@ let build_presence_snapshot state =
         else ref_line)
     else "main"
   in
+  runtime_id, branch
+;;
+
+let build_presence_snapshot state =
+  let base = base_path_of_state state in
+  let runtime_id, branch = runtime_id_and_branch state in
   let entries =
     let agents = Client_registry_eio.list_active ~within_seconds:300.0 () in
     List.map
@@ -121,6 +172,35 @@ let build_presence_snapshot state =
     ; "supervisor", `String "local"
     ; "connected", `Bool true
     ; "entries", `List entries
+    ]
+;;
+
+let build_cursor_snapshot state uri =
+  let base = base_path_of_state state in
+  let runtime_id, branch = runtime_id_and_branch state in
+  let partition = resolve_partition_for_query ~state ~uri in
+  let keeper_id = keeper_id_param uri in
+  let file_path = file_path_param uri in
+  let limit = parse_positive_int_query ~default:50 ~max_value:200 uri "limit" in
+  let offset = parse_non_negative_int_query ~default:0 uri "offset" in
+  let cursors =
+    Ide_bridge.list_cursors
+      ~base_path:base
+      ~partition
+      ?keeper_id
+      ?file_path
+      ~limit
+      ~offset
+      ()
+  in
+  `Assoc
+    [ "runtime_id", `String runtime_id
+    ; "branch", `String branch
+    ; "connected", `Bool true
+    ; "cursors", `List cursors
+    ; "count", `Int (List.length cursors)
+    ; "limit", `Int limit
+    ; "offset", `Int offset
     ]
 ;;
 
@@ -357,12 +437,72 @@ let add_routes router =
            reqd)
       request
       reqd)
+  |> Http.Router.get "/api/v1/ide/events" (fun request reqd ->
+    with_public_read
+      (fun state _req reqd ->
+         let uri = Uri.of_string request.target in
+         match event_kind_param uri with
+         | Error msg ->
+           Http.Response.json_value
+             ~status:`Bad_request
+             ~request
+             (json_error msg)
+             reqd
+         | Ok kind ->
+           let base = base_path_of_state state in
+           let partition = resolve_partition_for_query ~state ~uri in
+           let keeper_id = keeper_id_param uri in
+           let limit = parse_positive_int_query ~default:50 ~max_value:200 uri "limit" in
+           let offset = parse_non_negative_int_query ~default:0 uri "offset" in
+           let events =
+             Ide_bridge.list_events
+               ~base_path:base
+               ~partition
+               ?kind
+               ?keeper_id
+               ~limit
+               ~offset
+               ()
+           in
+           let kind_json =
+             match kind with
+             | Some k -> `String (Ide_bridge.event_kind_to_string k)
+             | None -> `String "all"
+           in
+           let result =
+             `Assoc
+               [ "events", `List events
+               ; "count", `Int (List.length events)
+               ; "kind", kind_json
+               ; "limit", `Int limit
+               ; "offset", `Int offset
+               ]
+           in
+           Http.Response.json_value
+             ~compress:true
+             ~request
+             (json_ok result)
+             reqd)
+      request
+      reqd)
   (* [build_presence_snapshot] extracted in main — conflict resolved by taking
      main's helper call instead of our inline construction. *)
   |> Http.Router.get "/api/v1/ide/presence" (fun request reqd ->
     with_public_read
       (fun state _req reqd ->
          let snapshot = build_presence_snapshot state in
+         Http.Response.json_value
+           ~compress:true
+           ~request
+           (json_ok snapshot)
+           reqd)
+      request
+      reqd)
+  |> Http.Router.get "/api/v1/ide/cursors" (fun request reqd ->
+    with_public_read
+      (fun state _req reqd ->
+         let uri = Uri.of_string request.target in
+         let snapshot = build_cursor_snapshot state uri in
          Http.Response.json_value
            ~compress:true
            ~request
@@ -412,6 +552,56 @@ let add_routes router =
              | exn ->
                Log.Server.error
                  "IDE presence SSE loop exited: %s"
+                 (Printexc.to_string exn);
+               Httpun.Body.Writer.close writer)
+         | _ -> Httpun.Body.Writer.close writer)
+      request
+      reqd)
+  |> Http.Router.get "/api/v1/ide/cursors/stream" (fun request reqd ->
+    with_public_read
+      (fun state _req inner_reqd ->
+         let uri = Uri.of_string request.target in
+         let origin = get_origin request in
+         let headers =
+           Httpun.Headers.of_list
+             ([ "content-type", "text/event-stream"
+              ; "cache-control", "no-cache"
+              ; "connection", "keep-alive"
+              ; "x-accel-buffering", "no"
+              ]
+              @ cors_headers origin)
+         in
+         let response = Httpun.Response.create ~headers `OK in
+         let writer = Httpun.Reqd.respond_with_streaming inner_reqd response in
+         let write_snapshot () =
+           let snapshot_json =
+             Yojson.Safe.to_string (build_cursor_snapshot state uri)
+           in
+           let event = Printf.sprintf "data: %s\n\n" snapshot_json in
+           Httpun.Body.Writer.write_string writer event
+         in
+         write_snapshot ();
+         match state.Mcp_server.sw, state.Mcp_server.clock with
+         | Some sw, Some clock ->
+           Eio.Fiber.fork ~sw (fun () ->
+             let rec loop () =
+               (try
+                  Eio.Time.sleep clock 30.0;
+                  write_snapshot ();
+                  loop ()
+                with
+                | Eio.Cancel.Cancelled _ as e -> raise e
+                | exn ->
+                  Log.Server.debug
+                    "IDE cursor SSE ping loop error: %s"
+                    (Printexc.to_string exn));
+               Httpun.Body.Writer.close writer
+             in
+             try loop () with
+             | Eio.Cancel.Cancelled _ as e -> raise e
+             | exn ->
+               Log.Server.error
+                 "IDE cursor SSE loop exited: %s"
                  (Printexc.to_string exn);
                Httpun.Body.Writer.close writer)
          | _ -> Httpun.Body.Writer.close writer)

--- a/lib/server/server_ide_http.mli
+++ b/lib/server/server_ide_http.mli
@@ -6,8 +6,11 @@
     - POST /api/v1/ide/annotations
     - DELETE /api/v1/ide/annotations/:id
     - GET  /api/v1/ide/regions
+    - GET  /api/v1/ide/events
     - GET  /api/v1/ide/presence
     - GET  /api/v1/ide/presence/stream
+    - GET  /api/v1/ide/cursors
+    - GET  /api/v1/ide/cursors/stream
 
     All routes use the workspace base resolution from
     {!Server_routes_http_routes_workspace} so the IDE reads/writes

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -38,6 +38,118 @@ let respond_dashboard_ok ?request reqd =
     (`Assoc [ ("ok", `Bool true) ])
     reqd
 
+let execute_output_heartbeat_s = 15.0
+
+let handle_execute_output_stream ~sw ~clock request reqd =
+  with_public_read
+    (fun _state req inner_reqd ->
+       let path = Http.Request.path req in
+       let keeper =
+         match
+           Server_utils.extract_path_param
+             ~prefix:"/api/dashboard/execute-output/"
+             path
+         with
+         | Some value -> Some value
+         | None ->
+           Server_utils.extract_path_param
+             ~prefix:"/api/v1/dashboard/execute-output/"
+             path
+       in
+       match keeper with
+       | None ->
+         respond_dashboard_error
+           ~status:`Bad_request
+           ~request:req
+           inner_reqd
+           "keeper path parameter is required"
+       | Some keeper ->
+         let keeper_name = Uri.pct_decode keeper |> String.trim in
+         let origin = get_origin req in
+         let headers =
+           Httpun.Headers.of_list
+             ([ "content-type", "text/event-stream"
+              ; "cache-control", "no-cache"
+              ; "connection", "keep-alive"
+              ; "x-accel-buffering", "no"
+              ]
+              @ cors_headers origin)
+         in
+         let response = Httpun.Response.create ~headers `OK in
+         let writer = Httpun.Reqd.respond_with_streaming inner_reqd response in
+         let closed = ref false in
+         let close_stream () =
+           if not !closed
+           then (
+             closed := true;
+             try Httpun.Body.Writer.close writer with
+             | exn ->
+               Log.Dashboard.warn
+                 "execute output stream close failed: %s"
+                 (Printexc.to_string exn))
+         in
+         let write_string data =
+           if !closed
+           then false
+           else (
+             try
+               Httpun.Body.Writer.write_string writer data;
+               true
+             with
+             | Eio.Cancel.Cancelled _ as e -> raise e
+             | exn ->
+               Log.Dashboard.warn
+                 "execute output stream write failed: %s"
+                 (Printexc.to_string exn);
+               close_stream ();
+               false)
+         in
+         let write_json json =
+           write_string (Dashboard_execute_output.sse_frame json)
+         in
+         match Dashboard_execute_output.subscribe ~keeper_name with
+         | None ->
+           (* fire-and-forget: best-effort terminal event before closing stream. *)
+           ignore (write_json (Dashboard_execute_output.event_json ~keeper_name));
+           close_stream ()
+         | Some subscriber ->
+           let wrote_initial =
+             write_string "retry: 1500\n\n"
+             && write_json (Dashboard_execute_output.event_json ~keeper_name)
+           in
+           if not wrote_initial
+           then Dashboard_execute_output.unsubscribe subscriber
+           else
+             Eio.Fiber.fork ~sw (fun () ->
+               Eio.Switch.run (fun stream_sw ->
+                 Eio.Switch.on_release stream_sw (fun () ->
+                   Dashboard_execute_output.unsubscribe subscriber;
+                   close_stream ());
+                 let rec loop () =
+                   if not !closed
+                   then (
+                     match
+                       Eio.Time.with_timeout clock execute_output_heartbeat_s (fun () ->
+                         Ok (Dashboard_execute_output.take_event subscriber))
+                     with
+                     | Ok event ->
+                       if
+                         write_json
+                           (Dashboard_execute_output.stream_event_json event)
+                       then loop ()
+                     | Error `Timeout ->
+                       if write_string ": heartbeat\n\n" then loop ())
+                 in
+                 try loop () with
+                 | Eio.Cancel.Cancelled _ as e -> raise e
+                 | exn ->
+                   Log.Dashboard.warn
+                     "execute output stream loop failed: %s"
+                     (Printexc.to_string exn);
+                   close_stream ())))
+    request
+    reqd
+
 let runtime_config_raw_json ~path ~source_text ~reloaded =
   `Assoc
     [ ("ok", `Bool true)
@@ -82,6 +194,12 @@ let add_routes ~sw ~clock router =
            handle_broadcast state agent_name reqd body_str
          )
        ) request reqd)
+  |> Http.Router.prefix_get
+       "/api/dashboard/execute-output/"
+       (handle_execute_output_stream ~sw ~clock)
+  |> Http.Router.prefix_get
+       "/api/v1/dashboard/execute-output/"
+       (handle_execute_output_stream ~sw ~clock)
 
   (* Batch dashboard endpoint: single request replaces 4 separate API calls *)
   |> Http.Router.get "/api/v1/dashboard" (fun request reqd ->

--- a/reports/dashboard-ide-boundary-20260607.html
+++ b/reports/dashboard-ide-boundary-20260607.html
@@ -1,0 +1,805 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Dashboard IDE Boundary Report - 2026-06-07</title>
+  <style>
+    :root {
+      --bg: #f7f7f4;
+      --panel: #ffffff;
+      --panel-2: #f0f3f6;
+      --ink: #20242a;
+      --muted: #5f6875;
+      --border: #d9dee5;
+      --accent: #1768ac;
+      --ok: #177245;
+      --warn: #9a5b00;
+      --bad: #a43232;
+      --code: #111827;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--ink);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.55;
+    }
+
+    main {
+      width: min(1180px, calc(100vw - 40px));
+      margin: 0 auto;
+      padding: 32px 0 56px;
+    }
+
+    header {
+      padding: 28px 0 18px;
+      border-bottom: 2px solid var(--ink);
+      margin-bottom: 24px;
+    }
+
+    h1, h2, h3 {
+      margin: 0;
+      line-height: 1.2;
+    }
+
+    h1 {
+      font-size: 30px;
+      letter-spacing: 0;
+    }
+
+    h2 {
+      margin-top: 32px;
+      padding-top: 20px;
+      border-top: 1px solid var(--border);
+      font-size: 22px;
+    }
+
+    h3 {
+      margin-top: 20px;
+      font-size: 16px;
+    }
+
+    p { margin: 10px 0; }
+
+    code, pre {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    }
+
+    code {
+      color: var(--code);
+      background: #eef1f4;
+      padding: 1px 4px;
+      border-radius: 4px;
+    }
+
+    pre {
+      margin: 12px 0;
+      padding: 14px 16px;
+      background: #101820;
+      color: #eef5ff;
+      border-radius: 6px;
+      overflow-x: auto;
+      line-height: 1.45;
+      font-size: 13px;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 14px 0 22px;
+      background: var(--panel);
+      border: 1px solid var(--border);
+      font-size: 13px;
+    }
+
+    th, td {
+      padding: 10px 12px;
+      border: 1px solid var(--border);
+      vertical-align: top;
+      text-align: left;
+    }
+
+    th {
+      background: var(--panel-2);
+      font-weight: 700;
+      color: #1d2733;
+    }
+
+    ul {
+      margin: 8px 0 12px;
+      padding-left: 22px;
+    }
+
+    li { margin: 5px 0; }
+
+    .meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: 14px;
+      color: var(--muted);
+      font-size: 13px;
+    }
+
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 4px 8px;
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      background: var(--panel);
+    }
+
+    .summary {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 12px;
+      margin: 18px 0 24px;
+    }
+
+    .card {
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-left: 4px solid var(--accent);
+      border-radius: 6px;
+      padding: 14px;
+      min-height: 120px;
+    }
+
+    .card strong {
+      display: block;
+      margin-bottom: 6px;
+      font-size: 15px;
+    }
+
+    .severity {
+      display: inline-block;
+      min-width: 38px;
+      padding: 2px 6px;
+      border-radius: 4px;
+      color: #fff;
+      text-align: center;
+      font-weight: 700;
+      font-size: 12px;
+    }
+
+    .p0 { background: var(--bad); }
+    .p1 { background: var(--warn); }
+    .p2 { background: var(--accent); }
+    .ok { background: var(--ok); }
+
+    .flow {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 10px;
+      margin: 14px 0;
+    }
+
+    .flow-box {
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 12px;
+      min-height: 110px;
+    }
+
+    .flow-box b {
+      display: block;
+      margin-bottom: 6px;
+      color: #14212f;
+    }
+
+    .note {
+      background: #fff8e8;
+      border: 1px solid #e9c983;
+      border-left: 4px solid var(--warn);
+      padding: 12px 14px;
+      border-radius: 6px;
+      margin: 12px 0;
+    }
+
+    .bad-note {
+      background: #fff1f1;
+      border-color: #e6b5b5;
+      border-left-color: var(--bad);
+    }
+
+    .good-note {
+      background: #eefaf2;
+      border-color: #b8dcc5;
+      border-left-color: var(--ok);
+    }
+
+    .small {
+      font-size: 12px;
+      color: var(--muted);
+    }
+
+    @media (max-width: 900px) {
+      main { width: min(100vw - 24px, 1180px); padding-top: 16px; }
+      .summary, .flow { grid-template-columns: 1fr; }
+      table { font-size: 12px; }
+      th, td { padding: 8px; }
+    }
+  </style>
+</head>
+<body>
+<main>
+  <header>
+    <h1>Dashboard IDE Boundary Report</h1>
+    <p>Tool, Keeper, IDE, Sandbox, Board, Task, Goal, Turn 흐름과 결합도 분석</p>
+    <div class="meta">
+      <span class="pill">작성일: 2026-06-07 KST</span>
+      <span class="pill">기준: <code>origin/main</code> @ <code>14806fe3de</code></span>
+      <span class="pill">범위: <code>dashboard/src/components/ide</code>, <code>lib/ide</code>, <code>lib/keeper</code>, <code>lib/server</code></span>
+      <span class="pill">산출물: 정적 HTML 감사 보고서</span>
+    </div>
+  </header>
+
+  <section>
+    <h2>1. 핵심 결론</h2>
+    <div class="summary">
+      <div class="card">
+        <strong>IDE는 독립 모듈이 아니라 cross-domain facade다</strong>
+        <p><code>ide-shell.ts</code>가 route, Keeper, workspace, Goal/Task, Board, PR/Git/Log/Telemetry, LSP, terminal drawer를 한 곳에서 조합한다.</p>
+      </div>
+      <div class="card">
+        <strong>데이터 plane이 7갈래다</strong>
+        <p>dashboard projection, workspace REST, <code>.masc-ide</code> JSONL, activity graph, board/decision fetch, presence SSE, LSP WS가 frontend에서 join된다.</p>
+      </div>
+      <div class="card">
+        <strong>구현 누락과 schema drift가 있다</strong>
+        <p><code>.masc-ide/tool_events</code> read API, execute-output backend, presence cursor payload가 현재 코드 기준으로 비어 있거나 불일치한다.</p>
+      </div>
+    </div>
+
+    <div class="bad-note">
+      <strong>판정:</strong> IDE boundary는 “컴포넌트가 도메인 상태를 읽는 정도”를 넘어섰다. 현재 구조는
+      <code>routeLinksForContext</code>, <code>IdeShell</code>, <code>IdeActivityPanel</code>, <code>IdeKeeperWorkPanel</code>이 domain adapter 역할까지 같이 수행한다.
+      개선은 UI 리팩토링보다 먼저 <em>context contract / event contract / presence contract</em>를 분리하는 순서가 맞다.
+    </div>
+  </section>
+
+  <section>
+    <h2>2. 전체 흐름도</h2>
+    <div class="flow">
+      <div class="flow-box">
+        <b>Runtime Producers</b>
+        <code>Keeper_agent_run</code><br>
+        <code>Keeper_run_tools_hooks</code><br>
+        <code>Keeper_tool_execute_runtime</code><br>
+        <code>Activity_graph.emit</code>
+      </div>
+      <div class="flow-box">
+        <b>Storage / Projection</b>
+        <code>.masc-ide/*.jsonl</code><br>
+        <code>.masc/activity-events</code><br>
+        dashboard execution/planning/memory snapshots<br>
+        workspace filesystem/git
+      </div>
+      <div class="flow-box">
+        <b>HTTP / WS / SSE</b>
+        <code>/api/v1/ide/*</code><br>
+        <code>/api/v1/workspace/*</code><br>
+        <code>/api/v1/activity/events</code><br>
+        dashboard WS surfaces<br>
+        <code>/api/v1/ide/lsp</code>
+      </div>
+      <div class="flow-box">
+        <b>IDE Consumers</b>
+        <code>IdeShell</code><br>
+        <code>IdeDataWorkspaceStore</code><br>
+        <code>IdeContextLens</code><br>
+        <code>IdeActivityPanel</code><br>
+        <code>IdeKeeperWorkPanel</code>
+      </div>
+    </div>
+
+    <pre>Route hash / global dashboard state
+  -> IdeShell route parser
+  -> focusIdeContextAnchor(activeIdeFile + ideContextFocus)
+  -> IdeDataWorkspaceStore
+  -> workspace tree/file + git blame/diff + IDE annotations/regions
+  -> Editor / Context Lens / Explorer / Toolbar
+
+Keeper turn
+  -> Keeper_agent_run emits turn_event to .masc-ide
+  -> Tool hook emits tool_event and PR event to .masc-ide
+  -> Activity_graph emits separate activity events
+  -> IDE consumes activity events, but not yet .masc-ide tool/turn/pr events
+
+Tool Execute
+  -> typed Shell IR
+  -> sandbox/local dispatch
+  -> success JSON includes command_descriptor
+  -> Ide_bridge parses descriptor
+  -> PR/Git semantics are persisted as IDE bridge events
+  -> frontend route links infer Goal/Task/Git/Telemetry from task/cursor/context
+</pre>
+  </section>
+
+  <section>
+    <h2>3. Domain 흐름 매트릭스</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Domain</th>
+          <th>주요 SSOT / 생산자</th>
+          <th>API / 저장소</th>
+          <th>IDE 소비자</th>
+          <th>결합 상태</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Tool</td>
+          <td><code>Keeper_run_tools_hooks.assemble_hooks</code>의 <code>on_tool_executed</code>, <code>Keeper_tool_execute_runtime</code> typed Shell IR 실행</td>
+          <td><code>.masc-ide/tool_events.jsonl</code>, <code>.masc-ide/pr_events.jsonl</code>, tool result JSON의 <code>command_descriptor</code></td>
+          <td><code>IdeActivityPanel</code>, <code>ExecuteOutputDrawer</code>, <code>IdeContextLens</code>가 activity/context/task/cursor를 조합</td>
+          <td><span class="severity p0">P0</span> producer는 있으나 tool/turn/pr IDE events를 읽는 REST/consumer가 보이지 않는다.</td>
+        </tr>
+        <tr>
+          <td>Keeper</td>
+          <td>dashboard execution snapshot, Keeper registry/meta, active keeper signal</td>
+          <td>dashboard WS <code>execution</code>, <code>/api/v1/agents</code>, <code>/api/v1/status</code>, <code>/api/v1/ide/presence</code></td>
+          <td><code>IdeShell</code>, <code>IdeKeeperWorkPanel</code>, <code>IdeInterject</code>, <code>InspectorKeeperBDI</code>, presence strip</td>
+          <td><span class="severity p1">P1</span> route keeper가 없으면 global active keeper 또는 첫 keeper로 fallback되어 IDE context가 암묵적으로 바뀐다.</td>
+        </tr>
+        <tr>
+          <td>IDE</td>
+          <td><code>Ide_annotations</code>, <code>Ide_region_tracker</code>, <code>Ide_bridge</code></td>
+          <td><code>.masc-ide/annotations.jsonl</code>, <code>regions.jsonl</code>, <code>tool_events.jsonl</code>, <code>turn_events.jsonl</code>, <code>pr_events.jsonl</code></td>
+          <td><code>IdeDataWorkspaceStore</code>, <code>IdeEditor</code>, <code>IdeContextLens</code>, <code>IdeMemoryPanel</code></td>
+          <td><span class="severity p1">P1</span> annotations/regions는 REST가 있으나 bridge events는 read surface가 빠져 있다.</td>
+        </tr>
+        <tr>
+          <td>Sandbox</td>
+          <td><code>Keeper_sandbox_runner.effective_sandbox_profile</code>, Docker/local dispatch, workspace resolver</td>
+          <td><code>/api/v1/workspace/tree</code>, <code>/api/v1/workspace/file</code>, <code>/api/v1/git/blame</code>, <code>/api/v1/git/diff</code></td>
+          <td><code>IdeDataWorkspaceStore</code>, editor ownership/diff, status bar workspace source</td>
+          <td><span class="severity p1">P1</span> IDE는 repo/playground/server-base 세 filesystem view를 한 화면에서 조합한다.</td>
+        </tr>
+        <tr>
+          <td>Board</td>
+          <td>Board dispatch + dashboard memory projection + Activity_graph board events</td>
+          <td><code>fetchBoard</code>, dashboard memory snapshot, <code>/api/v1/activity/events</code></td>
+          <td><code>IdeConversationRail</code>, <code>IdeActivityPanel</code>, <code>routeLinksForContext</code></td>
+          <td><span class="severity p1">P1</span> board post text에서 PR/Task/Git refs를 regex로 재추출한다.</td>
+        </tr>
+        <tr>
+          <td>Task</td>
+          <td>dashboard execution snapshot <code>tasks</code>, Keeper current task, tool hook task scope</td>
+          <td>dashboard WS <code>execution</code>, <code>selectedTask</code>, activity context</td>
+          <td><code>IdeDataWorkspaceStore</code>, <code>IdeKeeperWorkPanel</code>, <code>ExecuteOutputDrawer</code></td>
+          <td><span class="severity p1">P1</span> selected dashboard task가 IDE annotation query filter에 직접 들어간다.</td>
+        </tr>
+        <tr>
+          <td>Goal</td>
+          <td>dashboard planning snapshot <code>goals</code>, task goal_id</td>
+          <td>dashboard WS <code>goals</code>, <code>/api/v1/dashboard/planning</code></td>
+          <td><code>IdeKeeperWorkPanel</code>, context routes, status bar</td>
+          <td><span class="severity p2">P2</span> Goal progress는 IDE panel에서 dashboard goal helper를 직접 호출한다.</td>
+        </tr>
+        <tr>
+          <td>Turn</td>
+          <td><code>Keeper_agent_run</code> start/end, unified turn success activity emit</td>
+          <td><code>.masc-ide/turn_events.jsonl</code>, <code>activity-events/YYYY-MM/DD.jsonl</code></td>
+          <td><code>IdeActivityPanel</code>, context lens, trace store</td>
+          <td><span class="severity p1">P1</span> turn 이벤트 저장소가 두 개이며 IDE는 activity graph 쪽만 실질적으로 소비한다.</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section>
+    <h2>4. 코드 레벨 흐름표</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>#</th>
+          <th>흐름</th>
+          <th>생산자 / 경계</th>
+          <th>소비자</th>
+          <th>코드 근거</th>
+          <th>해석</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>1</td>
+          <td>URL route -> IDE focus</td>
+          <td><code>IdeShell</code>가 route params를 읽어 file/line/surface/keeper/goal/task/board/comment/pr/git/log/session/operation/worker/telemetry로 펼침</td>
+          <td><code>focusIdeContextAnchor</code>, status bar, terminal drawer, panels</td>
+          <td><code>dashboard/src/components/ide/ide-shell.ts:122-128</code>, <code>446-546</code></td>
+          <td>route parsing이 IDE shell 안에 크고, keeper fallback이 global state에 의존한다.</td>
+        </tr>
+        <tr>
+          <td>2</td>
+          <td>IDE file -> workspace data</td>
+          <td><code>activeIdeFile</code>, <code>activeKeeperName</code>, active repo id, <code>selectedTask</code></td>
+          <td>tree/file/blame/diff/annotations/regions store</td>
+          <td><code>dashboard/src/components/ide/ide-data-workspace-store.ts:1-35</code>, <code>151-243</code></td>
+          <td>IDE data store가 workspace API뿐 아니라 Keeper와 Goal/Task UI state를 직접 import한다.</td>
+        </tr>
+        <tr>
+          <td>3</td>
+          <td>workspace browsing</td>
+          <td><code>classify_workspace_query</code>로 project/repo/playground base를 결정</td>
+          <td>tree/file/blame/diff endpoint</td>
+          <td><code>lib/server/server_routes_http_routes_workspace.ml:561-691</code>, <code>dashboard/src/api/workspace.ts:44-113</code></td>
+          <td>IDE가 보는 파일과 <code>.masc-ide</code> 저장 위치가 다르다. report/repo/playground context가 섞이면 trace가 어긋날 수 있다.</td>
+        </tr>
+        <tr>
+          <td>4</td>
+          <td>annotations / regions</td>
+          <td><code>server_ide_http</code>가 server base <code>.masc-ide</code> partition을 읽고 쓴다</td>
+          <td><code>fetchIdeAnnotations</code>, <code>fetchIdeRegions</code>, editor/context lens/memory panel</td>
+          <td><code>lib/server/server_ide_http.ml:129-359</code>, <code>dashboard/src/api/ide.ts:17-123</code></td>
+          <td>annotation schema는 Goal/Task/Board/Comment/PR/Git/Log/Runtime ids를 이미 모두 품고 있다. IDE-local contract라기보다 workspace context contract다.</td>
+        </tr>
+        <tr>
+          <td>5</td>
+          <td>Keeper turn event</td>
+          <td><code>Keeper_agent_run</code> start/end가 <code>Ide_bridge.ingest_turn_event</code> 호출</td>
+          <td><code>.masc-ide/turn_events.jsonl</code></td>
+          <td><code>lib/keeper/keeper_agent_run.ml:112-149</code>, <code>lib/ide/ide_bridge.ml:62-87</code></td>
+          <td>write path는 있으나 현재 frontend read path는 검색되지 않는다.</td>
+        </tr>
+        <tr>
+          <td>6</td>
+          <td>Tool call -> IDE event</td>
+          <td><code>on_tool_executed</code> hook에서 outcome/typed_outcome/duration/input/output을 bridge로 전달</td>
+          <td><code>.masc-ide/tool_events.jsonl</code>, PR descriptor event</td>
+          <td><code>lib/keeper/keeper_run_tools_hooks.ml:119-184</code>, <code>lib/ide/ide_bridge.ml:188-224</code></td>
+          <td>Tool event semantic extraction이 Keeper hook 안에서 IDE bridge로 직결된다.</td>
+        </tr>
+        <tr>
+          <td>7</td>
+          <td>Tool execute -> command descriptor</td>
+          <td>typed Shell IR 성공 결과에 <code>Ide_command_descriptor.compute</code> 결과를 붙임</td>
+          <td><code>Ide_bridge.extract_descriptor_from_output</code>가 PR/Git 의미로 재해석</td>
+          <td><code>lib/keeper/keeper_tool_execute_runtime.ml:222-295</code>, <code>441-449</code>, <code>lib/ide/ide_command_descriptor.ml:41-127</code></td>
+          <td>Shell IR schema 변화가 IDE PR/Git event 생성에 직접 영향을 준다.</td>
+        </tr>
+        <tr>
+          <td>8</td>
+          <td>Tool write -> code regions</td>
+          <td><code>Ide_region_tracker.ingest_tool_call</code>가 <code>write_file/edit_file/apply_patch</code> args에서 path/diff/content를 추출</td>
+          <td><code>.masc-ide/regions.jsonl</code>, editor region overlay</td>
+          <td><code>lib/ide/ide_region_tracker.ml:105-228</code>, <code>lib/keeper/keeper_tool_filesystem_runtime.ml:433-482</code></td>
+          <td>file tool argument schema가 region producer contract다. explicit typed region event가 아니다.</td>
+        </tr>
+        <tr>
+          <td>9</td>
+          <td>Activity graph -> IDE activity</td>
+          <td><code>Activity_graph.event_to_yojson</code>가 payload/tags에서 context 생성</td>
+          <td><code>IdeActivityPanel</code>가 다시 payload/tags/context를 정규화</td>
+          <td><code>lib/activity_graph/activity_graph_types.ml:210-303</code>, <code>dashboard/src/components/ide/ide-activity-panel.ts:183-310</code></td>
+          <td>context extraction이 backend/frontend에 중복되어 drift 가능성이 높다.</td>
+        </tr>
+        <tr>
+          <td>10</td>
+          <td>Context -> route links</td>
+          <td><code>routeLinksForContext</code>가 Code/Goal/Task/Board/Comment/PR/Git/Log/Telemetry/Keeper route를 생성</td>
+          <td>toolbar, editor, activity, conversation, keeper work, terminal drawer</td>
+          <td><code>dashboard/src/components/ide/ide-context-lens.ts:1124-1269</code></td>
+          <td>이 함수는 IDE helper 위치에 있지만 실제로 dashboard-wide route contract다.</td>
+        </tr>
+        <tr>
+          <td>11</td>
+          <td>Board/Decision -> IDE conversation</td>
+          <td><code>fetchBoard</code>, <code>fetchKeeperDecisions</code>, board text regex refs</td>
+          <td><code>IdeConversationRail</code>, trace bridge</td>
+          <td><code>dashboard/src/components/ide/ide-conversation-rail.ts:74-180</code>, <code>482-512</code></td>
+          <td>Board post 내용이 operational route source가 된다. contract가 아니라 text parsing이다.</td>
+        </tr>
+        <tr>
+          <td>12</td>
+          <td>Presence / cursor</td>
+          <td><code>/api/v1/ide/presence/stream</code>은 active client snapshot을 유지하고, <code>/api/v1/ide/cursors/stream</code>은 cursor snapshot을 분리 제공함</td>
+          <td><code>keeper-cursor-overlay</code>가 cursor stream만 읽고 file_path/line/focus_mode/tool_name/turn이 있는 row만 표시</td>
+          <td><code>lib/server/server_ide_http.ml</code>, <code>lib/ide/ide_bridge.ml</code>, <code>dashboard/src/components/ide/keeper-cursor-overlay.ts</code></td>
+          <td>presence-only payload가 cursor placeholder로 승격되지 않는다. cursor row는 tool hook input에 real file/line이 있을 때만 생성된다.</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section>
+    <h2>5. 경계 실패 / 강결합 지점</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>우선순위</th>
+          <th>지점</th>
+          <th>증상</th>
+          <th>왜 문제인가</th>
+          <th>개선 방향</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><span class="severity p0">P0</span></td>
+          <td><code>.masc-ide/tool_events|turn_events|pr_events</code></td>
+          <td>write producer와 tests는 있지만 HTTP read endpoint/frontend consumer가 검색되지 않는다.</td>
+          <td>Keeper/Tool/Turn bridge가 운영 화면에 닿지 않아, 저장 비용만 있고 IDE 분석에는 activity graph를 우회 사용한다.</td>
+          <td><code>GET /api/v1/ide/events?kind=tool|turn|pr</code>를 만들고 Activity/Trace store가 이 stream을 first-class source로 읽게 하거나, producer를 제거한다.</td>
+        </tr>
+        <tr>
+          <td><span class="severity p1">P1</span></td>
+          <td>Execute output drawer</td>
+          <td>2026-06-07 slice에서 <code>/api/dashboard/execute-output/:keeper</code>와 <code>/api/v1/dashboard/execute-output/:keeper</code> SSE route가 추가됐고, 후속 slice에서 line ring + long-lived SSE tail로 확장됐다.</td>
+          <td>drawer backend 부재 P0와 completed-output line tail은 닫혔다. 다만 현재 producer는 Execute completion boundary 기반이라 process 실행 중 stdout/stderr capture는 아직 별도 확장 대상이다.</td>
+          <td>후속은 executor/process drain 지점에서 RFC-0025식 running stdout/stderr line producer를 붙이는 작업이다.</td>
+        </tr>
+        <tr>
+          <td><span class="severity p1">P1</span></td>
+          <td>Presence stream schema</td>
+          <td>2026-06-07 slice에서 <code>/api/v1/ide/cursors</code>와 <code>/api/v1/ide/cursors/stream</code>이 추가됐다. 기존 presence stream은 presence strip 전용 contract로 남는다.</td>
+          <td>placeholder cursor, line 0 guard, stale focus P0는 닫혔다. 아직 editor/LSP native cursor producer는 없고 tool-hook input 기반 cursor만 생성된다.</td>
+          <td>후속은 editor/LSP cursor producer와 IDE WS snapshot surface에 cursor freshness를 포함하는 작업이다.</td>
+        </tr>
+        <tr>
+          <td><span class="severity p1">P1</span></td>
+          <td><code>IdeShell</code></td>
+          <td>IDE 화면 조립, route parser, terminal policy, statusbar domain chip, keeper fallback을 한 파일이 소유한다.</td>
+          <td>IDE를 수정할 때 Keeper/Board/Goal/Telemetry route 규칙을 같이 건드리게 된다.</td>
+          <td><code>ide-route-context.ts</code>, <code>ide-runtime-view-model.ts</code>, <code>ide-layout-shell.ts</code>로 분리한다.</td>
+        </tr>
+        <tr>
+          <td><span class="severity p1">P1</span></td>
+          <td><code>IdeDataWorkspaceStore</code></td>
+          <td><code>activeKeeperName</code>과 <code>selectedTask</code>를 직접 import하여 annotation query를 필터링한다.</td>
+          <td>IDE file view가 dashboard Goal/Task selection state에 의해 암묵적으로 바뀐다.</td>
+          <td>store 생성 input으로 explicit scope를 넘기고, default는 file/repo only로 둔다.</td>
+        </tr>
+        <tr>
+          <td><span class="severity p1">P1</span></td>
+          <td>Activity context normalization</td>
+          <td>backend <code>Activity_graph</code>와 frontend <code>IdeActivityPanel</code>이 payload/tag context 추출 규칙을 중복 보유한다.</td>
+          <td>새 id field가 추가될 때 한쪽만 갱신되면 IDE route link가 누락된다.</td>
+          <td>backend가 canonical <code>context</code>를 보장하고 frontend는 legacy fallback만 telemetry warning과 함께 유지한다.</td>
+        </tr>
+        <tr>
+          <td><span class="severity p1">P1</span></td>
+          <td><code>routeLinksForContext</code></td>
+          <td>IDE 폴더 안에 있지만 workspace/monitoring/repository route contract 전체를 안다.</td>
+          <td>Board/Goal/Task/Telemetry route 변경이 IDE 모듈 변경으로 나타난다.</td>
+          <td><code>dashboard/src/context-routing</code> 같은 dashboard-wide adapter로 승격하고 generated schema와 묶는다.</td>
+        </tr>
+        <tr>
+          <td><span class="severity p1">P1</span></td>
+          <td>annotation mutation auth</td>
+          <td><code>POST/DELETE /api/v1/ide/annotations</code>도 <code>with_public_read</code> wrapper를 사용한다.</td>
+          <td>local dashboard auth policy상 의도일 수 있으나, mutation endpoint 이름과 auth wrapper 의미가 맞지 않는다.</td>
+          <td>write auth helper로 분리하거나, local-only public write 의도를 route comment/test로 고정한다.</td>
+        </tr>
+        <tr>
+          <td><span class="severity p2">P2</span></td>
+          <td><code>IdeMemoryPanel</code></td>
+          <td>server comment에 따르면 현재 memory endpoint는 annotation 기반 memory entries만 반환한다.</td>
+          <td>Memory UI가 실제 semantic/episode memory와 다르게 보일 수 있다.</td>
+          <td>이름을 <code>IdeAnnotationMemoryPanel</code>로 좁히거나 Neo4j/pgvector memory adapter를 별도 계약으로 붙인다.</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section>
+    <h2>6. 빠진 구현 후보</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>항목</th>
+          <th>현재 상태</th>
+          <th>필요 구현</th>
+          <th>검증 기준</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>IDE event reader</td>
+          <td><code>Ide_bridge</code>가 <code>tool_events.jsonl</code>, <code>turn_events.jsonl</code>, <code>pr_events.jsonl</code>을 쓴다.</td>
+          <td><code>server_ide_http</code>에 paginated/read-only endpoint 추가. dashboard store에 event source 추가.</td>
+          <td>tool call 후 <code>/api/v1/ide/events?kind=tool</code>에서 최신 keeper/tool/turn이 보이고 IDE trace에 표시된다.</td>
+        </tr>
+        <tr>
+          <td>Live execute output backend</td>
+          <td><code>lib/dashboard/dashboard_execute_output.ml(i)</code>가 completed Execute stdout/stderr를 per-keeper byte ring과 line ring에 보관하고 snapshot + live <code>line</code>/<code>task_closed</code> SSE frame을 반환한다.</td>
+          <td>현재 Execute completion boundary에서는 long-lived line tail이 가능하다. 실행 중 drain 단계 stdout/stderr producer는 다음 P1 확장이다.</td>
+          <td><code>curl -N /api/dashboard/execute-output/sangsu</code>가 초기 <code>snapshot</code>/<code>no_task</code> 후 future <code>line</code>/<code>task_closed</code> frame을 유지한다. focused test: <code>test_dashboard_execute_output.exe</code>.</td>
+        </tr>
+        <tr>
+          <td>Cursor event producer</td>
+          <td><code>cursor_events.jsonl</code> producer가 tool hook input의 real file/line을 cursor row로 저장한다.</td>
+          <td>후속은 editor/LSP native cursor event를 같은 <code>/api/v1/ide/cursors</code> contract로 추가한다.</td>
+          <td>presence strip과 editor cursor chip이 같은 keeper/file/line을 표시하고 line 0 placeholder가 사라진다.</td>
+        </tr>
+        <tr>
+          <td>IDE WS snapshot surface</td>
+          <td>runtime bootstrap dashboard WS provider는 <code>shell/execution/operator/transport/namespace/composite/board/goals</code>만 제공한다.</td>
+          <td><code>ide</code> snapshot surface 추가: focus, annotations, regions, events, presence freshness.</td>
+          <td>WS-only dashboard 모드에서 IDE가 polling 없이 동일한 data freshness를 가진다.</td>
+        </tr>
+        <tr>
+          <td>Shared context schema</td>
+          <td>annotation, activity, route links, board text refs가 모두 비슷한 id set을 따로 정규화한다.</td>
+          <td>OCaml/TS 공통 <code>IdeContextRef</code> schema와 validator를 도입한다.</td>
+          <td>schema drift guard comment가 제거되고 null label crash test가 shared validator에서 막힌다.</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section>
+    <h2>7. 개선 순서 제안</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Phase</th>
+          <th>목표</th>
+          <th>작업</th>
+          <th>효과</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><span class="severity p0">0</span></td>
+          <td>깨진 기능과 죽은 producer 정리</td>
+          <td>IDE bridge event reader 추가, execute-output snapshot/line-tail route 연결, presence/cursor schema 분리 완료</td>
+          <td>IDE 화면의 “눌렀는데 안 되는” 지점을 제거하고 runtime evidence를 살린다.</td>
+        </tr>
+        <tr>
+          <td><span class="severity p1">1</span></td>
+          <td>Context contract 단일화</td>
+          <td><code>IdeContextRef</code> shared schema, backend context canonicalization, frontend fallback 축소</td>
+          <td>Goal/Task/Board/PR/Git/Log/Telemetry 링크 누락과 drift를 줄인다.</td>
+        </tr>
+        <tr>
+          <td><span class="severity p1">2</span></td>
+          <td>IDE facade 얇게 만들기</td>
+          <td><code>IdeShell</code>에서 route parsing/status model/terminal policy/panel data를 view-model adapter로 분리</td>
+          <td>IDE layout 변경과 runtime/domain 변경의 PR blast radius가 줄어든다.</td>
+        </tr>
+        <tr>
+          <td><span class="severity p1">3</span></td>
+          <td>Snapshot plane 정렬</td>
+          <td>dashboard WS provider에 <code>ide</code> surface 추가, activity/ide events freshness metric 노출</td>
+          <td>polling, REST, WS, SSE가 제각각 stale해지는 문제를 관측 가능하게 만든다.</td>
+        </tr>
+        <tr>
+          <td><span class="severity p2">4</span></td>
+          <td>UX 사용성 개선</td>
+          <td>terminal, activity, keeper work, context lens가 같은 route/context badge 모델을 쓰도록 정리</td>
+          <td>운영자가 “이 이벤트가 어느 Goal/Task/PR/line에서 왔는지”를 한 번에 추적한다.</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section>
+    <h2>8. 의존성 재배치 초안</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>현재 위치</th>
+          <th>현재 책임</th>
+          <th>권장 위치</th>
+          <th>분리 이유</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>components/ide/ide-context-lens.ts</code></td>
+          <td>context anchors + route link builder + text ref regex + surface count</td>
+          <td><code>dashboard/src/context-routing/</code> + <code>components/ide/context-lens-view.ts</code></td>
+          <td>route builder는 IDE가 아니라 dashboard-wide domain adapter다.</td>
+        </tr>
+        <tr>
+          <td><code>components/ide/ide-shell.ts</code></td>
+          <td>layout, route parse, statusbar, terminal selection, domain focus</td>
+          <td><code>ide-shell.ts</code>는 layout만, parser/model은 <code>ide-route-state.ts</code>/<code>ide-statusbar-model.ts</code></td>
+          <td>IDE shell을 고치면서 Keeper/Goal/Board route 규칙을 건드리지 않게 한다.</td>
+        </tr>
+        <tr>
+          <td><code>components/ide/ide-data-workspace-store.ts</code></td>
+          <td>workspace fetch + keeper/repo/task scope 구독</td>
+          <td><code>ide-workspace-store.ts</code> + explicit <code>IdeWorkspaceScope</code></td>
+          <td>selected task나 active keeper가 파일 로딩 query에 몰래 들어가지 않게 한다.</td>
+        </tr>
+        <tr>
+          <td><code>lib/ide/ide_bridge.ml</code></td>
+          <td>tool/turn/pr event write + descriptor parsing + PR event synthesis</td>
+          <td>write bridge 유지, read API는 <code>server_ide_http</code>, descriptor parse는 Shell IR event adapter로 명시</td>
+          <td>IDE write model과 Shell IR semantic model의 경계를 명확히 한다.</td>
+        </tr>
+        <tr>
+          <td><code>IdeActivityPanel</code></td>
+          <td>activity fetch + context extraction + progress model + rendering</td>
+          <td><code>run-activity-store</code>가 canonical context만 받고, panel은 rendering만</td>
+          <td>backend/frontend context derivation 중복을 없앤다.</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section>
+    <h2>9. 코드 근거 색인</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>파일</th>
+          <th>라인</th>
+          <th>근거</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr><td><code>dashboard/src/components/ide/ide-shell.ts</code></td><td>122-128, 291-376, 409-546, 601-727</td><td>keeper fallback, statusbar domain chips, route param parsing, IDE layout composition.</td></tr>
+        <tr><td><code>dashboard/src/components/ide/ide-data-workspace-store.ts</code></td><td>1-35, 151-243</td><td>active file, active keeper, selected task, repo id를 workspace fetch와 annotation query에 결합.</td></tr>
+        <tr><td><code>dashboard/src/api/ide.ts</code></td><td>17-123</td><td>annotation input/filter가 Goal/Task/Board/Comment/PR/Git/Log/Session/Operation/Worker ids를 모두 포함.</td></tr>
+        <tr><td><code>lib/server/server_ide_http.ml</code></td><td>14-69, 129-359, 373-420, 420-463</td><td>workspace base resolver, annotation/region REST, presence SSE, annotation-backed memory endpoint.</td></tr>
+        <tr><td><code>lib/keeper/keeper_agent_run.ml</code></td><td>112-149</td><td>turn start/completed를 IDE bridge로 기록.</td></tr>
+        <tr><td><code>lib/keeper/keeper_run_tools_hooks.ml</code></td><td>119-184</td><td>tool executed hook이 IDE tool event와 PR descriptor event를 기록.</td></tr>
+        <tr><td><code>lib/keeper/keeper_tool_execute_runtime.ml</code></td><td>112-180, 222-295, 441-449</td><td>typed Shell IR, sandbox profile, risk gate, command descriptor injection.</td></tr>
+        <tr><td><code>lib/ide/ide_bridge.ml</code></td><td>8-24, 188-224, 258-395</td><td>tool/turn/pr events JSONL write and descriptor-based PR event synthesis.</td></tr>
+        <tr><td><code>lib/ide/ide_region_tracker.ml</code></td><td>105-228</td><td>file-write tool args에서 code region을 추출.</td></tr>
+        <tr><td><code>lib/activity_graph/activity_graph_types.ml</code></td><td>210-303</td><td>payload/tags에서 canonical context를 생성.</td></tr>
+        <tr><td><code>dashboard/src/components/ide/ide-activity-panel.ts</code></td><td>183-310, 774-799</td><td>activity API event를 IDE RunActivityEvent로 재정규화하고 route context 생성.</td></tr>
+        <tr><td><code>dashboard/src/components/ide/ide-context-lens.ts</code></td><td>303-351, 1008-1055, 1124-1269</td><td>null guard workaround, text ref regex, dashboard route link builder.</td></tr>
+        <tr><td><code>dashboard/src/components/ide/ide-keeper-work-panel.ts</code></td><td>61-83, 331-383</td><td>global keepers/tasks/goals를 읽어 Keeper work summary 생성.</td></tr>
+        <tr><td><code>dashboard/src/components/ide/ide-conversation-rail.ts</code></td><td>74-180, 482-512</td><td>Board/decision fetch와 text ref 기반 route link 생성.</td></tr>
+        <tr><td><code>dashboard/src/api/execute-output.ts</code></td><td>45-95</td><td>frontend SSE client endpoint.</td></tr>
+        <tr><td><code>dashboard/design-system/RFC/0025-live-execute-output-drawer.md</code></td><td>72-90</td><td>execute-output server module/handler가 계획되어 있으나 현재 route 검색상 부재.</td></tr>
+        <tr><td><code>lib/server/server_runtime_bootstrap.ml</code></td><td>761-797</td><td>dashboard WS snapshot provider에 <code>ide</code> surface가 없다.</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section>
+    <h2>10. 진행 상태와 다음 작업</h2>
+    <div class="good-note">
+      <strong>2026-06-07 worktree 진행 반영:</strong>
+      <ul>
+        <li><code>Ide_bridge.list_events</code> reader를 추가하여 <code>tool_events.jsonl</code>, <code>turn_events.jsonl</code>, <code>pr_events.jsonl</code>을 newest-first, <code>kind</code>, <code>keeper_id</code>, <code>limit</code>, <code>offset</code> 기준으로 읽는다.</li>
+        <li><code>GET /api/v1/ide/events</code>를 추가했다. <code>kind=tool|turn|pr|all</code>와 기존 <code>repo_id</code>/<code>canonical_url</code> partition resolver를 사용한다.</li>
+        <li><code>dashboard/src/api/ide.ts</code>에 <code>fetchIdeEvents</code>를 추가하고, <code>IdeActivityPanel</code>이 bridge events를 기존 activity timeline/context lens/trace bridge에 병합한다.</li>
+        <li>이로써 “runtime이 IDE용 bridge events를 쓰지만 IDE가 읽지 않는” P0 gap은 read surface 기준으로 닫혔다.</li>
+        <li><code>Dashboard_execute_output</code> collector를 추가했다. completed Execute stdout/stderr를 per-keeper ring에 저장하고 <code>snapshot</code>/<code>no_task</code> SSE frame으로 직렬화한다.</li>
+        <li><code>/api/dashboard/execute-output/:keeper</code>와 <code>/api/v1/dashboard/execute-output/:keeper</code> route를 추가하고, typed Shell IR dispatch 성공 후 <code>Keeper_keepalive_signal.record_execute_output_callback</code>으로 producer를 연결했다.</li>
+        <li><code>Dashboard_execute_output</code>을 per-keeper line ring + subscriber model로 확장했다. route는 초기 snapshot 후 long-lived SSE tail을 유지하며 <code>line</code>/<code>task_closed</code> frame과 heartbeat를 보낸다.</li>
+        <li><code>cursor_events.jsonl</code> producer와 <code>Ide_bridge.list_cursors</code> reader를 추가했다. tool hook input에 non-empty <code>file_path</code>와 positive <code>line</code>/<code>line_start</code>가 있을 때만 cursor row를 저장한다.</li>
+        <li><code>GET /api/v1/ide/cursors</code>와 <code>GET /api/v1/ide/cursors/stream</code>을 추가했다. 기존 presence endpoint는 active client presence 전용으로 남기고, <code>keeper-cursor-overlay</code>는 dedicated cursor stream만 읽는다.</li>
+      </ul>
+    </div>
+
+    <div class="note">
+      <strong>검증 완료:</strong>
+      <ul>
+        <li><code>./scripts/dune-local.sh build test/test_ide_bridge.exe lib/server/server_ide_http.ml lib/ide/ide_bridge.ml</code></li>
+        <li><code>./_build/default/test/test_ide_bridge.exe</code> — 24 tests</li>
+        <li><code>./scripts/dune-local.sh build test/test_dashboard_execute_output.exe lib/dashboard/dashboard_execute_output.ml lib/server/server_routes_http_routes_dashboard.ml lib/keeper/keeper_tool_execute_runtime.ml</code></li>
+        <li><code>./_build/default/test/test_dashboard_execute_output.exe</code> — 7 tests</li>
+        <li><code>pnpm exec vitest run src/api/ide.test.ts src/components/ide/ide-activity-panel.test.ts src/components/ide/keeper-cursor-overlay.test.ts src/api/execute-output.test.ts src/components/ide/execute-output-drawer.test.ts</code> — 42 tests</li>
+        <li><code>pnpm exec tsc --noEmit --pretty</code></li>
+        <li><code>opam exec -- ocamlformat --check lib/ide/ide_bridge.ml lib/ide/ide_bridge.mli lib/server/server_ide_http.ml lib/server/server_ide_http.mli test/test_ide_bridge.ml</code></li>
+        <li><code>scripts/ci/check-determinism-contract.sh --base origin/main --head HEAD</code></li>
+      </ul>
+    </div>
+
+    <div class="note">
+      <strong>남은 P0:</strong>
+      <ul>
+        <li>없음. 현재 남은 항목은 P1 후속: editor/LSP native cursor producer, Execute running-output producer, IDE WS snapshot surface다.</li>
+      </ul>
+    </div>
+
+    <p>event reader, execute-output route, presence/cursor split을 먼저 닫은 이유는 그대로다. 이 구멍을 메워야 이후 Shell IR, Task/Goal, Board context 개선을 운영 화면에서 검증할 수 있다. 다음 순서는 executor/process drain 단계의 running-output producer를 붙이고, IDE WS snapshot surface에 cursor/event freshness를 포함하는 것이다.</p>
+  </section>
+</main>
+</body>
+</html>

--- a/test/dune
+++ b/test/dune
@@ -86,6 +86,7 @@
   test_dashboard_perf
   test_dashboard_tool_host_events
   test_dashboard_nav_event
+  test_dashboard_execute_output
   test_tool_assignment_telemetry
   test_dashboard_link_preview
   test_gate_keeper_backend
@@ -338,6 +339,7 @@
   test_dashboard_perf
   test_dashboard_tool_host_events
   test_dashboard_nav_event
+  test_dashboard_execute_output
   test_tool_assignment_telemetry
   test_dashboard_link_preview
   test_gate_keeper_backend

--- a/test/test_dashboard_execute_output.ml
+++ b/test/test_dashboard_execute_output.ml
@@ -1,0 +1,171 @@
+open Alcotest
+
+module EO = Dashboard_execute_output
+module Router = Masc.Http_server_eio.Router
+
+let status_ok = `Assoc [ "kind", `String "exit"; "code", `Int 0 ]
+
+let with_fresh f () =
+  EO.reset_for_testing ();
+  f ()
+
+let test_no_task_event () =
+  let json = EO.event_json ~keeper_name:"sangsu" in
+  let open Yojson.Safe.Util in
+  check string "type" "no_task" (json |> member "type" |> to_string);
+  check string "keeper" "sangsu" (json |> member "keeper" |> to_string);
+  check bool "closed" true (json |> member "closed" |> to_bool)
+
+let test_snapshot_merges_completed_output () =
+  EO.inject_for_testing
+    ~keeper_name:"Sangsu"
+    ~task_id:"task-1"
+    ~stdout:"first\n"
+    ~stderr:""
+    ~status:status_ok
+    ();
+  EO.inject_for_testing
+    ~keeper_name:"sangsu"
+    ~task_id:"task-2"
+    ~stdout:"second\n"
+    ~stderr:"err\n"
+    ~status:status_ok
+    ();
+  match EO.snapshot ~keeper_name:"sangsu" with
+  | None -> fail "expected snapshot"
+  | Some snapshot ->
+    check string "keeper normalized" "sangsu" snapshot.keeper;
+    check (option string) "latest task" (Some "task-2") snapshot.task_id;
+    check int "task count" 2 snapshot.task_count;
+    check string "stdout" "first\nsecond\n" snapshot.stdout_since;
+    check string "stderr" "err\n" snapshot.stderr_since;
+    check int "stdout bytes" 13 snapshot.since_stdout;
+    check int "stderr bytes" 4 snapshot.since_stderr;
+    check bool "closed" true snapshot.closed
+
+let test_snapshot_json_shape () =
+  EO.inject_for_testing
+    ~keeper_name:"sangsu"
+    ~task_id:"task-123"
+    ~generated_at:1000.0
+    ~stdout:"ok\n"
+    ~stderr:""
+    ~status:status_ok
+    ();
+  let json = EO.event_json ~keeper_name:"sangsu" in
+  let open Yojson.Safe.Util in
+  check string "type" "snapshot" (json |> member "type" |> to_string);
+  check string "task" "task-123" (json |> member "task_id" |> to_string);
+  check string "stdout" "ok\n" (json |> member "stdout_since" |> to_string);
+  check bool "closed" true (json |> member "closed" |> to_bool);
+  check int "status code" 0 (json |> member "status" |> member "code" |> to_int)
+
+let test_snapshot_line_ring_shape () =
+  EO.inject_for_testing
+    ~keeper_name:"sangsu"
+    ~task_id:"task-123"
+    ~generated_at:1000.0
+    ~stdout:"ok\nsecond"
+    ~stderr:"warn\n"
+    ~status:status_ok
+    ();
+  let lines = EO.output_lines_for_testing ~keeper_name:"sangsu" in
+  check int "line count" 3 (List.length lines);
+  check string "first stream" "stdout" (List.hd lines).stream;
+  check string "first text" "ok" (List.hd lines).text;
+  let json = EO.event_json ~keeper_name:"sangsu" in
+  let open Yojson.Safe.Util in
+  let json_lines = json |> member "lines" |> to_list in
+  check int "json line count" 3 (List.length json_lines);
+  check string "json line text" "ok" (List.hd json_lines |> member "text" |> to_string);
+  check int "json line ts" 1000000 (List.hd json_lines |> member "ts_ms" |> to_int)
+
+let test_live_tail_subscriber_receives_line_and_close () =
+  Eio_main.run (fun env ->
+    match EO.subscribe ~keeper_name:"sangsu" with
+    | None -> fail "expected subscriber"
+    | Some subscriber ->
+      Fun.protect
+        ~finally:(fun () -> EO.unsubscribe subscriber)
+        (fun () ->
+           EO.inject_for_testing
+             ~keeper_name:"sangsu"
+             ~task_id:"task-123"
+             ~generated_at:1000.0
+             ~stdout:"ok\n"
+             ~stderr:""
+             ~status:status_ok
+             ();
+           let take_json () =
+             EO.take_event subscriber |> EO.stream_event_json
+           in
+           let line_json =
+             Eio.Time.with_timeout_exn (Eio.Stdenv.clock env) 1.0 take_json
+           in
+           let closed_json =
+             Eio.Time.with_timeout_exn (Eio.Stdenv.clock env) 1.0 take_json
+           in
+           let open Yojson.Safe.Util in
+           check string "line type" "line" (line_json |> member "type" |> to_string);
+           check
+             string
+             "line text"
+             "ok"
+             (line_json |> member "line" |> member "text" |> to_string);
+           check
+             string
+             "closed type"
+             "task_closed"
+             (closed_json |> member "type" |> to_string);
+           check bool "closed" true (closed_json |> member "closed" |> to_bool)))
+
+let test_sse_frame () =
+  let frame = EO.sse_frame (`Assoc [ "type", `String "snapshot" ]) in
+  check bool "event header" true (String.starts_with ~prefix:"event: output\n" frame);
+  check bool "data line" true (String.contains frame '{');
+  check bool "terminator" true (String.ends_with ~suffix:"\n\n" frame)
+
+let test_dashboard_routes_match_keeper_path () =
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      let routes =
+        Server_routes_http_routes_dashboard.add_routes
+          ~sw
+          ~clock:(Eio.Stdenv.clock env)
+          (Router.create ())
+      in
+      let check_route label path expected =
+        let request = Httpun.Request.create `GET path in
+        match Router.resolve routes request with
+        | `Matched route -> check string label expected route.path
+        | `Method_not_allowed -> fail (label ^ " returned method_not_allowed")
+        | `Not_found -> fail (label ^ " returned not_found")
+      in
+      check_route
+        "legacy route"
+        "/api/dashboard/execute-output/sangsu"
+        "/api/dashboard/execute-output/";
+      check_route
+        "v1 route"
+        "/api/v1/dashboard/execute-output/sangsu"
+        "/api/v1/dashboard/execute-output/"))
+
+let () =
+  run
+    "Dashboard_execute_output"
+    [ ( "events"
+      , [ test_case "no task event" `Quick (with_fresh test_no_task_event)
+        ; test_case
+            "snapshot merges completed output"
+            `Quick
+            (with_fresh test_snapshot_merges_completed_output)
+        ; test_case "snapshot json shape" `Quick (with_fresh test_snapshot_json_shape)
+        ; test_case "snapshot line ring shape" `Quick (with_fresh test_snapshot_line_ring_shape)
+        ; test_case
+            "live tail subscriber receives line and close"
+            `Quick
+            (with_fresh test_live_tail_subscriber_receives_line_and_close)
+        ; test_case "sse frame" `Quick test_sse_frame
+        ; test_case "routes match keeper path" `Quick test_dashboard_routes_match_keeper_path
+        ] )
+    ]

--- a/test/test_ide_bridge.ml
+++ b/test/test_ide_bridge.ml
@@ -132,6 +132,168 @@ let test_ingest_multiple_events () =
     check int "two events" 2 !count)
 ;;
 
+let json_string key json =
+  Yojson.Safe.Util.member key json |> Yojson.Safe.Util.to_string
+;;
+
+let json_intlit key json =
+  match Yojson.Safe.Util.member key json with
+  | `Int i -> Int64.of_int i
+  | `Intlit s -> Int64.of_string s
+  | _ -> failwith ("expected int field " ^ key)
+;;
+
+let json_int key json =
+  Yojson.Safe.Util.member key json |> Yojson.Safe.Util.to_int
+;;
+
+let test_list_events_filters_keeper_and_pages () =
+  with_temp_dir (fun base_dir ->
+    Ide_bridge.ingest_tool_event
+      ~base_path:base_dir
+      ~tool_name:"execute"
+      ~keeper_id:"k1"
+      ~turn_id:"t-old"
+      ~outcome:"success"
+      ~typed_outcome:"progress"
+      ~latency_ms:100
+      ~summary:"old"
+      ~file_path:None
+      ~timestamp_ms:1000L
+      ();
+    Ide_bridge.ingest_tool_event
+      ~base_path:base_dir
+      ~tool_name:"read_file"
+      ~keeper_id:"k2"
+      ~turn_id:"t-other"
+      ~outcome:"success"
+      ~typed_outcome:"progress"
+      ~latency_ms:100
+      ~summary:"other"
+      ~file_path:None
+      ~timestamp_ms:3000L
+      ();
+    Ide_bridge.ingest_tool_event
+      ~base_path:base_dir
+      ~tool_name:"write_file"
+      ~keeper_id:"k1"
+      ~turn_id:"t-new"
+      ~outcome:"success"
+      ~typed_outcome:"progress"
+      ~latency_ms:100
+      ~summary:"new"
+      ~file_path:None
+      ~timestamp_ms:2000L
+      ();
+    let events =
+      Ide_bridge.list_events
+        ~base_path:base_dir
+        ~kind:Ide_bridge.Tool
+        ~keeper_id:"k1"
+        ~limit:1
+        ()
+    in
+    match events with
+    | [ event ] ->
+      check string "keeper filter" "k1" (json_string "keeper_id" event);
+      check string "newest event" "t-new" (json_string "turn_id" event)
+    | _ -> fail "expected one paged event")
+;;
+
+let test_list_events_merges_kinds_newest_first () =
+  with_temp_dir (fun base_dir ->
+    Ide_bridge.ingest_tool_event
+      ~base_path:base_dir
+      ~tool_name:"execute"
+      ~keeper_id:"k1"
+      ~turn_id:"t-tool"
+      ~outcome:"success"
+      ~typed_outcome:"progress"
+      ~latency_ms:100
+      ~summary:"tool"
+      ~file_path:None
+      ~timestamp_ms:1000L
+      ();
+    Ide_bridge.ingest_pr_event
+      ~base_path:base_dir
+      ~pr_number:42
+      ~pull_request_url:"https://github.com/owner/repo/pull/42"
+      ~pr_title:"feat"
+      ~pr_state:"open"
+      ~repo:"owner/repo"
+      ~keeper_id:"k1"
+      ~turn_id:"t-pr"
+      ~comment_count:0
+      ~review_status:None
+      ~timestamp_ms:2000L;
+    Ide_bridge.ingest_turn_event
+      ~base_path:base_dir
+      ~turn_id:"t-turn"
+      ~keeper_id:"k1"
+      ~phase:"completed"
+      ~model_used:None
+      ~tools_used:[]
+      ~stop_reason:None
+      ~duration_ms:None
+      ~timestamp_ms:3000L;
+    let events = Ide_bridge.list_events ~base_path:base_dir ~limit:3 () in
+    check (list string) "newest-first types" [ "turn"; "pr"; "tool" ]
+      (List.map (json_string "type") events);
+    check (list int64) "newest-first timestamps" [ 3000L; 2000L; 1000L ]
+      (List.map (json_intlit "timestamp_ms") events))
+;;
+
+let test_cursor_from_hook_uses_real_file_and_line () =
+  with_temp_dir (fun base_dir ->
+    let input =
+      `Assoc
+        [ "file_path", `String "lib/test.ml"
+        ; "line_start", `Int 12
+        ; "line_end", `Int 14
+        ; "column", `Int 3
+        ]
+    in
+    Ide_bridge.ingest_tool_event_from_hook
+      ~base_path:base_dir
+      ~tool_name:"keeper_ide_annotate"
+      ~keeper_id:"k1"
+      ~turn_id:"turn-7"
+      ~outcome:"ok"
+      ~typed_outcome_str:"progress"
+      ~duration_ms:10.0
+      ~output_text:"annotated"
+      ~input;
+    match Ide_bridge.list_cursors ~base_path:base_dir () with
+    | [ cursor ] ->
+      check string "keeper_id" "k1" (json_string "keeper_id" cursor);
+      check string "file_path" "lib/test.ml" (json_string "file_path" cursor);
+      check int "line" 12 (json_int "line" cursor);
+      check int "column" 3 (json_int "column" cursor);
+      check string "focus_mode" "editing" (json_string "focus_mode" cursor);
+      check string "tool_name" "keeper_ide_annotate" (json_string "tool_name" cursor);
+      check int "turn" 7 (json_int "turn" cursor);
+      let selection_end = Yojson.Safe.Util.member "selection_end" cursor in
+      check int "selection end line" 14 (json_int "line" selection_end)
+    | _ -> fail "expected one cursor")
+;;
+
+let test_cursor_from_hook_skips_missing_line () =
+  with_temp_dir (fun base_dir ->
+    let input = `Assoc [ "file_path", `String "lib/test.ml" ] in
+    Ide_bridge.ingest_tool_event_from_hook
+      ~base_path:base_dir
+      ~tool_name:"keeper_ide_annotate"
+      ~keeper_id:"k1"
+      ~turn_id:"turn-7"
+      ~outcome:"ok"
+      ~typed_outcome_str:"progress"
+      ~duration_ms:10.0
+      ~output_text:"annotated"
+      ~input;
+    check int "no cursor without line" 0
+      (List.length (Ide_bridge.list_cursors ~base_path:base_dir ())))
+;;
+
 let test_hook_extracts_file_path_from_path_key () =
   with_temp_dir (fun base_dir ->
     let input = `Assoc [ "path", `String "lib/test.ml"; "content", `String "hello" ] in
@@ -408,6 +570,14 @@ let () =
       , [ test_case "tool event" `Quick test_ingest_tool_event
         ; test_case "turn event" `Quick test_ingest_turn_event
         ; test_case "multiple events" `Quick test_ingest_multiple_events
+        ] )
+    ; ( "read"
+      , [ test_case "filters keeper and pages" `Quick test_list_events_filters_keeper_and_pages
+        ; test_case "merges kinds newest first" `Quick test_list_events_merges_kinds_newest_first
+        ] )
+    ; ( "cursor"
+      , [ test_case "from hook uses real file and line" `Quick test_cursor_from_hook_uses_real_file_and_line
+        ; test_case "from hook skips missing line" `Quick test_cursor_from_hook_skips_missing_line
         ] )
     ; ( "hook_extract"
       , [ test_case "file_path from path key" `Quick test_hook_extracts_file_path_from_path_key


### PR DESCRIPTION
## What changed

- Added `Ide_bridge.list_events` so existing `.masc-ide/{tool,turn,pr}_events.jsonl` producers have a read surface.
- Added `GET /api/v1/ide/events` with `kind`, `keeper_id`, `limit`, `offset`, and existing repo/canonical partition resolution.
- Added `fetchIdeEvents` and merged bridge events into the IDE activity timeline/context lens/trace path.
- Added `Dashboard_execute_output`, a bounded per-keeper completed Execute stdout/stderr collector with `snapshot`/`no_task` SSE frame serialization.
- Added `/api/dashboard/execute-output/:keeper` and `/api/v1/dashboard/execute-output/:keeper` route coverage, plus a typed Shell IR producer hook through `Keeper_keepalive_signal.record_execute_output_callback`.
- Added the static boundary report and updated it with the completed event-reader and execute-output route slices plus the remaining presence/cursor P0.

## Why

The IDE bridge already persisted runtime/tool/turn/PR events, but the dashboard had no first-class REST consumer for those JSONL records. The execute-output drawer also had a client-side stream path with no backend route. This closes both dashboard-facing producer/consumer gaps before tackling the remaining presence/cursor semantic contract split.

## Validation

- `./scripts/dune-local.sh build test/test_ide_bridge.exe test/test_dashboard_execute_output.exe lib/server/server_ide_http.ml lib/server/server_routes_http_routes_dashboard.ml lib/keeper/keeper_tool_execute_runtime.ml`
- `./_build/default/test/test_ide_bridge.exe` (22 tests)
- `./_build/default/test/test_dashboard_execute_output.exe` (5 tests)
- `pnpm exec vitest run src/api/ide.test.ts src/components/ide/ide-activity-panel.test.ts src/api/execute-output.test.ts src/components/ide/execute-output-drawer.test.ts` (33 tests)
- `pnpm exec tsc --noEmit --pretty`
- `git diff --check` and `git diff --cached --check`
- `xmllint --html --noout reports/dashboard-ide-boundary-20260607.html` exited 0 with expected HTML5 tag parser warnings
