### PR TITLE
fix(otel): wire keeper dashboard metrics

### DIFF
--- a/infrastructure/monitoring/grafana/provisioning/dashboards/masc-keeper-full.json
+++ b/infrastructure/monitoring/grafana/provisioning/dashboards/masc-keeper-full.json
@@ -1,0 +1,2617 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "panels": [],
+      "title": "Turn Lifecycle",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Completed turns per minute grouped by keeper.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth",
+            "pointSize": 0,
+            "showPoints": "never"
+          },
+          "unit": "cpm"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 1
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (keeper) (rate(masc_keeper_turns_total{keeper=~\"$keeper\"}[$__rate_interval])) * 60",
+          "legendFormat": "{{keeper}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Turns/min by Keeper",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Turn latency percentiles across all keepers.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "lineInterpolation": "smooth",
+            "pointSize": 0,
+            "showPoints": "never"
+          },
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 1
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum(rate(masc_keeper_turn_latency_bucket_total{keeper=~\"$keeper\"}[$__rate_interval])) by (le)) * 1000",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.9, sum(rate(masc_keeper_turn_latency_bucket_total{keeper=~\"$keeper\"}[$__rate_interval])) by (le)) * 1000",
+          "legendFormat": "p90",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(masc_keeper_turn_latency_bucket_total{keeper=~\"$keeper\"}[$__rate_interval])) by (le)) * 1000",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "Turn Latency p50 / p90 / p99",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Turn latency p90 broken down by model.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "lineInterpolation": "smooth",
+            "pointSize": 0,
+            "showPoints": "never"
+          },
+          "unit": "ms"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 1
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.9, sum(rate(masc_keeper_turn_latency_by_model_bucket_total{keeper=~\"$keeper\"}[$__rate_interval])) by (le, model)) * 1000",
+          "legendFormat": "{{model}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Turn Latency p90 by Model",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Rate of turn phase duration observations by phase name.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "lineInterpolation": "smooth",
+            "pointSize": 0,
+            "showPoints": "never"
+          },
+          "unit": "ops"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (phase) (rate(masc_keeper_turn_phase_duration_seconds_count_total{keeper=~\"$keeper\"}[$__rate_interval]))",
+          "legendFormat": "{{phase}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Turn Phase Duration",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Current rate of turn scheduling, starting, and completion.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "cpm"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Scheduled"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Started"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Completed"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(masc_keeper_turn_scheduled_total{keeper=~\"$keeper\"}[$__rate_interval])) * 60",
+          "legendFormat": "Scheduled",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(masc_keeper_turn_starts_total{keeper=~\"$keeper\"}[$__rate_interval])) * 60",
+          "legendFormat": "Started",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(rate(masc_keeper_turn_completed_total{keeper=~\"$keeper\"}[$__rate_interval])) * 60",
+          "legendFormat": "Completed",
+          "refId": "C"
+        }
+      ],
+      "title": "Scheduled vs Started vs Completed",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "panels": [],
+      "title": "FSM State Machine",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Keeper FSM edge transition rate by edge label.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "lineInterpolation": "smooth",
+            "pointSize": 0,
+            "showPoints": "never"
+          },
+          "unit": "cpm"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 18
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (edge) (rate(masc_keeper_fsm_edge_transitions_total{keeper=~\"$keeper\"}[$__rate_interval])) * 60",
+          "legendFormat": "{{edge}}",
+          "refId": "A"
+        }
+      ],
+      "title": "FSM Edge Transitions/min",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Turn-level FSM transition rate by edge.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "lineInterpolation": "smooth",
+            "pointSize": 0,
+            "showPoints": "never"
+          },
+          "unit": "cpm"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 18
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (edge) (rate(masc_keeper_turn_fsm_transitions_total{keeper=~\"$keeper\"}[$__rate_interval])) * 60",
+          "legendFormat": "{{edge}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Turn FSM Transitions",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Keeper lifecycle transition rate by transition type.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ops"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 18
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (transition) (rate(masc_keeper_lifecycle_transitions_total{keeper=~\"$keeper\"}[$__rate_interval]))",
+          "legendFormat": "{{transition}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Lifecycle Transitions",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Terminal turn gate rejections by keeper.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth",
+            "pointSize": 0,
+            "showPoints": "never"
+          },
+          "unit": "cpm"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 26
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (keeper) (rate(masc_keeper_turn_gate_rejected_terminal_total{keeper=~\"$keeper\"}[$__rate_interval])) * 60",
+          "legendFormat": "{{keeper}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Turn Gate Rejected",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Turn livelock detection blocks by keeper.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "red",
+            "mode": "fixed"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineInterpolation": "smooth",
+            "pointSize": 0,
+            "showPoints": "never"
+          },
+          "unit": "cpm"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 26
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (keeper) (rate(masc_keeper_turn_livelock_blocks_total{keeper=~\"$keeper\"}[$__rate_interval])) * 60",
+          "legendFormat": "{{keeper}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Turn Livelock Blocks",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 34
+      },
+      "panels": [],
+      "title": "Prompt & Instruction Monitoring",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Byte length of system_prompt and user_message segments per keeper.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "lineInterpolation": "smooth",
+            "pointSize": 0,
+            "showPoints": "never"
+          },
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 35
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "masc_keeper_prompt_segment_bytes{segment=\"system_prompt\", keeper=~\"$keeper\"}",
+          "legendFormat": "{{keeper}} / system_prompt",
+          "refId": "A"
+        },
+        {
+          "expr": "masc_keeper_prompt_segment_bytes{segment=\"user_message\", keeper=~\"$keeper\"}",
+          "legendFormat": "{{keeper}} / user_message",
+          "refId": "B"
+        }
+      ],
+      "title": "Prompt Segment Bytes",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Distribution of turn-intent template render outcomes.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ok"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "fallback"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "empty"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "super-light-orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 35
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (outcome) (increase(masc_keeper_prompt_template_render_outcome_total{keeper=~\"$keeper\"}[$__range]))",
+          "instant": true,
+          "legendFormat": "{{outcome}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Template Render Outcome",
+      "transparent": true,
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Hash of system+user prompt per keeper. Value changes indicate prompt reconfiguration.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 35
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      },
+      "targets": [
+        {
+          "expr": "masc_keeper_turn_instruction_hash{keeper=~\"$keeper\"}",
+          "legendFormat": "{{keeper}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Instruction Hash Timeline",
+      "transparent": true,
+      "type": "state-timeline"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Prompt rendering and injection failures by prompt type.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth",
+            "pointSize": 0,
+            "showPoints": "never"
+          },
+          "unit": "cpm"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 43
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (prompt) (rate(masc_keeper_prompt_failures_total{keeper=~\"$keeper\"}[$__rate_interval])) * 60",
+          "legendFormat": "{{prompt}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Prompt Failures",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Persona drift detection: missing persona references by keeper.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "orange",
+            "mode": "fixed"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth",
+            "pointSize": 0,
+            "showPoints": "never"
+          },
+          "unit": "cpm"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 43
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (keeper) (rate(masc_keeper_persona_drift_missing_total{keeper=~\"$keeper\"}[$__rate_interval])) * 60",
+          "legendFormat": "{{keeper}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Persona Drift Missing",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 51
+      },
+      "panels": [],
+      "title": "Tool Calls",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "90th percentile tool call duration by tool name.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "lineInterpolation": "smooth",
+            "pointSize": 0,
+            "showPoints": "never"
+          },
+          "unit": "ms"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 52
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.9, sum(rate(masc_keeper_tool_call_duration_seconds_bucket_total{keeper=~\"$keeper\"}[$__rate_interval])) by (le, tool)) * 1000",
+          "legendFormat": "{{tool}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Tool Call Duration p90",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Tool calls by parameter completeness status per tool.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*complete.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*missing.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 52
+      },
+      "options": {
+        "barWidth": 0.5,
+        "groupWidth": 0.7,
+        "legend": {
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true
+        },
+        "orientation": "horizontal",
+        "showValue": "always"
+      },
+      "targets": [
+        {
+          "expr": "sum by (tool, status) (increase(masc_keeper_tool_call_param_completeness_total{keeper=~\"$keeper\"}[$__range]))",
+          "instant": true,
+          "legendFormat": "{{tool}} / {{status}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Tool Call Param Completeness",
+      "transparent": true,
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Tool use failures by tool name.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth",
+            "pointSize": 0,
+            "showPoints": "never"
+          },
+          "unit": "cpm"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 52
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (tool) (rate(masc_keeper_tool_use_failure_total{keeper=~\"$keeper\"}[$__rate_interval])) * 60",
+          "legendFormat": "{{tool}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Tool Use Failures",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "OAS worker execution errors by keeper.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "red",
+            "mode": "fixed"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth",
+            "pointSize": 0,
+            "showPoints": "never"
+          },
+          "unit": "cpm"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 60
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (keeper) (rate(masc_keeper_oas_execution_errors_total{keeper=~\"$keeper\"}[$__rate_interval])) * 60",
+          "legendFormat": "{{keeper}}",
+          "refId": "A"
+        }
+      ],
+      "title": "OAS Execution Errors",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "OAS deterministic tool failures by keeper.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "orange",
+            "mode": "fixed"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth",
+            "pointSize": 0,
+            "showPoints": "never"
+          },
+          "unit": "cpm"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 60
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (keeper) (rate(masc_keeper_tools_oas_deterministic_failures_total{keeper=~\"$keeper\"}[$__rate_interval])) * 60",
+          "legendFormat": "{{keeper}}",
+          "refId": "A"
+        }
+      ],
+      "title": "OAS Deterministic Failures",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Circuit breaker trip events by keeper.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "dark-red",
+            "mode": "fixed"
+          },
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "lineInterpolation": "linear",
+            "pointSize": 0,
+            "showPoints": "never"
+          },
+          "unit": "cpm"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 60
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (keeper) (rate(masc_keeper_circuit_breaker_trips_total{keeper=~\"$keeper\"}[$__rate_interval])) * 60",
+          "legendFormat": "{{keeper}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Circuit Breaker Trips",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 68
+      },
+      "panels": [],
+      "title": "Token & Cost",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Input token consumption rate by keeper.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth",
+            "pointSize": 0,
+            "showPoints": "never"
+          },
+          "unit": "cpm"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 69
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "sum"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (keeper) (rate(masc_keeper_input_tokens_total{keeper=~\"$keeper\"}[$__rate_interval])) * 60",
+          "legendFormat": "{{keeper}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Input Tokens/min",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Output token generation rate by keeper.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth",
+            "pointSize": 0,
+            "showPoints": "never"
+          },
+          "unit": "cpm"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 69
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "sum"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (keeper) (rate(masc_keeper_output_tokens_total{keeper=~\"$keeper\"}[$__rate_interval])) * 60",
+          "legendFormat": "{{keeper}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Output Tokens/min",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Cache creation and read token rates.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "lineInterpolation": "smooth",
+            "pointSize": 0,
+            "showPoints": "never"
+          },
+          "unit": "cpm"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "cache_creation"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "cache_read"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "light-purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 69
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(masc_keeper_cache_creation_tokens_total{keeper=~\"$keeper\"}[$__rate_interval])) * 60",
+          "legendFormat": "cache_creation",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(masc_keeper_cache_read_tokens_total{keeper=~\"$keeper\"}[$__rate_interval])) * 60",
+          "legendFormat": "cache_read",
+          "refId": "B"
+        }
+      ],
+      "title": "Cache Tokens",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Cumulative cost in USD by keeper and total.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 4,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 50
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 77
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "masc_keeper_total_cost_usd{keeper=~\"$keeper\"}",
+          "legendFormat": "{{keeper}}",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(masc_keeper_total_cost_usd{keeper=~\"$keeper\"})",
+          "legendFormat": "TOTAL",
+          "refId": "B"
+        }
+      ],
+      "title": "Total Cost USD",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Projected hourly spend rate.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "max": 10,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 2
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 77
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(masc_keeper_total_cost_usd{keeper=~\"$keeper\"}[1h])) * 3600",
+          "legendFormat": "$/hr",
+          "refId": "A"
+        }
+      ],
+      "title": "Cost Rate $/hr",
+      "transparent": true,
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Output/Input token ratio. Higher means more efficient use of context.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 3,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.1
+              },
+              {
+                "color": "green",
+                "value": 0.3
+              }
+            ]
+          },
+          "unit": "ratio"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 77
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(masc_keeper_output_tokens_total{keeper=~\"$keeper\"}[$__rate_interval])) / sum(rate(masc_keeper_input_tokens_total{keeper=~\"$keeper\"}[$__rate_interval]))",
+          "legendFormat": "out/in ratio",
+          "refId": "A"
+        }
+      ],
+      "title": "Token Efficiency (out/in)",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 85
+      },
+      "panels": [],
+      "title": "Context & Idle",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Maximum observed context utilization ratio per keeper.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.7
+              },
+              {
+                "color": "red",
+                "value": 0.9
+              }
+            ]
+          },
+          "unit": "ratiounit"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 86
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "targets": [
+        {
+          "expr": "masc_keeper_context_max_observed_total{keeper=~\"$keeper\"}",
+          "legendFormat": "{{keeper}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Context Utilization",
+      "transparent": true,
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Current idle time in seconds by keeper.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 60
+              },
+              {
+                "color": "red",
+                "value": 300
+              }
+            ]
+          },
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 86
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "masc_keeper_idle_seconds{keeper=~\"$keeper\"}",
+          "legendFormat": "{{keeper}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Idle Seconds",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Consecutive idle turn count by keeper.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 3
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 86
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "masc_keeper_consecutive_idle{keeper=~\"$keeper\"}",
+          "legendFormat": "{{keeper}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Consecutive Idle",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Consecutive stay-silent turn count by keeper.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 3
+              },
+              {
+                "color": "orange",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 86
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "masc_keeper_stay_silent_streak{keeper=~\"$keeper\"}",
+          "legendFormat": "{{keeper}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Stay Silent Streak",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Auto-resume events by keeper.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "lineInterpolation": "smooth",
+            "pointSize": 0,
+            "showPoints": "never"
+          },
+          "unit": "cpm"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 94
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (keeper) (rate(masc_keeper_auto_resumed_total{keeper=~\"$keeper\"}[$__rate_interval])) * 60",
+          "legendFormat": "{{keeper}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Auto Resumed",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 102
+      },
+      "panels": [],
+      "title": "Compaction & Memory",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Context compaction rate by keeper.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "lineInterpolation": "smooth",
+            "pointSize": 0,
+            "showPoints": "never"
+          },
+          "unit": "cpm"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 103
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (keeper) (rate(masc_keeper_compactions_total{keeper=~\"$keeper\"}[$__rate_interval])) * 60",
+          "legendFormat": "{{keeper}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Compactions/min",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Tokens saved by compaction by keeper.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "lineInterpolation": "smooth",
+            "pointSize": 0,
+            "showPoints": "never"
+          },
+          "unit": "cpm"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 103
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (keeper) (rate(masc_keeper_compaction_saved_tokens_total{keeper=~\"$keeper\"}[$__rate_interval])) * 60",
+          "legendFormat": "{{keeper}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Compaction Saved Tokens",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Context size reduction ratio from last compaction by keeper.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.3
+              },
+              {
+                "color": "green",
+                "value": 0.5
+              }
+            ]
+          },
+          "unit": "percentunit"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 103
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "targets": [
+        {
+          "expr": "masc_keeper_compaction_ratio_change{keeper=~\"$keeper\"}",
+          "legendFormat": "{{keeper}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Compaction Ratio Change",
+      "transparent": true,
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Memory consolidation operations by keeper.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "lineInterpolation": "smooth",
+            "pointSize": 0,
+            "showPoints": "never"
+          },
+          "unit": "cpm"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 111
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (keeper) (rate(masc_keeper_memory_consolidations_total{keeper=~\"$keeper\"}[$__rate_interval])) * 60",
+          "legendFormat": "{{keeper}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Memory Consolidations",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Distribution of memory LLM summary outcomes.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "success"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "partial"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "failure"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 111
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (outcome) (increase(masc_keeper_memory_llm_summary_outcomes_total{keeper=~\"$keeper\"}[$__range]))",
+          "instant": true,
+          "legendFormat": "{{outcome}}",
+          "refId": "A"
+        }
+      ],
+      "title": "LLM Summary Outcomes",
+      "transparent": true,
+      "type": "piechart"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 119
+      },
+      "panels": [],
+      "title": "Health & Errors",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Keeper heartbeat successes per minute by keeper.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth",
+            "pointSize": 0,
+            "showPoints": "never"
+          },
+          "unit": "cpm"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 120
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (keeper) (rate(masc_keeper_heartbeat_successes_total{keeper=~\"$keeper\"}[$__rate_interval])) * 60",
+          "legendFormat": "{{keeper}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Heartbeat Success Rate",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Execution receipt processing failures by keeper.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "red",
+            "mode": "fixed"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth",
+            "pointSize": 0,
+            "showPoints": "never"
+          },
+          "unit": "cpm"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 120
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (keeper) (rate(masc_keeper_execution_receipt_failures_total{keeper=~\"$keeper\"}[$__rate_interval])) * 60",
+          "legendFormat": "{{keeper}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Execution Receipt Failures",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Directive processing failures by keeper.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "orange",
+            "mode": "fixed"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth",
+            "pointSize": 0,
+            "showPoints": "never"
+          },
+          "unit": "cpm"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 120
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (keeper) (rate(masc_keeper_directive_failures_total{keeper=~\"$keeper\"}[$__rate_interval])) * 60",
+          "legendFormat": "{{keeper}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Directive Failures",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Receipts with unmapped disposition values by keeper.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "dark-yellow",
+            "mode": "fixed"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth",
+            "pointSize": 0,
+            "showPoints": "never"
+          },
+          "unit": "cpm"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 128
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (keeper) (rate(masc_keeper_receipt_unmapped_disposition_total{keeper=~\"$keeper\"}[$__rate_interval])) * 60",
+          "legendFormat": "{{keeper}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Receipt Unmapped Disposition",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Keeper restart attempts by keeper.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "dark-red",
+            "mode": "fixed"
+          },
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "lineInterpolation": "linear",
+            "pointSize": 0,
+            "showPoints": "never"
+          },
+          "unit": "cpm"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 128
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (keeper) (rate(masc_keeper_restart_attempts_total{keeper=~\"$keeper\"}[$__rate_interval])) * 60",
+          "legendFormat": "{{keeper}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Restart Attempts",
+      "transparent": true,
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "masc",
+    "keeper",
+    "observability"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "VictoriaMetrics",
+          "value": "P4169E866C3094E38"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(masc_keeper_turns_total, keeper)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Keeper",
+        "multi": true,
+        "name": "keeper",
+        "options": [],
+        "query": {
+          "label": "Keeper",
+          "qry": "label_values(masc_keeper_turns_total, keeper)"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timezone": "browser",
+  "title": "MASC Keeper Full Observability",
+  "uid": "masc-keeper-full",
+  "version": 1
+}

--- a/lib/keeper/keeper_hooks_oas_idle.ml
+++ b/lib/keeper/keeper_hooks_oas_idle.ml
@@ -112,7 +112,15 @@ let on_idle_decision ~consecutive_idle_turns ~allowed_tools ~tool_names
   on_idle_decision_with_threshold ~skip_at ~consecutive_idle_turns
     ~allowed_tools ~tool_names
 
-let keeper_idle_decision ~meta_ref ~consecutive_idle_turns ~tool_names =
+let keeper_idle_decision
+    ~(meta_ref : Keeper_meta_contract.keeper_meta ref)
+    ~consecutive_idle_turns
+    ~tool_names =
+  let keeper_name = (!meta_ref).name in
+  Otel_metric_store.set_gauge
+    Keeper_metrics.(to_string ConsecutiveIdle)
+    ~labels:[ label_keeper, keeper_name ]
+    (Float.of_int (max 0 consecutive_idle_turns));
   let allowed_tools =
     Keeper_tool_policy.keeper_allowed_tool_names !meta_ref in
   let decision =
@@ -122,10 +130,10 @@ let keeper_idle_decision ~meta_ref ~consecutive_idle_turns ~tool_names =
     | [] -> "<none>" | names -> String.concat ", " names in
   (match decision with
    | Agent_sdk.Hooks.Skip ->
-     Log.Keeper.warn ~keeper_name:(!meta_ref).name "idle_turns=%d repeated_tools=[%s] — requesting stop"
+     Log.Keeper.warn ~keeper_name "idle_turns=%d repeated_tools=[%s] — requesting stop"
        consecutive_idle_turns tools_str
    | Agent_sdk.Hooks.Nudge _ ->
-     Log.Keeper.info ~keeper_name:(!meta_ref).name "idle_turns=%d tools=[%s] — nudging LLM via Nudge"
+     Log.Keeper.info ~keeper_name "idle_turns=%d tools=[%s] — nudging LLM via Nudge"
        consecutive_idle_turns tools_str
    | _ -> ());
   decision

--- a/lib/keeper/keeper_hooks_oas_response_metrics.ml
+++ b/lib/keeper/keeper_hooks_oas_response_metrics.ml
@@ -121,6 +121,40 @@ let record_response_content_quality_metric ~keeper_name
         ]
       ()
 
+let tool_call_duration_bucket_metric =
+  Keeper_metrics.(to_string ToolCallDurationBucket)
+
+let tool_call_duration_bucket_bounds =
+  [ 0.05, "0.05"
+  ; 0.1, "0.1"
+  ; 0.25, "0.25"
+  ; 0.5, "0.5"
+  ; 1.0, "1"
+  ; 2.5, "2.5"
+  ; 5.0, "5"
+  ; 10.0, "10"
+  ; 30.0, "30"
+  ; 60.0, "60"
+  ]
+
+let record_keeper_tool_duration_bucket ~labels duration_seconds =
+  let duration_seconds = max 0.0 duration_seconds in
+  let emit_bucket le ~increment =
+    let labels = labels @ [ "le", le ] in
+    Otel_metric_store.register_counter
+      ~name:tool_call_duration_bucket_metric
+      ~help:tool_call_duration_bucket_metric
+      ~labels
+      ();
+    if increment then
+      Otel_metric_store.inc_counter tool_call_duration_bucket_metric ~labels ()
+  in
+  List.iter
+    (fun (upper_bound, le) ->
+       emit_bucket le ~increment:(duration_seconds <= upper_bound))
+    tool_call_duration_bucket_bounds;
+  emit_bucket "+Inf" ~increment:true
+
 (* default_context_max + context_max_of_telemetry moved to
    Keeper_hooks_oas_types (intra-library file split, 2026-05-16). *)
 
@@ -157,15 +191,19 @@ let record_keeper_tool_duration_metric
     ~(keeper_name : string)
     (summary : tool_execution_summary)
   : unit =
+  let labels =
+    [label_keeper, keeper_name
+    ; label_provider, summary.provider
+    ; label_tool, summary.tool_name
+    ; label_outcome, summary.outcome
+    ]
+  in
+  let duration_seconds = summary.duration_ms /. ms_per_second in
   Otel_metric_store.observe_histogram
     Keeper_metrics.(to_string ToolCallDuration)
-    ~labels:
-      [label_keeper, keeper_name
-      ; "provider", summary.provider
-      ; "tool", summary.tool_name
-      ; "outcome", summary.outcome
-      ]
-    (summary.duration_ms /. ms_per_second)
+    ~labels
+    duration_seconds;
+  record_keeper_tool_duration_bucket ~labels duration_seconds
 
 (** Emit prompt/decode tokens-per-second histograms from an OAS turn
     response.  Safe to call with [telemetry = None] (no-op) and with

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -61,6 +61,7 @@ type t =
   | DispatchEventFailures
   | DirectiveFailures
   | ToolCallDuration
+  | ToolCallDurationBucket
   | WriteMetaFailures
   | MetaReadFailures
   | ApprovalQueueFailures
@@ -279,6 +280,7 @@ let to_string = function
   | DispatchEventFailures -> "masc_keeper_dispatch_event_failures_total"
   | DirectiveFailures -> "masc_keeper_directive_failures_total"
   | ToolCallDuration -> "masc_keeper_tool_call_duration_seconds"
+  | ToolCallDurationBucket -> "masc_keeper_tool_call_duration_seconds_bucket_total"
   | WriteMetaFailures -> "masc_keeper_write_meta_failures_total"
   | MetaReadFailures -> "masc_keeper_meta_read_failures_total"
   | ApprovalQueueFailures -> "masc_keeper_approval_queue_failures_total"
@@ -468,7 +470,7 @@ let all : t list =
     CompactionNoop; ToolPairRepair; ToolEmissionRegistrySize; ToolEmissionPushes;
     ToolUnderusedAllowedCount; ToolUnderusedAllowed; PathRejection; IdeOrphanWrites;
     PathResolverIdentityMismatch; HeartbeatSuccesses; HeartbeatFailures; CleanupTrackingFailures;
-    DispatchEventFailures; DirectiveFailures; ToolCallDuration; WriteMetaFailures;
+    DispatchEventFailures; DirectiveFailures; ToolCallDuration; ToolCallDurationBucket; WriteMetaFailures;
     MetaReadFailures; ApprovalQueueFailures; GuardsFailures; ProfileLoadFailures;
     CompactAuditFailures; CompactAuditRetentionParse; CompactAuditDrainBatches; CompactAuditDrainBatchSizeBucket;
     FsFailures; CrashPersistenceFailures; GenerationLineageFailures; KeepaliveSignalFailures;

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -52,6 +52,7 @@ type t =
   | DispatchEventFailures
   | DirectiveFailures
   | ToolCallDuration
+  | ToolCallDurationBucket
   | WriteMetaFailures
   | MetaReadFailures
   | ApprovalQueueFailures

--- a/test/dune
+++ b/test/dune
@@ -109,6 +109,8 @@
   test_masc_oas_bridge_timeout_guard
   test_keeper_llm_bridge
   test_keeper_hooks_oas_log_shape
+  test_keeper_idle_metric
+  test_keeper_tool_duration_buckets
   test_keeper_tool_use_failure_counter
   test_keeper_compaction_outcome_counter
   test_keeper_usage_trust_counter
@@ -366,6 +368,8 @@
   test_masc_oas_bridge_timeout_guard
   test_keeper_llm_bridge
   test_keeper_hooks_oas_log_shape
+  test_keeper_idle_metric
+  test_keeper_tool_duration_buckets
   test_keeper_tool_use_failure_counter
   test_keeper_compaction_outcome_counter
   test_keeper_usage_trust_counter

--- a/test/test_keeper_idle_metric.ml
+++ b/test/test_keeper_idle_metric.ml
@@ -1,0 +1,64 @@
+module HK = Masc.Keeper_hooks_oas_idle
+module Metrics = Masc.Otel_metric_store
+
+let make_meta_ref name : Masc.Keeper_meta_contract.keeper_meta ref =
+  let json : Yojson.Safe.t =
+    `Assoc
+      [ "name", `String name
+      ; "agent_name", `String name
+      ; "trace_id", `String "keeper-idle-metric-test"
+      ; "tool_access", Json_util.json_string_list []
+      ]
+  in
+  match Masc_test_deps.meta_of_json_fixture json with
+  | Ok meta -> ref meta
+  | Error e -> failwith ("make_meta_ref: " ^ e)
+
+let test_keeper_idle_decision_sets_gauge () =
+  let keeper = "test-keeper-idle-metric" in
+  let meta_ref = make_meta_ref keeper in
+  ignore
+    (HK.keeper_idle_decision
+       ~meta_ref
+       ~consecutive_idle_turns:2
+       ~tool_names:[ "keeper_board_list" ]
+      : Agent_sdk.Hooks.hook_decision);
+  Alcotest.(check (float 0.0001))
+    "consecutive idle gauge"
+    2.0
+    (Metrics.metric_value_or_zero
+       Keeper_metrics.(to_string ConsecutiveIdle)
+       ~labels:[ "keeper", keeper ]
+       ())
+
+let test_keeper_idle_decision_clamps_negative_gauge () =
+  let keeper = "test-keeper-idle-metric-negative" in
+  let meta_ref = make_meta_ref keeper in
+  ignore
+    (HK.keeper_idle_decision
+       ~meta_ref
+       ~consecutive_idle_turns:(-1)
+       ~tool_names:[]
+      : Agent_sdk.Hooks.hook_decision);
+  Alcotest.(check (float 0.0001))
+    "negative idle count clamps to zero"
+    0.0
+    (Metrics.metric_value_or_zero
+       Keeper_metrics.(to_string ConsecutiveIdle)
+       ~labels:[ "keeper", keeper ]
+       ())
+
+let () =
+  Alcotest.run
+    "keeper_idle_metric"
+    [ ( "consecutive_idle"
+      , [ Alcotest.test_case
+            "keeper_idle_decision sets gauge"
+            `Quick
+            test_keeper_idle_decision_sets_gauge
+        ; Alcotest.test_case
+            "negative count clamps to zero"
+            `Quick
+            test_keeper_idle_decision_clamps_negative_gauge
+        ] )
+    ]

--- a/test/test_keeper_tool_duration_buckets.ml
+++ b/test/test_keeper_tool_duration_buckets.ml
@@ -1,0 +1,100 @@
+module HK = Masc.Keeper_hooks_oas
+module Metrics = Masc.Otel_metric_store
+
+let keeper = "test-keeper-tool-duration-buckets"
+let tool = "keeper_board_list"
+let provider = HK.runtime_lane_label
+let outcome = "ok"
+
+let base_labels =
+  [ "keeper", keeper; "provider", provider; "tool", tool; "outcome", outcome ]
+
+let bucket_metric = Keeper_metrics.(to_string ToolCallDurationBucket)
+let duration_metric = Keeper_metrics.(to_string ToolCallDuration)
+
+let bucket_count le =
+  Metrics.metric_value_or_zero bucket_metric ~labels:(base_labels @ [ "le", le ]) ()
+
+let summary duration_ms =
+  HK.tool_execution_summary ~tool_name:tool ~model:"provider-owned-model" ~success:true
+    ~duration_ms
+
+let test_metric_names_match_dashboard_queries () =
+  Alcotest.(check string)
+    "bucket metric"
+    "masc_keeper_tool_call_duration_seconds_bucket_total"
+    bucket_metric;
+  Alcotest.(check string)
+    "duration metric"
+    "masc_keeper_tool_call_duration_seconds"
+    duration_metric
+
+let test_record_emits_sum_count_and_cumulative_buckets () =
+  let before_sum = Metrics.metric_value_or_zero duration_metric ~labels:base_labels () in
+  let before_count =
+    Metrics.metric_value_or_zero (duration_metric ^ "_count") ~labels:base_labels ()
+  in
+  let before_le_1 = bucket_count "1" in
+  let before_le_2_5 = bucket_count "2.5" in
+  let before_inf = bucket_count "+Inf" in
+  HK.record_keeper_tool_duration_metric ~keeper_name:keeper (summary 1200.0);
+  Alcotest.(check (float 0.0001))
+    "sum adds seconds"
+    (before_sum +. 1.2)
+    (Metrics.metric_value_or_zero duration_metric ~labels:base_labels ());
+  Alcotest.(check (float 0.0001))
+    "count increments"
+    (before_count +. 1.0)
+    (Metrics.metric_value_or_zero (duration_metric ^ "_count") ~labels:base_labels ());
+  Alcotest.(check (float 0.0001))
+    "lower bucket remains unchanged"
+    before_le_1
+    (bucket_count "1");
+  Alcotest.(check (float 0.0001))
+    "matching upper bucket increments"
+    (before_le_2_5 +. 1.0)
+    (bucket_count "2.5");
+  Alcotest.(check (float 0.0001))
+    "+Inf bucket increments"
+    (before_inf +. 1.0)
+    (bucket_count "+Inf")
+
+let test_record_materializes_zero_lower_bucket () =
+  let keeper = "test-keeper-tool-duration-long" in
+  let labels =
+    [ "keeper", keeper
+    ; "provider", provider
+    ; "tool", tool
+    ; "outcome", outcome
+    ]
+  in
+  let count le =
+    Metrics.metric_value_or_zero bucket_metric ~labels:(labels @ [ "le", le ]) ()
+  in
+  HK.record_keeper_tool_duration_metric ~keeper_name:keeper (summary 65_000.0);
+  Alcotest.(check (float 0.0001))
+    "finite lower bucket exists at zero"
+    0.0
+    (count "60");
+  Alcotest.(check (float 0.0001)) "+Inf increments" 1.0 (count "+Inf")
+
+let () =
+  Alcotest.run
+    "keeper_tool_duration_buckets"
+    [ ( "names"
+      , [ Alcotest.test_case
+            "match dashboard metric names"
+            `Quick
+            test_metric_names_match_dashboard_queries
+        ] )
+    ; ( "record"
+      , [ Alcotest.test_case
+            "sum count and cumulative buckets"
+            `Quick
+            test_record_emits_sum_count_and_cumulative_buckets
+        ; Alcotest.test_case
+            "long observations materialize lower buckets"
+            `Quick
+            test_record_materializes_zero_lower_bucket
+        ] )
+    ]

--- a/test/test_otel_zero_fill.ml
+++ b/test/test_otel_zero_fill.ml
@@ -50,7 +50,7 @@ let test_keeper_metrics_all_complete () =
   (* [Keeper_metrics.all] cannot be compiler-enforced without an enumerate
      ppx; this count is the drift tripwire.  If this fails after adding a
      constructor, add it to [all] as well. *)
-  check int "Keeper_metrics.all covers every constructor" 206
+  check int "Keeper_metrics.all covers every constructor" 207
     (List.length Keeper_metrics.all);
   let names = List.map Keeper_metrics.to_string Keeper_metrics.all in
   check int "to_string is injective over all"


### PR DESCRIPTION
Summary:
- emit masc_keeper_consecutive_idle from keeper idle decisions
- emit cumulative tool-call duration buckets for Grafana histogram_quantile panels
- add the live masc-keeper-full dashboard to Grafana provisioning

Tests:
- env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-codex-otel-3000 opam exec -- dune build --root . test/test_keeper_idle_metric.exe test/test_keeper_tool_duration_buckets.exe test/test_otel_zero_fill.exe
- _build-codex-otel-3000/default/test/test_keeper_idle_metric.exe
- _build-codex-otel-3000/default/test/test_keeper_tool_duration_buckets.exe
- _build-codex-otel-3000/default/test/test_otel_zero_fill.exe