### PR TITLE
refactor(board): add additionalProperties: false to all board tool schemas

### DIFF
--- a/lib/tool_surface/tool_shard_types_schemas_board.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_board.ml
@@ -28,6 +28,7 @@ let board_tools : Masc_domain.tool_schema list =
                       ] )
                 ] )
           ; "required", `List [ `String "post_id" ]
+          ; "additionalProperties", `Bool false
           ]
     }
   ; { name = "keeper_board_post"
@@ -110,6 +111,7 @@ let board_tools : Masc_domain.tool_schema list =
                       ] )
                 ] )
           ; "required", `List [ `String "content" ]
+          ; "additionalProperties", `Bool false
           ]
     }
   ; { name = "keeper_board_list"
@@ -157,6 +159,7 @@ let board_tools : Masc_domain.tool_schema list =
                       ; "description", `String "Sort order (default: recent)"
                       ] )
                 ] )
+          ; "additionalProperties", `Bool false
           ]
     }
   ; { name = "keeper_board_comment"
@@ -186,6 +189,7 @@ let board_tools : Masc_domain.tool_schema list =
                       ] )
                 ] )
           ; "required", `List [ `String "post_id"; `String "content" ]
+          ; "additionalProperties", `Bool false
           ]
     }
   ; { name = "keeper_board_vote"
@@ -220,13 +224,19 @@ let board_tools : Masc_domain.tool_schema list =
                       ] )
                 ] )
           ; "required", `List [ `String "post_id" ]
+          ; "additionalProperties", `Bool false
           ]
     }
   ; { name = "keeper_board_stats"
     ; description =
         "Get board activity statistics: total posts, comments, votes, active hearths. \
          Use to understand overall board health and engagement levels."
-    ; input_schema = `Assoc [ "type", `String "object"; "properties", `Assoc [] ]
+    ; input_schema =
+        `Assoc
+          [ "type", `String "object"
+          ; "properties", `Assoc []
+          ; "additionalProperties", `Bool false
+          ]
     }
   ; { name = "keeper_board_search"
     ; description =
@@ -260,6 +270,7 @@ let board_tools : Masc_domain.tool_schema list =
                       ] )
                 ] )
           ; "required", `List [ `String "query" ]
+          ; "additionalProperties", `Bool false
           ]
     }
   ; { name = "keeper_board_curation_read"
@@ -268,7 +279,12 @@ let board_tools : Masc_domain.tool_schema list =
          recommended ordering, highlights, tag suggestions, answer matches, health \
          score, rationale, and provenance. Returns null when no snapshot has been \
          submitted yet."
-    ; input_schema = `Assoc [ "type", `String "object"; "properties", `Assoc [] ]
+    ; input_schema =
+        `Assoc
+          [ "type", `String "object"
+          ; "properties", `Assoc []
+          ; "additionalProperties", `Bool false
+          ]
     }
   ; { name = "keeper_board_curation_submit"
     ; description =
@@ -340,6 +356,7 @@ let board_tools : Masc_domain.tool_schema list =
                       ] )
                 ] )
           ; "required", `List [ `String "rationale" ]
+          ; "additionalProperties", `Bool false
           ]
     }
   ]


### PR DESCRIPTION
## Summary

All 9 keeper_board_* tool input_schemas에 `additionalProperties: false`를 추가했다.

LLM이 board tool 호출 시 스키마에 정의되지 않은 필드를 전송하는 것을 방지한다.

## Changes

- `tool_shard_types_schemas_board.ml`: 9개 schema에 `additionalProperties: false` 추가
  - keeper_board_post_get, keeper_board_post, keeper_board_list
  - keeper_board_comment, keeper_board_vote, keeper_board_stats
  - keeper_board_search, keeper_board_curation_read, keeper_board_curation_submit
- keeper_board_stats, keeper_board_curation_read: 싱글라인 input_schema를 멀티라인으로 확장

## Verification

- `dune build` 통과 (해당 모듈)