### PR TITLE
fix(keeper): align .mli signatures with ?home_ground parameter

### DIFF
--- a/lib/keeper/keeper_context_runtime.mli
+++ b/lib/keeper/keeper_context_runtime.mli
@@ -304,6 +304,7 @@ val build_keeper_system_prompt
   -> ?persona_extended:string
   -> ?keeper_name:string
   -> ?active_goals:(string * string * string) list
+  -> ?home_ground:string
   -> unit
   -> string
 

--- a/lib/keeper/keeper_execution.mli
+++ b/lib/keeper/keeper_execution.mli
@@ -66,6 +66,7 @@ val build_keeper_system_prompt :
   ?persona_extended:string ->
   ?keeper_name:string ->
   ?active_goals:(string * string * string) list ->
+  ?home_ground:string ->
   unit ->
   string
 

--- a/lib/keeper/keeper_prompt.mli
+++ b/lib/keeper/keeper_prompt.mli
@@ -40,8 +40,8 @@ val build_keeper_system_prompt :
   instructions:string ->
   ?persona_extended:string ->
   ?keeper_name:string ->
-  ?home_ground:string ->
   ?active_goals:(string * string * string) list ->
+  ?home_ground:string ->
   unit ->
   string
 


### PR DESCRIPTION
PR #20485 added ?home_ground to keeper_prompt.ml but left 3 .mli files out of sync: keeper_prompt.mli had wrong label order (?home_ground before ?active_goals), keeper_execution.mli and keeper_context_runtime.mli were missing ?home_ground entirely. dune build @check passes.