### PR TITLE
fix: inline masc_deliver in keeper_tool_progress (missed in #20589)

### DIFF
--- a/lib/keeper/keeper_tool_progress.ml
+++ b/lib/keeper/keeper_tool_progress.ml
@@ -65,7 +65,7 @@ let completion_tool_names : string list =
      breaker). Without this, 4+ events/day were rejected as passive_only even
      though the LLM had decided no fit (sangsu/janitor/taskmaster on 2026-04-27
      00:17-00:58 UTC, idle_seconds 28-40h, claimable_count 44-46). *)
-  Keeper_tool_name.legacy_masc_deliver_name
+  "masc_deliver"
   :: List.map
        Keeper_tool_name.to_string
        Keeper_tool_name.


### PR DESCRIPTION
Missed reference when removing `legacy_masc_deliver_name` from `.mli` in #20589. Inline the string literal.