### PR TITLE
test: add unit tests for slice_default_events_to_limit (#19313)

### DIFF
--- a/lib/server/server_activity_http.mli
+++ b/lib/server/server_activity_http.mli
@@ -45,6 +45,14 @@ val parse_since_ms : string -> int option
     - [["7d"]] -> [Some 604_800_000]
     - [["5"]] / [["m"]] / [["bad"]] -> [None] *)
 
+val slice_default_events_to_limit :
+  Yojson.Safe.t -> limit:int -> Yojson.Safe.t
+(** [slice_default_events_to_limit json ~limit] trims the
+    ["events"] list inside a default-shaped activity response down
+    to [limit] entries, dropping the oldest.  Updates ["count"],
+    ["limit"], and ["next_after_seq"] accordingly.  Pure —
+    exposed for unit testing ({!Test_server_activity_http}). *)
+
 (** {1 JSON dispatchers}
 
     All three take [~deps ~state request] and return a

--- a/test/dune
+++ b/test/dune
@@ -135,6 +135,7 @@
   test_ide_bridge
   test_command_descriptor
   test_server_ide_lsp_proxy
+  test_server_activity_http
   test_ide_paths
   test_ide_canonical_url_join
   test_keeper_runtime_contract
@@ -387,6 +388,7 @@
   test_ide_bridge
   test_command_descriptor
   test_server_ide_lsp_proxy
+  test_server_activity_http
   test_ide_paths
   test_ide_canonical_url_join
   test_keeper_runtime_contract

--- a/test/test_server_activity_http.ml
+++ b/test/test_server_activity_http.ml
@@ -1,0 +1,129 @@
+(** Unit tests for [Server_activity_http.slice_default_events_to_limit].
+
+    RFC-0201 Step 1 follow-up (issue #19313).  Guards the default-query
+    path that serves [Dashboard_snapshot.current ()].activity_events_default. *)
+
+open Alcotest
+
+let yojson = testable Yojson.Safe.pp Yojson.Safe.equal
+
+let mk_event ~seq kind =
+  `Assoc [ ("seq", `Int seq); ("kind", `String kind) ]
+
+let mk_input ?(after_seq = 0) ?next_after_seq ?(limit = 200) events =
+  let base =
+    [ ("events", `List events)
+    ; ("count", `Int (List.length events))
+    ; ("limit", `Int limit)
+    ; ("after_seq", `Int after_seq)
+    ]
+  in
+  match next_after_seq with
+  | Some n -> `Assoc (("next_after_seq", `Int n) :: base)
+  | None -> `Assoc base
+
+let get_field key = function
+  | `Assoc fields -> List.assoc_opt key fields
+  | _ -> None
+
+let get_int_field key json =
+  match get_field key json with
+  | Some (`Int n) -> Some n
+  | _ -> None
+
+let get_list_field key json =
+  match get_field key json with
+  | Some (`List xs) -> Some xs
+  | _ -> None
+
+let test_len_lt_limit () =
+  (* Case 1: fewer events than limit — events preserved, limit refreshed. *)
+  let events = [ mk_event ~seq:1 "a"; mk_event ~seq:2 "b" ] in
+  let input = mk_input events in
+  let got = Server_activity_http.slice_default_events_to_limit input ~limit:10 in
+  check (option int) "limit updated" (Some 10) (get_int_field "limit" got);
+  check (option int) "count preserved" (Some 2) (get_int_field "count" got);
+  check (option int) "after_seq preserved" (Some 0)
+    (get_int_field "after_seq" got);
+  check (list yojson) "events preserved" events
+    (Option.value (get_list_field "events" got) ~default:[])
+
+let test_len_eq_limit () =
+  (* Case 2: exactly at limit — events preserved, limit refreshed. *)
+  let events = [ mk_event ~seq:1 "a"; mk_event ~seq:2 "b" ] in
+  let input = mk_input events in
+  let got = Server_activity_http.slice_default_events_to_limit input ~limit:2 in
+  check (option int) "limit updated" (Some 2) (get_int_field "limit" got);
+  check (list yojson) "events preserved" events
+    (Option.value (get_list_field "events" got) ~default:[])
+
+let test_len_gt_limit () =
+  (* Case 3: more events than limit — drop oldest, keep tail. *)
+  let events =
+    [ mk_event ~seq:1 "a"
+    ; mk_event ~seq:2 "b"
+    ; mk_event ~seq:3 "c"
+    ; mk_event ~seq:4 "d"
+    ]
+  in
+  let input = mk_input ~next_after_seq:0 events in
+  let got = Server_activity_http.slice_default_events_to_limit input ~limit:2 in
+  let expected_events = [ mk_event ~seq:3 "c"; mk_event ~seq:4 "d" ] in
+  check (list yojson) "tail 2 kept" expected_events
+    (Option.value (get_list_field "events" got) ~default:[]);
+  check (option int) "count updated" (Some 2) (get_int_field "count" got);
+  check (option int) "limit updated" (Some 2) (get_int_field "limit" got);
+  (* next_after_seq comes from the last kept event's seq *)
+  check (option int) "next_after_seq from last seq" (Some 4)
+    (get_int_field "next_after_seq" got)
+
+let test_empty_events () =
+  (* Case 4: empty list — next_after_seq falls back to after_seq. *)
+  let input = mk_input ~after_seq:42 ~next_after_seq:0 [] in
+  let got = Server_activity_http.slice_default_events_to_limit input ~limit:10 in
+  check (list yojson) "events empty" []
+    (Option.value (get_list_field "events" got) ~default:[]);
+  check (option int) "next_after_seq falls back to after_seq" (Some 42)
+    (get_int_field "next_after_seq" got)
+
+let test_missing_seq () =
+  (* Case 5: last event lacks seq — next_after_seq falls back to
+     input's next_after_seq field. *)
+  let event_no_seq = `Assoc [ ("kind", `String "x") ] in
+  let input = mk_input ~next_after_seq:99 [ event_no_seq ] in
+  let got =
+    Server_activity_http.slice_default_events_to_limit input ~limit:10
+  in
+  check (option int) "next_after_seq falls back to field" (Some 99)
+    (get_int_field "next_after_seq" got)
+
+let test_non_assoc_passthrough () =
+  (* Case 6: non-Assoc input — passthrough unchanged. *)
+  let input = `String "not an object" in
+  let got = Server_activity_http.slice_default_events_to_limit input ~limit:10 in
+  check yojson "passthrough" input got
+
+let test_count_and_limit_updated () =
+  (* When slicing occurs, count and limit fields are refreshed. *)
+  let events =
+    [ mk_event ~seq:1 "a"; mk_event ~seq:2 "b"; mk_event ~seq:3 "c" ]
+  in
+  let input = mk_input events in
+  let got =
+    Server_activity_http.slice_default_events_to_limit input ~limit:2
+  in
+  check (option int) "count updated" (Some 2) (get_int_field "count" got);
+  check (option int) "limit updated" (Some 2) (get_int_field "limit" got)
+
+let () =
+  run "Server_activity_http"
+    [ ( "slice_default_events_to_limit"
+      , [ test_case "len < limit" `Quick test_len_lt_limit
+        ; test_case "len == limit" `Quick test_len_eq_limit
+        ; test_case "len > limit" `Quick test_len_gt_limit
+        ; test_case "empty events" `Quick test_empty_events
+        ; test_case "missing seq fallback" `Quick test_missing_seq
+        ; test_case "non-Assoc passthrough" `Quick test_non_assoc_passthrough
+        ; test_case "count and limit updated" `Quick test_count_and_limit_updated
+        ] )
+    ]


### PR DESCRIPTION
## Summary

Adds dedicated unit-test coverage for `Server_activity_http.slice_default_events_to_limit`, the default-query path introduced in RFC-0201 Step 1 (PR #19212).

## Changes

- `lib/server/server_activity_http.mli`: expose `slice_default_events_to_limit` as a pure helper (documented, test-only surface — no internal state leaked).
- `test/test_server_activity_http.ml` (new): 7 Alcotest cases covering all specified scenarios from #19313:
  1. `len < limit` — events preserved, limit metadata refreshed
  2. `len == limit` — events preserved, metadata refreshed
  3. `len > limit` — oldest dropped, tail kept, `next_after_seq` updated from last event seq
  4. empty events — `next_after_seq` falls back to `after_seq`
  5. missing seq — `next_after_seq` falls back to input field value
  6. non-Assoc input — passthrough unchanged
  7. count and limit refreshed during slicing
- `test/dune`: register in Group 1 (pure synchronous tests).

## Verification

- `dune exec test/test_server_activity_http.exe` — 7/7 pass
- `dune exec test/test_activity_graph.exe` — 15/15 pass (regression check on existing `Server_activity_http` consumer)
- `dune build @check` — clean

Closes #19313

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>