### PR TITLE
feat(grafana): add Jaeger traces panel to masc-overview dashboard

### DIFF
--- a/infrastructure/monitoring/grafana/provisioning/dashboards/masc-overview.json
+++ b/infrastructure/monitoring/grafana/provisioning/dashboards/masc-overview.json
@@ -690,6 +690,43 @@
           "showLegend": true
         }
       }
+    },
+    {
+      "type": "traces",
+      "title": "Recent Traces",
+      "gridPos": {
+        "x": 0,
+        "y": 96,
+        "w": 24,
+        "h": 16
+      },
+      "datasource": {
+        "type": "jaeger",
+        "uid": "PC9A941E8F2E49454"
+      },
+      "description": "Recent distributed traces from the masc service.",
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "jaeger",
+            "uid": "PC9A941E8F2E49454"
+          },
+          "queryType": "search",
+          "service": "masc",
+          "operation": "",
+          "tags": "",
+          "minDuration": "",
+          "maxDuration": "",
+          "limit": 20
+        }
+      ],
+      "options": {
+        "sort": {
+          "sortBy": "startTime",
+          "sortOrder": "desc"
+        }
+      }
     }
   ],
   "refresh": "30s",


### PR DESCRIPTION
## What
Add a 'Recent Traces' panel to the bottom of the masc-overview Grafana dashboard so operators can see distributed traces without leaving Grafana.

## Changes
- New `traces` panel using the Jaeger datasource (service=masc, limit=20).
- Placed at y=96, full width (w=24, h=16).

## Why
Previously metrics were in Grafana but traces required switching to the Jaeger UI (port 16686). Now everything is in one place.

## Verification
- Grafana API confirms the panel is present after restart.
- Jaeger has live traces for service=masc.