### PR TITLE
fix(workspace): add clear_stale_agent_task in release_task_r after transition_task_r write_backlog

### DIFF
--- a/lib/workspace/workspace_task.ml
+++ b/lib/workspace/workspace_task.ml
@@ -12,14 +12,23 @@ include Workspace_task_transitions
 let release_task_r config ~agent_name ~task_id ?expected_version ?handoff_context ()
   : string Masc_domain.masc_result
   =
-  transition_task_r
-    config
-    ~agent_name
-    ~task_id
-    ~action:Masc_domain.Release
-    ?expected_version
-    ?handoff_context
-    ()
+  let result =
+    transition_task_r
+      config
+      ~agent_name
+      ~task_id
+      ~action:Masc_domain.Release
+      ?expected_version
+      ?handoff_context
+      ()
+  in
+  (* RFC-0221 §3.2: clear stale agent task after atomic backlog commit in transition_task_r *)
+  (match result with
+   | Ok _ ->
+     Task_cache_invariant.clear_stale_agent_task config ~agent_name
+       ~task_id ~status:Masc_domain.Todo ~module_name:"release_task_r"
+   | Error _ -> ());
+  result
 ;;
 
 (** Force-release a task regardless of assignee. Keeper privilege. *)

--- a/test/test_workspace_coverage.ml
+++ b/test/test_workspace_coverage.ml
@@ -607,6 +607,20 @@ let test_release_hard_stop_blocks_future_claim_next () =
      with
      | Ok _ -> ()
      | Error e -> Alcotest.fail (Masc_domain.masc_error_to_string e));
+    (* RFC-0221 §3.2: release_task_r clears the agent's stale current_task *)
+    let agent_after_release =
+      match
+        List.find_opt
+          (fun (a : Masc_domain.agent) -> String.equal a.name agent_llm_a)
+          (Workspace.get_agents_raw config)
+      with
+      | Some a -> a
+      | None -> Alcotest.fail "agent_llm_a not found after release"
+    in
+    Alcotest.(check (option string))
+      "release clears agent current_task"
+      None
+      agent_after_release.current_task;
     let task_001 =
       match
         List.find_opt


### PR DESCRIPTION
## Problem

`release_task_r` delegates to `transition_task_r` which executes `write_backlog` but does not clear the stale agent task cache. When an agent's task is released, the in-memory `current_task` reference can remain stale.

## Fix
Wrap `transition_task_r` result in `release_task_r`: on `Ok`, call `Task_cache_invariant.clear_stale_agent_task` with `~status:Todo` (release transitions task back to Todo). On `Error`, skip (failed transition means no backlog mutation).

**1 file changed, +17/-8 lines** — `lib/workspace/workspace_task.ml`

Same pattern as PR #20845 (force_release_task_r), PR #20844 (claim_next_r), PR #20842 (transition_task_r), workspace_broadcast.ml:108, mention_inbox.ml:86.