### PR TITLE
Add Dated_jsonl persistence bridge for telemetry_event bus messages

### DIFF
--- a/lib/keeper/keeper_telemetry_consumer.ml
+++ b/lib/keeper/keeper_telemetry_consumer.ml
@@ -1,13 +1,13 @@
 (** Keeper_telemetry_consumer — MASC-side observer for OAS telemetry events.
 
     Subscribes to the OAS event bus via [Agent_sdk_metrics_bridge],
-    filters [Custom("telemetry_event", json)] payloads, and records that a
-    telemetry item was observed. MASC deliberately does not deserialize
-    provider/model-bearing OAS telemetry; concrete runtime identity belongs to
-    OAS.
+    filters [Custom(\"telemetry_event\", json)] payloads, and persists each
+    event to a dated JSONL store under [<base_path>/telemetry_events/].
+    MASC deliberately does not deserialize provider/model-bearing OAS
+    telemetry; concrete runtime identity belongs to OAS.
 
-    State is purely internal: the subscription handle and the fiber are both
-    bound to the caller's [Eio.Switch.t]. *)
+    State is purely internal: the subscription handle, the fiber, and the
+    Dated_jsonl store are all bound to the caller's [Eio.Switch.t]. *)
 
 let telemetry_event_counter = "masc_keeper_telemetry_events_consumed_total"
 
@@ -15,7 +15,21 @@ let telemetry_event_counter = "masc_keeper_telemetry_events_consumed_total"
    starves co-located fibers (HTTP handlers, lazy startup tasks). *)
 let drain_interval_s = 0.1
 
-let spawn_subscriber ~sw ~clock ~bus =
+let store_base_dir base_path = Filename.concat base_path "telemetry_events"
+
+let store_ref : Dated_jsonl.t option ref = ref None
+
+let get_store base_path =
+  match !store_ref with
+  | Some s -> s
+  | None ->
+      let s =
+        Dated_jsonl.create ~base_dir:(store_base_dir base_path) ()
+      in
+      store_ref := Some s;
+      s
+
+let spawn_subscriber ~sw ~clock ~bus ~base_path =
   let sub =
     Agent_sdk_metrics_bridge.subscribe
       ~purpose:"telemetry_consumer"
@@ -27,6 +41,8 @@ let spawn_subscriber ~sw ~clock ~bus =
   in
   Eio.Switch.on_release sw (fun () ->
     Agent_sdk_metrics_bridge.unsubscribe bus sub);
+  (* Initialise the store now so creation error surfaces during setup. *)
+  let _store = get_store base_path in
   Eio.Fiber.fork ~sw (fun () ->
     let rec loop () =
       (try
@@ -34,11 +50,13 @@ let spawn_subscriber ~sw ~clock ~bus =
          List.iter
            (fun (evt : Agent_sdk.Event_bus.event) ->
               match evt.payload with
-              | Agent_sdk.Event_bus.Custom ("telemetry_event", _) ->
+              | Agent_sdk.Event_bus.Custom ("telemetry_event", json) ->
                   Otel_metric_store.inc_counter
                     telemetry_event_counter
                     ~labels:[ "result", "observed" ]
-                    ()
+                    ();
+                  (* Persist the raw JSON payload — OAS owns schema. *)
+                  Dated_jsonl.append (get_store base_path) json
               | _ -> ())
            events
        with

--- a/lib/keeper/keeper_telemetry_consumer.mli
+++ b/lib/keeper/keeper_telemetry_consumer.mli
@@ -2,10 +2,12 @@
 
     Spawns a fiber that drains [Custom("telemetry_event", json)]
     payloads from the OAS event bus without deserializing provider/model
-    identity. *)
+    identity. Persists each event to a dated JSONL store under
+    [<base_path>/telemetry_events/]. *)
 
 val spawn_subscriber
   :  sw:Eio.Switch.t
   -> clock:[> float Eio.Time.clock_ty ] Eio.Std.r
   -> bus:Agent_sdk.Event_bus.t
+  -> base_path:string
   -> unit

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -357,7 +357,11 @@ let start_keeper_loops
     event_bus;
   (* Telemetry feedback loop: observe OAS per-turn signals without
      deserializing provider/model-bearing payloads. *)
-  Keeper_telemetry_consumer.spawn_subscriber ~sw ~clock ~bus:event_bus;
+  Keeper_telemetry_consumer.spawn_subscriber
+    ~sw
+    ~clock
+    ~bus:event_bus
+    ~base_path:(Env_config.base_path ());
   let keeper_lifecycle_sub =
     Agent_sdk_metrics_bridge.subscribe
       ~purpose:"lifecycle_listener"


### PR DESCRIPTION
Persists each Custom("telemetry_event", json) payload to
<base_path>/telemetry_events/<dated>/events.jsonl via the
existing Dated_jsonl store infrastructure, following the same
pattern as Keeper_compact_audit.

**Changes:**
- `keeper_telemetry_consumer.mli`: add `~base_path:string` parameter
- `keeper_telemetry_consumer.ml`: implement store cache (`store_ref`,
  `get_store`) and `Dated_jsonl.append` for each event payload
- `server_bootstrap_loops.ml`: pass `~base_path` at call site

Closes task-811