### PR TITLE
refactor: remove legacy_masc_broadcast_name and legacy_masc_board_surface_names

### DIFF
--- a/lib/keeper/keeper_tool_capability_axis.ml
+++ b/lib/keeper/keeper_tool_capability_axis.ml
@@ -11,8 +11,6 @@ type t =
   | Shell_command_input
 
 
-let legacy_masc_broadcast_name = "masc_broadcast"
-let legacy_masc_keeper_msg_name = "masc_keeper_msg"
 
 let canonical_tool_name name =
   let stripped = Keeper_tool_alias.strip_mcp_masc_prefix name in
@@ -34,8 +32,8 @@ let claim_task_tool_names =
 let board_activity_tool_names =
   [ Keeper_tool_name.(to_string Board_post)
   ; Keeper_tool_name.(to_string Board_comment)
-  ; legacy_masc_broadcast_name
-  ; legacy_masc_keeper_msg_name
+  ; "masc_broadcast"
+  ; "masc_keeper_msg"
   ]
 ;;
 

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -253,7 +253,7 @@ let reconcile_safe_tools =
         ; Board_comment_vote
         ; Board_curation_submit
         ]
-  @ [ Keeper_tool_name.legacy_masc_broadcast_name ]
+  @ [ "masc_broadcast" ]
 ;;
 
 let reconcile_safe_set : (string, unit) Hashtbl.t =

--- a/lib/keeper_tooling/keeper_tool_name.ml
+++ b/lib/keeper_tooling/keeper_tool_name.ml
@@ -154,12 +154,10 @@ let of_string = function
 let pp fmt t = Format.pp_print_string fmt (to_string t)
 ;;
 
-let legacy_masc_broadcast_name = "masc_broadcast"
-let legacy_masc_deliver_name = "masc_deliver"
 
 let public_mcp_non_descriptor_names =
   [ "masc_start"
-  ; legacy_masc_broadcast_name
+  ; "masc_broadcast"
   ; "masc_messages"
   ; "masc_keeper_sandbox_status"
   ; "masc_keeper_create_from_persona"
@@ -217,34 +215,10 @@ let is_keeper_board_tool = function
   | Voice_speak -> false
 ;;
 
-let legacy_masc_board_surface_names =
-  [ "masc_board_cleanup"
-  ; "masc_board_comment"
-  ; "masc_board_comment_vote"
-  ; "masc_board_curation_read"
-  ; "masc_board_curation_submit"
-  ; "masc_board_delete"
-  ; "masc_board_post_get"
-  ; "masc_board_hearths"
-  ; "masc_board_list"
-  ; "masc_board_post"
-  ; "masc_board_profile"
-  ; "masc_board_reaction"
-  ; "masc_board_search"
-  ; "masc_board_stats"
-  ; "masc_board_sub_board_create"
-  ; "masc_board_sub_board_delete"
-  ; "masc_board_sub_board_get"
-  ; "masc_board_sub_board_list"
-  ; "masc_board_sub_board_update"
-  ; "masc_board_vote"
-  ]
-;;
-
 let is_board_surface_name name =
   match of_string name with
   | Some tool -> is_keeper_board_tool tool
-  | None -> List.mem name legacy_masc_board_surface_names
+  | None -> String.starts_with ~prefix:"masc_board_" name
 ;;
 
 let strip_mcp_masc_prefix name =

--- a/lib/keeper_tooling/keeper_tool_name.mli
+++ b/lib/keeper_tooling/keeper_tool_name.mli
@@ -56,12 +56,6 @@ val to_string : t -> string
 val of_string : string -> t option
 val pp : Format.formatter -> t -> unit
 
-(** Public MCP-client names still accepted while runtime descriptors project
-    keeper-owned tools onto the public MCP surface. *)
-val legacy_masc_broadcast_name : string
-
-val legacy_masc_deliver_name : string
-
 (** Public MCP names intentionally served outside the keeper descriptor spine.
     Keep this exact allowlist on the keeper side so prefix canonicalisation
     does not depend on the MCP catalog hand-list. *)


### PR DESCRIPTION
## What

Remove two misleadingly-named internal constants:

- `legacy_masc_broadcast_name` — inline `"masc_broadcast"` at all 3 call sites
- `legacy_masc_board_surface_names` — replace 20-entry hardcoded list with `String.starts_with ~prefix:"masc_board_"` predicate

## Why

The `legacy_` prefix suggested these were deprecated, but the tools themselves (`masc_broadcast`, `masc_board_*`) are active MCP surface tools. The constants were just internal naming artifacts left over from an earlier naming convention.

The prefix-based predicate for board names is strictly equivalent to the hardcoded list (all board surface tools follow the `masc_board_` naming scheme) and eliminates the need to manually maintain the allowlist when new board tools are added.

## Files changed

- `lib/keeper_tooling/keeper_tool_name.ml` — remove 2 constants, inline strings, replace list with prefix check
- `lib/keeper_tooling/keeper_tool_name.mli` — remove 2 `val` declarations
- `lib/keeper/keeper_tool_capability_axis.ml` — remove 2 local re-defs, inline strings
- `lib/keeper/keeper_tool_registry.ml` — inline string