### PR TITLE
fix(exec): forward pipeline output callbacks

### DIFF
--- a/lib/exec/exec_dispatch.ml
+++ b/lib/exec/exec_dispatch.ml
@@ -86,6 +86,14 @@ let apply_redirect_plan plan result =
 let unsupported_redirect_result message =
   { status = Unix.WEXITED 1; stdout = ""; stderr = message }
 
+let emit_captured_output on_output_chunk result =
+  match on_output_chunk with
+  | None -> result
+  | Some on_chunk ->
+      on_chunk (`Stdout result.stdout);
+      on_chunk (`Stderr result.stderr);
+      result
+
 let status_is_success = function
   | Unix.WEXITED 0 -> true
   | Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> false
@@ -284,92 +292,94 @@ let docker_pipeline_specs stages =
   in
   loop None None [] stages
 
-let rec dispatch_pipeline ?stdin_content stages =
-  match stages with
-  | [] ->
-      invalid_pipeline "empty pipeline not supported in native dispatch"
-  | [ _ ] ->
-      invalid_pipeline "single-stage pipeline not supported in native dispatch"
-  | _ ->
-      (match host_pipeline_specs stages with
-       | Some specs ->
-           let raw_source =
-             specs
-             |> List.map (fun stage -> String.concat " " stage.Process_eio.argv)
-             |> String.concat " | "
-           in
-           let status, stdout, stderr =
-             Exec_gate.run_argv_pipeline_with_status_split
-               ~actor:`Tool_local_runtime
-               ~raw_source
-               ~summary:"exec dispatch pipeline"
+(* TEL-OK: this lower-level Shell IR dispatcher is wrapped by Execute/keeper
+   telemetry at the action boundary; it only preserves captured output delivery. *)
+let rec dispatch_pipeline ?stdin_content ?on_output_chunk stages =
+  let result =
+    match stages with
+    | [] ->
+        invalid_pipeline "empty pipeline not supported in native dispatch"
+    | [ _ ] ->
+        invalid_pipeline "single-stage pipeline not supported in native dispatch"
+    | _ ->
+        (match host_pipeline_specs stages with
+         | Some specs ->
+             let raw_source =
                specs
-           in
-           { status; stdout; stderr }
-       | None -> (
-           match docker_pipeline_specs stages with
-           | Some (runner, specs) ->
-               let status, stdout, stderr = runner ~stages:specs in
-               { status; stdout; stderr }
-           | None ->
-               let rec chain ~prev_stdout ~status ~stderr = function
-                 | [] -> { status; stdout = prev_stdout; stderr }
-                 | Shell_ir.Simple s :: rest ->
-                     let stage_result =
-                       dispatch_simple
-                         ~stdin_content:prev_stdout
-                         s
-                     in
-                     let status = pipeline_status status stage_result.status in
-                     let stderr = stderr ^ stage_result.stderr in
-                     if status_is_timeout stage_result.status
-                     then { status; stdout = stage_result.stdout; stderr }
-                     else
-                       chain
-                         ~prev_stdout:stage_result.stdout
-                         ~status
-                         ~stderr
-                         rest
-                 | Pipeline _ :: _ ->
-                     { status = Unix.WEXITED 1
-                     ; stdout = ""
-                     ; stderr =
-                         stderr ^ "nested pipeline not supported in native dispatch"
-                     }
-               in
-               (match stages with
-                | [] | [ _ ] ->
-                    invalid_pipeline "invalid pipeline arity in native dispatch"
-                | first :: rest -> (
-                  match first with
-                  | Shell_ir.Simple s ->
-                      let first_result = dispatch_simple s in
-                      let status =
-                        pipeline_status (Unix.WEXITED 0) first_result.status
-                      in
-                      if status_is_timeout first_result.status
-                      then
-                        { status
-                        ; stdout = first_result.stdout
-                        ; stderr = first_result.stderr
-                        }
-                      else
-                        chain
-                          ~prev_stdout:first_result.stdout
-                          ~status
-                          ~stderr:first_result.stderr
-                          rest
-                  | Pipeline _ ->
-                      invalid_pipeline
-                        "nested pipeline not supported in native dispatch" ))))
+               |> List.map (fun stage -> String.concat " " stage.Process_eio.argv)
+               |> String.concat " | "
+             in
+             let status, stdout, stderr =
+               Exec_gate.run_argv_pipeline_with_status_split
+                 ~actor:`Tool_local_runtime
+                 ~raw_source
+                 ~summary:"exec dispatch pipeline"
+                 specs
+             in
+             { status; stdout; stderr }
+         | None -> (
+             match docker_pipeline_specs stages with
+             | Some (runner, specs) ->
+                 let status, stdout, stderr = runner ~stages:specs in
+                 { status; stdout; stderr }
+             | None ->
+                 let rec chain ~prev_stdout ~status ~stderr = function
+                   | [] -> { status; stdout = prev_stdout; stderr }
+                   | Shell_ir.Simple s :: rest ->
+                       let stage_result =
+                         dispatch_simple
+                           ~stdin_content:prev_stdout
+                           s
+                       in
+                       let status = pipeline_status status stage_result.status in
+                       let stderr = stderr ^ stage_result.stderr in
+                       if status_is_timeout stage_result.status
+                       then { status; stdout = stage_result.stdout; stderr }
+                       else
+                         chain
+                           ~prev_stdout:stage_result.stdout
+                           ~status
+                           ~stderr
+                           rest
+                   | Pipeline _ :: _ ->
+                       { status = Unix.WEXITED 1
+                       ; stdout = ""
+                       ; stderr =
+                           stderr ^ "nested pipeline not supported in native dispatch"
+                       }
+                 in
+                 (match stages with
+                  | [] | [ _ ] ->
+                      invalid_pipeline "invalid pipeline arity in native dispatch"
+                  | first :: rest -> (
+                    match first with
+                    | Shell_ir.Simple s ->
+                        let first_result = dispatch_simple s in
+                        let status =
+                          pipeline_status (Unix.WEXITED 0) first_result.status
+                        in
+                        if status_is_timeout first_result.status
+                        then
+                          { status
+                          ; stdout = first_result.stdout
+                          ; stderr = first_result.stderr
+                          }
+                        else
+                          chain
+                            ~prev_stdout:first_result.stdout
+                            ~status
+                            ~stderr:first_result.stderr
+                            rest
+                    | Pipeline _ ->
+                        invalid_pipeline
+                          "nested pipeline not supported in native dispatch" ))))
+  in
+  emit_captured_output on_output_chunk result
 
 and dispatch ?on_output_chunk (ir : Shell_ir.t) =
   match ir with
   | Shell_ir.Simple s -> dispatch_simple ?on_output_chunk s
-  | Pipeline stages ->
-    (* Pipelines do not yet expose per-stage chunk callbacks; an
-       [on_output_chunk] provided here is ignored. *)
-    dispatch_pipeline stages
+  | Pipeline stages -> dispatch_pipeline ?on_output_chunk stages
 
 let dispatch_decided ?on_output_chunk (envelope : Shell_ir_risk.decided Shell_ir_risk.decided_ir) :
     dispatch_result =

--- a/lib/exec/exec_dispatch.mli
+++ b/lib/exec/exec_dispatch.mli
@@ -38,7 +38,12 @@ val dispatch_decided :
     ensures the IR has passed through [Shell_ir_risk.classify]. *)
 
 val dispatch_pipeline :
-  ?stdin_content:string -> Shell_ir.t list -> dispatch_result
+  ?stdin_content:string ->
+  ?on_output_chunk:([ `Stdout of string | `Stderr of string ] -> unit) ->
+  Shell_ir.t list ->
+  dispatch_result
 (** Execute a pipeline of commands, streaming stdout between stages.
     Handles [Simple] stages natively; nested [Pipeline] stages are
-    rejected with an error. *)
+    rejected with an error.  [?on_output_chunk] receives the final
+    captured stdout/stderr after pipeline completion; it is not yet a
+    per-process-read streaming callback. *)

--- a/test/test_exec_dispatch.ml
+++ b/test/test_exec_dispatch.ml
@@ -118,6 +118,57 @@ let () =
   assert (String.trim result.stdout = "y");
   assert (result.status <> Unix.WEXITED 124)
 
+(* --- dispatch_decided forwards pipeline captured output chunks --- *)
+
+let () =
+  with_eio @@ fun () ->
+  let open Masc_exec.Shell_ir in
+  let sh_bin = Masc_exec.Exec_program.of_string "sh" |> Result.get_ok in
+  let cat_bin = Masc_exec.Exec_program.of_string "cat" |> Result.get_ok in
+  let host_sandbox = Masc_exec.Sandbox_target.host () in
+  let sh_stage =
+    Simple
+      {
+        bin = sh_bin;
+        args =
+          [
+            Lit ("-c", default_meta);
+            Lit ("printf out; printf err >&2", default_meta);
+          ];
+        env = [];
+        cwd = None;
+        redirects = [];
+        sandbox = host_sandbox;
+      }
+  in
+  let cat_stage =
+    Simple
+      {
+        bin = cat_bin;
+        args = [];
+        env = [];
+        cwd = None;
+        redirects = [];
+        sandbox = host_sandbox;
+      }
+  in
+  let envelope =
+    { Masc_exec.Shell_ir_risk.ir = Pipeline [ sh_stage; cat_stage ]
+    ; risk = Masc_exec.Shell_ir_risk.R0_Read
+    }
+  in
+  let chunks = ref [] in
+  let result =
+    Masc_exec.Exec_dispatch.dispatch_decided
+      ~on_output_chunk:(fun chunk -> chunks := chunk :: !chunks)
+      envelope
+  in
+  assert (result.status = Unix.WEXITED 0);
+  assert (result.stdout = "out");
+  assert (result.stderr = "err");
+  assert (List.mem (`Stdout "out") !chunks);
+  assert (List.mem (`Stderr "err") !chunks)
+
 (* --- dispatch pipeline exit code: last nonzero wins --- *)
 
 let () =


### PR DESCRIPTION
## Summary

- Forward Shell IR pipeline captured output through `dispatch_decided ~on_output_chunk`.
- Add an isolated `masc_exec` sublib regression test so the pipeline callback proof is not blocked by unrelated root-library board alias drift.
- Keep the current contract explicit: pipeline callbacks receive final captured stdout/stderr after completion; live per-read pipeline streaming is still a follow-up.
- Bump the MASC OAS/`agent_sdk` pin to `v0.205.11` so current runtime code can use `Agent_sdk.Builder.with_trace_link`.

Part of #20811
Fixes #20834

## Proof Matrix

1. Shell IR only path
   - Typed Execute descriptor exposes `executable`/`argv`/`pipeline`, not raw `cmd`/`command`.
   - Keeper Execute lowers typed input once to Shell IR, classifies that IR, then dispatches through `Keeper_tool_execute_shell_ir.dispatch_classified`.
   - `scripts/audit-shell-ir-consumption.sh --baseline scripts/shell-ir-consumption-baseline.json` passes.
   - CI `Shell IR Consumption Ratchet` passes.

2. SSOT / drift guards
   - `scripts/lint-spawn-bounded.sh` passes; spawn sites remain allowlisted.
   - `scripts/check-oas-pin.sh --local-only` passes with `agent_sdk v0.205.11`.
   - `scripts/oas-drift-check.sh` passes for the pinned OAS API surface.
   - CI `Meta Guards`, `OCaml Structure Ratchet`, `Tool substrate adapter surface ratchet`, and `Tool -> Keeper dependency-direction ratchet` pass.

3. Parallel execution
   - OAS PR jeong-sik/oas#2005 is merged and makes provider/model parallel-tool capability drive effective `disable_parallel_tool_use`.
   - MASC Shell IR pipeline callback no longer drops output callbacks.
   - `lib/exec/test/test_exec_dispatch_pipeline_callback.ml` proves `dispatch_decided ~on_output_chunk` receives captured pipeline output.

4. Async execution
   - `Bg_task` already owns background shell lifecycle primitives (`spawn/read/kill/list`) below the public surface.
   - Typed Execute still rejects the legacy `run_in_background` flag; this PR does not re-open a raw-shell async backdoor.
   - Keeper message async uses `Keeper_msg_async.submit` plus `Keeper_turn_admission.run_serialized` for the one-turn-per-keeper safety invariant.
   - Remaining architecture cleanup is tracked in #20812: align async keeper_msg with the RFC-0225 per-keeper serial consumer model.

## Verification

- `git diff --check`
- `ocamlformat --check lib/exec/test/test_exec_dispatch_pipeline_callback.ml`
- `scripts/ci/check-telemetry-coverage.sh`
- `scripts/lint-spawn-bounded.sh`
- `scripts/audit-shell-ir-consumption.sh --baseline scripts/shell-ir-consumption-baseline.json`
- `scripts/check-oas-pin.sh --local-only`
- `scripts/oas-drift-check.sh`
- `scripts/dune-local.sh build lib/runtime/masc_runtime.cmxa`
- `scripts/dune-local.sh build lib/exec/masc_exec.cmxa`
- `scripts/dune-local.sh build lib/exec/test/test_exec_dispatch_pipeline_callback.exe`
- `./_build/default/lib/exec/test/test_exec_dispatch_pipeline_callback.exe`
- `scripts/dune-local.sh build test/test_exec_dispatch.exe` is still blocked by #20827 (stale `Board.Board_*` root aliases outside this PR).
