### PR TITLE
chore(deps): masc.opam.locked agent_sdk 0.204.1 → 0.205.0 동기화

### DIFF
--- a/masc.opam.locked
+++ b/masc.opam.locked
@@ -11,7 +11,7 @@ homepage: "https://github.com/jeong-sik/masc"
 doc: "https://github.com/jeong-sik/masc"
 bug-reports: "https://github.com/jeong-sik/masc/issues"
 depends: [
-  "agent_sdk" {= "0.204.1"}
+  "agent_sdk" {= "0.205.0"}
   "alcotest" {with-test & = "1.9.1"}
   "ambient-context-eio" {= "0.2"}
   "bigstringaf" {= "0.10.0"}
@@ -86,8 +86,8 @@ build: [
 dev-repo: "git+https://github.com/jeong-sik/masc.git"
 pin-depends: [
   [
-    "agent_sdk.0.204.1"
-    "git+https://github.com/jeong-sik/oas.git#cd556806d6ef1131e4bafadce6c762a1ebee1295"
+    "agent_sdk.0.205.0"
+    "git+https://github.com/jeong-sik/oas.git#bb5aa41191d1bf406edbef4f0ecc9d6ed4cff88f"
   ]
   [
     "bisect_ppx.2.8.3"


### PR DESCRIPTION
## 목적

`masc.opam`은 `agent_sdk >= 0.205.0`을 요구(#20627에서 bump)하지만 `masc.opam.locked`는 여전히 `0.204.1 @ cd556806`을 고정한 **split-brain** 상태를 해소합니다.

## 배경

`opam install --locked`로 재현 빌드 시 lockfile이 `0.204.1`을 끌어오는데, 이 버전은 OAS SSE 스트리밍 typed-error-state fix(`4d4e1271`, `06f6f031` — 0.204.6/0.204.8 출시)를 **포함하지 않습니다.** 즉 lockfile만 신뢰하는 경로는 phantom completion / `NetworkError{Unknown}` 평탄화가 살아있는 구버전 OAS로 빌드됩니다.

- `masc.opam` (진실): `>= 0.205.0`
- `masc.opam.locked` (stale): `= 0.204.1`
- 실제 switch: `0.205.0 @ bb5aa411` (fix 포함)

CI는 `masc.opam` 기반(`--locked` 미사용)이라 checks는 영향받지 않았으나, lockfile은 재현 빌드 계약이므로 `masc.opam`과 일치해야 합니다.

## 변경

`masc.opam.locked` 3줄:
- `depends`: `agent_sdk {= "0.204.1"}` → `{= "0.205.0"}`
- `pin-depends`: `agent_sdk.0.204.1` → `agent_sdk.0.205.0`
- pin hash: `cd556806…` → `bb5aa411…` (oas `v0.205.0` 태그 커밋과 교차검증)

## 검증

- `opam lint masc.opam.locked` → exit 0 (warning 74는 사전존재 neo4j pin, 본 변경 무관)
- oas `git rev-parse v0.205.0` = `bb5aa411…`, 해당 커밋 `dune-project` version = `0.205.0`
- agent_sdk 0.205.0 depends가 0.204.1 대비 새 transitive dep 없음 → lockfile 3줄 외 변경 불필요

## 건드리지 않은 것

- 코드(`.ml/.mli`) 0줄. 의존성 메타데이터만.
- `masc.opam` (이미 #20627에서 올바름)

RFC-WAIVED: 의존성 lockfile 메타데이터 동기화. credential/operator/keeper-sandbox/hooks/workflow subsystem 변경 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>