### PR TITLE
fix(keeper): convert circuit breaker Gate #1 to typed predicate (#19777)

### DIFF
--- a/lib/keeper/keeper_tool_dispatch_runtime.ml
+++ b/lib/keeper/keeper_tool_dispatch_runtime.ml
@@ -231,20 +231,21 @@ let failure_class_of_tool_result_payload payload =
   with
   | Ok json ->
     if Safe_ops.json_bool ~default:false "ok" json
-    then Some "success"
+    then None
     else (
       match Safe_ops.json_string_opt "failure_class" json with
-      | Some _ as failure_class -> failure_class
-      | None -> None)
-  | Error _ -> None
+      | Some class_str ->
+        (match Tool_result.tool_failure_class_of_string class_str with
+         | Some _ as fc -> fc
+         | None -> Some Tool_result.Runtime_failure)
+      | None -> Some Tool_result.Runtime_failure)
+  | Error _ -> Some Tool_result.Runtime_failure
 ;;
 
-let should_apply_circuit_breaker_to_failure_payload payload =
-  match failure_class_of_tool_result_payload payload with
-  | Some "success" -> false
-  | Some ("policy_rejection" | "workflow_rejection") -> false
-  | Some _
-  | None -> true
+let should_apply_circuit_breaker_to_failure_payload failure_class_opt =
+  match failure_class_opt with
+  | Some Tool_result.Policy_rejection | Some Tool_result.Workflow_rejection -> false
+  | Some Tool_result.Transient_error | Some Tool_result.Runtime_failure | None -> true
 ;;
 
 let is_policy_gate_error raw_output =
@@ -332,7 +333,8 @@ let execute_keeper_tool_call_with_outcome
       }
     | `Failure, Structured_error | `Failure, Structured_success | `Failure, Plain_text ->
       let raw_output =
-        if should_apply_circuit_breaker_to_failure_payload result.raw_output
+        let failure_class = failure_class_of_tool_result_payload result.raw_output in
+        if should_apply_circuit_breaker_to_failure_payload failure_class
         then
           Keeper_failure_circuit_breaker.maybe_enrich_error
             ~keeper_name:meta.name

--- a/lib/keeper/keeper_tool_dispatch_runtime.mli
+++ b/lib/keeper/keeper_tool_dispatch_runtime.mli
@@ -126,13 +126,14 @@ type executed_tool_result =
 val classify_tool_result_payload : string -> tool_result_payload
 
 (** Extract the optional [failure_class] field from a structured keeper
-    tool payload. Returns [None] for plain text or malformed JSON. *)
-val failure_class_of_tool_result_payload : string -> string option
+    tool payload. Returns [None] on success, [Some Runtime_failure] on
+    plain text or malformed JSON. *)
+val failure_class_of_tool_result_payload : string -> Tool_result.tool_failure_class option
 
 (** [false] when a failed tool payload is a business-rule workflow
     rejection that should be shown to the keeper without opening the
     repeated-failure circuit breaker. *)
-val should_apply_circuit_breaker_to_failure_payload : string -> bool
+val should_apply_circuit_breaker_to_failure_payload : Tool_result.tool_failure_class option -> bool
 
 (** Tag-based dispatch callback for masc_* tools without handler registry entries.
     Set at server init to [Keeper_tag_dispatch.dispatch]. Default: returns None.


### PR DESCRIPTION
## Summary

Convert `failure_class_of_tool_result_payload` and `should_apply_circuit_breaker_to_failure_payload` from string matching to typed `Tool_result.tool_failure_class` matching. This closes the string-classifier antipattern flagged in CLAUDE.md and makes future variant additions a compile error at the gate.

## Changes

- `failure_class_of_tool_result_payload` now returns `Tool_result.tool_failure_class option` instead of `string option`.
  - Success payload → `None`
  - Unknown/malformed failure class → `Some Runtime_failure` (conservative: count the breaker)
- `should_apply_circuit_breaker_to_failure_payload` now takes `Tool_result.tool_failure_class option`.
  - Exhaustive match over all four variants + `None`
  - `Policy_rejection` and `Workflow_rejection` → exempt (`false`)
  - `Transient_error`, `Runtime_failure`, `None` → count (`true`)
- Call site in `execute_keeper_tool_call_with_outcome` updated to pre-compute `failure_class` and pass it to the predicate.

## Verification

- `dune build @check` passes in worktree.
- No external callers of the changed `.mli` signatures.

## Related

- Closes #19777 (partial — Gate #1 typed predicate)
- Gate #2 (`Keeper_tools_oas_failure_boundary`) already operates on typed `tool_failure_class`; no change needed there.
- Remaining validation producer tagging (issue §1) left for follow-up PRs per-site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)