### PR TITLE
fix(runtime): adjust make_http_transport call signature for agent_sdk >= 0.204.3

### DIFF
--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -220,7 +220,7 @@ let provider_config_preserving_http_transport
     ~net
     ~(provider_cfg : Llm_provider.Provider_config.t)
   : Llm_provider.Llm_transport.t =
-  let http_transport = Llm_provider.Complete.make_http_transport ~sw ~net () in
+  let http_transport = Llm_provider.Complete.make_http_transport () in
   let patch_request (req : Llm_provider.Llm_transport.completion_request) =
     { req with
       config =


### PR DESCRIPTION
The recent agent_sdk bump (>= 0.204.3) changed the signature of 'Llm_provider.Complete.make_http_transport' by removing Eio ~sw and ~net parameters from the initial constructor and utilizing other parameter setups. This PR aligns the instantiation of http_transport in 'runtime_agent.ml' by calling it with unit () to match the updated type signature.