### PR TITLE
docs: refresh stale runtime_event_bridge source path references (#20091)

### DIFF
--- a/docs/OPERATOR-SCHEMA-SURFACE-INDEX.md
+++ b/docs/OPERATOR-SCHEMA-SURFACE-INDEX.md
@@ -18,7 +18,7 @@ Machine-readable catalog: `docs/schema-surfaces/operator-output-surfaces.v1.json
 | `masc.keeper_tool_call_log.jsonl.v1` | Keeper tool-call I/O JSONL | `lib/keeper_tool_call_log.mli` | Tool-call log tests |
 | `masc.runtime_contract_projection.v1` | Runtime contract JSON projection | `lib/keeper/keeper_runtime_contract.mli` | Tool-call/runtime contract tests |
 | `masc.mcp_openapi_tool_schema.v1` | MCP tool schemas and generated OpenAPI | `lib/keeper/keeper_schema.mli`, `lib/tool_schema_dsl.mli` | Tool matrix and OpenAPI smoke tests |
-| `masc.oas_bridge_events.v1` | OAS custom events bridged into MASC | `lib/runtime/runtime_event_bridge.mli`, event inventory doc | OAS integration tests |
+| `masc.oas_bridge_events.v1` | OAS custom events bridged into MASC | `lib/keeper/keeper_event_bridge.mli`, event inventory doc | OAS integration tests |
 
 ## Boundary Rules
 

--- a/docs/schema-surfaces/operator-output-surfaces.v1.json
+++ b/docs/schema-surfaces/operator-output-surfaces.v1.json
@@ -135,7 +135,7 @@
       "consumer": ["dashboard SSE bridge", "OAS event subscribers"],
       "wire_or_artifact": "OAS Custom events relayed into MASC surfaces",
       "schema_source": [
-        "lib/runtime/runtime_event_bridge.mli",
+        "lib/keeper/keeper_event_bridge.mli",
         "docs/SYSTEM-EVENT-AND-SNAPSHOT-INVENTORY.md"
       ],
       "validator": "OAS integration bridge tests",

--- a/lib/keeper/keeper_event_bridge.ml
+++ b/lib/keeper/keeper_event_bridge.ml
@@ -419,7 +419,7 @@ let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t optio
     Log.Misc.warn
       "oas_event_bridge: SSE-degraded to kind-only payload for unmigrated OAS \
        variant kind=%s correlation_id=%s run_id=%s ts=%f fix: add explicit arm in \
-       lib/runtime/runtime_event_bridge.ml::native_event_to_json for this kind"
+       lib/keeper/keeper_event_bridge.ml::native_event_to_json for this kind"
       kind
       correlation_id
       run_id
@@ -430,9 +430,9 @@ let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t optio
         ; ( "note"
           , `String
               "kind-only fallback; explicit arm not yet wired in \
-               runtime_event_bridge.native_event_to_json" )
+               keeper_event_bridge.native_event_to_json" )
         ; ( "migration_target"
-          , `String "lib/runtime/runtime_event_bridge.ml::native_event_to_json" )
+          , `String "lib/keeper/keeper_event_bridge.ml::native_event_to_json" )
         ]
     in
     Some (wrap ~event_type:kind ~payload ())


### PR DESCRIPTION
## Summary
Closes #20091

Replace references to `lib/runtime/runtime_event_bridge.mli` and `runtime_event_bridge.native_event_to_json` with the keeper module location `lib/keeper/keeper_event_bridge.mli` and `keeper_event_bridge.native_event_to_json`.

## Changes
- `docs/OPERATOR-SCHEMA-SURFACE-INDEX.md` — schema source path
- `docs/schema-surfaces/operator-output-surfaces.v1.json` — machine-readable catalog
- `lib/keeper/keeper_event_bridge.ml` — diagnostic/log strings (3 occurrences)

## Verification
- [x] `rg 'runtime_event_bridge' docs/ lib/keeper/` returns no stale hits
- [x] `dune build @check` passes (no OCaml changes beyond string literals)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>