### PR TITLE
fix(discord): release gateway socket before reconnect

### DIFF
--- a/lib/gate/discord_gateway_client.ml
+++ b/lib/gate/discord_gateway_client.ml
@@ -1,8 +1,9 @@
 (* RFC-0203 Phase 1.2b.3 — I/O loop bridging Discord_wss_connection and
    Discord_gateway_state.
 
-   Single session, no reconnect. Phase 1.4 will wrap this in a backoff
-   loop that re-creates the WSS connection on Reconnect_requested. *)
+   The state machine owns reconnect/backoff decisions. This I/O loop
+   applies those effects by closing the current WSS session before
+   opening the next one. *)
 
 type intent = Discord_gateway_state.intent =
   | Guilds

--- a/lib/gate/discord_gateway_state.ml
+++ b/lib/gate/discord_gateway_state.ml
@@ -615,7 +615,8 @@ let handle_wss_closed t ~now_mono ~code ~reason =
                 (Printf.sprintf "Discord fatal close %d: %s" code reason)
           ; resume_context = None
           }
-        , [ Log
+        , [ Close_wss { code; reason }
+          ; Log
               { level = `Error
               ; message =
                   Printf.sprintf
@@ -632,7 +633,8 @@ let handle_wss_closed t ~now_mono ~code ~reason =
             ~resume_context
         in
         ( t'
-        , [ Schedule_backoff { delay_ms }
+        , [ Close_wss { code; reason }
+          ; Schedule_backoff { delay_ms }
           ; Log
               { level = `Warn
               ; message =

--- a/test/test_discord_gateway_state.ml
+++ b/test/test_discord_gateway_state.ml
@@ -833,6 +833,7 @@ let test_wss_closed_from_connected_is_resumable () =
   (match S.state m' with
    | S.Reconnect_pending { resumable = true; _ } -> ()
    | _ -> fail "expected Reconnect_pending resumable=true");
+  check bool "Close_wss emitted" true (has_close_wss effects);
   check bool "Schedule_backoff emitted" true
     (has_schedule_backoff effects)
 
@@ -850,6 +851,7 @@ let test_wss_closed_fatal_goes_to_failed () =
   (match S.state m' with
    | S.Failed _ -> ()
    | _ -> fail "expected Failed for fatal close code 4014");
+  check bool "Close_wss emitted" true (has_close_wss effects);
   check bool "no Schedule_backoff on fatal close" false
     (has_schedule_backoff effects)
 


### PR DESCRIPTION
## Summary
- release the active Discord WSS session when the gateway reports Wss_closed
- prevent reconnect backoff from dropping Open_wss because conn_ref stayed Some
- add state-machine regression coverage for Close_wss on nonfatal and fatal closes

## Verification
- scripts/dune-local.sh build test/test_discord_gateway_state.exe
- ./_build/default/test/test_discord_gateway_state.exe
- scripts/dune-local.sh build lib/gate/masc_gate.cmxa

## Evidence
- live logs showed Open_wss while conn_ref still Some after WSS close at 2026-06-11T11:24:03Z
