### PR TITLE
feat(runtime): fail-fast when stream idle configured without a clock (RFC-OAS-026 §4.6, F1 step 3a)

### DIFF
--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -296,6 +296,43 @@ let runtime_observation_for_completed_config ~total_duration_ms
     ~attempt_details_source:"runtime_agent_terminal"
     ()
 
+(* RFC-OAS-026 §4.6: [read_sse] arms the stream-idle deadline only when BOTH a
+   clock and the idle timeout are present. masc's clock derivation resolves to
+   [None] when the process runtime is uninitialised; a [None] clock with a
+   configured [stream_idle_timeout_s] would silently disarm the only
+   I2-legitimate streaming timeout and let a mid-stream stall hang to the
+   attempt watchdog (the exact silent no-op the RFC forbids). Fail loudly so a
+   wiring regression is visible. A [None] idle (the legitimate opt-out) with a
+   [None] clock stays [None]. Split into a pure decision over the two clock
+   sources so the failure path is testable without an Eio runtime. *)
+let decide_clock_for_idle
+    ~(stream_idle_timeout_s : float option)
+    ~(process_clock : (float Eio.Time.clock_ty Eio.Resource.t, string) result)
+    ~(ctx_clock : float Eio.Time.clock_ty Eio.Resource.t option)
+  : float Eio.Time.clock_ty Eio.Resource.t option =
+  match process_clock, ctx_clock with
+  | Ok c, _ -> Some c
+  | Error _, (Some _ as c) -> c
+  | Error e, None ->
+    (match stream_idle_timeout_s with
+     | Some idle ->
+       failwith
+         (Printf.sprintf
+            "runtime_agent: stream_idle_timeout_s configured (%.1fs) but no \
+             clock resolvable (%s); refusing to run with a silently disarmed \
+             stream idle timeout"
+            idle
+            e)
+     | None -> None)
+;;
+
+let resolve_clock_for_idle ~(stream_idle_timeout_s : float option) =
+  decide_clock_for_idle
+    ~stream_idle_timeout_s
+    ~process_clock:(Process_eio.get_clock ())
+    ~ctx_clock:(Eio_context.get_clock_opt ())
+;;
+
 module For_testing = struct
   let request_runtime_fields_on_base_config =
     request_runtime_fields_on_base_config
@@ -304,6 +341,7 @@ module For_testing = struct
   let runtime_id_of_config = runtime_id_of_config
   let runtime_observation_for_completed_config =
     runtime_observation_for_completed_config
+  let decide_clock_for_idle = decide_clock_for_idle
 end
 
 (* ================================================================ *)
@@ -362,9 +400,7 @@ let build
     ~(config : config)
   : (Agent_sdk.Agent.t, Agent_sdk.Error.sdk_error) result =
   let clock =
-    match Process_eio.get_clock () with
-    | Ok c -> Some c
-    | Error _ -> Eio_context.get_clock_opt ()
+    resolve_clock_for_idle ~stream_idle_timeout_s:config.stream_idle_timeout_s
   in
   match
     transport_for_provider
@@ -468,9 +504,7 @@ let resume_from_checkpoint
     ~(checkpoint : Agent_sdk.Checkpoint.t)
   : (Agent_sdk.Agent.t, Agent_sdk.Error.sdk_error) result =
   let clock =
-    match Process_eio.get_clock () with
-    | Ok c -> Some c
-    | Error _ -> Eio_context.get_clock_opt ()
+    resolve_clock_for_idle ~stream_idle_timeout_s:config.stream_idle_timeout_s
   in
   match
     transport_for_provider

--- a/lib/runtime/runtime_agent.mli
+++ b/lib/runtime/runtime_agent.mli
@@ -186,6 +186,14 @@ module For_testing : sig
 
   val runtime_id_of_config : config -> string
 
+  (* RFC-OAS-026 §4.6 fail-fast (pure decision; raises [Failure] when an idle
+     deadline is configured but no clock resolves). *)
+  val decide_clock_for_idle :
+    stream_idle_timeout_s:float option ->
+    process_clock:(float Eio.Time.clock_ty Eio.Resource.t, string) result ->
+    ctx_clock:float Eio.Time.clock_ty Eio.Resource.t option ->
+    float Eio.Time.clock_ty Eio.Resource.t option
+
   val runtime_observation_for_completed_config :
     total_duration_ms:float -> config -> Runtime_observation.runtime_observation
 end

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -373,6 +373,38 @@ let test_runtime_agent_max_turns_is_continuation_checkpoint () =
   check string "status" "continuation_checkpoint" lifecycle.status;
   check (option string) "no error" None lifecycle.error
 
+(* RFC-OAS-026 §4.6: a configured stream-idle deadline with no resolvable clock
+   must fail loudly rather than silently disarm the only I2-legitimate
+   streaming timeout. *)
+let test_clock_failfast_raises_when_idle_set_without_clock () =
+  try
+    let _ =
+      Runtime_agent.For_testing.decide_clock_for_idle
+        ~stream_idle_timeout_s:(Some 120.0)
+        ~process_clock:(Error "process runtime not initialised")
+        ~ctx_clock:None
+    in
+    fail "expected failure when idle is configured but no clock resolves"
+  with
+  | Failure msg ->
+    check
+      bool
+      "message identifies the configured idle deadline with no clock"
+      true
+      (String.starts_with
+         ~prefix:"runtime_agent: stream_idle_timeout_s configured"
+         msg)
+
+let test_clock_failfast_opt_out_when_no_idle_no_clock () =
+  (* Legitimate opt-out: no idle deadline + no clock stays None, no raise. *)
+  let clock =
+    Runtime_agent.For_testing.decide_clock_for_idle
+      ~stream_idle_timeout_s:None
+      ~process_clock:(Error "no runtime")
+      ~ctx_clock:None
+  in
+  check bool "no idle + no clock -> None" true (Option.is_none clock)
+
 let () =
   run "runtime_provider_auth_headers"
     [ ( "provider_config"
@@ -408,5 +440,13 @@ let () =
             "dashboard runtime provider reachability contracts"
             `Quick
             test_dashboard_runtime_probe_reachability_contracts
+        ; test_case
+            "clock fail-fast raises when idle set without clock (RFC-OAS-026)"
+            `Quick
+            test_clock_failfast_raises_when_idle_set_without_clock
+        ; test_case
+            "clock fail-fast opt-out when no idle no clock"
+            `Quick
+            test_clock_failfast_opt_out_when_no_idle_no_clock
         ] )
     ]


### PR DESCRIPTION
## 목표

RFC-OAS-026 §6 **step 3의 masc-internal 절반** (clock fail-fast §4.6). oas#1950(transport 캐리어)이 dispatch drop을 막았지만, masc 쪽엔 별도 구멍이 있다: `read_sse`는 **clock과 idle가 둘 다 Some일 때만** idle를 무장하는데, masc의 clock 유도가 `None`으로 떨어지면 `stream_idle_timeout_s`가 설정돼 있어도 **조용히 무장 해제** → mid-stream stall이 attempt watchdog까지 hang.

## 근본 원인

`runtime_agent.ml`의 clock 유도 `match Process_eio.get_clock () with Ok c -> Some c | Error _ -> Eio_context.get_clock_opt ()`는 두 소스 모두 `None`을 줄 수 있다(process runtime 미초기화 시). idle 설정 + clock None = silent disarm — RFC가 금지하는 silent no-op.

## 변경

- `runtime_agent.ml`: clock 유도를 `decide_clock_for_idle`(두 clock 소스에 대한 **순수 결정** — Eio 런타임 없이 실패 경로 테스트 가능) + `resolve_clock_for_idle`(실제 소스) 로 추출. idle 설정됐는데 어느 소스도 clock을 못 풀면 **fail-fast**(loud); idle=None(정당 opt-out) + clock None은 None 유지.
- 적용: stream-idle consumer 2곳(`build`, `resume_from_checkpoint`). run 경로의 clock은 `max_execution_time_s`(별개·의도적 미설정)용이라 그대로 둠.
- `For_testing`에 `decide_clock_for_idle` 노출 + raise/opt-out 테스트.

## 검증

- `dune exec --root . test/test_runtime_provider_auth_headers.exe`: 신규 fail-fast 테스트 포함 통과.
- 순수 결정 함수라 `process_clock=Error _, ctx_clock=None, idle=Some` → raise, `idle=None` → None을 real clock 없이 검증.

## 비고 / 후속

- 이건 step 3의 masc-internal 절반(oas release에 **안 막힘**). 나머지 절반(pin `>= 0.205.0` + optional request-field 하드닝)은 oas#1950 release 후.
- **§6 hard 순서**: F1 armed end-to-end 검증 전 masc 1800s attempt watchdog/livelock 임계값 retune 금지 (I1 무한 hang 부활).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
