### PR TITLE
feat(keeper): per-keeper turn single-flight admission (RFC-0225 §3.1)

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -127,6 +127,7 @@
   keeper_turn_up
   keeper_turn_lifecycle
   keeper_msg_async
+  keeper_turn_admission
   keeper_heartbeat_loop_observations
   keeper_supervisor_startup_helpers
   keeper_supervisor_restart_noop

--- a/lib/keeper/keeper_heartbeat_loop_cycle.ml
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.ml
@@ -39,7 +39,11 @@ open Keeper_types_profile
 module In_turn_pulse = Keeper_heartbeat_loop_in_turn_pulse
 module Observations = Keeper_heartbeat_loop_observations
 
-let run_keeper_cycle
+(* Body of [run_keeper_cycle], runnable only while holding the keeper's
+   turn slot ([Keeper_turn_admission]). The post-failure meta re-reads stay
+   inside the slot for the same reason as the chat lane: a concurrent turn
+   must not interleave with this lane's meta writes (RFC-0225 §1). *)
+let run_keeper_cycle_admitted
       ~ctx
       ~meta_after_cursor_persist
       ~stop
@@ -117,4 +121,47 @@ let run_keeper_cycle
       ~base_path:ctx.config.base_path
       ~keeper_name:meta_after_cursor_persist.name;
     updated
+;;
+
+let run_keeper_cycle
+      ~ctx
+      ~meta_after_cursor_persist
+      ~stop
+      ~obs
+      ~(turn_decision : Keeper_world_observation.keeper_cycle_decision)
+      ~shared_context
+      ()
+  =
+  match
+    Keeper_turn_admission.run_if_free
+      ~base_path:ctx.config.base_path
+      ~keeper_name:meta_after_cursor_persist.name
+      (run_keeper_cycle_admitted
+         ~ctx
+         ~meta_after_cursor_persist
+         ~stop
+         ~obs
+         ~turn_decision
+         ~shared_context)
+  with
+  | `Ran updated -> updated
+  | `Busy in_flight ->
+    (* Another lane holds this keeper's turn slot (RFC-0225 §3.1): skip the
+       cycle and return the pre-cycle meta unchanged. The next heartbeat
+       retries naturally — same shape as the pre-existing skip decisions. *)
+    let holder =
+      match in_flight with
+      | Some { Keeper_turn_admission.lane; started_at } ->
+        (* NDT-OK: gettimeofday renders the in-flight turn age for the log line only *)
+        Printf.sprintf
+          "%s turn running for %.0fs"
+          (Keeper_turn_admission.lane_to_string lane)
+          (Unix.gettimeofday () -. started_at)
+      | None -> "holder info not yet published"
+    in
+    Log.Keeper.info
+      "%s: turn slot busy (%s); skipping autonomous cycle until next heartbeat"
+      meta_after_cursor_persist.name
+      holder;
+    meta_after_cursor_persist
 ;;

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -149,7 +149,12 @@ let preflight_keeper_msg ctx args : (unit, string) result =
 
 (* -- handle_keeper_msg: orchestrator ---------------------------------------- *)
 
-let handle_keeper_msg ?on_text_delta ?on_event ctx args : tool_result =
+(* Body of [handle_keeper_msg], runnable only while holding the keeper's
+   turn slot ([Keeper_turn_admission]). Covers [Keeper_agent_run.run_turn]
+   AND the post-turn meta/lifecycle writes — both must stay inside the slot
+   or a concurrent turn can clobber the checkpoint and regress
+   [total_turns] (2026-06-10 RCA, RFC-0225 §1). *)
+let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ctx args : tool_result =
   let on_event =
     match on_event with
     | Some cb -> Some cb
@@ -682,3 +687,35 @@ let handle_keeper_msg ?on_text_delta ?on_event ctx args : tool_result =
               tool_result_ok (Yojson.Safe.to_string reply_json)
 
 ))))))
+
+let handle_keeper_msg ?on_text_delta ?on_event ctx args : tool_result =
+  let name = get_string args "name" "" in
+  if not (validate_name name) then
+    (* Invalid input cannot reach run_turn; let the admitted body produce
+       its precise validation error without holding the slot. *)
+    run_keeper_msg_turn_admitted ?on_text_delta ?on_event ctx args
+  else
+    match
+      Keeper_turn_admission.run_serialized
+        ~base_path:ctx.config.base_path
+        ~keeper_name:name
+        (fun () -> run_keeper_msg_turn_admitted ?on_text_delta ?on_event ctx args)
+    with
+    | `Ran result -> result
+    | `Rejected { Keeper_turn_admission.waiting; in_flight } ->
+        let in_flight_text =
+          match in_flight with
+          | None -> ""
+          | Some { Keeper_turn_admission.lane; started_at } ->
+              (* NDT-OK: gettimeofday renders the in-flight turn age for the error text only *)
+              Printf.sprintf
+                "; in-flight %s turn running for %.0fs"
+                (Keeper_turn_admission.lane_to_string lane)
+                (Unix.gettimeofday () -. started_at)
+        in
+        tool_result_error
+          (Printf.sprintf
+             "keeper %s turn queue is full (%d chat requests waiting%s); retry later"
+             name
+             waiting
+             in_flight_text)

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -153,7 +153,13 @@ let preflight_keeper_msg ctx args : (unit, string) result =
    turn slot ([Keeper_turn_admission]). Covers [Keeper_agent_run.run_turn]
    AND the post-turn meta/lifecycle writes — both must stay inside the slot
    or a concurrent turn can clobber the checkpoint and regress
-   [total_turns] (2026-06-10 RCA, RFC-0225 §1). *)
+   [total_turns] (2026-06-10 RCA, RFC-0225 §1).
+
+   Precondition: the caller holds the keeper's turn slot, OR the call
+   returns before any keeper-state read/write (the invalid-name path in
+   [handle_keeper_msg] calls this directly because the validation guard
+   below exits first). Do not add keeper-state mutation ahead of the
+   validation guards without moving it behind the slot. *)
 let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ctx args : tool_result =
   let on_event =
     match on_event with

--- a/lib/keeper/keeper_turn_admission.ml
+++ b/lib/keeper/keeper_turn_admission.ml
@@ -1,0 +1,128 @@
+(** Per-keeper turn single-flight gate. See keeper_turn_admission.mli. *)
+
+type lane =
+  | Autonomous
+  | Chat
+
+type in_flight_info =
+  { lane : lane
+  ; started_at : float
+  }
+
+type rejection =
+  { waiting : int
+  ; in_flight : in_flight_info option
+  }
+
+let lane_to_string = function
+  | Autonomous -> "autonomous"
+  | Chat -> "chat"
+;;
+
+(* Bound chosen to absorb a normal dashboard message burst while keeping the
+   worst-case pile-up behind a long autonomous turn small; rejected callers
+   get a typed error and can retry. *)
+let max_waiting_chat_requests = 8
+
+type slot =
+  { turn_mu : Eio.Mutex.t
+    (* Held across the whole admitted turn (possibly minutes): must be
+       fiber-cooperative, hence Eio.Mutex. Manipulated with raw
+       lock/try_lock/unlock — [use_rw] would poison the slot when a turn
+       raises, deadlocking the keeper forever. *)
+  ; state_mu : Stdlib.Mutex.t
+    (* Guards [info]/[waiting]. Critical sections never yield, so the
+       non-cooperative mutex is the right choice here. *)
+  ; mutable info : in_flight_info option
+  ; mutable waiting : int
+  }
+
+let slots : (string, slot) Hashtbl.t = Hashtbl.create 16
+
+(* Module-level singleton table: Stdlib.Mutex because lookup can be reached
+   outside an Eio context (e.g. test setup) and the critical section never
+   yields. *)
+let slots_mu = Stdlib.Mutex.create ()
+
+let slot_for ~base_path ~keeper_name =
+  let key = Keeper_registry_types.registry_key ~base_path keeper_name in
+  Stdlib.Mutex.protect slots_mu (fun () ->
+    match Hashtbl.find_opt slots key with
+    | Some slot -> slot
+    | None ->
+      let slot =
+        { turn_mu = Eio.Mutex.create ()
+        ; state_mu = Stdlib.Mutex.create ()
+        ; info = None
+        ; waiting = 0
+        }
+      in
+      Hashtbl.add slots key slot;
+      slot)
+;;
+
+let set_info slot info = Stdlib.Mutex.protect slot.state_mu (fun () -> slot.info <- info)
+let peek_info slot = Stdlib.Mutex.protect slot.state_mu (fun () -> slot.info)
+
+(* Precondition: the calling fiber holds [slot.turn_mu]. There is no
+   suspension point between acquiring the mutex and entering [f], so
+   cancellation cannot leak the slot; the exception arm releases on every
+   raise out of [f], including [Eio.Cancel.Cancelled]. *)
+let run_locked slot ~lane f =
+  (* NDT-OK: gettimeofday timestamps the in-flight info for observability only *)
+  set_info slot (Some { lane; started_at = Unix.gettimeofday () });
+  match f () with
+  | v ->
+    set_info slot None;
+    Eio.Mutex.unlock slot.turn_mu;
+    `Ran v
+  | exception exn ->
+    set_info slot None;
+    Eio.Mutex.unlock slot.turn_mu;
+    raise exn
+;;
+
+let run_if_free ~base_path ~keeper_name f =
+  let slot = slot_for ~base_path ~keeper_name in
+  if Eio.Mutex.try_lock slot.turn_mu
+  then run_locked slot ~lane:Autonomous f
+  else `Busy (peek_info slot)
+;;
+
+let run_serialized ~base_path ~keeper_name f =
+  let slot = slot_for ~base_path ~keeper_name in
+  let may_wait =
+    Stdlib.Mutex.protect slot.state_mu (fun () ->
+      if slot.waiting >= max_waiting_chat_requests
+      then false
+      else (
+        slot.waiting <- slot.waiting + 1;
+        true))
+  in
+  if not may_wait
+  then (
+    let waiting = Stdlib.Mutex.protect slot.state_mu (fun () -> slot.waiting) in
+    `Rejected { waiting; in_flight = peek_info slot })
+  else (
+    (* [Fun.protect] rather than [Switch.on_release]: there is no ambient
+       switch here, the finally never raises and never yields, and the only
+       suspension point it covers is the cancellable [Eio.Mutex.lock] wait
+       itself — a cancelled waiter leaves the queue, a successful one stops
+       counting as waiting once it holds the slot. *)
+    Fun.protect
+      ~finally:(fun () ->
+        Stdlib.Mutex.protect slot.state_mu (fun () -> slot.waiting <- slot.waiting - 1))
+      (fun () -> Eio.Mutex.lock slot.turn_mu);
+    run_locked slot ~lane:Chat f)
+;;
+
+module For_testing = struct
+  let reset () = Stdlib.Mutex.protect slots_mu (fun () -> Hashtbl.reset slots)
+
+  let peek ~base_path ~keeper_name =
+    let key = Keeper_registry_types.registry_key ~base_path keeper_name in
+    Stdlib.Mutex.protect slots_mu (fun () -> Hashtbl.find_opt slots key)
+    |> Option.map (fun slot ->
+      Stdlib.Mutex.protect slot.state_mu (fun () -> slot.info, slot.waiting))
+  ;;
+end

--- a/lib/keeper/keeper_turn_admission.mli
+++ b/lib/keeper/keeper_turn_admission.mli
@@ -1,0 +1,77 @@
+(** Keeper_turn_admission — per-keeper turn single-flight gate (RFC-0225 §3.1).
+
+    Every keeper-turn entry path must pass this gate before reaching
+    [Keeper_agent_run.run_turn]:
+
+    - the chat lane ([Keeper_turn.handle_keeper_msg]; every transport —
+      dashboard stream route, async [Keeper_msg_async] dispatch, direct
+      [masc_keeper_msg_stream]) admits with [run_serialized];
+    - the autonomous lane ([Keeper_heartbeat_loop_cycle.run_keeper_cycle])
+      admits with [run_if_free].
+
+    Without the gate the two lanes execute turns concurrently for the same
+    keeper. Measured corruption (2026-06-10 voice-repeat RCA): checkpoint
+    last-writer-wins clobber, [total_turns] regression 385→370, and
+    tool_calls cross-attribution. *)
+
+type lane =
+  | Autonomous (** heartbeat-scheduled cycle; skips when the slot is busy *)
+  | Chat (** operator/connector message turn; queues when the slot is busy *)
+
+type in_flight_info =
+  { lane : lane
+  ; started_at : float (** Unix epoch seconds when the turn was admitted *)
+  }
+
+type rejection =
+  { waiting : int (** chat requests already waiting on this keeper's slot *)
+  ; in_flight : in_flight_info option
+    (** the turn holding the slot, if observable at rejection time *)
+  }
+
+val lane_to_string : lane -> string
+
+val max_waiting_chat_requests : int
+(** Upper bound on chat requests parked on one keeper's slot. Beyond this
+    [run_serialized] rejects instead of queueing, so a message burst cannot
+    pile up unbounded waiting fibers behind a long autonomous turn. *)
+
+val run_if_free
+  :  base_path:string
+  -> keeper_name:string
+  -> (unit -> 'a)
+  -> [ `Ran of 'a | `Busy of in_flight_info option ]
+(** Run [f] holding the keeper's turn slot, or return [`Busy] without
+    blocking when another turn is in flight. The autonomous lane uses this:
+    a busy slot skips the cycle and the next heartbeat retries naturally.
+    [`Busy None] means the slot is held but the holder has not yet published
+    its info (admission in progress on another fiber). Exceptions from [f]
+    (including [Eio.Cancel.Cancelled]) release the slot and re-raise. *)
+
+val run_serialized
+  :  base_path:string
+  -> keeper_name:string
+  -> (unit -> 'a)
+  -> [ `Ran of 'a | `Rejected of rejection ]
+(** Run [f] holding the keeper's turn slot, waiting (fiber-cooperatively, in
+    Eio.Mutex wakeup order) while another turn is in flight. The chat lane
+    uses this: dashboard/connector messages queue rather than error. Returns
+    [`Rejected] only when [max_waiting_chat_requests] chat requests are
+    already waiting. Cancellation while waiting leaves the queue; exceptions
+    from [f] release the slot and re-raise.
+
+    Caller contract: a synchronous self-targeted call from inside the same
+    keeper's admitted turn waits for its own turn to finish and is bounded
+    only by the caller's turn budget — do not call this from within an
+    admitted turn of the same keeper. *)
+
+module For_testing : sig
+  val reset : unit -> unit
+  (** Drop every slot. Only safe when no turn is in flight. *)
+
+  val peek
+    :  base_path:string
+    -> keeper_name:string
+    -> (in_flight_info option * int) option
+  (** [(info, waiting)] for the keeper's slot, or [None] if never created. *)
+end

--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-06-07T13:29:07Z (HEAD: 4428536f05)
+Generated: 2026-06-10T13:37:43Z (HEAD: 75c984bec)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 
@@ -13,12 +13,12 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 
 | Metric | Value |
 |--------|-------|
-| Total .tla files | 90 |
-| Manual specs | 90 |
+| Total .tla files | 91 |
+| Manual specs | 91 |
 | TTrace (auto-generated) | 0 |
 | Directories | 19 |
-| Total .cfg files | 186 |
-| Buggy .cfg (bug-model pair) | 95 |
+| Total .cfg files | 188 |
+| Buggy .cfg (bug-model pair) | 96 |
 
 `kind` column: **manual** = hand-authored spec; **ttrace** = TLC counterexample export (`*TTrace*` or trace marker in header). `cfg`/`buggy` columns count companion `.cfg` files. `invariants/properties` lists names per cfg label (`clean=...`, `buggy=...`). `source hash` is the tracked `.tla` blob fingerprint.
 
@@ -63,7 +63,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | ToolCallContract.tla | ToolCallContract | manual | 2 | 1 | clean={inv:Safety} buggy={inv:NeverDropSilently} | a33a3185f14e |
 | TurnEvidenceChain.tla | TurnEvidenceChain | manual | 2 | 1 | clean={inv:TypeOK, inv:TerminalHasFullEvidence, inv:TerminalVisibleInRuntimeLens, inv:OasBoundaryGeneric} buggy={inv:TerminalHasFullEvidence} | 0790cfbf9572 |
 
-### specs/bug-models (20 specs)
+### specs/bug-models (21 specs)
 
 | File | Module | Kind | cfg | buggy | Invariants / Properties | Source Hash |
 |------|--------|------|-----|-------|-------------------------|---------------|
@@ -81,6 +81,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | KeepalivePhaseConsistency.tla | KeepalivePhaseConsistency | manual | 2 | 1 | clean={inv:TypeOK, inv:KeepalivePhaseConsistent, inv:InFlightImpliesRunning} buggy={inv:TypeOK, inv:KeepalivePhaseConsistent, inv:InFlightImpliesRunning} | dd37d9bd7796 |
 | KeeperPhaseRace.tla | KeeperPhaseRace | manual | 2 | 1 | clean={inv:TypeOK, inv:CrashImpliesThreshold, inv:RecordOnlyOnCrash, inv:CounterBoundedByObservations} buggy={inv:TypeOK, inv:CrashImpliesThreshold, inv:RecordOnlyOnCrash, inv:CounterBoundedByObservations} | 3c697ce837c8 |
 | KeeperTaskInterlock.tla | KeeperTaskInterlock | manual | 3 | 1 | clean={inv:TypeOK, inv:NoDeadKeeperHoldsTask, inv:ClaimerNotDead, inv:AwaitingVerificationHasClaimer} buggy={inv:TypeOK, inv:NoDeadKeeperHoldsTask, inv:ClaimerNotDead} current={inv:TypeOK} | c14aa70b51e4 |
+| KeeperTurnSingleFlight.tla | KeeperTurnSingleFlight | manual | 2 | 1 | clean={inv:TypeOK, inv:SingleFlight} buggy={inv:TypeOK, inv:SingleFlight} | b9c881db6540 |
 | KeeperWorkPipelineBug.tla | KeeperWorkPipelineBug | manual | 2 | 1 | clean={inv:TypeOK, inv:WorkspaceAlwaysBounded, inv:IdentityConsistent} buggy={inv:TypeOK, inv:WorkspaceAlwaysBounded} | dc1e83209ec5 |
 | KeeperWorktreeContainment.tla | KeeperWorktreeContainment | manual | 3 | 2 | clean={inv:KeeperWorktreeKind, inv:KeeperWorktreeOwner, inv:TypeOK} other-playground-buggy={inv:KeeperWorktreeKind, inv:KeeperWorktreeOwner, inv:TypeOK} server-root-buggy={inv:KeeperWorktreeKind, inv:KeeperWorktreeOwner, inv:TypeOK} | fc57677b6dc2 |
 | MemoryCompaction.tla | MemoryCompaction | manual | 2 | 1 | clean={inv:ConstraintsPreserved NeverEmpty ResultBounded LongTermProtected RecentFloorRespected} buggy={inv:ConstraintsPreserved NeverEmpty ResultBounded LongTermProtected RecentFloorRespected} | 0002c4c1a901 |

--- a/specs/bug-models/KeeperTurnSingleFlight-buggy.cfg
+++ b/specs/bug-models/KeeperTurnSingleFlight-buggy.cfg
@@ -1,0 +1,12 @@
+\* Buggy model: pre-RFC-0225 runtime — chat fork_daemon-per-request
+\* (BuggyChatBypass) and heartbeat without in-flight check
+\* (BuggyAutonomousBypass) start turns without admission.
+\* SingleFlight MUST be violated; if all invariants pass under
+\* SpecBuggy, the spec is too weak.
+SPECIFICATION SpecBuggy
+CONSTANTS
+    Keepers = {k1, k2}
+    MaxWaiting = 2
+INVARIANT TypeOK
+INVARIANT SingleFlight
+CHECK_DEADLOCK FALSE

--- a/specs/bug-models/KeeperTurnSingleFlight.cfg
+++ b/specs/bug-models/KeeperTurnSingleFlight.cfg
@@ -1,0 +1,9 @@
+\* Clean model: every turn passes Keeper_turn_admission.
+\* Expected: no invariant violation.
+SPECIFICATION Spec
+CONSTANTS
+    Keepers = {k1, k2}
+    MaxWaiting = 2
+INVARIANT TypeOK
+INVARIANT SingleFlight
+CHECK_DEADLOCK FALSE

--- a/specs/bug-models/KeeperTurnSingleFlight.tla
+++ b/specs/bug-models/KeeperTurnSingleFlight.tla
@@ -1,0 +1,116 @@
+---- MODULE KeeperTurnSingleFlight ----
+\* RFC-0225 §3.1: per-keeper turn single-flight admission.
+\*
+\* Mirrors the runtime [Keeper_turn_admission] (lib/keeper/
+\* keeper_turn_admission.ml). Two lanes start keeper turns:
+\*
+\*   - chat lane  | Keeper_turn.handle_keeper_msg -> run_serialized:
+\*                | requests queue (bounded by MaxWaiting =
+\*                | max_waiting_chat_requests) and run one at a time.
+\*   - autonomous | Keeper_heartbeat_loop_cycle.run_keeper_cycle ->
+\*     lane       | run_if_free: a busy slot skips the cycle.
+\*
+\* OCaml <-> TLA+ mapping:
+\*
+\*   variable     | OCaml site
+\*   -------------+--------------------------------------------------
+\*   running[k]   | slot.turn_mu held (0 = free, 1 = one admitted
+\*                | turn; 2 is reachable only through the bug actions)
+\*   waiting[k]   | slot.waiting (chat requests parked on the slot)
+\*
+\* The bug actions model the pre-RFC-0225 runtime measured in the
+\* 2026-06-10 voice-repeat RCA: Keeper_msg_async forked a daemon per
+\* chat request and the heartbeat lane had no in-flight check, so both
+\* lanes ran Keeper_agent_run.run_turn concurrently for one keeper
+\* (checkpoint clobber, total_turns regression, tool_calls
+\* cross-attribution).
+
+EXTENDS TLC, Naturals
+
+CONSTANTS
+    Keepers,    \* model keeper names
+    MaxWaiting  \* OCaml max_waiting_chat_requests (small in the model)
+
+VARIABLES
+    running,    \* keeper -> number of in-flight turns
+    waiting     \* keeper -> parked chat requests
+
+vars == << running, waiting >>
+
+TypeOK ==
+    /\ running \in [Keepers -> 0..2]
+    /\ waiting \in [Keepers -> 0..MaxWaiting]
+
+\* THE invariant of RFC-0225 §3.1: at most one in-flight turn per keeper.
+SingleFlight == \A k \in Keepers : running[k] <= 1
+
+Init ==
+    /\ running = [k \in Keepers |-> 0]
+    /\ waiting = [k \in Keepers |-> 0]
+
+\* A chat request arrives and joins the keeper's queue. Beyond
+\* MaxWaiting the runtime rejects with a typed error (state-invisible
+\* here: the guard simply disables this action).
+ChatEnqueue(k) ==
+    /\ waiting[k] < MaxWaiting
+    /\ waiting' = [waiting EXCEPT ![k] = @ + 1]
+    /\ UNCHANGED running
+
+\* run_serialized acquires the free slot for the head waiter.
+ChatAdmit(k) ==
+    /\ running[k] = 0
+    /\ waiting[k] > 0
+    /\ running' = [running EXCEPT ![k] = 1]
+    /\ waiting' = [waiting EXCEPT ![k] = @ - 1]
+
+\* run_if_free admits the heartbeat cycle on a free slot. A busy slot
+\* skips the cycle, which leaves the state unchanged (stuttering).
+AutonomousAdmit(k) ==
+    /\ running[k] = 0
+    /\ running' = [running EXCEPT ![k] = 1]
+    /\ UNCHANGED waiting
+
+\* The admitted turn finishes (normal return, exception, or
+\* cancellation — every release path of run_locked).
+TurnComplete(k) ==
+    /\ running[k] > 0
+    /\ running' = [running EXCEPT ![k] = @ - 1]
+    /\ UNCHANGED waiting
+
+Next ==
+    \E k \in Keepers :
+        \/ ChatEnqueue(k)
+        \/ ChatAdmit(k)
+        \/ AutonomousAdmit(k)
+        \/ TurnComplete(k)
+
+Spec == Init /\ [][Next]_vars
+
+\* Bug: the pre-RFC chat lane (Keeper_msg_async fork_daemon per
+\* request) starts the queued turn without passing admission, even
+\* while another turn is in flight. SingleFlight MUST be violated.
+BuggyChatBypass(k) ==
+    /\ waiting[k] > 0
+    /\ running[k] < 2
+    /\ running' = [running EXCEPT ![k] = @ + 1]
+    /\ waiting' = [waiting EXCEPT ![k] = @ - 1]
+
+\* Bug: the pre-RFC heartbeat lane starts a scheduled cycle with no
+\* in-flight check (keeper_turn.ml had none before RFC-0225).
+BuggyAutonomousBypass(k) ==
+    /\ running[k] = 1
+    /\ running' = [running EXCEPT ![k] = 2]
+    /\ UNCHANGED waiting
+
+NextBuggy ==
+    \E k \in Keepers :
+        \/ ChatEnqueue(k)
+        \/ ChatAdmit(k)
+        \/ AutonomousAdmit(k)
+        \/ TurnComplete(k)
+        \/ BuggyChatBypass(k)
+        \/ BuggyAutonomousBypass(k)
+
+SpecBuggy == Init /\ [][NextBuggy]_vars
+
+====

--- a/test/dune
+++ b/test/dune
@@ -1395,6 +1395,8 @@
 
 (include stanzas/test_keeper_msg_cancel.inc)
 
+(include stanzas/test_keeper_turn_admission.inc)
+
 (include stanzas/test_keeper_memory_bank_consensus_re_10399.inc)
 
 (include stanzas/test_keeper_meta_canonical_seed.inc)

--- a/test/stanzas/test_keeper_turn_admission.inc
+++ b/test/stanzas/test_keeper_turn_admission.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_turn_admission)
+ (modules test_keeper_turn_admission)
+ (libraries masc_test_deps))

--- a/test/test_keeper_turn_admission.ml
+++ b/test/test_keeper_turn_admission.ml
@@ -1,0 +1,187 @@
+(* test_keeper_turn_admission.ml — RFC-0225 §3.1 per-keeper turn
+   single-flight gate.
+
+   Verifies the admission invariant the 2026-06-10 voice-repeat RCA showed
+   was missing: at most one in-flight turn per keeper, the autonomous lane
+   skips a busy slot, the chat lane queues with a bounded waiting cap, and
+   every release path (normal return, exception, cancellation while
+   waiting) restores the slot. *)
+
+open Masc
+
+let failures = ref 0
+
+let check name cond =
+  if cond
+  then Printf.printf "  ✓ %s\n%!" name
+  else (
+    incr failures;
+    Printf.printf "  ✗ %s\n%!" name)
+;;
+
+let base_path = "/tmp/masc_test_turn_admission"
+let keeper_name = "admission-keeper"
+let reset () = Keeper_turn_admission.For_testing.reset ()
+
+let test_free_slot_admits () =
+  reset ();
+  Printf.printf "Test 1: free slot admits both lanes\n%!";
+  (match Keeper_turn_admission.run_if_free ~base_path ~keeper_name (fun () -> 41 + 1) with
+   | `Ran 42 -> check "run_if_free admits on a free slot" true
+   | `Ran _ | `Busy _ -> check "run_if_free admits on a free slot" false);
+  match Keeper_turn_admission.run_serialized ~base_path ~keeper_name (fun () -> "ok") with
+  | `Ran "ok" -> check "run_serialized admits on a free slot" true
+  | `Ran _ | `Rejected _ -> check "run_serialized admits on a free slot" false
+;;
+
+let test_autonomous_skips_in_flight_chat () =
+  reset ();
+  Printf.printf "Test 2: autonomous lane skips while a chat turn is in flight\n%!";
+  Eio.Switch.run (fun sw ->
+    let started, set_started = Eio.Promise.create () in
+    let release, set_release = Eio.Promise.create () in
+    Eio.Fiber.fork ~sw (fun () ->
+      match
+        Keeper_turn_admission.run_serialized ~base_path ~keeper_name (fun () ->
+          Eio.Promise.resolve set_started ();
+          Eio.Promise.await release)
+      with
+      | `Ran () -> ()
+      | `Rejected _ -> check "chat turn admitted on a free slot" false);
+    Eio.Promise.await started;
+    (match Keeper_turn_admission.run_if_free ~base_path ~keeper_name (fun () -> ()) with
+     | `Busy (Some { Keeper_turn_admission.lane = Chat; _ }) ->
+       check "run_if_free reports Busy with the in-flight chat lane" true
+     | `Busy _ -> check "run_if_free reports Busy with the in-flight chat lane" false
+     | `Ran () -> check "run_if_free must not admit during an in-flight turn" false);
+    Eio.Promise.resolve set_release ())
+;;
+
+let test_chat_turns_serialize () =
+  reset ();
+  Printf.printf "Test 3: concurrent chat turns never overlap\n%!";
+  let in_flight = ref 0 in
+  let max_in_flight = ref 0 in
+  let completed = ref 0 in
+  Eio.Switch.run (fun sw ->
+    for _ = 1 to 4 do
+      Eio.Fiber.fork ~sw (fun () ->
+        match
+          Keeper_turn_admission.run_serialized ~base_path ~keeper_name (fun () ->
+            incr in_flight;
+            if !in_flight > !max_in_flight then max_in_flight := !in_flight;
+            (* Suspension point inside the turn: an admission bug would let
+               another fiber enter here and push [in_flight] to 2. *)
+            Eio.Fiber.yield ();
+            decr in_flight;
+            incr completed)
+        with
+        | `Ran () -> ()
+        | `Rejected _ -> check "no rejection below the waiting cap" false)
+    done);
+  check "max in-flight turns is exactly 1" (!max_in_flight = 1);
+  check "all 4 chat turns completed" (!completed = 4)
+;;
+
+let test_waiting_cap_rejects () =
+  reset ();
+  Printf.printf "Test 4: chat requests beyond the waiting cap are rejected\n%!";
+  Eio.Switch.run (fun sw ->
+    let started, set_started = Eio.Promise.create () in
+    let release, set_release = Eio.Promise.create () in
+    Eio.Fiber.fork ~sw (fun () ->
+      ignore
+        (Keeper_turn_admission.run_serialized ~base_path ~keeper_name (fun () ->
+           Eio.Promise.resolve set_started ();
+           Eio.Promise.await release)));
+    Eio.Promise.await started;
+    (* Park exactly [max_waiting_chat_requests] waiters behind the holder.
+       [Fiber.fork] runs the child until its first suspension point, so each
+       waiter has joined the queue before the next fork. *)
+    for _ = 1 to Keeper_turn_admission.max_waiting_chat_requests do
+      Eio.Fiber.fork ~sw (fun () ->
+        ignore (Keeper_turn_admission.run_serialized ~base_path ~keeper_name (fun () -> ())))
+    done;
+    (match Keeper_turn_admission.For_testing.peek ~base_path ~keeper_name with
+     | Some (_, waiting) ->
+       check
+         (Printf.sprintf
+            "queue holds %d waiters (cap %d)"
+            waiting
+            Keeper_turn_admission.max_waiting_chat_requests)
+         (waiting = Keeper_turn_admission.max_waiting_chat_requests)
+     | None -> check "slot exists after queueing" false);
+    (match Keeper_turn_admission.run_serialized ~base_path ~keeper_name (fun () -> ()) with
+     | `Rejected { Keeper_turn_admission.waiting; in_flight } ->
+       check "request beyond the cap is rejected" true;
+       check
+         "rejection reports a full queue"
+         (waiting >= Keeper_turn_admission.max_waiting_chat_requests);
+       (match in_flight with
+        | Some { Keeper_turn_admission.lane = Chat; _ } ->
+          check "rejection reports the in-flight lane" true
+        | Some _ | None -> check "rejection reports the in-flight lane" false)
+     | `Ran () -> check "request beyond the cap is rejected" false);
+    Eio.Promise.resolve set_release ());
+  (* The switch only exits after every parked waiter ran; the slot must be
+     fully drained. *)
+  match Keeper_turn_admission.For_testing.peek ~base_path ~keeper_name with
+  | Some (None, 0) -> check "queue fully drained after release" true
+  | Some _ | None -> check "queue fully drained after release" false
+;;
+
+let test_exception_releases_slot () =
+  reset ();
+  Printf.printf "Test 5: an exception inside the turn releases the slot\n%!";
+  (try
+     ignore
+       (Keeper_turn_admission.run_if_free ~base_path ~keeper_name (fun () ->
+          failwith "boom"))
+   with
+   | Failure _ -> ());
+  match Keeper_turn_admission.run_if_free ~base_path ~keeper_name (fun () -> ()) with
+  | `Ran () -> check "slot released after an exception" true
+  | `Busy _ -> check "slot released after an exception" false
+;;
+
+let test_cancelled_waiter_leaves_queue () =
+  reset ();
+  Printf.printf "Test 6: a cancelled waiter leaves the queue\n%!";
+  Eio.Switch.run (fun sw ->
+    let started, set_started = Eio.Promise.create () in
+    let release, set_release = Eio.Promise.create () in
+    Eio.Fiber.fork ~sw (fun () ->
+      ignore
+        (Keeper_turn_admission.run_serialized ~base_path ~keeper_name (fun () ->
+           Eio.Promise.resolve set_started ();
+           Eio.Promise.await release)));
+    Eio.Promise.await started;
+    (* [Fiber.first] cancels the loser: the waiter blocks on the slot, the
+       second branch returns immediately, so the waiter is cancelled while
+       queued. Its turn body must never run. *)
+    Eio.Fiber.first
+      (fun () ->
+         ignore
+           (Keeper_turn_admission.run_serialized ~base_path ~keeper_name (fun () ->
+              check "cancelled waiter must not run its turn" false)))
+      (fun () -> ());
+    (match Keeper_turn_admission.For_testing.peek ~base_path ~keeper_name with
+     | Some (_, 0) -> check "waiting count restored after cancellation" true
+     | Some (_, _) | None -> check "waiting count restored after cancellation" false);
+    Eio.Promise.resolve set_release ())
+;;
+
+let () =
+  Eio_main.run @@ fun _env ->
+  test_free_slot_admits ();
+  test_autonomous_skips_in_flight_chat ();
+  test_chat_turns_serialize ();
+  test_waiting_cap_rejects ();
+  test_exception_releases_slot ();
+  test_cancelled_waiter_leaves_queue ();
+  if !failures > 0
+  then (
+    Printf.printf "FAILED: %d check(s)\n%!" !failures;
+    exit 1)
+  else Printf.printf "All keeper_turn_admission checks passed\n%!"
+;;


### PR DESCRIPTION
RFC-0225 (docs/rfc/RFC-0225-per-keeper-turn-single-flight.md) Rollout 1단계 — §3.1 admission primitive.

## 문제 (RFC-0225 §1, 2026-06-10 voice repeat RCA)

런타임 어디에도 "keeper당 in-flight turn 1개"를 강제하는 지점이 없었습니다. autonomous turn(FSM tid=370, 17분)과 chat turn(tid=382-386)이 sangsu에서 동시 실행되어 checkpoint last-writer-wins clobber("방금 한 말을 잊음"), `total_turns` 385→370 후퇴, tool_calls JSONL cross-attribution이 측정되었습니다.

## 변경

새 모듈 `Keeper_turn_admission` (keeper별 turn slot, `Eio.Mutex` 기반):

| Lane | 진입점 | Busy 시 동작 |
|------|--------|-------------|
| Chat (모든 transport) | `Keeper_turn.handle_keeper_msg` | **대기** (Eio.Mutex wakeup 순서, `max_waiting_chat_requests=8` 초과 시 typed queue-full 에러) |
| Autonomous | `Keeper_heartbeat_loop_cycle.run_keeper_cycle` | **스킵** (다음 heartbeat가 자연 재시도) |

- 두 래퍼 모두 post-turn meta/lifecycle 쓰기까지 slot 안에 유지 — run_turn만 직렬화하면 stale meta 쓰기 race가 남습니다.
- raw `lock`/`try_lock`/`unlock` 사용: `use_rw`는 turn 예외 시 mutex를 poison시켜 keeper를 영구 deadlock시킵니다.
- 해제 경로 전수: 정상 반환 / 예외(Cancelled 포함) / 대기 중 취소. mutex 획득과 `f` 진입 사이에 suspension point가 없어 cancellation leak 불가.

### RFC 스케치와의 의도적 차이

1. RFC §3.1은 `try_admit`/`release` linear token을 스케치했으나, 구현은 token을 내부에서 관리하는 `run_if_free`/`run_serialized` 래퍼로 봉인했습니다 — 호출자가 release를 누락할 수 있는 표면 자체를 제거.
2. "fork_daemon-per-request를 serial consumer fiber로 교체" 항목: `Keeper_msg_async`의 daemon 구조는 유지하되, 모든 daemon이 admission에서 FIFO 대기하므로 **Eio.Mutex 대기열이 곧 per-keeper serial queue**입니다. 이렇게 하면 async 경로뿐 아니라 동기 `masc_keeper_msg_stream` 직행 경로(`keeper_tool_surface_ops.ml:743` — daemon을 거치지 않음)도 같은 게이트를 통과합니다. 진입점 전수 확인: chat 4경로(stream route, surface_ops 608/656 async, 743 sync) 모두 `Turn.handle_keeper_msg`로 수렴, autonomous는 `unified_turn_execution.ml:172` 단일.

## 검증

- `test/test_keeper_turn_admission.ml` 12 checks green: 동시 chat turn 4개에서 max in-flight=1, autonomous skip + in-flight lane 보고, 대기 cap 초과 거부, 예외/취소 시 slot·대기열 복원, drain 후 잔존 상태 0.
- TLA+ bug model `specs/bug-models/KeeperTurnSingleFlight`: clean spec 36 states no error / buggy spec(pre-RFC 두 bypass 경로) `SingleFlight` invariant violated — 양쪽 모두 요구대로.
- `dune build --root . @check` + default target 모두 EXIT=0 (@check가 expr-level 타입 에러를 놓치는 케이스 대비).
- 변경 파일 전부 ocamlformat clean.

## 미검증 / 알려진 한계

- 같은 keeper의 admitted turn 안에서 동기 self-targeted `masc_keeper_msg_stream` 호출은 자기 turn이 끝날 때까지 대기하며, caller의 turn budget으로만 바운드됩니다 (.mli caller contract에 문서화). 자기-대상 동기 호출 차단은 tool layer의 후속 과제.
- 실 fleet에서 heartbeat skip 로그(`turn slot busy`) 빈도는 재배포 후 관찰 필요.

## Rollout 잔여 (별도 PR)

- §3.2 checkpoint versioned CAS + monotonic meta
- §3.3 tool_call log context run-identity rekey

MASC task-745.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
