### PR TITLE
feat(execute): add running-output streaming producer

### DIFF
--- a/lib/dashboard/dashboard_execute_output.ml
+++ b/lib/dashboard/dashboard_execute_output.ml
@@ -32,6 +32,11 @@ type snapshot = {
 }
 
 type stream_event =
+  | Task_opened_event of {
+      keeper : string;
+      task_id : string option;
+      generated_at : float;
+    }
   | Line_event of {
       keeper : string;
       task_id : string option;
@@ -64,6 +69,11 @@ let table : (string, entry Queue.t) Hashtbl.t = Hashtbl.create 16
 let line_table : (string, output_line Queue.t) Hashtbl.t = Hashtbl.create 16
 let subscribers : (string, subscriber list) Hashtbl.t = Hashtbl.create 16
 let next_subscriber_id = ref 0
+
+(* Open stream tracking so that live chunks carry the same task_id as the
+   execution that produced them. *)
+type open_stream_state = { task_id : string option }
+let open_streams : (string, open_stream_state) Hashtbl.t = Hashtbl.create 16
 
 let normalize_keeper keeper_name =
   keeper_name |> String.trim |> String.lowercase_ascii
@@ -167,7 +177,7 @@ let broadcast_events subscribers events =
          subscribers)
     events
 
-let append_completed ~keeper_name (entry : entry) =
+let append_completed ?(emit_events = true) ~keeper_name (entry : entry) =
   let keeper = normalize_keeper keeper_name in
   if keeper = ""
   then ()
@@ -176,33 +186,101 @@ let append_completed ~keeper_name (entry : entry) =
     let current_subscribers =
       with_lock (fun () -> append_completed_locked ~keeper entry lines)
     in
-    let events =
-      List.map
-        (fun line ->
-           Line_event { keeper; task_id = entry.task_id; line; generated_at = entry.generated_at })
-        lines
-      @ [ Task_closed_event
-            { keeper
-            ; task_id = entry.task_id
-            ; status = entry.status
-            ; generated_at = entry.generated_at
-            }
-        ]
-    in
-    broadcast_events current_subscribers events)
+    if emit_events
+    then (
+      let events =
+        List.map
+          (fun line ->
+             Line_event { keeper; task_id = entry.task_id; line; generated_at = entry.generated_at })
+          lines
+        @ [ Task_closed_event
+              { keeper
+              ; task_id = entry.task_id
+              ; status = entry.status
+              ; generated_at = entry.generated_at
+              }
+          ]
+      in
+      broadcast_events current_subscribers events)
+  )
 
 let record_failure exn =
   Log.Dashboard.warn
     "dashboard execute output collector failed: %s"
     (Printexc.to_string exn)
 
-let record_completed ~keeper_name ~task_id ~stdout ~stderr ~status =
+let record_completed ~keeper_name ~task_id ~stdout ~stderr ~status ?(streamed = false) () =
   let entry =
     { task_id; stdout; stderr; status; generated_at = now_unix () }
   in
-  try append_completed ~keeper_name entry with
+  try append_completed ~emit_events:(not streamed) ~keeper_name entry with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn -> record_failure exn
+
+let record_stream_start ~keeper_name ~task_id =
+  let keeper = normalize_keeper keeper_name in
+  if keeper = ""
+  then ()
+  else (
+    let generated_at = now_unix () in
+    let current_subscribers =
+      with_lock (fun () ->
+        Hashtbl.replace open_streams keeper { task_id };
+        Hashtbl.find_opt subscribers keeper |> Option.value ~default:[])
+    in
+    broadcast_events current_subscribers [ Task_opened_event { keeper; task_id; generated_at } ])
+
+let append_stream_chunk ~keeper_name ~stream chunk =
+  let keeper = normalize_keeper keeper_name in
+  if keeper = "" || String.equal chunk ""
+  then ()
+  else (
+    let generated_at = now_unix () in
+    let ts_ms = ts_ms_of_unix generated_at in
+    let stream_label =
+      match stream with
+      | `Stdout -> "stdout"
+      | `Stderr -> "stderr"
+    in
+    let lines = output_lines_for_chunk ~ts_ms ~stream:stream_label chunk in
+    let task_id, current_subscribers =
+      with_lock (fun () ->
+        let task_id =
+          match Hashtbl.find_opt open_streams keeper with
+          | Some state -> state.task_id
+          | None -> None
+        in
+        let line_q =
+          match Hashtbl.find_opt line_table keeper with
+          | Some q -> q
+          | None ->
+            let q = Queue.create () in
+            Hashtbl.add line_table keeper q;
+            q
+        in
+        List.iter (append_bounded line_q line_ring_cap) lines;
+        task_id, Hashtbl.find_opt subscribers keeper |> Option.value ~default:[])
+    in
+    let events =
+      List.map
+        (fun line -> Line_event { keeper; task_id; line; generated_at })
+        lines
+    in
+    broadcast_events current_subscribers events)
+
+let record_stream_end ~keeper_name ~task_id ~status =
+  let keeper = normalize_keeper keeper_name in
+  if keeper = ""
+  then ()
+  else (
+    let generated_at = now_unix () in
+    let current_subscribers =
+      with_lock (fun () ->
+        Hashtbl.remove open_streams keeper;
+        Hashtbl.find_opt subscribers keeper |> Option.value ~default:[])
+    in
+    broadcast_events current_subscribers
+      [ Task_closed_event { keeper; task_id; status; generated_at } ])
 
 let snapshot_state keeper_name =
   let keeper = normalize_keeper keeper_name in
@@ -310,6 +388,16 @@ let event_json ~keeper_name =
   | None -> no_task_json keeper_name
 
 let stream_event_json = function
+  | Task_opened_event { keeper; task_id; generated_at } ->
+    `Assoc
+      [ "type", `String "task_opened"
+      ; "kind", `String "task_opened"
+      ; "keeper", `String keeper
+      ; "keeper_id", `String keeper
+      ; "task_id", option_json (fun value -> `String value) task_id
+      ; "closed", `Bool false
+      ; "generated_at", `Float generated_at
+      ]
   | Line_event { keeper; task_id; line; generated_at } ->
     `Assoc
       [ "type", `String "line"
@@ -372,6 +460,7 @@ let reset_for_testing () =
     Hashtbl.clear table;
     Hashtbl.clear line_table;
     Hashtbl.clear subscribers;
+    Hashtbl.clear open_streams;
     next_subscriber_id := 0)
 
 let output_lines_for_testing ~keeper_name =
@@ -397,6 +486,22 @@ let inject_for_testing
 
 let () =
   Keeper_keepalive_signal.register_record_execute_output
-    (fun ~keeper_name ~task_id ~stdout ~stderr ~status ->
-       record_completed ~keeper_name ~task_id ~stdout ~stderr ~status)
+    (fun ~keeper_name ~task_id ~stdout ~stderr ~status ~streamed ->
+       record_completed ~streamed ~keeper_name ~task_id ~stdout ~stderr ~status ())
+;;
+
+let () =
+  Keeper_keepalive_signal.register_record_execute_stream_chunk
+    (fun ~keeper_name ~stream chunk ->
+       append_stream_chunk ~keeper_name ~stream chunk)
+;;
+
+let () =
+  Keeper_keepalive_signal.register_record_execute_stream_start
+    (fun ~keeper_name ~task_id -> record_stream_start ~keeper_name ~task_id)
+;;
+
+let () =
+  Keeper_keepalive_signal.register_record_execute_stream_end
+    (fun ~keeper_name ~task_id ~status -> record_stream_end ~keeper_name ~task_id ~status)
 ;;

--- a/lib/dashboard/dashboard_execute_output.mli
+++ b/lib/dashboard/dashboard_execute_output.mli
@@ -36,9 +36,29 @@ val record_completed :
   stdout:string ->
   stderr:string ->
   status:Yojson.Safe.t ->
+  ?streamed:bool ->
+  unit ->
   unit
-(** Record a completed Execute invocation. Non-cancellation failures are logged
-    and swallowed by the implementation because this path is observational. *)
+(** Record a completed Execute invocation.  When [~streamed:true] the line and
+    task_closed events have already been emitted via
+    {!append_stream_chunk}/{!record_stream_end}, so this call only updates the
+    retained snapshot.  Non-cancellation failures are logged and swallowed by
+    the implementation because this path is observational. *)
+
+val record_stream_start :
+  keeper_name:string -> task_id:string option -> unit
+(** Emit a [task_opened] event to current subscribers and bind subsequent
+    chunks to [task_id] until [record_stream_end] is called. *)
+
+val append_stream_chunk :
+  keeper_name:string -> stream:[ `Stdout | `Stderr ] -> string -> unit
+(** Append a live output chunk, split it into lines, and broadcast [line]
+    events to current subscribers. Empty chunks are ignored. *)
+
+val record_stream_end :
+  keeper_name:string -> task_id:string option -> status:Yojson.Safe.t -> unit
+(** Emit a [task_closed] event to current subscribers and release the open
+    stream binding. *)
 
 val snapshot : keeper_name:string -> snapshot option
 (** Latest retained Execute output for [keeper_name], if any. *)

--- a/lib/exec/exec_dispatch.ml
+++ b/lib/exec/exec_dispatch.ml
@@ -158,7 +158,7 @@ let process_spec_of_simple (s : Shell_ir.simple) =
   in
   (argv, env, cwd)
 
-let dispatch_simple ?timeout_sec ?stdin_content (s : Shell_ir.simple) =
+let dispatch_simple ?timeout_sec ?stdin_content ?on_output_chunk (s : Shell_ir.simple) =
   let argv, env, cwd = process_spec_of_simple s in
   let timeout_sec = dispatch_timeout_sec timeout_sec in
   match redirect_plan_of_redirects s.redirects with
@@ -171,24 +171,58 @@ let dispatch_simple ?timeout_sec ?stdin_content (s : Shell_ir.simple) =
       let run () =
         match stdin_content with
         | None ->
-          Exec_gate.run_argv_with_status_split
-            ~actor:`Tool_local_runtime
-            ~raw_source
-            ~summary:"exec dispatch simple"
-            ~timeout_sec
-            ?env:host_env
-            ?cwd
-            argv
+          (match on_output_chunk with
+           | None ->
+             Exec_gate.run_argv_with_status_split
+               ~actor:`Tool_local_runtime
+               ~raw_source
+               ~summary:"exec dispatch simple"
+               ~timeout_sec
+               ?env:host_env
+               ?cwd
+               argv
+           | Some on_chunk ->
+             Exec_gate.run_argv_with_status_split_streaming
+               ~actor:`Tool_local_runtime
+               ~raw_source
+               ~summary:"exec dispatch simple streaming"
+               ~timeout_sec
+               ?env:host_env
+               ?cwd
+               ~on_stdout_chunk:(fun chunk -> on_chunk (`Stdout chunk))
+               ~on_stderr_chunk:(fun chunk -> on_chunk (`Stderr chunk))
+               argv)
         | Some stdin_content ->
-          Exec_gate.run_argv_with_stdin_and_status_split
-            ~actor:`Tool_local_runtime
-            ~raw_source
-            ~summary:"exec dispatch simple stdin"
-            ~timeout_sec
-            ?env:host_env
-            ?cwd
-            ~stdin_content
-            argv
+          (match on_output_chunk with
+           | None ->
+             Exec_gate.run_argv_with_stdin_and_status_split
+               ~actor:`Tool_local_runtime
+               ~raw_source
+               ~summary:"exec dispatch simple stdin"
+               ~timeout_sec
+               ?env:host_env
+               ?cwd
+               ~stdin_content
+               argv
+           | Some on_chunk ->
+             (* WORKAROUND: streaming stdin path is not yet wired; callback
+                receives the full stdout/stderr after completion. 근본 해결:
+                extend Process_eio.run_argv_with_stdin_and_status_split with
+                chunk callbacks and route here. *)
+             let status, stdout, stderr =
+               Exec_gate.run_argv_with_stdin_and_status_split
+                 ~actor:`Tool_local_runtime
+                 ~raw_source
+                 ~summary:"exec dispatch simple stdin streaming"
+                 ~timeout_sec
+                 ?env:host_env
+                 ?cwd
+                 ~stdin_content
+                 argv
+             in
+             on_chunk (`Stdout stdout);
+             on_chunk (`Stderr stderr);
+             status, stdout, stderr)
       in
       (match run () with
        | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
@@ -197,11 +231,20 @@ let dispatch_simple ?timeout_sec ?stdin_content (s : Shell_ir.simple) =
        | status, stdout, stderr ->
          apply_redirect_plan redirect_plan { status; stdout; stderr })
     | Docker { runner; _ } ->
+    (* WORKAROUND: Docker sandbox runner does not expose chunk callbacks yet;
+       the callback, if provided, receives the full captured output after
+       completion.  근본 해결: extend the Docker runner contract with
+       ~on_stdout_chunk/~on_stderr_chunk. *)
     (match runner ~stdin_content ~argv ~env ~cwd ~timeout_sec with
      | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
      | exception exn ->
        { status = Unix.WEXITED 1; stdout = ""; stderr = Printexc.to_string exn }
      | status, stdout, stderr ->
+       (match on_output_chunk with
+        | None -> ()
+        | Some on_chunk ->
+          on_chunk (`Stdout stdout);
+          on_chunk (`Stderr stderr));
        apply_redirect_plan redirect_plan { status; stdout; stderr }))
 
 (* --- pipeline + entry point (mutually recursive) --- *)
@@ -357,11 +400,14 @@ let rec dispatch_pipeline ?timeout_sec stages =
                       invalid_pipeline
                         "nested pipeline not supported in native dispatch" ))))
 
-and dispatch ?timeout_sec (ir : Shell_ir.t) =
+and dispatch ?timeout_sec ?on_output_chunk (ir : Shell_ir.t) =
   match ir with
-  | Shell_ir.Simple s -> dispatch_simple ?timeout_sec s
-  | Pipeline stages -> dispatch_pipeline ?timeout_sec stages
+  | Shell_ir.Simple s -> dispatch_simple ?timeout_sec ?on_output_chunk s
+  | Pipeline stages ->
+    (* Pipelines do not yet expose per-stage chunk callbacks; an
+       [on_output_chunk] provided here is ignored. *)
+    dispatch_pipeline ?timeout_sec stages
 
-let dispatch_decided ?timeout_sec (envelope : Shell_ir_risk.decided Shell_ir_risk.decided_ir) :
+let dispatch_decided ?timeout_sec ?on_output_chunk (envelope : Shell_ir_risk.decided Shell_ir_risk.decided_ir) :
     dispatch_result =
-  dispatch ?timeout_sec envelope.Shell_ir_risk.ir
+  dispatch ?timeout_sec ?on_output_chunk envelope.Shell_ir_risk.ir

--- a/lib/exec/exec_dispatch.mli
+++ b/lib/exec/exec_dispatch.mli
@@ -9,14 +9,24 @@ val resolve_arg : Shell_ir.arg -> string
 
 
 val dispatch_simple :
-  ?timeout_sec:float -> ?stdin_content:string -> Shell_ir.simple -> dispatch_result
+  ?timeout_sec:float ->
+  ?stdin_content:string ->
+  ?on_output_chunk:([ `Stdout of string | `Stderr of string ] -> unit) ->
+  Shell_ir.simple ->
+  dispatch_result
 (** Execute a simple command via argv-based spawn.  [stdin_content] is
     used by pipeline dispatch when a previous stage's stdout must be
     forwarded without dropping the stage's sandbox target.  [?timeout_sec]
-    overrides the dispatch default. *)
+    overrides the dispatch default.  [?on_output_chunk] is invoked for
+    every chunk read from stdout/stderr while the process is running on
+    the host sandbox path; Docker and pipeline paths currently emit the
+    full captured output after completion. *)
 
 val dispatch :
-  ?timeout_sec:float -> Shell_ir.t -> dispatch_result
+  ?timeout_sec:float ->
+  ?on_output_chunk:([ `Stdout of string | `Stderr of string ] -> unit) ->
+  Shell_ir.t ->
+  dispatch_result
 (** General dispatch over any [Shell_ir.t] variant.  [Simple] routes
     to [dispatch_simple]; [Pipeline] routes to internal pipeline
     logic.  Prefer [dispatch_decided] for production keeper paths.
@@ -24,7 +34,9 @@ val dispatch :
 
 val dispatch_decided :
   ?timeout_sec:float ->
-  Shell_ir_risk.decided Shell_ir_risk.decided_ir -> dispatch_result
+  ?on_output_chunk:([ `Stdout of string | `Stderr of string ] -> unit) ->
+  Shell_ir_risk.decided Shell_ir_risk.decided_ir ->
+  dispatch_result
 (** RFC-0160 S3: dispatch a risk-classified IR.  The phantom type
     ensures the IR has passed through [Shell_ir_risk.classify]. *)
 

--- a/lib/exec/exec_gate.ml
+++ b/lib/exec/exec_gate.ml
@@ -39,6 +39,17 @@ let run_argv_with_status_split ~actor:_ ~raw_source:_ ~summary:_
     ?(timeout_sec = default_exec_timeout_sec) ?env ?cwd argv =
   Process_eio.run_argv_with_status_split ~timeout_sec ?env ?cwd argv
 
+let run_argv_with_status_split_streaming ~actor:_ ~raw_source:_ ~summary:_
+    ?(timeout_sec = default_exec_timeout_sec) ?env ?cwd
+    ~on_stdout_chunk ~on_stderr_chunk argv =
+  Process_eio.run_argv_with_status_split_streaming
+    ~timeout_sec
+    ?env
+    ?cwd
+    ~on_stdout_chunk
+    ~on_stderr_chunk
+    argv
+
 let run_argv_with_stdin_and_status ~actor:_ ~raw_source:_ ~summary:_
     ?(timeout_sec = default_exec_timeout_sec) ?env ?cwd ~stdin_content argv =
   Process_eio.run_argv_with_stdin_and_status ~timeout_sec ?env ?cwd

--- a/lib/exec/exec_gate.mli
+++ b/lib/exec/exec_gate.mli
@@ -41,6 +41,19 @@ val run_argv_with_status_split :
   (Unix.process_status * string * string)
 (** Delegates to [Process_eio.run_argv_with_status_split]. *)
 
+val run_argv_with_status_split_streaming :
+  actor:Agent_id.t ->
+  raw_source:string ->
+  summary:string ->
+  ?timeout_sec:float ->
+  ?env:string array ->
+  ?cwd:string ->
+  on_stdout_chunk:(string -> unit) ->
+  on_stderr_chunk:(string -> unit) ->
+  string list ->
+  (Unix.process_status * string * string)
+(** Delegates to [Process_eio.run_argv_with_status_split_streaming]. *)
+
 val run_argv_with_stdin_and_status :
   actor:Agent_id.t ->
   raw_source:string ->

--- a/lib/keeper/keeper_keepalive_signal.ml
+++ b/lib/keeper/keeper_keepalive_signal.ml
@@ -45,14 +45,50 @@ let record_execute_output_callback
      stdout:string ->
      stderr:string ->
      status:Yojson.Safe.t ->
+     streamed:bool ->
      unit)
       ref
   =
   ref
-    (fun ~keeper_name:_ ~task_id:_ ~stdout:_ ~stderr:_ ~status:_ -> ())
+    (fun ~keeper_name:_ ~task_id:_ ~stdout:_ ~stderr:_ ~status:_ ~streamed:_ -> ())
 
 let register_record_execute_output f =
   record_execute_output_callback := f
+;;
+
+let record_execute_stream_chunk_callback
+  : (keeper_name:string ->
+     stream:[ `Stdout | `Stderr ] ->
+     string ->
+     unit)
+      ref
+  =
+  ref (fun ~keeper_name:_ ~stream:_ _chunk -> ())
+
+let register_record_execute_stream_chunk f =
+  record_execute_stream_chunk_callback := f
+;;
+
+let record_execute_stream_start_callback
+  : (keeper_name:string -> task_id:string option -> unit) ref
+  =
+  ref (fun ~keeper_name:_ ~task_id:_ -> ())
+
+let register_record_execute_stream_start f =
+  record_execute_stream_start_callback := f
+;;
+
+let record_execute_stream_end_callback
+  : (keeper_name:string ->
+     task_id:string option ->
+     status:Yojson.Safe.t ->
+     unit)
+      ref
+  =
+  ref (fun ~keeper_name:_ ~task_id:_ ~status:_ -> ())
+
+let register_record_execute_stream_end f =
+  record_execute_stream_end_callback := f
 ;;
 
 (* Skip log throttle removed with manual_reconcile blocker — no more

--- a/lib/keeper/keeper_keepalive_signal.mli
+++ b/lib/keeper/keeper_keepalive_signal.mli
@@ -56,6 +56,7 @@ val record_execute_output_callback :
    stdout:string ->
    stderr:string ->
    status:Yojson.Safe.t ->
+   streamed:bool ->
    unit)
     ref
 
@@ -65,12 +66,44 @@ val register_record_execute_output :
    stdout:string ->
    stderr:string ->
    status:Yojson.Safe.t ->
+   streamed:bool ->
    unit) ->
   unit
 
+val record_execute_stream_chunk_callback :
+  (keeper_name:string ->
+   stream:[ `Stdout | `Stderr ] ->
+   string ->
+   unit)
+    ref
 
+val register_record_execute_stream_chunk :
+  (keeper_name:string ->
+   stream:[ `Stdout | `Stderr ] ->
+   string ->
+   unit) ->
+  unit
 
+val record_execute_stream_start_callback :
+  (keeper_name:string -> task_id:string option -> unit) ref
 
+val register_record_execute_stream_start :
+  (keeper_name:string -> task_id:string option -> unit) ->
+  unit
+
+val record_execute_stream_end_callback :
+  (keeper_name:string ->
+   task_id:string option ->
+   status:Yojson.Safe.t ->
+   unit)
+    ref
+
+val register_record_execute_stream_end :
+  (keeper_name:string ->
+   task_id:string option ->
+   status:Yojson.Safe.t ->
+   unit) ->
+  unit
 
 (** FSM guard identity helpers (Cycle 43).
     Wrapped by [Keeper_fsm_guard_runtime.wrap_unit] at call sites. *)

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -373,6 +373,46 @@ let handle_tool_execute_typed
           (* NDT-OK: wall clock is used only for elapsed telemetry, never for
              dispatch branching or policy decisions. *)
           let t0 = Unix.gettimeofday () in
+          let task_id =
+            Option.map Keeper_id.Task_id.to_string meta.current_task_id
+          in
+          let stream_dispatch =
+            Sys.getenv_opt "MASC_STREAM_EXECUTE_OUTPUT" <> Some "false"
+          in
+          if stream_dispatch
+          then (
+            try
+              !Keeper_keepalive_signal.record_execute_stream_start_callback
+                ~keeper_name:meta.name
+                ~task_id
+            with
+            | Eio.Cancel.Cancelled _ as e -> raise e
+            | exn ->
+              Log.Dashboard.warn
+                "execute stream start callback failed keeper=%s: %s"
+                meta.name
+                (Printexc.to_string exn));
+          let on_output_chunk chunk =
+            if stream_dispatch
+            then (
+              let stream, data =
+                match chunk with
+                | `Stdout s -> `Stdout, s
+                | `Stderr s -> `Stderr, s
+              in
+              try
+                !Keeper_keepalive_signal.record_execute_stream_chunk_callback
+                  ~keeper_name:meta.name
+                  ~stream
+                  data
+              with
+              | Eio.Cancel.Cancelled _ as e -> raise e
+              | exn ->
+                Log.Dashboard.warn
+                  "execute stream chunk callback failed keeper=%s: %s"
+                  meta.name
+                  (Printexc.to_string exn))
+          in
           let dispatch_result =
             Keeper_tool_execute_shell_ir.dispatch_classified
               ~allowed_commands
@@ -380,6 +420,7 @@ let handle_tool_execute_typed
               ~base_path:root
               ~workdir:cwd
               ~sandbox:dispatch_sandbox
+              ~on_output_chunk
               envelope
           in
           match dispatch_result with
@@ -427,14 +468,31 @@ let handle_tool_execute_typed
               then result.stdout
               else result.stdout ^ result.stderr
             in
+            let status_json =
+              Keeper_alerting_path.process_status_to_json result.status
+            in
+            if stream_dispatch
+            then (
+              try
+                !Keeper_keepalive_signal.record_execute_stream_end_callback
+                  ~keeper_name:meta.name
+                  ~task_id
+                  ~status:status_json
+              with
+              | Eio.Cancel.Cancelled _ as e -> raise e
+              | exn ->
+                Log.Dashboard.warn
+                  "execute stream end callback failed keeper=%s: %s"
+                  meta.name
+                  (Printexc.to_string exn));
             (try
                !Keeper_keepalive_signal.record_execute_output_callback
                  ~keeper_name:meta.name
-                 ~task_id:
-                   (Option.map Keeper_id.Task_id.to_string meta.current_task_id)
+                 ~task_id
                  ~stdout:result.stdout
                  ~stderr:result.stderr
-                 ~status:(Keeper_alerting_path.process_status_to_json result.status)
+                 ~status:status_json
+                 ~streamed:stream_dispatch
              with
              | Eio.Cancel.Cancelled _ as e -> raise e
              | exn ->

--- a/lib/keeper_tooling/keeper_tool_execute_shell_ir.ml
+++ b/lib/keeper_tooling/keeper_tool_execute_shell_ir.ml
@@ -108,6 +108,7 @@ let dispatch_classified
       ?base_path
       ~workdir
       ~sandbox
+      ?on_output_chunk
       envelope
   =
   let ir = envelope.Masc_exec.Shell_ir_risk.ir in
@@ -127,7 +128,7 @@ let dispatch_classified
     ~f_allow:(fun _context ->
       match validate_paths ?keeper_id ?base_path ~workdir ir with
       | Error e -> Error (Path_reject e)
-      | Ok () -> Ok (Masc_exec.Exec_dispatch.dispatch_decided ?timeout_sec envelope))
+      | Ok () -> Ok (Masc_exec.Exec_dispatch.dispatch_decided ?timeout_sec ?on_output_chunk envelope))
 ;;
 
 (* TEL-OK: wrapper only classifies before delegating to dispatch_classified. *)
@@ -140,6 +141,7 @@ let dispatch
       ?base_path
       ~workdir
       ~sandbox
+      ?on_output_chunk
       ir
   =
   dispatch_classified
@@ -151,5 +153,6 @@ let dispatch
     ?base_path
     ~workdir
     ~sandbox
+    ?on_output_chunk
     (classify ir)
 ;;

--- a/lib/keeper_tooling/keeper_tool_execute_shell_ir.mli
+++ b/lib/keeper_tooling/keeper_tool_execute_shell_ir.mli
@@ -65,12 +65,14 @@ val dispatch_classified :
   ?base_path:string ->
   workdir:string ->
   sandbox:Masc_exec.Sandbox_target.t ->
+  ?on_output_chunk:([ `Stdout of string | `Stderr of string ] -> unit) ->
   Masc_exec.Shell_ir_risk.decided Masc_exec.Shell_ir_risk.decided_ir ->
   (Masc_exec.Exec_dispatch.dispatch_result, dispatch_error) result
 (** Run the canonical keeper Shell IR pipeline for an already-classified IR:
     typed gate -> path validation -> dispatch_decided. [redirect_allowed]
     defaults to [true] for the historical tool execute path; legacy code-shell
-    callers pass [false]. *)
+    callers pass [false].  [?on_output_chunk] is forwarded to the host
+    dispatch path for live output streaming. *)
 
 val dispatch :
   ?timeout_sec:float ->
@@ -81,6 +83,7 @@ val dispatch :
   ?base_path:string ->
   workdir:string ->
   sandbox:Masc_exec.Sandbox_target.t ->
+  ?on_output_chunk:([ `Stdout of string | `Stderr of string ] -> unit) ->
   Masc_exec.Shell_ir.t ->
   (Masc_exec.Exec_dispatch.dispatch_result, dispatch_error) result
 (** Run the canonical keeper Shell IR pipeline:

--- a/lib/process/dune
+++ b/lib/process/dune
@@ -23,5 +23,6 @@
   masc_cancel_safe
   eio
   eio.unix
+  cstruct
   unix
   threads))

--- a/lib/process/process_eio.ml
+++ b/lib/process/process_eio.ml
@@ -513,6 +513,50 @@ let spawn_and_drain_both ?phase_ref ~sw pm ~cwd ?env ?stdin_source argv stdout_b
   | `Exited n -> Unix.WEXITED n
   | `Signaled n -> Unix.WSIGNALED n
 
+let spawn_and_drain_both_streaming ?phase_ref ~sw pm ~cwd ?env ?stdin_source argv
+    ~on_stdout_chunk ~on_stderr_chunk stdout_buf stderr_buf =
+  let stdout_r, stdout_w = Eio.Process.pipe ~sw pm in
+  let stderr_r, stderr_w = Eio.Process.pipe ~sw pm in
+  let proc =
+    Eio.Process.spawn ~sw pm ~cwd ?env
+      ?stdin:stdin_source
+      ~stdout:stdout_w
+      ~stderr:stderr_w
+      argv
+  in
+  Option.iter (fun r -> r := Timeout_origin.Command) phase_ref;
+  Eio.Flow.close stdout_w;
+  Eio.Flow.close stderr_w;
+  let chunk_size = 4096 in
+  let rec drain r buf ~on_chunk chunk =
+    match
+      try Eio.Flow.single_read r chunk with
+      | End_of_file -> 0
+    with
+    | 0 -> Eio.Flow.close r
+    | n ->
+      let s = Cstruct.to_string (Cstruct.sub chunk 0 n) in
+      on_chunk s;
+      Buffer.add_string buf s;
+      drain r buf ~on_chunk chunk
+  in
+  (try
+     Eio.Fiber.both
+       (fun () ->
+         let chunk = Cstruct.create chunk_size in
+         drain stdout_r stdout_buf ~on_chunk:on_stdout_chunk chunk)
+       (fun () ->
+         let chunk = Cstruct.create chunk_size in
+         drain stderr_r stderr_buf ~on_chunk:on_stderr_chunk chunk)
+   with Eio.Cancel.Cancelled _ as e ->
+     (try Eio.Flow.close stdout_r with Eio.Cancel.Cancelled _ as ce -> raise ce | exn -> Log.Misc.warn "spawn_and_drain_both_streaming: stdout flow close failed: %s" (Printexc.to_string exn));
+     (try Eio.Flow.close stderr_r with Eio.Cancel.Cancelled _ as ce -> raise ce | exn -> Log.Misc.warn "spawn_and_drain_both_streaming: stderr flow close failed: %s" (Printexc.to_string exn));
+     raise e);
+  let status = Eio.Process.await proc in
+  match status with
+  | `Exited n -> Unix.WEXITED n
+  | `Signaled n -> Unix.WSIGNALED n
+
 type pipeline_stage = {
   argv : string list;
   env : string array option;
@@ -812,6 +856,88 @@ let run_argv_with_status_split ?(timeout_sec = default_timeout_sec) ?env ?cwd
                     "",
                     process_error_output ~label
                       ~reason:(reason_of_exn_for_output exn) () )))
+
+let run_argv_with_status_split_streaming
+    ?(timeout_sec = default_timeout_sec)
+    ?env
+    ?cwd
+    ~on_stdout_chunk
+    ~on_stderr_chunk
+    (argv : string list)
+    : Unix.process_status * string * string
+  =
+  Exec_tap.record ~kind:Exec_tap.Process_eio_run_argv_with_status ~argv ?env ?cwd ();
+  with_spawn_guard (fun () ->
+      if not (is_initialized ())
+      then run_unix_argv_with_status_split_fallback ~timeout_sec ?env ?cwd argv
+      else (
+        match get_proc_mgr (), get_clock (), get_cwd_default () with
+        | Error _, _, _ | _, Error _, _ | _, _, Error _ ->
+          run_unix_argv_with_status_split_fallback ~timeout_sec ?env ?cwd argv
+        | Ok pm, Ok clk, Ok default_cwd ->
+          let effective_cwd =
+            match cwd with
+            | None -> default_cwd
+            | Some dir -> Eio.Path.(default_cwd / dir)
+          in
+          let stdout_buf = Buffer.create default_buffer_size in
+          let stderr_buf = Buffer.create 256 in
+          let label = String.concat " " (List.map Filename.quote argv) in
+          let phase_ref = ref Timeout_origin.Spawn in
+          try
+            Eio.Time.with_timeout_exn clk timeout_sec (fun () ->
+                let unix_status =
+                  Eio.Switch.run (fun sw ->
+                      spawn_and_drain_both_streaming
+                        ~phase_ref
+                        ~sw
+                        pm
+                        ~cwd:effective_cwd
+                        ?env
+                        ~on_stdout_chunk
+                        ~on_stderr_chunk
+                        argv
+                        stdout_buf
+                        stderr_buf)
+                in
+                unix_status, Buffer.contents stdout_buf, Buffer.contents stderr_buf)
+          with
+          | Eio.Time.Timeout ->
+            Log.Misc.warn "[Process_eio] Timeout after %.0fs (%s): %s"
+              timeout_sec (Timeout_origin.to_label !phase_ref) label;
+            observe_process_timeout argv ~timeout_sec ~origin:!phase_ref;
+            let timeout_status = Unix.WEXITED 124 in
+            let stdout = Buffer.contents stdout_buf in
+            let stderr = Buffer.contents stderr_buf in
+            let stderr =
+              if String.trim stdout = "" && String.trim stderr = ""
+              then process_error_output ~label
+                     ~reason:(Printf.sprintf "timeout after %.0fs" timeout_sec) ()
+              else stderr
+            in
+            timeout_status, stdout, stderr
+          | Eio.Cancel.Cancelled _ as exn -> raise exn
+          | exn ->
+            if should_retry_unix_fallback exn
+            then (
+              Log.Misc.warn
+                "[Process_eio] argv bind error, retrying via Unix fallback: %s — %s"
+                label (Printexc.to_string exn);
+              run_unix_argv_with_status_split_fallback ~timeout_sec ?env ?cwd argv)
+            else if is_downstream_pipe_closed exn
+            then (
+              Log.Misc.debug
+                "[Process_eio] argv pipe closed by reader: %s — %s"
+                label (Printexc.to_string exn);
+              ( Unix.WEXITED 127,
+                "",
+                process_error_output ~label ~reason:"pipe closed by reader" () ))
+            else (
+              Log.Misc.error "[Process_eio] argv error: %s — %s" label
+                (Printexc.to_string exn);
+              ( Unix.WEXITED 127,
+                "",
+                process_error_output ~label ~reason:(reason_of_exn_for_output exn) () ))))
 
 let run_argv_pipeline_with_status_split ?(timeout_sec = default_timeout_sec)
     (stages : pipeline_stage list) : Unix.process_status * string * string =

--- a/lib/process/process_eio.mli
+++ b/lib/process/process_eio.mli
@@ -137,6 +137,19 @@ val run_argv_with_status_split :
 (** Like [run_argv_with_status], but returns
     [(status, stdout, stderr)] without combining stderr into stdout. *)
 
+val run_argv_with_status_split_streaming :
+  ?timeout_sec:float ->
+  ?env:string array ->
+  ?cwd:string ->
+  on_stdout_chunk:(string -> unit) ->
+  on_stderr_chunk:(string -> unit) ->
+  string list ->
+  (Unix.process_status * string * string)
+(** Like [run_argv_with_status_split], but invokes [on_stdout_chunk] and
+    [on_stderr_chunk] for every chunk read from the child pipes while the
+    process is still running. The returned strings still contain the full
+    captured output. *)
+
 type pipeline_stage = {
   argv : string list;
   env : string array option;

--- a/test/test_dashboard_execute_output.ml
+++ b/test/test_dashboard_execute_output.ml
@@ -119,6 +119,165 @@ let test_live_tail_subscriber_receives_line_and_close () =
              (closed_json |> member "type" |> to_string);
            check bool "closed" true (closed_json |> member "closed" |> to_bool)))
 
+let test_stream_start_emits_task_opened () =
+  Eio_main.run (fun env ->
+    match EO.subscribe ~keeper_name:"sangsu" with
+    | None -> fail "expected subscriber"
+    | Some subscriber ->
+      Fun.protect
+        ~finally:(fun () -> EO.unsubscribe subscriber)
+        (fun () ->
+           EO.record_stream_start ~keeper_name:"sangsu" ~task_id:(Some "task-stream");
+           let json =
+             Eio.Time.with_timeout_exn
+               (Eio.Stdenv.clock env)
+               1.0
+               (fun () -> EO.take_event subscriber |> EO.stream_event_json)
+           in
+           let open Yojson.Safe.Util in
+           check string "type" "task_opened" (json |> member "type" |> to_string);
+           check string "task" "task-stream" (json |> member "task_id" |> to_string);
+           check bool "closed" false (json |> member "closed" |> to_bool)))
+
+let test_stream_chunk_emits_line () =
+  Eio_main.run (fun env ->
+    match EO.subscribe ~keeper_name:"sangsu" with
+    | None -> fail "expected subscriber"
+    | Some subscriber ->
+      Fun.protect
+        ~finally:(fun () -> EO.unsubscribe subscriber)
+        (fun () ->
+           EO.record_stream_start ~keeper_name:"sangsu" ~task_id:(Some "task-stream");
+           (* drain task_opened *)
+           let _ =
+             Eio.Time.with_timeout_exn
+               (Eio.Stdenv.clock env)
+               1.0
+               (fun () -> EO.take_event subscriber |> EO.stream_event_json)
+           in
+           EO.append_stream_chunk ~keeper_name:"sangsu" ~stream:`Stdout "hello\nworld";
+           let line1 =
+             Eio.Time.with_timeout_exn
+               (Eio.Stdenv.clock env)
+               1.0
+               (fun () -> EO.take_event subscriber |> EO.stream_event_json)
+           in
+           let line2 =
+             Eio.Time.with_timeout_exn
+               (Eio.Stdenv.clock env)
+               1.0
+               (fun () -> EO.take_event subscriber |> EO.stream_event_json)
+           in
+           let open Yojson.Safe.Util in
+           check string "first type" "line" (line1 |> member "type" |> to_string);
+           check
+             string
+             "first text"
+             "hello"
+             (line1 |> member "line" |> member "text" |> to_string);
+           check string "first stream" "stdout" (line1 |> member "line" |> member "stream" |> to_string);
+           check string "second type" "line" (line2 |> member "type" |> to_string);
+           check
+             string
+             "second text"
+             "world"
+             (line2 |> member "line" |> member "text" |> to_string)))
+
+let test_stream_end_emits_task_closed () =
+  Eio_main.run (fun env ->
+    match EO.subscribe ~keeper_name:"sangsu" with
+    | None -> fail "expected subscriber"
+    | Some subscriber ->
+      Fun.protect
+        ~finally:(fun () -> EO.unsubscribe subscriber)
+        (fun () ->
+           EO.record_stream_start ~keeper_name:"sangsu" ~task_id:(Some "task-stream");
+           let _ =
+             Eio.Time.with_timeout_exn
+               (Eio.Stdenv.clock env)
+               1.0
+               (fun () -> EO.take_event subscriber |> EO.stream_event_json)
+           in
+           EO.record_stream_end
+             ~keeper_name:"sangsu"
+             ~task_id:(Some "task-stream")
+             ~status:status_ok;
+           let closed_json =
+             Eio.Time.with_timeout_exn
+               (Eio.Stdenv.clock env)
+               1.0
+               (fun () -> EO.take_event subscriber |> EO.stream_event_json)
+           in
+           let open Yojson.Safe.Util in
+           check
+             string
+             "type"
+             "task_closed"
+             (closed_json |> member "type" |> to_string);
+           check bool "closed" true (closed_json |> member "closed" |> to_bool);
+           check int "status code" 0 (closed_json |> member "status" |> member "code" |> to_int)))
+
+let test_stream_completed_does_not_duplicate_events () =
+  Eio_main.run (fun env ->
+    match EO.subscribe ~keeper_name:"sangsu" with
+    | None -> fail "expected subscriber"
+    | Some subscriber ->
+      Fun.protect
+        ~finally:(fun () -> EO.unsubscribe subscriber)
+        (fun () ->
+           EO.record_stream_start ~keeper_name:"sangsu" ~task_id:(Some "task-stream");
+           (* task_opened *)
+           let _ =
+             Eio.Time.with_timeout_exn
+               (Eio.Stdenv.clock env)
+               1.0
+               (fun () -> EO.take_event subscriber)
+           in
+           EO.append_stream_chunk ~keeper_name:"sangsu" ~stream:`Stdout " streamed line\n";
+           (* line event from chunk *)
+           let _ =
+             Eio.Time.with_timeout_exn
+               (Eio.Stdenv.clock env)
+               1.0
+               (fun () -> EO.take_event subscriber)
+           in
+           EO.record_stream_end
+             ~keeper_name:"sangsu"
+             ~task_id:(Some "task-stream")
+             ~status:status_ok;
+           EO.record_completed
+             ~keeper_name:"sangsu"
+             ~task_id:(Some "task-stream")
+             ~stdout:" streamed line\n"
+             ~stderr:""
+             ~status:status_ok
+             ~streamed:true
+             ();
+           (* record_stream_end emitted task_closed; record_completed with
+              [~streamed:true] must not emit additional line or closed events. *)
+           let closed_json =
+             Eio.Time.with_timeout_exn
+               (Eio.Stdenv.clock env)
+               1.0
+               (fun () -> EO.take_event subscriber |> EO.stream_event_json)
+           in
+           let open Yojson.Safe.Util in
+           check
+             string
+             "type"
+             "task_closed"
+             (closed_json |> member "type" |> to_string);
+           (* Subscriber queue should now be empty because record_completed
+              with [~streamed:true] does not emit line events. *)
+           try
+             Eio.Time.with_timeout_exn
+               (Eio.Stdenv.clock env)
+               0.1
+               (fun () -> EO.take_event subscriber |> ignore);
+             fail "unexpected extra event after streamed completion"
+           with
+           | Eio.Time.Timeout -> ()))
+
 let test_sse_frame () =
   let frame = EO.sse_frame (`Assoc [ "type", `String "snapshot" ]) in
   check bool "event header" true (String.starts_with ~prefix:"event: output\n" frame);
@@ -165,6 +324,12 @@ let () =
             "live tail subscriber receives line and close"
             `Quick
             (with_fresh test_live_tail_subscriber_receives_line_and_close)
+        ; test_case "stream start emits task_opened" `Quick (with_fresh test_stream_start_emits_task_opened)
+        ; test_case "stream chunk emits line" `Quick (with_fresh test_stream_chunk_emits_line)
+        ; test_case "stream end emits task_closed" `Quick (with_fresh test_stream_end_emits_task_closed)
+        ; test_case "stream completed does not duplicate events"
+            `Quick
+            (with_fresh test_stream_completed_does_not_duplicate_events)
         ; test_case "sse frame" `Quick test_sse_frame
         ; test_case "routes match keeper path" `Quick test_dashboard_routes_match_keeper_path
         ] )

--- a/test/test_process_eio_coverage.ml
+++ b/test/test_process_eio_coverage.ml
@@ -236,6 +236,51 @@ let test_run_argv_with_status_includes_stderr_on_failure () =
   check bool "stderr surfaced in output" true
     (contains output "stderr-only")
 
+let test_run_argv_with_status_split_streaming_invokes_callbacks () =
+  Eio_main.run @@ fun env ->
+  let proc_mgr = Eio.Stdenv.process_mgr env in
+  let clock = Eio.Stdenv.clock env in
+  let cwd_default = Eio.Stdenv.fs env in
+  Process_eio.init ~cwd_default ~proc_mgr ~clock;
+  let stdout_chunks = ref [] in
+  let stderr_chunks = ref [] in
+  let status, stdout, stderr =
+    Process_eio.run_argv_with_status_split_streaming
+      ~on_stdout_chunk:(fun s -> stdout_chunks := s :: !stdout_chunks)
+      ~on_stderr_chunk:(fun s -> stderr_chunks := s :: !stderr_chunks)
+      [ "/bin/sh"
+      ; "-c"
+      ; "printf 'stdout-chunk\\n'; printf 'stderr-chunk\\n' >&2"
+      ]
+  in
+  let code = match status with Unix.WEXITED c -> c | _ -> 1 in
+  check int "streaming exit code" 0 code;
+  check string "streaming stdout captured" "stdout-chunk\n" stdout;
+  check string "streaming stderr captured" "stderr-chunk\n" stderr;
+  check bool "streaming stdout callback invoked" true (List.length !stdout_chunks > 0);
+  check bool "streaming stderr callback invoked" true (List.length !stderr_chunks > 0)
+
+let test_run_argv_with_status_split_streaming_multiple_chunks () =
+  Eio_main.run @@ fun env ->
+  let proc_mgr = Eio.Stdenv.process_mgr env in
+  let clock = Eio.Stdenv.clock env in
+  let cwd_default = Eio.Stdenv.fs env in
+  Process_eio.init ~cwd_default ~proc_mgr ~clock;
+  let chunk_count = Atomic.make 0 in
+  let status, stdout, _stderr =
+    Process_eio.run_argv_with_status_split_streaming
+      ~on_stdout_chunk:(fun _ -> Atomic.incr chunk_count)
+      ~on_stderr_chunk:(fun _ -> ())
+      [ "/bin/sh"
+      ; "-c"
+      ; "i=0; while [ $i -lt 500 ]; do printf '%s' 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'; i=$((i+1)); done; printf '\\n'"
+      ]
+  in
+  let code = match status with Unix.WEXITED c -> c | _ -> 1 in
+  check int "multi-chunk exit code" 0 code;
+  check int "multi-chunk stdout length" 25001 (String.length stdout);
+  check bool "multi-chunk received more than one chunk" true (Atomic.get chunk_count > 1)
+
 let test_reset_for_testing_clears_runtime () =
   Eio_main.run @@ fun env ->
   let proc_mgr = Eio.Stdenv.process_mgr env in
@@ -291,6 +336,10 @@ let () =
              test_run_argv_with_status_cwd_override;
            test_case "run_argv_with_status-includes-stderr-on-failure" `Quick
              test_run_argv_with_status_includes_stderr_on_failure;
+           test_case "run_argv_with_status_split_streaming-invokes-callbacks" `Quick
+             test_run_argv_with_status_split_streaming_invokes_callbacks;
+           test_case "run_argv_with_status_split_streaming-multiple-chunks" `Quick
+             test_run_argv_with_status_split_streaming_multiple_chunks;
            test_case "reset_for_testing-clears-runtime" `Quick
              test_reset_for_testing_clears_runtime;
          ] );


### PR DESCRIPTION
## Summary

Dashboard IDE Boundary P1 Task 3: add a producer that captures stdout/stderr chunks from running Shell IR processes and streams them to the dashboard execute-output SSE endpoint.

## Changes

- **Process_eio**: add `spawn_and_drain_both_streaming` with `Eio.Flow.single_read`-based chunk reads and stdout/stderr callbacks. EOF handled via zero-read and `End_of_file` exception.
- **Exec_gate**: add `run_argv_with_status_split_streaming` wrapper.
- **Exec_dispatch**: add optional `?on_output_chunk` to `dispatch_simple`, `dispatch`, and `dispatch_decided`. Host path uses real-time callbacks; Docker / stdin / pipeline paths currently fall back to post-completion bulk callback.
- **Keeper_tool_execute_shell_ir**: forward `?on_output_chunk` through `dispatch_classified`.
- **Keeper_keepalive_signal**: add `record_execute_stream_chunk_callback`, `record_execute_stream_start_callback`, and `record_execute_stream_end_callback`. Extend `record_execute_output_callback` with `streamed:bool`.
- **Dashboard_execute_output**: add `Task_opened_event` variant and `record_stream_start`, `append_stream_chunk`, `record_stream_end` APIs. Add `?streamed:bool` to `record_completed` to suppress duplicate line/closed events.
- **keeper_tool_execute_runtime**: wire streaming callbacks around Shell IR dispatch. Feature-flagged via `MASC_STREAM_EXECUTE_OUTPUT` (default enabled).

## Verification

- [x] `dune build @check --root .` PASS
- [x] `dune build . --root .` PASS
- [x] `dune exec test/test_dashboard_execute_output.exe --root .` 11/11 PASS
- [x] `dune exec test/test_process_eio_coverage.exe --root .` 20/20 PASS
- [x] `dune exec test/test_exec_dispatch.exe --root .` PASS

## Breaking / Risk

- Existing completed-only paths are preserved (`?on_output_chunk` is optional).
- Docker sandbox / pipeline / stdin paths emit bulk callbacks after completion rather than true per-chunk streaming (marked with `WORKAROUND` comments and root-fix notes).
- `record_execute_output_callback` ref signature gained `streamed:bool`; the only registered consumer is `Dashboard_execute_output`.

Closes dashboard IDE Boundary P1 Task 3.
