### PR TITLE
chore(cleanup): gitignore + pre-push hook for dune build trace dumps (#20467)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# RFC-0209 follow-up: refuse push that introduces dune build trace dumps.
+#
+# Triggered by git push (core.hooksPath=.githooks).  Each branch in the
+# push is diffed against its remote-tracking ref; if any new or
+# modified path matches the leak patterns, the push is refused with a
+# non-zero exit before any refs are written.
+#
+# Leak source: DUNE_BUILD_DIR=_build-<suffix> dune build emits
+# _build-<suffix>/trace.csexp containing the full process environment
+# (including active API keys for Supabase, RunPod, OpenAI, etc.).
+# This is a dune build-trace footgun, not a dune bug; we block the
+# patterns explicitly.
+
+set -euo pipefail
+
+remote="$1"
+url="$2"
+
+# Zero-SHA: branch is being created (no upstream yet)
+zero=0000000000000000000000000000000000000000
+
+LEAK_FOUND=0
+
+while read -r local_ref local_sha remote_ref remote_sha; do
+  case "$local_ref" in
+    refs/heads/*) ;;
+    *) continue ;;
+  esac
+  range="$remote_sha..$local_sha"
+  if [ "$remote_sha" = "$zero" ]; then
+    range="$local_sha"
+  fi
+  if git diff --name-only "$range" -- 2>/dev/null \
+       | grep -E '^(trace\.csexp$|_build-[^/]*/)'; then
+    echo "pre-push: REFUSING push of $local_ref"
+    echo "  Reason: trace.csexp or _build-*/ path detected in diff range $range"
+    echo "  Strip with: git rm -r --cached <path>  # then re-commit"
+    echo "  Or: ensure the path is ignored by .gitignore (pattern: _build-*/ or trace.csexp)"
+    LEAK_FOUND=1
+  fi
+done
+
+exit "$LEAK_FOUND"

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # OCaml build artifacts
 _build/
 _build_*/
+# Dune build trace dumps (RFC-0209: env serialization footgun — DUNE_BUILD_DIR=_build-* writes trace.csexp with full env including API keys)
+_build-*/
+trace.csexp
 *.install
 *.merlin
 .merlin


### PR DESCRIPTION
# chore(cleanup): gitignore + pre-push hook for dune build trace dumps (#20467)

## Context

GitHub Secret Scanning produced 9 alerts (`publicly_leaked: true`, all
`state: resolved, resolution: revoked`) for API keys committed to
`codex/keeper-turn-admission-20260607`. The leak source was commit
`fb4e590456` which added `_build-env-knob-catalog/trace.csexp` — a dune
build-trace dump that serializes the full process environment
(including active Supabase / RunPod / OpenAI / Anthropic / DeepSeek /
HuggingFace / Groq / Google / Discord credentials).

`trace.csexp` content: 38KB S-expression of
`DUNE_BUILD_DIR=_build-env-knob-catalog dune build`, which dumps the
process environment under the `(lang dune 3.0) (4:env (...))` form.

The user's resolved-state alerts indicate the credentials are
revoked; this PR lands the defense-in-depth so the leak class cannot
recur on `main`, regardless of which branch the next occurrence
originates from.

## Root cause (RFC-0209, env-serialization footgun)

`DUNE_BUILD_DIR=_build-<suffix>` causes dune to write
`_build-<suffix>/trace.csexp` containing the full env. The
`.gitignore` only had `_build/` and `_build_*/` patterns — the dash
separator was unmatched, so the directory slipped into the index.
Meanwhile, `core.hooksPath` was `.git/hooks` (the default), so the
pre-commit hook in `.githooks/` was dead code and never caught the
leak.

This is not a dune bug — it is a footgun in our local build
invocation pattern. The fix is twofold: ignore the pattern, and
gate the push.

## Changes

| Path | Change |
|------|--------|
| `.gitignore` | add `_build-*/` and `trace.csexp` patterns |
| `.githooks/pre-push` (new, executable) | refuse push that introduces `trace.csexp` or `_build-*` paths |

A subsequent `core.hooksPath=.githooks` configuration change is
applied at the per-clone level (each developer runs
`git config core.hooksPath .githooks`); the pre-push hook is itself
a no-op until that config is set, but the script is committed so
the config switch is a one-liner.

## Defense-in-depth verification

| Layer | Method | Result |
|-------|--------|--------|
| 1. `git check-ignore -v _build-env-knob-catalog/trace.csexp` | the new pattern matches | matches `_build-*/` |
| 2. Synthetic leak commit + `.githooks/pre-push` | push against leak SHA range | hook exits 1, lists 6 leak paths |
| 3. `git rev-list --objects --all` (PR-A branch) | full object enumeration | 0 leak paths |
| 4. `git ls-files` (PR-A branch) | working-tree index | 0 leak paths |
| 5. `git ls-tree -r HEAD` (PR-A branch) | this branch tip | 0 leak paths |

The 5 layers are independent: index patterns, push-side guard, full
history sweep, working-tree index, branch tip. The PR-A branch is a
clean rebase on `main` (`a657796d9` + `5ed991825` base) with no
leak paths anywhere in its history.

## Excising the leaked blob (out of scope here, in codex branch)

A separate filter-repo operation on
`codex/keeper-turn-admission-20260607` physically excises the
`_build-env-knob-catalog/**` blob and `trace.csexp` from that
branch's history. That work is staged on the local codex branch
tip and does not need to land on `main` (the leak was never on
`main` — squash-merge of PR #20402 dropped the offending paths).
The codex branch is currently local-only; if it ever reaches remote,
it will already be clean. This PR is the `main`-side defense; the
codex branch's history-rewrite is a separate, contained operation.

## Not a workaround

This is a *direct root-cause removal* — the pattern that allowed
the leak is now ignored, and the pattern that allows the leak is
now blocked at push time. No `WORKAROUND:` / `RFC-WAIVED:` line is
needed.

RFC-0209 (env-scrub leak prevention) applies directly. Precedent:
PR #20520 (scrub ambient env in docker/system sandbox subprocesses,
merged) and the `.githooks/pre-push` pattern used by
`pre-push-hook-full-tree-secret-scan` (#14924 follow-up).

## References

- GitHub Secret Scanning alert #20467 (9 alerts, all resolved/revoked)
- Commit `fb4e590456` (leak source, excised from codex branch only)
- `lib/core/eio_guard.ml:60-67` (Eio defensive pattern)
- `feedback_dune_check_misses_expr_type_errors.md` (related lint advice)
- `feedback_pre_push_hook_full_tree_secret_scan_bug.md` (the prior
  pre-push redaction test bug — fixed separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
