### PR TITLE
chore: remove masc_claim_next legacy alias (→ keeper_task_claim)

### DIFF
--- a/bin/gen_tool_descriptors.ml
+++ b/bin/gen_tool_descriptors.ml
@@ -136,7 +136,7 @@ let masc_plan_init_spec : tool_spec =
   ; description =
       "Initialize a planning context for a task, creating task_plan.md, notes.md, and \
        deliverable.md structure. Use when starting structured work on a claimed task \
-       that needs planning artifacts. After masc_claim_next or masc_add_task; follow up \
+       that needs planning artifacts. After keeper_task_claim; follow up \
        with masc_plan_update to write the plan."
   ; parameters =
       [ { p_name = "task_id"
@@ -197,7 +197,7 @@ let masc_plan_set_task_spec : tool_spec =
   ; description =
       "Set the current task for your session so you can omit task_id in subsequent \
        planning calls. Use when starting work on a task after claiming it. After \
-       masc_claim_next; auto-cleared on session end."
+       keeper_task_claim; auto-cleared on session end."
   ; parameters =
       [ { p_name = "task_id"
         ; p_type = T_string { enum = None; default = None }

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -78,7 +78,7 @@ let tools_for_affordance = function
     [ "keeper_board_post"; "keeper_board_comment"; "masc_broadcast" ]
   | Message_sweep -> [ "masc_messages"; "masc_keeper_msg" ]
   | Task_claim ->
-    [ "keeper_task_claim"; "masc_claim_next" ]
+    [ "keeper_task_claim" ]
   | Task_audit ->
     [ "keeper_tasks_audit"; "keeper_task_force_release"; "keeper_task_force_done";
       "keeper_tasks_list"; "masc_tasks" ]
@@ -116,7 +116,7 @@ let preferred_tool_names_for_turn_affordances turn_affordances =
        | Message_sweep ->
          [ "masc_keeper_msg"; "masc_broadcast" ]
        | Task_claim ->
-         [ "keeper_task_claim"; "masc_claim_next" ]
+         [ "keeper_task_claim" ]
        | Task_audit ->
          [ "keeper_tasks_audit"; "keeper_task_force_release";
            "keeper_task_force_done" ]
@@ -232,7 +232,7 @@ let tool_search_alias_entries =
   ; "masc_agent_fitness", "에이전트 평가 점수 피트니스"
   ; "masc_web_search", "웹 검색 인터넷 온라인 구글"
   ; "masc_web_fetch", "웹 페이지 가져오기 읽기 URL 페치"
-  ; "masc_claim_next", "다음태스크 가져오기 할당"
+
   ]
 
 let tool_search_aliases name =

--- a/lib/keeper/keeper_run_tools_task_scope.ml
+++ b/lib/keeper/keeper_run_tools_task_scope.ml
@@ -26,7 +26,7 @@ let current_task_id_of_meta (meta : Keeper_meta_contract.keeper_meta) =
 ;;
 
 let task_id_scope_of_claim_output ~tool_name output_text =
-  if not (List.mem tool_name [ "keeper_task_claim"; "masc_claim_next" ])
+  if not (List.mem tool_name [ "keeper_task_claim" ])
   then None
   else (
     let output_text =

--- a/lib/keeper/keeper_tool_capability_axis.ml
+++ b/lib/keeper/keeper_tool_capability_axis.ml
@@ -10,7 +10,7 @@ type t =
   | Board_activity
   | Shell_command_input
 
-let legacy_masc_claim_next_name = "masc_claim_next"
+
 let legacy_masc_broadcast_name = "masc_broadcast"
 let legacy_masc_keeper_msg_name = "masc_keeper_msg"
 
@@ -28,7 +28,7 @@ let candidate_names name =
 ;;
 
 let claim_task_tool_names =
-  [ Keeper_tool_name.(to_string Task_claim); legacy_masc_claim_next_name ]
+  [ Keeper_tool_name.(to_string Task_claim) ]
 ;;
 
 let board_activity_tool_names =

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -1124,8 +1124,6 @@ let internal_descriptors : t list =
       "Add a task to the workspace plan." ~readonly:false
   ; masc_task_descriptor "batch_add" "masc_batch_add_tasks"
       "Add multiple tasks in a single call." ~readonly:false
-  ; masc_task_descriptor "claim_next" "masc_claim_next"
-      "Claim the next available task." ~readonly:false
   ; masc_task_descriptor "task_history" "masc_task_history"
       "Read history events for a task." ~readonly:true
   ; masc_task_descriptor "tasks" "masc_tasks"

--- a/lib/keeper/keeper_tool_progress.ml
+++ b/lib/keeper/keeper_tool_progress.ml
@@ -53,7 +53,7 @@ let effect_of_progress_class = function
 ;;
 
 let claim_context_tool_names : string list =
-  [ Keeper_tool_name.legacy_masc_claim_next_name; Keeper_tool_name.(to_string Task_claim) ]
+  [ Keeper_tool_name.(to_string Task_claim) ]
 ;;
 
 let completion_tool_names : string list =

--- a/lib/keeper/keeper_tool_progress.mli
+++ b/lib/keeper/keeper_tool_progress.mli
@@ -45,7 +45,7 @@ val effect_of_progress_class : tool_progress_class -> turn_effect
 val classify_tool_progress_with_outcome
   : string -> Keeper_tool_outcome.t option -> turn_effect
 
-(** Canonical names of claim-context tools (Task_claim, Claim_next). *)
+(** Canonical names of claim-context tools (Task_claim). *)
 val claim_context_tool_names : string list
 
 (** Canonical names of completion tools (Task_done variants, Stay_silent,

--- a/lib/keeper/keeper_tools_oas_bundle.ml
+++ b/lib/keeper/keeper_tools_oas_bundle.ml
@@ -11,7 +11,7 @@ open Keeper_tools_oas
 
 let task_state_hint ~(config : Workspace.config) ~(meta : Keeper_meta_contract.keeper_meta) : string =
   match meta.current_task_id with
-  | None -> "No task currently assigned. Use masc_claim_next or masc_tasks to find one."
+  | None -> "No task currently assigned. Use keeper_task_claim or masc_tasks to find one."
   | Some tid ->
     let task_id = Keeper_id.Task_id.to_string tid in
     (match Workspace_backlog.read_backlog_r config with

--- a/lib/keeper_tooling/keeper_tool_name.ml
+++ b/lib/keeper_tooling/keeper_tool_name.ml
@@ -157,7 +157,6 @@ let of_string = function
 let pp fmt t = Format.pp_print_string fmt (to_string t)
 ;;
 
-let legacy_masc_claim_next_name = "masc_claim_next"
 let legacy_masc_broadcast_name = "masc_broadcast"
 let legacy_masc_deliver_name = "masc_deliver"
 

--- a/lib/keeper_tooling/keeper_tool_name.mli
+++ b/lib/keeper_tooling/keeper_tool_name.mli
@@ -59,8 +59,6 @@ val pp : Format.formatter -> t -> unit
 
 (** Public MCP-client names still accepted while runtime descriptors project
     keeper-owned tools onto the public MCP surface. *)
-val legacy_masc_claim_next_name : string
-
 val legacy_masc_broadcast_name : string
 
 val legacy_masc_deliver_name : string

--- a/lib/masc_error_recovery.ml
+++ b/lib/masc_error_recovery.ml
@@ -40,7 +40,7 @@ let recovery_hint (message : string) : string option =
   else if contains msg "task not found" || contains msg "not found" && contains msg "task" then
     Some "Call masc_status to see available tasks."
   else if contains msg "already claimed" then
-    Some "Call masc_status to see other available tasks, or use masc_claim_next."
+    Some "Call masc_status to see other available tasks, or use keeper_task_claim."
   else if contains msg "no unclaimed tasks" then
     Some "Call masc_add_task to create a new task."
   else if contains msg "rate limit" || contains msg "too many" then

--- a/lib/masc_error_recovery.mli
+++ b/lib/masc_error_recovery.mli
@@ -5,7 +5,7 @@
     Called by [mcp_server_eio_call_tool] on tool failure: the
     hint is appended to the error envelope so the agent can pick
     the suggested follow-up tool ([masc_init], [masc_status],
-    [masc_claim_next], …) without round-tripping through the
+    [keeper_task_claim], …) without round-tripping through the
     operator.
 
     Internal helper [contains] (byte-wise substring scan,
@@ -28,7 +28,7 @@ val recovery_hint : string -> string option
       [masc_start(path=…)]
     - "not session-bound" / "bind the session" → [masc_start]
     - "task not found" / ("not found" ∧ "task") → [masc_status]
-    - "already claimed" → [masc_status] / [masc_claim_next]
+    - "already claimed" → [masc_status] / [keeper_task_claim]
     - "no unclaimed tasks" → [masc_add_task]
     - "rate limit" / "too many" → wait + retry (transient)
     - "workspace" ∧ "set" → [masc_start(path=…)]

--- a/lib/mcp_server_eio_protocol.ml
+++ b/lib/mcp_server_eio_protocol.ml
@@ -110,7 +110,6 @@ let resource_id_of_uri uri =
 
 let affected_resource_ids_for_tool = function
   | "masc_add_task"
-  | "masc_claim_next"
   | "masc_transition"
   | "masc_update_priority"
   | "masc_plan_set_task"

--- a/lib/mcp_server_eio_tool_profile.ml
+++ b/lib/mcp_server_eio_tool_profile.ml
@@ -20,7 +20,7 @@ Do not assume access to any other MASC tool from this endpoint."
 
 let managed_agent_instructions =
   "MASC managed-agent profile exposes the internal agent control surface. \
-Prefer canonical task-control tools such as masc_status, masc_tasks, masc_claim_next, masc_transition, and masc_plan_set_task. \
+Prefer canonical task-control tools such as masc_status, masc_tasks, keeper_task_claim, masc_transition, and masc_plan_set_task. \
 Do not assume that the public /mcp surface and the managed-agent surface have the same inventory."
 
 let managed_agent_passthrough_tool_names =
@@ -221,7 +221,6 @@ let custom_tool_titles : (string * string) list = [
   ("masc_add_task", "Add Task");
   ("masc_batch_add_tasks", "Batch Add Tasks");
   ("masc_transition", "Transition Task State");
-  ("masc_claim_next", "Claim Next Task");
   ("masc_update_priority", "Update Task Priority");
   ("masc_task_history", "Task Event History");
   (* Communication *)
@@ -247,7 +246,6 @@ let custom_tool_titles : (string * string) list = [
   ("masc_operator_action", "Operator Action");
   ("masc_operator_confirm", "Operator Confirm");
   (* SDK projections *)
-  ("masc_claim_next", "Claim Next Task");
   (* Misc *)
   ("masc_cleanup_zombies", "Clean Up Zombie Agents");
 

--- a/lib/mcp_server_eio_tool_profile.mli
+++ b/lib/mcp_server_eio_tool_profile.mli
@@ -52,7 +52,7 @@ val default_instructions : string
 val managed_agent_instructions : string
 (** [Managed_agent] profile instructions.  Names the canonical
     task-control tools ([masc_status], [masc_tasks],
-    [masc_claim_next], [masc_transition], [masc_plan_set_task])
+    [keeper_task_claim], [masc_transition], [masc_plan_set_task])
     and warns that the public /mcp surface and managed-agent
     surface diverge in inventory. *)
 

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -100,7 +100,7 @@ You have access to MASC MCP tools via mcp__masc__* prefix.
 - mcp__masc__masc_status - Get project status
 - mcp__masc__masc_tasks - List all tasks
 - mcp__masc__masc_transition - Claim/start/done/cancel/release a task
-- mcp__masc__masc_claim_next - Auto-claim highest priority
+- mcp__masc__keeper_task_claim - Auto-claim highest priority
 - mcp__masc__masc_broadcast - Send message to all
 - mcp__masc__masc_heartbeat - Update your heartbeat
 

--- a/lib/response/response.ml
+++ b/lib/response/response.ml
@@ -302,7 +302,7 @@ let task_already_claimed ~task_id ~claimed_by : t =
     ])
     ~hints:[
       Printf.sprintf "Align with '%s' who owns this task" claimed_by;
-      "Use masc_claim_next to get the next available task";
+      "Use keeper_task_claim to get the next available task";
       "Or create a new task with masc_add_task";
     ]
     ()

--- a/lib/sdk_tool_contract.ml
+++ b/lib/sdk_tool_contract.ml
@@ -63,13 +63,6 @@ let sdk_bindings : sdk_tool_binding list =
       arg_bindings = [ ("tasks", Input_field "tasks") ];
     };
     {
-      sdk_name = "masc_claim_next";
-      canonical_operation = "masc_claim_next";
-      description = "Claim the next available task automatically by priority order. Use when you are ready to work and any pending task is acceptable.";
-      input_schema = object_schema [];
-      arg_bindings = [ ("agent_name", Agent_name) ];
-    };
-    {
       sdk_name = "masc_broadcast";
       canonical_operation = "masc_broadcast";
       description = "Broadcast a message to all active agents. Use when sharing status updates, workspace signals, or requesting help from any available agent.";

--- a/lib/task/tool_task.ml
+++ b/lib/task/tool_task.ml
@@ -639,7 +639,6 @@ let dispatch ctx ~name ~args : Tool_result.result option =
   match name with
   | "masc_add_task" -> Some (handle_add_task ~tool_name:name ~start_time:start ctx args)
   | "masc_batch_add_tasks" -> Some (handle_batch_add_tasks ~tool_name:name ~start_time:start ctx args)
-  | "masc_claim_next" -> Some (handle_claim_next ~tool_name:name ~start_time:start ctx args)
   | "masc_transition" -> Some (handle_transition ~tool_name:name ~start_time:start ctx args)
   | "masc_update_priority" -> Some (handle_update_priority ~tool_name:name ~start_time:start ctx args)
   | "masc_tasks" -> Some (handle_tasks ~tool_name:name ~start_time:start ctx args)

--- a/lib/task/tool_task.mli
+++ b/lib/task/tool_task.mli
@@ -42,7 +42,7 @@ val completion_rejection_message : ?allow_force:bool -> string -> string
 
 (** [build_claim_observation_payload ~now ~agent_name ~task_id] builds the
     downstream collaboration-observation fragment for a successful
-    [masc_claim_next] write/readback result. MASC uses a central workspace
+    [keeper_task_claim] write/readback result. MASC uses a central workspace
     store here, so CRDT-specific [logical_clock] and [convergence_delay_ms]
     are left null. *)
 val build_claim_observation_payload :

--- a/lib/task/tool_task_handlers.ml
+++ b/lib/task/tool_task_handlers.ml
@@ -393,7 +393,7 @@ let handle_claim ~tool_name ~start_time ctx args =
      dispatch path bypasses MCP entry session binding, so this gate produced
      false-negative rejects for every agent turn (fleet evidence:
      <base-path>/.masc/agents/ empty while agents run normally; only
-     masc_claim/masc_claim_next failed).  Workspace.claim_task_r works on
+     masc_claim/keeper_task_claim failed).  Workspace.claim_task_r works on
      agent_name alone; gate added no real authorization. *)
   if Option.is_some (Json_util.assoc_member_opt "agent_role" args) then
     Tool_result.error

--- a/lib/task/tool_task_schemas.ml
+++ b/lib/task/tool_task_schemas.ml
@@ -23,8 +23,6 @@ module Float = Stdlib.Float
 
 let masc_add_task_name =
   Tool_name.Task_name.to_string Tool_name.Task_name.Add_task
-let masc_claim_next_name =
-  Tool_name.Task_name.to_string Tool_name.Task_name.Claim_next
 
 let schemas : Masc_domain.tool_schema list = [
   {
@@ -181,20 +179,7 @@ Tip: Look for status='todo' tasks to claim.";
       ]);
     ];
   };
-  {
-    name = "masc_claim_next";
-    description = "Automatically claim the highest priority unclaimed task. Use this when you want to pick up the most important available work without manually checking the task board. Returns the claimed task details including priority level and a claim_observation fragment for the verified write/readback result.";
-    input_schema = `Assoc [
-      ("type", `String "object");
-      ("properties", `Assoc [
-        ("agent_name", `Assoc [
-          ("type", `String "string");
-          ("description", `String "Your agent name");
-        ]);
-      ]);
-      ("required", `List [`String "agent_name"]);
-    ];
-  };
+
   {
     name = "masc_update_priority";
     description = "Change the priority of a task. Priority 1 is highest (most urgent), 5 is lowest. Use this to reprioritize work based on new information or urgency changes.";
@@ -226,7 +211,7 @@ Use submit_for_verification only for explicit review of a claimed/in_progress ta
 Tasks created through %s complete via action='done' after LLM completion review; \
 they do not route normal completion through the verifier agent."
       masc_add_task_name
-      masc_claim_next_name
+      "keeper_task_claim"
       masc_add_task_name;
     input_schema = `Assoc [
       ("type", `String "object");

--- a/lib/task/tool_task_schemas.mli
+++ b/lib/task/tool_task_schemas.mli
@@ -7,7 +7,7 @@
     @since God file decomposition — extracted from [tool_task.ml] *)
 
 (** Static list of [Masc_domain.tool_schema] records, one per task operation
-    (masc_add_task, masc_claim_next, masc_transition,
+    (masc_add_task, keeper_task_claim, masc_transition,
     masc_task_state, …). Each entry carries [name], [description], and
     [input_schema] (JSON Schema object).
 

--- a/lib/tool/tool_catalog.ml
+++ b/lib/tool/tool_catalog.ml
@@ -209,7 +209,6 @@ let explicit_metadata : (string * metadata) list =
       actor_broadcast_tool );
     ("masc_tool_help", read_state_tool);
     ("masc_plan_get", broadcast_tool);
-    ("masc_claim_next", claim_task_tool);
     ("masc_transition", complete_task_tool);
     ("masc_plan_set_task", actor_broadcast_tool);
     ("masc_broadcast", broadcast_tool);

--- a/lib/tool/tool_name.ml
+++ b/lib/tool/tool_name.ml
@@ -34,7 +34,6 @@ module Task_name = struct
   type t =
     | Add_task
     | Batch_add_tasks
-    | Claim_next
     | Task_history
     | Tasks
     | Transition
@@ -43,7 +42,6 @@ module Task_name = struct
   let to_string = function
     | Add_task -> "masc_add_task"
     | Batch_add_tasks -> "masc_batch_add_tasks"
-    | Claim_next -> "masc_claim_next"
     | Task_history -> "masc_task_history"
     | Tasks -> "masc_tasks"
     | Transition -> "masc_transition"
@@ -53,7 +51,6 @@ module Task_name = struct
   let of_string = function
     | "masc_add_task" -> Some Add_task
     | "masc_batch_add_tasks" -> Some Batch_add_tasks
-    | "masc_claim_next" -> Some Claim_next
     | "masc_task_history" -> Some Task_history
     | "masc_tasks" -> Some Tasks
     | "masc_transition" -> Some Transition

--- a/lib/tool/tool_name.mli
+++ b/lib/tool/tool_name.mli
@@ -11,7 +11,6 @@ module Task_name : sig
   type t =
     | Add_task
     | Batch_add_tasks
-    | Claim_next
     | Task_history
     | Tasks
     | Transition

--- a/lib/tool_agent.ml
+++ b/lib/tool_agent.ml
@@ -379,7 +379,6 @@ let handle_agent_card ?(tool_name = "masc_agent_card") ?(start_time = 0.0) ctx a
                    "masc_status";
                    "masc_agents";
                    "masc_tasks";
-                   "masc_claim_next";
                    "masc_transition";
                    "masc_dashboard";
                    "masc_tool_help";

--- a/lib/tool_catalog_surfaces/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces/tool_catalog_surfaces.ml
@@ -56,7 +56,6 @@ let public_mcp_surface_tools =
     "masc_add_task"
   ; "masc_batch_add_tasks"
   ; "masc_tasks"
-  ; "masc_claim_next"
   ; "masc_transition"
   ; (* Planning *)
     "masc_goal_list"
@@ -98,7 +97,6 @@ let public_mcp_surface_tools =
 let spawned_agent_surface_tools =
   [ "masc_status"
   ; "masc_tasks"
-  ; "masc_claim_next"
   ; "masc_transition"
   ; "masc_task_history"
   ; "masc_broadcast"
@@ -139,7 +137,6 @@ let spawned_agent_surface_tools =
 let local_worker_surface_tools =
   [ "masc_status"
   ; "masc_tasks"
-  ; "masc_claim_next"
   ; "masc_transition"
   ; "masc_add_task"
   ; "masc_heartbeat"
@@ -177,7 +174,6 @@ let local_worker_surface_tools =
 let session_min_surface_tools =
   [ "masc_status"
   ; "masc_tasks"
-  ; "masc_claim_next"
   ; "masc_plan_set_task"
   ; "masc_transition"
   ; "masc_add_task"
@@ -248,14 +244,12 @@ let workspace_role_tools : string list =
   ; "masc_board_post_get"
   ; "masc_board_sub_board_list"
   ; "masc_board_sub_board_get"
-  ; "masc_claim_next"
   ; "masc_transition"
   ]
 ;;
 
 let execution_role_tools : string list =
   [ "masc_heartbeat"
-  ; "masc_claim_next"
   ; "masc_transition"
   ; "masc_broadcast"
   ; "masc_run_init"

--- a/lib/tool_surface/tool_prefilter.ml
+++ b/lib/tool_surface/tool_prefilter.ml
@@ -39,14 +39,6 @@ let synonyms : (string * string list) list =
     , [ "happening"; "activity"; "overview"; "summary"; "monitor"; "big picture" ] )
   ; ( "masc_broadcast"
     , [ "notify"; "announce"; "tell"; "inform"; "alert"; "everyone"; "let know" ] )
-  ; ( "masc_claim_next"
-    , [ "claim next task"
-      ; "pick up task"
-      ; "assign me"
-      ; "next task"
-      ; "give me work"
-      ; "take task"
-      ] )
   ; "masc_add_task", [ "create task"; "new task"; "make task"; "register task" ]
   ; "masc_messages", [ "chat"; "conversation"; "history"; "log"; "what was said" ]
   ; "masc_agents", [ "who is working"; "team members"; "workers"; "collaborators" ]

--- a/lib/tool_surface/tool_resource_axis.ml
+++ b/lib/tool_surface/tool_resource_axis.ml
@@ -199,7 +199,6 @@ let classify_catalog_tool ~tool_name =
   | "masc_board_vote" -> Some Board_write
   | "masc_add_task"
   | "masc_batch_add_tasks"
-  | "masc_claim_next"
   | "masc_deliver"
   | "masc_goal_transition"
   | "masc_goal_upsert"

--- a/lib/tool_workspace.ml
+++ b/lib/tool_workspace.ml
@@ -99,7 +99,7 @@ let effective_cluster_name (config : Workspace.config) =
 
 (* Handlers *)
 
-let lifecycle_tools = [ "masc_claim_next"; "masc_transition" ]
+let lifecycle_tools = [ "keeper_task_claim"; "masc_transition" ]
 let is_lifecycle_tool tool = List.exists (String.equal tool) lifecycle_tools
 
 let unique_strings items =
@@ -458,7 +458,7 @@ let status_summary_string (ctx : context) =
         if Stdlib.List.length binding.assigned_task_ids > 0
         then [ "masc_heartbeat"; "masc_transition" ]
         else if fresh_todo_count > 0
-        then [ "masc_claim_next"; "masc_status" ]
+        then [ "keeper_task_claim"; "masc_status" ]
         else [ "masc_status"; "masc_add_task" ]
       in
       let tools =
@@ -471,7 +471,7 @@ let status_summary_string (ctx : context) =
               List.filter (fun tool -> not (String.equal tool "masc_transition")) tools
             in
             let tools =
-              if fresh_todo_count > 0 then "masc_claim_next" :: tools else tools
+              if fresh_todo_count > 0 then "keeper_task_claim" :: tools else tools
             in
             unique_strings tools
           | Some _ | None -> tools)

--- a/lib/trajectory/trajectory.ml
+++ b/lib/trajectory/trajectory.ml
@@ -64,7 +64,7 @@ type trajectory = {
   outcome : trajectory_outcome;
   task_id : string option;
   (** Claimed task ID for cost attribution.
-      Set when keeper claims a task via masc_claim_next or masc_transition;
+      Set when keeper claims a task via keeper_task_claim or masc_transition;
       None if no task claimed.
       Enables per-task cost aggregation from trajectory summaries. *)
 }

--- a/lib/transport.ml
+++ b/lib/transport.ml
@@ -339,7 +339,6 @@ module Rest = struct
           "masc_add_task";
           "masc_batch_add_tasks";
           "masc_transition";
-          "masc_claim_next";
         ] );
       ( "planning",
         [

--- a/lib/types/masc_error.ml
+++ b/lib/types/masc_error.ml
@@ -66,7 +66,6 @@ let limit_for_category config = function
 let category_for_tool_opt = function
   | "masc_broadcast" -> Some BroadcastLimit
   | "masc_add_task"
-  | "masc_claim_next"
   | "masc_update_priority"
   | "masc_plan_set_task"
   | "masc_plan_clear_task"

--- a/lib/workspace/workspace_task_transitions.ml
+++ b/lib/workspace/workspace_task_transitions.ml
@@ -170,7 +170,7 @@ let transition_task_r
               | Masc_domain.Claimed _, Masc_domain.Release when not own_assignee ->
                 " Remediation: this task is claimed by another keeper. Use \
                  masc_board_post to ask that agent to release/hand off, or claim a \
-                 different task with masc_claim_next."
+                 different task with keeper_task_claim."
               | Masc_domain.Claimed _, Masc_domain.Done_action when not own_assignee ->
                 " Remediation: only the current assignee can mark a task done. Pick a \
                  different task or align via masc_board_post."
@@ -178,10 +178,10 @@ let transition_task_r
                 when not own_assignee ->
                 " Remediation: cancellation requires owning the task. Use \
                  masc_board_post to ask the current assignee to cancel or release, or \
-                 claim a different task with masc_claim_next."
+                 claim a different task with keeper_task_claim."
               | Masc_domain.InProgress _, Masc_domain.Claim ->
                 " Remediation: task is already in_progress under someone. Use \
-                 masc_claim_next for unclaimed work."
+                 keeper_task_claim for unclaimed work."
               | Masc_domain.InProgress _, Masc_domain.Start ->
                 " Remediation: task is already in_progress. Valid actions from \
                  in_progress: done, submit_for_verification, release, cancel."

--- a/lib/workspace_assertions.ml
+++ b/lib/workspace_assertions.ml
@@ -45,7 +45,7 @@ let assertion_kind_of_string_lenient = function
 ;;
 
 let assertion_fix_hint = function
-  | Task_claimed -> "Claim a task with masc_transition(action=claim) or masc_claim_next"
+  | Task_claimed -> "Claim a task with masc_transition(action=claim) or keeper_task_claim"
   | Current_task_set ->
     "Call masc_plan_set_task to choose or re-sync the active task when current_task is \
      unset, stale, or ambiguous"

--- a/test/test_auth_bearer_mismatch_9786.ml
+++ b/test/test_auth_bearer_mismatch_9786.ml
@@ -5,7 +5,7 @@ module Types = Masc_domain
    #9786: agent A presents a token that resolves to credential
    owner B.  The Auth layer rejects with an [Unauthorized] error
    but the failure was invisible to Otel_metric_store — dashboards could
-   only see downstream runtimes (masc_claim_next failures, keeper
+   only see downstream runtimes (keeper_task_claim failures, keeper
    degraded proactive state) with no upstream cause.
 
    This test pins the new

--- a/test/test_bind_required_guard_counter.ml
+++ b/test/test_bind_required_guard_counter.ml
@@ -26,7 +26,7 @@ let test_metric_name_stable () =
     Masc.Otel_metric_store.metric_tool_bind_required_guard
 
 let test_increments_workspace_uninitialized () =
-  let tool = "masc_claim_next" in
+  let tool = "keeper_task_claim" in
   let agent_name = "san-test-9770" in
   let reason = "workspace_uninitialized" in
   let before = counter_for ~tool ~agent_name ~reason in
@@ -42,7 +42,7 @@ let test_increments_workspace_uninitialized () =
     (counter_for ~tool ~agent_name ~reason)
 
 let test_increments_agent_not_bound () =
-  let tool = "masc_claim_next" in
+  let tool = "keeper_task_claim" in
   let agent_name = "nic-test-9770" in
   let reason = "agent_not_bound" in
   let before = counter_for ~tool ~agent_name ~reason in
@@ -78,7 +78,7 @@ let test_label_isolation_across_reasons () =
     (counter_for ~tool ~agent_name ~reason:"workspace_uninitialized")
 
 let test_label_isolation_across_agents () =
-  let tool = "masc_claim_next" in
+  let tool = "keeper_task_claim" in
   let reason = "agent_not_bound" in
   let agent_a = "alpha-9770" in
   let agent_b = "beta-9770" in

--- a/test/test_governance_pipeline.ml
+++ b/test/test_governance_pipeline.ml
@@ -5,7 +5,7 @@ module Workspace = Masc.Workspace
 module Tool_dispatch = Tool_dispatch
 module Tool_result = Tool_result
 
-let explicit_claim_tool = "masc_claim_next"
+let explicit_claim_tool = "keeper_task_claim"
 let generic_transition_tool = "masc_transition"
 let transition_claim_input = `Assoc [("action", `String "claim")]
 let transition_start_input = `Assoc [("action", `String "start")]

--- a/test/test_keeper_tool_capability_axis.ml
+++ b/test/test_keeper_tool_capability_axis.ml
@@ -8,8 +8,6 @@ let check_support capability name expected =
 
 let test_claim_task_supports_keeper_and_public_projection () =
   check_support Axis.Claim_task "keeper_task_claim" true;
-  check_support Axis.Claim_task "masc_claim_next" true;
-  check_support Axis.Claim_task "mcp__masc__masc_claim_next" true;
   check_support Axis.Claim_task "keeper_tasks_list" false
 ;;
 

--- a/test/test_keeper_tool_resolution.ml
+++ b/test/test_keeper_tool_resolution.ml
@@ -188,7 +188,7 @@ let policy_tool_names =
       "masc_agents";
       "masc_batch_add_tasks";
       "masc_broadcast";
-      "masc_claim_next";
+
       "masc_dashboard";
       "masc_goal_list";
       "masc_goal_transition";

--- a/test/test_keeper_typed_labels.ml
+++ b/test/test_keeper_typed_labels.ml
@@ -227,20 +227,13 @@ let test_contract_status_labels_unique () =
 let test_pp_contract_status_surfaces_missing_list () =
   let s =
     format_to_string Keeper_contract_classifier.pp_contract_status
-      (Surface_mismatch { missing = [ "keeper_task_claim"; "masc_claim_next" ] })
+      (Surface_mismatch { missing = [ "keeper_task_claim" ] })
   in
   Alcotest.(check bool)
     "pp_contract_status surfaces first missing tool"
     true
     (try
        ignore (Str.search_forward (Str.regexp_string "keeper_task_claim") s 0);
-       true
-     with Not_found -> false);
-  Alcotest.(check bool)
-    "pp_contract_status surfaces second missing tool"
-    true
-    (try
-       ignore (Str.search_forward (Str.regexp_string "masc_claim_next") s 0);
        true
      with Not_found -> false)
 

--- a/test/test_keeper_unified_claim_progress.ml
+++ b/test/test_keeper_unified_claim_progress.ml
@@ -10,11 +10,7 @@ let test_claim_tool_classification_covers_supported_claim_tools () =
     "keeper claim is claim tool"
     true
     (KTP.is_claim_tool_name "keeper_task_claim");
-  check
-    bool
-    "masc claim next is claim tool"
-    true
-    (KTP.is_claim_tool_name "masc_claim_next");
+
   check
     bool
     "removed claim task alias is not claim tool"

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -1608,10 +1608,10 @@ let test_execute_tool_explicit_generated_alias_claim_next_not_rewritten_by_token
        ~priority:2 ~description:"");
   let result =
     Mcp_eio.execute_tool_eio ~sw ~clock ~auth_token:raw_token state
-      ~name:"masc_claim_next"
+      ~name:"keeper_task_claim"
       ~arguments:(`Assoc [ ("agent_name", `String "dashboard-eager-manta") ])
   in
-  check_auth_preflight_result ~tool_name:"masc_claim_next"
+  check_auth_preflight_result ~tool_name:"keeper_task_claim"
     (Tool_result.is_success result) ((Tool_result.message result));
   check_task_still_todo state.workspace_config "task-001";
   cleanup_dir base_path
@@ -1676,7 +1676,7 @@ let test_execute_tool_hyphenated_generated_alias_claim_next_reuses_base_token ()
   let result =
     Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:"sid-hyphenated-generated-alias"
       ~auth_token:raw_token state
-      ~name:"masc_claim_next"
+      ~name:"keeper_task_claim"
       ~arguments:(`Assoc [ ("agent_name", `String "qa-king-warm-heron") ])
   in
   if not (Tool_result.is_success result) then
@@ -1709,10 +1709,10 @@ let test_execute_tool_claim_next_requires_auth_before_mutation () =
        ~priority:2 ~description:"");
   let result =
     Mcp_eio.execute_tool_eio ~sw ~clock state
-      ~name:"masc_claim_next"
+      ~name:"keeper_task_claim"
       ~arguments:(`Assoc [ ("agent_name", `String "uncredentialed-agent") ])
   in
-  check_auth_preflight_result ~tool_name:"masc_claim_next"
+  check_auth_preflight_result ~tool_name:"keeper_task_claim"
     (Tool_result.is_success result) ((Tool_result.message result));
   check_task_still_todo state.workspace_config "task-001";
   Alcotest.(check (option string)) "no current task after rejected claim_next" None

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -60,7 +60,7 @@ let strict_success_names =
     "masc_board_vote";
     "masc_broadcast";
     "masc_check";
-    "masc_claim_next";
+
     "masc_dashboard";
     "masc_heartbeat";
     "masc_keeper_down";
@@ -509,7 +509,7 @@ let ensure_code_file fixture =
       relative_path
 
 let prepare_for_name fixture name =
-  if List.mem name [ "masc_claim_next"; "masc_transition"; "masc_plan_set_task" ] then
+  if List.mem name [ "keeper_task_claim"; "masc_transition"; "masc_plan_set_task" ] then
     ignore (ensure_task fixture);
   if List.mem name [ "masc_plan_get"; "masc_plan_update"; "masc_plan_get_task"; "masc_plan_clear_task" ] then
     ensure_plan_initialized fixture;

--- a/test/test_telemetry_unified.ml
+++ b/test/test_telemetry_unified.ml
@@ -206,7 +206,7 @@ let test_keeper_tool_called_scope_promoted_for_filters () =
                 `String "Tool_called";
                 `Assoc
                   [
-                    ("tool_name", `String "masc_claim_next");
+                    ("tool_name", `String "keeper_task_claim");
                     ("success", `Bool true);
                     ("duration_ms", `Int 42);
                     ("agent_id", `String "agent_code-mcp-client");
@@ -228,7 +228,7 @@ let test_keeper_tool_called_scope_promoted_for_filters () =
   match List.hd result.entries with
   | `Assoc fields ->
     let json = `Assoc fields in
-    Alcotest.(check string) "tool promoted" "masc_claim_next"
+    Alcotest.(check string) "tool promoted" "keeper_task_claim"
       (json_string_field "tool_name" json);
     Alcotest.(check string) "session promoted" "mcp-session-1"
       (json_string_field "session_id" json);

--- a/test/test_tool_dispatch.ml
+++ b/test/test_tool_dispatch.ml
@@ -203,7 +203,7 @@ let () =
       ( "did_you_mean_9784",
         [
           test_case "find_similar_names returns close match" `Quick (fun () ->
-              register_full ~tool_name:"__sim_masc_claim_next" ~handler:echo_handler ();
+              register_full ~tool_name:"__sim_keeper_task_claim" ~handler:echo_handler ();
               register_full ~tool_name:"__sim_masc_add_task" ~handler:echo_handler ();
               register_full ~tool_name:"__sim_masc_bind" ~handler:echo_handler ();
               let suggestions =
@@ -213,7 +213,7 @@ let () =
               check bool "non-empty suggestions" true
                 (List.length suggestions >= 1);
               check bool "top suggestion is closest" true
-                (List.hd suggestions = "__sim_masc_claim_next"));
+                (List.hd suggestions = "__sim_keeper_task_claim"));
           test_case "find_similar_names empty when nothing close" `Quick (fun () ->
               let suggestions =
                 Tool_dispatch.find_similar_names

--- a/test/test_tool_prefilter.ml
+++ b/test/test_tool_prefilter.ml
@@ -41,8 +41,7 @@ let essential_tools = [
     "List tasks in backlog with their status and assignee.";
   make_schema "masc_add_task"
     "Add a new task to the backlog for agents to claim.";
-  make_schema "masc_claim_next"
-    "Claim the highest priority unclaimed task.";
+
   make_schema "masc_plan_init"
     "Initialize a planning context for a task.";
   make_schema "masc_plan_get"
@@ -132,11 +131,6 @@ let test_synonym_dashboard () =
   check bool "synonym: dashboard via 'activity overview'" true
     (has_tool "masc_dashboard" result)
 
-let test_synonym_claim_next () =
-  let result = Tool_prefilter.filter
-    ~tools:essential_tools ~query:"give me work to do" ~k:3 in
-  check bool "synonym: claim_next via 'give me work'" true
-    (has_tool "masc_claim_next" result)
 
 (* ================================================================ *)
 (* Tests: new tool family synonym retrieval                         *)
@@ -257,7 +251,6 @@ let () =
         [
           test_case "broadcast via synonym" `Quick test_synonym_broadcast;
           test_case "dashboard via synonym" `Quick test_synonym_dashboard;
-          test_case "claim_next via synonym" `Quick test_synonym_claim_next;
           test_case "code_search via synonym" `Quick test_synonym_code_search;
           test_case "code_read via synonym" `Quick test_synonym_code_read;
           test_case "worktree preparation via synonym" `Quick test_synonym_worktree_prepare;

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -343,7 +343,7 @@ let () = test "dispatch_transition_claim" (fun () ->
 let () = test "dispatch_claim_next" (fun () ->
   let ctx = make_test_ctx () in
   let args = `Assoc [] in
-  match Task.Tool.dispatch ctx ~name:"masc_claim_next" ~args with
+  match Task.Tool.dispatch ctx ~name:"keeper_task_claim" ~args with
   | Some _ -> ()
   | None -> failwith "dispatch returned None"
 )

--- a/test/test_tool_workspace_coverage.ml
+++ b/test/test_tool_workspace_coverage.ml
@@ -636,7 +636,7 @@ let () =
       assert (
         str_contains result "Lifecycle actions are credential-blocked for test-agent");
       assert (not (str_contains result "Suggested next: masc_status -> masc_transition"));
-      assert (not (str_contains result "Suggested next: masc_claim_next"))
+      assert (not (str_contains result "Suggested next: keeper_task_claim"))
     | None -> failwith "dispatch returned None")
 ;;
 
@@ -688,7 +688,7 @@ let () =
       assert (str_contains result "owned=- | current=task-001");
       assert (str_contains result "drift_reason=no_owned");
       assert (str_contains result "claim_first_suppressed=no");
-      assert_contains result "Suggested next: masc_claim_next -> masc_status";
+      assert_contains result "Suggested next: keeper_task_claim -> masc_status";
       assert_not_contains result "Suggested next: masc_status -> masc_transition"
     | None -> failwith "dispatch returned None")
 ;;


### PR DESCRIPTION
## Summary

`masc_claim_next` was a legacy string alias that dispatched to the same `handle_claim_next` handler as `keeper_task_claim`. The codebase explicitly tagged it as `legacy_masc_claim_next_name` in keeper_tooling SSOT.

This PR removes **all** references to `masc_claim_next` across 50 files, leaving `keeper_task_claim` as the single canonical name.

## What changed

| Area | Files |
|---|---|
| Enum | `tool_name.ml/mli`: removed `Claim_next` variant from `Task_name` |
| SSOT | `keeper_tool_name.ml/mli`: removed `legacy_masc_claim_next_name` |
| Keeper internals | `capability_axis`, `progress`, `descriptor`, `run_tools_task_scope`, `agent_tool_surface`, `tools_oas_bundle` |
| Dispatch | `tool_task.ml`: removed dispatch arm |
| Schema | `tool_task_schemas.ml`: removed binding + name |
| SDK | `sdk_tool_contract.ml`: removed binding |
| MCP surface | `mcp_server_eio_protocol`, `mcp_server_eio_tool_profile`, `tool_prefilter`, `tool_resource_axis`, `tool_catalog_surfaces` |
| Runtime | `transport`, `tool_workspace`, `tool_agent`, `tool_catalog`, `orchestrator`, `response`, `masc_error_recovery`, `workspace_assertions`, `workspace_task_transitions` |
| Tests | 15 test files — assertions updated to `keeper_task_claim` |

## Before / After

```
before: keeper_task_claim, masc_claim_next  → same handler
after:  keeper_task_claim only
```

## Not changed

- `masc_broadcast` — live MCP surface tool (not legacy)
- `masc_deliver` — canonical plan completion tool (not legacy)