### PR TITLE
fix(keeper): increase liveness TTFT budget for slow providers

### DIFF
--- a/lib/keeper_runtime/keeper_attempt_liveness.ml
+++ b/lib/keeper_runtime/keeper_attempt_liveness.ml
@@ -18,7 +18,7 @@ type budget = {
    are tuned from successful TTFT/inter-chunk/wall samples in
    [Keeper_attempt_liveness_config]. *)
 let bootstrap : budget =
-  { ttft_max = 600.0; inter_chunk_max = 120.0; attempt_wall_max = 1800.0 }
+  { ttft_max = 1200.0; inter_chunk_max = 120.0; attempt_wall_max = 1800.0 }
 
 module Stream_chunk = struct
   type kind =

--- a/lib/keeper_runtime/keeper_attempt_liveness_config.ml
+++ b/lib/keeper_runtime/keeper_attempt_liveness_config.ml
@@ -187,7 +187,7 @@ let budget_of_samples samples =
   | Some ttft_ms, Some inter_ms, Some wall_ms ->
     let ttft_max =
       tuned_seconds
-        ~floor:30.0
+        ~floor:60.0
         ~ceiling:900.0
         ~multiplier:1.5
         ~add:5.0


### PR DESCRIPTION
## Problem

`no_first_token` errors kill keeper cycles across all providers (primarily `ollama_cloud.deepseek-v4-flash`, also `runpod_mtp.qwen36-35b-a3b-mtp`). Latency clusters at ~1,380,000ms (23 min) and escalates to ~1,800,000ms (30 min) — exceeding the liveness TTFT budget.

## Root Cause

OAS per-provider slot scheduler (`max_concurrent=4` for Ollama) creates queueing delays. When N keepers (13+) hit the same provider concurrently:

- 4 requests proceed immediately
- Remaining requests queue in OAS `slot_scheduler.ml`
- Queue wait (up to 20+ min) + actual provider TTFT exceeds liveness budget
- Liveness guard kills with `no_first_token` despite legitimate provider progress

PR #20416 isolated liveness budget per provider (fixing cross-provider contamination), but the absolute budget floor (30s tuned / 600s bootstrap) is still too low for OAS queueing + slow provider TTFT.

## Changes

| File | Change |
|------|--------|
| `keeper_attempt_liveness.ml` | Bootstrap `ttft_max`: 600s → 1200s |
| `keeper_attempt_liveness_config.ml` | Tuned `ttft_max` floor: 30s → 60s |

## Local Verification

- Change scope: 2 float literals in 2 files
- Full `dune build` blocked by global lock contention in worktree (see `memory/reference_masc_mcp_dune_local_lock_contention.md`)
- CI build verification pending

## Follow-up

OAS-side fix required to address the root cause:
- Increase `max_concurrent` for Ollama/OpenAI_compat in `provider_throttle.ml` (currently 4)
- Or add HTTP connection pooling to `http_client.ml` (currently one connection per request)

This PR is a MASC-side mitigation; the OAS-side fix eliminates the queueing bottleneck.

