### PR TITLE
refactor(run): remove masc_run_log and masc_run_deliverable tools

### DIFF
--- a/docs/rfc/RFC-0182-masc-descriptor-projection.md
+++ b/docs/rfc/RFC-0182-masc-descriptor-projection.md
@@ -114,7 +114,7 @@ Add 113 entries to `internal_descriptors` in `lib/keeper/agent_tool_descriptor.m
 | `masc_workspace_*` (workspace status/heartbeat/goal) | ~8 | `Tool_masc_workspace_dispatch` |
 | `masc_task_*` | ~7 | `Tool_masc_task_dispatch` |
 | `masc_operator_*` | ~6 | `Tool_masc_operator_dispatch` |
-| `masc_run_*` | ~6 | `Tool_masc_run_dispatch` |
+| `masc_run_*` | ~4 | `Tool_masc_run_dispatch` |
 | `masc_agent_*` | ~5 | `Tool_masc_agent_dispatch` |
 | `masc_library_*` | ~5 | `Tool_masc_library_dispatch` |
 | `masc_control_*` (pause/resume) | ~3 | `Tool_masc_control_dispatch` |
@@ -124,6 +124,13 @@ Add 113 entries to `internal_descriptors` in `lib/keeper/agent_tool_descriptor.m
 | Singletons (`masc_bind`, `masc_broadcast`, `masc_execute`, etc.) | ~32 | individual variants |
 
 Net new `runtime_handler` variants: ~14 cluster + ~25 singletons = **~39**. Net new descriptor entries: **113**. After this RFC: `internal_descriptors` = 39 + 113 = **152**.
+
+> Update (2026-06-09): the `masc_run_*` cluster dropped from 6 to 4
+> tools — `masc_run_log` and `masc_run_deliverable` were removed (0
+> recorded writes in fleet logs; the surviving `init`/`plan`/`get`/`list`
+> cover run tracking). The `~N` per-cluster counts above are live
+> approximations; the net-new totals are the point-in-time projection
+> at RFC authoring and are left as the historical record.
 
 The In_process handler for each cluster routes to the existing typed dispatcher — no logic is moved out of `tool_board_dispatch.ml`, `tool_task.ml`, etc. The descriptor layer is a *projection*, not a relocation.
 

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -1152,7 +1152,7 @@ let internal_descriptors : t list =
       "Append a workspace note." ~readonly:false
   ; masc_plan_descriptor "deliver" "masc_deliver"
       "Record a deliverable against the plan." ~readonly:false
-  (* ── RFC-0182 §3.1 — masc_run_* cluster (6 entries) ──────────── *)
+  (* ── RFC-0182 §3.1 — masc_run_* cluster (4 entries) ──────────── *)
   ; masc_run_descriptor "masc_run_init"
       "Initialise a workspace run." ~readonly:false
   ; masc_run_descriptor "masc_run_list"
@@ -1160,12 +1160,8 @@ let internal_descriptors : t list =
   ; masc_run_descriptor "masc_run_get"
       "Read a single run by id, creating an empty run record when missing."
       ~readonly:false
-  ; masc_run_descriptor "masc_run_log"
-      "Read or append run log events." ~readonly:false
   ; masc_run_descriptor "masc_run_plan"
       "Read the run plan." ~readonly:true
-  ; masc_run_descriptor "masc_run_deliverable"
-      "Read or attach a run deliverable." ~readonly:false
   (* ── RFC-0182 §3.1 — masc_agent_* cluster (5 entries) ────────── *)
   ; masc_agent_descriptor "agents" "masc_agents"
       "List registered agents." ~readonly:true

--- a/lib/run_eio.ml
+++ b/lib/run_eio.ml
@@ -4,8 +4,6 @@
     Stores:
     - run.json (metadata)
     - plan.md
-    - deliverable.md
-    - log.jsonl (append-only)
 *)
 
 open Workspace_utils
@@ -15,15 +13,8 @@ type run_record = {
   task_id: string;
   agent_name: string option;
   plan: string;
-  deliverable: string;
   created_at: string;
   updated_at: string;
-}
-
-(** Log entry *)
-type log_entry = {
-  timestamp: string;
-  note: string;
 }
 
 let now_iso () = Masc_domain.now_iso ()
@@ -33,7 +24,6 @@ let run_record_to_json (r : run_record) : Yojson.Safe.t =
     ("task_id", `String r.task_id);
     ("agent_name", Json_util.string_opt_to_json r.agent_name);
     ("plan", `String r.plan);
-    ("deliverable", `String r.deliverable);
     ("created_at", `String r.created_at);
     ("updated_at", `String r.updated_at);
   ]
@@ -45,27 +35,10 @@ let run_record_of_json (json : Yojson.Safe.t) : run_record option =
   | Some task_id, Some created_at, Some updated_at ->
     let agent_name = Safe_ops.json_string_opt "agent_name" json in
     let plan = Safe_ops.json_string ~default:"" "plan" json in
-    let deliverable = Safe_ops.json_string ~default:"" "deliverable" json in
-    Some { task_id; agent_name; plan; deliverable; created_at; updated_at }
+    Some { task_id; agent_name; plan; created_at; updated_at }
   | _ ->
     Otel_metric_store.inc_counter Otel_metric_store.metric_error_events ~labels:[("type", Error_event_type.(to_label Parsing))] ();
     Log.Misc.error "run_of_json: missing required fields";
-    None
-
-let log_entry_to_json (e : log_entry) : Yojson.Safe.t =
-  `Assoc [
-    ("timestamp", `String e.timestamp);
-    ("note", `String e.note);
-  ]
-
-let log_entry_of_json (json : Yojson.Safe.t) : log_entry option =
-  match Safe_ops.json_string_opt "timestamp" json,
-        Safe_ops.json_string_opt "note" json with
-  | Some timestamp, Some note ->
-    Some { timestamp; note }
-  | _ ->
-    Otel_metric_store.inc_counter Otel_metric_store.metric_error_events ~labels:[("type", Error_event_type.(to_label Parsing))] ();
-    Log.Misc.error "log_entry_of_json: missing required fields";
     None
 
 let runs_dir (config : config) =
@@ -79,12 +52,6 @@ let run_json_path config task_id =
 
 let plan_path config task_id =
   Filename.concat (run_dir config task_id) "plan.md"
-
-let deliverable_path config task_id =
-  Filename.concat (run_dir config task_id) "deliverable.md"
-
-let log_path config task_id =
-  Filename.concat (run_dir config task_id) "log.jsonl"
 
 let ensure_run_dir config task_id =
   let dir = run_dir config task_id in
@@ -133,7 +100,6 @@ let init config ~task_id ~agent_name : (run_record, string) result =
       task_id;
       agent_name;
       plan = "";
-      deliverable = "";
       created_at;
       updated_at = created_at;
     } in
@@ -141,14 +107,6 @@ let init config ~task_id ~agent_name : (run_record, string) result =
     let plan_file = plan_path config task_id in
     if not (path_exists config plan_file) then
       write_text_file plan_file "# Run Plan\n\n";
-    let deliverable_file = deliverable_path config task_id in
-    if not (path_exists config deliverable_file) then
-      write_text_file deliverable_file "";
-    let log_file = log_path config task_id in
-    if not (path_exists config log_file) then begin
-      mkdir_p (Filename.dirname log_file);
-      Fs_compat.save_file log_file ""
-    end;
     write_run config run;
     Ok run
   with
@@ -161,9 +119,8 @@ let init config ~task_id ~agent_name : (run_record, string) result =
     on [run.json]; two concurrent callers (different fibers handling
     [tool_run] MCP requests for the same task) would each read the
     same snapshot and the later writer would overwrite the earlier
-    [plan] / [deliverable] update.  The sibling [append_log] already
-    uses [with_file_lock] on its log file; extend the same discipline
-    to [run.json] writes.  The [plan.md] mirror at [plan_path] is a
+    [plan] update.  Wrapped in a [with_file_lock] on [run.json] to
+    serialise those writes.  The [plan.md] mirror at [plan_path] is a
     single full-content overwrite, so it does not need a separate
     lock — writing the mirror and the [run.json] record inside the
     same critical section keeps them consistent. *)
@@ -183,84 +140,6 @@ let update_plan config ~task_id ~content : (run_record, string) result =
   | Eio.Cancel.Cancelled _ as e -> raise e
   | e -> Error (Printexc.to_string e)
 
-(** Append log entry *)
-let append_log config ~task_id ~note : (log_entry, string) result =
-  try
-    ensure_initialized config;
-    ensure_run_dir config task_id;
-    let entry = { timestamp = Masc_domain.now_iso (); note } in
-    let file = log_path config task_id in
-    with_file_lock config file (fun () ->
-      Fs_compat.append_jsonl file (log_entry_to_json entry)
-    );
-    Ok entry
-  with
-  | Eio.Cancel.Cancelled _ as e -> raise e
-  | e -> Error (Printexc.to_string e)
-
-(** Set deliverable.  Same lost-update concern as [update_plan] —
-    read_run → modify → write_run is a read-modify-write on
-    [run.json] that two concurrent fibers could each read from the
-    same snapshot and clobber.  Wrapped in the same [run.json] file
-    lock for identical reasons. *)
-let set_deliverable config ~task_id ~content : (run_record, string) result =
-  try
-    let run_file = run_json_path config task_id in
-    with_file_lock config run_file (fun () ->
-      match read_run config task_id with
-      | Error e -> Error e
-      | Ok run ->
-          let updated = { run with deliverable = content; updated_at = Masc_domain.now_iso () } in
-          let path = deliverable_path config task_id in
-          write_text_file path content;
-          write_run config updated;
-          Ok updated)
-  with
-  | Eio.Cancel.Cancelled _ as e -> raise e
-  | e -> Error (Printexc.to_string e)
-
-(** Read logs (optionally tail N).
-
-    When [limit] is given the fold drives a bounded [Queue.t] sized to
-    [n] (drop-oldest on overflow), so peak live memory is O(n) instead
-    of O(file_line_count) and the post-fold [List.length] / [mapi] /
-    [filter] / [map snd] trim chain is gone.
-
-    Same ring-buffer pattern as
-    [institution_eio.load_recent_episodes_jsonl] (PR #14873) and
-    [Log.Ring.load_from_file] (PR #14904 after Copilot review): for
-    tail-N over an unbounded append-only JSONL the streaming fold
-    should *also* be the trim, otherwise the win from
-    [Fs_compat.fold_jsonl_lines] is canceled by a downstream list
-    materialisation. *)
-let read_logs config ~task_id ?limit () : log_entry list =
-  let file = log_path config task_id in
-  if not (Sys.file_exists file) then []
-  else
-    match limit with
-    | None ->
-      Fs_compat.fold_jsonl_lines
-        ~init:[]
-        ~f:(fun acc ~line_no:_ j ->
-          match log_entry_of_json j with
-          | Some e -> e :: acc
-          | None -> acc)
-        file
-      |> List.rev
-    | Some n when n <= 0 -> []
-    | Some n ->
-      let ring : log_entry Queue.t = Queue.create () in
-      Fs_compat.fold_jsonl_lines
-        ~init:()
-        ~f:(fun () ~line_no:_ j ->
-          match log_entry_of_json j with
-          | None -> ()
-          | Some e ->
-            Queue.add e ring;
-            if Queue.length ring > n then ignore (Queue.pop ring))
-        file;
-      List.of_seq (Queue.to_seq ring)
-
 (** Get run details. Missing runs are bootstrapped so resume/read paths do
     not block autonomous keeper turns before any explicit masc_run_init call. *)
 let get ?agent_name config ~task_id : (Yojson.Safe.t, string) result =
@@ -278,17 +157,9 @@ let get ?agent_name config ~task_id : (Yojson.Safe.t, string) result =
       let text = read_text_file (plan_path config task_id) in
       if text = "" then run.plan else text
     in
-    let deliverable_content =
-      let text = read_text_file (deliverable_path config task_id) in
-      if text = "" then run.deliverable else text
-    in
-    let logs = read_logs config ~task_id ~limit:50 () in
     let json = `Assoc [
       ("run", run_record_to_json run);
       ("plan", `String plan_content);
-      ("deliverable", `String deliverable_content);
-      ("logs", `List (List.map log_entry_to_json logs));
-      ("log_count", `Int (List.length logs));
     ] in
     Ok json
 

--- a/lib/run_eio.mli
+++ b/lib/run_eio.mli
@@ -4,9 +4,7 @@
     files live under the run directory:
 
     - [run.json]       — metadata ({!run_record} serialised)
-    - [plan.md]        — planning document
-    - [deliverable.md] — task output
-    - [log.jsonl]      — append-only event log ({!log_entry}) *)
+    - [plan.md]        — planning document *)
 
 (** {1 Types} *)
 
@@ -14,14 +12,8 @@ type run_record = {
   task_id : string;
   agent_name : string option;
   plan : string;
-  deliverable : string;
   created_at : string;
   updated_at : string;
-}
-
-type log_entry = {
-  timestamp : string;
-  note : string;
 }
 
 (** {1 JSON serde}
@@ -33,10 +25,6 @@ val run_record_to_json : run_record -> Yojson.Safe.t
 
 val run_record_of_json : Yojson.Safe.t -> run_record option
 
-val log_entry_to_json : log_entry -> Yojson.Safe.t
-
-val log_entry_of_json : Yojson.Safe.t -> log_entry option
-
 (** {1 Path builders} *)
 
 val runs_dir : Workspace_utils.config -> string
@@ -46,10 +34,6 @@ val run_dir : Workspace_utils.config -> string -> string
 val run_json_path : Workspace_utils.config -> string -> string
 
 val plan_path : Workspace_utils.config -> string -> string
-
-val deliverable_path : Workspace_utils.config -> string -> string
-
-val log_path : Workspace_utils.config -> string -> string
 
 (** Create {!run_dir} and parents if missing. *)
 val ensure_run_dir : Workspace_utils.config -> string -> unit
@@ -62,9 +46,9 @@ val write_text_file : string -> string -> unit
 
 (** {1 Run lifecycle}
 
-    [init] / [update_plan] / [set_deliverable] / [append_log] implement
-    read-modify-write safety via per-[run.json] file locks to prevent
-    lost updates across concurrent fibers. *)
+    [init] / [update_plan] implement read-modify-write safety via
+    per-[run.json] file locks to prevent lost updates across
+    concurrent fibers. *)
 
 val write_run : Workspace_utils.config -> run_record -> unit
 
@@ -72,8 +56,7 @@ val read_run :
   Workspace_utils.config -> string -> (run_record, string) result
 
 (** [init config ~task_id ~agent_name] creates the run directory,
-    default [plan.md] / [deliverable.md] / [log.jsonl], and writes an
-    initial [run.json]. *)
+    a default [plan.md], and writes an initial [run.json]. *)
 val init :
   Workspace_utils.config ->
   task_id:string ->
@@ -87,34 +70,10 @@ val update_plan :
   content:string ->
   (run_record, string) result
 
-(** File-locked append to [log.jsonl]. *)
-val append_log :
-  Workspace_utils.config ->
-  task_id:string ->
-  note:string ->
-  (log_entry, string) result
-
-(** File-locked read-modify-write on [run.json]. *)
-val set_deliverable :
-  Workspace_utils.config ->
-  task_id:string ->
-  content:string ->
-  (run_record, string) result
-
 (** {1 Queries} *)
 
-(** [read_logs ?limit ()] returns all log entries when [limit] is
-    absent; otherwise the last [limit] entries (tail). *)
-val read_logs :
-  Workspace_utils.config ->
-  task_id:string ->
-  ?limit:int ->
-  unit ->
-  log_entry list
-
-(** Bundle {!run_record} + plan text + deliverable text + last 50 logs
-    into a single JSON object. Creates the run scaffold first when
-    [run.json] is missing. *)
+(** Bundle {!run_record} + plan text into a single JSON object.
+    Creates the run scaffold first when [run.json] is missing. *)
 val get :
   ?agent_name:string ->
   Workspace_utils.config ->

--- a/lib/tool/tool_catalog.ml
+++ b/lib/tool/tool_catalog.ml
@@ -280,8 +280,6 @@ let explicit_metadata : (string * metadata) list =
     ("masc_run_list", read_state_tool);
     ("masc_run_init", broadcast_tool);
     ("masc_run_plan", broadcast_tool);
-    ("masc_run_log", broadcast_tool);
-    ("masc_run_deliverable", broadcast_tool);
     ( "sidecar",
       {
         destructive_tool with

--- a/lib/tool_catalog_surfaces/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces/tool_catalog_surfaces.ml
@@ -164,8 +164,6 @@ let local_worker_surface_tools =
   ; "masc_board_curation_submit"
   ; "masc_run_init"
   ; "masc_run_plan"
-  ; "masc_run_log"
-  ; "masc_run_deliverable"
   ; "masc_run_get"
   ; "masc_run_list"
   ]
@@ -253,8 +251,6 @@ let execution_role_tools : string list =
   ; "masc_transition"
   ; "masc_broadcast"
   ; "masc_run_init"
-  ; "masc_run_log"
-  ; "masc_run_deliverable"
   ; "masc_run_get"
   ; "masc_tool_help"
   ]

--- a/lib/tool_run.ml
+++ b/lib/tool_run.ml
@@ -18,7 +18,7 @@ module Float = Stdlib.Float
 (** Run Tool Handlers
 
     Extracted from mcp_server_eio.ml for testability.
-    6 tools: run_init, run_plan, run_log, run_deliverable, run_get, run_list
+    4 tools: run_init, run_plan, run_get, run_list
 *)
 
 (** Tool handler context *)
@@ -77,38 +77,6 @@ let handle_run_plan ~tool_name ~start_time ctx args : Tool_result.result =
         ~start_time
         (Printf.sprintf "Failed to update run plan: %s" e)
 
-let handle_run_log ~tool_name ~start_time ctx args : Tool_result.result =
-  let task_id = get_string args "task_id" "" in
-  if String.equal task_id "" then
-    task_id_required ~tool_name ~start_time
-  else
-    let note = get_string args "note" "" in
-    match Run_eio.append_log ctx.config ~task_id ~note with
-  | Ok entry ->
-      Tool_result.make_ok ~tool_name ~start_time ~data:(Run_eio.log_entry_to_json entry) ()
-  | Error e ->
-      Tool_result.make_err
-        ~tool_name
-        ~class_:Tool_result.Runtime_failure
-        ~start_time
-        (Printf.sprintf "Failed to append run log: %s" e)
-
-let handle_run_deliverable ~tool_name ~start_time ctx args : Tool_result.result =
-  let task_id = get_string args "task_id" "" in
-  if String.equal task_id "" then
-    task_id_required ~tool_name ~start_time
-  else
-    let deliverable = get_string args "deliverable" "" in
-    match Run_eio.set_deliverable ctx.config ~task_id ~content:deliverable with
-  | Ok run ->
-      Tool_result.make_ok ~tool_name ~start_time ~data:(Run_eio.run_record_to_json run) ()
-  | Error e ->
-      Tool_result.make_err
-        ~tool_name
-        ~class_:Tool_result.Runtime_failure
-        ~start_time
-        (Printf.sprintf "Failed to set run deliverable: %s" e)
-
 let handle_run_get ~tool_name ~start_time ctx args : Tool_result.result =
   let task_id = get_string args "task_id" "" in
   if String.equal task_id "" then
@@ -140,8 +108,6 @@ let dispatch ctx ~name ~args : Tool_result.result option =
   match name with
   | "masc_run_init" -> lift (handle_run_init ~tool_name:name ~start_time:start ctx args)
   | "masc_run_plan" -> lift (handle_run_plan ~tool_name:name ~start_time:start ctx args)
-  | "masc_run_log" -> lift (handle_run_log ~tool_name:name ~start_time:start ctx args)
-  | "masc_run_deliverable" -> lift (handle_run_deliverable ~tool_name:name ~start_time:start ctx args)
   | "masc_run_get" -> lift (handle_run_get ~tool_name:name ~start_time:start ctx args)
   | "masc_run_list" -> lift (handle_run_list ~tool_name:name ~start_time:start ctx args)
   | _ -> None
@@ -150,9 +116,9 @@ let schemas : Masc_domain.tool_schema list = [
   (* masc_run_init *)
   {
     name = "masc_run_init";
-    description = "Create an execution memory directory (.masc/runs/{task_id}/) to track plan, logs, and deliverables. \
+    description = "Create an execution memory directory (.masc/runs/{task_id}/) to track the run plan. \
 Call when starting work on a claimed task to enable structured progress tracking. \
-After init, use masc_run_plan to set approach, masc_run_log for notes, masc_run_deliverable to close.";
+After init, use masc_run_plan to set approach and masc_run_get to review.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -189,52 +155,10 @@ After init, use masc_run_plan to set approach, masc_run_log for notes, masc_run_
     ];
   };
 
-  (* masc_run_log *)
-  {
-    name = "masc_run_log";
-    description = "Append a timestamped note (ISO8601) to a task's execution log for audit and handoff continuity. \\nCall when reaching milestones, finding blockers, or making key decisions during task execution. \\nPair with masc_run_plan for the approach and masc_run_get to review the full log.";
-    input_schema = `Assoc [
-      ("type", `String "object");
-      ("properties", `Assoc [
-        ("task_id", `Assoc [
-          ("type", `String "string");
-          ("description", `String "Task ID");
-        ]);
-        ("note", `Assoc [
-          ("type", `String "string");
-          ("description", `String "Note to add (will be timestamped)");
-        ]);
-      ]);
-      ("required", `List [`String "task_id"; `String "note"]);
-    ];
-  };
-
-  (* masc_run_deliverable *)
-  {
-    name = "masc_run_deliverable";
-    description = "Record the final deliverable (markdown) and mark the task run as completed. \
-Call when task implementation is finished and verified to close out the execution record. \
-After recording, the run shows as completed in masc_run_list and masc_run_get.";
-    input_schema = `Assoc [
-      ("type", `String "object");
-      ("properties", `Assoc [
-        ("task_id", `Assoc [
-          ("type", `String "string");
-          ("description", `String "Task ID");
-        ]);
-        ("deliverable", `Assoc [
-          ("type", `String "string");
-          ("description", `String "The deliverable (markdown supported)");
-        ]);
-      ]);
-      ("required", `List [`String "task_id"; `String "deliverable"]);
-    ];
-  };
-
   (* masc_run_get *)
   {
     name = "masc_run_get";
-    description = "Retrieve full execution history (plan, timestamped logs, deliverable) for a task as markdown. \\nIf the task has no run record yet, create an empty run scaffold and return it so resume flow can continue. \\nUse when resuming work on a task, reviewing progress, or preparing a handoff. \\nPair with masc_run_log to add entries.";
+    description = "Retrieve the run record and execution plan for a task. \\nIf the task has no run record yet, create an empty run scaffold and return it so resume flow can continue. \\nUse when resuming work on a task, reviewing progress, or preparing a handoff. \\nPair with masc_run_plan to set the plan.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -250,7 +174,7 @@ After recording, the run shows as completed in masc_run_list and masc_run_get.";
   (* masc_run_list *)
   {
     name = "masc_run_list";
-    description = "List all task runs with their status (active/completed), plan presence, and log count. \\nUse when starting a session to find abandoned work or review completed runs. \\nAfter finding a run, call masc_run_get for full details or masc_run_init to start a new one.";
+    description = "List all task runs with their status (active/completed) and plan presence. \\nUse when starting a session to find abandoned work or review completed runs. \\nAfter finding a run, call masc_run_get for full details or masc_run_init to start a new one.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);

--- a/lib/tool_run.mli
+++ b/lib/tool_run.mli
@@ -2,7 +2,7 @@
 (** Run Tool Handlers
 
     Extracted from mcp_server_eio.ml for testability.
-    6 tools: run_init, run_plan, run_log, run_deliverable, run_get, run_list
+    4 tools: run_init, run_plan, run_get, run_list
 *)
 
 (** Tool handler context *)
@@ -15,8 +15,6 @@ type context = {
 
 val handle_run_init : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
 val handle_run_plan : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
-val handle_run_log : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
-val handle_run_deliverable : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
 val handle_run_get : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
 val handle_run_list : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
 

--- a/lib/tool_schemas/tool_schemas_run.ml
+++ b/lib/tool_schemas/tool_schemas_run.ml
@@ -1,7 +1,7 @@
 (** Tool_schemas_run — SSOT for run-tracking tool schemas.
 
-    Defines schemas for task execution lifecycle: init, plan, log,
-    deliverable, get, and list.
+    Defines schemas for task execution lifecycle: init, plan, get,
+    and list.
 *)
 
 open Masc_domain
@@ -40,41 +40,6 @@ let schemas : Masc_domain.tool_schema list =
                   ("plan", `Assoc [ ("type", `String "string") ]);
                 ] );
             ("required", `List [ `String "task_id"; `String "plan" ]);
-            ("additionalProperties", `Bool false);
-          ];
-    };
-    {
-      name = "masc_run_log";
-      description =
-        "Append a timestamped note to a task's execution log for audit and handoff continuity. Use when reaching milestones, finding blockers, or making key decisions during execution.";
-      input_schema =
-        `Assoc
-          [
-            ("type", `String "object");
-            ( "properties",
-              `Assoc
-                [
-                  ("task_id", `Assoc [ ("type", `String "string") ]);
-                  ("note", `Assoc [ ("type", `String "string") ]);
-                ] );
-            ("required", `List [ `String "task_id"; `String "note" ]);
-            ("additionalProperties", `Bool false);
-          ];
-    };
-    {
-      name = "masc_run_deliverable";
-      description = "Record the final deliverable/output of a task run.";
-      input_schema =
-        `Assoc
-          [
-            ("type", `String "object");
-            ( "properties",
-              `Assoc
-                [
-                  ("task_id", `Assoc [ ("type", `String "string") ]);
-                  ("deliverable", `Assoc [ ("type", `String "string") ]);
-                ] );
-            ("required", `List [ `String "task_id"; `String "deliverable" ]);
             ("additionalProperties", `Bool false);
           ];
     };

--- a/lib/tool_schemas/tool_schemas_run.mli
+++ b/lib/tool_schemas/tool_schemas_run.mli
@@ -1,4 +1,4 @@
-(** Tool_schemas_run — SSOT for the six run-tracking tool
+(** Tool_schemas_run — SSOT for the four run-tracking tool
     schemas.
 
     Surface order:
@@ -6,13 +6,9 @@
       and start tracking; required [task_id], [agent_name].
     - [masc_run_plan]        — set / update execution plan;
       required [task_id], [plan].
-    - [masc_run_log]         — append a timestamped note to the
-      run's audit log; required [task_id], [note].
-    - [masc_run_deliverable] — record the final output;
-      required [task_id], [deliverable].
-    - [masc_run_get]         — retrieve plan + logs +
-      deliverables for one run, creating an empty scaffold when
-      missing; required [task_id].
+    - [masc_run_get]         — retrieve the run record + plan for
+      one run, creating an empty scaffold when missing; required
+      [task_id].
     - [masc_run_list]        — list all runs with status; no
       required params.
 
@@ -22,9 +18,9 @@
     SDK's tool-routing tables grep them at startup. *)
 
 val schemas : Masc_domain.tool_schema list
-(** The six run-tracking schemas in the surface order documented
+(** The four run-tracking schemas in the surface order documented
     above. List length and [name] strings are pinned at the
-    contract seam — a rename of [masc_run_log] to
-    [masc_run_note] (or any other rebranding) must touch this
+    contract seam — a rename of [masc_run_get] to
+    [masc_run_read] (or any other rebranding) must touch this
     file as part of an explicit migration so the agent
     SDK's routing tables stay in sync. *)

--- a/test/test_run_eio_coverage.ml
+++ b/test/test_run_eio_coverage.ml
@@ -2,7 +2,6 @@
 
     Tests for run record types and JSON serialization:
     - run_record type
-    - log_entry type
     - JSON roundtrip functions
 *)
 
@@ -19,7 +18,6 @@ let test_run_record_basic () =
     task_id = "task-001";
     agent_name = None;
     plan = "# Plan\n- Step 1";
-    deliverable = "";
     created_at = "2024-01-01T10:00:00Z";
     updated_at = "2024-01-01T10:00:00Z";
   } in
@@ -31,43 +29,12 @@ let test_run_record_with_agent () =
     task_id = "task-002";
     agent_name = Some "agent_llm_a";
     plan = "Do the thing";
-    deliverable = "Done";
     created_at = "2024-01-01T09:00:00Z";
     updated_at = "2024-01-01T11:00:00Z";
   } in
   match r.agent_name with
   | Some a -> check string "agent_name" "agent_llm_a" a
   | None -> fail "expected Some"
-
-let test_run_record_deliverable () =
-  let r : Run_eio.run_record = {
-    task_id = "task-003";
-    agent_name = Some "provider_f";
-    plan = "";
-    deliverable = "# Result\nSuccessfully completed.";
-    created_at = "";
-    updated_at = "";
-  } in
-  check bool "has deliverable" true (String.length r.deliverable > 0)
-
-(* ============================================================
-   log_entry Type Tests
-   ============================================================ *)
-
-let test_log_entry_type () =
-  let e : Run_eio.log_entry = {
-    timestamp = "2024-01-01T12:00:00Z";
-    note = "Started task execution";
-  } in
-  check string "timestamp" "2024-01-01T12:00:00Z" e.timestamp;
-  check string "note" "Started task execution" e.note
-
-let test_log_entry_empty_note () =
-  let e : Run_eio.log_entry = {
-    timestamp = "2024-01-01T12:30:00Z";
-    note = "";
-  } in
-  check string "empty note" "" e.note
 
 (* ============================================================
    JSON Serialization Tests
@@ -78,7 +45,6 @@ let test_run_record_json_roundtrip () =
     task_id = "rt-001";
     agent_name = Some "agent_llm_a";
     plan = "# Plan Content";
-    deliverable = "# Deliverable Content";
     created_at = "2024-01-01T10:00:00Z";
     updated_at = "2024-01-01T12:00:00Z";
   } in
@@ -86,8 +52,7 @@ let test_run_record_json_roundtrip () =
   match Run_eio.run_record_of_json json with
   | Some decoded ->
       check string "task_id" original.task_id decoded.task_id;
-      check string "plan" original.plan decoded.plan;
-      check string "deliverable" original.deliverable decoded.deliverable
+      check string "plan" original.plan decoded.plan
   | None -> fail "json decode failed"
 
 let test_run_record_json_none_agent () =
@@ -95,7 +60,6 @@ let test_run_record_json_none_agent () =
     task_id = "rt-002";
     agent_name = None;
     plan = "";
-    deliverable = "";
     created_at = "2024-01-01T10:00:00Z";
     updated_at = "2024-01-01T10:00:00Z";
   } in
@@ -103,18 +67,6 @@ let test_run_record_json_none_agent () =
   match Run_eio.run_record_of_json json with
   | Some decoded ->
       check bool "agent_name None" true (decoded.agent_name = None)
-  | None -> fail "json decode failed"
-
-let test_log_entry_json_roundtrip () =
-  let original : Run_eio.log_entry = {
-    timestamp = "2024-01-01T15:00:00Z";
-    note = "Completed step 3";
-  } in
-  let json = Run_eio.log_entry_to_json original in
-  match Run_eio.log_entry_of_json json with
-  | Some decoded ->
-      check string "timestamp" original.timestamp decoded.timestamp;
-      check string "note" original.note decoded.note
   | None -> fail "json decode failed"
 
 (* ============================================================
@@ -182,7 +134,7 @@ let test_read_nonexistent () =
   | Ok _ -> fail "expected error"
 
 (* ============================================================
-   Eio IO Tests: update_plan / set_deliverable
+   Eio IO Tests: update_plan
    ============================================================ *)
 
 let test_update_plan () =
@@ -192,51 +144,6 @@ let test_update_plan () =
   | Ok run ->
       check bool "plan updated" true (String.length run.plan > 0)
   | Error e -> failf "update_plan failed: %s" e
-
-let test_set_deliverable () =
-  with_initialized_masc @@ fun config ->
-  ignore (Run_eio.init config ~task_id:"task-deliv-001" ~agent_name:(Some "agent_code"));
-  match Run_eio.set_deliverable config ~task_id:"task-deliv-001" ~content:"# Deliverable\nCompleted successfully." with
-  | Ok run ->
-      check bool "deliverable set" true (String.length run.deliverable > 0)
-  | Error e -> failf "set_deliverable failed: %s" e
-
-(* ============================================================
-   Eio IO Tests: append_log / read_logs
-   ============================================================ *)
-
-let test_append_log () =
-  with_initialized_masc @@ fun config ->
-  ignore (Run_eio.init config ~task_id:"task-log-001" ~agent_name:(Some "agent_llm_a"));
-  match Run_eio.append_log config ~task_id:"task-log-001" ~note:"Started processing" with
-  | Ok entry ->
-      check bool "has timestamp" true (String.length entry.timestamp > 0);
-      check string "note" "Started processing" entry.note
-  | Error e -> failf "append_log failed: %s" e
-
-let test_read_logs_empty () =
-  with_initialized_masc @@ fun config ->
-  ignore (Run_eio.init config ~task_id:"task-log-002" ~agent_name:(Some "agent_llm_a"));
-  let logs = Run_eio.read_logs config ~task_id:"task-log-002" () in
-  check int "empty logs" 0 (List.length logs)
-
-let test_read_logs_multiple () =
-  with_initialized_masc @@ fun config ->
-  ignore (Run_eio.init config ~task_id:"task-log-003" ~agent_name:(Some "agent_llm_a"));
-  ignore (Run_eio.append_log config ~task_id:"task-log-003" ~note:"Log 1");
-  ignore (Run_eio.append_log config ~task_id:"task-log-003" ~note:"Log 2");
-  ignore (Run_eio.append_log config ~task_id:"task-log-003" ~note:"Log 3");
-  let logs = Run_eio.read_logs config ~task_id:"task-log-003" () in
-  check int "three logs" 3 (List.length logs)
-
-let test_read_logs_with_limit () =
-  with_initialized_masc @@ fun config ->
-  ignore (Run_eio.init config ~task_id:"task-log-004" ~agent_name:(Some "agent_llm_a"));
-  ignore (Run_eio.append_log config ~task_id:"task-log-004" ~note:"Log 1");
-  ignore (Run_eio.append_log config ~task_id:"task-log-004" ~note:"Log 2");
-  ignore (Run_eio.append_log config ~task_id:"task-log-004" ~note:"Log 3");
-  let logs = Run_eio.read_logs config ~task_id:"task-log-004" ~limit:2 () in
-  check int "limited to 2" 2 (List.length logs)
 
 (* ============================================================
    Eio IO Tests: get / list
@@ -248,7 +155,7 @@ let test_get_run () =
   match Run_eio.get config ~task_id:"task-get-001" with
   | Ok json ->
       let open Yojson.Safe.Util in
-      (* get returns: { "run": {...}, "plan": ..., "deliverable": ..., "logs": ... } *)
+      (* get returns: { "run": {...}, "plan": ... } *)
       let run = json |> member "run" in
       let task_id = run |> member "task_id" |> to_string in
       check string "task_id" "task-get-001" task_id;
@@ -301,18 +208,6 @@ let test_run_record_of_json_invalid_type () =
   | None -> ()
   | Some _ -> fail "expected None for invalid type"
 
-let test_log_entry_of_json_missing_field () =
-  let json = `Assoc [("timestamp", `String "2024-01-01")] in
-  match Run_eio.log_entry_of_json json with
-  | None -> ()  (* note missing *)
-  | Some _ -> fail "expected None"
-
-let test_log_entry_of_json_invalid () =
-  let json = `Null in
-  match Run_eio.log_entry_of_json json with
-  | None -> ()
-  | Some _ -> fail "expected None"
-
 (* ============================================================
    Error Path Tests
    ============================================================ *)
@@ -323,17 +218,6 @@ let test_update_plan_nonexistent () =
   | Error _ -> ()
   | Ok _ -> fail "expected error"
 
-let test_set_deliverable_nonexistent () =
-  with_initialized_masc @@ fun config ->
-  match Run_eio.set_deliverable config ~task_id:"nonexistent-task" ~content:"deliv" with
-  | Error _ -> ()
-  | Ok _ -> fail "expected error"
-
-let test_read_logs_nonexistent () =
-  with_initialized_masc @@ fun config ->
-  let logs = Run_eio.read_logs config ~task_id:"nonexistent" () in
-  check int "empty for nonexistent" 0 (List.length logs)
-
 (* ============================================================
    Additional JSON Tests
    ============================================================ *)
@@ -343,7 +227,6 @@ let test_run_record_json_all_fields () =
     task_id = "all-fields";
     agent_name = Some "agent";
     plan = "# My Plan\n- Step 1\n- Step 2";
-    deliverable = "# Result\nSuccess!";
     created_at = "2024-01-01T00:00:00Z";
     updated_at = "2024-01-02T00:00:00Z";
   } in
@@ -352,18 +235,6 @@ let test_run_record_json_all_fields () =
   check string "task_id" "all-fields" (json |> member "task_id" |> to_string);
   check string "agent_name" "agent" (json |> member "agent_name" |> to_string);
   check string "created_at" "2024-01-01T00:00:00Z" (json |> member "created_at" |> to_string)
-
-let test_log_entry_json_long_note () =
-  let long_note = String.make 10000 'x' in
-  let entry : Run_eio.log_entry = {
-    timestamp = "2024-01-01T00:00:00Z";
-    note = long_note;
-  } in
-  let json = Run_eio.log_entry_to_json entry in
-  match Run_eio.log_entry_of_json json with
-  | Some decoded ->
-      check int "long note preserved" 10000 (String.length decoded.note)
-  | None -> fail "decode failed"
 
 (* ============================================================
    Edge Cases for IO Functions
@@ -381,20 +252,6 @@ let test_init_run_idempotent () =
        | Some a -> check string "agent" "second" a
        | None -> fail "expected agent")
   | Error e -> failf "init failed: %s" e
-
-let test_get_run_with_logs () =
-  with_initialized_masc @@ fun config ->
-  ignore (Run_eio.init config ~task_id:"task-logs-get" ~agent_name:(Some "agent_llm_a"));
-  ignore (Run_eio.append_log config ~task_id:"task-logs-get" ~note:"Log 1");
-  ignore (Run_eio.append_log config ~task_id:"task-logs-get" ~note:"Log 2");
-  match Run_eio.get config ~task_id:"task-logs-get" with
-  | Ok json ->
-      let open Yojson.Safe.Util in
-      let logs = json |> member "logs" |> to_list in
-      check int "has 2 logs" 2 (List.length logs);
-      let log_count = json |> member "log_count" |> to_int in
-      check int "log_count" 2 log_count
-  | Error e -> failf "get failed: %s" e
 
 let test_get_run_with_updated_plan () =
   with_initialized_masc @@ fun config ->
@@ -416,16 +273,10 @@ let () =
     "run_record", [
       test_case "basic" `Quick test_run_record_basic;
       test_case "with agent" `Quick test_run_record_with_agent;
-      test_case "deliverable" `Quick test_run_record_deliverable;
-    ];
-    "log_entry", [
-      test_case "type" `Quick test_log_entry_type;
-      test_case "empty note" `Quick test_log_entry_empty_note;
     ];
     "json_roundtrip", [
       test_case "run_record" `Quick test_run_record_json_roundtrip;
       test_case "run_record none agent" `Quick test_run_record_json_none_agent;
-      test_case "log_entry" `Quick test_log_entry_json_roundtrip;
     ];
     "eio_init_read", [
       test_case "init run" `Quick test_init_run;
@@ -434,13 +285,6 @@ let () =
     ];
     "eio_update", [
       test_case "update plan" `Quick test_update_plan;
-      test_case "set deliverable" `Quick test_set_deliverable;
-    ];
-    "eio_logs", [
-      test_case "append log" `Quick test_append_log;
-      test_case "read logs empty" `Quick test_read_logs_empty;
-      test_case "read logs multiple" `Quick test_read_logs_multiple;
-      test_case "read logs limit" `Quick test_read_logs_with_limit;
     ];
     "eio_get_list", [
       test_case "get run" `Quick test_get_run;
@@ -451,21 +295,15 @@ let () =
     "json_edge_cases", [
       test_case "run_record missing field" `Quick test_run_record_of_json_missing_field;
       test_case "run_record invalid type" `Quick test_run_record_of_json_invalid_type;
-      test_case "log_entry missing field" `Quick test_log_entry_of_json_missing_field;
-      test_case "log_entry invalid" `Quick test_log_entry_of_json_invalid;
     ];
     "error_paths", [
       test_case "update plan nonexistent" `Quick test_update_plan_nonexistent;
-      test_case "set deliverable nonexistent" `Quick test_set_deliverable_nonexistent;
-      test_case "read logs nonexistent" `Quick test_read_logs_nonexistent;
     ];
     "additional_json", [
       test_case "run_record all fields" `Quick test_run_record_json_all_fields;
-      test_case "log_entry long note" `Quick test_log_entry_json_long_note;
     ];
     "io_edge_cases", [
       test_case "init idempotent" `Quick test_init_run_idempotent;
-      test_case "get with logs" `Quick test_get_run_with_logs;
       test_case "get with updated plan" `Quick test_get_run_with_updated_plan;
     ];
   ]


### PR DESCRIPTION
## 무엇을 / 왜

`masc_run_*` execution-memory 표면의 쓰기 툴 2개(`masc_run_log`, `masc_run_deliverable`)를 제거합니다.

- fleet 로그상 두 툴의 기록은 0건(`masc_run_get`은 51건 호출). 라이터가 사라지면 `masc_run_get`이 영원히 빈 `logs: []` / `deliverable: ""`를 반환 — MANIFEST가 금지하는 죽은 출력이 됩니다.
- 툴만 지우면 `Run_eio.append_log`/`set_deliverable`/`read_logs`/`log_entry`/`run_record.deliverable`이 모두 dead(외부 소비자 0건, grep 확인). 정합성을 위해 끝까지 잘라냈습니다.

**유지**: `masc_run_init`, `masc_run_plan`, `masc_run_get`, `masc_run_list` (run 추적).

## 변경 범위

표면 제거(schema + handler + dispatch + catalog + descriptor):
- `tool_schemas_run.ml/.mli`: 6 -> 4 schemas
- `tool_run.ml/.mli`: `handle_run_log`/`handle_run_deliverable` + dispatch + 인라인 schema 제거, 제거된 툴을 언급하던 설명 문자열 정리
- `tool_catalog.ml`, `tool_catalog_surfaces.ml`(full surface + execution role), `keeper_tool_descriptor.ml`: 2개 엔트리 제거

죽은 impl 제거(`run_eio.ml/.mli`):
- `append_log`, `set_deliverable`, `read_logs`, `log_entry` 타입 + 코덱, `log_path`/`deliverable_path`, `run_record.deliverable` 필드
- `init`이 더 이상 `deliverable.md` / `log.jsonl`을 만들지 않음
- `get`은 `{ run, plan }`만 반환
- `run.json`의 `deliverable` 필드 제거는 읽기 BC-safe(`Safe_ops.json_string ~default:""`)

`RFC-0182 §3.1`: `masc_run_*` cluster count 6 -> 4 + 제거 근거 노트.

## 로컬 검증

- `dune build --root .` exit 0
- `test_run_eio_coverage.exe`: 18/18 pass (제거 표면 정리)
- **신규 테스트 실패 0건 (origin/main `38603d2df` 대조 실증)**:
  - `test_keeper_tool_matrix`: base 5 failures/105 tests → 본 PR 4 failures/103 tests. 사라진 2 테스트 = `masc_run_log`/`masc_run_deliverable` 케이스(동적 매트릭스). 줄어든 1 failure = pre-existing `084_masc_run_deliverable` 실패 제거. `089_masc_run_plan` 실패는 base에 동일 존재(init 없이 plan 호출 시 guard 문자열 미스 — pre-existing 테스트 갭).
  - `descriptor_registry_integrity`(3), `schema_surface_index`(1), `keeper_tool_policy_masc_surface`(1), `tool_descriptors_gen`(4): base와 카운트 **완전 동일**. 모두 board/Grep/composite/dashboard 관련 pre-existing, 본 변경과 무관.

## 미검증 / 후속

- pre-existing 테스트 갭: `masc_run_plan`을 `masc_run_init` 없이 호출하면 `update_plan`이 "No execution run record exists yet"로 실패하나 매트릭스 guard 목록에 해당 문자열이 없어 FAIL 처리. 본 PR 범위 밖(별도 이슈 후보).
- 별개 안티패턴: run 스키마가 `tool_schemas_run.ml`(SSOT)와 `tool_run.ml` 인라인에 중복 정의. 이번엔 양쪽 일관 제거만 하고 dedup은 별도 작업.

RFC-WAIVED: tool schema/descriptor 표면 축소이며 credential/operator/sandbox/hooks 경로 미해당. SSOT 정합성을 위해 RFC-0182 §3.1 cluster count(6 -> 4)는 같은 PR에서 갱신.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
