### PR TITLE
fix(gate): pass gateway_state/status_source through connector_json projection

### DIFF
--- a/lib/gate/channel_gate_discord_state.ml
+++ b/lib/gate/channel_gate_discord_state.ml
@@ -401,6 +401,8 @@ let connector_json ?gate_status_json ?(audit_limit = 10) () =
       ("stale", `Bool (bool_member status "stale"));
       ("stale_after_sec", `Int (int_member status "stale_after_sec"));
       ("error", `String (string_member status "error"));
+      ("status_source", `String (string_member status "status_source"));
+      ("gateway_state", `String (string_member status "gateway_state"));
       ("status_path", `String (string_member status "status_path"));
       ("binding_store_path", `String (string_member status "binding_store_path"));
       ("audit_path", `String (string_member status "audit_path"));

--- a/test/test_channel_gate_discord_state.ml
+++ b/test/test_channel_gate_discord_state.ml
@@ -196,6 +196,13 @@ let test_connectors_json_advertises_gate_connector_descriptor () =
       (connector |> U.member "connector_id" |> U.to_string);
     check string "display name" "Discord"
       (connector |> U.member "display_name" |> U.to_string);
+    (* status_json carries these (#20813), but connector_json re-projects a
+       fixed field list, so passthrough must be asserted on the connectors
+       surface — the dashboard reads this endpoint, not status_json. *)
+    check string "status_source passthrough" "in_process_gateway"
+      (connector |> U.member "status_source" |> U.to_string);
+    check string "gateway_state passthrough" "disconnected"
+      (connector |> U.member "gateway_state" |> U.to_string);
     check bool "bindings capability exposed" true
       (connector |> U.member "capabilities" |> U.to_list
        |> List.exists (function


### PR DESCRIPTION
## 문제

대시보드 Connectors 페이지에 Discord `gw <state>` 칩이 프로덕션에서 한 번도 렌더되지 않았습니다.

- #20813이 `status_json`에 `gateway_state`/`status_source`를 추가했고, #20840 대시보드 스키마는 두 필드를 파싱합니다.
- 그런데 대시보드가 실제로 읽는 표면은 `GET /api/v1/gate/connectors`이고, 그 엔트리를 만드는 `connector_json`은 `status_json()` 결과를 **고정 필드 whitelist로 재투영**합니다. 그 목록에 두 필드가 없어 이 레이어에서 떨어져 나갔습니다.
- `error` 필드는 통과했기 때문에 (라이브에서 "Discord fatal close 4004: Authentication failed."가 표시됨) 누락이 가려졌습니다.

라이브 증거: `curl /api/v1/gate/connectors`의 discord 엔트리 key 목록에 `gateway_state`/`status_source` 부재 확인 (2026-06-11 19:3x KST).

## 수정

- `connector_json` 투영에 `status_source`, `gateway_state` passthrough 2줄 추가.
- descriptor 테스트에 두 필드의 connectors-표면 단언 추가 — `status_json`이 아니라 **대시보드가 읽는 그 엔드포인트**에서 계약을 고정합니다 (unit test가 producer 출력만 보고 transport 투영을 놓치는 패턴 방지).

## 검증

- `dune build @check` + `test_channel_gate_discord_state.exe` 11/11 green (신규 단언 2개 포함).
- 수정 전 코드에서는 신규 단언이 정확히 실패함 (필드 부재).

## 후속 검토 (선택)

`connector_json`이 status 필드를 손으로 재나열하는 구조 자체가 이런 drift의 원천입니다. status_json assoc을 splice하고 composite 필드(storage_paths/runtime_summary/binding_summary/observed_channel)만 append하는 구조로 바꾸면 같은 부류의 누락이 타입 차원에서 사라집니다 — 표면 변화가 커서 이 PR에서는 하지 않았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
