### PR TITLE
fix(test): repair botched evidence_claims literal insertion (broken main from #20661)

### DIFF
--- a/test/test_mcp_server_eio_call_tool.ml
+++ b/test/test_mcp_server_eio_call_tool.ml
@@ -67,7 +67,7 @@ let empty_contract : Masc_domain.task_contract =
     required_evidence = [];
     inspect_gate_evidence = [];
     verify_gate_evidence = [];
-    ; evidence_claims = []
+    evidence_claims = [];
     stale_claim_timeout_sec = 0;
     links =
       {

--- a/test/test_task_completion_path_10449.ml
+++ b/test/test_task_completion_path_10449.ml
@@ -20,7 +20,7 @@ let empty_contract : T.task_contract = {
   required_evidence = [];
   inspect_gate_evidence = [];
   verify_gate_evidence = [];
-  ; evidence_claims = []
+  evidence_claims = [];
   stale_claim_timeout_sec = 0;
   links = empty_links;
 }

--- a/test/test_verification_fsm.ml
+++ b/test/test_verification_fsm.ml
@@ -64,7 +64,7 @@ let add_strict_task config =
     required_evidence = [];
     inspect_gate_evidence = [];
     verify_gate_evidence = ["output.json"];
-    ; evidence_claims = []
+    evidence_claims = [];
     stale_claim_timeout_sec = 0;
     links = { operation_id = None; session_id = None };
   } in
@@ -90,7 +90,7 @@ let add_required_evidence_only_task config =
     required_evidence = ["artifact://coverage.json"];
     inspect_gate_evidence = [];
     verify_gate_evidence = [];
-    ; evidence_claims = []
+    evidence_claims = [];
     stale_claim_timeout_sec = 0;
     links = { operation_id = None; session_id = None };
   } in
@@ -118,7 +118,7 @@ let add_placeholder_evidence_task config =
     required_evidence = ["completion_notes"];
     inspect_gate_evidence = [];
     verify_gate_evidence = ["reviewable_evidence_ref"];
-    ; evidence_claims = []
+    evidence_claims = [];
     stale_claim_timeout_sec = 0;
     links = { operation_id = None; session_id = None };
   } in


### PR DESCRIPTION
## 문제 (broken main)

`dune build .`(default target)가 3개 test 파일에서 `Syntax error: } expected`로 실패합니다. main이 깨진 상태입니다.

## 근본 원인

`#20661`(e28d18a, RFC-0199 Phase B evidence_claims)의 codemod가 **trailing-semicolon 스타일** 레코드 리터럴에 **leading-semicolon 템플릿**(`  ; evidence_claims = []`)을 삽입 → 직전 필드의 `;`와 합쳐져 이중 `;` + `evidence_claims` 뒤 `;` 누락:

```
  verify_gate_evidence = [];
  ; evidence_claims = []      ← stray 앞 ';' + 뒤 ';' 없음
  stale_claim_timeout_sec = 0;
```

## 변경

trailing-semicolon 스타일로 깨진 5개 리터럴을 `evidence_claims = [];`로 수정:
- `test_task_completion_path_10449.ml`
- `test_mcp_server_eio_call_tool.ml`
- `test_verification_fsm.ml` (×3)

**leading-semicolon 스타일 리터럴**(`test_cdal_evidence_gate.ml`, `test_workspace_task_verification_phase_e.ml`, `lib/workspace/workspace_task_classify.ml`)은 이미 유효(컴파일됨)하여 **미변경**.

## 검증

- `dune build --root . .`(default target, 사용자가 실패한 그 명령) **green**.

CI Build&Test가 `#20661` 머지 시 이 syntax error를 잡지 못한 점(gate-skip 추정)은 별도 추적 가치가 있습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)