### PR TITLE
feat: bootstrap health proof for MASC_INTERNAL_MCP_TOKEN (#19689 slice 1)

### DIFF
--- a/lib/keeper/keeper_sandbox_control.ml
+++ b/lib/keeper/keeper_sandbox_control.ml
@@ -225,7 +225,7 @@ let start_managed_container
                         ~actor:`System_sandbox
                         ~raw_source:(String.concat " " argv)
                         ~summary:"keeper sandbox control exec"
-                        ~env:(Unix.environment ())
+                        ~env:(Env_keeper_scrub.filter_environment (Unix.environment ()))
                         ~cwd:(Sys.getcwd ())
                         ~timeout_sec
                         argv)

--- a/lib/keeper/keeper_sandbox_docker.ml
+++ b/lib/keeper/keeper_sandbox_docker.ml
@@ -197,7 +197,7 @@ let cleanup_oneshot_container ~container_name =
         ~actor:`System_sandbox
         ~raw_source:(String.concat " " argv)
         ~summary:"keeper docker oneshot cleanup"
-        ~env:(Unix.environment ())
+        ~env:(Env_keeper_scrub.filter_environment (Unix.environment ()))
         ~cwd:(Sys.getcwd ())
         ~timeout_sec:(docker_cleanup_rm_timeout_sec ())
         argv)
@@ -571,7 +571,7 @@ let run_docker_shell_command_with_status_internal
                                 ~actor:`System_sandbox
                                 ~raw_source:(String.concat " " argv)
                                 ~summary:"keeper docker command"
-                                ~env:(Unix.environment ())
+                                ~env:(Env_keeper_scrub.filter_environment (Unix.environment ()))
                                 ~cwd:(Sys.getcwd ())
                                 ~timeout_sec
                                 ~stdin_content:cmd

--- a/lib/keeper/keeper_sandbox_read_backend.ml
+++ b/lib/keeper/keeper_sandbox_read_backend.ml
@@ -159,7 +159,7 @@ let run_command_with_status ?turn_sandbox_factory
                 ~actor:`System_sandbox
                 ~raw_source:(String.concat " " argv)
                 ~summary:"keeper docker read sandboxed command"
-                ~env:(Unix.environment ())
+                ~env:(Env_keeper_scrub.filter_environment (Unix.environment ()))
                 ~cwd:(Sys.getcwd ()) ~timeout_sec argv)
         in
         (match st with

--- a/lib/keeper/keeper_sandbox_runtime_setup.ml
+++ b/lib/keeper/keeper_sandbox_runtime_setup.ml
@@ -50,7 +50,7 @@ let run_docker_argv_with_status ~summary ~timeout_sec argv =
       ~actor:`System_sandbox
       ~raw_source:(String.concat " " argv)
       ~summary
-      ~env:(Unix.environment ())
+      ~env:(Env_keeper_scrub.filter_environment (Unix.environment ()))
       ~cwd:(Sys.getcwd ())
       ~timeout_sec
       argv)

--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -200,7 +200,7 @@ let run_argv_with_status_retry_eintr ?timeout_sec argv =
           ~actor:`System_sandbox
           ~raw_source:(String.concat " " argv)
           ~summary:"keeper turn sandbox command"
-          ~env:(Unix.environment ())
+          ~env:(Env_keeper_scrub.filter_environment (Unix.environment ()))
           ~cwd:(Sys.getcwd ())
           argv
       in
@@ -231,7 +231,7 @@ let run_argv_with_status_split_retry_eintr ?timeout_sec argv =
           ~actor:`System_sandbox
           ~raw_source:(String.concat " " argv)
           ~summary:"keeper turn sandbox command"
-          ~env:(Unix.environment ())
+          ~env:(Env_keeper_scrub.filter_environment (Unix.environment ()))
           ~cwd:(Sys.getcwd ())
           argv
       in
@@ -256,7 +256,7 @@ let run_argv_with_stdin_and_status_retry_eintr ?timeout_sec ~stdin_content argv 
           ~actor:`System_sandbox
           ~raw_source:(String.concat " " argv)
           ~summary:"keeper turn sandbox stdin command"
-          ~env:(Unix.environment ())
+          ~env:(Env_keeper_scrub.filter_environment (Unix.environment ()))
           ~cwd:(Sys.getcwd ())
           ~stdin_content
           argv
@@ -281,7 +281,7 @@ let run_argv_with_stdin_and_status_split_retry_eintr ?timeout_sec ~stdin_content
           ~actor:`System_sandbox
           ~raw_source:(String.concat " " argv)
           ~summary:"keeper turn sandbox stdin command"
-          ~env:(Unix.environment ())
+          ~env:(Env_keeper_scrub.filter_environment (Unix.environment ()))
           ~cwd:(Sys.getcwd ())
           ~stdin_content
           argv
@@ -589,7 +589,7 @@ let run_exec_pipeline_with_status_once
           let cwd = Option.value stage_cwd ~default:cwd in
           let container_cwd = container_cwd_of_host t ~host_cwd:cwd in
           let argv = docker_exec_pipeline_argv t ~container_name ~container_cwd command_argv in
-          { Process_eio.argv; env = Some (Unix.environment ()); cwd = Some (Sys.getcwd ()) })
+          { Process_eio.argv; env = Some (Env_keeper_scrub.filter_environment (Unix.environment ())); cwd = Some (Sys.getcwd ()) })
         stages
     in
     Ok (run_argv_pipeline_with_status_split_retry_eintr process_stages)

--- a/lib/otel_metric_store/otel_identity_metric_names.ml
+++ b/lib/otel_metric_store/otel_identity_metric_names.ml
@@ -61,3 +61,7 @@ let metric_governance_judge_unparseable = "masc_governance_judge_unparseable_tot
 let metric_governance_lenient_json_fallback_hit =
   "masc_governance_lenient_json_fallback_hit_total"
 ;;
+
+let metric_startup_internal_keeper_token_sync =
+  "masc_startup_internal_keeper_token_sync_total"
+;;

--- a/lib/otel_metric_store/otel_identity_metric_names.mli
+++ b/lib/otel_metric_store/otel_identity_metric_names.mli
@@ -23,3 +23,4 @@ val metric_workspace_bind_normalize_outcome : string
 val metric_config_unknown_keys_ignored : string
 val metric_governance_judge_unparseable : string
 val metric_governance_lenient_json_fallback_hit : string
+val metric_startup_internal_keeper_token_sync : string

--- a/lib/server/server_runtime_startup_credentials.ml
+++ b/lib/server/server_runtime_startup_credentials.ml
@@ -54,10 +54,31 @@ let sync_admin_token_env (state : Mcp_server.server_state) =
 
 let sync_internal_keeper_token_env (state : Mcp_server.server_state) =
   let base_path = state.Mcp_server.workspace_config.base_path in
+  let pre_existing =
+    match Sys.getenv_opt "MASC_INTERNAL_MCP_TOKEN" with
+    | Some raw when String.trim raw <> "" -> true
+    | _ -> false
+  in
   let raw_token = Auth.ensure_internal_keeper_token base_path in
   Unix.putenv "MASC_INTERNAL_MCP_TOKEN" raw_token;
-  Log.Server.info
-    "startup internal keeper MCP token synced via MASC_INTERNAL_MCP_TOKEN"
+  let post_existing =
+    match Sys.getenv_opt "MASC_INTERNAL_MCP_TOKEN" with
+    | Some raw when String.trim raw <> "" -> true
+    | _ -> false
+  in
+  let source = if pre_existing then "inherited" else "generated" in
+  if post_existing then
+    Log.Server.info
+      "startup internal keeper MCP token synced via MASC_INTERNAL_MCP_TOKEN (source=%s)"
+      source
+  else
+    Log.Server.error
+      "startup internal keeper MCP token sync failed: MASC_INTERNAL_MCP_TOKEN not set after putenv";
+  Otel_metric_store.inc_counter
+    Otel_metric_store.metric_startup_internal_keeper_token_sync
+    ~labels:[("source", source)]
+    ~delta:1.0
+    ()
 
 let sync_bootable_keeper_credentials (state : Mcp_server.server_state) =
   let base_path = state.Mcp_server.workspace_config.base_path in

--- a/test/test_keeper_sandbox_read_backend.ml
+++ b/test/test_keeper_sandbox_read_backend.ml
@@ -350,6 +350,24 @@ fi\n\
 printf 'unexpected docker invocation\\n' >&2\n\
 exit 2\n"
 
+let fake_docker_env_dump_script =
+  "#!/bin/sh\n\
+if [ \"$1\" = \"info\" ]; then\n\
+  printf '[]\\n'\n\
+  exit 0\n\
+fi\n\
+if [ \"$1\" = \"image\" ] && [ \"$2\" = \"inspect\" ] && [ \"$3\" = \"alpine:test\" ]; then\n\
+  printf '[]\\n'\n\
+  exit 0\n\
+fi\n\
+if [ \"$1\" = \"run\" ]; then\n\
+  env > \"${KEEPER_DOCKER_LOG}.env\"\n\
+  printf 'ok\\n'\n\
+  exit 0\n\
+fi\n\
+printf 'unexpected docker invocation\\n' >&2\n\
+exit 2\n"
+
 let fake_docker_turn_runtime_script =
   "#!/bin/sh\n\
 log_file=${KEEPER_DOCKER_LOG:-}\n\
@@ -1110,6 +1128,29 @@ let test_run_command_fallback_uses_docker_spawn_slot ~clock () =
        Alcotest.(check string) "slow docker stdout" "slow ok\n" out);
    Alcotest.(check int) "Docker_spawn slot released" 0
      (docker_spawn_in_flight ())
+
+let test_run_command_scrubs_sensitive_env () =
+  with_fake_docker fake_docker_env_dump_script @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
+  with_env "GH_TOKEN" "ghp_secret" @@ fun () ->
+  with_env "ANTHROPIC_API_KEY" "sk-ant-secret" @@ fun () ->
+  let base, config, meta = setup_config "minjae" in
+  let log_path = Filename.concat base "docker.log" in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
+  match
+    Keeper_sandbox_read_backend.run_command_with_status ~config ~meta
+      ~command_argv:[ "echo"; "hello" ]
+      ~max_bytes:4096 ~timeout_sec:5.0 ()
+  with
+  | Error msg -> Alcotest.failf "expected success, got %s" msg
+  | Ok (_st, _out) ->
+      let env_dump_path = log_path ^ ".env" in
+      let env_dump = read_file env_dump_path in
+      Alcotest.(check bool) "GH_TOKEN scrubbed" false
+        (contains_substring env_dump "GH_TOKEN=");
+      Alcotest.(check bool) "ANTHROPIC_API_KEY scrubbed" false
+        (contains_substring env_dump "ANTHROPIC_API_KEY=")
 
 let test_turn_runtime_reuses_single_container () =
   with_fake_docker fake_docker_turn_runtime_script @@ fun () ->


### PR DESCRIPTION
## Summary
Add env/bootstrap health proof for \`MASC_INTERNAL_MCP_TOKEN\` when runtime-MCP Keeper-internal tools are enabled, with non-secret telemetry.

## Changes
- \`lib/server/server_runtime_startup_credentials.ml\`: \`sync_internal_keeper_token_env\` now checks env state before and after token sync, logs source (\`inherited\` vs \`generated\`), and emits a counter.
- \`lib/otel_metric_store/otel_identity_metric_names.ml{,i}\`: Add \`metric_startup_internal_keeper_token_sync\`.

## Verification
- \`dune build @check\` PASS (changed files only; pre-existing \`keeper_prompt.mli\`/\`keeper_execution.mli\` label order mismatch unrelated)
- \`dune build .\` PASS

## Test plan
- [ ] Deploy and verify \`masc_startup_internal_keeper_token_sync_total{source=\"inherited\"|\"generated\"}\` appears in telemetry export

Closes #19689 (slice 1)