### PR TITLE
fix(test): remove unused arguments from sync_keeper_presence call in integration test

### DIFF
--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -473,11 +473,8 @@ let test_fresh_presence_preserves_turn_failures () =
         (Masc.Keeper_heartbeat_loop.sync_keeper_presence
            ~ctx
            ~meta_current:meta
-           ~t_presence_start:100.0
            ~consecutive_failures:(ref 0)
-           ~last_successful_heartbeat_ts:(ref 99.0)
-           ~work_as_hb:(fun () -> true)
-           ~max_silence:(fun () -> 60.0));
+           ~last_successful_heartbeat_ts:(ref 99.0));
       check int
         "turn failures preserved"
         1


### PR DESCRIPTION
Removes unused parameters from the sync_keeper_presence call in test_heartbeat_integration.ml to match the updated function signature, resolving OCaml compilation errors.