### PR TITLE
feat(keeper): paged lane pull — before-ts walk with bounded reads (RFC-0228 P1)

### DIFF
--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -448,6 +448,28 @@ let load_jsonl_diagnostics (path : string) : Yojson.Safe.t list * int =
     Malformed lines are logged and dropped. *)
 let load_jsonl (path : string) : Yojson.Safe.t list = fst (load_jsonl_diagnostics path)
 
+(* Bounded byte slice of a file. Clamps to the current size; a missing
+   file or an empty clamped range returns "". Stdlib-blocking like the
+   other tail-readers — callers bound [len], so the read cost is fixed
+   regardless of file size (RFC-0228 P1). *)
+let read_slice ~path ~from ~len =
+  if not (file_exists path) || len <= 0 then ""
+  else begin
+    let ic = Stdlib.open_in_bin path in
+    Stdlib.Fun.protect
+      ~finally:(fun () -> Stdlib.close_in_noerr ic)
+      (fun () ->
+         let size = Stdlib.in_channel_length ic in
+         let from = if from < 0 then 0 else if from > size then size else from in
+         let len = Stdlib.min len (size - from) in
+         if len <= 0 then ""
+         else begin
+           Stdlib.seek_in ic from;
+           Stdlib.really_input_string ic len
+         end)
+  end
+;;
+
 (* Fold over newline-terminated lines appended after byte offset [from].
    Append-only JSONL stores never rewrite earlier bytes, so a (offset,
    accumulator) pair is a pure function of the file prefix — callers cache

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -158,6 +158,12 @@ val fold_jsonl_lines
     truncated or rotated) restarts the scan from byte 0. Returns
     [(init, 0)] when [path] does not exist. Lines are raw strings;
     callers parse (and decide how to surface malformed rows). *)
+(** [read_slice ~path ~from ~len] returns the byte slice
+    [[from, from+len)] of the file, clamped to its current size.
+    Missing file or empty clamped range returns [""]. Callers bound
+    [len], so one call never scales with file size (RFC-0228 P1). *)
+val read_slice : path:string -> from:int -> len:int -> string
+
 val fold_appended_lines
   :  path:string
   -> from:int

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -337,58 +337,123 @@ let rec drop_leading_tool_messages = function
    degrades to a shorter window, never to an error or a full scan. *)
 let tail_read_bytes = 4 * 1024 * 1024
 
-let load ~base_dir ~keeper_name : chat_message list =
+(* RFC-0228 P1: binary-search probes for [before]-paging are tiny
+   bounded reads; a probe only needs to span a handful of lines. A
+   probe landing inside an oversized line degrades the cut estimate
+   (shorter window), never correctness — the final ts filter discards
+   overshoot rows. *)
+let probe_bytes = 256 * 1024
+
+type page = { messages : chat_message list; has_more : bool }
+
+(* Lines of the byte slice [[from, upto)). When [from > 0] the first
+   element is a (potentially partial) line fragment — dropped, same
+   rationale as the RFC-0226 P2 tail read. A final element without a
+   terminating '\n' (mid-line [upto], or a writer-in-flight tail) is
+   dropped the same way; split yields [""] there for boundary cuts, so
+   only true fragments are removed. *)
+let slice_lines ~path ~from ~upto : string list =
+  if upto <= from then []
+  else
+    let slice = Fs_compat.read_slice ~path ~from ~len:(upto - from) in
+    let lines = String.split_on_char '\n' slice in
+    let lines = match lines with _ :: rest when from > 0 -> rest | l -> l in
+    match List.rev lines with
+    | last :: rev_rest when last <> "" -> List.rev rev_rest
+    | _ -> lines
+
+(* Metric-quiet ts extractor for probes: probed lines are re-read by
+   the real parse later, so a malformed row must not double-count in
+   the read-drop metrics. *)
+let quiet_line_ts line : float option =
+  try
+    match Json_util.assoc_member_opt "ts" (Yojson.Safe.from_string line) with
+    | Some (`Float f) -> Some f
+    | _ -> None
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | _ -> None
+
+let probe_ts ~path ~size pos : float option =
+  let upto = min size (pos + probe_bytes) in
+  List.find_map
+    (fun line ->
+      let trimmed = String.trim line in
+      if trimmed = "" then None else quiet_line_ts trimmed)
+    (slice_lines ~path ~from:pos ~upto)
+
+(* Largest prefix [[0, cut)) holding only lines with ts < [before].
+   Append-only wall-clock stamps make line ts monotone in byte offset,
+   so this is a plain byte-offset binary search: ~log2(size/probe)
+   probes, each bounded. The returned cut overshoots by at most one
+   probe window; callers filter by ts. *)
+let find_cut ~path ~size ~before : int =
+  let lo = ref 0 and hi = ref size in
+  while !hi - !lo > probe_bytes do
+    let mid = !lo + ((!hi - !lo) / 2) in
+    match probe_ts ~path ~size mid with
+    | Some t when t < before -> lo := mid
+    | Some _ | None -> hi := mid
+  done;
+  !hi
+
+let load_page ~base_dir ~keeper_name ?before () : page =
   let path = chat_path ~base_dir ~keeper_name in
-  if not (Sys.file_exists path) then []
+  if not (Sys.file_exists path) then { messages = []; has_more = false }
   else
   try
-    let from =
-      match Fs_compat.file_size path with
-      | Some size when size > tail_read_bytes -> size - tail_read_bytes
-      | Some _ | None -> 0
+    let size = Option.value (Fs_compat.file_size path) ~default:0 in
+    let upto, keep =
+      match before with
+      | None -> (size, fun (_ : chat_message) -> true)
+      | Some b ->
+          (* Rows without ts (legacy) are unorderable and stay
+             unreachable through paging; the tail window still serves
+             them. *)
+          ( find_cut ~path ~size ~before:b,
+            fun (m : chat_message) ->
+              match m.ts with Some t -> t < b | None -> false )
     in
+    let from = if upto > tail_read_bytes then upto - tail_read_bytes else 0 in
     (* Single pass: keep a running window of the last [max_history]
        user/assistant messages plus their tool lines. *)
     let q = Queue.create () in
     let primary_count = ref 0 in
+    let evicted = ref false in
     let pop_front () =
+      evicted := true;
       let popped = Queue.pop q in
       if not (is_tool_message popped) then decr primary_count
     in
-    (* A mid-line [from] makes the first folded item a line fragment;
-       dropping it unconditionally when [from > 0] also drops one full
-       line when [from] lands exactly on a boundary — irrelevant under
-       the window's slack, and it keeps fragment noise out of the
-       read-drop metrics. *)
-    let skip_partial_first = ref (from > 0) in
-    let (), _boundary =
-      Fs_compat.fold_appended_lines ~path ~from ~init:() ~f:(fun () line ->
-        if !skip_partial_first then skip_partial_first := false
-        else
-          let trimmed = String.trim line in
-          if trimmed <> "" then
-            match parse_line ~file_path:path trimmed with
-            | Some msg ->
-                Queue.push msg q;
-                if not (is_tool_message msg) then incr primary_count;
-                while
-                  !primary_count > max_history
-                  || Queue.length q > max_total_lines
-                do
-                  pop_front ()
-                done
-            | None -> ())
+    List.iter
+      (fun line ->
+        let trimmed = String.trim line in
+        if trimmed <> "" then
+          match parse_line ~file_path:path trimmed with
+          | Some msg when keep msg ->
+              Queue.push msg q;
+              if not (is_tool_message msg) then incr primary_count;
+              while
+                !primary_count > max_history
+                || Queue.length q > max_total_lines
+              do
+                pop_front ()
+              done
+          | Some _ | None -> ())
+      (slice_lines ~path ~from ~upto);
+    let messages =
+      Queue.fold (fun acc msg -> msg :: acc) [] q
+      |> List.rev
+      |> drop_leading_tool_messages
     in
-    Queue.fold (fun acc msg -> msg :: acc) [] q
-    |> List.rev
-    |> drop_leading_tool_messages
+    { messages; has_more = from > 0 || !evicted }
   with
   | Sys_error detail ->
       report_persistence_read_drop
         ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
         ~path
         ~detail;
-      []
+      { messages = []; has_more = false }
   | exn ->
       Otel_metric_store.inc_counter
         Keeper_metrics.(to_string ChatStoreFailures)
@@ -396,7 +461,10 @@ let load ~base_dir ~keeper_name : chat_message list =
         ();
       Log.Keeper.warn "keeper_chat_store: load failed for %s: %s"
         (sanitize_name keeper_name) (Printexc.to_string exn);
-      []
+      { messages = []; has_more = false }
+
+let load ~base_dir ~keeper_name : chat_message list =
+  (load_page ~base_dir ~keeper_name ()).messages
 
 let to_json_array (messages : chat_message list) : Yojson.Safe.t =
   `List

--- a/lib/keeper/keeper_chat_store.mli
+++ b/lib/keeper/keeper_chat_store.mli
@@ -123,6 +123,20 @@ val append_user_message :
 val load :
   base_dir:string -> keeper_name:string -> chat_message list
 
+type page = { messages : chat_message list; has_more : bool }
+
+(** [load_page ~base_dir ~keeper_name ?before ()] is the paged form of
+    {!load} (RFC-0228 P1): with [before] (a message [ts]) it returns
+    the window of messages strictly older than that stamp; without it,
+    the tail window. [has_more] reports whether rows older than the
+    returned window remain — walk backward by passing the oldest
+    returned [ts] as the next [before]. Bounded I/O per call:
+    binary-search probes plus one window slice, never a full scan.
+    Legacy rows without [ts] are unreachable through paging (the tail
+    window still serves them). *)
+val load_page :
+  base_dir:string -> keeper_name:string -> ?before:float -> unit -> page
+
 (** {1 Serialisation} *)
 
 (** JSON array of messages. Entries without a timestamp omit the

--- a/lib/keeper/keeper_surface_read.ml
+++ b/lib/keeper/keeper_surface_read.ml
@@ -105,7 +105,20 @@ let take_last n items =
     in
     drop (len - n) items
 
-let respond ~surface ~limit (messages : Store.chat_message list) : string =
+(* Oldest ts across the whole loaded page (not just the lane filter):
+   passing it back as the next [before] guarantees walk progress even
+   when a page holds no rows for the requested lane (RFC-0228 P1). *)
+let page_oldest_ts (messages : Store.chat_message list) : float option =
+  List.fold_left
+    (fun acc (m : Store.chat_message) ->
+      match (acc, m.ts) with
+      | None, ts -> ts
+      | Some a, Some t when t < a -> Some t
+      | some, _ -> some)
+    None messages
+
+let respond ~surface ~limit ~has_more (messages : Store.chat_message list) :
+    string =
   let surface = String.trim surface in
   if surface = "" then
     Yojson.Safe.to_string
@@ -130,10 +143,12 @@ let respond ~surface ~limit (messages : Store.chat_message list) : string =
     let shown = take_last limit lane in
     Yojson.Safe.to_string
       (`Assoc
-        [
-          ("surface", `String surface);
-          ("messages", `List (List.map message_json shown));
-          ("participants", `List (List.map participant_json (roster lane)));
-          ("lane_row_count", `Int (List.length lane));
-          ("returned", `Int (List.length shown));
-        ])
+        ([
+           ("surface", `String surface);
+           ("messages", `List (List.map message_json shown));
+           ("participants", `List (List.map participant_json (roster lane)));
+           ("lane_row_count", `Int (List.length lane));
+           ("returned", `Int (List.length shown));
+           ("has_more", `Bool has_more);
+         ]
+        @ opt_float_field "oldest_ts" (page_oldest_ts messages)))

--- a/lib/keeper/keeper_surface_read.mli
+++ b/lib/keeper/keeper_surface_read.mli
@@ -22,21 +22,27 @@ type participant = {
 val default_limit : int
 val max_limit : int
 
-(** [respond ~surface ~limit messages] filters [messages] to rows whose
-    [source] label equals [surface] (trimmed, exact), returning a JSON
-    object string:
-    [{surface, messages, participants, lane_row_count, returned}].
+(** [respond ~surface ~limit ~has_more messages] filters [messages] to
+    rows whose [source] label equals [surface] (trimmed, exact),
+    returning a JSON object string: [{surface, messages, participants,
+    lane_row_count, returned, has_more, oldest_ts?}].
 
     - [messages]: the last [limit] lane rows (chronological), each with
       role/content/ts/source and speaker fields when present — the
       same field vocabulary as the REST history endpoint.
     - [participants]: roster folded over ALL loaded lane rows (not just
       the returned slice), sorted by [last_seen] descending.
+    - [has_more] / [oldest_ts] (RFC-0228 P1): [oldest_ts] is the oldest
+      stamp across the whole loaded page — not just the lane — so
+      passing it as the next call's [before] always makes progress,
+      even through pages with no rows for this lane. Omitted when the
+      page carries no stamped rows.
     - Rows without a [source] label (written before source labelling)
       never match; the description of the tool says so.
     - Blank [surface] is an error JSON, not a default lane. *)
 val respond :
   surface:string ->
   limit:int ->
+  has_more:bool ->
   Keeper_chat_store.chat_message list ->
   string

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -90,12 +90,17 @@ let handle_surface_read ~config ~(meta : keeper_meta) ~args =
   let limit =
     Safe_ops.json_int ~default:Keeper_surface_read.default_limit "limit" args
   in
-  let messages =
-    Keeper_chat_store.load
+  let before = Safe_ops.json_float_opt "before" args in
+  let page =
+    Keeper_chat_store.load_page
       ~base_dir:config.Workspace.base_path
       ~keeper_name:meta.name
+      ?before
+      ()
   in
-  Keeper_surface_read.respond ~surface ~limit messages
+  Keeper_surface_read.respond ~surface ~limit
+    ~has_more:page.Keeper_chat_store.has_more
+    page.Keeper_chat_store.messages
 ;;
 
 let handle_surface_post ~config ~(meta : keeper_meta) ~args =
@@ -131,7 +136,7 @@ let handle_surface_post ~config ~(meta : keeper_meta) ~args =
           ~source:"dashboard";
         Keeper_surface_post.ok_json ~surface ()
     | Ok (Keeper_surface_post.To_discord { channel_id }) -> (
-        match Channel_gate_discord_state.send_message ~channel_id ~content with
+        match Channel_gate_discord_state.send_message ~channel_id ~content () with
         | Error send_error ->
             Keeper_surface_post.error_json
               (Format.asprintf "discord send failed: %a"

--- a/lib/tool_surface/tool_shard_types_schemas_surface.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_surface.ml
@@ -31,6 +31,17 @@ let surface_tools : Masc_domain.tool_schema list =
                             "Maximum lane messages to return (default 20, \
                              max 100)" )
                       ] )
+                ; ( "before"
+                  , `Assoc
+                      [ "type", `String "number"
+                      ; ( "description"
+                        , `String
+                            "Page backward: return messages strictly older \
+                             than this ts (a message timestamp from a \
+                             previous call). Walk history by passing the \
+                             oldest_ts of the previous response; stop when \
+                             has_more is false." )
+                      ] )
                 ] )
           ; "required", `List [ `String "surface" ]
           ]

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -387,9 +387,89 @@ let test_tail_bounded_load_matches_full_scan_window () =
              "assistant" last.K.role
        | [] -> Alcotest.fail "expected non-empty window"))
 
+(* RFC-0228 P1 — backward paging. Raw JSONL with controlled ts so the
+   page boundaries are exact. *)
+let write_numbered_lane ~path ~total ~pad_bytes =
+  let padding = String.make pad_bytes 'x' in
+  let buf = Buffer.create (total * (pad_bytes + 80)) in
+  for i = 1 to total do
+    Buffer.add_string buf
+      (Yojson.Safe.to_string
+         (`Assoc
+            [
+              ("role", `String (if i mod 2 = 1 then "user" else "assistant"));
+              ("content", `String (Printf.sprintf "msg-%04d %s" i padding));
+              ("ts", `Float (float_of_int i));
+            ]));
+    Buffer.add_char buf '\n'
+  done;
+  write_file path (Buffer.contents buf)
+
+let content_no (m : K.chat_message) =
+  int_of_string (String.sub m.K.content 4 4)
+
+let test_load_page_walks_backward_small_file () =
+  let base_dir = temp_base_path "keeper-chat-store-page-small" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-page-small" in
+      write_numbered_lane
+        ~path:(chat_path ~base_dir ~keeper_name)
+        ~total:300 ~pad_bytes:0;
+      (* Page 1: strictly older than ts 250 → window 150..249. *)
+      let p1 = K.load_page ~base_dir ~keeper_name ~before:250.0 () in
+      Alcotest.(check int) "window size" 100 (List.length p1.K.messages);
+      Alcotest.(check int) "first" 150 (content_no (List.hd p1.K.messages));
+      Alcotest.(check int) "last" 249
+        (content_no (List.hd (List.rev p1.K.messages)));
+      Alcotest.(check bool) "older rows remain" true p1.K.has_more;
+      (* Page 2: walk with the oldest returned ts. *)
+      let p2 = K.load_page ~base_dir ~keeper_name ~before:150.0 () in
+      Alcotest.(check int) "page2 first" 50 (content_no (List.hd p2.K.messages));
+      (* Final page: fewer rows than the window, nothing older. *)
+      let p3 = K.load_page ~base_dir ~keeper_name ~before:50.0 () in
+      Alcotest.(check int) "page3 size" 49 (List.length p3.K.messages);
+      Alcotest.(check int) "page3 first" 1 (content_no (List.hd p3.K.messages));
+      Alcotest.(check bool) "history exhausted" false p3.K.has_more;
+      (* before older than everything → empty, exhausted. *)
+      let p4 = K.load_page ~base_dir ~keeper_name ~before:1.0 () in
+      Alcotest.(check int) "empty page" 0 (List.length p4.K.messages);
+      Alcotest.(check bool) "empty page exhausted" false p4.K.has_more)
+
+let test_load_page_binary_search_large_file () =
+  let base_dir = temp_base_path "keeper-chat-store-page-large" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-page-large" in
+      (* ~5.3 MiB: larger than both the 4 MiB window slice and the
+         256 KiB probe, so find_cut's loop actually narrows. *)
+      write_numbered_lane
+        ~path:(chat_path ~base_dir ~keeper_name)
+        ~total:5200 ~pad_bytes:1000;
+      let p = K.load_page ~base_dir ~keeper_name ~before:5000.0 () in
+      Alcotest.(check int) "window size" 100 (List.length p.K.messages);
+      Alcotest.(check int) "first" 4900 (content_no (List.hd p.K.messages));
+      Alcotest.(check int) "last" 4999
+        (content_no (List.hd (List.rev p.K.messages)));
+      Alcotest.(check bool) "older rows remain" true p.K.has_more;
+      (* Tail mode on the same file reports more history too. *)
+      let tail = K.load_page ~base_dir ~keeper_name () in
+      Alcotest.(check int) "tail last" 5200
+        (content_no (List.hd (List.rev tail.K.messages)));
+      Alcotest.(check bool) "tail has_more" true tail.K.has_more)
+
 let () =
   Alcotest.run "keeper_chat_store"
     [
+      ( "paging (RFC-0228)",
+        [
+          Alcotest.test_case "load_page walks backward (small file)" `Quick
+            test_load_page_walks_backward_small_file;
+          Alcotest.test_case "load_page binary search (large file)" `Quick
+            test_load_page_binary_search_large_file;
+        ] );
       ( "persistence_read_drops",
         [
           Alcotest.test_case "malformed rows increment drop metrics" `Quick

--- a/test/test_keeper_surface_read.ml
+++ b/test/test_keeper_surface_read.ml
@@ -52,7 +52,7 @@ let discord_fixture : Store.chat_message list =
   ]
 
 let test_lane_filter_excludes_other_sources_and_legacy () =
-  let json = parse (SR.respond ~surface:"discord" ~limit:50 discord_fixture) in
+  let json = parse (SR.respond ~surface:"discord" ~limit:50 ~has_more:false discord_fixture) in
   check int "lane rows" 4 (to_int (member "lane_row_count" json));
   check int "returned" 4 (to_int (member "returned" json));
   let contents =
@@ -69,7 +69,7 @@ let test_lane_filter_excludes_other_sources_and_legacy () =
     contents
 
 let test_roster_groups_by_id_latest_name_wins () =
-  let json = parse (SR.respond ~surface:"discord" ~limit:50 discord_fixture) in
+  let json = parse (SR.respond ~surface:"discord" ~limit:50 ~has_more:false discord_fixture) in
   let participants = to_list (member "participants" json) in
   check int "two participants" 2 (List.length participants);
   let find id =
@@ -92,7 +92,7 @@ let test_roster_groups_by_id_latest_name_wins () =
     (to_string_j (member "id" (List.hd participants)))
 
 let test_limit_truncates_messages_not_roster () =
-  let json = parse (SR.respond ~surface:"discord" ~limit:2 discord_fixture) in
+  let json = parse (SR.respond ~surface:"discord" ~limit:2 ~has_more:false discord_fixture) in
   check int "returned capped" 2 (to_int (member "returned" json));
   check int "lane count still full" 4 (to_int (member "lane_row_count" json));
   check int "roster still full" 2
@@ -106,7 +106,7 @@ let test_limit_truncates_messages_not_roster () =
     contents
 
 let test_keeper_own_lines_are_not_participants () =
-  let json = parse (SR.respond ~surface:"discord" ~limit:50 discord_fixture) in
+  let json = parse (SR.respond ~surface:"discord" ~limit:50 ~has_more:false discord_fixture) in
   let ids =
     to_list (member "participants" json)
     |> List.map (fun p -> to_string_j (member "id" p))
@@ -115,18 +115,45 @@ let test_keeper_own_lines_are_not_participants () =
     (List.exists (fun id -> String.equal id "keeper") ids)
 
 let test_blank_surface_is_error () =
-  let json = parse (SR.respond ~surface:"  " ~limit:10 discord_fixture) in
+  let json = parse (SR.respond ~surface:"  " ~limit:10 ~has_more:false discord_fixture) in
   check bool "error field present" true (member "error" json <> `Null)
 
 let test_empty_lane_is_success_with_zero_rows () =
-  let json = parse (SR.respond ~surface:"slack" ~limit:10 discord_fixture) in
+  let json = parse (SR.respond ~surface:"slack" ~limit:10 ~has_more:false discord_fixture) in
   check int "lane empty" 0 (to_int (member "lane_row_count" json));
   check int "no participants" 0
     (List.length (to_list (member "participants" json)))
 
+(* RFC-0228 P1 — paging fields. oldest_ts spans the whole page (the
+   dashboard ts=1.0 row), not just the discord lane, so a walk makes
+   progress through pages that hold no rows for the requested lane. *)
+let test_paging_fields_reflect_page_not_lane () =
+  let json =
+    parse (SR.respond ~surface:"discord" ~limit:50 ~has_more:true discord_fixture)
+  in
+  check bool "has_more passthrough" true
+    (Yojson.Safe.Util.to_bool (member "has_more" json));
+  check (float 0.0001) "oldest_ts is page-wide" 1.0
+    (Yojson.Safe.Util.to_number (member "oldest_ts" json))
+
+let test_oldest_ts_absent_when_page_unstamped () =
+  let json =
+    parse
+      (SR.respond ~surface:"discord" ~limit:10 ~has_more:false
+         [ msg ~source:"discord" ~role:"user" "no ts row" ])
+  in
+  check bool "oldest_ts omitted" true (member "oldest_ts" json = `Null)
+
 let () =
   run "keeper_surface_read"
     [
+      ( "paging (RFC-0228)",
+        [
+          test_case "has_more + page-wide oldest_ts" `Quick
+            test_paging_fields_reflect_page_not_lane;
+          test_case "oldest_ts absent when page unstamped" `Quick
+            test_oldest_ts_absent_when_page_unstamped;
+        ] );
       ( "lane filter",
         [
           test_case "excludes other sources and legacy rows" `Quick


### PR DESCRIPTION
## RFC-0228 P1 — paged lane pull (`before` ts 역방향 walk)

RFC: `docs/rfc/RFC-0228-paged-lane-pull-fact-retention-harness.md` (#20779, merged)

> **선행**: #20786 (main unbreak — #20777 시그니처 미이행 call site). 이 PR의 `keeper_tool_in_process_runtime.ml`에 동일 1줄(`send_message ... ()`)이 포함되어 있습니다 — #20786 머지 후 rebase하면 자동으로 사라지는 의도된 중복입니다. **#20786 먼저 머지 후 이 PR을 rebase**하는 순서를 권합니다.

### 무엇이 생기나

keeper가 window 밖 역사를 결정론적으로 걸을 수 있게 됩니다:

```
keeper_surface_read {surface: "discord", before: <이전 응답의 oldest_ts>}
→ {messages, participants, has_more, oldest_ts}
```

- `before` = 이전 호출이 돌려준 메시지 ts. **서버 상태 없음** — cursor 금지 원칙(RFC-0228 §2.2) 그대로, 호출자가 상태를 듭니다
- `oldest_ts`는 lane이 아니라 **페이지 전체** 기준 — 요청한 lane의 행이 없는 페이지를 만나도 walk가 전진합니다
- `has_more=false`에서 멈춤

### 어떻게 비용을 묶나

append-only + wall-clock ts ⇒ **라인 ts가 바이트 오프셋에 단조** ⇒ cut을 바이트 오프셋 이진 탐색으로 찾습니다 (probe 256 KiB × ~log₂(size/probe)회, metric-quiet) + 4 MiB window slice 1회. 호출당 I/O가 파일 크기와 무관합니다. probe 정밀도 한계의 overshoot은 최종 ts 필터가 버립니다 (정확성은 필터, 탐색은 근사 — 역할 분리).

- `Fs_compat.read_slice` 신규 (clamped bounded slice 프리미티브)
- `load` = `load_page`의 tail 모드로 재정의 (기존 호출자 의미 불변)
- legacy 무-ts 행은 paging으로 도달 불가 (정렬 불가) — tail window가 계속 서빙, mli에 명시

### 검증

- `@check` + default: EXIT=0
- `test_keeper_chat_store` 13/13 — 신규 2: 소형(300행, 필터 경로: 250→150..249→50→1..49, has_more 전이 정확) + **대형 5.3 MiB(이진 탐색 실가동: probe < window < size)** 페이지 경계 정밀 일치
- `test_keeper_surface_read` 8/8 — 신규 2: has_more/oldest_ts 페이지-기준, 무-ts 페이지에서 oldest_ts 생략
- `keeper_tool_matrix_case_runner.exe keeper_surface_read` → ok:true (4번째 관문)
- 로컬 검증은 #20786 fix를 얹은 트리에서 수행 (main이 해당 타입 에러로 red)

### 한계

- probe가 256 KiB 초과 단일 라인(거대 첨부) 내부에 착지하면 cut 추정이 이르게 잡혀 window가 짧아질 수 있음 — 에러/오답이 아니라 P2와 같은 degrade 클래스, 주석 명시

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
