### PR TITLE
fix(otel): stop tick fiber on any unexpected exception (#20219)

### DIFF
--- a/lib/otel_spans/opentelemetry_client_cohttp_eio.ml
+++ b/lib/otel_spans/opentelemetry_client_cohttp_eio.ml
@@ -496,7 +496,15 @@ let create_backend ~sw ?(stop = Atomic.make false) ?(config = Config.make ()) en
         try B.tick () with
         | Eio.Cancel.Cancelled _ as e -> raise e
         | Eio.Mutex.Poisoned cause -> stop_tick_after_poisoned_mutex ~stop cause
-        | exn -> Log.Telemetry.warn "otel tick failed: %s" (Printexc.to_string exn)
+        | exn ->
+          (* Any exception from tick() is unexpected: HTTP errors are handled
+             internally, and Batch uses Stdlib.Mutex. Stop the fiber to prevent
+             log spam; the backend must be restarted to resume export. *)
+          Atomic.set stop true;
+          Atomic.set tick_degraded_state true;
+          Log.Telemetry.error
+            "otel tick failed, stopping fiber: %s"
+            (Printexc.to_string exn)
     done);
   (module B)
 ;;


### PR DESCRIPTION
## Summary

Fixes #20219. The OTel exporter tick fiber's catch-all branch previously logged a WARN and continued the retry loop. When `Eio.Mutex.Poisoned` (or any unexpected exception) was raised, this produced repeated log spam every 0.5s.

## Changes

- Stop the tick fiber and set degraded state on any non-Cancelled exception from `B.tick()`
- Log at ERROR level instead of WARN to reflect severity
- Keep the `Eio.Mutex.Poisoned` handler as a fallback

## Rationale

`B.tick()` already handles expected errors internally:
- HTTP errors are caught by `Httpc.send` and returned as `Error`
- `Batch.pop_if_ready` uses `Stdlib.Mutex` (not `Eio.Mutex`)

Any exception reaching the outer handler is unexpected and indicates a serious problem. Continuing to retry wastes CPU and creates noise.

## Verification

- `dune build lib/otel_spans/masc_otel_spans.cma` compiles cleanly
- `dune exec test/test_otel_tick_poison_source.exe` passes

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>