### PR TITLE
fix(runtime): restore typed provider-context error enrichment

### DIFF
--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -342,10 +342,14 @@ let run_try_provider
            | None -> run_fn ()))
     in
     let result =
+      (* Restore typed provider-context enrichment (auth-env / not-found hints).
+         [Runtime_candidate] lives below [lib/keeper] and cannot reach this
+         keeper-level helper, so the enrichment is applied here at the consumer
+         with the candidate's provider config. *)
       Result.map_error
-        (Runtime_candidate.enrich_sdk_error
+        (Keeper_runtime_attempt.enrich_sdk_error
            ~runtime_id:ctx.error_runtime_id
-           candidate)
+           ~provider_cfg:(Runtime_candidate.provider_cfg candidate))
         result
     in
     let checkpoint_after =

--- a/lib/runtime/runtime_candidate.ml
+++ b/lib/runtime/runtime_candidate.ml
@@ -45,12 +45,6 @@ let runtime_mcp_policy_for_agent ~agent_name (t : t) runtime_mcp_policy =
 let default_config ~name ~system_prompt ~tools (t : t) =
   Runtime_agent.default_config ~name ~provider_cfg:t.config ~system_prompt ~tools
 
-(* Error decoration collapsed to identity: the deleted version added provider
-   auth-env / not-found hints via the annihilated runtime attempt-fsm helpers. *)
-let enrich_sdk_error ~runtime_id:(_ : string) (_ : t)
-    (err : Agent_sdk.Error.sdk_error) =
-  err
-
 (* Runtime-label helpers for dashboard grouping. Delegates to the canonical
    local-runtime detector in Runtime_provider_binding (loopback + no-auth). *)
 let local_runtime_provider_id () =

--- a/lib/runtime/runtime_candidate.mli
+++ b/lib/runtime/runtime_candidate.mli
@@ -46,8 +46,6 @@ val default_config :
   tools:Agent_sdk.Tool.t list ->
   t ->
   Runtime_agent.config
-val enrich_sdk_error :
-  runtime_id:string -> t -> Agent_sdk.Error.sdk_error -> Agent_sdk.Error.sdk_error
 val first_health_cooldown : t -> (string * string) option
 val has_recovery_evidence : t -> bool
 


### PR DESCRIPTION
## 무엇 / 왜

`Runtime_candidate.enrich_sdk_error`가 **identity로 붕괴**해, provider 실패 진단에 유용한 **auth-env / not-found 힌트**를 떨어뜨리고 있었습니다(원본 enrichment는 runtime attempt-fsm 헬퍼 정리 때 제거됨, 코드 주석이 자인). 이것이 streaming error-state-loss 분석의 LP6입니다.

작동하는 typed enrichment는 이미 `Keeper_runtime_attempt.enrich_sdk_error`에 존재합니다:
- `Api(AuthError)` → 어느 API-key env var인지 + 비었는지/로드됐는지 힌트
- not-found `Api(InvalidRequest)` → `base_url` / `request_path` / endpoint 힌트

## 변경

`Runtime_candidate`(lib/runtime)는 lib/keeper **아래**라 이 keeper-레벨 헬퍼를 호출할 수 없습니다(경계). 그래서:
- **consumer(`keeper_turn_driver_try_provider`)에서** candidate의 provider config(`Runtime_candidate.provider_cfg`)로 enrichment를 적용하도록 리라우트.
- `Runtime_candidate.enrich_sdk_error`(identity, 유일 caller였음) + `.mli` 항목 **삭제**(dead).

net −4줄(dead 제거 + 리라우트). 리라우트 대상은 기존에 존재·테스트된 함수.

## 검증

- masc `lib/` + `test/` 빌드 **EXIT=0**(cycle/unbound 없음, enrichment 메시지 변경으로 깨지는 테스트 없음). ocamlformat clean.
- 동작 검증은 routing 대상(`Keeper_runtime_attempt.enrich_sdk_error`)이 pre-existing tested function이고, 본 변경은 순수 경로 변경(compile-verified). 전체 스위트는 CI.

## 맥락 / 범위

streaming error-state-loss 시리즈: PR-A(OAS typed SSE errors, MERGED #1956) → masc pin 0.204.8(MERGED #20596) → 이 PR이 masc-side LP6. **LP7**(`keeper_recording_error_state.classify_error` + `keeper_failure_circuit_breaker.classify_error` 등 string 분류기 → typed recording threading)은 다중 사이트 + RFC-0144 워크어라운드-선셋 영역이라 **별도 RFC**로 분리. OAS truncation 감지는 #1961(별개).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
