### PR TITLE
feat(keeper): person notes — deliberate per-speaker memory (RFC-0229 P1)

### DIFF
--- a/lib/governance_pipeline_risk.ml
+++ b/lib/governance_pipeline_risk.ml
@@ -25,6 +25,7 @@ let capability_classification : (string * capability_class list) list =
     ("keeper_library_read", [ Sensitive_access ]);
     ("keeper_surface_read", [ Sensitive_access ]);
     ("keeper_surface_post", [ State_modification ]);
+    ("keeper_person_note_set", [ State_modification ]);
     ("tool_edit_file", [ State_modification ]);
     ("tool_write_file", [ State_modification ]);
   ]
@@ -147,7 +148,7 @@ let risk_of_keeper (k : Keeper_tool_name.t) : risk_level =
   | Tool_search | Tools_list | Voice_agent | Voice_listen
   | Voice_session_end | Voice_session_start | Voice_sessions | Voice_speak -> Low
   | Board_sub_board_create | Board_sub_board_update | Task_claim | Task_create | Task_done
-  | Surface_post
+  | Surface_post | Person_note_set
     -> Medium
   | Fs_edit | Fs_write | Fs_read | Ide_annotate -> High
   | Board_sub_board_delete | Task_force_done | Task_force_release -> Critical

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -200,6 +200,7 @@ let tool_search_alias_entries =
   ; "keeper_library_read", "라이브러리 문서 읽기 지식"
   ; "keeper_surface_read", "커넥터 대화 읽기 디스코드 채널 화자 명부 서피스"
   ; "keeper_surface_post", "커넥터 발화 보내기 디스코드 채널 메시지 전송 서피스"
+  ; "keeper_person_note_set", "사람 기억 노트 저장 화자 메모 명부 로스터"
   ; "keeper_time_now", "시간 현재 타임스탬프"
   ; "keeper_context_status", "컨텍스트 상태 토큰 사용량"
   ; "keeper_tools_list", "도구 목록 기능 할수있는것 능력"

--- a/lib/keeper/keeper_person_notes.ml
+++ b/lib/keeper/keeper_person_notes.ml
@@ -1,0 +1,113 @@
+(* See .mli. Sibling of Keeper_chat_store: same path/sanitize/failure
+   conventions, separate directory and metric. *)
+
+let sanitize_name name =
+  Workspace_utils_backend_setup.sanitize_namespace_segment name
+
+let notes_dir base_dir =
+  Filename.concat
+    (Common.masc_dir_from_base_path ~base_path:base_dir)
+    "keeper_person_notes"
+
+let notes_path ~base_dir ~keeper_name =
+  Filename.concat (notes_dir base_dir) (sanitize_name keeper_name ^ ".jsonl")
+
+let persistence_surface = "keeper_person_notes"
+
+let report_read_drop ~reason ~path ~detail =
+  Safe_ops.report_persistence_read_drop
+    ~on_drop:(fun () ->
+      Otel_metric_store.inc_counter
+        Otel_metric_store.metric_persistence_read_drops
+        ~labels:[ ("surface", persistence_surface); ("reason", reason) ]
+        ())
+    ~surface:persistence_surface
+    ~reason
+    ~path
+    ~detail
+
+let set_note ~base_dir ~keeper_name ~(speaker_id : string) ~(note : string) ()
+    =
+  try
+    ignore (Keeper_fs.ensure_dir (notes_dir base_dir));
+    let line =
+      Yojson.Safe.to_string
+        (`Assoc
+          [
+            ("speaker_id", `String speaker_id);
+            ("note", `String note);
+            ("ts", `Float (Time_compat.now ()));
+          ])
+    in
+    Fs_compat.append_file (notes_path ~base_dir ~keeper_name) (line ^ "\n")
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string PersonNoteStoreFailures)
+      ~labels:[ ("operation", "append") ]
+      ();
+    Log.Keeper.warn "keeper_person_notes: append failed for %s: %s"
+      (sanitize_name keeper_name) (Printexc.to_string exn)
+
+let parse_row ~file_path line : (string * string) option =
+  try
+    let json = Yojson.Safe.from_string line in
+    let field key =
+      match Json_util.assoc_member_opt key json with
+      | Some (`String v) -> Some v
+      | _ -> None
+    in
+    match field "speaker_id" with
+    | Some id when String.trim id <> "" ->
+        Some (String.trim id, Option.value (field "note") ~default:"")
+    | Some _ | None ->
+        report_read_drop
+          ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
+          ~path:file_path
+          ~detail:"person-note row missing non-empty speaker_id";
+        None
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | Yojson.Json_error detail ->
+    report_read_drop
+      ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
+      ~path:file_path
+      ~detail;
+    None
+
+let notes ~base_dir ~keeper_name : (string * string) list =
+  let path = notes_path ~base_dir ~keeper_name in
+  if not (Sys.file_exists path) then []
+  else
+    try
+      (* Latest row wins per speaker; insertion order of first
+         appearance is irrelevant to callers (roster sorts on its own
+         keys). Blank note = tombstone. *)
+      let tbl : (string, string) Hashtbl.t = Hashtbl.create 8 in
+      let (), _boundary =
+        Fs_compat.fold_appended_lines ~path ~from:0 ~init:()
+          ~f:(fun () line ->
+            match parse_row ~file_path:path (String.trim line) with
+            | Some (id, note) -> Hashtbl.replace tbl id note
+            | None -> ())
+      in
+      Hashtbl.fold
+        (fun id note acc ->
+          if String.trim note = "" then acc else (id, note) :: acc)
+        tbl []
+    with
+    | Sys_error detail ->
+        report_read_drop
+          ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
+          ~path
+          ~detail;
+        []
+    | exn ->
+        Otel_metric_store.inc_counter
+          Keeper_metrics.(to_string PersonNoteStoreFailures)
+          ~labels:[ ("operation", "load") ]
+          ();
+        Log.Keeper.warn "keeper_person_notes: load failed for %s: %s"
+          (sanitize_name keeper_name) (Printexc.to_string exn);
+        []

--- a/lib/keeper/keeper_person_notes.mli
+++ b/lib/keeper/keeper_person_notes.mli
@@ -1,0 +1,31 @@
+(** Keeper_person_notes — deliberate per-speaker memory (RFC-0229 P1).
+
+    Append-only JSONL per keeper:
+    [<base_dir>/.masc/keeper_person_notes/<name>.jsonl], rows
+    [{"speaker_id":"98791450001","note":"...","ts":1781400000.0}].
+
+    A note exists only because the keeper called
+    [keeper_person_note_set] in a turn — no automatic extraction, no
+    background writer. The current note per speaker is the last row
+    (fold-at-read, latest wins); a blank note row is a tombstone, so
+    deletion needs no delete operation. Volume grows with deliberate
+    writes only, so reads are whole-file at v1 (revisit with a tail
+    bound only if measured otherwise). *)
+
+(** [set_note ~base_dir ~keeper_name ~speaker_id ~note ()] appends one
+    note row. Blank [note] clears. Failures are logged and counted
+    ([PersonNoteStoreFailures]), never raised past
+    {!Eio.Cancel.Cancelled} — same policy as the chat store appends. *)
+val set_note :
+  base_dir:string ->
+  keeper_name:string ->
+  speaker_id:string ->
+  note:string ->
+  unit ->
+  unit
+
+(** [notes ~base_dir ~keeper_name] folds the file into the current
+    note per speaker: latest row wins, tombstoned (blank) entries are
+    absent. Missing file is []. Unparseable lines are skipped and
+    counted as persistence read drops. *)
+val notes : base_dir:string -> keeper_name:string -> (string * string) list

--- a/lib/keeper/keeper_surface_read.ml
+++ b/lib/keeper/keeper_surface_read.ml
@@ -7,6 +7,7 @@ type participant = {
   first_seen : float option;
   last_seen : float option;
   message_count : int;
+  note : string option;
 }
 
 let default_limit = 20
@@ -46,7 +47,8 @@ let participant_json (p : participant) : Yojson.Safe.t =
     @ [ ("authority", `String (Store.authority_label p.authority)) ]
     @ opt_float_field "first_seen" p.first_seen
     @ opt_float_field "last_seen" p.last_seen
-    @ [ ("message_count", `Int p.message_count) ])
+    @ [ ("message_count", `Int p.message_count) ]
+    @ opt_string_field "note" p.note)
 
 (* Roster fold: one bucket per speaker_id over user lines. The most
    recent non-empty name wins (people rename; the log remembers, the
@@ -67,6 +69,7 @@ let roster (lane : Store.chat_message list) : participant list =
                   first_seen = m.ts;
                   last_seen = m.ts;
                   message_count = 1;
+                  note = None;
                 }
             | Some p ->
                 {
@@ -117,8 +120,43 @@ let page_oldest_ts (messages : Store.chat_message list) : float option =
       | some, _ -> some)
     None messages
 
-let respond ~surface ~limit ~has_more (messages : Store.chat_message list) :
-    string =
+(* RFC-0229 P1: notes are keeper-scoped deliberate memory. Union them
+   into the roster — annotating people still present, and resurrecting
+   noted people whose chat rows aged out of the window (note-only
+   entries: no sightings, zero message_count, External authority since
+   ids come from connector rosters). *)
+let with_notes (notes : (string * string) list) (roster : participant list) :
+    participant list =
+  let annotated =
+    List.map
+      (fun p ->
+        match List.assoc_opt p.id notes with
+        | Some n when String.trim n <> "" -> { p with note = Some n }
+        | Some _ | None -> p)
+      roster
+  in
+  let known = List.map (fun p -> p.id) annotated in
+  let note_only =
+    List.filter_map
+      (fun (id, n) ->
+        if String.trim n = "" || List.mem id known then None
+        else
+          Some
+            {
+              id;
+              name = None;
+              authority = Store.External;
+              first_seen = None;
+              last_seen = None;
+              message_count = 0;
+              note = Some n;
+            })
+      notes
+  in
+  annotated @ note_only
+
+let respond ~surface ~limit ~has_more ~notes
+    (messages : Store.chat_message list) : string =
   let surface = String.trim surface in
   if surface = "" then
     Yojson.Safe.to_string
@@ -146,7 +184,9 @@ let respond ~surface ~limit ~has_more (messages : Store.chat_message list) :
         ([
            ("surface", `String surface);
            ("messages", `List (List.map message_json shown));
-           ("participants", `List (List.map participant_json (roster lane)));
+           ( "participants",
+            `List (List.map participant_json (with_notes notes (roster lane)))
+          );
            ("lane_row_count", `Int (List.length lane));
            ("returned", `Int (List.length shown));
            ("has_more", `Bool has_more);

--- a/lib/keeper/keeper_surface_read.mli
+++ b/lib/keeper/keeper_surface_read.mli
@@ -17,6 +17,8 @@ type participant = {
   first_seen : float option;
   last_seen : float option;
   message_count : int;
+  note : string option;
+      (** Keeper-authored person note (RFC-0229), latest non-blank. *)
 }
 
 val default_limit : int
@@ -44,5 +46,11 @@ val respond :
   surface:string ->
   limit:int ->
   has_more:bool ->
+  notes:(string * string) list ->
   Keeper_chat_store.chat_message list ->
   string
+(** [notes] (RFC-0229 P1) are keeper-scoped (not lane-scoped): they
+    annotate matching roster entries, and a noted speaker absent from
+    the loaded rows still appears as a note-only participant (zero
+    [message_count], no sightings) — deliberate memory outliving the
+    log window. *)

--- a/lib/keeper/keeper_tool_alias.ml
+++ b/lib/keeper/keeper_tool_alias.ml
@@ -77,6 +77,7 @@ let is_masc_mcp_descriptor (d : Keeper_tool_descriptor.t) =
   | Tool_library_read
   | Tool_surface_read
   | Tool_surface_post
+  | Tool_person_note_set
   | Tool_ide_annotate
   | Tool_voice_dispatch
   | Tool_task_dispatch

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -41,6 +41,7 @@ type runtime_handler =
   | Tool_library_read
   | Tool_surface_read
   | Tool_surface_post
+  | Tool_person_note_set
   | Tool_ide_annotate
   | Tool_voice_dispatch
   | Tool_task_dispatch
@@ -128,6 +129,7 @@ let runtime_handler_to_string = function
   | Tool_library_read -> "tool_library_read"
   | Tool_surface_read -> "tool_surface_read"
   | Tool_surface_post -> "tool_surface_post"
+  | Tool_person_note_set -> "tool_person_note_set"
   | Tool_ide_annotate -> "tool_ide_annotate"
   | Tool_voice_dispatch -> "tool_voice_dispatch"
   | Tool_task_dispatch -> "tool_task_dispatch"
@@ -695,6 +697,22 @@ let surface_post_schema =
     ]
 ;;
 
+let person_note_set_schema =
+  object_schema
+    ~required:[ "speaker_id"; "note" ]
+    [ property
+        "speaker_id"
+        "string"
+        "Stable speaker id from the roster (Discord snowflake). Notes \
+         attach to ids, never to display names."
+    ; property
+        "note"
+        "string"
+        "What to remember about this person. Blank clears the note \
+         (tombstone)."
+    ]
+;;
+
 let read_only_in_process_policy ?(inline_safe = false) ?(maintenance_only = false)
       ()
   =
@@ -1048,6 +1066,17 @@ let internal_descriptors : t list =
       ~input_schema:surface_post_schema
       ~policy:(write_in_process_policy ())
       ~handler:Tool_surface_post
+  ; in_process_descriptor
+      ~id:"keeper.person.note_set"
+      ~name:"keeper_person_note_set"
+      ~description:
+        "Remember (or clear) a note about a person met on a connected \
+         surface, keyed by their roster speaker_id. Deliberate memory: \
+         the note survives after their chat rows age out of the log \
+         window and shows up on the keeper_surface_read roster."
+      ~input_schema:person_note_set_schema
+      ~policy:(write_in_process_policy ())
+      ~handler:Tool_person_note_set
     (* ── IDE (RFC-0179 PR-3) ──────────────────────────────────── *)
   ; in_process_descriptor
       ~id:"keeper.ide.annotate"

--- a/lib/keeper/keeper_tool_descriptor.mli
+++ b/lib/keeper/keeper_tool_descriptor.mli
@@ -46,6 +46,7 @@ type runtime_handler =
   | Tool_library_read
   | Tool_surface_read
   | Tool_surface_post
+  | Tool_person_note_set
   | Tool_ide_annotate
   | Tool_voice_dispatch
   | Tool_task_dispatch

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -98,9 +98,46 @@ let handle_surface_read ~config ~(meta : keeper_meta) ~args =
       ?before
       ()
   in
+  let notes =
+    Keeper_person_notes.notes
+      ~base_dir:config.Workspace.base_path
+      ~keeper_name:meta.name
+  in
   Keeper_surface_read.respond ~surface ~limit
     ~has_more:page.Keeper_chat_store.has_more
+    ~notes
     page.Keeper_chat_store.messages
+;;
+
+let handle_person_note_set ~config ~(meta : keeper_meta) ~args =
+  let speaker_id =
+    String.trim (Safe_ops.json_string ~default:"" "speaker_id" args)
+  in
+  (* note is NOT trimmed to emptiness-only: a blank note is the
+     deliberate tombstone (RFC-0229 §3.1). *)
+  let note = Safe_ops.json_string ~default:"" "note" args in
+  if speaker_id = "" then
+    Yojson.Safe.to_string
+      (`Assoc
+        [ ( "error"
+          , `String
+              "speaker_id is required. Use the id field from the \
+               keeper_surface_read roster." )
+        ])
+  else begin
+    Keeper_person_notes.set_note
+      ~base_dir:config.Workspace.base_path
+      ~keeper_name:meta.name
+      ~speaker_id
+      ~note
+      ();
+    Yojson.Safe.to_string
+      (`Assoc
+        [ "ok", `Bool true
+        ; "speaker_id", `String speaker_id
+        ; "cleared", `Bool (String.trim note = "")
+        ])
+  end
 ;;
 
 let handle_surface_post ~config ~(meta : keeper_meta) ~args =

--- a/lib/keeper/keeper_tool_in_process_runtime.mli
+++ b/lib/keeper/keeper_tool_in_process_runtime.mli
@@ -60,6 +60,12 @@ val handle_surface_post
   -> args:Yojson.Safe.t
   -> string
 
+val handle_person_note_set
+  :  config:Workspace.config
+  -> meta:keeper_meta
+  -> args:Yojson.Safe.t
+  -> string
+
 val handle_ide_annotate
   :  config:Workspace.config
   -> meta:keeper_meta

--- a/lib/keeper/keeper_tool_runtime.ml
+++ b/lib/keeper/keeper_tool_runtime.ml
@@ -59,6 +59,7 @@ let handle_filesystem ctx descriptor args =
   | Tool_library_read
   | Tool_surface_read
   | Tool_surface_post
+  | Tool_person_note_set
   | Tool_ide_annotate
   | Tool_voice_dispatch
   | Tool_task_dispatch
@@ -112,6 +113,7 @@ let handle_shell_ir ctx descriptor args =
   | Tool_library_read
   | Tool_surface_read
   | Tool_surface_post
+  | Tool_person_note_set
   | Tool_ide_annotate
   | Tool_voice_dispatch
   | Tool_task_dispatch
@@ -178,6 +180,12 @@ let handle_in_process ctx descriptor args =
   | Tool_surface_post ->
     Some
       (Keeper_tool_in_process_runtime.handle_surface_post
+         ~config:ctx.config
+         ~meta:ctx.meta
+         ~args)
+  | Tool_person_note_set ->
+    Some
+      (Keeper_tool_in_process_runtime.handle_person_note_set
          ~config:ctx.config
          ~meta:ctx.meta
          ~args)

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -157,6 +157,7 @@ type t =
   | AlertPersistFailures
   | MetricsSseFailures
   | ChatStoreFailures
+  | PersonNoteStoreFailures
   | ObservationQueryFailures
   | OasOnStop
   | OasOnIdleEscalated
@@ -383,6 +384,7 @@ let to_string = function
   | AlertPersistFailures -> "masc_keeper_alert_persist_failures_total"
   | MetricsSseFailures -> "masc_keeper_metrics_sse_failures_total"
   | ChatStoreFailures -> "masc_keeper_chat_store_failures_total"
+  | PersonNoteStoreFailures -> "masc_keeper_person_note_store_failures_total"
   | ObservationQueryFailures -> "masc_keeper_observation_query_failures_total"
   | OasOnStop -> "masc_keeper_oas_on_stop_total"
   | OasOnIdleEscalated -> "masc_keeper_oas_on_idle_escalated_total"
@@ -494,7 +496,7 @@ let all : t list =
     MemoryLlmSummaryOutcomes; MemoryLlmSummaryChainExhausted; UserVisibleReplySource; ContinuitySummarySource;
     SummarizerStateScrubs; SummarizerStateBlocksRemoved; OasEnvKeyRejections; ContinuityTsRecovered;
     MemoryWriteFailures; MemoryConsolidations; WriteMetaCycleFailures; AlertPersistFailures;
-    MetricsSseFailures; ChatStoreFailures; ObservationQueryFailures; OasOnStop;
+    MetricsSseFailures; ChatStoreFailures; PersonNoteStoreFailures; ObservationQueryFailures; OasOnStop;
     OasOnIdleEscalated; InvariantViolations; FsmEdgeTransitions; TurnFsmTransitions;
     TurnPhaseDuration; LifecycleTransitions; LifecycleCallbackFailures; CompactionCallbackRecoveries;
     EventBusDrain; SupervisorCleanupFailures; SpawnSlotDenied; RegistryUpdateDropped;

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -148,6 +148,7 @@ type t =
   | AlertPersistFailures
   | MetricsSseFailures
   | ChatStoreFailures
+  | PersonNoteStoreFailures
   | ObservationQueryFailures
   | OasOnStop
   | OasOnIdleEscalated

--- a/lib/keeper_tooling/keeper_tool_name.ml
+++ b/lib/keeper_tooling/keeper_tool_name.ml
@@ -39,6 +39,7 @@ type t =
   | Stay_silent
   | Surface_read
   | Surface_post
+  | Person_note_set
   | Task_claim
   | Task_create
   | Task_done
@@ -88,6 +89,7 @@ let to_string = function
   | Stay_silent -> "keeper_stay_silent"
   | Surface_read -> "keeper_surface_read"
   | Surface_post -> "keeper_surface_post"
+  | Person_note_set -> "keeper_person_note_set"
   | Task_claim -> "keeper_task_claim"
   | Task_create -> "keeper_task_create"
   | Task_done -> "keeper_task_done"
@@ -138,6 +140,7 @@ let of_string = function
   | "keeper_stay_silent" -> Some Stay_silent
   | "keeper_surface_read" -> Some Surface_read
   | "keeper_surface_post" -> Some Surface_post
+  | "keeper_person_note_set" -> Some Person_note_set
   | "keeper_task_claim" -> Some Task_claim
   | "keeper_task_create" -> Some Task_create
   | "keeper_task_done" -> Some Task_done
@@ -205,6 +208,7 @@ let is_keeper_board_tool = function
   | Stay_silent
   | Surface_read
   | Surface_post
+  | Person_note_set
   | Task_claim
   | Task_create
   | Task_done

--- a/lib/keeper_tooling/keeper_tool_name.mli
+++ b/lib/keeper_tooling/keeper_tool_name.mli
@@ -37,6 +37,7 @@ type t =
   | Stay_silent
   | Surface_read
   | Surface_post
+  | Person_note_set
   | Task_claim
   | Task_create
   | Task_done

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -114,14 +114,14 @@ let shard_library : shard =
   }
 ;;
 
-(* RFC-0223 P3: connector surface lane reading. keeper_surface_post
-   (P4) joins this shard when it ships. *)
+(* RFC-0223 P3/P4 + RFC-0229: connector surface lane reading, acting,
+   and per-person notes. *)
 let shard_surface : shard =
   { name = "surface"
   ; tools = surface_tools
   ; read_only_tools = [ "keeper_surface_read" ]
   ; removable = true
-  ; description = "Connected surfaces: read lane conversation, roster"
+  ; description = "Connected surfaces: read lane conversation, roster, person notes"
   }
 ;;
 

--- a/lib/tool_surface/tool_prefilter.ml
+++ b/lib/tool_surface/tool_prefilter.ml
@@ -230,6 +230,13 @@ let synonyms : (string * string list) list =
       ; "message the dashboard"
       ; "speak on lane"
       ] )
+  ; ( "keeper_person_note_set"
+    , [ "remember this person"
+      ; "note about speaker"
+      ; "who is this user"
+      ; "save person info"
+      ; "clear person note"
+      ] )
   ; ( "keeper_tools_list"
     , [ "what can you do"
       ; "capabilities"

--- a/lib/tool_surface/tool_shard_types_schemas_surface.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_surface.ml
@@ -80,4 +80,35 @@ let surface_tools : Masc_domain.tool_schema list =
           ; "required", `List [ `String "surface"; `String "content" ]
           ]
     }
+  ; { name = "keeper_person_note_set"
+    ; description =
+        "Remember (or clear) a note about a person met on a connected \
+         surface, keyed by their roster speaker_id (RFC-0229). The note \
+         survives after their messages age out of the log window and \
+         shows up on the keeper_surface_read roster."
+    ; input_schema =
+        `Assoc
+          [ "type", `String "object"
+          ; ( "properties"
+            , `Assoc
+                [ ( "speaker_id"
+                  , `Assoc
+                      [ "type", `String "string"
+                      ; ( "description"
+                        , `String
+                            "Stable speaker id from the roster (Discord \
+                             snowflake); notes attach to ids, never names" )
+                      ] )
+                ; ( "note"
+                  , `Assoc
+                      [ "type", `String "string"
+                      ; ( "description"
+                        , `String
+                            "What to remember about this person; blank \
+                             clears the note" )
+                      ] )
+                ] )
+          ; "required", `List [ `String "speaker_id"; `String "note" ]
+          ]
+    }
   ]

--- a/test/dune
+++ b/test/dune
@@ -182,6 +182,7 @@
   test_keeper_unified_inline_skip
   test_keeper_unified_metacognition
   test_keeper_surface_post
+  test_keeper_person_notes
   test_keeper_surface_read
   test_keeper_surface_presence_prompt
   test_keeper_unified_verification_surface
@@ -446,6 +447,7 @@
   test_keeper_unified_inline_skip
   test_keeper_unified_metacognition
   test_keeper_surface_post
+  test_keeper_person_notes
   test_keeper_surface_read
   test_keeper_surface_presence_prompt
   test_keeper_unified_verification_surface

--- a/test/test_keeper_person_notes.ml
+++ b/test/test_keeper_person_notes.ml
@@ -1,0 +1,72 @@
+(* RFC-0229 P1 — Keeper_person_notes store: append-only rows,
+   fold-at-read latest-wins, blank-note tombstone. *)
+
+module N = Masc.Keeper_person_notes
+
+let rec remove_tree path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path
+      |> Array.iter (fun name -> remove_tree (Filename.concat path name));
+      Unix.rmdir path
+    end
+    else Sys.remove path
+
+let temp_base_path prefix =
+  Filename.concat
+    (Filename.get_temp_dir_name ())
+    (Printf.sprintf "%s-%d-%d" prefix (Unix.getpid ()) (Random.bits ()))
+
+let with_base_dir f =
+  let base_dir = temp_base_path "keeper-person-notes" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () -> f base_dir)
+
+let keeper_name = "person-notes-keeper"
+
+let test_latest_note_wins () =
+  with_base_dir (fun base_dir ->
+      N.set_note ~base_dir ~keeper_name ~speaker_id:"111"
+        ~note:"first impression" ();
+      N.set_note ~base_dir ~keeper_name ~speaker_id:"222" ~note:"second person"
+        ();
+      N.set_note ~base_dir ~keeper_name ~speaker_id:"111"
+        ~note:"updated impression" ();
+      let notes = N.notes ~base_dir ~keeper_name in
+      Alcotest.(check int) "two speakers" 2 (List.length notes);
+      Alcotest.(check (option string))
+        "latest wins" (Some "updated impression")
+        (List.assoc_opt "111" notes);
+      Alcotest.(check (option string))
+        "other intact" (Some "second person")
+        (List.assoc_opt "222" notes))
+
+let test_blank_note_is_tombstone () =
+  with_base_dir (fun base_dir ->
+      N.set_note ~base_dir ~keeper_name ~speaker_id:"111" ~note:"to be erased"
+        ();
+      N.set_note ~base_dir ~keeper_name ~speaker_id:"111" ~note:"" ();
+      Alcotest.(check int)
+        "tombstoned entry absent" 0
+        (List.length (N.notes ~base_dir ~keeper_name)))
+
+let test_missing_file_is_empty () =
+  with_base_dir (fun base_dir ->
+      Alcotest.(check int)
+        "no file, no notes" 0
+        (List.length (N.notes ~base_dir ~keeper_name)))
+
+let () =
+  Alcotest.run "keeper_person_notes"
+    [
+      ( "fold",
+        [
+          Alcotest.test_case "latest note wins per speaker" `Quick
+            test_latest_note_wins;
+          Alcotest.test_case "blank note tombstones" `Quick
+            test_blank_note_is_tombstone;
+          Alcotest.test_case "missing file is empty" `Quick
+            test_missing_file_is_empty;
+        ] );
+    ]

--- a/test/test_keeper_surface_read.ml
+++ b/test/test_keeper_surface_read.ml
@@ -52,7 +52,7 @@ let discord_fixture : Store.chat_message list =
   ]
 
 let test_lane_filter_excludes_other_sources_and_legacy () =
-  let json = parse (SR.respond ~surface:"discord" ~limit:50 ~has_more:false discord_fixture) in
+  let json = parse (SR.respond ~surface:"discord" ~limit:50 ~has_more:false ~notes:[] discord_fixture) in
   check int "lane rows" 4 (to_int (member "lane_row_count" json));
   check int "returned" 4 (to_int (member "returned" json));
   let contents =
@@ -69,7 +69,7 @@ let test_lane_filter_excludes_other_sources_and_legacy () =
     contents
 
 let test_roster_groups_by_id_latest_name_wins () =
-  let json = parse (SR.respond ~surface:"discord" ~limit:50 ~has_more:false discord_fixture) in
+  let json = parse (SR.respond ~surface:"discord" ~limit:50 ~has_more:false ~notes:[] discord_fixture) in
   let participants = to_list (member "participants" json) in
   check int "two participants" 2 (List.length participants);
   let find id =
@@ -92,7 +92,7 @@ let test_roster_groups_by_id_latest_name_wins () =
     (to_string_j (member "id" (List.hd participants)))
 
 let test_limit_truncates_messages_not_roster () =
-  let json = parse (SR.respond ~surface:"discord" ~limit:2 ~has_more:false discord_fixture) in
+  let json = parse (SR.respond ~surface:"discord" ~limit:2 ~has_more:false ~notes:[] discord_fixture) in
   check int "returned capped" 2 (to_int (member "returned" json));
   check int "lane count still full" 4 (to_int (member "lane_row_count" json));
   check int "roster still full" 2
@@ -106,7 +106,7 @@ let test_limit_truncates_messages_not_roster () =
     contents
 
 let test_keeper_own_lines_are_not_participants () =
-  let json = parse (SR.respond ~surface:"discord" ~limit:50 ~has_more:false discord_fixture) in
+  let json = parse (SR.respond ~surface:"discord" ~limit:50 ~has_more:false ~notes:[] discord_fixture) in
   let ids =
     to_list (member "participants" json)
     |> List.map (fun p -> to_string_j (member "id" p))
@@ -115,11 +115,11 @@ let test_keeper_own_lines_are_not_participants () =
     (List.exists (fun id -> String.equal id "keeper") ids)
 
 let test_blank_surface_is_error () =
-  let json = parse (SR.respond ~surface:"  " ~limit:10 ~has_more:false discord_fixture) in
+  let json = parse (SR.respond ~surface:"  " ~limit:10 ~has_more:false ~notes:[] discord_fixture) in
   check bool "error field present" true (member "error" json <> `Null)
 
 let test_empty_lane_is_success_with_zero_rows () =
-  let json = parse (SR.respond ~surface:"slack" ~limit:10 ~has_more:false discord_fixture) in
+  let json = parse (SR.respond ~surface:"slack" ~limit:10 ~has_more:false ~notes:[] discord_fixture) in
   check int "lane empty" 0 (to_int (member "lane_row_count" json));
   check int "no participants" 0
     (List.length (to_list (member "participants" json)))
@@ -129,17 +129,43 @@ let test_empty_lane_is_success_with_zero_rows () =
    progress through pages that hold no rows for the requested lane. *)
 let test_paging_fields_reflect_page_not_lane () =
   let json =
-    parse (SR.respond ~surface:"discord" ~limit:50 ~has_more:true discord_fixture)
+    parse (SR.respond ~surface:"discord" ~limit:50 ~has_more:true ~notes:[] discord_fixture)
   in
   check bool "has_more passthrough" true
     (Yojson.Safe.Util.to_bool (member "has_more" json));
   check (float 0.0001) "oldest_ts is page-wide" 1.0
     (Yojson.Safe.Util.to_number (member "oldest_ts" json))
 
+(* RFC-0229 P1 — roster union with person notes. *)
+let test_notes_annotate_and_resurrect_participants () =
+  let notes =
+    [ ("98791450001", "deploy owner"); ("00009999", "met three weeks ago") ]
+  in
+  let json =
+    parse
+      (SR.respond ~surface:"discord" ~limit:50 ~has_more:false ~notes
+         discord_fixture)
+  in
+  let participants = to_list (member "participants" json) in
+  let find id =
+    List.find
+      (fun p -> to_string_j (member "id" p) = id)
+      participants
+  in
+  check string "lane participant annotated" "deploy owner"
+    (to_string_j (member "note" (find "98791450001")));
+  let ghost = find "00009999" in
+  check string "note-only participant resurrected" "met three weeks ago"
+    (to_string_j (member "note" ghost));
+  check int "note-only has no sightings" 0
+    (to_int (member "message_count" ghost));
+  check bool "unnoted participant carries no note field" true
+    (member "note" (find "55500001111") = `Null)
+
 let test_oldest_ts_absent_when_page_unstamped () =
   let json =
     parse
-      (SR.respond ~surface:"discord" ~limit:10 ~has_more:false
+      (SR.respond ~surface:"discord" ~limit:10 ~has_more:false ~notes:[]
          [ msg ~source:"discord" ~role:"user" "no ts row" ])
   in
   check bool "oldest_ts omitted" true (member "oldest_ts" json = `Null)
@@ -153,6 +179,8 @@ let () =
             test_paging_fields_reflect_page_not_lane;
           test_case "oldest_ts absent when page unstamped" `Quick
             test_oldest_ts_absent_when_page_unstamped;
+          test_case "notes annotate and resurrect participants" `Quick
+            test_notes_annotate_and_resurrect_participants;
         ] );
       ( "lane filter",
         [

--- a/test/test_keeper_tool_matrix_cases.ml
+++ b/test/test_keeper_tool_matrix_cases.ml
@@ -339,6 +339,10 @@ let keeper_arguments fixture (schema : Masc_domain.tool_schema) =
       `Assoc
         [ ("surface", `String "dashboard");
           ("content", `String "tool matrix surface post") ]
+  | "keeper_person_note_set" ->
+      `Assoc
+        [ ("speaker_id", `String "98791450001");
+          ("note", `String "tool matrix person note") ]
   | "keeper_tasks_list" -> `Assoc [ ("include_done", `Bool true) ]
   | "keeper_task_force_release" ->
       `Assoc

--- a/test/test_keeper_tool_resolution.ml
+++ b/test/test_keeper_tool_resolution.ml
@@ -167,6 +167,7 @@ let policy_tool_names =
       "keeper_library_read";
       "keeper_surface_read";
       "keeper_surface_post";
+      "keeper_person_note_set";
       "keeper_library_search";
       "keeper_memory_search";
       "keeper_memory_write";


### PR DESCRIPTION
## RFC-0229 P1 — person notes (의도적 화자 메모리)

RFC: `docs/rfc/RFC-0229-keeper-person-notes.md` (#20779, merged)

### 무엇이 생기나

roster는 log window 파생이라 "3주 전에 만난 사람"은 노트가 필요해지는 바로 그 시점에 명부에서 사라집니다. 이제:

```
keeper_person_note_set {speaker_id: "98791450001", note: "스토어 배포 담당"}
keeper_surface_read {surface: "discord"}
→ participants: [..., {id, note: "스토어 배포 담당", ...},
                 {id: "<아웃된 사람>", note: "...", message_count: 0}]
```

- **노트는 keeper가 턴에서 의도적으로 쓴 것만 존재** — 자동 추출 없음, 백그라운드 없음 (owner constraint)
- append-only JSONL + fold-at-read latest-wins, **빈 note = tombstone** (delete 연산 없이 삭제)
- roster union: 일치 참가자에 `note` 부착 + window 아웃된 noted speaker를 note-only 참가자로 부활(`message_count: 0`)
- keeper-private: 인프라가 노트를 broadcast/echo하지 않음 — 아는 걸 말할지는 프롬프트 영역(#20782와 일관)

### 등록 스윕 (P3 체크리스트 전 항목)

name variant(ml+mli) / risk Medium+`State_modification` / alias / runtime 3사이트 / descriptor+schema / **surface shard 합류**(`default_shard_names` 추가 불필요 — 기존 surface shard) / prefilter / 한국어 디스커버리 / `PersonNoteStoreFailures` metric variant(ml+mli).

### 검증

- `@check` + default: EXIT=0
- `test_keeper_person_notes` 3/3 (latest-wins / tombstone / missing-file)
- `test_keeper_surface_read` 9/9 (신규: union — annotate + resurrect + 무노트 참가자에 note 필드 없음)
- `keeper_tool_matrix_case_runner.exe keeper_person_note_set` → **ok:true**
- `test_keeper_tool_resolution` 4 fail = 문서화된 pre-existing 세트(keeper_report_state + matrix 캐스케이드) 그대로 — 이름·개수 동일, person_note 무관

### 한계

- Owner(대시보드) 화자는 chat 라인에 `speaker_id`가 없어(P1 설계) 노트 대상이 사실상 External — RFC §2.3과 일치, mli에 명시
- note-only 참가자의 authority는 External로 표기 (노트가 authority를 운반하지 않음)

P2(대시보드 roster note 표시)는 별도 PR.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
