### PR TITLE
fix(keeper,telemetry): remove fleet-freeze mechanism — incremental summary reads + non-blocking FSM audit appends

### DIFF
--- a/lib/dated_jsonl/dated_jsonl.ml
+++ b/lib/dated_jsonl/dated_jsonl.ml
@@ -431,14 +431,22 @@ let iter_range t ~since ~until f =
       end)
       months
 
-(* Per-file non-empty-line count keyed by (path, byte size). Day-files are
-   append-only and split by date: a closed (past-day) file never changes, so
-   its count is a pure function of its size. Caching it means a repeated
-   full-store count re-reads only the current day-file (whose size grows)
-   instead of every historical file. Any size change (append, prune, rewrite)
-   misses the cache and recomputes, so the cached count never drifts. *)
+(* Per-file non-empty-line count cached as (boundary, count). Day-files are
+   append-only and split by date, so the count of newline-terminated lines
+   before a byte boundary is a pure function of the file prefix: a closed
+   (past-day) file hits the cache forever, and the growing current-day file
+   re-reads only the bytes appended since the last call instead of the whole
+   file. A boundary past the current size (prune/rewrite) falls back to a
+   full rescan, so the cached count never drifts.
+
+   Counting contract: only '\n'-terminated lines are counted. A trailing
+   partially-flushed line is invisible until its newline lands — for the
+   monotonic dashboard counters served by [count_entries] that is the
+   correct staleness direction (undercount by at most the in-flight line).
+   Audit callers that must count an unterminated trailing line use
+   [count_entries_uncached]. *)
 type file_count_entry =
-  { fc_size : int
+  { fc_boundary : int
   ; fc_count : int
   }
 
@@ -447,24 +455,31 @@ let file_count_cache_mu = Stdlib.Mutex.create ()
 
 let count_non_empty_lines_cached path =
   let size = try (Unix.stat path).Unix.st_size with Unix.Unix_error _ -> -1 in
-  let cached =
-    if size < 0
-    then None
-    else
+  if size < 0
+  then count_non_empty_lines path
+  else begin
+    let cached =
       Stdlib.Mutex.protect file_count_cache_mu (fun () ->
-        match Hashtbl.find_opt file_count_cache path with
-        | Some e when e.fc_size = size -> Some e.fc_count
-        | _ -> None)
-  in
-  match cached with
-  | Some n -> n
-  | None ->
-    let n = count_non_empty_lines path in
-    if size >= 0
-    then
+        Hashtbl.find_opt file_count_cache path)
+    in
+    match cached with
+    | Some e when e.fc_boundary = size -> e.fc_count
+    | cached ->
+      let from, base =
+        match cached with
+        | Some e when e.fc_boundary < size -> e.fc_boundary, e.fc_count
+        | _ -> 0, 0
+      in
+      let delta, boundary =
+        Fs_compat.fold_appended_lines ~path ~from ~init:0
+          ~f:(fun acc _line -> acc + 1)
+      in
+      let count = base + delta in
       Stdlib.Mutex.protect file_count_cache_mu (fun () ->
-        Hashtbl.replace file_count_cache path { fc_size = size; fc_count = n });
-    n
+        Hashtbl.replace file_count_cache path
+          { fc_boundary = boundary; fc_count = count });
+      count
+  end
 
 let fold_day_file_counts t ~counter =
   let months = list_month_dirs t.base_dir in
@@ -482,61 +497,20 @@ let fold_day_file_counts t ~counter =
    that must not observe any caching use this directly. *)
 let count_entries_uncached t = fold_day_file_counts t ~counter:count_non_empty_lines
 
-(* Per-file-cached full count. O(current day-file) in steady state because
-   closed day-files hit [file_count_cache]. Size-keyed, so it carries none of
-   the staleness window of the [count_cache] TTL below. *)
+(* Per-file-cached full count. O(appended bytes) in steady state: closed
+   day-files hit [file_count_cache] outright and the growing current-day
+   file re-reads only its delta. *)
 let count_entries_incremental t =
   fold_day_file_counts t ~counter:count_non_empty_lines_cached
 
-(* RFC-0162 §3.2: process-local TTL cache around [count_entries].
-
-   The dashboard refreshes Tool Monitor / Fleet Health / Tool Quality
-   surfaces every 30 s. Each surface calls [count_entries] on the
-   same store (`.masc/tool_calls/`, `.masc/oas-events/`, etc.),
-   opening and closing every day-file to count newlines. With 30
-   day-files × 15 MB on a single store this turns into a hot
-   read-side load that competes for the same OS fd budget as the
-   write-side append it is reporting on.
-
-   The cached count is good for [count_cache_ttl_sec] seconds. A
-   stale count is acceptable for the dashboard surface: appends are
-   monotonic increases, so a slightly stale total under-counts by
-   at most [ttl × append_rate], which is well below the dashboard
-   refresh granularity. Tests and audit callers that need the
-   live count use [count_entries_uncached]. *)
-let count_cache_ttl_sec = 10.0
-
-type count_cache_entry =
-  { entry_count : int
-  ; computed_at : float
-  }
-
-let count_cache : (string, count_cache_entry) Hashtbl.t = Hashtbl.create 8
-let count_cache_mu = Stdlib.Mutex.create ()
-
-let count_entries t =
-  let key = t.base_dir in
-  let now = Unix.gettimeofday () in
-  let cached_opt =
-    Stdlib.Mutex.protect count_cache_mu (fun () ->
-      match Hashtbl.find_opt count_cache key with
-      | Some entry when now -. entry.computed_at < count_cache_ttl_sec ->
-        Some entry.entry_count
-      | _ -> None)
-  in
-  match cached_opt with
-  | Some n -> n
-  | None ->
-    (* Per-file cache keeps this miss O(current day-file) even though the
-       store has many large historical files. *)
-    let n = count_entries_incremental t in
-    Stdlib.Mutex.protect count_cache_mu (fun () ->
-      Hashtbl.replace count_cache key { entry_count = n; computed_at = now });
-    n
-;;
+(* The RFC-0162 §3.2 10s-TTL store-level cache that used to sit here is
+   removed: the boundary-keyed per-file cache above makes a [count_entries]
+   call O(appended bytes), so the TTL layer no longer bought anything and
+   only added a staleness window plus a second cache surface to reason
+   about. *)
+let count_entries = count_entries_incremental
 
 let reset_count_cache_for_testing () =
-  Stdlib.Mutex.protect count_cache_mu (fun () -> Hashtbl.reset count_cache);
   Stdlib.Mutex.protect file_count_cache_mu (fun () -> Hashtbl.reset file_count_cache)
 ;;
 let read_range t ~since ~until =

--- a/lib/dated_jsonl/dated_jsonl.mli
+++ b/lib/dated_jsonl/dated_jsonl.mli
@@ -82,22 +82,24 @@ val prune : t -> days:int -> int
 [@@@warning "-32"]
 val count_entries : t -> int
 [@@@warning "+32"]
-(* [count_entries t] returns the total number of non-empty lines across all
-   day-files. Scans files by counting newlines without JSON parsing.
-
-   Backed by a process-local TTL cache (RFC-0162 §3.2) keyed on
-   [base_dir]. The cached count is good for ~10 s; concurrent
-   dashboard refresh surfaces share the result so a 30 s window
-   costs one scan, not three. Tests and audit callers that need
-   the live count should use [count_entries_uncached]. *)
+(* [count_entries t] returns the total number of non-empty,
+   newline-terminated lines across all day-files. Scans bytes without
+   JSON parsing, backed by a per-file (boundary, count) cache: closed
+   day-files are never re-read and the growing current-day file only
+   re-reads the bytes appended since the previous call, so a call is
+   O(appended bytes) — exact, no TTL staleness window (the RFC-0162
+   §3.2 TTL layer this replaced traded 10 s of staleness for a bound
+   the incremental cache now provides structurally). A trailing line
+   not yet terminated by '\n' is not counted until its newline lands;
+   audit callers that must include it use [count_entries_uncached]. *)
 
 val count_entries_uncached : t -> int
-(** Like [count_entries] but bypasses the TTL cache. Use in tests
-    or rare audit paths that must observe the live filesystem
-    count. RFC-0162 §3.2. *)
+(** Like [count_entries] but bypasses the per-file cache and counts a
+    trailing unterminated line. Use in tests or rare audit paths that
+    must observe the live filesystem byte-for-byte. *)
 
 val reset_count_cache_for_testing : unit -> unit
-(** Reset the [count_entries] TTL cache. Test-only. *)
+(** Reset the per-file incremental count cache. Test-only. *)
 
 val load_tail_lines : string -> max_lines:int -> string list
 (** [load_tail_lines file ~max_lines] efficiently reads the last [max_lines]

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -448,6 +448,55 @@ let load_jsonl_diagnostics (path : string) : Yojson.Safe.t list * int =
     Malformed lines are logged and dropped. *)
 let load_jsonl (path : string) : Yojson.Safe.t list = fst (load_jsonl_diagnostics path)
 
+(* Fold over newline-terminated lines appended after byte offset [from].
+   Append-only JSONL stores never rewrite earlier bytes, so a (offset,
+   accumulator) pair is a pure function of the file prefix — callers cache
+   it and re-scan only the delta instead of the whole file. Bytes after the
+   last '\n' (a partially flushed line) are excluded from both the fold and
+   the returned boundary, so the next call re-reads them once the writer
+   completes the line. A [from] beyond EOF (file truncated/rotated) falls
+   back to a full scan from byte 0; callers detect shrinkage the same way
+   via the returned boundary. Blank lines advance the boundary but are not
+   folded. *)
+let fold_appended_lines ~path ~from ~init ~f =
+  if not (file_exists path)
+  then init, 0
+  else begin
+    let ic = open_in_bin path in
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr ic)
+      (fun () ->
+         let len = in_channel_length ic in
+         let from = if from < 0 || from > len then 0 else from in
+         seek_in ic from;
+         let chunk = Bytes.create 65536 in
+         let line_buf = Buffer.create 256 in
+         let acc = ref init in
+         let boundary = ref from in
+         let pos = ref from in
+         let rec loop () =
+           let n = input ic chunk 0 (Bytes.length chunk) in
+           if n > 0
+           then begin
+             for i = 0 to n - 1 do
+               match Bytes.get chunk i with
+               | '\n' ->
+                 let line = Buffer.contents line_buf in
+                 Buffer.clear line_buf;
+                 boundary := !pos + i + 1;
+                 if not (String.equal (String.trim line) "")
+                 then acc := f !acc line
+               | c -> Buffer.add_char line_buf c
+             done;
+             pos := !pos + n;
+             loop ()
+           end
+         in
+         loop ();
+         !acc, !boundary)
+  end
+;;
+
 (** Stream JSONL line-by-line, folding [f] over parsed values.
 
     Uses [Eio.Buf_read.lines] over [Eio.Path.with_open_in] when the

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -144,6 +144,27 @@ val fold_jsonl_lines
   -> string
   -> 'acc
 
+(** [fold_appended_lines ~path ~from ~init ~f] folds [f] over the raw
+    non-blank, newline-terminated lines whose bytes start at offset
+    [from], returning [(acc, boundary)] where [boundary] is the offset
+    just past the last ['\n'] consumed.
+
+    Contract for incremental readers over append-only JSONL stores:
+    cache [(boundary, acc)] per path and pass the cached [boundary] as
+    [from] on the next call — only the appended delta is re-read.
+    Bytes after the last ['\n'] (a partially flushed line) are neither
+    folded nor included in [boundary], so they are re-read once the
+    writer completes the line. A [from] outside [0, file_size] (file
+    truncated or rotated) restarts the scan from byte 0. Returns
+    [(init, 0)] when [path] does not exist. Lines are raw strings;
+    callers parse (and decide how to surface malformed rows). *)
+val fold_appended_lines
+  :  path:string
+  -> from:int
+  -> init:'acc
+  -> f:('acc -> string -> 'acc)
+  -> 'acc * int
+
 (** Append JSON value as line to JSONL file.
 
     Backed by a process-local per-path fd cache (RFC-0162 §3.4).

--- a/lib/keeper/keeper_transition_audit.ml
+++ b/lib/keeper/keeper_transition_audit.ml
@@ -108,6 +108,138 @@ let observe_append_failure ~site exn =
     Log.Keeper.warn "transition_audit %s failed: %s" site (Printexc.to_string exn)
 ;;
 
+(* ================================================================ *)
+(* Async default-store append queue                                  *)
+(*                                                                   *)
+(* Every FSM transition used to run [Dated_jsonl.append] inline on   *)
+(* the keeper fiber: fd_accountant Log_writer semaphore -> per-store *)
+(* Eio.Mutex shared by ALL keepers -> blocking write+flush. The      *)
+(* 2026-06-10 fleet-freeze capture shows 12 keepers whose last       *)
+(* observable event was the [fsm:transition] log line emitted        *)
+(* immediately before this append — turn liveness was coupled to     *)
+(* forensics durability through untimed shared locks. Per the module *)
+(* contract (see [append_to_sink] doc) the in-memory ring is the     *)
+(* authoritative live trail and the JSONL store is restart           *)
+(* forensics, so the store write must never park a turn: recorders   *)
+(* enqueue here and a maintenance fiber drains the queue off the     *)
+(* keeper hot path (same shape as [Keeper_tool_call_log]'s async     *)
+(* append).                                                          *)
+(*                                                                   *)
+(* The queue is bounded so a stalled drain cannot grow memory        *)
+(* without limit; an overflow drops the incoming record, counts it   *)
+(* under the existing TransitionAuditFailures metric, and warns.     *)
+(* By contract a drop loses forensics rows only, never ring (live)   *)
+(* state. Until [start_flush_fiber] runs (tests, non-server          *)
+(* embedders) appends stay synchronous.                              *)
+(* ================================================================ *)
+
+type pending_append =
+  { pending_site : string
+  ; pending_json : Yojson.Safe.t
+  }
+
+let append_queue_capacity = 4096
+let append_flush_interval_s = 0.5
+let append_queue_mu = Stdlib.Mutex.create ()
+let append_queue : pending_append Stdlib.Queue.t = Stdlib.Queue.create ()
+let async_append_active = Atomic.make false
+let append_queue_dropped = Atomic.make 0
+
+let with_append_queue_lock f =
+  Stdlib.Mutex.lock append_queue_mu;
+  Fun.protect ~finally:(fun () -> Stdlib.Mutex.unlock append_queue_mu) f
+;;
+
+let queued_count_for_testing () =
+  with_append_queue_lock (fun () -> Stdlib.Queue.length append_queue)
+;;
+
+let dropped_count_for_testing () = Atomic.get append_queue_dropped
+
+let append_now ~site json =
+  match get_default_store () with
+  | None -> ()
+  | Some store ->
+    (try Dated_jsonl.append store json with
+     | exn -> observe_append_failure ~site exn)
+;;
+
+let flush_pending () =
+  let batch =
+    with_append_queue_lock (fun () ->
+      let drained = Stdlib.Queue.create () in
+      Stdlib.Queue.transfer append_queue drained;
+      drained)
+  in
+  let n = Stdlib.Queue.length batch in
+  Stdlib.Queue.iter
+    (fun { pending_site; pending_json } -> append_now ~site:pending_site pending_json)
+    batch;
+  n
+;;
+
+let enqueue_or_append ~site json =
+  if not (Atomic.get async_append_active)
+  then append_now ~site json
+  else begin
+    let dropped =
+      with_append_queue_lock (fun () ->
+        if Stdlib.Queue.length append_queue >= append_queue_capacity
+        then true
+        else begin
+          Stdlib.Queue.add { pending_site = site; pending_json = json } append_queue;
+          false
+        end)
+    in
+    if dropped
+    then begin
+      Otel_metric_store.inc_counter
+        Keeper_metrics.(to_string TransitionAuditFailures)
+        ~labels:[ "site", "async_queue_overflow" ]
+        ();
+      let dropped_count = Atomic.fetch_and_add append_queue_dropped 1 + 1 in
+      Log.Keeper.warn
+        "transition_audit: dropped %d forensics record(s) — async append queue \
+         full (drain fiber stalled or store unavailable)"
+        dropped_count
+    end
+  end
+;;
+
+let start_flush_fiber ~sw ~clock =
+  Atomic.set async_append_active true;
+  Eio.Fiber.fork_daemon ~sw (fun () ->
+    Log.Keeper.info
+      "transition_audit: async flush fiber started (interval=%.1fs, capacity=%d)"
+      append_flush_interval_s
+      append_queue_capacity;
+    let rec loop () =
+      match Eio.Time.sleep clock append_flush_interval_s with
+      | exception Eio.Cancel.Cancelled _ -> `Stop_daemon
+      | () ->
+        (match flush_pending () with
+         | (_ : int) -> ()
+         | exception Eio.Cancel.Cancelled _ -> ()
+         | exception exn ->
+           Log.Keeper.warn
+             "transition_audit: async flush iteration failed: %s"
+             (Printexc.to_string exn));
+        loop ()
+    in
+    loop ());
+  Shutdown.register ~name:"keeper_transition_audit_flush" ~priority:24 (fun () ->
+    try
+      let n = flush_pending () in
+      if n > 0
+      then Log.Keeper.info "transition_audit: shutdown flush wrote %d records" n
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
+      Log.Keeper.warn
+        "transition_audit: shutdown flush failed: %s"
+        (Printexc.to_string exn))
+;;
+
 (** Append a single jsonl line for the given transition. Wraps the record
     json with the keeper name so a single sink file can mux multiple
     keepers. Any IO error is observed and suppressed: the in-memory ring is
@@ -131,41 +263,29 @@ let append_to_sink ~keeper_name (rec_ : transition_record) =
 ;;
 
 let append_to_default_store ~keeper_name (rec_ : transition_record) =
-  match get_default_store () with
-  | None -> ()
-  | Some store ->
-    let json = `Assoc [ "keeper", `String keeper_name; "record", to_json rec_ ] in
-    (try Dated_jsonl.append store json with
-     | exn -> observe_append_failure ~site:"default_transition_append" exn)
+  let json = `Assoc [ "keeper", `String keeper_name; "record", to_json rec_ ] in
+  enqueue_or_append ~site:"default_transition_append" json
 ;;
 
 let append_completed_turn_to_default_store ~keeper_name (rec_ : completed_turn_record) =
-  match get_default_store () with
-  | None -> ()
-  | Some store ->
-    let json =
-      `Assoc
-        [ "keeper", `String keeper_name; "completed_turn", completed_turn_to_json rec_ ]
-    in
-    (try Dated_jsonl.append store json with
-     | exn -> observe_append_failure ~site:"default_completed_append" exn)
+  let json =
+    `Assoc
+      [ "keeper", `String keeper_name; "completed_turn", completed_turn_to_json rec_ ]
+  in
+  enqueue_or_append ~site:"default_completed_append" json
 ;;
 
 let append_turn_fsm_transition_to_default_store
       ~keeper_name
       (rec_ : turn_fsm_transition_record)
   =
-  match get_default_store () with
-  | None -> ()
-  | Some store ->
-    let json =
-      `Assoc
-        [ "keeper", `String keeper_name
-        ; "turn_fsm_transition", turn_fsm_transition_to_json rec_
-        ]
-    in
-    (try Dated_jsonl.append store json with
-     | exn -> observe_append_failure ~site:"default_turn_fsm_append" exn)
+  let json =
+    `Assoc
+      [ "keeper", `String keeper_name
+      ; "turn_fsm_transition", turn_fsm_transition_to_json rec_
+      ]
+  in
+  enqueue_or_append ~site:"default_turn_fsm_append" json
 ;;
 
 let record_transition ~keeper_name (rec_ : transition_record) =
@@ -201,6 +321,10 @@ let recent_transitions_json ~keeper_name ~limit : Yojson.Safe.t =
     match sink_path (), get_default_store () with
     | Some _, _ | _, None -> `List []
     | None, Some store ->
+      (* Store readers run on dashboard fibers, not keeper turns: draining
+         the async queue here is a cheap way to keep store-backed reads
+         consistent with just-recorded transitions. *)
+      let (_ : int) = flush_pending () in
       let items =
         Dated_jsonl.read_recent store (max limit 1 * 8)
         |> List.filter_map (function
@@ -263,6 +387,7 @@ let recent_completed_turns_from_store ~keeper_name ~limit =
   match sink_path (), get_default_store () with
   | Some _, _ | _, None -> []
   | None, Some store ->
+    let (_ : int) = flush_pending () in
     Dated_jsonl.read_recent store (max limit 1 * 8)
     |> List.filter_map (function
       | `Assoc fields ->
@@ -296,8 +421,15 @@ module For_testing = struct
   let reset_state () =
     Hashtbl.clear rings;
     Hashtbl.clear completed_turn_rings;
+    with_append_queue_lock (fun () -> Stdlib.Queue.clear append_queue);
+    Atomic.set async_append_active false;
+    Atomic.set append_queue_dropped 0;
     default_store_ref := None
   ;;
+
+  let queued_count = queued_count_for_testing
+  let dropped_count = dropped_count_for_testing
+  let set_async_append_active v = Atomic.set async_append_active v
 
   let clear_completed_turn_ring ~keeper_name =
     Hashtbl.remove completed_turn_rings keeper_name

--- a/lib/keeper/keeper_transition_audit.mli
+++ b/lib/keeper/keeper_transition_audit.mli
@@ -41,8 +41,35 @@ val record_turn_fsm_transition :
 val recent_completed_turns :
   keeper_name:string -> limit:int -> completed_turn_record list
 
+(** {1 Async Forensics Append}
+
+    The in-memory rings above are the authoritative live trail; the
+    dated-JSONL default store is restart forensics. Recorders therefore
+    never write the store inline on the keeper fiber once
+    [start_flush_fiber] has run — they enqueue, and the flush fiber
+    drains every 0.5 s. Before [start_flush_fiber] (tests, non-server
+    embedders) recording appends synchronously, preserving the previous
+    behavior. *)
+
+(** Start the background drain fiber on [sw] and switch recorders to
+    enqueue mode. Registers a shutdown hook that flushes the remaining
+    queue. Call once from server bootstrap. *)
+val start_flush_fiber : sw:Eio.Switch.t -> clock:_ Eio.Time.clock -> unit
+
+(** Drain all queued forensics records to the default store now.
+    Returns the number of records written. Store-backed readers call
+    this before reading; safe from any fiber. *)
+val flush_pending : unit -> int
+
 module For_testing : sig
   val reset_state : unit -> unit
   val clear_completed_turn_ring : keeper_name:string -> unit
   val observe_append_failure : site:string -> exn -> unit
+  val queued_count : unit -> int
+  val dropped_count : unit -> int
+
+  (** Toggle enqueue mode without spawning the drain fiber, so tests can
+      exercise the queue deterministically. [reset_state] sets it back to
+      false (synchronous appends). *)
+  val set_async_append_active : bool -> unit
 end

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -145,11 +145,6 @@ let run (ctx : ctx)
          Keeper_registry.mark_turn_provider_attempt_started
            ~base_path:config.base_path
            meta.name;
-         Keeper_turn_fsm.emit_transition
-           ~keeper_name:meta.name
-           ~turn_id:keeper_turn_id
-           ~prev:Keeper_turn_fsm.Awaiting_provider
-           Keeper_turn_fsm.Streaming;
          Keeper_unified_turn_attempt_watchdog.dispatch
            ~clock
            ~attempt_watchdog_s:None
@@ -163,6 +158,16 @@ let run (ctx : ctx)
                ~keeper_turn_id
                ())
            ~run:(fun () ->
+             (* Emit INSIDE the watchdog window: the 2026-06-10 freeze showed
+                this transition's forensics append can park, and any park
+                before [dispatch] arms its [Eio.Time.with_timeout_exn] is
+                unrescuable by design — the safety cap must cover everything
+                that happens once the keeper claims to be Streaming. *)
+             Keeper_turn_fsm.emit_transition
+               ~keeper_name:meta.name
+               ~turn_id:keeper_turn_id
+               ~prev:Keeper_turn_fsm.Awaiting_provider
+               Keeper_turn_fsm.Streaming;
              Keeper_agent_run.run_turn
                ~config
                ~meta:run_meta

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -74,6 +74,10 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
     ~cluster_name:state.workspace_config.backend_config.Backend_types.cluster_name
     ();
   Keeper_tool_call_log.start_flush_fiber ~sw ~clock;
+  (* Transition-audit forensics writes leave the keeper hot path: recorders
+     enqueue and this fiber drains (2026-06-10 fleet-freeze fix — the inline
+     append serialized all keepers on one store mutex). *)
+  Keeper_transition_audit.start_flush_fiber ~sw ~clock;
   Otel_dispatch_hook.install ();
   (* PR-S3: register the OTel/Otel_metric_store dispatch span wrapper. [Tool_dispatch]
      (lib/tool/, masc_tool_dispatch) no longer code-depends on [Tool_telemetry]
@@ -212,6 +216,10 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
                + prune_dir (Filename.concat masc "activity-events")
                + prune_dir (Filename.concat masc "voice_sessions")
                + prune_dir (Filename.concat masc "tool_calls")
+               (* transition-audit was absent from this list since its
+                  introduction (RFC-0002) — 82 MB across 3 month-dirs by
+                  2026-06-10, scanned by every store-fallback read. *)
+               + prune_dir (Filename.concat masc "transition-audit")
              in
              if total > 0
              then

--- a/lib/telemetry_unified/telemetry_unified.ml
+++ b/lib/telemetry_unified/telemetry_unified.ml
@@ -788,26 +788,105 @@ let execution_receipt_summary_stats ~masc_root =
            (count_acc, latest_acc))
        (0, None)
 
+(* Per-trace-file incremental summary cache for the snapshot loop.
+
+   The 2 s [Dashboard_snapshot.refresh_loop] calls [summary_json] on every
+   cycle; until 2026-06-10 this path tail-re-parsed every trace file in
+   every keeper dir (~480 MB store) through Yojson on each cycle, pegging
+   Executor_pool worker domains from boot — the measured CPU burn behind
+   the 16-keeper fleet freeze (capture:
+   .tmp/masc-freeze-captures/20260610-094442).
+
+   Trace files are append-only whole-line JSONL, so (tool-call count,
+   latest tool-call ts) up to a byte boundary is a pure function of the
+   file prefix: closed trace files hit the cache forever and the live
+   trace file re-parses only the bytes appended since the previous cycle.
+   A boundary past the current size (rotation/manual edit) rescans from
+   byte 0. Entries for deleted files are dropped on the next readdir pass
+   that no longer lists them only via rescan-from-zero semantics; the
+   residual map entry costs one small record per departed path. *)
+type trajectory_file_summary =
+  { tfs_boundary : int
+  ; tfs_tool_calls : int
+  ; tfs_latest_ts : float option
+  }
+
+let trajectory_summary_cache : (string, trajectory_file_summary) Hashtbl.t =
+  Hashtbl.create 64
+
+let trajectory_summary_cache_mu = Stdlib.Mutex.create ()
+
+let reset_trajectory_summary_cache_for_testing () =
+  Stdlib.Mutex.protect trajectory_summary_cache_mu (fun () ->
+    Hashtbl.reset trajectory_summary_cache)
+
+let trajectory_file_summary path : trajectory_file_summary option =
+  match Unix.stat path with
+  | exception (Unix.Unix_error _ | Sys_error _) -> None
+  | st ->
+    let size = st.Unix.st_size in
+    let cached =
+      Stdlib.Mutex.protect trajectory_summary_cache_mu (fun () ->
+        Hashtbl.find_opt trajectory_summary_cache path)
+    in
+    (match cached with
+     | Some e when e.tfs_boundary = size -> Some e
+     | cached ->
+       let from, count0, latest0 =
+         match cached with
+         | Some e when e.tfs_boundary < size ->
+           e.tfs_boundary, e.tfs_tool_calls, e.tfs_latest_ts
+         | _ -> 0, 0, None
+       in
+       let (count, latest), boundary =
+         Fs_compat.fold_appended_lines ~path ~from ~init:(count0, latest0)
+           ~f:(fun (count, latest) line ->
+             match Yojson.Safe.from_string line with
+             | exception Yojson.Json_error _ -> count, latest
+             | json ->
+               if trajectory_tool_call_json json
+               then begin
+                 let latest =
+                   match extract_ts json with
+                   | ts when ts > 0.0 -> max_ts_opt latest ts
+                   | _ -> latest
+                 in
+                 count + 1, latest
+               end
+               else count, latest)
+       in
+       let entry =
+         { tfs_boundary = boundary; tfs_tool_calls = count; tfs_latest_ts = latest }
+       in
+       Stdlib.Mutex.protect trajectory_summary_cache_mu (fun () ->
+         Hashtbl.replace trajectory_summary_cache path entry);
+       Some entry)
+
 let trajectory_tool_call_summary_stats ~masc_root =
   discover_trajectory_keeper_dirs masc_root
   |> List.fold_left
        (fun (count_acc, latest_acc) (_name, dir) ->
-         let entries =
-           protect_source_read Trajectory_tool_call
-             ~site:"trajectory_tool_call_summary_readdir" ~default:[]
-             (fun () ->
-             if not (Sys.file_exists dir) then []
-             else Sys.readdir dir
-             |> Array.to_list
-             |> List.filter (fun name -> Filename.check_suffix name ".jsonl")
-             |> List.concat_map (fun name ->
-                  read_trajectory_file (Filename.concat dir name)
-                    ~max_lines:unbounded_window_scan_cap ()))
-         in
-         ( count_acc + List.length entries,
-           match latest_ts_of_entries entries with
-           | Some ts -> max_ts_opt latest_acc ts
-           | None -> latest_acc ))
+         protect_source_read Trajectory_tool_call
+           ~site:"trajectory_tool_call_summary_readdir"
+           ~default:(count_acc, latest_acc)
+           (fun () ->
+             if not (Sys.file_exists dir) then (count_acc, latest_acc)
+             else
+               Sys.readdir dir
+               |> Array.to_list
+               |> List.filter (fun name -> Filename.check_suffix name ".jsonl")
+               |> List.fold_left
+                    (fun (count_acc, latest_acc) name ->
+                      match
+                        trajectory_file_summary (Filename.concat dir name)
+                      with
+                      | None -> count_acc, latest_acc
+                      | Some s ->
+                        ( count_acc + s.tfs_tool_calls,
+                          match s.tfs_latest_ts with
+                          | Some ts -> max_ts_opt latest_acc ts
+                          | None -> latest_acc ))
+                    (count_acc, latest_acc)))
        (0, None)
 
 let goal_event_summary_stats ~masc_root =
@@ -1050,3 +1129,10 @@ let summary_json ~base_path ~masc_root () : Yojson.Safe.t =
     ("coverage_gaps", `List coverage_gaps);
     ("total_entries", `Int total_entries);
   ]
+
+module For_testing = struct
+  let trajectory_tool_call_summary_stats = trajectory_tool_call_summary_stats
+
+  let reset_trajectory_summary_cache_for_testing =
+    reset_trajectory_summary_cache_for_testing
+end

--- a/lib/telemetry_unified/telemetry_unified.mli
+++ b/lib/telemetry_unified/telemetry_unified.mli
@@ -103,3 +103,16 @@ val replay_retention_json :
 (** [replay_retention_json ~base_path ~masc_root ~sources] returns the
     provenance block for the dashboard telemetry replay endpoint, including
     the selected source list and durable stores read for each source. *)
+
+module For_testing : sig
+  val trajectory_tool_call_summary_stats :
+    masc_root:string -> int * float option
+  (** Exposes the per-trace-file incremental summary used by
+      [summary_json] for the trajectory source: (tool-call entry count,
+      latest tool-call ts). Production callers go through
+      [summary_json]. *)
+
+  val reset_trajectory_summary_cache_for_testing : unit -> unit
+  (** Clear the per-file (boundary, count, latest_ts) cache so a test
+      observes cold-start behavior. *)
+end

--- a/test/test_dated_jsonl_count_cache.ml
+++ b/test/test_dated_jsonl_count_cache.ml
@@ -1,10 +1,12 @@
-(** RFC-0162 §3.2 — [Dated_jsonl.count_entries] TTL cache tests.
+(** [Dated_jsonl.count_entries] incremental per-file cache tests.
 
-    Verifies the cache returns a stale (but cheap) count within the
-    TTL window and refreshes after expiry. The contract is:
-      - cached value within 10 s window
-      - [count_entries_uncached] always scans
-      - [reset_count_cache_for_testing] clears state *)
+    The boundary-keyed cache replaced the RFC-0162 §3.2 TTL layer:
+    [count_entries] is exact (no staleness window) and O(appended bytes)
+    per call. The contract is:
+      - growth behind the cache is visible on the very next call
+      - only '\n'-terminated lines are counted; [count_entries_uncached]
+        also counts a trailing unterminated line
+      - [reset_count_cache_for_testing] clears per-file state *)
 
 open Alcotest
 
@@ -36,41 +38,85 @@ let write_jsonl_line path line =
   close_out oc
 ;;
 
-(* Seed a Dated_jsonl store with [n] records on a single day so we
-   have a deterministic count_entries baseline. *)
-let seed_store base_dir n =
+let write_raw path content =
+  let dir = Filename.dirname path in
+  if not (Sys.file_exists dir) then Unix.mkdir dir 0o755;
+  let oc =
+    open_out_gen [ Open_append; Open_creat; Open_wronly ] 0o644 path
+  in
+  output_string oc content;
+  close_out oc
+;;
+
+let today_day_path base_dir =
   let tm = Unix.gmtime (Unix.gettimeofday ()) in
   let month_dir =
     Printf.sprintf "%04d-%02d" (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1)
   in
   let day_file = Printf.sprintf "%02d.jsonl" tm.Unix.tm_mday in
-  let path = Filename.concat (Filename.concat base_dir month_dir) day_file in
+  Filename.concat (Filename.concat base_dir month_dir) day_file
+;;
+
+(* Seed a Dated_jsonl store with [n] records on a single day so we
+   have a deterministic count_entries baseline. *)
+let seed_store base_dir n =
+  let path = today_day_path base_dir in
   for i = 1 to n do
     write_jsonl_line path (Printf.sprintf "{\"seq\":%d}" i)
   done
 ;;
 
-let test_cache_returns_stale_within_ttl () =
+let test_growth_is_visible_immediately () =
   Dated_jsonl.reset_count_cache_for_testing ();
-  let base = tmpdir "count_cache_stale" in
+  let base = tmpdir "count_incr_growth" in
   seed_store base 10;
   let t = Dated_jsonl.create ~base_dir:base () in
-  (* First call populates the cache. *)
-  let first = Dated_jsonl.count_entries t in
-  check int "first call counts 10" 10 first;
-  (* Add 5 more records *behind the cache*. *)
+  check int "first call counts 10" 10 (Dated_jsonl.count_entries t);
+  (* Append behind the populated cache: the incremental scan must pick the
+     delta up on the very next call — no TTL staleness window exists. *)
   seed_store base 5;
-  (* Cached value (10) is returned — staleness is the contract. *)
-  let cached = Dated_jsonl.count_entries t in
-  check int "cached count still 10 within TTL" 10 cached;
-  (* Uncached path observes the true count. *)
-  let live = Dated_jsonl.count_entries_uncached t in
-  check int "uncached path sees the live 15" 15 live
+  check int "growth visible on next call" 15 (Dated_jsonl.count_entries t);
+  check
+    int
+    "cached count equals uncached"
+    (Dated_jsonl.count_entries_uncached t)
+    (Dated_jsonl.count_entries t)
+;;
+
+let test_unterminated_trailing_line () =
+  Dated_jsonl.reset_count_cache_for_testing ();
+  let base = tmpdir "count_incr_partial" in
+  seed_store base 2;
+  let path = today_day_path base in
+  (* Simulate a writer that flushed half a line: no trailing newline. *)
+  write_raw path "{\"seq\":3";
+  let t = Dated_jsonl.create ~base_dir:base () in
+  check int "partial line not counted" 2 (Dated_jsonl.count_entries t);
+  check int "uncached counts the partial tail" 3 (Dated_jsonl.count_entries_uncached t);
+  (* Writer completes the line: both paths agree again. *)
+  write_raw path "}\n";
+  check int "completed line now counted" 3 (Dated_jsonl.count_entries t);
+  check int "uncached agrees" 3 (Dated_jsonl.count_entries_uncached t)
+;;
+
+let test_shrunk_file_rescans () =
+  Dated_jsonl.reset_count_cache_for_testing ();
+  let base = tmpdir "count_incr_shrink" in
+  seed_store base 6;
+  let t = Dated_jsonl.create ~base_dir:base () in
+  check int "baseline 6" 6 (Dated_jsonl.count_entries t);
+  (* Rewrite the day-file smaller (prune/rotation shape): the cached
+     boundary now exceeds the file size, forcing a full rescan. *)
+  let path = today_day_path base in
+  Sys.remove path;
+  write_jsonl_line path "{\"seq\":1}";
+  write_jsonl_line path "{\"seq\":2}";
+  check int "shrunk file rescanned from zero" 2 (Dated_jsonl.count_entries t)
 ;;
 
 let test_reset_clears_cache () =
   Dated_jsonl.reset_count_cache_for_testing ();
-  let base = tmpdir "count_cache_reset" in
+  let base = tmpdir "count_incr_reset" in
   seed_store base 3;
   let t = Dated_jsonl.create ~base_dir:base () in
   let _ = Dated_jsonl.count_entries t in
@@ -82,8 +128,8 @@ let test_reset_clears_cache () =
 
 let test_distinct_stores_have_independent_caches () =
   Dated_jsonl.reset_count_cache_for_testing ();
-  let base_a = tmpdir "count_cache_a" in
-  let base_b = tmpdir "count_cache_b" in
+  let base_a = tmpdir "count_incr_a" in
+  let base_b = tmpdir "count_incr_b" in
   seed_store base_a 4;
   seed_store base_b 7;
   let ta = Dated_jsonl.create ~base_dir:base_a () in
@@ -101,32 +147,26 @@ let write_to_day base ~ym ~day n =
   done
 ;;
 
-(* The per-file count cache (keyed by path + byte size) must produce the same
-   total as a full uncached scan across many day-files — the realistic store
-   shape it optimises — and must reflect a file that grew (size change
-   invalidates the cached per-file count, so the total never drifts). *)
+(* The per-file cache must produce the same total as a full uncached scan
+   across many day-files — the realistic store shape it optimises — and a
+   grown file must be reflected without any cache reset. *)
 let test_per_file_cache_matches_uncached_across_days () =
   Dated_jsonl.reset_count_cache_for_testing ();
-  let base = tmpdir "count_cache_perfile" in
+  let base = tmpdir "count_incr_perfile" in
   write_to_day base ~ym:"2026-05" ~day:"01" 4;
   write_to_day base ~ym:"2026-05" ~day:"02" 3;
   write_to_day base ~ym:"2026-06" ~day:"09" 2;
   let t = Dated_jsonl.create ~base_dir:base () in
-  (* First cached-miss populates the per-file cache; total must equal the
-     true scan across all three day-files. *)
   check
     int
     "multi-day cached count equals uncached"
     (Dated_jsonl.count_entries_uncached t)
     (Dated_jsonl.count_entries t);
   check int "multi-day total is 9" 9 (Dated_jsonl.count_entries t);
-  (* Grow one day-file, then force a recompute. The size change must
-     invalidate that file's cached count so the new total is observed. *)
   write_to_day base ~ym:"2026-06" ~day:"09" 6;
-  Dated_jsonl.reset_count_cache_for_testing ();
   check
     int
-    "after growth, cached count equals uncached"
+    "after growth, cached count equals uncached without reset"
     (Dated_jsonl.count_entries_uncached t)
     (Dated_jsonl.count_entries t);
   check int "after growth total is 15" 15 (Dated_jsonl.count_entries t)
@@ -135,11 +175,16 @@ let test_per_file_cache_matches_uncached_across_days () =
 let () =
   Alcotest.run
     "dated_jsonl_count_cache"
-    [ ( "count_cache"
+    [ ( "incremental_count"
       , [ test_case
-            "cache returns stale within TTL, uncached path is live"
+            "growth behind the cache is visible immediately"
             `Quick
-            test_cache_returns_stale_within_ttl
+            test_growth_is_visible_immediately
+        ; test_case
+            "unterminated trailing line excluded until newline lands"
+            `Quick
+            test_unterminated_trailing_line
+        ; test_case "shrunk file forces full rescan" `Quick test_shrunk_file_rescans
         ; test_case "reset clears the cache" `Quick test_reset_clears_cache
         ; test_case
             "distinct stores have independent caches"

--- a/test/test_keeper_transition_audit.ml
+++ b/test/test_keeper_transition_audit.ml
@@ -295,6 +295,67 @@ let test_turn_fsm_emit_transition_appends_wal_row () =
           | rows ->
             failf "expected one turn_fsm_transition row, got %d" (List.length rows)))
 
+(* ── Async append queue ─────────────────────────────────────────── *)
+
+let default_store_dir base_dir =
+  Filename.concat
+    (Common.masc_dir_from_base_path ~base_path:base_dir)
+    "transition-audit"
+
+(* With enqueue mode on, recording must not write the store inline (that
+   inline write under shared locks is what parked 12 keepers in the
+   2026-06-10 freeze); the row lands only when the drain runs. *)
+let test_async_queue_defers_store_write_until_flush () =
+  Audit.For_testing.reset_state ();
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Audit.For_testing.reset_state ();
+      cleanup_dir base_dir)
+    (fun () ->
+      with_env "MASC_KEEPER_TRANSITION_LOG" "" (fun () ->
+          with_env "MASC_BASE_PATH" base_dir (fun () ->
+              with_env "MASC_BASE_PATH_INPUT" base_dir (fun () ->
+                  Audit.For_testing.set_async_append_active true;
+                  KTF.emit_transition
+                    ~keeper_name:"async-queue-keeper"
+                    ~turn_id:7
+                    ~prev:KTF.Streaming
+                    KTF.Completing;
+                  check int "record queued, not yet flushed" 1
+                    (Audit.For_testing.queued_count ());
+                  check bool "store not written before flush" false
+                    (Sys.file_exists (default_store_dir base_dir));
+                  let written = Audit.flush_pending () in
+                  check int "flush writes the queued record" 1 written;
+                  check int "queue drained" 0 (Audit.For_testing.queued_count ());
+                  check int "nothing dropped" 0 (Audit.For_testing.dropped_count ());
+                  check bool "store materialized by flush" true
+                    (Sys.file_exists (default_store_dir base_dir))))))
+
+(* Synchronous fallback: before [start_flush_fiber] (tests, non-server
+   embedders) recording appends inline, preserving previous behavior. *)
+let test_sync_fallback_appends_inline () =
+  Audit.For_testing.reset_state ();
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Audit.For_testing.reset_state ();
+      cleanup_dir base_dir)
+    (fun () ->
+      with_env "MASC_KEEPER_TRANSITION_LOG" "" (fun () ->
+          with_env "MASC_BASE_PATH" base_dir (fun () ->
+              with_env "MASC_BASE_PATH_INPUT" base_dir (fun () ->
+                  KTF.emit_transition
+                    ~keeper_name:"sync-fallback-keeper"
+                    ~turn_id:8
+                    ~prev:KTF.Streaming
+                    KTF.Completing;
+                  check int "nothing queued in sync mode" 0
+                    (Audit.For_testing.queued_count ());
+                  check bool "store written inline" true
+                    (Sys.file_exists (default_store_dir base_dir))))))
+
 let test_default_transition_append_failure_is_observed_and_ring_retained () =
   Audit.For_testing.reset_state ();
   with_invalid_default_store (fun () ->
@@ -444,6 +505,13 @@ let () =
             test_runtime_trust_timeline_carries_transition_operator_signal;
           test_case "turn FSM emit appends WAL row" `Quick
             test_turn_fsm_emit_transition_appends_wal_row;
+        ] );
+      ( "async_append_queue",
+        [
+          test_case "enqueue defers store write until flush" `Quick
+            test_async_queue_defers_store_write_until_flush;
+          test_case "sync fallback appends inline" `Quick
+            test_sync_fallback_appends_inline;
         ] );
       ( "append_failures",
         [

--- a/test/test_telemetry_unified.ml
+++ b/test/test_telemetry_unified.ml
@@ -1242,6 +1242,67 @@ let test_cluster_keeper_metrics () =
   in
   Alcotest.(check int) "cluster keeper metric found" 1 (List.length entries)
 
+(* ── Trajectory summary incremental cache ─────────── *)
+
+let trajectory_row ~ts ~tool_name =
+  Yojson.Safe.to_string
+    (`Assoc
+       [ ("ts", `Float ts)
+       ; ("turn", `Int 1)
+       ; ("tool_name", `String tool_name)
+       ; ("args", `Assoc [])
+       ; ("result", `String "ok")
+       ])
+  ^ "\n"
+
+let thinking_row ~ts =
+  Yojson.Safe.to_string
+    (`Assoc
+       [ ("type", `String "thinking")
+       ; ("ts", `Float ts)
+       ; ("content", `String "reasoning text")
+       ])
+  ^ "\n"
+
+(* The (count, latest_ts) summary must (a) count only tool-call rows,
+   (b) pick appended rows up on the next call without any cache reset —
+   the snapshot loop calls this every 2 s and must not re-parse the whole
+   store — and (c) agree with a cold-cache recomputation. *)
+let test_trajectory_summary_incremental () =
+  Telemetry_unified.For_testing.reset_trajectory_summary_cache_for_testing ();
+  let dir = tmpdir "telem_traj_summary_incr" in
+  let root = masc_root dir in
+  let keeper_dir = Filename.concat root "trajectories/alice" in
+  Fs_compat.mkdir_p keeper_dir;
+  let trace = Filename.concat keeper_dir "trace-1.jsonl" in
+  Fs_compat.append_file trace (trajectory_row ~ts:100.0 ~tool_name:"tool_a");
+  Fs_compat.append_file trace (thinking_row ~ts:150.0);
+  Fs_compat.append_file trace (trajectory_row ~ts:200.0 ~tool_name:"tool_b");
+  let count, latest =
+    Telemetry_unified.For_testing.trajectory_tool_call_summary_stats
+      ~masc_root:root
+  in
+  Alcotest.(check int) "thinking rows excluded from count" 2 count;
+  Alcotest.(check (option (float 0.001))) "latest ts from tool rows only"
+    (Some 200.0) latest;
+  (* Append behind the warm cache: the delta must be picked up without a
+     reset (this is the property the 2 s snapshot loop depends on). *)
+  Fs_compat.append_file trace (trajectory_row ~ts:300.0 ~tool_name:"tool_c");
+  let count2, latest2 =
+    Telemetry_unified.For_testing.trajectory_tool_call_summary_stats
+      ~masc_root:root
+  in
+  Alcotest.(check int) "appended tool row visible without reset" 3 count2;
+  Alcotest.(check (option (float 0.001))) "latest ts advanced" (Some 300.0) latest2;
+  (* Cold cache must agree with the warm incremental result. *)
+  Telemetry_unified.For_testing.reset_trajectory_summary_cache_for_testing ();
+  let count3, latest3 =
+    Telemetry_unified.For_testing.trajectory_tool_call_summary_stats
+      ~masc_root:root
+  in
+  Alcotest.(check int) "cold recomputation agrees" count2 count3;
+  Alcotest.(check (option (float 0.001))) "cold latest agrees" latest2 latest3
+
 (* ── Runner ──────────────────────────────────────── *)
 
 let () =
@@ -1314,6 +1375,8 @@ let () =
             test_summary_bad_trajectory_root_observed_once;
           Alcotest.test_case "counts all rows beyond recent cap" `Quick
             test_summary_counts_all_entries_beyond_recent_cap;
+          Alcotest.test_case "trajectory summary cache is incremental" `Quick
+            test_trajectory_summary_incremental;
           Alcotest.test_case "replay retention selected sources" `Quick
             test_replay_retention_lists_selected_sources;
         ] );


### PR DESCRIPTION
## 증상

16+ keeper fleet이 재시작 후 ~5분 만에 전원 정지. 한 keeper가 멈추면 전부 멈춤. 2026-06-10 라이브 캡처(`~/me/.tmp/masc-freeze-captures/20260610-094442`) 기준:

- 12 keeper 전원이 09:23:41–44Z에 `awaiting_tool/awaiting_provider -> streaming` 전이 후 **30분간 0 turn** — 정확히 1800s `attempt_watchdog_safety_deadline`에서만 사살됨 (trajectory summary `"status":"gated"`, `total_turns:0` 반복).
- 그동안 `main_eio.exe` CPU 123% 지속: Executor_pool worker domain이 `Telemetry_unified` → `Yojson.Safe.from_string` lex 루프에서 연소 (sample 프로파일 첨부 캡처 참조).
- `/health`는 0.9ms 정상 응답 — main domain은 멀쩡, keeper fiber만 파킹.

## RCA

**① CPU burn (boot부터)**: `Dashboard_snapshot.refresh_loop`(2s, boot에서 시작, 브라우저 불필요)가 매 사이클 `summary_json`을 호출하고, trajectory summary가 **483MB 저장소의 모든 trace 파일을 `max_lines=50_000`으로 Yojson tail 재파싱**. #20668의 mtime-skip은 windowed read 경로에만 적용되어 summary 경로는 무방비. 계산 결과는 고작 `(entry_count, latest_ts)` 두 값.

**② keeper 동반 정지**: 모든 `Keeper_turn_fsm.emit_transition`이 `[fsm:transition]` 로그 직후 공유 `transition-audit` store(82MB, RFC-0002 이후 prune 無)에 **keeper fiber 인라인으로 `Dated_jsonl.append`** — fd_accountant `Log_writer` 세마포어(무timeout) → store별 `Eio.Mutex`(배타, 12 keeper 전원 직렬화) → blocking flush. 정지 keeper들의 마지막 관측 이벤트가 정확히 이 로그 라인. 게다가 `Awaiting_provider->Streaming` emit은 **watchdog 무장 이전**에 실행되어 여기서 파킹되면 1800s 캡조차 적용 안 됨.

타임아웃 진공 보강 사실: `[turn] timeout_sec=300`/`stream_idle_timeout_sec=120`(runtime.toml)은 HTTP 구간만 커버하고, #20667의 `execution_idle_timeout_s`는 배선만 있고 **값을 넣는 곳이 0곳**(별도 이슈로 처리).

## 변경

house idiom(타이머/캡 추가가 아니라 구조 수정 — #20510 revert, #20512, #20624 선례)에 따라:

| 변경 | 파일 | 성격 |
|---|---|---|
| `fold_appended_lines`: append-only JSONL 증분 스캐너 (boundary 이후 바이트만, 미완성 trailing line 제외) | `fs_compat` | 신규 공용 1개 (아래 2곳이 공유) |
| trajectory summary를 trace-파일별 `(boundary, tool_calls, latest_ts)` 증분 캐시로 — 2s 사이클 비용 O(appended bytes), summary 경로의 50k full-tail 파싱 제거 | `telemetry_unified` | 구조 수정 |
| `count_entries` per-file 캐시를 boundary-키 증분으로 승격, **RFC-0162 §3.2 10s TTL 레이어 삭제** (#20646 size-keyed 캐시가 이미 대체 — 캐시 표면 2→1, staleness 윈도 제거) | `dated_jsonl` | SSOT 정리(표면 삭제) |
| FSM forensics append를 bounded queue + 0.5s drain fiber로 (기존 `Keeper_tool_call_log` 패턴 미러). in-memory ring이 정본이라는 모듈 자체 계약 그대로. `start_flush_fiber` 이전(테스트/임베더)에는 기존 동기 동작 유지 | `keeper_transition_audit` | 구조 수정 |
| `Awaiting_provider->Streaming` emit을 watchdog `~run` 내부로 이동 — Streaming 구간 전체가 안전캡 안에 들어옴 | `keeper_unified_turn_execution` | 순서 결함 수정 |
| `transition-audit`를 24h prune 루프에 편입 | `server_bootstrap_maintenance` | 보존정책 누락 수정 |

WORKAROUND-WAIVED: bounded queue는 symptom 억제용 cap이 아니라 liveness/durability 경계 분리의 필수 속성(무한 큐=OOM)이며, 동일 패턴이 이미 `Keeper_tool_call_log`에 정착된 house idiom. drop은 forensics 행만 잃고(ring 정본 유지) 매 건 WARN + `TransitionAuditFailures` 메트릭으로 가시화.

## 검증

- `dune build --root . @check` + default target 모두 clean (squash 후 머지 SHA에서 재검 예정)
- `test_dated_jsonl_count_cache` 6/6 (증분 계약으로 재작성: 즉시 가시성, 미완성 라인 제외, shrink 재스캔)
- `test_keeper_transition_audit` 17/17 (+2: enqueue-defer-flush, sync fallback)
- `test_telemetry_unified` 36/37 (+1: 증분 summary 캐시) — 유일 실패 `summary coverage-gap counter`는 **이 diff를 stash한 origin/main에서도 동일 재현 (pre-existing)**
- `test_fs_compat` 12/13 — `remove_tree no shell injection` 실패도 base 재현 (pre-existing)
- `test_dated_jsonl` 21/21, `test_keeper_turn_fsm_emit` 13/13, `test_dated_jsonl_mutex_registry_10372` 6/6

## 후속 (별도 이슈/PR로 분리)

1. **Fd_accountant 중복 모듈 통합** — `lib/fd_accountant.ml` vs `lib/fd_accountant/` 두 벌이 링크되어 pressure hook과 Provider_http 슬롯이 서로 다른 인스턴스에 — `/health`의 `in_flight=0`이 거짓말을 하는 관측 split-brain.
2. **#20667 `execution_idle_timeout_s` dead plumbing** — 값 setter 0곳. 배선 제거 또는 TOML key 부여 결정 필요.
3. **dead config 정리** — `[heartbeat] board_debounce_sec`(TOML 무시, 코드 60.0 하드코딩), binding `max-concurrent`(RFC-0206 이후 미강제), `wait_timeout_sec`(ignore됨), `admission_wait` 리터럴 180.0.
4. **trajectories 저장소 구조** — date-partition + retention (#20668 본문이 스스로 지목한 구조 fix). 483MB 성장 중.
5. **OAS SSE 파서** — `String.sub line 0 7 = "event: "` 인덱스 산술이 스펙상 유효한 `data:foo`(공백 없음)를 무음 드롭. OAS repo 별도 PR.

MASC: task-702 (claimed by codex-mcp-client)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
