### PR TITLE
fix(process): release lifetime guard on unexpected waitpid errors

### DIFF
--- a/lib/process/bg_task.ml
+++ b/lib/process/bg_task.ml
@@ -216,7 +216,9 @@ let start_exit_watcher st =
        | exception Unix.Unix_error (Unix.EINTR, _, _) -> wait ()
        | exception Unix.Unix_error (Unix.ECHILD, _, _) ->
            with_reg (fun () -> release_lifetime_guard st)
-       | exception exn -> observe_sidecar_failure ~site:"waitpid" exn
+       | exception exn ->
+           observe_sidecar_failure ~site:"waitpid" exn;
+           with_reg (fun () -> release_lifetime_guard st)
      in
      wait)
 


### PR DESCRIPTION
The catch-all exception handler in Bg_task.start_exit_watcher (line 219) did not call release_lifetime_guard when Unix.waitpid raised an unexpected exception. This caused a permanent fd_accountant slot leak. Fix: add with_reg (fun () -> release_lifetime_guard st) to the catch-all branch, mirroring the ECHILD branch. dune build @check passes.