### PR TITLE
feat(keeper): coalesce queued chat messages into one turn per route

### DIFF
--- a/lib/keeper/keeper_chat_consumer.ml
+++ b/lib/keeper/keeper_chat_consumer.ml
@@ -6,21 +6,38 @@ let poll_interval_sec =
       try float_of_string s with Failure _ -> 1.0)
   | None -> 1.0
 
-let start ~sw ~clock ~handle_turn =
+let start ~sw ~clock ~base_path ~handle_turn =
   let rec poll_loop () =
     let keeper_names = Keeper_chat_queue.all_keeper_names () in
     List.iter
       (fun keeper_name ->
-         match Keeper_chat_queue.dequeue ~keeper_name with
-         | None -> ()
-         | Some queued ->
-             (try handle_turn ~sw ~keeper_name ~queued_message:queued with
-              | Eio.Cancel.Cancelled _ as e -> raise e
-              | exn ->
-                  Log.Keeper.warn
-                    "keeper_chat_consumer: handle_turn failed for keeper=%s: %s"
+         (* While a turn is in flight, leave queued messages in place so
+            everything sent during the turn coalesces into ONE follow-up
+            turn instead of one turn per message — the keeper then answers
+            with the full accumulated context (RFC-0225 single-flight
+            makes the in-flight state observable). *)
+         match Keeper_turn_admission.in_flight ~base_path ~keeper_name with
+         | Some _ -> ()
+         | None -> (
+             let batch = Keeper_chat_queue.dequeue_batch ~keeper_name in
+             (match batch with
+              | _ :: _ :: _ ->
+                  Log.Keeper.info
+                    "keeper_chat_consumer: coalesced %d queued messages into \
+                     one turn for keeper=%s"
+                    (List.length batch)
                     keeper_name
-                    (Printexc.to_string exn)))
+              | [] | [ _ ] -> ());
+             match Keeper_chat_queue.merge_batch batch with
+             | None -> ()
+             | Some queued ->
+                 (try handle_turn ~sw ~keeper_name ~queued_message:queued with
+                  | Eio.Cancel.Cancelled _ as e -> raise e
+                  | exn ->
+                      Log.Keeper.warn
+                        "keeper_chat_consumer: handle_turn failed for keeper=%s: %s"
+                        keeper_name
+                        (Printexc.to_string exn))))
       keeper_names;
     Eio.Time.sleep clock poll_interval_sec;
     poll_loop ()

--- a/lib/keeper/keeper_chat_consumer.mli
+++ b/lib/keeper/keeper_chat_consumer.mli
@@ -9,9 +9,17 @@
 
     @since 2.145.0 *)
 
-(** [start ~sw ~clock ~handle_turn ()] begins a background fiber that
-    polls [Keeper_chat_queue] every [MASC_KEEPER_QUEUE_POLL_SEC] seconds
-    (default 1.0) and calls [handle_turn] for each queued message.
+(** [start ~sw ~clock ~base_path ~handle_turn] begins a background fiber
+    that polls [Keeper_chat_queue] every [MASC_KEEPER_QUEUE_POLL_SEC]
+    seconds (default 1.0).
+
+    Per keeper and per tick: when a turn is in flight
+    ([Keeper_turn_admission.in_flight]), queued messages are left to
+    accumulate; once the slot is free, the head run of same-source
+    messages is drained ([Keeper_chat_queue.dequeue_batch]) and merged
+    into ONE coalesced message ([Keeper_chat_queue.merge_batch]) before
+    [handle_turn] runs — messages sent during a turn answer together in
+    a single follow-up turn instead of one turn each.
 
     The fiber runs until [sw] is released.
 
@@ -21,5 +29,6 @@
 val start :
   sw:Eio.Switch.t ->
   clock:_ Eio.Time.clock ->
+  base_path:string ->
   handle_turn:(sw:Eio.Switch.t -> keeper_name:string -> queued_message:Keeper_chat_queue.queued_message -> unit) ->
   unit

--- a/lib/keeper/keeper_chat_queue.ml
+++ b/lib/keeper/keeper_chat_queue.ml
@@ -54,6 +54,51 @@ let dequeue ~keeper_name =
           Eio.Mutex.use_rw ~protect:true entry.mutex (fun () ->
               if Queue.is_empty entry.q then None else Some (Queue.pop entry.q)))
 
+let same_source a b =
+  match (a, b) with
+  | Dashboard, Dashboard -> true
+  | ( Discord { channel_id = c1; user_id = u1 },
+      Discord { channel_id = c2; user_id = u2 } ) ->
+      String.equal c1 c2 && String.equal u1 u2
+  | Slack { channel = c1; user_id = u1 }, Slack { channel = c2; user_id = u2 }
+    ->
+      String.equal c1 c2 && String.equal u1 u2
+  | Dashboard, (Discord _ | Slack _)
+  | Discord _, (Dashboard | Slack _)
+  | Slack _, (Dashboard | Discord _) ->
+      false
+
+let dequeue_batch ~keeper_name =
+  Eio.Mutex.use_rw ~protect:true registry_mutex (fun () ->
+      match Hashtbl.find_opt registry keeper_name with
+      | None -> []
+      | Some entry ->
+          Eio.Mutex.use_rw ~protect:true entry.mutex (fun () ->
+              match Queue.take_opt entry.q with
+              | None -> []
+              | Some first ->
+                  let rec drain acc =
+                    match Queue.peek_opt entry.q with
+                    | Some next when same_source first.source next.source ->
+                        let next = Queue.pop entry.q in
+                        drain (next :: acc)
+                    | Some _ | None -> List.rev acc
+                  in
+                  first :: drain []))
+
+let merge_batch batch =
+  match batch with
+  | [] -> None
+  | [ msg ] -> Some msg
+  | first :: _ ->
+      Some
+        {
+          content = String.concat "\n\n" (List.map (fun m -> m.content) batch);
+          attachments = List.concat_map (fun m -> m.attachments) batch;
+          timestamp = first.timestamp;
+          source = first.source;
+        }
+
 let length ~keeper_name =
   Eio.Mutex.use_rw ~protect:true registry_mutex (fun () ->
       match Hashtbl.find_opt registry keeper_name with

--- a/lib/keeper/keeper_chat_queue.mli
+++ b/lib/keeper/keeper_chat_queue.mli
@@ -38,6 +38,26 @@ val enqueue : keeper_name:string -> queued_message -> unit
     [None] if the queue is empty or does not exist. *)
 val dequeue : keeper_name:string -> queued_message option
 
+(** [same_source a b] is true when two messages share a reply route:
+    the dashboard surface, the same Discord channel+user, or the same
+    Slack channel+user. Coalescing across different routes would lose
+    reply routing. *)
+val same_source : message_source -> message_source -> bool
+
+(** [dequeue_batch keeper_name] removes and returns the head run of
+    messages sharing the same source ([same_source]), preserving FIFO
+    order. Stops at the first message with a different source so each
+    coalesced turn answers one reply route. Returns [[]] when the queue
+    is empty or absent. *)
+val dequeue_batch : keeper_name:string -> queued_message list
+
+(** [merge_batch batch] coalesces a same-source batch into one message:
+    contents joined in arrival order with a blank line, attachments
+    concatenated, the first message's timestamp (queueing latency stays
+    measurable), the shared source. [None] on [[]]; a singleton is
+    returned unchanged. *)
+val merge_batch : queued_message list -> queued_message option
+
 (** [length keeper_name] returns the number of queued messages. *)
 val length : keeper_name:string -> int
 

--- a/lib/keeper/keeper_turn_admission.ml
+++ b/lib/keeper/keeper_turn_admission.ml
@@ -116,6 +116,13 @@ let run_serialized ~base_path ~keeper_name f =
     run_locked slot ~lane:Chat f)
 ;;
 
+let in_flight ~base_path ~keeper_name =
+  let key = Keeper_registry_types.registry_key ~base_path keeper_name in
+  match Stdlib.Mutex.protect slots_mu (fun () -> Hashtbl.find_opt slots key) with
+  | None -> None
+  | Some slot -> peek_info slot
+;;
+
 module For_testing = struct
   let reset () = Stdlib.Mutex.protect slots_mu (fun () -> Hashtbl.reset slots)
 

--- a/lib/keeper/keeper_turn_admission.mli
+++ b/lib/keeper/keeper_turn_admission.mli
@@ -65,6 +65,17 @@ val run_serialized
     only by the caller's turn budget — do not call this from within an
     admitted turn of the same keeper. *)
 
+val in_flight
+  :  base_path:string
+  -> keeper_name:string
+  -> in_flight_info option
+(** Read-only snapshot of the turn currently holding the keeper's slot,
+    or [None] when the slot is free or the keeper is unknown. Gating
+    callers (e.g. the chat consumer leaving queued messages to coalesce
+    while a turn runs) tolerate the narrow window where a holder has
+    locked the slot but not yet published its info — a turn forked on a
+    stale [None] simply waits at the slot. *)
+
 module For_testing : sig
   val reset : unit -> unit
   (** Drop every slot. Only safe when no turn is in flight. *)

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -900,6 +900,7 @@ let start_keeper_loops
          handle_turn wires process_single_turn for actual turn execution. *)
       (try
          Keeper_chat_consumer.start ~sw ~clock
+           ~base_path:state.Mcp_server.workspace_config.base_path
            ~handle_turn:(fun ~sw ~keeper_name ~queued_message ->
              let open Server_routes_http_keeper_stream in
              let now = Time_compat.now () in

--- a/test/dune
+++ b/test/dune
@@ -1398,6 +1398,8 @@
 
 (include stanzas/test_keeper_msg_cancel.inc)
 
+(include stanzas/test_keeper_chat_coalescing.inc)
+
 (include stanzas/test_keeper_turn_admission.inc)
 
 (include stanzas/test_keeper_memory_bank_consensus_re_10399.inc)

--- a/test/stanzas/test_keeper_chat_coalescing.inc
+++ b/test/stanzas/test_keeper_chat_coalescing.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_chat_coalescing)
+ (modules test_keeper_chat_coalescing)
+ (libraries masc_test_deps))

--- a/test/test_keeper_chat_coalescing.ml
+++ b/test/test_keeper_chat_coalescing.ml
@@ -1,0 +1,156 @@
+(* test_keeper_chat_coalescing.ml — chat queue coalescing (task-759).
+
+   Messages that accumulate while a keeper's turn is in flight must
+   drain as ONE same-source FIFO batch and merge into a single message;
+   different reply routes (dashboard vs Discord vs Slack, or different
+   channel/user) must never merge. Also covers the read-only
+   [Keeper_turn_admission.in_flight] accessor the consumer gates on. *)
+
+open Masc
+
+let failures = ref 0
+
+let check name cond =
+  if cond
+  then Printf.printf "  ✓ %s\n%!" name
+  else (
+    incr failures;
+    Printf.printf "  ✗ %s\n%!" name)
+;;
+
+let msg ?(attachments = []) ~content ~ts source =
+  { Keeper_chat_queue.content; attachments; timestamp = ts; source }
+;;
+
+let attachment ~id =
+  { Keeper_chat_store.id
+  ; att_type = "file"
+  ; name = id ^ ".txt"
+  ; size = 1
+  ; mime_type = "text/plain"
+  ; data = "d"
+  }
+;;
+
+let contents batch = List.map (fun m -> m.Keeper_chat_queue.content) batch
+
+let test_same_source () =
+  Printf.printf "Test 1: same_source pairs reply routes correctly\n%!";
+  let open Keeper_chat_queue in
+  check "dashboard ~ dashboard" (same_source Dashboard Dashboard);
+  check
+    "same Discord channel+user"
+    (same_source
+       (Discord { channel_id = "c1"; user_id = "u1" })
+       (Discord { channel_id = "c1"; user_id = "u1" }));
+  check
+    "different Discord user does not merge"
+    (not
+       (same_source
+          (Discord { channel_id = "c1"; user_id = "u1" })
+          (Discord { channel_id = "c1"; user_id = "u2" })));
+  check
+    "different Slack channel does not merge"
+    (not
+       (same_source
+          (Slack { channel = "a"; user_id = "u" })
+          (Slack { channel = "b"; user_id = "u" })));
+  check
+    "dashboard does not merge with Discord"
+    (not (same_source Dashboard (Discord { channel_id = "c"; user_id = "u" })))
+;;
+
+let test_dequeue_batch_runs () =
+  Printf.printf "Test 2: dequeue_batch drains same-source runs in FIFO order\n%!";
+  let keeper_name = "coalesce-runs" in
+  Keeper_chat_queue.clear ~keeper_name;
+  let discord = Keeper_chat_queue.Discord { channel_id = "c"; user_id = "u" } in
+  List.iter
+    (Keeper_chat_queue.enqueue ~keeper_name)
+    [ msg ~content:"d1" ~ts:1.0 Keeper_chat_queue.Dashboard
+    ; msg ~content:"d2" ~ts:2.0 Keeper_chat_queue.Dashboard
+    ; msg ~content:"x1" ~ts:3.0 discord
+    ; msg ~content:"d3" ~ts:4.0 Keeper_chat_queue.Dashboard
+    ];
+  let first = Keeper_chat_queue.dequeue_batch ~keeper_name in
+  check "first batch is the dashboard run" (contents first = [ "d1"; "d2" ]);
+  let second = Keeper_chat_queue.dequeue_batch ~keeper_name in
+  check "second batch stops at the route boundary" (contents second = [ "x1" ]);
+  let third = Keeper_chat_queue.dequeue_batch ~keeper_name in
+  check "third batch picks up the trailing dashboard message"
+    (contents third = [ "d3" ]);
+  check "queue is drained" (Keeper_chat_queue.dequeue_batch ~keeper_name = []);
+  check "length is zero after drain" (Keeper_chat_queue.length ~keeper_name = 0)
+;;
+
+let test_merge_batch () =
+  Printf.printf "Test 3: merge_batch coalesces content and attachments\n%!";
+  let single = msg ~content:"only" ~ts:5.0 Keeper_chat_queue.Dashboard in
+  (match Keeper_chat_queue.merge_batch [ single ] with
+   | Some m -> check "singleton is returned unchanged" (m = single)
+   | None -> check "singleton is returned unchanged" false);
+  check "empty batch merges to None" (Keeper_chat_queue.merge_batch [] = None);
+  let batch =
+    [ msg ~content:"first" ~ts:1.0 ~attachments:[ attachment ~id:"a" ]
+        Keeper_chat_queue.Dashboard
+    ; msg ~content:"second" ~ts:2.0 Keeper_chat_queue.Dashboard
+    ; msg ~content:"third" ~ts:3.0 ~attachments:[ attachment ~id:"b" ]
+        Keeper_chat_queue.Dashboard
+    ]
+  in
+  match Keeper_chat_queue.merge_batch batch with
+  | None -> check "merged batch exists" false
+  | Some m ->
+    check
+      "contents join in arrival order with blank lines"
+      (String.equal m.Keeper_chat_queue.content "first\n\nsecond\n\nthird");
+    check
+      "attachments concatenate in order"
+      (List.map (fun a -> a.Keeper_chat_store.id) m.Keeper_chat_queue.attachments
+       = [ "a"; "b" ]);
+    check "timestamp is the first message's" (m.Keeper_chat_queue.timestamp = 1.0);
+    check
+      "source is the shared route"
+      (Keeper_chat_queue.same_source m.Keeper_chat_queue.source
+         Keeper_chat_queue.Dashboard)
+;;
+
+let test_in_flight_accessor () =
+  Printf.printf "Test 4: in_flight reflects the slot the consumer gates on\n%!";
+  Keeper_turn_admission.For_testing.reset ();
+  let base_path = "/tmp/masc_test_chat_coalescing" in
+  let keeper_name = "coalesce-keeper" in
+  check
+    "unknown keeper reads as free"
+    (Keeper_turn_admission.in_flight ~base_path ~keeper_name = None);
+  Eio.Switch.run (fun sw ->
+    let started, set_started = Eio.Promise.create () in
+    let release, set_release = Eio.Promise.create () in
+    Eio.Fiber.fork ~sw (fun () ->
+      ignore
+        (Keeper_turn_admission.run_serialized ~base_path ~keeper_name (fun () ->
+           Eio.Promise.resolve set_started ();
+           Eio.Promise.await release)));
+    Eio.Promise.await started;
+    (match Keeper_turn_admission.in_flight ~base_path ~keeper_name with
+     | Some { Keeper_turn_admission.lane = Chat; _ } ->
+       check "in-flight chat turn is visible" true
+     | Some _ | None -> check "in-flight chat turn is visible" false);
+    Eio.Promise.resolve set_release ());
+  check
+    "slot reads as free again after release"
+    (Keeper_turn_admission.in_flight ~base_path ~keeper_name = None)
+;;
+
+let () =
+  Eio_main.run @@ fun _env ->
+  test_same_source ();
+  test_dequeue_batch_runs ();
+  test_merge_batch ();
+  test_in_flight_accessor ();
+  if !failures > 0
+  then (
+    Printf.printf "FAILED: %d check(s)\n%!" !failures;
+    exit 1)
+  else Printf.printf "All keeper_chat_coalescing checks passed\n%!"
+;;


### PR DESCRIPTION
사용자 요청 (2026-06-11): "큐에 메시지가 쌓이면 틱마다 보낸 만큼 모아서 한 번에 보내져야지, 매번 싱글 턴으로 답하면 맥락이 쪼개진다." MASC task-759.

## 변경 전 / 후

| | 변경 전 | 변경 후 |
|--|---------|---------|
| turn 중 도착한 메시지 N개 | 메시지당 1턴 (N턴, 맥락 분절) | 큐에 누적 → slot이 비면 **1턴으로 병합** |
| consumer 동작 | 틱마다 1개 dequeue → 즉시 fork (admission 대기열에 적체) | busy면 보류, free면 같은 route 연속 run을 일괄 drain |

## 구현

- `Keeper_turn_admission.in_flight`: consumer가 게이팅에 쓰는 read-only slot 스냅샷 (#20739의 For_testing.peek에서 info 절반 승격). 홀더가 lock 후 info 게시 전인 좁은 창에서 stale `None`이 나올 수 있으나, 그 경우 fork된 턴이 slot에서 잠깐 대기할 뿐 — .mli에 문서화.
- `Keeper_chat_queue.same_source` / `dequeue_batch` / `merge_batch`: 배치는 **reply route 경계에서 정지** (dashboard vs Discord/Slack의 channel+user). 다른 route를 합치면 응답이 한쪽 채널로만 라우팅되므로, 병합된 턴은 항상 정확히 하나의 route에 응답합니다. 병합 형식: 도착 순서대로 빈 줄 join, 첨부 concat, timestamp는 첫 메시지(대기 latency 측정 보존), source 공유.
- `Keeper_chat_consumer.start`에 `~base_path` 추가 + busy-gate. 2개 이상 병합 시 info 로그 (`coalesced N queued messages`) — 배포 후 동작 확인 신호.

## 의존성

#20739 (RFC-0225 single-flight) 위에서만 성립 — slot 점유가 관측 가능해야 "busy면 누적, free면 일괄 drain"이 정의됩니다.

## 검증

- `test_keeper_chat_coalescing` 20 checks green: route 페어링(다른 user/channel/표면 비병합), FIFO run 분할(D,D,S,D → [D,D],[S],[D]), 병합 형태(content join/첨부 순서/첫 timestamp), held slot 동안 `in_flight` 가시성.
- 기존 `test_keeper_turn_admission` 12 checks 그대로 green, `test_env_config_keeper_bootstrap_intervals` 9 green.
- `dune build --root . @check` + default target 모두 EXIT=0, 변경 8파일 ocamlformat clean.

## 알려진 트레이드오프

- 병합된 턴의 user_content는 chat history에 한 덩어리로 저장됩니다 (메시지별 행 분리 아님). 모델 입장에서는 사용자가 여러 문단을 한 번에 보낸 것과 동일.
- Dashboard·Discord 메시지가 교차 도착하면 route별로 순차 턴이 됩니다 (병합하지 않는 것이 맞음 — 응답 라우팅 보존).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
