### PR TITLE
bump(deps): agent_sdk >= 0.204.5, OAS pin SHA to latest main

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -53,7 +53,7 @@
   ; (upstream piaf 0.2.0 missing conf-libssl dependency on macOS arm64).
   (piaf (>= 0.2.0))
   (eio-ssl (>= 0.3.0))
-  (agent_sdk (>= 0.204.3))
+  (agent_sdk (>= 0.204.5))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))

--- a/masc.opam
+++ b/masc.opam
@@ -28,7 +28,7 @@ depends: [
   "websocket" {>= "2.17"}
   "piaf" {>= "0.2.0"}
   "eio-ssl" {>= "0.3.0"}
-  "agent_sdk" {>= "0.204.3"}
+  "agent_sdk" {>= "0.204.5"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_VERSION="v0.204.3"
+readonly OAS_AGENT_SDK_BASE_VERSION="v0.204.5"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="1aa5ede5d2983308b808299dadc49af4bd799498"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.204.3"
+readonly OAS_AGENT_SDK_SHA="f84da7ad090eacdb485d78ba5d0bee6c839cba15"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.204.5"


### PR DESCRIPTION
## Changes

Bump agent_sdk dependency from `0.204.3` → `0.204.5`.

### OAS v0.204.5 includes:
- **feat(streaming):** add `Connected` and `Timeout` constructors to `sse_event` (#1947)
- **feat(streaming):** propagate Connected and Timeout events down the callback line (#1945)
- **fix:** `make_http_transport` signature cleanup (removed trailing `unit` arg)

### Files changed:
| File | Change |
|------|--------|
| `scripts/oas-agent-sdk-pin.sh` | SHA → `f84da7ad`, version → `0.204.5` |
| `dune-project` | `agent_sdk >= 0.204.5` |
| `masc.opam` | `agent_sdk >= 0.204.5` |