### PR TITLE
feat(keeper): add per-runtime-lane concurrency gate

### DIFF
--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -423,10 +423,27 @@ let run_try_provider
         finalize_liveness ();
         Printexc.raise_with_backtrace exn bt
     in
+    (* Per-lane concurrency gate: limits inflight requests per runtime lane
+       using the max-concurrent value from runtime.toml binding config.
+       Placed outside with_liveness_attempt because:
+       - Lane gate = admission control (prevents dispatch)
+       - Liveness = observation/kill (monitors running stream) *)
+    let lane_key = Runtime_candidate.provider_label candidate in
+    let lane_max_concurrent =
+      match Runtime.get_runtime_by_id ctx.runtime_id with
+      | Some rt ->
+        let b = rt.Runtime.binding in
+        b.max_concurrent
+      | None -> 0  (* runtime resolved earlier; 0 disables the gate as fallback *)
+    in
     (match
-       (* RFC-0206: the runtime CLI-preflight wrapper is gone; run the single
-          provider attempt directly. *)
-       (fun () ->
+       Runtime_lane_capacity.with_lane_capacity
+         ~lane_key
+         ~max_concurrent:lane_max_concurrent
+         (fun ~capacity_wait_ms ->
+            let _ = capacity_wait_ms in
+            (* RFC-0206: the runtime CLI-preflight wrapper is gone; run the single
+               provider attempt directly. *)
             let result =
               with_liveness_attempt (fun ~attempt_sw ~liveness_on_event ->
                 let effective_checkpoint =
@@ -484,11 +501,22 @@ let run_try_provider
                                 })))
                    | None -> run_fn ()))
             in
-            Ok result) ()
+            result)
      with
-     | Error err ->
+     | Error rejection ->
        finalize_liveness ();
-       Error err, None, None
+       Error
+         (Agent_sdk.Error.Api
+            (Timeout
+               { message =
+                   Printf.sprintf
+                     "Runtime lane %s capacity full: %d/%d slots, waited %dms"
+                     rejection.lane_key
+                     rejection.inflight
+                     rejection.limit
+                     rejection.waited_ms
+               })),
+       None, None
      | Ok result ->
        finalize_liveness ();
        let liveness_success_sample = liveness_success_sample () in

--- a/lib/keeper/runtime_lane_capacity.ml
+++ b/lib/keeper/runtime_lane_capacity.ml
@@ -1,0 +1,141 @@
+(** Per-runtime-lane capacity gate.
+
+    Limits concurrent keeper turns per runtime lane (provider+model binding).
+    The lane key is the provider label (e.g. "ollama_cloud"), and the limit
+    comes from [Runtime.binding.max_concurrent] in runtime.toml.
+
+    This is the third tier in the 3-tier admission stack:
+    - Tier 1: {!Keeper_turn_capacity} — global + per-keeper limits
+    - Tier 2 (this module): per-lane limit from binding config
+    - Observation: {!Keeper_attempt_liveness} — kill stalled streams, not prevention
+
+    The lane gate sits between the per-keeper gate and the liveness observer
+    in the dispatch chain:
+    {[
+      keeper_heartbeat_loop
+        → Keeper_turn_capacity.with_turn_capacity (global + per-keeper)
+          → keeper_turn_driver.run_named
+            → Runtime_lane_capacity.with_lane_capacity (this module)
+              → with_liveness_attempt (observation/kill)
+                → provider stream
+    ]}
+
+    When [max_concurrent <= 0], the gate is disabled (immediate admission).
+
+    Config source: runtime.toml [binding].max-concurrent, e.g.
+    {[
+      [ollama_cloud.deepseek-v4-flash]
+      max-concurrent = 8
+    ]} *)
+
+type rejection =
+  { lane_key : string
+  ; limit : int
+  ; inflight : int
+  ; waited_ms : int
+  }
+
+type acquired =
+  { release : unit -> unit
+  ; wait_ms : int
+  }
+
+(** Per-lane inflight counters. Key = provider_label (e.g. "ollama_cloud").
+    Thread-safe via atomic per-key counters. *)
+module Lane = struct
+  let table : (string, int Atomic.t) Hashtbl.t = Hashtbl.create 16
+
+  let get_counter lane_key =
+    match Hashtbl.find_opt table lane_key with
+    | Some counter -> counter
+    | None ->
+      (* Race-safe: if two fibers create for the same key, both start at 0.
+         The second Hashtbl.replace overwrites with an equivalent counter. *)
+      let counter = Atomic.make 0 in
+      Hashtbl.replace table lane_key counter;
+      counter
+
+  let incr lane_key =
+    let counter = get_counter lane_key in
+    Atomic.incr counter
+
+  let decr lane_key =
+    let counter = get_counter lane_key in
+    let rec loop () =
+      let current = Atomic.get counter in
+      if current <= 0
+      then ()
+      else if not (Atomic.compare_and_set counter current (current - 1))
+      then loop ()
+    in
+    loop ()
+
+  let get lane_key =
+    let counter = get_counter lane_key in
+    Atomic.get counter
+end
+
+let waited_ms ~started_at =
+  let waited_s = Time_compat.now () -. started_at in
+  int_of_float ((if waited_s < 0.0 then 0.0 else waited_s) *. 1000.0)
+;;
+
+let acquire_lane_capacity ~lane_key ~max_concurrent ~timeout_s =
+  (* Disabled gate: immediate admission with no-op release. *)
+  if max_concurrent <= 0
+  then Ok { release = (fun () -> ()); wait_ms = 0 }
+  else
+    let started_at = Time_compat.now () in
+    let rec loop () =
+      let current = Lane.get lane_key in
+      if current >= max_concurrent
+      then
+        if Time_compat.now () -. started_at >= timeout_s
+        then
+          Error
+            { lane_key
+            ; limit = max_concurrent
+            ; inflight = current
+            ; waited_ms = waited_ms ~started_at
+            }
+        else (
+          Eio.Fiber.yield ();
+          loop ())
+      else
+        (* CAS: only admit if our stale read hasn't been overtaken. *)
+        let counter = Lane.get_counter lane_key in
+        if Atomic.compare_and_set counter current (current + 1)
+        then
+          let released = Atomic.make false in
+          Ok
+            { release =
+                (fun () ->
+                   if Atomic.compare_and_set released false true
+                   then Lane.decr lane_key)
+            ; wait_ms = waited_ms ~started_at
+            }
+        else (
+          Eio.Fiber.yield ();
+          loop ())
+    in
+    loop ()
+;;
+
+let with_lane_capacity ?timeout_s ~lane_key ~max_concurrent f =
+  let timeout_s =
+    match timeout_s with
+    | Some value -> value
+    | None -> Keeper_runtime_resolved.admission_wait_timeout_sec ()
+  in
+  match acquire_lane_capacity ~lane_key ~max_concurrent ~timeout_s with
+  | Error rejection -> Error rejection
+  | Ok acquired ->
+    Fun.protect
+      ~finally:acquired.release
+      (fun () -> Ok (f ~capacity_wait_ms:acquired.wait_ms))
+;;
+
+let inflight_for_test lane_key = Lane.get lane_key
+
+let reset_for_test () =
+  Hashtbl.clear Lane.table

--- a/lib/keeper/runtime_lane_capacity.mli
+++ b/lib/keeper/runtime_lane_capacity.mli
@@ -1,0 +1,39 @@
+(** Per-runtime-lane capacity gate.
+
+    Limits concurrent keeper turns per runtime lane (provider+model binding).
+    See {!Runtime_lane_capacity} for full documentation. *)
+
+type rejection =
+  { lane_key : string
+  ; limit : int
+  ; inflight : int
+  ; waited_ms : int
+  }
+
+type acquired =
+  { release : unit -> unit
+  ; wait_ms : int
+  }
+
+(** Acquire a lane capacity permit, blocking up to [timeout_s] if full.
+    Returns [Error rejection] on timeout, [Ok acquired] on admission.
+    The caller must call [acquired.release] exactly once. *)
+val acquire_lane_capacity :
+  lane_key:string -> max_concurrent:int -> timeout_s:float ->
+  (acquired, rejection) result
+
+(** Convenience wrapper: acquire, run [f], release in finally.
+    On admission, [f] receives [~capacity_wait_ms] for observability.
+    On rejection, returns [Error rejection] without calling [f]. *)
+val with_lane_capacity :
+  ?timeout_s:float ->
+  lane_key:string ->
+  max_concurrent:int ->
+  (capacity_wait_ms:int -> 'a) ->
+  ('a, rejection) result
+
+(** Current inflight count for a lane key (test access). *)
+val inflight_for_test : string -> int
+
+(** Clear all lane counters (test teardown). *)
+val reset_for_test : unit -> unit

--- a/test/dune
+++ b/test/dune
@@ -1347,6 +1347,8 @@
 
 (include stanzas/test_keeper_turn_capacity.inc)
 
+(include stanzas/test_runtime_lane_capacity.inc)
+
 (include stanzas/test_http_pages_asset_read.inc)
 
 (include stanzas/test_bounded_proc.inc)

--- a/test/stanzas/test_runtime_lane_capacity.inc
+++ b/test/stanzas/test_runtime_lane_capacity.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_runtime_lane_capacity)
+ (modules test_runtime_lane_capacity)
+ (libraries masc alcotest eio eio_main))

--- a/test/test_runtime_lane_capacity.ml
+++ b/test/test_runtime_lane_capacity.ml
@@ -1,0 +1,125 @@
+open Alcotest
+
+let run_eio f = Eio_main.run (fun _env -> f ())
+
+let test_blocks_at_max_concurrent () =
+  Masc.Runtime_lane_capacity.reset_for_test ();
+  run_eio (fun () ->
+    let result =
+      Masc.Runtime_lane_capacity.with_lane_capacity
+        ~timeout_s:0.001
+        ~lane_key:"ollama_cloud"
+        ~max_concurrent:1
+        (fun ~capacity_wait_ms:_ ->
+           (* Inner attempt to same lane should be rejected *)
+           let inner =
+             Masc.Runtime_lane_capacity.with_lane_capacity
+               ~timeout_s:0.001
+               ~lane_key:"ollama_cloud"
+               ~max_concurrent:1
+               (fun ~capacity_wait_ms:_ -> ())
+           in
+           match inner with
+           | Error { Masc.Runtime_lane_capacity.lane_key; limit; inflight; _ } ->
+             check string "lane_key" "ollama_cloud" lane_key;
+             check int "limit" 1 limit;
+             check int "inflight" 1 inflight
+           | Ok () -> fail "second concurrent request bypassed lane capacity")
+    in
+    match result with
+    | Ok () -> ()
+    | Error err ->
+      failf "first request rejected limit=%d inflight=%d" err.limit err.inflight);
+  check int "released" 0 (Masc.Runtime_lane_capacity.inflight_for_test "ollama_cloud")
+;;
+
+let test_different_lanes_independent () =
+  Masc.Runtime_lane_capacity.reset_for_test ();
+  run_eio (fun () ->
+    let result =
+      Masc.Runtime_lane_capacity.with_lane_capacity
+        ~timeout_s:0.001
+        ~lane_key:"ollama_cloud"
+        ~max_concurrent:1
+        (fun ~capacity_wait_ms:_ ->
+           (* Different lane should be admitted independently *)
+           let inner =
+             Masc.Runtime_lane_capacity.with_lane_capacity
+               ~timeout_s:0.001
+               ~lane_key:"runpod_mtp"
+               ~max_concurrent:1
+               (fun ~capacity_wait_ms:_ -> ())
+           in
+           match inner with
+           | Ok () -> ()
+           | Error err ->
+             failf "different lane rejected lane_key=%s" err.lane_key)
+    in
+    match result with
+    | Ok () -> ()
+    | Error err ->
+      failf "first request rejected lane=%s" err.lane_key);
+  check int "ollama released" 0 (Masc.Runtime_lane_capacity.inflight_for_test "ollama_cloud");
+  check int "runpod released" 0 (Masc.Runtime_lane_capacity.inflight_for_test "runpod_mtp")
+;;
+
+let test_disabled_allows_unlimited () =
+  Masc.Runtime_lane_capacity.reset_for_test ();
+  run_eio (fun () ->
+    let result =
+      Masc.Runtime_lane_capacity.with_lane_capacity
+        ~timeout_s:0.001
+        ~lane_key:"ollama_cloud"
+        ~max_concurrent:0
+        (fun ~capacity_wait_ms:_ ->
+           (* Disabled gate: inner request to same lane should pass *)
+           let inner =
+             Masc.Runtime_lane_capacity.with_lane_capacity
+               ~timeout_s:0.001
+               ~lane_key:"ollama_cloud"
+               ~max_concurrent:0
+               (fun ~capacity_wait_ms:_ -> ())
+           in
+           match inner with
+           | Ok () -> ()
+           | Error err ->
+             failf "rejected while disabled lane=%s" err.lane_key)
+    in
+    match result with
+    | Ok () -> ()
+    | Error err ->
+      failf "first request rejected while disabled lane=%s" err.lane_key);
+  (* Disabled gate should not increment counters *)
+  check int "no counter leak" 0 (Masc.Runtime_lane_capacity.inflight_for_test "ollama_cloud")
+;;
+
+let test_release_on_exception () =
+  Masc.Runtime_lane_capacity.reset_for_test ();
+  (* with_lane_capacity uses Fun.protect ~finally, so the release runs
+     even when the body raises. The exception re-propagates, so we
+     catch it here to observe the counter state afterwards. *)
+  (try
+    run_eio (fun () ->
+      ignore
+        (Masc.Runtime_lane_capacity.with_lane_capacity
+           ~timeout_s:0.001
+           ~lane_key:"ollama_cloud"
+           ~max_concurrent:1
+           (fun ~capacity_wait_ms:_ ->
+              raise Exit)))
+  with Exit -> ());
+  check int "released after exception" 0
+    (Masc.Runtime_lane_capacity.inflight_for_test "ollama_cloud")
+;;
+
+let () =
+  run
+    "runtime_lane_capacity"
+    [ ( "lane gate"
+      , [ test_case "blocks at max_concurrent" `Quick test_blocks_at_max_concurrent
+        ; test_case "different lanes are independent"
+            `Quick test_different_lanes_independent
+        ; test_case "disabled allows unlimited" `Quick test_disabled_allows_unlimited
+        ; test_case "releases on exception" `Quick test_release_on_exception
+        ] )
+    ]


### PR DESCRIPTION
## Summary

PR #20402가 `keeper_turn_slot.ml`을 통째로 삭제하여 모든 동시성 제어가 사라졌습니다. 19개 keeper가 `ollama_cloud.deepseek-v4-flash`에 제한 없이 동시 요청 → 2,679건/일 `no_first_token` 타임아웃.

## Changes

**신규 모듈**: `runtime_lane_capacity.ml` + `.mli`
- per-lane admission gate (provider_label 키, atomic CAS)
- `runtime.toml`의 기존 `[binding].max-concurrent` 값을 사용 (새 설정 불필요)
- `max_concurrent <= 0`이면 gate 비활성화

**dispatch chain 삽입**: `keeper_turn_driver_try_provider.ml`
- `Runtime_lane_capacity.with_lane_capacity`이 `with_liveness_attempt`를 감쌈
- lane gate = admission control (dispatch 방지)
- liveness = observation/kill (스트림 모니터링)
- `ctx.runtime_id` → `Runtime.get_runtime_by_id` → `binding.max_concurrent` 직접 조회

**테스트**: 4개 (blocks at limit, different lanes independent, disabled allows unlimited, releases on exception)

## 3-tier gate 아키텍처

| Tier | 모듈 | 축 | 제어 |
|------|------|-----|------|
| 1 | `Keeper_turn_capacity` | keeper_name | global 32 + per-keeper 2 |
| 2 | `Runtime_lane_capacity` ← NEW | provider_label | per-lane max-concurrent from config |
| 3 | `Keeper_attempt_liveness` | candidate_key | 관측/kill (budget) |

## Verification

- `dune build --root .` OK
- `dune build @check --root .` OK
- `test_keeper_turn_capacity.exe` 6/6 pass (regression)
- `test_runtime_lane_capacity.exe` 4/4 pass (new)

## Follow-up

- `runtime_adapter.ml`의 dead `internal_model_rotation_count` write 제거
- per-keeper limit (현재 2) 값 조정 검토

🤖 Generated with [Claude Code](https://claude.com/claude-code)
