### PR TITLE
feat(keeper-chat): persist tool calls and connector source per turn

### DIFF
--- a/dashboard/src/api/schemas/keeper-chat-history.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.ts
@@ -19,6 +19,7 @@
 import {
   number,
   object,
+  optional,
   safeParse,
   string,
   type InferOutput,
@@ -28,6 +29,14 @@ export const KeeperChatHistoryMessageSchema = object({
   role: string(),
   content: string(),
   ts: number(),
+  // Tool-call rows (role === 'tool') persisted by keeper_chat_store.ml
+  // carry the executed tool's id/name; `content` holds the accumulated
+  // argument JSON. `source` names the originating connector
+  // ('dashboard' | 'discord' | 'slack' | 'agent') on every row of a
+  // turn. All three are absent on legacy rows.
+  tool_call_id: optional(string()),
+  tool_call_name: optional(string()),
+  source: optional(string()),
 })
 
 export type KeeperChatHistoryMessage = InferOutput<typeof KeeperChatHistoryMessageSchema>

--- a/dashboard/src/keeper-state.test.ts
+++ b/dashboard/src/keeper-state.test.ts
@@ -152,6 +152,68 @@ describe('thread history merge & persistence', () => {
     expect(entries[1]?.timestamp).toBeTruthy()
   })
 
+  it('maps persisted tool rows to the live tool-entry convention', () => {
+    const entries = chatHistoryEntriesFromRest('echo', [
+      { role: 'user', content: 'run checks', ts: 1_780_000_000 },
+      {
+        role: 'tool',
+        content: '{"path":"x"}',
+        ts: 1_780_000_000,
+        tool_call_id: 'toolu_1',
+        tool_call_name: 'Read',
+        source: 'dashboard',
+      },
+      { role: 'assistant', content: 'all green', ts: 1_780_000_000 },
+    ])
+    expect(entries.map(e => e.role)).toEqual(['user', 'tool', 'assistant'])
+    const tool = entries[1]
+    // Same id/shape as the live TOOL_CALL_* path so replaceThread dedups
+    // a rehydrated row against a still-mounted live entry.
+    expect(tool?.id).toBe('tool-toolu_1')
+    expect(tool?.source).toBe('tool_result')
+    expect(tool?.label).toBe('Read')
+    // Argument JSON must come through verbatim, not reply-formatted.
+    expect(tool?.text).toBe('{"path":"x"}')
+    expect(tool?.delivery).toBe('history')
+  })
+
+  it('drops tool rows that lack id or name and keeps the rest of the turn', () => {
+    const entries = chatHistoryEntriesFromRest('echo', [
+      { role: 'user', content: 'hi', ts: 1_780_000_000 },
+      { role: 'tool', content: '{}', ts: 1_780_000_000, tool_call_id: 'toolu_2' },
+      { role: 'assistant', content: 'done', ts: 1_780_000_000 },
+    ])
+    expect(entries.map(e => e.role)).toEqual(['user', 'assistant'])
+    expect(entries[1]?.label).toBe('echo')
+  })
+
+  it('dedups a rehydrated tool row against the live tool entry', () => {
+    appendThreadEntry('echo', entry({
+      id: 'tool-toolu_3',
+      role: 'tool',
+      source: 'tool_result',
+      text: '{"q":1}',
+      rawText: '{"q":1}',
+      delivery: 'delivered',
+    }))
+
+    mergeServerHistoryEntries('echo', chatHistoryEntriesFromRest('echo', [
+      { role: 'user', content: 'query', ts: 1_780_000_000 },
+      {
+        role: 'tool',
+        content: '{"q":1}',
+        ts: 1_780_000_000,
+        tool_call_id: 'toolu_3',
+        tool_call_name: 'masc_status',
+      },
+      { role: 'assistant', content: 'answer', ts: 1_780_000_000 },
+    ]))
+
+    const thread = keeperThreads.value.echo ?? []
+    expect(thread.filter(e => e.role === 'tool')).toHaveLength(1)
+    expect(thread.map(e => e.role)).toEqual(['user', 'tool', 'assistant'])
+  })
+
   it('inserts before the target entry and appends when the target is missing', () => {
     appendThreadEntry('echo', entry({ id: 'reply-1', role: 'assistant', source: 'direct_assistant' }))
     insertThreadEntryBefore('echo', 'reply-1', entry({ id: 'tool-1', role: 'tool', source: 'tool_result' }))

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -387,16 +387,54 @@ export function mergeServerHistoryEntries(
   replaceThread(name, entries)
 }
 
+interface RestChatHistoryMessage {
+  role: string
+  content: string
+  ts: number
+  tool_call_id?: string
+  tool_call_name?: string
+  source?: string
+}
+
+/** Convert a persisted tool-call row into the same entry shape the live
+ *  TOOL_CALL_* stream path produces (keeper-stream.ts): id `tool-<id>`,
+ *  role 'tool', label = tool name, text = accumulated argument JSON.
+ *  Matching the live convention means a reload re-renders the tool card
+ *  and replaceThread dedups it against a still-mounted live entry. The
+ *  raw content is used as-is — formatKeeperVisibleReply is for keeper
+ *  reply text and would mangle argument JSON. */
+function toolHistoryEntry(message: RestChatHistoryMessage): KeeperConversationEntry | null {
+  if (!message.tool_call_id || !message.tool_call_name) return null
+  return {
+    id: `tool-${message.tool_call_id}`,
+    role: 'tool',
+    source: 'tool_result',
+    label: message.tool_call_name,
+    text: message.content,
+    rawText: message.content,
+    timestamp: toIsoTimestamp(message.ts),
+    delivery: 'history',
+    streamState: null,
+    details: null,
+  }
+}
+
 /** Convert REST chat-history messages ({role, content, ts-seconds}) into
  *  conversation entries, chaining source inference the same way
  *  status-detail history does. */
 export function chatHistoryEntriesFromRest(
   keeperName: string,
-  messages: Array<{ role: string; content: string; ts: number }>,
+  messages: RestChatHistoryMessage[],
 ): KeeperConversationEntry[] {
   let previousSource: KeeperConversationSource | null = null
   const entries: KeeperConversationEntry[] = []
   messages.forEach((message, index) => {
+    if (message.role === 'tool') {
+      // Tool rows do not participate in user/assistant source chaining.
+      const toolEntry = toolHistoryEntry(message)
+      if (toolEntry) entries.push(toolEntry)
+      return
+    }
     const normalized = normalizeHistoryEntry(
       { role: message.role, content: message.content, ts_unix: message.ts },
       index,

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -6,6 +6,11 @@
     Line format:
     {v {"role":"user","content":"hello","ts":1774000000.0} v}
 
+    Tool-call lines (persisted between the user and assistant lines of a
+    turn) carry the executed tool name and accumulated arguments:
+    {v {"role":"tool","content":"{\"path\":\"x\"}","ts":...,
+        "tool_call_id":"toolu_1","tool_call_name":"Read","source":"dashboard"} v}
+
     @since 2.145.0 *)
 
 let sanitize_name name =
@@ -45,22 +50,36 @@ type attachment = {
   data : string;
 }
 
+type tool_call = {
+  call_id : string;
+  call_name : string;
+  args : string;
+}
+
 type chat_message = {
   role : string;
   content : string;
   ts : float option;
   attachments : attachment list option;
+  tool_call_id : string option;
+  tool_call_name : string option;
+  source : string option;
 }
 
-let encode_line ~role ~content ~ts ?attachments () : string =
+let opt_string_field key = function
+  | None -> []
+  | Some value -> [ (key, `String value) ]
+
+let encode_line ~role ~content ~ts ?attachments ?tool_call_id ?tool_call_name
+    ?source () : string =
   let base_fields = [
     ("role", `String role);
     ("content", `String content);
     ("ts", `Float ts);
   ] in
-  let all_fields =
+  let attachment_fields =
     match attachments with
-    | None | Some [] -> base_fields
+    | None | Some [] -> []
     | Some atts ->
         let att_json = List.map (fun att ->
           `Assoc [
@@ -72,19 +91,55 @@ let encode_line ~role ~content ~ts ?attachments () : string =
             ("data", `String att.data);
           ]
         ) atts in
-        ("attachments", `List att_json) :: base_fields
+        [("attachments", `List att_json)]
+  in
+  let all_fields =
+    base_fields
+    @ attachment_fields
+    @ opt_string_field "tool_call_id" tool_call_id
+    @ opt_string_field "tool_call_name" tool_call_name
+    @ opt_string_field "source" source
   in
   Yojson.Safe.to_string (`Assoc all_fields)
 
-let append_pair ~base_dir ~keeper_name
-    ~(user_content : string) ~(assistant_content : string) ~(user_attachments : attachment list) =
+(* Tool calls with empty accumulated arguments are normalised to "{}" so
+   every persisted line keeps a non-empty [content] (the read-side
+   validity check and the dashboard history mapping both require it). *)
+let normalize_tool_args args =
+  if String.trim args = "" then "{}" else args
+
+let normalize_tool_call_id ~position call_id =
+  if String.trim call_id = "" then Printf.sprintf "tc-%d" position else call_id
+
+let append_turn ~base_dir ~keeper_name ~(user_content : string)
+    ~(user_attachments : attachment list) ?(tool_calls = []) ?source
+    ~(assistant_content : string) () =
   try
     ensure_dir_once ~base_dir;
     let path = chat_path ~base_dir ~keeper_name in
     let ts = Time_compat.now () in
-    let user_line = encode_line ~role:"user" ~content:user_content ~ts ~attachments:user_attachments () in
-    let asst_line = encode_line ~role:"assistant" ~content:assistant_content ~ts () in
-    Fs_compat.append_file path (user_line ^ "\n" ^ asst_line ^ "\n")
+    let user_line =
+      encode_line ~role:"user" ~content:user_content ~ts
+        ~attachments:user_attachments ?source ()
+    in
+    let tool_lines =
+      List.mapi
+        (fun position tc ->
+          encode_line ~role:"tool"
+            ~content:(normalize_tool_args tc.args)
+            ~ts
+            ~tool_call_id:(normalize_tool_call_id ~position tc.call_id)
+            ~tool_call_name:tc.call_name
+            ?source ())
+        tool_calls
+    in
+    let asst_line =
+      encode_line ~role:"assistant" ~content:assistant_content ~ts ?source ()
+    in
+    let payload =
+      String.concat "\n" ((user_line :: tool_lines) @ [ asst_line ]) ^ "\n"
+    in
+    Fs_compat.append_file path payload
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
@@ -103,6 +158,14 @@ let parse_line ~file_path (line : string) : chat_message option =
     let ts =
       (try Some ((match Json_util.assoc_member_opt "ts" json with Some (`Float f) -> f | _ -> 0.0))
        with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None) in
+    let opt_string key =
+      match Json_util.assoc_member_opt key json with
+      | Some (`String value) when String.trim value <> "" -> Some value
+      | _ -> None
+    in
+    let tool_call_id = opt_string "tool_call_id" in
+    let tool_call_name = opt_string "tool_call_name" in
+    let source = opt_string "source" in
     let attachments =
       match Json_util.assoc_member_opt "attachments" json with
       | Some (`List att_list) ->
@@ -131,7 +194,13 @@ let parse_line ~file_path (line : string) : chat_message option =
         ~path:file_path
         ~detail:"chat row missing non-empty role/content";
       None)
-    else Some { role; content; ts; attachments }
+    else if role = "tool" && tool_call_name = None then (
+      report_persistence_read_drop
+        ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
+        ~path:file_path
+        ~detail:"tool chat row missing non-empty tool_call_name";
+      None)
+    else Some { role; content; ts; attachments; tool_call_id; tool_call_name; source }
   with Yojson.Json_error detail ->
     report_persistence_read_drop
       ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
@@ -139,7 +208,21 @@ let parse_line ~file_path (line : string) : chat_message option =
       ~detail;
     None
 
+(* Window bounds for [load]. [max_history] counts user/assistant
+   messages only, so tool lines never shrink the visible conversation
+   depth. [max_total_lines] is the absolute guard (tool lines included)
+   against a pathological tool-spam turn blowing up the payload. *)
 let max_history = 100
+let max_total_lines = 400
+
+let is_tool_message (msg : chat_message) = String.equal msg.role "tool"
+
+(* A turn is persisted as user, tool*, assistant. Evicting the front of
+   the window can leave tool lines whose owning user line is gone;
+   render-wise they are orphans, so trim them. *)
+let rec drop_leading_tool_messages = function
+  | msg :: rest when is_tool_message msg -> drop_leading_tool_messages rest
+  | messages -> messages
 
 let load ~base_dir ~keeper_name : chat_message list =
   let path = chat_path ~base_dir ~keeper_name in
@@ -148,8 +231,14 @@ let load ~base_dir ~keeper_name : chat_message list =
   try
     let content = Fs_compat.load_file path in
     let lines = String.split_on_char '\n' content in
-    (* Single pass: keep a running window of last max_history entries *)
+    (* Single pass: keep a running window of the last [max_history]
+       user/assistant messages plus their tool lines. *)
     let q = Queue.create () in
+    let primary_count = ref 0 in
+    let pop_front () =
+      let popped = Queue.pop q in
+      if not (is_tool_message popped) then decr primary_count
+    in
     List.iter
       (fun line ->
         let trimmed = String.trim line in
@@ -157,10 +246,18 @@ let load ~base_dir ~keeper_name : chat_message list =
           match parse_line ~file_path:path trimmed with
           | Some msg ->
               Queue.push msg q;
-              if Queue.length q > max_history then ignore (Queue.pop q)
+              if not (is_tool_message msg) then incr primary_count;
+              while
+                !primary_count > max_history
+                || Queue.length q > max_total_lines
+              do
+                pop_front ()
+              done
           | None -> ())
       lines;
-    Queue.fold (fun acc msg -> msg :: acc) [] q |> List.rev
+    Queue.fold (fun acc msg -> msg :: acc) [] q
+    |> List.rev
+    |> drop_leading_tool_messages
   with
   | Sys_error detail ->
       report_persistence_read_drop
@@ -187,6 +284,9 @@ let to_json_array (messages : chat_message list) : Yojson.Safe.t =
             ] @ (match m.ts with
                  | Some t -> [("ts", `Float t)]
                  | None -> [])
+              @ opt_string_field "tool_call_id" m.tool_call_id
+              @ opt_string_field "tool_call_name" m.tool_call_name
+              @ opt_string_field "source" m.source
               @ (match m.attachments with
                  | None | Some [] -> []
                  | Some atts ->

--- a/lib/keeper/keeper_chat_store.mli
+++ b/lib/keeper/keeper_chat_store.mli
@@ -6,6 +6,11 @@
     JSON objects of the form
     {v {"role":"user","content":"hello","ts":1774000000.0} v}
 
+    Tool-call lines persisted between a turn's user and assistant lines
+    additionally carry [tool_call_id] / [tool_call_name]; every line of
+    a turn may carry the originating connector in [source]
+    (e.g. "dashboard", "discord", "slack", "agent").
+
     @since 2.145.0 *)
 
 (** {1 Types} *)
@@ -19,35 +24,52 @@ type attachment = {
   data : string;
 }
 
+(** One executed tool call within a turn. [args] holds the accumulated
+    argument JSON; empty arguments are persisted as ["{}"]. *)
+type tool_call = {
+  call_id : string;
+  call_name : string;
+  args : string;
+}
+
 type chat_message = {
   role : string;
   content : string;
   ts : float option;
   attachments : attachment list option;
+  tool_call_id : string option;
+  tool_call_name : string option;
+  source : string option;
 }
 
 (** {1 I/O} *)
 
-(** [append_pair ~base_dir ~keeper_name ~user_content ~assistant_content]
-    appends two lines (user then assistant) sharing a single
-    timestamp. Failures are logged but never raised except for
-    {!Eio.Cancel.Cancelled}. *)
-val append_pair :
+(** [append_turn ~base_dir ~keeper_name ~user_content ~user_attachments
+    ?tool_calls ?source ~assistant_content ()] appends one completed
+    turn as consecutive lines — user, one line per tool call, assistant
+    — sharing a single timestamp, in one write. Failures are logged but
+    never raised except for {!Eio.Cancel.Cancelled}. *)
+val append_turn :
   base_dir:string ->
   keeper_name:string ->
   user_content:string ->
-  assistant_content:string ->
   user_attachments:attachment list ->
+  ?tool_calls:tool_call list ->
+  ?source:string ->
+  assistant_content:string ->
+  unit ->
   unit
 
-(** [load ~base_dir ~keeper_name] returns the most recent
-    [max_history] messages in chronological order. Missing files
-    return [[]]. Unparseable lines are skipped. *)
+(** [load ~base_dir ~keeper_name] returns the most recent messages in
+    chronological order: the last 100 user/assistant messages plus the
+    tool lines belonging to them (absolute bound 400 lines). Missing
+    files return [[]]. Unparseable lines are skipped. *)
 val load :
   base_dir:string -> keeper_name:string -> chat_message list
 
 (** {1 Serialisation} *)
 
 (** JSON array of messages. Entries without a timestamp omit the
-    [ts] field. *)
+    [ts] field; [tool_call_id] / [tool_call_name] / [source] appear
+    only when present. *)
 val to_json_array : chat_message list -> Yojson.Safe.t

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -540,12 +540,17 @@ let append_direct_chat_pair_if_reply ~(config : Workspace.config) ~name ~args re
     match user_content, direct_reply_visible_text (tool_result_body result) with
     | "", _ | _, None -> ()
     | _, Some assistant_content ->
-        Keeper_chat_store.append_pair
+        (* Agent-initiated [masc_keeper_msg] path: only the final tool
+           result is visible here (no stream events), so no tool lines
+           are persisted for this surface. *)
+        Keeper_chat_store.append_turn
           ~base_dir:config.base_path
           ~keeper_name:name
           ~user_content
+          ~user_attachments:[]
+          ~source:"agent"
           ~assistant_content
-          ~user_attachments:[])
+          ())
 ;;
 
 (* RFC-0182 Phase 5 PR-B: ctx-free body for [masc_keeper_msg] descriptor

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -569,16 +569,50 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
             "keeper_stream: worker event push failed: %s"
             (Printexc.to_string exn)
   in
+  (* Mirror tool-call SDK events flowing through [on_event] so the
+     completed turn persists tool lines alongside the user/assistant
+     pair (the dashboard re-renders tool cards after a reload). The
+     accumulator runs in the worker fiber and is collected after
+     dispatch returns in that same fiber, so no synchronisation is
+     needed. The non-streaming fallback path emits no events and
+     therefore persists no tool lines. *)
+  let tool_call_cells : (int, Buffer.t) Hashtbl.t = Hashtbl.create 4 in
+  let tool_calls_rev : (string * string * Buffer.t) list ref = ref [] in
+  let record_tool_event = function
+    | Agent_sdk.Types.ContentBlockStart
+        { index; tool_id = Some tool_id; tool_name = Some tool_name; _ } ->
+        let buf = Buffer.create 64 in
+        Hashtbl.replace tool_call_cells index buf;
+        tool_calls_rev := (tool_id, tool_name, buf) :: !tool_calls_rev
+    | Agent_sdk.Types.ContentBlockDelta { index; delta = InputJsonDelta args } ->
+        (match Hashtbl.find_opt tool_call_cells index with
+         | Some buf -> Buffer.add_string buf args
+         | None -> ())
+    | _ -> ()
+  in
+  let collected_tool_calls () =
+    List.rev_map
+      (fun (call_id, call_name, buf) ->
+        { Keeper_chat_store.call_id; call_name; args = Buffer.contents buf })
+      !tool_calls_rev
+  in
+  let chat_source =
+    if has_connector_context then payload.channel else "dashboard"
+  in
   let on_event evt =
+    record_tool_event evt;
     push_worker_event (Stream_event evt)
   in
   let persist_failure_reply err =
-    Keeper_chat_store.append_pair
+    Keeper_chat_store.append_turn
       ~base_dir:state.Mcp_server.workspace_config.base_path
       ~keeper_name:payload.name
       ~user_content:payload.message
       ~user_attachments:payload.attachments
+      ~tool_calls:(collected_tool_calls ())
+      ~source:chat_source
       ~assistant_content:(persisted_error_reply err)
+      ()
   in
   let timeout_sec = Option.map float_of_int payload.timeout_sec in
   let request_id =
@@ -612,12 +646,15 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
         | Ok (true, body) ->
             let _payload_json_opt, visible_reply = extract_visible_reply body in
             if not (is_continuation_checkpoint_reply visible_reply) then
-              Keeper_chat_store.append_pair
+              Keeper_chat_store.append_turn
                 ~base_dir:state.Mcp_server.workspace_config.base_path
                 ~keeper_name:payload.name
                 ~user_content:payload.message
                 ~user_attachments:payload.attachments
-                ~assistant_content:visible_reply;
+                ~tool_calls:(collected_tool_calls ())
+                ~source:chat_source
+                ~assistant_content:visible_reply
+                ();
             push_worker_event (Stream_terminal (true, body));
             Tool_result.ok ~tool_name:"masc_keeper_msg" ~start_time body
         | Ok (false, err) ->

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -85,6 +85,131 @@ let test_load_records_malformed_row_drops () =
         1.0
         (drop_value invalid_payload -. before_invalid_payload))
 
+let roles messages = List.map (fun (m : K.chat_message) -> m.role) messages
+
+let test_append_turn_roundtrip () =
+  let base_dir = temp_base_path "keeper-chat-store-turn" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-turn" in
+      K.append_turn ~base_dir ~keeper_name
+        ~user_content:"run the checks"
+        ~user_attachments:[]
+        ~tool_calls:
+          [
+            { K.call_id = "toolu_1"; call_name = "Read"; args = {|{"path":"x"}|} };
+            (* Empty args normalise to "{}", empty id to a positional one. *)
+            { K.call_id = ""; call_name = "masc_status"; args = "  " };
+          ]
+        ~source:"dashboard"
+        ~assistant_content:"all green"
+        ();
+      let messages = K.load ~base_dir ~keeper_name in
+      Alcotest.(check (list string)) "turn line order"
+        [ "user"; "tool"; "tool"; "assistant" ]
+        (roles messages);
+      let tool1 = List.nth messages 1 in
+      let tool2 = List.nth messages 2 in
+      let asst = List.nth messages 3 in
+      Alcotest.(check (option string)) "tool id persisted"
+        (Some "toolu_1") tool1.tool_call_id;
+      Alcotest.(check (option string)) "tool name persisted"
+        (Some "Read") tool1.tool_call_name;
+      Alcotest.(check string) "tool args persisted" {|{"path":"x"}|} tool1.content;
+      Alcotest.(check (option string)) "empty tool id gets positional fallback"
+        (Some "tc-1") tool2.tool_call_id;
+      Alcotest.(check string) "empty args normalised" "{}" tool2.content;
+      Alcotest.(check (option string)) "source persisted on every line"
+        (Some "dashboard") asst.source;
+      Alcotest.(check (option string)) "assistant has no tool id"
+        None asst.tool_call_id)
+
+let test_legacy_lines_parse_without_new_fields () =
+  let base_dir = temp_base_path "keeper-chat-store-legacy" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-legacy" in
+      let path = chat_path ~base_dir ~keeper_name in
+      write_file path
+        ({|{"role":"user","content":"hello","ts":1.0}|} ^ "\n"
+        ^ {|{"role":"assistant","content":"world","ts":1.0}|} ^ "\n");
+      match K.load ~base_dir ~keeper_name with
+      | [ user; assistant ] ->
+          Alcotest.(check (option string)) "legacy user has no source" None user.source;
+          Alcotest.(check (option string)) "legacy assistant has no tool id"
+            None assistant.tool_call_id
+      | messages ->
+          Alcotest.failf "expected 2 messages, got %d" (List.length messages))
+
+let test_tool_row_missing_name_dropped () =
+  let base_dir = temp_base_path "keeper-chat-store-toolname" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-toolname" in
+      let path = chat_path ~base_dir ~keeper_name in
+      let invalid_payload = Safe_ops.persistence_read_drop_reason_invalid_payload in
+      let before = drop_value invalid_payload in
+      write_file path
+        ({|{"role":"user","content":"hi","ts":1.0}|} ^ "\n"
+        ^ {|{"role":"tool","content":"{}","ts":1.0,"tool_call_id":"toolu_9"}|} ^ "\n"
+        ^ {|{"role":"assistant","content":"done","ts":1.0}|} ^ "\n");
+      let messages = K.load ~base_dir ~keeper_name in
+      Alcotest.(check (list string)) "nameless tool row dropped"
+        [ "user"; "assistant" ] (roles messages);
+      Alcotest.(check (float 0.001)) "drop counted as invalid payload"
+        1.0
+        (drop_value invalid_payload -. before))
+
+let test_window_keeps_tool_lines_of_retained_turns () =
+  let base_dir = temp_base_path "keeper-chat-store-window" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-window" in
+      (* 51 turns of (user, tool, assistant) = 102 primaries; the window
+         keeps the last 100 primaries (50 full turns) and trims the
+         leading turn's orphaned tool line. *)
+      for i = 1 to 51 do
+        K.append_turn ~base_dir ~keeper_name
+          ~user_content:(Printf.sprintf "u%d" i)
+          ~user_attachments:[]
+          ~tool_calls:
+            [ { K.call_id = Printf.sprintf "t%d" i; call_name = "Read"; args = "{}" } ]
+          ~assistant_content:(Printf.sprintf "a%d" i)
+          ()
+      done;
+      let messages = K.load ~base_dir ~keeper_name in
+      Alcotest.(check int) "50 full turns survive" 150 (List.length messages);
+      let primaries =
+        List.filter (fun (m : K.chat_message) -> m.role <> "tool") messages
+      in
+      Alcotest.(check int) "primary window is 100" 100 (List.length primaries);
+      match messages with
+      | first :: _ ->
+          Alcotest.(check string) "window starts at a user line, not an orphan tool"
+            "user" first.role;
+          Alcotest.(check string) "oldest retained turn is turn 2" "u2" first.content
+      | [] -> Alcotest.fail "expected non-empty window")
+
+let test_orphan_leading_tool_lines_trimmed () =
+  let base_dir = temp_base_path "keeper-chat-store-orphan" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-orphan" in
+      let path = chat_path ~base_dir ~keeper_name in
+      write_file path
+        ({|{"role":"tool","content":"{}","ts":1.0,"tool_call_id":"t0","tool_call_name":"Read"}|}
+         ^ "\n"
+        ^ {|{"role":"user","content":"hi","ts":2.0}|} ^ "\n"
+        ^ {|{"role":"assistant","content":"yo","ts":2.0}|} ^ "\n");
+      let messages = K.load ~base_dir ~keeper_name in
+      Alcotest.(check (list string)) "leading orphan tool trimmed"
+        [ "user"; "assistant" ] (roles messages))
+
 let () =
   Alcotest.run "keeper_chat_store"
     [
@@ -92,5 +217,18 @@ let () =
         [
           Alcotest.test_case "malformed rows increment drop metrics" `Quick
             test_load_records_malformed_row_drops;
+          Alcotest.test_case "tool row without name dropped" `Quick
+            test_tool_row_missing_name_dropped;
+        ] );
+      ( "tool_call_persistence",
+        [
+          Alcotest.test_case "append_turn roundtrip" `Quick
+            test_append_turn_roundtrip;
+          Alcotest.test_case "legacy lines parse" `Quick
+            test_legacy_lines_parse_without_new_fields;
+          Alcotest.test_case "window counts primaries only" `Quick
+            test_window_keeps_tool_lines_of_retained_turns;
+          Alcotest.test_case "orphan leading tool lines trimmed" `Quick
+            test_orphan_leading_tool_lines_trimmed;
         ] );
     ]


### PR DESCRIPTION
## 요약

PR #20691 후속 1/3 — **서버 keeper_chat_store에 tool call 라인 영속화**. 리로드 후에도 tool 카드가 표시됩니다.

기존에는 tool call이 AG-UI SSE(`TOOL_CALL_*`)로 라이브 렌더만 되고 `.masc/keeper_chat/<name>.jsonl`에는 user/assistant pair만 남아, 새로고침하면 tool 기록이 사라졌습니다.

## 변경

### 서버 (OCaml)
- `keeper_chat_store`: `append_pair` → `append_turn`. 한 턴을 user → `role:"tool"` 라인(N개) → assistant 순서로 단일 write에 영속화. tool 라인은 `tool_call_id`/`tool_call_name`을, args JSON은 `content`에 담음. 빈 args는 write-time에 `"{}"`로 정규화 (read-side repair 없음)
- **`source` 필드**: 턴의 모든 라인에 발신 커넥터를 기록 (`dashboard` | 커넥터 채널 | `agent`). 차기 Discord 통합에서 "1 keeper ← 여러 커넥터 → 1 컨텍스트" 수렴 시 출처 구분의 기반
- `load` 윈도우: user/assistant 100개 기준으로 계산 (tool 라인이 대화 깊이를 잠식하지 않음), 절대 가드 400라인, 선두 고아 tool 라인 트림
- 스트림 라우트(`process_single_turn`): worker fiber의 `on_event`에서 `ContentBlockStart`/`InputJsonDelta`를 미러링해 누적, 성공·실패 영속화 경로 양쪽에 전달. 같은 fiber에서 수집하므로 동기화 불요. queue consumer(Discord/Slack 유입)도 동일 처리기를 재사용하므로 자동 적용
- agent-initiated `masc_keeper_msg` 경로(surface_ops)는 최종 결과만 보이므로 tool 라인 없이 `source:"agent"`만 기록

### 대시보드 (TS)
- history 스키마에 `tool_call_id`/`tool_call_name`/`source` optional 추가 (스키마 주석이 이미 tool role 도입을 예견)
- REST 매핑이 tool row를 라이브 `TOOL_CALL_*` 경로와 **동일한 엔트리 규약**(`id: tool-<id>`, `source:'tool_result'`, label=tool명)으로 변환 → 리로드 후 tool 카드 재렌더 + 라이브 엔트리와 자연 dedup. args JSON은 reply 포매터를 우회해 원문 유지

### 하위 호환
- 레거시 라인(신규 필드 없음)은 그대로 파싱 (테스트 포함)
- JSONL reader는 `load` 1곳뿐임을 전수 확인 (keeper 프롬프트 빌딩에 누수 없음). TUI는 SSE만 파싱하며 미지 이벤트는 Ignore
- 이중 기록 검증: HTTP 스트림 경로(`handle_keeper_msg_stream`)는 surface_ops append 래퍼를 통과하지 않음을 코드 추적으로 확인

## 검증
- `dune build --root .` (default + `@check`) EXIT=0, `@fmt` clean
- `test_keeper_chat_store` 6/6 (신규 4: append_turn 왕복, 레거시 파싱, 윈도우 primary-only 계산, 고아 tool 트림)
- dashboard: tsc 0 errors (--diagnostics로 실행 증명), eslint 0, vitest **500 files / 6,442 tests** green (신규 3)

## 남은 후속 (별도 PR)
- 두 채팅 표면(KeeperConversationPanel / KeeperChatPanel) store 통일
- Discord/Slack 커넥터 메시지의 세션 중 라이브 머지

Refs task-727

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
