### PR TITLE
fix(keeper): pass board_health_score as optional arg, unbreak main

### DIFF
--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -695,7 +695,7 @@ let keeper_cycle_decision
             ~base_cooldown:meta.proactive.cooldown_sec
             ~since_last:since_last_scheduled_autonomous
             ~consecutive_noop_count:meta.runtime.proactive_rt.consecutive_noop_count
-            ~board_health_score
+            ?board_health_score
             ()
         in
         let task_cooldown_divisor =


### PR DESCRIPTION
## main 빌드 복구 — `board_health_score` optional-arg 전달 오류

`6fe5ad4a9` (feat(scheduler): adjust autonomous turn frequency based on board health_score)가 main을 깨뜨렸습니다:

- 호출부(`keeper_world_observation.ml:698`)는 로컬에서 계산한 `float option`을 `~board_health_score`(labeled)로 전달
- 시그니처는 `?board_health_score:float` (`.mli:273`) — labeled 전달은 외부 타입 `float`을 요구 → **모든 빌드에서 type error**
- 해당 커밋의 `Build and Test`는 surface gate로 **skipped** → broken main으로 머지됨 (24h 내 gate-skip broken-main 4번째: R6 ratchet ×2, doc-truth, 이번 빌드)

### 수정

`~board_health_score` → `?board_health_score` 1줄. `?label:expr`는 option을 그대로 전달하므로 작성자 의도(`None` = 무조정, `Some h` = health 기반 cooldown 조정)가 보존됩니다.

### 검증

- `dune build --root . @check` EXIT=0, default target EXIT=0 (동일 base에서 확인)
- 수정 없이 재현: `keeper_world_observation.ml:698` "This value has type float option but an expression was expected of type float"

### 참고

gate-skip 구조 결함(검사 입력 파일 ↔ 스킵 조건 불일치)은 별도 이슈로 기록 예정 — 이번 건은 docs-only가 아니라 **`.ml` 변경인데도 skipped**라 클래스가 다를 수 있어, 해당 run의 gate 판정 로그 확인이 필요합니다.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
