### PR TITLE
fix(keeper): align build_keeper_system_prompt param order in .mli files

### DIFF
--- a/lib/keeper/keeper_context_runtime.mli
+++ b/lib/keeper/keeper_context_runtime.mli
@@ -305,7 +305,6 @@ val build_keeper_system_prompt
   -> ?keeper_name:string
   -> ?home_ground:string
   -> ?active_goals:(string * string * string) list
-  -> ?home_ground:string
   -> unit
   -> string
 

--- a/lib/keeper/keeper_execution.mli
+++ b/lib/keeper/keeper_execution.mli
@@ -67,7 +67,6 @@ val build_keeper_system_prompt :
   ?keeper_name:string ->
   ?home_ground:string ->
   ?active_goals:(string * string * string) list ->
-  ?home_ground:string ->
   unit ->
   string
 

--- a/lib/keeper/keeper_prompt.mli
+++ b/lib/keeper/keeper_prompt.mli
@@ -40,8 +40,8 @@ val build_keeper_system_prompt :
   instructions:string ->
   ?persona_extended:string ->
   ?keeper_name:string ->
-  ?active_goals:(string * string * string) list ->
   ?home_ground:string ->
+  ?active_goals:(string * string * string) list ->
   unit ->
   string
 


### PR DESCRIPTION
## Summary

`dune build .` 에러 3개 수정. `build_keeper_system_prompt`의 optional param 순서가 `.ml`과 `.mli`에서 불일치.

## Changes
- `keeper_prompt.mli`: `?active_goals` ↔ `?home_ground` 순서 swap
- `keeper_execution.mli`: 중복 `?home_ground` 제거  
- `keeper_context_runtime.mli`: 중복 `?home_ground` 제거

## Verification
- `dune build .` 0 에러