### PR TITLE
fix(keeper): per-runtime autonomous semaphore + remove legacy slot_state

### DIFF
--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -385,6 +385,8 @@ type autonomous_waiter =
 type autonomous_lane =
   { queue : autonomous_waiter Queue.t
   ; active_count : int ref
+  ; semaphore : Eio.Semaphore.t
+  ; concurrency : int
   }
 
 let autonomous_lanes_mutex = Eio.Mutex.create ()
@@ -408,12 +410,45 @@ let record_autonomous_queue_depth depth =
     (float_of_int depth)
 ;;
 
+(** Per-runtime concurrency: look up a runtime-specific concurrency
+    limit from TOML config. Falls back to [autonomous_turn_limit] when
+    no runtime-specific override exists. The TOML key is
+    [MASC_KEEPER_AUTONOMOUS_CONCURRENCY_<RUNTIME_ID>] where runtime_id
+    dots and hyphens are replaced by underscores and uppercased.
+    E.g. runtime_id [ollama_cloud.deepseek-v4-flash] becomes
+    [MASC_KEEPER_AUTONOMOUS_CONCURRENCY_OLLAMA_CLOUD_DEEPSEEK_V4_FLASH]. *)
+let runtime_concurrency runtime_id =
+  let key =
+    "MASC_KEEPER_AUTONOMOUS_CONCURRENCY_"
+    ^ (runtime_id
+       |> String.map (fun c -> if c = '.' || c = '-' then '_' else Char.uppercase_ascii c))
+  in
+  turn_concurrency_int_of_env_default
+    key
+    ~default:autonomous_turn_limit
+    ~min_v:1
+    ~max_v:max_int
+;;
+
+(** Get or create a lane for the given [runtime_id], including a
+    per-runtime semaphore sized to that runtime's concurrency limit. *)
 let get_or_create_lane runtime_id =
   match Hashtbl.find_opt autonomous_lanes runtime_id with
   | Some lane -> lane
   | None ->
-    let lane = { queue = Queue.create (); active_count = ref 0 } in
+    let concurrency = runtime_concurrency runtime_id in
+    let lane =
+      { queue = Queue.create ()
+      ; active_count = ref 0
+      ; semaphore = Eio.Semaphore.make concurrency
+      ; concurrency
+      }
+    in
     Hashtbl.replace autonomous_lanes runtime_id lane;
+    Log.Keeper.info
+      "autonomous_lane: created lane for runtime=%s concurrency=%d"
+      runtime_id
+      concurrency;
     lane
 ;;
 


### PR DESCRIPTION
## Summary
- Add per-runtime [semaphore] and [concurrency] to [autonomous_lane], looked up from [MASC_KEEPER_AUTONOMOUS_CONCURRENCY_<RUNTIME_ID>] env with fallback to [autonomous_turn_limit].
- Per-runtime concurrency: runtime_id dots and hyphens are replaced by underscores and uppercased for TOML config lookup.

## Changes
- lib/keeper/keeper_turn_slot_acquire.ml: Add semaphore and concurrency fields to autonomous_lane record; add runtime_concurrency helper; size per-runtime semaphore at lane creation time.

## Related
- Issue #20402
- PR #20345 (per-runtime queue lanes — prerequisite)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>