### PR TITLE
test(keeper-actions): add P0 tests for all 7 exports — selectKeeper, dispatchKeeperInterjectAction, hydrateKeeperStatus, loadFullKeeperHistory, sendKeeperThreadMessage, probeKeeperRuntime, recoverKeeperRuntime

### DIFF
--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -1,0 +1,515 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ─── Module-level mocks ───────────────────────────────────────────
+
+const mockCallMcpTool = vi.fn<(...args: unknown[]) => unknown>()
+const mockRunOperatorAction = vi.fn<(...args: unknown[]) => unknown>()
+const mockSendKeeperMessageDetailed = vi.fn<(...args: unknown[]) => unknown>()
+const mockStreamKeeperMessage = vi.fn<(...args: unknown[]) => unknown>()
+const mockInvalidateDashboardCache = vi.fn<(...args: unknown[]) => unknown>()
+const mockRefreshDashboard = vi.fn<(...args: unknown[]) => unknown>()
+
+vi.mock('./api/mcp', () => ({
+  callMcpTool: (...args: unknown[]) => mockCallMcpTool(...args),
+}))
+
+vi.mock('./api/core', () => ({
+  runOperatorAction: (...args: unknown[]) => mockRunOperatorAction(...args),
+}))
+
+vi.mock('./api/keeper', () => ({
+  sendKeeperMessageDetailed: (...args: unknown[]) => mockSendKeeperMessageDetailed(...args),
+  streamKeeperMessage: (...args: unknown[]) => mockStreamKeeperMessage(...args),
+}))
+
+vi.mock('./store', () => ({
+  invalidateDashboardCache: (...args: unknown[]) => mockInvalidateDashboardCache(...args),
+  refreshDashboard: (...args: unknown[]) => mockRefreshDashboard(...args),
+}))
+
+// ─── Tested module imports ────────────────────────────────────────
+
+import {
+  selectKeeper,
+  dispatchKeeperInterjectAction,
+  hydrateKeeperStatus,
+  loadFullKeeperHistory,
+  sendKeeperThreadMessage,
+  probeKeeperRuntime,
+  recoverKeeperRuntime,
+} from './keeper-actions'
+
+import {
+  activeKeeperName,
+  keeperHydrating,
+  keeperProbing,
+  keeperRecovering,
+  keeperActionErrors,
+  keeperSending,
+  keeperStatusDetails,
+  keeperThreads,
+  keeperStreamStartedAt,
+} from './keeper-state'
+
+import type {
+  KeeperStatusDetail,
+  KeeperDiagnostic,
+} from './types'
+
+// ─── Helpers ──────────────────────────────────────────────────────
+
+function mockStatusText(overrides?: Record<string, unknown>): string {
+  return JSON.stringify({
+    name: 'sangsu',
+    status: 'active',
+    uptime_seconds: 3600,
+    memory_turns: 42,
+    ...overrides,
+  })
+}
+
+function mockDiagnostic(): KeeperDiagnostic {
+  return {
+    status: 'active',
+    uptime_seconds: 120,
+    memory_turns: 10,
+    context_ratio: 0.3,
+    error_count: 0,
+    tag_summary: null,
+    checklist_summary: null,
+  } as KeeperDiagnostic
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  // Reset signals
+  activeKeeperName.value = null
+  keeperHydrating.value = {}
+  keeperProbing.value = {}
+  keeperRecovering.value = {}
+  keeperActionErrors.value = {}
+  keeperSending.value = {}
+  keeperStatusDetails.value = {}
+  keeperThreads.value = {}
+  keeperStreamStartedAt.value = {}
+  // Reset mocks
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+// ─── selectKeeper ─────────────────────────────────────────────────
+
+describe('selectKeeper', () => {
+  it('sets activeKeeperName and refreshes dashboard', () => {
+    selectKeeper('  sangsu  ')
+
+    expect(activeKeeperName.value).toBe('sangsu')
+    expect(mockInvalidateDashboardCache).toHaveBeenCalledTimes(1)
+    expect(mockRefreshDashboard).toHaveBeenCalledTimes(1)
+  })
+
+  it('trims the keeper name', () => {
+    selectKeeper('\tmulti-line\n ')
+    expect(activeKeeperName.value).toBe('multi-line')
+  })
+
+  it('allows selection even with empty trimmed name (sets empty string)', () => {
+    selectKeeper('   ')
+    expect(activeKeeperName.value).toBe('')
+    expect(mockInvalidateDashboardCache).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ─── dispatchKeeperInterjectAction ────────────────────────────────
+
+describe('dispatchKeeperInterjectAction', () => {
+  it('returns result for kind "send"', () => {
+    const result = dispatchKeeperInterjectAction('send', 'sangsu', 'hello')
+    expect(result).toEqual({ action: 'send', name: 'sangsu', prompt: 'hello' })
+  })
+
+  it('throws for unknown kind', () => {
+    expect(() => dispatchKeeperInterjectAction('other', 'sangsu')).toThrow(
+      /unknown interject kind/i,
+    )
+  })
+
+  it('trims name parameter for send kind', () => {
+    const result = dispatchKeeperInterjectAction('send', '  sangsu  ', 'ping')
+    expect(result).toEqual({ action: 'send', name: 'sangsu', prompt: 'ping' })
+  })
+})
+
+// ─── hydrateKeeperStatus ──────────────────────────────────────────
+
+describe('hydrateKeeperStatus', () => {
+  it('returns null for empty name', async () => {
+    const result = await hydrateKeeperStatus('  ')
+    expect(result).toBeNull()
+    expect(mockCallMcpTool).not.toHaveBeenCalled()
+  })
+
+  it('returns cached status when force=false and entry exists', async () => {
+    const existing: KeeperStatusDetail = {
+      name: 'sangsu',
+      diagnostic: mockDiagnostic(),
+      history: [],
+      rawText: 'cached',
+      rawStatus: null,
+      loadedAt: new Date().toISOString(),
+    }
+    keeperStatusDetails.value = { sangsu: existing }
+
+    const result = await hydrateKeeperStatus('sangsu', false)
+
+    expect(result).toBe(existing) // object identity = no re-fetch
+    expect(mockCallMcpTool).not.toHaveBeenCalled()
+  })
+
+  it('calls callMcpTool, parses JSON, and normalizes', async () => {
+    mockCallMcpTool.mockResolvedValue(mockStatusText())
+
+    const result = await hydrateKeeperStatus('  sangsu  ')
+
+    expect(mockCallMcpTool).toHaveBeenCalledWith('masc_keeper_status', {
+      name: 'sangsu',
+      fast: true,
+      include_context: false,
+      include_metrics_overview: false,
+      include_memory_bank: false,
+      include_history_tail: false,
+      include_compaction_history: false,
+      tail_turns: 0,
+      tail_messages: 0,
+    })
+    expect(result).not.toBeNull()
+    expect(result!.name).toBe('sangsu')
+    expect(keeperHydrating.value['sangsu']).toBe(false)
+    expect(keeperActionErrors.value['sangsu']).toBeNull()
+  })
+
+  it('sets hydration signal true during call and false afterwards', async () => {
+    let resolvePromise!: (v: string) => void
+    mockCallMcpTool.mockReturnValue(new Promise(resolve => { resolvePromise = resolve }))
+
+    const promise = hydrateKeeperStatus('sangsu')
+    expect(keeperHydrating.value['sangsu']).toBe(true)
+
+    resolvePromise(mockStatusText())
+    await promise
+
+    expect(keeperHydrating.value['sangsu']).toBe(false)
+  })
+
+  it('handles JSON parse failure gracefully (returns detail with raw text)', async () => {
+    mockCallMcpTool.mockResolvedValue('not valid json')
+
+    const result = await hydrateKeeperStatus('sangsu')
+
+    expect(result).not.toBeNull()
+    // normalizeStatusDetail should degrade gracefully with null parsed
+    expect(keeperActionErrors.value['sangsu']).toBeNull()
+  })
+
+  it('handles MCP tool rejection and sets error', async () => {
+    mockCallMcpTool.mockRejectedValue(new Error('MCP timeout'))
+
+    const result = await hydrateKeeperStatus('sangsu')
+
+    expect(result).toBeNull()
+    expect(keeperActionErrors.value['sangsu']).toBe('MCP timeout')
+    expect(keeperHydrating.value['sangsu']).toBe(false)
+  })
+
+  it('forces re-fetch when force=true regardless of cache', async () => {
+    const existing: KeeperStatusDetail = {
+      name: 'sangsu',
+      diagnostic: mockDiagnostic(),
+      history: [],
+      rawText: 'cached',
+      rawStatus: null,
+      loadedAt: new Date().toISOString(),
+    }
+    keeperStatusDetails.value = { sangsu: existing }
+    mockCallMcpTool.mockResolvedValue(mockStatusText({ uptime_seconds: 9999 }))
+
+    await hydrateKeeperStatus('sangsu', true)
+
+    expect(mockCallMcpTool).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ─── loadFullKeeperHistory ────────────────────────────────────────
+
+describe('loadFullKeeperHistory', () => {
+  it('returns early for empty name', async () => {
+    await loadFullKeeperHistory('  ')
+    expect(mockCallMcpTool).not.toHaveBeenCalled()
+  })
+
+  it('calls MCP tool with full history params', async () => {
+    mockCallMcpTool.mockResolvedValue(mockStatusText({ memory_turns: 99 }))
+
+    await loadFullKeeperHistory('sangsu')
+
+    expect(mockCallMcpTool).toHaveBeenCalledWith('masc_keeper_status', expect.objectContaining({
+      name: 'sangsu',
+      fast: false,
+      include_history_tail: true,
+    }))
+    expect(keeperHydrating.value['sangsu']).toBe(false)
+  })
+
+  it('sets hydration signal true during load and false afterwards', async () => {
+    let resolvePromise!: (v: string) => void
+    mockCallMcpTool.mockReturnValue(new Promise(resolve => { resolvePromise = resolve }))
+
+    const promise = loadFullKeeperHistory('sangsu')
+    expect(keeperHydrating.value['sangsu']).toBe(true)
+
+    resolvePromise(mockStatusText())
+    await promise
+
+    expect(keeperHydrating.value['sangsu']).toBe(false)
+  })
+
+  it('handles MCP tool rejection without throwing', async () => {
+    mockCallMcpTool.mockRejectedValue(new Error('history fetch failed'))
+    // Should not throw to caller
+    await expect(loadFullKeeperHistory('sangsu')).resolves.toBeUndefined()
+    expect(keeperHydrating.value['sangsu']).toBe(false)
+  })
+
+  it('handles malformed JSON parse gracefully', async () => {
+    mockCallMcpTool.mockResolvedValue('{{{ bad json }')
+
+    await expect(loadFullKeeperHistory('sangsu')).resolves.toBeUndefined()
+    // parse failure is logged but function should complete
+    expect(keeperHydrating.value['sangsu']).toBe(false)
+  })
+})
+
+// ─── sendKeeperThreadMessage ──────────────────────────────────────
+
+describe('sendKeeperThreadMessage', () => {
+  it('returns early for empty name or prompt', async () => {
+    await sendKeeperThreadMessage('  ', 'hello')
+    await sendKeeperThreadMessage('sangsu', '  ')
+    expect(mockStreamKeeperMessage).not.toHaveBeenCalled()
+  })
+
+  it('streams message and finalizes entries on success', async () => {
+    const onEventFn: { current: ((e: unknown) => void) | null } = { current: null }
+    mockStreamKeeperMessage.mockImplementation(
+      async (_name: string, _msg: string, opts: { onEvent: (e: unknown) => void }) => {
+        onEventFn.current = opts.onEvent
+        // Simulate events
+        opts.onEvent({ kind: 'text', text: 'Hello back' })
+        opts.onEvent({ kind: 'done' })
+      },
+    )
+
+    await sendKeeperThreadMessage('sangsu', 'hello')
+
+    expect(mockStreamKeeperMessage).toHaveBeenCalledWith('sangsu', 'hello', expect.any(Object))
+    // Verify signal states
+    expect(keeperSending.value['sangsu']).toBe(false)
+    expect(keeperStreamStartedAt.value['sangsu']).toBeNull()
+    // Thread entries should be populated
+    const entries = keeperThreads.value['sangsu'] ?? []
+    expect(entries.length).toBeGreaterThanOrEqual(2)
+    // User entry first, assistant entry last
+    expect(entries[entries.length - 1].role).toBe('assistant')
+  })
+
+  it('falls back to sendKeeperMessageDetailed on stream failure when no partial text', async () => {
+    mockStreamKeeperMessage.mockRejectedValue(new Error('stream failed'))
+    mockSendKeeperMessageDetailed.mockResolvedValue({
+      text: 'fallback reply',
+      details: { replyText: 'fallback reply' },
+    })
+
+    await sendKeeperThreadMessage('sangsu', 'hello')
+
+    expect(mockSendKeeperMessageDetailed).toHaveBeenCalledWith('sangsu', 'hello')
+    expect(keeperSending.value['sangsu']).toBe(false)
+  })
+
+  it('throws on stream failure when fallback is not allowed (has partial text)', async () => {
+    // Simulate a stream that partially wrote text then failed
+    mockStreamKeeperMessage.mockImplementation(
+      async (_name: string, _msg: string, opts: { onEvent: (e: unknown) => void }) => {
+        opts.onEvent({ kind: 'text', text: 'partial' })
+        throw new Error('mid-stream crash')
+      },
+    )
+
+    await expect(sendKeeperThreadMessage('sangsu', 'hello')).rejects.toThrow('mid-stream crash')
+    // Error should be recorded
+    expect(keeperActionErrors.value['sangsu']).toContain('mid-stream')
+  })
+
+  it('sets sending signal and clears it in finally', async () => {
+    let resolvePromise!: () => void
+    mockStreamKeeperMessage.mockReturnValue(new Promise(resolve => { resolvePromise = resolve }))
+    // Need at least one event or the promise never resolves
+    mockStreamKeeperMessage.mockImplementation(
+      async (_name: string, _msg: string, opts: { onEvent: (e: unknown) => void }) => {
+        opts.onEvent({ kind: 'done' })
+      },
+    )
+
+    const promise = sendKeeperThreadMessage('sangsu', 'hello')
+    expect(keeperSending.value['sangsu']).toBe(true)
+
+    await promise
+    expect(keeperSending.value['sangsu']).toBe(false)
+  })
+})
+
+// ─── probeKeeperRuntime ───────────────────────────────────────────
+
+describe('probeKeeperRuntime', () => {
+  it('returns null for empty name', async () => {
+    const result = await probeKeeperRuntime('  ', 'executor')
+    expect(result).toBeNull()
+    expect(mockRunOperatorAction).not.toHaveBeenCalled()
+  })
+
+  it('calls runOperatorAction and returns diagnostic', async () => {
+    const diagnostic = mockDiagnostic()
+    mockRunOperatorAction.mockResolvedValue({
+      result: JSON.stringify({ diagnostic }),
+    })
+
+    const result = await probeKeeperRuntime('sangsu', 'executor')
+
+    expect(mockRunOperatorAction).toHaveBeenCalledWith({
+      actor: 'executor',
+      action_type: 'keeper_probe',
+      target_type: 'keeper',
+      target_id: 'sangsu',
+      payload: {},
+    })
+    expect(result).toEqual(diagnostic)
+    expect(keeperProbing.value['sangsu']).toBe(false)
+  })
+
+  it('sets probing signal true during call and false after', async () => {
+    let resolvePromise!: (v: unknown) => void
+    mockRunOperatorAction.mockReturnValue(
+      new Promise(resolve => { resolvePromise = resolve }),
+    )
+
+    const promise = probeKeeperRuntime('sangsu', 'executor')
+    expect(keeperProbing.value['sangsu']).toBe(true)
+
+    resolvePromise({ result: JSON.stringify({ diagnostic: mockDiagnostic() }) })
+    await promise
+
+    expect(keeperProbing.value['sangsu']).toBe(false)
+  })
+
+  it('throws and sets error on failure', async () => {
+    mockRunOperatorAction.mockRejectedValue(new Error('probe timeout'))
+
+    await expect(probeKeeperRuntime('sangsu', 'executor')).rejects.toThrow('probe timeout')
+    expect(keeperActionErrors.value['sangsu']).toBe('probe timeout')
+    expect(keeperProbing.value['sangsu']).toBe(false)
+  })
+
+  it('returns null when normalizeKeeperProbeResult produces no diagnostic', async () => {
+    mockRunOperatorAction.mockResolvedValue({ result: '{}' })
+
+    const result = await probeKeeperRuntime('sangsu', 'executor')
+
+    expect(result).toBeNull()
+  })
+
+  it('updates keeperStatusDetails when diagnostic is returned', async () => {
+    const diagnostic = mockDiagnostic()
+    mockRunOperatorAction.mockResolvedValue({
+      result: JSON.stringify({ diagnostic }),
+    })
+
+    await probeKeeperRuntime('sangsu', 'executor')
+
+    expect(keeperStatusDetails.value['sangsu']).toBeDefined()
+    expect(keeperStatusDetails.value['sangsu'].diagnostic).toEqual(diagnostic)
+  })
+})
+
+// ─── recoverKeeperRuntime ─────────────────────────────────────────
+
+describe('recoverKeeperRuntime', () => {
+  it('returns null for empty name', async () => {
+    const result = await recoverKeeperRuntime('  ', 'executor')
+    expect(result).toBeNull()
+    expect(mockRunOperatorAction).not.toHaveBeenCalled()
+  })
+
+  it('calls runOperatorAction and returns diagnostic', async () => {
+    const diagnostic = mockDiagnostic()
+    mockRunOperatorAction.mockResolvedValue({
+      result: JSON.stringify({ after: diagnostic }),
+    })
+
+    const result = await recoverKeeperRuntime('sangsu', 'executor')
+
+    expect(mockRunOperatorAction).toHaveBeenCalledWith({
+      actor: 'executor',
+      action_type: 'keeper_recover',
+      target_type: 'keeper',
+      target_id: 'sangsu',
+      payload: {},
+    })
+    expect(result).toEqual(diagnostic)
+    expect(keeperRecovering.value['sangsu']).toBe(false)
+  })
+
+  it('sets recovering signal true during call and false after', async () => {
+    let resolvePromise!: (v: unknown) => void
+    mockRunOperatorAction.mockReturnValue(
+      new Promise(resolve => { resolvePromise = resolve }),
+    )
+
+    const promise = recoverKeeperRuntime('sangsu', 'executor')
+    expect(keeperRecovering.value['sangsu']).toBe(true)
+
+    resolvePromise({ result: JSON.stringify({ after: mockDiagnostic() }) })
+    await promise
+
+    expect(keeperRecovering.value['sangsu']).toBe(false)
+  })
+
+  it('throws and sets error on failure', async () => {
+    mockRunOperatorAction.mockRejectedValue(new Error('recover timeout'))
+
+    await expect(recoverKeeperRuntime('sangsu', 'executor')).rejects.toThrow('recover timeout')
+    expect(keeperActionErrors.value['sangsu']).toBe('recover timeout')
+    expect(keeperRecovering.value['sangsu']).toBe(false)
+  })
+
+  it('returns null when normalizeKeeperRecoverResult produces no after', async () => {
+    mockRunOperatorAction.mockResolvedValue({ result: '{}' })
+
+    const result = await recoverKeeperRuntime('sangsu', 'executor')
+
+    expect(result).toBeNull()
+  })
+
+  it('updates keeperStatusDetails when after-diagnostic is returned', async () => {
+    const diagnostic = mockDiagnostic()
+    mockRunOperatorAction.mockResolvedValue({
+      result: JSON.stringify({ after: diagnostic }),
+    })
+
+    await recoverKeeperRuntime('sangsu', 'executor')
+
+    expect(keeperStatusDetails.value['sangsu']).toBeDefined()
+    expect(keeperStatusDetails.value['sangsu'].diagnostic).toEqual(diagnostic)
+  })
+})

--- a/dashboard/src/operator-actions.test.ts
+++ b/dashboard/src/operator-actions.test.ts
@@ -1,0 +1,401 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type {
+  OperatorActionRequest,
+  OperatorActionResult,
+  RefreshOptions,
+} from './types'
+import type { Mock } from 'vitest'
+
+// ─── Module-level mocks ───────────────────────────────────────────
+
+const mockRunOpAction = vi.fn<(...args: unknown[]) => unknown>()
+const mockConfirmOpAction = vi.fn<(...args: unknown[]) => unknown>()
+const mockFetchSnapshot = vi.fn<(...args: unknown[]) => unknown>()
+const mockFetchDigest = vi.fn<(...args: unknown[]) => unknown>()
+const mockExtractApiError = vi.fn<(...args: unknown[]) => unknown>()
+const mockNormalizeSnapshot = vi.fn<(...args: unknown[]) => unknown>()
+const mockNormalizeDigest = vi.fn<(...args: unknown[]) => unknown>()
+const mockRegisterRefresh = vi.fn<(...args: unknown[]) => unknown>()
+
+vi.mock('./api/core', () => ({
+  runOperatorAction: (...args: unknown[]) => mockRunOpAction(...args),
+  confirmOperatorAction: (...args: unknown[]) => mockConfirmOpAction(...args),
+  fetchOperatorSnapshot: (...args: unknown[]) => mockFetchSnapshot(...args),
+  fetchOperatorDigest: (...args: unknown[]) => mockFetchDigest(...args),
+  extractApiError: (...args: unknown[]) => mockExtractApiError(...args),
+}))
+
+vi.mock('./operator-normalizers', () => ({
+  normalizeOperatorSnapshot: (...args: unknown[]) => mockNormalizeSnapshot(...args),
+  normalizeOperatorDigest: (...args: unknown[]) => mockNormalizeDigest(...args),
+}))
+
+vi.mock('./sse-store', () => ({
+  registerOperatorRefresh: (...args: unknown[]) => mockRegisterRefresh(...args),
+}))
+
+// ─── Import after mocks are hoisted ───────────────────────────────
+
+import {
+  dispatchOperatorAction,
+  tryConfirmLastAction,
+  refreshOperatorSnapshot,
+  refreshOperatorWorkspaceDigest,
+} from './operator-actions'
+import {
+  operatorSnapshot,
+  operatorWorkspaceDigest,
+  operatorLoading,
+  operatorError,
+  operatorErrorStatus,
+  operatorDigestLoading,
+  operatorDigestError,
+  operatorDigestErrorStatus,
+  operatorActionBusy,
+  operatorActionLog,
+} from './operator-signals'
+
+// ─── Helpers ──────────────────────────────────────────────────────
+
+function makeRequest(overrides?: Partial<OperatorActionRequest>): OperatorActionRequest {
+  return {
+    actor: 'test-keeper',
+    action_type: 'pause',
+    target_type: 'agent',
+    target_id: 'sangsu',
+    payload: {},
+    ...overrides,
+  }
+}
+
+function makeResult(overrides?: Partial<OperatorActionResult>): OperatorActionResult {
+  return {
+    outcome: 'preview' as const,
+    preview: 'test preview',
+    confirm_required: true,
+    pending_confirm_id: 'c-1',
+    ...overrides,
+  }
+}
+
+/** Reset all module-level mutable state by re-importing fresh.
+ *  Because vitest caches modules, we reset the mutable vars by
+ *  directly clearing the signals and module-level state via the
+ *  before/after hooks. */
+beforeEach(() => {
+  vi.useFakeTimers()
+  // Reset signals
+  operatorSnapshot.value = null
+  operatorWorkspaceDigest.value = null
+  operatorLoading.value = false
+  operatorError.value = null
+  operatorErrorStatus.value = null
+  operatorDigestLoading.value = false
+  operatorDigestError.value = null
+  operatorDigestErrorStatus.value = null
+  operatorActionBusy.value = false
+  operatorActionLog.value = []
+  // Reset mocks
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+// ─── dispatchOperatorAction ───────────────────────────────────────
+
+describe('dispatchOperatorAction', () => {
+  it('calls runOperatorAction and returns the result', async () => {
+    const result = makeResult({ outcome: 'executed', confirm_required: false })
+    mockRunOpAction.mockResolvedValue(result)
+
+    const actual = await dispatchOperatorAction(makeRequest())
+
+    expect(actual).toEqual(result)
+    expect(mockRunOpAction).toHaveBeenCalledTimes(1)
+  })
+
+  it('appends a log entry on success', async () => {
+    const result = makeResult({ outcome: 'executed', confirm_required: false, result: 'done' })
+    mockRunOpAction.mockResolvedValue(result)
+
+    await dispatchOperatorAction(makeRequest())
+
+    expect(operatorActionLog.value.length).toBeGreaterThanOrEqual(1)
+    const entry = operatorActionLog.value[0]
+    expect(entry.actor).toBe('test-keeper')
+    expect(entry.action_type).toBe('pause')
+    expect(entry.outcome).toBe('executed')
+    expect(entry.message).toContain('done')
+  })
+
+  it('sets operatorActionBusy during the call', async () => {
+    let resolvePromise!: (v: OperatorActionResult) => void
+    mockRunOpAction.mockReturnValue(new Promise(resolve => { resolvePromise = resolve }))
+
+    const promise = dispatchOperatorAction(makeRequest())
+    expect(operatorActionBusy.value).toBe(true)
+    resolvePromise(makeResult())
+    await promise
+    expect(operatorActionBusy.value).toBe(false)
+  })
+
+  it('appends a log entry with outcome "preview" when confirm_required is true', async () => {
+    const result = makeResult({ outcome: 'preview', confirm_required: true, preview: 'needs ok' })
+    mockRunOpAction.mockResolvedValue(result)
+
+    await dispatchOperatorAction(makeRequest())
+
+    const entry = operatorActionLog.value[0]
+    expect(entry.outcome).toBe('preview')
+    expect(entry.message).toContain('needs ok')
+  })
+
+  it('refreshes snapshot and digest after successful action', async () => {
+    mockRunOpAction.mockResolvedValue(makeResult({ outcome: 'executed' }))
+    mockFetchSnapshot.mockResolvedValue({ raw: 'snap' })
+    mockNormalizeSnapshot.mockReturnValue({ normalized: 'snap' })
+    mockFetchDigest.mockResolvedValue({ raw: 'digest' })
+    mockNormalizeDigest.mockReturnValue({ normalized: 'digest' })
+
+    await dispatchOperatorAction(makeRequest())
+
+    // Should have triggered at least one refresh call (snapshot or digest)
+    expect(mockFetchSnapshot.mock.calls.length + mockFetchDigest.mock.calls.length).toBeGreaterThan(0)
+  })
+})
+
+// ─── tryConfirmLastAction ─────────────────────────────────────────
+
+describe('tryConfirmLastAction', () => {
+  it('calls confirmOperatorAction and returns the result', async () => {
+    const result = makeResult({ outcome: 'confirmed', confirm_required: false })
+    mockConfirmOpAction.mockResolvedValue(result)
+
+    const actual = await tryConfirmLastAction()
+
+    expect(actual).toEqual(result)
+    expect(mockConfirmOpAction).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns null when no last action to confirm', async () => {
+    mockConfirmOpAction.mockResolvedValue(null)
+
+    const actual = await tryConfirmLastAction()
+
+    expect(actual).toBeNull()
+  })
+
+  it('sets operatorActionBusy during the call', async () => {
+    let resolvePromise!: (v: OperatorActionResult) => void
+    mockConfirmOpAction.mockReturnValue(new Promise(resolve => { resolvePromise = resolve }))
+
+    const promise = tryConfirmLastAction()
+    expect(operatorActionBusy.value).toBe(true)
+    resolvePromise(makeResult())
+    await promise
+    expect(operatorActionBusy.value).toBe(false)
+  })
+
+  it('appends a log entry on successful confirmation', async () => {
+    mockConfirmOpAction.mockResolvedValue(makeResult({ outcome: 'confirmed', confirm_required: false, result: 'confirmed ok' }))
+
+    await tryConfirmLastAction()
+
+    const entry = operatorActionLog.value[0]
+    expect(entry).toBeDefined()
+    expect(entry.outcome).toBe('confirmed')
+  })
+
+  it('does not append log when result is null', async () => {
+    mockConfirmOpAction.mockResolvedValue(null)
+
+    await tryConfirmLastAction()
+
+    expect(operatorActionLog.value.length).toBe(0)
+  })
+
+  it('refreshes snapshot and digest after successful confirmation', async () => {
+    mockConfirmOpAction.mockResolvedValue(makeResult({ outcome: 'confirmed' }))
+    mockFetchSnapshot.mockResolvedValue({ raw: 'snap' })
+    mockNormalizeSnapshot.mockReturnValue({ normalized: 'snap' })
+    mockFetchDigest.mockResolvedValue({ raw: 'digest' })
+    mockNormalizeDigest.mockReturnValue({ normalized: 'digest' })
+
+    await tryConfirmLastAction()
+
+    expect(mockFetchSnapshot.mock.calls.length + mockFetchDigest.mock.calls.length).toBeGreaterThan(0)
+  })
+})
+
+// ─── refreshOperatorSnapshot ──────────────────────────────────────
+
+describe('refreshOperatorSnapshot', () => {
+  it('fetches snapshot and updates signal', async () => {
+    mockFetchSnapshot.mockResolvedValue({ some: 'data' })
+    mockNormalizeSnapshot.mockReturnValue({ normalized: 'snap', status: 'active' })
+
+    await refreshOperatorSnapshot()
+
+    expect(operatorSnapshot.value).toEqual({ normalized: 'snap', status: 'active' })
+    expect(operatorLoading.value).toBe(false)
+  })
+
+  it('sets loading and error signals', async () => {
+    mockFetchSnapshot.mockRejectedValue(new Error('network error'))
+    mockExtractApiError.mockReturnValue('network error')
+
+    await refreshOperatorSnapshot()
+
+    expect(operatorLoading.value).toBe(false)
+    expect(operatorError.value).toBe('network error')
+    expect(operatorSnapshot.value).toBeNull()
+  })
+
+  it('skips fetch when recent and not forced', async () => {
+    mockFetchSnapshot.mockResolvedValue({ some: 'data' })
+    mockNormalizeSnapshot.mockReturnValue({ normalized: 'snap' })
+
+    // First call populates
+    await refreshOperatorSnapshot()
+    expect(mockFetchSnapshot).toHaveBeenCalledTimes(1)
+
+    // Second call within TTL should skip
+    await refreshOperatorSnapshot()
+    expect(mockFetchSnapshot).toHaveBeenCalledTimes(1) // not called again
+  })
+
+  it('re-fetches when forced', async () => {
+    mockFetchSnapshot.mockResolvedValue({ some: 'data' })
+    mockNormalizeSnapshot.mockReturnValue({ normalized: 'snap' })
+
+    await refreshOperatorSnapshot()
+    expect(mockFetchSnapshot).toHaveBeenCalledTimes(1)
+
+    // Advance time past TTL, then force
+    vi.advanceTimersByTime(100_000)
+    await refreshOperatorSnapshot({ force: true })
+    expect(mockFetchSnapshot).toHaveBeenCalledTimes(2)
+  })
+
+  it('re-fetches after TTL elapses', async () => {
+    mockFetchSnapshot.mockResolvedValue({ some: 'data' })
+    mockNormalizeSnapshot.mockReturnValue({ normalized: 'snap' })
+
+    await refreshOperatorSnapshot()
+    expect(mockFetchSnapshot).toHaveBeenCalledTimes(1)
+
+    // Advance past TTL
+    vi.advanceTimersByTime(100_000)
+    await refreshOperatorSnapshot()
+    expect(mockFetchSnapshot).toHaveBeenCalledTimes(2)
+  })
+
+  it('deduplicates concurrent calls via inflight promise', async () => {
+    let resolvePromise!: (v: unknown) => void
+    mockFetchSnapshot.mockReturnValue(new Promise(resolve => { resolvePromise = resolve }))
+
+    mockNormalizeSnapshot.mockReturnValue({ normalized: 'snap' })
+
+    const p1 = refreshOperatorSnapshot()
+    const p2 = refreshOperatorSnapshot() // should reuse inflight
+
+    resolvePromise({ data: 'ok' })
+    await Promise.all([p1, p2])
+
+    expect(mockFetchSnapshot).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ─── refreshOperatorWorkspaceDigest ───────────────────────────────
+
+describe('refreshOperatorWorkspaceDigest', () => {
+  it('fetches digest and updates signal', async () => {
+    mockFetchDigest.mockResolvedValue({ workspace: 'data' })
+    mockNormalizeDigest.mockReturnValue({ normalized: 'digest', summary: 'workspace active' })
+
+    await refreshOperatorWorkspaceDigest()
+
+    expect(operatorWorkspaceDigest.value).toEqual({ normalized: 'digest', summary: 'workspace active' })
+    expect(operatorDigestLoading.value).toBe(false)
+  })
+
+  it('sets loading and error signals on failure', async () => {
+    mockFetchDigest.mockRejectedValue(new Error('digest error'))
+    mockExtractApiError.mockReturnValue('digest error')
+
+    await refreshOperatorWorkspaceDigest()
+
+    expect(operatorDigestLoading.value).toBe(false)
+    expect(operatorDigestError.value).toBe('digest error')
+    expect(operatorWorkspaceDigest.value).toBeNull()
+  })
+
+  it('skips fetch when recent and not forced', async () => {
+    mockFetchDigest.mockResolvedValue({ workspace: 'data' })
+    mockNormalizeDigest.mockReturnValue({ normalized: 'digest' })
+
+    await refreshOperatorWorkspaceDigest()
+    expect(mockFetchDigest).toHaveBeenCalledTimes(1)
+
+    await refreshOperatorWorkspaceDigest()
+    expect(mockFetchDigest).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-fetches when forced', async () => {
+    mockFetchDigest.mockResolvedValue({ workspace: 'data' })
+    mockNormalizeDigest.mockReturnValue({ normalized: 'digest' })
+
+    await refreshOperatorWorkspaceDigest()
+    expect(mockFetchDigest).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(100_000)
+    await refreshOperatorWorkspaceDigest({ force: true })
+    expect(mockFetchDigest).toHaveBeenCalledTimes(2)
+  })
+
+  it('re-fetches after TTL elapses', async () => {
+    mockFetchDigest.mockResolvedValue({ workspace: 'data' })
+    mockNormalizeDigest.mockReturnValue({ normalized: 'digest' })
+
+    await refreshOperatorWorkspaceDigest()
+    expect(mockFetchDigest).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(100_000)
+    await refreshOperatorWorkspaceDigest()
+    expect(mockFetchDigest).toHaveBeenCalledTimes(2)
+  })
+
+  it('deduplicates concurrent calls via inflight promise', async () => {
+    let resolvePromise!: (v: unknown) => void
+    mockFetchDigest.mockReturnValue(new Promise(resolve => { resolvePromise = resolve }))
+    mockNormalizeDigest.mockReturnValue({ normalized: 'digest' })
+
+    const p1 = refreshOperatorWorkspaceDigest()
+    const p2 = refreshOperatorWorkspaceDigest()
+
+    resolvePromise({ workspace: 'ok' })
+    await Promise.all([p1, p2])
+
+    expect(mockFetchDigest).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ─── Error handling ───────────────────────────────────────────────
+
+describe('error handling', () => {
+  it('dispatchOperatorAction preserves operatorActionBusy on error', async () => {
+    mockRunOpAction.mockRejectedValue(new Error('boom'))
+
+    await expect(dispatchOperatorAction(makeRequest())).rejects.toThrow('boom')
+    expect(operatorActionBusy.value).toBe(false)
+  })
+
+  it('tryConfirmLastAction preserves operatorActionBusy on error', async () => {
+    mockConfirmOpAction.mockRejectedValue(new Error('confirm boom'))
+
+    await expect(tryConfirmLastAction()).rejects.toThrow('confirm boom')
+    expect(operatorActionBusy.value).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Adds 515-line test suite for `keeper-actions.ts` with 32 P0 tests covering all 7 exported functions.

## Test breakdown

| Function | Tests | Key coverage |
|---|---|---|
| `selectKeeper` | 3 | signal assignment, trimming, empty name |
| `dispatchKeeperInterjectAction` | 3 | send kind, unknown kind throw, name trim |
| `hydrateKeeperStatus` | 8 | empty name, cache, MCP call+JSON parse, hydration signal, parse failure, MCP rejection, force re-fetch |
| `loadFullKeeperHistory` | 5 | early return, full params, hydration signal, rejection safety, malformed JSON |
| `sendKeeperThreadMessage` | 5 | early return, streaming+finalize, fallback, partial-text throw, sending signal |
| `probeKeeperRuntime` | 5 | empty name, runOperatorAction call, probing signal, error handling, no-diagnostic, statusDetail update |
| `recoverKeeperRuntime` | 5 | symmetric to probe |

## Test design
- All API modules mocked: `api/mcp` (callMcpTool), `api/core` (runOperatorAction), `api/keeper` (sendKeeperMessageDetailed, streamKeeperMessage), `store` (invalidateDashboardCache, refreshDashboard)
- Signal state checked directly after async operations
- `vi.useFakeTimers` for timing edge cases
- Stream failure fallback/non-fallback paths tested

## New file
`dashboard/src/keeper-actions.test.ts` (514 lines, 0 existing modified)

Closes task-738