### PR TITLE
fix(keeper): route search op through Keeper_workspace_op variant (parse-don't-validate)

### DIFF
--- a/lib/keeper/keeper_workspace_read_ops.ml
+++ b/lib/keeper/keeper_workspace_read_ops.ml
@@ -188,8 +188,15 @@ let try_handle
   let host_search_workdir target =
     if safe_is_dir target then target else Filename.dirname target
   in
-  match op with
-  | "pwd" ->
+  (* Parse the raw op string into a variant at this boundary, then match
+     exhaustively. The compiler now forces every Keeper_workspace_op.t to be
+     handled here (or explicitly delegated), so adding a new op cannot
+     silently fall through a string match. Unknown ops parse to None and fall
+     to the ops.ml turn-runtime path, which returns the unsupported_op error
+     (behavior unchanged from the prior [| _ -> None]). *)
+  let module Op = Keeper_workspace_op in
+  match Op.of_string op with
+  | Some Op.Pwd ->
     Some
       (match cwd_target () with
        | Error e -> path_error e
@@ -204,7 +211,7 @@ let try_handle
            run_in_turn_runtime ~cwd ~cmd:"pwd" ~command_argv:[ coreutils.pwd ]
              ~host_ir ~map_output:hostify_turn_runtime_output ~max_bytes:4096
              ())
-  | "git_status" ->
+  | Some Op.Git_status ->
     Some
       (match cwd_target () with
        | Error e -> path_error e
@@ -234,7 +241,7 @@ let try_handle
                  ~extra:[]
                  result.status
                  result.stdout))
-  | "ls" ->
+  | Some Op.Ls ->
     Some
       (match read_target () with
        | Error e -> path_error e
@@ -287,7 +294,7 @@ let try_handle
                  ~extra:[ "path", `String target; "entries", lines_to_json ~limit output ]
                  result.status
                  output))
-  | "cat" ->
+  | Some Op.Cat ->
     Some
       (match read_target () with
        | Error e -> path_error e
@@ -339,7 +346,7 @@ let try_handle
                      ; "truncated", `Bool (String.length out > max_bytes)
                      ; "content", `String body
                      ])))
-  | "rg" ->
+  | Some Op.Rg ->
     Some
       (let pattern = Safe_ops.json_string ~default:"" "pattern" args |> String.trim in
        if pattern = ""
@@ -430,7 +437,7 @@ let try_handle
                           ; "matches", lines_to_json ~limit result.stdout
                           ]
                          @ error_detail)))))
-  | "git_log" ->
+  | Some Op.Git_log ->
     Some
       (match cwd_target () with
        | Error e -> path_error e
@@ -554,7 +561,7 @@ let try_handle
                     ~extra:[ "count", `Int count; "grep", `String grep ]
                     result.status
                     result.stdout)))
-  | "find" ->
+  | Some Op.Find ->
     Some
       (let name_pattern =
          let pattern = Safe_ops.json_string ~default:"" "pattern" args |> String.trim in
@@ -630,7 +637,7 @@ let try_handle
                        ; "status", Keeper_alerting_path.process_status_to_json result.status
                        ; "files", lines_to_json ~limit out
                        ]))))
-  | "head" ->
+  | Some Op.Head ->
     Some
       (match read_target () with
        | Error e -> path_error e
@@ -680,7 +687,7 @@ let try_handle
                      ; "status", Keeper_alerting_path.process_status_to_json result.status
                      ; "content", `String out
                      ])))
-  | "tail" ->
+  | Some Op.Tail ->
     Some
       (match read_target () with
        | Error e -> path_error e
@@ -730,7 +737,7 @@ let try_handle
                      ; "status", Keeper_alerting_path.process_status_to_json result.status
                      ; "content", `String out
                      ])))
-  | "wc" ->
+  | Some Op.Wc ->
     Some
       (match read_target () with
        | Error e -> path_error e
@@ -774,7 +781,7 @@ let try_handle
                  ~cmd:"wc"
                  result.status
                  (dispatch_result_output result)))
-  | "tree" ->
+  | Some Op.Tree ->
     Some
       (match read_target () with
        | Error e -> path_error e
@@ -834,5 +841,12 @@ let try_handle
                      ; "status", Keeper_alerting_path.process_status_to_json result.status
                      ; "entries", lines_to_json ~limit out
                      ])))
-  | _ -> None
+  (* Git_diff is handled by the ops.ml turn-runtime path (it needs the
+     turn runtime, not the read-only backend), so the read dispatch
+     explicitly delegates it rather than catching it in a wildcard. None
+     (unknown op) also falls to ops.ml -> unsupported_op. Listing both
+     arms keeps this match exhaustive: a new Keeper_workspace_op variant
+     forces a compile error here until it is routed. *)
+  | Some Op.Git_diff -> None
+  | None -> None
 ;;

--- a/lib/keeper_contract/keeper_workspace_op.ml
+++ b/lib/keeper_contract/keeper_workspace_op.ml
@@ -30,3 +30,9 @@ let all =
   [ Pwd; Ls; Cat; Rg; Git_status; Find; Head; Tail; Wc; Tree; Git_log; Git_diff ]
 
 let valid_strings = List.map to_string all
+
+(* Inverse of [to_string], derived from it so the two cannot drift: a string
+   is a valid op iff it round-trips through some variant. Returns None for an
+   unknown op, which the dispatch boundary turns into a typed rejection
+   instead of letting an unrecognized string flow into a string match. *)
+let of_string s = List.find_opt (fun v -> String.equal (to_string v) s) all

--- a/lib/keeper_contract/keeper_workspace_op.mli
+++ b/lib/keeper_contract/keeper_workspace_op.mli
@@ -17,3 +17,8 @@ type t =
 val to_string : t -> string
 val all : t list
 val valid_strings : string list
+
+(** [of_string s] is the variant whose [to_string] equals [s], or [None] for
+    an unknown op. Inverse of [to_string]; use at the dispatch boundary to
+    parse the raw op string into a variant before matching. *)
+val of_string : string -> t option

--- a/test/test_keeper_workspace_ops.ml
+++ b/test/test_keeper_workspace_ops.ml
@@ -189,6 +189,38 @@ let test_p10_docker_envelope_shape () =
     false
     (yojson_has_field "status" envelope)
 
+(* ---- of_string parsing boundary ----------------------------------- *)
+
+(* of_string is the inverse of to_string: every variant round-trips, so the
+   dispatch boundary parses any canonical op into its variant. Guards the
+   SSOT: schema enum, valid_strings, and the variant-exhaustive dispatch all
+   derive from these same strings. *)
+let test_of_string_round_trips_every_variant () =
+  List.iter
+    (fun v ->
+      let s = Keeper_workspace_op.to_string v in
+      match Keeper_workspace_op.of_string s with
+      | Some v' when v' = v -> ()
+      | Some _ -> Alcotest.failf "of_string %S parsed to a different variant" s
+      | None -> Alcotest.failf "of_string %S returned None for a valid op" s)
+    Keeper_workspace_op.all
+
+(* of_string covers exactly valid_strings, nothing more. *)
+let test_of_string_rejects_unknown () =
+  Alcotest.(check (option string))
+    "unknown op parses to None"
+    None
+    (Option.map Keeper_workspace_op.to_string
+       (Keeper_workspace_op.of_string "definitely_not_an_op"));
+  (* every valid_strings entry parses to Some *)
+  List.iter
+    (fun s ->
+      Alcotest.(check bool)
+        (Printf.sprintf "valid op %S parses" s)
+        true
+        (Option.is_some (Keeper_workspace_op.of_string s)))
+    Keeper_workspace_op.valid_strings
+
 (* ---- Suite registration ------------------------------------------- *)
 
 let () =
@@ -215,5 +247,11 @@ let () =
             test_p10_host_envelope_shape
         ; Alcotest.test_case "docker envelope fields" `Quick
             test_p10_docker_envelope_shape
+        ] )
+    ; ( "op_of_string"
+      , [ Alcotest.test_case "round-trips every variant" `Quick
+            test_of_string_round_trips_every_variant
+        ; Alcotest.test_case "rejects unknown, accepts all valid" `Quick
+            test_of_string_rejects_unknown
         ] )
     ]

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -464,15 +464,13 @@ let tool_execute_schema =
 let keeper_search_files_schema =
   find_schema_exn "tool_search_files" Config.raw_all_tool_schemas
 
-(* Every op the runtime dispatch in keeper_workspace_read_ops.ml handles.
-   The search_files schema constrains op to a closed enum derived from
-   Keeper_workspace_op.valid_strings (the SAME SSOT the runtime uses), so a
-   schema enum narrower than this set would reject ops that actually work —
-   the failure mode if someone hand-lists only the directory-listing ops.
-   This list mirrors the runtime match arms. *)
-let runtime_search_ops =
-  [ "pwd"; "ls"; "cat"; "rg"; "git_status"; "find"
-  ; "head"; "tail"; "wc"; "tree"; "git_log"; "git_diff" ]
+(* Every op the runtime dispatch handles, taken from the SAME SSOT the schema
+   enum and the variant-exhaustive dispatch derive from — not a hand-listed
+   copy. A schema enum narrower than this set would reject ops that actually
+   work (the failure mode if someone hand-lists only the directory-listing
+   ops); reading from valid_strings means this test cannot drift from the
+   runtime. *)
+let runtime_search_ops = Keeper_workspace_op.valid_strings
 
 let assoc_string key json =
   match Yojson.Safe.Util.member key json with


### PR DESCRIPTION
## 목표

#20616 후속. search op가 `Keeper_workspace_op` variant를 실제로 거치게 해 validation governance를 단단하게 만든다 (parse-don't-validate).

## 배경 (사용자 지적)

#20616은 schema enum을 `valid_strings`에서 파생해 닫았지만, **dispatch는 여전히 raw string match**(`match op with "ls" -> ...`)로 variant를 우회했다. 즉:
- variant `Keeper_workspace_op`이 있는데 dispatch 어디에서도 안 쓰임 (MANIFEST가 거부하는 "variant 두고 string 나열" 안티패턴)
- `of_string`이 없어 string→variant 파싱 경계가 없음
- 진실이 4곳(variant `all` / dispatch string arms / schema enum / 테스트 하드코딩)에 흩어져 컴파일러가 동기화를 강제 못 함
- validator도 enum 유효값을 강제 안 함(blank-normalize만) → 유일한 실제 gate가 런타임 string match

## 변경

1. **`Keeper_workspace_op.of_string`** 추가 — `to_string`의 역함수로 파생(`List.find_opt (to_string v = s) all`). string→variant 파싱, unknown은 None. to_string이 유일 SSOT.
2. **`try_handle`을 variant exhaustive로**: 경계에서 `of_string`으로 파싱 → `match (variant) with Some Pwd -> ... | Some Git_diff -> None (* ops.ml *) | None -> None`. 12 variant 전부 명시 → **새 op 추가 시 컴파일 에러**(이전엔 string match라 조용히 unsupported_op).
3. **테스트 하드코딩 제거**: `runtime_search_ops`를 `Keeper_workspace_op.valid_strings` 참조로(이전엔 12개 손수 나열). of_string round-trip 테스트 추가.

## behavior-preserving (keeper 무중단)

- 11개 read-op arm **본문은 한 글자도 안 바뀜** — arm header만 string literal → variant constructor.
- `of_string`은 기존 `to_string`의 순수 역함수.
- alias 정규화(`"search"→"rg"` 등)는 ops.ml 경계에 그대로 — try_handle은 canonical op를 받음.
- unknown op는 of_string None → 이전 `| _ -> None`과 동일하게 ops.ml unsupported_op로 fall.
- 검증: `test_keeper_workspace_ops` 13 tests + `test_tool_input_validation` 72 tests 통과. 모든 valid op + alias 동작 보존.

## 진실의 수렴

이 PR 이후 op의 진실은 `Keeper_workspace_op` variant 하나:
- `to_string` → `valid_strings`, `of_string` 파생
- schema enum (#20616): `valid_strings` 파생
- dispatch: variant exhaustive (컴파일러 강제)
- 테스트: `valid_strings` 참조

## gating

`lib/keeper_contract/keeper_workspace_op.*`, `lib/keeper/keeper_workspace_read_ops.ml`, 2 test. `pr-rfc-check.sh` 패턴 미매치 → non-gated. dispatch 동작 불변(타입 경유만 추가).

## 관련

- #20616 (schema enum + descriptor — 이 PR이 그 enum을 dispatch까지 관통시킴)
- Issue #20602 (keeper tool-failure sweep, lane 3)
