### PR TITLE
docs: refresh design docs for removed OAS Proof_store surface (#20080)

### DIFF
--- a/docs/design/CDAL-PHASE1A-TEAM-START-HERE.md
+++ b/docs/design/CDAL-PHASE1A-TEAM-START-HERE.md
@@ -59,7 +59,7 @@ Before writing code, confirm the producer side:
 - `oas/docs/schemas/cdal-proof-bundle-v1.json` — proof bundle JSON Schema
 - `oas/lib/mode_enforcer.ml` — runtime enforcement logic (producer side)
 - `oas/lib/proof_capture.ml` — proof artifact writer (producer side)
-- `oas/lib/proof_store.mli` — proof store read interface
+- `oas/lib/runtime_store.mli` / `oas/lib/runtime_replay.mli` — runtime replay/run-window read interfaces (current); historical `proof_store.mli` was removed
 - `masc/lib/cdal_eval_v1.ml` — current evaluator (anti-pattern reference, not implementation guide). The previous `cdal_eval.ml` was renamed to `cdal_eval_v1.ml` to mark it as the legacy path; `cdal_loader.ml`, `cdal_judge.ml`, `cdal_friction_projection.ml` (the Phase-1A deliverables listed in §1) now exist under `lib/` and are the canonical successors.
 
 These files tell you what exists today.

--- a/docs/design/cdal-contract-kernel-and-advisory-split.md
+++ b/docs/design/cdal-contract-kernel-and-advisory-split.md
@@ -101,7 +101,7 @@ MCP Protocol SDK  <--  OAS (Agent SDK)  <--  MASC (Agent stream)
 Module ownership:
 
 - `Cdal_loader`, `Cdal_judge`, `Cdal_friction`, `Cdal_advice` belong to MASC.
-- `Proof_store`, `Proof_capture`, `Mode_enforcer`, `Contract_runner` belong to OAS.
+- `Runtime_store`, `Runtime_replay`, `Proof_capture`, `Mode_enforcer`, `Contract_runner` belong to OAS.
 - Wire types and transport belong to MCP Protocol SDK.
 
 Anti-patterns:
@@ -151,10 +151,12 @@ It is not acceptable as part of a deterministic contract kernel unless the parti
 
 ### 3.4 Proof Integrity and Loading Boundaries
 
-`proof-store://` is an OAS-owned read/write scheme. OAS exposes the public
-read surface through `Agent_sdk.Proof_store`; MASC uses
-`lib/proof_artifact_reader.ml` as a narrow adapter and must not mirror the
-directory layout.
+`runtime-store://` is the OAS-owned read/write scheme for runtime replay and
+run-window queries.  OAS exposes the public read surface through
+`Agent_sdk.Runtime_store` and `Agent_sdk.Runtime_replay`; MASC consumes these
+through `lib/cdal_runtime/` adapters and must not mirror the directory layout.
+The historical `proof-store://` scheme and `Agent_sdk.Proof_store` surface were
+removed.
 
 Remaining deterministic-kernel gap:
 
@@ -715,19 +717,20 @@ Cdal_advice
 
 ### 11.2 OAS Reader API Status
 
-OAS owns the read side for the `proof-store://` scheme. MASC readers should
-delegate to `Agent_sdk.Proof_store` through the local adapter, preserving OAS as
-the authority for scheme parsing, traversal rejection, and filesystem layout.
+OAS owns the read side for the `runtime-store://` scheme.  MASC readers should
+delegate to `Agent_sdk.Runtime_store` / `Agent_sdk.Runtime_replay` through the
+local adapter, preserving OAS as the authority for run-window semantics and
+replay layout.
 
 Current public APIs:
 
-- `Proof_store.resolve_ref`
-- `Proof_store.read_json`
-- `Proof_store.read_jsonl`
-- `Proof_store.load_manifest`
-- `Proof_store.load_contract`
+- `Runtime_store.list_runs`
+- `Runtime_store.Last_n_runs`
+- `Runtime_store.Session`
+- `Runtime_store.Rolling_seconds`
+- `Runtime_replay.sync_windows_from_store`
 
-This keeps the proof-store scheme and layout authoritative in OAS rather than
+This keeps the runtime-store scheme and layout authoritative in OAS rather than
 MASC.
 
 ## 12. Regression Checklist
@@ -779,8 +782,8 @@ Phase-1B exit criteria:
 
 ### Phase 2: OAS Read API
 
-- upstream `Proof_store` read-side APIs
-- switch MASC loader to OAS-owned ref resolution
+- upstream `Runtime_store` / `Runtime_replay` read-side APIs
+- switch MASC loader to OAS-owned run-window resolution
 - keep schema v1 compatibility
 
 ### Phase 3: Typed Evidence v2 and Check Expansion

--- a/docs/design/cross-run-loader-and-window-spec.md
+++ b/docs/design/cross-run-loader-and-window-spec.md
@@ -43,12 +43,11 @@ Reason:
 
 Cross-run windows require at least:
 
-- `Proof_store.resolve_ref`
-- `Proof_store.read_json`
-- `Proof_store.read_jsonl`
-- `Proof_store.load_contract`
-- `Proof_store.load_manifest`
-- `Proof_store.list_runs`
+- `Runtime_store.list_runs`
+- `Runtime_store.Last_n_runs`
+- `Runtime_store.Session`
+- `Runtime_store.Rolling_seconds`
+- `Runtime_replay.sync_windows_from_store`
 
 `list_runs` must define:
 
@@ -164,68 +163,34 @@ Runs may use different proof manifest schema versions. The loader must handle ve
 
 Since the current schema remains at version 1 (with optional fields added via `[@yojson.default]`), normalization is handled by the existing `Cdal_proof.of_json` decoder. A separate `normalize_manifest` function is not needed at this time. If a future schema v2 introduces breaking field changes, an explicit normalizer should be added.
 
-## 11. Proof_store Read-Side API (OAS, Implemented)
+## 11. Runtime_store / Runtime_replay Read-Side API (OAS, Current)
 
-OAS now owns the `proof-store://` read side through `Agent_sdk.Proof_store`.
-MASC must consume that public surface through `lib/cdal/proof_artifact_reader.ml`
-instead of reconstructing proof-store paths.
+OAS now owns the runtime replay/run-window surface through `Agent_sdk.Runtime_store`
+and `Agent_sdk.Runtime_replay`.  The historical `proof-store://` read side
+(`Agent_sdk.Proof_store`) was removed; MASC should not reference it.
 
-Current public read surface in OAS `proof_store.mli`:
+Current public read surface in OAS:
 
-- `resolve_ref`
-- `read_json`
-- `read_jsonl`
-- `load_manifest`
-- `load_contract`
-- `list_runs`
-- `list_runs_ordered`
-- `load_window`
+- `Runtime_store.list_runs`
+- `Runtime_store.Last_n_runs`
+- `Runtime_store.Session`
+- `Runtime_store.Rolling_seconds`
+- `Runtime_replay.sync_windows_from_store`
+- checkpoint delta projection helpers
 
-The cross-run window APIs use the following public types:
+MASC consumes these through `lib/cdal_runtime/` evidence writers and runtime
+adapters rather than through a separate `proof_artifact_reader.ml` module.
 
-```ocaml
-(** Run metadata for ordering and filtering. *)
-type run_info = {
-  run_id: string;
-  ended_at: float;         (** from Cdal_proof.t.ended_at *)
-  schema_version: int;     (** proof manifest schema version *)
-  scope: string option;    (** opaque scope label set by producer *)
-}
-
-type window_bounds = {
-  max_runs: int;           (** hard limit on run count, default 50 *)
-  max_bytes: int;          (** hard limit on total bytes scanned, default 50MB *)
-}
-
-(** List runs with metadata, ordered by [ended_at] ascending,
-    tie-broken by [run_id].
-    Corrupted manifests are excluded and reported in the errors list. *)
-val list_runs_ordered :
-  config ->
-  ?scope:string ->
-  ?bounds:window_bounds ->
-  unit ->
-  (run_info list * string list, string) result
-
-(** Load manifests for a window of runs.
-    Readable runs returned; unreadable runs reported as errors. *)
-val load_window :
-  config ->
-  run_ids:string list ->
-  ?bounds:window_bounds ->
-  unit ->
-  ((Cdal_proof.t * Yojson.Safe.t) list * string list, string) result
-```
-
-These signatures keep the existing `list_runs` backward compatible and add
-structured alternatives for deterministic window queries. Implementation and
-layout validation stay in OAS `proof_store.ml`; MASC adapters only delegate.
+These signatures replace the historical `list_runs_ordered` / `load_window`
+Proof_store API with a replay-oriented window model.  Implementation and layout
+validation stay in OAS `runtime_store.ml` / `runtime_replay.ml`; MASC adapters
+only delegate.
 
 ## 12. Regression Checklist
 
 Future cross-run reader changes must preserve:
 
-- `list_runs_ordered` is implemented with stable ordering
+- `Runtime_store.list_runs` / `Runtime_replay.sync_windows_from_store` are implemented with stable ordering
 - scope and ordering rules are explicit
 - late-arrival policy is enforced (snapshot semantics, no retroactive mutation)
 - retention is documented and enforced

--- a/docs/design/external-agent-framework-patterns-rfc.md
+++ b/docs/design/external-agent-framework-patterns-rfc.md
@@ -119,7 +119,7 @@ Implementation anchors:
 - `lib/verification.ml`
 - `lib/tool_verification.ml`
 - `lib/cdal_loader.ml`
-- `lib/cdal/proof_artifact_reader.ml`
+- `lib/cdal_runtime/` — runtime evidence and replay adapters
 
 Expected output:
 


### PR DESCRIPTION
## Summary
Closes #20080

Replace stale references to `Agent_sdk.Proof_store` / `proof_store.mli` /
`proof_artifact_reader.ml` with the current OAS `Runtime_store` /
`Runtime_replay` surfaces.

## Changes
- `docs/design/cross-run-loader-and-window-spec.md` — section 2, 11, 12
- `docs/design/cdal-contract-kernel-and-advisory-split.md` — sections 3.4, 11.2, module ownership
- `docs/design/CDAL-PHASE1A-TEAM-START-HERE.md` — producer-side file list
- `docs/design/external-agent-framework-patterns-rfc.md` — adapter file list

## Verification
- [x] `rg 'Proof_store|proof_store|proof_artifact_reader' docs/design/` returns no stale hits

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>