### PR TITLE
fix(shell-ir): Make field completeness, effect telemetry, dense OTel

### DIFF
--- a/lib/exec/capability_check_typed.ml
+++ b/lib/exec/capability_check_typed.ml
@@ -412,8 +412,16 @@ let of_command = function
       arg action_flag :: compression_flags @ [ arg "-f"; arg archive ]
     in
     [ Capability.Exec_program (Exec_program.of_known Exec_program.Tar, flag_args @ List.map arg paths) ]
-  | Shell_ir_typed.W (Make { target; jobs }) ->
-    let flag_args = match jobs with None -> [] | Some j -> [ arg "-j"; arg (string_of_int j) ] in
+  | Shell_ir_typed.W (Make { target; jobs; directory; makefile; dry_run; keep_going; silent; always_make }) ->
+    let flag_args =
+      (match jobs with None -> [] | Some j -> [ arg "-j"; arg (string_of_int j) ])
+      @ (match directory with None -> [] | Some d -> [ arg "-C"; arg d ])
+      @ (match makefile with None -> [] | Some f -> [ arg "-f"; arg f ])
+      @ (if dry_run then [ arg "-n" ] else [])
+      @ (if keep_going then [ arg "-k" ] else [])
+      @ (if silent then [ arg "-s" ] else [])
+      @ (if always_make then [ arg "-B" ] else [])
+    in
     let target_args = match target with None -> [] | Some t -> [ arg t ] in
     [ Capability.Exec_program (Exec_program.of_known Exec_program.Make, flag_args @ target_args) ]
   | Shell_ir_typed.W (Diff { file1; file2; unified; brief }) ->

--- a/lib/exec/dune
+++ b/lib/exec/dune
@@ -18,7 +18,8 @@
   eio
   unix
   yojson
-  re))
+  re
+  logs))
 
 ; RFC-0054 PR-3 — auto-generate parallel-verification walkers for
 ; Shell_ir_typed. The generator's spec lives in

--- a/lib/exec/exec_dispatch.ml
+++ b/lib/exec/exec_dispatch.ml
@@ -373,4 +373,15 @@ and dispatch ?on_output_chunk (ir : Shell_ir.t) =
 
 let dispatch_decided ?on_output_chunk (envelope : Shell_ir_risk.decided Shell_ir_risk.decided_ir) :
     dispatch_result =
+  (match envelope.Shell_ir_risk.risk with
+   | Shell_ir_risk.Destructive_protected ->
+       Logs.warn (fun m ->
+         m
+           "Exec_dispatch: destructive_protected command dispatched: %a"
+           Shell_ir.pp
+           envelope.Shell_ir_risk.ir)
+   | Shell_ir_risk.R0_Read
+   | Shell_ir_risk.R1_Reversible_mutation
+   | Shell_ir_risk.R2_Irreversible ->
+       ());
   dispatch ?on_output_chunk envelope.Shell_ir_risk.ir

--- a/lib/exec/shell_ir_typed.ml
+++ b/lib/exec/shell_ir_typed.ml
@@ -443,14 +443,22 @@ let pp fmt = function
        | `Bzip2 -> "bzip2"
        | `Xz -> "xz"
        | `Zstd -> "zstd")
-  | W (Make { target; jobs }) ->
+  | W (Make { target; jobs; directory; makefile; dry_run; keep_going; silent; always_make }) ->
     Format.fprintf
       fmt
-      "Make(target=%a, jobs=%a)"
+      "Make(target=%a, jobs=%a, directory=%a, makefile=%a, dry_run=%b, keep_going=%b, silent=%b, always_make=%b)"
       (Format.pp_print_option Format.pp_print_string)
       target
       (Format.pp_print_option Format.pp_print_int)
       jobs
+      (Format.pp_print_option Format.pp_print_string)
+      directory
+      (Format.pp_print_option Format.pp_print_string)
+      makefile
+      dry_run
+      keep_going
+      silent
+      always_make
   | W (Diff { file1; file2; unified; brief }) ->
     Format.fprintf fmt "Diff(file1=%s, file2=%s, unified=%b, brief=%b)" file1 file2 unified brief
   | W (Sed { expression; file; in_place; extended_regex; suppress_output }) ->

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -414,15 +414,40 @@ let handle_tool_execute_typed
                of live traffic observable. An offline scan of typed_hit=true
                / total gives the real exercise rate of the typed model vs the
                Generic escape hatch. *)
+            let effects = Masc_exec.Exec_effect.extract ir in
+            let effects_str = Format.asprintf "%a" Masc_exec.Exec_effect.pp_set effects in
             Log.Keeper.info
-              "shell_ir dispatch keeper=%s sandbox=%s status=%s elapsed_ms=%d risk_class=%s typed_hit=%b"
+              "shell_ir dispatch keeper=%s sandbox=%s status=%s elapsed_ms=%d risk_class=%s typed_hit=%b effects=%s"
               meta.name
               (Keeper_types_profile_sandbox.sandbox_profile_to_string sandbox_profile)
               (Keeper_sandbox_exec_failure.status_label result.status)
               elapsed_ms
               (Masc_exec.Shell_ir_risk.string_of_risk_class
                  (Masc_exec.Shell_ir_risk.risk_class envelope))
-              (Masc_exec.Shell_ir_risk.typed_hit_of_ir ir);
+              (Masc_exec.Shell_ir_risk.typed_hit_of_ir ir)
+              effects_str;
+            Otel_spans.add_attrs
+              ~attrs:[
+                ( "shell_ir.risk_class"
+                , `String
+                    (Masc_exec.Shell_ir_risk.string_of_risk_class
+                       (Masc_exec.Shell_ir_risk.risk_class envelope)) )
+              ; ( "shell_ir.typed_hit"
+                , `Bool (Masc_exec.Shell_ir_risk.typed_hit_of_ir ir) )
+              ; "shell_ir.effects", `String effects_str
+              ]
+              ();
+            List.iter
+              (fun (eff : Masc_exec.Exec_effect.t) ->
+                 Otel_metric_store.inc_counter
+                   (Keeper_metrics.to_string Keeper_metrics.ShellIrEffectTotal)
+                   ~labels:[
+                     ( "kind"
+                     , Masc_exec.Exec_effect.string_of_effect_kind eff.kind )
+                   ; "source", eff.source
+                   ]
+                   ())
+              effects;
             let output =
               if String.equal result.stderr ""
               then result.stdout

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -218,6 +218,7 @@ type t =
   | KeeperTurnInstructionHash   (* gauge: hash of system+user prompt for change detection *)
   | KeeperToolCallRetryLoop     (* counter: consecutive identical tool calls with errors *)
   | AttemptWatchdogFired        (* counter: 1800s safety-cap watchdog killed a stuck attempt *)
+  | ShellIrEffectTotal          (* counter: fine-grained Shell IR effect decomposition *)
 
 (** String conversion
 
@@ -450,6 +451,7 @@ let to_string = function
   | KeeperTurnInstructionHash -> "masc_keeper_turn_instruction_hash"
   | KeeperToolCallRetryLoop -> "masc_keeper_tool_call_retry_loop_total"
   | AttemptWatchdogFired -> "masc_keeper_attempt_watchdog_fired_total"
+  | ShellIrEffectTotal -> "masc_keeper_shell_ir_effect_total"
 ;;
 
 (* Every constructor of [t], in declaration order.  Consumed by
@@ -509,7 +511,7 @@ let all : t list =
     UsageAnomalyReason; ConfigEnvParseFailures; PostTurnWireinFailures; RecurringFailures;
     TurnCleanupFailures; MemoryBankLoadHistorySwallowedExceptions; MemoryRecallReadErrors; RuntimeHttpProbeJsonParseFailures;
     PromptSegmentBytes; PromptTemplateRenderOutcome; ToolCallParamCompleteness; KeeperTurnInstructionHash;
-    KeeperToolCallRetryLoop; AttemptWatchdogFired
+    KeeperToolCallRetryLoop; AttemptWatchdogFired; ShellIrEffectTotal
   ]
 ;;
 

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -208,6 +208,7 @@ type t =
   | KeeperTurnInstructionHash
   | KeeperToolCallRetryLoop
   | AttemptWatchdogFired
+  | ShellIrEffectTotal
 
 val to_string : t -> string
 

--- a/lib/keeper_tooling/keeper_tool_execute_shell_ir.ml
+++ b/lib/keeper_tooling/keeper_tool_execute_shell_ir.ml
@@ -1,7 +1,8 @@
 module Shell_gate = Masc_exec_command_gate.Shell_command_gate
 
 let classify ir =
-  Masc_exec.Shell_ir_risk.classify (Masc_exec.Shell_ir_risk.undecided ir)
+  let checked = Masc_exec.Checked_shell_ir.classify_proof ir in
+  Masc_exec.Checked_shell_ir.to_decided_ir checked
 ;;
 
 let lit text = Masc_exec.Shell_ir.Lit (text, Masc_exec.Shell_ir.default_meta)


### PR DESCRIPTION
## Summary

RFC-0208 P1 Shell IR production telemetry hook-up + Make constructor field completeness fixes.

## Changes

### Bug Fixes
- **`Make` constructor field completeness** (`shell_ir_typed.ml` `pp`): now prints all 8 fields (target, jobs, directory, makefile, dry_run, keep_going, silent, always_make) instead of only 2.
- **`Make` capability derivation** (`capability_check_typed.ml`): emits `-C`, `-f`, `-n`, `-k`, `-s`, `-B` flags so policy decisions see the full argv.

### Telemetry / Observability
- Wire `Exec_effect.extract` into keeper dispatch:
  - Log line now includes `effects=%s`
  - OTel span attributes: `shell_ir.risk_class`, `shell_ir.typed_hit`, `shell_ir.effects`
  - New keeper metric `ShellIrEffectTotal` incremented per effect with `kind` + `source` labels.
- `exec_dispatch.ml`: warns when `Destructive_protected` commands are dispatched.

### Refactoring
- `Keeper_tool_execute_shell_ir.classify` now routes through `Checked_shell_ir.classify_proof` (RFC-0208 proof bundle), replacing the inline classify/undecided pair.

## Verification
- [x] Local dune build passes (`scripts/dune-local.sh build lib/keeper/keeper_tool_execute_runtime.ml`)
- [ ] CI green

## Follow-up (not in this PR)
- Connect `Approval_policy_typed.decide` to `dispatch_classified` for opt-in approval gating.
- Catalog remaining stub/silent-failure patterns across `lib/exec/` and `lib/keeper/`.
