### PR TITLE
fix(discord): complete send_message signature migration, unbreak main

### DIFF
--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -131,7 +131,7 @@ let handle_surface_post ~config ~(meta : keeper_meta) ~args =
           ~source:"dashboard";
         Keeper_surface_post.ok_json ~surface ()
     | Ok (Keeper_surface_post.To_discord { channel_id }) -> (
-        match Channel_gate_discord_state.send_message ~channel_id ~content with
+        match Channel_gate_discord_state.send_message ~channel_id ~content () with
         | Error send_error ->
             Keeper_surface_post.error_json
               (Format.asprintf "discord send failed: %a"

--- a/test/test_channel_gate_discord_state_in_process.ml
+++ b/test/test_channel_gate_discord_state_in_process.ml
@@ -70,7 +70,7 @@ let test_send_message_without_token_returns_missing_token () =
 
 let test_send_message_with_whitespace_token_returns_missing_token () =
   setenv "DISCORD_BOT_TOKEN" "   ";
-  (match State.send_message ~channel_id:"123" ~content:"hi" with
+  (match State.send_message ~channel_id:"123" ~content:"hi" () with
    | Error State.Missing_token -> ()
    | Error other ->
      fail

--- a/test/test_discord_rest_client.ml
+++ b/test/test_discord_rest_client.ml
@@ -18,7 +18,7 @@ let header_value headers name =
 
 let test_build_request_url_targets_channel () =
   let url, _, _ =
-    R.build_request ~token:"abc" ~channel_id:"1234567890" ~content:"hi"
+    R.build_request ~token:"abc" ~channel_id:"1234567890" ~content:"hi" ()
   in
   check string "v10 channel URL"
     "https://discord.com/api/v10/channels/1234567890/messages"
@@ -26,7 +26,7 @@ let test_build_request_url_targets_channel () =
 
 let test_build_request_authorization_uses_bot_scheme () =
   let _, headers, _ =
-    R.build_request ~token:"sekret" ~channel_id:"CH" ~content:"."
+    R.build_request ~token:"sekret" ~channel_id:"CH" ~content:"." ()
   in
   check string "Authorization header" "Bot sekret"
     (header_value headers "Authorization");
@@ -35,7 +35,7 @@ let test_build_request_authorization_uses_bot_scheme () =
 
 let test_build_request_user_agent_present () =
   let _, headers, _ =
-    R.build_request ~token:"t" ~channel_id:"c" ~content:"."
+    R.build_request ~token:"t" ~channel_id:"c" ~content:"." ()
   in
   let ua = header_value headers "User-Agent" in
   (* Discord requires DiscordBot ($url, $version) shape. *)
@@ -45,7 +45,7 @@ let test_build_request_user_agent_present () =
 
 let test_build_request_body_is_content_object () =
   let _, _, body =
-    R.build_request ~token:"t" ~channel_id:"c" ~content:"hello \"world\""
+    R.build_request ~token:"t" ~channel_id:"c" ~content:"hello \"world\"" ()
   in
   let json = Yojson.Safe.from_string body in
   match json with


### PR DESCRIPTION
## main 빌드 복구 (오늘 2번째, 클래스는 다름)

#20777이 `send_message`/`build_request`에 `?reply_to_message_id` + `unit`을 추가하면서 **call site 6곳을 미이행** — `keeper_surface_post` discord arm(`keeper_tool_in_process_runtime.ml:134`) + 자체 테스트 5곳. main 전체 빌드가 partial-application 타입 에러로 사망.

### 원인 클래스: stale merge-ref (gate-skip 아님)

branch protection이 `required_status_checks.strict=false`라, green check를 받은 뒤 base가 전진해도 재검증 없이 머지됩니다. #20777은 자기 시점엔 green이었고, 시그니처와 충돌하는 P4 call site는 머지 후에야 만났습니다. `enforce_admins`(오늘 적용)로는 못 막는 잔여 구멍 — `strict=true`로 막을 수 있으나 모든 PR이 base 전진마다 rebase+재CI를 요구하게 되어 이 repo의 머지 속도와 정면 충돌합니다. 판단 필요해서 일단 켜지 않았습니다 (#20776에 기록).

### 수정

6곳에 `()` (surface_post는 reply 참조 없는 일반 발화라 `?reply_to_message_id` 미사용이 올바른 의미).

### 검증

- `dune build @check` EXIT=0
- `test_discord_rest_client` 10/10, `test_channel_gate_discord_state_in_process` 7/7

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
