### PR TITLE
fix(logging): repair main build breaks from #20651 (type/scope errors)

### DIFF
--- a/lib/cache_eio.ml
+++ b/lib/cache_eio.ml
@@ -94,7 +94,7 @@ let entry_of_json (json : Yojson.Safe.t) : cache_entry option =
     Log.Misc.error "JSON type error in entry_of_json: missing required fields (key=%s value=%s created_at=%s)"
       (match key with Some s -> s | None -> "(absent)")
       (match value with Some s -> s | None -> "(absent)")
-      (match created_at with Some s -> s | None -> "(absent)");
+      (match created_at with Some s -> string_of_float s | None -> "(absent)");
     None
 ;;
 

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -159,7 +159,7 @@ let run_turn
        with Eio.Cancel.Cancelled _ as ce -> raise ce
        | exn ->
          Log.Keeper.warn "keeper:%s emit_observation_turn_end failed: %s"
-           (!meta_ref).name (Printexc.to_string exn));
+           meta.name (Printexc.to_string exn));
       Turn_helpers.emit_turn_end_safely ~keeper_name:meta.name ()
   in
   Eio_guard.protect ~finally:safe_emit_turn_end

--- a/lib/run_eio.ml
+++ b/lib/run_eio.ml
@@ -29,9 +29,10 @@ let run_record_to_json (r : run_record) : Yojson.Safe.t =
   ]
 
 let run_record_of_json (json : Yojson.Safe.t) : run_record option =
-  match Safe_ops.json_string_opt "task_id" json,
-        Safe_ops.json_string_opt "created_at" json,
-        Safe_ops.json_string_opt "updated_at" json with
+  let task_id = Safe_ops.json_string_opt "task_id" json in
+  let created_at = Safe_ops.json_string_opt "created_at" json in
+  let updated_at = Safe_ops.json_string_opt "updated_at" json in
+  match task_id, created_at, updated_at with
   | Some task_id, Some created_at, Some updated_at ->
     let agent_name = Safe_ops.json_string_opt "agent_name" json in
     let plan = Safe_ops.json_string ~default:"" "plan" json in


### PR DESCRIPTION
## 문제 — main 빌드 깨짐 (#20651)

`#20651` (feat(logging): structured logging to silent decision points)이 추가한 에러-경로 로그 3곳이 타입/스코프 오류로 **컴파일되지 않아 main이 깨졌다**.

```
lib/cache_eio.ml:97   created_at(float)를 %s로 출력 → float ≠ string
lib/run_eio.ml:42     task_id/created_at/updated_at가 `_` 분기에서 unbound
lib/keeper/keeper_agent_run.ml:162  (!meta_ref).name — meta_ref 미존재
```

(내 PR #20652는 #20651 이전 베이스라 단독으로는 clean 했지만, main에 머지되며 #20651 깨짐을 상속했다.)

## 수정

- **cache_eio.ml**: `created_at`은 float. missing-fields 로그에서 `string_of_float`로 변환.
- **run_eio.ml**: `task_id`/`created_at`/`updated_at`는 성공 match 분기에서만 바인딩됐다. `json_string_opt` 파싱을 match 앞 `let`으로 올려 양쪽 분기에서 접근 가능하게.
- **keeper_agent_run.ml**: `(!meta_ref).name` → `meta.name` (바로 다음 줄에서 이미 `meta.name` 사용).

동작 변경 없음 — 에러-경로 로그 라인의 컴파일 오류만 교정.

## 검증

전체 `dune build .` 통과.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
