### PR TITLE
chore(keeper): remove dead error_selected_model_raw field

### DIFF
--- a/lib/keeper/keeper_turn_driver_provider_attempt.ml
+++ b/lib/keeper/keeper_turn_driver_provider_attempt.ml
@@ -130,11 +130,6 @@ let client_capacity_full_decision ~capacity_key =
 let success_selected_model_raw candidate =
   Some (Runtime_candidate.model_health_key candidate)
 
-(* Error/rejected/exhausted observations intentionally leave the concrete
-   selected model absent. Downstream attribution uses candidate_models or the
-   runtime route for those outcomes. *)
-let error_selected_model_raw = None
-
 let health_error_kind label =
   Keeper_binding_health.error_kind_of_string label
 

--- a/lib/keeper/keeper_turn_driver_provider_attempt.mli
+++ b/lib/keeper/keeper_turn_driver_provider_attempt.mli
@@ -66,7 +66,6 @@ val client_capacity_full_decision :
 val success_selected_model_raw :
   Runtime_candidate.t -> string option
 
-val error_selected_model_raw : string option
 val health_error_kind : string -> Keeper_binding_health.error_kind
 
 val record_candidate_health_success :

--- a/lib/keeper/keeper_turn_driver_try_runtime.ml
+++ b/lib/keeper/keeper_turn_driver_try_runtime.ml
@@ -12,7 +12,6 @@ type try_runtime_ctx =
   ; name : string
   ; candidate_count : int
   ; configured_labels : string list
-  ; error_selected_model_raw : string option
   ; capture : Runtime_observation.runtime_metrics_capture
   ; runtime_strategy_name_ref : string option ref
   ; try_provider_ctx : Keeper_turn_driver_try_provider.try_provider_ctx
@@ -131,7 +130,6 @@ let run
     ( pre_dispatch_required_tool_rejections_rev
     , ctx.candidate_count
     , ctx.configured_labels
-    , ctx.error_selected_model_raw
     , ctx.capture
     , ctx.runtime_mcp_policy
     , ctx.tools


### PR DESCRIPTION
Remove error_selected_model_raw — a dead field that was always None. PR #20480 tried to promote this as model_id in Capacity_backpressure, but the source is hardcoded None with zero consumers. dune build @check passes.