### PR TITLE
fix(keeper): emit HeartbeatSuccesses metric on fresh heartbeat skip

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop_presence.ml
+++ b/lib/keeper/keeper_heartbeat_loop_presence.ml
@@ -151,6 +151,10 @@ let sync_keeper_presence
       ~base_path:ctx.config.base_path
       meta_current.name
       Keeper_state_machine.Heartbeat_ok;
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string HeartbeatSuccesses)
+      ~labels:[ "keeper", meta_current.name ]
+      ();
     note_turn_failures_preserved_after_heartbeat ~ctx ~meta:meta_current;
     meta_current)
   else (


### PR DESCRIPTION
## Problem

`sync_keeper_presence` skips the full presence sync when the heartbeat is considered fresh (last successful heartbeat within `max_silence`). However, it also skipped the `Otel_metric_store.inc_counter` call for `HeartbeatSuccesses`.

This causes the Grafana "Keeper Heartbeats / min" panel to show **No data** even though heartbeats are occurring normally (observable in logs as "smart heartbeat: idle wake").

## Fix

Emit the `HeartbeatSuccesses` counter in the `presence_fresh` branch as well, so the metric accurately reflects heartbeat activity regardless of freshness optimization.

## Verification

- `dune build @check` passes (local build pending due to shared Dune lock)