### PR TITLE
feat(verification): bind verifier on claim, never clobber the obligation (RFC-0220 PR-2)

### DIFF
--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -291,6 +291,19 @@ type task_status =
   | Cancelled of { cancelled_by: string; cancelled_at: string; reason: string option }
 [@@deriving show]
 
+(** RFC-0220 §3.5: the [task_status] of an [AwaitingVerification] obligation
+    once [verifier] has claimed it as its satisfier. The obligation is preserved
+    (it stays in the verifier pool, and any non-submitter can still
+    approve/reject it — [decide]'s approval arms match the phase with [_]) and
+    the verifier is recorded in [phase]. Single construction site shared by the
+    FSM decider and both claim writers ([claim_task_r], [claim_next_r]) so the
+    bound-verifier shape never drifts across surfaces. The binding is advisory:
+    it records who is verifying, not who is permitted to — an abandoned
+    [Verifier_assigned] task is re-claimable by another verifier. *)
+let bind_verifier ~verifier ~assignee ~submitted_at ~verification_id =
+  AwaitingVerification
+    { assignee; submitted_at; verification_id; phase = Verifier_assigned { verifier } }
+
 (* Simple string representation for dashboard *)
 let task_status_to_string = function
   | Todo -> "todo"

--- a/lib/types/types_core.mli
+++ b/lib/types/types_core.mli
@@ -92,6 +92,18 @@ type task_status =
   | Cancelled of { cancelled_by : string; cancelled_at : string; reason : string option }
 [@@deriving show]
 
+(** RFC-0220 §3.5: [task_status] of an [AwaitingVerification] obligation once
+    [verifier] has claimed it as its satisfier — status preserved, verifier
+    recorded in [phase]. Single construction authority shared by [decide] and
+    both claim writers. Advisory binding: records who is verifying, not who is
+    permitted to (any non-submitter may still approve/reject). *)
+val bind_verifier
+  :  verifier:string
+  -> assignee:string
+  -> submitted_at:string
+  -> verification_id:string
+  -> task_status
+
 val task_status_to_string : task_status -> string
 val string_of_task_status : task_status -> string
 val task_status_icon : task_status -> string

--- a/lib/workspace/workspace_task_claim.ml
+++ b/lib/workspace/workspace_task_claim.ml
@@ -135,32 +135,29 @@ let claim_task_r config ~agent_name ~task_id ()
              (fun (state, acc) (t : task) ->
                 if t.id = task_id
                 then (
-                  match t.task_status with
-                  | Todo ->
+                  (* RFC-0220 §3.5: one claim decision, shared with the
+                     auto-claim path ([claim_next_r]). [resolve_claim] owns the
+                     self-check (normalized via [same_task_actor]) and, for a
+                     cross-agent verification claim, binds the verifier into the
+                     [AwaitingVerification] status — no longer a status-
+                     preserving no-op that deferred verifier identity to a
+                     separate store (#19314). *)
+                  match
+                    Workspace_task_lifecycle.resolve_claim
+                      ~same_actor:(fun a ->
+                        Workspace_task_classify.same_task_actor config a agent_name)
+                      ~agent_name
+                      ~now:(now_iso ())
+                      t.task_status
+                  with
+                  | Workspace_task_lifecycle.Worker_claim status ->
                     let t = clear_reclaim_decision t in
-                    let t' =
-                      { t with
-                        task_status =
-                          Claimed { assignee = agent_name; claimed_at = now_iso () }
-                      }
-                    in
-                    `Claimed_ok, t' :: acc
-                  | Claimed { assignee; _ }
-                  | InProgress { assignee; _ }
-                    when assignee = agent_name -> `Already_mine, t :: acc
-                  | AwaitingVerification { assignee; verification_id; _ } ->
-                    if assignee = agent_name then `Already_mine, t :: acc
-                    else
-                    (* Cross-agent verification dispatch: verifier claims the
-                       AwaitingVerification task without changing its status.
-                       Verification.assign_verifier is called after the fold.
-                       Issue #19314. *)
-                    `Claimed_verification verification_id, t :: acc
-                  | Claimed { assignee; _ }
-                  | InProgress { assignee; _ }
-                  | Done { assignee; _ }
-                  | Cancelled { cancelled_by = assignee; _ } ->
-                    `Claimed_by assignee, t :: acc)
+                    `Claimed_ok, { t with task_status = status } :: acc
+                  | Workspace_task_lifecycle.Verifier_claim status ->
+                    `Claimed_verification, { t with task_status = status } :: acc
+                  | Workspace_task_lifecycle.Self_owned -> `Already_mine, t :: acc
+                  | Workspace_task_lifecycle.Held_by_other holder ->
+                    `Claimed_by holder, t :: acc)
                 else state, t :: acc)
              (`Not_found, [])
              backlog.tasks
@@ -175,14 +172,21 @@ let claim_task_r config ~agent_name ~task_id ()
                { message = Printf.sprintf "Task %s is already claimed by you" task_id
                ; auto_released_task_ids = []
                })
-         | `Claimed_verification verification_id ->
-           (* Issue #19314: Cross-agent verification dispatch.
-              The task stays in AwaitingVerification; we assign the verifier
-              in the verification store and set the agent's current_task.
-              WORKAROUND: Verification.assign_verifier lives in masc lib but
-              masc_workspace cannot depend on masc (cycle). Verifier assignment
-              is deferred to the verification dispatch loop instead. *)
-           let () = () in
+         | `Claimed_verification ->
+           (* Issue #19314 / RFC-0220 §3.5: cross-agent verification dispatch.
+              The task stays [AwaitingVerification]; [resolve_claim] has bound
+              this agent as the verifier in [phase] (Verifier_assigned). Persist
+              that status and point the agent at the task. The verifier binding
+              now lives in the task FSM (single authority via [phase]), so the
+              former defer-to-dispatch-loop workaround is gone — no cross-lib
+              call into [Verification.assign_verifier] is needed. *)
+           let new_backlog =
+             { tasks = new_tasks
+             ; last_updated = now_iso ()
+             ; version = backlog.version + 1
+             }
+           in
+           write_backlog config new_backlog;
            Workspace_task_classify.update_local_agent_state config ~agent_name (fun agent ->
              { agent with status = Busy; current_task = Some task_id });
            let _ =

--- a/lib/workspace/workspace_task_lifecycle.ml
+++ b/lib/workspace/workspace_task_lifecycle.ml
@@ -32,6 +32,46 @@ let verification_deadline ~now ~timeout_seconds =
   Some (Masc_domain.iso8601_of_unix_seconds (submitted_at +. timeout_seconds))
 ;;
 
+(** RFC-0220 §3.5: the outcome of [agent_name] claiming a task in [status].
+    Shared by the explicit ([Workspace_task_claim.claim_task_r]) and auto
+    ([Workspace_task_schedule.claim_next_r]) claim writers so they never
+    diverge on the same claimable status — the divergence flagged in §3.5 was
+    that auto-claim overwrote [AwaitingVerification] with [Claimed], clobbering
+    the verification obligation. [same_actor] normalizes actor identity (keeper
+    alias vs nickname); both writers pass
+    [Workspace_task_classify.same_task_actor config _ agent_name], so the
+    self-block lives here once, in one equality semantics. *)
+type claim_resolution =
+  | Worker_claim of Masc_domain.task_status
+      (** [Todo] -> [Claimed] by this agent. *)
+  | Verifier_claim of Masc_domain.task_status
+      (** [AwaitingVerification] submitted by another actor -> the obligation is
+          preserved with this agent bound as verifier ([phase]). *)
+  | Self_owned
+      (** This actor already holds the task (own [Claimed]/[InProgress]) or
+          submitted the obligation (own [AwaitingVerification]); claiming is a
+          no-op, never a self-verification. *)
+  | Held_by_other of string
+      (** Held by another actor, or terminal ([Done]/[Cancelled]); the string
+          names the current holder for the caller's error message. *)
+
+let resolve_claim ~same_actor ~agent_name ~now (status : Masc_domain.task_status) =
+  match status with
+  | Masc_domain.Todo ->
+    Worker_claim (Masc_domain.Claimed { assignee = agent_name; claimed_at = now })
+  | Masc_domain.AwaitingVerification { assignee; submitted_at; verification_id; _ } ->
+    if same_actor assignee
+    then Self_owned
+    else
+      Verifier_claim
+        (Masc_domain.bind_verifier
+           ~verifier:agent_name ~assignee ~submitted_at ~verification_id)
+  | Masc_domain.Claimed { assignee; _ } | Masc_domain.InProgress { assignee; _ } ->
+    if same_actor assignee then Self_owned else Held_by_other assignee
+  | Masc_domain.Done { assignee; _ } -> Held_by_other assignee
+  | Masc_domain.Cancelled { cancelled_by; _ } -> Held_by_other cancelled_by
+;;
+
 let decide
       ~verification_enabled
       ~verification_timeout_seconds
@@ -56,10 +96,22 @@ let decide
     , (Masc_domain.Claimed { assignee; _ } | Masc_domain.InProgress { assignee; _ }) ) ->
     if same_agent assignee then ok task_status else Error Invalid_transition
   | Masc_domain.Claim, Masc_domain.Done _ -> ok task_status
-  | Masc_domain.Claim, Masc_domain.AwaitingVerification { assignee; _ } ->
-    (* Cross-agent verification dispatch: verifier claims the task without
-       changing status. Self-verification is blocked. Issue #19314. *)
-    if same_agent assignee then Error Invalid_transition else ok task_status
+  | ( Masc_domain.Claim
+    , Masc_domain.AwaitingVerification { assignee; submitted_at; verification_id; _ } ) ->
+    (* Cross-agent verification dispatch (#19314): a verifier — not the
+       submitter — claims the obligation. RFC-0220 §3.5: preserve the
+       [AwaitingVerification] status and bind the verifier in [phase] so the
+       satisfier is recorded in the task FSM (single authority) instead of a
+       separate store. [set_current] points the verifier at the task, matching
+       the explicit claim path. Self-claim is blocked: the submitter cannot
+       verify their own work. *)
+    if same_agent assignee
+    then Error Invalid_transition
+    else
+      ok
+        ~set_current:task_id
+        (Masc_domain.bind_verifier
+           ~verifier:agent_name ~assignee ~submitted_at ~verification_id)
   | Masc_domain.Claim, Masc_domain.Cancelled _ ->
     Error Invalid_transition
   (* ── Start ────────────────────────────────────── *)

--- a/lib/workspace/workspace_task_lifecycle.mli
+++ b/lib/workspace/workspace_task_lifecycle.mli
@@ -18,6 +18,28 @@ type decision =
   ; drift : drift option
   }
 
+(** RFC-0220 §3.5: the outcome of an agent claiming a task in a given status,
+    shared by the explicit and auto claim writers so they never diverge on the
+    same claimable status. The self-block (a submitter cannot verify their own
+    [AwaitingVerification]) lives in {!resolve_claim}, once, under one
+    [same_actor] equality. *)
+type claim_resolution =
+  | Worker_claim of Masc_domain.task_status
+  | Verifier_claim of Masc_domain.task_status
+  | Self_owned
+  | Held_by_other of string
+
+(** [resolve_claim ~same_actor ~agent_name ~now status] is the claim outcome.
+    [same_actor name] must report whether [name] is the same logical actor as
+    the claiming agent (callers pass
+    [Workspace_task_classify.same_task_actor config _ agent_name]). *)
+val resolve_claim
+  :  same_actor:(string -> bool)
+  -> agent_name:string
+  -> now:string
+  -> Masc_domain.task_status
+  -> claim_resolution
+
 val decide
   :  verification_enabled:bool
   -> verification_timeout_seconds:float

--- a/lib/workspace/workspace_task_schedule.ml
+++ b/lib/workspace/workspace_task_schedule.ml
@@ -347,8 +347,29 @@ let claim_next_r
                 ; "blocked", `Int (List.length verification_blocked_todo)
                 ; "ts", `String (now_iso ())
                 ]);
+        (* RFC-0220 §3.5: eligibility and the claim outcome are one decision
+           ([Workspace_task_lifecycle.resolve_claim]). A submitter's own
+           [AwaitingVerification] resolves to [Self_owned] and is excluded here,
+           so a worker never auto-claims (self-verifies) its own obligation; a
+           cross-agent obligation resolves to [Verifier_claim] and stays
+           eligible so the satisfier is always reachable.
+           [task_claim_next_action_is_claimable] still owns the Todo reclaim
+           gate. *)
+        let same_actor a = Workspace_task_classify.same_task_actor config a agent_name in
+        let resolves_claimable (t : Masc_domain.task) =
+          match
+            Workspace_task_lifecycle.resolve_claim
+              ~same_actor ~agent_name ~now:(now_iso ()) t.task_status
+          with
+          | Workspace_task_lifecycle.Worker_claim _
+          | Workspace_task_lifecycle.Verifier_claim _ -> true
+          | Workspace_task_lifecycle.Self_owned
+          | Workspace_task_lifecycle.Held_by_other _ -> false
+        in
         let unclaimed =
-          List.filter Masc_domain.task_claim_next_action_is_claimable sorted
+          sorted
+          |> List.filter Masc_domain.task_claim_next_action_is_claimable
+          |> List.filter resolves_claimable
         in
         (* Also exclude the just-released task: the agent is moving on,
          re-claiming the same task would be a no-op loop. *)
@@ -448,17 +469,32 @@ let claim_next_r
               }
           , None )
          | _ :: _, task :: _ ->
-           (* Claim this task *)
+           (* Claim this task. [resolve_claim] yields the post-claim status:
+              [Claimed] for a Todo worker claim, or a verifier-bound
+              [AwaitingVerification] for a cross-agent verification claim
+              (RFC-0220 §3.5 — preserve the obligation as the satisfier, do not
+              clobber it to [Claimed]). The [Self_owned]/[Held_by_other] arms
+              are unreachable here: [unclaimed] admits only tasks that resolve
+              to a claim (same [resolve_claim]); the defensive fallback keeps
+              the worker-claim behavior rather than raising on the claim path. *)
+           let claimed_status =
+             match
+               Workspace_task_lifecycle.resolve_claim
+                 ~same_actor ~agent_name ~now:(now_iso ()) task.task_status
+             with
+             | Workspace_task_lifecycle.Worker_claim s
+             | Workspace_task_lifecycle.Verifier_claim s -> s
+             | Workspace_task_lifecycle.Self_owned
+             | Workspace_task_lifecycle.Held_by_other _ ->
+               Masc_domain.Claimed { assignee = agent_name; claimed_at = now_iso () }
+           in
            let new_tasks =
              List.map
                (fun (t : task) ->
                   if t.id = task.id
                   then (
                     let t = Workspace_task.clear_reclaim_decision t in
-                    { t with
-                      task_status =
-                        Claimed { assignee = agent_name; claimed_at = now_iso () }
-                    })
+                    { t with task_status = claimed_status })
                   else t)
                working_tasks
            in
@@ -513,10 +549,8 @@ let claim_next_r
              ~transition:Masc_domain.Claim
              ~details:
                (Workspace_task.task_transition_details
-                  ~from_status:Masc_domain.Todo
-                  ~to_status:
-                    (Masc_domain.Claimed
-                       { assignee = agent_name; claimed_at = now_iso () })
+                  ~from_status:task.task_status
+                  ~to_status:claimed_status
                   ());
           let message =
             match released_task_id with

--- a/test/test_workspace_task_lifecycle.ml
+++ b/test/test_workspace_task_lifecycle.ml
@@ -68,6 +68,27 @@ let assert_actions ~ctx ~expected ~actual =
     exit 1)
 ;;
 
+let fail msg =
+  Printf.printf "FAIL %s\n%!" msg;
+  exit 1
+;;
+
+let decide_claim ~same_agent ~agent_name ~task_id ~task_status =
+  L.decide
+    ~verification_enabled:true
+    ~verification_timeout_seconds:0.0
+    ~new_verification_id:(fun () -> "vrf-new")
+    ~same_agent
+    ~agent_name
+    ~task_id
+    ~task_status
+    ~action:D.Claim
+    ~now
+    ~force:false
+    ~notes:""
+    ~reason:""
+;;
+
 (* Cross-check: [valid_next_actions] returns exactly the [task_action]s for
    which [decide] returns [Ok], under the same caller context. *)
 let assert_consistent_with_decide
@@ -310,6 +331,88 @@ let test_exhaustive_consistency () =
     statuses
 ;;
 
+(* ── RFC-0220 §3.5: cross-agent claim binds the verifier ───── *)
+
+(* A verifier (not the submitter) claiming an [AwaitingVerification] obligation
+   preserves the obligation and records the claimer in [phase] —
+   [Verifier_assigned] — with [set_current] pointing the verifier at the task.
+   The status is NOT clobbered to [Claimed]; the submitter is preserved as
+   [assignee]. This is the satisfier binding that the auto-claim path also
+   reuses via [resolve_claim]. *)
+let test_claim_awaiting_binds_verifier () =
+  match
+    decide_claim
+      ~same_agent:(fun a -> String.equal a "verifier-x")
+      ~agent_name:"verifier-x"
+      ~task_id:"task-1"
+      ~task_status:(mk_awaiting other)
+  with
+  | Ok
+      { L.new_status =
+          D.AwaitingVerification { phase = D.Verifier_assigned { verifier }; assignee; _ }
+      ; set_current
+      ; _
+      } ->
+    if not (String.equal verifier "verifier-x") then fail "verifier not bound to the claimer";
+    if not (String.equal assignee other) then fail "submitter (assignee) must be preserved";
+    (match set_current with
+     | Some t when String.equal t "task-1" -> ()
+     | _ -> fail "cross-agent claim must point the verifier at the task (set_current)")
+  | Ok { L.new_status; _ } ->
+    fail
+      (Printf.sprintf
+         "expected AwaitingVerification/Verifier_assigned, got %s"
+         (D.task_status_to_string new_status))
+  | Error _ -> fail "cross-agent claim of AwaitingVerification must be accepted"
+;;
+
+(* The submitter cannot claim (self-verify) their own obligation. *)
+let test_claim_awaiting_by_self_blocked () =
+  match
+    decide_claim
+      ~same_agent:(fun a -> String.equal a owner)
+      ~agent_name:owner
+      ~task_id:"task-2"
+      ~task_status:(mk_awaiting owner)
+  with
+  | Error _ -> ()
+  | Ok _ -> fail "submitter must not claim (self-verify) their own AwaitingVerification"
+;;
+
+(* [resolve_claim] is the single claim decision shared by both writers. Pin all
+   four outcomes, including the self-block. *)
+let test_resolve_claim_outcomes () =
+  let actor x a = String.equal a x in
+  (match L.resolve_claim ~same_actor:(actor "w") ~agent_name:"w" ~now D.Todo with
+   | L.Worker_claim (D.Claimed { assignee = "w"; _ }) -> ()
+   | _ -> fail "Todo should resolve to Worker_claim Claimed");
+  (match L.resolve_claim ~same_actor:(actor "v") ~agent_name:"v" ~now (mk_awaiting other) with
+   | L.Verifier_claim
+       (D.AwaitingVerification { phase = D.Verifier_assigned { verifier = "v" }; assignee; _ })
+     when String.equal assignee other -> ()
+   | _ -> fail "cross-agent AwaitingVerification should resolve to Verifier_claim (verifier bound, submitter preserved)");
+  (match L.resolve_claim ~same_actor:(actor other) ~agent_name:other ~now (mk_awaiting other) with
+   | L.Self_owned -> ()
+   | _ -> fail "own AwaitingVerification should resolve to Self_owned (the self-block)");
+  (match L.resolve_claim ~same_actor:(actor "z") ~agent_name:"z" ~now (mk_claimed other) with
+   | L.Held_by_other h when String.equal h other -> ()
+   | _ -> fail "Claimed-by-other should resolve to Held_by_other naming the holder")
+;;
+
+(* [Verifier_assigned] must survive a serialize -> parse round-trip so the
+   satisfier binding is durable across backlog writes. *)
+let test_verifier_assigned_codec_roundtrip () =
+  let status =
+    D.bind_verifier ~verifier:"v" ~assignee:other ~submitted_at:now ~verification_id:"vrf-1"
+  in
+  match D.task_status_of_yojson (D.task_status_to_yojson status) with
+  | Ok
+      (D.AwaitingVerification
+        { phase = D.Verifier_assigned { verifier = "v" }; verification_id = "vrf-1"; assignee; _ })
+    when String.equal assignee other -> ()
+  | _ -> fail "Verifier_assigned must round-trip through the task_status codec"
+;;
+
 (* ── runner ───────────────────────────────────────────────── *)
 
 let () =
@@ -324,5 +427,9 @@ let () =
   test_cancelled ();
   test_verification_disabled_todo ();
   test_exhaustive_consistency ();
+  test_claim_awaiting_binds_verifier ();
+  test_claim_awaiting_by_self_blocked ();
+  test_resolve_claim_outcomes ();
+  test_verifier_assigned_codec_roundtrip ();
   print_endline "test_task_state_lifecycle: all assertions passed"
 ;;


### PR DESCRIPTION
## Goal

RFC-0220 **PR-2** (satisfier convergence). Follows #20588 (PR-1, **merged** as `b9abb6b`); base is `main`, so this diff is the §3.5 change only.

PR-1 folded the verification sub-state into `task_status` and removed the Todo-scoped claim gate, so an `AwaitingVerification` obligation is always in the verifier pool. This PR closes the **§3.5 satisfier divergence**: the two claim surfaces treated the same claimable status inconsistently, and the auto-claim path *destroyed* the obligation.

## The bug it fixes

`claim_next_r` overwrote any claimed task's status with `Claimed { assignee }`. Since **#19314** an `AwaitingVerification` task is claimable via `claim_next_r` (`task_claim_decision`), so a verifier reaching it through auto-claim **clobbered the verification obligation** — the satisfier was silently destroyed. The explicit path (`claim_task_r`) preserved the status but deferred verifier identity to a separate store (a workaround forced by a lib cycle), so the binding was never recorded on the task.

## Single decision, three surfaces

- **`types_core`**: `bind_verifier` — the one constructor for the post-claim status (status preserved, `phase = Verifier_assigned { verifier }`). **Advisory binding**: `decide`'s approve/reject arms match the phase with `_`, so any non-submitter can still approve/reject — an abandoned `Verifier_assigned` task stays re-claimable. It records *who is verifying*, not *who is permitted to* (a dead verifier cannot recreate the stall in a new form).
- **`workspace_task_lifecycle`**: `resolve_claim`, the total claim decision shared by both writers (`Worker_claim | Verifier_claim | Self_owned | Held_by_other`). The self-block lives here once, under a normalized `same_actor` (`same_task_actor`), not raw string equality. `decide`'s cross-agent `Claim` arm now produces the verifier-bound status (+ `set_current`) so the generic transition path agrees with the writers.
- **`claim_task_r`**: route the fold through `resolve_claim` and persist the result. The verifier binding now lives in the task FSM, so the defer-to-dispatch-loop **workaround is removed** (no cross-lib call into `Verification.assign_verifier`).
- **`claim_next_r`**: eligibility and the claim outcome are one `resolve_claim` decision. A submitter's own `AwaitingVerification` resolves to `Self_owned` and is excluded (no self-verification); a cross-agent obligation resolves to `Verifier_claim` and is preserved instead of clobbered.

## Local verification

- `dune build --root .` (default target) → **exit 0**; `@check` → exit 0.
- New tests (`test_workspace_task_lifecycle`): cross-agent claim binds the verifier + preserves submitter + `set_current`; self-claim of own obligation blocked; `resolve_claim`'s four outcomes incl. the self-block; `Verifier_assigned` codec round-trip. → **all passed**.
- `test_verification_fsm` → **20/20** (approve/reject are phase-agnostic, so unchanged).
- `test_workspace` → **7 failures, identical to base** (PR-1 tip + clean `origin/main`): standalone-only agent-join config-dir env + RNG-init; **not regressions** from this PR.

## Invariants (audit I1 / advisory-not-gate)

The §3.5 binding must not become a gate: a dead assigned-verifier must not block approval, or it would move the 8-day stall rather than remove it. Verified: `decide`'s `Approve_verification`/`Reject_verification` arms and `task_claim_decision` match the phase with `_` (phase-agnostic); the self-block is the only verifier-identity check and it keys on the submitter (`assignee`), not the bound verifier.

RFC-WAIVED: verification FSM + task scheduling, not a credential/identity/operator/sandbox/hooks subsystem. RFC-0220 §3.5 governs this change.
