### PR TITLE
fix(telemetry): restore coverage-gap counter emit severed in #20189

### DIFF
--- a/lib/telemetry_coverage_gap/dune
+++ b/lib/telemetry_coverage_gap/dune
@@ -5,4 +5,4 @@
  (public_name masc.telemetry_coverage_gap)
  (wrapped false)
  (modules telemetry_coverage_gap)
- (libraries dated_jsonl masc_core masc_types time_compat yojson))
+ (libraries dated_jsonl masc_core masc_types otel_metric_store time_compat yojson))

--- a/lib/telemetry_coverage_gap/telemetry_coverage_gap.ml
+++ b/lib/telemetry_coverage_gap/telemetry_coverage_gap.ml
@@ -36,6 +36,20 @@ let class_json = function
 let record ~masc_root ~source ~producer ~durable_store ~dashboard_surface
     ~stale_reason ?keeper_name ?trace_id ?error ?exn () =
   let raw_error, error_class = derive_error_and_class ~error ~exn in
+  (* The OTel counter was severed in #20189 (Prometheus surface purge)
+     without an Otel_metric_store replacement; every coverage-gap record
+     must also bump the counter so dashboards see gaps without reading
+     the JSONL store. *)
+  Otel_metric_store_core.inc_counter
+    Otel_builtin_metric_names.metric_telemetry_coverage_gap
+    ~labels:
+      [
+        ("source", source);
+        ("producer", producer);
+        ("dashboard_surface", dashboard_surface);
+        ("stale_reason", stale_reason);
+      ]
+    ();
   let store = Dated_jsonl.create ~base_dir:(store_dir masc_root) () in
   let now = Time_compat.now () in
   let json =

--- a/lib/telemetry_coverage_gap/telemetry_coverage_gap.ml
+++ b/lib/telemetry_coverage_gap/telemetry_coverage_gap.ml
@@ -36,10 +36,10 @@ let class_json = function
 let record ~masc_root ~source ~producer ~durable_store ~dashboard_surface
     ~stale_reason ?keeper_name ?trace_id ?error ?exn () =
   let raw_error, error_class = derive_error_and_class ~error ~exn in
-  (* The OTel counter was severed in #20189 (Prometheus surface purge)
-     without an Otel_metric_store replacement; every coverage-gap record
-     must also bump the counter so dashboards see gaps without reading
-     the JSONL store. *)
+  (* The OTel counter was severed in #20189 (retired scrape-backend
+     purge) without an Otel_metric_store replacement; every coverage-gap
+     record must also bump the counter so dashboards see gaps without
+     reading the JSONL store. *)
   Otel_metric_store_core.inc_counter
     Otel_builtin_metric_names.metric_telemetry_coverage_gap
     ~labels:

--- a/test/test_keeper_lifecycle_hooks.ml
+++ b/test/test_keeper_lifecycle_hooks.ml
@@ -9,7 +9,11 @@
 open Alcotest
 
 module H = Masc.Keeper_lifecycle_hooks
-module P = Otel_metric_store
+(* Masc.Otel_metric_store is the store production code writes to.
+   The bare Otel_metric_store module here is the test shim
+   (test/deps/otel_metric_store.ml) with its own private store, so
+   reading it can never observe lib emits. *)
+module P = Masc.Otel_metric_store
 module SM = Keeper_state_machine
 module TCG = Telemetry_coverage_gap
 


### PR DESCRIPTION
## 무엇

`masc_telemetry_coverage_gap_total` counter emit을 복원했습니다. 선언(`otel_builtin_metric_names.ml`)만 있고 emit 사이트가 0인 production-dead metric이었습니다.

## 왜

- #20189 (Prometheus surface purge)가 `Telemetry_coverage_gap.record`의 `Prometheus.inc_counter` 블록을 삭제하면서 Otel_metric_store 대체 배선을 하지 않았습니다. 이후 coverage gap은 JSONL store에만 기록되고 metric으로는 보이지 않았습니다.
- `test_telemetry_unified` "summary surfaces coverage gaps"가 이 절단 이후 계속 실패 상태였습니다 (2026-06-10 OTel 감사에서 pre-existing 1실패로 기록).

## 어떻게

- `record`에 `Otel_metric_store_core.inc_counter` 복원 — 원래 라벨 4종(source, producer, dashboard_surface, stale_reason) 그대로, `telemetry_unified`의 sublib emit idiom과 동일.
- `lib/telemetry_coverage_gap/dune`에 `otel_metric_store` 의존 추가 (cycle 없음: otel_metric_store는 eio/mtime/masc_log만 의존).
- `test_keeper_lifecycle_hooks`의 `module P = Otel_metric_store` → `Masc.Otel_metric_store` 교정. bare 이름은 test shim(`test/deps/otel_metric_store.ml`, 자체 private store)이라 lib emit을 영원히 관측 못 해 "swallows exceptions" 단언이 0에 고정돼 있었습니다.

## 검증

- `dune build --root . @check` EXIT=0
- `dune build --root . bin/main_eio.exe` EXIT=0
- `test_telemetry_unified` 37/37 green (이전: 1 fail)
- `test_keeper_lifecycle_hooks` 7/7 green (이전: 1 fail)

## 남는 것 (별도 이슈로)

테스트 40개 파일이 여전히 bare `Otel_metric_store`(shim)를 읽습니다 — production emit을 관측할 수 없는 false-green 표면. 후속 이슈로 기록 예정.

RFC-WAIVED: telemetry emit 복원 + 테스트 교정 2-file 수정, RFC-gated subsystem(credential/operator/sandbox/hooks) 비해당.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
