### PR TITLE
chore: update agent_sdk pin in masc.opam.locked (#20354)

### DIFF
--- a/masc.opam.locked
+++ b/masc.opam.locked
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "masc"
-version: "0.18.13"
+version: "0.19.37"
 synopsis: "Multi-Agent Shared Context MCP Server in OCaml"
 description:
   "MASC Protocol: File-based workspace collaboration for Claude, Gemini, and Codex agents"
@@ -11,7 +11,7 @@ homepage: "https://github.com/jeong-sik/masc"
 doc: "https://github.com/jeong-sik/masc"
 bug-reports: "https://github.com/jeong-sik/masc/issues"
 depends: [
-  "agent_sdk" {= "0.194.0"}
+  "agent_sdk" {= "0.204.1"}
   "alcotest" {with-test & = "1.9.1"}
   "ambient-context-eio" {= "0.2"}
   "bigstringaf" {= "0.10.0"}
@@ -86,8 +86,8 @@ build: [
 dev-repo: "git+https://github.com/jeong-sik/masc.git"
 pin-depends: [
   [
-    "agent_sdk.0.194.0"
-    "git+https://github.com/jeong-sik/oas.git#d88e2fe4f62519229b0f6069a0c1f7896316233a"
+    "agent_sdk.0.204.1"
+    "git+https://github.com/jeong-sik/oas.git#cd556806d6ef1131e4bafadce6c762a1ebee1295"
   ]
   [
     "bisect_ppx.2.8.3"


### PR DESCRIPTION
## Summary

Update stale `masc.opam.locked` to match the active pin truth:

| Field | Before | After | Source of truth |
|-------|--------|-------|-----------------|
| version | 0.18.13 | 0.19.37 | `masc.opam` (generated from `dune-project`) |
| agent_sdk | 0.194.0 | 0.204.1 | `dune-project` floor |
| oas pin | d88e2fe4 | cd556806 | `scripts/oas-agent-sdk-pin.sh` |

Fixes #20354.

## Test plan

- [x] `masc.opam.locked` agent_sdk version matches `dune-project`
- [x] `masc.opam.locked` oas pin SHA matches `scripts/oas-agent-sdk-pin.sh`
- [x] `masc.opam.locked` version matches `masc.opam`

🤖 Generated with [Claude Code](https://claude.com/claude-code)