### PR TITLE
test(dashboard): fix connector + runtime-panel stale tests (final 2 of Dashboard test-step backlog)

### DIFF
--- a/dashboard/src/components/connector-quick-bind.test.ts
+++ b/dashboard/src/components/connector-quick-bind.test.ts
@@ -90,7 +90,9 @@ describe('QuickBindForm', () => {
     input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
     await flushUi()
 
-    const bindCall = fetchSpy.mock.calls.find(c => String(c[0]).includes('/api/v1/gate/connector/bind'))
+    const bindCall = fetchSpy.mock.calls.find(c =>
+      String(c[0]).includes('/api/v1/gate/connector/bind') && String(c[0]).includes('name=slack'),
+    )
     expect(bindCall).toBeTruthy()
     const body = bindCall?.[1]?.body as string
     expect(body).toContain('"channel_id":"C09TK9L4DV4"')

--- a/dashboard/src/components/runtime-panel.test.ts
+++ b/dashboard/src/components/runtime-panel.test.ts
@@ -93,7 +93,7 @@ describe('RuntimePanel', () => {
     expect(container.textContent).toContain('Diagnostics')
     expect(container.textContent).toContain('Transport diagnostics')
     expect(container.textContent).toContain('Feature cleanup')
-    expect(container.textContent).not.toContain('RuntimeMonitor')
+    expect(container.textContent).toContain('RuntimeMonitor')
     expect(container.textContent).toContain('VerificationSpecsPanel')
   })
 
@@ -107,8 +107,10 @@ describe('RuntimePanel', () => {
     expect(oas).not.toBeNull()
     expect(oas?.closest('details')).toBeNull()
 
+    // #20492 promoted "providers" from a collapsed details to its own
+    // selectable view and made RuntimeMonitor a visible default lane, so only
+    // verification remains as collapsed progressive-disclosure detail here.
     const detailIds = [
-      'runtime-details-providers',
       'runtime-details-verification',
     ]
     for (const id of detailIds) {
@@ -118,7 +120,7 @@ describe('RuntimePanel', () => {
       expect((el as HTMLDetailsElement).open).toBe(false)
     }
     expect(container.textContent).toContain('RuntimeHealthSnapshot')
-    expect(container.textContent).not.toContain('RuntimeMonitor')
+    expect(container.textContent).toContain('RuntimeMonitor')
   })
 
   it('explicit drill-down views bypass progressive disclosure', async () => {
@@ -195,7 +197,7 @@ describe('RuntimePanel', () => {
 
     expect(container.textContent).toContain('OasHealthChip')
     expect(container.textContent).toContain('RuntimeHealthSnapshot')
-    expect(container.textContent).not.toContain('RuntimeMonitor')
+    expect(container.textContent).toContain('RuntimeMonitor')
   })
 
   it('passes current view value to FilterChips', async () => {


### PR DESCRIPTION
## 변경 — Dashboard test step의 pre-existing stale 테스트 2파일 (connector, runtime-panel)

### 배경
PR #20666이 Dashboard CI의 `tsc`(step 9)를 고치자, 그동안 가려져 있던 test step(step 10)의 pre-existing 실패 5파일이 드러났습니다. 이미 머지된 것: #20670(ide-context-lens), #20671(auth-status). 이 PR은 마지막 2파일을 고칩니다.

두 건 모두 **컴포넌트는 정상**임을 확인하고(버그 숨김 없이) 테스트 결함만 교정했습니다.

### 1. `connector-quick-bind` (1건) — test 격리 결함 (컴포넌트 정상)
"pressing Enter submits the bind"(connectorId=slack)가 bind fetch 호출을 connector 무관 predicate(`/connector/bind`)로 찾아, 직전 discord 테스트의 leaked 호출(`channel_id:'1234567890'`)을 매칭. **격리 실행 시 통과**(컴포넌트 정상 증명). discord 테스트가 `name=discord`로 스코프하는 패턴을 미러링해 `name=slack` 추가.

### 2. `runtime-panel` (3건) — #20492 재설계에 테스트 미추종
#20492("runtime call counts visibility")가 default monitoring view를 재구성: collapsed `#runtime-details-providers`를 제거하고 `RuntimeMonitor`를 가시 default lane으로, "providers"를 독립 view로 승격. 테스트(#20399, 그 이전)는 옛 레이아웃을 기대. default-view 3개 테스트를 현 레이아웃에 맞춤(RuntimeMonitor 가시, verification만 collapsed). drill-down(config/audit) 테스트는 `.not.toContain('RuntimeMonitor')` 유지. **컴포넌트 무변경.**

> ⚠️ 리뷰 노트: #20492 commit 메시지가 `#runtime-details-providers` 제거를 명시하지 않았습니다. providers가 독립 view가 된 것으로 보아 의도된 제거로 판단했으나, 만약 unintended regression이면 테스트가 아니라 컴포넌트를 복원해야 합니다.

### 검증
- `connector-quick-bind` 11/11, `runtime-panel` 9/9
- **전체 main config 스위트 499 파일 / 6422 테스트 통과 (0 실패)** — 5개 fix 모두 적용 시 측정
- tsc 0, eslint clean

### 범위
이 PR로 Dashboard test step(step 10) 5파일 backlog가 완전히 해소됩니다 (#20666 tsc + #20670 + #20671 + 본 PR). 이후 Dashboard job green 예상.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
