### PR TITLE
fix(keeper): restore task-completion contract to autonomous turn prompt

### DIFF
--- a/config/prompts/keeper.unified.system.md
+++ b/config/prompts/keeper.unified.system.md
@@ -22,7 +22,7 @@ Your lifecycle:
 What you can do:
 - **Board**: post opinions, findings, suggestions (`keeper_board_post`). Comment on others' posts (`keeper_board_comment`). Vote (`keeper_board_vote`). The board is where keepers talk, argue, and share ideas.
 - **Tools**: use the visible tool-search/list tool (`keeper_tool_search` when it is in the active schema, otherwise `keeper_tools_list`) to discover the active runtime schema/descriptor surface. Do not call a tool name that is not in your active schema.
-- **Tasks**: claim tasks from the backlog (`keeper_task_claim`), work on them, mark done.
+- **Tasks**: claim tasks from the backlog (`keeper_task_claim`), work on them, and close them with `keeper_task_done` (see "Closing claimed tasks" below).
 - **Forge/PR work**: this is not a separate keeper tool family. When an assigned task explicitly requires a forge operation and Execute is visible, run the ordinary CLI as typed argv from a scoped repo cwd. Do not use hidden implementation tool names or autonomous PR discovery.
 - **Library**: search and read shared knowledge (`keeper_library_search`, `keeper_library_read`).
 - **Shell**: inspect files and search source with the allowed aliases (`Read`, `Grep`). Use `Execute` for command execution when the active schema exposes it. Do not call hidden implementation names unless the active schema literally lists that exact name.
@@ -98,6 +98,9 @@ Your checkpoint, decision records, and board posts survive across turns and rest
 Do not try to finish everything in this turn. Focus on one observation and one action.
 The next turn will have a fresh context but your checkpoint carries forward — use it.
 Use extend_turns only when a single coherent action genuinely requires more steps (e.g., read-edit-build-verify). Do not use it to cram unrelated work into one turn.
+
+### Closing claimed tasks
+When you claim a task (`keeper_task_claim`), you MUST close it before ending the work. Once the deliverable is complete, call `keeper_task_done` and include PR/artifact evidence in the result text. Spreading the work across turns is fine, but a claimed task whose deliverable is already satisfied must be closed — do not leave it to oscillate back to the backlog. If you cannot make progress, report the concrete blocker (`SPEECH_ACT: request_help`) instead of holding the task idle. (Do not re-claim, re-submit, or re-close a task that is already awaiting_verification; see Verification lifecycle.)
 
 ### Possible actions (pick one per turn)
 - Reply to a pending mention in the current namespace conversation


### PR DESCRIPTION
## 목표

autonomous keeper 턴이 claim한 task를 **닫으라는 지시를 구조적으로 못 받던** 결함을 고칩니다. keeper들이 task를 claim → 탐색(Read/Grep/Execute) → `keeper_task_done` 호출 0회 → force-release → 재claim 하는 churn(task-676 cyc50, task-670 cyc33, task-681 cyc12)의 **확정된 proximate root**.

## 근본 원인 (trace로 확정)

autonomous/heartbeat keeper cycle은 system prompt를 `Keeper_unified_prompt.build_prompt`(= `keeper.unified.system.md` + turn_intent)로 조립하고, `keeper_unified_turn.ml:278`에서 `~base_system_prompt`를 `_`로 **버립니다**. 그런데 완료 계약("claim한 task는 끝내기 전 MUST close, `keeper_task_done`에 evidence 포함")은 `core_behavior.md:10` / `capabilities.md:7`에만 있고, 이건 **reactive 턴 경로**에서만 조립됩니다. 결과: scheduled autonomous 턴 도는 keeper는 task를 닫으라는 지시를 못 받음. `keeper.unified.system.md:25`는 "mark done"만 — 툴명·evidence·close 지시 0.

라이브 로그(`system_log_2026-06-09.jsonl`) trace 결과: **never_attempt 지배적** (3개 중 2 never_attempt, 1 still_running, 0 attempt_rejected). claim한 task가 `keeper_task_done`/`submit_for_verification`을 **한 번도 호출 안 함** — evidence gate 거부가 아니라 완료를 애초에 시도 안 함.

## 변경

- `config/prompts/keeper.unified.system.md` (단일 파일, +4/-1)
  - `**Tasks**` 능력 줄을 close 지시로 보강
  - `### Closing claimed tasks` 섹션 추가 — `core_behavior.md:10`의 기존 완료 계약 이식(신규 prose 아님) + anti-oscillation 지시(이미 충족된 claim task는 닫아야 하며 backlog로 bounce 금지, 진행 불가 시 구체적 blocker 보고)

`keeper_task_done`은 `Done_action`으로 라우팅되며 CDAL substring evidence gate를 **면제**받습니다(`tool_task.ml:288-298` — 그 gate는 `submit_for_verification`에만 발화). 따라서 이 변경이 non-completion을 evidence-gate 거부로 전환시키지 않습니다.

## 로컬 검증

- `scripts/validate-prompt-paths.sh` PASS (path drift 없음)
- frontmatter / `template_variables` 미변경 — 렌더링 영향 없음 (body prose 추가만)
- pre-commit: `*.md`라 dune build 스킵(#19345 doc-only 경로)
- 기존 prompt 테스트(`test_prompt_registry_defaults` 등)는 fixture 기반이라 실제 파일 본문을 assert하지 않음 → 본 변경과 무관, 무영향

## 남은 미검증 / 후속

- **런타임 검증 필요**: 효과(keeper가 실제 `keeper_task_done` 호출)는 서버 재시작 후 라이브 관찰로만 증명 가능. config/prompts는 startup bootstrap 스캔으로 반영.
- **regression guard 미포함 (의도적)**: 원본에도 `keeper_task_done`이 *부정* 문맥(awaiting_verification 금지)으로 존재해 토큰 grep guard는 무의미하고, prose substring을 잠그는 건 string-match anti-pattern. 비취약 guard는 완료가 typed/checkable 개념이 되는 후속 RFC에서 진짜 테스트로 추가.
- **구조적 후속(별도 RFC)**: 완료를 LLM 재량이 아니라 **typed acceptance criterion + 하네스 평가**로 driving (checkable task는 결정론적 자동완료, force-release-reclaim livelock을 typed Blocked escalation으로 대체). 본 PR은 proximate-root만 처리.

RFC-WAIVED: config/prompts 프롬프트 콘텐츠 복원으로, credential/identity/operator/sandbox/hooks/workflow 등 RFC-gated subsystem 미해당. 구조적 변경은 별도 RFC로 추진 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
