### PR TITLE
fix(workspace): add clear_stale_agent_task to stale-release paths in claim_next_r

### DIFF
--- a/lib/workspace/workspace_task_schedule.ml
+++ b/lib/workspace/workspace_task_schedule.ml
@@ -451,7 +451,10 @@ let claim_next_r
          discipline used by [Workspace_task] transitions (PR #6634). *)
         let clear_agent_state_after_release () =
           match released_task_id with
-          | Some _ ->
+          | Some rid ->
+            (* RFC-0221 §3.2: flush stale current_task from in-memory context cache *)
+            Task_cache_invariant.clear_stale_agent_task config ~agent_name
+              ~task_id:rid ~status:Masc_domain.Todo ~module_name:"claim_next_r";
             Workspace_task.update_local_agent_state config ~agent_name (fun agent ->
               { agent with status = Active; current_task = None })
           | None -> ()


### PR DESCRIPTION
## Problem

Two stale-release `write_backlog` sites (lines 471, 484) in `claim_next_r` execute `write_backlog` but `clear_agent_state_after_release()` only updates the agent file on disk (`update_local_agent_state`) without flushing the in-memory agent context cache. This allows stale `current_task` references to persist after a release.

## Fix
Move `Task_cache_invariant.clear_stale_agent_task` call inside `clear_agent_state_after_release()` so both stale-release paths are covered with `~status:Todo` (release transitions task back to unclaimed).

**1 file changed, +4/-1 lines** — `lib/workspace/workspace_task_schedule.ml`

Same pattern as PR #20844 (claim path in same file), PR #20846 (release_task_r), PR #20845 (force_release_task_r / claim_r), PR #20842 (transition_task_r).