### PR TITLE
fix(docs): repair main Meta Guards — restore 5 doc-truth anchors dropped by README rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ MASC는 동일한 Keeper에 대해 **단 하나의 Active Turn만 허용**하는
 *   `lib/gate/`: Surface 모듈화 및 외부 어댑터 프로토콜 추상화.
 *   `lib/runtime/`: TOML 스키마 파싱 및 단일 프로바이더 정책 수렴.
 *   `lib/dashboard/` + `dashboard/` (TS): 뷰어 및 웹 모니터링 컨트롤 패널.
+    주요 진입점: Monitoring `dashboard#monitoring?section=journey` ·
+    Ops `dashboard#command?section=operations` ·
+    Connectors `dashboard#connectors?section=connector-status` ·
+    Workspace `dashboard#workspace?section=verification`.
 *   `lib/ide/`: Multi-keeper 커서, region tracker, LSP 프록시 브리지.
 
 ### 5.2 Key Document Map
@@ -122,6 +126,7 @@ MASC는 동일한 Keeper에 대해 **단 하나의 Active Turn만 허용**하는
 *   **[docs/rfc/RFC-0223-*.md](docs/rfc/RFC-0223-typed-connector-surfaces-presence-pull-speaker.md):** 다중 Surface presence 및 Lane Context 풀(pull) 설계서.
 *   **[docs/rfc/RFC-0225-*.md](docs/rfc/RFC-0225-per-keeper-turn-single-flight.md):** Single-flight turn admission 및 직렬 큐잉 사양.
 *   **[docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md](docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md):** 관리 패널 인증 런북.
+*   **[docs/RELEASE-EVIDENCE.md](docs/RELEASE-EVIDENCE.md):** 릴리즈 smoke + proof bundle 증적 절차 (`make release-evidence`).
 
 ---
 


### PR DESCRIPTION
## 무엇

main의 Meta Guards(`Check doc truth`)가 #20744 이후 깨진 것을 복구합니다. Meta Guards를 실제로 실행하는 모든 PR이 merge-ref에서 본인 변경과 무관하게 red가 됩니다 (#20750에서 발견 — 재실행으로도 동일 실패, transient 아님 확인).

## 원인

#20744(README 전면 재작성, README-only)가 `scripts/check-doc-truth.sh`가 요구하는 앵커 5개를 제거:

- `docs/RELEASE-EVIDENCE.md` 링크 (script:102)
- dashboard deep link 4종 `#monitoring?section=journey` / `#command?section=operations` / `#connectors?section=connector-status` / `#workspace?section=verification` (script:104-107)

docs-only PR이라 `Detect Changed Surfaces` 게이트가 Meta Guards를 스킵한 채 머지 — **R6 ratchet 사고(#20728/#20733)와 동일한 gate-skip broken-main 패턴, 24시간 내 3번째.**

## 변경

새 README 구조를 유지하면서 앵커만 복원:
- §5.2 Key Document Map에 `docs/RELEASE-EVIDENCE.md` 행 추가 (문서는 main에 존재하며 doc index에서도 canonical 요구)
- §5.1의 dashboard 항목 아래 deep link 4종 한 줄 추가

## 검증

- `bash scripts/check-doc-truth.sh` → `Doc truth OK` + `code_refs OK` (EXIT=0)
- 수정 전 동일 트리에서 5개 앵커 누락 전수 재현 (require_contains 루프 대조)

## 후속 (별도)

docs-only PR이 doc-truth 앵커를 깨뜨릴 수 있으므로 `Detect Changed Surfaces`가 `README.md`/`docs/` 변경 시 `Check doc truth` 스텝은 실행하도록 조정 필요 — R6 때와 같은 구조 결함. 이슈로 기록 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
