### PR TITLE
feat(board): add exclude_author parameter to masc_board_list

### DIFF
--- a/lib/board/board_dispatch.ml
+++ b/lib/board/board_dispatch.ml
@@ -387,10 +387,12 @@ let get_post ~post_id =
   match backend () with
   | Jsonl store -> Board.get_post store ~post_id
 
-let list_posts ?(visibility_filter = None) ?hearth ?author_filter ?post_kind_filter
+let list_posts ?(visibility_filter = None) ?hearth ?author_filter ?exclude_author_filter
+    ?post_kind_filter
     ?(sort_by = Hot) ?(exclude_system = false) ?(exclude_automation = false)
     ?(limit = 50) () =
   let author_filter = normalize_author_filter author_filter in
+  let exclude_author_filter = normalize_author_filter exclude_author_filter in
   let apply_visibility_and_hearth_filters posts =
     let posts =
       match visibility_filter with
@@ -418,6 +420,7 @@ let list_posts ?(visibility_filter = None) ?hearth ?author_filter ?post_kind_fil
   | Jsonl store ->
       let needs_full_scan =
         Option.is_some author_filter
+        || Option.is_some exclude_author_filter
         ||
         match sort_by with
         | Hot -> false
@@ -451,6 +454,19 @@ let list_posts ?(visibility_filter = None) ?hearth ?author_filter ?post_kind_fil
                 agent_matches_author_filter ~needle post.author
                 || Hashtbl.mem matching_comment_post_ids
                      (Board.Post_id.to_string post.id))
+              filtered
+      in
+      (* Exclude posts by author (post author only, not comment author).
+         Unlike the positive author_filter which matches comment authors too,
+         exclusion is post-author-only: hiding agent X should not remove
+         agent Y's post just because X commented on it. *)
+      let filtered =
+        match exclude_author_filter with
+        | None -> filtered
+        | Some needle ->
+            List.filter
+              (fun (post : Board.post) ->
+                not (agent_matches_author_filter ~needle post.author))
               filtered
       in
       Board.take limit filtered

--- a/lib/board/board_dispatch.mli
+++ b/lib/board/board_dispatch.mli
@@ -148,6 +148,7 @@ val list_posts :
   ?visibility_filter:Board.visibility option ->
   ?hearth:string ->
   ?author_filter:string ->
+  ?exclude_author_filter:string ->
   ?post_kind_filter:Board.post_kind ->
   ?sort_by:sort_order ->
   ?exclude_system:bool ->

--- a/lib/board_tool_adapter/board_tool_post.ml
+++ b/lib/board_tool_adapter/board_tool_post.ml
@@ -188,6 +188,13 @@ let handle_post_list_uncached ~tool_name ~start_time args : Tool_result.result =
       if String.equal s "" then None else Some s
     | None -> None
   in
+  let exclude_author_filter =
+    match get_string_opt args "exclude_author" with
+    | Some s ->
+      let s = String.trim s in
+      if String.equal s "" then None else Some s
+    | None -> None
+  in
   let since = get_float_opt args "since" in
   let visibility_filter =
     match visibility_str with
@@ -215,6 +222,7 @@ let handle_post_list_uncached ~tool_name ~start_time args : Tool_result.result =
         ~visibility_filter
         ?hearth
         ?author_filter
+        ?exclude_author_filter
         ~exclude_system
         ~exclude_automation
         ~sort_by

--- a/lib/board_tool_adapter/board_tool_schemas.ml
+++ b/lib/board_tool_adapter/board_tool_schemas.ml
@@ -226,6 +226,16 @@ let tool_post_list : Masc_domain.tool_schema =
                           "Filter posts by author name (case-insensitive substring match)"
                       )
                     ] )
+              ; ( "exclude_author"
+                , `Assoc
+                    [ "type", `String "string"
+                    ; "maxLength", `Int 100
+                    ; ( "description"
+                      , `String
+                          "Exclude posts by author name (case-insensitive substring match). \
+                           Pass your own agent name to avoid self-referential loops."
+                      )
+                    ] )
               ; ( "since"
                 , `Assoc
                     [ "type", `String "number"

--- a/lib/tool_surface/tool_shard_types_schemas_board.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_board.ml
@@ -185,6 +185,16 @@ let board_tools : Masc_domain.tool_schema list =
                             "Compact one-line per post. Set false for full \
                              body/TTL/visibility" )
                       ] )
+                ; ( "exclude_author"
+                  , `Assoc
+                      [ "type", `String "string"
+                      ; "maxLength", `Int 100
+                      ; ( "description"
+                        , `String
+                            "Exclude posts by author name (case-insensitive substring \
+                             match). Pass your own keeper name to avoid self-referential \
+                             loops when reading the board." )
+                      ] )
                 ] )
           ; "additionalProperties", `Bool false
           ]


### PR DESCRIPTION
## Summary

Adds `exclude_author` filter parameter to `masc_board_list` and `keeper_board_list` tools, allowing agents to exclude posts by a specific author from query results.

## Problem

Keeper agents reading the board via `masc_board_list` see ALL posts including their own, creating a self-referential feedback loop:
1. Keeper posts analysis of task-X
2. Next turn, keeper calls `masc_board_list`, sees its own post
3. Keeper reacts to its own post, posts more analysis
4. User instructions get buried in this self-referential noise

The observation layer (`keeper_world_observation.ml:242`) and board signal matching (`keeper_world_observation_board_signal.ml:117`) already filter self-authored posts via `is_self_author`, but the **explicit tool call path** did not.

## Changes

| File | Change |
|------|--------|
| `lib/board/board_dispatch.ml` | Add `?exclude_author_filter` param, normalize, include in `needs_full_scan`, apply post-author-only exclusion after positive `author_filter` |
| `lib/board/board_dispatch.mli` | Update `list_posts` interface signature |
| `lib/board_tool_adapter/board_tool_post.ml` | Parse `exclude_author` from tool args, pass to dispatch |
| `lib/board_tool_adapter/board_tool_schemas.ml` | Add `exclude_author` string property to MCP schema |
| `lib/tool_surface/tool_shard_types_schemas_board.ml` | Add `exclude_author` to keeper surface schema |

## Design Decisions

- **Post-author-only exclusion**: Unlike the positive `author_filter` which also matches comment authors, `exclude_author` only checks post authors. Rationale: if agent X commented on agent Y's post, excluding X should not hide Y's post.
- **Same matching as `author`**: Uses the same case-insensitive substring matching via `agent_matches_author_filter`.
- **Backward compatible**: Optional parameter, defaults to None (no exclusion).
- **Cache-safe**: `board_list_cache_key` serializes full args JSON, so `exclude_author` is automatically part of the cache key.

## Verification

```bash
cd .worktrees/fix/board-exclude-author
dune build --root .  # PASS (0 errors)
```

## Related

- Closes: #20746
- MASC: task-755

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
