### PR TITLE
fix(test): update keeper circuit breaker call sites to typed signature

### DIFF
--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -998,8 +998,11 @@ let test_execute_git_without_github_bundle_succeeds () =
   let log = if Sys.file_exists log_path then read_file log_path else "" in
   Alcotest.(check bool) "typed git uses docker exec" true
     (contains_substring log "\nexec ");
+  let failure_class =
+    Keeper_tool_dispatch_runtime.failure_class_of_tool_result_payload raw
+  in
   Alcotest.(check bool) "typed git avoids credential blocker" false
-    (Keeper_tool_dispatch_runtime.should_apply_circuit_breaker_to_failure_payload raw)
+    (Keeper_tool_dispatch_runtime.should_apply_circuit_breaker_to_failure_payload failure_class)
 
 let test_execute_git_c_option_missing_dir_blocks_before_docker () =
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -1,4 +1,5 @@
 open Alcotest
+open Tool_result
 
 module KET = Masc.Keeper_tool_dispatch_runtime
 module KES = Masc.Keeper_tool_shared_runtime
@@ -722,20 +723,33 @@ let test_workflow_rejection_payload_skips_circuit_breaker () =
       ~fields:[ "failure_class", `String "runtime_failure" ]
       "No such file or directory"
   in
+  let workflow_class =
+    KET.failure_class_of_tool_result_payload workflow_payload
+  in
+  let egress_class =
+    KET.failure_class_of_tool_result_payload egress_payload
+  in
+  let legacy_class =
+    KET.failure_class_of_tool_result_payload legacy_egress_payload
+  in
+  let runtime_class =
+    KET.failure_class_of_tool_result_payload runtime_payload
+  in
+  let string_of_class = Option.map tool_failure_class_to_string in
   check (option string) "extracts workflow class" (Some "workflow_rejection")
-    (KET.failure_class_of_tool_result_payload workflow_payload);
+    (string_of_class workflow_class);
   check bool "workflow rejection does not trip circuit breaker" false
-    (KET.should_apply_circuit_breaker_to_failure_payload workflow_payload);
+    (KET.should_apply_circuit_breaker_to_failure_payload workflow_class);
   check (option string) "extracts egress policy class" (Some "policy_rejection")
-    (KET.failure_class_of_tool_result_payload egress_payload);
+    (string_of_class egress_class);
   check bool "egress policy rejection does not trip circuit breaker" false
-    (KET.should_apply_circuit_breaker_to_failure_payload egress_payload);
+    (KET.should_apply_circuit_breaker_to_failure_payload egress_class);
   check (option string) "legacy egress has no inferred class" None
-    (KET.failure_class_of_tool_result_payload legacy_egress_payload);
+    (string_of_class legacy_class);
   check bool "legacy egress still trips circuit breaker" true
-    (KET.should_apply_circuit_breaker_to_failure_payload legacy_egress_payload);
+    (KET.should_apply_circuit_breaker_to_failure_payload legacy_class);
   check bool "runtime failure still trips circuit breaker" true
-    (KET.should_apply_circuit_breaker_to_failure_payload runtime_payload)
+    (KET.should_apply_circuit_breaker_to_failure_payload runtime_class)
 
 let test_tool_execute_raw_cmd_requires_typed_shell_ir () =
   with_exec_fixture "tool_execute_raw_cmd_requires_typed_shell_ir"

--- a/test/test_keeper_validation_breaker_exempt.ml
+++ b/test/test_keeper_validation_breaker_exempt.ml
@@ -56,19 +56,26 @@ let payload =
 
 (* A — producer: keeper_task_create validation errors carry policy_rejection. *)
 let test_producer_tags_policy_rejection () =
+  let classified = Dispatch.failure_class_of_tool_result_payload payload in
   check (option string) "validation payload carries policy_rejection class"
     (Some "policy_rejection")
-    (Dispatch.failure_class_of_tool_result_payload payload)
+    (Option.map TR.tool_failure_class_to_string classified)
 
 (* B — Gate #1 (health breaker): validation is exempt, but an UNCLASSIFIED
    error still counts (conservative: unknown -> fail, never permissive-default
    per CLAUDE.md anti-pattern #2). *)
 let test_gate1_exempts_validation_but_counts_unclassified () =
+  let validation_class =
+    Dispatch.failure_class_of_tool_result_payload payload
+  in
   check bool "Gate#1 exempts policy_rejection validation" false
-    (Dispatch.should_apply_circuit_breaker_to_failure_payload payload);
+    (Dispatch.should_apply_circuit_breaker_to_failure_payload validation_class);
+  let unclassified_class =
+    Dispatch.failure_class_of_tool_result_payload
+      {|{"error":"contract must be an object when provided"}|}
+  in
   check bool "Gate#1 still counts an unclassified (class-less) error" true
-    (Dispatch.should_apply_circuit_breaker_to_failure_payload
-       {|{"error":"contract must be an object when provided"}|})
+    (Dispatch.should_apply_circuit_breaker_to_failure_payload unclassified_class)
 
 (* C — Gate #2 (per-(tool,args) breaker): validation is NOT a workflow
    rejection, so identical bad args remain counted (retry-block intact). This


### PR DESCRIPTION
## Summary

Fix-up for [PR #20457](https://github.com/jeong-sik/masc/pull/20457) (merge SHA `16bd189060`): update three test call sites to match the new typed signature of `failure_class_of_tool_result_payload` (returns `Tool_result.tool_failure_class option`) and `should_apply_circuit_breaker_to_failure_payload` (takes `Tool_failure_class option`).

`dune build .` on `main` currently fails with three test-compile errors; this PR restores the build.

## Cause

PR #20457 converted Gate #1 of the keeper circuit breaker from string matching to typed matching over `Tool_result.tool_failure_class`. The PR body claimed "No external callers of the changed `.mli` signatures" — that was incorrect. Three test files call these functions directly:

| File | Function | Old call | New call |
|---|---|---|---|
| `test/test_keeper_sandbox_docker_route.ml:1002` | `should_apply_circuit_breaker_to_failure_payload` | `raw` (string) | pre-compute via `failure_class_of_tool_result_payload raw` |
| `test/test_keeper_validation_breaker_exempt.ml:58-71` | both | payload (string) | pre-compute then pass typed |
| `test/test_keeper_tool_dispatch_runtime.ml:725-738` | both | 4 payload strings | pre-compute, 4 typed handles |

Lib callers (`lib/keeper/keeper_tool_dispatch_runtime.ml:336-337`) were correctly updated in #20457; only the test layer was missed.

## Changes

- Add `open Tool_result` in `test_keeper_tool_dispatch_runtime.ml` (header `module TR` not used there).
- Pre-compute `failure_class` via the new typed accessor in each test, then pass the typed result to the breaker predicate.
- Display the typed class via `tool_failure_class_to_string` (the lib's SSOT stringifier at `lib/tool_types/tool_result.ml:35-40`) to keep Alcotest `(option string)` comparators. This preserves the typed invariant — `to_string` is a lib-provided surface, not a string-widening helper added here.

## Verification

- `dune build .` (default target — @check alone would miss these expression-level type errors per prior divergence): **exit 0**
- `git diff --stat` shows 3 files / +36/-12, all under `test/`. No lib change.
- Typed invariant preserved: callers see `tool_failure_class option`, not raw `string option`. New variant additions in `Tool_result.tool_failure_class` will be caught at compile time by these tests, exactly as Gate #1 itself is now compile-checked.

## Related

- PR #20457 — original typed conversion (Claude Sonnet 4.6, jeong-sik merger)
- Issue: caller of `Keeper_tool_dispatch_runtime.failure_class_of_tool_result_payload` and `should_apply_circuit_breaker_to_failure_payload` were missed in the original PR's verification step. The PR's "no external callers" claim is contradicted by the three test files; the verification relied on `dune build @check` rather than `dune build .` (default target), which does not exercise test executables.

## RFC / Workaround Gate

`WORKAROUND-WAIVED: This PR is a fix-up for an unfulfilled verification step in PR #20457 (the original PR claimed "no external callers"; three test sites were missed). The change preserves the typed invariant and adds no string-classifier widening or symptom suppression. The signature is the new typed surface; the test sites were the producers of the call-graph evidence the original PR cited.`

