### PR TITLE
fix(keeper): clarify tool_access and tool_denylist schema descriptions (#20081)

### DIFF
--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -93,7 +93,7 @@ let keeper_schemas : tool_schema list = [
         ]);
         ("tool_access",
           tool_access_schema
-            "Canonical tool candidate profile list, e.g. ['masc_status', 'tool_execute']. Runtime execution also applies descriptor availability, denylist, per-turn OAS allowlist, and eval gates.");
+            "Persisted tool candidate profiles for discovery. Does not alone grant execution; runtime applies descriptor availability, denylist, per-turn OAS policy, and eval gates.");
         ("tool_denylist", `Assoc [
           ("type", `String "array");
           ("items", `Assoc [("type", `String "string")]);
@@ -243,11 +243,11 @@ let keeper_schemas : tool_schema list = [
         ]);
         ("tool_access",
           tool_access_schema
-            "Canonical tool candidate profile list, e.g. ['masc_status', 'tool_execute']. Runtime execution also applies descriptor availability, denylist, per-turn OAS allowlist, and eval gates.");
+            "Persisted tool candidate profiles for discovery. Does not alone grant execution; runtime applies descriptor availability, denylist, per-turn OAS policy, and eval gates.");
         ("tool_denylist", `Assoc [
           ("type", `String "array");
           ("items", `Assoc [("type", `String "string")]);
-          ("description", `String "Tool names to remove after tool_access candidate profile resolution.");
+          ("description", `String "Execution removal layer after candidate discovery. Excludes matching tools from runtime execution.");
         ]);
       ]);
       ("required", `List [`String "name"]);

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -1553,6 +1553,54 @@ let test_keeper_schema_tool_access_rejects_string_value () =
   | Error _ -> ()
 ;;
 
+let get_schema_property_description schema name =
+  match schema with
+  | `Assoc fields ->
+    (match List.assoc_opt "properties" fields with
+     | Some (`Assoc props) ->
+       (match List.assoc_opt name props with
+        | Some (`Assoc prop_fields) ->
+          (match List.assoc_opt "description" prop_fields with
+           | Some (`String desc) -> Some desc
+           | _ -> None)
+        | _ -> None)
+     | _ -> None)
+  | _ -> None
+;;
+
+let test_keeper_schema_tool_access_description_no_allowlist () =
+  let schemas = Keeper_schema.keeper_schemas in
+  let check_schema tool_name =
+    match List.find_opt (fun s -> s.Masc_domain.name = tool_name) schemas with
+    | None -> Alcotest.failf "%s schema not found" tool_name
+    | Some schema ->
+      (match get_schema_property_description schema.Masc_domain.input_schema "tool_access" with
+       | None -> Alcotest.failf "%s: tool_access description missing" tool_name
+       | Some desc ->
+         if String_util.contains_substring desc "allowlist"
+         then Alcotest.failf "%s: tool_access description contains 'allowlist': %s" tool_name desc;
+         if not (String_util.contains_substring desc "candidate profiles for discovery")
+         then Alcotest.failf "%s: tool_access description missing expected text: %s" tool_name desc)
+  in
+  check_schema "masc_keeper_create_from_persona";
+  check_schema "masc_keeper_up"
+;;
+
+let test_keeper_schema_tool_denylist_description () =
+  let schemas = Keeper_schema.keeper_schemas in
+  let check_schema tool_name =
+    match List.find_opt (fun s -> s.Masc_domain.name = tool_name) schemas with
+    | None -> Alcotest.failf "%s schema not found" tool_name
+    | Some schema ->
+      (match get_schema_property_description schema.Masc_domain.input_schema "tool_denylist" with
+       | None -> Alcotest.failf "%s: tool_denylist description missing" tool_name
+       | Some desc ->
+         if not (String_util.contains_substring desc "Execution removal layer")
+         then Alcotest.failf "%s: tool_denylist description missing expected text: %s" tool_name desc)
+  in
+  check_schema "masc_keeper_up"
+;;
+
 (* ================================================================ *)
 (* Runner                                                            *)
 (* ================================================================ *)
@@ -1688,5 +1736,9 @@ let () =
         test_keeper_schema_tool_access_rejects_object;
       Alcotest.test_case "string value rejected" `Quick
         test_keeper_schema_tool_access_rejects_string_value;
+      Alcotest.test_case "description does not contain allowlist" `Quick
+        test_keeper_schema_tool_access_description_no_allowlist;
+      Alcotest.test_case "denylist description is execution removal layer" `Quick
+        test_keeper_schema_tool_denylist_description;
     ]);
   ]


### PR DESCRIPTION
## Summary

Closes #20081.

Keeper schema descriptions for `tool_access` still used "Canonical tool candidate profile list" and "allowlist" wording that overstates the static role of the field. Runtime execution is gated by descriptor availability, denylist, per-turn OAS policy, and eval gates — the persisted list alone does not grant access.

## Changes

- `lib/keeper/keeper_schema.ml`:
  - `tool_access` description (both `masc_keeper_create_from_persona` and `masc_keeper_up`): replaced "Canonical tool candidate profile list, e.g. ... Runtime execution also applies ... allowlist" with "Persisted tool candidate profiles for discovery. Does not alone grant execution; runtime applies ..."
  - `tool_denylist` description (`masc_keeper_up`): replaced "Tool names to remove after tool_access candidate profile resolution" with "Execution removal layer after candidate discovery. Excludes matching tools from runtime execution."

- `test/test_tool_input_validation.ml`:
  - Added `get_schema_property_description` helper to extract property descriptions from schema JSON.
  - Added `test_keeper_schema_tool_access_description_no_allowlist`: asserts both schemas' `tool_access` descriptions do not contain "allowlist" and contain "candidate profiles for discovery".
  - Added `test_keeper_schema_tool_denylist_description`: asserts `masc_keeper_up`'s `tool_denylist` description contains "Execution removal layer".

## Verification

```
dune build --root . test/test_tool_input_validation.exe
_build/default/test/test_tool_input_validation.exe test "keeper_schema_tool_access"
# 5 tests run, all passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)