### PR TITLE
fix(keeper): #20440 이후 spawn_slots.mli 동기화

### DIFF
--- a/lib/keeper/keeper_registry_spawn_slots.mli
+++ b/lib/keeper/keeper_registry_spawn_slots.mli
@@ -2,18 +2,14 @@
 
 type denial_reason =
   | Fd_pressure_active
-  | Disk_pressure_active
   | Fd_admission_blocked
-  | Disk_admission_blocked
   | Max_active_keepers of { running_count : int; max_keepers : int }
 
 val to_label : denial_reason -> string
 val to_detail : denial_reason -> string
 
 val decision
-  :  ?base_path:string
-  -> ?fd_admitted:bool
-  -> ?disk_admitted:bool
+  :  ?fd_admitted:bool
   -> running_count:int
   -> unit
   -> (unit, denial_reason) result


### PR DESCRIPTION
## 요약

#20440에서 `keeper_registry_spawn_slots.ml`의 `denial_reason` variant와 `decision` 함수 시그니처를 정리했으나, `.mli` 인터페이스 파일이 동기화되지 않아 현재 origin/main이 컴파일 실패 상태입니다.

## 변경 내용

- `Disk_pressure_active`, `Disk_admission_blocked` variant 제거
- `decision` 함수의 `?base_path`, `?disk_admitted` 선택적 인자 제거
- `.ml` 구현과 `.mli` 인터페이스를 일치시킴

## 검증

- 로컬 worktree에서 `dune build @check` 통과 확인

## 관련

- #20440 (원인 PR)
- origin/main 현재 broken 상태 해소

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>