### PR TITLE
feat(keeper): RFC-0223 P4 — keeper_surface_post act tool (dashboard + discord)

### DIFF
--- a/lib/governance_pipeline_risk.ml
+++ b/lib/governance_pipeline_risk.ml
@@ -24,6 +24,7 @@ let capability_classification : (string * capability_class list) list =
     ("keeper_library_search", [ Sensitive_access ]);
     ("keeper_library_read", [ Sensitive_access ]);
     ("keeper_surface_read", [ Sensitive_access ]);
+    ("keeper_surface_post", [ State_modification ]);
     ("tool_edit_file", [ State_modification ]);
     ("tool_write_file", [ State_modification ]);
   ]
@@ -146,6 +147,7 @@ let risk_of_keeper (k : Keeper_tool_name.t) : risk_level =
   | Tool_search | Tools_list | Voice_agent | Voice_listen
   | Voice_session_end | Voice_session_start | Voice_sessions | Voice_speak -> Low
   | Board_sub_board_create | Board_sub_board_update | Task_claim | Task_create | Task_done
+  | Surface_post
     -> Medium
   | Fs_edit | Fs_write | Fs_read | Ide_annotate -> High
   | Board_sub_board_delete | Task_force_done | Task_force_release -> Critical

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -199,6 +199,7 @@ let tool_search_alias_entries =
   ; "keeper_library_search", "라이브러리 지식 문서 검색"
   ; "keeper_library_read", "라이브러리 문서 읽기 지식"
   ; "keeper_surface_read", "커넥터 대화 읽기 디스코드 채널 화자 명부 서피스"
+  ; "keeper_surface_post", "커넥터 발화 보내기 디스코드 채널 메시지 전송 서피스"
   ; "keeper_time_now", "시간 현재 타임스탬프"
   ; "keeper_context_status", "컨텍스트 상태 토큰 사용량"
   ; "keeper_tools_list", "도구 목록 기능 할수있는것 능력"

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -180,6 +180,26 @@ let append_turn ~base_dir ~keeper_name ~(user_content : string)
     Log.Keeper.warn "keeper_chat_store: append failed for %s: %s"
       (sanitize_name keeper_name) (Printexc.to_string exn)
 
+(* RFC-0223 P4: keeper-initiated message on one lane. A single
+   assistant line — there is no user turn to pair it with. *)
+let append_assistant_message ~base_dir ~keeper_name ~(content : string)
+    ?source () =
+  try
+    ensure_dir_once ~base_dir;
+    let path = chat_path ~base_dir ~keeper_name in
+    let ts = Time_compat.now () in
+    let line = encode_line ~role:"assistant" ~content ~ts ?source () in
+    Fs_compat.append_file path (line ^ "\n")
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string ChatStoreFailures)
+      ~labels:[("operation", Keeper_chat_store_operation.(to_label Append))]
+      ();
+    Log.Keeper.warn "keeper_chat_store: assistant append failed for %s: %s"
+      (sanitize_name keeper_name) (Printexc.to_string exn)
+
 let parse_line ~file_path (line : string) : chat_message option =
   try
     let json = Yojson.Safe.from_string line in

--- a/lib/keeper/keeper_chat_store.mli
+++ b/lib/keeper/keeper_chat_store.mli
@@ -89,6 +89,18 @@ val append_turn :
   unit ->
   unit
 
+(** [append_assistant_message ~base_dir ~keeper_name ~content ?source ()]
+    appends one keeper-initiated assistant line with no paired user
+    turn (RFC-0223 P4 [keeper_surface_post]). Same failure policy as
+    {!append_turn}. *)
+val append_assistant_message :
+  base_dir:string ->
+  keeper_name:string ->
+  content:string ->
+  ?source:string ->
+  unit ->
+  unit
+
 (** [load ~base_dir ~keeper_name] returns the most recent messages in
     chronological order: the last 100 user/assistant messages plus the
     tool lines belonging to them (absolute bound 400 lines). Missing

--- a/lib/keeper/keeper_surface_post.ml
+++ b/lib/keeper/keeper_surface_post.ml
@@ -1,0 +1,53 @@
+type post_target =
+  | To_dashboard
+  | To_discord of { channel_id : string }
+
+let dashboard_label = "dashboard"
+let discord_label = "discord"
+
+let resolve_target ~surface ~channel_id ~bound_discord_channels :
+    (post_target, string) result =
+  let surface = String.trim surface in
+  if String.equal surface dashboard_label then Ok To_dashboard
+  else if String.equal surface discord_label then
+    let bound = List.map String.trim bound_discord_channels in
+    match (channel_id, bound) with
+    | _, [] ->
+        Error
+          "this keeper has no Discord channel binding; bind a channel first \
+           (posting to an unbound surface is an error, not a no-op)"
+    | None, [ only ] -> Ok (To_discord { channel_id = only })
+    | None, _ :: _ :: _ ->
+        Error
+          (Printf.sprintf
+             "multiple Discord channels are bound (%s); pass channel_id to \
+              pick one"
+             (String.concat ", " bound))
+    | Some requested, bound ->
+        let requested = String.trim requested in
+        if List.exists (String.equal requested) bound then
+          Ok (To_discord { channel_id = requested })
+        else
+          Error
+            (Printf.sprintf
+               "channel_id %s is not bound to this keeper (bound: %s)"
+               requested
+               (String.concat ", " bound))
+  else
+    Error
+      (Printf.sprintf
+         "posting to %S is not supported: discord and dashboard only in this \
+          phase (generic gate connectors have no send surface yet)"
+         surface)
+
+let ok_json ~surface ?message_id () =
+  let fields =
+    [ ("status", `String "posted"); ("surface", `String surface) ]
+    @ match message_id with
+      | Some id -> [ ("message_id", `String id) ]
+      | None -> []
+  in
+  Yojson.Safe.to_string (`Assoc fields)
+
+let error_json message =
+  Yojson.Safe.to_string (`Assoc [ ("error", `String message) ])

--- a/lib/keeper/keeper_surface_post.mli
+++ b/lib/keeper/keeper_surface_post.mli
@@ -1,0 +1,33 @@
+(** Keeper_surface_post — act on one connected surface (RFC-0223 P4).
+
+    Decision layer behind the [keeper_surface_post] tool: resolve which
+    lane a post goes to, purely from the requested surface label, the
+    optional channel id, and the keeper's current Discord bindings.
+    Posting to a surface the keeper is not bound to is an error, not a
+    no-op (RFC-0223 §4 P4). All transport I/O stays in the runtime
+    handler. *)
+
+type post_target =
+  | To_dashboard
+      (** Persist an assistant line + broadcast [keeper_chat_appended];
+          the dashboard is always present. *)
+  | To_discord of { channel_id : string }
+
+val resolve_target :
+  surface:string ->
+  channel_id:string option ->
+  bound_discord_channels:string list ->
+  (post_target, string) result
+(** Deterministic lane resolution:
+    - blank surface or blank content are rejected by the caller; this
+      function only routes.
+    - ["dashboard"] → [To_dashboard].
+    - ["discord"] → the bound channel when exactly one exists; the
+      given [channel_id] when it is among the bindings; an error
+      naming the bound channels when ambiguous, unbound, or the id is
+      not bound.
+    - any other label → error: P4 ships discord + dashboard only
+      (generic gate connectors have no send surface yet). *)
+
+val ok_json : surface:string -> ?message_id:string -> unit -> string
+val error_json : string -> string

--- a/lib/keeper/keeper_tool_alias.ml
+++ b/lib/keeper/keeper_tool_alias.ml
@@ -76,6 +76,7 @@ let is_masc_mcp_descriptor (d : Keeper_tool_descriptor.t) =
   | Tool_library_search
   | Tool_library_read
   | Tool_surface_read
+  | Tool_surface_post
   | Tool_ide_annotate
   | Tool_voice_dispatch
   | Tool_task_dispatch

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -40,6 +40,7 @@ type runtime_handler =
   | Tool_library_search
   | Tool_library_read
   | Tool_surface_read
+  | Tool_surface_post
   | Tool_ide_annotate
   | Tool_voice_dispatch
   | Tool_task_dispatch
@@ -126,6 +127,7 @@ let runtime_handler_to_string = function
   | Tool_library_search -> "tool_library_search"
   | Tool_library_read -> "tool_library_read"
   | Tool_surface_read -> "tool_surface_read"
+  | Tool_surface_post -> "tool_surface_post"
   | Tool_ide_annotate -> "tool_ide_annotate"
   | Tool_voice_dispatch -> "tool_voice_dispatch"
   | Tool_task_dispatch -> "tool_task_dispatch"
@@ -675,6 +677,24 @@ let surface_read_schema =
     ]
 ;;
 
+let surface_post_schema =
+  object_schema
+    ~required:[ "surface"; "content" ]
+    [ property
+        "surface"
+        "string"
+        "Lane to post to: 'dashboard' or 'discord'. Posting to a surface \
+         this keeper is not bound to is an error, not a no-op."
+    ; property "content" "string" "Message text to deliver on the lane."
+    ; property
+        "channel_id"
+        "string"
+        "Discord channel snowflake. Required only when more than one \
+         channel is bound to this keeper; must be one of the bound \
+         channels."
+    ]
+;;
+
 let read_only_in_process_policy ?(inline_safe = false) ?(maintenance_only = false)
       ()
   =
@@ -1018,6 +1038,16 @@ let internal_descriptors : t list =
       ~input_schema:surface_read_schema
       ~policy:(read_only_in_process_policy ())
       ~handler:Tool_surface_read
+  ; in_process_descriptor
+      ~id:"keeper.surface.post"
+      ~name:"keeper_surface_post"
+      ~description:
+        "Post a message to one connected surface lane: 'dashboard' (appears \
+         in the operator's chat transcript) or 'discord' (sends to the bound \
+         channel). Posting to an unbound surface is an error."
+      ~input_schema:surface_post_schema
+      ~policy:(write_in_process_policy ())
+      ~handler:Tool_surface_post
     (* ── IDE (RFC-0179 PR-3) ──────────────────────────────────── *)
   ; in_process_descriptor
       ~id:"keeper.ide.annotate"

--- a/lib/keeper/keeper_tool_descriptor.mli
+++ b/lib/keeper/keeper_tool_descriptor.mli
@@ -45,6 +45,7 @@ type runtime_handler =
   | Tool_library_search
   | Tool_library_read
   | Tool_surface_read
+  | Tool_surface_post
   | Tool_ide_annotate
   | Tool_voice_dispatch
   | Tool_task_dispatch

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -98,6 +98,56 @@ let handle_surface_read ~config ~(meta : keeper_meta) ~args =
   Keeper_surface_read.respond ~surface ~limit messages
 ;;
 
+let handle_surface_post ~config ~(meta : keeper_meta) ~args =
+  let surface = String.trim (Safe_ops.json_string ~default:"" "surface" args) in
+  let content = Safe_ops.json_string ~default:"" "content" args in
+  let channel_id =
+    match String.trim (Safe_ops.json_string ~default:"" "channel_id" args) with
+    | "" -> None
+    | id -> Some id
+  in
+  if surface = "" then
+    Keeper_surface_post.error_json
+      "surface is required. Good: surface='dashboard'."
+  else if String.trim content = "" then
+    Keeper_surface_post.error_json "content is required and must be non-empty."
+  else
+    let bound_discord_channels =
+      Channel_gate_discord_state.bound_channels ~keeper_name:meta.name
+    in
+    match
+      Keeper_surface_post.resolve_target ~surface ~channel_id
+        ~bound_discord_channels
+    with
+    | Error message -> Keeper_surface_post.error_json message
+    | Ok Keeper_surface_post.To_dashboard ->
+        Keeper_chat_store.append_assistant_message
+          ~base_dir:config.Workspace.base_path
+          ~keeper_name:meta.name
+          ~content
+          ~source:"dashboard"
+          ();
+        Keeper_chat_broadcast.chat_appended ~keeper_name:meta.name
+          ~source:"dashboard";
+        Keeper_surface_post.ok_json ~surface ()
+    | Ok (Keeper_surface_post.To_discord { channel_id }) -> (
+        match Channel_gate_discord_state.send_message ~channel_id ~content with
+        | Error send_error ->
+            Keeper_surface_post.error_json
+              (Format.asprintf "discord send failed: %a"
+                 Channel_gate_discord_state.pp_send_error send_error)
+        | Ok message_id ->
+            Keeper_chat_store.append_assistant_message
+              ~base_dir:config.Workspace.base_path
+              ~keeper_name:meta.name
+              ~content
+              ~source:"discord"
+              ();
+            Keeper_chat_broadcast.chat_appended ~keeper_name:meta.name
+              ~source:"discord";
+            Keeper_surface_post.ok_json ~surface ~message_id ())
+;;
+
 let handle_ide_annotate ~config ~(meta : keeper_meta) ~args =
   Keeper_tool_ide_runtime.handle_ide_annotate
     ~config

--- a/lib/keeper/keeper_tool_in_process_runtime.mli
+++ b/lib/keeper/keeper_tool_in_process_runtime.mli
@@ -54,6 +54,12 @@ val handle_surface_read
   -> args:Yojson.Safe.t
   -> string
 
+val handle_surface_post
+  :  config:Workspace.config
+  -> meta:keeper_meta
+  -> args:Yojson.Safe.t
+  -> string
+
 val handle_ide_annotate
   :  config:Workspace.config
   -> meta:keeper_meta

--- a/lib/keeper/keeper_tool_runtime.ml
+++ b/lib/keeper/keeper_tool_runtime.ml
@@ -58,6 +58,7 @@ let handle_filesystem ctx descriptor args =
   | Tool_library_search
   | Tool_library_read
   | Tool_surface_read
+  | Tool_surface_post
   | Tool_ide_annotate
   | Tool_voice_dispatch
   | Tool_task_dispatch
@@ -110,6 +111,7 @@ let handle_shell_ir ctx descriptor args =
   | Tool_library_search
   | Tool_library_read
   | Tool_surface_read
+  | Tool_surface_post
   | Tool_ide_annotate
   | Tool_voice_dispatch
   | Tool_task_dispatch
@@ -170,6 +172,12 @@ let handle_in_process ctx descriptor args =
   | Tool_surface_read ->
     Some
       (Keeper_tool_in_process_runtime.handle_surface_read
+         ~config:ctx.config
+         ~meta:ctx.meta
+         ~args)
+  | Tool_surface_post ->
+    Some
+      (Keeper_tool_in_process_runtime.handle_surface_post
          ~config:ctx.config
          ~meta:ctx.meta
          ~args)

--- a/lib/keeper_tooling/keeper_tool_name.ml
+++ b/lib/keeper_tooling/keeper_tool_name.ml
@@ -38,6 +38,7 @@ type t =
   | Search_files
   | Stay_silent
   | Surface_read
+  | Surface_post
   | Task_claim
   | Task_create
   | Task_done
@@ -86,6 +87,7 @@ let to_string = function
   | Search_files -> "tool_search_files"
   | Stay_silent -> "keeper_stay_silent"
   | Surface_read -> "keeper_surface_read"
+  | Surface_post -> "keeper_surface_post"
   | Task_claim -> "keeper_task_claim"
   | Task_create -> "keeper_task_create"
   | Task_done -> "keeper_task_done"
@@ -135,6 +137,7 @@ let of_string = function
   | "tool_search_files" -> Some Search_files
   | "keeper_stay_silent" -> Some Stay_silent
   | "keeper_surface_read" -> Some Surface_read
+  | "keeper_surface_post" -> Some Surface_post
   | "keeper_task_claim" -> Some Task_claim
   | "keeper_task_create" -> Some Task_create
   | "keeper_task_done" -> Some Task_done
@@ -201,6 +204,7 @@ let is_keeper_board_tool = function
   | Search_files
   | Stay_silent
   | Surface_read
+  | Surface_post
   | Task_claim
   | Task_create
   | Task_done

--- a/lib/keeper_tooling/keeper_tool_name.mli
+++ b/lib/keeper_tooling/keeper_tool_name.mli
@@ -36,6 +36,7 @@ type t =
   | Search_files
   | Stay_silent
   | Surface_read
+  | Surface_post
   | Task_claim
   | Task_create
   | Task_done

--- a/lib/tool_surface/tool_prefilter.ml
+++ b/lib/tool_surface/tool_prefilter.ml
@@ -223,6 +223,13 @@ let synonyms : (string * string list) list =
       ; "participants roster"
       ; "connected surface"
       ] )
+  ; ( "keeper_surface_post"
+    , [ "send discord message"
+      ; "post to channel"
+      ; "reply on surface"
+      ; "message the dashboard"
+      ; "speak on lane"
+      ] )
   ; ( "keeper_tools_list"
     , [ "what can you do"
       ; "capabilities"

--- a/lib/tool_surface/tool_shard_types_schemas_surface.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_surface.ml
@@ -35,4 +35,38 @@ let surface_tools : Masc_domain.tool_schema list =
           ; "required", `List [ `String "surface" ]
           ]
     }
+  ; { name = "keeper_surface_post"
+    ; description =
+        "Post a message to one connected surface lane: 'dashboard' (appears \
+         in the operator's chat transcript) or 'discord' (sends to the bound \
+         channel). Posting to an unbound surface is an error."
+    ; input_schema =
+        `Assoc
+          [ "type", `String "object"
+          ; ( "properties"
+            , `Assoc
+                [ ( "surface"
+                  , `Assoc
+                      [ "type", `String "string"
+                      ; ( "description"
+                        , `String "Lane to post to: 'dashboard' or 'discord'" )
+                      ] )
+                ; ( "content"
+                  , `Assoc
+                      [ "type", `String "string"
+                      ; ( "description"
+                        , `String "Message text to deliver on the lane" )
+                      ] )
+                ; ( "channel_id"
+                  , `Assoc
+                      [ "type", `String "string"
+                      ; ( "description"
+                        , `String
+                            "Discord channel snowflake; required only when \
+                             more than one channel is bound" )
+                      ] )
+                ] )
+          ; "required", `List [ `String "surface"; `String "content" ]
+          ]
+    }
   ]

--- a/test/dune
+++ b/test/dune
@@ -181,6 +181,7 @@
   test_keeper_unified_idle_cooldown
   test_keeper_unified_inline_skip
   test_keeper_unified_metacognition
+  test_keeper_surface_post
   test_keeper_surface_read
   test_keeper_surface_presence_prompt
   test_keeper_unified_verification_surface
@@ -444,6 +445,7 @@
   test_keeper_unified_idle_cooldown
   test_keeper_unified_inline_skip
   test_keeper_unified_metacognition
+  test_keeper_surface_post
   test_keeper_surface_read
   test_keeper_surface_presence_prompt
   test_keeper_unified_verification_surface

--- a/test/test_keeper_surface_post.ml
+++ b/test/test_keeper_surface_post.ml
@@ -1,0 +1,130 @@
+(* RFC-0223 P4 — Keeper_surface_post target resolution + assistant-only
+   store append.
+
+   resolve_target is pure (surface label + channel arg + bindings in,
+   target or error out). The Discord transport path needs a live REST
+   client and stays operational; the dashboard persistence path is
+   covered against a temp store here. *)
+
+open Alcotest
+
+module Store = Masc.Keeper_chat_store
+module SP = Masc.Keeper_surface_post
+
+let target_pp fmt = function
+  | SP.To_dashboard -> Format.fprintf fmt "To_dashboard"
+  | SP.To_discord { channel_id } ->
+      Format.fprintf fmt "To_discord{%s}" channel_id
+
+let target : SP.post_target testable = testable target_pp ( = )
+
+let resolve = SP.resolve_target
+
+(* ── resolve_target ─────────────────────────────────────────────── *)
+
+let test_dashboard_always_resolves () =
+  check (result target string) "no bindings needed" (Ok SP.To_dashboard)
+    (resolve ~surface:"dashboard" ~channel_id:None ~bound_discord_channels:[])
+
+let test_discord_unbound_is_error () =
+  match resolve ~surface:"discord" ~channel_id:None ~bound_discord_channels:[] with
+  | Error message ->
+      check bool "names the unbound condition" true
+        (Astring.String.is_infix ~affix:"no Discord channel binding" message)
+  | Ok _ -> fail "unbound discord must not resolve"
+
+let test_discord_single_binding_resolves_implicitly () =
+  check (result target string) "single binding"
+    (Ok (SP.To_discord { channel_id = "98791450001" }))
+    (resolve ~surface:"discord" ~channel_id:None
+       ~bound_discord_channels:[ "98791450001" ])
+
+let test_discord_multiple_bindings_require_channel_id () =
+  (match
+     resolve ~surface:"discord" ~channel_id:None
+       ~bound_discord_channels:[ "111"; "222" ]
+   with
+  | Error message ->
+      check bool "lists bound channels" true
+        (Astring.String.is_infix ~affix:"111, 222" message)
+  | Ok _ -> fail "ambiguous binding must not resolve");
+  check (result target string) "explicit channel_id picks one"
+    (Ok (SP.To_discord { channel_id = "222" }))
+    (resolve ~surface:"discord" ~channel_id:(Some "222")
+       ~bound_discord_channels:[ "111"; "222" ])
+
+let test_discord_foreign_channel_id_is_error () =
+  match
+    resolve ~surface:"discord" ~channel_id:(Some "999")
+      ~bound_discord_channels:[ "111" ]
+  with
+  | Error message ->
+      check bool "names the rejected id" true
+        (Astring.String.is_infix ~affix:"999" message)
+  | Ok _ -> fail "foreign channel_id must not resolve"
+
+let test_unsupported_surface_is_error () =
+  List.iter
+    (fun surface ->
+      match resolve ~surface ~channel_id:None ~bound_discord_channels:[] with
+      | Error message ->
+          check bool (surface ^ " unsupported") true
+            (Astring.String.is_infix ~affix:"not supported" message)
+      | Ok _ -> fail (surface ^ " must not resolve in P4"))
+    [ "slack"; "telegram"; "openclaw" ]
+
+(* ── append_assistant_message ───────────────────────────────────── *)
+
+let with_temp_base_dir f =
+  let dir =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "surface-post-%d" (Unix.getpid ()))
+  in
+  let masc = Filename.concat dir ".masc" in
+  let keeper_chat = Filename.concat masc "keeper_chat" in
+  List.iter
+    (fun d -> if not (Sys.file_exists d) then Unix.mkdir d 0o755)
+    [ dir; masc; keeper_chat ];
+  Fun.protect
+    ~finally:(fun () ->
+      Array.iter
+        (fun f -> try Sys.remove (Filename.concat keeper_chat f) with _ -> ())
+        (try Sys.readdir keeper_chat with Sys_error _ -> [||]))
+    (fun () -> f dir)
+
+let test_assistant_message_persists_with_source () =
+  with_temp_base_dir (fun base_dir ->
+      Store.append_assistant_message ~base_dir ~keeper_name:"post-keeper"
+        ~content:"keeper-initiated hello" ~source:"discord" ();
+      let messages = Store.load ~base_dir ~keeper_name:"post-keeper" in
+      check int "one line" 1 (List.length messages);
+      let m = List.hd messages in
+      check string "role" "assistant" m.Store.role;
+      check string "content" "keeper-initiated hello" m.Store.content;
+      check (option string) "source" (Some "discord") m.Store.source;
+      check bool "no speaker on keeper output" true (m.Store.speaker = None))
+
+let () =
+  run "keeper_surface_post"
+    [
+      ( "resolve_target",
+        [
+          test_case "dashboard always resolves" `Quick
+            test_dashboard_always_resolves;
+          test_case "discord unbound is an error" `Quick
+            test_discord_unbound_is_error;
+          test_case "single binding resolves implicitly" `Quick
+            test_discord_single_binding_resolves_implicitly;
+          test_case "multiple bindings require channel_id" `Quick
+            test_discord_multiple_bindings_require_channel_id;
+          test_case "foreign channel_id is an error" `Quick
+            test_discord_foreign_channel_id_is_error;
+          test_case "unsupported surfaces are errors" `Quick
+            test_unsupported_surface_is_error;
+        ] );
+      ( "assistant append",
+        [
+          test_case "persists assistant line with source" `Quick
+            test_assistant_message_persists_with_source;
+        ] );
+    ]

--- a/test/test_keeper_tool_matrix_cases.ml
+++ b/test/test_keeper_tool_matrix_cases.ml
@@ -335,6 +335,10 @@ let keeper_arguments fixture (schema : Masc_domain.tool_schema) =
   | "keeper_library_read" ->
       `Assoc [ ("topic", `String (Generic.ensure_library_topic fixture.generic)) ]
   | "keeper_surface_read" -> `Assoc [ ("surface", `String "dashboard") ]
+  | "keeper_surface_post" ->
+      `Assoc
+        [ ("surface", `String "dashboard");
+          ("content", `String "tool matrix surface post") ]
   | "keeper_tasks_list" -> `Assoc [ ("include_done", `Bool true) ]
   | "keeper_task_force_release" ->
       `Assoc

--- a/test/test_keeper_tool_resolution.ml
+++ b/test/test_keeper_tool_resolution.ml
@@ -166,6 +166,7 @@ let policy_tool_names =
       "keeper_context_status";
       "keeper_library_read";
       "keeper_surface_read";
+      "keeper_surface_post";
       "keeper_library_search";
       "keeper_memory_search";
       "keeper_memory_write";


### PR DESCRIPTION
## 무엇

RFC-0223 P4 — `keeper_surface_post` 도구. keeper가 연결된 surface lane 하나에 **능동적으로 발화**합니다. 이로써 RFC-0223 phase 4개(P1 speaker #20726 / P2 presence #20738 / P3 read #20750 / P4 act) 전부 완료입니다.

RFC: `docs/rfc/RFC-0223-typed-connector-surfaces-presence-pull-speaker.md` §4 P4

## 동작

```
keeper_surface_post { surface: "dashboard"|"discord", content: string, channel_id?: string }
```

| lane | 경로 |
|---|---|
| `dashboard` | `append_assistant_message`(신규, user 턴 없는 단독 assistant 라인) + `keeper_chat_appended` SSE broadcast → 운영자 화면에 라이브 표시 |
| `discord` | `Channel_gate_discord_state.send_message` → 성공 시 동일하게 영속+broadcast → **`keeper_surface_read`가 keeper 자신의 발화도 lane 히스토리로 보여줌** |

## 바인딩 규칙 (RFC §4: "unbound = 에러, no-op 아님")

`resolve_target` pure 함수 — surface 라벨 + channel_id 인자 + 현재 Discord 바인딩만으로 결정:

- 바인딩 0개 → 에러 (바인딩 먼저 하라고 안내)
- 정확히 1개 → 암묵 사용
- 복수 → `channel_id` 필수, 에러 메시지에 바인딩 목록 제시
- 바인딩에 없는 `channel_id` → 거부 (id 명시)
- slack/telegram/openclaw 등 → "not supported in this phase" 정직한 에러 (generic gate connector에는 send 표면이 아직 없음)

## 등록 표면

P3에서 기록한 8단계 체크리스트 그대로: `Keeper_tool_name` variant(컴파일러가 risk/alias/dispatch 강제), descriptor(`write_in_process_policy`), risk **Medium**(외부 제3자 도달) + `State_modification`, shard `surface` 합류(P3가 만든 shard — `default_shard_names`는 이미 포함), prefilter/한국어 키워드, matrix/resolution 테스트.

## 검증 (rebase 후 main 트리에서 재실행)

- `@check` + default EXIT=0, fmt clean, DET/NDT PASS, SSOT 0, doc-truth OK
- 신규 `test_keeper_surface_post` 7/7 (routing 6 + assistant 영속 1)
- **end-to-end**: `keeper_tool_matrix_case_runner.exe keeper_surface_post` → `ok:true` (dashboard 경로 실제 영속+broadcast)
- 회귀: surface_read 6, chat_store 9 green

## 한계 (명시)

- Discord 전송 성공 후 영속 실패 가능성: `append_assistant_message`는 `append_turn`과 동일한 best-effort 정책(로그+카운터, 미raise) — 메시지는 나갔는데 히스토리에 없는 창이 이론상 존재. 전송과 영속을 트랜잭션으로 묶을 수단이 없어(외부 API) RFC의 기존 store 정책을 따름.
- Discord 실전송 경로는 live REST 필요 → 운영 검증 항목 (RFC §6 Manual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
