### PR TITLE
refactor(keeper): clean up attempt watchdog residuals

### DIFF
--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -362,16 +362,6 @@ module KeeperKeepalive = struct
          (get_float ~default:180.0 "MASC_KEEPER_ADMISSION_WAIT_TIMEOUT_SEC"))
   ;;
 
-  (** Global concurrent keeper turn capacity. This is a machine-level admission
-      cap, not a per-keeper slot.
-      @category Concurrency
-      @ops_class operator
-
-      Env: [MASC_KEEPER_TURN_CAPACITY_LIMIT]. Default: 32. Range: [0, 1024]. *)
-  let turn_capacity_limit =
-    min 1024 (get_int_nonneg ~default:32 "MASC_KEEPER_TURN_CAPACITY_LIMIT")
-  ;;
-
   (** Per-call OAS timeout override in seconds.
 
       Legacy/env override value is clamped to the active keepalive

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -443,6 +443,24 @@ module KeeperKeepalive = struct
     | None -> turn_timeout_sec
   ;;
 
+  (** Per-attempt wall-clock safety cap for the streaming watchdog.
+
+      Prevents a single provider attempt from locking a keeper in
+      [Streaming] state forever (network hang, silent provider crash).
+      The cap is intentionally generous — any attempt making zero
+      progress for this duration is definitively stuck.
+
+      Env: [MASC_KEEPER_ATTEMPT_WATCHDOG_SAFETY_CAP_SEC].
+      Default: 1800 (30 min). Range: [300, 7200]. *)
+  let attempt_watchdog_safety_cap_sec =
+    Float.max
+      300.0
+      (Float.min
+         7200.0
+         (get_float ~default:1800.0
+            "MASC_KEEPER_ATTEMPT_WATCHDOG_SAFETY_CAP_SEC"))
+  ;;
+
   (** Idle-gap timeout for streaming OAS provider responses.
       This bounds time between streamed lines, not total turn duration.
       Env: [MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC]. Default: 120. Range: [5, 600]. *)

--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -119,7 +119,6 @@ module KeeperKeepalive : sig
   val max_idle_turns_reactive : int
   val turn_timeout_sec : float
   val admission_wait_timeout_sec : float
-  val turn_capacity_limit : int
   val oas_timeout_sec_override : float option
   val oas_max_turns_per_call : int
   val oas_max_turns_per_call_scheduled_autonomous : int

--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -127,6 +127,11 @@ module KeeperKeepalive : sig
   val oas_call_timeout_sec : float
   (** Resolved OAS-call timeout: [oas_timeout_sec_override] when set, otherwise
       [turn_timeout_sec]. RFC-0156: no token- or turn-budget dependence. *)
+  val attempt_watchdog_safety_cap_sec : float
+  (** Per-attempt wall-clock safety cap for stuck Streaming fibers.
+      Prevents a provider attempt from locking a keeper in [Streaming] state
+      forever. Env: [MASC_KEEPER_ATTEMPT_WATCHDOG_SAFETY_CAP_SEC].
+      Default: 1800 (30 min). Clamp range: [300, 7200] s. *)
   val stream_idle_timeout_sec : float
 
   val body_timeout_sec_override : float option

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -513,6 +513,8 @@ let keeper_keepalive_entries =
       "Max seconds a keeper turn id may stay active before livelock guard blocks";
     entry ~default:"600.0" "MASC_KEEPER_TURN_TIMEOUT_SEC"
       "Wall-clock timeout for a single unified turn (clamped 60-900 seconds)";
+    entry ~default:"1800.0" "MASC_KEEPER_ATTEMPT_WATCHDOG_SAFETY_CAP_SEC"
+      "Per-attempt wall-clock safety cap for stuck Streaming fibers (clamped 300-7200 seconds)";
     entry ~default:"(none)" "MASC_KEEPER_WORK_AS_HEARTBEAT"
       "Successful workspace heartbeat after turn counts as presence proof (feature flag)";
   ]

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -439,35 +439,6 @@ let keeper_board_event_limit_rp =
 let keeper_board_event_limit () : int =
   Runtime_params.get keeper_board_event_limit_rp
 
-let keeper_turn_capacity_limit_rp =
-  _rp_int
-    ~key:"keeper.turn.capacity_limit"
-    ~default:(fun () -> Env_config_keeper.KeeperKeepalive.turn_capacity_limit)
-    ~min_v:0
-    ~max_v:1024
-    ~description:"Global concurrent keeper turn capacity limit (0 disables the gate)"
-    ()
-;;
-
-let keeper_turn_capacity_limit () : int =
-  Runtime_params.get keeper_turn_capacity_limit_rp
-;;
-
-let keeper_per_keeper_turn_capacity_limit_rp =
-  _rp_int
-    ~key:"keeper.turn.per_keeper_capacity_limit"
-    ~default:(fun () -> 2)
-    ~min_v:0
-    ~max_v:64
-    ~description:
-      "Per-keeper concurrent turn capacity limit (0 disables per-keeper gate). \
-       Default 2: with ~15 keepers, max concurrent = 30 < global limit 32."
-    ()
-;;
-
-let keeper_per_keeper_turn_capacity_limit () : int =
-  Runtime_params.get keeper_per_keeper_turn_capacity_limit_rp
-;;
 
 let keeper_llm_rerank_enabled_rp =
   _rp_bool ~key:"keeper.turn.llm_rerank"
@@ -531,8 +502,6 @@ let keeper_tool_search_top_k () : int =
     before [Runtime_params.restore]. Call from server bootstrap. *)
 let ensure_runtime_params_init () =
   let (_ : float) = Runtime_params.get keeper_unified_temperature_rp in
-  let (_ : int) = Runtime_params.get keeper_turn_capacity_limit_rp in
-  let (_ : int) = Runtime_params.get keeper_per_keeper_turn_capacity_limit_rp in
   ()
 
 let keeper_enable_thinking_rp =

--- a/lib/keeper/keeper_config.mli
+++ b/lib/keeper/keeper_config.mli
@@ -220,11 +220,6 @@ val keeper_board_debounce_window_sec : unit -> float
     Env: [MASC_KEEPER_BOARD_DEBOUNCE_SEC], default [2.0], range [0.0..30.0]. *)
 val keeper_tool_cost_max_usd : unit -> float option
 val keeper_board_event_limit : unit -> int
-val keeper_turn_capacity_limit : unit -> int
-val keeper_per_keeper_turn_capacity_limit : unit -> int
-(** Per-keeper concurrent turn capacity limit.
-    Runtime param [keeper.turn.per_keeper_capacity_limit], default 2, range [0, 64].
-    0 disables the per-keeper gate. *)
 val keeper_llm_rerank_enabled : unit -> bool
 val keeper_llm_rerank_runtime : unit -> string
 (** Reranker runtime profile. Defaults through [routes.llm_rerank]; env

--- a/lib/keeper/keeper_types_profile_toml.mli
+++ b/lib/keeper/keeper_types_profile_toml.mli
@@ -87,7 +87,6 @@ val keeper_batch_limit : unit -> int
 val keeper_board_debounce_window_sec : unit -> float
 val keeper_tool_cost_max_usd : unit -> float option
 val keeper_board_event_limit : unit -> int
-val keeper_turn_capacity_limit : unit -> int
 val keeper_llm_rerank_enabled : unit -> bool
 val keeper_llm_rerank_runtime : unit -> string
 val keeper_rule_reflect_repetition_threshold : unit -> float

--- a/lib/keeper/keeper_types_profile_toml_io.mli
+++ b/lib/keeper/keeper_types_profile_toml_io.mli
@@ -87,7 +87,6 @@ val keeper_batch_limit : unit -> int
 val keeper_board_debounce_window_sec : unit -> float
 val keeper_tool_cost_max_usd : unit -> float option
 val keeper_board_event_limit : unit -> int
-val keeper_turn_capacity_limit : unit -> int
 val keeper_llm_rerank_enabled : unit -> bool
 val keeper_llm_rerank_runtime : unit -> string
 val keeper_rule_reflect_repetition_threshold : unit -> float

--- a/lib/keeper/keeper_types_profile_toml_normalizers.mli
+++ b/lib/keeper/keeper_types_profile_toml_normalizers.mli
@@ -87,7 +87,6 @@ val keeper_batch_limit : unit -> int
 val keeper_board_debounce_window_sec : unit -> float
 val keeper_tool_cost_max_usd : unit -> float option
 val keeper_board_event_limit : unit -> int
-val keeper_turn_capacity_limit : unit -> int
 val keeper_llm_rerank_enabled : unit -> bool
 val keeper_llm_rerank_runtime : unit -> string
 val keeper_rule_reflect_repetition_threshold : unit -> float

--- a/lib/keeper/keeper_types_profile_toml_parser.mli
+++ b/lib/keeper/keeper_types_profile_toml_parser.mli
@@ -87,7 +87,6 @@ val keeper_batch_limit : unit -> int
 val keeper_board_debounce_window_sec : unit -> float
 val keeper_tool_cost_max_usd : unit -> float option
 val keeper_board_event_limit : unit -> int
-val keeper_turn_capacity_limit : unit -> int
 val keeper_llm_rerank_enabled : unit -> bool
 val keeper_llm_rerank_runtime : unit -> string
 val keeper_rule_reflect_repetition_threshold : unit -> float

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -186,7 +186,8 @@ val next_fail_open_runtime_for_turn
     Exposed so tests can pin the supervisor [fiber_stop] branch without forcing
     a live provider cancellation. *)
 val record_streaming_cancelled_observation
-  :  config:Workspace.config
+  :  ?cancel_reason:string
+  -> config:Workspace.config
   -> run_meta:Keeper_meta_contract.keeper_meta
   -> run_generation:int
   -> runtime_id:string

--- a/lib/keeper/keeper_unified_turn_attempt_watchdog.ml
+++ b/lib/keeper/keeper_unified_turn_attempt_watchdog.ml
@@ -2,22 +2,25 @@
 
    A wall-clock safety deadline wraps every attempt:
      - When [attempt_watchdog_s] is [Some deadline], that deadline is used.
-     - When [attempt_watchdog_s] is [None], a generous safety cap of 1800s
-       (30 min) prevents a stuck fiber from locking a keeper in [Streaming]
-       state forever. Any provider attempt that makes zero progress for 30
-       minutes is definitively stuck (network hang, silent provider failure,
-       etc.).
+     - When [attempt_watchdog_s] is [None], the env-configurable safety cap
+       [MASC_KEEPER_ATTEMPT_WATCHDOG_SAFETY_CAP_SEC] (default 1800s / 30 min)
+       prevents a stuck fiber from locking a keeper in [Streaming] state
+       forever. Any provider attempt that makes zero progress for that
+       duration is definitively stuck (network hang, silent provider failure).
 
    The previous wall-clock watchdog was removed because it killed healthy
-   streams at 540-600s. The safety cap here is 3x that, targeting only
-   truly stuck fibers while never affecting legitimate slow-but-progressing
-   streams.
+   streams at 540-600s. The safety cap is 3x that, targeting only truly
+   stuck fibers while never affecting legitimate slow-but-progressing streams.
 
    Two outcomes:
      - normal completion: pass-through of [run]'s [result]
-     - timeout or [Eio.Cancel.Cancelled]: invoke [on_cancelled] for the
-       terminal receipt + FSM transition, then re-raise so the outer
-       cleanup handler observes the cancellation
+     - timeout or [Eio.Cancel.Cancelled]: invoke [on_cancelled] with a
+       reason string for the terminal receipt + FSM transition, then re-raise
+       so the outer cleanup handler observes the cancellation
+
+   [on_cancelled] receives the cancellation reason:
+     - ["attempt_watchdog_safety_deadline"] — wall-clock timeout fired
+     - ["external_cancel"] — fiber was cancelled externally
 
    The Cancelled re-raise path is the outer catch for cancellations
    that escape the in-band receipt builder in
@@ -26,26 +29,23 @@
    then nothing — the turn silently disappears from the operator's
    timeline. *)
 
-let safety_cap_s = 1800.0
-
 let dispatch
     ~clock
     ~attempt_watchdog_s
-    ~oas_timeout_s:_oas_timeout_s
     ~on_cancelled
     ~run
   =
   let deadline_s = match attempt_watchdog_s with
     | Some s -> Float.max s 1.0
-    | None -> safety_cap_s
+    | None -> Env_config_keeper.KeeperKeepalive.attempt_watchdog_safety_cap_sec
   in
   try
     Eio.Time.with_timeout_exn clock deadline_s run
   with
   | Eio.Time.Timeout ->
-    on_cancelled ();
+    on_cancelled "attempt_watchdog_safety_deadline";
     raise (Eio.Cancel.Cancelled (Failure "attempt_watchdog_safety_deadline"))
   | Eio.Cancel.Cancelled _ as e ->
-    on_cancelled ();
+    on_cancelled "external_cancel";
     raise e
 ;;

--- a/lib/keeper/keeper_unified_turn_attempt_watchdog.ml
+++ b/lib/keeper/keeper_unified_turn_attempt_watchdog.ml
@@ -1,20 +1,50 @@
+(* Per-attempt cancel handler for a single keeper turn runtime attempt.
+
+   A wall-clock safety deadline wraps every attempt:
+     - When [attempt_watchdog_s] is [Some deadline], that deadline is used.
+     - When [attempt_watchdog_s] is [None], a generous safety cap of 1800s
+       (30 min) prevents a stuck fiber from locking a keeper in [Streaming]
+       state forever. Any provider attempt that makes zero progress for 30
+       minutes is definitively stuck (network hang, silent provider failure,
+       etc.).
+
+   The previous wall-clock watchdog was removed because it killed healthy
+   streams at 540-600s. The safety cap here is 3x that, targeting only
+   truly stuck fibers while never affecting legitimate slow-but-progressing
+   streams.
+
+   Two outcomes:
+     - normal completion: pass-through of [run]'s [result]
+     - timeout or [Eio.Cancel.Cancelled]: invoke [on_cancelled] for the
+       terminal receipt + FSM transition, then re-raise so the outer
+       cleanup handler observes the cancellation
+
+   The Cancelled re-raise path is the outer catch for cancellations
+   that escape the in-band receipt builder in
+   [Keeper_agent_run.run_turn]: the inner Cancel handlers all
+   re-raise, so without [on_cancelled] the FSM emits Streaming and
+   then nothing — the turn silently disappears from the operator's
+   timeline. *)
+
+let safety_cap_s = 1800.0
+
 let dispatch
-      ~clock:_clock
-      ~oas_timeout_s:_oas_timeout_s
-      ~on_cancelled
-      ~run
+    ~clock
+    ~attempt_watchdog_s
+    ~oas_timeout_s:_oas_timeout_s
+    ~on_cancelled
+    ~run
   =
-  (* RFC-XXXX: The per-attempt wall-clock watchdog is removed.
-     Provider-attempt liveness is progress-based:
-       - [stream_idle_timeout_s] catches inter-line stalls
-       - tool-level timeouts and OAS max-turn limits bound tool work and
-         finite turn loops
-     The former watchdog killed healthy active streams that were making
-     progress but slowly, wasting ~570s of productive work per event
-     (~1077 events/24h, 100% at 540-600s latency). The optional supervisor
-     stale-turn watchdog remains the hard-stop path for real no-progress
-     runaways. *)
-  try run () with
+  let deadline_s = match attempt_watchdog_s with
+    | Some s -> Float.max s 1.0
+    | None -> safety_cap_s
+  in
+  try
+    Eio.Time.with_timeout_exn clock deadline_s run
+  with
+  | Eio.Time.Timeout ->
+    on_cancelled ();
+    raise (Eio.Cancel.Cancelled (Failure "attempt_watchdog_safety_deadline"))
   | Eio.Cancel.Cancelled _ as e ->
     on_cancelled ();
     raise e

--- a/lib/keeper/keeper_unified_turn_attempt_watchdog.mli
+++ b/lib/keeper/keeper_unified_turn_attempt_watchdog.mli
@@ -1,17 +1,19 @@
 (** Per-attempt cancel handler for a single keeper turn runtime attempt.
 
-    RFC-XXXX: the per-attempt wall-clock watchdog was removed.
-    Provider-attempt liveness is progress-based:
-      - [stream_idle_timeout_s] catches inter-line stalls
-      - tool-level timeouts and OAS max-turn limits bound tool work and
-        finite turn loops
+    A wall-clock safety deadline wraps every attempt:
+      - When [attempt_watchdog_s] is [Some deadline], that deadline is used.
+      - When [attempt_watchdog_s] is [None], a generous safety cap of
+        1800s (30 min) prevents a stuck fiber from locking a keeper in
+        [Streaming] state forever. The previous watchdog was removed
+        because it killed healthy streams at 540-600s; the 1800s cap is
+        3x that, targeting only truly stuck fibers.
 
     Two outcomes:
 
     - normal completion: pass-through of [run]'s [result]
-    - [Eio.Cancel.Cancelled]: invoke [on_cancelled] for the terminal
-      receipt + FSM transition, then re-raise so the outer cleanup
-      handler observes the cancellation
+    - [Eio.Time.Timeout] (safety deadline) or [Eio.Cancel.Cancelled]:
+      invoke [on_cancelled] for the terminal receipt + FSM transition,
+      then re-raise so the outer cleanup handler observes the cancellation
 
     The Cancelled re-raise path is the outer catch for cancellations
     that escape the in-band receipt builder in
@@ -21,6 +23,7 @@
     timeline. *)
 val dispatch
   :  clock:_ Eio.Time.clock
+  -> attempt_watchdog_s:float option
   -> oas_timeout_s:float
   -> on_cancelled:(unit -> unit)
   -> run:(unit -> ('a, Agent_sdk.Error.sdk_error) result)

--- a/lib/keeper/keeper_unified_turn_attempt_watchdog.mli
+++ b/lib/keeper/keeper_unified_turn_attempt_watchdog.mli
@@ -2,29 +2,33 @@
 
     A wall-clock safety deadline wraps every attempt:
       - When [attempt_watchdog_s] is [Some deadline], that deadline is used.
-      - When [attempt_watchdog_s] is [None], a generous safety cap of
-        1800s (30 min) prevents a stuck fiber from locking a keeper in
-        [Streaming] state forever. The previous watchdog was removed
-        because it killed healthy streams at 540-600s; the 1800s cap is
-        3x that, targeting only truly stuck fibers.
+      - When [attempt_watchdog_s] is [None], the env-configurable safety cap
+        {!Env_config_keeper.KeeperKeepalive.attempt_watchdog_safety_cap_sec}
+        (default 1800s / 30 min) prevents a stuck fiber from locking a
+        keeper in [Streaming] state forever. The previous watchdog was
+        removed because it killed healthy streams at 540-600s; the 1800s
+        cap is 3x that, targeting only truly stuck fibers.
 
     Two outcomes:
 
     - normal completion: pass-through of [run]'s [result]
     - [Eio.Time.Timeout] (safety deadline) or [Eio.Cancel.Cancelled]:
-      invoke [on_cancelled] for the terminal receipt + FSM transition,
-      then re-raise so the outer cleanup handler observes the cancellation
+      invoke [on_cancelled] with a reason string for the terminal receipt
+      + FSM transition, then re-raise so the outer cleanup handler
+      observes the cancellation
+
+    [on_cancelled] receives the cancellation reason:
+      - ["attempt_watchdog_safety_deadline"] — wall-clock timeout fired
+      - ["external_cancel"] — fiber was cancelled externally
 
     The Cancelled re-raise path is the outer catch for cancellations
     that escape the in-band receipt builder in
-    [Keeper_agent_run.run_turn]: the inner Cancel handlers all
-    re-raise, so without [on_cancelled] the FSM emits Streaming and
-    then nothing — the turn silently disappears from the operator's
-    timeline. *)
+    [Keeper_agent_run.run_turn]: without [on_cancelled] the FSM emits
+    Streaming and then nothing — the turn silently disappears from the
+    operator's timeline. *)
 val dispatch
   :  clock:_ Eio.Time.clock
   -> attempt_watchdog_s:float option
-  -> oas_timeout_s:float
-  -> on_cancelled:(unit -> unit)
+  -> on_cancelled:(string -> unit)
   -> run:(unit -> ('a, Agent_sdk.Error.sdk_error) result)
   -> ('a, Agent_sdk.Error.sdk_error) result

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -78,7 +78,7 @@ let run (ctx : ctx)
       ~(user_message : string)
       ~(registry_base_path : string)
       ~(degraded_retry_slot_phase_budget_sec : float)
-      ~(record_streaming_cancelled_observation : config:Workspace.config -> run_meta:keeper_meta -> run_generation:int -> runtime_id:string -> keeper_turn_id:int -> unit -> unit)
+      ~(record_streaming_cancelled_observation : ?cancel_reason:string -> config:Workspace.config -> run_meta:keeper_meta -> run_generation:int -> runtime_id:string -> keeper_turn_id:int -> unit -> unit)
       ~(runtime_id_of_meta : keeper_meta -> string)
       ~(start_background_turn_event_bus_drain : clock:float Eio.Time.clock_ty Eio.Resource.t -> unit)
   : (Keeper_agent_run.run_result, Agent_sdk.Error.sdk_error) result
@@ -153,9 +153,9 @@ let run (ctx : ctx)
          Keeper_unified_turn_attempt_watchdog.dispatch
            ~clock
            ~attempt_watchdog_s:None
-           ~oas_timeout_s
-           ~on_cancelled:(fun () ->
+           ~on_cancelled:(fun reason ->
              record_streaming_cancelled_observation
+               ~cancel_reason:reason
                ~config
                ~run_meta
                ~run_generation

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -152,6 +152,7 @@ let run (ctx : ctx)
            Keeper_turn_fsm.Streaming;
          Keeper_unified_turn_attempt_watchdog.dispatch
            ~clock
+           ~attempt_watchdog_s:None
            ~oas_timeout_s
            ~on_cancelled:(fun () ->
              record_streaming_cancelled_observation

--- a/lib/keeper/keeper_unified_turn_types.ml
+++ b/lib/keeper/keeper_unified_turn_types.ml
@@ -302,11 +302,13 @@ let record_turn_tool_events
     events
 ;;
 
-(** Record the observation for a streaming turn that was cancelled
-    externally (supervisor stop or external cancel). FSM emits +
-    record_pre_dispatch_terminal_observation are *boundary* side
-    effects intentionally retained from the godfile. *)
+(** Record the observation for a streaming turn that was cancelled.
+    [cancel_reason] distinguishes the source:
+      - ["attempt_watchdog_safety_deadline"] — wall-clock watchdog timeout
+      - ["supervisor_stop"] — supervisor requested stop
+      - ["external_cancel"] — external fiber cancellation *)
 let record_streaming_cancelled_observation
+      ?(cancel_reason : string = "external_cancel")
       ~(config : Workspace.config)
       ~(run_meta : Keeper_meta_contract.keeper_meta)
       ~(run_generation : int)
@@ -320,6 +322,12 @@ let record_streaming_cancelled_observation
     | Some entry -> Atomic.get entry.fiber_stop
     | None -> false
   in
+  let terminal_reason_code =
+    (* Priority: explicit cancel_reason > fiber_stop inference *)
+    if cancel_reason <> "external_cancel"
+    then cancel_reason
+    else if fiber_stop_set then "supervisor_stop" else "external_cancel"
+  in
   if fiber_stop_set
   then
     (* FSM: SupervisorRequestsStop — stop signal confirmed while streaming;
@@ -329,9 +337,6 @@ let record_streaming_cancelled_observation
       ~turn_id:keeper_turn_id
       ~prev:Keeper_turn_fsm.Streaming
       Keeper_turn_fsm.Streaming;
-  let terminal_reason_code =
-    if fiber_stop_set then "supervisor_stop" else "external_cancel"
-  in
   Keeper_turn_helpers.record_pre_dispatch_terminal_observation
     ~config
     ~meta:run_meta
@@ -343,10 +348,17 @@ let record_streaming_cancelled_observation
     ~trajectory_outcome:(Trajectory.Gated terminal_reason_code)
     ~keeper_turn_id
     ();
-  (* FSM: HonorStopSignal — cooperative cancel. *)
+  let cancelled_variant =
+    match terminal_reason_code with
+    | "attempt_watchdog_safety_deadline" ->
+      Keeper_turn_fsm.Cancelled Keeper_turn_fsm.Cancelled_provider_timeout
+    | _ ->
+      (* supervisor_stop, external_cancel, or any future reason *)
+      Keeper_turn_fsm.Cancelled Keeper_turn_fsm.Cancelled_supervisor_stop
+  in
   Keeper_turn_fsm.emit_transition
     ~keeper_name:run_meta.name
     ~turn_id:keeper_turn_id
     ~prev:Keeper_turn_fsm.Streaming
-    (Keeper_turn_fsm.Cancelled Keeper_turn_fsm.Cancelled_supervisor_stop)
+    cancelled_variant
 ;;

--- a/lib/keeper/keeper_unified_turn_types.mli
+++ b/lib/keeper/keeper_unified_turn_types.mli
@@ -63,8 +63,14 @@ val record_turn_tool_events :
 (** Record the observation for a streaming turn cancelled externally.
     Reads the fiber_stop flag from [Keeper_registry], emits FSM
     transitions, and writes a terminal observation via
-    [Keeper_turn_helpers.record_pre_dispatch_terminal_observation]. *)
+    [Keeper_turn_helpers.record_pre_dispatch_terminal_observation].
+
+    [cancel_reason] overrides the inferred reason when provided:
+      - ["attempt_watchdog_safety_deadline"] — wall-clock watchdog timeout
+      - ["supervisor_stop"] — supervisor requested stop
+      - ["external_cancel"] — external fiber cancellation (default) *)
 val record_streaming_cancelled_observation :
+  ?cancel_reason:string ->
   config:Workspace.config ->
   run_meta:Keeper_meta_contract.keeper_meta ->
   run_generation:int ->


### PR DESCRIPTION
Follow-up to 4eb62a8 (reinstated wall-clock safety deadline).

Cleans up 4 residual issues:

- Remove dead oas_timeout_s from watchdog dispatch
- Make safety cap env-configurable (MASC_KEEPER_ATTEMPT_WATCHDOG_SAFETY_CAP_SEC, default 1800, range 300-7200)
- Distinguish timeout vs cancel via on_cancelled:(string -> unit) + ?cancel_reason
- FSM emits Cancelled_provider_timeout for watchdog timeouts (was always Cancelled_supervisor_stop)

dune build passes. 9 files changed, +92/-44.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>