### PR TITLE
fix(keeper): route resolve_shared not-found to rich Missing_file hint

### DIFF
--- a/lib/keeper/keeper_tool_filesystem_runtime.ml
+++ b/lib/keeper/keeper_tool_filesystem_runtime.ml
@@ -151,6 +151,21 @@ let resolve_read_file_target
       let resolve_shared candidate =
         match resolve_keeper_read_path ~config ~meta ~raw_path:candidate with
         | Ok _ as ok -> ok
+        (* Mirror resolve_projected below: route a
+           path_not_found_under_allowed_roots rejection to Missing_file so
+           the keeper gets the rich missing_file_error_json (your_playground
+           + live available_repos scan) instead of the bare {error}. The
+           bare message text says "check your_playground for available
+           files" but Read_path_error omits that field, so repo-prefixed
+           paths (incl. masc-mcp->masc rename-drift victims) could not
+           self-correct. This removes an asymmetry between the two sibling
+           resolvers; it adds no new classifier (the prefix check already
+           exists in resolve_projected). *)
+        | Error e
+          when String.starts_with
+                 ~prefix:"path_not_found_under_allowed_roots:"
+                 e ->
+          Error (Missing_file { target = candidate; error = e })
         | Error e -> Error (Read_path_error e)
       in
       let resolve_projected candidate =

--- a/test/test_keeper_visible_path_projection.ml
+++ b/test/test_keeper_visible_path_projection.ml
@@ -167,6 +167,44 @@ let test_read_with_visible_repo_cwd_and_relative_file_path () =
     (parse_string "content" raw)
 ;;
 
+(* Regression: a repo-prefixed read of a path that does not exist (e.g.
+   the masc-mcp->masc rename-drift case, or a hallucinated file) routes
+   through resolve_shared. Before the fix, resolve_shared wrapped every
+   error as Read_path_error -> bare {error}, so the keeper-facing result
+   omitted your_playground / available_repos even though the message text
+   says "check your_playground for available files". The fix mirrors
+   resolve_projected: a path_not_found_under_allowed_roots rejection
+   becomes Missing_file -> rich missing_file_error_json. Assert the rich
+   hint reaches the keeper-facing result. *)
+let test_repo_prefixed_missing_read_surfaces_playground_hint () =
+  setup
+  @@ fun ~config ~meta ~playground:_ ->
+  allow_repo ~config ~meta "masc";
+  let raw =
+    Keeper_tool_filesystem_runtime.handle_read_file
+      ~turn_sandbox_factory:None
+      ~config
+      ~keeper_name:meta.name
+      ~args:
+        (`Assoc
+            [ "path", `String "repos/masc/lib/keeper/does_not_exist_xyz.ml"
+            ; "max_bytes", `Int 4096
+            ])
+  in
+  if parse_ok raw then Alcotest.failf "expected Read to fail, got ok: %s" raw;
+  (* missing_file_error_json carries your_playground + available_repos;
+     Read_path_error (the old behaviour) carries neither. *)
+  let has_hint =
+    let json = parse raw in
+    (match Json.member "your_playground" json with `Null -> false | _ -> true)
+    || (match Json.member "available_repos" json with `Null -> false | _ -> true)
+  in
+  Alcotest.(check bool)
+    "repo-prefixed not-found surfaces your_playground/available_repos hint"
+    true
+    has_hint
+;;
+
 let test_write_visible_mind_path () =
   setup ~sandbox:Keeper_types_profile_sandbox.Docker
   @@ fun ~config ~meta ~playground ->
@@ -211,6 +249,10 @@ let () =
             "Write visible mind path"
             `Quick
             test_write_visible_mind_path
+        ; Alcotest.test_case
+            "repo-prefixed missing read surfaces playground hint"
+            `Quick
+            test_repo_prefixed_missing_read_surfaces_playground_hint
         ] )
     ]
 ;;


### PR DESCRIPTION
## 목표

`resolve_shared`가 `path_not_found_under_allowed_roots` 거부를 rich `Missing_file` hint로 라우팅하게 해, repo-prefixed 경로 거부 시 keeper가 self-correct할 수 있게 한다.

## 배경 (진단 근거)

keeper 도구 실패 sweep(Issue #20602, lane 4)에서 확정. `keeper_tool_filesystem_runtime.ml`의 두 sibling resolver가 비대칭:
- `resolve_projected` (line 156-): `path_not_found_under_allowed_roots:` prefix 검출 시 → `Missing_file` → rich `missing_file_error_json` (`your_playground` + live `available_repos` scan).
- `resolve_shared` (line 151-): **모든 에러를 `Read_path_error`로 wrap** → bare `{error}` (hint 필드 누락).

repo-prefixed 경로(`sandbox_rooted_relative_path`)는 `resolve_shared`로 간다. fleet log 2026-06-09에서 `repos/masc/dune-project`가 12회 거부됐는데(masc-mcp→masc rename-drift), 메시지는 "check your_playground for available files"라 하면서 payload엔 그 필드가 없어 모델이 self-correct 불가 → 같은 경로 반복 거부.

## 변경

`resolve_shared`에 `resolve_projected`의 기존 prefix 검출 분기를 미러. sibling 비대칭 제거이며 새 분류기 추가가 아니다(prefix 검출은 resolve_projected에 이미 존재). drifted path를 rewrite/normalize하지 않는다(rename을 가리게 됨) — 대신 실제 available_repos를 모델에게 줘 deterministic하게 self-correct하게 한다.

## 검증

- `test_keeper_visible_path_projection.ml`(consumer-level via `handle_read_file`): repo-prefixed 없는 파일 Read → `your_playground`/`available_repos` 도달.
- **fix 없이 FAIL, fix 있으면 PASS 확인** (테스트가 resolve_shared 분기를 실제로 탐을 증명). 5 tests 통과.

## gating

`lib/keeper/keeper_tool_filesystem_runtime.ml` 변경. `pr-rfc-check.sh` 패턴(credential_/keeper_gh_/host_config/repo_manager/operator_control/dashboard credential) 미매치 → non-gated. credential/identity/sandbox containment 동작 변경 없음(에러 메시지 payload 일관성만).

## 관련

- Issue #20602 (keeper tool-failure sweep, lane 4)
