### PR TITLE
fix(keeper): pass body_timeout_s through to OAS call

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -518,6 +518,7 @@ let run_turn
                     ~max_turns
                     ~max_idle_turns
                     ?stream_idle_timeout_s
+                    ~body_timeout_s:timeout_s
                     ~temperature
                     ~max_tokens
                     ?max_cost_usd

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -52,6 +52,7 @@ let run_named
     ?(max_turns = 20)
     ?(max_idle_turns = 3)
     ?stream_idle_timeout_s
+    ?body_timeout_s
     ?(temperature = Runtime_provider_defaults.agent_default_temperature)
     ?(max_tokens = Runtime_provider_defaults.agent_default_max_tokens)
     ?max_input_tokens
@@ -150,6 +151,7 @@ let run_named
     max_turns;
     max_idle_turns;
     stream_idle_timeout_s;
+    body_timeout_s;
     temperature;
     max_tokens;
     max_input_tokens;

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -102,6 +102,7 @@ val run_named :
   ?max_turns:int ->
   ?max_idle_turns:int ->
   ?stream_idle_timeout_s:float ->
+  ?body_timeout_s:float ->
   ?temperature:float ->
   ?max_tokens:int ->
   ?max_input_tokens:int ->

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -31,6 +31,7 @@ type try_provider_ctx =
   ; max_turns : int
   ; max_idle_turns : int
   ; stream_idle_timeout_s : float option
+  ; body_timeout_s : float option
   ; temperature : float
   ; max_tokens : int
   ; max_input_tokens : int option
@@ -256,14 +257,7 @@ let run_try_provider
               stream_idle_timeout_for_attempt ~configured:ctx.stream_idle_timeout_s
           ; max_execution_time_s =
               max_execution_time_for_attempt ?per_provider_timeout_s ()
-          ; body_timeout_s =
-              (* SSOT: Keeper_runtime_resolved.body_timeout_override_sec
-                 (driven by MASC_KEEPER_BODY_TIMEOUT_SEC). OAS applies this
-                 only to non-streaming sync body reads; streaming attempts
-                 deliberately rely on [stream_idle_timeout_s] plus liveness
-                 observation so healthy reasoning bursts are not killed by
-                 total duration. *)
-              body_timeout_for_attempt ?per_provider_timeout_s ()
+          ; body_timeout_s = ctx.body_timeout_s
           ; temperature = ctx.temperature
           ; max_idle_turns = ctx.max_idle_turns
           ; guardrails = ctx.guardrails

--- a/lib/keeper/keeper_turn_driver_try_provider.mli
+++ b/lib/keeper/keeper_turn_driver_try_provider.mli
@@ -14,6 +14,7 @@ type try_provider_ctx =
   ; max_turns : int
   ; max_idle_turns : int
   ; stream_idle_timeout_s : float option
+  ; body_timeout_s : float option
   ; temperature : float
   ; max_tokens : int
   ; max_input_tokens : int option


### PR DESCRIPTION
## Problem

stream_idle_timeout_s was forwarded but body_timeout_s was dropped,
so OAS never set a body-read timeout on streaming attempts.

OAS requires both clock + body_timeout_s Some to arm the timeout.

## Fix

- Add ?body_timeout_s to Keeper_turn_driver.run_named
- Thread it through try_provider_ctx to Runtime_candidate
- keeper_agent_run.ml: passthrough ~body_timeout_s:timeout_s
  (the same OAS call timeout already computed for the attempt)

Refs: PR #20497 follow-up