### PR TITLE
purge(config): reduce lock timeout 1800s→120s, remove dead coding_timeout, clean stale TODOs

### DIFF
--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -17,9 +17,11 @@ end
 (** {1 Lock Configuration} *)
 
 module Lock = struct
-  (** Default lock timeout (seconds) *)
+  (** Default lock timeout (seconds).
+      Reduced from 1800s (30 min) to 120s (2 min) — file locks should
+      fail fast; a 30-minute wait masks contention bugs. *)
   let timeout_seconds =
-    get_float ~default:1800.0 "MASC_LOCK_TIMEOUT_SEC"
+    get_float ~default:120.0 "MASC_LOCK_TIMEOUT_SEC"
 
   (** Lock expiry warning threshold (seconds before expiry) *)
   let expiry_warning_seconds =
@@ -130,10 +132,6 @@ module Spawn = struct
       Higher value (600s) allows for slow network/API conditions while preventing indefinite hangs. *)
   let timeout_seconds =
     int_of_float (get_float ~default:600.0 "MASC_SPAWN_TIMEOUT_SEC")
-
-  (** Extended timeout for coding mode (seconds). Default 2 hours. *)
-  let coding_timeout_seconds =
-    int_of_float (get_float ~default:7200.0 "MASC_SPAWN_CODING_TIMEOUT_SEC")
 
   (** Grace period before timeout — sends SIGTERM for checkpoint opportunity (seconds). *)
   let grace_period_seconds =

--- a/lib/config/env_config_runtime.mli
+++ b/lib/config/env_config_runtime.mli
@@ -85,7 +85,6 @@ end
 
 module Spawn : sig
   val timeout_seconds : int
-  val coding_timeout_seconds : int
   val grace_period_seconds : int
 end
 

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -571,8 +571,8 @@ let lock_entries =
   [
     entry ~default:"300.0" "MASC_LOCK_EXPIRY_WARNING_SEC"
       "Lock expiry warning threshold (seconds before expiry)";
-    entry ~default:"1800.0" "MASC_LOCK_TIMEOUT_SEC"
-      "Default lock timeout (seconds, 30 min)";
+    entry ~default:"120.0" "MASC_LOCK_TIMEOUT_SEC"
+      "Default lock timeout (seconds, 2 min)";
   ]
 
 let memory_entries = []
@@ -705,8 +705,6 @@ let smart_heartbeat_entries =
 
 let spawn_entries =
   [
-    entry ~default:"7200.0" "MASC_SPAWN_CODING_TIMEOUT_SEC"
-      "Extended timeout for coding mode (seconds, 2 hours)";
     entry ~default:"60.0" "MASC_SPAWN_GRACE_PERIOD_SEC"
       "Grace period before timeout for SIGTERM checkpoint (seconds)";
     entry ~default:"600.0" "MASC_SPAWN_TIMEOUT_SEC"

--- a/lib/keeper/keeper_alerting.ml
+++ b/lib/keeper/keeper_alerting.ml
@@ -162,9 +162,7 @@ let is_alert_deduplicated ~(keeper_name : string) ~(reasons : string list) : boo
     The score is the sum of matched weights, capped at 1.0.
 
     Signal bonuses are additive modifiers for structural indicators
-    (guardrail stops, context pressure, alignment drops, tool usage).
-
-    TODO(RFC-0001 Phase 3): Register in Runtime_params for runtime tuning. *)
+    (guardrail stops, context pressure, alignment drops, tool usage). *)
 
 let alert_keyword_weights : (string * float) list = [
   ("장애",     0.35);  (* Korean: outage/failure *)

--- a/lib/reputation.ml
+++ b/lib/reputation.ml
@@ -236,9 +236,7 @@ let clamp01 value = Float.max 0.0 (Float.min 1.0 value)
     Beta distribution feedback (votes, quality signals).
 
     Board activity is capped at [board_activity_cap] to prevent
-    high-volume low-quality posting from inflating scores.
-
-    TODO(RFC-0001 Phase 3): Register in Runtime_params for tuning. *)
+    high-volume low-quality posting from inflating scores. *)
 let weight_completion = 0.35
 let weight_response   = 0.25
 let weight_board      = 0.25

--- a/lib/thompson/thompson_sampling.ml
+++ b/lib/thompson/thompson_sampling.ml
@@ -425,8 +425,7 @@ let record_action ~agent_name ~action =
       post-verifier false positives exist.
 
     These should be calibrated against actual agent performance data once
-    Phase 0 instrumentation (RFC-0001) collects baseline metrics.
-    TODO(RFC-0001): Register in Runtime_params for runtime tuning. *)
+    Phase 0 instrumentation (RFC-0001) collects baseline metrics. *)
 let quality_pass_alpha_boost = 0.3
 let quality_warn_beta_nudge  = 0.1
 let quality_fail_beta_penalty = 0.5


### PR DESCRIPTION
## Codebase Purge — Immediate Actions

### 1. Lock timeout: 1800s → 120s
`MASC_LOCK_TIMEOUT_SEC` default reduced from **30 minutes** to **2 minutes**.

File locks should fail fast. A 30-minute wait masks contention bugs and causes cascading stalls. If a lock can't be acquired in 2 minutes, something is fundamentally wrong and should be surfaced as an error, not silently waited on.

### 2. Dead code removal: `Spawn.coding_timeout_seconds`
`MASC_SPAWN_CODING_TIMEOUT_SEC` (7200s / 2 hour default) was:
- ✅ Defined in `env_config_runtime.ml`
- ✅ Declared in `env_config_runtime.mli`
- ✅ Snapshotted in `env_config_snapshot.ml`
- ❌ **Never referenced anywhere else in the codebase**

Removed from all three files.

### 3. Stale TODO cleanup
Removed 3 RFC-0001 Phase 3 TODOs that called for Runtime_params registration:
- `keeper_alerting.ml`: alert keyword weights
- `reputation.ml`: reputation component weights
- `thompson_sampling.ml`: quality boost/penalty values

These are stable design constants. One (`guard_penalty_beta`) is already env-configurable. The others don't benefit from runtime tuning — they're architecture, not config.

## Files changed (6)

| File | Change |
|------|--------|
| `lib/config/env_config_runtime.ml` | Lock timeout 1800→120, removed `coding_timeout_seconds` |
| `lib/config/env_config_runtime.mli` | Removed `coding_timeout_seconds` from Spawn sig |
| `lib/config/env_config_snapshot.ml` | Lock default 1800→120, removed spawn coding entry |
| `lib/keeper/keeper_alerting.ml` | Removed stale TODO |
| `lib/reputation.ml` | Removed stale TODO |
| `lib/thompson/thompson_sampling.ml` | Removed stale TODO |

## Verification
`dune build lib/config lib/keeper lib/thompson` passes.