### PR TITLE
feat(task): RFC-0199 Phase B — typed evidence_claims + deterministic completion harness

### DIFF
--- a/lib/types/deterministic_evidence_evaluator.ml
+++ b/lib/types/deterministic_evidence_evaluator.ml
@@ -1,0 +1,79 @@
+type probe =
+  { file_bytes : string -> int option
+  ; command_exit : string -> int option
+  ; pr_merged : repo:string -> pr:int -> bool option
+  ; ci_passed : repo:string -> pr:int -> bool option
+  ; custom_check : id:string -> payload:Yojson.Safe.t -> bool option
+  }
+
+type outcome =
+  | Satisfied
+  | Unsatisfied of string
+  | Indeterminate of string
+
+let outcome_to_string = function
+  | Satisfied -> "satisfied"
+  | Unsatisfied reason -> Printf.sprintf "unsatisfied(%s)" reason
+  | Indeterminate reason -> Printf.sprintf "indeterminate(%s)" reason
+
+let size_ok ~min_bytes n =
+  match min_bytes with None -> true | Some m -> n >= m
+
+let min_bytes_str = function Some m -> string_of_int m | None -> "0"
+
+let eval_file ~path ~min_bytes (probe : probe) =
+  match probe.file_bytes path with
+  | None -> Unsatisfied (Printf.sprintf "%s: absent" path)
+  | Some n when size_ok ~min_bytes n -> Satisfied
+  | Some n ->
+    Unsatisfied (Printf.sprintf "%s: %dB < min %s" path n (min_bytes_str min_bytes))
+
+let eval_claim (probe : probe) (claim : Evidence_claim.t) : outcome =
+  let open Evidence_claim in
+  match claim with
+  | Artifact_exists { path; min_bytes } -> eval_file ~path ~min_bytes probe
+  | File_changed { path; min_bytes } -> eval_file ~path ~min_bytes probe
+  | Tests_pass { command; expected_exit } -> (
+    match probe.command_exit command with
+    | None -> Indeterminate (Printf.sprintf "could not run: %s" command)
+    | Some code when code = expected_exit -> Satisfied
+    | Some code ->
+      Unsatisfied (Printf.sprintf "%s: exit %d <> %d" command code expected_exit))
+  | PR_merged { repo; pr_number } -> (
+    match probe.pr_merged ~repo ~pr:pr_number with
+    | None -> Indeterminate (Printf.sprintf "pr %s#%d: unknown" repo pr_number)
+    | Some true -> Satisfied
+    | Some false -> Unsatisfied (Printf.sprintf "pr %s#%d not merged" repo pr_number))
+  | CI_pass { repo; pr_number } -> (
+    match probe.ci_passed ~repo ~pr:pr_number with
+    | None -> Indeterminate (Printf.sprintf "ci %s#%d: unknown" repo pr_number)
+    | Some true -> Satisfied
+    | Some false -> Unsatisfied (Printf.sprintf "ci %s#%d not passing" repo pr_number))
+  | Custom_check { id; payload } -> (
+    match probe.custom_check ~id ~payload with
+    | None -> Indeterminate (Printf.sprintf "custom %s: unknown id / uncheckable" id)
+    | Some true -> Satisfied
+    | Some false -> Unsatisfied (Printf.sprintf "custom %s failed" id))
+
+let is_indeterminate = function
+  | Indeterminate _ -> true
+  | Satisfied | Unsatisfied _ -> false
+
+let is_unsatisfied = function
+  | Unsatisfied _ -> true
+  | Satisfied | Indeterminate _ -> false
+
+let eval_all (probe : probe) (claims : Evidence_claim.t list) : outcome =
+  match claims with
+  | [] -> Unsatisfied "no typed claims declared"
+  | _ ->
+    let outcomes = List.map (eval_claim probe) claims in
+    (* Indeterminate dominates Unsatisfied: if any claim could not be
+       evaluated, report indeterminate rather than a false definite "no".
+       Satisfied requires every claim Satisfied over a non-empty list. *)
+    (match List.find_opt is_indeterminate outcomes with
+     | Some ind -> ind
+     | None -> (
+       match List.find_opt is_unsatisfied outcomes with
+       | Some uns -> uns
+       | None -> Satisfied))

--- a/lib/types/deterministic_evidence_evaluator.mli
+++ b/lib/types/deterministic_evidence_evaluator.mli
@@ -1,0 +1,53 @@
+(** Deterministic_evidence_evaluator — RFC-0199 Phase B.
+
+    Evaluates a typed {!Evidence_claim.t} (or a list) to decide whether a
+    task's declared completion criteria are objectively satisfied, WITHOUT
+    verifier judgment. This is the consumer the Phase A schema was missing
+    (the reason the [required_evidence_typed] field was fan-in-0 and removed
+    2026-06-03); it is introduced together with a producer (the
+    [task_contract.evidence_claims] field) and a completion-driving caller.
+
+    Boundary (manifesto: deterministic vs side-effecting): this module is
+    pure. All world access — file stat, command execution, forge queries —
+    is injected via {!probe}, so parsers, validators, and tests evaluate
+    claims without real I/O. Callers in the completion path construct a
+    {!probe} backed by the sandbox file system / Shell-IR runner.
+
+    Unknown is never permissive (CLAUDE.md anti-pattern #2): a probe that
+    cannot determine an answer returns [None], which the evaluator maps to
+    {!Indeterminate}, NOT {!Satisfied}. A task only auto-completes on an
+    all-[Satisfied] verdict over a NON-EMPTY claim list. *)
+
+type probe =
+  { file_bytes : string -> int option
+        (** [Some n] when the path exists with [n] bytes; [None] when absent.
+            Absent is a definite answer (Unsatisfied), not Indeterminate. *)
+  ; command_exit : string -> int option
+        (** [Some exit_code] after running the command; [None] when the
+            command could not be run at all (Indeterminate). *)
+  ; pr_merged : repo:string -> pr:int -> bool option
+        (** [Some true]/[Some false] when the forge state is known; [None]
+            when it could not be queried (Indeterminate). *)
+  ; ci_passed : repo:string -> pr:int -> bool option
+  ; custom_check : id:string -> payload:Yojson.Safe.t -> bool option
+        (** Dispatched on the typed [id] (allowlist), not a free-form string
+            classifier; [None] for an unknown id (Indeterminate). *)
+  }
+
+type outcome =
+  | Satisfied
+  | Unsatisfied of string  (** a definite "no", with a human reason *)
+  | Indeterminate of string  (** could not be evaluated; never auto-completes *)
+
+val eval_claim : probe -> Evidence_claim.t -> outcome
+(** Evaluate a single claim. Exhaustive over the closed sum. *)
+
+val eval_all : probe -> Evidence_claim.t list -> outcome
+(** [Satisfied] iff the list is non-empty and every claim is [Satisfied].
+    An empty list returns [Unsatisfied "no typed claims declared"] — it is
+    never vacuously satisfied, so a task without declared claims is never
+    auto-completed. Returns the first non-[Satisfied] outcome otherwise
+    ([Indeterminate] dominates [Unsatisfied] so a partial probe failure is
+    reported as indeterminate rather than a false "no"). *)
+
+val outcome_to_string : outcome -> string

--- a/lib/types/dune
+++ b/lib/types/dune
@@ -9,6 +9,7 @@
   masc_error
   ids
   evidence_claim
+  deterministic_evidence_evaluator
   types_core
   types_auth
   masc_domain

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -520,6 +520,8 @@ type task_contract = {
   required_evidence : string list; [@default []]
   inspect_gate_evidence : string list; [@default []]
   verify_gate_evidence : string list; [@default []]
+  evidence_claims : Evidence_claim.t list; [@default []]
+  (* RFC-0199 Phase B: typed deterministic completion criteria (see .mli). *)
   stale_claim_timeout_sec : int; [@default 0]
   links : task_execution_links; [@default { operation_id = None; session_id = None }]
 } [@@deriving show, yojson { strict = false }]

--- a/lib/types/types_core.mli
+++ b/lib/types/types_core.mli
@@ -128,6 +128,14 @@ type task_contract =
   ; required_evidence : string list [@default []]
   ; inspect_gate_evidence : string list [@default []]
   ; verify_gate_evidence : string list [@default []]
+  ; evidence_claims : Evidence_claim.t list [@default []]
+        (* RFC-0199 Phase B: typed deterministic completion criteria the
+           harness can check without verifier judgment. Declared by the task
+           author (masc_add_task contract arg), evaluated by
+           Deterministic_evidence_evaluator. Re-introduced with producer +
+           consumer wired (unlike the fan-in-0 required_evidence_typed removed
+           2026-06-03); legacy required_evidence strings are NOT auto-parsed
+           into claims (that would be a substring classifier). *)
   ; stale_claim_timeout_sec : int [@default 0]
   ; links : task_execution_links
         [@default { operation_id = None; session_id = None }]

--- a/lib/workspace/workspace_task_classify.ml
+++ b/lib/workspace/workspace_task_classify.ml
@@ -191,6 +191,7 @@ let empty_task_contract =
   ; required_evidence = []
   ; inspect_gate_evidence = []
   ; verify_gate_evidence = []
+  ; evidence_claims = []
   ; stale_claim_timeout_sec = 0
   ; links = { operation_id = None; session_id = None }
   }

--- a/test/dune
+++ b/test/dune
@@ -764,6 +764,7 @@
   test_keeper_prompt_external
   test_keeper_recurring
   test_evidence_claim_schema
+  test_deterministic_evidence_evaluator
   test_verification_fsm
   test_governance_yojson_roundtrip
   test_eval_calibration
@@ -942,6 +943,7 @@
   test_keeper_prompt_external
   test_keeper_recurring
   test_evidence_claim_schema
+  test_deterministic_evidence_evaluator
   test_verification_fsm
   test_governance_yojson_roundtrip
   test_eval_calibration

--- a/test/test_cdal_evidence_gate.ml
+++ b/test/test_cdal_evidence_gate.ml
@@ -47,6 +47,7 @@ let make_contract
   ; required_evidence
   ; inspect_gate_evidence
   ; verify_gate_evidence
+  ; evidence_claims = []
   ; stale_claim_timeout_sec = 0
   ; links = { operation_id = None; session_id = None }
   }

--- a/test/test_deterministic_evidence_evaluator.ml
+++ b/test/test_deterministic_evidence_evaluator.ml
@@ -1,0 +1,127 @@
+(** RFC-0199 Phase B — Deterministic_evidence_evaluator unit tests.
+
+    Pure evaluator: every probe is a stub, so these tests assert the
+    branch logic (Satisfied / Unsatisfied / Indeterminate) without real I/O.
+    Key invariants under test:
+    - Unknown is never permissive: a [None] probe answer -> Indeterminate,
+      never Satisfied.
+    - [eval_all []] is never vacuously Satisfied (no claims -> no auto-complete).
+    - Satisfied requires every claim Satisfied over a non-empty list.
+    - Indeterminate dominates Unsatisfied in [eval_all]. *)
+
+module E = Evidence_claim
+module Ev = Deterministic_evidence_evaluator
+
+(* A probe where every world query is "unknown" (None) / absent. Tests
+   override only the fields they exercise. *)
+let blank_probe : Ev.probe =
+  { file_bytes = (fun _ -> None)
+  ; command_exit = (fun _ -> None)
+  ; pr_merged = (fun ~repo:_ ~pr:_ -> None)
+  ; ci_passed = (fun ~repo:_ ~pr:_ -> None)
+  ; custom_check = (fun ~id:_ ~payload:_ -> None)
+  }
+
+let is_satisfied = function Ev.Satisfied -> true | _ -> false
+let is_unsat = function Ev.Unsatisfied _ -> true | _ -> false
+let is_indet = function Ev.Indeterminate _ -> true | _ -> false
+
+let check_outcome name pred outcome =
+  Alcotest.(check bool) (name ^ " — got " ^ Ev.outcome_to_string outcome) true (pred outcome)
+
+let artifact path = E.Artifact_exists { path; min_bytes = None }
+let artifact_min path n = E.Artifact_exists { path; min_bytes = Some n }
+
+let test_artifact_present () =
+  let probe = { blank_probe with file_bytes = (fun _ -> Some 42) } in
+  check_outcome "present artifact satisfies" is_satisfied
+    (Ev.eval_claim probe (artifact ".masc/voice_config.json"))
+
+let test_artifact_absent () =
+  check_outcome "absent artifact unsatisfied (definite no)" is_unsat
+    (Ev.eval_claim blank_probe (artifact ".masc/voice_config.json"))
+
+let test_artifact_too_small () =
+  let probe = { blank_probe with file_bytes = (fun _ -> Some 5) } in
+  check_outcome "artifact below min_bytes unsatisfied" is_unsat
+    (Ev.eval_claim probe (artifact_min "x" 100))
+
+let test_artifact_min_met () =
+  let probe = { blank_probe with file_bytes = (fun _ -> Some 200) } in
+  check_outcome "artifact at/over min_bytes satisfied" is_satisfied
+    (Ev.eval_claim probe (artifact_min "x" 100))
+
+let test_tests_pass_exit_match () =
+  let probe = { blank_probe with command_exit = (fun _ -> Some 0) } in
+  check_outcome "command exit matches -> satisfied" is_satisfied
+    (Ev.eval_claim probe (E.Tests_pass { command = "dune build"; expected_exit = 0 }))
+
+let test_tests_pass_exit_mismatch () =
+  let probe = { blank_probe with command_exit = (fun _ -> Some 1) } in
+  check_outcome "command exit mismatch -> unsatisfied" is_unsat
+    (Ev.eval_claim probe (E.Tests_pass { command = "dune build"; expected_exit = 0 }))
+
+let test_tests_pass_cannot_run () =
+  (* blank_probe.command_exit returns None = could not run *)
+  check_outcome "command could not run -> indeterminate (not a false no)" is_indet
+    (Ev.eval_claim blank_probe (E.Tests_pass { command = "dune build"; expected_exit = 0 }))
+
+let test_unknown_never_permissive () =
+  (* every blank probe answer is None; no claim may come back Satisfied *)
+  let claims =
+    [ E.PR_merged { repo = "masc"; pr_number = 1 }
+    ; E.CI_pass { repo = "masc"; pr_number = 1 }
+    ; E.Custom_check { id = "x"; payload = `Null }
+    ]
+  in
+  List.iter
+    (fun c ->
+      check_outcome "unknown probe -> not satisfied" (fun o -> not (is_satisfied o))
+        (Ev.eval_claim blank_probe c))
+    claims
+
+let test_eval_all_empty_not_satisfied () =
+  check_outcome "empty claim list is never vacuously satisfied" is_unsat
+    (Ev.eval_all blank_probe [])
+
+let test_eval_all_all_satisfied () =
+  let probe = { blank_probe with file_bytes = (fun _ -> Some 10) } in
+  check_outcome "all claims satisfied -> Satisfied" is_satisfied
+    (Ev.eval_all probe [ artifact "a"; artifact "b" ])
+
+let test_eval_all_one_absent () =
+  (* a present, b absent *)
+  let probe =
+    { blank_probe with file_bytes = (fun p -> if String.equal p "a" then Some 10 else None) }
+  in
+  check_outcome "one absent -> Unsatisfied" is_unsat
+    (Ev.eval_all probe [ artifact "a"; artifact "b" ])
+
+let test_eval_all_indeterminate_dominates () =
+  (* one definite Unsatisfied (absent file) + one Indeterminate (cannot run) *)
+  let probe = { blank_probe with file_bytes = (fun _ -> None) } in
+  check_outcome "indeterminate dominates unsatisfied" is_indet
+    (Ev.eval_all probe
+       [ E.Tests_pass { command = "x"; expected_exit = 0 } (* indeterminate *)
+       ; artifact "absent" (* unsatisfied *)
+       ])
+
+let () =
+  Alcotest.run "deterministic_evidence_evaluator"
+    [ ( "eval_claim",
+        [ Alcotest.test_case "artifact present" `Quick test_artifact_present
+        ; Alcotest.test_case "artifact absent" `Quick test_artifact_absent
+        ; Alcotest.test_case "artifact too small" `Quick test_artifact_too_small
+        ; Alcotest.test_case "artifact min met" `Quick test_artifact_min_met
+        ; Alcotest.test_case "tests_pass exit match" `Quick test_tests_pass_exit_match
+        ; Alcotest.test_case "tests_pass exit mismatch" `Quick test_tests_pass_exit_mismatch
+        ; Alcotest.test_case "tests_pass cannot run" `Quick test_tests_pass_cannot_run
+        ; Alcotest.test_case "unknown never permissive" `Quick test_unknown_never_permissive
+        ] )
+    ; ( "eval_all",
+        [ Alcotest.test_case "empty not satisfied" `Quick test_eval_all_empty_not_satisfied
+        ; Alcotest.test_case "all satisfied" `Quick test_eval_all_all_satisfied
+        ; Alcotest.test_case "one absent" `Quick test_eval_all_one_absent
+        ; Alcotest.test_case "indeterminate dominates" `Quick test_eval_all_indeterminate_dominates
+        ] )
+    ]

--- a/test/test_mcp_server_eio_call_tool.ml
+++ b/test/test_mcp_server_eio_call_tool.ml
@@ -67,6 +67,7 @@ let empty_contract : Masc_domain.task_contract =
     required_evidence = [];
     inspect_gate_evidence = [];
     verify_gate_evidence = [];
+    ; evidence_claims = []
     stale_claim_timeout_sec = 0;
     links =
       {

--- a/test/test_task_completion_path_10449.ml
+++ b/test/test_task_completion_path_10449.ml
@@ -20,6 +20,7 @@ let empty_contract : T.task_contract = {
   required_evidence = [];
   inspect_gate_evidence = [];
   verify_gate_evidence = [];
+  ; evidence_claims = []
   stale_claim_timeout_sec = 0;
   links = empty_links;
 }

--- a/test/test_verification_fsm.ml
+++ b/test/test_verification_fsm.ml
@@ -64,6 +64,7 @@ let add_strict_task config =
     required_evidence = [];
     inspect_gate_evidence = [];
     verify_gate_evidence = ["output.json"];
+    ; evidence_claims = []
     stale_claim_timeout_sec = 0;
     links = { operation_id = None; session_id = None };
   } in
@@ -89,6 +90,7 @@ let add_required_evidence_only_task config =
     required_evidence = ["artifact://coverage.json"];
     inspect_gate_evidence = [];
     verify_gate_evidence = [];
+    ; evidence_claims = []
     stale_claim_timeout_sec = 0;
     links = { operation_id = None; session_id = None };
   } in
@@ -116,6 +118,7 @@ let add_placeholder_evidence_task config =
     required_evidence = ["completion_notes"];
     inspect_gate_evidence = [];
     verify_gate_evidence = ["reviewable_evidence_ref"];
+    ; evidence_claims = []
     stale_claim_timeout_sec = 0;
     links = { operation_id = None; session_id = None };
   } in

--- a/test/test_workspace_task_verification_phase_e.ml
+++ b/test/test_workspace_task_verification_phase_e.ml
@@ -60,6 +60,7 @@ let test_contracted_task_includes_contract_refs () =
     ; required_evidence = [ "test_keeper_lifecycle PASS" ]
     ; inspect_gate_evidence = []
     ; verify_gate_evidence = [ "PR #18810 merged" ]
+    ; evidence_claims = []
     ; stale_claim_timeout_sec = 0
     ; links = { operation_id = None; session_id = None }
     }


### PR DESCRIPTION
## ⚠️ Draft / WIP — 단독 머지 금지

이 PR은 RFC-0199 **Phase B의 검증된 핵심**(typed 필드 + evaluator + 테스트)만 담습니다. **완료 wiring(consumer 호출)이 아직 없어 production fan-in = 0** 입니다. 이 상태로 머지하면 RFC-0199 Phase A의 `required_evidence_typed`가 2026-06-03 제거된 것과 **동일한 fan-in-0 dead code**가 됩니다. wiring PR과 함께(또는 그 전에) 머지하지 마세요.

## 무엇 / 왜

keeper가 task를 claim만 하고 완료에 도달 못 하는 churn(task-676 cyc50, task-681 cyc12; never_attempt)의 **구조적(하네스) 해법**. owner 요청: "프롬프트 강화 말고 하네스, 괴상한 substring 매치 금지."

구현 중 발견: 제안하려던 typed acceptance criterion은 **이미 존재**합니다 — `lib/types/evidence_claim.ml`의 `Evidence_claim.t`(RFC-0199 Phase A). 그래서 새 타입을 만들지 않고 **RFC-0199 Phase B(미구현 `Deterministic_evidence_evaluator`)를 구현**합니다.

## 변경 (검증된 핵심)

- **Producer**: `task_contract.evidence_claims : Evidence_claim.t list [@default []]` (types_core). task 작성자가 `masc_add_task` contract 인자로 선언 → 기존 `task_contract_of_yojson`가 자동 파싱. **legacy `required_evidence` string을 substring 파싱하지 않음**(그건 RFC-0088 string 분류기 안티패턴 = owner 금지 사항).
- **Consumer**: `lib/types/deterministic_evidence_evaluator.ml` — 순수, probe 주입(file stat / command exit / forge state), closed sum exhaustive. **Unknown은 비permissive**(`None`→`Indeterminate`, 절대 `Satisfied` 아님). `eval_all []`은 vacuous Satisfied 아님(claim 없으면 auto-complete 안 함).
- 8개 `task_contract` literal 생성 사이트에 `evidence_claims = []` 추가.
- `test/test_deterministic_evidence_evaluator.ml` — **12 테스트** (eval_claim 전 분기 + eval_all 우선순위).

## 로컬 검증

- `dune build lib` EXIT=0 (전체 lib green)
- `test_deterministic_evidence_evaluator.exe` — **12/12 PASS**
- fragile-match ratchet(-w+4)이 초기 `_ ->` catch-all 잡음 → exhaustive로 교정(매니페스토 원칙 정합)

## 남은 작업 (이 PR 이후, 머지 전 필수)

- **완료 wiring**: keeper-turn 레이어(Eio+sandbox I/O 보유)에서 claimed task의 `evidence_claims`를 평가 → `Satisfied`면 측정값을 evidence로 Done 구동(§7.1 harness→Done 직행; §7.2 claim-time/turn-boundary). probe 실 I/O 구성(file_bytes=Eio fs, command_exit=Shell-IR)이 핵심. 이게 production fan-in을 만들어 mergeable해짐.
- **RFC-0222 reframe**: RFC-0222(머지됨)는 이 `Evidence_claim`을 미인용·재발명 → RFC-0199 Phase B 구현으로 reframe/supersede 필요(split-brain 해소).
- subjective task(task-676)는 `Manual_review`(빈 claim)로 미커버 — 별개.

## 비범위

`Evidence_claim.t` 스키마는 변경 없음(RFC-0199 Phase A 그대로). 라이브 완료 경로(claim/transition) 미변경 — wiring PR에서.

RFC-WAIVED: RFC-0199 Phase B 구현이며 변경 영역(lib/types, lib/workspace/workspace_task_classify, test)이 credential/operator/sandbox/hooks/workflow 등 RFC-gated subsystem 미해당.

WORKAROUND-WAIVED: 본문이 'substring 분류기'/'fan-in' 등을 언급하나 모두 **회피·금지 대상으로 인용**(이 PR은 그 안티패턴을 제거하는 typed 구현). 실제 워크어라운드 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
