### PR TITLE
fix(dashboard): preserve streaming timing fields in decodeRuntimeModelMetric (#20001)

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -837,6 +837,9 @@ function decodeRuntimeModelMetric(raw: unknown): DashboardRuntimeModelMetric | n
               : null,
             coverage_reason: asNullableString(r.coverage_reason),
             coverage_stage: asNullableString(r.coverage_stage),
+            streaming_ttfrc_ms: asNumber(r.streaming_ttfrc_ms) ?? null,
+            streaming_inter_chunk_count: asNumber(r.streaming_inter_chunk_count) ?? null,
+            streaming_inter_chunk_avg_ms: asNumber(r.streaming_inter_chunk_avg_ms) ?? null,
           }))
       : null,
     buckets: Array.isArray(raw.buckets)


### PR DESCRIPTION
## Summary

`decodeRuntimeModelMetric` was dropping three streaming fields when decoding `recent_entries`:
- `streaming_ttfrc_ms`
- `streaming_inter_chunk_count`
- `streaming_inter_chunk_avg_ms`

The type declared them (lines 673-675) and the backend emits them, but the decoder rebuilt each entry object without copying them, so the cost dashboard rendered Avg TTFRC as empty.

## Change

Add the three fields to the `recent_entries` map in `decodeRuntimeModelMetric`.

## Test plan

- [x] `pnpm run typecheck` passes
- [x] `src/api/dashboard.test.ts` 44/44 passes

Fixes #20001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)