### PR TITLE
feat(keeper): add keeper_name/model_id to Capacity_backpressure (#18321)

### DIFF
--- a/lib/keeper/keeper_turn_driver_try_runtime.ml
+++ b/lib/keeper/keeper_turn_driver_try_runtime.ml
@@ -53,8 +53,42 @@ let http_status_of_http_error = function
   | Some (Llm_provider.Http_client.HttpError { code; _ }) -> Some code
   | _ -> None
 
-let sdk_error_of_exhausted last_err =
-  Agent_sdk.Error.Internal (Runtime_attempt_fsm.to_user_message last_err)
+let capacity_backpressure_of_http_error ~ctx ~source detail retry_after =
+  Keeper_internal_error.sdk_error_of_masc_internal_error
+    (Keeper_internal_error.Capacity_backpressure
+       { runtime_id = ctx.error_runtime_id
+       ; keeper_name =
+           (let name = String.trim ctx.keeper_name in
+            if String.equal name "" then None else Some name)
+       ; model_id = ctx.error_selected_model_raw
+       ; source
+       ; detail
+       ; retry_after
+       })
+
+let sdk_error_of_exhausted ~ctx last_err =
+  match last_err with
+  | Some
+      (Llm_provider.Http_client.ProviderFailure
+         { kind =
+             Llm_provider.Http_client.Capacity_exhausted { retry_after; _ }
+         ; message
+         }) ->
+    capacity_backpressure_of_http_error ~ctx ~source:Provider_capacity message
+      (match retry_after with
+       | Some s -> Keeper_internal_error.Explicit s
+       | None ->
+         Keeper_internal_error.Synthetic_default
+           Keeper_binding_health_config.default_capacity_backpressure_backoff_sec)
+  | Some
+      (Llm_provider.Http_client.NetworkError
+         { kind = Llm_provider.Http_client.Local_resource_exhaustion; message
+         }) ->
+    capacity_backpressure_of_http_error ~ctx ~source:Client_capacity message
+      (Keeper_internal_error.Synthetic_default
+         Keeper_binding_health_config.default_capacity_backpressure_backoff_sec)
+  | _ ->
+    Agent_sdk.Error.Internal (Runtime_attempt_fsm.to_user_message last_err)
 
 let maybe_mark_provider_attempt_started ctx =
   match ctx.base_path, String.trim ctx.keeper_name with
@@ -147,7 +181,7 @@ let run
     , ctx.turn_deadline )
   in
   let rec loop resume_checkpoint last_err = function
-    | [] -> Error (sdk_error_of_exhausted last_err)
+    | [] -> Error (sdk_error_of_exhausted ~ctx last_err)
     | candidate :: rest ->
       let is_last = rest = [] in
       maybe_mark_provider_attempt_started ctx;
@@ -180,7 +214,7 @@ let run
            Some (Llm_provider.Http_client.AcceptRejected { reason })
          in
          if is_last
-         then Error (sdk_error_of_exhausted last_err)
+         then Error (sdk_error_of_exhausted ~ctx last_err)
          else loop checkpoint_after last_err rest
        | Error err ->
          Keeper_turn_driver_provider_attempt.record_candidate_health_error
@@ -196,8 +230,8 @@ let run
            loop checkpoint_after (Some err) rest
          | Some err ->
            if is_last
-           then Error (sdk_error_of_exhausted (Some err))
-           else Error (sdk_error_of_exhausted (Some err))
+           then Error (sdk_error_of_exhausted ~ctx (Some err))
+           else Error (sdk_error_of_exhausted ~ctx (Some err))
          | None ->
            if is_last then Error err else loop checkpoint_after last_err rest)
   in

--- a/lib/keeper_runtime/keeper_internal_error.ml
+++ b/lib/keeper_runtime/keeper_internal_error.ml
@@ -108,6 +108,8 @@ type masc_internal_error =
     }
   | Capacity_backpressure of {
       runtime_id : string;
+      keeper_name : string option;
+      model_id : string option;
       source : capacity_backpressure_source;
       detail : string;
       retry_after : capacity_retry_after;
@@ -217,7 +219,7 @@ let masc_internal_error_to_json = function
         ("runtime_id", `String runtime_id);
         ("reason", runtime_exhaustion_reason_to_json reason);
       ]
-  | Capacity_backpressure { runtime_id; source; detail; retry_after } ->
+  | Capacity_backpressure { runtime_id; keeper_name; model_id; source; detail; retry_after } ->
     let runtime_id = runtime_id_to_string runtime_id in
     let retry_after_fields =
       match retry_after with
@@ -227,6 +229,11 @@ let masc_internal_error_to_json = function
         [ ("retry_after_sec", `Float s); ("retry_after_synthetic", `Bool true) ]
       | No_retry_hint -> [ ("retry_after_sec", `Null) ]
     in
+    let optional_fields =
+      List.filter_map
+        (fun (k, v) -> Option.map (fun s -> (k, `String s)) v)
+        [ ("keeper_name", keeper_name); ("model_id", model_id) ]
+    in
     `Assoc
       ([
          ("kind", `String "capacity_backpressure");
@@ -234,6 +241,7 @@ let masc_internal_error_to_json = function
          ("source", `String (capacity_backpressure_source_to_string source));
          ("detail", `String detail);
        ]
+      @ optional_fields
       @ retry_after_fields)
   | Resumable_cli_session { runtime_id; detail; exit_code } ->
     let runtime_id = runtime_id_to_string runtime_id in
@@ -342,7 +350,7 @@ let summarize_list ?(empty = "none") values =
   | _ -> String.concat ", " values
 
 let summary_of_masc_internal_error = function
-  | Capacity_backpressure { runtime_id; source; detail; retry_after } ->
+  | Capacity_backpressure { runtime_id; keeper_name; model_id; source; detail; retry_after } ->
       let retry_after_suffix =
         match retry_after with
         | Explicit value -> Printf.sprintf "; retry_after=%.1fs" value
@@ -350,13 +358,21 @@ let summary_of_masc_internal_error = function
           Printf.sprintf "; retry_after=%.1fs (synthetic)" value
         | No_retry_hint -> ""
       in
+      let ctx_suffix =
+        match keeper_name, model_id with
+        | Some k, Some m -> Printf.sprintf "; keeper=%s; model=%s" k m
+        | Some k, None -> Printf.sprintf "; keeper=%s" k
+        | None, Some m -> Printf.sprintf "; model=%s" m
+        | None, None -> ""
+      in
       Some
         (Printf.sprintf
-           "Capacity backpressure blocked runtime %s; source=%s; detail=%s%s"
+           "Capacity backpressure blocked runtime %s; source=%s; detail=%s%s%s"
            (runtime_id_to_string runtime_id)
            (capacity_backpressure_source_to_string source)
            detail
-           retry_after_suffix)
+           retry_after_suffix
+           ctx_suffix)
   | Provider_timeout
       {
         budget_sec;
@@ -499,9 +515,11 @@ let parse_masc_internal_error_json (json : Yojson.Safe.t) :
                  | Some s when retry_after_synthetic -> Synthetic_default s
                  | Some s -> Explicit s
                in
+               let keeper_name = string_opt_of_assoc "keeper_name" json in
+               let model_id = string_opt_of_assoc "model_id" json in
                Some
                  (Capacity_backpressure
-                    { runtime_id; source; detail; retry_after })
+                    { runtime_id; keeper_name; model_id; source; detail; retry_after })
              | None -> None)
           | _ -> None)
       | Some (`String "resumable_cli_session") -> (


### PR DESCRIPTION
## Summary
- `Capacity_backpressure` variant now carries `keeper_name` and `model_id`
- Live construction path (`sdk_error_of_exhausted`) produces typed `[masc_oas_error]` JSON instead of plain strings when capacity exhaustion occurs

## Changes
- `lib/keeper/keeper_turn_driver_try_runtime.ml`: wire `keeper_name` and `model_id` into `capacity_backpressure_of_http_error`
- `lib/keeper_runtime/keeper_internal_error.ml`: extend `Capacity_backpressure` record with `keeper_name` and `model_id` fields

## Test plan
- [ ] `dune build @check` passes
- [ ] Existing tests compile

Closes #18321

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>