### PR TITLE
test(exec): ratchet async surface boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -406,6 +406,9 @@ jobs:
         if: needs.changes.outputs.lib_deps == 'true'
         run: python3 scripts/lib_dep_report.py --self-test
 
+      - name: Check Execute async surface contract
+        run: bash scripts/check-execute-async-surface.sh
+
       - name: Sublib boundary gate self-test (RFC-0056 G1)
         if: needs.changes.outputs.lib_deps == 'true'
         run: python3 scripts/audit-sublib-cycle.py --self-test

--- a/docs/EXECUTE-RUNBOOK.md
+++ b/docs/EXECUTE-RUNBOOK.md
@@ -1,6 +1,6 @@
 ---
 status: runbook
-last_verified: 2026-05-21
+last_verified: 2026-06-11
 code_refs:
   - lib/exec/exec_semantic.ml
   - lib/exec/exec_buffer.ml
@@ -30,6 +30,8 @@ background task lifecycle are not part of the callable surface.
 - `Grep` owns file/content search. Execute owns typed command execution.
 - Does not cover: the runtime verifier itself or the approval layer for MCP
   tools.
+- Async boundary: background shell lifecycle primitives live in `Bg_task`;
+  they are not exposed through the typed `Execute` callable surface.
 
 ## Current Rollout State
 
@@ -71,6 +73,24 @@ Pipeline:
 Shell metacharacters inside `argv` are data. Use `pipeline` for pipes
 instead of embedding `|` in a string. For read-only observation prefer
 `Grep`; for file edits use `Edit`/`Write`.
+
+## Async Boundary Proof
+
+`Execute` remains synchronous at the callable-surface level. The public schema
+rejects legacy background flags and accepts only typed command fields:
+`executable`, `argv`, `pipeline`, `env`, `cwd`, `timeout_sec`, `stdin`,
+`stdout`, and `stderr`.
+
+Background shell lifecycle support exists below that boundary in `Bg_task`
+(`spawn` / `read` / `kill` / `list`). Keeper-turn async messaging is a separate
+surface (`keeper_msg`, `keeper_msg_result`, `keeper_msg_cancel`,
+`keeper_msg_list`) and is serialized through `Keeper_turn_admission`.
+
+Verification:
+
+```bash
+bash scripts/check-execute-async-surface.sh
+```
 
 ## Counter Endpoint
 

--- a/scripts/check-execute-async-surface.sh
+++ b/scripts/check-execute-async-surface.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+require_text() {
+  local file="$1"
+  local needle="$2"
+  local label="$3"
+
+  if ! grep -Fq -- "$needle" "${ROOT}/${file}"; then
+    echo "execute-async-surface: missing ${label}: ${file}" >&2
+    echo "  expected text: ${needle}" >&2
+    exit 1
+  fi
+}
+
+require_normalized_text() {
+  local file="$1"
+  local needle="$2"
+  local label="$3"
+  local haystack
+
+  haystack="$(tr '\n' ' ' < "${ROOT}/${file}" | tr -s ' ')"
+  if [[ "${haystack}" != *"${needle}"* ]]; then
+    echo "execute-async-surface: missing ${label}: ${file}" >&2
+    echo "  expected text: ${needle}" >&2
+    exit 1
+  fi
+}
+
+reject_text() {
+  local file="$1"
+  local needle="$2"
+  local label="$3"
+
+  if grep -Fq -- "$needle" "${ROOT}/${file}"; then
+    echo "execute-async-surface: forbidden ${label}: ${file}" >&2
+    echo "  forbidden text: ${needle}" >&2
+    exit 1
+  fi
+}
+
+require_text \
+  "docs/EXECUTE-RUNBOOK.md" \
+  "Execute is typed-only: callers provide" \
+  "typed-only Execute runbook claim"
+require_normalized_text \
+  "docs/EXECUTE-RUNBOOK.md" \
+  "old background task lifecycle are not part of the callable surface" \
+  "background lifecycle exclusion in Execute runbook"
+
+require_text \
+  "lib/tool_surface/tool_shard_types_schemas_execute.ml" \
+  "Accepted fields: executable, argv, pipeline, env, cwd, timeout_sec, stdin, stdout, stderr." \
+  "typed Execute accepted-field list"
+require_normalized_text \
+  "lib/tool_surface/tool_shard_types_schemas_execute.ml" \
+  "this tool no longer \\ exposes background task lifecycle tools" \
+  "typed Execute background lifecycle exclusion"
+reject_text \
+  "lib/tool_surface/tool_shard_types_schemas_execute.ml" \
+  "run_in_background" \
+  "legacy Execute background flag"
+
+require_text \
+  "test/test_tool_input_validation.ml" \
+  "legacy background flag not exposed" \
+  "schema rejection proof"
+require_text \
+  "test/test_tool_input_validation.ml" \
+  "test_validate_args_tool_execute_rejects_background_flag" \
+  "validation rejection proof"
+
+require_text \
+  "lib/process/bg_task.mli" \
+  "Background shell task lifecycle" \
+  "internal Bg_task lifecycle owner"
+require_text "lib/process/bg_task.mli" "val spawn" "Bg_task spawn primitive"
+require_text "lib/process/bg_task.mli" "val read" "Bg_task read primitive"
+require_text "lib/process/bg_task.mli" "val kill" "Bg_task kill primitive"
+require_text "lib/process/bg_task.mli" "val list" "Bg_task list primitive"
+
+require_text \
+  "lib/keeper/keeper_msg_async.mli" \
+  "Fire-and-forget keeper message execution" \
+  "keeper_msg async owner"
+require_text "lib/keeper/keeper_msg_async.mli" "val submit" "keeper_msg submit"
+require_text "lib/keeper/keeper_msg_async.mli" "val poll" "keeper_msg poll"
+require_text "lib/keeper/keeper_msg_async.mli" "val cancel" "keeper_msg cancel"
+require_text \
+  "lib/keeper/keeper_msg_async.mli" \
+  "val list_for_keeper" \
+  "keeper_msg async list"
+require_text \
+  "lib/keeper/keeper_turn_admission.mli" \
+  "async [Keeper_msg_async] dispatch" \
+  "async keeper_msg admission contract"
+require_text \
+  "lib/keeper/keeper_turn_admission.mli" \
+  "run_serialized" \
+  "keeper turn serialized admission"
+
+echo "execute-async-surface: PASS"


### PR DESCRIPTION
## Summary

- Add `scripts/check-execute-async-surface.sh` to ratchet the async boundary:
  - public typed `Execute` stays typed-only and rejects legacy `run_in_background`
  - internal background shell lifecycle remains owned by `Bg_task`
  - keeper message async remains a separate `keeper_msg` request-id/poll/cancel/list surface
  - async keeper turns remain tied to `Keeper_turn_admission.run_serialized`
- Wire the new ratchet into CI Meta Guards.
- Refresh `docs/EXECUTE-RUNBOOK.md` with the verified async boundary proof.

Part of #20811
Refs #20812

## Verification

- `bash scripts/check-execute-async-surface.sh`
- `bash -n scripts/check-execute-async-surface.sh`
- `git diff --check`
- `bash scripts/check-doc-truth.sh`

## Notes

This does not add first-class async Execute job IDs. It makes the current boundary mechanically provable before that design choice: async shell lifecycle exists below the public surface in `Bg_task`, while public typed `Execute` remains synchronous and does not expose legacy raw-shell background flags.
