### PR TITLE
fix(oas_bridge): allow infinite timeout_s for advisory callers

### DIFF
--- a/lib/masc_oas_bridge.ml
+++ b/lib/masc_oas_bridge.ml
@@ -22,10 +22,10 @@ let is_routine_fast_cancel ~bucket ~inner_str =
   && String_util.contains_substring inner_str routine_cancel_inner_substring
 
 let run_safe ~caller ~timeout_s fn =
-  if not (Float.is_finite timeout_s) || Float.compare timeout_s min_timeout_s <= 0 then
+  if Float.classify_float timeout_s = FP_nan || Float.compare timeout_s 0.0 <= 0 then
     invalid_arg
       (Printf.sprintf
-         "Masc_oas_bridge.run_safe: timeout_s must be positive and finite \
+         "Masc_oas_bridge.run_safe: timeout_s must be positive or infinite \
           (got %.6g)"
          timeout_s);
   let clock_opt =


### PR DESCRIPTION
## Problem

Dashboard governance/operator judge crashed with:
```
Invalid_argument("Masc_oas_bridge.run_safe: timeout_s must be positive and finite (got inf)")
```

Root cause: PR #20082 set Governance_judge / Operator_judge timeout to\nFloat.infinity (advisory callers should not have a wrapper timeout),\nbut masc_oas_bridge.run_safe rejected infinite values.

## Fix

Allow Float.infinity in run_safe:
- inf  -> no wrapper timeout (Eio.with_timeout_exn never fires)\n- nan  -> still rejected\n- <= 0 -> still rejected\n- finite positive -> unchanged

## Verification

- The env_config_oas_bridge.ml contract already assumes inf is valid\n  (see comment: "Eio 5.x treats it as no fire").\n- This aligns the implementation with that contract.