### PR TITLE
refactor(keeper): route IDE annotations through neutral bus

### DIFF
--- a/lib/agent_observation/agent_observation.ml
+++ b/lib/agent_observation/agent_observation.ml
@@ -150,34 +150,88 @@ type write_region_event =
   ; tool_call_json : Yojson.Safe.t
   }
 
+type annotation_kind =
+  | Comment
+  | Decision
+  | Question
+  | Bookmark
+
+let annotation_kind_to_string = function
+  | Comment -> "Comment"
+  | Decision -> "Decision"
+  | Question -> "Question"
+  | Bookmark -> "Bookmark"
+;;
+
+let annotation_kind_of_string = function
+  | "Comment" -> Some Comment
+  | "Decision" -> Some Decision
+  | "Question" -> Some Question
+  | "Bookmark" -> Some Bookmark
+  | _ -> None
+;;
+
+type annotation_request =
+  { base_path : string
+  ; keeper_id : string
+  ; file_path : string
+  ; line_start : int
+  ; line_end : int
+  ; kind : annotation_kind
+  ; content : string
+  ; goal_id : string option
+  ; task_id : string option
+  ; board_post_id : string option
+  ; comment_id : string option
+  ; pr_id : string option
+  ; git_ref : string option
+  ; log_id : string option
+  ; session_id : string option
+  ; operation_id : string option
+  ; worker_run_id : string option
+  }
+
+type annotation_result =
+  { id : string
+  ; file_path : string
+  ; line_start : int
+  ; line_end : int
+  }
+
 type tool_event_sink = tool_event -> unit
 type pr_event_sink = pr_event -> unit
 type turn_event_sink = turn_event -> unit
 type write_region_sink = write_region_event -> unit
+type annotation_sink = annotation_request -> (annotation_result, string) result
 
 let noop_tool_event_sink (_ : tool_event) = ()
 let noop_pr_event_sink (_ : pr_event) = ()
 let noop_turn_event_sink (_ : turn_event) = ()
 let noop_write_region_sink (_ : write_region_event) = ()
+let noop_annotation_sink (_ : annotation_request) = Error "annotation sink is not installed"
 
 let tool_event_sink = Atomic.make noop_tool_event_sink
 let pr_event_sink = Atomic.make noop_pr_event_sink
 let turn_event_sink = Atomic.make noop_turn_event_sink
 let write_region_sink = Atomic.make noop_write_region_sink
+let annotation_sink = Atomic.make noop_annotation_sink
 
 let register_tool_event_sink sink = Atomic.set tool_event_sink sink
 let register_pr_event_sink sink = Atomic.set pr_event_sink sink
 let register_turn_event_sink sink = Atomic.set turn_event_sink sink
 let register_write_region_sink sink = Atomic.set write_region_sink sink
+let register_annotation_sink sink = Atomic.set annotation_sink sink
 
 let emit_tool_event event = Atomic.get tool_event_sink event
 let emit_pr_event event = Atomic.get pr_event_sink event
 let emit_turn_event event = Atomic.get turn_event_sink event
 let emit_write_region_event event = Atomic.get write_region_sink event
+let emit_annotation_request request = Atomic.get annotation_sink request
 
 let reset_for_testing () =
   Atomic.set tool_event_sink noop_tool_event_sink;
   Atomic.set pr_event_sink noop_pr_event_sink;
   Atomic.set turn_event_sink noop_turn_event_sink;
-  Atomic.set write_region_sink noop_write_region_sink
+  Atomic.set write_region_sink noop_write_region_sink;
+  Atomic.set annotation_sink noop_annotation_sink
 ;;

--- a/lib/agent_observation/agent_observation.mli
+++ b/lib/agent_observation/agent_observation.mli
@@ -54,20 +54,59 @@ type write_region_event =
   ; tool_call_json : Yojson.Safe.t
   }
 
+type annotation_kind =
+  | Comment
+  | Decision
+  | Question
+  | Bookmark
+
+val annotation_kind_to_string : annotation_kind -> string
+val annotation_kind_of_string : string -> annotation_kind option
+
+type annotation_request =
+  { base_path : string
+  ; keeper_id : string
+  ; file_path : string
+  ; line_start : int
+  ; line_end : int
+  ; kind : annotation_kind
+  ; content : string
+  ; goal_id : string option
+  ; task_id : string option
+  ; board_post_id : string option
+  ; comment_id : string option
+  ; pr_id : string option
+  ; git_ref : string option
+  ; log_id : string option
+  ; session_id : string option
+  ; operation_id : string option
+  ; worker_run_id : string option
+  }
+
+type annotation_result =
+  { id : string
+  ; file_path : string
+  ; line_start : int
+  ; line_end : int
+  }
+
 type tool_event_sink = tool_event -> unit
 type pr_event_sink = pr_event -> unit
 type turn_event_sink = turn_event -> unit
 type write_region_sink = write_region_event -> unit
+type annotation_sink = annotation_request -> (annotation_result, string) result
 
 val register_tool_event_sink : tool_event_sink -> unit
 val register_pr_event_sink : pr_event_sink -> unit
 val register_turn_event_sink : turn_event_sink -> unit
 val register_write_region_sink : write_region_sink -> unit
+val register_annotation_sink : annotation_sink -> unit
 
 val emit_tool_event : tool_event -> unit
 val emit_pr_event : pr_event -> unit
 val emit_turn_event : turn_event -> unit
 val emit_write_region_event : write_region_event -> unit
+val emit_annotation_request : annotation_request -> (annotation_result, string) result
 
 val reset_for_testing : unit -> unit
 (** Reset sinks to no-op. Intended for isolated tests only. *)

--- a/lib/ide/ide_bridge.ml
+++ b/lib/ide/ide_bridge.ml
@@ -187,6 +187,13 @@ let now_ms () =
   Int64.of_float (Unix.gettimeofday () *. 1000.0)
 ;;
 
+let annotation_kind_to_ide = function
+  | Agent_observation.Comment -> Ide_annotation_types.Comment
+  | Agent_observation.Decision -> Ide_annotation_types.Decision
+  | Agent_observation.Question -> Ide_annotation_types.Question
+  | Agent_observation.Bookmark -> Ide_annotation_types.Bookmark
+;;
+
 let list_kind_events ~base_path ~partition ~kind ?keeper_id () =
   let dir = Ide_paths.partition_store_dir ~base_dir:base_path partition in
   let path = Filename.concat dir (event_file_name kind) in
@@ -832,7 +839,56 @@ let install_agent_observation_sinks () =
         ~partition:event.partition
         ~keeper_id:event.keeper_id
         ~turn:event.turn
-        event.tool_call_json)
+        event.tool_call_json);
+  Agent_observation.register_annotation_sink
+    (fun ({ base_path
+           ; keeper_id
+           ; file_path
+           ; line_start
+           ; line_end
+           ; kind
+           ; content
+           ; goal_id
+           ; task_id
+           ; board_post_id
+           ; comment_id
+           ; pr_id
+           ; git_ref
+           ; log_id
+           ; session_id
+           ; operation_id
+           ; worker_run_id
+           }
+          : Agent_observation.annotation_request) ->
+      match
+        Ide_annotations.create
+          ~base_dir:base_path
+          ~keeper_id
+          ~file_path
+          ~line_start
+          ~line_end
+          ~kind:(annotation_kind_to_ide kind)
+          ~content
+          ?goal_id
+          ?task_id
+          ?board_post_id
+          ?comment_id
+          ?pr_id
+          ?git_ref
+          ?log_id
+          ?session_id
+          ?operation_id
+          ?worker_run_id
+          ()
+      with
+      | Error msg -> Error msg
+      | Ok annotation ->
+        Ok
+          { Agent_observation.id = annotation.id
+          ; file_path = annotation.file_path
+          ; line_start = annotation.line_start
+          ; line_end = annotation.line_end
+          })
 ;;
 
 let () = install_agent_observation_sinks ()

--- a/lib/keeper/keeper_tool_ide_runtime.ml
+++ b/lib/keeper/keeper_tool_ide_runtime.ml
@@ -10,7 +10,6 @@ open Keeper_types
 open Keeper_meta_contract
 open Keeper_types_profile
 open Keeper_tool_shared_runtime
-open Ide_annotation_types
 
 let handle_ide_annotate
       ~(config : Workspace.config)
@@ -44,30 +43,30 @@ let handle_ide_annotate
   then error_json "content is required for ide_annotate"
   else (
     let kind =
-      match Ide_annotations.annotation_kind_of_string kind_str with
+      match Agent_observation.annotation_kind_of_string kind_str with
       | Some k -> k
-      | None -> Comment
+      | None -> Agent_observation.Comment
     in
     match
-      Ide_annotations.create
-        ~base_dir
-        ~keeper_id:keeper_name
-        ~file_path
-        ~line_start
-        ~line_end
-        ~kind
-        ~content
-        ?goal_id
-        ?task_id
-        ?board_post_id
-        ?comment_id
-        ?pr_id
-        ?git_ref
-        ?log_id
-        ?session_id
-        ?operation_id
-        ?worker_run_id
-        ()
+      Agent_observation.emit_annotation_request
+        { base_path = base_dir
+        ; keeper_id = keeper_name
+        ; file_path
+        ; line_start
+        ; line_end
+        ; kind
+        ; content
+        ; goal_id
+        ; task_id
+        ; board_post_id
+        ; comment_id
+        ; pr_id
+        ; git_ref
+        ; log_id
+        ; session_id
+        ; operation_id
+        ; worker_run_id
+        }
     with
     | Ok annotation ->
       Yojson.Safe.to_string

--- a/test/test_agent_observation_bridge.ml
+++ b/test/test_agent_observation_bridge.ml
@@ -129,6 +129,54 @@ let test_write_region_observation_reaches_ide_storage () =
     | _ -> fail "expected one region")
 ;;
 
+let test_annotation_request_reaches_ide_storage () =
+  with_temp_dir (fun base_dir ->
+    install_fresh_ide_sink ();
+    let result =
+      Agent_observation.emit_annotation_request
+        { base_path = base_dir
+        ; keeper_id = "keeper-epsilon"
+        ; file_path = "lib/annotated.ml"
+        ; line_start = 7
+        ; line_end = 9
+        ; kind = Agent_observation.Decision
+        ; content = "route through neutral observation bus"
+        ; goal_id = Some "goal-17"
+        ; task_id = None
+        ; board_post_id = Some "post-3"
+        ; comment_id = None
+        ; pr_id = None
+        ; git_ref = None
+        ; log_id = None
+        ; session_id = None
+        ; operation_id = None
+        ; worker_run_id = None
+        }
+    in
+    match result with
+    | Error msg -> failf "annotation request failed: %s" msg
+    | Ok created ->
+      check string "result file" "lib/annotated.ml" created.file_path;
+      check int "result line start" 7 created.line_start;
+      check int "result line end" 9 created.line_end;
+      let filter : Ide_annotation_types.annotation_filter =
+        { file_path = Some "lib/annotated.ml"
+        ; keeper_id = Some "keeper-epsilon"
+        ; goal_id = Some "goal-17"
+        ; task_id = None
+        }
+      in
+      (match Ide_annotations.list ~base_dir ~filter () with
+       | [ annotation ] ->
+         check string "id" created.id annotation.id;
+         check string "content" "route through neutral observation bus" annotation.content;
+         check (option string) "board post" (Some "post-3") annotation.board_post_id;
+         (match annotation.kind with
+          | Ide_annotation_types.Decision -> ()
+          | _ -> fail "expected Decision annotation kind")
+       | rows -> failf "expected one annotation, got %d" (List.length rows)))
+;;
+
 let () =
   run
     "agent_observation_bridge"
@@ -143,6 +191,10 @@ let () =
             "write-region observation reaches IDE storage"
             `Quick
             test_write_region_observation_reaches_ide_storage
+        ; test_case
+            "annotation request reaches IDE storage"
+            `Quick
+            test_annotation_request_reaches_ide_storage
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- Add neutral annotation request/result plumbing to Agent_observation.
- Register an IDE bridge annotation sink that maps neutral annotation requests into Ide_annotations.create.
- Remove Keeper_tool_ide_runtime's direct Ide_annotations / Ide_annotation_types dependency.
- Cover the new request path in test_agent_observation_bridge.

## Verification
- ocamlformat --check lib/agent_observation/agent_observation.ml lib/agent_observation/agent_observation.mli lib/ide/ide_bridge.ml lib/keeper/keeper_tool_ide_runtime.ml test/test_agent_observation_bridge.ml
- env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_keeper_ide_annotation_boundary dune build --root . test/test_agent_observation_bridge.exe test/test_ide_annotations.exe
- ./_build_keeper_ide_annotation_boundary/default/test/test_agent_observation_bridge.exe
- ./_build_keeper_ide_annotation_boundary/default/test/test_ide_annotations.exe
- rg -n "Ide_bridge|Ide_annotations|Ide_annotation_types|Ide_region_tracker|Ide_" lib/keeper/keeper_tool_ide_runtime.ml lib/keeper/keeper_tool_ide_runtime.mli
- rg -n "Ide_bridge|Ide_command_descriptor|Ide_event_types|Ide_annotations|Ide_annotation_types|Ide_region_tracker" lib/keeper lib/tool lib/tool_surface lib/tool_types lib/tool_call_quality_benchmark
- rg -n "Ide_" lib/keeper lib/tool lib/tool_surface lib/tool_types lib/tool_call_quality_benchmark
- rg -n "failwith|assert false|Fun\.protect|Mutex\.(lock|unlock)|Stdlib\.Lazy" lib/agent_observation/agent_observation.ml lib/agent_observation/agent_observation.mli lib/ide/ide_bridge.ml lib/keeper/keeper_tool_ide_runtime.ml test/test_agent_observation_bridge.ml