### PR TITLE
feat(verification): system-level verifier dispatch + dashboard alarm (#19314)

### DIFF
--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -11,7 +11,7 @@ import { connected, reconnectCount, lastDisconnectedAt } from '../sse'
 import { dashboardWsOnlyEnabled } from '../dashboard-ws-cutover'
 import { dashboardWsConnected, dashboardWsSseFallbackActive } from '../dashboard-ws-state'
 import { isKeeperPaused } from '../lib/keeper-predicates'
-import { dashboardLoading, executionError, keepers, serverStatus, shellCounts, shellRuntimeResolution } from '../store'
+import { dashboardLoading, executionError, keepers, serverStatus, shellCounts, shellRuntimeResolution, tasksByStatus } from '../store'
 import { missionSnapshot, missionLoading } from '../mission-signals'
 import { namespaceTruth, namespaceTruthInitializing } from '../namespace-truth-store'
 import {
@@ -198,6 +198,7 @@ interface DashboardHealthInput {
   runtimeProviderProbeError?: string | null
   executionError: string | null
   loading: boolean
+  pendingVerificationCount?: number
 }
 
 // RFC-0135 PR-3: the local `keeperLooksPaused` was one of four
@@ -606,6 +607,19 @@ export function dashboardHealthChips(input: DashboardHealthInput): DashboardHeal
     })
   }
 
+  const vrfCount = input.pendingVerificationCount ?? 0
+  if (vrfCount > 0) {
+    chips.push({
+      key: 'verification-backlog',
+      label: `Verification ${vrfCount}`,
+      detail:
+        vrfCount >= 5
+          ? `${vrfCount} tasks are awaiting verification. This is a high backlog that may delay task completion.`
+          : `${vrfCount} task${vrfCount === 1 ? '' : 's'} awaiting verification.`,
+      tone: vrfCount >= 5 ? 'bad' : 'warn',
+    })
+  }
+
   if (chips.length === 0) {
     chips.push({
       key: input.loading ? 'hydrating' : 'runtime-ok',
@@ -686,6 +700,7 @@ export function DashboardHealthStrip() {
     runtimeProviderProbeError: shellRuntimeProviderProbeError.value,
     executionError: executionError.value,
     loading: dashboardLoading.value || namespaceTruthInitializing.value,
+    pendingVerificationCount: tasksByStatus.value.awaitingVerification.length,
   })
 
   return html`

--- a/dashboard/src/components/status-tray.ts
+++ b/dashboard/src/components/status-tray.ts
@@ -436,9 +436,9 @@ function PopoverContent({
           <div class="font-mono text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Keepers</div>
           <div class="mt-0.5 text-sm font-semibold tabular-nums">${summary.counts.keeperAttention}</div>
         </div>
-        <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-1.5">
-          <div class="font-mono text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Verify</div>
-          <div class="mt-0.5 text-sm font-semibold tabular-nums">${summary.counts.pendingVerificationTasks}</div>
+        <div class="rounded-[var(--r-1)] border ${summary.counts.pendingVerificationTasks >= 3 ? 'border-[var(--warn-20)] bg-[var(--warn-10)]' : 'border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]'} px-2 py-1.5">
+          <div class="font-mono text-3xs uppercase tracking-[var(--track-caps)] ${summary.counts.pendingVerificationTasks >= 3 ? 'text-[var(--warn-bright)]' : 'text-[var(--color-fg-muted)]'}">Verify</div>
+          <div class="mt-0.5 text-sm font-semibold tabular-nums ${summary.counts.pendingVerificationTasks >= 3 ? 'text-[var(--warn-bright)]' : ''}">${summary.counts.pendingVerificationTasks}</div>
         </div>
       </div>
       ${summary.counts.unacknowledgedErrors > 0 ? html`

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -576,9 +576,16 @@ let task_claim_decision (task : task) =
        Claim_available (task_claim_readiness task)
      | Reclaim_gate_blocked_by_policy reason ->
        Claim_unavailable (Claim_block_reclaim_policy reason))
+  | AwaitingVerification { verification_id; _ } ->
+    (* Verification tasks with a valid verification_id can be claimed by
+       other agents for cross-agent verification dispatch. The actual
+       cross-agent check (self-verification block) happens in claim_task_r.
+       Issue #19314. *)
+    (match verification_id with
+     | Some _ -> Claim_available (task_claim_readiness task)
+     | None -> Claim_unavailable (Claim_block_not_todo task.task_status))
   | Claimed _
   | InProgress _
-  | AwaitingVerification _
   | Done _
   | Cancelled _ ->
     Claim_unavailable (Claim_block_not_todo task.task_status)

--- a/lib/workspace/workspace_task_claim.ml
+++ b/lib/workspace/workspace_task_claim.ml
@@ -183,11 +183,18 @@ let claim_task_r config ~agent_name ~task_id ()
                     `Claimed_ok, t' :: acc
                   | Claimed { assignee; _ }
                   | InProgress { assignee; _ }
-                  | AwaitingVerification { assignee; _ }
                     when assignee = agent_name -> `Already_mine, t :: acc
+                  | AwaitingVerification { assignee; verification_id; submitted_at; deadline }
+                    when assignee = agent_name -> `Already_mine, t :: acc
+                  | AwaitingVerification { assignee; verification_id; submitted_at; deadline }
+                    when assignee <> agent_name ->
+                    (* Cross-agent verification dispatch: verifier claims the
+                       AwaitingVerification task without changing its status.
+                       Verification.assign_verifier is called after the fold.
+                       Issue #19314. *)
+                    `Claimed_verification { assignee; verification_id; submitted_at; deadline }, t :: acc
                   | Claimed { assignee; _ }
                   | InProgress { assignee; _ }
-                  | AwaitingVerification { assignee; _ }
                   | Done { assignee; _ }
                   | Cancelled { cancelled_by = assignee; _ } ->
                     `Claimed_by assignee, t :: acc)
@@ -204,6 +211,55 @@ let claim_task_r config ~agent_name ~task_id ()
              (`Existing_claim
                { message = Printf.sprintf "Task %s is already claimed by you" task_id
                ; auto_released_task_ids = []
+               })
+         | `Claimed_verification { verification_id; _ } ->
+           (* Issue #19314: Cross-agent verification dispatch.
+              The task stays in AwaitingVerification; we assign the verifier
+              in the verification store and set the agent's current_task. *)
+           let () =
+             match verification_id with
+             | Some vrf_id ->
+               (match Verification.assign_verifier
+                        ~base_path:config.Workspace.base_path
+                        ~req_id:vrf_id
+                        ~verifier:agent_name with
+                | Ok _ -> ()
+                | Error e ->
+                  Log.Task.warn
+                    "Verification.assign_verifier failed for task=%s vrf=%s verifier=%s: %s"
+                    task_id vrf_id agent_name e)
+             | None -> ()
+           in
+           Workspace_task_classify.update_local_agent_state config ~agent_name (fun agent ->
+             { agent with status = Busy; current_task = Some task_id });
+           let _ =
+             broadcast
+               config
+               ~from_agent:agent_name
+               ~content:(Printf.sprintf "Assigned as verifier for %s" task_id)
+           in
+           Workspace_task_classify.emit_task_activity
+             config
+             ~agent_name
+             ~task_id
+             ~kind:(Event_kind.Task.to_string Event_kind.Task.Claimed)
+             ~payload:(`Assoc
+               [ "task_id", `String task_id
+               ; "verification_dispatch", `Bool true
+               ]);
+           log_event
+             config
+             (`Assoc
+               [ "type", `String "task_claim_verification"
+               ; "agent", `String agent_name
+               ; "actor_kind", `String (Workspace_task_classify.task_actor_kind agent_name)
+               ; "task", `String task_id
+               ; "ts", `String (now_iso ())
+               ]);
+           Ok
+             (`New_claim
+               { message = Printf.sprintf "%s assigned as verifier for %s" agent_name task_id
+               ; auto_released_task_ids = auto_released_ids
                })
          | `Claimed_ok ->
            let new_backlog =

--- a/lib/workspace/workspace_task_lifecycle.ml
+++ b/lib/workspace/workspace_task_lifecycle.ml
@@ -56,7 +56,11 @@ let decide
     , (Masc_domain.Claimed { assignee; _ } | Masc_domain.InProgress { assignee; _ }) ) ->
     if same_agent assignee then ok task_status else Error Invalid_transition
   | Masc_domain.Claim, Masc_domain.Done _ -> ok task_status
-  | Masc_domain.Claim, (Masc_domain.AwaitingVerification _ | Masc_domain.Cancelled _) ->
+  | Masc_domain.Claim, Masc_domain.AwaitingVerification { assignee; _ } ->
+    (* Cross-agent verification dispatch: verifier claims the task without
+       changing status. Self-verification is blocked. Issue #19314. *)
+    if same_agent assignee then Error Invalid_transition else ok task_status
+  | Masc_domain.Claim, Masc_domain.Cancelled _ ->
     Error Invalid_transition
   (* ── Start ────────────────────────────────────── *)
   | Masc_domain.Start, Masc_domain.Claimed { assignee; _ } ->

--- a/lib/workspace/workspace_task_schedule.ml
+++ b/lib/workspace/workspace_task_schedule.ml
@@ -303,7 +303,8 @@ let claim_next_r
             (fun (task : Masc_domain.task) ->
                match task.task_status with
                | Claimed _ | InProgress _ -> true
-               | Todo | AwaitingVerification _ | Done _ | Cancelled _ -> false)
+               | AwaitingVerification { assignee; _ } -> assignee <> agent_name
+               | Todo | Done _ | Cancelled _ -> false)
             working_tasks
         in
         (* Starvation prevention: Calculate effective priority


### PR DESCRIPTION
## Summary
Issue #19314: AwaitingVerification 태스크가 verifier keeper에게 자동 할당되도록 시스템 레벨 처리 + 대시보드 가시성/알람 추가.

## System-level changes
- `task_claim_decision`: AwaitingVerification 상태의 태스크를 원래 작업자가 아닌 agent가 claim할 수 있도록 허용
- `workspace_task_schedule`: admission_tasks에 AwaitingVerification 포함 (단, 원래 작업자 제외)
- `workspace_task_claim`: cross-agent claim 시 `Verification.assign_verifier` 호출 + `current_task` 설정 (상태는 AwaitingVerification 유지)
- `workspace_task_lifecycle`: Claim 액션에서 AwaitingVerification 허용 (self-verification 차단)

## Dashboard + alarm
- `DashboardHealthStrip`: verification backlog chip 추가 (1+ warn, 5+ bad)
- `status-tray`: backlog >= 3 시 Verify 패널에 warn 스타일 적용

## Test plan
- [ ] dune build @check (pre-existing failures in unrelated files)
- [ ] dashboard pnpm typecheck
- [ ] Manual: submit task for verification → 다른 agent가 claim 가능 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)