### PR TITLE
refactor: remove two read-only refs identified by RFC-OAS-015 Category C scan (#20049)

### DIFF
--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -69,9 +69,8 @@ let execute_tool_eio
   Otel_metric_store.record_request ();
   let config = state.Mcp_server.workspace_config in
   let registry = state.Mcp_server.session_registry in
-  (* Fix 3: Cache workspace_initialized to avoid repeated stat syscalls.
-     Updated after auto-init succeeds. *)
-  let workspace_init_cached = ref (Workspace.is_initialized config) in
+  (* Fix 3: Cache workspace_initialized to avoid repeated stat syscalls. *)
+  let workspace_init_cached = Workspace.is_initialized config in
   (* Fix 4: Check resolved-name cache for fast identity resolution.
      On 2nd+ call in the same MCP session, the cached name preserves the
      nickname selected by the prior session binding without relying on sidecar files. *)
@@ -88,7 +87,7 @@ let execute_tool_eio
   let caller_identity =
     Mcp_server_eio_caller_identity.resolve ~config ~tool_name:name ~arguments
       ~identity ~cached_resolved_agent ~auth_token ~internal_keeper_runtime
-      ~workspace_initialized:(fun () -> !workspace_init_cached)
+      ~workspace_initialized:(fun () -> workspace_init_cached)
       ~log_mcp_exn
   in
   let agent_name = caller_identity.agent_name in
@@ -181,7 +180,7 @@ let execute_tool_eio
           in
           (match owner_keeper_identity with
            | Some (keeper_name, keeper_id)
-             when agent_name <> "unknown" && !workspace_init_cached ->
+             when agent_name <> "unknown" && workspace_init_cached ->
              (try
                 Workspace_task.update_local_agent_state config ~agent_name (fun agent ->
                   let meta =
@@ -229,7 +228,7 @@ let execute_tool_eio
               | Tool_catalog.Real | Tool_catalog.Adapter | Tool_catalog.Placeholder ->
                 false
             in
-            if (not skip_heartbeat) && !workspace_init_cached
+            if (not skip_heartbeat) && workspace_init_cached
             then (
               try
                 let (_ : string) = Workspace.heartbeat config ~agent_name in

--- a/lib/session.ml
+++ b/lib/session.ml
@@ -494,7 +494,7 @@ module McpSessionStore = struct
   let state_mutex = Mutex.create ()
   let loop_started = Atomic.make false
 
-  let max_age = ref Env_config.Session.max_age_seconds
+  let max_age = Env_config.Session.max_age_seconds
 
   let process_msg state msg =
     match msg with
@@ -599,7 +599,7 @@ module McpSessionStore = struct
 
   let cleanup_stale () =
     let p, r = Eio.Promise.create () in
-    dispatch (Cleanup_stale (Time_compat.now (), !max_age, r));
+    dispatch (Cleanup_stale (Time_compat.now (), max_age, r));
     await_if_needed p
 
   let to_json (s : mcp_session) : Yojson.Safe.t =


### PR DESCRIPTION
## Summary
Closes #20049

Reclassifies the 18 Category C candidates from the RFC-OAS-015 ref-scan:

- **16 false positives**: refs mutated through aliases or helper-function
  parameters (progress_ref, section_timings_ref, keeper turn/heartbeat refs,
  mcp_server_eio_resource fields, etc.)
- **2 true positives**: refs that are read but never reassigned within their
  scope.

## Changes
- `lib/session.ml: max_age` — plain `let` binding (never reassigned)
- `lib/mcp_server_eio_execute.ml: workspace_init_cached` — plain `let` binding
  (never reassigned; removed stale "Updated after auto-init succeeds" comment)

## Verification
- [x] Category C scan re-run confirms these two no longer appear
- [x] `dune build @check` passes (no behavioral change, only ref→let)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>