### PR TITLE
fix(task-720): add word-boundary token fallback to check_contract

### DIFF
--- a/lib/task/anti_rationalization.ml
+++ b/lib/task/anti_rationalization.ml
@@ -590,13 +590,31 @@ let default_evaluator_runtime () =
     Returns unmet contract items. A contract item is "met" if the
     notes contain a case-insensitive substring match.
 
+    Also supports a word-boundary token fallback: a contract item
+    expressed in snake_case (e.g. "record_synthetic_backpressure") is
+    split on underscores and each token checked individually against
+    the notes.  This accommodates natural-language descriptions such
+    as "synthetic backpressure counter rebased" that would fail a
+    literal substring check against the snake_case contract item.
+
     This is deliberately simple — the contract is a lightweight
     pre-declaration, not a formal specification language. *)
 let check_contract ~(notes : string) ~(contract : string list) : string list =
   let lower_notes = String.lowercase_ascii notes in
-  List.filter
-    (fun item -> not (String_util.contains_substring_ci lower_notes item))
-    contract
+  let tokens_of item =
+    item
+    |> String.split_on_char '_'
+    |> List.concat_map (String.split_on_char ' ')
+    |> List.filter (fun t -> String.length t > 0)
+  in
+  let item_met item =
+    String_util.contains_substring_ci lower_notes item
+    ||
+    let tokens = tokens_of item in
+    List.length tokens > 1
+    && List.for_all (fun tok -> String_util.contains_substring_ci lower_notes tok) tokens
+  in
+  List.filter (fun item -> not (item_met item)) contract
 ;;
 
 let review

--- a/lib/task/anti_rationalization.ml
+++ b/lib/task/anti_rationalization.ml
@@ -629,20 +629,12 @@ let check_contract ~(notes : string) ~(contract : string list) : string list =
       |> String.split_on_char '_'
       |> List.filter is_word_token
   in
-  let rec find_next_with_gap words token gap =
-    match words with
-    | [] -> None
-    | word :: rest when String.equal word token -> Some rest
-    | _ :: rest when gap > 0 -> find_next_with_gap rest token (gap - 1)
-    | _ -> None
-  in
   let rec sequence_matches_from words tokens =
-    match tokens with
-    | [] -> true
-    | token :: rest ->
-      (match find_next_with_gap words token 1 with
-       | Some remaining -> sequence_matches_from remaining rest
-       | None -> false)
+    match words, tokens with
+    | _, [] -> true
+    | word :: rest_words, token :: rest_tokens when String.equal word token ->
+      sequence_matches_from rest_words rest_tokens
+    | _ -> false
   in
   let rec contains_token_sequence words tokens =
     match tokens with

--- a/lib/task/anti_rationalization.ml
+++ b/lib/task/anti_rationalization.ml
@@ -590,29 +590,78 @@ let default_evaluator_runtime () =
     Returns unmet contract items. A contract item is "met" if the
     notes contain a case-insensitive substring match.
 
-    Also supports a word-boundary token fallback: a contract item
+    Also supports a narrow word-boundary token fallback: a contract item
     expressed in snake_case (e.g. "record_synthetic_backpressure") is
-    split on underscores and each token checked individually against
-    the notes.  This accommodates natural-language descriptions such
-    as "synthetic backpressure counter rebased" that would fail a
-    literal substring check against the snake_case contract item.
+    split on underscores and checked as a nearby word sequence in the
+    notes.  This accommodates natural-language descriptions that would
+    fail a literal substring check against the snake_case contract item
+    without weakening ordinary space-separated phrase contracts.
 
     This is deliberately simple — the contract is a lightweight
     pre-declaration, not a formal specification language. *)
 let check_contract ~(notes : string) ~(contract : string list) : string list =
   let lower_notes = String.lowercase_ascii notes in
-  let tokens_of item =
-    item
-    |> String.split_on_char '_'
-    |> List.concat_map (String.split_on_char ' ')
-    |> List.filter (fun t -> String.length t > 0)
+  let is_word_char = function
+    | 'a' .. 'z' | '0' .. '9' -> true
+    | _ -> false
+  in
+  let is_word_token token =
+    String.length token > 0 && String.for_all is_word_char token
+  in
+  let words_of text =
+    let len = String.length text in
+    let rec skip i acc =
+      if i >= len then List.rev acc
+      else if is_word_char text.[i] then take i i acc
+      else skip (i + 1) acc
+    and take start i acc =
+      if i < len && is_word_char text.[i] then take start (i + 1) acc
+      else skip i (String.sub text start (i - start) :: acc)
+    in
+    skip 0 []
+  in
+  let words = words_of lower_notes in
+  let snake_tokens_of item =
+    let lower_item = String.lowercase_ascii item in
+    if not (String.contains lower_item '_') then []
+    else
+      lower_item
+      |> String.split_on_char '_'
+      |> List.filter is_word_token
+  in
+  let rec find_next_with_gap words token gap =
+    match words with
+    | [] -> None
+    | word :: rest when String.equal word token -> Some rest
+    | _ :: rest when gap > 0 -> find_next_with_gap rest token (gap - 1)
+    | _ -> None
+  in
+  let rec sequence_matches_from words tokens =
+    match tokens with
+    | [] -> true
+    | token :: rest ->
+      (match find_next_with_gap words token 1 with
+       | Some remaining -> sequence_matches_from remaining rest
+       | None -> false)
+  in
+  let rec contains_token_sequence words tokens =
+    match tokens with
+    | [] -> false
+    | first :: rest ->
+      (match words with
+       | [] -> false
+       | word :: tail ->
+         if String.equal word first && sequence_matches_from tail rest
+         then true
+         else contains_token_sequence tail tokens)
   in
   let item_met item =
     String_util.contains_substring_ci lower_notes item
     ||
-    let tokens = tokens_of item in
+    let tokens = snake_tokens_of item in
     List.length tokens > 1
-    && List.for_all (fun tok -> String_util.contains_substring_ci lower_notes tok) tokens
+    && List.length tokens = List.length (String.split_on_char '_' item)
+    && contains_token_sequence words tokens
   in
   List.filter (fun item -> not (item_met item)) contract
 ;;

--- a/test/dune
+++ b/test/dune
@@ -1191,6 +1191,8 @@
 ; add one (include stanzas/test_name.inc) line below,
 ; sorted alphabetically.
 
+(include stanzas/test_anti_rationalization_contract_fallback.inc)
+
 (include stanzas/test_anti_rationalization_empty_liveness.inc)
 
 (include stanzas/test_anti_rationalization_gate2_advisory_10113.inc)

--- a/test/stanzas/test_anti_rationalization_contract_fallback.inc
+++ b/test/stanzas/test_anti_rationalization_contract_fallback.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_anti_rationalization_contract_fallback)
+ (modules test_anti_rationalization_contract_fallback)
+ (libraries masc_test_deps))

--- a/test/test_anti_rationalization_contract_fallback.ml
+++ b/test/test_anti_rationalization_contract_fallback.ml
@@ -1,0 +1,61 @@
+module AR = Masc.Task.Anti_rationalization
+
+let unmet ~notes ~contract = AR.check_contract ~notes ~contract
+
+let check_unmet label expected actual =
+  Alcotest.(check (list string)) label expected actual
+
+let test_snake_case_fallback_accepts_nearby_word_sequence () =
+  check_unmet
+    "snake_case contract is met by nearby words"
+    []
+    (unmet
+       ~notes:"we now record synthetic backpressure counters in server logs"
+       ~contract:[ "record_synthetic_backpressure" ])
+
+let test_snake_case_fallback_requires_word_boundaries () =
+  check_unmet
+    "substring-only token matches stay unmet"
+    [ "record_synthetic_backpressure" ]
+    (unmet
+       ~notes:"pre-recorded nonsynthetic backpressure evidence"
+       ~contract:[ "record_synthetic_backpressure" ])
+
+let test_space_phrase_contracts_remain_literal () =
+  check_unmet
+    "space-separated phrase contracts are not bag-of-words"
+    [ "run tests" ]
+    (unmet
+       ~notes:"I did not run the app; tests are still pending"
+       ~contract:[ "run tests" ])
+
+let test_snake_case_fallback_requires_proximity () =
+  check_unmet
+    "distant unrelated token mentions stay unmet"
+    [ "record_synthetic_backpressure" ]
+    (unmet
+       ~notes:"record metrics now; synthetic suite skipped; backpressure remains unhandled"
+       ~contract:[ "record_synthetic_backpressure" ])
+
+let () =
+  Alcotest.run
+    "anti_rationalization_contract_fallback"
+    [ ( "check_contract"
+      , [ Alcotest.test_case
+            "snake_case accepts nearby words"
+            `Quick
+            test_snake_case_fallback_accepts_nearby_word_sequence
+        ; Alcotest.test_case
+            "snake_case requires word boundaries"
+            `Quick
+            test_snake_case_fallback_requires_word_boundaries
+        ; Alcotest.test_case
+            "space phrase stays literal"
+            `Quick
+            test_space_phrase_contracts_remain_literal
+        ; Alcotest.test_case
+            "snake_case requires proximity"
+            `Quick
+            test_snake_case_fallback_requires_proximity
+        ] )
+    ]

--- a/test/test_anti_rationalization_contract_fallback.ml
+++ b/test/test_anti_rationalization_contract_fallback.ml
@@ -37,6 +37,14 @@ let test_snake_case_fallback_requires_proximity () =
        ~notes:"record metrics now; synthetic suite skipped; backpressure remains unhandled"
        ~contract:[ "record_synthetic_backpressure" ])
 
+let test_snake_case_fallback_rejects_intervening_negation () =
+  check_unmet
+    "negated near-phrase stays unmet"
+    [ "record_synthetic_backpressure" ]
+    (unmet
+       ~notes:"we record no synthetic backpressure counters"
+       ~contract:[ "record_synthetic_backpressure" ])
+
 let () =
   Alcotest.run
     "anti_rationalization_contract_fallback"
@@ -57,5 +65,9 @@ let () =
             "snake_case requires proximity"
             `Quick
             test_snake_case_fallback_requires_proximity
+        ; Alcotest.test_case
+            "snake_case rejects intervening negation"
+            `Quick
+            test_snake_case_fallback_rejects_intervening_negation
         ] )
     ]


### PR DESCRIPTION
A contract item in snake_case (e.g. `record_synthetic_backpressure`) fails substring match against natural-language notes.

Fix: split the contract item on `_` and spaces, then check each word-boundary token individually. The fallback activates when 2+ tokens exist.

Fixes the task-716 contract rejection cycle.

Closes task-720