### PR TITLE
feat: scope provider health cooldowns per keeper lane and disable visibility idle backoff

### DIFF
--- a/lib/keeper/keeper_heartbeat_visibility_gate.ml
+++ b/lib/keeper/keeper_heartbeat_visibility_gate.ml
@@ -37,20 +37,12 @@ let visible_consumer_count () =
 ;;
 
 let visibility_gate_decision
-      ~(visible_consumers : int)
-      ~(has_pending_signal : bool)
-      ~(now : float)
-      ~(last_heartbeat_cycle_ts : float)
+      ~visible_consumers:_
+      ~has_pending_signal:_
+      ~now:_
+      ~last_heartbeat_cycle_ts:_
       (decision : Keeper_heartbeat_smart.decision)
   : Keeper_heartbeat_smart.decision
   =
-  match decision with
-  | Keeper_heartbeat_smart.Emit
-    when visible_consumers <= 0
-         && (not has_pending_signal)
-         && last_heartbeat_cycle_ts > 0.0
-         && now -. last_heartbeat_cycle_ts < unobserved_visibility_idle_window_s ->
-    Keeper_heartbeat_smart.Skip_idle
-      (last_heartbeat_cycle_ts +. unobserved_visibility_idle_window_s)
-  | _ -> decision
+  decision
 ;;

--- a/lib/keeper/keeper_turn_driver_provider_attempt.ml
+++ b/lib/keeper/keeper_turn_driver_provider_attempt.ml
@@ -133,19 +133,26 @@ let success_selected_model_raw candidate =
 let health_error_kind label =
   Keeper_binding_health.error_kind_of_string label
 
-let record_candidate_health_success candidate ~latency_ms =
+let scoped_provider_key ~keeper_name provider_key =
+  let keeper_name = String.trim keeper_name in
+  if String.equal keeper_name "" then provider_key
+  else keeper_name ^ "@" ^ provider_key
+
+let record_candidate_health_success ~keeper_name candidate ~latency_ms =
   Runtime_candidate.health_keys candidate
   |> List.iter (fun provider_key ->
+    let provider_key = scoped_provider_key ~keeper_name provider_key in
     Keeper_binding_health.record_success
       Keeper_binding_health.global
       ~provider_key
       ~latency_ms
       ())
 
-let record_candidate_health_rejected candidate ~reason =
+let record_candidate_health_rejected ~keeper_name candidate ~reason =
   let error_kind = health_error_kind "accept_rejected" in
   Runtime_candidate.health_keys candidate
   |> List.iter (fun provider_key ->
+    let provider_key = scoped_provider_key ~keeper_name provider_key in
     Keeper_binding_health.record_rejected
       Keeper_binding_health.global
       ~provider_key
@@ -313,7 +320,7 @@ let sdk_error_runtime_fallback_class (err : Agent_sdk.Error.sdk_error) :
   else if sdk_error_is_max_turns_exceeded err then Some fallback_class_max_turns
   else None
 
-let record_candidate_health_error candidate sdk_err =
+let record_candidate_health_error ~keeper_name candidate sdk_err =
   let error_reason = Agent_sdk.Error.to_string sdk_err in
   let health_keys = Runtime_candidate.health_keys candidate in
   if sdk_error_is_hard_quota sdk_err
@@ -321,6 +328,7 @@ let record_candidate_health_error candidate sdk_err =
     let error_kind = health_error_kind "hard_quota" in
     health_keys
     |> List.iter (fun provider_key ->
+      let provider_key = scoped_provider_key ~keeper_name provider_key in
       Keeper_binding_health.record_hard_quota
         Keeper_binding_health.global
         ~provider_key
@@ -332,6 +340,7 @@ let record_candidate_health_error candidate sdk_err =
     let error_kind = health_error_kind "terminal_provider_runtime_failure" in
     health_keys
     |> List.iter (fun provider_key ->
+      let provider_key = scoped_provider_key ~keeper_name provider_key in
       Keeper_binding_health.record_terminal_failure
         Keeper_binding_health.global
         ~provider_key
@@ -344,6 +353,7 @@ let record_candidate_health_error candidate sdk_err =
       let error_kind = health_error_kind "soft_rate_limited" in
       health_keys
       |> List.iter (fun provider_key ->
+        let provider_key = scoped_provider_key ~keeper_name provider_key in
         Keeper_binding_health.record_soft_rate_limited
           Keeper_binding_health.global
           ~provider_key
@@ -355,6 +365,7 @@ let record_candidate_health_error candidate sdk_err =
       let error_kind = health_error_kind "provider_error" in
       health_keys
       |> List.iter (fun provider_key ->
+        let provider_key = scoped_provider_key ~keeper_name provider_key in
         Keeper_binding_health.record_failure
           Keeper_binding_health.global
           ~provider_key

--- a/lib/keeper/keeper_turn_driver_provider_attempt.mli
+++ b/lib/keeper/keeper_turn_driver_provider_attempt.mli
@@ -69,12 +69,12 @@ val success_selected_model_raw :
 val health_error_kind : string -> Keeper_binding_health.error_kind
 
 val record_candidate_health_success :
-  Runtime_candidate.t -> latency_ms:float -> unit
+  keeper_name:string -> Runtime_candidate.t -> latency_ms:float -> unit
 
 val record_candidate_health_rejected :
-  Runtime_candidate.t -> reason:string -> unit
+  keeper_name:string -> Runtime_candidate.t -> reason:string -> unit
 
 val record_candidate_health_error :
-  Runtime_candidate.t -> Agent_sdk.Error.sdk_error -> unit
+  keeper_name:string -> Runtime_candidate.t -> Agent_sdk.Error.sdk_error -> unit
 
 val runtime_candidate_label : string

--- a/lib/keeper/keeper_turn_driver_try_runtime.ml
+++ b/lib/keeper/keeper_turn_driver_try_runtime.ml
@@ -166,6 +166,7 @@ let run
       (match result with
        | Ok run_result when ctx.accept run_result.Runtime_agent.response ->
          Keeper_turn_driver_provider_attempt.record_candidate_health_success
+           ~keeper_name:ctx.keeper_name
            candidate
            ~latency_ms;
          ctx.record_provider_health_result candidate ~success:true ~http_status:None;
@@ -174,6 +175,7 @@ let run
        | Ok run_result ->
          let reason = "accept predicate rejected runtime response" in
          Keeper_turn_driver_provider_attempt.record_candidate_health_rejected
+           ~keeper_name:ctx.keeper_name
            candidate
            ~reason;
          let last_err =
@@ -184,6 +186,7 @@ let run
          else loop checkpoint_after last_err rest
        | Error err ->
          Keeper_turn_driver_provider_attempt.record_candidate_health_error
+           ~keeper_name:ctx.keeper_name
            candidate
            err;
          let http_err = sdk_error_to_http_error err in

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -746,6 +746,7 @@ let keeper_cycle_decision
           if should_run
           then
             provider_cooldown_remaining_sec
+              ~keeper_name:meta.name
               ~runtime_id:(runtime_id)
           else None
         in

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -285,12 +285,12 @@ val should_inject_entropic_oscillation :
 
 val keeper_cycle_decision :
   ?provider_cooldown_remaining_sec:
-    (runtime_id:string -> int option) ->
+    (keeper_name:string -> runtime_id:string -> int option) ->
   meta:Keeper_meta_contract.keeper_meta -> world_observation -> keeper_cycle_decision
 
 val unified_turn_decision :
   ?provider_cooldown_remaining_sec:
-    (runtime_id:string -> int option) ->
+    (keeper_name:string -> runtime_id:string -> int option) ->
   meta:Keeper_meta_contract.keeper_meta -> world_observation -> keeper_cycle_decision
 
 val should_run_keeper_cycle :

--- a/lib/keeper/keeper_world_observation_provider_cooldown.ml
+++ b/lib/keeper/keeper_world_observation_provider_cooldown.ml
@@ -24,7 +24,13 @@ let fallback_runtime_for_provider_cooldown
   then None
   else Some (Keeper_config.default_runtime_id ())
 
+let scoped_provider_key ~keeper_name provider_key =
+  let keeper_name = String.trim keeper_name in
+  if String.equal keeper_name "" then provider_key
+  else keeper_name ^ "@" ^ provider_key
+
 let provider_cooldown_remaining_sec_for_runtime
+      ~(keeper_name : string)
       ~(runtime_id : string)
   : int option
   =
@@ -38,6 +44,7 @@ let provider_cooldown_remaining_sec_for_runtime
     let provider_infos =
       List.map
         (fun provider_key ->
+           let provider_key = scoped_provider_key ~keeper_name provider_key in
            Keeper_binding_health.provider_info
              Keeper_binding_health.global
              ~provider_key)
@@ -75,6 +82,7 @@ let provider_capacity_blocked_task_count
     let runtime_id = runtime_id_of_meta meta in
     match
       provider_cooldown_remaining_sec
+        ~keeper_name:meta.name
         ~runtime_id:(runtime_id)
     with
     | Some _

--- a/lib/keeper/keeper_world_observation_provider_cooldown.mli
+++ b/lib/keeper/keeper_world_observation_provider_cooldown.mli
@@ -4,10 +4,10 @@ val fallback_runtime_for_provider_cooldown :
   string option
 
 val provider_cooldown_remaining_sec_for_runtime :
-  runtime_id:string -> int option
+  keeper_name:string -> runtime_id:string -> int option
 
 val provider_capacity_blocked_task_count :
-  ?provider_cooldown_remaining_sec:(runtime_id:string -> int option) ->
+  ?provider_cooldown_remaining_sec:(keeper_name:string -> runtime_id:string -> int option) ->
   meta:Keeper_meta_contract.keeper_meta ->
   claimable_task_count:int ->
   unit ->

--- a/test/test_smart_heartbeat_keepalive.ml
+++ b/test/test_smart_heartbeat_keepalive.ml
@@ -149,17 +149,15 @@ let test_cycle_pauses_on_skip_idle () =
 
 let test_visibility_gate_delays_unobserved_idle_emit () =
   let now = 1_000.0 in
-  match
+  let decision =
     KK.visibility_gate_decision
       ~visible_consumers:0
       ~has_pending_signal:false
       ~now
       ~last_heartbeat_cycle_ts:(now -. 60.0)
       HS.Emit
-  with
-  | HS.Skip_idle next ->
-    check bool "next heartbeat stays bounded" true (next > now)
-  | HS.Emit | HS.Skip_busy -> fail "expected unobserved emit to become Skip_idle"
+  in
+  check bool "unobserved idle remains emit because visibility gate backoff is disabled" true (decision = HS.Emit)
 
 let test_visibility_gate_allows_pending_signal () =
   let decision =


### PR DESCRIPTION
This PR scopes LLM provider health check and cooldown tracking per keeper lane (e.g., `keeper_name@provider_key`) to avoid a single keeper's rate-limiting or failure triggering a global cooldown block across all other keepers. It also disables the 15-minute visibility gate idle backoff to prevent idle keepers from falling into prolonged sleep states when there are no active dashboard consumers.