### PR TITLE
feat(observability): add OTel-native stack (Grafana + Jaeger + VictoriaMetrics)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,44 +1,30 @@
 # MASC MCP – local / single-host docker-compose orchestration.
 #
-# Production runs on Railway today; this compose file is for:
-#   - reproducible local stack-style runs (so docker stop respects
-#     the OCaml 4-phase graceful shutdown),
-#   - k8s/Nomad migrations that read compose for restart/log knobs,
-#   - smoke tests in `.github/workflows/deploy-railway.yml` if we ever
-#     want to drive them via compose.
+# Observability stack (OTel-native, no Prometheus):
+#   masc ──OTLP/HTTP──▶ otel-collector ──┬──OTLP/gRPC──▶ jaeger (traces)
+#                                        └──prometheusremotewrite──▶ victoriametrics (metrics)
+#   grafana ──queries──▶ jaeger + victoriametrics (UI: http://localhost:3000)
 #
-# Knobs explained:
-#   - restart: unless-stopped — re-launch on crash, but never on a
-#     `docker compose stop`. Aligns with infrastructure/launchd plist
-#     `KeepAlive.SuccessfulExit=false`.
-#   - stop_grace_period: 75s — sits 15s above MASC_SHUTDOWN_FORCE_TIMEOUT
-#     (60s) so the in-process force-exit watchdog can flush final logs
-#     before docker escalates to SIGKILL. Setting them equal raced both
-#     timers at ~60s and lost the last log line on shutdown.
-#   - logging: json-file with max-size=10m × max-file=3 → ~30MB upper
-#     bound per container. Container logs cap is independent of the
-#     in-tree `lib/masc_log/log.ml` 7-day rotation.
-#   - volumes: durable JSONL state under /app/.masc (matches Dockerfile
-#     VOLUME). The image-baked /app/config remains read-only seed.
+# Production runs on Railway today; this compose file is for:
+#   - reproducible local stack-style runs,
+#   - k8s/Nomad migrations that read compose for restart/log knobs,
+#   - local observability development.
 
 services:
   masc:
+    # To run masc inside docker:
+    #   docker compose --profile masc up -d
+    # Requires a linux binary (masc-linux-x64) or OCaml cross-compile.
+    profiles: ["masc"]
     build:
       context: .
       dockerfile: Dockerfile
       args:
-        # Override locally:
-        #   docker compose build --build-arg BINARY_PATH=_build/default/bin/main_eio.exe
         BINARY_PATH: masc-linux-x64
     image: masc:local
     container_name: masc
     restart: unless-stopped
     stop_signal: SIGTERM
-    # Give the server's force-exit watchdog (MASC_SHUTDOWN_FORCE_TIMEOUT
-    # below) a few seconds of headroom before Docker sends SIGKILL.
-    # Setting these equal would race: the watchdog and Docker would
-    # both fire at ~60s and the process could be killed mid-final-flush,
-    # losing the last log lines and post-shutdown hook telemetry.
     stop_grace_period: 75s
     ports:
       - "8080:8080"
@@ -48,6 +34,9 @@ services:
       MASC_CONFIG_DIR: /app/config
       MASC_SHUTDOWN_CLEANUP_TIMEOUT: "10"
       MASC_SHUTDOWN_FORCE_TIMEOUT: "60"
+      MASC_OTEL_ENABLED: "true"
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4318"
+      OTEL_SERVICE_NAME: "masc"
     volumes:
       - masc-state:/app/.masc
     healthcheck:
@@ -61,6 +50,53 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
+
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:latest
+    container_name: masc-otel-collector
+    command: ["--config=/etc/otelcol-contrib/config.yaml"]
+    volumes:
+      - ./infrastructure/monitoring/otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml
+    ports:
+      - "4318:4318"
+    depends_on:
+      - jaeger
+      - victoriametrics
+    restart: unless-stopped
+
+  jaeger:
+    image: jaegertracing/all-in-one:latest
+    container_name: masc-jaeger
+    ports:
+      - "16686:16686"
+    environment:
+      COLLECTOR_OTLP_ENABLED: "true"
+    restart: unless-stopped
+
+  victoriametrics:
+    image: victoriametrics/victoria-metrics:latest
+    container_name: masc-victoriametrics
+    ports:
+      - "8428:8428"
+    command:
+      - "-retentionPeriod=7d"
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: masc-grafana
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./infrastructure/monitoring/grafana/provisioning:/etc/grafana/provisioning
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_FEATURE_TOGGLES_ENABLE: "traceQLStreaming"
+    depends_on:
+      - jaeger
+      - victoriametrics
+    restart: unless-stopped
 
 volumes:
   masc-state:

--- a/infrastructure/monitoring/grafana/provisioning/datasources/jaeger.yml
+++ b/infrastructure/monitoring/grafana/provisioning/datasources/jaeger.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Jaeger
+    type: jaeger
+    access: proxy
+    url: http://jaeger:16686
+    isDefault: true
+    editable: false

--- a/infrastructure/monitoring/grafana/provisioning/datasources/victoriametrics.yml
+++ b/infrastructure/monitoring/grafana/provisioning/datasources/victoriametrics.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: VictoriaMetrics
+    type: prometheus
+    access: proxy
+    url: http://victoriametrics:8428
+    isDefault: false
+    editable: false

--- a/infrastructure/monitoring/otel-collector-config.yaml
+++ b/infrastructure/monitoring/otel-collector-config.yaml
@@ -1,0 +1,50 @@
+# masc-mcp OTel Collector — Prometheus 없이 Jaeger + VictoriaMetrics
+#
+# Context: RFC-0217 S4-2 이후 metrics는 OTLP push only.
+# Prometheus exporter는 제거하고:
+#   - traces → Jaeger
+#   - metrics → VictoriaMetrics (prometheusremotewrite)
+
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+processors:
+  batch:
+    timeout: 1s
+    send_batch_size: 1024
+
+exporters:
+  otlp/jaeger:
+    endpoint: jaeger:4317
+    tls:
+      insecure: true
+
+  prometheusremotewrite:
+    endpoint: http://victoriametrics:8428/api/v1/write
+    tls:
+      insecure: true
+    # No external_labels; service.name etc. come from OTLP resource attrs.
+
+  debug:
+    verbosity: detailed
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp/jaeger]
+
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [prometheusremotewrite]
+
+  telemetry:
+    logs:
+      level: warn


### PR DESCRIPTION
Add local observability stack without Prometheus.