### PR TITLE
chore(ratchet): lower g3 facade consumer floor to 2

### DIFF
--- a/scripts/audit-shell-ir-consumption.sh
+++ b/scripts/audit-shell-ir-consumption.sh
@@ -157,7 +157,7 @@ g2_ir_sig=$(rg -c '^let is_(write_operation|destructive_bash_operation) \(.*: Sh
 # Keeper_tool_execute_shell_ir facade, which calls gate_typed and dispatches
 # decided IR. Count keeper consumer files rather than direct gate_typed refs so
 # the metric survives facade extraction and module renames.
-g3_min_facade_consumers=3
+g3_min_facade_consumers=2
 g3_gate_typed=$(list_code_files 'Keeper_tool_execute_shell_ir\.(dispatch|dispatch_classified)' \
   | rg '^lib/keeper/' \
   | wc -l | tr -d ' ')

--- a/scripts/shell-ir-consumption-baseline.json
+++ b/scripts/shell-ir-consumption-baseline.json
@@ -5,7 +5,7 @@
   "g1_parse_string_total_refs_nontest": 3,
   "g2_classifier_string_sig": 0,
   "g2_classifier_ir_sig": 2,
-  "g3_dispatcher_adopting_keeper_files": 3,
+  "g3_dispatcher_adopting_keeper_files": 2,
   "g4_risk_in_simple": 0,
   "g4_phantom_envelope": 18,
   "g4_dispatch_decided_consumers": 5,


### PR DESCRIPTION
Lower g3_min_facade_consumers to 2 in audit script and update baseline JSON after search_files cleanup (PR #20626) which reduced facade consumers from 3 to 2.