### PR TITLE
fix(keeper): point Read-on-directory error at a real listing tool

### DIFF
--- a/lib/keeper/keeper_sandbox_read_backend.ml
+++ b/lib/keeper/keeper_sandbox_read_backend.ml
@@ -217,8 +217,9 @@ let read_file ?turn_sandbox_factory ~config ~(meta : keeper_meta) ~host_path
       Error
         (Printf.sprintf
            "docker_cat_failed: path_is_directory: %s (Read requires a file, \
-            not a directory; use the currently exposed read/listing tools for directory \
-            listings)"
+            not a directory; to list a directory use Grep with op='ls' (e.g. \
+            op='ls', path='%s') or Execute with ls)"
+           host_path
            host_path)
     else
       run_command ?turn_sandbox_factory ~config ~meta

--- a/test/test_keeper_sandbox_read_backend.ml
+++ b/test/test_keeper_sandbox_read_backend.ml
@@ -241,6 +241,30 @@ let test_read_missing_file_preflight_errors () =
          in
          loop 0)
 
+(* Read on a directory must point the keeper at a tool that actually
+   exists. The old message said "use the currently exposed read/listing
+   tools" without naming one; since #20594 exposed op on the search tool,
+   the message now names Grep op='ls' (and Execute ls). Guards against the
+   message regressing to a phantom-tool reference. *)
+let test_read_directory_names_a_real_listing_tool () =
+  let base, config, meta = setup_config "minjae" in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  let host_root = Keeper_sandbox.host_root_abs_of_meta ~config meta in
+  let dir_path = Filename.concat host_root "mind/somedir" in
+  ensure_dir dir_path;
+  match
+    Keeper_sandbox_read_backend.read_file ~config ~meta ~host_path:dir_path
+      ~max_bytes:4096 ~timeout_sec:5.0 ()
+  with
+  | Ok _ -> Alcotest.fail "expected path_is_directory error for a directory"
+  | Error msg ->
+      Alcotest.(check bool) "error reports path_is_directory" true
+        (contains_substring msg "path_is_directory");
+      Alcotest.(check bool)
+        "error names a real listing tool (op='ls')"
+        true
+        (contains_substring msg "op='ls'")
+
 (* ── run_command error paths
    (exercised without invoking docker) ──────────────────────────── *)
 
@@ -1334,6 +1358,8 @@ let run_tests ~clock () =
             `Quick test_read_outside_playground_returns_mapping_error;
           Alcotest.test_case "missing file preflight errors" `Quick
             test_read_missing_file_preflight_errors;
+          Alcotest.test_case "directory read names a real listing tool" `Quick
+            test_read_directory_names_a_real_listing_tool;
         ] );
       ( "run_command",
         [


### PR DESCRIPTION
## 목표

Read-on-directory 에러 메시지가 실재하는 listing 도구(Grep `op='ls'`)를 명명하게 해, keeper가 디렉토리를 Read하다 실패할 때 self-correct하게 한다.

## 배경 (진단 근거)

keeper 도구 실패 sweep(Issue #20602, lane 3)에서 mixed로 분류. 두 부분:

1. **(이미 #20594로 해결)** Grep description이 "directory listings"를 광고하나 op가 도달 불가했던 문제 — `5cbfc58 (#20594)`가 typed `op` 파라미터(`rg`/`ls`/`tree`/`git_status`)를 schema에 노출해 해결됨. 현재 코드에선 `op='ls'`가 실재 도달 가능 경로다. (sweep 진단은 #20594 이전 코드를 봤음 — 본 PR에서 재검증 후 이 부분은 손대지 않음.)

2. **(본 PR)** `keeper_sandbox_read_backend.ml`의 `path_is_directory` 에러가 "use the currently exposed read/listing tools"라고만 하고 실재 도구를 안 가리킴. masc-improver/issue_king(docker)이 디렉토리를 Read하다 반복 실패(fleet log ~23건). 이제 `op='ls'`가 실재하므로 메시지에 명시.

## 변경

`keeper_sandbox_read_backend.ml`의 디렉토리 에러 메시지를 "to list a directory use Grep with op='ls' ... or Execute with ls"로 변경. 문자열 리터럴만 변경, containment 동작 불변.

option A(typed op enum을 별도 노출하는 capability 확장)는 채택하지 않음 — #20594가 이미 op를 노출했고, traversal surface 확장은 RFC-급이며 진단된 결함(메시지가 거짓)을 넘어선다. surgical하게 메시지만 고침.

## 검증

- `test_keeper_sandbox_read_backend.ml`(consumer-level via `read_file`): 디렉토리 Read → `path_is_directory` + `op='ls'` 명명 확인.
- **메시지 fix 없이 FAIL, 있으면 PASS 확인.**
- 무관한 pre-existing fail(`fallback uses Docker_spawn slot`)은 base에서도 동일 fail(stash 대조 확인) — docker quick-suite flake, 본 PR과 무관.

## gating

`keeper_sandbox_read_backend.ml`은 `pr-rfc-check.sh` 운영 패턴 미매치이나 workflow-pr.md §11 prose의 `keeper_sandbox*` glob에 해당.

RFC-WAIVED: error-message string literal only, no containment/credential/sandbox-boundary behavior change. 도달 가능 도구(op='ls', #20594)를 가리키도록 텍스트만 정정.

## 관련

- Issue #20602 (keeper tool-failure sweep, lane 3)
- #20594 (op 파라미터 노출 — lane 3의 절반을 선해결)
