### PR TITLE
feat(health_score): add board_health_score to autonomous cooldown

### DIFF
--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -42,6 +42,7 @@ type world_observation =
   ; backlog_updated_since_last_scheduled_autonomous : bool
   ; active_agent_count : int
   ; connected_surfaces : Gate_surface.surface_presence list
+  ; board_health_score : float option
   }
 
 type keeper_cycle_channel =
@@ -467,6 +468,7 @@ let observe
   ; active_agent_count
   ; connected_surfaces =
       Gate_surface.connected_surfaces_for_keeper ~keeper_name:meta.name
+  ; board_health_score = None
   }
 ;;
 
@@ -500,6 +502,7 @@ let observe_direct_keeper_msg ~(config : Workspace.config) ~(meta : keeper_meta)
   ; active_agent_count = count_active_agents ~config
   ; connected_surfaces =
       Gate_surface.connected_surfaces_for_keeper ~keeper_name:meta.name
+  ; board_health_score = None
   }
 ;;
 

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -74,6 +74,10 @@ type world_observation = {
       autonomous attempt. Lets task-triggered wakeups bypass cooldown once
       so newly added work is not delayed behind the previous turn's timer. *)
 
+  board_health_score : float option;
+  (** Optional curation health score [0.0, 1.0] from the board. Below 0.4
+      the scheduled autonomous cooldown is multiplied to suppress turns. *)
+
   active_agent_count : int;
   (** Number of agents currently active in the workspace. *)
 

--- a/lib/keeper_contract/keeper_world_observation_turn_types.ml
+++ b/lib/keeper_contract/keeper_world_observation_turn_types.ml
@@ -55,6 +55,7 @@ type skip_reason =
   | Provider_cooldown_pending of { remaining_sec : int }
   | Idle_gate_pending of { remaining_sec : int }
   | Cooldown_pending of { remaining_sec : int }
+  | Health_score_cooldown of { remaining_sec : int }
   | No_signal
 
 type turn_verdict =
@@ -82,6 +83,7 @@ let skip_reason_to_string = function
   | Provider_cooldown_pending _ -> "provider_cooldown_pending"
   | Idle_gate_pending _ -> "idle_gate_pending"
   | Cooldown_pending _ -> "cooldown_pending"
+  | Health_score_cooldown _ -> "health_score_cooldown"
   | No_signal -> "no_signal"
 ;;
 

--- a/lib/keeper_contract/keeper_world_observation_turn_types.mli
+++ b/lib/keeper_contract/keeper_world_observation_turn_types.mli
@@ -32,6 +32,7 @@ type skip_reason =
   | Provider_cooldown_pending of { remaining_sec : int }
   | Idle_gate_pending of { remaining_sec : int }
   | Cooldown_pending of { remaining_sec : int }
+  | Health_score_cooldown of { remaining_sec : int }
   | No_signal
 
 type turn_verdict =


### PR DESCRIPTION
Add Health_score_cooldown skip_reason variant, board_health_score field to world_observation, and health_score_multiplier in effective_scheduled_autonomous cooldown.