### PR TITLE
feat(server): person-notes endpoint (RFC-0229 P2 server half)

### DIFF
--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -37,6 +37,26 @@ let handle_keeper_get_subroutes state req request reqd =
       in
       Server_auth.respond_json_value_with_cors ~status:`OK request reqd
         (Keeper_chat_store.to_json_array messages)
+  else if ends_with "/person-notes" then
+    (* RFC-0229 P2: keeper-authored person notes for the roster pane.
+       Read-only fold over the notes store; same shape as the tool
+       surface ([{speaker_id, note}]). *)
+    let name = extract_name "/person-notes" in
+    if name = "" then
+      Server_auth.respond_json_value_with_cors ~status:`Bad_request request reqd
+        (error_json "missing keeper name")
+    else
+      let base_dir = state.Mcp_server.workspace_config.base_path in
+      let notes = Keeper_person_notes.notes ~base_dir ~keeper_name:name in
+      Server_auth.respond_json_value_with_cors ~status:`OK request reqd
+        (`List
+          (List.map
+             (fun (speaker_id, note) ->
+               `Assoc
+                 [ ("speaker_id", `String speaker_id)
+                 ; ("note", `String note)
+                 ])
+             notes))
   else if ends_with keeper_suffix_checkpoints then
     let name = extract_name keeper_suffix_checkpoints in
     if String.length name = 0 then


### PR DESCRIPTION
## RFC-0229 P2 — server half: person-notes REST endpoint

> **스택**: #20788 (P1) 위. P1 머지 후 rebase하면 단독 diff가 됩니다.

`GET /api/v1/keepers/:name/person-notes` → `[{speaker_id, note}]` — `Keeper_person_notes.notes`의 read-only fold, 도구 표면과 동일한 행 형태. 기존 `/chat/history` 라우트와 같은 dispatcher/auth/CORS 경로.

### 범위 분할 근거

P2의 UI render(roster pane에 note 표시)는 대시보드 상태/컴포넌트/vitest 배선이 별도 작업 단위라 분리합니다 (worktree node_modules 함정 포함 — 검증 절차가 다름). endpoint가 먼저 있어야 UI PR이 mock 없이 실데이터로 개발 가능합니다.

### 검증

- `@check` + default: EXIT=0
- 라우트는 10줄 위임 — 저장소 fold 로직은 P1의 `test_keeper_person_notes` 3/3이 커버. HTTP 레벨은 기존 route 패턴 그대로(신규 분기 없음)
- 수동: `curl $MASC/api/v1/keepers/<name>/person-notes` → `[]` (노트 없음) 또는 행 배열

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
