### PR TITLE
chore(deps): bump agent_sdk pin for Qwen3 capability fix

### DIFF
--- a/masc.opam.locked
+++ b/masc.opam.locked
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "masc"
-version: "0.19.37"
+version: "0.19.40"
 synopsis: "Multi-Agent Shared Context MCP Server in OCaml"
 description:
   "MASC Protocol: File-based workspace collaboration for Claude, Gemini, and Codex agents"
@@ -12,61 +12,192 @@ doc: "https://github.com/jeong-sik/masc"
 bug-reports: "https://github.com/jeong-sik/masc/issues"
 depends: [
   "agent_sdk" {= "0.205.0"}
-  "alcotest" {with-test & = "1.9.1"}
+  "alcotest" {= "1.9.1" & with-test}
+  "ambient-context" {= "0.2"}
   "ambient-context-eio" {= "0.2"}
+  "angstrom" {= "0.16.1"}
+  "asn1-combinators" {= "0.3.2"}
+  "astring" {= "0.8.5"}
+  "atd" {= "4.2.0"}
+  "atdgen" {= "4.2.0"}
+  "atdgen-runtime" {= "4.2.0"}
+  "atdts" {= "4.2.0"}
+  "atomic" {= "base"}
+  "base" {= "v0.17.3"}
+  "base-bigarray" {= "base"}
+  "base-bytes" {= "base"}
+  "base-domains" {= "base"}
+  "base-effects" {= "base"}
+  "base-nnp" {= "base"}
+  "base-threads" {= "base"}
+  "base-unix" {= "base"}
+  "base64" {= "3.5.2"}
   "bigstringaf" {= "0.10.0"}
-  "bisect_ppx" {with-test & = "2.8.3"}
+  "biniou" {= "1.2.2"}
+  "bisect_ppx" {= "2.8.3" & with-test}
+  "bos" {= "0.2.1"}
+  "bstr" {= "0.0.4"}
   "ca-certs" {= "1.0.1"}
-  "cmdliner" {= "2.1.0"}
+  "camlp-streams" {= "5.0.1"}
+  "checkseum" {= "0.5.2"}
+  "cmdliner" {= "2.1.1"}
   "cohttp" {= "6.2.1"}
   "cohttp-eio" {= "6.2.1"}
+  "conduit" {= "8.0.0"}
+  "conf-gmp" {= "5"}
+  "conf-gmp-powm-sec" {= "4"}
+  "conf-libssl" {= "4"}
+  "conf-pkg-config" {= "4"}
+  "conf-protoc" {= "4.4.0"}
+  "conf-sqlite3" {= "1"}
+  "conf-zstd" {= "1.3.8"}
+  "cppo" {= "1.8.0"}
   "crunch" {= "4.0.0"}
+  "csexp" {= "1.5.2"}
   "cstruct" {= "6.2.0"}
   "ctypes" {= "0.24.0"}
-  "ctypes-foreign" {= "0.24.0"}
+  "decompress" {= "1.5.3"}
   "digestif" {= "1.3.0"}
+  "domain-local-await" {= "1.0.1"}
   "domain-name" {= "0.5.0"}
-  "dune" {= "3.22.0"}
+  "dune" {= "3.22.2"}
+  "dune-build-info" {= "3.22.2"}
+  "dune-compiledb" {= "0.6.0"}
+  "dune-configurator" {= "3.22.2"}
+  "duration" {= "0.2.1"}
+  "easy-format" {= "1.3.4"}
   "eio" {= "1.3"}
+  "eio-ssl" {= "0.3.0"}
   "eio_main" {= "1.3"}
   "eio_posix" {= "1.3"}
+  "eqaf" {= "0.10"}
+  "ezjsonm" {= "1.3.0"}
+  "faraday" {= "0.8.2"}
+  "fmt" {= "0.11.0"}
+  "fpath" {= "0.7.3"}
+  "gen" {= "1.1"}
+  "gluten" {= "0.5.2"}
+  "gluten-eio" {= "0.5.2"}
+  "gmap" {= "0.3.0"}
   "graphql" {= "0.14.0"}
   "graphql_parser" {= "0.14.0"}
   "grpc-direct" {= "0.2.6"}
   "grpc-direct-core" {= "0.2.6"}
   "h2" {= "0.13.0"}
   "h2-eio" {= "0.13.0"}
+  "hex" {= "1.5.0"}
+  "hmap" {= "0.8.1"}
+  "hpack" {= "0.13.0"}
+  "http" {= "6.2.1"}
   "httpun" {= "0.2.0"}
   "httpun-eio" {= "0.2.0"}
+  "httpun-types" {= "0.2.0"}
   "httpun-ws" {= "0.2.0"}
   "httpun-ws-eio" {= "0.2.0"}
   "integers" {= "0.7.0"}
+  "iomux" {= "0.4"}
+  "ipaddr" {= "5.6.2"}
+  "ipaddr-sexp" {= "5.6.2"}
+  "jane-street-headers" {= "v0.17.0"}
+  "js_of_ocaml-compiler" {= "6.3.2"}
+  "jsonm" {= "1.0.2"}
+  "jst-config" {= "v0.17.0"}
+  "kdf" {= "1.0.0"}
+  "ke" {= "0.6"}
+  "logs" {= "0.10.0"}
+  "lwt" {= "6.1.2"}
+  "lwt-dllist" {= "1.1.0"}
+  "macaddr" {= "5.6.2"}
+  "magic-mime" {= "1.3.1"}
   "mcp_protocol" {= "1.3.0"}
+  "menhir" {= "20250912"}
+  "menhirCST" {= "20250912"}
+  "menhirLib" {= "20250912"}
+  "menhirSdk" {= "20250912"}
   "mirage-crypto" {= "1.2.0"}
+  "mirage-crypto-ec" {= "1.2.0"}
+  "mirage-crypto-pk" {= "1.2.0"}
   "mirage-crypto-rng" {= "1.2.0"}
+  "mirage-crypto-rng-eio" {= "1.2.0"}
   "mtime" {= "2.1.0"}
-  "neo4j_bolt_eio" {= "0.5.1"}
+  "num" {= "1.6"}
   "ocaml" {= "5.4.1"}
+  "ocaml-base-compiler" {= "5.4.1"}
+  "ocaml-compiler" {= "5.4.1"}
+  "ocaml-compiler-libs" {= "v0.17.0"}
+  "ocaml-config" {= "3"}
+  "ocaml-options-vanilla" {= "1"}
   "ocaml-protoc-plugin" {= "6.2.0"}
+  "ocaml-syntax-shims" {= "1.0.0"}
   "ocaml-webrtc" {= "0.2.6"}
+  "ocaml_intrinsics_kernel" {= "v0.17.1"}
+  "ocamlbuild" {= "0.16.1"}
+  "ocamlfind" {= "1.9.8"}
+  "ocplib-endian" {= "1.2"}
   "odoc" {= "3.1.0" & with-doc}
+  "odoc-parser" {= "3.1.0" & with-doc}
+  "ohex" {= "0.2.0"}
+  "omd" {= "2.0.0~alpha4"}
   "opentelemetry" {= "0.13"}
+  "optint" {= "0.3.0"}
   "otoml" {= "1.0.5"}
+  "parsexp" {= "v0.17.0"}
   "pbrt" {= "3.1.1"}
-  "pbrt_services" {= "3.1.1"}
+  "pecu" {= "0.7"}
+  "piaf" {= "0.2.0"}
+  "ppx_assert" {= "v0.17.0"}
+  "ppx_base" {= "v0.17.0"}
+  "ppx_cold" {= "v0.17.0"}
+  "ppx_compare" {= "v0.17.0"}
+  "ppx_derivers" {= "1.2.1"}
   "ppx_deriving" {= "6.1.1"}
+  "ppx_deriving_jsonschema" {= "0.0.4"}
   "ppx_deriving_yojson" {= "3.10.0"}
+  "ppx_enumerate" {= "v0.17.0"}
+  "ppx_expect" {= "v0.17.3"}
+  "ppx_globalize" {= "v0.17.2"}
+  "ppx_hash" {= "v0.17.0"}
+  "ppx_here" {= "v0.17.0"}
+  "ppx_inline_test" {= "v0.17.1"}
   "ppx_let" {= "v0.17.1"}
-  "ppxlib" {= "0.37.0"}
-  "qcheck-alcotest" {with-test & = "0.91"}
-  "qcheck-core" {with-test & = "0.91"}
+  "ppx_optcomp" {= "v0.17.1"}
+  "ppx_sexp_conv" {= "v0.17.1"}
+  "ppxlib" {= "0.38.0"}
+  "ppxlib_jane" {= "v0.17.4"}
+  "prettym" {= "0.0.5"}
+  "psq" {= "0.2.1"}
+  "ptime" {= "1.2.0"}
+  "qcheck-alcotest" {= "0.91" & with-test}
+  "qcheck-core" {= "0.91" & with-test}
   "re" {= "1.14.0"}
-  "sqlite3" {= "5.4.0"}
+  "rresult" {= "0.7.0"}
+  "sedlex" {= "3.7"}
+  "seq" {= "base"}
+  "sexplib" {= "v0.17.0"}
+  "sexplib0" {= "v0.17.0"}
+  "sqlite3" {= "5.4.1"}
+  "ssl" {= "0.7.0"}
+  "stdio" {= "v0.17.0"}
+  "stdlib-shims" {= "0.3.0"}
+  "stringext" {= "1.6.0"}
+  "thread-local-storage" {= "0.2"}
+  "thread-table" {= "1.0.0"}
+  "time_now" {= "v0.17.0"}
   "tls" {= "2.0.4"}
   "tls-eio" {= "2.0.4"}
+  "topkg" {= "1.1.1"}
+  "tyxml" {= "4.6.0" & with-doc}
+  "unstrctrd" {= "0.4"}
   "uri" {= "4.4.0"}
+  "uri-sexp" {= "4.4.0"}
+  "uucp" {= "17.0.0"}
   "uuidm" {= "0.9.10"}
+  "uunf" {= "17.0.0"}
+  "uutf" {= "1.0.4"}
+  "websocket" {= "2.17"}
+  "x509" {= "1.0.6"}
   "yojson" {= "3.0.0"}
+  "zarith" {= "1.14"}
   "zstd" {= "0.4"}
 ]
 build: [
@@ -86,36 +217,24 @@ build: [
 dev-repo: "git+https://github.com/jeong-sik/masc.git"
 pin-depends: [
   [
-    "agent_sdk.0.205.0"
-    "git+https://github.com/jeong-sik/oas.git#bb5aa41191d1bf406edbef4f0ecc9d6ed4cff88f"
-  ]
+  "agent_sdk.0.205.0"
+  "git+https://github.com/jeong-sik/oas.git#cdc274cb3c815e966fdbacc8cb5612033f80ef7f"
+]
   [
     "bisect_ppx.2.8.3"
     "git+https://github.com/patricoferris/bisect_ppx.git#5.2"
   ]
   [
-    "grpc-direct.0.2.6"
-    "git+https://github.com/jeong-sik/grpc-direct.git#840b6cd6fe822d3577aa26147e7dc71ca25abecc"
-  ]
+  "grpc-direct.0.2.6"
+  "git+https://github.com/jeong-sik/grpc-direct.git#d7269ebebf9e4688486cc6591c66e794607e7b0f"
+]
   [
-    "grpc-direct-core.0.2.6"
-    "git+https://github.com/jeong-sik/grpc-direct.git#840b6cd6fe822d3577aa26147e7dc71ca25abecc"
-  ]
+  "grpc-direct-core.0.2.6"
+  "git+https://github.com/jeong-sik/grpc-direct.git#d7269ebebf9e4688486cc6591c66e794607e7b0f"
+]
   [
     "mcp_protocol.1.3.0"
     "git+https://github.com/jeong-sik/mcp-protocol-sdk.git#v1.3.0"
-  ]
-  [
-    "neo4j_bolt_common.0.5.1"
-    "git+https://github.com/jeong-sik/ocaml-neo4j-bolt.git#a1ca30c1247db5c58934e99306fe330419f7b21a"
-  ]
-  [
-    "neo4j_bolt_eio.0.5.1"
-    "git+https://github.com/jeong-sik/ocaml-neo4j-bolt.git#a1ca30c1247db5c58934e99306fe330419f7b21a"
-  ]
-  [
-    "neo4j_packstream.0.5.1"
-    "git+https://github.com/jeong-sik/ocaml-neo4j-bolt.git#a1ca30c1247db5c58934e99306fe330419f7b21a"
   ]
   [
     "ocaml-webrtc.0.2.6"


### PR DESCRIPTION
## Problem
OAS Qwen3 capability fix (PR #1976) merged but masc opam pin still points to pre-fix commit.

## Changes
- Bump agent_sdk pin to `cdc274cb` (includes Qwen3 capability correction)
- Regenerate stale lockfile (0.19.37 → 0.19.40, adds ambient-context etc.)

## Verification
- `dune build --root . @check` passes

Depends on: jeong-sik/oas#1976 (merged)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
