### PR TITLE
fix(keeper): schedule retry on capacity backpressure with No_retry_hint (#18475)

### DIFF
--- a/lib/keeper/keeper_runtime_attempt.ml
+++ b/lib/keeper/keeper_runtime_attempt.ml
@@ -392,6 +392,12 @@ let sdk_error_capacity_backpressure_retry_hint err =
   | Some
       (Keeper_internal_error.Capacity_backpressure
          { retry_after = Synthetic_default s; _ }) -> Some (Cbr_synthetic_default s)
+  | Some
+      (Keeper_internal_error.Capacity_backpressure
+         { retry_after = No_retry_hint; _ }) ->
+    Some
+      (Cbr_synthetic_default
+         Keeper_binding_health_config.default_capacity_backpressure_backoff_sec)
   | _ -> None
 
 let sdk_error_capacity_backpressure_retry_after_s = function


### PR DESCRIPTION
## Problem

`sdk_error_capacity_backpressure_retry_hint` silently drops `No_retry_hint` via the catch-all `_ -> None`, causing the retry dispatcher to schedule no retry and permanently stall the keeper.

## Root cause

When upstream capacity backpressure lacks a `retry_after_sec` field, deserialization produces `No_retry_hint`. The existing code only matched `Explicit` and `Synthetic_default` arms, letting `No_retry_hint` fall through to `None`. The dispatcher then interprets `None` as "no retry needed", leaving the keeper stalled indefinitely.

## Fix

Add an explicit match arm for `No_retry_hint` that returns `Cbr_synthetic_default` with the configured backoff (`Keeper_binding_health_config.default_capacity_backpressure_backoff_sec`, currently 30.0s).

## Verification

- `dune build @check`
- `dune build .`

Fixes #18475

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>