### PR TITLE
fix(keeper): offload fd-pressure sysctl probe to a systhread (F4)

### DIFF
--- a/lib/keeper_runtime/keeper_fd_pressure.ml
+++ b/lib/keeper_runtime/keeper_fd_pressure.ml
@@ -44,7 +44,6 @@ type system_fd_cache_entry =
   }
 
 let system_fd_cache : system_fd_cache_entry option Atomic.t = Atomic.make None
-let system_fd_mutex = Stdlib.Mutex.create ()
 
 type admission_block =
   | Fd_pressure_cooldown of float
@@ -382,6 +381,18 @@ let system_fd_probe_ttl_sec () =
   |> Float.min 30.0
 ;;
 
+(* The detect spawns a [sysctl] subprocess on darwin and does a blocking
+   [input_line] drain. Run it via [Eio_guard.run_in_systhread] so the blocking
+   read does not freeze the owning Eio domain's event-loop thread; the guard
+   falls back to a direct call before [Eio_guard.enable ()] (unit tests / init).
+
+   No mutex around the detect: [system_fd_cache] is an [Atomic], and the probe is
+   an idempotent read-only [sysctl] read, so concurrent duplicate detects are
+   harmless (last-write-wins). A [Stdlib.Mutex] held across the systhread offload
+   would be held across a yield (the installed [With_process] guard acquires an
+   [Eio.Semaphore]; see fd_accountant.ml install_with_process_sandbox_exec_guard),
+   which is a defect on OCaml 5.x. Contrast [process_nofile_soft_limit]: its detect
+   is a non-yielding native [getrlimit] stub, so its Stdlib.Mutex stays. *)
 let system_fd_snapshot ?now () =
   let now = Option.value ~default:(Time_compat.now ()) now in
   let fresh = function
@@ -392,16 +403,11 @@ let system_fd_snapshot ?now () =
   match fresh (Atomic.get system_fd_cache) with
   | Some snapshot -> snapshot
   | None ->
-    Stdlib.Mutex.lock system_fd_mutex;
-    Fun.protect
-      ~finally:(fun () -> Stdlib.Mutex.unlock system_fd_mutex)
-      (fun () ->
-        match fresh (Atomic.get system_fd_cache) with
-        | Some snapshot -> snapshot
-        | None ->
-          let snapshot = detect_system_fd_snapshot_now () in
-          Atomic.set system_fd_cache (Some { sampled_at = now; snapshot });
-          snapshot)
+    let snapshot =
+      Eio_guard.run_in_systhread (fun () -> detect_system_fd_snapshot_now ())
+    in
+    Atomic.set system_fd_cache (Some { sampled_at = now; snapshot });
+    snapshot
 ;;
 
 (* Fleet baseline. Default targets 64 active keepers:

--- a/test/test_keeper_fd_pressure_fleet.ml
+++ b/test/test_keeper_fd_pressure_fleet.ml
@@ -207,6 +207,101 @@ let test_engage_external_crit_extends_warn () =
     (after_crit > after_warn);
   FD.reset_for_tests ()
 
+(* F4 — system FD probe offloaded to a systhread.
+
+   [system_fd_snapshot] (reached via [admit_turn] with no [~system_fds]) runs the
+   darwin [sysctl] subprocess, which does a blocking [input_line] drain. The fix
+   offloads that detect via [Eio_guard.run_in_systhread] so the blocking read does
+   not freeze the owning Eio domain's event-loop thread, and drops the
+   [Stdlib.Mutex] that previously wrapped the detect (would be held across the
+   offload yield).
+
+   Test 1 is darwin-gated on the same predicate production uses
+   ([SystemVersion.plist]) because the freeze is darwin-only: the linux path uses a
+   non-spawning [read_first_line] and never reaches the subprocess guard. *)
+
+let darwin_host () =
+  Sys.file_exists "/System/Library/CoreServices/SystemVersion.plist"
+
+(* A [With_process] guard whose [run] blocks the calling thread for [delay]
+   seconds before delegating. With the fix, the whole detect (guard + subprocess)
+   runs on a systhread, so this blocks the systhread, not the event loop. *)
+let blocking_process_guard ~delay : With_process.process_guard =
+  { run =
+      (fun f ->
+        Unix.sleepf delay;
+        f ())
+  }
+
+let test_probe_offload_keeps_domain_alive () =
+  if not (darwin_host ())
+  then
+    (* Linux short-circuits before the subprocess guard; freeze is darwin-only. *)
+    ()
+  else (
+    let blocking_delay = 1.5 in
+    Eio_main.run (fun _env ->
+      Eio_guard.enable ();
+      Fun.protect
+        ~finally:(fun () ->
+          With_process.reset_process_guard_for_testing ();
+          FD.reset_for_tests ();
+          Eio_guard.disable ())
+        (fun () ->
+          FD.reset_for_tests ();
+          With_process.set_process_guard (blocking_process_guard ~delay:blocking_delay);
+          let sentinel = Atomic.make 0 in
+          let stop = Atomic.make false in
+          Eio.Fiber.both
+            (fun () ->
+              (* Triggers the offloaded probe (no [~system_fds] supplied). With
+                 the offload, this fiber suspends on the systhread and yields the
+                 domain; without it, the domain is frozen for [blocking_delay]. *)
+              let _ : bool = FD.admit_turn ~active_keepers:1 () in
+              Atomic.set stop true)
+            (fun () ->
+              while not (Atomic.get stop) do
+                Atomic.incr sentinel;
+                Eio.Fiber.yield ()
+              done);
+          (* With the fix the sentinel spins freely while the probe blocks on the
+             systhread, so it advances well past a handful of iterations. With the
+             old (event-loop-thread) blocking probe it would be ~0. *)
+          let observed = Atomic.get sentinel in
+          Alcotest.(check bool)
+            (Printf.sprintf
+               "sentinel advanced during blocked probe (observed=%d > 10)"
+               observed)
+            true
+            (observed > 10))))
+
+let test_concurrent_snapshot_no_relock () =
+  (* Portable: after the mutex drop there is nothing to relock, so N concurrent
+     probes must complete without raising and each return a bool decision. With
+     the old [Stdlib.Mutex] held across a yielding guard this was the relock /
+     [Sys_error] hazard. *)
+  Eio_main.run (fun _env ->
+    Eio_guard.enable ();
+    Fun.protect
+      ~finally:(fun () ->
+        FD.reset_for_tests ();
+        Eio_guard.disable ())
+      (fun () ->
+        FD.reset_for_tests ();
+        let fan = 16 in
+        Eio.Switch.run (fun sw ->
+          let promises =
+            List.init fan (fun _ ->
+              Eio.Fiber.fork_promise ~sw (fun () ->
+                Eio.Fiber.yield ();
+                FD.admit_turn ~active_keepers:1 ()))
+          in
+          let results = List.map Eio.Promise.await_exn promises in
+          Alcotest.(check int)
+            "all concurrent probes returned a decision"
+            fan
+            (List.length results))))
+
 let () =
   Alcotest.run
     "keeper_fd_pressure_fleet"
@@ -237,5 +332,11 @@ let () =
             test_engage_external_stale_ts_is_noop
         ; Alcotest.test_case "CRIT extends WARN cooldown" `Quick
             test_engage_external_crit_extends_warn
+        ] )
+    ; ( "system-fd-probe-offload"
+      , [ Alcotest.test_case "blocked probe does not freeze the domain (darwin)" `Quick
+            test_probe_offload_keeps_domain_alive
+        ; Alcotest.test_case "concurrent probes do not relock after mutex drop" `Quick
+            test_concurrent_snapshot_no_relock
         ] )
     ]


### PR DESCRIPTION
## 문제 (problem)

`Keeper_fd_pressure.system_fd_snapshot` (turn admission gate가 `admit_turn`을 통해 `~system_fds` 없이 호출 → 기본 인자 표현식으로 도달; `keeper_heartbeat_loop.ml:323` → `keeper_fd_pressure.ml:748/737/515`)는 darwin에서 `/usr/sbin/sysctl` 서브프로세스를 띄우고 `With_process.drain_lines`의 blocking `input_line` 루프로 출력을 읽습니다 (`with_process.ml:48-54`).

이 detect가 keeper의 **소유 Eio 도메인** 이벤트 루프 스레드 위에서 직접 실행됩니다. keeper keepalive/turn 루프는 도메인 풀이 아니라 소유 도메인에서 돌고 (`keeper_supervisor_launch.ml:91-97/124-125`, RFC-0059 PR-7의 `Domain_pool` 라우팅은 unsafe로 revert됨), `Cancel_safe.protect`는 in-flight blocking C read를 중단시키지 못합니다. 따라서 `sysctl`이 stall/hang 하면 해당 도메인의 모든 keeper가 turn을 멈춥니다 (I1 위반: keeper는 영구히 멈추면 안 됨). 발생 빈도는 process-wide TTL 캐시(기본 2.0s)로 제한되므로 저빈도이지만, stall 시 high-impact 한 latent freeze입니다.

추가로, detect가 `Stdlib.Mutex.lock system_fd_mutex` 하에서 실행됩니다 (`keeper_fd_pressure.ml:395`). production에서 `Fd_accountant`가 `With_process` guard를 설치하고 (`fd_accountant.ml:201-206`), 그 guard의 `run`이 `Eio.Semaphore.acquire`로 fiber를 yield 합니다 (`fd_accountant.ml:109/123`). `Stdlib.Mutex`를 yield 너머로 들고 있는 것은 OCaml 5.x에서 same-thread relock (ERRORCHECK 시 `Sys_error`) 또는 deadlock으로, 둘 다 결함입니다.

## 수정 (fix)

`system_fd_snapshot`을 다음과 같이 변경:

- blocking detect (`detect_system_fd_snapshot_now`)를 `Eio_guard.run_in_systhread`로 offload (`lib/core/eio_guard.ml:41`). Eio 런타임이 준비되면 `Eio_unix.run_in_systhread`로 시스템 스레드에서 실행하고, `Eio_guard.enable ()` 이전(unit test/module-init)에는 직접 `f ()`로 fallback. blocking C read가 이벤트 루프 스레드를 막지 않으므로 같은 도메인의 다른 fiber가 계속 진행합니다.
- `system_fd_mutex` (그리고 detect를 감싸던 `Fun.protect`)를 제거. `system_fd_cache`가 이미 `Atomic`이고 (`keeper_fd_pressure.ml:46`), `sysctl` 프로브는 idempotent read-only이므로 동시 중복 detect는 무해합니다 (last-write-wins). single-flight에 의존하는 caller는 없습니다 (모든 reader는 반환된 snapshot 값만 소비). mutex 제거로 Hazard B(mutex-across-yield)가 이동이 아니라 소멸합니다.

비대칭 보존: `process_nofile_soft_limit`은 native non-yielding `getrlimit` C stub를 쓰므로 `Stdlib.Mutex`를 유지합니다. 소스 주석에 이 비대칭을 명시해 향후 "consistency-fix"를 방지합니다.

dune 변경 없음: `lib/keeper_runtime/dune`는 이미 `masc_core`를 의존하고, `Eio_guard`는 `masc_core`에 있으며 `Eio_unix`는 기존 `eio` 의존으로 도달합니다.

## 검증 (verification)

- `dune build --root . @check` — PASS (출력 없음, 에러/경고 0).
- `dune build --root . lib/keeper_runtime` — PASS (expression-level 변경이라 lib full build로 확인; @check만으로는 누락 가능). `system_fd_mutex` 제거 후 unused 경고 없음 → 다른 참조 없음 확인.
- `dune exec --root . test/test_keeper_fd_pressure_fleet.exe` — 12/12 PASS (기존 10 + 신규 2).

신규 테스트 2개 (`test/test_keeper_fd_pressure_fleet.ml`):

1. `blocked probe does not freeze the domain (darwin)` — darwin-gate (production과 동일한 `SystemVersion.plist` predicate). blocking `With_process` guard(`Unix.sleepf 1.5`)를 설치하고 `admit_turn`(offload된 darwin 프로브 트리거)과 sentinel fiber를 `Eio.Fiber.both`로 병행 실행. 프로브가 systhread에서 1.5s 막히는 동안 sentinel이 진행함을 단언 (`observed > 10`). offload 없으면 도메인이 얼어 sentinel은 ~0. 실측 총 실행 1.515s가 도메인이 얼지 않았음을 입증.
2. `concurrent probes do not relock after mutex drop` — portable (전 플랫폼 CI 실행). N개 동시 `admit_turn`가 예외 없이 모두 bool decision을 반환함을 단언. mutex 제거 후 relock 대상이 없음을 smoke로 확인.

## S4 ref

S4 (keeper fiber/concurrency 수정 묶음)의 F4. immediate code-pr (offload + mutex drop)로 I1 liveness를 복원합니다. 권장 follow-up은 `sysctl` 서브프로세스를 native `sysctlbyname` C stub로 대체하는 것 (서브프로세스/FD 소비/stall freeze 제거, nofile 프로브와 대칭) — 별도 PR로 분리합니다. design: `.tmp/masc-fiber-fixes-2026-06-09/F4-fd-pressure-offload-design.md`.

design §4 대비 deviation: design은 `test/keeper_runtime/`에 새 테스트를 두고 `With_process` guard seam이 CI-portable 하다고 했으나, 이 repo의 테스트는 `test/` flat 구조이고 linux detect 경로가 서브프로세스 guard에 도달하기 전에 short-circuit 하므로 Test 1은 darwin-gate로 두었습니다. Test 2는 portable로 유지.

이 변경은 blocking syscall을 systhread로 옮기고 불필요한 lock을 제거하는 근본 수정(I1 liveness 복원)입니다. native stub follow-up은 더 큰 durable root fix로 별도 PR입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
