### PR TITLE
ci(rfc): require ledger bump on RFC claims, wire numbering into Meta Guards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,6 +370,24 @@ jobs:
             --recent-main 50 \
             --duplicate-policy warn
 
+      - name: RFC numbering + ledger claim guard
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: origin/${{ github.base_ref }}
+          HEAD_REF: ${{ github.event.pull_request.head.sha }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # Runs on every PR (not gated on a changes output) so the gate
+          # cannot be skipped by the very class of mismatch it guards
+          # against (#20776). Cheap: pure git metadata + one gh call.
+          bash scripts/ci/git-fetch-retry.sh origin "${{ github.base_ref }}" --depth=200
+          PR_BODY="$(gh pr view "$PR_NUMBER" --json body --jq .body || echo "")"
+          export PR_BODY
+          python3 scripts/rfc_enforcer.py \
+            --check-numbering --base-ref "$BASE_REF" --head-ref "$HEAD_REF"
+          python3 scripts/rfc_enforcer.py --check-ledger-monotonic
+
       - name: Check doc truth
         if: needs.changes.outputs.doc_truth == 'true'
         run: |

--- a/scripts/rfc_enforcer.py
+++ b/scripts/rfc_enforcer.py
@@ -335,7 +335,70 @@ def check_numbering(base_ref: str, head_ref: str, pr_body: str) -> List[Violatio
             )
         )
 
+    violations.extend(_check_ledger_bumped(head_ref, added, optin))
     return violations
+
+
+def _ledger_value_at(ref: str) -> Optional[int]:
+    """Return .next-number parsed from the given ref, or None."""
+    try:
+        out = _git("show", f"{ref}:docs/rfc/.next-number")
+    except subprocess.CalledProcessError:
+        return None
+    value = out.strip()
+    if re.fullmatch(r"[0-9]{4}", value) is None:
+        return None
+    return int(value)
+
+
+def _check_ledger_bumped(
+    head_ref: str, added: List[str], optin: Set[str]
+) -> List[Violation]:
+    """Require a PR that claims a new RFC number to move the ledger past it.
+
+    Collision against base_ref only catches a race after one side merges.
+    When the claiming PR must also bump docs/rfc/.next-number in the same
+    PR, two concurrent claims of the frontier number both rewrite the
+    ledger line, so the second one surfaces at merge time (conflict or a
+    rerun collision) instead of landing silently (the #20764 / #20761
+    race, same class as #20717 / #20718).
+    """
+    claimed: List[int] = []
+    for path in added:
+        m = _RFC_FILENAME_RE.match(Path(path).name)
+        if m is None or m.group(1) in optin:
+            continue
+        claimed.append(int(m.group(1)))
+    if not claimed:
+        return []
+    highest = max(claimed)
+    ledger = _ledger_value_at(head_ref)
+    if ledger is None:
+        return [
+            Violation(
+                Path("docs/rfc/.next-number"),
+                0,
+                "RFC_LEDGER_UNREADABLE",
+                f"PR adds RFC-{highest:04d} but docs/rfc/.next-number on "
+                f"{head_ref} is missing or not a 4-digit number.",
+            )
+        ]
+    if ledger <= highest:
+        return [
+            Violation(
+                Path("docs/rfc/.next-number"),
+                0,
+                "RFC_LEDGER_NOT_BUMPED",
+                (
+                    f"PR adds RFC-{highest:04d} but .next-number is "
+                    f"{ledger:04d}. Bump docs/rfc/.next-number to at least "
+                    f"{highest + 1:04d} in the same PR (scripts/"
+                    "rfc-allocate-next.sh does both) so a concurrent claim "
+                    "of the same number conflicts instead of merging."
+                ),
+            )
+        ]
+    return []
 
 
 def main() -> int:


### PR DESCRIPTION
## RFC 번호 open-PR 레이스의 결정론적 차단 — #20776 제안 3

### 문제

`check-numbering`은 base(main) 대비 충돌만 봅니다. 두 PR이 동시에 같은 번호를 점유하면 둘 다 green → 한쪽 머지 후에야 다른 쪽이 충돌 — 그마저 stale green check면 그냥 머지됩니다. 실제 2회 발생: #20717 vs #20718 (0223), #20761 vs #20764 (0226, 오늘 개번 처리). 공통점: **점유 PR이 `.next-number`를 bump하지 않아** ledger가 레이스를 못 잡았습니다.

### 수정

1. **`RFC_LEDGER_NOT_BUMPED` 규칙** (rfc_enforcer): `RFC-NNNN` 파일을 추가하는 PR은 같은 PR에서 `.next-number`를 NNNN+1 이상으로 bump해야 함. 동시 점유 시 두 PR이 같은 ledger 라인을 고치므로 **두 번째가 merge conflict 또는 rerun 충돌로 표면화** — 침묵 머지 불가. ledger보다 낮은 gap 번호 점유는 기존 collision 규칙 소관이라 면제, `RFC-EXTEND` opt-in 불변.
2. **Meta Guards 편입** (ci.yml): 기존 `rfc-number-collision-check` 워크플로는 path-filtered 별도 워크플로라 required가 될 수 없습니다 (required + path-filter = 무관 PR이 "expected"로 영구 블록되는 함정). Meta Guards는 모든 heavy PR에서 돌고 `CI Gate`(required)가 집계하므로, 이 경로로 사실상 required가 됩니다. changes output에 게이트하지 않고 항상 실행 — **게이트-스킵으로 게이트를 우회하는 클래스(#20776) 자체를 차단**. 비용: git 메타데이터 + gh 1콜.

### 검증

- 양성: 개번된 #20764 head (0227 점유, ledger 0228) → no collisions
- 음성: bump 없는 RFC-0229 합성 점유 → `RFC_LEDGER_NOT_BUMPED`, exit 1
- 회귀: gap 번호(RFC-0100) 점유 → 기존 `RFC_NUMBER_COLLISION` 그대로
- ci.yml: yaml.safe_load OK

### 같은 트랙에서 함께 처리된 것 (이 PR 밖)

- `enforce_admins=true` 적용 완료 (API, 즉시 발효) — `6fe5ad4a9` 직접 push 클래스 차단. 사건 4는 gate-skip이 아니라 **CI가 돌아서 failure였는데 push가 우회**한 것임을 check-runs로 확정했습니다 (#20776에 정정 코멘트 예정).
- gate-skip docs 클래스(사건 1·2)는 #20729(lint superset) + doc_truth 패턴으로 이미 교정되어 있음을 확인.

Closes 일부: #20776 (제안 1은 별도 — 스킵 조건의 입력 파일 유도는 후속)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
