### PR TITLE
fix(workspace): cap cycle_count at 100 (#18853)

### DIFF
--- a/lib/workspace/workspace_task_transition_executor.ml
+++ b/lib/workspace/workspace_task_transition_executor.ml
@@ -39,10 +39,16 @@ let normalize_task_before_status ~action task =
     task
 ;;
 
+(** Upper bound for [cycle_count] to prevent unbounded growth from
+    claim->release hot-potato patterns (issue #18853).  100 allows
+    5x headroom above the [severe] escalation threshold (20) while
+    capping the context bloat measured at 1000+ cycles. *)
+let max_cycle_count = 100
+
 let release_counters ~action task handoff_context =
   match action with
   | Masc_domain.Release ->
-    ( task.cycle_count + 1
+    ( min (task.cycle_count + 1) max_cycle_count
     , Workspace_task_claim.derive_release_reclaim_policy task handoff_context
     , Workspace_task_claim.derive_release_do_not_reclaim_reason task handoff_context )
   | Masc_domain.Claim


### PR DESCRIPTION
## Summary
Add `max_cycle_count = 100` in `release_counters` to stop claim->release hot-potato patterns from inflating `cycle_count` indefinitely.

## Context
Issue #18853 reported that `task.cycle_count` has no upper guard. Each `Release` action increments it unconditionally, leading to:
- Unbounded context growth (measured at 1000+ cycles in production logs)
- Noise in escalation diagnostics (threshold/major/severe logic keys off cycle_count)

## Change
- Introduce `max_cycle_count = 100` (5x headroom above the `severe` escalation threshold of 20)
- Cap increment with `min (task.cycle_count + 1) max_cycle_count`

## Verification
- `dune build @check` passes
- Escalation thresholds at 4/9/19 remain unaffected (capped value > all thresholds)

Closes #18853

🤖 Generated with [Claude Code](https://claude.com/claude-code)