### PR TITLE
fix(voice): restore macOS open playback fallback

### DIFF
--- a/lib/voice/voice_bridge.ml
+++ b/lib/voice/voice_bridge.ml
@@ -410,6 +410,25 @@ let attempt_tts_endpoint
                    ; "local_playback_reason", `String reason
                    ])
                endpoint)
+        | `Opened handoff_seconds ->
+          Ok
+            (append_provider_metadata
+               (`Assoc
+                   [ "status", `String "spoken"
+                   ; "agent_id", `String agent_id
+                   ; "voice", `String voice
+                   ; "audio_file", `String audio_file
+                   ; "audio_size", `Int file_size
+                   ; ( "message_preview"
+                     , `String
+                         (String.sub message 0 (min 50 (String.length message))) )
+                   ; "local_playback_status", `String "opened"
+                   ; "local_playback_reason"
+                     , `String
+                         "blocking local players failed; handed audio file to macOS open"
+                   ; "open_handoff_seconds", `Float handoff_seconds
+                   ])
+               endpoint)
         | `Played played_seconds ->
           Ok
             (append_provider_metadata

--- a/lib/voice_bridge_core/voice_bridge_core.ml
+++ b/lib/voice_bridge_core/voice_bridge_core.ml
@@ -141,10 +141,10 @@ let find_executable_in_path ?path_value executable =
   in
   List.find_opt (fun path -> Sys.file_exists path && not (Sys.is_directory path)) candidates
 
-(* `open` is intentionally NOT a candidate: it hands the file to an external
-   app and returns immediately, so it would report `Played ~0.1s` without the
-   audio having been heard — a fake success under the blocking speak
-   contract. Systems without a real player fail explicitly instead. *)
+(* `open` is intentionally last and reported as `Opened`, not `Played`: it hands
+   the file to a GUI app and returns immediately. It still matters on macOS
+   sessions where command-line CoreAudio backends cannot see a default output
+   device but Finder/QuickTime can. *)
 let local_playback_argvs ?path_value ~audio_file () =
   let commands =
     [
@@ -152,6 +152,7 @@ let local_playback_argvs ?path_value ~audio_file () =
       ("ffplay", [ "-nodisp"; "-autoexit"; "-loglevel"; "error" ]);
       ("mpg123", [ "-q" ]);
       ("play", [ "-q" ]);
+      ("open", []);
     ]
   in
   commands
@@ -247,6 +248,7 @@ let audio_duration_seconds ~audio_file =
       fibers both pass the outer [is_dedup_hit] before either records).
     - [`Skipped reason] if playback was intentionally skipped.
     - [`Failed reason] if playback was requested but unavailable or failed.
+    - [`Opened dur] if playback was handed off to macOS [open(1)].
     - [`Played dur] if playback succeeded with the given duration.
 
     When [message] is [None] the dedup re-check is skipped (legacy callers that
@@ -263,7 +265,7 @@ let run_local_playback ~sw:_ ~agent_id ?message ~audio_file () =
       match local_playback_argvs ~audio_file () with
       | [] ->
         let reason =
-          "no afplay/ffplay/mpg123/play executable found"
+          "no afplay/ffplay/mpg123/play/open executable found"
         in
         log_error
           (Printf.sprintf "local voice playback unavailable: %s" reason);
@@ -320,12 +322,21 @@ let run_local_playback ~sw:_ ~agent_id ?message ~audio_file () =
                   with
                   | Unix.WEXITED 0, _ ->
                     let dur = Unix.gettimeofday () -. t0 in
-                    log_info
-                      (Printf.sprintf
-                         "local voice playback finished: agent=%s file=%s via=%s \
-                          duration=%.1fs"
-                         agent_id audio_file executable dur);
-                    `Played dur
+                    if String.equal (Filename.basename executable) "open" then begin
+                      log_info
+                        (Printf.sprintf
+                           "local voice playback handed off: agent=%s file=%s via=%s \
+                            duration=%.1fs"
+                           agent_id audio_file executable dur);
+                      `Opened dur
+                    end else begin
+                      log_info
+                        (Printf.sprintf
+                           "local voice playback finished: agent=%s file=%s via=%s \
+                            duration=%.1fs"
+                           agent_id audio_file executable dur);
+                      `Played dur
+                    end
                   | Unix.WEXITED 124, _ ->
                     (* WEXITED 124 is Process_eio's synthesized status for a
                        timeout kill: the player ran past the probed duration
@@ -402,7 +413,12 @@ let run_local_playback ~sw:_ ~agent_id ?message ~audio_file () =
 let start_local_playback ~sw ~agent_id ~audio_file =
   ignore
     (run_local_playback ~sw ~agent_id ~audio_file ()
-      : [ `Dedup_hit | `Failed of string | `Played of float | `Skipped of string ])
+      : [ `Dedup_hit
+        | `Failed of string
+        | `Opened of float
+        | `Played of float
+        | `Skipped of string
+        ])
 
 (** Voice used when [load_voice_config ()] itself fails. This is the
     only remaining hardcoded fallback; the normal "agent not listed"

--- a/lib/voice_bridge_core/voice_bridge_core.mli
+++ b/lib/voice_bridge_core/voice_bridge_core.mli
@@ -121,7 +121,7 @@ val run_local_playback :
   ?message:string ->
   audio_file:string ->
   unit ->
-  [ `Dedup_hit | `Played of float | `Skipped of string | `Failed of string ]
+  [ `Dedup_hit | `Opened of float | `Played of float | `Skipped of string | `Failed of string ]
 (** Mutex-protected local audio playback with a 30s dedup window
     keyed on [(agent_id, hash message)]. Returns:
 
@@ -135,6 +135,9 @@ val run_local_playback :
       kill is terminal: the fallback chain is NOT tried, because partial audio
       has likely played and a fallback player would replay the same file from
       0:00 (the audible-repeat amplifier in the 2026-06-10 voice incident);
+    - [`Opened duration_seconds] — the file was handed to macOS [open(1)] after
+      all blocking players failed. This is a GUI handoff fallback; playback
+      completion is not observable from the runtime;
     - [`Played duration_seconds] — playback succeeded.
 
     When [message] is omitted the dedup re-check is skipped (legacy

--- a/test/test_voice_runtime_overlay.ml
+++ b/test/test_voice_runtime_overlay.ml
@@ -56,6 +56,17 @@ let read_lines path =
     loop [])
 ;;
 
+let write_file path contents =
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc contents)
+;;
+
+let mkdir_if_missing path =
+  if not (Sys.file_exists path) then Unix.mkdir path 0o755
+;;
+
 let test_resolve_voice_aliases () =
   let elevenlabs = Option.get (Voice.resolve_adapter "elevenlabs") in
   check string "elevenlabs alias" "elevenlabs-direct" elevenlabs.canonical_name;
@@ -401,6 +412,85 @@ let test_playback_timeout_parsers_and_budget () =
     (Voice_bridge_core.playback_timeout_sec_for ~duration_sec:None)
 ;;
 
+let write_local_playback_config () =
+  let config_path = Voice_config.config_path () in
+  mkdir_if_missing (Filename.dirname config_path);
+  write_file config_path
+    {|
+{
+  "tts": {
+    "default_model": "test-tts",
+    "default_voice": "test-voice",
+    "default_voice_settings": {
+      "stability": 0.5,
+      "similarity_boost": 0.75,
+      "style": 0.0
+    },
+    "agent_voices": {},
+    "agent_voice_settings": {},
+    "endpoints": [
+      {
+        "id": "test-tts",
+        "kind": "elevenlabs_direct",
+        "api_key_env": "ELEVENLABS_API_KEY",
+        "enabled": true
+      }
+    ]
+  },
+  "stt": {
+    "default_model": "test-stt",
+    "endpoints": [
+      {
+        "id": "test-stt",
+        "kind": "elevenlabs_direct",
+        "api_key_env": "ELEVENLABS_API_KEY",
+        "enabled": true
+      }
+    ]
+  },
+  "session": {
+    "endpoints": []
+  },
+  "local_playback": {
+    "enabled": true,
+    "agents": []
+  }
+}
+|}
+;;
+
+let test_playback_open_fallback_reports_handoff () =
+  Eio_main.run
+  @@ fun _env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  write_local_playback_config ();
+  let bin_dir = Filename.concat voice_session_test_base "fake-playback-bin" in
+  mkdir_if_missing bin_dir;
+  let fake_afplay = Filename.concat bin_dir "afplay" in
+  let fake_open = Filename.concat bin_dir "open" in
+  write_file fake_afplay "#!/bin/sh\nexit 1\n";
+  write_file fake_open "#!/bin/sh\nexit 0\n";
+  Unix.chmod fake_afplay 0o755;
+  Unix.chmod fake_open 0o755;
+  let audio_file = Filename.concat voice_session_test_base "voice-open-fallback.mp3" in
+  write_file audio_file "fake audio bytes";
+  with_env "PATH" (Some bin_dir) (fun () ->
+    match
+      Voice_bridge_core.run_local_playback
+        ~sw
+        ~agent_id:"sangsu"
+        ~message:"open fallback regression"
+        ~audio_file
+        ()
+    with
+    | `Opened _ -> ()
+    | `Dedup_hit -> fail "expected open handoff, got dedup"
+    | `Failed reason -> fail ("expected open handoff, got failed: " ^ reason)
+    | `Played _ -> fail "expected open handoff, got played"
+    | `Skipped reason -> fail ("expected open handoff, got skipped: " ^ reason))
+;;
+
 let () =
   run
     "voice_runtime_overlay"
@@ -451,6 +541,10 @@ let () =
             "duration parsers and timeout budget"
             `Quick
             test_playback_timeout_parsers_and_budget
+        ; test_case
+            "open fallback reports handoff"
+            `Quick
+            test_playback_open_fallback_reports_handoff
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- restore macOS open(1) as the last local playback fallback after blocking players fail
- report open fallback as local_playback_status=opened instead of fake played_seconds
- add a regression test for failed blocking player -> open handoff

## Live evidence
- Current keeper generated TTS audio at /Users/dancer/me/.masc/audio/1781095303_sangsu.mp3
- The file decodes successfully with mpg123 -t
- In this execution environment, CLI playback backends cannot open a default audio device, matching the no-audible-output failure mode after open(1) was removed in #20724

## Verification
- git diff --check
- scripts/dune-local.sh build test/test_voice_runtime_overlay.exe
- ./_build/default/test/test_voice_runtime_overlay.exe