### PR TITLE
refactor(ide): extract IdeBreadcrumb and IdeReviewFocusStrip from ide-shell.ts

### DIFF
--- a/dashboard/src/components/ide/ide-breadcrumb.ts
+++ b/dashboard/src/components/ide/ide-breadcrumb.ts
@@ -1,0 +1,137 @@
+import { html } from 'htm/preact'
+import { useEffect, useState } from 'preact/hooks'
+import { activeIdeFile, focusIdeContextAnchor } from './ide-state'
+import { cursorOverlaySignal, getKeeperColor, type KeeperCursor } from './keeper-cursor-overlay'
+import { routeLinksForContext } from './ide-context-lens'
+
+const FILE_ICONS: Readonly<Record<string, string>> = {
+  '.ts': '🟦', '.tsx': '🟦',
+  '.js': '🟨', '.jsx': '🟨',
+  '.py': '🐍', '.ml': '🐫', '.mli': '🐫',
+  '.rs': '🦀', '.go': '🔵',
+  '.json': '📋', '.md': '📝',
+  '.html': '🌐', '.css': '🎨',
+  '.toml': '⚙️', '.yaml': '⚙️', '.yml': '⚙️',
+}
+
+export function IdeBreadcrumb() {
+  const [filePath, setFilePath] = useState(activeIdeFile.value)
+  useEffect(() => {
+    const unsub = activeIdeFile.subscribe(f => setFilePath(f))
+    return () => unsub()
+  }, [])
+
+  const [overlay, setOverlay] = useState(cursorOverlaySignal.value)
+  useEffect(() => {
+    const unsub = cursorOverlaySignal.subscribe(v => setOverlay(v))
+    return () => unsub()
+  }, [])
+
+  if (filePath === null) {
+    return html`
+      <nav
+        aria-label="Editor breadcrumb (no file)"
+        style=${{ color: 'var(--color-fg-disabled)', fontStyle: 'italic' }}
+      >no active file</nav>
+    `
+  }
+  const segments = filePath.split('/')
+  const fileName = segments.at(-1) ?? ""
+  const ext = fileName.includes('.') ? fileName.slice(fileName.lastIndexOf('.')) : ''
+  const icon = FILE_ICONS[ext] ?? '📄'
+
+  const activeOnFile: Array<{
+    readonly keeperId: string
+    readonly color: string
+    readonly focusMode: KeeperCursor['focus_mode']
+    readonly toolName: string | undefined
+    readonly turn: number | undefined
+    readonly line: number
+  }> = []
+  for (const [keeperId, cursor] of overlay.cursors) {
+    if (cursor.file_path === filePath) {
+      activeOnFile.push({
+        keeperId,
+        color: getKeeperColor(keeperId).cursor,
+        focusMode: cursor.focus_mode,
+        toolName: cursor.tool_name,
+        turn: cursor.turn,
+        line: cursor.line,
+      })
+    }
+  }
+
+  const activateKeeperBreadcrumb = (keeper: (typeof activeOnFile)[number]) => {
+    focusIdeContextAnchor({
+      file_path: filePath,
+      line: keeper.line,
+      surface: 'Keeper',
+      label: keeper.toolName ?? keeper.focusMode,
+      source_id: `breadcrumb:${keeper.keeperId}:${keeper.line}`,
+      keeper_id: keeper.keeperId,
+      route_links: routeLinksForContext({
+        filePath,
+        line: keeper.line,
+        surface: 'Keeper',
+        label: keeper.toolName ?? keeper.focusMode,
+        sourceId: `breadcrumb:${keeper.keeperId}:${keeper.line}`,
+        keeperId: keeper.keeperId,
+      }),
+    })
+  }
+
+  return html`
+    <div
+      role="navigation"
+      aria-label="File breadcrumb"
+      data-testid="ide-breadcrumb"
+      class="flex items-center gap-1.5 border-b border-[var(--color-border-divider)] bg-[var(--color-bg-elevated)] px-3 py-1 font-mono text-2xs"
+    >
+      <span aria-hidden="true" style=${{ fontSize: '12px', lineHeight: '16px' }}>${icon}</span>
+      <span
+        class="flex min-w-0 items-center gap-0.5 text-[var(--color-fg-secondary)]"
+        style=${{ overflow: 'hidden' }}
+      >
+        ${segments.map((seg, i) => html`
+          ${i > 0 ? html`<span class="text-[var(--color-fg-disabled)]">/</span>` : null}
+          <span
+            class=${i === segments.length - 1 ? 'text-[var(--color-fg-primary)]' : ''}
+            style=${{ whiteSpace: 'nowrap' }}
+          >${seg}</span>
+        `)}
+      </span>
+      ${activeOnFile.length > 0
+        ? html`
+          <span class="flex items-center gap-1 ml-auto shrink-0">
+            ${activeOnFile.map(k => html`
+              <button
+                key=${k.keeperId}
+                type="button"
+                class="ide-breadcrumb-keeper"
+                title=${`${k.keeperId} · ${k.focusMode}${k.toolName ? ` · ${k.toolName}` : ''}${k.turn != null ? ` · turn ${k.turn}` : ''}`}
+                aria-label=${`Focus ${k.keeperId} keeper context at line ${k.line}`}
+                onClick=${() => activateKeeperBreadcrumb(k)}
+                style=${{ color: 'var(--color-fg-muted)' }}
+              >
+                <span
+                  aria-hidden="true"
+                  style=${{
+                    width: '7px',
+                    height: '7px',
+                    borderRadius: '50%',
+                    background: k.color,
+                    display: 'inline-block',
+                    boxShadow: k.focusMode === 'editing' ? `0 0 4px ${k.color}` : 'none',
+                  }}
+                />
+                <span>${k.keeperId}</span>
+                ${k.toolName ? html`<span class="text-[var(--color-fg-disabled)]" style=${{ fontSize: '10px' }}>${k.toolName}</span>` : null}
+                ${k.turn != null ? html`<span style=${{ fontSize: '10px', color: 'var(--color-accent-fg)' }}>T${k.turn}</span>` : null}
+              </button>
+            `)}
+          </span>
+        `
+        : null}
+    </div>
+  `
+}

--- a/dashboard/src/components/ide/ide-review-focus-strip.ts
+++ b/dashboard/src/components/ide/ide-review-focus-strip.ts
@@ -1,0 +1,21 @@
+import { html } from 'htm/preact'
+import { IDE_LAYER_LABELS, REVIEW_FOCUS_LAYERS } from './ide-toolbar'
+
+export function IdeReviewFocusStrip({ activeLayers }: { readonly activeLayers: ReadonlySet<string> }) {
+  const layerLabels = REVIEW_FOCUS_LAYERS
+    .filter(layer => activeLayers.has(layer))
+    .map(layer => IDE_LAYER_LABELS.get(layer) ?? layer)
+
+  return html`
+    <div
+      data-testid="ide-review-focus"
+      class="flex flex-wrap items-center gap-2 border-b border-[var(--color-border-divider)] bg-[var(--color-bg-elevated)] px-3 py-2 text-2xs text-[var(--color-fg-muted)]"
+    >
+      <span class="font-mono uppercase tracking-[var(--track-caps)] text-[var(--color-accent-fg)]">review focus</span>
+      <span class="font-mono">UNIFIED</span>
+      <span class="text-[var(--color-fg-disabled)]">·</span>
+      <span class="font-mono">${layerLabels.length > 0 ? layerLabels.join(' / ') : 'custom layers'}</span>
+      <span class="ml-auto font-mono text-[var(--color-fg-disabled)]">context rail</span>
+    </div>
+  `
+}

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -17,13 +17,19 @@ import { IdeKeeperWorkPanel } from './ide-keeper-work-panel'
 import { IdeInterject } from './ide-interject'
 import { ExecuteOutputDrawer } from './execute-output-drawer'
 import { IdePresenceStrip } from './ide-presence-strip'
-import { IDE_LAYERS, IdeToolbar } from './ide-toolbar'
+import {
+  IDE_LAYERS,
+  IDE_LAYER_LABELS,
+  REVIEW_FOCUS_LAYERS,
+  IdeToolbar,
+} from './ide-toolbar'
+import { IdeBreadcrumb } from './ide-breadcrumb'
+import { IdeReviewFocusStrip } from './ide-review-focus-strip'
 import { InspectorKeeperBDI } from './inspector-keeper-bdi'
 import { pinKeeper } from './multi-keeper-pin-store'
 import { OverlayKeeperTrace } from './overlay-keeper-trace'
 import { IdePersistencePanel } from './ide-persistence-panel'
 import { IdeMemoryPanel } from './ide-memory-panel'
-import { cursorOverlaySignal, getKeeperColor, type KeeperCursor } from './keeper-cursor-overlay'
 import { routeLinksForContext } from './ide-context-lens'
 import { navigate, route } from '../../router'
 import { activeKeeperName } from '../../keeper-state'
@@ -58,9 +64,7 @@ export interface IdeStatusbarModel {
 }
 
 const IDE_LAYER_KINDS = new Set(IDE_LAYERS.map(layer => layer.kind))
-const IDE_LAYER_LABELS = new Map(IDE_LAYERS.map(layer => [layer.kind, layer.label]))
 const IDE_ACTIVITY_POLL_MS = 10_000
-export const REVIEW_FOCUS_LAYERS = ['keeper-trace', 'approve', 'notes'] as const
 const REVIEW_FOCUS_LAYER_PARAM = REVIEW_FOCUS_LAYERS.join(',')
 const EMPTY_LAYER_PARAM = 'none'
 const STATUSBAR_LAYER_PRIORITY: ReadonlyArray<string> = [
@@ -769,156 +773,3 @@ function useSubscribedValue<T>(
   return value
 }
 
-function IdeReviewFocusStrip({ activeLayers }: { readonly activeLayers: ReadonlySet<string> }) {
-  const layerLabels = REVIEW_FOCUS_LAYERS
-    .filter(layer => activeLayers.has(layer))
-    .map(layer => IDE_LAYER_LABELS.get(layer) ?? layer)
-
-  return html`
-    <div
-      data-testid="ide-review-focus"
-      class="flex flex-wrap items-center gap-2 border-b border-[var(--color-border-divider)] bg-[var(--color-bg-elevated)] px-3 py-2 text-2xs text-[var(--color-fg-muted)]"
-    >
-      <span class="font-mono uppercase tracking-[var(--track-caps)] text-[var(--color-accent-fg)]">review focus</span>
-      <span class="font-mono">UNIFIED</span>
-      <span class="text-[var(--color-fg-disabled)]">·</span>
-      <span class="font-mono">${layerLabels.length > 0 ? layerLabels.join(' / ') : 'custom layers'}</span>
-      <span class="ml-auto font-mono text-[var(--color-fg-disabled)]">context rail</span>
-    </div>
-  `
-}
-
-// ── Editor Breadcrumb ────────────────────────────────────────────
-
-const FILE_ICONS: Readonly<Record<string, string>> = {
-  '.ts': '🟦', '.tsx': '🟦',
-  '.js': '🟨', '.jsx': '🟨',
-  '.py': '🐍', '.ml': '🐫', '.mli': '🐫',
-  '.rs': '🦀', '.go': '🔵',
-  '.json': '📋', '.md': '📝',
-  '.html': '🌐', '.css': '🎨',
-  '.toml': '⚙️', '.yaml': '⚙️', '.yml': '⚙️',
-}
-
-function IdeBreadcrumb() {
-  const [filePath, setFilePath] = useState(activeIdeFile.value)
-  useEffect(() => {
-    const unsub = activeIdeFile.subscribe(f => setFilePath(f))
-    return () => unsub()
-  }, [])
-
-  const [overlay, setOverlay] = useState(cursorOverlaySignal.value)
-  useEffect(() => {
-    const unsub = cursorOverlaySignal.subscribe(v => setOverlay(v))
-    return () => unsub()
-  }, [])
-
-  if (filePath === null) {
-    return html`
-      <nav
-        aria-label="Editor breadcrumb (no file)"
-        style=${{ color: 'var(--color-fg-disabled)', fontStyle: 'italic' }}
-      >no active file</nav>
-    `
-  }
-  const segments = filePath.split('/')
-  const fileName = segments.at(-1) ?? ""
-  const ext = fileName.includes('.') ? fileName.slice(fileName.lastIndexOf('.')) : ''
-  const icon = FILE_ICONS[ext] ?? '📄'
-
-  // Keepers currently on this file with activity detail
-  const activeOnFile: Array<{
-    readonly keeperId: string
-    readonly color: string
-    readonly focusMode: KeeperCursor['focus_mode']
-    readonly toolName: string | undefined
-    readonly turn: number | undefined
-    readonly line: number
-  }> = []
-  for (const [keeperId, cursor] of overlay.cursors) {
-    if (cursor.file_path === filePath) {
-      activeOnFile.push({
-        keeperId,
-        color: getKeeperColor(keeperId).cursor,
-        focusMode: cursor.focus_mode,
-        toolName: cursor.tool_name,
-        turn: cursor.turn,
-        line: cursor.line,
-      })
-    }
-  }
-
-  const activateKeeperBreadcrumb = (keeper: (typeof activeOnFile)[number]) => {
-    focusIdeContextAnchor({
-      file_path: filePath,
-      line: keeper.line,
-      surface: 'Keeper',
-      label: keeper.toolName ?? keeper.focusMode,
-      source_id: `breadcrumb:${keeper.keeperId}:${keeper.line}`,
-      keeper_id: keeper.keeperId,
-      route_links: routeLinksForContext({
-        filePath,
-        line: keeper.line,
-        surface: 'Keeper',
-        label: keeper.toolName ?? keeper.focusMode,
-        sourceId: `breadcrumb:${keeper.keeperId}:${keeper.line}`,
-        keeperId: keeper.keeperId,
-      }),
-    })
-  }
-
-  return html`
-    <div
-      role="navigation"
-      aria-label="File breadcrumb"
-      data-testid="ide-breadcrumb"
-      class="flex items-center gap-1.5 border-b border-[var(--color-border-divider)] bg-[var(--color-bg-elevated)] px-3 py-1 font-mono text-2xs"
-    >
-      <span aria-hidden="true" style=${{ fontSize: '12px', lineHeight: '16px' }}>${icon}</span>
-      <span
-        class="flex min-w-0 items-center gap-0.5 text-[var(--color-fg-secondary)]"
-        style=${{ overflow: 'hidden' }}
-      >
-        ${segments.map((seg, i) => html`
-          ${i > 0 ? html`<span class="text-[var(--color-fg-disabled)]">/</span>` : null}
-          <span
-            class=${i === segments.length - 1 ? 'text-[var(--color-fg-primary)]' : ''}
-            style=${{ whiteSpace: 'nowrap' }}
-          >${seg}</span>
-        `)}
-      </span>
-      ${activeOnFile.length > 0
-        ? html`
-          <span class="flex items-center gap-1 ml-auto shrink-0">
-            ${activeOnFile.map(k => html`
-              <button
-                key=${k.keeperId}
-                type="button"
-                class="ide-breadcrumb-keeper"
-                title=${`${k.keeperId} · ${k.focusMode}${k.toolName ? ` · ${k.toolName}` : ''}${k.turn != null ? ` · turn ${k.turn}` : ''}`}
-                aria-label=${`Focus ${k.keeperId} keeper context at line ${k.line}`}
-                onClick=${() => activateKeeperBreadcrumb(k)}
-                style=${{ color: 'var(--color-fg-muted)' }}
-              >
-                <span
-                  aria-hidden="true"
-                  style=${{
-                    width: '7px',
-                    height: '7px',
-                    borderRadius: '50%',
-                    background: k.color,
-                    display: 'inline-block',
-                    boxShadow: k.focusMode === 'editing' ? `0 0 4px ${k.color}` : 'none',
-                  }}
-                />
-                <span>${k.keeperId}</span>
-                ${k.toolName ? html`<span class="text-[var(--color-fg-disabled)]" style=${{ fontSize: '10px' }}>${k.toolName}</span>` : null}
-                ${k.turn != null ? html`<span style=${{ fontSize: '10px', color: 'var(--color-accent-fg)' }}>T${k.turn}</span>` : null}
-              </button>
-            `)}
-          </span>
-        `
-        : null}
-    </div>
-  `
-}

--- a/dashboard/src/components/ide/ide-toolbar.ts
+++ b/dashboard/src/components/ide/ide-toolbar.ts
@@ -49,6 +49,9 @@ export const IDE_LAYERS: ReadonlyArray<OverlayLayer> = [
   { kind: 'explode', label: 'EXPLODE', description: 'per-keeper ghost copies', mutuallyExclusive: true },
 ]
 
+export const IDE_LAYER_LABELS = new Map(IDE_LAYERS.map(layer => [layer.kind, layer.label]))
+export const REVIEW_FOCUS_LAYERS = ['keeper-trace', 'approve', 'notes'] as const
+
 interface IdeToolbarProps {
   readonly activeView: ViewTab
   readonly activeLayers: ReadonlySet<string>


### PR DESCRIPTION
## Summary

Extract two sub-components from the oversized `ide-shell.ts` (924 → 775 lines) to improve maintainability and separate concerns.

### Changes

- **New** `ide-breadcrumb.ts`: `IdeBreadcrumb` component + `FILE_ICONS` constant (~130 lines)
- **New** `ide-review-focus-strip.ts`: `IdeReviewFocusStrip` component (~20 lines)
- **Modified** `ide-toolbar.ts`: export `IDE_LAYER_LABELS` and `REVIEW_FOCUS_LAYERS` as the SSOT for layer definitions, preventing circular dependencies
- **Modified** `ide-shell.ts`: import the extracted components and constants, remove inlined definitions

### Why

`ide-shell.ts` had grown to 924 lines with mixed responsibilities (routing utilities, statusbar model, shell component, breadcrumb, review focus strip). Per the 300-line file threshold, splitting out standalone UI components reduces cognitive load and enables independent iteration.

### Verification

- [x] Components compile after extraction (import graph verified)
- [x] No circular dependencies introduced
- [x] `IDE_LAYER_LABELS` and `REVIEW_FOCUS_LAYERS` moved to `ide-toolbar.ts` (already the SSOT for `IDE_LAYERS`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)