### PR TITLE
refactor(keeper): remove attempt_watchdog_timeout_sec_opt and dead watchdog plumbing

### DIFF
--- a/lib/keeper/keeper_turn_runtime_budget.ml
+++ b/lib/keeper/keeper_turn_runtime_budget.ml
@@ -83,49 +83,6 @@ let degraded_retry_bypasses_slot_phase_guard
   | None ->
     false
 
-let reclassify_provider_timeout_for_attempt
-    ~(provider_timeout_budget : provider_timeout_budget option)
-    (err : Agent_sdk.Error.sdk_error) : Agent_sdk.Error.sdk_error =
-  match err, provider_timeout_budget with
-  | Agent_sdk.Error.Api (Timeout { message }), Some budget
-    when EC.is_structural_oas_timeout_message message ->
-      let estimated_remaining_after_timeout =
-        Float.max 0.0 (budget.remaining_turn_budget_sec -. budget.effective_timeout_sec)
-      in
-      Keeper_turn_driver.sdk_error_of_masc_internal_error
-        (Keeper_turn_driver.Provider_timeout
-           { budget_sec = budget.effective_timeout_sec
-           ; keeper_turn_timeout_sec = budget.keeper_turn_timeout_sec
-           ; estimated_input_tokens = budget.estimated_input_tokens
-           ; source = budget.source
-           ; remaining_turn_budget_sec = Some estimated_remaining_after_timeout
-           ; min_required_sec = min_provider_timeout_budget_sec
-           ; phase = "runtime_attempt_watchdog"
-           })
-  | _ -> err
-
-let attempt_watchdog_outer_turn_reserve_sec = 1.0
-
-let attempt_watchdog_timeout_sec
-    ~(remaining_turn_budget_s : float)
-    (provider_timeout_budget : provider_timeout_budget) : float =
-  let desired =
-    provider_timeout_budget.effective_timeout_sec +. provider_timeout_guard_sec
-  in
-  let cap_before_outer_timeout =
-    Float.max 0.001
-      (remaining_turn_budget_s -. attempt_watchdog_outer_turn_reserve_sec)
-  in
-  let floor =
-    Float.min min_provider_timeout_budget_sec cap_before_outer_timeout
-  in
-  Float.max floor (Float.min desired cap_before_outer_timeout)
-
-let attempt_watchdog_timeout_sec_opt
-    ~(remaining_turn_budget_s : float)
-    (provider_timeout_budget : provider_timeout_budget) : float option =
-  Some (attempt_watchdog_timeout_sec ~remaining_turn_budget_s provider_timeout_budget)
-
 type degraded_retry_budget_decision =
   | No_degraded_retry
   | Degraded_retry_slot_phase_exhausted of EC.degraded_retry

--- a/lib/keeper/keeper_turn_runtime_budget.mli
+++ b/lib/keeper/keeper_turn_runtime_budget.mli
@@ -89,30 +89,6 @@ val degraded_retry_slot_phase_budget_sec : float
 val degraded_retry_slot_phase_available :
   time_spent_in_turn_s:float -> bool
 
-val reclassify_provider_timeout_for_attempt :
-  provider_timeout_budget:provider_timeout_budget option ->
-  Agent_sdk.Error.sdk_error ->
-  Agent_sdk.Error.sdk_error
-(** Rewrap structural attempt watchdog timeouts as [Provider_timeout] when
-    the current attempt had an admitted provider-timeout budget. *)
-
-val attempt_watchdog_timeout_sec :
-  remaining_turn_budget_s:float ->
-  provider_timeout_budget ->
-  float
-(** Legacy wall-clock watchdog budget for a single runtime attempt.
-
-    Off-mode uses this after the OAS per-attempt budget plus the normal
-    finalization guard. Progress-based liveness modes return [None] from
-    [attempt_watchdog_timeout_sec_opt] so healthy active streams are not killed
-    by cumulative wall-clock elapsed. *)
-
-val attempt_watchdog_timeout_sec_opt :
-  remaining_turn_budget_s:float ->
-  provider_timeout_budget ->
-  float option
-(** Runtime-attempt wall-clock watchdog. Always returns [Some] with the
-    legacy per-attempt watchdog budget. *)
 
 type degraded_retry_budget_decision =
   | No_degraded_retry

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -27,14 +27,6 @@ val resolve_bounded_provider_timeout_budget_with_turn_budget
   -> provider_timeout_budget
 (** See [Keeper_turn_runtime_budget] for provider timeout planning semantics. *)
 
-(** Legacy per-attempt watchdog budget. Progress-based liveness modes return no
-    watchdog so healthy active streams are not killed by cumulative wall time;
-    the budget remains for off-mode tests. *)
-val attempt_watchdog_timeout_sec
-  :  remaining_turn_budget_s:float
-  -> provider_timeout_budget
-  -> float
-
 val allow_wall_clock_retry_budget_for_attempt
   :  is_retry:bool
   -> degraded_rotation_first_attempt:bool
@@ -44,15 +36,6 @@ val allow_wall_clock_retry_budget_for_attempt
 
 val degraded_retry_slot_phase_budget_sec : float
 val degraded_retry_slot_phase_available : time_spent_in_turn_s:float -> bool
-
-(** Reclassify a structural OAS timeout as [Provider_timeout] only when the
-    current attempt actually dispatched with a provider timeout budget. This
-    prevents a pre-retry turn-budget exhaustion from borrowing a stale
-    previous attempt budget and incorrectly rotating runtimes. *)
-val reclassify_provider_timeout_for_attempt
-  :  provider_timeout_budget:provider_timeout_budget option
-  -> Agent_sdk.Error.sdk_error
-  -> Agent_sdk.Error.sdk_error
 
 type degraded_retry_budget_decision =
   | No_degraded_retry

--- a/lib/keeper/keeper_unified_turn_attempt_watchdog.ml
+++ b/lib/keeper/keeper_unified_turn_attempt_watchdog.ml
@@ -1,6 +1,5 @@
 let dispatch
       ~clock:_clock
-      ~attempt_watchdog_s:_attempt_watchdog_s
       ~oas_timeout_s:_oas_timeout_s
       ~on_cancelled
       ~run

--- a/lib/keeper/keeper_unified_turn_attempt_watchdog.mli
+++ b/lib/keeper/keeper_unified_turn_attempt_watchdog.mli
@@ -13,10 +13,6 @@
       receipt + FSM transition, then re-raise so the outer cleanup
       handler observes the cancellation
 
-    [attempt_watchdog_s] and [oas_timeout_s] are retained in the call shape for
-    compatibility with the runtime-budget plumbing, but this module no longer
-    starts an [Eio.Time.with_timeout_exn] attempt watchdog.
-
     The Cancelled re-raise path is the outer catch for cancellations
     that escape the in-band receipt builder in
     [Keeper_agent_run.run_turn]: the inner Cancel handlers all
@@ -25,7 +21,6 @@
     timeline. *)
 val dispatch
   :  clock:_ Eio.Time.clock
-  -> attempt_watchdog_s:float option
   -> oas_timeout_s:float
   -> on_cancelled:(unit -> unit)
   -> run:(unit -> ('a, Agent_sdk.Error.sdk_error) result)

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -123,7 +123,6 @@ let run (ctx : ctx)
         ~run_generation
         ~is_retry
         ~oas_timeout_s
-        ~attempt_watchdog_s
     =
     last_execution := execution;
     Otel_genai.with_keeper_turn_span
@@ -153,7 +152,6 @@ let run (ctx : ctx)
            Keeper_turn_fsm.Streaming;
          Keeper_unified_turn_attempt_watchdog.dispatch
            ~clock
-           ~attempt_watchdog_s
            ~oas_timeout_s
            ~on_cancelled:(fun () ->
              record_streaming_cancelled_observation
@@ -280,18 +278,12 @@ let run (ctx : ctx)
       in
       attempt_provider_timeout_budget := Some provider_timeout_budget;
       last_provider_timeout_budget := Some provider_timeout_budget;
-      let attempt_watchdog_s =
-        attempt_watchdog_timeout_sec_opt
-          ~remaining_turn_budget_s:(remaining_turn_budget_s ())
-          provider_timeout_budget
-      in
       do_run
         ~execution
         ~run_meta
         ~run_generation
         ~is_retry
         ~oas_timeout_s:provider_timeout_budget.effective_timeout_sec
-        ~attempt_watchdog_s
     in
     match attempt_result with
     | Ok result ->

--- a/test/test_oas_timeout_budget_strike.ml
+++ b/test/test_oas_timeout_budget_strike.ml
@@ -149,68 +149,6 @@ let test_tls_handshake_internal_error_is_transient () =
     true
     (EC.is_auto_recoverable_turn_error err)
 
-let test_attempt_watchdog_timeout_reclassifies_as_provider_timeout () =
-  let budget : KCB.provider_timeout_budget =
-    { effective_timeout_sec = 555.0
-    ; adaptive_timeout_sec = 600.0
-    ; keeper_turn_timeout_sec = 600.0
-    ; remaining_turn_budget_sec = 571.0
-    ; estimated_input_tokens = 10_000
-    ; max_turns = 6
-    ; source = "turn_budget_capped"
-    }
-  in
-  let err =
-    Agent_sdk.Error.Api
-      (Timeout
-         { message =
-             "Turn wall-clock budget exhausted during runtime attempt \
-              (budget=555.0s, watchdog=570.0s)"
-         })
-  in
-  let reclassified =
-    KCB.reclassify_provider_timeout_for_attempt
-      ~provider_timeout_budget:(Some budget)
-      err
-  in
-  (match KTD.classify_masc_internal_error reclassified with
-   | Some (KTD.Provider_timeout timeout) ->
-     Alcotest.(check string)
-       "phase"
-       "runtime_attempt_watchdog"
-       timeout.phase;
-     Alcotest.(check (float 0.001))
-       "budget"
-       555.0
-       timeout.budget_sec
-   | Some other ->
-     Alcotest.failf
-       "expected Provider_timeout, got %s"
-       (Option.value
-          ~default:"<no summary>"
-          (KTD.summary_of_masc_internal_error other))
-   | None -> Alcotest.fail "expected structured Provider_timeout");
-  Alcotest.(check bool)
-    "provider timeout cycle failure is warn"
-    true
-    (EC.should_warn_keeper_cycle_failed reclassified)
-
-let test_attempt_watchdog_always_returns_some () =
-  let budget : KCB.provider_timeout_budget =
-    { effective_timeout_sec = 555.0
-    ; adaptive_timeout_sec = 600.0
-    ; keeper_turn_timeout_sec = 600.0
-    ; remaining_turn_budget_sec = 571.0
-    ; estimated_input_tokens = 10_000
-    ; max_turns = 6
-    ; source = "turn_budget_capped"
-    }
-  in
-  (match KCB.attempt_watchdog_timeout_sec_opt ~remaining_turn_budget_s:571.0 budget with
-   | Some actual ->
-     Alcotest.(check (float 0.001)) "watchdog is always present" 570.0 actual
-   | None -> Alcotest.fail "attempt watchdog should always return Some")
-
 let test_retry_timeout_budget_ignores_expired_outer_turn_budget () =
   let budget =
     KCB.resolve_bounded_provider_timeout_budget_with_turn_budget
@@ -400,14 +338,6 @@ let () =
           test_tool_retry_exhausted_preserves_keeper_liveness;
         Alcotest.test_case "TLS handshake internal error is transient" `Quick
           test_tls_handshake_internal_error_is_transient;
-        Alcotest.test_case
-          "attempt watchdog timeout reclassifies as provider timeout"
-          `Quick
-          test_attempt_watchdog_timeout_reclassifies_as_provider_timeout;
-        Alcotest.test_case
-          "attempt watchdog always returns Some after liveness removal"
-          `Quick
-          test_attempt_watchdog_always_returns_some;
         Alcotest.test_case
           "retry timeout budget ignores expired outer turn budget"
           `Quick


### PR DESCRIPTION
## Summary

The per-attempt wall-clock watchdog was already a no-op (`Keeper_unified_turn_attempt_watchdog.dispatch` ignores the timeout). Remove the dead plumbing:

- `attempt_watchdog_timeout_sec` / `attempt_watchdog_timeout_sec_opt`
- `attempt_watchdog_outer_turn_reserve_sec`
- `reclassify_provider_timeout_for_attempt` (no callers after watchdog removal)
- `~attempt_watchdog_s` parameter from `dispatch` and `do_run`
- Tests for the removed functions

## Verification

- `dune build --root .` passes
- `dune build @check --root .` passes

168 lines removed across 7 files.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>