### PR TITLE
fix(keeper): sync spawn_slots .mli with disk-pressure removal

### DIFF
--- a/lib/keeper/keeper_registry_spawn_slots.mli
+++ b/lib/keeper/keeper_registry_spawn_slots.mli
@@ -2,18 +2,14 @@
 
 type denial_reason =
   | Fd_pressure_active
-  | Disk_pressure_active
   | Fd_admission_blocked
-  | Disk_admission_blocked
   | Max_active_keepers of { running_count : int; max_keepers : int }
 
 val to_label : denial_reason -> string
 val to_detail : denial_reason -> string
 
 val decision
-  :  ?base_path:string
-  -> ?fd_admitted:bool
-  -> ?disk_admitted:bool
+  :  ?fd_admitted:bool
   -> running_count:int
   -> unit
   -> (unit, denial_reason) result


### PR DESCRIPTION
PR #20440 removed disk pressure variants from .ml and keeper_registry.ml but missed the .mli. Remove Disk_pressure_active, Disk_admission_blocked and stale params from .mli. Follow-up to #20440. Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>