### PR TITLE
fix(keeper): clear stale diagnostic last_error via keeper self-progress signal

### DIFF
--- a/lib/keeper/keeper_status_runtime.ml
+++ b/lib/keeper/keeper_status_runtime.ml
@@ -238,25 +238,54 @@ let keeper_error_hint ~agent_status ~meta =
           | Some reason when looks_error_like reason -> Some reason
           | _ -> None))
 
+(* A live signal newer than the persisted error snapshot means
+   [last_proactive_reason] is stale and must not surface as a current error.
+   Shared by quiet-reason classification and the dashboard diagnostic so a
+   running keeper that has recovered does not keep showing a dead error string
+   — including across server restarts, where the persisted snapshot is reloaded
+   verbatim and never reset.
+
+   Two independent supersede paths, because the persisted error and the live
+   signal can come from different sources:
+
+   - Keeper self-progress: the error is recorded on the last *proactive* cycle
+     ([proactive_rt.last_ts]). If the keeper has completed any later turn
+     ([usage.last_turn_ts] strictly greater), the proactive error predates the
+     keeper's current activity and is stale. Keepers do not publish an external
+     agent-registry record ([.masc/agents/]), so this is the only path that
+     fires for them. Equality (the erroring proactive turn *is* the latest
+     turn) does not supersede — a fresh error stays visible.
+
+   - External agent-registry signal: present for non-keeper participants that
+     write an agent record. A fresh live presence newer than all recorded
+     activity. Threshold preserved verbatim so non-keeper behaviour is
+     unchanged. *)
+let live_signal_supersedes_persisted_error ~keepalive_running ~agent_status ~meta =
+  if not keepalive_running then false
+  else begin
+    let proactive_error_ts = meta.runtime.proactive_rt.last_ts in
+    let last_turn_ts = meta.runtime.usage.last_turn_ts in
+    let self_progressed_past_proactive_error =
+      proactive_error_ts > 0.0 && last_turn_ts > proactive_error_ts
+    in
+    let external_live_signal =
+      json_bool "exists" agent_status false
+      && agent_runtime_has_live_signal agent_status
+      &&
+      match agent_last_seen_ts_opt agent_status with
+      | Some last_seen_ts -> last_seen_ts > max proactive_error_ts last_turn_ts
+      | None -> false
+    in
+    self_progressed_past_proactive_error || external_live_signal
+  end
+
 let classify_keeper_quiet_reason ~meta ~keepalive_running ~agent_status ~now_ts =
   let quiet_active = quiet_hours_active () in
   let agent_exists = json_bool "exists" agent_status false in
   let agent_status_text = agent_status_text agent_status in
-  let live_signal_supersedes_persisted_error =
-    keepalive_running
-    && agent_exists
-    && agent_runtime_has_live_signal agent_status
-    &&
-    match agent_last_seen_ts_opt agent_status with
-    | Some last_seen_ts ->
-        let persisted_error_ts =
-          max meta.runtime.proactive_rt.last_ts meta.runtime.usage.last_turn_ts
-        in
-        last_seen_ts > persisted_error_ts
-    | None -> false
-  in
   let error_hint =
-    if live_signal_supersedes_persisted_error then None
+    if live_signal_supersedes_persisted_error ~keepalive_running ~agent_status ~meta
+    then None
     else keeper_error_hint ~agent_status ~meta
   in
   if not meta.proactive.enabled then
@@ -515,7 +544,13 @@ let keeper_diagnostic_json
     keeper_reply_snapshot_of_history history_items
   in
   let last_error =
-    Json_util.string_opt_to_json (keeper_error_hint ~agent_status ~meta)
+    (* Mirror classify_keeper_quiet_reason: a recovered running keeper whose
+       live signal postdates the persisted error must not surface the stale
+       reason. Without this guard the dashboard "이전 오류" badge survives
+       server restarts because the snapshot is reloaded verbatim. *)
+    if live_signal_supersedes_persisted_error ~keepalive_running ~agent_status ~meta
+    then `Null
+    else Json_util.string_opt_to_json (keeper_error_hint ~agent_status ~meta)
   in
   `Assoc
     [

--- a/test/dune
+++ b/test/dune
@@ -63,6 +63,7 @@
   test_mcp_session_id_header
   test_keeper_sdk_error_typed_bridge
   test_keeper_status_bridge
+  test_keeper_diagnostic_stale_last_error
   test_read_drop_reason
   test_log_ring_encoder
   test_eio_context_fiber_local
@@ -318,6 +319,7 @@
   test_mcp_session_id_header
   test_keeper_sdk_error_typed_bridge
   test_keeper_status_bridge
+  test_keeper_diagnostic_stale_last_error
   test_read_drop_reason
   test_log_ring_encoder
   test_eio_context_fiber_local

--- a/test/test_keeper_diagnostic_stale_last_error.ml
+++ b/test/test_keeper_diagnostic_stale_last_error.ml
@@ -1,0 +1,158 @@
+(** Regression: a recovered running keeper must not keep surfacing a stale
+    [last_proactive_reason] as [diagnostic.last_error].
+
+    Before the fix, [keeper_diagnostic_json] read the persisted error snapshot
+    unconditionally, while [classify_keeper_quiet_reason] suppressed it via the
+    supersede guard. The two fields disagreed, so the dashboard "이전 오류"
+    badge (sourced from [diagnostic.last_error]) survived server restarts — the
+    persisted snapshot is reloaded verbatim and never reset.
+
+    Production shape matters here: keepers do NOT publish an external
+    agent-registry record ([.masc/agents/<agent_name>.json] is absent), so the
+    real [agent_status] passed in is [{exists=false}]. The supersede therefore
+    has to fire on the keeper's OWN signal — a turn completed after the
+    erroring proactive cycle ([usage.last_turn_ts] > [proactive_rt.last_ts]).
+    The tests pin both: the keeper-self path with the production [{exists=false}]
+    status, and the external-registry path for non-keeper participants.
+
+    The error reason modelled here is the deleted tool-retry-budget bug
+    (#20624): "Tool retry budget exhausted after 2/2 retries". *)
+
+open Masc
+
+let error_reason = "unified:error:Tool retry budget exhausted after 2/2 retries"
+
+(* Fixed epochs. The erroring proactive cycle is at [proactive_error_ts]; a
+   later keeper turn is at [later_turn_ts]. *)
+let proactive_error_ts = 1_780_994_419.0 (* ~2026-06-09T08:40Z, echo's real error *)
+let later_turn_ts = 1_781_022_342.0 (* ~2026-06-09T16:25Z, echo's real last turn *)
+let now_ts = 1_781_100_000.0
+
+(* Local member access avoids pulling yojson in as a direct dune dependency;
+   yojson values are plain polymorphic variants. *)
+let string_member key json =
+  match json with
+  | `Assoc fields -> (
+      match List.assoc_opt key fields with
+      | Some (`String s) -> Some s
+      | _ -> None)
+  | _ -> None
+;;
+
+let meta_with_persisted_error ~proactive_ts ~last_turn_ts =
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+        [ ("name", `String "stalekeeper")
+        ; ("agent_name", `String "keeper-stalekeeper-agent")
+        ; ("trace_id", `String "trace-stalekeeper")
+        ; ("runtime_id", `String "ollama_cloud.deepseek-v4-flash")
+        ; ("last_proactive_outcome", `String "error")
+        ; ("last_proactive_reason", `String error_reason)
+        ; ("last_proactive_ts", `Float proactive_ts)
+        ; ("last_turn_ts", `Float last_turn_ts)
+        ; ("total_turns", `Int 5)
+        ; ("proactive_count_total", `Int 5)
+        ])
+  with
+  | Ok meta -> meta
+  | Error err -> Alcotest.failf "meta_of_json_fixture failed: %s" err
+;;
+
+(* The real agent_status a keeper gets: no agent-registry file -> exists=false. *)
+let keeper_agent_status = `Assoc [ ("exists", `Bool false) ]
+
+(* A non-keeper participant that publishes a fresh live agent record. *)
+let external_live_agent_status ~last_seen =
+  `Assoc
+    [ ("exists", `Bool true)
+    ; ("status", `String "idle")
+    ; ("last_seen_ago_s", `Float 5.0)
+    ; ("last_seen", `String last_seen)
+    ]
+;;
+
+let last_error_of_diagnostic ~meta ~agent_status ~keepalive_running =
+  Keeper_status_runtime.keeper_diagnostic_json
+    ~meta
+    ~agent_status
+    ~keepalive_running
+    ~history_items:[]
+    ~now_ts
+  |> string_member "last_error"
+;;
+
+(* Production case: keeper (exists=false agent_status) that turned after its
+   erroring proactive cycle. This is the case that previously kept showing
+   "이전 오류" across restarts and that the external-signal-only guard could
+   never clear. *)
+let test_keeper_self_progress_hides_stale_error () =
+  let meta =
+    meta_with_persisted_error ~proactive_ts:proactive_error_ts ~last_turn_ts:later_turn_ts
+  in
+  Alcotest.(check (option string))
+    "keeper turned after the proactive error -> last_error suppressed"
+    None
+    (last_error_of_diagnostic ~meta ~agent_status:keeper_agent_status ~keepalive_running:true)
+;;
+
+(* Fresh error: the erroring proactive cycle IS the latest turn (timestamps
+   equal). Nothing has happened since, so the error is the keeper's current
+   state and must stay visible. *)
+let test_fresh_error_stays_visible () =
+  let meta =
+    meta_with_persisted_error ~proactive_ts:proactive_error_ts ~last_turn_ts:proactive_error_ts
+  in
+  Alcotest.(check (option string))
+    "error is the latest turn -> last_error retains the reason"
+    (Some error_reason)
+    (last_error_of_diagnostic ~meta ~agent_status:keeper_agent_status ~keepalive_running:true)
+;;
+
+(* Offline keeper: no keepalive, guard cannot fire, error remains ("최근 오류"). *)
+let test_offline_keeper_keeps_error () =
+  let meta =
+    meta_with_persisted_error ~proactive_ts:proactive_error_ts ~last_turn_ts:later_turn_ts
+  in
+  Alcotest.(check (option string))
+    "offline keeper -> last_error retains the reason"
+    (Some error_reason)
+    (last_error_of_diagnostic ~meta ~agent_status:keeper_agent_status ~keepalive_running:false)
+;;
+
+(* External-registry path (non-keeper participant): a fresh live presence newer
+   than all recorded activity supersedes even without keeper self-progress. *)
+let test_external_live_signal_hides_stale_error () =
+  let meta =
+    meta_with_persisted_error ~proactive_ts:proactive_error_ts ~last_turn_ts:proactive_error_ts
+  in
+  let agent_status = external_live_agent_status ~last_seen:"2026-06-09T16:00:00Z" in
+  Alcotest.(check (option string))
+    "fresh external live signal -> last_error suppressed"
+    None
+    (last_error_of_diagnostic ~meta ~agent_status ~keepalive_running:true)
+;;
+
+let () =
+  Alcotest.run
+    "keeper_diagnostic_stale_last_error"
+    [ ( "supersede of persisted proactive error"
+      , [ Alcotest.test_case
+            "keeper self-progress hides stale error"
+            `Quick
+            test_keeper_self_progress_hides_stale_error
+        ; Alcotest.test_case
+            "fresh error stays visible"
+            `Quick
+            test_fresh_error_stays_visible
+        ; Alcotest.test_case
+            "offline keeper keeps error"
+            `Quick
+            test_offline_keeper_keeps_error
+        ; Alcotest.test_case
+            "external live signal hides stale error"
+            `Quick
+            test_external_live_signal_hides_stale_error
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 문제

대시보드 keeper roster의 "이전 오류" 배지가 재시작 후에도 사라지지 않음. 근원은 이미 삭제된 tool-retry-budget 버그(#20624)의 에러 문자열이 `keepers/<name>.json`의 `last_proactive_reason` 스냅샷에 박혀, 서버 재시작 시 그대로 reload되기 때문.

## 근본 원인

- 배지는 `keeper_diagnostic_json`의 `last_error` 필드에서 나오고, 이는 `last_proactive_reason`을 무조건 읽었음.
- `classify_keeper_quiet_reason`은 이미 supersede 가드로 이 스냅샷을 억제하고 있었으나, `last_error`는 그러지 않아 두 필드가 불일치 → 회복한 keeper도 죽은 에러를 계속 표면화.
- 기존 supersede는 외부 agent 레지스트리(`.masc/agents/<agent_name>.json`)의 live signal에만 의존. keeper는 그 레코드를 쓰지 않으므로(`.masc/agents/` 비어 있음) keeper에 대해선 항상 무발화 → 배지가 영원히 지속.

## 변경

- `live_signal_supersedes_persisted_error`를 공유 함수로 추출하고, **keeper-자체 진행 신호**를 추가: 에러는 마지막 proactive 사이클(`proactive_rt.last_ts`)에 기록되므로, 이후 턴(`usage.last_turn_ts > proactive_rt.last_ts`)이 있으면 그 에러는 현재 활동보다 과거 = stale. 동률(에러가 곧 마지막 턴)이면 supersede 안 함 — fresh error는 노출 유지.
- 외부 레지스트리 분기의 threshold는 한 글자도 안 바꿔 non-keeper 참가자 동작은 byte-identical 보존.
- `keeper_diagnostic_json`의 `last_error`에도 동일 가드 적용 (classify와 일관).

## 검증

- 로컬 빌드 green (`dune build lib/`).
- 신규 회귀 테스트 4-case, **프로덕션 agent_status 형태(`{exists=false}`)**로 작성: keeper self-progress 억제 / fresh error 노출 / offline 노출 / 외부 live signal 억제.
- Mutation check: self-progress 분기를 끄면 keeper case가 stale 문자열로 되돌아가 실패 (테스트가 그 분기를 실제로 검증함을 증명).
- 기존 `test_keeper_status_bridge`(4), `test_heartbeat_integration`(23) 회귀 없음.
- 실측: 현재 "이전 오류" 배지 keeper 4개(echo/imseonghan/issue_king/masc-improver) 모두 `last_turn_ts > last_proactive_ts` → 픽스 후 read-time에 100% 해소.

RFC-WAIVED: keeper status/diagnostic 표면의 read-time 일관성 교정. credential/identity/sandbox/operator-control/hooks 등 게이트 대상 subsystem 미해당. 신규 기능/계약 변경 없음.
