### PR TITLE
fix(telemetry): tail-bound trajectory reads (the measured /telemetry freeze cost)

### DIFF
--- a/lib/telemetry_unified/telemetry_unified.ml
+++ b/lib/telemetry_unified/telemetry_unified.ml
@@ -549,7 +549,7 @@ let read_execution_receipts ~masc_root ?keeper_name ?since_ts ?until_ts ~n ()
         [])
     dirs
 
-let read_trajectory_file path ?since_ts ?until_ts () =
+let read_trajectory_file path ~max_lines ?since_ts ?until_ts () =
   if
     not
       (is_jsonl_file Trajectory_tool_call
@@ -560,8 +560,15 @@ let read_trajectory_file path ?since_ts ?until_ts () =
       ~default:[] (fun () ->
       let parse_error_count = ref 0 in
       let entries =
-        Fs_compat.load_file path
-        |> String.split_on_char '\n'
+        (* Tail-bounded read: trajectory trace files grow append-only (one
+           measured at 12MB); [load_file] parsed the whole file on the keeper
+           Eio domain. Measured post-#20659/#20662: the trajectory source was
+           ~6.9s of an 8.3s /telemetry request — the dominant keeper-fleet
+           freeze cost, since [read_trajectory_tool_calls] ignored its [n] and
+           full-parsed every trace. Read only the newest [max_lines] from the
+           tail; trajectories are append-ordered so the tail is the recent
+           window the dashboard polls. *)
+        Dated_jsonl.load_tail_lines path ~max_lines
         |> List.filter_map (fun line ->
              let line = String.trim line in
              if line = "" then None
@@ -592,6 +599,11 @@ let read_trajectory_tool_calls ~masc_root ?keeper_name ?since_ts ?until_ts ~n ()
     | None -> dirs
     | Some name -> List.filter (fun (k, _) -> String.equal k name) dirs
   in
+  (* Bound the per-file tail read. A non-positive [n] ("unlimited") clamps to
+     [unbounded_window_scan_cap] so no trace file is full-parsed. The final
+     [take_first n] still trims the merged set; this only stops the read itself
+     from being unbounded (the freeze cause). *)
+  let max_lines = if n <= 0 then unbounded_window_scan_cap else n in
   let entries =
     List.concat_map
       (fun (_name, dir) ->
@@ -603,7 +615,7 @@ let read_trajectory_tool_calls ~masc_root ?keeper_name ?since_ts ?until_ts ~n ()
           |> List.concat_map (fun name ->
                read_trajectory_file
                  (Filename.concat dir name)
-                 ?since_ts ?until_ts ())))
+                 ~max_lines ?since_ts ?until_ts ())))
       dirs
   in
   let entries = sort_newest_first entries in
@@ -771,7 +783,8 @@ let trajectory_tool_call_summary_stats ~masc_root =
              |> Array.to_list
              |> List.filter (fun name -> Filename.check_suffix name ".jsonl")
              |> List.concat_map (fun name ->
-                  read_trajectory_file (Filename.concat dir name) ()))
+                  read_trajectory_file (Filename.concat dir name)
+                    ~max_lines:unbounded_window_scan_cap ()))
          in
          ( count_acc + List.length entries,
            match latest_ts_of_entries entries with


### PR DESCRIPTION
## 문제 (측정)

#20662(handler n bound) + #20659(dated_jsonl read bound) 배포 후에도 `/api/v1/dashboard/telemetry` windowed 폴링이 **4.88s**, CPU 100%+ (sample: `camlYojson` + GC 476 샘플 지배). per-source latency:

| source | latency |
|--------|---------|
| **trajectory_tool_call** | **6.88s** |
| execution_receipt | 0.47s |
| agent_event / tool_call_io / oas_event | <0.01s |

즉 keeper-fleet freeze 의 잔존 원인 = trajectory source.

## 근본 원인

`read_trajectory_tool_calls` 가 `~n` 을 무시하고, `read_trajectory_file` 이 `Fs_compat.load_file` 로 trace 파일을 통째로 메모리에 로드 후 파싱합니다 (한 trace 파일 측정 12MB, keeper Eio 도메인에서). handler n (#20662) 을 2000 으로 줘도 이 경로는 n 을 무시하므로 무효였습니다.

## 변경

- `read_trajectory_file`: `Fs_compat.load_file` → `Dated_jsonl.load_tail_lines ~max_lines` (이미 export 된 tail-biased reader). trace 는 append-ordered 라 tail 이 대시보드가 폴링하는 최근 window 입니다.
- `read_trajectory_tool_calls`: `~n` 을 per-file `max_lines` 로 전달. `n<=0` ("무제한") 은 `unbounded_window_scan_cap` (50000, #20659 도입) 으로 clamp.
- summary-stats caller 도 같은 cap 으로 bound.

이로써 `/telemetry` read 경로의 모든 source 가 tail-bounded reader 를 통과합니다 (어떤 source 도 store 를 full-parse 하지 않음).

## 검증

- 36 tests: trajectory + summary (count 정확성 `counts all rows beyond recent cap` 포함) 전부 pass, regression 0.
- 잔여 1 failure (`summary surfaces coverage gaps`, Otel counter 테스트) 는 base `f3afdac` 의 기존 결함으로 본 변경과 무관.
- 런타임 before(windowed 4.88s)/after 는 배포 후 `curl` 으로 확인 예정.

## 관계

- #20659 (dated_jsonl read bound, **MERGED**) + #20662 (handler default n bound, **MERGED**) 와 상보적. 이 PR 이 `/telemetry` read 경로의 마지막 unbounded source (trajectory) 를 마감합니다.

## follow-up (별도, 본 PR 범위 외)

다른 엔드포인트/경로의 unbounded reader: `audit_log:614` (43M), `keeper_api` `Trajectory.read_all_lines` (별도 엔드포인트), `tool_usage_log:321`, `eval_calibration:344`. 같은 bounded-by-construction 으로 흡수 필요.

RFC-WAIVED: telemetry read 경로 성능 수정. credential/identity/operator/sandbox/hooks/workflow 비해당. tail-bound (load_file 제거) 가 root 이며 cap 은 "무제한 요청" backstop.
