### PR TITLE
fix: break nested OCaml comment in server_routes_http_routes_workspace

### DIFF
--- a/lib/server/server_routes_http_routes_workspace.ml
+++ b/lib/server/server_routes_http_routes_workspace.ml
@@ -302,7 +302,7 @@ let rec scan_dir_bounded ?diff_by_path ~base ~depth ~max_depth ~remaining acc di
     in
     (* Sort alphabetically, then partition directories-first so that
        the node limit (default 750) is consumed by directory trees
-       (lib/, src/) before leaf files (*.py, *.md).  Without this,
+       (lib/, src/) before leaf files ( *.py, *.md).  Without this,
        a flat directory like ~/me with hundreds of root-level files
        exhausts the limit before important subdirectories appear. *)
     let entries =


### PR DESCRIPTION
## Root cause

OCaml comments are **nestable**. In the comment added by #20575:

```ocaml
(* Sort alphabetically, then partition directories-first so that
   the node limit (default 750) is consumed by directory trees
   (lib/, src/) before leaf files (*.py, *.md).  Without this,
```

The sequence `(*.py` contains `(*` which OCaml treats as opening a **nested comment**. The closing `*)` at the end of the comment block then closes the *nested* comment — leaving the outer comment unclosed → `Error: Comment not terminated`.

## Fix

Add a space after `(` so the `(*` sequence is broken:
```diff
- (lib/, src/) before leaf files (*.py, *.md).
+ (lib/, src/) before leaf files ( *.py, *.md).
```