### PR TITLE
fix(agent_sdk): add missing ?model and () for agent_sdk 0.204.3 compat

### DIFF
--- a/lib/keeper/keeper_hooks_oas.mli
+++ b/lib/keeper/keeper_hooks_oas.mli
@@ -121,7 +121,7 @@ val cost_event_payload :
   cost_usd:float ->
   ?usage_missing:bool ->
   ?usage_trust:Keeper_usage_trust.t ->
-  ?telemetry:Agent_sdk.Types.inference_telemetry -> unit -> Yojson.Safe.t
+  ?telemetry:Agent_sdk.Types.inference_telemetry -> ?model:string -> unit -> Yojson.Safe.t
 (** Assemble the structured cost-ledger event without writing it. *)
 
 val emit_cost_event :

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -220,7 +220,7 @@ let provider_config_preserving_http_transport
     ~net
     ~(provider_cfg : Llm_provider.Provider_config.t)
   : Llm_provider.Llm_transport.t =
-  let http_transport = Llm_provider.Complete.make_http_transport ~sw ~net in
+  let http_transport = Llm_provider.Complete.make_http_transport ~sw ~net () in
   let patch_request (req : Llm_provider.Llm_transport.completion_request) =
     { req with
       config =


### PR DESCRIPTION
## Summary
- `keeper_hooks_oas.mli`: `cost_event_payload`에 누락된 `?model:string` 추가
- `runtime_agent.ml`: `make_http_transport ~sw ~net` 뒤에 누락된 `()` 추가

agent_sdk 0.204.3 bump 후 signature 불일치로 broken main을 고칩니다.

## 검증
- [x] `dune build bin/main_eio.exe` 통과
- [x] 서버 실행 (`MASC_OTEL_ENABLED=true`) 성공
- [x] Jaeger trace 수신 확인 (`masc` 서비스 3+ traces)
- [x] VictoriaMetrics metric 수신 확인 (`masc_*` metric 다수)

🤖 Generated with [Claude Code](https://claude.com/claude-code)