### PR TITLE
fix(runtime): remove extra () from make_http_transport for agent_sdk 0.204.4

### DIFF
--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -220,7 +220,7 @@ let provider_config_preserving_http_transport
     ~net
     ~(provider_cfg : Llm_provider.Provider_config.t)
   : Llm_provider.Llm_transport.t =
-  let http_transport = Llm_provider.Complete.make_http_transport ~sw ~net () in
+  let http_transport = Llm_provider.Complete.make_http_transport ~sw ~net in
   let patch_request (req : Llm_provider.Llm_transport.completion_request) =
     { req with
       config =


### PR DESCRIPTION
## Problem

PR #20559 re-added `~sw ~net` to match the agent_sdk 0.204.3 signature but kept the trailing `()` from the old signature. agent_sdk 0.204.4 (now pinned on main) changed the signature to `~sw -> ~net -> Llm_transport.t` (no unit argument), causing a compile error:

```
Error: The function Llm_provider.Complete.make_http_transport has type
         sw:Eio__core.Switch.t ->
         net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
         Llm_provider.Llm_transport.t
       It is applied to too many arguments
```

## Fix

Remove the trailing `()` from the `make_http_transport` call.

## Verification

`dune build lib/runtime/masc_runtime.cma --root=.` passes.