### PR TITLE
fix(keeper): restore runtime health probe removed in PR 20402

### DIFF
--- a/lib/keeper/keeper_health_probe.ml
+++ b/lib/keeper/keeper_health_probe.ml
@@ -155,6 +155,25 @@ let record_item_result ~keeper_name ~item_id ~success =
   set_item_health ~keeper_name ~item_id status
 ;;
 
+let set_runtime_status ~runtime_id status =
+  Eio.Mutex.use_rw ~protect:true health_cache_mu (fun () ->
+    Hashtbl.replace health_cache (runtime_id, "") (status, Time_compat.now ()))
+;;
+
+(** [get_runtime_status ~runtime_id] reads the runtime-level entry
+    written by [run_once].  Three-valued:
+      - [Healthy]    : last probe saw the runtime at < threshold ratio.
+      - [Unhealthy r]: last probe saw the runtime at >= threshold ratio.
+      - [Unknown]    : probe never wrote this runtime (e.g. boot before
+                       first sweep, or no running keepers in the runtime
+                       at the time of the last scan). *)
+let get_runtime_status ~runtime_id =
+  Eio.Mutex.use_ro health_cache_mu (fun () ->
+    match Hashtbl.find_opt health_cache (runtime_id, "") with
+    | Some (status, _) -> status
+    | None -> Unknown)
+;;
+
 (* ------------------------------------------------------------------ *)
 (* Runtime health check                                               *)
 (* ------------------------------------------------------------------ *)
@@ -191,10 +210,46 @@ let max_failed_allowed_for_runtime ~total =
 type runtime_scan_acc =
   { total : int
   ; failed : int
+  ; failure_reasons : Keeper_registry.failure_reason option list
   }
 
 let empty_runtime_scan_acc =
-  { total = 0; failed = 0 }
+  { total = 0; failed = 0; failure_reasons = [] }
+;;
+
+let dominant_runtime_pressure_class failure_reasons =
+  let counts = Hashtbl.create 8 in
+  List.iter
+    (fun reason ->
+       match runtime_pressure_class_of_failure_reason reason with
+       | None -> ()
+       | Some cls ->
+         let label = runtime_pressure_class_to_string cls in
+         let n =
+           match Hashtbl.find_opt counts label with
+           | Some n -> n
+           | None -> 0
+         in
+         Hashtbl.replace counts label (n + 1))
+    failure_reasons;
+  let ranked =
+    counts
+    |> Hashtbl.to_seq
+    |> List.of_seq
+    |> List.sort (fun (label_a, count_a) (label_b, count_b) ->
+      match compare count_b count_a with
+      | 0 -> String.compare label_a label_b
+      | n -> n)
+  in
+  match ranked with
+  | (label, _) :: _ -> Some label
+  | [] -> None
+;;
+
+let runtime_failure_reason acc =
+  match dominant_runtime_pressure_class acc.failure_reasons with
+  | Some label -> "failure_ratio:" ^ label
+  | None -> "failure_ratio"
 ;;
 
 let scan_runtime_health ~base_path =
@@ -212,6 +267,10 @@ let scan_runtime_health ~base_path =
        let acc' =
          { total = acc.total + 1
          ; failed = acc.failed + if failed then 1 else 0
+         ; failure_reasons =
+             (if failed
+              then entry.last_failure_reason :: acc.failure_reasons
+              else acc.failure_reasons)
          }
        in
        Hashtbl.replace by_runtime runtime_id acc')
@@ -242,4 +301,32 @@ let scan_runtime_health ~base_path =
 let check_runtime_health ~base_path =
   scan_runtime_health ~base_path
   |> List.map (fun (runtime_id, healthy, _acc) -> runtime_id, healthy)
+;;
+
+let run_once ~base_path =
+  let results = scan_runtime_health ~base_path in
+  List.iter
+    (fun (runtime_id, healthy, acc) ->
+       let status =
+         if healthy then Healthy else Unhealthy (runtime_failure_reason acc)
+       in
+       set_runtime_status ~runtime_id status)
+    results
+;;
+
+let rec probe_loop ~base_path ~interval_sec ~clock () =
+  (* Cancel-aware: Safe_ops.protect re-raises Eio.Cancel.Cancelled and swallows
+     other exceptions so a transient registry I/O failure cannot kill the fiber
+     and leave runtime status stale forever. *)
+  Safe_ops.protect ~default:() (fun () -> run_once ~base_path);
+  Eio.Time.sleep clock interval_sec;
+  probe_loop ~base_path ~interval_sec ~clock ()
+;;
+
+let start_probe ~sw ~base_path ~interval_sec ~clock =
+  if interval_sec <= 0.0
+  then ()
+  else
+    Eio.Fiber.fork ~sw (fun () ->
+      Eio.Switch.run (fun _sw -> probe_loop ~base_path ~interval_sec ~clock ()))
 ;;

--- a/lib/keeper/keeper_health_probe.mli
+++ b/lib/keeper/keeper_health_probe.mli
@@ -76,3 +76,31 @@ val max_failed_allowed_for_runtime : total:int -> int
     [failed <= max_failed_allowed_for_runtime ~total].  This function
     reads registry state and performs no runtime/provider calls. *)
 val check_runtime_health : base_path:string -> (string * bool) list
+
+(** [get_runtime_status ~runtime_id] returns the cached runtime-level
+    [health_status] written by [run_once].  This preserves the [Unknown]
+    case so the supervisor's auto-resume guard can distinguish
+    "no probe data yet" from
+    "probe observed restart pressure" and treat the former
+    permissively.
+
+    Background: prior to wiring this distinction, the supervisor's
+    Phase 3.5 guard collapsed [Unknown] and [Unhealthy] to the same
+    boolean result — turning the boot-time cold-cache window into a
+    permanent auto-resume lockout for every runtime. *)
+val get_runtime_status : runtime_id:string -> health_status
+
+(** [run_once ~base_path] runs [check_runtime_health] and writes the
+    results into the runtime cache.  Idempotent and bounded (registry
+    scan, no I/O).  Safe to call from the supervisor sweep on every
+    beat — [Keeper_supervisor.sweep_and_recover] does so to keep the
+    cache live without depending on the background fiber. *)
+val run_once : base_path:string -> unit
+
+(** {1 Background probe fiber} *)
+
+(** [start_probe ~sw ~base_path ~interval_sec ~clock] spawns a background Eio
+    fiber that runs [check_runtime_health] every [interval_sec] seconds
+    and writes the results into the runtime cache. *)
+val start_probe :
+  sw:Eio.Switch.t -> base_path:string -> interval_sec:float -> clock:float Eio.Time.clock_ty Eio.Resource.t -> unit

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -22,6 +22,14 @@ let sweep_and_recover (ctx : _ context) =
   in
   let dead_ttl_sec = Runtime_params.get Governance_registry.keeper_dead_ttl_sec in
   let base_path = ctx.config.base_path in
+  (* Refresh the runtime health cache before Phase 3.5 reads it.  Without this
+     call the cache stayed cold (PR #14146 introduced the cache and
+     [Phase 3.5] guard but never wired a writer), so every runtime looked
+     unhealthy and auto-resume was silently disabled across the fleet.
+     [run_once] is a registry scan — bounded, no I/O — so running it
+     inline on every 30 s sweep is cheap.  [Safe_ops.protect] keeps a
+     transient registry exception from killing the sweep. *)
+  Safe_ops.protect ~default:() (fun () -> Keeper_health_probe.run_once ~base_path);
   (* Phase 2: sweep order — restart/unregister FIRST, reconcile LAST.
      This prevents reconcile from re-launching keepers that sweep is about
      to process (defense-in-depth alongside is_registered check). *)


### PR DESCRIPTION
## Summary

PR #20402 removed `Keeper_health_probe.run_once`, `set_runtime_status`, `get_runtime_status`, and the background probe fiber. Without these, the runtime health cache stayed cold, so every runtime looked unhealthy and auto-resume was silently disabled across the fleet.

## Changes

- Restore `set_runtime_status` / `get_runtime_status`
- Restore `run_once` / `probe_loop` / `start_probe`
- Restore `failure_reasons` tracking in `runtime_scan_acc`
- Restore `Keeper_health_probe.run_once` call in supervisor sweep

## Evidence

- `dune build --root . lib/masc.cma` compiles successfully.

## Root cause

The removed comment in `keeper_supervisor.ml` stated:

> Without this call the cache stayed cold (PR #14146 introduced the cache and [Phase 3.5] guard but never wired a writer), so every runtime looked unhealthy and auto-resume was silently disabled across the fleet.

This comment and the `run_once` call were both removed in PR #20402, leaving the cache permanently cold.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
