### PR TITLE
refactor(keeper): remove dead safety-net configs + watchdog cleanup

### DIFF
--- a/lib/config/env_config.ml
+++ b/lib/config/env_config.ml
@@ -55,10 +55,9 @@ let print_summary () =
   Log.Env.info "KeeperAlert(SlackDM): enabled=%b user_id_set=%b"
     Env_config_keeper.KeeperAlert.slack_dm_enabled
     (String.trim Env_config_keeper.KeeperAlert.slack_dm_user_id <> "");
-  Log.Env.info "KeeperKeepalive: interval=%ds max_hb_failures=%d debounce=%.0fs sleep_chunk=%.1fs jitter=%.2f"
+  Log.Env.info "KeeperKeepalive: interval=%ds max_hb_failures=%d sleep_chunk=%.1fs jitter=%.2f"
     Env_config_keeper.KeeperKeepalive.interval_sec
     Env_config_keeper.KeeperKeepalive.max_consecutive_failures
-    Env_config_keeper.KeeperKeepalive.board_debounce_sec
     Env_config_keeper.KeeperKeepalive.sleep_chunk_sec
     Env_config_keeper.KeeperKeepalive.jitter_factor;
   Log.Env.info "WorkAsHeartbeat: enabled=%b max_silence=%.0fs"

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -269,11 +269,6 @@ module KeeperKeepalive = struct
   (** Board-reactive wakeup debounce in seconds. Prevents rapid repeated
       wakeups from the same board post. Default: 60.0.
       Range: [5, 300]. *)
-  let board_debounce_sec =
-    Float.max
-      5.0
-      (Float.min 300.0 (get_float ~default:60.0 "MASC_KEEPER_BOARD_DEBOUNCE_SEC"))
-  ;;
 
   (** Interruptible sleep chunk size in seconds. Smaller = faster wakeup
       response but more CPU polling. Default: 2.0.

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -339,23 +339,6 @@ module KeeperKeepalive = struct
          (get_float ~default:600.0 "MASC_KEEPER_TURN_TIMEOUT_SEC"))
   ;;
 
-  (** Maximum time a proactive keeper will wait in the MASC admission queue
-      before abandoning the current OAS attempt.
-
-      With admission max_concurrent=1 (MLX decode serial), a keeper may wait
-      for the full duration of the preceding keeper's turn. Observed turn
-      durations: 180-963s. Default 180s covers the common case (GLM runtime
-      completes in ~180s) while avoiding indefinite waits.
-
-      Env: [MASC_KEEPER_ADMISSION_WAIT_TIMEOUT_SEC]. Default: 180.0.
-      Range: [5, 1200]. *)
-  let admission_wait_timeout_sec =
-    Float.max
-      5.0
-      (Float.min
-         1200.0
-         (get_float ~default:180.0 "MASC_KEEPER_ADMISSION_WAIT_TIMEOUT_SEC"))
-  ;;
 
   (** Per-call OAS timeout override in seconds.
 

--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -112,7 +112,6 @@ module KeeperKeepalive : sig
   val interval_sec : int
   val max_consecutive_failures : int
   val max_consecutive_turn_failures : int
-  val board_debounce_sec : float
   val sleep_chunk_sec : float
   val jitter_factor : float
   val max_idle_turns_autonomous : int

--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -117,7 +117,6 @@ module KeeperKeepalive : sig
   val max_idle_turns_autonomous : int
   val max_idle_turns_reactive : int
   val turn_timeout_sec : float
-  val admission_wait_timeout_sec : float
   val oas_timeout_sec_override : float option
 
 

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -483,8 +483,6 @@ let keeper_grpc_entries =
 
 let keeper_keepalive_entries =
   [
-    entry ~default:"180.0" "MASC_KEEPER_ADMISSION_WAIT_TIMEOUT_SEC"
-      "Max wait in admission queue before abandoning OAS attempt (clamped 5-1200)";
     entry ~default:"30" "MASC_KEEPER_HEARTBEAT_INTERVAL_SEC"
       "Heartbeat cycle interval (clamped 5-300 seconds)";
     entry ~default:"0.2" "MASC_KEEPER_HEARTBEAT_JITTER_FACTOR"

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -485,8 +485,6 @@ let keeper_keepalive_entries =
   [
     entry ~default:"180.0" "MASC_KEEPER_ADMISSION_WAIT_TIMEOUT_SEC"
       "Max wait in admission queue before abandoning OAS attempt (clamped 5-1200)";
-    entry ~default:"60.0" "MASC_KEEPER_BOARD_DEBOUNCE_SEC"
-      "Board-reactive wakeup debounce (seconds, clamped 5-300)";
     entry ~default:"30" "MASC_KEEPER_HEARTBEAT_INTERVAL_SEC"
       "Heartbeat cycle interval (clamped 5-300 seconds)";
     entry ~default:"0.2" "MASC_KEEPER_HEARTBEAT_JITTER_FACTOR"

--- a/lib/governance_registry.ml
+++ b/lib/governance_registry.ml
@@ -575,7 +575,6 @@ let surfaces =
       param_keys = [
         "keeper.turn.temperature";
         "keeper.turn.max_output_tokens";
-        "keeper.turn.board_event_limit";
         "keeper.turn.tool_cost_max_usd";
         "keeper.turn.llm_rerank";
         "keeper.turn.llama_slots";

--- a/lib/governance_registry.ml
+++ b/lib/governance_registry.ml
@@ -575,7 +575,6 @@ let surfaces =
       param_keys = [
         "keeper.turn.temperature";
         "keeper.turn.max_output_tokens";
-        "keeper.turn.tool_cost_max_usd";
         "keeper.turn.llm_rerank";
         "keeper.turn.llama_slots";
         "keeper.turn.tool_search_top_k";

--- a/lib/governance_registry.ml
+++ b/lib/governance_registry.ml
@@ -611,7 +611,6 @@ let surfaces =
       description = "Keeper rule engine thresholds (reflect, plan, guardrail)";
       risk = "low";
       param_keys = [
-        "keeper.rule.reflect_repetition";
         "keeper.rule.plan_goal_alignment_max";
         "keeper.rule.plan_response_alignment_max";
         "keeper.rule.guardrail_repetition";

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -419,7 +419,7 @@ let run_turn
       if
         Llm_provider.Request_priority.resolve priority
         = Llm_provider.Request_priority.Proactive
-      then Some (Keeper_runtime_resolved.admission_wait_timeout_sec ())
+      then Some 180.0
       else None
     in
     ignore (Keeper_alerting_path.ensure_sandbox_bundle ~config ~meta);

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -430,14 +430,6 @@ let keeper_tool_cost_max_usd () : float option =
   | v when Float.compare v 0.0 <= 0 -> None
   | v -> Some v
 
-let keeper_board_event_limit_rp =
-  _rp_int ~key:"keeper.turn.board_event_limit"
-    ~default:(fun () -> int_of_env_default "MASC_KEEPER_BOARD_EVENT_LIMIT"
-                          ~default:10 ~min_v:1 ~max_v:50)
-    ~min_v:1 ~max_v:50
-    ~description:"Max board events injected per turn" ()
-let keeper_board_event_limit () : int =
-  Runtime_params.get keeper_board_event_limit_rp
 
 
 let keeper_llm_rerank_enabled_rp =

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -411,16 +411,6 @@ let keeper_batch_limit () : int =
   Runtime_params.get keeper_batch_limit_rp
 
 
-let keeper_tool_cost_max_usd_rp =
-  _rp_float ~key:"keeper.turn.tool_cost_max_usd"
-    ~default:(fun () -> float_of_env_default "MASC_KEEPER_TOOL_COST_MAX_USD"
-                          ~default:0.0 ~min_v:0.0 ~max_v:50.0)
-    ~min_v:0.0 ~max_v:50.0
-    ~description:"Per-tool cost ceiling (USD, 0=disabled)" ()
-let keeper_tool_cost_max_usd () : float option =
-  match Runtime_params.get keeper_tool_cost_max_usd_rp with
-  | v when Float.compare v 0.0 <= 0 -> None
-  | v -> Some v
 
 
 

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -410,14 +410,6 @@ let keeper_batch_limit_rp =
 let keeper_batch_limit () : int =
   Runtime_params.get keeper_batch_limit_rp
 
-let keeper_board_debounce_window_sec_rp =
-  _rp_float ~key:"keeper.board.debounce_window_sec"
-    ~default:(fun () -> float_of_env_default "MASC_KEEPER_BOARD_DEBOUNCE_SEC"
-                          ~default:2.0 ~min_v:0.0 ~max_v:30.0)
-    ~min_v:0.0 ~max_v:30.0
-    ~description:"Time window to coalesce board signals into one turn (seconds)" ()
-let keeper_board_debounce_window_sec () : float =
-  Runtime_params.get keeper_board_debounce_window_sec_rp
 
 let keeper_tool_cost_max_usd_rp =
   _rp_float ~key:"keeper.turn.tool_cost_max_usd"

--- a/lib/keeper/keeper_config.mli
+++ b/lib/keeper/keeper_config.mli
@@ -215,9 +215,6 @@ val keeper_proactive_task_cooldown_divisor : unit -> int
 val keeper_proactive_task_min_cooldown_sec : unit -> int
 
 val keeper_batch_limit : unit -> int
-val keeper_board_debounce_window_sec : unit -> float
-(** Time window (seconds) to coalesce board signals into a single keeper turn.
-    Env: [MASC_KEEPER_BOARD_DEBOUNCE_SEC], default [2.0], range [0.0..30.0]. *)
 val keeper_tool_cost_max_usd : unit -> float option
 val keeper_llm_rerank_enabled : unit -> bool
 val keeper_llm_rerank_runtime : unit -> string

--- a/lib/keeper/keeper_config.mli
+++ b/lib/keeper/keeper_config.mli
@@ -215,7 +215,6 @@ val keeper_proactive_task_cooldown_divisor : unit -> int
 val keeper_proactive_task_min_cooldown_sec : unit -> int
 
 val keeper_batch_limit : unit -> int
-val keeper_tool_cost_max_usd : unit -> float option
 val keeper_llm_rerank_enabled : unit -> bool
 val keeper_llm_rerank_runtime : unit -> string
 (** Reranker runtime profile. Defaults through [routes.llm_rerank]; env

--- a/lib/keeper/keeper_config.mli
+++ b/lib/keeper/keeper_config.mli
@@ -219,7 +219,6 @@ val keeper_board_debounce_window_sec : unit -> float
 (** Time window (seconds) to coalesce board signals into a single keeper turn.
     Env: [MASC_KEEPER_BOARD_DEBOUNCE_SEC], default [2.0], range [0.0..30.0]. *)
 val keeper_tool_cost_max_usd : unit -> float option
-val keeper_board_event_limit : unit -> int
 val keeper_llm_rerank_enabled : unit -> bool
 val keeper_llm_rerank_runtime : unit -> string
 (** Reranker runtime profile. Defaults through [routes.llm_rerank]; env

--- a/lib/keeper/keeper_config.mli
+++ b/lib/keeper/keeper_config.mli
@@ -221,7 +221,6 @@ val keeper_llm_rerank_runtime : unit -> string
 (** Reranker runtime profile. Defaults through [routes.llm_rerank]; env
     overrides may be either a concrete profile name or a logical route key. *)
 
-val keeper_rule_reflect_repetition_threshold : unit -> float
 val keeper_rule_plan_goal_alignment_threshold : unit -> float
 val keeper_rule_plan_response_alignment_threshold : unit -> float
 val keeper_rule_guardrail_repetition_threshold : unit -> float

--- a/lib/keeper/keeper_config_rule_thresholds.ml
+++ b/lib/keeper/keeper_config_rule_thresholds.ml
@@ -11,14 +11,6 @@ open Keeper_config_rp_helpers
 (* Rule engine thresholds                                           *)
 (* ================================================================ *)
 
-let keeper_rule_reflect_repetition_rp =
-  _rp_float ~key:"keeper.rule.reflect_repetition"
-    ~default:(fun () -> float_of_env_default "MASC_KEEPER_RULE_REFLECT_REPETITION"
-                          ~default:0.86 ~min_v:0.0 ~max_v:1.0)
-    ~min_v:0.0 ~max_v:1.0
-    ~description:"Reflect rule: repetition similarity threshold" ()
-let keeper_rule_reflect_repetition_threshold () : float =
-  Runtime_params.get keeper_rule_reflect_repetition_rp
 
 let keeper_rule_plan_goal_alignment_rp =
   _rp_float ~key:"keeper.rule.plan_goal_alignment_max"

--- a/lib/keeper/keeper_config_rule_thresholds.mli
+++ b/lib/keeper/keeper_config_rule_thresholds.mli
@@ -1,5 +1,3 @@
-val keeper_rule_reflect_repetition_rp : float Runtime_params.param
-val keeper_rule_reflect_repetition_threshold : unit -> float
 val keeper_rule_plan_goal_alignment_rp : float Runtime_params.param
 val keeper_rule_plan_goal_alignment_threshold : unit -> float
 val keeper_rule_plan_response_alignment_rp :

--- a/lib/keeper/keeper_heartbeat_snapshot.ml
+++ b/lib/keeper/keeper_heartbeat_snapshot.ml
@@ -271,7 +271,7 @@ let write_heartbeat_snapshot
       ; handoff_cooldown_sec = meta_current.handoff_cooldown_sec
       ; auto_handoff_enabled = meta_current.auto_handoff
       ; reflect_repetition_threshold =
-          Keeper_config.keeper_rule_reflect_repetition_threshold ()
+          0.86
       ; plan_goal_alignment_threshold =
           Keeper_config.keeper_rule_plan_goal_alignment_threshold ()
       ; plan_response_alignment_threshold =

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -140,12 +140,10 @@ let consume_board_stimulus_batch ~meta_after_triage batch =
 
 let heartbeat_event_intake ~ctx ~meta_after_triage ~pending_board_events =
   (* RFC-0020 §3 Rule 4 — drain at most one Event Layer stimulus
-     per turn. Board signals are coalesced by a debounce window before
-     falling back to a single non-board queue dequeue. *)
-  let window = Keeper_config.keeper_board_debounce_window_sec () in
+     per turn. Board signals are coalesced by the default debounce
+     window in {!Keeper_event_queue.drain_board_window} (2 s). *)
   let board_batch =
     Keeper_registry_event_queue.drain_board
-      ~window_sec:window
       ~base_path:ctx.config.base_path
       meta_after_triage.name
   in

--- a/lib/keeper/keeper_keepalive_signal.ml
+++ b/lib/keeper/keeper_keepalive_signal.ml
@@ -224,7 +224,7 @@ let wakeup_all_keepers ?base_path () =
 
 (* ── Board-reactive policy constants ── *)
 
-let board_reactive_debounce_sec = Env_config.KeeperKeepalive.board_debounce_sec
+let board_reactive_debounce_sec = 60.0
 
 let board_reactive_generic_wakeup_limit =
   Keeper_config.int_of_env_default

--- a/lib/keeper/keeper_memory_recall.ml
+++ b/lib/keeper/keeper_memory_recall.ml
@@ -538,7 +538,7 @@ let evaluate_keeper_auto_rules
         ; handoff_cooldown_sec = meta.handoff_cooldown_sec
         ; auto_handoff_enabled = meta.auto_handoff
         ; reflect_repetition_threshold =
-            keeper_rule_reflect_repetition_threshold ()
+            0.86
         ; plan_goal_alignment_threshold =
             keeper_rule_plan_goal_alignment_threshold ()
         ; plan_response_alignment_threshold =

--- a/lib/keeper/keeper_runtime_resolved.ml
+++ b/lib/keeper/keeper_runtime_resolved.ml
@@ -85,7 +85,7 @@ let turn_timeout_sec_live () =
 let admission_wait_timeout_sec_live () =
   Float.max 5.0
     (Float.min 1200.0
-       (get_float ~default:180.0 "MASC_KEEPER_ADMISSION_WAIT_TIMEOUT_SEC"))
+       (180.0))
 
 let stream_idle_timeout_sec_live () =
   Float.max 5.0

--- a/lib/keeper/keeper_types_profile_toml.mli
+++ b/lib/keeper/keeper_types_profile_toml.mli
@@ -84,7 +84,6 @@ val keeper_proactive_min_interval_sec : unit -> int
 val keeper_proactive_task_cooldown_divisor : unit -> int
 val keeper_proactive_task_min_cooldown_sec : unit -> int
 val keeper_batch_limit : unit -> int
-val keeper_tool_cost_max_usd : unit -> float option
 val keeper_llm_rerank_enabled : unit -> bool
 val keeper_llm_rerank_runtime : unit -> string
 val keeper_rule_plan_goal_alignment_threshold : unit -> float

--- a/lib/keeper/keeper_types_profile_toml.mli
+++ b/lib/keeper/keeper_types_profile_toml.mli
@@ -86,7 +86,6 @@ val keeper_proactive_task_min_cooldown_sec : unit -> int
 val keeper_batch_limit : unit -> int
 val keeper_board_debounce_window_sec : unit -> float
 val keeper_tool_cost_max_usd : unit -> float option
-val keeper_board_event_limit : unit -> int
 val keeper_llm_rerank_enabled : unit -> bool
 val keeper_llm_rerank_runtime : unit -> string
 val keeper_rule_reflect_repetition_threshold : unit -> float

--- a/lib/keeper/keeper_types_profile_toml.mli
+++ b/lib/keeper/keeper_types_profile_toml.mli
@@ -84,7 +84,6 @@ val keeper_proactive_min_interval_sec : unit -> int
 val keeper_proactive_task_cooldown_divisor : unit -> int
 val keeper_proactive_task_min_cooldown_sec : unit -> int
 val keeper_batch_limit : unit -> int
-val keeper_board_debounce_window_sec : unit -> float
 val keeper_tool_cost_max_usd : unit -> float option
 val keeper_llm_rerank_enabled : unit -> bool
 val keeper_llm_rerank_runtime : unit -> string

--- a/lib/keeper/keeper_types_profile_toml.mli
+++ b/lib/keeper/keeper_types_profile_toml.mli
@@ -87,7 +87,6 @@ val keeper_batch_limit : unit -> int
 val keeper_tool_cost_max_usd : unit -> float option
 val keeper_llm_rerank_enabled : unit -> bool
 val keeper_llm_rerank_runtime : unit -> string
-val keeper_rule_reflect_repetition_threshold : unit -> float
 val keeper_rule_plan_goal_alignment_threshold : unit -> float
 val keeper_rule_plan_response_alignment_threshold : unit -> float
 val keeper_rule_guardrail_repetition_threshold : unit -> float

--- a/lib/keeper/keeper_types_profile_toml_io.mli
+++ b/lib/keeper/keeper_types_profile_toml_io.mli
@@ -84,7 +84,6 @@ val keeper_proactive_min_interval_sec : unit -> int
 val keeper_proactive_task_cooldown_divisor : unit -> int
 val keeper_proactive_task_min_cooldown_sec : unit -> int
 val keeper_batch_limit : unit -> int
-val keeper_tool_cost_max_usd : unit -> float option
 val keeper_llm_rerank_enabled : unit -> bool
 val keeper_llm_rerank_runtime : unit -> string
 val keeper_rule_plan_goal_alignment_threshold : unit -> float

--- a/lib/keeper/keeper_types_profile_toml_io.mli
+++ b/lib/keeper/keeper_types_profile_toml_io.mli
@@ -86,7 +86,6 @@ val keeper_proactive_task_min_cooldown_sec : unit -> int
 val keeper_batch_limit : unit -> int
 val keeper_board_debounce_window_sec : unit -> float
 val keeper_tool_cost_max_usd : unit -> float option
-val keeper_board_event_limit : unit -> int
 val keeper_llm_rerank_enabled : unit -> bool
 val keeper_llm_rerank_runtime : unit -> string
 val keeper_rule_reflect_repetition_threshold : unit -> float

--- a/lib/keeper/keeper_types_profile_toml_io.mli
+++ b/lib/keeper/keeper_types_profile_toml_io.mli
@@ -84,7 +84,6 @@ val keeper_proactive_min_interval_sec : unit -> int
 val keeper_proactive_task_cooldown_divisor : unit -> int
 val keeper_proactive_task_min_cooldown_sec : unit -> int
 val keeper_batch_limit : unit -> int
-val keeper_board_debounce_window_sec : unit -> float
 val keeper_tool_cost_max_usd : unit -> float option
 val keeper_llm_rerank_enabled : unit -> bool
 val keeper_llm_rerank_runtime : unit -> string

--- a/lib/keeper/keeper_types_profile_toml_io.mli
+++ b/lib/keeper/keeper_types_profile_toml_io.mli
@@ -87,7 +87,6 @@ val keeper_batch_limit : unit -> int
 val keeper_tool_cost_max_usd : unit -> float option
 val keeper_llm_rerank_enabled : unit -> bool
 val keeper_llm_rerank_runtime : unit -> string
-val keeper_rule_reflect_repetition_threshold : unit -> float
 val keeper_rule_plan_goal_alignment_threshold : unit -> float
 val keeper_rule_plan_response_alignment_threshold : unit -> float
 val keeper_rule_guardrail_repetition_threshold : unit -> float

--- a/lib/keeper/keeper_types_profile_toml_normalizers.mli
+++ b/lib/keeper/keeper_types_profile_toml_normalizers.mli
@@ -84,7 +84,6 @@ val keeper_proactive_min_interval_sec : unit -> int
 val keeper_proactive_task_cooldown_divisor : unit -> int
 val keeper_proactive_task_min_cooldown_sec : unit -> int
 val keeper_batch_limit : unit -> int
-val keeper_tool_cost_max_usd : unit -> float option
 val keeper_llm_rerank_enabled : unit -> bool
 val keeper_llm_rerank_runtime : unit -> string
 val keeper_rule_plan_goal_alignment_threshold : unit -> float

--- a/lib/keeper/keeper_types_profile_toml_normalizers.mli
+++ b/lib/keeper/keeper_types_profile_toml_normalizers.mli
@@ -86,7 +86,6 @@ val keeper_proactive_task_min_cooldown_sec : unit -> int
 val keeper_batch_limit : unit -> int
 val keeper_board_debounce_window_sec : unit -> float
 val keeper_tool_cost_max_usd : unit -> float option
-val keeper_board_event_limit : unit -> int
 val keeper_llm_rerank_enabled : unit -> bool
 val keeper_llm_rerank_runtime : unit -> string
 val keeper_rule_reflect_repetition_threshold : unit -> float

--- a/lib/keeper/keeper_types_profile_toml_normalizers.mli
+++ b/lib/keeper/keeper_types_profile_toml_normalizers.mli
@@ -84,7 +84,6 @@ val keeper_proactive_min_interval_sec : unit -> int
 val keeper_proactive_task_cooldown_divisor : unit -> int
 val keeper_proactive_task_min_cooldown_sec : unit -> int
 val keeper_batch_limit : unit -> int
-val keeper_board_debounce_window_sec : unit -> float
 val keeper_tool_cost_max_usd : unit -> float option
 val keeper_llm_rerank_enabled : unit -> bool
 val keeper_llm_rerank_runtime : unit -> string

--- a/lib/keeper/keeper_types_profile_toml_normalizers.mli
+++ b/lib/keeper/keeper_types_profile_toml_normalizers.mli
@@ -87,7 +87,6 @@ val keeper_batch_limit : unit -> int
 val keeper_tool_cost_max_usd : unit -> float option
 val keeper_llm_rerank_enabled : unit -> bool
 val keeper_llm_rerank_runtime : unit -> string
-val keeper_rule_reflect_repetition_threshold : unit -> float
 val keeper_rule_plan_goal_alignment_threshold : unit -> float
 val keeper_rule_plan_response_alignment_threshold : unit -> float
 val keeper_rule_guardrail_repetition_threshold : unit -> float

--- a/lib/keeper/keeper_types_profile_toml_parser.mli
+++ b/lib/keeper/keeper_types_profile_toml_parser.mli
@@ -84,7 +84,6 @@ val keeper_proactive_min_interval_sec : unit -> int
 val keeper_proactive_task_cooldown_divisor : unit -> int
 val keeper_proactive_task_min_cooldown_sec : unit -> int
 val keeper_batch_limit : unit -> int
-val keeper_tool_cost_max_usd : unit -> float option
 val keeper_llm_rerank_enabled : unit -> bool
 val keeper_llm_rerank_runtime : unit -> string
 val keeper_rule_plan_goal_alignment_threshold : unit -> float

--- a/lib/keeper/keeper_types_profile_toml_parser.mli
+++ b/lib/keeper/keeper_types_profile_toml_parser.mli
@@ -86,7 +86,6 @@ val keeper_proactive_task_min_cooldown_sec : unit -> int
 val keeper_batch_limit : unit -> int
 val keeper_board_debounce_window_sec : unit -> float
 val keeper_tool_cost_max_usd : unit -> float option
-val keeper_board_event_limit : unit -> int
 val keeper_llm_rerank_enabled : unit -> bool
 val keeper_llm_rerank_runtime : unit -> string
 val keeper_rule_reflect_repetition_threshold : unit -> float

--- a/lib/keeper/keeper_types_profile_toml_parser.mli
+++ b/lib/keeper/keeper_types_profile_toml_parser.mli
@@ -84,7 +84,6 @@ val keeper_proactive_min_interval_sec : unit -> int
 val keeper_proactive_task_cooldown_divisor : unit -> int
 val keeper_proactive_task_min_cooldown_sec : unit -> int
 val keeper_batch_limit : unit -> int
-val keeper_board_debounce_window_sec : unit -> float
 val keeper_tool_cost_max_usd : unit -> float option
 val keeper_llm_rerank_enabled : unit -> bool
 val keeper_llm_rerank_runtime : unit -> string

--- a/lib/keeper/keeper_types_profile_toml_parser.mli
+++ b/lib/keeper/keeper_types_profile_toml_parser.mli
@@ -87,7 +87,6 @@ val keeper_batch_limit : unit -> int
 val keeper_tool_cost_max_usd : unit -> float option
 val keeper_llm_rerank_enabled : unit -> bool
 val keeper_llm_rerank_runtime : unit -> string
-val keeper_rule_reflect_repetition_threshold : unit -> float
 val keeper_rule_plan_goal_alignment_threshold : unit -> float
 val keeper_rule_plan_response_alignment_threshold : unit -> float
 val keeper_rule_guardrail_repetition_threshold : unit -> float

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -265,7 +265,7 @@ let run_keeper_cycle
                    ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
                    ~generation:meta.runtime.generation ()
                in
-               let max_cost_usd = Keeper_config.keeper_tool_cost_max_usd () in
+               let max_cost_usd = None in
                (* 4. Build turn prompt callback: use our unified system prompt *)
                let build_turn_prompt ~base_system_prompt:_ ~messages:_
                  : Keeper_agent_run.turn_prompt

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -259,8 +259,7 @@ let collect_board_events_with_cursor_policy
                 targets)
            recent)
     in
-    let event_limit = Keeper_config.keeper_board_event_limit () in
-    let rec consume_posts remaining last_cursor acc = function
+    let rec consume_posts last_cursor acc = function
       | [] -> List.rev acc, last_cursor
       | (p : Board.post) :: rest ->
         let post_id = Board.Post_id.to_string p.id in
@@ -271,7 +270,7 @@ let collect_board_events_with_cursor_policy
            Log.Keeper.debug
              "board dedup: skipping post_id=%s (no new external since my comment)"
              post_id;
-           consume_posts remaining (Some next_cursor) acc rest
+           consume_posts (Some next_cursor) acc rest
          | `Never ->
            let signal : Board_dispatch.board_signal =
              { kind = Board_dispatch.Board_post_created
@@ -290,12 +289,10 @@ let collect_board_events_with_cursor_policy
                "board dedup: skipping post_id=%s (no explicit mention and no prior \
                 keeper participation)"
                post_id;
-             consume_posts remaining (Some next_cursor) acc rest)
-           else if remaining <= 0
-           then List.rev acc, last_cursor
+             consume_posts (Some next_cursor) acc rest)
            else
              consume_posts
-               (remaining - 1)
+               
                (Some next_cursor)
                ({ post_id
                 ; author = Board.Agent_id.to_string p.author
@@ -314,9 +311,7 @@ let collect_board_events_with_cursor_policy
                 :: acc)
                rest
          | `New_external (count, ext_author, ext_preview) ->
-           if remaining <= 0
-           then List.rev acc, last_cursor
-           else (
+           (
              let signal : Board_dispatch.board_signal =
                { kind = Board_dispatch.Board_post_created
                ; post_id
@@ -329,7 +324,7 @@ let collect_board_events_with_cursor_policy
              in
              let matched = board_signal_match ~continuity_summary ~meta ~signal in
              consume_posts
-               (remaining - 1)
+               
                (Some next_cursor)
                ({ post_id
                 ; author = Board.Agent_id.to_string p.author
@@ -348,7 +343,7 @@ let collect_board_events_with_cursor_policy
                 :: acc)
                rest))
     in
-    let final_events, last_cursor = consume_posts event_limit None [] recent in
+    let final_events, last_cursor = consume_posts None [] recent in
     if advance_cursor
     then (
       match last_cursor with

--- a/lib/keeper_runtime/keeper_runtime_config.ml
+++ b/lib/keeper_runtime/keeper_runtime_config.ml
@@ -34,7 +34,6 @@ let key_to_env =
     "turn.oas_timeout_sec",             "MASC_KEEPER_OAS_TIMEOUT_SEC";
     "turn.stream_idle_timeout_sec",     "MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC";
     "turn.cli_subprocess_idle_sec",     "MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC";
-    "turn.admission_wait_timeout_sec",  "MASC_KEEPER_ADMISSION_WAIT_TIMEOUT_SEC";
     "turn.capacity_limit",              "MASC_KEEPER_TURN_CAPACITY_LIMIT";
     "turn.max_consecutive_hb_failures", "MASC_KEEPER_MAX_CONSECUTIVE_HB_FAILURES";
     "turn.max_consecutive_turn_failures", "MASC_KEEPER_MAX_CONSECUTIVE_TURN_FAILURES";

--- a/lib/keeper_runtime/keeper_runtime_config.ml
+++ b/lib/keeper_runtime/keeper_runtime_config.ml
@@ -41,7 +41,6 @@ let key_to_env =
     "turn.max_consecutive_turn_failures", "MASC_KEEPER_MAX_CONSECUTIVE_TURN_FAILURES";
     "turn.batch_limit",                 "MASC_KEEPER_BATCH_LIMIT";
     "turn.tool_cost_max_usd",           "MASC_KEEPER_TOOL_COST_MAX_USD";
-    "turn.board_event_limit",           "MASC_KEEPER_BOARD_EVENT_LIMIT";
     "turn.llm_rerank",                  "MASC_KEEPER_LLM_RERANK";
     "turn.llm_rerank_runtime",          "MASC_KEEPER_LLM_RERANK_RUNTIME";
     "turn.temperature",                 "MASC_KEEPER_UNIFIED_TEMP";

--- a/lib/keeper_runtime/keeper_runtime_config.ml
+++ b/lib/keeper_runtime/keeper_runtime_config.ml
@@ -39,7 +39,6 @@ let key_to_env =
     "turn.max_consecutive_hb_failures", "MASC_KEEPER_MAX_CONSECUTIVE_HB_FAILURES";
     "turn.max_consecutive_turn_failures", "MASC_KEEPER_MAX_CONSECUTIVE_TURN_FAILURES";
     "turn.batch_limit",                 "MASC_KEEPER_BATCH_LIMIT";
-    "turn.tool_cost_max_usd",           "MASC_KEEPER_TOOL_COST_MAX_USD";
     "turn.llm_rerank",                  "MASC_KEEPER_LLM_RERANK";
     "turn.llm_rerank_runtime",          "MASC_KEEPER_LLM_RERANK_RUNTIME";
     "turn.temperature",                 "MASC_KEEPER_UNIFIED_TEMP";

--- a/lib/keeper_runtime/keeper_runtime_config.ml
+++ b/lib/keeper_runtime/keeper_runtime_config.ml
@@ -25,7 +25,6 @@ let key_to_env =
     "heartbeat.smart_heartbeat",        "MASC_KEEPER_SMART_HEARTBEAT";
     "heartbeat.jitter_factor",          "MASC_KEEPER_HEARTBEAT_JITTER_FACTOR";
     "heartbeat.sleep_chunk_sec",        "MASC_KEEPER_SLEEP_CHUNK_SEC";
-    "heartbeat.board_debounce_sec",     "MASC_KEEPER_BOARD_DEBOUNCE_SEC";
     "heartbeat.board_generic_wakeup_limit", "MASC_KEEPER_BOARD_GENERIC_WAKEUP_LIMIT";
     "heartbeat.board_wakeup_max",       "MASC_KEEPER_BOARD_WAKEUP_MAX";
     (* [proactive] *)

--- a/lib/keeper_runtime/keeper_runtime_config.mli
+++ b/lib/keeper_runtime/keeper_runtime_config.mli
@@ -77,7 +77,6 @@ val resolve_overrides :
 
       [turn]
       stream_idle_timeout_sec   = 120
-      tool_cost_max_usd           = 1.25
       llm_rerank                  = true
     ]}
 

--- a/lib/keeper_runtime/keeper_runtime_config.mli
+++ b/lib/keeper_runtime/keeper_runtime_config.mli
@@ -69,7 +69,6 @@ val resolve_overrides :
 
       [heartbeat]
       sleep_chunk_sec             = 1.5
-      board_debounce_sec          = 30
       board_generic_wakeup_limit  = 3
       board_wakeup_max            = 4
 

--- a/test/test_runtime_toml_overrides.ml
+++ b/test/test_runtime_toml_overrides.ml
@@ -115,7 +115,6 @@ let test_applies_sleep_and_throttle_overrides () =
      fairness_cooldown_sec = 3\n\
      [heartbeat]\n\
      sleep_chunk_sec = 1.5\n\
-     board_debounce_sec = 30\n\
      board_generic_wakeup_limit = 5\n\
      board_wakeup_max = 6\n\
      [turn]\n\
@@ -126,7 +125,7 @@ let test_applies_sleep_and_throttle_overrides () =
   let count, overrides =
     Keeper_runtime_config.resolve_overrides ~env_lookup:empty_env doc
   in
-  check int "applied sleep/throttle overrides" 9 count;
+  check int "applied sleep/throttle overrides" 8 count;
   check (option string) "autoboot max canonical env"
     (Some "6")
     (List.assoc_opt "MASC_KEEPER_AUTOBOOT_MAX" overrides);
@@ -136,9 +135,6 @@ let test_applies_sleep_and_throttle_overrides () =
   check (option string) "sleep chunk"
     (Some "1.5")
     (List.assoc_opt "MASC_KEEPER_SLEEP_CHUNK_SEC" overrides);
-  check (option string) "board debounce"
-    (Some "30")
-    (List.assoc_opt "MASC_KEEPER_BOARD_DEBOUNCE_SEC" overrides);
   check (option string) "board generic wakeup limit"
     (Some "5")
     (List.assoc_opt "MASC_KEEPER_BOARD_GENERIC_WAKEUP_LIMIT" overrides);

--- a/test/test_runtime_toml_overrides.ml
+++ b/test/test_runtime_toml_overrides.ml
@@ -65,15 +65,6 @@ let test_missing_file_returns_zero () =
   | Ok n -> failf "expected 0 overrides, got %d" n
   | Error msg -> failf "unexpected error: %s" msg
 
-let test_missing_file_keeps_cost_threshold_unset_by_default () =
-  with_clean_boot_overrides @@ fun () ->
-  with_base_path @@ fun base_path ->
-  match Keeper_runtime_config.load_and_apply ~base_path with
-  | Error msg -> failf "unexpected error: %s" msg
-  | Ok _ ->
-    check (option (float 0.0001)) "cost threshold unset by default"
-      None
-      (Keeper_config.keeper_tool_cost_max_usd ())
 
 let test_applies_autonomous_max_turns () =
   let doc = parse_or_fail "[autonomous]\nmax_turns_per_call = 7\n" in
@@ -154,7 +145,6 @@ let test_applies_sleep_and_throttle_overrides () =
 let test_applies_turn_execution_overrides () =
   let doc = parse_or_fail
     "[turn]\n\
-     tool_cost_max_usd = 1.25\n\
      llm_rerank = true\n\
      llm_rerank_runtime = \"tool_rerank_fast\"\n\
      temperature = 0.65\n\
@@ -164,10 +154,7 @@ let test_applies_turn_execution_overrides () =
   let count, overrides =
     Keeper_runtime_config.resolve_overrides ~env_lookup:empty_env doc
   in
-  check int "applied 6" 6 count;
-  check (option string) "tool cost ceiling"
-    (Some "1.25")
-    (List.assoc_opt "MASC_KEEPER_TOOL_COST_MAX_USD" overrides);
+  check int "applied 6" 5 count;
   check (option string) "llm rerank"
     (Some "true")
     (List.assoc_opt "MASC_KEEPER_LLM_RERANK" overrides);
@@ -207,7 +194,7 @@ let test_applies_memory_overrides () =
   let count, overrides =
     Keeper_runtime_config.resolve_overrides ~env_lookup:empty_env doc
   in
-  check int "applied 6" 6 count;
+  check int "applied 6" 5 count;
   check (option string) "memory max notes"
     (Some "321")
     (List.assoc_opt "MASC_KEEPER_MEMORY_MAX_NOTES" overrides);
@@ -328,32 +315,7 @@ let test_load_and_apply_records_boot_override () =
         0.42
         (Env_config_keeper.KeeperRuntime.deliberation_daily_budget_usd ())
 
-let test_load_and_apply_records_turn_cost_override () =
-  with_clean_boot_overrides @@ fun () ->
-  with_base_path @@ fun base_path ->
-  write_toml base_path "[turn]\ntool_cost_max_usd = 1.25\n";
-  match Keeper_runtime_config.load_and_apply ~base_path with
-  | Error msg -> failf "unexpected error: %s" msg
-  | Ok n ->
-    check int "applied count" 1 n;
-    check (option string) "boot override stored"
-      (Some "1.25")
-      (Config_boot_overrides.get_opt "MASC_KEEPER_TOOL_COST_MAX_USD")
 
-let test_load_and_apply_records_disabled_turn_cost_override () =
-  with_clean_boot_overrides @@ fun () ->
-  with_base_path @@ fun base_path ->
-  write_toml base_path "[turn]\ntool_cost_max_usd = 0\n";
-  match Keeper_runtime_config.load_and_apply ~base_path with
-  | Error msg -> failf "unexpected error: %s" msg
-  | Ok n ->
-    check int "applied count" 1 n;
-    check (option string) "boot override stored"
-      (Some "0")
-      (Config_boot_overrides.get_opt "MASC_KEEPER_TOOL_COST_MAX_USD");
-    check (option (float 0.0001)) "cost threshold unset"
-      None
-      (Keeper_config.keeper_tool_cost_max_usd ())
 
 let with_env name value f =
   let prev = Sys.getenv_opt name in
@@ -566,8 +528,6 @@ let () =
   run "runtime_toml_overrides"
     [ ( "resolve_overrides"
       , [ test_case "missing file returns 0 overrides" `Quick test_missing_file_returns_zero
-        ; test_case "missing file keeps cost threshold unset by default" `Quick
-            test_missing_file_keeps_cost_threshold_unset_by_default
         ; test_case "applies autonomous max_turns_per_call" `Quick test_applies_autonomous_max_turns
         ; test_case "applies multiple overrides" `Quick test_applies_multiple_overrides
         ; test_case "applies sleep/throttle overrides" `Quick test_applies_sleep_and_throttle_overrides
@@ -583,8 +543,6 @@ let () =
         ; test_case "unknown keys ignored" `Quick test_unknown_keys_ignored
         ; test_case "parse error returns Error" `Quick test_parse_error_returns_error
         ; test_case "load_and_apply records boot override" `Quick test_load_and_apply_records_boot_override
-        ; test_case "load_and_apply records turn cost override" `Quick test_load_and_apply_records_turn_cost_override
-        ; test_case "load_and_apply records disabled turn cost override" `Quick test_load_and_apply_records_disabled_turn_cost_override
         ; test_case "explicit MASC_CONFIG_DIR wins over base path" `Quick test_explicit_config_dir_wins_over_base_path
         ; test_case "float value round trip" `Quick test_float_value_round_trip
         ; test_case "resolved runtime freezes toml values after init" `Quick test_resolved_runtime_freezes_toml_values_after_init

--- a/test/test_runtime_toml_overrides.ml
+++ b/test/test_runtime_toml_overrides.ml
@@ -121,13 +121,12 @@ let test_applies_sleep_and_throttle_overrides () =
      [turn]\n\
      admission_wait_timeout_sec = 20\n\
      capacity_limit = 3\n\
-     batch_limit = 9\n\
-     board_event_limit = 7\n"
+     batch_limit = 9\n"
   in
   let count, overrides =
     Keeper_runtime_config.resolve_overrides ~env_lookup:empty_env doc
   in
-  check int "applied sleep/throttle overrides" 10 count;
+  check int "applied sleep/throttle overrides" 9 count;
   check (option string) "autoboot max canonical env"
     (Some "6")
     (List.assoc_opt "MASC_KEEPER_AUTOBOOT_MAX" overrides);
@@ -154,10 +153,7 @@ let test_applies_sleep_and_throttle_overrides () =
     (List.assoc_opt "MASC_KEEPER_TURN_CAPACITY_LIMIT" overrides);
   check (option string) "batch limit"
     (Some "9")
-    (List.assoc_opt "MASC_KEEPER_BATCH_LIMIT" overrides);
-  check (option string) "board event limit"
-    (Some "7")
-    (List.assoc_opt "MASC_KEEPER_BOARD_EVENT_LIMIT" overrides)
+    (List.assoc_opt "MASC_KEEPER_BATCH_LIMIT" overrides)
 
 let test_applies_turn_execution_overrides () =
   let doc = parse_or_fail

--- a/test/test_runtime_toml_overrides.ml
+++ b/test/test_runtime_toml_overrides.ml
@@ -109,14 +109,13 @@ let test_applies_sleep_and_throttle_overrides () =
      board_generic_wakeup_limit = 5\n\
      board_wakeup_max = 6\n\
      [turn]\n\
-     admission_wait_timeout_sec = 20\n\
      capacity_limit = 3\n\
      batch_limit = 9\n"
   in
   let count, overrides =
     Keeper_runtime_config.resolve_overrides ~env_lookup:empty_env doc
   in
-  check int "applied sleep/throttle overrides" 8 count;
+  check int "applied sleep/throttle overrides" 7 count;
   check (option string) "autoboot max canonical env"
     (Some "6")
     (List.assoc_opt "MASC_KEEPER_AUTOBOOT_MAX" overrides);
@@ -132,9 +131,6 @@ let test_applies_sleep_and_throttle_overrides () =
   check (option string) "board wakeup max"
     (Some "6")
     (List.assoc_opt "MASC_KEEPER_BOARD_WAKEUP_MAX" overrides);
-  check (option string) "admission wait"
-    (Some "20")
-    (List.assoc_opt "MASC_KEEPER_ADMISSION_WAIT_TIMEOUT_SEC" overrides);
   check (option string) "capacity limit"
     (Some "3")
     (List.assoc_opt "MASC_KEEPER_TURN_CAPACITY_LIMIT" overrides);

--- a/test/test_work_as_heartbeat.ml
+++ b/test/test_work_as_heartbeat.ml
@@ -50,9 +50,6 @@ let test_keepalive_max_failures_range () =
   check bool "failures >= 2" true (v >= 2);
   check bool "failures <= 50" true (v <= 50)
 
-let test_keepalive_board_debounce_default () =
-  check (float 0.1) "default debounce 60s" 60.0
-    Cfg.KeeperKeepalive.board_debounce_sec
 
 let test_keepalive_sleep_chunk_default () =
   check (float 0.01) "default sleep chunk 2.0s" 2.0
@@ -140,10 +137,6 @@ let test_config_invariant_sweep_independent () =
   check bool "backoff_max >= backoff_base" true
     (Cfg.KeeperSupervisor.backoff_max_s >= backoff_base)
 
-let test_config_invariant_debounce_ge_interval () =
-  let debounce = Cfg.KeeperKeepalive.board_debounce_sec in
-  let interval = Float.of_int Cfg.KeeperKeepalive.interval_sec in
-  check bool "board debounce >= interval" true (debounce >= interval)
 
 (* ── Freshness decision pure logic ──────────────────────── *)
 
@@ -240,7 +233,6 @@ let () =
       test_case "interval range" `Quick test_keepalive_interval_range;
       test_case "max_failures default" `Quick test_keepalive_max_failures_default;
       test_case "max_failures range" `Quick test_keepalive_max_failures_range;
-      test_case "board_debounce default" `Quick test_keepalive_board_debounce_default;
       test_case "sleep_chunk default" `Quick test_keepalive_sleep_chunk_default;
       test_case "jitter default" `Quick test_keepalive_jitter_default;
       test_case "jitter range" `Quick test_keepalive_jitter_range;
@@ -272,7 +264,6 @@ let () =
     "config_invariants", [
       test_case "max_silence >= interval" `Quick test_config_invariant_silence_ge_interval;
       test_case "sweep/backoff coherence" `Quick test_config_invariant_sweep_independent;
-      test_case "debounce >= interval" `Quick test_config_invariant_debounce_ge_interval;
     ];
     "percentile", [
       test_case "empty array" `Quick test_percentile_empty;


### PR DESCRIPTION
## Summary

Remove 6 redundant keeper safety-net configs that duplicate provider/protocol-level limits, plus clean up the per-attempt watchdog residuals.

**Philosophy**: Configs that are redundant with provider-level limits should be removed entirely, not just disabled. The model's own `end_turn`, provider timeouts, and context reducers already provide the necessary safety nets.

## Changes

### Watchdog cleanup (2 commits)
- **`df6c4a5`** Clean up attempt watchdog residuals: remove dead `oas_timeout_s` param, add `cancel_reason` to `on_cancelled` callback, env-configurable safety cap
- **`29f5b24`** Remove dead `turn_capacity_limit` config (0 consumers outside config definitions)

### Dead config removal (5 commits)
- **`63fc1c0`** Remove `keeper_board_event_limit` — context reducer handles overflow (Closes #20536)
- **`f02e9a3`** Remove `keeper_board_debounce_window_sec` — `drain_board_window` has sensible 2s default (Closes #20537)
- **`599f896`** Remove `keeper_rule_reflect_repetition_threshold` — hardcoded to 0.86 (previous default) (Closes #20538)
- **`d67da8b`** Remove `keeper_tool_cost_max_usd` — provider billing enforces limits at API level (Closes #20535)
- **`15689e8`** Remove `admission_wait_timeout_sec` — hardcoded to 180s (previous default) (Closes #20539)

## Stats
- 7 commits, 31 files, **+116 / -285** (net -169 lines)

## Remaining
- #20528 `max_turns` removal — 105 files, requires agent_sdk repo change. Separate PR.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>