### PR TITLE
fix(test): correct span_wrapper trace_id tuple type in test_tool_dispatch

### DIFF
--- a/test/test_tool_dispatch.ml
+++ b/test/test_tool_dispatch.ml
@@ -256,7 +256,7 @@ let () =
               let probe : Tool_dispatch.span_wrapper =
                 fun ?force_new_trace_id:_ ~tool_name body ->
                   calls := tool_name :: !calls;
-                  body (fun () -> Some "probe-trace")
+                  body (fun () -> Some ("probe-trace", "probe-trace"))
               in
               Tool_dispatch.set_span_wrapper probe;
               let token =


### PR DESCRIPTION
## Summary

Fixes a type mismatch in `test/test_tool_dispatch.ml` where the `span_wrapper` probe callback returned a single `string` instead of the expected `trace_id * trace_id` (`string * string`) tuple.

## Change

- Line 259: `Some "probe-trace"` → `Some ("probe-trace", "probe-trace")`

## Context

`Tool_dispatch.span_wrapper` expects a callback of type:
```ocaml
(unit -> (trace_id * trace_id) option) -> Tool_result.result option * string
```

The test probe was passing `Some "probe-trace"` (`string option`) where `(string * string) option` was required.

## Verification

- `dune build test/test_tool_dispatch.exe` compiles