### PR TITLE
refactor(dashboard): typed thread kind parsing in ide-conversation-rail

### DIFF
--- a/dashboard/src/components/ide/ide-conversation-rail.test.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail.test.ts
@@ -3,6 +3,7 @@ import { h } from 'preact'
 import { render } from 'preact'
 import { fireEvent, waitFor } from '@testing-library/preact'
 import {
+  boardKindFromPost,
   conversationContextSummary,
   IdeConversationRail,
   postsToAnchoredThreads,
@@ -498,5 +499,42 @@ describe('IdeConversationRail', () => {
     })
 
     expect(conversationContextSummary([])).toBeNull()
+  })
+})
+
+describe('boardKindFromPost', () => {
+  function stubPost(hearth: string | null): BoardPost {
+    return {
+      id: 'p-1',
+      author: 'keeper',
+      title: 'title',
+      body: 'body',
+      content: 'content',
+      tags: [],
+      votes: 0,
+      comment_count: 0,
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+      hearth,
+    } as BoardPost
+  }
+
+  it('maps known hearth values to ThreadKind', () => {
+    expect(boardKindFromPost(stubPost('approve'))).toBe('approve')
+    expect(boardKindFromPost(stubPost('flag'))).toBe('flag')
+    expect(boardKindFromPost(stubPost('question'))).toBe('question')
+    expect(boardKindFromPost(stubPost('suggest'))).toBe('suggest')
+    expect(boardKindFromPost(stubPost('note'))).toBe('note')
+  })
+
+  it('is case-insensitive for hearth', () => {
+    expect(boardKindFromPost(stubPost('APPROVE'))).toBe('approve')
+    expect(boardKindFromPost(stubPost('Flag'))).toBe('flag')
+  })
+
+  it('defaults to note for unknown or missing hearth', () => {
+    expect(boardKindFromPost(stubPost(null))).toBe('note')
+    expect(boardKindFromPost(stubPost(''))).toBe('note')
+    expect(boardKindFromPost(stubPost('unknown'))).toBe('note')
   })
 })

--- a/dashboard/src/components/ide/ide-conversation-rail.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail.ts
@@ -93,23 +93,22 @@ function parseIsoToMs(iso: string): number {
   return new Date(iso).getTime()
 }
 
-function boardKindFromPost(post: BoardPost): ThreadKind {
-  if (post.hearth) {
-    switch (post.hearth.toLowerCase()) {
-      case 'approve': return 'approve'
-      case 'flag': return 'flag'
-      case 'question': return 'question'
-      case 'suggest': return 'suggest'
-      case 'note': return 'note'
-    }
+function parseThreadKind(hearth: string): ThreadKind | null {
+  switch (hearth.toLowerCase()) {
+    case 'approve': return 'approve'
+    case 'flag': return 'flag'
+    case 'question': return 'question'
+    case 'suggest': return 'suggest'
+    case 'note': return 'note'
+    default: return null
   }
-  const body = (post.body ?? '').toLowerCase()
-  const title = (post.title ?? '').toLowerCase()
-  const text = `${title} ${body}`
-  if (text.includes('approve') || text.includes('ship it') || text.includes('looks good')) return 'approve'
-  if (text.includes('flag') || text.includes('blocker') || text.includes('race condition')) return 'flag'
-  if (text.includes('suggest') || text.includes('could you') || text.includes('recommend')) return 'suggest'
-  if (text.includes('?') || text.includes('question') || text.includes('should')) return 'question'
+}
+
+export function boardKindFromPost(post: BoardPost): ThreadKind {
+  if (post.hearth) {
+    const kind = parseThreadKind(post.hearth)
+    if (kind !== null) return kind
+  }
   return 'note'
 }
 


### PR DESCRIPTION
## Summary
- Replace `boardKindFromPost` string-substring heuristic with exhaustive typed `parseThreadKind`.
- Export `boardKindFromPost` for direct unit testing.
- Add 3 test cases covering known hearth mapping, case insensitivity, and default fallback.

## Motivation
The previous implementation fell back to scanning `post.body` and `post.title` for keywords like "approve", "flag", "blocker", "?", etc. This is a string-classifier anti-pattern: it silently misclassifies posts, cannot be exhaustively checked by the compiler, and drifts as content conventions change. A typed closed sum (`ThreadKind`) should be parsed from a single structured field (`hearth`), not inferred from free text.

## Verification
- `boardKindFromPost` is now pure: `hearth` -> `ThreadKind` with a null default to `'note'`.
- Unit tests added in `ide-conversation-rail.test.ts`.

## Checklist
- [x] Typed parse (no substring fallback)
- [x] Exported for testability
- [x] Unit tests added
- [ ] Local test run (no node_modules in worktree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)