### PR TITLE
[#18346] Dashboard Vitest fetch guard

### DIFF
--- a/dashboard/vitest-setup.ts
+++ b/dashboard/vitest-setup.ts
@@ -112,6 +112,19 @@ vi.mock('mermaid', () => ({
   },
 }))
 
+// Block real network requests in tests. Tests that intentionally need
+// fetch must install an explicit mock (vi.fn() or msw).
+vi.stubGlobal(
+  'fetch',
+  vi.fn((input: RequestInfo | URL, _init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    throw new Error(
+      `Real network request blocked in tests: ${url}\n` +
+        `If this test intentionally uses fetch, mock it with vi.fn() or msw.`
+    )
+  })
+)
+
 // Mock ninja-keys Web Component to avoid Happy DOM parsing errors
 vi.mock('ninja-keys', () => {
   if (!customElements.get('ninja-keys')) {


### PR DESCRIPTION
## Summary
Add a global fetch guard to `dashboard/vitest-setup.ts` that blocks real network requests during tests. Any test that unintentionally calls `fetch` will fail fast with a descriptive error instead of hanging on localhost or leaking to external services.

## Changes
- `dashboard/vitest-setup.ts`: install `vi.stubGlobal('fetch', ...)` that throws on every invocation, directing test authors to mock fetch explicitly.

## Verification
- `npx vitest run --reporter=dot` in `dashboard/` shows no new failures from the guard (pre-existing failures in other test files remain unchanged).

Closes #18346

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>