### PR TITLE
fix(server): add missing IDE presence API endpoints

### DIFF
--- a/lib/server/server_ide_http.ml
+++ b/lib/server/server_ide_http.ml
@@ -6,6 +6,7 @@
 
 open Server_auth
 open Server_utils
+open Masc_domain
 module Http = Http_server_eio
 
 let base_path_of_state state = state.Mcp_server.workspace_config.base_path
@@ -207,6 +208,47 @@ let build_cursor_snapshot state uri =
 let add_routes router =
   Ide_bridge.install_agent_observation_sinks ();
   router
+  |> Http.Router.get "/api/v1/agents" (fun request reqd ->
+    with_public_read
+      (fun state _req reqd ->
+         let agents = Client_registry_eio.list_active ~within_seconds:300.0 () in
+         let entries =
+           List.map
+             (fun (a : Client_identity.t) ->
+                `Assoc
+                  [ "name", `String a.Client_identity.agent_name
+                  ; "status", `String "active"
+                  ; "current_task", `Null
+                  ; "model", `Null
+                  ])
+             agents
+         in
+         Http.Response.json_value
+           ~compress:true
+           ~request
+           (json_ok (`Assoc [ "agents", `List entries ]))
+           reqd)
+      request
+      reqd)
+  |> Http.Router.get "/api/v1/status" (fun request reqd ->
+    with_public_read
+      (fun state _req reqd ->
+         let config = state.Mcp_server.workspace_config in
+         let workspace_state = Workspace.read_state config in
+         let tempo = Tempo.get_tempo config in
+         let json = `Assoc [
+           "cluster", `String (Env_config_core.cluster_name ());
+           "project", `String workspace_state.project;
+           "tempo_interval_s", `Float tempo.current_interval_s;
+           "paused", `Bool workspace_state.paused;
+         ] in
+         Http.Response.json_value
+           ~compress:true
+           ~request
+           (json_ok json)
+           reqd)
+      request
+      reqd)
   |> Http.Router.get "/api/v1/ide/annotations" (fun request reqd ->
     with_public_read
       (fun state _req reqd ->

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -176,6 +176,107 @@ let runtime_config_path_error_status message =
   then `Not_found
   else `Internal_server_error
 
+(* ── Git helpers for worktree status ── *)
+
+let git_run ~cwd args =
+  let argv = "git" :: "-C" :: cwd :: "--no-optional-locks" :: args in
+  let raw_source = String.concat " " (List.map Filename.quote argv) in
+  try
+    let (status, out) =
+      Masc_exec.Exec_gate.run_argv_with_status
+        ~actor:(Masc_exec.Agent_id.of_string "system/dashboard_api")
+        ~raw_source
+        ~summary:"dashboard api git command"
+        ~timeout_sec:5.0
+        argv
+    in
+    match status with
+    | Unix.WEXITED 0 -> Some (String.trim out)
+    | _ -> None
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | _ -> None
+;;
+
+type worktree_info =
+  { path : string
+  ; head : string
+  ; branch : string option
+  }
+
+let parse_worktree_list out =
+  let lines = String.split_on_char '\n' out in
+  let rec collect acc current = function
+    | [] -> List.rev (Option.to_list current @ acc)
+    | line :: rest ->
+      if String.starts_with ~prefix:"worktree " line
+      then (
+        let path = String.sub line 9 (String.length line - 9) in
+        collect acc (Some { path; head = ""; branch = None }) rest)
+      else if String.starts_with ~prefix:"HEAD " line
+      then (
+        let head = String.sub line 5 (String.length line - 5) in
+        collect acc (Option.map (fun w -> { w with head }) current) rest)
+      else if String.starts_with ~prefix:"branch " line
+      then (
+        let branch = String.sub line 7 (String.length line - 7) in
+        let branch_name =
+          if String.starts_with ~prefix:"refs/heads/" branch
+          then String.sub branch 11 (String.length branch - 11)
+          else branch
+        in
+        collect acc (Option.map (fun w -> { w with branch = Some branch_name }) current) rest)
+      else if String.trim line = ""
+      then collect (Option.to_list current @ acc) None rest
+      else collect acc current rest
+  in
+  collect [] None lines
+;;
+
+let git_status_counts ~cwd =
+  match git_run ~cwd [ "status"; "--porcelain" ] with
+  | None -> 0, 0
+  | Some out ->
+    let lines = String.split_on_char '\n' out in
+    let changed = ref 0 in
+    let staged = ref 0 in
+    List.iter
+      (fun line ->
+         if line = ""
+         then ()
+         else if String.length line >= 2
+         then (
+           let first = line.[0] in
+           let second = line.[1] in
+           if first <> ' ' && first <> '?' then incr staged;
+           if second <> ' ' then incr changed;
+           if first = '?' && second = '?'
+           then (
+             decr staged;
+             incr changed)))
+      lines;
+    !changed, !staged
+;;
+
+let worktree_info_to_json ~base_path w =
+  let changed_count, staged_count = git_status_counts ~cwd:w.path in
+  let keeper_attached =
+    match w.branch with
+    | Some b -> String.contains b '/'
+    | None -> false
+  in
+  `Assoc
+    [ "worktree_path", `String w.path
+    ; "branch", `String (Option.value ~default:"" w.branch)
+    ; "changed_count", `Int changed_count
+    ; "staged_count", `Int staged_count
+    ; "head_sha", `String w.head
+    ; "pr_number", `Null
+    ; "pr_state", `Null
+    ; "keeper_attached", `Bool keeper_attached
+    ]
+;;
+
 let add_routes ~sw ~clock router =
   router
   |> Http.Router.post "/api/v1/broadcast" (fun request reqd ->
@@ -1132,3 +1233,29 @@ let add_routes ~sw ~clock router =
 
   (* ── Agent API routes (extracted) ── *)
   |> Server_dashboard_http_agent_api.add_agent_api_routes
+  |> Http.Router.get "/api/dashboard/worktree-status" (fun request reqd ->
+       with_public_read
+         (fun state _req reqd ->
+            let base_path = state.Mcp_server.workspace_config.base_path in
+            let worktrees =
+              match git_run ~cwd:base_path [ "worktree"; "list"; "--porcelain" ] with
+              | None -> []
+              | Some out -> parse_worktree_list out
+            in
+            let json_entries = List.map (worktree_info_to_json ~base_path) worktrees in
+            let body_lines =
+              List.map
+                (fun json -> Printf.sprintf "data: %s\n\n" (Yojson.Safe.to_string json))
+                json_entries
+              |> String.concat ""
+            in
+            let headers =
+              Httpun.Headers.of_list
+                [ "content-type", "text/event-stream"
+                ; "cache-control", "no-cache"
+                ]
+            in
+            let response = Httpun.Response.create ~headers `OK in
+            Httpun.Reqd.respond_with_string reqd response body_lines)
+         request
+         reqd)


### PR DESCRIPTION
## Summary

Dashboard IDE presence strip shows all agents as \"disconnect\" because three REST endpoints it calls via `Promise.all` were missing from the HTTP/1 router.

## Root Cause

`ide-presence-strip.ts` calls:
1. `GET /api/v1/agents`
2. `GET /api/v1/status`
3. `GET /api/dashboard/worktree-status`

Only `/api/v1/ide/*` routes existed in `server_ide_http.ml`. When any `Promise.all` promise rejects, the catch block returns `disconnectedSnapshot('fetch_failed')`.

## Changes

- `server_ide_http.ml`: add `/api/v1/agents` (active agent list from `Client_registry_eio`) and `/api/v1/status` (cluster/project/tempo/paused state)
- `server_routes_http_routes_dashboard.ml`: add `/api/dashboard/worktree-status` with `git worktree list --porcelain` parsing and per-worktree branch/status counts

## Test Plan

- [x] `dune build --root . lib/server/` compiles cleanly
- [ ] Server restart + IDE page load shows agents as active
- [ ] `/api/v1/agents` returns JSON with agent list
- [ ] `/api/v1/status` returns cluster/tempo/project state
- [ ] `/api/dashboard/worktree-status` returns worktree entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)