### PR TITLE
fix(otel): disable library self-trace to stop encode-proto span pollution

### DIFF
--- a/lib/otel_spans/otel_spans.ml
+++ b/lib/otel_spans/otel_spans.ml
@@ -36,6 +36,14 @@ let init () =
   if Otel_config.enabled && not (Atomic.get initialized) then begin
     Atomic.set initialized true;
     OT.Globals.service_name := Otel_config.service_name;
+    (* Disable the opentelemetry library's internal self-instrumentation
+       ("encode-proto" spans emitted by Self_trace.with_ in client/signal.ml).
+       When the exporter encodes a batch while running on a keeper fiber, the
+       self-span nests into that fiber's active ambient scope and attaches to
+       the live invoke_agent (keeper-turn) trace. Measured on a post-deploy
+       production trace (commit c36e0d1, masc service): 2260 of 2283 spans
+       (99%) were encode-proto noise. These carry no application signal. *)
+    Opentelemetry_client.Self_trace.set_enabled false;
     (* ambient-context-eio storage is set automatically when the library is linked.
        Eio fiber-local context propagation works via Ambient_context_eio.storage. *)
     ignore (Ambient_context_eio.storage : Ambient_context.Storage.t)


### PR DESCRIPTION
## 문제 (실측 audit, live production Jaeger)

opentelemetry 라이브러리의 `Self_trace` self-instrumentation이 batch 인코딩마다 `encode-proto` internal span을 생성합니다 (`client/signal.ml:49`). 인코딩이 keeper fiber에서 실행되면 이 self-span이 활성 `invoke_agent`(keeper-turn) ambient scope에 nest되어 해당 trace에 붙습니다.

**배포 후 production trace 측정 (commit `c36e0d1`, masc service):**
- trace `955040d4` (03:52Z, 배포 03:42Z 이후): 2283 spans 중 **2260개(99%)** 가 `encode-proto` noise
- 같은 trace에 19개 keeper turn이 누적

이것이 monolithic keeper-turn trace의 압도적 주범입니다. 어제 `tool_dispatch` 단위 trace 분리(`force_new_trace_id`, #20581/#20592)는 tool dispatch 경계만 다뤘고, keeper-turn 레벨의 이 오염은 미해결로 남아 있었습니다.

## 변경

`Otel_spans.init`에서 `Opentelemetry_client.Self_trace.set_enabled false` 호출 (한 줄). `init`은 양쪽 exporter setup 경로(`setup_exporter_with`, `setup_exporter`)의 공통 초기화 지점입니다. 시그니처 변경 없음 → 호출부 영향 없음.

`encode-proto` span은 애플리케이션 신호를 담지 않는 라이브러리 내부 동작 trace이므로, 이를 끄는 것은 noise 제거(근본 제거)이며 silent failure를 가리는 telemetry-as-fix가 아닙니다.

## 검증 계획

- [x] `dune build --root . lib/otel_spans/` PASS (`Opentelemetry_client.Self_trace` 접근 확인)
- [ ] 재배포 후 live Jaeger에서 `invoke_agent` trace의 `encode-proto` span 수 = 0 확인 (예상: 2283 → ~23 spans)

## 범위 밖 (별도)

- **keeper turn(`invoke_agent`) trace 미분리** (audit Gap #2): 19개 keeper turn이 한 trace에 묶이는 문제. `force_new_trace_id`를 keeper turn 경계에 적용하는 것은 keeper-turn↔tool_dispatch trace 분리 모델 설계가 필요해 별도 작업으로 분리합니다.

RFC-WAIVED: telemetry exporter noise 제거로 RFC 게이트 subsystem(credential/operator/keeper sandbox/dashboard credential/hooks/workflow) 비해당.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
