### PR TITLE
feat(keeper): wire RFC-0199 Phase B evidence harness into claim path (completes #20661)

### DIFF
--- a/lib/keeper/keeper_deterministic_evidence_probe.ml
+++ b/lib/keeper/keeper_deterministic_evidence_probe.ml
@@ -1,0 +1,30 @@
+(* RFC-0199 Phase B — see .mli. Adapts the keeper sandbox file system into a
+   Deterministic_evidence_evaluator.probe and reuses the (tested) pure
+   evaluator. Only file_bytes is backed by real I/O in v1; the other probe
+   functions return None (Indeterminate) so their claim kinds never
+   auto-complete until wired. *)
+
+let make_probe ~(config : Workspace.config)
+    ~(meta : Keeper_meta_contract.keeper_meta) :
+    Deterministic_evidence_evaluator.probe =
+  let file_bytes raw_path =
+    match
+      Keeper_tool_shared_runtime.resolve_keeper_read_path ~config ~meta ~raw_path
+    with
+    | Error _ -> None
+    | Ok abs_path -> Fs_compat.file_size abs_path
+  in
+  { Deterministic_evidence_evaluator.file_bytes
+  ; command_exit = (fun _ -> None)
+  ; pr_merged = (fun ~repo:_ ~pr:_ -> None)
+  ; ci_passed = (fun ~repo:_ ~pr:_ -> None)
+  ; custom_check = (fun ~id:_ ~payload:_ -> None)
+  }
+
+let all_satisfied ~config ~meta claims =
+  match
+    Deterministic_evidence_evaluator.eval_all (make_probe ~config ~meta) claims
+  with
+  | Deterministic_evidence_evaluator.Satisfied -> true
+  | Deterministic_evidence_evaluator.Unsatisfied _
+  | Deterministic_evidence_evaluator.Indeterminate _ -> false

--- a/lib/keeper/keeper_deterministic_evidence_probe.mli
+++ b/lib/keeper/keeper_deterministic_evidence_probe.mli
@@ -1,0 +1,23 @@
+(** RFC-0199 Phase B — keeper-side probe adapter.
+
+    Runs {!Deterministic_evidence_evaluator} against a claimed task's typed
+    [task_contract.evidence_claims] using the keeper sandbox file system as
+    the probe. This is the production consumer that gives the typed field a
+    non-zero fan-in (the Phase A [required_evidence_typed] field was removed
+    for fan-in 0; this re-introduction ships with a real consumer).
+
+    v1 supports file-existence claims ([Artifact_exists] / [File_changed]);
+    other claim kinds ([Tests_pass], [PR_merged], [CI_pass], [Custom_check])
+    resolve to [None] -> [Indeterminate] (never auto-complete) until their
+    probes (Shell-IR command runner, forge queries) are wired. *)
+
+val all_satisfied :
+     config:Workspace.config
+  -> meta:Keeper_meta_contract.keeper_meta
+  -> Evidence_claim.t list
+  -> bool
+(** [true] iff the NON-EMPTY claim list evaluates to [Satisfied] under a probe
+    backed by the keeper's sandbox-resolved file system. An empty list and any
+    [Unknown]/[Indeterminate] claim yield [false] — Unknown is never
+    permissive, so a task is auto-completed only when every declared claim is
+    a definite, measured "yes". *)

--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -555,6 +555,7 @@ let handle_keeper_task_tool
     in
     let wip_rejections = List.rev !wip_rejections in
     let auto_started_ok = ref false in
+    let harness_completed = ref false in
     (match result with
      | Workspace.Claim_next_claimed { task_id; _ } ->
        sync_keeper_meta_current_task ~config ~meta ~task_id;
@@ -581,7 +582,45 @@ let handle_keeper_task_tool
          in
          auto_started_ok := Tool_result.is_success start_result
        end else
-         auto_started_ok := true
+         auto_started_ok := true;
+       (* RFC-0199 Phase B: deterministic evidence harness. When the claimed
+          task declares typed [evidence_claims] and all are satisfied by a file
+          probe, complete it immediately — no LLM turn. Uses [force_done_task_r]
+          so a deterministic check does not route through the non-deterministic
+          anti-rationalization gate (force_done is the existing keeper-Done
+          path; Done_action is exempt from the CDAL substring gate). Guarded to
+          Claimed/InProgress so it never hits the AwaitingVerification
+          Invalid_transition; idempotent if another agent reached Done first. *)
+       (match
+          Workspace.get_tasks_raw config
+          |> List.find_opt (fun (t : Masc_domain.task) ->
+                 String.equal t.id task_id)
+        with
+        | Some
+            { contract = Some { evidence_claims = _ :: _ as claims; _ }
+            ; task_status = (Masc_domain.Claimed _ | Masc_domain.InProgress _)
+            ; _
+            }
+          when Keeper_deterministic_evidence_probe.all_satisfied ~config ~meta
+                 claims ->
+          let summary =
+            claims
+            |> List.map Evidence_claim.to_human_string
+            |> String.concat "; "
+          in
+          let notes =
+            Printf.sprintf
+              "RFC-0199 deterministic harness: %d evidence claim(s) satisfied \
+               [%s]"
+              (List.length claims) summary
+          in
+          (match
+             Workspace.force_done_task_r config
+               ~agent_name:(keeper_agent_sender ~meta) ~task_id ~notes ()
+           with
+           | Ok _ -> harness_completed := true
+           | Error _ -> ())
+        | _ -> ())
      | Workspace.Claim_next_no_unclaimed
      | Workspace.Claim_next_no_eligible _
      | Workspace.Claim_next_error _ -> ());
@@ -598,7 +637,12 @@ let handle_keeper_task_tool
     let message =
       match result with
       | Workspace.Claim_next_claimed { message; _ } ->
-          if !auto_started_ok then message ^ " Task auto-started — begin work now."
+          if !harness_completed then
+            message
+            ^ " Task completed immediately — all declared evidence claims were \
+               already satisfied (no work needed)."
+          else if !auto_started_ok then
+            message ^ " Task auto-started — begin work now."
           else message
       | Workspace.Claim_next_no_unclaimed -> "No unclaimed tasks. ACTION: Stop task-checking — nothing to claim."
       | Workspace.Claim_next_no_eligible


### PR DESCRIPTION
## 무엇

#20661에서 머지된 RFC-0199 Phase B **core**(typed `evidence_claims` 필드 + `Deterministic_evidence_evaluator`)에 **production consumer를 배선**해 체인을 완성합니다. #20661 단독으로는 consumer가 없어 fan-in 0(2026-06-03 제거된 `required_evidence_typed`와 동일 상태)이었습니다 — 이 PR이 그 갭을 닫습니다.

> 경위: #20661이 Draft였으나 wiring을 push하기 전 auto-merge됨(브랜치 삭제). 이 PR은 fresh branch에서 wiring만 올립니다. #20661의 깨진 test literal은 #20663이 이미 수정.

## 변경

- **`lib/keeper/keeper_deterministic_evidence_probe.ml`**: keeper sandbox FS(`resolve_keeper_read_path` + `Fs_compat.file_size`)를 `Deterministic_evidence_evaluator.probe`로 어댑트 — 머지된 순수 evaluator 재사용. v1은 `file_bytes`만 실 I/O; `Tests_pass`/`PR_merged`/`CI_pass`/`Custom_check`는 `None`(Indeterminate)이라 wiring 전까지 auto-complete 안 함.
- **`lib/keeper/keeper_tool_task_runtime.ml`**: keeper가 task를 claim+auto-start한 직후, `evidence_claims`를 평가 → 비어있지 않고 전부 `Satisfied`면 `force_done_task_r`로 **즉시 완료(LLM 턴 0)**. stale "create X" churn 해소(task-681: artifact 이미 존재 → claim 즉시 Done, oscillation 제거).

## 설계 포인트

- **결정론 유지**: `handle_transition`이 아니라 `force_done_task_r` 사용 — 비결정론적 anti-rationalization LLM gate를 우회. harness가 LLM 판단에 의존하면 typed 검증의 목적이 무너짐.
- **안전 가드**: Claimed/InProgress만 발화(AwaitingVerification `Invalid_transition` 회피), Done에 idempotent. Done_action은 CDAL substring gate 면제(tool_task.ml:288-298), `persisted_contract_rejection`은 no-op.
- 청사진은 file:line으로 트리 대조 검증(force_done_task_r, FSM decide Done_action, resolve_keeper_read_path, Fs_compat.file_size).

## 검증

- 전체 masc lib green (현재 main 위에서).
- evaluator 12 unit (main에 머지됨), 수정된 completion 테스트(cdal/verification_fsm/task_completion/evidence_claim_schema) green.

## 남은 권고 (후속)

- **end-to-end 통합 테스트**: task+Artifact_exists(파일 존재) → claim → auto-Done 을 keeper-context로 검증(현재는 evaluator unit + build + 청사진 검증까지). keeper-context 스캐폴딩이 필요해 별도.
- **Tests_pass wiring**: `command_exit`를 Shell-IR runner로 배선(v1은 file-probe만).
- **RFC-0222 reframe**: RFC-0199 Phase B 구현으로 cross-ref/supersede(현재 `Evidence_claim` 미인용 재발명 = split-brain).

RFC-WAIVED: RFC-0199 Phase B 구현. 변경 영역(lib/keeper/keeper_tool_task_runtime, 신규 probe)이 credential/keeper_sandbox*/keeper_shell_*/operator/hooks/workflow 등 RFC-gated subsystem 미해당.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
