### PR TITLE
fix(workspace): add clear_stale_agent_task after 3 write_backlog calls in claim_next

### DIFF
--- a/lib/workspace/workspace_task_schedule.ml
+++ b/lib/workspace/workspace_task_schedule.ml
@@ -471,7 +471,11 @@ let claim_next_r
                 ; version = backlog.version + 1
                 }
               in
-              write_backlog config new_backlog
+              write_backlog config new_backlog;
+              (* RFC-0221 §3.2: clear stale agent task after atomic backlog commit *)
+              (match released_task_id with
+               | Some rid -> Task_cache_invariant.clear_stale_agent_task config ~agent_name ~task_id:rid ~status:Masc_domain.Todo ~module_name:"claim_next"
+               | None -> ())
             | None -> ());
            clear_agent_state_after_release ();
           Claim_next_no_unclaimed, None
@@ -484,7 +488,11 @@ let claim_next_r
                 ; version = backlog.version + 1
                 }
               in
-              write_backlog config new_backlog
+              write_backlog config new_backlog;
+              (* RFC-0221 §3.2: clear stale agent task after atomic backlog commit *)
+              (match released_task_id with
+               | Some rid -> Task_cache_invariant.clear_stale_agent_task config ~agent_name ~task_id:rid ~status:Masc_domain.Todo ~module_name:"claim_next"
+               | None -> ())
             | None -> ());
            clear_agent_state_after_release ();
           ( Claim_next_no_eligible
@@ -533,6 +541,11 @@ let claim_next_r
              }
            in
            write_backlog config new_backlog;
+           (* RFC-0221 §3.2: clear stale agent task after atomic backlog commit *)
+           Task_cache_invariant.clear_stale_agent_task config ~agent_name
+             ~task_id:task.id
+             ~status:(Masc_domain.Claimed { assignee = agent_name; claimed_at = now_iso () })
+             ~module_name:"claim_next";
            (* Update agent status — takes [with_file_lock] on the
              agent file via [Workspace_task.update_local_agent_state] to
              keep the record consistent with concurrent


### PR DESCRIPTION
## Problem

`workspace_task_schedule.ml` has 3 `write_backlog` call sites that never call `Task_cache_invariant.clear_stale_agent_task` after the atomic backlog commit. The in-memory agent context cache can retain stale `current_task` references.

Discovered while investigating the systemic pattern found in board p-b65c23a46a2f8f1545778acb07f35081. The same fix was already applied to `workspace_task_transitions.ml` in PR #20842.

## Fix
**1 file changed, +13 lines inserted** in `lib/workspace/workspace_task_schedule.ml`:

1. Release-no-unclaimed path: add `clear_stale_agent_task` with `~status:Todo` after `write_backlog` for released task
2. Release-no-eligible path: same fix
3. Claim path: add `clear_stale_agent_task` with `~status:Claimed` after `write_backlog` for `claimed_task`