### PR TITLE
fix(test): adapt tests to typed tool_failure_class return type

### DIFF
--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -999,7 +999,8 @@ let test_execute_git_without_github_bundle_succeeds () =
   Alcotest.(check bool) "typed git uses docker exec" true
     (contains_substring log "\nexec ");
   Alcotest.(check bool) "typed git avoids credential blocker" false
-    (Keeper_tool_dispatch_runtime.should_apply_circuit_breaker_to_failure_payload raw)
+    (Keeper_tool_dispatch_runtime.should_apply_circuit_breaker_to_failure_payload
+       (Keeper_tool_dispatch_runtime.failure_class_of_tool_result_payload raw))
 
 let test_execute_git_c_option_missing_dir_blocks_before_docker () =
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -723,19 +723,28 @@ let test_workflow_rejection_payload_skips_circuit_breaker () =
       "No such file or directory"
   in
   check (option string) "extracts workflow class" (Some "workflow_rejection")
-    (KET.failure_class_of_tool_result_payload workflow_payload);
+    (Option.map Tool_result.tool_failure_class_to_string
+       (KET.failure_class_of_tool_result_payload workflow_payload));
   check bool "workflow rejection does not trip circuit breaker" false
-    (KET.should_apply_circuit_breaker_to_failure_payload workflow_payload);
+    (KET.should_apply_circuit_breaker_to_failure_payload
+       (KET.failure_class_of_tool_result_payload workflow_payload));
   check (option string) "extracts egress policy class" (Some "policy_rejection")
-    (KET.failure_class_of_tool_result_payload egress_payload);
+    (Option.map Tool_result.tool_failure_class_to_string
+       (KET.failure_class_of_tool_result_payload egress_payload));
   check bool "egress policy rejection does not trip circuit breaker" false
-    (KET.should_apply_circuit_breaker_to_failure_payload egress_payload);
-  check (option string) "legacy egress has no inferred class" None
-    (KET.failure_class_of_tool_result_payload legacy_egress_payload);
+    (KET.should_apply_circuit_breaker_to_failure_payload
+       (KET.failure_class_of_tool_result_payload egress_payload));
+  (* legacy egress has no failure_class field → typed parser defaults to
+     Runtime_failure (conservative: unknown → fail, CLAUDE.md anti-pattern #2). *)
+  check (option string) "legacy egress defaults to runtime_failure" (Some "runtime_failure")
+    (Option.map Tool_result.tool_failure_class_to_string
+       (KET.failure_class_of_tool_result_payload legacy_egress_payload));
   check bool "legacy egress still trips circuit breaker" true
-    (KET.should_apply_circuit_breaker_to_failure_payload legacy_egress_payload);
+    (KET.should_apply_circuit_breaker_to_failure_payload
+       (KET.failure_class_of_tool_result_payload legacy_egress_payload));
   check bool "runtime failure still trips circuit breaker" true
-    (KET.should_apply_circuit_breaker_to_failure_payload runtime_payload)
+    (KET.should_apply_circuit_breaker_to_failure_payload
+       (KET.failure_class_of_tool_result_payload runtime_payload))
 
 let test_tool_execute_raw_cmd_requires_typed_shell_ir () =
   with_exec_fixture "tool_execute_raw_cmd_requires_typed_shell_ir"

--- a/test/test_keeper_validation_breaker_exempt.ml
+++ b/test/test_keeper_validation_breaker_exempt.ml
@@ -58,17 +58,20 @@ let payload =
 let test_producer_tags_policy_rejection () =
   check (option string) "validation payload carries policy_rejection class"
     (Some "policy_rejection")
-    (Dispatch.failure_class_of_tool_result_payload payload)
+    (Option.map TR.tool_failure_class_to_string
+       (Dispatch.failure_class_of_tool_result_payload payload))
 
 (* B — Gate #1 (health breaker): validation is exempt, but an UNCLASSIFIED
    error still counts (conservative: unknown -> fail, never permissive-default
    per CLAUDE.md anti-pattern #2). *)
 let test_gate1_exempts_validation_but_counts_unclassified () =
   check bool "Gate#1 exempts policy_rejection validation" false
-    (Dispatch.should_apply_circuit_breaker_to_failure_payload payload);
+    (Dispatch.should_apply_circuit_breaker_to_failure_payload
+       (Dispatch.failure_class_of_tool_result_payload payload));
   check bool "Gate#1 still counts an unclassified (class-less) error" true
     (Dispatch.should_apply_circuit_breaker_to_failure_payload
-       {|{"error":"contract must be an object when provided"}|})
+       (Dispatch.failure_class_of_tool_result_payload
+          {|{"error":"contract must be an object when provided"}|}))
 
 (* C — Gate #2 (per-(tool,args) breaker): validation is NOT a workflow
    rejection, so identical bad args remain counted (retry-block intact). This


### PR DESCRIPTION
## Summary

PR #20457 converted `failure_class_of_tool_result_payload` to return `Tool_result.tool_failure_class option` and `should_apply_circuit_breaker_to_failure_payload` to accept `tool_failure_class option`. Three test files were not updated, causing main-branch `dune build .` failure.

## Changes

| File | Fix |
|------|-----|
| `test_keeper_tool_dispatch_runtime.ml` | `Option.map tool_failure_class_to_string` for Alcotest string checks; pipe through `failure_class_of_tool_result_payload` before circuit breaker |
| `test_keeper_validation_breaker_exempt.ml` | Same two-part adaptation |
| `test_keeper_sandbox_docker_route.ml` | Pipe raw payload through `failure_class_of_tool_result_payload` before circuit breaker call |

## Behavioral note

Legacy egress payload (no `failure_class` field) was asserted as `None`. The typed parser now conservatively returns `Runtime_failure` — assertion updated to match. This aligns with CLAUDE.md anti-pattern #2 (unknown → fail, never permissive default).

## Verification

`dune build --root .` pass, `@runtest` for the 3 modified test files all green.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>