### PR TITLE
fix(keeper): isolate chat-adapter fibers from the shared switch (F5)

### DIFF
--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -963,9 +963,23 @@ let start_keeper_loops
                     keeper_name;
                   (match discord_bot_token_opt () with
                    | Some token ->
-                       Eio.Fiber.fork ~sw (fun () ->
-                         Keeper_chat_discord.adapter_loop ~token
-                           ~channel_id ~events)
+                       (* fork_logged_fiber, not bare Eio.Fiber.fork: the
+                          adapter body runs after this synchronous frame
+                          returns, so the enclosing try/with cannot catch an
+                          exception it raises later. A bare fork would fail
+                          the shared [sw] and cancel every sibling fiber under
+                          it. [on_error] contains non-Cancelled exceptions;
+                          [fork_logged_fiber] re-raises Cancelled to preserve
+                          structured teardown. *)
+                       fork_logged_fiber ~sw
+                         ~on_error:(fun exn ->
+                           Log.Keeper.error
+                             "keeper_chat_consumer: Discord adapter fiber \
+                              crashed for keeper=%s: %s"
+                             keeper_name (Printexc.to_string exn))
+                         (fun () ->
+                           Keeper_chat_discord.adapter_loop ~token
+                             ~channel_id ~events)
                    | None ->
                        Log.Keeper.warn
                          "keeper_chat_consumer: \
@@ -979,9 +993,18 @@ let start_keeper_loops
                     keeper_name;
                   (match Sys.getenv_opt "MASC_SLACK_BOT_TOKEN" with
                    | Some token ->
-                       Eio.Fiber.fork ~sw (fun () ->
-                         Keeper_chat_slack.adapter_loop ~token
-                           ~channel ~events)
+                       (* Isolate from the shared [sw] like the Discord arm
+                          above; a bare fork would cancel sibling fibers if
+                          the adapter raises a non-Cancelled exception. *)
+                       fork_logged_fiber ~sw
+                         ~on_error:(fun exn ->
+                           Log.Keeper.error
+                             "keeper_chat_consumer: Slack adapter fiber \
+                              crashed for keeper=%s: %s"
+                             keeper_name (Printexc.to_string exn))
+                         (fun () ->
+                           Keeper_chat_slack.adapter_loop ~token
+                             ~channel ~events)
                    | None ->
                        Log.Keeper.warn
                          "keeper_chat_consumer: \

--- a/test/test_server_bootstrap_loop_fork_helper.ml
+++ b/test/test_server_bootstrap_loop_fork_helper.ml
@@ -44,6 +44,22 @@ let test_bootstrap_sites_use_logged_helper () =
     (count_substring ~haystack:content ~needle:"fork_logged_fiber" >= 2)
 ;;
 
+(* The sibling ratchet [test_raw_fork_is_owned_by_helper] only constrains
+   server_bootstrap_loops_fiber.ml. The chat-adapter (Discord/Slack) sites in
+   server_bootstrap_loops.ml used raw [Eio.Fiber.fork ~sw] directly, escaping
+   that ratchet: a non-Cancelled exception from an adapter loop would fail the
+   shared switch and cancel sibling fibers. Close the gap by asserting the
+   loops module spawns no raw fork either; every site routes through
+   [fork_logged_fiber]. *)
+let test_loops_has_no_raw_fork () =
+  let content = read_file "lib/server/server_bootstrap_loops.ml" in
+  check int
+    "no raw Eio.Fiber.fork in server_bootstrap_loops; sites route through \
+     fork_logged_fiber"
+    0
+    (count_substring ~haystack:content ~needle:"Eio.Fiber.fork ~sw (fun () ->")
+;;
+
 let test_crash_log_names_remain_specific () =
   let content = read_file "lib/server/server_bootstrap_loops.ml" in
   List.iter
@@ -64,6 +80,7 @@ let () =
       , [ test_case "raw-fork-owned-by-helper" `Quick test_raw_fork_is_owned_by_helper
         ; test_case "bootstrap-sites-use-helper" `Quick
             test_bootstrap_sites_use_logged_helper
+        ; test_case "loops-has-no-raw-fork" `Quick test_loops_has_no_raw_fork
         ; test_case "crash-log-names-remain-specific" `Quick
             test_crash_log_names_remain_specific
         ] )


### PR DESCRIPTION
## 목표

키퍼 chat 어댑터(Discord/Slack) fiber 가 공유 switch(`sw`)에서 raw `Eio.Fiber.fork` 로 spawn 되어, 어댑터 루프가 non-Cancelled 예외를 raise 하면 그 switch 의 형제 fiber(전 키퍼 + supervisor sweep + 모든 background loop)가 함께 cancel 되는 **fleet-wide crash 벡터**를 제거한다.

근거: 2026-06-09 fiber/await 감사 `~/me/.tmp/masc-fiber-audit-2026-06-09/DIAGNOSIS.md` 의 **F5 (S6)**.

## 근본 원인

- `lib/server/server_bootstrap_loops.ml` 의 chat consumer 가 어댑터를 `Eio.Fiber.fork ~sw (fun () -> Keeper_chat_{discord,slack}.adapter_loop ...)` 로 spawn.
- 동기 setup 을 감싼 `try ... with | Cancelled -> raise | exn -> log` 는 fork 가 **즉시 반환**하므로 어댑터 루프 본체(나중에 실행)의 예외를 잡지 못한다.
- 따라서 어댑터의 non-Cancelled 예외는 공유 `sw` 로 전파 → 구조적 동시성에 의해 형제 전원 cancel.
- 코드베이스 전역 불변식(모든 bootstrap/background fiber 는 `fork_logged_fiber` 경유)을 깨는 단 두 사이트였다.
- 게다가 ratchet 테스트 `test_server_bootstrap_loop_fork_helper` 는 `server_bootstrap_loops_fiber.ml` 만 검사하고 `server_bootstrap_loops.ml` 의 raw fork 는 보지 않아 이 두 사이트가 **빈틈으로 빠져나갔다**.

## 변경

- `server_bootstrap_loops.ml`: Discord/Slack 어댑터 fork 2곳을 `fork_logged_fiber ~sw ~on_error:(...)` 로 교체. `fork_logged_fiber` 는 non-Cancelled 예외를 `on_error`(키퍼별 crash 로그)로 격리하고 `Eio.Cancel.Cancelled` 는 re-raise 해 구조적 teardown 을 보존한다.
- `test_server_bootstrap_loop_fork_helper.ml`: ratchet 에 `test_loops_has_no_raw_fork` 추가 — `server_bootstrap_loops.ml` 의 raw `Eio.Fiber.fork ~sw (fun () ->` 가 0개임을 강제해 빈틈을 닫고 회귀를 차단.

## 검증

- `dune build --root . @check`: green.
- `dune exec --root . test/test_server_bootstrap_loop_fork_helper.exe`: 신규 `loops-has-no-raw-fork` 포함 전체 통과.
- `_loops.ml` raw fork 카운트: 0 (변경 전 2), `fork_logged_fiber` 사용처: 7.

## 비고

- `fork_logged_fiber` 는 기존 검증된 헬퍼로, 코드베이스 전역에서 `fork_subsystem` 이 사용한다 (1:1 기계적 swap).
- on_error 는 codebase-wide wrap-and-swallow 규율과 일치(비-Cancelled 격리 + 로그, Cancelled re-raise).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
