### PR TITLE
feat(telemetry): persist telemetry_event bus messages via Dated_jsonl

### DIFF
--- a/lib/keeper/keeper_telemetry_consumer.ml
+++ b/lib/keeper/keeper_telemetry_consumer.ml
@@ -1,21 +1,29 @@
 (** Keeper_telemetry_consumer — MASC-side observer for OAS telemetry events.
 
     Subscribes to the OAS event bus via [Agent_sdk_metrics_bridge],
-    filters [Custom("telemetry_event", json)] payloads, and records that a
-    telemetry item was observed. MASC deliberately does not deserialize
-    provider/model-bearing OAS telemetry; concrete runtime identity belongs to
-    OAS.
+    filters [Custom("telemetry_event", json)] payloads, persists each
+    event to [{base_path}/data/harness-telemetry/YYYY-MM/DD.jsonl] via
+    {!Dated_jsonl}, and increments an OTel counter for dashboard
+    visibility.
 
-    State is purely internal: the subscription handle and the fiber are both
-    bound to the caller's [Eio.Switch.t]. *)
+    MASC deliberately does not deserialize provider/model-bearing OAS
+    telemetry; concrete runtime identity belongs to OAS.
+
+    State is purely internal: the subscription handle, the fiber, and the
+    {!Dated_jsonl.t} store are all bound to the caller's [Eio.Switch.t]. *)
 
 let telemetry_event_counter = "masc_keeper_telemetry_events_consumed_total"
 
-(* drain is non-blocking; loop must yield or it pins the Eio domain and
+(* Drain is non-blocking; the loop must yield or it pins the Eio domain and
    starves co-located fibers (HTTP handlers, lazy startup tasks). *)
 let drain_interval_s = 0.1
 
-let spawn_subscriber ~sw ~clock ~bus =
+let spawn_subscriber ~sw ~clock ~base_path ~bus =
+  let store =
+    Dated_jsonl.create
+      ~base_dir:(Filename.concat base_path "data/harness-telemetry")
+      ()
+  in
   let sub =
     Agent_sdk_metrics_bridge.subscribe
       ~purpose:"telemetry_consumer"
@@ -34,11 +42,12 @@ let spawn_subscriber ~sw ~clock ~bus =
          List.iter
            (fun (evt : Agent_sdk.Event_bus.event) ->
               match evt.payload with
-              | Agent_sdk.Event_bus.Custom ("telemetry_event", _) ->
+              | Agent_sdk.Event_bus.Custom ("telemetry_event", json) ->
                   Otel_metric_store.inc_counter
                     telemetry_event_counter
                     ~labels:[ "result", "observed" ]
-                    ()
+                    ();
+                  Dated_jsonl.append store json
               | _ -> ())
            events
        with

--- a/lib/keeper/keeper_telemetry_consumer.mli
+++ b/lib/keeper/keeper_telemetry_consumer.mli
@@ -2,10 +2,18 @@
 
     Spawns a fiber that drains [Custom("telemetry_event", json)]
     payloads from the OAS event bus without deserializing provider/model
-    identity. *)
+    identity.  Each event is persisted to
+    [{base_path}/data/harness-telemetry/YYYY-MM/DD.jsonl] via
+    {!Dated_jsonl}. *)
 
 val spawn_subscriber
   :  sw:Eio.Switch.t
   -> clock:[> float Eio.Time.clock_ty ] Eio.Std.r
+  -> base_path:string
   -> bus:Agent_sdk.Event_bus.t
   -> unit
+(** [spawn_subscriber ~sw ~clock ~base_path ~bus] forks a fiber that
+    drains [Custom("telemetry_event", json)] payloads from [bus],
+    persists each one to [{base_path}/data/harness-telemetry/YYYY-MM/DD.jsonl],
+    and increments an OTel counter.  The fiber yields every 100 ms so
+    co-located fibers are not starved. *)

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -357,7 +357,8 @@ let start_keeper_loops
     event_bus;
   (* Telemetry feedback loop: observe OAS per-turn signals without
      deserializing provider/model-bearing payloads. *)
-  Keeper_telemetry_consumer.spawn_subscriber ~sw ~clock ~bus:event_bus;
+  Keeper_telemetry_consumer.spawn_subscriber
+    ~sw ~clock ~base_path:(Env_config.base_path ()) ~bus:event_bus;
   let keeper_lifecycle_sub =
     Agent_sdk_metrics_bridge.subscribe
       ~purpose:"lifecycle_listener"


### PR DESCRIPTION
## Summary

Persists `telemetry_event` Custom payloads from the MASC Event_bus to date-split JSONL files so dashboards and offline analysis can consume them without scraping the bus.

**Changes (3 files, +31/-13):**

- `keeper_telemetry_consumer.mli`: add `~base_path:string` param, document JSONL output at `{base_path}/data/harness-telemetry/YYYY-MM/DD.jsonl`
- `keeper_telemetry_consumer.ml`: create `Dated_jsonl` store on startup, call `Dated_jsonl.append` on each observed `Custom("telemetry_event", json)` event alongside existing OTel counter increment
- `server_bootstrap_loops.ml`: pass `~base_path:(Env_config.base_path ())`

**Rationale**: the telemetry_event bus is populated by `keeper_event_publisher.ml` (already merged in #20850 / upstream/main). The consumer existed but only counted events — this finishes the pipeline by persisting them to disk in the same date-split layout as harness-compact audit.

**Merge verification**: built on fresh HEAD of upstream/main (d5359788f). Zero merge conflicts. Verified clean build compiles (depends on `Dated_jsonl` which is already a member of the `masc_mcp` library).