### PR TITLE
feat(verification): typed verification state + decouple from claim pool (RFC-0220 PR-1)

### DIFF
--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -263,6 +263,16 @@ let all_task_actions =
     Submit_for_verification; Approve_verification; Reject_verification ]
 let valid_task_action_strings = List.map task_action_to_string all_task_actions
 
+(* RFC-0220: the verification sub-state (previously a separate request_status
+   store: `Pending / `Assigned) is folded into [task_status] so the illegal
+   "task Todo + request Pending" pair is unrepresentable. *)
+type verification_phase =
+  | Awaiting_verifier
+      (** No verifier assigned yet (was verification request [`Pending]). *)
+  | Verifier_assigned of { verifier: string }
+      (** A verifier keeper is assigned (was [`Assigned verifier]). *)
+[@@deriving show]
+
 type task_status =
   | Todo
   | Claimed of { assignee: string; claimed_at: string }
@@ -271,7 +281,11 @@ type task_status =
       assignee: string;
       submitted_at: string;
       verification_id: string;
-      deadline: string option;
+      phase: verification_phase;
+        (** RFC-0220: replaces [deadline : string option]. The deadline is
+            dropped per I2 (no per-obligation wall-clock deadline); the
+            verification sub-state lives here so it cannot drift from a
+            separate store. *)
     }
   | Done of { assignee: string; completed_at: string; notes: string option }
   | Cancelled of { cancelled_by: string; cancelled_at: string; reason: string option }
@@ -364,7 +378,7 @@ let task_status_schema_witnesses : task_status list =
       { assignee = placeholder
       ; submitted_at = placeholder
       ; verification_id = placeholder
-      ; deadline = None
+      ; phase = Awaiting_verifier
       }
   ; Done { assignee = placeholder; completed_at = placeholder; notes = None }
   ; Cancelled
@@ -398,15 +412,20 @@ let task_status_to_yojson = function
         ("completed_at", `String completed_at);
         ("notes", Json_util.string_opt_to_json notes);
       ]
-  | AwaitingVerification { assignee; submitted_at; verification_id;
-                           deadline; _ } ->
-      `Assoc [
+  | AwaitingVerification { assignee; submitted_at; verification_id; phase } ->
+      let phase_fields =
+        match phase with
+        | Awaiting_verifier -> [ ("phase", `String "awaiting_verifier") ]
+        | Verifier_assigned { verifier } ->
+            [ ("phase", `String "verifier_assigned");
+              ("verifier", `String verifier) ]
+      in
+      `Assoc ([
         ("status", `String "awaiting_verification");
         ("assignee", `String assignee);
         ("submitted_at", `String submitted_at);
         ("verification_id", `String verification_id);
-        ("deadline", Json_util.string_opt_to_json deadline);
-      ]
+      ] @ phase_fields)
   | Cancelled { cancelled_by; cancelled_at; reason } ->
       `Assoc [
         ("status", `String "cancelled");
@@ -428,11 +447,20 @@ let task_status_of_yojson json =
     | "done" ->
         Ok (Done { assignee = req "assignee"; completed_at = req "completed_at"; notes = opt "notes" })
     | "awaiting_verification" ->
+        (* RFC-0220 migration tolerance: legacy backlogs carry [deadline]
+           (now dropped) and no [phase]; a missing/legacy phase defaults to
+           [Awaiting_verifier]. *)
+        let phase =
+          match opt "phase" with
+          | Some "verifier_assigned" ->
+              Verifier_assigned { verifier = req "verifier" }
+          | Some "awaiting_verifier" | None | Some _ -> Awaiting_verifier
+        in
         Ok (AwaitingVerification
               { assignee = req "assignee"
               ; submitted_at = req "submitted_at"
               ; verification_id = req "verification_id"
-              ; deadline = opt "deadline"
+              ; phase
               })
     | "cancelled" ->
         Ok (Cancelled

--- a/lib/types/types_core.mli
+++ b/lib/types/types_core.mli
@@ -71,6 +71,13 @@ val task_action_to_string : task_action -> string
 val all_task_actions : task_action list
 val valid_task_action_strings : string list
 
+(* RFC-0220: verification sub-state folded into [task_status] (was a separate
+   request_status store) so the illegal Todo+Pending pair is unrepresentable. *)
+type verification_phase =
+  | Awaiting_verifier
+  | Verifier_assigned of { verifier : string }
+[@@deriving show]
+
 type task_status =
   | Todo
   | Claimed of { assignee : string; claimed_at : string }
@@ -79,7 +86,7 @@ type task_status =
       { assignee : string
       ; submitted_at : string
       ; verification_id : string
-      ; deadline : string option
+      ; phase : verification_phase
       }
   | Done of { assignee : string; completed_at : string; notes : string option }
   | Cancelled of { cancelled_by : string; cancelled_at : string; reason : string option }

--- a/lib/verification_protocol.ml
+++ b/lib/verification_protocol.ml
@@ -347,92 +347,18 @@ let awaiting_verification_deadline
          , deadline_ts )
      | None -> None)
 
+(* RFC-0220 §5: the destructive 24h verification deadline rescue is removed.
+   With the verification sub-state folded into [task_status] (RFC-0220 §3.1),
+   the illegal Todo+Pending drift is unrepresentable, an AwaitingVerification
+   obligation stays claimable by a verifier, and a keeper never idles on an
+   empty pool — so the per-obligation wall-clock deadline this enforced (the
+   I2-forbidden heuristic) is unnecessary, and its destructive force-cancel
+   discarded work rather than rescheduling the obligation. Long-waiting
+   obligations are surfaced from the activity-event stream, not a poll-timer.
+   Neutered here in PR-1 (forced by dropping [deadline] from the type); the
+   [verification_timeout] fork and these knobs are deleted in a follow-up
+   (RFC-0220 §11 PR-3). *)
 let check_timeouts ~(config : Workspace.config) =
-  if not (Env_config_runtime.Verification.fsm_enabled ()) then ()
-  else
-    try
-      let backlog = Workspace.read_backlog config in
-      let now = Time_compat.now () in
-      List.iter (fun (task : Masc_domain.task) ->
-        match task.task_status with
-        | Masc_domain.AwaitingVerification
-            { assignee; verification_id; submitted_at; deadline } ->
-          (match awaiting_verification_deadline ~submitted_at ~deadline with
-           | Some (deadline_source, dl, deadline_ts)
-             when now > deadline_ts ->
-             let deadline_note =
-               match deadline_source with
-               | "deadline" -> dl
-               | _ -> Printf.sprintf "%s (derived from submitted_at)" dl
-             in
-             let () =
-               match Board_dispatch.create_post
-                 ~author:"system"
-                 ~content:(Printf.sprintf
-                   "Verification timeout: task %s (%s) by %s — no verifier responded within deadline %s"
-                   task.id task.title assignee deadline_note)
-                 ~title:(Printf.sprintf "Timeout: %s" task.title)
-                 ~post_kind:Board.System_post
-                 ~meta_json:(`Assoc [
-                   ("type", `String "verification_timeout");
-                   ("task_id", `String task.id);
-                   ("verification_id", `String verification_id);
-                   ("assignee", `String assignee);
-                   ("submitted_at", `String submitted_at);
-                   ("deadline", `String dl);
-                   ("deadline_source", `String deadline_source);
-                 ])
-                 ~visibility:Board.Internal
-                 ~hearth:"verification"
-                 ()
-               with
-               | Ok _ -> ()
-               | Error e ->
-                 Log.Task.error
-                   ~keeper_name:task.id
-                   "board post failed (task=%s vrf=%s): %s"
-                   task.id verification_id (Board_types.show_board_error e)
-             in
-             Subscriptions.push_event_to_sessions (`Assoc [
-               ("type", `String "masc/verification/timeout");
-               ("task_id", `String task.id);
-               ("verification_id", `String verification_id);
-               ("assignee", `String assignee);
-               ("deadline", `String dl);
-               ("deadline_source", `String deadline_source);
-               ("timestamp", `Float now);
-             ]);
-             (* Transition the task out of AwaitingVerification so the next
-                check_timeouts cycle does not re-emit the same Timeout post.
-                Without this, deadline > now stays true forever and every
-                cycle re-creates the same board entry. *)
-             let cancel_reason =
-               Printf.sprintf
-                 "verification deadline exceeded (assignee=%s, vrf=%s, deadline=%s, source=%s)"
-                 assignee verification_id dl deadline_source
-             in
-             (match
-                Workspace.force_cancel_task_r
-                  config
-                  ~agent_name:"system"
-                  ~task_id:task.id
-                  ~reason:cancel_reason
-                  ()
-              with
-              | Ok _ -> ()
-              | Error e ->
-                Log.Task.error
-                  ~keeper_name:task.id
-                  "verification timeout transition failed (task=%s vrf=%s): %s"
-                  task.id verification_id
-                  (Masc_domain.show_masc_error e))
-           | Some _ -> ()
-           | None -> ())
-        | Todo | Claimed _ | InProgress _ | Done _ | Cancelled _ -> ()
-      ) backlog.tasks
-    with
-    | Eio.Cancel.Cancelled _ as e -> raise e
-    | exn ->
-      Log.Task.error "verification timeout check failed: %s"
-        (Printexc.to_string exn)
+  let _ = config in
+  ()
 ;;

--- a/lib/workspace/workspace_task_lifecycle.ml
+++ b/lib/workspace/workspace_task_lifecycle.ml
@@ -124,8 +124,9 @@ let decide
            { assignee
            ; submitted_at = now
            ; verification_id = new_verification_id ()
-           ; deadline =
-               verification_deadline ~now ~timeout_seconds:verification_timeout_seconds
+           (* RFC-0220: a fresh submission has no verifier yet. [deadline]
+              dropped per I2 (no per-obligation wall-clock deadline). *)
+           ; phase = Masc_domain.Awaiting_verifier
            })
     else Error Invalid_transition
   | ( Masc_domain.Submit_for_verification

--- a/lib/workspace/workspace_task_schedule.ml
+++ b/lib/workspace/workspace_task_schedule.ml
@@ -28,38 +28,15 @@ let task_is_claim_pool_candidate (task : Masc_domain.task) =
   Masc_domain.task_claim_next_action_is_claimable task
 ;;
 
-type verification_claim_state =
-  [ `Pending
-  | `Assigned
-  | `Passed
-  | `Rejected
-  ]
-
-let verification_claim_state_of_status (status : Workspace_verification_store.request_status) =
-  match status with
-  | `Pending -> `Pending
-  | `Assigned _ -> `Assigned
-  | `Completed `Pass -> `Passed
-  | `Completed (`Fail _ | `Partial _) -> `Rejected
-;;
-
-let latest_verification_status_by_task config =
-  let latest = Hashtbl.create 16 in
-  Workspace_verification_store.list_request_headers config.base_path
-  |> List.iter (fun (req : Workspace_verification_store.request_header) ->
-    let state = verification_claim_state_of_status req.status in
-    match Hashtbl.find_opt latest req.task_id with
-    | Some (latest_created_at, _) when latest_created_at >= req.created_at -> ()
-    | Some _ | None -> Hashtbl.replace latest req.task_id (req.created_at, state));
-  latest
-;;
-
-let verification_blocks_claim latest_status_by_task (task : Masc_domain.task) =
-  match Hashtbl.find_opt latest_status_by_task task.id with
-  | Some (_, `Pending) | Some (_, `Assigned) -> true
-  | Some (_, `Rejected) -> false
-  | Some (_, `Passed) | None -> false
-;;
+(* RFC-0220 §3.2: verification state no longer gates the worker claim pool.
+   The cross-store join (request_status -> claim eligibility) is removed: an
+   AwaitingVerification obligation stays claimable by a verifier (§3.5), and a
+   drifted Todo task with a dangling Pending evidence record is just a normal
+   claimable Todo (the evidence record is no longer read for scheduling). This
+   removal is the part that makes the §1.1 stranding disappear — there is
+   nothing left to drift against. (The now-always-empty [verification_blocked_*]
+   plumbing + the [verification_blocked_count] field are cosmetic dead code,
+   removed in a follow-up per §11.) *)
 
 let underscore_name = Workspace_task_receipts.underscore_name
 let hyphen_name = Workspace_task_receipts.hyphen_name
@@ -348,10 +325,8 @@ let claim_next_r
                  false)
             all_todo
         in
-        let latest_verification_status = latest_verification_status_by_task config in
-        let verification_blocked_todo =
-          List.filter (verification_blocks_claim latest_verification_status) all_todo
-        in
+        (* RFC-0220 §3.2: no verification-based exclusion from the claim pool. *)
+        let verification_blocked_todo : Masc_domain.task list = [] in
         if blocked_todo <> []
         then
           log_event

--- a/lib/workspace/workspace_task_schedule.mli
+++ b/lib/workspace/workspace_task_schedule.mli
@@ -5,30 +5,11 @@ open Masc_domain
 include module type of Workspace_utils
 include module type of Workspace_state
 
-(** Lifecycle state of a verification request, used by the claim
-    gate to decide whether a task can be reclaimed. *)
-type verification_claim_state =
-  [ `Pending
-  | `Assigned
-  | `Passed
-  | `Rejected
-  ]
-
 val task_status_label : Masc_domain.task_status -> string
 val task_is_claim_pool_candidate : Masc_domain.task -> bool
 
-val verification_claim_state_of_status
-  :  Workspace_verification_store.request_status
-  -> verification_claim_state
-
-val latest_verification_status_by_task
-  :  config
-  -> (string, float * verification_claim_state) Hashtbl.t
-
-val verification_blocks_claim
-  :  (string, 'a * verification_claim_state) Hashtbl.t
-  -> Masc_domain.task
-  -> bool
+(* RFC-0220 §3.2: claim-pool verification gate functions removed
+   (verification no longer gates the claim pool). *)
 
 val underscore_name : string -> string
 val hyphen_name : string -> string

--- a/test/test_task_cache_invariant_13397.ml
+++ b/test/test_task_cache_invariant_13397.ml
@@ -33,7 +33,7 @@ let status_awaiting =
     { assignee = "k1"
     ; submitted_at = now
     ; verification_id = "req-1"
-    ; deadline = None
+    ; phase = Awaiting_verifier
     }
 
 let test_is_terminal_done () =

--- a/test/test_task_status_label_10421.ml
+++ b/test/test_task_status_label_10421.ml
@@ -24,7 +24,7 @@ let awaiting =
     assignee = "k1";
     submitted_at = now_iso;
     verification_id = "req-1";
-    deadline = None;
+    phase = Awaiting_verifier;
   }
 let done_ = T.Done {
   assignee = "k1";

--- a/test/test_tool_workspace_coverage.ml
+++ b/test/test_tool_workspace_coverage.ml
@@ -859,7 +859,7 @@ let () =
     let h =
       next_hint
         (Masc_domain.AwaitingVerification
-           { assignee = "a"; submitted_at = "t"; verification_id = "v"; deadline = None })
+           { assignee = "a"; submitted_at = "t"; verification_id = "v"; phase = Masc_domain.Awaiting_verifier })
     in
     assert (str_contains h "approve");
     assert (str_contains h "reject"))

--- a/test/test_verification_fsm.ml
+++ b/test/test_verification_fsm.ml
@@ -224,29 +224,6 @@ let test_submit_for_verification_moves_to_awaiting () =
       Alcotest.(check string) "status" "awaiting_verification"
         (status_string config task_id))
 
-let test_submit_for_verification_sets_timeout_deadline () =
-  with_env "MASC_VERIFICATION_TIMEOUT_DEADLINE_SEC" "86400" @@ fun () ->
-  with_temp_config ~fsm_enabled:true @@ fun config ->
-    let task_id = add_strict_task config in
-    claim_and_start config "worker" task_id;
-    match Workspace.transition_task_r config ~agent_name:"worker"
-            ~task_id ~action:Masc_domain.Submit_for_verification () with
-    | Error e -> Alcotest.fail ("submit failed: " ^ Masc_domain.show_masc_error e)
-    | Ok _ ->
-      match get_task config task_id with
-      | Some { task_status =
-                 Masc_domain.AwaitingVerification { submitted_at; deadline = Some deadline; _ };
-               _ } ->
-        let submitted_ts = Masc_domain.parse_iso8601 submitted_at in
-        let deadline_ts = Masc_domain.parse_iso8601 deadline in
-        Alcotest.(check (float 0.0)) "deadline offset"
-          86400.0
-          (deadline_ts -. submitted_ts)
-      | Some { task_status = Masc_domain.AwaitingVerification { deadline = None; _ }; _ } ->
-        Alcotest.fail "awaiting verification deadline missing"
-      | Some _ -> Alcotest.fail "task is not awaiting verification"
-      | None -> Alcotest.fail "task not found"
-
 let test_submit_for_verification_from_claimed_moves_to_awaiting () =
   with_temp_config ~fsm_enabled:true (fun config ->
     let task_id = add_strict_task config in
@@ -808,25 +785,6 @@ let test_reject_retry_recovers_completed_verdict_orphan () =
            Astring.String.is_infix ~affix:"retry after orphan" reason
          | _ -> false))
 
-let test_claim_next_skips_pending_verification_tasks () =
-  with_temp_config ~fsm_enabled:true (fun config ->
-    let task_1 = add_strict_task config in
-    let task_2 = add_strict_task config in
-    claim_and_start config "worker" task_1;
-    (match Workspace.transition_task_r config ~agent_name:"worker"
-             ~task_id:task_1 ~action:Masc_domain.Submit_for_verification () with
-     | Ok _ -> ()
-     | Error e -> Alcotest.fail ("submit failed: " ^ Masc_domain.show_masc_error e));
-    ignore
-      (create_pending_request config ~task_id:task_1 ~worker:"worker"
-         ~request_id:"vrf-pending-claim-next");
-    Workspace.claim_next_r config ~agent_name:"worker" ()
-    |> expect_claim_next_claimed ~task_id:task_2 ~released_task_id:None;
-    Alcotest.(check string) "pending task remains awaiting_verification"
-      "awaiting_verification" (status_string config task_1);
-    Workspace.claim_next_r config ~agent_name:"other" ()
-    |> expect_claim_next_no_unclaimed)
-
 let test_claim_next_preserves_rejected_verification_owner_task () =
   with_temp_config ~fsm_enabled:true (fun config ->
     let task_1 = add_strict_task config in
@@ -854,28 +812,6 @@ let test_claim_next_preserves_rejected_verification_owner_task () =
     |> expect_claim_next_claimed ~task_id:task_1 ~released_task_id:None;
     Workspace.claim_next_r config ~agent_name:"other" ()
     |> expect_claim_next_claimed ~task_id:task_2 ~released_task_id:None)
-
-let test_claim_next_blocks_pending_requests_stored_only_under_masc_root () =
-  with_temp_config ~fsm_enabled:true (fun config ->
-    let task_id = add_strict_task config in
-    let req =
-      match Verification.create_request ~base_path:config.Workspace.base_path
-              ~task_id ~output:`Null ~criteria:[] ~worker:"worker"
-              ~request_id:"vrf-masc-root-only" () with
-      | Ok req -> req
-      | Error e -> Alcotest.fail ("create_request failed: " ^ e)
-    in
-    let active_path =
-      Filename.concat (Filename.concat (Workspace_utils.masc_dir config) "verifications")
-        (req.id ^ ".json")
-    in
-    Alcotest.(check bool) "request stored under .masc" true
-      (Sys.file_exists active_path);
-    Alcotest.(check bool) "legacy root verifications absent" false
-      (Sys.file_exists
-         (Filename.concat config.Workspace.base_path "verifications"));
-    Workspace.claim_next_r config ~agent_name:"other" ()
-    |> expect_claim_next_no_eligible)
 
 let test_self_approval_blocked () =
   with_temp_config ~fsm_enabled:true (fun config ->
@@ -972,119 +908,6 @@ let test_fsm_disabled_submit_fails () =
       Alcotest.(check bool) "error mentions FSM disabled" true
         (Astring.String.is_infix ~affix:"not enabled" msg))
 
-(* ================================================================ *)
-(* Verification timeout transition (check_timeouts)                  *)
-(* ================================================================ *)
-
-(* Move a task's deadline far into the past so the next check_timeouts
-   cycle sees [now > deadline_ts] without sleeping. *)
-let force_deadline_past config task_id =
-  let backlog = Workspace.read_backlog config in
-  let past_iso =
-    Masc_domain.iso8601_of_unix_seconds (Time_compat.now () -. 3600.0)
-  in
-  let new_tasks =
-    List.map (fun (t : Masc_domain.task) ->
-      if t.id <> task_id then t
-      else match t.task_status with
-        | Masc_domain.AwaitingVerification fields ->
-          { t with task_status =
-              Masc_domain.AwaitingVerification { fields with deadline = Some past_iso } }
-        | _ -> t)
-      backlog.tasks
-  in
-  Workspace.write_backlog config { backlog with tasks = new_tasks }
-
-let force_missing_deadline_submitted_at_past config task_id =
-  let backlog = Workspace.read_backlog config in
-  let timeout = Env_config_runtime.Verification.timeout_deadline_seconds () in
-  let submitted_at =
-    Masc_domain.iso8601_of_unix_seconds
-      (Time_compat.now () -. timeout -. 3600.0)
-  in
-  let new_tasks =
-    List.map
-      (fun (t : Masc_domain.task) ->
-         if t.id <> task_id
-         then t
-         else
-           match t.task_status with
-           | Masc_domain.AwaitingVerification fields ->
-             { t with
-               task_status =
-                 Masc_domain.AwaitingVerification
-                   { fields with submitted_at; deadline = None }
-             }
-           | _ -> t)
-      backlog.tasks
-  in
-  Workspace.write_backlog config { backlog with tasks = new_tasks }
-
-let test_check_timeouts_transitions_awaiting_to_cancelled () =
-  with_temp_config ~fsm_enabled:true (fun config ->
-    let task_id = add_strict_task config in
-    claim_and_start config "worker" task_id;
-    (match Workspace.transition_task_r config ~agent_name:"worker"
-             ~task_id ~action:Masc_domain.Submit_for_verification () with
-     | Error e -> Alcotest.fail ("submit failed: " ^ Masc_domain.show_masc_error e)
-     | Ok _ -> ());
-    Alcotest.(check string) "pre-check status" "awaiting_verification"
-      (status_string config task_id);
-    force_deadline_past config task_id;
-    Verification_protocol.check_timeouts ~config;
-    Alcotest.(check string) "post-check status" "cancelled"
-      (status_string config task_id);
-    match get_task config task_id with
-    | Some { task_status = Masc_domain.Cancelled { cancelled_by; reason; _ }; _ } ->
-      Alcotest.(check string) "cancelled_by system" "system" cancelled_by;
-      let reason_str = Option.value reason ~default:"" in
-      Alcotest.(check bool)
-        "reason mentions verification deadline" true
-        (Astring.String.is_infix ~affix:"verification deadline" reason_str)
-    | _ -> Alcotest.fail "task is not Cancelled after check_timeouts")
-
-let test_check_timeouts_transitions_legacy_missing_deadline () =
-  with_temp_config ~fsm_enabled:true (fun config ->
-    let task_id = add_strict_task config in
-    claim_and_start config "worker" task_id;
-    (match
-       Workspace.transition_task_r
-         config
-         ~agent_name:"worker"
-         ~task_id
-         ~action:Masc_domain.Submit_for_verification
-         ()
-     with
-     | Error e -> Alcotest.fail ("submit failed: " ^ Masc_domain.show_masc_error e)
-     | Ok _ -> ());
-    force_missing_deadline_submitted_at_past config task_id;
-    Verification_protocol.check_timeouts ~config;
-    Alcotest.(check string) "post-check status" "cancelled"
-      (status_string config task_id);
-    match get_task config task_id with
-    | Some { task_status = Masc_domain.Cancelled { reason; _ }; _ } ->
-      let reason_str = Option.value reason ~default:"" in
-      Alcotest.(check bool)
-        "reason records fallback source"
-        true
-        (Astring.String.is_infix ~affix:"source=submitted_at_fallback" reason_str)
-    | _ -> Alcotest.fail "task is not Cancelled after check_timeouts")
-
-let test_check_timeouts_idempotent_after_cancel () =
-  with_temp_config ~fsm_enabled:true (fun config ->
-    let task_id = add_strict_task config in
-    claim_and_start config "worker" task_id;
-    (match Workspace.transition_task_r config ~agent_name:"worker"
-             ~task_id ~action:Masc_domain.Submit_for_verification () with
-     | Error e -> Alcotest.fail ("submit failed: " ^ Masc_domain.show_masc_error e)
-     | Ok _ -> ());
-    force_deadline_past config task_id;
-    Verification_protocol.check_timeouts ~config;
-    let status_after_first = status_string config task_id in
-    Verification_protocol.check_timeouts ~config;
-    let status_after_second = status_string config task_id in
-    Alcotest.(check string) "first check cancels" "cancelled" status_after_first;
-    Alcotest.(check string) "second check is no-op" "cancelled" status_after_second)
 
 (* ================================================================ *)
 (* Test suite                                                        *)
@@ -1095,8 +918,6 @@ let () =
     ("transitions_enabled", [
       Alcotest.test_case "submit moves to awaiting_verification" `Quick
         test_submit_for_verification_moves_to_awaiting;
-      Alcotest.test_case "submit sets timeout deadline" `Quick
-        test_submit_for_verification_sets_timeout_deadline;
       Alcotest.test_case "submit from claimed moves to awaiting_verification"
         `Quick test_submit_for_verification_from_claimed_moves_to_awaiting;
       Alcotest.test_case "submit prepare failure keeps task in_progress"
@@ -1129,12 +950,8 @@ let () =
         "reject retry recovers completed verdict orphan"
         `Quick
         test_reject_retry_recovers_completed_verdict_orphan;
-      Alcotest.test_case "claim_next skips pending verification tasks" `Quick
-        test_claim_next_skips_pending_verification_tasks;
       Alcotest.test_case "claim_next preserves rejected owner task" `Quick
         test_claim_next_preserves_rejected_verification_owner_task;
-      Alcotest.test_case ".masc pending verification blocks claim_next" `Quick
-        test_claim_next_blocks_pending_requests_stored_only_under_masc_root;
       Alcotest.test_case "self-approval blocked" `Quick
         test_self_approval_blocked;
       Alcotest.test_case "self-rejection blocked" `Quick
@@ -1149,15 +966,5 @@ let () =
         test_submit_verdict_pass;
       Alcotest.test_case "submit_verdict Fail preserves reason" `Quick
         test_submit_verdict_fail;
-    ]);
-    ("timeout_check", [
-      Alcotest.test_case "check_timeouts transitions AwaitingVerification to Cancelled"
-        `Quick test_check_timeouts_transitions_awaiting_to_cancelled;
-      Alcotest.test_case
-        "check_timeouts expires legacy AwaitingVerification without deadline"
-        `Quick
-        test_check_timeouts_transitions_legacy_missing_deadline;
-      Alcotest.test_case "check_timeouts is idempotent after cancellation"
-        `Quick test_check_timeouts_idempotent_after_cancel;
     ]);
   ]

--- a/test/test_workspace.ml
+++ b/test/test_workspace.ml
@@ -854,7 +854,7 @@ let test_release_stale_claims_releases_stale_verification () =
                    { assignee = stale_nick
                    ; submitted_at = old_time
                    ; verification_id = "vrf-test"
-                   ; deadline = None
+                   ; phase = Masc_domain.Awaiting_verifier
                    }
              }
            else task)

--- a/test/test_workspace_goal_index.ml
+++ b/test/test_workspace_goal_index.ml
@@ -106,7 +106,7 @@ let test_open_count_only_non_terminal () =
     ; make_task ~id:"t3" ~goal_id:(Some "g1") ~status:cancelled_status
     ; make_task ~id:"t4" ~goal_id:(Some "g1") ~status:(Claimed { assignee = "a"; claimed_at = "" })
     ; make_task ~id:"t5" ~goal_id:(Some "g1") ~status:(InProgress { assignee = "a"; started_at = "" })
-    ; make_task ~id:"t6" ~goal_id:(Some "g1") ~status:(AwaitingVerification { assignee = "a"; submitted_at = ""; verification_id = ""; deadline = None })
+    ; make_task ~id:"t6" ~goal_id:(Some "g1") ~status:(AwaitingVerification { assignee = "a"; submitted_at = ""; verification_id = ""; phase = Awaiting_verifier })
     ]
   in
   let index = Workspace_goal_index.build_goal_task_index tasks in

--- a/test/test_workspace_task_lifecycle.ml
+++ b/test/test_workspace_task_lifecycle.ml
@@ -21,7 +21,7 @@ let mk_in_progress assignee =
 
 let mk_awaiting assignee =
   D.AwaitingVerification
-    { assignee; submitted_at = now; verification_id = "v1"; deadline = None }
+    { assignee; submitted_at = now; verification_id = "v1"; phase = Awaiting_verifier }
 ;;
 
 let mk_done assignee =
@@ -201,8 +201,11 @@ let test_awaiting_verification_by_other () =
     L.valid_next_actions
       ~verification_enabled:true ~same_agent:false ~force:false ~task_status
   in
-  (* Approver path: same_agent=false (not the submitter) → Approve / Reject ok. *)
-  let expected = [ D.Approve_verification; D.Reject_verification ] in
+  (* same_agent=false (not the submitter): a verifier may Approve / Reject, and
+     may also Claim the task to verify it (cross-agent verification dispatch,
+     Issue #19314 / RFC-0220 §3.5). The prior expectation predated #19314's
+     cross-agent Claim arm in [decide]; align it with the actual behavior. *)
+  let expected = [ D.Claim; D.Approve_verification; D.Reject_verification ] in
   assert_actions ~ctx:"awaiting-by-other" ~expected ~actual;
   assert_consistent_with_decide
     ~ctx:"awaiting-by-other/consistency" ~verification_enabled:true


### PR DESCRIPTION
## Goal

RFC-0220 PR-1 (foundation). Make the illegal **"task `Todo` + verification request `Pending`"** pair — the cross-store drift that stranded task-628/629 for 8 days — *unrepresentable*, and remove the Todo-scoped claim-pool gate that stranded such tasks with no non-destructive rescue.

This is the F3 fix from the 2026-06-09 keeper fiber/await audit. It supports invariant **I2**: the only legitimate timeout is the OAS provider transport timeout; per-obligation wall-clock deadlines are not used as control flow.

RFC: **RFC-0220** (`docs/rfc/RFC-0220-*`, merged #20570).

## Changes (13 files)

- **`types_core`**: add `verification_phase = Awaiting_verifier | Verifier_assigned of { verifier }`; replace `AwaitingVerification`'s `deadline : string option` with `phase : verification_phase`. Codec carries `phase` inline with **migration tolerance** — legacy backlogs (`deadline` present / `phase` absent) decode to `Awaiting_verifier`.
- **`workspace_task_schedule` (.ml/.mli)**: delete the Todo-scoped cross-store gate (`verification_claim_state*`, `latest_verification_status_by_task`, `verification_blocks_claim`). With the verification state folded into `task_status` there is no second store to drift against, so a drifted `Todo` task is just a normal claimable `Todo`. This unsticks task-628/629.
- **`verification_protocol`**: neuter `check_timeouts` — the destructive 24h deadline rescue is removed (it discarded work; I2-forbidden heuristic).
- **Tests**: drop obsolete deadline/timeout + the 2 claim-gate tests; fix `AwaitingVerification` construction sites (`deadline -> phase`) across 6 files; correct the stale `awaiting-by-other` expectation to include `Claim`.

## Local verification

- `dune build --root . @check` → **exit 0** (full build green).
- `test/test_verification_fsm.exe` → **20/20** (this PR's domain).
- `test/test_workspace_task_lifecycle.exe` → **all assertions passed**.

## Pre-existing failures (proven on clean `origin/main` @ `5981a45`, NOT regressions)

- `test_workspace` 7 failures (rejoin/heartbeat/messages) — **identical on clean main**; standalone `dune exec` lacks the agent-join config dir.
- `test_tool_workspace_coverage` RNG `default generator not initialized` — that file has no `Mirage_crypto_rng_unix.use_default ()` init line; standalone-only.
- `awaiting-by-other` showing `[approve,claim,reject]` — **fails identically on clean main** (`expected [approve,reject]` vs `actual [approve,claim,reject]`). The `Claim` arm is #19314's cross-agent verifier dispatch (`task_claim_decision`), present on main; this PR only corrects the test's stale expectation to match `decide`/`valid_next_actions`.

## Deferred to PR-2 (RFC-0220; pre-existing #19314 interactions, not introduced here)

- **§3.5** `claim_next_r` (`workspace_task_schedule.ml:459`) overwrites a claimed `AwaitingVerification` task with `Claimed`, clobbering the verification obligation. `AwaitingVerification` has been claimable via `claim_next_r` since **#19314** (`task_claim_decision:607`); this PR does **not** change that reachability (the deleted gate was Todo-only — verified via `git show origin/main`). PR-2 routes it through the verifier-preserve path (`workspace_task_claim.ml:151-158`).
- **§8** deterministic reconciler that honors a prior submission instead of re-doing.
- Cosmetic: remove the now-always-zero `verification_blocked_count` plumbing.

RFC-WAIVED: not in a credential/identity/operator/sandbox/hooks subsystem (verification FSM + task scheduling). RFC-0220 governs this change.
