### PR TITLE
fix(keeper): use binding-specific runtime_id as lane key

### DIFF
--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -305,8 +305,15 @@ let run_try_provider
        on legitimately slow providers. Standard agent SDKs (OpenAI, Anthropic,
        LangChain, Vercel AI) use HTTP-level timeouts only. *)
     (* Per-lane concurrency gate: limits inflight requests per runtime lane
-       using the max-concurrent value from runtime.toml binding config. *)
-    let lane_key = Runtime_candidate.provider_label candidate in
+       using the max-concurrent value from runtime.toml binding config.
+
+       lane_key MUST be binding-specific (ctx.runtime_id, e.g.
+       "ollama_cloud.deepseek-v4-flash") — NOT provider kind / provider_label.
+       Runtime_candidate.provider_label returns the provider kind
+       ("openai_compat") which causes ALL OpenAI-compatible providers to share
+       a single counter, ignoring per-binding max-concurrent in runtime.toml.
+       See: provider lane key collapse bug, 2026-06-08. *)
+    let lane_key = ctx.runtime_id in
     let lane_max_concurrent =
       match Runtime.get_runtime_by_id ctx.runtime_id with
       | Some rt ->


### PR DESCRIPTION
## Problem

Runtime_lane_capacity used Runtime_candidate.provider_label as the lane
key. This function returns the provider kind (e.g. openai_compat), not a
binding-specific identifier.

Result: all OpenAI-compatible providers (ollama_cloud.deepseek-v4-flash,
runpod_mtp.qwen36-35b-a3b-mtp, local_mtp, etc.) share a single counter with
max_concurrent = 8, even though runtime.toml configures per-binding limits.

With 16 keepers and per-keeper limit = 2, up to 32 concurrent turns compete
for the same 8 slots — causing lane capacity timeout (180s) followed by
liveness no_first_token after retry exhaustion (30min total latency).

## Fix

Use ctx.runtime_id (binding-specific, e.g. ollama_cloud.deepseek-v4-flash)
as lane_key. This gives each binding its own independent counter, matching
the per-binding max_concurrent configuration in runtime.toml.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/code)