### PR TITLE
fix(keeper): remove disk pressure admission check from spawn slots

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -466,7 +466,7 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
     if Keeper_registry.is_registered ~base_path:ctx.config.base_path m.name
     then Log.Keeper.info "start_keepalive: skipped %s (already registered)" m.name
     else
-      match Keeper_registry.spawn_slots_decision ~base_path:ctx.config.base_path () with
+      match Keeper_registry.spawn_slots_decision () with
       | Error reason ->
         Keeper_registry.record_spawn_slot_denied ~keeper_name:m.name ~surface:"keepalive" reason;
         publish_keeper_lifecycle

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -306,38 +306,34 @@ let set_started_at_for_test ~base_path name started_at =
 
 type spawn_slot_denial_reason = Spawn_slots.denial_reason =
   | Fd_pressure_active
-  | Disk_pressure_active
   | Fd_admission_blocked
-  | Disk_admission_blocked
   | Max_active_keepers of { running_count : int; max_keepers : int }
 
 let spawn_slot_denial_reason_to_label = Spawn_slots.to_label
 let spawn_slot_denial_reason_to_detail = Spawn_slots.to_detail
 
-let spawn_slots_decision_internal ?base_path ?fd_admitted ?disk_admitted () =
+let spawn_slots_decision_internal ?fd_admitted () =
   Spawn_slots.decision
-    ?base_path
     ?fd_admitted
-    ?disk_admitted
     ~running_count:(Atomic.get running_count_atomic)
     ()
 ;;
 
-let spawn_slots_decision ?base_path () = spawn_slots_decision_internal ?base_path ()
+let spawn_slots_decision () = spawn_slots_decision_internal ()
 
-let spawn_slots_available ?base_path () =
-  match spawn_slots_decision ?base_path () with
+let spawn_slots_available () =
+  match spawn_slots_decision () with
   | Ok () -> true
   | Error _ -> false
 ;;
 
 module For_testing = struct
-  let spawn_slots_decision ?fd_admitted ?disk_admitted () =
-    spawn_slots_decision_internal ?fd_admitted ?disk_admitted ()
+  let spawn_slots_decision ?fd_admitted () =
+    spawn_slots_decision_internal ?fd_admitted ()
   ;;
 
-  let spawn_slots_available ?fd_admitted ?disk_admitted () =
-    match spawn_slots_decision ?fd_admitted ?disk_admitted () with
+  let spawn_slots_available ?fd_admitted () =
+    match spawn_slots_decision ?fd_admitted () with
     | Ok () -> true
     | Error _ -> false
   ;;

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -258,20 +258,17 @@ val count_running : ?base_path:string -> unit -> int
 (** Closed reason for a keeper launch/admission denial. *)
 type spawn_slot_denial_reason =
   | Fd_pressure_active
-  | Disk_pressure_active
   | Fd_admission_blocked
-  | Disk_admission_blocked
   | Max_active_keepers of { running_count : int; max_keepers : int }
 
 val spawn_slot_denial_reason_to_label : spawn_slot_denial_reason -> string
 val spawn_slot_denial_reason_to_detail : spawn_slot_denial_reason -> string
 
-(** Check if there are available spawn slots and return the denial reason when blocked.
-    [base_path] enables disk admission probing for the target runtime root. *)
-val spawn_slots_decision : ?base_path:string -> unit -> (unit, spawn_slot_denial_reason) result
+(** Check if there are available spawn slots and return the denial reason when blocked. *)
+val spawn_slots_decision : unit -> (unit, spawn_slot_denial_reason) result
 
 (** Compatibility bool wrapper over [spawn_slots_decision]. *)
-val spawn_slots_available : ?base_path:string -> unit -> bool
+val spawn_slots_available : unit -> bool
 
 (** Emit the durable signal for a denied keeper launch/admission. *)
 val record_spawn_slot_denied :
@@ -280,13 +277,11 @@ val record_spawn_slot_denied :
 module For_testing : sig
   val spawn_slots_decision :
     ?fd_admitted:bool ->
-    ?disk_admitted:bool ->
     unit ->
     (unit, spawn_slot_denial_reason) result
 
   val spawn_slots_available :
     ?fd_admitted:bool ->
-    ?disk_admitted:bool ->
     unit ->
     bool
 end

--- a/lib/keeper/keeper_registry_spawn_slots.ml
+++ b/lib/keeper/keeper_registry_spawn_slots.ml
@@ -2,24 +2,18 @@
 
 type denial_reason =
   | Fd_pressure_active
-  | Disk_pressure_active
   | Fd_admission_blocked
-  | Disk_admission_blocked
   | Max_active_keepers of { running_count : int; max_keepers : int }
 
 let to_label = function
   | Fd_pressure_active -> "fd_pressure_active"
-  | Disk_pressure_active -> "disk_pressure_active"
   | Fd_admission_blocked -> "fd_admission_blocked"
-  | Disk_admission_blocked -> "disk_admission_blocked"
   | Max_active_keepers _ -> "max_active_keepers"
 ;;
 
 let to_detail = function
   | Fd_pressure_active -> "spawn slot denied: fd pressure cooldown active"
-  | Disk_pressure_active -> "spawn slot denied: disk pressure cooldown active"
   | Fd_admission_blocked -> "spawn slot denied: fd admission guard rejected launch"
-  | Disk_admission_blocked -> "spawn slot denied: disk admission guard rejected launch"
   | Max_active_keepers { running_count; max_keepers } ->
     Printf.sprintf
       "spawn slot denied: max active keepers reached (running_count=%d max_keepers=%d)"
@@ -27,7 +21,7 @@ let to_detail = function
       max_keepers
 ;;
 
-let decision ?base_path ?fd_admitted ?disk_admitted ~running_count () =
+let decision ?fd_admitted ~running_count () =
   let max_keepers = Keeper_runtime_resolved.bootstrap_max_active_keepers () in
   let fd_admitted () =
     match fd_admitted with
@@ -38,22 +32,10 @@ let decision ?base_path ?fd_admitted ?disk_admitted ~running_count () =
         ~starting_keepers:1
         ()
   in
-  let disk_admitted () =
-    match disk_admitted with
-    | Some admitted -> admitted
-    | None ->
-      (match base_path with
-       | None -> true
-       | Some masc_root -> Keeper_disk_pressure.admit_turn ~masc_root ())
-  in
   if Keeper_fd_pressure.active ()
   then Error Fd_pressure_active
-  else if Keeper_disk_pressure.active ()
-  then Error Disk_pressure_active
   else if not (fd_admitted ())
   then Error Fd_admission_blocked
-  else if not (disk_admitted ())
-  then Error Disk_admission_blocked
   else if max_keepers > 0 && running_count >= max_keepers
   then Error (Max_active_keepers { running_count; max_keepers })
   else Ok ()

--- a/lib/keeper/keeper_supervisor_supervise_keepalive.ml
+++ b/lib/keeper/keeper_supervisor_supervise_keepalive.ml
@@ -50,7 +50,7 @@ let supervise_keepalive
   if Keeper_registry.is_registered ~base_path:ctx.config.base_path meta.name
   then ()
   else
-    match Keeper_registry.spawn_slots_decision ~base_path:ctx.config.base_path () with
+    match Keeper_registry.spawn_slots_decision () with
     | Error reason ->
       Keeper_registry.record_spawn_slot_denied ~keeper_name:meta.name ~surface:"supervisor" reason;
       publish_lifecycle


### PR DESCRIPTION
## Summary
Removes the disk pressure admission guard from keeper spawn-slot decisions.

The `Keeper_disk_pressure` check was denying keeper launch with an opaque `disk_admission_blocked` reason that lacked numeric detail (available bytes, min free, percent). Instead of enriching the log, remove the guard entirely: fd pressure and max-active-keeper limits remain as the operative backpressure mechanisms.

## Changes
- `keeper_registry_spawn_slots.ml`: remove `Disk_pressure_active` and `Disk_admission_blocked` variants, remove `base_path`/`disk_admitted` params
- `keeper_registry.ml` / `.mli`: propagate signature simplification
- `keeper_keepalive.ml` / `keeper_supervisor_supervise_keepalive.ml`: drop `~base_path` from `spawn_slots_decision` calls

## Verification
- `dune build @check` passes
- 5 files changed, 14 insertions(+), 41 deletions(-)

## Test plan
- [ ] `dune build` clean
- [ ] CI checks green
- [ ] Keeper spawn denial logs no longer show `disk_admission_blocked`

🤖 Generated with [Claude Code](https://claude.com/claude-code)