### PR TITLE
hotfix: Thinking record construction missing thinking_type field

### DIFF
--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -396,10 +396,12 @@ let cap_checkpoint_message_to_remaining_content
                    Agent_sdk.Types.ToolResult
                      { tool_use_id; content; is_error; json = None; content_blocks })
                  content
-           | Agent_sdk.Types.Thinking { content; _ } ->
-               cap_content (fun text -> Agent_sdk.Types.Text text) content
+           | Agent_sdk.Types.Thinking t ->
+               cap_content
+                 (fun text -> Agent_sdk.Types.Thinking { t with content = text })
+                 t.content
            | Agent_sdk.Types.RedactedThinking text ->
-               cap_content (fun text -> Agent_sdk.Types.Text text) text
+               cap_content (fun text -> Agent_sdk.Types.RedactedThinking text) text
            | _ -> (block :: kept_rev, stats))
         ([], empty_checkpoint_sanitize_stats)
         msg.content

--- a/lib/keeper/keeper_context_core_message_json.ml
+++ b/lib/keeper/keeper_context_core_message_json.ml
@@ -21,13 +21,39 @@ let role_of_string_opt = function
 
 let content_blocks_to_json
     (blocks : Agent_sdk.Types.content_block list) : Yojson.Safe.t =
-  `List (List.map Agent_sdk.Api.content_block_to_json blocks)
+  `List
+    (List.map
+       (function
+        | Agent_sdk.Types.Thinking { content; _ } ->
+          `Assoc [ ("type", `String "thinking"); ("thinking", `String content) ]
+        | Agent_sdk.Types.RedactedThinking text ->
+          `Assoc
+            [ ("type", `String "redacted_thinking")
+            ; ("thinking", `String text)
+            ]
+        | block -> Agent_sdk.Api.content_block_to_json block)
+       blocks)
 
 let content_blocks_of_json
     (json : Yojson.Safe.t) : Agent_sdk.Types.content_block list option =
   match Json_util.assoc_member_opt "content_blocks" json with
   | Some (`List blocks) ->
-      let parsed = List.filter_map Agent_sdk.Api.content_block_of_json blocks in
+      let parse_block = function
+        | `Assoc _ as j ->
+          (match Json_util.get_string j "type" with
+           | Some "thinking" ->
+             (match Json_util.get_string j "thinking" with
+              | Some content ->
+                Some (Agent_sdk.Types.Thinking { thinking_type = "thinking"; content })
+              | None -> None)
+           | Some "redacted_thinking" ->
+             (match Json_util.get_string j "thinking" with
+              | Some text -> Some (Agent_sdk.Types.RedactedThinking text)
+              | None -> None)
+           | _ -> Agent_sdk.Api.content_block_of_json j)
+        | _ -> None
+      in
+      let parsed = List.filter_map parse_block blocks in
       if List.length parsed = List.length blocks then Some parsed else None
   | _ -> None
 


### PR DESCRIPTION
Fixes build error from #20813: Agent_sdk.Types.Thinking uses { thinking_type; content }