### PR TITLE
fix(test): remove stale State_report test after #20573

### DIFF
--- a/test/test_keeper_tool_name.ml
+++ b/test/test_keeper_tool_name.ml
@@ -33,24 +33,6 @@ let test_non_write_board_surface_names () =
     ]
 ;;
 
-let test_state_report_name_round_trips () =
-  check
-    (option (testable Keeper_tool_name.pp ( = )))
-    "of_string"
-    (Some Keeper_tool_name.State_report)
-    (Keeper_tool_name.of_string "keeper_report_state");
-  check
-    string
-    "to_string"
-    "keeper_report_state"
-    (Keeper_tool_name.to_string Keeper_tool_name.State_report);
-  check
-    bool
-    "not board write"
-    false
-    (Keeper_tool_name.is_board_write_surface_name "keeper_report_state")
-;;
-
 let () =
   run
     "Keeper_tool_name"
@@ -60,10 +42,6 @@ let () =
             "rejects non-write and unknown surfaces"
             `Quick
             test_non_write_board_surface_names
-        ; test_case
-            "state report name round-trips"
-            `Quick
-            test_state_report_name_round_trips
         ] )
     ]
 ;;


### PR DESCRIPTION
## Problem
`test_keeper_tool_name.ml` references `Keeper_tool_name.State_report` which was removed in #20573 (remove broken keeper_report_state tool), causing a build error.

## Fix
Remove `test_state_report_name_round_trips` function and its `test_case` registration.

The workspace file comment error (`server_routes_http_routes_workspace.ml:303`) was a stale `_build` artifact — resolved by rebuilding.