### PR TITLE
feat(keeper-chat): live-merge connector messages via keeper_chat_appended push

### DIFF
--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { callMcpTool } = vi.hoisted(() => ({ callMcpTool: vi.fn() }))
 const { runOperatorAction } = vi.hoisted(() => ({ runOperatorAction: vi.fn() }))
@@ -25,9 +25,47 @@ import { keeperThreads, keeperActionErrors } from './keeper-state'
 import {
   _resetChatHydrationForTests,
   hydrateKeeperChatHistory,
+  noteKeeperChatAppended,
   sendKeeperThreadMessage,
 } from './keeper-actions'
 import type { KeeperChatStreamEvent } from './api'
+
+describe('noteKeeperChatAppended', () => {
+  beforeEach(() => {
+    keeperThreads.value = {}
+    keeperActionErrors.value = {}
+    _resetChatHydrationForTests()
+    fetchKeeperChatHistory.mockReset()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('skips keepers whose transcript was never hydrated', async () => {
+    noteKeeperChatAppended('echo')
+    await vi.runAllTimersAsync()
+    expect(fetchKeeperChatHistory).not.toHaveBeenCalled()
+  })
+
+  it('debounces a burst of appends into one forced refetch', async () => {
+    fetchKeeperChatHistory.mockResolvedValue([
+      { role: 'user', content: 'hi', ts: 1_780_000_000 },
+    ])
+    await hydrateKeeperChatHistory('echo')
+    expect(fetchKeeperChatHistory).toHaveBeenCalledTimes(1)
+
+    noteKeeperChatAppended('echo')
+    noteKeeperChatAppended('echo')
+    noteKeeperChatAppended('echo')
+    await vi.runAllTimersAsync()
+
+    // One additional fetch despite the once-per-keeper hydration guard
+    // (force) and despite three push events (debounce).
+    expect(fetchKeeperChatHistory).toHaveBeenCalledTimes(2)
+  })
+})
 
 describe('hydrateKeeperChatHistory', () => {
   beforeEach(() => {

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -159,6 +159,29 @@ export async function hydrateKeeperChatHistory(
   }
 }
 
+// Trailing per-keeper debounce for keeper_chat_appended pushes so a
+// burst of turns (queue drain, multi-connector traffic) coalesces into
+// one history refetch instead of one round-trip per message.
+const chatRefreshTimers = new Map<string, ReturnType<typeof setTimeout>>()
+const CHAT_APPENDED_REFRESH_DELAY_MS = 400
+
+/** React to a server `keeper_chat_appended` push: re-merge the
+ *  persisted transcript so messages arriving through other connectors
+ *  (Discord, Slack, agent MCP) appear without a page reload. Keepers
+ *  whose transcript was never hydrated are skipped — the mount
+ *  hydration fetches the full window when the panel first opens. */
+export function noteKeeperChatAppended(name: string): void {
+  const keeperName = name.trim()
+  if (!keeperName) return
+  if (!hydratedChatKeepers.has(keeperName)) return
+  const pending = chatRefreshTimers.get(keeperName)
+  if (pending) clearTimeout(pending)
+  chatRefreshTimers.set(keeperName, setTimeout(() => {
+    chatRefreshTimers.delete(keeperName)
+    void hydrateKeeperChatHistory(keeperName, { force: true })
+  }, CHAT_APPENDED_REFRESH_DELAY_MS))
+}
+
 export async function loadFullKeeperHistory(name: string): Promise<void> {
   const keeperName = name.trim()
   if (!keeperName) return

--- a/dashboard/src/keeper-runtime.ts
+++ b/dashboard/src/keeper-runtime.ts
@@ -21,6 +21,7 @@ export {
   hydrateKeeperStatus,
   hydrateKeeperChatHistory,
   loadFullKeeperHistory,
+  noteKeeperChatAppended,
   sendKeeperThreadMessage,
   probeKeeperRuntime,
   recoverKeeperRuntime,

--- a/dashboard/src/schemas/sse.ts
+++ b/dashboard/src/schemas/sse.ts
@@ -48,6 +48,7 @@ const FIXED_SSE_EVENT_TYPES = new Set([
   'masc/keeper_guardrail',
   'keeper_phase_changed',
   'keeper_composite_changed',
+  'keeper_chat_appended',
   'keeper_tool_call',
   'masc/keeper_tool_call',
   'keeper_tool_skipped',
@@ -73,6 +74,7 @@ const FIXED_SSE_EVENT_TYPES = new Set([
 const STRING_FIELDS = new Set([
   'severity',
   'source',
+  'connector',
   'agent',
   'from',
   'from_agent',

--- a/dashboard/src/sse-store.test.ts
+++ b/dashboard/src/sse-store.test.ts
@@ -41,6 +41,7 @@ const showToast = vi.fn<(message: string, kind?: string, durationMs?: number) =>
 const replayOasRuntimeTelemetry = vi.fn<() => Promise<void>>(async () => {})
 const hydrateFleetCompositeSnapshot = vi.fn<(payload: unknown) => void>()
 const hydrateGoalTreeSnapshot = vi.fn<(payload: unknown) => boolean>(() => true)
+const noteKeeperChatAppended = vi.fn<(name: string) => void>()
 
 async function flushAsyncWork(): Promise<void> {
   await vi.dynamicImportSettled()
@@ -90,6 +91,9 @@ async function loadSseStore() {
   }))
   vi.doMock('./goal-tree-state', () => ({
     hydrateGoalTreeSnapshot,
+  }))
+  vi.doMock('./keeper-runtime', () => ({
+    noteKeeperChatAppended,
   }))
   vi.doMock('./router', () => ({ route }))
   const sseStore = await import('./sse-store')
@@ -270,6 +274,19 @@ describe('setupSSEReaction reconnect hydration', () => {
     await flushAsyncWork()
 
     expect(refreshBoard).toHaveBeenCalledTimes(1)
+  })
+
+  it('routes keeper_chat_appended pushes to the live chat refresh hook', async () => {
+    const { sseStore } = await loadSseStore()
+
+    sseStore.routeServerPushEvent({
+      type: 'keeper_chat_appended',
+      name: 'echo',
+      connector: 'discord',
+    })
+    await flushAsyncWork()
+
+    expect(noteKeeperChatAppended).toHaveBeenCalledWith('echo')
   })
 
   it('routes board reaction changes through the board refresh budget', async () => {

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -534,6 +534,21 @@ export function hydrateServerPushEvent(event: SSEEvent): boolean {
     return true
   }
 
+  if (event.type === 'keeper_chat_appended') {
+    const payload = event as unknown as { name?: string }
+    const name = typeof payload.name === 'string' ? payload.name : ''
+    if (name) {
+      // Dynamic import keeps sse-store decoupled from the keeper action
+      // layer (same pattern as the agent-failed notification above).
+      void import('./keeper-runtime')
+        .then(mod => { mod.noteKeeperChatAppended(name) })
+        .catch(err => {
+          console.debug('[SSE] keeper chat refresh unavailable', err instanceof Error ? err.message : '')
+        })
+    }
+    return true
+  }
+
   if (event.type === 'post_created' && handleBoardPostCreated(event)) {
     return true
   }

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -29,6 +29,7 @@ export type SSEEventType =
   | 'masc/keeper_guardrail'
   | 'keeper_phase_changed'
   | 'keeper_composite_changed'
+  | 'keeper_chat_appended'
   | 'keeper_tool_call'
   | 'masc/keeper_tool_call'
   | 'keeper_tool_skipped'
@@ -130,6 +131,10 @@ export interface SSEEvent {
   type: SSEEventType
   severity?: JournalSeverity
   source?: JournalSource
+  // Originating connector for keeper_chat_appended ('dashboard' |
+  // 'discord' | 'slack' | 'agent' | gate channel). Distinct from
+  // [source], which is reserved for the journal origin.
+  connector?: string
   agent?: string
   from?: string
   from_agent?: string

--- a/lib/keeper/keeper_chat_broadcast.ml
+++ b/lib/keeper/keeper_chat_broadcast.ml
@@ -1,0 +1,31 @@
+(** SSE broadcast helper for keeper chat persistence events.
+
+    Mirrors [Keeper_registry_broadcast]: a pure side-effect wrapper
+    around [Sse.broadcast] with a failure counter + WARN log. *)
+
+let chat_appended ~keeper_name ~source =
+  try
+    (* Field is named [connector], not [source]: the dashboard SSE
+       vocabulary already reserves [source] for the journal origin
+       (JournalSource), and the chat JSONL's own [source] column is a
+       different boundary. *)
+    let json =
+      `Assoc
+        [ ("type", `String "keeper_chat_appended");
+          ("name", `String keeper_name);
+          ("connector", `String source);
+          ("ts_unix", `Float (Time_compat.now ()));
+        ]
+    in
+    Sse.broadcast json
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string SseBroadcastFailures)
+      ~labels:[ ("keeper", keeper_name); ("site", "chat_appended") ]
+      ();
+    Log.Keeper.warn
+      "keeper_chat_broadcast: chat_appended name=%s failed: %s"
+      keeper_name
+      (Printexc.to_string exn)

--- a/lib/keeper/keeper_chat_broadcast.mli
+++ b/lib/keeper/keeper_chat_broadcast.mli
@@ -1,0 +1,20 @@
+(** SSE broadcast helper for keeper chat persistence events.
+
+    Pure side-effect wrapper — no chat store state read or written.
+    Mirrors [Keeper_registry_broadcast] for lifecycle events. *)
+
+(** Broadcast a [keeper_chat_appended] SSE event after a completed turn
+    is persisted to the keeper's chat JSONL. The dashboard uses it to
+    re-merge the server transcript live, so messages arriving through
+    other connectors (Discord, Slack, agent MCP) appear without a page
+    reload.
+
+    The event has no dashboard slice mapping on purpose: slice-less
+    events take the WS raw-forward catch-all to every authenticated
+    session, which is the right cost profile for low-frequency chat
+    turns.
+
+    Exceptions from [Sse.broadcast] are counted on the
+    [keeper_sse_broadcast_failures] counter (site [chat_appended]) and
+    logged at WARN. {!Eio.Cancel.Cancelled} propagates. *)
+val chat_appended : keeper_name:string -> source:string -> unit

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -550,7 +550,8 @@ let append_direct_chat_pair_if_reply ~(config : Workspace.config) ~name ~args re
           ~user_attachments:[]
           ~source:"agent"
           ~assistant_content
-          ())
+          ();
+        Keeper_chat_broadcast.chat_appended ~keeper_name:name ~source:"agent")
 ;;
 
 (* RFC-0182 Phase 5 PR-B: ctx-free body for [masc_keeper_msg] descriptor

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -612,7 +612,9 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
       ~tool_calls:(collected_tool_calls ())
       ~source:chat_source
       ~assistant_content:(persisted_error_reply err)
-      ()
+      ();
+    Keeper_chat_broadcast.chat_appended
+      ~keeper_name:payload.name ~source:chat_source
   in
   let timeout_sec = Option.map float_of_int payload.timeout_sec in
   let request_id =
@@ -645,7 +647,7 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
         match dispatch_result with
         | Ok (true, body) ->
             let _payload_json_opt, visible_reply = extract_visible_reply body in
-            if not (is_continuation_checkpoint_reply visible_reply) then
+            if not (is_continuation_checkpoint_reply visible_reply) then begin
               Keeper_chat_store.append_turn
                 ~base_dir:state.Mcp_server.workspace_config.base_path
                 ~keeper_name:payload.name
@@ -655,6 +657,9 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
                 ~source:chat_source
                 ~assistant_content:visible_reply
                 ();
+              Keeper_chat_broadcast.chat_appended
+                ~keeper_name:payload.name ~source:chat_source
+            end;
             push_worker_event (Stream_terminal (true, body));
             Tool_result.ok ~tool_name:"masc_keeper_msg" ~start_time body
         | Ok (false, err) ->


### PR DESCRIPTION
## 요약

PR #20691 후속 3/3 — **커넥터 메시지 라이브 머지**. Discord/Slack/agent 경유 메시지가 대시보드가 열려 있는 동안 **새로고침 없이** 나타납니다.

기존에는 history가 패널 mount 시 1회만 hydrate되어, 세션 중 다른 커넥터로 도착한 메시지는 전체 리로드 전까지 보이지 않았습니다. 사용자가 말한 "Keeper 1명이 여러 곳을 바라보고 모두 1개의 컨텍스트로 모이는" 구조의 대시보드 측 선행 작업입니다.

## 설계: push-triggered pull

- 서버는 턴 영속화 직후 가벼운 알림(`keeper_chat_appended` {name, connector})만 broadcast
- 클라이언트는 알림을 받으면 해당 keeper의 history를 **재fetch + 재머지** (페이로드를 직접 신뢰하지 않음 → WS 재연결 중 놓친 이벤트가 있어도 다음 알림에서 SSOT로 수렴, 기존 검증된 dedup 경로 재사용)

## 변경

### 서버 (OCaml)
- 신규 `Keeper_chat_broadcast.chat_appended` — `Keeper_registry_broadcast` 패턴 미러 (실패 카운터 + WARN, Cancelled 전파)
- emit 3지점: 스트림 라우트 성공/실패 영속화 직후 + agent direct-reply 경로
- **slice 매핑 의도적 생략**: slice 없는 이벤트는 WS raw-forward catch-all로 모든 인증 세션에 전달 — 저빈도 chat 턴에 맞는 비용 프로파일 (`post_created` 등과 동일 경로)

### 대시보드 (TS)
- SSE type union + 런타임 스키마에 `keeper_chat_appended` 추가 (parse-or-drop 경계라 누락 시 이벤트가 조용히 드롭됨)
- `noteKeeperChatAppended`: keeper별 400ms trailing debounce 후 forced re-merge. **미hydrate keeper는 스킵** (mount hydration이 커버)
- sse-store → keeper 액션 레이어는 dynamic import로 결합도 차단 (기존 agent-failed 패턴 동일)
- 이벤트 필드명은 `connector` — SSE 어휘에서 `source`는 JournalSource로 예약돼 있어 tsc가 충돌을 잡아냄

## 검증
- `dune build --root .` (default + `@check`) + `@fmt` clean
- tsc 0 errors, eslint 0, vitest **500 files / 6,445 tests** green (신규 3: debounce 수렴, 미hydrate 스킵, SSE 라우팅)

## 관계
- **#20697 위에 스택** (append 지점 공유). #20697 머지 후 base가 main으로 자동 전환됩니다
- #20703 (표면 통일)과는 독립

Refs task-727

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
