### PR TITLE
fix(otel): attach dispatch_hook attrs to ambient span to keep traces at spans=1

### DIFF
--- a/lib/otel_dispatch_hook/otel_dispatch_hook.ml
+++ b/lib/otel_dispatch_hook/otel_dispatch_hook.ml
@@ -194,9 +194,13 @@ let tool_span_attrs (result : Tool_result.result) =
   gen_ai_attrs @ request_context_attrs () @ status_attrs
 ;;
 
-(** Record a tool call as an OTel span. *)
+(** Record a tool call as an OTel span or attach to the ambient dispatch span.
+
+    When an ambient dispatch span exists (e.g. [Tool_telemetry.with_span]),
+    attributes and status are attached to that span so the trace stays at
+    [spans=1].  Only falls back to creating a standalone span when no ambient
+    scope is present. *)
 let on_tool_result (result : Tool_result.result) : unit =
-  (* OTel span: only when enabled *)
   if enabled ()
   then (
     let status =
@@ -208,11 +212,18 @@ let on_tool_result (result : Tool_result.result) : unit =
              ~message:(Tool_result.message result)
              ~code:OT.Span_status.Status_code_error)
     in
-    emit_span
-      ~name:(tool_call_span_name ~tool_name:(Tool_result.tool_name result))
-      ~attrs:(tool_span_attrs result)
-      ?status
-      ())
+    match OT.Scope.get_ambient_scope () with
+    | Some scope ->
+      (* Attach to the ambient dispatch span instead of creating a nested
+         child span.  Keeps per-tool traces at spans=1. *)
+      OT.Scope.add_attrs scope (fun () -> tool_span_attrs result);
+      Option.iter (OT.Scope.set_status scope) status
+    | None ->
+      emit_span
+        ~name:(tool_call_span_name ~tool_name:(Tool_result.tool_name result))
+        ~attrs:(tool_span_attrs result)
+        ?status
+        ())
 ;;
 
 (* Histogram + span emission fires only for handled results. Non-handled


### PR DESCRIPTION
## Summary

The Otel_dispatch_hook observer was creating a nested child span (tools/call <name>) under the tool_dispatch span, resulting in spans=2 per trace even with force_new_trace_id:true. This change attaches the GenAI semantic attributes and span status to the ambient dispatch span instead, keeping each tool dispatch trace at spans=1.

## Change

- Otel_dispatch_hook.on_tool_result: when an ambient OTel scope exists (set by Tool_telemetry.with_span), attach tool_span_attrs and status directly to that scope rather than calling emit_span.
- Falls back to creating a standalone span only when no ambient scope is present.

## Verification

- [x] dune build lib/otel_dispatch_hook/otel_dispatch_hook.cmxa compiles
- [ ] Deploy and verify spans=1 in Jaeger/Grafana

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>