### PR TITLE
fix(event-bus): oas_runtime bus Block -> Drop_oldest to stop fleet freeze

### DIFF
--- a/lib/masc_event_bus_policy.ml
+++ b/lib/masc_event_bus_policy.ml
@@ -20,12 +20,25 @@ let oas_runtime =
   {
     bus_name = "oas_runtime";
     buffer_size = 256;
-    policy = Block;
+    policy = Drop_oldest;
     rationale =
-      "Block + 256 buffer: turn-pipeline events must not be dropped; \
-       slow subscriber back-pressures publishers so the keeper hold \
-       state surfaces as observable back-pressure rather than silent \
-       loss.";
+      "Drop_oldest + 256 buffer: oas_runtime carries OBSERVATIONAL \
+       turn-pipeline events (telemetry counter [Keeper_telemetry_consumer], \
+       SSE dashboard relay [Keeper_event_bridge], best-effort compaction \
+       audit [Keeper_compact_audit], metrics [Agent_sdk_metrics_bridge]). \
+       Durable turn/event replay reads the JSONL telemetry surface \
+       (dashboard_oas_bridge.durable_replay_surface, \
+       /api/v1/dashboard/telemetry?source=oas_event), NOT this live bus, so \
+       no subscriber requires completeness. Under [Block] a slow subscriber \
+       fills the 256 buffer and back-pressure freezes EVERY keeper publisher \
+       inside Event_bus.publish with no timeout, suspending the whole fleet \
+       until restart (RCA 2026-06-10: sustained multi-minute keeper freeze, \
+       keepers wedged in turn-pipeline publish; not the HTTP/idle path). \
+       Drop_oldest sheds the stalest observational event instead of freezing \
+       the fleet; the durable surface retains the data. Trade-off: a \
+       sustained >256 backlog can rarely orphan a compaction-audit \
+       start/complete pair (acceptable for a best-effort audit). \
+       masc_domain keeps Block (workspace-invariant events).";
   }
 ;;
 

--- a/lib/masc_event_bus_policy.mli
+++ b/lib/masc_event_bus_policy.mli
@@ -42,16 +42,21 @@ type t = private {
 }
 
 val oas_runtime : t
-(** Bus shared with the OAS turn pipeline.  [Block] is required so a
-    slow subscriber back-pressures publishers (no event loss during
-    turn replay).  256 buffer matches OAS's own default and is the
-    measured headroom for a single turn's emissions. *)
+(** Bus shared with the OAS turn pipeline.  [Drop_oldest] (not [Block]):
+    every subscriber is observational (telemetry counter, SSE relay,
+    best-effort compaction audit, metrics) and durable turn/event replay
+    reads the JSONL telemetry surface, not this live bus — so no consumer
+    requires completeness.  [Block] here coupled keeper turn progress to
+    subscriber drain speed: a slow subscriber filled the 256 buffer and
+    back-pressure froze every keeper publisher inside [Event_bus.publish]
+    with no timeout (RCA 2026-06-10 fleet freeze).  Dropping the stalest
+    observational event is strictly preferable to freezing the fleet. *)
 
 val masc_domain : t
 (** Bus for MASC-domain events (broadcast, heartbeat, keeper, autonomy,
-    harness, trust).  Same configuration as [oas_runtime] — these are
-    semantic events whose loss would silently break the workspace
-    invariants. *)
+    harness, trust).  [Block] (unlike [oas_runtime]) — these are semantic
+    events whose loss would silently break the workspace invariants, and
+    its publishers are not the keeper turn pipeline. *)
 
 val create_bus : t -> Agent_sdk.Event_bus.t
 (** Materialise the chosen configuration and publish the


### PR DESCRIPTION
## 증상

MASC keeper fleet이 잠깐 돌다가 **전부 멈추고 재시작 전까지 회복 안 됨**(간헐적, 수 분~수십 분 지속). watcher로 라이브 freeze를 ground-truth로 포착.

## Root cause

`oas_runtime` Event_bus(키퍼 turn 파이프라인이 FSM/telemetry/lifecycle 이벤트를 publish하는 bus)가 `policy=Block` + 256 버퍼였습니다. **Block이면 가득 찬 subscriber stream이 publisher를 back-pressure** — `Event_bus.publish`가 `Eio.Stream.add`에서 **timeout 없이 블록**합니다. 구독자 하나의 drain이 stall하면(telemetry consumer 등) 256 버퍼가 가득 차고, **모든 키퍼 fiber가 `Event_bus.publish`에서 wedge** → fleet freeze.

이게 6+ iteration의 모든 관측을 통합 설명합니다(상세 RCA: memory `project-masc-keeper-stall-two-causes.md`):
- 동시 freeze / main Eio 도메인 poll-idle / suspended fiber(thread sample 불가시) / timeout 0 발화 / 재시작 회복 / "stream_idle armed인데 미발동"=wedge가 read가 아니라 **event publish**.
- 소거: TLS-cancel(oas#1986 테스트 pass)/빈-frame/CPU-domain-starvation/fd-slot/pool/clock-None/retry 전부 측정-refute. clock=Some라 HTTP 60s 무장→wedge는 HTTP 아님.
- 소스 증거: `pipeline_common.ml` 테스트 주석 "fiber blocked inside Event_bus.publish (Block policy, full stream, no drainer)".

## Fix

`masc_event_bus_policy.oas_runtime`: **`Block` → `Drop_oldest`** (한 줄 + 근거 갱신).

**안전성** (워크어라운드 아님):
- oas_runtime 구독자 4종 모두 **관찰용**: `Keeper_telemetry_consumer`(counter), `Keeper_event_bridge`(SSE relay), `Keeper_compact_audit`(best-effort), `Agent_sdk_metrics_bridge`.
- **durable turn/event replay는 JSONL telemetry surface**(`dashboard_oas_bridge.durable_replay_surface`)가 담당 — 이 라이브 bus 아님. → **no-loss 필요 구독자 0**. (.mli의 기존 "no event loss during turn replay" 근거는 오귀속.)
- Drop_oldest는 가장 오래된 관찰 이벤트를 버릴 뿐 데이터는 durable surface에 보존. fleet-freeze 커플링을 *제거*하는 root fix.
- Trade-off: 지속 >256 backlog 시 compaction-audit start/complete 페어가 드물게 orphan 가능(best-effort 감사라 허용).
- `masc_domain`은 Block 유지(워크스페이스 불변식 이벤트, 키퍼 미publish).

## 검증

- `@check` green (compile-safe).
- **freeze-elimination은 배포 후 watcher로 empirical 검증**(`~/me/.tmp/masc-freeze-watch/`): 트리거(어느 subscriber가 stall)는 동적 bus 메트릭(`masc_oas_bus_subscriber_stream_depth`/`publish_block_seconds`)이 정의만 되고 emit 미배선이라 라이브 직접측정 불가 → fix 배포 후 sustained freeze 재발 없음으로 확인.

## Follow-up

- 동적 bus 메트릭 emit 배선(depth/block_seconds) → 향후 freeze를 라이브 confirm + 범인 subscriber 특정.
- per-subscriber policy(OAS `subscribe ?policy`)로 compaction-audit만 Block 유지 — orphan 가능성까지 제거하고 싶을 때(현재는 bus-wide Drop로 충분).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
