### PR TITLE
fix(keeper): surface rg stderr in Grep result so keepers can self-correct

### DIFF
--- a/lib/keeper/keeper_workspace_read_ops.ml
+++ b/lib/keeper/keeper_workspace_read_ops.ml
@@ -403,16 +403,33 @@ let try_handle
                      | Unix.WEXITED 0 | Unix.WEXITED 1 -> true
                      | _ -> false
                    in
+                   (* On non-zero rg exit (exit 2 for an unrecognized
+                      --type/--glob value or a missing path), surface rg's
+                      own stderr so the keeper can self-correct instead of
+                      retrying the same broken argv until the circuit
+                      breaker trips. exit_code.ml's generic exit-2 hint
+                      already promises "Check stderr for details", but the
+                      rg result dropped stderr — this fulfils that broken
+                      contract. It does NOT classify stderr (RFC-0089: no
+                      new string classifier; status.category stays typed,
+                      error_detail is a human-readable diagnostic). *)
+                   let trimmed_stderr = String.trim result.stderr in
+                   let error_detail =
+                     if is_ok || String.equal trimmed_stderr ""
+                     then []
+                     else [ "error_detail", `String trimmed_stderr ]
+                   in
                    Yojson.Safe.to_string
                      (`Assoc
-                         [ "ok", `Bool is_ok
-                         ; "op", `String op
-                         ; "path", `String target
-                         ; "pattern", `String pattern
-                         ; "via", `String "host"
-                         ; "status", Keeper_alerting_path.process_status_to_json result.status
-                         ; "matches", lines_to_json ~limit result.stdout
-                         ]))))
+                         ([ "ok", `Bool is_ok
+                          ; "op", `String op
+                          ; "path", `String target
+                          ; "pattern", `String pattern
+                          ; "via", `String "host"
+                          ; "status", Keeper_alerting_path.process_status_to_json result.status
+                          ; "matches", lines_to_json ~limit result.stdout
+                          ]
+                         @ error_detail)))))
   | "git_log" ->
     Some
       (match cwd_target () with

--- a/test/test_keeper_tool_search_files_containment.ml
+++ b/test/test_keeper_tool_search_files_containment.ml
@@ -306,6 +306,52 @@ let test_local_keeper_rg_file_path_uses_parent_workdir () =
       None
       (parse_field raw "error"))
 
+(* Regression: a keeper that asks rg for an extension that is not a
+   ripgrep type name (e.g. type="mli", a common ask in an OCaml repo)
+   makes rg exit 2. Previously the rg result dropped stderr, so the
+   keeper saw only the generic "usage_error / Wrong arguments" hint and
+   retried the same broken argv until the circuit breaker tripped. The
+   fix surfaces rg's own stderr in error_detail. This is a consumer-level
+   (transport-aware) assertion: handle_tool_search_files is the function
+   keeper_tool_runtime.ml returns verbatim to the keeper, so what we
+   assert here is exactly what the keeper receives — no producer-only gap. *)
+let test_local_keeper_rg_invalid_type_surfaces_stderr () =
+  setup ~keeper_name:"garnet" ~sandbox:Keeper_types_profile_sandbox.Local
+  @@ fun ~base:_ ~config ~meta ~playground ->
+  if not (Keeper_tool_execute_path.shell_command_available "rg") then ()
+  else (
+    let file_path = Filename.concat playground "demo.ml" in
+    ignore (Fs_compat.save_file_atomic file_path "let run_named = true\n");
+    let raw =
+      Keeper_tool_command_runtime.handle_tool_search_files
+        ~turn_sandbox_factory:None
+        ~exec_cache:None
+        ~config
+        ~meta
+        ~args:
+          (`Assoc
+            [
+              ("op", `String "rg");
+              ("pattern", `String "run_named");
+              ("path", `String "demo.ml");
+              ("type", `String "mli");
+            ])
+    in
+    Alcotest.(check (option bool)) "invalid rg type makes the call fail"
+      (Some false)
+      (parse_bool_field raw "ok");
+    match parse_field raw "error_detail" with
+    | None ->
+        Alcotest.failf
+          "error_detail absent: keeper cannot see why rg failed. raw=%s" raw
+    | Some detail ->
+        Alcotest.(check bool)
+          "error_detail surfaces rg's real unrecognized-type stderr"
+          true
+          (String_util.contains_substring
+             (String.lowercase_ascii detail)
+             "unrecognized file type"))
+
 let test_docker_keeper_blocks_find_outside () =
   setup ~keeper_name:"minjae" ~sandbox:Keeper_types_profile_sandbox.Docker
   @@ fun ~base ~config ~meta ~playground:_ ->
@@ -528,6 +574,9 @@ let () =
             test_docker_keeper_blocks_rg_outside;
           Alcotest.test_case "local keeper rg file path uses parent workdir"
             `Quick test_local_keeper_rg_file_path_uses_parent_workdir;
+          Alcotest.test_case
+            "local keeper rg invalid type surfaces stderr to keeper"
+            `Quick test_local_keeper_rg_invalid_type_surfaces_stderr;
           Alcotest.test_case "docker keeper blocks find outside" `Quick
             test_docker_keeper_blocks_find_outside;
           Alcotest.test_case "docker keeper allows inside playground"


### PR DESCRIPTION
## 목표

keeper의 Grep(`tool_search_files`, op=rg) 호출이 실패할 때 rg의 실제 stderr를 결과에 담아, keeper가 스스로 교정할 수 있게 한다.

## 배경 (진단 근거)

keeper 도구 실패 로그 6-lane sweep에서 확정한 server_bug. host-path rg 핸들러(`keeper_workspace_read_ops.ml`)가 stderr를 버려서, keeper가 rg type name이 아닌 값(예: `type="mli"`)이나 없는 경로를 주면 exit 2가 나는데, 결과에는 `exit_code.ml`의 generic `usage_error / "Wrong arguments or flags"` hint만 담겨 keeper가 원인을 알 수 없다. keeper는 같은 argv를 재시도하다 circuit breaker가 트립된다.

- fleet log(`~/me/.masc/logs/system_log_2026-06-0{7,8,9}.jsonl`): `type=string:3 -> error` 7건(06-09 6건, 증가 추세), 전부 `via:host`.
- 재현: `rg --type mli x /tmp` → `rg: unrecognized file type: mli`, exit 2 (rg type-list에 `mli` 없음; `ocaml`/`ml`만 존재).
- 같은 파일의 다른 op(git_diff 등 :281)는 이미 stderr를 노출하는데 rg path만 누락 — 같은 파일 내 비대칭.

## 변경

`keeper_workspace_read_ops.ml` host rg path: non-zero exit일 때 `error_detail`(trimmed stderr)를 결과 JSON에 추가.

- stderr를 **분류하지 않는다** (RFC-0089: string classifier 추가 금지). `status.category`는 typed로 유지하고 `error_detail`은 사람이 읽는 diagnostic.
- `exit_code.ml`의 hint가 이미 "Check stderr for details"라 약속하는데 결과가 stderr를 안 담던 broken contract를 이행하는 것 — 새 메커니즘 추가가 아니다.
- type→glob 자동 변환은 채택하지 않음 (unknown→permissive-default 안티패턴).

## 검증

- `test_local_keeper_rg_invalid_type_surfaces_stderr` 추가: `handle_tool_search_files`(keeper_tool_runtime.ml이 verbatim 반환하는 consumer-facing producer)를 type="mli"로 호출 → `ok=false` + `error_detail`에 rg의 실제 stderr 도달 검증 (transport-aware).
- `test_keeper_tool_search_files_containment` 18 tests 통과, 기존 17 회귀 없음.

## scope / 후속

- host 경로만. 관측 실패가 전부 `via:host`. docker-routed sandbox parity(`Keeper_sandbox_read_runner` stderr 노출)는 별도 RFC-gated 후속.
- RFC: `keeper_workspace_read_ops.ml`은 keeper_sandbox*/keeper_shell*/credential* 패턴 미매치 → non-gated.

WORKAROUND-WAIVED: "surface stderr"는 텔레메트리-as-fix(증상만 visible)가 아니라 keeper가 self-correct하도록 만드는 actionable de-mask다. silent failure를 그대로 두지 않고 실패를 actionable하게 만든다(circuit-breaker 루프 제거). 분류기 추가도, permissive default도 없다.
