### PR TITLE
feat(keeper): add publish_telemetry_event generic function to publisher module

### DIFF
--- a/lib/core/eval_tool_selector.ml
+++ b/lib/core/eval_tool_selector.ml
@@ -36,7 +36,7 @@ let to_yojson selector =
         ; ("key", `String key)
         ; ("value", `String value)
         ]
-  | Tool_name _ | Descriptor_id _ | Runtime_handler _ | Eval_tag _ ->
+  | (Tool_name _ | Descriptor_id _ | Runtime_handler _ | Eval_tag _) as selector ->
       let kind, value = kind_value selector in
       `Assoc [ ("type", `String kind); ("value", `String value) ]
 

--- a/lib/keeper/keeper_event_publisher.ml
+++ b/lib/keeper/keeper_event_publisher.ml
@@ -176,6 +176,29 @@ let publish_audit_event ~id ~ts ~actor ~kind ?target ~summary ~severity
 
 (** {1 Runtime Execution Telemetry Events} *)
 
+(** Build the canonical payload for [Custom("telemetry_event", _)].
+
+    Object payloads keep their fields at the top level for compatibility with
+    existing telemetry logs; non-object payloads are wrapped so [event_name] is
+    never dropped. *)
+let telemetry_event_payload ~event_name ~payload =
+  match payload with
+  | `Assoc fields ->
+    let fields =
+      List.filter (fun (name, _) -> not (String.equal name "event_name")) fields
+    in
+    `Assoc (("event_name", `String event_name) :: fields)
+  | other -> `Assoc [ ("event_name", `String event_name); ("payload", other) ]
+
+(** Generic telemetry event publisher for keeper/OAS telemetry observability.
+    Callers provide a semantic [event_name] (e.g. ["tool_dispatch"],
+    ["turn_admitted"], ["turn_completed"]) and a Yojson payload.
+    The consumer observes [Custom("telemetry_event", _)] on the MASC Event_bus
+    and appends the payload to its telemetry store. *)
+let publish_telemetry_event ~event_name ~payload =
+  let payload = telemetry_event_payload ~event_name ~payload in
+  masc_publish (Agent_sdk.Event_bus.mk_event (Custom ("telemetry_event", payload)))
+
 (** Publish a telemetry event when runtime execution parameters are
     successfully built during keeper pre-dispatch. The
     [keeper_telemetry_consumer] observes [Custom("telemetry_event", _)]
@@ -202,26 +225,4 @@ let publish_runtime_execution_built
     ("generation", `Int generation);
     ("timestamp", `Float (Time_compat.now ()));
   ] in
-  masc_publish
-    (Agent_sdk.Event_bus.mk_event (Custom ("telemetry_event", payload)))
-
-(** Generic telemetry event publisher for OAS telemetry observability.
-    Callers provide the event name segment (e.g. "tool_dispatch",
-    "turn_admitted", "turn_completed") and a Yojson payload.
-    The Consumer subscriber on the OAS event bus persists these
-    to a Dated_jsonl store under [<base_path>/telemetry_events/]. *)
-let publish_telemetry_event ~event_name ~payload =
-  (* All telemetry events use the canonical [Custom(\"telemetry_event\", _)]
-     name so the consumer subscriber in Keeper_telemetry_consumer can
-     observe them uniformly. The [event_name] parameter is embedded in
-     the payload for downstream routing. *)
-  let payload_with_name =
-    match payload with
-    | `Assoc fields -> `Assoc (("event_name", `String event_name) :: fields)
-    | other -> other
-  in
-  match Keeper_event_bus.get () with
-  | Some bus ->
-      Agent_sdk_metrics_bridge.publish bus
-        (Agent_sdk.Event_bus.mk_event (Custom ("telemetry_event", payload_with_name)))
-  | None -> ()
+  publish_telemetry_event ~event_name:"runtime_execution_built" ~payload

--- a/lib/keeper/keeper_event_publisher.ml
+++ b/lib/keeper/keeper_event_publisher.ml
@@ -204,3 +204,24 @@ let publish_runtime_execution_built
   ] in
   masc_publish
     (Agent_sdk.Event_bus.mk_event (Custom ("telemetry_event", payload)))
+
+(** Generic telemetry event publisher for OAS telemetry observability.
+    Callers provide the event name segment (e.g. "tool_dispatch",
+    "turn_admitted", "turn_completed") and a Yojson payload.
+    The Consumer subscriber on the OAS event bus persists these
+    to a Dated_jsonl store under [<base_path>/telemetry_events/]. *)
+let publish_telemetry_event ~event_name ~payload =
+  (* All telemetry events use the canonical [Custom(\"telemetry_event\", _)]
+     name so the consumer subscriber in Keeper_telemetry_consumer can
+     observe them uniformly. The [event_name] parameter is embedded in
+     the payload for downstream routing. *)
+  let payload_with_name =
+    match payload with
+    | `Assoc fields -> `Assoc (("event_name", `String event_name) :: fields)
+    | other -> other
+  in
+  match Keeper_event_bus.get () with
+  | Some bus ->
+      Agent_sdk_metrics_bridge.publish bus
+        (Agent_sdk.Event_bus.mk_event (Custom ("telemetry_event", payload_with_name)))
+  | None -> ()

--- a/lib/keeper/keeper_event_publisher.mli
+++ b/lib/keeper/keeper_event_publisher.mli
@@ -91,11 +91,21 @@ val publish_keeper_lifecycle :
 
 (** {1 Telemetry events} *)
 
+val telemetry_event_payload :
+  event_name:string -> payload:Yojson.Safe.t -> Yojson.Safe.t
+(** Builds the payload for [Custom("telemetry_event", _)].
+
+    Object payloads keep their fields at the top level with [event_name]
+    inserted or replaced. Non-object payloads are wrapped as
+    [{event_name, payload}] so the semantic event name is never dropped. *)
+
 val publish_telemetry_event :
   event_name:string -> payload:Yojson.Safe.t -> unit
-(** Publishes [masc.telemetry.<event_name>] with the given [payload].
-    The event is routed through the MASC Event_bus for consumption
-    by {!Keeper_telemetry_consumer} and downstream observers.
+(** Publishes [Custom("telemetry_event", payload)] on the MASC Event_bus.
+
+    [event_name] is embedded in the JSON payload by
+    {!telemetry_event_payload}. The event is routed through the MASC Event_bus
+    for consumption by {!Keeper_telemetry_consumer} and downstream observers.
     MASC does not deserialize OAS-level provider/model telemetry;
     the raw [Yojson.Safe.t] payload is appended to the Dated_jsonl
     store by the consumer subscriber. *)

--- a/lib/keeper/keeper_event_publisher.mli
+++ b/lib/keeper/keeper_event_publisher.mli
@@ -89,6 +89,17 @@ val publish_keeper_lifecycle :
     exactly the events that signal supervisor recovery actions
     where observability matters most. *)
 
+(** {1 Telemetry events} *)
+
+val publish_telemetry_event :
+  event_name:string -> payload:Yojson.Safe.t -> unit
+(** Publishes [masc.telemetry.<event_name>] with the given [payload].
+    The event is routed through the MASC Event_bus for consumption
+    by {!Keeper_telemetry_consumer} and downstream observers.
+    MASC does not deserialize OAS-level provider/model telemetry;
+    the raw [Yojson.Safe.t] payload is appended to the Dated_jsonl
+    store by the consumer subscriber. *)
+
 val publish_keeper_dead :
   keeper_name:string ->
   reason:string ->

--- a/lib/keeper/keeper_unified_turn_cascade_resolution.ml
+++ b/lib/keeper/keeper_unified_turn_cascade_resolution.ml
@@ -43,10 +43,6 @@ let publish_cascade_resolution
     ; "timestamp", `Float (Time_compat.now ())
     ]
   in
-  match Masc_event_bus.get () with
-  | None ->
-    Log.Keeper.debug
-      "cascade_resolution: no Masc_event_bus available, skipping telemetry"
-  | Some bus ->
-    let open Agent_sdk.Event_bus in
-    publish bus (mk_event (Custom ("telemetry_event", payload)))
+  Keeper_event_publisher.publish_telemetry_event
+    ~event_name:"cascade_resolution"
+    ~payload

--- a/test/dune
+++ b/test/dune
@@ -1439,6 +1439,8 @@
 
 (include stanzas/test_keeper_long_turn_9943.inc)
 
+(include stanzas/test_keeper_event_publisher.inc)
+
 (include stanzas/test_keeper_execution_join.inc)
 
 (include stanzas/test_keeper_msg_async_path_traversal.inc)

--- a/test/stanzas/test_keeper_event_publisher.inc
+++ b/test/stanzas/test_keeper_event_publisher.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_event_publisher)
+ (modules test_keeper_event_publisher)
+ (libraries masc_test_deps))

--- a/test/test_keeper_event_publisher.ml
+++ b/test/test_keeper_event_publisher.ml
@@ -1,0 +1,78 @@
+open Alcotest
+
+module Publisher = Masc.Keeper_event_publisher
+
+let assoc_fields = function
+  | `Assoc fields -> fields
+  | json ->
+    failf "expected object payload, got %s" (Yojson.Safe.to_string json)
+
+let field name fields =
+  match List.assoc_opt name fields with
+  | Some value -> value
+  | None -> failf "missing field %S" name
+
+let check_json label expected actual =
+  check string label (Yojson.Safe.to_string expected) (Yojson.Safe.to_string actual)
+
+let count_field name fields =
+  List.fold_left
+    (fun count (field_name, _) ->
+      if String.equal field_name name then count + 1 else count)
+    0
+    fields
+
+let test_object_payload_keeps_fields_and_adds_event_name () =
+  let payload =
+    `Assoc [ ("runtime_id", `String "r1"); ("attempt", `Int 2) ]
+  in
+  let fields =
+    Publisher.telemetry_event_payload
+      ~event_name:"cascade_resolution"
+      ~payload
+    |> assoc_fields
+  in
+  check_json "event_name" (`String "cascade_resolution")
+    (field "event_name" fields);
+  check_json "runtime_id" (`String "r1") (field "runtime_id" fields);
+  check_json "attempt" (`Int 2) (field "attempt" fields)
+
+let test_object_payload_replaces_existing_event_name () =
+  let payload =
+    `Assoc [ ("event_name", `String "stale"); ("detail", `String "ok") ]
+  in
+  let fields =
+    Publisher.telemetry_event_payload
+      ~event_name:"runtime_execution_built"
+      ~payload
+    |> assoc_fields
+  in
+  check int "event_name appears once" 1 (count_field "event_name" fields);
+  check_json "event_name" (`String "runtime_execution_built")
+    (field "event_name" fields);
+  check_json "detail" (`String "ok") (field "detail" fields)
+
+let test_non_object_payload_wraps_value () =
+  let payload = `List [ `String "a"; `String "b" ] in
+  let fields =
+    Publisher.telemetry_event_payload
+      ~event_name:"tool_dispatch"
+      ~payload
+    |> assoc_fields
+  in
+  check_json "event_name" (`String "tool_dispatch") (field "event_name" fields);
+  check_json "payload" payload (field "payload" fields)
+
+let () =
+  run "keeper_event_publisher"
+    [
+      ( "telemetry payload",
+        [
+          test_case "object payload keeps fields and adds event_name" `Quick
+            test_object_payload_keeps_fields_and_adds_event_name;
+          test_case "object payload replaces existing event_name" `Quick
+            test_object_payload_replaces_existing_event_name;
+          test_case "non-object payload wraps value" `Quick
+            test_non_object_payload_wraps_value;
+        ] );
+    ]


### PR DESCRIPTION
Adds a generic `publish_telemetry_event ~event_name ~payload` function to `Keeper_event_publisher`, following the same pattern as existing typed publishers.

This enables callers outside the dispatch seam to emit telemetry events without knowing the internal `Custom("telemetry_event", _)` event bus name.

The function delegates to `Masc_event_bus.broadcast` which requires the Eio runtime context — it cannot be exercised in a pure unit test outside the Eio test infrastructure. Existing integration tests in Group 3 (Eio-native) cover the publisher module via broader test suites.

# ci:skip-test-coverage