### PR TITLE
feat(dashboard): OAS event pagination and OTel link

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -2646,6 +2646,8 @@ export type TelemetryResponse = {
   query?: Record<string, unknown>
   count: number
   total_matching_entries?: number
+  offset?: number
+  has_more?: boolean
   truncated?: boolean
   entries: TelemetryEntry[]
 }
@@ -2735,6 +2737,8 @@ function decodeTelemetryResponse(raw: unknown): TelemetryResponse | null {
     query: isRecord(raw.query) ? raw.query : undefined,
     count: asNumber(raw.count, 0),
     total_matching_entries: asNumber(raw.total_matching_entries, asNumber(raw.count, 0)),
+    offset: asNumber(raw.offset, 0),
+    has_more: asBoolean(raw.has_more, false),
     truncated: asBoolean(raw.truncated, false),
     entries: asRecordArray(raw.entries)
       .map(decodeTelemetryEntry)
@@ -2823,6 +2827,7 @@ export function fetchTelemetry(opts?: {
   since_ms?: number
   until_ms?: number
   n?: number
+  offset?: number
   signal?: AbortSignal
 }): Promise<TelemetryResponse> {
   const params = new URLSearchParams()
@@ -2834,6 +2839,7 @@ export function fetchTelemetry(opts?: {
   if (typeof opts?.since_ms === 'number') params.set('since_ms', String(opts.since_ms))
   if (typeof opts?.until_ms === 'number') params.set('until_ms', String(opts.until_ms))
   if (typeof opts?.n === 'number') params.set('n', String(opts.n))
+  if (typeof opts?.offset === 'number') params.set('offset', String(opts.offset))
   const qs = params.toString()
   return get<Record<string, unknown>>(`/api/v1/dashboard/telemetry${qs ? '?' + qs : ''}`, { signal: opts?.signal })
     .then((raw) => {

--- a/dashboard/src/components/oas-health-chip.ts
+++ b/dashboard/src/components/oas-health-chip.ts
@@ -2,8 +2,9 @@
 // Consumes oasHealthSummary computed signal (previously dead).
 
 import { html } from 'htm/preact'
-import { useComputed } from '@preact/signals'
+import { useComputed, useSignal } from '@preact/signals'
 import { oasHealthSummary, oasAgentEvents, oasKeeperSnapshots } from '../store'
+import { loadMoreOasEvents } from '../oas-runtime-store'
 import { SectionCard } from './common/card'
 import { StatTile } from './common/stat-tile'
 import { EmptyState } from './common/feedback-state'
@@ -105,6 +106,17 @@ export function OasHealthChip() {
     const tick = summary.value.lastKeeperTick
     return tick == null || Date.now() - tick > STALE_MS
   })
+  const isLoadingMore = useSignal(false)
+
+  async function handleLoadMore() {
+    if (isLoadingMore.value) return
+    isLoadingMore.value = true
+    try {
+      await loadMoreOasEvents()
+    } finally {
+      isLoadingMore.value = false
+    }
+  }
 
   if (summary.value.replayTotalMatchingEvents === 0) {
     return html`
@@ -191,6 +203,15 @@ export function OasHealthChip() {
                   </li>
                 `)}
               </ul>
+              ${summary.value.hasMore ? html`
+                <button
+                  class="mt-2 text-2xs text-[var(--color-fg-muted)] hover:text-[var(--color-fg-primary)] underline disabled:opacity-50"
+                  onClick=${handleLoadMore}
+                  disabled=${isLoadingMore.value}
+                >
+                  ${isLoadingMore.value ? '불러오는 중...' : '더 보기'}
+                </button>
+              ` : null}
             </div>
           ` : null}
           ${recentKeepers.value.length > 0 ? html`
@@ -215,6 +236,16 @@ export function OasHealthChip() {
           ` : null}
         </div>
       ` : null}
+      <div class="mt-2 text-right">
+        <a
+          href="http://127.0.0.1:16686"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-3xs text-[var(--color-fg-muted)] hover:text-[var(--color-fg-primary)] underline"
+        >
+          OpenTelemetry에서 보기 →
+        </a>
+      </div>
     <//>
   `
 }

--- a/dashboard/src/oas-runtime-store.ts
+++ b/dashboard/src/oas-runtime-store.ts
@@ -5,6 +5,7 @@ import { fetchTelemetry, type TelemetryEntry } from './api/dashboard'
 import { OAS_TELEMETRY_REPLAY_LIMIT } from './config/constants'
 import {
   oasTotalEvents,
+  oasAgentEvents,
   noteOasReplayWindow,
   pushOasAgentEvent,
   recordOasError,
@@ -606,6 +607,17 @@ export function hydrateOasRuntimeFromTelemetryEntries(entries: TelemetryEntry[])
   })
 }
 
+export function appendOasRuntimeFromTelemetryEntries(entries: TelemetryEntry[]): void {
+  const ordered = [...entries].sort((a, b) => {
+    const left = coerceOasRuntimeEnvelope(a)
+    const right = coerceOasRuntimeEnvelope(b)
+    return (left ? (eventReportedUnixSeconds(left) ?? 0) : 0) - (right ? (eventReportedUnixSeconds(right) ?? 0) : 0)
+  })
+  for (const entry of ordered) {
+    applyOasRuntimeEvent(entry, { origin: 'replay' })
+  }
+}
+
 export async function replayOasRuntimeTelemetry(signal?: AbortSignal): Promise<void> {
   const generation = ++replayGeneration
   const response = await fetchTelemetry({
@@ -618,6 +630,22 @@ export async function replayOasRuntimeTelemetry(signal?: AbortSignal): Promise<v
   noteOasReplayWindow({
     loadedEvents: oasTotalEvents.value,
     totalMatchingEvents: response.total_matching_entries ?? response.count,
-    truncated: response.truncated ?? false,
+    truncated: response.has_more ?? response.truncated ?? false,
+  })
+}
+
+export async function loadMoreOasEvents(signal?: AbortSignal): Promise<void> {
+  const currentOffset = oasAgentEvents.value.length
+  const response = await fetchTelemetry({
+    source: 'oas_event',
+    n: OAS_TELEMETRY_REPLAY_LIMIT,
+    offset: currentOffset,
+    signal,
+  })
+  appendOasRuntimeFromTelemetryEntries(response.entries)
+  noteOasReplayWindow({
+    loadedEvents: oasTotalEvents.value,
+    totalMatchingEvents: response.total_matching_entries ?? response.count,
+    truncated: response.has_more ?? response.truncated ?? false,
   })
 }

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -434,6 +434,7 @@ export const oasHealthSummary: ReadonlySignal<OasHealthSummary> = computed(() =>
   replayLoadedEvents: oasReplayLoadedEvents.value,
   replayTotalMatchingEvents: oasReplayTotalMatchingEvents.value,
   replayTruncated: oasReplayTruncated.value,
+  hasMore: oasReplayTruncated.value,
   totalLlmCalls: oasTotalLlmCalls.value,
   totalErrors: oasTotalErrors.value,
   lastLlmCallTs: oasLastLlmCallTs.value,

--- a/dashboard/src/types/oas.ts
+++ b/dashboard/src/types/oas.ts
@@ -92,6 +92,7 @@ export interface OasHealthSummary {
   replayLoadedEvents: number
   replayTotalMatchingEvents: number
   replayTruncated: boolean
+  hasMore: boolean
   totalLlmCalls: number
   totalErrors: number
   lastLlmCallTs: number | null

--- a/lib/dated_jsonl/dated_jsonl.ml
+++ b/lib/dated_jsonl/dated_jsonl.ml
@@ -325,9 +325,10 @@ let append t json =
 
 let set_append_guard guard = Atomic.set append_guard guard
 
-let read_recent t n =
+let read_recent ?(offset=0) t n =
   if n <= 0 then []
   else begin
+    let skip = ref offset in
     let collected = ref [] in
     let count = ref 0 in
     let months = list_month_dirs t.base_dir in
@@ -339,17 +340,20 @@ let read_recent t n =
          List.iter (fun d ->
            if !count >= n then raise_notrace Done;
            let path = Filename.concat month_path d in
-           let remaining = n - !count in
-           let lines = load_tail_lines path ~max_lines:remaining in
+           let need = n - !count + !skip in
+           let lines = load_tail_lines path ~max_lines:need in
            let rev_lines = List.rev lines in
            List.iter (fun line ->
-             if !count < n then begin
-               (try
-                  let json = Yojson.Safe.from_string line in
+             if !count >= n then raise_notrace Done;
+             (try
+                let json = Yojson.Safe.from_string line in
+                if !skip > 0 then
+                  decr skip
+                else begin
                   collected := json :: !collected;
                   incr count
-                with Yojson.Json_error _ -> ())
-             end
+                end
+              with Yojson.Json_error _ -> ())
            ) rev_lines
          ) days
        ) months
@@ -357,9 +361,10 @@ let read_recent t n =
     !collected
   end
 
-let read_recent_lines t n =
+let read_recent_lines ?(offset=0) t n =
   if n <= 0 then []
   else begin
+    let skip = ref offset in
     let collected = ref [] in
     let count = ref 0 in
     let months = list_month_dirs t.base_dir in
@@ -371,11 +376,14 @@ let read_recent_lines t n =
          List.iter (fun d ->
            if !count >= n then raise_notrace Done;
            let path = Filename.concat month_path d in
-           let remaining = n - !count in
-           let lines = load_tail_lines path ~max_lines:remaining in
+           let need = n - !count + !skip in
+           let lines = load_tail_lines path ~max_lines:need in
            let rev_lines = List.rev lines in
            List.iter (fun line ->
-             if !count < n then begin
+             if !count >= n then raise_notrace Done;
+             if !skip > 0 then
+               decr skip
+             else begin
                collected := line :: !collected;
                incr count
              end

--- a/lib/dated_jsonl/dated_jsonl.mli
+++ b/lib/dated_jsonl/dated_jsonl.mli
@@ -35,11 +35,12 @@ val set_append_guard : ((unit -> unit) -> unit) -> unit
     runtimes can install resource accounting/backpressure without making this
     low-level storage library depend on those policy modules. *)
 
-val read_recent : t -> int -> Yojson.Safe.t list
-(** [read_recent t n] returns the newest [n] entries in chronological order
-    (oldest first).  Scans day-files from newest to oldest, stops early. *)
+val read_recent : ?offset:int -> t -> int -> Yojson.Safe.t list
+(** [read_recent ?offset t n] returns the newest [n] entries in chronological
+    order (oldest first), skipping the first [offset] newest entries.
+    Scans day-files from newest to oldest, stops early. *)
 
-val read_recent_lines : t -> int -> string list
+val read_recent_lines : ?offset:int -> t -> int -> string list
 (** Like {!read_recent} but returns raw JSONL strings (no parse).
     Useful for tail-readers that do their own parsing. *)
 

--- a/lib/server/server_routes_http_routes_dashboard_setup.ml
+++ b/lib/server/server_routes_http_routes_dashboard_setup.ml
@@ -85,6 +85,13 @@ let handle_telemetry request reqd =
         |> max 0
       | None -> if has_time_window then 0 else 100
     in
+    let offset =
+      match Server_utils.query_param req "offset" with
+      | Some raw ->
+        Option.value ~default:0 (int_of_string_opt raw)
+        |> max 0 |> min 5000
+      | None -> 0
+    in
     let sources =
       match Server_utils.query_param req "source" with
       | None -> Telemetry_unified.all_sources
@@ -107,6 +114,7 @@ let handle_telemetry request reqd =
                    `String (Telemetry_unified.source_to_string source))
                  sources) );
           ("n", `Int n);
+          ("offset", `Int offset);
           ( "keeper",
             Option.fold ~none:`Null
               ~some:(fun value -> `String value)
@@ -144,8 +152,8 @@ let handle_telemetry request reqd =
     let opt_ts = function None -> "" | Some f -> Printf.sprintf "%.3f" f in
     let cache_key =
       Printf.sprintf
-        "telemetry:%s:%s:src=%s:n=%d:k=%s:s=%s:o=%s:w=%s:since=%s:until=%s"
-        base_path masc_root sources_key n
+        "telemetry:%s:%s:src=%s:n=%d:off=%d:k=%s:s=%s:o=%s:w=%s:since=%s:until=%s"
+        base_path masc_root sources_key n offset
         (opt_str keeper_name) (opt_str session_id)
         (opt_str operation_id) (opt_str worker_run_id)
         (opt_ts since_ts) (opt_ts until_ts)
@@ -156,7 +164,7 @@ let handle_telemetry request reqd =
         Server_timing.measure timing Telemetry_query (fun () ->
           Telemetry_unified.read_unified_result ~base_path ~masc_root
             ~sources ?keeper_name ?session_id ?operation_id
-            ?worker_run_id ?since_ts ?until_ts ~n ())
+            ?worker_run_id ?since_ts ?until_ts ~n ~offset ())
       in
       let generated_at = Masc_domain.now_iso () in
       Server_timing.measure timing Json_serialize (fun () ->
@@ -171,6 +179,8 @@ let handle_telemetry request reqd =
           ("query", query_json);
           ("count", `Int (List.length result.entries));
           ("total_matching_entries", `Int result.total_matching_entries);
+          ("offset", `Int offset);
+          ("has_more", `Bool (offset + List.length result.entries < result.total_matching_entries));
           ("truncated", `Bool result.truncated);
           ("entries", `List result.entries);
         ])

--- a/lib/telemetry_unified/telemetry_unified.ml
+++ b/lib/telemetry_unified/telemetry_unified.ml
@@ -629,7 +629,7 @@ let read_goal_events ~masc_root ?since_ts ?until_ts ~n () : Yojson.Safe.t list =
 
 let read_unified_result ~base_path ~masc_root ?(sources = all_sources)
     ?keeper_name ?session_id ?operation_id ?worker_run_id ?since_ts ?until_ts
-    ?(n = 100) () : read_result =
+    ?(n = 100) ?(offset = 0) () : read_result =
   let limited = n > 0 in
   let has_filter =
     Option.is_some keeper_name || Option.is_some session_id
@@ -638,8 +638,8 @@ let read_unified_result ~base_path ~masc_root ?(sources = all_sources)
   in
   let per_source =
     if not limited then 0
-    else if has_filter then max n (n * 2)
-    else n + 1
+    else if has_filter then max (n + offset) ((n + offset) * 2)
+    else n + offset + 1
   in
   let all_entries =
     List.concat_map (fun source ->
@@ -694,16 +694,16 @@ let read_unified_result ~base_path ~masc_root ?(sources = all_sources)
   let sorted = sort_newest_first filtered in
   let total_matching_entries = List.length sorted in
   let entries =
-    if not limited || total_matching_entries <= n then sorted
-    else take_first n sorted
+    if not limited || total_matching_entries <= offset + n then sorted
+    else sorted |> List.drop offset |> take_first n
   in
-  { entries; total_matching_entries; truncated = limited && total_matching_entries > n }
+  { entries; total_matching_entries; truncated = limited && total_matching_entries > offset + n }
 
 let read_unified ~base_path ~masc_root ?sources ?keeper_name ?session_id
-    ?operation_id ?worker_run_id ?since_ts ?until_ts ?n () :
+    ?operation_id ?worker_run_id ?since_ts ?until_ts ?n ?offset () :
     Yojson.Safe.t list =
   (read_unified_result ~base_path ~masc_root ?sources ?keeper_name ?session_id
-     ?operation_id ?worker_run_id ?since_ts ?until_ts ?n ()).entries
+     ?operation_id ?worker_run_id ?since_ts ?until_ts ?n ?offset ()).entries
 
 (* ── Summary ────────────────────────────────────────── *)
 

--- a/lib/telemetry_unified/telemetry_unified.mli
+++ b/lib/telemetry_unified/telemetry_unified.mli
@@ -52,6 +52,7 @@ val read_unified :
   ?since_ts:float ->
   ?until_ts:float ->
   ?n:int ->
+  ?offset:int ->
   unit ->
   Yojson.Safe.t list
 (** [read_unified ~base_path ~masc_root ?sources ?keeper_name ?session_id
@@ -78,6 +79,7 @@ val read_unified_result :
   ?since_ts:float ->
   ?until_ts:float ->
   ?n:int ->
+  ?offset:int ->
   unit ->
   read_result
 (** Like {!read_unified}, but also returns the total number of matching


### PR DESCRIPTION
## 변경 내용

### Backend
- `Dated_jsonl.read_recent`에 `?offset` 추가 (최신 N개 중 offset만큼 스킵)
- `Telemetry_unified.read_unified_result`에 offset 전파
- `/api/v1/dashboard/telemetry` 핸들러가 `offset` 쿼리 파라미터 파싱 (0~5000 클램프)
- 응답에 `offset`과 `has_more` 필드 추가
- 캐시 키에 offset 포함

### Frontend
- `fetchTelemetry`에 `offset` 파라미터 추가
- `appendOasRuntimeFromTelemetryEntries` 추가 (기존 이벤트 유지하면서 append)
- `loadMoreOasEvents` 액션 추가
- OAS Health Chip에 **"더 보기"** 버튼 추가 (hasMore일 때만 노출)
- **OpenTelemetry** 바로가기 링크 추가
