### PR TITLE
ci: make lint gate a superset of check-ssot R6 scan paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,7 +237,15 @@ jobs:
             build=true
           fi
 
-          if has_match '^(bin/|lib/|test/|proto/|config/|dune-project$|dune-workspace$|.*\.opam$|scripts/install\.sh$|scripts/check-eio-conventions\.sh$|scripts/check-feature-flag-consistency\.sh$|scripts/check-toml-syntax\.sh$|scripts/validate-prompt-paths\.sh$|scripts/check-boundary-guard\.sh$|scripts/check-boundary-guard-mli-pairs\.sh$|scripts/check-ssot\.sh$|scripts/gen-grpc-descriptors\.sh$|scripts/lint/no-unknown-permissive-default\.sh$|scripts/lint/no-unknown-permissive-default\.allowlist$|scripts/lint/yojson-option-default\.py$|scripts/lint/yojson-option-default\.allowlist$|scripts/lint/no-docstring-escape-quote\.sh$|scripts/lint/no-hardcoded-colors-dashboard\.sh$|scripts/lint/no-hardcoded-colors-dashboard\.allowlist$|scripts/lint/dashboard-ssot-keeper-state\.sh$|scripts/lint/dashboard-ssot-keeper-state\.allowlist$|scripts/lint/dashboard-ssot-agent-status\.sh$|scripts/lint/dashboard-ssot-agent-status\.allowlist$|scripts/ci/|scripts/check-variants\.sh$|dashboard/src/)'; then
+          # The lint trigger set must stay a superset of every path the Lint
+          # job reads. scripts/check-ssot.sh R6 scans bin/ lib/ scripts/ docs/,
+          # so docs/ and scripts/ (whole tree, not just the curated entries)
+          # must trigger Lint — otherwise a docs-only or scripts-only PR can
+          # merge gate-skipped while pushing an R6 count past its baseline,
+          # breaking Lint for every subsequent PR (#20729: RFC docs #20717 /
+          # #20718 landed bare ~/.masc paths and took main's Lint red).
+          # scripts/ subsumes the previously enumerated scripts/* entries.
+          if has_match '^(bin/|lib/|test/|proto/|config/|docs/|scripts/|dune-project$|dune-workspace$|.*\.opam$|dashboard/src/)'; then
             lint=true
           fi
 


### PR DESCRIPTION
Closes #20729.

## 문제

`Detect Changed Surfaces` 게이트의 lint surface 정규식에 `docs/`가 없고, `scripts/`는 큐레이션된 개별 항목만 매칭했습니다. 그러나 Lint job이 실행하는 `scripts/check-ssot.sh`의 R6 ratchet은 `bin lib scripts docs` 4개 트리를 스캔합니다.

결과: docs-only PR(#20717/#20718)이 bare `~/.masc` 경로를 추가하면서 **Lint가 스킵된 채 머지** → R6 카운트가 baseline(9)을 초과(11) → 이후 모든 PR의 Lint가 red (2026-06-10 broken main, 핫픽스 #20728로 카운트만 복구). 임의의 `scripts/*.sh` 신규 파일도 동일한 실패 모양이 가능했습니다.

## 수정

게이트 불변식을 복원합니다: **lint 트리거 경로 집합 ⊇ Lint job이 읽는 경로 집합.**

- lint 정규식에 `docs/`와 `scripts/`(전체 트리) 추가.
- `scripts/`가 기존에 나열된 모든 `scripts/...` 개별 항목의 strict superset이므로 해당 항목들을 제거해 정규식 단순화 (행동 보존).
- 불변식과 사고 경위를 정규식 위 주석으로 명시.

## 검증

- YAML 파싱 통과.
- 정규식 시뮬레이션 17케이스: 사고 파일 2건(RFC-0223/0224 docs) lint=true, 기존 큐레이션 scripts 항목 6건 전부 lint=true 유지, 신규 `scripts/*.sh` lint=true, 비트리거(README.md — R6 스캔 대상 아님 / dashboard/package.json / specs/) lint=false 유지.

## 트레이드오프

docs-only PR에서도 Lint(~44s)가 돌게 됩니다. R6 사고의 재발 방지 대비 수용 가능한 비용입니다. 근본적으로는 게이트 정규식과 checker 스캔 집합이 두 곳에 중복 정의된 구조라 drift 위험이 남습니다 — 이번 수정은 집합을 정렬하고 주석으로 상호 참조를 명시하는 선에서 정리했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
