### PR TITLE
test(event-bus): guard oas_runtime=Drop_oldest policy (follow-up #20676)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -1547,6 +1547,8 @@
 
 (include stanzas/test_timeout_policy.inc)
 
+(include stanzas/test_masc_event_bus_policy.inc)
+
 (include stanzas/test_timeout_policy_overshoot_counter.inc)
 
 (include stanzas/test_tool_call_replay_harness.inc)

--- a/test/stanzas/test_masc_event_bus_policy.inc
+++ b/test/stanzas/test_masc_event_bus_policy.inc
@@ -1,0 +1,6 @@
+; oas_runtime bus backpressure policy guard (RCA 2026-06-10 fleet freeze)
+
+(test
+ (name test_masc_event_bus_policy)
+ (modules test_masc_event_bus_policy)
+ (libraries masc_test_deps))

--- a/test/test_masc_event_bus_policy.ml
+++ b/test/test_masc_event_bus_policy.ml
@@ -1,0 +1,50 @@
+(* Guards the deliberate backpressure-policy choice on the keeper-facing
+   [oas_runtime] bus.
+
+   [oas_runtime] MUST be [Drop_oldest], not [Block]: under [Block] a slow
+   subscriber back-pressures publishers, so a full 256 buffer freezes every
+   keeper fiber inside [Event_bus.publish] with no timeout (RCA 2026-06-10
+   sustained fleet freeze). Every oas_runtime subscriber is observational and
+   durable replay reads the JSONL surface, so no consumer needs completeness.
+
+   [masc_domain] stays [Block] (workspace-invariant events).
+
+   OAS [test_event_bus.ml] proves [Drop_oldest] evicts the queue head when full
+   (non-blocking delivery); this test guards MASC's policy *assignment* so a
+   revert of [oas_runtime] to [Block] fails CI. *)
+
+open Masc
+
+let test_oas_runtime_drop_oldest () =
+  Alcotest.(check bool)
+    "oas_runtime uses Drop_oldest so a slow subscriber cannot freeze keeper \
+     publishers"
+    true
+    Masc_event_bus_policy.(oas_runtime.policy = Drop_oldest)
+
+let test_oas_runtime_not_block () =
+  Alcotest.(check bool)
+    "oas_runtime is NOT Block (Block re-introduces the fleet-freeze coupling)"
+    false
+    Masc_event_bus_policy.(oas_runtime.policy = Block)
+
+let test_masc_domain_stays_block () =
+  Alcotest.(check bool)
+    "masc_domain stays Block (workspace-invariant events; not the keeper \
+     turn pipeline)"
+    true
+    Masc_event_bus_policy.(masc_domain.policy = Block)
+
+let () =
+  Alcotest.run
+    "masc_event_bus_policy"
+    [ ( "oas_runtime_backpressure"
+      , [ Alcotest.test_case "oas_runtime = Drop_oldest" `Quick
+            test_oas_runtime_drop_oldest
+        ; Alcotest.test_case "oas_runtime <> Block" `Quick
+            test_oas_runtime_not_block
+        ; Alcotest.test_case "masc_domain = Block" `Quick
+            test_masc_domain_stays_block
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 목적

#20676(`oas_runtime` bus `Block` → `Drop_oldest`, RCA-2026-06-10 fleet freeze fix, **머지됨**)의 정책 선택을 회귀로부터 가드하는 테스트입니다.

## 내용

`test_masc_event_bus_policy.ml`: `Masc_event_bus_policy`의 정책 할당을 단정.
- `oas_runtime = Drop_oldest` (Block이면 slow subscriber가 키퍼 publisher를 freeze)
- `oas_runtime <> Block`
- `masc_domain = Block` (워크스페이스 불변식 이벤트)

OAS `test_event_bus.ml`이 `Drop_oldest` non-blocking eviction 동작을 이미 커버하므로, 이 테스트는 **MASC의 정책 할당**만 가드합니다(누가 oas_runtime을 Block으로 되돌리면 CI fail).

## 검증

로컬 `dune exec test/test_masc_event_bus_policy.exe` → 3/3 PASS (origin/main 기준, fix 포함).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
