### PR TITLE
feat(logging): add structured logging to silent decision points

### DIFF
--- a/lib/cache_eio.ml
+++ b/lib/cache_eio.ml
@@ -91,7 +91,10 @@ let entry_of_json (json : Yojson.Safe.t) : cache_entry option =
   | Some key, Some value, Some created_at ->
     Some { key; value; created_at; expires_at; tags }
   | _ ->
-    Log.Misc.error "JSON type error in entry_of_json: missing required fields";
+    Log.Misc.error "JSON type error in entry_of_json: missing required fields (key=%s value=%s created_at=%s)"
+      (match key with Some s -> s | None -> "(absent)")
+      (match value with Some s -> s | None -> "(absent)")
+      (match created_at with Some s -> s | None -> "(absent)");
     None
 ;;
 

--- a/lib/cdal_evidence_gate.ml
+++ b/lib/cdal_evidence_gate.ml
@@ -154,11 +154,20 @@ let decide ~task_id ~task_opt ~notes ~handoff_context () =
   match (task_opt : Masc_domain.task option) with
   | Some t when Option.is_some t.contract ->
     if evidence_is_substantive ~notes ~handoff_context t.contract
-    then Pass
+    then begin
+      Log.Task.info "cdal_evidence_gate PASS task=%s notes_len=%d handoff_refs=%d"
+        task_id (String.length (String.trim notes))
+        (match handoff_context with None -> 0 | Some hc -> List.length hc.evidence_refs);
+      Pass
+    end
     else
       let unsatisfied =
         unsatisfied_required_evidence ~notes ~handoff_context t.contract
       in
+      Log.Task.warn "cdal_evidence_gate REJECT task=%s unsatisfied=%d notes_len=%d handoff_refs=%d rule=%s"
+        task_id (List.length unsatisfied) (String.length (String.trim notes))
+        (match handoff_context with None -> 0 | Some hc -> List.length hc.evidence_refs)
+        rule_id_evidence_incomplete;
       Reject
         { reason = reason_evidence_incomplete ~required_evidence:unsatisfied
         ; rule_id = rule_id_evidence_incomplete

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -155,7 +155,11 @@ let run_turn
         }
     in
     fun () ->
-      (try emit_observation_turn_end () with _ -> ());
+      (try emit_observation_turn_end ()
+       with Eio.Cancel.Cancelled _ as ce -> raise ce
+       | exn ->
+         Log.Keeper.warn "keeper:%s emit_observation_turn_end failed: %s"
+           (!meta_ref).name (Printexc.to_string exn));
       Turn_helpers.emit_turn_end_safely ~keeper_name:meta.name ()
   in
   Eio_guard.protect ~finally:safe_emit_turn_end

--- a/lib/run_eio.ml
+++ b/lib/run_eio.ml
@@ -38,7 +38,10 @@ let run_record_of_json (json : Yojson.Safe.t) : run_record option =
     Some { task_id; agent_name; plan; created_at; updated_at }
   | _ ->
     Otel_metric_store.inc_counter Otel_metric_store.metric_error_events ~labels:[("type", Error_event_type.(to_label Parsing))] ();
-    Log.Misc.error "run_of_json: missing required fields";
+    Log.Misc.error "run_of_json: missing required fields (task_id=%s created_at=%s updated_at=%s)"
+      (match task_id with Some s -> s | None -> "(absent)")
+      (match created_at with Some s -> s | None -> "(absent)")
+      (match updated_at with Some s -> s | None -> "(absent)");
     None
 
 let runs_dir (config : config) =


### PR DESCRIPTION
## Summary

전수 로깅 감사에서 발견된 침묵 결정 지점과 정미포획 사이트에 구조적 로깅을 추가합니다.

## Changes

### 1. cdal_evidence_gate — gate 결정 로깅 (+8 lines)
- `decide` 함수에서 PASS/REJECT 시 `Log.Task.info`/`Log.Task.warn` 추가
- 로그 필드: task_id, notes_len, handoff_refs, rule_id
- **이전**: keeper가 task done을 시도했을 때 gate가 조용히 차단 → operator는 원인 추적 불가
- **이후**: gate 통과/거부가 모두 로그에 기록됨

### 2. keeper_agent_run — observation emission 정미포획 수정 (+4 lines)
- `try emit_observation_turn_end () with _ -> ()` → Cancel-aware catch + `Log.Keeper.warn`
- **이전**: Eio.Cancel.Cancelled 포함 모든 예외 조용히 삼킴 (fiber starvation 위험)
- **이후**: Cancel은 re-raise, 다른 예외는 keeper 이름과 함께 경고 로그

### 3. cache_eio — 에러 컨텍스트 보강 (+3 lines)
- `"missing required fields"` → 어떤 필드가 누락되었는지 key/value/created_at 상태 출력

### 4. run_eio — 에러 컨텍스트 보강 (+3 lines)
- `"missing required fields"` → task_id/created_at/updated_at 상태 출력

## Context

초기 audit에서 masc lib/ 1,338개 파일 중 921개(69%)가 Log 참조 없음을 발견.
재검증 결과 대부분 타입 정의/순수함수/래퍼로, 실제 로깅이 필요한 critical-path 모듈은 소수였음.
본 PR은 그중 영향이 가장 큰 4개 사이트를 우선 수정합니다.

## Audit Summary (masc)

| 지표 | 수치 |
|------|------|
| Total lib/ .ml files | 1,338 |
| Files with Log calls | 417 (31%) |
| Files with zero Log | 921 (69%) |
| Total Log calls | 1,912 |

## OAS Audit Summary

별도 감사 완료. OAS는 207개 파일 중 25개(12%)만 Log.create 사용.
`llm_provider/` 하위 9,731줄에 Log 호출 0건이 가장 큰 갭.
OAS 로깅 개선은 후속 PR로 분리 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
