### PR TITLE
test(dashboard): modernize ide-context-lens fixtures for #20513 structured-context classification

### DIFF
--- a/dashboard/src/components/ide/ide-context-lens.test.ts
+++ b/dashboard/src/components/ide/ide-context-lens.test.ts
@@ -40,6 +40,16 @@ const events: ReadonlyArray<RunActivityEvent> = [
     kind: 'board.comment.created',
     tags: ['pr:15000', 'goal:goal-ide'],
     timestamp_ms: 100,
+    // Structured surface classification (#20513 replaced regex/tag/text
+    // parsing with event.context for surface counts). Drives goal/task/
+    // board/pr/git surfaces; comment stays sourced from the annotation.
+    context: {
+      goal_id: 'goal-ide',
+      task_id: 'task-42',
+      board_post_id: 'post-1',
+      pr_id: '15000',
+      git_ref: 'abc123',
+    },
   },
 ]
 
@@ -768,6 +778,17 @@ describe('IdeContextLens', () => {
           'line:27',
         ].join(' '),
         tags: ['pr:15000'],
+        // Surface classification/count reads event.context (#20513); the
+        // detail text still feeds route-link refs (eventRouteRefs retained).
+        // pr_id selects the PR surface; session/op/wr light the runtime
+        // surface. line stays in detail (context.line without file_path is
+        // filtered out by deriveIdeContextLens).
+        context: {
+          pr_id: '15000',
+          session_id: 'sess-9',
+          operation_id: 'op-9',
+          worker_run_id: 'wr-9',
+        },
       }],
       overlay: { ...overlay, cursors: new Map() },
     })
@@ -831,6 +852,14 @@ describe('IdeContextLens', () => {
         target: 'runtime scope',
         timestamp_ms: 400,
         detail: 'session:sess-9 op:op-9 wr:wr-9 line:27',
+        // Runtime surface classification reads event.context (#20513).
+        // line stays in detail (refs.line); context.line without file_path
+        // would be filtered out by deriveIdeContextLens.
+        context: {
+          session_id: 'sess-9',
+          operation_id: 'op-9',
+          worker_run_id: 'wr-9',
+        },
       }],
       overlay: { ...overlay, cursors: new Map() },
     })


### PR DESCRIPTION
## 변경 — `ide-context-lens.test.ts` stale fixture를 #20513 structured-context API로 번역

### 배경
PR #20666이 Dashboard CI의 `tsc`(step 9)를 고치자, 그동안 가려져 있던 **test step(step 10)의 pre-existing 실패들**이 드러났습니다. main에선 tsc가 먼저 실패해 test step이 한 번도 실행되지 않았습니다.

이 PR은 그중 `ide-context-lens.test.ts`의 4건을 고칩니다.

### 근본 원인
`#20513` ("remove regex-based event text classification from ide-context-lens")이 surface 분류/카운트를 regex·tag·free-text 파싱에서 **structured `event.context` 필드**로 전환했으나, `ide-context-lens.test.ts`를 갱신하지 않았습니다. 테스트는 여전히 old API(`tags`/`detail` 텍스트)로 입력을 주어 surface가 `quiet/count:0`로 떨어졌습니다.

### 수정 — fixture 입력만 번역, assertion 무변경
event fixture를 structured `event.context`로 번역(assertion은 한 줄도 안 바꿈):
- 공유 `events`(evt-1): `context { goal_id, task_id, board_post_id, pr_id, git_ref }` → goal/task/board/pr/git surface 재카운트(Goal 2, Task 2, Git 3, PR 1, Board 1). comment는 annotation에서 유지.
- "promotes tagged activity references": `context { pr_id, session_id, operation_id, worker_run_id }` → PR surface 분류 + runtime surface 점등. detail 텍스트는 route-link refs로 유지(`eventRouteRefs` 잔존).
- "promotes tagged runtime references": `context { session_id, operation_id, worker_run_id }` → runtime surface 분류.

`line`은 detail 텍스트에 유지: `context.line`을 `context.file_path` 없이 주면 `deriveIdeContextLens`가 이벤트를 드롭(필터 198-203). 기능 부활도 assertion 거세도 아닌, **유지된 API로의 입력 현대화**.

### 검증
- `ide-context-lens.test.ts`: **24/24** (was 20/24)
- `tsc --noEmit`: 0 (base는 #20666 포함)
- `eslint`: clean

### 범위 — Dashboard 단독 green 아님
Dashboard test step에는 **다른 pre-existing 실패 4파일**이 더 있습니다(전부 tsc red에 가려져 있던 것, 이 PR과 무관): `auth-status.test.ts`, `auth-status.a11y.test.ts`, `connector-quick-bind.test.ts`, `runtime-panel.test.ts`. 각각 별개 root cause로 별도 추적/수정합니다. 이 PR은 5개 중 1개를 해소합니다.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
