### PR TITLE
feat(obs): publish telemetry_event on cascade resolution decisions

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -115,6 +115,7 @@
   keeper_unified_turn_retry_setup
   keeper_unified_turn_terminal_error
   keeper_unified_turn_attempt_watchdog
+  keeper_unified_turn_cascade_resolution
   keeper_unified_turn_execution
   keeper_unified_turn_livelock_block
   keeper_context_runtime

--- a/lib/keeper/keeper_unified_turn_cascade_resolution.ml
+++ b/lib/keeper/keeper_unified_turn_cascade_resolution.ml
@@ -1,0 +1,47 @@
+(** Keeper_unified_turn_cascade_resolution — Telemetry-event publishing
+    for cascade (retry/rotation) resolution decisions.
+
+    Publishes a [telemetry_event] on the MASC Event_bus each time the
+    keeper retry loop resolves a cascade decision type.
+
+    @since task-786 *)
+
+let decision_kind_to_string : cascade_decision_kind -> string = function
+  | Degraded_retry_allowed -> "degraded_retry_allowed"
+  | Degraded_retry_slot_phase_exhausted -> "degraded_retry_slot_phase_exhausted"
+  | No_degraded_retry -> "no_degraded_retry"
+  | Transient_network_retry -> "transient_network_retry"
+
+let publish_cascade_resolution
+    ~keeper_name
+    ~runtime_id
+    ~decision
+    ~reason
+    ~next_runtime
+    ~attempt
+    ~error_kind
+    ~error_message
+    ()
+  =
+  let payload = `Assoc
+    [ "keeper_name", `String keeper_name
+    ; "runtime_id", `String runtime_id
+    ; "decision", `String (decision_kind_to_string decision)
+    ; "reason", `String reason
+    ; "next_runtime",
+      (match next_runtime with Some r -> `String r | None -> `Null)
+    ; "attempt", `Int attempt
+    ; "error_kind",
+      (match error_kind with Some k -> `String k | None -> `Null)
+    ; "error_message",
+      (match error_message with Some m -> `String m | None -> `Null)
+    ; "timestamp", `Float (Time_compat.now ())
+    ]
+  in
+  match Masc_event_bus.get () with
+  | None ->
+    Log.Keeper.debug
+      "cascade_resolution: no Masc_event_bus available, skipping telemetry"
+  | Some bus ->
+    let open Agent_sdk.Event_bus in
+    publish bus (mk_event (Custom ("telemetry_event", payload)))

--- a/lib/keeper/keeper_unified_turn_cascade_resolution.mli
+++ b/lib/keeper/keeper_unified_turn_cascade_resolution.mli
@@ -1,0 +1,42 @@
+(** Keeper_unified_turn_cascade_resolution — Telemetry-event publishing
+    for cascade (retry/rotation) resolution decisions.
+
+    Publishes a [telemetry_event] on the MASC Event_bus each time the
+    keeper retry loop resolves a cascade decision — degraded retry
+    allowed, slot-phase exhausted, no degraded retry, or transient
+    network retry.
+
+    [keeper_telemetry_consumer] observes [Custom("telemetry_event", _)]
+    on the bus and increments
+    [masc_keeper_telemetry_events_consumed_total].
+
+    @since task-786 *)
+
+(** {1 Decision kind} *)
+
+type cascade_decision_kind =
+  | Degraded_retry_allowed
+  | Degraded_retry_slot_phase_exhausted
+  | No_degraded_retry
+  | Transient_network_retry
+(** Kind of cascade resolution decision. *)
+
+(** {1 Publishing} *)
+
+val publish_cascade_resolution :
+  keeper_name:string ->
+  runtime_id:string ->
+  decision:cascade_decision_kind ->
+  reason:string ->
+  next_runtime:string option ->
+  attempt:int ->
+  error_kind:string option ->
+  error_message:string option ->
+  unit
+(** Publishes a [telemetry_event] with payload
+    [{ keeper_name, runtime_id, decision, reason, next_runtime,
+       attempt, error_kind, error_message, timestamp }].
+
+    Call at each cascade resolution point in the retry loop so
+    observability can track provider fallback patterns, slot-phase
+    exhaustion events, and transient retries. *)

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -419,6 +419,16 @@ let run (ctx : ctx)
             err
         with
         | Degraded_retry_allowed degraded_retry ->
+          Keeper_unified_turn_cascade_resolution.publish_cascade_resolution
+            ~keeper_name:meta.name
+            ~runtime_id:execution.runtime_id
+            ~decision:Degraded_retry_allowed
+            ~reason:(EC.degraded_retry_reason_to_string degraded_retry.fallback_reason)
+            ~next_runtime:(Some degraded_retry.next_runtime)
+            ~attempt
+            ~error_kind:(Some (Keeper_agent_error.sdk_error_kind err))
+            ~error_message:(Some (Agent_sdk.Error.to_string err))
+            ();
           (match
              Keeper_unified_turn_pre_dispatch
              .build_runtime_execution
@@ -506,6 +516,16 @@ let run (ctx : ctx)
                    next_execution_runtime_id :: attempted_runtimes
                })
         | Degraded_retry_slot_phase_exhausted degraded_retry ->
+          Keeper_unified_turn_cascade_resolution.publish_cascade_resolution
+            ~keeper_name:meta.name
+            ~runtime_id:execution.runtime_id
+            ~decision:Degraded_retry_slot_phase_exhausted
+            ~reason:(EC.degraded_retry_reason_to_string degraded_retry.fallback_reason)
+            ~next_runtime:(Some degraded_retry.next_runtime)
+            ~attempt
+            ~error_kind:(Some (Keeper_agent_error.sdk_error_kind err))
+            ~error_message:(Some (Agent_sdk.Error.to_string err))
+            ();
           let productive_phase_elapsed_ms, retry_phase_elapsed_ms =
             current_turn_phase_elapsed_ms ()
           in
@@ -535,6 +555,16 @@ let run (ctx : ctx)
         | No_degraded_retry
           when EC.is_transient_network_error err
                && attempt <= EC.max_transient_retries () ->
+          Keeper_unified_turn_cascade_resolution.publish_cascade_resolution
+            ~keeper_name:meta.name
+            ~runtime_id:execution.runtime_id
+            ~decision:Transient_network_retry
+            ~reason:"transient_network_error"
+            ~next_runtime:None
+            ~attempt
+            ~error_kind:(Some (Keeper_agent_error.sdk_error_kind err))
+            ~error_message:(Some (Agent_sdk.Error.to_string err))
+            ();
           let delay = EC.transient_backoff_sec attempt in
           Log.Keeper.warn
             "%s: transient network error runtime=%s max_context=%d \
@@ -576,6 +606,16 @@ let run (ctx : ctx)
             ; attempted_runtimes
             }
         | No_degraded_retry when EC.is_context_overflow err ->
+          Keeper_unified_turn_cascade_resolution.publish_cascade_resolution
+            ~keeper_name:meta.name
+            ~runtime_id:execution.runtime_id
+            ~decision:No_degraded_retry
+            ~reason:"context_overflow_after_oas_retry"
+            ~next_runtime:None
+            ~attempt
+            ~error_kind:(Some (Keeper_agent_error.sdk_error_kind err))
+            ~error_message:(Some (Agent_sdk.Error.to_string err))
+            ();
           let current_turn_event_bus =
             drain_turn_event_bus ~site:"context_overflow_capture" ()
           in
@@ -611,6 +651,16 @@ let run (ctx : ctx)
           mark_terminal_error err;
           Error err
         | No_degraded_retry ->
+          Keeper_unified_turn_cascade_resolution.publish_cascade_resolution
+            ~keeper_name:meta.name
+            ~runtime_id:execution.runtime_id
+            ~decision:No_degraded_retry
+            ~reason:"terminal_error_no_degraded_retry"
+            ~next_runtime:None
+            ~attempt
+            ~error_kind:(Some (Keeper_agent_error.sdk_error_kind err))
+            ~error_message:(Some (Agent_sdk.Error.to_string err))
+            ();
           mark_terminal_error err;
           Error err)
   in


### PR DESCRIPTION
Adds a new private module `Keeper_unified_turn_cascade_resolution` that publishes `telemetry_event` on the MASC Event_bus at each cascade (retry/rotation) resolution decision point:

- **Degraded_retry_allowed** — provider fallback triggered
- **Degraded_retry_slot_phase_exhausted** — slot budget consumed
- **No_degraded_retry** — terminal error (context overflow, no retry path)
- **Transient_network_retry** — transient error with backoff retry

Telemetry payload includes keeper_name, runtime_id, decision kind, reason, next_runtime, attempt count, error_kind, error_message, and timestamp. Follows the existing `keeper_event_publisher` telemetry pattern.

Closes task-786