### PR TITLE
fix(keeper): include anchor string in state_block instruction_text

### DIFF
--- a/lib/keeper_registry/keeper_state_block_prompt.ml
+++ b/lib/keeper_registry/keeper_state_block_prompt.ml
@@ -17,9 +17,9 @@ let instruction_text =
   String.concat "\n"
     [
       Printf.sprintf
-        "For non-direct keeper turns, report continuity using the [STATE] block \
-         at the end of your response. Fields: %s. All fields are optional but \
-         provide as many as you can."
+        "State block template: for non-direct keeper turns, report continuity \
+         using the [STATE] block at the end of your response. Fields: %s. All \
+         fields are optional but provide as many as you can."
         field_summary;
       template_text;
     ]


### PR DESCRIPTION
## Problem
`build_keeper_system_prompt: critical prompt anchors missing (state_block_template)` WARN on every keeper startup (~51 emissions/restart). The anchor check looks for "State block template" in the final system prompt, but `instruction_text` substituted into constitution.md never contained this string.

## Changes
- Prepend "State block template:" to `Keeper_state_block_prompt.instruction_text` so the normal constitution render path satisfies the anchor check without requiring the recovery guard fallback.

## Verification
- dune build passes
- `test_keeper_prompt_constitution_fallback` 3/3 pass
- `test_keeper_prompt_external` 7/7 pass (including "system prompt includes state block template")

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
