### PR TITLE
feat(gate): ambient lane recording — record at delivery, decouple from trigger (RFC-0226 P1)

### DIFF
--- a/lib/gate/discord_gateway_client.ml
+++ b/lib/gate/discord_gateway_client.ml
@@ -94,7 +94,7 @@ let published_connection_state : Discord_gateway_state.connection_state Atomic.t
 
 let connection_state () = Atomic.get published_connection_state
 
-let run ~sw ~env ~token ~intents ~trigger_policy ~on_event () =
+let run ~sw ~env ~token ~intents ~trigger_policy ~on_event ~on_ambient () =
   let config : Discord_gateway_state.config = {
     token; intents; bot_user_id = None; trigger_policy;
   } in
@@ -183,6 +183,7 @@ let run ~sw ~env ~token ~intents ~trigger_policy ~on_event () =
         Eio.Time.sleep clock (float_of_int delay_ms /. 1000.0);
         Eio.Stream.add input_mailbox Discord_gateway_state.Backoff_elapsed)
     | Emit_event ev -> on_event ev
+    | Emit_ambient ev -> on_ambient ev
     | Log { level; message } -> log_effect level message
   in
 

--- a/lib/gate/discord_gateway_client.mli
+++ b/lib/gate/discord_gateway_client.mli
@@ -60,11 +60,17 @@ val run :
   intents:intent list ->
   trigger_policy:trigger_policy ->
   on_event:(gateway_event -> unit) ->
+  on_ambient:(gateway_event -> unit) ->
   unit ->
   unit
 (** Connect to Discord Gateway, identify with [intents], dispatch
     events that pass [trigger_policy] to [on_event]. Blocks until
     [sw] is closed.
+
+    [on_ambient] receives [Message_create] events that fail
+    [trigger_policy] but are not the bot's own echo (RFC-0226):
+    record-only delivery — the handler persists the line to the bound
+    keeper's lane history and must not start a turn.
 
     Internally:
     1. Create {!Discord_gateway_state.t} with [trigger_policy].

--- a/lib/gate/discord_gateway_state.ml
+++ b/lib/gate/discord_gateway_state.ml
@@ -128,6 +128,7 @@ type gateway_effect =
   | Schedule_heartbeat of { interval_ms : int }
   | Schedule_backoff of { delay_ms : int }
   | Emit_event of dispatched_event
+  | Emit_ambient of dispatched_event
   | Log of { level : [ `Info | `Warn | `Error ]; message : string }
 
 (* ── Config ────────────────────────────────────────────────────── *)
@@ -526,7 +527,18 @@ let handle_dispatch t (frame : frame) =
                ~bot_user_id:t'.config.bot_user_id ~author_id
                ~mentions_bot
            then (t', [ Emit_event ev ])
-           else no_op t'
+           else if is_self ~bot_user_id:t'.config.bot_user_id author_id
+           then
+             (* The bot's own echo: its outbound is persisted at send
+                time (keeper_surface_post / gate reply); recording the
+                gateway echo would double-record by another route. *)
+             no_op t'
+           else
+             (* RFC-0226: policy decides turn start only. A message
+                that fails the trigger policy is still conversation
+                in a channel the bot sits in — deliver it for
+                record-only handling. *)
+             (t', [ Emit_ambient ev ])
        | Ok (Reaction_add { user_id; _ } as ev) ->
            if
              reaction_passes_policy t'.config.trigger_policy

--- a/lib/gate/discord_gateway_state.mli
+++ b/lib/gate/discord_gateway_state.mli
@@ -153,6 +153,11 @@ type gateway_effect =
   | Schedule_heartbeat of { interval_ms : int }
   | Schedule_backoff of { delay_ms : int }
   | Emit_event of dispatched_event   (** Surface to caller's on_event. *)
+  | Emit_ambient of dispatched_event
+      (** Record-only delivery (RFC-0226): a [Message_create] that
+          failed [trigger_policy] but is not the bot's own echo. The
+          I/O layer persists it to the bound keeper's lane history;
+          it must not start a turn. *)
   | Log of { level : [ `Info | `Warn | `Error ]; message : string }
 
 (** {1 Configuration} *)

--- a/lib/gate_keeper_backend.ml
+++ b/lib/gate_keeper_backend.ml
@@ -105,6 +105,29 @@ let dispatch ~sw ~clock ~proc_mgr ~net ~config
       (filesystem_safe_or_unknown channel)
       (filesystem_safe_or_unknown channel_workspace_id)
   in
+  (* RFC-0226: the gate inbound boundary is the sole recorder of
+     connector user lines. Recording happens here — post
+     validation/dedup ([Channel_gate.handle_inbound]), pre turn — so a
+     failed or silent turn cannot drop the inbound message. The reply
+     path ([Keeper_tool_surface_ops.append_direct_chat_pair_if_reply])
+     appends the assistant line only for connector traffic. The line
+     carries the raw [content]; the contextualized wrapper below is
+     turn input, not conversation history. *)
+  let lane = String.trim channel in
+  let opt value = match String.trim value with "" -> None | v -> Some v in
+  Keeper_chat_store.append_user_message
+    ~base_dir:config.Workspace.base_path
+    ~keeper_name:(String.trim keeper_name)
+    ~content:(String.trim content)
+    ~source:lane
+    ~speaker:
+      { Keeper_chat_store.speaker_id = opt channel_user_id
+      ; speaker_name = opt channel_user_name
+      ; speaker_authority = Keeper_chat_store.External
+      }
+    ();
+  Keeper_chat_broadcast.chat_appended
+    ~keeper_name:(String.trim keeper_name) ~source:lane;
   let args =
     `Assoc [
       ("name", `String (String.trim keeper_name));

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -200,6 +200,27 @@ let append_assistant_message ~base_dir ~keeper_name ~(content : string)
     Log.Keeper.warn "keeper_chat_store: assistant append failed for %s: %s"
       (sanitize_name keeper_name) (Printexc.to_string exn)
 
+(* RFC-0226: inbound user line recorded at delivery time, before (and
+   independent of) any turn. A single user line — the assistant reply,
+   if one ever comes, is appended separately by the reply path. *)
+let append_user_message ~base_dir ~keeper_name ~(content : string)
+    ?source ?speaker () =
+  try
+    ensure_dir_once ~base_dir;
+    let path = chat_path ~base_dir ~keeper_name in
+    let ts = Time_compat.now () in
+    let line = encode_line ~role:"user" ~content ~ts ?source ?speaker () in
+    Fs_compat.append_file path (line ^ "\n")
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string ChatStoreFailures)
+      ~labels:[("operation", Keeper_chat_store_operation.(to_label Append))]
+      ();
+    Log.Keeper.warn "keeper_chat_store: user append failed for %s: %s"
+      (sanitize_name keeper_name) (Printexc.to_string exn)
+
 let parse_line ~file_path (line : string) : chat_message option =
   try
     let json = Yojson.Safe.from_string line in

--- a/lib/keeper/keeper_chat_store.mli
+++ b/lib/keeper/keeper_chat_store.mli
@@ -101,6 +101,21 @@ val append_assistant_message :
   unit ->
   unit
 
+(** [append_user_message ~base_dir ~keeper_name ~content ?source
+    ?speaker ()] appends one inbound user line with no paired
+    assistant turn (RFC-0226). Written at delivery time by the inbound
+    recorder — the Discord gateway's ambient arm and the gate dispatch
+    boundary — so the line lands whether or not a turn starts or
+    replies. Same failure policy as {!append_turn}. *)
+val append_user_message :
+  base_dir:string ->
+  keeper_name:string ->
+  content:string ->
+  ?source:string ->
+  ?speaker:speaker ->
+  unit ->
+  unit
+
 (** [load ~base_dir ~keeper_name] returns the most recent messages in
     chronological order: the last 100 user/assistant messages plus the
     tool lines belonging to them (absolute bound 400 lines). Missing

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -543,38 +543,34 @@ let append_direct_chat_pair_if_reply ~(config : Workspace.config) ~name ~args re
         (* Agent-initiated [masc_keeper_msg] path: only the final tool
            result is visible here (no stream events), so no tool lines
            are persisted for this surface. *)
-        (* RFC-0223 P1: the channel gate routes connector traffic
-           (Discord, openclaw, ...) through this same tool path and
-           passes its identity in [channel] / [channel_user_id] /
-           [channel_user_name] ([Gate_keeper_backend.dispatch]). With
-           them present the line carries the lane label and an External
-           speaker instead of the generic "agent" source; without them
-           this is a genuine agent-initiated message. *)
+        (* RFC-0226 ownership split: connector traffic (a non-empty
+           [channel], set by [Gate_keeper_backend.dispatch]) had its
+           user line recorded at the gate inbound boundary, at delivery
+           time — appending it again here would double-record. This
+           site owns the assistant reply only. Without [channel] this
+           is a genuine agent-initiated message with no upstream
+           recorder, so it still owns the full pair. *)
         let channel = String.trim (get_string args "channel" "") in
-        let source, speaker =
-          if channel = "" then ("agent", None)
-          else
-            let opt key =
-              match String.trim (get_string args key "") with
-              | "" -> None
-              | value -> Some value
-            in
-            ( channel,
-              Some
-                { Keeper_chat_store.speaker_id = opt "channel_user_id";
-                  speaker_name = opt "channel_user_name";
-                  speaker_authority = Keeper_chat_store.External } )
-        in
-        Keeper_chat_store.append_turn
-          ~base_dir:config.base_path
-          ~keeper_name:name
-          ~user_content
-          ~user_attachments:[]
-          ~source
-          ?speaker
-          ~assistant_content
-          ();
-        Keeper_chat_broadcast.chat_appended ~keeper_name:name ~source)
+        if channel = "" then begin
+          Keeper_chat_store.append_turn
+            ~base_dir:config.base_path
+            ~keeper_name:name
+            ~user_content
+            ~user_attachments:[]
+            ~source:"agent"
+            ~assistant_content
+            ();
+          Keeper_chat_broadcast.chat_appended ~keeper_name:name ~source:"agent"
+        end
+        else begin
+          Keeper_chat_store.append_assistant_message
+            ~base_dir:config.base_path
+            ~keeper_name:name
+            ~content:assistant_content
+            ~source:channel
+            ();
+          Keeper_chat_broadcast.chat_appended ~keeper_name:name ~source:channel
+        end)
 ;;
 
 (* RFC-0182 Phase 5 PR-B: ctx-free body for [masc_keeper_msg] descriptor

--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -114,6 +114,43 @@ let on_event ~dispatch (ev : Gw.gateway_event) =
   | Gw.Ignored _ ->
     ()
 
+(* RFC-0226 ambient lane recording: a bound-channel message that failed
+   the trigger policy is still conversation the keeper sits in. Persist
+   a single user line — no dispatch, no turn. Unbound channels drop, as
+   on the dispatch path. *)
+let handle_ambient ~base_dir
+      ~(channel_id : string) ~(author_id : string)
+      ~(author_name : string option) ~(content : string) =
+  match State.keeper_for_channel ~channel_id with
+  | None -> ()
+  | Some keeper_name ->
+    let trimmed = String.trim content in
+    if String.equal trimmed "" then ()
+    else if String.length trimmed > Channel_gate.max_content_length () then
+      (* Same inbound bound the turn path enforces
+         ([Channel_gate.handle_inbound] validation): a message this
+         size cannot become a turn either; it is rejected, not
+         truncated. *)
+      ()
+    else begin
+      Keeper_chat_store.append_user_message
+        ~base_dir ~keeper_name ~content:trimmed
+        ~source:State.channel
+        ~speaker:
+          { Keeper_chat_store.speaker_id = Some author_id
+          ; speaker_name = author_name
+          ; speaker_authority = Keeper_chat_store.External
+          }
+        ();
+      Keeper_chat_broadcast.chat_appended ~keeper_name ~source:State.channel
+    end
+
+let on_ambient ~base_dir (ev : Gw.gateway_event) =
+  match ev with
+  | Gw.Message_create { channel_id; author_id; author_name; content; _ } ->
+    handle_ambient ~base_dir ~channel_id ~author_id ~author_name ~content
+  | Gw.Ready _ | Gw.Reaction_add _ | Gw.Ignored _ -> ()
+
 (* ---------------------------------------------------------------- *)
 (* Start                                                            *)
 (* ---------------------------------------------------------------- *)
@@ -149,6 +186,11 @@ let start ~sw ~env ~clock ~state =
           ~intents:default_intents
           ~trigger_policy:policy
           ~on_event:(on_event ~dispatch)
+          ~on_ambient:(fun ev ->
+            (* Read base_path per event: [workspace_config] is mutable
+               (workspace-switch tools swap it). *)
+            on_ambient
+              ~base_dir:state.Mcp_server.workspace_config.base_path ev)
           ()
       with
       | Eio.Cancel.Cancelled _ as e -> raise e

--- a/test/test_discord_gateway_state.ml
+++ b/test/test_discord_gateway_state.ml
@@ -502,6 +502,9 @@ let connected_with_policy ~policy ~bot_user_id =
 let has_emit_event effects =
   List.exists (function S.Emit_event _ -> true | _ -> false) effects
 
+let has_emit_ambient effects =
+  List.exists (function S.Emit_ambient _ -> true | _ -> false) effects
+
 let dispatch_frame ~event_name ~payload ~seq : S.frame =
   { op = S.Op_dispatch
   ; s = Some seq
@@ -637,6 +640,70 @@ let test_policy_all_emits_messages_and_reactions () =
   in
   check bool "Emit_event for any reaction under All" true
     (has_emit_event react_effects)
+
+(* ---------------------------------------------------------------- *)
+(* RFC-0226 — ambient lane recording. A message that fails the      *)
+(* trigger policy (and is not the bot's own echo) is delivered as   *)
+(* Emit_ambient: record-only, never a turn. Policy decides exactly  *)
+(* one thing — whether a turn starts.                               *)
+(* ---------------------------------------------------------------- *)
+
+let step_message m ~author_id ?(mention_ids = []) () =
+  let payload =
+    message_create_payload
+      ~id:"AMB" ~channel_id:"C1" ~author_id ~content:"ambient text"
+      ~mention_ids ()
+  in
+  let _, effects =
+    S.step m ~now_mono:3.0
+      (S.Frame_received
+         (dispatch_frame ~event_name:"MESSAGE_CREATE" ~payload ~seq:9))
+  in
+  effects
+
+let test_ambient_mention_only_plain_message () =
+  let m = connected_with_policy ~policy:S.Mention_only ~bot_user_id:"BOT" in
+  let effects = step_message m ~author_id:"U1" () in
+  check bool "no turn for non-mention" false (has_emit_event effects);
+  check bool "ambient delivery for non-mention" true
+    (has_emit_ambient effects)
+
+let test_ambient_absent_when_policy_passes () =
+  let m = connected_with_policy ~policy:S.Mention_only ~bot_user_id:"BOT" in
+  let effects = step_message m ~author_id:"U1" ~mention_ids:[ "BOT" ] () in
+  check bool "turn for mention" true (has_emit_event effects);
+  check bool "no double delivery when policy passes" false
+    (has_emit_ambient effects)
+
+let test_ambient_user_only_other_author () =
+  let m =
+    connected_with_policy ~policy:(S.User_only "VINCENT") ~bot_user_id:"BOT"
+  in
+  let effects = step_message m ~author_id:"STRANGER" () in
+  check bool "no turn for other author" false (has_emit_event effects);
+  check bool "ambient delivery for other author" true
+    (has_emit_ambient effects)
+
+let test_ambient_never_for_self () =
+  let m = connected_with_policy ~policy:S.All ~bot_user_id:"BOT" in
+  let effects = step_message m ~author_id:"BOT" () in
+  check bool "self echo never a turn" false (has_emit_event effects);
+  check bool "self echo never ambient (outbound persisted at send)"
+    false (has_emit_ambient effects)
+
+let test_ambient_not_for_reactions () =
+  let m = connected_with_policy ~policy:S.Mention_only ~bot_user_id:"BOT" in
+  let payload =
+    reaction_add_payload
+      ~channel_id:"C1" ~message_id:"M1" ~user_id:"U1" ~emoji_name:"👍" ()
+  in
+  let _, effects =
+    S.step m ~now_mono:3.0
+      (S.Frame_received
+         (dispatch_frame ~event_name:"MESSAGE_REACTION_ADD" ~payload ~seq:9))
+  in
+  check bool "a reaction is a trigger signal, not conversation" false
+    (has_emit_ambient effects)
 
 (* ---------------------------------------------------------------- *)
 (* RFC-0203 Phase 3 follow-up — self-skip guard. Bot-authored events *)
@@ -1003,6 +1070,18 @@ let () =
             `Quick test_policy_user_only_reaction_matching_reactor_passes
         ; test_case "all + any message + any reaction => both Emit_event"
             `Quick test_policy_all_emits_messages_and_reactions
+        ] )
+    ; ( "ambient lane (RFC-0226)"
+      , [ test_case "mention_only + plain message => Emit_ambient" `Quick
+            test_ambient_mention_only_plain_message
+        ; test_case "policy pass => Emit_event only, no ambient" `Quick
+            test_ambient_absent_when_policy_passes
+        ; test_case "user_only + other author => Emit_ambient" `Quick
+            test_ambient_user_only_other_author
+        ; test_case "self echo => neither event nor ambient" `Quick
+            test_ambient_never_for_self
+        ; test_case "reactions never ambient" `Quick
+            test_ambient_not_for_reactions
         ] )
     ; ( "self-skip guard"
       , [ test_case "self message suppressed under All" `Quick

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -182,6 +182,48 @@ let test_speaker_external_roundtrip () =
       | messages ->
           Alcotest.failf "expected 2 messages, got %d" (List.length messages))
 
+(* RFC-0226: an inbound line recorded at delivery time stands alone —
+   no paired assistant turn — and a later reply-path assistant append
+   joins it on the same lane without duplicating the user line. *)
+let test_append_user_message_roundtrip () =
+  let base_dir = temp_base_path "keeper-chat-store-ambient" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-ambient" in
+      K.append_user_message ~base_dir ~keeper_name
+        ~content:"two humans chatting, no mention"
+        ~source:"discord"
+        ~speaker:
+          { K.speaker_id = Some "55501";
+            speaker_name = Some "jane";
+            speaker_authority = K.External }
+        ();
+      K.append_assistant_message ~base_dir ~keeper_name
+        ~content:"reply recorded separately" ~source:"discord" ();
+      match K.load ~base_dir ~keeper_name with
+      | [ user; assistant ] ->
+          Alcotest.(check string) "lone user line first" "user" user.K.role;
+          Alcotest.(check string) "content"
+            "two humans chatting, no mention" user.K.content;
+          Alcotest.(check (option string)) "source"
+            (Some "discord") user.K.source;
+          (match user.speaker with
+           | Some sp ->
+               Alcotest.(check (option string)) "speaker id"
+                 (Some "55501") sp.K.speaker_id;
+               Alcotest.(check (option string)) "speaker name"
+                 (Some "jane") sp.K.speaker_name;
+               Alcotest.(check string) "authority external"
+                 "external" (K.authority_label sp.K.speaker_authority)
+           | None -> Alcotest.fail "ambient user line lost its speaker");
+          Alcotest.(check string) "assistant joins the lane"
+            "assistant" assistant.K.role;
+          Alcotest.(check string) "no duplicated user line"
+            "reply recorded separately" assistant.K.content
+      | messages ->
+          Alcotest.failf "expected 2 messages, got %d" (List.length messages))
+
 let test_speaker_owner_roundtrip () =
   let base_dir = temp_base_path "keeper-chat-store-speaker-own" in
   Fun.protect
@@ -314,6 +356,8 @@ let () =
         [
           Alcotest.test_case "external speaker roundtrip" `Quick
             test_speaker_external_roundtrip;
+          Alcotest.test_case "ambient user line roundtrip (RFC-0226)" `Quick
+            test_append_user_message_roundtrip;
           Alcotest.test_case "owner speaker roundtrip" `Quick
             test_speaker_owner_roundtrip;
           Alcotest.test_case "unknown authority reported, not guessed" `Quick


### PR DESCRIPTION
## RFC-0226 P1 — ambient lane recording (기록 ≠ 트리거)

RFC: #20761 (merged, `docs/rfc/RFC-0226-ambient-lane-recording.md`)

### 무엇이 바뀌나

trigger policy는 이제 **턴 시작 여부만** 결정합니다. 기록은 인바운드 delivery 경계가 소유합니다:

| 지점 | 변경 |
|---|---|
| `discord_gateway_state` | `gateway_effect`에 `Emit_ambient` (closed-sum) — policy 탈락 + 비-self `Message_create`를 record-only로 전달. self echo는 어느 쪽도 아님(아웃바운드는 송신 시점에 P4가 영속) |
| `server_discord_in_process_gateway` | ambient arm: 바인딩된 채널이면 External speaker로 단독 user 라인 append + `chat_appended` broadcast. dispatch 없음, 턴 없음. 빈/초과 길이(`Channel_gate.max_content_length`, 턴 경로와 동일 경계)는 기록 안 함 |
| `gate_keeper_backend.dispatch` | **수렴점 기록**: validation/dedup 통과 직후, 턴 시작 전에 user 라인 append — 실패/침묵 턴이 인바운드를 더 이상 유실하지 않음. raw content 기록(`[External channel context]` 래퍼는 턴 입력 전용으로 유지) |
| `append_direct_chat_pair_if_reply` | connector 트래픽(`channel ≠ ""`)은 assistant-only append (경계가 user 라인을 이미 기록). agent 경로(`channel = ""`)는 pair 유지 |
| `keeper_chat_store` | `append_user_message` 신규 (P4 `append_assistant_message`와 대칭, 동일 실패 정책) |

### 구현 중 발견 — RFC §3.3 전제 교정 (별도 docs PR로 후속)

RFC 초안 §3.3은 sidecar가 stream route로 들어온다고 가정했으나, 실측 결과 **imessage-bot / cli-connector는 `POST /api/v1/gate/message`(gate route)로 들어와** Discord와 같은 reply-path 영속에 수렴합니다 (`sidecars/shared/gate_shared/gate_client_base.py`). 따라서 기록 지점을 커넥터별 핸들러가 아니라 수렴점(`Gate_keeper_backend.dispatch`)으로 올렸습니다 — silent-turn 구멍이 **모든 gate 소비자**에서 닫히고, 채널명 문자열 분기(per-connector recorder)도 불필요해집니다. RFC 본문 교정은 #20761이 이미 머지되어 별도 PR로 올립니다.

### 이중 기록 방지 (dedup 기계 없음)

메시지는 정확히 두 경로 중 하나만 탑니다:
- policy 통과 → `Emit_event` → `handle_inbound`(validation/dedup) → `dispatch` 진입부가 기록
- policy 탈락 → `Emit_ambient` → gateway arm이 기록 (dispatch에 도달하지 않음)

reply-path는 connector 행에서 user 라인을 더 이상 쓰지 않으므로, 분리는 구조적으로 exhaustive + disjoint.

### 검증

- `dune build --root . @check` + default target: EXIT=0 (rebase 후 재확인)
- `test_discord_gateway_state`: 46/46 — 신규 "ambient lane (RFC-0226)" 그룹 5종: mention_only 탈락→ambient / policy 통과→event만(이중 전달 없음) / user_only 타 작성자→ambient / self→어느 쪽도 아님 / reaction→ambient 아님
- `test_keeper_chat_store`: 10/10 — ambient user 라인 round-trip (단독 user 라인 + 이후 assistant 합류, user 라인 중복 없음, speaker/source 보존)
- 연관 스위트 green: surface_read 6, surface_post 7, channel_gate 14, gate_surface 8, presence_prompt 4

### 미검증 / 한계

- `Gate_keeper_backend.dispatch`의 기록 부분은 unit test 미포함 (실 dispatch는 sw/clock/proc_mgr/net + 실제 keeper 턴 필요). store 함수 round-trip + code-read로 커버. 수동 검증 절차는 RFC §6.
- 존재하지 않는 keeper_name으로 HTTP gate 호출 시 빈 lane 파일이 생길 수 있음 (sanitized 파일명, Bearer auth 뒤 surface — 수용).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
