### PR TITLE
refactor(keeper): remove admission_reasons and skip_reasons from keepalive_scheduling_decision

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -74,8 +74,6 @@ type keepalive_scheduling_decision = Keeper_heartbeat_loop_scheduling.keepalive_
   runtime_backpressure : runtime_backpressure_decision;
   should_run_turn : bool;
   verdict_reasons : string list;
-  admission_reasons : string list;
-  skip_reasons : string list;
   channel : string;
 }
 
@@ -182,7 +180,6 @@ let run_keepalive_unified_turn
         | None -> "-"
       in
       let verdict_strs = scheduling.verdict_reasons in
-      let admission_reason_strs = scheduling.admission_reasons in
       let channel_str = scheduling.channel in
       if not should_run_turn
       then (
@@ -201,7 +198,7 @@ let run_keepalive_unified_turn
              Otel_metric_store.inc_counter proactive_skip_reason_metric
                ~labels:[ "keeper", meta_after_triage.name; "reason", reason_str ]
                ())
-          admission_reason_strs;
+          verdict_strs;
         (* #10940 follow-up — Otel_metric_store counters aggregate skip reasons
            across time, but operators need recent skip verdict context
            when diagnosing idle/quiet keepers. Stamping the registry on
@@ -211,7 +208,7 @@ let run_keepalive_unified_turn
            Keeper_registry.record_skip_reasons
              ~base_path:ctx.config.base_path
              meta_after_triage.name
-             ~reasons:admission_reason_strs
+             ~reasons:verdict_strs
          | Runtime_backpressured { runtime_id; reason } ->
            record_runtime_backpressure_observation
              ~base_path:ctx.config.base_path

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -68,8 +68,6 @@ type keepalive_scheduling_decision = {
   runtime_backpressure : Keeper_heartbeat_loop_observations.runtime_backpressure_decision;
   should_run_turn : bool;
   verdict_reasons : string list;
-  admission_reasons : string list;
-  skip_reasons : string list;
   channel : string;
 }
 

--- a/lib/keeper/keeper_heartbeat_loop_scheduling.ml
+++ b/lib/keeper/keeper_heartbeat_loop_scheduling.ml
@@ -21,8 +21,6 @@ type keepalive_scheduling_decision = {
   runtime_backpressure : runtime_backpressure_decision;
   should_run_turn : bool;
   verdict_reasons : string list;
-  admission_reasons : string list;
-  skip_reasons : string list;
   channel : string;
 }
 
@@ -54,20 +52,12 @@ let decide_keepalive_scheduling
   let verdict_reasons =
     Keeper_world_observation.verdict_reasons_to_strings turn_decision.verdict
   in
-  let admission_reasons =
-    match runtime_backpressure with
-    | Runtime_admitted -> verdict_reasons
-    | Runtime_backpressured { reason; _ } ->
-      Observations.runtime_backpressure_observation_reasons ~reason
-  in
   let channel = Keeper_world_observation.channel_to_string turn_decision.channel in
   { turn_decision
   ; requested_should_run_turn
   ; runtime_backpressure
   ; should_run_turn
   ; verdict_reasons
-  ; admission_reasons
-  ; skip_reasons = admission_reasons
   ; channel
   }
 ;;

--- a/lib/keeper/keeper_heartbeat_loop_scheduling.mli
+++ b/lib/keeper/keeper_heartbeat_loop_scheduling.mli
@@ -6,8 +6,6 @@ type keepalive_scheduling_decision = {
   runtime_backpressure : Keeper_heartbeat_loop_observations.runtime_backpressure_decision;
   should_run_turn : bool;
   verdict_reasons : string list;
-  admission_reasons : string list;
-  skip_reasons : string list;
   channel : string;
 }
 


### PR DESCRIPTION
## Summary

Remove `admission_reasons` and `skip_reasons` fields from `keepalive_scheduling_decision`.

## Why

- `skip_reasons`: Dead field. Added in PR #20402 but never read by any consumer.
- `admission_reasons`: Redundant with `verdict_reasons`.
  - `Runtime_admitted` path: identical to `verdict_reasons`
  - `Runtime_backpressured` path: never consumed by skip-recording code (that branch calls `record_runtime_backpressure_observation` instead)

## Changes

- Remove both fields from `keepalive_scheduling_decision` record (4 files)
- Replace `admission_reason_strs` usage with `verdict_strs` in:
  - `Otel_metric_store.inc_counter proactive_skip_reason_metric`
  - `Keeper_registry.record_skip_reasons`

## Verification

- `dune build lib/keeper/keeper_heartbeat_loop_scheduling.ml lib/keeper/keeper_heartbeat_loop.ml` passes

## Co-Authored-By

Claude Opus 4.8 <noreply@anthropic.com>
