### PR TITLE
fix(keeper): make search op a closed enum + steer directory listing in descriptors

### DIFF
--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -166,6 +166,21 @@ let property name typ description =
   name, `Assoc [ "type", `String typ; "description", `String description ]
 ;;
 
+(* String property constrained to a closed set of values. Use when the
+   accepted values are a finite, code-defined set so the schema is a
+   single source of truth with the runtime dispatch (parse, don't
+   validate): the model is told the exact options up front instead of
+   guessing a free-form string. [values] should be derived from the
+   runtime's own enumeration, never hand-listed. *)
+let property_enum name ~values description =
+  ( name
+  , `Assoc
+      [ "type", `String "string"
+      ; "enum", `List (List.map (fun v -> `String v) values)
+      ; "description", `String description
+      ] )
+;;
+
 let object_schema ?(required = []) properties =
   `Assoc
     [ "type", `String "object"
@@ -235,10 +250,13 @@ let write_file_schema =
 let search_files_schema =
   object_schema
     ~required:[]
-    [ property
+    [ property_enum
         "op"
-        "string"
-        "Structured operation to run (e.g. 'rg', 'ls', 'tree', 'git_status'). Defaults to 'rg' when pattern is provided."
+        ~values:Keeper_workspace_op.valid_strings
+        "Structured operation to run. Use op='ls' (or 'tree') to list a \
+         directory's contents, op='rg' to search file contents, op='cat' to \
+         read a file, op='git_status'/'git_log'/'git_diff' for git views. \
+         Defaults to 'rg' when a pattern is given."
     ; property "pattern" "string" "Regular expression to search for (required when op is 'rg')."
     ; property
         "path"
@@ -493,9 +511,10 @@ let public_descriptors =
       ~public_aliases:[ "Search" ]
       ~internal_name:"tool_search_files"
       ~description:
-        "Inspect the project workspace through structured read-only operations \
-         including ripgrep search, file reads, directory listings, and scoped \
-         git status/log/diff views."
+        "Inspect the project workspace through structured read-only operations. \
+         To list a directory's contents use op='ls' (or op='tree'); to search \
+         file contents use op='rg'; also supports file reads (op='cat') and \
+         scoped git status/log/diff views."
       ~input_schema:search_files_schema
       ~policy:
         (policy
@@ -516,8 +535,9 @@ let public_descriptors =
       ~internal_name:"tool_read_file"
       ~description:
         "Read one existing file from the keeper sandbox or an allowed path with no \
-         implicit cwd. Pass cwd explicitly for repo-relative reads. Read never \
-         inherits Execute cwd."
+         implicit cwd. Read targets a single FILE; to list a directory's contents \
+         use Grep with op='ls'. Pass cwd explicitly for repo-relative reads. Read \
+         never inherits Execute cwd."
       ~input_schema:read_file_schema
       ~policy:
         (policy

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -461,6 +461,19 @@ let keeper_board_search_schema =
 let tool_execute_schema =
   find_schema_exn "tool_execute" Config.raw_all_tool_schemas
 
+let keeper_search_files_schema =
+  find_schema_exn "tool_search_files" Config.raw_all_tool_schemas
+
+(* Every op the runtime dispatch in keeper_workspace_read_ops.ml handles.
+   The search_files schema constrains op to a closed enum derived from
+   Keeper_workspace_op.valid_strings (the SAME SSOT the runtime uses), so a
+   schema enum narrower than this set would reject ops that actually work —
+   the failure mode if someone hand-lists only the directory-listing ops.
+   This list mirrors the runtime match arms. *)
+let runtime_search_ops =
+  [ "pwd"; "ls"; "cat"; "rg"; "git_status"; "find"
+  ; "head"; "tail"; "wc"; "tree"; "git_log"; "git_diff" ]
+
 let assoc_string key json =
   match Yojson.Safe.Util.member key json with
   | `String value -> value
@@ -604,6 +617,50 @@ let test_validate_args_keeper_board_list_rejects_unknown_field () =
       "expected unknown field to be rejected, but it passed: %s"
       (Yojson.Safe.to_string forwarded)
   | Error _ -> ()
+
+(* The op enum (derived from Keeper_workspace_op.valid_strings) must accept
+   EVERY op the runtime dispatch handles. Guards the regression where the
+   enum is hand-listed with only the directory-listing ops, silently
+   breaking cat/pwd/find/head/tail/wc/git_log/git_diff. *)
+let test_search_op_enum_accepts_all_runtime_ops () =
+  List.iter
+    (fun op ->
+      match
+        Tool_input_validation.validate_args
+          ~schema:keeper_search_files_schema
+          ~name:"tool_search_files"
+          ~args:(`Assoc [ "op", `String op; "pattern", `String "x" ])
+          ()
+      with
+      | Ok _ -> ()
+      | Error result ->
+        Alcotest.failf
+          "runtime op %S rejected by search_files schema enum: %s"
+          op
+          (Yojson.Safe.to_string (Tool_result.data result)))
+    runtime_search_ops
+
+(* Documents where enforcement actually lives. The schema enum on `op` is
+   ADVISORY: it tells the model the exact valid set (discoverability), but
+   Tool_input_validation does NOT enforce JSON-Schema enum, so an unknown op
+   passes validation here. The real rejection happens downstream in the
+   runtime dispatch (keeper_workspace_ops.ml: unknown op -> "unsupported_op"
+   with supported_ops = Keeper_workspace_op.valid_strings). If a future
+   validator starts enforcing enum, this test flips to Error and should be
+   updated together with the enum's role. *)
+let test_search_op_enum_is_advisory_not_validator_enforced () =
+  match
+    Tool_input_validation.validate_args
+      ~schema:keeper_search_files_schema
+      ~name:"tool_search_files"
+      ~args:(`Assoc [ "op", `String "definitely_not_an_op"; "pattern", `String "x" ])
+      ()
+  with
+  | Ok _ -> () (* expected today: enum is advisory, not validator-enforced *)
+  | Error _ ->
+    Alcotest.fail
+      "validator now enforces the op enum — update this test and the \
+       enum's documented role (advisory -> enforced)"
 
 let param_by_name name params =
   List.find_opt
@@ -1724,6 +1781,10 @@ let () =
         test_validate_args_keeper_board_search_accepts_compact;
       Alcotest.test_case "keeper_board_list still rejects unknown field" `Quick
         test_validate_args_keeper_board_list_rejects_unknown_field;
+      Alcotest.test_case "search op enum accepts all runtime ops" `Quick
+        test_search_op_enum_accepts_all_runtime_ops;
+      Alcotest.test_case "search op enum is advisory (not validator-enforced)" `Quick
+        test_search_op_enum_is_advisory_not_validator_enforced;
       Alcotest.test_case "tool_execute exposes typed boundary" `Quick
         test_tool_execute_schema_exposes_typed_boundary;
       Alcotest.test_case "tool_execute rejects empty args with class" `Quick


### PR DESCRIPTION
## 목표

keeper가 디렉토리를 Read하다 실패하는 반복 패턴(~23건/3일, Issue #20602 lane 3)의 **근본**을 친다 — affordance/discoverability. 에러 메시지 땜질(#20611)이 아니라, keeper가 애초에 디렉토리를 Read하지 않도록 op='ls'를 도구 선택 시점에 보이게 한다.

## 근본 원인 (측정됨)

- keeper들이 코드 구조 탐색(lib/keeper, repos, .worktrees) 시 "이 경로를 보자"의 자연스러운 동사인 **Read**를 친다. directory-listing 능력(op='ls')은 검색 동사인 **Grep** 안에 free-form string op로 묻혀 있어 keeper가 7-tool 목록에서 떠올리지 못한다.
- **메시지 fix는 반증됨**: "use the read/listing tools" 문구는 #20312(6/6)부터 live였고 그 채로 32건 발생. 메시지 3번 수정해도 행동 불변 (Read 분석은 별도 Workflow로 fleet log 검증).
- keeper recovery는 13/13(100%)이라 심각도는 낮음(대부분 5초 tool-call 1회 낭비). 그래서 Read 의미론 재설계(union)는 과잉으로 판단, **op enum + descriptor**로 right-size.

## 변경

1. **`search_files_schema` op: free-form string → closed enum**, `Keeper_workspace_op.valid_strings`(런타임 dispatch와 동일 SSOT)에서 파생. description이 op='ls'/'tree'를 앞세움.
2. **Grep description**: "to list a directory's contents use op='ls'" 앞세움.
3. **Read description**: "Read targets a single FILE; to list a directory use Grep with op='ls'" — keeper의 자연스러운 첫 선택을 redirect.

`property_enum` 헬퍼 추가 (enum을 SSOT에서 파생, 하드코딩 금지).

## 정직한 scope

- **enum은 advisory**: `Tool_input_validation`은 JSON-Schema enum을 강제하지 **않는다**(테스트로 측정·문서화). unknown op는 input validation을 통과하고, 실제 거부는 런타임 dispatch(`keeper_workspace_ops.ml` → `unsupported_op`)가 한다. enum의 가치는 **discoverability(모델이 valid set을 봄) + schema/runtime SSOT 정렬**이지 새 validation gate가 아니다.
- **Read total화(union)는 의도적으로 deferred**: 이 discovery fix만으로 incident rate가 줄어드는지 fleet log로 측정 후 부족하면 escalate.

## 검증

- `test_tool_input_validation.ml`:
  - `search op enum accepts all runtime ops`: 12개 런타임 op 전부 schema 통과 (enum을 listing op 4개로만 하드코딩하면 cat/pwd/find/head/tail/wc/git_log/git_diff가 깨지는 회귀 방지).
  - `search op enum is advisory (not validator-enforced)`: enum이 validator 강제가 아님을 문서화 (미래에 강제되면 테스트가 flip).
- 72 tests 통과.

## 성공 지표

배포 후 fleet log(`~/me/.masc/logs/system_log_*.jsonl`)의 `path_is_directory` 라인 수가 ~0으로 감소하는가 (baseline 32라인/10 events, 06-08+06-09). 미감소 시 Read total화로 escalate.

## gating

`lib/keeper/keeper_tool_descriptor.ml` (descriptor/schema)만 변경. `pr-rfc-check.sh` 패턴 미매치 → non-gated. cwd_scope 불변(containment 변화 없음).

## 관련

- Issue #20602 (keeper tool-failure sweep, lane 3)
- #20594 (op 파라미터 노출 — 이 PR이 그 affordance를 discoverable하게 만듦)
- #20611 (에러 메시지 — 정확한 fallback으로 유지, 보완재)
