### PR TITLE
fix(runtime): add missing ~sw ~net args to make_http_transport for agent_sdk 0.204.3

### DIFF
--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -220,7 +220,7 @@ let provider_config_preserving_http_transport
     ~net
     ~(provider_cfg : Llm_provider.Provider_config.t)
   : Llm_provider.Llm_transport.t =
-  let http_transport = Llm_provider.Complete.make_http_transport () in
+  let http_transport = Llm_provider.Complete.make_http_transport ~sw ~net () in
   let patch_request (req : Llm_provider.Llm_transport.completion_request) =
     { req with
       config =


### PR DESCRIPTION
agent_sdk 0.204.3 changed make_http_transport signature from [~sw ~net] to [~sw ~net ()]. Without the unit argument the function returns a partially-applied function instead of the Llm_transport.t record, causing the complete_sync field access to fail with which is not a record type.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>