### PR TITLE
ci: exclude infrastructure/monitoring from retired-metrics ratchet (#20591)

### DIFF
--- a/scripts/lint/no-retired-metrics-backend.sh
+++ b/scripts/lint/no-retired-metrics-backend.sh
@@ -72,6 +72,7 @@ else
     --glob '!dashboard/node_modules/**' \
     --glob '!_build/**' \
     --glob '!scripts/lint/no-retired-metrics-backend.sh' \
+    --glob '!infrastructure/monitoring/**' \
     "$RETIRED_PATTERN" \
     "${existing_roots[@]}" \
     | sort -u >"$current_tmp" || true


### PR DESCRIPTION
## Problem

`Retired metrics backend ratchet` 체크가 모든 PR에서 false-fail. 원인은 `infrastructure/monitoring/` 내 VictoriaMetrics 설정 파일들이 Prometheus 프로토콜 식별자(`type: prometheus`, `prometheusremotewrite`)를 포함하고 있어서 ratchet가 이를 retired backend residue로 오판.

## Root Cause

VictoriaMetrics는 Prometheus wire-protocol을 사용하므로 Grafana datasource의 `type: prometheus`와 OTel collector의 `prometheusremotewrite` exporter는 **현재 활성 모니터링 스택의 정당한 프로토콜 식별자**임. Ratchet의 "active surface" 정의가 `infrastructure/monitoring/`까지 포함하면서 두 최근 프로젝트(Grafana 대시보드 추가 + Prometheus 코드 숙청)의 main-레벨 split-brain 발생.

## Fix

`rg --glob '!infrastructure/monitoring/**'` 추가. 22 hits → 0 hits.

## Verification

```bash
bash scripts/lint/no-retired-metrics-backend.sh --fail
# [no-retired-metrics-backend] OK
```

Clean origin/main에서도 동일하게 0 hits 확인.

## Scope

- Ratchet 검색 범위에서 `infrastructure/monitoring/` 제외
- "Retired backend in OCaml/active serving code" ≠ "Prometheus-protocol datasource in monitoring infra" 경계 명확화

Closes #20591

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>