### PR TITLE
fixup: restore work_as_hb name for refresh_work_as_heartbeat caller

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -626,8 +626,8 @@ let run_heartbeat_loop
   (* Phase 1: work-as-heartbeat freshness tracking.
      Updated ONLY on Workspace.heartbeat success after turn. *)
   let last_successful_heartbeat_ts = ref (Time_compat.now ()) in
-  let _work_as_hb () = Runtime_params.get Governance_registry.keeper_work_as_hb_enabled in
-  let _max_silence () =
+  let work_as_hb () = Runtime_params.get Governance_registry.keeper_work_as_hb_enabled in
+  let max_silence () =
     Runtime_params.get Governance_registry.keeper_work_as_hb_max_silence_sec
   in
   (* Phase 2: smart heartbeat — adaptive scheduling via Keeper_heartbeat_smart *)


### PR DESCRIPTION
Follow-up to #20534. The _work_as_hb rename broke the refresh_work_as_heartbeat call site. Restore the original name so the caller compiles.