### PR TITLE
fix(keeper): make effective_core_tools universe-aware on descriptor publics (#20061)

### DIFF
--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -67,7 +67,7 @@ let core_always_tools =
     corresponding action tool (fs_read → fs_edit, board_list → board_post,
     shell → github).  This prevents the "read-only polling loop" where
     the model repeatedly observes but cannot find tools to act. *)
-let core_discovery_tools =
+let base_core_tools =
   core_always_tools
   @ List.map
       Keeper_tool_name.to_string
@@ -90,12 +90,17 @@ let core_discovery_tools =
         ; (* Discovery fallback for meta/admin tools *)
           Tools_list
         ]
+;;
+
+let core_discovery_tools =
+  base_core_tools
   (* RFC-0064/RFC-016x: public capability names replace internal names
      in the LLM-facing discovery surface. *)
   @ Keeper_tool_descriptor.public_names ()
 ;;
 
 let effective_core_tools () = core_discovery_tools
+;;
 
 let core_always_set : (string, unit) Hashtbl.t =
   let tbl = Hashtbl.create (List.length core_always_tools) in
@@ -279,6 +284,23 @@ let masc_schemas_snapshot () =
 let injected_masc_tool_names () =
   masc_schemas_snapshot ()
   |> List.map (fun (schema : Masc_domain.tool_schema) -> schema.name)
+;;
+
+(* ── Universe-aware effective core tools ─────────────────────── *)
+
+let effective_core_tools () =
+  let universe_set =
+    injected_masc_tool_names ()
+    |> List.fold_left
+         (fun acc name -> Set_util.StringSet.add name acc)
+         Set_util.StringSet.empty
+  in
+  let descriptor_publics =
+    Keeper_tool_descriptor.public_descriptors
+    |> List.filter (fun d -> Set_util.StringSet.mem d.Keeper_tool_descriptor.internal_name universe_set)
+    |> List.concat_map Keeper_tool_descriptor.public_names_of_descriptor
+  in
+  base_core_tools @ descriptor_publics
 ;;
 
 (* ── keeper_tool_search schema ───────────────────────────────── *)

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -683,6 +683,56 @@ let test_rfc_0190_allowlist_has_no_descriptor () =
       (String.concat ", " stale)
 ;;
 
+(* ── effective_core_tools universe-aware behaviour ─────────────── *)
+
+let test_effective_core_tools_is_subset_of_discovery () =
+  let effective = Registry.effective_core_tools () in
+  let discovery = Registry.core_discovery_tools in
+  List.iter
+    (fun name ->
+       if not (List.mem name discovery)
+       then
+         Alcotest.failf
+           "effective_core_tools contains %S not in core_discovery_tools"
+           name)
+    effective
+;;
+
+let test_effective_core_tools_without_universe_has_no_descriptor_publics () =
+  (* Before set_masc_schemas, injected_masc_tool_names () returns [].
+     Descriptor public names should NOT appear in effective_core_tools
+     when their internal_name is absent from the universe. *)
+  let effective = Registry.effective_core_tools () in
+  let descriptor_publics = Descriptor.public_names () in
+  List.iter
+    (fun name ->
+       if List.mem name effective
+       then
+         Alcotest.failf
+           "effective_core_tools contains descriptor public %S when universe is empty"
+           name)
+    descriptor_publics
+;;
+
+let test_effective_core_tools_with_full_universe_matches_discovery () =
+  let all_schemas =
+    List.map
+      (fun d ->
+         { Masc_domain.name = d.Descriptor.internal_name
+         ; description = d.Descriptor.description
+         ; input_schema = d.Descriptor.input_schema
+         })
+      (all_descriptors ())
+  in
+  Registry.set_masc_schemas all_schemas;
+  let effective = Registry.effective_core_tools () in
+  let discovery = Registry.core_discovery_tools in
+  Alcotest.(check (list string))
+    "effective_core_tools with full universe matches core_discovery_tools"
+    (List.sort String.compare discovery)
+    (List.sort String.compare effective)
+;;
+
 let () =
   Alcotest.run
     "keeper_tool_descriptor_registry_integrity"
@@ -768,5 +818,19 @@ let () =
             "mutation boundary delegates to descriptor policy"
             `Quick
             test_mutation_boundary_delegates_to_descriptor_policy
+        ] )
+    ; ( "universe-aware-effective-core"
+      , [ test_case
+            "effective_core_tools is subset of core_discovery_tools"
+            `Quick
+            test_effective_core_tools_is_subset_of_discovery
+        ; test_case
+            "effective_core_tools without universe has no descriptor publics"
+            `Quick
+            test_effective_core_tools_without_universe_has_no_descriptor_publics
+        ; test_case
+            "effective_core_tools with full universe matches discovery"
+            `Quick
+            test_effective_core_tools_with_full_universe_matches_discovery
         ] )
     ]


### PR DESCRIPTION
## Summary

`effective_core_tools ()` previously returned `core_discovery_tools` statically, which unconditionally appended all `Keeper_tool_descriptor.public_names ()`. This caused `validate_allow_list` to prune non-universe names on every turn, producing WARN spam.

This PR makes `effective_core_tools ()` filter descriptor public names by universe membership (`injected_masc_tool_names ()`), so only descriptors whose `internal_name` is present in the universe are included.

`core_discovery_tools` is retained unchanged for `Keeper_tool_affinity.pre_populate_from_history` compatibility.

## Changes

- `lib/keeper/keeper_tool_registry.ml`: Split `base_core_tools` from `core_discovery_tools`; make `effective_core_tools ()` universe-aware by filtering `Keeper_tool_descriptor.public_descriptors` against `injected_masc_tool_names ()` before projecting public names.
- `test/test_keeper_tool_descriptor_registry_integrity.ml`: Add 3 tests verifying subset property, empty-universe exclusion, and full-universe recovery.

## Test plan

- [x] `dune build` compiles cleanly
- [x] `test_keeper_tool_descriptor_registry_integrity.exe` passes (24/24)
- [x] `test_keeper_tool_matrix.exe` passes (spot-checked 089, 094, 012)

Closes #20061

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>