### PR TITLE
fix(keeper): use actual taskboard tool schema in cluster_descriptor

### DIFF
--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -628,6 +628,13 @@ let passthrough_object_schema =
     [ "type", `String "object"; "additionalProperties", `Bool true ]
 ;;
 
+let find_taskboard_schema_opt name =
+  List.find_opt (fun (s : Masc_domain.tool_schema) -> String.equal s.name name)
+    Tool_shard_types.taskboard_tools
+  |> Option.map (fun (s : Masc_domain.tool_schema) -> s.input_schema)
+;;
+
+
 let tool_search_schema =
   object_schema
     ~required:[ "query" ]
@@ -715,11 +722,16 @@ let cluster_descriptor ~id ~name ~description ~handler ~readonly
     then read_only_in_process_policy ~inline_safe ~maintenance_only ()
     else write_in_process_policy ~inline_safe ~maintenance_only ()
   in
+  let input_schema =
+    match find_taskboard_schema_opt name with
+    | Some schema -> schema
+    | None -> passthrough_object_schema
+  in
   in_process_descriptor
     ~id
     ~name
     ~description
-    ~input_schema:passthrough_object_schema
+    ~input_schema
     ~policy
     ~handler
 ;;


### PR DESCRIPTION
## Problem
`cluster_descriptor` hard-coded `passthrough_object_schema` for every tool, ignoring the per-tool input schemas already defined in `Tool_shard_types.taskboard_tools`.  This meant taskboard tools were advertised as accepting any JSON object instead of their real parameters.

## Fix
Add `find_taskboard_schema_opt` to look up the actual schema by name and fall back to `passthrough_object_schema` only for non-taskboard tools.

## Why it was missing before
The original `cluster_descriptor` was written before taskboard tools had stable schemas (or as a shortcut to avoid plumbing schema lookup).  Once `taskboard_tools` carried accurate `input_schema` values, the fallback was never updated.
