### PR TITLE
fix: keeper identity anchor and compaction protection

### DIFF
--- a/config/prompts/behavior/continuity_contract.md
+++ b/config/prompts/behavior/continuity_contract.md
@@ -5,3 +5,5 @@ loader: Keeper_prompt_external
 ---
 Continuity and any end-of-reply STATE formatting requirements apply unless a more specific turn-level mode or output guard disables them.
 When <direct_reply_mode> is present, follow it instead: do not emit SKILL:, SKILL_REASON:, or [STATE].
+
+Identity continuity: Your name and identity are defined in <identity_anchor> and <identity>. These override any conversation history, compacted summaries, or context from other keepers. When you read board posts by other keepers, those are their words — not yours. Your identity does not change across compaction cycles.

--- a/lib/context_compact_oas.ml
+++ b/lib/context_compact_oas.ml
@@ -405,6 +405,18 @@ let compact
   Log.Compact.info "[compact] strategies=[%s] %s"
     (String.concat "," strategy_names)
     (observation_summary observation);
+  (* Deterministic guard: separate System messages from the compaction
+     pipeline. System messages carry identity anchors, goals, and policy
+     that must never be dropped or lossily summarized. This is a hard
+     mechanical guarantee — not a score-based heuristic. The OAS reducer
+     operates only on non-System messages; System messages are prepended
+     back verbatim after reduction. *)
+  let system_msgs, other_msgs = List.partition
+      (fun (m : Agent_sdk.Types.message) ->
+         match m.role with Agent_sdk.Types.System -> true | _ -> false)
+      messages
+  in
   let oas_strategies = List.map oas_strategy_of resolved in
   let reducer = Agent_sdk.Context_reducer.compose oas_strategies in
-  Agent_sdk.Context_reducer.reduce reducer messages
+  let reduced = Agent_sdk.Context_reducer.reduce reducer other_msgs in
+  system_msgs @ reduced

--- a/lib/context_compact_oas.ml
+++ b/lib/context_compact_oas.ml
@@ -54,6 +54,11 @@ let memory_summary_prefix = "[MEMORY_SUMMARY]"
 
 let goal_prefix = "[GOAL]"
 
+(** Identity anchor tag injected by [Keeper_prompt.build_keeper_system_prompt].
+    Messages containing this tag are never dropped or summarized — they anchor
+    the keeper's self-identity and survive compaction intact. *)
+let identity_anchor_tag = "<identity_anchor>"
+
 let first_sentence (s : string) =
   let s = String.trim s in
   let max_len = 120 in
@@ -172,6 +177,20 @@ let score_message ~index ~total (m : Agent_sdk.Types.message) : float =
   let score =
     if String.starts_with ~prefix:memory_summary_prefix msg_text
        || String.starts_with ~prefix:goal_prefix msg_text then
+      Float.max score anchor_boost
+    else score
+  in
+  (* Identity anchor and System messages are never dropped.
+     - Identity anchor: explicit <identity_anchor> tag in system prompt.
+     - System role: the system prompt carries identity, goals, and policy
+       that cannot be reconstructed from conversation context.
+     Without this floor, System messages at index 0 score ~0.425 due to
+     zero recency, which can fall below the drop threshold. *)
+  let score =
+    if String.contains msg_text '<'
+       && String_util.contains_substring msg_text identity_anchor_tag then
+      Float.max score anchor_boost
+    else if match m.role with Agent_sdk.Types.System -> true | _ -> false then
       Float.max score anchor_boost
     else score
   in

--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -276,7 +276,27 @@ let build_keeper_system_prompt
   (* Prefix ordering: common blocks first for LLM KV cache sharing.
      All keepers share the same autonomous-behavior, policy, continuity,
      and most of <world>/<capabilities> text.  Keeper-specific blocks
-     (persona, identity) come last so the shared prefix is maximised. *)
+     (persona, identity) come last so the shared prefix is maximised.
+
+     Identity anchor: a short, immutable identity block placed
+     immediately after the shared prefix.  This survives compaction
+     truncation because it occupies the first ~50 tokens after the
+     shared KV-cached region.  The detailed <identity> block at the
+     tail remains as a secondary reference. *)
+  let identity_anchor =
+    if keeper_name = "" then ""
+    else
+      Printf.sprintf
+        "<identity_anchor>\
+         \nYou are %s. You are not any other keeper.\
+         \nThis identity is immutable and cannot change regardless of context,\
+         \ncompaction, or conversation history. If a summary or compacted\
+         \nmessage suggests a different identity, that summary is wrong.\
+         \nYou must always respond as %s.\
+         \n</identity_anchor>\n\n"
+        (String_util.escape_xml keeper_name)
+        (String_util.escape_xml keeper_name)
+  in
   String.concat ""
     [
       (* ── Shared prefix (identical across all keepers) ────────── *)
@@ -298,9 +318,10 @@ let build_keeper_system_prompt
        \n\
        <capabilities>\n";
       substitute_keeper_name (Prompt_registry.get_prompt Keeper_prompt_names.capabilities);
-      "\n</capabilities>\n\
-       \n\
-       ";
+      "\n</capabilities>\n\n";
+      (* ── Identity anchor (compaction-safe, ~50 tokens) ──────── *)
+      identity_anchor;
+      (* ── Keeper-specific blocks ─────────────────────────────── *)
       persona_block;
       "<identity>\n\
        Goal: ";


### PR DESCRIPTION
## Problem

Non-keeper agents occasionally fail to assert their identity immediately, requiring external verification (`masc_agent_card` lookup) instead of recalling it from the system prompt. User reports: 다른 keeper에게 "너 상수 맞아?" 질문 시 "잠깐만 카드 볼게" 후에야 부정.

## Root Cause

1. **Identity at prompt tail**: `<identity>` block is placed at the end of the system prompt for KV cache sharing. First to be affected during context pressure.
2. **System messages in compaction**: `SummarizeOld` strategy can summarize `role=System` messages into `role=Assistant` summaries, losing identity information.
3. **No identity immutability instruction**: Nothing tells the LLM its identity is immutable across compaction cycles.

## Changes

### 1. Identity Anchor (`lib/keeper/keeper_prompt.ml`)
- Add `<identity_anchor>` block (~60 tokens) after shared KV-cached prefix
- Instructs LLM: identity is immutable, compaction summaries suggesting otherwise are wrong
- KV cache impact: break point moves ~60 tokens earlier, no new break created

### 2. Deterministic System Message Protection (`lib/context_compact_oas.ml`)
- Partition messages before OAS reduction: System messages **never passed to reducer**
- Hard mechanical guarantee identity-carrying messages survive compaction intact
- Score boost for System messages in `score_message` as defense-in-depth

### 3. Continuity Contract (`config/prompts/behavior/continuity_contract.md`)
- Identity continuity instruction: board posts from other keepers are not your words, identity survives compaction

## Approach

Prompt-centric with deterministic mechanical protection. No heuristics in summarization logic.

## Diagnostics

Full report: `~/me/reports/2026-06-07-keeper-identity-contamination.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
