### PR TITLE
fix(retry): delete MASC code-level tool-retry budget; retrying is the keeper's competence

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -502,19 +502,12 @@ let run_turn
                           ~site:"runtime_runtime"
                           config
                           manifest)
-                      (* Keepers use turn-level retry for transient errors but benefit
-              from OAS per-call retry for validation errors (malformed tool
-              args). retry_on_validation_error=true lets OAS re-prompt the
-              LLM with structured feedback instead of wasting a full turn.
-              retry_on_recoverable_tool_error remains false — tool-level
-              errors are handled by MASC's consecutive failure guardrail. *)
-                    ~tool_retry_policy:
-                      { Agent_sdk.Tool_retry_policy.max_retries = 2
-                      ; retry_on_validation_error = true
-                      ; retry_on_recoverable_tool_error = false
-                      ; feedback_style =
-                          Agent_sdk.Tool_retry_policy.Structured_tool_result
-                      }
+                      (* No code-level tool-retry budget. Retrying a malformed
+              tool call (e.g. missing required arg) is the keeper's own
+              competence: the SDK delivers the validation error back to the
+              model (pipeline [None] branch) and the agent loop decides whether
+              to re-emit. Runaway is bounded by max_idle_turns + token budget,
+              not a retry count that halts the turn. *)
                     ~max_idle_turns
                     ?stream_idle_timeout_s
                     ~body_timeout_s:timeout_s

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -115,9 +115,12 @@ let local_model_gate =
   }
 ;;
 
-(* Boundary: MASC selects the internal retry policy, but OAS owns
-   retry classification, feedback synthesis, and loop control. *)
-let default_internal_tool_retry_policy = Agent_sdk.Tool_retry_policy.default_internal
+(* Boundary: MASC does not impose a tool-retry budget on workers. Retrying a
+   malformed tool call is the keeper's own competence — the SDK delivers the
+   validation error back to the model (pipeline [None] branch) and the agent
+   loop decides whether to re-emit. OAS owns retry classification, feedback
+   synthesis, and loop control; runaway is bounded by token budget + idle
+   turns, not a code-level retry count. *)
 let default_gate_config () = { local_model_gate with denied_tools = [] }
 
 (* ================================================================ *)
@@ -182,7 +185,6 @@ let build_agent
     |> Agent_sdk.Builder.with_tools tools
     |> Agent_sdk.Builder.with_hooks hooks
     |> Agent_sdk.Builder.with_guardrails guardrails
-    |> Agent_sdk.Builder.with_tool_retry_policy default_internal_tool_retry_policy
     |> Agent_sdk.Builder.with_raw_trace raw_trace
     |> Agent_sdk.Builder.with_periodic_callbacks heartbeat_callbacks
     |> Agent_sdk.Builder.with_description (description_of_meta meta)
@@ -623,7 +625,6 @@ and resume_worker_via_oas
       ~raw_trace
       ~periodic_callbacks:heartbeat_cbs
       ~guardrails
-      ~tool_retry_policy:default_internal_tool_retry_policy
       ()
   in
   let options =


### PR DESCRIPTION
## 무엇을

MASC가 에이전트에 부과하던 **코드레벨 tool-retry budget(`max_retries=2`)을 삭제**합니다. 부과 지점은 두 곳이었습니다:

- `worker_oas.ml`: `default_internal_tool_retry_policy` 바인딩 + 빌드 경로(`with_tool_retry_policy`) + resume 경로(`~tool_retry_policy`)
- `keeper/keeper_agent_run.ml`: `run_named`에 인라인 `{ max_retries = 2; ... }`

둘 다 정책 인자를 omit → SDK 기본 `None`. pipeline `None` 분기(`Ok tool_results`)는 validation 에러를 모델에 normal tool result로 돌려주고, 에이전트 루프가 재시도 여부를 결정합니다. `ToolRetryExhausted`로 턴을 죽이는 코드 경로가 사라집니다.

## 왜

retry budget이 keeper를 2/2에서 멈췄습니다. trace 증거(`oas-ollama_cloud.deepseek-v4-flash` / keeper `sangsu`): 모델이 `keeper_board_post_get {}`(필수 `post_id` 누락)를 2회 실패 후 **3번째에 실제 post_id로 복구**하는데, 2/2 cap이 복구 전에 턴을 종료시켜 진전 0으로 헛돕니다.

**재시도를 계속할지 말지는 keeper(LLM)의 역량이지, 코드가 카운터로 턴을 죽일 일이 아닙니다.** 결정론적 자원 한계(token budget, `max_idle_turns`)만 코드가 강제하고, 행동 결정(재시도?)은 keeper에 둡니다. OAS는 자체 retry classification/feedback/loop control을 소유합니다(`worker_oas` boundary 주석 참조).

`#20620`을 대체합니다 — 그 PR은 이미 `None`이던 keeper-context 기본값만 건드려 실제 culprit(위 두 지점)을 못 고쳤습니다.

## 범위 / 후속

`?tool_retry_policy` optional 플럼빙(`build_resume_config`, `run_named`, config 필드)은 이제 항상 `None`인 미사용 capability로 남습니다. 타입레벨 완전 제거는 별도 follow-up(여러 record 필드 ripple).

## 검증

- `dune build --root . lib` → exit 0.
- grep 전수: masc lib/bin에 `with_tool_retry_policy` / `Tool_retry_policy.max_retries` / `default_internal` 부과 지점 0개 잔존.
- 신규 테스트 없음 — 삭제이며 None-branch 동작은 agent_sdk(OAS)가 소유/테스트.

WORKAROUND-WAIVED: cap/cooldown을 *추가*하는 변경이 아니라, 코드레벨 retry-count cap을 *삭제*하고 기존 token/idle backpressure에 위임하는 변경입니다(CLAUDE.md "cap → root is backpressure" 방향). symptom 억제 신규 표면 없음.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
