### PR TITLE
feat(ide): dashboard IDE boundary P1 follow-up (snapshot + cursor)

### DIFF
--- a/lib/ide/ide_bridge.ml
+++ b/lib/ide/ide_bridge.ml
@@ -564,6 +564,40 @@ let ingest_cursor_event_from_hook
          "Ide_bridge.ingest_cursor_event_from_hook error: %s\n%!"
          (Printexc.to_string exn))
   | _ -> ()
+
+let ingest_cursor_event
+    ~base_path
+    ~keeper_id
+    ~file_path
+    ~line
+    ?column
+    ?selection_end
+    ?focus_mode
+    ~source
+    ()
+  =
+  let column = Option.value column ~default:0 in
+  let focus_mode = Option.value focus_mode ~default:"edit" in
+  let timestamp_ms = now_ms () in
+  let json =
+    cursor_event_json
+      ~keeper_id
+      ~file_path
+      ~line
+      ~column
+      ?selection_end
+      ~focus_mode
+      ~last_update:timestamp_ms
+      ~tool_name:source
+      ~turn_id:""
+      ()
+  in
+  (try append_cursor ~base_dir:base_path ~partition:default_partition json
+   with exn ->
+     Printf.eprintf
+       "Ide_bridge.ingest_cursor_event error: %s\n%!"
+       (Printexc.to_string exn))
+;;
 ;;
 
 (** Extract tool event parameters from raw hook data and ingest.

--- a/lib/ide/ide_bridge.mli
+++ b/lib/ide/ide_bridge.mli
@@ -30,6 +30,21 @@ val list_cursors :
   ?offset:int ->
   unit ->
   Yojson.Safe.t list
+
+(** Ingest a cursor event from an external source (e.g. editor or LSP).
+    Unlike [ingest_cursor_event_from_hook], this does not require a tool hook
+    context and uses the provided [source] label as the tool_name field. *)
+val ingest_cursor_event :
+  base_path:string ->
+  keeper_id:string ->
+  file_path:string ->
+  line:int ->
+  ?column:int ->
+  ?selection_end:(int * int) ->
+  ?focus_mode:string ->
+  source:string ->
+  unit ->
+  unit
 (** Return latest valid cursor records, newest first. Cursor records are
     produced from tool hooks only when the hook input contains a non-empty
     file path and a positive line number. *)

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -531,6 +531,77 @@ let dashboard_goals_snapshot_json ~(config : Workspace.config) : Yojson.Safe.t =
     [ "planning", dashboard_planning_http_json ~config
     ; "tree", dashboard_goals_tree_http_json ~config
     ]
+
+let dashboard_ide_snapshot_json ~(config : Workspace.config) : Yojson.Safe.t =
+  let base_path = config.base_path in
+  let partition = Ide_paths.Orphan in
+  let limit = 10 in
+  let events =
+    Ide_bridge.list_events
+      ~base_path
+      ~partition
+      ~limit
+      ~offset:0
+      ()
+  in
+  let cursors =
+    Ide_bridge.list_cursors
+      ~base_path
+      ~partition
+      ~limit
+      ~offset:0
+      ()
+  in
+  let annotations =
+    Ide_annotations.list
+      ~base_dir:base_path
+      ~partition
+      ~filter:{ file_path = None; keeper_id = None; goal_id = None; task_id = None }
+      ()
+  in
+  let regions =
+    Ide_region_tracker.read_regions
+      ~base_dir:base_path
+      ~partition
+      ()
+  in
+  let active_keepers =
+    try
+      List.map
+        (fun (a : Client_identity.t) ->
+           `Assoc
+             [ "keeper_id", `String a.Client_identity.agent_name
+             ; "last_seen_ms", `Intlit (Printf.sprintf "%.0f" (a.Client_identity.registered_at *. 1000.0))
+             ])
+        (Client_registry_eio.list_active ~within_seconds:300.0 ())
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | _exn -> []
+  in
+  `Assoc
+    [ "events", `Assoc
+        [ "count", `Int (List.length events)
+        ; "recent", `List events
+        ]
+    ; "cursors", `Assoc
+        [ "count", `Int (List.length cursors)
+        ; "recent", `List cursors
+        ]
+    ; "annotations", `Assoc
+        [ "count", `Int (List.length annotations)
+        ]
+    ; "regions", `Assoc
+        [ "count", `Int (List.length regions)
+        ]
+    ; "presence", `Assoc
+        [ "active_keepers", `List active_keepers
+        ; "count", `Int (List.length active_keepers)
+        ]
+    ; "freshness", `Assoc
+        [ "snapshot_at", `String (Masc_domain.now_iso ())
+        ]
+    ]
+;;
 ;;
 
 

--- a/lib/server/server_dashboard_http.mli
+++ b/lib/server/server_dashboard_http.mli
@@ -109,6 +109,9 @@ val dashboard_goals_tree_http_json :
 val dashboard_goals_snapshot_json :
   config:Workspace.config -> Yojson.Safe.t
 
+val dashboard_ide_snapshot_json :
+  config:Workspace.config -> Yojson.Safe.t
+
 val dashboard_goal_detail_http_json :
   config:Workspace.config -> goal_id:string -> Yojson.Safe.t
 

--- a/lib/server/server_ide_http.ml
+++ b/lib/server/server_ide_http.ml
@@ -511,6 +511,62 @@ let add_routes router =
            reqd)
       request
       reqd)
+  |> Http.Router.post "/api/v1/ide/cursors" (fun request reqd ->
+    with_public_read
+      (fun state req reqd ->
+         let base = base_path_of_state state in
+         Http.Request.read_body_async reqd (fun body_str ->
+           let json =
+             try Yojson.Safe.from_string body_str with
+             | _ -> `Assoc []
+           in
+           let find_string key =
+             match json with
+             | `Assoc fields ->
+               (match List.assoc_opt key fields with
+                | Some (`String s) when s <> "" -> Some s
+                | _ -> None)
+             | _ -> None
+           in
+           let find_int key =
+             match json with
+             | `Assoc fields ->
+               (match List.assoc_opt key fields with
+                | Some (`Int i) -> Some i
+                | Some (`Intlit s) -> int_of_string_opt s
+                | _ -> None)
+             | _ -> None
+           in
+           match
+             ( find_string "file_path"
+             , find_int "line"
+             , find_string "keeper_id" )
+           with
+           | Some file_path, Some line, Some keeper_id
+             when line >= 1 ->
+             let column = find_int "column" in
+             let source = Option.value (find_string "source") ~default:"editor" in
+             Ide_bridge.ingest_cursor_event
+               ~base_path:base
+               ~keeper_id
+               ~file_path
+               ~line
+               ?column
+               ~source
+               ();
+             Http.Response.json_value
+               ~status:`Created
+               ~request
+               (json_ok (`Assoc [ "ok", `Bool true ]))
+               reqd
+           | _ ->
+             Http.Response.json_value
+               ~status:`Bad_request
+               ~request
+               (json_error "Missing required fields: file_path, line (>=1), keeper_id")
+               reqd))
+      request
+      reqd)
   |> Http.Router.get "/api/v1/ide/presence/stream" (fun request reqd ->
     with_public_read
       (fun state _req inner_reqd ->

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -793,6 +793,10 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
             Some
               (Server_dashboard_http.dashboard_goals_snapshot_json
                  ~config:state.Mcp_server.workspace_config)
+        | "ide" ->
+            Some
+              (Server_dashboard_http.dashboard_ide_snapshot_json
+                 ~config:state.Mcp_server.workspace_config)
         | _ ->
             None);
       (* Standalone WebSocket transport (enabled by default, opt-out via MASC_WS_ENABLED=0) *)


### PR DESCRIPTION
## Summary

Dashboard IDE Boundary Report (2026-06-07) P1 follow-up 중 Task 1, 2를 구현합니다.

### Changes

- **IDE WS Snapshot Surface**
  - `dashboard_ide_snapshot_json` 추가: events, cursors, annotations, regions, presence, freshness 데이터 포함
  - dashboard WebSocket snapshot provider에 `'ide'` surface 등록

- **Editor/LSP Native Cursor Producer**
  - `Ide_bridge.ingest_cursor_event` 추가 (tool hook 없이 외부 source에서 cursor event 기록)
  - `POST /api/v1/ide/cursors` endpoint 추가: editor/LSP가 cursor position을 서버에 전송

### Verification

- `dune build @check` PASS

### Remaining

- Task 3: Execute running-output producer (`Masc_exec.Exec_dispatch` streaming 수정 필요, 별도 후속)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
