### PR TITLE
feat(dashboard): stale-tab bundle staleness banner

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -42,6 +42,7 @@ import { selectedAgentName } from './components/agent-detail-selection'
 import { selectedTask } from './components/goals/task-detail-selection'
 import { ToastContainer } from './components/common/toast'
 import { ConfirmDialogOverlay } from './components/common/confirm-dialog'
+import { BundleStalenessBanner, installBundleStalenessWatch } from './components/bundle-staleness-banner'
 import { startErrorCleanup, stopErrorCleanup } from './components/common/error-notification-state'
 import { DashboardStatusTray } from './components/status-tray'
 import { DashboardFocusModeToggle, dashboardFocusMode } from './components/focus-mode-toggle'
@@ -216,6 +217,9 @@ export function App() {
     // Error notification cleanup (removes old acknowledged errors)
     startErrorCleanup()
 
+    // Detect a newer served bundle when the tab is picked up again
+    const uninstallStalenessWatch = installBundleStalenessWatch()
+
     return () => {
       cancelled = true
       stopSseFallback()
@@ -227,6 +231,7 @@ export function App() {
       stopPeriodicRefresh()
       stopErrorCleanup()
       disposeNamespaceTruthScheduler()
+      uninstallStalenessWatch()
     }
   }, [])
 
@@ -366,6 +371,7 @@ export function App() {
       `}
       <${ToastContainer} />
       <${ConfirmDialogOverlay} />
+      <${BundleStalenessBanner} />
       <${Suspense} fallback=${null}>
         <${LazyCommandPalette} />
       <//>

--- a/dashboard/src/components/bundle-staleness-banner.test.ts
+++ b/dashboard/src/components/bundle-staleness-banner.test.ts
@@ -1,0 +1,155 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import {
+  BundleStalenessBanner,
+  checkBundleStaleness,
+  currentEntryBundleSrc,
+  extractEntryBundleSrc,
+  installBundleStalenessWatch,
+  newerBundleAvailable,
+  resetBundleStalenessState,
+} from './bundle-staleness-banner'
+
+const SERVED_HTML = (hash: string) => `<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <script type="module" crossorigin src="/dashboard/assets/index-${hash}.js"></script>
+  <link rel="modulepreload" crossorigin href="/dashboard/assets/vendor-7p9DjONY.js">
+</head>
+<body><div id="app"></div></body>
+</html>`
+
+// No type="module": happy-dom would try to actually load the module
+// and spam the run with fetch failures. The component queries on the
+// src substring only, so the type attribute is irrelevant to the test.
+const mountOwnEntryScript = (hash: string): HTMLScriptElement => {
+  const script = document.createElement('script')
+  script.setAttribute('src', `/dashboard/assets/index-${hash}.js`)
+  document.head.appendChild(script)
+  return script
+}
+
+const fetchReturning = (body: string, ok = true) =>
+  vi.fn().mockResolvedValue({ ok, text: async () => body } as Response)
+
+const flushUi = async () => {
+  for (let i = 0; i < 4; i++) await Promise.resolve()
+}
+
+describe('extractEntryBundleSrc', () => {
+  it('extracts the hashed entry path from served index.html', () => {
+    expect(extractEntryBundleSrc(SERVED_HTML('fMmTbvTW')))
+      .toBe('/dashboard/assets/index-fMmTbvTW.js')
+  })
+
+  it('ignores modulepreload chunks (href=, not src=)', () => {
+    const noEntry = SERVED_HTML('x').replace(/<script[^>]*><\/script>/, '')
+    expect(extractEntryBundleSrc(noEntry)).toBeNull()
+  })
+
+  it('returns null for dev-server HTML without a hashed entry', () => {
+    expect(extractEntryBundleSrc('<script type="module" src="/src/main.tsx"></script>'))
+      .toBeNull()
+  })
+})
+
+describe('checkBundleStaleness', () => {
+  let ownScript: HTMLScriptElement | null = null
+  beforeEach(() => resetBundleStalenessState())
+  afterEach(() => {
+    ownScript?.remove()
+    ownScript = null
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('does not probe when the tab has no hashed entry (dev server)', async () => {
+    const fetchSpy = fetchReturning(SERVED_HTML('AAAA'))
+    expect(currentEntryBundleSrc()).toBeNull()
+    await checkBundleStaleness(fetchSpy)
+    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(newerBundleAvailable.value).toBe(false)
+  })
+
+  it('stays quiet when the served hash matches this tab', async () => {
+    ownScript = mountOwnEntryScript('SAME')
+    await checkBundleStaleness(fetchReturning(SERVED_HTML('SAME')))
+    expect(newerBundleAvailable.value).toBe(false)
+  })
+
+  it('arms the banner when the server serves a different hash', async () => {
+    ownScript = mountOwnEntryScript('OLD1')
+    await checkBundleStaleness(fetchReturning(SERVED_HTML('NEW2')))
+    expect(newerBundleAvailable.value).toBe(true)
+  })
+
+  it('treats a failed probe as no information (offline must not nag)', async () => {
+    ownScript = mountOwnEntryScript('OLD1')
+    await checkBundleStaleness(vi.fn().mockRejectedValue(new Error('offline')))
+    expect(newerBundleAvailable.value).toBe(false)
+  })
+
+  it('treats a non-200 response as no information', async () => {
+    ownScript = mountOwnEntryScript('OLD1')
+    await checkBundleStaleness(fetchReturning('Service Unavailable', false))
+    expect(newerBundleAvailable.value).toBe(false)
+  })
+
+  it('re-probes when the tab regains visibility', async () => {
+    ownScript = mountOwnEntryScript('OLD1')
+    vi.stubGlobal('fetch', fetchReturning(SERVED_HTML('NEW2')))
+    const uninstall = installBundleStalenessWatch()
+    document.dispatchEvent(new Event('visibilitychange'))
+    await flushUi()
+    expect(newerBundleAvailable.value).toBe(true)
+    uninstall()
+  })
+})
+
+describe('BundleStalenessBanner', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    resetBundleStalenessState()
+  })
+  afterEach(() => {
+    document.body.removeChild(container)
+  })
+
+  it('renders nothing while the tab is current', () => {
+    render(html`<${BundleStalenessBanner} />`, container)
+    expect(container.querySelector('[data-bundle-staleness-banner]')).toBeNull()
+  })
+
+  it('shows reload + dismiss once a newer bundle is detected', async () => {
+    newerBundleAvailable.value = true
+    render(html`<${BundleStalenessBanner} />`, container)
+    await flushUi()
+    expect(container.querySelector('[data-bundle-staleness-banner]')).toBeTruthy()
+  })
+
+  it('reload button triggers the injected reload', async () => {
+    newerBundleAvailable.value = true
+    const reload = vi.fn()
+    render(html`<${BundleStalenessBanner} reload=${reload} />`, container)
+    await flushUi()
+    const buttons = container.querySelectorAll('button')
+    const reloadBtn = Array.from(buttons).find(b => b.textContent?.includes('새로고침'))!
+    reloadBtn.click()
+    expect(reload).toHaveBeenCalledTimes(1)
+  })
+
+  it('dismiss hides the banner without reloading', async () => {
+    newerBundleAvailable.value = true
+    render(html`<${BundleStalenessBanner} />`, container)
+    await flushUi()
+    const buttons = container.querySelectorAll('button')
+    const dismissBtn = Array.from(buttons).find(b => b.textContent?.includes('나중에'))!
+    dismissBtn.click()
+    await flushUi()
+    expect(container.querySelector('[data-bundle-staleness-banner]')).toBeNull()
+  })
+})

--- a/dashboard/src/components/bundle-staleness-banner.ts
+++ b/dashboard/src/components/bundle-staleness-banner.ts
@@ -1,0 +1,127 @@
+// BundleStalenessBanner — a long-lived tab keeps executing the bundle
+// it booted with, even after the server starts serving a newer build.
+// The stale tab then drives the server through code paths the current
+// source no longer has (2026-06-11: a pre-RFC-0203 tab fired
+// POST /api/v1/sidecar/stop?name=discord — an endpoint no current UI
+// calls — and the operator saw a ghost error). BuildIdentityBadge
+// shows the *server's* build; nothing compared it to the bundle the
+// tab itself is running. This banner closes that gap.
+//
+// Detection is purely client-side: Vite stamps a content hash into the
+// entry script name (/dashboard/assets/index-<hash>.js). The tab's own
+// <script> tag still carries the hash it booted from; re-fetching
+// /dashboard returns the index.html the server serves NOW. Different
+// hash ⇒ newer bundle. Checks run when the tab regains visibility or
+// focus — the moment a stale tab is picked up again — so there is no
+// polling loop. A tab that stays visible through a deploy is not
+// covered; it will be caught on its next focus cycle.
+//
+// The banner never reloads on its own: an unprompted reload can eat
+// in-progress form state (channel drafts, config edits).
+
+import { html } from 'htm/preact'
+import { signal } from '@preact/signals'
+import { ActionButton } from './common/button'
+
+export const newerBundleAvailable = signal(false)
+const dismissed = signal(false)
+
+export function resetBundleStalenessState() {
+  newerBundleAvailable.value = false
+  dismissed.value = false
+}
+
+/** Matches the entry-script reference in the served index.html. Only
+    <script> tags carry src= (modulepreload chunks use href=), and Vite
+    emits exactly one hashed entry per page, so the first src= match is
+    the entry bundle. */
+const ENTRY_SRC_RE = /src="(\/dashboard\/assets\/index-[\w-]+\.js)"/
+
+/** Pure: extract the hashed entry-bundle path from an index.html
+    document. Returns null when no hashed entry is referenced (dev
+    server HTML, error pages). */
+export function extractEntryBundleSrc(indexHtml: string): string | null {
+  const match = indexHtml.match(ENTRY_SRC_RE)
+  return match?.[1] ?? null
+}
+
+/** The entry-bundle path this tab booted from, read off its own
+    <script type="module"> tag. Null under the Vite dev server (which
+    serves /src/main.tsx unhashed) — staleness checks are a no-op
+    there. */
+export function currentEntryBundleSrc(doc: Document = document): string | null {
+  const script = doc.querySelector('script[src*="/dashboard/assets/index-"]')
+  return script?.getAttribute('src') ?? null
+}
+
+/** Compare this tab's entry bundle against the one the server serves
+    now; arm the banner signal on mismatch. Probe failures (offline,
+    non-200, no hash in the response) never arm the banner — a failed
+    probe proves nothing about staleness. */
+export async function checkBundleStaleness(
+  fetchImpl: typeof fetch = fetch,
+  doc: Document = document,
+): Promise<void> {
+  const own = currentEntryBundleSrc(doc)
+  if (own === null) return
+  try {
+    const res = await fetchImpl('/dashboard', { cache: 'no-store' })
+    if (!res.ok) return
+    const served = extractEntryBundleSrc(await res.text())
+    if (served !== null && served !== own) {
+      newerBundleAvailable.value = true
+    }
+  } catch {
+    // Offline or transient network failure — re-checked on next focus.
+  }
+}
+
+/** Install visibility/focus listeners that re-probe on tab return.
+    Returns the uninstaller (for the app root's effect cleanup). */
+export function installBundleStalenessWatch(
+  doc: Document = document,
+  win: Window = window,
+): () => void {
+  const onReturn = () => {
+    if (doc.visibilityState === 'visible') void checkBundleStaleness(fetch, doc)
+  }
+  doc.addEventListener('visibilitychange', onReturn)
+  win.addEventListener('focus', onReturn)
+  return () => {
+    doc.removeEventListener('visibilitychange', onReturn)
+    win.removeEventListener('focus', onReturn)
+  }
+}
+
+interface BannerProps {
+  /** Injected for tests; defaults to a full page reload. */
+  reload?: () => void
+}
+
+export function BundleStalenessBanner({ reload }: BannerProps = {}) {
+  if (!newerBundleAvailable.value || dismissed.value) return null
+  const doReload = reload ?? (() => { window.location.reload() })
+  return html`
+    <div
+      data-bundle-staleness-banner
+      class="fixed bottom-5 left-1/2 z-[var(--z-overlay-toast,3070)] flex -translate-x-1/2 items-center gap-3 rounded-[var(--r-2)] border border-solid border-[var(--warn-20)] bg-[var(--color-bg-surface)] px-4 py-2.5 text-xs text-[var(--color-fg-primary)] shadow-[var(--shadow-panel)]"
+      role="status"
+    >
+      <span>
+        새 대시보드 빌드가 배포되었습니다 — 이 탭은 이전 번들을 실행 중입니다.
+      </span>
+      <${ActionButton}
+        variant="primary"
+        size="sm"
+        ariaLabel="reload to latest dashboard build"
+        onClick=${doReload}
+      >새로고침<//>
+      <${ActionButton}
+        variant="ghost"
+        size="sm"
+        ariaLabel="dismiss stale bundle notice"
+        onClick=${() => { dismissed.value = true }}
+      >나중에<//>
+    </div>
+  `
+}


### PR DESCRIPTION
## 무엇

탭이 부팅 시점의 번들을 계속 실행하다가, 서버가 더 새 빌드를 서빙 중이면 하단에 배너로 알리고 새로고침 버튼을 제공합니다.

## 왜

오늘(2026-06-11) 실제 발생: RFC-0203 이전 번들을 돌리던 탭이 `POST /api/v1/sidecar/stop?name=discord`를 호출 — 현재 소스 어디에도 없는 호출이라 운영자가 유령 에러를 봤습니다. `BuildIdentityBadge`는 서버 빌드만 보여주고, 탭 자신의 번들과 비교하는 장치는 없었습니다.

## 어떻게

- Vite가 entry 스크립트 이름에 박는 콘텐츠 해시를 이용: 탭 자신의 `<script src="/dashboard/assets/index-<hash>.js">` vs `/dashboard` 재요청으로 받은 index.html의 해시를 비교
- 체크 시점은 `visibilitychange`/`focus` 복귀 시에만 — 폴링 루프 없음
- 자동 리로드 없음 (작성 중인 channel draft, config 폼 보호) — 새로고침/나중에 버튼만
- 프로브 실패(오프라인, non-200, 해시 없음)는 정보 없음으로 취급해 배너를 켜지 않음
- dev 서버(해시 없는 entry)에서는 자동으로 no-op

## 경계

탭이 deploy 내내 visible+focused 상태로 유지되는 경우는 다음 focus 사이클까지 감지하지 못합니다 (의도: 폴링 배제).

## 검증

- `tsc --noEmit` 0 errors
- vitest 신규 13/13 (extract/probe/visibility/render/reload/dismiss), 기존 `app.test.ts` 2/2
- eslint 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
