### PR TITLE
refactor(retry): delete dead tool_retry_policy plumbing across runtime/keeper

### DIFF
--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -61,7 +61,6 @@ let run_named
     ?guardrails
     ?hooks
     ?context_reducer
-    ?tool_retry_policy
     ?raw_trace
     ?on_event
     ?on_yield
@@ -157,7 +156,6 @@ let run_named
     guardrails;
     hooks;
     context_reducer;
-    tool_retry_policy;
     raw_trace;
     transport_resolved;
     runtime_mcp_policy;

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -110,7 +110,6 @@ val run_named :
   ?guardrails:Agent_sdk.Guardrails.t ->
   ?hooks:Agent_sdk.Hooks.hooks ->
   ?context_reducer:Agent_sdk.Context_reducer.t ->
-  ?tool_retry_policy:Agent_sdk.Tool_retry_policy.t ->
   ?raw_trace:Agent_sdk.Raw_trace.t ->
   ?on_event:(Agent_sdk.Types.sse_event -> unit) ->
   ?on_yield:(unit -> unit) ->

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -38,7 +38,6 @@ type try_provider_ctx =
   ; guardrails : Agent_sdk.Guardrails.t option
   ; hooks : Agent_sdk.Hooks.hooks option
   ; context_reducer : Agent_sdk.Context_reducer.t option
-  ; tool_retry_policy : Agent_sdk.Tool_retry_policy.t option
   ; raw_trace : Agent_sdk.Raw_trace.t option
   ; (* Transport *)
     transport_resolved : Masc_grpc_transport.t
@@ -261,7 +260,6 @@ let run_try_provider
           ; guardrails = ctx.guardrails
           ; hooks
           ; context_reducer = ctx.context_reducer
-          ; tool_retry_policy = ctx.tool_retry_policy
           ; description =
               Some (Printf.sprintf "runtime:%s/runtime" ctx.runtime_id)
           ; transport = ctx.transport_resolved

--- a/lib/keeper/keeper_turn_driver_try_provider.mli
+++ b/lib/keeper/keeper_turn_driver_try_provider.mli
@@ -21,7 +21,6 @@ type try_provider_ctx =
   ; guardrails : Agent_sdk.Guardrails.t option
   ; hooks : Agent_sdk.Hooks.hooks option
   ; context_reducer : Agent_sdk.Context_reducer.t option
-  ; tool_retry_policy : Agent_sdk.Tool_retry_policy.t option
   ; raw_trace : Agent_sdk.Raw_trace.t option
   ; transport_resolved : Masc_grpc_transport.t
   ; runtime_mcp_policy : Llm_provider.Llm_transport.runtime_mcp_policy option

--- a/lib/keeper/keeper_turn_driver_wrappers.ml
+++ b/lib/keeper/keeper_turn_driver_wrappers.ml
@@ -31,7 +31,6 @@ let config_for_label
     ?guardrails
     ?hooks
     ?context_reducer
-    ?tool_retry_policy
     ?enable_thinking
     ?compact_ratio
     ?approval
@@ -55,7 +54,6 @@ let config_for_label
       guardrails;
       hooks;
       context_reducer;
-      tool_retry_policy;
       enable_thinking;
       description;
       compact_ratio;
@@ -84,7 +82,6 @@ let run_model_by_label
     ?guardrails
     ?hooks
     ?context_reducer
-    ?tool_retry_policy
     ?enable_thinking
     ?compact_ratio
     ?on_event
@@ -98,7 +95,6 @@ let run_model_by_label
     config_for_label ~name:"oas-label-model" ~model_label ~system_prompt
       ~tools ~max_tokens ?max_input_tokens ?max_cost_usd ~temperature
       ~max_idle_turns ?stream_idle_timeout_s ?guardrails ?hooks ?context_reducer
-      ?tool_retry_policy
       ?enable_thinking
       ?compact_ratio
       ~description:(Some (Printf.sprintf "model_label:%s" model_label))
@@ -170,7 +166,6 @@ let run_named_with_masc_tools
     ?(accept = fun (_ : Agent_sdk_response.api_response) -> true)
     ?guardrails
     ?hooks
-    ?tool_retry_policy
     ?raw_trace
     ?on_event
     ?on_yield
@@ -192,7 +187,6 @@ let run_named_with_masc_tools
   Keeper_turn_driver.run_named ~runtime_id ~goal ?priority ~system_prompt ~tools:oas_tools
     ~temperature ~max_tokens ?max_input_tokens ?max_cost_usd
     ?stream_idle_timeout_s ?wait_timeout_sec ?guardrails ?hooks
-    ?tool_retry_policy
     ~accept
     ?compact_ratio
     ?approval
@@ -213,7 +207,6 @@ let run_model_with_masc_tools
     ?wait_timeout_sec
     ?guardrails
     ?hooks
-    ?tool_retry_policy
     ?enable_thinking
     ?compact_ratio
     ?raw_trace
@@ -227,7 +220,7 @@ let run_model_with_masc_tools
   let* config =
     config_for_label ~name:"oas-explicit-model" ~model_label ~system_prompt
       ~tools:[] ~max_tokens ?max_input_tokens ?max_cost_usd ~temperature
-      ?stream_idle_timeout_s ?guardrails ?hooks ?tool_retry_policy ?enable_thinking
+      ?stream_idle_timeout_s ?guardrails ?hooks ?enable_thinking
       ?compact_ratio
       ~description:(Some (Printf.sprintf "model_label:%s" model_label))
       ()

--- a/lib/keeper/keeper_turn_driver_wrappers.mli
+++ b/lib/keeper/keeper_turn_driver_wrappers.mli
@@ -25,7 +25,6 @@ val run_model_by_label :
   ?guardrails:Agent_sdk.Guardrails.t ->
   ?hooks:Agent_sdk.Hooks.hooks ->
   ?context_reducer:Agent_sdk.Context_reducer.t ->
-  ?tool_retry_policy:Agent_sdk.Tool_retry_policy.t ->
   ?enable_thinking:bool ->
   ?compact_ratio:float ->
   ?on_event:(Agent_sdk.Types.sse_event -> unit) ->
@@ -55,7 +54,6 @@ val run_named_with_masc_tools :
   ?accept:(Agent_sdk_response.api_response -> bool) ->
   ?guardrails:Agent_sdk.Guardrails.t ->
   ?hooks:Agent_sdk.Hooks.hooks ->
-  ?tool_retry_policy:Agent_sdk.Tool_retry_policy.t ->
   ?raw_trace:Agent_sdk.Raw_trace.t ->
   ?on_event:(Agent_sdk.Types.sse_event -> unit) ->
   ?on_yield:(unit -> unit) ->
@@ -85,7 +83,6 @@ val run_model_with_masc_tools :
   ?wait_timeout_sec:float ->
   ?guardrails:Agent_sdk.Guardrails.t ->
   ?hooks:Agent_sdk.Hooks.hooks ->
-  ?tool_retry_policy:Agent_sdk.Tool_retry_policy.t ->
   ?enable_thinking:bool ->
   ?compact_ratio:float ->
   ?raw_trace:Agent_sdk.Raw_trace.t ->

--- a/lib/local/worker_container.ml
+++ b/lib/local/worker_container.ml
@@ -413,7 +413,6 @@ let append_worker_completion_log ~base_path ~worker_name
 let build_resume_config ~worker_name ~provider ~model_id ~system_prompt ~tools
     ~max_turns ~thinking_enabled ~hooks ~raw_trace ?(periodic_callbacks = [])
     ?(guardrails : Agent_sdk.Guardrails.t option)
-    ?(tool_retry_policy : Agent_sdk.Tool_retry_policy.t option)
     () =
   let config =
     {
@@ -449,7 +448,6 @@ let build_resume_config ~worker_name ~provider ~model_id ~system_prompt ~tools
       hooks;
       guardrails = effective_guardrails;
       raw_trace = Some raw_trace;
-      tool_retry_policy;
       periodic_callbacks;
     }
   in

--- a/lib/local/worker_container.mli
+++ b/lib/local/worker_container.mli
@@ -205,7 +205,6 @@ val build_resume_config :
   raw_trace:Agent_sdk.Raw_trace.t ->
   ?periodic_callbacks:Agent_sdk.Agent.periodic_callback list ->
   ?guardrails:Agent_sdk.Guardrails.t ->
-  ?tool_retry_policy:Agent_sdk.Tool_retry_policy.t ->
   unit ->
   Agent_sdk.Types.agent_config * Agent_sdk.Agent.options
 (** Assembles the [(config, options)] pair consumed by

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -47,7 +47,6 @@ type config =
   description : string option;
   initial_messages : Agent_sdk.Types.message list;
   raw_trace : Agent_sdk.Raw_trace.t option;
-  tool_retry_policy : Agent_sdk.Tool_retry_policy.t option;
   enable_thinking : bool option;
   transport : Masc_grpc_transport.t;
   allowed_paths : string list;

--- a/lib/runtime/runtime_agent.mli
+++ b/lib/runtime/runtime_agent.mli
@@ -69,7 +69,6 @@ type config = Runtime_agent_context.config = {
   description : string option;
   initial_messages : Agent_sdk.Types.message list;
   raw_trace : Agent_sdk.Raw_trace.t option;
-  tool_retry_policy : Agent_sdk.Tool_retry_policy.t option;
   enable_thinking : bool option;
   transport : Masc_grpc_transport.t;
   allowed_paths : string list;

--- a/lib/runtime/runtime_agent_context.ml
+++ b/lib/runtime/runtime_agent_context.ml
@@ -62,7 +62,6 @@ type config =
   ; description : string option
   ; initial_messages : Agent_sdk.Types.message list
   ; raw_trace : Agent_sdk.Raw_trace.t option
-  ; tool_retry_policy : Agent_sdk.Tool_retry_policy.t option
   ; enable_thinking : bool option
   ; transport : Masc_grpc_transport.t
   ; allowed_paths : string list
@@ -119,7 +118,6 @@ let default_config
   ; description = None
   ; initial_messages = []
   ; raw_trace = None
-  ; tool_retry_policy = None
   ; enable_thinking = None
   ; transport = Masc_grpc_transport.from_env ()
   ; allowed_paths = []
@@ -210,11 +208,6 @@ let builder_without_approval
   let builder =
     match config.raw_trace with
     | Some raw_trace -> Agent_sdk.Builder.with_raw_trace raw_trace builder
-    | None -> builder
-  in
-  let builder =
-    match config.tool_retry_policy with
-    | Some policy -> Agent_sdk.Builder.with_tool_retry_policy policy builder
     | None -> builder
   in
   let builder =
@@ -354,7 +347,6 @@ let prepare_resume ~(config : config) ~(checkpoint : Agent_sdk.Checkpoint.t)
     ; context_injector = config.context_injector
     ; event_bus = config.event_bus
     ; raw_trace = config.raw_trace
-    ; tool_retry_policy = config.tool_retry_policy
     ; allowed_paths = config.allowed_paths
     ; description = config.description
     ; approval = config.approval

--- a/lib/runtime/runtime_agent_context.mli
+++ b/lib/runtime/runtime_agent_context.mli
@@ -63,7 +63,6 @@ type config = {
   description : string option;
   initial_messages : Agent_sdk.Types.message list;
   raw_trace : Agent_sdk.Raw_trace.t option;
-  tool_retry_policy : Agent_sdk.Tool_retry_policy.t option;
   enable_thinking : bool option;
   transport : Masc_grpc_transport.t;
   allowed_paths : string list;


### PR DESCRIPTION
## 무엇을

`#20624`의 follow-up. 거기서 tool-retry budget을 부과하던 두 지점(worker_oas, keeper_agent_run)을 삭제해 어떤 코드도 정책을 `Some`으로 설정하지 않게 됐습니다. 남은 `tool_retry_policy` 플럼빙은 **항상 `None`인 미사용 capability**였습니다. 이를 end-to-end로 삭제합니다.

- `runtime_agent_context`: `config` 필드 + `default_config` 값 + **유일 소비처**였던 `Builder.with_tool_retry_policy` 적용 + `runtime_agent` options로의 복사
- `runtime_agent`: options 필드
- `keeper_turn_driver` / `_wrappers` / `_try_provider`: `?tool_retry_policy` 파라미터들, ctx 필드, punning 생성
- `worker_container.build_resume_config`: `?tool_retry_policy` 파라미터 + punning

## 왜

dead concept를 남기지 않습니다(CLAUDE.md). 정책 capability가 type을 명시적으로 다시 추가하지 않는 한 되살아날 수 없게 합니다. tool-retry는 keeper의 역량으로 남고(SDK `None` 분기가 validation 에러를 모델에 전달), runaway는 `max_idle_turns` + token budget으로 바운드됩니다.

## 검증

- post-merge `origin/main`(#20624 포함) 위에서 cherry-pick → `dune build --root .` (lib+bin+tests) exit 0.
- grep 전수: masc lib/bin에 `tool_retry_policy` 잔존 0.
- 순수 삭제 (12파일 +1/−31); 신규 테스트 없음.

WORKAROUND-WAIVED: cap/cooldown 추가가 아니라 dead 플럼빙 삭제입니다. symptom 억제 신규 표면 없음.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
