### PR TITLE
feat(keeper): RFC-0230 P2 — scope messages = unanswered operator (Owner) lines

### DIFF
--- a/lib/keeper/keeper_world_observation_message_scope.ml
+++ b/lib/keeper/keeper_world_observation_message_scope.ml
@@ -110,20 +110,31 @@ let speaker_display (m : Keeper_chat_store.chat_message) : string =
 
    Pure over the loaded lane so it is testable without I/O; [collect_message_scope]
    only adds the [Keeper_chat_store.load]. *)
+
+(* The watermark: ts of the keeper's own last lane line (assistant role). A user
+   line at or before it is already answered. *)
+let last_self_ts (messages : Keeper_chat_store.chat_message list) : float =
+  List.fold_left
+    (fun acc (m : Keeper_chat_store.chat_message) ->
+      match m.ts with
+      | Some ts when m.role = "assistant" && ts > acc -> ts
+      | _ -> acc)
+    0.0
+    messages
+;;
+
+let is_owner_authored (m : Keeper_chat_store.chat_message) : bool =
+  match m.speaker with
+  | Some (s : Keeper_chat_store.speaker) -> s.speaker_authority = Keeper_chat_store.Owner
+  | None -> false
+;;
+
 let pending_mentions_of_messages
       ~(targets : string list)
       (messages : Keeper_chat_store.chat_message list)
   : (string * string) list
   =
-  let my_last_ts =
-    List.fold_left
-      (fun acc (m : Keeper_chat_store.chat_message) ->
-        match m.ts with
-        | Some ts when m.role = "assistant" && ts > acc -> ts
-        | _ -> acc)
-      0.0
-      messages
-  in
+  let my_last_ts = last_self_ts messages in
   List.filter_map
     (fun (m : Keeper_chat_store.chat_message) ->
       match m.ts with
@@ -133,12 +144,37 @@ let pending_mentions_of_messages
     messages
 ;;
 
-(* [pending_scope_messages] (the second list) is reserved for RFC-0230 P2. *)
+(* RFC-0230 P2 — scope messages: a keeper's lane is, in practice, an operator
+   (Owner) conversation. The operator often addresses the keeper without an
+   "@name", so an unanswered Owner line that is not already a mention is a scope
+   message. External (connector) chatter without a mention is ignored, so a busy
+   channel does not flood the keeper. Same watermark as mentions; the mention
+   exclusion keeps the two reactive signals disjoint. *)
+let pending_scope_of_messages
+      ~(targets : string list)
+      (messages : Keeper_chat_store.chat_message list)
+  : (string * string) list
+  =
+  let my_last_ts = last_self_ts messages in
+  List.filter_map
+    (fun (m : Keeper_chat_store.chat_message) ->
+      match m.ts with
+      | Some ts
+        when ts > my_last_ts
+             && m.role = "user"
+             && is_owner_authored m
+             && not (line_mentions ~targets m.content) -> Some (speaker_display m, m.content)
+      | _ -> None)
+    messages
+;;
+
 let collect_message_scope ~(config : Workspace.config) ~(meta : keeper_meta)
   : (string * string) list * (string * string) list
   =
   let messages =
     Keeper_chat_store.load ~base_dir:config.base_path ~keeper_name:meta.name
   in
-  pending_mentions_of_messages ~targets:(message_feed_targets meta) messages, []
+  let targets = message_feed_targets meta in
+  ( pending_mentions_of_messages ~targets messages
+  , pending_scope_of_messages ~targets messages )
 ;;

--- a/lib/keeper/keeper_world_observation_message_scope.mli
+++ b/lib/keeper/keeper_world_observation_message_scope.mli
@@ -23,6 +23,17 @@ val pending_mentions_of_messages
   -> Keeper_chat_store.chat_message list
   -> (string * string) list
 
+(** [pending_scope_of_messages ~targets messages] returns the [(speaker,
+    content)] of every unanswered Owner-authored user line that is {e not} a
+    mention — the operator addressing the keeper without an "@name". External
+    (connector) lines and lines already counted as mentions are excluded, so
+    this signal stays disjoint from mentions and does not flood on busy
+    channels. Same watermark as {!pending_mentions_of_messages}; pure. *)
+val pending_scope_of_messages
+  :  targets:string list
+  -> Keeper_chat_store.chat_message list
+  -> (string * string) list
+
 val collect_message_scope
   :  config:Workspace.config
   -> meta:keeper_meta

--- a/test/test_keeper_mention_scope.ml
+++ b/test/test_keeper_mention_scope.ml
@@ -81,6 +81,42 @@ let test_assistant_self_mention_ignored () =
     (contents (MS.pending_mentions_of_messages ~targets messages))
 ;;
 
+let speaker_with authority : Store.speaker option =
+  Some { speaker_id = None; speaker_name = None; speaker_authority = authority }
+;;
+
+let owner = speaker_with Store.Owner
+let external_ = speaker_with Store.External
+
+let test_owner_unmentioned_line_is_scope () =
+  let messages = [ msg ~role:"user" ~ts:(Some 10.0) ~speaker:owner "can you check the deploy" ] in
+  check (list string) "operator without @ -> scope" [ "can you check the deploy" ]
+    (contents (MS.pending_scope_of_messages ~targets messages))
+;;
+
+let test_owner_mention_is_not_scope () =
+  (* an owner line that mentions is a mention, not a scope message (disjoint) *)
+  let messages = [ msg ~role:"user" ~ts:(Some 10.0) ~speaker:owner "@dreamer check it" ] in
+  check (list string) "owner mention excluded from scope" []
+    (contents (MS.pending_scope_of_messages ~targets messages))
+;;
+
+let test_external_unmentioned_is_not_scope () =
+  let messages = [ msg ~role:"user" ~ts:(Some 10.0) ~speaker:external_ "random channel chatter" ] in
+  check (list string) "external without @ -> ignored" []
+    (contents (MS.pending_scope_of_messages ~targets messages))
+;;
+
+let test_answered_owner_line_is_cleared () =
+  let messages =
+    [ msg ~role:"user" ~ts:(Some 10.0) ~speaker:owner "please check"
+    ; msg ~role:"assistant" ~ts:(Some 11.0) "done"
+    ]
+  in
+  check (list string) "answered owner line -> cleared" []
+    (contents (MS.pending_scope_of_messages ~targets messages))
+;;
+
 let () =
   run "keeper_mention_scope"
     [ ( "line_mentions"
@@ -97,6 +133,12 @@ let () =
         ; test_case "answered_cleared" `Quick test_answered_mention_is_cleared
         ; test_case "rementioned_pending" `Quick test_rementioned_after_reply_is_pending
         ; test_case "assistant_self_ignored" `Quick test_assistant_self_mention_ignored
+        ] )
+    ; ( "pending_scope_of_messages"
+      , [ test_case "owner_unmentioned_is_scope" `Quick test_owner_unmentioned_line_is_scope
+        ; test_case "owner_mention_not_scope" `Quick test_owner_mention_is_not_scope
+        ; test_case "external_unmentioned_ignored" `Quick test_external_unmentioned_is_not_scope
+        ; test_case "answered_owner_cleared" `Quick test_answered_owner_line_is_cleared
         ] )
     ]
 ;;


### PR DESCRIPTION
## What

RFC-0230 P2: implement `pending_scope_of_messages` — a keeper reacts to its
operator (Owner) even when not @-mentioned.

## Why this, not a "scope subscription"

There is no scope/subscription/channel concept on `keeper_meta` (only
`mention_targets`), so a generic "subscribed scope" would be an invented
concept. The one grounded distinction is `chat_message.speaker.speaker_authority`
= `Owner | External`: the authenticated dashboard operator is `Owner`, connector
chatter is `External` (RFC-0223 §3).

A keeper's lane is, in practice, an operator conversation, and the operator
often addresses it without an "@name". So:

- **scope message** = an unanswered `Owner` user line that is **not** a mention.
- `External` lines without a mention are ignored (a busy connector channel does
  not flood the keeper).
- Mentions are excluded, so the two reactive signals stay disjoint.

Same "lane is the state" watermark as mentions (P1): pending iff after the
keeper's own last line; replying clears it. No new state, no cursor.

## Change

- Extract `last_self_ts` (shared watermark) and add `is_owner_authored`.
- Add `pending_scope_of_messages` (pure); `collect_message_scope` now returns
  both lists instead of `mentions, []`.

This lights up the previously-dead `pending_scope_messages` consumers
(`scope_message` / `message_sweep` reactive classification in
`keeper_unified_metrics_support`, prompt formatting in `keeper_unified_prompt`).

## Verification

- `dune build --root . @check` clean.
- `test_keeper_mention_scope`: 15 cases (11 prior + 4 scope — owner-unmentioned
  is scope, owner-mention excluded, external-unmentioned ignored, answered
  cleared). All pure, no I/O.

## Integration audit (always-[] to non-empty)

A 9-agent audit traced every consumer of `pending_scope_messages` (wake
predicates, turn success, metrics classification, prompt, social models,
post-turn guards) plus 3 adversarial passes. Result: no consumer flips turn
success/failure (`keeper_unified_turn.ml:893-931` is observation-blind; the
failure-policy plane consumes only error-derived inputs), scope+mention
co-occurrence collapses into a single Run verdict per cycle, and the prompt
section is capped (12 entries, 120-byte previews, ~2KB worst case).

Two grounded properties of the current tree:

- **Self-clearing at write time, today**: the only Owner-authority writer is
  the bearer-gated dashboard route (`server_routes_http_keeper_stream.ml:621`),
  and both its persistence paths write the Owner user line and the answering
  assistant line at the same ts in one `append_turn` after the turn completes.
  Pending requires strict `ts > watermark`, so persisted Owner exchanges
  self-clear. Non-empty scope currently fires only on a torn mid-append read
  (at most one spurious reactive turn, self-correcting). The signal becomes
  live when a delivery-time Owner recording path lands (RFC-0226 ambient
  recording direction).
- **No self-feed**: keeper outputs are assistant/tool roles and only raise the
  watermark; connector lines are `External` and excluded by construction.

## Known limitations (routed, not fixed here)

- A reactive turn that does not post to the lane does not advance the
  watermark, so an ignored Owner line re-wakes the keeper — bounded to one
  turn per heartbeat interval (`keeper_heartbeat_loop.ml:860-872` sleeps
  base+jitter every cycle; base default 30s, clamp floor 5s). This is the same
  exemption shape as the pre-existing mention/board reactive signals — this PR
  adds a third member to that class, it does not change the class. The root is
  reactive wake policy, owned by the deferred RFC-0230 §8.3 follow-up.
- `keeper_unified_metrics_result.ml:124-130` refreshes reactive `last_ts` for
  board/mention turns but omits scope (pre-wired asymmetry, now reachable).
  Bounded cadence effect on the next scheduled-autonomous interval; follow-up
  candidate alongside §8.3.

## RFC

`docs/rfc/RFC-0230-keeper-mention-scope-reactivity.md` (merged). Completes the
second list of `collect_message_scope`; mentions shipped in #20806.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
