### PR TITLE
test(runtime_attempt_fsm): cover live decision helpers with an executable suite

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -73,6 +73,7 @@
   test_keeper_turn_terminal_disposition_field
   test_keeper_reconcile_state
   test_attempt_state
+  test_runtime_attempt_fsm
   test_actor_mailbox
   test_domain_pool
   test_sse
@@ -334,6 +335,7 @@
   test_keeper_turn_terminal_disposition_field
   test_keeper_reconcile_state
   test_attempt_state
+  test_runtime_attempt_fsm
   test_actor_mailbox
   test_domain_pool
   test_sse

--- a/test/test_runtime_attempt_fsm.ml
+++ b/test/test_runtime_attempt_fsm.ml
@@ -1,0 +1,167 @@
+(** Unit tests for Runtime_attempt_fsm.
+
+    Covers the functions with production callers first ([should_try_next],
+    [to_user_message], [provider_outcome_to_string]) and documents the pure
+    [decide] matrix.  Only [Call_err]/[Accept_rejected]-reachable paths are
+    exercised: constructing the opaque [Llm_provider.Types.api_response]
+    needed for [Call_ok] is not possible from this test. *)
+
+open Runtime_attempt_fsm
+
+let mk_http_err ?(code = 429) ?(body = "") () =
+  Llm_provider.Http_client.HttpError { code; body }
+
+let mk_network_err ?(message = "net err") () =
+  Llm_provider.Http_client.NetworkError
+    { message; kind = Llm_provider.Http_client.Unknown }
+
+let mk_timeout_err ?(message = "timeout") () =
+  Llm_provider.Http_client.TimeoutError
+    { message; phase = Llm_provider.Http_client.Wall_clock }
+
+let mk_provider_terminal ?(message = "terminal") () =
+  Llm_provider.Http_client.ProviderTerminal
+    { kind = Llm_provider.Http_client.Other "test_terminal"; message }
+
+let mk_accept_rejected ?(reason = "quality") () =
+  Llm_provider.Http_client.AcceptRejected { reason }
+
+(* --- should_try_next (live: keeper_turn_driver_try_runtime) --- *)
+
+let check_retry name expected err =
+  Alcotest.(check bool) name expected (should_try_next err)
+
+let test_should_try_http_408 () = check_retry "408 retries" true (mk_http_err ~code:408 ())
+let test_should_try_http_409 () = check_retry "409 retries" true (mk_http_err ~code:409 ())
+let test_should_try_http_429 () = check_retry "429 retries" true (mk_http_err ~code:429 ())
+let test_should_try_http_500 () = check_retry "500 retries" true (mk_http_err ~code:500 ())
+let test_should_try_http_400 () = check_retry "400 stops" false (mk_http_err ~code:400 ())
+let test_should_try_http_404 () = check_retry "404 stops" false (mk_http_err ~code:404 ())
+let test_should_try_network () = check_retry "network retries" true (mk_network_err ())
+let test_should_try_timeout () = check_retry "timeout retries" true (mk_timeout_err ())
+
+let test_should_try_terminal () =
+  check_retry "provider terminal stops" false (mk_provider_terminal ())
+
+let test_should_try_accept_rejected () =
+  check_retry "accept rejection stops" false (mk_accept_rejected ())
+
+(* --- decide: Call_err / Accept_rejected matrix --- *)
+
+let test_decide_call_err_retryable_not_last () =
+  match
+    decide ~accept_on_exhaustion:false ~is_last:false
+      (Call_err (mk_http_err ~code:429 ()))
+  with
+  | Try_next { last_err = Some _ } -> ()
+  | _ -> Alcotest.fail "retryable + not-last should yield Try_next with last_err"
+
+let test_decide_call_err_retryable_last () =
+  match
+    decide ~accept_on_exhaustion:false ~is_last:true
+      (Call_err (mk_http_err ~code:429 ()))
+  with
+  | Exhausted { last_err = Some _ } -> ()
+  | _ -> Alcotest.fail "retryable + last should yield Exhausted with last_err"
+
+let test_decide_call_err_terminal_not_last () =
+  match
+    decide ~accept_on_exhaustion:false ~is_last:false
+      (Call_err (mk_provider_terminal ()))
+  with
+  | Exhausted { last_err = Some _ } -> ()
+  | _ -> Alcotest.fail "non-retryable error should yield Exhausted even when not last"
+
+let test_decide_accept_rejected_not_last () =
+  (* Accept_rejected carries a response we cannot construct; route the same
+     error shape through Call_err to pin the retry classification instead. *)
+  match
+    decide ~accept_on_exhaustion:false ~is_last:false
+      (Call_err (mk_accept_rejected ()))
+  with
+  | Exhausted { last_err = Some (Llm_provider.Http_client.AcceptRejected _) } -> ()
+  | _ -> Alcotest.fail "AcceptRejected via Call_err is non-retryable → Exhausted"
+
+let test_decide_and_record_delegates () =
+  let outcome = Call_err (mk_http_err ~code:500 ()) in
+  let direct = decide ~accept_on_exhaustion:false ~is_last:false outcome in
+  let recorded =
+    decide_and_record ~runtime_id:"rt-test" ~accept_on_exhaustion:false
+      ~is_last:false outcome
+  in
+  match direct, recorded with
+  | Try_next _, Try_next _ -> ()
+  | _ -> Alcotest.fail "decide_and_record must match decide for the same outcome"
+
+(* --- to_user_message (live: keeper_turn_driver_try_runtime) --- *)
+
+let contains ~needle haystack =
+  let nl = String.length needle and hl = String.length haystack in
+  let rec scan i = i + nl <= hl && (String.sub haystack i nl = needle || scan (i + 1)) in
+  nl = 0 || scan 0
+
+let test_user_message_http () =
+  let msg = to_user_message (Some (mk_http_err ~code:503 ~body:"overloaded" ())) in
+  Alcotest.(check bool) "mentions HTTP 503" true (contains ~needle:"503" msg)
+
+let test_user_message_accept_rejected () =
+  let msg = to_user_message (Some (mk_accept_rejected ~reason:"low quality" ())) in
+  Alcotest.(check string) "reason passes through" "low quality" msg
+
+let test_user_message_network () =
+  let msg = to_user_message (Some (mk_network_err ~message:"conn reset" ())) in
+  Alcotest.(check string) "network message passes through" "conn reset" msg
+
+let test_user_message_none () =
+  Alcotest.(check bool) "absent error still yields a message" true
+    (String.length (to_user_message None) > 0)
+
+(* --- provider_outcome_to_string --- *)
+
+let test_outcome_to_string_call_err () =
+  Alcotest.(check bool) "Call_err serializes non-empty" true
+    (String.length (provider_outcome_to_string (Call_err (mk_http_err ()))) > 0)
+
+let test_outcome_option_to_string_none () =
+  Alcotest.(check bool) "None serializes non-empty" true
+    (String.length (provider_outcome_option_to_string None) > 0)
+
+let () =
+  Alcotest.run "runtime_attempt_fsm"
+    [ ( "should_try_next"
+      , [ Alcotest.test_case "HTTP 408" `Quick test_should_try_http_408
+        ; Alcotest.test_case "HTTP 409" `Quick test_should_try_http_409
+        ; Alcotest.test_case "HTTP 429" `Quick test_should_try_http_429
+        ; Alcotest.test_case "HTTP 500" `Quick test_should_try_http_500
+        ; Alcotest.test_case "HTTP 400" `Quick test_should_try_http_400
+        ; Alcotest.test_case "HTTP 404" `Quick test_should_try_http_404
+        ; Alcotest.test_case "network error" `Quick test_should_try_network
+        ; Alcotest.test_case "timeout" `Quick test_should_try_timeout
+        ; Alcotest.test_case "provider terminal" `Quick test_should_try_terminal
+        ; Alcotest.test_case "accept rejected" `Quick test_should_try_accept_rejected
+        ] )
+    ; ( "decide"
+      , [ Alcotest.test_case "retryable not-last" `Quick
+            test_decide_call_err_retryable_not_last
+        ; Alcotest.test_case "retryable last" `Quick
+            test_decide_call_err_retryable_last
+        ; Alcotest.test_case "terminal not-last" `Quick
+            test_decide_call_err_terminal_not_last
+        ; Alcotest.test_case "accept-rejected via Call_err" `Quick
+            test_decide_accept_rejected_not_last
+        ; Alcotest.test_case "decide_and_record delegates" `Quick
+            test_decide_and_record_delegates
+        ] )
+    ; ( "to_user_message"
+      , [ Alcotest.test_case "HTTP 503" `Quick test_user_message_http
+        ; Alcotest.test_case "accept rejected reason" `Quick
+            test_user_message_accept_rejected
+        ; Alcotest.test_case "network message" `Quick test_user_message_network
+        ; Alcotest.test_case "none" `Quick test_user_message_none
+        ] )
+    ; ( "provider_outcome_to_string"
+      , [ Alcotest.test_case "Call_err" `Quick test_outcome_to_string_call_err
+        ; Alcotest.test_case "option none" `Quick
+            test_outcome_option_to_string_none
+        ] )
+    ]


### PR DESCRIPTION
## Summary (rework — feature scope dropped, tests kept)

리뷰에서 구조 문제 2건이 확인되어 main 기준으로 재구성했습니다 (`e0af28ffc`):

1. **헤드라인 기능(`?log_warn` 주입 + `~source` threading)은 프로덕션 호출자 0인 함수를 계측** — 라이브 재시도 루프(`keeper_turn_driver_try_runtime.ml`)는 `should_try_next`로 결정을 인라인 재유도하고 `decision` 타입을 생성/소비하지 않습니다. 추가된 로깅은 프로덕션에서 발화 불가 (#20689의 dead-module 계측과 동일 클래스) → 드랍.
2. **테스트 파일에 `Alcotest.run` 엔트리포인트가 없어 21개 케이스가 0개 실행**되는 구조였음 → 러너 포함 재작성.

## 유지한 가치

실행되는 테스트 21개 (`test/dune` 등록 포함):
- `should_try_next` 재시도 분류 10케이스 (408/409/429/500 retry, 400/404/terminal/accept-rejected stop, network/timeout retry) — **라이브 함수** (try_runtime:195에서 호출)
- `to_user_message` 렌더링 4케이스 — **라이브 함수**
- `provider_outcome(_option)_to_string` 2케이스
- 순수 `decide` 매트릭스 + `decide_and_record` 위임 5케이스 (현재 시점 문서화)

constructor는 agent_sdk 0.205.8 실제 타입 기준 (`TimeoutError`에 `phase`, `ProviderTerminal`에 `provider_terminal_kind` — 이전 커밋의 환각 constructor 이슈 해소).

## 후속 (별도 이슈로 에스컬레이션)

`decide`/`decision` 표면의 adopt-or-delete 결정은 hot path 변경이라 drive-by PR로 정하지 않고 이슈로 분리 — 라이브 루프에 `if is_last then X else X` 동일-양팔 분기, FSM에만 있는 추측성 `accept_on_exhaustion` 의미론 포함.

## Verification

- `dune build --root . @check` / default target exit 0
- `ocamlformat --check` clean
- `test_runtime_attempt_fsm.exe` — **21/21 green** (실제 실행 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)