### PR TITLE
refactor(keeper): remove dead is_tool_retry_exhausted_error classifier

### DIFF
--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -626,20 +626,12 @@ let degraded_rotation_after_recoverable_error
          (* Contract violation: all candidates exhausted. Cap rotation. *)
          None)
 
-let is_tool_retry_exhausted_error (_err : Agent_sdk.Error.sdk_error) : bool =
-  false
-;;
-
 let is_auto_recoverable_turn_error (err : Agent_sdk.Error.sdk_error) : bool =
   is_transient_network_error err
   || is_server_rejected_parse_error err
-  || is_tool_retry_exhausted_error err
   || is_auto_recoverable_runtime_exhausted_error err
 
 let should_warn_keeper_cycle_failed (err : Agent_sdk.Error.sdk_error) : bool =
-  if is_tool_retry_exhausted_error err
-  then true
-  else
   match Keeper_turn_driver.classify_masc_internal_error err with
   | Some (Keeper_turn_driver.Provider_timeout _) -> true
   | Some (Keeper_turn_driver.Capacity_backpressure _) -> true

--- a/lib/keeper/keeper_error_classify.mli
+++ b/lib/keeper/keeper_error_classify.mli
@@ -35,11 +35,6 @@ val is_model_rejected_parse_error : Agent_sdk.Error.sdk_error -> bool
     failure counting, even if same-turn retry is still disabled. *)
 val is_auto_recoverable_turn_error : Agent_sdk.Error.sdk_error -> bool
 
-(** [true] when OAS exhausted retries for malformed tool-call arguments.
-    The turn failed, but this is a model/tool-call validation miss, not a
-    runtime/provider health failure. *)
-val is_tool_retry_exhausted_error : Agent_sdk.Error.sdk_error -> bool
-
 (** [true] when the turn runner should record the immediate
     ["keeper cycle FAILED"] line as WARN instead of ERROR because the
     heartbeat policy layer will handle the failure as a provider/OAS budget

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -590,7 +590,6 @@ let run_keeper_cycle
                     (Trajectory.Failed (Agent_sdk.Error.to_string err));
                   let e_str = Agent_sdk.Error.to_string err in
                   let is_transient = EC.is_transient_network_error err in
-                  let is_tool_retry_exhausted = EC.is_tool_retry_exhausted_error err in
                   (match Keeper_turn_driver.classify_masc_internal_error err with
                    | Some (Keeper_turn_driver.Provider_timeout _) ->
                      Otel_metric_store.inc_counter
@@ -675,8 +674,6 @@ let run_keeper_cycle
                      then " (ambiguous partial commit)"
                      else if is_server_parse_rejection
                      then " (server parse rejection, auto-recoverable)"
-                     else if is_tool_retry_exhausted
-                     then " (tool retry exhausted, auto-recoverable)"
                      else if is_transient
                      then " (transient, cooldown preserved)"
                      else if EC.should_warn_keeper_cycle_failed err


### PR DESCRIPTION
## What

Remove the dead `is_tool_retry_exhausted_error` classifier from the keeper
error-classification path.

## Why

The tool-retry budget was deleted in #20624, after which
`is_tool_retry_exhausted_error` returns a constant `false`. Every consumer
became an unreachable branch:

- `is_auto_recoverable_turn_error` — a `|| <false>` disjunct.
- `should_warn_keeper_cycle_failed` — an `if ... then true else <match>`
  wrapper whose then-branch never fired.
- `keeper_unified_turn` — a local binding plus a log-suffix `else if` branch
  that never produced its string.

This is a removal, not a workaround: it deletes a dead surface rather than
adding a classifier. Behavior is unchanged because every removed branch was
unreachable. OCaml's exhaustive references let the compiler confirm there are
no remaining call sites (verified: 0 references after the change).

## Scope

3 files, 16 deletions: `keeper_error_classify.ml` / `.mli`,
`keeper_unified_turn.ml`. No new types, no behavior change.

## Verification

`dune build --root . @check` green from a clean worktree. Edited modules
type-check (`masc__Keeper_error_classify.cmt` and
`masc__Keeper_unified_turn.cmt` produced).

## Reference

Surfaced by research `2026-06-10-masc-autonomy-determinism-harness` (R7).
Not an RFC-gated subsystem (`keeper_error_classify` / `keeper_unified_turn`
are not credential / identity / repo / operator / sandbox / hooks / workflow).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
