### PR TITLE
fix(keeper): guard keeper_board_post_get against empty post_id args

### DIFF
--- a/lib/keeper/keeper_tool_board_runtime.ml
+++ b/lib/keeper/keeper_tool_board_runtime.ml
@@ -179,7 +179,18 @@ let handle_keeper_board_tool
       (String_util.utf8_safe ~max_bytes:203 ~suffix:"..." msg |> String_util.to_string);
     tool_result_or_error result)
   | "keeper_board_list" -> dispatch_board Tool_name.Board_name.Board_list args
-  | "keeper_board_post_get" -> dispatch_board Tool_name.Board_name.Board_post_get args
+  | "keeper_board_post_get" ->
+    (match string_arg "post_id" args with
+     | Some pid when String.trim pid <> "" ->
+       dispatch_board Tool_name.Board_name.Board_post_get args
+     | _ ->
+       error_json
+         ~fields:[ "reason", `String "missing_post_id"
+                 ; "recovery", `String "call keeper_board_list or keeper_board_search first" ]
+         "keeper_board_post_get requires post_id (format: p-xxxx). \
+          You sent empty or missing post_id. Call keeper_board_list \
+          or keeper_board_search first to discover available post IDs, \
+          then retry with the post_id you want to read.")
   | "keeper_board_comment" ->
     dispatch_board
       Tool_name.Board_name.Board_comment


### PR DESCRIPTION
## Problem

`deepseek-v4-flash` (and potentially other weaker models) repeatedly call `keeper_board_post_get` with `{}` (no `post_id`), causing a recurring failure chain:

```
correction_pipeline still invalid after deterministic fixes
→ Tool retry budget exhausted after 2/2 retries
→ keeper cycle FAILED (auto-recoverable)
→ operator_disposition: unmapped → investigate regression of #11651
```

### Root Cause

The correction_pipeline can handle type coercion, default injection, and format normalization — but **cannot** synthesize a required `post_id` that requires semantic extraction from context. The model sends `{}`, the SDK retries twice, and the model sends `{}` again both times.

## Fix

Intercept at the MASC `keeper_tool_board_runtime` dispatch layer **before** the call reaches the SDK's retry loop:

```diff
-  | "keeper_board_post_get" -> dispatch_board Board_post_get args
+  | "keeper_board_post_get" ->
+    (match string_arg "post_id" args with
+     | Some pid when String.trim pid <> "" ->
+       dispatch_board Board_post_get args
+     | _ ->
+       error_json ... "Call keeper_board_list or keeper_board_search first")
```

This prevents the retry budget burn and returns a clear recovery action to the model.

## Impact

- Eliminates the recurring `ToolRetryExhausted` crash noise for board_post_get
- Saves 2 wasted retry turns per occurrence
- Gives the model a deterministic corrective path instead of repeating `{}`

Refs: #11651