### PR TITLE
fix(ide): sort file tree alphabetically dirs-first, widen right rail

### DIFF
--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -580,7 +580,7 @@
 
 .ide-plane-grid {
   display: grid;
-  grid-template-columns: minmax(200px, 248px) minmax(420px, 1fr) minmax(320px, 380px);
+  grid-template-columns: minmax(200px, 248px) minmax(420px, 1fr) minmax(320px, 420px);
   grid-template-rows: minmax(0, 1fr) minmax(180px, 32%);
   height: 100%;
   min-height: 0;

--- a/lib/server/server_routes_http_routes_workspace.ml
+++ b/lib/server/server_routes_http_routes_workspace.ml
@@ -293,12 +293,30 @@ let file_tree_node ~diff_by_path ~path ~label ~depth ~parent ~has_children =
 let rec scan_dir_bounded ?diff_by_path ~base ~depth ~max_depth ~remaining acc dir =
   if depth > max_depth || remaining <= 0 then (acc, remaining)
   else
-    let entries =
+    let raw_entries =
       workspace_or_default
         ~site:"tree_readdir"
         ~path:dir
         ~default:[]
         (fun () -> Sys.readdir dir |> Array.to_list)
+    in
+    (* Sort alphabetically, then partition directories-first so that
+       the node limit (default 750) is consumed by directory trees
+       (lib/, src/) before leaf files (*.py, *.md).  Without this,
+       a flat directory like ~/me with hundreds of root-level files
+       exhausts the limit before important subdirectories appear. *)
+    let entries =
+      let sorted = List.sort String.compare raw_entries in
+      let dirs, files = List.partition (fun name ->
+        let full = Filename.concat dir name in
+        workspace_or_default
+          ~warn_on_failure:false
+          ~site:"tree_is_directory_partition"
+          ~path:full
+          ~default:false
+          (fun () -> Sys.is_directory full)
+      ) sorted in
+      dirs @ files
     in
     let rec fold acc remaining = function
       | [] -> (acc, remaining)


### PR DESCRIPTION
## Problem

IDE 파일 트리에 3가지 문제가 있었습니다:

1. **lib 등 핵심 디렉토리 누락**: `Sys.readdir`이 파일시스템 순서(HFS+ hash)로 반환 → 루트에 파일 100+개가 먼저 750 노드 한도를 소진 → `lib/`, `workspace/` 같은 디렉토리가 아예 등장하지 않음
2. **정렬 안 됨**: 서버/클라이언트 모두 정렬하지 않아 무작위 순서로 표시
3. **우측 위젯 바 너무 좁음**: `minmax(320px, 380px)` 상한으로 공간 부족

## Changes

- **`lib/server/server_routes_http_routes_workspace.ml`**: `scan_dir_bounded`에서 `Sys.readdir` 결과를 알파벳순 정렬 후 디렉토리를 파일보다 먼저 배치 (dirs-first). 750 노드 한도가 leaf file이 아닌 디렉토리 트리에 먼저 소비되도록 보장.
- **`dashboard/src/styles/dashboard.css`**: 우측 레일 상한을 380px → 420px로 확장.

## Before

```
Root entries (5, unsorted):
  analyze_sentry.py, instructions, .gitignore.bak, shards, .gemini
  (lib, workspace, agents 등 100+ 디렉토리가 750 한도 초과로 누락)
```

## After (expected)

```
Root entries (sorted, dirs-first):
  agents/, assets/, common/, dashboard/, docs/, features/...,
  analyze_sentry.py, CLAUDE.md, ...
```

## Note

`runtime_unknown` 연결 상태는 별도 이슈 — SSE/WebSocket 연결이 REST API와 독립적으로 관리됨.
