### PR TITLE
feat(keeper): RFC-0223 P2 — connector surface presence in world prompt

### DIFF
--- a/lib/gate/channel_gate_connector.ml
+++ b/lib/gate/channel_gate_connector.ml
@@ -21,6 +21,8 @@ module type S = sig
     channel_id:string ->
     actor_name:string ->
     (Yojson.Safe.t, string) result
+  val bound_channels : keeper_name:string -> string list
+  val connected : unit -> bool
 end
 
 let registry : (string, (module S)) Hashtbl.t = Hashtbl.create 4

--- a/lib/gate/channel_gate_connector.mli
+++ b/lib/gate/channel_gate_connector.mli
@@ -48,6 +48,16 @@ module type S = sig
     actor_name:string ->
     (Yojson.Safe.t, string) result
   (** Remove a channel-to-keeper binding. *)
+
+  val bound_channels : keeper_name:string -> string list
+  (** Channel ids currently bound to [keeper_name], freshly read from
+      the connector's binding store on each call (no cached state).
+      Sorted by channel id. RFC-0223 P2. *)
+
+  val connected : unit -> bool
+  (** Whether the connector's transport is currently believed live.
+      Recomputed per call from the connector's own liveness source
+      (status file staleness, in-process gateway state). RFC-0223 P2. *)
 end
 
 (** {1 Registry} *)

--- a/lib/gate/channel_gate_discord_state.ml
+++ b/lib/gate/channel_gate_discord_state.ml
@@ -498,6 +498,29 @@ let keeper_for_channel ~channel_id =
         else None)
       candidates
 
+(* RFC-0223 P2: presence surface. Both recomputed per call — no cached
+   presence state. *)
+
+let bound_channels ~keeper_name =
+  let normalized = String.trim keeper_name in
+  if String.equal normalized "" then []
+  else
+    read_bindings ()
+    |> List.filter_map (fun (b : binding) ->
+           if String.equal b.keeper_name normalized then Some b.channel_id
+           else None)
+
+let connected () =
+  (* The in-process gateway (RFC-0203) is the only Discord transport;
+     its run loop publishes the typed connection state. The legacy
+     sidecar status file is not consulted: nothing writes it since the
+     Python sidecar was deleted. *)
+  match Discord_gateway_client.connection_state () with
+  | Discord_gateway_state.Connected _ -> true
+  | Disconnected | Awaiting_hello | Identifying | Resuming
+  | Reconnect_pending _ | Failed _ ->
+      false
+
 type send_error =
   | Missing_token
   | Rest_error of Discord_rest_client.error

--- a/lib/gate/channel_gate_discord_state.mli
+++ b/lib/gate/channel_gate_discord_state.mli
@@ -73,6 +73,16 @@ val keeper_for_channel : channel_id:string -> string option
     Returns [None] when no binding exists, when the channel id is
     blank, or when the binding store is unreadable. *)
 
+val bound_channels : keeper_name:string -> string list
+(** Channel snowflakes bound to [keeper_name], freshly read from the
+    binding store on each call. Empty on blank name or unreadable
+    store. RFC-0223 P2 presence. *)
+
+val connected : unit -> bool
+(** Whether the in-process gateway's run loop currently reports
+    [Connected]. Reads {!Discord_gateway_client.connection_state};
+    no file indirection. RFC-0223 P2 presence. *)
+
 (** Typed failure modes for {!send_message}. Closed sum — adding
     a new variant forces every consumer to handle it. *)
 type send_error =

--- a/lib/gate/channel_gate_imessage_state.ml
+++ b/lib/gate/channel_gate_imessage_state.ml
@@ -207,6 +207,27 @@ let connector_state_label ~available ~connected ~stale =
   else if connected then "connected"
   else "disconnected"
 
+(* RFC-0223 P2: presence surface. Both recomputed per call — no cached
+   presence state. *)
+
+let bound_channels ~keeper_name =
+  let normalized = String.trim keeper_name in
+  if String.equal normalized "" then []
+  else
+    read_bindings ()
+    |> List.filter_map (fun (b : binding) ->
+           if String.equal b.keeper_name normalized then Some b.channel_id
+           else None)
+
+let connected () =
+  (* Same liveness reading as [status_json]: the sidecar heartbeats its
+     status file; a missing or stale file means not live. *)
+  match read_json_file_opt (status_path ()) with
+  | None -> false
+  | Some json ->
+      let updated_at = string_member json "updated_at" in
+      bool_member json "connected" && not (stale_of_updated_at updated_at)
+
 let status_json ?(audit_limit = 10) () =
   let status_path = status_path () in
   let live_status = read_json_file_opt status_path in

--- a/lib/gate/channel_gate_imessage_state.mli
+++ b/lib/gate/channel_gate_imessage_state.mli
@@ -52,3 +52,13 @@ val unbind :
   (Yojson.Safe.t, string) result
 (** Remove a channel→keeper binding, append an audit event, and
     return the removed binding row as JSON. *)
+
+(** {1 Presence (RFC-0223 P2)} *)
+
+val bound_channels : keeper_name:string -> string list
+(** Channel ids bound to [keeper_name], freshly read from the binding
+    store on each call. *)
+
+val connected : unit -> bool
+(** Whether the sidecar's status file reports a live, non-stale
+    connection. *)

--- a/lib/gate/channel_gate_sidecar_state.ml
+++ b/lib/gate/channel_gate_sidecar_state.ml
@@ -210,6 +210,27 @@ module Make (Config : Config) = struct
     else if connected then "connected"
     else "disconnected"
 
+  (* RFC-0223 P2: presence surface. Both recomputed per call — no
+     cached presence state. *)
+
+  let bound_channels ~keeper_name =
+    let normalized = String.trim keeper_name in
+    if String.equal normalized "" then []
+    else
+      read_bindings ()
+      |> List.filter_map (fun (b : binding) ->
+             if String.equal b.keeper_name normalized then Some b.channel_id
+             else None)
+
+  let connected () =
+    (* Same liveness reading as [status_json]: the sidecar heartbeats
+       its status file; a missing or stale file means not live. *)
+    match read_json_file_opt (status_path ()) with
+    | None -> false
+    | Some json ->
+        let updated_at = string_member json "updated_at" in
+        bool_member json "connected" && not (stale_of_updated_at updated_at)
+
   let status_json ?(audit_limit = 10) () =
     let status_path = status_path () in
     let live_status = read_json_file_opt status_path in

--- a/lib/gate/discord_gateway_client.ml
+++ b/lib/gate/discord_gateway_client.ml
@@ -83,6 +83,17 @@ let log_effect level message =
   | `Warn -> Log.Discord.warn "%s" message
   | `Error -> Log.Discord.error "%s" message
 
+(* RFC-0223 P2: the run loop's connection state, published so presence
+   derivation (Channel_gate_discord_state.connected) can read it without
+   file indirection. One gateway per process (single bot token), so a
+   module-level register is unambiguous. Written only by [run]'s
+   state-machine step; everyone else reads. *)
+let published_connection_state : Discord_gateway_state.connection_state Atomic.t
+  =
+  Atomic.make Discord_gateway_state.Disconnected
+
+let connection_state () = Atomic.get published_connection_state
+
 let run ~sw ~env ~token ~intents ~trigger_policy ~on_event () =
   let config : Discord_gateway_state.config = {
     token; intents; bot_user_id = None; trigger_policy;
@@ -179,6 +190,7 @@ let run ~sw ~env ~token ~intents ~trigger_policy ~on_event () =
     let now = now_mono env in
     let (s', effects) = Discord_gateway_state.step !state ~now_mono:now input in
     state := s';
+    Atomic.set published_connection_state (Discord_gateway_state.state s');
     List.iter run_effect effects
   in
 

--- a/lib/gate/discord_gateway_client.mli
+++ b/lib/gate/discord_gateway_client.mli
@@ -75,3 +75,11 @@ val run :
     4. On [Close_wss] effect: tear down, reschedule per backoff.
 
     @raise Failure until Phase 1.2 ships the implementation. *)
+
+(** {1 Connection state (RFC-0223 P2)} *)
+
+val connection_state : unit -> Discord_gateway_state.connection_state
+(** Last connection state published by the {!run} loop's state machine.
+    [Disconnected] until [run] has started. One gateway per process
+    (single bot token); written only by [run], safe to read from any
+    fiber. Feeds connector presence ([Channel_gate_discord_state]). *)

--- a/lib/gate/dune
+++ b/lib/gate/dune
@@ -19,6 +19,7 @@
   discord_rest_client
   discord_wss_connection
   gate_protocol
+  gate_surface
   gate_time_util)
  ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
  (flags

--- a/lib/gate/gate_surface.ml
+++ b/lib/gate/gate_surface.ml
@@ -1,0 +1,44 @@
+type t =
+  | Dashboard
+  | Discord of { workspace_id : string option; channel_id : string option }
+  | Slack of { workspace_id : string option; channel_id : string option }
+  | Gate of { channel : string; channel_id : string option }
+
+let dashboard_label = "dashboard"
+let discord_label = "discord"
+let slack_label = "slack"
+
+let label = function
+  | Dashboard -> dashboard_label
+  | Discord _ -> discord_label
+  | Slack _ -> slack_label
+  | Gate { channel; _ } -> channel
+
+let of_source ~source ~workspace_id ~channel_id =
+  if String.equal source dashboard_label then Dashboard
+  else if String.equal source discord_label then
+    Discord { workspace_id; channel_id }
+  else if String.equal source slack_label then
+    Slack { workspace_id; channel_id }
+  else Gate { channel = source; channel_id }
+
+type surface_presence = { surface : t; alive : bool }
+
+let surface_of_connector ~channel ~channel_id =
+  of_source ~source:channel ~workspace_id:None ~channel_id:(Some channel_id)
+
+let connected_surfaces_for_keeper ~keeper_name =
+  let connector_surfaces =
+    Channel_gate_connector.all ()
+    |> List.concat_map (fun (module C : Channel_gate_connector.S) ->
+           let alive = C.connected () in
+           C.bound_channels ~keeper_name
+           |> List.map (fun channel_id ->
+                  { surface = surface_of_connector ~channel:C.channel ~channel_id
+                  ; alive
+                  }))
+    (* Registry iteration order is a Hashtbl fold; sort for stable
+       prompt rendering. *)
+    |> List.sort compare
+  in
+  { surface = Dashboard; alive = true } :: connector_surfaces

--- a/lib/gate/gate_surface.mli
+++ b/lib/gate/gate_surface.mli
@@ -1,0 +1,51 @@
+(** Gate_surface — typed connector surface identity (RFC-0223 §3).
+
+    A surface is one lane a keeper can hear from or speak to: the
+    dashboard, a bound Discord/Slack channel, or any other connector
+    speaking the generic gate protocol. The type round-trips to the
+    on-disk [source] labels written by {!Keeper_chat_store.append_turn}
+    producers ("dashboard" / "discord" / "slack" / connector channel
+    labels).
+
+    RFC names this module [Surface]; the [Gate_] prefix follows the
+    masc_gate convention ([(wrapped false)] puts modules in the global
+    namespace, so a bare [Surface] is too generic). *)
+
+type t =
+  | Dashboard
+  | Discord of { workspace_id : string option; channel_id : string option }
+  | Slack of { workspace_id : string option; channel_id : string option }
+  | Gate of { channel : string; channel_id : string option }
+      (** Any other connector speaking the generic gate protocol;
+          [channel] is the connector's registered label, verbatim.
+          [workspace_id]/[channel_id] are [option] because chat rows
+          persist only the [source] label today — a row-derived
+          surface knows its lane label but not always the lane id. *)
+
+val label : t -> string
+(** Round-trips to today's on-disk [source] strings: ["dashboard"],
+    ["discord"], ["slack"], or the gate channel label verbatim. *)
+
+val of_source :
+  source:string -> workspace_id:string option -> channel_id:string option -> t
+(** Parse a persisted [source] label. Unknown labels map to
+    [Gate { channel = source; _ }] — the honest reading (every
+    non-builtin source IS a gate channel label), not a permissive
+    default. *)
+
+(** {1 Presence (RFC-0223 P2)} *)
+
+type surface_presence = { surface : t; alive : bool }
+
+val connected_surfaces_for_keeper :
+  keeper_name:string -> surface_presence list
+(** Surfaces currently attached to [keeper_name], recomputed from the
+    connector registry's binding stores and liveness sources on every
+    call — no cached presence state (RFC-0223 §2 principle 6).
+
+    The dashboard is always present and alive (the bearer-gated chat
+    route always exists; no per-keeper dashboard attachment is
+    tracked). Connector entries come from
+    {!Channel_gate_connector.all}, so only connectors registered in
+    this process (server startup) are visible. Sorted for stable
+    prompt rendering. *)

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -40,6 +40,24 @@ let format_goals (goal_ids : string list) : string =
   String.concat "\n"
     (List.map (fun gid -> Printf.sprintf "- %s" gid) goal_ids)
 
+(** Format one connected-surface presence line (RFC-0223 P2).
+    Presence only: lane label + liveness, no content, no counts. *)
+let format_surface_presence (p : Gate_surface.surface_presence) : string =
+  let lane =
+    match p.surface with
+    | Gate_surface.Dashboard -> "dashboard"
+    | Gate_surface.Discord { channel_id = Some channel; _ } ->
+        Printf.sprintf "discord #%s" channel
+    | Gate_surface.Discord { channel_id = None; _ } -> "discord"
+    | Gate_surface.Slack { channel_id = Some channel; _ } ->
+        Printf.sprintf "slack #%s" channel
+    | Gate_surface.Slack { channel_id = None; _ } -> "slack"
+    | Gate_surface.Gate { channel; channel_id = Some channel_id } ->
+        Printf.sprintf "%s #%s" channel channel_id
+    | Gate_surface.Gate { channel; channel_id = None } -> channel
+  in
+  Printf.sprintf "%s (%s)" lane (if p.alive then "alive" else "offline")
+
 let format_scope_messages
     (messages : (string * string) list) : string =
   let shown_messages, omitted =
@@ -599,7 +617,29 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
          (List.length observation.active_goals));
     Buffer.add_string ubuf (format_goals observation.active_goals);
     Buffer.add_string ubuf "\n\n");
-  (* 2. Namespace state — usually lower churn than inbox/board detail *)
+  (* 2. Connected surfaces — connector presence, changes only on
+     bind/unbind or transport flaps (RFC-0223 P2). Omitted when only
+     the implicit dashboard is attached: every keeper has the
+     dashboard, so dashboard-only presence carries no signal. *)
+  let connector_presence =
+    List.filter
+      (fun (p : Gate_surface.surface_presence) ->
+        match p.surface with
+        | Gate_surface.Dashboard -> false
+        | Gate_surface.Discord _ | Gate_surface.Slack _ | Gate_surface.Gate _
+          ->
+            true)
+      observation.connected_surfaces
+  in
+  if connector_presence <> [] then (
+    Buffer.add_string ubuf "### Connected Surfaces\n";
+    List.iter
+      (fun p ->
+        Buffer.add_string ubuf
+          (Printf.sprintf "- %s\n" (format_surface_presence p)))
+      observation.connected_surfaces;
+    Buffer.add_char ubuf '\n');
+  (* 3. Namespace state — usually lower churn than inbox/board detail *)
   if
     observation.unclaimed_task_count > 0
     || observation.claimable_task_count > 0
@@ -642,12 +682,12 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
     Buffer.add_string ubuf
       (Printf.sprintf "- Active agents: %d\n" observation.active_agent_count);
     Buffer.add_char ubuf '\n');
-  (* 3. Context health — stable resource framing *)
+  (* 4. Context health — stable resource framing *)
   Buffer.add_string ubuf
     (Printf.sprintf "### Context\n- Utilization: %.0f%%\n- Idle: %ds\n"
        (observation.context_ratio *. 100.0)
        observation.idle_seconds);
-  (* 4. Autonomous trigger — lower churn than reactive inboxes *)
+  (* 5. Autonomous trigger — lower churn than reactive inboxes *)
   let turn_decision =
     Keeper_world_observation.keeper_cycle_decision ~meta observation
   in
@@ -658,7 +698,7 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
     Buffer.add_string ubuf "\n### Autonomous Trigger\n";
     Buffer.add_string ubuf (String.concat "\n" autonomous_trigger);
     Buffer.add_char ubuf '\n');
-  (* 5. Continuity — usually large and moderately stable, so keep it
+  (* 6. Continuity — usually large and moderately stable, so keep it
      before highly volatile reactive sections for better prefix reuse.
      Inject only forward-looking fields (Goal, Next plan, Next, OpenQuestions,
      Constraints). Backward-looking fields (Done, Progress, Decisions) are
@@ -680,14 +720,14 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
       "- If this turn was still scheduled or backlog/repo signals remain, investigate that mismatch instead of echoing the prior idle conclusion.\n";
     Buffer.add_string ubuf continuity_for_prompt;
     Buffer.add_char ubuf '\n');
-  (* 6. Pending mentions — reactive trigger *)
+  (* 7. Pending mentions — reactive trigger *)
   if observation.pending_mentions <> [] then (
     Buffer.add_string ubuf
       (Printf.sprintf "### Pending Mentions (%d)\n"
          (List.length observation.pending_mentions));
     Buffer.add_string ubuf (format_mentions observation.pending_mentions);
     Buffer.add_string ubuf "\n\n");
-  (* 7. Scope messages — reactive trigger *)
+  (* 8. Scope messages — reactive trigger *)
   if observation.pending_scope_messages <> [] then (
     Buffer.add_string ubuf
       (Printf.sprintf "### Scope Messages (%d recent)\n"
@@ -695,7 +735,7 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
     Buffer.add_string ubuf
       (format_scope_messages observation.pending_scope_messages);
     Buffer.add_string ubuf "\n\n");
-  (* 8. Claimable work — advisory operational guidance.
+  (* 9. Claimable work — advisory operational guidance.
      Body lives at config/prompts/keeper.immediate_task_move.md. The OCaml
      side only owns the section header and the trailing blank line; the
      bullet prose stays in the markdown file alongside the other keeper
@@ -707,7 +747,7 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
          ~enabled:true
          Keeper_prompt_names.immediate_task_move);
     Buffer.add_char ubuf '\n');
-  (* 9. Board activity — reactive trigger *)
+  (* 10. Board activity — reactive trigger *)
   if observation.pending_board_events <> [] then (
     Buffer.add_string ubuf
       (Printf.sprintf "### Board Activity (%d new)\n"

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -42,6 +42,7 @@ type world_observation =
   ; pending_verification_count : int
   ; backlog_updated_since_last_scheduled_autonomous : bool
   ; active_agent_count : int
+  ; connected_surfaces : Gate_surface.surface_presence list
   }
 
 type keeper_cycle_channel =
@@ -467,6 +468,8 @@ let observe
   ; pending_verification_count
   ; backlog_updated_since_last_scheduled_autonomous
   ; active_agent_count
+  ; connected_surfaces =
+      Gate_surface.connected_surfaces_for_keeper ~keeper_name:meta.name
   }
 ;;
 
@@ -499,6 +502,8 @@ let observe_direct_keeper_msg ~(config : Workspace.config) ~(meta : keeper_meta)
   ; pending_verification_count
   ; backlog_updated_since_last_scheduled_autonomous
   ; active_agent_count = count_active_agents ~config
+  ; connected_surfaces =
+      Gate_surface.connected_surfaces_for_keeper ~keeper_name:meta.name
   }
 ;;
 

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -81,6 +81,12 @@ type world_observation = {
 
   active_agent_count : int;
   (** Number of agents currently active in the workspace. *)
+
+  connected_surfaces : Gate_surface.surface_presence list;
+  (** Connector surfaces attached to this keeper (RFC-0223 P2).
+      Recomputed from binding stores + connector liveness on every
+      observation; the dashboard entry is always present. Presence
+      only — no conversation content, no counts. *)
 }
 
 type keeper_cycle_channel =

--- a/test/dune
+++ b/test/dune
@@ -180,6 +180,7 @@
   test_keeper_unified_idle_cooldown
   test_keeper_unified_inline_skip
   test_keeper_unified_metacognition
+  test_keeper_surface_presence_prompt
   test_keeper_unified_verification_surface
   test_keeper_fsm_guard_actions
   test_keeper_callback_hardening
@@ -439,6 +440,7 @@
   test_keeper_unified_idle_cooldown
   test_keeper_unified_inline_skip
   test_keeper_unified_metacognition
+  test_keeper_surface_presence_prompt
   test_keeper_unified_verification_surface
   test_keeper_fsm_guard_actions
   test_keeper_callback_hardening
@@ -1236,6 +1238,7 @@
 (include stanzas/test_channel_gate_metrics.inc)
 
 (include stanzas/test_channel_gate_discord_state_in_process.inc)
+(include stanzas/test_gate_surface.inc)
 
 (include stanzas/test_discord_gateway_state.inc)
 

--- a/test/stanzas/test_gate_surface.inc
+++ b/test/stanzas/test_gate_surface.inc
@@ -1,0 +1,7 @@
+; RFC-0223 P2 — Gate_surface (typed connector surface + presence).
+; Minimal-deps stanza, same insulation rationale as
+; test_channel_gate_discord_state_in_process.
+(test
+ (name test_gate_surface)
+ (modules test_gate_surface)
+ (libraries alcotest unix yojson masc.gate))

--- a/test/test_gate_surface.ml
+++ b/test/test_gate_surface.ml
@@ -1,0 +1,172 @@
+(* RFC-0223 P2 — Gate_surface unit tests.
+
+   - [label]/[of_source] round-trip over known labels and the
+     unknown-label -> [Gate] case (RFC-0223 §6).
+   - [connected_surfaces_for_keeper] presence derivation against a
+     temp Discord binding store: dashboard always present, bound
+     channel listed, liveness false while no gateway runs.
+
+   Minimal-deps executable (masc.gate only), mirroring
+   test_channel_gate_discord_state_in_process. *)
+
+open Alcotest
+
+module Surface = Gate_surface
+
+let surface_pp fmt (s : Surface.t) =
+  match s with
+  | Surface.Dashboard -> Format.fprintf fmt "Dashboard"
+  | Surface.Discord { workspace_id; channel_id } ->
+      Format.fprintf fmt "Discord{ws=%s;ch=%s}"
+        (Option.value workspace_id ~default:"-")
+        (Option.value channel_id ~default:"-")
+  | Surface.Slack { workspace_id; channel_id } ->
+      Format.fprintf fmt "Slack{ws=%s;ch=%s}"
+        (Option.value workspace_id ~default:"-")
+        (Option.value channel_id ~default:"-")
+  | Surface.Gate { channel; channel_id } ->
+      Format.fprintf fmt "Gate{%s;ch=%s}" channel
+        (Option.value channel_id ~default:"-")
+
+let surface : Surface.t testable = testable surface_pp ( = )
+
+let presence_pp fmt (p : Surface.surface_presence) =
+  Format.fprintf fmt "{%a alive=%b}" surface_pp p.surface p.alive
+
+let presence : Surface.surface_presence testable = testable presence_pp ( = )
+
+(* ---------------------------------------------------------------- *)
+(* label / of_source round-trip                                     *)
+(* ---------------------------------------------------------------- *)
+
+let of_source_plain source =
+  Surface.of_source ~source ~workspace_id:None ~channel_id:None
+
+let test_builtin_labels_parse_to_builtin_variants () =
+  check surface "dashboard" Surface.Dashboard (of_source_plain "dashboard");
+  check surface "discord"
+    (Surface.Discord { workspace_id = None; channel_id = None })
+    (of_source_plain "discord");
+  check surface "slack"
+    (Surface.Slack { workspace_id = None; channel_id = None })
+    (of_source_plain "slack")
+
+let test_unknown_label_maps_to_gate_not_a_builtin () =
+  (* Honest reading: every non-builtin source IS a gate channel
+     label. "agent" (keeper's own output) and connector labels both
+     land here. *)
+  List.iter
+    (fun source ->
+      check surface source
+        (Surface.Gate { channel = source; channel_id = None })
+        (of_source_plain source))
+    [ "openclaw"; "agent"; "imessage"; "telegram" ]
+
+let test_label_round_trips_every_source () =
+  List.iter
+    (fun source ->
+      check string source source (Surface.label (of_source_plain source)))
+    [ "dashboard"; "discord"; "slack"; "openclaw"; "agent"; "imessage" ]
+
+let test_of_source_carries_lane_ids () =
+  check surface "discord lane"
+    (Surface.Discord
+       { workspace_id = Some "guild-1"; channel_id = Some "chan-1" })
+    (Surface.of_source ~source:"discord" ~workspace_id:(Some "guild-1")
+       ~channel_id:(Some "chan-1"));
+  check surface "gate lane"
+    (Surface.Gate { channel = "openclaw"; channel_id = Some "room-9" })
+    (Surface.of_source ~source:"openclaw" ~workspace_id:None
+       ~channel_id:(Some "room-9"))
+
+(* ---------------------------------------------------------------- *)
+(* connected_surfaces_for_keeper                                    *)
+(* ---------------------------------------------------------------- *)
+
+let with_binding_store entries f =
+  let path = Filename.temp_file "gate-surface-bindings" ".json" in
+  let json =
+    `Assoc (List.map (fun (ch, keeper) -> (ch, `String keeper)) entries)
+  in
+  let oc = open_out_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc (Yojson.Safe.to_string json));
+  Unix.putenv "MASC_DISCORD_BINDING_STORE_PATH" path;
+  Fun.protect
+    ~finally:(fun () ->
+      Unix.putenv "MASC_DISCORD_BINDING_STORE_PATH" "";
+      try Sys.remove path with Sys_error _ -> ())
+    f
+
+let register_discord () =
+  Channel_gate_connector.register (module Channel_gate_discord_state)
+
+let test_dashboard_always_present () =
+  register_discord ();
+  with_binding_store [] (fun () ->
+      let surfaces =
+        Surface.connected_surfaces_for_keeper ~keeper_name:"unbound-keeper"
+      in
+      check (list presence) "dashboard only"
+        [ { Surface.surface = Surface.Dashboard; alive = true } ]
+        surfaces)
+
+let test_bound_discord_channel_listed_offline_without_gateway () =
+  register_discord ();
+  with_binding_store
+    [ ("98791450001", "surface-keeper"); ("12300000000", "other-keeper") ]
+    (fun () ->
+      let surfaces =
+        Surface.connected_surfaces_for_keeper ~keeper_name:"surface-keeper"
+      in
+      check (list presence) "dashboard + own discord channel, not alive"
+        [ { Surface.surface = Surface.Dashboard; alive = true }
+        ; { Surface.surface =
+              Surface.Discord
+                { workspace_id = None; channel_id = Some "98791450001" }
+          ; alive = false
+          }
+        ]
+        surfaces)
+
+let test_bound_channels_blank_keeper_is_empty () =
+  with_binding_store
+    [ ("98791450001", "surface-keeper") ]
+    (fun () ->
+      check (list string) "blank name" []
+        (Channel_gate_discord_state.bound_channels ~keeper_name:"  ");
+      check (list string) "bound name" [ "98791450001" ]
+        (Channel_gate_discord_state.bound_channels
+           ~keeper_name:"surface-keeper"))
+
+let test_discord_not_connected_without_run_loop () =
+  check bool "no gateway => not connected" false
+    (Channel_gate_discord_state.connected ())
+
+let () =
+  run "gate_surface"
+    [
+      ( "of_source/label",
+        [
+          test_case "builtin labels parse to builtin variants" `Quick
+            test_builtin_labels_parse_to_builtin_variants;
+          test_case "unknown label maps to Gate" `Quick
+            test_unknown_label_maps_to_gate_not_a_builtin;
+          test_case "label round-trips every source" `Quick
+            test_label_round_trips_every_source;
+          test_case "of_source carries lane ids" `Quick
+            test_of_source_carries_lane_ids;
+        ] );
+      ( "presence",
+        [
+          test_case "dashboard always present" `Quick
+            test_dashboard_always_present;
+          test_case "bound discord channel listed, offline without gateway"
+            `Quick test_bound_discord_channel_listed_offline_without_gateway;
+          test_case "bound_channels blank keeper" `Quick
+            test_bound_channels_blank_keeper_is_empty;
+          test_case "discord not connected without run loop" `Quick
+            test_discord_not_connected_without_run_loop;
+        ] );
+    ]

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -84,6 +84,7 @@ let base_observation : WO.world_observation =
   ; pending_verification_count = 0
   ; backlog_updated_since_last_scheduled_autonomous = false
   ; active_agent_count = 0
+  ; connected_surfaces = []
   }
 
 (* ══════════════════════════════════════════════════════════

--- a/test/test_keeper_reactive_wake_backlog_gate.ml
+++ b/test/test_keeper_reactive_wake_backlog_gate.ml
@@ -112,6 +112,7 @@ let global_backlog_obs : WO.world_observation =
   ; pending_verification_count = 0
   ; backlog_updated_since_last_scheduled_autonomous = true
   ; active_agent_count = 1
+  ; connected_surfaces = []
   }
 
 let decide ~reactive_wake =

--- a/test/test_keeper_surface_presence_prompt.ml
+++ b/test/test_keeper_surface_presence_prompt.ml
@@ -1,0 +1,160 @@
+(* RFC-0223 P2 — Connected Surfaces section in the unified world prompt.
+
+   Integration criterion from the RFC (§6): a keeper with connector
+   bindings sees the presence section; a keeper with only the implicit
+   dashboard does not. *)
+
+open Alcotest
+
+module WO = Masc.Keeper_world_observation
+module Prompt = Masc.Keeper_unified_prompt
+
+let base_observation : WO.world_observation =
+  {
+    pending_mentions = [];
+    pending_board_events = [];
+    pending_scope_messages = [];
+    message_cursor_updates = [];
+    idle_seconds = 0;
+    active_goals = [];
+    continuity_summary = "";
+    context_ratio = 0.0;
+    unclaimed_task_count = 0;
+    claimable_task_count = 0;
+    provider_capacity_blocked_task_count = 0;
+    failed_task_count = 0;
+    pending_verification_count = 0;
+    backlog_updated_since_last_scheduled_autonomous = false;
+    active_agent_count = 0;
+    connected_surfaces = [];
+  }
+
+let meta : Masc.Keeper_meta_contract.keeper_meta =
+  let json =
+    `Assoc
+      [
+        ("name", `String "presence-keeper");
+        ("trace_id", `String "test-trace-presence");
+        ("goal", `String "test goal");
+      ]
+  in
+  match Masc_test_deps.meta_of_json_fixture json with
+  | Ok m -> m
+  | Error e -> failwith ("meta_of_json failed: " ^ e)
+
+(* build_prompt's Autonomous Trigger section consults the default
+   runtime (RFC-0206: no silent fallback), so tests must initialize it
+   with a throwaway config. Same fixture as test_keeper_status_bridge. *)
+let runtime_toml =
+  {|
+[runtime]
+default = "test_provider.test_model"
+
+[providers.test_provider]
+display-name = "Test Provider"
+protocol = "provider_d-http"
+endpoint = "http://127.0.0.1:1"
+
+[models.test_model]
+api-name = "test-model"
+max-context = 8192
+tools-support = true
+streaming = true
+
+[test_provider.test_model]
+is-default = true
+max-concurrent = 1
+|}
+
+let init_runtime_default_for_tests () =
+  let path = Filename.temp_file "surface_presence_runtime_" ".toml" in
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc runtime_toml);
+  match Runtime.init_default ~config_path:path with
+  | Ok () -> ()
+  | Error e -> Alcotest.failf "Runtime.init_default failed: %s" e
+
+let user_message observation =
+  let _system, user =
+    Prompt.build_prompt ~meta ~base_path:"/tmp/unused" ~observation ()
+  in
+  user
+
+let contains ~needle haystack =
+  let n = String.length needle and h = String.length haystack in
+  let rec loop i =
+    if i + n > h then false
+    else if String.sub haystack i n = needle then true
+    else loop (i + 1)
+  in
+  loop 0
+
+let dashboard_presence : Gate_surface.surface_presence =
+  { surface = Gate_surface.Dashboard; alive = true }
+
+let discord_presence ~alive : Gate_surface.surface_presence =
+  {
+    surface =
+      Gate_surface.Discord
+        { workspace_id = None; channel_id = Some "98791450001" };
+    alive;
+  }
+
+let test_bound_keeper_sees_presence_section () =
+  let user =
+    user_message
+      {
+        base_observation with
+        connected_surfaces = [ dashboard_presence; discord_presence ~alive:true ];
+      }
+  in
+  check bool "section header" true
+    (contains ~needle:"### Connected Surfaces" user);
+  check bool "discord lane line" true
+    (contains ~needle:"- discord #98791450001 (alive)" user);
+  check bool "dashboard line" true
+    (contains ~needle:"- dashboard (alive)" user)
+
+let test_offline_surface_rendered_as_offline () =
+  let user =
+    user_message
+      {
+        base_observation with
+        connected_surfaces =
+          [ dashboard_presence; discord_presence ~alive:false ];
+      }
+  in
+  check bool "offline marker" true
+    (contains ~needle:"- discord #98791450001 (offline)" user)
+
+let test_dashboard_only_keeper_has_no_section () =
+  let user =
+    user_message
+      { base_observation with connected_surfaces = [ dashboard_presence ] }
+  in
+  check bool "no section for implicit dashboard" false
+    (contains ~needle:"### Connected Surfaces" user)
+
+let test_empty_presence_has_no_section () =
+  let user = user_message base_observation in
+  check bool "no section when empty" false
+    (contains ~needle:"### Connected Surfaces" user)
+
+let () =
+  init_runtime_default_for_tests ();
+  run "keeper_surface_presence_prompt"
+    [
+      ( "connected surfaces section",
+        [
+          test_case "bound keeper sees presence section" `Quick
+            test_bound_keeper_sees_presence_section;
+          test_case "offline surface rendered as offline" `Quick
+            test_offline_surface_rendered_as_offline;
+          test_case "dashboard-only keeper has no section" `Quick
+            test_dashboard_only_keeper_has_no_section;
+          test_case "empty presence has no section" `Quick
+            test_empty_presence_has_no_section;
+        ] );
+    ]

--- a/test/test_keeper_unified_verification_surface.ml
+++ b/test/test_keeper_unified_verification_surface.ml
@@ -20,6 +20,7 @@ let base_observation : WO.world_observation =
     pending_verification_count = 0;
     backlog_updated_since_last_scheduled_autonomous = false;
     active_agent_count = 0;
+    connected_surfaces = [];
   }
 
 let sample_board_event : WO.pending_board_event =


### PR DESCRIPTION
## 무엇

RFC-0223 P2 — keeper world prompt에 **Connected Surfaces** 섹션을 추가합니다. keeper가 자신에게 연결된 커넥터 lane(Discord 채널 등)의 존재와 liveness를 매 관측마다 인지합니다.

RFC: `docs/rfc/RFC-0223-typed-connector-surfaces-presence-pull-speaker.md` §4 P2 (P1 = #20726, 머지됨)

## 설계 원칙 (RFC §2)

- **Presence만, content 없음**: lane 라벨 + alive 플래그만. 메시지 수/roster/내용 없음 (그건 P3 pull tool).
- **상태 기계 없음** (§2 원칙 6): 바인딩 스토어 + 커넥터 liveness를 **매 관측마다 재계산**. 캐시·커서·버짓 없음.
- dashboard-only keeper는 섹션 자체가 생략됩니다 (모든 keeper가 dashboard를 가지므로 무신호) — RFC §6 통합 기준 그대로.

## 구현 포인트

| 영역 | 내용 |
|---|---|
| `lib/gate/gate_surface.ml` (신규) | typed surface (`Dashboard \| Discord \| Slack \| Gate`), `label`/`of_source` round-trip, `connected_surfaces_for_keeper` |
| `Channel_gate_connector.S` 확장 | `bound_channels` + `connected` 2개 멤버 추가 — sidecar functor(slack/telegram 커버), iMessage, Discord 3곳 구현. status_json blob 재파싱 대신 typed 접근 |
| `Discord_gateway_client` | run loop의 typed `connection_state`를 모듈 레벨 register로 publish. **설계 결정**: legacy status 파일은 Python sidecar 삭제 후 writer-less(항상 offline 보고)였음 — 같은 프로세스이므로 파일 우회 없이 직접 읽기. 이벤트마다 파일 쓰기 안 함(I/O churn 회피) |
| `world_observation.connected_surfaces` | observe / observe_direct_keeper_msg 양쪽에서 채움 |
| 렌더러 | Active Goals 직후 (안정 섹션, prefix-cache 순서 유지). `- discord #<channel> (alive)` 형식 |

### RFC §3 대비 변경점 (사유 명시)

- 모듈명 `Surface` → `Gate_surface`: masc_gate는 `(wrapped false)`라 글로벌 네임스페이스 — bare `Surface`는 과도하게 generic.
- `workspace_id`/`channel_id`를 `string option`으로: 바인딩 스토어와 chat row가 해당 id를 항상 갖지 않음 — `string` 강제는 빈 문자열 조작을 낳음.
- `Gate` variant에 `channel_id : string option` 추가: 한 커넥터에 복수 채널 바인딩 시 lane 구분에 필요.

## 검증

- `dune build @check` + default target EXIT=0
- 신규: `test_gate_surface` 8/8 (round-trip, unknown→Gate, presence 유도, blank-name guard), `test_keeper_surface_presence_prompt` 4/4 (bound→섹션 있음 / dashboard-only→없음 / offline 렌더)
- 회귀: verification_surface 12, reactive_wake 3, discord in_process 7, imessage 2, connector_routes 6, heartbeat_integration 23 — 전부 green
- 로컬 게이트: `check-determinism-contract.sh` PASS, `check-ssot.sh` ERROR 0, 제 파일 fmt clean

## 후속 (이 PR 범위 밖)

- P3 `keeper_surface_read` (lane 필터 읽기 + derived roster), P4 `keeper_surface_post` — RFC §4
- discord `status_json`(dashboard 표시용)은 여전히 legacy 파일 기반 — in-process register와의 통합은 별도 정리 후보

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
