### PR TITLE
fix(runtime): honor per-model thinking-support in keeper thinking gate

### DIFF
--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -159,6 +159,12 @@ let max_context_of_runtime_id (id : string) : int option =
   | None -> None
 ;;
 
+let thinking_support_of_runtime_id (id : string) : bool option =
+  match get_runtime_by_id id with
+  | Some rt -> Some rt.model.thinking_support
+  | None -> None
+;;
+
 (* fail-fast: uninitialized = startup-ordering bug, NOT a recoverable
    condition. 이전 [| None -> "tool_strict"] 하드코딩 fallback 은 90 사이트에
    조작된 id 를 흘리는 Unknown→Permissive 안티패턴이라 제거했다 (RFC-0206 §2.1).

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -59,6 +59,12 @@ val max_context_of_runtime_id : string -> int option
     not configured.  Budgeting callers use this to size a per-keeper routed turn
     against the same runtime that dispatch will use. *)
 
+val thinking_support_of_runtime_id : string -> bool option
+(** [thinking-support] capability of the model bound to runtime [id], or [None]
+    when the id is not configured (e.g. before {!init_default}).  Consumed by
+    {!Runtime_inference.for_runtime} to gate keeper thinking per model from the
+    runtime.toml SSOT. *)
+
 val get_default_runtime_id : unit -> string
 (** @raise Failure if {!init_default} has not run. No silent fallback
     (RFC-0206 §2.1): an unresolved default is a startup-ordering bug, not a

--- a/lib/runtime/runtime_inference.ml
+++ b/lib/runtime/runtime_inference.ml
@@ -9,7 +9,29 @@ type seed = {
   thinking_enabled : bool option;
 }
 
-let for_runtime ~name:_ = { thinking_budget = None; thinking_enabled = None }
+(** Map a model's [thinking-support] capability (runtime.toml SSOT) to the
+    keeper thinking seed.
+
+    The keeper turn loop ([Keeper_run_tools_hooks]) consumes [thinking_enabled]
+    as a capability gate: [Some false] forces thinking OFF for the turn — a
+    model declared [thinking-support = false] (e.g. Qwen lanes kept out of
+    thinking mode to avoid token exhaustion) never thinks regardless of the
+    [keeper.turn.enable_thinking] policy — while [Some true]/[None] defer to
+    that policy.
+
+    [None] argument means the runtime id is not in the loaded config (unknown
+    id, or before [Runtime.init_default]): no per-model signal, defer to policy.
+
+    [thinking_budget] stays [None] here: the per-model [max_thinking_budget] is
+    a ceiling, not an active budget, so wiring it as the active budget would be
+    a category error — the keeper's adaptive budget owns the active value. *)
+let seed_of_thinking_support (thinking_support : bool option) : seed =
+  { thinking_budget = None; thinking_enabled = thinking_support }
+;;
+
+let for_runtime ~name =
+  seed_of_thinking_support (Runtime.thinking_support_of_runtime_id name)
+;;
 
 let validate_max_tokens_within_ceiling ~runtime_id ~provider_ceiling value =
   match provider_ceiling with

--- a/lib/runtime/runtime_inference.mli
+++ b/lib/runtime/runtime_inference.mli
@@ -12,7 +12,16 @@ type seed = {
   thinking_enabled : bool option;
 }
 
+val seed_of_thinking_support : bool option -> seed
+(** Pure: map a model's [thinking-support] capability to the keeper thinking
+    seed.  [Some false] is a force-thinking-off signal (capability gate);
+    [Some true]/[None] defer to [keeper.turn.enable_thinking]. *)
+
 val for_runtime : name:string -> seed
+(** Per-model thinking seed for runtime [name], resolved from the runtime.toml
+    [thinking-support] of the bound model via
+    {!Runtime.thinking_support_of_runtime_id}.  See {!seed_of_thinking_support}
+    for the gate semantics. *)
 
 val validate_max_tokens_within_ceiling :
   runtime_id:string ->

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -394,6 +394,100 @@ let test_turn_budget_uses_routed_runtime () =
       budget)
 ;;
 
+(* ---- per-model thinking gate: runtime.toml [thinking-support] drives the
+   keeper thinking seed via [Runtime_inference.for_runtime] ----
+
+   The keeper turn loop ([Keeper_run_tools_hooks]) treats the seed's
+   [thinking_enabled] as a capability gate: [Some false] forces thinking off,
+   [Some true]/[None] defer to [keeper.turn.enable_thinking].  So a model
+   declared [thinking-support = false] never thinks regardless of the global
+   policy, while a thinking-capable model follows it. *)
+
+let runtime_config_thinking =
+  {|
+[runtime]
+default = "ollama_cloud.think"
+
+[providers.ollama_cloud]
+display-name = "Ollama Cloud"
+protocol = "provider_d-http"
+endpoint = "https://ollama.example/v1"
+
+[models.think]
+api-name = "think"
+max-context = 128000
+tools-support = true
+thinking-support = true
+streaming = true
+
+[models.nothink]
+api-name = "nothink"
+max-context = 128000
+tools-support = true
+thinking-support = false
+streaming = true
+
+[ollama_cloud.think]
+is-default = true
+max-concurrent = 1
+
+[ollama_cloud.nothink]
+max-concurrent = 1
+|}
+;;
+
+let with_runtime_thinking f =
+  with_temp_dir "runtime-thinking-gate" @@ fun dir ->
+  let path = Filename.concat dir "runtime.toml" in
+  write_file path runtime_config_thinking;
+  (match Runtime.init_default ~config_path:path with
+   | Ok () -> ()
+   | Error msg -> Alcotest.failf "runtime init_default failed: %s" msg);
+  f ()
+;;
+
+let test_thinking_support_true_defers_to_policy () =
+  with_runtime_thinking (fun () ->
+    let seed = Runtime_inference.for_runtime ~name:"ollama_cloud.think" in
+    Alcotest.(check (option bool))
+      "thinking-capable model emits Some true (defer to keeper.turn.enable_thinking)"
+      (Some true)
+      seed.Runtime_inference.thinking_enabled)
+;;
+
+let test_thinking_support_false_forces_off () =
+  with_runtime_thinking (fun () ->
+    let seed = Runtime_inference.for_runtime ~name:"ollama_cloud.nothink" in
+    Alcotest.(check (option bool))
+      "non-thinking model emits Some false (capability gate forces thinking off)"
+      (Some false)
+      seed.Runtime_inference.thinking_enabled)
+;;
+
+let test_thinking_unknown_runtime_defers () =
+  with_runtime_thinking (fun () ->
+    let seed = Runtime_inference.for_runtime ~name:"bogus.binding" in
+    Alcotest.(check (option bool))
+      "unknown runtime id emits None (no per-model signal, defer to policy)"
+      None
+      seed.Runtime_inference.thinking_enabled)
+;;
+
+let test_seed_of_thinking_support_gate_contract () =
+  Alcotest.(check (option bool))
+    "Some false -> force thinking off"
+    (Some false)
+    (Runtime_inference.seed_of_thinking_support (Some false)).Runtime_inference.thinking_enabled;
+  Alcotest.(check (option bool))
+    "Some true -> defer to policy"
+    (Some true)
+    (Runtime_inference.seed_of_thinking_support (Some true)).Runtime_inference.thinking_enabled;
+  Alcotest.(check (option bool))
+    "None -> defer to policy"
+    None
+    (Runtime_inference.seed_of_thinking_support None).Runtime_inference.thinking_enabled
+;;
+
 let () =
   Alcotest.run
     "runtime_per_keeper_routing"
@@ -448,6 +542,24 @@ let () =
             "turn budget uses the routed runtime"
             `Quick
             test_turn_budget_uses_routed_runtime
+        ] )
+    ; ( "per-model thinking gate"
+      , [ Alcotest.test_case
+            "thinking-support=true defers to keeper policy (Some true)"
+            `Quick
+            test_thinking_support_true_defers_to_policy
+        ; Alcotest.test_case
+            "thinking-support=false forces thinking off (Some false)"
+            `Quick
+            test_thinking_support_false_forces_off
+        ; Alcotest.test_case
+            "unknown runtime id defers (None)"
+            `Quick
+            test_thinking_unknown_runtime_defers
+        ; Alcotest.test_case
+            "seed_of_thinking_support gate contract (pure)"
+            `Quick
+            test_seed_of_thinking_support_gate_contract
         ] )
     ]
 ;;


### PR DESCRIPTION
## 문제

`runtime.toml`의 per-model `thinking-support`가 **파싱만 되고 소비되지 않았다**. `runtime_inference.for_runtime`가 `~name:_` 스텁이라 항상 `{thinking_enabled=None}`을 반환 → keeper thinking은 전역 `keeper.turn.enable_thinking` 하나로만 제어됐다.

결과: 주력 모델을 deepseek-v4(thinking 지원)로 바꿔도, Qwen 시절 토큰 고갈을 이유로 꺼둔 전역 기본값(`false`)이 그대로 남아 thinking이 안 켜졌다. 반대로 전역을 켜면 Qwen 레인까지 thinking이 켜져 토큰을 소모한다. per-model 의도가 코드에 닿지 않는 dead config였다.

## 변경

- `Runtime.thinking_support_of_runtime_id : string -> bool option` 추가 — 형제 리졸버 `max_context_of_runtime_id`를 그대로 미러. runtime.toml SSOT에서 모델의 `thinking-support`를 runtime_id로 해석한다.
- `Runtime_inference.for_runtime`가 그 리졸버를 호출해 `seed.thinking_enabled`로 반환. 순수 결정 함수 `seed_of_thinking_support`로 로직 분리(테스트 가능).
- keeper 소비 로직(`Keeper_run_tools_hooks` `Some false -> 강제 off | _ -> 정책 위임`)은 **무변경**.

## 경계 (capability gate)

| 레이어 | 질문 | 출처 |
|---|---|---|
| capability | "이 모델이 thinking 해도 되나?" | runtime.toml `thinking-support` (per-model) |
| policy | "지금 thinking 할까?" | `keeper.turn.enable_thinking` (전역) |

effective = `thinking-support=false`면 **강제 off**(Qwen 등 토큰 고갈 방지), `true`/미설정이면 정책에 위임. 전역 플래그를 켜둬도 per-model false 모델은 자동 보호된다 — 모델 전환을 config가 따라간다.

## 검증

- 통합 테스트 3 + 순수 계약 1 (`test_runtime_per_keeper_routing.ml`): thinking 모델→`Some true`(위임), 비-thinking→`Some false`(강제 off), unknown id→`None`(위임), 그리고 `seed_of_thinking_support` 게이트 계약.
- 라이브 probe(Ollama Cloud, deepseek-v4-flash): `reasoning_effort:none`→reasoning_content 0건+오답, `medium`/`high`→반환+정답. OAS wire-format 정상 확인.

## NOT workaround

스텁(dead config)을 제거해 의도된 동작을 살린 것. 새 string 분류기/telemetry counter/cap/cooldown 없음. RFC-게이트 subsystem(credential/operator/sandbox/hooks/workflow) 아님.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
