### PR TITLE
refactor(exec_policy): remove dead command_blocked_hint

### DIFF
--- a/lib/exec_policy/exec_policy.ml
+++ b/lib/exec_policy/exec_policy.ml
@@ -5,78 +5,12 @@
 
 module Paths = Exec_policy_paths
 module Log_sanitize = Exec_policy_log_sanitize
-module Command_syntax = Exec_policy_command_syntax
+
 module Mutation_classifier = Exec_policy_mutation_classifier
 module Exec_shell_gate = Masc_exec_command_gate.Shell_command_gate
 
 let resolve_path = Paths.resolve_path
 let validate_path = Paths.validate_path
-
-let command_blocked_hint name =
-  let looks_like_source_code s =
-    (match String.index_opt s '.' with
-     | Some i -> i > 0 && i < String.length s - 1
-     | None -> false)
-    || List.mem
-         s
-         [ "let"
-         ; "match"
-         ; "if"
-         ; "then"
-         ; "else"
-         ; "fun"
-         ; "rec"
-         ; "in"
-         ; "module"
-         ; "open"
-         ; "type"
-         ; "def"
-         ; "class"
-         ; "import"
-         ; "from"
-         ]
-  in
-  let alt =
-    match name with
-    | "sort" | "uniq" -> " Use rg or jq for filtering."
-    | "sed" | "awk" -> " Use Edit or Write for file changes."
-    | "find" -> " Use rg --files or Grep."
-    | "curl" | "wget" ->
-      " Use WebFetch to fetch page content, or WebSearch to find sources."
-    | "gh" ->
-      " Use Execute from a repo worktree for direct commands, or masc_board_post \
-       to escalate. Use git directly for repository/worktree/branch operations."
-    | "docker"
-    | "podman"
-    | "kubectl"
-    | "systemctl"
-    | "brew"
-    | "apt"
-    | "apt-get"
-    | "yum"
-    | "dnf" ->
-      Printf.sprintf
-        " '%s' operates on host / cluster state and is deliberately excluded from the \
-         keeper sandbox. If you need this operation, escalate to an operator via \
-         masc_board_post instead of retrying."
-        name
-    | "ssh" | "scp" | "rsync" | "ftp" | "sftp" | "nc" ->
-      Printf.sprintf
-        " '%s' is a network primitive and is not permitted. Keeper network access goes \
-         through WebSearch or WebFetch tools."
-        name
-    | _ when looks_like_source_code name ->
-      " This looks like source code, not a shell command - use Edit / Write / \
-       Read instead."
-    | _ -> ""
-  in
-  Printf.sprintf
-    "Command blocked: '%s' is not allowed. See \
-     keeper_tools_list for the exhaustive tool surface, and Read / Edit / \
-     Write for file operations.%s"
-    name
-    alt
-;;
 
 type block_reason =
   | Empty_command


### PR DESCRIPTION
## Summary

`command_blocked_hint`(65줄)은 `Command_not_allowed` variant가 `block_reason`에서 제거된 이후 호출자가 0인 dead function. `Command_syntax` module alias도 unreferenced.

## Changes

- `command_blocked_hint` 함수 제거 (65줄)
- `Command_syntax` unused module alias 제거

## Verification

```
dune build @check: exit 0 ✅
PPX safe_shell: 8/8 ✅
Shell command gate: 19/19 ✅
Keeper readonly hints: 3/3 ✅
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)