### PR TITLE
ci: fix invalid workflow file - expression syntax inside shell comment

### DIFF
--- a/.github/workflows/test-coverage-check.yml
+++ b/.github/workflows/test-coverage-check.yml
@@ -26,9 +26,9 @@ jobs:
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          # GITHUB_OUTPUT is an environment variable, not an expression
-          # context: ${{ GITHUB_OUTPUT }} expands to "" and breaks the
-          # redirect.
+          # GITHUB_OUTPUT must be referenced as a shell variable; the
+          # expression-context form is undefined there and invalidates
+          # the whole workflow file (even inside a shell comment).
           if echo "$PR_BODY" | grep -q '# ci:skip-test-coverage'; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
#20784 머지본의 `run:` 블록 셸 주석에 `${{ GITHUB_OUTPUT }}` 리터럴이 들어 있었습니다. GitHub은 `run` 문자열 전체에서 expression을 평가하므로(셸 주석 여부 무관) `GITHUB_OUTPUT`이 expression context에 없어 **워크플로 파일 전체가 invalid** 처리되었고, 그 결과 main push마다 no-job failure run이 생성되고 있었습니다 (11:20/12:22/12:33 KST 5연속 실패가 이것).

수정: 주석에서 expression 구문 제거 (문장으로 풀어 설명).

검증: `actionlint` clean — 수정 전엔 `28:91: undefined variable "GITHUB_OUTPUT"` 1건 보고. 로컬 PyYAML은 통과했던 것이라 YAML 문법이 아니라 GitHub expression 검증 레벨의 문제.

원인 제공 커밋은 제 수리 커밋 `7b870b407`입니다 — 버그를 설명하는 주석이 그 버그를 재생산한 케이스.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
