### PR TITLE
fix(tool_agent): keep agent fitness read-only for Thompson stats

### DIFF
--- a/lib/tool_agent.ml
+++ b/lib/tool_agent.ml
@@ -190,8 +190,10 @@ let min_avg_time metrics_list =
     to prioritize "finishes correctly" over "finishes fast" based on observed MASC
     usage patterns where incomplete tasks cause more rework than slow tasks.
 
-    TODO: Validate empirically — track selection outcomes vs task success rate
-    to determine if the current weighting produces better team compositions. *)
+    TODO: Validate empirically — correlate ranking snapshots with later task
+    success rate to determine if the current weighting produces better team
+    compositions.  This read path must not update Thompson alpha/beta directly; real
+    task outcome feedback flows through [Workspace_hooks.record_thompson_result_fn]. *)
 type fitness_weights = {
   w_completion : float;
   w_reliability : float;

--- a/test/test_tool_agent_coverage.ml
+++ b/test/test_tool_agent_coverage.ml
@@ -230,6 +230,22 @@ let test_agent_fitness_specific () =
   Alcotest.(check bool) "has response" true (String.length (Tool_result.message result) > 0);
   )
 
+let test_agent_fitness_does_not_mutate_thompson_stats () =
+  with_ctx (fun ctx ->
+  let agent_name = "fitness-read-only-agent" in
+  let stats = Thompson_sampling.get_stats agent_name in
+  stats.alpha <- 2.0;
+  stats.beta <- 3.0;
+  stats.selections <- 4;
+  let args = `Assoc [("agent_name", `String agent_name); ("days", `Int 7)] in
+  let result = Tool_agent.handle_agent_fitness ctx args in
+  Alcotest.(check bool) "fitness succeeds" true (Tool_result.is_success result);
+  let after = Thompson_sampling.get_stats agent_name in
+  Alcotest.(check (float 0.0001)) "alpha unchanged" 2.0 after.alpha;
+  Alcotest.(check (float 0.0001)) "beta unchanged" 3.0 after.beta;
+  Alcotest.(check int) "selections unchanged" 4 after.selections;
+  )
+
 (* ============================================================
    Handler tests — meta_cognition_snapshot
    ============================================================ *)
@@ -400,6 +416,8 @@ let () =
     ("agent_update", [
       Alcotest.test_case "no agents" `Quick test_agent_fitness_no_agents;
       Alcotest.test_case "specific agent" `Quick test_agent_fitness_specific;
+      Alcotest.test_case "fitness is read-only for thompson" `Quick
+        test_agent_fitness_does_not_mutate_thompson_stats;
     ]);
     ("get_metrics", [
       Alcotest.test_case "no data returns not_found" `Quick test_get_metrics_no_data;


### PR DESCRIPTION
## Summary

Keeps `masc_agent_fitness` as a read-only ranking/reporting path for Thompson-related fitness inputs.

The previous version recorded `Post_verifier.Pass` for the top-ranked agent on every fitness query. That would make repeated dashboard/tool reads mutate Thompson alpha/beta and bias the posterior without observing task success.

## Changes

- Reworded the fitness TODO to say ranking snapshots should be correlated with later task outcomes.
- Explicitly documents that task success/failure feedback belongs to `Workspace_hooks.record_thompson_result_fn`.
- Added regression coverage proving `handle_agent_fitness` does not mutate Thompson alpha, beta, or selection counters.

## Follow-up

Full Thompson scheduling/persistence wiring is tracked separately in #20835.

## Verification

- `opam exec -- ocamlformat --inplace lib/tool_agent.ml test/test_tool_agent_coverage.ml`
- `git diff --check`
- `MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_20833_fix scripts/dune-local.sh build test/test_tool_agent_coverage.exe`
- `_build_20833_fix/default/test/test_tool_agent_coverage.exe`
- `MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_20833_fix scripts/dune-local.sh build lib/masc.cma`
