### PR TITLE
fix(keeper): preserve thinking blocks in history JSONL

### DIFF
--- a/lib/keeper/keeper_context_core_message_json.ml
+++ b/lib/keeper/keeper_context_core_message_json.ml
@@ -24,12 +24,16 @@ let content_blocks_to_json
   `List
     (List.map
        (function
-        | Agent_sdk.Types.Thinking { content; _ } ->
-          `Assoc [ ("type", `String "thinking"); ("thinking", `String content) ]
+        | Agent_sdk.Types.Thinking { thinking_type; content } ->
+          `Assoc
+            [ ("type", `String "thinking")
+            ; ("thinking", `String content)
+            ; ("thinking_type", `String thinking_type)
+            ]
         | Agent_sdk.Types.RedactedThinking text ->
           `Assoc
             [ ("type", `String "redacted_thinking")
-            ; ("thinking", `String text)
+            ; ("data", `String text)
             ]
         | block -> Agent_sdk.Api.content_block_to_json block)
        blocks)
@@ -47,7 +51,7 @@ let content_blocks_of_json
                 Some (Agent_sdk.Types.Thinking { thinking_type = "thinking"; content })
               | None -> None)
            | Some "redacted_thinking" ->
-             (match Json_util.get_string j "thinking" with
+             (match Json_util.get_string j "data" with
               | Some text -> Some (Agent_sdk.Types.RedactedThinking text)
               | None -> None)
            | _ -> Agent_sdk.Api.content_block_of_json j)


### PR DESCRIPTION
## Problem

When using DeepSeek V4 Flash with `enable_thinking=true`, the model's
`reasoning_content` (returned as `Thinking` variant) was not properly
serialized in `history.internal.jsonl` by `content_block_to_json`.

This caused reasoning content to be lost or mis-categorized in the
dashboard history view.

## Changes

- `keeper_context_core.ml`: Preserve `Thinking`/`RedactedThinking`
  variants through checkpoint sanitize instead of converting to `Text`
- `keeper_context_core_message_json.ml`: Add explicit JSON mapping
  for `thinking` (`thinking_type` + `thinking`) and
  `redacted_thinking` (`data`) blocks, matching OAS
  `Api_common.content_block_to_json` format

## Verification

- `dune build @check` passes (pre-existing `test_tool_dispatch.ml`
  error unrelated)