### PR TITLE
fix(dashboard): preserve QuickBind draft on bind failure + guard Enter double-submit

### DIFF
--- a/dashboard/src/components/connector-quick-bind.test.ts
+++ b/dashboard/src/components/connector-quick-bind.test.ts
@@ -98,6 +98,84 @@ describe('QuickBindForm', () => {
     expect(body).toContain('"channel_id":"C09TK9L4DV4"')
   })
 
+  it('bind FAILURE preserves the typed channel ID and re-enables the form (regression: draft wiped on failure)', async () => {
+    // Local flag instead of fetchSpy.mock.calls: spyOn(globalThis, 'fetch')
+    // accumulates call history across tests in this file, so only state
+    // recorded by THIS implementation is trustworthy. Fresh Response per
+    // call — the body is single-use.
+    let bindRequested = false
+    vi.spyOn(globalThis, 'fetch').mockImplementation((url) => {
+      if (String(url).includes('/api/v1/gate/connector/bind')) bindRequested = true
+      return Promise.resolve(new Response(JSON.stringify({ error: 'unknown keeper' }), { status: 404 }))
+    })
+    render(html`<${QuickBindForm} connectorId="discord" keepers=${[mkKeeper('kpr-a')]} />`, container)
+    const form = container.querySelector('[data-quick-bind="discord"]')!
+    const input = form.querySelector('input') as HTMLInputElement
+    input.value = '1234567890123456789'
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    await vi.waitFor(() => { expect(bindRequested).toBe(true) })
+    // The failure path (error-body read -> toast -> setEntry) is
+    // microtask-chained; two macrotask hops guarantee it has settled.
+    await new Promise(resolve => setTimeout(resolve, 0))
+    await new Promise(resolve => setTimeout(resolve, 0))
+    await flushUi()
+
+    const btn = Array.from(form.querySelectorAll('button')).find(b => b.textContent?.includes('Bind')) as HTMLButtonElement
+    // 'Bind' (not '연결 중...') + enabled proves the submitting cycle
+    // completed — guards against asserting the draft before the wipe
+    // would have happened.
+    expect(btn).toBeTruthy()
+    expect(btn.disabled).toBe(false)
+    expect(input.value).toBe('1234567890123456789')
+  })
+
+  it('bind SUCCESS clears the channel draft for the next bind', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    )
+    render(html`<${QuickBindForm} connectorId="discord" keepers=${[mkKeeper('kpr-a')]} />`, container)
+    const form = container.querySelector('[data-quick-bind="discord"]')!
+    const input = form.querySelector('input') as HTMLInputElement
+    input.value = '1234567890123456789'
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    await vi.waitFor(() => { expect(input.value).toBe('') })
+  })
+
+  it('a second Enter while a bind is in flight does not fire a second POST (regression: Enter bypassed the submitting guard)', async () => {
+    // Count via the implementation, not fetchSpy.mock.calls — spyOn call
+    // history accumulates across tests in this file and would also count
+    // earlier tests' bind POSTs.
+    const deferred: Array<(r: Response) => void> = []
+    let bindPosts = 0
+    vi.spyOn(globalThis, 'fetch').mockImplementation((url) => {
+      if (String(url).includes('/api/v1/gate/connector/bind')) bindPosts += 1
+      return new Promise<Response>(resolve => { deferred.push(resolve) })
+    })
+    render(html`<${QuickBindForm} connectorId="discord" keepers=${[mkKeeper('kpr-a')]} />`, container)
+    const form = container.querySelector('[data-quick-bind="discord"]')!
+    const input = form.querySelector('input') as HTMLInputElement
+    input.value = '1234567890123456789'
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    await flushUi()
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    await flushUi()
+
+    expect(bindPosts).toBe(1)
+
+    // Settle the in-flight bind so it cannot leak into the next test.
+    deferred.forEach(resolve => { resolve(new Response(JSON.stringify({ ok: true }), { status: 200 })) })
+    await flushUi()
+  })
+
   it('renders the connector-specific placeholder (Slack shows C-prefix example, not Discord snowflake)', () => {
     render(html`<${QuickBindForm} connectorId="slack" keepers=${[mkKeeper('kpr-a')]} />`, container)
     const input = container.querySelector('[data-quick-bind="slack"] input') as HTMLInputElement

--- a/dashboard/src/components/connector-quick-bind.ts
+++ b/dashboard/src/components/connector-quick-bind.ts
@@ -71,19 +71,18 @@ export function channelIdPlaceholder(connectorId: string): string {
 }
 
 async function submit(connectorId: string, entry: FormEntry) {
+  // The Bind button is disabled while submitting, but the Enter key path
+  // is not — without this guard a second Enter (double-tap or held-key
+  // auto-repeat) fires a concurrent bind POST for the same draft.
+  if (entry.submitting) return
   const channel = entry.channelId.trim()
   if (!channel || !entry.keeperName) return
   setEntry(connectorId, { submitting: true })
-  try {
-    await bindConnector(connectorId, entry.keeperName, channel)
-    // bindConnector already refreshes + toasts; we just clear the local
-    // channel draft so the operator can immediately bind another.
-    setEntry(connectorId, { channelId: '', submitting: false })
-  } catch {
-    // bindConnector already surfaced the toast; still need to unwedge the
-    // submitting state so the operator can retry.
-    setEntry(connectorId, { submitting: false })
-  }
+  const ok = await bindConnector(connectorId, entry.keeperName, channel)
+  // bindConnector surfaces success/error toasts itself and never rejects.
+  // Clear the draft only on success — on failure the operator needs the
+  // typed channel ID intact to retry.
+  setEntry(connectorId, ok ? { channelId: '', submitting: false } : { submitting: false })
 }
 
 export function QuickBindForm({ connectorId, keepers }: {

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -590,10 +590,13 @@ export async function stopSidecar(connectorId: string) {
   }
 }
 
-export async function bindConnector(connectorId: string, keeperName: string, channelId: string) {
+/** Returns true only when the bind POST succeeded. Errors are surfaced
+    here (toast + 상세 dialog) and swallowed, so this promise never
+    rejects — callers must branch on the boolean, not try/catch. */
+export async function bindConnector(connectorId: string, keeperName: string, channelId: string): Promise<boolean> {
   const keeper = keeperName.trim()
   const channel = channelId.trim()
-  if (!keeper || !channel) return
+  if (!keeper || !channel) return false
 
   patchConnectorUiState(connectorId, { actionLoading: true })
   try {
@@ -607,8 +610,10 @@ export async function bindConnector(connectorId: string, keeperName: string, cha
     })
     await refresh()
     showToast(`Bound ${channel} -> ${keeper}`, 'success')
+    return true
   } catch (err) {
     showConnectorActionError(`바인딩 실패: ${channel} → ${keeper}`, err)
+    return false
   } finally {
     patchConnectorUiState(connectorId, { actionLoading: false })
   }


### PR DESCRIPTION
## 무엇

"버튼 핸들러 다 올바른가?" 감사(17-agent adversarial audit)에서 확정된 QuickBindForm 버그 2건 수정.

## 버그 1 — bind 실패 시 입력한 채널 ID가 지워짐

`bindConnector`는 에러를 내부에서 처리(토스트 + 상세 다이얼로그)하고 **절대 reject하지 않습니다**. 따라서 QuickBindForm의 `catch`는 dead code였고, success 분기의 draft 초기화가 **실패 시에도 실행** — 운영자가 재시도하려는 순간 입력값이 사라졌습니다. (per-keeper 폼은 draft를 success 경로에서만 지워서 이 문제가 없음 — QuickBind만 회귀.)

수정: `bindConnector`가 성공 여부 boolean을 반환하고, draft는 성공 시에만 초기화.

## 버그 2 — Enter 키가 submitting 가드를 우회

Bind 버튼은 `disabled=${entry.submitting}`로 잠기지만 **키보드 경로는 아무 가드가 없었음** — Enter 더블탭/꾹 누름(auto-repeat)이 동일 draft로 동시 bind POST를 발사하고, 첫 호출의 `finally`가 카드 전체 actionLoading 락을 조기 해제했습니다.

수정: `submit()` 진입 시 `entry.submitting`이면 early return.

## 검증

- 회귀 테스트 3건 추가 (실패 시 draft 보존 / 성공 시 draft 초기화 / in-flight 중 2번째 Enter 무시)
- **Mutation 검증**: 구 컴포넌트 코드에서 새 테스트 2건이 정확히 실패, 수정 코드에서 14/14 PASS
- `tsc --noEmit` 0 errors, connector 3개 테스트 파일 48/48 PASS, eslint 0 errors
- 테스트 작성 중 발견: vitest 4의 `vi.spyOn(globalThis, 'fetch').mock.calls`가 같은 파일 내 테스트 간 누적됨 → 새 테스트는 mock implementation 로컬 카운터로 계수 (주석 명시)

감사 출처: 동일 감사에서 edge 4건(in-flight 중 blanket reset, 헤더↔rail 락 비대칭, in-process pill 힌트, bindings pill dead scroll)과 toast/dialog edge 3건도 확정 — 별도 처리 대상.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
