### PR TITLE
[codex] Fix keeper runtime detail save flow

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -1,4 +1,13 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const devTokenMock = vi.hoisted(() => ({
+  ensureDevToken: vi.fn(() => Promise.resolve()),
+}))
+
+vi.mock('./dev-token', () => ({
+  ensureDevToken: devTokenMock.ensureDevToken,
+}))
+
 import {
   fetchDashboardShell,
   fetchDashboardExecutionTrust,
@@ -12,6 +21,7 @@ import {
   fetchDashboardMemory,
   fetchDashboardMission,
   fetchDashboardMissionBriefing,
+  fetchDashboardRuntimeProbe,
   fetchCostLatency,
   fetchKeeperConfig,
   fetchKeeperCostMetrics,
@@ -20,6 +30,7 @@ import {
   fetchRuntimeProviders,
   fetchRuntimeTomlConfig,
   fetchRuntimeModelMetrics,
+  patchKeeperConfig,
   saveRuntimeTomlConfig,
   fetchDashboardCacheStats,
   fetchTelemetry,
@@ -32,6 +43,8 @@ import { keeperRuntimeBlockerLabel } from '../lib/keeper-runtime-display'
 
 afterEach(() => {
   vi.unstubAllGlobals()
+  devTokenMock.ensureDevToken.mockClear()
+  devTokenMock.ensureDevToken.mockResolvedValue(undefined)
 })
 
 function makeRawGoalNode(overrides: Record<string, unknown> = {}) {
@@ -1613,6 +1626,72 @@ describe('fetchKeeperConfig', () => {
   })
 })
 
+describe('keeper config mutation API', () => {
+  it('ensures dashboard auth before posting runtime_id changes', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        name: 'keeper-sangsu',
+        execution: {
+          selected_runtime_id: 'b.two',
+          selected_runtime_canonical: 'b.two',
+          runtime_options: ['a.one', 'b.two'],
+        },
+        sources: {
+          default_source_kind: 'toml',
+          default_manifest_path: '/tmp/.masc/config/keepers/sangsu.toml',
+        },
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await patchKeeperConfig('keeper-sangsu', { runtime_id: 'b.two' })
+
+    expect(devTokenMock.ensureDevToken).toHaveBeenCalledTimes(1)
+    expect(devTokenMock.ensureDevToken.mock.invocationCallOrder[0]).toBeLessThan(
+      fetchMock.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('/api/v1/keepers/keeper-sangsu/config')
+    expect(init.method).toBe('POST')
+    expect(JSON.parse(init.body as string)).toEqual({ runtime_id: 'b.two' })
+    expect(result.execution.selected_runtime_id).toBe('b.two')
+  })
+})
+
+describe('dashboard runtime probe API', () => {
+  it('ensures dashboard auth before fetching runtime probe status', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        generated_at: '2026-06-10T12:00:00Z',
+        probe: {
+          status: 'ok',
+          probe_ok: true,
+          summary: { runtimes: 1, reachable: 1, failed: 0 },
+          providers: [],
+        },
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchDashboardRuntimeProbe(true)
+
+    expect(devTokenMock.ensureDevToken).toHaveBeenCalledTimes(1)
+    expect(devTokenMock.ensureDevToken.mock.invocationCallOrder[0]).toBeLessThan(
+      fetchMock.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/dashboard/runtime-probe?force=1')
+    expect(result.probe?.probe_ok).toBe(true)
+  })
+})
+
 describe('runtime.toml raw config API', () => {
   it('fetches and normalizes the raw runtime.toml source', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
@@ -1631,6 +1710,10 @@ describe('runtime.toml raw config API', () => {
 
     const result = await fetchRuntimeTomlConfig()
 
+    expect(devTokenMock.ensureDevToken).toHaveBeenCalledTimes(1)
+    expect(devTokenMock.ensureDevToken.mock.invocationCallOrder[0]).toBeLessThan(
+      fetchMock.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    )
     expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/runtime/config/raw')
     expect(result.path).toBe('/tmp/.masc/config/runtime.toml')
     expect(result.file_name).toBe('runtime.toml')
@@ -1656,6 +1739,10 @@ describe('runtime.toml raw config API', () => {
 
     const result = await saveRuntimeTomlConfig(sourceText)
 
+    expect(devTokenMock.ensureDevToken).toHaveBeenCalledTimes(1)
+    expect(devTokenMock.ensureDevToken.mock.invocationCallOrder[0]).toBeLessThan(
+      fetchMock.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    )
     expect(fetchMock).toHaveBeenCalledTimes(1)
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
     expect(url).toBe('/api/v1/runtime/config/raw')

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -12,6 +12,7 @@ import {
 import { normalizePendingConfirmation } from '../pending-confirm'
 import { normalizeKeeperTrustTerminalReason } from '../keeper-store-normalize'
 import { currentDashboardActor, get, post, withRetries, type AbortableRequestOptions } from './core'
+import { ensureDevToken } from './dev-token'
 import { DEFAULT_WINDOW_MINUTES_24H } from '../config/constants'
 import {
   parseAgentRelationsResponse,
@@ -1800,11 +1801,12 @@ export function fetchToolMetrics(): Promise<ToolMetricsResponse> {
   return get('/api/v1/tool-metrics')
 }
 
-export function fetchDashboardRuntimeProbe(
+export async function fetchDashboardRuntimeProbe(
   force = false,
   opts?: AbortableRequestOptions,
 ): Promise<DashboardRuntimeProbeResponse> {
   const query = force ? '?force=1' : ''
+  await ensureDevToken()
   return get(`/api/v1/dashboard/runtime-probe${query}`, { signal: opts?.signal })
 }
 
@@ -2186,10 +2188,11 @@ export type KeeperConfigUpdatePayload = {
   handoff_cooldown_sec?: number
 }
 
-export function patchKeeperConfig(
+export async function patchKeeperConfig(
   name: string,
   payload: KeeperConfigUpdatePayload,
 ): Promise<KeeperConfig> {
+  await ensureDevToken()
   return post<unknown>(
     `/api/v1/keepers/${encodeURIComponent(name)}/config`,
     payload,
@@ -2217,11 +2220,13 @@ function normalizeRuntimeTomlConfig(raw: unknown): RuntimeTomlConfig {
   }
 }
 
-export function fetchRuntimeTomlConfig(): Promise<RuntimeTomlConfig> {
+export async function fetchRuntimeTomlConfig(): Promise<RuntimeTomlConfig> {
+  await ensureDevToken()
   return get<unknown>('/api/v1/runtime/config/raw').then(normalizeRuntimeTomlConfig)
 }
 
-export function saveRuntimeTomlConfig(sourceText: string): Promise<RuntimeTomlConfig> {
+export async function saveRuntimeTomlConfig(sourceText: string): Promise<RuntimeTomlConfig> {
+  await ensureDevToken()
   return post<unknown>('/api/v1/runtime/config/raw', {
     source_text: sourceText,
   }).then(normalizeRuntimeTomlConfig)

--- a/dashboard/src/components/keeper-detail-body.ts
+++ b/dashboard/src/components/keeper-detail-body.ts
@@ -102,6 +102,9 @@ export function KeeperDetailBody({
 }: KeeperDetailBodyProps) {
   return html`
     <div class="mx-auto flex w-full max-w-[1180px] flex-col gap-5">
+        <${KeeperRuntimeAlertStrip} keeper=${keeper} />
+        <${KeeperDetailSectionRail} />
+
         <${KeeperDetailSection}
           id="keeper-comms"
           eyebrow="대화 & 세션"
@@ -114,9 +117,6 @@ export function KeeperDetailBody({
             <${SessionTraceView} agentName=${keeper.name} isKeeper=${true} keeperStatus=${keeper.status} keeperGeneration=${keeper.generation} />
           <//>
         <//>
-
-        <${KeeperRuntimeAlertStrip} keeper=${keeper} />
-        <${KeeperDetailSectionRail} />
 
         <${KeeperDetailSection}
           id="keeper-summary"

--- a/dashboard/src/components/keeper-detail-page.ts
+++ b/dashboard/src/components/keeper-detail-page.ts
@@ -193,7 +193,7 @@ export function KeeperDetailPage() {
 
   return html`
     <div class="mx-auto flex w-full max-w-[1380px] flex-col gap-5 pb-8" data-route-focused-keeper=${keeper.name}>
-      <div class="sticky top-0 z-20 mx-auto w-full max-w-[1180px] overflow-hidden rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] shadow-none backdrop-blur-xl">
+      <div class="sm:sticky sm:top-0 z-20 mx-auto w-full max-w-[1180px] overflow-hidden rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] shadow-none backdrop-blur-xl">
         <div class="flex flex-col items-stretch justify-between gap-3 px-4 py-2.5 sm:flex-row sm:items-center sm:px-5">
           <${KeeperDetailHeaderInfo}
             keeper=${keeper}

--- a/dashboard/src/components/keeper-detail-shell.test.ts
+++ b/dashboard/src/components/keeper-detail-shell.test.ts
@@ -1,7 +1,15 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { html } from 'htm/preact'
 import { render } from 'preact'
-import { KeeperDetailSection, KeeperDetailSectionRail } from './keeper-detail-shell'
+import {
+  KeeperDetailSection,
+  KeeperDetailSectionRail,
+  activeKeeperDetailSection,
+} from './keeper-detail-shell'
+
+async function flush() {
+  await new Promise(resolve => setTimeout(resolve, 0))
+}
 
 describe('KeeperDetailSection', () => {
   let container: HTMLDivElement
@@ -9,6 +17,7 @@ describe('KeeperDetailSection', () => {
   beforeEach(() => {
     container = document.createElement('div')
     document.body.appendChild(container)
+    activeKeeperDetailSection.value = 'keeper-summary'
   })
 
   afterEach(() => {
@@ -34,6 +43,7 @@ describe('KeeperDetailSection', () => {
   })
 
   it('sets section id and aria-label', () => {
+    activeKeeperDetailSection.value = 'keeper-debug'
     render(
       html`<${KeeperDetailSection}
         id="keeper-debug"
@@ -51,6 +61,7 @@ describe('KeeperDetailSection', () => {
   })
 
   it('applies scroll margin and compact section styling', () => {
+    activeKeeperDetailSection.value = 'keeper-config'
     render(
       html`<${KeeperDetailSection}
         id="keeper-config"
@@ -69,6 +80,7 @@ describe('KeeperDetailSection', () => {
   })
 
   it('keeps locked-open primary sections visible without a collapse button', () => {
+    activeKeeperDetailSection.value = 'keeper-comms'
     render(
       html`<${KeeperDetailSection}
         id="keeper-comms"
@@ -96,6 +108,7 @@ describe('KeeperDetailSectionRail', () => {
   beforeEach(() => {
     container = document.createElement('div')
     document.body.appendChild(container)
+    activeKeeperDetailSection.value = 'keeper-comms'
   })
 
   afterEach(() => {
@@ -116,5 +129,30 @@ describe('KeeperDetailSectionRail', () => {
     expect(container.textContent).toContain('디버그')
     expect(container.textContent).not.toContain('상태 기계, KPI')
     expect(container.textContent).not.toContain('실시간 대화와 세션 이벤트')
+  })
+
+  it('switches the active detail tab', async () => {
+    render(html`
+      <${KeeperDetailSectionRail} />
+      <${KeeperDetailSection} id="keeper-comms" eyebrow="CHAT" title="Conversation">
+        <div data-testid="comms-child">Comms</div>
+      <//>
+      <${KeeperDetailSection} id="keeper-runtime" eyebrow="RUN" title="Runtime">
+        <div data-testid="runtime-child">Runtime</div>
+      <//>
+    `, container)
+
+    expect(container.querySelector('[data-testid="comms-child"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="runtime-child"]')).toBeNull()
+
+    const runtimeTab = Array.from(container.querySelectorAll('button[role="tab"]'))
+      .find(button => button.textContent === '진단') as HTMLButtonElement | undefined
+    expect(runtimeTab).toBeTruthy()
+    runtimeTab!.click()
+    await flush()
+
+    expect(activeKeeperDetailSection.value).toBe('keeper-runtime')
+    expect(container.querySelector('[data-testid="comms-child"]')).toBeNull()
+    expect(container.querySelector('[data-testid="runtime-child"]')).not.toBeNull()
   })
 })

--- a/dashboard/src/components/keeper-detail-shell.ts
+++ b/dashboard/src/components/keeper-detail-shell.ts
@@ -1,6 +1,6 @@
 import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'
-import { useState } from 'preact/hooks'
+import { signal } from '@preact/signals'
 import { TimeAgo } from './common/time-ago'
 import type { Keeper } from '../types'
 import { keepers } from '../store'
@@ -115,6 +115,8 @@ type KeeperDetailSectionId =
   | 'keeper-config'
   | 'keeper-debug'
 
+export const activeKeeperDetailSection = signal<KeeperDetailSectionId>('keeper-comms')
+
 const KEEPER_DETAIL_SECTIONS: Array<{
   id: KeeperDetailSectionId
   label: string
@@ -145,22 +147,29 @@ const KEEPER_DETAIL_SECTIONS: Array<{
   },
 ]
 
-function scrollToKeeperDetailSection(sectionId: KeeperDetailSectionId): void {
-  document.getElementById(sectionId)?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+function selectKeeperDetailSection(sectionId: KeeperDetailSectionId): void {
+  activeKeeperDetailSection.value = sectionId
 }
 
 export function KeeperDetailSectionRail() {
+  const active = activeKeeperDetailSection.value
   return html`
     <nav
-      class="sticky top-[64px] z-10 overflow-x-auto border-b border-[var(--color-border-default)] bg-[var(--color-bg-page)] py-1.5"
+      class="sm:sticky sm:top-[var(--header-h)] z-10 overflow-x-auto border-b border-[var(--color-border-default)] bg-[var(--color-bg-page)] py-1.5"
       aria-label="키퍼 상세 섹션"
     >
-      <div class="flex min-w-max items-center gap-1.5 px-1">
+      <div class="flex min-w-max items-center gap-1.5 px-1" role="tablist" aria-label="키퍼 상세 탭">
         ${KEEPER_DETAIL_SECTIONS.map((section) => html`
           <button
+            id=${`${section.id}-tab`}
             type="button"
-            class="h-8 shrink-0 rounded-[var(--r-1)] border border-transparent px-3 text-2xs font-semibold text-[var(--color-fg-muted)] transition-colors hover:border-[var(--color-border-default)] hover:bg-[var(--color-bg-surface)] hover:text-[var(--color-fg-primary)]"
-            onClick=${() => scrollToKeeperDetailSection(section.id)}
+            role="tab"
+            aria-selected=${active === section.id}
+            aria-controls=${section.id}
+            class=${active === section.id
+              ? 'h-8 shrink-0 rounded-[var(--r-1)] border border-[var(--accent-30)] bg-[var(--accent-12)] px-3 text-2xs font-semibold text-[var(--color-accent-fg)] transition-colors'
+              : 'h-8 shrink-0 rounded-[var(--r-1)] border border-transparent px-3 text-2xs font-semibold text-[var(--color-fg-muted)] transition-colors hover:border-[var(--color-border-default)] hover:bg-[var(--color-bg-surface)] hover:text-[var(--color-fg-primary)]'}
+            onClick=${() => selectKeeperDetailSection(section.id)}
           >
             ${section.label}
           </button>
@@ -174,7 +183,6 @@ export function KeeperDetailSection({
   id,
   eyebrow,
   title,
-  defaultCollapsed = false,
   lockedOpen = false,
   variant = 'default',
   children,
@@ -182,11 +190,8 @@ export function KeeperDetailSection({
   id: KeeperDetailSectionId
   eyebrow: string
   title: string
-  /** When true, the section body starts collapsed and the operator
-   *  expands it by clicking the header. Defaults to expanded so the
-   *  long-standing always-open behaviour is preserved for callers
-   *  that do not opt in. Quick-jump links via [scrollToKeeperDetailSection]
-   *  still resolve to the header anchor regardless of the body state. */
+  /** Preserved for old call sites; top-level keeper detail sections now render
+   *  as tabs, while nested CollapsibleSection handles local disclosure. */
   defaultCollapsed?: boolean
   /** Primary sections, such as the chat lane, stay open and do not expose
    *  collapse controls. */
@@ -194,8 +199,7 @@ export function KeeperDetailSection({
   variant?: 'default' | 'primary'
   children: ComponentChildren
 }) {
-  const [collapsed, setCollapsed] = useState(lockedOpen ? false : defaultCollapsed)
-  const isCollapsed = lockedOpen ? false : collapsed
+  const isActive = activeKeeperDetailSection.value === id
   const bodyId = `${id}-body`
   const sectionClass = variant === 'primary'
     ? 'scroll-mt-24 rounded-[var(--r-2)] bg-transparent shadow-none'
@@ -203,6 +207,7 @@ export function KeeperDetailSection({
   const headerClass = variant === 'primary'
     ? 'sr-only'
     : 'flex w-full items-center justify-between gap-3 border-b border-[var(--color-border-default)] px-4 py-3 text-left transition-colors hover:bg-[var(--color-bg-hover)] sm:px-5'
+  if (!isActive) return null
   const headerContent = html`
     <div class="min-w-0">
       <div class="text-3xs font-semibold uppercase tracking-[var(--track-brand)] text-[var(--color-fg-muted)]">${eyebrow}</div>
@@ -212,37 +217,20 @@ export function KeeperDetailSection({
       ? html`<span class="shrink-0 rounded-[var(--r-0)] border border-[var(--accent-20)] bg-[var(--accent-10)] px-2 py-1 text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-accent-fg)]">기본</span>`
       : lockedOpen
         ? null
-      : html`
-        <span
-          aria-hidden="true"
-          class=${`shrink-0 text-[var(--color-fg-muted)] transition-transform duration-[var(--t-med)] ${isCollapsed ? '' : 'rotate-180'}`}
-        >▾</span>
-      `}
+      : null}
   `
   return html`
     <section
       id=${id}
       class=${sectionClass}
       aria-label=${title}
+      aria-labelledby=${`${id}-tab`}
+      role="tabpanel"
     >
-      ${lockedOpen
-        ? html`<div class=${headerClass}>${headerContent}</div>`
-        : html`
-          <button
-            type="button"
-            class=${headerClass}
-            aria-expanded=${!isCollapsed}
-            aria-controls=${bodyId}
-            onClick=${() => setCollapsed((c: boolean) => !c)}
-          >
-            ${headerContent}
-          </button>
-        `}
-      ${isCollapsed ? null : html`
-        <div id=${bodyId} class=${variant === 'primary' ? 'flex flex-col gap-4 px-0 py-0' : 'flex flex-col gap-4 px-4 py-4 sm:px-5'}>
-          ${children}
-        </div>
-      `}
+      <div class=${headerClass}>${headerContent}</div>
+      <div id=${bodyId} class=${variant === 'primary' ? 'flex flex-col gap-4 px-0 py-0' : 'flex flex-col gap-4 px-4 py-4 sm:px-5'}>
+        ${children}
+      </div>
     </section>
   `
 }

--- a/dashboard/src/components/keeper-detail.test.ts
+++ b/dashboard/src/components/keeper-detail.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { cleanup, render, screen } from '@testing-library/preact'
+import { cleanup, fireEvent, render, screen } from '@testing-library/preact'
 import { html } from 'htm/preact'
 
 import type { Keeper } from '../types'
@@ -137,6 +137,7 @@ vi.mock('../router', () => ({
 }))
 
 import { KeeperDetailPage } from './keeper-detail-page'
+import { activeKeeperDetailSection } from './keeper-detail-shell'
 import {
   clearKeeperDetailSelection,
   closeKeeperDetail,
@@ -262,6 +263,7 @@ describe('KeeperDetailPage', () => {
       params: { section: 'agents', view: 'keepers', keeper: 'analyst' },
       postId: null,
     }
+    activeKeeperDetailSection.value = 'keeper-comms'
     vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({}), {
       headers: { 'content-type': 'application/json' },
       status: 200,
@@ -333,7 +335,12 @@ describe('KeeperDetailPage', () => {
     expect(screen.queryByText('FSM Hub (6축 상태 머신)')).toBeNull()
     const pageText = container.textContent ?? ''
     expect(pageText.indexOf('대화 / 세션')).toBeGreaterThanOrEqual(0)
-    expect(pageText.indexOf('운영 상태 개요')).toBeGreaterThan(pageText.indexOf('대화 / 세션'))
+    expect(pageText.indexOf('운영 상태 개요')).toBe(-1)
+    const statusTab = screen.getByRole('tab', { name: '상태' })
+    fireEvent.click(statusTab)
+    expect(statusTab.getAttribute('aria-selected')).toBe('true')
+    expect(screen.getByText('운영 상태 개요')).toBeTruthy()
+    expect(screen.queryByText('대화 / 세션')).toBeNull()
     expect(mocks.selectKeeper).toHaveBeenCalledWith('analyst')
   })
 


### PR DESCRIPTION
## Summary
- gate keeper config mutation and runtime config/probe calls on loopback dev-token bootstrap before issuing authenticated dashboard requests
- convert keeper detail from a long all-sections page into top-level tabs so only one detail section renders at a time
- adjust keeper detail sticky behavior so the mobile runtime editor is not covered while scrolling

## Root cause
The keeper runtime selector could enable a save in the UI, but the authenticated save/probe requests could race the loopback dev-token bootstrap and hit `401 Unauthorized`. That made the runtime change appear saved from the operator surface while the server config did not change.

## Validation
- `pnpm --dir dashboard exec vitest run src/api/dashboard.test.ts src/components/keeper-detail-shell.test.ts src/components/keeper-detail.test.ts src/components/keeper-runtime-model-editor.test.ts --no-file-parallelism --maxWorkers=1` -> 84 tests passed
- `pnpm --dir dashboard exec tsc --noEmit --pretty false`
- `pnpm --dir dashboard exec eslint src/api/dashboard.ts src/api/dashboard.test.ts src/components/keeper-detail-shell.ts src/components/keeper-detail-body.ts src/components/keeper-detail-page.ts src/components/keeper-detail-shell.test.ts src/components/keeper-detail.test.ts` -> source files passed; test files are ignored by current ESLint config warnings only
- Playwright Chromium against `http://localhost:5173/dashboard/monitoring/agents?keeper=sangsu`: desktop and mobile both selected the `진단` tab, found 5 runtime options, changing runtime enabled `저장`, `되돌리기` disabled it again, and there were no 4xx/5xx responses or page errors

## Live runtime note
I did not click final `저장` against the live `sangsu` keeper during QA to avoid changing `/Users/dancer/me/.masc` runtime state. The rendered flow was validated up to the enabled save action, and the API regression tests cover the authenticated POST ordering.