### PR TITLE
fix(keeper): expose compact on keeper_board_list/search schemas

### DIFF
--- a/lib/tool_surface/tool_shard_types_schemas_board.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_board.ml
@@ -169,6 +169,22 @@ let board_tools : Masc_domain.tool_schema list =
                         , `List (List.map (fun s -> `String s) sort_order_enum_strings) )
                       ; "description", `String "Sort order (default: recent)"
                       ] )
+                ; (* Mirror masc_board_list: the board_list backend
+                     (board_tool_post.ml handle_post_list_uncached) already
+                     reads [compact] (default true), but the keeper surface
+                     omitted it, so a keeper could never request full output
+                     and qa-king's [compact] arg was rejected as an
+                     unsupported field. additionalProperties stays false —
+                     unknown fields remain fail-closed. *)
+                  ( "compact"
+                  , `Assoc
+                      [ "type", `String "boolean"
+                      ; "default", `Bool true
+                      ; ( "description"
+                        , `String
+                            "Compact one-line per post. Set false for full \
+                             body/TTL/visibility" )
+                      ] )
                 ] )
           ; "additionalProperties", `Bool false
           ]
@@ -283,6 +299,19 @@ let board_tools : Masc_domain.tool_schema list =
                         , `String
                             "Max results (default: 20, max: 100). Numeric \
                              strings are accepted; prefer the bare integer form." )
+                      ] )
+                ; (* Mirror masc_board_search: the search backend
+                     (board_tool_handlers.ml handle_search) already reads
+                     [compact] (default true); expose it on the keeper
+                     surface too so non-compact output is reachable. *)
+                  ( "compact"
+                  , `Assoc
+                      [ "type", `String "boolean"
+                      ; "default", `Bool true
+                      ; ( "description"
+                        , `String
+                            "Compact one-line per post. Set false for full \
+                             body/TTL/visibility" )
                       ] )
                 ] )
           ; "required", `List [ `String "query" ]

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -452,6 +452,12 @@ let tool_edit_file_schema =
 let keeper_board_post_schema =
   find_schema_exn "keeper_board_post" Config.raw_all_tool_schemas
 
+let keeper_board_list_schema =
+  find_schema_exn "keeper_board_list" Config.raw_all_tool_schemas
+
+let keeper_board_search_schema =
+  find_schema_exn "keeper_board_search" Config.raw_all_tool_schemas
+
 let tool_execute_schema =
   find_schema_exn "tool_execute" Config.raw_all_tool_schemas
 
@@ -548,6 +554,56 @@ let test_registered_hook_keeper_board_post_accepts_sources_array () =
   in
   Alcotest.(check bool) "not blocked" true (Option.is_none blocked);
   check_keeper_board_post_sources_preserved forwarded
+
+(* Regression: the board_list/search backends already read [compact]
+   (board_tool_post.ml handle_post_list_uncached, board_tool_handlers.ml
+   handle_search), but the keeper_board_* schemas omitted it, so
+   qa-king's keeper_board_list compact=true was rejected as an
+   unsupported field. Assert the keeper surface now accepts compact while
+   additionalProperties stays false (unknown fields still rejected). *)
+let test_validate_args_keeper_board_list_accepts_compact () =
+  match
+    Tool_input_validation.validate_args
+      ~schema:keeper_board_list_schema
+      ~name:"keeper_board_list"
+      ~args:(`Assoc [ "limit", `Int 5; "compact", `Bool false ])
+      ()
+  with
+  | Ok _ -> ()
+  | Error result ->
+    Alcotest.failf
+      "expected keeper_board_list compact arg to pass validation, got %s"
+      (Yojson.Safe.to_string (Tool_result.data result))
+
+let test_validate_args_keeper_board_search_accepts_compact () =
+  match
+    Tool_input_validation.validate_args
+      ~schema:keeper_board_search_schema
+      ~name:"keeper_board_search"
+      ~args:(`Assoc [ "query", `String "x"; "compact", `Bool false ])
+      ()
+  with
+  | Ok _ -> ()
+  | Error result ->
+    Alcotest.failf
+      "expected keeper_board_search compact arg to pass validation, got %s"
+      (Yojson.Safe.to_string (Tool_result.data result))
+
+(* Guard the other direction: a genuinely unknown field must still be
+   rejected (additionalProperties:false not loosened). *)
+let test_validate_args_keeper_board_list_rejects_unknown_field () =
+  match
+    Tool_input_validation.validate_args
+      ~schema:keeper_board_list_schema
+      ~name:"keeper_board_list"
+      ~args:(`Assoc [ "limit", `Int 5; "definitely_not_a_field", `Bool true ])
+      ()
+  with
+  | Ok forwarded ->
+    Alcotest.failf
+      "expected unknown field to be rejected, but it passed: %s"
+      (Yojson.Safe.to_string forwarded)
+  | Error _ -> ()
 
 let param_by_name name params =
   List.find_opt
@@ -1662,6 +1718,12 @@ let () =
         test_registered_hook_tool_edit_file_patch_args;
       Alcotest.test_case "keeper_board_post accepts sources array" `Quick
         test_registered_hook_keeper_board_post_accepts_sources_array;
+      Alcotest.test_case "keeper_board_list accepts compact" `Quick
+        test_validate_args_keeper_board_list_accepts_compact;
+      Alcotest.test_case "keeper_board_search accepts compact" `Quick
+        test_validate_args_keeper_board_search_accepts_compact;
+      Alcotest.test_case "keeper_board_list still rejects unknown field" `Quick
+        test_validate_args_keeper_board_list_rejects_unknown_field;
       Alcotest.test_case "tool_execute exposes typed boundary" `Quick
         test_tool_execute_schema_exposes_typed_boundary;
       Alcotest.test_case "tool_execute rejects empty args with class" `Quick


### PR DESCRIPTION
## 목표

`keeper_board_list` / `keeper_board_search` schema에 `compact` 필드를 노출해 schema↔backend capability gap을 닫는다.

## 배경 (진단 근거)

keeper 도구 실패 sweep(Issue #20602, lane 5)에서 확정. board_list/search backend는 이미 `compact`(default true)를 읽는다:
- `board_tool_post.ml` `handle_post_list_uncached`
- `board_tool_handlers.ml` `handle_search`

그런데 `keeper_board_*` schema는 `compact`를 빠뜨린 반면 sibling `masc_board_*` schema(`board_tool_schemas.ml:237,393`)는 노출한다. 결과:
1. keeper가 full(non-compact) 출력을 keeper surface로 절대 요청할 수 없다.
2. `compact`를 넘긴 keeper(qa-king, fleet log 2026-06-09)가 `unsupported field`로 거부됐다.
3. masc_*/keeper_* cross-surface drift가 모델을 compact 사용으로 유도한다.

## 변경

`keeper_board_list`, `keeper_board_search` schema에 typed boolean `compact` 추가 (masc_board_* mirror). `additionalProperties: false` 유지 — unknown field는 여전히 fail-closed. validation 완화가 아니라 capability gap + drift 해소.

## 검증

- `test_tool_input_validation.ml`(pre-hook과 동일한 `validate_args` 파이프라인, consumer-level):
  - `keeper_board_list accepts compact`
  - `keeper_board_search accepts compact`
  - `keeper_board_list still rejects unknown field` (additionalProperties:false 유지 확인)
- 70 tests 전체 통과.

## gating

`lib/tool_surface/` board schema만 변경. credential/identity/sandbox/operator/hooks/workflow 미해당 → non-gated.

## 관련

- Issue #20602 (keeper tool-failure sweep, lane 5)
