### PR TITLE
perf(telemetry): bound windowed telemetry reads to n most-recent entries

### DIFF
--- a/lib/dated_jsonl/dated_jsonl.ml
+++ b/lib/dated_jsonl/dated_jsonl.ml
@@ -544,6 +544,70 @@ let read_range t ~since ~until =
   iter_range t ~since ~until (fun json -> collected := json :: !collected);
   List.rev !collected
 
+(* Like [read_range] but bounded to the [n] most recent entries within
+   [since, until] (inclusive day range). Reads newest day-file first and
+   only the tail of each file, parsing at most ~[n] entries instead of the
+   whole window. [read_range] parses every entry in the range, which is
+   unbounded over large stores; callers that already pass a result limit
+   should use this so a wide window cannot scan months of multi-MB files.
+   Returns entries oldest-first within the collected set (same convention
+   as [read_recent]). *)
+let read_range_recent ?(offset = 0) t ~since ~until n =
+  if n <= 0
+  then []
+  else (
+    match parse_date since, parse_date until with
+    | None, _ | _, None -> []
+    | Some (since_month, since_day), Some (until_month, until_day) ->
+      let skip = ref offset in
+      let collected = ref [] in
+      let count = ref 0 in
+      let months = list_month_dirs t.base_dir in
+      let exception Done in
+      (try
+         List.iter
+           (fun m ->
+              if String.compare m since_month >= 0
+                 && String.compare m until_month <= 0
+              then begin
+                let month_path = Filename.concat t.base_dir m in
+                let days = list_day_files month_path in
+                List.iter
+                  (fun d ->
+                     if !count >= n then raise_notrace Done;
+                     let day_num = Filename.remove_extension d in
+                     let dominated =
+                       (m = since_month && String.compare day_num since_day < 0)
+                       || (m = until_month && String.compare day_num until_day > 0)
+                     in
+                     if not dominated
+                     then begin
+                       let path = Filename.concat month_path d in
+                       let need = n - !count + !skip in
+                       let lines = load_tail_lines path ~max_lines:need in
+                       let rev_lines = List.rev lines in
+                       List.iter
+                         (fun line ->
+                            if !count >= n then raise_notrace Done;
+                            try
+                              let json = Yojson.Safe.from_string line in
+                              if !skip > 0
+                              then decr skip
+                              else begin
+                                collected := json :: !collected;
+                                incr count
+                              end
+                            with
+                            | Yojson.Json_error _ -> ())
+                         rev_lines
+                     end)
+                  days
+              end)
+           months
+       with
+       | Done -> ());
+      !collected)
+
 let prune t ~days =
   let mutex = Atomic.get t.mutex in
   Eio.Mutex.use_ro mutex (fun () -> prune_unlocked t ~days)

--- a/lib/dated_jsonl/dated_jsonl.mli
+++ b/lib/dated_jsonl/dated_jsonl.mli
@@ -49,6 +49,21 @@ val read_range : t -> since:string -> until:string -> Yojson.Safe.t list
     within [[since, until]] (inclusive, format ["YYYY-MM-DD"]).
     Result is in chronological order. *)
 
+val read_range_recent
+  :  ?offset:int
+  -> t
+  -> since:string
+  -> until:string
+  -> int
+  -> Yojson.Safe.t list
+(** [read_range_recent ?offset t ~since ~until n] returns at most the newest
+    [n] entries whose day-file falls within [[since, until]] (inclusive). Reads
+    newest day-file first and only the tail of each file, so it parses ~[n]
+    entries instead of the whole window — use it instead of {!read_range} when
+    a result bound exists and the window may span large stores. Result is
+    chronological (oldest-first) within the collected set, matching
+    {!read_recent}. *)
+
 val iter_all : t -> (Yojson.Safe.t -> unit) -> unit
 (** [iter_all t f] calls [f] for every parseable JSONL entry in chronological
     order without loading a whole day-file into memory. Malformed rows are

--- a/lib/telemetry_unified/telemetry_unified.ml
+++ b/lib/telemetry_unified/telemetry_unified.ml
@@ -441,7 +441,11 @@ let read_fixed_source dir source ~n ?since_ts ?until_ts () : Yojson.Safe.t list 
         match effective_day_window ?since_ts ?until_ts () with
         | None -> Dated_jsonl.read_recent store n
         | Some (since_day, until_day) ->
-          Dated_jsonl.read_range store ~since:since_day ~until:until_day
+          (* Honour [n] on the windowed path too: [read_range] parsed every
+             entry in the day range (unbounded over multi-MB stores), then this
+             function dropped all but [n]. Bound the parse to the [n] most
+             recent in-window entries instead. *)
+          Dated_jsonl.read_range_recent store ~since:since_day ~until:until_day n
       in
       let entries =
         List.filter (within_requested_window ?since_ts ?until_ts) entries

--- a/test/test_dated_jsonl.ml
+++ b/test/test_dated_jsonl.ml
@@ -195,6 +195,39 @@ let test_read_range_malformed () =
   let result = Dated_jsonl.read_range store ~since:"bad" ~until:"dates" in
   check int "malformed dates return empty" 0 (List.length result)
 
+let test_read_range_recent () =
+  let dir = tmpdir "dated_jsonl_range_recent" in
+  write_dated_file dir "2026-01" "01" [ {|{"i":1}|}; {|{"i":2}|}; {|{"i":3}|} ];
+  write_dated_file dir "2026-01" "02" [ {|{"i":4}|}; {|{"i":5}|}; {|{"i":6}|} ];
+  write_dated_file dir "2026-02" "01" [ {|{"i":7}|}; {|{"i":8}|}; {|{"i":9}|} ];
+  let store = Dated_jsonl.create ~base_dir:dir () in
+  let ints r = List.map json_i r in
+  (* newest 2 in window come from the tail of the newest in-range day-file *)
+  check
+    (list int)
+    "newest 2 in window"
+    [ 8; 9 ]
+    (ints (Dated_jsonl.read_range_recent store ~since:"2026-01-02" ~until:"2026-02-01" 2));
+  (* newest 5, spanning two in-range day-files, oldest-first within result *)
+  check
+    (list int)
+    "newest 5 across range"
+    [ 5; 6; 7; 8; 9 ]
+    (ints (Dated_jsonl.read_range_recent store ~since:"2026-01-01" ~until:"2026-02-01" 5));
+  (* a day outside the window is excluded; n larger than available returns all *)
+  check
+    (list int)
+    "single in-range day returns its entries"
+    [ 4; 5; 6 ]
+    (ints (Dated_jsonl.read_range_recent store ~since:"2026-01-02" ~until:"2026-01-02" 100));
+  check
+    int
+    "n=0 returns empty"
+    0
+    (List.length
+       (Dated_jsonl.read_range_recent store ~since:"2026-01-01" ~until:"2026-02-01" 0))
+;;
+
 let test_iter_all_chronological_skips_malformed () =
   let dir = tmpdir "dated_jsonl_iter_all" in
   write_dated_file dir "2026-01" "01" [ {|{"i":1}|}; "not-json" ];
@@ -334,6 +367,7 @@ let () =
         [
           test_case "today range non-empty" `Quick test_read_range;
           test_case "malformed dates safe" `Quick test_read_range_malformed;
+          test_case "range_recent returns newest n in window" `Quick test_read_range_recent;
           test_case "iter_all chronological" `Quick
             test_iter_all_chronological_skips_malformed;
           test_case "iter_range chronological" `Quick test_iter_range_chronological;


### PR DESCRIPTION
#20646(머지됨, count_entries per-file 캐시)의 후속. 같은 keeper-freeze 스핀의 *나머지* 경로를 닫는다.

## 문제
`Telemetry_unified.read_fixed_source`는 `~n`(결과 제한)을 받지만 **윈도우 경로에서 무시**했다: `Dated_jsonl.read_range`가 day 범위 내 *모든* 항목을 Yojson 파싱(50~82MB tool_calls/oas-events 스토어에서 unbounded)한 뒤 호출부가 n개만 남겼다. 대시보드가 넓은 윈도우를 요청하면 keeper의 Eio 도메인에서 수개월치 거대 파일을 파싱 → 협조적 스케줄러가 keeper fiber를 굶김.

## 수정
`Dated_jsonl.read_range_recent` 추가: 범위 내 **newest day-file부터 tail만** 읽어 최대 ~n개 in-window 항목만 파싱(read_recent 의미를 날짜 범위로 제한). `read_fixed_source`의 윈도우 경로를 이걸로 배선해 `~n`을 no-window 경로와 일관되게 honor.

`eval_calibration`의 윈도우 read는 limit 없는 full-window 통계라 의도적으로 `read_range` 유지.

## 검증
`test_dated_jsonl.ml` +1 (다중 day-file에서 윈도우 내 최신 n, 범위 제외, n≤0). 21/21 green. telemetry_unified 컴파일 확인.

## Follow-up
read_range 스핀이 #20646 배포 후에도 잔존하는지는 라이브 관측으로 확인 권장(트리거 caller가 실제로 넓은 윈도우를 거는지).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
