### PR TITLE
feat(telemetry): add OTel instruction monitoring metrics and Grafana dashboard

### DIFF
--- a/infrastructure/monitoring/grafana/provisioning/dashboards/masc-overview.json
+++ b/infrastructure/monitoring/grafana/provisioning/dashboards/masc-overview.json
@@ -727,6 +727,180 @@
           "sortOrder": "desc"
         }
       }
+    },
+    {
+      "type": "row",
+      "title": "Keeper Instruction Monitoring",
+      "gridPos": {
+        "x": 0,
+        "y": 112,
+        "w": 24,
+        "h": 1
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Prompt Segment Bytes",
+      "gridPos": {
+        "x": 0,
+        "y": 113,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "description": "Byte length of system_prompt and user_message segments per keeper after sanitization.",
+      "targets": [
+        {
+          "expr": "masc_keeper_prompt_segment_bytes{segment=\"system_prompt\"}",
+          "legendFormat": "{{keeper}} / system_prompt",
+          "refId": "A"
+        },
+        {
+          "expr": "masc_keeper_prompt_segment_bytes{segment=\"user_message\"}",
+          "legendFormat": "{{keeper}} / user_message",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "pointSize": 0,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Template Render Outcome",
+      "gridPos": {
+        "x": 12,
+        "y": 113,
+        "w": 6,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "description": "Turn-intent template render outcomes: ok, fallback, empty.",
+      "targets": [
+        {
+          "expr": "sum by (outcome) (rate(masc_keeper_prompt_template_render_outcome_total[5m]))",
+          "legendFormat": "{{outcome}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "color": {
+            "mode": "palette-classic"
+          }
+        }
+      },
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value"
+      }
+    },
+    {
+      "type": "barchart",
+      "title": "Tool Call Param Completeness",
+      "gridPos": {
+        "x": 18,
+        "y": 113,
+        "w": 6,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "description": "Tool calls by parameter completeness status per tool.",
+      "targets": [
+        {
+          "expr": "sum by (tool, status) (rate(masc_keeper_tool_call_param_completeness_total[5m]))",
+          "legendFormat": "{{tool}} / {{status}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "color": {
+            "mode": "palette-classic"
+          }
+        }
+      },
+      "options": {
+        "orientation": "horizontal",
+        "legend": {
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true
+        },
+        "showValue": "always"
+      }
+    },
+    {
+      "type": "state-timeline",
+      "title": "Turn Instruction Hash",
+      "gridPos": {
+        "x": 0,
+        "y": 121,
+        "w": 24,
+        "h": 6
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "description": "Hash of system+user prompt per keeper for change detection. Value changes indicate prompt reconfiguration.",
+      "targets": [
+        {
+          "expr": "masc_keeper_turn_instruction_hash",
+          "legendFormat": "{{keeper}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          }
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      }
     }
   ],
   "refresh": "30s",

--- a/lib/keeper/keeper_tool_alias.ml
+++ b/lib/keeper/keeper_tool_alias.ml
@@ -136,6 +136,16 @@ let record_route_outcome ~tool ~routed_to ~result =
       ; "routed_to", safe_routed_to_label routed_to
       ; "result", result
       ]
+    ();
+  (* Instruction monitoring: track per-tool invocation completeness.
+     result="ok" means parameters were accepted by the runtime surface;
+     other results (miss/error) indicate the call did not complete normally. *)
+  Otel_metric_store.inc_counter
+    (Keeper_metrics.to_string ToolCallParamCompleteness)
+    ~labels:
+      [ ("tool", safe_tool_label tool)
+      ; ("status", if String.equal result "ok" then "complete" else "incomplete")
+      ]
     ()
 ;;
 

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -737,4 +737,19 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
     (Keeper_metrics.to_string PromptSegmentBytes)
     ~labels:[("keeper", meta.name); ("segment", "user_message")]
     (Float.of_int (String.length sanitized_user));
+  (* Instruction hash: emit a stable numeric fingerprint of the full prompt
+     composition (system + user) so Grafana can detect when the instruction
+     changes between turns without storing the prompt content itself.
+     Uses first 8 hex chars of SHA-256 as an integer (32-bit). *)
+  let prompt_hash =
+    let combined = sanitized_system ^ sanitized_user in
+    let hex =
+      Digestif.SHA256.(to_hex (digest_string combined))
+    in
+    Int32.to_float (Int32.of_string ("0x" ^ String.sub hex 0 8))
+  in
+  Otel_metric_store.set_gauge
+    (Keeper_metrics.to_string KeeperTurnInstructionHash)
+    ~labels:[("keeper", meta.name)]
+    prompt_hash;
   ( sanitized_system, sanitized_user )

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -277,30 +277,41 @@ let fallback_turn_intent_block reason =
   turn_intent_fallback_block
 
 let resolve_turn_intent_block substitutions =
+  let observe_outcome label =
+    Otel_metric_store.inc_counter
+      (Keeper_metrics.to_string PromptTemplateRenderOutcome)
+      ~labels:[("template", "turn_intent"); ("outcome", label)]
+      ()
+  in
   match
     Prompt_registry.render_prompt_template Keeper_prompt_names.turn_intent
       substitutions
   with
   | Ok value ->
       let rendered = String.trim value in
-      if String.equal rendered "" then
-        fallback_turn_intent_block "rendered prompt was empty"
-      else
-        rendered
+      if String.equal rendered "" then (
+        observe_outcome "empty";
+        fallback_turn_intent_block "rendered prompt was empty")
+      else (
+        observe_outcome "ok";
+        rendered)
   | Error msg ->
       let raw =
         String.trim (Prompt_registry.get_prompt Keeper_prompt_names.turn_intent)
       in
-      if String.equal raw "" then
+      if String.equal raw "" then (
+        observe_outcome "fallback";
         fallback_turn_intent_block
-          (Printf.sprintf "%s; raw prompt was empty after render failure" msg)
-      else if contains_template_placeholder raw then
+          (Printf.sprintf "%s; raw prompt was empty after render failure" msg))
+      else if contains_template_placeholder raw then (
+        observe_outcome "fallback";
         fallback_turn_intent_block
           (Printf.sprintf
              "%s; raw prompt still contained template placeholders after render \
               failure"
-             msg)
+             msg))
       else (
+        observe_outcome "fallback";
         observe_turn_intent_render_failure msg;
         raw)
 
@@ -712,5 +723,18 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
   let user_message =
     Buffer.contents ubuf
   in
-  ( sanitize_retired_tool_names system_prompt,
-    sanitize_retired_tool_names user_message )
+  let sanitized_system = sanitize_retired_tool_names system_prompt in
+  let sanitized_user = sanitize_retired_tool_names user_message in
+  Otel_metric_store.inc_counter
+    (Keeper_metrics.to_string PromptSegmentBytes)
+    ~labels:[("keeper", meta.name); ("segment", "system_prompt")]
+    ();
+  Otel_metric_store.set_gauge
+    (Keeper_metrics.to_string PromptSegmentBytes)
+    ~labels:[("keeper", meta.name); ("segment", "system_prompt")]
+    (Float.of_int (String.length sanitized_system));
+  Otel_metric_store.set_gauge
+    (Keeper_metrics.to_string PromptSegmentBytes)
+    ~labels:[("keeper", meta.name); ("segment", "user_message")]
+    (Float.of_int (String.length sanitized_user));
+  ( sanitized_system, sanitized_user )

--- a/lib/keeper_metrics.ml
+++ b/lib/keeper_metrics.ml
@@ -211,6 +211,12 @@ type t =
   | MemoryBankLoadHistorySwallowedExceptions
   | MemoryRecallReadErrors
   | RuntimeHttpProbeJsonParseFailures
+  (* Instruction monitoring metrics *)
+  | PromptSegmentBytes
+  | PromptTemplateRenderOutcome
+  | ToolCallParamCompleteness
+  | KeeperTurnInstructionHash
+  | KeeperToolCallRetryLoop
 
 (** String conversion
 
@@ -437,4 +443,9 @@ let to_string = function
       "masc_keeper_memory_recall_read_errors_total"
   | RuntimeHttpProbeJsonParseFailures ->
       "masc_runtime_http_probe_json_parse_failures_total"
+  | PromptSegmentBytes -> "masc_keeper_prompt_segment_bytes"
+  | PromptTemplateRenderOutcome -> "masc_keeper_prompt_template_render_outcome_total"
+  | ToolCallParamCompleteness -> "masc_keeper_tool_call_param_completeness_total"
+  | KeeperTurnInstructionHash -> "masc_keeper_turn_instruction_hash"
+  | KeeperToolCallRetryLoop -> "masc_keeper_tool_call_retry_loop_total"
 ;;

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -211,6 +211,12 @@ type t =
   | MemoryBankLoadHistorySwallowedExceptions
   | MemoryRecallReadErrors
   | RuntimeHttpProbeJsonParseFailures
+  (* Instruction monitoring metrics *)
+  | PromptSegmentBytes          (* histogram: bytes per prompt segment *)
+  | PromptTemplateRenderOutcome (* counter: template render ok/fallback/empty *)
+  | ToolCallParamCompleteness   (* counter: tool calls with all required params vs missing *)
+  | KeeperTurnInstructionHash   (* gauge: hash of system+user prompt for change detection *)
+  | KeeperToolCallRetryLoop     (* counter: consecutive identical tool calls with errors *)
 
 (** String conversion
 
@@ -437,4 +443,9 @@ let to_string = function
       "masc_keeper_memory_recall_read_errors_total"
   | RuntimeHttpProbeJsonParseFailures ->
       "masc_runtime_http_probe_json_parse_failures_total"
+  | PromptSegmentBytes -> "masc_keeper_prompt_segment_bytes"
+  | PromptTemplateRenderOutcome -> "masc_keeper_prompt_template_render_outcome_total"
+  | ToolCallParamCompleteness -> "masc_keeper_tool_call_param_completeness_total"
+  | KeeperTurnInstructionHash -> "masc_keeper_turn_instruction_hash"
+  | KeeperToolCallRetryLoop -> "masc_keeper_tool_call_retry_loop_total"
 ;;

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -202,5 +202,10 @@ type t =
   | MemoryBankLoadHistorySwallowedExceptions
   | MemoryRecallReadErrors
   | RuntimeHttpProbeJsonParseFailures
+  | PromptSegmentBytes
+  | PromptTemplateRenderOutcome
+  | ToolCallParamCompleteness
+  | KeeperTurnInstructionHash
+  | KeeperToolCallRetryLoop
 
 val to_string : t -> string


### PR DESCRIPTION
## Motivation
Sangsu keeper was stuck in infinite loop but the pattern was invisible without prompt-level telemetry.

## New Metrics (5)
- PromptSegmentBytes (gauge): prompt byte sizes per keeper
- PromptTemplateRenderOutcome (counter): render ok/fallback/empty
- ToolCallParamCompleteness (counter): per-tool invocation completeness
- KeeperTurnInstructionHash (gauge): reserved for prompt change detection
- KeeperToolCallRetryLoop (counter): reserved for LLM repetition

## Grafana Dashboard
4 new panels in Keeper Instruction Monitoring section.

## Test plan
- [x] dune build @check passes
- [ ] Deploy, verify metrics in VictoriaMetrics
- [ ] Verify Grafana panels render with live data

🤖 Generated with [Claude Code](https://claude.com/claude-code)
