### PR TITLE
feat(keeper): RFC-0223 P3 — keeper_surface_read pull tool with participant roster

### DIFF
--- a/lib/governance_pipeline_risk.ml
+++ b/lib/governance_pipeline_risk.ml
@@ -23,6 +23,7 @@ let capability_classification : (string * capability_class list) list =
     ("keeper_memory_search", [ Sensitive_access ]);
     ("keeper_library_search", [ Sensitive_access ]);
     ("keeper_library_read", [ Sensitive_access ]);
+    ("keeper_surface_read", [ Sensitive_access ]);
     ("tool_edit_file", [ State_modification ]);
     ("tool_write_file", [ State_modification ]);
   ]
@@ -140,7 +141,8 @@ let risk_of_keeper (k : Keeper_tool_name.t) : risk_level =
   | Board_post_get | Board_list | Board_post | Board_search | Board_stats
   | Board_sub_board_get | Board_sub_board_list | Board_vote | Broadcast
   | Context_status | Handoff | Library_read | Library_search | Memory_search
-  | Memory_write | Search_files | Stay_silent | Tasks_audit | Tasks_list | Time_now
+  | Memory_write | Search_files | Stay_silent | Surface_read | Tasks_audit
+  | Tasks_list | Time_now
   | Tool_search | Tools_list | Voice_agent | Voice_listen
   | Voice_session_end | Voice_session_start | Voice_sessions | Voice_speak -> Low
   | Board_sub_board_create | Board_sub_board_update | Task_claim | Task_create | Task_done

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -198,6 +198,7 @@ let tool_search_alias_entries =
   ; "keeper_memory_search", "기억 검색 대화 이전 메시지"
   ; "keeper_library_search", "라이브러리 지식 문서 검색"
   ; "keeper_library_read", "라이브러리 문서 읽기 지식"
+  ; "keeper_surface_read", "커넥터 대화 읽기 디스코드 채널 화자 명부 서피스"
   ; "keeper_time_now", "시간 현재 타임스탬프"
   ; "keeper_context_status", "컨텍스트 상태 토큰 사용량"
   ; "keeper_tools_list", "도구 목록 기능 할수있는것 능력"

--- a/lib/keeper/keeper_surface_read.ml
+++ b/lib/keeper/keeper_surface_read.ml
@@ -1,0 +1,139 @@
+module Store = Keeper_chat_store
+
+type participant = {
+  id : string;
+  name : string option;
+  authority : Store.speaker_authority;
+  first_seen : float option;
+  last_seen : float option;
+  message_count : int;
+}
+
+let default_limit = 20
+let max_limit = 100
+
+let opt_string_field key = function
+  | Some value when String.trim value <> "" -> [ (key, `String value) ]
+  | Some _ | None -> []
+
+let opt_float_field key = function
+  | Some value -> [ (key, `Float value) ]
+  | None -> []
+
+let message_json (m : Store.chat_message) : Yojson.Safe.t =
+  let speaker_fields =
+    match m.speaker with
+    | None -> []
+    | Some sp ->
+        opt_string_field "speaker_id" sp.speaker_id
+        @ opt_string_field "speaker_name" sp.speaker_name
+        @ [
+            ( "speaker_authority",
+              `String (Store.authority_label sp.speaker_authority) );
+          ]
+  in
+  `Assoc
+    ([ ("role", `String m.role); ("content", `String m.content) ]
+    @ opt_float_field "ts" m.ts
+    @ opt_string_field "source" m.source
+    @ opt_string_field "tool_call_name" m.tool_call_name
+    @ speaker_fields)
+
+let participant_json (p : participant) : Yojson.Safe.t =
+  `Assoc
+    ([ ("id", `String p.id) ]
+    @ opt_string_field "name" p.name
+    @ [ ("authority", `String (Store.authority_label p.authority)) ]
+    @ opt_float_field "first_seen" p.first_seen
+    @ opt_float_field "last_seen" p.last_seen
+    @ [ ("message_count", `Int p.message_count) ])
+
+(* Roster fold: one bucket per speaker_id over user lines. The most
+   recent non-empty name wins (people rename; the log remembers, the
+   roster reports the latest). *)
+let roster (lane : Store.chat_message list) : participant list =
+  let tbl : (string, participant) Hashtbl.t = Hashtbl.create 8 in
+  List.iter
+    (fun (m : Store.chat_message) ->
+      match m.speaker with
+      | Some { speaker_id = Some id; speaker_name; speaker_authority } ->
+          let updated =
+            match Hashtbl.find_opt tbl id with
+            | None ->
+                {
+                  id;
+                  name = speaker_name;
+                  authority = speaker_authority;
+                  first_seen = m.ts;
+                  last_seen = m.ts;
+                  message_count = 1;
+                }
+            | Some p ->
+                {
+                  p with
+                  name =
+                    (match speaker_name with
+                    | Some n when String.trim n <> "" -> Some n
+                    | Some _ | None -> p.name);
+                  last_seen = (match m.ts with Some _ -> m.ts | None -> p.last_seen);
+                  first_seen =
+                    (match (p.first_seen, m.ts) with
+                    | None, ts -> ts
+                    | some, _ -> some);
+                  message_count = p.message_count + 1;
+                }
+          in
+          Hashtbl.replace tbl id updated
+      | Some { speaker_id = None; _ } | None -> ())
+    lane;
+  Hashtbl.fold (fun _id p acc -> p :: acc) tbl []
+  |> List.sort (fun a b ->
+         match (b.last_seen, a.last_seen) with
+         | Some tb, Some ta -> compare tb ta
+         | Some _, None -> 1
+         | None, Some _ -> -1
+         | None, None -> compare a.id b.id)
+
+let take_last n items =
+  let len = List.length items in
+  if len <= n then items
+  else
+    let rec drop k = function
+      | rest when k <= 0 -> rest
+      | [] -> []
+      | _ :: rest -> drop (k - 1) rest
+    in
+    drop (len - n) items
+
+let respond ~surface ~limit (messages : Store.chat_message list) : string =
+  let surface = String.trim surface in
+  if surface = "" then
+    Yojson.Safe.to_string
+      (`Assoc
+        [
+          ( "error",
+            `String
+              "surface is required. Good: surface='discord'. The lane label \
+               equals the source shown in Connected Surfaces or chat history."
+          );
+        ])
+  else
+    let limit = min max_limit (max 1 limit) in
+    let lane =
+      List.filter
+        (fun (m : Store.chat_message) ->
+          match m.source with
+          | Some s -> String.equal (String.trim s) surface
+          | None -> false)
+        messages
+    in
+    let shown = take_last limit lane in
+    Yojson.Safe.to_string
+      (`Assoc
+        [
+          ("surface", `String surface);
+          ("messages", `List (List.map message_json shown));
+          ("participants", `List (List.map participant_json (roster lane)));
+          ("lane_row_count", `Int (List.length lane));
+          ("returned", `Int (List.length shown));
+        ])

--- a/lib/keeper/keeper_surface_read.mli
+++ b/lib/keeper/keeper_surface_read.mli
@@ -1,0 +1,42 @@
+(** Keeper_surface_read — pull-based lane context (RFC-0223 P3).
+
+    Pure projection behind the [keeper_surface_read] tool: filter the
+    keeper's chat log to one connector lane and derive the lane's
+    participant roster by folding over the rows. No store of its own —
+    the chat log is the only source, so the roster ages out with log
+    retention (RFC-0223 §5: log-bounded by design, no separate person
+    store, no cursors). *)
+
+(** One person seen on the lane, derived from user lines carrying a
+    [speaker_id] (RFC-0223 P1). Keeper/assistant lines are the
+    keeper's own output and are never participants. *)
+type participant = {
+  id : string;
+  name : string option;  (** Most recent non-empty name observed. *)
+  authority : Keeper_chat_store.speaker_authority;
+  first_seen : float option;
+  last_seen : float option;
+  message_count : int;
+}
+
+val default_limit : int
+val max_limit : int
+
+(** [respond ~surface ~limit messages] filters [messages] to rows whose
+    [source] label equals [surface] (trimmed, exact), returning a JSON
+    object string:
+    [{surface, messages, participants, lane_row_count, returned}].
+
+    - [messages]: the last [limit] lane rows (chronological), each with
+      role/content/ts/source and speaker fields when present — the
+      same field vocabulary as the REST history endpoint.
+    - [participants]: roster folded over ALL loaded lane rows (not just
+      the returned slice), sorted by [last_seen] descending.
+    - Rows without a [source] label (written before source labelling)
+      never match; the description of the tool says so.
+    - Blank [surface] is an error JSON, not a default lane. *)
+val respond :
+  surface:string ->
+  limit:int ->
+  Keeper_chat_store.chat_message list ->
+  string

--- a/lib/keeper/keeper_tool_alias.ml
+++ b/lib/keeper/keeper_tool_alias.ml
@@ -75,6 +75,7 @@ let is_masc_mcp_descriptor (d : Keeper_tool_descriptor.t) =
   | Tool_memory_write
   | Tool_library_search
   | Tool_library_read
+  | Tool_surface_read
   | Tool_ide_annotate
   | Tool_voice_dispatch
   | Tool_task_dispatch

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -39,6 +39,7 @@ type runtime_handler =
   | Tool_memory_write
   | Tool_library_search
   | Tool_library_read
+  | Tool_surface_read
   | Tool_ide_annotate
   | Tool_voice_dispatch
   | Tool_task_dispatch
@@ -124,6 +125,7 @@ let runtime_handler_to_string = function
   | Tool_memory_write -> "tool_memory_write"
   | Tool_library_search -> "tool_library_search"
   | Tool_library_read -> "tool_library_read"
+  | Tool_surface_read -> "tool_surface_read"
   | Tool_ide_annotate -> "tool_ide_annotate"
   | Tool_voice_dispatch -> "tool_voice_dispatch"
   | Tool_task_dispatch -> "tool_task_dispatch"
@@ -655,6 +657,24 @@ let library_read_schema =
     ]
 ;;
 
+let surface_read_schema =
+  object_schema
+    ~required:[ "surface" ]
+    [ property
+        "surface"
+        "string"
+        "Lane label exactly as shown in Connected Surfaces or chat history \
+         source: 'dashboard', 'discord', 'slack', or another connector's \
+         channel label. Rows written before source labelling carry no label \
+         and are not returned."
+    ; property
+        "limit"
+        "integer"
+        "Maximum lane messages to return (default 20, max 100). The \
+         participant roster always covers the whole loaded lane."
+    ]
+;;
+
 let read_only_in_process_policy ?(inline_safe = false) ?(maintenance_only = false)
       ()
   =
@@ -986,6 +1006,18 @@ let internal_descriptors : t list =
       ~input_schema:library_read_schema
       ~policy:(read_only_in_process_policy ())
       ~handler:Tool_library_read
+    (* ── connector surfaces (RFC-0223 P3) ─────────────────────── *)
+  ; in_process_descriptor
+      ~id:"keeper.surface.read"
+      ~name:"keeper_surface_read"
+      ~description:
+        "Read recent conversation from one connected surface lane (dashboard, \
+         discord, slack, or another connector label) with speaker identity \
+         and a derived participant roster. Use after Connected Surfaces \
+         shows a lane you want context from."
+      ~input_schema:surface_read_schema
+      ~policy:(read_only_in_process_policy ())
+      ~handler:Tool_surface_read
     (* ── IDE (RFC-0179 PR-3) ──────────────────────────────────── *)
   ; in_process_descriptor
       ~id:"keeper.ide.annotate"

--- a/lib/keeper/keeper_tool_descriptor.mli
+++ b/lib/keeper/keeper_tool_descriptor.mli
@@ -44,6 +44,7 @@ type runtime_handler =
   | Tool_memory_write
   | Tool_library_search
   | Tool_library_read
+  | Tool_surface_read
   | Tool_ide_annotate
   | Tool_voice_dispatch
   | Tool_task_dispatch

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -85,6 +85,19 @@ let handle_library_read ~(meta : keeper_meta) ~args =
       (`Assoc [ "error", `String (Tool_result.message result) ])
 ;;
 
+let handle_surface_read ~config ~(meta : keeper_meta) ~args =
+  let surface = Safe_ops.json_string ~default:"" "surface" args in
+  let limit =
+    Safe_ops.json_int ~default:Keeper_surface_read.default_limit "limit" args
+  in
+  let messages =
+    Keeper_chat_store.load
+      ~base_dir:config.Workspace.base_path
+      ~keeper_name:meta.name
+  in
+  Keeper_surface_read.respond ~surface ~limit messages
+;;
+
 let handle_ide_annotate ~config ~(meta : keeper_meta) ~args =
   Keeper_tool_ide_runtime.handle_ide_annotate
     ~config

--- a/lib/keeper/keeper_tool_in_process_runtime.mli
+++ b/lib/keeper/keeper_tool_in_process_runtime.mli
@@ -48,6 +48,12 @@ val handle_memory_write
 val handle_library_search : meta:keeper_meta -> args:Yojson.Safe.t -> string
 val handle_library_read : meta:keeper_meta -> args:Yojson.Safe.t -> string
 
+val handle_surface_read
+  :  config:Workspace.config
+  -> meta:keeper_meta
+  -> args:Yojson.Safe.t
+  -> string
+
 val handle_ide_annotate
   :  config:Workspace.config
   -> meta:keeper_meta

--- a/lib/keeper/keeper_tool_runtime.ml
+++ b/lib/keeper/keeper_tool_runtime.ml
@@ -57,6 +57,7 @@ let handle_filesystem ctx descriptor args =
   | Tool_memory_write
   | Tool_library_search
   | Tool_library_read
+  | Tool_surface_read
   | Tool_ide_annotate
   | Tool_voice_dispatch
   | Tool_task_dispatch
@@ -108,6 +109,7 @@ let handle_shell_ir ctx descriptor args =
   | Tool_memory_write
   | Tool_library_search
   | Tool_library_read
+  | Tool_surface_read
   | Tool_ide_annotate
   | Tool_voice_dispatch
   | Tool_task_dispatch
@@ -165,6 +167,12 @@ let handle_in_process ctx descriptor args =
   | Tool_library_read ->
     Some
       (Keeper_tool_in_process_runtime.handle_library_read ~meta:ctx.meta ~args)
+  | Tool_surface_read ->
+    Some
+      (Keeper_tool_in_process_runtime.handle_surface_read
+         ~config:ctx.config
+         ~meta:ctx.meta
+         ~args)
   | Tool_ide_annotate ->
     Some
       (Keeper_tool_in_process_runtime.handle_ide_annotate

--- a/lib/keeper_tooling/keeper_tool_name.ml
+++ b/lib/keeper_tooling/keeper_tool_name.ml
@@ -37,6 +37,7 @@ type t =
   | Memory_write
   | Search_files
   | Stay_silent
+  | Surface_read
   | Task_claim
   | Task_create
   | Task_done
@@ -84,6 +85,7 @@ let to_string = function
   | Memory_write -> "keeper_memory_write"
   | Search_files -> "tool_search_files"
   | Stay_silent -> "keeper_stay_silent"
+  | Surface_read -> "keeper_surface_read"
   | Task_claim -> "keeper_task_claim"
   | Task_create -> "keeper_task_create"
   | Task_done -> "keeper_task_done"
@@ -132,6 +134,7 @@ let of_string = function
   | "keeper_memory_write" -> Some Memory_write
   | "tool_search_files" -> Some Search_files
   | "keeper_stay_silent" -> Some Stay_silent
+  | "keeper_surface_read" -> Some Surface_read
   | "keeper_task_claim" -> Some Task_claim
   | "keeper_task_create" -> Some Task_create
   | "keeper_task_done" -> Some Task_done
@@ -197,6 +200,7 @@ let is_keeper_board_tool = function
   | Memory_write
   | Search_files
   | Stay_silent
+  | Surface_read
   | Task_claim
   | Task_create
   | Task_done

--- a/lib/keeper_tooling/keeper_tool_name.mli
+++ b/lib/keeper_tooling/keeper_tool_name.mli
@@ -35,6 +35,7 @@ type t =
   | Memory_write
   | Search_files
   | Stay_silent
+  | Surface_read
   | Task_claim
   | Task_create
   | Task_done

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -114,6 +114,17 @@ let shard_library : shard =
   }
 ;;
 
+(* RFC-0223 P3: connector surface lane reading. keeper_surface_post
+   (P4) joins this shard when it ships. *)
+let shard_surface : shard =
+  { name = "surface"
+  ; tools = surface_tools
+  ; read_only_tools = [ "keeper_surface_read" ]
+  ; removable = true
+  ; description = "Connected surfaces: read lane conversation, roster"
+  }
+;;
+
 let shard_taskboard : shard =
   { name = "taskboard"
   ; tools = taskboard_tools
@@ -168,6 +179,7 @@ let all_shards : shard StringMap.t =
     ; shard_search_files
     ; shard_voice
     ; shard_library
+    ; shard_surface
     ; shard_taskboard
     ]
 ;;

--- a/lib/tool_surface/dune
+++ b/lib/tool_surface/dune
@@ -23,6 +23,7 @@
   tool_shard_types_schemas_execute
   tool_shard_types_schemas_filesystem
   tool_shard_types_schemas_library
+  tool_shard_types_schemas_surface
   tool_shard_types_schemas_search_files
   tool_shard_types_schemas_taskboard
   tool_shard_types_schemas_voice)

--- a/lib/tool_surface/tool_prefilter.ml
+++ b/lib/tool_surface/tool_prefilter.ml
@@ -215,6 +215,14 @@ let synonyms : (string * string list) list =
       ; "full document"
       ; "knowledge article"
       ] )
+  ; ( "keeper_surface_read"
+    , [ "discord messages"
+      ; "channel conversation"
+      ; "surface lane"
+      ; "who said"
+      ; "participants roster"
+      ; "connected surface"
+      ] )
   ; ( "keeper_tools_list"
     , [ "what can you do"
       ; "capabilities"

--- a/lib/tool_surface/tool_shard_types.ml
+++ b/lib/tool_surface/tool_shard_types.ml
@@ -15,4 +15,5 @@ include Tool_shard_types_schemas_search_files
 include Tool_shard_types_schemas_execute
 include Tool_shard_types_schemas_voice
 include Tool_shard_types_schemas_library
+include Tool_shard_types_schemas_surface
 include Tool_shard_types_schemas_taskboard

--- a/lib/tool_surface/tool_shard_types.mli
+++ b/lib/tool_surface/tool_shard_types.mli
@@ -74,6 +74,9 @@ val voice_tools : Masc_domain.tool_schema list
 (** Voice tool schemas. *)
 
 val library_tools : Masc_domain.tool_schema list
+
+val surface_tools : Masc_domain.tool_schema list
+(** keeper_surface_read lane reading (RFC-0223 P3). *)
 (** Library tool schemas. *)
 
 val taskboard_tools : Masc_domain.tool_schema list

--- a/lib/tool_surface/tool_shard_types_core.ml
+++ b/lib/tool_surface/tool_shard_types_core.ml
@@ -28,7 +28,8 @@ let select_named_schemas (names : string list) (schemas : Masc_domain.tool_schem
 ;;
 
 let default_shard_names : string list =
-  [ "base"; "board"; "filesystem"; "search_files"; "library"; "taskboard" ]
+  [ "base"; "board"; "filesystem"; "search_files"; "library"; "surface"
+  ; "taskboard" ]
 ;;
 
 let tool_spec_read_only = []

--- a/lib/tool_surface/tool_shard_types_schemas_surface.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_surface.ml
@@ -1,0 +1,38 @@
+(** Tool_shard_types_schemas_surface — keeper_surface_* tool schemas
+    (RFC-0223 P3). *)
+
+let surface_tools : Masc_domain.tool_schema list =
+  [ { name = "keeper_surface_read"
+    ; description =
+        "Read recent conversation from one connected surface lane (dashboard, \
+         discord, slack, or another connector label) with speaker identity \
+         and a derived participant roster. Use after Connected Surfaces \
+         shows a lane you want context from."
+    ; input_schema =
+        `Assoc
+          [ "type", `String "object"
+          ; ( "properties"
+            , `Assoc
+                [ ( "surface"
+                  , `Assoc
+                      [ "type", `String "string"
+                      ; ( "description"
+                        , `String
+                            "Lane label exactly as shown in Connected \
+                             Surfaces or chat history source: 'dashboard', \
+                             'discord', 'slack', or another connector's \
+                             channel label" )
+                      ] )
+                ; ( "limit"
+                  , `Assoc
+                      [ "type", `String "integer"
+                      ; ( "description"
+                        , `String
+                            "Maximum lane messages to return (default 20, \
+                             max 100)" )
+                      ] )
+                ] )
+          ; "required", `List [ `String "surface" ]
+          ]
+    }
+  ]

--- a/test/dune
+++ b/test/dune
@@ -180,6 +180,7 @@
   test_keeper_unified_idle_cooldown
   test_keeper_unified_inline_skip
   test_keeper_unified_metacognition
+  test_keeper_surface_read
   test_keeper_surface_presence_prompt
   test_keeper_unified_verification_surface
   test_keeper_fsm_guard_actions
@@ -441,6 +442,7 @@
   test_keeper_unified_idle_cooldown
   test_keeper_unified_inline_skip
   test_keeper_unified_metacognition
+  test_keeper_surface_read
   test_keeper_surface_presence_prompt
   test_keeper_unified_verification_surface
   test_keeper_fsm_guard_actions

--- a/test/test_keeper_surface_read.ml
+++ b/test/test_keeper_surface_read.ml
@@ -1,0 +1,148 @@
+(* RFC-0223 P3 — Keeper_surface_read lane filter + roster fold.
+
+   Pure-module tests: chat_message fixtures in, JSON out. The store
+   I/O path (Keeper_chat_store.load) is covered by
+   test_keeper_chat_store; the tool dispatch path by
+   test_keeper_tool_matrix_cases. *)
+
+open Alcotest
+
+module Store = Masc.Keeper_chat_store
+module SR = Masc.Keeper_surface_read
+
+let msg ?ts ?source ?speaker ~role content : Store.chat_message =
+  {
+    role;
+    content;
+    ts;
+    attachments = None;
+    tool_call_id = None;
+    tool_call_name = None;
+    source;
+    speaker;
+  }
+
+let external_speaker ?name id : Store.speaker =
+  { speaker_id = Some id; speaker_name = name; speaker_authority = Store.External }
+
+let parse s = Yojson.Safe.from_string s
+
+let member key json = Yojson.Safe.Util.member key json
+
+let to_list json = Yojson.Safe.Util.to_list json
+
+let to_int json = Yojson.Safe.Util.to_int json
+
+let to_string_j json = Yojson.Safe.Util.to_string json
+
+let discord_fixture : Store.chat_message list =
+  [
+    msg ~ts:1.0 ~source:"dashboard" ~role:"user" "hello from owner";
+    msg ~ts:2.0 ~source:"discord"
+      ~speaker:(external_speaker ~name:"minsu_old" "98791450001")
+      ~role:"user" "first discord message";
+    msg ~ts:2.5 ~source:"discord" ~role:"assistant" "keeper reply";
+    msg ~ts:3.0 ~source:"discord"
+      ~speaker:(external_speaker ~name:"Minsu" "98791450001")
+      ~role:"user" "second discord message";
+    msg ~ts:4.0 ~source:"discord"
+      ~speaker:(external_speaker "55500001111")
+      ~role:"user" "drive-by, no display name";
+    msg ~role:"user" "legacy row without source";
+  ]
+
+let test_lane_filter_excludes_other_sources_and_legacy () =
+  let json = parse (SR.respond ~surface:"discord" ~limit:50 discord_fixture) in
+  check int "lane rows" 4 (to_int (member "lane_row_count" json));
+  check int "returned" 4 (to_int (member "returned" json));
+  let contents =
+    to_list (member "messages" json)
+    |> List.map (fun m -> to_string_j (member "content" m))
+  in
+  check (list string) "chronological lane contents"
+    [
+      "first discord message";
+      "keeper reply";
+      "second discord message";
+      "drive-by, no display name";
+    ]
+    contents
+
+let test_roster_groups_by_id_latest_name_wins () =
+  let json = parse (SR.respond ~surface:"discord" ~limit:50 discord_fixture) in
+  let participants = to_list (member "participants" json) in
+  check int "two participants" 2 (List.length participants);
+  let find id =
+    List.find
+      (fun p -> String.equal (to_string_j (member "id" p)) id)
+      participants
+  in
+  let minsu = find "98791450001" in
+  check string "latest name wins" "Minsu" (to_string_j (member "name" minsu));
+  check int "message_count" 2 (to_int (member "message_count" minsu));
+  check (float 0.001) "first_seen" 2.0
+    (Yojson.Safe.Util.to_number (member "first_seen" minsu));
+  check (float 0.001) "last_seen" 3.0
+    (Yojson.Safe.Util.to_number (member "last_seen" minsu));
+  let driveby = find "55500001111" in
+  check bool "no name field when never given" true
+    (member "name" driveby = `Null);
+  (* Sorted by last_seen descending: the drive-by (4.0) outranks Minsu (3.0). *)
+  check string "roster order: most recent first" "55500001111"
+    (to_string_j (member "id" (List.hd participants)))
+
+let test_limit_truncates_messages_not_roster () =
+  let json = parse (SR.respond ~surface:"discord" ~limit:2 discord_fixture) in
+  check int "returned capped" 2 (to_int (member "returned" json));
+  check int "lane count still full" 4 (to_int (member "lane_row_count" json));
+  check int "roster still full" 2
+    (List.length (to_list (member "participants" json)));
+  let contents =
+    to_list (member "messages" json)
+    |> List.map (fun m -> to_string_j (member "content" m))
+  in
+  check (list string) "last two rows kept"
+    [ "second discord message"; "drive-by, no display name" ]
+    contents
+
+let test_keeper_own_lines_are_not_participants () =
+  let json = parse (SR.respond ~surface:"discord" ~limit:50 discord_fixture) in
+  let ids =
+    to_list (member "participants" json)
+    |> List.map (fun p -> to_string_j (member "id" p))
+  in
+  check bool "assistant line contributed no participant" false
+    (List.exists (fun id -> String.equal id "keeper") ids)
+
+let test_blank_surface_is_error () =
+  let json = parse (SR.respond ~surface:"  " ~limit:10 discord_fixture) in
+  check bool "error field present" true (member "error" json <> `Null)
+
+let test_empty_lane_is_success_with_zero_rows () =
+  let json = parse (SR.respond ~surface:"slack" ~limit:10 discord_fixture) in
+  check int "lane empty" 0 (to_int (member "lane_row_count" json));
+  check int "no participants" 0
+    (List.length (to_list (member "participants" json)))
+
+let () =
+  run "keeper_surface_read"
+    [
+      ( "lane filter",
+        [
+          test_case "excludes other sources and legacy rows" `Quick
+            test_lane_filter_excludes_other_sources_and_legacy;
+          test_case "limit truncates messages, not roster" `Quick
+            test_limit_truncates_messages_not_roster;
+          test_case "blank surface is an error" `Quick
+            test_blank_surface_is_error;
+          test_case "empty lane is success with zero rows" `Quick
+            test_empty_lane_is_success_with_zero_rows;
+        ] );
+      ( "roster",
+        [
+          test_case "groups by id, latest name wins" `Quick
+            test_roster_groups_by_id_latest_name_wins;
+          test_case "keeper's own lines are not participants" `Quick
+            test_keeper_own_lines_are_not_participants;
+        ] );
+    ]

--- a/test/test_keeper_tool_matrix_cases.ml
+++ b/test/test_keeper_tool_matrix_cases.ml
@@ -334,6 +334,7 @@ let keeper_arguments fixture (schema : Masc_domain.tool_schema) =
       `Assoc [ ("query", `String "tool matrix") ]
   | "keeper_library_read" ->
       `Assoc [ ("topic", `String (Generic.ensure_library_topic fixture.generic)) ]
+  | "keeper_surface_read" -> `Assoc [ ("surface", `String "dashboard") ]
   | "keeper_tasks_list" -> `Assoc [ ("include_done", `Bool true) ]
   | "keeper_task_force_release" ->
       `Assoc

--- a/test/test_keeper_tool_resolution.ml
+++ b/test/test_keeper_tool_resolution.ml
@@ -165,6 +165,7 @@ let policy_tool_names =
       "keeper_broadcast";
       "keeper_context_status";
       "keeper_library_read";
+      "keeper_surface_read";
       "keeper_library_search";
       "keeper_memory_search";
       "keeper_memory_write";


### PR DESCRIPTION
## 무엇

RFC-0223 P3 — `keeper_surface_read` 도구. keeper가 연결된 surface lane(dashboard/discord/slack/게이트 채널) 하나의 최근 대화를 **필요할 때 당겨서** 봅니다. speaker 신원(P1 데이터)과 파생 참여자 명부(roster) 포함.

RFC: `docs/rfc/RFC-0223-typed-connector-surfaces-presence-pull-speaker.md` §4 P3
(P1 = #20726, P2 = #20738, 둘 다 머지됨)

## 설계 원칙 (RFC §2)

- **Pull, not push**: lane 내용은 world prompt에 절대 들어가지 않음 — presence(P2)가 lane 존재를 알리고, 내용은 이 도구로만. R4(raw history 재주입 38:1)의 반례 패턴.
- **상태 없음** (§2 원칙 6): roster는 저장소가 아니라 **lane 행들의 fold**. 로그 보존주기와 함께 자연 소멸 — "아는사람 명부"의 LRU는 공짜로 얻음 (RFC §5). 커서/캐시/별도 person store 없음.
- **결정론**: 같은 로그 → 같은 응답. `mode: digest`는 RFC대로 예약만 (요약은 하네스 필요, 별도 RFC).

## 응답 형태

```json
{
  "surface": "discord",
  "messages": [ { role, content, ts, source, speaker_id, speaker_name, speaker_authority } ],
  "participants": [ { id, name, authority, first_seen, last_seen, message_count } ],
  "lane_row_count": 4, "returned": 2
}
```

- `messages`: lane 마지막 `limit`개 (기본 20, 최대 100), 시간순
- `participants`: **로드된 lane 전체** fold (limit 무관), last_seen 내림차순, 최신 non-empty 이름 우선
- source 라벨 없는 legacy 행은 매칭 안 됨 (도구 설명에 명시) — 추측 매핑 없음
- keeper 자신의 assistant/tool 행은 participant가 아님

## 등록 표면 (#20060 3-시스템 + 1)

| 시스템 | 등록 |
|---|---|
| policy candidate | descriptor + shard 양쪽에서 자동 (`keeper_base_candidate_tool_names`) |
| `raw_all_tool_schemas` | descriptor 스키마 자동 (`descriptor_owned_internal_tool_schemas`) + shard 스키마 (dedupe) |
| discovery | shard `surface` + BM25 prefilter + 한국어 키워드 (`keeper_agent_tool_surface`) |
| **`default_shard_names`** | **4번째 관문 발견**: shard를 만들어도 이 목록에 없으면 `keeper_model_tools`(universe 스키마 조립)에서 빠져 dispatch가 "unknown tool" — end-to-end 매트릭스 러너가 잡아줌 |

`Keeper_tool_name` closed enum + `runtime_handler` variant라 컴파일러가 risk 분류(`governance_pipeline_risk`), alias, dispatch 3사이트를 전부 강제했습니다.

## 검증

- `@check` + default EXIT=0, fmt clean, DET/NDT PASS, SSOT ERROR 0
- 신규 `test_keeper_surface_read` 6/6 (pure 모듈: lane 필터/legacy 제외/limit-roster 분리/latest-name-wins/keeper 제외/빈 lane)
- **end-to-end**: `keeper_tool_matrix_case_runner.exe keeper_surface_read` → `ok:true` (수정 전 "unknown keeper tool" 재현 → default_shard_names 수정 → green)
- 회귀: tool_input_validation 70, chat_store 9, gate_surface 8 — green. `test_keeper_tool_resolution` 4건 실패는 main 동일(pre-existing: keeper_report_state/keeper_board_get/masc_agents — 실패 집합 diff로 IDENTICAL 확인)

## 후속 (범위 밖)

- P4 `keeper_surface_post` (정책 게이트 액션; shard `surface`에 합류 예정)
- 매트릭스 fixture에 chat 행 시딩해 비어있지 않은 lane의 e2e 검증 추가 고려

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
