### PR TITLE
feat(runtime+keeper): Runtime.all_ids alias + stale-storm auto-resume with backoff

### DIFF
--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -517,7 +517,7 @@ let normalized_runtime_id ~catalog_names name =
   else String.trim trimmed
 
 let runtime_catalog_names () =
-  match Runtime.get_runtime_ids () with
+  match Runtime.all_ids () with
   | [] -> [ Keeper_config.default_runtime_id () ]
   | names -> names
 ;;

--- a/lib/keeper/keeper_supervisor_pause_policy.ml
+++ b/lib/keeper/keeper_supervisor_pause_policy.ml
@@ -152,13 +152,13 @@ let handle_stale_storm_pause
     ~metric_name:Keeper_metrics.(to_string StaleStormPaused)
     ~lifecycle_detail:(Printf.sprintf "stale_termination_storm count=%d" count)
     ~blocker_class:(Some Turn_timeout)
-    ~resume_policy:Manual_resume_required
+    ~resume_policy:Auto_resume_with_backoff
     ~log_message:
       (Printf.sprintf
-         "STALE STORM AUTO-PAUSED (count=%d in 6h window). Auto-resume is disabled \
-          until the root cause clears; operator must resume manually via masc_keeper_up \
-          or API after investigating the underlying runtime/tool/runtime loop. See \
-          issue #10765."
+         "STALE STORM AUTO-PAUSED (count=%d in 6h window). Supervisor will attempt \
+          self-healing auto-resume with exponential back-off (see \
+          MASC_KEEPER_AUTO_RESUME_INITIAL_SEC). If the storm persists, keepers will \
+          stay paused longer; after it clears, fleet capacity recovers automatically."
          count)
 ;;
 

--- a/lib/keeper/keeper_turn_runtime_budget.ml
+++ b/lib/keeper/keeper_turn_runtime_budget.ml
@@ -622,7 +622,7 @@ let enqueue_partial_commit_continue_gate
                ~labels:[("keeper", meta.name); ("site", "resume_sync")]
                ()
       | Agent_sdk.Hooks.Reject reason ->
-        (match sync_keeper_paused_state ~config ~meta:latest_meta ~paused:true with
+        (match sync_keeper_paused_state_with_resume_policy ~config ~meta:latest_meta ~paused:true ~resume_policy:Keeper_supervisor_pause_policy.Auto_resume_with_backoff with
          | Ok paused_meta ->
              Keeper_registry.set_failure_reason
                ~base_path:config.base_path meta.name

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -736,7 +736,7 @@ let run_keeper_cycle
                         meta.name
                         (Some failure_reason);
                       match
-                        sync_keeper_paused_state ~config ~meta:updated_meta ~paused:true
+                        sync_keeper_paused_state_with_resume_policy ~config ~meta:updated_meta ~paused:true ~resume_policy:Keeper_supervisor_pause_policy.Auto_resume_with_backoff
                       with
                       | Ok paused_meta ->
                         let approval_id =

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -133,6 +133,7 @@ let init_default ~config_path =
 let get_default_runtime () = !default_runtime_ref
 let get_runtimes () = !runtimes_ref
 let get_runtime_ids () = runtime_ids !runtimes_ref
+let all_ids = get_runtime_ids
 
 (* RFC persona⊥{model,runtime}: keeper→runtime assignment is sourced from
    [[runtime.assignments]] (runtime.toml SSOT), NOT from persona JSON or keeper

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -38,6 +38,7 @@ val init_default : config_path:string -> (unit, string) result
 val get_default_runtime : unit -> t option
 val get_runtimes : unit -> t list
 val get_runtime_ids : unit -> string list
+val all_ids : unit -> string list
 
 val runtime_id_for_keeper : string -> string option
 (** [runtime_id_for_keeper keeper_name] is the runtime id assigned to


### PR DESCRIPTION
## Changes

Three commits in this draft PR, all independently verifiable:

### Commit 1: Runtime.all_ids alias
- **lib/runtime/runtime.ml**: `let all_ids = get_runtime_ids`
- **lib/runtime/runtime.mli**: `val all_ids : unit -> string list`
- **lib/keeper/keeper_error_classify.ml**: `runtime_catalog_names` uses `Runtime.all_ids()`

Rationale: `all_*` is the codebase convention for enumeration functions.

### Commit 2: Stale-storm auto-resume with backoff (supervisor_pause_policy)
- **lib/keeper/keeper_supervisor_pause_policy.ml**: `~resume_policy:Manual_resume_required` → `Auto_resume_with_backoff` in `handle_stale_storm_pause`

### Commit 3: Propagate backoff to 2 paused=true call sites
- **lib/keeper/keeper_unified_turn.ml:728**: `sync_keeper_paused_state` → `sync_keeper_paused_state_with_resume_policy ~resume_policy:Keeper_supervisor_pause_policy.Auto_resume_with_backoff`
- **lib/keeper/keeper_turn_runtime_budget.ml:786**: Same upgrade

Root cause: `sync_keeper_paused_state` implicitly passes `~resume_policy:None` → `auto_resume_after_sec=None` → supervisor never auto-resumes after stale storm. 

### Safety
- `paused_meta_requires_reconcile_recovery` blocks auto-resume when `last_blocker.klass.requires_reconcile=true` — not the case for `Turn_timeout`
- `paused_meta_auto_resume_due` enforces exponential backoff cooldown
- Existing `get_runtime_ids` callers unchanged
- `~paused:false` (resume) paths at `keeper_turn_runtime_budget.ml:770` left unchanged

Refs task-704, task-677 (initial), extended during code review corrections from analyst/albini on board