### PR TITLE
feat(dashboard): Discord gateway monitoring — machine-state chip, message flow, READY identity

### DIFF
--- a/dashboard/src/api/schemas/gate-connectors.ts
+++ b/dashboard/src/api/schemas/gate-connectors.ts
@@ -202,6 +202,14 @@ const GateConnectorInfoRawSchema = object({
   connected: fallback(boolean(), false),
   stale: fallback(boolean(), false),
   stale_after_sec: fallback(number(), 0),
+  // In-process gateway machine state (RFC-0203 / #20813): disconnected /
+  // awaiting_hello / identifying / resuming / connected /
+  // reconnect_pending / failed. Sidecar connectors don't emit it —
+  // empty means "not advertised".
+  gateway_state: fallback(string(), ''),
+  // 'in_process_gateway' for connectors whose status comes from the
+  // typed gateway state machine; empty for sidecar status files.
+  status_source: fallback(string(), ''),
   error: fallback(string(), ''),
   status_path: fallback(string(), ''),
   binding_store_path: fallback(string(), ''),
@@ -239,6 +247,8 @@ export interface GateConnectorInfo {
   connected: boolean
   stale: boolean
   stale_after_sec: number
+  gateway_state: string
+  status_source: string
   error: string
   status_path: string
   binding_store_path: string
@@ -335,6 +345,8 @@ function parseGateConnectorInfo(raw: unknown): GateConnectorInfo | null {
     connected: outer.output.connected,
     stale: outer.output.stale,
     stale_after_sec: outer.output.stale_after_sec,
+    gateway_state: outer.output.gateway_state,
+    status_source: outer.output.status_source,
     error: outer.output.error,
     status_path: outer.output.status_path,
     binding_store_path: outer.output.binding_store_path,

--- a/dashboard/src/components/connector-flow.test.ts
+++ b/dashboard/src/components/connector-flow.test.ts
@@ -1,0 +1,165 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import {
+  ConnectorFlowSection,
+  channelStatsFor,
+  bindingRowsFor,
+  recentEventsFor,
+} from './connector-flow'
+import { parseGateStatusData } from '../api/schemas/gate-status'
+import { parseGateConnectorsData } from '../api/schemas/gate-connectors'
+import type { GateConnectorInfo } from '../api/gate'
+
+// Fixtures go through the REAL boundary parsers so they cannot drift
+// from the schema the production fetch path enforces.
+
+function mkGate(overrides?: Partial<Record<string, unknown>>) {
+  return parseGateStatusData({
+    channels: [
+      {
+        channel: 'discord',
+        message_count: 12,
+        success_count: 10,
+        error_count: 2,
+        duplicate_count: 1,
+        success_rate_pct: 91,
+        avg_duration_ms: 1400,
+        last_activity: '2026-06-11T00:00:00Z',
+      },
+    ],
+    bindings: [
+      {
+        channel: 'discord',
+        workspace_id: '149325',
+        keeper: 'sangsu',
+        message_count: 9,
+        success_count: 8,
+        error_count: 1,
+        last_activity: '2026-06-11T00:00:00Z',
+      },
+      {
+        channel: 'slack',
+        workspace_id: 'C0123',
+        keeper: 'luna',
+        message_count: 3,
+      },
+    ],
+    recent_events: [
+      { seq: 1, timestamp: '2026-06-11T00:00:00Z', channel: 'discord', workspace_id: '149325', keeper: 'sangsu', outcome: 'success', duration_ms: 900 },
+      { seq: 3, timestamp: '2026-06-11T00:02:00Z', channel: 'discord', workspace_id: '149325', keeper: 'sangsu', outcome: 'keeper_error', error: 'upstream timeout', duration_ms: 4800 },
+      { seq: 2, timestamp: '2026-06-11T00:01:00Z', channel: 'slack', workspace_id: 'C0123', keeper: 'luna', outcome: 'success' },
+    ],
+    ...(overrides ?? {}),
+  })
+}
+
+function mkConnector(overrides?: Partial<Record<string, unknown>>): GateConnectorInfo {
+  const data = parseGateConnectorsData({
+    generated_at: '2026-06-11T00:00:00Z',
+    connectors: [
+      {
+        connector_id: 'discord',
+        display_name: 'Discord',
+        channel: 'discord',
+        capabilities: ['bindings'],
+        status: 'connected',
+        available: true,
+        connected: true,
+        recent_audit: [
+          {
+            timestamp: '2026-06-11T00:00:00Z',
+            action: 'bind',
+            guild_id: 'g1',
+            channel_id: '149325',
+            keeper_name: 'sangsu',
+            actor_id: 'dashboard',
+            actor_name: 'dashboard',
+          },
+        ],
+        ...(overrides ?? {}),
+      },
+    ],
+  })
+  const connector = data.connectors[0]
+  if (!connector) throw new Error('fixture connector failed to parse')
+  return connector
+}
+
+describe('connector-flow pure helpers', () => {
+  it('channelStatsFor prefers the connector observed_channel aggregation', () => {
+    const connector = mkConnector({
+      observed_channel: { channel: 'discord', message_count: 99 },
+    })
+    const stats = channelStatsFor(connector, mkGate())
+    expect(stats?.message_count).toBe(99)
+  })
+
+  it('channelStatsFor falls back to the gate channel row, null when absent', () => {
+    const connector = mkConnector()
+    expect(channelStatsFor(connector, mkGate())?.message_count).toBe(12)
+    expect(channelStatsFor(connector, mkGate({ channels: [] }))).toBeNull()
+    expect(channelStatsFor(connector, null)).toBeNull()
+  })
+
+  it('bindingRowsFor returns only this channel\'s rows', () => {
+    const rows = bindingRowsFor(mkConnector(), mkGate())
+    expect(rows.map(r => r.keeper)).toEqual(['sangsu'])
+  })
+
+  it('recentEventsFor sorts newest-first by seq and caps at the limit', () => {
+    const events = recentEventsFor(mkConnector(), mkGate(), 1)
+    expect(events.map(e => e.seq)).toEqual([3])
+    const all = recentEventsFor(mkConnector(), mkGate())
+    expect(all.map(e => e.seq)).toEqual([3, 1])
+  })
+})
+
+describe('ConnectorFlowSection render', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    document.body.removeChild(container)
+  })
+
+  it('renders stats, binding rows, events, and audit history', () => {
+    render(
+      html`<${ConnectorFlowSection} connector=${mkConnector()} gate=${mkGate()} />`,
+      container,
+    )
+    const section = container.querySelector('[data-connector-flow="discord"]')!
+    expect(section).toBeTruthy()
+    expect(section.querySelector('[data-flow-stats]')?.textContent).toContain('12')
+    expect(section.querySelector('[data-flow-bindings]')?.textContent).toContain('sangsu')
+    expect(section.querySelector('[data-flow-bindings]')?.textContent).not.toContain('luna')
+    expect(section.querySelector('[data-flow-events]')?.textContent).toContain('keeper_error')
+    expect(section.querySelector('[data-flow-audit]')?.textContent).toContain('bind')
+    expect(section.querySelector('[data-flow-audit]')?.textContent).toContain('149325')
+  })
+
+  it('renders nothing when there is no flow data at all', () => {
+    const connector = mkConnector({ recent_audit: [] })
+    const gate = mkGate({ channels: [], bindings: [], recent_events: [] })
+    render(
+      html`<${ConnectorFlowSection} connector=${connector} gate=${gate} />`,
+      container,
+    )
+    expect(container.querySelector('[data-connector-flow]')).toBeNull()
+  })
+
+  it('shows the empty-stats message when only audit history exists', () => {
+    const gate = mkGate({ channels: [], bindings: [], recent_events: [] })
+    render(
+      html`<${ConnectorFlowSection} connector=${mkConnector()} gate=${gate} />`,
+      container,
+    )
+    const section = container.querySelector('[data-connector-flow="discord"]')!
+    expect(section.querySelector('[data-flow-empty]')).toBeTruthy()
+    expect(section.querySelector('[data-flow-audit]')).toBeTruthy()
+  })
+})

--- a/dashboard/src/components/connector-flow.ts
+++ b/dashboard/src/components/connector-flow.ts
@@ -1,0 +1,191 @@
+// ConnectorFlowSection — message-flow monitoring for a connector card.
+//
+// Everything rendered here was ALREADY fetched by the connector page
+// (GET /api/v1/gate/status channels/bindings/recent_events + the
+// connector's recent_audit) and silently dropped before render. This
+// section surfaces it: inbound counts and success rate, per-keeper
+// binding traffic, the latest gate events, and the binding-change
+// audit trail. No new endpoint, no polling of its own.
+
+import { html } from 'htm/preact'
+import type {
+  BindingInfo,
+  ChannelInfo,
+  DiscordAuditEntry,
+  GateConnectorInfo,
+  GateEventInfo,
+  GateStatusData,
+} from '../api/gate'
+import { formatTimeAgoEn } from '../lib/format-time'
+import { SurfaceCard } from './common/card'
+
+const MAX_EVENT_ROWS = 5
+const MAX_AUDIT_ROWS = 5
+
+/** Pure: the aggregated channel stats for a connector. Prefers the
+    connector's own observed_channel aggregation; falls back to the
+    matching row in the gate status channel list. */
+export function channelStatsFor(
+  connector: GateConnectorInfo | null,
+  gate: GateStatusData | null,
+): ChannelInfo | null {
+  if (connector?.observed_channel) return connector.observed_channel
+  const channel = connector?.channel ?? ''
+  if (!channel || !gate) return null
+  return gate.channels.find(c => c.channel === channel) ?? null
+}
+
+/** Pure: per-keeper binding traffic rows for this connector's channel. */
+export function bindingRowsFor(
+  connector: GateConnectorInfo | null,
+  gate: GateStatusData | null,
+): BindingInfo[] {
+  const channel = connector?.channel ?? ''
+  if (!channel || !gate) return []
+  return gate.bindings.filter(b => b.channel === channel)
+}
+
+/** Pure: latest gate events for this connector's channel, newest first. */
+export function recentEventsFor(
+  connector: GateConnectorInfo | null,
+  gate: GateStatusData | null,
+  limit = MAX_EVENT_ROWS,
+): GateEventInfo[] {
+  const channel = connector?.channel ?? ''
+  if (!channel || !gate) return []
+  return gate.recent_events
+    .filter(e => e.channel === channel)
+    .slice()
+    .sort((a, b) => b.seq - a.seq)
+    .slice(0, limit)
+}
+
+function outcomeTone(outcome: string): string {
+  if (outcome === 'success') return 'text-emerald-400'
+  if (outcome === 'duplicate') return 'text-[var(--color-fg-disabled)]'
+  return 'text-[var(--color-status-warn)]'
+}
+
+function StatChip({ label, value }: { label: string; value: string }) {
+  return html`
+    <span class="inline-flex items-baseline gap-1 whitespace-nowrap">
+      <span class="text-3xs uppercase tracking-4 text-[var(--color-fg-disabled)]">${label}</span>
+      <span class="font-mono text-2xs text-[var(--color-fg-primary)]">${value}</span>
+    </span>
+  `
+}
+
+export function ConnectorFlowSection({ connector, gate }: {
+  connector: GateConnectorInfo | null
+  gate: GateStatusData | null
+}) {
+  const stats = channelStatsFor(connector, gate)
+  const bindingRows = bindingRowsFor(connector, gate)
+  const events = recentEventsFor(connector, gate)
+  const audit = (connector?.recent_audit ?? []).slice(0, MAX_AUDIT_ROWS)
+
+  if (!stats && bindingRows.length === 0 && events.length === 0 && audit.length === 0) {
+    return null
+  }
+
+  return html`
+    <${SurfaceCard}
+      class="mt-3 !bg-[var(--color-bg-elevated)] !px-3 !py-2.5 text-2xs"
+      data-connector-flow=${connector?.connector_id ?? ''}
+    >
+      <div class="mb-1.5 text-3xs font-semibold uppercase tracking-4 text-[var(--color-fg-disabled)]">
+        메시지 흐름
+      </div>
+
+      ${stats
+        ? html`
+            <div class="flex flex-wrap items-center gap-x-3 gap-y-1" data-flow-stats>
+              <${StatChip} label="in" value=${String(stats.message_count)} />
+              <${StatChip} label="ok" value=${`${stats.success_count} (${stats.success_rate_pct}%)`} />
+              <${StatChip} label="err" value=${String(stats.error_count)} />
+              <${StatChip} label="dup" value=${String(stats.duplicate_count)} />
+              ${stats.avg_duration_ms > 0
+                ? html`<${StatChip} label="avg" value=${`${Math.round(stats.avg_duration_ms)}ms`} />`
+                : null}
+              ${stats.last_activity
+                ? html`<${StatChip} label="last" value=${formatTimeAgoEn(stats.last_activity)} />`
+                : null}
+            </div>
+          `
+        : html`
+            <div class="text-[var(--color-fg-disabled)]" data-flow-empty>
+              아직 게이트로 들어온 메시지가 없습니다.
+            </div>
+          `}
+
+      ${bindingRows.length > 0
+        ? html`
+            <div class="mt-2 space-y-0.5" data-flow-bindings>
+              ${bindingRows.map(row => html`
+                <div class="flex flex-wrap items-center gap-x-2 text-2xs">
+                  <span class="font-mono text-[var(--color-fg-primary)]">${row.keeper}</span>
+                  <span class="text-[var(--color-fg-disabled)]">←</span>
+                  <span class="font-mono text-3xs text-[var(--color-fg-disabled)]" title=${row.workspace_id}>
+                    ${row.workspace_id}
+                  </span>
+                  <span class="text-3xs text-[var(--color-fg-disabled)]">
+                    in ${row.message_count} · ok ${row.success_count} · err ${row.error_count}
+                  </span>
+                  ${row.last_activity
+                    ? html`<span class="text-3xs text-[var(--color-fg-disabled)]">· ${formatTimeAgoEn(row.last_activity)}</span>`
+                    : null}
+                </div>
+              `)}
+            </div>
+          `
+        : null}
+
+      ${events.length > 0
+        ? html`
+            <div class="mt-2" data-flow-events>
+              <div class="text-3xs uppercase tracking-4 text-[var(--color-fg-disabled)]">최근 이벤트</div>
+              <div class="mt-0.5 space-y-0.5">
+                ${events.map(ev => html`
+                  <div class="flex flex-wrap items-center gap-x-2 font-mono text-3xs">
+                    <span class="text-[var(--color-fg-disabled)]">${formatTimeAgoEn(ev.timestamp)}</span>
+                    <span class="text-[var(--color-fg-primary)]">${ev.keeper}</span>
+                    <span class=${outcomeTone(ev.outcome)}>${ev.outcome}</span>
+                    ${ev.duration_ms > 0
+                      ? html`<span class="text-[var(--color-fg-disabled)]">${Math.round(ev.duration_ms)}ms</span>`
+                      : null}
+                    ${ev.error
+                      ? html`<span class="min-w-0 truncate text-[var(--color-status-warn)]" title=${ev.error}>${ev.error}</span>`
+                      : null}
+                  </div>
+                `)}
+              </div>
+            </div>
+          `
+        : null}
+
+      ${audit.length > 0
+        ? html`
+            <div class="mt-2" data-flow-audit>
+              <div class="text-3xs uppercase tracking-4 text-[var(--color-fg-disabled)]">바인딩 변경 이력</div>
+              <div class="mt-0.5 space-y-0.5">
+                ${audit.map((entry: DiscordAuditEntry) => html`
+                  <div class="flex flex-wrap items-center gap-x-2 font-mono text-3xs">
+                    <span class="text-[var(--color-fg-disabled)]">${formatTimeAgoEn(entry.timestamp)}</span>
+                    <span class=${entry.action === 'unbind' ? 'text-[var(--color-status-warn)]' : 'text-emerald-400'}>
+                      ${entry.action}
+                    </span>
+                    <span class="text-[var(--color-fg-disabled)]" title=${entry.channel_id}>${entry.channel_id}</span>
+                    <span class="text-[var(--color-fg-disabled)]">→</span>
+                    <span class="text-[var(--color-fg-primary)]">${entry.keeper_name}</span>
+                    ${entry.previous_keeper
+                      ? html`<span class="text-[var(--color-fg-disabled)]">(was ${entry.previous_keeper})</span>`
+                      : null}
+                  </div>
+                `)}
+              </div>
+            </div>
+          `
+        : null}
+    <//>
+  `
+}

--- a/dashboard/src/components/connector-status.test.ts
+++ b/dashboard/src/components/connector-status.test.ts
@@ -505,6 +505,86 @@ describe('ConnectorStatusPanel', () => {
     expect(text).not.toContain('disconnected')
   })
 
+  it('shows the gateway machine-state chip when it adds info beyond the coarse label', async () => {
+    const fetchGateStatus = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleGateResponse())
+    const fetchGateConnectors = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleConnectorsResponse({
+      connectors: [{
+        ...sampleConnectorsResponse().connectors[0],
+        connected: false,
+        status: 'disconnected',
+        gateway_state: 'reconnect_pending',
+        status_source: 'in_process_gateway',
+      }],
+    }))
+    const fetchGateKeepers = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleKeepersResponse())
+
+    const { ConnectorStatusPanel } = await loadComponentWithApi({
+      fetchGateStatus,
+      fetchGateConnectors,
+      fetchGateKeepers,
+      lastEvent: signal(null),
+    })
+
+    render(html`<${ConnectorStatusPanel} />`, container)
+    await flushUi()
+
+    const chip = container.querySelector('[data-gateway-state-chip]') as HTMLElement | null
+    expect(chip).not.toBeNull()
+    expect(chip!.textContent).toContain('reconnect_pending')
+  })
+
+  it('hides the gateway chip when the machine state merely repeats the coarse label', async () => {
+    const fetchGateStatus = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleGateResponse())
+    const fetchGateConnectors = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleConnectorsResponse({
+      connectors: [{
+        ...sampleConnectorsResponse().connectors[0],
+        connected: true,
+        status: 'connected',
+        gateway_state: 'connected',
+        status_source: 'in_process_gateway',
+      }],
+    }))
+    const fetchGateKeepers = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleKeepersResponse())
+
+    const { ConnectorStatusPanel } = await loadComponentWithApi({
+      fetchGateStatus,
+      fetchGateConnectors,
+      fetchGateKeepers,
+      lastEvent: signal(null),
+    })
+
+    render(html`<${ConnectorStatusPanel} />`, container)
+    await flushUi()
+
+    expect(container.querySelector('[data-gateway-state-chip]')).toBeNull()
+  })
+
+  it('mounts the message-flow section fed by gate status data', async () => {
+    const fetchGateStatus = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleGateResponse())
+    const fetchGateConnectors = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleConnectorsResponse())
+    const fetchGateKeepers = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleKeepersResponse())
+
+    const { ConnectorStatusPanel } = await loadComponentWithApi({
+      fetchGateStatus,
+      fetchGateConnectors,
+      fetchGateKeepers,
+      lastEvent: signal(null),
+    })
+
+    render(html`<${ConnectorStatusPanel} />`, container)
+    await flushUi()
+
+    const flow = container.querySelector('[data-connector-flow="discord"]') as HTMLElement | null
+    expect(flow).not.toBeNull()
+    // Channel aggregate from sampleGateResponse: 12 in / 10 ok.
+    expect(flow!.querySelector('[data-flow-stats]')?.textContent).toContain('12')
+    // Per-keeper binding traffic row.
+    expect(flow!.querySelector('[data-flow-bindings]')?.textContent).toContain('luna')
+    // Recent gate event + binding audit history.
+    expect(flow!.querySelector('[data-flow-events]')?.textContent).toContain('keeper_error')
+    expect(flow!.querySelector('[data-flow-audit]')?.textContent).toContain('bind')
+  })
+
   it('renders iMessage reply mode metadata when advertised by the runtime', async () => {
     const fetchGateStatus = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleGateResponse())
     const fetchGateConnectors = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleConnectorsResponse({

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -38,6 +38,7 @@ import { ConnectorReadinessRail, deriveRail, getRailInflight, withRailInflight }
 import { StartupCheckBanner, markStartAttempt, clearStartAttempt } from './sidecar-startup-watch'
 import { showConnectorActionError } from './connector-action-error'
 import { QuickBindForm } from './connector-quick-bind'
+import { ConnectorFlowSection } from './connector-flow'
 import { ConnectorOverviewStrip } from './connector-overview-strip'
 import { ConnectorKeeperMatrix, deriveMatrix } from './connector-keeper-matrix'
 import { ConnectorPathsStrip } from './connector-paths-strip'
@@ -495,6 +496,8 @@ function placeholderConnector(connectorId: KnownConnectorId): GateConnectorInfo 
     connected: false,
     stale: false,
     stale_after_sec: 0,
+    gateway_state: '',
+    status_source: '',
     error: '',
     status_path: '',
     binding_store_path: '',
@@ -668,6 +671,11 @@ function ConnectorLivePanel({
   const bindingActionsEnabled = connector != null && connector.capabilities.includes('bindings')
   const directLabel = connectorStateLabel(connector)
   const directTone = connectorStateTone(connector)
+  // In-process gateway machine state (RFC-0203 / #20813). Shown only
+  // when the connector advertises it AND it adds information beyond
+  // the coarse 4-word label (reconnect_pending, identifying, failed...).
+  const gatewayState = connector?.gateway_state ?? ''
+  const showGatewayChip = gatewayState !== '' && gatewayState !== directLabel
 
   let gateHealthLabel = 'unknown'
   if (connector?.gate_healthy === true) {
@@ -815,6 +823,9 @@ function ConnectorLivePanel({
           <span class=${`inline-block h-2 w-2 rounded-full ${dotClassForLabel(directLabel)}`}></span>
           <span>${directLabel}</span>
         </span>
+        ${showGatewayChip
+          ? html`<span class="text-3xs lowercase text-[var(--color-fg-disabled)]" data-gateway-state-chip>gw ${gatewayState}</span>`
+          : null}
         <${MutedSpan}><span aria-hidden="true">· </span>hb ${timeAgo(connector?.updated_at ?? '')}</${MutedSpan}>
         ${connector?.reply_mode
           ? html`<${MutedSpan}><span aria-hidden="true">· </span>reply ${connector.reply_mode}</${MutedSpan}>`
@@ -887,6 +898,8 @@ function ConnectorLivePanel({
       ${connector?.available === true && keepers.length > 0
         ? html`<${QuickBindForm} connectorId=${connectorId} keepers=${keepers} />`
         : null}
+
+      <${ConnectorFlowSection} connector=${connector} gate=${gate} />
 
       ${ui.headerExpanded
         ? html`

--- a/lib/gate/channel_gate_discord_state.ml
+++ b/lib/gate/channel_gate_discord_state.ml
@@ -220,6 +220,8 @@ let record_ready ~bot_user_id =
     (Some
        {
          ready_bot_user_id = bot_user_id;
+         (* NDT-OK: READY wall-clock is operator-facing telemetry only
+            (status_json last_ready_at); no control flow reads it. *)
          ready_at = Gate_time_util.iso8601_of_unix (Unix.gettimeofday ());
        })
 

--- a/lib/gate/channel_gate_discord_state.ml
+++ b/lib/gate/channel_gate_discord_state.ml
@@ -205,6 +205,24 @@ let gateway_state_label = function
   | Reconnect_pending _ -> "reconnect_pending"
   | Failed _ -> "failed"
 
+(* Bot identity captured from the gateway's READY dispatch. The legacy
+   sidecar wrote this to status.json; the in-process gateway (RFC-0203)
+   keeps it in memory — nothing writes that file anymore. *)
+type ready_info = {
+  ready_bot_user_id : string;
+  ready_at : string;
+}
+
+let last_ready : ready_info option Atomic.t = Atomic.make None
+
+let record_ready ~bot_user_id =
+  Atomic.set last_ready
+    (Some
+       {
+         ready_bot_user_id = bot_user_id;
+         ready_at = Gate_time_util.iso8601_of_unix (Unix.gettimeofday ());
+       })
+
 let status_json ?(audit_limit = 10) () =
   let status_path = status_path () in
   let binding_store_path = binding_store_read_path () in
@@ -257,9 +275,23 @@ let status_json ?(audit_limit = 10) () =
       ("names_path", `String names_path);
       ("names", Names.to_json name_map);
       ("updated_at", `String updated_at);
-      ("last_ready_at", `String (if connected then updated_at else ""));
+      ( "last_ready_at",
+        (* The READY timestamp survives reconnect_pending/resuming dips,
+           so operators can tell "was up, recovering" from "never came
+           up" — current liveness is gateway_state above. *)
+        `String
+          (match Atomic.get last_ready with
+           | Some { ready_at; _ } -> ready_at
+           | None -> "") );
+      (* READY carries only the bot user id; the gateway does not parse
+         the username. Empty is honest — the dead sidecar file used to
+         supply a stale value here. *)
       ("bot_user_name", `String "");
-      ("bot_user_id", `String "");
+      ( "bot_user_id",
+        `String
+          (match Atomic.get last_ready with
+           | Some { ready_bot_user_id; _ } -> ready_bot_user_id
+           | None -> "") );
       ("guild_count", `Int 0);
       ("gate_base_url", `String "in-process");
       ("gate_healthy", if connected then `Bool true else `Null);

--- a/lib/gate/channel_gate_discord_state.mli
+++ b/lib/gate/channel_gate_discord_state.mli
@@ -83,6 +83,12 @@ val connected : unit -> bool
     [Connected]. Reads {!Discord_gateway_client.connection_state};
     no file indirection. RFC-0223 P2 presence. *)
 
+val record_ready : bot_user_id:string -> unit
+(** Called by the in-process gateway's READY handler. Stores the bot
+    identity and timestamp that {!status_json} reports as
+    [bot_user_id] / [last_ready_at]. Atomic write — safe to call from
+    the gateway fiber while HTTP handlers read. *)
+
 (** Typed failure modes for {!send_message}. Closed sum — adding
     a new variant forces every consumer to handle it. *)
 type send_error =

--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -98,6 +98,7 @@ let handle_message_create ~dispatch
 let on_event ~dispatch (ev : Gw.gateway_event) =
   match ev with
   | Gw.Ready { bot_user_id; _ } ->
+    State.record_ready ~bot_user_id;
     Log.Server.info "Discord gateway READY (bot_user_id=%s)" bot_user_id
   | Gw.Message_create
       { channel_id; message_id; author_id; author_name; content;

--- a/test/test_channel_gate_discord_state.ml
+++ b/test/test_channel_gate_discord_state.ml
@@ -95,6 +95,24 @@ let test_status_json_ignores_legacy_sidecar_status_file () =
     check int "runtime bindings from persisted bindings" 0
       (json |> U.member "runtime_bindings_count" |> U.to_int)))
 
+(* record_ready ordering: this test runs in the same process as the
+   blank-identity assertions above, so it must come after them in the
+   suite — last_ready is module-global and has no reset (production
+   never clears it; a fresh READY only overwrites). *)
+let test_record_ready_surfaces_bot_identity () =
+  with_temp_dir @@ fun dir ->
+  with_discord_paths dir (fun () ->
+  with_env "DISCORD_BOT_TOKEN" None (fun () ->
+    Discord_state.record_ready ~bot_user_id:"bot-42";
+    let json = Discord_state.status_json () in
+    check string "bot_user_id from READY" "bot-42"
+      (json |> U.member "bot_user_id" |> U.to_string);
+    check bool "last_ready_at non-empty" true
+      (String.length (json |> U.member "last_ready_at" |> U.to_string) > 0);
+    (* Identity is observation, not liveness: gateway is still down. *)
+    check bool "connected stays false" false
+      (json |> U.member "connected" |> U.to_bool)))
+
 let test_bind_persists_binding_and_audit () =
   with_temp_dir @@ fun dir ->
   with_discord_paths dir (fun () ->
@@ -278,6 +296,8 @@ let () =
             test_status_json_reports_in_process_gateway_status;
           test_case "ignores legacy sidecar status file" `Quick
             test_status_json_ignores_legacy_sidecar_status_file;
+          test_case "record_ready surfaces bot identity" `Quick
+            test_record_ready_surfaces_bot_identity;
           test_case "bind persists binding and audit" `Quick
             test_bind_persists_binding_and_audit;
           test_case "unbind removes binding" `Quick


### PR DESCRIPTION
## 무엇

"대시보드에서 Keeper의 Discord 설정 + 모니터링" 중 **모니터링** 절반. #20813(status_json → typed gateway state 전환) 위에 얹는 3개 조각, 신규 엔드포인트 없음.

## 변경

### 1. `record_ready` — READY 봇 정체성 캡처 (OCaml)
#20813은 `bot_user_id: ""` 고정 + `last_ready_at`을 현재시각으로 대용했습니다. 이제 게이트웨이 READY 핸들러가 `bot_user_id`와 READY 시각을 인메모리(Atomic)로 저장하고 status_json이 보고합니다. READY 시각은 reconnect dip을 살아남아 "올라왔다가 복구 중"과 "한 번도 안 올라옴"을 구분할 수 있습니다.

### 2. `gateway_state` 대시보드 파싱 + 헤더 칩
서버는 #20813부터 `gateway_state`/`status_source`를 보내는데 대시보드 스키마에 없어 버려지고 있었습니다. 파싱 추가 + coarse 라벨(offline/stale/connected/disconnected)보다 정보가 많을 때만(`identifying`, `reconnect_pending`, `failed`...) 헤더에 `gw <state>` 칩 표시. 중복 표기는 숨김.

### 3. `ConnectorFlowSection` — 메시지 흐름
페이지가 이미 fetch하고 렌더 전에 버리던 데이터를 표면화:
- 채널 집계: in / ok(성공률) / err / dup / avg / last
- Keeper별 바인딩 트래픽 (`sangsu ← 1493… in 9 · ok 8 · err 1`)
- 최근 게이트 이벤트 5건 (outcome 색상, duration, 에러)
- 바인딩 변경 감사 이력 5건 (bind/unbind, 이전 keeper)

데이터 전무 시 렌더 안 함. 흐름 fixture는 production boundary parser(`parseGateStatusData`/`parseGateConnectorsData`)를 통과시켜 스키마 drift 불가.

## 검증

- `dune build @check` + `lib/gate lib/server` default target clean
- `test_channel_gate_discord_state` 11/11 (record_ready 케이스 추가, 모듈-글로벌 상태라 blank-identity 테스트 뒤 순서 고정 — 주석 명시)
- dashboard: tsc 0 errors / vitest **6514/6514** / eslint 0 errors
- 칩 회귀 2건(정보 추가 시 표시, 중복 시 숨김) + 흐름 마운트 1건 + connector-flow 단위 7건

## 남은 절반 (설정 — 별도 PR)

트리거 정책(`MASC_DISCORD_TRIGGER_POLICY`) 대시보드 편집은 RFC-0203 §Non-goals(3종 외 정책 금지)와 충돌하지 않는 형태(3종 선택 UI)로 설계 필요 — env var SSOT를 깨지 않으려면 RFC 1줄 개정이 선행되어야 해서 분리했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
