### PR TITLE
fix(otel): unify keeper metric label key to "keeper" + repair dashboard $keeper variable

### DIFF
--- a/infrastructure/monitoring/grafana/provisioning/dashboards/masc-keeper-full.json
+++ b/infrastructure/monitoring/grafana/provisioning/dashboards/masc-keeper-full.json
@@ -513,8 +513,8 @@
       },
       "targets": [
         {
-          "expr": "sum by (edge) (rate(masc_keeper_turn_fsm_transitions_total{keeper=~\"$keeper\"}[$__rate_interval])) * 60",
-          "legendFormat": "{{edge}}",
+          "expr": "sum by (from, to) (rate(masc_keeper_turn_fsm_transitions_total{keeper=~\"$keeper\"}[$__rate_interval])) * 60",
+          "legendFormat": "{{from}} -> {{to}}",
           "refId": "A"
         }
       ],
@@ -554,8 +554,8 @@
       },
       "targets": [
         {
-          "expr": "sum by (transition) (rate(masc_keeper_lifecycle_transitions_total{keeper=~\"$keeper\"}[$__rate_interval]))",
-          "legendFormat": "{{transition}}",
+          "expr": "sum by (from_phase, to_phase) (rate(masc_keeper_lifecycle_transitions_total{keeper=~\"$keeper\"}[$__rate_interval]))",
+          "legendFormat": "{{from_phase}} -> {{to_phase}}",
           "refId": "A"
         }
       ],
@@ -2587,8 +2587,9 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(masc_keeper_turns_total, keeper)",
+        "definition": "label_values(masc_keeper_heartbeat_successes_total, keeper)",
         "hide": 0,
+        "allValue": ".*",
         "includeAll": true,
         "label": "Keeper",
         "multi": true,
@@ -2596,7 +2597,7 @@
         "options": [],
         "query": {
           "label": "Keeper",
-          "qry": "label_values(masc_keeper_turns_total, keeper)"
+          "qry": "label_values(masc_keeper_heartbeat_successes_total, keeper)"
         },
         "refresh": 2,
         "regex": "",

--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -53,7 +53,7 @@ let archive_credential_file config ~agent_name ~reason =
       then
         Otel_metric_store.inc_counter
           Otel_metric_store.metric_config_credential_archived_starvation
-          ~labels:[ "keeper_name", agent_name ]
+          ~labels:[ "keeper", agent_name ]
           ()
     with
     | Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/auth/auth.ml
+++ b/lib/auth/auth.ml
@@ -52,7 +52,7 @@ let archive_credential_file config ~agent_name ~reason =
       then
         Auth_metric_store.inc_counter
           Auth_metric_store.metric_config_credential_archived_starvation
-          ~labels:[ "keeper_name", agent_name ]
+          ~labels:[ "keeper", agent_name ]
           ()
     with
     | Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -163,7 +163,7 @@ let observe_dashboard_snapshot_latency ms =
   inc_bucket "+Inf"
 ;;
 
-let dashboard_all_zero_labels = [ "keeper_name", "__dashboard__" ]
+let dashboard_all_zero_labels = [ "keeper", "__dashboard__" ]
 
 let render_sub_operation_timings_all_zero (t : render_phase_timings_ms) =
   t.n_keepers > 0

--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -345,7 +345,7 @@ let write_meta_with_merge
        | Ok (Some latest) ->
          Otel_metric_store.inc_counter
            Otel_metric_store.metric_write_meta_cas_retry_total
-           ~labels:[("keeper_name", caller.name)]
+           ~labels:[("keeper", caller.name)]
            ();
          Log.Keeper.info
            "write_meta CAS retry %d/%d for %s (caller had %d, disk %d; field-level merge)"

--- a/lib/keeper/keeper_turn_livelock.ml
+++ b/lib/keeper/keeper_turn_livelock.ml
@@ -88,7 +88,7 @@ let record_started_metrics ~keeper outcome =
     ~labels:[ ("keeper", keeper) ] ();
   Otel_metric_store.inc_counter
     Keeper_metrics.(to_string TurnScheduled)
-    ~labels:[ ("keeper_name", keeper) ] ();
+    ~labels:[ ("keeper", keeper) ] ();
   (match outcome with
    | Fresh -> ()
    | Reattempt _ ->

--- a/lib/keeper/keeper_unified_metrics_snapshot.ml
+++ b/lib/keeper/keeper_unified_metrics_snapshot.ml
@@ -94,7 +94,7 @@ let append_metrics_snapshot ~(config : Workspace.config) ~(meta : keeper_meta)
     ~latency_ms;
   Otel_metric_store.inc_counter
     Keeper_metrics.(to_string TurnCompleted)
-    ~labels:[("keeper_name", meta.name)]
+    ~labels:[("keeper", meta.name)]
     ();
   let snapshot =
     `Assoc

--- a/lib/keeper/keeper_unified_metrics_support.ml
+++ b/lib/keeper/keeper_unified_metrics_support.ml
@@ -249,7 +249,7 @@ let record_usage_trust ~keeper_name ~(trust : usage_trust) =
   | Usage_missing | Usage_trusted -> ()
 
 let record_keeper_total_cost_usd ~keeper_name ~total_cost_usd =
-  let labels = [ ("keeper_name", keeper_name) ] in
+  let labels = [ ("keeper", keeper_name) ] in
   Otel_metric_store.register_gauge
     ~name:Keeper_metrics.(to_string TotalCostUsd)
     ~help:keeper_total_cost_usd_help
@@ -263,7 +263,7 @@ let record_keeper_total_cost_usd ~keeper_name ~total_cost_usd =
 let record_keeper_idle_seconds ~keeper_name ~idle_seconds =
   Otel_metric_store.set_gauge
     Keeper_metrics.(to_string IdleSeconds)
-    ~labels:[ ("keeper_name", keeper_name) ]
+    ~labels:[ ("keeper", keeper_name) ]
     (float_of_int (max 0 idle_seconds))
 
 (* RFC-0182 §3.1 cycle break — codecs live in [Turn_mode_codec]. *)

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -576,7 +576,7 @@ let run_keeper_cycle
                     (Trajectory.Gated "input_required");
                   Otel_metric_store.inc_counter
                     Keeper_metrics.(to_string Turns)
-                    ~labels:[ "keeper_name", meta.name; "outcome", "input_required" ]
+                    ~labels:[ "keeper", meta.name; "outcome", "input_required" ]
                     ();
                   cycle_completed := true;
                   post_turn_complete_task ~cycle_completed;
@@ -627,7 +627,7 @@ let run_keeper_cycle
                   let is_ambiguous_partial = ambiguous_commit_tools <> [] in
                   Otel_metric_store.inc_counter
                     Keeper_metrics.(to_string Turns)
-                    ~labels:[ "keeper_name", meta.name; "outcome", "failure" ]
+                    ~labels:[ "keeper", meta.name; "outcome", "failure" ]
                     ();
                   (if EC.is_provider_timeout_error err
                    then

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -280,32 +280,32 @@ let emit_usage_metrics_and_log
   in
   Otel_metric_store.inc_counter
     Keeper_metrics.(to_string Turns)
-    ~labels:[ "keeper_name", updated_meta.name; "outcome", outcome_label ]
+    ~labels:[ "keeper", updated_meta.name; "outcome", outcome_label ]
     ();
   if usage_trusted
   then (
     Otel_metric_store.inc_counter
       Keeper_metrics.(to_string InputTokens)
-      ~labels:[ "keeper_name", updated_meta.name; "model", runtime_lane_label ]
+      ~labels:[ "keeper", updated_meta.name; "model", runtime_lane_label ]
       ~delta:(float_of_int result.usage.input_tokens)
       ();
     Otel_metric_store.inc_counter
       Keeper_metrics.(to_string OutputTokens)
-      ~labels:[ "keeper_name", updated_meta.name; "model", runtime_lane_label ]
+      ~labels:[ "keeper", updated_meta.name; "model", runtime_lane_label ]
       ~delta:(float_of_int result.usage.output_tokens)
       ();
     if result.usage.cache_creation_input_tokens > 0
     then
       Otel_metric_store.inc_counter
         Keeper_metrics.(to_string CacheCreationTokens)
-        ~labels:[ "keeper_name", updated_meta.name; "model", runtime_lane_label ]
+        ~labels:[ "keeper", updated_meta.name; "model", runtime_lane_label ]
         ~delta:(float_of_int result.usage.cache_creation_input_tokens)
         ();
     if result.usage.cache_read_input_tokens > 0
     then
       Otel_metric_store.inc_counter
         Keeper_metrics.(to_string CacheReadTokens)
-        ~labels:[ "keeper_name", updated_meta.name; "model", runtime_lane_label ]
+        ~labels:[ "keeper", updated_meta.name; "model", runtime_lane_label ]
         ~delta:(float_of_int result.usage.cache_read_input_tokens)
         ())
   else (
@@ -319,7 +319,7 @@ let emit_usage_metrics_and_log
          Otel_metric_store.inc_counter
            Keeper_metrics.(to_string UsageAnomalies)
            ~labels:
-             [ "keeper_name", updated_meta.name
+             [ "keeper", updated_meta.name
              ; "model", runtime_lane_label
              ; "reason", reason
              ]

--- a/scripts/check-ssot.sh
+++ b/scripts/check-ssot.sh
@@ -106,6 +106,27 @@ check_rule "R6-home-masc-root" 9 \
   '' \
   bin lib scripts docs
 
+# SSOT-R7 — OTel metric label key for keeper identity is "keeper".
+# "keeper_name" in a metric label list splits the label vocabulary: Grafana
+# template variables and panel group-bys query "keeper", so keeper_name-keyed
+# series render as 0/No data (masc-keeper-full broke this way; the $keeper
+# variable sourced label_values(masc_keeper_turns_total, keeper) and got an
+# empty list). JSON codec fields named "keeper_name" are NOT affected — this
+# rule only matches inside ~labels:[...] lists and let <name>labels = [...] bindings.
+# Needs -U (multiline): label lists wrap across lines.
+r7_pattern='(~labels:|let [a-z_]*labels\s*=\s*)\[[^\]]{0,400}"keeper_name"'
+r7_count="$({ rg -U -c --no-heading "$r7_pattern" bin lib test 2>/dev/null || true; } \
+  | awk -F: '{sum += $2} END {print sum+0}')"
+if [ "$r7_count" -gt 0 ]; then
+  echo "ERROR[R7-metric-label-keeper-name]: $r7_count occurrences (baseline 0)." >&2
+  echo "  Replace with: \"keeper\" — the canonical metric label key (cf. Keeper_hooks_oas_types.label_keeper)." >&2
+  echo "  Offending sites:" >&2
+  rg -U -l "$r7_pattern" bin lib test 2>/dev/null | sed 's/^/    /' >&2
+  fail=1
+else
+  echo "OK[R7-metric-label-keeper-name]: 0 occurrences (baseline 0)."
+fi
+
 # SSOT-R3 (tool-name literal) is intentionally deferred to #8448's landing:
 # the raw `"masc_..."` match is too noisy without the Tool_name.Keeper variant
 # refactor in place. Add to this script once #8448 introduces a narrow dispatch

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -669,7 +669,7 @@ let test_ensure_keeper_credential_archives_dual_identity_bare () =
       let archive_metric () =
         Masc.Otel_metric_store.metric_value_or_zero
           Masc.Otel_metric_store.metric_config_credential_archived_starvation
-          ~labels:[("keeper_name", "sangsu")]
+          ~labels:[("keeper", "sangsu")]
           ()
       in
       let before_archive_metric = archive_metric () in

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -640,7 +640,7 @@ let record_test_credential_archive () =
   in
   Lib.Otel_metric_store.inc_counter
     Lib.Otel_metric_store.metric_config_credential_archived_starvation
-    ~labels:[("keeper_name", keeper_name)]
+    ~labels:[("keeper", keeper_name)]
     ()
 
 let test_credential_monitoring_json_surfaces_archive_counter () =

--- a/test/test_dashboard_render_timing_9766.ml
+++ b/test/test_dashboard_render_timing_9766.ml
@@ -73,7 +73,7 @@ let snapshot_latency_bucket le =
 let dashboard_all_zero_value () =
   Metrics.metric_value_or_zero
     Metrics.metric_dashboard_metric_all_zeros
-    ~labels:[("keeper_name", "__dashboard__")]
+    ~labels:[("keeper", "__dashboard__")]
     ()
 
 let test_record_timings_observes_otel_metric_store () =

--- a/test/test_keeper_meta_cas_retry.ml
+++ b/test/test_keeper_meta_cas_retry.ml
@@ -111,7 +111,7 @@ let test_retry_succeeds_after_concurrent_bump () =
     let before_retry_metric =
       Otel_metric_store.metric_value_or_zero
         Otel_metric_store.metric_write_meta_cas_retry_total
-        ~labels:[("keeper_name", "beta")]
+        ~labels:[("keeper", "beta")]
         ()
     in
     (match
@@ -123,7 +123,7 @@ let test_retry_succeeds_after_concurrent_bump () =
     let after_retry_metric =
       Otel_metric_store.metric_value_or_zero
         Otel_metric_store.metric_write_meta_cas_retry_total
-        ~labels:[("keeper_name", "beta")]
+        ~labels:[("keeper", "beta")]
         ()
     in
     let final = match Keeper_meta_store.read_meta config "beta" with

--- a/test/test_keeper_turn_livelock_10121.ml
+++ b/test/test_keeper_turn_livelock_10121.ml
@@ -49,7 +49,7 @@ let starts_for ~keeper =
 
 let scheduled_for ~keeper =
   Metrics.metric_value_or_zero Keeper_metrics.(to_string TurnScheduled)
-    ~labels:[ ("keeper_name", keeper) ] ()
+    ~labels:[ ("keeper", keeper) ] ()
 
 let reattempts_for ~keeper =
   Metrics.metric_value_or_zero Keeper_metrics.(to_string TurnReattempts)


### PR DESCRIPTION
## Summary

masc-keeper-full Grafana 대시보드가 활동 중에도 거의 전 패널 0/No data로 렌더링되는 문제의 근본 수정입니다.

**진단** (VictoriaMetrics 실측 전수 대조): 대시보드가 참조하는 43개 메트릭은 전부 실존하고 신선하게 export됩니다. 문제는 메트릭 라벨 키가 `keeper`(21개 메트릭)와 `keeper_name`(7개 메트릭: turns/input·output_tokens/total_cost/idle_seconds/turn_scheduled·completed)으로 갈라져 있고, 하필 `$keeper` 템플릿 변수가 `label_values(masc_keeper_turns_total, keeper)` — keeper_name 진영 메트릭 — 을 소스로 써서 **변수 옵션이 항상 빈 목록**이 되는 것. "All"이 빈 매칭으로 전개되어 keeper 라벨이 없는 init zero-fill 0-셀만 잡히고, 시간당 4,146건 흐르던 `turn_fsm_transitions`까지 0으로 그려졌습니다.

## 변경

1. **라벨 어휘 통일 (lib 9파일 + test 5파일)**: 메트릭 `~labels`의 `"keeper_name"` → `"keeper"` (정본: `Keeper_hooks_oas_types.label_keeper`). 간접 바인딩 2곳 포함 (`keeper_unified_metrics_support.ml` TotalCostUsd, `dashboard_execution.ml` all_zero gauge). JSON codec 필드 `keeper_name`은 해당 없음(미변경).
2. **check-ssot.sh R7 ratchet (baseline 0)**: `~labels:[...]` / `let <name>labels = [...]` 내 `"keeper_name"` 재유입 차단 (multiline rg -U).
3. **대시보드 수정**: `$keeper` 변수 소스를 `masc_keeper_heartbeat_successes_total`(keeper-라벨, 모든 live keeper가 발화)로 교체 + `allValue: ".*"` 추가, Turn FSM 패널 `sum by (edge)`→`sum by (from, to)`(실제 라벨), Lifecycle `sum by (transition)`→`sum by (from_phase, to_phase)`.

## Verification

- `dune build --root . @check` exit 0 / `dune build --root .` (default target) exit 0
- `bash scripts/check-ssot.sh` exit 0 — `OK[R7-metric-label-keeper-name]: 0 (baseline 0)`, 기존 룰 변동 없음
- 영향 테스트: `test_keeper_turn_livelock_10121` 11/11, `test_dashboard_render_timing_9766` 7/7 green
- `test_keeper_meta_cas_retry`(2)/`test_auth`(2)/`test_dashboard_http_core`(7) 실패는 **origin/main(75c984bec) 임시 worktree에서 동일 실행으로 실패 테스트 이름까지 일치 확인** — pre-existing
- 대시보드 JSON: `json.load` 유효성 + 변경 라인 non-ASCII 없음

## Notes

- 효과는 masc 서버 재배포 후 새 시리즈부터 적용. 기존 `keeper_name` 시리즈는 자연 만료(대시보드 변수는 heartbeat 소스라 전환기에도 동작).
- 진단 중 확인한 부수 사실: 7일간 0인 카운터 12개(livelock/receipt failures/restart 등)는 emit 사이트 전부 살아 있고 이벤트가 진짜 없었던 것. compactions 정지(5~13h)는 #20694 효과의 측정 증거.
- 잔여(스코프 외): `fsm_edge_transitions`/`template_render_outcome`/`tools_oas_deterministic_failures`는 keeper 속성 자체가 없음(집계는 동작, per-keeper 귀속만 불가) — 필요 시 후속.

MASC: task-746

🤖 Generated with [Claude Code](https://claude.com/claude-code)
