### PR TITLE
fix(otel): remove stray inc_counter that froze prompt-segment gauge as a counter

### DIFF
--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -725,10 +725,12 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
   in
   let sanitized_system = sanitize_retired_tool_names system_prompt in
   let sanitized_user = sanitize_retired_tool_names user_message in
-  Otel_metric_store.inc_counter
-    (Keeper_metrics.to_string PromptSegmentBytes)
-    ~labels:[("keeper", meta.name); ("segment", "system_prompt")]
-    ();
+  (* set_gauge only: a stray inc_counter here used to create this
+     (name, labels) cell as Counter first, so the system_prompt series
+     kept Counter kind, carried a non-monotonic byte length, and exported
+     as masc_keeper_prompt_segment_bytes_total while user_message exported
+     as the intended gauge. The store keys cells by (name, labels) and
+     never retypes an existing cell. *)
   Otel_metric_store.set_gauge
     (Keeper_metrics.to_string PromptSegmentBytes)
     ~labels:[("keeper", meta.name); ("segment", "system_prompt")]


### PR DESCRIPTION
## 증상 (감사 발견 → 운영 재현)

OTel 감사(#20690 시리즈)에서 `masc_keeper_prompt_segment_bytes_total`이 "코드 무근원 잔재"로 분류되어 `delete_series`로 삭제했는데, 새 바이너리 재기동 후 **11 시리즈로 즉시 부활** — 잔재가 아니라 현행 코드가 만들고 있었습니다.

## 원인

`keeper_unified_prompt.ml`이 `system_prompt` 세그먼트에 대해 같은 (이름, 라벨)로 **`inc_counter` → `set_gauge`를 연속 호출**합니다 (#20657 잔재로 추정). store는 (name, labels) 키로 셀을 만들고 **기존 셀의 타입을 절대 바꾸지 않으므로**:

- 첫 `inc_counter`가 셀을 **Counter**로 생성
- `set_gauge`는 값만 덮어씀 (바이트 길이 — non-monotonic)
- Counter ⇒ monotonic sum으로 수출 ⇒ collector가 `_total` 부착
- 결과: `system_prompt`는 `..._bytes_total`(가짜 counter), `user_message`는 `..._bytes`(정상 gauge)로 **이름이 갈라짐**

## 변경

stray `inc_counter` 1콜 삭제 + 재발 방지 주석. 두 세그먼트 모두 Grafana "Prompt Segment Bytes" 패널이 쿼리하는 `masc_keeper_prompt_segment_bytes` gauge로 수출됩니다.

## 검증

- `dune build lib/keeper` 클린.
- `test_keeper_prompt_metrics` 변화 없음 (2 실패는 프롬프트 문구 단언, origin/main 동일 재현 pre-existing).
- 배포 후 운영 1회: `curl 'http://localhost:8428/api/v1/admin/tsdb/delete_series?match[]=masc_keeper_prompt_segment_bytes_total'`

RFC-0217 관련 (단일 백엔드 위 메트릭 타입 위생). 감사 원장: `~/me/.tmp/otel-audit/PLAN.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
