### PR TITLE
feat(keeper): persist full per-turn thinking trajectory (untruncated, every turn)

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -567,10 +567,11 @@ let run_turn
                  receipt_model_used_ref := Some model;
                  receipt_stop_reason_ref := Some result.stop_reason;
                  receipt_runtime_observation_ref := result.runtime_observation;
-                 Keeper_agent_run_thinking_trajectory.persist_response_content
-                   ~keeper_name:meta.name
-                   ~trajectory_acc
-                   result.response.content;
+                 (* Thinking is now persisted per-turn inside the after_turn
+                    hook (Keeper_hooks_oas), untruncated, for EVERY turn. The
+                    old post-run single-shot capture here saved only the final
+                    turn's reasoning and would double-write the terminal turn
+                    now, so it was removed. *)
                  let actual_keeper_tool_names =
                    Keeper_agent_result.tool_names_of_calls (List.rev acc.tool_calls)
                  in

--- a/lib/keeper/keeper_agent_run_thinking_trajectory.ml
+++ b/lib/keeper/keeper_agent_run_thinking_trajectory.ml
@@ -18,7 +18,10 @@ let append_entry ~keeper_name ~failure_label (acc : Trajectory.accumulator) entr
       ()
 ;;
 
-let persist_response_content ~keeper_name ~trajectory_acc content =
+(* [turn] is the per-turn index from the OAS [after_turn] hook
+   ([Hooks.AfterTurn { turn; _ }]), NOT [acc.turn]: this is invoked once per
+   turn so every turn's reasoning is stamped with its own turn number. *)
+let persist_response_content ~keeper_name ~trajectory_acc ~turn content =
   match trajectory_acc with
   | None -> ()
   | Some acc ->
@@ -30,7 +33,7 @@ let persist_response_content ~keeper_name ~trajectory_acc content =
           let entry : Trajectory.thinking_entry =
             { ts = now
             ; ts_iso = now_iso
-            ; turn = acc.Trajectory.turn
+            ; turn
             ; content
             ; content_length = String.length content
             ; redacted = false
@@ -41,7 +44,7 @@ let persist_response_content ~keeper_name ~trajectory_acc content =
           let entry : Trajectory.thinking_entry =
             { ts = now
             ; ts_iso = now_iso
-            ; turn = acc.Trajectory.turn
+            ; turn
             ; content = "[redacted]"
             ; content_length = 0
             ; redacted = true

--- a/lib/keeper/keeper_agent_run_thinking_trajectory.mli
+++ b/lib/keeper/keeper_agent_run_thinking_trajectory.mli
@@ -1,5 +1,10 @@
 val persist_response_content
   :  keeper_name:string
   -> trajectory_acc:Trajectory.accumulator option
+  -> turn:int
   -> Agent_sdk.Types.content_block list
   -> unit
+(** Append every [Thinking]/[RedactedThinking] block in [content] to the
+    keeper's trajectory JSONL, stamped with [turn]. Call once per turn from the
+    [after_turn] hook so no turn's reasoning is dropped. Text is persisted
+    untruncated (see {!Trajectory.append_thinking}). *)

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -450,7 +450,14 @@ let make_hooks
              ~cost_usd:cost_usd_for_event ~usage_missing
              ~usage_trust
              ?telemetry:response.telemetry
-             ~model:response.model ()
+             ~model:response.model ();
+           (* 남김없이: persist THIS turn's reasoning (full, untruncated) every
+              turn. The prior single post-run capture (Keeper_agent_run) saved
+              only the final turn's thinking; turns 1..N-1 were merely counted
+              by the log line above. *)
+           Keeper_agent_run_thinking_trajectory.persist_response_content
+             ~keeper_name:meta.name ~trajectory_acc:(Some acc) ~turn
+             response.content
          | None -> ());
         let text = Agent_sdk.Types.text_of_content response.content in
         let has_state_block =

--- a/lib/trajectory/trajectory.ml
+++ b/lib/trajectory/trajectory.ml
@@ -287,7 +287,12 @@ let append_thinking ~(masc_root : string) ~(keeper_name : string) ~(trace_id : s
   let dir = trajectories_dir masc_root keeper_name in
   Fs_compat.mkdir_p dir;
   let path = trajectory_path masc_root keeper_name trace_id in
-  let json = thinking_entry_to_json entry in
+  (* 남김없이: the thinking trajectory is the eval/audit SSOT, so persist the
+     FULL untruncated reasoning text. Truncation is a read/display concern
+     ([content_max_len] query param on the trajectory endpoint), never a
+     write-time one — truncating here destroyed reasoning before it was ever
+     stored. [content_length] still records the true length either way. *)
+  let json = thinking_entry_to_json ~content_max_len:0 entry in
   Fs_compat.append_jsonl path json
 
 (** Write a trajectory summary line (appended after session ends). *)

--- a/test/test_trajectory.ml
+++ b/test/test_trajectory.ml
@@ -550,6 +550,67 @@ let test_read_entries_since_no_dir () =
 (* Runner                                                            *)
 (* ================================================================ *)
 
+(* ================================================================ *)
+(* Test: thinking trajectory — full untruncated text, per-turn        *)
+(* ================================================================ *)
+
+let read_thinking_jsonl ~masc_root ~keeper_name ~trace_id =
+  let path = Filename.concat masc_root
+    (Printf.sprintf "trajectories/%s/%s.jsonl" keeper_name trace_id) in
+  if not (Sys.file_exists path) then []
+  else begin
+    let ic = open_in path in
+    Fun.protect ~finally:(fun () -> close_in_noerr ic) (fun () ->
+      let rec loop acc =
+        match input_line ic with
+        | line -> loop (Yojson.Safe.from_string line :: acc)
+        | exception End_of_file -> List.rev acc
+      in
+      loop [])
+  end
+
+(* append_thinking must persist the FULL text, not the legacy 2000-byte cap. *)
+let test_append_thinking_persists_untruncated () =
+  with_tmpdir (fun dir ->
+    let big = String.make 9000 'x' in
+    let entry : Trajectory.thinking_entry = {
+      ts = 1000.0; ts_iso = "2026-06-09T00:00:00Z"; turn = 4;
+      content = big; content_length = String.length big; redacted = false;
+    } in
+    Trajectory.append_thinking ~masc_root:dir ~keeper_name:"k" ~trace_id:"th1" entry;
+    let lines = read_thinking_jsonl ~masc_root:dir ~keeper_name:"k" ~trace_id:"th1" in
+    Alcotest.(check int) "one thinking line" 1 (List.length lines);
+    let open Yojson.Safe.Util in
+    let row = List.hd lines in
+    Alcotest.(check string) "type=thinking" "thinking" (row |> member "type" |> to_string);
+    Alcotest.(check int) "content untruncated (9000B, not 2000 cap)" 9000
+      (row |> member "content" |> to_string |> String.length);
+    Alcotest.(check int) "content_length records true length" 9000
+      (row |> member "content_length" |> to_int))
+
+(* persist_response_content stamps every block with the hook's ~turn (not
+   acc.turn) and writes one line per thinking block, untruncated. *)
+let test_persist_response_content_per_turn_full () =
+  with_tmpdir (fun dir ->
+    let acc = Trajectory.create_accumulator
+      ~masc_root:dir ~keeper_name:"k" ~trace_id:"th2" ~generation:0 () in
+    (* acc.turn stays 0; the hook passes ~turn:11 — assert ~turn wins. *)
+    let big = String.make 5000 'a' in
+    let content = [
+      Agent_sdk.Types.Thinking { thinking_type = "reasoning"; content = big };
+      Agent_sdk.Types.Thinking { thinking_type = "reasoning"; content = "second block" };
+    ] in
+    Keeper_agent_run_thinking_trajectory.persist_response_content
+      ~keeper_name:"k" ~trajectory_acc:(Some acc) ~turn:11 content;
+    let lines = read_thinking_jsonl ~masc_root:dir ~keeper_name:"k" ~trace_id:"th2" in
+    let open Yojson.Safe.Util in
+    Alcotest.(check int) "both thinking blocks persisted" 2 (List.length lines);
+    List.iter (fun row ->
+      Alcotest.(check int) "turn stamped from hook (11), not acc.turn (0)" 11
+        (row |> member "turn" |> to_int)) lines;
+    Alcotest.(check int) "first block untruncated (5000B)" 5000
+      (List.hd lines |> member "content" |> to_string |> String.length))
+
 let () =
   Alcotest.run "Trajectory" [
     ("tool_cost", [
@@ -609,5 +670,11 @@ let () =
       Alcotest.test_case "parses persisted gate summary" `Quick
         test_read_entries_since_result_parses_gate_summary;
       Alcotest.test_case "nonexistent directory" `Quick test_read_entries_since_no_dir;
+    ]);
+    ("thinking_trajectory", [
+      Alcotest.test_case "append_thinking persists full untruncated text" `Quick
+        test_append_thinking_persists_untruncated;
+      Alcotest.test_case "persist_response_content stamps hook turn, all blocks" `Quick
+        test_persist_response_content_per_turn_full;
     ]);
   ]


### PR DESCRIPTION
## 문제 — reasoning(thinking) 로깅이 불완전했다

keeper 턴의 reasoning 텍스트는 두 군데서 손실됐다:

- **A. 마지막 턴만 캡처**: `keeper_agent_run.ml`이 multi-turn 루프 종료 후 `persist_response_content`를 **1회만** 호출 → N턴 중 turn N의 thinking만 저장, turns 1..N-1은 로그 라인에서 **카운트만** 됨.
- **B. 쓰기 시점 2000바이트 truncation**: `Trajectory.append_thinking`가 `thinking_entry_to_json`을 기본 `content_max_len=2000`으로 호출 → 디스크 기록 전에 reasoning 본문이 잘림.

라이브 검증: deepseek-v4-flash 턴 1개가 streaming으로 thinking 청크 236개를 내지만(`Streaming_summary.kind_breakdown.thinking=236`), 디스크엔 1턴분 + 2000바이트만 남았다.

## 변경 — 남김없이 (full, every turn)

- `trajectory.ml`: `append_thinking`가 `~content_max_len:0`으로 기록 → **untruncated**. truncation은 read/display 경계(`content_max_len` query param)로만 한정. `content_length`는 항상 실제 길이 기록.
- `keeper_agent_run_thinking_trajectory.ml(/.mli)`: `persist_response_content`에 `~turn` 추가 → 훅이 넘기는 per-turn index로 스탬프(이전엔 `acc.turn`).
- `keeper_hooks_oas.ml`: `after_turn` 훅의 기존 `Some acc` 블록에서 **매 턴** `persist_response_content`로 그 턴의 thinking 기록(emit_cost_event 옆). OAS는 pipeline Stage 4에서 terminal 턴 포함 매 턴 `after_turn`을 발화하므로 최종 턴도 누락 없음.
- `keeper_agent_run.ml`: post-run 단발 캡처 제거(이제 훅이 매 턴 처리; 안 지우면 terminal 턴 이중기록).

## 경계 / 안전

- **strip 무관**: thinking strip은 요청 직렬화(API 재전송용)에만 적용 — 응답 content 블록은 그대로. (verified)
- **남김없이 보증**: `.masc/trajectories/`에는 prune/retention 코드가 없음(append-only) — thinking 라인은 삭제되지 않음. (grep verified)
- **RedactedThinking**: provider가 암호화해 반환 → 물리적으로 복원 불가, `"[redacted]"`로 기록. "남김없이"는 provider가 plaintext로 주는 모든 reasoning에 한정.
- **저장량**: 사용자 명시 — 비용 무관. cap/cooldown/dedup 추가 금지(= truncation 버그류 재발).

## 조회

```
GET /api/v1/keepers/{name}/trajectory?include_thinking=true&content_max_len=0
```
`content_max_len=0` → 저장된 full 텍스트 반환(엔드포인트가 이미 0 통과 지원).

## 검증

- `test_trajectory.ml` +2: (1) `append_thinking`가 9000바이트를 자르지 않고 기록, (2) `persist_response_content ~turn:11`이 모든 thinking 블록을 hook turn으로 스탬프 + untruncated.
- NOT workaround: truncation 제거 + per-turn 이전 = 의도된 캡처 완성. 새 분류기/카운터/cap 없음. RFC-게이트 subsystem 아님.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
