### PR TITLE
feat(discord): export gateway otel metrics

### DIFF
--- a/infrastructure/monitoring/grafana/provisioning/dashboards/masc-overview.json
+++ b/infrastructure/monitoring/grafana/provisioning/dashboards/masc-overview.json
@@ -1464,6 +1464,189 @@
         }
       ],
       "description": "Connection pool from Pool_metrics.current_snapshot (export wiring restored)."
+    },
+    {
+      "id": 16,
+      "type": "row",
+      "title": "Discord Connector",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 169,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 17,
+      "type": "timeseries",
+      "title": "Discord Gateway Events / min",
+      "gridPos": {
+        "x": 0,
+        "y": 170,
+        "w": 8,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum by (event, route) (rate(masc_discord_gateway_events_total[5m])) * 60",
+          "legendFormat": "{{event}} / {{route}}",
+          "refId": "A"
+        }
+      ],
+      "description": "Gateway readiness, message, reaction, ignored, and WSS open events by low-cardinality route."
+    },
+    {
+      "id": 18,
+      "type": "timeseries",
+      "title": "Discord Inbound Dispatch / min",
+      "gridPos": {
+        "x": 8,
+        "y": 170,
+        "w": 8,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum by (outcome) (rate(masc_discord_inbound_dispatch_total[5m])) * 60",
+          "legendFormat": "{{outcome}}",
+          "refId": "A"
+        }
+      ],
+      "description": "Mention/control dispatch outcomes: dropped unbound, gate error, empty reply, sent, and send error."
+    },
+    {
+      "id": 19,
+      "type": "timeseries",
+      "title": "Discord Ambient Capture / min",
+      "gridPos": {
+        "x": 16,
+        "y": 170,
+        "w": 8,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum by (outcome) (rate(masc_discord_ambient_record_total[5m])) * 60",
+          "legendFormat": "{{outcome}}",
+          "refId": "A"
+        }
+      ],
+      "description": "Ambient lane write outcomes. This intentionally excludes Discord channel/user/message identifiers."
+    },
+    {
+      "id": 20,
+      "type": "timeseries",
+      "title": "Discord Reconnects and Closes",
+      "gridPos": {
+        "x": 0,
+        "y": 178,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(masc_discord_gateway_reconnect_scheduled_total[5m])) * 60",
+          "legendFormat": "reconnects/min",
+          "refId": "A"
+        },
+        {
+          "expr": "sum by (code) (rate(masc_discord_gateway_closes_total[5m])) * 60",
+          "legendFormat": "close {{code}}/min",
+          "refId": "B"
+        }
+      ],
+      "description": "Connector stability signal: reconnect scheduling plus gateway close codes."
+    },
+    {
+      "id": 21,
+      "type": "timeseries",
+      "title": "Discord Outbound Replies / min",
+      "gridPos": {
+        "x": 12,
+        "y": 178,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum by (outcome) (rate(masc_discord_outbound_replies_total[5m])) * 60",
+          "legendFormat": "{{outcome}}",
+          "refId": "A"
+        }
+      ],
+      "description": "Reply send outcomes from Discord-bound keeper responses."
     }
   ],
   "refresh": "30s",
@@ -1482,5 +1665,5 @@
   "timezone": "browser",
   "title": "MASC Overview",
   "uid": "masc-overview",
-  "version": 2
+  "version": 3
 }

--- a/lib/gate/discord_gateway_client.ml
+++ b/lib/gate/discord_gateway_client.ml
@@ -140,6 +140,9 @@ let run ~sw ~env ~token ~intents ~trigger_policy ~on_event ~on_ambient () =
     let open Discord_gateway_state in
     match eff with
     | Open_wss { url } ->
+      Discord_observability.record_gateway_event
+        ~route:Discord_observability.Control
+        Discord_observability.Open_wss;
       (match !conn_ref with
        | Some _ ->
          log_effect `Warn
@@ -149,7 +152,7 @@ let run ~sw ~env ~token ~intents ~trigger_policy ~on_event ~on_ambient () =
          let conn = Discord_wss_connection.connect ~sw ~env ~url in
          conn_ref := Some conn;
          Eio.Fiber.fork ~sw (fun () -> reader_loop conn))
-    | Close_wss _ ->
+    | Close_wss { code; reason = _ } ->
       (* Phase 1.4b: explicit close. Discord_wss_connection.close
          resolves the inner session switch's close-signal promise,
          which lets that switch return, which cancels reader/writer
@@ -157,6 +160,7 @@ let run ~sw ~env ~token ~intents ~trigger_policy ~on_event ~on_ambient () =
          pending read raises Cancelled; our reader_loop exception
          arm pushes a redundant Wss_closed input that the state
          machine no-ops because it is already in Reconnect_pending. *)
+      Discord_observability.record_gateway_close ~code;
       (match !conn_ref with
        | Some c -> Discord_wss_connection.close c
        | None -> ());
@@ -180,11 +184,33 @@ let run ~sw ~env ~token ~intents ~trigger_policy ~on_event ~on_ambient () =
     | Schedule_heartbeat { interval_ms } ->
       heartbeat_ms := Some interval_ms
     | Schedule_backoff { delay_ms } ->
+      Discord_observability.record_gateway_reconnect_scheduled ();
       Eio.Fiber.fork ~sw (fun () ->
         Eio.Time.sleep clock (float_of_int delay_ms /. 1000.0);
         Eio.Stream.add input_mailbox Discord_gateway_state.Backoff_elapsed)
-    | Emit_event ev -> on_event ev
-    | Emit_ambient ev -> on_ambient ev
+    | Emit_event ev ->
+      let event, route =
+        match ev with
+        | Ready _ -> Discord_observability.Ready, Discord_observability.Control
+        | Message_create _ ->
+          Discord_observability.Message_create, Discord_observability.Triggered
+        | Reaction_add _ ->
+          Discord_observability.Reaction_add, Discord_observability.Triggered
+        | Ignored _ -> Discord_observability.Ignored, Discord_observability.Control
+      in
+      Discord_observability.record_gateway_event ~route event;
+      on_event ev
+    | Emit_ambient ev ->
+      let event =
+        match ev with
+        | Ready _ -> Discord_observability.Ready
+        | Message_create _ -> Discord_observability.Message_create
+        | Reaction_add _ -> Discord_observability.Reaction_add
+        | Ignored _ -> Discord_observability.Ignored
+      in
+      Discord_observability.record_gateway_event
+        ~route:Discord_observability.Ambient event;
+      on_ambient ev
     | Log { level; message } -> log_effect level message
   in
 

--- a/lib/gate/discord_observability.ml
+++ b/lib/gate/discord_observability.ml
@@ -1,0 +1,97 @@
+(** Discord connector observability helpers. *)
+
+type gateway_route =
+  | Control
+  | Triggered
+  | Ambient
+
+type gateway_event =
+  | Ready
+  | Message_create
+  | Reaction_add
+  | Ignored
+  | Open_wss
+
+type inbound_outcome =
+  | Dropped_unbound
+  | Gate_error
+  | Empty_reply
+  | Reply_sent
+  | Reply_send_error
+
+type ambient_outcome =
+  | Ambient_recorded
+  | Ambient_dropped_unbound
+  | Ambient_dropped_empty
+  | Ambient_dropped_too_long
+
+type reply_outcome =
+  | Reply_empty
+  | Reply_send_ok
+  | Reply_send_failed
+
+let gateway_route_label = function
+  | Control -> "control"
+  | Triggered -> "triggered"
+  | Ambient -> "ambient"
+
+let gateway_event_label = function
+  | Ready -> "ready"
+  | Message_create -> "message_create"
+  | Reaction_add -> "reaction_add"
+  | Ignored -> "ignored"
+  | Open_wss -> "open_wss"
+
+let inbound_outcome_label = function
+  | Dropped_unbound -> "dropped_unbound"
+  | Gate_error -> "gate_error"
+  | Empty_reply -> "empty_reply"
+  | Reply_sent -> "reply_sent"
+  | Reply_send_error -> "reply_send_error"
+
+let ambient_outcome_label = function
+  | Ambient_recorded -> "recorded"
+  | Ambient_dropped_unbound -> "dropped_unbound"
+  | Ambient_dropped_empty -> "dropped_empty"
+  | Ambient_dropped_too_long -> "dropped_too_long"
+
+let reply_outcome_label = function
+  | Reply_empty -> "empty"
+  | Reply_send_ok -> "sent"
+  | Reply_send_failed -> "send_error"
+
+let inc name ~labels =
+  Otel_metric_store_core.inc_counter name ~labels ()
+
+let record_gateway_event ~route event =
+  inc
+    Otel_transport_metric_names.metric_discord_gateway_events
+    ~labels:
+      [ "event", gateway_event_label event
+      ; "route", gateway_route_label route
+      ]
+
+let record_gateway_close ~code =
+  inc
+    Otel_transport_metric_names.metric_discord_gateway_closes
+    ~labels:[ "code", string_of_int code ]
+
+let record_gateway_reconnect_scheduled () =
+  inc
+    Otel_transport_metric_names.metric_discord_gateway_reconnect_scheduled
+    ~labels:[]
+
+let record_inbound_dispatch outcome =
+  inc
+    Otel_transport_metric_names.metric_discord_inbound_dispatch
+    ~labels:[ "outcome", inbound_outcome_label outcome ]
+
+let record_ambient outcome =
+  inc
+    Otel_transport_metric_names.metric_discord_ambient_record
+    ~labels:[ "outcome", ambient_outcome_label outcome ]
+
+let record_reply outcome =
+  inc
+    Otel_transport_metric_names.metric_discord_outbound_replies
+    ~labels:[ "outcome", reply_outcome_label outcome ]

--- a/lib/gate/discord_observability.mli
+++ b/lib/gate/discord_observability.mli
@@ -1,0 +1,48 @@
+(** Discord connector observability helpers.
+
+    Metric labels are intentionally low-cardinality: no channel, guild, user,
+    message, or keeper identifiers are exported. Runtime identity stays in
+    JSONL logs and connector status surfaces. *)
+
+type gateway_route =
+  | Control
+  | Triggered
+  | Ambient
+
+type gateway_event =
+  | Ready
+  | Message_create
+  | Reaction_add
+  | Ignored
+  | Open_wss
+
+type inbound_outcome =
+  | Dropped_unbound
+  | Gate_error
+  | Empty_reply
+  | Reply_sent
+  | Reply_send_error
+
+type ambient_outcome =
+  | Ambient_recorded
+  | Ambient_dropped_unbound
+  | Ambient_dropped_empty
+  | Ambient_dropped_too_long
+
+type reply_outcome =
+  | Reply_empty
+  | Reply_send_ok
+  | Reply_send_failed
+
+val gateway_route_label : gateway_route -> string
+val gateway_event_label : gateway_event -> string
+val inbound_outcome_label : inbound_outcome -> string
+val ambient_outcome_label : ambient_outcome -> string
+val reply_outcome_label : reply_outcome -> string
+
+val record_gateway_event : route:gateway_route -> gateway_event -> unit
+val record_gateway_close : code:int -> unit
+val record_gateway_reconnect_scheduled : unit -> unit
+val record_inbound_dispatch : inbound_outcome -> unit
+val record_ambient : ambient_outcome -> unit
+val record_reply : reply_outcome -> unit

--- a/lib/gate/dune
+++ b/lib/gate/dune
@@ -14,6 +14,7 @@
   channel_gate_slack_state
   channel_gate_telegram_state
   channel_gate_metrics
+  discord_observability
   discord_gateway_client
   discord_gateway_state
   discord_rest_client
@@ -51,4 +52,5 @@
   masc_pulse
   masc.http_client
   masc.masc_log
+  otel_metric_store
   fs_compat))

--- a/lib/otel_metric_store/otel_transport_metric_names.ml
+++ b/lib/otel_metric_store/otel_transport_metric_names.ml
@@ -46,6 +46,31 @@ let metric_ws_bytes_cache_hits = Otel_metric_store_core.declare_counter "masc_ws
 let metric_ws_bytes_cache_misses = Otel_metric_store_core.declare_counter "masc_ws_bytes_cache_misses_total"
 let metric_ws_dashboard_hello_latency_seconds = "masc_ws_dashboard_hello_latency_seconds"
 
+let metric_discord_gateway_events =
+  Otel_metric_store_core.declare_counter "masc_discord_gateway_events_total"
+;;
+
+let metric_discord_gateway_closes =
+  Otel_metric_store_core.declare_counter "masc_discord_gateway_closes_total"
+;;
+
+let metric_discord_gateway_reconnect_scheduled =
+  Otel_metric_store_core.declare_counter
+    "masc_discord_gateway_reconnect_scheduled_total"
+;;
+
+let metric_discord_inbound_dispatch =
+  Otel_metric_store_core.declare_counter "masc_discord_inbound_dispatch_total"
+;;
+
+let metric_discord_ambient_record =
+  Otel_metric_store_core.declare_counter "masc_discord_ambient_record_total"
+;;
+
+let metric_discord_outbound_replies =
+  Otel_metric_store_core.declare_counter "masc_discord_outbound_replies_total"
+;;
+
 let metric_dashboard_execution_render_phase_sec =
   "masc_dashboard_execution_render_phase_seconds"
 ;;

--- a/lib/otel_metric_store/otel_transport_metric_names.mli
+++ b/lib/otel_metric_store/otel_transport_metric_names.mli
@@ -49,6 +49,32 @@ val metric_sidecar_schema_field_types_json_parse_failures : string
     Labels: [outcome = success | error]. *)
 val metric_ws_dashboard_hello_latency_seconds : string
 
+(** Discord gateway events emitted from the in-process WSS client.
+    Labels: [event], [route]. *)
+val metric_discord_gateway_events : string
+
+(** Discord gateway close effects interpreted by the WSS client.
+    Labels: [code]. *)
+val metric_discord_gateway_closes : string
+
+(** Discord gateway reconnect backoffs scheduled by the state machine. *)
+val metric_discord_gateway_reconnect_scheduled : string
+
+(** Triggered Discord inbound messages after keeper binding lookup.
+    Labels: [outcome] =
+    [dropped_unbound | gate_error | empty_reply | reply_sent |
+     reply_send_error]. *)
+val metric_discord_inbound_dispatch : string
+
+(** Ambient Discord messages that did not trigger a turn.
+    Labels: [outcome] =
+    [recorded | dropped_unbound | dropped_empty | dropped_too_long]. *)
+val metric_discord_ambient_record : string
+
+(** Discord REST replies attempted by the gateway reply path.
+    Labels: [outcome] = [sent | send_error | empty]. *)
+val metric_discord_outbound_replies : string
+
 (** Dashboard execution render phase latency histogram. Labels:
     [phase] = total | snapshot | operations | enrich | enrich_per_keeper
             | data_load | assemble.

--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -63,6 +63,8 @@ let handle_message_create ~dispatch
   | None ->
     (* No binding for this channel — drop quietly. The bot may be in
        channels it isn't bound to (e.g. server-wide guild messages). *)
+    Discord_observability.record_inbound_dispatch
+      Discord_observability.Dropped_unbound;
     ()
   | Some keeper_name ->
     let msg : Channel_gate.inbound_message =
@@ -82,15 +84,29 @@ let handle_message_create ~dispatch
     in
     (match Channel_gate.handle_inbound ~dispatch msg with
      | Error gate_err ->
+       Discord_observability.record_inbound_dispatch
+         Discord_observability.Gate_error;
        Log.Server.warn "discord inbound -> keeper failed (channel=%s keeper=%s): %s"
          channel_id keeper_name
          (Channel_gate.gate_error_to_string gate_err)
      | Ok out ->
-       if String.equal out.content "" then ()
+       if String.equal out.content "" then begin
+         Discord_observability.record_inbound_dispatch
+           Discord_observability.Empty_reply;
+         Discord_observability.record_reply Discord_observability.Reply_empty
+       end
        else
          (match State.send_message ~channel_id ~content:out.content ~reply_to_message_id:message_id () with
-          | Ok _ -> ()
+          | Ok _ ->
+            Discord_observability.record_inbound_dispatch
+              Discord_observability.Reply_sent;
+            Discord_observability.record_reply
+              Discord_observability.Reply_send_ok
           | Error e ->
+            Discord_observability.record_inbound_dispatch
+              Discord_observability.Reply_send_error;
+            Discord_observability.record_reply
+              Discord_observability.Reply_send_failed;
             Log.Server.error "discord send_message failed (channel=%s): %s"
               channel_id
               (Format.asprintf "%a" State.pp_send_error e)))
@@ -123,16 +139,21 @@ let handle_ambient ~base_dir
       ~(channel_id : string) ~(author_id : string)
       ~(author_name : string option) ~(content : string) =
   match State.keeper_for_channel ~channel_id with
-  | None -> ()
+  | None ->
+    Discord_observability.record_ambient
+      Discord_observability.Ambient_dropped_unbound
   | Some keeper_name ->
     let trimmed = String.trim content in
-    if String.equal trimmed "" then ()
+    if String.equal trimmed "" then
+      Discord_observability.record_ambient
+        Discord_observability.Ambient_dropped_empty
     else if String.length trimmed > Channel_gate.max_content_length () then
       (* Same inbound bound the turn path enforces
          ([Channel_gate.handle_inbound] validation): a message this
          size cannot become a turn either; it is rejected, not
          truncated. *)
-      ()
+      Discord_observability.record_ambient
+        Discord_observability.Ambient_dropped_too_long
     else begin
       Keeper_chat_store.append_user_message
         ~base_dir ~keeper_name ~content:trimmed
@@ -143,7 +164,9 @@ let handle_ambient ~base_dir
           ; speaker_authority = Keeper_chat_store.External
           }
         ();
-      Keeper_chat_broadcast.chat_appended ~keeper_name ~source:State.channel
+      Keeper_chat_broadcast.chat_appended ~keeper_name ~source:State.channel;
+      Discord_observability.record_ambient
+        Discord_observability.Ambient_recorded
     end
 
 let on_ambient ~base_dir (ev : Gw.gateway_event) =

--- a/test/dune
+++ b/test/dune
@@ -1261,6 +1261,8 @@
 
 (include stanzas/test_discord_gateway_state.inc)
 
+(include stanzas/test_discord_observability.inc)
+
 (include stanzas/test_discord_rest_client.inc)
 
 (include stanzas/test_ci_run_tests_script.inc)

--- a/test/stanzas/test_discord_observability.inc
+++ b/test/stanzas/test_discord_observability.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_discord_observability)
+ (modules test_discord_observability)
+ (libraries alcotest masc.gate otel_metric_store))

--- a/test/test_discord_observability.ml
+++ b/test/test_discord_observability.ml
@@ -1,0 +1,71 @@
+open Alcotest
+
+module Obs = Discord_observability
+module Metrics = Otel_metric_store_core
+module Names = Otel_transport_metric_names
+
+let check_delta ?(labels = []) metric_name f =
+  let before = Metrics.metric_value_or_zero metric_name ~labels () in
+  f ();
+  let after = Metrics.metric_value_or_zero metric_name ~labels () in
+  check (float 0.0001) "metric delta" 1.0 (after -. before)
+
+let test_label_contract () =
+  check string "route control" "control" (Obs.gateway_route_label Obs.Control);
+  check string "route triggered" "triggered"
+    (Obs.gateway_route_label Obs.Triggered);
+  check string "event message_create" "message_create"
+    (Obs.gateway_event_label Obs.Message_create);
+  check string "dispatch dropped_unbound" "dropped_unbound"
+    (Obs.inbound_outcome_label Obs.Dropped_unbound);
+  check string "ambient too_long" "dropped_too_long"
+    (Obs.ambient_outcome_label Obs.Ambient_dropped_too_long);
+  check string "reply failed" "send_error"
+    (Obs.reply_outcome_label Obs.Reply_send_failed)
+
+let test_gateway_event_counter () =
+  let labels = [ "event", "message_create"; "route", "triggered" ] in
+  check_delta Names.metric_discord_gateway_events ~labels (fun () ->
+    Obs.record_gateway_event ~route:Obs.Triggered Obs.Message_create)
+
+let test_gateway_close_counter () =
+  let labels = [ "code", "1001" ] in
+  check_delta Names.metric_discord_gateway_closes ~labels (fun () ->
+    Obs.record_gateway_close ~code:1001)
+
+let test_gateway_reconnect_counter () =
+  check_delta Names.metric_discord_gateway_reconnect_scheduled (fun () ->
+    Obs.record_gateway_reconnect_scheduled ())
+
+let test_inbound_dispatch_counter () =
+  let labels = [ "outcome", "gate_error" ] in
+  check_delta Names.metric_discord_inbound_dispatch ~labels (fun () ->
+    Obs.record_inbound_dispatch Obs.Gate_error)
+
+let test_ambient_counter () =
+  let labels = [ "outcome", "recorded" ] in
+  check_delta Names.metric_discord_ambient_record ~labels (fun () ->
+    Obs.record_ambient Obs.Ambient_recorded)
+
+let test_reply_counter () =
+  let labels = [ "outcome", "sent" ] in
+  check_delta Names.metric_discord_outbound_replies ~labels (fun () ->
+    Obs.record_reply Obs.Reply_send_ok)
+
+let () =
+  run "discord_observability"
+    [ ( "labels"
+      , [ test_case "low-cardinality labels are stable" `Quick
+            test_label_contract
+        ] )
+    ; ( "metrics"
+      , [ test_case "gateway event counter" `Quick test_gateway_event_counter
+        ; test_case "gateway close counter" `Quick test_gateway_close_counter
+        ; test_case "gateway reconnect counter" `Quick
+            test_gateway_reconnect_counter
+        ; test_case "inbound dispatch counter" `Quick
+            test_inbound_dispatch_counter
+        ; test_case "ambient counter" `Quick test_ambient_counter
+        ; test_case "reply counter" `Quick test_reply_counter
+        ] )
+    ]


### PR DESCRIPTION
## What changed

- Add Discord-specific OTel counters for gateway events, closes, reconnect scheduling, triggered inbound dispatch outcomes, ambient record outcomes, and outbound reply outcomes.
- Wire metrics into the in-process Discord WSS client and server ingress path.
- Add a Discord Connector section to the provisioned Grafana overview dashboard, backed by the new VictoriaMetrics/OTLP metric names.
- Keep labels low-cardinality: no channel, guild, user, message, or keeper identifiers are exported.
- Add focused tests for the Discord observability label contract and metric increments.

## Why

The Discord connector already had JSONL logs and chat persistence, but Grafana/OTLP consumers could not distinguish key runtime states such as reconnect churn, unbound drops, ambient recording, gate errors, empty replies, or Discord REST reply failures.

This PR makes those states visible as stable OTel metric names while preserving the existing JSONL/status surfaces as the identity-rich truth source.

## Validation

- `env DUNE_BUILD_DIR=_build-discord-otel dune build --root /Users/dancer/me/workspace/yousleepwhen/masc/.worktrees/discord-otel-observability-20260611 test/test_discord_observability.exe test/test_discord_gateway_state.exe lib/gate/masc_gate.cmxa`
- `env DUNE_BUILD_DIR=_build-discord-otel ./_build-discord-otel/default/test/test_discord_observability.exe`
- `env DUNE_BUILD_DIR=_build-discord-otel ./_build-discord-otel/default/test/test_discord_gateway_state.exe`
- `env DUNE_BUILD_DIR=_build-discord-otel ./_build-discord-otel/default/test/test_channel_gate_discord_state_in_process.exe`
- `ocamlformat --check ...touched OCaml files...`
- `git diff --check`
- `env DUNE_BUILD_DIR=_build-discord-otel-main dune build --root /Users/dancer/me/workspace/yousleepwhen/masc/.worktrees/discord-otel-observability-20260611 bin/main_eio.exe`
- `jq empty infrastructure/monitoring/grafana/provisioning/dashboards/masc-overview.json`

Note: `scripts/dune-local.sh` wrapper was attempted, but another worktree held `/tmp/me-dune-local.lock`; focused isolated Dune build dirs were used to avoid interrupting that work.
