### PR TITLE
fix(dashboard): emit fleet composite generated_at as unix number

### DIFF
--- a/lib/server/server_dashboard_http_composite_enrich.ml
+++ b/lib/server/server_dashboard_http_composite_enrich.ml
@@ -51,7 +51,13 @@ let dashboard_fleet_composite_json ~(config : Workspace.config) () : Yojson.Safe
   let entries = Keeper_registry.all ~base_path:config.base_path () in
   let snapshots = List.map (dashboard_keeper_composite_json ~config) entries in
   `Assoc
-    [ "generated_at", `String (Masc_domain.now_iso ())
+    (* generated_at is a unix-second number (not ISO8601 string) to match the
+       sibling timestamps in this same envelope (snapshots[].started_at /
+       last_progress_at / ended_at are all `Float) and the dashboard's
+       runtime-attention staleness arithmetic (fleet-fsm-matrix.ts:558 computes
+       `generatedAt - latest`, which requires a number). The dashboard valibot
+       schema FleetCompositeSnapshotSchema declares generated_at: number(). *)
+    [ "generated_at", `Float (Unix.gettimeofday ())
     ; "count", `Int (List.length snapshots)
     ; "snapshots", `List snapshots
     ]


### PR DESCRIPTION
## 문제

Fleet composite endpoint(`GET /api/v1/keepers/composite`)가 `generated_at`을 ISO8601 string으로 내보내는데, 같은 envelope의 형제 타임스탬프(`snapshots[].started_at` / `last_progress_at` / `ended_at`)는 전부 unix-second `Float`입니다. 대시보드가 payload를 거부합니다:

```
Fleet snapshot failed: composite schema drift:
generated_at: Invalid type: Expected number but received '2026-06-09T09:19:41Z'
```

## 진단 (서버 단독 drift, 3개 독립 증거로 number가 정본 확정)

1. **valibot schema**: `FleetCompositeSnapshotSchema.generated_at: number()` (`dashboard/src/api/schemas/keeper-composite.ts:278`)
2. **소비처 산술**: `fleet-fsm-matrix.ts:558`이 `Math.floor(generatedAt - latest)`로 staleness age 계산 — ISO string이면 `NaN`
3. **테스트 fixture**: `fleet-fsm-matrix.test.ts:106`이 `generated_at: 1_713_000_000` (unix 초) 사용

에러가 **`generated_at`만** 실패를 보고한다는 점이 형제 타임스탬프는 이미 number로 도착함을 증명합니다 — 즉 서버 자신이 내부 불일치 상태였고, 이 한 필드만 outlier였습니다.

## 변경

`server_dashboard_http_composite_enrich.ml:54`: String(now_iso) -> Float(Unix.gettimeofday).

같은 envelope의 다른 타임스탬프와 동일 소스(`Unix.gettimeofday`, 초 단위)를 사용해 일관성을 맞춥니다. 다른 endpoint(mission/status/board/namespace-truth/operator/governance, `server_dashboard_http.ml:111/258/511`)의 `generated_at`은 대시보드가 `asString(...)`으로 string을 올바르게 기대하므로 **건드리지 않습니다**.

## 검증

- [x] `dune build @check` EXIT=0
- [x] `dune build lib/server/` (default target) EXIT=0
- [x] fleet composite envelope의 `generated_at`을 string으로 고정하는 서버 테스트 없음 확인 (`test_dashboard_snapshot.ml`은 별개 내부 record를 검증)
- [ ] 배포 후 라이브: 대시보드 `composite schema drift: generated_at` 에러 소멸 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
