### PR TITLE
fixup: silence unused max_silence warning

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -627,7 +627,7 @@ let run_heartbeat_loop
      Updated ONLY on Workspace.heartbeat success after turn. *)
   let last_successful_heartbeat_ts = ref (Time_compat.now ()) in
   let work_as_hb () = Runtime_params.get Governance_registry.keeper_work_as_hb_enabled in
-  let max_silence () =
+  let _max_silence () =
     Runtime_params.get Governance_registry.keeper_work_as_hb_max_silence_sec
   in
   (* Phase 2: smart heartbeat — adaptive scheduling via Keeper_heartbeat_smart *)


### PR DESCRIPTION
Follow-up to #20534 / #20540. max_silence is no longer used after removing the presence_fresh guard. Prefix with _ to silence the -warn-error build failure.