### PR TITLE
revert(keeper): remove wall-clock watchdog, body_timeout_s now covers it

### DIFF
--- a/lib/keeper/keeper_unified_turn_attempt_watchdog.ml
+++ b/lib/keeper/keeper_unified_turn_attempt_watchdog.ml
@@ -1,50 +1,20 @@
-(* Per-attempt cancel handler for a single keeper turn runtime attempt.
-
-   A wall-clock safety deadline wraps every attempt:
-     - When [attempt_watchdog_s] is [Some deadline], that deadline is used.
-     - When [attempt_watchdog_s] is [None], a generous safety cap of 1800s
-       (30 min) prevents a stuck fiber from locking a keeper in [Streaming]
-       state forever. Any provider attempt that makes zero progress for 30
-       minutes is definitively stuck (network hang, silent provider failure,
-       etc.).
-
-   The previous wall-clock watchdog was removed because it killed healthy
-   streams at 540-600s. The safety cap here is 3x that, targeting only
-   truly stuck fibers while never affecting legitimate slow-but-progressing
-   streams.
-
-   Two outcomes:
-     - normal completion: pass-through of [run]'s [result]
-     - timeout or [Eio.Cancel.Cancelled]: invoke [on_cancelled] for the
-       terminal receipt + FSM transition, then re-raise so the outer
-       cleanup handler observes the cancellation
-
-   The Cancelled re-raise path is the outer catch for cancellations
-   that escape the in-band receipt builder in
-   [Keeper_agent_run.run_turn]: the inner Cancel handlers all
-   re-raise, so without [on_cancelled] the FSM emits Streaming and
-   then nothing — the turn silently disappears from the operator's
-   timeline. *)
-
-let safety_cap_s = 1800.0
-
 let dispatch
-    ~clock
-    ~attempt_watchdog_s
-    ~oas_timeout_s:_oas_timeout_s
-    ~on_cancelled
-    ~run
+      ~clock:_clock
+      ~oas_timeout_s:_oas_timeout_s
+      ~on_cancelled
+      ~run
   =
-  let deadline_s = match attempt_watchdog_s with
-    | Some s -> Float.max s 1.0
-    | None -> safety_cap_s
-  in
-  try
-    Eio.Time.with_timeout_exn clock deadline_s run
-  with
-  | Eio.Time.Timeout ->
-    on_cancelled ();
-    raise (Eio.Cancel.Cancelled (Failure "attempt_watchdog_safety_deadline"))
+  (* RFC-XXXX: The per-attempt wall-clock watchdog is removed.
+     Provider-attempt liveness is progress-based:
+       - [stream_idle_timeout_s] catches inter-line stalls
+       - tool-level timeouts and OAS max-turn limits bound tool work and
+         finite turn loops
+     The former watchdog killed healthy active streams that were making
+     progress but slowly, wasting ~570s of productive work per event
+     (~1077 events/24h, 100% at 540-600s latency). The optional supervisor
+     stale-turn watchdog remains the hard-stop path for real no-progress
+     runaways. *)
+  try run () with
   | Eio.Cancel.Cancelled _ as e ->
     on_cancelled ();
     raise e

--- a/lib/keeper/keeper_unified_turn_attempt_watchdog.mli
+++ b/lib/keeper/keeper_unified_turn_attempt_watchdog.mli
@@ -1,19 +1,17 @@
 (** Per-attempt cancel handler for a single keeper turn runtime attempt.
 
-    A wall-clock safety deadline wraps every attempt:
-      - When [attempt_watchdog_s] is [Some deadline], that deadline is used.
-      - When [attempt_watchdog_s] is [None], a generous safety cap of
-        1800s (30 min) prevents a stuck fiber from locking a keeper in
-        [Streaming] state forever. The previous watchdog was removed
-        because it killed healthy streams at 540-600s; the 1800s cap is
-        3x that, targeting only truly stuck fibers.
+    RFC-XXXX: the per-attempt wall-clock watchdog was removed.
+    Provider-attempt liveness is progress-based:
+      - [stream_idle_timeout_s] catches inter-line stalls
+      - tool-level timeouts and OAS max-turn limits bound tool work and
+        finite turn loops
 
     Two outcomes:
 
     - normal completion: pass-through of [run]'s [result]
-    - [Eio.Time.Timeout] (safety deadline) or [Eio.Cancel.Cancelled]:
-      invoke [on_cancelled] for the terminal receipt + FSM transition,
-      then re-raise so the outer cleanup handler observes the cancellation
+    - [Eio.Cancel.Cancelled]: invoke [on_cancelled] for the terminal
+      receipt + FSM transition, then re-raise so the outer cleanup
+      handler observes the cancellation
 
     The Cancelled re-raise path is the outer catch for cancellations
     that escape the in-band receipt builder in
@@ -23,7 +21,6 @@
     timeline. *)
 val dispatch
   :  clock:_ Eio.Time.clock
-  -> attempt_watchdog_s:float option
   -> oas_timeout_s:float
   -> on_cancelled:(unit -> unit)
   -> run:(unit -> ('a, Agent_sdk.Error.sdk_error) result)

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -152,7 +152,6 @@ let run (ctx : ctx)
            Keeper_turn_fsm.Streaming;
          Keeper_unified_turn_attempt_watchdog.dispatch
            ~clock
-           ~attempt_watchdog_s:None
            ~oas_timeout_s
            ~on_cancelled:(fun () ->
              record_streaming_cancelled_observation


### PR DESCRIPTION
## Why

PR #20497 added a 30-minute wall-clock safety watchdog for stuck Streaming fibers.
PR #20506 added body_timeout_s passthrough to OAS calls (10-minute ceiling).

These two mechanisms overlap: both cap total attempt duration.
body_timeout_s (10 min) fires before the watchdog (30 min), making the watchdog dead code.

## What

Revert PR #20497. The OAS-level body_timeout_s is the correct layer for this — it cancels via Eio naturally and surfaces TimeoutError to the retry/FSM layer without keeper-specific watchdog machinery.

Keeps the FSM transition to Cancelled_provider_timeout on timeout because OAS already raises that error variant.

Refs: #20497, #20506