### PR TITLE
test(harness): fact-retention harness — deterministic reachability + live recall runner (RFC-0228 P2)

### DIFF
--- a/scripts/harness/fact-retention.sh
+++ b/scripts/harness/fact-retention.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# RFC-0228 P2 — fact-retention harness, live half.
+#
+# Deterministic half (CI): test/test_fact_retention_reachability.ml
+# proves every planted fact is mechanically reachable through the
+# paged pull. This script measures the non-deterministic half: does a
+# LIVE keeper actually walk history (keeper_surface_read before-paging)
+# to recover facts that scrolled past its window?
+#
+# Modes:
+#   gen    --out FILE [--pages N]
+#          Write a fixture lane JSONL to FILE and a facts manifest to
+#          FILE.facts (tab-separated: key<TAB>token<TAB>page_depth).
+#          NEVER writes into ~/.masc — the operator decides where to
+#          place the fixture (e.g. a scratch keeper's lane file, server
+#          stopped, then restart).
+#   recall --keeper NAME --facts FILE.facts [--server URL]
+#          For each fact, ask the keeper for the value via
+#          POST /api/v1/gate/message and grep the reply for the token.
+#          Prints per-depth recall JSON. Auth: $FACT_HARNESS_TOKEN as
+#          Bearer when set.
+#
+# Recall semantics: a hit means the keeper produced the exact planted
+# token. The fixture pads facts deeper than one window, so a keeper
+# that never pages cannot score above the page-1 bucket — that gap is
+# the metric.
+set -euo pipefail
+
+SERVER="${MASC_SERVER:-http://localhost:8935}"
+PAGES=11
+
+mode="${1:-}"; shift || true
+
+case "$mode" in
+  gen)
+    OUT=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --out) OUT="$2"; shift 2 ;;
+        --pages) PAGES="$2"; shift 2 ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+      esac
+    done
+    [ -n "$OUT" ] || { echo "gen requires --out FILE" >&2; exit 2; }
+    total=$(( PAGES * 100 ))
+    # Facts at tail page 1, middle, and the oldest page. Plain case
+    # functions, not declare -A: macOS ships bash 3.2.
+    mid_page=$(( (PAGES + 1) / 2 ))
+    fact_line() {
+      case "$1" in
+        ALPHA) echo $(( total - 50 )) ;;
+        BRAVO) echo $(( total - (mid_page - 1) * 100 - 50 )) ;;
+        CHARLIE) echo 50 ;;
+      esac
+    }
+    fact_page() {
+      case "$1" in
+        ALPHA) echo 1 ;;
+        BRAVO) echo "$mid_page" ;;
+        CHARLIE) echo "$PAGES" ;;
+      esac
+    }
+    : > "$OUT"
+    for (( i=1; i<=total; i++ )); do
+      role=$([ $(( i % 2 )) -eq 1 ] && echo user || echo assistant)
+      content="filler chatter $(printf '%04d' "$i")"
+      for key in ALPHA BRAVO CHARLIE; do
+        if [ "$(fact_line "$key")" -eq "$i" ]; then
+          content="the $(echo "$key" | tr 'A-Z' 'a-z') deployment token is FACT-${key}-7319"
+        fi
+      done
+      printf '{"role":"%s","content":"%s","ts":%d.0,"source":"discord"}\n' \
+        "$role" "$content" "$i" >> "$OUT"
+    done
+    : > "${OUT}.facts"
+    for key in ALPHA BRAVO CHARLIE; do
+      printf '%s\tFACT-%s-7319\t%d\n' "$key" "$key" "$(fact_page "$key")" >> "${OUT}.facts"
+    done
+    echo "fixture: $OUT ($total lines, $PAGES pages); manifest: ${OUT}.facts"
+    ;;
+
+  recall)
+    KEEPER="" FACTS=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --keeper) KEEPER="$2"; shift 2 ;;
+        --facts) FACTS="$2"; shift 2 ;;
+        --server) SERVER="$2"; shift 2 ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+      esac
+    done
+    [ -n "$KEEPER" ] && [ -f "$FACTS" ] || {
+      echo "recall requires --keeper NAME --facts FILE.facts" >&2; exit 2; }
+    auth=()
+    [ -n "${FACT_HARNESS_TOKEN:-}" ] && auth=(-H "Authorization: Bearer ${FACT_HARNESS_TOKEN}")
+    hits=0; misses=0; rows=()
+    while IFS=$'\t' read -r key token page; do
+      lc_key=$(echo "$key" | tr 'A-Z' 'a-z')
+      question="What is the ${lc_key} deployment token mentioned earlier in this channel? It may be far back - walk the history with keeper_surface_read using its before parameter until you find it. Reply with the exact token."
+      body=$(jq -n \
+        --arg keeper "$KEEPER" --arg content "$question" --arg idem "fact-$key-$$" \
+        '{channel:"discord", channel_user_id:"fact-harness", channel_user_name:"fact-harness",
+          channel_workspace_id:"fact-harness", keeper_name:$keeper, content:$content,
+          idempotency_key:$idem, metadata:{}}')
+      reply=$(curl -sS -X POST "${SERVER}/api/v1/gate/message" \
+        -H 'Content-Type: application/json' ${auth[@]+"${auth[@]}"} -d "$body" \
+        | jq -r '.reply // ""')
+      if [[ "$reply" == *"$token"* ]]; then verdict=hit; hits=$((hits+1));
+      else verdict=miss; misses=$((misses+1)); fi
+      rows+=("{\"fact\":\"$key\",\"page_depth\":$page,\"verdict\":\"$verdict\"}")
+      echo "[$verdict] $key (page $page)" >&2
+    done < "$FACTS"
+    total=$((hits + misses))
+    printf '{"keeper":"%s","recall":%s,"hits":%d,"total":%d,"facts":[%s]}\n' \
+      "$KEEPER" "$(jq -n --argjson h "$hits" --argjson t "$total" '$h / ([$t,1]|max)')" \
+      "$hits" "$total" "$(IFS=,; echo "${rows[*]}")"
+    ;;
+
+  *)
+    sed -n '2,25p' "$0" | sed 's/^# \{0,1\}//'
+    exit 2
+    ;;
+esac

--- a/test/dune
+++ b/test/dune
@@ -183,6 +183,7 @@
   test_keeper_unified_metacognition
   test_keeper_surface_post
   test_keeper_person_notes
+  test_fact_retention_reachability
   test_keeper_surface_read
   test_keeper_surface_presence_prompt
   test_keeper_unified_verification_surface
@@ -448,6 +449,7 @@
   test_keeper_unified_metacognition
   test_keeper_surface_post
   test_keeper_person_notes
+  test_fact_retention_reachability
   test_keeper_surface_read
   test_keeper_surface_presence_prompt
   test_keeper_unified_verification_surface

--- a/test/test_fact_retention_reachability.ml
+++ b/test/test_fact_retention_reachability.ml
@@ -1,0 +1,151 @@
+(* RFC-0228 P2 — fact-retention harness, deterministic half.
+
+   Proves the *mechanism*: every fact planted in a lane is reachable
+   through the paged pull (load_page before-walk), at the expected
+   page depth, with one call per page. The non-deterministic half —
+   whether a live keeper chooses to walk — is the live runner
+   (scripts/harness/fact-retention.sh) and is gated outside CI.
+
+   Fixture is formula-generated (no Random): reproducible by
+   construction. *)
+
+module K = Masc.Keeper_chat_store
+
+let rec remove_tree path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path
+      |> Array.iter (fun name -> remove_tree (Filename.concat path name));
+      Unix.rmdir path
+    end
+    else Sys.remove path
+
+let temp_base_path prefix =
+  Filename.concat
+    (Filename.get_temp_dir_name ())
+    (Printf.sprintf "%s-%d-%d" prefix (Unix.getpid ()) (Random.bits ()))
+
+let keeper_name = "fact-retention-keeper"
+
+let chat_path ~base_dir =
+  Filename.concat
+    (Filename.concat
+       (Common.masc_dir_from_base_path ~base_path:base_dir)
+       "keeper_chat")
+    (Workspace_utils_backend_setup.sanitize_namespace_segment keeper_name
+    ^ ".jsonl")
+
+(* 1,100 primaries = 11 pages of [max_history] = 100. Facts planted at
+   line numbers chosen to land on pages 1, 4, and 11 (counted from the
+   tail): page k covers lines (total - k*100 + 1) .. (total - (k-1)*100). *)
+let total_lines = 1100
+let facts = [ ("ALPHA", 1050, 1); ("BRAVO", 750, 4); ("CHARLIE", 50, 11) ]
+
+let fact_token key = Printf.sprintf "FACT-%s-7319" key
+
+let write_fixture ~path =
+  let dir = Filename.dirname path in
+  let rec mkdir_p d =
+    if d = "" || d = "." || d = "/" || Sys.file_exists d then ()
+    else begin
+      mkdir_p (Filename.dirname d);
+      Unix.mkdir d 0o755
+    end
+  in
+  mkdir_p dir;
+  let buf = Buffer.create (total_lines * 90) in
+  for i = 1 to total_lines do
+    let content =
+      match List.find_opt (fun (_, line, _) -> line = i) facts with
+      | Some (key, _, _) ->
+          Printf.sprintf "the %s deployment token is %s" (String.lowercase_ascii key)
+            (fact_token key)
+      | None -> Printf.sprintf "filler chatter %04d" i
+    in
+    Buffer.add_string buf
+      (Yojson.Safe.to_string
+         (`Assoc
+           [
+             ("role", `String (if i mod 2 = 1 then "user" else "assistant"));
+             ("content", `String content);
+             ("ts", `Float (float_of_int i));
+             ("source", `String "discord");
+           ]));
+    Buffer.add_char buf '\n'
+  done;
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc (Buffer.contents buf))
+
+let page_contains token (page : K.page) =
+  List.exists
+    (fun (m : K.chat_message) ->
+      Astring.String.is_infix ~affix:token m.K.content)
+    page.K.messages
+
+let oldest_ts (page : K.page) =
+  match page.K.messages with
+  | [] -> None
+  | first :: _ -> first.K.ts
+
+(* Walk back from the tail until [token] appears; return pages read. *)
+let pages_to_find ~base_dir token : int option =
+  let max_pages = 50 in
+  let rec go ~before ~page_no =
+    if page_no > max_pages then None
+    else
+      let page =
+        match before with
+        | None -> K.load_page ~base_dir ~keeper_name ()
+        | Some b -> K.load_page ~base_dir ~keeper_name ~before:b ()
+      in
+      if page_contains token page then Some page_no
+      else if not page.K.has_more then None
+      else
+        match oldest_ts page with
+        | None -> None
+        | Some ts -> go ~before:(Some ts) ~page_no:(page_no + 1)
+  in
+  go ~before:None ~page_no:1
+
+let test_every_planted_fact_is_reachable_at_depth () =
+  let base_dir = temp_base_path "fact-retention" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      write_fixture ~path:(chat_path ~base_dir);
+      List.iter
+        (fun (key, _line, expected_page) ->
+          match pages_to_find ~base_dir (fact_token key) with
+          | Some n ->
+              Alcotest.(check int)
+                (Printf.sprintf "%s found at expected depth" key)
+                expected_page n
+          | None ->
+              Alcotest.failf "fact %s unreachable through paged pull" key)
+        facts)
+
+let test_walk_terminates_at_history_start () =
+  let base_dir = temp_base_path "fact-retention-end" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      write_fixture ~path:(chat_path ~base_dir);
+      (* A token that was never planted: the walk must exhaust all 11
+         pages and stop on has_more=false, not loop. *)
+      Alcotest.(check (option int))
+        "absent fact exhausts cleanly" None
+        (pages_to_find ~base_dir "FACT-NEVER-0000"))
+
+let () =
+  Alcotest.run "fact_retention_reachability"
+    [
+      ( "paged reachability (RFC-0228 P2)",
+        [
+          Alcotest.test_case "every planted fact reachable at its depth"
+            `Quick test_every_planted_fact_is_reachable_at_depth;
+          Alcotest.test_case "walk terminates at history start" `Quick
+            test_walk_terminates_at_history_start;
+        ] );
+    ]


### PR DESCRIPTION
## RFC-0228 P2 — fact-retention harness

RFC §4 (#20779, merged). digest 작업의 선행 게이트 — "recall은 측정하지, 가정하지 않는다."

### 결정론/비결정론 경계로 분할

| Half | 무엇을 증명 | 어디서 |
|---|---|---|
| **CI** (`test_fact_retention_reachability`) | **메커니즘**: 1,100행 lane에 page depth 1/4/11로 심은 fact가 `load_page` before-walk로 정확히 그 depth에서 도달됨 + 없는 fact는 `has_more=false`에서 깨끗하게 종료 (무한 walk 없음) | 2/2 green |
| **Live** (`scripts/harness/fact-retention.sh`) | **행동**: 라이브 keeper가 실제로 페이징을 *하는가* — gate route로 질문, 응답에서 심은 토큰 grep, per-depth recall JSON | 운영자 실행 |

### Live 러너 사용법 (지금 라이브 검증에 바로 쓸 수 있음)

```bash
# 1) fixture 생성 (~/.masc에 절대 직접 쓰지 않음 — 배치는 운영자 판단)
scripts/harness/fact-retention.sh gen --out /tmp/fact-lane.jsonl --pages 11
# 2) scratch keeper의 lane에 배치 (서버 정지 상태에서) 후 재시작
# 3) recall 측정
FACT_HARNESS_TOKEN=<bearer> scripts/harness/fact-retention.sh recall \
  --keeper <scratch-keeper> --facts /tmp/fact-lane.jsonl.facts
```

fixture는 fact를 window(100 primaries) 너머에 심으므로, **페이징을 안 하는 keeper는 page-1 bucket 이상을 못 맞춥니다** — 그 갭이 메트릭입니다.

### 검증

- `@check` EXIT=0, 신규 테스트 2/2
- `gen` 스모크: 1,100행 fixture + manifest(depth 1/6/11) 생성 확인, fact 라인 위치 검증
- bash 3.2 호환 (`declare -A`/`${var,,}` 제거, 빈 배열 `set -u` 가드) — macOS 기본 bash에서 동작

### 비포함 (RFC대로)

- `mode: digest` — 이 하네스가 먼저 살아 있고, paged pull로 부족하다는 실측이 나올 때만
- CI에서의 live half 실행 — LLM 의존이라 RFC-0227(benchmark canary) 인프라 소관

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
