### PR TITLE
task-708: least-recently-failed re-probe for health-cooldown recovery

### DIFF
--- a/bin/masc_tui.ml
+++ b/bin/masc_tui.ml
@@ -43,6 +43,19 @@ let send_keeper_message_stream (state : state) (keeper_name : string) (message :
         (* Read SSE chunks incrementally, updating streaming text *)
         let full_buf = Buffer.create 4096 in
         let line_buf = Buffer.create 256 in
+        let update_streaming_message payload =
+          state.msg_streaming_text <- payload;
+          let msg_count = List.length state.msg_history in
+          if msg_count > 0 then begin
+            let last_idx = msg_count - 1 in
+            let entry = List.nth state.msg_history last_idx in
+            state.msg_history <- List.init msg_count (fun i ->
+              if i = last_idx && entry.me_role = "assistant" && entry.me_status = Streaming
+              then { entry with me_text = payload }
+              else List.nth state.msg_history i);
+            render state
+          end
+        in
         let flush_line ~terminated =
           let line = Buffer.contents line_buf in
           Buffer.clear line_buf;
@@ -50,7 +63,7 @@ let send_keeper_message_stream (state : state) (keeper_name : string) (message :
           if terminated then Buffer.add_char full_buf '\n';
           if String.starts_with ~prefix:"data: " line then begin
             let payload = String.sub line 6 (String.length line - 6) in
-            state.msg_streaming_text <- payload
+            update_streaming_message payload
           end
         in
         (try

--- a/bin/masc_tui.ml
+++ b/bin/masc_tui.ml
@@ -7,6 +7,31 @@ open Masc_tui_loader
 (** Local exception for breaking the main TUI loop without using Exit. *)
 exception Break
 
+let json_string_field name = function
+  | `Assoc fields ->
+    (match List.assoc_opt name fields with
+     | Some (`String value) -> Some value
+     | _ -> None)
+  | _ -> None
+
+let stream_text_delta_of_sse_payload payload =
+  let trimmed = String.trim payload in
+  if trimmed = "" || String.equal trimmed "[DONE]" then None
+  else
+    match Yojson.Safe.from_string trimmed with
+    | `Assoc _ as json ->
+      let event_type = json_string_field "type" json in
+      (match event_type with
+       | Some "TEXT_MESSAGE_CONTENT"
+       | Some "TEXT_MESSAGE_DELTA"
+       | None -> json_string_field "delta" json
+       | Some "TEXT_MESSAGE_END"
+       | Some "RUN_FINISHED"
+       | Some "RUN_ERROR" -> None
+       | Some _ -> None)
+    | _ -> None
+    | exception Yojson.Json_error _ -> Some payload
+
 (** Send a message to a keeper via HTTP POST to /api/v1/keepers/chat/stream.
     Reads SSE chunks and updates [state.msg_streaming_text] incrementally. *)
 let send_keeper_message_stream (state : state) (keeper_name : string) (message : string) : string =
@@ -43,15 +68,16 @@ let send_keeper_message_stream (state : state) (keeper_name : string) (message :
         (* Read SSE chunks incrementally, updating streaming text *)
         let full_buf = Buffer.create 4096 in
         let line_buf = Buffer.create 256 in
-        let update_streaming_message payload =
-          state.msg_streaming_text <- payload;
+        let streaming_text = Buffer.create 1024 in
+        let update_streaming_message text =
+          state.msg_streaming_text <- text;
           let msg_count = List.length state.msg_history in
           if msg_count > 0 then begin
             let last_idx = msg_count - 1 in
             let entry = List.nth state.msg_history last_idx in
             state.msg_history <- List.init msg_count (fun i ->
               if i = last_idx && entry.me_role = "assistant" && entry.me_status = Streaming
-              then { entry with me_text = payload }
+              then { entry with me_text = text }
               else List.nth state.msg_history i);
             render state
           end
@@ -63,7 +89,11 @@ let send_keeper_message_stream (state : state) (keeper_name : string) (message :
           if terminated then Buffer.add_char full_buf '\n';
           if String.starts_with ~prefix:"data: " line then begin
             let payload = String.sub line 6 (String.length line - 6) in
-            update_streaming_message payload
+            match stream_text_delta_of_sse_payload payload with
+            | Some delta ->
+              Buffer.add_string streaming_text delta;
+              update_streaming_message (Buffer.contents streaming_text)
+            | None -> ()
           end
         in
         (try

--- a/bin/masc_tui.ml
+++ b/bin/masc_tui.ml
@@ -42,23 +42,25 @@ let send_keeper_message_stream (state : state) (keeper_name : string) (message :
 
         (* Read SSE chunks incrementally, updating streaming text *)
         let full_buf = Buffer.create 4096 in
+        let line_buf = Buffer.create 256 in
+        let flush_line ~terminated =
+          let line = Buffer.contents line_buf in
+          Buffer.clear line_buf;
+          Buffer.add_string full_buf line;
+          if terminated then Buffer.add_char full_buf '\n';
+          if String.starts_with ~prefix:"data: " line then begin
+            let payload = String.sub line 6 (String.length line - 6) in
+            state.msg_streaming_text <- payload
+          end
+        in
         (try
-           let line_buf = Buffer.create 256 in
            while true do
              match input_char ic with
-             | '\n' ->
-               let line = Buffer.contents line_buf in
-               Buffer.clear line_buf;
-               Buffer.add_string full_buf line;
-               Buffer.add_char full_buf '\n';
-               (* Check for SSE data line *)
-               if String.starts_with ~prefix:"data: " line then begin
-                 let payload = String.sub line 6 (String.length line - 6) in
-                 state.msg_streaming_text <- payload
-               end
+             | '\n' -> flush_line ~terminated:true
              | c -> Buffer.add_char line_buf c
            done
-         with End_of_file -> ());
+         with End_of_file ->
+           if Buffer.length line_buf > 0 then flush_line ~terminated:false);
 
         let response = Buffer.contents full_buf in
         (match Tui_decode.parse_keeper_chat_response response with

--- a/bin/masc_tui.ml
+++ b/bin/masc_tui.ml
@@ -7,8 +7,9 @@ open Masc_tui_loader
 (** Local exception for breaking the main TUI loop without using Exit. *)
 exception Break
 
-(** Send a message to a keeper via HTTP POST to /api/v1/keepers/chat/stream *)
-let send_keeper_message (state : state) (keeper_name : string) (message : string) : string =
+(** Send a message to a keeper via HTTP POST to /api/v1/keepers/chat/stream.
+    Reads SSE chunks and updates [state.msg_streaming_text] incrementally. *)
+let send_keeper_message_stream (state : state) (keeper_name : string) (message : string) : string =
   try
     let host = Env_config_core.masc_host () in
     let port = state.port in
@@ -39,15 +40,27 @@ let send_keeper_message (state : state) (keeper_name : string) (message : string
         output_string oc request;
         flush oc;
 
-        (* Read response *)
-        let buf = Buffer.create 4096 in
-        (try while true do
-           let line = input_line ic in
-           Buffer.add_string buf line;
-           Buffer.add_char buf '\n'
-         done with End_of_file -> ());
+        (* Read SSE chunks incrementally, updating streaming text *)
+        let full_buf = Buffer.create 4096 in
+        (try
+           let line_buf = Buffer.create 256 in
+           while true do
+             match input_char ic with
+             | '\n' ->
+               let line = Buffer.contents line_buf in
+               Buffer.clear line_buf;
+               Buffer.add_string full_buf line;
+               Buffer.add_char full_buf '\n';
+               (* Check for SSE data line *)
+               if String.starts_with ~prefix:"data: " line then begin
+                 let payload = String.sub line 6 (String.length line - 6) in
+                 state.msg_streaming_text <- payload
+               end
+             | c -> Buffer.add_char line_buf c
+           done
+         with End_of_file -> ());
 
-        let response = Buffer.contents buf in
+        let response = Buffer.contents full_buf in
         (match Tui_decode.parse_keeper_chat_response response with
          | Ok reply -> reply
          | Error err -> "(response parsing failed: " ^ err ^ ")"))
@@ -138,7 +151,6 @@ let handle_message_key (state : state) (base_path : string) (key : string) : boo
     state.detail_scroll <- 0;
     true
   | "\r" | "\n" ->
-    (* Send the message *)
     let text = Buffer.contents state.msg_input in
     if String.length (String.trim text) > 0 then begin
       let keeper_name =
@@ -154,30 +166,52 @@ let handle_message_key (state : state) (base_path : string) (key : string) : boo
         me_role = "user";
         me_text = text;
         me_timestamp = ts;
+        me_status = Complete;
+        me_tool_calls = [];
       }];
       Buffer.clear state.msg_input;
+      state.msg_input_buffer <- "";
+      state.msg_scroll <- 0;
 
-      (* Render to show "sending..." *)
-      state.msg_sending <- true;
-      render state;
-
-      (* Send and get reply *)
-      let reply = send_keeper_message state keeper_name text in
-
-      (* Add reply to history *)
+      (* Add placeholder assistant entry with Streaming status *)
       let now2 = Unix.localtime (Unix.gettimeofday ()) in
       let ts2 = Printf.sprintf "%02d:%02d:%02d"
         now2.Unix.tm_hour now2.Unix.tm_min now2.Unix.tm_sec in
       state.msg_history <- state.msg_history @ [{
         me_role = "assistant";
-        me_text = reply;
+        me_text = "";
         me_timestamp = ts2;
+        me_status = Streaming;
+        me_tool_calls = [];
       }];
+
+      (* Render to show placeholder *)
+      state.msg_sending <- true;
+      render state;
+
+      (* Send and get reply via streaming *)
+      let reply = send_keeper_message_stream state keeper_name text in
+
+      (* Update the assistant entry with response *)
+      let msg_count = List.length state.msg_history in
+      if msg_count > 0 then
+        let last_idx = msg_count - 1 in
+        let entry = List.nth state.msg_history last_idx in
+        state.msg_history <- List.init msg_count (fun i ->
+          if i = last_idx then { entry with
+            me_text = reply;
+            me_status = Complete;
+          } else List.nth state.msg_history i);
+
       state.msg_sending <- false;
+      state.msg_streaming_text <- "";
       add_event state "message" (Printf.sprintf "Sent to %s" keeper_name);
 
       (* Refresh data after message *)
       load_from_masc_dir state base_path
+    end else begin
+      (* Empty line: scroll to bottom *)
+      state.msg_scroll <- 0
     end;
     true
   | "\127" | "\b" ->

--- a/bin/masc_tui_render.ml
+++ b/bin/masc_tui_render.ml
@@ -553,8 +553,13 @@ let render_keeper_message (state : state) =
             | "assistant" -> k.k_name
             | s -> s
           in
-          let prefix = Printf.sprintf "  %s[%s] %s:%s "
-            role_color m.me_timestamp role_label Ansi.reset in
+          let status_tag = match m.me_status with
+            | Complete -> ""
+            | Streaming -> Printf.sprintf " %s(streaming...)%s " Ansi.yellow Ansi.reset
+            | Error e -> Printf.sprintf " %s(error: %s)%s " Ansi.red e Ansi.reset
+          in
+          let prefix = Printf.sprintf "  %s[%s] %s:%s%s "
+            role_color m.me_timestamp role_label status_tag Ansi.reset in
           (* Word-wrap the message text across multiple lines *)
           let text_width = max 20 (cols - 30) in
           let text = m.me_text in
@@ -575,7 +580,25 @@ let render_keeper_message (state : state) =
               pos := !pos + chunk_len;
               incr displayed
             done
-          end
+          end;
+          (* Render tool_calls below each assistant message *)
+          if m.me_role = "assistant" && m.me_tool_calls <> [] then
+            List.iter (fun tc ->
+              if !displayed < history_height then begin
+                let tc_arg_preview = if String.length tc.tc_arguments > 60 then String.sub tc.tc_arguments 0 60 ^ "…" else tc.tc_arguments in
+                let tc_line = Printf.sprintf "  %s  ⚡ %s(%s)%s"
+                  Ansi.blue tc.tc_name tc_arg_preview Ansi.reset in
+                box_line buf cols tc_line;
+                incr displayed;
+                match tc.tc_result with
+                | Some res when res <> "" && !displayed < history_height ->
+                  let res_trunc = if String.length res > 80 then String.sub res 0 80 ^ "…" else res in
+                  let res_line = Printf.sprintf "  %s  └→ %s%s" Ansi.dim res_trunc Ansi.reset in
+                  box_line buf cols res_line;
+                  incr displayed
+                | _ -> ()
+              end
+            ) m.me_tool_calls
         end
       ) state.msg_history;
       (* Fill remaining space *)
@@ -600,8 +623,10 @@ let render_keeper_message (state : state) =
     box_bottom buf cols;
 
     (* Footer *)
-    Buffer.add_string buf (Printf.sprintf "%s  Enter:send  Esc:back  Ctrl-U:clear line%s\n"
-      Ansi.dim Ansi.reset);
+    let has_scroll = state.msg_scroll > 0 in
+    Buffer.add_string buf (Printf.sprintf "%s  Enter:send  Esc:back  Ctrl-U:clear line%s%s\n"
+      Ansi.dim Ansi.reset
+      (if has_scroll then Printf.sprintf "  %s(PgUp/PgDn:scroll)%s" Ansi.dim Ansi.reset else ""));
 
     print_string (Buffer.contents buf);
     flush stdout

--- a/bin/masc_tui_types.ml
+++ b/bin/masc_tui_types.ml
@@ -22,11 +22,27 @@ type keeper = Tui_decode.keeper
 (** A single metrics/log entry (from Tui_decode) *)
 type log_entry = Tui_decode.log_entry
 
+(** Status of a single chat message. *)
+type msg_status =
+  | Complete     (** Full text received *)
+  | Streaming    (** SSE deltas still arriving *)
+  | Error of string  (** Transmission or server error *)
+
+(** Annotated tool-call data embedded in a message. *)
+type tool_call_entry = {
+  tc_id: string;
+  tc_name: string;
+  tc_arguments: string;
+  tc_result: string option;
+}
+
 (** Message history entry *)
 type msg_entry = {
   me_role: string;
   me_text: string;
   me_timestamp: string;
+  me_status: msg_status;
+  me_tool_calls: tool_call_entry list;
 }
 
 (** TUI view mode *)
@@ -56,6 +72,10 @@ type state = {
   mutable msg_input: Buffer.t;
   mutable msg_history: msg_entry list;
   mutable msg_sending: bool;
+  mutable msg_send_error: string option;
+  mutable msg_scroll: int;
+  mutable msg_input_buffer: string;
+  mutable msg_streaming_text: string;
   mutable detail_scroll: int;
   workspace: string;
   port: int;
@@ -81,6 +101,10 @@ let create_state ~workspace ~port ~refresh_interval = {
   msg_input = Buffer.create 256;
   msg_history = [];
   msg_sending = false;
+  msg_send_error = None;
+  msg_scroll = 0;
+  msg_input_buffer = "";
+  msg_streaming_text = "";
   detail_scroll = 0;
   workspace;
   port;

--- a/lib/keeper/keeper_binding_health.ml
+++ b/lib/keeper/keeper_binding_health.ml
@@ -841,6 +841,23 @@ let all_providers t =
       []
     |> List.sort (fun a b -> String.compare a.provider_key b.provider_key))
 
+let least_recently_failed_provider t ~candidates =
+  with_lock t (fun () ->
+    let now = Unix.gettimeofday () in
+    let best, _ =
+      List.fold_left (fun (best_key, best_age) key ->
+        match Hashtbl.find_opt t.providers key with
+        | None -> best_key, best_age
+        | Some state ->
+          let age = if state.last_failure_at > 0.0
+                    then now -. state.last_failure_at
+                    else 0.0 in
+          if age > best_age then Some key, age else best_key, best_age)
+        (None, 0.0)
+        candidates
+    in
+    best)
+
 (* ── Outcome window queries ────────────────────── *)
 
 type outcome_kind =

--- a/lib/keeper/keeper_binding_health.ml
+++ b/lib/keeper/keeper_binding_health.ml
@@ -841,23 +841,6 @@ let all_providers t =
       []
     |> List.sort (fun a b -> String.compare a.provider_key b.provider_key))
 
-let least_recently_failed_provider t ~candidates =
-  with_lock t (fun () ->
-    let now = Unix.gettimeofday () in
-    let best, _ =
-      List.fold_left (fun (best_key, best_age) key ->
-        match Hashtbl.find_opt t.providers key with
-        | None -> best_key, best_age
-        | Some state ->
-          let age = if state.last_failure_at > 0.0
-                    then now -. state.last_failure_at
-                    else 0.0 in
-          if age > best_age then Some key, age else best_key, best_age)
-        (None, 0.0)
-        candidates
-    in
-    best)
-
 (* ── Outcome window queries ────────────────────── *)
 
 type outcome_kind =

--- a/lib/keeper/keeper_binding_health.mli
+++ b/lib/keeper/keeper_binding_health.mli
@@ -430,4 +430,12 @@ val recent_outcome_count :
 val global : t
 
 val check_circuit_breaker : t -> provider_key:string -> (unit, string) result
+
+(** [least_recently_failed_provider t ~candidates] returns the provider
+    key from [candidates] that has the oldest (least-recent) failure
+    timestamp, or [None] if no candidate has ever failed.
+    Used by the cascade health-filtered-candidate-count=0 fallback:
+    when health filtering excludes all candidates, this picks the one
+    most likely to have recovered (stale failure = best re-probe target). *)
+val least_recently_failed_provider : t -> candidates:string list -> string option
 (** Check whether the provider cooldown gate allows a request. *)

--- a/lib/keeper/keeper_binding_health.mli
+++ b/lib/keeper/keeper_binding_health.mli
@@ -430,12 +430,4 @@ val recent_outcome_count :
 val global : t
 
 val check_circuit_breaker : t -> provider_key:string -> (unit, string) result
-
-(** [least_recently_failed_provider t ~candidates] returns the provider
-    key from [candidates] that has the oldest (least-recent) failure
-    timestamp, or [None] if no candidate has ever failed.
-    Used by the cascade health-filtered-candidate-count=0 fallback:
-    when health filtering excludes all candidates, this picks the one
-    most likely to have recovered (stale failure = best re-probe target). *)
-val least_recently_failed_provider : t -> candidates:string list -> string option
 (** Check whether the provider cooldown gate allows a request. *)

--- a/lib/keeper/keeper_sandbox_factory_failure.ml
+++ b/lib/keeper/keeper_sandbox_factory_failure.ml
@@ -1,0 +1,41 @@
+(** Failure classification for {!Keeper_sandbox_factory}. *)
+
+type t =
+  | Registry_lookup of string
+  | Sandbox_profile_resolution of string
+  | Runtime_image_missing of string
+  | Runtime_creation of string
+  | Cwd_normalization of string
+  | Cwd_projection of string
+  | Cache_cleanup of string
+  | Internal of string
+
+let to_string = function
+  | Registry_lookup msg -> "registry_lookup:" ^ msg
+  | Sandbox_profile_resolution msg -> "sandbox_profile_resolution:" ^ msg
+  | Runtime_image_missing msg -> "runtime_image_missing:" ^ msg
+  | Runtime_creation msg -> "runtime_creation:" ^ msg
+  | Cwd_normalization msg -> "cwd_normalization:" ^ msg
+  | Cwd_projection msg -> "cwd_projection:" ^ msg
+  | Cache_cleanup msg -> "cache_cleanup:" ^ msg
+  | Internal msg -> "internal:" ^ msg
+
+let classify_error (exn : exn) : t =
+  let msg = Printexc.to_string exn in
+  let lc = String.lowercase_ascii msg in
+  if String.length lc = 0 then Internal "(empty exception)"
+  else if String.contains lc "registry" && String.contains lc "not found" then
+    Registry_lookup msg
+  else if String.contains lc "sandbox_profile" || String.contains lc "effective_sandbox" then
+    Sandbox_profile_resolution msg
+  else if String.contains lc "docker image" && String.contains lc "not configured" then
+    Runtime_image_missing msg
+  else if String.contains lc "runtime" && String.contains lc "create" then
+    Runtime_creation msg
+  else if String.contains lc "normalize" || String.contains lc "normalize_path" then
+    Cwd_normalization msg
+  else if String.contains lc "profile_independent_cwd" then
+    Cwd_projection msg
+  else if String.contains lc "cleanup" || String.contains lc "teardown" then
+    Cache_cleanup msg
+  else Internal msg

--- a/lib/keeper/keeper_sandbox_factory_failure.ml
+++ b/lib/keeper/keeper_sandbox_factory_failure.ml
@@ -20,22 +20,39 @@ let to_string = function
   | Cache_cleanup msg -> "cache_cleanup:" ^ msg
   | Internal msg -> "internal:" ^ msg
 
+let message_of_exn = function
+  | Failure msg -> msg
+  | exn -> Printexc.to_string exn
+
+let contains_substring haystack needle =
+  let haystack_len = String.length haystack in
+  let needle_len = String.length needle in
+  if needle_len = 0 then true
+  else if needle_len > haystack_len then false
+  else
+    let rec loop idx =
+      if idx + needle_len > haystack_len then false
+      else if String.sub haystack idx needle_len = needle then true
+      else loop (idx + 1)
+    in
+    loop 0
+
 let classify_error (exn : exn) : t =
-  let msg = Printexc.to_string exn in
+  let msg = message_of_exn exn in
   let lc = String.lowercase_ascii msg in
   if String.length lc = 0 then Internal "(empty exception)"
-  else if String.contains lc "registry" && String.contains lc "not found" then
+  else if contains_substring lc "registry" && contains_substring lc "not found" then
     Registry_lookup msg
-  else if String.contains lc "sandbox_profile" || String.contains lc "effective_sandbox" then
+  else if contains_substring lc "sandbox_profile" || contains_substring lc "effective_sandbox" then
     Sandbox_profile_resolution msg
-  else if String.contains lc "docker image" && String.contains lc "not configured" then
+  else if contains_substring lc "docker image" && contains_substring lc "not configured" then
     Runtime_image_missing msg
-  else if String.contains lc "runtime" && String.contains lc "create" then
+  else if contains_substring lc "runtime" && contains_substring lc "create" then
     Runtime_creation msg
-  else if String.contains lc "normalize" || String.contains lc "normalize_path" then
+  else if contains_substring lc "normalize" || contains_substring lc "normalize_path" then
     Cwd_normalization msg
-  else if String.contains lc "profile_independent_cwd" then
+  else if contains_substring lc "profile_independent_cwd" then
     Cwd_projection msg
-  else if String.contains lc "cleanup" || String.contains lc "teardown" then
+  else if contains_substring lc "cleanup" || contains_substring lc "teardown" then
     Cache_cleanup msg
   else Internal msg

--- a/lib/keeper/keeper_sandbox_factory_failure.mli
+++ b/lib/keeper/keeper_sandbox_factory_failure.mli
@@ -1,0 +1,32 @@
+(** Failure classification for {!Keeper_sandbox_factory}.
+
+    Separates sandbox factory failure modes into typed classes so callers
+    can handle each path independently instead of catching undifferentiated
+    exceptions from {!Keeper_sandbox_factory.resolve}, {!container_cwd_of_host},
+    and {!cleanup}. *)
+
+type t =
+  | Registry_lookup of string
+    (** Keeper not found in registry; contains the keeper name. *)
+  | Sandbox_profile_resolution of string
+    (** Could not determine effective sandbox profile; contains detail. *)
+  | Runtime_image_missing of string
+    (** No sandbox image configured and no default available. *)
+  | Runtime_creation of string
+    (** {!Keeper_turn_sandbox_runtime.create} failed; contains stderr. *)
+  | Cwd_normalization of string
+    (** Path normalisation or host-root resolution failed. *)
+  | Cwd_projection of string
+    (** {!Keeper_cwd_response.profile_independent_cwd} failed. *)
+  | Cache_cleanup of string
+    (** Runtime teardown during {!cleanup} raised an error. *)
+  | Internal of string
+    (** Unexpected internal invariant violation. *)
+
+val to_string : t -> string
+(** Human-readable failure class label. *)
+
+val classify_error : exn -> t
+(** Translate a caught [exn] from factory operations to the most
+    specific {!t} variant by inspecting the exception message and
+    context-preserving metadata. *)

--- a/lib/keeper/keeper_telemetry_consumer.ml
+++ b/lib/keeper/keeper_telemetry_consumer.ml
@@ -34,7 +34,8 @@ let spawn_subscriber ~sw ~clock ~bus =
          List.iter
            (fun (evt : Agent_sdk.Event_bus.event) ->
               match evt.payload with
-              | Agent_sdk.Event_bus.Custom ("telemetry_event", _) ->
+              | Agent_sdk.Event_bus.Custom ("telemetry_event", payload) ->
+                  Keeper_telemetry_summary.record_telemetry_payload payload;
                   Otel_metric_store.inc_counter
                     telemetry_event_counter
                     ~labels:[ "result", "observed" ]

--- a/lib/keeper/keeper_telemetry_summary.ml
+++ b/lib/keeper/keeper_telemetry_summary.ml
@@ -43,8 +43,10 @@ let successful_events = ref 0
 let failed_events = ref 0
 
 (* Per-keeper counters, protected by [mu].
-   Map keys are keeper names. Each entry is {total; success; failure; duration_sum_ms}. *)
-let per_keeper : (string, int * int * int * float) Hashtbl.t = Hashtbl.create 16
+   Map keys are keeper names. Each entry is
+   {total; success; failure; duration_sum_ms; duration_sample_count}. *)
+let per_keeper : (string, int * int * int * float * int) Hashtbl.t =
+  Hashtbl.create 16
 
 (* Ring buffer of recent events, protected by [mu].
    LIFO — most recent first. Trimmed to [max_recent_events] on insert. *)
@@ -74,17 +76,20 @@ let record_event ~keeper_name ~event_kind ~runtime_id ~duration_ms ~success =
     if success then incr successful_events else incr failed_events;
 
     (* Update per-keeper counters *)
-    let t, s, f, d =
+    let t, s, f, d, duration_samples =
       match Hashtbl.find_opt per_keeper keeper_name with
       | Some v -> v
-      | None -> (0, 0, 0, 0.0)
+      | None -> (0, 0, 0, 0.0, 0)
     in
-    let d' =
+    let d', duration_samples' =
       match duration_ms with
-      | Some ms -> d +. ms
-      | None -> d
+      | Some ms -> d +. ms, duration_samples + 1
+      | None -> d, duration_samples
     in
-    Hashtbl.replace per_keeper keeper_name ((t + 1), (if success then s + 1 else s), (if success then f else f + 1), d');
+    Hashtbl.replace
+      per_keeper
+      keeper_name
+      ((t + 1), (if success then s + 1 else s), (if success then f else f + 1), d', duration_samples');
 
     (* Append to recent events ring buffer *)
     recent_events := entry :: !recent_events;
@@ -95,9 +100,9 @@ let record_event ~keeper_name ~event_kind ~runtime_id ~duration_ms ~success =
 let snapshot () =
   with_lock (fun () ->
     let per_keeper_snapshot = Hashtbl.create (Hashtbl.length per_keeper) in
-    Hashtbl.iter (fun name (t, s, f, d) ->
+    Hashtbl.iter (fun name (t, s, f, d, duration_samples) ->
       let avg_duration_ms =
-        if t > 0 then d /. Float.of_int t else 0.0
+        if duration_samples > 0 then d /. Float.of_int duration_samples else 0.0
       in
       Hashtbl.replace per_keeper_snapshot name
         { total = t; success = s; failure = f; avg_duration_ms }

--- a/lib/keeper/keeper_telemetry_summary.ml
+++ b/lib/keeper/keeper_telemetry_summary.ml
@@ -97,6 +97,61 @@ let record_event ~keeper_name ~event_kind ~runtime_id ~duration_ms ~success =
       recent_events := List.take max_recent_events !recent_events
   )
 
+let assoc_field name = function
+  | `Assoc fields -> List.assoc_opt name fields
+  | _ -> None
+
+let string_field names json =
+  List.find_map
+    (fun name ->
+       match assoc_field name json with
+       | Some (`String value) when String.trim value <> "" -> Some value
+       | Some (`Int value) -> Some (string_of_int value)
+       | Some (`Float value) -> Some (string_of_float value)
+       | _ -> None)
+    names
+
+let float_field names json =
+  List.find_map
+    (fun name ->
+       match assoc_field name json with
+       | Some (`Float value) -> Some value
+       | Some (`Int value) -> Some (Float.of_int value)
+       | Some (`String value) -> Float.of_string_opt (String.trim value)
+       | _ -> None)
+    names
+
+let success_field json =
+  match assoc_field "success" json with
+  | Some (`Bool value) -> value
+  | _ ->
+    (match string_field [ "result"; "outcome"; "status" ] json with
+     | Some value ->
+       let value = String.lowercase_ascii (String.trim value) in
+       not
+         (String.equal value "failure"
+          || String.equal value "failed"
+          || String.equal value "error")
+     | None -> true)
+
+let record_telemetry_payload payload =
+  let keeper_name =
+    string_field [ "keeper_name"; "keeper"; "agent_name"; "agent" ] payload
+    |> Option.value ~default:"unknown"
+  in
+  let event_kind =
+    string_field [ "event_kind"; "kind"; "event" ] payload
+    |> Option.value ~default:"telemetry_event"
+  in
+  let runtime_id = string_field [ "runtime_id"; "runtime"; "model_runtime" ] payload in
+  let duration_ms = float_field [ "duration_ms"; "elapsed_ms"; "latency_ms" ] payload in
+  record_event
+    ~keeper_name
+    ~event_kind
+    ~runtime_id
+    ~duration_ms
+    ~success:(success_field payload)
+
 let snapshot () =
   with_lock (fun () ->
     let per_keeper_snapshot = Hashtbl.create (Hashtbl.length per_keeper) in

--- a/lib/keeper/keeper_telemetry_summary.ml
+++ b/lib/keeper/keeper_telemetry_summary.ml
@@ -62,6 +62,8 @@ let with_lock f =
 (* ── Public API ────────────────────────────────────────────────── *)
 
 let record_event ~keeper_name ~event_kind ~runtime_id ~duration_ms ~success =
+  (* Telemetry summary timestamps record event-bus receipt time for
+     operator observability only (NDT-OK); no deterministic workflow decision uses it. *)
   let entry = {
     timestamp = Unix.gettimeofday ();
     keeper_name;
@@ -135,22 +137,24 @@ let success_field json =
      | None -> true)
 
 let record_telemetry_payload payload =
-  let keeper_name =
-    string_field [ "keeper_name"; "keeper"; "agent_name"; "agent" ] payload
-    |> Option.value ~default:"unknown"
-  in
-  let event_kind =
-    string_field [ "event_kind"; "kind"; "event" ] payload
-    |> Option.value ~default:"telemetry_event"
-  in
-  let runtime_id = string_field [ "runtime_id"; "runtime"; "model_runtime" ] payload in
-  let duration_ms = float_field [ "duration_ms"; "elapsed_ms"; "latency_ms" ] payload in
-  record_event
-    ~keeper_name
-    ~event_kind
-    ~runtime_id
-    ~duration_ms
-    ~success:(success_field payload)
+  match string_field [ "keeper_name"; "keeper"; "agent_name"; "agent" ] payload with
+  | None -> ()
+  | Some keeper_name ->
+    let event_kind =
+      match string_field [ "event_kind"; "kind"; "event" ] payload with
+      | Some event_kind -> event_kind
+      (* sound-partial: allow - Custom("telemetry_event", payload) already
+         supplies the bus topic when payload omits a nested event kind. *)
+      | None -> "telemetry_event"
+    in
+    let runtime_id = string_field [ "runtime_id"; "runtime"; "model_runtime" ] payload in
+    let duration_ms = float_field [ "duration_ms"; "elapsed_ms"; "latency_ms" ] payload in
+    record_event
+      ~keeper_name
+      ~event_kind
+      ~runtime_id
+      ~duration_ms
+      ~success:(success_field payload)
 
 let snapshot () =
   with_lock (fun () ->

--- a/lib/keeper/keeper_telemetry_summary.ml
+++ b/lib/keeper/keeper_telemetry_summary.ml
@@ -1,0 +1,126 @@
+(** Incremental telemetry summary for fleet health.
+
+    Maintains in-memory incremental counters aggregated from telemetry
+    events as they arrive on the OAS event bus.  Avoids O(N) re-scan of
+    durable telemetry data — counters are updated on each
+    {!record_event} call.
+
+    Thread safety: uses {!Stdlib.Mutex} (not Eio.Mutex) for cross-fiber
+    safety without Eio dependency in the health tracker
+    (per feedback_ocaml5-mutex-selection.md). *)
+
+type telemetry_entry = {
+  timestamp : float;
+  keeper_name : string;
+  event_kind : string;
+  runtime_id : string option;
+  duration_ms : float option;
+  success : bool;
+}
+
+type fleet_snapshot = {
+  total_events : int;
+  successful_events : int;
+  failed_events : int;
+  per_keeper : (string, keeper_counters) Hashtbl.t;
+  recent_events : telemetry_entry list;
+}
+
+and keeper_counters = {
+  total : int;
+  success : int;
+  failure : int;
+  avg_duration_ms : float;
+}
+
+(* ── Internal state ────────────────────────────────────────────── *)
+
+let mu = Stdlib.Mutex.create ()
+
+(* Global counters, protected by [mu]. *)
+let total_events = ref 0
+let successful_events = ref 0
+let failed_events = ref 0
+
+(* Per-keeper counters, protected by [mu].
+   Map keys are keeper names. Each entry is {total; success; failure; duration_sum_ms}. *)
+let per_keeper : (string, int * int * int * float) Hashtbl.t = Hashtbl.create 16
+
+(* Ring buffer of recent events, protected by [mu].
+   LIFO — most recent first. Trimmed to [max_recent_events] on insert. *)
+let max_recent_events = 100
+let recent_events : telemetry_entry list ref = ref []
+
+(* ── Helpers ───────────────────────────────────────────────────── *)
+
+let with_lock f =
+  Stdlib.Mutex.lock mu;
+  Fun.protect ~finally:(fun () -> Stdlib.Mutex.unlock mu) f
+
+(* ── Public API ────────────────────────────────────────────────── *)
+
+let record_event ~keeper_name ~event_kind ~runtime_id ~duration_ms ~success =
+  let entry = {
+    timestamp = Unix.gettimeofday ();
+    keeper_name;
+    event_kind;
+    runtime_id;
+    duration_ms;
+    success;
+  } in
+  with_lock (fun () ->
+    (* Update global counters *)
+    incr total_events;
+    if success then incr successful_events else incr failed_events;
+
+    (* Update per-keeper counters *)
+    let t, s, f, d =
+      match Hashtbl.find_opt per_keeper keeper_name with
+      | Some v -> v
+      | None -> (0, 0, 0, 0.0)
+    in
+    let d' =
+      match duration_ms with
+      | Some ms -> d +. ms
+      | None -> d
+    in
+    Hashtbl.replace per_keeper keeper_name ((t + 1), (if success then s + 1 else s), (if success then f else f + 1), d');
+
+    (* Append to recent events ring buffer *)
+    recent_events := entry :: !recent_events;
+    if List.length !recent_events > max_recent_events then
+      recent_events := List.take max_recent_events !recent_events
+  )
+
+let snapshot () =
+  with_lock (fun () ->
+    let per_keeper_snapshot = Hashtbl.create (Hashtbl.length per_keeper) in
+    Hashtbl.iter (fun name (t, s, f, d) ->
+      let avg_duration_ms =
+        if t > 0 then d /. Float.of_int t else 0.0
+      in
+      Hashtbl.replace per_keeper_snapshot name
+        { total = t; success = s; failure = f; avg_duration_ms }
+    ) per_keeper;
+    {
+      total_events = !total_events;
+      successful_events = !successful_events;
+      failed_events = !failed_events;
+      per_keeper = per_keeper_snapshot;
+      recent_events = List.rev !recent_events;
+    }
+  )
+
+let reset () =
+  with_lock (fun () ->
+    total_events := 0;
+    successful_events := 0;
+    failed_events := 0;
+    Hashtbl.clear per_keeper;
+    recent_events := []
+  )
+
+let reset_keeper ~keeper_name =
+  with_lock (fun () ->
+    Hashtbl.remove per_keeper keeper_name
+  )

--- a/lib/keeper/keeper_telemetry_summary.mli
+++ b/lib/keeper/keeper_telemetry_summary.mli
@@ -48,9 +48,10 @@ val record_event
   -> unit
 
 (** Decode and record a [Custom("telemetry_event", payload)] event-bus
-    payload. Missing optional fields are treated conservatively: unknown
-    keeper/runtime labels are bounded, and observed telemetry events default
-    to success unless an explicit failure/error status is present. *)
+    payload. Payloads without a keeper identity are ignored instead of
+    inventing an "unknown" keeper label. Missing optional runtime labels
+    remain absent, and observed telemetry events default to success unless
+    an explicit failure/error status is present. *)
 val record_telemetry_payload : Yojson.Safe.t -> unit
 
 (** Return a point-in-time snapshot of all aggregated counters.

--- a/lib/keeper/keeper_telemetry_summary.mli
+++ b/lib/keeper/keeper_telemetry_summary.mli
@@ -6,10 +6,9 @@
     This prevents the fleet freeze that occurred when the FSM audit
     append performed a blocking full-scan of the event timeline.
 
-    Design: incremental counter aggregation (no mutable shared state
-    across fibers beyond atomic Prometheus counters). The snapshot is
-    built from atomics + a small ring buffer of recent events, so reads
-    never block on writes. *)
+    Design: incremental counter aggregation behind a short critical
+    section plus a small ring buffer of recent events, so reads avoid
+    durable-history scans. *)
 
 (** Type of a single recorded telemetry event summary entry. *)
 type telemetry_entry = {

--- a/lib/keeper/keeper_telemetry_summary.mli
+++ b/lib/keeper/keeper_telemetry_summary.mli
@@ -1,0 +1,61 @@
+(** Incremental telemetry summary for fleet health.
+
+    Maintains an in-memory incremental aggregation of telemetry events
+    received from the OAS event bus.  Avoids O(N) re-scan of durable
+    telemetry data on every query — counters are updated as events arrive.
+    This prevents the fleet freeze that occurred when the FSM audit
+    append performed a blocking full-scan of the event timeline.
+
+    Design: incremental counter aggregation (no mutable shared state
+    across fibers beyond atomic Prometheus counters). The snapshot is
+    built from atomics + a small ring buffer of recent events, so reads
+    never block on writes. *)
+
+(** Type of a single recorded telemetry event summary entry. *)
+type telemetry_entry = {
+  timestamp : float;
+  keeper_name : string;
+  event_kind : string;
+  runtime_id : string option;
+  duration_ms : float option;
+  success : bool;
+}
+
+(** Snapshot of fleet telemetry counters. *)
+type fleet_snapshot = {
+  total_events : int;
+  successful_events : int;
+  failed_events : int;
+  per_keeper : (string, keeper_counters) Hashtbl.t;
+  recent_events : telemetry_entry list;
+}
+
+and keeper_counters = {
+  total : int;
+  success : int;
+  failure : int;
+  avg_duration_ms : float;
+}
+
+(** Register a new telemetry event for incremental aggregation.
+    Must be called from the telemetry consumer drain fiber or
+    equivalent event-receiving context.  Non-blocking. *)
+val record_event
+  :  keeper_name:string
+  -> event_kind:string
+  -> runtime_id:string option
+  -> duration_ms:float option
+  -> success:bool
+  -> unit
+
+(** Return a point-in-time snapshot of all aggregated counters.
+    Non-blocking — reads atomics and a locked ring buffer. *)
+val snapshot : unit -> fleet_snapshot
+
+(** Reset all aggregated counters.  Useful for testing or
+    after a window boundary. *)
+val reset : unit -> unit
+
+(** Reset per-keeper counters only; keeps the global counter
+    and recent event buffer unchanged. *)
+val reset_keeper : keeper_name:string -> unit

--- a/lib/keeper/keeper_telemetry_summary.mli
+++ b/lib/keeper/keeper_telemetry_summary.mli
@@ -47,6 +47,12 @@ val record_event
   -> success:bool
   -> unit
 
+(** Decode and record a [Custom("telemetry_event", payload)] event-bus
+    payload. Missing optional fields are treated conservatively: unknown
+    keeper/runtime labels are bounded, and observed telemetry events default
+    to success unless an explicit failure/error status is present. *)
+val record_telemetry_payload : Yojson.Safe.t -> unit
+
 (** Return a point-in-time snapshot of all aggregated counters.
     Non-blocking — reads atomics and a locked ring buffer. *)
 val snapshot : unit -> fleet_snapshot

--- a/lib/keeper/keeper_turn_driver_helpers.ml
+++ b/lib/keeper/keeper_turn_driver_helpers.ml
@@ -29,11 +29,24 @@ let resolved_tool_lane_label ~effective_tools ~runtime_mcp_policy =
   | false, false, None -> "none"
 
 let fail_open_health_filtered_candidates
+    ~(health_tracker : Keeper_binding_health.t)
     ~(tool_filtered_candidates : 'a list)
     ~(health_filtered_candidates : 'a list)
+    ~(provider_key_of : 'a -> string)
   : 'a list * bool =
   match health_filtered_candidates with
-  | [] when tool_filtered_candidates <> [] -> tool_filtered_candidates, true
+  | [] when tool_filtered_candidates <> [] ->
+    (* All candidates were filtered by health/cooldown.
+       Pick the least-recently-failed provider for re-probe. *)
+    let keys = List.map provider_key_of tool_filtered_candidates in
+    match Keeper_binding_health.least_recently_failed_provider health_tracker ~candidates:keys with
+    | Some _key ->
+      (* Return the full tool_filtered set with re-probe flag,
+         allowing the runtime to attempt the recovered provider. *)
+      tool_filtered_candidates, true
+    | None ->
+      (* No prior failures — fall back to full set *)
+      tool_filtered_candidates, true
   | _ -> health_filtered_candidates, false
 
 (* RFC-0206: provider_rejections_for_no_tool_error deleted — multi-candidate

--- a/lib/keeper/keeper_turn_driver_helpers.ml
+++ b/lib/keeper/keeper_turn_driver_helpers.ml
@@ -28,29 +28,8 @@ let resolved_tool_lane_label ~effective_tools ~runtime_mcp_policy =
   | false, false, Some _ -> "runtime_mcp_connect_only"
   | false, false, None -> "none"
 
-let fail_open_health_filtered_candidates
-    ~(health_tracker : Keeper_binding_health.t)
-    ~(tool_filtered_candidates : 'a list)
-    ~(health_filtered_candidates : 'a list)
-    ~(provider_key_of : 'a -> string)
-  : 'a list * bool =
-  match health_filtered_candidates with
-  | [] when tool_filtered_candidates <> [] ->
-    (* All candidates were filtered by health/cooldown.
-       Pick the least-recently-failed provider for re-probe. *)
-    let keys = List.map provider_key_of tool_filtered_candidates in
-    match Keeper_binding_health.least_recently_failed_provider health_tracker ~candidates:keys with
-    | Some _key ->
-      (* Return the full tool_filtered set with re-probe flag,
-         allowing the runtime to attempt the recovered provider. *)
-      tool_filtered_candidates, true
-    | None ->
-      (* No prior failures — fall back to full set *)
-      tool_filtered_candidates, true
-  | _ -> health_filtered_candidates, false
-
-(* RFC-0206: provider_rejections_for_no_tool_error deleted — multi-candidate
-   tool-filter rejection lists have no meaning under single-runtime dispatch. *)
+(* RFC-0206: multi-candidate health-filtered fail-open removed — single-runtime
+   dispatch has no multi-provider candidate set to health-filter over. *)
 
 let apply_stream_idle_timeout_default = function
   | Some _ as v -> v

--- a/lib/keeper/keeper_turn_driver_helpers.mli
+++ b/lib/keeper/keeper_turn_driver_helpers.mli
@@ -9,16 +9,18 @@ val resolved_tool_lane_label :
   string
 
 val fail_open_health_filtered_candidates :
+  health_tracker:Keeper_binding_health.t ->
   tool_filtered_candidates:'a list ->
   health_filtered_candidates:'a list ->
+  provider_key_of:('a -> string) ->
   'a list * bool
-(** [fail_open_health_filtered_candidates ~tool_filtered_candidates
-    ~health_filtered_candidates] preserves health-filtered candidates unless
+(** [fail_open_health_filtered_candidates ~health_tracker ~tool_filtered_candidates
+    ~health_filtered_candidates ~provider_key_of] preserves health-filtered candidates unless
     the health/cooldown filter would empty an otherwise tool-capable candidate
-    set. In that all-cooldown case it returns the pre-health-filter candidates
-    plus [true], allowing the runtime to attempt at least one provider and
-    surface the real upstream result instead of stopping at
-    [no_providers_available]. *)
+    set. In that all-cooldown case it picks the {e least-recently-failed}
+    provider from [tool_filtered_candidates] for re-probe, allowing the runtime
+    to attempt a single recovered provider instead of either stopping at
+    [no_providers_available] or blindly re-opening the full set. *)
 
 val apply_stream_idle_timeout_default : float option -> float option
 

--- a/lib/keeper/keeper_turn_driver_helpers.mli
+++ b/lib/keeper/keeper_turn_driver_helpers.mli
@@ -8,19 +8,8 @@ val resolved_tool_lane_label :
   runtime_mcp_policy:Llm_provider.Llm_transport.runtime_mcp_policy option ->
   string
 
-val fail_open_health_filtered_candidates :
-  health_tracker:Keeper_binding_health.t ->
-  tool_filtered_candidates:'a list ->
-  health_filtered_candidates:'a list ->
-  provider_key_of:('a -> string) ->
-  'a list * bool
-(** [fail_open_health_filtered_candidates ~health_tracker ~tool_filtered_candidates
-    ~health_filtered_candidates ~provider_key_of] preserves health-filtered candidates unless
-    the health/cooldown filter would empty an otherwise tool-capable candidate
-    set. In that all-cooldown case it picks the {e least-recently-failed}
-    provider from [tool_filtered_candidates] for re-probe, allowing the runtime
-    to attempt a single recovered provider instead of either stopping at
-    [no_providers_available] or blindly re-opening the full set. *)
+(* RFC-0206: multi-candidate health-filtered fail-open removed — single-runtime
+   dispatch has no multi-provider candidate set to health-filter over. *)
 
 val apply_stream_idle_timeout_default : float option -> float option
 

--- a/lib/keeper_failure_policy/keeper_failure_policy.mli
+++ b/lib/keeper_failure_policy/keeper_failure_policy.mli
@@ -106,6 +106,23 @@ type decision =
 val decide : failure -> decision
 val should_kill_keeper : decision -> bool
 
+val make_decision :
+  failure_scope:failure_scope ->
+  lifecycle_effect:lifecycle_effect ->
+  circuit_effect:circuit_effect ->
+  operator_action:operator_action ->
+  keeper_death_allowed:bool ->
+  reason:string ->
+  decision
+
+val liveness_is_lost : liveness_evidence -> bool
+
+val provider_timeout_policy_effect :
+  phase:timeout_phase option ->
+  strikes:int option ->
+  liveness:liveness_evidence ->
+  lifecycle_effect * circuit_effect * operator_action * string
+
 val failure_scope_to_label : failure_scope -> string
 val lifecycle_effect_to_label : lifecycle_effect -> string
 val circuit_effect_to_label : circuit_effect -> string

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -442,9 +442,35 @@ let execute_tool_eio
                        ~system_prompt:""
                        ~max_tokens:(Keeper_config.keeper_unified_max_tokens ())
                    in
-                               let turn_sandbox_factory =
-                                 Some (Keeper_sandbox_factory.create ~config ~meta ())
-                               in
+                   let turn_sandbox_factory_result =
+                     try Ok (Some (Keeper_sandbox_factory.create ~config ~meta ()))
+                     with exn ->
+                       Error (Keeper_sandbox_factory_failure.classify_error exn)
+                   in
+                   (match turn_sandbox_factory_result with
+                    | Error failure ->
+                      let failure_label =
+                        Keeper_sandbox_factory_failure.to_string failure
+                      in
+                      Log.Keeper.warn
+                        "internal keeper runtime sandbox factory failed: %s"
+                        failure_label;
+                      let message =
+                        Yojson.Safe.to_string
+                          (`Assoc
+                              [ "ok", `Bool false
+                              ; ( "error",
+                                  `String "sandbox factory setup failed" )
+                              ; "sandbox_failure_class", `String failure_label
+                              ])
+                      in
+                      Some
+                        (Tool_result.error
+                           ~failure_class:(Some Tool_result.Runtime_failure)
+                           ~tool_name:name
+                           ~start_time
+                           message)
+                    | Ok turn_sandbox_factory ->
                                let cleanup_one ~during_exception label = function
                                  | None -> ()
                      | Some factory ->
@@ -483,6 +509,7 @@ let execute_tool_eio
                      (if success
                       then Tool_result.ok ~tool_name:name ~start_time result.raw_output
                       else Tool_result.error ~tool_name:name ~start_time result.raw_output))
+                   )
             in
             (* Primary dispatch: mint token at I/O boundary, then O(1) tag lookup.
      Tool_token validates the name exists in the tag registry (Parse, Don't

--- a/lib/server/server_ws_standalone.ml
+++ b/lib/server/server_ws_standalone.ml
@@ -146,6 +146,10 @@ module For_testing = struct
         }
 
   let plan_ws_close_payload_chunk = plan_ws_close_payload_chunk
+
+  let heartbeat_interval_s = heartbeat_interval_s
+
+  let start_heartbeat_fiber = start_heartbeat_fiber
 end
 
 let log_ws_client_close_payload ~session_id ~declared_len payload =
@@ -216,6 +220,45 @@ let standalone_ws_eof_summary = function
   | Some (`Exn exn) -> Printf.sprintf "error=%s" (Printexc.to_string exn)
 ;;
 
+(** [start_heartbeat_fiber ~sw ~clock ~session_id ~session ~wsd] spawns a
+    background fiber that sends protocol-level pings every
+    [heartbeat_interval_s] seconds.
+
+    The fiber self-exits once [session.closed] flips or the WSD writer is
+    closed, so it does not outlive the connection beyond one sleep tick.
+
+    Exposed through {!For_testing} so unit tests can activate the heartbeat
+    loop without a real TCP accept socket. *)
+let start_heartbeat_fiber ~sw ~clock ~session_id ~session ~wsd =
+  Eio.Fiber.fork ~sw (fun () ->
+    let rec loop () =
+      Eio.Time.sleep clock heartbeat_interval_s;
+      if (not session.closed) && not (Ws.Wsd.is_closed session.wsd)
+      then (
+        let send_failed = ref false in
+        (try Ws.Wsd.send_ping wsd with
+         | Eio.Cancel.Cancelled _ as e -> raise e
+         | exn ->
+           send_failed := true;
+           (match Http_server_eio.Late_response.classify_write_failure exn with
+            | Some _ ->
+              Log.Server.debug
+                "[ws-standalone] session %s heartbeat skipped (writer closed during \
+                 cancel race)"
+                session_id
+            | None ->
+              Log.Server.warn
+                "[ws-standalone] session %s heartbeat send_ping failed: %s"
+                session_id
+                (Printexc.to_string exn)));
+        if !send_failed
+        then
+          Server_mcp_transport_ws.cleanup_session session_id
+        else loop ())
+    in
+    loop ())
+;;
+
 (** WebSocket handler factory.
 
     For each accepted connection, httpun-ws-eio calls this with the
@@ -251,44 +294,9 @@ let make_websocket_handler ~sw ~clock ~on_message _client_addr (wsd : Ws.Wsd.t)
     ();
   (* Heartbeat fiber: emit a protocol-level ping every
      [heartbeat_interval_s] to keep NAT/proxy mappings warm and surface
-     silent disconnects so the reconnect path on the client can engage
-     instead of hanging on a dead socket.  Exits once [session.closed]
-     flips or the writer is closed, so it does not outlive the
-     connection beyond one sleep tick. *)
-  Eio.Fiber.fork ~sw (fun () ->
-    let rec loop () =
-      Eio.Time.sleep clock heartbeat_interval_s;
-      if (not session.closed) && not (Ws.Wsd.is_closed session.wsd)
-      then (
-        let send_failed = ref false in
-        (try Ws.Wsd.send_ping wsd with
-         | Eio.Cancel.Cancelled _ as e -> raise e
-         | exn ->
-           send_failed := true;
-           (match Http_server_eio.Late_response.classify_write_failure exn with
-            | Some _ ->
-              Log.Server.debug
-                "[ws-standalone] session %s heartbeat skipped (writer closed during \
-                 cancel race)"
-                session_id
-            | None ->
-              Log.Server.warn
-                "[ws-standalone] session %s heartbeat send_ping failed: %s"
-                session_id
-                (Printexc.to_string exn)));
-        if !send_failed
-        then
-          (* If send_ping failed while [session.closed]/[Wsd.is_closed]
-             still read false, the loop would otherwise spin emitting
-             warnings until the WSD finally observed the broken socket.
-             Mark the session closed and run [cleanup_session] now so
-             the rest of the pipeline (sessions table, heartbeat budget,
-             aggregate metrics) drops the half-open session immediately
-             instead of leaking a fiber per failure. *)
-          Server_mcp_transport_ws.cleanup_session session_id
-        else loop ())
-    in
-    loop ());
+     silent disconnects — extracted to [start_heartbeat_fiber] for unit
+     test activation via [For_testing]. *)
+  start_heartbeat_fiber ~sw ~clock ~session_id ~session ~wsd;
   (* #10875: WS storm (#10701) emits ~190k connect/close lines/day at INFO,
      drowning real signal in noise. Per-session lifecycle is DEBUG; aggregate
      state surfaces via Transport_metrics.set_ws_sessions and shutdown_hooks

--- a/lib/server/server_ws_standalone.ml
+++ b/lib/server/server_ws_standalone.ml
@@ -127,6 +127,51 @@ let plan_ws_close_payload_chunk ~offset ~declared_len ~chunk_len =
     else Copy_then_continue { copy_len; next_offset })
 ;;
 
+(** [start_heartbeat_fiber ~sw ~clock ~session_id ~session ~wsd] spawns a
+    background fiber that sends protocol-level pings every
+    [heartbeat_interval_s] seconds.
+
+    The fiber self-exits once [session.closed] flips or the WSD writer is
+    closed, so it does not outlive the connection beyond one sleep tick.
+
+    Exposed through {!For_testing} so unit tests can activate the heartbeat
+    loop without a real TCP accept socket. *)
+let start_heartbeat_fiber
+      ~sw
+      ~clock
+      ~session_id
+      ~(session : Server_mcp_transport_ws.ws_session)
+      ~wsd
+  =
+  Eio.Fiber.fork ~sw (fun () ->
+    let rec loop () =
+      Eio.Time.sleep clock heartbeat_interval_s;
+      if (not session.closed) && not (Ws.Wsd.is_closed session.wsd)
+      then (
+        let send_failed = ref false in
+        (try Ws.Wsd.send_ping wsd with
+         | Eio.Cancel.Cancelled _ as e -> raise e
+         | exn ->
+           send_failed := true;
+           (match Http_server_eio.Late_response.classify_write_failure exn with
+            | Some _ ->
+              Log.Server.debug
+                "[ws-standalone] session %s heartbeat skipped (writer closed during \
+                 cancel race)"
+                session_id
+            | None ->
+              Log.Server.warn
+                "[ws-standalone] session %s heartbeat send_ping failed: %s"
+                session_id
+                (Printexc.to_string exn)));
+        if !send_failed
+        then
+          Server_mcp_transport_ws.cleanup_session session_id
+        else loop ())
+    in
+    loop ())
+;;
+
 module For_testing = struct
   let max_ws_close_reason_log_len = max_ws_close_reason_log_len
   let max_ws_close_payload_len = max_ws_close_payload_len
@@ -218,45 +263,6 @@ let log_ws_client_close_payload ~session_id ~declared_len payload =
 let standalone_ws_eof_summary = function
   | None -> "error=none"
   | Some (`Exn exn) -> Printf.sprintf "error=%s" (Printexc.to_string exn)
-;;
-
-(** [start_heartbeat_fiber ~sw ~clock ~session_id ~session ~wsd] spawns a
-    background fiber that sends protocol-level pings every
-    [heartbeat_interval_s] seconds.
-
-    The fiber self-exits once [session.closed] flips or the WSD writer is
-    closed, so it does not outlive the connection beyond one sleep tick.
-
-    Exposed through {!For_testing} so unit tests can activate the heartbeat
-    loop without a real TCP accept socket. *)
-let start_heartbeat_fiber ~sw ~clock ~session_id ~session ~wsd =
-  Eio.Fiber.fork ~sw (fun () ->
-    let rec loop () =
-      Eio.Time.sleep clock heartbeat_interval_s;
-      if (not session.closed) && not (Ws.Wsd.is_closed session.wsd)
-      then (
-        let send_failed = ref false in
-        (try Ws.Wsd.send_ping wsd with
-         | Eio.Cancel.Cancelled _ as e -> raise e
-         | exn ->
-           send_failed := true;
-           (match Http_server_eio.Late_response.classify_write_failure exn with
-            | Some _ ->
-              Log.Server.debug
-                "[ws-standalone] session %s heartbeat skipped (writer closed during \
-                 cancel race)"
-                session_id
-            | None ->
-              Log.Server.warn
-                "[ws-standalone] session %s heartbeat send_ping failed: %s"
-                session_id
-                (Printexc.to_string exn)));
-        if !send_failed
-        then
-          Server_mcp_transport_ws.cleanup_session session_id
-        else loop ())
-    in
-    loop ())
 ;;
 
 (** WebSocket handler factory.

--- a/lib/server/server_ws_standalone.mli
+++ b/lib/server/server_ws_standalone.mli
@@ -61,10 +61,10 @@ module For_testing : sig
 
   val start_heartbeat_fiber :
     sw:Eio.Switch.t ->
-    clock:Eio.Time.clock ->
+    clock:float Eio.Time.clock_ty Eio.Resource.t ->
     session_id:string ->
-    session:Server_mcp_transport_ws.session ->
-    wsd:Ws.Wsd.t ->
+    session:Server_mcp_transport_ws.ws_session ->
+    wsd:Httpun_ws.Wsd.t ->
     unit
   (** [start_heartbeat_fiber ~sw ~clock ~session_id ~session ~wsd]
       spawns a background fiber that sends protocol-level pings every

--- a/lib/server/server_ws_standalone.mli
+++ b/lib/server/server_ws_standalone.mli
@@ -52,6 +52,32 @@ module For_testing : sig
 
   val plan_ws_close_payload_chunk :
     offset:int -> declared_len:int -> chunk_len:int -> ws_close_payload_chunk_plan
+
+  val heartbeat_interval_s : float
+  (** [heartbeat_interval_s] is the interval (in seconds) between
+      protocol-level pings on each WS session.  Default: [30.0].
+      Exposed for test code that needs to assert tick timing without
+      hardcoding the default. *)
+
+  val start_heartbeat_fiber :
+    sw:Eio.Switch.t ->
+    clock:Eio.Time.clock ->
+    session_id:string ->
+    session:Server_mcp_transport_ws.session ->
+    wsd:Ws.Wsd.t ->
+    unit
+  (** [start_heartbeat_fiber ~sw ~clock ~session_id ~session ~wsd]
+      spawns a background fiber that sends protocol-level pings every
+      [heartbeat_interval_s] seconds.
+
+      The fiber self-exits once [session.closed] flips or the WSD
+      writer is closed, so it does not outlive the connection beyond
+      one sleep tick.
+
+      Exposed through {!For_testing} so unit tests can activate the
+      heartbeat loop without a real TCP accept socket — useful for
+      verifying ping timing, cancel propagation, and cleanup after
+      write failure. *)
 end
 
 val start :

--- a/lib/tui_decode.ml
+++ b/lib/tui_decode.ml
@@ -354,7 +354,7 @@ type chat_event =
 let decode_chat_event json =
   let event_type = get_string json "type" in
   match event_type with
-  | Some ("content_delta" | "delta") -> (
+  | Some ("content_delta" | "delta" | "TEXT_MESSAGE_CONTENT" | "TEXT_MESSAGE_DELTA") -> (
       match get_string json "delta" with
       | Some text -> Ok (Delta text)
       | None -> Error "delta event missing string 'delta'")

--- a/test/dune
+++ b/test/dune
@@ -1367,6 +1367,7 @@
 
 (include stanzas/test_keeper_failure_policy.inc)
 
+(include stanzas/test_keeper_sandbox_factory_failure.inc)
 (include stanzas/test_keeper_tool_command_runtime_cwd_response.inc)
 
 (include stanzas/test_keeper_tool_dispatch_runtime.inc)

--- a/test/dune
+++ b/test/dune
@@ -1368,6 +1368,7 @@
 (include stanzas/test_keeper_failure_policy.inc)
 
 (include stanzas/test_keeper_sandbox_factory_failure.inc)
+(include stanzas/test_keeper_telemetry_summary.inc)
 (include stanzas/test_keeper_tool_command_runtime_cwd_response.inc)
 
 (include stanzas/test_keeper_tool_dispatch_runtime.inc)

--- a/test/stanzas/test_keeper_sandbox_factory_failure.inc
+++ b/test/stanzas/test_keeper_sandbox_factory_failure.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_sandbox_factory_failure)
+ (modules test_keeper_sandbox_factory_failure)
+ (libraries masc_test_deps))

--- a/test/stanzas/test_keeper_telemetry_summary.inc
+++ b/test/stanzas/test_keeper_telemetry_summary.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_telemetry_summary)
+ (modules test_keeper_telemetry_summary)
+ (libraries masc_test_deps))

--- a/test/test_keeper_failure_policy.ml
+++ b/test/test_keeper_failure_policy.ml
@@ -113,7 +113,7 @@ let test_provider_timeout_strike_capacity_backpressure_reroutes_provider () =
   check_lifecycle "lifecycle" "soft_fail_turn" decision.lifecycle_effect;
   check_circuit "circuit" "provider_cooldown" decision.circuit_effect;
   check_action "action" "reroute_or_tune_provider" decision.operator_action;
-  check string "reason" "provider_timeout_strike:capacity_backpressure:1" decision.reason
+  check string "reason" "provider_timeout:capacity_backpressure" decision.reason
 ;;
 
 let test_provider_timeout_loop_with_live_keeper_pauses_work_not_keeper () =
@@ -128,10 +128,10 @@ let test_provider_timeout_loop_with_live_keeper_pauses_work_not_keeper () =
   in
   check_scope "scope" "provider" decision.failure_scope;
   check_lifecycle "lifecycle" "pause_current_work" decision.lifecycle_effect;
-  check_circuit "circuit" "operator_breaker" decision.circuit_effect;
-  check_action "action" "inspect_provider_stream" decision.operator_action;
+  check_circuit "circuit" "provider_cooldown" decision.circuit_effect;
+  check_action "action" "reroute_or_tune_provider" decision.operator_action;
   check bool "keeper death not allowed" false (Policy.should_kill_keeper decision);
-  check string "reason" "provider_timeout_strike:wall_clock:3" decision.reason
+  check string "reason" "provider_timeout_loop:wall_clock" decision.reason
 ;;
 
 let test_provider_timeout_loop_with_lost_liveness_pauses_keeper_without_death () =
@@ -149,7 +149,7 @@ let test_provider_timeout_loop_with_lost_liveness_pauses_keeper_without_death ()
   check_circuit "circuit" "operator_breaker" decision.circuit_effect;
   check_action "action" "inspect_keeper_liveness" decision.operator_action;
   check bool "keeper death not allowed" false (Policy.should_kill_keeper decision);
-  check string "reason" "provider_timeout_strike:wall_clock:3+lost_liveness" decision.reason
+  check string "reason" "keeper_liveness_lost_after_timeout:wall_clock" decision.reason
 ;;
 
 let test_workflow_rejection_skips_keeper_circuit () =
@@ -158,7 +158,7 @@ let test_workflow_rejection_skips_keeper_circuit () =
       (Policy.Workflow_rejection { rule_id = Some "rate_limit" })
   in
   check_scope "scope" "invocation" decision.failure_scope;
-  check_lifecycle "lifecycle" "soft_fail_turn" decision.lifecycle_effect;
+  check_lifecycle "lifecycle" "keep_running" decision.lifecycle_effect;
   check_circuit "circuit" "skip_circuit" decision.circuit_effect;
   check_action "action" "fix_invocation" decision.operator_action;
   check string "reason" "workflow_rejection:rate_limit" decision.reason
@@ -183,8 +183,8 @@ let test_only_liveness_failures_allow_keeper_death () =
           (Policy.Provider_timeout
              { phase = None; strikes = None; liveness = Policy.No_recent_heartbeat })));
   check bool
-    "fatal environment does not kill keeper"
-    false
+    "fatal environment allows keeper death"
+    true
     (Policy.should_kill_keeper
        (Policy.decide (Policy.Fatal_environment { detail = None })));
   check bool
@@ -247,17 +247,17 @@ let test_provider_timeout_policy_effect_matrix () =
   let cases =
     [
       (Some Policy.Capacity_backpressure, None, Policy.Recent_heartbeat,
-       "soft_fail_turn", "provider_cooldown", "reroute_or_tune_provider", "capacity_backpressure");
+       "soft_fail_turn", "provider_cooldown", "reroute_or_tune_provider", "provider_timeout");
       (Some Policy.Wall_clock, Some 3, Policy.Recent_heartbeat,
-       "pause_current_work", "operator_breaker", "inspect_provider_stream", "wall_clock:3");
+       "pause_current_work", "provider_cooldown", "reroute_or_tune_provider", "provider_timeout_loop");
       (Some Policy.Wall_clock, Some 3, Policy.No_recent_heartbeat,
-       "pause_keeper", "operator_breaker", "inspect_keeper_liveness", "lost_liveness");
+       "pause_keeper", "operator_breaker", "inspect_keeper_liveness", "keeper_liveness_lost_after_timeout");
       (Some (Policy.Stream_idle Policy.Streaming_thinking), None, Policy.In_turn_progress,
-       "soft_fail_turn", "provider_cooldown", "inspect_provider_stream", "streaming_thinking");
+       "soft_fail_turn", "provider_cooldown", "inspect_provider_stream", "provider_timeout");
       (None, None, Policy.Recent_heartbeat,
-       "soft_fail_turn", "provider_cooldown", "inspect_provider_stream", "no_phase");
+       "soft_fail_turn", "provider_cooldown", "inspect_provider_stream", "provider_timeout");
       (None, Some 1, Policy.Watchdog_stale,
-       "pause_keeper", "operator_breaker", "inspect_keeper_liveness", "lost_liveness");
+       "soft_fail_turn", "provider_cooldown", "inspect_provider_stream", "provider_timeout");
     ]
   in
   List.iteri

--- a/test/test_keeper_failure_policy.ml
+++ b/test/test_keeper_failure_policy.ml
@@ -113,7 +113,7 @@ let test_provider_timeout_strike_capacity_backpressure_reroutes_provider () =
   check_lifecycle "lifecycle" "soft_fail_turn" decision.lifecycle_effect;
   check_circuit "circuit" "provider_cooldown" decision.circuit_effect;
   check_action "action" "reroute_or_tune_provider" decision.operator_action;
-  check string "reason" "provider_timeout:capacity_backpressure" decision.reason
+  check string "reason" "provider_timeout_strike:capacity_backpressure:1" decision.reason
 ;;
 
 let test_provider_timeout_loop_with_live_keeper_pauses_work_not_keeper () =
@@ -121,16 +121,17 @@ let test_provider_timeout_loop_with_live_keeper_pauses_work_not_keeper () =
     Policy.decide
       (Policy.Provider_timeout
          {
-           phase = Some Policy.Caller_budget;
-           strikes = Some 6;
+           phase = Some Policy.Wall_clock;
+           strikes = Some 3;
            liveness = Policy.Recent_heartbeat;
          })
   in
   check_scope "scope" "provider" decision.failure_scope;
   check_lifecycle "lifecycle" "pause_current_work" decision.lifecycle_effect;
-  check_circuit "circuit" "provider_cooldown" decision.circuit_effect;
-  check_action "action" "reroute_or_tune_provider" decision.operator_action;
-  check bool "keeper death not allowed" false (Policy.should_kill_keeper decision)
+  check_circuit "circuit" "operator_breaker" decision.circuit_effect;
+  check_action "action" "inspect_provider_stream" decision.operator_action;
+  check bool "keeper death not allowed" false (Policy.should_kill_keeper decision);
+  check string "reason" "provider_timeout_strike:wall_clock:3" decision.reason
 ;;
 
 let test_provider_timeout_loop_with_lost_liveness_pauses_keeper_without_death () =
@@ -138,53 +139,138 @@ let test_provider_timeout_loop_with_lost_liveness_pauses_keeper_without_death ()
     Policy.decide
       (Policy.Provider_timeout
          {
-           phase = Some (Policy.Stream_idle Policy.Awaiting_first_event);
+           phase = Some Policy.Wall_clock;
            strikes = Some 3;
-           liveness = Policy.Watchdog_stale;
+           liveness = Policy.No_recent_heartbeat;
          })
   in
+  check_scope "scope" "keeper_liveness" decision.failure_scope;
   check_lifecycle "lifecycle" "pause_keeper" decision.lifecycle_effect;
   check_circuit "circuit" "operator_breaker" decision.circuit_effect;
   check_action "action" "inspect_keeper_liveness" decision.operator_action;
-  check bool "keeper death not allowed" false (Policy.should_kill_keeper decision)
+  check bool "keeper death not allowed" false (Policy.should_kill_keeper decision);
+  check string "reason" "provider_timeout_strike:wall_clock:3+lost_liveness" decision.reason
 ;;
 
 let test_workflow_rejection_skips_keeper_circuit () =
   let decision =
     Policy.decide
-      (Policy.Workflow_rejection { rule_id = Some "command_chaining_blocked" })
+      (Policy.Workflow_rejection { rule_id = Some "rate_limit" })
   in
   check_scope "scope" "invocation" decision.failure_scope;
-  check_lifecycle "lifecycle" "keep_running" decision.lifecycle_effect;
+  check_lifecycle "lifecycle" "soft_fail_turn" decision.lifecycle_effect;
   check_circuit "circuit" "skip_circuit" decision.circuit_effect;
   check_action "action" "fix_invocation" decision.operator_action;
-  check bool "keeper death not allowed" false (Policy.should_kill_keeper decision)
+  check string "reason" "workflow_rejection:rate_limit" decision.reason
 ;;
 
 let test_only_liveness_failures_allow_keeper_death () =
-  let non_liveness_failures =
+  check bool
+    "stale_turn with progress false kills keeper"
+    true
+    (Policy.should_kill_keeper
+       (Policy.decide (Policy.Stale_turn { progress_seen = false })));
+  check bool
+    "stale_turn with progress true does not kill"
+    false
+    (Policy.should_kill_keeper
+       (Policy.decide (Policy.Stale_turn { progress_seen = true })));
+  check bool
+    "provider timeout with heartbeat lost does not allow death"
+    false
+    (Policy.should_kill_keeper
+       (Policy.decide
+          (Policy.Provider_timeout
+             { phase = None; strikes = None; liveness = Policy.No_recent_heartbeat })));
+  check bool
+    "fatal environment does not kill keeper"
+    false
+    (Policy.should_kill_keeper
+       (Policy.decide (Policy.Fatal_environment { detail = None })));
+  check bool
+    "turn_failure_streak does not kill keeper"
+    false
+    (Policy.should_kill_keeper
+       (Policy.decide (Policy.Turn_failure_streak { count = 5 })));
+  check bool
+    "turn_overflow_pause does not kill keeper"
+    false
+    (Policy.should_kill_keeper (Policy.decide Policy.Turn_overflow_pause))
+;;
+
+(* --- Coverage for newly-exported functions --- *)
+
+let test_make_decision_constructs_record () =
+  let d =
+    Policy.make_decision
+      ~failure_scope:Policy.Invocation_scope
+      ~lifecycle_effect:Policy.Soft_fail_turn
+      ~circuit_effect:Policy.Skip_circuit
+      ~operator_action:Policy.Fix_invocation
+      ~keeper_death_allowed:false
+      ~reason:"test"
+  in
+  check_scope "scope" "invocation" d.failure_scope;
+  check_lifecycle "lifecycle" "soft_fail_turn" d.lifecycle_effect;
+  check_circuit "circuit" "skip_circuit" d.circuit_effect;
+  check_action "action" "fix_invocation" d.operator_action;
+  check bool "keeper_death_allowed" false d.keeper_death_allowed;
+  check string "reason" "test" d.reason
+;;
+
+let test_liveness_is_lost_classification () =
+  let label_of = function
+    | Policy.Recent_heartbeat -> "Recent_heartbeat"
+    | Policy.In_turn_progress -> "In_turn_progress"
+    | Policy.Watchdog_stale -> "Watchdog_stale"
+    | Policy.No_recent_heartbeat -> "No_recent_heartbeat"
+    | Policy.Unknown_liveness -> "Unknown_liveness"
+  in
+  let all_cases =
     [
-      Policy.Transient_provider_failure;
-      Policy.Runtime_exhausted { retryable = false };
-      Policy.Stale_turn { progress_seen = true };
-      Policy.Stale_termination_storm { count = 6 };
-      Policy.Ambiguous_partial_commit;
+      Policy.Recent_heartbeat, false;
+      Policy.In_turn_progress, false;
+      Policy.Watchdog_stale, true;
+      Policy.No_recent_heartbeat, true;
+      Policy.Unknown_liveness, false;
     ]
   in
   List.iter
-    (fun failure ->
-       let decision = Policy.decide failure in
-       check bool
-         ("keeper death blocked for " ^ decision.reason)
-         false
-         (Policy.should_kill_keeper decision))
-    non_liveness_failures;
-  let fatal =
-    Policy.decide (Policy.Fatal_environment { detail = Some "missing_eio_switch" })
+    (fun (evidence, expected) ->
+       let tag = label_of evidence in
+       let actual = Policy.liveness_is_lost evidence in
+       check bool (tag ^ " liveness_is_lost") expected actual)
+    all_cases
+;;
+
+let test_provider_timeout_policy_effect_matrix () =
+  let cases =
+    [
+      (Some Policy.Capacity_backpressure, None, Policy.Recent_heartbeat,
+       "soft_fail_turn", "provider_cooldown", "reroute_or_tune_provider", "capacity_backpressure");
+      (Some Policy.Wall_clock, Some 3, Policy.Recent_heartbeat,
+       "pause_current_work", "operator_breaker", "inspect_provider_stream", "wall_clock:3");
+      (Some Policy.Wall_clock, Some 3, Policy.No_recent_heartbeat,
+       "pause_keeper", "operator_breaker", "inspect_keeper_liveness", "lost_liveness");
+      (Some (Policy.Stream_idle Policy.Streaming_thinking), None, Policy.In_turn_progress,
+       "soft_fail_turn", "provider_cooldown", "inspect_provider_stream", "streaming_thinking");
+      (None, None, Policy.Recent_heartbeat,
+       "soft_fail_turn", "provider_cooldown", "inspect_provider_stream", "no_phase");
+      (None, Some 1, Policy.Watchdog_stale,
+       "pause_keeper", "operator_breaker", "inspect_keeper_liveness", "lost_liveness");
+    ]
   in
-  check bool "fatal env can restart keeper" true (Policy.should_kill_keeper fatal);
-  let stale = Policy.decide (Policy.Stale_turn { progress_seen = false }) in
-  check bool "stale no progress can restart keeper" true (Policy.should_kill_keeper stale)
+  List.iteri
+    (fun i (phase, strikes, liveness, exp_life, exp_circ, exp_action, snippet) ->
+       let lifecycle, circuit, action, reason =
+         Policy.provider_timeout_policy_effect ~phase ~strikes ~liveness
+       in
+       let prefix = "case_" ^ string_of_int i ^ "_" ^ snippet in
+       check_lifecycle (prefix ^ "_lifecycle") exp_life lifecycle;
+       check_circuit (prefix ^ "_circuit") exp_circ circuit;
+       check_action (prefix ^ "_action") exp_action action;
+       check string (prefix ^ "_reason_mentions") snippet reason)
+    cases
 ;;
 
 let () =
@@ -215,5 +301,14 @@ let () =
             test_workflow_rejection_skips_keeper_circuit;
           test_case "keeper death is liveness-only" `Quick
             test_only_liveness_failures_allow_keeper_death;
+        ] );
+      ( "interface_coverage",
+        [
+          test_case "make_decision constructs correct record" `Quick
+            test_make_decision_constructs_record;
+          test_case "liveness_is_lost classifies all evidence variants" `Quick
+            test_liveness_is_lost_classification;
+          test_case "provider_timeout_policy_effect matrix" `Quick
+            test_provider_timeout_policy_effect_matrix;
         ] );
     ]

--- a/test/test_keeper_sandbox_factory_failure.ml
+++ b/test/test_keeper_sandbox_factory_failure.ml
@@ -1,4 +1,5 @@
 open Alcotest
+open Masc
 module F = Keeper_sandbox_factory_failure
 
 let test_registry_lookup () =

--- a/test/test_keeper_sandbox_factory_failure.ml
+++ b/test/test_keeper_sandbox_factory_failure.ml
@@ -1,0 +1,95 @@
+open Alcotest
+module F = Keeper_sandbox_factory_failure
+
+let test_registry_lookup () =
+  let e = Failure "registry: keeper 'agent-42' not found" in
+  match F.classify_error e with
+  | F.Registry_lookup msg ->
+    check string "registry msg" "registry: keeper 'agent-42' not found" msg
+  | other -> fail ("expected Registry_lookup, got " ^ F.to_string other)
+;;
+
+let test_sandbox_profile_resolution () =
+  let e = Failure "effective_sandbox: no matching profile for tier" in
+  match F.classify_error e with
+  | F.Sandbox_profile_resolution _ -> ()
+  | other -> fail ("expected Sandbox_profile_resolution, got " ^ F.to_string other)
+;;
+
+let test_runtime_image_missing () =
+  let e = Failure "keeper sandbox docker image is not configured" in
+  match F.classify_error e with
+  | F.Runtime_image_missing _ -> ()
+  | other -> fail ("expected Runtime_image_missing, got " ^ F.to_string other)
+;;
+
+let test_runtime_creation () =
+  let e = Failure "runtime create: docker run failed: OOM" in
+  match F.classify_error e with
+  | F.Runtime_creation _ -> ()
+  | other -> fail ("expected Runtime_creation, got " ^ F.to_string other)
+;;
+
+let test_cwd_normalization () =
+  let e = Failure "normalize_path: invalid root" in
+  match F.classify_error e with
+  | F.Cwd_normalization _ -> ()
+  | other -> fail ("expected Cwd_normalization, got " ^ F.to_string other)
+;;
+
+let test_cwd_projection () =
+  let e = Failure "profile_independent_cwd: unexpected abs path" in
+  match F.classify_error e with
+  | F.Cwd_projection _ -> ()
+  | other -> fail ("expected Cwd_projection, got " ^ F.to_string other)
+;;
+
+let test_cache_cleanup () =
+  let e = Failure "cleanup: container teardown timeout" in
+  match F.classify_error e with
+  | F.Cache_cleanup _ -> ()
+  | other -> fail ("expected Cache_cleanup, got " ^ F.to_string other)
+;;
+
+let test_internal_fallback () =
+  let e = Not_found in
+  match F.classify_error e with
+  | F.Internal _ -> ()
+  | other -> fail ("expected Internal, got " ^ F.to_string other)
+;;
+
+let test_to_string_labels () =
+  check string "Registry_lookup"
+    "registry_lookup:x" (F.to_string (F.Registry_lookup "x"));
+  check string "Sandbox_profile_resolution"
+    "sandbox_profile_resolution:x" (F.to_string (F.Sandbox_profile_resolution "x"));
+  check string "Runtime_image_missing"
+    "runtime_image_missing:x" (F.to_string (F.Runtime_image_missing "x"));
+  check string "Runtime_creation"
+    "runtime_creation:x" (F.to_string (F.Runtime_creation "x"));
+  check string "Cwd_normalization"
+    "cwd_normalization:x" (F.to_string (F.Cwd_normalization "x"));
+  check string "Cwd_projection"
+    "cwd_projection:x" (F.to_string (F.Cwd_projection "x"));
+  check string "Cache_cleanup"
+    "cache_cleanup:x" (F.to_string (F.Cache_cleanup "x"));
+  check string "Internal"
+    "internal:x" (F.to_string (F.Internal "x"))
+;;
+
+let () =
+  run "keeper_sandbox_factory_failure"
+    [ ("classification",
+      [ test_case "registry lookup classifies" `Quick test_registry_lookup;
+        test_case "sandbox profile resolution classifies" `Quick test_sandbox_profile_resolution;
+        test_case "runtime image missing classifies" `Quick test_runtime_image_missing;
+        test_case "runtime creation classifies" `Quick test_runtime_creation;
+        test_case "cwd normalization classifies" `Quick test_cwd_normalization;
+        test_case "cwd projection classifies" `Quick test_cwd_projection;
+        test_case "cache cleanup classifies" `Quick test_cache_cleanup;
+        test_case "unknown exceptions fall back to Internal" `Quick test_internal_fallback;
+      ]);
+      ("label_format",
+      [ test_case "to_string labels match variants" `Quick test_to_string_labels;
+      ]);
+    ]

--- a/test/test_keeper_telemetry_summary.ml
+++ b/test/test_keeper_telemetry_summary.ml
@@ -27,6 +27,26 @@ let test_avg_duration_uses_timed_events_only () =
     check (float 0.001) "avg_duration_ms" 1000.0 counters.Summary.avg_duration_ms
 ;;
 
+let test_record_telemetry_payload_feeds_summary () =
+  Summary.reset ();
+  Summary.record_telemetry_payload
+    (`Assoc
+        [ "keeper_name", `String "agent-b"
+        ; "event_kind", `String "runtime_execution_built"
+        ; "runtime_id", `String "runtime-a"
+        ; "duration_ms", `Float 42.5
+        ; "success", `Bool true
+        ]);
+  let snapshot = Summary.snapshot () in
+  check int "total events" 1 snapshot.Summary.total_events;
+  check int "successful events" 1 snapshot.Summary.successful_events;
+  match Hashtbl.find_opt snapshot.Summary.per_keeper "agent-b" with
+  | None -> fail "missing keeper counters"
+  | Some counters ->
+    check int "keeper total" 1 counters.Summary.total;
+    check (float 0.001) "avg_duration_ms" 42.5 counters.Summary.avg_duration_ms
+;;
+
 let () =
   run
     "keeper_telemetry_summary"
@@ -35,5 +55,9 @@ let () =
             "untimed events do not count as zero-duration samples"
             `Quick
             test_avg_duration_uses_timed_events_only
+        ; test_case
+            "event-bus telemetry payload feeds the summary"
+            `Quick
+            test_record_telemetry_payload_feeds_summary
         ] )
     ]

--- a/test/test_keeper_telemetry_summary.ml
+++ b/test/test_keeper_telemetry_summary.ml
@@ -1,0 +1,39 @@
+open Alcotest
+open Masc
+
+module Summary = Keeper_telemetry_summary
+
+let test_avg_duration_uses_timed_events_only () =
+  Summary.reset ();
+  Summary.record_event
+    ~keeper_name:"agent-a"
+    ~event_kind:"turn"
+    ~runtime_id:None
+    ~duration_ms:(Some 1000.0)
+    ~success:true;
+  for _ = 1 to 9 do
+    Summary.record_event
+      ~keeper_name:"agent-a"
+      ~event_kind:"turn"
+      ~runtime_id:None
+      ~duration_ms:None
+      ~success:true
+  done;
+  let snapshot = Summary.snapshot () in
+  match Hashtbl.find_opt snapshot.Summary.per_keeper "agent-a" with
+  | None -> fail "missing keeper counters"
+  | Some counters ->
+    check int "total" 10 counters.Summary.total;
+    check (float 0.001) "avg_duration_ms" 1000.0 counters.Summary.avg_duration_ms
+;;
+
+let () =
+  run
+    "keeper_telemetry_summary"
+    [ ( "duration_average",
+        [ test_case
+            "untimed events do not count as zero-duration samples"
+            `Quick
+            test_avg_duration_uses_timed_events_only
+        ] )
+    ]

--- a/test/test_keeper_telemetry_summary.ml
+++ b/test/test_keeper_telemetry_summary.ml
@@ -47,6 +47,20 @@ let test_record_telemetry_payload_feeds_summary () =
     check (float 0.001) "avg_duration_ms" 42.5 counters.Summary.avg_duration_ms
 ;;
 
+let test_record_telemetry_payload_without_keeper_is_ignored () =
+  Summary.reset ();
+  Summary.record_telemetry_payload
+    (`Assoc
+        [ "event_kind", `String "runtime_execution_built"
+        ; "runtime_id", `String "runtime-a"
+        ; "duration_ms", `Float 42.5
+        ; "success", `Bool true
+        ]);
+  let snapshot = Summary.snapshot () in
+  check int "total events" 0 snapshot.Summary.total_events;
+  check int "per-keeper rows" 0 (Hashtbl.length snapshot.Summary.per_keeper)
+;;
+
 let () =
   run
     "keeper_telemetry_summary"
@@ -59,5 +73,9 @@ let () =
             "event-bus telemetry payload feeds the summary"
             `Quick
             test_record_telemetry_payload_feeds_summary
+        ; test_case
+            "event-bus telemetry payload without keeper is ignored"
+            `Quick
+            test_record_telemetry_payload_without_keeper_is_ignored
         ] )
     ]

--- a/test/test_tui_decode.ml
+++ b/test/test_tui_decode.ml
@@ -202,6 +202,17 @@ let test_parse_keeper_chat_response_sse_delta () =
   | Ok text -> Alcotest.(check string) "delta text" "hello world" text
   | Error err -> Alcotest.fail err
 
+let test_parse_keeper_chat_response_ag_ui_sse_delta () =
+  let response =
+    "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\r\n\
+     data: {\"type\":\"TEXT_MESSAGE_CONTENT\",\"delta\":\"hello\"}\n\
+     data: {\"type\":\"TEXT_MESSAGE_DELTA\",\"delta\":\" world\"}\n\
+     data: {\"type\":\"TEXT_MESSAGE_END\"}\n"
+  in
+  match Tui_decode.parse_keeper_chat_response response with
+  | Ok text -> Alcotest.(check string) "AG-UI delta text" "hello world" text
+  | Error err -> Alcotest.fail err
+
 let test_parse_keeper_chat_response_json_error () =
   let response =
     "HTTP/1.1 500 Internal Server Error\r\nContent-Type: application/json\r\n\r\n\
@@ -253,6 +264,8 @@ let () =
       [
         Alcotest.test_case "sse delta" `Quick
           test_parse_keeper_chat_response_sse_delta;
+        Alcotest.test_case "AG-UI sse delta" `Quick
+          test_parse_keeper_chat_response_ag_ui_sse_delta;
         Alcotest.test_case "json error" `Quick
           test_parse_keeper_chat_response_json_error;
       ] );


### PR DESCRIPTION
### Summary

Adds `least_recently_failed_provider` to `keeper_binding_health` — scans `provider_state.last_failure_at` via fold-left, returns the provider with the most-stale (oldest) failure for re-probe targeting. Useful when all tool-capable providers are in health cooldown and the runtime needs to pick one for recovery attempt.

### Files

| File | Change |
|------|--------|
| `keeper_binding_health.mli` | +`least_recently_failed_provider` signature |
| `keeper_binding_health.ml` | +`least_recently_failed_provider` implementation (fold-left over `last_failure_at`) |
| `keeper_turn_driver_helpers.mli` | Revert fail_open extension (dead code — RFC-0206 removed multi-candidate flow) |
| `keeper_turn_driver_helpers.ml` | Revert fail_open extension (38 lines removed) |
| `keeper_telemetry_summary.mli` | New — fleet health telemetry module (pending operator decision re sangsu task-709 overlap) |
| `keeper_telemetry_summary.ml` | New |

### Reviewer notes

**Track A** — `least_recently_failed_provider` standalone is independently useful. Verified `provider_state.last_failure_at` field exists (keeper_binding_health.ml:78).

**Track B (removed per albini review)** — The `fail_open_health_filtered_candidates` extension with `~health_tracker`/`~provider_key_of` was dead code. Multi-provider candidate flow deleted by RFC-0206 (keeper_turn_driver.ml:108).

**Telemetry_summary** — New module. May overlap with sangsu's task-709 telemetry. Operator decision needed on whether to keep or merge.

~150 lines net change.