### PR TITLE
feat(worktree): guard PR cleanup worktrees against concurrent reuse (#20361)

### DIFF
--- a/scripts/cleanup-merged-worktrees.sh
+++ b/scripts/cleanup-merged-worktrees.sh
@@ -50,6 +50,7 @@ skipped=0
 dirty=0
 nested=0
 active=0
+locked=0
 
 while read -r branch; do
   [ -z "$branch" ] && continue
@@ -76,6 +77,14 @@ while read -r branch; do
     continue
   fi
 
+  if worktree_cleanup_is_locked "$wt_path"; then
+    local owner
+    owner="$(cat "$wt_path/.masc-lock" 2>/dev/null || true)"
+    echo "LOCKED $wt_path (branch $branch) — skipped (held by $owner)"
+    locked=$((locked+1))
+    continue
+  fi
+
   if [ "$APPLY" -eq 1 ]; then
     if git worktree remove "$wt_path" 2>/dev/null; then
       echo "REMOVED $wt_path (branch $branch)"
@@ -94,8 +103,8 @@ done <<< "$MERGED_BRANCHES"
 if [ "$APPLY" -eq 1 ]; then
   git worktree prune
   echo ""
-  echo "Summary: removed=$removed skipped=$skipped dirty=$dirty nested=$nested active=$active"
+  echo "Summary: removed=$removed skipped=$skipped dirty=$dirty nested=$nested active=$active locked=$locked"
 else
   echo ""
-  echo "Summary: $removed candidates (dry run — pass --apply to remove; dirty=$dirty nested=$nested active=$active)"
+  echo "Summary: $removed candidates (dry run — pass --apply to remove; dirty=$dirty nested=$nested active=$active locked=$locked)"
 fi

--- a/scripts/lib/worktree-cleanup-guards.sh
+++ b/scripts/lib/worktree-cleanup-guards.sh
@@ -44,3 +44,14 @@ worktree_cleanup_is_runtime_referenced() {
   [ -n "$_WORKTREE_CLEANUP_RUNTIME_REFS" ] || return 1
   printf '%s\n' "$_WORKTREE_CLEANUP_RUNTIME_REFS" | grep -F -- "$wt_path" >/dev/null 2>&1
 }
+
+# Lock guard: skip worktrees held by a live process.
+# Sourced from scripts/lib/worktree-lock.sh.
+worktree_cleanup_is_locked() {
+  local wt_path="$1"
+  local lock_file="$wt_path/.masc-lock"
+  [ -f "$lock_file" ] || return 1
+  local pid
+  pid="$(awk '{print $NF}' "$lock_file" 2>/dev/null || true)"
+  [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null
+}

--- a/scripts/lib/worktree-lock.sh
+++ b/scripts/lib/worktree-lock.sh
@@ -1,0 +1,76 @@
+# Worktree concurrency lock primitives.
+#
+# Usage:
+#   source scripts/lib/worktree-lock.sh
+#   worktree_lock_acquire "/path/to/.worktrees/feature-x" "agent-name" || exit 1
+#   ... do work ...
+#   worktree_lock_release "/path/to/.worktrees/feature-x"
+#
+# A lock is a file at <worktree>/.masc-lock containing the agent name and PID.
+# Stale locks (PID no longer alive) are automatically reclaimed.
+
+worktree_lock_path() {
+  local wt_path="$1"
+  printf '%s/.masc-lock' "$wt_path"
+}
+
+worktree_lock_is_stale() {
+  local lock_file="$1"
+  local pid
+  pid="$(awk '{print $NF}' "$lock_file" 2>/dev/null || true)"
+  [[ -z "$pid" ]] && return 0
+  ! kill -0 "$pid" 2>/dev/null
+}
+
+worktree_lock_check() {
+  local wt_path="$1"
+  local lock_file
+  lock_file="$(worktree_lock_path "$wt_path")"
+  if [[ -f "$lock_file" ]]; then
+    if worktree_lock_is_stale "$lock_file"; then
+      return 0
+    fi
+    return 1
+  fi
+  return 0
+}
+
+worktree_lock_owner() {
+  local wt_path="$1"
+  local lock_file
+  lock_file="$(worktree_lock_path "$wt_path")"
+  if [[ -f "$lock_file" ]]; then
+    cat "$lock_file" 2>/dev/null || true
+  fi
+}
+
+worktree_lock_acquire() {
+  local wt_path="$1"
+  local agent_name="${2:-unknown}"
+  local lock_file
+  lock_file="$(worktree_lock_path "$wt_path")"
+
+  if [[ -f "$lock_file" ]]; then
+    if ! worktree_lock_is_stale "$lock_file"; then
+      return 1
+    fi
+  fi
+
+  printf '%s %d\n' "$agent_name" "$$" > "$lock_file"
+  return 0
+}
+
+worktree_lock_release() {
+  local wt_path="$1"
+  local lock_file
+  lock_file="$(worktree_lock_path "$wt_path")"
+  if [[ -f "$lock_file" ]]; then
+    local pid
+    pid="$(awk '{print $NF}' "$lock_file" 2>/dev/null || true)"
+    if [[ "$pid" == "$$" ]]; then
+      rm -f "$lock_file"
+      return 0
+    fi
+  fi
+  return 1
+}


### PR DESCRIPTION
## Summary

Add worktree concurrency lock primitives to prevent multiple agents from concurrently reusing the same PR cleanup worktree.

## Product impact

- Agents/scripts can now acquire a lock before using a worktree
- Cleanup scripts skip locked worktrees automatically
- Stale locks (dead PID) are reclaimed automatically

## Evidence

- New file: `scripts/lib/worktree-lock.sh`
- Updated: `scripts/lib/worktree-cleanup-guards.sh` (adds `worktree_cleanup_is_locked`)
- Updated: `scripts/cleanup-merged-worktrees.sh` (skips LOCKED worktrees)

## Direct evidence

```
schema_version: 1
direct_ratio: 3/3
provenance: direct
```

## Review evidence

- Self-reviewed: lock file format is "agent_name PID", stale detection uses kill -0
- Cleanup script correctly reports LOCKED status in summary

## Linked issue

Closes #20361