### PR TITLE
feat(keeper): RFC-0230 P1 — typed lane_signal boundary parse

### DIFF
--- a/lib/keeper/keeper_world_observation_message_scope.ml
+++ b/lib/keeper/keeper_world_observation_message_scope.ml
@@ -44,6 +44,42 @@ let is_keeper_authored_message author =
   Option.is_some (Keeper_identity.canonical_keeper_name_from_agent_name author)
 ;;
 
+(* RFC-0230 §3.1 — boundary parse: turn one lane line into a typed signal.
+
+   Pure over primitive inputs: [self_tokens] is the keeper's identity-token set
+   (see [self_identity_tokens]) and [mention_targets] its addressable names (see
+   [message_feed_targets]). The "@<target>" substring scan mirrors the board
+   mention matcher (Keeper_world_observation_board_signal.match_signal) and runs
+   once here, producing a typed [lane_signal] rather than a downstream substring
+   gate. P1 classifies a non-self, non-mention line as [Ambient]; [Scope_message]
+   is emitted in RFC-0230 P2 once scope subscription is wired. *)
+type lane_signal =
+  | Direct_mention of { speaker : string; at : float }
+  | Scope_message of { speaker : string; at : float }
+  | Self_authored
+  | Ambient
+
+let classify_lane_line
+      ~(self_tokens : string list)
+      ~(mention_targets : string list)
+      ~(speaker : string)
+      ~(text : string)
+      ~(at : float)
+  : lane_signal
+  =
+  if is_self_author ~self_tokens speaker
+  then Self_authored
+  else (
+    let haystack = String.lowercase_ascii text in
+    let is_mention target =
+      let needle = "@" ^ String.lowercase_ascii (String.trim target) in
+      needle <> "@" && String_util.contains_substring haystack needle
+    in
+    if List.exists is_mention mention_targets
+    then Direct_mention { speaker; at }
+    else Ambient)
+;;
+
 let collect_message_scope ~(config : Workspace.config) ~(meta : keeper_meta)
   : (string * string) list * (string * string) list * (string * int) list
   =

--- a/lib/keeper/keeper_world_observation_message_scope.mli
+++ b/lib/keeper/keeper_world_observation_message_scope.mli
@@ -8,6 +8,29 @@ val self_identity_tokens : keeper_meta -> string list
 val is_self_author : self_tokens:string list -> string -> bool
 val is_keeper_authored_message : string -> bool
 
+(** A lane line parsed into a typed signal at the observation boundary
+    (RFC-0230 §3.1). [Scope_message] is reserved for P2; P1's
+    {!classify_lane_line} emits only [Direct_mention], [Self_authored], and
+    [Ambient]. *)
+type lane_signal =
+  | Direct_mention of { speaker : string; at : float }
+  | Scope_message of { speaker : string; at : float }
+  | Self_authored
+  | Ambient
+
+(** [classify_lane_line ~self_tokens ~mention_targets ~speaker ~text ~at]
+    parses one lane line into a {!lane_signal}. A line authored by the keeper
+    itself (per [self_tokens]) is [Self_authored]; otherwise an "@<target>"
+    match against [mention_targets] yields [Direct_mention], and anything else
+    is [Ambient]. Pure: no [keeper_meta], no I/O. *)
+val classify_lane_line
+  :  self_tokens:string list
+  -> mention_targets:string list
+  -> speaker:string
+  -> text:string
+  -> at:float
+  -> lane_signal
+
 val collect_message_scope
   :  config:Workspace.config
   -> meta:keeper_meta

--- a/test/dune
+++ b/test/dune
@@ -30,6 +30,7 @@
 (tests
  (names
   test_keeper_reactive_wake_backlog_gate
+  test_keeper_lane_signal
   test_board_activity_cache
   test_jsonl_mtime_projection
   test_jsonl_incremental_projection
@@ -296,6 +297,7 @@
   test_log_severity_outcome_level)
  (modules
   test_keeper_reactive_wake_backlog_gate
+  test_keeper_lane_signal
   test_board_activity_cache
   test_jsonl_mtime_projection
   test_jsonl_incremental_projection

--- a/test/test_keeper_lane_signal.ml
+++ b/test/test_keeper_lane_signal.ml
@@ -1,0 +1,73 @@
+(* Alcotest unit tests for
+   [Keeper_world_observation_message_scope.classify_lane_line] (RFC-0230 P1).
+
+   The classifier is a pure boundary parse, so these tests need no keeper_meta
+   construction — only the keeper's identity tokens and addressable names. *)
+
+open Masc.Keeper_world_observation_message_scope
+
+let label = function
+  | Direct_mention _ -> "direct_mention"
+  | Scope_message _ -> "scope_message"
+  | Self_authored -> "self_authored"
+  | Ambient -> "ambient"
+;;
+
+let self_tokens = [ "dreamer" ]
+let mention_targets = [ "dreamer" ]
+
+let classify ~speaker ~text =
+  classify_lane_line ~self_tokens ~mention_targets ~speaker ~text ~at:1.0
+;;
+
+let test_direct_mention () =
+  let s = classify ~speaker:"alice" ~text:"hey @dreamer take a look" in
+  Alcotest.(check string) "@target by another speaker" "direct_mention" (label s);
+  match s with
+  | Direct_mention { speaker; _ } ->
+    Alcotest.(check string) "speaker preserved" "alice" speaker
+  | _ -> Alcotest.fail "expected Direct_mention"
+;;
+
+let test_self_authored_wins_over_mention () =
+  (* A keeper that @-mentions itself must not wake itself: self check first. *)
+  let s = classify ~speaker:"Dreamer" ~text:"@dreamer note to self" in
+  Alcotest.(check string) "self speaker overrides mention" "self_authored" (label s)
+;;
+
+let test_ambient () =
+  let s = classify ~speaker:"alice" ~text:"just chatting about the weather" in
+  Alcotest.(check string) "no mention, not self" "ambient" (label s)
+;;
+
+let test_other_target_is_ambient () =
+  let s = classify ~speaker:"alice" ~text:"hey @bob can you help" in
+  Alcotest.(check string) "mention of a different target" "ambient" (label s)
+;;
+
+let test_case_insensitive_mention () =
+  let s = classify ~speaker:"alice" ~text:"PING @DREAMER NOW" in
+  Alcotest.(check string) "uppercase @MENTION still matches" "direct_mention" (label s)
+;;
+
+let test_empty_targets_is_ambient () =
+  let s =
+    classify_lane_line ~self_tokens ~mention_targets:[] ~speaker:"alice"
+      ~text:"@dreamer" ~at:1.0
+  in
+  Alcotest.(check string) "no mention_targets to match" "ambient" (label s)
+;;
+
+let () =
+  Alcotest.run "keeper_lane_signal"
+    [ ( "classify_lane_line"
+      , [ Alcotest.test_case "direct_mention" `Quick test_direct_mention
+        ; Alcotest.test_case "self_authored_wins" `Quick
+            test_self_authored_wins_over_mention
+        ; Alcotest.test_case "ambient" `Quick test_ambient
+        ; Alcotest.test_case "other_target_ambient" `Quick test_other_target_is_ambient
+        ; Alcotest.test_case "case_insensitive" `Quick test_case_insensitive_mention
+        ; Alcotest.test_case "empty_targets_ambient" `Quick test_empty_targets_is_ambient
+        ] )
+    ]
+;;


### PR DESCRIPTION
## What

RFC-0230 P1: add the typed `lane_signal` boundary parse (`classify_lane_line`)
to `keeper_world_observation_message_scope`.

## Why

RFC-0230 §3.1 specifies that a lane line is parsed **once** into a typed signal
(`Direct_mention` / `Scope_message` / `Self_authored` / `Ambient`) instead of
being re-scanned as a string by downstream consumers. The `@<target>` match
mirrors the existing board mention matcher
(`Keeper_world_observation_board_signal.match_signal`) and reuses the identity
helpers already in the module (`is_self_author`, `message_feed_targets`), so
the string match is a sanctioned boundary parse producing a typed value — not a
downstream substring classifier.

## Scope (additive, no behavior change)

- `collect_message_scope` is untouched (still the stub) — nothing reads
  `lane_signal` yet.
- `Scope_message` is reserved for P2 (scope subscription); P1 classifies a
  non-self, non-mention line as `Ambient`.
- The engagement FSM and the cursor-scaffolding removal are P2.

The classifier is pure over primitive inputs (`self_tokens`,
`mention_targets`) — no `keeper_meta`, no I/O — and checks self-authorship
before the mention, so a keeper that `@`-mentions itself does not wake itself.

## Verification

- `dune build --root . @check` clean.
- `test/test_keeper_lane_signal.ml` — 6 cases pass (direct mention, self-author
  precedence, ambient, non-target mention, case-insensitivity, empty targets).
- The edited module's `.cmt`
  (`masc__Keeper_world_observation_message_scope.cmt`) is produced — type-check
  passed, not just exit 0.

## RFC

`docs/rfc/RFC-0230-keeper-mention-scope-reactivity.md` (merged via #20794 /
#20797). This is P1 of its phase plan (§4).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
