### PR TITLE
fix(ci): update agent_sdk pin to 0.204.1

### DIFF
--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_VERSION="v0.204.0"
+readonly OAS_AGENT_SDK_BASE_VERSION="v0.204.1"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="cd556806d6ef1131e4bafadce6c762a1ebee1295"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.204.0"
+readonly OAS_AGENT_SDK_SHA="2679eeafb0c31de45593b6e27d5bc1eaa0b316f9"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.204.1"


### PR DESCRIPTION
## Summary

Fixes broken main caused by agent_sdk version mismatch.

`masc.opam` requires `agent_sdk >= 0.204.1` (since #20450), but the CI pin script `scripts/oas-agent-sdk-pin.sh` was still pinning `agent_sdk` to `0.204.0` (SHA `cd556806`). This caused all CI jobs to fail with:

```
No solution found, exiting
  - deps-of-masc → agent_sdk >= 0.204.1
  no matching version
```

## Changes

- Update `OAS_AGENT_SDK_SHA` to `2679eeafb0c31de45593b6e27d5bc1eaa0b316f9` (OAS main HEAD, agent_sdk 0.204.1)
- Update `OAS_AGENT_SDK_BASE_VERSION` to `v0.204.1`
- Update `OAS_AGENT_SDK_MIN_VERSION` to `0.204.1`

## Verification

- [x] OAS main SHA verified to contain `agent_sdk 0.204.1`
- [ ] CI passes after merge

## Related

- Broken main from #20450