### PR TITLE
feat(dashboard): connector bind discoverability + action error detail split

### DIFF
--- a/dashboard/src/components/connector-action-error.test.ts
+++ b/dashboard/src/components/connector-action-error.test.ts
@@ -1,0 +1,78 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import {
+  rawErrorText,
+  showConnectorActionError,
+} from './connector-action-error'
+import { ToastContainer, _testGetToasts, _testResetToasts } from './common/toast'
+
+const RAW_SERVER_ERROR =
+  'POST /api/v1/sidecar/stop?name=discord: sidecar directory not found for discord; '
+  + 'looked under /Users/op/me/sidecars/discord-bot. Set MASC_SIDECAR_ROOT=/path/to/masc.'
+
+describe('rawErrorText', () => {
+  it('unwraps Error message', () => {
+    expect(rawErrorText(new Error('boom'))).toBe('boom')
+  })
+
+  it('stringifies non-Error throws', () => {
+    expect(rawErrorText('plain string')).toBe('plain string')
+    expect(rawErrorText(42)).toBe('42')
+  })
+})
+
+describe('showConnectorActionError', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    _testResetToasts()
+  })
+  afterEach(() => {
+    document.body.removeChild(container)
+    vi.restoreAllMocks()
+  })
+
+  it('toast carries the headline only — server internals stay out', () => {
+    showConnectorActionError('discord sidecar 중지 실패', new Error(RAW_SERVER_ERROR))
+    const toasts = _testGetToasts()
+    expect(toasts.length).toBe(1)
+    expect(toasts[0]!.message).toBe('discord sidecar 중지 실패')
+    expect(toasts[0]!.message).not.toContain('MASC_SIDECAR_ROOT')
+    expect(toasts[0]!.message).not.toContain('/Users/')
+    expect(toasts[0]!.type).toBe('error')
+  })
+
+  it('renders a 상세 action button on the toast', async () => {
+    showConnectorActionError('바인딩 실패: 123 → luna', new Error(RAW_SERVER_ERROR))
+    render(html`<${ToastContainer} />`, container)
+    await Promise.resolve()
+    const buttons = Array.from(container.querySelectorAll('button'))
+    expect(buttons.some(b => b.textContent?.includes('상세'))).toBe(true)
+  })
+
+  it('상세 opens a dialog containing the raw server text', async () => {
+    showConnectorActionError('바인딩 실패: 123 → luna', new Error(RAW_SERVER_ERROR))
+    render(html`<${ToastContainer} />`, container)
+    await Promise.resolve()
+    const detailBtn = Array.from(container.querySelectorAll('button'))
+      .find(b => b.textContent?.includes('상세'))!
+    detailBtn.click()
+    // The confirm-dialog overlay renders from its own module signal —
+    // mount it and look for the raw text.
+    const { ConfirmDialogOverlay } = await import('./common/confirm-dialog')
+    const dialogHost = document.createElement('div')
+    document.body.appendChild(dialogHost)
+    try {
+      render(html`<${ConfirmDialogOverlay} />`, dialogHost)
+      await Promise.resolve()
+      expect(dialogHost.textContent).toContain('MASC_SIDECAR_ROOT')
+      expect(dialogHost.textContent).toContain('바인딩 실패: 123 → luna')
+    } finally {
+      render(null, dialogHost)
+      document.body.removeChild(dialogHost)
+    }
+  })
+})

--- a/dashboard/src/components/connector-action-error.ts
+++ b/dashboard/src/components/connector-action-error.ts
@@ -1,0 +1,50 @@
+// Connector action failures — headline toast, raw detail on demand.
+//
+// The server's error text for sidecar/bind actions carries operator
+// internals (filesystem paths it probed, env-var hints — e.g. the
+// 2026-06-11 sidecar-stop error listed two absolute paths and a
+// MASC_SIDECAR_ROOT instruction). Dumping that into a toast buries the
+// one thing the operator needs first: which action on which connector
+// failed. The headline comes from the call site's typed context — no
+// string classification of the server text — and the raw text stays
+// one click away, copyable for a report.
+
+import { showActionToast, showToast } from './common/toast'
+import { requestConfirm } from './common/confirm-dialog'
+
+export function rawErrorText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}
+
+/** Error toast for a connector action: [headline] + '상세' button that
+    opens the full server text in a dialog. */
+export function showConnectorActionError(headline: string, err: unknown): void {
+  const raw = rawErrorText(err)
+  showActionToast(
+    headline,
+    { label: '상세', onClick: () => { void openConnectorErrorDetail(headline, raw) } },
+    'error',
+  )
+}
+
+/** requestConfirm doubles as the read-only detail dialog: confirm =
+    close, the secondary (cancel) slot = copy-and-close. Copy is the
+    one follow-up operators actually take from here (pasting the raw
+    text into an issue or a terminal search). */
+export async function openConnectorErrorDetail(headline: string, raw: string): Promise<void> {
+  const closedWithoutCopy = await requestConfirm({
+    title: headline,
+    message: raw,
+    confirmText: '닫기',
+    cancelText: '복사 후 닫기',
+    tone: 'info',
+  })
+  if (!closedWithoutCopy) {
+    try {
+      await navigator.clipboard.writeText(raw)
+      showToast('오류 내용을 클립보드에 복사했습니다.', 'success')
+    } catch {
+      showToast('클립보드 복사 실패 — 본문을 직접 선택해 복사하세요.', 'warning')
+    }
+  }
+}

--- a/dashboard/src/components/connector-quick-bind.ts
+++ b/dashboard/src/components/connector-quick-bind.ts
@@ -1,8 +1,10 @@
 // QuickBindForm — single-row keeper↔channel binding without having to
 // scroll down to the keeper directory, expand a keeper, and then paste
-// the channel ID. Mounted at the top of a connector card when the
-// connector is live and has keepers available but zero bindings yet
-// (the gap state the rail marks "warn").
+// the channel ID. Mounted at the top of a connector card whenever the
+// connector is live and has keepers available. (Originally gated to
+// the zero-bindings gap state; widened 2026-06-11 after an operator
+// could not find the per-keeper add-channel affordance buried at the
+// bottom of the card — the form is the card's primary bind entry now.)
 //
 // The underlying POST body matches the existing bindConnector helper in
 // connector-status.ts — we don't duplicate the call path.

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -36,6 +36,7 @@ import { SidecarLogToggle, SidecarLogViewer } from './sidecar-log-viewer'
 import { ConnectorConfigToggle, ConnectorConfigForm, openConnectorConfig } from './connector-config-form'
 import { ConnectorReadinessRail, deriveRail, getRailInflight, withRailInflight } from './connector-readiness-rail'
 import { StartupCheckBanner, markStartAttempt, clearStartAttempt } from './sidecar-startup-watch'
+import { showConnectorActionError } from './connector-action-error'
 import { QuickBindForm } from './connector-quick-bind'
 import { ConnectorOverviewStrip } from './connector-overview-strip'
 import { ConnectorKeeperMatrix, deriveMatrix } from './connector-keeper-matrix'
@@ -567,7 +568,7 @@ export async function startSidecar(connectorId: string) {
     showToast(`${connectorId} sidecar 시작 요청 — 잠시 후 상태 갱신됩니다.`, 'success')
     await refresh()
   } catch (err) {
-    showToast(err instanceof Error ? err.message : 'start failed', 'error')
+    showConnectorActionError(`${connectorId} sidecar 시작 실패`, err)
   } finally {
     patchConnectorUiState(connectorId, { actionLoading: false })
   }
@@ -583,7 +584,7 @@ export async function stopSidecar(connectorId: string) {
     showToast(`${connectorId} sidecar에 SIGTERM 전송`, 'success')
     await refresh()
   } catch (err) {
-    showToast(err instanceof Error ? err.message : 'stop failed', 'error')
+    showConnectorActionError(`${connectorId} sidecar 중지 실패`, err)
   } finally {
     patchConnectorUiState(connectorId, { actionLoading: false })
   }
@@ -607,7 +608,7 @@ export async function bindConnector(connectorId: string, keeperName: string, cha
     await refresh()
     showToast(`Bound ${channel} -> ${keeper}`, 'success')
   } catch (err) {
-    showToast(err instanceof Error ? err.message : 'bind failed', 'error')
+    showConnectorActionError(`바인딩 실패: ${channel} → ${keeper}`, err)
   } finally {
     patchConnectorUiState(connectorId, { actionLoading: false })
   }
@@ -625,7 +626,7 @@ async function unbindConnector(connectorId: string, channelId: string) {
     await refresh()
     showToast(`Unbound ${channel}`, 'success')
   } catch (err) {
-    showToast(err instanceof Error ? err.message : 'unbind failed', 'error')
+    showConnectorActionError(`바인딩 해제 실패: ${channel}`, err)
   } finally {
     patchConnectorUiState(connectorId, { actionLoading: false })
   }
@@ -876,7 +877,7 @@ function ConnectorLivePanel({
 
       <${StartupCheckBanner} connectorId=${connectorId} sidecarUp=${connector?.available === true} />
 
-      ${connector?.available === true && configuredBindings.length === 0 && keepers.length > 0
+      ${connector?.available === true && keepers.length > 0
         ? html`<${QuickBindForm} connectorId=${connectorId} keepers=${keepers} />`
         : null}
 
@@ -1185,12 +1186,12 @@ function ConnectorLivePanel({
                     ${bindingActionsEnabled
                       ? html`
                           <div class="mt-2">
-                            <button
-                              type="button"
-                              class="cursor-pointer text-2xs text-[var(--color-fg-disabled)] hover:text-[var(--color-fg-primary)]"
-                              aria-label=${`add channel to ${group.name}`}
+                            <${ActionButton}
+                              variant="subtle"
+                              size="sm"
+                              ariaLabel=${`add channel to ${group.name}`}
                               onClick=${toggleExpand}
-                            >${expanded ? '− close' : '+ add channel'}</button>
+                            >${expanded ? '− 닫기' : '+ 채널 연결'}<//>
                           </div>
                           ${expanded
                             ? html`


### PR DESCRIPTION
## 무엇

오늘(2026-06-11) Discord 셋업에서 실제로 겪은 Connectors 페이지 마찰 2건 해소.

## 1. 바인딩 발견성

**증상**: 운영자가 "연결 버튼이 어디 있는지" 못 찾음. 입구가 카드 하단 keeper 행 속의 작은 회색 텍스트(`+ add channel`)뿐이었고, 상단 QuickBindForm은 "바인딩 0개" 갭 상태에서만 마운트.

**변경**:
- keeper 행의 bare 텍스트 버튼 → `ActionButton`(subtle) **`+ 채널 연결`** 로 승격 (aria-label 유지)
- QuickBindForm 마운트 조건을 `live && keepers>0 && bindings==0` → `live && keepers>0` 으로 완화 — 커넥터가 살아있으면 카드 상단에 바인딩 폼이 항상 보임

## 2. 액션 에러 표면

**증상**: sidecar stop 실패 시 서버 원문(탐색한 절대경로 2개 + `MASC_SIDECAR_ROOT=...` 힌트)이 토스트에 그대로 노출 — 무슨 액션이 실패했는지가 내부 정보에 묻힘.

**변경**: 신규 `connector-action-error.ts`
- 토스트 = 호출처의 typed 컨텍스트로 만든 한 줄 헤드라인 (`discord sidecar 중지 실패`, `바인딩 실패: <ch> → <keeper>` 등 4개 액션)
- 서버 원문 = 토스트의 **상세** 버튼 → 다이얼로그 (닫기 / 복사 후 닫기)
- 서버 텍스트 string 분류 없음 — 원문은 가공 없이 보존, 출처는 호출처에서 옴

## 검증

- `tsc --noEmit` 0 errors / eslint 0 errors
- vitest: 신규 connector-action-error 5/5 (헤드라인에 내부정보 부재, 상세 버튼, 다이얼로그에 원문 노출), 기존 connector-status + connector-quick-bind 37/37
- dashboard TS 전용 변경 (`.ml` 0줄)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
