### PR TITLE
fix(lint): restore SSOT R6 ratchet broken by gate-skipped docs PRs

### DIFF
--- a/docs/rfc/RFC-0223-typed-connector-surfaces-presence-pull-speaker.md
+++ b/docs/rfc/RFC-0223-typed-connector-surfaces-presence-pull-speaker.md
@@ -39,7 +39,7 @@ gateway is alive, or that it could be spoken through.
 ### 1.2 No pull: lane history exists on disk but is unreachable from a turn
 
 Every connector's traffic is already persisted into one JSONL per keeper
-(`~/.masc/keeper_chat/<name>.jsonl`) with a `source` label
+(`<base-path>/.masc/keeper_chat/<name>.jsonl`) with a `source` label
 (`keeper_chat_store.mli:35-43` **(verified)**). The only reader is the
 dashboard hydration endpoint `GET /api/v1/keepers/:name/chat/history`
 (`server_dashboard_http_keeper_api.ml:28-39` **(verified)**). The keeper

--- a/docs/rfc/RFC-0224-structured-completion-report.md
+++ b/docs/rfc/RFC-0224-structured-completion-report.md
@@ -30,7 +30,7 @@ A task may pre-declare a `completion_contract : string list` (free-text checklis
 Facts about the current state **(verified 2026-06-10)**:
 
 - `MASC_VERIFICATION_FSM_ENABLED` default = `true` (`feature_flag_registry.ml:197-200`, since 0.9.3).
-- The legacy gate's only firing signature (`"contract unmet (legacy)"` / `"completion contract not satisfied"`) appears **0 times** in June `~/.masc/logs/system_log_*.jsonl` — the substring gate is dead on the production path.
+- The legacy gate's only firing signature (`"contract unmet (legacy)"` / `"completion contract not satisfied"`) appears **0 times** in June `<base-path>/.masc/logs/system_log_*.jsonl` — the substring gate is dead on the production path.
 - PR #20699 (closed 2026-06-10) added a word-boundary token fallback to the dead gate, claiming to fix the task-716 rejection cycle. The matching predicate was well-built and tested, but it strengthened a string classifier (CLAUDE.md workaround signature #2) on a path that never executes; the actual task-716 rejections came from the live Gate 3 / evidence-gate lane.
 
 The structural defect, independent of which layer fires: **the producer's claim of contract satisfaction is inferred from prose** — by substring in the dead lane, by an LLM reading unstructured notes in the live lane. A keeper can rationalize by silence: notes that simply never mention an obligation force the judge to infer the omission. That inference step is where both the false-reject churn (task-716 style) and the rationalization risk live.

--- a/scripts/check-ssot.sh
+++ b/scripts/check-ssot.sh
@@ -100,7 +100,7 @@ check_rule "R5-health-path" 0 \
 
 # SSOT-R6 — no home-anchored MASC runtime root. Runtime state must resolve
 # from an explicit base path and then append .masc.
-check_rule "R6-home-masc-root" 10 \
+check_rule "R6-home-masc-root" 9 \
   "<base-path>/.masc with explicit MASC_BASE_PATH or --base-path" \
   '(\$HOME|\$\{HOME[^}]*\}|~)/[^[:space:]`'\''"]*\.masc([/[:space:]`'\''".,)]|$)' \
   '' \


### PR DESCRIPTION
## 무엇

main의 Lint(`Check SSOT bypass ratchet`, R6-home-masc-root)가 11/10으로 깨진 것을 복구합니다.

## 원인

docs-only PR #20717, #20718이 각각 bare `~/.masc` 런타임 경로 표기를 추가했는데, 두 PR 모두 `Detect Changed Surfaces` 게이트가 Lint job을 스킵해 ratchet이 실행되지 않은 채 머지되었습니다. 이후 Lint를 실제로 실행하는 모든 PR(예: #20724)이 본인 변경과 무관하게 red가 됩니다.

- 검증: `origin/main`(`425770ae9`) 클린 worktree에서 `bash scripts/check-ssot.sh` 실행 → `ERROR[R6-home-masc-root]: 11 (baseline 10)` 재현
- baseline 10의 마지막 검증 시점은 `c4df7c44d`(2026-06-05), 11번째/12번째 표기는 모두 오늘 추가

## 변경

1. `RFC-0223-typed-connector-surfaces` L42, `RFC-0224-structured-completion-report` L33의 bare `~/.masc`를 `<base-path>/.masc`로 교정 — `docs/BOOT-ENV-STATE-INVENTORY.md` 표기 규칙 준수 (bare `~/.masc`는 shell에서 `$HOME/.masc`로 해석되어 사실관계도 틀림)
2. baseline 10 → 9 paired-update (교정 후 실측 9)

## 검증

- `bash scripts/check-ssot.sh` → `OK[R6-home-masc-root]: 9 (baseline 9)`, 전체 룰 ERROR 0

## 후속 (별도)

docs-only PR이 ratchet 스크립트 변경 없이도 ratchet 카운트에 영향을 줄 수 있으므로, `Detect Changed Surfaces` 게이트가 `docs/` 변경 시에도 `check-ssot.sh`(R6는 docs를 스캔함)를 실행하도록 조정 필요 — 이슈로 기록 예정. 게이트-스킵 broken main은 #19327/#19340에 이어 재발 패턴.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
