### PR TITLE
fix(voice): enlarge playback timeout 60s→300s and restore sync contract

### DIFF
--- a/lib/config/env_config_exec_timeout.ml
+++ b/lib/config/env_config_exec_timeout.ml
@@ -122,7 +122,7 @@ let known_default_sec = function
   | Http -> Some 15.0             (* tool_local_runtime_verify probe was 15s *)
   | Startup -> Some 30.0          (* server_bootstrap docker preflight 30s *)
   | Build_identity -> Some 5.0    (* git probe was 5s *)
-  | Voice -> Some 60.0            (* local playback was 60s — under-budget regression risk *)
+  | Voice -> Some 300.0            (* local playback was 60s — under-budget regression risk *)
   | Workspace_identity -> Some 5.0    (* tty probe was 5s *)
   | Http_routes -> Some 15.0      (* workspace git command via http was 15s *)
   | Repo_manager_git -> Some 300.0 (* repo_manager git was 300s — clone/fetch on slow networks *)

--- a/lib/keeper/keeper_tool_voice_runtime.ml
+++ b/lib/keeper/keeper_tool_voice_runtime.ml
@@ -62,7 +62,7 @@ let handle_speak ~(meta : keeper_meta) ~(args : Yojson.Safe.t) =
     with
     | Some sw, Some clock, Some net ->
       (match
-         Voice_bridge.enqueue_agent_speak
+         Voice_bridge.agent_speak
            ~sw
            ~clock
            ~net


### PR DESCRIPTION
## RCA

### Defect 1 (restart-on-timeout)
`Env_config_exec_timeout.ml:125` set `Voice -> Some 60.0` — the exec gate at `voice_bridge_core.ml:230` kills the playback subprocess for audio clips longer than 60s.

**Fix:** Raise to `Some 300.0` (matches `Repo_manager_git` ceiling).

### Defect 2 (broken sync contract)
`keeper_tool_voice_runtime.ml:65` (handle_speak) called `enqueue_agent_speak` (explicitly async — returns `status="queued"` immediately). The tool caller expects a synchronous result carrying the actual playback outcome.

**Fix:** Change to `agent_speak` (synchronous — blocks until playback completes).

## Changes
- `lib/config/env_config_exec_timeout.ml`: Voice timeout 60.0 → 300.0
- `lib/keeper/keeper_tool_voice_runtime.ml`: enqueue_agent_speak → agent_speak

## Test evidence
- Build compiles (both files type-check)
- Sync contract: agent_speak returns `(Yojson.Safe.t, string) result` with `played` or `error` — no longer returns queued placeholder
- Timeout: 300s covers typical long audio clips (5 min ceiling vs previous 1 min)