### PR TITLE
fix(keeper): restore goal-scope claim fallback so keepers don't idle on a non-matching scope

### DIFF
--- a/lib/keeper/keeper_runtime_contract.ml
+++ b/lib/keeper/keeper_runtime_contract.ml
@@ -38,6 +38,19 @@ let task_is_linked_to_keeper_goals goal_ids (task : Masc_domain.task) =
        | None -> false)
     goal_ids
 
+(* A task is claimable-by-a-fresh-keeper only in [Todo]. Enumerate every
+   [task_status] variant so a new constructor forces a decision here rather than
+   silently widening "claimable" to e.g. a future [BlockedOnReview]. *)
+let task_is_unclaimed_todo (task : Masc_domain.task) =
+  match task.task_status with
+  | Masc_domain.Todo -> true
+  | Masc_domain.AwaitingVerification _
+  | Masc_domain.Claimed _
+  | Masc_domain.InProgress _
+  | Masc_domain.Done _
+  | Masc_domain.Cancelled _ ->
+    false
+
 type claim_goal_scope = {
   task_filter : Masc_domain.task -> bool;
   mode : string;
@@ -45,8 +58,9 @@ type claim_goal_scope = {
   fallback_reason : string option;
 }
 
-let resolve_claim_goal_scope ~(config : Workspace.config) ~(meta : keeper_meta) () =
-  ignore config;
+(* Pure in-memory scope derived from [meta] alone — no disk read. The
+   [active_goal_ids] hard filter; an empty scope means all_tasks. *)
+let meta_only_claim_goal_scope (meta : keeper_meta) =
   match meta.active_goal_ids with
   | [] ->
       {
@@ -56,16 +70,62 @@ let resolve_claim_goal_scope ~(config : Workspace.config) ~(meta : keeper_meta) 
         fallback_reason = None;
       }
   | goal_ids ->
-    {
-      task_filter = task_is_linked_to_keeper_goals goal_ids;
-      mode = "active_goal_ids";
-      effective_goal_ids = goal_ids;
-      fallback_reason = None;
-    }
+      {
+        task_filter = task_is_linked_to_keeper_goals goal_ids;
+        mode = "active_goal_ids";
+        effective_goal_ids = goal_ids;
+        fallback_reason = None;
+      }
+
+(* Resolve the claim filter for a keeper's [active_goal_ids].
+
+   Goal-scope is a *priority hint*, not a hard gate: a keeper must never sit idle
+   while the backlog holds claimable work. When the keeper's active goals have no
+   claimable (Todo + unclaimed) task linked to them, widen the filter back to
+   all_tasks and record [fallback_reason] so the widening is visible.
+
+   Restores the [allow_empty_goal_scope_fallback] stopgap (RFC-0067 §1, PR
+   #13673) that was dropped when the resolver was simplified to a pure in-memory
+   match. Without it, a keeper whose goal carries no live task — or whose backlog
+   tasks are all goal_id=None — is starved indefinitely (the observed
+   "scope-blocked deadlock"). Note RFC-0067 §3's proposed *atomicity* design
+   (scope-version tokens) is a separate, unimplemented direction; this is the
+   stopgap, reinstated by operator decision, not that design.
+
+   Reads the backlog ([get_tasks_safe], a disk read) to test for a claimable
+   scoped task. Kept on the claim path only — NOT the per-turn observation path
+   ([resolve_observation_claim_goal_scope]), which stays pure-meta to avoid
+   adding a per-keeper, per-cycle backlog read. *)
+let resolve_claim_goal_scope ~(config : Workspace.config) ~(meta : keeper_meta) () =
+  match meta.active_goal_ids with
+  | [] -> meta_only_claim_goal_scope meta
+  | goal_ids ->
+    let scoped_claimable_exists =
+      Workspace.get_tasks_safe config
+      |> List.exists (fun task ->
+             task_is_unclaimed_todo task
+             && task_is_linked_to_keeper_goals goal_ids task)
+    in
+    if scoped_claimable_exists then meta_only_claim_goal_scope meta
+    else
+      {
+        task_filter = (fun (_task : Masc_domain.task) -> true);
+        (* Reuse the established mode label consumed by
+           [Keeper_tool_task_runtime.claim_scope_context_suffix] rather than
+           minting a new string — a second label for the same concept would
+           drift the two sites apart. *)
+        mode = "empty_goal_scope_fallback_all_tasks";
+        effective_goal_ids = goal_ids;
+        fallback_reason = Some "no_scoped_claimable_tasks";
+      }
 
 let resolve_observation_claim_goal_scope ~(config : Workspace.config)
     ~(meta : keeper_meta) () =
-  resolve_claim_goal_scope ~config ~meta ()
+  (* Signal-only: the observation surface just needs the scope hint, not the
+     claimability-aware fallback. Stays pure-meta so the per-turn observation
+     path adds no backlog disk read. *)
+  ignore config;
+  meta_only_claim_goal_scope meta
 
 let task_is_blocked (task : Masc_domain.task) =
   (* Enumerate every [task_status] variant so the compiler flags any new

--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -205,7 +205,11 @@ let no_eligible_action_for_claim_scope claim_goal_scope ~excluded_count =
     let scope_hint =
       match claim_goal_scope.Keeper_runtime_contract.mode with
       | "active_goal_ids" ->
-        " Active goal scope is a hard claim gate; create/link a matching task or clear active_goal_ids."
+        (* Scope only stays in [active_goal_ids] mode when a Todo task IS linked
+           to the goal (otherwise the resolver falls back to all_tasks). So a
+           no-eligible here means those scoped tasks exist but are blocked /
+           awaiting verification — not a scope lock to clear. *)
+        " Scoped tasks exist but are blocked or awaiting verification; resolve those blockers."
       | _ -> ""
     in
     Printf.sprintf

--- a/test/test_keeper_runtime_contract.ml
+++ b/test/test_keeper_runtime_contract.ml
@@ -75,31 +75,65 @@ let test_active_goal_ids_filter_claimable_tasks () =
         failf "expected scoped claim, got error: %s" msg)
 ;;
 
-let test_active_goal_ids_block_out_of_scope_tasks () =
+let test_no_scoped_match_falls_back_to_all_tasks () =
   let config = make_config () in
   Fun.protect
     ~finally:(fun () -> cleanup_config config)
     (fun () ->
+      (* Backlog holds a claimable task linked to goal-b while the keeper is
+         scoped to goal-a. Goal-scope is a priority hint, not a hard gate: with
+         no goal-a task to claim, the keeper falls back to all_tasks instead of
+         starving. Restores RFC-0067 §1 allow_empty_goal_scope_fallback. *)
       add_task ~goal_id:"goal-b" config ~title:"goal b task";
       let meta = make_meta ~active_goal_ids:[ "goal-a" ] () in
       let scope =
         Keeper_runtime_contract.resolve_claim_goal_scope ~config ~meta ()
       in
+      check string "fallback mode" "empty_goal_scope_fallback_all_tasks"
+        scope.mode;
+      check (option string) "fallback reason recorded"
+        (Some "no_scoped_claimable_tasks") scope.fallback_reason;
+      check (list string) "effective goal ids preserved" [ "goal-a" ]
+        scope.effective_goal_ids;
       match
         Workspace.claim_next_r config ~agent_name:"keeper-runtime-contract"
           ~task_filter:scope.task_filter
           ()
       with
-      | Workspace.Claim_next_no_eligible
-          { scope_excluded_count; claim_pool_candidate_count; _ } ->
-        check int "scope excluded out-of-goal task" 1 scope_excluded_count;
-        check int "claim pool still saw task" 1 claim_pool_candidate_count
       | Workspace.Claim_next_claimed { task_id; _ } ->
-        failf "out-of-scope task should not be claimed, got %s" task_id
+        check string "claimed via fallback" "task-001" task_id
+      | Workspace.Claim_next_no_eligible { excluded_count; _ } ->
+        failf "expected fallback claim, got no_eligible excluded=%d"
+          excluded_count
       | Workspace.Claim_next_no_unclaimed ->
-        fail "expected no_eligible, got no_unclaimed"
+        fail "expected fallback claim, got no_unclaimed"
       | Workspace.Claim_next_error msg ->
-        failf "expected no_eligible, got error: %s" msg)
+        failf "expected fallback claim, got error: %s" msg)
+;;
+
+let test_scoped_match_present_keeps_isolation () =
+  let config = make_config () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_config config)
+    (fun () ->
+      (* When the keeper's goal DOES have a claimable task, scope stays a hard
+         filter: out-of-scope work is left for its own keeper. Fallback only
+         triggers on an empty scoped pool. *)
+      add_task ~goal_id:"goal-a" config ~title:"goal a task";
+      add_task ~goal_id:"goal-b" config ~title:"goal b task";
+      let meta = make_meta ~active_goal_ids:[ "goal-a" ] () in
+      let scope =
+        Keeper_runtime_contract.resolve_claim_goal_scope ~config ~meta ()
+      in
+      check string "scoped mode" "active_goal_ids" scope.mode;
+      check (option string) "no fallback reason" None scope.fallback_reason;
+      let tasks = Workspace.get_tasks_raw config in
+      let included =
+        tasks
+        |> List.filter scope.task_filter
+        |> List.map (fun (task : Masc_domain.task) -> task.title)
+      in
+      check (list string) "only linked task in scope" [ "goal a task" ] included)
 ;;
 
 let () =
@@ -108,8 +142,10 @@ let () =
     [ ( "active_goal_claim_scope"
       , [ test_case "filters claimable tasks" `Quick
             test_active_goal_ids_filter_claimable_tasks
-        ; test_case "blocks out-of-scope tasks" `Quick
-            test_active_goal_ids_block_out_of_scope_tasks
+        ; test_case "keeps isolation when scoped match present" `Quick
+            test_scoped_match_present_keeps_isolation
+        ; test_case "falls back to all_tasks when no scoped match" `Quick
+            test_no_scoped_match_falls_back_to_all_tasks
         ] )
     ]
 ;;


### PR DESCRIPTION
## 문제

`resolve_claim_goal_scope`가 `active_goal_ids`를 **hard claim gate**로 취급해, 자기 goal에 linked된 claimable Todo가 없는 keeper는 backlog에 일이 있어도 idle로 멈췄습니다.

실측(라이브 `.masc`):
- keeper `imseonghan` = `active_goal_ids=[goal-system-recovery]`, 그 goal로 태깅된 Todo **0개** → 0 claimable → 멈춤
- 동시에 11개 Todo가 `goal_id=None`이라 어떤 goal-scoped keeper에게도 안 보임
- keeper들이 board에서 "scope-blocked deadlock / fleet 폐기"로 over-diagnose

이는 의도된 설계가 아니라, resolver가 pure in-memory match로 단순화되며 **RFC-0067 §1의 `allow_empty_goal_scope_fallback` stopgap(PR #13673)이 제거되어 생긴 regression**입니다.

## 변경

goal-scope를 hard gate에서 **priority hint**로 환원합니다.

- scoped claimable(Todo+unclaimed) task가 있으면 → 기존 hard filter 유지 (격리 보존)
- 없으면 → `all_tasks`로 widen (`mode=empty_goal_scope_fallback_all_tasks`, `fallback_reason` 기록 → widening visible)
- observation hot path(`resolve_observation_claim_goal_scope`)는 **pure-meta 유지** — per-keeper/per-turn backlog disk read 추가 금지 (최근 keeper freeze가 per-call disk read starvation이었음)
- 거짓이 된 힌트 텍스트("Active goal scope is a hard claim gate") 정정

기존 호출부 `keeper_tool_task_runtime.ml:191`이 이미 소비하던 mode label `empty_goal_scope_fallback_all_tasks`를 재사용 (새 문자열 신설 시 두 사이트 drift).

## 남은 구멍 (disclose)

이 fix는 **scoped Todo가 0개일 때만** fallback합니다. scoped Todo가 존재하나 전부 wip-admission으로 막히면 fallback이 발동하지 않아 idle 가능 — 현재 관측된 멈춤(scoped Todo 0)은 100% 해소되지만 이 가설 케이스는 닫지 않습니다. root fix(schedule-level retry: admission 이후 eligible=∅이면 scope 완화)와 `mode:string`→closed variant는 후속 이슈로 분리합니다.

후속: #20673 (wip-block 잔여 구멍 / schedule-level retry), #20674 (mode → closed variant)

## RFC

RFC-0067 §1 `allow_empty_goal_scope_fallback` stopgap 복원. RFC-0067 §3의 atomicity 설계(scope-version token)는 별개의 미구현 방향이며 이 PR은 그 설계가 아니라 stopgap을 사용자(operator) 결정으로 재도입한 것입니다.

WORKAROUND-WAIVED: "fallback" 시그니처는 false positive. typed 두 개념을 string에 압축하는 fallback-resolution 안티패턴이 아니라, RFC-0067 §1에 명시된 기존 동작(goal-scope=priority hint)의 복원이며 `fallback_reason`으로 widening을 visible하게 만듦.

## 검증

- `test_keeper_runtime_contract` 3/3: fallback 동작 + scoped 격리 유지 + 기존 filter
- `tool_task_coverage`: 83중 2 fail = **origin/main 동일 (신규 실패 delta 0)**; 2건은 pre-existing sandbox/dispatch 미주입 backlog
- worktree root(`dune --root .`)에서 빌드+테스트 — main repo 흡수 함정 회피

## 미검증

- claim path의 task_filter + admission_filter 2단계 통합 테스트(현 unit은 task_filter만) — 위 "남은 구멍" 이슈에서 다룸
