### PR TITLE
fix(telemetry): restore unified source read-failure counter (#20194)

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -223,6 +223,7 @@
    masc.lockfree_atomic
    masc.json_field
    masc.pool_metrics
+   masc.otel_metric_store
    masc.otel_spans
    masc.otel_genai
    masc.otel_trace_context

--- a/lib/keeper/keeper_registry_spawn_slots.mli
+++ b/lib/keeper/keeper_registry_spawn_slots.mli
@@ -2,18 +2,14 @@
 
 type denial_reason =
   | Fd_pressure_active
-  | Disk_pressure_active
   | Fd_admission_blocked
-  | Disk_admission_blocked
   | Max_active_keepers of { running_count : int; max_keepers : int }
 
 val to_label : denial_reason -> string
 val to_detail : denial_reason -> string
 
 val decision
-  :  ?base_path:string
-  -> ?fd_admitted:bool
-  -> ?disk_admitted:bool
+  :  ?fd_admitted:bool
   -> running_count:int
   -> unit
   -> (unit, denial_reason) result

--- a/lib/otel_metric_store/dune
+++ b/lib/otel_metric_store/dune
@@ -1,0 +1,24 @@
+(include_subdirs no)
+
+(library
+ (name otel_metric_store)
+ (public_name masc.otel_metric_store)
+ (wrapped false)
+ (modules
+  otel_builtin_metric_names
+  otel_core_metric_names
+  otel_identity_metric_names
+  otel_metric_hotpath
+  otel_metric_key
+  otel_metric_names
+  otel_metric_process
+  otel_metric_store_core
+  otel_oas_metric_names
+  otel_policy_metric_names
+  otel_runtime_metric_names
+  otel_transport_metric_names)
+ (libraries
+  eio
+  mtime
+  mtime.clock
+  masc_log))

--- a/lib/telemetry_unified_source/dune
+++ b/lib/telemetry_unified_source/dune
@@ -8,5 +8,6 @@
  (libraries
   eio
   masc.config
+  masc.otel_metric_store
   masc_log
   yojson))

--- a/lib/telemetry_unified_source/telemetry_unified_source_meta.ml
+++ b/lib/telemetry_unified_source/telemetry_unified_source_meta.ml
@@ -8,6 +8,10 @@ open Telemetry_unified_source
 
 let observe_source_read_failure source ~site ~error =
   let source = source_to_string source in
+  Otel_metric_store_core.inc_counter
+    Otel_builtin_metric_names.metric_telemetry_unified_source_read_failures
+    ~labels:[ ("source", source); ("site", site) ]
+    ();
   Log.Telemetry.warn
     "telemetry_unified source read failure: source=%s site=%s error=%s"
     source site error


### PR DESCRIPTION
## Summary

Fixes #20194

Prometheus purge (#20189) removed `Prometheus.inc_counter` from `observe_source_read_failure` but never replaced it with `Otel_metric_store` equivalent. The `telemetry_unified_source` leaf sub-library lost its counter increment.

## Changes

1. **Extract `masc.otel_metric_store` sub-library** — `lib/otel_metric_store/` was previously compiled via `include_subdirs unqualified` as part of `masc`. Extract it into a standalone sub-library so `telemetry_unified_source` (a leaf that `masc` depends on) can depend on it without creating a cycle.

2. **Wire counter increment** — `observe_source_read_failure` now calls `Otel_metric_store_core.inc_counter` with `metric_telemetry_unified_source_read_failures` and `[source, site]` labels.

3. **Fix pre-existing `.mli` mismatch** — `keeper_registry_spawn_slots.mli` still had `Disk_pressure_active` / `Disk_admission_blocked` variants that commit `a36cf8c542` removed from the `.ml`.

## Verification

- `dune build @check` passes
- `test/test_telemetry_unified.exe`: 34/35 pass; the 1 failure (`summary.005 coverage gap counter`) is a pre-existing issue where `Telemetry_coverage_gap.record` does not increment `metric_telemetry_coverage_gap` — unrelated to this PR.
- All 5 `source_read_failure_metric` tests pass.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>