### PR TITLE
[codex] fix Discord in-process connector status

### DIFF
--- a/dashboard/src/components/connector-config-form.test.ts
+++ b/dashboard/src/components/connector-config-form.test.ts
@@ -122,14 +122,14 @@ describe('ConnectorConfigToggle', () => {
   })
 
   it('flips aria-expanded to true when clicked', async () => {
-    mockedGet.mockResolvedValue({ ok: true, id: 'discord', schema: { properties: {}, required: [] } })
-    render(html`<${ConnectorConfigToggle} connectorId="discord" />`, container)
+    mockedGet.mockResolvedValue({ ok: true, id: 'slack', schema: { properties: {}, required: [] } })
+    render(html`<${ConnectorConfigToggle} connectorId="slack" />`, container)
     const btn = container.querySelector('button')!
     btn.click()
     await flushUi()
     expect(btn.getAttribute('aria-expanded')).toBe('true')
     expect(mockedGet).toHaveBeenCalledWith(
-      expect.stringContaining('/api/v1/sidecar/schema?name=discord'),
+      expect.stringContaining('/api/v1/sidecar/schema?name=slack'),
     )
   })
 })
@@ -153,21 +153,41 @@ describe('ConnectorConfigForm', () => {
     expect(container.textContent?.trim()).toBe('')
   })
 
-  it('Save button stays disabled while a required field is empty', async () => {
-    mockedGet.mockResolvedValue({
-      ok: true,
-      id: 'discord',
-      schema: {
-        properties: {
-          DISCORD_BOT_TOKEN: { type: 'string' },
-        },
-        required: ['DISCORD_BOT_TOKEN'],
-      },
-    })
+  it('renders in-process Discord config guidance without sidecar API calls', async () => {
     render(html`
       <div>
         <${ConnectorConfigToggle} connectorId="discord" />
         <${ConnectorConfigForm} connectorId="discord" />
+      </div>
+    `, container)
+    ;(container.querySelector('button[aria-expanded]') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(mockedGet).not.toHaveBeenCalled()
+    expect(mockedPost).not.toHaveBeenCalled()
+    const panel = container.querySelector('[data-in-process-config-panel]')
+    expect(panel).toBeTruthy()
+    expect(panel?.textContent).toContain('server in-process')
+    expect(panel?.textContent).toContain('DISCORD_BOT_TOKEN')
+    expect(panel?.textContent).not.toContain('Save')
+    expect(panel?.textContent).not.toContain('자동 재시작')
+  })
+
+  it('Save button stays disabled while a required field is empty', async () => {
+    mockedGet.mockResolvedValue({
+      ok: true,
+      id: 'slack',
+      schema: {
+        properties: {
+          SLACK_BOT_TOKEN: { type: 'string' },
+        },
+        required: ['SLACK_BOT_TOKEN'],
+      },
+    })
+    render(html`
+      <div>
+        <${ConnectorConfigToggle} connectorId="slack" />
+        <${ConnectorConfigForm} connectorId="slack" />
       </div>
     `, container)
     ;(container.querySelector('button[aria-expanded]') as HTMLButtonElement).click()
@@ -179,7 +199,7 @@ describe('ConnectorConfigForm', () => {
     expect(saveBtn).toBeTruthy()
     expect(saveBtn?.disabled).toBe(true)
     // Required field surfaces in the form (label) so operator can see what's missing.
-    expect(container.textContent).toContain('DISCORD_BOT_TOKEN')
+    expect(container.textContent).toContain('SLACK_BOT_TOKEN')
   })
 
   it('Save button POSTs to /api/v1/sidecar/config when required field is filled', async () => {
@@ -187,7 +207,7 @@ describe('ConnectorConfigForm', () => {
       // 1) schema GET
       .mockResolvedValueOnce({
         ok: true,
-        id: 'discord',
+        id: 'slack',
         schema: {
           properties: {
             GATE_BASE_URL: { type: 'string', default: 'http://localhost:8935' },
@@ -198,12 +218,12 @@ describe('ConnectorConfigForm', () => {
       // 2) current-values GET (no file yet)
       .mockResolvedValueOnce({ ok: true, exists: false, values: {} })
     // 3) save POST
-    mockedPost.mockResolvedValueOnce({ ok: true, id: 'discord', written_fields: 1 })
+    mockedPost.mockResolvedValueOnce({ ok: true, id: 'slack', written_fields: 1 })
 
     render(html`
       <div>
-        <${ConnectorConfigToggle} connectorId="discord" />
-        <${ConnectorConfigForm} connectorId="discord" />
+        <${ConnectorConfigToggle} connectorId="slack" />
+        <${ConnectorConfigForm} connectorId="slack" />
       </div>
     `, container)
     ;(container.querySelector('button[aria-expanded]') as HTMLButtonElement).click()
@@ -220,7 +240,7 @@ describe('ConnectorConfigForm', () => {
     expect(mockedGet).toHaveBeenCalledTimes(2)
     expect(mockedPost).toHaveBeenCalledTimes(1)
     const saveCall = mockedPost.mock.calls[0]
-    expect(saveCall?.[0]).toContain('/api/v1/sidecar/config?name=discord')
+    expect(saveCall?.[0]).toContain('/api/v1/sidecar/config?name=slack')
     expect(JSON.stringify(saveCall?.[1])).toContain('GATE_BASE_URL')
   })
 
@@ -229,7 +249,7 @@ describe('ConnectorConfigForm', () => {
       // 1) schema GET
       .mockResolvedValueOnce({
         ok: true,
-        id: 'discord',
+        id: 'slack',
         schema: {
           properties: { GATE_BASE_URL: { type: 'string', default: 'http://localhost:8935' } },
           required: [],
@@ -247,8 +267,8 @@ describe('ConnectorConfigForm', () => {
 
     render(html`
       <div>
-        <${ConnectorConfigToggle} connectorId="discord" />
-        <${ConnectorConfigForm} connectorId="discord" />
+        <${ConnectorConfigToggle} connectorId="slack" />
+        <${ConnectorConfigForm} connectorId="slack" />
       </div>
     `, container)
     ;(container.querySelector('button[aria-expanded]') as HTMLButtonElement).click()
@@ -271,35 +291,35 @@ describe('ConnectorConfigForm', () => {
 
     expect(mockedGet).toHaveBeenCalledTimes(2)
     expect(mockedPost).toHaveBeenCalledTimes(3)
-    expect(mockedPost.mock.calls[1]?.[0]).toContain('/api/v1/sidecar/stop?name=discord')
-    expect(mockedPost.mock.calls[2]?.[0]).toContain('/api/v1/sidecar/start?name=discord')
+    expect(mockedPost.mock.calls[1]?.[0]).toContain('/api/v1/sidecar/stop?name=slack')
+    expect(mockedPost.mock.calls[2]?.[0]).toContain('/api/v1/sidecar/start?name=slack')
   })
 
-  it('renders where-to-find hint block for DISCORD_BOT_TOKEN when schema contains it', async () => {
+  it('renders where-to-find hint block for SLACK_BOT_TOKEN when schema contains it', async () => {
     mockedGet.mockResolvedValue({
       ok: true,
-      id: 'discord',
+      id: 'slack',
       schema: {
         properties: {
-          DISCORD_BOT_TOKEN: { type: 'string' },
+          SLACK_BOT_TOKEN: { type: 'string' },
           GATE_BASE_URL: { type: 'string', default: 'http://localhost:8935' },
         },
-        required: ['DISCORD_BOT_TOKEN'],
+        required: ['SLACK_BOT_TOKEN'],
       },
     })
     render(html`
       <div>
-        <${ConnectorConfigToggle} connectorId="discord" />
-        <${ConnectorConfigForm} connectorId="discord" />
+        <${ConnectorConfigToggle} connectorId="slack" />
+        <${ConnectorConfigForm} connectorId="slack" />
       </div>
     `, container)
     ;(container.querySelector('button[aria-expanded]') as HTMLButtonElement).click()
     await flushUi()
     await flushUi()
 
-    const hint = container.querySelector('[data-field-hint="DISCORD_BOT_TOKEN"]')
+    const hint = container.querySelector('[data-field-hint="SLACK_BOT_TOKEN"]')
     expect(hint).toBeTruthy()
-    expect(hint?.textContent).toContain('Discord Developer Portal')
+    expect(hint?.textContent).toContain('Slack App')
     // Unknown fields stay clean — hint must not leak to GATE_BASE_URL.
     expect(container.querySelector('[data-field-hint="GATE_BASE_URL"]')).toBeNull()
   })
@@ -309,7 +329,7 @@ describe('ConnectorConfigForm', () => {
     mockedGet
       .mockResolvedValueOnce({
         ok: true,
-        id: 'discord',
+        id: 'slack',
         schema: { properties: { GATE_BASE_URL: { type: 'string', default: 'http://x' } }, required: [] },
       })
       .mockResolvedValueOnce({ ok: true, exists: false, values: {} })
@@ -317,8 +337,8 @@ describe('ConnectorConfigForm', () => {
 
     render(html`
       <div>
-        <${ConnectorConfigToggle} connectorId="discord" />
-        <${ConnectorConfigForm} connectorId="discord" />
+        <${ConnectorConfigToggle} connectorId="slack" />
+        <${ConnectorConfigForm} connectorId="slack" />
       </div>
     `, container)
     ;(container.querySelector('button[aria-expanded]') as HTMLButtonElement).click()
@@ -344,7 +364,7 @@ describe('ConnectorConfigForm', () => {
     mockedGet
       .mockResolvedValueOnce({
         ok: true,
-        id: 'discord',
+        id: 'slack',
         schema: { properties: { GATE_BASE_URL: { type: 'string', default: 'http://x' } }, required: [] },
       })
       .mockResolvedValueOnce({ ok: true, exists: false, values: {} })
@@ -355,8 +375,8 @@ describe('ConnectorConfigForm', () => {
 
     render(html`
       <div>
-        <${ConnectorConfigToggle} connectorId="discord" />
-        <${ConnectorConfigForm} connectorId="discord" />
+        <${ConnectorConfigToggle} connectorId="slack" />
+        <${ConnectorConfigForm} connectorId="slack" />
       </div>
     `, container)
     ;(container.querySelector('button[aria-expanded]') as HTMLButtonElement).click()
@@ -376,16 +396,16 @@ describe('ConnectorConfigForm', () => {
 
     expect(mockedGet).toHaveBeenCalledTimes(2)
     expect(mockedPost).toHaveBeenCalledTimes(3)
-    expect(mockedPost.mock.calls[0]?.[0]).toContain('/api/v1/sidecar/config?name=discord')
-    expect(mockedPost.mock.calls[1]?.[0]).toContain('/api/v1/sidecar/stop?name=discord')
-    expect(mockedPost.mock.calls[2]?.[0]).toContain('/api/v1/sidecar/start?name=discord')
+    expect(mockedPost.mock.calls[0]?.[0]).toContain('/api/v1/sidecar/config?name=slack')
+    expect(mockedPost.mock.calls[1]?.[0]).toContain('/api/v1/sidecar/stop?name=slack')
+    expect(mockedPost.mock.calls[2]?.[0]).toContain('/api/v1/sidecar/start?name=slack')
   })
 
   it('auto-restart soft-stop: if stop rejects, start still fires', async () => {
     mockedGet
       .mockResolvedValueOnce({
         ok: true,
-        id: 'discord',
+        id: 'slack',
         schema: { properties: { GATE_BASE_URL: { type: 'string', default: 'http://x' } }, required: [] },
       })
       .mockResolvedValueOnce({ ok: true, exists: false, values: {} })
@@ -396,8 +416,8 @@ describe('ConnectorConfigForm', () => {
 
     render(html`
       <div>
-        <${ConnectorConfigToggle} connectorId="discord" />
-        <${ConnectorConfigForm} connectorId="discord" />
+        <${ConnectorConfigToggle} connectorId="slack" />
+        <${ConnectorConfigForm} connectorId="slack" />
       </div>
     `, container)
     ;(container.querySelector('button[aria-expanded]') as HTMLButtonElement).click()
@@ -421,20 +441,20 @@ describe('ConnectorConfigForm', () => {
   it('after toggle + fetch, renders required field marker and password input for token', async () => {
     mockedGet.mockResolvedValue({
       ok: true,
-      id: 'discord',
+      id: 'slack',
       schema: {
         properties: {
-          DISCORD_BOT_TOKEN: { type: 'string', title: 'Discord Bot Token' },
+          SLACK_BOT_TOKEN: { type: 'string', title: 'Slack Bot Token' },
           GATE_BASE_URL: { type: 'string', default: 'http://localhost:8935' },
         },
-        required: ['DISCORD_BOT_TOKEN'],
+        required: ['SLACK_BOT_TOKEN'],
       },
     })
 
     render(html`
       <div>
-        <${ConnectorConfigToggle} connectorId="discord" />
-        <${ConnectorConfigForm} connectorId="discord" />
+        <${ConnectorConfigToggle} connectorId="slack" />
+        <${ConnectorConfigForm} connectorId="slack" />
       </div>
     `, container)
     const toggle = container.querySelector('button[aria-expanded]') as HTMLButtonElement
@@ -442,7 +462,7 @@ describe('ConnectorConfigForm', () => {
     await flushUi()
     await flushUi()
 
-    expect(container.textContent).toContain('DISCORD_BOT_TOKEN')
+    expect(container.textContent).toContain('SLACK_BOT_TOKEN')
     expect(container.textContent).toContain('GATE_BASE_URL')
     expect(container.textContent).toContain('1 required')
     const tokenInput = container.querySelector('input[type="password"]')

--- a/dashboard/src/components/connector-config-form.ts
+++ b/dashboard/src/components/connector-config-form.ts
@@ -70,6 +70,24 @@ interface FormEntry {
 
 const formState = signal<Record<string, FormEntry>>({})
 
+interface InProcessConfigGuide {
+  displayName: string
+  envVar: string
+  docsRef: string
+}
+
+const IN_PROCESS_CONFIG_GUIDES: Record<string, InProcessConfigGuide> = {
+  discord: {
+    displayName: 'Discord',
+    envVar: 'DISCORD_BOT_TOKEN',
+    docsRef: 'docs/CONNECTOR-CONFIG-SCHEMA.md',
+  },
+}
+
+function inProcessConfigGuide(id: string): InProcessConfigGuide | null {
+  return IN_PROCESS_CONFIG_GUIDES[id] ?? null
+}
+
 function emptyEntry(): FormEntry {
   return {
     fields: [],
@@ -278,7 +296,7 @@ export function ConnectorConfigToggle({ connectorId }: { connectorId: string }) 
       setEntry(connectorId, { open: false })
     } else {
       setEntry(connectorId, { open: true })
-      if (entry.fields.length === 0 && !entry.loading) {
+      if (inProcessConfigGuide(connectorId) === null && entry.fields.length === 0 && !entry.loading) {
         void fetchSchema(connectorId)
       }
     }
@@ -389,6 +407,57 @@ function FieldWidget({ id, field, value, revealed }: {
 export function ConnectorConfigForm({ connectorId }: { connectorId: string }) {
   const entry = getEntry(connectorId)
   if (!entry.open) return null
+
+  const inProcess = inProcessConfigGuide(connectorId)
+  if (inProcess !== null) {
+    const hint = getFieldHint(inProcess.envVar)
+    return html`
+      <${SurfaceCard}
+        class="mt-3 !border-[var(--accent-20)] !bg-[var(--accent-10)]/5 !p-3 text-2xs"
+        id=${`connector-config-${connectorId}`}
+        data-in-process-config-panel
+      >
+        <div class="mb-2 flex flex-wrap items-center gap-2">
+          <span class="text-3xs uppercase tracking-4 text-[var(--color-fg-disabled)]">server in-process</span>
+          <span class="font-semibold text-[var(--color-fg-primary)]">${inProcess.displayName} 설정</span>
+        </div>
+        <div class="text-[var(--color-fg-secondary)]">
+          ${inProcess.displayName}는 외부 sidecar가 아니라 서버 프로세스 내부 gateway로 실행됩니다. 이 패널은
+          <span class="mx-1 font-mono text-[var(--color-fg-primary)]">${inProcess.envVar}</span>
+          위치만 보여주며, sidecar schema/config/start/stop API를 호출하지 않습니다.
+        </div>
+        ${hint === null
+          ? null
+          : html`
+              <${SurfaceCard} class="mt-2 !border-[var(--accent-20)] !bg-[var(--accent-10)]/5 !px-2 !py-1 text-3xs text-[var(--color-accent-fg)]" data-field-hint=${inProcess.envVar}>
+                <span>${hint.where}</span>
+                ${hint.url
+                  ? html`
+                      <a
+                        href=${hint.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="ml-1 underline hover:text-[var(--color-accent-fg)]"
+                      >열기 ↗</a>
+                    `
+                  : null}
+              </${SurfaceCard}>
+            `}
+        <div class="mt-3 border-t border-[var(--color-border-default)] pt-2.5">
+          <div class="mb-1 text-3xs uppercase tracking-4 text-[var(--color-fg-disabled)]">
+            env
+          </div>
+          <${CopyableCode}
+            command=${`${inProcess.envVar}=<token>`}
+            ariaLabel=${`${inProcess.displayName} in-process env var`}
+          />
+          <div class="mt-1 text-3xs text-[var(--color-fg-disabled)]">
+            ${inProcess.docsRef} 기준: 서버 환경변수에 설정한 뒤 MASC 서버를 재기동해야 gateway 연결에 반영됩니다.
+          </div>
+        </div>
+      </${SurfaceCard}>
+    `
+  }
 
   useEffect(() => {
     if (entry.fields.length === 0 && !entry.loading && !entry.error) {
@@ -552,7 +621,7 @@ export function openConnectorConfig(id: string) {
   const entry = getEntry(id)
   if (!entry.open) {
     setEntry(id, { open: true })
-    if (entry.fields.length === 0 && !entry.loading) {
+    if (inProcessConfigGuide(id) === null && entry.fields.length === 0 && !entry.loading) {
       void fetchSchema(id)
     }
   }

--- a/dashboard/src/components/connector-status.test.ts
+++ b/dashboard/src/components/connector-status.test.ts
@@ -782,6 +782,7 @@ describe('ConnectorStatusPanel', () => {
     // No Start/Stop button, no copyable run.sh command.
     expect(inProcessPanel!.querySelector('button[aria-label*="start"]')).toBeNull()
     expect(inProcessPanel!.querySelector('[data-copy-button]')).toBeNull()
+    expect(container.querySelector('[aria-controls="sidecar-log-discord"]')).toBeNull()
   })
 
   it('shows no-keepers empty state when keeper directory is empty', async () => {

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -834,9 +834,11 @@ function ConnectorLivePanel({
                 >${isActionLoading ? '…' : 'Stop'}</button>
               `
             : null}
-          <${SidecarLogToggle} connectorId=${connectorId} />
+          ${!isInProcessConnector(connectorId)
+            ? html`<${SidecarLogToggle} connectorId=${connectorId} />`
+            : null}
           <${ConnectorConfigToggle} connectorId=${connectorId} />
-          ${sidecarLogPath
+          ${sidecarLogPath && !isInProcessConnector(connectorId)
             ? html`<span class="cursor-help text-3xs text-[var(--color-fg-disabled)]" title=${sidecarLogPath} aria-hidden="true">↗</span>`
             : null}
           <button
@@ -934,7 +936,9 @@ function ConnectorLivePanel({
           `
         : null}
 
-      <${SidecarLogViewer} connectorId=${connectorId} />
+      ${!isInProcessConnector(connectorId)
+        ? html`<${SidecarLogViewer} connectorId=${connectorId} />`
+        : null}
       <${ConnectorConfigForm} connectorId=${connectorId} />
 
       ${keeperDirectoryError && keepers.length === 0

--- a/lib/gate/channel_gate_discord_state.ml
+++ b/lib/gate/channel_gate_discord_state.ml
@@ -183,20 +183,30 @@ let bool_member json key =
 let bool_option_member json key =
   Json_util.get_bool json key
 
-let stale_of_updated_at updated_at =
-  match Gate_time_util.parse_iso8601_opt updated_at with
-  | Some ts -> Unix.gettimeofday () -. ts > float_of_int (stale_after_sec ())
-  | None -> true
-
 let connector_state_label ~available ~connected ~stale =
   if not available then "offline"
   else if stale then "stale"
   else if connected then "connected"
   else "disconnected"
 
+let bot_token_opt () =
+  match Sys.getenv_opt "DISCORD_BOT_TOKEN" with
+  | None -> None
+  | Some raw ->
+    let trimmed = String.trim raw in
+    if String.equal trimmed "" then None else Some trimmed
+
+let gateway_state_label = function
+  | Discord_gateway_state.Disconnected -> "disconnected"
+  | Awaiting_hello -> "awaiting_hello"
+  | Identifying -> "identifying"
+  | Resuming -> "resuming"
+  | Connected _ -> "connected"
+  | Reconnect_pending _ -> "reconnect_pending"
+  | Failed _ -> "failed"
+
 let status_json ?(audit_limit = 10) () =
   let status_path = status_path () in
-  let live_status = read_json_file_opt status_path in
   let binding_store_path = binding_store_read_path () in
   let audit_path = binding_audit_read_path () in
   let names_path = Names.names_read_path () in
@@ -204,23 +214,29 @@ let status_json ?(audit_limit = 10) () =
   let configured_bindings = read_bindings () in
   let recent_audit = read_recent_audit ~limit:audit_limit in
   let channel = "discord" in
-  let available = Option.is_some live_status in
-  let updated_at =
-    match live_status with
-    | Some json -> string_member json "updated_at"
-    | None -> ""
+  let gateway_state = Discord_gateway_client.connection_state () in
+  let token_present = Option.is_some (bot_token_opt ()) in
+  let available =
+    match gateway_state with
+    | Disconnected -> token_present
+    | Awaiting_hello | Identifying | Resuming | Connected _
+    | Reconnect_pending _ | Failed _ -> true
   in
-  let stale = if not available then true else stale_of_updated_at updated_at in
   let connected =
-    match live_status with
-    | Some json -> bool_member json "connected" && not stale
-    | None -> false
+    match gateway_state with
+    | Connected _ -> true
+    | Disconnected | Awaiting_hello | Identifying | Resuming
+    | Reconnect_pending _ | Failed _ -> false
   in
-  let error = if available then "" else "connector status file not found" in
-  let status_field key f default =
-    match live_status with
-    | Some json -> f json key
-    | None -> default
+  let stale = false in
+  let updated_at = Gate_time_util.iso8601_of_unix (Unix.gettimeofday ()) in
+  let error =
+    match gateway_state with
+    | Disconnected ->
+      if token_present then "" else "DISCORD_BOT_TOKEN is unset or empty"
+    | Failed msg -> msg
+    | Awaiting_hello | Identifying | Resuming | Connected _
+    | Reconnect_pending _ -> ""
   in
   `Assoc
     [
@@ -231,33 +247,24 @@ let status_json ?(audit_limit = 10) () =
       ("stale_after_sec", `Int (stale_after_sec ()));
       ("status", `String (connector_state_label ~available ~connected ~stale));
       ("error", `String error);
+      ("status_source", `String "in_process_gateway");
+      ("gateway_state", `String (gateway_state_label gateway_state));
       ("status_path", `String status_path);
       ("binding_store_path", `String binding_store_path);
       ("audit_path", `String audit_path);
       ("names_path", `String names_path);
       ("names", Names.to_json name_map);
       ("updated_at", `String updated_at);
-      ( "last_ready_at",
-        `String (status_field "last_ready_at" string_member "") );
-      ( "bot_user_name",
-        `String (status_field "bot_user_name" string_member "") );
-      ("bot_user_id", `String (status_field "bot_user_id" string_member ""));
-      ("guild_count", `Int (status_field "guild_count" int_member 0));
-      ( "gate_base_url",
-        `String (status_field "gate_base_url" string_member "") );
-      ( "gate_healthy",
-        Option.value ~default:`Null
-          (Option.map (fun value -> `Bool value)
-             (match live_status with
-              | Some json -> bool_option_member json "gate_healthy"
-              | None -> None)) );
-      ( "gate_health_checked_at",
-        `String (status_field "gate_health_checked_at" string_member "") );
-      ( "binding_source",
-        `String (status_field "binding_source" string_member "") );
-      ( "runtime_bindings_count",
-        `Int (status_field "runtime_bindings_count" int_member 0) );
-      ("pid", `Int (status_field "pid" int_member 0));
+      ("last_ready_at", `String (if connected then updated_at else ""));
+      ("bot_user_name", `String "");
+      ("bot_user_id", `String "");
+      ("guild_count", `Int 0);
+      ("gate_base_url", `String "in-process");
+      ("gate_healthy", if connected then `Bool true else `Null);
+      ("gate_health_checked_at", `String (if connected then updated_at else ""));
+      ("binding_source", `String "persisted");
+      ("runtime_bindings_count", `Int (List.length configured_bindings));
+      ("pid", `Int (if available then Unix.getpid () else 0));
       ( "configured_bindings",
         `List (List.map binding_json configured_bindings) );
       ("recent_audit", `List recent_audit);
@@ -530,13 +537,6 @@ let pp_send_error fmt = function
     Format.fprintf fmt "DISCORD_BOT_TOKEN is unset or empty"
   | Rest_error e ->
     Format.fprintf fmt "discord rest error: %a" Discord_rest_client.pp_error e
-
-let bot_token_opt () =
-  match Sys.getenv_opt "DISCORD_BOT_TOKEN" with
-  | None -> None
-  | Some raw ->
-    let trimmed = String.trim raw in
-    if String.equal trimmed "" then None else Some trimmed
 
 let send_message ~channel_id ~content ?reply_to_message_id () =
   match bot_token_opt () with

--- a/test/test_channel_gate_discord_state.ml
+++ b/test/test_channel_gate_discord_state.ml
@@ -48,9 +48,10 @@ let with_discord_paths dir f =
       with_env "MASC_DISCORD_BINDING_AUDIT_PATH" (Some audit_path) (fun () ->
         with_env "MASC_DISCORD_NAMES_PATH" (Some names_path) f)))
 
-let test_status_json_reports_missing_live_status () =
+let test_status_json_reports_in_process_gateway_status () =
   with_temp_dir @@ fun dir ->
   with_discord_paths dir (fun () ->
+  with_env "DISCORD_BOT_TOKEN" None (fun () ->
     let json = Discord_state.status_json () in
     check string "channel" "discord"
       (json |> U.member "channel" |> U.to_string);
@@ -58,12 +59,41 @@ let test_status_json_reports_missing_live_status () =
       (json |> U.member "available" |> U.to_bool);
     check bool "connected false" false
       (json |> U.member "connected" |> U.to_bool);
-    check bool "stale true" true
+    check bool "stale false" false
       (json |> U.member "stale" |> U.to_bool);
-    check string "generic missing-status error" "connector status file not found"
+    check string "status source" "in_process_gateway"
+      (json |> U.member "status_source" |> U.to_string);
+    check string "gateway state" "disconnected"
+      (json |> U.member "gateway_state" |> U.to_string);
+    check string "missing-token error" "DISCORD_BOT_TOKEN is unset or empty"
       (json |> U.member "error" |> U.to_string);
     check int "no configured bindings" 0
-      (json |> U.member "configured_bindings" |> U.to_list |> List.length))
+      (json |> U.member "configured_bindings" |> U.to_list |> List.length)))
+
+let test_status_json_ignores_legacy_sidecar_status_file () =
+  with_temp_dir @@ fun dir ->
+  with_discord_paths dir (fun () ->
+  with_env "DISCORD_BOT_TOKEN" None (fun () ->
+    let status_path = Filename.concat dir "status.json" in
+    Yojson.Safe.to_file status_path
+      (`Assoc
+        [
+          ("updated_at", `String "2026-05-10T16:49:47Z");
+          ("connected", `Bool true);
+          ("bot_user_name", `String "legacy-sidecar");
+          ("runtime_bindings_count", `Int 99);
+        ]);
+    let json = Discord_state.status_json () in
+    check string "source" "in_process_gateway"
+      (json |> U.member "status_source" |> U.to_string);
+    check bool "legacy stale file ignored" false
+      (json |> U.member "stale" |> U.to_bool);
+    check bool "legacy connected file ignored" false
+      (json |> U.member "connected" |> U.to_bool);
+    check string "legacy bot name ignored" ""
+      (json |> U.member "bot_user_name" |> U.to_string);
+    check int "runtime bindings from persisted bindings" 0
+      (json |> U.member "runtime_bindings_count" |> U.to_int)))
 
 let test_bind_persists_binding_and_audit () =
   with_temp_dir @@ fun dir ->
@@ -244,8 +274,10 @@ let () =
     [
       ( "status",
         [
-          test_case "missing live status" `Quick
-            test_status_json_reports_missing_live_status;
+          test_case "in-process gateway status" `Quick
+            test_status_json_reports_in_process_gateway_status;
+          test_case "ignores legacy sidecar status file" `Quick
+            test_status_json_ignores_legacy_sidecar_status_file;
           test_case "bind persists binding and audit" `Quick
             test_bind_persists_binding_and_audit;
           test_case "unbind removes binding" `Quick


### PR DESCRIPTION
## Summary

- Stop treating Discord as an external sidecar in the dashboard config/log controls.
- Render Discord config as an in-process gateway panel backed by DISCORD_BOT_TOKEN guidance.
- Derive Discord connector status from Discord_gateway_client.connection_state() instead of stale legacy sidecar status files.
- Add regression coverage for stale legacy status files and Discord config avoiding sidecar API calls.

## Product impact

- User-visible change: Discord connector settings no longer show schema fetch failures or sidecar stop/log affordances for a deleted sidecar.
- Discord status reflects the in-process gateway state instead of a 2026-05-10 legacy heartbeat file.
- Slack/iMessage/Telegram sidecar config and lifecycle paths are unchanged.

## Evidence

- curl -sS -i 'http://127.0.0.1:8935/api/v1/sidecar/schema?name=discord' returned HTTP 503 because sidecars/discord-bot is deleted.
- curl -sS 'http://127.0.0.1:8935/api/v1/gate/connectors' showed Discord stale from 2026-05-10 legacy status file.
- pnpm exec vitest run --config vitest.config.ts src/components/connector-config-form.test.ts src/components/connector-status.test.ts --no-file-parallelism --maxWorkers=1
- pnpm run typecheck
- pnpm run lint
- pnpm run build
- bash scripts/ci/check-determinism-contract.sh
- opam exec -- ocamlformat --check lib/gate/channel_gate_discord_state.ml
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_channel_gate_discord_state.exe
- ./_build/default/test/test_channel_gate_discord_state.exe
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_channel_gate_discord_state_in_process.exe
- ./_build/default/test/test_channel_gate_discord_state_in_process.exe

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 0/10
provenance: operator_proxy
stages:
  - name: live_schema_failure_probe
    command: "curl -sS -i 'http://127.0.0.1:8935/api/v1/sidecar/schema?name=discord'"
    result: "HTTP 503: deleted discord-bot sidecar path"
  - name: live_connector_status_probe
    command: "curl -sS 'http://127.0.0.1:8935/api/v1/gate/connectors'"
    result: "Discord status read stale legacy 2026-05-10 heartbeat"
  - name: dashboard_focused_tests
    command: "pnpm exec vitest run --config vitest.config.ts src/components/connector-config-form.test.ts src/components/connector-status.test.ts --no-file-parallelism --maxWorkers=1"
    result: "PASS 42 tests"
  - name: dashboard_typecheck
    command: "pnpm run typecheck"
    result: "PASS"
  - name: dashboard_lint
    command: "pnpm run lint"
    result: "PASS"
  - name: dashboard_build
    command: "pnpm run build"
    result: "PASS with existing Vite warnings"
  - name: determinism_guard
    command: "bash scripts/ci/check-determinism-contract.sh"
    result: "PASS"
  - name: ocamlformat_check
    command: "opam exec -- ocamlformat --check lib/gate/channel_gate_discord_state.ml"
    result: "PASS"
  - name: ocaml_status_build_and_test
    command: "env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_channel_gate_discord_state.exe && ./_build/default/test/test_channel_gate_discord_state.exe"
    result: "PASS 10 tests"
  - name: ocaml_in_process_helper_build_and_test
    command: "env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_channel_gate_discord_state_in_process.exe && ./_build/default/test/test_channel_gate_discord_state_in_process.exe"
    result: "PASS 7 tests"
```

## GOAL LOOP ACT checklist

- [x] Observe - live schema/status probes showed Discord still routed through deleted sidecar surfaces.
- [x] Orient - mapped drift to RFC-0203 in-process gateway boundary and stale status-file reads.
- [x] Decide - narrow fix to Discord dashboard controls and Discord connector status projection.
- [x] Act - updated dashboard controls, backend status source, and regression tests.
- [x] Verify - focused dashboard, TypeScript, build, and OCaml tests passed.
- [x] Loop - no follow-up required for this bug; live server needs rebuilt/restarted after merge.

## Review evidence

- Local code review: scoped to Discord in-process connector drift; non-Discord sidecar flows left unchanged.
- Cross-model review: not run; local focused tests cover the regression path.

## Linked issue

- Closes #
- Relates #

## Variant addition checklist

- [x] **OCaml** - no variant added/removed; match on Discord connection state remains exhaustive.
- [x] **TypeScript** - no union member added/removed.
- [x] **TLA+ spec** - not applicable; no domain literal changed.
- [x] **Event / JSON schema** - no schema enum changed; status JSON adds fields without enum expansion.
- [ ] **`make check-variants` passes** - not run; no variant/domain/schema enum change in this PR.
