### PR TITLE
fix(voice): restore sync contract in handle_speak (agent_speak not enqueue_agent_speak)

### DIFF
--- a/lib/keeper/keeper_tool_voice_runtime.ml
+++ b/lib/keeper/keeper_tool_voice_runtime.ml
@@ -112,7 +112,7 @@ let handle_speak
     with
     | Some sw, Some clock, Some net ->
       (match
-         Voice_bridge.enqueue_agent_speak
+         Voice_bridge.agent_speak
            ~sw
            ~clock
            ~net


### PR DESCRIPTION
## Defect

`handle_speak` at `keeper_tool_voice_runtime.ml:115` called `enqueue_agent_speak` — an async queue function that returns `status="queued"` immediately. The tool contract expects a synchronous result carrying the actual playback outcome.

## Fix

Changed to `agent_speak` (synchronous — blocks until playback completes, returns `played` or `error` instead of `queued`).

Both signatures return `(Yojson.Safe.t, string) result`, so the call site compiles identically. The semantic change is that the response now reflects actual playback status.

## Timeline

- The 60s playback timeout restart defect (Defect 1) was already resolved upstream by #20512 (`8cf76afa`) which deleted the caller-side timeout wrapper entirely.
- This PR contains **only** the sync-contract fix (Defect 2).

## RCA references
- `keeper_tool_voice_runtime.ml:115` — enqueue_agent_speak → agent_speak
- `voice_bridge.mli:45-56` — both agent_speak and enqueue_agent_speak share the same return type