### PR TITLE
fix(keeper): correct cost source labels to match test contract (#20332)

### DIFF
--- a/lib/keeper_hooks/keeper_hooks_oas_types.ml
+++ b/lib/keeper_hooks/keeper_hooks_oas_types.ml
@@ -112,8 +112,8 @@ type cost_status =
 let cost_label_reported = "reported"
 let cost_label_known_free = "known_free"
 let cost_label_no_tokens = "no_tokens"
-let cost_label_usage_missing = "usage_missing"
-let cost_label_usage_untrusted = "usage_untrusted"
+let cost_label_usage_missing = "missing_usage"
+let cost_label_usage_untrusted = "untrusted_usage"
 let cost_label_runtime_unknown = "runtime_unknown"
 let cost_label_oas_cost_unreported = "oas_cost_unreported"
 

--- a/lib/keeper_hooks_oas_types/keeper_hooks_oas_types.ml
+++ b/lib/keeper_hooks_oas_types/keeper_hooks_oas_types.ml
@@ -112,8 +112,8 @@ type cost_status =
 let cost_label_reported = "reported"
 let cost_label_known_free = "known_free"
 let cost_label_no_tokens = "no_tokens"
-let cost_label_usage_missing = "usage_missing"
-let cost_label_usage_untrusted = "usage_untrusted"
+let cost_label_usage_missing = "missing_usage"
+let cost_label_usage_untrusted = "untrusted_usage"
 let cost_label_runtime_unknown = "runtime_unknown"
 let cost_label_oas_cost_unreported = "oas_cost_unreported"
 


### PR DESCRIPTION
## Summary
- `cost_label_usage_missing` and `cost_label_usage_untrusted` were swapped: the constants said `usage_missing` / `usage_untrusted` while the #10318 test contract expects `missing_usage` / `untrusted_usage`.
- This caused `test_cost_usd_source_attribution_10318` to fail with source-label drift.
- Fix both copies (`lib/keeper_hooks_oas_types` and `lib/keeper_hooks`) to avoid future divergence.

## Test plan
- [x] `dune exec test/test_cost_usd_source_attribution_10318.exe` passes (9/9)

Closes #20332

🤖 Generated with [Claude Code](https://claude.com/claude-code)