### PR TITLE
refactor(keeper): move Shell_ir_risk observability helpers into facade

### DIFF
--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -271,7 +271,7 @@ let handle_tool_execute_typed
             meta.name
             error
             (message_for_log reason)
-            (Masc_exec.Shell_ir_risk.typed_hit_of_ir ir)
+            (Keeper_tool_execute_shell_ir.typed_hit_of_ir ir)
             cmd_for_log;
           let deterministic_retry_fields =
             match deterministic_reason with
@@ -300,7 +300,7 @@ let handle_tool_execute_typed
         in
         let envelope = Keeper_tool_execute_shell_ir.classify ir in
         let typed_error_json msg = error_json ~fields:typed_error_fields msg in
-        if Masc_exec.Shell_ir_risk.is_destructive envelope
+        if Keeper_tool_execute_shell_ir.is_destructive envelope
         then
           blocked_result
             ~deterministic_reason:
@@ -421,9 +421,9 @@ let handle_tool_execute_typed
               (Keeper_types_profile_sandbox.sandbox_profile_to_string sandbox_profile)
               (Keeper_sandbox_exec_failure.status_label result.status)
               elapsed_ms
-              (Masc_exec.Shell_ir_risk.string_of_risk_class
-                 (Masc_exec.Shell_ir_risk.risk_class envelope))
-              (Masc_exec.Shell_ir_risk.typed_hit_of_ir ir);
+              (Keeper_tool_execute_shell_ir.string_of_risk_class
+                 (Keeper_tool_execute_shell_ir.risk_class envelope))
+              (Keeper_tool_execute_shell_ir.typed_hit_of_ir ir);
             let output =
               if String.equal result.stderr ""
               then result.stdout

--- a/lib/keeper_tooling/keeper_tool_execute_shell_ir.ml
+++ b/lib/keeper_tooling/keeper_tool_execute_shell_ir.ml
@@ -4,6 +4,11 @@ let classify ir =
   Masc_exec.Shell_ir_risk.classify (Masc_exec.Shell_ir_risk.undecided ir)
 ;;
 
+let is_destructive = Masc_exec.Shell_ir_risk.is_destructive
+let risk_class = Masc_exec.Shell_ir_risk.risk_class
+let typed_hit_of_ir = Masc_exec.Shell_ir_risk.typed_hit_of_ir
+let string_of_risk_class = Masc_exec.Shell_ir_risk.string_of_risk_class
+
 let lit text = Masc_exec.Shell_ir.Lit (text, Masc_exec.Shell_ir.default_meta)
 
 let env_bindings bindings = List.map (fun (key, value) -> key, lit value) bindings

--- a/lib/keeper_tooling/keeper_tool_execute_shell_ir.mli
+++ b/lib/keeper_tooling/keeper_tool_execute_shell_ir.mli
@@ -2,6 +2,17 @@ val classify :
   Masc_exec.Shell_ir.t ->
   Masc_exec.Shell_ir_risk.decided Masc_exec.Shell_ir_risk.decided_ir
 
+val is_destructive :
+  Masc_exec.Shell_ir_risk.decided Masc_exec.Shell_ir_risk.decided_ir -> bool
+
+val risk_class :
+  Masc_exec.Shell_ir_risk.decided Masc_exec.Shell_ir_risk.decided_ir ->
+  Masc_exec.Shell_ir_risk.risk_class
+
+val typed_hit_of_ir : Masc_exec.Shell_ir.t -> bool
+
+val string_of_risk_class : Masc_exec.Shell_ir_risk.risk_class -> string
+
 val with_cwd : raw:string -> cwd:string -> Masc_exec.Shell_ir.t -> Masc_exec.Shell_ir.t
 
 val simple :


### PR DESCRIPTION
Re-export is_destructive, risk_class, typed_hit_of_ir, and string_of_risk_class through Keeper_tool_execute_shell_ir so that keeper_tool_execute_runtime.ml no longer reaches directly into Masc_exec.Shell_ir_risk.

Keeper_tool_execute_shell_ir is the canonical facade between keeper execution runtime and the core Shell IR risk classifier. Narrowing the keeper->core dependency surface makes future refactors safer.

Build: dune build lib/keeper_tooling/ lib/keeper/ OK
Tests: test_shell_ir_effect_projection 8/8, test_shell_ir_risk 20/20 OK