### PR TITLE
[codex] Centralize keeper provider timeout classification

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -94,6 +94,7 @@
   keeper_agent_run_sidecar
   keeper_agent_run_finalize_response
   keeper_agent_result
+  keeper_provider_runtime_boundary
   keeper_agent_error
   keeper_run_tools_hooks
   keeper_run_tools_search

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -181,31 +181,8 @@ let is_receipt_lost_error (err : Agent_sdk.Error.sdk_error) : bool =
   | Agent_sdk.Error.Io _ -> false
   | Agent_sdk.Error.Orchestration _ -> false
 
-(** Provider-level timeout (not structural OAS wall-clock budget). *)
 let is_provider_timeout_error (err : Agent_sdk.Error.sdk_error) : bool =
-  match err with
-  | Agent_sdk.Error.Api (Timeout _) -> true
-  | Agent_sdk.Error.Provider (Llm_provider.Error.Timeout _) -> true
-  (* Not a provider-level timeout. *)
-  | Agent_sdk.Error.Api (NetworkError _ | Overloaded _ | ServerError _
-    | RateLimited _ | AuthError _ | InvalidRequest _ | NotFound _
-    | ContextOverflow _) -> false
-  | Agent_sdk.Error.Provider
-      (Llm_provider.Error.NetworkError _ | Llm_provider.Error.ServerError _
-      | Llm_provider.Error.RateLimit _ | Llm_provider.Error.AuthError _
-      | Llm_provider.Error.MissingApiKey _ | Llm_provider.Error.NotFound _
-      | Llm_provider.Error.CapacityExhausted _ | Llm_provider.Error.HardQuota _
-      | Llm_provider.Error.InvalidRequest _ | Llm_provider.Error.InvalidConfig _
-      | Llm_provider.Error.ParseError _ | Llm_provider.Error.ProviderUnavailable _
-      | Llm_provider.Error.ProviderTerminal _
-      | Llm_provider.Error.UnknownVariant _) -> false
-  | Agent_sdk.Error.Agent _ -> false
-  | Agent_sdk.Error.Mcp _ -> false
-  | Agent_sdk.Error.Config _ -> false
-  | Agent_sdk.Error.Serialization _ -> false
-  | Agent_sdk.Error.Io _ -> false
-  | Agent_sdk.Error.Orchestration _ -> false
-  | Agent_sdk.Error.Internal _ -> false
+  Keeper_provider_runtime_boundary.is_provider_timeout_error err
 
 (* 524 is Cloudflare's "origin responded too slowly" timeout. At keeper
    orchestration level this means the current provider lane is saturated or
@@ -632,14 +609,17 @@ let is_auto_recoverable_turn_error (err : Agent_sdk.Error.sdk_error) : bool =
   || is_auto_recoverable_runtime_exhausted_error err
 
 let should_warn_keeper_cycle_failed (err : Agent_sdk.Error.sdk_error) : bool =
-  match Keeper_turn_driver.classify_masc_internal_error err with
-  | Some (Keeper_turn_driver.Provider_timeout _) -> true
+  if Keeper_provider_runtime_boundary.is_provider_timeout_error err
+  then true
+  else
+    match Keeper_turn_driver.classify_masc_internal_error err with
   | Some (Keeper_turn_driver.Capacity_backpressure _) -> true
   | Some (Keeper_turn_driver.Runtime_exhausted _)
   | Some (Keeper_turn_driver.Resumable_cli_session _)
   | Some (Keeper_turn_driver.Accept_rejected _)
   | Some (Keeper_turn_driver.Admission_queue_timeout _)
   | Some (Keeper_turn_driver.Admission_queue_rejected _)
+  | Some (Keeper_turn_driver.Provider_timeout _)
   | Some (Keeper_turn_driver.Turn_timeout _)
   | Some (Keeper_turn_driver.Max_tokens_ceiling_violation _)
   | Some (Keeper_turn_driver.Ambiguous_post_commit _)

--- a/lib/keeper/keeper_heartbeat_loop_observations.ml
+++ b/lib/keeper/keeper_heartbeat_loop_observations.ml
@@ -93,31 +93,7 @@ let prior_provider_timeout_strikes ~base_path ~keeper_name =
 ;;
 
 let is_provider_timeout_error (err : Agent_sdk.Error.sdk_error) =
-  (* Enumerate every [masc_internal_error] variant + [None] so the
-     compiler flags any new constructor here. Mirrors the fix in
-     [degraded_retry_bypasses_slot_phase_guard] (PR #14716) and
-     [runtime_permanently_dead] (PR #14762); this site was missed in
-     both sweeps — the same predicate shape exists in three places
-     and only this one still had a catch-all. *)
-  match Keeper_turn_driver.classify_masc_internal_error err with
-  | Some (Keeper_turn_driver.Provider_timeout _) -> true
-  | Some
-      ( Keeper_turn_driver.Runtime_exhausted _
-      | Keeper_turn_driver.Capacity_backpressure _
-      | Keeper_turn_driver.Resumable_cli_session _
-
-      | Keeper_turn_driver.Accept_rejected _
-      | Keeper_turn_driver.Admission_queue_timeout _
-      | Keeper_turn_driver.Admission_queue_rejected _
-      | Keeper_turn_driver.Turn_timeout _
-      | Keeper_turn_driver.Max_tokens_ceiling_violation _
-      | Keeper_turn_driver.Ambiguous_post_commit _
-      (* RFC-0159 Phase A: Internal_* variants are not OAS-budget timeouts. *)
-      | Keeper_turn_driver.Internal_unhandled_exception _
-      | Keeper_turn_driver.Internal_bridge_exception _
-      | Keeper_turn_driver.Internal_contract_rejected _ )
-  | None ->
-    false
+  Keeper_provider_runtime_boundary.is_provider_timeout_error err
 ;;
 
 let timeout_phase_of_provider_timeout_phase phase =
@@ -134,33 +110,11 @@ let provider_timeout_policy_decision
       ~(strikes : int)
       (err : Agent_sdk.Error.sdk_error)
   : Keeper_failure_policy.decision option
-  =
-  match Keeper_turn_driver.classify_masc_internal_error err with
-  | Some (Keeper_turn_driver.Provider_timeout { phase; _ }) ->
-    Some
-      (Keeper_failure_policy.decide
-         (Keeper_failure_policy.Provider_timeout
-            { phase = timeout_phase_of_provider_timeout_phase phase
-            ; strikes = Some strikes
-            ; liveness = Keeper_failure_policy.Recent_heartbeat
-            }))
-  | Some
-      ( Keeper_turn_driver.Runtime_exhausted _
-      | Keeper_turn_driver.Capacity_backpressure _
-      | Keeper_turn_driver.Resumable_cli_session _
-
-      | Keeper_turn_driver.Accept_rejected _
-      | Keeper_turn_driver.Admission_queue_timeout _
-      | Keeper_turn_driver.Admission_queue_rejected _
-      | Keeper_turn_driver.Turn_timeout _
-      | Keeper_turn_driver.Max_tokens_ceiling_violation _
-      | Keeper_turn_driver.Ambiguous_post_commit _
-      (* RFC-0159 Phase A: Internal_* variants are not OAS-budget timeouts. *)
-      | Keeper_turn_driver.Internal_unhandled_exception _
-      | Keeper_turn_driver.Internal_bridge_exception _
-      | Keeper_turn_driver.Internal_contract_rejected _ )
-  | None ->
-    None
+=
+  Keeper_provider_runtime_boundary.provider_timeout_policy_decision
+    ~strikes
+    ~liveness:Keeper_failure_policy.Recent_heartbeat
+    err
 ;;
 
 let provider_timeout_metric_outcome

--- a/lib/keeper/keeper_provider_runtime_boundary.ml
+++ b/lib/keeper/keeper_provider_runtime_boundary.ml
@@ -1,0 +1,127 @@
+(** Provider/runtime failure boundary for SDK errors crossing from OAS into
+    keeper policy. *)
+
+type timeout_source =
+  | Oas_api
+  | Oas_provider
+  | Masc_internal
+
+type provider_timeout =
+  { phase : Keeper_failure_policy.timeout_phase option
+  ; source : timeout_source
+  }
+
+type t =
+  | Provider_timeout of provider_timeout
+  | Not_provider_runtime_failure
+
+let timeout_phase_of_label label =
+  Keeper_failure_policy.timeout_phase_of_label label
+;;
+
+let timeout_phase_of_oas_phase phase =
+  Llm_provider.Http_client.timeout_phase_to_label phase
+  |> timeout_phase_of_label
+;;
+
+let timeout_phase_of_masc_internal_phase phase =
+  let phase = String.trim phase in
+  if String.equal phase "" then None else timeout_phase_of_label phase
+;;
+
+let provider_timeout ~source ~phase =
+  Provider_timeout { source; phase }
+;;
+
+let classify_masc_internal_error = function
+  | Some (Keeper_internal_error.Provider_timeout { phase; _ }) ->
+    provider_timeout
+      ~source:Masc_internal
+      ~phase:(timeout_phase_of_masc_internal_phase phase)
+  | Some
+      ( Keeper_internal_error.Runtime_exhausted _
+      | Keeper_internal_error.Capacity_backpressure _
+      | Keeper_internal_error.Resumable_cli_session _
+      | Keeper_internal_error.Accept_rejected _
+      | Keeper_internal_error.Admission_queue_timeout _
+      | Keeper_internal_error.Admission_queue_rejected _
+      | Keeper_internal_error.Turn_timeout _
+      | Keeper_internal_error.Max_tokens_ceiling_violation _
+      | Keeper_internal_error.Ambiguous_post_commit _
+      | Keeper_internal_error.Internal_unhandled_exception _
+      | Keeper_internal_error.Internal_bridge_exception _
+      | Keeper_internal_error.Internal_contract_rejected _ )
+  | None ->
+    Not_provider_runtime_failure
+;;
+
+let classify_provider_error = function
+  | Llm_provider.Error.Timeout { timeout_phase; _ } ->
+    provider_timeout
+      ~source:Oas_provider
+      ~phase:(Option.bind timeout_phase timeout_phase_of_oas_phase)
+  | Llm_provider.Error.NetworkError { timeout_phase = Some phase; _ } ->
+    provider_timeout
+      ~source:Oas_provider
+      ~phase:(timeout_phase_of_oas_phase phase)
+  | Llm_provider.Error.MissingApiKey _
+  | Llm_provider.Error.InvalidConfig _
+  | Llm_provider.Error.ParseError _
+  | Llm_provider.Error.UnknownVariant _
+  | Llm_provider.Error.ProviderUnavailable _
+  | Llm_provider.Error.RateLimit _
+  | Llm_provider.Error.HardQuota _
+  | Llm_provider.Error.CapacityExhausted _
+  | Llm_provider.Error.AuthError _
+  | Llm_provider.Error.ServerError _
+  | Llm_provider.Error.NetworkError _
+  | Llm_provider.Error.InvalidRequest _
+  | Llm_provider.Error.NotFound _
+  | Llm_provider.Error.ProviderTerminal _ ->
+    Not_provider_runtime_failure
+;;
+
+let classify_sdk_error (err : Agent_sdk.Error.sdk_error) : t =
+  match Keeper_internal_error.classify_masc_internal_error err with
+  | Some _ as internal_error -> classify_masc_internal_error internal_error
+  | None ->
+    (match err with
+     | Agent_sdk.Error.Api (Timeout _) ->
+       provider_timeout ~source:Oas_api ~phase:None
+     | Agent_sdk.Error.Provider provider_error ->
+       classify_provider_error provider_error
+     | Agent_sdk.Error.Api (NetworkError _ | Overloaded _ | ServerError _
+       | RateLimited _ | AuthError _ | InvalidRequest _ | NotFound _
+       | ContextOverflow _)
+     | Agent_sdk.Error.Agent _
+     | Agent_sdk.Error.Mcp _
+     | Agent_sdk.Error.Config _
+     | Agent_sdk.Error.Serialization _
+     | Agent_sdk.Error.Io _
+     | Agent_sdk.Error.Orchestration _
+     | Agent_sdk.Error.Internal _ ->
+       Not_provider_runtime_failure)
+;;
+
+let is_provider_timeout = function
+  | Provider_timeout _ -> true
+  | Not_provider_runtime_failure -> false
+;;
+
+let is_provider_timeout_error err =
+  classify_sdk_error err |> is_provider_timeout
+;;
+
+let provider_timeout_failure ~strikes ~liveness (timeout : provider_timeout) =
+  Keeper_failure_policy.Provider_timeout
+    { phase = timeout.phase; strikes; liveness }
+;;
+
+let provider_timeout_policy_decision ~strikes ~liveness err =
+  match classify_sdk_error err with
+  | Provider_timeout timeout ->
+    Some
+      (Keeper_failure_policy.decide
+         (provider_timeout_failure ~strikes:(Some strikes) ~liveness timeout))
+  | Not_provider_runtime_failure -> None
+;;

--- a/lib/keeper/keeper_provider_runtime_boundary.mli
+++ b/lib/keeper/keeper_provider_runtime_boundary.mli
@@ -1,0 +1,36 @@
+(** Provider/runtime failure boundary for SDK errors crossing from OAS into
+    keeper policy.
+
+    This module deliberately does not classify keeper tool invocation or task
+    workflow rejections. Those are MASC domain outcomes, not provider/runtime
+    failures. *)
+
+type timeout_source =
+  | Oas_api
+  | Oas_provider
+  | Masc_internal
+
+type provider_timeout =
+  { phase : Keeper_failure_policy.timeout_phase option
+  ; source : timeout_source
+  }
+
+type t =
+  | Provider_timeout of provider_timeout
+  | Not_provider_runtime_failure
+
+val classify_sdk_error : Agent_sdk.Error.sdk_error -> t
+val is_provider_timeout : t -> bool
+val is_provider_timeout_error : Agent_sdk.Error.sdk_error -> bool
+
+val provider_timeout_failure
+  :  strikes:int option
+  -> liveness:Keeper_failure_policy.liveness_evidence
+  -> provider_timeout
+  -> Keeper_failure_policy.failure
+
+val provider_timeout_policy_decision
+  :  strikes:int
+  -> liveness:Keeper_failure_policy.liveness_evidence
+  -> Agent_sdk.Error.sdk_error
+  -> Keeper_failure_policy.decision option

--- a/test/stanzas/test_oas_timeout_budget_strike.inc
+++ b/test/stanzas/test_oas_timeout_budget_strike.inc
@@ -1,4 +1,4 @@
 (test
  (name test_oas_timeout_budget_strike)
  (modules test_oas_timeout_budget_strike)
- (libraries masc masc.keeper_failure_policy masc.keeper_runtime alcotest eio eio_main agent_sdk))
+ (libraries masc masc.keeper_failure_policy masc.keeper_runtime alcotest eio eio_main agent_sdk agent_sdk.llm_provider))

--- a/test/test_oas_timeout_budget_strike.ml
+++ b/test/test_oas_timeout_budget_strike.ml
@@ -71,6 +71,18 @@ let provider_timeout_error ~phase =
        ; phase
        })
 
+let raw_provider_timeout_error ~phase =
+  Agent_sdk.Error.Provider
+    (Llm_provider.Error.Timeout
+       { provider = "test_provider"
+       ; timeout_phase = phase
+       ; detail = "provider timeout"
+       })
+
+let raw_api_timeout_error () =
+  Agent_sdk.Error.Api
+    (Llm_provider.Retry.Timeout { message = "Per-provider timeout after 90.0s" })
+
 let turn_timeout_error () =
   KTD.sdk_error_of_masc_internal_error (KTD.Turn_timeout { elapsed_sec = 600.0 })
 
@@ -106,6 +118,47 @@ let test_cycle_failed_log_level_is_policy_aware () =
     false
     (EC.should_warn_keeper_cycle_failed (turn_timeout_error ()))
 
+let test_raw_oas_provider_timeout_uses_same_policy () =
+  let err =
+    raw_provider_timeout_error
+      ~phase:
+        (Some
+           (Llm_provider.Http_client.Stream_idle
+              Llm_provider.Http_client.Streaming_thinking))
+  in
+  Alcotest.(check bool)
+    "raw provider timeout is a provider timeout"
+    true
+    (EC.is_provider_timeout_error err);
+  Alcotest.(check bool)
+    "raw provider timeout cycle failure is warn"
+    true
+    (EC.should_warn_keeper_cycle_failed err);
+  match
+    KH.provider_timeout_policy_decision
+      ~strikes:KK.provider_timeout_strike_limit
+      err
+  with
+  | None -> Alcotest.fail "expected provider timeout policy decision"
+  | Some decision ->
+    Alcotest.(check string)
+      "reason preserves OAS timeout phase"
+      "provider_timeout_loop:stream_idle:streaming_thinking"
+      decision.reason
+
+let test_raw_oas_api_timeout_uses_same_policy () =
+  let err = raw_api_timeout_error () in
+  Alcotest.(check bool)
+    "raw API timeout is a provider timeout"
+    true
+    (EC.is_provider_timeout_error err);
+  match KH.provider_timeout_policy_decision ~strikes:1 err with
+  | None -> Alcotest.fail "expected provider timeout policy decision"
+  | Some decision ->
+    Alcotest.(check string)
+      "phase-free API timeout keeps generic reason"
+      "provider_timeout"
+      decision.reason
 
 let test_tls_handshake_internal_error_is_transient () =
   let err = tls_handshake_internal_error () in
@@ -305,6 +358,10 @@ let () =
           test_strike_limit_is_soft_backoff;
         Alcotest.test_case "cycle failure log level is policy-aware" `Quick
           test_cycle_failed_log_level_is_policy_aware;
+        Alcotest.test_case "raw OAS provider timeout uses same policy" `Quick
+          test_raw_oas_provider_timeout_uses_same_policy;
+        Alcotest.test_case "raw OAS API timeout uses same policy" `Quick
+          test_raw_oas_api_timeout_uses_same_policy;
         Alcotest.test_case "TLS handshake internal error is transient" `Quick
           test_tls_handshake_internal_error_is_transient;
         Alcotest.test_case


### PR DESCRIPTION
## Summary

- Add a small keeper provider/runtime boundary for classifying provider timeout failures crossing from OAS into MASC keeper policy.
- Route `Keeper_error_classify.is_provider_timeout_error` and heartbeat provider-timeout policy through that boundary.
- Preserve OAS timeout phase evidence for raw provider timeout errors while keeping raw API timeout phase-free.

## Scope

This intentionally does not change task workflow rejection, task FSM, or keeper tool workflow handling. The new boundary only classifies provider/runtime timeout failures.

## Validation

- `ocamlformat --check lib/keeper/keeper_provider_runtime_boundary.ml lib/keeper/keeper_provider_runtime_boundary.mli lib/keeper/keeper_error_classify.ml lib/keeper/keeper_heartbeat_loop_observations.ml test/test_oas_timeout_budget_strike.ml`
- `scripts/dune-local.sh build test/test_oas_timeout_budget_strike.exe`
- `scripts/dune-local.sh exec ./test/test_oas_timeout_budget_strike.exe`