### PR TITLE
fix(log): decouple console mirror writes from the Eio domain — pty block froze the fleet

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -638,6 +638,11 @@ let run_cmd host port base_path =
   acquire_pid_lock port;
   acquire_base_path_lock normalized_base_path;
   Log.init_from_env ();
+  (* Decouple console mirror writes from the Eio domain before any keeper
+     boots: with fd 2 on a pty, a full pty buffer (scrollback/copy-mode)
+     blocks write(2) outside the scheduler and halts the whole fleet
+     (#20684, 2026-06-10 live stall). *)
+  Console_sink.start ();
   if stripped_base_path <> ""
      && String.equal (Filename.basename stripped_base_path) Common.masc_dirname
   then

--- a/lib/masc_log/console_sink.ml
+++ b/lib/masc_log/console_sink.ml
@@ -1,0 +1,135 @@
+(* Console mirror sink — decouples per-record console output from the
+   producing domain.
+
+   Every log record used to reach the console via a direct
+   [Printf.eprintf "...%!"] on the calling fiber. With fd 2 on a pty, a
+   full pty buffer (terminal scrollback, copy-mode selection, slow
+   renderer) blocks [write(2)] OUTSIDE the Eio scheduler and halts the
+   entire domain — observed live on 2026-06-10 11:26-11:28 KST as a
+   fleet-wide ~60 s stall whose log lines were stamped at write time and
+   burst out only after the terminal was released (issue #20684).
+
+   Contract:
+   - The console is a convenience MIRROR. The JSONL file sink
+     ([Log.Persist.write_to_sink]) and the in-memory ring stay
+     authoritative and lossless.
+   - Before [start] (tests, CLI one-shots, pre-boot), [write] stays
+     synchronous — identical to the historical behavior.
+   - After [start], [write] enqueues into a bounded queue drained by a
+     dedicated OS thread; the thread alone performs the possibly-blocking
+     fd write. When the writer is blocked long enough to fill the queue,
+     incoming MIRROR lines are dropped and counted; a marker line
+     reporting the drop count is emitted once the writer unblocks. *)
+
+let capacity = 8192
+let queue : string Queue.t = Queue.create ()
+let mu = Mutex.create ()
+let cond = Condition.create ()
+let enqueue_active = Atomic.make false
+let thread_spawned = Atomic.make false
+let dropped = Atomic.make 0
+
+(* Test seam: the possibly-blocking line writer. Production default is
+   stderr + flush, matching the historical [Printf.eprintf "%s\n%!"]. *)
+let stderr_write line =
+  output_string stderr (line ^ "\n");
+  flush stderr
+
+let writer_override : (string -> unit) option Atomic.t = Atomic.make None
+
+let current_writer () =
+  match Atomic.get writer_override with
+  | Some w -> w
+  | None -> stderr_write
+
+let write_batch ~last_reported_drops batch =
+  Queue.iter
+    (fun line ->
+       try current_writer () line with
+       | _ ->
+         (* A failing console writer must never take the process down;
+            the file sink still has the record. *)
+         ())
+    batch;
+  let d = Atomic.get dropped in
+  if d > !last_reported_drops
+  then begin
+    (try
+       current_writer ()
+         (Printf.sprintf
+            "[console-sink] dropped %d console line(s) while the console writer \
+             was blocked (file sink unaffected)"
+            (d - !last_reported_drops))
+     with
+     | _ -> ());
+    last_reported_drops := d
+  end
+
+let take_batch_blocking () =
+  Mutex.lock mu;
+  while Queue.is_empty queue do
+    Condition.wait cond mu
+  done;
+  let batch = Queue.create () in
+  Queue.transfer queue batch;
+  Mutex.unlock mu;
+  batch
+
+let writer_loop () =
+  let last_reported_drops = ref 0 in
+  while true do
+    let batch = take_batch_blocking () in
+    write_batch ~last_reported_drops batch
+  done
+
+let start () =
+  Atomic.set enqueue_active true;
+  if Atomic.compare_and_set thread_spawned false true
+  then ignore (Thread.create writer_loop () : Thread.t)
+
+let dropped_count () = Atomic.get dropped
+
+let write line =
+  if not (Atomic.get enqueue_active)
+  then current_writer () line
+  else begin
+    Mutex.lock mu;
+    let full = Queue.length queue >= capacity in
+    if not full
+    then begin
+      Queue.add line queue;
+      Condition.signal cond
+    end;
+    Mutex.unlock mu;
+    if full then ignore (Atomic.fetch_and_add dropped 1 : int)
+  end
+
+module For_testing = struct
+  let set_writer w = Atomic.set writer_override w
+
+  (* Enqueue mode without the OS thread, so tests drain deterministically. *)
+  let set_enqueue_active v = Atomic.set enqueue_active v
+
+  let queued_count () =
+    Mutex.lock mu;
+    let n = Queue.length queue in
+    Mutex.unlock mu;
+    n
+
+  let drain_now () =
+    Mutex.lock mu;
+    let batch = Queue.create () in
+    Queue.transfer queue batch;
+    Mutex.unlock mu;
+    let n = Queue.length batch in
+    write_batch ~last_reported_drops:(ref (Atomic.get dropped)) batch;
+    n
+
+  let reset () =
+    Mutex.lock mu;
+    Queue.clear queue;
+    Mutex.unlock mu;
+    Atomic.set enqueue_active false;
+    Atomic.set dropped 0;
+    Atomic.set writer_override None
+end

--- a/lib/masc_log/console_sink.mli
+++ b/lib/masc_log/console_sink.mli
@@ -1,0 +1,40 @@
+(** Console mirror sink — the console is a convenience mirror of the log
+    stream; the JSONL file sink and in-memory ring are authoritative.
+
+    Before {!start}, {!write} performs the write synchronously on the
+    caller (historical behavior — tests and CLI one-shots unchanged).
+    After {!start}, {!write} enqueues into a bounded queue drained by a
+    dedicated OS thread, so a blocked console fd (full pty buffer:
+    terminal scrollback, copy-mode, slow renderer) can no longer halt
+    the calling domain. On overflow, incoming mirror lines are dropped
+    and counted; a marker reporting the drop count is emitted when the
+    writer unblocks. See issue #20684 for the live incident. *)
+
+(** Switch to enqueue mode and spawn the writer thread (idempotent).
+    Call once at server startup, before keepers boot. *)
+val start : unit -> unit
+
+(** Emit one console line (no trailing newline). Never blocks after
+    {!start}; synchronous before. *)
+val write : string -> unit
+
+(** Total mirror lines dropped due to a blocked console writer. *)
+val dropped_count : unit -> int
+
+module For_testing : sig
+  (** Replace the fd writer ([None] restores stderr). *)
+  val set_writer : (string -> unit) option -> unit
+
+  (** Toggle enqueue mode WITHOUT spawning the writer thread, so tests
+      drain deterministically via {!drain_now}. *)
+  val set_enqueue_active : bool -> unit
+
+  val queued_count : unit -> int
+
+  (** Drain the queue synchronously on the calling thread; returns the
+      number of lines written. *)
+  val drain_now : unit -> int
+
+  (** Clear queue/counters, restore synchronous mode and stderr writer. *)
+  val reset : unit -> unit
+end

--- a/lib/masc_log/dune
+++ b/lib/masc_log/dune
@@ -4,8 +4,8 @@
  (name masc_log)
  (public_name masc.masc_log)
  (wrapped false)
- (modules log system_log_category)
+ (modules log system_log_category console_sink)
  ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
  (flags
   (:standard -w +4))
- (libraries unix yojson time_compat eio fs_compat))
+ (libraries unix threads.posix yojson time_compat eio fs_compat))

--- a/lib/masc_log/log.ml
+++ b/lib/masc_log/log.ml
@@ -681,7 +681,7 @@ let log level ?(ctx : string option) fmt =
         | Some c -> Printf.sprintf "[%s] [%s] [%s]" (timestamp ()) level_str c
         | None -> Printf.sprintf "[%s] [%s]" (timestamp ()) level_str
       in
-      Printf.eprintf "%s %s\n%!" prefix msg;
+      Console_sink.write (prefix ^ " " ^ msg);
       Ring.push ~level ~module_name ~message:msg ()
     end
   ) fmt
@@ -695,7 +695,7 @@ let emit level ?(module_name = "") ?(details = `Null) message =
       else
         Printf.sprintf "[%s] [%s] [%s]" (timestamp ()) level_str module_name
     in
-    Printf.eprintf "%s %s\n%!" prefix message;
+    Console_sink.write (prefix ^ " " ^ message);
     Ring.push ~level ~module_name ~message ~details ()
   end
 
@@ -733,7 +733,7 @@ let error ?ctx fmt = log Error ?ctx fmt
    [~level:Log.Error/Warn/Debug] explicitly, so the option was dead code
    masquerading as flexibility. *)
 let emit_legacy_raw ~level ?(module_name = "") ~source message =
-  Printf.eprintf "%s\n%!" message;
+  Console_sink.write message;
   Ring.push ~level ~source ~module_name ~message ()
 
 let legacy_stderr ~level ?module_name message =
@@ -743,7 +743,7 @@ let legacy_traceln ~level ?module_name message =
   emit_legacy_raw ~level ?module_name ~source:Legacy_traceln message
 
 let client_tool_host_error ?(module_name = "ToolHost") ?(details = `Null) message =
-  Printf.eprintf "%s\n%!" message;
+  Console_sink.write message;
   Ring.push ~level:Error ~source:Client_tool_host
     ~module_name ~message ~details ()
 
@@ -815,7 +815,7 @@ module Make (M : sig val name : string end) = struct
             Printf.sprintf "[%s] [%s] [%s]"
               (timestamp ()) level_str M.name
       in
-      Printf.eprintf "%s %s\n%!" prefix message;
+      Console_sink.write (prefix ^ " " ^ message);
       Ring.push ?keeper_name ?turn_id
         ~level ~module_name:M.name ~message ~details ()
     end

--- a/test/dune
+++ b/test/dune
@@ -56,6 +56,7 @@
   test_auth_login
   test_audit_log
   test_system_log_category
+  test_console_sink
   test_governance_anomaly
   test_http_negotiation
   test_mcp_h1_h2_admission_parity
@@ -312,6 +313,7 @@
   test_auth_login
   test_audit_log
   test_system_log_category
+  test_console_sink
   test_governance_anomaly
   test_http_negotiation
   test_mcp_h1_h2_admission_parity

--- a/test/test_console_sink.ml
+++ b/test/test_console_sink.ml
@@ -1,0 +1,77 @@
+(** Console_sink — the console mirror must never block log producers.
+
+    Contract under test (issue #20684):
+    - synchronous before enqueue mode (historical behavior)
+    - enqueue mode: write returns without touching the fd writer
+    - bounded queue: overflow drops incoming mirror lines and counts them
+    - drain writes queued lines in order and reports drops once *)
+
+open Alcotest
+
+let with_clean_sink f =
+  Console_sink.For_testing.reset ();
+  Fun.protect ~finally:Console_sink.For_testing.reset f
+;;
+
+let test_synchronous_before_start () =
+  with_clean_sink (fun () ->
+    let written = ref [] in
+    Console_sink.For_testing.set_writer (Some (fun l -> written := l :: !written));
+    Console_sink.write "direct line";
+    check (list string) "written immediately, nothing queued" [ "direct line" ]
+      !written;
+    check int "queue untouched" 0 (Console_sink.For_testing.queued_count ()))
+;;
+
+let test_enqueue_mode_defers_fd_write () =
+  with_clean_sink (fun () ->
+    let written = ref [] in
+    Console_sink.For_testing.set_writer (Some (fun l -> written := l :: !written));
+    Console_sink.For_testing.set_enqueue_active true;
+    Console_sink.write "queued line";
+    check (list string) "fd writer not called by producer" [] !written;
+    check int "line queued" 1 (Console_sink.For_testing.queued_count ());
+    let n = Console_sink.For_testing.drain_now () in
+    check int "drain wrote the line" 1 n;
+    check (list string) "drained to writer" [ "queued line" ] !written)
+;;
+
+let test_overflow_drops_and_counts () =
+  with_clean_sink (fun () ->
+    let written = ref 0 in
+    Console_sink.For_testing.set_writer (Some (fun _ -> incr written));
+    Console_sink.For_testing.set_enqueue_active true;
+    (* Fill past capacity (8192): a blocked writer must not block writers,
+       only shed mirror lines. *)
+    for i = 1 to 9000 do
+      Console_sink.write (Printf.sprintf "line %d" i)
+    done;
+    check int "queue capped at capacity" 8192
+      (Console_sink.For_testing.queued_count ());
+    check int "overflow counted as drops" 808 (Console_sink.dropped_count ());
+    let n = Console_sink.For_testing.drain_now () in
+    check int "drain writes the capped batch" 8192 n)
+;;
+
+let test_writer_exception_does_not_escape () =
+  with_clean_sink (fun () ->
+    Console_sink.For_testing.set_writer (Some (fun _ -> failwith "fd broken"));
+    Console_sink.For_testing.set_enqueue_active true;
+    Console_sink.write "line a";
+    Console_sink.write "line b";
+    let n = Console_sink.For_testing.drain_now () in
+    check int "drain survives a throwing writer" 2 n)
+;;
+
+let () =
+  run "console_sink"
+    [ ( "mirror_contract"
+      , [ test_case "synchronous before start" `Quick test_synchronous_before_start
+        ; test_case "enqueue mode defers fd write" `Quick
+            test_enqueue_mode_defers_fd_write
+        ; test_case "overflow drops and counts" `Quick test_overflow_drops_and_counts
+        ; test_case "writer exception contained" `Quick
+            test_writer_exception_does_not_escape
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 증상 (라이브, 2026-06-10 11:26–11:28 KST)

#20677 머지·재기동 후에도 "약 2분 전체 정지 후 재개"가 발생. 시스템 로그 분석:

- 02:26:29Z 이후 **~60초간 로그 0줄**, 그 뒤 02:27:30Z에 **860줄 일괄 분출**
- 분출분에는 02:26:28Z에 직접 라인이 찍힌 턴들의 `oas:event` 미러가 포함 (같은 turn 번호/tool) — 라인은 **write 시점**에 stamp되므로, 생산자가 쉰 게 아니라 **writer가 막혀 있었다**는 증거
- 평소 ~5초 턴이 `turn_duration_sec=111.2`
- 정지 시점 = 운영자가 해당 터미널에서 로그를 **복사하던 순간**. 서버 fd 0/1/2가 `/dev/ttys019`(포그라운드 pty)에 연결되어 있었음

## 원인

모든 로그 레코드가 호출 fiber에서 `Printf.eprintf "...%!"`로 콘솔에 직접 기록됩니다. pty 버퍼가 차면(스크롤백 위로 올림, copy-mode 선택, 느린 렌더러) `write(2)`가 **Eio 스케줄러 바깥에서** 블록 → main domain 전체 정지.

**"keeper 하나가 멈추면 다 멈추는 느낌"의 실체가 이것입니다**: keeper들은 전부 한 Eio domain 위의 fiber이고, 도메인을 막는 블로킹 syscall 하나(이번엔 pty write)가 전원을 동시에 세웁니다. keeper가 범인인 적이 없고, 콘솔이 범인이었습니다. (#20684)

## 변경

`Console_sink` (lib/masc_log/console_sink.{ml,mli}):

- per-record 콘솔 출력은 bounded queue(8192) → **전용 OS 스레드**만 블로킹 가능 fd write 수행
- overflow 시 들어오는 **미러 라인만** drop + 카운트, writer가 풀리면 drop 수를 마커 라인으로 1회 보고
- `start()` 이전(테스트/CLI 단발)에는 기존과 동일하게 동기 — 서버만 `main_eio`에서 keeper 부팅 전에 `start()`
- hot-path 5곳(`Log.log`/`Log.emit`/module logger `emit`/`emit_legacy_raw`/`client_tool_host_error`)을 경유시키고, file-sink 내부 자가진단 WARN 등 희귀 경로는 직접 eprintf 유지

WORKAROUND-WAIVED: bounded queue + drop은 symptom 억제 cap이 아니라 경계 분리의 필수 속성입니다 — 콘솔은 **편의 미러**이고 JSONL file sink(`write_to_sink`)와 in-memory ring이 정본(무손실)으로 남습니다. 무한 큐는 OOM, 동기 유지는 본 사고 그 자체. drop은 카운터+마커로 가시화됩니다. 동일 형태의 house 선례: `Keeper_tool_call_log` async append, #20676 event-bus Drop_oldest.

## 검증

- `dune build @check` + default target clean
- `test_console_sink` 4/4 (start 전 동기 / enqueue가 fd write 지연 / overflow drop+count / writer 예외 격리)
- `test_log_ring_encoder` 8/8, `test_log_severity_outcome_level` 2/2
- `test_system_log_category` 4/5 — 실패 1건(enumeration size 13 vs 11)은 **diff stash 후 origin/main에서 동일 재현 (pre-existing)**

## 운영 메모

이 PR 배포 전까지는 서버를 pty에 붙여 실행하지 말 것 — stdout/stderr를 파일로 리다이렉트하고 `tail -f`로 관찰. (현재 11:11 기동 프로세스가 pty 부착 상태)

Closes #20684

🤖 Generated with [Claude Code](https://claude.com/claude-code)
