### PR TITLE
fix(telemetry): break dependency cycle and type mismatch in keeper_event_publisher

### DIFF
--- a/lib/keeper/keeper_event_publisher.ml
+++ b/lib/keeper/keeper_event_publisher.ml
@@ -185,21 +185,20 @@ let publish_audit_event ~id ~ts ~actor ~kind ?target ~summary ~severity
     counter stayed at zero despite successful turn setups. *)
 let publish_runtime_execution_built
     ~keeper_name
-    ~(execution : Keeper_turn_runtime_budget.runtime_execution)
+    ~runtime_id
+    ~max_tokens
+    ~max_context
+    ~effective_budget
+    ~temperature
     ~generation
   =
-  let max_ctx_res_str =
-    match execution.max_context_resolution with
-    | Keeper_context_runtime.Resolved_to n -> string_of_int n
-    | Unresolved -> "unresolved"
-  in
   let payload = `Assoc [
     ("keeper_name", `String keeper_name);
-    ("runtime_id", `String execution.runtime_id);
-    ("max_tokens", `Int execution.max_tokens);
-    ("max_context", `Int execution.max_context);
-    ("max_context_resolution", `String max_ctx_res_str);
-    ("temperature", `Float execution.temperature);
+    ("runtime_id", `String runtime_id);
+    ("max_tokens", `Int max_tokens);
+    ("max_context", `Int max_context);
+    ("max_context_resolution", `String (string_of_int effective_budget));
+    ("temperature", `Float temperature);
     ("generation", `Int generation);
     ("timestamp", `Float (Time_compat.now ()));
   ] in

--- a/lib/keeper/keeper_event_publisher.mli
+++ b/lib/keeper/keeper_event_publisher.mli
@@ -129,3 +129,13 @@ val publish_audit_event :
     via SSE without polling.
 
     Shape: [{id, ts, actor, kind, target?, summary, severity, payload?}]. *)
+
+val publish_runtime_execution_built :
+  keeper_name:string ->
+  runtime_id:string ->
+  max_tokens:int ->
+  max_context:int ->
+  effective_budget:int ->
+  temperature:float ->
+  generation:int ->
+  unit

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -213,7 +213,11 @@ let run_keeper_cycle
               ();
             Keeper_event_publisher.publish_runtime_execution_built
               ~keeper_name:meta.name
-              ~execution:initial_execution
+              ~runtime_id:initial_execution.runtime_id
+              ~max_tokens:initial_execution.max_tokens
+              ~max_context:initial_execution.max_context
+              ~effective_budget:initial_execution.max_context_resolution.effective_budget
+              ~temperature:initial_execution.temperature
               ~generation;
             let turn_id = keeper_turn_id in
             (match


### PR DESCRIPTION
## Description
1. Broke the dependency cycle (`Audit_log -> Keeper_event_publisher -> ... -> Governance_pipeline -> Audit_log`) by decoupling `Keeper_event_publisher` from the `Keeper_turn_runtime_budget.runtime_execution` record type. 
   - `publish_runtime_execution_built` now accepts individual fields rather than the full `runtime_execution` record, preventing OCaml from importing modules that form a cycle.
2. Resolved type mismatch error in `keeper_event_publisher.ml` where `max_context_resolution` (a record type) was matched against variant constructors (`Resolved_to` / `Unresolved`).
3. Added the correct `val publish_runtime_execution_built` declaration in `keeper_event_publisher.mli`.
4. Updated the call site in `keeper_unified_turn.ml` to destruct the fields and pass them individually.

## Test Evidence
`dune build` completed successfully on `masc-mcp` after decoupling.