### PR TITLE
fix(runtime): remove premature 2/2 tool-retry kill, defer to token/idle backpressure

### DIFF
--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -920,3 +920,27 @@ module Workspace_git = struct
 end
 
 (** {1 Internal Safety Configuration} *)
+
+(** Per-keeper tool-call self-correction policy.
+
+    The agent SDK terminates a turn with [ToolRetryExhausted] once a tool call
+    fails validation more than [max_retries] times (SDK default 2). A weak model
+    that emits a malformed call — e.g. [keeper_board_post_get {}] omitting the
+    required [post_id], then recovering with the real id on a later re-prompt —
+    is killed at 2/2 before it self-corrects. OSS agent loops (pydantic-ai,
+    openclaw) do not gate tool self-correction on a low retry count: they
+    re-prompt until the model converges (typically 1-3 tries) and bound runaway
+    with token/idle budgets instead of an arbitrary retry count.
+
+    [validation_self_correction_ceiling] removes that premature count cap by
+    raising it far above the convergence point, delegating backpressure to the
+    bounds already enforced per turn — the per-request token budget and
+    [max_idle_turns]. It is a last-ditch runaway tripwire, not a quality gate;
+    lower it to restore a strict cap.
+
+    @category Runtime
+    @ops_class operator *)
+module Tool_retry = struct
+  let validation_self_correction_ceiling =
+    get_int ~default:16 "MASC_TOOL_VALIDATION_SELF_CORRECTION_CEILING"
+end

--- a/lib/config/env_config_runtime.mli
+++ b/lib/config/env_config_runtime.mli
@@ -346,3 +346,14 @@ end
 module Workspace_git : sig
   val local_op_timeout_sec : float
 end
+
+(** {1 Per-keeper tool-call self-correction} *)
+
+module Tool_retry : sig
+  (** Max validation-error re-prompts before the SDK terminates a turn with
+      [ToolRetryExhausted]. Raised far above the SDK default (2) so a weak model
+      can self-correct a malformed tool call; the real per-turn backpressure is
+      the token budget + [max_idle_turns], and this count is only a runaway
+      tripwire. Env: [MASC_TOOL_VALIDATION_SELF_CORRECTION_CEILING]. *)
+  val validation_self_correction_ceiling : int
+end

--- a/lib/runtime/runtime_agent_context.ml
+++ b/lib/runtime/runtime_agent_context.ml
@@ -119,7 +119,15 @@ let default_config
   ; description = None
   ; initial_messages = []
   ; raw_trace = None
-  ; tool_retry_policy = None
+  ; (* Replace the SDK's premature 2/2 validation-retry kill with a high
+       self-correction ceiling. The real per-turn backpressure is the token
+       budget + [max_idle_turns] above; this ceiling is only a runaway
+       tripwire. See [Env_config_runtime.Tool_retry]. *)
+    tool_retry_policy =
+      Some
+        { Agent_sdk.Tool_retry_policy.default_internal with
+          max_retries = Env_config_runtime.Tool_retry.validation_self_correction_ceiling
+        }
   ; enable_thinking = None
   ; transport = Masc_grpc_transport.from_env ()
   ; allowed_paths = []

--- a/test/tool_retry_self_correction/dune
+++ b/test/tool_retry_self_correction/dune
@@ -1,0 +1,7 @@
+; Standalone alcotest: validation-error self-correction is not killed at the
+; SDK's default 2/2 retry cap. Regression guard for the keeper {}-tool-call
+; livelock (sangsu / keeper_board_post_get omitting required post_id).
+
+(test
+ (name test_tool_retry_self_correction)
+ (libraries alcotest agent_sdk masc.config))

--- a/test/tool_retry_self_correction/test_tool_retry_self_correction.ml
+++ b/test/tool_retry_self_correction/test_tool_retry_self_correction.ml
@@ -1,0 +1,64 @@
+(* Regression guard for the keeper {}-tool-call livelock.
+
+   A weak keeper model (e.g. deepseek-v4-flash on keeper "sangsu") emits
+   [keeper_board_post_get {}] omitting the required [post_id], fails input
+   validation, then recovers with a real post_id on a later re-prompt. The
+   SDK's default policy ([max_retries = 2]) terminated the turn with
+   [ToolRetryExhausted] at 2/2 — before the recovery attempt. masc now injects
+   [Env_config_runtime.Tool_retry.validation_self_correction_ceiling] so
+   validation errors keep re-prompting; runaway is bounded by the per-turn
+   token budget + max_idle_turns, not this count. *)
+
+module Trp = Agent_sdk.Tool_retry_policy
+
+let ceiling = Env_config_runtime.Tool_retry.validation_self_correction_ceiling
+
+let policy : Trp.t = { Trp.default_internal with max_retries = ceiling }
+
+(* error_class is [Unknown], not the [classify Validation_error -> Deterministic]
+   projection: [failure_enabled] short-circuits Deterministic failures to
+   [No_retry] before the count matters, so the live retry path (which the user
+   observed re-prompting "2/2") runs on a non-Deterministic class that defers to
+   the [retry_on_validation_error] toggle. *)
+let validation_failure : Trp.failure =
+  { tool_name = "keeper_board_post_get"
+  ; detail = "post_id: MISSING (required: string)"
+  ; kind = Trp.Validation_error
+  ; error_class = Trp.Unknown
+  }
+
+(* The old default killed the turn at exactly prior_retries = 2 (2/2). *)
+let sdk_default_kill_point = 2
+
+let test_ceiling_above_default_kill () =
+  Alcotest.(check bool)
+    "ceiling is above the SDK default 2/2 kill point"
+    true
+    (ceiling > sdk_default_kill_point)
+
+let test_validation_retries_past_old_cap () =
+  match Trp.decide ~policy ~prior_retries:sdk_default_kill_point [ validation_failure ] with
+  | Trp.Retry _ -> ()
+  | Trp.Exhausted _ ->
+    Alcotest.fail "validation error still terminated at the old 2/2 cap"
+  | Trp.No_retry -> Alcotest.fail "validation error must remain retryable"
+
+let test_exhausts_only_at_ceiling () =
+  (* prior_retries = ceiling -> retry_count = ceiling + 1 > max_retries -> Exhausted.
+     The tripwire still fires as a last-ditch runaway guard. *)
+  match Trp.decide ~policy ~prior_retries:ceiling [ validation_failure ] with
+  | Trp.Exhausted _ -> ()
+  | Trp.Retry _ | Trp.No_retry ->
+    Alcotest.fail "ceiling must still exhaust as a runaway tripwire"
+
+let () =
+  Alcotest.run "tool_retry_self_correction"
+    [ ( "self_correction"
+      , [ Alcotest.test_case "ceiling above default kill" `Quick
+            test_ceiling_above_default_kill
+        ; Alcotest.test_case "retries past old 2/2 cap" `Quick
+            test_validation_retries_past_old_cap
+        ; Alcotest.test_case "exhausts only at ceiling" `Quick
+            test_exhausts_only_at_ceiling
+        ] )
+    ]


### PR DESCRIPTION
## 무엇을 / 왜

Keeper 턴이 LLM의 **tool-call validation 에러(예: `keeper_board_post_get {}` — 필수 `post_id` 누락)** 에 대해 SDK 기본 retry budget `max_retries=2`로 2/2에서 `ToolRetryExhausted`를 던지며 **턴을 죽입니다.**

실측(`~/me/.masc/traces` oas-snapshot, agent `oas-ollama_cloud.deepseek-v4-flash` = keeper `sangsu`): 모델은 `{}` 2회 실패 후 **3번째 시도에 실제 `post_id`로 스스로 복구**합니다(`messages[9,18,25]`). 그러나 2/2 cap이 복구 시도 전에 턴을 종료시켜, sangsu가 매 스케줄 턴(~30분)마다 진전 0으로 헛도는 것처럼 보입니다.

## 변경

`runtime_agent_context.default_config`의 `tool_retry_policy = None`(→ SDK 기본 2) 을 높은 self-correction ceiling으로 교체:

```ocaml
tool_retry_policy =
  Some { Agent_sdk.Tool_retry_policy.default_internal with
         max_retries = Env_config_runtime.Tool_retry.validation_self_correction_ceiling }
```

- 신규 env knob `MASC_TOOL_VALIDATION_SELF_CORRECTION_CEILING` (기본 16).
- `retry_on_validation_error`/`retry_on_recoverable_tool_error`는 SDK 기본(true) 유지.
- retry 카운터는 `agent.context`별(per-keeper)이라 16 keeper 동시 실행에서 **cross-contamination 없음**.

## 설계 근거 (OSS 대조)

- **pydantic-ai**: per-tool retry 카운터 + `ModelRetry` 재프롬프트. validation 실패를 낮은 글로벌 count로 막지 않음.
- **openclaw**: agent-loop가 `while(true)` (retry count cap 없음). 종료는 abort/stopReason/token. malformed call은 `tool-call-repair`로 수리.

두 진영 모두 tool self-correction을 **낮은 retry count로 게이트하지 않고**, token/idle budget으로 runaway를 바운드합니다. 이 PR은 그 방향에 맞춰 임의 count cap을 제거하고, 이미 턴마다 강제되는 **per-request 토큰 budget + `max_idle_turns=3`** 에 backpressure를 이양합니다. ceiling(16)은 quality gate가 아니라 last-ditch runaway tripwire입니다.

## 검증

- `dune build --root . lib/runtime lib/config` → exit 0.
- 신규 회귀 테스트 `test/tool_retry_self_correction/` 3/3 통과:
  - ceiling > SDK 기본 kill point(2)
  - `prior_retries=2`(옛 2/2 kill 지점)에서 `Retry` (No more termination)
  - `prior_retries=ceiling`에서만 `Exhausted` (tripwire 유지)
- 테스트는 `error_class = Unknown` 경로를 고정 — `failure_enabled`가 `Deterministic`을 무조건 No_retry로 단락시키므로, 라이브 retry 경로는 비-Deterministic 분류에서만 동작함을 명시.

## 범위 / 후속

이 PR은 **조기 retry-count kill 제거**까지입니다. 모델이 `{}`를 *애초에 내는* 구조적 root는 별도 follow-up으로 남깁니다: visible `post_id`가 없을 때 `keeper_board_post_get`를 tool 목록에서 제외(parse-don't-validate, illegal call unrepresentable).

WORKAROUND-WAIVED: cap/cooldown을 *추가*하는 변경이 아니라, 임의 retry-count cap을 *제거*하고 기존 token/idle backpressure로 이양하는 변경입니다(CLAUDE.md "cap → root is backpressure" 방향). symptom 억제 신규 표면 없음.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
