### PR TITLE
fix(keeper): remove presence_fresh guard, always emit heartbeat metric

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -626,8 +626,8 @@ let run_heartbeat_loop
   (* Phase 1: work-as-heartbeat freshness tracking.
      Updated ONLY on Workspace.heartbeat success after turn. *)
   let last_successful_heartbeat_ts = ref (Time_compat.now ()) in
-  let work_as_hb () = Runtime_params.get Governance_registry.keeper_work_as_hb_enabled in
-  let max_silence () =
+  let _work_as_hb () = Runtime_params.get Governance_registry.keeper_work_as_hb_enabled in
+  let _max_silence () =
     Runtime_params.get Governance_registry.keeper_work_as_hb_max_silence_sec
   in
   (* Phase 2: smart heartbeat — adaptive scheduling via Keeper_heartbeat_smart *)
@@ -703,16 +703,13 @@ let run_heartbeat_loop
           ~last_successful_heartbeat_ts
           ~last_heartbeat_cycle_ts
       then (
-        (* Phase 1: skip presence sync when recent workspace heartbeat proves freshness *)
+        (* Phase 1: sync presence and emit heartbeat metric *)
         let meta_current =
           sync_keeper_presence
             ~ctx
             ~meta_current
-            ~t_presence_start
             ~consecutive_failures
             ~last_successful_heartbeat_ts
-            ~work_as_hb
-            ~max_silence
         in
         (* RFC-0002: fiber crash on heartbeat threshold breach *)
         if

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -19,11 +19,8 @@ val repair_identity_drift_for_keepalive :
 val sync_keeper_presence :
   ctx:'a context ->
   meta_current:keeper_meta ->
-  t_presence_start:float ->
   consecutive_failures:int ref ->
   last_successful_heartbeat_ts:float ref ->
-  work_as_hb:(unit -> bool) ->
-  max_silence:(unit -> float) ->
   keeper_meta
 
 val collect_keepalive_board_events :

--- a/lib/keeper/keeper_heartbeat_loop_presence.ml
+++ b/lib/keeper/keeper_heartbeat_loop_presence.ml
@@ -132,21 +132,14 @@ let note_turn_failures_preserved_after_heartbeat ~(ctx : _ context) ~(meta : kee
 let sync_keeper_presence
       ~(ctx : _ context)
       ~(meta_current : keeper_meta)
-      ~(t_presence_start : float)
       ~(consecutive_failures : int ref)
       ~(last_successful_heartbeat_ts : float ref)
-      ~(work_as_hb : unit -> bool)
-      ~(max_silence : unit -> float)
   : keeper_meta
   =
-  let presence_fresh =
-    work_as_hb () && t_presence_start -. !last_successful_heartbeat_ts < max_silence ()
-  in
-  if presence_fresh
-  then (
-    Log.Keeper.debug
-      "presence sync skipped: fresh heartbeat %.0fs ago"
-      (t_presence_start -. !last_successful_heartbeat_ts);
+  try
+    let synced = meta_current in
+    consecutive_failures := 0;
+    last_successful_heartbeat_ts := Time_compat.now ();
     Keeper_registry.dispatch_event_unit
       ~base_path:ctx.config.base_path
       meta_current.name
@@ -156,74 +149,35 @@ let sync_keeper_presence
       ~labels:[ "keeper", meta_current.name ]
       ();
     note_turn_failures_preserved_after_heartbeat ~ctx ~meta:meta_current;
-    meta_current)
-  else (
-    try
-      let synced = meta_current in
-      let presence_errors = [] in
-      if presence_errors <> []
-      then (
-        incr consecutive_failures;
-        Log.Keeper.warn
-          "workspace presence failed (%d/%d)"
-          !consecutive_failures
-          (Keeper_heartbeat_snapshot.max_consecutive_heartbeat_failures ());
-        (* RFC-0002: dispatch heartbeat failure *)
-        (* RFC-0002: dispatch heartbeat failure *)
-        Otel_metric_store.inc_counter
-          Keeper_metrics.(to_string HeartbeatFailures)
-          ~labels:[ "keeper", meta_current.name ]
-          ();
-        Keeper_registry.dispatch_event_unit
-          ~base_path:ctx.config.base_path
-          meta_current.name
-          (Keeper_state_machine.Heartbeat_failed
-             { consecutive = !consecutive_failures
-             ; max_allowed =
-                 Keeper_heartbeat_snapshot.max_consecutive_heartbeat_failures ()
-             }))
-      else (
-        consecutive_failures := 0;
-        last_successful_heartbeat_ts := Time_compat.now ();
-        (* RFC-0002: dispatch heartbeat success *)
-        Keeper_registry.dispatch_event_unit
-          ~base_path:ctx.config.base_path
-          meta_current.name
-          Keeper_state_machine.Heartbeat_ok;
-        Otel_metric_store.inc_counter
-          Keeper_metrics.(to_string HeartbeatSuccesses)
-          ~labels:[ "keeper", meta_current.name ]
-          ();
-        note_turn_failures_preserved_after_heartbeat ~ctx ~meta:meta_current);
-      match write_meta ctx.config synced with
-      | Ok () -> synced
-      | Error e ->
-        Otel_metric_store.inc_counter
-          Keeper_metrics.(to_string WriteMetaFailures)
-          ~labels:[ "keeper", synced.name; "phase", "heartbeat" ]
-          ();
-        Log.Keeper.warn "write_meta failed (heartbeat): %s" e;
-        synced
-    with
-    | Eio.Cancel.Cancelled _ as e -> raise e
-    | exn ->
-      incr consecutive_failures;
+    match write_meta ctx.config synced with
+    | Ok () -> synced
+    | Error e ->
       Otel_metric_store.inc_counter
-        Keeper_metrics.(to_string WorkspaceHeartbeatFailures)
-        ~labels:[ "keeper", meta_current.name ]
+        Keeper_metrics.(to_string WriteMetaFailures)
+        ~labels:[ "keeper", synced.name; "phase", "heartbeat" ]
         ();
-      Log.Keeper.error
-        "workspace heartbeat failed (%d/%d): %s"
-        !consecutive_failures
-        (Keeper_heartbeat_snapshot.max_consecutive_heartbeat_failures ())
-        (Printexc.to_string exn);
-      (* RFC-0002: dispatch heartbeat failure *)
-      Keeper_registry.dispatch_event_unit
-        ~base_path:ctx.config.base_path
-        meta_current.name
-        (Keeper_state_machine.Heartbeat_failed
-           { consecutive = !consecutive_failures
-           ; max_allowed = Keeper_heartbeat_snapshot.max_consecutive_heartbeat_failures ()
-           });
-      meta_current)
+      Log.Keeper.warn "write_meta failed (heartbeat): %s" e;
+      synced
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    incr consecutive_failures;
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string WorkspaceHeartbeatFailures)
+      ~labels:[ "keeper", meta_current.name ]
+      ();
+    Log.Keeper.error
+      "workspace heartbeat failed (%d/%d): %s"
+      !consecutive_failures
+      (Keeper_heartbeat_snapshot.max_consecutive_heartbeat_failures ())
+      (Printexc.to_string exn);
+    (* RFC-0002: dispatch heartbeat failure *)
+    Keeper_registry.dispatch_event_unit
+      ~base_path:ctx.config.base_path
+      meta_current.name
+      (Keeper_state_machine.Heartbeat_failed
+         { consecutive = !consecutive_failures
+         ; max_allowed = Keeper_heartbeat_snapshot.max_consecutive_heartbeat_failures ()
+         });
+    meta_current
 ;;

--- a/lib/keeper/keeper_heartbeat_loop_presence.mli
+++ b/lib/keeper/keeper_heartbeat_loop_presence.mli
@@ -23,10 +23,7 @@ val note_turn_failures_preserved_after_heartbeat :
 val sync_keeper_presence :
   ctx:'a Keeper_types_profile.context ->
   meta_current:Keeper_meta_contract.keeper_meta ->
-  t_presence_start:float ->
   consecutive_failures:int ref ->
   last_successful_heartbeat_ts:float ref ->
-  work_as_hb:(unit -> bool) ->
-  max_silence:(unit -> float) ->
   Keeper_meta_contract.keeper_meta
 (** Publish keeper heartbeat presence and update failure counters. *)


### PR DESCRIPTION
## Problem

The `presence_fresh` optimization in `sync_keeper_presence` skipped both the full presence sync and the `HeartbeatSuccesses` metric when the last successful heartbeat was within `max_silence`. This caused Grafana to show **No data** for Keeper Heartbeats even though heartbeats were occurring (visible in logs as "smart heartbeat: idle wake").

## Fix

Remove the guard entirely:
- Always update `last_successful_heartbeat_ts`
- Always emit `HeartbeatSuccesses` counter
- Always dispatch `Heartbeat_ok` event
- Simplify the function by removing the if/else branch

Also removes the unused `work_as_hb` and `max_silence` parameters from the function signature and all call sites.

## Files changed
- `lib/keeper/keeper_heartbeat_loop_presence.ml`
- `lib/keeper/keeper_heartbeat_loop_presence.mli`
- `lib/keeper/keeper_heartbeat_loop.ml`
- `lib/keeper/keeper_heartbeat_loop.mli`