### PR TITLE
fix(dashboard): error-detail dialog copied on Escape dismiss

### DIFF
--- a/dashboard/src/components/connector-action-error.test.ts
+++ b/dashboard/src/components/connector-action-error.test.ts
@@ -70,9 +70,84 @@ describe('showConnectorActionError', () => {
       await Promise.resolve()
       expect(dialogHost.textContent).toContain('MASC_SIDECAR_ROOT')
       expect(dialogHost.textContent).toContain('바인딩 실패: 123 → luna')
+      // Resolve the dialog so its module-level open state does not leak
+      // into the next test.
+      Array.from(dialogHost.querySelectorAll('button'))
+        .find(b => b.textContent?.includes('닫기') && !b.textContent.includes('복사'))!
+        .click()
+      await Promise.resolve()
     } finally {
       render(null, dialogHost)
       document.body.removeChild(dialogHost)
     }
+  })
+})
+
+describe('openConnectorErrorDetail — copy sits on confirm, never on dismiss', () => {
+  let dialogHost: HTMLElement
+  let writeText: ReturnType<typeof vi.fn>
+
+  beforeEach(async () => {
+    dialogHost = document.createElement('div')
+    document.body.appendChild(dialogHost)
+    writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    })
+    _testResetToasts()
+    const { ConfirmDialogOverlay } = await import('./common/confirm-dialog')
+    render(html`<${ConfirmDialogOverlay} />`, dialogHost)
+  })
+  afterEach(() => {
+    render(null, dialogHost)
+    document.body.removeChild(dialogHost)
+    vi.restoreAllMocks()
+  })
+
+  // Exact-match on trimmed text: '복사 후 닫기' contains '닫기', so a
+  // substring find could grab the wrong button.
+  const dialogButton = (label: string) =>
+    Array.from(dialogHost.querySelectorAll('button'))
+      .find(b => b.textContent?.trim() === label)!
+
+  // Macrotask flush: DialogOverlay attaches its document-level Escape
+  // listener inside useEffect, which preact schedules on rAF/timer —
+  // microtasks alone leave the listener unattached.
+  const flushUi = async () => {
+    await new Promise(resolve => setTimeout(resolve, 30))
+  }
+
+  it('Escape dismiss closes WITHOUT copying (ESC/backdrop map to cancel)', async () => {
+    const { openConnectorErrorDetail } = await import('./connector-action-error')
+    const pending = openConnectorErrorDetail('headline', RAW_SERVER_ERROR)
+    await flushUi()
+    expect(dialogHost.textContent).toContain('MASC_SIDECAR_ROOT')
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    await pending
+    await flushUi()
+    expect(writeText).not.toHaveBeenCalled()
+    expect(dialogHost.textContent ?? '').not.toContain('MASC_SIDECAR_ROOT')
+  })
+
+  it('복사 후 닫기 copies the raw text to the clipboard', async () => {
+    const { openConnectorErrorDetail } = await import('./connector-action-error')
+    const pending = openConnectorErrorDetail('headline', RAW_SERVER_ERROR)
+    await flushUi()
+    dialogButton('복사 후 닫기').click()
+    await pending
+    await flushUi()
+    expect(writeText).toHaveBeenCalledWith(RAW_SERVER_ERROR)
+    expect(_testGetToasts().some(t => t.message.includes('복사했습니다'))).toBe(true)
+  })
+
+  it('닫기 button closes without copying', async () => {
+    const { openConnectorErrorDetail } = await import('./connector-action-error')
+    const pending = openConnectorErrorDetail('headline', RAW_SERVER_ERROR)
+    await flushUi()
+    dialogButton('닫기').click()
+    await pending
+    await flushUi()
+    expect(writeText).not.toHaveBeenCalled()
   })
 })

--- a/dashboard/src/components/connector-action-error.ts
+++ b/dashboard/src/components/connector-action-error.ts
@@ -27,19 +27,20 @@ export function showConnectorActionError(headline: string, err: unknown): void {
   )
 }
 
-/** requestConfirm doubles as the read-only detail dialog: confirm =
-    close, the secondary (cancel) slot = copy-and-close. Copy is the
-    one follow-up operators actually take from here (pasting the raw
-    text into an issue or a terminal search). */
+/** requestConfirm doubles as the read-only detail dialog. Copy must
+    sit on the CONFIRM slot: ConfirmDialogOverlay maps Escape and
+    backdrop-click to onCancel, so anything on the cancel slot also
+    fires on accidental dismissal. Confirm only fires on a deliberate
+    button click — cancel/Escape/backdrop are all a plain close. */
 export async function openConnectorErrorDetail(headline: string, raw: string): Promise<void> {
-  const closedWithoutCopy = await requestConfirm({
+  const copyRequested = await requestConfirm({
     title: headline,
     message: raw,
-    confirmText: '닫기',
-    cancelText: '복사 후 닫기',
+    confirmText: '복사 후 닫기',
+    cancelText: '닫기',
     tone: 'info',
   })
-  if (!closedWithoutCopy) {
+  if (copyRequested) {
     try {
       await navigator.clipboard.writeText(raw)
       showToast('오류 내용을 클립보드에 복사했습니다.', 'success')


### PR DESCRIPTION
## 무엇

#20800의 에러 상세 다이얼로그에서 **ESC/배경클릭으로 닫기만 해도 클립보드에 에러 텍스트가 복사되던 결함** 수정.

## 원인

`ConfirmDialogOverlay`는 ESC와 backdrop 클릭을 `onCancel`로 매핑하는데(`confirm-dialog.ts` `handleClose`), #20800이 cancel 슬롯에 "복사 후 닫기"를 배치 → dismiss 제스처 전부가 복사 동작을 발화.

## 수정

슬롯 교환: **confirm = 복사 후 닫기** (의도적 버튼 클릭에만 발화), **cancel = 닫기** (ESC/배경클릭 포함 모든 dismiss는 순수 닫기). 동작 의미상으로도 confirm 슬롯이 "행동하는 선택"이라 dialog 설계와 정합.

## 검증

- vitest 8/8 — 신규 회귀 3건: 실제 overlay를 마운트해 ① document에 ESC 디스패치 → clipboard 미호출 + 다이얼로그 닫힘 ② 복사 후 닫기 클릭 → `writeText(raw)` 호출 + 성공 토스트 ③ 닫기 버튼 → 미복사
- `tsc --noEmit` 0 / eslint 0

발견 경위: 사용자 질문 "버튼 이벤트 핸들러 다 올바른가?" → 머지된 main에서 핸들러 경로 전수 추적 중 발견.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
