### PR TITLE
refactor(exec_core): remove dead code and unused mli exports

### DIFF
--- a/lib/exec_core.ml
+++ b/lib/exec_core.ml
@@ -46,13 +46,6 @@ type validator_stage =
   | Probe_search
   | Allowed
 
-let validator_stage_to_string = function
-  | Probe_task_state -> "probe_task_state"
-  | Probe_http -> "probe_http"
-  | Probe_search -> "probe_search"
-  | Allowed -> "allowed"
-;;
-
 type artifact_policy =
   | Inline_only
   | Persist_if_large

--- a/lib/exec_core.mli
+++ b/lib/exec_core.mli
@@ -105,18 +105,11 @@ type exec_env_snapshot = {
   project_name : string option;
 }
 
-val string_of_project_kind : project_kind -> string
-val detect_project_kind : string -> project_kind
 val snapshot_env : cwd:string -> exec_env_snapshot
-val env_snapshot_to_json : exec_env_snapshot -> Yojson.Safe.t
 
 val classify_command_of_ir : Masc_exec.Shell_ir.t -> classification
 (** IR-based classification. Direct consumers of parsed Shell IR
     should use this. *)
-
-val default_classification : classification
-(** Constant classification used when no IR is available:
-    [{ family = Unknown; reversibility = Read_only; risk = Low; write_intent = false }]. *)
 
 val classification_to_json : classification -> Yojson.Safe.t
 
@@ -127,8 +120,6 @@ val semantic_status_of_process :
   Unix.process_status ->
   semantic_status
 
-val string_of_retryability : retryability -> string
-
 val build_process_outcome :
   classification:classification ->
   artifact_policy:artifact_policy ->
@@ -138,24 +129,6 @@ val build_process_outcome :
   status:Unix.process_status ->
   output:string ->
   outcome
-
-val build_blocked_outcome :
-  ?classification:classification ->
-  cmd:string ->
-  error:string ->
-  reason:string ->
-  ?hint:string ->
-  ?alternatives:string list ->
-  ?retryability:retryability ->
-  ?diag:diagnosis option ->
-  unit ->
-  outcome
-
-val outcome_to_json :
-  ?extra:(string * Yojson.Safe.t) list ->
-  ?env_snapshot:exec_env_snapshot option ->
-  outcome ->
-  Yojson.Safe.t
 
 val process_result_json :
   ?artifact_policy:artifact_policy ->


### PR DESCRIPTION
- Delete validator_stage_to_string (5 lines): defined but never called anywhere in the module or externally.
- Remove 8 unused mli exports that are only consumed by internal helper chains (process_result_json / blocked_result_json / snapshot_env): string_of_project_kind, detect_project_kind, env_snapshot_to_json, default_classification, build_process_outcome, build_blocked_outcome, outcome_to_json, string_of_retryability.

These shrink the public surface to what is actually exercised by keeper callers.

- dune build lib/exec_core.ml OK
- test_shell_ir_effect_projection 8/8 OK