### PR TITLE
perf(keeper): tail-bounded keeper_chat_store.load (RFC-0226 P2)

### DIFF
--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -306,13 +306,26 @@ let rec drop_leading_tool_messages = function
   | msg :: rest when is_tool_message msg -> drop_leading_tool_messages rest
   | messages -> messages
 
+(* RFC-0226 P2: [load] serves a fixed window ([max_total_lines]) but
+   used to read and JSON-parse the whole file to build it, so its cost
+   scaled with lane size — the same pathology family as the
+   2026-06-09 telemetry-JSONL incident (multi-MB files starving the
+   Eio domain). Read a bounded tail instead: [max_total_lines] lines
+   at ~10 KiB each leaves wide slack over the gate's 4 KB content
+   bound. A tail whose recent lines are larger (attachment payloads)
+   degrades to a shorter window, never to an error or a full scan. *)
+let tail_read_bytes = 4 * 1024 * 1024
+
 let load ~base_dir ~keeper_name : chat_message list =
   let path = chat_path ~base_dir ~keeper_name in
   if not (Sys.file_exists path) then []
   else
   try
-    let content = Fs_compat.load_file path in
-    let lines = String.split_on_char '\n' content in
+    let from =
+      match Fs_compat.file_size path with
+      | Some size when size > tail_read_bytes -> size - tail_read_bytes
+      | Some _ | None -> 0
+    in
     (* Single pass: keep a running window of the last [max_history]
        user/assistant messages plus their tool lines. *)
     let q = Queue.create () in
@@ -321,22 +334,30 @@ let load ~base_dir ~keeper_name : chat_message list =
       let popped = Queue.pop q in
       if not (is_tool_message popped) then decr primary_count
     in
-    List.iter
-      (fun line ->
-        let trimmed = String.trim line in
-        if trimmed <> "" then
-          match parse_line ~file_path:path trimmed with
-          | Some msg ->
-              Queue.push msg q;
-              if not (is_tool_message msg) then incr primary_count;
-              while
-                !primary_count > max_history
-                || Queue.length q > max_total_lines
-              do
-                pop_front ()
-              done
-          | None -> ())
-      lines;
+    (* A mid-line [from] makes the first folded item a line fragment;
+       dropping it unconditionally when [from > 0] also drops one full
+       line when [from] lands exactly on a boundary — irrelevant under
+       the window's slack, and it keeps fragment noise out of the
+       read-drop metrics. *)
+    let skip_partial_first = ref (from > 0) in
+    let (), _boundary =
+      Fs_compat.fold_appended_lines ~path ~from ~init:() ~f:(fun () line ->
+        if !skip_partial_first then skip_partial_first := false
+        else
+          let trimmed = String.trim line in
+          if trimmed <> "" then
+            match parse_line ~file_path:path trimmed with
+            | Some msg ->
+                Queue.push msg q;
+                if not (is_tool_message msg) then incr primary_count;
+                while
+                  !primary_count > max_history
+                  || Queue.length q > max_total_lines
+                do
+                  pop_front ()
+                done
+            | None -> ())
+    in
     Queue.fold (fun acc msg -> msg :: acc) [] q
     |> List.rev
     |> drop_leading_tool_messages

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -300,6 +300,51 @@ let test_orphan_leading_tool_lines_trimmed () =
       Alcotest.(check (list string)) "leading orphan tool trimmed"
         [ "user"; "assistant" ] (roles messages))
 
+(* RFC-0226 P2: a lane larger than the tail-read bound must still
+   yield exactly the window a full scan would — the bound only caps
+   bytes read, never changes window semantics. 5,200 x ~1 KiB lines
+   ≈ 5.3 MiB > the 4 MiB tail bound, so [load] starts mid-file. *)
+let test_tail_bounded_load_matches_full_scan_window () =
+  let base_dir = temp_base_path "keeper-chat-store-tail" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-tail" in
+      let path = chat_path ~base_dir ~keeper_name in
+      let padding = String.make 1000 'x' in
+      let total = 5200 in
+      let buf = Buffer.create (total * 1100) in
+      for i = 1 to total do
+        let role = if i mod 2 = 1 then "user" else "assistant" in
+        let line =
+          Yojson.Safe.to_string
+            (`Assoc
+               [ ("role", `String role);
+                 ("content", `String (Printf.sprintf "msg-%04d %s" i padding));
+                 ("ts", `Float (float_of_int i));
+               ])
+        in
+        Buffer.add_string buf line;
+        Buffer.add_char buf '\n'
+      done;
+      write_file path (Buffer.contents buf);
+      let messages = K.load ~base_dir ~keeper_name in
+      Alcotest.(check int) "window is 100 primaries" 100 (List.length messages);
+      let content_prefix (m : K.chat_message) = String.sub m.K.content 0 8 in
+      (match messages with
+       | first :: _ ->
+           Alcotest.(check string) "window starts at line 5101"
+             "msg-5101" (content_prefix first);
+           Alcotest.(check string) "line 5101 is a user line" "user" first.K.role
+       | [] -> Alcotest.fail "expected non-empty window");
+      (match List.rev messages with
+       | last :: _ ->
+           Alcotest.(check string) "window ends at line 5200"
+             "msg-5200" (content_prefix last);
+           Alcotest.(check string) "line 5200 is an assistant line"
+             "assistant" last.K.role
+       | [] -> Alcotest.fail "expected non-empty window"))
+
 let () =
   Alcotest.run "keeper_chat_store"
     [
@@ -329,5 +374,7 @@ let () =
             test_window_keeps_tool_lines_of_retained_turns;
           Alcotest.test_case "orphan leading tool lines trimmed" `Quick
             test_orphan_leading_tool_lines_trimmed;
+          Alcotest.test_case "tail-bounded load matches full-scan window (RFC-0226 P2)"
+            `Quick test_tail_bounded_load_matches_full_scan_window;
         ] );
     ]


### PR DESCRIPTION
## RFC-0226 P2 — tail-bounded `keeper_chat_store.load`

RFC: #20761 (merged), §3.4. P1(#20771)과 독립 — 어느 쪽이 먼저 머지돼도 됩니다 (RFC §4).

### 문제

`load`는 고정 윈도우(마지막 100 primaries / 절대 400줄)만 반환하지만, 윈도우를 만들기 위해 **파일 전체를 읽고 전 라인을 Yojson 파싱**했습니다 (`Fs_compat.load_file` + full scan). 읽기 비용이 lane 파일 크기에 비례 — 2026-06-09 telemetry JSONL CPU 기아(50–82MB 파일이 Eio 도메인 독점)와 같은 병리 계열입니다. P1의 ambient 기록은 바쁜 채널의 쓰기량 클래스를 바꾸므로, 읽기 경로가 파일 크기에 비례하지 않게 만드는 것이 root fix입니다 (쓰기 cap은 owner constraint 위반 — RFC §2 원칙 5).

### 수정

- `tail_read_bytes = 4 MiB`: `file_size - bound`로 seek 후 `Fs_compat.fold_appended_lines`(기존 프리미티브, 오프셋 시작 + partial-line 계약)로 폴드
- `from > 0`이면 첫 폴드 라인을 무조건 드랍 — mid-line 시작의 fragment 제거. `from`이 정확히 라인 경계면 유효 라인 1개를 더 버리지만 윈도우 슬랙(400줄 ≪ 4 MiB) 안에서 무해하고, fragment가 read-drop 메트릭에 위양성 노이즈를 내지 않게 함
- bound 미만 파일은 `from = 0` — 기존과 동일 경로. 윈도우 의미는 불변, 읽는 바이트만 capped
- 첨부(base64) 등으로 최근 라인이 비대한 파일은 윈도우가 짧아지는 방향으로 degrade — 에러도, full scan도 아님

### 검증

- `dune build --root . @check` + default: EXIT=0
- `test_keeper_chat_store` 10/10 — 신규: 5,200 × ~1 KiB(≈5.3 MiB > bound) lane에서 full-scan과 동일한 윈도우(5101–5200, role 보존). 기존 윈도우/orphan-trim 테스트는 `from=0` 경로 회귀 커버
- 참고: 로컬 검증 시점의 main(`6fe5ad4a9`)은 무관한 타입 에러로 깨져 있어 #20773 fix를 로컬에만 얹어 검증했습니다 (이 PR에는 미포함). CI는 #20773 머지 후 green이 됩니다.

### 한계

- 4 MiB 상수는 측정 기반이 아니라 슬랙 기반(400줄 × ~10 KiB, gate content 4 KB 경계의 10×). 실측 후 조정 여지는 있으나 상수 위치가 한 곳이라 변경 비용 낮음.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
