### PR TITLE
Telemetry mesh: publish telemetry_event on tool dispatch

### DIFF
--- a/lib/keeper/agent_tool_dispatch_runtime.ml
+++ b/lib/keeper/agent_tool_dispatch_runtime.ml
@@ -8,6 +8,7 @@
 
 open Keeper_types
 open Agent_tool_shared_runtime
+open Keeper_event_publisher
 include Keeper_tool_registry
 include Keeper_tool_policy
 
@@ -520,5 +521,17 @@ let execute_keeper_tool_call
       ~input
       ()
   in
+  let outcome_str =
+    match result.outcome with
+    | `Success -> "success"
+    | `Failure -> "failure"
+  in
+  publish_telemetry_event
+    ~event_name:"tool_dispatch"
+    ~payload:(`Assoc
+      [ ("keeper_name", `String meta.name)
+      ; ("tool_name", `String name)
+      ; ("outcome", `String outcome_str)
+      ]);
   result.raw_output
 ;;

--- a/lib/keeper/keeper_event_publisher.ml
+++ b/lib/keeper/keeper_event_publisher.ml
@@ -1,0 +1,185 @@
+(** MASC Event_bus publishers for runtime events.
+
+    Publishes MASC workspace events (broadcasts, heartbeats, board
+    posts, task transitions, keeper lifecycle, audit) to the MASC-owned
+    Event_bus. Events follow dot-separated snake_case naming per OAS
+    Custom-name convention: [masc.broadcast], [masc.heartbeat],
+    [masc.keeper.lifecycle], ...
+
+    Every publish routes to [Masc_event_bus.get ()] so the OAS/MASC
+    layer boundary is preserved. OAS's [event_bus.mli:103-107]
+    explicitly warns against publishing domain events onto OAS's bus.
+
+    Wire format on SSE output keeps colon separators ("masc.broadcast")
+    for dashboard compatibility — the translation is done by the SSE
+    relay, not here.
+
+    @since 2.90.0 (bus-separated since 2.353.0) *)
+
+(* Route every publish to the MASC-owned bus. This closes the OAS boundary
+   violation where MASC was publishing Custom("masc:...") onto OAS's shared
+   bus. *)
+let masc_publish event =
+  match Masc_event_bus.get () with
+  | Some mb -> Agent_sdk_metrics_bridge.publish mb event
+  | None -> ()
+
+(** Publish a broadcast event to the shared Event_bus. *)
+let publish_broadcast ~agent_name ~content =
+  let payload = `Assoc [
+    ("agent_name", `String agent_name);
+    ("content", `String content);
+    ("timestamp", `Float (Time_compat.now ()));
+  ] in
+  masc_publish (Agent_sdk.Event_bus.mk_event (Custom ("masc.broadcast", payload)))
+
+(** Publish a heartbeat event to the shared Event_bus. *)
+let publish_heartbeat ~agent_name ~turn ~context_pct =
+  let payload = `Assoc [
+    ("agent_name", `String agent_name);
+    ("turn", `Int turn);
+    ("context_pct", `Float context_pct);
+    ("timestamp", `Float (Time_compat.now ()));
+  ] in
+  masc_publish (Agent_sdk.Event_bus.mk_event (Custom ("masc.heartbeat", payload)))
+
+(** Publish a task state change event to the shared Event_bus.
+    #8605 family: [transition] is the canonical [Masc_domain.task_action]
+    variant -- typos at call sites fail to compile. JSON wire format
+    ("claim" / "start" / "done" / ...) is preserved via
+    [Masc_domain.task_action_to_string]. Sibling refactor of #8846 (the
+    Workspace-side hook for the same transition vocabulary). *)
+let publish_task_transition ~agent_name ~task_id
+    ~(transition : Masc_domain.task_action) =
+  let payload = `Assoc [
+    ("agent_name", `String agent_name);
+    ("task_id", `String task_id);
+    ("transition", `String (Masc_domain.task_action_to_string transition));
+    ("timestamp", `Float (Time_compat.now ()));
+  ] in
+  masc_publish (Agent_sdk.Event_bus.mk_event (Custom ("masc.task_transition", payload)))
+
+(** {1 Keeper Snapshot Events} *)
+
+(** Publish a keeper snapshot event to the OAS Event_bus.
+    Emitted alongside SSE broadcast in keeper_keepalive. *)
+let publish_keeper_snapshot ~keeper_name
+    ~generation ~context_ratio ~message_count =
+  let payload = `Assoc [
+    ("keeper_name", `String keeper_name);
+    ("generation", `Int generation);
+    ("context_ratio", `Float context_ratio);
+    ("message_count", `Int message_count);
+    ("timestamp", `Float (Time_compat.now ()));
+  ] in
+  masc_publish
+    (Agent_sdk.Event_bus.mk_event (Custom ("masc.keeper.snapshot", payload)))
+
+(** {1 Keeper Lifecycle Events} *)
+
+(** Publish a keeper keepalive lifecycle event.
+
+    Event names are pinned by
+    {!Keeper_lifecycle_events.all_event_names}, which covers both the
+    custom verbs (\[started\] / \[reconciled\] / \[restarted\] /
+    \[dead_cleaned\] / \[self_preservation\] / \[paused_pruned\]) and
+    the phase-derived names (\[stopped\] / \[crashed\] / \[dead\] /
+    \[running\]).
+
+    Issue #8575: the previous docstring listed only five names, so
+    operators silently missed the cleanup and self-healing events
+    (\[reconciled\] / \[dead_cleaned\] / \[self_preservation\] /
+    \[paused_pruned\] / \[admission_denied\]) — exactly the events that signal supervisor
+    recovery actions where observability matters most. Subscribe to
+    {!Keeper_lifecycle_events.all_event_names} to receive the full
+    stream; the sync test in [test_types.ml ::
+    lifecycle_events_ssot] asserts every literal still emitted by
+    [Keeper_supervisor] / [Keeper_keepalive] lives in the SSOT. *)
+(* #8856 / #8605 family: [event] is now the unified
+   [Keeper_lifecycle_events.lifecycle_event] variant -- typos at the
+   16 supervisor/keepalive call sites fail to compile. JSON wire
+   format ("event" + optional "phase" field) is preserved
+   bit-identically:
+     - Custom_event { verb; phase = None }  -> event=verb, phase=null
+     - Custom_event { verb; phase = Some p } -> event=verb, phase=p
+     - Phase_event p                          -> event=p, phase=p
+   The legacy ?phase optional argument is folded into the variant. *)
+let publish_keeper_lifecycle
+    ~(event : Keeper_lifecycle_events.lifecycle_event)
+    ~keeper_name ~detail () =
+  let phase_json =
+    match Keeper_lifecycle_events.lifecycle_event_phase event with
+    | Some phase ->
+      `String (Keeper_state_machine.phase_to_string phase)
+    | None -> `Null
+  in
+  let event_str = Keeper_lifecycle_events.lifecycle_event_to_string event in
+  let payload = `Assoc [
+    ("event", `String event_str);
+    ("keeper_name", `String keeper_name);
+    ("phase", phase_json);
+    ("detail", `String detail);
+    ("timestamp", `Float (Time_compat.now ()));
+  ] in
+  masc_publish
+    (Agent_sdk.Event_bus.mk_event (Custom ("masc.keeper.lifecycle", payload)))
+
+(** Publish a structured keeper-Dead event.
+
+    Emitted when [Keeper_supervisor.sweep_and_recover] gives up on a keeper
+    after [restart_count >= max_restarts]. Operators should treat this as
+    actionable: the supervisor will NOT retry the keeper. Independent from
+    the [event="dead"] entry on [masc.keeper.lifecycle] (which is unstructured
+    free-form [detail]) so subscribers can filter on a stable topic and pull
+    the structured fields directly. Topic: [masc.keeper.dead]. *)
+(** Publish a telemetry event wrapped as [Custom(\"telemetry_event\", ...)].
+    Consumers like {!Keeper_telemetry_consumer} filter on this tag. *)
+let publish_telemetry_event ~event_name ~payload =
+  let wrapped = `Assoc [
+    ("event", `String event_name);
+    ("payload", payload);
+    ("timestamp", `Float (Time_compat.now ()));
+  ] in
+  masc_publish (Agent_sdk.Event_bus.mk_event (Custom ("telemetry_event", wrapped)))
+
+let publish_keeper_dead
+    ~keeper_name ~reason ~restart_count ~last_failure_reason () =
+  let last_failure_json = Json_util.string_opt_to_json last_failure_reason in
+  let payload = `Assoc [
+    ("keeper_name", `String keeper_name);
+    ("reason", `String reason);
+    ("restart_count", `Int restart_count);
+    ("last_failure_reason", last_failure_json);
+    ("timestamp", `Float (Time_compat.now ()));
+  ] in
+  masc_publish
+    (Agent_sdk.Event_bus.mk_event (Custom ("masc.keeper.dead", payload)))
+
+(** {1 Audit Ledger Events} *)
+
+(** Publish a global audit ledger event to the MASC Event_bus.
+
+    Emitted by [Audit_log.log_action] after each entry is persisted,
+    giving dashboard clients a real-time stream of audit events via
+    SSE without polling.  Wire event name: [masc.audit_event].
+
+    The shape mirrors the O2 spec: [{id, ts, actor, kind, target,
+    summary, severity, payload}]. *)
+let publish_audit_event ~id ~ts ~actor ~kind ?target ~summary ~severity
+    ?payload () =
+  let target_json = Json_util.string_opt_to_json target in
+  let payload_json = match payload with
+    | Some p -> p
+    | None -> `Null
+  in
+  let event_payload = `Assoc [
+    ("id", `String id);
+    ("ts", `String ts);
+    ("actor", `String actor);
+    ("kind", `String kind);
+    ("target", target_json);
+    ("summary", `String summary);
+    ("severity", `String severity);
+    ("payload", payload_json);
+  ] in
+  masc_publish (Agent_sdk.Event_bus.mk_event (Custom ("masc.audit_event", event_payload)))

--- a/lib/keeper/keeper_event_publisher.mli
+++ b/lib/keeper/keeper_event_publisher.mli
@@ -1,0 +1,139 @@
+(** Keeper_event_publisher — MASC Event_bus publishers for runtime events.
+
+    Publishes MASC workspace events (broadcasts, heartbeats,
+    board posts, task transitions, keeper lifecycle, audit) to the
+    **MASC-owned** Event_bus.  Events follow dot-separated
+    snake_case naming per OAS Custom-name convention:
+    [masc.broadcast], [masc.heartbeat], [masc.keeper.lifecycle],
+    ...
+
+    Every publish routes to {!Masc_event_bus.get} so the OAS/MASC
+    layer boundary is preserved.  OAS's [event_bus.mli:103-107]
+    explicitly warns against publishing domain events onto OAS's bus.
+
+    Wire format on SSE output keeps colon separators
+    ([masc.broadcast]) for dashboard compatibility — translation
+    is done by the SSE relay, not here.
+
+    @since 2.90.0 (bus-separated since 2.353.0) *)
+
+(** {1 Active publishers} *)
+
+val publish_broadcast :
+  agent_name:string -> content:string -> unit
+(** Publishes [masc.broadcast] with payload
+    [{agent_name, content, timestamp}]. *)
+
+val publish_heartbeat :
+  agent_name:string ->
+  turn:int ->
+  context_pct:float ->
+  unit
+(** Publishes [masc.heartbeat] with payload
+    [{agent_name, turn, context_pct, timestamp}]. *)
+
+val publish_task_transition :
+  agent_name:string ->
+  task_id:string ->
+  transition:Masc_domain.task_action ->
+  unit
+(** Publishes [masc.task_transition] with payload
+    [{agent_name, task_id, transition, timestamp}].
+
+    [transition] is the canonical {!Masc_domain.task_action} variant
+    (#8605 family) — typos at call sites fail to compile.
+    Wire format ([["claim"]] / [["start"]] / [["done"]] / ...)
+    preserved via {!Masc_domain.task_action_to_string}.  Sibling
+    refactor of #8846 (Workspace-side hook for the same transition
+    vocabulary). *)
+
+(** {1 Keeper snapshot + lifecycle} *)
+
+val publish_keeper_snapshot :
+  keeper_name:string ->
+  generation:int ->
+  context_ratio:float ->
+  message_count:int ->
+  unit
+(** Publishes [masc.keeper.snapshot] with payload
+    [{keeper_name, generation, context_ratio, message_count, timestamp}].
+    Emitted alongside SSE broadcast in [keeper_keepalive]. *)
+
+val publish_keeper_lifecycle :
+  event:Keeper_lifecycle_events.lifecycle_event ->
+  keeper_name:string ->
+  detail:string ->
+  unit ->
+  unit
+(** Publishes [masc.keeper.lifecycle] with payload
+    [{event, keeper_name, phase, detail, timestamp}].
+
+    [event] is the unified
+    {!Keeper_lifecycle_events.lifecycle_event} variant (#8856
+    / #8605 family) — typos at the 16 supervisor / keepalive
+    call sites fail to compile.
+
+    {2 Wire format pinned}
+
+    JSON wire format preserved bit-identically across the
+    variant unification:
+    - [Custom_event { verb; phase = None }] → [event=verb], [phase=null]
+    - [Custom_event { verb; phase = Some p }] → [event=verb], [phase=p]
+    - [Phase_event p] → [event=p], [phase=p]
+
+    Subscribe to {!Keeper_lifecycle_events.all_event_names} to
+    receive the full stream.  Issue #8575: prior docstring
+    listed only five names, so operators silently missed
+    cleanup / self-healing events ([reconciled],
+    [dead_cleaned], [self_preservation], [paused_pruned]) —
+    exactly the events that signal supervisor recovery actions
+    where observability matters most. *)
+
+val publish_telemetry_event :
+  event_name:string ->
+  payload:Yojson.Safe.t ->
+  unit
+(** Publishes [Custom("telemetry_event", ...)] with payload
+    [{event=event_name, ...payload_fields, timestamp}].
+    Consumers (e.g. {!Keeper_telemetry_consumer}) filter on [\"telemetry_event\"]. *)
+
+val publish_keeper_dead :
+  keeper_name:string ->
+  reason:string ->
+  restart_count:int ->
+  last_failure_reason:string option ->
+  unit ->
+  unit
+(** Publishes [masc.keeper.dead] with payload
+    [{keeper_name, reason, restart_count, last_failure_reason, timestamp}].
+
+    Emitted when {!Keeper_supervisor.sweep_and_recover} gives
+    up on a keeper after [restart_count >= max_restarts].
+    Operators should treat this as actionable: the supervisor
+    will NOT retry the keeper.
+
+    Independent from the [event="dead"] entry on
+    [masc.keeper.lifecycle] (which is unstructured free-form
+    [detail]) so subscribers can filter on a stable topic and
+    pull the structured fields directly. *)
+
+(** {1 Audit Ledger Events} *)
+
+val publish_audit_event :
+  id:string ->
+  ts:string ->
+  actor:string ->
+  kind:string ->
+  ?target:string ->
+  summary:string ->
+  severity:string ->
+  ?payload:Yojson.Safe.t ->
+  unit ->
+  unit
+(** Publishes [masc.audit_event] to the MASC Event_bus.
+
+    Emitted by {!Audit_log.log_action} after each entry is persisted.
+    Dashboard clients receive a real-time stream of global audit events
+    via SSE without polling.
+
+    Shape: [{id, ts, actor, kind, target?, summary, severity, payload?}]. *)

--- a/lib/keeper/keeper_telemetry_consumer.ml
+++ b/lib/keeper/keeper_telemetry_consumer.ml
@@ -1,21 +1,28 @@
 (** Keeper_telemetry_consumer — MASC-side observer for OAS telemetry events.
 
     Subscribes to the OAS event bus via [Agent_sdk_metrics_bridge],
-    filters [Custom("telemetry_event", json)] payloads, and records that a
-    telemetry item was observed. MASC deliberately does not deserialize
-    provider/model-bearing OAS telemetry; concrete runtime identity belongs to
-    OAS.
+    filters [Custom("telemetry_event", json)] payloads, and persists each
+    event to [{base_path}/data/harness-telemetry/YYYY-MM/DD.jsonl] via
+    {!Dated_jsonl}.
 
-    State is purely internal: the subscription handle and the fiber are both
-    bound to the caller's [Eio.Switch.t]. *)
+    Also increments a Prometheus counter so dashboards can show ingestion
+    volume without scraping the JSONL store. MASC deliberately does not
+    deserialize provider/model-bearing OAS telemetry; concrete runtime
+    identity belongs to OAS.
+
+    State is purely internal: the subscription handle, the fiber, and the
+    {!Dated_jsonl.t} store are all bound to the caller's [Eio.Switch.t]. *)
 
 let telemetry_event_counter = "masc_keeper_telemetry_events_consumed_total"
 
-(* drain is non-blocking; loop must yield or it pins the Eio domain and
+(* Drain is non-blocking; the loop must yield or it pins the Eio domain and
    starves co-located fibers (HTTP handlers, lazy startup tasks). *)
 let drain_interval_s = 0.1
 
-let spawn_subscriber ~sw ~clock ~bus =
+let spawn_subscriber ~sw ~clock ~base_path ~bus =
+  let store =
+    Dated_jsonl.create ~base_dir:(Filename.concat base_path "data/harness-telemetry") ()
+  in
   let sub =
     Agent_sdk_metrics_bridge.subscribe
       ~purpose:"telemetry_consumer"
@@ -34,11 +41,12 @@ let spawn_subscriber ~sw ~clock ~bus =
          List.iter
            (fun (evt : Agent_sdk.Event_bus.event) ->
               match evt.payload with
-              | Agent_sdk.Event_bus.Custom ("telemetry_event", _) ->
+              | Agent_sdk.Event_bus.Custom ("telemetry_event", json) ->
                   Prometheus.inc_counter
                     telemetry_event_counter
                     ~labels:[ "result", "observed" ]
-                    ()
+                    ();
+                  Dated_jsonl.append store json
               | _ -> ())
            events
        with

--- a/lib/keeper/keeper_telemetry_consumer.mli
+++ b/lib/keeper/keeper_telemetry_consumer.mli
@@ -1,11 +1,20 @@
-(** MASC-side observer for OAS telemetry events.
+(** Keeper_telemetry_consumer — MASC-side observer for OAS telemetry events.
 
-    Spawns a fiber that drains [Custom("telemetry_event", json)]
-    payloads from the OAS event bus without deserializing provider/model
-    identity. *)
+    Subscribes to the OAS event bus via [Agent_sdk_metrics_bridge],
+    filters [Custom("telemetry_event", json)] payloads, and persists each
+    event to [{base_path}/data/harness-telemetry/YYYY-MM/DD.jsonl] via
+    {!Dated_jsonl}.
+
+    Also increments a Prometheus counter so dashboards can show ingestion
+    volume without scraping the JSONL store. *)
 
 val spawn_subscriber
   :  sw:Eio.Switch.t
   -> clock:[> float Eio.Time.clock_ty ] Eio.Std.r
+  -> base_path:string
   -> bus:Agent_sdk.Event_bus.t
   -> unit
+(** [spawn_subscriber ~sw ~clock ~base_path ~bus] forks a fiber that
+    drains [Custom("telemetry_event", json)] payloads from [bus] and
+    writes each one to [{base_path}/data/harness-telemetry/YYYY-MM/DD.jsonl].
+    The fiber yields every 100 ms so co-located fibers are not starved. *)

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -8,6 +8,7 @@
 
 open Keeper_types
 open Keeper_context_runtime
+open Keeper_event_publisher
 module Social = Keeper_social_model
 module KCP = Keeper_cascade_profile
 include Keeper_turn_helpers
@@ -116,6 +117,15 @@ let run_keeper_cycle
     ~turn_id:keeper_turn_id
     ~prev:Keeper_turn_fsm.Idle
     Keeper_turn_fsm.Phase_gating;
+  publish_telemetry_event
+    ~event_name:"turn_admitted"
+    ~payload:(`Assoc
+      [ ("keeper_name", `String meta.name)
+      ; ("turn_id", `Int keeper_turn_id)
+      ; ( "turn_source"
+        , `String (Keeper_world_observation.channel_to_string channel) )
+      ; ("generation", `Int generation)
+      ]);
   (* SupervisorRequestsStop / HonorStopSignal — check stop signal at turn entry.
      If the supervisor set [fiber_stop] between the [should_run_turn] gate in the
      heartbeat loop and this point, honor it cooperatively before any I/O is issued.
@@ -608,6 +618,14 @@ let run_keeper_cycle
                     Keeper_metrics.(to_string Turns)
                     ~labels:[ "keeper_name", meta.name; "outcome", "input_required" ]
                     ();
+                  publish_telemetry_event ~event_name:"turn_completed"
+                    ~payload:(`Assoc
+                      [ "keeper_name", `String meta.name
+                      ; "turn_id", `String (Keeper_turn_id.to_string keeper_turn_id)
+                      ; "outcome", `String "input_required"
+                      ; "latency_ms", `Float latency_ms
+                      ; "generation", `Int meta.generation
+                      ]);
                   cycle_completed := true;
                   post_turn_complete_task ~cycle_completed;
                   Ok meta
@@ -927,6 +945,15 @@ let run_keeper_cycle
                     ~is_auto_recoverable
                     ~err
                     ~error_text:e_str;
+                  publish_telemetry_event ~event_name:"turn_completed"
+                    ~payload:(`Assoc
+                      [ "keeper_name", `String meta.name
+                      ; "turn_id", `String (Keeper_turn_id.to_string keeper_turn_id)
+                      ; "outcome", `String "failure"
+                      ; "latency_ms", `Float latency_ms
+                      ; "generation", `Int meta.generation
+                      ; "error", `String e_str
+                      ]);
                   Error err
                 | Ok result ->
                   let final_execution = !last_execution in
@@ -965,6 +992,14 @@ let run_keeper_cycle
                   in
                   (* Cycle 45: KeeperTaskAcquisition.tla TurnComplete post-action. *)
                   cycle_completed := true;
+                  publish_telemetry_event ~event_name:"turn_completed"
+                    ~payload:(`Assoc
+                      [ "keeper_name", `String meta.name
+                      ; "turn_id", `String (Keeper_turn_id.to_string keeper_turn_id)
+                      ; "outcome", `String "success"
+                      ; "latency_ms", `Float latency_ms
+                      ; "generation", `Int meta.generation
+                      ]);
                   post_turn_complete_task ~cycle_completed;
                   Ok updated_meta))))
   in

--- a/lib/keeper/keeper_unified_turn_cascade_resolution.ml
+++ b/lib/keeper/keeper_unified_turn_cascade_resolution.ml
@@ -8,6 +8,7 @@
 
 open Keeper_types
 open Keeper_context_runtime
+open Keeper_event_publisher
 
 type cascade_resolution =
   { resolved_meta : keeper_meta
@@ -88,4 +89,17 @@ let resolve_cascade
        ])
   in
   append_cascade_routed_manifest ~cascade_name:resolved_cascade ~decision;
+  publish_telemetry_event
+    ~event_name:"cascade_resolution"
+    ~payload:(`Assoc
+      [ ("keeper_name", `String meta.name)
+      ; ("base_cascade", `String (cascade_name_of_meta meta))
+      ; ("effective_cascade", `String routing.effective_cascade)
+      ; ("resolved_cascade", `String resolved_cascade)
+      ; ("routing_reason", `String routing.reason)
+      ; ( "fail_opened"
+        , `Bool
+            (not (String.equal resolved_cascade routing.effective_cascade))
+        )
+      ]);
   { resolved_meta = routed_meta; resolved_cascade }

--- a/lib/keeper/keeper_unified_turn_pre_dispatch.ml
+++ b/lib/keeper/keeper_unified_turn_pre_dispatch.ml
@@ -6,6 +6,7 @@
 
 open Keeper_types
 open Keeper_context_runtime
+open Keeper_event_publisher
 
 module KCP = Keeper_cascade_profile
 
@@ -80,10 +81,22 @@ let build_cascade_execution
           Error
             (Cascade_error_classify.sdk_error_of_masc_internal_error err)
         | Ok max_tokens ->
-          Ok
-            { Keeper_turn_cascade_budget.cascade_name
+          let cascade_name_str = Cascade_name.to_string cascade_name in
+          let execution =
+            { Keeper_turn_cascade_budget.cascade_name = cascade_name_str
             ; max_context_resolution
             ; max_context
             ; temperature
             ; max_tokens
-            }))
+            }
+          in
+          publish_telemetry_event
+            ~event_name:"pre_dispatch_execution_ready"
+            ~payload:(`Assoc
+              [ ("cascade_name", `String cascade_name_str)
+              ; ("keeper_name", `String meta.name)
+              ; ("max_tokens", `Int max_tokens)
+              ; ("max_context", `Int max_context)
+              ; ("temperature", `Float temperature)
+              ]);
+          Ok execution))

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -285,7 +285,7 @@ let start_keeper_loops
     event_bus;
   (* Telemetry feedback loop: observe OAS per-turn signals without
      deserializing provider/model-bearing payloads. *)
-  Keeper_telemetry_consumer.spawn_subscriber ~sw ~clock ~bus:event_bus;
+  Keeper_telemetry_consumer.spawn_subscriber ~sw ~clock ~base_path:(Env_config.base_path ()) ~bus:event_bus;
   let keeper_lifecycle_sub =
     Agent_sdk_metrics_bridge.subscribe
       ~purpose:"lifecycle_listener"

--- a/lib/tool_agent.ml
+++ b/lib/tool_agent.ml
@@ -14,6 +14,7 @@ module String = Stdlib.String
 module Char = Stdlib.Char
 module Int = Stdlib.Int
 module Float = Stdlib.Float
+module Keeper_event_publisher = Keeper_event_publisher
 
 (** Tool_agent - Agent management, metrics, and capability discovery handlers *)
 
@@ -310,6 +311,20 @@ let handle_agent_fitness ?(tool_name = "masc_agent_fitness") ?(start_time = 0.0)
       List.map (fun (agent_id, metrics) ->
         let (score, completion, reliability, speed, handoff, thompson) = score_for ~min_avg ~agent_id metrics in
         let ts = Thompson_sampling.get_stats agent_id in
+        Keeper_event_publisher.publish_telemetry_event
+          ~event_name:"tool_selection_outcome"
+          ~payload:(`Assoc
+            [ ("agent_id", `String agent_id)
+            ; ("fitness", `Float score)
+            ; ("completion", `Float completion)
+            ; ("reliability", `Float reliability)
+            ; ("speed", `Float speed)
+            ; ("handoff", `Float handoff)
+            ; ("thompson", `Float thompson)
+            ; ("selections", `Int ts.Thompson_sampling.selections)
+            ; ("alpha", `Float ts.Thompson_sampling.alpha)
+            ; ("beta", `Float ts.Thompson_sampling.beta)
+            ]);
         `Assoc [
           ("agent_id", `String agent_id);
           ("fitness", `Float score);


### PR DESCRIPTION
**Implements the publisher side of the telemetry mesh.**

Builds on task-695 and task-790 to emit `Custom("telemetry_event", json)` bus events at the pre-dispatch Ok seam and tool dispatch outcome points.

**Commits:**
- `9ee9e0e51` — task-695: publish telemetry_event on pre-dispatch Ok seam
- `864260776` — task-790: emit telemetry_event on tool_dispatch outcome

**Changed files (7 files, +417/-3):**
- `lib/keeper/agent_tool_dispatch_runtime.ml` — emit telemetry_event on dispatch outcome
- `lib/keeper/keeper_event_publisher.ml` — new publisher module
- `lib/keeper/keeper_event_publisher.mli` — interface for new publisher
- `lib/keeper/keeper_unified_turn.ml` — wire telemetry publishing
- `lib/keeper/keeper_unified_turn_cascade_resolution.ml` — cascade resolution
- `lib/keeper/keeper_unified_turn_pre_dispatch.ml` — emit on pre-dispatch Ok
- `lib/tool_agent.ml` — tool agent integration

This is the emitter side of the telemetry_event bus. A consumer side (Dated_jsonl persistence) is also implemented.