### PR TITLE
[#19689] Scrub ambient env in Docker/System sandbox subprocesses (slice 2)

### DIFF
--- a/lib/keeper/keeper_sandbox_control.ml
+++ b/lib/keeper/keeper_sandbox_control.ml
@@ -225,7 +225,7 @@ let start_managed_container
                         ~actor:`System_sandbox
                         ~raw_source:(String.concat " " argv)
                         ~summary:"keeper sandbox control exec"
-                        ~env:(Unix.environment ())
+                        ~env:(Env_keeper_scrub.filter_environment (Unix.environment ()))
                         ~cwd:(Sys.getcwd ())
                         ~timeout_sec
                         argv)

--- a/lib/keeper/keeper_sandbox_docker.ml
+++ b/lib/keeper/keeper_sandbox_docker.ml
@@ -197,7 +197,7 @@ let cleanup_oneshot_container ~container_name =
         ~actor:`System_sandbox
         ~raw_source:(String.concat " " argv)
         ~summary:"keeper docker oneshot cleanup"
-        ~env:(Unix.environment ())
+        ~env:(Env_keeper_scrub.filter_environment (Unix.environment ()))
         ~cwd:(Sys.getcwd ())
         ~timeout_sec:(docker_cleanup_rm_timeout_sec ())
         argv)
@@ -571,7 +571,7 @@ let run_docker_shell_command_with_status_internal
                                 ~actor:`System_sandbox
                                 ~raw_source:(String.concat " " argv)
                                 ~summary:"keeper docker command"
-                                ~env:(Unix.environment ())
+                                ~env:(Env_keeper_scrub.filter_environment (Unix.environment ()))
                                 ~cwd:(Sys.getcwd ())
                                 ~timeout_sec
                                 ~stdin_content:cmd

--- a/lib/keeper/keeper_sandbox_read_backend.ml
+++ b/lib/keeper/keeper_sandbox_read_backend.ml
@@ -159,7 +159,7 @@ let run_command_with_status ?turn_sandbox_factory
                 ~actor:`System_sandbox
                 ~raw_source:(String.concat " " argv)
                 ~summary:"keeper docker read sandboxed command"
-                ~env:(Unix.environment ())
+                ~env:(Env_keeper_scrub.filter_environment (Unix.environment ()))
                 ~cwd:(Sys.getcwd ()) ~timeout_sec argv)
         in
         (match st with

--- a/lib/keeper/keeper_sandbox_runtime_setup.ml
+++ b/lib/keeper/keeper_sandbox_runtime_setup.ml
@@ -50,7 +50,7 @@ let run_docker_argv_with_status ~summary ~timeout_sec argv =
       ~actor:`System_sandbox
       ~raw_source:(String.concat " " argv)
       ~summary
-      ~env:(Unix.environment ())
+      ~env:(Env_keeper_scrub.filter_environment (Unix.environment ()))
       ~cwd:(Sys.getcwd ())
       ~timeout_sec
       argv)

--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -200,7 +200,7 @@ let run_argv_with_status_retry_eintr ?timeout_sec argv =
           ~actor:`System_sandbox
           ~raw_source:(String.concat " " argv)
           ~summary:"keeper turn sandbox command"
-          ~env:(Unix.environment ())
+          ~env:(Env_keeper_scrub.filter_environment (Unix.environment ()))
           ~cwd:(Sys.getcwd ())
           argv
       in
@@ -231,7 +231,7 @@ let run_argv_with_status_split_retry_eintr ?timeout_sec argv =
           ~actor:`System_sandbox
           ~raw_source:(String.concat " " argv)
           ~summary:"keeper turn sandbox command"
-          ~env:(Unix.environment ())
+          ~env:(Env_keeper_scrub.filter_environment (Unix.environment ()))
           ~cwd:(Sys.getcwd ())
           argv
       in
@@ -256,7 +256,7 @@ let run_argv_with_stdin_and_status_retry_eintr ?timeout_sec ~stdin_content argv 
           ~actor:`System_sandbox
           ~raw_source:(String.concat " " argv)
           ~summary:"keeper turn sandbox stdin command"
-          ~env:(Unix.environment ())
+          ~env:(Env_keeper_scrub.filter_environment (Unix.environment ()))
           ~cwd:(Sys.getcwd ())
           ~stdin_content
           argv
@@ -281,7 +281,7 @@ let run_argv_with_stdin_and_status_split_retry_eintr ?timeout_sec ~stdin_content
           ~actor:`System_sandbox
           ~raw_source:(String.concat " " argv)
           ~summary:"keeper turn sandbox stdin command"
-          ~env:(Unix.environment ())
+          ~env:(Env_keeper_scrub.filter_environment (Unix.environment ()))
           ~cwd:(Sys.getcwd ())
           ~stdin_content
           argv
@@ -589,7 +589,7 @@ let run_exec_pipeline_with_status_once
           let cwd = Option.value stage_cwd ~default:cwd in
           let container_cwd = container_cwd_of_host t ~host_cwd:cwd in
           let argv = docker_exec_pipeline_argv t ~container_name ~container_cwd command_argv in
-          { Process_eio.argv; env = Some (Unix.environment ()); cwd = Some (Sys.getcwd ()) })
+          { Process_eio.argv; env = Some (Env_keeper_scrub.filter_environment (Unix.environment ())); cwd = Some (Sys.getcwd ()) })
         stages
     in
     Ok (run_argv_pipeline_with_status_split_retry_eintr process_stages)

--- a/test/test_keeper_sandbox_read_backend.ml
+++ b/test/test_keeper_sandbox_read_backend.ml
@@ -350,6 +350,24 @@ fi\n\
 printf 'unexpected docker invocation\\n' >&2\n\
 exit 2\n"
 
+let fake_docker_env_dump_script =
+  "#!/bin/sh\n\
+if [ \"$1\" = \"info\" ]; then\n\
+  printf '[]\\n'\n\
+  exit 0\n\
+fi\n\
+if [ \"$1\" = \"image\" ] && [ \"$2\" = \"inspect\" ] && [ \"$3\" = \"alpine:test\" ]; then\n\
+  printf '[]\\n'\n\
+  exit 0\n\
+fi\n\
+if [ \"$1\" = \"run\" ]; then\n\
+  env > \"${KEEPER_DOCKER_LOG}.env\"\n\
+  printf 'ok\\n'\n\
+  exit 0\n\
+fi\n\
+printf 'unexpected docker invocation\\n' >&2\n\
+exit 2\n"
+
 let fake_docker_turn_runtime_script =
   "#!/bin/sh\n\
 log_file=${KEEPER_DOCKER_LOG:-}\n\
@@ -1110,6 +1128,29 @@ let test_run_command_fallback_uses_docker_spawn_slot ~clock () =
        Alcotest.(check string) "slow docker stdout" "slow ok\n" out);
    Alcotest.(check int) "Docker_spawn slot released" 0
      (docker_spawn_in_flight ())
+
+let test_run_command_scrubs_sensitive_env () =
+  with_fake_docker fake_docker_env_dump_script @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
+  with_env "GH_TOKEN" "ghp_secret" @@ fun () ->
+  with_env "ANTHROPIC_API_KEY" "sk-ant-secret" @@ fun () ->
+  let base, config, meta = setup_config "minjae" in
+  let log_path = Filename.concat base "docker.log" in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
+  match
+    Keeper_sandbox_read_backend.run_command_with_status ~config ~meta
+      ~command_argv:[ "echo"; "hello" ]
+      ~max_bytes:4096 ~timeout_sec:5.0 ()
+  with
+  | Error msg -> Alcotest.failf "expected success, got %s" msg
+  | Ok (_st, _out) ->
+      let env_dump_path = log_path ^ ".env" in
+      let env_dump = read_file env_dump_path in
+      Alcotest.(check bool) "GH_TOKEN scrubbed" false
+        (contains_substring env_dump "GH_TOKEN=");
+      Alcotest.(check bool) "ANTHROPIC_API_KEY scrubbed" false
+        (contains_substring env_dump "ANTHROPIC_API_KEY=")
 
 let test_turn_runtime_reuses_single_container () =
   with_fake_docker fake_docker_turn_runtime_script @@ fun () ->


### PR DESCRIPTION
## Summary

Issue #19689 slice 2: Apply `Env_keeper_scrub.filter_environment` to all Docker and System sandbox subprocess spawns.

### Changes
- `lib/keeper/keeper_sandbox_control.ml`: `start_managed_container` docker run
- `lib/keeper/keeper_sandbox_docker.ml`: 2 spawn sites
- `lib/keeper/keeper_sandbox_read_backend.ml`: fallback docker spawn
- `lib/keeper/keeper_sandbox_runtime_setup.ml`: `run_docker_argv_with_status`
- `lib/keeper/keeper_turn_sandbox_runtime.ml`: 5 sites + `Process_eio` env record
- `test/test_keeper_sandbox_read_backend.ml`: regression test verifying sensitive keys are scrubbed

### Verification
- `dune build @check` PASS
- `dune build test/test_keeper_sandbox_read_backend.exe` PASS
- 35/35 tests run (1 pre-existing flaky failure in `run_command.005` unrelated to this change)

### RFC Check
`bash ~/me/scripts/pr-rfc-check.sh --pr-body /tmp/pr-body.md` PASS