### PR TITLE
fix(keeper): correct gRPC heartbeat wiring and fix upstream compile errors

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -626,7 +626,7 @@ let run_heartbeat_loop
   (* Phase 1: work-as-heartbeat freshness tracking.
      Updated ONLY on Workspace.heartbeat success after turn. *)
   let last_successful_heartbeat_ts = ref (Time_compat.now ()) in
-  let _work_as_hb () = Runtime_params.get Governance_registry.keeper_work_as_hb_enabled in
+  let work_as_hb () = Runtime_params.get Governance_registry.keeper_work_as_hb_enabled in
   let _max_silence () =
     Runtime_params.get Governance_registry.keeper_work_as_hb_max_silence_sec
   in

--- a/lib/keeper/keeper_heartbeat_loop_scheduling.ml
+++ b/lib/keeper/keeper_heartbeat_loop_scheduling.ml
@@ -48,7 +48,10 @@ let decide_keepalive_scheduling
     | Runtime_backpressured _ -> false
   in
   let verdict_reasons =
-    Keeper_world_observation.verdict_reasons_to_strings turn_decision.verdict
+    let base = Keeper_world_observation.verdict_reasons_to_strings turn_decision.verdict in
+    match runtime_backpressure with
+    | Runtime_backpressured _ -> "runtime_backpressure" :: base
+    | Runtime_admitted -> base
   in
   let channel = Keeper_world_observation.channel_to_string turn_decision.channel in
   { turn_decision

--- a/lib/server/keeper_grpc_heartbeat.ml
+++ b/lib/server/keeper_grpc_heartbeat.ml
@@ -107,15 +107,15 @@ let run_grpc_heartbeat_fiber
       ~(interval_sec : float)
       ~(clock : _ Eio.Time.clock)
   =
-  match Eio_context.get_switch_opt (), Atomic.get grpc_env_ref with
-  | None, _ | _, None ->
+  match Atomic.get grpc_env_ref with
+  | None ->
     Otel_metric_store.inc_counter
       Keeper_metrics.(to_string HeartbeatFailures)
-      ~labels:[ "keeper", agent_name; "site", "grpc_no_eio_context" ]
+      ~labels:[ "keeper", agent_name; "site", "grpc_no_env" ]
       ();
-    Log.Keeper.warn "gRPC heartbeat: Eio context or env not available";
+    Log.Keeper.warn "gRPC heartbeat: Eio env not available";
     None
-  | Some grpc_sw, Some env ->
+  | Some env ->
     let close_ref = Atomic.make false in
     Eio.Fiber.fork ~sw (fun () ->
       let rec connect_loop attempts =
@@ -133,7 +133,7 @@ let run_grpc_heartbeat_fiber
             agent_name)
         else (
           let send, recv, close_stream =
-            Masc_grpc_client.heartbeat_stream grpc_client ~sw:grpc_sw ~env
+            Masc_grpc_client.heartbeat_stream grpc_client ~sw ~env
           in
           (try
              run_grpc_heartbeat_stream
@@ -181,8 +181,9 @@ let start_keeper_grpc_heartbeat
         m.name
         (Int64.of_float (Time_compat.now () *. 1000.0))
     in
+    let sw = Option.value (Keeper_supervisor.get_global_switch ()) ~default:ctx.sw in
     run_grpc_heartbeat_fiber
-      ~sw:ctx.sw
+      ~sw
       ~stop
       ~grpc_client:client
       ~config:ctx.config

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -473,11 +473,8 @@ let test_fresh_presence_preserves_turn_failures () =
         (Masc.Keeper_heartbeat_loop.sync_keeper_presence
            ~ctx
            ~meta_current:meta
-           ~t_presence_start:100.0
            ~consecutive_failures:(ref 0)
-           ~last_successful_heartbeat_ts:(ref 99.0)
-           ~work_as_hb:(fun () -> true)
-           ~max_silence:(fun () -> 60.0));
+           ~last_successful_heartbeat_ts:(ref 99.0));
       check int
         "turn failures preserved"
         1


### PR DESCRIPTION
This PR resolves the Eio switch wiring in the gRPC heartbeat adapter to prevent keepers from cascading-failing together. It also resolves compiling drift on the main branch (fixing _work_as_hb parameter mismatch and sync_keeper_presence signatures) and updates keeper scheduling verdict reasons to successfully pass all integration tests.