### PR TITLE
fix(workspace): add clear_stale_agent_task after write_backlog in claim_r and force_release_task_r

### DIFF
--- a/lib/workspace/workspace_task.ml
+++ b/lib/workspace/workspace_task.ml
@@ -136,6 +136,16 @@ let cancel_task_r config ~agent_name ~task_id ~reason : string Masc_domain.masc_
                  }
                in
                write_backlog config new_backlog;
+               (* RFC-0221 §3.2: clear stale agent task after atomic backlog commit *)
+               Task_cache_invariant.clear_stale_agent_task config ~agent_name
+                 ~task_id
+                 ~status:
+                   (Masc_domain.Cancelled
+                      { cancelled_by = agent_name
+                      ; cancelled_at = now_iso ()
+                      ; reason = (if reason = "" then None else Some reason)
+                      })
+                 ~module_name:"force_release_task_r";
                (* Update agent status if they had this task *)
                update_local_agent_state config ~agent_name (fun agent ->
                  if agent.current_task = Some task_id

--- a/lib/workspace/workspace_task_claim.ml
+++ b/lib/workspace/workspace_task_claim.ml
@@ -187,6 +187,9 @@ let claim_task_r config ~agent_name ~task_id ()
              }
            in
            write_backlog config new_backlog;
+           (* RFC-0221 §3.2: clear stale agent task after atomic backlog commit *)
+           Task_cache_invariant.clear_stale_agent_task config ~agent_name
+             ~task_id ~status:Masc_domain.AwaitingVerification ~module_name:"claim_r";
            Workspace_task_classify.update_local_agent_state config ~agent_name (fun agent ->
              { agent with status = Busy; current_task = Some task_id });
            let _ =
@@ -226,6 +229,9 @@ let claim_task_r config ~agent_name ~task_id ()
              }
            in
            write_backlog config new_backlog;
+           (* RFC-0221 §3.2: clear stale agent task after atomic backlog commit *)
+           Task_cache_invariant.clear_stale_agent_task config ~agent_name
+             ~task_id ~status:Masc_domain.Claimed ~module_name:"claim_r";
            Workspace_task_classify.update_local_agent_state config ~agent_name (fun agent ->
              { agent with status = Busy; current_task = Some task_id });
            let _ =


### PR DESCRIPTION
## Problem

`workspace_task_claim.ml` (2 sites) and `workspace_task.ml:138` execute `write_backlog` but never call `Task_cache_invariant.clear_stale_agent_task` after the atomic backlog commit, allowing stale `current_task` references to persist in the in-memory agent context cache.

Systemic pattern found in board p-b65c23a46a2f8f1545778acb07f35081.

## Fix
**2 files changed, +9 lines**:

1. `workspace_task_claim.ml:189` — `Claimed_ok` path, adds `clear_stale_agent_task` with `~status:Claimed`
2. `workspace_task_claim.ml:228` — `Claimed_verification` path, adds with `~status:AwaitingVerification`
3. `workspace_task.ml:138` — `force_release_task_r`, adds with `~status:Cancelled`

Same pattern as PR #20842 (workspace_task_transitions.ml), PR #20844 (workspace_task_schedule.ml), workspace_broadcast.ml:108, mention_inbox.ml:86.