### PR TITLE
docs: fix boundary matrix stale refs after #20491

### DIFF
--- a/docs/TOML-RELOAD-MATRIX.md
+++ b/docs/TOML-RELOAD-MATRIX.md
@@ -31,7 +31,7 @@ The key distinction is:
 | File | Purpose | Load point | Reload trigger | Reload class | Notes |
 | --- | --- | --- | --- | --- | --- |
 | `<base_path>/.masc/config/runtime.toml` | startup env seeding for `MASC_KEEPER_*` knobs | server bootstrap before `Env_config_keeper` consumers initialize | none | `boot_static` | values are recorded in a process-local boot override store; edits require restart |
-| `<resolved-config-root>/tool_policy.toml` | keeper tool group policy | server bootstrap via `init_policy_config` | none | `boot_static` | groups are stored in process memory once loaded |
+| ~~`<resolved-config-root>/tool_policy.toml`~~ | ~~keeper tool group policy~~ | ~~deleted~~ | — | — | Loader (`keeper_tool_policy_config.ml`) removed. Tool access is descriptor/registry-driven. |
 | `<resolved-config-root>/keepers/*.toml` | declarative keeper profile defaults | keeper create/up, explicit keeper operations, supervisor reconcile | next supervisor sweep or next keeper create/up | `sweep_dynamic` | running keepers re-sync declarative fields; no standalone file watcher |
 | `<resolved-config-root>/runtime.toml` | runtime catalog source | model resolve path in OAS/MASC (rendered in memory) | next resolve / next turn | `request_dynamic` | invalid TOML blocks runtime load; `runtime.json` is retired |
 
@@ -51,17 +51,11 @@ Operational meaning:
 - This file is a startup default injector, not a live runtime tuning plane.
 - If live tuning is needed, the correct target is `Runtime_params`.
 
-### `tool_policy.toml`
+### `tool_policy.toml` (retired)
 
-- Loaded once by
-  [`Keeper_tool_policy.init_policy_config`](../lib/keeper/keeper_tool_policy.ml)
-- Resolved from the active config root by
-  [`keeper_tool_policy_config.ml`](../lib/keeper/keeper_tool_policy_config.ml)
-
-Operational meaning:
-
-- Editing this file changes policy for the next process boot.
-- There is no in-process policy reload path today.
+- **Deleted**: `keeper_tool_policy_config.ml` and its TOML loader were removed.
+  Tool access is now descriptor/registry-driven with denylist filtering only.
+- The `config/tool_policy.toml` file is no longer read at boot.
 
 ### `keepers/*.toml`
 

--- a/docs/design/keeper-tool-boundary-matrix.md
+++ b/docs/design/keeper-tool-boundary-matrix.md
@@ -167,8 +167,6 @@ Each path below must appear exactly once and use one owner from the table above.
 - `lib/keeper/keeper_tool_path_validation.mli` - tool-surface-policy
 - `lib/keeper/keeper_tool_persona_audit.ml` - tool-surface-policy
 - `lib/keeper/keeper_tool_persona_audit.mli` - tool-surface-policy
-- `lib/keeper/keeper_tool_policy_config.ml` - tool-surface-policy
-- `lib/keeper/keeper_tool_policy_config.mli` - tool-surface-policy
 - `lib/keeper/keeper_tool_policy.ml` - tool-surface-policy
 - `lib/keeper/keeper_tool_policy.mli` - tool-surface-policy
 - `lib/keeper/keeper_tool_progress.ml` - tool-surface-policy


### PR DESCRIPTION
## Summary

Follow-up to #20491 — the doc fix removing stale `keeper_tool_policy_config` references from boundary matrices was not included in the squash merge.

This caused main CI to fail on `OCaml Structure Ratchet` (keeper-tool-boundary-matrix audit).

## Changes

- Remove deleted `lib/keeper/keeper_tool_policy_config.ml{,i}` from `docs/design/keeper-tool-boundary-matrix.md`
- Mark `tool_policy.toml` as retired in `docs/TOML-RELOAD-MATRIX.md`

## Verification

- `scripts/audit-keeper-tool-boundary-matrix.sh` passes locally
- No code changes; docs only

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>