### PR TITLE
test(fd_accountant): wrap state tests in Eio.Switch.run (PR-C1.1, follow-up to #20604)

### DIFF
--- a/test/test_fd_accountant_state.ml
+++ b/test/test_fd_accountant_state.ml
@@ -33,6 +33,16 @@ open Alcotest
 module FA = Fd_accountant
 
 let test_idle_projects_to_zero () =
+  (* Eio.Mutex.use_rw ~protect:true installs a Cancel.protect that
+     performs [Cancel.Get_context].  Eio.Switch.run is the only
+     handler for that effect, so even Idle reads must run inside a
+     switch.  Eio_main.run is needed to provide the underlying
+     event-loop fiber; the inner Eio.Switch.run gives Cancel.protect
+     a cancellation context to read.  This mirrors PR-B's
+     dashboard_governance_judge tests, which use the same wrap
+     pattern. *)
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun _sw ->
   List.iter
     (fun kind ->
       let h = FA.read_holding ~kind in
@@ -41,6 +51,7 @@ let test_idle_projects_to_zero () =
 
 let test_mark_acquire_then_release () =
   Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun _sw ->
   List.iter
     (fun kind ->
       let () =
@@ -54,6 +65,7 @@ let test_mark_acquire_then_release () =
 
 let test_second_mark_acquire_advances_hold_id () =
   Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun _sw ->
   (* PR-B / dashboard_governance_judge surfaced [hold_id] as a
      monotonic cycle identifier.  The same pattern applies here:
      the second [mark_acquire] returns a strictly larger
@@ -77,6 +89,7 @@ let test_second_mark_acquire_advances_hold_id () =
 
 let test_stray_mark_release_is_noop () =
   Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun _sw ->
   let kind = FA.Provider_http in
   let () = check int "idle baseline 0" 0 (FA.read_holding ~kind) in
   (* Stray release on Idle: a user-site exception path that
@@ -88,6 +101,7 @@ let test_stray_mark_release_is_noop () =
 
 let test_kinds_are_independent () =
   Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun _sw ->
   let a = FA.Docker_spawn in
   let b = FA.Sandbox_exec in
   let _ = FA.mark_acquire ~kind:a in
@@ -99,6 +113,7 @@ let test_kinds_are_independent () =
 
 let test_idle_after_release_under_concurrent_reader () =
   Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun _sw ->
   (* Regression: a previous [Eio.Switch.on_release] callback
      could over-decrement and the [max 0 (... - 1)] clamp would
      mask the leak (the projection was 0 even when the


### PR DESCRIPTION
# [PR-C1.1] test/test_fd_accountant_state.ml: wrap tests in Eio.Switch.run

Follow-up to **PR #20604 (PR-C1 MERGED)** which introduced the typed
`fd_holding_state` state machine and the white-box test file
`test_fd_accountant_state.ml` driving `mark_acquire` / `mark_release` /
`read_holding` directly.

## Symptom (on merged SHA 37dfb8067)

3 of 6 tests in `test_fd_accountant_state` failed on the merged SHA:

- `test_idle_projects_to_zero`: `Effect.Unhandled(Cancel.Get_context)` at
  `test_fd_accountant_state.ml:38` (the very first `FA.read_holding` call
  had no `Eio.Switch.run` wrapper).
- `test_mark_acquire_then_release`: `Eio__Eio_mutex.Poisoned(_)` —
  inherited from the previous test's uncaught `Get_context`.
- `test_kinds_are_independent`: `Eio__Eio_mutex.Poisoned(_)` — same
  cascading poison.

## Root cause

`mark_acquire_slot` / `mark_release_slot` / `read_holding_slot`
(`lib/fd_accountant/fd_accountant.ml:111-127`) all use
`Eio.Mutex.use_rw ~protect:true`.  With `~protect:true`, Eio wraps the
critical section in `Cancel.protect`, which performs
`Cancel.Get_context` (`Eio/core/cancel.ml`).  `Eio.Switch.run` is the
ONLY handler for that effect (`Eio/core/switch.ml` — `run_internal` is
the dispatcher).

In production this works because `with_slot` (`fd_accountant.ml:179-185`)
opens an `Eio.Switch.run` scope before calling the slot transition
functions.  The new white-box tests called the same slot transitions
**without** the surrounding switch, so even an Idle read failed at the
first `use_rw ~protect:true` call.

After the first test's `Effect.Unhandled` propagated out, the mutex was
permanently `Poisoned`, and every subsequent test in the same process
also failed.

## Fix

Wrap all six test bodies in
```ocaml
Eio_main.run @@ fun _env ->
Eio.Switch.run @@ fun _sw ->
  ...
```

so the mutex's `Cancel.protect` scope has a valid cancel context.  This
mirrors PR-B's `dashboard_governance_judge` tests, which use the same
wrap pattern.  The first test carries the explanatory comment; the
other five use the same one-line wrapper without duplication.

## Verification (merged SHA 37dfb8067)

- `dune exec --root . test/test_fd_accountant_state.exe` → **6/6 pass**.
- `dune build --root . @check` → exit 0.
- `test_fd_accountant` regression check: 5 pre-existing failures
  (kind discrimination 3, slot semantics 5, process 3, 4, 5) — verified
  by `git stash` + rerun that the same 5 fail on the bare merged SHA
  before this commit.  None of the 5 are caused by this commit.

The 5 pre-existing `test_fd_accountant` failures are independent of
PR-C1 / PR-C1.1 and are tracked separately.

## Diff

| File | Lines | Change |
|------|-------|--------|
| `test/test_fd_accountant_state.ml` | +15/-0 | Wrap all 6 test bodies in `Eio.Switch.run`. 1 explanatory comment on test 1. |

## Out of scope

- The 5 pre-existing `test_fd_accountant` failures (Bg_task lifetime
  mutex cascade, Keeper_fd_pressure cache, child binding) — separate
  audit, not caused by this commit.
- The 5 pre-existing `test_fd_accountant` failures are a *test-harness*
  problem (module-level state persists across tests) not a *production*
  problem.  Production never has a poisoned mutex because PR-C1's
  typed state machine prevents the path that poisons it.
