### PR TITLE
fix(workspace): remove implicit auto-release on task claim (#18839)

### DIFF
--- a/lib/workspace/workspace_task_claim.ml
+++ b/lib/workspace/workspace_task_claim.ml
@@ -20,39 +20,6 @@ let clear_reclaim_decision (task : Masc_domain.task) =
     { task with reclaim_policy = None; do_not_reclaim_reason = None }
 ;;
 
-(** Preempt Claimed-only tasks owned by [agent_name] back to Todo.
-    InProgress/AwaitingVerification tasks are left untouched. *)
-let auto_release_claimed_for_agent config ~agent_name ~exclude_task_id (backlog : Masc_domain.backlog)
-    =
-  let claimed_by_me =
-    backlog.tasks |> List.filter_map (fun (t : task) ->
-      match t.task_status with
-      | Claimed { assignee; _ }
-        when Workspace_task_classify.same_task_actor config assignee agent_name
-             && t.id <> exclude_task_id -> Some t.id
-      | Todo | Claimed _ | InProgress _
-      | AwaitingVerification _ | Done _ | Cancelled _ -> None)
-  in
-  match claimed_by_me with
-  | [] -> (backlog, [])
-  | ids ->
-    let new_tasks = List.map (fun (t : task) ->
-      if List.mem t.id ids then { t with task_status = Todo } else t) backlog.tasks in
-    ({ backlog with tasks = new_tasks }, ids)
-
-(* fire-and-forget: broadcast auto-release for operator visibility *)
-let broadcast_auto_releases config ~agent_name ~claimed_task_id auto_released_ids =
-  List.iter (fun released_id ->
-      ignore (broadcast config ~from_agent:agent_name
-        ~content:(Printf.sprintf "Auto-released %s (claimed, not started) to claim %s"
-           released_id claimed_task_id));
-      log_event config (`Assoc
-        [ ("type", `String "task_auto_release"); ("agent", `String agent_name)
-        ; ("task", `String released_id); ("reason", `String "preempted_for_claim")
-        ; ("ts", `String (now_iso ())) ]))
-    auto_released_ids
-;;
-
 let active_owned_task_ids_for_agent config ~agent_name (backlog : Masc_domain.backlog)
   =
   backlog.tasks
@@ -140,9 +107,6 @@ let claim_task_r config ~agent_name ~task_id ()
                (Masc_domain.Task (Masc_domain.Task_error.InvalidState
                   (Printf.sprintf "Task %s is blocked from re-claim: %s" task_id r)))
            | Claim_available _ | Claim_unavailable (Claim_block_not_todo _) -> Ok ()
-         in
-         let (backlog, auto_released_ids) =
-           auto_release_claimed_for_agent config ~agent_name ~exclude_task_id:task_id backlog
          in
          let* () =
            match task.task_status with
@@ -248,7 +212,7 @@ let claim_task_r config ~agent_name ~task_id ()
            Ok
              (`New_claim
                { message = Printf.sprintf "%s assigned as verifier for %s" agent_name task_id
-               ; auto_released_task_ids = auto_released_ids
+               ; auto_released_task_ids = []
                })
          | `Claimed_ok ->
            let new_backlog =
@@ -292,18 +256,10 @@ let claim_task_r config ~agent_name ~task_id ()
                   ~to_status:
                     (Masc_domain.Claimed { assignee = agent_name; claimed_at = now_iso () })
                   ());
-           (* Broadcast auto-released tasks (Claimed-only, preempted for this claim) *)
-           broadcast_auto_releases config ~agent_name ~claimed_task_id:task_id auto_released_ids;
-           let claim_msg =
-             match auto_released_ids with
-             | [] -> Printf.sprintf "%s claimed %s" agent_name task_id
-             | ids ->
-               Printf.sprintf "%s claimed %s (auto-released %s)"
-                 agent_name task_id (String.concat ", " ids)
-           in
+           let claim_msg = Printf.sprintf "%s claimed %s" agent_name task_id in
            Ok
              (`New_claim
-               { message = claim_msg; auto_released_task_ids = auto_released_ids })
+               { message = claim_msg; auto_released_task_ids = [] })
        with
        | Eio.Cancel.Cancelled _ as e -> raise e
        | e -> Error (Masc_domain.System (Masc_domain.System_error.IoError (Printexc.to_string e)))))

--- a/lib/workspace/workspace_task_claim.mli
+++ b/lib/workspace/workspace_task_claim.mli
@@ -30,21 +30,13 @@ val active_ownership_conflict_for_claim :
 
 (** Typed outcome of a successful claim.
 
-    [auto_released_task_ids] is the list of *other* tasks previously
-    held by the same agent that the claim implicitly auto-released
-    (see #10421 / #18839: hot-potato pattern where a keeper churns
-    through [task_claim_next] without finishing). Empty when the agent
-    held no prior claims; non-empty when [task_claim_next] preempted
-    them. Previously this list was only visible as a substring of the
-    [message] field (["… (auto-released X, Y)"]); MCP handlers had to
-    re-parse it. Surfaced as a typed field so callers — including the
-    MCP envelope that feeds the LLM keeper response — can react
-    without string parsing.
-
-    RFC-0088 §1 (counter-as-fix) note: this PR only widens the typed
-    surface so a caller *can* observe the auto-release. Behaviour is
-    unchanged. The follow-up RFC step (reject + explicit release) is
-    out of scope for this PR. *)
+    [auto_released_task_ids] is legacy and always empty.
+    Auto-release of previously Claimed tasks was removed in #18839
+    to stop the hot-potato pattern where a keeper churned through
+    [task_claim_next] without finishing. Keepers must now explicitly
+    release tasks via [keeper_task_release] before claiming another.
+    The field is retained for backward compatibility with existing
+    MCP consumers that pattern-match on the record shape. *)
 type claim_outcome = {
   message : string;
   auto_released_task_ids : string list;


### PR DESCRIPTION
## Summary

Closes #18839.

Remove the implicit auto-release behavior in `task_claim_next` that silently preempted Claimed-only tasks back to Todo. This was the root cause of the "hot-potato" pattern where keepers churned through claims without finishing.

## Changes

- Remove `auto_release_claimed_for_agent` function
- Remove `broadcast_auto_releases` function
- `auto_released_task_ids` in `claim_outcome` is now always `[]` (retained for backward compatibility with MCP consumers)
- Claim message no longer mentions auto-released tasks

## Behaviour change

Keepers must now explicitly call `keeper_task_release` before claiming another task. The existing ownership-conflict check (`active_ownership_conflict_for_claim`) and `Already_mine` handling remain unchanged.

## Verification

- `dune build @check` — clean
- `dune build .` — clean (cache store warning only, not a code error)

## Test plan

- [ ] Keeper integration tests pass
- [ ] `masc_claim_next` with existing Claimed task → `Already_mine` or ownership-conflict error
- [ ] No auto-release broadcast events emitted