### PR TITLE
feat(verification): approve/reject status-first, best-effort verdict audit (RFC-0221 step 3)

### DIFF
--- a/docs/rfc/RFC-0221-atomic-verification-submission.md
+++ b/docs/rfc/RFC-0221-atomic-verification-submission.md
@@ -56,6 +56,19 @@ This asymmetry is principled, not incidental: the outcome's *dependency on the
 record* points the commit order. It yields atomicity-of-outcome without a
 cross-file transaction.
 
+A second, mechanical fact forces the same order independently of the
+content-vs-audit argument: **approve has no clean compensation.** Submit
+*creates* the record, so its compensation is `delete_request` — a clean inverse
+(§3.1). Approve/reject *update* the record submit created (`Pending` →
+`Completed`). If approve went record-first, a `write_backlog` failure would need
+to revert `Completed → Pending`; the only inverse available is the `delete_request`
+from §3.1, which would erase the **submission** record entirely — destroying the
+`output` / `criteria` the verifier must read after the task bounces back to
+`AwaitingVerification`. That revert is not a transition the `Verification` state
+machine offers. No clean compensation exists, so approve/reject *cannot* be made
+record-first-with-compensation the way submit is — status-first is the only
+order that keeps the stores consistent on the error path.
+
 ## 3. Design
 
 ### 3.1 Submit: record-first, status-commit, compensate
@@ -81,6 +94,20 @@ best-effort step. `write_backlog` (task → `Done` / `InProgress`) is the commit
 Failure 금지) but does not roll back — the outcome and its verdict already live
 in `task_status`.
 
+**Reject's reason is not lost.** Reject is the one verdict whose outcome
+(`InProgress { assignee; started_at }`) carries no notes field, so the reason
+text (`~reason`) is not in `task_status`. It does not need to be: the worker's
+feedback channel is the **separate** post-commit notify
+(`verification_notify_verdict_fn` → board post `"Rejected task … : <reason>"` +
+SSE), invoked in `tool_task.ml` *after* `transition_task_r` returns `Ok` — a
+different hook from the record write (`verification_record_verdict_fn`), wired
+apart in `workspace_metric_hooks.ml`. The audit record is not the reason's
+delivery path. status-first in fact *improves* reject: under the old record-first
+gate a record-write failure returned `Error`, so the notify (which only fires on
+`Ok`) never ran and the worker was never told it was rejected. Under status-first
+the transition commits, returns `Ok`, and the notify always runs — only the audit
+record is best-effort.
+
 This **reverses a deliberate, tested contract**: `test_approve_prepare_failure_keeps_task_awaiting`
 and `test_reject_prepare_failure_keeps_task_awaiting` assert "if the verdict
 cannot be recorded, do not transition". Under single-authority that contract is
@@ -105,6 +132,36 @@ A non-terminal record whose task is terminal (`Done` / `Cancelled`) or absent is
 inert. Reap lazily (on the next read of that task's verification view) or in a
 documented sweep. Not load-bearing for correctness — purely storage hygiene.
 
+### 3.5 Why the orphan is inert (consumer audit)
+
+status-first turns *every* audit-write I/O failure (not just a rare crash) into
+the pair "record `Pending` + task `Done`/`InProgress`" — the same *shape* as the
+628/629 drift. This is benign **only if** no code acts on a `Pending` record
+without joining `task_status`. Every consumer of the task-verification record was
+enumerated (`rg "load_request|list_requests" lib/`) and classified:
+
+| Consumer | Reads `Pending`? | Class |
+|---|---|---|
+| `dashboard_verification.ml` (summary/requests JSON) | yes | display |
+| `workspace_verification_store.load_request_header` (dir listing) | yes | inventory / telemetry |
+| `keeper_world_observation_inputs.pending_verification` | yes | **behavior — but joined** |
+| `goal_verification.list_requests_for_goal` | no (different type: `goal_verification_request`) | orthogonal |
+| `verification.ml` internal (`save_request`, `submit_verdict`) | yes | mechanics |
+
+The only behavior-driving consumer is the keeper world-observation count that
+gates keeper wake/scheduling. It does **not** count raw actionable records; it
+filters `backlog.tasks` through `task_has_actionable_verification`, which returns
+`true` only when `task.task_status = AwaitingVerification` with a matching id
+(`keeper_world_observation_inputs.ml:35-45,76-82`). A `Done` task with a `Pending`
+orphan hits the `Done -> false` arm and is not counted — the join makes the count
+`task_status`-authoritative. The raw actionable-id list has no other consumer.
+
+So the orphan is **an expected benign state**, not a moved bug: no scheduler,
+timeout, claim-gate, or gauge acts on it. (Were any consumer found to act on a
+`Pending` record unjoined, the fix would be to make *that* consumer
+`task_status`-authoritative — extending single-authority — not to abandon
+status-first.)
+
 ## 4. Why this is not itself a workaround
 
 - It removes the root (the drift-able two-write), it does not instrument or
@@ -114,6 +171,20 @@ documented sweep. Not load-bearing for correctness — purely storage hygiene.
   because the record never gates or overrides the outcome.
 - The migration is a one-time legacy step with a removal point (after it runs),
   not standing machinery.
+
+The §3.4 inert-reaper looks superficially like the §8 every-boot reconciler this
+RFC rejects; it is not, and the distinction holds **only because** the §3.5 audit
+passed:
+
+- The §8 reconciler repairs a *behavior-affecting* pair on every boot — it keeps
+  a live root (the two-write drift) survivable by sanitizing on read. The root
+  still produces new drift; the reconciler hides it.
+- The §3.4 reaper GCs a *benign* stale-audit record **after** write-ordering has
+  already made `task_status` authoritative (the root is fixed, not hidden). It is
+  storage hygiene over a state §3.5 proved no behavior reads. If §3.5 had found a
+  behavior-driving unjoined consumer, the orphan would *not* be benign and the
+  reaper *would* collapse into the §8 pattern — so the two are bound: the reaper
+  is legitimate iff the consumer audit holds.
 
 ## 5. Implementation order
 

--- a/lib/workspace/workspace_task_transitions.ml
+++ b/lib/workspace/workspace_task_transitions.ml
@@ -273,82 +273,13 @@ let transition_task_r
             , _
             , None ) -> Ok ()) [@warning "-4"]
         in
-(* WORKAROUND: same justification as previous let*. *)
-        let* () =
-          (match action, task.task_status, prepare_verification_verdict with
-          | ( Masc_domain.Approve_verification
-            , Masc_domain.AwaitingVerification { verification_id; _ }
-            , Some prepare ) ->
-            (match
-               prepare
-                 ~task
-                 ~verifier:agent_name
-                 ~verification_id
-                 ~decision:(`Approve notes)
-             with
-             | Ok () -> Ok ()
-             | Error e ->
-               Error
-                 (Masc_domain.System
-                    (Masc_domain.System_error.IoError
-                       (Printf.sprintf
-                          "verification verdict persistence failed before status \
-                           transition (task=%s vrf=%s): %s"
-                          task_id
-                          verification_id
-                          e))))
-          | ( Masc_domain.Reject_verification
-            , Masc_domain.AwaitingVerification { verification_id; _ }
-            , Some prepare ) ->
-            let reject_reason = if notes <> "" then notes else reason in
-            (match
-               prepare
-                 ~task
-                 ~verifier:agent_name
-                 ~verification_id
-                 ~decision:(`Reject reject_reason)
-             with
-             | Ok () -> Ok ()
-             | Error e ->
-               Error
-                 (Masc_domain.System
-                    (Masc_domain.System_error.IoError
-                       (Printf.sprintf
-                          "verification verdict persistence failed before status \
-                           transition (task=%s vrf=%s): %s"
-                          task_id
-                          verification_id
-                          e))))
-          | ( (Masc_domain.Approve_verification | Masc_domain.Reject_verification)
-            , _
-            , Some _ ) ->
-            Error
-              (Masc_domain.Task
-                 (Masc_domain.Task_error.InvalidState
-                    (Printf.sprintf
-                       "verification verdict action did not start from \
-                        AwaitingVerification for task %s"
-                       task_id)))
-          | ( ( Masc_domain.Claim
-              | Masc_domain.Start
-              | Masc_domain.Done_action
-              | Masc_domain.Cancel
-              | Masc_domain.Release
-              | Masc_domain.Submit_for_verification
-              )
-            , _
-            , Some _ ) -> Ok ()
-          | ( ( Masc_domain.Claim
-              | Masc_domain.Start
-              | Masc_domain.Done_action
-              | Masc_domain.Cancel
-              | Masc_domain.Release
-              | Masc_domain.Submit_for_verification
-              | Masc_domain.Approve_verification
-              | Masc_domain.Reject_verification )
-            , _
-            , None ) -> Ok ()) [@warning "-4"]
-        in
+(* RFC-0221 §3.2: the approve/reject verdict record write is NOT gated here
+   anymore. [task_status] is the sole outcome authority (approve → Done with
+   the verdict in [notes]; reject → InProgress with the reason delivered via
+   the separate post-commit notify), so the record is audit, not content, and
+   it is written best-effort AFTER [write_backlog] commits — see below. The
+   old pre-write gate made an audit-write failure block a decided outcome and
+   re-admitted the drift (record Completed, task AwaitingVerification). *)
         (match decision.drift with
          | Some Workspace_task_lifecycle.Claimed_to_done_skip ->
 (* FSM drift: TLA+ KeeperTaskInterlock.DoneTask requires in_progress. *)
@@ -476,6 +407,70 @@ let transition_task_r
                  | Masc_domain.Approve_verification
                  | Masc_domain.Reject_verification -> ()));
              raise exn);
+          (* RFC-0221 §3.2: write the verdict audit record best-effort AFTER the
+             commit. The outcome already lives in [task_status] (approve → Done
+             carrying the verdict in [notes]; reject → InProgress, its reason
+             delivered by the separate post-commit notify), so a record-write
+             failure is logged, not surfaced — it can neither block nor
+             contradict the committed outcome. A failure leaves an inert orphan
+             (record non-terminal, task terminal / in-progress) reaped per §3.4;
+             no behavior-driving consumer acts on it (§3.5 consumer audit).
+             [prepare] returns a result on I/O error; a cancellation raises and
+             propagates to the outer handler. Nested exhaustive match (no
+             catch-all) so a new action / status forces review. *)
+          (match prepare_verification_verdict with
+           | None -> ()
+           | Some prepare ->
+             (match action with
+              | Masc_domain.Approve_verification ->
+                (match task.task_status with
+                 | Masc_domain.AwaitingVerification { verification_id; _ } ->
+                   (match
+                      prepare ~task ~verifier:agent_name ~verification_id
+                        ~decision:(`Approve notes)
+                    with
+                    | Ok () -> ()
+                    | Error e ->
+                      Log.TaskState.warn
+                        "[RFC-0221] verdict audit write failed post-commit \
+                         (task=%s vrf=%s decision=approve): %s — outcome stands, \
+                         record left inert"
+                        task_id
+                        verification_id
+                        e)
+                 | Masc_domain.Todo
+                 | Masc_domain.Claimed _
+                 | Masc_domain.InProgress _
+                 | Masc_domain.Done _
+                 | Masc_domain.Cancelled _ -> ())
+              | Masc_domain.Reject_verification ->
+                (match task.task_status with
+                 | Masc_domain.AwaitingVerification { verification_id; _ } ->
+                   let reject_reason = if notes <> "" then notes else reason in
+                   (match
+                      prepare ~task ~verifier:agent_name ~verification_id
+                        ~decision:(`Reject reject_reason)
+                    with
+                    | Ok () -> ()
+                    | Error e ->
+                      Log.TaskState.warn
+                        "[RFC-0221] verdict audit write failed post-commit \
+                         (task=%s vrf=%s decision=reject): %s — outcome stands, \
+                         record left inert"
+                        task_id
+                        verification_id
+                        e)
+                 | Masc_domain.Todo
+                 | Masc_domain.Claimed _
+                 | Masc_domain.InProgress _
+                 | Masc_domain.Done _
+                 | Masc_domain.Cancelled _ -> ())
+              | Masc_domain.Claim
+              | Masc_domain.Start
+              | Masc_domain.Done_action
+              | Masc_domain.Cancel
+              | Masc_domain.Release
+              | Masc_domain.Submit_for_verification -> ()));
           update_local_agent_state config ~agent_name (fun agent ->
             match set_current with
             | Some _ -> { agent with status = Busy; current_task = Some task_id }

--- a/test/test_verification_fsm.ml
+++ b/test/test_verification_fsm.ml
@@ -539,7 +539,14 @@ let test_reject_by_other_agent_moves_to_in_progress () =
       Alcotest.(check string) "status" "in_progress"
         (status_string config task_id))
 
-let test_approve_prepare_failure_keeps_task_awaiting () =
+(* RFC-0221 §3.2: the verdict record write is best-effort POST-commit. A
+   record-store failure must NOT block a decided outcome — the approval already
+   lives in [task_status] (Done, with the verdict in notes). This is the
+   deliberate reversal of the old "keeps_task_awaiting" contract (which let an
+   audit-write failure block the outcome and re-admit the drift). The failed
+   write leaves the record Pending: an inert orphan (§3.5), which proves the
+   failure was tolerated, not hidden. *)
+let test_approve_verdict_failure_still_completes () =
   with_temp_config ~fsm_enabled:true (fun config ->
     let task_id = add_strict_task config in
     claim_and_start config "worker" task_id;
@@ -575,23 +582,27 @@ let test_approve_prepare_failure_keeps_task_awaiting () =
         ()
     in
     match result with
-    | Ok _ -> Alcotest.fail "approve should fail when verdict persistence fails"
     | Error e ->
-      Alcotest.(check bool) "prepare called" true !prepare_called;
-      Alcotest.(check string) "status remains awaiting_verification"
-        "awaiting_verification" (status_string config task_id);
-      let msg = Masc_domain.show_masc_error e in
-      Alcotest.(check bool) "error mentions verdict persistence" true
-        (Astring.String.is_infix
-           ~affix:"verification verdict persistence failed"
-           msg);
+      Alcotest.fail
+        ("approve must complete despite verdict-store failure: "
+         ^ Masc_domain.show_masc_error e)
+    | Ok _ ->
+      Alcotest.(check bool) "verdict prepare attempted post-commit" true
+        !prepare_called;
+      Alcotest.(check string) "status moves to done"
+        "done" (status_string config task_id);
       (match Verification.load_request config.Workspace.base_path req.id with
        | Error err -> Alcotest.fail ("load_request failed: " ^ err)
        | Ok updated ->
-         Alcotest.(check bool) "request remains pending" true
+         Alcotest.(check bool) "record left pending (audit write tolerated)" true
            (match updated.status with Pending -> true | _ -> false)))
 
-let test_reject_prepare_failure_keeps_task_awaiting () =
+(* RFC-0221 §3.2 (reject side): same reversal. The outcome (InProgress, task
+   bounced back to the worker) is in [task_status]; the reject reason reaches
+   the worker via the separate post-commit notify, not this record. So an
+   audit-record failure must not block the bounce. The failed write leaves the
+   record Pending — inert (§3.5). *)
+let test_reject_verdict_failure_still_transitions () =
   with_temp_config ~fsm_enabled:true (fun config ->
     let task_id = add_strict_task config in
     claim_and_start config "worker" task_id;
@@ -628,20 +639,19 @@ let test_reject_prepare_failure_keeps_task_awaiting () =
         ()
     in
     match result with
-    | Ok _ -> Alcotest.fail "reject should fail when verdict persistence fails"
     | Error e ->
-      Alcotest.(check bool) "prepare called" true !prepare_called;
-      Alcotest.(check string) "status remains awaiting_verification"
-        "awaiting_verification" (status_string config task_id);
-      let msg = Masc_domain.show_masc_error e in
-      Alcotest.(check bool) "error mentions verdict persistence" true
-        (Astring.String.is_infix
-           ~affix:"verification verdict persistence failed"
-           msg);
+      Alcotest.fail
+        ("reject must transition despite verdict-store failure: "
+         ^ Masc_domain.show_masc_error e)
+    | Ok _ ->
+      Alcotest.(check bool) "verdict prepare attempted post-commit" true
+        !prepare_called;
+      Alcotest.(check string) "status moves back to in_progress"
+        "in_progress" (status_string config task_id);
       (match Verification.load_request config.Workspace.base_path req.id with
        | Error err -> Alcotest.fail ("load_request failed: " ^ err)
        | Ok updated ->
-         Alcotest.(check bool) "request remains pending" true
+         Alcotest.(check bool) "record left pending (audit write tolerated)" true
          (match updated.status with Pending -> true | _ -> false)))
 
 let test_approve_retry_recovers_completed_verdict_orphan () =
@@ -938,10 +948,10 @@ let () =
         test_approve_by_other_agent_moves_to_done;
       Alcotest.test_case "cross-agent reject moves to in_progress" `Quick
         test_reject_by_other_agent_moves_to_in_progress;
-      Alcotest.test_case "approve prepare failure keeps task awaiting" `Quick
-        test_approve_prepare_failure_keeps_task_awaiting;
-      Alcotest.test_case "reject prepare failure keeps task awaiting" `Quick
-        test_reject_prepare_failure_keeps_task_awaiting;
+      Alcotest.test_case "approve completes despite verdict-store failure" `Quick
+        test_approve_verdict_failure_still_completes;
+      Alcotest.test_case "reject transitions despite verdict-store failure" `Quick
+        test_reject_verdict_failure_still_transitions;
       Alcotest.test_case
         "approve retry recovers completed verdict orphan"
         `Quick


### PR DESCRIPTION
## Goal

RFC-0221 **step 3**, the follow-up to #20613 (steps 1–2, submit-side atomicity, merged `330b8b5`). This PR makes the **approve/reject** path **status-first**: `task_status` commits first, and the verification record's verdict is written best-effort afterward. An audit-write failure can then neither block nor contradict a decided outcome.

RFC: **RFC-0221** §3.2 / §3.5 / §4 (`docs/rfc/RFC-0221-atomic-verification-submission.md`; this PR adds those sections on top of the version merged in #20613).

## What it changes

- **Remove** the pre-write verdict gate in `transition_task_r`. It made the verdict record write a precondition of the status transition — so a record-store I/O failure returned `Error` and the task stayed `AwaitingVerification`, re-admitting the very drift RFC-0220/0221 close (record `Completed`, task `AwaitingVerification`).
- **Add** a post-commit best-effort verdict write after `write_backlog`. On failure it logs `Log.TaskState.warn`; the transition still succeeds. The match is nested-exhaustive (no catch-all) so a new action/status forces review.
- **Reverse** the two deliberate `test_{approve,reject}_prepare_failure_keeps_task_awaiting` contracts → `still_completes` / `still_transitions` (outcome commits; record left `Pending` to prove the failure is *tolerated, not hidden*). The two `*_retry_recovers_completed_verdict_orphan` tests stay green.

## Why status-first is the only correct order (two independent reasons)

1. **No record dependency.** Approve's verdict is fully in `Done.notes` (`workspace_task_lifecycle.ml:196`); reject's outcome is `InProgress` and its reason reaches the worker via the **separate** post-commit notify (board JSONL post + SSE, `tool_task.ml:518/529`, fired on `Ok`), not the record. The record is pure audit for both verdicts.
2. **No clean compensation.** Submit *creates* the record (inverse = `delete_request`, #20613). Approve/reject *update* submit's record (`Pending`→`Completed`); a record-first approve would need a `Completed`→`Pending` revert, and the only inverse available (`delete_request`) would erase the verifier's submission content. That revert is not a `Verification` state-machine transition. So the record-first-with-compensation pattern that works for submit cannot apply here.

Side effect: status-first also fixes a latent reject bug — under the old gate a record-write failure returned `Error`, so the notify (fires only on `Ok`) never ran and the worker was never told it was rejected. Now the notify always runs.

## Why the orphan is inert (consumer audit — RFC §3.5)

A failed best-effort write leaves "record `Pending` + task `Done`/`InProgress`" — the same *shape* as the 628/629 drift, on every audit-write I/O failure (not just a rare crash). This is benign only if no code acts on a `Pending` record without joining `task_status`. Every task-verification-record consumer was enumerated (RFC §3.5 table). The only behavior-driving one — the keeper world-observation `pending_verification` count that gates keeper wake — filters `backlog.tasks` through `task_has_actionable_verification`, which returns `true` only for `AwaitingVerification` tasks (`keeper_world_observation_inputs.ml:35-45,76-82`); a `Done` orphan hits the `Done -> false` arm and is not counted. The raw actionable-id list has no other consumer. No scheduler/timeout/claim-gate/gauge acts on the orphan.

This was independently checked by a 5-axis adversarial review (inert-consumer, verdict-text-loss, removed-InvalidState-guard, post-commit-match-correctness, compensation-untouched): **all confirmed safe, 0 refutations**, each with `file:line` evidence.

## Verification

- `dune build --root . @check` and default target on top of `origin/main` (`330b8b5`) → exit 0.
- `test_verification_fsm` 20/20 (incl. reversed `approve completes despite verdict-store failure`, `reject transitions despite verdict-store failure`, and both `*_retry_recovers_completed_verdict_orphan`).
- `test_verification` 38/38, `test_workspace_task_verification_phase_e` 5/5, `test_workspace_task_lifecycle` passed.

## Relationship to #20613 and follow-up

This PR is **code-independent** of #20613's submit compensation (it does not use `delete_request`); it shares only the RFC-0221 framing. Remaining (separate PRs):
- **Step 4**: one-time migration honoring legacy task-628/629 (`Pending` record → `AwaitingVerification`; documented one-time run, not boot machinery).
- **Step 5**: inert-record reaping (storage hygiene). The §3.4 reaper is GC over a benign stale-audit record *after* write-ordering fixed the root — distinct from the §8 every-boot reconciler this RFC rejects, which repaired a behavior-affecting pair to hide a live root (RFC §4).

A submit crash *between* the record write and the commit still leaves an orphan record; it is inert and resolved by step 4, never by per-boot repair.

RFC-WAIVED: verification store + task-transition path, not a credential/identity/operator/sandbox/hooks subsystem. RFC-0221 governs this change.
