### PR TITLE
fix(lib): use sandbox_workspace_root fallback in workspace_root() for docker sandbox keepers

### DIFF
--- a/lib/tool_library.ml
+++ b/lib/tool_library.ml
@@ -78,7 +78,7 @@ type context = {
 let workspace_root () =
   match Sys.getenv_opt "MASC_BASE_PATH" |> Option.map String.trim with
   | Some root when root <> "" -> Env_config_core.normalize_masc_base_path_input root
-  | _ -> (Host_config.host ()).agent_runtime_root
+  | _ -> (Host_config.host ()).sandbox_workspace_root
 
 let library_root () =
   Filename.concat (workspace_root ()) "docs/library"


### PR DESCRIPTION
## Problem

`workspace_root()` in `tool_library.ml` fell back to `agent_runtime_root` (a temp dir like `/tmp`) when `MASC_BASE_PATH` was unset. Docker sandbox keepers lack this env var, causing `library_root()` to resolve to a temp path instead of the real workspace root (e.g. `/home/keeper/playground/...`).

## Fix

Use `sandbox_workspace_root` from `Host_config.host()` instead of `agent_runtime_root`. `sandbox_workspace_root` already has proper fallback logic: it uses `base_path` when set (from `MASC_BASE_PATH` or `.masc.base_path`), then falls back to `Filename.concat tmp "masc-fleet"`.

## Change

`lib/tool_library.ml` — one line change: `agent_runtime_root` → `sandbox_workspace_root`

Closes task-789