### PR TITLE
fix(keeper): gate global-backlog turns by wake source to stop broadcast stampede

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -128,6 +128,7 @@ let run_keepalive_unified_turn
       ~pending_board_events
       ~(stop : bool Atomic.t)
       ~(proactive_warmup_elapsed : bool)
+      ~(reactive_wake : bool)
       ~(shared_context : Agent_sdk.Context.t)
   : keeper_meta
   =
@@ -147,6 +148,7 @@ let run_keepalive_unified_turn
       in
       let scheduling =
         decide_keepalive_scheduling
+          ~reactive_wake
           ~stop
           ~meta:meta_after_triage
           obs
@@ -408,6 +410,7 @@ let run_smart_heartbeat_gate
       ~(smart_hb_config : Keeper_heartbeat_smart.config)
       ~(last_successful_heartbeat_ts : float ref)
       ~(last_heartbeat_cycle_ts : float ref)
+      ~(wake_source : Keeper_keepalive_signal.sleep_outcome ref)
   : bool
   =
   let smart_hb_decision =
@@ -545,6 +548,12 @@ let run_smart_heartbeat_gate
            ~labels:[ "keeper", meta_current.name ]
            ()
        | Keeper_keepalive_signal.Stopped | Keeper_keepalive_signal.Timeout -> ());
+      (* Carry the idle-backoff sleep result forward so the turn evaluator can
+         tell a broadcast-driven [Woken] from this keeper's own cadence
+         [Timeout]. Only the real sleep (Skip_idle) writes here; Emit/Skip_busy
+         synthesize [Timeout] without sleeping and must NOT clobber the prior
+         inter-cycle wake source used by active keepers. *)
+      wake_source := outcome;
       outcome
     | Keeper_heartbeat_smart.Emit ->
       last_heartbeat_cycle_ts := Time_compat.now ();
@@ -648,6 +657,12 @@ let run_heartbeat_loop
      no operator has modified it.  Initialized to 0.0 so the first
      cycle always reads. *)
   let last_meta_mtime = ref 0.0 in
+  (* Wake-source carry (thundering-herd fix). Records whether the most recent
+     sleep ended via an external broadcast wakeup ([Woken]) or this keeper's own
+     cadence timer ([Timeout]). Read at turn dispatch so a broadcast-driven early
+     wake does not let the GLOBAL task backlog drive a turn on every keeper at
+     once. Single-fiber owned, like the other loop-local refs above. *)
+  let last_wake_source = ref Keeper_keepalive_signal.Timeout in
   let rec loop () =
     if Atomic.get stop
     then ()
@@ -702,6 +717,7 @@ let run_heartbeat_loop
           ~smart_hb_config
           ~last_successful_heartbeat_ts
           ~last_heartbeat_cycle_ts
+          ~wake_source:last_wake_source
       then (
         (* Phase 1: sync presence and emit heartbeat metric *)
         let meta_current =
@@ -758,6 +774,15 @@ let run_heartbeat_loop
              pre/post guards mirror the spec's [turn_state] transition
              "running" -> "idle". *)
           turn_running := true;
+          (* [Woken] => this cycle was triggered by an external broadcast, not
+             the keeper's own cadence; suppress global-backlog-driven turns to
+             avoid the all-keeper stampede. *)
+          let reactive_wake =
+            match !last_wake_source with
+            | Keeper_keepalive_signal.Woken -> true
+            | Keeper_keepalive_signal.Timeout | Keeper_keepalive_signal.Stopped ->
+              false
+          in
           let r =
             run_keepalive_unified_turn
               ~ctx
@@ -765,6 +790,7 @@ let run_heartbeat_loop
               ~pending_board_events
               ~stop
               ~proactive_warmup_elapsed
+              ~reactive_wake
               ~shared_context
           in
           Keeper_keepalive_signal.pre_turn_complete_heartbeat ~turn_running;
@@ -844,13 +870,16 @@ let run_heartbeat_loop
         let jitter =
           base *. Env_config.KeeperKeepalive.jitter_factor *. Random.float 1.0
         in
-        ignore
-          (Keeper_keepalive_signal.interruptible_sleep
-             ~clock:ctx.clock
-             ~stop
-             ~wakeup
-             (base +. jitter)
-           : Keeper_keepalive_signal.sleep_outcome));
+        (* Carry the inter-cycle sleep result into the next iteration so the
+           turn evaluator can distinguish a broadcast wakeup ([Woken]) from this
+           keeper's own cadence ([Timeout]). For active keepers this is the only
+           sleep, so it is the dominant wake-source signal. *)
+        last_wake_source :=
+          Keeper_keepalive_signal.interruptible_sleep
+            ~clock:ctx.clock
+            ~stop
+            ~wakeup
+            (base +. jitter));
       if Atomic.get stop then () else loop ())
   in
   loop ()

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -71,6 +71,7 @@ type keepalive_scheduling_decision = {
 val decide_keepalive_scheduling :
   ?runtime_id_of_meta:(keeper_meta -> string) ->
   ?runtime_resilience_of_name:(string -> string option) ->
+  ?reactive_wake:bool ->
   stop:bool Atomic.t ->
   meta:keeper_meta ->
   Keeper_world_observation.world_observation ->
@@ -99,6 +100,7 @@ val run_keepalive_unified_turn :
   pending_board_events:Keeper_world_observation.pending_board_event list ->
   stop:bool Atomic.t ->
   proactive_warmup_elapsed:bool ->
+  reactive_wake:bool ->
   shared_context:Agent_sdk.Context.t ->
   keeper_meta
 
@@ -164,6 +166,7 @@ val run_smart_heartbeat_gate :
   smart_hb_config:Keeper_heartbeat_smart.config ->
   last_successful_heartbeat_ts:float ref ->
   last_heartbeat_cycle_ts:float ref ->
+  wake_source:Keeper_keepalive_signal.sleep_outcome ref ->
   bool
 
 val maybe_write_heartbeat_snapshot :

--- a/lib/keeper/keeper_heartbeat_loop_scheduling.ml
+++ b/lib/keeper/keeper_heartbeat_loop_scheduling.ml
@@ -27,11 +27,14 @@ type keepalive_scheduling_decision = {
 let decide_keepalive_scheduling
       ?(runtime_id_of_meta = Keeper_meta_contract.runtime_id_of_meta)
       ?(runtime_resilience_of_name = fun _ -> None)
+      ?(reactive_wake = false)
       ~stop
       ~meta
       obs
   =
-  let turn_decision = Keeper_world_observation.keeper_cycle_decision ~meta obs in
+  let turn_decision =
+    Keeper_world_observation.keeper_cycle_decision ~reactive_wake ~meta obs
+  in
   let requested_should_run_turn =
     (not (Atomic.get stop)) && turn_decision.should_run
   in

--- a/lib/keeper/keeper_heartbeat_loop_scheduling.mli
+++ b/lib/keeper/keeper_heartbeat_loop_scheduling.mli
@@ -12,6 +12,7 @@ type keepalive_scheduling_decision = {
 val decide_keepalive_scheduling :
   ?runtime_id_of_meta:(Keeper_meta_contract.keeper_meta -> string) ->
   ?runtime_resilience_of_name:(string -> string option) ->
+  ?reactive_wake:bool ->
   stop:bool Atomic.t ->
   meta:Keeper_meta_contract.keeper_meta ->
   Keeper_world_observation.world_observation ->

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -604,6 +604,7 @@ let should_inject_entropic_oscillation ~since_last_scheduled_autonomous ~draw_pe
 
 let keeper_cycle_decision
       ?(provider_cooldown_remaining_sec = provider_cooldown_remaining_sec_for_runtime)
+      ?(reactive_wake = false)
       ~(meta : keeper_meta)
       (observation : world_observation)
   =
@@ -732,14 +733,26 @@ let keeper_cycle_decision
                ~since_last_scheduled_autonomous
                ~draw_percent:(Random.int 100)
         in
+        (* Reactive-wake gate (thundering-herd fix). When this evaluation runs
+           because an external broadcast woke the keeper early ([reactive_wake]),
+           the GLOBAL task backlog must not, on its own, drive a turn: otherwise
+           a single task release/add broadcasts to every keeper and all of them
+           run a full LLM turn against the shared (claimable-by-anyone) pool — N
+           turns for work at most one keeper can claim. Global backlog is instead
+           picked up on the keeper's own cadence (sleep Timeout) and by the
+           supervisor sweep. Per-keeper signals (mention/board/scope) are handled
+           by the Reactive channel above and are unaffected. Time-based liveness
+           reasons (bootstrap / min_interval / idle_gate+cooldown / oscillation)
+           key on the keeper's own clock, so they stay ungated. *)
+        let backlog_drives_turn =
+          (not reactive_wake) && (backlog_fresh || backlog_elapsed)
+        in
         let should_run =
           is_bootstrap
           || should_oscillate
           || min_interval_elapsed
           || (proactive_work_ready
-              && (backlog_fresh
-                  || backlog_elapsed
-                  || (idle_gate_elapsed && cooldown_elapsed)))
+              && (backlog_drives_turn || (idle_gate_elapsed && cooldown_elapsed)))
         in
         let runtime_id = runtime_id_of_meta meta in
         let provider_cooldown_remaining_sec =

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -286,11 +286,18 @@ val should_inject_entropic_oscillation :
 val keeper_cycle_decision :
   ?provider_cooldown_remaining_sec:
     (keeper_name:string -> runtime_id:string -> int option) ->
+  ?reactive_wake:bool ->
   meta:Keeper_meta_contract.keeper_meta -> world_observation -> keeper_cycle_decision
+(** [reactive_wake] (default [false]) marks evaluations triggered by an external
+    broadcast wakeup rather than the keeper's own cadence timer. When set, a
+    GLOBAL task backlog alone does not drive a turn — this prevents the
+    all-keeper stampede on each task release/add. Per-keeper Reactive triggers
+    and time-based liveness reasons are unaffected. *)
 
 val unified_turn_decision :
   ?provider_cooldown_remaining_sec:
     (keeper_name:string -> runtime_id:string -> int option) ->
+  ?reactive_wake:bool ->
   meta:Keeper_meta_contract.keeper_meta -> world_observation -> keeper_cycle_decision
 
 val should_run_keeper_cycle :

--- a/test/dune
+++ b/test/dune
@@ -29,6 +29,7 @@
 
 (tests
  (names
+  test_keeper_reactive_wake_backlog_gate
   test_board_activity_cache
   test_jsonl_mtime_projection
   test_jsonl_incremental_projection
@@ -283,6 +284,7 @@
   test_workspace_goal_index
   test_log_severity_outcome_level)
  (modules
+  test_keeper_reactive_wake_backlog_gate
   test_board_activity_cache
   test_jsonl_mtime_projection
   test_jsonl_incremental_projection

--- a/test/test_keeper_reactive_wake_backlog_gate.ml
+++ b/test/test_keeper_reactive_wake_backlog_gate.ml
@@ -1,0 +1,172 @@
+(** Reactive-wake gate for [keeper_cycle_decision] — thundering-herd fix.
+
+    A single task release/add broadcasts to every keeper with [mention=None],
+    which wakes ALL keepers ([wakeup_all_keepers]) at once. Before this gate,
+    each woken keeper saw the GLOBAL (claimable-by-anyone) backlog signal and
+    ran a full LLM turn, so one claimable task produced N turns. The gate keys
+    backlog-driven turns on the wake source:
+
+    - cadence wake ([Timeout], [reactive_wake=false]): global backlog drives a
+      turn as before (the keeper's own scheduled cadence).
+    - broadcast wake ([Woken], [reactive_wake=true]): global backlog alone does
+      NOT drive a turn — the work is picked up on the keeper's own cadence and by
+      the supervisor sweep, not by an all-keeper stampede.
+
+    Per-keeper Reactive triggers (mention/board/scope) and time-based liveness
+    reasons (bootstrap / min_interval / idle_gate+cooldown / oscillation) are
+    unaffected; only the global-backlog path is gated. *)
+
+open Alcotest
+
+module WO = Masc.Keeper_world_observation
+
+(* Provider cooldown is global in-memory state; pin it to "no cooldown" so the
+   decision is driven purely by the backlog gate under test. *)
+let no_provider_cooldown ~keeper_name:_ ~runtime_id:_ = None
+
+(* [keeper_cycle_decision] resolves a runtime id (via [runtime_id_of_meta] ->
+   [Runtime.get_default_runtime_id]) unconditionally, which fails fast when no
+   default runtime is initialised (RFC-0206 §2.1). Initialise a minimal default
+   runtime the same way the other keeper unit tests do. *)
+let runtime_toml =
+  {|
+[runtime]
+default = "test_provider.test_model"
+
+[providers.test_provider]
+display-name = "Test Provider"
+protocol = "provider_d-http"
+endpoint = "http://127.0.0.1:1"
+
+[models.test_model]
+api-name = "test-model"
+max-context = 8192
+tools-support = true
+streaming = true
+
+[test_provider.test_model]
+is-default = true
+max-concurrent = 1
+|}
+;;
+
+let init_runtime_default_for_tests () =
+  let path = Filename.temp_file "keeper_herd_runtime_" ".toml" in
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc runtime_toml);
+  match Runtime.init_default ~config_path:path with
+  | Ok () -> ()
+  | Error e -> Alcotest.failf "Runtime.init_default failed: %s" e
+;;
+
+let make_meta name =
+  let json =
+    `Assoc
+      [ ("name", `String name)
+      ; ("agent_name", `String ("agent-" ^ name))
+      ; ("trace_id", `String ("trace-herd-" ^ name))
+      ; ("goal", `String "thundering herd backlog gate test")
+      ]
+  in
+  match Masc_test_deps.meta_of_json_fixture json with
+  | Ok meta -> meta
+  | Error err -> Alcotest.fail ("make_meta failed: " ^ err)
+
+(* Warm, non-bootstrap meta: a recent-but-past scheduled-autonomous turn so
+   [since_last] is small and finite. This avoids the bootstrap / min_interval /
+   entropic-oscillation paths (all time-based), isolating the global-backlog
+   decision branch. Uses the same clock ([Time_compat.now]) the decision reads. *)
+let warm_backlog_meta () =
+  let meta = make_meta "herd" in
+  let now = Time_compat.now () in
+  { meta with
+    proactive = { enabled = true; idle_sec = 600; cooldown_sec = 1800 }
+  ; runtime =
+      { meta.runtime with
+        proactive_rt =
+          { meta.runtime.proactive_rt with
+            last_ts = now -. 30.0
+          ; consecutive_noop_count = 0
+          }
+      }
+  }
+
+(* Global backlog present (one claimable task in the shared pool, backlog just
+   updated) but NO per-keeper reactive trigger: no mention, no board event, no
+   scope message. This is exactly the broadcast-wake-into-shared-pool scenario. *)
+let global_backlog_obs : WO.world_observation =
+  { pending_mentions = []
+  ; pending_board_events = []
+  ; pending_scope_messages = []
+  ; message_cursor_updates = []
+  ; idle_seconds = 0
+  ; active_goals = []
+  ; continuity_summary = ""
+  ; context_ratio = 0.0
+  ; unclaimed_task_count = 1
+  ; claimable_task_count = 1
+  ; provider_capacity_blocked_task_count = 0
+  ; failed_task_count = 0
+  ; pending_verification_count = 0
+  ; backlog_updated_since_last_scheduled_autonomous = true
+  ; active_agent_count = 1
+  }
+
+let decide ~reactive_wake =
+  let meta = warm_backlog_meta () in
+  WO.keeper_cycle_decision
+    ~provider_cooldown_remaining_sec:no_provider_cooldown
+    ~reactive_wake
+    ~meta
+    global_backlog_obs
+
+(* Baseline: the keeper's own cadence (Timeout) still runs on global backlog. *)
+let test_cadence_wake_runs_on_backlog () =
+  let d = decide ~reactive_wake:false in
+  check bool "cadence wake (Timeout) runs on global backlog" true d.should_run
+
+(* Fix: a broadcast-driven wake (Woken) must NOT run on global backlog alone,
+   otherwise every keeper stampedes on each task release/add. *)
+let test_broadcast_wake_skips_global_backlog () =
+  let d = decide ~reactive_wake:true in
+  check
+    bool
+    "broadcast wake (Woken) does NOT stampede on global backlog"
+    false
+    d.should_run
+
+(* The gate must not change the channel: this is still a scheduled-autonomous
+   evaluation (the reactive channel handles per-keeper mention/board/scope). *)
+let test_gate_keeps_scheduled_channel () =
+  let d = decide ~reactive_wake:true in
+  check
+    bool
+    "gated broadcast wake stays on the scheduled-autonomous channel"
+    true
+    (match d.channel with
+     | WO.Scheduled_autonomous -> true
+     | WO.Reactive -> false)
+
+let () = init_runtime_default_for_tests ()
+
+let () =
+  run
+    "keeper reactive-wake backlog gate"
+    [ ( "thundering_herd"
+      , [ test_case
+            "cadence wake runs on global backlog"
+            `Quick
+            test_cadence_wake_runs_on_backlog
+        ; test_case
+            "broadcast wake skips global backlog"
+            `Quick
+            test_broadcast_wake_skips_global_backlog
+        ; test_case
+            "gate keeps scheduled-autonomous channel"
+            `Quick
+            test_gate_keeps_scheduled_channel
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Problem

A single task lifecycle event (`keeper_task_force_release`, `add_task`,
`batch_add_tasks`, `cancel_task`) calls `Workspace.broadcast` with `mention=None`.
That routes to `wakeup_all_keepers`, which flips every running keeper's
`fiber_wakeup` atomic in one `StringMap.iter` pass — no jitter, no fan-out cap.
Each woken keeper then evaluates `keeper_cycle_decision`, sees the **global**
`task_backlog` signal (claimable-by-anyone pool), and runs a full LLM turn. One
released task therefore produces ~N full turns across N keepers, of which at most
one results in a claim. Live logs show the rest are no-ops (`mode=noop`,
`synthesized from 0 tools`, `nudging`), each spending 10k–38k tokens.

The root is that "wake up to check" and "run a full turn" were not separated:
the turn decision keyed on a *global* signal regardless of *why* the keeper woke.
(The per-keeper relevance producer `collect_message_scope` is also currently a
stub — `[],[],[]` since #20156 — so mention/scope reactive triggers cannot fire;
the only live differentiator was the global backlog.)

## Fix

Thread the **wake source** (`Woken` = external broadcast vs `Timeout` = this
keeper's own cadence timer) from the heartbeat sleep into `keeper_cycle_decision`
as `reactive_wake`, and gate the global-backlog run path on it:

- `reactive_wake=false` (cadence / `Timeout`): global backlog drives a turn as
  before — unchanged behaviour.
- `reactive_wake=true` (broadcast / `Woken`): `backlog_fresh` / `backlog_elapsed`
  no longer drive a turn. The work is picked up on the keeper's own cadence and
  by the supervisor sweep, not by an all-keeper stampede.

Per-keeper Reactive triggers (mention / board / scope, handled in the Reactive
channel *before* the scheduled-autonomous branch) and time-based liveness reasons
(`is_bootstrap` / `min_interval` / `idle_gate+cooldown` / oscillation, which key
on the keeper's own clock) are untouched.

This is a correctness gate on the decision input, not a cap/cooldown/dedup/counter
on a symptom: it makes the turn decision depend on the actual wake source instead
of letting a foreign broadcast drive a turn off a global signal. It restores the
wakeup↔turn separation the broadcast wiring collapsed.

## Changed files

- `lib/keeper/keeper_world_observation.ml(.mli)` — `keeper_cycle_decision` gains
  `?reactive_wake`; `should_run` gates `backlog_fresh || backlog_elapsed` behind
  `not reactive_wake`.
- `lib/keeper/keeper_heartbeat_loop_scheduling.ml(.mli)` — `decide_keepalive_scheduling`
  forwards `?reactive_wake`.
- `lib/keeper/keeper_heartbeat_loop.ml(.mli)` — `run_smart_heartbeat_gate` records
  the idle-backoff sleep outcome into a `wake_source` ref; the inter-cycle sleep
  outcome (previously `ignore`d) is captured too; the turn dispatch derives
  `reactive_wake` and passes it to `run_keepalive_unified_turn`.
- `test/test_keeper_reactive_wake_backlog_gate.ml` (+ `test/dune`) — new.

## Verification

- `scripts/dune-local.sh build lib/masc.cma` — builds clean.
- New unit test `test_keeper_reactive_wake_backlog_gate`:
  - cadence wake (`reactive_wake=false`) + global backlog → `should_run=true`
    (baseline preserved);
  - broadcast wake (`reactive_wake=true`) + global backlog, no per-keeper trigger
    → `should_run=false` (the fix);
  - channel stays `scheduled_autonomous` (gate does not misroute).

## Tradeoff

A newly claimable task is now picked up on each keeper's own cadence plus the
~30s supervisor sweep instead of an instant all-keeper wake. Latency-to-claim
rises modestly; wasted no-op turns per task event drop from ~N to ~1. Not yet
exercised end-to-end against a live fleet — covered by the unit test + build.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
