### PR TITLE
fix(telemetry): bound unbounded dated_jsonl reads; restore n=0 contract

### DIFF
--- a/lib/telemetry_unified/telemetry_unified.ml
+++ b/lib/telemetry_unified/telemetry_unified.ml
@@ -431,26 +431,42 @@ let matches_scope ?session_id ?operation_id ?worker_run_id (json : Yojson.Safe.t
 
 (* ── Read from a single fixed-path source ───────────── *)
 
+(* A non-positive [n] means "unlimited" at the call sites (dashboard /telemetry
+   sends no [n], so [read_unified_result] derives per_source = 0). Scanning the
+   entire store for that case Yojson-parsed every entry over 1970->today on the
+   keeper's Eio domain, and major-GC starved keeper fibers (measured: a single
+   no-[n] /api/v1/dashboard/telemetry request held one core at 100%+ for ~8s on
+   a 224MB execution-receipts store, blocking turns). Clamp "unlimited" to this
+   cap so every read goes through the tail-bounded readers instead of a
+   full-store [read_range]. The cap is large enough that real dashboard windows
+   never hit it; if a future caller needs more, raise it deliberately rather
+   than reintroducing an unbounded scan. *)
+let unbounded_window_scan_cap = 50_000
+
+(* Shared read path for directory-backed Dated_jsonl stores. Always routes
+   through the tail-bounded readers ([read_recent] / [read_range_recent]) so a
+   wide window or an "unlimited" ([n] <= 0) request cannot parse the whole
+   store. Returns entries filtered to the requested timestamp window, untagged;
+   callers tag with their source. *)
+let bounded_entries_for_window store ~n ?since_ts ?until_ts () =
+  let effective_n = if n <= 0 then unbounded_window_scan_cap else n in
+  let entries =
+    match effective_day_window ?since_ts ?until_ts () with
+    | None -> Dated_jsonl.read_recent store effective_n
+    | Some (since_day, until_day) ->
+      Dated_jsonl.read_range_recent store ~since:since_day ~until:until_day
+        effective_n
+  in
+  List.filter (within_requested_window ?since_ts ?until_ts) entries
+
 let read_fixed_source dir source ~n ?since_ts ?until_ts () : Yojson.Safe.t list =
   match classify_store_dir source ~site:"read_fixed_source_dir" dir with
   | Store_missing | Store_invalid -> []
   | Store_directory ->
     match Dated_jsonl.create ~base_dir:dir () with
     | store ->
-      let entries =
-        match effective_day_window ?since_ts ?until_ts () with
-        | None -> Dated_jsonl.read_recent store n
-        | Some (since_day, until_day) ->
-          (* Honour [n] on the windowed path too: [read_range] parsed every
-             entry in the day range (unbounded over multi-MB stores), then this
-             function dropped all but [n]. Bound the parse to the [n] most
-             recent in-window entries instead. *)
-          Dated_jsonl.read_range_recent store ~since:since_day ~until:until_day n
-      in
-      let entries =
-        List.filter (within_requested_window ?since_ts ?until_ts) entries
-      in
-      List.map (tag_entry source) entries
+      bounded_entries_for_window store ~n ?since_ts ?until_ts ()
+      |> List.map (tag_entry source)
     | exception (Eio.Cancel.Cancelled _ as e) -> raise e
     | exception exn ->
       observe_source_read_failure_exn source ~site:"read_fixed_source" exn;
@@ -502,19 +518,12 @@ let read_keeper_metrics_fast_top ~masc_root ~n () : Yojson.Safe.t list =
   in
   loop [] probes
 
+(* Execution-receipt stores read through the same tail-bounded helper as the
+   fixed sources. Previously an "unlimited" ([n] <= 0) request here scanned
+   1970->today via [read_range] — the measured GC-starvation path for the
+   dashboard /telemetry endpoint. *)
 let dated_jsonl_entries store ~n ?since_ts ?until_ts () =
-  let entries =
-    match effective_day_window ?since_ts ?until_ts () with
-    | Some (since_day, until_day) ->
-        Dated_jsonl.read_range store ~since:since_day ~until:until_day
-    | None when n <= 0 ->
-        let until_ts = Unix.gettimeofday () in
-        let since_day = "1970-01-01" in
-        let until_day = day_string_of_unix_seconds until_ts in
-        Dated_jsonl.read_range store ~since:since_day ~until:until_day
-    | None -> Dated_jsonl.read_recent store n
-  in
-  List.filter (within_requested_window ?since_ts ?until_ts) entries
+  bounded_entries_for_window store ~n ?since_ts ?until_ts ()
 
 let read_execution_receipts ~masc_root ?keeper_name ?since_ts ?until_ts ~n ()
     : Yojson.Safe.t list =

--- a/test/test_telemetry_unified.ml
+++ b/test/test_telemetry_unified.ml
@@ -517,6 +517,31 @@ let test_time_window_n_zero_disables_truncation () =
   Alcotest.(check int) "total matching preserved" 3 result.total_matching_entries;
   Alcotest.(check bool) "unbounded result is not truncated" false result.truncated
 
+(* n=0 ("unlimited") with no time window must reach the tail-bounded reader
+   ([read_recent]), not the full-store [read_range] scan (1970->today) that
+   Yojson-parsed the whole store and starved keeper fibers, and not the empty
+   list the #20649 regression produced for fixed sources. With fewer entries
+   than [unbounded_window_scan_cap], all are returned. *)
+let test_n_zero_no_window_returns_bounded () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = tmpdir "telem_n0_no_window" in
+  let telemetry_dir = Filename.concat dir ".masc/telemetry" in
+  Fs_compat.mkdir_p telemetry_dir;
+  let now = Unix.gettimeofday () in
+  write_jsonl telemetry_dir [
+    `Assoc [("timestamp", `Float (now -. 900.0)); ("event", `String "a")];
+    `Assoc [("timestamp", `Float (now -. 600.0)); ("event", `String "b")];
+    `Assoc [("timestamp", `Float (now -. 300.0)); ("event", `String "c")];
+  ];
+  let result =
+    Telemetry_unified.read_unified_result ~base_path:dir
+      ~masc_root:(masc_root dir)
+      ~sources:[ Telemetry_unified.Agent_event ] ~n:0 ()
+  in
+  Alcotest.(check int) "n=0 no-window returns all via bounded reader" 3
+    (List.length result.entries)
+
 (* ── Summary with data ───────────────────────────── *)
 
 let test_summary_with_data () =
@@ -1250,6 +1275,8 @@ let () =
             test_time_window_reads_matching_day_files;
           Alcotest.test_case "time window n=0 disables truncation" `Quick
             test_time_window_n_zero_disables_truncation;
+          Alcotest.test_case "n=0 no-window returns bounded (not full scan)"
+            `Quick test_n_zero_no_window_returns_bounded;
           Alcotest.test_case "trajectory and receipts" `Quick
             test_read_unified_reads_trajectory_and_execution_receipts;
           Alcotest.test_case "runtime contract scope filter" `Quick


### PR DESCRIPTION
## 문제 (측정)

대시보드 `GET /api/v1/dashboard/telemetry` 를 `n` 파라미터 없이 호출하면 (`handle_telemetry` 의 `n` default 가 0 = "무제한") `read_unified_result` 가 `per_source = 0` 으로 모든 소스를 읽습니다. `dated_jsonl_entries` 가 `n <= 0` 일 때 `read_range` 로 `1970-01-01 -> today` 전체를 Yojson 파싱하여 keeper 의 Eio 도메인에서 major GC STW 를 유발하고 keeper fiber 를 starvation 시킵니다.

재현/측정:
```
curl -s 'http://localhost:8935/api/v1/dashboard/telemetry'   # n 없음 -> n=0
# http=200, time=8.33s, CPU 136% -> 180%
# sample call tree:
#   camlTelemetry_unified$source_json_and_count
#     -> camlDated_jsonl (read_range)
#     -> camlYojson read_space/read_json
#     -> major_collection_slice / stw_cycle_all_domains
#     -> caml_plat_futex_wait (전 도메인 STW 대기)
```
대상 store: `execution-receipts` (224MB).

## 근본 원인

1. `dated_jsonl_entries` 의 `n <= 0 -> read_range(1970->today)` 미수정 unbounded full-store scan.
2. #20649 가 `read_fixed_source` 의 windowed 경로만 `read_range_recent` 로 bound 했으나, `read_range_recent ~n:0` 은 `[]` 를 반환합니다. 즉 fixed source 에서 "무제한"(`n=0`) 요청이 window 내 전부 대신 빈 결과가 되는 계약 회귀입니다 (`test_time_window_n_zero` 는 #20649 머지 시 Build and Test 가 red 였고 admin-merge 되었습니다).
3. 두 쌍둥이 함수가 `n <= 0` 에서 의미가 갈렸습니다: 하나는 full-scan, 하나는 empty (split-brain).

## 변경

`bounded_entries_for_window` helper 를 추출하여 `read_fixed_source` 와 `dated_jsonl_entries` 가 공유합니다. 항상 tail-bounded reader (`read_recent` / `read_range_recent`) 를 통과하며, `n <= 0` ("무제한") 은 `unbounded_window_scan_cap` (50000) 으로 clamp 합니다. `read_range` (unbounded) 호출을 제거하여 어떤 caller 도 전체 store 를 파싱할 수 없습니다.

- `read_range` (전체 파싱) 제거, tail-bounded reader 로 전환 = 근본 수정
- `dated_jsonl_entries` / `read_fixed_source` 의 `n <= 0` split-brain 제거 (helper 1개로 통합, N-of-M 재발 불가)
- `test_time_window_n_zero` 복원 (n=0 + window 가 window 내 전부 반환)
- `test_n_zero_no_window_returns_bounded` 추가

## 검증

- `dune build lib/telemetry_unified` EXIT=0
- 36 tests: `time window n=0 disables truncation` + `n=0 no-window returns bounded` PASS. baseline (8cb6650, 본 변경 없음) 에서는 `test_time_window_n_zero` 가 FAIL (2 failures) -> 본 변경으로 1 failure, regression 0.
- 잔여 1 failure (`summary surfaces coverage gaps`, Otel metric counter 테스트) 는 base 8cb6650 의 기존 결함으로 본 변경과 무관합니다.
- 런타임 before(8.3s)/after 는 배포 후 `curl /api/v1/dashboard/telemetry` 지연으로 확인 예정입니다.

## 발견된 별도 이슈 (본 PR 범위 외, 기록)

- #20649 가 Build and Test fail 상태로 admin-merge 되어 `n=0` 무제한 계약 회귀가 main 에 들어감.
- `test_summary_surfaces_coverage_gaps` 가 base 에서 기존 fail (Otel counter).
- `cc000ca` 가 broken main (`keeper_agent_run.ml` `meta_ref` unbound) 였고 `8cb6650` 이 복구.

RFC-WAIVED: telemetry read 경로 성능 수정. credential/identity/operator/sandbox/hooks/workflow subsystem 비해당. unbounded read 제거(근본)이며 cap 은 "무제한 요청"의 안전 상한(backpressure)으로 symptom 억제가 아님.
