### PR TITLE
fix(keeper): isolate liveness budget per provider

### DIFF
--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -299,11 +299,13 @@ let run_try_provider
   | Error err -> Error err, None, None
   | Ok config ->
     let liveness_mode = Keeper_attempt_liveness_config.current_mode () in
-    (* MASC stores one neutral runtime-lane budget; concrete provider/model
-       identities remain on the OAS side.  Otel_metric_store receives only the public,
-       bounded provider bucket for TTFT/inter-chunk grouping. *)
-    let candidate_key = Keeper_attempt_liveness_config.runtime_candidate_key in
+    (* Per-provider candidate key for liveness budget isolation. Each provider
+       (ollama_cloud, openai_compat, anthropic, etc.) maintains its own success
+       history and tuned budget. Previously all providers shared one key
+       "runtime", causing cross-provider budget contamination — see
+       keeper_attempt_liveness_config.ml normalize_candidate_key comment. *)
     let provider_label = Runtime_candidate.provider_label candidate in
+    let candidate_key = provider_label in
     let liveness_observer_opt =
       match liveness_mode with
       | Keeper_attempt_liveness_config.Off ->

--- a/lib/keeper_runtime/keeper_attempt_liveness_config.ml
+++ b/lib/keeper_runtime/keeper_attempt_liveness_config.ml
@@ -95,13 +95,23 @@ let valid_sample (s : success_sample) =
   && finite_non_negative s.max_inter_chunk_ms
   && finite_non_negative s.wall_ms
 
-(* RFC-0132 PR-2: liveness candidate key = external boundary; redact via SSOT. *)
+(* Legacy constant kept for test compatibility. Production code passes
+   the actual provider label via [candidate_key] so budgets are isolated
+   per provider instead of shared across all providers under one key.
+
+   Before this fix, all providers shared the key "runtime". Fast-provider
+   success samples (e.g. Claude TTFT ~2s) tuned the shared TTFT budget
+   down to the floor (30s). Slow providers (e.g. deepseek-v4-flash via
+   Cloudflare, TTFT 30-60s+) were then killed with no_first_token despite
+   making legitimate progress. The error message blamed the specific slow
+   provider, but the killing budget was set by a completely different
+   provider. *)
 let runtime_candidate_key =
   Boundary_redaction.to_string Boundary_redaction.runtime_model_label
 
 let normalize_candidate_key raw =
   let key = String.trim raw in
-  if key = "" then None else Some runtime_candidate_key
+  if key = "" then None else Some key
 
 let take = List.take
 


### PR DESCRIPTION
## Problem

All providers shared a single candidate key `runtime` in the liveness success history, AND the tuned budget mechanism tightened TTFT below OAS's own idle timeout, causing `no_first_token` kills on legitimately slow providers.

286 `no_first_token` events observed in a single day across multiple providers (deepseek-v4-flash, qwen36-35b-a3b-mtp).

## Root Cause (2-layer)

### Layer 1: Shared candidate key `"runtime"`

`normalize_candidate_key` mapped all providers to the same key `Boundary_redaction.runtime_model_label` = `"runtime"`. Fast-provider success samples contaminated slow-provider budgets.

### Layer 2: Tuned budget < OAS idle timeout

The tuning mechanism (`budget_of_samples`) could tighten `ttft_max` to floor 30s. Since OAS's `stream_idle_timeout_s` is 120s:

| Budget | TTFT | OAS idle | Who fires first? |
|--------|------|----------|------------------|
| Bootstrap | 600s | 120s | OAS → `wire_error` (correct) |
| Tuned | 30s | 120s | Liveness → `no_first_token` (bug) |

**`no_first_token` is mathematically impossible with bootstrap budget** — OAS always fires first. The tuned budget created a condition where the liveness guard killed streams that OAS would have handled correctly.

## Fix (2 commits)

1. **`normalize_candidate_key`**: preserves actual provider key instead of mapping to redacted constant
2. **`budget_for_candidate`**: always returns bootstrap (600s TTFT, 120s inter-chunk, 1800s wall). Tuning removed entirely.

Success history and tuning functions retained for test compat but `budget_for_candidate` no longer consumes them.

## Verification

- `dune build --root .` passes (both commits)
- No liveness-specific tests exist; full CI validates

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
