### PR TITLE
[Docs] Fix stale references in docs and comments (#20065, #20069, #20077)

### DIFF
--- a/docs/PERFORMANCE-SLO.md
+++ b/docs/PERFORMANCE-SLO.md
@@ -25,6 +25,25 @@
 - 연결 성공 < 1s
 - 이벤트 전달 지연 P95 < 500ms
 
+### LLM Provider Streaming Latency
+
+현재 MASC는 OAS provider의 **TTFRC**(Time To First Response Chunk)만 측정한다.
+OAS `Streaming_summary.ttft_ms`(Time To First Token)는 MASC가 직접 소비하지 않는다.
+
+- `keeper_telemetry_consumer.ml`은 OAS telemetry event를 counter-only로 관찰하며,
+  provider model-bearing payload는 역직렬화하지 않는다.
+- `llm_metric_bridge.ml`의 `on_streaming_first_chunk` 콜백은 response chunk가
+  도착한 시점(`ttfrc_ms`)만 기록한다.
+
+노출 메트릭:
+
+- `masc_llm_provider_streaming_first_chunk` — TTFRC histogram (seconds)
+- `gen_ai.response.time_to_first_chunk` — OpenTelemetry GenAI semconv TTFRC
+
+**TTFT-to-client**(= provider TTFT + transport overhead)는 현재 측정되지 않는다.
+OAS RFC-OAS-020이 요구하는 consumer SLO를 추가하려면 OAS `Streaming_summary`를
+파싱하거나 `Metrics.t` 콜백 계약에 TTFT 필드를 추가해야 한다.
+
 ## 측정 방법
 - `benchmarks/quick-bench.sh`
 - `benchmarks/benchmark.sh`

--- a/docs/rfc/RFC-0081-telemetry-envelope-and-pivot-timeline.md
+++ b/docs/rfc/RFC-0081-telemetry-envelope-and-pivot-timeline.md
@@ -23,17 +23,17 @@ implementation_prs: [15137]
 
 Two operator-facing defects in masc's telemetry view of OAS streams are addressed here. Per-chunk noise — the third defect originally bundled in the closed RFC-0073 — is the upstream `agent_sdk` repo's emission surface and is now scoped under **RFC-OAS-019** in `~/me/workspace/yousleepwhen/oas`.
 
-1. **Envelope context null** — every `oas:telemetry_event` record written to `.masc/oas-events/YYYY-MM/DD.jsonl` (the durable OAS-event store; see `lib/telemetry_unified.ml:105` and `lib/runtime/runtime_event_bridge.ml:1086`) has `agent_name`, `task_id`, `turn` as `null`. Operators cannot answer "which keeper, which turn, which goal produced this record?" from the raw jsonl alone.
+1. **Envelope context null** — every `oas:telemetry_event` record written to `.masc/oas-events/YYYY-MM/DD.jsonl` (the durable OAS-event store; see `lib/telemetry_unified.ml:105` and `lib/keeper/keeper_event_bridge.ml:710`) has `agent_name`, `task_id`, `turn` as `null`. Operators cannot answer "which keeper, which turn, which goal produced this record?" from the raw jsonl alone.
 
 2. **Pivot impossibility** — there is no `(keeper_name | goal_id) → ordered events` query path. `tool_agent_timeline` (6-source merger) is keyed on `agent_name` only; `telemetry_unified` exposes no keeper/goal filter; the dashboard `keeper-detail-state.ts` mounts a trajectory slot but the backend it talks to has no turn-grouped event endpoint. Goal detail has no timeline tab.
 
-This RFC fixes both at the **read boundary**, not the write boundary. The relay code in `runtime_event_bridge.ml` is unchanged. Three rounds of design (fiber-local binding → shared Hashtbl → read-time join) plus three rounds of grep verification settled on read-time as the structural fit: agent_sdk's `event_envelope` does not carry a turn-level identifier (per-event `fresh_id ()` defaults at `oas/lib/event_envelope.ml:55-57`), so any write-time stamping mechanism would race or fail. The fix instead extends `keeper_runtime_manifest` with three timestamp/id fields and lets `telemetry_unified` perform a time-overlap join at API read time. The user-visible artifacts (pivot UI, pivot API) deliver the same stamped events; only the inside of the system is simpler.
+This RFC fixes both at the **read boundary**, not the write boundary. The relay code in `keeper_event_bridge.ml` is unchanged. Three rounds of design (fiber-local binding → shared Hashtbl → read-time join) plus three rounds of grep verification settled on read-time as the structural fit: agent_sdk's `event_envelope` does not carry a turn-level identifier (per-event `fresh_id ()` defaults at `oas/lib/event_envelope.ml:55-57`), so any write-time stamping mechanism would race or fail. The fix instead extends `keeper_runtime_manifest` with three timestamp/id fields and lets `telemetry_unified` perform a time-overlap join at API read time. The user-visible artifacts (pivot UI, pivot API) deliver the same stamped events; only the inside of the system is simpler.
 
 The emission-side change (per-chunk noise) is RFC-OAS-019's responsibility.
 
 ## 1. Cross-repo boundary (why this RFC exists separately)
 
-`agent_sdk` is consumed via opam pin `git+https://github.com/jeong-sik/oas.git#<sha>` (`dune-project` line 44: `(agent_sdk (>= 0.193.10))`). The `Streaming_chunk_n` payload variant lives in `lib/llm_provider/telemetry_event.ml:20-24` of the `oas` repo, not in masc. masc receives `Event_bus.Custom("telemetry_event", json)` payloads via the upstream SDK, filters them in `keeper_telemetry_consumer.ml` (counter-only, no deserialization), and relays them to a dated JSONL store at `lib/runtime/runtime_event_bridge.ml:1086` under `.masc/oas-events/<YYYY-MM>/<DD>.jsonl`. (Earlier drafts of this RFC referenced `lib/telemetry_eio.ml:114` for this surface; that path is the *agent_event* surface, `.masc/telemetry/`, with a different typed event set — corrected here after grep verification.)
+`agent_sdk` is consumed via opam pin `git+https://github.com/jeong-sik/oas.git#<sha>` (`dune-project` line 44: `(agent_sdk (>= 0.193.10))`). The `Streaming_chunk_n` payload variant lives in `lib/llm_provider/telemetry_event.ml:20-24` of the `oas` repo, not in masc. masc receives `Event_bus.Custom("telemetry_event", json)` payloads via the upstream SDK, filters them in `keeper_telemetry_consumer.ml` (counter-only, no deserialization), and relays them to a dated JSONL store at `lib/keeper/keeper_event_bridge.ml:710` under `.masc/oas-events/<YYYY-MM>/<DD>.jsonl`. (Earlier drafts of this RFC referenced `lib/telemetry_eio.ml:114` for this surface; that path is the *agent_event* surface, `.masc/telemetry/`, with a different typed event set — corrected here after grep verification.)
 
 | Concern | Owner repo | RFC |
 |---|---|---|
@@ -53,7 +53,7 @@ Mixing the two would break the SDK Independence Gate that `oas` enforces on Read
 
 ## 3. Non-goals
 
-- Modify `runtime_event_bridge.ml` or anything else on the write side. The relay path remains unchanged.
+- Modify `keeper_event_bridge.ml` or anything else on the write side. The relay path remains unchanged.
 - Re-emit, throttle, or deduplicate any upstream `oas:telemetry_event` payload. The bus contents are RFC-OAS-019's responsibility. masc consumes whatever the SDK publishes.
 - Stamp envelope fields directly into `.masc/oas-events/` jsonl. Three rounds of grep verification showed write-time stamping does not fit OAS event-envelope semantics; the read-time join is the structural fix.
 - Rewrite the dashboard timeline framework. `vis-timeline` is already loaded by `fsm-hub-timeline-panels.ts` — reuse, don't replace.
@@ -67,11 +67,11 @@ After three rounds of grep verification this RFC settled on a *read-time join* r
 
 | Round | Mechanism | Blocked because |
 |---|---|---|
-| 1 | `Eio.Fiber.with_binding` lookup in `wrap_event` | relay runs in a *background fiber* (`runtime_event_bridge.ml:1082` `start_impl`), so keeper-turn-local bindings do not propagate to it |
+| 1 | `Eio.Fiber.with_binding` lookup in `wrap_event` | relay runs in a *background fiber* (`keeper_event_bridge.ml:772` `start_impl`), so keeper-turn-local bindings do not propagate to it |
 | 2 | Shared `Keeper_context` Hashtbl keyed on `oas_run_id`, registered at keeper turn start | OAS `event_envelope.ml:55-57` defaults `correlation_id` and `run_id` to `fresh_id ()` *per event*; agent_sdk does not guarantee a turn-level identifier in published envelopes. A keeper-side `register oas_run_id` has no stable id to register under |
 | 3 (chosen) | Read-time join — no write-side change | works without assuming a propagated id; relies only on data that already exists in `keeper_runtime_manifest` and the OAS-event `ts_unix` |
 
-`lib/runtime/runtime_event_bridge.ml` is **unchanged**. `.masc/oas-events/<YYYY-MM>/<DD>.jsonl` continues to be written with `agent_name`/`task_id`/`turn` null when the OAS publisher did not supply them. Stamping happens at read time, not write time.
+`lib/keeper/keeper_event_bridge.ml` is **unchanged**. `.masc/oas-events/<YYYY-MM>/<DD>.jsonl` continues to be written with `agent_name`/`task_id`/`turn` null when the OAS publisher did not supply them. Stamping happens at read time, not write time.
 
 At read time, `lib/telemetry_unified.ml` and `lib/tool_agent_timeline.ml` join each `.masc/oas-events/` row to the turn that owns it. The join is in two stages:
 
@@ -103,7 +103,7 @@ type stamped_event =
 |---|---|---|
 | `turn_started_at` (float, unix s) | `Time_compat.now ()` at turn entry | lower bound of the window |
 | `turn_ended_at` (float, unix s) | `Time_compat.now ()` at turn finalize | upper bound; written on success, abort, or timeout |
-| `correlation_id_first` (string option) | first OAS envelope `correlation_id` observed during the turn (recorded via `runtime_event_bridge` log hook or `Agent_sdk.Event_bus` callback) | disambiguator when multiple keepers overlap |
+| `correlation_id_first` (string option) | first OAS envelope `correlation_id` observed during the turn (recorded via `keeper_event_bridge` log hook or `Agent_sdk.Event_bus` callback) | disambiguator when multiple keepers overlap |
 | `task_id` / `goal_id` / `agent_name` | already on the manifest row | join's output payload |
 
 No new file family is created — the manifest is the lookup table. This is a deliberate retraction from the second draft, which proposed a parallel `.masc/run-index/` file. The manifest already carries `keeper_name`, `keeper_turn_id`, and `task_id` (per `keeper_runtime_manifest.ml:204` `runtime_manifest_context`); adding two timestamps and one optional id is `~3 LoC` of struct extension plus a write-time `Time_compat.now ()` at the finalize site.
@@ -225,7 +225,7 @@ Three additional fields per row: `turn_started_at: float`, `turn_ended_at: float
 
 ### 8.4 Alternative — fiber-local binding (rejected after grep)
 
-Tried first. The oas-events relay is a *background fiber* (`runtime_event_bridge.ml:1082` `Eio.Fiber.fork ~sw` inside `start_impl`) subscribed to the OAS bus. `Eio.Fiber.with_binding` propagates only down the same fiber stack, so the relay never sees a binding installed in a keeper turn fiber.
+Tried first. The oas-events relay is a *background fiber* (`keeper_event_bridge.ml:783` `Eio.Fiber.fork ~sw` inside `start_impl`) subscribed to the OAS bus. `Eio.Fiber.with_binding` propagates only down the same fiber stack, so the relay never sees a binding installed in a keeper turn fiber.
 
 ### 8.5 Alternative — explicit shared map keyed on `oas_run_id` (rejected after grep)
 
@@ -247,5 +247,5 @@ Deferred. The OAS publishers do not currently surface an external `client_correl
 
 - Sync with RFC-0046 author on `keeper-detail-state.ts` slot layout (timeline above/below FsmHub) before Phase 2b.
 - Decide whether `Timeline` tab in `goal-tree.ts` is the only mount or if a "fleet timeline" view is wanted later (defer).
-- Confirm the wiring point where `runtime_event_bridge` (or `keeper_telemetry_consumer`) can observe the first OAS envelope `correlation_id` per keeper turn so it can be persisted into `keeper_runtime_manifest` at finalize. If neither path can attribute "first correlation_id seen during turn X" without a back-channel from the relay to the keeper, the `correlation_id_first` field is dropped and §4.1 step 2 (id-prefix disambiguation) is dropped with it — time-overlap remains the sole join.
+- Confirm the wiring point where `keeper_event_bridge` (or `keeper_telemetry_consumer`) can observe the first OAS envelope `correlation_id` per keeper turn so it can be persisted into `keeper_runtime_manifest` at finalize. If neither path can attribute "first correlation_id seen during turn X" without a back-channel from the relay to the keeper, the `correlation_id_first` field is dropped and §4.1 step 2 (id-prefix disambiguation) is dropped with it — time-overlap remains the sole join.
 - If `"unscoped"` bucket size becomes a real operator pain (visible from the pivot API's `unscoped_count`), evaluate §8.8 (agent_sdk envelope extension) as the upgrade path.

--- a/lib/keeper/keeper_execution_receipt_types.ml
+++ b/lib/keeper/keeper_execution_receipt_types.ml
@@ -95,8 +95,8 @@ let runtime_outcome_to_string = function
 (* Receipt-level result of the completion-contract evaluation for the turn.
    Closed union of three producer paths:
      1. Initial-state marker from [keeper_run_tools]: [Contract_unknown].
-     2. Boundary-state overrides: [Contract_violated] (agent_run
-        CompletionContractViolation), [Contract_not_dispatched]
+     2. Boundary-state overrides: [Contract_violated] (text-only turn
+        with no keeper tool names), [Contract_not_dispatched]
         (turn_helpers pre-dispatch), [Contract_no_capable_provider]
         (run_tools no-provider escape).
      3. Six outcomes mirrored from


### PR DESCRIPTION
## Summary

Fixes three documentation/comment staleness issues:

1. **#20065** — `docs/rfc/RFC-0081-telemetry-envelope-and-pivot-timeline.md`: Replace 8+ stale `runtime_event_bridge` references with actual `keeper_event_bridge.ml` paths. The file `runtime_event_bridge` never existed in git history.

2. **#20069** — `docs/PERFORMANCE-SLO.md`: Document the TTFRC-only measurement boundary. MASC measures `ttfrc_ms` via `llm_metric_bridge.ml`; OAS `Streaming_summary.ttft_ms` is not consumed. TTFT-to-client SLO requires extending the `Metrics.t` callback contract or parsing OAS `Streaming_summary`.

3. **#20077** — `lib/keeper/keeper_execution_receipt_types.ml`: Remove stale `CompletionContractViolation` reference from a comment. OAS removed this variant; MASC's `Contract_violated` is an internal evaluation result (text-only turn with no keeper tool names), not a direct OAS mapping.

## Verification

- `dune build .` passes.
- Note: `dune build @check` has pre-existing expression-level type errors in `keeper_hooks_oas.mli` and `runtime_agent.ml` unrelated to this change.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>