### PR TITLE
keeper: add central runtime admission

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -379,7 +379,7 @@ let run_keepalive_unified_turn
           ~kind:Semaphore_wait_pending
           ();
         match
-          Keeper_turn_slot.with_keeper_turn_slot
+          Keeper_turn_slot.with_keeper_turn_slot_admission
             ~runtime_profile:(runtime_id_of_meta meta_after_triage)
             ~keeper_name:meta_after_triage.name
             ~channel:turn_decision.channel
@@ -396,6 +396,23 @@ let run_keepalive_unified_turn
         with
         | Ok meta -> meta
         | Error (`Semaphore_wait_timeout timeout) ->
+          handle_semaphore_wait_timeout ~ctx ~meta_after_triage ~turn_decision timeout
+        | Error `Fleet_paused ->
+          Log.Keeper.info
+            "%s: skipping turn because fleet runtime admission is paused"
+            meta_after_triage.name;
+          meta_after_cursor_persist
+        | Error `Fleet_stopped ->
+          Log.Keeper.warn
+            "%s: rejecting turn because fleet runtime admission is stopped"
+            meta_after_triage.name;
+          meta_after_cursor_persist
+        | Error (`Runtime_capacity_exceeded _ as err) ->
+          let timeout =
+            Keeper_turn_slot.timeout_of_runtime_admission_error
+              ~keeper_name:meta_after_triage.name
+              err
+          in
           handle_semaphore_wait_timeout ~ctx ~meta_after_triage ~turn_decision timeout)
       else if obs.message_cursor_updates <> []
       then meta_after_cursor_persist

--- a/lib/keeper/keeper_turn_admission.ml
+++ b/lib/keeper/keeper_turn_admission.ml
@@ -1,0 +1,121 @@
+(** Central admission for keeper runtime-turn execution.
+
+    V1 manages only the runtime-turn resource. Per-keeper turn ordering and
+    autonomous/reactive channel fairness remain in [Keeper_turn_slot]. *)
+
+type resource_kind =
+  | Runtime_turn
+
+type fleet_admission_state =
+  | Running
+  | Paused
+  | Stopped
+
+type runtime_capacity_snapshot =
+  { resource_kind : resource_kind
+  ; runtime_limit : int
+  ; runtime_inflight : int
+  }
+
+type admission_error =
+  | Fleet_paused
+  | Fleet_stopped
+  | Runtime_capacity_exceeded of runtime_capacity_snapshot
+
+let resource_kind_to_string = function
+  | Runtime_turn -> "runtime_turn"
+;;
+
+let fleet_admission_state_to_string = function
+  | Running -> "running"
+  | Paused -> "paused"
+  | Stopped -> "stopped"
+;;
+
+let admission_error_to_string = function
+  | Fleet_paused -> "fleet_paused"
+  | Fleet_stopped -> "fleet_stopped"
+  | Runtime_capacity_exceeded snapshot ->
+    Printf.sprintf
+      "%s_capacity_exceeded(inflight=%d,limit=%d)"
+      (resource_kind_to_string snapshot.resource_kind)
+      snapshot.runtime_inflight
+      snapshot.runtime_limit
+;;
+
+let fleet_state = Atomic.make Running
+let global_runtime_limit = Atomic.make 32
+let global_runtime_inflight = Atomic.make 0
+
+let configure_runtime_turn_limit limit =
+  Atomic.set global_runtime_limit (max 1 limit)
+;;
+
+let runtime_turn_limit () = Atomic.get global_runtime_limit
+let runtime_turn_inflight () = Atomic.get global_runtime_inflight
+
+let pause_fleet_admission () = Atomic.set fleet_state Paused
+let resume_fleet_admission () = Atomic.set fleet_state Running
+let stop_fleet_admission () = Atomic.set fleet_state Stopped
+let fleet_admission_state () = Atomic.get fleet_state
+
+let check_fleet_admission () =
+  match fleet_admission_state () with
+  | Running -> Ok ()
+  | Paused -> Error Fleet_paused
+  | Stopped -> Error Fleet_stopped
+;;
+
+let capacity_snapshot ~runtime_limit ~runtime_inflight =
+  { resource_kind = Runtime_turn; runtime_limit; runtime_inflight }
+;;
+
+let acquire_runtime_turn_lease ~keeper_name ~channel () =
+  let channel_label = Keeper_world_observation.channel_to_string channel in
+  let rec loop () =
+    match check_fleet_admission () with
+    | Error _ as error -> error
+    | Ok () ->
+      let current = Atomic.get global_runtime_inflight in
+      let limit = runtime_turn_limit () in
+      if current >= limit
+      then (
+        Log.Keeper.routine
+          "runtime_admission: capacity exceeded keeper=%s channel=%s inflight=%d limit=%d"
+          keeper_name
+          channel_label
+          current
+          limit;
+        Error (Runtime_capacity_exceeded (capacity_snapshot ~runtime_limit:limit ~runtime_inflight:current)))
+      else if Atomic.compare_and_set global_runtime_inflight current (current + 1)
+      then Ok ()
+      else loop ()
+  in
+  loop ()
+;;
+
+let release_runtime_turn_lease () =
+  let rec loop () =
+    let current = Atomic.get global_runtime_inflight in
+    if current <= 0
+    then Log.Keeper.warn "runtime_admission: release requested with inflight=%d" current
+    else if not (Atomic.compare_and_set global_runtime_inflight current (current - 1))
+    then loop ()
+  in
+  loop ()
+;;
+
+let with_runtime_turn_lease ~keeper_name ~channel f =
+  match acquire_runtime_turn_lease ~keeper_name ~channel () with
+  | Error _ as error -> error
+  | Ok () ->
+    Eio_guard.protect
+      ~finally:release_runtime_turn_lease
+      (fun () -> Ok (f ()))
+;;
+
+let reset_for_test ?(runtime_turn_limit = 32) () =
+  Atomic.set fleet_state Running;
+  Atomic.set global_runtime_inflight 0;
+  configure_runtime_turn_limit runtime_turn_limit
+;;

--- a/lib/keeper/keeper_turn_admission.mli
+++ b/lib/keeper/keeper_turn_admission.mli
@@ -1,0 +1,53 @@
+(** Central admission for keeper runtime-turn execution.
+
+    This module owns the fleet-wide resource lease for [Runtime_turn]. It does
+    not own per-keeper sequencing, autonomous FIFO fairness, voice I/O,
+    sidecar output, or host FD/disk pressure gates. *)
+
+type resource_kind =
+  | Runtime_turn
+
+type fleet_admission_state =
+  | Running
+  | Paused
+  | Stopped
+
+type runtime_capacity_snapshot =
+  { resource_kind : resource_kind
+  ; runtime_limit : int
+  ; runtime_inflight : int
+  }
+
+type admission_error =
+  | Fleet_paused
+  | Fleet_stopped
+  | Runtime_capacity_exceeded of runtime_capacity_snapshot
+
+val resource_kind_to_string : resource_kind -> string
+val fleet_admission_state_to_string : fleet_admission_state -> string
+val admission_error_to_string : admission_error -> string
+
+val configure_runtime_turn_limit : int -> unit
+val runtime_turn_limit : unit -> int
+val runtime_turn_inflight : unit -> int
+
+val pause_fleet_admission : unit -> unit
+val resume_fleet_admission : unit -> unit
+val stop_fleet_admission : unit -> unit
+val fleet_admission_state : unit -> fleet_admission_state
+
+val acquire_runtime_turn_lease :
+  keeper_name:string ->
+  channel:Keeper_world_observation.keeper_cycle_channel ->
+  unit ->
+  (unit, admission_error) result
+
+val release_runtime_turn_lease : unit -> unit
+
+val with_runtime_turn_lease :
+  keeper_name:string ->
+  channel:Keeper_world_observation.keeper_cycle_channel ->
+  (unit -> 'a) ->
+  ('a, admission_error) result
+
+val reset_for_test : ?runtime_turn_limit:int -> unit -> unit

--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -742,31 +742,33 @@ let release_keeper_turn_slot_impl ~keeper_name ~(stamp_autonomous_completion : b
     state.turn_acquisition_id := None);
   if !(state.acquired_autonomous)
   then (
-    ignore
-      (release_recorded_holder
-         ~keeper_name
-         ~label:Autonomous_pool
-         ~acquisition_id:!(state.autonomous_acquisition_id)
-         ~before_release:(fun () ->
-           (* Stamp completion time only for normal completion, before releasing
-              the semaphore so that [maybe_yield_for_fairness] can measure the
-              correct interval when this keeper's heartbeat loops back
-              immediately. *)
-           if stamp_autonomous_completion
-           then
-             safe_bookkeeping ~op:"record_autonomous_completion" (fun () ->
-               record_autonomous_completion ~keeper_name))
-         autonomous_turn_semaphore);
+    let (_ : bool) =
+      release_recorded_holder
+        ~keeper_name
+        ~label:Autonomous_pool
+        ~acquisition_id:!(state.autonomous_acquisition_id)
+        ~before_release:(fun () ->
+          (* Stamp completion time only for normal completion, before releasing
+             the semaphore so that [maybe_yield_for_fairness] can measure the
+             correct interval when this keeper's heartbeat loops back
+             immediately. *)
+          if stamp_autonomous_completion
+          then
+            safe_bookkeeping ~op:"record_autonomous_completion" (fun () ->
+              record_autonomous_completion ~keeper_name))
+        autonomous_turn_semaphore
+    in
     state.acquired_autonomous := false;
     state.autonomous_acquisition_id := None);
   if !(state.acquired_reactive)
   then (
-    ignore
-      (release_recorded_holder
-         ~keeper_name
-         ~label:Reactive_pool
-         ~acquisition_id:!(state.reactive_acquisition_id)
-         reactive_turn_semaphore);
+    let (_ : bool) =
+      release_recorded_holder
+        ~keeper_name
+        ~label:Reactive_pool
+        ~acquisition_id:!(state.reactive_acquisition_id)
+        reactive_turn_semaphore
+    in
     state.acquired_reactive := false;
     state.reactive_acquisition_id := None)
 ;;

--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -1,5 +1,5 @@
-(* keeper_turn_slot — semaphores, autonomous wait queue, budget-exhaustion strikes,
-   and the main [with_keeper_turn_slot] gate. *)
+(* keeper_turn_slot — per-keeper turn lanes, autonomous wait queue,
+   budget-exhaustion strikes, and the main [with_keeper_turn_slot] gate. *)
 
 open Keeper_types
 open Keeper_meta_contract
@@ -135,7 +135,22 @@ let check_throttle_divergence () =
     | Toml | Default -> ()
 ;;
 let () = check_throttle_divergence ()
-let turn_semaphore = Eio.Semaphore.make effective_turn_throttle_limit
+let () =
+  Keeper_turn_admission.configure_runtime_turn_limit effective_turn_throttle_limit
+;;
+
+let keeper_turn_slots : (string, Eio.Semaphore.t) Hashtbl.t = Hashtbl.create 32
+let keeper_turn_slots_mutex = Eio.Mutex.create ()
+
+let get_or_create_keeper_turn_slot keeper_name =
+  Eio.Mutex.use_rw ~protect:true keeper_turn_slots_mutex (fun () ->
+    match Hashtbl.find_opt keeper_turn_slots keeper_name with
+    | Some sem -> sem
+    | None ->
+      let sem = Eio.Semaphore.make 1 in
+      Hashtbl.replace keeper_turn_slots keeper_name sem;
+      sem)
+;;
 
 (* 2026-05-05 fleet-stuck diagnosis: when a peer holds the semaphore for 60+ seconds the wait timeout WARN says "peers holding slot" but never names *which* peer.  Operators are then blind to which ke... *)
 type holder_key =
@@ -303,7 +318,11 @@ let () =
        (turn_concurrency_env_opt "MASC_KEEPER_REACTIVE_CONCURRENCY"))
 ;;
 let reactive_turn_semaphore = Eio.Semaphore.make reactive_turn_limit
-let turn_semaphore_value_for_test () = Eio.Semaphore.get_value turn_semaphore
+let turn_semaphore_value_for_test () =
+  Keeper_turn_admission.runtime_turn_limit ()
+  - Keeper_turn_admission.runtime_turn_inflight ()
+;;
+
 let autonomous_turn_semaphore_value_for_test () =
   Eio.Semaphore.get_value autonomous_turn_semaphore
 ;;
@@ -315,16 +334,24 @@ let autonomous_slot_holders ~now = snapshot_holders ~label:Autonomous_pool ~now
 let reactive_slot_holders ~now = snapshot_holders ~label:Reactive_pool ~now
 let force_release_stale_holder ~keeper_name =
   let released = ref [] in
-  let release_if_held ~label sem =
+  let release_if_held ~label ~release_one =
     let release_count = mark_holder_force_released ~label ~keeper_name in
     for _ = 1 to release_count do
-      Eio.Semaphore.release sem;
+      release_one ();
       released := slot_pool_to_string label :: !released
     done
   in
-  release_if_held ~label:Turn_pool turn_semaphore;
-  release_if_held ~label:Autonomous_pool autonomous_turn_semaphore;
-  release_if_held ~label:Reactive_pool reactive_turn_semaphore;
+  release_if_held
+    ~label:Turn_pool
+    ~release_one:(fun () ->
+      Eio.Semaphore.release (get_or_create_keeper_turn_slot keeper_name);
+      Keeper_turn_admission.release_runtime_turn_lease ());
+  release_if_held
+    ~label:Autonomous_pool
+    ~release_one:(fun () -> Eio.Semaphore.release autonomous_turn_semaphore);
+  release_if_held
+    ~label:Reactive_pool
+    ~release_one:(fun () -> Eio.Semaphore.release reactive_turn_semaphore);
   List.rev !released
 ;;
 let format_slot_holders ?(limit = 5) holders =
@@ -564,7 +591,7 @@ let semaphore_wait_timeout_snapshot ~phase ?queue_ahead ?(holders = []) ()
   ; timeout_phase = phase
   ; timeout_autonomous_available = Eio.Semaphore.get_value autonomous_turn_semaphore
   ; timeout_reactive_available = Eio.Semaphore.get_value reactive_turn_semaphore
-  ; timeout_turn_available = Eio.Semaphore.get_value turn_semaphore
+  ; timeout_turn_available = turn_semaphore_value_for_test ()
   ; timeout_queue_depth = autonomous_wait_queue_depth ()
   ; timeout_queue_ahead = queue_ahead
   ; timeout_holders = holders
@@ -587,6 +614,7 @@ type keeper_turn_slot_state =
   { acquired_autonomous : bool ref
   ; acquired_reactive : bool ref
   ; acquired_turn : bool ref
+  ; acquired_runtime_turn : bool ref
   ; autonomous_acquisition_id : int option ref
   ; reactive_acquisition_id : int option ref
   ; turn_acquisition_id : int option ref
@@ -597,6 +625,7 @@ let make_keeper_turn_slot_state () =
   { acquired_autonomous = ref false
   ; acquired_reactive = ref false
   ; acquired_turn = ref false
+  ; acquired_runtime_turn = ref false
   ; autonomous_acquisition_id = ref None
   ; reactive_acquisition_id = ref None
   ; turn_acquisition_id = ref None
@@ -650,7 +679,8 @@ let release_recorded_holder
       label_str
       keeper_name;
     before_release ();
-    Eio.Semaphore.release sem
+    Eio.Semaphore.release sem;
+    false
   | Some acquisition_id ->
     let force_released =
       try consume_force_release ~label ~keeper_name ~acquisition_id with
@@ -676,7 +706,8 @@ let release_recorded_holder
         keeper_name
     else (
       before_release ();
-      Eio.Semaphore.release sem)
+      Eio.Semaphore.release sem);
+    force_released
 ;;
 
 let release_keeper_turn_slot_impl ~keeper_name ~(stamp_autonomous_completion : bool) state
@@ -689,38 +720,53 @@ let release_keeper_turn_slot_impl ~keeper_name ~(stamp_autonomous_completion : b
      permit ownership. *)
   if !(state.acquired_turn)
   then (
-    release_recorded_holder
-      ~keeper_name
-      ~label:Turn_pool
-      ~acquisition_id:!(state.turn_acquisition_id)
-      turn_semaphore;
+    let keeper_turn_sem = get_or_create_keeper_turn_slot keeper_name in
+    let turn_was_force_released =
+      match !(state.turn_acquisition_id) with
+      | None ->
+        Eio.Semaphore.release keeper_turn_sem;
+        false
+      | Some _ ->
+        release_recorded_holder
+          ~keeper_name
+          ~label:Turn_pool
+          ~acquisition_id:!(state.turn_acquisition_id)
+          keeper_turn_sem
+    in
+    if !(state.acquired_runtime_turn)
+    then (
+      if not turn_was_force_released
+      then Keeper_turn_admission.release_runtime_turn_lease ();
+      state.acquired_runtime_turn := false);
     state.acquired_turn := false;
     state.turn_acquisition_id := None);
   if !(state.acquired_autonomous)
   then (
-    release_recorded_holder
-      ~keeper_name
-      ~label:Autonomous_pool
-      ~acquisition_id:!(state.autonomous_acquisition_id)
-      ~before_release:(fun () ->
-        (* Stamp completion time only for normal completion, before releasing
-           the semaphore so that [maybe_yield_for_fairness] can measure the
-           correct interval when this keeper's heartbeat loops back
-           immediately. *)
-        if stamp_autonomous_completion
-        then
-          safe_bookkeeping ~op:"record_autonomous_completion" (fun () ->
-            record_autonomous_completion ~keeper_name))
-      autonomous_turn_semaphore;
+    ignore
+      (release_recorded_holder
+         ~keeper_name
+         ~label:Autonomous_pool
+         ~acquisition_id:!(state.autonomous_acquisition_id)
+         ~before_release:(fun () ->
+           (* Stamp completion time only for normal completion, before releasing
+              the semaphore so that [maybe_yield_for_fairness] can measure the
+              correct interval when this keeper's heartbeat loops back
+              immediately. *)
+           if stamp_autonomous_completion
+           then
+             safe_bookkeeping ~op:"record_autonomous_completion" (fun () ->
+               record_autonomous_completion ~keeper_name))
+         autonomous_turn_semaphore);
     state.acquired_autonomous := false;
     state.autonomous_acquisition_id := None);
   if !(state.acquired_reactive)
   then (
-    release_recorded_holder
-      ~keeper_name
-      ~label:Reactive_pool
-      ~acquisition_id:!(state.reactive_acquisition_id)
-      reactive_turn_semaphore;
+    ignore
+      (release_recorded_holder
+         ~keeper_name
+         ~label:Reactive_pool
+         ~acquisition_id:!(state.reactive_acquisition_id)
+         reactive_turn_semaphore);
     state.acquired_reactive := false;
     state.reactive_acquisition_id := None)
 ;;
@@ -761,7 +807,7 @@ let release_keeper_turn_slot ~keeper_name state =
 let force_release_holder_for ~keeper_name : (string * float) list =
   let now = Time_compat.now () in
   let released_with_age = ref [] in
-  let try_release ~label ~sem =
+  let try_release ~label ~release_one =
     let snapshots =
       with_holder_lock (fun () ->
         purge_expired_force_released_holders_locked ~now;
@@ -793,7 +839,7 @@ let force_release_holder_for ~keeper_name : (string * float) list =
     List.iter
       (fun (_key, acquired_at) ->
          let age = now -. acquired_at in
-         Eio.Semaphore.release sem;
+         release_one ();
          released_with_age := (label_str, age) :: !released_with_age;
          Otel_metric_store.inc_counter
            Keeper_metrics.(to_string SlotForceReleased)
@@ -807,9 +853,17 @@ let force_release_holder_for ~keeper_name : (string * float) list =
            age)
       snapshots
   in
-  try_release ~label:Reactive_pool ~sem:reactive_turn_semaphore;
-  try_release ~label:Autonomous_pool ~sem:autonomous_turn_semaphore;
-  try_release ~label:Turn_pool ~sem:turn_semaphore;
+  try_release
+    ~label:Reactive_pool
+    ~release_one:(fun () -> Eio.Semaphore.release reactive_turn_semaphore);
+  try_release
+    ~label:Autonomous_pool
+    ~release_one:(fun () -> Eio.Semaphore.release autonomous_turn_semaphore);
+  try_release
+    ~label:Turn_pool
+    ~release_one:(fun () ->
+      Eio.Semaphore.release (get_or_create_keeper_turn_slot keeper_name);
+      Keeper_turn_admission.release_runtime_turn_lease ());
   !released_with_age
 ;;
 
@@ -1049,7 +1103,21 @@ let observe_semaphore_wait_seconds ~keeper_name ~runtime_profile ~channel second
   inc_bucket "+Inf"
 ;;
 
-let with_keeper_turn_slot ?(runtime_profile = "unknown") ~keeper_name ~channel f =
+let admission_error_to_result = function
+  | Keeper_turn_admission.Fleet_paused -> `Fleet_paused
+  | Keeper_turn_admission.Fleet_stopped -> `Fleet_stopped
+  | Keeper_turn_admission.Runtime_capacity_exceeded snapshot ->
+    `Runtime_capacity_exceeded snapshot
+;;
+
+let current_fleet_admission_result () =
+  match Keeper_turn_admission.fleet_admission_state () with
+  | Keeper_turn_admission.Running -> Ok ()
+  | Keeper_turn_admission.Paused -> Error `Fleet_paused
+  | Keeper_turn_admission.Stopped -> Error `Fleet_stopped
+;;
+
+let with_keeper_turn_slot_admission ?(runtime_profile = "unknown") ~keeper_name ~channel f =
   let is_autonomous =
     match channel with
     | Keeper_world_observation.Scheduled_autonomous -> true
@@ -1064,6 +1132,7 @@ let with_keeper_turn_slot ?(runtime_profile = "unknown") ~keeper_name ~channel f
      log lines from every other surface that uses the SSOT helper —
      operators grepping for one form silently missed the other. *)
   let channel_label = Keeper_world_observation.channel_to_string channel in
+  let keeper_turn_sem = get_or_create_keeper_turn_slot keeper_name in
   (* Track acquisitions in mutable flags so the outer Fun.protect can
      release exactly the slots we hold — regardless of which result or
      exception path fires (Eio.Cancel.Cancelled or any other). This
@@ -1150,7 +1219,7 @@ let with_keeper_turn_slot ?(runtime_profile = "unknown") ~keeper_name ~channel f
       keeper_name
       channel_label
       (Eio.Semaphore.get_value autonomous_turn_semaphore)
-      (Eio.Semaphore.get_value turn_semaphore)
+      (turn_semaphore_value_for_test ())
       queue_depth;
     Otel_metric_store.set_gauge
       Keeper_metrics.(to_string TurnQueueDepth)
@@ -1159,48 +1228,61 @@ let with_keeper_turn_slot ?(runtime_profile = "unknown") ~keeper_name ~channel f
   in
   let acquire_all () =
     let t0 = Time_compat.now () in
-    log_acquire_attempt ();
-    let autonomous_result =
-      if is_autonomous
-      then (
-        (* Fairness cooldown: if this keeper recently completed a turn and
+    match current_fleet_admission_result () with
+    | Error _ as e -> e
+    | Ok () ->
+      log_acquire_attempt ();
+      let turn_slot_result =
+        acquire_bounded ~label:Turn_pool ~phase:Turn_slot keeper_turn_sem
+      in
+      (match turn_slot_result with
+       | Error _ as e -> e
+       | Ok () ->
+         slot_state.acquired_turn := true;
+         run_after_acquire_flag_hook_for_test
+           ~label:(slot_pool_to_string Turn_pool)
+           ~keeper_name;
+         let autonomous_result =
+           if is_autonomous
+           then (
+             (* Fairness cooldown: if this keeper recently completed a turn and
              other keepers are waiting, yield before re-entering the FIFO
              queue to give peers a chance to reach head-of-queue first.
              See [maybe_yield_for_fairness] and #6810. *)
-        maybe_yield_for_fairness ~keeper_name;
-        let ticket = enqueue_autonomous_waiter ~keeper_name ~runtime_id:runtime_profile in
-        slot_state.autonomous_ticket := Some ticket;
-        (* Reset the queue-head timeout clock to the moment we bound the
+             maybe_yield_for_fairness ~keeper_name;
+             let ticket = enqueue_autonomous_waiter ~keeper_name ~runtime_id:runtime_profile in
+             slot_state.autonomous_ticket := Some ticket;
+             (* Reset the queue-head timeout clock to the moment we bound the
              queue, NOT [t0] (slot-entry). Otherwise [maybe_yield_for_fairness]
              above silently consumes the [semaphore_wait_timeout_sec] budget
              before we even appear in the FIFO, producing the symptom
              "skipping turn (semaphore wait > 60s, peers holding slot,
              autonomous_available=N)" with N>0 because the slot is genuinely
              free but we ran out of budget while sleeping in fairness yield. *)
-        let queue_entered_at = Time_compat.now () in
-        match
-          wait_for_autonomous_queue_head
-            ~keeper_name ~ticket ~runtime_id:runtime_profile ~started_at:queue_entered_at
-        with
-        | Error _ as e -> e
-        | Ok () ->
-          (* The FIFO should order admission into the semaphore wait queue,
+             let queue_entered_at = Time_compat.now () in
+             match
+               wait_for_autonomous_queue_head
+                 ~keeper_name ~ticket ~runtime_id:runtime_profile ~started_at:queue_entered_at
+             with
+             | Error _ as e -> e
+             | Ok () ->
+               (* The FIFO should order admission into the semaphore wait queue,
              not hold the queue head hostage while this fiber waits for an
              autonomous permit. Once we are at the head, drop the ticket
              before [acquire_bounded] so tail keepers can also enter the
              semaphore wait queue instead of burning their whole
              queue-head timeout behind one slow head waiter. *)
-          drop_autonomous_waiter ~ticket;
-          slot_state.autonomous_ticket := None;
-          (match
-             acquire_bounded
-               ~label:Autonomous_pool
-               ~phase:Autonomous_slot
-               autonomous_turn_semaphore
-           with
-           | Error _ as e -> e
-           | Ok () ->
-             (* Cancel-race fix (see acquire_bounded comment): set the
+               drop_autonomous_waiter ~ticket;
+               slot_state.autonomous_ticket := None;
+               (match
+                  acquire_bounded
+                    ~label:Autonomous_pool
+                    ~phase:Autonomous_slot
+                    autonomous_turn_semaphore
+                with
+                | Error _ as e -> e
+                | Ok () ->
+                  (* Cancel-race fix (see acquire_bounded comment): set the
                  [acquired_*] flag BEFORE [record_holder]. The flag is a
                  plain ref assignment (no cancel point); record_holder
                  acquires a [~protect:true] mutex (cancel-safe within
@@ -1208,78 +1290,80 @@ let with_keeper_turn_slot ?(runtime_profile = "unknown") ~keeper_name ~channel f
                  here the semaphore is reported as not-held and never
                  leaks; if it arrives after the flag set, release path
                  calls drop_holder (no-op when no entry exists). *)
-             slot_state.acquired_autonomous := true;
-             run_after_acquire_flag_hook_for_test
-               ~label:(slot_pool_to_string Autonomous_pool)
-               ~keeper_name;
-             let acquisition_id =
-               record_holder
-                 ~label:Autonomous_pool
-                 ~keeper_name
-                 ~acquired_at:(Time_compat.now ())
-             in
-             slot_state.autonomous_acquisition_id := Some acquisition_id;
-             Ok ()))
-      else Ok ()
-    in
-    match autonomous_result with
-    | Error _ as e -> e
-    | Ok () ->
-      let reactive_result =
-        if is_autonomous
-        then Ok ()
-        else (
-          match
-            acquire_bounded
-              ~label:Reactive_pool
-              ~phase:Reactive_slot
-              reactive_turn_semaphore
-          with
+                  slot_state.acquired_autonomous := true;
+                  run_after_acquire_flag_hook_for_test
+                    ~label:(slot_pool_to_string Autonomous_pool)
+                    ~keeper_name;
+                  let acquisition_id =
+                    record_holder
+                      ~label:Autonomous_pool
+                      ~keeper_name
+                      ~acquired_at:(Time_compat.now ())
+                  in
+                  slot_state.autonomous_acquisition_id := Some acquisition_id;
+                  Ok ()))
+           else Ok ()
+         in
+         (match autonomous_result with
           | Error _ as e -> e
           | Ok () ->
-            (* Cancel-race fix: flag THEN record_holder. *)
-            slot_state.acquired_reactive := true;
-            run_after_acquire_flag_hook_for_test
-              ~label:(slot_pool_to_string Reactive_pool)
-              ~keeper_name;
-            let acquisition_id =
-              record_holder
-                ~label:Reactive_pool
-                ~keeper_name
-                ~acquired_at:(Time_compat.now ())
+            let reactive_result =
+              if is_autonomous
+              then Ok ()
+              else (
+                match
+                  acquire_bounded
+                    ~label:Reactive_pool
+                    ~phase:Reactive_slot
+                    reactive_turn_semaphore
+                with
+                | Error _ as e -> e
+                | Ok () ->
+                  (* Cancel-race fix: flag THEN record_holder. *)
+                  slot_state.acquired_reactive := true;
+                  run_after_acquire_flag_hook_for_test
+                    ~label:(slot_pool_to_string Reactive_pool)
+                    ~keeper_name;
+                  let acquisition_id =
+                    record_holder
+                      ~label:Reactive_pool
+                      ~keeper_name
+                      ~acquired_at:(Time_compat.now ())
+                  in
+                  slot_state.reactive_acquisition_id := Some acquisition_id;
+                  Ok ())
             in
-            slot_state.reactive_acquisition_id := Some acquisition_id;
-            Ok ())
-      in
-      (match reactive_result with
-       | Error _ as e -> e
-       | Ok () ->
-         (match acquire_bounded ~label:Turn_pool ~phase:Turn_slot turn_semaphore with
-          | Error _ as e -> e
-          | Ok () ->
-            (* Cancel-race fix: flag THEN record_holder. *)
-            slot_state.acquired_turn := true;
-            run_after_acquire_flag_hook_for_test
-              ~label:(slot_pool_to_string Turn_pool)
-              ~keeper_name;
-            let acquisition_id =
-              record_holder
-                ~label:Turn_pool
-                ~keeper_name
-                ~acquired_at:(Time_compat.now ())
-            in
-            slot_state.turn_acquisition_id := Some acquisition_id;
-            let semaphore_wait_sec = Time_compat.now () -. t0 in
-            observe_semaphore_wait_seconds
-              ~keeper_name
-              ~runtime_profile
-              ~channel:channel_label
-              semaphore_wait_sec;
-            let semaphore_wait_ms =
-              int_of_float
-                ((if semaphore_wait_sec < 0.0 then 0.0 else semaphore_wait_sec) *. 1000.0)
-            in
-            Ok semaphore_wait_ms))
+            (match reactive_result with
+             | Error _ as e -> e
+             | Ok () ->
+               (match
+                  Keeper_turn_admission.acquire_runtime_turn_lease
+                    ~keeper_name
+                    ~channel
+                    ()
+                with
+                | Error err -> Error (admission_error_to_result err)
+                | Ok () ->
+                  slot_state.acquired_runtime_turn := true;
+                  let acquisition_id =
+                    record_holder
+                      ~label:Turn_pool
+                      ~keeper_name
+                      ~acquired_at:(Time_compat.now ())
+                  in
+                  slot_state.turn_acquisition_id := Some acquisition_id;
+                  let semaphore_wait_sec = Time_compat.now () -. t0 in
+                  observe_semaphore_wait_seconds
+                    ~keeper_name
+                    ~runtime_profile
+                    ~channel:channel_label
+                    semaphore_wait_sec;
+                  let semaphore_wait_ms =
+                    int_of_float
+                      ((if semaphore_wait_sec < 0.0 then 0.0 else semaphore_wait_sec)
+                       *. 1000.0)
+                  in
+                  Ok semaphore_wait_ms))))
   in
   Eio_guard.protect
     ~finally:(fun () -> release_keeper_turn_slot ~keeper_name slot_state)
@@ -1287,6 +1371,30 @@ let with_keeper_turn_slot ?(runtime_profile = "unknown") ~keeper_name ~channel f
        match acquire_all () with
        | Error _ as e -> e
        | Ok semaphore_wait_ms -> Ok (f ~semaphore_wait_ms))
+;;
+
+let timeout_of_runtime_admission_error ~keeper_name error =
+  let holders = snapshot_holders ~label:Turn_pool ~now:(Time_compat.now ()) in
+  (match error with
+   | `Fleet_paused ->
+     Log.Keeper.info "runtime_admission: fleet paused, skipping keeper=%s" keeper_name
+   | `Fleet_stopped ->
+     Log.Keeper.warn "runtime_admission: fleet stopped, rejecting keeper=%s" keeper_name
+   | `Runtime_capacity_exceeded snapshot ->
+     Log.Keeper.routine
+       "runtime_admission: capacity exceeded keeper=%s inflight=%d limit=%d"
+       keeper_name
+       snapshot.Keeper_turn_admission.runtime_inflight
+       snapshot.runtime_limit);
+  semaphore_wait_timeout_snapshot ~phase:Turn_slot ~holders ()
+;;
+
+let with_keeper_turn_slot ?runtime_profile ~keeper_name ~channel f =
+  match with_keeper_turn_slot_admission ?runtime_profile ~keeper_name ~channel f with
+  | Ok _ as ok -> ok
+  | Error (`Semaphore_wait_timeout _ as e) -> Error e
+  | Error ((`Fleet_paused | `Fleet_stopped | `Runtime_capacity_exceeded _) as e) ->
+    Error (`Semaphore_wait_timeout (timeout_of_runtime_admission_error ~keeper_name e))
 ;;
 
 let with_keeper_turn_slot_for_test ?runtime_profile ~keeper_name ~channel f =

--- a/lib/keeper/keeper_turn_slot.mli
+++ b/lib/keeper/keeper_turn_slot.mli
@@ -1,7 +1,8 @@
-(** Keeper Turn Slot — concurrency control for keeper turn execution.
+(** Keeper Turn Slot — keeper-local sequencing for turn execution.
 
-    Manages semaphores, fairness queuing, and slot diagnostics for
-    keeper turn concurrency.
+    Manages per-keeper turn lanes, autonomous/reactive fairness queuing, and
+    slot diagnostics. Fleet-wide runtime capacity is leased through
+    {!Keeper_turn_admission}.
 
     All type definitions ([slot_pool], [semaphore_wait_phase],
     [semaphore_wait_timeout]) and their pure converters live in
@@ -45,7 +46,6 @@ val throttle_source_to_string : throttle_source -> string
 (** Canonical string representation for logs and JSON surfaces:
     ["env_override" | "toml" | "default"]. *)
 
-val turn_semaphore : Eio.Semaphore.t
 val autonomous_turn_semaphore : Eio.Semaphore.t
 val reactive_turn_semaphore : Eio.Semaphore.t
 
@@ -231,6 +231,27 @@ val peek_budget_exhaustion_for_test : keeper_name:string -> int
 val set_budget_exhaustion_for_test : keeper_name:string -> strikes:int -> unit
 
 type keeper_turn_slot_state
+
+val with_keeper_turn_slot_admission :
+  ?runtime_profile:string ->
+  keeper_name:string ->
+  channel:Keeper_world_observation.keeper_cycle_channel ->
+  (semaphore_wait_ms:int -> 'a) ->
+  ( 'a
+  , [> `Semaphore_wait_timeout of semaphore_wait_timeout
+    | `Fleet_paused
+    | `Fleet_stopped
+    | `Runtime_capacity_exceeded of Keeper_turn_admission.runtime_capacity_snapshot
+    ] )
+  result
+
+val timeout_of_runtime_admission_error :
+  keeper_name:string ->
+  [< `Fleet_paused
+   | `Fleet_stopped
+   | `Runtime_capacity_exceeded of Keeper_turn_admission.runtime_capacity_snapshot
+  ] ->
+  semaphore_wait_timeout
 
 val with_keeper_turn_slot :
   ?runtime_profile:string ->

--- a/test/dune
+++ b/test/dune
@@ -1480,6 +1480,8 @@
 
 (include stanzas/test_keeper_turn_slot_force_release.inc)
 
+(include stanzas/test_keeper_turn_admission.inc)
+
 (include stanzas/test_keeper_turn_slot_holders.inc)
 
 (include stanzas/test_keeper_turn_slot_types.inc)

--- a/test/stanzas/test_keeper_turn_admission.inc
+++ b/test/stanzas/test_keeper_turn_admission.inc
@@ -1,0 +1,6 @@
+; Central runtime admission tests for Keeper_turn_admission
+
+(test
+ (name test_keeper_turn_admission)
+ (modules test_keeper_turn_admission)
+ (libraries masc_test_deps))

--- a/test/test_keeper_turn_admission.ml
+++ b/test/test_keeper_turn_admission.ml
@@ -1,0 +1,222 @@
+(** Regression tests for central runtime admission plus per-keeper lanes.
+
+    V1 has one central resource, [Runtime_turn]. Keeper-local ordering stays in
+    [Keeper_turn_slot]; the central lease is acquired only after the keeper's
+    own lane and channel slot are admitted. *)
+
+module KK = Masc.Keeper_keepalive
+module KTA = Masc.Keeper_turn_admission
+module KTS = Masc.Keeper_turn_slot
+
+let reactive = Masc.Keeper_world_observation.Reactive
+
+exception Injected_body_failure
+
+let assert_eq ~msg ~expected ~actual =
+  if expected <> actual
+  then failwith (Printf.sprintf "%s: expected=%d actual=%d" msg expected actual)
+;;
+
+let with_fresh_state ?(runtime_turn_limit = 32) body () =
+  Eio_main.run @@ fun env ->
+  Masc_test_deps.init_eio_clock env;
+  KK.set_after_acquire_flag_hook_for_test None;
+  KK.clear_force_released_markers_for_test ();
+  KK.reset_autonomous_completion_for_test ();
+  KK.reset_autonomous_turn_queue_for_test ();
+  KTA.reset_for_test ~runtime_turn_limit ();
+  Fun.protect
+    ~finally:(fun () -> KTA.reset_for_test ())
+    body
+;;
+
+let expect_ok_setup_lease ~keeper_name =
+  match KTA.acquire_runtime_turn_lease ~keeper_name ~channel:reactive () with
+  | Ok () -> ()
+  | Error err ->
+    failwith
+      (Printf.sprintf
+         "failed to acquire setup runtime lease: %s"
+         (KTA.admission_error_to_string err))
+;;
+
+let test_runtime_limit_caps_distinct_keepers () =
+  expect_ok_setup_lease ~keeper_name:"admission-holder";
+  Fun.protect
+    ~finally:KTA.release_runtime_turn_lease
+    (fun () ->
+       assert_eq
+         ~msg:"setup lease consumes one runtime turn"
+         ~expected:1
+         ~actual:(KTA.runtime_turn_inflight ());
+       let result =
+         KTS.with_keeper_turn_slot_admission
+           ~keeper_name:"admission-candidate"
+           ~channel:reactive
+           (fun ~semaphore_wait_ms:_ ->
+              failwith "runtime capacity failure should happen before body")
+       in
+       match result with
+       | Error (`Runtime_capacity_exceeded snapshot) ->
+         assert_eq
+           ~msg:"snapshot records configured runtime limit"
+           ~expected:1
+           ~actual:snapshot.KTA.runtime_limit;
+         assert_eq
+           ~msg:"snapshot records current runtime inflight"
+           ~expected:1
+           ~actual:snapshot.KTA.runtime_inflight;
+         assert_eq
+           ~msg:"failed admission does not consume another lease"
+           ~expected:1
+           ~actual:(KTA.runtime_turn_inflight ())
+       | Error `Fleet_paused -> failwith "unexpected fleet paused"
+       | Error `Fleet_stopped -> failwith "unexpected fleet stopped"
+       | Error (`Semaphore_wait_timeout _) -> failwith "unexpected local slot timeout"
+       | Ok () -> failwith "runtime capacity failure should reject candidate")
+;;
+
+let test_fleet_pause_and_stop_do_not_consume_runtime () =
+  KTA.pause_fleet_admission ();
+  let paused =
+    KTS.with_keeper_turn_slot_admission
+      ~keeper_name:"paused-keeper"
+      ~channel:reactive
+      (fun ~semaphore_wait_ms:_ -> failwith "paused fleet should skip body")
+  in
+  (match paused with
+   | Error `Fleet_paused -> ()
+   | Error err ->
+     failwith
+       (Printf.sprintf
+          "expected Fleet_paused, got %s"
+          (match err with
+           | `Fleet_stopped -> "Fleet_stopped"
+           | `Runtime_capacity_exceeded _ -> "Runtime_capacity_exceeded"
+           | `Semaphore_wait_timeout _ -> "Semaphore_wait_timeout"
+           | `Fleet_paused -> "Fleet_paused"))
+   | Ok () -> failwith "paused fleet should reject admission");
+  assert_eq
+    ~msg:"paused fleet does not consume runtime lease"
+    ~expected:0
+    ~actual:(KTA.runtime_turn_inflight ());
+  KTA.reset_for_test ();
+  KTA.stop_fleet_admission ();
+  let stopped =
+    KTS.with_keeper_turn_slot_admission
+      ~keeper_name:"stopped-keeper"
+      ~channel:reactive
+      (fun ~semaphore_wait_ms:_ -> failwith "stopped fleet should skip body")
+  in
+  (match stopped with
+   | Error `Fleet_stopped -> ()
+   | Error _ -> failwith "expected Fleet_stopped"
+   | Ok () -> failwith "stopped fleet should reject admission");
+  assert_eq
+    ~msg:"stopped fleet does not consume runtime lease"
+    ~expected:0
+    ~actual:(KTA.runtime_turn_inflight ())
+;;
+
+let test_same_keeper_lane_waits_before_runtime_lease () =
+  Eio_main.run @@ fun env ->
+  Masc_test_deps.init_eio_clock env;
+  let clock = Eio.Stdenv.clock env in
+  KK.set_after_acquire_flag_hook_for_test None;
+  KK.clear_force_released_markers_for_test ();
+  KK.reset_autonomous_completion_for_test ();
+  KK.reset_autonomous_turn_queue_for_test ();
+  KTA.reset_for_test ~runtime_turn_limit:2 ();
+  Eio.Switch.run (fun sw ->
+    let first_entered, resolve_first_entered = Eio.Promise.create () in
+    let release_first, resolve_release_first = Eio.Promise.create () in
+    let second_entered, resolve_second_entered = Eio.Promise.create () in
+    let second_done, resolve_second_done = Eio.Promise.create () in
+    Eio.Fiber.fork ~sw (fun () ->
+      match
+        KTS.with_keeper_turn_slot_admission
+          ~keeper_name:"same-keeper-lane"
+          ~channel:reactive
+          (fun ~semaphore_wait_ms:_ ->
+             Eio.Promise.resolve resolve_first_entered ();
+             Eio.Promise.await release_first)
+      with
+      | Ok () -> ()
+      | Error _ -> failwith "first same-keeper admission unexpectedly failed");
+    Eio.Promise.await first_entered;
+    assert_eq
+      ~msg:"first keeper turn holds one runtime lease"
+      ~expected:1
+      ~actual:(KTA.runtime_turn_inflight ());
+    Eio.Fiber.fork ~sw (fun () ->
+      let result =
+        KTS.with_keeper_turn_slot_admission
+          ~keeper_name:"same-keeper-lane"
+          ~channel:reactive
+          (fun ~semaphore_wait_ms:_ ->
+             Eio.Promise.resolve resolve_second_entered ())
+      in
+      Eio.Promise.resolve resolve_second_done result);
+    Eio.Time.sleep clock 0.02;
+    (match Eio.Promise.peek second_entered with
+     | None -> ()
+     | Some () -> failwith "second same-keeper turn entered before first released");
+    assert_eq
+      ~msg:"same keeper waits in local lane before consuming runtime lease"
+      ~expected:1
+      ~actual:(KTA.runtime_turn_inflight ());
+    Eio.Promise.resolve resolve_release_first ();
+    match Eio.Promise.await second_done with
+    | Ok () -> ()
+    | Error _ -> failwith "second same-keeper admission unexpectedly failed");
+  assert_eq
+    ~msg:"same keeper lane releases all runtime leases"
+    ~expected:0
+    ~actual:(KTA.runtime_turn_inflight ());
+  KTA.reset_for_test ()
+;;
+
+let test_runtime_lease_released_when_body_raises () =
+  (try
+     ignore
+       (KTS.with_keeper_turn_slot_admission
+          ~keeper_name:"raising-keeper"
+          ~channel:reactive
+          (fun ~semaphore_wait_ms:_ ->
+             assert_eq
+               ~msg:"body holds runtime lease"
+               ~expected:1
+               ~actual:(KTA.runtime_turn_inflight ());
+             raise Injected_body_failure));
+     failwith "expected injected body failure"
+   with
+   | Injected_body_failure -> ());
+  assert_eq
+    ~msg:"runtime lease released after body exception"
+    ~expected:0
+    ~actual:(KTA.runtime_turn_inflight ())
+;;
+
+let () =
+  let cases =
+    [ ( "runtime limit caps distinct keepers"
+      , with_fresh_state ~runtime_turn_limit:1 test_runtime_limit_caps_distinct_keepers )
+    ; ( "fleet pause and stop reject without consuming runtime"
+      , with_fresh_state test_fleet_pause_and_stop_do_not_consume_runtime )
+    ; ( "same keeper waits in local lane before runtime lease"
+      , test_same_keeper_lane_waits_before_runtime_lease )
+    ; ( "runtime lease released when body raises"
+      , with_fresh_state ~runtime_turn_limit:1 test_runtime_lease_released_when_body_raises
+      )
+    ]
+  in
+  List.iter
+    (fun (name, body) ->
+       try
+         body ();
+         Printf.printf "ok   %s\n" name
+       with exn ->
+         Printf.printf "FAIL %s: %s\n" name (Printexc.to_string exn);
+         exit 1)
+    cases
+;;

--- a/test/test_keeper_turn_slot_holders.ml
+++ b/test/test_keeper_turn_slot_holders.ml
@@ -9,17 +9,20 @@
     requires an Eio fiber context (Eio.Mutex on holder_table). *)
 
 module KK = Masc.Keeper_keepalive
+module KTA = Masc.Keeper_turn_admission
 module KTS = Masc.Keeper_turn_slot
 
 exception After_flag_injected
 
 let with_fresh_state body () =
-  Eio_main.run @@ fun _env ->
-    KK.set_after_acquire_flag_hook_for_test None;
-    KK.clear_force_released_markers_for_test ();
-    KK.reset_autonomous_completion_for_test ();
-    KK.reset_autonomous_turn_queue_for_test ();
-    body ()
+  Eio_main.run @@ fun env ->
+  Masc_test_deps.init_eio_clock env;
+  KK.set_after_acquire_flag_hook_for_test None;
+  KK.clear_force_released_markers_for_test ();
+  KK.reset_autonomous_completion_for_test ();
+  KK.reset_autonomous_turn_queue_for_test ();
+  KTA.reset_for_test ();
+  body ()
 
 let assert_eq ~msg ~expected ~actual =
   if expected <> actual then
@@ -392,40 +395,38 @@ let test_force_released_autonomous_holder_does_not_stamp_completion () =
          "force-released autonomous holder stamped normal completion: delay=%.3f"
          delay)
 
-let test_no_clock_exhausted_turn_slot_fails_closed () =
-  match Eio_context.get_clock_opt () with
-  | Some _ ->
-      (* This executable normally runs without a global Eio_context clock.
-         If a wider test runner has installed one, the no-clock branch is
-         not reachable in this process. *)
+let test_runtime_admission_exhausted_turn_slot_fails_closed () =
+  KTA.reset_for_test ~runtime_turn_limit:1 ();
+  match
+    KTA.acquire_runtime_turn_lease
+      ~keeper_name:"diag-runtime-holder"
+      ~channel:Masc.Keeper_world_observation.Reactive
       ()
-  | None ->
-      let rec acquire_all acquired =
-        if Eio.Semaphore.get_value KTS.turn_semaphore <= 0 then acquired
-        else begin
-          Eio.Semaphore.acquire KTS.turn_semaphore;
-          acquire_all (acquired + 1)
-        end
-      in
-      let rec release_n = function
-        | n when n <= 0 -> ()
-        | n ->
-            Eio.Semaphore.release KTS.turn_semaphore;
-            release_n (n - 1)
-      in
-      let acquired = acquire_all 0 in
+  with
+  | Error err ->
+      failwith
+        (Printf.sprintf
+           "failed to acquire setup runtime lease: %s"
+           (KTA.admission_error_to_string err))
+  | Ok () ->
       Fun.protect
-        ~finally:(fun () -> release_n acquired)
+        ~finally:(fun () ->
+          KTA.release_runtime_turn_lease ();
+          KTA.reset_for_test ())
         (fun () ->
           let result =
             KK.with_keeper_turn_slot_for_test
-              ~keeper_name:"diag-no-clock-exhausted"
+              ~keeper_name:"diag-runtime-exhausted"
               ~channel:Masc.Keeper_world_observation.Reactive
               (fun ~semaphore_wait_ms:_ ->
-                failwith "exhausted turn slot should fail before body runs")
+                failwith "exhausted runtime admission should fail before body runs")
           in
           match result with
           | Error (`Semaphore_wait_timeout snapshot) ->
+              assert_eq
+                ~msg:"runtime admission failure maps to turn-slot timeout"
+                ~expected:0
+                ~actual: snapshot.timeout_turn_available;
               if snapshot.timeout_phase <> KK.Turn_slot then
                 failwith
                   (Printf.sprintf
@@ -433,7 +434,7 @@ let test_no_clock_exhausted_turn_slot_fails_closed () =
                      (KK.semaphore_wait_phase_to_string
                         snapshot.timeout_phase))
           | Ok _ ->
-              failwith "exhausted no-clock acquire should fail closed")
+              failwith "exhausted runtime admission should fail closed")
 
 let test_force_release_marker_ttl_bounds_unfinalized_fibers () =
   KK.clear_force_released_markers_for_test ();
@@ -477,8 +478,8 @@ let () =
         test_force_release_marker_does_not_leak_to_replacement;
       "force released autonomous holder skips completion stamp",
         test_force_released_autonomous_holder_does_not_stamp_completion;
-      "no-clock exhausted turn slot fails closed",
-        test_no_clock_exhausted_turn_slot_fails_closed;
+      "runtime admission exhausted turn slot fails closed",
+        test_runtime_admission_exhausted_turn_slot_fails_closed;
       "force release marker ttl bounds unfinalized fibers",
         test_force_release_marker_ttl_bounds_unfinalized_fibers;
     ]


### PR DESCRIPTION
## Summary

- add `Keeper_turn_admission` as the central Runtime_turn admission gate
- replace the global keeper turn semaphore with per-keeper one-slot lanes
- acquire central runtime capacity only after keeper-local lane/channel admission
- wire heartbeat to handle fleet paused/stopped/runtime-capacity outcomes explicitly
- add focused admission regression coverage

## Tests

- `git diff --check`
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_codex_admission dune build --root . test/test_keeper_turn_admission.exe test/test_keeper_turn_slot_holders.exe`
- `_build_codex_admission/default/test/test_keeper_turn_admission.exe`
- `_build_codex_admission/default/test/test_keeper_turn_slot_holders.exe`
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_codex_admission dune build --root . test/test_keeper_turn_slot_lane_isolation.exe test/test_keeper_semaphore_wait_queue_head_clock.exe`
- `_build_codex_admission/default/test/test_keeper_turn_slot_lane_isolation.exe`
- `_build_codex_admission/default/test/test_keeper_semaphore_wait_queue_head_clock.exe`
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_codex_admission_check dune build --root . @check`
