### PR TITLE
chore(keeper): purge dead Sdk_tool_retry_exhausted blocker_class

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -1582,7 +1582,6 @@ describe('fetchKeeperConfig', () => {
       ['sdk_cost_budget_exceeded', 'SDK 비용 예산 초과'],
       ['sdk_unrecognized_stop_reason', 'SDK 미식별 정지 사유'],
       ['sdk_idle_detected', 'SDK Idle 감지'],
-      ['sdk_tool_retry_exhausted', 'SDK 도구 재시도 소진'],
       ['sdk_guardrail_violation', 'SDK 가드레일 위반'],
       ['sdk_tripwire_violation', 'SDK Tripwire 위반'],
       ['sdk_exit_condition_met', 'SDK 종료 조건 충족'],

--- a/dashboard/src/lib/keeper-runtime-display.test.ts
+++ b/dashboard/src/lib/keeper-runtime-display.test.ts
@@ -238,7 +238,6 @@ describe('keeperRuntimeBlockerLabel', () => {
     expect(keeperRuntimeBlockerLabel('sdk_cost_budget_exceeded')).toBe('SDK 비용 예산 초과')
     expect(keeperRuntimeBlockerLabel('sdk_unrecognized_stop_reason')).toBe('SDK 미식별 정지 사유')
     expect(keeperRuntimeBlockerLabel('sdk_idle_detected')).toBe('SDK Idle 감지')
-    expect(keeperRuntimeBlockerLabel('sdk_tool_retry_exhausted')).toBe('SDK 도구 재시도 소진')
     expect(keeperRuntimeBlockerLabel('sdk_guardrail_violation')).toBe('SDK 가드레일 위반')
     expect(keeperRuntimeBlockerLabel('sdk_tripwire_violation')).toBe('SDK Tripwire 위반')
     expect(keeperRuntimeBlockerLabel('sdk_exit_condition_met')).toBe('SDK 종료 조건 충족')

--- a/dashboard/src/lib/keeper-runtime-display.ts
+++ b/dashboard/src/lib/keeper-runtime-display.ts
@@ -413,7 +413,6 @@ const runtimeBlockerLabels = {
   sdk_cost_budget_exceeded: 'SDK 비용 예산 초과',
   sdk_unrecognized_stop_reason: 'SDK 미식별 정지 사유',
   sdk_idle_detected: 'SDK Idle 감지',
-  sdk_tool_retry_exhausted: 'SDK 도구 재시도 소진',
   sdk_guardrail_violation: 'SDK 가드레일 위반',
   sdk_tripwire_violation: 'SDK Tripwire 위반',
   sdk_exit_condition_met: 'SDK 종료 조건 충족',

--- a/dashboard/src/lib/runtime-blocker-class.ts
+++ b/dashboard/src/lib/runtime-blocker-class.ts
@@ -65,7 +65,6 @@ const BACKEND_KEEPER_META_BLOCKER_CLASSES = [
   'sdk_cost_budget_exceeded',
   'sdk_unrecognized_stop_reason',
   'sdk_idle_detected',
-  'sdk_tool_retry_exhausted',
   'sdk_guardrail_violation',
   'sdk_tripwire_violation',
   'sdk_exit_condition_met',

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -446,7 +446,6 @@ export const KEEPER_RUNTIME_BLOCKER_CLASSES = [
   'sdk_cost_budget_exceeded',
   'sdk_unrecognized_stop_reason',
   'sdk_idle_detected',
-  'sdk_tool_retry_exhausted',
   'sdk_guardrail_violation',
   'sdk_tripwire_violation',
   'sdk_exit_condition_met',

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -195,7 +195,6 @@ type blocker_class =
   | Sdk_cost_budget_exceeded
   | Sdk_unrecognized_stop_reason
   | Sdk_idle_detected
-  | Sdk_tool_retry_exhausted
   | Sdk_guardrail_violation
   | Sdk_tripwire_violation
   | Sdk_exit_condition_met
@@ -221,7 +220,6 @@ let blocker_class_to_string = function
   | Sdk_cost_budget_exceeded -> "sdk_cost_budget_exceeded"
   | Sdk_unrecognized_stop_reason -> "sdk_unrecognized_stop_reason"
   | Sdk_idle_detected -> "sdk_idle_detected"
-  | Sdk_tool_retry_exhausted -> "sdk_tool_retry_exhausted"
   | Sdk_guardrail_violation -> "sdk_guardrail_violation"
   | Sdk_tripwire_violation -> "sdk_tripwire_violation"
   | Sdk_exit_condition_met -> "sdk_exit_condition_met"
@@ -248,7 +246,6 @@ let blocker_class_of_serialized_string = function
   | "sdk_cost_budget_exceeded" -> Some Sdk_cost_budget_exceeded
   | "sdk_unrecognized_stop_reason" -> Some Sdk_unrecognized_stop_reason
   | "sdk_idle_detected" -> Some Sdk_idle_detected
-  | "sdk_tool_retry_exhausted" -> Some Sdk_tool_retry_exhausted
   | "sdk_guardrail_violation" -> Some Sdk_guardrail_violation
   | "sdk_tripwire_violation" -> Some Sdk_tripwire_violation
   | "sdk_exit_condition_met" -> Some Sdk_exit_condition_met
@@ -296,7 +293,6 @@ let blocker_class_continue_gate = function
   | Sdk_cost_budget_exceeded
   | Sdk_unrecognized_stop_reason
   | Sdk_idle_detected
-  | Sdk_tool_retry_exhausted
   | Sdk_guardrail_violation
   | Sdk_tripwire_violation
   | Sdk_exit_condition_met

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -173,7 +173,6 @@ type blocker_class =
   | Sdk_cost_budget_exceeded
   | Sdk_unrecognized_stop_reason
   | Sdk_idle_detected
-  | Sdk_tool_retry_exhausted
   | Sdk_guardrail_violation
   | Sdk_tripwire_violation
   | Sdk_exit_condition_met

--- a/lib/keeper/keeper_rollover.ml
+++ b/lib/keeper/keeper_rollover.ml
@@ -88,7 +88,6 @@ let blocker_class_indicates_overflow (klass : blocker_class) : bool =
   | Sdk_cost_budget_exceeded
   | Sdk_unrecognized_stop_reason
   | Sdk_idle_detected
-  | Sdk_tool_retry_exhausted
   | Sdk_guardrail_violation
   | Sdk_tripwire_violation
   | Sdk_exit_condition_met

--- a/lib/keeper/keeper_status_bridge_blocker.ml
+++ b/lib/keeper/keeper_status_bridge_blocker.ml
@@ -171,7 +171,6 @@ let runtime_blocker_surface_of_typed_class ?(summary = "") (cls : blocker_class)
     | Sdk_cost_budget_exceeded
     | Sdk_unrecognized_stop_reason
     | Sdk_idle_detected
-    | Sdk_tool_retry_exhausted
     | Sdk_guardrail_violation
     | Sdk_tripwire_violation
     | Sdk_exit_condition_met
@@ -211,13 +210,6 @@ let stale_kill_class_summary (kill_class : Keeper_registry.stale_kill_class) =
       "noop_failure_loop: %d consecutive turn(s) produced no tool calls; stale watchdog \
        stopped the keeper."
       noop_count
-;;
-
-let sdk_tool_retry_exhausted_code_prefix = "agent_error_tool_retry_exhausted"
-
-let provider_runtime_code_is_sdk_tool_retry_exhausted code =
-  String.equal code sdk_tool_retry_exhausted_code_prefix
-  || String.starts_with ~prefix:(sdk_tool_retry_exhausted_code_prefix ^ ":") code
 ;;
 
 let runtime_blocker_surface_of_failure_reason (reason : Keeper_registry.failure_reason) =
@@ -274,16 +266,6 @@ let runtime_blocker_surface_of_failure_reason (reason : Keeper_registry.failure_
                window; keeper was auto-paused before restart loop."
               distinct_count)
          Stale_fleet_batch)
-  | Keeper_registry.Provider_runtime_error { code; detail; _ }
-    when provider_runtime_code_is_sdk_tool_retry_exhausted code ->
-    Some
-      (runtime_blocker_surface_of_typed_class
-         ~summary:
-           (Printf.sprintf
-              "OAS tool retry budget exhausted; inspect tool arguments/schema \
-               first. Detail: %s"
-              detail)
-         Sdk_tool_retry_exhausted)
   | Keeper_registry.Provider_runtime_error { code; detail; _ } ->
     Some
       { blocker_class = "provider_runtime_error"

--- a/lib/keeper/keeper_supervisor_types.ml
+++ b/lib/keeper/keeper_supervisor_types.ml
@@ -147,7 +147,6 @@ let paused_meta_legacy_auto_resume_after_sec (meta : keeper_meta) =
           | Sdk_cost_budget_exceeded
           | Sdk_unrecognized_stop_reason
           | Sdk_idle_detected
-          | Sdk_tool_retry_exhausted
           | Sdk_guardrail_violation
           | Sdk_tripwire_violation
           | Sdk_exit_condition_met

--- a/test/test_blocker_class_exhaustiveness.ml
+++ b/test/test_blocker_class_exhaustiveness.ml
@@ -11,21 +11,6 @@ open Alcotest
 module Kmc = Masc.Keeper_meta_contract
 open Kmc
 
-let string_contains ~needle haystack =
-  let needle_len = String.length needle in
-  let haystack_len = String.length haystack in
-  if needle_len = 0
-  then true
-  else
-    let rec loop i =
-      if i + needle_len > haystack_len
-      then false
-      else
-        String.equal (String.sub haystack i needle_len) needle || loop (i + 1)
-    in
-    loop 0
-;;
-
 (* ── All variants listed exhaustively ──────────────────────────── *)
 
 (** Canonical list of all [blocker_class] variants.  When a new variant is
@@ -59,7 +44,6 @@ let all_variants : blocker_class list =
   ; Sdk_cost_budget_exceeded
   ; Sdk_unrecognized_stop_reason
   ; Sdk_idle_detected
-  ; Sdk_tool_retry_exhausted
   ; Sdk_guardrail_violation
   ; Sdk_tripwire_violation
   ; Sdk_exit_condition_met
@@ -121,7 +105,7 @@ let test_unknown_string () =
 (** Pin the variant count so additions are visible in diffs.  When adding a
     new [blocker_class] variant, bump this number and add the variant to
     [all_variants]. *)
-let expected_variant_count = 32
+let expected_variant_count = 31
 
 let test_variant_count () =
   let count = List.length all_variants in
@@ -150,6 +134,11 @@ let all_sdk_agent_variants : (string * SdkE.sdk_error) list =
     , SdkE.Agent
         (SdkE.AgentExecutionTimeout
            { elapsed_sec = 10.0; timeout_sec = 5.0; turn_count = 3; max_turns = 10 })
+    )
+  ; ( "AgentExecutionIdleTimeout"
+    , SdkE.Agent
+        (SdkE.AgentExecutionIdleTimeout
+           { idle_sec = 10.0; idle_timeout_sec = 5.0; turn_count = 3; max_turns = 10 })
     )
   ; ( "MaxTurnsExceeded"
     , SdkE.Agent (SdkE.MaxTurnsExceeded { turns = 10; limit = 10 }) )
@@ -306,33 +295,6 @@ let test_reason_none_provider_error_falls_through () =
     surface.KSB.blocker_class
 ;;
 
-let test_tool_retry_provider_error_uses_sdk_surface () =
-  let surface =
-    provider_runtime_surface_exn
-      ~reason:None
-      ~code:"agent_error_tool_retry_exhausted:attempts=2,limit=2"
-      ~detail:"Tool retry budget exhausted after 2/2 retries: masc_library_search {}"
-      ()
-  in
-  check string
-    "tool retry code -> sdk_tool_retry_exhausted surface"
-    "sdk_tool_retry_exhausted"
-    surface.KSB.blocker_class;
-  check bool "continue_gate false" false surface.KSB.continue_gate;
-  check bool
-    "summary points at tool args"
-    true
-    (string_contains ~needle:"tool arguments/schema" surface.KSB.summary);
-  check bool
-    "summary keeps retry detail"
-    true
-    (string_contains ~needle:"Tool retry budget exhausted" surface.KSB.summary);
-  check bool
-    "summary avoids provider catch-all wording"
-    false
-    (string_contains ~needle:"Provider runtime catch-all" surface.KSB.summary)
-;;
-
 (* ── Runner ────────────────────────────────────────────────────── *)
 
 let () =
@@ -358,8 +320,6 @@ let () =
             test_typed_provider_reason_falls_through
         ; test_case "reason=None provider error falls through" `Quick
             test_reason_none_provider_error_falls_through
-        ; test_case "tool retry provider record uses sdk surface" `Quick
-            test_tool_retry_provider_error_uses_sdk_surface
         ] )
     ]
 ;;

--- a/test/test_keeper_rollover_gate.ml
+++ b/test/test_keeper_rollover_gate.ml
@@ -57,7 +57,6 @@ let non_overflow_classes_are_not_matched () =
     Keeper_meta_contract.Sdk_cost_budget_exceeded;
     Keeper_meta_contract.Sdk_unrecognized_stop_reason;
     Keeper_meta_contract.Sdk_idle_detected;
-    Keeper_meta_contract.Sdk_tool_retry_exhausted;
     Keeper_meta_contract.Sdk_guardrail_violation;
     Keeper_meta_contract.Sdk_tripwire_violation;
     Keeper_meta_contract.Sdk_exit_condition_met;


### PR DESCRIPTION
## 목적

OAS 0.205.0이 `Tool_retry_policy` / `ToolRetryExhausted` surface를 제거하면서, masc 측 `Sdk_tool_retry_exhausted` blocker_class가 **runtime-dead**가 되었습니다. 유일한 producer가 string-gated `Provider_runtime_error` arm(`provider_runtime_code_is_sdk_tool_retry_exhausted`, 리터럴 코드 `"agent_error_tool_retry_exhausted"` 매칭)이었고 SDK가 이 코드를 방출하지 않습니다. string gate 때문에 컴파일러가 dead로 못 잡던 케이스입니다.

## 접근

Compiler-guided removal: blocker_class sum type에서 변형을 제거한 뒤 `dune build @check`가 flag하는 모든 match site를 정리.

- `keeper_meta_contract.ml/.mli`: 변형 + to_string/of_string/continue_gate arm 제거
- `keeper_status_bridge_blocker.ml`: string-gated producer arm 제거(generic `Provider_runtime_error` catch-all이 해당 코드를 처리), code-prefix const, predicate helper 제거
- `keeper_rollover.ml`, `keeper_supervisor_types.ml`: 사라진 arm 제거
- dashboard(`runtime-blocker-class.ts`, `types/core.ts`, `keeper-runtime-display.ts` + 테스트 2개): union member + label 제거

## 함께 고친 pre-existing 결함

같은 파일을 편집하다 발견: `all_sdk_agent_variants`가 `AgentExecutionIdleTimeout`(OAS가 추가한 12번째 SDK Agent 에러 변형)을 누락 → `expected_agent_variant_count = 12` pin이 origin/main에서 이미 `12 vs 11`로 실패 중이었습니다. 누락 항목을 추가(형제 `AgentExecutionTimeout`처럼 `Oas_agent_execution_timeout`으로 매핑).

## 검증

- `dune build @check`: EXIT 0
- `test_blocker_class_exhaustiveness`: 10/10 (variant count pin 포함)
- `test_keeper_rollover_gate`: 11/11
- dashboard `tsc`: 변경 파일 0건 (8건 `ide/*` 에러는 origin/main과 동일한 pre-existing)
- dashboard vitest `keeper-runtime-display`: 43/43

## 건드리지 않은 것

- LIVE인 다른 SDK blocker 계열(`Sdk_max_turns_exceeded`/`Sdk_token_budget_exceeded`/`Sdk_cost_budget_exceeded` 등)은 보존. 이들의 `continue_gate`(halt 여부) 재검토는 별도 논의/PR.
- `RFC-0062` 문서의 역사적 언급은 보존.

RFC-WAIVED: dead-code 제거(신규 surface/credential/operator 변경 없음). blocker_class telemetry label 1개 + 그 string-gated producer 삭제로, 동작 변경 없음(generic catch-all이 동일 코드 경로 처리).
