### PR TITLE
fix(otel): force fresh trace root per keeper turn to split monolithic traces

### DIFF
--- a/lib/otel_genai/otel_genai.ml
+++ b/lib/otel_genai/otel_genai.ml
@@ -229,5 +229,14 @@ let with_keeper_turn_span
     Otel_spans.with_span
       ~name:(keeper_turn_span_name ~keeper_name)
       ~attrs
+      (* Force a fresh trace root per keeper turn. Without this the keeper-turn
+         span inherits the ambient trace context, and many turns from different
+         keepers accumulate under one trace. Observed on a production trace:
+         19 invoke_agent spans in a single trace, with mixed structure (some a
+         real root, others referencing a parent span absent from the trace).
+         Mirrors the tool-dispatch boundary fix (one trace root per operation,
+         #20581). Tool dispatches already start their own trace, so this does
+         not lose a parent/child link that previously existed. *)
+      ~force_new_trace_id:true
       (fun _trace_id -> f ()))
 ;;


### PR DESCRIPTION
## 문제 (실측 audit, live production Jaeger)

`with_keeper_turn_span`(`lib/otel_genai/otel_genai.ml`)이 `force_new_trace_id` 없이 `Otel_spans.with_span`을 호출해, keeper-turn span이 ambient trace context를 상속합니다. 그 결과 서로 다른 keeper의 turn들이 한 trace에 누적됩니다.

**production trace 관측 (commit `c36e0d1`):**
- trace `d7bb1653` / `955040d4`: 한 trace에 **19개 `invoke_agent` span**(garnet, echo, verifier, rondo, nick0cave 등 서로 다른 keeper)
- root span 구조 혼재: 일부는 진짜 root(parent 없음), 일부는 같은 trace 안에 존재하지 않는 부모 span을 참조(dangling)

이는 PR #20609(self-trace 오염 제거)와 함께 원래의 "monolithic keeper-turn trace" 문제의 두 번째 축입니다. #20609는 noise(encode-proto 99%)를 제거했고, 이 PR은 turn 경계 분리를 다룹니다.

## 변경

`with_keeper_turn_span`의 span 생성에 `~force_new_trace_id:true` 추가 (tool_dispatch 경계에 적용한 #20581과 동일 패턴). keeper turn마다 독립 trace root를 시작합니다.

`tool_dispatch`는 이미 자체 trace를 시작(force_new)하므로, keeper turn을 force_new로 바꿔도 **기존에 존재하던 부모-자식 링크를 잃지 않습니다**.

메커니즘(어떤 long-lived 부모 span이 turn들을 묶었는지)은 단정하지 않고, 관측된 사실(다수 turn이 한 trace_id 공유 + root/dangling 혼재 구조)과 fix 동작(turn마다 trace root 강제)만 기록합니다.

## 검증 계획 (Draft 유지)

- [x] `dune build --root . lib/otel_genai/` PASS
- [ ] 재배포 후 **실제 keeper turn이 발생한** 새 `invoke_agent` trace 조회 → root span 1개 + 다른 keeper의 invoke_agent가 같은 trace에 없음 확인
  - 주의: 외부 MCP tool 호출(masc_status)은 tool_dispatch trace만 만들고 keeper turn을 발화시키지 않음. fleet의 자율 turn 활동 필요.

RFC-WAIVED: telemetry trace 구조 개선으로 RFC 게이트 subsystem(credential/operator/keeper sandbox/dashboard credential/hooks/workflow) 비해당.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
