### PR TITLE
fix(observability): correct MASC Overview dashboard metric queries

### DIFF
--- a/infrastructure/monitoring/grafana/provisioning/dashboards/masc-overview.json
+++ b/infrastructure/monitoring/grafana/provisioning/dashboards/masc-overview.json
@@ -22,7 +22,7 @@
   "panels": [
     {
       "type": "timeseries",
-      "title": "Requests / sec",
+      "title": "Keeper Heartbeats / min",
       "gridPos": {
         "x": 0,
         "y": 0,
@@ -33,11 +33,11 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Total HTTP request rate across all surfaces.",
+      "description": "Keeper heartbeat success rate.",
       "targets": [
         {
-          "expr": "sum(rate(http_server_request_duration_count[5m]))",
-          "legendFormat": "rps",
+          "expr": "sum(rate(masc_keeper_heartbeat_successes_total[5m])) * 60",
+          "legendFormat": "hb/min",
           "refId": "A"
         }
       ],
@@ -65,7 +65,7 @@
     },
     {
       "type": "timeseries",
-      "title": "P99 Latency",
+      "title": "Dashboard Snapshot Latency p99",
       "gridPos": {
         "x": 8,
         "y": 0,
@@ -76,10 +76,10 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "99th percentile of HTTP request latency.",
+      "description": "99th percentile dashboard snapshot latency.",
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum(rate(http_server_request_duration_bucket[5m])) by (le)) * 1000",
+          "expr": "histogram_quantile(0.99, sum(rate(masc_dashboard_snapshot_latency_seconds_bucket_total[5m])) by (le)) * 1000",
           "legendFormat": "p99",
           "refId": "A"
         }
@@ -109,7 +109,7 @@
     },
     {
       "type": "stat",
-      "title": "Error Rate %",
+      "title": "Keeper Receipt Failure Rate %",
       "gridPos": {
         "x": 16,
         "y": 0,
@@ -120,11 +120,11 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "5xx error rate over the last 5 minutes.",
+      "description": "Keeper execution receipt failure rate.",
       "targets": [
         {
-          "expr": "sum(rate(http_server_request_duration_count{status_code=~\"5..\"}[5m])) / sum(rate(http_server_request_duration_count[5m])) * 100",
-          "legendFormat": "error %",
+          "expr": "sum(rate(masc_keeper_execution_receipt_failures_total[5m])) / (sum(rate(masc_keeper_execution_receipt_failures_total[5m])) + sum(rate(masc_keeper_heartbeat_successes_total[5m]))) * 100",
+          "legendFormat": "failure %",
           "refId": "A"
         }
       ],
@@ -160,7 +160,7 @@
     },
     {
       "type": "timeseries",
-      "title": "Keeper FSM Transitions",
+      "title": "Keeper Lifecycle Transitions",
       "gridPos": {
         "x": 0,
         "y": 8,
@@ -171,10 +171,10 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Keeper turn FSM transition rate by destination state.",
+      "description": "Keeper lifecycle transition rate by destination state.",
       "targets": [
         {
-          "expr": "sum by (to) (rate(masc_keeper_turn_fsm_transitions_total[5m]))",
+          "expr": "sum by (to) (rate(masc_keeper_lifecycle_transitions_total[5m]))",
           "legendFormat": "{{to}}",
           "refId": "A"
         }
@@ -300,10 +300,10 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "GenAI client operation rate (LLM calls).",
+      "description": "GenAI client calls per minute.",
       "targets": [
         {
-          "expr": "sum(rate(gen_ai_client_operation_duration_count[5m])) * 60",
+          "expr": "sum(rate(gen_ai_client_operation_duration_count_total[5m])) * 60",
           "legendFormat": "calls/min",
           "refId": "A"
         }
@@ -333,7 +333,7 @@
     },
     {
       "type": "barchart",
-      "title": "Tool Calls by Name",
+      "title": "Token Usage / min",
       "gridPos": {
         "x": 0,
         "y": 24,
@@ -344,11 +344,11 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Tool call rate per tool name.",
+      "description": "Token usage rate by type (input / output).",
       "targets": [
         {
-          "expr": "sum by (tool_name) (rate(masc_tool_call_total[5m]))",
-          "legendFormat": "{{tool_name}}",
+          "expr": "sum by (token_type) (rate(gen_ai_client_token_usage[5m])) * 60",
+          "legendFormat": "{{token_type}}",
           "refId": "A"
         }
       ],
@@ -372,7 +372,7 @@
     },
     {
       "type": "stat",
-      "title": "Tool Success Rate %",
+      "title": "Goal Attainment %",
       "gridPos": {
         "x": 12,
         "y": 32,
@@ -383,11 +383,11 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Percentage of successful tool calls.",
+      "description": "Average goal attainment percentage.",
       "targets": [
         {
-          "expr": "sum(rate(masc_tool_call_total{status=\"success\"}[5m])) / sum(rate(masc_tool_call_total[5m])) * 100",
-          "legendFormat": "{{__name__}}",
+          "expr": "avg(masc_goal_attainment_pct)",
+          "legendFormat": "attainment",
           "refId": "A"
         }
       ],
@@ -417,11 +417,11 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Number of currently active keepers.",
+      "description": "Number of distinct keepers emitting heartbeats.",
       "targets": [
         {
-          "expr": "masc_keeper_active_gauge",
-          "legendFormat": "{{__name__}}",
+          "expr": "count(count by (keeper) (masc_keeper_heartbeat_successes_total))",
+          "legendFormat": "keepers",
           "refId": "A"
         }
       ],
@@ -440,7 +440,7 @@
     },
     {
       "type": "timeseries",
-      "title": "Keeper Turn Duration p99",
+      "title": "Keeper Compactions / min",
       "gridPos": {
         "x": 8,
         "y": 48,
@@ -451,11 +451,11 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "99th percentile keeper turn processing time.",
+      "description": "Keeper context compaction rate.",
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum(rate(masc_keeper_turn_duration_seconds_bucket[5m])) by (le)) * 1000",
-          "legendFormat": "p99",
+          "expr": "sum(rate(masc_keeper_compactions_total[5m])) * 60",
+          "legendFormat": "compactions/min",
           "refId": "A"
         }
       ],
@@ -483,7 +483,7 @@
     },
     {
       "type": "stat",
-      "title": "Active Goals",
+      "title": "Goal Attainment Measured",
       "gridPos": {
         "x": 0,
         "y": 56,
@@ -494,11 +494,11 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Number of currently open goals.",
+      "description": "Average measured goal attainment count.",
       "targets": [
         {
-          "expr": "masc_goal_active_total",
-          "legendFormat": "{{__name__}}",
+          "expr": "avg(masc_goal_attainment_measured)",
+          "legendFormat": "measured",
           "refId": "A"
         }
       ],
@@ -517,7 +517,7 @@
     },
     {
       "type": "timeseries",
-      "title": "Task Terminal Rate",
+      "title": "Keeper Input Tokens / min",
       "gridPos": {
         "x": 8,
         "y": 64,
@@ -528,11 +528,11 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Task completion vs failure rate.",
+      "description": "Keeper input token consumption rate.",
       "targets": [
         {
-          "expr": "sum by (status) (rate(masc_task_terminal_total[5m]))",
-          "legendFormat": "{{status}}",
+          "expr": "sum(rate(masc_keeper_input_tokens_total[5m])) * 60",
+          "legendFormat": "tokens/min",
           "refId": "A"
         }
       ],
@@ -560,7 +560,7 @@
     },
     {
       "type": "timeseries",
-      "title": "Board Posts / min",
+      "title": "Board Signal Wakeups / min",
       "gridPos": {
         "x": 0,
         "y": 72,
@@ -571,11 +571,11 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Posts per minute by board.",
+      "description": "Keeper board signal wakeup rate (capped).",
       "targets": [
         {
-          "expr": "sum by (board) (rate(masc_board_post_total[5m])) * 60",
-          "legendFormat": "{{board}}",
+          "expr": "sum(rate(masc_keeper_board_signal_wakeup_capped_total[5m])) * 60",
+          "legendFormat": "wakeups/min",
           "refId": "A"
         }
       ],
@@ -603,7 +603,7 @@
     },
     {
       "type": "timeseries",
-      "title": "Memory Usage",
+      "title": "OCaml Heap Memory",
       "gridPos": {
         "x": 0,
         "y": 80,
@@ -614,11 +614,11 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Process resident memory.",
+      "description": "OCaml heap size in megabytes.",
       "targets": [
         {
-          "expr": "process_resident_memory_bytes / 1024 / 1024",
-          "legendFormat": "MB",
+          "expr": "masc_gc_heap_words * 8 / 1024 / 1024",
+          "legendFormat": "heap MB",
           "refId": "A"
         }
       ],
@@ -646,7 +646,7 @@
     },
     {
       "type": "timeseries",
-      "title": "GC Allocated Rate",
+      "title": "GC Major Allocation Rate",
       "gridPos": {
         "x": 12,
         "y": 88,
@@ -657,10 +657,10 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "OCaml GC allocation rate.",
+      "description": "OCaml major heap allocation rate.",
       "targets": [
         {
-          "expr": "rate(ocaml_gc_allocated_bytes[5m]) / 1024 / 1024",
+          "expr": "rate(masc_gc_major_words[5m]) * 8 / 1024 / 1024",
           "legendFormat": "MB/s",
           "refId": "A"
         }


### PR DESCRIPTION
모든 패널의 PromQL 쿼리를 실제 VictoriaMetrics에 수집되는 메트릭 이름으로 교체합니다.\n\n기존에는 추정한 메트릭 이름을 사용해 No data가 떴습니다.\n\n변경된 패널:\n- Keeper Heartbeats / min\n- Dashboard Snapshot Latency p99\n- Keeper Receipt Failure Rate %\n- Keeper Lifecycle Transitions\n- LLM Calls/min (gen_ai_client_operation_duration_count_total)\n- Token Usage/min\n- Goal Attainment %\n- Active Keepers\n- Keeper Compactions/min\n- Goal Attainment Measured\n- Keeper Input Tokens/min\n- Board Signal Wakeups/min\n- OCaml Heap Memory\n- GC Major Allocation Rate