### PR TITLE
[codex] Add keeper secret projection dashboard

### DIFF
--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -39,6 +39,8 @@ export type {
   KeeperLastOutcome,
   KeeperCompositeExecution,
   KeeperRuntimeAttention,
+  KeeperSecretProjection,
+  KeeperSecretFileMount,
   KeeperPhaseDiagnosis,
   KeeperPhaseDiagnosisRow,
   KeeperCompositePhase,

--- a/dashboard/src/api/schemas/keeper-composite.test.ts
+++ b/dashboard/src/api/schemas/keeper-composite.test.ts
@@ -232,6 +232,34 @@ describe('parseKeeperCompositeSnapshot', () => {
     expect(result.runtime_attention?.fiber_stop_requested).toBe(false)
   })
 
+  it('parses secret projection status without secret values', () => {
+    const result = parseKeeperCompositeSnapshot({
+      ...VALID_SNAPSHOT,
+      secret_projection: {
+        status: 'ready',
+        configured: true,
+        root: '/Users/dancer/me/.masc/secrets/sangsu',
+        source: 'workspace_masc_secrets',
+        env_count: 1,
+        file_count: 1,
+        env_names: ['GH_TOKEN'],
+        file_mounts: [
+          {
+            host_path: '/Users/dancer/me/.masc/secrets/sangsu/files/home/keeper/.ssh/id_ed25519',
+            container_path: '/home/keeper/.ssh/id_ed25519',
+          },
+        ],
+        values_validated: true,
+        error: null,
+        next_action: 'none',
+      },
+    })
+
+    expect(result.secret_projection?.status).toBe('ready')
+    expect(result.secret_projection?.env_names).toEqual(['GH_TOKEN'])
+    expect(JSON.stringify(result.secret_projection)).not.toContain('ghs_')
+  })
+
   it('parses snapshot with measurement auto_rules', () => {
     const result = parseKeeperCompositeSnapshot({
       ...VALID_SNAPSHOT,

--- a/dashboard/src/api/schemas/keeper-composite.ts
+++ b/dashboard/src/api/schemas/keeper-composite.ts
@@ -177,6 +177,25 @@ const KeeperRuntimeAttentionSchema = object({
   live_turn_last_progress_at: optional(nullable(number())),
 })
 
+const KeeperSecretFileMountSchema = object({
+  host_path: string(),
+  container_path: string(),
+})
+
+const KeeperSecretProjectionSchema = object({
+  status: string(),
+  configured: boolean(),
+  root: string(),
+  source: string(),
+  env_count: number(),
+  file_count: number(),
+  env_names: fallback(array(string()), []),
+  file_mounts: fallback(array(KeeperSecretFileMountSchema), []),
+  values_validated: boolean(),
+  error: nullable(string()),
+  next_action: string(),
+})
+
 const OperatorRecommendedActionSchema = object({
   action_type: string(),
   target_type: string(),
@@ -234,6 +253,7 @@ export const KeeperCompositeSnapshotSchema = object({
   last_turn_ts: optional(number()),
   execution: optional(KeeperCompositeExecutionSchema),
   runtime_attention: optional(KeeperRuntimeAttentionSchema),
+  secret_projection: optional(KeeperSecretProjectionSchema),
   recommended_actions: fallback(array(OperatorRecommendedActionSchema), []),
   /** @deprecated kept only for old backend experiments; new payloads use `execution`. */
   latest_receipt: optional(unknown()),
@@ -247,6 +267,8 @@ export type KeeperPhaseDiagnosisRow = InferOutput<typeof KeeperPhaseDiagnosisRow
 export type KeeperLastOutcome = InferOutput<typeof KeeperLastOutcomeSchema>
 export type KeeperCompositeExecution = InferOutput<typeof KeeperCompositeExecutionSchema>
 export type KeeperRuntimeAttention = InferOutput<typeof KeeperRuntimeAttentionSchema>
+export type KeeperSecretProjection = InferOutput<typeof KeeperSecretProjectionSchema>
+export type KeeperSecretFileMount = InferOutput<typeof KeeperSecretFileMountSchema>
 export type KeeperCompositePhase = InferOutput<typeof KeeperCompositePhaseSchema>
 export type KeeperCompositeTurnPhase = InferOutput<typeof KeeperCompositeTurnPhaseSchema>
 export type KeeperCompositeDecisionStage = InferOutput<typeof KeeperCompositeDecisionStageSchema>

--- a/dashboard/src/components/keeper-detail-body.ts
+++ b/dashboard/src/components/keeper-detail-body.ts
@@ -22,6 +22,7 @@ import {
 } from './keeper-detail-telemetry'
 import {
   KeeperLiveTruthPanel,
+  KeeperSecretProjectionPanel,
   RuntimeLensSection,
   RuntimeSignals,
   TurnBudgetSection,
@@ -180,6 +181,7 @@ export function KeeperDetailBody({
           ${'' /* ── 런타임 model 편집 (RFC-0207 persona runtime_id) — surfaced here so it is one expand away, not buried under 설정 → Keeper 설정 → 소스 ── */}
           <${KeeperRuntimeModelEditor} keeperName=${keeper.name} />
           <${KeeperToolTelemetry} keeperName=${keeper.name} />
+          <${KeeperSecretProjectionPanel} projection=${compositeSnapshot?.secret_projection} />
           <${KeeperEvalQualityPanel} keeperName=${keeper.name} />
           <${CollapsibleSection} title="Live Truth (composite/runtime 합성)" open=${false}>
             <${KeeperLiveTruthPanel}

--- a/dashboard/src/components/keeper-detail-runtime.test.ts
+++ b/dashboard/src/components/keeper-detail-runtime.test.ts
@@ -10,6 +10,7 @@ import {
   BudgetSourceBadge,
   RuntimeLensSection,
   RuntimeSignals,
+  KeeperSecretProjectionPanel,
   budgetSourceLabel,
   budgetSourceTone,
   filterSignalGroups,
@@ -848,6 +849,36 @@ describe('RuntimeLensSection', () => {
     expect(summary.runtimeWarnings).toEqual(['Runtime build commit differs from server repo HEAD.'])
     expect(summary.runtimeBuildLabel).toBe('386514c1f9 vs workspace d0add960d7')
     expect(summary.runtimeRepoLabel).toBe('.worktrees/stale-server')
+  })
+
+  it('renders secret projection status without secret values', () => {
+    render(h(KeeperSecretProjectionPanel, {
+      projection: {
+        status: 'ready',
+        configured: true,
+        root: '/Users/dancer/me/.masc/secrets/sangsu',
+        source: 'workspace_masc_secrets',
+        env_count: 1,
+        file_count: 1,
+        env_names: ['GH_TOKEN'],
+        file_mounts: [
+          {
+            host_path: '/Users/dancer/me/.masc/secrets/sangsu/files/home/keeper/.ssh/id_ed25519',
+            container_path: '/home/keeper/.ssh/id_ed25519',
+          },
+        ],
+        values_validated: true,
+        error: null,
+        next_action: 'none',
+      },
+    }))
+
+    expect(screen.getByTestId('keeper-secret-projection')).toBeInTheDocument()
+    expect(screen.getByText('ready')).toBeInTheDocument()
+    expect(screen.getByText('1 env · 1 files')).toBeInTheDocument()
+    expect(screen.getByText('GH_TOKEN')).toBeInTheDocument()
+    expect(screen.getByText('/home/keeper/.ssh/id_ed25519')).toBeInTheDocument()
+    expect(screen.queryByText(/ghs_/)).toBeNull()
   })
 })
 

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -22,6 +22,7 @@ import { formatIndependentCounters, formatRatioPair } from './counter-format'
 import type { Keeper } from '../types'
 import type {
   KeeperCompositeSnapshot,
+  KeeperSecretProjection,
   KeeperRuntimeLensClockEdge,
   KeeperRuntimeLensClockGroup,
   KeeperRuntimeLensLane,
@@ -305,6 +306,109 @@ export function KeeperLiveTruthPanel({
           ${summary.runtimeRepoLabel ? html`<span class="font-mono">repo ${summary.runtimeRepoLabel}</span>` : null}
         </div>
       ` : null}
+    </div>
+  `
+}
+
+function secretProjectionTone(status: string | null | undefined): StatusChipTone {
+  switch (status) {
+    case 'ready':
+      return 'ok'
+    case 'error':
+      return 'bad'
+    case 'empty':
+      return 'warn'
+    case 'absent':
+    default:
+      return 'neutral'
+  }
+}
+
+function secretProjectionLabel(status: string | null | undefined): string {
+  switch (status) {
+    case 'ready':
+      return 'ready'
+    case 'error':
+      return 'error'
+    case 'empty':
+      return 'empty'
+    case 'absent':
+      return 'not configured'
+    default:
+      return 'unknown'
+  }
+}
+
+function truncateSecretProjectionList(values: readonly string[], limit: number): string {
+  if (values.length === 0) return 'none'
+  const visible = values.slice(0, limit)
+  const suffix = values.length > visible.length ? ` +${values.length - visible.length}` : ''
+  return `${visible.join(', ')}${suffix}`
+}
+
+export function KeeperSecretProjectionPanel({
+  projection,
+}: {
+  projection: KeeperSecretProjection | null | undefined
+}) {
+  if (!projection) {
+    return html`
+      <div
+        class="rounded-[var(--r-5)] border border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] p-4"
+        data-testid="keeper-secret-projection"
+      >
+        <div class="flex items-center justify-between gap-3">
+          <div>
+            <div class="text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Secret projection</div>
+            <div class="mt-1 text-sm font-medium text-[var(--color-fg-primary)]">backend not reporting</div>
+          </div>
+          <${StatusChip} tone="neutral" uppercase=${false}>unknown<//>
+        </div>
+      </div>
+    `
+  }
+
+  const tone = secretProjectionTone(projection.status)
+  const filePaths = projection.file_mounts.map(mount => mount.container_path)
+  const envSummary = truncateSecretProjectionList(projection.env_names, 5)
+  const fileSummary = truncateSecretProjectionList(filePaths, 4)
+  const summary =
+    projection.status === 'ready'
+      ? `${projection.env_count} env · ${projection.file_count} files`
+      : projection.status === 'error'
+        ? projection.error ?? 'projection error'
+        : projection.next_action
+
+  return html`
+    <div
+      class="rounded-[var(--r-5)] border border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] p-4"
+      data-testid="keeper-secret-projection"
+    >
+      <div class="flex flex-wrap items-start justify-between gap-3">
+        <div class="min-w-0">
+          <div class="text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Secret projection</div>
+          <div class="mt-1 flex flex-wrap items-center gap-2">
+            <${StatusChip} tone=${tone} uppercase=${false}>${secretProjectionLabel(projection.status)}<//>
+            <span class="text-sm font-medium text-[var(--color-fg-primary)]">${summary}</span>
+          </div>
+        </div>
+        <span class="font-mono text-3xs text-[var(--color-fg-muted)]">${projection.source}</span>
+      </div>
+
+      <div class="mt-3 grid grid-cols-1 gap-2 md:grid-cols-2">
+        <${SignalRow} label="root" value=${projection.root} />
+        <${SignalRow} label="env names" value=${envSummary} />
+        <${SignalRow} label="file mounts" value=${fileSummary} />
+        <${SignalRow} label="validation" value=${projection.values_validated ? 'values validated · values redacted' : 'structure only'} />
+      </div>
+
+      ${projection.error
+        ? html`
+            <div class="mt-3 rounded-[var(--r-1)] border border-[var(--bad-20)] bg-[var(--bad-10)] px-3 py-2 text-xs text-[var(--bad-light)]">
+              ${projection.error}
+            </div>
+          `
+        : null}
     </div>
   `
 }

--- a/dashboard/src/components/tools/config-resolution-panel.test.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.test.ts
@@ -29,40 +29,42 @@ describe('ConfigResolutionPanel', () => {
     document.body.appendChild(container)
     vi.stubGlobal(
       'fetch',
-      vi.fn().mockResolvedValue(
-        new Response(
-          JSON.stringify({
-            generated_at: '2026-04-10T00:00:00Z',
-            cache_hit: true,
-            cache_age_sec: 3.2,
-            probe: {
-              source: 'ollama native runtime',
-              effective_model: 'qwen3.5:35b-a3b-coding-nvfp4',
-              server_url: 'http://127.0.0.1:11434',
-              model_loaded_before_probe: true,
-              model_loaded_after_probe: true,
-              loaded_models_after: [{ name: 'qwen3.5:35b-a3b-coding-nvfp4' }],
-              runs: [
-                {
-                  load_duration_ms: 33.6,
-                  prompt_tokens_per_second: 26.1,
-                  generation_tokens_per_second: 65.5,
+      vi.fn().mockImplementation(() =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({
+              generated_at: '2026-04-10T00:00:00Z',
+              cache_hit: true,
+              cache_age_sec: 3.2,
+              probe: {
+                source: 'ollama native runtime',
+                effective_model: 'qwen3.5:35b-a3b-coding-nvfp4',
+                server_url: 'http://127.0.0.1:11434',
+                model_loaded_before_probe: true,
+                model_loaded_after_probe: true,
+                loaded_models_after: [{ name: 'qwen3.5:35b-a3b-coding-nvfp4' }],
+                runs: [
+                  {
+                    load_duration_ms: 33.6,
+                    prompt_tokens_per_second: 26.1,
+                    generation_tokens_per_second: 65.5,
+                  },
+                ],
+                kv_cache_assessment: {
+                  signal: 'likely_reused',
+                  note: 'Prompt evaluation time dropped materially on a repeated prompt.',
+                  prompt_eval_duration_reduction_ratio: 0.42,
                 },
-              ],
-              kv_cache_assessment: {
-                signal: 'likely_reused',
-                note: 'Prompt evaluation time dropped materially on a repeated prompt.',
-                prompt_eval_duration_reduction_ratio: 0.42,
+                observations: ['Repeated prompt_eval_duration_ms dropped enough to suggest repeated-prefix reuse.'],
+                errors: [],
+                probe_ok: true,
               },
-              observations: ['Repeated prompt_eval_duration_ms dropped enough to suggest repeated-prefix reuse.'],
-              errors: [],
-              probe_ok: true,
+            }),
+            {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
             },
-          }),
-          {
-            status: 200,
-            headers: { 'Content-Type': 'application/json' },
-          },
+          ),
         ),
       ),
     )

--- a/dashboard/src/components/tools/config-resolution-panel.test.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.test.ts
@@ -27,44 +27,47 @@ describe('ConfigResolutionPanel', () => {
   beforeEach(() => {
     container = document.createElement('div')
     document.body.appendChild(container)
+    // Mint a fresh Response per fetch call: a Response body is
+    // single-use, and fetchDashboardRuntimeProbe issues more than one
+    // fetch since #20734 (ensureDevToken precedes the probe request).
+    // A shared mockResolvedValue Response makes the second read fail
+    // with "failed to read response body".
     vi.stubGlobal(
       'fetch',
-      vi.fn().mockImplementation(() =>
-        Promise.resolve(
-          new Response(
-            JSON.stringify({
-              generated_at: '2026-04-10T00:00:00Z',
-              cache_hit: true,
-              cache_age_sec: 3.2,
-              probe: {
-                source: 'ollama native runtime',
-                effective_model: 'qwen3.5:35b-a3b-coding-nvfp4',
-                server_url: 'http://127.0.0.1:11434',
-                model_loaded_before_probe: true,
-                model_loaded_after_probe: true,
-                loaded_models_after: [{ name: 'qwen3.5:35b-a3b-coding-nvfp4' }],
-                runs: [
-                  {
-                    load_duration_ms: 33.6,
-                    prompt_tokens_per_second: 26.1,
-                    generation_tokens_per_second: 65.5,
-                  },
-                ],
-                kv_cache_assessment: {
-                  signal: 'likely_reused',
-                  note: 'Prompt evaluation time dropped materially on a repeated prompt.',
-                  prompt_eval_duration_reduction_ratio: 0.42,
+      vi.fn().mockImplementation(async () =>
+        new Response(
+          JSON.stringify({
+            generated_at: '2026-04-10T00:00:00Z',
+            cache_hit: true,
+            cache_age_sec: 3.2,
+            probe: {
+              source: 'ollama native runtime',
+              effective_model: 'qwen3.5:35b-a3b-coding-nvfp4',
+              server_url: 'http://127.0.0.1:11434',
+              model_loaded_before_probe: true,
+              model_loaded_after_probe: true,
+              loaded_models_after: [{ name: 'qwen3.5:35b-a3b-coding-nvfp4' }],
+              runs: [
+                {
+                  load_duration_ms: 33.6,
+                  prompt_tokens_per_second: 26.1,
+                  generation_tokens_per_second: 65.5,
                 },
-                observations: ['Repeated prompt_eval_duration_ms dropped enough to suggest repeated-prefix reuse.'],
-                errors: [],
-                probe_ok: true,
+              ],
+              kv_cache_assessment: {
+                signal: 'likely_reused',
+                note: 'Prompt evaluation time dropped materially on a repeated prompt.',
+                prompt_eval_duration_reduction_ratio: 0.42,
               },
-            }),
-            {
-              status: 200,
-              headers: { 'Content-Type': 'application/json' },
+              observations: ['Repeated prompt_eval_duration_ms dropped enough to suggest repeated-prefix reuse.'],
+              errors: [],
+              probe_ok: true,
             },
-          ),
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          },
         ),
       ),
     )

--- a/lib/keeper/keeper_secret_projection.ml
+++ b/lib/keeper/keeper_secret_projection.ml
@@ -7,6 +7,11 @@ type source_kind =
   | Env_source
   | File_source
 
+type secret_root_info =
+  { root : string
+  ; source : string
+  }
+
 let trim_env_opt key =
   match Sys.getenv_opt key with
   | Some value ->
@@ -15,14 +20,21 @@ let trim_env_opt key =
   | None -> None
 ;;
 
-let secret_root ~base_path ~keeper_name =
+let secret_root_info ~base_path ~keeper_name =
   let keeper_dir = Workspace_utils.safe_filename keeper_name in
   match trim_env_opt "MASC_SECRET_DIR" with
-  | Some root -> Filename.concat root keeper_dir
+  | Some root -> { root = Filename.concat root keeper_dir; source = "MASC_SECRET_DIR" }
   | None ->
-    Filename.concat
-      (Filename.concat (Common.masc_dir_from_base_path ~base_path) "secrets")
-      keeper_dir
+    { root =
+        Filename.concat
+          (Filename.concat (Common.masc_dir_from_base_path ~base_path) "secrets")
+          keeper_dir
+    ; source = "workspace_masc_secrets"
+    }
+;;
+
+let secret_root ~base_path ~keeper_name =
+  (secret_root_info ~base_path ~keeper_name).root
 ;;
 
 let path_exists path =
@@ -212,6 +224,121 @@ let collect_file_entries files_root =
     match walk [] files_root [] with
     | Error _ as err -> err
     | Ok entries -> Ok (List.rev entries)
+;;
+
+let json_string_list values =
+  `List (List.map (fun value -> `String value) values)
+;;
+
+let file_mount_json (host_path, container_path) =
+  `Assoc [ "host_path", `String host_path; "container_path", `String container_path ]
+;;
+
+let status_json
+      ~root
+      ~source
+      ~status
+      ~configured
+      ~env_names
+      ~file_entries
+      ~error
+      ~next_action
+  =
+  `Assoc
+    [ "status", `String status
+    ; "configured", `Bool configured
+    ; "root", `String root
+    ; "source", `String source
+    ; "env_count", `Int (List.length env_names)
+    ; "file_count", `Int (List.length file_entries)
+    ; "env_names", json_string_list env_names
+    ; "file_mounts", `List (List.map file_mount_json file_entries)
+    ; "values_validated", `Bool true
+    ; "error", (match error with Some err -> `String err | None -> `Null)
+    ; "next_action", `String next_action
+    ]
+;;
+
+let dashboard_status_json ~base_path ~keeper_name =
+  let { root; source } = secret_root_info ~base_path ~keeper_name in
+  if not (path_exists root)
+  then
+    status_json
+      ~root
+      ~source
+      ~status:"absent"
+      ~configured:false
+      ~env_names:[]
+      ~file_entries:[]
+      ~error:None
+      ~next_action:("create " ^ root ^ "/env and/or " ^ root ^ "/files")
+  else if not (is_directory root)
+  then
+    status_json
+      ~root
+      ~source
+      ~status:"error"
+      ~configured:true
+      ~env_names:[]
+      ~file_entries:[]
+      ~error:(Some ("keeper secret root is not a directory: " ^ root))
+      ~next_action:"replace the secret root with a directory"
+  else (
+    match reject_symlink ~kind:File_source root with
+    | Error err ->
+      status_json
+        ~root
+        ~source
+        ~status:"error"
+        ~configured:true
+        ~env_names:[]
+        ~file_entries:[]
+        ~error:(Some err)
+        ~next_action:"replace the secret root symlink with a real directory"
+    | Ok _ ->
+      let env_root = Filename.concat root "env" in
+      let files_root = Filename.concat root "files" in
+      (match load_env_entries env_root with
+       | Error err ->
+         status_json
+           ~root
+           ~source
+           ~status:"error"
+           ~configured:true
+           ~env_names:[]
+           ~file_entries:[]
+           ~error:(Some err)
+           ~next_action:"fix keeper secret env entries"
+       | Ok env_entries ->
+         (match collect_file_entries files_root with
+          | Error err ->
+            status_json
+              ~root
+              ~source
+              ~status:"error"
+              ~configured:true
+              ~env_names:(List.map fst env_entries)
+              ~file_entries:[]
+              ~error:(Some err)
+              ~next_action:"fix keeper secret file entries"
+          | Ok file_entries ->
+            let status =
+              if env_entries = [] && file_entries = [] then "empty" else "ready"
+            in
+            let next_action =
+              if String.equal status "ready"
+              then "none"
+              else "add entries under env/ and/or files/"
+            in
+            status_json
+              ~root
+              ~source
+              ~status
+              ~configured:true
+              ~env_names:(List.map fst env_entries)
+              ~file_entries
+              ~error:None
+              ~next_action)))
 ;;
 
 let write_env_file ~container_name entries =

--- a/lib/keeper/keeper_secret_projection.mli
+++ b/lib/keeper/keeper_secret_projection.mli
@@ -5,3 +5,6 @@ type t =
 
 val docker_args_for_keeper :
   base_path:string -> keeper_name:string -> container_name:string -> (t, string) result
+
+val dashboard_status_json :
+  base_path:string -> keeper_name:string -> Yojson.Safe.t

--- a/lib/server/server_dashboard_http_composite_enrich.ml
+++ b/lib/server/server_dashboard_http_composite_enrich.ml
@@ -26,6 +26,11 @@ let enrich_composite_snapshot_json
       composite_recommended_actions_json ~keeper_name ~snapshot:json ~execution ~attention
     in
     let runtime_attention = composite_runtime_attention_json attention ~snapshot:json in
+    let secret_projection =
+      Keeper_secret_projection.dashboard_status_json
+        ~base_path:config.base_path
+        ~keeper_name
+    in
     `Assoc
       (fields
        @ [ "keeper", `String keeper_name
@@ -33,6 +38,7 @@ let enrich_composite_snapshot_json
          ; "execution", execution
          ; "runtime_attention", runtime_attention
          ; "recommended_actions", recommended_actions
+         ; "secret_projection", secret_projection
          ])
   | other -> other
 ;;

--- a/test/test_keeper_secret_projection.ml
+++ b/test/test_keeper_secret_projection.ml
@@ -65,6 +65,34 @@ let contains_substring haystack needle =
   loop 0
 ;;
 
+let assoc_member name = function
+  | `Assoc fields -> List.assoc_opt name fields
+  | _ -> None
+;;
+
+let json_string name json =
+  match assoc_member name json with
+  | Some (`String value) -> value
+  | _ -> Alcotest.failf "missing string field %s" name
+;;
+
+let json_int name json =
+  match assoc_member name json with
+  | Some (`Int value) -> value
+  | _ -> Alcotest.failf "missing int field %s" name
+;;
+
+let json_string_list name json =
+  match assoc_member name json with
+  | Some (`List values) ->
+    List.map
+      (function
+        | `String value -> value
+        | _ -> Alcotest.failf "non-string value in %s" name)
+      values
+  | _ -> Alcotest.failf "missing string list field %s" name
+;;
+
 let rec env_file_arg = function
   | "--env-file" :: path :: _ -> Some path
   | _ :: rest -> env_file_arg rest
@@ -229,6 +257,64 @@ let test_symlink_env_dir_rejects () =
            (contains_substring err "symlink"))
 ;;
 
+let test_dashboard_status_absent_root () =
+  let base = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  with_env "MASC_SECRET_DIR" "" @@ fun () ->
+  let json =
+    Keeper_secret_projection.dashboard_status_json
+      ~base_path:base
+      ~keeper_name:"minjae"
+  in
+  Alcotest.(check string) "status" "absent" (json_string "status" json);
+  Alcotest.(check int) "env count" 0 (json_int "env_count" json);
+  Alcotest.(check int) "file count" 0 (json_int "file_count" json)
+;;
+
+let test_dashboard_status_redacts_values () =
+  let base = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  with_env "MASC_SECRET_DIR" "" @@ fun () ->
+  let root = secret_root_default ~base ~keeper_name:"minjae" in
+  let token_path = Filename.concat (Filename.concat root "env") "GH_TOKEN" in
+  let ssh_path =
+    Filename.concat
+      (Filename.concat root "files")
+      "home/keeper/.ssh/id_ed25519"
+  in
+  write_file token_path "ghs_dashboard_secret\n";
+  write_file ssh_path "PRIVATE KEY";
+  let json =
+    Keeper_secret_projection.dashboard_status_json
+      ~base_path:base
+      ~keeper_name:"minjae"
+  in
+  let raw = Yojson.Safe.to_string json in
+  Alcotest.(check string) "status" "ready" (json_string "status" json);
+  Alcotest.(check int) "env count" 1 (json_int "env_count" json);
+  Alcotest.(check int) "file count" 1 (json_int "file_count" json);
+  Alcotest.(check (list string)) "env names" [ "GH_TOKEN" ]
+    (json_string_list "env_names" json);
+  Alcotest.(check bool) "raw env value redacted" false
+    (contains_substring raw "ghs_dashboard_secret")
+;;
+
+let test_dashboard_status_reports_projection_error () =
+  let base = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  with_env "MASC_SECRET_DIR" "" @@ fun () ->
+  let root = secret_root_default ~base ~keeper_name:"minjae" in
+  write_file (Filename.concat (Filename.concat root "env") "BAD-NAME") "x";
+  let json =
+    Keeper_secret_projection.dashboard_status_json
+      ~base_path:base
+      ~keeper_name:"minjae"
+  in
+  Alcotest.(check string) "status" "error" (json_string "status" json);
+  Alcotest.(check bool) "mentions invalid env name" true
+    (contains_substring (Yojson.Safe.to_string json) "invalid keeper secret env name")
+;;
+
 let () =
   Alcotest.run
     "keeper secret projection"
@@ -244,6 +330,12 @@ let () =
         ; Alcotest.test_case "symlink file rejects" `Quick test_symlink_file_rejects
         ; Alcotest.test_case "symlink env dir rejects" `Quick
             test_symlink_env_dir_rejects
+        ; Alcotest.test_case "dashboard status absent root" `Quick
+            test_dashboard_status_absent_root
+        ; Alcotest.test_case "dashboard status redacts values" `Quick
+            test_dashboard_status_redacts_values
+        ; Alcotest.test_case "dashboard status reports projection error" `Quick
+            test_dashboard_status_reports_projection_error
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- add dashboard-safe keeper secret projection status JSON to the existing projection module
- attach `secret_projection` to keeper composite snapshots so single and fleet views share the same read model
- render secret projection status in keeper diagnostics without exposing secret values

## Validation
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build --build-dir _build_secret_dashboard test/test_keeper_secret_projection.exe lib/server/server_dashboard_http_composite_enrich.ml`
- `_build_secret_dashboard/default/test/test_keeper_secret_projection.exe`
- `pnpm install --offline --frozen-lockfile`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm exec vitest run --config vitest.config.ts src/api/schemas/keeper-composite.test.ts src/components/keeper-detail-runtime.test.ts --no-file-parallelism --maxWorkers=1`
- `ocamlformat --check lib/keeper/keeper_secret_projection.ml lib/keeper/keeper_secret_projection.mli lib/server/server_dashboard_http_composite_enrich.ml test/test_keeper_secret_projection.ml`
- `scripts/check-ssot.sh`
- `bash scripts/ci/check-ignore-without-comment-diff.sh --base origin/main --head HEAD`
- `git diff --check`