### PR TITLE
fix(keeper): add turn_completed telemetry event to failure path after Agent.run()

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -889,6 +889,14 @@ dominant source of the observed CAS race exhaustion after
                     ~is_auto_recoverable
                     ~err
                     ~error_text:e_str;
+                  (* RFC-0221 §3.4: emit turn_completed telemetry on all exit paths
+                     after Agent.run() — success path emits via
+                     Keeper_unified_turn_success → keeper_unified_metrics_snapshot;
+                     failure path emits here directly. *)
+                  Otel_metric_store.inc_counter
+                    Keeper_metrics.(to_string TurnCompleted)
+                    ~labels:[("keeper", meta.name)]
+                    ();
                   Error err
                 | Ok result ->
                   let final_execution = !last_execution in


### PR DESCRIPTION
## Problem

The failure path (`Error err` branch) after `Agent.run()` in `keeper_unified_turn.ml` does not emit the `TurnCompleted` telemetry counter. The success path emits this via `Keeper_unified_turn_success` -> `keeper_unified_metrics_snapshot`, but failures complete `Agent.run()` without recording the metric.

## Solution

Added `Otel_metric_store.inc_counter Keeper_metrics.(to_string TurnCompleted)` in the failure path before `Error err` return (RFC-0221 §3.4).

- 1 file changed: `lib/keeper/keeper_unified_turn.ml`
- +8 lines (Otel counter + comment + blank lines)
- The `Otel_metric_store` and `Keeper_metrics` modules are already available via `include Keeper_turn_helpers`

Closes task-801