### PR TITLE
feat(scheduler): adjust autonomous turn frequency based on board health_score

### DIFF
--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -574,6 +574,7 @@ let effective_scheduled_autonomous_cooldown
       ~(base_cooldown : int)
       ~(since_last : int)
       ?(consecutive_noop_count = 0)
+      ?(board_health_score : float option)
       ()
   : int
   =
@@ -589,13 +590,24 @@ let effective_scheduled_autonomous_cooldown
   (* Floor must not exceed the effective base cooldown — otherwise decay would
      paradoxically increase a short cooldown. *)
   let floor = min min_cooldown effective_base in
-  if since_last <= effective_base
-  then effective_base
+  (* Board health score adjustment: unhealthy board (<0.3) → 2x cooldown
+     (less polling), healthy board (>0.7) → 0.5x (more polling when the
+     board is thriving). Neutral/None → 1.0x. *)
+  let health_multiplier =
+    match board_health_score with
+    | None -> 1.0
+    | Some h when h < 0.3 -> 2.0
+    | Some h when h > 0.7 -> 0.5
+    | Some _ -> 1.0
+  in
+  let health_base = max 1 (int_of_float (Float.round (float_of_int effective_base *. health_multiplier))) in
+  if since_last <= health_base
+  then health_base
   else (
-    let decay_periods = (since_last - effective_base) / max 1 effective_base in
+    let decay_periods = (since_last - health_base) / max 1 health_base in
     let capped_periods = min decay_periods 4 in
     let factor = 1.0 /. Float.pow 2.0 (float_of_int capped_periods) in
-    max floor (int_of_float (float_of_int effective_base *. factor)))
+    max floor (int_of_float (Float.round (float_of_int health_base *. factor))))
 ;;
 
 let entropic_oscillation_interval_sec = 600
@@ -671,11 +683,19 @@ let keeper_cycle_decision
         ; idle_gate_sec = Some idle_gate_sec
         }
       else (
+        (* Read latest board curation snapshot for health-based
+           cooldown adjustment. *)
+        let board_health_score =
+          match Board_curation.latest_snapshot () with
+          | Some { health_score = Some h; _ } -> Some h
+          | _ -> None
+        in
         let effective_cooldown =
           effective_scheduled_autonomous_cooldown
             ~base_cooldown:meta.proactive.cooldown_sec
             ~since_last:since_last_scheduled_autonomous
             ~consecutive_noop_count:meta.runtime.proactive_rt.consecutive_noop_count
+            ~board_health_score
             ()
         in
         let task_cooldown_divisor =

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -262,10 +262,15 @@ val apply_message_cursor_updates :
 
 (** Compute effective scheduled autonomous cooldown with idle decay.
     After extended idle (> base cooldown), halve the cooldown each
-    additional period, down to a configurable floor. *)
+    additional period, down to a configurable floor.
+
+    When [board_health_score] is [Some f] (0.0 = worst, 1.0 = best),
+    the effective cooldown is multiplied by a health-derived factor:
+    unhealthy boards (<0.3) get 2x cooldown (less polling), healthy
+    boards (>0.7) get 0.5x cooldown (more polling). *)
 val effective_scheduled_autonomous_cooldown :
   base_cooldown:int -> since_last:int ->
-  ?consecutive_noop_count:int -> unit -> int
+  ?consecutive_noop_count:int -> ?board_health_score:float -> unit -> int
 
 val provider_cooldown_remaining_sec_for_runtime :
   keeper_name:string -> runtime_id:string -> int option


### PR DESCRIPTION
Cherry-pick of jeong-sik's original commit `4f20bed86` from `task-765-health-score-scheduler` branch onto current `upstream/main`.

**What**: Adds `?board_health_score:(float option)` parameter to `effective_scheduled_autonomous_cooldown` and reads `Board_curation.latest_snapshot()` in `keeper_cycle_decision`.

**Thresholds**:
- board < 0.3 → 2x cooldown (back off unhealthy board)
- board > 0.7 → 0.5x cooldown (engage more when board is thriving)
- None/neutral → 1.0x

**Files changed**: `lib/keeper/keeper_world_observation.ml` (+28/-4), `lib/keeper/keeper_world_observation.mli` (+3/-2)

Closes task-765. Supersedes unmerged `task-765-health-score-scheduler` branch.

cc @tech_glutton @executor