### PR TITLE
fix(telemetry): skip out-of-window trace files in trajectory read (fan-out)

### DIFF
--- a/lib/telemetry_unified/telemetry_unified.ml
+++ b/lib/telemetry_unified/telemetry_unified.ml
@@ -591,6 +591,22 @@ let read_trajectory_file path ~max_lines ?since_ts ?until_ts () =
                !parse_error_count);
       entries)
 
+(* A trace file whose last write predates [since_ts] cannot hold entries in the
+   requested window: traces are append-ordered, so the file mtime tracks the
+   newest entry. Skip such files without opening them. Observatory polls a 1h
+   window, but the store keeps ~84 trace files across keepers (most >7d old), so
+   the windowed read tail-read every one (#20665 bounded per-file lines but not
+   the file fan-out — measured 3.2s windowed vs 0.25s no-window). mtime-skip
+   cuts the per-call fan-out from all-files to in-window-files. Conservative on
+   stat failure (keeps the file) and when no window is requested. *)
+let trace_file_within_since ~since_ts path =
+  match since_ts with
+  | None -> true
+  | Some since ->
+    (match Unix.stat path with
+     | st -> st.Unix.st_mtime >= since
+     | exception _ -> true)
+
 let read_trajectory_tool_calls ~masc_root ?keeper_name ?since_ts ?until_ts ~n ()
     : Yojson.Safe.t list =
   let dirs = discover_trajectory_keeper_dirs masc_root in
@@ -611,7 +627,9 @@ let read_trajectory_tool_calls ~masc_root ?keeper_name ?since_ts ?until_ts ~n ()
           ~site:"read_trajectory_tool_calls_readdir" ~default:[] (fun () ->
           Sys.readdir dir
           |> Array.to_list
-          |> List.filter (fun name -> Filename.check_suffix name ".jsonl")
+          |> List.filter (fun name ->
+               Filename.check_suffix name ".jsonl"
+               && trace_file_within_since ~since_ts (Filename.concat dir name))
           |> List.concat_map (fun name ->
                read_trajectory_file
                  (Filename.concat dir name)


### PR DESCRIPTION
## 문제 (측정)

#20665 (trajectory tail-bound) MERGED 후에도 windowed `/telemetry` **3.2s**, CPU 100%+. per-source: trajectory windowed **3.18s** vs no-window **0.25s** (같은 tail-bound, 동일 n). 원인 = **file fan-out**: `read_trajectory_tool_calls` 가 84 trace 파일 (keeper 당 3-12, 대부분 >7d) 을 전부 open. `execution_receipt` 는 0.05s — Dated_jsonl 이 day-file 을 날짜로 skip 하지만 trajectory 는 그런 skip 이 없었습니다.

## 근본 (n-knob 아님)

n=2000→200 으로 줄여도 84 파일은 그대로 열립니다. trace 파일 mtime 이 window 밖이면 파일 자체를 skip 해야 합니다. observatory `DEFAULT_RANGE='1h'` → `since_ms = now - 1h`. trace mtime 분포: <1h **17 files**, <7d 9, >7d **58 files** → 67 files skip 가능.

## 변경

`trace_file_within_since`: 파일 mtime 이 `since_ts` 이전이면 열지 않고 skip (trace 는 append-ordered 라 mtime = 최신 엔트리; mtime < since ⇒ 마지막 엔트리가 window 밖). observatory 1h window 가 84 → in-window (~17) 파일만 읽습니다. stat 실패 / no-window 는 보수적 (파일 read, #20665 tail-bound 유지).

## 검증

- 36 tests: trajectory + summary 전부 pass, regression 0 (잔여 1 failure `coverage_gaps` = Otel counter, base 기존, 무관).
- 런타임 before(windowed 3.2s)/after 는 배포 후 observatory 의 literal request (keeper + `since_ms=now-1h`) 로 확인 예정.

## 관계 / follow-up

- #20659 (dated_jsonl read bound) + #20662 (handler default n) + #20665 (trajectory tail-bound) 모두 MERGED. 이 PR 이 trajectory **file fan-out** 을 마감 (tail-bound 가 per-file 줄 수를, 이 PR 이 file 수를 bound).
- follow-up (별도): `audit_log:614` (43M), `keeper_api` `Trajectory.read_all_lines` (별도 엔드포인트), `tool_usage_log`, `eval_calibration`.

RFC-WAIVED: telemetry read 경로 성능. window 밖 파일 skip (read 자체 제거) 가 root 이며 n-knob 아님. credential/identity/operator/sandbox/hooks/workflow 비해당.
