### PR TITLE
fix(keeper): reset livelock stuck-age on provider_timeout terminal (F2)

### DIFF
--- a/lib/keeper/keeper_unified_turn_types.ml
+++ b/lib/keeper/keeper_unified_turn_types.ml
@@ -351,6 +351,22 @@ let record_streaming_cancelled_observation
   let cancelled_variant =
     match terminal_reason_code with
     | "attempt_watchdog_safety_deadline" ->
+      (* The attempt watchdog firing is an environmental terminal (the
+         provider stalled mid-stream), not a same-turn re-dispatch storm.
+         [Keeper_turn_livelock.classify_and_decide] keys [Stuck_age_exceeded]
+         off [first_started_at], i.e. the FIRST dispatch of this turn_id; a
+         retry after the watchdog cancel inherits that ~watchdog-budget-old
+         timestamp and trips the stuck-age gate on the very next dispatch,
+         routing the keeper to operator_pause (human-gated resume). That
+         pause on a transport stall contradicts the invariant that a keeper
+         keeps acting autonomously. Reset the livelock entry so the retry is
+         classified Fresh. Rapid re-dispatch storm detection is unaffected:
+         only the watchdog/provider_timeout terminal clears the counter, and
+         only for the keeper whose turn just timed out. The underlying
+         mid-stream stall (dropped OAS stream-idle deadline) is addressed
+         separately; this prevents the symptom from escalating to a
+         fleet-wide pause. *)
+      Keeper_turn_livelock.reset_keeper_livelock ~keeper:run_meta.name;
       Keeper_turn_fsm.Cancelled Keeper_turn_fsm.Cancelled_provider_timeout
     | _ ->
       (* supervisor_stop, external_cancel, or any future reason *)

--- a/test/test_keeper_turn_livelock_10121.ml
+++ b/test/test_keeper_turn_livelock_10121.ml
@@ -270,6 +270,46 @@ let test_guard_forward_advance_resets () =
    | L.Started L.Fresh -> ()
    | _ -> Alcotest.fail "turn 8 should reset guard state")
 
+(* F2: a provider_timeout terminal (the attempt watchdog firing mid-stream)
+   resets the livelock entry via [reset_keeper_livelock] before the same
+   turn_id is re-dispatched (see keeper_unified_turn_types.ml,
+   "attempt_watchdog_safety_deadline" arm). Pin the invariant that wiring
+   relies on: a re-dispatch whose age would otherwise cross
+   [stuck_after_sec] is reclassified [Fresh] once the entry is reset, so a
+   transport stall routes to autonomous retry instead of
+   [Stuck_age_exceeded] -> operator_pause. Mirror of
+   [test_guard_blocks_on_stuck_age] with the reset interposed. *)
+let test_reset_clears_stuck_age_for_provider_timeout () =
+  L.reset_for_tests ();
+  let keeper = "test-keeper-reset-stuck-age-10121" in
+  let now = ref 10.0 in
+  let call () =
+    L.guard_and_record_turn_start
+      ~now:(fun () -> !now)
+      ~keeper
+      ~turn_id:24
+      ~max_attempts:10
+      ~stuck_after_sec:30.0
+      ()
+  in
+  (match call () with
+   | L.Started L.Fresh -> ()
+   | _ -> Alcotest.fail "first attempt should start fresh");
+  (* Age now far exceeds the threshold; without the reset this is the exact
+     scenario [test_guard_blocks_on_stuck_age] proves blocks. *)
+  now := 1810.0;
+  L.reset_keeper_livelock ~keeper;
+  (match call () with
+   | L.Started L.Fresh -> ()
+   | L.Blocked (L.Stuck_age_exceeded _) ->
+     Alcotest.fail
+       "after reset_keeper_livelock the same turn_id must not trip stuck-age"
+   | _ -> Alcotest.fail "after reset the same turn_id should start Fresh");
+  Alcotest.(check (float 0.0001))
+    "no stuck-age block recorded for this keeper after reset"
+    0.0
+    (blocks_for ~keeper ~reason:"stuck_age_exceeded")
+
 let () =
   Alcotest.run "keeper_turn_livelock_10121"
     [
@@ -310,5 +350,7 @@ let () =
             (with_eio test_guard_blocks_on_stuck_age);
           Alcotest.test_case "forward advance resets guard" `Quick
             (with_eio test_guard_forward_advance_resets);
+          Alcotest.test_case "reset clears stuck-age (provider_timeout)" `Quick
+            (with_eio test_reset_clears_stuck_age_for_provider_timeout);
         ] );
     ]


### PR DESCRIPTION
## 목표

provider mid-stream stall로 attempt watchdog이 turn을 cancel한 직후, 같은 `turn_id` 재dispatch가 livelock stuck-age 게이트를 즉시 trip해 키퍼가 `operator_pause`(인간 resume 필요)로 가던 것을 막는다. provider stall에도 키퍼는 자율 retry를 유지해야 한다 (키퍼는 멈추지 않는다).

근거: 2026-06-09 fiber/await 감사 `~/me/.tmp/masc-fiber-audit-2026-06-09/DIAGNOSIS.md` 의 **F2 (S2 cross-seam fix)**. 2026-06-08 fleet 정지(15개 키퍼 전원 `operator_pause`)의 proximate cause.

## 근본 원인 (livelock 분류기의 의미 혼동)

- `Keeper_turn_livelock.classify_and_decide` 는 `Stuck_age_exceeded` 를 `first_started_at` = **turn_id 의 *최초* dispatch 시각** 기준으로 판정한다.
- attempt watchdog 의 `attempt_watchdog_safety_deadline` terminal 은 provider 가 mid-stream 으로 침묵해 발생하는 **환경적 terminal** 이지, 키퍼의 rapid re-dispatch storm 이 아니다. 그런데 watchdog cancel 후의 retry 는 그 ~watchdog-budget 만큼 묵은 `first_started_at` 을 그대로 물려받는다.
- 동일값 충돌: attempt_watchdog cap (1800s) == livelock `stuck_after_sec` (1800s) → cancel 직후 첫 retry 가 `age_sec >= stuck_after_sec` 을 **반드시** 만족 → `Stuck_age_exceeded` → `operator_pause`.

즉 "clean terminal 직후의 fresh retry" 를 "1800s 동안 stuck" 으로 **오분류** 하는 분류기 결함이다.

## 변경

- `lib/keeper/keeper_unified_turn_types.ml`: provider_timeout 분류 arm (`"attempt_watchdog_safety_deadline"`)에서 `Keeper_turn_livelock.reset_keeper_livelock ~keeper` 호출 → 다음 dispatch 가 `Fresh` 로 분류된다.
- storm 감지는 보존: provider_timeout terminal 에만, 해당 키퍼에만 리셋한다. 다른 terminal(`supervisor_stop`/`external_cancel`)·다른 키퍼·rapid same-turn re-dispatch(`Attempts_exhausted` 경로)는 영향 없음.

## 검증

- `dune build --root . @check`: green.
- `dune exec --root . test/test_keeper_turn_livelock_10121.exe`: **11/11 OK** (`Test Successful in 0.058s`).
- 신규 테스트 `test_reset_clears_stuck_age_for_provider_timeout`: reset 후 age 1810s > threshold 30s 인 같은 turn_id 가 `Stuck_age_exceeded` 대신 `Started Fresh` 로 분류됨을 증명 (`test_guard_blocks_on_stuck_age` 의 mirror + reset 개입).

## 미검증 / 후속

- producer→consumer wiring(`record_streaming_cancelled_observation` 이 실제로 reset 을 호출하는 경로)은 code-read 로 확인 (exhaustive match arm). config/registry/FSM fixture 가 필요한 통합 테스트는 후속.
- 이 PR 은 S2(분류기 오분류 → fleet pause)를 고친다. 그 stall 자체의 root(dropped OAS stream-idle deadline)는 별도 F1 (transport carrier, RFC 필요) 에서 다룬다.

WORKAROUND-WAIVED: 본 변경은 cap/cooldown/dedup/repair 형태의 증상 억제가 아니라 livelock 분류기의 first_started_at 의미 혼동(최초 dispatch vs 현재 시도 시작)을 교정하는 근본 수정이다. 상세: DIAGNOSIS.md §3 S2.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
