### PR TITLE
Emit goal attainment metrics from dashboard snapshot refresh loop

### DIFF
--- a/lib/dashboard/dashboard_goals.ml
+++ b/lib/dashboard/dashboard_goals.ml
@@ -26,11 +26,6 @@ let observe_goal_attainment_metrics (goal : Goal_store.goal) attainment =
   Otel_metric_store.set_gauge Otel_metric_store.metric_goal_attainment_measured ~labels
     measured
 
-
-
-
-
-
 let keeper_runtime_trust_snapshot_json ~config ~(meta : Keeper_meta_contract.keeper_meta) =
   try Keeper_runtime_trust_snapshot.snapshot_json ~config ~meta with
   | exn ->
@@ -153,6 +148,24 @@ let build_goal_verification_projection ~(config : Workspace.config) goals =
     (fun goal_id -> Hashtbl.find_opt latest_request_table goal_id),
     (fun goal_id ->
       Option.value (Hashtbl.find_opt events_table goal_id) ~default:[]) )
+
+let emit_all_goal_attainment_metrics ~(config : Workspace.config) =
+  let goals = Goal_store.list_goals config () in
+  let tasks = Workspace.get_tasks_safe config in
+  let ( _effective_policy_for_goal,
+        _open_request_for_goal,
+        _latest_request_for_goal,
+        _events_for_goal ) =
+    build_goal_verification_projection ~config goals
+  in
+  let forest = build_forest ~config ~goals ~tasks in
+  let all_nodes = flatten_tree [] forest in
+  List.iter
+    (fun (node : tree_node) ->
+      let goal = node.goal in
+      let attainment = goal_attainment_to_json goal node in
+      observe_goal_attainment_metrics goal attainment)
+    all_nodes
 
 let rec tree_node_to_json ?(effective_policy_for_goal = fun _ -> None)
     ?(open_request_for_goal = fun _ -> None)

--- a/lib/dashboard/dashboard_goals.mli
+++ b/lib/dashboard/dashboard_goals.mli
@@ -106,6 +106,13 @@ val dashboard_goals_tree_json :
     by the [/api/dashboard/goals/tree] route and the
     regression test. *)
 
+val emit_all_goal_attainment_metrics :
+  config:Workspace.config -> unit
+(** Recomputes the goal forest and emits OTLP gauge metrics
+    ([masc_goal_attainment_pct] + [masc_goal_attainment_measured])
+    for every goal.  Safe to call from the background snapshot
+    refresh loop. *)
+
 (** {1 Per-goal detail} *)
 
 val goal_detail_json :

--- a/lib/dashboard/dashboard_snapshot.ml
+++ b/lib/dashboard/dashboard_snapshot.ml
@@ -236,6 +236,14 @@ let refresh_loop
       safe "activity_swimlane_default" (fun () ->
         Activity_graph.agent_spans_json config ~limit:500 ())
     in
+    (* Emit goal attainment metrics on every snapshot refresh so Grafana
+       panels stay current even when no client hits the goals API. *)
+    (try Dashboard_goals.emit_all_goal_attainment_metrics ~config with
+     | Eio.Cancel.Cancelled _ as e -> raise e
+     | exn ->
+       Log.Dashboard.warn
+         "dashboard_snapshot refresh: goal attainment metrics failed: %s"
+         (Printexc.to_string exn));
     {
       generated_at = Unix.gettimeofday ();
       generation = next_generation ();


### PR DESCRIPTION
Previously `masc_goal_attainment_pct` and `masc_goal_attainment_measured` were only emitted when a client hit the goals API. This meant Grafana panels showed 'No data' during idle periods.

**Changes:**
- Add `Dashboard_goals.emit_all_goal_attainment_metrics` which recomputes the goal forest and emits OTLP gauge metrics for every goal.
- Wire it into `Dashboard_snapshot.refresh_loop` so metrics are refreshed on every snapshot interval regardless of API traffic.

**Testing:**
- `dune build lib/dashboard/masc_dashboard.cma` passes.