### PR TITLE
[codex] Add keeper external attention store

### DIFF
--- a/docs/design/external-attention-autonomy.html
+++ b/docs/design/external-attention-autonomy.html
@@ -1,0 +1,435 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>External Attention Autonomy Design</title>
+  <style type="text/css">
+    :root {
+      color-scheme: light;
+      --bg: #f7f8fa;
+      --panel: #ffffff;
+      --ink: #202124;
+      --muted: #5f6368;
+      --line: #d9dde3;
+      --blue: #1a73e8;
+      --green: #0f8a5f;
+      --amber: #b05d00;
+      --red: #b3261e;
+      --violet: #6f42c1;
+      --slate: #334155;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--ink);
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.55;
+    }
+
+    .page-header {
+      background: #111827;
+      color: white;
+      padding: 32px 40px 28px;
+      border-bottom: 1px solid #0f172a;
+    }
+
+    .page-header h1 {
+      margin: 0 0 8px;
+      font-size: 30px;
+      line-height: 1.15;
+      letter-spacing: 0;
+      font-weight: 720;
+    }
+
+    .page-header p {
+      margin: 0;
+      color: #cbd5e1;
+      max-width: 980px;
+      font-size: 15px;
+    }
+
+    .page-main {
+      max-width: 1180px;
+      margin: 0 auto;
+      padding: 28px 24px 48px;
+    }
+
+    .section {
+      margin: 0 0 24px;
+      padding: 24px;
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+    }
+
+    h2 {
+      margin: 0 0 14px;
+      font-size: 21px;
+      line-height: 1.25;
+      letter-spacing: 0;
+    }
+
+    h3 {
+      margin: 22px 0 10px;
+      font-size: 16px;
+      letter-spacing: 0;
+    }
+
+    p { margin: 0 0 12px; }
+
+    .meta {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 10px;
+      margin-top: 18px;
+    }
+
+    .meta div, .status-card {
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 12px;
+      background: #fbfcfe;
+      min-width: 0;
+    }
+
+    .label {
+      display: block;
+      color: var(--muted);
+      font-size: 12px;
+      margin-bottom: 3px;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+    }
+
+    code, pre {
+      font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+      font-size: 13px;
+    }
+
+    code {
+      background: #eef2f7;
+      border: 1px solid #dfe5ee;
+      border-radius: 4px;
+      padding: 1px 4px;
+    }
+
+    pre {
+      overflow: auto;
+      border-radius: 8px;
+      padding: 14px;
+      background: #0f172a;
+      color: #e5e7eb;
+      line-height: 1.45;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 12px 0;
+      font-size: 14px;
+    }
+
+    th, td {
+      text-align: left;
+      vertical-align: top;
+      border: 1px solid var(--line);
+      padding: 9px 10px;
+    }
+
+    th { background: #f1f4f8; }
+
+    ul { margin: 8px 0 0 20px; padding: 0; }
+    li { margin: 5px 0; }
+
+    .diagram {
+      display: grid;
+      grid-template-columns: repeat(5, minmax(0, 1fr));
+      gap: 10px;
+      align-items: stretch;
+      margin: 16px 0;
+    }
+
+    .node {
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: #f8fafc;
+      padding: 12px;
+      min-height: 92px;
+      position: relative;
+    }
+
+    .node strong {
+      display: block;
+      margin-bottom: 5px;
+      font-size: 14px;
+    }
+
+    .node p {
+      margin: 0;
+      color: var(--muted);
+      font-size: 13px;
+    }
+
+    .node:not(:last-child)::after {
+      content: ">";
+      position: absolute;
+      right: -9px;
+      top: 34px;
+      color: var(--blue);
+      font-weight: 800;
+      background: var(--panel);
+      padding: 0 2px;
+    }
+
+    .status-grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 10px;
+      margin-top: 12px;
+    }
+
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      height: 24px;
+      border-radius: 999px;
+      padding: 0 9px;
+      font-size: 12px;
+      font-weight: 650;
+      color: white;
+      margin-bottom: 6px;
+    }
+
+    .ready { background: var(--green); }
+    .busy { background: var(--blue); }
+    .zzz { background: var(--slate); }
+    .blocked { background: var(--red); }
+    .offline { background: #6b7280; }
+    .degraded { background: var(--amber); }
+
+    .callout {
+      border-left: 4px solid var(--blue);
+      padding: 12px 14px;
+      background: #eef5ff;
+      border-radius: 6px;
+      margin: 12px 0;
+    }
+
+    .risk {
+      border-left-color: var(--amber);
+      background: #fff7ed;
+    }
+
+    .ok {
+      border-left-color: var(--green);
+      background: #ecfdf5;
+    }
+
+    @media (max-width: 900px) {
+      .page-header { padding: 24px; }
+      .page-main { padding: 18px 14px 34px; }
+      .section { padding: 18px; }
+      .meta, .diagram, .status-grid { grid-template-columns: 1fr; }
+      .node:not(:last-child)::after { display: none; }
+    }
+  </style>
+</head>
+<body>
+  <div class="page-header">
+    <h1>External Attention Autonomy Design</h1>
+    <p>Discord를 특수 케이스로 보지 않고, 모든 외부 채널을 같은 keeper attention lifecycle로 흡수하는 MASC 설계안.</p>
+    <div class="meta">
+      <div><span class="label">Date</span>2026-06-11</div>
+      <div><span class="label">Repo Head</span><code>d5359788f</code></div>
+      <div><span class="label">Runtime Root</span><code>/Users/dancer/me/.masc</code></div>
+      <div><span class="label">Boundary</span>MASC owns this, OAS stays generic</div>
+    </div>
+  </div>
+
+  <div class="page-main">
+    <div class="section">
+      <h2>1. Target Shape</h2>
+      <p>외부 메시지는 transport adapter를 지나면 Discord/Slack/GitHub라는 이름을 잃고, keeper별 pending attention item으로만 동작해야 한다.</p>
+      <div class="diagram">
+        <div class="node"><strong>Adapter</strong><p>Discord, Slack, GitHub, dashboard, webhook</p></div>
+        <div class="node"><strong>External Attention</strong><p>durable event, dedupe, urgency, actor, preview</p></div>
+        <div class="node"><strong>Availability</strong><p>Ready, Busy, Zzz, Offline, Blocked, Degraded</p></div>
+        <div class="node"><strong>World Observation</strong><p>reactive turn trigger and prompt section</p></div>
+        <div class="node"><strong>Keeper Turn</strong><p>claim, resolve, ignore, or keep pending</p></div>
+      </div>
+      <div class="callout ok">
+        같은 content/urgency/target keeper라면 Discord <code>surface_ref</code>를 Slack <code>surface_ref</code>로 바꿔도 scheduler와 availability 결과가 같아야 한다.
+      </div>
+    </div>
+
+    <div class="section">
+      <h2>2. Current Code Truth</h2>
+      <table summary="Current implementation anchors for external attention design">
+        <thead><tr><th>Area</th><th>Current behavior</th><th>Source</th></tr></thead>
+        <tbody>
+          <tr><td>Discord triggered path</td><td>Bound channel messages call <code>Channel_gate.handle_inbound</code> and send the resulting reply back to Discord.</td><td><code>server_discord_in_process_gateway.ml:58-96</code></td></tr>
+          <tr><td>Ambient recording</td><td>Non-trigger bound Discord messages are written to keeper chat, no turn.</td><td><code>server_discord_in_process_gateway.ml:118-147</code></td></tr>
+          <tr><td>Gate dispatch</td><td>External channel context is wrapped, then <code>masc_keeper_msg</code> streams through keeper execution.</td><td><code>gate_keeper_backend.ml:73-90</code>, <code>126-171</code></td></tr>
+          <tr><td>Message salience</td><td><code>collect_message_scope</code> reads chat rows and reports mentions after the last keeper assistant line.</td><td><code>keeper_world_observation_message_scope.ml:104-143</code></td></tr>
+          <tr><td>Reactive decision</td><td>Pending mentions, board events, and scope messages switch the decision channel to Reactive.</td><td><code>keeper_world_observation.ml:624-662</code></td></tr>
+          <tr><td>Single-flight</td><td>Autonomous skips when busy; chat serializes/queues through admission.</td><td><code>keeper_turn_admission.mli:1-19</code>, <code>39-61</code></td></tr>
+          <tr><td>Composite surface</td><td>Runtime attention exposes stale/blocked/idle signals, but not pending external attention.</td><td><code>server_dashboard_http_composite_claims.ml:422-526</code></td></tr>
+        </tbody>
+      </table>
+      <div class="callout risk">
+        <code>RFC-0230</code>의 “producer is stubbed” 설명은 현재 <code>d5359788f</code>와 어긋난다. 현재 구현에는 mention watermark가 있고, 남은 gap은 first-class external attention lifecycle과 operator availability surface다.
+      </div>
+    </div>
+
+    <div class="section">
+      <h2>3. Data Contract</h2>
+      <p>새 MASC module 후보: <code>Keeper_external_attention</code>. 저장 경로는 live base path 기준이다.</p>
+      <pre><code>&lt;base_path&gt;/.masc/external_attention/&lt;keeper&gt;.jsonl</code></pre>
+      <pre><code>type surface_ref =
+  | Dashboard of { session_id : string option }
+  | Discord of {
+      guild_id : string option;
+      channel_id : string;          (* channel id or thread channel id *)
+      parent_channel_id : string option;
+      thread_id : string option;
+    }
+  | Slack of { team_id : string option; channel_id : string; thread_ts : string option }
+  | Github of { repo : string; notification_id : string option }
+  | Webhook of { source : string; event_id : string }
+  | Gate of { label : string; address : (string * string) list }
+
+type conversation_ref =
+  { conversation_id : string; surface : surface_ref }
+
+type external_message_ref =
+  { surface : surface_ref; message_id : string; reply_to_message_id : string option }
+
+type urgency =
+  | Mention | Direct_message | Ambient | System
+
+type event =
+  | Recorded of item
+  | Claimed_for_turn of { event_id : string; claim_id : string; turn_id : int option; claimed_at : float }
+  | Resolved of { event_id : string; resolved_at : float; reason : string }
+  | Ignored of { event_id : string; ignored_at : float; reason : string }</code></pre>
+      <p>각 item은 <code>event_id</code>, <code>dedupe_key</code>, <code>keeper_name</code>, <code>conversation_ref</code>, optional <code>external_message_ref</code>, actor, urgency, redacted preview, timestamp를 가진다. 현재 pending set은 append-only event log의 projection이다.</p>
+      <div class="callout ok">
+        <code>dedupe_key</code>는 inbound event id이고 conversation lane key가 아니다. Discord channel과 Discord thread는 둘 다 <code>discord:&lt;guild&gt;:&lt;channel_id&gt;</code> 형태의 conversation id를 쓰며, thread 메시지는 thread channel id가 <code>channel_id</code>가 된다.
+      </div>
+      <div class="callout risk">
+        Pending semantics are adapter-policy-owned; lifecycle semantics are MASC-store-owned. Discord/Slack/GitHub별 "무엇을 pending으로 볼지"는 adapter boundary에서 결정한다.
+      </div>
+    </div>
+
+    <div class="section">
+      <h2>4. Availability Model</h2>
+      <div class="status-grid">
+        <div class="status-card"><span class="pill ready">Ready</span><p>실행 가능하고 trigger attention이 pending. 지금 turn으로 승격 가능.</p></div>
+        <div class="status-card"><span class="pill busy">Busy</span><p>이미 autonomous/chat/tool turn이 in-flight. 새 attention은 pending으로 남음.</p></div>
+        <div class="status-card"><span class="pill zzz">Zzz</span><p>실행 가능하지만 pending trigger attention이 없음. sleep/cooldown/poll wait.</p></div>
+        <div class="status-card"><span class="pill offline">Offline</span><p>fiber/runtime이 없거나 phase상 실행 불가. recover/start가 먼저.</p></div>
+        <div class="status-card"><span class="pill blocked">Blocked</span><p>paused, approval, provider exhaustion, continue gate 등으로 실행 불가.</p></div>
+        <div class="status-card"><span class="pill degraded">Degraded</span><p>명확한 hard block은 아니지만 stale/uncertain 상태. probe 필요.</p></div>
+      </div>
+      <h3>Composite JSON Extension</h3>
+      <pre><code>{
+  "availability": {
+    "state": "busy",
+    "reason": "turn_in_flight",
+    "current_turn": {
+      "lane": "autonomous",
+      "started_at": 1781180100.0,
+      "last_progress_at": 1781180163.0
+    },
+    "pending_attention_count": 3,
+    "top_pending_attention": {
+      "source_label": "discord",
+      "urgency": "mention",
+      "actor_label": "Alex",
+      "preview": "@sangsu ..."
+    },
+    "next_action": "will_process_after_current_turn"
+  }
+}</code></pre>
+    </div>
+
+    <div class="section">
+      <h2>5. Scheduler Wiring</h2>
+      <p><code>world_observation</code>에 <code>pending_external_attention</code>을 추가하고 기존 reactive graph에 연결한다.</p>
+      <ul>
+        <li><code>durable_signal_present</code>: pending trigger attention이 있으면 true.</li>
+        <li><code>actionable_signal_present</code>: pending trigger attention이 있으면 true.</li>
+        <li><code>turn_reason</code>: <code>External_attention_pending</code> 추가.</li>
+        <li><code>keeper_cycle_decision</code>: pending trigger attention은 <code>Reactive</code> channel.</li>
+        <li><code>Keeper_unified_prompt</code>: <code>### External Attention</code> section 추가.</li>
+      </ul>
+      <pre><code>### External Attention (2 pending)
+- [discord mention] Alex in #ops at 20:29: "@sangsu can you check ..."
+- [github mention] review request in yousleepwhen/masc#20871: "Need owner..."</code></pre>
+    </div>
+
+    <div class="section">
+      <h2>6. Behavior Examples</h2>
+      <h3>Busy Keeper, Discord Mention</h3>
+      <pre><code>Sangsu autonomous turn in flight
+-> Discord mention arrives
+-> external_attention Pending recorded
+-> availability = Busy, pending_attention_count = 1
+-> no second same-keeper turn starts
+-> current turn finishes
+-> next reactive turn includes item
+-> item Claimed_for_turn, then Resolved after reply</code></pre>
+      <h3>Zzz Keeper, Slack Mention</h3>
+      <pre><code>Sangsu has no in-flight turn and no pending attention
+-> availability = Zzz
+-> Slack app_mention arrives
+-> same lifecycle shape, Slack surface_ref
+-> availability = Ready
+-> wakeup for high urgency
+-> reactive turn behavior matches Discord</code></pre>
+    </div>
+
+    <div class="section">
+      <h2>7. Implementation Slices</h2>
+      <table summary="External attention implementation slices and validation plan">
+        <thead><tr><th>Phase</th><th>Files</th><th>Validation</th></tr></thead>
+        <tbody>
+          <tr><td>P1 Store/type</td><td><code>keeper_external_attention.ml/mli</code>, <code>test_keeper_external_attention.ml</code></td><td>surface/conversation refs, JSON roundtrip, dedupe, stale-claim projection</td></tr>
+          <tr><td>P2 Adapter record</td><td><code>gate_keeper_backend.ml</code>, <code>server_discord_in_process_gateway.ml</code></td><td>record before dispatch, duplicate message id ignored</td></tr>
+          <tr><td>P3 Observation/prompt</td><td><code>keeper_world_observation.ml/mli</code>, <code>keeper_unified_prompt.ml</code></td><td>pending item produces Reactive decision and prompt section</td></tr>
+          <tr><td>P4 Availability surface</td><td><code>keeper_availability.ml/mli</code>, composite HTTP, dashboard normalizers/types</td><td>Busy/Ready/Zzz/Blocked derivation tests</td></tr>
+          <tr><td>P5 Wake/resolution</td><td><code>keeper_keepalive.ml</code>, <code>keeper_heartbeat_loop.ml</code>, unified turn finalize</td><td>wakeup, claimed, resolved, ignored lifecycle</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="section">
+      <h2>8. Acceptance Tests</h2>
+      <ul>
+        <li>Source substitution: Discord and Slack fixtures with same keeper/content produce same scheduler result.</li>
+        <li>Busy queue: autonomous turn holds the slot; external mention does not start another turn and surfaces Busy.</li>
+        <li>Zzz wake: healthy sleeping keeper becomes Ready and wakes on mention/direct message.</li>
+        <li>Blocked preserves pending: paused/runtime-blocked keeper keeps pending attention but does not resolve it.</li>
+        <li>Resolution clears: successful reply moves Claimed to Resolved and prevents repeat reactive turns.</li>
+        <li>Stale claim recovers: crash after claim projects the item back to pending.</li>
+        <li>Restart durability: Pending survives server restart.</li>
+      </ul>
+    </div>
+
+    <div class="section">
+      <h2>9. Invariants</h2>
+      <ul>
+        <li><code>NoDroppedAddressedAttention</code>: mention/direct attention cannot disappear without Resolved or Ignored.</li>
+        <li><code>AtMostOneTurnPerKeeper</code>: pending attention cannot bypass single-flight.</li>
+        <li><code>SourceNeutralAttention</code>: changing only adapter/surface does not change scheduler decision.</li>
+        <li><code>BusySurfacesPending</code>: in-flight plus pending trigger attention shows Busy, not Zzz.</li>
+        <li><code>BlockedDoesNotResolve</code>: blocked/paused/offline cannot mark attention resolved.</li>
+      </ul>
+    </div>
+  </div>
+</body>
+</html>

--- a/docs/design/external-attention-autonomy.md
+++ b/docs/design/external-attention-autonomy.md
@@ -1,0 +1,734 @@
+# External Attention Autonomy Design
+
+Date: 2026-06-11
+Status: Draft implementation design
+Scope: MASC keeper autonomy, connector-neutral attention, operator surface
+Out of scope: OAS provider/model/transport internals
+
+## 1. Goal
+
+Make an external message affect a keeper's autonomous turn behavior through one
+transport-neutral contract.
+
+Discord is only one adapter. If the same event arrives from Slack, GitHub,
+webhook, dashboard inbox, or another gate connector, the keeper scheduler and
+operator surface must behave the same:
+
+```text
+transport adapter
+  -> external_attention event
+  -> per-keeper durable pending attention
+  -> keeper availability surface
+  -> world observation / reactive turn decision
+  -> keeper turn
+  -> claim / resolution
+```
+
+The feature must not move Discord-specific policy into OAS. OAS remains the
+provider/model/turn execution substrate. MASC owns transport semantics,
+autonomy, keeper scheduling, and operator-facing state.
+
+## 2. Current Evidence
+
+[근거] `git -C ~/me/workspace/yousleepwhen/masc rev-parse --short HEAD` ->
+`d5359788f`, checked `2026-06-11T20:31:38+0900`, trust High.
+
+[근거] `curl -fsS 'http://127.0.0.1:8935/health?full=1' | jq ...`, checked
+`2026-06-11T20:31:38+0900`, trust High:
+
+- runtime process repo root: `/Users/dancer/me/workspace/yousleepwhen/masc`
+- effective base path: `/Users/dancer/me`
+- effective MASC root: `/Users/dancer/me/.masc`
+- build commit: `d5359788f`
+- fleet safety: degraded because paused/blocked keeper capacity is below target
+
+[근거] `curl -fsS 'http://127.0.0.1:8935/api/v1/keepers/sangsu/composite' | jq ...`,
+checked `2026-06-11T20:31:38+0900`, trust High:
+
+- `keeper=sangsu`
+- `phase=running`
+- `runtime_attention.state=ok`
+- `runtime_attention.needs_attention=false`
+- `runtime_attention.live_turn_started_at=null`
+
+Current code anchors:
+
+| Area | Current behavior | Source |
+|---|---|---|
+| Discord triggered path | `Message_create` maps a bound channel to a keeper and calls `Channel_gate.handle_inbound`; successful output is sent back to Discord. | `lib/server/server_discord_in_process_gateway.ml:58-96` |
+| Discord ambient path | Messages that fail trigger policy are recorded as chat user lines, but no turn is dispatched. | `lib/server/server_discord_in_process_gateway.ml:118-147` |
+| Gate dispatch | `Gate_keeper_backend.dispatch` records a connector user line, contextualizes external channel metadata, then calls `Keeper_tool_surface.dispatch_stream` with `masc_keeper_msg`. | `lib/gate_keeper_backend.ml:73-90`, `lib/gate_keeper_backend.ml:126-171` |
+| Chat persistence | Connector/dashboard chat rows persist under `<base_dir>/.masc/keeper_chat/<keeper>.jsonl`, with `source` and `speaker_authority`. | `lib/keeper/keeper_chat_store.mli:1-14`, `lib/keeper/keeper_chat_store.ml:19-23` |
+| Message salience | Current `collect_message_scope` loads keeper chat history and reports user lines mentioning the keeper after the keeper's last assistant line. Scope messages are still reserved for a later phase. | `lib/keeper/keeper_world_observation_message_scope.ml:104-143` |
+| World observation | `observe` includes pending mentions, pending board events, pending scope messages, task counts, and connected surfaces. | `lib/keeper/keeper_world_observation.ml:421-470` |
+| Reactive turn decision | `keeper_cycle_decision` runs a Reactive turn for pending mentions, board events, or scope messages before falling back to scheduled autonomous cadence. | `lib/keeper/keeper_world_observation.ml:624-662` |
+| Prompt context | The unified prompt renders connected surfaces, pending mentions, pending scope messages, and board events. | `lib/keeper/keeper_unified_prompt.ml:620-655`, `lib/keeper/keeper_unified_prompt.ml:737-776` |
+| Single-flight | Chat waits/queues, autonomous skips when the same keeper already has an in-flight turn. | `lib/keeper/keeper_turn_admission.mli:1-19`, `lib/keeper/keeper_turn_admission.mli:39-61` |
+| Chat queue coalescing | While a turn is in flight, queued chat messages stay queued and coalesce into one later turn. | `lib/keeper/keeper_chat_consumer.ml:9-40` |
+| Runtime attention surface | Composite attention currently reports blocked/stale/idle runtime attention, but not transport-neutral pending external attention. | `lib/server/server_dashboard_http_composite_claims.ml:422-526` |
+
+Important drift note: `docs/rfc/RFC-0230-keeper-mention-scope-reactivity.md`
+is adjacent, but its early statement that `collect_message_scope` is a stub is
+stale for `d5359788f`. The current producer already implements mention
+watermarking from `Keeper_chat_store`. This design builds on the current code,
+not the stale RFC claim.
+
+## 3. Problem
+
+The system has two different concepts that currently look similar in the UI:
+
+1. A transport message can already reach a keeper as a chat/direct turn.
+2. A keeper's autonomous turn selection only reacts to the signals that are
+   represented in world observation.
+
+When Sangsu is in Discord, the connector can be alive and bound, but autonomous
+turns only care if the message has been promoted into a keeper salience signal.
+The current mention-watermark path helps, but it is coupled to chat history and
+does not expose a first-class pending external attention object.
+
+Missing pieces:
+
+- no durable, source-neutral `external_attention` lifecycle;
+- no shared adapter contract for Discord/Slack/GitHub/webhook/dashboard inbox;
+- no typed `surface_ref` / `conversation_ref` that lets Discord channels,
+  Discord threads, Slack threads, and dashboard sessions keep distinct lanes;
+- no explicit boundary saying platform adapters own "what becomes pending",
+  while the shared store owns only lifecycle;
+- no operator surface that says "Sangsu is Busy, 3 external items are pending";
+- no explicit `Ready | Busy | Zzz | Offline | Blocked` availability projection
+  derived from keeper scheduler state plus pending attention;
+- no acceptance test proving source substitution preserves behavior.
+
+## 4. Design Principles
+
+1. Transport-neutral after the adapter boundary.
+   Discord, Slack, GitHub, webhook, dashboard inbox, and future gate connectors
+   all emit the same MASC event shape.
+
+2. Durable before dispatch.
+   An inbound attention item is recorded before any model turn is attempted. A
+   failed turn, busy slot, restart, or silent provider failure cannot drop it.
+
+3. Single-flight is respected.
+   If the keeper is already running a turn, the new attention item becomes
+   pending and the surface says `Busy`; it must not start a second same-keeper
+   turn.
+
+4. Prompt salience is explicit.
+   World observation includes a bounded list of pending external attention. The
+   prompt gets a dedicated section, not a hidden side effect of chat history.
+
+5. OAS remains generic.
+   OAS does not learn about Discord, Slack, Sangsu, gate bindings, keeper
+   availability, or pending attention. OAS sees ordinary turn context.
+
+6. Surface state is scheduler state.
+   `Busy`, `Zzz`, `Ready`, `Offline`, and `Blocked` describe whether a keeper can
+   process an item now; they are not transport status labels.
+
+7. Pending semantics are adapter-policy-owned.
+   Discord, Slack, GitHub, dashboard, and webhooks each decide which inbound
+   event becomes `Mention`, `Direct_message`, `Ambient`, or `System`. The shared
+   store never contains Discord-specific "is this pending?" logic; it receives
+   already-classified attention and manages only durable lifecycle.
+
+## 5. Data Contract
+
+Add a MASC-owned module:
+
+```ocaml
+module Keeper_external_attention : sig
+  type surface_ref =
+    | Dashboard of { session_id : string option }
+    | Discord of
+        { guild_id : string option
+        ; channel_id : string
+          (** Discord channel id. For thread messages this is the thread
+              channel id; plain channel messages use the parent channel id. *)
+        ; parent_channel_id : string option
+        ; thread_id : string option
+        }
+    | Slack of
+        { team_id : string option
+        ; channel_id : string
+        ; thread_ts : string option
+        }
+    | Github of { repo : string; notification_id : string option }
+    | Webhook of { source : string; event_id : string }
+    | Gate of { label : string; address : (string * string) list }
+
+  type conversation_ref =
+    { conversation_id : string
+    ; surface : surface_ref
+    }
+
+  type external_message_ref =
+    { surface : surface_ref
+    ; message_id : string
+    ; reply_to_message_id : string option
+    }
+
+  type urgency =
+    | Mention
+    | Direct_message
+    | Ambient
+    | System
+
+  type actor =
+    { actor_id : string option
+    ; display_name : string option
+    ; authority : Keeper_chat_store.speaker_authority
+    }
+
+  type item =
+    { event_id : string
+    ; dedupe_key : string
+    ; keeper_name : string
+    ; conversation : conversation_ref
+    ; external_message : external_message_ref option
+    ; source_label : string
+    ; actor : actor
+    ; urgency : urgency
+    ; content_preview : string
+    ; content_ref : string option
+    ; received_at : float
+    ; metadata : (string * string) list
+    }
+
+  type event =
+    | Recorded of item
+    | Claimed_for_turn of
+        { event_id : string
+        ; claim_id : string
+        ; turn_id : int option
+        ; claimed_at : float
+        }
+    | Resolved of { event_id : string; resolved_at : float; reason : string }
+    | Ignored of { event_id : string; ignored_at : float; reason : string }
+
+  type record_result =
+    [ `Recorded
+    | `Duplicate of item
+    | `Error of string
+    ]
+
+  val record :
+    base_path:string ->
+    item ->
+    record_result
+
+  val pending_for_keeper :
+    base_path:string ->
+    keeper_name:string ->
+    ?now:float ->
+    ?claim_stale_after:float ->
+    limit:int ->
+    unit ->
+    item list
+
+  val claim_for_turn :
+    base_path:string ->
+    keeper_name:string ->
+    event_ids:string list ->
+    claim_id:string ->
+    turn_id:int option ->
+    ?now:float ->
+    unit ->
+    (unit, string) result
+
+  val mark_resolved :
+    base_path:string ->
+    keeper_name:string ->
+    event_ids:string list ->
+    reason:string ->
+    ?now:float ->
+    unit ->
+    (unit, string) result
+
+  val mark_ignored :
+    base_path:string ->
+    keeper_name:string ->
+    event_ids:string list ->
+    reason:string ->
+    ?now:float ->
+    unit ->
+    (unit, string) result
+end
+```
+
+Suggested persistence:
+
+```text
+<base_path>/.masc/external_attention/<keeper>.jsonl
+```
+
+Each line is one append-only `event`. The current `Pending` set is a projection:
+latest event per `event_id`, excluding terminal `Resolved` / `Ignored` events
+and recovering stale claims by policy. `event_id = sha256(dedupe_key)`;
+`dedupe_key` is transport-derived and identifies one inbound external event:
+
+```text
+discord:<channel_id>:<message_id>
+slack:<team_id>:<channel_id>:<event_ts>
+github:<repo>:<notification_id>
+dashboard:<session_id>:<message_id>
+webhook:<source>:<event_id>
+```
+
+`dedupe_key` is not the conversation lane key. Lane identity lives in
+`conversation_ref.conversation_id`:
+
+```text
+discord:<guild-or-unknown>:<channel_id>
+slack:<team-or-unknown>:<channel_id>:<thread_ts-or-channel>
+dashboard:<keeper>:<session-or-default>
+github:<repo>:<notification-or-thread>
+```
+
+The store is event-sourced so retries are idempotent and lifecycle changes are
+auditable. No in-memory mutable registry is part of correctness. A later
+compaction can write `<keeper>.snapshot.json`, but P1 should start with
+append-only JSONL.
+
+Content policy:
+
+- Persist `content_preview` after keeper secret redaction.
+- Persist full conversation content in `Keeper_chat_store` when the source is a
+  chat lane; `content_ref` can later point to a chat row once chat rows have a
+  stable row id.
+- Never trust actor authority from message text. Authority comes from route:
+  dashboard owner route -> `Owner`; connector routes -> `External`.
+
+## 6. Adapter Contract
+
+Every adapter owns its pending policy, then calls one helper before dispatching
+or queueing:
+
+```ocaml
+type wake_policy =
+  | Wake
+  | Do_not_wake
+
+type adapter_attention_policy =
+  { classify : inbound_event -> Keeper_external_attention.urgency option
+  ; conversation_ref :
+      inbound_event -> Keeper_external_attention.conversation_ref
+  ; external_message_ref :
+      inbound_event -> Keeper_external_attention.external_message_ref option
+  ; dedupe_key : inbound_event -> string
+  ; wake_policy : Keeper_external_attention.urgency -> wake_policy
+  }
+
+val record_external_attention :
+  base_path:string ->
+  keeper_name:string ->
+  conversation:Keeper_external_attention.conversation_ref ->
+  ?external_message:Keeper_external_attention.external_message_ref ->
+  actor:Keeper_external_attention.actor ->
+  urgency:Keeper_external_attention.urgency ->
+  content_preview:string ->
+  dedupe_key:string ->
+  metadata:(string * string) list ->
+  Keeper_external_attention.item
+```
+
+Mapping rules:
+
+| Adapter | Conversation lane | Urgency | Wake default |
+|---|---|---|---|
+| Discord mention/DM | `discord:<guild>:<channel_id>`; thread messages use the thread channel id | `Mention` or `Direct_message` | wake |
+| Discord ambient bound lane | same Discord lane | `Ambient` | do not wake |
+| Slack app mention/IM | team + channel + thread ts when present | `Mention` or `Direct_message` | wake |
+| Dashboard inbox/chat | keeper + session/default | `Direct_message` | direct queue/turn |
+| GitHub mention/review request | repo + notification/thread | `Mention` or `System` | policy/batch |
+| Generic gate/webhook | adapter supplied | adapter supplied | adapter supplied |
+
+The adapter may still write the existing `Keeper_chat_store` user line. The new
+attention store is not a replacement for chat history; it is the turn-trigger
+and operator-visible lifecycle.
+
+Boundary rule:
+
+```text
+Pending semantics are adapter-policy-owned.
+Lifecycle semantics are MASC-store-owned.
+```
+
+## 7. Scheduler Semantics
+
+Add `pending_external_attention` to `Keeper_world_observation.world_observation`:
+
+```ocaml
+type external_attention_summary =
+  { event_id : string
+  ; source_label : string
+  ; urgency : string
+  ; actor_label : string
+  ; received_at : float
+  ; preview : string
+  }
+
+type world_observation =
+  { ...
+  ; pending_external_attention : external_attention_summary list
+  }
+```
+
+Then wire it into existing decision points:
+
+- `durable_signal_present`: true when pending trigger attention is non-empty.
+- `actionable_signal_present`: true when pending trigger attention is non-empty.
+- `proactive_work_signal_present`: true for `Mention` and `Direct_message`;
+  optional for `Ambient`.
+- `turn_reason`: add `External_attention_pending`.
+- `keeper_cycle_decision`: any pending trigger attention makes the channel
+  `Reactive`, like current pending mentions/board/scope messages.
+- `Keeper_unified_prompt`: add `### External Attention` after `Connected
+  Surfaces` and before `Namespace State`.
+
+Prompt section example:
+
+```text
+### External Attention (2 pending)
+- [discord mention] Alex in #ops at 20:29: "@sangsu can you check ..."
+- [github mention] review request in yousleepwhen/masc#20871: "Need owner..."
+```
+
+When building the turn, append `Claimed_for_turn` for selected event ids with a
+fresh `claim_id`. When the turn successfully persists an assistant reply, append
+`Resolved`. If the keeper deliberately stays silent, append `Ignored` with the
+silence reason. If a process dies after claim and before terminal resolution,
+stale-claim recovery projects the item back to pending instead of dropping it.
+
+## 8. Availability Surface
+
+Add a keeper availability projection independent from transport:
+
+```ocaml
+module Keeper_availability : sig
+  type state =
+    | Ready
+    | Busy
+    | Zzz
+    | Offline
+    | Blocked
+    | Degraded
+
+  type t =
+    { state : state
+    ; reason : string option
+    ; current_turn : Yojson.Safe.t option
+    ; pending_attention_count : int
+    ; top_pending_attention : Yojson.Safe.t option
+    ; next_action : string
+    }
+end
+```
+
+Derivation:
+
+| State | Condition | Display meaning |
+|---|---|---|
+| `Busy` | `Keeper_turn_admission.in_flight` is `Some _` or composite `live_turn` is present | Keeper is already doing a turn. New attention remains pending. |
+| `Ready` | no in-flight turn, lifecycle can execute, pending attention count > 0 | A turn can be promoted now. |
+| `Zzz` | no in-flight turn, lifecycle can execute, pending count = 0, keeper is in sleep/cooldown/poll wait | Nothing urgent is pending; wakeup can change this. |
+| `Offline` | registry/fiber not running or phase cannot execute because keeper is offline | Wakeup alone may not work; recover/start first. |
+| `Blocked` | runtime blocker, approval gate, paused state, provider exhaustion, or continue gate prevents execution | Human/actionable intervention required. |
+| `Degraded` | stale/uncertain/runtime attention says not fully healthy but not hard-blocked | Probe or inspect before relying on automation. |
+
+Composite JSON extension:
+
+```json
+{
+  "availability": {
+    "state": "busy",
+    "reason": "turn_in_flight",
+    "current_turn": {
+      "lane": "autonomous",
+      "started_at": 1781180100.0,
+      "last_progress_at": 1781180163.0
+    },
+    "pending_attention_count": 3,
+    "top_pending_attention": {
+      "source_label": "discord",
+      "urgency": "mention",
+      "actor_label": "Alex",
+      "preview": "@sangsu ..."
+    },
+    "next_action": "will_process_after_current_turn"
+  }
+}
+```
+
+Dashboard copy:
+
+- `Busy`: "Sangsu is busy with an autonomous turn. 3 external items pending."
+- `Ready`: "Sangsu can process 1 pending external item now."
+- `Zzz`: "Sangsu is sleeping; no pending external attention."
+- `Offline`: "Sangsu is offline; recover before wakeup."
+- `Blocked`: "Sangsu is blocked; inspect runtime/approval state."
+
+## 9. Flow Examples
+
+### 9.1 Busy Keeper, Discord Mention
+
+```text
+Sangsu autonomous turn is in flight.
+Discord mention arrives.
+Adapter records external_attention Pending.
+Availability becomes Busy + pending_attention_count=1.
+No second same-keeper turn starts.
+Current turn finishes.
+Next heartbeat/chat consumer observes pending attention.
+Reactive turn starts with External Attention section.
+Item is Claimed_for_turn, then Resolved after reply.
+```
+
+### 9.2 Zzz Keeper, Slack Mention
+
+```text
+Sangsu has no in-flight turn and no pending attention -> Zzz.
+Slack app_mention arrives.
+Adapter records the same lifecycle shape with a Slack surface_ref.
+Availability becomes Ready.
+Wakeup flag is set for high urgency.
+Reactive turn starts.
+Prompt and lifecycle behavior match Discord case.
+```
+
+### 9.3 Ambient Channel Message
+
+```text
+Bound Discord channel receives ordinary ambient chat.
+Adapter records chat history as today.
+If urgency=Ambient, attention item may be retained for context but does not
+force immediate turn unless policy says the keeper observes ambient traffic.
+Availability may show pending ambient count separately, but `Ready` is reserved
+for items allowed to trigger a turn.
+```
+
+## 10. Implementation Slices
+
+### P1. Store and Type Contract
+
+Files:
+
+- add `lib/keeper/keeper_external_attention.ml`
+- add `lib/keeper/keeper_external_attention.mli`
+- add tests in `test/test_keeper_external_attention.ml`
+- add Dune entries
+
+Behavior:
+
+- source-neutral event type;
+- typed `surface_ref`, `conversation_ref`, and `external_message_ref`;
+- JSON encode/decode;
+- append-only durable record under `<base>/.masc/external_attention`;
+- idempotent `record` by `event_id`;
+- pending read with bounded limit and stale-claim projection.
+
+Validation:
+
+```bash
+cd ~/me/workspace/yousleepwhen/masc
+scripts/dune-local.sh build test/test_keeper_external_attention.exe
+./_build/default/test/test_keeper_external_attention.exe
+```
+
+### P2. Gate Adapter Recording
+
+Files:
+
+- `lib/gate_keeper_backend.ml`
+- `lib/server/server_discord_in_process_gateway.ml`
+- later: Slack/dashboard/GitHub adapters as they enter the same gate shape
+
+Behavior:
+
+- record attention before keeper dispatch;
+- keep current chat-store write;
+- use the existing gate idempotency key as the dedupe key;
+- do not put Discord-specific code outside the adapter/boundary layer.
+
+Validation:
+
+- duplicate Discord `message_id` records one attention item;
+- Discord and Slack fixtures produce identical pending item semantics except
+  adapter-owned `surface_ref/source_label`;
+- trigger-policy ambient messages are recorded as `Ambient` and do not force a
+  turn by default.
+
+### P3. Observation and Prompt
+
+Files:
+
+- `lib/keeper/keeper_world_observation.ml`
+- `lib/keeper/keeper_world_observation.mli`
+- `lib/keeper/keeper_unified_prompt.ml`
+- related metric/result helpers for reactive reason labeling
+
+Behavior:
+
+- `pending_external_attention` joins existing pending mentions/board/scope;
+- `External_attention_pending` becomes a typed reactive run reason;
+- prompt renders the bounded list;
+- selected items are claimed with `Claimed_for_turn`.
+
+Validation:
+
+- pending attention makes `keeper_cycle_decision.should_run=true`;
+- source substitution does not change decision;
+- prompt contains `### External Attention` with source labels and previews.
+
+### P4. Availability Surface
+
+Files:
+
+- add `lib/keeper/keeper_availability.ml`
+- add `lib/keeper/keeper_availability.mli`
+- `lib/server/server_dashboard_http_composite_claims.ml`
+- `lib/server/server_dashboard_http_composite_enrich.ml`
+- `dashboard/src/types/core.ts`
+- `dashboard/src/keeper-store-normalize.ts`
+- relevant dashboard component for keeper cards/detail
+
+Behavior:
+
+- expose `availability` JSON in keeper composite;
+- derive `Busy` from turn admission/live turn;
+- derive `Ready` from executable keeper + pending trigger attention;
+- derive `Zzz` from executable keeper + no pending trigger attention;
+- keep `Blocked/Offline/Degraded` tied to lifecycle/runtime state.
+
+Validation:
+
+- busy turn + new attention -> `availability.state=busy`;
+- no turn + pending trigger attention -> `ready`;
+- no turn + no pending attention -> `zzz`;
+- blocked runtime with pending attention -> `blocked`, not `ready`.
+
+### P5. Wakeup Wiring and Resolution
+
+Files:
+
+- `lib/keeper/keeper_keepalive.ml`
+- `lib/keeper/keeper_heartbeat_loop.ml`
+- `lib/keeper/keeper_unified_turn*.ml`
+- possibly `Keeper_chat_consumer` if queued chat should drain pending attention
+  explicitly
+
+Behavior:
+
+- high-urgency pending attention sets `fiber_wakeup`;
+- busy keepers do not start a concurrent turn;
+- successful reply resolves claimed attention items;
+- stay-silent or decline marks included items as `Ignored` with reason.
+
+Validation:
+
+- regression for "no dropped addressed attention";
+- regression for "no second same-keeper turn while busy";
+- restart test: pending attention survives server restart.
+
+## 11. Test Matrix
+
+| Test | Setup | Expected |
+|---|---|---|
+| Source substitution | one Discord mention and one Slack mention with same keeper/content | both become pending trigger attention with identical scheduler behavior |
+| Busy queue | autonomous turn holds slot, external mention arrives | no second turn; `Busy`; pending count increments |
+| Zzz wake | no in-flight turn, keeper healthy, mention arrives | `Ready`; high urgency sets wakeup |
+| Blocked preserves pending | keeper paused/runtime blocked, mention arrives | pending count increments; `Blocked`; no turn until unblocked |
+| Resolution clears | pending item claimed in successful turn | lifecycle projects to `Resolved`; no repeat reactive turn |
+| Stay silent explicit | pending item claimed and model chooses no reply | lifecycle projects to `Ignored` with reason; no infinite reactivity |
+| Stale claim recovers | claim is recorded, process dies before terminal event | item projects back to pending after claim timeout |
+| Restart durability | record pending item, restart server, observe | item is still pending |
+| Ambient policy | ambient bound-lane message arrives | stored as `Ambient`; does not force turn unless policy enables ambient trigger |
+
+## 12. TLA / Invariants
+
+Model the attention lifecycle separately from transport:
+
+```text
+Pending -> ClaimedForTurn -> Resolved
+Pending -> ClaimedForTurn -> Ignored
+ClaimedForTurn -> Pending  (stale claim recovery)
+Pending -> Ignored
+```
+
+Invariants:
+
+- `NoDroppedAddressedAttention`: a `Mention` or `Direct_message` cannot disappear
+  without `Resolved` or `Ignored`.
+- `AtMostOneTurnPerKeeper`: pending attention never bypasses turn single-flight.
+- `SourceNeutralAttention`: changing adapter/surface without changing urgency,
+  target keeper, or content does not change scheduler decision.
+- `BusySurfacesPending`: if a keeper is in-flight and pending trigger attention
+  exists, availability is `Busy`, not `Zzz`.
+- `BlockedDoesNotResolve`: blocked/paused/offline state cannot mark attention
+  resolved.
+
+Bug actions to include:
+
+- `DropPendingOnBusy`
+- `DiscordBypassesAttention`
+- `SecondTurnStartsWhileBusy`
+- `BlockedMarksResolved`
+- `AmbientForcesTurnWithoutPolicy`
+- `ClaimedDiesAndDropsAttention`
+
+## 13. Dashboard Placement
+
+Keeper list/card:
+
+- compact badge: `Ready`, `Busy`, `Zzz`, `Blocked`, `Offline`, `Degraded`
+- pending count next to the badge
+- source icon/label for top pending item
+
+Keeper detail:
+
+- new "Attention" tab or panel near runtime/turn controls;
+- pending list with source, actor, age, urgency, preview;
+- current turn row when Busy;
+- explicit next action text.
+
+Do not bury this under connector settings. The operator asks "why is Sangsu not
+looking at Discord?" while staring at Sangsu, so the answer belongs on the
+keeper surface.
+
+## 14. Open Decisions
+
+1. Should `Ambient` ever wake a keeper automatically?
+   - Conservative default: no. It is visible context, not trigger attention.
+
+2. Should pending external attention reuse `Keeper_chat_store` as the only
+   storage?
+   - No for P1. Chat history is recall; attention is scheduler state. Keep a
+   separate small lifecycle store, optionally cross-reference chat later.
+
+3. Should direct gate dispatch still synchronously wait for a reply?
+   - For operator/dashboard direct chat, yes. For connector events while Busy,
+   prefer record + pending surface over blocking the adapter fiber behind a
+   long autonomous turn.
+
+4. Should `pending_mentions` stay?
+   - Yes initially. P3 can bridge `pending_external_attention` into the same
+   reactive consumer graph. Later, mention-watermark can become a producer of
+   `external_attention` instead of a separate prompt section.
+
+5. Should external reaction/receipt events be part of P1?
+   - No. Discord emoji/read receipts are intentionally excluded from this slice.
+   First ship durable pending attention, availability, and reactive resolution.
+
+## 15. Definition of Done
+
+- The same test fixture can swap Discord `surface_ref` for Slack `surface_ref`
+  and keep the same scheduler/availability result.
+- Discord channel and Discord thread messages get distinct conversation ids
+  without special scheduler behavior.
+- If Sangsu is already in an autonomous turn, a new external mention makes the
+  keeper surface show `Busy` with pending count and top pending item.
+- If Sangsu is sleeping and a mention arrives, availability becomes `Ready` and
+  the keeper wakes through the existing wakeup path.
+- Pending attention survives restart and is not cleared by failed dispatch.
+- OAS has no Discord/Slack/GitHub-specific code changes.
+- Dashboard exposes the state near the keeper, not only in connector settings.

--- a/lib/keeper/keeper_external_attention.ml
+++ b/lib/keeper/keeper_external_attention.ml
@@ -1,0 +1,612 @@
+(* See .mli. *)
+
+let sanitize_name name =
+  Workspace_utils_backend_setup.sanitize_namespace_segment name
+
+let attention_dir base_path =
+  Filename.concat
+    (Common.masc_dir_from_base_path ~base_path)
+    "external_attention"
+
+let attention_path ~base_path ~keeper_name =
+  Filename.concat (attention_dir base_path) (sanitize_name keeper_name ^ ".jsonl")
+
+let ensure_attention_dir ~base_path =
+  let (_ : string) = Keeper_fs.ensure_dir (attention_dir base_path) in
+  ()
+
+let persistence_surface = "keeper_external_attention"
+
+let default_claim_stale_after_s = 900.0
+
+type surface_ref =
+  | Dashboard of { session_id : string option }
+  | Discord of {
+      guild_id : string option;
+      channel_id : string;
+      parent_channel_id : string option;
+      thread_id : string option;
+    }
+  | Slack of {
+      team_id : string option;
+      channel_id : string;
+      thread_ts : string option;
+    }
+  | Github of { repo : string; notification_id : string option }
+  | Webhook of { source : string; event_id : string }
+  | Gate of { label : string; address : (string * string) list }
+
+type conversation_ref = {
+  conversation_id : string;
+  surface : surface_ref;
+}
+
+type external_message_ref = {
+  surface : surface_ref;
+  message_id : string;
+  reply_to_message_id : string option;
+}
+
+type urgency =
+  | Mention
+  | Direct_message
+  | Ambient
+  | System
+
+type actor = {
+  actor_id : string option;
+  display_name : string option;
+  authority : Keeper_chat_store.speaker_authority;
+}
+
+type item = {
+  event_id : string;
+  dedupe_key : string;
+  keeper_name : string;
+  conversation : conversation_ref;
+  external_message : external_message_ref option;
+  source_label : string;
+  actor : actor;
+  urgency : urgency;
+  content_preview : string;
+  content_ref : string option;
+  received_at : float;
+  metadata : (string * string) list;
+}
+
+type event =
+  | Recorded of item
+  | Claimed_for_turn of {
+      event_id : string;
+      claim_id : string;
+      turn_id : int option;
+      claimed_at : float;
+    }
+  | Resolved of {
+      event_id : string;
+      resolved_at : float;
+      reason : string;
+    }
+  | Ignored of {
+      event_id : string;
+      ignored_at : float;
+      reason : string;
+    }
+
+type record_result =
+  [ `Recorded
+  | `Duplicate of item
+  | `Error of string
+  ]
+
+let event_id_of_dedupe_key key =
+  Digestif.SHA256.(digest_string key |> to_hex)
+
+let urgency_to_string = function
+  | Mention -> "mention"
+  | Direct_message -> "direct_message"
+  | Ambient -> "ambient"
+  | System -> "system"
+
+let urgency_of_string = function
+  | "mention" -> Some Mention
+  | "direct_message" -> Some Direct_message
+  | "ambient" -> Some Ambient
+  | "system" -> Some System
+  | _ -> None
+
+let opt_string_field key = function
+  | None -> []
+  | Some value -> [ (key, `String value) ]
+
+let opt_int_field key = function
+  | None -> []
+  | Some value -> [ (key, `Int value) ]
+
+let string_assoc_json fields =
+  `Assoc (List.map (fun (key, value) -> (key, `String value)) fields)
+
+let string_assoc_of_json = function
+  | `Assoc fields ->
+      Ok
+        (List.filter_map
+           (fun (key, value) ->
+             match value with
+             | `String s -> Some (key, s)
+             | _ -> None)
+           fields)
+  | _ -> Error "expected string object"
+
+let required_string key = function
+  | `Assoc fields -> (
+      match List.assoc_opt key fields with
+      | Some (`String value) -> Ok value
+      | _ -> Error (Printf.sprintf "missing string field %s" key))
+  | _ -> Error "expected object"
+
+let optional_string key = function
+  | `Assoc fields -> (
+      match List.assoc_opt key fields with
+      | Some (`String value) when String.trim value <> "" -> Some value
+      | Some (`String _) | Some `Null | None -> None
+      | Some _ -> None)
+  | _ -> None
+
+let optional_int key = function
+  | `Assoc fields -> (
+      match List.assoc_opt key fields with
+      | Some (`Int value) -> Some value
+      | Some `Null | None -> None
+      | Some _ -> None)
+  | _ -> None
+
+let required_float key = function
+  | `Assoc fields -> (
+      match List.assoc_opt key fields with
+      | Some (`Float value) -> Ok value
+      | Some (`Int value) -> Ok (float_of_int value)
+      | _ -> Error (Printf.sprintf "missing float field %s" key))
+  | _ -> Error "expected object"
+
+let required_object key = function
+  | `Assoc fields -> (
+      match List.assoc_opt key fields with
+      | Some (`Assoc _ as obj) -> Ok obj
+      | _ -> Error (Printf.sprintf "missing object field %s" key))
+  | _ -> Error "expected object"
+
+let optional_object key = function
+  | `Assoc fields -> (
+      match List.assoc_opt key fields with
+      | Some (`Assoc _ as obj) -> Some obj
+      | Some `Null | None -> None
+      | Some _ -> None)
+  | _ -> None
+
+let ( let* ) = Result.bind
+
+let surface_ref_to_json = function
+  | Dashboard { session_id } ->
+      `Assoc
+        ([ ("kind", `String "dashboard") ] @ opt_string_field "session_id" session_id)
+  | Discord { guild_id; channel_id; parent_channel_id; thread_id } ->
+      `Assoc
+        ([ ("kind", `String "discord"); ("channel_id", `String channel_id) ]
+        @ opt_string_field "guild_id" guild_id
+        @ opt_string_field "parent_channel_id" parent_channel_id
+        @ opt_string_field "thread_id" thread_id)
+  | Slack { team_id; channel_id; thread_ts } ->
+      `Assoc
+        ([ ("kind", `String "slack"); ("channel_id", `String channel_id) ]
+        @ opt_string_field "team_id" team_id
+        @ opt_string_field "thread_ts" thread_ts)
+  | Github { repo; notification_id } ->
+      `Assoc
+        ([ ("kind", `String "github"); ("repo", `String repo) ]
+        @ opt_string_field "notification_id" notification_id)
+  | Webhook { source; event_id } ->
+      `Assoc
+        [
+          ("kind", `String "webhook");
+          ("source", `String source);
+          ("event_id", `String event_id);
+        ]
+  | Gate { label; address } ->
+      `Assoc
+        [
+          ("kind", `String "gate");
+          ("label", `String label);
+          ("address", string_assoc_json address);
+        ]
+
+let surface_ref_of_json json =
+  let* kind = required_string "kind" json in
+  match kind with
+  | "dashboard" -> Ok (Dashboard { session_id = optional_string "session_id" json })
+  | "discord" ->
+      let* channel_id = required_string "channel_id" json in
+      Ok
+        (Discord
+           {
+             guild_id = optional_string "guild_id" json;
+             channel_id;
+             parent_channel_id = optional_string "parent_channel_id" json;
+             thread_id = optional_string "thread_id" json;
+           })
+  | "slack" ->
+      let* channel_id = required_string "channel_id" json in
+      Ok
+        (Slack
+           {
+             team_id = optional_string "team_id" json;
+             channel_id;
+             thread_ts = optional_string "thread_ts" json;
+           })
+  | "github" ->
+      let* repo = required_string "repo" json in
+      Ok (Github { repo; notification_id = optional_string "notification_id" json })
+  | "webhook" ->
+      let* source = required_string "source" json in
+      let* event_id = required_string "event_id" json in
+      Ok (Webhook { source; event_id })
+  | "gate" ->
+      let* label = required_string "label" json in
+      let address =
+        match optional_object "address" json with
+        | None -> Ok []
+        | Some obj -> string_assoc_of_json obj
+      in
+      let* address = address in
+      Ok (Gate { label; address })
+  | other -> Error (Printf.sprintf "unknown surface kind %S" other)
+
+let conversation_ref_to_json c =
+  `Assoc
+    [
+      ("conversation_id", `String c.conversation_id);
+      ("surface", surface_ref_to_json c.surface);
+    ]
+
+let conversation_ref_of_json json =
+  let* conversation_id = required_string "conversation_id" json in
+  let* surface_json = required_object "surface" json in
+  let* surface = surface_ref_of_json surface_json in
+  Ok { conversation_id; surface }
+
+let external_message_ref_to_json m =
+  `Assoc
+    ([ ("surface", surface_ref_to_json m.surface); ("message_id", `String m.message_id) ]
+    @ opt_string_field "reply_to_message_id" m.reply_to_message_id)
+
+let external_message_ref_of_json json =
+  let* surface_json = required_object "surface" json in
+  let* surface = surface_ref_of_json surface_json in
+  let* message_id = required_string "message_id" json in
+  Ok { surface; message_id; reply_to_message_id = optional_string "reply_to_message_id" json }
+
+let actor_to_json actor =
+  `Assoc
+    (opt_string_field "actor_id" actor.actor_id
+    @ opt_string_field "display_name" actor.display_name
+    @ [
+        ( "authority",
+          `String (Keeper_chat_store.authority_label actor.authority) );
+      ])
+
+let actor_of_json json =
+  let* authority_label = required_string "authority" json in
+  match Keeper_chat_store.authority_of_label authority_label with
+  | None -> Error (Printf.sprintf "unknown actor authority %S" authority_label)
+  | Some authority ->
+      Ok
+        {
+          actor_id = optional_string "actor_id" json;
+          display_name = optional_string "display_name" json;
+          authority;
+        }
+
+let item_to_json item =
+  `Assoc
+    ([ ("event_id", `String item.event_id);
+       ("dedupe_key", `String item.dedupe_key);
+       ("keeper_name", `String item.keeper_name);
+       ("conversation", conversation_ref_to_json item.conversation);
+       ("source_label", `String item.source_label);
+       ("actor", actor_to_json item.actor);
+       ("urgency", `String (urgency_to_string item.urgency));
+       ("content_preview", `String item.content_preview);
+       ("received_at", `Float item.received_at);
+       ("metadata", string_assoc_json item.metadata);
+     ]
+    @ (match item.external_message with
+      | None -> []
+      | Some ref_ -> [ ("external_message", external_message_ref_to_json ref_) ])
+    @ opt_string_field "content_ref" item.content_ref)
+
+let item_of_json json =
+  let* event_id = required_string "event_id" json in
+  let* dedupe_key = required_string "dedupe_key" json in
+  let* keeper_name = required_string "keeper_name" json in
+  let* conversation_json = required_object "conversation" json in
+  let* conversation = conversation_ref_of_json conversation_json in
+  let external_message =
+    match optional_object "external_message" json with
+    | None -> Ok None
+    | Some obj ->
+        let* msg = external_message_ref_of_json obj in
+        Ok (Some msg)
+  in
+  let* external_message = external_message in
+  let* source_label = required_string "source_label" json in
+  let* actor_json = required_object "actor" json in
+  let* actor = actor_of_json actor_json in
+  let* urgency_label = required_string "urgency" json in
+  let* urgency =
+    match urgency_of_string urgency_label with
+    | Some urgency -> Ok urgency
+    | None -> Error (Printf.sprintf "unknown urgency %S" urgency_label)
+  in
+  let* content_preview = required_string "content_preview" json in
+  let* received_at = required_float "received_at" json in
+  let metadata =
+    match optional_object "metadata" json with
+    | None -> Ok []
+    | Some obj -> string_assoc_of_json obj
+  in
+  let* metadata = metadata in
+  Ok
+    {
+      event_id;
+      dedupe_key;
+      keeper_name;
+      conversation;
+      external_message;
+      source_label;
+      actor;
+      urgency;
+      content_preview;
+      content_ref = optional_string "content_ref" json;
+      received_at;
+      metadata;
+    }
+
+let event_to_json = function
+  | Recorded item -> `Assoc [ ("event", `String "recorded"); ("item", item_to_json item) ]
+  | Claimed_for_turn { event_id; claim_id; turn_id; claimed_at } ->
+      `Assoc
+        ([ ("event", `String "claimed_for_turn");
+           ("event_id", `String event_id);
+           ("claim_id", `String claim_id);
+           ("claimed_at", `Float claimed_at);
+         ]
+        @ opt_int_field "turn_id" turn_id)
+  | Resolved { event_id; resolved_at; reason } ->
+      `Assoc
+        [
+          ("event", `String "resolved");
+          ("event_id", `String event_id);
+          ("resolved_at", `Float resolved_at);
+          ("reason", `String reason);
+        ]
+  | Ignored { event_id; ignored_at; reason } ->
+      `Assoc
+        [
+          ("event", `String "ignored");
+          ("event_id", `String event_id);
+          ("ignored_at", `Float ignored_at);
+          ("reason", `String reason);
+        ]
+
+let event_of_json json =
+  let* tag = required_string "event" json in
+  match tag with
+  | "recorded" ->
+      let* item_json = required_object "item" json in
+      let* item = item_of_json item_json in
+      Ok (Recorded item)
+  | "claimed_for_turn" ->
+      let* event_id = required_string "event_id" json in
+      let* claim_id = required_string "claim_id" json in
+      let* claimed_at = required_float "claimed_at" json in
+      Ok
+        (Claimed_for_turn
+           {
+             event_id;
+             claim_id;
+             turn_id = optional_int "turn_id" json;
+             claimed_at;
+           })
+  | "resolved" ->
+      let* event_id = required_string "event_id" json in
+      let* resolved_at = required_float "resolved_at" json in
+      let* reason = required_string "reason" json in
+      Ok (Resolved { event_id; resolved_at; reason })
+  | "ignored" ->
+      let* event_id = required_string "event_id" json in
+      let* ignored_at = required_float "ignored_at" json in
+      let* reason = required_string "reason" json in
+      Ok (Ignored { event_id; ignored_at; reason })
+  | other -> Error (Printf.sprintf "unknown external attention event %S" other)
+
+let report_read_drop ~reason ~path ~detail =
+  Safe_ops.report_persistence_read_drop
+    ~on_drop:(fun () ->
+      Otel_metric_store.inc_counter
+        Otel_metric_store.metric_persistence_read_drops
+        ~labels:[ ("surface", persistence_surface); ("reason", reason) ]
+        ())
+    ~surface:persistence_surface ~reason ~path ~detail
+
+let parse_line ~file_path line =
+  try
+    match event_of_json (Yojson.Safe.from_string line) with
+    | Ok event -> Some event
+    | Error detail ->
+        report_read_drop
+          ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
+          ~path:file_path ~detail;
+        None
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | Yojson.Json_error detail ->
+      report_read_drop
+        ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
+        ~path:file_path ~detail;
+      None
+
+let load_events ~base_path ~keeper_name =
+  let path = attention_path ~base_path ~keeper_name in
+  if not (Sys.file_exists path) then []
+  else
+    try
+      let events_rev, _boundary =
+        Fs_compat.fold_appended_lines ~path ~from:0 ~init:[]
+          ~f:(fun acc line ->
+            let line = String.trim line in
+            if line = "" then acc
+            else
+              match parse_line ~file_path:path line with
+              | Some event -> event :: acc
+              | None -> acc)
+      in
+      List.rev events_rev
+    with
+    | Sys_error detail ->
+        report_read_drop
+          ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
+          ~path ~detail;
+        []
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
+        Log.Keeper.warn "keeper_external_attention: load failed for %s: %s"
+          (sanitize_name keeper_name) (Printexc.to_string exn);
+        []
+
+let append_event ~base_path ~keeper_name event =
+  try
+    ensure_attention_dir ~base_path;
+    let path = attention_path ~base_path ~keeper_name in
+    Fs_compat.append_file path (Yojson.Safe.to_string (event_to_json event) ^ "\n");
+    Ok ()
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+      let detail = Printexc.to_string exn in
+      Log.Keeper.warn "keeper_external_attention: append failed for %s: %s"
+        (sanitize_name keeper_name) detail;
+      Error detail
+
+let recorded_item_by_event_id events event_id =
+  List.find_map
+    (function
+      | Recorded item when String.equal item.event_id event_id -> Some item
+      | Recorded _ | Claimed_for_turn _ | Resolved _ | Ignored _ -> None)
+    events
+
+let record ~base_path (item : item) =
+  let events = load_events ~base_path ~keeper_name:item.keeper_name in
+  match recorded_item_by_event_id events item.event_id with
+  | Some existing -> `Duplicate existing
+  | None -> (
+      match append_event ~base_path ~keeper_name:item.keeper_name (Recorded item) with
+      | Ok () -> `Recorded
+      | Error detail -> `Error detail)
+
+let now_or_default = function
+  | Some now -> now
+  | None -> Time_compat.now ()
+
+let append_many ~base_path ~keeper_name events =
+  try
+    ensure_attention_dir ~base_path;
+    let path = attention_path ~base_path ~keeper_name in
+    let jsons = List.map event_to_json events in
+    Fs_compat.append_jsonl_batch path jsons;
+    Ok ()
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+      let detail = Printexc.to_string exn in
+      Log.Keeper.warn "keeper_external_attention: append batch failed for %s: %s"
+        (sanitize_name keeper_name) detail;
+      Error detail
+
+let claim_for_turn ~base_path ~keeper_name ~event_ids ~claim_id ~turn_id ?now () =
+  let claimed_at = now_or_default now in
+  let events =
+    List.map
+      (fun event_id -> Claimed_for_turn { event_id; claim_id; turn_id; claimed_at })
+      event_ids
+  in
+  append_many ~base_path ~keeper_name events
+
+let mark_resolved ~base_path ~keeper_name ~event_ids ~reason ?now () =
+  let resolved_at = now_or_default now in
+  let events =
+    List.map
+      (fun event_id -> Resolved { event_id; resolved_at; reason })
+      event_ids
+  in
+  append_many ~base_path ~keeper_name events
+
+let mark_ignored ~base_path ~keeper_name ~event_ids ~reason ?now () =
+  let ignored_at = now_or_default now in
+  let events =
+    List.map
+      (fun event_id -> Ignored { event_id; ignored_at; reason })
+      event_ids
+  in
+  append_many ~base_path ~keeper_name events
+
+type projected_state =
+  | Pending of item
+  | Claimed of item * float
+  | Terminal
+
+let project_pending events ~now ~claim_stale_after =
+  let tbl : (string, projected_state) Hashtbl.t = Hashtbl.create 16 in
+  List.iter
+    (function
+      | Recorded item -> (
+          match Hashtbl.find_opt tbl item.event_id with
+          | Some Terminal -> ()
+          | Some (Claimed _ | Pending _) | None ->
+              Hashtbl.replace tbl item.event_id (Pending item))
+      | Claimed_for_turn { event_id; claimed_at; _ } -> (
+          match Hashtbl.find_opt tbl event_id with
+          | Some (Pending item) -> Hashtbl.replace tbl event_id (Claimed (item, claimed_at))
+          | Some (Claimed _ | Terminal) | None -> ())
+      | Resolved { event_id; _ } | Ignored { event_id; _ } ->
+          Hashtbl.replace tbl event_id Terminal)
+    events;
+  Hashtbl.fold
+    (fun _ state acc ->
+      match state with
+      | Pending item -> item :: acc
+      | Claimed (item, claimed_at)
+        when now -. claimed_at > claim_stale_after ->
+          item :: acc
+      | Claimed _ | Terminal -> acc)
+    tbl []
+  |> List.sort (fun a b -> compare a.received_at b.received_at)
+
+let take limit items =
+  let rec loop n acc = function
+    | _ when n <= 0 -> List.rev acc
+    | [] -> List.rev acc
+    | item :: rest -> loop (n - 1) (item :: acc) rest
+  in
+  loop limit [] items
+
+let pending_for_keeper ~base_path ~keeper_name ?now ?claim_stale_after ~limit () =
+  let now = now_or_default now in
+  let claim_stale_after =
+    match claim_stale_after with
+    | Some seconds -> seconds
+    | None -> default_claim_stale_after_s
+  in
+  let pending =
+    load_events ~base_path ~keeper_name
+    |> project_pending ~now ~claim_stale_after
+  in
+  take (max 0 limit) pending

--- a/lib/keeper/keeper_external_attention.mli
+++ b/lib/keeper/keeper_external_attention.mli
@@ -1,0 +1,170 @@
+(** Keeper_external_attention — durable, connector-neutral attention lifecycle.
+
+    This store records external attention before keeper dispatch. Adapter
+    policy decides which platform events become attention; this module only
+    persists the typed surface/conversation coordinates and folds lifecycle
+    events into a pending projection.
+
+    Stored at:
+    [<base_path>/.masc/external_attention/<sanitized-keeper>.jsonl]. *)
+
+(** {1 Coordinates} *)
+
+type surface_ref =
+  | Dashboard of { session_id : string option }
+  | Discord of {
+      guild_id : string option;
+      channel_id : string;
+      parent_channel_id : string option;
+      thread_id : string option;
+    }
+  | Slack of {
+      team_id : string option;
+      channel_id : string;
+      thread_ts : string option;
+    }
+  | Github of { repo : string; notification_id : string option }
+  | Webhook of { source : string; event_id : string }
+  | Gate of { label : string; address : (string * string) list }
+
+type conversation_ref = {
+  conversation_id : string;
+  surface : surface_ref;
+}
+
+type external_message_ref = {
+  surface : surface_ref;
+  message_id : string;
+  reply_to_message_id : string option;
+}
+
+(** {1 Attention event model} *)
+
+type urgency =
+  | Mention
+  | Direct_message
+  | Ambient
+  | System
+
+type actor = {
+  actor_id : string option;
+  display_name : string option;
+  authority : Keeper_chat_store.speaker_authority;
+}
+
+type item = {
+  event_id : string;
+  dedupe_key : string;
+  keeper_name : string;
+  conversation : conversation_ref;
+  external_message : external_message_ref option;
+  source_label : string;
+  actor : actor;
+  urgency : urgency;
+  content_preview : string;
+  content_ref : string option;
+  received_at : float;
+  metadata : (string * string) list;
+}
+
+type event =
+  | Recorded of item
+  | Claimed_for_turn of {
+      event_id : string;
+      claim_id : string;
+      turn_id : int option;
+      claimed_at : float;
+    }
+  | Resolved of {
+      event_id : string;
+      resolved_at : float;
+      reason : string;
+    }
+  | Ignored of {
+      event_id : string;
+      ignored_at : float;
+      reason : string;
+    }
+
+(** Default stale claim timeout used by {!pending_for_keeper}. *)
+val default_claim_stale_after_s : float
+
+val event_id_of_dedupe_key : string -> string
+
+(** {1 Labels and JSON codecs} *)
+
+val urgency_to_string : urgency -> string
+val urgency_of_string : string -> urgency option
+
+val surface_ref_to_json : surface_ref -> Yojson.Safe.t
+val surface_ref_of_json : Yojson.Safe.t -> (surface_ref, string) result
+
+val conversation_ref_to_json : conversation_ref -> Yojson.Safe.t
+val conversation_ref_of_json : Yojson.Safe.t -> (conversation_ref, string) result
+
+val external_message_ref_to_json : external_message_ref -> Yojson.Safe.t
+
+val external_message_ref_of_json :
+  Yojson.Safe.t -> (external_message_ref, string) result
+
+val actor_to_json : actor -> Yojson.Safe.t
+val actor_of_json : Yojson.Safe.t -> (actor, string) result
+
+val item_to_json : item -> Yojson.Safe.t
+val item_of_json : Yojson.Safe.t -> (item, string) result
+
+val event_to_json : event -> Yojson.Safe.t
+val event_of_json : Yojson.Safe.t -> (event, string) result
+
+(** {1 Store operations} *)
+
+type record_result =
+  [ `Recorded
+  | `Duplicate of item
+  | `Error of string
+  ]
+
+val record : base_path:string -> item -> record_result
+(** Appends [Recorded item] unless [event_id] already exists in the log. *)
+
+val claim_for_turn :
+  base_path:string ->
+  keeper_name:string ->
+  event_ids:string list ->
+  claim_id:string ->
+  turn_id:int option ->
+  ?now:float ->
+  unit ->
+  (unit, string) result
+
+val mark_resolved :
+  base_path:string ->
+  keeper_name:string ->
+  event_ids:string list ->
+  reason:string ->
+  ?now:float ->
+  unit ->
+  (unit, string) result
+
+val mark_ignored :
+  base_path:string ->
+  keeper_name:string ->
+  event_ids:string list ->
+  reason:string ->
+  ?now:float ->
+  unit ->
+  (unit, string) result
+
+val load_events : base_path:string -> keeper_name:string -> event list
+
+val pending_for_keeper :
+  base_path:string ->
+  keeper_name:string ->
+  ?now:float ->
+  ?claim_stale_after:float ->
+  limit:int ->
+  unit ->
+  item list
+(** Returns pending items ordered by [received_at], capped to [limit].
+    A non-terminal claim older than [claim_stale_after] is projected back
+    to pending instead of dropped. *)

--- a/test/dune
+++ b/test/dune
@@ -136,6 +136,7 @@
   test_keeper_timing
   test_keeper_token_count
   test_keeper_chat_store
+  test_keeper_external_attention
   test_keeper_runtime_trust_snapshot
   test_keeper_tool_audit_snapshot
   test_ide_annotations
@@ -406,6 +407,7 @@
   test_keeper_timing
   test_keeper_token_count
   test_keeper_chat_store
+  test_keeper_external_attention
   test_keeper_runtime_trust_snapshot
   test_keeper_tool_audit_snapshot
   test_ide_annotations

--- a/test/test_keeper_external_attention.ml
+++ b/test/test_keeper_external_attention.ml
@@ -1,0 +1,202 @@
+module A = Masc.Keeper_external_attention
+
+let rec remove_tree path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path
+      |> Array.iter (fun name -> remove_tree (Filename.concat path name));
+      Unix.rmdir path
+    end
+    else Sys.remove path
+
+let temp_base_path prefix =
+  Filename.concat (Filename.get_temp_dir_name ())
+    (Printf.sprintf "%s-%d-%d" prefix (Unix.getpid ()) (Random.bits ()))
+
+let expect_ok = function
+  | Ok () -> ()
+  | Error detail -> Alcotest.failf "expected Ok, got Error %s" detail
+
+let discord_surface ?thread_id ?parent_channel_id channel_id =
+  A.Discord
+    {
+      guild_id = Some "guild-1";
+      channel_id;
+      parent_channel_id;
+      thread_id;
+    }
+
+let conversation ?(surface = discord_surface "chan-1") id =
+  { A.conversation_id = id; surface }
+
+let external_message ?(surface = discord_surface "chan-1") message_id =
+  { A.surface = surface; message_id; reply_to_message_id = None }
+
+let item ?(dedupe_key = "discord:chan-1:msg-1") ?(keeper_name = "sangsu")
+    ?(conversation = conversation "discord:guild-1:chan-1")
+    ?external_message ?(urgency = A.Mention) ?(received_at = 10.0)
+    ?(preview = "@sangsu check this") () =
+  {
+    A.event_id = A.event_id_of_dedupe_key dedupe_key;
+    dedupe_key;
+    keeper_name;
+    conversation;
+    external_message;
+    source_label = "discord";
+    actor =
+      {
+        actor_id = Some "user-1";
+        display_name = Some "Alex";
+        authority = Masc.Keeper_chat_store.External;
+      };
+    urgency;
+    content_preview = preview;
+    content_ref = None;
+    received_at;
+    metadata = [ ("fixture", "yes") ];
+  }
+
+let check_roundtrip name encode decode value =
+  match decode (encode value) with
+  | Ok decoded -> Alcotest.(check bool) name true (decoded = value)
+  | Error detail -> Alcotest.failf "%s decode failed: %s" name detail
+
+let test_json_roundtrip () =
+  let thread_surface =
+    discord_surface ~thread_id:"thread-1" ~parent_channel_id:"chan-parent"
+      "thread-1"
+  in
+  let conv = conversation ~surface:thread_surface "discord:guild-1:thread-1" in
+  let msg = external_message ~surface:thread_surface "msg-1" in
+  let att = item ~conversation:conv ~external_message:msg () in
+  check_roundtrip "surface" A.surface_ref_to_json A.surface_ref_of_json
+    thread_surface;
+  check_roundtrip "conversation" A.conversation_ref_to_json
+    A.conversation_ref_of_json conv;
+  check_roundtrip "external message" A.external_message_ref_to_json
+    A.external_message_ref_of_json msg;
+  check_roundtrip "item" A.item_to_json A.item_of_json att;
+  check_roundtrip "recorded event" A.event_to_json A.event_of_json
+    (A.Recorded att);
+  check_roundtrip "claimed event" A.event_to_json A.event_of_json
+    (A.Claimed_for_turn
+       {
+         event_id = att.A.event_id;
+         claim_id = "claim-1";
+         turn_id = Some 42;
+         claimed_at = 20.0;
+       });
+  check_roundtrip "resolved event" A.event_to_json A.event_of_json
+    (A.Resolved
+       { event_id = att.A.event_id; resolved_at = 30.0; reason = "replied" })
+
+let with_temp_base name f =
+  let base_path = temp_base_path name in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_path with _ -> ())
+    (fun () -> f base_path)
+
+let test_record_dedupes_and_reads_pending () =
+  with_temp_base "keeper-external-attention-record" @@ fun base_path ->
+  let att = item () in
+  (match A.record ~base_path att with
+  | `Recorded -> ()
+  | `Duplicate _ -> Alcotest.fail "first record was duplicate"
+  | `Error detail -> Alcotest.failf "record failed: %s" detail);
+  (match A.record ~base_path att with
+  | `Duplicate duplicate ->
+      Alcotest.(check string) "duplicate event id" att.A.event_id
+        duplicate.A.event_id
+  | `Recorded -> Alcotest.fail "duplicate record appended again"
+  | `Error detail -> Alcotest.failf "duplicate record failed: %s" detail);
+  Alcotest.(check int) "one physical recorded event" 1
+    (List.length (A.load_events ~base_path ~keeper_name:att.A.keeper_name));
+  match A.pending_for_keeper ~base_path ~keeper_name:att.A.keeper_name ~limit:10 () with
+  | [ pending ] ->
+      Alcotest.(check string) "pending event id" att.A.event_id pending.A.event_id
+  | pending ->
+      Alcotest.failf "expected 1 pending item, got %d" (List.length pending)
+
+let test_claim_resolution_and_ignore_projection () =
+  with_temp_base "keeper-external-attention-lifecycle" @@ fun base_path ->
+  let one = item ~dedupe_key:"discord:chan-1:msg-1" ~received_at:1.0 () in
+  let two = item ~dedupe_key:"discord:chan-1:msg-2" ~received_at:2.0 () in
+  ignore (A.record ~base_path one : A.record_result);
+  ignore (A.record ~base_path two : A.record_result);
+  expect_ok
+    (A.claim_for_turn ~base_path ~keeper_name:"sangsu"
+       ~event_ids:[ one.A.event_id ] ~claim_id:"claim-1" ~turn_id:(Some 7)
+       ~now:10.0 ());
+  let pending =
+    A.pending_for_keeper ~base_path ~keeper_name:"sangsu" ~now:11.0
+      ~claim_stale_after:60.0 ~limit:10 ()
+  in
+  Alcotest.(check (list string)) "claimed item hidden"
+    [ two.A.event_id ]
+    (List.map (fun i -> i.A.event_id) pending);
+  expect_ok
+    (A.mark_resolved ~base_path ~keeper_name:"sangsu"
+       ~event_ids:[ one.A.event_id ] ~reason:"replied" ~now:12.0 ());
+  expect_ok
+    (A.mark_ignored ~base_path ~keeper_name:"sangsu"
+       ~event_ids:[ two.A.event_id ] ~reason:"silent" ~now:13.0 ());
+  Alcotest.(check int) "all terminal" 0
+    (List.length
+       (A.pending_for_keeper ~base_path ~keeper_name:"sangsu" ~now:14.0
+          ~limit:10 ()))
+
+let test_stale_claim_projects_back_to_pending () =
+  with_temp_base "keeper-external-attention-stale-claim" @@ fun base_path ->
+  let att = item () in
+  ignore (A.record ~base_path att : A.record_result);
+  expect_ok
+    (A.claim_for_turn ~base_path ~keeper_name:"sangsu"
+       ~event_ids:[ att.A.event_id ] ~claim_id:"claim-1" ~turn_id:None
+       ~now:10.0 ());
+  Alcotest.(check int) "fresh claim hidden" 0
+    (List.length
+       (A.pending_for_keeper ~base_path ~keeper_name:"sangsu" ~now:11.0
+          ~claim_stale_after:5.0 ~limit:10 ()));
+  match
+    A.pending_for_keeper ~base_path ~keeper_name:"sangsu" ~now:20.0
+      ~claim_stale_after:5.0 ~limit:10 ()
+  with
+  | [ pending ] ->
+      Alcotest.(check string) "stale claim recovered" att.A.event_id
+        pending.A.event_id
+  | pending ->
+      Alcotest.failf "expected recovered pending item, got %d"
+        (List.length pending)
+
+let test_discord_channel_and_thread_conversation_ids_stay_distinct () =
+  let channel =
+    conversation ~surface:(discord_surface "chan-1") "discord:guild-1:chan-1"
+  in
+  let thread =
+    conversation
+      ~surface:
+        (discord_surface ~thread_id:"thread-1" ~parent_channel_id:"chan-1"
+           "thread-1")
+      "discord:guild-1:thread-1"
+  in
+  Alcotest.(check bool) "distinct lane ids" true
+    (channel.A.conversation_id <> thread.A.conversation_id)
+
+let () =
+  Alcotest.run "keeper_external_attention"
+    [
+      ( "json",
+        [ Alcotest.test_case "surface/item/event roundtrip" `Quick test_json_roundtrip ]
+      );
+      ( "store",
+        [
+          Alcotest.test_case "record dedupes and reads pending" `Quick
+            test_record_dedupes_and_reads_pending;
+          Alcotest.test_case "claim, resolve, ignore projection" `Quick
+            test_claim_resolution_and_ignore_projection;
+          Alcotest.test_case "stale claim projects back to pending" `Quick
+            test_stale_claim_projects_back_to_pending;
+          Alcotest.test_case "Discord channel/thread lanes are distinct" `Quick
+            test_discord_channel_and_thread_conversation_ids_stay_distinct;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

- Add a MASC-only `Keeper_external_attention` append-only store for external conversation attention.
- Model stable `surface_ref`, `conversation_ref`, and `external_message_ref` values so Discord channels and threads remain separate lanes.
- Add lifecycle projection for `Recorded`, `Claimed_for_turn`, `Resolved`, and `Ignored`, including stale claim recovery.
- Document the external attention boundary and keep the first slice free of emoji/reaction receipts.

## Boundary

- OAS is untouched.
- Pending/ack behavior remains adapter/platform policy; MASC owns durable attention lifecycle state.

## Validation

- `ocamlformat --check lib/keeper/keeper_external_attention.mli lib/keeper/keeper_external_attention.ml test/test_keeper_external_attention.ml`
- `git diff --check`
- `scripts/dune-local.sh build test/test_keeper_external_attention.exe`
- `scripts/dune-local.sh exec ./test/test_keeper_external_attention.exe`
