### PR TITLE
fix(keeper-chat): restore live text-delta streaming with per-delta redaction

### DIFF
--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -559,10 +559,16 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
       (if payload.attachments = [] then base_fields
        else ("attachments", `List (List.map attachment_json payload.attachments)) :: base_fields)
   in
-  (* Buffer model text deltas until the terminal payload arrives. This
-     avoids sending raw partial output before the full reply can pass
-     through keeper-scoped redaction. *)
+  (* Stream model text deltas live with per-delta redaction — the same
+     treatment ThinkingDelta and Tool_call_args already get in
+     [consume_worker_events]. A pattern that spans a delta boundary can
+     escape the live view; the persisted turn and the terminal reply still
+     pass through full-text redaction, so the durable record stays clean.
+     [streamed_text] keeps the raw concatenation as the terminal
+     empty-reply fallback; [deltas_sent] suppresses the terminal chunk
+     re-send so streamed text is not rendered twice. *)
   let streamed_text = Buffer.create 256 in
+  let deltas_sent = ref false in
   let worker_events = Eio.Stream.create 512 in
   let push_worker_event event =
     if not !closed then
@@ -749,7 +755,9 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
              Keeper_chat_events.publish events
                (Event_error { message = redact_text ("Timeout: " ^ reason) })
          | Agent_sdk.Types.ContentBlockDelta { delta = TextDelta text; _ } ->
-             Buffer.add_string streamed_text text
+             deltas_sent := true;
+             Buffer.add_string streamed_text text;
+             Keeper_chat_events.publish events (Text_delta (redact_text text))
          | Agent_sdk.Types.ContentBlockDelta { delta = ThinkingDelta text; _ } ->
              Keeper_chat_events.publish events
                (Custom
@@ -785,7 +793,7 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
           let is_checkpoint =
             is_continuation_checkpoint_reply visible_reply
           in
-          if not is_checkpoint then
+          if (not is_checkpoint) && not !deltas_sent then
             split_keeper_reply_chunks visible_reply
             |> List.iter (fun chunk ->
                    Keeper_chat_events.publish events (Text_delta chunk));


### PR DESCRIPTION
## What

Restore live text-delta streaming in the dashboard keeper chat, applying
`redact_text` to each delta — the same per-delta treatment `ThinkingDelta`
and `Tool_call_args` already receive in the same match.

## Regression this fixes

#20825 (merged 2026-06-11 08:34Z, live since the 19:18 KST restart) routed
`TextDelta` into a buffer that is only flushed at the terminal payload, so
the dashboard chat lost token streaming entirely — replies appear all at
once after the turn completes. Operator-visible symptom: "Streaming Chat
기능이 말짱 사라졌음" plus the stream-stall warning firing on every reply.

The buffering was inconsistent within its own match arms: thinking deltas
(line below) and tool-arg deltas kept streaming live with per-delta
`redact_text`. This PR applies that existing standard to the reply text.

## Change (one file)

`lib/server/server_routes_http_keeper_stream.ml`:

- `TextDelta` arm publishes `Text_delta (redact_text text)` live, keeps
  feeding `streamed_text` (still the terminal empty-reply fallback), and
  sets a restored `deltas_sent` flag.
- Terminal chunk re-send is skipped when deltas were streamed
  (`(not is_checkpoint) && not !deltas_sent`), so text is not rendered
  twice — this restores the pre-#20825 fallback-only semantics.

## Redaction property (stated honestly)

- Per-delta `redact_text` catches any sensitive pattern contained within a
  single delta. A pattern that spans a delta boundary can appear in the
  live view — identical to the exposure `ThinkingDelta` and
  `Tool_call_args` already accept.
- The durable record is unaffected: the persisted turn
  (`keeper_chat_store`, redacted by #20825) and the terminal
  `visible_reply` both still pass through full-text redaction, so a reload
  shows the fully redacted version.

## Verification

- `dune build --root . @check` clean.
- `dune build --root . bin/main_eio.exe` (default target) clean — guards
  against expression-level errors `@check` does not fire on.
- No unit harness exists for `process_single_turn` event flow (I/O
  orchestrator); behavior change is a 3-line diff restoring the
  pre-#20825 flag semantics, verified by code-read against
  `git log -L` of the removed `deltas_sent` logic.

## RFC

Chat lane surface: RFC-0225 (single-flight admission) and RFC-0223 §3
(speaker authority) unaffected — this PR changes only the SSE event
emission for the in-flight request. Follow-up candidate (separate): a
streaming-safe incremental redactor so boundary-spanning patterns are also
caught live; deferred because `sensitive_value_re` (24+ run) is
unbounded-length, which needs a designed holdback contract, not a quick
patch.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
