### PR TITLE
feat(keeper): schedule-level scope fallback so admission-blocked scope can't starve a keeper (#20673)

### DIFF
--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -555,14 +555,25 @@ let handle_keeper_task_tool
       Workspace.claim_next_r config ~agent_name:meta.agent_name
         ~task_filter:claim_goal_scope.task_filter
         ~admission_filter:wip_admission_filter
+        ~allow_scope_fallback:true
         ()
     in
     let wip_rejections = List.rev !wip_rejections in
     let auto_started_ok = ref false in
     let harness_completed = ref false in
     (match result with
-     | Workspace.Claim_next_claimed { task_id; _ } ->
+     | Workspace.Claim_next_claimed { task_id; scope_widened; _ } ->
        sync_keeper_meta_current_task ~config ~meta ~task_id;
+       (* Make the scope override visible: this is a claim outside the keeper's
+          active_goal_ids, taken because no in-scope task was admission-eligible
+          (schedule-level fallback). Silent widening would let operators misread
+          the keeper's scope. *)
+       if scope_widened then
+         Log.Keeper.info ~keeper_name:meta.name
+           "goal-scope widened to all_tasks for claim of %s: no in-scope task was \
+            admission-eligible (active_goal_ids=[%s])"
+           task_id
+           (String.concat ", " meta.active_goal_ids);
        (* Guard: claim_next_r returns existing active tasks via Existing_claim
           (task_state_schedule.ml:302). When the task is already InProgress,
           dispatching Start produces an InvalidState transition error every

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -951,6 +951,11 @@ type claim_next_result =
       priority : int;
       released_task_id : string option;  (** Legacy field; claim_next no longer auto-releases active work. *)
       message : string;
+      scope_widened : bool;
+          (** True when goal-scope was widened to all_tasks because no scoped
+              task was admission-eligible (schedule-level fallback). Lets the
+              operator distinguish a scope-overriding claim from an ordinary
+              in-scope claim. *)
     }
   | Claim_next_no_unclaimed
   | Claim_next_no_eligible of

--- a/lib/types/types_core.mli
+++ b/lib/types/types_core.mli
@@ -320,6 +320,7 @@ type claim_next_result =
       ; priority : int
       ; released_task_id : string option
       ; message : string
+      ; scope_widened : bool
       }
   | Claim_next_no_unclaimed
   | Claim_next_no_eligible of

--- a/lib/workspace/workspace_task.ml
+++ b/lib/workspace/workspace_task.ml
@@ -227,6 +227,7 @@ type claim_next_result = Masc_domain.claim_next_result =
       ; priority : int
       ; released_task_id : string option
       ; message : string
+      ; scope_widened : bool
       }
   | Claim_next_no_unclaimed
   | Claim_next_no_eligible of

--- a/lib/workspace/workspace_task.mli
+++ b/lib/workspace/workspace_task.mli
@@ -82,6 +82,7 @@ type claim_next_result = Masc_domain.claim_next_result =
       priority : int;
       released_task_id : string option;
       message : string;
+      scope_widened : bool;
     }
   | Claim_next_no_unclaimed
   | Claim_next_no_eligible of

--- a/lib/workspace/workspace_task_schedule.ml
+++ b/lib/workspace/workspace_task_schedule.ml
@@ -207,6 +207,7 @@ let claim_next_r
       ?(admission_filter :
          active_tasks:Masc_domain.task list -> Masc_domain.task -> bool =
         fun ~active_tasks:_ _ -> true)
+      ?(allow_scope_fallback = false)
       ()
   =
   let exception Existing_claim of claim_next_result in
@@ -273,6 +274,7 @@ let claim_next_r
                    ; priority = prev.priority
                    ; released_task_id = None
                    ; message
+                   ; scope_widened = false
                    })));
         let released_task_id, working_tasks = None, backlog.tasks in
         let active_admission_tasks =
@@ -408,7 +410,30 @@ let claim_next_r
                (not (List.mem t.id all_excluded)) && effective_task_filter t)
             candidates
         in
-        let eligible = eligible_from unclaimed in
+        let scoped_eligible = eligible_from unclaimed in
+        (* Goal-scope must not starve a keeper: when [allow_scope_fallback] and no
+           scoped task is admission-eligible, widen to all_tasks. [admission_allowed]
+           and [all_excluded] are still enforced — only [task_filter] (the goal
+           scope) is dropped — so a wip-blocked scoped task stays excluded while an
+           unscoped task can be claimed. Schedule-level companion to the RFC-0067 §1
+           resolve-side fallback; this layer additionally covers the
+           scoped-task-exists-but-admission-blocked case that the resolver cannot
+           see. *)
+        let eligible, scope_widened =
+          match scoped_eligible with
+          | _ :: _ -> scoped_eligible, false
+          | [] when allow_scope_fallback ->
+            let widened =
+              List.filter
+                (fun (t : task) ->
+                   (not (List.mem t.id all_excluded)) && admission_allowed t)
+                unclaimed
+            in
+            (match widened with
+             | _ :: _ -> widened, true
+             | [] -> [], false)
+          | [] -> scoped_eligible, false
+        in
         let explicit_excluded_count =
           List.length exclude_task_ids
           +
@@ -576,6 +601,7 @@ let claim_next_r
               ; priority = task.priority
               ; released_task_id
               ; message
+              ; scope_widened
               }
           , Some task.id ))
     with

--- a/lib/workspace/workspace_task_schedule.mli
+++ b/lib/workspace/workspace_task_schedule.mli
@@ -66,6 +66,10 @@ val claim_next_r
   -> ?task_filter:(Masc_domain.task -> bool)
   -> ?admission_filter:
        (active_tasks:Masc_domain.task list -> Masc_domain.task -> bool)
+  -> ?allow_scope_fallback:bool
+       (** When [true] and no goal-scoped task is admission-eligible, widen the
+           claim pool to all_tasks (admission still enforced). Result carries
+           [scope_widened = true]. Default [false] preserves the hard scope. *)
   -> unit
   -> Masc_domain.claim_next_result
 

--- a/test/test_workspace_coverage.ml
+++ b/test/test_workspace_coverage.ml
@@ -1694,6 +1694,53 @@ let test_claim_task_r_already_claimed () =
     | _ -> Alcotest.fail "Expected TaskAlreadyClaimed")
 ;;
 
+(* Schedule-level scope fallback (#20673): a keeper must not idle when the only
+   in-scope task is admission-blocked while an unscoped task is claimable. This
+   runs through claim_next_r with BOTH task_filter (scope) and admission_filter
+   (wip), the composition the resolver-direct test cannot exercise. *)
+let test_scope_widen_claims_unscoped_when_scoped_admission_blocked () =
+  with_test_env (fun config ->
+    (* task-001: scoped to goal-x but admission-blocked.
+       task-002: unscoped (goal_id=None), admission-eligible. *)
+    let _ =
+      Workspace.add_task ~goal_id:"goal-x" config ~title:"scoped blocked"
+        ~priority:1 ~description:""
+    in
+    let _ =
+      Workspace.add_task config ~title:"unscoped open" ~priority:1 ~description:""
+    in
+    let agent_name = "agent_llm_a" in
+    let task_filter (t : Masc_domain.task) =
+      match t.goal_id with
+      | Some g -> String.equal g "goal-x"
+      | None -> false
+    in
+    let admission_filter ~active_tasks:_ (t : Masc_domain.task) =
+      not (String.equal t.id "task-001")
+    in
+    (* Hard scope (default allow_scope_fallback=false): the scoped task is
+       admission-blocked and the unscoped task is out-of-scope -> no eligible. *)
+    (match
+       Workspace.claim_next_r config ~agent_name ~task_filter ~admission_filter ()
+     with
+     | Workspace.Claim_next_no_eligible _ -> ()
+     | Workspace.Claim_next_claimed { task_id; _ } ->
+       Alcotest.failf "hard scope must not claim, got %s" task_id
+     | _ -> Alcotest.fail "expected no_eligible under hard scope");
+    (* Fallback: widen drops scope but keeps admission -> claims the unscoped
+       task and flags scope_widened. The admission-blocked scoped task stays out. *)
+    match
+      Workspace.claim_next_r config ~agent_name ~task_filter ~admission_filter
+        ~allow_scope_fallback:true ()
+    with
+    | Workspace.Claim_next_claimed { task_id; scope_widened; _ } ->
+      Alcotest.(check string) "claimed unscoped via widen" "task-002" task_id;
+      Alcotest.(check bool) "scope_widened flag set" true scope_widened
+    | Workspace.Claim_next_no_eligible _ ->
+      Alcotest.fail "fallback must claim the unscoped task, got no_eligible"
+    | _ -> Alcotest.fail "expected claim under fallback")
+;;
+
 (* ============================================================ *)
 (* GC (Garbage Collection) Tests                                 *)
 (* ============================================================ *)
@@ -1964,6 +2011,10 @@ let () =
             "claim_task_r already claimed"
             `Quick
             test_claim_task_r_already_claimed
+        ; Alcotest.test_case
+            "scope fallback claims unscoped when scoped admission-blocked"
+            `Quick
+            test_scope_widen_claims_unscoped_when_scoped_admission_blocked
         ] )
     ; (* === GC === *)
       ( "gc"


### PR DESCRIPTION
Closes #20673.

## 문제

#20672가 goal-scope를 priority hint로 환원했지만 **resolve-level**이라 admission을 볼 수 없었습니다. scoped Todo가 *존재*하나 전부 wip-admission으로 막히면, resolver는 hard scope를 유지하고 keeper는 unscoped(`goal_id=None`) 일이 backlog에 있어도 idle했습니다. #20672가 disclose한 잔여 구멍입니다.

## 변경

`claim_next_r`에 `?allow_scope_fallback`(기본 false; keeper claim path만 true) 추가. scoped+admission eligible 집합이 비면 all_tasks로 widen하되 **`admission_filter`와 exclusion은 계속 enforce** — wip-block된 scoped task는 제외된 채, admission-eligible한 unscoped task를 claim. **admission 이후** 판정이라 resolver가 못 보는 케이스를 닫습니다.

## Visibility (silent override 방지)

- `claim_next_result.Claim_next_claimed`에 `scope_widened : bool` 추가
- keeper claim path가 schedule-level widen 발동 시 info 로그
- resolve-level fallback(#20672)은 claim-success의 `active_goal_scope_json`(effective_mode/fallback_reason)으로 별도 노출

두 layer가 widen을 **다른 채널**로 노출합니다(JSON vs 로그). 같은 결과에 signal이 inverted(resolve: mode=fallback/scope_widened=false, schedule: mode=active_goal_ids/scope_widened=true) — #20674에 기록, mode→variant 전환 시 통합.

## #20672와 공존 (통합 안 함)

resolve-side `mode`가 "scoped Todo가 존재했는가"를 인코딩하고, no_eligible operator 메시지가 그 구분에 의존합니다. 통합하면 그 signal이 사라지므로 공존이 정확. two-layer 통합은 #20674로 분리.

## 검증

- 신규 `test_workspace_coverage` 케이스: `claim_next_r`를 **task_filter(scope) + admission_filter(wip) 둘 다** 통과 — scoped task admission-block + unscoped admission-eligible → unscoped claim, `scope_widened=true`; 기본(hard scope) → no_eligible
- suite delta **0 vs origin/main** (5 pre-existing 실패 불변)
- **full `dune build` green** (CI hard-required 게이트 등가)
- `@check` EXIT=0, 변경 8파일 ocamlformat clean

## RFC

RFC-0067 §1 (goal-scope fallback) 확장. admission 계속 enforce → RFC-0153 backpressure 충돌 없음.

WORKAROUND-WAIVED: "fallback" 시그니처는 false positive. typed 두 개념을 string에 압축하는 fallback-resolution 안티패턴이 아니라, scope를 priority hint로 환원하는 RFC-0067 §1 동작의 schedule-level 보완이며 `scope_widened`/로그로 visible. mode→variant root-fix는 #20674로 분리 기록.

## 미검증

- live 환경 11 keeper × per-cycle 부하 측정 (observation path는 미변경이라 영향 없음; claim path만 `allow_scope_fallback`)
