### PR TITLE
refactor(server_bootstrap_http): pair connection-release steps in with_cleanups_on_release scope (PR-C5)

### DIFF
--- a/lib/server/server_bootstrap_http.ml
+++ b/lib/server/server_bootstrap_http.ml
@@ -72,13 +72,39 @@ let print_startup_banner
   then Printf.printf "   POST /webrtc/offer, /webrtc/answer → WebRTC signaling\n%!"
 ;;
 
+(** Run a list of cleanups on [sw] release, executing all of them
+    even if an earlier one raises a non-Cancel exception.  Each cleanup
+    runs under its own [try/with] so a single failure cannot prevent
+    the remaining cleanups (RFC-0194 §3 PR-B spirit: an
+    [Eio.Switch.on_release] callback must be *all-or-nothing* across
+    its cleanup steps).  [Eio.Cancel.Cancelled] propagates as usual so
+    structured-concurrency cancellation honors the enclosing fiber.
+
+    List ordering is preserved: cleanups run in the order supplied. *)
+let with_cleanups_on_release ~sw cleanups =
+  Eio.Switch.on_release sw (fun () ->
+    List.iter
+      (fun cleanup ->
+         try cleanup ()
+         with
+         | Eio.Cancel.Cancelled _ as e -> raise e
+         | exn ->
+           Log.Misc.warn "on_release cleanup failed: %s"
+             (Printexc.to_string exn))
+      cleanups)
+;;
+
 let on_connection_release conn_sw ~mode ~listener_tag flow =
-  Eio.Switch.on_release conn_sw (fun () ->
-    Transport_metrics.record_http_connection_closed ~mode;
-    try Eio.Flow.close flow with
-    | Eio.Cancel.Cancelled _ as e -> raise e
-    | exn ->
-      Log.Misc.warn "[%s] flow close: %s" listener_tag (Printexc.to_string exn))
+  with_cleanups_on_release ~sw:conn_sw
+    [
+      (fun () -> Transport_metrics.record_http_connection_closed ~mode);
+      (fun () ->
+         try Eio.Flow.close flow with
+         | Eio.Cancel.Cancelled _ as e -> raise e
+         | exn ->
+           Log.Misc.warn "[%s] flow close: %s" listener_tag
+             (Printexc.to_string exn));
+    ]
 ;;
 
 let register_listener_lifecycle ~sw ~mode =

--- a/lib/server/server_bootstrap_http.mli
+++ b/lib/server/server_bootstrap_http.mli
@@ -39,6 +39,19 @@ val print_startup_banner :
     Pinned at the contract seam — operator log scrapers parse the
     "MASC MCP Server listening on http://" line. *)
 
+(** {1 Internal helpers} *)
+
+val with_cleanups_on_release :
+  sw:Eio.Switch.t -> (unit -> unit) list -> unit
+(** [with_cleanups_on_release ~sw cleanups] runs each cleanup on
+    [sw] release.  Each cleanup is wrapped in its own [try/with] so
+    a single non-[Cancelled] exception cannot prevent the remaining
+    cleanups (RFC-0194 §3 PR-B spirit: an [Eio.Switch.on_release]
+    callback must be all-or-nothing across its steps).
+    [Eio.Cancel.Cancelled] propagates as usual so structured
+    cancellation honors the enclosing fiber.  Cleanups run in the
+    order supplied. *)
+
 (** {1 Accept loops} *)
 
 val serve :

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -122,9 +122,11 @@ let handle_execute_output_stream ~sw ~clock request reqd =
            else
              Eio.Fiber.fork ~sw (fun () ->
                Eio.Switch.run (fun stream_sw ->
-                 Eio.Switch.on_release stream_sw (fun () ->
-                   Dashboard_execute_output.unsubscribe subscriber;
-                   close_stream ());
+                 Server_bootstrap_http.with_cleanups_on_release ~sw:stream_sw
+                   [
+                     (fun () -> Dashboard_execute_output.unsubscribe subscriber);
+                     close_stream;
+                   ];
                  let rec loop () =
                    if not !closed
                    then (

--- a/test/dune
+++ b/test/dune
@@ -51,6 +51,7 @@
   test_fd_accountant
   test_fd_accountant_state
   test_operator_control_snapshot_state
+  test_with_cleanups_on_release
   test_auth_login
   test_audit_log
   test_system_log_category
@@ -304,6 +305,7 @@
   test_fd_accountant
   test_fd_accountant_state
   test_operator_control_snapshot_state
+  test_with_cleanups_on_release
   test_auth_login
   test_audit_log
   test_system_log_category

--- a/test/test_with_cleanups_on_release.ml
+++ b/test/test_with_cleanups_on_release.ml
@@ -1,0 +1,149 @@
+(** White-box tests for [Server_bootstrap_http.with_cleanups_on_release]
+    introduced by PR-C5 (follow-up to PR-B / PR #20583, PR-C1, PR-C2).
+
+    PR-B replaced the per-fiber [int Atomic.t] counter and its
+    [Eio.Switch.on_release] decrement callback with a typed state
+    machine.  PR-C1 spread the same pattern to [fd_accountant].
+    PR-C2 took a *different* shape for [operator_control_snapshot] --
+    [Fun.protect ~finally] scope encapsulation.
+
+    PR-C5 takes yet another shape for the
+    [server_bootstrap_http] / [server_routes_http_routes_dashboard]
+    call sites: a [with_cleanups_on_release] helper that runs each
+    cleanup step in its own [try/with] so a single non-Cancelled
+    exception in step N cannot skip step N+1.
+
+    The underlying [Eio.Switch.on_release] callback is *cancel-safe*
+    (it fires on both normal exit and [Eio.Cancel.Cancelled] unwind)
+    but *not exception-safe* when the body has multiple sequential
+    cleanup steps.  For example, the pre-fix [on_connection_release]
+    did [Transport_metrics.record_http_connection_closed ~mode]
+    followed by [Eio.Flow.close flow]; if the first step raised, the
+    flow close was skipped and the descriptor leaked.  The helper
+    eliminates that failure mode by isolating each step.
+
+    The white-box tests below drive [with_cleanups_on_release]
+    directly to verify the all-or-nothing invariant across the
+    cleanup list. *)
+
+open Alcotest
+module SBH = Server_bootstrap_http
+
+let test_with_cleanups_on_release_runs_all_on_normal_exit () =
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun sw ->
+  let order = ref [] in
+  let cleanup_a () = order := "a" :: !order in
+  let cleanup_b () = order := "b" :: !order in
+  let cleanup_c () = order := "c" :: !order in
+  SBH.with_cleanups_on_release ~sw [ cleanup_a; cleanup_b; cleanup_c ] ;
+  Eio.Switch.run (fun _trigger_sw ->
+      (* Trigger a no-op cancellation so the on_release fires
+         on a clean switch without other side effects. *)
+      ());
+  (* Force the on_release by failing the switch with a benign
+     error; that runs all on_release callbacks then unwinds. *)
+  (try
+     Eio.Switch.run (fun release_sw ->
+         SBH.with_cleanups_on_release ~sw:release_sw
+           [ cleanup_a; cleanup_b; cleanup_c ];
+         Eio.Switch.fail release_sw (Failure "trigger release"))
+   with
+   | Failure _ -> ()) ;
+  (* The first invocation registered on [sw] (the *outer*
+     one) which never failed.  We only observe side effects of
+     the second invocation, which registered on [release_sw]
+     and ran on its fail. *)
+  let observed = List.rev !order in
+  check string "all cleanups ran in order on release"
+    "abc" (String.concat "" observed)
+
+let test_with_cleanups_on_release_continues_after_step_exception () =
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun _outer_sw ->
+  let step_a_ran = ref false in
+  let step_b_ran = ref false in
+  let step_c_ran = ref false in
+  let failing_cleanup () =
+    step_a_ran := true ;
+    raise (Failure "intentional step failure")
+  in
+  let surviving_cleanup_b () = step_b_ran := true in
+  let surviving_cleanup_c () = step_c_ran := true in
+  (try
+     Eio.Switch.run (fun release_sw ->
+         SBH.with_cleanups_on_release ~sw:release_sw
+           [ failing_cleanup; surviving_cleanup_b; surviving_cleanup_c ];
+         Eio.Switch.fail release_sw (Failure "trigger release"))
+   with
+   | Failure _ -> ()) ;
+  check bool "step A ran (and raised)" true !step_a_ran ;
+  check bool "step B ran despite step A's exception" true !step_b_ran ;
+  check bool "step C ran despite step A's exception" true !step_c_ran
+
+let test_with_cleanups_on_release_preserves_list_order () =
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun _outer_sw ->
+  let order = ref [] in
+  let make_cleanup label () = order := label :: !order in
+  (try
+     Eio.Switch.run (fun release_sw ->
+         SBH.with_cleanups_on_release ~sw:release_sw
+           [ make_cleanup "first"; make_cleanup "second"; make_cleanup "third" ];
+         Eio.Switch.fail release_sw (Failure "trigger release"))
+   with
+   | Failure _ -> ()) ;
+  check string "cleanups run in supplied order"
+    "third-second-first"
+    (String.concat "-" (List.rev !order))
+
+(** Cancelled semantics: when the switch unwinds with Cancelled,
+    the on_release callback fires and *all* cleanups run.  Cancelled
+    itself only propagates from the *fiber* operation (e.g.
+    [Eio.Time.sleep]) that observes the cancellation -- not from
+    inside the cleanup list.  So this test asserts both cleanups
+    ran and the fiber observed Cancelled, not the cleanups. *)
+let test_with_cleanups_on_release_runs_all_on_cancel () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun outer_sw ->
+  let step_a_ran = ref false in
+  let step_b_ran = ref false in
+  let helper_observed_cancel = ref false in
+  let clock = Eio.Stdenv.clock env in
+  Eio.Fiber.fork ~sw:outer_sw (fun () ->
+      try
+        Eio.Switch.run (fun inner_sw ->
+            SBH.with_cleanups_on_release ~sw:inner_sw
+              [ (fun () -> step_a_ran := true);
+                (fun () -> step_b_ran := true) ];
+            (* Suspend; the outer [Eio.Switch.fail] below cancels
+               this fiber mid-sleep, then the inner switch unwinds
+               and the on_release callback runs. *)
+            Eio.Time.sleep clock 60.0)
+      with
+      | Eio.Cancel.Cancelled _ -> helper_observed_cancel := true
+      | _ -> ()) ;
+  Eio.Time.sleep clock 0.3 ;
+  Eio.Switch.fail outer_sw (Failure "trigger release") ;
+  Eio.Time.sleep clock 0.3 ;
+  check bool "fiber observed Eio.Cancel.Cancelled" true
+    !helper_observed_cancel ;
+  check bool "step A ran on switch unwind" true !step_a_ran ;
+  check bool "step B ran on switch unwind (after step A)" true !step_b_ran
+
+let () =
+  run "With_cleanups_on_release"
+    [ "with_cleanups_on_release runs all on normal exit"
+    , [ test_case "all cleanups run in order when the switch unwinds" `Quick
+          test_with_cleanups_on_release_runs_all_on_normal_exit ]
+    ; "with_cleanups_on_release continues after step exception"
+    , [ test_case "later cleanups run even when an earlier one raises" `Quick
+          test_with_cleanups_on_release_continues_after_step_exception ]
+    ; "with_cleanups_on_release preserves list order"
+    , [ test_case "cleanups run in the order they are supplied" `Quick
+          test_with_cleanups_on_release_preserves_list_order ]
+    ; "with_cleanups_on_release runs all on cancel"
+    , [ test_case "all cleanups run on Cancelled unwind" `Quick
+          test_with_cleanups_on_release_runs_all_on_cancel ]
+    ]
+;;


### PR DESCRIPTION
## Summary

PR-C5 — the fourth installment in the `Eio.Switch.on_release` call-site
audit (task #19, in_progress).  Spreads the PR-B fix shape to
`lib/server`'s connection-release callbacks.  Fourth distinct shape,
alongside PR-B/C1 (typed state machine), PR-C2 (`Fun.protect` scope),
and PR-C1.

## Background

The accept loops in `server_bootstrap_http.ml` register an
`Eio.Switch.on_release` callback on every accepted connection to
(a) record the close metric and (b) close the flow.  That callback
is *cancel-safe* (it fires on both normal exit and `Eio.Cancel.Cancelled`
unwind) but *not exception-safe*: a non-Cancelled exception in step
(a) would skip step (b) and leak the file descriptor.  The dashboard
execute-output stream in `server_routes_http_routes_dashboard.ml` had
the same shape (unsubscribe subscriber + close_stream).

PR-B (PR #20583) replaced the per-fiber `int Atomic.t` slot counter
and its `Eio.Switch.on_release` decrement callback with a typed
variant.  PR-C1 spread the same pattern to `fd_accountant`.  PR-C2
took a different shape (`Fun.protect ~finally` scope) for
`operator_control_snapshot`'s per-slot semaphore pair.  PR-C3
(`masc_http_client/pool.ml`) and PR-C4
(`keeper_heartbeat_loop_in_turn_pulse.ml`) audited but required
no fix — already exception-safe.

## Fix

A new helper `with_cleanups_on_release ~sw cleanups` runs the cleanup
list in order on `sw` release, isolating each step in its own
`try/with`.  A non-Cancelled exception in step N is logged but does
not skip step N+1.  `Eio.Cancel.Cancelled` propagates as usual so
structured-concurrency cancellation honors the enclosing fiber.

The helper is the fourth fix shape, distinct from PR-B/C1's typed
state machine and PR-C2's `Fun.protect` scope, because the resource
is a *sequential cleanup list* rather than a counter or a single
semaphore.  `List.iter` of the cleanup list is the natural primitive;
typed state machine would be a "telemetry-as-fix" mismatch
(workaround rejection bar §1).

Call sites converted:

| File | Line | Old shape | New shape |
|------|------|-----------|-----------|
| `lib/server/server_bootstrap_http.ml` | 97-108 | `Eio.Switch.on_release` with 2 sequential steps | `with_cleanups_on_release` |
| `lib/server/server_routes_http_routes_dashboard.ml` | 125-127 | inline `Eio.Switch.on_release` with 2 steps | `Server_bootstrap_http.with_cleanups_on_release` |

The four `mark_stopped` callbacks at lines 91 and 117 are single-step
(no parameters, no exception risk) and stay as plain
`Eio.Switch.on_release`.  Refactoring them would add the helper call
overhead without benefit — these are *atomic* (1 step) and
*idempotent* under cancellation.

## Tests

`test/test_with_cleanups_on_release.ml` — 4 white-box tests exercising
`with_cleanups_on_release` directly, independent of
`on_connection_release`:

| Test | Invariant verified |
|------|--------------------|
| runs all on normal exit | all 3 cleanups run in order when switch unwinds via `Eio.Switch.fail` |
| continues after step exception | step A raises non-Cancelled → step B and C still run |
| preserves list order | cleanups run in the supplied order (List.iter semantics) |
| runs all on cancel | switch cancellation fires on_release → all cleanups run; Cancelled propagates from the *suspending operation* (Eio.Time.sleep), not from inside the cleanup list |

`Server_bootstrap_http.with_cleanups_on_release` is exposed in the
`.mli` for the white-box test suite.

Local verification:
- `python3 scripts/ci/check-fun-protect-finally-guard.py` PASS
- `ocamlformat --check` on the 4 modified/new files PASS
- `dune build @check` on the *PR-C5 diff* (filtering out the
  pre-existing `ToolRetryExhausted` errors on `origin/main`): the
  PR-C5 changes are 0 errors, 0 warnings.  The `ToolRetryExhausted`
  errors are pre-existing on `origin/main` (PR #20621 in-flight
  Draft to clean up SDK variant removals).  Our PR-C5 test exe
  cannot be built locally until that fix lands, but our *diff* is
  clean.

## Why a fourth fix shape, not typed state machine

PR-B / PR-C1 (typed variant) was needed because the counter itself
could be in *inconsistent* states (e.g. `int` counter decremented on
cancel but never incremented on acquire).  PR-C2 (`Fun.protect`) was
needed because the slot is owned by a semaphore with no separate
"state" to desynchronise.  PR-C5 (multi-step list) is the simplest
possible shape: a sequence of idempotent cleanup steps where the
only invariant is "all steps run, regardless of earlier step
exceptions, except for Cancelled which propagates as the cancel
signal".  No state machine is needed; `List.iter` of `try/with` is
the right primitive.  Introducing a typed state machine would be
the workaroud rejection bar's "telemetry-as-fix" pattern (counting
steps that can't be desynced).

## Workaround Rejection Bar

No workaround signatures present:

- No telemetry-as-fix (no new counters, no "make leak visible")
- No string/substring classifier
- No N-of-M site patching (single helper, full coverage of
  multi-step on_release callbacks in `lib/server` — the 2 inline
  call sites in `serve` / `serve_h2` / `serve_auto` and the 1
  inline call in `server_routes_http_routes_dashboard.ml` are
  all converted through `on_connection_release` or the helper
  directly)
- No cap/cooldown/dedup/repair
- No workaround REQUIRED (production is not currently blocked;
  this is preventive, matching PR-C1/C2/C3/C4 coverage)

## CI status

`check-fun-protect-finally-guard.py` PASS on commit `6300497b1`.
`ocamlformat --check` PASS on all 4 modified/new files.

`dune build @check` on the PR-C5 diff is 0 errors / 0 warnings
(filtering pre-existing `ToolRetryExhausted` errors on
`origin/main` which PR #20621 in-flight Draft is fixing).

## RFC discovery

Scanned `docs/rfc/` and `~/me/docs/rfc/` for `server_bootstrap`,
`HTTP cleanup`, `connection release` keywords.  No matching RFC
exists for the connection-release helper.  The closest spirit is
RFC-0194 §3 (structured-concurrency cleanup discipline), which is
the same line PR-B/C1/C2 followed.  This PR is a refactor of
existing production code with no behaviour change on the happy
path.

## Note on `origin/main` red

`origin/main` is currently red on `dune build @check` because of
`ToolRetryExhausted` references that the agent_sdk SDK update
removed (`lib/keeper/keeper_error_classify.ml:631`,
`lib/keeper/keeper_status_bridge_blocker.ml:74`,
`lib/keeper/keeper_event_bridge_error_json.ml:119`,
`lib/keeper/keeper_agent_error.ml:54`, plus 2 test files).  PR
#20621 (`fix(worker): disable OAS tool-level retry that crashes
keepers on empty-arg calls`) is in-flight Draft to clean that up.
Our PR-C5 changes do not touch any of those files; the
`ToolRetryExhausted` errors are pre-existing on `origin/main`
HEAD `b51449081` and unrelated to PR-C5.  Once #20621 lands, our
PR-C5 CI will be green.

## Checklist

- [x] `dune build @check` on the PR-C5 diff: 0 errors, 0 warnings
  (filtering pre-existing `origin/main` red)
- [x] `python3 scripts/ci/check-fun-protect-finally-guard.py`: PASS
- [x] `ocamlformat --check` on all 4 modified/new files: PASS
- [x] Workaround Rejection Bar: no signatures present
- [x] PR-C3 / PR-C4 audit complete (no-fix decisions, task #23 / #24
  marked completed)
- [ ] User review/merge
- [ ] Verify on merged SHA (per `feedback_verify_behavior_on_merged_sha`)
- [ ] PR-C3..C5 audit complete (task #19 closure pending)
- [ ] Local test execution pending PR #20621 (pre-existing main red)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
