### PR TITLE
fix(ide): 5 recurring dashboard issues

### DIFF
--- a/dashboard/src/api/dev-token.ts
+++ b/dashboard/src/api/dev-token.ts
@@ -1,3 +1,4 @@
+import { signal, type ReadonlySignal } from '@preact/signals'
 import {
   clearStoredToken,
   currentDashboardActor,
@@ -11,6 +12,25 @@ import {
 const DEV_TOKEN_FETCH_TIMEOUT_MS = 3000
 
 let devTokenBootstrapPromise: Promise<void> | null = null
+
+/**
+ * Tracks the outcome of the loopback dev-token bootstrap so the UI can
+ * distinguish "auth required but no token" from "network error" etc.
+ *   idle       — not yet attempted
+ *   fetching   — in-flight
+ *   ok         — token stored
+ *   no_endpoint — /dev-token returned 404 (loopback disabled or strict auth)
+ *   network    — fetch threw (server down, CORS, DNS)
+ */
+export type DevTokenBootstrapStatus =
+  | 'idle'
+  | 'fetching'
+  | 'ok'
+  | 'no_endpoint'
+  | 'network'
+
+export const devTokenBootstrapStatus: ReadonlySignal<DevTokenBootstrapStatus> =
+  signal<DevTokenBootstrapStatus>('idle')
 
 interface DevTokenBootstrapPayload {
   token?: unknown
@@ -45,6 +65,7 @@ export async function ensureDevToken(): Promise<void> {
   devTokenBootstrapPromise = (async () => {
     const storedMeta = getStoredTokenMeta()
     const storedToken = getStoredToken()
+    ;(devTokenBootstrapStatus as { value: DevTokenBootstrapStatus }).value = 'fetching'
     try {
       const res = await fetchWithTimeout(
         '/api/v1/dashboard/dev-token',
@@ -55,11 +76,15 @@ export async function ensureDevToken(): Promise<void> {
         if (res.status === 404 && storedMeta?.source === 'dev') {
           clearStoredToken()
         }
+        ;(devTokenBootstrapStatus as { value: DevTokenBootstrapStatus }).value = 'no_endpoint'
         return
       }
       const payload = (await res.json()) as DevTokenBootstrapPayload
       const token = typeof payload.token === 'string' ? payload.token.trim() : ''
-      if (!token) return
+      if (!token) {
+        ;(devTokenBootstrapStatus as { value: DevTokenBootstrapStatus }).value = 'no_endpoint'
+        return
+      }
       const actor = typeof payload.actor === 'string' ? payload.actor.trim() : 'dashboard'
       const scope =
         typeof payload.scope === 'string' && payload.scope.trim() !== ''
@@ -77,9 +102,9 @@ export async function ensureDevToken(): Promise<void> {
           scope,
         })
       }
+      ;(devTokenBootstrapStatus as { value: DevTokenBootstrapStatus }).value = 'ok'
     } catch {
-      /* Loopback endpoint unavailable (LAN bind, strict auth, offline).
-         Leave auth headers empty; caller will surface the 401 as before. */
+      ;(devTokenBootstrapStatus as { value: DevTokenBootstrapStatus }).value = 'network'
     }
   })()
   return devTokenBootstrapPromise

--- a/dashboard/src/api/workspace.ts
+++ b/dashboard/src/api/workspace.ts
@@ -7,6 +7,7 @@ export type { WorkspaceSource } from './workspace-source'
 export interface WorkspaceTreeResult {
   readonly nodes: ReadonlyArray<FileTreeNode>
   readonly source: WorkspaceSource
+  readonly basePath: string | null
 }
 
 // --- Blame ---
@@ -65,6 +66,7 @@ export async function fetchWorkspaceTree(
   return {
     nodes: data,
     source: parseWorkspaceSource(headers.get('X-Workspace-Source')),
+    basePath: headers.get('X-Workspace-Base-Path'),
   }
 }
 

--- a/dashboard/src/components/auth-status.ts
+++ b/dashboard/src/components/auth-status.ts
@@ -6,9 +6,11 @@ import { useId } from '../../design-system/headless-preact/use-id'
 import {
   clearStoredToken,
   currentDashboardActor,
+  dashboardBearerToken,
   isRemoteAccess,
   setStoredToken,
 } from '../api/core'
+import { devTokenBootstrapStatus } from '../api/dev-token'
 import { resetMcpClientState } from '../api/mcp'
 import { dashboardAuthAccess, cleanErrorMessage } from '../lib/dashboard-auth-access'
 import {
@@ -51,6 +53,8 @@ function authBadgeSummary(): {
   const role = summary?.effective_role ?? summary?.default_role ?? 'unknown'
   const actor = summary?.effective_agent ?? summary?.token_agent ?? currentDashboardActor()
   const hasError = summary?.auth_error_code != null || (summary?.token_present === true && !validated)
+  const hasToken = !!dashboardBearerToken()
+  const bootstrap = devTokenBootstrapStatus.value
 
   if (validated) {
     return {
@@ -62,6 +66,13 @@ function authBadgeSummary(): {
     return {
       dotColor: 'bg-[var(--color-status-err)] shadow-[0_0_6px_rgb(var(--err-glow)/0.45)]',
       label: 'Auth error',
+    }
+  }
+  // No token and bootstrap failed — show actionable prompt
+  if (!hasToken && (bootstrap === 'no_endpoint' || bootstrap === 'network')) {
+    return {
+      dotColor: 'bg-[var(--color-status-err)] shadow-[0_0_6px_rgb(var(--err-glow)/0.45)]',
+      label: 'Login required',
     }
   }
   if (remote) {

--- a/dashboard/src/components/ide/ide-data-workspace-store.ts
+++ b/dashboard/src/components/ide/ide-data-workspace-store.ts
@@ -42,6 +42,8 @@ export interface IdeDataWorkspaceStore {
   readonly subscribeDiffRows: (listener: () => void) => () => void
   readonly workspaceSource: () => WorkspaceSource
   readonly subscribeWorkspaceSource: (listener: () => void) => () => void
+  readonly workspaceBasePath: () => string | null
+  readonly subscribeWorkspaceBasePath: (listener: () => void) => () => void
   readonly repositories: () => ReadonlyArray<Repository>
   readonly activeRepositoryId: () => string | null
   readonly setActiveRepositoryId: (repoId: string | null) => void
@@ -116,6 +118,7 @@ export function createIdeDataWorkspaceStore(): IdeDataWorkspaceStore {
 
   const diffRowsSignal = signal<ReadonlyArray<UnifiedDiffRow>>([])
   const workspaceSourceSignal = signal<WorkspaceSource>({ kind: 'project' })
+  const workspaceBasePathSignal = signal<string | null>(null)
   const repositoriesSignal = signal<ReadonlyArray<Repository>>([])
   const activeRepositoryIdSignal = signal<string | null>(null)
   const annotationsSignal = signal<ReadonlyArray<IdeAnnotation>>([])
@@ -166,10 +169,11 @@ export function createIdeDataWorkspaceStore(): IdeDataWorkspaceStore {
     const opts = { keeper: keeperParam, repoId, signal }
 
     // Load file tree (independent of active file — needed to suggest first file)
-    fetchWorkspaceTree(2, opts).then(({ nodes, source }) => {
+    fetchWorkspaceTree(2, opts).then(({ nodes, source, basePath }) => {
       if (signal.aborted) return
       fileTreeStore.seed(nodes)
       workspaceSourceSignal.value = source
+      workspaceBasePathSignal.value = basePath
 
       // Self-healing: if the selected repo is unreachable (missing .git,
       // path does not exist, etc.), exclude it and auto-switch to the next
@@ -257,6 +261,9 @@ export function createIdeDataWorkspaceStore(): IdeDataWorkspaceStore {
     // signal core's internal tracking).
     subscribeWorkspaceSource: (listener: () => void) =>
       workspaceSourceSignal.subscribe(listener),
+    workspaceBasePath: () => workspaceBasePathSignal.value,
+    subscribeWorkspaceBasePath: (listener: () => void) =>
+      workspaceBasePathSignal.subscribe(listener),
     repositories: () => repositoriesSignal.value,
     activeRepositoryId: () => activeRepositoryIdSignal.value,
     setActiveRepositoryId: (repoId: string | null) => {

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -36,6 +36,8 @@ import { navigate, route } from '../../router'
 import { activeKeeperName } from '../../keeper-state'
 import { keepers } from '../../store'
 import { connected } from '../../sse'
+import { dashboardBearerToken } from '../../api/core'
+import { devTokenBootstrapStatus } from '../../api/dev-token'
 import { dashboardWsOnlyEnabled } from '../../dashboard-ws-cutover'
 import { dashboardWsConnected, dashboardWsSseFallbackActive } from '../../dashboard-ws-state'
 import type { Repository } from '../../api/repositories'
@@ -59,6 +61,7 @@ export interface IdeStatusbarChip {
 
 export interface IdeStatusbarModel {
   readonly workspaceLabel: string
+  readonly workspaceBasePath: string | null
   readonly chips: ReadonlyArray<IdeStatusbarChip>
   readonly connectionLabel: string
   readonly connectionTone: IdeConnectionTone
@@ -98,6 +101,7 @@ interface IdeStatusbarInput {
   readonly repositories?: ReadonlyArray<Repository>
   readonly activeRepositoryId?: string | null
   readonly workspaceSource?: WorkspaceSource
+  readonly workspaceBasePath?: string | null
   readonly dashboardConnected?: boolean
 }
 
@@ -229,6 +233,29 @@ function dashboardRuntimeConnected(): boolean {
   return connected.value
 }
 
+/**
+ * Derive a human-readable label for the disconnected state so the statusbar
+ * tells the user *why* rather than just "reconnecting".
+ */
+function disconnectionReasonLabel(): string {
+  const hasToken = !!dashboardBearerToken()
+  const bootstrap = devTokenBootstrapStatus.value
+
+  if (!hasToken && bootstrap === 'no_endpoint') {
+    return 'runtime · auth required'
+  }
+  if (!hasToken && bootstrap === 'network') {
+    return 'runtime · server unreachable'
+  }
+  if (!hasToken && bootstrap === 'fetching') {
+    return 'runtime · bootstrapping...'
+  }
+  if (!hasToken) {
+    return 'runtime · no token'
+  }
+  return 'runtime · reconnecting'
+}
+
 function statusbarLayerLabel(activeLayers: ReadonlySet<string>): string | null {
   if (activeLayers.size === 0) return null
   const labels = STATUSBAR_LAYER_PRIORITY
@@ -306,6 +333,7 @@ export function deriveIdeStatusbarModel({
   repositories,
   activeRepositoryId,
   workspaceSource,
+  workspaceBasePath = null,
   dashboardConnected = false,
 }: IdeStatusbarInput): IdeStatusbarModel {
   const chips: IdeStatusbarChip[] = []
@@ -374,8 +402,11 @@ export function deriveIdeStatusbarModel({
 
   return {
     workspaceLabel: statusbarWorkspaceLabel(repositories, activeRepositoryId, workspaceSource),
+    workspaceBasePath,
     chips,
-    connectionLabel: dashboardConnected ? 'runtime · live' : 'runtime · reconnecting',
+    connectionLabel: dashboardConnected
+      ? 'runtime · live'
+      : disconnectionReasonLabel(),
     connectionTone: dashboardConnected ? 'ok' : 'warn',
   }
 }
@@ -434,6 +465,10 @@ export function IdeShell() {
   const workspaceSource = useSubscribedValue(
     workspaceStore.workspaceSource,
     workspaceStore.subscribeWorkspaceSource,
+  )
+  const workspaceBasePath = useSubscribedValue(
+    workspaceStore.workspaceBasePath,
+    workspaceStore.subscribeWorkspaceBasePath,
   )
   const [activeFilePath, setActiveFilePath] = useState(activeIdeFile.value)
 
@@ -547,6 +582,7 @@ export function IdeShell() {
     repositories,
     activeRepositoryId,
     workspaceSource,
+    workspaceBasePath,
     dashboardConnected: dashboardRuntimeConnected(),
   })
 
@@ -622,6 +658,9 @@ export function IdeShell() {
           class="chip sm is-brass"
           style=${{ flexShrink: 0 }}
           data-testid="ide-statusbar-workspace"
+          title=${statusbar.workspaceBasePath
+            ? `base_path: ${statusbar.workspaceBasePath} (set MASC_BASE_PATH to change)`
+            : undefined}
         >${statusbar.workspaceLabel}</span>
         <div
           class="ide-plane-statusbar-meta"

--- a/lib/server/server_routes_http_routes_workspace.ml
+++ b/lib/server/server_routes_http_routes_workspace.ml
@@ -152,6 +152,12 @@ let json_response_with_source ~status ~source req reqd json =
   Http.Response.json_value ~status ~extra_headers:(source_header source)
     ~request:req json reqd
 
+let json_response_with_source_and_base ~status ~source ~base_path req reqd json =
+  let headers = ("X-Workspace-Base-Path", sanitize_header_value base_path)
+                :: source_header source in
+  Http.Response.json_value ~status ~extra_headers:headers
+    ~request:req json reqd
+
 (* --- Safe path --- *)
 
 let is_digit c = c >= '0' && c <= '9'
@@ -599,7 +605,8 @@ let add_routes router =
                scan_dir ~diff_by_path ~base ~depth:0 ~max_depth:depth ~max_nodes [] base
            in
            let json = `List (List.rev nodes) in
-           json_response_with_source ~status:`OK ~source request reqd json)
+           json_response_with_source_and_base
+             ~status:`OK ~source ~base_path:base request reqd json)
          request reqd)
 
   |> Http.Router.get "/api/v1/workspace/file" (fun request reqd ->

--- a/scripts/build-dashboard-if-needed.sh
+++ b/scripts/build-dashboard-if-needed.sh
@@ -83,8 +83,12 @@ if needs_rebuild; then
     if [ "$log_file" != "/dev/null" ]; then
       rm -f "$log_file"
     fi
-    echo "[dashboard] Build failed (non-fatal)." >&2
-    exit 0
+    echo "[dashboard] Build FAILED. Dashboard SPA is stale — fix vite errors or pass --non-fatal." >&2
+    if [[ "${MASC_DASHBOARD_BUILD_NON_FATAL:-}" == "1" ]]; then
+      echo "[dashboard] Continuing (MASC_DASHBOARD_BUILD_NON_FATAL=1)." >&2
+      exit 0
+    fi
+    exit 1
   fi
   tail -n 6 "$log_file" >&2 || true
   if [ "$log_file" != "/dev/null" ]; then


### PR DESCRIPTION
## Problem

IDE 대시보드에서 반복적으로 발생하는 5가지 근본 이슈를 수정합니다.

## Changes

### 1. Dashboard 빌드 실패를 무조건 삼킴 (최빈 발생)
- **Before**: build-dashboard-if-needed.sh에서 vite 빌드 실패 시 exit 0
- **After**: exit 1. MASC_DASHBOARD_BUILD_NON_FATAL=1로 legacy 동작 유지

### 2. Auth token 부트스트랩 실패 시 조용함
- **Before**: dev-token.ts catch {} 가 모든 에러를 삼킴
- **After**: devTokenBootstrapStatus signal 노출 (idle/fetching/ok/no_endpoint/network)
- statusbar에서 "auth required" / "server unreachable" 구분 표시

### 3. base_path 표시 불가
- **After**: X-Workspace-Base-Path 응답 헤더 추가 + statusbar tooltip

### 4. Auth badge 눈에 띄지 않음
- **After**: 토큰 없이 bootstrap 실패 시 "Login required" 빨간 뱃지

### 5. dune lock 경합 (문서화만)
- 이미 MASC_DUNE_THROTTLE=0 옵션 존재. 발견성 개선은 별도 PR.

## Files Changed (7)

- `scripts/build-dashboard-if-needed.sh`: exit 0 → exit 1 on failure
- `dashboard/src/api/dev-token.ts`: +devTokenBootstrapStatus signal
- `dashboard/src/api/workspace.ts`: +basePath in WorkspaceTreeResult
- `dashboard/src/components/auth-status.ts`: "Login required" badge
- `dashboard/src/components/ide/ide-data-workspace-store.ts`: +workspaceBasePath
- `dashboard/src/components/ide/ide-shell.ts`: statusbar base_path + disconnect reason
- `lib/server/server_routes_http_routes_workspace.ml`: +X-Workspace-Base-Path header
