### PR TITLE
feat(telemetry): emit telemetry_event on build_runtime_execution Ok path (task-688)

### DIFF
--- a/lib/keeper/keeper_event_publisher.ml
+++ b/lib/keeper/keeper_event_publisher.ml
@@ -173,3 +173,35 @@ let publish_audit_event ~id ~ts ~actor ~kind ?target ~summary ~severity
     ("payload", payload_json);
   ] in
   masc_publish (Agent_sdk.Event_bus.mk_event (Custom ("masc.audit_event", event_payload)))
+
+(** {1 Runtime Execution Telemetry Events} *)
+
+(** Publish a telemetry event when runtime execution parameters are
+    successfully built during keeper pre-dispatch. The
+    [keeper_telemetry_consumer] observes [Custom("telemetry_event", _)]
+    on the bus and increments [masc_keeper_telemetry_events_consumed_total].
+    Before this publisher existed, the Ok path of
+    [build_runtime_execution] never emitted a telemetry event, so the
+    counter stayed at zero despite successful turn setups. *)
+let publish_runtime_execution_built
+    ~keeper_name
+    ~(execution : Keeper_turn_runtime_budget.runtime_execution)
+    ~generation
+  =
+  let max_ctx_res_str =
+    match execution.max_context_resolution with
+    | Keeper_context_runtime.Resolved_to n -> string_of_int n
+    | Unresolved -> "unresolved"
+  in
+  let payload = `Assoc [
+    ("keeper_name", `String keeper_name);
+    ("runtime_id", `String execution.runtime_id);
+    ("max_tokens", `Int execution.max_tokens);
+    ("max_context", `Int execution.max_context);
+    ("max_context_resolution", `String max_ctx_res_str);
+    ("temperature", `Float execution.temperature);
+    ("generation", `Int generation);
+    ("timestamp", `Float (Time_compat.now ()));
+  ] in
+  masc_publish
+    (Agent_sdk.Event_bus.mk_event (Custom ("telemetry_event", payload)))

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -211,6 +211,10 @@ let run_keeper_cycle
               ~trajectory_outcome:Trajectory.Completed
               ~keeper_turn_id
               ();
+            Keeper_event_publisher.publish_runtime_execution_built
+              ~keeper_name:meta.name
+              ~execution:initial_execution
+              ~generation;
             let turn_id = keeper_turn_id in
             (match
                Keeper_turn_livelock.guard_and_record_turn_start


### PR DESCRIPTION
## Problem (task-688, P1)

`build_runtime_execution` Ok path never emits a `telemetry_event` to the Event_bus. `keeper_telemetry_consumer` subscribes to `Custom("telemetry_event", _)` but receives zero events on success, so `masc_keeper_telemetry_events_consumed_total` stays at 0.

## Changes

- `lib/keeper/keeper_event_publisher.ml`: Add `publish_runtime_execution_built` carrying `runtime_id`, `max_tokens`, `max_context`, `max_context_resolution`, `temperature`, `generation`.
- `lib/keeper/keeper_unified_turn.ml`: Call it from the Ok branch of `build_runtime_execution`, right after `record_pre_dispatch_terminal_observation`.

## Before

```
Ok path: record observation → livelock check → prompt build
(telemetry_event counter: 0)
```

## After

```
Ok path: record observation → emit telemetry_event → livelock check → prompt build
(telemetry_event counter: +1 per successful pre-dispatch)
```
