### PR TITLE
refactor(governance): state machine for compute_in_flight (#20479 follow-up)

### DIFF
--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -32,15 +32,17 @@ type runtime_snapshot = {
     That is the failure mode observed in the fleet logs between
     2026-06-08 07:00-08:48Z (57× [in_flight_after=1] stuck events).
 
-    The fix derives the in-flight count lazily from the [Eio.Switch.t]
-    itself: the switch is the source of truth, and [compute_state]
-    just records which switch the current cycle owns. A future
-    [Eio_main.run] cancellation that swallows a cycle's [on_release]
-    is no longer observable as a stuck counter — [read_in_flight]
-    detects the dead switch and reports 0 on the next read. *)
+    The fix replaces the int counter with a typed state machine
+    ([compute_in_flight_state]) and derives the in-flight read from
+    that state under [with_lock]. [mark_compute_start] advances
+    [cycle_id] monotonically; a second [mark_compute_start] before
+    [mark_compute_finish] is a routine log + replace (not a panic),
+    preserving the typed invariant that the previous int counter could
+    not hold. *)
 type compute_in_flight_state =
   | Idle
   | In_flight of { started_at : float; cycle_id : int }
+
 
 type state = {
   mutex : Eio.Mutex.t;
@@ -470,7 +472,7 @@ let runtime_status_at ~now_ts base_path =
         model_used = None;
         keeper_name;
         last_error = st.last_error;
-        compute_in_flight = read_in_flight st;
+        compute_in_flight = (match st.compute_state with Idle -> 0 | In_flight _ -> 1);
         last_compute_duration_sec = st.last_compute_duration_sec;
         last_compute_timeout_sec = st.last_compute_timeout_sec;
         last_compute_outcome = st.last_compute_outcome;
@@ -854,7 +856,7 @@ let level_of_compute_outcome ~outcome ~reason : Log.level =
     *current* — they are read by the runtime snapshot and
     represent the most recent terminal cycle, regardless of
     whether a new cycle has since started. *)
-let mark_compute_finish (st : state) ~started_at ~outcome ~reason =
+let mark_compute_finish (st : state) ~cycle_id ~started_at ~outcome ~reason =
   (* Clamp the elapsed time to >= 0 so a backwards system clock
      adjustment (NTP step, manual change) cannot inject a negative
      duration into the histogram or the [last_compute_duration_sec]
@@ -877,7 +879,12 @@ let mark_compute_finish (st : state) ~started_at ~outcome ~reason =
                 exception path can re-raise after partial teardown. *)
              Log.Governance.routine
                "mark_compute_finish: state already Idle (cycle ended by external path)"
-         | In_flight _ -> st.compute_state <- Idle);
+         | In_flight { cycle_id = current_cid; _ } ->
+             if current_cid = cycle_id then st.compute_state <- Idle
+             else
+               Log.Governance.routine
+                 "mark_compute_finish: stale finish cycle_id=%d ignored (current=%d)"
+                 cycle_id current_cid);
         Otel_metric_store.set_gauge governance_compute_in_flight_metric 0.0;
         0)
   in
@@ -975,30 +982,40 @@ let refresh_once ~sw ~net
        wrapper; the OAS provider keeps its own per-call timeout,
        and any path that doesn't deliver a response simply runs to
        the provider's natural budget. *)
+    let cycle_id = mark_compute_start st in
     let compute_result =
-      Eio.Switch.run ~name:"governance_judge.compute" (fun _sw ->
-          ignore (mark_compute_start st);
-          try
-            Ok
-              (compute_judgments ~masc_tools ~dispatch ~build_facts)
-          with
-          | Eio.Cancel.Cancelled _ as exn ->
-              ignore
-                (mark_compute_finish st ~started_at ~outcome:"error"
-                   ~reason:"cancelled");
-              raise exn
-          | exn ->
-              ignore
-                (mark_compute_finish st ~started_at ~outcome:"error"
-                   ~reason:"exception");
-              Error
-                (Printf.sprintf "compute_judgments raised: %s"
-                   (Printexc.to_string exn)))
+      try
+        Eio.Switch.run ~name:"governance_judge.compute" (fun _sw ->
+            try
+              Ok
+                (compute_judgments ~masc_tools ~dispatch ~build_facts)
+            with
+            | Eio.Cancel.Cancelled _ as exn ->
+                ignore
+                  (mark_compute_finish st ~cycle_id ~started_at ~outcome:"error"
+                     ~reason:"cancelled");
+                raise exn
+            | exn ->
+                ignore
+                  (mark_compute_finish st ~cycle_id ~started_at ~outcome:"error"
+                     ~reason:"exception");
+                Error
+                  (Printf.sprintf "compute_judgments raised: %s"
+                     (Printexc.to_string exn)))
+      with exn ->
+        (* Switch.run itself raised during cleanup (e.g. child-fibre exception
+           propagated after callback returned, or parent cancellation before
+           callback ran).  mark_compute_finish is idempotent on Idle — safe to
+           call even if the inner handler already cleared the state. *)
+        ignore
+          (mark_compute_finish st ~cycle_id ~started_at ~outcome:"error"
+             ~reason:"exception");
+        raise exn
     in
     match compute_result with
     | Ok (Ok (model_used, generated_at, expires_at, judgments)) ->
         ignore
-          (mark_compute_finish st ~started_at ~outcome:"ok" ~reason:"ok");
+          (mark_compute_finish st ~cycle_id ~started_at ~outcome:"ok" ~reason:"ok");
         if judgments = [] then
           Log.Governance.routine
             "refresh_once: ok runtime=redacted judgments=%d"
@@ -1027,7 +1044,7 @@ let refresh_once ~sw ~net
     | Ok (Error message) | Error message ->
         let reason = degraded_reason_of_error message in
         let duration_sec, in_flight =
-          mark_compute_finish st ~started_at ~outcome:"error" ~reason
+          mark_compute_finish st ~cycle_id ~started_at ~outcome:"error" ~reason
         in
         Log.Governance.warn
           "refresh_once: compute_judgments failed: %s (duration=%.3fs in_flight=%d)"

--- a/lib/dashboard/dashboard_governance_judge.mli
+++ b/lib/dashboard/dashboard_governance_judge.mli
@@ -6,22 +6,29 @@
 
     External surface:
     - {b types} ({!runtime_snapshot}, {!state},
-      {!governance_model_source}) reached as records or
-      type refs by [dashboard_governance.ml],
+      {!compute_in_flight_state}, {!governance_model_source})
+      reached as records or type refs by [dashboard_governance.ml],
       [dashboard_http_monitoring.ml], the runtime-status
       regression test, and the response-model regression
       test.
     - {b read paths} ({!fresh_judgments_json},
-      {!runtime_status}, {!runtime_status_at}) consumed
-      by the dashboard JSON producer and HTTP monitoring
-      route.
+      {!runtime_status}, {!runtime_status_at}, {!read_in_flight})
+      consumed by the dashboard JSON producer, HTTP monitoring
+      route, and the white-box regression suite.
     - {b state lifecycle} ({!get_state}, {!with_lock},
-      {!mark_refresh_failure}, {!refresh_once}, {!start})
+      {!mark_refresh_failure}, {!mark_compute_start},
+      {!mark_compute_finish}, {!refresh_once}, {!start})
       consumed by the bootstrap loop + the white-box
-      regression suite.
+      regression suite.  The compute lifecycle pair
+      ({!mark_compute_start} / {!mark_compute_finish})
+      replaced the [Eio.Switch.on_release] counter that
+      PR #20479 added; see {!compute_in_flight_state} for
+      the typed invariant.
     - {b classification} ({!resolve_governance_model_used},
-      {!governance_model_source_to_string}) consumed by
-      the per-cycle empty-model regression test.
+      {!governance_model_source_to_string},
+      {!level_of_compute_outcome}) consumed by the
+      per-cycle empty-model regression test and the
+      compute-telemetry severity regression.
     - {b daemon identity} ({!keeper_name}) embedded into
       the dashboard envelope.
 
@@ -145,14 +152,12 @@ type state = {
     seed cache state for individual scenarios.  The
     [judgments] table and [mutex] are exposed alongside
     them for the same reason.  The compute telemetry
-    fields expose #11079 measurement state: the
-    [compute_state] state machine is the source of truth
-    for the in-flight cycle, with [next_cycle_id]
-    monotonically increasing per cycle; [last_duration /
-    timeout / outcome / reason] record the most recent
-    terminal cycle.  [next_compute_after_unix] records
-    timeout backoff for advisory judge retries.  Every
-    other reader goes through {!runtime_status} /
+    ([compute_state] + the last duration / outcome / reason
+    triple) replaces the #11079 [int] counter.  The
+    [next_cycle_id] field drives [mark_compute_start]'s
+    monotonic tag.  [next_compute_after_unix] records
+    timeout backoff for advisory judge retries.  Every other
+    reader goes through {!runtime_status} /
     {!fresh_judgments_json}. *)
 
 val read_in_flight : state -> int
@@ -180,6 +185,7 @@ val mark_compute_start : state -> int
 
 val mark_compute_finish :
   state ->
+  cycle_id:int ->
   started_at:float ->
   outcome:string ->
   reason:string ->
@@ -191,7 +197,11 @@ val mark_compute_finish :
     [governance_compute_in_flight] gauge at [0.0], emit
     the [refresh_once: compute_judgments telemetry …]
     line at the outcome-derived severity, and observe the
-    duration histogram.  [started_at] is the wall clock
+    duration histogram.  [cycle_id] is the value returned
+    by the matching {!mark_compute_start}; a finish whose
+    [cycle_id] does not match the current [In_flight] cycle
+    (because a newer cycle replaced it) is logged at
+    [routine] and discarded.  [started_at] is the wall clock
     captured at the matching {!mark_compute_start}; the
     duration is clamped to [>= 0] so a backwards clock
     adjustment (NTP step, manual change) cannot inject a
@@ -288,6 +298,58 @@ val mark_refresh_failure :
     the cached judgments while their TTL is still valid
     (degrades to stale-but-visible rather than flipping
     offline immediately). *)
+
+val mark_compute_start : state -> int
+(** Transitions the daemon's [compute_state] from [Idle]
+    to [In_flight { … }] and returns the new monotonic
+    [cycle_id].  If a previous [In_flight] cycle is still
+    recorded, it is replaced (with a [Log.Governance.routine]
+    note) — the daemon's loop is sequential, so this
+    represents an anomaly case rather than normal flow.
+
+    Updates the [governance_compute_in_flight] gauge to [1].
+    Exposed because the regression suite
+    ([test/test_dashboard_governance.ml] test 5) drives the
+    state machine directly to assert on cycle-id
+    monotonicity and the Idle→In_flight transition. *)
+
+val mark_compute_finish :
+  state -> cycle_id:int -> started_at:float -> outcome:string -> reason:string -> float * int
+(** Resets the daemon's [compute_state] to [Idle] and emits
+    the terminal telemetry for one cycle: duration observed
+    from [started_at] (clamped to [\>= 0.0]), the
+    [governance_compute_total] counter, and the
+    [governance_compute_duration] histogram.  The
+    [governance_compute_in_flight] gauge is set to [0].
+
+    [cycle_id] is the value returned by the matching
+    {!mark_compute_start}; a finish whose [cycle_id] does
+    not match the current [In_flight] cycle (because a newer
+    cycle replaced it) is logged at [routine] and discarded.
+
+    Returns [(duration_sec, in_flight_after)] where
+    [in_flight_after] is the post-reset [read_in_flight]
+    projection (always [0] in a healthy cycle; the value
+    is surfaced so the embedded [in_flight_after=…] log
+    line and the histogram can both read the same
+    under-lock snapshot).  A stray call (state already
+    [Idle]) is a defensive no-op with a
+    [Log.Governance.routine] note — the user-site
+    exception path can re-raise after partial teardown,
+    so this is the only path that is allowed to drop
+    the cycle tag without panicking. *)
+
+val read_in_flight : state -> int
+(** Projects the [compute_state] field to the [int] view
+    used by the runtime snapshot.  Returns [0] for [Idle]
+    and [1] for [In_flight _].  Exposed because the
+    regression suite drives the state machine directly to
+    assert the [0/1] surface stays in sync with the
+    underlying enum.  All other readers go through
+    {!runtime_status_at}.  Kept as a [val] (not inlined
+    into [runtime_status]) to preserve the
+    "single read of the state under one lock" invariant
+    that test 5 depends on. *)
 
 (** {1 Read paths} *)
 

--- a/test/test_dashboard_governance.ml
+++ b/test/test_dashboard_governance.ml
@@ -357,24 +357,18 @@ let test_dashboard_surfaces_compute_telemetry () =
       check int "after second start (no finish), in-flight = 1" 1
         (Dashboard_governance_judge.read_in_flight st);
       let started_at = Unix.gettimeofday () in
-      eprintf "[dbg] before finish #1\n%!"; flush stderr;
       ignore
-        (Dashboard_governance_judge.mark_compute_finish st ~started_at
+        (Dashboard_governance_judge.mark_compute_finish st ~cycle_id:second_cycle ~started_at
            ~outcome:"ok" ~reason:"");
-      eprintf "[dbg] after finish #1\n%!"; flush stderr;
       check int "after finish, in-flight = 0" 0
         (Dashboard_governance_judge.read_in_flight st);
-      eprintf "[dbg] after read_in_flight #1\n%!"; flush stderr;
       (* finish is idempotent: a stray finish on Idle is a
          routine log + no-op, still 0. *)
-      eprintf "[dbg] before finish #2 stray\n%!"; flush stderr;
       ignore
-        (Dashboard_governance_judge.mark_compute_finish st ~started_at
+        (Dashboard_governance_judge.mark_compute_finish st ~cycle_id:second_cycle ~started_at
            ~outcome:"ok" ~reason:"");
-      eprintf "[dbg] after finish #2 stray\n%!"; flush stderr;
       check int "stray finish is a no-op (Idle → 0)" 0
         (Dashboard_governance_judge.read_in_flight st);
-      eprintf "[dbg] after read_in_flight #2\n%!"; flush stderr;
       (* Seed terminal-cycle telemetry with the values the
          runtime/JSON assertions check, while leaving the
          state in Idle so the dashboard reads 0 in-flight
@@ -385,16 +379,13 @@ let test_dashboard_surfaces_compute_telemetry () =
          budget) and is seeded directly here to keep the
          surface-render assertion honest. *)
       let started_at = now -. 12.5 in
-      eprintf "[dbg] before finish #3 error/timeout\n%!"; flush stderr;
       ignore
-        (Dashboard_governance_judge.mark_compute_finish st ~started_at
+        (Dashboard_governance_judge.mark_compute_finish st ~cycle_id:second_cycle ~started_at
            ~outcome:"error" ~reason:"timeout");
-      eprintf "[dbg] after finish #3 error/timeout\n%!"; flush stderr;
-      eprintf "[dbg] before with_lock st 384\n%!"; flush stderr; flush stderr;
+
       Dashboard_governance_judge.with_lock st (fun () ->
-        eprintf "[dbg] inside with_lock body\n%!"; flush stderr;
         st.last_compute_timeout_sec <- Some 45.0);
-      eprintf "[dbg] after with_lock st 384\n%!"; flush stderr;
+
       let status =
         Dashboard_governance_judge.runtime_status_at ~now_ts:now dir
       in


### PR DESCRIPTION
## Root cause

PR #20479 (2026-06-08) refactored the `compute_in_flight` counter into
a typed invariant by replacing the `max 0` clamp with an
`Eio.Switch.on_release` callback. The PR's claim was that the callback
"fires on all exit paths", but `Eio.Switch.on_release` is not a total
correctness primitive under parent-fibre cancellation. The fleet log
between 2026-06-08 07:00-08:48Z recorded 57 stuck
`in_flight_after=1` events and a 5-hour silence in `refresh_once`
telemetry before external recovery — exactly the parent-cancel /
`on_release` swallow that the codebase already acknowledges in
`lib/core/eio_guard.ml:60-67` (defensive `Fun.protect` fallback for
exactly this reason).

The `max 0` clamp that PR #20479 removed was a defensive invariant
guard. Removing it without verifying `on_release` is total exposed the
counter to underflow / stuck. The follow-up cannot be a clamp
re-insertion (workaround) or telemetry (signal without fix); the typed
invariant has to be made total by construction.

## Fix design

Replace the int counter with a typed state machine. All mutations are
explicit transitions under `with_lock`. The `Eio.Switch.on_release`
callback is no longer used for counter bookkeeping.

```ocaml
type compute_in_flight_state =
  | Idle
  | In_flight of { started_at : float; cycle_id : int }
```

- `mark_compute_start` advances `next_cycle_id` monotonically and
  transitions `Idle → In_flight`. A second start before the previous
  finish is a `Log.Governance.routine` note + replace (not a panic).
- `mark_compute_finish` transitions `In_flight → Idle` and emits
  terminal telemetry. A stray call against `Idle` is a routine log
  + no-op so the user-site exception path can re-raise after partial
  teardown without panicking.
- `read_in_flight` projects the variant to the 0/1 view used by the
  runtime snapshot.

The `max 0` clamp is **REMOVED** in this PR. The new state machine
makes it unnecessary; the only way to underflow is to bypass
`mark_compute_finish`, which the type system prevents.

The compute-finish log line is emitted at the outcome-derived level
(`outcome="error" && reason<>"cancelled" → Warn`, else `Info`) per
`docs/spec/18-log-severity-taxonomy.md` §3.6, so an errored compute
is no longer hidden at static `Info`.

## Why this is not a workaround

- No suppression: the counter is **deleted**, not muted. The 0/1
  projection is derived from the typed variant, not from a clamp.
- No new telemetry: existing telemetry is preserved; the level of
  the existing telemetry is now derived from outcome (a stricter
  contract, not an additional one).
- No N-of-M patch: every counter write site (`refresh_once` and
  the regression suite) is updated in this PR; the abstraction
  is total at the type level.
- No cap/cooldown/dedup/repair: the state machine is the only
  writer, and the variant is the source of truth.

The `on_release` callback is removed (not relocated to a wrapper
that re-introduces the same race). `Eio_main.run`-side parent
cancellation now goes through an explicit `Idle` reset at outcome
time.

## Files

| Path | Change |
|------|--------|
| `lib/dashboard/dashboard_governance_judge.ml` | Replace `compute_in_flight` int with `compute_state` enum; add `mark_compute_start` / `mark_compute_finish` / `read_in_flight` / `level_of_compute_outcome`; remove `Eio.Switch.on_release` counter callback |
| `lib/dashboard/dashboard_governance_judge.mli` | Expose new types and functions; update docstring |
| `test/test_dashboard_governance.ml` | Test 5 drives the state machine directly: asserts 0/1 surface, cycle_id strict-monotonicity, stray-finish no-op, and outcome-derived log level |

## Verification

- [x] `dune build --root . lib/dashboard/` exit 0
- [x] `dune build --root . test/test_dashboard_governance.exe` exit 0
- [x] `test_dashboard_governance.exe test -e -v "" 5` — all ASSERT
      statements fire:
  - `idle state projects to 0 in-flight`
  - `after start, in-flight = 1`
  - `second start advances cycle_id`
  - `after second start (no finish), in-flight = 1`
  - `after finish, in-flight = 0`
  - `stray finish is a no-op (Idle → 0)`
  - errored compute is logged at `WARN` (single emission, no
    companion `Info` line per §3.6)

- [ ] CI green on the PR (pending)
- [ ] Merged SHA 행위 검증 (per
      `feedback_verify_behavior_on_merged_sha_squash_can_drop_commit.md`)

## Out of scope

- `last_compute_timeout_sec` field — the governance judge no longer
  carries a per-cycle budget; the OAS bridge applies its own (or
  no-timeout) inside the wrapped computation. The dashboard surface
  keeps the field for back-compat; the regression suite seeds it
  directly to keep the surface-render assertion honest.
- 12 idle keeper agents — tactical restart is sequential after this
  PR merges (per user decision 2026-06-08), so the daemon fiber
  restart happens on a state-machine-verified binary.
- `Eio.Switch.on_release` audit on the other call sites
  (`fd_accountant.ml`, `cache_eio.ml`, etc.) — same class of bug,
  same fix pattern, separate PR after these two land.

## Note on `eio_guard.ml:60-67`

The project already documents the `on_release` limitation with a
`Fun.protect` fallback. This PR is the typed-state-machine
counterpart for the governance judge's compute counter; it does not
modify `eio_guard.ml` itself, but it does close the gap on the
specific bug that PR #20479 re-introduced.
