### PR TITLE
[codex] Add keeper secret projection

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -39,6 +39,7 @@
   keeper_tool_filesystem_runtime
   keeper_tool_registered_runtime
   keeper_tool_ide_runtime
+  keeper_secret_projection
   keeper_sandbox_docker
   keeper_tool_execute_runtime_paths
   keeper_tool_execute_path

--- a/lib/keeper/keeper_sandbox_docker.ml
+++ b/lib/keeper/keeper_sandbox_docker.ml
@@ -286,6 +286,7 @@ let docker_run_argv
       ~gid
       ~seccomp_args
       ~identity_mounts
+      ~secret_args
       ~image
       ~ttl_sec
   =
@@ -324,6 +325,7 @@ let docker_run_argv
   @ Keeper_sandbox_runtime.docker_workspace_state_mount_args
       ~base_path:config.base_path
       ~container_root
+  @ secret_args
   @ network_args
   @ identity_mounts
   @ [ image; "bash"; "-l"; "-s" ]
@@ -543,80 +545,93 @@ let run_docker_shell_command_with_status_internal
                      with
                      | Error err -> sandbox_error err
                      | Ok identity_mounts ->
-                       let argv =
-                         docker_run_argv
-                           ~config
-                           ~meta
-                           ~container_name
-                           ~container_root
-                           ~container_cwd
-                           ~host_root
-                           ~network_label
-                           ~network_args
-                           ~uid
-                           ~gid
-                           ~seccomp_args
-                           ~identity_mounts
-                           ~image
-                           ~ttl_sec:(docker_oneshot_ttl_sec ~timeout_sec)
-                       in
-                       (try
-                          let status, output =
-                            Eio_guard.protect
-                              ~finally:(fun () ->
-                                cleanup_oneshot_container ~container_name)
-                            @@ fun () ->
-                            Docker_spawn_throttle.with_slot (fun () ->
-                              Masc_exec.Exec_gate.run_argv_with_stdin_and_status
-                                ~actor:`System_sandbox
-                                ~raw_source:(String.concat " " argv)
-                                ~summary:"keeper docker command"
-                                ~env:(Env_keeper_scrub.filter_environment (Unix.environment ()))
-                                ~cwd:(Sys.getcwd ())
-                                ~timeout_sec
-                                ~stdin_content:cmd
-                                argv)
-                          in
-                          let semantic_status =
-                            docker_command_semantic_status ~cmd ~status ~output
-                          in
-                          let semantic_ok = semantic_ok_of_status semantic_status in
-                          if not semantic_ok
-                          then
-                            Keeper_sandbox_exec_failure.record_docker_failure
+                       (match
+                          Keeper_secret_projection.docker_args_for_keeper
+                            ~base_path:config.base_path
+                            ~keeper_name:meta.name
+                            ~container_name
+                        with
+                        | Error err ->
+                          sandbox_error ("docker_shell_failed: secret_projection: " ^ err)
+                        | Ok secret_projection ->
+                          let argv =
+                            docker_run_argv
                               ~config
                               ~meta
-                              ~image
-                              ~container_kind:"oneshot"
+                              ~container_name
+                              ~container_root
+                              ~container_cwd
+                              ~host_root
                               ~network_label
-                              ~status
-                              ~output
-                          else
-                            Keeper_registry.clear_error
-                              ~base_path:config.base_path
-                              meta.name;
-                          Ok
-                            { status
-                            ; output
-                            ; image
-                            ; network_label
-                            ; cwd
-                            ; semantic_status = Some semantic_status
-                            ; semantic_ok
-                            }
-                        with
-                        | Eio.Cancel.Cancelled _ as exn -> raise exn
-                        | Failure err -> sandbox_error err
-                        | Sys_error err ->
-                          sandbox_error
-                            (Printf.sprintf "docker_shell_failed: sys_error: %s" err)
-                        | Unix.Unix_error (code, fn, arg) ->
-                          sandbox_error
-                            (Printf.sprintf
-                               "docker_shell_failed: unix_error: %s: %s(%s)"
-                               (Unix.error_message code)
-                               fn
-                               arg))))))))
+                              ~network_args
+                              ~uid
+                              ~gid
+                              ~seccomp_args
+                              ~identity_mounts
+                              ~secret_args:secret_projection.docker_args
+                              ~image
+                              ~ttl_sec:(docker_oneshot_ttl_sec ~timeout_sec)
+                          in
+                          (try
+                             let status, output =
+                               Eio_guard.protect
+                                 ~finally:(fun () ->
+                                   secret_projection.cleanup ();
+                                   cleanup_oneshot_container ~container_name)
+                               @@ fun () ->
+                               Docker_spawn_throttle.with_slot (fun () ->
+                                 Masc_exec.Exec_gate.run_argv_with_stdin_and_status
+                                   ~actor:`System_sandbox
+                                   ~raw_source:(String.concat " " argv)
+                                   ~summary:"keeper docker command"
+                                   ~env:
+                                     (Env_keeper_scrub.filter_environment
+                                        (Unix.environment ()))
+                                   ~cwd:(Sys.getcwd ())
+                                   ~timeout_sec
+                                   ~stdin_content:cmd
+                                   argv)
+                             in
+                             let semantic_status =
+                               docker_command_semantic_status ~cmd ~status ~output
+                             in
+                             let semantic_ok = semantic_ok_of_status semantic_status in
+                             if not semantic_ok
+                             then
+                               Keeper_sandbox_exec_failure.record_docker_failure
+                                 ~config
+                                 ~meta
+                                 ~image
+                                 ~container_kind:"oneshot"
+                                 ~network_label
+                                 ~status
+                                 ~output
+                             else
+                               Keeper_registry.clear_error
+                                 ~base_path:config.base_path
+                                 meta.name;
+                             Ok
+                               { status
+                               ; output
+                               ; image
+                               ; network_label
+                               ; cwd
+                               ; semantic_status = Some semantic_status
+                               ; semantic_ok
+                               }
+                           with
+                           | Eio.Cancel.Cancelled _ as exn -> raise exn
+                           | Failure err -> sandbox_error err
+                           | Sys_error err ->
+                             sandbox_error
+                               (Printf.sprintf "docker_shell_failed: sys_error: %s" err)
+                           | Unix.Unix_error (code, fn, arg) ->
+                             sandbox_error
+                               (Printf.sprintf
+                                  "docker_shell_failed: unix_error: %s: %s(%s)"
+                                  (Unix.error_message code)
+                                  fn
+                                  arg)))))))))
 ;;
 
 let run_docker_shell_command_with_status =

--- a/lib/keeper/keeper_sandbox_read_backend.ml
+++ b/lib/keeper/keeper_sandbox_read_backend.ml
@@ -55,7 +55,7 @@ let container_path_of_host ~config ~(meta : keeper_meta) ~host_path
    [program ; arg1 ; ... ] is appended by the caller via
    [build_docker_argv ~command_argv]. *)
 let build_docker_argv ~image ~container_name ~base_path ~host_root ~croot
-    ~uid ~gid ~seccomp_args ~command_argv =
+    ~uid ~gid ~seccomp_args ~secret_args ~command_argv =
   Keeper_sandbox_runtime.docker_command_argv ()
   @ [
       "run";
@@ -93,6 +93,7 @@ let build_docker_argv ~image ~container_name ~base_path ~host_root ~croot
   @ Keeper_sandbox_runtime.docker_workspace_state_mount_args
       ~base_path
       ~container_root:croot
+  @ secret_args
   @ [
     image;
   ]
@@ -154,18 +155,40 @@ let run_command_with_status ?turn_sandbox_factory
         let container_name = container_name_of meta in
         let uid = Unix.getuid () in
         let gid = Unix.getgid () in
+        match
+          Keeper_secret_projection.docker_args_for_keeper
+            ~base_path:config.base_path
+            ~keeper_name:meta.name
+            ~container_name
+        with
+        | Error err -> Error ("docker_read_failed: secret_projection: " ^ err)
+        | Ok secret_projection ->
         let argv =
-          build_docker_argv ~image ~container_name ~base_path:config.base_path ~host_root ~croot
-            ~uid ~gid ~seccomp_args ~command_argv
+          build_docker_argv
+            ~image
+            ~container_name
+            ~base_path:config.base_path
+            ~host_root
+            ~croot
+            ~uid
+            ~gid
+            ~seccomp_args
+            ~secret_args:secret_projection.docker_args
+            ~command_argv
         in
         let st, out =
-          Docker_spawn_throttle.with_slot (fun () ->
-              Masc_exec.Exec_gate.run_argv_with_status
-                ~actor:`System_sandbox
-                ~raw_source:(String.concat " " argv)
-                ~summary:"keeper docker read sandboxed command"
-                ~env:(Env_keeper_scrub.filter_environment (Unix.environment ()))
-                ~cwd:(Sys.getcwd ()) ~timeout_sec argv)
+          Eio_guard.protect
+            ~finally:secret_projection.cleanup
+            (fun () ->
+               Docker_spawn_throttle.with_slot (fun () ->
+                 Masc_exec.Exec_gate.run_argv_with_status
+                   ~actor:`System_sandbox
+                   ~raw_source:(String.concat " " argv)
+                   ~summary:"keeper docker read sandboxed command"
+                   ~env:(Env_keeper_scrub.filter_environment (Unix.environment ()))
+                   ~cwd:(Sys.getcwd ())
+                   ~timeout_sec
+                   argv))
         in
         (match st with
          | Unix.WEXITED code

--- a/lib/keeper/keeper_secret_projection.ml
+++ b/lib/keeper/keeper_secret_projection.ml
@@ -1,0 +1,303 @@
+type t =
+  { docker_args : string list
+  ; cleanup : unit -> unit
+  }
+
+type source_kind =
+  | Env_source
+  | File_source
+
+let trim_env_opt key =
+  match Sys.getenv_opt key with
+  | Some value ->
+    let trimmed = String.trim value in
+    if String.equal trimmed "" then None else Some trimmed
+  | None -> None
+;;
+
+let secret_root ~base_path ~keeper_name =
+  let keeper_dir = Workspace_utils.safe_filename keeper_name in
+  match trim_env_opt "MASC_SECRET_DIR" with
+  | Some root -> Filename.concat root keeper_dir
+  | None ->
+    Filename.concat
+      (Filename.concat (Common.masc_dir_from_base_path ~base_path) "secrets")
+      keeper_dir
+;;
+
+let path_exists path =
+  try Sys.file_exists path with
+  | Sys_error _ -> false
+;;
+
+let is_directory path =
+  try Sys.is_directory path with
+  | Sys_error _ -> false
+;;
+
+let list_dir_sorted path =
+  try Ok (Sys.readdir path |> Array.to_list |> List.sort String.compare) with
+  | Sys_error msg -> Error msg
+;;
+
+let lstat path =
+  try Ok (Unix.lstat path) with
+  | Unix.Unix_error (err, fn, arg) ->
+    Error
+      (Printf.sprintf
+         "%s%s%s"
+         (Unix.error_message err)
+         (if String.equal fn "" then "" else ": " ^ fn)
+         (if String.equal arg "" then "" else " " ^ arg))
+;;
+
+let source_label = function
+  | Env_source -> "env"
+  | File_source -> "files"
+;;
+
+let reject_symlink ~kind path =
+  match lstat path with
+  | Error err -> Error err
+  | Ok st ->
+    (match st.Unix.st_kind with
+     | Unix.S_LNK ->
+       Error
+         (Printf.sprintf
+            "keeper secret %s entry must not be a symlink: %s"
+            (source_label kind)
+            path)
+     | _ -> Ok st)
+;;
+
+let valid_env_name name =
+  let len = String.length name in
+  let valid_first = function
+    | 'A' .. 'Z' | 'a' .. 'z' | '_' -> true
+    | _ -> false
+  in
+  let valid_rest = function
+    | 'A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '_' -> true
+    | _ -> false
+  in
+  len > 0
+  && valid_first name.[0]
+  &&
+  let rec loop i =
+    if i = len then true else valid_rest name.[i] && loop (i + 1)
+  in
+  loop 1
+;;
+
+let read_file path =
+  let ic = open_in_bin path in
+  Fun.protect ~finally:(fun () -> close_in ic) @@ fun () ->
+  really_input_string ic (in_channel_length ic)
+;;
+
+let strip_one_final_newline value =
+  let len = String.length value in
+  if len >= 2 && Char.equal value.[len - 2] '\r' && Char.equal value.[len - 1] '\n'
+  then String.sub value 0 (len - 2)
+  else if len >= 1 && (Char.equal value.[len - 1] '\n' || Char.equal value.[len - 1] '\r')
+  then String.sub value 0 (len - 1)
+  else value
+;;
+
+let contains_char value c =
+  String.contains value c
+;;
+
+let read_env_entry path =
+  try
+    let value = read_file path |> strip_one_final_newline in
+    if contains_char value '\n' || contains_char value '\r'
+    then Error (Printf.sprintf "keeper secret env value must be single-line: %s" path)
+    else if contains_char value '\000'
+    then Error (Printf.sprintf "keeper secret env value must not contain NUL: %s" path)
+    else Ok value
+  with
+  | Sys_error msg -> Error msg
+;;
+
+let load_env_entries env_root =
+  if not (path_exists env_root)
+  then Ok []
+  else if not (is_directory env_root)
+  then Error (Printf.sprintf "keeper secret env path is not a directory: %s" env_root)
+  else (
+    match reject_symlink ~kind:Env_source env_root with
+    | Error _ as err -> err
+    | Ok _ ->
+    (match list_dir_sorted env_root with
+     | Error err -> Error err
+     | Ok names ->
+      let rec loop acc = function
+        | [] -> Ok (List.rev acc)
+        | name :: rest ->
+          if not (valid_env_name name)
+          then Error (Printf.sprintf "invalid keeper secret env name: %s" name)
+          else
+            let path = Filename.concat env_root name in
+            (match reject_symlink ~kind:Env_source path with
+             | Error _ as err -> err
+             | Ok st ->
+               (match st.Unix.st_kind with
+                | Unix.S_REG ->
+                  (match read_env_entry path with
+                   | Error _ as err -> err
+                   | Ok value -> loop ((name, value) :: acc) rest)
+                | _ ->
+                  Error
+                    (Printf.sprintf
+                       "keeper secret env entry must be a regular file: %s"
+                       path)))
+      in
+      loop [] names))
+;;
+
+let valid_rel_component component =
+  not
+    (String.equal component ""
+     || String.equal component "."
+     || String.equal component ".."
+     || contains_char component '/')
+;;
+
+let container_path_of_rel rel =
+  "/" ^ String.concat "/" rel
+;;
+
+let collect_file_entries files_root =
+  let rec walk rel host_dir acc =
+    match reject_symlink ~kind:File_source host_dir with
+    | Error _ as err -> err
+    | Ok st ->
+      (match st.Unix.st_kind with
+       | Unix.S_DIR ->
+         (match list_dir_sorted host_dir with
+          | Error err -> Error err
+          | Ok names ->
+            let rec loop acc = function
+              | [] -> Ok acc
+              | name :: rest ->
+                if not (valid_rel_component name)
+                then
+                  Error
+                    (Printf.sprintf "invalid keeper secret file path component: %s" name)
+                else (
+                  match walk (rel @ [ name ]) (Filename.concat host_dir name) acc with
+                  | Error _ as err -> err
+                  | Ok acc -> loop acc rest)
+            in
+            loop acc names)
+       | Unix.S_REG ->
+         if rel = []
+         then Error (Printf.sprintf "keeper secret files root is not a directory: %s" files_root)
+         else Ok ((host_dir, container_path_of_rel rel) :: acc)
+       | Unix.S_LNK ->
+         Error
+           (Printf.sprintf "keeper secret file entry must not be a symlink: %s" host_dir)
+       | _ ->
+         Error
+           (Printf.sprintf
+              "keeper secret file entry must be a regular file or directory: %s"
+              host_dir))
+  in
+  if not (path_exists files_root)
+  then Ok []
+  else if not (is_directory files_root)
+  then Error (Printf.sprintf "keeper secret files path is not a directory: %s" files_root)
+  else
+    match walk [] files_root [] with
+    | Error _ as err -> err
+    | Ok entries -> Ok (List.rev entries)
+;;
+
+let write_env_file ~container_name entries =
+  if entries = []
+  then Ok None
+  else
+    let prefix =
+      "masc_keeper_secret_env_"
+      ^ Workspace_utils.safe_filename container_name
+      ^ "_"
+    in
+    try
+      let path = Filename.temp_file prefix ".env" in
+      (try
+         Unix.chmod path 0o600;
+         let oc = open_out_gen [ Open_wronly; Open_trunc; Open_binary ] 0o600 path in
+         Fun.protect
+           ~finally:(fun () -> close_out oc)
+           (fun () ->
+              List.iter
+                (fun (name, value) ->
+                   output_string oc name;
+                   output_char oc '=';
+                   output_string oc value;
+                   output_char oc '\n')
+                entries);
+         Ok (Some path)
+       with
+       | exn ->
+         (try if Sys.file_exists path then Sys.remove path with
+          | Sys_error _ | Unix.Unix_error _ -> ());
+         raise exn)
+    with
+    | Sys_error msg -> Error msg
+    | Unix.Unix_error (err, fn, arg) ->
+      Error
+        (Printf.sprintf
+           "%s%s%s"
+           (Unix.error_message err)
+           (if String.equal fn "" then "" else ": " ^ fn)
+           (if String.equal arg "" then "" else " " ^ arg))
+;;
+
+let cleanup_files paths =
+  List.iter
+    (fun path ->
+       try if Sys.file_exists path then Sys.remove path with
+       | Sys_error _ | Unix.Unix_error _ -> ())
+    paths
+;;
+
+let docker_args_for_keeper ~base_path ~keeper_name ~container_name =
+  let root = secret_root ~base_path ~keeper_name in
+  if not (path_exists root)
+  then Ok { docker_args = []; cleanup = (fun () -> ()) }
+  else if not (is_directory root)
+  then Error (Printf.sprintf "keeper secret root is not a directory: %s" root)
+  else (
+    match reject_symlink ~kind:File_source root with
+    | Error _ as err -> err
+    | Ok _ ->
+      let env_root = Filename.concat root "env" in
+      let files_root = Filename.concat root "files" in
+      (match load_env_entries env_root with
+       | Error _ as err -> err
+       | Ok env_entries ->
+         (match collect_file_entries files_root with
+          | Error _ as err -> err
+          | Ok file_entries ->
+            (match write_env_file ~container_name env_entries with
+             | Error _ as err -> err
+             | Ok env_file ->
+               let env_args =
+                 match env_file with
+                 | None -> []
+                 | Some path -> [ "--env-file"; path ]
+               in
+               let file_args =
+                 file_entries
+                 |> List.concat_map (fun (host, container) ->
+                   [ "-v"; host ^ ":" ^ container ^ ":ro" ])
+               in
+               let cleanup =
+                 match env_file with
+                 | None -> fun () -> ()
+                 | Some path -> fun () -> cleanup_files [ path ]
+               in
+               Ok { docker_args = env_args @ file_args; cleanup }))))
+;;

--- a/lib/keeper/keeper_secret_projection.mli
+++ b/lib/keeper/keeper_secret_projection.mli
@@ -1,0 +1,7 @@
+type t =
+  { docker_args : string list
+  ; cleanup : unit -> unit
+  }
+
+val docker_args_for_keeper :
+  base_path:string -> keeper_name:string -> container_name:string -> (t, string) result

--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -360,6 +360,14 @@ let start_container (t : t) ~timeout_sec =
        with
        | Error _ as err -> err
        | Ok identity_mounts ->
+       (match
+          Keeper_secret_projection.docker_args_for_keeper
+            ~base_path:t.config.base_path
+            ~keeper_name:t.meta.name
+            ~container_name
+        with
+        | Error err -> Error ("docker_container_start_failed: secret_projection: " ^ err)
+        | Ok secret_projection ->
          let argv =
            Keeper_sandbox_runtime.docker_command_argv ()
            @ [ "run"; "-d"; "--rm"; "--name"; container_name ]
@@ -399,11 +407,16 @@ let start_container (t : t) ~timeout_sec =
            @ Keeper_sandbox_runtime.docker_workspace_state_mount_args
                ~base_path:t.config.base_path
                ~container_root:t.container_root
+           @ secret_projection.docker_args
            @ identity_mounts
            @ network_args
            @ [ image; "tail"; "-f"; "/dev/null" ]
          in
-         let st, out = run_argv_with_status_retry_eintr argv in
+         let st, out =
+           Eio_guard.protect
+             ~finally:secret_projection.cleanup
+             (fun () -> run_argv_with_status_retry_eintr argv)
+         in
          (match st with
           | Unix.WEXITED 0 ->
             let inspect_argv =
@@ -464,7 +477,7 @@ let start_container (t : t) ~timeout_sec =
               (Printf.sprintf
                  "docker_container_start_failed: %s%s"
                  (Keeper_sandbox_runtime.docker_failure_output_for_log out)
-                 mount_context))))
+                 mount_context)))))
 ;;
 
 let ensure_started (t : t) ~timeout_sec =

--- a/test/dune
+++ b/test/dune
@@ -184,6 +184,7 @@
   test_keeper_fsm_guard_actions
   test_keeper_callback_hardening
   test_keeper_behavioral_regime
+  test_keeper_secret_projection
   test_keeper_toml
   test_runtime_toml_overrides
   test_runtime_provider_auth_headers
@@ -443,6 +444,7 @@
   test_keeper_fsm_guard_actions
   test_keeper_callback_hardening
   test_keeper_behavioral_regime
+  test_keeper_secret_projection
   test_keeper_toml
   test_runtime_toml_overrides
   test_runtime_provider_auth_headers

--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -100,6 +100,14 @@ let docker_log_has_container_execution log =
   contains_substring ("\n" ^ log) "\nrun "
   || contains_substring ("\n" ^ log) "\nexec "
 
+let env_file_path_from_docker_line line =
+  let rec loop = function
+    | "--env-file" :: path :: _ -> Some path
+    | _ :: rest -> loop rest
+    | [] -> None
+  in
+  loop (String.split_on_char ' ' line)
+
 let rec ensure_dir path =
   if path = "" || path = "." || path = "/" then ()
   else if Sys.file_exists path then ()
@@ -1748,6 +1756,39 @@ let test_docker_shell_mounts_numeric_user_identity () =
     (contains_substring (read_file group_path)
        (Printf.sprintf "keeper:x:%d:" (Unix.getgid ())))
 
+let test_docker_shell_projects_keeper_secret_dir () =
+  with_fake_docker fake_docker_echo_script @@ fun () ->
+  setup ~sandbox:Keeper_types_profile_sandbox.Docker
+  @@ fun ~config ~meta ~playground ->
+  let secret_root =
+    Filename.concat
+      (Filename.concat (Filename.concat config.Workspace.base_path Common.masc_dirname) "secrets")
+      (Workspace_utils.safe_filename meta.name)
+  in
+  let token_path = Filename.concat (Filename.concat secret_root "env") "GH_TOKEN" in
+  let ssh_path =
+    Filename.concat
+      (Filename.concat secret_root "files")
+      "home/keeper/.ssh/id_ed25519"
+  in
+  ensure_dir (Filename.dirname token_path);
+  ensure_dir (Filename.dirname ssh_path);
+  write_file token_path "projected-token\n";
+  write_file ssh_path "PRIVATE KEY";
+  let log_path = Filename.concat config.Workspace.base_path "docker.log" in
+  let line = run_docker_shell_command ~config ~meta ~playground ~log_path in
+  Alcotest.(check bool) "projected raw token not in docker argv" false
+    (contains_substring line "projected-token");
+  Alcotest.(check bool) "projected env uses env-file" true
+    (contains_substring line "--env-file ");
+  Alcotest.(check bool) "projected file mounted read-only" true
+    (contains_substring line (ssh_path ^ ":/home/keeper/.ssh/id_ed25519:ro"));
+  (match env_file_path_from_docker_line line with
+   | None -> Alcotest.fail "missing --env-file path in docker log"
+   | Some env_file ->
+     Alcotest.(check bool) "env-file cleaned after docker run" false
+       (Sys.file_exists env_file))
+
 let test_docker_shell_does_not_synthesize_git_author_identity () =
   with_fake_docker fake_docker_echo_script @@ fun () ->
   setup ~sandbox:Keeper_types_profile_sandbox.Docker
@@ -1782,6 +1823,53 @@ let test_execute_fake_docker_executes () =
     (parse_string_field raw "via");
   Alcotest.(check bool) "bash output includes fake docker stdout" true
     (response_mentions raw "output" "stdout:")
+
+let test_turn_runtime_projects_keeper_secret_dir () =
+  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
+  with_fake_docker fake_docker_echo_script @@ fun () ->
+  setup ~sandbox:Keeper_types_profile_sandbox.Docker
+  @@ fun ~config ~meta ~playground ->
+  let secret_root =
+    Filename.concat
+      (Filename.concat (Filename.concat config.Workspace.base_path Common.masc_dirname) "secrets")
+      (Workspace_utils.safe_filename meta.name)
+  in
+  let token_path = Filename.concat (Filename.concat secret_root "env") "GH_TOKEN" in
+  let ssh_path =
+    Filename.concat
+      (Filename.concat secret_root "files")
+      "home/keeper/.ssh/id_ed25519"
+  in
+  ensure_dir (Filename.dirname token_path);
+  ensure_dir (Filename.dirname ssh_path);
+  write_file token_path "projected-token\n";
+  write_file ssh_path "PRIVATE KEY";
+  let log_path = Filename.concat config.Workspace.base_path "docker.log" in
+  with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
+  with_turn_sandbox_factory ~config ~meta @@ fun factory ->
+  let raw =
+    Keeper_tool_command_runtime.handle_tool_execute
+      ~turn_sandbox_factory:(Some factory)
+      ~exec_cache:None
+      ~config
+      ~meta
+      ~args:(tool_execute_typed_exec_args ~cwd:playground "echo" ~argv:[ "hello" ])
+      ()
+  in
+  Alcotest.(check (option bool)) "bash via fake docker is ok" (Some true)
+    (parse_bool_field raw "ok");
+  let log = read_file log_path in
+  Alcotest.(check bool) "projected raw token not in docker argv" false
+    (contains_substring log "projected-token");
+  Alcotest.(check bool) "turn container uses env-file" true
+    (contains_substring log "--env-file ");
+  Alcotest.(check bool) "turn container mounts file read-only" true
+    (contains_substring log (ssh_path ^ ":/home/keeper/.ssh/id_ed25519:ro"));
+  (match env_file_path_from_docker_line log with
+   | None -> Alcotest.fail "missing --env-file path in docker log"
+   | Some env_file ->
+     Alcotest.(check bool) "env-file cleaned after container start" false
+       (Sys.file_exists env_file))
 
 let test_execute_allows_validator_safe_pipe_redirect_in_docker_route () =
   with_tool_policy_config @@ fun () ->
@@ -2179,8 +2267,14 @@ let () =
             "docker shell mounts passwd entry for numeric uid"
             `Quick test_docker_shell_mounts_numeric_user_identity;
           Alcotest.test_case
+            "docker shell projects keeper secret directory"
+            `Quick test_docker_shell_projects_keeper_secret_dir;
+          Alcotest.test_case
             "docker shell does not synthesize git author identity"
             `Quick test_docker_shell_does_not_synthesize_git_author_identity;
+          Alcotest.test_case
+            "turn runtime projects keeper secret directory"
+            `Quick test_turn_runtime_projects_keeper_secret_dir;
           Alcotest.test_case
             "sandbox-root git with no repo blocks before docker exec"
             `Quick test_sandbox_root_git_cwd_zero_repo_blocks_before_exec;

--- a/test/test_keeper_sandbox_read_backend.ml
+++ b/test/test_keeper_sandbox_read_backend.ml
@@ -67,6 +67,14 @@ let contains_substring haystack needle =
   in
   loop 0
 
+let env_file_path_from_docker_line line =
+  let rec loop = function
+    | "--env-file" :: path :: _ -> Some path
+    | _ :: rest -> loop rest
+    | [] -> None
+  in
+  loop (String.split_on_char ' ' line)
+
 let docker_spawn_in_flight () =
   let snapshot = Fd_accountant.fd_snapshot () in
   List.assoc Fd_accountant.Docker_spawn snapshot.per_kind
@@ -369,6 +377,27 @@ if [ \"$1\" = \"run\" ]; then\n\
   fi\n\
   sleep 0.2\n\
   printf 'slow ok\\n'\n\
+  exit 0\n\
+fi\n\
+printf 'unexpected docker invocation\\n' >&2\n\
+exit 2\n"
+
+let fake_docker_log_run_script =
+  "#!/bin/sh\n\
+log_file=${KEEPER_DOCKER_LOG:-}\n\
+if [ -n \"$log_file\" ]; then\n\
+  printf '%s\\n' \"$*\" >> \"$log_file\"\n\
+fi\n\
+if [ \"$1\" = \"info\" ]; then\n\
+  printf '[]\\n'\n\
+  exit 0\n\
+fi\n\
+if [ \"$1\" = \"image\" ] && [ \"$2\" = \"inspect\" ] && [ \"$3\" = \"alpine:test\" ]; then\n\
+  printf '[]\\n'\n\
+  exit 0\n\
+fi\n\
+if [ \"$1\" = \"run\" ]; then\n\
+  printf 'ok\\n'\n\
   exit 0\n\
 fi\n\
 printf 'unexpected docker invocation\\n' >&2\n\
@@ -1153,6 +1182,55 @@ let test_run_command_fallback_uses_docker_spawn_slot ~clock () =
    Alcotest.(check int) "Docker_spawn slot released" 0
      (docker_spawn_in_flight ())
 
+let test_run_command_projects_keeper_secret_dir () =
+  with_fake_docker fake_docker_log_run_script @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_SECCOMP_PROFILE" "" @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_REQUIRE_ROOTLESS" "false" @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_REQUIRE_USERNS" "false" @@ fun () ->
+  let base, config, meta = setup_config "minjae" in
+  let log_path = Filename.concat base "docker.log" in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  let secret_root =
+    Filename.concat
+      (Filename.concat (Filename.concat base Common.masc_dirname) "secrets")
+      (Workspace_utils.safe_filename meta.name)
+  in
+  let token_path = Filename.concat (Filename.concat secret_root "env") "GH_TOKEN" in
+  let ssh_path =
+    Filename.concat
+      (Filename.concat secret_root "files")
+      "home/keeper/.ssh/id_ed25519"
+  in
+  ensure_dir (Filename.dirname token_path);
+  ensure_dir (Filename.dirname ssh_path);
+  write_file token_path "projected-token\n";
+  write_file ssh_path "PRIVATE KEY";
+  with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
+  match
+    Keeper_sandbox_read_backend.run_command_with_status
+      ~config
+      ~meta
+      ~command_argv:[ "echo"; "hello" ]
+      ~max_bytes:4096
+      ~timeout_sec:5.0
+      ()
+  with
+  | Error msg -> Alcotest.failf "expected success, got %s" msg
+  | Ok (_st, _out) ->
+    let line = read_file log_path in
+    Alcotest.(check bool) "projected raw token not in docker argv" false
+      (contains_substring line "projected-token");
+    Alcotest.(check bool) "projected env uses env-file" true
+      (contains_substring line "--env-file ");
+    Alcotest.(check bool) "projected file mounted read-only" true
+      (contains_substring line (ssh_path ^ ":/home/keeper/.ssh/id_ed25519:ro"));
+    (match env_file_path_from_docker_line line with
+     | None -> Alcotest.fail "missing --env-file path in docker log"
+     | Some env_file ->
+       Alcotest.(check bool) "env-file cleaned after docker run" false
+         (Sys.file_exists env_file))
+
 let test_run_command_scrubs_sensitive_env () =
   with_fake_docker fake_docker_env_dump_script @@ fun () ->
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
@@ -1375,6 +1453,8 @@ let run_tests ~clock () =
             test_run_command_preserves_bare_command_argv;
           Alcotest.test_case "fallback uses Docker_spawn slot" `Quick
             (test_run_command_fallback_uses_docker_spawn_slot ~clock);
+          Alcotest.test_case "projects keeper secret directory" `Quick
+            test_run_command_projects_keeper_secret_dir;
           Alcotest.test_case "default fs hardening helpers" `Quick
             test_default_fs_hardening_helpers;
           Alcotest.test_case "relaxed fs helpers" `Quick

--- a/test/test_keeper_secret_projection.ml
+++ b/test/test_keeper_secret_projection.ml
@@ -1,0 +1,249 @@
+module Keeper_secret_projection = Masc.Keeper_secret_projection
+
+let with_env key value f =
+  let prior = Sys.getenv_opt key in
+  Unix.putenv key value;
+  Fun.protect
+    ~finally:(fun () ->
+      match prior with
+      | Some v -> Unix.putenv key v
+      | None -> Unix.putenv key "")
+    f
+;;
+
+let temp_dir () =
+  let d = Filename.temp_file "keeper_secret_projection_" "" in
+  Unix.unlink d;
+  Unix.mkdir d 0o755;
+  d
+;;
+
+let rec ensure_dir path =
+  if path = "" || path = "." || path = "/" then ()
+  else if Sys.file_exists path then ()
+  else (
+    let parent = Filename.dirname path in
+    if parent <> path then ensure_dir parent;
+    Unix.mkdir path 0o755)
+;;
+
+let cleanup_dir dir =
+  let rec rm path =
+    match Unix.lstat path with
+    | { Unix.st_kind = Unix.S_DIR; _ } ->
+      Array.iter (fun name -> rm (Filename.concat path name)) (Sys.readdir path);
+      Unix.rmdir path
+    | _ -> Unix.unlink path
+    | exception Unix.Unix_error _ -> ()
+  in
+  try rm dir with
+  | _ -> ()
+;;
+
+let write_file path content =
+  ensure_dir (Filename.dirname path);
+  let oc = open_out_bin path in
+  Fun.protect ~finally:(fun () -> close_out oc) @@ fun () ->
+  output_string oc content
+;;
+
+let read_file path =
+  let ic = open_in_bin path in
+  Fun.protect ~finally:(fun () -> close_in ic) @@ fun () ->
+  really_input_string ic (in_channel_length ic)
+;;
+
+let contains_substring haystack needle =
+  let hlen = String.length haystack in
+  let nlen = String.length needle in
+  let rec loop i =
+    if nlen = 0 then true
+    else if i + nlen > hlen then false
+    else if String.sub haystack i nlen = needle then true
+    else loop (i + 1)
+  in
+  loop 0
+;;
+
+let rec env_file_arg = function
+  | "--env-file" :: path :: _ -> Some path
+  | _ :: rest -> env_file_arg rest
+  | [] -> None
+;;
+
+let secret_root_default ~base ~keeper_name =
+  Filename.concat
+    (Filename.concat (Filename.concat base Common.masc_dirname) "secrets")
+    (Workspace_utils.safe_filename keeper_name)
+;;
+
+let test_missing_secret_dir_is_noop () =
+  let base = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  with_env "MASC_SECRET_DIR" "" @@ fun () ->
+  match
+    Keeper_secret_projection.docker_args_for_keeper
+      ~base_path:base
+      ~keeper_name:"minjae"
+      ~container_name:"container"
+  with
+  | Error err -> Alcotest.fail err
+  | Ok projection ->
+    Alcotest.(check (list string)) "no docker args" [] projection.docker_args;
+    projection.cleanup ()
+;;
+
+let test_env_and_files_project_to_docker_args () =
+  let base = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  with_env "MASC_SECRET_DIR" "" @@ fun () ->
+  let root = secret_root_default ~base ~keeper_name:"MinJae" in
+  let token_path = Filename.concat (Filename.concat root "env") "GH_TOKEN" in
+  let ssh_path =
+    Filename.concat
+      (Filename.concat root "files")
+      "home/keeper/.ssh/id_ed25519"
+  in
+  write_file token_path "ghs_projected_secret\n";
+  write_file ssh_path "PRIVATE KEY";
+  match
+    Keeper_secret_projection.docker_args_for_keeper
+      ~base_path:base
+      ~keeper_name:"MinJae"
+      ~container_name:"container"
+  with
+  | Error err -> Alcotest.fail err
+  | Ok projection ->
+    let args = String.concat " " projection.docker_args in
+    Alcotest.(check bool) "raw secret not in argv" false
+      (contains_substring args "ghs_projected_secret");
+    Alcotest.(check bool) "ssh file mounted read-only" true
+      (contains_substring
+         args
+         (ssh_path ^ ":/home/keeper/.ssh/id_ed25519:ro"));
+    (match env_file_arg projection.docker_args with
+     | None -> Alcotest.fail "missing --env-file"
+     | Some env_file ->
+       Alcotest.(check string)
+         "env file content"
+         "GH_TOKEN=ghs_projected_secret\n"
+         (read_file env_file);
+       projection.cleanup ();
+       Alcotest.(check bool) "env file cleaned up" false (Sys.file_exists env_file))
+;;
+
+let test_secret_dir_override_uses_keeper_subdir () =
+  let base = temp_dir () in
+  let override_root = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      cleanup_dir base;
+      cleanup_dir override_root)
+    (fun () ->
+       with_env "MASC_SECRET_DIR" override_root @@ fun () ->
+       let keeper_root =
+         Filename.concat override_root (Workspace_utils.safe_filename "MinJae")
+       in
+       write_file (Filename.concat (Filename.concat keeper_root "env") "GH_TOKEN") "override";
+       match
+         Keeper_secret_projection.docker_args_for_keeper
+           ~base_path:base
+           ~keeper_name:"MinJae"
+           ~container_name:"container"
+       with
+       | Error err -> Alcotest.fail err
+       | Ok projection ->
+         (match env_file_arg projection.docker_args with
+          | None -> Alcotest.fail "missing --env-file"
+          | Some env_file ->
+            Alcotest.(check string) "override env content" "GH_TOKEN=override\n"
+              (read_file env_file);
+            projection.cleanup ()))
+;;
+
+let test_invalid_env_name_rejects () =
+  let base = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  with_env "MASC_SECRET_DIR" "" @@ fun () ->
+  let root = secret_root_default ~base ~keeper_name:"minjae" in
+  write_file (Filename.concat (Filename.concat root "env") "BAD-NAME") "x";
+  match
+    Keeper_secret_projection.docker_args_for_keeper
+      ~base_path:base
+      ~keeper_name:"minjae"
+      ~container_name:"container"
+  with
+  | Ok _ -> Alcotest.fail "expected invalid env name rejection"
+  | Error err ->
+    Alcotest.(check bool) "mentions invalid env name" true
+      (contains_substring err "invalid keeper secret env name")
+;;
+
+let test_symlink_file_rejects () =
+  let base = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  with_env "MASC_SECRET_DIR" "" @@ fun () ->
+  let root = secret_root_default ~base ~keeper_name:"minjae" in
+  let outside = Filename.concat base "outside-secret" in
+  write_file outside "x";
+  let link_path =
+    Filename.concat (Filename.concat root "files") "home/keeper/.ssh/id_ed25519"
+  in
+  ensure_dir (Filename.dirname link_path);
+  Unix.symlink outside link_path;
+  match
+    Keeper_secret_projection.docker_args_for_keeper
+      ~base_path:base
+      ~keeper_name:"minjae"
+      ~container_name:"container"
+  with
+  | Ok _ -> Alcotest.fail "expected symlink rejection"
+  | Error err ->
+    Alcotest.(check bool) "mentions symlink" true
+      (contains_substring err "symlink")
+;;
+
+let test_symlink_env_dir_rejects () =
+  let base = temp_dir () in
+  let outside = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      cleanup_dir base;
+      cleanup_dir outside)
+    (fun () ->
+       with_env "MASC_SECRET_DIR" "" @@ fun () ->
+       write_file (Filename.concat outside "GH_TOKEN") "x";
+       let root = secret_root_default ~base ~keeper_name:"minjae" in
+       let env_root = Filename.concat root "env" in
+       ensure_dir root;
+       Unix.symlink outside env_root;
+       match
+         Keeper_secret_projection.docker_args_for_keeper
+           ~base_path:base
+           ~keeper_name:"minjae"
+           ~container_name:"container"
+       with
+       | Ok _ -> Alcotest.fail "expected env directory symlink rejection"
+       | Error err ->
+         Alcotest.(check bool) "mentions symlink" true
+           (contains_substring err "symlink"))
+;;
+
+let () =
+  Alcotest.run
+    "keeper secret projection"
+    [ ( "projection"
+      , [ Alcotest.test_case "missing secret dir is noop" `Quick
+            test_missing_secret_dir_is_noop
+        ; Alcotest.test_case "env and files project to docker args" `Quick
+            test_env_and_files_project_to_docker_args
+        ; Alcotest.test_case "MASC_SECRET_DIR uses keeper subdir" `Quick
+            test_secret_dir_override_uses_keeper_subdir
+        ; Alcotest.test_case "invalid env name rejects" `Quick
+            test_invalid_env_name_rejects
+        ; Alcotest.test_case "symlink file rejects" `Quick test_symlink_file_rejects
+        ; Alcotest.test_case "symlink env dir rejects" `Quick
+            test_symlink_env_dir_rejects
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

- Add Keeper secret directory projection for Docker sandbox runtimes.
- Treat `<base_path>/.masc/secrets/<safe_keeper_name>/` as the filesystem SSOT, with optional `MASC_SECRET_DIR` override.
- Project `env/NAME` files through Docker `--env-file` and `files/...` entries as read-only container path mounts.
- Wire the projection into one-shot Docker shell, turn-scoped Docker containers, and the Docker read backend without adding Keeper TOML, keeper_meta, or OAS state.

## Validation

- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build --build-dir _build_secret_projection test/test_keeper_secret_projection.exe test/test_keeper_sandbox_docker_route.exe test/test_keeper_sandbox_read_backend.exe`
- `_build_secret_projection/default/test/test_keeper_secret_projection.exe`
- `_build_secret_projection/default/test/test_keeper_sandbox_docker_route.exe test docker_route_contract 17,19`
- `_build_secret_projection/default/test/test_keeper_sandbox_read_backend.exe test run_command 6`
- `git diff --check`