### PR TITLE
fix(worker): pass Eio clock context dynamically to Agent.run

### DIFF
--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -686,7 +686,13 @@ and run_existing_worker_agent
           worker_name
           (Printexc.to_string exn))
     (fun () ->
-       let result = Agent_sdk.Agent.run ~sw agent prompt in
+       let result =
+         Agent_sdk.Agent.run
+           ~sw
+           ?clock:(Eio_context.get_clock_opt ())
+           agent
+           prompt
+       in
        let raw_trace_run = Agent_sdk.Agent.last_raw_trace_run agent in
        let evidence_session_id =
          Worker_container.evidence_session_id_of_worker_run


### PR DESCRIPTION
Supply Eio clock context dynamically using Eio_context.get_clock_opt () in run_existing_worker_agent so OAS can enforce stream timeouts during execution.