### PR TITLE
refactor(keeper): remove worktree_path field and active_worktrees status output

### DIFF
--- a/lib/keeper/keeper_runtime_contract.ml
+++ b/lib/keeper/keeper_runtime_contract.ml
@@ -279,7 +279,6 @@ let action_radius_json ~tool_name ~input ~success ~duration_ms ?error
         "path";
         "file_path";
         "repo_path";
-        "worktree_path";
         "cwd";
       ]
       input

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -1005,20 +1005,6 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
                  (* Last 10 PRs, most recent first *)
                  `List (List.take 10 (List.rev entries))
                with Sys_error _ -> `List []);
-             ("active_worktrees",
-               let worktrees_dir = Filename.concat config.base_path ".worktrees" in
-               try
-                 let entries = Sys.readdir worktrees_dir |> Array.to_list in
-                 let keeper_prefix = Keeper_alerting_path.sanitize_keeper_name m.name in
-                 let matching = List.filter (fun name ->
-                   String.starts_with ~prefix:(keeper_prefix ^ "-") name
-                   || String.starts_with ~prefix:(keeper_prefix ^ "/") name
-                   || name = keeper_prefix) entries in
-                 `List (List.map (fun name -> `Assoc [
-                   "name", `String name;
-                   "path", `String (Filename.concat ".worktrees" name);
-                 ]) matching)
-               with Sys_error _ -> `List []);
            ]);
          ]) in
          let response = Yojson.Safe.pretty_to_string json in


### PR DESCRIPTION
## Problem

Remaining code-level worktree references that are not core path-classification concerns.

## Change

- Remove `"worktree_path"` from tool input field aliases in `keeper_runtime_contract`. Keepers should use `"path"` or `"cwd"` like any other directory.

- Remove `"active_worktrees"` from `keeper_status_detail` JSON output. Worktree presence is not a code-level concern; if needed it belongs in prompts or scripts, not in hardcoded status fields.

## Rationale

Code-level information and prompt/script-level information are different.
Playground already provides individual space; worktree is a git tool that keepers use when they choose to.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
🤖 Generated with [Claude Code](https://claude.com/claude-code)
