### PR TITLE
fix(dashboard): repair 8 pre-existing tsc errors in ide components

### DIFF
--- a/dashboard/src/components/ide/ide-activity-panel.ts
+++ b/dashboard/src/components/ide/ide-activity-panel.ts
@@ -1,6 +1,6 @@
 import { html } from 'htm/preact'
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
-import { useSignalValue } from './use-signal-value'
+import { useSignalValue, useStoreSubscription } from './use-signal-value'
 import { get } from '../../api/core'
 import { fetchIdeEvents, type IdeBridgeEvent } from '../../api/ide'
 import { asRecord, isPositiveSafeInteger } from '../common/normalize'
@@ -475,7 +475,7 @@ export function IdeActivityPanel(props: IdeActivityPanelProps = {}) {
     }
   }, [store, refreshMs])
 
-  useSignalValue(store)
+  useStoreSubscription(store.subscribe)
   useSignalValue(globalPresenceSnapshot)
   useSignalValue(cursorOverlaySignal)
   useSignalValue(ideConversationThreadSnapshot)

--- a/dashboard/src/components/ide/ide-editor-signals.ts
+++ b/dashboard/src/components/ide/ide-editor-signals.ts
@@ -5,7 +5,7 @@ import { lspDiagnosticSnapshot } from './ide-lsp-client'
 import { ideConversationThreadSnapshot } from './ide-context-bridge'
 import { focusIdeContextAnchor, normalizeIdeContextFilePath } from './ide-state'
 import { setIdeReplayUntilMs } from './ide-replay-state'
-import { routeLinksForContext } from './ide-context-route-links'
+import { routeLinksForContext } from './ide-context-lens'
 import type { KeeperTraceEvent } from './keeper-trace-store'
 
 export interface CurrentFileSignal {

--- a/dashboard/src/components/ide/ide-editor.ts
+++ b/dashboard/src/components/ide/ide-editor.ts
@@ -1,6 +1,6 @@
 import { html } from 'htm/preact'
 import { useRef, useEffect, useMemo, useState } from 'preact/hooks'
-import { useSignalValue } from './use-signal-value'
+import { useSignalValue, useStoreSubscription } from './use-signal-value'
 import { EditorState } from '@codemirror/state'
 import { EditorView } from '@codemirror/view'
 import type { CodeDocumentStore } from './code-document-store'
@@ -94,8 +94,8 @@ export function IdeEditor({
   onKeeperLineSelect,
   annotations = [],
 }: IdeEditorProps) {
-  useSignalValue(documentStore)
-  useSignalValue(ownershipStore)
+  useStoreSubscription(documentStore.subscribe)
+  useStoreSubscription(ownershipStore.subscribe)
   useSignalValue(cursorOverlaySignal)
   useSignalValue(globalPresenceSnapshot)
   useSignalValue(ideContextFocus)
@@ -468,8 +468,8 @@ function CodeMirrorEditor({
     ready,
   ])
 
-  useSignalValue(documentStore)
-  useSignalValue(ownershipStore)
+  useStoreSubscription(documentStore.subscribe)
+  useStoreSubscription(ownershipStore.subscribe)
   useSignalValue(keeperTraceState)
 
   return html`

--- a/dashboard/src/components/ide/ide-interject.ts
+++ b/dashboard/src/components/ide/ide-interject.ts
@@ -1,6 +1,6 @@
 import { html } from 'htm/preact'
 import { useEffect, useState } from 'preact/hooks'
-import { useSignalValue } from './use-signal-value'
+import { useStoreSubscription } from './use-signal-value'
 import type { FunctionComponent } from 'preact'
 import { dispatchKeeperInterjectAction } from '../../keeper-actions'
 import { activeKeeperName } from '../../keeper-state'
@@ -44,7 +44,7 @@ export const IdeInterject: FunctionComponent<IdeInterjectProps> = ({ keeperName 
       initialActiveKeeper: resolveActiveKeeper(keeperName),
       dispatch: dispatchInterject,
     }))
-  useSignalValue(interjectStore)
+  useStoreSubscription(interjectStore.subscribe)
 
   useEffect(() => {
     const unsub = activeKeeperName.subscribe(name => {

--- a/dashboard/src/components/ide/ide-presence-strip.ts
+++ b/dashboard/src/components/ide/ide-presence-strip.ts
@@ -1,6 +1,6 @@
 import { html } from 'htm/preact'
 import { useEffect, useMemo, useState } from 'preact/hooks'
-import { useSignalValue } from './use-signal-value'
+import { useSignalValue, useStoreSubscription } from './use-signal-value'
 import { authHeaders, fetchWithTimeout, get } from '../../api/core'
 import { DEFAULT_GET_TIMEOUT_MS } from '../../config/constants'
 import { KeeperBadge } from '../keeper-badge'
@@ -228,7 +228,7 @@ export function IdePresenceStrip() {
     return unsub
   }, [presenceStore])
 
-  useSignalValue(presenceStore)
+  useStoreSubscription(presenceStore.subscribe)
   useSignalValue(cursorOverlaySignal)
 
   const current = presenceStore.snapshot()

--- a/dashboard/src/components/ide/use-signal-value.ts
+++ b/dashboard/src/components/ide/use-signal-value.ts
@@ -49,3 +49,16 @@ export function useSubscribedSnapshot<T>(
 
   return value
 }
+
+// Subscribe to an external store for re-render side effects only. Use this when
+// the component reads store state through accessor methods (in render, effects,
+// or callbacks) rather than a single reactive value. useSignalValue and
+// useSubscribedValue/useSubscribedSnapshot return a value; this returns nothing
+// because the caller already reads via the store's own accessors. The store's
+// listener is called with no argument, so a value-returning hook does not fit.
+export function useStoreSubscription(
+  subscribe: (listener: () => void) => () => void,
+): void {
+  const [, forceRender] = useState(0)
+  useEffect(() => subscribe(() => forceRender(tick => tick + 1)), [subscribe])
+}


### PR DESCRIPTION
## 변경 — `src/components/ide`의 pre-existing tsc 에러 8건 수정

`tsc --noEmit`가 여러 main 커밋에 걸쳐 `src/components/ide`에서 실패하고 있었습니다 (Dashboard CI norm-red, 이번 세션의 thinking/OAS-pin 작업과 무관한 별개 잔재). 독립적인 두 근본 원인:

### 1. stray import (TS2307 ×1)
`ide-editor-signals.ts:8`이 존재하지 않는 `./ide-context-route-links`에서 `routeLinksForContext`를 import. 이 심볼은 `./ide-context-lens:1009`에 정의되어 있고, **다른 15개 파일은 이미 거기서 import**. #20548 split refactor가 남긴 half-done extraction으로 보이며, phantom 파일을 새로 만들지 않고 stray import만 정상 경로로 재지정.

### 2. store를 signal로 오인 (TS2345 ×7)
7개 호출부가 store 객체를 `useSignalValue(signal: { value; subscribe })`에 전달. 그러나 이 store들(`RunActivityStore` 등)은 `subscribe: (listener: () => void) => () => void`만 노출하고 `.value`가 없음.

기존 `useSignalValue(store)`는 **re-render 측면에서 사실상 no-op**이었습니다:
- `useState(store.value)` = `useState(undefined)`
- `store.subscribe(next => setValue(next))` — listener가 **인자 없이** 호출됨 → `setValue(undefined)` → React same-value bailout
- 컴포넌트는 형제 진짜-signal 구독(`useSignalValue(globalPresenceSnapshot)` 등)에 의해서만 re-render되며 곁다리로 `store.events()`를 다시 읽고 있었음.

**`useStoreSubscription(subscribe)` 추가** — 구독 전용 hook으로, store 변경 시 re-render만 강제:
```ts
export function useStoreSubscription(
  subscribe: (listener: () => void) => () => void,
): void {
  const [, forceRender] = useState(0)
  useEffect(() => subscribe(() => forceRender(tick => tick + 1)), [subscribe])
}
```

#### 왜 기존 두 헬퍼와 중복이 아닌가
`useSignalValue` / `useSubscribedValue` / `useSubscribedSnapshot`은 모두 **값을 반환**합니다. 이 7개 사이트(특히 `ide-editor`)는 store 상태를 render·effect·callback 안에서 **accessor 메서드**(`documentStore.document()`, `presenceStore.snapshot()` 등)로 읽고, 구독은 오직 re-render 트리거 용도입니다. listener가 인자를 받지 않는 store에는 값-반환 hook이 맞지 않습니다. 이 빠진 프리미티브를 작성자가 잘못 `useSignalValue(store)`로 메운 것이며, 7개 사이트 **전부** 마이그레이션했습니다 (부분 마이그레이션 아님).

> 동작 변경 동반: store 기인 re-render가 형제 signal에 우연히 가려지던 상태에서 **신뢰성 있게** 동작하도록 바뀝니다 (개선 방향).

## 검증
- `tsc --noEmit`: **8 → 0**
- `eslint`: 변경 6파일 clean
- `vitest`: **59 passed** (ide-activity-panel, ide-editor, ide-interject, ide-presence-strip + a11y)

## 범위
- 이 PR은 **Dashboard `tsc` 8→0**만 green으로 만듭니다. main의 다른 norm-red 체크(OCaml Structure Ratchet, Meta Guards)는 별개 사안으로 남습니다.
- ide/* 컴포넌트는 credential/identity subsystem이 아니므로 RFC discovery gate 비대상.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
