### PR TITLE
fix(worker): disable OAS tool-level retry that crashes keepers on empty-arg calls

### DIFF
--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -115,9 +115,21 @@ let local_model_gate =
   }
 ;;
 
-(* Boundary: MASC selects the internal retry policy, but OAS owns
-   retry classification, feedback synthesis, and loop control. *)
-let default_internal_tool_retry_policy = Agent_sdk.Tool_retry_policy.default_internal
+(* MASC disables OAS tool-level retry. A tool failure (e.g. the model emitting
+   empty {} args for a required-arg tool) is returned to the model as a
+   tool_result so the turn loop self-corrects on the next turn. Previously
+   [default_internal] retried these (OAS classifies Validation_error as
+   Transient), exhausted the 2-retry budget, and the Exhausted branch turned the
+   failure into a turn-fatal Error; that accumulated to keeper crash via 10
+   consecutive turn failures. The turn loop (max_turns) already bounds repeated
+   tool calls, so tool-level retry was redundant. Root OAS fix tracked
+   separately: Tool_retry_policy.classify maps Validation_error to Transient and
+   should map it to Deterministic. *)
+let default_internal_tool_retry_policy =
+  { Agent_sdk.Tool_retry_policy.default_internal with
+    retry_on_validation_error = false
+  ; retry_on_recoverable_tool_error = false
+  }
 let default_gate_config () = { local_model_gate with denied_tools = [] }
 
 (* ================================================================ *)


### PR DESCRIPTION
## 증상

deepseek-v4-flash keeper가 단일 required-arg tool(`keeper_memory_search`, `keeper_board_post_get`)을 빈 인자 `{}`로 호출하면 keeper가 멈추거나 crash합니다.

실제 fleet log (`system_log_2026-06-09`):
```
error=Tool retry budget exhausted after 2/2 retries:
  - keeper_board_post_get: {} → "post_id": MISSING (required: string)
terminal_reason=agent_error_tool_retry_exhausted:attempts=2,limit=2
→ tech_glutton: 10 consecutive turn failures → registry: phase new=crashed
```

## 원인

masc가 `worker_oas.ml`에서 모든 OAS agent에 `default_internal` tool_retry_policy를 주입합니다. tool 실패 시:

1. OAS `Tool_retry_policy.classify`가 `Validation_error`(빈 인자)를 `Transient`로 분류 → retry 대상
2. 모델이 같은 `{}`를 반복 → 2-retry budget 소진
3. `Exhausted` 분기가 실패를 turn-fatal `Error (ToolRetryExhausted)`로 전환 (`pipeline.ml:392`)
4. 이런 turn 실패가 10회 누적 → keeper crash

turn loop(`max_turns`)이 이미 반복 tool 호출을 제한하므로 tool-level retry는 중복이고, `Exhausted → Error`만 정상적인 tool 실패를 turn-fatal로 만드는 해악입니다.

## 변경

`worker_oas.ml`의 retry policy 주입을 비활성화합니다(`retry_on_validation_error=false`, `retry_on_recoverable_tool_error=false`). 모든 tool 실패가 `No_retry → Ok tool_results`로 모델에 전달되어, 다음 turn에서 self-correct합니다(표준 agent loop: tool 실패는 결과일 뿐, 모델이 다음 판단).

OAS는 건드리지 않습니다 — OAS 기본값은 이미 `None`(retry 없음)이고 `pipeline.ml`의 `| None -> Ok tool_results`가 올바릅니다. masc 주입만 무력화합니다.

## 검증

- [x] `dune build @check` 통과 (record update 타입 정합)
- [ ] 배포 후 fleet log에서 `tool retry exhausted` / `consecutive turn failures` 이벤트 소멸 확인

컴파일 안전만 확보된 상태이며, crash 감소는 배포 후 fleet log로 확인합니다.

## OAS root fix (별도 추적)

OAS `Tool_retry_policy.classify`가 `Validation_error → Transient`로 매핑하지만, OAS 자신의 `tool_retry_policy.mli` 계약은 "`invalid_arguments`는 `Deterministic`(retry futile)"이라 명시합니다. 이 masc 변경은 즉시 증상을 차단하고, OAS `classify`의 `Validation_error → Deterministic` 교정이 root fix로 별도 PR에서 진행됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
