### PR TITLE
fix(keeper): remove inter_chunk_idle residue

### DIFF
--- a/lib/keeper/keeper_health_probe.ml
+++ b/lib/keeper/keeper_health_probe.ml
@@ -92,7 +92,6 @@ let provider_runtime_pressure_class ~code ~detail ~http_status ~runtime_id =
     contains "timeout"
     || contains "timed out"
     || contains "no_first_token"
-    || contains "inter_chunk_idle"
     || contains "max_execution_time"
     || contains "wall-clock timeout"
     || http_is_any [ 408; 504; 524 ]

--- a/lib/keeper/keeper_unified_turn_types.ml
+++ b/lib/keeper/keeper_unified_turn_types.ml
@@ -49,8 +49,6 @@ let runtime_exhaustion_detail_code detail =
   let contains needle = String_util.contains_substring_ci detail needle in
   if contains "no_first_token"
   then "runtime_exhausted_no_first_token"
-  else if contains "inter_chunk_idle"
-  then "runtime_exhausted_inter_chunk_idle"
   else if contains "http 429" || contains "usage limit" || contains "rate limit"
   then "runtime_exhausted_rate_limited"
   else if contains "max_execution_time"

--- a/lib/keeper_tooling/keeper_provider_error_class.ml
+++ b/lib/keeper_tooling/keeper_provider_error_class.ml
@@ -8,7 +8,6 @@
 type response_timeout_kind =
   | Connection_timeout
   | First_token_timeout
-  | Inter_chunk_idle
   | Wall_clock_timeout
 
 type t =
@@ -50,7 +49,6 @@ let timeout_http_statuses =
 let response_timeout_kind_to_string = function
   | Connection_timeout -> "connection_timeout"
   | First_token_timeout -> "first_token_timeout"
-  | Inter_chunk_idle -> "inter_chunk_idle"
   | Wall_clock_timeout -> "wall_clock_timeout"
 ;;
 

--- a/lib/keeper_tooling/keeper_provider_error_class.mli
+++ b/lib/keeper_tooling/keeper_provider_error_class.mli
@@ -31,10 +31,7 @@ type response_timeout_kind =
           evidence is available. *)
   | First_token_timeout
       (** Streaming connection opened but no first token arrived
-          before the agreed deadline.  Distinct from
-          [Inter_chunk_idle] because retry strategy differs. *)
-  | Inter_chunk_idle
-      (** Streaming response stalled mid-flight between tokens. *)
+          before the agreed deadline. *)
   | Wall_clock_timeout
       (** Whole-turn wall-clock budget exceeded
           ([max_execution_time], orchestrator-side deadline). *)
@@ -130,8 +127,7 @@ val to_short_tag : t -> string
     [unspecified]. *)
 
 val response_timeout_kind_to_string : response_timeout_kind -> string
-(** [connection_timeout] / [first_token_timeout] / [inter_chunk_idle] /
-    [wall_clock_timeout]. *)
+(** [connection_timeout] / [first_token_timeout] / [wall_clock_timeout]. *)
 
 val raw_payload : t -> (string * string) option
 (** [Some (raw_code, raw_detail)] for [Unspecified], [None]

--- a/test/test_keeper_health_probe.ml
+++ b/test/test_keeper_health_probe.ml
@@ -98,7 +98,7 @@ let test_runtime_pressure_classifier () =
     (pressure_label_of_failure_reason
        (R.Provider_runtime_error
           { code = "provider_error"
-          ; detail = "inter_chunk_idle timeout"
+          ; detail = "connection timeout"
           ; provider_id = None
           ; http_status = Some 504
           ; runtime_id = None

--- a/test/test_keeper_provider_error_class.ml
+++ b/test/test_keeper_provider_error_class.ml
@@ -120,7 +120,6 @@ let test_response_timeout_kind_tags () =
   check string "Connection_timeout" "connection_timeout" (kt P.Connection_timeout);
   check string "First_token_timeout" "first_token_timeout"
     (kt P.First_token_timeout);
-  check string "Inter_chunk_idle" "inter_chunk_idle" (kt P.Inter_chunk_idle);
   check string "Wall_clock_timeout" "wall_clock_timeout"
     (kt P.Wall_clock_timeout)
 ;;

--- a/test/test_keeper_turn_disposition.ml
+++ b/test/test_keeper_turn_disposition.ml
@@ -298,16 +298,6 @@ let test_registry_failure_reason_preserves_no_provider_runtime_reason () =
     "runtime_exhausted_no_providers_available"
 ;;
 
-let test_registry_failure_reason_buckets_runtime_liveness_reason () =
-  let raw_error =
-    "Internal error: [masc_oas_error] \
-     {\"kind\":\"runtime_exhausted\",\"runtime_id\":\"runtime.ollama_cloud_stable\",\
-     \"reason\":{\"tag\":\"other_detail\",\"message\":\"Runtime attempt liveness guard \
-     killed runtime lane runtime.ollama_cloud_stable: inter_chunk_idle\"}}"
-  in
-  check_runtime_failure_reason raw_error "runtime_exhausted_inter_chunk_idle"
-;;
-
 let () =
   Alcotest.run
     "keeper_turn_disposition"
@@ -356,10 +346,6 @@ let () =
             "structured runtime no-provider reason is preserved"
             `Quick
             test_registry_failure_reason_preserves_no_provider_runtime_reason
-        ; Alcotest.test_case
-            "structured runtime liveness reason is bucketed"
-            `Quick
-            test_registry_failure_reason_buckets_runtime_liveness_reason
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary

Removes the remaining `inter_chunk_idle` references that survived the `keeper_attempt_liveness` subsystem purge in #20424.

## Changes

- Remove `Inter_chunk_idle` variant from `Keeper_provider_error_class`
- Remove `inter_chunk_idle` substring matching from health probe and unified turn types
- Update tests that referenced the removed variant/patterns

## Verification

- [x] `dune build @check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)