### PR TITLE
fix(log): include keeper_name in stderr prefix for Make.emit

### DIFF
--- a/lib/masc_log/log.ml
+++ b/lib/masc_log/log.ml
@@ -807,8 +807,14 @@ module Make (M : sig val name : string end) = struct
   let emit level ?(details = `Null) ?keeper_name ?turn_id message =
     if should_log_module level then begin
       let level_str = level_to_string level in
-      let prefix = Printf.sprintf "[%s] [%s] [%s]"
-        (timestamp ()) level_str M.name in
+      let prefix = match keeper_name with
+        | Some kn ->
+            Printf.sprintf "[%s] [%s] [%s/%s]"
+              (timestamp ()) level_str M.name kn
+        | None ->
+            Printf.sprintf "[%s] [%s] [%s]"
+              (timestamp ()) level_str M.name
+      in
       Printf.eprintf "%s %s\n%!" prefix message;
       Ring.push ?keeper_name ?turn_id
         ~level ~module_name:M.name ~message ~details ()


### PR DESCRIPTION
## Problem

FSM 트랜지션 로그에서 어느 Keeper가 트랜지션하는지 식별 불가:

```
[Keeper] [fsm:transition] awaiting_tool -> streaming action=StreamYieldsTool
[Keeper] keeper:ramarama turn=634 ...
[Keeper] [fsm:transition] streaming -> failed:provider_error action=ProviderError
```

`keeper:ramarama` 라인은 포맷 문자열에 수동 포함, `[fsm:transition]` 라인은 keeper_name 누락.

## Root Cause

`Make.emit` (log.ml:807)에서 `keeper_name`이 `Ring.push`(JSONL)에만 전달되고, stderr 출력(`Printf.eprintf`) prefix에는 포함되지 않음.

## Fix

`Make.emit`의 prefix에 keeper_name 포함:

```
Before: [INFO] [Keeper] [fsm:transition] awaiting_tool -> streaming
After:  [INFO] [Keeper/ramarama] [fsm:transition] awaiting_tool -> streaming
```

- keeper_name이 없는 시스템 로그는 기존 포맷 유지 (`[Keeper]`)
- JSONL structured log는 변경 없음 (이미 keeper_name 저장 중)
- 모든 `Log.Keeper.*` 호출에 일관 적용

## Verification

- `dune build @check` PASS
- `dune build .` PASS

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
