### PR TITLE
[codex] Redact Keeper chat secrets

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -40,6 +40,7 @@
   keeper_tool_registered_runtime
   keeper_tool_ide_runtime
   keeper_secret_projection
+  keeper_secret_redaction
   keeper_sandbox_docker
   keeper_tool_execute_runtime_paths
   keeper_tool_execute_path

--- a/lib/gate_keeper_backend.ml
+++ b/lib/gate_keeper_backend.ml
@@ -92,6 +92,14 @@ let contextualize_message ~channel ~channel_user_id ~channel_user_name
 let dispatch ~sw ~clock ~proc_mgr ~net ~config
     ~channel ~channel_user_id ~channel_user_name ~channel_workspace_id
     ~keeper_name ~content =
+  let keeper_name = String.trim keeper_name in
+  let redaction =
+    Keeper_secret_redaction.snapshot
+      ~base_path:config.Workspace.base_path
+      ~keeper_name
+  in
+  let redact_text = Keeper_secret_redaction.redact_text redaction in
+  let redact_json = Keeper_secret_redaction.redact_json redaction in
   let agent_name =
     agent_name_for_channel_actor ~channel ~channel_workspace_id ~channel_user_id
   in
@@ -117,7 +125,7 @@ let dispatch ~sw ~clock ~proc_mgr ~net ~config
   let opt value = match String.trim value with "" -> None | v -> Some v in
   Keeper_chat_store.append_user_message
     ~base_dir:config.Workspace.base_path
-    ~keeper_name:(String.trim keeper_name)
+    ~keeper_name
     ~content:(String.trim content)
     ~source:lane
     ~speaker:
@@ -127,10 +135,10 @@ let dispatch ~sw ~clock ~proc_mgr ~net ~config
       }
     ();
   Keeper_chat_broadcast.chat_appended
-    ~keeper_name:(String.trim keeper_name) ~source:lane;
+    ~keeper_name ~source:lane;
   let args =
     `Assoc [
-      ("name", `String (String.trim keeper_name));
+      ("name", `String keeper_name);
       ( "message",
         `String
           (contextualize_message ~channel ~channel_user_id ~channel_user_name
@@ -167,14 +175,14 @@ let dispatch ~sw ~clock ~proc_mgr ~net ~config
       let duration_ms =
         int_of_float ((Unix.gettimeofday () -. start_time) *. 1000.0)
       in
-      let reply = extract_reply_text body in
-      let structured = extract_structured body in
+      let reply = extract_reply_text body |> redact_text in
+      let structured = Option.map redact_json (extract_structured body) in
       let stats = match extract_turn_stats body with
         | Some s -> Some { s with duration_ms }
         | None -> Some { Gate_protocol.model_used = "runtime"; duration_ms; tokens_used = 0 }
       in
       Gate_protocol.Reply { content = reply; structured; stats }
   | Some result ->
-      Gate_protocol.Keeper_error_result (Tool_result.message result)
+      Gate_protocol.Keeper_error_result (redact_text (Tool_result.message result))
   | None ->
       Gate_protocol.Unavailable_result

--- a/lib/keeper/keeper_chat_discord.ml
+++ b/lib/keeper/keeper_chat_discord.ml
@@ -1,6 +1,7 @@
 (** Keeper_chat_discord — Discord delivery adapter for keeper chat events. *)
 
 let send_message ~token ~channel_id ~content =
+  let content = Observability_redact.redact_text content in
   let limit = Discord_rest_client.message_content_limit in
   let len = String.length content in
   if len = 0 then ()

--- a/lib/keeper/keeper_chat_slack.ml
+++ b/lib/keeper/keeper_chat_slack.ml
@@ -17,6 +17,7 @@ let pp_error fmt = function
 let slack_message_limit = 4000
 
 let send_message ~token ~channel ~content =
+  let content = Observability_redact.redact_text content in
   let truncated =
     if String.length content > slack_message_limit then
       String.sub content 0 slack_message_limit

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -86,6 +86,24 @@ type chat_message = {
   speaker : speaker option;
 }
 
+let redaction_for ~base_dir ~keeper_name =
+  Keeper_secret_redaction.snapshot ~base_path:base_dir ~keeper_name
+
+let redact_attachment redaction att =
+  { att with data = Keeper_secret_redaction.redact_text redaction att.data }
+
+let redact_tool_call redaction tc =
+  { tc with args = Keeper_secret_redaction.redact_text redaction tc.args }
+
+let redact_message redaction msg =
+  let attachments =
+    Option.map (List.map (redact_attachment redaction)) msg.attachments
+  in
+  { msg with
+    content = Keeper_secret_redaction.redact_text redaction msg.content;
+    attachments;
+  }
+
 let opt_string_field key = function
   | None -> []
   | Some value -> [ (key, `String value) ]
@@ -144,6 +162,17 @@ let append_turn ~base_dir ~keeper_name ~(user_content : string)
     ~(assistant_content : string) () =
   try
     ensure_dir_once ~base_dir;
+    let redaction = redaction_for ~base_dir ~keeper_name in
+    let user_content =
+      Keeper_secret_redaction.redact_text redaction user_content
+    in
+    let user_attachments =
+      List.map (redact_attachment redaction) user_attachments
+    in
+    let tool_calls = List.map (redact_tool_call redaction) tool_calls in
+    let assistant_content =
+      Keeper_secret_redaction.redact_text redaction assistant_content
+    in
     let path = chat_path ~base_dir ~keeper_name in
     let ts = Time_compat.now () in
     (* Speaker identity belongs to the user line only: tool and
@@ -186,6 +215,8 @@ let append_assistant_message ~base_dir ~keeper_name ~(content : string)
     ?source () =
   try
     ensure_dir_once ~base_dir;
+    let redaction = redaction_for ~base_dir ~keeper_name in
+    let content = Keeper_secret_redaction.redact_text redaction content in
     let path = chat_path ~base_dir ~keeper_name in
     let ts = Time_compat.now () in
     let line = encode_line ~role:"assistant" ~content ~ts ?source () in
@@ -207,6 +238,8 @@ let append_user_message ~base_dir ~keeper_name ~(content : string)
     ?source ?speaker () =
   try
     ensure_dir_once ~base_dir;
+    let redaction = redaction_for ~base_dir ~keeper_name in
+    let content = Keeper_secret_redaction.redact_text redaction content in
     let path = chat_path ~base_dir ~keeper_name in
     let ts = Time_compat.now () in
     let line = encode_line ~role:"user" ~content ~ts ?source ?speaker () in
@@ -442,9 +475,11 @@ let load_page ~base_dir ~keeper_name ?before () : page =
           | Some _ | None -> ())
       (slice_lines ~path ~from ~upto);
     let messages =
+      let redaction = redaction_for ~base_dir ~keeper_name in
       Queue.fold (fun acc msg -> msg :: acc) [] q
       |> List.rev
       |> drop_leading_tool_messages
+      |> List.map (redact_message redaction)
     in
     { messages; has_more = from > 0 || !evicted }
   with

--- a/lib/keeper/keeper_secret_projection.mli
+++ b/lib/keeper/keeper_secret_projection.mli
@@ -3,6 +3,15 @@ type t =
   ; cleanup : unit -> unit
   }
 
+type secret_root_info =
+  { root : string
+  ; source : string
+  }
+
+val secret_root_info : base_path:string -> keeper_name:string -> secret_root_info
+
+val secret_root : base_path:string -> keeper_name:string -> string
+
 val docker_args_for_keeper :
   base_path:string -> keeper_name:string -> container_name:string -> (t, string) result
 

--- a/lib/keeper/keeper_secret_redaction.ml
+++ b/lib/keeper/keeper_secret_redaction.ml
@@ -1,0 +1,134 @@
+type t = { patterns : Re.re list }
+
+let empty = { patterns = [] }
+
+let min_secret_len = 8
+let max_secret_file_bytes = 64 * 1024
+
+let path_exists path =
+  try Sys.file_exists path with
+  | Sys_error _ -> false
+
+let lstat_opt path =
+  try Some (Unix.lstat path) with
+  | Unix.Unix_error _ -> None
+
+let read_regular_file path st =
+  if st.Unix.st_size < 0 || st.Unix.st_size > max_secret_file_bytes then None
+  else
+    try
+      let ic = open_in_bin path in
+      Fun.protect
+        ~finally:(fun () -> close_in_noerr ic)
+        (fun () -> Some (really_input_string ic st.Unix.st_size))
+    with
+    | Sys_error _ | End_of_file -> None
+
+let strip_one_final_newline value =
+  let len = String.length value in
+  if len >= 2 && Char.equal value.[len - 2] '\r' && Char.equal value.[len - 1] '\n'
+  then String.sub value 0 (len - 2)
+  else if len >= 1 && (Char.equal value.[len - 1] '\n' || Char.equal value.[len - 1] '\r')
+  then String.sub value 0 (len - 1)
+  else value
+
+let add_value value acc =
+  let trimmed = String.trim value in
+  if String.length trimmed >= min_secret_len then trimmed :: acc else acc
+
+let add_lines value acc =
+  value
+  |> String.split_on_char '\n'
+  |> List.fold_left (fun acc line -> add_value line acc) acc
+
+let values_from_file path acc =
+  match lstat_opt path with
+  | Some st when st.Unix.st_kind = Unix.S_REG ->
+      (match read_regular_file path st with
+       | None -> acc
+       | Some value ->
+           acc
+           |> add_value (strip_one_final_newline value)
+           |> add_lines value)
+  | _ -> acc
+
+let collect_env_values env_root acc =
+  if not (path_exists env_root) then acc
+  else
+    match lstat_opt env_root with
+    | Some st when st.Unix.st_kind = Unix.S_DIR ->
+        (try
+           Sys.readdir env_root
+           |> Array.to_list
+           |> List.fold_left
+                (fun acc name -> values_from_file (Filename.concat env_root name) acc)
+                acc
+         with
+         | Sys_error _ -> acc)
+    | _ -> acc
+
+let collect_file_values files_root acc =
+  let rec walk path acc =
+    match lstat_opt path with
+    | Some st when st.Unix.st_kind = Unix.S_DIR ->
+        (try
+           Sys.readdir path
+           |> Array.to_list
+           |> List.fold_left
+                (fun acc name -> walk (Filename.concat path name) acc)
+                acc
+         with
+         | Sys_error _ -> acc)
+    | Some st when st.Unix.st_kind = Unix.S_REG ->
+        values_from_file path acc
+    | _ -> acc
+  in
+  if path_exists files_root then walk files_root acc else acc
+
+let dedupe values =
+  let tbl = Hashtbl.create 32 in
+  values
+  |> List.filter (fun value ->
+       if Hashtbl.mem tbl value then false
+       else (
+         Hashtbl.add tbl value ();
+         true))
+  |> List.sort (fun a b ->
+       compare (String.length b, b) (String.length a, a))
+
+let snapshot ~base_path ~keeper_name =
+  let root = Keeper_secret_projection.secret_root ~base_path ~keeper_name in
+  let env_root = Filename.concat root "env" in
+  let files_root = Filename.concat root "files" in
+  let values =
+    []
+    |> collect_env_values env_root
+    |> collect_file_values files_root
+    |> dedupe
+  in
+  let patterns =
+    List.map (fun value -> Re.compile (Re.str value)) values
+  in
+  { patterns }
+
+let redact_text t text =
+  let text =
+    List.fold_left
+      (fun acc pattern -> Re.replace_string pattern ~by:"[REDACTED]" acc)
+      text
+      t.patterns
+  in
+  Observability_redact.redact_text text
+
+let rec redact_json_exact t = function
+  | `String s -> `String (redact_text t s)
+  | `Assoc fields ->
+      `Assoc
+        (List.map
+           (fun (key, value) -> (key, redact_json_exact t value))
+           fields)
+  | `List items -> `List (List.map (redact_json_exact t) items)
+  | (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _) as json -> json
+
+let redact_json t json =
+  json |> redact_json_exact t |> Observability_redact.redact_json_strings

--- a/lib/keeper/keeper_secret_redaction.mli
+++ b/lib/keeper/keeper_secret_redaction.mli
@@ -1,0 +1,22 @@
+(** Keeper-scoped secret redaction for chat and connector surfaces.
+
+    This module is MASC-owned. It reads only the Keeper secret projection
+    roots and produces redacted copies of text/JSON values before they
+    cross storage or external channel boundaries. *)
+
+type t
+
+val empty : t
+
+val snapshot : base_path:string -> keeper_name:string -> t
+(** Snapshot exact secret values from the keeper's projected secret
+    root. Missing or unreadable roots produce {!empty}; redaction must
+    never fail a chat turn. *)
+
+val redact_text : t -> string -> string
+(** Replace exact projected secret values and generic sensitive patterns
+    with [\[REDACTED\]], preserving message length semantics except for
+    the replacements themselves. *)
+
+val redact_json : t -> Yojson.Safe.t -> Yojson.Safe.t
+(** Redact all string leaves in a JSON value, preserving shape. *)

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -143,6 +143,12 @@ let handle_person_note_set ~config ~(meta : keeper_meta) ~args =
 let handle_surface_post ~config ~(meta : keeper_meta) ~args =
   let surface = String.trim (Safe_ops.json_string ~default:"" "surface" args) in
   let content = Safe_ops.json_string ~default:"" "content" args in
+  let redaction =
+    Keeper_secret_redaction.snapshot
+      ~base_path:config.Workspace.base_path
+      ~keeper_name:meta.name
+  in
+  let safe_content = Keeper_secret_redaction.redact_text redaction content in
   let channel_id =
     match String.trim (Safe_ops.json_string ~default:"" "channel_id" args) with
     | "" -> None
@@ -166,14 +172,14 @@ let handle_surface_post ~config ~(meta : keeper_meta) ~args =
         Keeper_chat_store.append_assistant_message
           ~base_dir:config.Workspace.base_path
           ~keeper_name:meta.name
-          ~content
+          ~content:safe_content
           ~source:"dashboard"
           ();
         Keeper_chat_broadcast.chat_appended ~keeper_name:meta.name
           ~source:"dashboard";
         Keeper_surface_post.ok_json ~surface ()
     | Ok (Keeper_surface_post.To_discord { channel_id }) -> (
-        match Channel_gate_discord_state.send_message ~channel_id ~content () with
+        match Channel_gate_discord_state.send_message ~channel_id ~content:safe_content () with
         | Error send_error ->
             Keeper_surface_post.error_json
               (Format.asprintf "discord send failed: %a"
@@ -182,7 +188,7 @@ let handle_surface_post ~config ~(meta : keeper_meta) ~args =
             Keeper_chat_store.append_assistant_message
               ~base_dir:config.Workspace.base_path
               ~keeper_name:meta.name
-              ~content
+              ~content:safe_content
               ~source:"discord"
               ();
             Keeper_chat_broadcast.chat_appended ~keeper_name:meta.name

--- a/lib/observability_redact.ml
+++ b/lib/observability_redact.ml
@@ -39,6 +39,9 @@ let redact_patterns (s : string) : string =
   let s = Re.replace_string url_credential_re ~by:"://[REDACTED]@" s in
   Re.replace_string sensitive_value_re ~by:"[REDACTED]" s
 
+let redact_text (s : string) : string =
+  redact_patterns s
+
 let truncate ?(max_len = default_max_len) (s : string) : string =
   let s = String.trim s in
   if String.length s <= max_len then s
@@ -69,6 +72,18 @@ let rec preview_json_strings ?(max_len = default_max_len) (json : Yojson.Safe.t)
         (List.map (fun (k, v) -> (k, preview_json_strings ~max_len v)) fields)
   | `List items -> `List (List.map (preview_json_strings ~max_len) items)
   | (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _) as j -> j
+
+let rec redact_json_strings = function
+  | `String s -> `String (redact_text s)
+  | `Assoc fields ->
+      `Assoc
+        (List.map
+           (fun (key, value) ->
+             if is_sensitive_key key then (key, `String "[REDACTED]")
+             else (key, redact_json_strings value))
+           fields)
+  | `List items -> `List (List.map redact_json_strings items)
+  | (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _) as json -> json
 
 let rec redact_json_value = function
   | `Assoc fields ->

--- a/lib/observability_redact.mli
+++ b/lib/observability_redact.mli
@@ -20,6 +20,16 @@ val redact_preview : ?max_len:int -> string -> string
     and redact only the user-visible preview body so sha256/bytes/mime
     survive intact for downstream parsers. *)
 
+val redact_text : string -> string
+(** Strip known sensitive patterns without truncating or trimming the
+    input. Use this for user-visible chat/transport text where the full
+    message length must be preserved. *)
+
+val redact_json_strings : Yojson.Safe.t -> Yojson.Safe.t
+(** Recursively apply {!redact_text} to string leaves and replace
+    sensitive-key fields with [\[REDACTED\]], preserving structure and
+    without truncation. *)
+
 val preview_json_strings : ?max_len:int -> Yojson.Safe.t -> Yojson.Safe.t
 (** Recursively apply [redact_preview] to every string leaf, preserving
     JSON structure. Use this instead of [Yojson.Safe.to_string |>

--- a/lib/runtime/runtime_agent_context.ml
+++ b/lib/runtime/runtime_agent_context.ml
@@ -264,11 +264,6 @@ let builder_without_approval
     | None -> builder
   in
   let builder =
-    match config.trace_link with
-    | Some link -> Agent_sdk.Builder.with_trace_link (Some link) builder
-    | None -> builder
-  in
-  let builder =
     match config.enable_thinking with
     | Some enabled -> Agent_sdk.Builder.with_enable_thinking enabled builder
     | None -> builder

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -512,6 +512,12 @@ type keeper_stream_worker_event =
 let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
     ~payload ~run_id ~message_id ~agent_name
     ~(events : Keeper_chat_events.keeper_chat_event Eio.Stream.t) =
+  let base_path = state.Mcp_server.workspace_config.base_path in
+  let redaction =
+    Keeper_secret_redaction.snapshot ~base_path ~keeper_name:payload.name
+  in
+  let redact_text = Keeper_secret_redaction.redact_text redaction in
+  let redact_json = Keeper_secret_redaction.redact_json redaction in
   Keeper_chat_events.publish events
     (Run_started { run_id; thread_id });
   Keeper_chat_events.publish events
@@ -553,11 +559,10 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
       (if payload.attachments = [] then base_fields
        else ("attachments", `List (List.map attachment_json payload.attachments)) :: base_fields)
   in
-  (* Track whether any text deltas were streamed to the client.
-     When streaming is active, the MODEL text is sent token-by-token
-     during the call; we only need to send the final batch chunks
-     if no deltas were emitted (fallback path). *)
-  let deltas_sent = ref false in
+  (* Buffer model text deltas until the terminal payload arrives. This
+     avoids sending raw partial output before the full reply can pass
+     through keeper-scoped redaction. *)
+  let streamed_text = Buffer.create 256 in
   let worker_events = Eio.Stream.create 512 in
   let push_worker_event event =
     if not !closed then
@@ -621,7 +626,7 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
   in
   let persist_failure_reply err =
     Keeper_chat_store.append_turn
-      ~base_dir:state.Mcp_server.workspace_config.base_path
+      ~base_dir:base_path
       ~keeper_name:payload.name
       ~user_content:payload.message
       ~user_attachments:payload.attachments
@@ -636,7 +641,7 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
   let timeout_sec = Option.map float_of_int payload.timeout_sec in
   let request_id =
     Keeper_msg_async.submit ?timeout_sec ~clock ~sw
-      ~base_path:state.Mcp_server.workspace_config.base_path
+      ~base_path
       ~keeper_name:payload.name
       ~f:(fun () ->
         let start_time = Time_compat.now () in
@@ -666,7 +671,7 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
             let _payload_json_opt, visible_reply = extract_visible_reply body in
             if not (is_continuation_checkpoint_reply visible_reply) then begin
               Keeper_chat_store.append_turn
-                ~base_dir:state.Mcp_server.workspace_config.base_path
+                ~base_dir:base_path
                 ~keeper_name:payload.name
                 ~user_content:payload.message
                 ~user_attachments:payload.attachments
@@ -717,6 +722,7 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
              }
        });
   let publish_terminal ~status ~ok ?(message = "") () =
+    let message = redact_text message in
     let payload_json =
       keeper_request_terminal_payload ~request_id ~keeper_name:payload.name
         ~status ~ok ~message ()
@@ -740,40 +746,55 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
          | Agent_sdk.Types.Connected ->
              Keeper_chat_events.publish events (Custom { name = "KEEPER_CONNECTED"; value = `Null })
          | Agent_sdk.Types.Timeout reason ->
-             Keeper_chat_events.publish events (Event_error { message = "Timeout: " ^ reason })
+             Keeper_chat_events.publish events
+               (Event_error { message = redact_text ("Timeout: " ^ reason) })
          | Agent_sdk.Types.ContentBlockDelta { delta = TextDelta text; _ } ->
-             deltas_sent := true;
-             Keeper_chat_events.publish events (Text_delta text)
+             Buffer.add_string streamed_text text
          | Agent_sdk.Types.ContentBlockDelta { delta = ThinkingDelta text; _ } ->
-             Keeper_chat_events.publish events (Custom { name = "KEEPER_THINKING_DELTA"; value = `Assoc [ ("delta", `String text) ] })
+             Keeper_chat_events.publish events
+               (Custom
+                  { name = "KEEPER_THINKING_DELTA";
+                    value = `Assoc [ ("delta", `String (redact_text text)) ] })
          | Agent_sdk.Types.ContentBlockStart { index; tool_id = Some tid; tool_name = Some tname; _ } ->
              Hashtbl.replace index_to_tool_id index tid;
              Keeper_chat_events.publish events (Tool_call_start { tool_call_id = tid; tool_call_name = tname })
          | Agent_sdk.Types.ContentBlockDelta { index; delta = InputJsonDelta args } ->
              let tid = Hashtbl.find_opt index_to_tool_id index |> Option.value ~default:"" in
-             Keeper_chat_events.publish events (Tool_call_args { tool_call_id = tid; delta = args })
+             Keeper_chat_events.publish events
+               (Tool_call_args { tool_call_id = tid; delta = redact_text args })
          | Agent_sdk.Types.ContentBlockStop { index } ->
              let tid = Hashtbl.find_opt index_to_tool_id index |> Option.value ~default:"" in
              Keeper_chat_events.publish events (Tool_call_end { tool_call_id = tid })
          | _ -> ());
         consume_worker_events ()
     | Stream_terminal (false, err) ->
+        let err = redact_text err in
         publish_terminal ~status:"error" ~ok:false ~message:err ();
         Keeper_chat_events.publish events (Event_error { message = err })
     | Stream_terminal (true, body) -> (
         try
           let payload_json_opt, visible_reply = extract_visible_reply body in
+          let visible_reply =
+            match String.trim visible_reply with
+            | "" ->
+                let streamed = Buffer.contents streamed_text |> String.trim in
+                if streamed = "" then visible_reply else streamed
+            | _ -> visible_reply
+          in
+          let visible_reply = redact_text visible_reply in
           let is_checkpoint =
             is_continuation_checkpoint_reply visible_reply
           in
-          if (not !deltas_sent) && not is_checkpoint then
+          if not is_checkpoint then
             split_keeper_reply_chunks visible_reply
             |> List.iter (fun chunk ->
                    Keeper_chat_events.publish events (Text_delta chunk));
           (match payload_json_opt with
            | Some payload_json ->
                Keeper_chat_events.publish events
-                 (Custom { name = "KEEPER_REPLY_DETAILS"; value = payload_json })
+                 (Custom
+                    { name = "KEEPER_REPLY_DETAILS";
+                      value = redact_json payload_json })
            | None -> ());
           if is_checkpoint then
             Keeper_chat_events.publish events
@@ -790,7 +811,7 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
         with
         | Eio.Cancel.Cancelled _ as e -> raise e
         | exn ->
-            let message = Printexc.to_string exn in
+            let message = redact_text (Printexc.to_string exn) in
             publish_terminal ~status:"error" ~ok:false ~message ();
             Keeper_chat_events.publish events
               (Event_error { message }))
@@ -799,6 +820,13 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
 
 
 let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
+  let redaction =
+    Keeper_secret_redaction.snapshot
+      ~base_path:state.Mcp_server.workspace_config.base_path
+      ~keeper_name:payload.name
+  in
+  let redact_text = Keeper_secret_redaction.redact_text redaction in
+  let redact_json = Keeper_secret_redaction.redact_json redaction in
   let origin = get_origin request in
   let headers =
     Httpun.Headers.of_list
@@ -838,6 +866,7 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
       | Keeper_chat_events.Assistant -> Ag_ui.Assistant
     in
     let send_error message =
+      let message = redact_text message in
       match !current_run_id with
       | Some run_id ->
           send_keeper_error writer mutex closed ~thread_id:!current_thread_id
@@ -875,7 +904,8 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
               keeper_stream_send_event writer mutex closed
                 Ag_ui.(
                   make_event ~thread_id:!current_thread_id ~run_id:!current_run_id
-                    ~message_id:!current_message_id ~delta:(Some text)
+                    ~message_id:!current_message_id
+                    ~delta:(Some (redact_text text))
                     Text_message_content)
             then loop ()
         | Text_message_end ->
@@ -890,7 +920,9 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
               keeper_stream_send_event writer mutex closed
                 Ag_ui.(
                   make_event ~thread_id:!current_thread_id ~run_id:!current_run_id
-                    ~custom_name:(Some name) ~custom_value:(Some value) Custom)
+                    ~custom_name:(Some name)
+                    ~custom_value:(Some (redact_json value))
+                    Custom)
             then loop ()
         | Tool_call_start { tool_call_id; tool_call_name } ->
             if
@@ -905,7 +937,8 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
               keeper_stream_send_event writer mutex closed
                 Ag_ui.(
                   make_event ~thread_id:!current_thread_id ~run_id:!current_run_id
-                    ~tool_call_id:(Some tool_call_id) ~delta:(Some delta)
+                    ~tool_call_id:(Some tool_call_id)
+                    ~delta:(Some (redact_text delta))
                     Tool_call_args)
             then loop ()
         | Tool_call_end { tool_call_id } ->

--- a/test/dune
+++ b/test/dune
@@ -192,6 +192,7 @@
   test_keeper_callback_hardening
   test_keeper_behavioral_regime
   test_keeper_secret_projection
+  test_keeper_secret_redaction
   test_keeper_toml
   test_runtime_toml_overrides
   test_runtime_provider_auth_headers
@@ -461,6 +462,7 @@
   test_keeper_callback_hardening
   test_keeper_behavioral_regime
   test_keeper_secret_projection
+  test_keeper_secret_redaction
   test_keeper_toml
   test_runtime_toml_overrides
   test_runtime_provider_auth_headers

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -29,6 +29,32 @@ let write_file path content =
     ~finally:(fun () -> close_out_noerr oc)
     (fun () -> output_string oc content)
 
+let read_file path =
+  let ic = open_in_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () -> really_input_string ic (in_channel_length ic))
+
+let with_env key value f =
+  let prior = Sys.getenv_opt key in
+  Unix.putenv key value;
+  Fun.protect
+    ~finally:(fun () ->
+      match prior with
+      | Some v -> Unix.putenv key v
+      | None -> Unix.putenv key "")
+    f
+
+let contains_substring haystack needle =
+  String_util.contains_substring haystack needle
+
+let secret_root_default ~base_dir ~keeper_name =
+  Filename.concat
+    (Filename.concat
+       (Common.masc_dir_from_base_path ~base_path:base_dir)
+       "secrets")
+    (Workspace_utils.safe_filename keeper_name)
+
 let drop_value reason =
   P.metric_value_or_zero P.metric_persistence_read_drops
     ~labels:[("surface", "keeper_chat_store"); ("reason", reason)]
@@ -142,6 +168,75 @@ let test_legacy_lines_parse_without_new_fields () =
             None assistant.tool_call_id
       | messages ->
           Alcotest.failf "expected 2 messages, got %d" (List.length messages))
+
+let test_append_turn_redacts_projected_secrets () =
+  let base_dir = temp_base_path "keeper-chat-store-redact" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      with_env "MASC_SECRET_DIR" "" @@ fun () ->
+      let keeper_name = "keeper-chat-redact" in
+      let root = secret_root_default ~base_dir ~keeper_name in
+      let env_secret = "chat.secret!" in
+      let file_secret = "file.secret!" in
+      write_file (Filename.concat (Filename.concat root "env") "GH_TOKEN")
+        (env_secret ^ "\n");
+      write_file
+        (Filename.concat (Filename.concat root "files") "home/keeper/key")
+        file_secret;
+      K.append_turn ~base_dir ~keeper_name
+        ~user_content:("use " ^ env_secret)
+        ~user_attachments:
+          [ { K.id = "att-1";
+              att_type = "text";
+              name = "secret.txt";
+              size = String.length file_secret;
+              mime_type = "text/plain";
+              data = file_secret } ]
+        ~tool_calls:
+          [ { K.call_id = "toolu_1";
+              call_name = "keeper_exec";
+              args = {|{"token":"|} ^ env_secret ^ {|"}|} } ]
+        ~assistant_content:("done " ^ file_secret)
+        ();
+      let raw = read_file (chat_path ~base_dir ~keeper_name) in
+      Alcotest.(check bool) "env secret not persisted" false
+        (contains_substring raw env_secret);
+      Alcotest.(check bool) "file secret not persisted" false
+        (contains_substring raw file_secret);
+      let messages = K.load ~base_dir ~keeper_name in
+      let rendered = Yojson.Safe.to_string (K.to_json_array messages) in
+      Alcotest.(check bool) "loaded view stays redacted" false
+        (contains_substring rendered env_secret);
+      Alcotest.(check bool) "redaction marker present" true
+        (contains_substring rendered "[REDACTED]"))
+
+let test_load_redacts_legacy_raw_secret_rows () =
+  let base_dir = temp_base_path "keeper-chat-store-read-redact" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      with_env "MASC_SECRET_DIR" "" @@ fun () ->
+      let keeper_name = "keeper-chat-read-redact" in
+      let root = secret_root_default ~base_dir ~keeper_name in
+      let secret = "legacy.secret!" in
+      write_file (Filename.concat (Filename.concat root "env") "GH_TOKEN") secret;
+      let path = chat_path ~base_dir ~keeper_name in
+      write_file path
+        (Yojson.Safe.to_string
+           (`Assoc
+              [ ("role", `String "assistant");
+                ("content", `String ("old row " ^ secret));
+                ("ts", `Float 1.0) ])
+         ^ "\n");
+      match K.load ~base_dir ~keeper_name with
+      | [ msg ] ->
+          Alcotest.(check bool) "legacy raw value hidden on read" false
+            (contains_substring msg.K.content secret);
+          Alcotest.(check bool) "marker present on read" true
+            (contains_substring msg.K.content "[REDACTED]")
+      | messages ->
+          Alcotest.failf "expected 1 message, got %d" (List.length messages))
 
 (* RFC-0223 P1 — speaker identity round-trips on the user line only. *)
 
@@ -494,6 +589,10 @@ let () =
             test_append_turn_roundtrip;
           Alcotest.test_case "legacy lines parse" `Quick
             test_legacy_lines_parse_without_new_fields;
+          Alcotest.test_case "append_turn redacts projected secrets" `Quick
+            test_append_turn_redacts_projected_secrets;
+          Alcotest.test_case "load redacts legacy raw secret rows" `Quick
+            test_load_redacts_legacy_raw_secret_rows;
           Alcotest.test_case "window counts primaries only" `Quick
             test_window_keeps_tool_lines_of_retained_turns;
           Alcotest.test_case "orphan leading tool lines trimmed" `Quick

--- a/test/test_keeper_secret_redaction.ml
+++ b/test/test_keeper_secret_redaction.ml
@@ -1,0 +1,123 @@
+module R = Masc.Keeper_secret_redaction
+
+let with_env key value f =
+  let prior = Sys.getenv_opt key in
+  Unix.putenv key value;
+  Fun.protect
+    ~finally:(fun () ->
+      match prior with
+      | Some v -> Unix.putenv key v
+      | None -> Unix.putenv key "")
+    f
+
+let temp_dir () =
+  let d = Filename.temp_file "keeper_secret_redaction_" "" in
+  Unix.unlink d;
+  Unix.mkdir d 0o755;
+  d
+
+let rec ensure_dir path =
+  if path = "" || path = "." || path = "/" then ()
+  else if Sys.file_exists path then ()
+  else (
+    let parent = Filename.dirname path in
+    if parent <> path then ensure_dir parent;
+    Unix.mkdir path 0o755)
+
+let cleanup_dir dir =
+  let rec rm path =
+    match Unix.lstat path with
+    | { Unix.st_kind = Unix.S_DIR; _ } ->
+        Array.iter (fun name -> rm (Filename.concat path name)) (Sys.readdir path);
+        Unix.rmdir path
+    | _ -> Unix.unlink path
+    | exception Unix.Unix_error _ -> ()
+  in
+  try rm dir with
+  | _ -> ()
+
+let write_file path content =
+  ensure_dir (Filename.dirname path);
+  let oc = open_out_bin path in
+  Fun.protect ~finally:(fun () -> close_out oc) @@ fun () ->
+  output_string oc content
+
+let secret_root_default ~base ~keeper_name =
+  Filename.concat
+    (Filename.concat (Filename.concat base Common.masc_dirname) "secrets")
+    (Workspace_utils.safe_filename keeper_name)
+
+let not_contains label haystack needle =
+  Alcotest.(check bool) label false (String_util.contains_substring haystack needle)
+
+let contains label haystack needle =
+  Alcotest.(check bool) label true (String_util.contains_substring haystack needle)
+
+let test_snapshot_redacts_env_and_file_values () =
+  let base = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  with_env "MASC_SECRET_DIR" "" @@ fun () ->
+  let keeper_name = "minjae" in
+  let root = secret_root_default ~base ~keeper_name in
+  let env_secret = "keeper.secret!" in
+  let file_secret = "file.secret!" in
+  write_file (Filename.concat (Filename.concat root "env") "GH_TOKEN")
+    (env_secret ^ "\n");
+  write_file
+    (Filename.concat (Filename.concat root "files") "home/keeper/.ssh/id")
+    ("header\n" ^ file_secret ^ "\nfooter");
+  let redaction = R.snapshot ~base_path:base ~keeper_name in
+  let redacted =
+    R.redact_text redaction
+      ("env=" ^ env_secret ^ " file=" ^ file_secret)
+  in
+  not_contains "env exact value hidden" redacted env_secret;
+  not_contains "file exact value hidden" redacted file_secret;
+  contains "redaction marker present" redacted "[REDACTED]"
+
+let test_short_values_are_not_exact_redacted () =
+  let base = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  with_env "MASC_SECRET_DIR" "" @@ fun () ->
+  let keeper_name = "shorty" in
+  let root = secret_root_default ~base ~keeper_name in
+  write_file (Filename.concat (Filename.concat root "env") "PIN") "1234567";
+  let redaction = R.snapshot ~base_path:base ~keeper_name in
+  Alcotest.(check string) "short value preserved"
+    "pin=1234567"
+    (R.redact_text redaction "pin=1234567")
+
+let test_json_redaction_preserves_shape () =
+  let base = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  with_env "MASC_SECRET_DIR" "" @@ fun () ->
+  let keeper_name = "json" in
+  let root = secret_root_default ~base ~keeper_name in
+  let env_secret = "json.secret!" in
+  write_file (Filename.concat (Filename.concat root "env") "GH_TOKEN")
+    env_secret;
+  let redaction = R.snapshot ~base_path:base ~keeper_name in
+  let json =
+    `Assoc
+      [ ("content", `String ("token " ^ env_secret));
+        ("password", `String "plain-password");
+        ("count", `Int 1) ]
+  in
+  let redacted = R.redact_json redaction json in
+  let raw = Yojson.Safe.to_string redacted in
+  not_contains "exact value hidden in json" raw env_secret;
+  not_contains "sensitive key value hidden" raw "plain-password";
+  contains "count preserved" raw {|"count":1|}
+
+let () =
+  Alcotest.run
+    "keeper secret redaction"
+    [ ( "snapshot",
+        [ Alcotest.test_case "redacts env and file exact values" `Quick
+            test_snapshot_redacts_env_and_file_values;
+          Alcotest.test_case "does not exact-redact short values" `Quick
+            test_short_values_are_not_exact_redacted;
+          Alcotest.test_case "redacts json while preserving shape" `Quick
+            test_json_redaction_preserves_shape;
+        ] )
+    ]

--- a/test/test_observability_redact.ml
+++ b/test/test_observability_redact.ml
@@ -27,6 +27,29 @@ let test_short_input_unchanged () =
   let preview = Observability_redact.redact_preview input in
   Alcotest.(check string) "short input preserved" "hello world" preview
 
+let test_redact_text_does_not_truncate () =
+  let secret = "sk-proj-abcdefghijklmnopqrstuvwxyz" in
+  let input = String.make 300 'x' ^ secret in
+  let redacted = Observability_redact.redact_text input in
+  Alcotest.(check bool) "not preview-truncated" false
+    (String_util.contains_substring redacted "...(truncated)");
+  Alcotest.(check bool) "secret removed" false
+    (String_util.contains_substring redacted secret)
+
+let test_redact_json_strings_redacts_sensitive_keys () =
+  let json =
+    `Assoc
+      [ ("content", `String "hello");
+        ("api_key", `String "short-but-sensitive");
+        ("nested", `Assoc [ ("token", `String "nested-token") ]) ]
+  in
+  let redacted = Observability_redact.redact_json_strings json in
+  let raw = Yojson.Safe.to_string redacted in
+  Alcotest.(check bool) "api_key hidden" false
+    (String_util.contains_substring raw "short-but-sensitive");
+  Alcotest.(check bool) "nested token hidden" false
+    (String_util.contains_substring raw "nested-token")
+
 let test_denied_tool_input_returns_none () =
   let result = Observability_redact.redact_tool_input
     ~tool_name:"tool_auth_create" (`String "secret data") in
@@ -119,6 +142,10 @@ let () =
           Alcotest.test_case "URL credential redacted" `Quick test_url_credential_redacted;
           Alcotest.test_case "max length enforced" `Quick test_max_length_enforced;
           Alcotest.test_case "short input unchanged" `Quick test_short_input_unchanged;
+          Alcotest.test_case "redact_text does not truncate" `Quick
+            test_redact_text_does_not_truncate;
+          Alcotest.test_case "redact_json_strings redacts sensitive keys"
+            `Quick test_redact_json_strings_redacts_sensitive_keys;
           Alcotest.test_case "blob marker preserves structure" `Quick
             test_blob_marker_preserves_structure;
           Alcotest.test_case "blob marker redacts preview body" `Quick


### PR DESCRIPTION
## Summary
- add a MASC-owned Keeper secret redaction layer for projected env/file values
- redact Keeper chat persistence, history reads, SSE/AG-UI output, Gate replies, surface posts, and channel adapters
- add non-truncating observability redaction for user-visible chat/transport text

## Root Cause
Keeper could receive projected secrets and then echo raw values into MASC-owned chat or connector surfaces. OAS is not the right owner for this policy because it must stay provider/transport focused and unaware of MASC secret roots or Keeper lifecycle.

## Impact
New Keeper chat rows are written redacted, legacy raw JSONL rows are redacted when read, and dashboard/connector output gets a final redaction pass before leaving MASC.

## Validation
- `MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_codex_redaction_pr scripts/dune-local.sh build test/test_keeper_secret_redaction.exe test/test_observability_redact.exe test/test_keeper_chat_store.exe`
- `_build_codex_redaction_pr/default/test/test_keeper_secret_redaction.exe`
- `_build_codex_redaction_pr/default/test/test_observability_redact.exe`
- `_build_codex_redaction_pr/default/test/test_keeper_chat_store.exe`