### PR TITLE
chore(deps): bump agent_sdk pin to >= 0.204.2

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -53,7 +53,7 @@
   ; (upstream piaf 0.2.0 missing conf-libssl dependency on macOS arm64).
   (piaf (>= 0.2.0))
   (eio-ssl (>= 0.3.0))
-  (agent_sdk (>= 0.204.1))
+  (agent_sdk (>= 0.204.2))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))


### PR DESCRIPTION
Bump minimum agent_sdk version to 0.204.2 to include OAS PR #1939 (provider slot scheduler bypass) and PR #1940 (version 0.204.2 bump).\n\nRequired to prevent the invisible OAS queueing that caused fleet-wide no_first_token errors.\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>