### PR TITLE
fix(workspace): allow Release action from Todo status

### DIFF
--- a/lib/workspace/workspace_task_classify.ml
+++ b/lib/workspace/workspace_task_classify.ml
@@ -336,7 +336,7 @@ let task_assignee_of_status = Masc_domain.task_assignee_of_status
 let valid_next_actions_for_status
   : Masc_domain.task_status -> Masc_domain.task_action list
   = function
-  | Masc_domain.Todo -> [ Masc_domain.Claim; Masc_domain.Cancel ]
+  | Masc_domain.Todo -> [ Masc_domain.Claim; Masc_domain.Release; Masc_domain.Cancel ]
   | Masc_domain.Claimed _ ->
     [ Masc_domain.Start
     ; Masc_domain.Done_action

--- a/test/test_tool_workspace_coverage.ml
+++ b/test/test_tool_workspace_coverage.ml
@@ -829,9 +829,10 @@ let () =
 let next_hint = Workspace_task.next_actions_hint
 
 let () =
-  test "next_hint_todo lists claim and cancel" (fun () ->
+  test "next_hint_todo lists claim, release, and cancel" (fun () ->
     let h = next_hint Masc_domain.Todo in
     assert (str_contains h "claim");
+    assert (str_contains h "release");
     assert (str_contains h "cancel");
     assert (str_contains h "valid_next_actions="))
 ;;


### PR DESCRIPTION
Aligns client-side gate validation with server FSM's no-op acceptance behavior for Release on Todo status, preventing keepers from throwing hard errors during state drift recovery.