### PR TITLE
feat(telemetry): force new trace root per tool dispatch

### DIFF
--- a/lib/keeper/keeper_tool_registered_runtime.ml
+++ b/lib/keeper/keeper_tool_registered_runtime.ml
@@ -94,7 +94,7 @@ let handle_masc_tool
                  propagation now 3/3 = 100% per RFC-0084 §2.1 North Star. *)
                let tag_dispatch_with_telemetry () =
                  let result, _outcome =
-                   Tool_telemetry.with_span ~tool_name:name (fun _trace_id_thunk ->
+                   Tool_telemetry.with_span ~force_new_trace_id:true ~tool_name:name (fun _trace_id_thunk ->
                      let r =
                        !Keeper_tool_shared_runtime.tag_dispatch_fn
                          ~config

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -496,7 +496,7 @@ let execute_tool_eio
                the keeper turn migration in PR-7. *)
             let dispatch_internal_with_telemetry () =
               let result, _outcome =
-                Tool_telemetry.with_span ~tool_name:name (fun _trace_id_thunk ->
+                Tool_telemetry.with_span ~force_new_trace_id:true ~tool_name:name (fun _trace_id_thunk ->
                   let r = dispatch_internal_keeper_runtime_tool () in
                   (* Route through the shared dispatch finalizer so MCP
                      internal-keeper-runtime calls run the same result
@@ -533,7 +533,7 @@ let execute_tool_eio
                     Tool_telemetry.with_span for 4-tuple emission. *)
                  let dispatch_tag_with_telemetry tag =
                    let result, _outcome =
-                     Tool_telemetry.with_span ~tool_name:name (fun _trace_id_thunk ->
+                     Tool_telemetry.with_span ~force_new_trace_id:true ~tool_name:name (fun _trace_id_thunk ->
                        let r = dispatch_by_tag tag in
                        (* Keep external MCP tools/call on the same
                           post-dispatch contract as internal keeper calls. *)

--- a/lib/otel_spans/otel_spans.ml
+++ b/lib/otel_spans/otel_spans.ml
@@ -194,11 +194,14 @@ let shutdown ?(enabled = Otel_config.enabled) () =
   Atomic.set _consecutive_failures 0
 
 (** Wrap a function in an OTel span. No-op when disabled.
-    Returns the result of [f]. *)
-let with_span ~name ?(attrs = []) f =
+    Returns the result of [f].
+    When [force_new_trace_id] is true, starts a fresh trace root instead
+    of nesting under the ambient parent span. Use at operation boundaries
+    (e.g. each tool dispatch) to keep traces small and readable. *)
+let with_span ~name ?(attrs = []) ?(force_new_trace_id = false) f =
   if not Otel_config.enabled then f (fun () -> None)
   else
-    OT.Trace.with_ name ~attrs (fun scope ->
+    OT.Trace.with_ ~force_new_trace_id name ~attrs (fun scope ->
       f (fun () ->
         let ctx = OT.Scope.to_span_ctx scope in
         Some (OT.Trace_id.to_hex (OT.Span_ctx.trace_id ctx))))

--- a/lib/otel_spans/otel_spans.mli
+++ b/lib/otel_spans/otel_spans.mli
@@ -44,10 +44,14 @@ val shutdown : ?enabled:bool -> unit -> unit
 (** [with_span ~name ~attrs f] wraps [f] in an OTel span.
     When disabled, calls [f] with a no-op trace-id extractor.
     [f] receives a thunk that returns [Some trace_id_hex] inside a span,
-    [None] otherwise. *)
+    [None] otherwise.
+
+    [force_new_trace_id] starts a fresh trace root instead of nesting under
+    the ambient parent. Use at operation boundaries to keep traces small. *)
 val with_span :
   name:string ->
   ?attrs:Opentelemetry.key_value list ->
+  ?force_new_trace_id:bool ->
   ((unit -> string option) -> 'a) ->
   'a
 

--- a/lib/tool/tool_dispatch.ml
+++ b/lib/tool/tool_dispatch.ml
@@ -137,12 +137,13 @@ let apply_result_transformer (r : Tool_result.result) : Tool_result.result =
 type trace_id = string
 
 type span_wrapper =
-  tool_name:string
+  ?force_new_trace_id:bool
+  -> tool_name:string
   -> ((unit -> trace_id option) -> Tool_result.result option * string)
   -> Tool_result.result option * string
 
 let identity_span_wrapper : span_wrapper =
-  fun ~tool_name:_ body -> body (fun () -> None)
+  fun ?force_new_trace_id:_ ~tool_name:_ body -> body (fun () -> None)
 ;;
 
 let span_wrapper_ref : span_wrapper ref = ref identity_span_wrapper

--- a/lib/tool/tool_dispatch.mli
+++ b/lib/tool/tool_dispatch.mli
@@ -91,7 +91,8 @@ val apply_result_transformer : Tool_result.result -> Tool_result.result
 type trace_id = string
 
 type span_wrapper =
-  tool_name:string
+  ?force_new_trace_id:bool
+  -> tool_name:string
   -> ((unit -> trace_id option) -> Tool_result.result option * string)
   -> Tool_result.result option * string
 (** Wrapper applied around the dispatch body in {!guarded_dispatch}. Mirrors the

--- a/lib/tool_telemetry.ml
+++ b/lib/tool_telemetry.ml
@@ -20,9 +20,9 @@ let register_metrics () =
   end
 ;;
 
-let with_span ~tool_name f =
+let with_span ?(force_new_trace_id = false) ~tool_name f =
   let span_name = "tool_dispatch." ^ tool_name in
-  Otel_spans.with_span ~name:span_name (fun trace_id_thunk ->
+  Otel_spans.with_span ~name:span_name ~force_new_trace_id (fun trace_id_thunk ->
     let result, outcome = f trace_id_thunk in
     Otel_metric_store.inc_counter
       counter_name

--- a/lib/tool_telemetry.mli
+++ b/lib/tool_telemetry.mli
@@ -31,7 +31,8 @@ type trace_id = string
     label. PR-10 will replace the [string] outcome with a typed
     [Dispatch_outcome.t]. *)
 val with_span
-  :  tool_name:string
+  :  ?force_new_trace_id:bool
+  -> tool_name:string
   -> ((unit -> trace_id option) -> 'a * string)
   -> 'a * string
 

--- a/test/test_tool_dispatch.ml
+++ b/test/test_tool_dispatch.ml
@@ -254,7 +254,7 @@ let () =
               register_full ~tool_name:tool ~handler:echo_handler ();
               let calls = ref [] in
               let probe : Tool_dispatch.span_wrapper =
-                fun ~tool_name body ->
+                fun ?force_new_trace_id:_ ~tool_name body ->
                   calls := tool_name :: !calls;
                   body (fun () -> Some "probe-trace")
               in
@@ -273,7 +273,7 @@ let () =
               let tool = "__test_span_wrap_b" in
               register_full ~tool_name:tool ~handler:echo_handler ();
               let calls = ref 0 in
-              Tool_dispatch.set_span_wrapper (fun ~tool_name:_ body ->
+              Tool_dispatch.set_span_wrapper (fun ?force_new_trace_id:_ ~tool_name:_ body ->
                   incr calls;
                   body (fun () -> None));
               Tool_dispatch.clear_hooks ();


### PR DESCRIPTION
## Summary

Splits monolithic 18,000+ span / 6h+ traces into independent per-operation traces by exposing `?force_new_trace_id` through the telemetry wrapper chain and activating it at all tool dispatch entry points.

## Changes

- `Otel_spans.with_span`: new optional `?force_new_trace_id` parameter forwarded to `Opentelemetry.Trace.with_`
- `Tool_telemetry.with_span`: accepts and forwards `?force_new_trace_id`
- `Tool_dispatch.span_wrapper` type + `identity_span_wrapper`: updated to carry the optional parameter
- `mcp_server_eio_execute.ml`: `~force_new_trace_id:true` at both internal and tag dispatch telemetry call sites
- `keeper_tool_registered_runtime.ml`: `~force_new_trace_id:true` at tag dispatch telemetry call site
- `test/test_tool_dispatch.ml`: updated mock span wrappers to match new type

## Motivation

`Opentelemetry.Trace.with_'` uses `Ambient_context` to find parent spans. Without `force_new_trace_id`, every tool dispatch nests under the same trace ID, causing a single trace to accumulate thousands of spans across hours. This makes Jaeger/Grafana unreadable.

## Verification

- `dune build --root . @check` passes (pre-existing `test_keeper_tool_name.ml` error unrelated)
- Each tool dispatch now starts a fresh trace root; trace size drops from O(thousands) to O(1) per operation

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>