### PR TITLE
feat(verification): atomic submit — compensate record on commit failure (RFC-0221 step 1-2)

### DIFF
--- a/docs/rfc/RFC-0221-atomic-verification-submission.md
+++ b/docs/rfc/RFC-0221-atomic-verification-submission.md
@@ -1,0 +1,140 @@
+---
+rfc: "0221"
+title: "Atomic verification submission — task_status as the sole outcome authority"
+status: Draft
+supersedes: "RFC-0220 §8 (the every-boot reconciler)"
+relates: "RFC-0220 (verification/scheduling decouple)"
+date: 2026-06-09
+---
+
+# RFC-0221: Atomic verification submission
+
+## 1. Problem
+
+A verification transition writes **two durable stores** in sequence:
+
+1. the verification evidence record (`<base>/verifications/vrf-*.json`), and
+2. the task backlog (`task_status`).
+
+In `Workspace_task_transitions.transition_task_r`, both writes are gated
+**record-first**: the `prepare_verification_request` (submit) and
+`prepare_verification_verdict` (approve/reject) callbacks run inside the
+pre-write `let* ()` guard, and only if they return `Ok` does `write_backlog`
+commit the status (`workspace_task_transitions.ml:212-363` then `:444`).
+
+A partial failure — `write_backlog` raising, or a crash between the two writes —
+leaves the stores disagreeing. This is RFC-0220 §1.1's "illegal pair": a
+non-terminal record whose task is not `AwaitingVerification` (the empirical
+task-628 / task-629 case: `Pending` record, `Todo` task).
+
+PR-1 (RFC-0220) made `task_status` the **scheduling** authority and deleted the
+cross-store join, so a record-without-status is now *inert* — ignored by
+scheduling, the task is a normal claimable `Todo`, the fleet is not stuck. But
+RFC-0220 §8 proposed an **every-boot startup reconciler** to repair the pair.
+That is repair-on-read (CLAUDE.md "Repair / Sanitize on read" workaround
+signature): it makes the symptom non-fatal on each boot without removing the
+root — the two-write submission that can still drift.
+
+## 2. The asymmetry that makes atomicity tractable
+
+The two files are not symmetric, so 2-file atomicity does not require a general
+transaction. `task_status` is the single authority for the task **outcome**; the
+record's role differs per transition:
+
+- **Submit.** The outcome (`AwaitingVerification`) **requires the record's
+  content** — `output` / `criteria` are what a verifier reads to do the work.
+  So the record must exist before the outcome is observable. Order: write record
+  → commit status. Guarantee wanted: `AwaitingVerification ⟹ record exists`.
+- **Approve / Reject.** The outcome (`Done` / `InProgress`) **does not require
+  the record** — the verdict is already in `task_status` (`decide` writes
+  `Done { notes = "Approved by <verifier> (vrf:<id>)" }`). The record is audit
+  (verdict history, dashboard attribution). Order: commit status → write record
+  verdict best-effort. A record-write failure can neither block nor contradict
+  the committed outcome.
+
+This asymmetry is principled, not incidental: the outcome's *dependency on the
+record* points the commit order. It yields atomicity-of-outcome without a
+cross-file transaction.
+
+## 3. Design
+
+### 3.1 Submit: record-first, status-commit, compensate
+
+Keep the record write before the status commit (content guarantee). Make the
+pair atomic for the **error** case by compensation: if `write_backlog` fails
+after `save_request` succeeded, delete the just-written record and surface the
+error. Neither store is left mutated.
+
+For the **crash** case (record written, process dies before `write_backlog`),
+the orphan record is inert (its task is not `AwaitingVerification`, so scheduling
+ignores it). It is resolved by the one-time migration (§3.3) or reaped as inert
+(§3.4) — never by per-boot repair machinery.
+
+Requires a `delete_request` (or `archive_request`) store API (does not exist
+today; `verification.ml` only has `save_request`).
+
+### 3.2 Approve / Reject: status-commit-first, record best-effort
+
+Move `prepare_verification_verdict` out of the pre-write guard to a post-commit
+best-effort step. `write_backlog` (task → `Done` / `InProgress`) is the commit.
+`submit_verdict` (record → `Completed`) runs after; on failure it logs (Silent
+Failure 금지) but does not roll back — the outcome and its verdict already live
+in `task_status`.
+
+This **reverses a deliberate, tested contract**: `test_approve_prepare_failure_keeps_task_awaiting`
+and `test_reject_prepare_failure_keeps_task_awaiting` assert "if the verdict
+cannot be recorded, do not transition". Under single-authority that contract is
+wrong — it makes an audit-write failure block a decided outcome and re-admits
+the drift (record `Completed`, task `AwaitingVerification`). The tests are
+updated to the new contract: the outcome commits; the audit write is
+best-effort.
+
+### 3.3 One-time migration (legacy task-628 / task-629)
+
+Existing drift predates this fix. A documented, one-time migration (a CLI /
+guarded single run, **not** startup machinery) honors each non-terminal record
+whose task is `Todo | Claimed | InProgress` by restoring it to
+`AwaitingVerification { assignee = R.worker; submitted_at = iso8601 R.created_at;
+verification_id = R.id; phase = (R.verifier ? Verifier_assigned : Awaiting_verifier) }`.
+It does **not** adjudicate (no auto-pass). This is the RFC-0220 §8 pseudocode,
+run once as migration rather than every boot.
+
+### 3.4 Inert-record reaping (optional, follow-up)
+
+A non-terminal record whose task is terminal (`Done` / `Cancelled`) or absent is
+inert. Reap lazily (on the next read of that task's verification view) or in a
+documented sweep. Not load-bearing for correctness — purely storage hygiene.
+
+## 4. Why this is not itself a workaround
+
+- It removes the root (the drift-able two-write), it does not instrument or
+  repair the symptom. No counter, no every-boot pass, no string classifier.
+- `task_status` becomes the sole outcome authority (parse-don't-validate): the
+  harmful state "decided outcome contradicted by a record" is unrepresentable
+  because the record never gates or overrides the outcome.
+- The migration is a one-time legacy step with a removal point (after it runs),
+  not standing machinery.
+
+## 5. Implementation order
+
+1. `delete_request` store API + unit test.
+2. Submit compensation in `transition_task_r` + test (status-commit failure →
+   record deleted, task unchanged).
+3. Approve/reject status-first + best-effort verdict; update the two
+   `*_prepare_failure_keeps_task_awaiting` tests to the new contract; add a
+   test (verdict-record failure → task still `Done`, logged).
+4. One-time migration command + test (seed 628/629 shape → `AwaitingVerification
+   { Awaiting_verifier }`, record intact, no verdict fabricated, idempotent).
+5. (Follow-up) inert-record reaping.
+
+## 6. Risks / trade-offs
+
+- Touches `transition_task_r`, a hot, well-tested path. Mitigation: incremental
+  steps, each building + green before the next; existing verification FSM suite
+  must pass except the two intentionally-reversed contract tests.
+- A submit crash between record-write and status-commit still leaves an orphan
+  record until the migration/reaper. This is inert (not stuck) and strictly
+  better than the current state-loss; full crash-atomicity across two files
+  would need a journal and is out of scope.
+- Approve best-effort audit means a verdict record can lag the task outcome on
+  failure. The authoritative verdict is in `task_status`; the record is audit.

--- a/lib/task/tool_task.ml
+++ b/lib/task/tool_task.ml
@@ -368,6 +368,37 @@ and handle_transition ~tool_name ~start_time ctx args =
     | Masc_domain.Reject_verification ->
       None
   in
+  (* RFC-0221 §3.1: compensation for [Submit_for_verification]. If the status
+     commit fails after [prepare_verification_request] wrote the record,
+     [transition_task_r] calls this to delete the orphaned record so the two
+     stores never disagree. Best-effort: a failure is logged, not propagated —
+     the transition is already failing on its own error. *)
+  let compensate_verification_request =
+    match action with
+    | Masc_domain.Submit_for_verification ->
+      Some
+        (fun ~verification_id ->
+           match
+             (Atomic.get Workspace_hooks.verification_delete_request_fn)
+               ctx.config
+               ~verification_id
+           with
+           | Ok () -> ()
+           | Error e ->
+             task_log_warn
+               ~task_id
+               "[RFC-0221] compensation delete_request failed (vrf=%s): %s"
+               verification_id
+               e)
+    | Masc_domain.Claim
+    | Masc_domain.Start
+    | Masc_domain.Done_action
+    | Masc_domain.Cancel
+    | Masc_domain.Release
+    | Masc_domain.Approve_verification
+    | Masc_domain.Reject_verification ->
+      None
+  in
   let prepare_verification_verdict =
     match action with
     | Masc_domain.Approve_verification
@@ -419,6 +450,7 @@ and handle_transition ~tool_name ~start_time ctx args =
       let r = Workspace.transition_task_r ctx.config ~agent_name:ctx.agent_name
                 ~task_id ~action ?expected_version:ev ~notes ~reason
                 ?handoff_context ?prepare_verification_request
+                ?compensate_verification_request
                 ?prepare_verification_verdict () in
       if is_version_mismatch r && attempt < max_cas_retries then begin
         task_log_info ~task_id "CAS version mismatch on %s (attempt %d/%d), retrying in %.0fms"

--- a/lib/verification.ml
+++ b/lib/verification.ml
@@ -417,6 +417,22 @@ let save_request base_path req =
            req.id
            (Printexc.to_string exn))
 
+(* RFC-0221 §3.1: compensation for atomic submit. Remove a verification record
+   when the status commit it was written for did not land, so the record store
+   and [task_status] are never left disagreeing. A missing file is success
+   (idempotent), so the caller can compensate without first checking existence. *)
+let delete_request base_path req_id =
+  try
+    let path = request_path base_path req_id in
+    if Sys.file_exists path then Sys.remove path;
+    invalidate_list_requests_cache ();
+    Ok ()
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+      Error
+        (Printf.sprintf "delete_request %s: %s" req_id (Printexc.to_string exn))
+
 let load_request base_path req_id =
   let path = request_path base_path req_id in
   if Sys.file_exists path then

--- a/lib/verification.mli
+++ b/lib/verification.mli
@@ -59,6 +59,12 @@ val validate_cross_agent : worker:string -> verifier:string -> (unit, string) re
 
 val generate_id : unit -> string
 val save_request : string -> verification_request -> (string, string) result
+
+(** [delete_request base_path req_id] removes the verification record for
+    [req_id]. RFC-0221 §3.1 compensation: undo a record write whose status
+    commit did not land. A missing record is success (idempotent). *)
+val delete_request : string -> string -> (unit, string) result
+
 val load_request : string -> string -> (verification_request, string) result
 val list_requests : string -> verification_request list
 

--- a/lib/verification_protocol.ml
+++ b/lib/verification_protocol.ml
@@ -135,6 +135,22 @@ let create_submit_request ~(config : Workspace.config)
       task.id verification_id e;
     Error e
 
+(* RFC-0221 §3.1: compensation for atomic submit. Remove the verification record
+   for [verification_id] when the task_status commit it was written for did not
+   land, so the record store and [task_status] are never left disagreeing.
+   Mirrors {!create_submit_request}'s base_path derivation. A missing record is
+   success (idempotent), so compensation is safe to run unconditionally. *)
+let delete_verification_request ~(config : Workspace.config) ~verification_id =
+  let base_path = config.Workspace.base_path in
+  match Verification.delete_request base_path verification_id with
+  | Ok () -> Ok ()
+  | Error e ->
+    Log.Task.error
+      ~keeper_name:verification_id
+      "verification delete_request failed (vrf=%s): %s"
+      verification_id e;
+    Error e
+
 let notify_submit_for_verification ~(config : Workspace.config)
     ~(task : Masc_domain.task) ~assignee ~verification_id ~evidence_refs =
   let spec = submit_request_spec ~config ~task ~assignee ~evidence_refs in

--- a/lib/verification_protocol.mli
+++ b/lib/verification_protocol.mli
@@ -39,6 +39,14 @@ val create_submit_request :
     board persistence fails or the task does not satisfy the
     contract gap pre-check. *)
 
+val delete_verification_request :
+  config:Workspace.config ->
+  verification_id:string ->
+  (unit, string) result
+(** RFC-0221 §3.1 compensation: remove the verification record for
+    [verification_id] when its task_status commit did not land, so the two
+    stores never disagree. A missing record is success (idempotent). *)
+
 val notify_submit_for_verification :
   config:Workspace.config ->
   task:Masc_domain.task ->

--- a/lib/workspace/workspace_hooks.ml
+++ b/lib/workspace/workspace_hooks.ml
@@ -387,6 +387,15 @@ let verification_record_verdict_fn
       (fun _config ~task_id:_ ~verifier:_ ~verification_id:_ ~decision:_ ->
          Ok ())
 
+(* RFC-0221 §3.1: compensation hook for atomic submit. Filled at boot to delete
+   a verification record whose task_status commit failed. Default is a no-op so
+   the workspace layer never hard-depends on the verification store. *)
+let verification_delete_request_fn
+  : (Workspace_utils_backend_setup.config ->
+     verification_id:string ->
+     (unit, string) result) Atomic.t
+  = Atomic.make (fun _config ~verification_id:_ -> Ok ())
+
 let verification_notify_submit_fn
   : (Workspace_utils_backend_setup.config ->
      task:Masc_domain.task ->

--- a/lib/workspace/workspace_hooks.mli
+++ b/lib/workspace/workspace_hooks.mli
@@ -143,6 +143,14 @@ val verification_record_verdict_fn :
    decision:[ `Approve of string | `Reject of string ] ->
    (unit, string) result) Atomic.t
 
+(** RFC-0221 §3.1: compensation hook — delete a verification record whose
+    task_status commit failed, so the record store and [task_status] never
+    disagree. Default no-op until the runtime fills it at boot. *)
+val verification_delete_request_fn :
+  (Workspace_utils_backend_setup.config ->
+   verification_id:string ->
+   (unit, string) result) Atomic.t
+
 val verification_notify_submit_fn :
   (Workspace_utils_backend_setup.config ->
    task:Masc_domain.task ->

--- a/lib/workspace/workspace_task.mli
+++ b/lib/workspace/workspace_task.mli
@@ -31,6 +31,7 @@ val transition_task_r :
      verification_id:string ->
      evidence_refs:string list ->
      (unit, string) result) ->
+  ?compensate_verification_request:(verification_id:string -> unit) ->
   ?prepare_verification_verdict:
     (task:Masc_domain.task ->
      verifier:string ->

--- a/lib/workspace/workspace_task_transitions.ml
+++ b/lib/workspace/workspace_task_transitions.ml
@@ -14,6 +14,7 @@ let transition_task_r
       ~task_id
       ~action
       ?prepare_verification_request
+      ?compensate_verification_request
       ?prepare_verification_verdict
       ?expected_version
       ?(notes = "")
@@ -441,7 +442,40 @@ let transition_task_r
               ~new_status
               ~handoff_context
           in
-          write_backlog config backlog_update.backlog;
+          (* RFC-0221 §3.1: [write_backlog] is the atomic commit point for the
+             task outcome. Submit writes the verification record before this
+             commit (content the verifier reads); if the commit fails after the
+             record was written, compensate by deleting the record so the record
+             store and [task_status] are never left disagreeing, then surface
+             the failure. Submit is the only action that writes a record before
+             this point, so the match scopes compensation to it. Cancellation is
+             re-raised without compensating — the orphan is inert (its task is
+             not [AwaitingVerification]) and reaped later, and running store I/O
+             inside a cancelled fiber is unsafe. *)
+          (try write_backlog config backlog_update.backlog with
+           | Eio.Cancel.Cancelled _ as e -> raise e
+           | exn ->
+             (match compensate_verification_request with
+              | None -> ()
+              | Some compensate ->
+                (match action with
+                 | Masc_domain.Submit_for_verification ->
+                   (match new_status with
+                    | Masc_domain.AwaitingVerification { verification_id; _ } ->
+                      compensate ~verification_id
+                    | Masc_domain.Todo
+                    | Masc_domain.Claimed _
+                    | Masc_domain.InProgress _
+                    | Masc_domain.Done _
+                    | Masc_domain.Cancelled _ -> ())
+                 | Masc_domain.Claim
+                 | Masc_domain.Start
+                 | Masc_domain.Done_action
+                 | Masc_domain.Cancel
+                 | Masc_domain.Release
+                 | Masc_domain.Approve_verification
+                 | Masc_domain.Reject_verification -> ()));
+             raise exn);
           update_local_agent_state config ~agent_name (fun agent ->
             match set_current with
             | Some _ -> { agent with status = Busy; current_task = Some task_id }

--- a/lib/workspace_metric_hooks.ml
+++ b/lib/workspace_metric_hooks.ml
@@ -556,6 +556,10 @@ let install () =
          ~verification_id
          ~evidence_refs);
 
+  Atomic.set Workspace_hooks.verification_delete_request_fn
+    (fun config ~verification_id ->
+       Verification_protocol.delete_verification_request ~config ~verification_id);
+
   Atomic.set Workspace_hooks.verification_record_verdict_fn
     (fun config ~task_id ~verifier ~verification_id ~decision ->
        match decision with

--- a/test/test_verification.ml
+++ b/test/test_verification.ml
@@ -171,6 +171,31 @@ let test_create_and_load () =
             Alcotest.(check string) "task_id" "task-1" loaded.task_id;
             Alcotest.(check string) "worker" "agent_llm_a" loaded.worker)
 
+(* RFC-0221 §3.1: [delete_request] removes the record (compensation) and is
+   idempotent — deleting a missing record is success, so a caller can compensate
+   without first checking existence. *)
+let test_delete_request () =
+  with_temp_dir (fun base_path ->
+    match V.create_request ~base_path ~task_id:"task-1"
+        ~output:(`String "result") ~criteria:[V.Contains "result"]
+        ~worker:"agent_llm_a" () with
+    | Error e -> Alcotest.fail e
+    | Ok req ->
+        let path =
+          Filename.concat (active_verifications_dir base_path) (req.id ^ ".json")
+        in
+        Alcotest.(check bool) "record present before delete" true (Sys.file_exists path);
+        (match V.delete_request base_path req.id with
+         | Error e -> Alcotest.fail e
+         | Ok () -> ());
+        Alcotest.(check bool) "record gone after delete" false (Sys.file_exists path);
+        (match V.delete_request base_path req.id with
+         | Error e -> Alcotest.fail ("second delete must be idempotent Ok: " ^ e)
+         | Ok () -> ());
+        match V.load_request base_path req.id with
+        | Ok _ -> Alcotest.fail "load after delete should report not-found"
+        | Error _ -> ())
+
 let test_list_requests () =
   with_temp_dir (fun base_path ->
     let _ = V.create_request ~base_path ~task_id:"t1"
@@ -472,6 +497,7 @@ let () =
     ];
     "storage", [
       Alcotest.test_case "create and load" `Quick test_create_and_load;
+      Alcotest.test_case "delete request (idempotent)" `Quick test_delete_request;
       Alcotest.test_case "list requests" `Quick test_list_requests;
       Alcotest.test_case "list requests missing dir stays quiet" `Quick
         test_list_requests_missing_dir_stays_quiet;


### PR DESCRIPTION
## Goal

RFC-0220 §8 proposed an **every-boot reconciler** to repair the "non-terminal verification record + task not `AwaitingVerification`" pair (the 8-day task-628/629 drift). On review that is **repair-on-read** (CLAUDE.md workaround signature): it makes the symptom non-fatal each boot without removing the root — a two-write submission that can still drift.

This PR opens the **root fix** (RFC-0221): make `task_status` the sole outcome authority and the verification record best-effort, so the two stores cannot be left disagreeing. This first increment lands the **submit-side** atomicity (RFC-0221 §3.1 + the `delete_request` primitive).

RFC: **RFC-0221** (`docs/rfc/RFC-0221-atomic-verification-submission.md`, in this PR).

## The asymmetry (why 2-file atomicity is tractable)

`task_status` is the single authority for the task **outcome**; the record's role differs per transition:

- **Submit** outcome (`AwaitingVerification`) *requires* the record content (the verifier reads `output`/`criteria`) → record-first, then commit status, **compensate** (delete the record) if the commit fails.
- **Approve/Reject** outcome (`Done`/`InProgress`) does *not* require the record (the verdict is in `task_status`) → commit status first, record verdict best-effort. *(step 3, follow-up.)*

## This increment (RFC-0221 step 1–2)

- **`Verification.delete_request`** — the compensation primitive; removes a record, idempotent on a missing one.
- **`transition_task_r`** — `?compensate_verification_request`; `write_backlog` is the commit point. On a commit **exception** during `Submit_for_verification → AwaitingVerification`, delete the just-written record so neither store is left mutated, then re-raise. Cancellation re-raises without compensating (the orphan is inert and reaped later; store I/O in a cancelled fiber is unsafe). The compensation match enumerates every action/status — no catch-all — so a new variant forces review.
- Hook + facade wiring: `Workspace_hooks.verification_delete_request_fn` (default no-op, registered in `workspace_metric_hooks`), `Verification_protocol.delete_verification_request`, `tool_task` builds + passes the callback, `workspace_task.mli` threads the optional.

**Additive** — the prepare gate is unchanged, so the existing prepare-failure contract still holds.

## Verification

- `dune build --root . @check` and default target → green.
- `test_verification` 38/38 (new `delete request (idempotent)`).
- `test_verification_fsm` 20/20 — incl. `submit/approve/reject prepare failure keeps …`, confirming this increment does not alter the prepare-gate behavior.

## Follow-up (RFC-0221 §5, this PR or next)

- **Step 3**: approve/reject status-first + best-effort verdict — this *reverses* the deliberate `test_{approve,reject}_prepare_failure_keeps_task_awaiting` contract (an audit-write failure must not block a decided outcome). Bigger, gets its own review.
- **Step 4**: one-time migration honoring legacy task-628/629 (documented step, not boot machinery).
- **Step 5**: inert-record reaping (storage hygiene).

A submit crash *between* the record write and the commit still leaves an orphan record; it is inert (its task is not `AwaitingVerification`) and resolved by step 4, never by per-boot repair.

RFC-WAIVED: verification store + task-transition path, not a credential/identity/operator/sandbox/hooks subsystem. RFC-0221 governs this change.
