### PR TITLE
fix(keeper): restore execute admission allowlists

### DIFF
--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -142,8 +142,12 @@ let handle_tool_execute_typed
              @ execution_location_fields cwd)
           e
       | Ok input ->
-        (match Keeper_tool_execute_typed_input.validate input with
-         | Error e ->
+        (match
+           if write_enabled
+           then Keeper_tool_execute_typed_input.validate_write input
+           else Keeper_tool_execute_typed_input.validate_readonly input
+         with
+          | Error e ->
            let alts =
              Keeper_tool_execute_typed_input.validation_error_alternatives e
            in

--- a/lib/keeper/keeper_tool_execute_typed_input.ml
+++ b/lib/keeper/keeper_tool_execute_typed_input.ml
@@ -25,6 +25,10 @@ type execute_input =
     }
 
 type validation_error =
+  | Executable_not_allowed of {
+      executable : string;
+      reason : string;
+    }
   | Empty_executable of { argv : string list }
   | Executable_repeated_in_argv0 of {
       executable : string;

--- a/lib/keeper/keeper_tool_execute_typed_input.ml
+++ b/lib/keeper/keeper_tool_execute_typed_input.ml
@@ -54,6 +54,100 @@ type validation_error =
   | Pipeline_too_short
   | Env_key_invalid of string
 
+type admission_mode =
+  | Write_enabled
+  | Readonly
+
+let write_enabled_programs =
+  Masc_exec.Exec_program.
+    [ Cat
+    ; Cargo
+    ; Cmake
+    ; Cut
+    ; Dune_local_sh
+    ; Echo
+    ; Env
+    ; File
+    ; Find
+    ; Gh
+    ; Git
+    ; Go
+    ; Gofmt
+    ; Gradle
+    ; Head
+    ; Java
+    ; Javac
+    ; Ls
+    ; Make
+    ; Mkdir
+    ; Mvn
+    ; Node
+    ; Npm
+    ; Ninja
+    ; Npx
+    ; Opam
+    ; Pip
+    ; Pnpm
+    ; Printf
+    ; Pwd
+    ; Pyright
+    ; Pytest
+    ; Python
+    ; Python3
+    ; Rg
+    ; Grep
+    ; Ruff
+    ; Rustc
+    ; Sed
+    ; Sort
+    ; Stat
+    ; Tail
+    ; Tr
+    ; Uniq
+    ; Uv
+    ; Wc
+    ; Which
+    ; Yarn
+    ]
+;;
+
+let readonly_programs =
+  Masc_exec.Exec_program.
+    [ Cat
+    ; Cut
+    ; Echo
+    ; Env
+    ; File
+    ; Find
+    ; Gh
+    ; Git
+    ; Head
+    ; Ls
+    ; Printf
+    ; Pwd
+    ; Rg
+    ; Grep
+    ; Sed
+    ; Sort
+    ; Stat
+    ; Tail
+    ; Tr
+    ; Uniq
+    ; Wc
+    ; Which
+    ]
+;;
+
+let allowed_commands = function
+  | Write_enabled -> List.map Masc_exec.Exec_program.name_of_known write_enabled_programs
+  | Readonly -> List.map Masc_exec.Exec_program.name_of_known readonly_programs
+;;
+
+let admission_mode_to_string = function
+  | Write_enabled -> "write-enabled"
+  | Readonly -> "read-only"
+;;
+
 let json_type_name (json : Yojson.Safe.t) =
   match json with
   | `Assoc _ -> "object"
@@ -405,6 +499,57 @@ let check_exec ~executable ~argv ~cwd ~env =
     Ok ())
 ;;
 
+let executable_admission_error executable reason =
+  Error (Executable_not_allowed { executable; reason })
+;;
+
+let check_allowlisted_executable ~mode executable =
+  let trimmed = String.trim executable in
+  match Masc_exec.Exec_program.of_string trimmed with
+  | Error (`Unknown _) ->
+    executable_admission_error trimmed "empty executable"
+  | Ok bin ->
+    let name = Masc_exec.Exec_program.to_string bin in
+    if List.mem name (allowed_commands mode)
+    then Ok ()
+    else
+      executable_admission_error
+        name
+        (Printf.sprintf
+           "not in %s Execute allowlist"
+           (admission_mode_to_string mode))
+;;
+
+let check_wrapper_target ~mode ~wrapper_name = function
+  | None ->
+    executable_admission_error
+      wrapper_name
+      (Printf.sprintf
+         "missing %s wrapper target"
+         (admission_mode_to_string mode))
+  | Some target -> check_allowlisted_executable ~mode target
+;;
+
+let check_wrapper_exec_target ~mode ~executable ~argv =
+  match Filename.basename executable with
+  | "env" ->
+    check_wrapper_target
+      ~mode
+      ~wrapper_name:"env"
+      (Exec_policy_command_syntax.command_after_env_prefix argv)
+  | "opam" -> (
+    match Exec_policy_command_syntax.opam_exec_command_name argv with
+    | Some "opam" -> Ok ()
+    | target -> check_wrapper_target ~mode ~wrapper_name:"opam" target)
+  | _ -> Ok ()
+;;
+
+let validate_admission_stage ~mode { executable; argv; _ } =
+  let ( let* ) = Result.bind in
+  let* () = check_exec ~executable ~argv ~cwd:None ~env:[] in
+  let* () = check_allowlisted_executable ~mode executable in
+  check_wrapper_exec_target ~mode ~executable:(String.trim executable) ~argv
+;;
 let check_redirect_target ~fd = function
   | Inherit | Discard -> Ok ()
   | File path when String.length path > 0 && path.[0] = '/' -> Ok ()
@@ -438,6 +583,25 @@ let validate = function
     each stages
 ;;
 
+let validate_admission ~mode input =
+  let ( let* ) = Result.bind in
+  let* () = validate input in
+  match input with
+  | Exec { executable; argv; _ } ->
+    let* () = check_allowlisted_executable ~mode executable in
+    check_wrapper_exec_target ~mode ~executable:(String.trim executable) ~argv
+  | Pipeline { stages; _ } ->
+    let rec each = function
+      | [] -> Ok ()
+      | stage :: rest ->
+        let* () = validate_admission_stage ~mode stage in
+        each rest
+    in
+    each stages
+;;
+
+let validate_write input = validate_admission ~mode:Write_enabled input
+let validate_readonly input = validate_admission ~mode:Readonly input
 let shell_bin ~argv executable =
   let trimmed = String.trim executable in
   if String.length trimmed = 0 then Error (Empty_executable { argv })
@@ -548,6 +712,14 @@ let pp_validation_error ppf = function
       ppf
       "executable %S was reported as duplicated in argv[0], but argv is empty"
       executable
+  | Executable_not_allowed { executable; reason } ->
+    Format.fprintf
+      ppf
+      "executable %S is not allowed for typed Execute (%s); use a structured \
+       read/search tool, WebFetch/WebSearch for network access, or request an \
+       appropriate Execute surface when mutation is intentional"
+      executable
+      reason
   | Argv_contains_shell_metachar { executable; index; token } ->
     Format.fprintf
       ppf

--- a/lib/keeper/keeper_tool_execute_typed_input.ml
+++ b/lib/keeper/keeper_tool_execute_typed_input.ml
@@ -25,7 +25,7 @@ type execute_input =
     }
 
 type validation_error =
-  | Executable_not_allowed of {
+  | Executable_not_allowlisted of {
       executable : string;
       reason : string;
     }
@@ -504,7 +504,7 @@ let check_exec ~executable ~argv ~cwd ~env =
 ;;
 
 let executable_admission_error executable reason =
-  Error (Executable_not_allowed { executable; reason })
+  Error (Executable_not_allowlisted { executable; reason })
 ;;
 
 let check_allowlisted_executable ~mode executable =
@@ -716,7 +716,7 @@ let pp_validation_error ppf = function
       ppf
       "executable %S was reported as duplicated in argv[0], but argv is empty"
       executable
-  | Executable_not_allowed { executable; reason } ->
+  | Executable_not_allowlisted { executable; reason } ->
     Format.fprintf
       ppf
       "executable %S is not allowed for typed Execute (%s); use a structured \

--- a/lib/keeper/keeper_tool_execute_typed_input.mli
+++ b/lib/keeper/keeper_tool_execute_typed_input.mli
@@ -75,7 +75,7 @@ type execute_input =
           redirects on the pipeline's endpoints are a deferred extension. *)
 
 type validation_error =
-  | Executable_not_allowed of {
+  | Executable_not_allowlisted of {
       executable : string;
       reason : string;
     }

--- a/lib/keeper/keeper_tool_execute_typed_input.mli
+++ b/lib/keeper/keeper_tool_execute_typed_input.mli
@@ -136,6 +136,17 @@ val validate : execute_input -> (unit, validation_error) result
     success, or the first {!validation_error} encountered.  No side
     effects, no exceptions. *)
 
+val validate_write : execute_input -> (unit, validation_error) result
+(** Run {!validate}, then enforce write-enabled Execute executable admission.
+    This preserves the curated dev-full command set before dispatch; arbitrary
+    non-allowlisted binaries such as [rm], [tar], and [patch] are rejected even
+    when the caller has write-capable Execute. *)
+
+val validate_readonly : execute_input -> (unit, validation_error) result
+(** Run {!validate}, then enforce read-only Execute executable admission.  The
+    read-only set is intentionally narrower than the full Shell IR catalog and
+    rejects write-capable binaries plus transparent-wrapper targets before
+    dispatch. *)
 val to_shell_ir_unvalidated :
   ?sandbox:Masc_exec.Sandbox_target.t ->
   execute_input ->

--- a/lib/keeper/keeper_tool_execute_typed_input.mli
+++ b/lib/keeper/keeper_tool_execute_typed_input.mli
@@ -75,6 +75,10 @@ type execute_input =
           redirects on the pipeline's endpoints are a deferred extension. *)
 
 type validation_error =
+  | Executable_not_allowed of {
+      executable : string;
+      reason : string;
+    }
   | Empty_executable of { argv : string list }
   | Executable_repeated_in_argv0 of {
       executable : string;

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -769,7 +769,7 @@ let expect_readonly_allowed label input =
 
 let expect_readonly_executable_rejected label input =
   match Keeper_tool_execute_typed_input.validate_readonly input with
-  | Error (Keeper_tool_execute_typed_input.Executable_not_allowed _) -> ()
+  | Error (Keeper_tool_execute_typed_input.Executable_not_allowlisted _) -> ()
   | Error e ->
     Alcotest.failf
       "%s should fail executable admission, got %s"
@@ -788,7 +788,7 @@ let expect_write_allowed label input =
 
 let expect_write_executable_rejected label input =
   match Keeper_tool_execute_typed_input.validate_write input with
-  | Error (Keeper_tool_execute_typed_input.Executable_not_allowed _) -> ()
+  | Error (Keeper_tool_execute_typed_input.Executable_not_allowlisted _) -> ()
   | Error e ->
     Alcotest.failf
       "%s should fail write executable admission, got %s"

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -758,6 +758,74 @@ let readonly_pipeline_input stages =
   | Error msg ->
     Alcotest.failf "expected typed Execute pipeline parse to pass, got %s" msg
 
+let expect_readonly_allowed label input =
+  match Keeper_tool_execute_typed_input.validate_readonly input with
+  | Ok () -> ()
+  | Error e ->
+    Alcotest.failf
+      "%s should pass read-only admission: %s"
+      label
+      (Keeper_tool_execute_input.typed_validation_error_text e)
+
+let expect_readonly_executable_rejected label input =
+  match Keeper_tool_execute_typed_input.validate_readonly input with
+  | Error (Keeper_tool_execute_typed_input.Executable_not_allowed _) -> ()
+  | Error e ->
+    Alcotest.failf
+      "%s should fail executable admission, got %s"
+      label
+      (Keeper_tool_execute_input.typed_validation_error_text e)
+  | Ok () -> Alcotest.failf "%s should fail executable admission" label
+
+let expect_write_allowed label input =
+  match Keeper_tool_execute_typed_input.validate_write input with
+  | Ok () -> ()
+  | Error e ->
+    Alcotest.failf
+      "%s should pass write admission: %s"
+      label
+      (Keeper_tool_execute_input.typed_validation_error_text e)
+
+let expect_write_executable_rejected label input =
+  match Keeper_tool_execute_typed_input.validate_write input with
+  | Error (Keeper_tool_execute_typed_input.Executable_not_allowed _) -> ()
+  | Error e ->
+    Alcotest.failf
+      "%s should fail write executable admission, got %s"
+      label
+      (Keeper_tool_execute_input.typed_validation_error_text e)
+  | Ok () -> Alcotest.failf "%s should fail write executable admission" label
+
+let test_tool_execute_readonly_admission_allows_diagnostic_exec () =
+  expect_readonly_allowed
+    "rg"
+    (readonly_exec_input "rg" [ "--files"; "lib" ]);
+  expect_readonly_allowed "git" (readonly_exec_input "git" [ "status"; "--short" ])
+
+let test_tool_execute_readonly_admission_rejects_risky_exec () =
+  expect_readonly_executable_rejected
+    "python3"
+    (readonly_exec_input "python3" [ "-c"; "print(1)" ]);
+  expect_readonly_executable_rejected
+    "curl"
+    (readonly_exec_input "curl" [ "https://example.com" ]);
+  expect_readonly_executable_rejected
+    "tar"
+    (readonly_exec_input "tar" [ "-xf"; "archive.tar" ]);
+  expect_readonly_executable_rejected
+    "patch"
+    (readonly_exec_input "patch" [ "-i"; "change.patch" ]);
+  expect_readonly_executable_rejected
+    "glab"
+    (readonly_exec_input "glab" [ "issue"; "close"; "1" ]);
+  expect_readonly_executable_rejected "unknown" (readonly_exec_input "definitely-not-a-tool" [])
+
+let test_tool_execute_readonly_admission_rejects_pipeline_stage () =
+  expect_readonly_executable_rejected
+    "pipeline"
+    (readonly_pipeline_input
+       [ "rg", [ "--files"; "lib" ]; "python3", [ "-c"; "print(1)" ] ])
+
 let test_tool_execute_write_validation_stays_structural () =
   match
     Keeper_tool_execute_typed_input.validate
@@ -768,6 +836,33 @@ let test_tool_execute_write_validation_stays_structural () =
     Alcotest.failf
       "write-capable structural validation should not reject executable: %s"
       (Keeper_tool_execute_input.typed_validation_error_text e)
+
+let test_tool_execute_write_admission_uses_allowlist () =
+  expect_write_allowed "mkdir" (readonly_exec_input "mkdir" [ "-p"; "dir" ]);
+  expect_write_allowed "git" (readonly_exec_input "git" [ "status"; "--short" ]);
+  expect_write_executable_rejected
+    "rm"
+    (readonly_exec_input "rm" [ "file.txt" ]);
+  expect_write_executable_rejected
+    "tar"
+    (readonly_exec_input "tar" [ "-xf"; "archive.tar" ]);
+  expect_write_executable_rejected
+    "patch"
+    (readonly_exec_input "patch" [ "-i"; "change.patch" ])
+
+let test_tool_execute_admission_checks_wrapper_targets () =
+  expect_write_allowed
+    "env git"
+    (readonly_exec_input "env" [ "git"; "status"; "--short" ]);
+  expect_write_executable_rejected
+    "env rm"
+    (readonly_exec_input "env" [ "rm"; "file.txt" ]);
+  expect_write_executable_rejected
+    "opam exec rm"
+    (readonly_exec_input "opam" [ "exec"; "--"; "rm"; "file.txt" ]);
+  expect_readonly_executable_rejected
+    "env glab"
+    (readonly_exec_input "env" [ "glab"; "issue"; "close"; "1" ])
 
 let tool_execute_exec_stage args =
   match Keeper_tool_execute_typed_input.of_json args with
@@ -1630,6 +1725,10 @@ let () =
         test_validate_args_tool_execute_accepts_typed_pipeline;
       Alcotest.test_case "tool_execute write validation stays structural" `Quick
         test_tool_execute_write_validation_stays_structural;
+      Alcotest.test_case "tool_execute write admission uses allowlist" `Quick
+        test_tool_execute_write_admission_uses_allowlist;
+      Alcotest.test_case "tool_execute admission checks wrapper targets" `Quick
+        test_tool_execute_admission_checks_wrapper_targets;
       Alcotest.test_case "tool_execute find expression not rewritten" `Quick
         test_tool_execute_find_expression_not_rewritten;
       Alcotest.test_case "tool_execute find global option not rewritten" `Quick


### PR DESCRIPTION
Follow-up for merged PR 20402: re-introduce typed Execute allowlist admission in write/read execution paths and add regression coverage for wrapper target checks and risky command rejection.