### PR TITLE
feat(board): typed task_id/goal_id fields and event hook stub

### DIFF
--- a/lib/board/board_core.mli
+++ b/lib/board/board_core.mli
@@ -231,6 +231,8 @@ val create_post_with_outcome
   -> ?ttl_hours:int
   -> ?hearth:string
   -> ?thread_id:string
+  -> ?task_id:string
+  -> ?goal_id:string
   -> unit
   -> (create_post_outcome, board_error) Result.t
 
@@ -258,6 +260,8 @@ val create_post
   -> ?ttl_hours:int
   -> ?hearth:string
   -> ?thread_id:string
+  -> ?task_id:string
+  -> ?goal_id:string
   -> unit
   -> (post, board_error) Result.t
 

--- a/lib/board/board_core_json.ml
+++ b/lib/board/board_core_json.ml
@@ -32,6 +32,12 @@ let post_to_yojson (p : post) : Yojson.Safe.t =
      @ (match p.thread_id with
         | Some t -> [ "thread_id", `String t ]
         | None -> [])
+     @ (match p.task_id with
+        | Some t -> [ "task_id", `String t ]
+        | None -> [])
+     @ (match p.goal_id with
+        | Some g -> [ "goal_id", `String g ]
+        | None -> [])
      @
      match p.meta_json with
      | Some meta -> [ "meta", meta ]

--- a/lib/board/board_core_persist.ml
+++ b/lib/board/board_core_persist.ml
@@ -380,6 +380,8 @@ let create_post_with_outcome
       ?(ttl_hours = Limits.default_ttl_hours)
   ?hearth
   ?thread_id
+  ?task_id
+  ?goal_id
   ()
   : (create_post_outcome, board_error) Result.t
   =
@@ -486,6 +488,8 @@ let create_post_with_outcome
                     ; reply_count = 0
                     ; hearth
                     ; thread_id
+                    ; task_id
+                    ; goal_id
                     }
                   in
                   Hashtbl.add store.posts (Post_id.to_string post.id) post;
@@ -494,18 +498,23 @@ let create_post_with_outcome
                   Ok (`Fresh post)
               in
               let rollup_task_id =
-                if
-                  is_status_rollup_candidate
-                    ~post_kind:normalized_kind
-                    ~title:normalized_title
-                    ~body:normalized_body
-                    ~meta_json:normalized_meta
-                then
-                  status_rollup_task_id
-                    ~title:normalized_title
-                    ~body:normalized_body
-                    ~meta_json:normalized_meta
-                else None
+                match task_id with
+                | Some t -> Some t
+                | None ->
+                  if
+                    is_status_rollup_candidate
+                      ~post_kind:normalized_kind
+                      ~title:normalized_title
+                      ~body:normalized_body
+                      ~meta_json:normalized_meta
+                      ()
+                  then
+                    status_rollup_task_id
+                      ~title:normalized_title
+                      ~body:normalized_body
+                      ~meta_json:normalized_meta
+                      ()
+                  else None
               in
               (match rollup_task_id with
                | Some task_id ->
@@ -577,6 +586,8 @@ let create_post
       ?ttl_hours
       ?hearth
       ?thread_id
+      ?task_id
+      ?goal_id
       ()
   =
   match
@@ -592,6 +603,8 @@ let create_post
       ?ttl_hours
       ?hearth
       ?thread_id
+      ?task_id
+      ?goal_id
       ()
   with
   | Ok outcome -> Ok (post_of_create_post_outcome outcome)

--- a/lib/board/board_core_persist.mli
+++ b/lib/board/board_core_persist.mli
@@ -72,12 +72,14 @@ type create_post_outcome =
 
 val post_of_create_post_outcome : create_post_outcome -> post
 val status_rollup_task_id :
-  title:string -> body:string -> meta_json:Yojson.Safe.t option -> string option
+  ?typed_task_id:string -> title:string -> body:string -> meta_json:Yojson.Safe.t option -> unit -> string option
 val is_status_rollup_candidate :
   post_kind:post_kind ->
   title:string ->
   body:string ->
   meta_json:Yojson.Safe.t option ->
+  ?task_id:string ->
+  unit ->
   bool
 val find_status_rollup_target_unlocked :
   store ->
@@ -100,6 +102,8 @@ val create_post_with_outcome :
   ?ttl_hours:int ->
   ?hearth:string ->
   ?thread_id:string ->
+  ?task_id:string ->
+  ?goal_id:string ->
   unit ->
   (create_post_outcome, board_error) result
 
@@ -115,5 +119,7 @@ val create_post :
   ?ttl_hours:int ->
   ?hearth:string ->
   ?thread_id:string ->
+  ?task_id:string ->
+  ?goal_id:string ->
   unit ->
   (post, board_error) result

--- a/lib/board/board_core_status_rollup.ml
+++ b/lib/board/board_core_status_rollup.ml
@@ -60,17 +60,31 @@ let task_id_from_text text =
   loop 0
 ;;
 
-let status_rollup_task_id ~title ~body ~meta_json =
-  match
-    List.find_map
-      (fun key -> Option.bind meta_json (Json_util.assoc_string_opt key))
-      [ "task_id"; "current_task_id"; "claimed_task_id"; "task" ]
-  with
+let status_rollup_task_id ?typed_task_id ~title ~body ~meta_json () =
+  match typed_task_id with
   | Some task_id -> Some (String.lowercase_ascii task_id)
   | None ->
-    (match task_id_from_text body with
-     | Some _ as task_id -> task_id
-     | None -> task_id_from_text title)
+    match
+      List.find_map
+        (fun key -> Option.bind meta_json (Json_util.assoc_string_opt key))
+        [ "task_id"; "current_task_id"; "claimed_task_id"; "task" ]
+    with
+    | Some task_id -> Some (String.lowercase_ascii task_id)
+    | None ->
+      (match task_id_from_text body with
+       | Some _ as task_id -> task_id
+       | None -> task_id_from_text title)
+;;
+
+(** Goal-based rollup — stub for future use. Returns [None] until
+    goal-level board aggregation is implemented. *)
+let status_rollup_goal_id ?typed_goal_id ~title ~body ~meta_json () =
+  match typed_goal_id with
+  | Some goal_id -> Some (String.lowercase_ascii goal_id)
+  | None ->
+    (match Option.bind meta_json (Json_util.assoc_string_opt "goal_id") with
+     | Some goal_id -> Some (String.lowercase_ascii goal_id)
+     | None -> None)
 ;;
 
 let status_only_terms =
@@ -131,12 +145,13 @@ let proof_or_handoff_terms =
   ]
 ;;
 
-let is_status_rollup_candidate ~post_kind ~title ~body ~meta_json =
+let is_status_rollup_candidate ~post_kind ~title ~body ~meta_json ?task_id () =
   match post_kind with
   | Human_post | System_post -> false
   | Automation_post ->
     String.length body <= max_status_rollup_body_length
-    && Option.is_some (status_rollup_task_id ~title ~body ~meta_json)
+    && (Option.is_some task_id
+        || Option.is_some (status_rollup_task_id ~title ~body ~meta_json ()))
     && contains_any_substring body status_only_terms
     && not (contains_any_substring body proof_or_handoff_terms)
 ;;
@@ -156,14 +171,18 @@ let find_status_rollup_target_unlocked
        in
        let same_hearth = Option.equal String.equal post.hearth hearth in
        let same_task =
-         match
-           status_rollup_task_id
-             ~title:post.title
-             ~body:post.body
-             ~meta_json:post.meta_json
-         with
+         match post.task_id with
          | Some existing_task_id -> String.equal existing_task_id task_id
-         | None -> false
+         | None ->
+           (match
+              status_rollup_task_id
+                ~title:post.title
+                ~body:post.body
+                ~meta_json:post.meta_json
+                ()
+            with
+            | Some existing_task_id -> String.equal existing_task_id task_id
+            | None -> false)
        in
        let recent =
          Stdlib.Float.compare (now -. post.updated_at) status_rollup_window_sec <= 0
@@ -179,6 +198,8 @@ let find_status_rollup_target_unlocked
               ~title:post.title
               ~body:post.body
               ~meta_json:post.meta_json
+              ?task_id:post.task_id
+              ()
        then (
          match acc with
          | Some current when current.updated_at >= post.updated_at -> acc

--- a/lib/board/board_core_status_rollup.mli
+++ b/lib/board/board_core_status_rollup.mli
@@ -8,13 +8,15 @@ val status_rollup_window_sec : float
 val max_status_rollup_body_length : int
 
 val status_rollup_task_id :
-  title:string -> body:string -> meta_json:Yojson.Safe.t option -> string option
+  ?typed_task_id:string -> title:string -> body:string -> meta_json:Yojson.Safe.t option -> unit -> string option
 
 val is_status_rollup_candidate :
   post_kind:post_kind ->
   title:string ->
   body:string ->
   meta_json:Yojson.Safe.t option ->
+  ?task_id:string ->
+  unit ->
   bool
 
 val find_status_rollup_target_unlocked :
@@ -25,3 +27,7 @@ val find_status_rollup_target_unlocked :
   task_id:string ->
   now:float ->
   post option
+
+(** Goal-based rollup — stub for future use. *)
+val status_rollup_goal_id :
+  ?typed_goal_id:string -> title:string -> body:string -> meta_json:Yojson.Safe.t option -> unit -> string option

--- a/lib/board/board_dispatch.ml
+++ b/lib/board/board_dispatch.ml
@@ -354,12 +354,14 @@ let matching_post_ids_for_comment_author_filter ~needle (comments : Board.commen
 
 let create_post ~author ~content ?title ?body ~post_kind ?meta_json
     ?(visibility = Board.Internal)
-    ?(ttl_hours = Board.Limits.default_ttl_hours) ?hearth ?thread_id () =
+    ?(ttl_hours = Board.Limits.default_ttl_hours) ?hearth ?thread_id
+    ?task_id ?goal_id () =
   match backend () with
   | Jsonl store ->
       (match
          Board.create_post_with_outcome store ~author ~content ?title ?body
-           ~post_kind ?meta_json ~visibility ~ttl_hours ?hearth ?thread_id ()
+           ~post_kind ?meta_json ~visibility ~ttl_hours ?hearth ?thread_id
+           ?task_id ?goal_id ()
        with
       | Ok (Board.Fresh_post post) ->
           let pid = Board.Post_id.to_string post.id in

--- a/lib/board/board_dispatch.mli
+++ b/lib/board/board_dispatch.mli
@@ -139,6 +139,8 @@ val create_post :
   ?ttl_hours:int ->
   ?hearth:string ->
   ?thread_id:string ->
+  ?task_id:string ->
+  ?goal_id:string ->
   unit ->
   (Board.post, Board.board_error) Result.t
 

--- a/lib/board/board_votes_json.ml
+++ b/lib/board/board_votes_json.ml
@@ -36,6 +36,8 @@ let post_of_yojson (json : Yojson.Safe.t) : post option =
     let reply_count = Safe_ops.json_int ~default:0 "reply_count" json in
     let hearth = Safe_ops.json_string_opt "hearth" json in
     let thread_id = Safe_ops.json_string_opt "thread_id" json in
+    let task_id = Safe_ops.json_string_opt "task_id" json in
+    let goal_id = Safe_ops.json_string_opt "goal_id" json in
     let post_kind_opt =
       match Safe_ops.json_string_opt "post_kind" json with
       | Some raw -> post_kind_of_string raw
@@ -105,6 +107,8 @@ let post_of_yojson (json : Yojson.Safe.t) : post option =
             ; reply_count
             ; hearth
             ; thread_id
+            ; task_id
+            ; goal_id
             })
      | _ -> None)
   | _ -> None

--- a/lib/board_types/board_types.ml
+++ b/lib/board_types/board_types.ml
@@ -160,6 +160,8 @@ type post = {
   reply_count: int;
   hearth: string option;     (* Topic category within the Board *)
   thread_id: string option;  (* Linked Conversation thread *)
+  task_id: string option;    (* Typed link to a workspace task *)
+  goal_id: string option;    (* Typed link to a workspace goal *)
 }
 
 type comment = {

--- a/lib/board_types/board_types.mli
+++ b/lib/board_types/board_types.mli
@@ -106,6 +106,8 @@ type post = {
   reply_count : int;
   hearth : string option;
   thread_id : string option;
+  task_id : string option;
+  goal_id : string option;
 }
 
 type comment = {

--- a/lib/workspace/workspace_hooks.ml
+++ b/lib/workspace/workspace_hooks.ml
@@ -365,6 +365,12 @@ let push_task_event_fn
   : (event_type:string -> details:(string * Yojson.Safe.t) list -> unit) Atomic.t
   = Atomic.make (fun ~event_type:_ ~details:_ -> ())
 
+(** Stub hook for task-event → board post wiring.
+    Default no-op until the runtime fills it at boot. *)
+let notify_board_of_task_event_fn
+  : (task:Masc_domain.task -> event:Event_kind.Task.t -> unit) Atomic.t
+  = Atomic.make (fun ~task:_ ~event:_ -> ())
+
 let verification_submit_request_fn
   : (Workspace_utils_backend_setup.config ->
      task:Masc_domain.task ->

--- a/lib/workspace/workspace_hooks.mli
+++ b/lib/workspace/workspace_hooks.mli
@@ -127,6 +127,13 @@ val record_thompson_result_fn :
 val push_task_event_fn :
   (event_type:string -> details:(string * Yojson.Safe.t) list -> unit) Atomic.t
 
+(** Stub hook for task-event → board post wiring.
+    Accepts a task record and an event kind so that task lifecycle
+    events (Created, Done, etc.) can automatically generate board posts.
+    Default no-op until the runtime fills it at boot. *)
+val notify_board_of_task_event_fn :
+  (task:Masc_domain.task -> event:Event_kind.Task.t -> unit) Atomic.t
+
 val verification_submit_request_fn :
   (Workspace_utils_backend_setup.config ->
    task:Masc_domain.task ->

--- a/lib/workspace/workspace_task_transitions.ml
+++ b/lib/workspace/workspace_task_transitions.ml
@@ -8,6 +8,28 @@ open Workspace_backlog
 include Workspace_task_classify
 include Workspace_task_create
 include Workspace_task_claim
+
+(** Map a task action to the corresponding event-kind variant.
+    Used by the board-notification stub below. *)
+let event_kind_of_task_action = function
+  | Masc_domain.Claim -> Event_kind.Task.Claimed
+  | Masc_domain.Start -> Event_kind.Task.Started
+  | Masc_domain.Done_action -> Event_kind.Task.Done
+  | Masc_domain.Cancel -> Event_kind.Task.Cancelled
+  | Masc_domain.Release -> Event_kind.Task.Released
+  | Masc_domain.Submit_for_verification -> Event_kind.Task.Submit_for_verification
+  | Masc_domain.Approve_verification -> Event_kind.Task.Approved
+  | Masc_domain.Reject_verification -> Event_kind.Task.Rejected
+;;
+
+(** Stub: notify the board subsystem that a task event occurred.
+    This is a hook point for the future event→board pipeline.
+    Currently a no-op until wired at runtime. *)
+let notify_board_of_task_event ~(task : Masc_domain.task) ~(action : Masc_domain.task_action) =
+  let event = event_kind_of_task_action action in
+  (Atomic.get Workspace_hooks.notify_board_of_task_event_fn) ~task ~event
+;;
+
 let transition_task_r
       config
       ~agent_name
@@ -564,6 +586,8 @@ let transition_task_r
                ~task_id
                ~kind:(Event_kind.Task.to_string Event_kind.Task.Rejected)
                ~payload:(`Assoc [ "task_id", `String task_id ]));
+          (* Future: wire task events to automatic board posts. *)
+          notify_board_of_task_event ~task ~action;
           let duration_ms = match action with
             | Masc_domain.Done_action | Masc_domain.Cancel ->
               Some (max 0 (int_of_float ((now_ts -. task_started_at_unix task.task_status) *. 1000.0)))


### PR DESCRIPTION
## Summary

Adds structured wiring between Board and Task/Goal concepts, replacing heuristic body-scan links.

### Changes
- **Board types**: Added `task_id : string option` and `goal_id : string option` to `Board_types.post`.
- **Serialization**: JSON read/write handles the new fields with safe absent-key fallback to `None`.
- **Status rollup**: `board_core_status_rollup.ml` now checks typed `task_id` first, falling back to heuristic meta/body scan only for legacy posts.
- **Creation API**: `Board_dispatch.create_post` and `Board_core_persist.create_post_with_outcome` accept optional `?task_id` / `?goal_id`.
- **Event wiring stub**: Added `Workspace_hooks.notify_board_of_task_event_fn` atomic hook and call site in `workspace_task_transitions.ml` (currently no-op default, ready for implementation).

### Verification
- `lib/board`, `lib/workspace`, `bin/main_eio.exe` compile
- `test_board_content_dedup` (9/9), `test_board_karma_ledger` (18/18), `test_vote_ts_preservation` (2/2) pass

### Pre-existing failures (unaffected)
- `test_board_dispatch` reclassify dry-run
- `test_tool_board_coverage` post_crud