### PR TITLE
refactor(keeper): separate sandbox factory failure classes (#19689)

### DIFF
--- a/lib/keeper/keeper_sandbox_factory.ml
+++ b/lib/keeper/keeper_sandbox_factory.ml
@@ -1,3 +1,8 @@
+type resolve_result =
+  | Runtime of Keeper_turn_sandbox_runtime.t
+  | No_factory
+  | Local_profile
+
 type t = {
   config : Workspace.config;
   meta : Keeper_meta_contract.keeper_meta;
@@ -58,7 +63,7 @@ let resolve (t : t) ~cwd =
       Option.value t.default_network_override ~default:effective_network
     in
     match effective_profile with
-    | Keeper_types_profile_sandbox.Local -> None
+    | Keeper_types_profile_sandbox.Local -> Local_profile
     | Keeper_types_profile_sandbox.Docker ->
       let host_root =
         Keeper_sandbox.host_root_abs_of_meta ~config:t.config meta
@@ -72,7 +77,7 @@ let resolve (t : t) ~cwd =
         , image )
       in
       match Hashtbl.find_opt t.cache key with
-      | Some r -> Some r
+      | Some r -> Runtime r
       | None ->
         let r =
           Keeper_turn_sandbox_runtime.create
@@ -83,10 +88,12 @@ let resolve (t : t) ~cwd =
             ()
         in
         Hashtbl.add t.cache key r;
-        Some r)
+        Runtime r)
 
 let resolve_opt t_opt ~cwd =
-  Option.bind t_opt (fun t -> resolve t ~cwd)
+  match t_opt with
+  | None -> No_factory
+  | Some t -> resolve t ~cwd
 
 let container_cwd_of_host t ~host_cwd =
   let meta = current_meta t in

--- a/lib/keeper/keeper_sandbox_factory.mli
+++ b/lib/keeper/keeper_sandbox_factory.mli
@@ -24,6 +24,11 @@
     [keeper_sandbox_docker] only consumes [Keeper_turn_sandbox_runtime.t]
     as a parameter and never constructs one itself. *)
 
+type resolve_result =
+  | Runtime of Keeper_turn_sandbox_runtime.t
+  | No_factory
+  | Local_profile
+
 type t
 
 val create :
@@ -39,23 +44,24 @@ val create :
 val resolve :
   t ->
   cwd:string ->
-  Keeper_turn_sandbox_runtime.t option
-(** Returns [Some runtime] when {!Keeper_sandbox_runner.effective_sandbox_profile}
+  resolve_result
+(** Returns [Runtime runtime] when {!Keeper_sandbox_runner.effective_sandbox_profile}
     yields [Docker] for the current registry meta, falling back to the
     construction meta when the keeper is not registered. [in_playground] is
     derived from [cwd] vs the keeper's playground root for runtime workspace
     reuse only. Memoizes per [(in_playground, network_mode, host_root, image)]
     so subsequent compatible calls reuse the same container without crossing
-    sandbox-profile or image drift. *)
+    sandbox-profile or image drift.
+
+    [Local_profile] is returned when the effective sandbox profile is [Local].
+    [No_factory] is only produced by {!resolve_opt}. *)
 
 val resolve_opt :
   t option ->
   cwd:string ->
-  Keeper_turn_sandbox_runtime.t option
-(** Convenience wrapper: [None] when [t option] is [None], otherwise
-    delegates to {!resolve}.  Lets call sites that previously matched
-    on [Keeper_turn_sandbox_runtime.t option] keep the same shape after
-    the factory rewrite. *)
+  resolve_result
+(** [No_factory] when [t option] is [None]. Otherwise delegates to {!resolve}.
+    Lets call sites distinguish "factory missing" from "Local profile". *)
 
 val container_cwd_of_host_opt : t option -> host_cwd:string -> string option
 (** Pure Docker CWD projection for response shaping. Unlike {!resolve_opt},

--- a/lib/keeper/keeper_sandbox_read_backend.ml
+++ b/lib/keeper/keeper_sandbox_read_backend.ml
@@ -110,7 +110,7 @@ let run_command_with_status ?turn_sandbox_factory
     ~(command_argv : string list) ~(max_bytes : int)
     ~(timeout_sec : float) () : (Unix.process_status * string, string) result =
   let cwd = host_playground_root ~config ~meta in
-  let runtime_opt =
+  let resolve_result =
     Keeper_sandbox_factory.resolve_opt turn_sandbox_factory ~cwd
   in
   let image =
@@ -118,7 +118,12 @@ let run_command_with_status ?turn_sandbox_factory
     | Some img when String.trim img <> "" -> img
     | _ -> Env_config_sandbox.Runtime.docker_image ()
   in
-  if Option.is_none runtime_opt && String.trim image = "" then
+  let no_runtime =
+    match resolve_result with
+    | Runtime _ -> false
+    | No_factory | Local_profile -> true
+  in
+  if no_runtime && String.trim image = "" then
     Error "keeper sandbox docker image is not configured"
   else if command_argv = [] then
     Error "run_command_with_status: command_argv is empty"
@@ -126,11 +131,11 @@ let run_command_with_status ?turn_sandbox_factory
     let head_program =
       match command_argv with prog :: _ -> prog | [] -> "?"
     in
-    match runtime_opt with
-    | Some runtime ->
+    match resolve_result with
+    | Runtime runtime ->
       Keeper_turn_sandbox_runtime.run_command_with_status
         ~ok_exit_codes runtime ~timeout_sec ~cwd ~command_argv ~max_bytes ()
-    | None ->
+    | No_factory | Local_profile ->
       match Keeper_sandbox_runtime.ensure_keeper_sandbox_image_present ~image ~timeout_sec with
       | Error err ->
         let typed = Keeper_sandbox_error.Image_not_found { image } in

--- a/lib/keeper/keeper_sandbox_shell_ir_target.ml
+++ b/lib/keeper/keeper_sandbox_shell_ir_target.ml
@@ -60,9 +60,15 @@ let docker_target ~turn_sandbox_factory ~meta ~cwd =
   in
   let timeout_sec = internal_sandbox_timeout_sec in
   match Keeper_sandbox_factory.resolve_opt turn_sandbox_factory ~cwd with
-  | None ->
-    Error (target_error "typed Shell IR Docker dispatch requires a turn sandbox factory")
-  | Some runtime ->
+  | No_factory ->
+    Error
+      (target_error
+         "typed Shell IR Docker dispatch requires a turn sandbox factory (no factory provided)")
+  | Local_profile ->
+    Error
+      (target_error
+         "typed Shell IR Docker dispatch requires a turn sandbox factory (sandbox profile is Local)")
+  | Runtime runtime ->
     let image = docker_image meta in
     (match
        Keeper_sandbox_runtime.ensure_keeper_sandbox_image_present_with_class

--- a/lib/keeper/keeper_tool_filesystem_runtime.ml
+++ b/lib/keeper/keeper_tool_filesystem_runtime.ml
@@ -510,8 +510,8 @@ let check_invariant_sandbox_isolation
   | Some factory ->
     let cwd = Filename.dirname target in
     (match Keeper_sandbox_factory.resolve_opt (Some factory) ~cwd with
-     | None -> Ok ()
-     | Some runtime ->
+     | No_factory | Local_profile -> Ok ()
+     | Runtime runtime ->
        let host_root = Keeper_turn_sandbox_runtime.host_root runtime in
        Keeper_invariant.sandbox_isolation
          ~sandbox_roots:[ host_root ]
@@ -601,7 +601,7 @@ let handle_file_write
                                 turn_sandbox_factory
                                 ~cwd:target
                             with
-                            | Some runtime ->
+                            | Runtime runtime ->
                               Keeper_turn_sandbox_runtime.overwrite_file
                                 runtime
                                 ~host_path:target
@@ -611,7 +611,8 @@ let handle_file_write
                                      ~bucket:Io
                                      ())
                                 ()
-                            | None -> Keeper_fs.save_atomic target updated
+                            | No_factory | Local_profile ->
+                              Keeper_fs.save_atomic target updated
                           in
                           (match write_result with
                            | Error msg ->
@@ -685,7 +686,7 @@ let handle_file_write
                             turn_sandbox_factory
                             ~cwd:target
                         with
-                        | Some runtime ->
+                        | Runtime runtime ->
                           (match mode with
                            | Append ->
                              Keeper_turn_sandbox_runtime.append_file
@@ -708,7 +709,7 @@ let handle_file_write
                                     ())
                                ()
                            | Patch -> Ok ())
-                        | None ->
+                        | No_factory | Local_profile ->
                           (match mode with
                            | Append ->
                              let parent = Filename.dirname target in

--- a/lib/keeper/keeper_workspace_ops.ml
+++ b/lib/keeper/keeper_workspace_ops.ml
@@ -96,7 +96,7 @@ let handle_tool_search_files
     let run_in_turn_runtime ?(ok_exit_codes = [ 0 ]) ~cwd ~cmd ~command_argv
         ?host_ir ~max_bytes ?(map_output = fun out -> out) ?(extra = []) () =
       match Keeper_sandbox_factory.resolve_opt turn_sandbox_factory ~cwd with
-      | Some runtime ->
+      | Runtime runtime ->
         (match
            Keeper_turn_sandbox_runtime.run_command_with_status
              ~ok_exit_codes
@@ -114,7 +114,7 @@ let handle_tool_search_files
          | Ok (st, out) ->
            render_completed_process_result ~root ~keeper_name:meta.name ~op ~cwd
              ~cmd ~extra st (map_output out))
-      | None ->
+      | No_factory | Local_profile ->
         (match host_ir with
          | None ->
            error_json

--- a/lib/keeper/keeper_workspace_read_ops.ml
+++ b/lib/keeper/keeper_workspace_read_ops.ml
@@ -116,7 +116,7 @@ let try_handle
   let run_in_turn_runtime ?(ok_exit_codes = [ 0 ]) ~cwd ~cmd ~command_argv
       ?host_ir ~max_bytes ?(map_output = fun out -> out) ?(extra = []) () =
     match Keeper_sandbox_factory.resolve_opt turn_sandbox_factory ~cwd with
-    | Some runtime ->
+    | Runtime runtime ->
       (match
          Keeper_turn_sandbox_runtime.run_command_with_status
            ~ok_exit_codes
@@ -134,7 +134,7 @@ let try_handle
        | Ok (st, out) ->
          render_completed_process_result ~root ~keeper_name:meta.name ~op ~cwd
            ~cmd ~extra st (map_output out))
-    | None ->
+    | No_factory | Local_profile ->
       (match host_ir with
        | None ->
          error_json
@@ -446,7 +446,7 @@ let try_handle
                 ~backend_cmd ~timeout_sec:(Env_config_sandbox.Shell_timeout.timeout_sec ~bucket:Read ()))
          else
            (match Keeper_sandbox_factory.resolve_opt turn_sandbox_factory ~cwd with
-            | Some runtime ->
+            | Runtime runtime ->
               let argv =
                 let base_argv =
                   [
@@ -507,7 +507,7 @@ let try_handle
                        ; "status", Keeper_alerting_path.process_status_to_json st
                        ; "entries", lines_to_json ~limit:50 out
                        ]))
-            | None ->
+            | No_factory | Local_profile ->
               let base_args =
                 [
                   "--no-optional-locks";


### PR DESCRIPTION
## Summary

Refactor `Keeper_sandbox_factory.resolve_opt` to return an explicit sum type
instead of `option`, separating two previously conflated no-sandbox reasons:

- `No_factory` — no turn sandbox factory was provided
- `Local_profile` — factory exists but effective sandbox profile is `Local`

This gives operators distinct diagnostics instead of a single ambiguous
"requires a turn sandbox factory" message.

## Changes

- `lib/keeper/keeper_sandbox_factory.ml` / `.mli`
  - Add `resolve_result = Runtime of ... | No_factory | Local_profile`
  - Update `resolve` and `resolve_opt` signatures
- 6 call-site files (8 call sites total)
  - `keeper_sandbox_shell_ir_target.ml` — differentiated error strings
  - `keeper_tool_filesystem_runtime.ml` — 3 call sites
  - `keeper_workspace_read_ops.ml` — 2 call sites
  - `keeper_workspace_ops.ml` — 1 call site
  - `keeper_sandbox_read_backend.ml` — 1 call site

## Verification

- `dune build lib/keeper` passes
- No behaviour change for the Docker profile path
- Exhaustive match on `resolve_result` enforced by the compiler

Issue: #19689
RFC-WAIVED: Mechanical refactoring (option → closed sum) within a single
subsystem; no new cross-module contracts or security boundaries introduced.