### PR TITLE
hotfix: cascade_resolution type missing + extra unit args

### DIFF
--- a/lib/keeper/keeper_unified_turn_cascade_resolution.ml
+++ b/lib/keeper/keeper_unified_turn_cascade_resolution.ml
@@ -6,6 +6,12 @@
 
     @since task-786 *)
 
+type cascade_decision_kind =
+  | Degraded_retry_allowed
+  | Degraded_retry_slot_phase_exhausted
+  | No_degraded_retry
+  | Transient_network_retry
+
 let decision_kind_to_string : cascade_decision_kind -> string = function
   | Degraded_retry_allowed -> "degraded_retry_allowed"
   | Degraded_retry_slot_phase_exhausted -> "degraded_retry_slot_phase_exhausted"
@@ -21,7 +27,6 @@ let publish_cascade_resolution
     ~attempt
     ~error_kind
     ~error_message
-    ()
   =
   let payload = `Assoc
     [ "keeper_name", `String keeper_name

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -428,8 +428,7 @@ let run (ctx : ctx)
             ~next_runtime:(Some degraded_retry.next_runtime)
             ~attempt
             ~error_kind:(Some (Keeper_agent_error.sdk_error_kind err))
-            ~error_message:(Some (Agent_sdk.Error.to_string err))
-            ();
+            ~error_message:(Some (Agent_sdk.Error.to_string err));
           (match
              Keeper_unified_turn_pre_dispatch
              .build_runtime_execution
@@ -525,8 +524,7 @@ let run (ctx : ctx)
             ~next_runtime:(Some degraded_retry.next_runtime)
             ~attempt
             ~error_kind:(Some (Keeper_agent_error.sdk_error_kind err))
-            ~error_message:(Some (Agent_sdk.Error.to_string err))
-            ();
+            ~error_message:(Some (Agent_sdk.Error.to_string err));
           let productive_phase_elapsed_ms, retry_phase_elapsed_ms =
             current_turn_phase_elapsed_ms ()
           in
@@ -564,8 +562,7 @@ let run (ctx : ctx)
             ~next_runtime:None
             ~attempt
             ~error_kind:(Some (Keeper_agent_error.sdk_error_kind err))
-            ~error_message:(Some (Agent_sdk.Error.to_string err))
-            ();
+            ~error_message:(Some (Agent_sdk.Error.to_string err));
           let delay = EC.transient_backoff_sec attempt in
           Log.Keeper.warn
             "%s: transient network error runtime=%s max_context=%d \
@@ -615,8 +612,7 @@ let run (ctx : ctx)
             ~next_runtime:None
             ~attempt
             ~error_kind:(Some (Keeper_agent_error.sdk_error_kind err))
-            ~error_message:(Some (Agent_sdk.Error.to_string err))
-            ();
+            ~error_message:(Some (Agent_sdk.Error.to_string err));
           let current_turn_event_bus =
             drain_turn_event_bus ~site:"context_overflow_capture" ()
           in
@@ -660,8 +656,7 @@ let run (ctx : ctx)
             ~next_runtime:None
             ~attempt
             ~error_kind:(Some (Keeper_agent_error.sdk_error_kind err))
-            ~error_message:(Some (Agent_sdk.Error.to_string err))
-            ();
+            ~error_message:(Some (Agent_sdk.Error.to_string err));
           mark_terminal_error err;
           Error err)
   in


### PR DESCRIPTION
Fixes build errors from #20816:
- Adds missing cascade_decision_kind type to .ml
- Removes extra () parameter from publish_cascade_resolution (not in mli)
- Fixes all 5 callers that passed ()