### PR TITLE
fix(dashboard): replace undefined forceRender with bumpThreads in ide-conversation-rail

### DIFF
--- a/dashboard/src/components/ide/ide-conversation-rail.test.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail.test.ts
@@ -369,6 +369,7 @@ describe('IdeConversationRail', () => {
       if (url.startsWith('/api/v1/board')) {
         return new Response(JSON.stringify({ posts: [{
           id: 'thread-line',
+          hearth: 'question',
           author: 'scholar',
           title: 'Review lib/runtime.ml:42',
           body: 'question fn:run about this line',

--- a/dashboard/src/components/ide/ide-conversation-rail.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail.ts
@@ -120,6 +120,7 @@ export function IdeConversationRail() {
   const [replayUntilMs, setReplayUntilMs] = useState<number | null>(ideReplayUntilMs.value)
   const [activeFile, setActiveFile] = useState(activeIdeFile.value)
   const [keeperName, setKeeperName] = useState(activeKeeperName.value)
+  const [, bumpThreads] = useState(0)
   useSignalValue(globalPresenceSnapshot)
   useSignalValue(cursorOverlaySignal)
   useEffect(() => {
@@ -150,7 +151,7 @@ export function IdeConversationRail() {
   useEffect(() => {
     const publish = () => {
       publishIdeConversationThreads(threadStore.filePath(), threadStore.visibleThreads())
-      forceRender((t: number) => t + 1)
+      bumpThreads((t: number) => t + 1)
     }
     const unsub = threadStore.subscribe(publish)
     publish()


### PR DESCRIPTION
## Summary

PR #20521 introduced typed `boardKindFromPost` but the follow-up fix that replaced the undefined `forceRender` reference was lost in squash-merge. This caused a runtime `ReferenceError` when the conversation rail's thread store published updates.

## Changes

- Add `const [, bumpThreads] = useState(0)` hook
- Replace `forceRender((t: number) => t + 1)` with `bumpThreads`
- Add `hearth: 'question'` to test mock post for typed kind mapping

## Verification

- [x] `npx vitest run src/components/ide/ide-conversation-rail.test.ts` — 12/12 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)