### PR TITLE
feat(keeper): add per-keeper turn capacity gate

### DIFF
--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -453,6 +453,22 @@ let keeper_turn_capacity_limit () : int =
   Runtime_params.get keeper_turn_capacity_limit_rp
 ;;
 
+let keeper_per_keeper_turn_capacity_limit_rp =
+  _rp_int
+    ~key:"keeper.turn.per_keeper_capacity_limit"
+    ~default:(fun () -> 2)
+    ~min_v:0
+    ~max_v:64
+    ~description:
+      "Per-keeper concurrent turn capacity limit (0 disables per-keeper gate). \
+       Default 2: with ~15 keepers, max concurrent = 30 < global limit 32."
+    ()
+;;
+
+let keeper_per_keeper_turn_capacity_limit () : int =
+  Runtime_params.get keeper_per_keeper_turn_capacity_limit_rp
+;;
+
 let keeper_llm_rerank_enabled_rp =
   _rp_bool ~key:"keeper.turn.llm_rerank"
     ~default:(fun () -> bool_of_env_default "MASC_KEEPER_LLM_RERANK" ~default:false)
@@ -516,6 +532,7 @@ let keeper_tool_search_top_k () : int =
 let ensure_runtime_params_init () =
   let (_ : float) = Runtime_params.get keeper_unified_temperature_rp in
   let (_ : int) = Runtime_params.get keeper_turn_capacity_limit_rp in
+  let (_ : int) = Runtime_params.get keeper_per_keeper_turn_capacity_limit_rp in
   ()
 
 let keeper_enable_thinking_rp =

--- a/lib/keeper/keeper_config.mli
+++ b/lib/keeper/keeper_config.mli
@@ -221,6 +221,10 @@ val keeper_board_debounce_window_sec : unit -> float
 val keeper_tool_cost_max_usd : unit -> float option
 val keeper_board_event_limit : unit -> int
 val keeper_turn_capacity_limit : unit -> int
+val keeper_per_keeper_turn_capacity_limit : unit -> int
+(** Per-keeper concurrent turn capacity limit.
+    Runtime param [keeper.turn.per_keeper_capacity_limit], default 2, range [0, 64].
+    0 disables the per-keeper gate. *)
 val keeper_llm_rerank_enabled : unit -> bool
 val keeper_llm_rerank_runtime : unit -> string
 (** Reranker runtime profile. Defaults through [routes.llm_rerank]; env

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -375,12 +375,21 @@ let run_keepalive_unified_turn
                     ()))
         with
         | Ok meta -> meta
-        | Error { Keeper_turn_capacity.limit; inflight; waited_ms } ->
+        | Error { Keeper_turn_capacity.limit; inflight; waited_ms; per_keeper_limit; per_keeper_inflight } ->
+          let reason =
+            if per_keeper_limit > 0 && per_keeper_inflight >= per_keeper_limit
+            then "per-keeper"
+            else "global"
+          in
           Log.Keeper.info
-            "%s: skipping turn because global turn capacity is full inflight=%d limit=%d waited_ms=%d"
+            "%s: skipping turn because %s turn capacity is full \
+             global=(inflight=%d limit=%d) per_keeper=(inflight=%d limit=%d) waited_ms=%d"
             meta_after_triage.name
+            reason
             inflight
             limit
+            per_keeper_inflight
+            per_keeper_limit
             waited_ms;
           meta_after_cursor_persist)
       else if obs.message_cursor_updates <> []

--- a/lib/keeper/keeper_turn_capacity.ml
+++ b/lib/keeper/keeper_turn_capacity.ml
@@ -1,7 +1,24 @@
+(** Keeper-turn capacity gate with global + per-keeper limits.
+
+    This is intentionally separate from {!Keeper_turn_holders}: holders are
+    diagnostics for turns that are already running, while this module admits or
+    rejects new turn bodies.
+
+    Two-tier admission:
+    - Global limit ([keeper.turn.capacity_limit], default 32): machine-level
+      concurrent turn cap shared across all keepers.
+    - Per-keeper limit ([keeper.turn.per_keeper_capacity_limit], default 2):
+      prevents a single keeper from monopolising provider capacity.
+
+    Both limits must be satisfied for admission. Rejection records which
+    limit was hit so the caller can log the specific bottleneck. *)
+
 type rejection =
   { limit : int
   ; inflight : int
   ; waited_ms : int
+  ; per_keeper_limit : int
+  ; per_keeper_inflight : int
   }
 
 type acquired =
@@ -10,6 +27,40 @@ type acquired =
   }
 
 let inflight = Atomic.make 0
+
+(** Per-keeper inflight tracking. Thread-safe via atomic per-key counters. *)
+module Per_keeper = struct
+  let table : (string, int Atomic.t) Hashtbl.t = Hashtbl.create 64
+
+  let get_counter keeper_name =
+    match Hashtbl.find_opt table keeper_name with
+    | Some counter -> counter
+    | None ->
+      (* Race-safe: if two fibers create for the same key, both start at 0.
+         The second Hashtbl.replace overwrites with an equivalent counter. *)
+      let counter = Atomic.make 0 in
+      Hashtbl.replace table keeper_name counter;
+      counter
+
+  let incr keeper_name =
+    let counter = get_counter keeper_name in
+    Atomic.incr counter
+
+  let decr keeper_name =
+    let counter = get_counter keeper_name in
+    let rec loop () =
+      let current = Atomic.get counter in
+      if current <= 0
+      then ()
+      else if not (Atomic.compare_and_set counter current (current - 1))
+      then loop ()
+    in
+    loop ()
+
+  let get keeper_name =
+    let counter = get_counter keeper_name in
+    Atomic.get counter
+end
 
 let waited_ms ~started_at =
   let waited_s = Time_compat.now () -. started_at in
@@ -27,45 +78,76 @@ let release_global_capacity () =
   loop ()
 ;;
 
-let acquire_global_capacity ~timeout_s =
+let acquire_capacity ~keeper_name ~timeout_s =
   let started_at = Time_compat.now () in
+  let global_limit = Keeper_config.keeper_turn_capacity_limit () in
+  let per_keeper_limit = Keeper_config.keeper_per_keeper_turn_capacity_limit () in
   let rec loop () =
-    let limit = Keeper_config.keeper_turn_capacity_limit () in
-    if limit <= 0
+    (* Fast path: both limits disabled *)
+    if global_limit <= 0 && per_keeper_limit <= 0
     then Ok { release = (fun () -> ()); wait_ms = waited_ms ~started_at }
     else (
-      let current = Atomic.get inflight in
-      if current < limit
+      let global_current = Atomic.get inflight in
+      let per_keeper_current = Per_keeper.get keeper_name in
+      (* Check per-keeper limit first (cheaper, more specific) *)
+      if per_keeper_limit > 0 && per_keeper_current >= per_keeper_limit
       then
-        if Atomic.compare_and_set inflight current (current + 1)
+        if Time_compat.now () -. started_at >= timeout_s
+        then
+          Error
+            { limit = global_limit
+            ; inflight = global_current
+            ; waited_ms = waited_ms ~started_at
+            ; per_keeper_limit
+            ; per_keeper_inflight = per_keeper_current
+            }
+        else (
+          Eio.Fiber.yield ();
+          loop ())
+      (* Check global limit *)
+      else if global_limit > 0 && global_current >= global_limit
+      then
+        if Time_compat.now () -. started_at >= timeout_s
+        then
+          Error
+            { limit = global_limit
+            ; inflight = global_current
+            ; waited_ms = waited_ms ~started_at
+            ; per_keeper_limit
+            ; per_keeper_inflight = per_keeper_current
+            }
+        else (
+          Eio.Fiber.yield ();
+          loop ())
+      (* Admission: increment both counters *)
+      else
+        if Atomic.compare_and_set inflight global_current (global_current + 1)
         then (
+          Per_keeper.incr keeper_name;
           let released = Atomic.make false in
           Ok
             { release =
                 (fun () ->
                    if Atomic.compare_and_set released false true
-                   then release_global_capacity ())
+                   then (
+                     release_global_capacity ();
+                     Per_keeper.decr keeper_name))
             ; wait_ms = waited_ms ~started_at
             })
         else (
           Eio.Fiber.yield ();
-          loop ())
-      else if Time_compat.now () -. started_at >= timeout_s
-      then Error { limit; inflight = current; waited_ms = waited_ms ~started_at }
-      else (
-        Eio.Fiber.yield ();
-        loop ()))
+          loop ()))
   in
   loop ()
 ;;
 
-let with_turn_capacity ?timeout_s ~keeper_name:_ ~channel:_ f =
+let with_turn_capacity ?timeout_s ~keeper_name ~channel:_ f =
   let timeout_s =
     match timeout_s with
     | Some value -> value
     | None -> Keeper_runtime_resolved.admission_wait_timeout_sec ()
   in
-  match acquire_global_capacity ~timeout_s with
+  match acquire_capacity ~keeper_name ~timeout_s with
   | Error rejection -> Error rejection
   | Ok acquired ->
     Fun.protect
@@ -74,3 +156,5 @@ let with_turn_capacity ?timeout_s ~keeper_name:_ ~channel:_ f =
 ;;
 
 let inflight_for_test () = Atomic.get inflight
+
+let per_keeper_inflight_for_test keeper_name = Per_keeper.get keeper_name

--- a/lib/keeper/keeper_turn_capacity.mli
+++ b/lib/keeper/keeper_turn_capacity.mli
@@ -1,4 +1,4 @@
-(** Global keeper-turn capacity gate.
+(** Global + per-keeper keeper-turn capacity gate.
 
     This is intentionally separate from {!Keeper_turn_holders}: holders are
     diagnostics for turns that are already running, while this module admits or
@@ -8,6 +8,8 @@ type rejection =
   { limit : int
   ; inflight : int
   ; waited_ms : int
+  ; per_keeper_limit : int
+  ; per_keeper_inflight : int
   }
 
 val with_turn_capacity :
@@ -18,3 +20,4 @@ val with_turn_capacity :
   ('a, rejection) result
 
 val inflight_for_test : unit -> int
+val per_keeper_inflight_for_test : string -> int

--- a/test/test_keeper_turn_capacity.ml
+++ b/test/test_keeper_turn_capacity.ml
@@ -13,9 +13,24 @@ let clear_capacity_limit () =
   | Error msg -> fail ("clear capacity limit failed: " ^ msg)
 ;;
 
-let with_capacity_limit value f =
-  set_capacity_limit value;
-  Fun.protect ~finally:clear_capacity_limit f
+let set_per_keeper_limit value =
+  match Masc.Runtime_params.set_by_key "keeper.turn.per_keeper_capacity_limit" (`Int value) with
+  | Ok () -> ()
+  | Error msg -> fail ("set per-keeper limit failed: " ^ msg)
+;;
+
+let clear_per_keeper_limit () =
+  match Masc.Runtime_params.clear_by_key "keeper.turn.per_keeper_capacity_limit" with
+  | Ok () -> ()
+  | Error msg -> fail ("clear per-keeper limit failed: " ^ msg)
+;;
+
+let with_limits ~global ~per_keeper f =
+  set_capacity_limit global;
+  set_per_keeper_limit per_keeper;
+  Fun.protect
+    ~finally:(fun () -> clear_capacity_limit (); clear_per_keeper_limit ())
+    f
 ;;
 
 let run_eio f = Eio_main.run (fun _env -> f ())
@@ -28,23 +43,28 @@ let test_default_capacity_preserves_fleet_gate () =
 
 let test_global_capacity_blocks_nested_turn () =
   run_eio (fun () ->
-    with_capacity_limit 1 (fun () ->
-      match
+    with_limits ~global:1 ~per_keeper:0 (fun () ->
+      let result =
         Masc.Keeper_turn_capacity.with_turn_capacity
           ~timeout_s:0.001
           ~keeper_name:"keeper-a"
           ~channel:Masc.Keeper_world_observation.Scheduled_autonomous
           (fun ~capacity_wait_ms:_ ->
-             Masc.Keeper_turn_capacity.with_turn_capacity
-               ~timeout_s:0.001
-               ~keeper_name:"keeper-b"
-               ~channel:Masc.Keeper_world_observation.Scheduled_autonomous
-               (fun ~capacity_wait_ms:_ -> ()))
-      with
-      | Ok (Error { Masc.Keeper_turn_capacity.limit; inflight; _ }) ->
-        check int "limit" 1 limit;
-        check int "inflight" 1 inflight
-      | Ok (Ok ()) -> fail "nested turn bypassed global capacity"
+             let inner =
+               Masc.Keeper_turn_capacity.with_turn_capacity
+                 ~timeout_s:0.001
+                 ~keeper_name:"keeper-b"
+                 ~channel:Masc.Keeper_world_observation.Scheduled_autonomous
+                 (fun ~capacity_wait_ms:_ -> ())
+             in
+             match inner with
+             | Error { Masc.Keeper_turn_capacity.limit; inflight; _ } ->
+               check int "limit" 1 limit;
+               check int "inflight" 1 inflight
+             | Ok () -> fail "nested turn bypassed global capacity")
+      in
+      match result with
+      | Ok () -> ()
       | Error err ->
         failf
           "first turn unexpectedly rejected limit=%d inflight=%d"
@@ -55,31 +75,140 @@ let test_global_capacity_blocks_nested_turn () =
 
 let test_disabled_capacity_allows_nested_turn () =
   run_eio (fun () ->
-    with_capacity_limit 0 (fun () ->
-      match
+    with_limits ~global:0 ~per_keeper:0 (fun () ->
+      let result =
         Masc.Keeper_turn_capacity.with_turn_capacity
           ~timeout_s:0.001
           ~keeper_name:"keeper-a"
           ~channel:Masc.Keeper_world_observation.Scheduled_autonomous
           (fun ~capacity_wait_ms:_ ->
-             Masc.Keeper_turn_capacity.with_turn_capacity
-               ~timeout_s:0.001
-               ~keeper_name:"keeper-b"
-               ~channel:Masc.Keeper_world_observation.Scheduled_autonomous
-               (fun ~capacity_wait_ms:_ -> ()))
-      with
-      | Ok (Ok ()) -> ()
-      | Ok (Error err) ->
-        failf
-          "nested turn rejected while disabled limit=%d inflight=%d"
-          err.Masc.Keeper_turn_capacity.limit
-          err.inflight
+             let inner =
+               Masc.Keeper_turn_capacity.with_turn_capacity
+                 ~timeout_s:0.001
+                 ~keeper_name:"keeper-b"
+                 ~channel:Masc.Keeper_world_observation.Scheduled_autonomous
+                 (fun ~capacity_wait_ms:_ -> ())
+             in
+             match inner with
+             | Ok () -> ()
+             | Error err ->
+               failf
+                 "nested turn rejected while disabled limit=%d inflight=%d"
+                 err.Masc.Keeper_turn_capacity.limit
+                 err.inflight)
+      in
+      match result with
+      | Ok () -> ()
       | Error err ->
         failf
           "first turn rejected while disabled limit=%d inflight=%d"
           err.Masc.Keeper_turn_capacity.limit
           err.inflight);
     check int "disabled does not leak" 0 (Masc.Keeper_turn_capacity.inflight_for_test ()))
+;;
+
+(* Per-keeper capacity tests *)
+
+let test_per_keeper_blocks_second_concurrent_turn () =
+  run_eio (fun () ->
+    with_limits ~global:32 ~per_keeper:1 (fun () ->
+      let result =
+        Masc.Keeper_turn_capacity.with_turn_capacity
+          ~timeout_s:0.001
+          ~keeper_name:"keeper-a"
+          ~channel:Masc.Keeper_world_observation.Scheduled_autonomous
+          (fun ~capacity_wait_ms:_ ->
+             let inner =
+               Masc.Keeper_turn_capacity.with_turn_capacity
+                 ~timeout_s:0.001
+                 ~keeper_name:"keeper-a"
+                 ~channel:Masc.Keeper_world_observation.Scheduled_autonomous
+                 (fun ~capacity_wait_ms:_ -> ())
+             in
+             match inner with
+             | Error { per_keeper_limit; per_keeper_inflight; _ } ->
+               check int "per_keeper_limit" 1 per_keeper_limit;
+               check int "per_keeper_inflight" 1 per_keeper_inflight
+             | Ok () ->
+               fail "same keeper got a second concurrent turn despite per-keeper limit=1")
+      in
+      match result with
+      | Ok () -> ()
+      | Error err ->
+        failf
+          "first turn unexpectedly rejected limit=%d inflight=%d"
+          err.Masc.Keeper_turn_capacity.limit
+          err.inflight);
+    check int "global released" 0 (Masc.Keeper_turn_capacity.inflight_for_test ());
+    check int "per-keeper released" 0
+      (Masc.Keeper_turn_capacity.per_keeper_inflight_for_test "keeper-a"))
+;;
+
+let test_per_keeper_allows_different_keepers () =
+  run_eio (fun () ->
+    with_limits ~global:32 ~per_keeper:1 (fun () ->
+      let result =
+        Masc.Keeper_turn_capacity.with_turn_capacity
+          ~timeout_s:0.001
+          ~keeper_name:"keeper-a"
+          ~channel:Masc.Keeper_world_observation.Scheduled_autonomous
+          (fun ~capacity_wait_ms:_ ->
+             let inner =
+               Masc.Keeper_turn_capacity.with_turn_capacity
+                 ~timeout_s:0.001
+                 ~keeper_name:"keeper-b"
+                 ~channel:Masc.Keeper_world_observation.Scheduled_autonomous
+                 (fun ~capacity_wait_ms:_ -> ())
+             in
+             match inner with
+             | Ok () -> ()
+             | Error err ->
+               failf
+                 "different keeper rejected despite per-keeper limit per_keeper_inflight=%d \
+                  per_keeper_limit=%d"
+                 err.per_keeper_inflight
+                 err.per_keeper_limit)
+      in
+      match result with
+      | Ok () -> ()
+      | Error err ->
+        failf
+          "first turn rejected limit=%d inflight=%d"
+          err.Masc.Keeper_turn_capacity.limit
+          err.inflight);
+    check int "all released" 0 (Masc.Keeper_turn_capacity.inflight_for_test ()))
+;;
+
+let test_per_keeper_disabled_allows_multiple () =
+  run_eio (fun () ->
+    with_limits ~global:32 ~per_keeper:0 (fun () ->
+      let result =
+        Masc.Keeper_turn_capacity.with_turn_capacity
+          ~timeout_s:0.001
+          ~keeper_name:"keeper-a"
+          ~channel:Masc.Keeper_world_observation.Scheduled_autonomous
+          (fun ~capacity_wait_ms:_ ->
+             let inner =
+               Masc.Keeper_turn_capacity.with_turn_capacity
+                 ~timeout_s:0.001
+                 ~keeper_name:"keeper-a"
+                 ~channel:Masc.Keeper_world_observation.Scheduled_autonomous
+                 (fun ~capacity_wait_ms:_ -> ())
+             in
+             match inner with
+             | Ok () -> ()
+             | Error err ->
+               failf
+                 "rejected while per-keeper disabled per_keeper_inflight=%d"
+                 err.per_keeper_inflight)
+      in
+      match result with
+      | Ok () -> ()
+      | Error err ->
+        failf
+          "first turn rejected while per-keeper disabled limit=%d"
+          err.Masc.Keeper_turn_capacity.limit);
+    check int "no leak" 0 (Masc.Keeper_turn_capacity.inflight_for_test ()))
 ;;
 
 let () =
@@ -89,5 +218,13 @@ let () =
       , [ test_case "default capacity is enabled" `Quick test_default_capacity_preserves_fleet_gate
         ; test_case "blocks nested turn at cap" `Quick test_global_capacity_blocks_nested_turn
         ; test_case "disabled gate allows nested turn" `Quick test_disabled_capacity_allows_nested_turn
+        ] )
+    ; ( "per-keeper gate"
+      , [ test_case "blocks second concurrent turn for same keeper"
+            `Quick test_per_keeper_blocks_second_concurrent_turn
+        ; test_case "allows different keepers concurrently"
+            `Quick test_per_keeper_allows_different_keepers
+        ; test_case "disabled per-keeper allows multiple"
+            `Quick test_per_keeper_disabled_allows_multiple
         ] )
     ]


### PR DESCRIPTION
## Summary

PR #20402 removed the legacy semaphore-based turn admission and replaced it with a global-only capacity gate (`keeper.turn.capacity_limit`, default 32). However, with ~15 active keepers sharing the same provider (e.g. `deepseek-v4-flash`), a single keeper can monopolise provider capacity by running multiple concurrent turns.

This PR adds a **per-keeper concurrent turn limit** alongside the existing global gate.

## Changes

| File | Change |
|------|--------|
| `keeper_turn_capacity.ml` | Per-keeper inflight tracking via Hashtbl of atomic counters. Checks per-keeper limit first (cheaper), then global. |
| `keeper_turn_capacity.mli` | Extended `rejection` record with `per_keeper_limit` and `per_keeper_inflight`. |
| `keeper_config.ml` | New Runtime_param `keeper.turn.per_keeper_capacity_limit` (default 2, range 0-64). |
| `keeper_config.mli` | Export new config function. |
| `keeper_heartbeat_loop.ml` | Rejection log shows which limit was hit (global vs per-keeper). |
| `test_keeper_turn_capacity.ml` | 3 new per-keeper tests + existing tests updated. |

## Admission Logic

```
acquire_capacity(keeper_name):
  1. Check per-keeper limit (default 2) — reject if this keeper already has 2+ turns
  2. Check global limit (default 32) — reject if total inflight >= 32
  3. Both pass → increment both counters, return acquired
```

With ~15 keepers × 2 per-keeper = 30 max concurrent, safely under global 32.

## Test Results

```
✅ global gate / default capacity is enabled
✅ global gate / blocks nested turn at cap
✅ global gate / disabled gate allows nested turn
✅ per-keeper gate / blocks second concurrent turn for same keeper
✅ per-keeper gate / allows different keepers concurrently
✅ per-keeper gate / disabled per-keeper allows multiple
```

## Configuration

| Param | Default | Range | Description |
|-------|---------|-------|-------------|
| `keeper.turn.capacity_limit` | 32 | 0-1024 | Global concurrent turn cap (0 = disabled) |
| `keeper.turn.per_keeper_capacity_limit` | 2 | 0-64 | Per-keeper concurrent turn cap (0 = disabled) |

Co-Authored-By: Claude <noreply@anthropic.com>