### PR TITLE
fix(keeper): reject removed initiative_enabled and persona_profile_path fields (#20331)

### DIFF
--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -507,12 +507,20 @@ let parse_keeper_state
 let reject_removed_keeper_meta_shapes (json : Yojson.Safe.t) =
   match json with
   | `Assoc fields ->
-    (match List.assoc_opt "last_blocker" fields with
-     | Some (`String _) ->
-       Error
-         "removed keeper meta field shape is no longer supported: \
-          last_blocker:string. Use structured last_blocker object."
-     | Some _ | None -> Ok ())
+    (match
+       List.find_opt
+         (fun (k, _) -> List.mem k [ "initiative_enabled"; "persona_profile_path" ])
+         fields
+     with
+     | Some (k, _) ->
+       Error ("removed keeper meta field is no longer supported: " ^ k)
+     | None ->
+       (match List.assoc_opt "last_blocker" fields with
+        | Some (`String _) ->
+          Error
+            "removed keeper meta field shape is no longer supported: \
+             last_blocker:string. Use structured last_blocker object."
+        | Some _ | None -> Ok ()))
   | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ -> Ok ()
 ;;
 


### PR DESCRIPTION
## Summary

`reject_removed_keeper_meta_shapes` in `Keeper_meta_json_parse` now rejects two legacy fields that were removed from the keeper meta schema but were still being silently ignored during JSON parsing:

- `initiative_enabled`
- `persona_profile_path`

This aligns the parser with the test expectations in `test_keeper_deliberation` (`keeper_field_cleanup` group).

## Test plan

- [x] `test/test_keeper_deliberation.exe` full suite passes (78 tests)
- [x] `dune build @check`
- [x] `dune build`

Closes #20331

🤖 Generated with [Claude Code](https://claude.com/claude-code)