### PR TITLE
[codex] Clean stale build artifacts on agent SDK interface drift

### DIFF
--- a/scripts/dune-local.sh
+++ b/scripts/dune-local.sh
@@ -527,6 +527,61 @@ if [[ "${GITHUB_ACTIONS:-}" != "true" \
 fi
 # -----------------------------------------------------------------------
 
+# --- auto-clean stale _build on installed agent_sdk interface change ----
+# The pin guard can be intentionally bypassed during local surgery with
+# MASC_SKIP_PIN_CHECK=1.  Even then, the shared opam switch may have moved
+# from one agent_sdk build to another while _build still contains CMIs
+# compiled against the previous Llm_provider.Provider_config interface.
+# Track the actual installed Provider_config CMI checksum and clear _build
+# when it changes, before Dune can produce a cascade of "inconsistent
+# assumptions" diagnostics.
+#
+# This guard is intentionally independent of MASC_SKIP_PIN_CHECK.  It does
+# not prove the pin is correct; it only keeps the current build directory
+# internally consistent with whatever agent_sdk is installed right now.
+_current_agent_sdk_provider_config_crc() {
+  command -v ocamlobjinfo >/dev/null 2>&1 || return 1
+
+  local llm_provider_dir provider_config_cmi
+  if command -v ocamlfind >/dev/null 2>&1; then
+    llm_provider_dir="$(ocamlfind query agent_sdk.llm_provider 2>/dev/null || true)"
+  elif command -v opam >/dev/null 2>&1; then
+    llm_provider_dir="$(opam exec -- ocamlfind query agent_sdk.llm_provider 2>/dev/null || true)"
+  else
+    return 1
+  fi
+
+  [[ -n "${llm_provider_dir}" ]] || return 1
+  provider_config_cmi="${llm_provider_dir%/}/llm_provider__Provider_config.cmi"
+  [[ -r "${provider_config_cmi}" ]] || return 1
+
+  ocamlobjinfo "${provider_config_cmi}" 2>/dev/null \
+    | awk '$2 == "Llm_provider__Provider_config" { print $1; found = 1; exit }
+           END { if (!found) exit 1 }'
+}
+
+if [[ "${GITHUB_ACTIONS:-}" != "true" \
+      && "${MASC_DUNE_DRY_RUN:-0}" != "1" \
+      && "${_subcommand}" != "clean" ]]; then
+  _provider_config_crc="$(_current_agent_sdk_provider_config_crc || true)"
+  if [[ -n "${_provider_config_crc}" ]]; then
+    _provider_config_build_dir="${DUNE_BUILD_DIR:-$repo_root/_build}"
+    _provider_config_marker="${_provider_config_build_dir}/.last-agent-sdk-provider-config-crc"
+    if [[ -f "${_provider_config_marker}" ]]; then
+      _last_provider_config_crc="$(cat "${_provider_config_marker}" 2>/dev/null || true)"
+      if [[ -n "${_last_provider_config_crc}" \
+            && "${_last_provider_config_crc}" != "${_provider_config_crc}" ]]; then
+        printf '[dune-local] agent_sdk Provider_config interface changed (%.8s -> %.8s) - cleaning stale _build artifacts\n' \
+          "${_last_provider_config_crc}" "${_provider_config_crc}" >&2
+        rm -rf "${_provider_config_build_dir}"
+      fi
+    fi
+    mkdir -p "${_provider_config_build_dir}" 2>/dev/null || true
+    printf '%s' "${_provider_config_crc}" > "${_provider_config_marker}"
+  fi
+fi
+# -----------------------------------------------------------------------
+
 # --- core opam-deps installed guard ------------------------------------
 # Catch the "deps declared but not installed" failure mode before Dune
 # emits a wall of cryptic abstract-cmi errors:

--- a/test/test_dune_local_script.ml
+++ b/test/test_dune_local_script.ml
@@ -153,6 +153,35 @@ fi
 if [ "$1" = "switch" ] && [ "$2" = "show" ]; then printf 'fake-switch\n'; exit 0; fi
 exit 0
 |};
+  (* Fake findlib/ocamlobjinfo for the installed-agent-sdk interface marker.
+     Keep this deterministic so tests never inspect the real opam switch. *)
+  let fake_llm_provider_dir =
+    Filename.concat (Filename.concat base "fake-agent-sdk") "llm_provider"
+  in
+  mkdir_p fake_llm_provider_dir;
+  write_file
+    (Filename.concat fake_llm_provider_dir "llm_provider__Provider_config.cmi")
+    "fake-cmi";
+  write_executable
+    (Filename.concat bin_dir "ocamlfind")
+    (Printf.sprintf
+       {|#!/bin/sh
+if [ "$1" = "query" ] && [ "$2" = "agent_sdk.llm_provider" ]; then
+  printf '%%s\n' %s
+  exit 0
+fi
+exit 1
+|}
+       (quote fake_llm_provider_dir));
+  write_executable
+    (Filename.concat bin_dir "ocamlobjinfo")
+    {|#!/bin/sh
+printf 'File %s\n' "$1"
+printf 'Unit name: Llm_provider__Provider_config\n'
+printf 'Interfaces imported:\n'
+printf '\t%s\tLlm_provider__Provider_config\n' "${MASC_TEST_PROVIDER_CONFIG_CRC:-feedfacefeedfacefeedfacefeedface}"
+exit 0
+|};
   (* Fake dune: log subcommand and exit 0 *)
   let dune_log = Filename.concat base "dune-calls.log" in
   write_executable
@@ -184,7 +213,10 @@ let run_dune_local base bin_dir ?(env = []) ?(unset_env = []) subcommand =
       ("PATH", path);
       ("GIT_CEILING_DIRECTORIES", base);
       ("DUNE_LOCAL_LOCK", lock_path);
+      ("DUNE_BUILD_DIR", Filename.concat base "_build");
       ("MASC_OPAM_LOCK_PATH", opam_lock_path);
+      ("MASC_DUNE_LOCK_HELD", "0");
+      ("MASC_OPAM_LOCK_HELD", "0");
     ]
     @ List.filter
         (fun (k, _) ->
@@ -238,6 +270,37 @@ let test_skip_pin_check_env_bypasses_guard () =
       in
       check int "exits zero when MASC_SKIP_PIN_CHECK=1" 0 code;
       check bool "dune was invoked" true (Sys.file_exists dune_log))
+
+let test_skip_pin_check_still_cleans_on_provider_config_crc_change () =
+  with_temp_dir "dune-local-provider-config-crc" (fun dir ->
+      let bin_dir, dune_log =
+        setup_fake_repo dir ~pin_check_exit_code:1
+          ~pin_check_stderr_msg:"pin mismatch"
+      in
+      let build_dir = Filename.concat dir "_build" in
+      mkdir_p build_dir;
+      write_file (Filename.concat build_dir ".last-agent-sdk-provider-config-crc")
+        "oldcrc";
+      write_file (Filename.concat build_dir "stale-object") "stale";
+      let code, _stdout, stderr =
+        run_dune_local dir bin_dir
+          ~env:
+            [
+              ("MASC_SKIP_PIN_CHECK", "1");
+              ("MASC_TEST_PROVIDER_CONFIG_CRC", "newcrc");
+            ]
+          ~unset_env:[ "GITHUB_ACTIONS" ]
+          "build"
+      in
+      check int "exits zero when pin guard is skipped" 0 code;
+      check bool "crc change message present" true
+        (contains_substring stderr "Provider_config interface changed");
+      check bool "stale build artifact removed" false
+        (Sys.file_exists (Filename.concat build_dir "stale-object"));
+      check string "crc marker refreshed" "newcrc"
+        (read_file
+           (Filename.concat build_dir ".last-agent-sdk-provider-config-crc"));
+      check bool "dune was invoked after cleanup" true (Sys.file_exists dune_log))
 
 let test_github_actions_bypasses_pin_guard () =
   with_temp_dir "dune-local-ci-bypass" (fun dir ->
@@ -722,6 +785,18 @@ esac
 base="${1##*/}"
 printf '%s\n' "$base"
 |};
+      write_executable (Filename.concat bin_dir "awk")
+        {|#!/bin/sh
+while read -r first second rest; do
+  if [ "$second" = "Llm_provider__Provider_config" ]; then
+    printf '%s\n' "$first"
+    exit 0
+  fi
+done
+exit 1
+|};
+      let build_dir = Filename.concat dir "_build" in
+      mkdir_p build_dir;
       let opam_path = Filename.concat bin_dir "opam" in
       let script =
         Filename.concat (Filename.concat dir "scripts") "dune-local.sh"
@@ -733,6 +808,7 @@ printf '%s\n' "$base"
               ("PATH", bin_dir);
               ("GIT_CEILING_DIRECTORIES", dir);
               ("DUNE_LOCAL_LOCK", Filename.concat dir "dune-local.lock");
+              ("DUNE_BUILD_DIR", build_dir);
               ("MASC_SKIP_PIN_CHECK", "1");
               ("MASC_SKIP_DEPS_CHECK", "1");
               ("MASC_SKIP_OCAML_VERSION_CHECK", "1");
@@ -1182,6 +1258,10 @@ let () =
             test_pin_drift_aborts_build;
           test_case "MASC_SKIP_PIN_CHECK=1 bypasses pin guard" `Quick
             test_skip_pin_check_env_bypasses_guard;
+          test_case
+            "MASC_SKIP_PIN_CHECK=1 still cleans on Provider_config CRC change"
+            `Quick
+            test_skip_pin_check_still_cleans_on_provider_config_crc_change;
           test_case "GITHUB_ACTIONS=true bypasses pin guard" `Quick
             test_github_actions_bypasses_pin_guard;
           test_case "opam absent skips pin guard" `Quick


### PR DESCRIPTION
## Summary

- Track the installed `agent_sdk.llm_provider` `Provider_config` CMI checksum in `scripts/dune-local.sh`.
- Clear the active local `DUNE_BUILD_DIR` when that checksum changes, even when `MASC_SKIP_PIN_CHECK=1` is set during local repair.
- Extend `test_dune_local_script` coverage with a fake installed SDK interface drift case and isolate script tests from inherited build/lock environment.

## Root Cause

A shared opam switch can move between `agent_sdk` builds while a repo `_build` still contains CMIs compiled against the previous `Llm_provider.Provider_config` interface. If the pin guard is intentionally skipped during local surgery, Dune can then report cascading `make inconsistent assumptions over interface Llm_provider__Provider_config` diagnostics.

This does not change MASC/OAS runtime boundaries or workflow rejection behavior. It only keeps the local build directory consistent with the installed SDK interface before Dune starts.

## Validation

- `ocamlformat --check test/test_dune_local_script.ml`
- `git diff --check`
- `scripts/dune-local.sh build test/test_dune_local_script.exe`
- `scripts/dune-local.sh exec ./test/test_dune_local_script.exe`
