### PR TITLE
fix(keeper): align provider cooldown signatures in keeper_world_observation.mli

### DIFF
--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -262,11 +262,11 @@ val effective_scheduled_autonomous_cooldown :
   ?consecutive_noop_count:int -> unit -> int
 
 val provider_cooldown_remaining_sec_for_runtime :
-  runtime_id:string -> int option
+  keeper_name:string -> runtime_id:string -> int option
 
 val provider_capacity_blocked_task_count :
   ?provider_cooldown_remaining_sec:
-    (runtime_id:string -> int option) ->
+    (keeper_name:string -> runtime_id:string -> int option) ->
   meta:Keeper_meta_contract.keeper_meta ->
   claimable_task_count:int ->
   unit ->


### PR DESCRIPTION
Align provider cooldown remaining sec for runtime and capacity blocked task count signatures in keeper_world_observation.mli to include keeper_name label. Fixes compilation failure in dune build.