### PR TITLE
refactor(exec_core): reuse envelope.is_destructive instead of reparsing

### DIFF
--- a/lib/exec_core.ml
+++ b/lib/exec_core.ml
@@ -336,7 +336,7 @@ let classify_command_of_ir ir =
     Masc_exec.Shell_ir_risk.classify (Masc_exec.Shell_ir_risk.undecided ir)
   in
   let risk_class = envelope.Masc_exec.Shell_ir_risk.risk in
-  let is_destructive = Exec_policy.is_destructive_bash_operation ir in
+  let is_destructive = Masc_exec.Shell_ir_risk.is_destructive envelope in
   let family =
     match first_effective_stage ir with
     | Some stage -> family_of_stage ~risk_class stage


### PR DESCRIPTION
classify_command_of_ir already obtains a Shell_ir_risk envelope via classify/undecided. Rather than calling Exec_policy.is_destructive_bash_operation (which re-flattens the IR to a word list and rescans it), read the already-computed is_destructive bit directly from the envelope.

This removes one redundant string-scan path and tightens the coupling: exec_core trusts the core classifier rather than independently reparsing.

- dune build lib/exec_core.ml OK
- test_shell_ir_effect_projection 8/8 OK