### PR TITLE
fix(telemetry): break dep cycle + fix type error from #20590

### DIFF
--- a/lib/keeper/keeper_event_publisher.ml
+++ b/lib/keeper/keeper_event_publisher.ml
@@ -185,21 +185,20 @@ let publish_audit_event ~id ~ts ~actor ~kind ?target ~summary ~severity
     counter stayed at zero despite successful turn setups. *)
 let publish_runtime_execution_built
     ~keeper_name
-    ~(execution : Keeper_turn_runtime_budget.runtime_execution)
+    ~runtime_id
+    ~max_tokens
+    ~max_context
+    ~max_context_resolution
+    ~temperature
     ~generation
   =
-  let max_ctx_res_str =
-    match execution.max_context_resolution with
-    | Keeper_context_runtime.Resolved_to n -> string_of_int n
-    | Unresolved -> "unresolved"
-  in
   let payload = `Assoc [
     ("keeper_name", `String keeper_name);
-    ("runtime_id", `String execution.runtime_id);
-    ("max_tokens", `Int execution.max_tokens);
-    ("max_context", `Int execution.max_context);
-    ("max_context_resolution", `String max_ctx_res_str);
-    ("temperature", `Float execution.temperature);
+    ("runtime_id", `String runtime_id);
+    ("max_tokens", `Int max_tokens);
+    ("max_context", `Int max_context);
+    ("max_context_resolution", `Int max_context_resolution);
+    ("temperature", `Float temperature);
     ("generation", `Int generation);
     ("timestamp", `Float (Time_compat.now ()));
   ] in

--- a/lib/keeper/keeper_event_publisher.mli
+++ b/lib/keeper/keeper_event_publisher.mli
@@ -109,6 +109,21 @@ val publish_keeper_dead :
     [detail]) so subscribers can filter on a stable topic and
     pull the structured fields directly. *)
 
+(** {1 Runtime Execution Telemetry} *)
+
+val publish_runtime_execution_built :
+  keeper_name:string ->
+  runtime_id:string ->
+  max_tokens:int ->
+  max_context:int ->
+  max_context_resolution:int ->
+  temperature:float ->
+  generation:int ->
+  unit
+(** Emits a [telemetry_event] when [build_runtime_execution] succeeds.
+    Extracts only primitive fields to avoid introducing module dependencies
+    that would create a dependency cycle through the keeper stack. *)
+
 (** {1 Audit Ledger Events} *)
 
 val publish_audit_event :

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -213,7 +213,13 @@ let run_keeper_cycle
               ();
             Keeper_event_publisher.publish_runtime_execution_built
               ~keeper_name:meta.name
-              ~execution:initial_execution
+              ~runtime_id:initial_execution.Keeper_turn_runtime_budget.runtime_id
+              ~max_tokens:initial_execution.Keeper_turn_runtime_budget.max_tokens
+              ~max_context:initial_execution.Keeper_turn_runtime_budget.max_context
+              ~max_context_resolution:
+                initial_execution.Keeper_turn_runtime_budget.max_context_resolution
+                  .Keeper_context_runtime.effective_budget
+              ~temperature:initial_execution.Keeper_turn_runtime_budget.temperature
               ~generation;
             let turn_id = keeper_turn_id in
             (match


### PR DESCRIPTION
Three build errors introduced by #20590:

1. **Dependency cycle**: Keeper_event_publisher took Keeper_turn_runtime_budget.runtime_execution, creating Audit_log→...→Governance_pipeline→Audit_log cycle. Fixed by taking primitive parameters.
2. **Type error**: max_context_resolution is a record, not a variant — Resolved_to pattern was invalid. Fixed by using .effective_budget field.
3. **Missing .mli export**: publish_runtime_execution_built was defined but not exported.