### PR TITLE
fix: add heartbeat staleness check to audit_orphan_tasks

### DIFF
--- a/lib/workspace/workspace_query.ml
+++ b/lib/workspace/workspace_query.ml
@@ -122,6 +122,8 @@ let audit_orphan_tasks config : (Masc_domain.task * string) list =
     let agents_path = agents_dir config in
     let active_names =
       load_agents_from_dir config agents_path ~include_inactive:false
+      |> List.filter (fun (agent : Masc_domain.agent) ->
+          not (Workspace_resilience.Time.is_stale agent.last_seen))
       |> List.map (fun (agent : Masc_domain.agent) -> agent.name)
     in
     let is_active_agent assignee =


### PR DESCRIPTION
## Root Cause

The phantom 'Failed tasks: 1' counter was caused by `audit_orphan_tasks` only filtering agents by `status <> Inactive`, without checking heartbeat timestamps. When a keeper crashed hard, its agent JSON still showed `status: Active` with a stale `last_seen`, so its claimed tasks were invisible to orphan detection.

## Fix

Added a `Workspace_resilience.Time.is_stale` filter (threshold: `default_zombie_threshold` = 300s / 5 min) to the `active_names` pipeline in `audit_orphan_tasks`. A crashed keeper with `last_seen` older than 5 minutes is now treated as inactive, making its claimed tasks visible for orphan detection and force-release.

## Diff

`+2` lines in `lib/workspace/workspace_query.ml`:

```ocaml
|> List.filter (fun (agent : Masc_domain.agent) ->
    not (Workspace_resilience.Time.is_stale agent.last_seen))
```

## Testing

The threshold (300s) matches `default_zombie_threshold` used by `Workspace_gc.cleanup_zombies`. Previously orphaned tasks from crashed keepers were masked until manual cleanup or a full agent file reset.

Closes task-744