### PR TITLE
[codex] Fix telemetry consumer test spawn args

### DIFF
--- a/test/test_keeper_telemetry_consumer.ml
+++ b/test/test_keeper_telemetry_consumer.ml
@@ -23,6 +23,18 @@ module KTC = Masc.Keeper_telemetry_consumer
 let target_iters = 5
 let inter_sleep_s = 0.02
 let total_expected_wall_clock_s = float_of_int target_iters *. inter_sleep_s
+let temp_counter = ref 0
+
+let temp_base_path prefix =
+  incr temp_counter;
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "%s_%d_%d_%.0f" prefix !temp_counter (Unix.getpid ())
+         (Unix.gettimeofday ()))
+  in
+  Fs_compat.mkdir_p dir;
+  dir
 
 (* Marker used to break out of [Switch.run] once the assertion data is
    collected. Using [Switch.fail] would propagate as the switch's
@@ -35,9 +47,10 @@ let test_drain_loop_yields_to_co_located_fiber () =
   Eio_main.run @@ fun env ->
     let clock = Eio.Stdenv.clock env in
     let bus = Agent_sdk.Event_bus.create () in
+    let base_path = temp_base_path "keeper_telemetry_consumer" in
     (try
       Eio.Switch.run (fun sw ->
-        KTC.spawn_subscriber ~sw ~clock ~bus;
+        KTC.spawn_subscriber ~sw ~clock ~base_path ~bus;
         for _ = 1 to target_iters do
           Eio.Time.sleep clock inter_sleep_s;
           incr counter


### PR DESCRIPTION
## Summary

- Update `test_keeper_telemetry_consumer` to pass the new `~base_path` argument to `Keeper_telemetry_consumer.spawn_subscriber`.
- Create a test-local temp base path so the telemetry consumer can initialize its dated JSONL store without relying on the caller environment.

## Root Cause

`Keeper_telemetry_consumer.spawn_subscriber` gained a required `~base_path` argument. The production caller was already updated, but the test still used the old call shape, so Dune promoted the resulting partial application warning into a build failure.

## Validation

- `ocamlformat --check test/test_keeper_telemetry_consumer.ml`
- `git diff --check`
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_telemetry_consumer_fix MASC_SKIP_PIN_CHECK=1 MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_telemetry_consumer.exe`
- `./_build_telemetry_consumer_fix/default/test/test_keeper_telemetry_consumer.exe`
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_full_no_cache MASC_SKIP_PIN_CHECK=1 MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build .`

Note: `DUNE_CACHE=disabled` was used to avoid the observed shared Dune cache cleanup flake: `rmdir(.../.cache/dune/...): Directory not empty`.