### PR TITLE
feat(keeper): RFC-0223 P1 — speaker identity persistence + Discord real names

### DIFF
--- a/dashboard/src/api/schemas/keeper-chat-history.test.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.test.ts
@@ -51,6 +51,27 @@ describe('safeParseKeeperChatHistoryMessage', () => {
     expect(safeParseKeeperChatHistoryMessage(undefined)).toBeNull()
   })
 
+  it('passes RFC-0223 speaker fields through when present', () => {
+    const out = safeParseKeeperChatHistoryMessage(
+      validMessage({
+        source: 'discord',
+        speaker_id: '98791450001',
+        speaker_name: 'Minsu',
+        speaker_authority: 'external',
+      }),
+    )
+    expect(out?.speaker_id).toBe('98791450001')
+    expect(out?.speaker_name).toBe('Minsu')
+    expect(out?.speaker_authority).toBe('external')
+  })
+
+  it('accepts rows without speaker fields (legacy and non-user lines)', () => {
+    const out = safeParseKeeperChatHistoryMessage(validMessage())
+    expect(out).not.toBeNull()
+    expect(out?.speaker_id).toBeUndefined()
+    expect(out?.speaker_authority).toBeUndefined()
+  })
+
   it('composes in a filter chain — drops garbage entries silently', () => {
     const raw: unknown[] = [
       validMessage(),

--- a/dashboard/src/api/schemas/keeper-chat-history.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.ts
@@ -37,6 +37,15 @@ export const KeeperChatHistoryMessageSchema = object({
   tool_call_id: optional(string()),
   tool_call_name: optional(string()),
   source: optional(string()),
+  // RFC-0223 P1 speaker identity, present on user rows written since
+  // then. `speaker_authority` is 'owner' (authenticated dashboard
+  // operator) or 'external' (arbitrary person on a connector channel);
+  // left as open string() per the same deploy-window rationale as
+  // `role` above. id/name are absent when the route supplies none
+  // (dashboard rows carry authority only).
+  speaker_id: optional(string()),
+  speaker_name: optional(string()),
+  speaker_authority: optional(string()),
 })
 
 export type KeeperChatHistoryMessage = InferOutput<typeof KeeperChatHistoryMessageSchema>

--- a/lib/gate/discord_gateway_client.ml
+++ b/lib/gate/discord_gateway_client.ml
@@ -22,6 +22,7 @@ type gateway_event = Discord_gateway_state.dispatched_event =
       { channel_id : string
       ; message_id : string
       ; author_id : string
+      ; author_name : string option
       ; content : string
       ; mentions_bot : bool
       }

--- a/lib/gate/discord_gateway_client.mli
+++ b/lib/gate/discord_gateway_client.mli
@@ -32,6 +32,7 @@ type gateway_event = Discord_gateway_state.dispatched_event =
       { channel_id : string
       ; message_id : string
       ; author_id : string
+      ; author_name : string option
       ; content : string
       ; mentions_bot : bool
       }

--- a/lib/gate/discord_gateway_state.ml
+++ b/lib/gate/discord_gateway_state.ml
@@ -78,6 +78,7 @@ type dispatched_event =
       { channel_id : string
       ; message_id : string
       ; author_id : string
+      ; author_name : string option
       ; content : string
       ; mentions_bot : bool
       }
@@ -275,6 +276,17 @@ let decode_message_create ~bot_user_id ~payload =
     | Some a -> field_string_opt "id" a
     | None -> None
   in
+  (* RFC-0223 P1: [global_name] is the user-facing display name and is
+     nullable; [username] is the unique handle and always present on
+     real payloads. Prefer the display name. *)
+  let author_name =
+    match author with
+    | None -> None
+    | Some a -> (
+        match field_string_opt "global_name" a with
+        | Some _ as name -> name
+        | None -> field_string_opt "username" a)
+  in
   let mentions_bot =
     match bot_user_id, assoc_opt "mentions" payload with
     | None, _ | _, None -> false
@@ -291,7 +303,8 @@ let decode_message_create ~bot_user_id ~payload =
   | Some channel_id, Some message_id, Some author_id ->
       Ok
         (Message_create
-           { channel_id; message_id; author_id; content; mentions_bot })
+           { channel_id; message_id; author_id; author_name; content;
+             mentions_bot })
   | _ ->
       Error "MESSAGE_CREATE payload: missing channel_id / id / author.id"
 

--- a/lib/gate/discord_gateway_state.mli
+++ b/lib/gate/discord_gateway_state.mli
@@ -77,6 +77,10 @@ type dispatched_event =
       { channel_id : string
       ; message_id : string
       ; author_id : string
+      ; author_name : string option
+        (** Display name: [author.global_name] when set, else
+            [author.username]; [None] only when the payload carries
+            neither (RFC-0223 P1). *)
       ; content : string
       ; mentions_bot : bool
       }

--- a/lib/gate_keeper_backend.ml
+++ b/lib/gate_keeper_backend.ml
@@ -114,6 +114,14 @@ let dispatch ~sw ~clock ~proc_mgr ~net ~config
              ~channel_workspace_id ~content) );
       ("direct_reply", `Bool true);
       ("channel_session_key", `String channel_session_key);
+      (* RFC-0223 P1: raw connector identity, consumed by
+         [Keeper_tool_surface_ops.append_direct_chat_pair_if_reply] so the
+         persisted chat line carries the lane label and speaker instead
+         of the generic "agent" source. Internal-only args, same class
+         as [direct_reply] / [channel_session_key]. *)
+      ("channel", `String channel);
+      ("channel_user_id", `String channel_user_id);
+      ("channel_user_name", `String channel_user_name);
     ]
   in
   let keeper_ctx : _ Keeper_tool_surface.context = {

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -56,6 +56,25 @@ type tool_call = {
   args : string;
 }
 
+type speaker_authority =
+  | Owner
+  | External
+
+let authority_label = function
+  | Owner -> "owner"
+  | External -> "external"
+
+let authority_of_label = function
+  | "owner" -> Some Owner
+  | "external" -> Some External
+  | _ -> None
+
+type speaker = {
+  speaker_id : string option;
+  speaker_name : string option;
+  speaker_authority : speaker_authority;
+}
+
 type chat_message = {
   role : string;
   content : string;
@@ -64,14 +83,22 @@ type chat_message = {
   tool_call_id : string option;
   tool_call_name : string option;
   source : string option;
+  speaker : speaker option;
 }
 
 let opt_string_field key = function
   | None -> []
   | Some value -> [ (key, `String value) ]
 
+let speaker_fields = function
+  | None -> []
+  | Some sp ->
+      opt_string_field "speaker_id" sp.speaker_id
+      @ opt_string_field "speaker_name" sp.speaker_name
+      @ [ ("speaker_authority", `String (authority_label sp.speaker_authority)) ]
+
 let encode_line ~role ~content ~ts ?attachments ?tool_call_id ?tool_call_name
-    ?source () : string =
+    ?source ?speaker () : string =
   let base_fields = [
     ("role", `String role);
     ("content", `String content);
@@ -99,6 +126,7 @@ let encode_line ~role ~content ~ts ?attachments ?tool_call_id ?tool_call_name
     @ opt_string_field "tool_call_id" tool_call_id
     @ opt_string_field "tool_call_name" tool_call_name
     @ opt_string_field "source" source
+    @ speaker_fields speaker
   in
   Yojson.Safe.to_string (`Assoc all_fields)
 
@@ -112,15 +140,17 @@ let normalize_tool_call_id ~position call_id =
   if String.trim call_id = "" then Printf.sprintf "tc-%d" position else call_id
 
 let append_turn ~base_dir ~keeper_name ~(user_content : string)
-    ~(user_attachments : attachment list) ?(tool_calls = []) ?source
+    ~(user_attachments : attachment list) ?(tool_calls = []) ?source ?speaker
     ~(assistant_content : string) () =
   try
     ensure_dir_once ~base_dir;
     let path = chat_path ~base_dir ~keeper_name in
     let ts = Time_compat.now () in
+    (* Speaker identity belongs to the user line only: tool and
+       assistant lines are the keeper's own output. *)
     let user_line =
       encode_line ~role:"user" ~content:user_content ~ts
-        ~attachments:user_attachments ?source ()
+        ~attachments:user_attachments ?source ?speaker ()
     in
     let tool_lines =
       List.mapi
@@ -166,6 +196,35 @@ let parse_line ~file_path (line : string) : chat_message option =
     let tool_call_id = opt_string "tool_call_id" in
     let tool_call_name = opt_string "tool_call_name" in
     let source = opt_string "source" in
+    let speaker =
+      let speaker_id = opt_string "speaker_id" in
+      let speaker_name = opt_string "speaker_name" in
+      match opt_string "speaker_authority" with
+      | Some label -> (
+          match authority_of_label label with
+          | Some speaker_authority ->
+              Some { speaker_id; speaker_name; speaker_authority }
+          | None ->
+              (* Unknown authority label: surface it instead of guessing
+                 a class; the row itself stays valid. *)
+              report_persistence_read_drop
+                ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
+                ~path:file_path
+                ~detail:
+                  (Printf.sprintf "unknown speaker_authority %S" label);
+              None)
+      | None ->
+          (match speaker_id, speaker_name with
+           | None, None -> ()
+           | _ ->
+               (* id/name without an authority class never comes from our
+                  writer; report so the producer gets fixed. *)
+               report_persistence_read_drop
+                 ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
+                 ~path:file_path
+                 ~detail:"speaker_id/speaker_name without speaker_authority");
+          None
+    in
     let attachments =
       match Json_util.assoc_member_opt "attachments" json with
       | Some (`List att_list) ->
@@ -200,7 +259,10 @@ let parse_line ~file_path (line : string) : chat_message option =
         ~path:file_path
         ~detail:"tool chat row missing non-empty tool_call_name";
       None)
-    else Some { role; content; ts; attachments; tool_call_id; tool_call_name; source }
+    else
+      Some
+        { role; content; ts; attachments; tool_call_id; tool_call_name;
+          source; speaker }
   with Yojson.Json_error detail ->
     report_persistence_read_drop
       ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
@@ -287,6 +349,7 @@ let to_json_array (messages : chat_message list) : Yojson.Safe.t =
               @ opt_string_field "tool_call_id" m.tool_call_id
               @ opt_string_field "tool_call_name" m.tool_call_name
               @ opt_string_field "source" m.source
+              @ speaker_fields m.speaker
               @ (match m.attachments with
                  | None | Some [] -> []
                  | Some atts ->

--- a/lib/keeper/keeper_chat_store.mli
+++ b/lib/keeper/keeper_chat_store.mli
@@ -32,6 +32,27 @@ type tool_call = {
   args : string;
 }
 
+(** Authority class of the human (or agent) whose message opened a
+    turn. Derived structurally from the arrival route, never from
+    message content: the authenticated dashboard route is [Owner];
+    anything carrying connector context is [External]. Persisted as
+    ["owner"] / ["external"] in [speaker_authority] (RFC-0223 §3). *)
+type speaker_authority =
+  | Owner
+  | External
+
+val authority_label : speaker_authority -> string
+val authority_of_label : string -> speaker_authority option
+
+(** Identity of the user-line author. [speaker_id] / [speaker_name] are
+    absent when the route supplies none (the dashboard is a single
+    authenticated operator and carries no per-user identity). *)
+type speaker = {
+  speaker_id : string option;
+  speaker_name : string option;
+  speaker_authority : speaker_authority;
+}
+
 type chat_message = {
   role : string;
   content : string;
@@ -40,15 +61,22 @@ type chat_message = {
   tool_call_id : string option;
   tool_call_name : string option;
   source : string option;
+  speaker : speaker option;
+      (** Present on user lines written since RFC-0223 P1; [None] on
+          older lines, tool/assistant lines, and lines whose persisted
+          [speaker_authority] label fails to parse (reported as a
+          persistence read drop, row otherwise kept). *)
 }
 
 (** {1 I/O} *)
 
 (** [append_turn ~base_dir ~keeper_name ~user_content ~user_attachments
-    ?tool_calls ?source ~assistant_content ()] appends one completed
-    turn as consecutive lines — user, one line per tool call, assistant
-    — sharing a single timestamp, in one write. Failures are logged but
-    never raised except for {!Eio.Cancel.Cancelled}. *)
+    ?tool_calls ?source ?speaker ~assistant_content ()] appends one
+    completed turn as consecutive lines — user, one line per tool call,
+    assistant — sharing a single timestamp, in one write. [speaker]
+    identifies the user-line author and is written on the user line
+    only. Failures are logged but never raised except for
+    {!Eio.Cancel.Cancelled}. *)
 val append_turn :
   base_dir:string ->
   keeper_name:string ->
@@ -56,6 +84,7 @@ val append_turn :
   user_attachments:attachment list ->
   ?tool_calls:tool_call list ->
   ?source:string ->
+  ?speaker:speaker ->
   assistant_content:string ->
   unit ->
   unit
@@ -70,6 +99,7 @@ val load :
 (** {1 Serialisation} *)
 
 (** JSON array of messages. Entries without a timestamp omit the
-    [ts] field; [tool_call_id] / [tool_call_name] / [source] appear
-    only when present. *)
+    [ts] field; [tool_call_id] / [tool_call_name] / [source] /
+    [speaker_id] / [speaker_name] / [speaker_authority] appear only
+    when present. *)
 val to_json_array : chat_message list -> Yojson.Safe.t

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -543,15 +543,38 @@ let append_direct_chat_pair_if_reply ~(config : Workspace.config) ~name ~args re
         (* Agent-initiated [masc_keeper_msg] path: only the final tool
            result is visible here (no stream events), so no tool lines
            are persisted for this surface. *)
+        (* RFC-0223 P1: the channel gate routes connector traffic
+           (Discord, openclaw, ...) through this same tool path and
+           passes its identity in [channel] / [channel_user_id] /
+           [channel_user_name] ([Gate_keeper_backend.dispatch]). With
+           them present the line carries the lane label and an External
+           speaker instead of the generic "agent" source; without them
+           this is a genuine agent-initiated message. *)
+        let channel = String.trim (get_string args "channel" "") in
+        let source, speaker =
+          if channel = "" then ("agent", None)
+          else
+            let opt key =
+              match String.trim (get_string args key "") with
+              | "" -> None
+              | value -> Some value
+            in
+            ( channel,
+              Some
+                { Keeper_chat_store.speaker_id = opt "channel_user_id";
+                  speaker_name = opt "channel_user_name";
+                  speaker_authority = Keeper_chat_store.External } )
+        in
         Keeper_chat_store.append_turn
           ~base_dir:config.base_path
           ~keeper_name:name
           ~user_content
           ~user_attachments:[]
-          ~source:"agent"
+          ~source
+          ?speaker
           ~assistant_content
           ();
-        Keeper_chat_broadcast.chat_appended ~keeper_name:name ~source:"agent")
+        Keeper_chat_broadcast.chat_appended ~keeper_name:name ~source)
 ;;
 
 (* RFC-0182 Phase 5 PR-B: ctx-free body for [masc_keeper_msg] descriptor

--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -69,9 +69,10 @@ let handle_message_create ~dispatch
       { channel = State.channel
       ; channel_user_id = author_id
       ; channel_user_name = Option.value author_name ~default:author_id
-        (* Display name ([global_name] else [username], RFC-0223 P1);
-           the snowflake stands in only for malformed payloads missing
-           both, keeping the gate's required field non-empty. *)
+        (* NDT-OK: display name ([global_name] else [username], RFC-0223
+           P1); the snowflake stands in only for malformed payloads
+           missing both — the gate contract requires a non-empty name,
+           and the id fallback preserves the pre-P1 behavior. *)
       ; channel_workspace_id = channel_id
       ; keeper_name
       ; content

--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -57,7 +57,8 @@ let resolved_trigger_policy () =
 
 let handle_message_create ~dispatch
       ~(channel_id : string) ~(message_id : string)
-      ~(author_id : string) ~(content : string) =
+      ~(author_id : string) ~(author_name : string option)
+      ~(content : string) =
   match State.keeper_for_channel ~channel_id with
   | None ->
     (* No binding for this channel — drop quietly. The bot may be in
@@ -67,12 +68,10 @@ let handle_message_create ~dispatch
     let msg : Channel_gate.inbound_message =
       { channel = State.channel
       ; channel_user_id = author_id
-      ; channel_user_name = author_id
-        (* The Gateway MESSAGE_CREATE payload carries author.username
-           and author.global_name but [Discord_gateway_state.decode_message_create]
-           currently extracts only [author_id]. Keeping the user
-           identity stable (id only) is acceptable for keeper
-           context; richer display naming is a follow-up. *)
+      ; channel_user_name = Option.value author_name ~default:author_id
+        (* Display name ([global_name] else [username], RFC-0223 P1);
+           the snowflake stands in only for malformed payloads missing
+           both, keeping the gate's required field non-empty. *)
       ; channel_workspace_id = channel_id
       ; keeper_name
       ; content
@@ -99,10 +98,13 @@ let on_event ~dispatch (ev : Gw.gateway_event) =
   match ev with
   | Gw.Ready { bot_user_id; _ } ->
     Log.Server.info "Discord gateway READY (bot_user_id=%s)" bot_user_id
-  | Gw.Message_create { channel_id; message_id; author_id; content; mentions_bot = _ } ->
+  | Gw.Message_create
+      { channel_id; message_id; author_id; author_name; content;
+        mentions_bot = _ } ->
     (* mentions_bot is already enforced by the trigger policy at the
        gateway-state layer; nothing extra to check here. *)
-    handle_message_create ~dispatch ~channel_id ~message_id ~author_id ~content
+    handle_message_create ~dispatch ~channel_id ~message_id ~author_id
+      ~author_name ~content
   | Gw.Reaction_add _ ->
     (* The previous Python sidecar used a configurable emoji
        trigger to drain pending messages. That feature is dropped in

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -599,6 +599,22 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
   let chat_source =
     if has_connector_context then payload.channel else "dashboard"
   in
+  (* RFC-0223 P1: authority derives from the arrival route. Connector
+     context means an arbitrary external person on that channel; its
+     absence means the authenticated dashboard operator (the route is
+     bearer-gated, and the dashboard supplies no per-user identity). *)
+  let chat_speaker : Keeper_chat_store.speaker =
+    if has_connector_context then
+      { speaker_id = Some payload.channel_user_id;
+        speaker_name =
+          (let name = String.trim payload.channel_user_name in
+           if name = "" then None else Some name);
+        speaker_authority = Keeper_chat_store.External }
+    else
+      { speaker_id = None;
+        speaker_name = None;
+        speaker_authority = Keeper_chat_store.Owner }
+  in
   let on_event evt =
     record_tool_event evt;
     push_worker_event (Stream_event evt)
@@ -611,6 +627,7 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
       ~user_attachments:payload.attachments
       ~tool_calls:(collected_tool_calls ())
       ~source:chat_source
+      ~speaker:chat_speaker
       ~assistant_content:(persisted_error_reply err)
       ();
     Keeper_chat_broadcast.chat_appended
@@ -655,6 +672,7 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
                 ~user_attachments:payload.attachments
                 ~tool_calls:(collected_tool_calls ())
                 ~source:chat_source
+                ~speaker:chat_speaker
                 ~assistant_content:visible_reply
                 ();
               Keeper_chat_broadcast.chat_appended

--- a/test/test_discord_gateway_state.ml
+++ b/test/test_discord_gateway_state.ml
@@ -295,17 +295,27 @@ let test_heartbeat_tick_when_connected () =
 (* ---------------------------------------------------------------- *)
 
 let message_create_payload
-    ~id ~channel_id ~author_id ~content ~mention_ids () : Yojson.Safe.t =
+    ~id ~channel_id ~author_id ?username ?global_name ~content ~mention_ids ()
+    : Yojson.Safe.t =
   let mentions =
     `List
       (List.map
          (fun uid -> `Assoc [ ("id", `String uid) ])
          mention_ids)
   in
+  let author_fields =
+    ("id", `String author_id)
+    :: (match username with
+        | Some u -> [ ("username", `String u) ]
+        | None -> [])
+    @ (match global_name with
+       | Some g -> [ ("global_name", `String g) ]
+       | None -> [])
+  in
   `Assoc
     [ ("id", `String id)
     ; ("channel_id", `String channel_id)
-    ; ("author", `Assoc [ ("id", `String author_id) ])
+    ; ("author", `Assoc author_fields)
     ; ("content", `String content)
     ; ("mentions", mentions)
     ]
@@ -346,12 +356,55 @@ let test_decode_message_create_with_mention () =
         { channel_id = "CH1"
         ; message_id = "MSG1"
         ; author_id = "USER1"
+        ; author_name = None
         ; content = "@BOT hi"
         ; mentions_bot = true
         }) ->
       ()
   | Ok _ -> fail "decoded wrong MESSAGE_CREATE fields"
   | Error msg -> fail msg
+
+(* RFC-0223 P1 — author display name extraction. *)
+
+let decode_author_name ~payload =
+  match
+    S.decode_dispatch
+      ~bot_user_id:(Some "BOT")
+      ~event_name:"MESSAGE_CREATE"
+      ~payload
+  with
+  | Ok (S.Message_create { author_name; _ }) -> author_name
+  | Ok _ -> fail "expected MESSAGE_CREATE"
+  | Error msg -> fail msg
+
+let test_decode_author_name_prefers_global_name () =
+  let payload =
+    message_create_payload
+      ~id:"MSG10" ~channel_id:"CH1" ~author_id:"USER1"
+      ~username:"minsu_handle" ~global_name:"Minsu"
+      ~content:"hi" ~mention_ids:[] ()
+  in
+  Alcotest.(check (option string)) "global_name wins"
+    (Some "Minsu") (decode_author_name ~payload)
+
+let test_decode_author_name_falls_back_to_username () =
+  let payload =
+    message_create_payload
+      ~id:"MSG11" ~channel_id:"CH1" ~author_id:"USER1"
+      ~username:"minsu_handle"
+      ~content:"hi" ~mention_ids:[] ()
+  in
+  Alcotest.(check (option string)) "username fallback"
+    (Some "minsu_handle") (decode_author_name ~payload)
+
+let test_decode_author_name_absent_when_payload_has_neither () =
+  let payload =
+    message_create_payload
+      ~id:"MSG12" ~channel_id:"CH1" ~author_id:"USER1"
+      ~content:"hi" ~mention_ids:[] ()
+  in
+  Alcotest.(check (option string)) "no name fields -> None"
+    None (decode_author_name ~payload)
 
 let test_decode_message_create_without_mention () =
   let payload =
@@ -921,6 +974,12 @@ let () =
             `Quick test_decode_message_create_with_mention
         ; test_case "MESSAGE_CREATE without mention sets mentions_bot=false"
             `Quick test_decode_message_create_without_mention
+        ; test_case "author_name prefers global_name" `Quick
+            test_decode_author_name_prefers_global_name
+        ; test_case "author_name falls back to username" `Quick
+            test_decode_author_name_falls_back_to_username
+        ; test_case "author_name absent when payload has neither" `Quick
+            test_decode_author_name_absent_when_payload_has_neither
         ; test_case "MESSAGE_REACTION_ADD unicode emoji" `Quick
             test_decode_reaction_add_unicode
         ; test_case "MESSAGE_REACTION_ADD custom emoji => name:id" `Quick

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -143,6 +143,96 @@ let test_legacy_lines_parse_without_new_fields () =
       | messages ->
           Alcotest.failf "expected 2 messages, got %d" (List.length messages))
 
+(* RFC-0223 P1 — speaker identity round-trips on the user line only. *)
+
+let speaker_label (msg : K.chat_message) =
+  match msg.speaker with
+  | None -> "absent"
+  | Some sp -> K.authority_label sp.speaker_authority
+
+let test_speaker_external_roundtrip () =
+  let base_dir = temp_base_path "keeper-chat-store-speaker-ext" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-speaker-ext" in
+      K.append_turn ~base_dir ~keeper_name
+        ~user_content:"hello from discord"
+        ~user_attachments:[]
+        ~source:"discord"
+        ~speaker:
+          { K.speaker_id = Some "98791450001";
+            speaker_name = Some "minsu";
+            speaker_authority = K.External }
+        ~assistant_content:"hi minsu"
+        ();
+      match K.load ~base_dir ~keeper_name with
+      | [ user; assistant ] ->
+          (match user.speaker with
+           | Some sp ->
+               Alcotest.(check (option string)) "speaker id persisted"
+                 (Some "98791450001") sp.K.speaker_id;
+               Alcotest.(check (option string)) "speaker name persisted"
+                 (Some "minsu") sp.K.speaker_name;
+               Alcotest.(check string) "authority external"
+                 "external" (K.authority_label sp.K.speaker_authority)
+           | None -> Alcotest.fail "user line lost its speaker");
+          Alcotest.(check string) "assistant line carries no speaker"
+            "absent" (speaker_label assistant)
+      | messages ->
+          Alcotest.failf "expected 2 messages, got %d" (List.length messages))
+
+let test_speaker_owner_roundtrip () =
+  let base_dir = temp_base_path "keeper-chat-store-speaker-own" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-speaker-own" in
+      K.append_turn ~base_dir ~keeper_name
+        ~user_content:"deploy it"
+        ~user_attachments:[]
+        ~source:"dashboard"
+        ~speaker:
+          { K.speaker_id = None;
+            speaker_name = None;
+            speaker_authority = K.Owner }
+        ~assistant_content:"deploying"
+        ();
+      match K.load ~base_dir ~keeper_name with
+      | [ user; _assistant ] -> (
+          match user.speaker with
+          | Some sp ->
+              Alcotest.(check (option string)) "owner has no id"
+                None sp.K.speaker_id;
+              Alcotest.(check string) "authority owner"
+                "owner" (K.authority_label sp.K.speaker_authority)
+          | None -> Alcotest.fail "owner speaker lost")
+      | messages ->
+          Alcotest.failf "expected 2 messages, got %d" (List.length messages))
+
+let test_unknown_speaker_authority_reported_not_guessed () =
+  let base_dir = temp_base_path "keeper-chat-store-speaker-bad" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-speaker-bad" in
+      let path = chat_path ~base_dir ~keeper_name in
+      let invalid_payload = Safe_ops.persistence_read_drop_reason_invalid_payload in
+      let before = drop_value invalid_payload in
+      write_file path
+        ({|{"role":"user","content":"hi","ts":1.0,"speaker_id":"x","speaker_authority":"admin"}|}
+        ^ "\n");
+      (match K.load ~base_dir ~keeper_name with
+       | [ user ] ->
+           Alcotest.(check string)
+             "unknown authority yields no speaker, row kept"
+             "absent" (speaker_label user)
+       | messages ->
+           Alcotest.failf "expected 1 message, got %d" (List.length messages));
+      Alcotest.(check (float 0.001)) "unknown authority counted as drop"
+        1.0
+        (drop_value invalid_payload -. before))
+
 let test_tool_row_missing_name_dropped () =
   let base_dir = temp_base_path "keeper-chat-store-toolname" in
   Fun.protect
@@ -219,6 +309,15 @@ let () =
             test_load_records_malformed_row_drops;
           Alcotest.test_case "tool row without name dropped" `Quick
             test_tool_row_missing_name_dropped;
+        ] );
+      ( "speaker_identity",
+        [
+          Alcotest.test_case "external speaker roundtrip" `Quick
+            test_speaker_external_roundtrip;
+          Alcotest.test_case "owner speaker roundtrip" `Quick
+            test_speaker_owner_roundtrip;
+          Alcotest.test_case "unknown authority reported, not guessed" `Quick
+            test_unknown_speaker_authority_reported_not_guessed;
         ] );
       ( "tool_call_persistence",
         [


### PR DESCRIPTION
## RFC-0223 P1 — speaker 영속화 + Discord 실명 파싱

RFC-0223 (§4 P1) 구현. 화자 신원이 턴 프롬프트(텍스트 블록)까지는 오지만 영속화에서 죽던 문제를 닫습니다.

### 변경

**store** (`keeper_chat_store`)
- `speaker_authority = Owner | External` closed sum + `speaker` 레코드 (`speaker_id`/`speaker_name` option)
- `chat_message.speaker : speaker option`, `append_turn ?speaker` — user 라인에만 기록 (tool/assistant는 keeper 출력)
- 디스크 키: `speaker_id` / `speaker_name` / `speaker_authority`("owner"|"external"), 구 라인 호환 (필드 부재 = `None`)
- 알 수 없는 authority 라벨: 추측 없이 persistence read drop 보고 + 행 유지

**identity 배선**
- stream route: connector context 있으면 `External {channel_user_id, channel_user_name}`, 없으면 인증된 대시보드 = `Owner` (구조 파생, 내용 추론 없음)
- gate dispatch → `masc_keeper_msg` args에 `channel`/`channel_user_id`/`channel_user_name` 추가 (internal-only, `direct_reply`와 동급)
- `append_direct_chat_pair_if_reply`: gate 경유면 **source = 채널 라벨 + External speaker** (기존엔 Discord 인입도 `"agent"`로 오기록 — P3 lane read의 전제라 함께 교정), 순수 agent 발화는 기존대로 `"agent"`

**Discord 실명**
- `decode_message_create`가 `author.global_name` → `author.username` 순으로 `author_name : string option` 추출 (기존엔 snowflake가 이름 자리 차지)
- `dispatched_event`/`gateway_event` 등식 4파일 동기 변경, in-process gateway가 실명 전달 (둘 다 없는 기형 payload만 id로 대체)

**dashboard**
- `keeper-chat-history` valibot 스키마에 3필드 optional 통과 배선 (렌더링은 후속)

### 검증
- `dune build @check` EXIT=0, default target 빌드 EXIT=0 (별도 확인)
- `test_keeper_chat_store` 9/9 (신규: external/owner round-trip, unknown-authority drop 보고)
- `test_discord_gateway_state` 41/41 (신규: global_name 우선/username fallback/부재 3종)
- dashboard `tsc --noEmit` 0 errors (main node_modules symlink + 직접 실행), `keeper-chat-history.test.ts` vitest 8/8 (신규 2)

### 비범위
- presence world prompt (P2), `keeper_surface_read`/`post` (P3/P4)
- gate 경로 user_content의 `[External channel context]` 블록 중복 제거 (speaker가 구조화됐으므로 후속에서 정리 가능)

RFC: docs/rfc/RFC-0223-typed-connector-surfaces-presence-pull-speaker.md (§4 P1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
