### PR TITLE
fix(workspace): clear stale agent task-cache after write_backlog in transition_task_r

### DIFF
--- a/lib/workspace/workspace_task_transitions.ml
+++ b/lib/workspace/workspace_task_transitions.ml
@@ -407,6 +407,12 @@ let transition_task_r
                  | Masc_domain.Approve_verification
                  | Masc_domain.Reject_verification -> ()));
              raise exn);
+          (* RFC-0221 §3.3: clear stale agent task-cache entries AFTER the
+             commit so agents that cache the task don't emit stale broadcasts
+             referencing the old status. *)
+          Task_cache_invariant.clear_stale_agent_task config
+            ~agent_name ~task_id ~status:new_status
+            ~module_name:"transition_task_r";
           (* RFC-0221 §3.2: write the verdict audit record best-effort AFTER the
              commit. The outcome already lives in [task_status] (approve → Done
              carrying the verdict in [notes]; reject → InProgress, its reason


### PR DESCRIPTION
## Problem

When `transition_task_r` commits a task transition (especially to a terminal status like Done/Cancelled), agents that still have that `task_id` cached in their `current_task` field can emit stale broadcasts or mentions referencing the old status. The stale-cache guard (`clear_stale_agent_task`) already existed in `workspace_broadcast` and `mention_inbox`, but was missing at the transition commit point itself.

## Change

`lib/workspace/workspace_task_transitions.ml` — adds `Task_cache_invariant.clear_stale_agent_task` call right after the `write_backlog` atomic commit point (RFC-0221 §3.3), before the verdict audit record write.

This clears the on-disk `current_task` for the transitioning agent at the source, before any broadcast is sent, preventing stale emissions proactively rather than reactively filtering them.

## Evidence

- 1 file changed, 6 insertions(+)
- Commit: c632ef1c7
- Call signature matches existing usage in `workspace_broadcast.ml:108` and `mention_inbox.ml:86`

Closes task-792