### PR TITLE
feat(exec): Shell IR Effect Proof P0 — effect axis types

### DIFF
--- a/lib/exec/exec_effect.ml
+++ b/lib/exec/exec_effect.ml
@@ -1,0 +1,135 @@
+(** Exec_effect — Effect axis types for Shell IR execution.
+
+    P0 of the Shell IR Effect Proof Design (RFC-0208 extension).
+    See [exec_effect.mli] for specification.
+
+    Note: [effect] is a reserved keyword in OCaml 5, so the primary
+    type is named [t] and the collection is [set]. *)
+
+(* --------------------------------------------------------------------------- *)
+(** {1 Effect types} *)
+
+type effect_kind =
+  | Fs_read
+  | Fs_write
+  | Fs_delete
+  | Process_spawn
+  | Shell_interpreter
+  | Net_egress
+  | Credential_use
+  | External_mutation
+
+let string_of_effect_kind = function
+  | Fs_read -> "Fs_read"
+  | Fs_write -> "Fs_write"
+  | Fs_delete -> "Fs_delete"
+  | Process_spawn -> "Process_spawn"
+  | Shell_interpreter -> "Shell_interpreter"
+  | Net_egress -> "Net_egress"
+  | Credential_use -> "Credential_use"
+  | External_mutation -> "External_mutation"
+;;
+
+let pp_effect_kind fmt k = Format.pp_print_string fmt (string_of_effect_kind k)
+
+let compare_effect_kind a b =
+  String.compare (string_of_effect_kind a) (string_of_effect_kind b)
+;;
+
+type t =
+  { kind : effect_kind
+  ; scope : string list
+  ; source : string
+  }
+
+type set = t list
+
+let pp fmt e =
+  Format.fprintf
+    fmt
+    "{ kind = %a; scope = [%a]; source = %S }"
+    pp_effect_kind
+    e.kind
+    (Format.pp_print_list
+       ~pp_sep:(fun fmt () -> Format.fprintf fmt "; ")
+       Format.pp_print_string)
+    e.scope
+    e.source
+;;
+
+let pp_set fmt es =
+  Format.fprintf
+    fmt
+    "[%a]"
+    (Format.pp_print_list ~pp_sep:(fun fmt () -> Format.fprintf fmt ";@ ") pp)
+    es
+;;
+
+(* --------------------------------------------------------------------------- *)
+(** {1 Effect-level risk mapping} *)
+
+let effect_kind_floor = function
+  | Fs_read -> Shell_ir_risk.R0_Read
+  | Fs_write -> Shell_ir_risk.R1_Reversible_mutation
+  | Fs_delete -> Shell_ir_risk.R2_Irreversible
+  | Process_spawn -> Shell_ir_risk.R1_Reversible_mutation
+  | Shell_interpreter -> Shell_ir_risk.Destructive_protected
+  | Net_egress -> Shell_ir_risk.R1_Reversible_mutation
+  | Credential_use -> Shell_ir_risk.R1_Reversible_mutation
+  | External_mutation -> Shell_ir_risk.R1_Reversible_mutation
+;;
+
+(* --------------------------------------------------------------------------- *)
+(** {1 Projection (legacy compatibility)} *)
+
+let project_risk (effects : set) : Shell_ir_risk.risk_class =
+  let max_risk a b =
+    let rank = function
+      | Shell_ir_risk.R0_Read -> 0
+      | Shell_ir_risk.R1_Reversible_mutation -> 1
+      | Shell_ir_risk.R2_Irreversible -> 2
+      | Shell_ir_risk.Destructive_protected -> 3
+    in
+    if rank a >= rank b then a else b
+  in
+  List.fold_left
+    (fun acc e -> max_risk acc (effect_kind_floor e.kind))
+    Shell_ir_risk.R0_Read
+    effects
+;;
+
+(* --------------------------------------------------------------------------- *)
+(** {1 Extraction} *)
+
+(** Gather path-like arguments from a [Shell_ir.simple] via the typed
+    lowering.  Falls back to an empty list if the lowering fails
+    (should not happen for well-formed IR). *)
+let scope_of_simple (s : Shell_ir.simple) : string list =
+  try Shell_ir_typed.path_args (Shell_ir_typed.of_simple s) with
+  | _ -> []
+;;
+
+(** P0 extraction delegates to the existing [Shell_ir_risk.classify]
+    analysis to guarantee the golden property:
+
+        project_risk (extract ir) = classify ir
+
+    The returned effect uses the classified risk as its kind floor,
+    and the typed-lowering path arguments as its scope.  P1 will
+    replace this with a fine-grained per-constructor decomposition. *)
+let extract (ir : Shell_ir.t) : set =
+  let risk = (Shell_ir_risk.classify (Shell_ir_risk.undecided ir)).risk in
+  let kind, source =
+    match risk with
+    | Shell_ir_risk.R0_Read -> Fs_read, "classify:R0"
+    | Shell_ir_risk.R1_Reversible_mutation -> Fs_write, "classify:R1"
+    | Shell_ir_risk.R2_Irreversible -> Fs_delete, "classify:R2"
+    | Shell_ir_risk.Destructive_protected -> Shell_interpreter, "classify:Destructive"
+  in
+  let scope =
+    match ir with
+    | Shell_ir.Simple s -> scope_of_simple s
+    | Shell_ir.Pipeline _ -> []
+  in
+  [ { kind; scope; source } ]
+;;

--- a/lib/exec/exec_effect.mli
+++ b/lib/exec/exec_effect.mli
@@ -1,0 +1,61 @@
+(** Exec_effect — Effect axis types for Shell IR execution.
+
+    P0 of the Shell IR Effect Proof Design (RFC-0208 extension).
+
+    Note: [effect] is a reserved keyword in OCaml 5, so the primary
+    type is named [t] (idiomatic: [Exec_effect.t]) and the collection
+    is [set] ([Exec_effect.set]). *)
+
+
+(** {1 Effect types} *)
+
+type effect_kind =
+  | Fs_read
+  | Fs_write
+  | Fs_delete
+  | Process_spawn
+  | Shell_interpreter
+  | Net_egress
+  | Credential_use
+  | External_mutation
+
+val string_of_effect_kind : effect_kind -> string
+val pp_effect_kind : Format.formatter -> effect_kind -> unit
+val compare_effect_kind : effect_kind -> effect_kind -> int
+
+type t =
+  { kind : effect_kind
+  ; scope : string list
+  ; source : string
+  }
+
+type set = t list
+
+val pp : Format.formatter -> t -> unit
+val pp_set : Format.formatter -> set -> unit
+
+
+(** {1 Effect-level risk mapping} *)
+
+val effect_kind_floor : effect_kind -> Shell_ir_risk.risk_class
+(** The minimum risk_class for a given effect kind. *)
+
+
+(** {1 Projection (legacy compatibility)} *)
+
+val project_risk : set -> Shell_ir_risk.risk_class
+(** Project an effect set back to the legacy scalar risk_class.
+
+    P0 golden invariant:
+        [project_risk (extract ir) = classify ir]
+    for every command in the test corpus. *)
+
+
+(** {1 Extraction} *)
+
+val extract : Shell_ir.t -> set
+(** Decompose a [Shell_ir.t] into its effect set.
+
+    P0 delegates to [Shell_ir_risk.classify] and maps the scalar
+    result to a single named effect. P1 will replace this with
+    per-constructor fine-grained decomposition. *)

--- a/lib/exec/test/dune
+++ b/lib/exec/test/dune
@@ -25,7 +25,8 @@
   test_shell_ir_typed_e2e
   test_shell_ir_differential
   test_shell_ir_oracle
-  test_shell_ir_risk_action_flags)
+  test_shell_ir_risk_action_flags
+  test_shell_ir_effect_projection)
  (libraries
   masc_exec
   masc_exec_bash_parser

--- a/lib/exec/test/test_shell_ir_effect_projection.ml
+++ b/lib/exec/test/test_shell_ir_effect_projection.ml
@@ -1,0 +1,205 @@
+(* RFC-0208 P0: Shell IR Effect Projection golden tests.
+
+   Guarantees: project_risk (extract ir) = classify ir
+   for every command in the test corpus. *)
+
+module IR = Masc_exec.Shell_ir
+module Risk = Masc_exec.Shell_ir_risk
+module Effect = Masc_exec.Exec_effect
+
+let bin s = Result.get_ok (Masc_exec.Exec_program.of_string s)
+
+let simple_ir bin_str args =
+  IR.Simple
+    { IR.bin = bin bin_str
+    ; args = List.map (fun a -> IR.Lit (a, IR.default_meta)) args
+    ; env = []
+    ; cwd = None
+    ; redirects = []
+    ; sandbox = Masc_exec.Sandbox_target.host ()
+    }
+
+let pipeline_ir stages =
+  IR.Pipeline (List.map (fun (b, a) -> simple_ir b a) stages)
+
+(* --------------------------------------------------------------------------- *)
+(** {1 Golden property: project_risk (extract ir) = classify ir} *)
+
+let check_projection ir =
+  let expected = (Risk.classify (Risk.undecided ir)).risk in
+  let actual = Effect.project_risk (Effect.extract ir) in
+  Alcotest.(check bool)
+    (Format.asprintf "project_risk ≡ classify: expected %a, got %a"
+       Risk.pp_risk_class expected Risk.pp_risk_class actual)
+    true
+    (expected = actual)
+
+let test_golden_r0 () =
+  let cmds =
+    [ simple_ir "ls" []
+    ; simple_ir "cat" [ "file.txt" ]
+    ; simple_ir "rg" [ "pattern" ]
+    ; simple_ir "git" [ "status" ]
+    ; simple_ir "git" [ "log"; "--oneline" ]
+    ; simple_ir "git" [ "branch"; "-a"; "--list"; "*20083*" ]
+    ; simple_ir "git" [ "branch"; "--show-current" ]
+    ; simple_ir "gh" [ "pr"; "view"; "123" ]
+    ; simple_ir "gh" [ "issue"; "list" ]
+    ; simple_ir "echo" [ "hello" ]
+    ; simple_ir "pwd" []
+    ; simple_ir "find" [ "."; "-name"; "*.ml" ]
+    ; simple_ir "head" [ "-n"; "10"; "file.txt" ]
+    ; simple_ir "grep" [ "foo"; "bar.txt" ]
+    ]
+  in
+  List.iter check_projection cmds
+
+let test_golden_r1 () =
+  let cmds =
+    [ simple_ir "git" [ "commit"; "-m"; "msg" ]
+    ; simple_ir "git" [ "push" ]
+    ; simple_ir "git" [ "checkout"; "-b"; "feature" ]
+    ; simple_ir "git" [ "branch"; "new-branch" ]
+    ; simple_ir "git" [ "branch"; "-d"; "old-branch" ]
+    ; simple_ir "git" [ "branch"; "-m"; "old"; "new" ]
+    ; simple_ir "npm" [ "install" ]
+    ; simple_ir "mkdir" [ "dir" ]
+    ; simple_ir "touch" [ "file" ]
+    ; simple_ir "curl" [ "https://example.com" ]
+    ; simple_ir "wget" [ "https://example.com/file" ]
+    ; simple_ir "ssh" [ "host"; "uptime" ]
+    ; simple_ir "scp" [ "file"; "host:/tmp/file" ]
+    ; simple_ir "rsync" [ "-av"; "src/"; "host:/tmp/src/" ]
+    ; simple_ir "cp" [ "a"; "b" ]
+    ; simple_ir "mv" [ "a"; "b" ]
+    ; simple_ir "sed" [ "-i"; "s/a/b/"; "file.txt" ]
+    ]
+  in
+  List.iter check_projection cmds
+
+let test_golden_r2 () =
+  let cmds =
+    [ simple_ir "rm" [ "file.txt" ]
+    ; simple_ir "rm" [ "-r"; "dir" ]
+    ; simple_ir "rmdir" [ "dir" ]
+    ; simple_ir "git" [ "reset"; "--hard"; "HEAD~1" ]
+    ; simple_ir "dd" [ "if=/dev/zero"; "of=/tmp/img"; "bs=1M"; "count=10" ]
+    ]
+  in
+  List.iter check_projection cmds
+
+let test_golden_destructive () =
+  let cmds =
+    [ simple_ir "git" [ "push"; "--force"; "origin"; "main" ]
+    ; simple_ir "git" [ "push"; "--force-with-lease"; "origin"; "main" ]
+    ; simple_ir "bash" [ "-c"; "echo x > /tmp/x" ]
+    ; simple_ir "sh" [ "-c"; "echo x > /tmp/x" ]
+    ; simple_ir "python3" [ "-c"; "open('x','w').write('1')" ]
+    ; simple_ir "node" [ "-e"; "require('fs').writeFileSync('x','1')" ]
+    ; simple_ir "sudo" [ "rm"; "file.txt" ]
+    ; simple_ir "rm" [ "-rf"; "/tmp/dir" ]
+    ]
+  in
+  List.iter check_projection cmds
+
+let test_golden_pipeline () =
+  let cmds =
+    [ pipeline_ir [ "cat", [ "file.txt" ]; "grep", [ "pattern" ] ]
+    ; pipeline_ir [ "echo", [ "x" ]; "tee", [ "file.txt" ] ]
+    ; pipeline_ir [ "ls", []; "sort", [] ]
+    ; pipeline_ir [ "cat", [ "f" ]; "bash", [ "-c"; "cat > /dev/null" ] ]
+    ]
+  in
+  List.iter check_projection cmds
+
+(* --------------------------------------------------------------------------- *)
+(** {1 Effect-level risk floor tests} *)
+
+let test_effect_kind_floor () =
+  Alcotest.(check bool)
+    "Fs_read → R0"
+    true
+    (Effect.effect_kind_floor Fs_read = Risk.R0_Read);
+  Alcotest.(check bool)
+    "Fs_write → R1"
+    true
+    (Effect.effect_kind_floor Fs_write = Risk.R1_Reversible_mutation);
+  Alcotest.(check bool)
+    "Fs_delete → R2"
+    true
+    (Effect.effect_kind_floor Fs_delete = Risk.R2_Irreversible);
+  Alcotest.(check bool)
+    "Shell_interpreter → Destructive_protected"
+    true
+    (Effect.effect_kind_floor Shell_interpreter = Risk.Destructive_protected);
+  Alcotest.(check bool)
+    "Net_egress → R1"
+    true
+    (Effect.effect_kind_floor Net_egress = Risk.R1_Reversible_mutation);
+  Alcotest.(check bool)
+    "Credential_use → R1"
+    true
+    (Effect.effect_kind_floor Credential_use = Risk.R1_Reversible_mutation);
+  Alcotest.(check bool)
+    "External_mutation → R1"
+    true
+    (Effect.effect_kind_floor External_mutation = Risk.R1_Reversible_mutation);
+  Alcotest.(check bool)
+    "Process_spawn → R1"
+    true
+    (Effect.effect_kind_floor Process_spawn = Risk.R1_Reversible_mutation)
+
+(* --------------------------------------------------------------------------- *)
+(** {1 Extract shape tests} *)
+
+let test_extract_non_empty () =
+  let ir = simple_ir "ls" [] in
+  let effects = Effect.extract ir in
+  Alcotest.(check bool) "extract returns at least one effect" true (List.length effects >= 1)
+
+let test_extract_scope_populated () =
+  let ir = simple_ir "cat" [ "file.txt" ] in
+  let effects = Effect.extract ir in
+  Alcotest.(check int) "extract scope is populated" 1 (List.length effects);
+  let e = List.hd effects in
+  Alcotest.(check bool) "scope contains path" true (List.mem "file.txt" e.scope)
+
+(* --------------------------------------------------------------------------- *)
+(** {1 Alcotest entrypoint} *)
+
+let () =
+  Alcotest.run
+    "shell_ir_effect_projection"
+    [ ( "golden.r0"
+      , [ Alcotest.test_case "project_risk ≡ classify (R0 corpus)" `Quick test_golden_r0 ]
+      )
+    ; ( "golden.r1"
+      , [ Alcotest.test_case "project_risk ≡ classify (R1 corpus)" `Quick test_golden_r1 ]
+      )
+    ; ( "golden.r2"
+      , [ Alcotest.test_case "project_risk ≡ classify (R2 corpus)" `Quick test_golden_r2 ]
+      )
+    ; ( "golden.destructive"
+      , [ Alcotest.test_case
+            "project_risk ≡ classify (Destructive corpus)"
+            `Quick
+            test_golden_destructive
+        ]
+      )
+    ; ( "golden.pipeline"
+      , [ Alcotest.test_case
+            "project_risk ≡ classify (Pipeline corpus)"
+            `Quick
+            test_golden_pipeline
+        ]
+      )
+    ; ( "effect_kind_floor"
+      , [ Alcotest.test_case "effect_kind_floor mapping" `Quick test_effect_kind_floor ]
+      )
+    ; ( "extract.shape"
+      , [ Alcotest.test_case "extract returns non-empty" `Quick test_extract_non_empty
+        ; Alcotest.test_case "extract scope populated" `Quick test_extract_scope_populated
+        ]
+      )
+    ]
+;;

--- a/test/dune
+++ b/test/dune
@@ -200,6 +200,7 @@
   test_exec_core
   test_exec_dispatch
   test_shell_ir_risk
+  test_exec_effect
   test_keeper_tool_execute_typed_input
   test_hitl_approval
   test_keeper_discovered_tools
@@ -453,6 +454,7 @@
   test_exec_core
   test_exec_dispatch
   test_shell_ir_risk
+  test_exec_effect
   test_keeper_tool_execute_typed_input
   test_hitl_approval
   test_keeper_discovered_tools

--- a/test/test_exec_effect.ml
+++ b/test/test_exec_effect.ml
@@ -1,0 +1,152 @@
+(** Golden tests for Exec_effect P0 invariant:
+
+        project_risk (extract ir) = classify ir
+
+    for every command in the Shell_ir_risk test corpus.
+
+    This ensures the effect decomposition is at least as precise
+    as the existing scalar classifier. *)
+
+module Parsed = Masc_exec.Parsed
+module Shell_ir = Masc_exec.Shell_ir
+module Shell_ir_risk = Masc_exec.Shell_ir_risk
+module Exec_effect = Masc_exec.Exec_effect
+module Bash = Masc_exec_bash_parser.Bash
+
+let classify_cmd cmd =
+  match Bash.parse_string cmd with
+  | Parsed.Parsed ir ->
+    let envelope = Shell_ir_risk.classify (Shell_ir_risk.undecided ir) in
+    Shell_ir_risk.risk_class envelope
+  | Parsed.Parse_error _ | Parsed.Parse_aborted _ | Parsed.Too_complex _ ->
+    failwith (Printf.sprintf "Failed to parse: %s" cmd)
+;;
+
+let extract_risk cmd =
+  match Bash.parse_string cmd with
+  | Parsed.Parsed ir ->
+    let es = Exec_effect.extract ir in
+    Exec_effect.project_risk es
+  | Parsed.Parse_error _ | Parsed.Parse_aborted _ | Parsed.Too_complex _ ->
+    failwith (Printf.sprintf "Failed to parse: %s" cmd)
+;;
+
+let check_golden cmd =
+  let expected = classify_cmd cmd in
+  let actual = extract_risk cmd in
+  if actual <> expected then
+    Alcotest.fail
+      (Printf.sprintf
+         "golden mismatch for %S: classify=%s, project_risk(extract)=%s"
+         cmd
+         (Shell_ir_risk.string_of_risk_class expected)
+         (Shell_ir_risk.string_of_risk_class actual))
+;;
+
+(* --- R0 corpus ------------------------------------------------------ *)
+
+let test_r0_corpus () =
+  List.iter check_golden
+    [ "ls"
+    ; "cat file.txt"
+    ; "pwd"
+    ; "echo hello"
+    ; "rg pattern lib/"
+    ; "git status"
+    ; "git log --oneline -5"
+    ; "git branch -a --list '*20083*'"
+    ; "git branch --show-current"
+    ; "git -C /repo status"
+    ; "git -c color.ui=false branch --show-current"
+    ; "git rev-parse HEAD"
+    ; "git remote -v"
+    ; "git config --get remote.origin.url"
+    ; "git config --global --get user.email"
+    ; "git tag -l"
+    ; "env FOO=bar git status"
+    ; "gh pr view 123"
+    ; "gh --repo owner/repo pr view 123"
+    ; "dune build"
+    ; "npm run build"
+    ]
+;;
+
+(* --- R1 corpus ------------------------------------------------------ *)
+
+let test_r1_corpus () =
+  List.iter check_golden
+    [ "mv a b"
+    ; "cp a b"
+    ; "mkdir dir"
+    ; "touch file"
+    ; "chmod 755 file"
+    ; "chown user file"
+    ; "chgrp group file"
+    ; "git push origin main"
+    ; "git commit -m msg"
+    ; "git add file.txt"
+    ; "git apply patch.diff"
+    ; "git -C /repo push origin branch"
+    ; "git -c user.name=x commit -m msg"
+    ; "git switch feature"
+    ; "git restore file.txt"
+    ; "git pull --ff-only"
+    ; "git fetch origin main"
+    ; "git config --global user.email x@example.com"
+    ; "git remote set-head origin -a"
+    ; "env FOO=bar git push origin branch"
+    ; "cat patch.diff | git apply"
+    ; "git checkout branch"
+    ; "git branch new-branch"
+    ; "git branch -d old-branch"
+    ; "git branch -m old new"
+    ; "dune clean"
+    ; "make test"
+    ; "make install"
+    ; "npm install pkg"
+    ; "truncate -s 0 file"
+    ; "mktemp"
+    ; "tee file.txt"
+    ; "curl https://example.com"
+    ; "wget https://example.com/file"
+    ; "ssh host uptime"
+    ; "scp file host:/tmp/file"
+    ; "rsync -av src/ host:/tmp/src/"
+    ; "env FOO=bar curl https://example.com"
+    ]
+;;
+
+(* --- R2 corpus ------------------------------------------------------ *)
+
+let test_r2_corpus () =
+  List.iter check_golden
+    [ "rm file.txt"
+    ; "rmdir dir"
+    ]
+;;
+
+(* --- Destructive corpus --------------------------------------------- *)
+
+let test_destructive_corpus () =
+  List.iter check_golden
+    [ "rm -rf /"
+    ; "sh -c 'echo hello'"
+    ; "bash -c 'echo hello'"
+    ]
+;;
+
+(* --- Test suite ----------------------------------------------------- *)
+
+let () =
+  Alcotest.run
+    "Exec_effect golden tests"
+    [ ( "R0 corpus golden"
+      , [ Alcotest.test_case "classify = project_risk(extract)" `Quick test_r0_corpus ] )
+    ; ( "R1 corpus golden"
+      , [ Alcotest.test_case "classify = project_risk(extract)" `Quick test_r1_corpus ] )
+    ; ( "R2 corpus golden"
+      , [ Alcotest.test_case "classify = project_risk(extract)" `Quick test_r2_corpus ] )
+    ; ( "Destructive corpus golden"
+      , [ Alcotest.test_case "classify = project_risk(extract)" `Quick test_destructive_corpus ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

P0 of the Shell IR Effect Proof Design (RFC-0208 extension). Adds 8 `effect_kind` types that name the axes collapsed by the scalar R0/R1/R2 risk classification.

## Design Doc

`reports/shell-ir-effect-proof-design-20260607.html` (branch `codex/shell-ir-proof-design-20260607`)

## Changes

- `lib/exec/exec_effect.ml` / `.mli` — New module with 8 effect_kind types, extract, project_risk
- `test/test_exec_effect.ml` — Golden tests verifying `project_risk(extract ir) = classify ir` for full corpus
- `lib/exec/test/test_shell_ir_effect_projection.ml` — Additional projection tests

## Golden Invariant (verified)

```
project_risk (extract ir) = Shell_ir_risk.classify ir
```

All 4 test groups pass (0.001s). No dispatch behavior change.

## Notes

- `effect` is OCaml 5 reserved keyword, types use `t` and `set`
- P1: per-constructor GADT decomposition + proof bundles

🤖 Generated with [Claude Code](https://claude.com/claude-code)
