### PR TITLE
refactor(env): default-deny allowlist for keeper subprocess env scrub

### DIFF
--- a/lib/env_keeper_scrub.ml
+++ b/lib/env_keeper_scrub.ml
@@ -1,94 +1,104 @@
-(* Exact keys copied from agent_llm_a-code's GHA_SUBPROCESS_SCRUB list at
-   src/utils/subprocessEnv.ts:15-53.
+(** Keeper subprocess env scrub / pass policy (RFC-0007 PR-1 / #9639 Cluster B).
 
-   Each group is documented in the reference. Rationale preserved so a
-   future reader can justify additions or removals. *)
+    Default-deny (allowlist) model: only explicitly permitted env vars cross
+    the keeper subprocess boundary. This eliminates the infinite-product-type
+    problem of maintaining an exhaustive denylist — new secrets are blocked by
+    default, and operators can extend the allowlist via
+    [MASC_KEEPER_ALLOW_EXTRA].
 
-let scrub : string list =
+    Keeper GitHub execution must use the selected MASC credential bundle,
+    never the operator's ambient GitHub token/config or SSH agent. *)
+
+(** Exact-match allowlist — env vars that are known-safe and required for
+    keeper / docker CLI / tool execution. *)
+let allow_exact : string list =
   [
-    (* Anthropic auth — MASC re-reads these per-request, subprocesses don't
-       need them and leaking them into a sandboxed container creates an
-       escape surface. *)
-    "ANTHROPIC_API_KEY";
-    "CLAUDE_CODE_OAUTH_TOKEN";
-    "ANTHROPIC_AUTH_TOKEN";
-    "ANTHROPIC_FOUNDRY_API_KEY";
-    "ANTHROPIC_CUSTOM_HEADERS";
+    (* Process basics *)
+    "PATH"; "HOME"; "TMPDIR"; "TMP"; "TEMP"
+  ; "LANG"; "LC_ALL"; "LC_CTYPE"
+  ; "USER"; "LOGNAME"; "SHELL"
+  ; "TERM"; "TERMINFO"; "PAGER"; "EDITOR"; "VISUAL"
+  ; "XDG_CONFIG_HOME"; "XDG_CACHE_HOME"; "XDG_DATA_HOME"
+  ; "OCAMLRUNPARAM"
+  ; "OPAMROOT"; "OPAM_SWITCH_PREFIX"
 
-    (* OTLP exporter headers — documented to carry Authorization: Bearer
-       tokens for monitoring backends; read in-process by the OTEL SDK. *)
-    "OTEL_EXPORTER_OTLP_HEADERS";
-    "OTEL_EXPORTER_OTLP_LOGS_HEADERS";
-    "OTEL_EXPORTER_OTLP_METRICS_HEADERS";
-    "OTEL_EXPORTER_OTLP_TRACES_HEADERS";
+    (* Docker CLI remote daemon connectivity *)
+  ; "DOCKER_HOST"; "DOCKER_TLS_VERIFY"; "DOCKER_CERT_PATH"
 
-    (* Cloud provider creds — same pattern (lazy SDK reads). *)
-    "AWS_SECRET_ACCESS_KEY";
-    "AWS_SESSION_TOKEN";
-    "AWS_BEARER_TOKEN_BEDROCK";
-    "GOOGLE_APPLICATION_CREDENTIALS";
-    "AZURE_CLIENT_SECRET";
-    "AZURE_CLIENT_CERTIFICATE_PATH";
+    (* Git user identity — not credentials by themselves. *)
+  ; "GIT_AUTHOR_NAME"; "GIT_AUTHOR_EMAIL"
+  ; "GIT_COMMITTER_NAME"; "GIT_COMMITTER_EMAIL"
 
-    (* GitHub Actions OIDC — consumed by the action's JS before the keeper
-       spawns; leaking these allows minting an App installation token. *)
-    "ACTIONS_ID_TOKEN_REQUEST_TOKEN";
-    "ACTIONS_ID_TOKEN_REQUEST_URL";
-
-    (* GitHub Actions artifact/cache API — cache poisoning pivot. *)
-    "ACTIONS_RUNTIME_TOKEN";
-    "ACTIONS_RUNTIME_URL";
-
-    (* Workflow-level duplicates — ALL_INPUTS contains api keys as JSON. *)
-    "ALL_INPUTS";
-    "OVERRIDE_GITHUB_TOKEN";
-    "DEFAULT_WORKFLOW_TOKEN";
-    "SSH_SIGNING_KEY";
-
-    (* Keeper GitHub work must use the selected MASC credential bundle.
-       Ambient host credentials would turn credential labels into a cosmetic
-       boundary. *)
-    "GH_TOKEN";
-    "GITHUB_TOKEN";
-    "GH_CONFIG_DIR";
-    "SSH_AUTH_SOCK";
-    "GIT_CONFIG_GLOBAL";
-    "GIT_CONFIG_SYSTEM";
-    "GIT_CONFIG_COUNT";
-
-    (* Stress test 2026-05-26 — same-category extensions to the reference
-       list. The reference (agent_llm_a-code) inherits from gh CLI usage,
-       but these were missed: *)
-    (* gh Enterprise token: same role as GH_TOKEN, different env name. *)
-    "GH_ENTERPRISE_TOKEN";
-    (* gh endpoint host override — operator setting GH_HOST=evil.com
-       would redirect keeper API calls without changing token. *)
-    "GH_HOST";
-    (* git credential helper / SSH command override — these let a host
-       env subvert keeper identity by injecting an arbitrary askpass or
-       ssh binary. Same category as GIT_CONFIG_GLOBAL above. *)
-    "GIT_ASKPASS";
-    "GIT_SSH";
-    "GIT_SSH_COMMAND";
+    (* MASC operational — these are read by Env_config_core and friends.
+       Secrets that happen to share the [MASC_] prefix are blocked by
+       [deny_prefixes] below. *)
+  ; "MASC_BASE_PATH"; "MASC_BASE_PATH_INPUT"
+  ; "MASC_BASE_PATH_RESOLUTION_SOURCE"
+  ; "MASC_CONFIG_DIR"; "MASC_STORAGE_TYPE"; "MASC_MODEL_CATALOG"
+  ; "MASC_HOST"; "MASC_HTTP_PORT"; "MASC_HTTP_BASE_URL"; "MASC_URL"
+  ; "MASC_ORCHESTRATOR_ENABLED"; "MASC_DISABLE_HITL"
+  ; "MASC_LOG_LEVEL"; "MASC_LOG_ROUTINE_LEVEL"
+  ; "MASC_TELEMETRY_ENABLED"; "MASC_PARSE_WARN"; "MASC_GOVERNANCE_LEVEL"
+  ; "MASC_GIT_FETCH_TIMEOUT_SEC"
+  ; "MASC_DATA_DIR"; "MASC_PERSONAS_DIR"
+  ; "MASC_SECRET_DIR"
+  ; "MASC_KEEPER_SCRUB_EXTRA"
+  ; "MASC_TEST_FAKE_DOCKER_PATH"
   ]
 
-let pass : string list =
-  [
-    (* Git user identity is not a credential by itself. Git config
-       location/count env is intentionally scrubbed above because it can
-       inject credential helpers or host-global settings. *)
-    "GIT_AUTHOR_NAME";
-    "GIT_AUTHOR_EMAIL";
-    "GIT_COMMITTER_NAME";
-    "GIT_COMMITTER_EMAIL";
+(** Prefix allowlist — env families that are safe to pass through.
+    [MASC_KEEPER_] covers runtime knobs (timeouts, thresholds, flags).
+    [LC_] covers locale. *)
+let allow_prefixes : string list =
+  [ "LC_"
+  ; "MASC_KEEPER_"
+  ; "MASC_LOG_"
+  ; "MASC_TELEMETRY_"
+  ; "MASC_GIT_"
+  ; "MASC_ORCHESTRATOR_"
+  ; "MASC_WS_"
+  ; "MASC_WEBRTC_"
   ]
 
-let scrub_table =
-  let t = Hashtbl.create (List.length scrub) in
-  List.iter (fun k -> Hashtbl.replace t k ()) scrub;
+(** Prefix denials — even under the [MASC_] family, these carry host-server
+    tokens and must never reach a keeper subprocess or container. *)
+let deny_prefixes : string list =
+  [ "MASC_ADMIN_"; "MASC_INTERNAL_" ]
+
+(** Suffix denials — any key ending with these is treated as a credential
+    regardless of prefix. *)
+let deny_suffixes : string list =
+  [ "_API_KEY"; "_TOKEN"; "_SECRET"; "_PASSWORD"; "_CREDENTIALS" ]
+
+let extra_allow_keys () =
+  match Sys.getenv_opt "MASC_KEEPER_ALLOW_EXTRA" with
+  | None -> []
+  | Some raw ->
+    String.split_on_char ',' raw
+    |> List.map String.trim
+    |> List.filter (fun s -> s <> "")
+
+let allow_exact_table =
+  let t = Hashtbl.create (List.length allow_exact) in
+  List.iter (fun k -> Hashtbl.replace t k ()) allow_exact;
   t
 
-let is_scrubbed key = Hashtbl.mem scrub_table key
+let is_allowed_exact key = Hashtbl.mem allow_exact_table key
+
+let is_allowed_prefix key =
+  List.exists (fun prefix -> String.starts_with ~prefix key) allow_prefixes
+
+let is_denied_prefix key =
+  List.exists (fun prefix -> String.starts_with ~prefix key) deny_prefixes
+
+let is_denied_suffix key =
+  List.exists (fun suffix -> String.ends_with ~suffix key) deny_suffixes
+
+let is_allowed key =
+  (is_allowed_exact key
+   || is_allowed_prefix key
+   || List.mem key (extra_allow_keys ()))
+  && not (is_denied_prefix key || is_denied_suffix key)
 
 let key_of_entry entry =
   match String.index_opt entry '=' with
@@ -97,5 +107,5 @@ let key_of_entry entry =
 
 let filter_environment existing =
   Array.to_list existing
-  |> List.filter (fun e -> not (is_scrubbed (key_of_entry e)))
+  |> List.filter (fun e -> is_allowed (key_of_entry e))
   |> Array.of_list

--- a/lib/env_keeper_scrub.mli
+++ b/lib/env_keeper_scrub.mli
@@ -1,37 +1,18 @@
 (** Keeper subprocess env scrub / pass policy (RFC-0007 PR-1 / #9639 Cluster B).
 
-    Long-lived host credentials (Anthropic API keys, AWS secrets, OIDC
-    request tokens, OTel exporter bearer headers) MUST NOT cross the
-    keeper subprocess boundary. They are consumed by the host process
-    (MASC server) and are not needed inside the keeper container or shell
-    subprocess.
+    Default-deny (allowlist) model: only explicitly permitted env vars cross
+    the keeper subprocess boundary. New secrets are blocked by default.
+    Operators can extend the allowlist via [MASC_KEEPER_ALLOW_EXTRA].
 
     Keeper GitHub execution must use the selected MASC credential bundle,
-    never the operator's ambient GitHub token/config or SSH agent.
-    [GH_TOKEN], [GITHUB_TOKEN], [GH_CONFIG_DIR], and [SSH_AUTH_SOCK]
-    are scrubbed at this boundary. Git config-location env such as
-    [GIT_CONFIG_GLOBAL] is also scrubbed because it can inject host
-    credential helpers; [GIT_*] non-secret behavior can still pass unless
-    a key is explicitly listed in [scrub].
+    never the operator's ambient GitHub token/config or SSH agent. *)
 
-    Design reference: [GHA_SUBPROCESS_SCRUB] in agent_llm_a-code at
-    [src/utils/subprocessEnv.ts:15-53]. *)
-
-val scrub : string list
-(** Env-var keys stripped before spawning a keeper subprocess. *)
-
-val pass : string list
-(** Env-var keys explicitly allowed through, documented for callers. Does
-    not participate in [filter_environment]'s positive list (everything
-    not on [scrub] is already allowed); serves as an assertion against
-    accidental future additions to [scrub]. *)
-
-val is_scrubbed : string -> bool
-(** [is_scrubbed key] returns [true] if the given env-var key is on the
-    scrub list. Prefix-based entries (e.g. future [ANTHROPIC_*]) are not
-    supported yet — exact match only. *)
+val is_allowed : string -> bool
+(** [is_allowed key] returns [true] if the given env-var key is on the
+    allowlist (exact or prefix match) and is not blocked by a credential
+    suffix or a secret-bearing prefix such as [MASC_ADMIN_]. *)
 
 val filter_environment : string array -> string array
-(** Return a copy of the given [Unix.environment]-shaped array with
-    scrubbed keys removed. Entries that do not contain ['='] are kept
-    as-is. *)
+(** Return a copy of the given [Unix.environment]-shaped array with only
+    allowed keys retained. Entries that do not contain ['='] are kept iff
+    their key is allowed. *)

--- a/lib/keeper/keeper_secret_projection.ml
+++ b/lib/keeper/keeper_secret_projection.ml
@@ -127,6 +127,13 @@ let read_env_entry path =
     then Error (Printf.sprintf "keeper secret env value must be single-line: %s" path)
     else if contains_char value '\000'
     then Error (Printf.sprintf "keeper secret env value must not contain NUL: %s" path)
+    else if String.length value > 0 && Char.equal value.[0] '#'
+    then
+      Error
+        (Printf.sprintf
+           "keeper secret env value must not start with '#', which docker --env-file \
+            treats as a comment: %s"
+           path)
     else Ok value
   with
   | Sys_error msg -> Error msg

--- a/test/dune
+++ b/test/dune
@@ -294,8 +294,10 @@
   test_alignment_score
   test_blocker_class_exhaustiveness
   test_workspace_goal_index
-  test_log_severity_outcome_level)
+  test_log_severity_outcome_level
+  test_env_keeper_scrub)
  (modules
+  test_env_keeper_scrub
   test_keeper_reactive_wake_backlog_gate
   test_keeper_lane_signal
   test_board_activity_cache
@@ -568,7 +570,8 @@
   test_alignment_score
   test_blocker_class_exhaustiveness
   test_workspace_goal_index
-  test_log_severity_outcome_level)
+  test_log_severity_outcome_level
+  test_env_keeper_scrub)
  (libraries masc_test_deps multimodal))
 
 ; Focused CI gate for runtime TOML validity.

--- a/test/test_env_git_noninteractive.ml
+++ b/test/test_env_git_noninteractive.ml
@@ -72,43 +72,48 @@ let test_inject_injects_when_missing () =
     out_list "GIT_ASKPASS="
 
 let test_scrub_membership () =
-  assert_true "ANTHROPIC_API_KEY scrubbed"
-    (Env_keeper_scrub.is_scrubbed "ANTHROPIC_API_KEY");
-  assert_true "AWS_SECRET_ACCESS_KEY scrubbed"
-    (Env_keeper_scrub.is_scrubbed "AWS_SECRET_ACCESS_KEY");
-  assert_true "ACTIONS_ID_TOKEN_REQUEST_TOKEN scrubbed"
-    (Env_keeper_scrub.is_scrubbed "ACTIONS_ID_TOKEN_REQUEST_TOKEN");
-  assert_true "OTEL_EXPORTER_OTLP_HEADERS scrubbed"
-    (Env_keeper_scrub.is_scrubbed "OTEL_EXPORTER_OTLP_HEADERS");
-  assert_true "GH_TOKEN scrubbed"
-    (Env_keeper_scrub.is_scrubbed "GH_TOKEN");
-  assert_true "GITHUB_TOKEN scrubbed"
-    (Env_keeper_scrub.is_scrubbed "GITHUB_TOKEN");
-  assert_true "GH_CONFIG_DIR scrubbed"
-    (Env_keeper_scrub.is_scrubbed "GH_CONFIG_DIR");
-  assert_true "SSH_AUTH_SOCK scrubbed"
-    (Env_keeper_scrub.is_scrubbed "SSH_AUTH_SOCK");
-  assert_true "GIT_CONFIG_GLOBAL scrubbed"
-    (Env_keeper_scrub.is_scrubbed "GIT_CONFIG_GLOBAL");
-  assert_true "GIT_CONFIG_COUNT scrubbed"
-    (Env_keeper_scrub.is_scrubbed "GIT_CONFIG_COUNT");
-  assert_false "PATH NOT scrubbed (neutral)"
-    (Env_keeper_scrub.is_scrubbed "PATH")
+  assert_true "ANTHROPIC_API_KEY denied"
+    (not (Env_keeper_scrub.is_allowed "ANTHROPIC_API_KEY"));
+  assert_true "AWS_SECRET_ACCESS_KEY denied"
+    (not (Env_keeper_scrub.is_allowed "AWS_SECRET_ACCESS_KEY"));
+  assert_true "ACTIONS_ID_TOKEN_REQUEST_TOKEN denied"
+    (not (Env_keeper_scrub.is_allowed "ACTIONS_ID_TOKEN_REQUEST_TOKEN"));
+  assert_true "OTEL_EXPORTER_OTLP_HEADERS denied"
+    (not (Env_keeper_scrub.is_allowed "OTEL_EXPORTER_OTLP_HEADERS"));
+  assert_true "GH_TOKEN denied"
+    (not (Env_keeper_scrub.is_allowed "GH_TOKEN"));
+  assert_true "GITHUB_TOKEN denied"
+    (not (Env_keeper_scrub.is_allowed "GITHUB_TOKEN"));
+  assert_true "GH_CONFIG_DIR denied"
+    (not (Env_keeper_scrub.is_allowed "GH_CONFIG_DIR"));
+  assert_true "SSH_AUTH_SOCK denied"
+    (not (Env_keeper_scrub.is_allowed "SSH_AUTH_SOCK"));
+  assert_true "GIT_CONFIG_GLOBAL denied"
+    (not (Env_keeper_scrub.is_allowed "GIT_CONFIG_GLOBAL"));
+  assert_true "GIT_CONFIG_COUNT denied"
+    (not (Env_keeper_scrub.is_allowed "GIT_CONFIG_COUNT"));
+  assert_true "PATH allowed"
+    (Env_keeper_scrub.is_allowed "PATH")
 
 let test_scrub_exact_match_only () =
-  (* Prefix match is explicitly a non-goal. *)
-  assert_false "ANTHROPIC_API_KEY_SUFFIX not scrubbed (exact match)"
-    (Env_keeper_scrub.is_scrubbed "ANTHROPIC_API_KEY_SUFFIX");
-  assert_false "PREFIX_ANTHROPIC_API_KEY not scrubbed (exact match)"
-    (Env_keeper_scrub.is_scrubbed "PREFIX_ANTHROPIC_API_KEY")
+  (* Suffix pattern now blocks anything ending in _API_KEY. *)
+  assert_true "ANTHROPIC_API_KEY_SUFFIX denied (suffix match)"
+    (not (Env_keeper_scrub.is_allowed "ANTHROPIC_API_KEY_SUFFIX"));
+  assert_true "PREFIX_ANTHROPIC_API_KEY denied (suffix match)"
+    (not (Env_keeper_scrub.is_allowed "PREFIX_ANTHROPIC_API_KEY"))
 
 let test_scrub_and_pass_disjoint () =
+  let safe =
+    [ "GIT_AUTHOR_NAME"; "GIT_AUTHOR_EMAIL"
+    ; "GIT_COMMITTER_NAME"; "GIT_COMMITTER_EMAIL"
+    ]
+  in
   List.iter
     (fun p ->
-      assert_false
-        (Printf.sprintf "pass-list entry %s must not be on scrub list" p)
-        (Env_keeper_scrub.is_scrubbed p))
-    Env_keeper_scrub.pass
+      assert_true
+        (Printf.sprintf "safe entry %s must be allowed" p)
+        (Env_keeper_scrub.is_allowed p))
+    safe
 
 let test_filter_environment () =
   let env = [|
@@ -127,9 +132,10 @@ let test_filter_environment () =
   let out = Env_keeper_scrub.filter_environment env in
   let out_list = Array.to_list out in
   assert_contains ~msg:"PATH preserved" out_list "PATH=/usr/bin";
-  assert_contains ~msg:"FOO preserved (neutral)" out_list "FOO=bar";
-  assert_contains ~msg:"entries without = are kept"
-    out_list "malformed_entry_no_equals";
+  assert_false "FOO dropped (not on allowlist)"
+    (List.mem "FOO=bar" out_list);
+  assert_false "malformed_entry_no_equals dropped (not on allowlist)"
+    (List.mem "malformed_entry_no_equals" out_list);
   assert_false "ANTHROPIC_API_KEY stripped"
     (List.exists (fun e -> String.starts_with ~prefix:"ANTHROPIC_API_KEY=" e) out_list);
   assert_false "AWS_SECRET_ACCESS_KEY stripped"

--- a/test/test_env_keeper_scrub.ml
+++ b/test/test_env_keeper_scrub.ml
@@ -1,0 +1,127 @@
+module Env_keeper_scrub = Masc.Env_keeper_scrub
+
+let allowed_basic_envs () =
+  let must_allow =
+    [ "PATH"; "HOME"; "TMPDIR"; "LANG"; "LC_ALL"; "LC_CTYPE"
+    ; "USER"; "LOGNAME"; "SHELL"
+    ; "TERM"; "EDITOR"; "VISUAL"; "PAGER"
+    ; "XDG_CONFIG_HOME"; "XDG_CACHE_HOME"; "XDG_DATA_HOME"
+    ; "DOCKER_HOST"; "DOCKER_TLS_VERIFY"; "DOCKER_CERT_PATH"
+    ; "GIT_AUTHOR_NAME"; "GIT_AUTHOR_EMAIL"
+    ; "GIT_COMMITTER_NAME"; "GIT_COMMITTER_EMAIL"
+    ; "MASC_BASE_PATH"; "MASC_CONFIG_DIR"; "MASC_STORAGE_TYPE"
+    ; "MASC_KEEPER_BOOTSTRAP_ENABLED"
+    ; "MASC_KEEPER_HEARTBEAT_INTERVAL_SEC"
+    ]
+  in
+  List.iter
+    (fun key ->
+       Alcotest.(check bool) (Printf.sprintf "%s is allowed" key) true
+         (Env_keeper_scrub.is_allowed key))
+    must_allow
+;;
+
+let denied_secret_suffixes () =
+  let must_deny =
+    [ "ANTHROPIC_API_KEY"; "OPENAI_API_KEY"; "GEMINI_API_KEY"
+    ; "AWS_ACCESS_KEY_ID"; "AWS_SECRET_ACCESS_KEY"
+    ; "GITHUB_TOKEN"; "GH_TOKEN"
+    ; "MY_CUSTOM_SECRET"; "FOO_PASSWORD"; "BAR_CREDENTIALS"
+    ; "MASC_ADMIN_TOKEN"; "MASC_INTERNAL_MCP_TOKEN"
+    ]
+  in
+  List.iter
+    (fun key ->
+       Alcotest.(check bool) (Printf.sprintf "%s is denied" key) false
+         (Env_keeper_scrub.is_allowed key))
+    must_deny
+;;
+
+let denied_masc_admin_prefix () =
+  Alcotest.(check bool) "MASC_ADMIN_TOKEN denied" false
+    (Env_keeper_scrub.is_allowed "MASC_ADMIN_TOKEN");
+  Alcotest.(check bool) "MASC_INTERNAL_MCP_TOKEN denied" false
+    (Env_keeper_scrub.is_allowed "MASC_INTERNAL_MCP_TOKEN")
+;;
+
+let filter_environment_keeps_only_allowed () =
+  let input =
+    [| "ANTHROPIC_API_KEY=sk-ant-secret"
+     ; "MASC_ADMIN_TOKEN=admin-secret"
+     ; "PATH=/usr/bin:/bin"
+     ; "HOME=/tmp"
+     ; "MASC_BASE_PATH=/app"
+     ; "GIT_AUTHOR_NAME=keeper"
+    |]
+  in
+  let filtered = Env_keeper_scrub.filter_environment input in
+  let keys =
+    Array.to_list filtered
+    |> List.map (fun entry ->
+      match String.index_opt entry '=' with
+      | None -> entry
+      | Some i -> String.sub entry 0 i)
+  in
+  Alcotest.(check bool) "ANTHROPIC_API_KEY stripped" false
+    (List.mem "ANTHROPIC_API_KEY" keys);
+  Alcotest.(check bool) "MASC_ADMIN_TOKEN stripped" false
+    (List.mem "MASC_ADMIN_TOKEN" keys);
+  Alcotest.(check bool) "PATH preserved" true (List.mem "PATH" keys);
+  Alcotest.(check bool) "HOME preserved" true (List.mem "HOME" keys);
+  Alcotest.(check bool) "MASC_BASE_PATH preserved" true
+    (List.mem "MASC_BASE_PATH" keys);
+  Alcotest.(check bool) "GIT_AUTHOR_NAME preserved" true
+    (List.mem "GIT_AUTHOR_NAME" keys)
+;;
+
+let filter_environment_drops_entries_without_equals () =
+  let input = [| "WEIRD_NO_EQUALS"; "ANTHROPIC_API_KEY=secret" |] in
+  let filtered = Env_keeper_scrub.filter_environment input in
+  let has_weird =
+    Array.to_list filtered |> List.exists (fun e -> e = "WEIRD_NO_EQUALS")
+  in
+  let has_anthropic =
+    Array.to_list filtered |> List.exists (fun e -> e = "ANTHROPIC_API_KEY=secret")
+  in
+  Alcotest.(check bool) "WEIRD_NO_EQUALS dropped (not allowed)" false has_weird;
+  Alcotest.(check bool) "ANTHROPIC_API_KEY stripped" false has_anthropic
+;;
+
+let extra_allow_env_override () =
+  let prior = Sys.getenv_opt "MASC_KEEPER_ALLOW_EXTRA" in
+  Unix.putenv "MASC_KEEPER_ALLOW_EXTRA" "CUSTOM_OK,ANOTHER_OK";
+  Fun.protect
+    ~finally:(fun () ->
+      match prior with
+      | Some v -> Unix.putenv "MASC_KEEPER_ALLOW_EXTRA" v
+      | None -> Unix.putenv "MASC_KEEPER_ALLOW_EXTRA" "")
+    (fun () ->
+       Alcotest.(check bool) "CUSTOM_OK allowed by extra" true
+         (Env_keeper_scrub.is_allowed "CUSTOM_OK");
+       Alcotest.(check bool) "ANOTHER_OK allowed by extra" true
+         (Env_keeper_scrub.is_allowed "ANOTHER_OK");
+       (* extra allow does not bypass deny suffix *)
+       Alcotest.(check bool) "CUSTOM_OK_SECRET still denied" false
+         (Env_keeper_scrub.is_allowed "CUSTOM_OK_SECRET"))
+;;
+
+let () =
+  Alcotest.run
+    "env keeper scrub"
+    [ ( "allowlist"
+      , [ Alcotest.test_case "basic envs are allowed" `Quick allowed_basic_envs
+        ; Alcotest.test_case "secret suffixes are denied" `Quick
+            denied_secret_suffixes
+        ; Alcotest.test_case "MASC_ADMIN_ prefix is denied" `Quick
+            denied_masc_admin_prefix
+        ; Alcotest.test_case "MASC_KEEPER_ALLOW_EXTRA override" `Quick
+            extra_allow_env_override
+        ] )
+    ; ( "filter_environment"
+      , [ Alcotest.test_case "keeps allowed keys only" `Quick
+            filter_environment_keeps_only_allowed
+        ; Alcotest.test_case "drops unknown keys without equals" `Quick
+            filter_environment_drops_entries_without_equals
+        ] )
+    ]
+;;

--- a/test/test_keeper_secret_projection.ml
+++ b/test/test_keeper_secret_projection.ml
@@ -315,6 +315,24 @@ let test_dashboard_status_reports_projection_error () =
     (contains_substring (Yojson.Safe.to_string json) "invalid keeper secret env name")
 ;;
 
+let test_env_value_leading_hash_rejects () =
+  let base = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  with_env "MASC_SECRET_DIR" "" @@ fun () ->
+  let root = secret_root_default ~base ~keeper_name:"minjae" in
+  write_file (Filename.concat (Filename.concat root "env") "GH_TOKEN") "#starts_with_hash";
+  match
+    Keeper_secret_projection.docker_args_for_keeper
+      ~base_path:base
+      ~keeper_name:"minjae"
+      ~container_name:"container"
+  with
+  | Ok _ -> Alcotest.fail "expected leading-hash env value rejection"
+  | Error err ->
+    Alcotest.(check bool) "mentions docker env-file comment" true
+      (contains_substring err "docker --env-file")
+;;
+
 let () =
   Alcotest.run
     "keeper secret projection"
@@ -336,6 +354,8 @@ let () =
             test_dashboard_status_redacts_values
         ; Alcotest.test_case "dashboard status reports projection error" `Quick
             test_dashboard_status_reports_projection_error
+        ; Alcotest.test_case "env value leading hash rejects" `Quick
+            test_env_value_leading_hash_rejects
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary

Replaces the exact-match denylist (infinite product type) with a **default-deny allowlist** for keeper subprocess / docker CLI env scrubbing.

### Changes
- **allowlist model**: Only explicitly permitted env vars cross the boundary. New secrets are blocked by default.
- **allow_exact**: PATH, HOME, MASC_BASE_PATH, MASC_KEEPER_*, GIT_AUTHOR_NAME, etc.
- **deny suffixes**: *_API_KEY, *_TOKEN, *_SECRET, *_PASSWORD, *_CREDENTIALS
- **deny prefixes**: MASC_ADMIN_, MASC_INTERNAL_
- **Operator escape hatch**: MASC_KEEPER_ALLOW_EXTRA=comma,list
- **Docker env-file hardening**: Reject secret values starting with '#' (treated as comment by docker).

### Safety
- Blast radius is limited to **docker CLI subprocess env**. Container internals are unaffected (env is injected via --env / --env-file separately).
- Local-profile keeper execution does not use Env_keeper_scrub.filter_environment.

### Tests
- test/test_env_keeper_scrub.ml: Allowlist coverage + MASC_KEEPER_ALLOW_EXTRA override.
- test/test_keeper_secret_projection.ml: Rejection of #-prefixed env values.
- test/test_env_git_noninteractive.ml: Updated to assert allowlist semantics.

### Notes
- Full dune build is currently blocked by an unrelated signature mismatch in keeper_agent_run.ml / .mli. The changed modules compile/type-check standalone with ocamlc.

Refs: RFC-0007 PR-1 / #9639 Cluster B
