### PR TITLE
test(dashboard): fix 3 pre-existing stale tests in Dashboard test step (auth-status, connector, runtime-panel)

### DIFF
--- a/dashboard/src/components/auth-status.a11y.test.ts
+++ b/dashboard/src/components/auth-status.a11y.test.ts
@@ -16,6 +16,7 @@ vi.mock('../store', () => ({
 vi.mock('../api/core', () => ({
   clearStoredToken: vi.fn(),
   currentDashboardActor: vi.fn().mockReturnValue('test'),
+  dashboardBearerToken: vi.fn().mockReturnValue(null),
   isRemoteAccess: vi.fn().mockReturnValue(false),
   setStoredToken: vi.fn(),
 }))

--- a/dashboard/src/components/auth-status.test.ts
+++ b/dashboard/src/components/auth-status.test.ts
@@ -20,6 +20,7 @@ vi.mock('../store', () => ({
 vi.mock('../api/core', () => ({
   clearStoredToken: vi.fn(),
   currentDashboardActor: vi.fn().mockReturnValue('test'),
+  dashboardBearerToken: vi.fn().mockReturnValue(null),
   isRemoteAccess: vi.fn().mockReturnValue(false),
   setStoredToken: vi.fn(),
 }))


### PR DESCRIPTION
## 변경 — Dashboard test step의 pre-existing stale 테스트 3파일 수정

### 배경
PR #20666이 Dashboard CI의 `tsc`(step 9)를 고치자, 그동안 가려져 있던 test step(step 10)의 pre-existing 실패들이 드러났습니다(main에선 tsc가 먼저 실패해 test step이 한 번도 안 돌았음). 실패는 5파일이었고, 이 PR은 그중 3파일을 고칩니다. (나머지 `ide-context-lens.test.ts`는 [#20670](https://github.com/jeong-sik/masc/pull/20670).)

세 건 모두 **컴포넌트/API 변경에 테스트가 뒤처진 stale** 또는 **테스트 자체 결함**으로 확인했고(컴포넌트는 정상), assertion 의미를 보존하며 교정했습니다.

### 1. `auth-status` (6건) — stale mock
`auth-status.ts`가 `dashboardBearerToken()`(`api/core.ts:78`)을 호출하나 `auth-status.test.ts`/`.a11y.test.ts`의 `vi.mock('../api/core')`에 그 export가 없어 `No "dashboardBearerToken" export` 에러. 두 mock에 `dashboardBearerToken: vi.fn().mockReturnValue(null)` 추가.

### 2. `connector-quick-bind` (1건) — test 격리 결함 (컴포넌트 정상)
"pressing Enter submits the bind"(connectorId=slack)가 bind fetch 호출을 connector 무관 predicate(`/connector/bind`)로 찾아, 직전 discord 테스트의 leaked 호출(`channel_id:'1234567890'`)을 매칭. **격리 실행 시 통과**(컴포넌트 정상 증명). discord 테스트가 `name=discord`로 스코프하는 패턴을 미러링해 `name=slack` 추가.

### 3. `runtime-panel` (3건) — #20492 재설계에 테스트 미추종
#20492("runtime call counts visibility")가 default monitoring view를 재구성: collapsed `#runtime-details-providers`를 제거하고 `RuntimeMonitor`를 가시 default lane으로, "providers"를 독립 view로 승격. 테스트(#20399, 그 이전)는 옛 레이아웃(RuntimeMonitor 부재 + collapsed providers)을 기대. default-view 3개 테스트를 현 레이아웃에 맞춤(RuntimeMonitor 가시, verification만 collapsed). drill-down(config/audit) 테스트는 `.not.toContain('RuntimeMonitor')` 유지. **컴포넌트 무변경.**

> ⚠️ 리뷰 노트: #20492 commit 메시지가 `#runtime-details-providers` 제거를 명시하지 않았습니다. providers가 독립 view가 된 것으로 보아 의도된 제거로 판단했으나, 만약 unintended regression이면 테스트가 아니라 컴포넌트를 복원해야 합니다.

### 검증
- `auth-status` 6/6, `connector-quick-bind` 11/11, `runtime-panel` 9/9
- tsc 0, eslint clean

### 범위
이 PR(3파일) + #20670(ide-context-lens) + 이미 머지된 #20666(tsc)이 함께 Dashboard job을 green으로 만듭니다.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
