### PR TITLE
fix(dashboard): bound default n for /telemetry to stop keeper-fleet freeze

### DIFF
--- a/lib/server/server_routes_http_routes_dashboard_setup.ml
+++ b/lib/server/server_routes_http_routes_dashboard_setup.ml
@@ -54,6 +54,34 @@ let handle_dashboard_link_previews = Server_routes_http_dashboard_handlers.handl
 let handle_dashboard_task_history = Server_routes_http_dashboard_handlers.handle_dashboard_task_history
 let handle_dashboard_workspace = Server_routes_http_dashboard_handlers.handle_dashboard_workspace
 
+(* Default page sizes for /api/v1/dashboard/telemetry when the client
+   omits [n]. A windowed request (since_ms/until_ms) previously defaulted
+   to n=0 (unbounded): a single Observatory poll
+   ([observatory.ts] fetchTelemetry with since_ms/until_ms and no n) then
+   Yojson-parsed up to the telemetry read clamp (50k, #20659) entries per
+   source across all sources — enough to peg the single Eio domain on a
+   non-yielding parse and freeze the keeper fleet. Bound the DEFAULT here;
+   an explicit n=0 still honours the all-in-window contract from #20659. *)
+let default_telemetry_limit = 100
+let default_windowed_telemetry_limit = 2000
+
+(* Resolve the effective entry limit for /api/v1/dashboard/telemetry.
+   Absent or unparseable [n_param] falls back to a bounded default
+   (windowed: [default_windowed_telemetry_limit], else
+   [default_telemetry_limit]) so no request defaults to an unbounded read.
+   An explicit n=0 parses to [Some 0] and is preserved (all-in-window,
+   clamped downstream by #20659). Pure + exposed so the freeze guard
+   (no permissive 0 default) is unit-testable. *)
+let resolve_telemetry_n ~has_time_window ~(n_param : string option) =
+  let default_n =
+    if has_time_window
+    then default_windowed_telemetry_limit
+    else default_telemetry_limit
+  in
+  match n_param with
+  | Some raw -> Option.value ~default:default_n (int_of_string_opt raw) |> max 0
+  | None -> default_n
+
 (* Telemetry unified view handler — extracted from add_routes pipeline
    as part of godfile near-threshold split. *)
 let handle_telemetry request reqd =
@@ -78,12 +106,8 @@ let handle_telemetry request reqd =
     in
     let has_time_window = Option.is_some since_ts || Option.is_some until_ts in
     let n =
-      match Server_utils.query_param req "n" with
-      | Some raw ->
-        Option.value ~default:(if has_time_window then 0 else 100)
-          (int_of_string_opt raw)
-        |> max 0
-      | None -> if has_time_window then 0 else 100
+      resolve_telemetry_n ~has_time_window
+        ~n_param:(Server_utils.query_param req "n")
     in
     let offset =
       match Server_utils.query_param req "offset" with

--- a/lib/server/server_routes_http_routes_dashboard_setup.mli
+++ b/lib/server/server_routes_http_routes_dashboard_setup.mli
@@ -20,6 +20,11 @@ val trimmed_query_param : Httpun.Request.t -> string -> string option
 val oas_telemetry_limit_param : Httpun.Request.t -> int
 val oas_telemetry_provider_param : Httpun.Request.t -> string option
 
+(** Effective entry limit for /api/v1/dashboard/telemetry. Absent or
+    unparseable [n_param] -> bounded default (windowed vs not); explicit
+    n=0 preserved. Exposed for the freeze-guard test. *)
+val resolve_telemetry_n : has_time_window:bool -> n_param:string option -> int
+
 val dashboard_dev_token_path : string -> string
 val ensure_dashboard_dev_token : string -> (string, string) result
 

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -1090,6 +1090,31 @@ let test_project_snapshot_wire_returns_snapshot_when_populated () =
      Re.execp re header);
   Dashboard_snapshot.reset_for_test ()
 
+(* Freeze guard: /api/v1/dashboard/telemetry must never default to an
+   unbounded read. Observatory polls with since_ms/until_ms and no [n];
+   before this fix the windowed default was n=0 (unbounded), letting one
+   poll Yojson-parse up to the read clamp (#20659: 50k) per source across
+   all sources and peg the single Eio domain -> keeper-fleet freeze. *)
+let test_telemetry_n_default_is_bounded () =
+  let resolve = Server_routes_http_routes_dashboard_setup.resolve_telemetry_n in
+  Alcotest.(check int)
+    "windowed + no n -> bounded default, never 0"
+    2000 (resolve ~has_time_window:true ~n_param:None);
+  Alcotest.(check int)
+    "no window + no n -> small default"
+    100 (resolve ~has_time_window:false ~n_param:None);
+  Alcotest.(check int)
+    "unparseable n -> bounded default, never 0"
+    2000 (resolve ~has_time_window:true ~n_param:(Some "garbage"));
+  (* #20659 all-in-window contract: explicit n=0 is honoured (clamped
+     downstream), so an operator can still request the full window. *)
+  Alcotest.(check int)
+    "explicit n=0 preserved"
+    0 (resolve ~has_time_window:true ~n_param:(Some "0"));
+  Alcotest.(check int)
+    "explicit positive n honoured"
+    500 (resolve ~has_time_window:true ~n_param:(Some "500"))
+
 let () =
   run "dashboard_http_core"
     [
@@ -1161,5 +1186,7 @@ let () =
             test_telemetry_summary_snapshot_wire_falls_back_when_empty;
           test_case "RFC-0138 project-snapshot wire returns snapshot when populated" `Quick
             test_project_snapshot_wire_returns_snapshot_when_populated;
+          test_case "telemetry n default is bounded (freeze guard)" `Quick
+            test_telemetry_n_default_is_bounded;
         ] );
     ]


### PR DESCRIPTION
## 문제

keeper fleet가 주기적으로 freeze → supervisor 재시작을 반복(오실레이션)했습니다. 원인은 단일 Eio 도메인이 Yojson 파싱에 점유되어 keeper fiber와 idle 타이머가 starvation되는 것입니다.

## 근본 원인 — Unknown→Permissive Default

`/api/v1/dashboard/telemetry` 핸들러는 time-window 요청에서 `n` 쿼리 파라미터가 없으면 기본값 `n=0`(무제한)을 사용했습니다. Observatory 대시보드 패널(`dashboard/src/components/observatory/observatory.ts`)이 `since_ms`/`until_ms`만 보내고 `n`을 생략하므로, 한 번의 폴이 `all_sources × (telemetry read clamp 50k, #20659)` entries를 Yojson 파싱 → 도메인 pegging.

sample(PID 13600, #20659 배포본)에서 spin이 `camlTelemetry_unified`(`fun_2583` + `extract_ts` + `try_numeric_field`)에 잔존함을 확인했습니다. `#20659`가 읽기를 50k로 clamp했으나 그 cap이 여전히 도메인을 점유할 만큼 컸습니다. 본 PR은 트리거 자체(요청 시점의 무제한 기본값)를 제거합니다.

## 변경

- `resolve_telemetry_n` 순수 함수 추출: `n` 부재/파싱불가 시 bounded default(windowed `2000`, 그 외 `100`)로 폴백. **explicit `n=0`은 보존**(all-in-window contract, #20659 — `int_of_string_opt "0" = Some 0`).
- `handle_telemetry`가 이 함수를 사용.
- drift-guard 테스트(`test_dashboard_http_core`): windowed+no-n이 0이 아닌 bounded여야 함 + explicit n=0 보존 검증.

## 검증

- `dune build --root . @check` + default target(`lib/server/`): green.
- `test_dashboard_http_core`: 신규 테스트 `telemetry n default is bounded (freeze guard)` PASS.
- baseline 대조: origin/main `7 fail / 33 run` → 본 PR `7 fail / 34 run`. **신규 실패 0** (기존 7건은 `Eio_context.set_env not called`(RFC-0107)·neo4j 미연결 등 환경/부트스트랩 의존 실패로, telemetry-n과 무관).

## 관계 / 범위

- `#20659`(telemetry_unified read-layer clamp)를 보완합니다. `telemetry_unified.ml`은 미변경이라 충돌 없습니다.
- 이 PR은 dashboard `/telemetry` 트리거만 닫습니다. 남은 unbounded 호출자(`audit_log.ml:614`, `Trajectory.read_all_lines`, `tool_usage_log.ml`)와 스토어 rotate/prune은 별도 follow-up입니다.
- 배포(rebuild + restart) 후 dashboard `/telemetry` curl 재측정으로 오실레이션 종료를 확인해야 합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
