### PR TITLE
feat(dashboard): show full untruncated reasoning in trajectory detail view

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -2273,10 +2273,13 @@ export function fetchKeeperTrajectory(
   // so omitting the param means "don't include".
   params.set('include_thinking', includeThinking ? 'true' : 'false')
   // Request full output for session trace detail view.
-  // Backend caps at 10000 for results, 50000 for thinking content.
+  // content_max_len=0 → no cap: surface the COMPLETE reasoning text in the
+  // detail view (남김없이). The backend persists thinking untruncated and
+  // treats 0 as "no truncation"; size is intentionally accepted here, this is
+  // the drill-in surface (the timeline list keeps the default preview cap).
   if (fullOutput) {
     params.set('result_max_len', '10000')
-    params.set('content_max_len', '50000')
+    params.set('content_max_len', '0')
   }
   const qs = params.toString()
   return get<TrajectoryResponse>(


### PR DESCRIPTION
## 변경

detail view(journey panel, session trace)가 trajectory를 `fullOutput=true`로 가져올 때 thinking을 50000B로 캡했음 → `content_max_len=0`(무제한)으로 전송해 **완전한 reasoning 텍스트 표시**(남김없이). 백엔드는 untruncated 영속(#20652) + 0=no-truncation 처리. timeline 리스트는 미리보기 캡 유지(detail로 drill-in).

대시보드 thinking 렌더링(`ThinkingDetail`, `include_thinking=true`)은 이미 존재 — 이 변경은 표시 캡만 제거.

## 검증
- vitest 45개 통과 (dashboard.test.ts + journey-panel.test.ts)
- tsc 신규 에러 0 (ide/* 에러는 pre-existing, 무관)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
