### PR TITLE
chore(deps): bump agent_sdk pin to >= 0.204.1

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -53,7 +53,7 @@
   ; (upstream piaf 0.2.0 missing conf-libssl dependency on macOS arm64).
   (piaf (>= 0.2.0))
   (eio-ssl (>= 0.3.0))
-  (agent_sdk (>= 0.204.0))
+  (agent_sdk (>= 0.204.1))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))


### PR DESCRIPTION
## Summary

Bump \`agent_sdk\` (OAS) minimum version from 0.204.0 to 0.204.1.

## Files Changed

1 file, 1 insertion(+), 1 deletion(-).

🤖 Generated with [Claude Code](https://claude.com/claude-code)