### PR TITLE
fix(deps): sync agent_sdk version floor with oas/main pin (0.204.2)

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -53,7 +53,7 @@
   ; (upstream piaf 0.2.0 missing conf-libssl dependency on macOS arm64).
   (piaf (>= 0.2.0))
   (eio-ssl (>= 0.3.0))
-  (agent_sdk (>= 0.204.3))
+  (agent_sdk (>= 0.204.2))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))

--- a/masc.opam
+++ b/masc.opam
@@ -28,7 +28,7 @@ depends: [
   "websocket" {>= "2.17"}
   "piaf" {>= "0.2.0"}
   "eio-ssl" {>= "0.3.0"}
-  "agent_sdk" {>= "0.204.3"}
+  "agent_sdk" {>= "0.204.2"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}


### PR DESCRIPTION
## Problem

CI `Build and Test`, `Lint`, and `Health` are all failing at `Install system and OCaml dependencies` with:

```
[ERROR] Package conflict!
  * Missing dependency:
    - deps-of-masc → agent_sdk >= 0.204.3
    no matching version
```

## Root Cause

- PR #20475 bumped `agent_sdk` to `>= 0.204.3` and pinned `feat/otel-env` HEAD (`6a5e7b4b`).
- PR #20487 reverted the pin back to `oas/main` HEAD (`9f4c6d92`), but **left the version floor at `0.204.3`**.
- `oas/main` HEAD (`9f4c6d92`) is identical to tag `v0.204.2`, so the pinned package provides version `0.204.2`.
- `opam install` fails because `0.204.2` does not satisfy `>= 0.204.3`.

## Fix

Restore `agent_sdk` version floor to `>= 0.204.2` in both `dune-project` and `masc.opam` to match the actually pinned SHA.