### PR TITLE
[codex] Add Discord typing wait projection

### DIFF
--- a/docs/design/channel-independent-turn-surface-plan.html
+++ b/docs/design/channel-independent-turn-surface-plan.html
@@ -1,0 +1,405 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Channel-Independent Turn Surface Plan</title>
+  <style>
+    :root {
+      --bg: #f5f7f8;
+      --panel: #ffffff;
+      --ink: #162027;
+      --muted: #5f6d77;
+      --line: #d9e0e5;
+      --code: #eef2f4;
+      --blue: #1d5f91;
+      --green: #14784f;
+      --amber: #a15d07;
+      --red: #b42318;
+      --violet: #6845aa;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--ink);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans KR", sans-serif;
+      line-height: 1.55;
+    }
+
+    header {
+      border-bottom: 1px solid var(--line);
+      background: var(--panel);
+      padding: 38px 34px 28px;
+    }
+
+    main {
+      max-width: 1260px;
+      margin: 0 auto;
+      padding: 26px 24px 72px;
+    }
+
+    h1, h2, h3 {
+      margin: 0;
+      line-height: 1.22;
+      letter-spacing: 0;
+    }
+
+    h1 { font-size: 34px; }
+    h2 { margin-top: 34px; font-size: 23px; }
+    h3 { margin-top: 18px; font-size: 17px; }
+    p { margin: 10px 0; }
+
+    code {
+      padding: 2px 5px;
+      border: 1px solid var(--line);
+      border-radius: 4px;
+      background: var(--code);
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      font-size: 0.92em;
+    }
+
+    pre {
+      overflow-x: auto;
+      margin: 12px 0 0;
+      padding: 14px;
+      border-radius: 8px;
+      background: #111820;
+      color: #e8edf2;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      font-size: 13px;
+      line-height: 1.45;
+    }
+
+    table {
+      width: 100%;
+      margin-top: 12px;
+      border-collapse: collapse;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      overflow: hidden;
+      background: var(--panel);
+    }
+
+    th, td {
+      padding: 10px 12px;
+      border-bottom: 1px solid var(--line);
+      text-align: left;
+      vertical-align: top;
+      font-size: 14px;
+    }
+
+    th {
+      background: #edf2f5;
+      color: #35434d;
+      font-size: 12px;
+      text-transform: uppercase;
+    }
+
+    tr:last-child td { border-bottom: 0; }
+
+    ul {
+      margin: 10px 0 0;
+      padding-left: 20px;
+    }
+
+    li { margin: 5px 0; }
+
+    .lede {
+      max-width: 940px;
+      color: var(--muted);
+      font-size: 16px;
+    }
+
+    .meta {
+      margin-top: 12px;
+      color: var(--muted);
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      font-size: 12px;
+    }
+
+    .grid {
+      display: grid;
+      gap: 12px;
+    }
+
+    .cards { grid-template-columns: repeat(5, minmax(0, 1fr)); margin-top: 18px; }
+    .two { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .three { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+
+    .card, .panel {
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: var(--panel);
+    }
+
+    .card {
+      min-height: 132px;
+      padding: 15px;
+    }
+
+    .panel {
+      margin-top: 14px;
+      padding: 18px;
+    }
+
+    .label {
+      display: inline-block;
+      margin-bottom: 8px;
+      padding: 2px 8px;
+      border-radius: 999px;
+      background: #e7ecef;
+      color: #2e3b43;
+      font-size: 12px;
+      font-weight: 700;
+    }
+
+    .big {
+      display: block;
+      margin-bottom: 6px;
+      font-size: 30px;
+      line-height: 1.05;
+      font-weight: 750;
+    }
+
+    .muted { color: var(--muted); }
+    .busy { color: var(--blue); }
+    .zzz { color: var(--violet); }
+    .idle { color: var(--green); }
+    .attention { color: var(--amber); }
+    .offline { color: var(--red); }
+
+    .flow {
+      display: grid;
+      grid-template-columns: 1fr 1fr 1fr 1fr;
+      gap: 10px;
+      margin-top: 12px;
+    }
+
+    .step {
+      min-height: 128px;
+      padding: 14px;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: var(--panel);
+    }
+
+    .arrow {
+      color: var(--muted);
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      font-size: 12px;
+    }
+
+    .callout {
+      margin-top: 14px;
+      padding: 14px 16px;
+      border-left: 4px solid var(--blue);
+      background: #edf5fb;
+    }
+
+    .callout.warning {
+      border-left-color: var(--amber);
+      background: #fff7e8;
+    }
+
+    .compact {
+      margin-top: 8px;
+      font-size: 13px;
+    }
+
+    .evidence {
+      margin-top: 10px;
+      color: var(--muted);
+      font-size: 13px;
+    }
+
+    a { color: var(--blue); }
+
+    @media (max-width: 980px) {
+      header { padding: 28px 20px 22px; }
+      main { padding: 20px 16px 56px; }
+      h1 { font-size: 28px; }
+      .cards, .three, .two, .flow { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Channel-Independent Turn Surface Plan</h1>
+    <p class="lede">Discord는 입력 채널일 뿐이다. Keeper가 자율 턴을 수행 중이면 모든 surface가 같은 `Busy`를 보여야 하고, 아무 턴도 없고 deterministic cycle을 기다리면 `Zzz`를 보여야 한다.</p>
+    <div class="meta">Status: design proposal · Created: 2026-06-11 · Companion MD: docs/design/channel-independent-turn-surface-plan.md</div>
+  </header>
+
+  <main>
+    <section class="grid cards">
+      <div class="card">
+        <span class="label">turn owner</span>
+        <span class="big busy">Busy</span>
+        <p class="compact">RFC-0225 admission slot has an owner. Lane can be autonomous, chat, board, MCP, or operator.</p>
+      </div>
+      <div class="card">
+        <span class="label">alive, waiting</span>
+        <span class="big zzz">Zzz</span>
+        <p class="compact">Keepalive is healthy, no turn is in flight, and the next autonomous/reactive trigger has not opened.</p>
+      </div>
+      <div class="card">
+        <span class="label">admissible</span>
+        <span class="big idle">Idle</span>
+        <p class="compact">Direct work can start now. This is not a connector state and does not depend on Discord.</p>
+      </div>
+      <div class="card">
+        <span class="label">human action</span>
+        <span class="big attention">Attention</span>
+        <p class="compact">RFC-0150 attention signal exists. The operator should inspect or unblock something.</p>
+      </div>
+      <div class="card">
+        <span class="label">not runnable</span>
+        <span class="big offline">Offline</span>
+        <p class="compact">Runtime, keepalive, or health says the keeper cannot currently execute.</p>
+      </div>
+    </section>
+
+    <section class="panel">
+      <h2>Decision</h2>
+      <p>MASC exposes one keeper-owned <code>turn_presence</code> read model. Channel adapters produce typed inbound events and optional source metadata; they never decide the primary availability label.</p>
+      <div class="callout">
+        <strong>Boundary:</strong> OAS remains responsible for provider/model execution, hooks, tool-use mechanics, and transport. MASC owns keeper admission, runtime presence, and dashboard/operator projection.
+      </div>
+    </section>
+
+    <section>
+      <h2>Derivation Order</h2>
+      <table>
+        <thead>
+          <tr><th>Priority</th><th>Input</th><th>Availability</th><th>Reason</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>1</td><td>runtime missing, keepalive stopped, health offline</td><td><strong class="offline">Offline</strong></td><td>No live execution surface.</td></tr>
+          <tr><td>2</td><td>RFC-0150 attention signal present</td><td><strong class="attention">Attention</strong></td><td>Human action is blocking useful progress.</td></tr>
+          <tr><td>3</td><td>RFC-0225 admission slot has an owner</td><td><strong class="busy">Busy</strong></td><td>A turn is currently in flight.</td></tr>
+          <tr><td>4</td><td>keepalive healthy, no turn, cooldown/no salience</td><td><strong class="zzz">Zzz</strong></td><td>Keeper is alive and waiting.</td></tr>
+          <tr><td>5</td><td>keepalive healthy, direct turn can start now</td><td><strong class="idle">Idle</strong></td><td>Direct work can be admitted.</td></tr>
+        </tbody>
+      </table>
+      <div class="callout warning">
+        <strong>Design point:</strong> `Busy` wins over channel origin. A Discord message received during an autonomous turn does not make the keeper Discord-active; the surface still shows `Busy · autonomous`.
+      </div>
+    </section>
+
+    <section>
+      <h2>Data Flow</h2>
+      <div class="flow">
+        <div class="step">
+          <h3>Channel Adapter</h3>
+          <p>Discord, Slack, dashboard chat, board, or MCP emits a typed inbound event with optional source metadata.</p>
+          <p class="arrow">source only</p>
+        </div>
+        <div class="step">
+          <h3>Turn Admission</h3>
+          <p>RFC-0225 single-flight owner decides whether a turn is admitted, queued, or skipped.</p>
+          <p class="arrow">authoritative Busy source</p>
+        </div>
+        <div class="step">
+          <h3>Turn Presence</h3>
+          <p><code>Keeper_turn_presence</code> derives <code>Busy</code>, <code>Zzz</code>, <code>Idle</code>, <code>Attention</code>, or <code>Offline</code>.</p>
+          <p class="arrow">closed sum read model</p>
+        </div>
+        <div class="step">
+          <h3>Surface</h3>
+          <p>Keeper Operations list/detail renders the same availability regardless of which channel woke the keeper.</p>
+          <p class="arrow">operator-facing label</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="panel">
+      <h2>Streaming And Typing Reference</h2>
+      <p>Hermes Agent is a useful surface reference: its gateway accepts platform messages, runs a shared agent loop, buffers stream deltas, and progressively edits one target-platform message. Its Discord adapter also keeps typing alive with an 8-second refresh loop while work is in progress.</p>
+      <div class="grid three">
+        <div class="step">
+          <h3>Typing</h3>
+          <p>Discord typing is a short-lived connector projection. MASC should refresh it only while an accepted inbound is waiting for keeper output.</p>
+          <p class="arrow">wait phase only</p>
+        </div>
+        <div class="step">
+          <h3>Streaming Out</h3>
+          <p>Progressive output should be an edit-loop transport: create a reply, coalesce deltas, patch the message, and finalize the visible text.</p>
+          <p class="arrow">future transport slice</p>
+        </div>
+        <div class="step">
+          <h3>Turn Presence</h3>
+          <p><code>Busy</code>, <code>Zzz</code>, and <code>Idle</code> still come from keeper runtime/admission state, not from Discord typing or edits.</p>
+          <p class="arrow">MASC-owned SSOT</p>
+        </div>
+      </div>
+      <p class="evidence">[근거] Discord typing expires after 10 seconds and returns 204 on success; Discord edit-message supports editing previously sent content; checked 2026-06-11 Asia/Seoul. Hermes README, architecture docs, stream consumer, and Discord adapter show the gateway/edit-loop/8-second typing pattern.</p>
+      <p class="evidence">
+        <a href="https://docs.discord.com/developers/resources/channel#trigger-typing-indicator">Discord typing API</a> ·
+        <a href="https://docs.discord.com/developers/resources/message#edit-message">Discord edit message API</a> ·
+        <a href="https://github.com/NousResearch/hermes-agent">Hermes Agent</a> ·
+        <a href="https://hermes-agent.nousresearch.com/docs/developer-guide/architecture">Hermes architecture</a>
+      </p>
+    </section>
+
+    <section class="grid two">
+      <div class="panel">
+        <h2>Wire Shape</h2>
+<pre>{
+  "keeper": "sangsu",
+  "turn_presence": {
+    "availability": "busy",
+    "label": "Busy",
+    "reason": "turn_in_flight",
+    "source_independent": true,
+    "in_flight": {
+      "lane": "autonomous",
+      "started_at": "2026-06-11T21:10:33+09:00",
+      "keeper_turn_id": 370,
+      "trace_id": "trace-1780648779957-00000",
+      "source": { "kind": "scheduler" }
+    },
+    "updated_at": "2026-06-11T21:10:34+09:00"
+  }
+}</pre>
+      </div>
+      <div class="panel">
+        <h2>Surface Placement</h2>
+        <ul>
+          <li><code>GET /api/v1/keepers/:name/composite</code> adds full <code>turn_presence</code>.</li>
+          <li>Keeper Operations list gets compact fields: availability, lane, reason, started_at.</li>
+          <li>Dashboard SSE emits <code>keeper_presence_changed</code> on kind or owner changes.</li>
+          <li>Connector health remains separate from keeper turn presence.</li>
+        </ul>
+      </div>
+    </section>
+
+    <section>
+      <h2>Implementation Phases</h2>
+      <table>
+        <thead>
+          <tr><th>Phase</th><th>Change</th><th>Verification</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>P0</td><td>Add <code>Keeper_turn_presence</code> type, JSON encoder, fixtures.</td><td>Focused Dune target, ocamlformat.</td></tr>
+          <tr><td>P1</td><td>Produce <code>Busy</code> from admission owner, derive <code>Zzz</code>/<code>Idle</code>/<code>Offline</code>.</td><td>Autonomous long turn stays <code>Busy</code>; release clears owner.</td></tr>
+          <tr><td>P2</td><td>Project into composite API and Keeper Operations UI.</td><td>Component tests and Playwright screenshot.</td></tr>
+          <tr><td>P3</td><td>Connector-neutral behavior tests.</td><td>Discord disabled; autonomous <code>Busy</code> still visible.</td></tr>
+          <tr><td>P4</td><td>Add streaming-out transport: initial reply, coalesced edits, final edit, fallback final send.</td><td>Fake stream yields multiple edits and one final visible response.</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="panel">
+      <h2>Done Criteria</h2>
+      <ul>
+        <li><code>sangsu</code> autonomous long turn shows <strong class="busy">Busy</strong> in Keeper Operations with Discord disabled.</li>
+        <li>After release, the same surface shows <strong class="zzz">Zzz</strong> or <strong class="idle">Idle</strong> based on direct-message admissibility.</li>
+        <li>Discord connector health can be down while keeper turn presence remains truthful.</li>
+        <li>No OAS public schema or provider/model code changes are required.</li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/design/channel-independent-turn-surface-plan.md
+++ b/docs/design/channel-independent-turn-surface-plan.md
@@ -1,0 +1,344 @@
+# Channel-Independent Turn Surface Plan
+
+Status: design proposal
+Created: 2026-06-11
+Scope: MASC keeper turn lifecycle, channel adapters, dashboard Keeper Operations surface
+HTML companion: `docs/design/channel-independent-turn-surface-plan.html`
+Related: RFC-0150, RFC-0203, RFC-0225, RFC-0230
+
+## Decision
+
+MASC should expose a channel-independent keeper turn presence read model.
+Discord, Slack, dashboard chat, board wakeups, and future connectors may start
+or observe a turn, but none of them should own the surface state that tells an
+operator whether a keeper is busy, asleep, idle, offline, or waiting for human
+attention.
+
+For `sangsu`, this means:
+
+- if an autonomous turn is currently running, every operator surface shows
+  `Busy` even when Discord is not the active channel;
+- if no turn is in flight and the keeper is only waiting for the next
+  deterministic cycle, surfaces show `Zzz`;
+- if a direct message can run immediately, surfaces show `Idle`;
+- if the keeper needs operator action, surfaces show `Attention`;
+- if runtime/keepalive is not available, surfaces show `Offline`.
+
+This is not an OAS feature. OAS owns provider/model execution, transport, hooks,
+tool-use mechanics, and agent turn internals. MASC owns keeper runtime,
+admission, state projection, and operator surfaces.
+
+## Problem
+
+The recent Discord work made a new channel visible, but the desired behavior is
+not Discord-specific. The operator question is:
+
+> If `sangsu` is already doing an autonomous turn, what should every surface say?
+
+Today the code has several adjacent signals, but no single surface contract:
+
+- `Keeper_heartbeat_loop_presence.keeper_agent_status` maps paused/current task
+  metadata to `Inactive`, `Busy`, or `Active`.
+- `Keeper_status_runtime.keeper_surface_status` derives a coarse UI status from
+  health plus agent runtime status.
+- RFC-0150 defines a typed `attention_signal` for human-action needs.
+- RFC-0225 defines the missing per-keeper single-flight admission point, which
+  is the correct source for in-flight turn ownership.
+- RFC-0203 deliberately keeps Discord as a connector, not as a keeper-facing
+  tool or polling loop.
+
+The gap is the read model that binds these together without making Discord,
+dashboard chat, or any other channel special.
+
+## Streaming And Typing Reference
+
+Hermes Agent is the closest external reference for this slice, but only at the
+surface projection level. Its gateway separates:
+
+- a platform adapter that receives a message and authorizes the user;
+- an agent runner that owns the turn;
+- a stream consumer that buffers deltas and progressively edits one platform
+  message;
+- a Discord typing loop that refreshes the typing indicator every 8 seconds
+  while work is in progress.
+
+MASC should borrow that projection pattern, not the agent boundary. In MASC:
+
+- `typing` is a connector-local projection of the response-wait phase;
+- `streaming out` is a connector-local edit-loop transport for response deltas;
+- `turn_presence` is still derived from keeper runtime/admission state;
+- OAS remains provider/model/transport and agent-turn mechanics, with no
+  MASC-specific surface state.
+
+[근거] Discord official channel API says the typing indicator is
+`POST /channels/{channel.id}/typing`, expires after 10 seconds, and returns 204
+on success; checked 2026-06-11 Asia/Seoul; confidence High:
+<https://docs.discord.com/developers/resources/channel#trigger-typing-indicator>.
+
+[근거] Discord official message API exposes edit-message semantics for
+previously sent messages, including editable `content`; checked 2026-06-11
+Asia/Seoul; confidence High:
+<https://docs.discord.com/developers/resources/message#edit-message>.
+
+[근거] Hermes Agent README and architecture docs describe one gateway process,
+multi-platform messaging, a shared agent loop, and platform-agnostic core;
+checked 2026-06-11 Asia/Seoul; confidence High:
+<https://github.com/NousResearch/hermes-agent>,
+<https://hermes-agent.nousresearch.com/docs/developer-guide/architecture>.
+
+[근거] Hermes `GatewayStreamConsumer` buffers synchronous agent deltas, rate
+limits them, and progressively edits a target-platform message; its Discord
+adapter keeps a typing loop alive at 8-second intervals; checked 2026-06-11
+Asia/Seoul; confidence Medium:
+<https://raw.githubusercontent.com/NousResearch/hermes-agent/refs/heads/main/gateway/stream_consumer.py>,
+<https://raw.githubusercontent.com/NousResearch/hermes-agent/refs/heads/main/gateway/platforms/discord.py>.
+
+## Model
+
+Introduce a typed MASC-owned read model:
+
+```ocaml
+type turn_lane =
+  | Autonomous
+  | Chat
+  | Board
+  | Mcp
+  | Operator
+
+type availability =
+  | Busy of in_flight_turn
+  | Zzz of sleep_context
+  | Idle of idle_context
+  | Attention of Keeper_attention_signal.t
+  | Offline of offline_context
+
+and in_flight_turn =
+  { lane : turn_lane
+  ; started_at : string
+  ; keeper_turn_id : int option
+  ; trace_id : string option
+  ; task_id : string option
+  ; source : channel_source option
+  }
+
+and channel_source =
+  { kind : [ `Dashboard | `Discord | `Slack | `Board | `Mcp | `Scheduler ]
+  ; conversation_key : string option
+  }
+```
+
+The invariant is simple: `availability` is derived from keeper runtime state,
+not from the channel that last produced an event.
+
+## State Derivation
+
+Evaluation order:
+
+| Priority | Input | Availability | Reason |
+|---|---|---|---|
+| 1 | keeper runtime missing, keepalive stopped, health offline | `Offline` | no live execution surface |
+| 2 | RFC-0150 attention signal present | `Attention` | operator action is blocking progress |
+| 3 | RFC-0225 admission slot has an owner | `Busy` | a turn is in flight |
+| 4 | keepalive healthy, no turn, deterministic cooldown or no salience | `Zzz` | autonomous lane is asleep/waiting |
+| 5 | keepalive healthy and direct turn can start now | `Idle` | direct work can be admitted |
+
+`Busy` wins over channel origin. A Discord message arriving while an autonomous
+turn is in flight should not make the surface look Discord-active; it should
+show `Busy` with the current lane set to `Autonomous` and the incoming message
+queued or marked waiting according to the admission policy.
+
+`Attention` is not a synonym for `Busy`. `Attention` means the next useful
+operator action is human-side inspection or intervention. `Busy` means MASC is
+already executing a turn.
+
+`Zzz` is not offline. It means the keeper is alive, has no in-flight turn, and
+is waiting for the next scheduled/reactive trigger.
+
+## Wire Shape
+
+Add `turn_presence` to keeper composite/status responses:
+
+```json
+{
+  "keeper": "sangsu",
+  "turn_presence": {
+    "availability": "busy",
+    "label": "Busy",
+    "reason": "turn_in_flight",
+    "source_independent": true,
+    "in_flight": {
+      "lane": "autonomous",
+      "started_at": "2026-06-11T21:10:33+09:00",
+      "keeper_turn_id": 370,
+      "trace_id": "trace-1780648779957-00000",
+      "task_id": null,
+      "source": { "kind": "scheduler", "conversation_key": null }
+    },
+    "sleep": null,
+    "attention": null,
+    "updated_at": "2026-06-11T21:10:34+09:00"
+  }
+}
+```
+
+For a sleeping keeper:
+
+```json
+{
+  "turn_presence": {
+    "availability": "zzz",
+    "label": "Zzz",
+    "reason": "autonomous_cooldown",
+    "source_independent": true,
+    "in_flight": null,
+    "sleep": {
+      "next_autonomous_after": "2026-06-11T21:22:00+09:00",
+      "direct_message_admissible": true
+    },
+    "attention": null,
+    "updated_at": "2026-06-11T21:15:00+09:00"
+  }
+}
+```
+
+## API And Surface Placement
+
+Primary read path:
+
+- `GET /api/v1/keepers/:name/composite`
+  - add `turn_presence`;
+  - used by selected Keeper Operations detail.
+
+Fleet summary path:
+
+- `GET /api/v1/dashboard/shell` or the current Keeper Operations list model
+  - include compact `turn_presence` fields for each keeper:
+    `availability`, `label`, `reason`, `lane`, `started_at`.
+
+Live update path:
+
+- existing dashboard SSE should emit `keeper_presence_changed` when the
+  availability kind changes or an in-flight owner starts/releases.
+
+No connector gets a dedicated presence endpoint. Discord status remains
+connector health; keeper turn presence remains keeper runtime health.
+
+## Implementation Plan
+
+### P0: Type and fixture
+
+- Add `Keeper_turn_presence.{ml,mli}` with the closed sums above.
+- Add JSON encoder and fixture tests for `busy`, `zzz`, `idle`, `attention`,
+  and `offline`.
+- Keep it read-only; no dashboard behavior change.
+
+Verification:
+
+- focused Dune target for the new test binary;
+- `ocamlformat --check` on touched OCaml files.
+
+### P1: Producer from admission and runtime state
+
+- Use RFC-0225 admission owner as the authoritative `Busy` source.
+- On admission, publish lane/start metadata into the registry read model.
+- On token release, clear the owner via `Switch.on_release`.
+- Derive `Zzz` from keepalive healthy + no in-flight owner + cooldown/no
+  salience.
+- Derive `Offline` from existing health/keepalive conditions.
+- Derive `Attention` from RFC-0150 signal when present and no turn is already
+  in flight.
+
+Verification:
+
+- long autonomous fake turn yields `Busy(Autonomous)`;
+- direct chat while autonomous is running does not overwrite lane;
+- release moves away from `Busy`;
+- offline keeper never reports `Zzz`.
+
+### P2: Dashboard Keeper Operations projection
+
+- Render compact badges in the keeper list:
+  - `Busy` with lane and elapsed time;
+  - `Zzz` with next deterministic cycle when known;
+  - `Idle`;
+  - `Attention`;
+  - `Offline`.
+- Selected keeper detail shows the same read model near the message/control
+  surface, not buried in diagnostics.
+- Avoid channel-specific badge text. The source may be shown as metadata, but
+  it must not drive the primary availability label.
+
+Verification:
+
+- component tests for badge mapping;
+- Playwright screenshot for Keeper Operations list and selected keeper detail;
+- dashboard typecheck/lint.
+
+### P3: Connector-neutral behavior tests
+
+- Disable Discord token and prove autonomous `Busy` still appears.
+- Simulate dashboard chat and prove it queues/waits while autonomous `Busy`
+  remains visible.
+- Simulate a connector-origin message and prove the surface still reports the
+  current in-flight lane rather than the connector name.
+
+### P4: Streaming-out transport
+
+- Extend the gate response path from single final `send_message` to a stream
+  projection contract.
+- Start with a Discord implementation:
+  - create an initial reply/placeholder message when the first visible delta
+    arrives;
+  - coalesce deltas by time and size;
+  - edit the same message with accumulated text;
+  - finalize with a final edit that removes any cursor/progress marker;
+  - fall back to one final message when edits fail or rate limits require it.
+- Keep this transport below `turn_presence`. Progressive edits do not decide
+  whether the keeper is `Busy`, `Zzz`, or `Idle`.
+
+Verification:
+
+- fake streamed keeper response yields multiple edit operations and one final
+  visible response;
+- rate-limit/error path falls back to a final send without dropping text;
+- direct non-streaming response keeps the existing send path;
+- no OAS public schema changes are required unless the OAS stream callback
+  contract itself changes.
+
+Verification:
+
+- integration test around composite JSON;
+- no references to Discord in the availability derivation module except
+  through generic `channel_source`.
+
+## Boundary Rules
+
+- OAS does not learn about `Busy`, `Zzz`, dashboard labels, or Discord.
+- Channel adapters produce typed inbound events and optional source metadata;
+  they do not decide keeper availability.
+- The dashboard reads MASC read models; it does not infer availability by
+  combining raw Discord status with keeper health.
+- `attention_signal` stays human-action oriented. It is an input to
+  `turn_presence`, not a replacement for it.
+- RFC-0225 admission is the long-term source of truth for `Busy`.
+
+## Open Questions
+
+1. Should `Attention` outrank `Busy` when a turn is in flight and also emits a
+   human-action signal? The proposal says no: an active turn remains `Busy`,
+   and the attention signal is nested metadata.
+2. Should `Zzz` require a known next autonomous timestamp? The proposal says no:
+   lack of a timestamp should still render as `Zzz` when keepalive is healthy
+   and no turn is in flight.
+3. Should queued direct messages have their own `Waiting` label? Defer until
+   RFC-0225 queue behavior lands; the first surface can show `Busy` plus
+   `queued_direct_messages`.
+
+## Done Criteria
+
+- `sangsu` autonomous long turn shows `Busy` in Keeper Operations with Discord
+  disabled.
+- After the turn releases and no reactive salience exists, the same surface
+  shows `Zzz` or `Idle` according to direct-message admissibility.
+- Discord connector health can be down while keeper presence remains truthful.
+- No OAS public schema or provider/model code changes are required.

--- a/lib/gate/channel_gate_discord_state.ml
+++ b/lib/gate/channel_gate_discord_state.ml
@@ -606,3 +606,11 @@ let send_message ~channel_id ~content ?reply_to_message_id () =
         | Error e -> Error (Rest_error e)
       in
       send_chunks true content
+
+let trigger_typing ~channel_id () =
+  match bot_token_opt () with
+  | None -> Error Missing_token
+  | Some token ->
+      (match Discord_rest_client.trigger_typing ~token ~channel_id () with
+       | Ok () -> Ok ()
+       | Error e -> Error (Rest_error e))

--- a/lib/gate/channel_gate_discord_state.mli
+++ b/lib/gate/channel_gate_discord_state.mli
@@ -89,7 +89,7 @@ val record_ready : bot_user_id:string -> unit
     [bot_user_id] / [last_ready_at]. Atomic write — safe to call from
     the gateway fiber while HTTP handlers read. *)
 
-(** Typed failure modes for {!send_message}. Closed sum — adding
+(** Typed failure modes for Discord REST actions. Closed sum — adding
     a new variant forces every consumer to handle it. *)
 type send_error =
   | Missing_token
@@ -114,3 +114,11 @@ val send_message :
 
     Must be called inside an Eio context (the underlying REST
     client uses the piaf-backed http pool). *)
+
+val trigger_typing :
+  channel_id:string ->
+  unit ->
+  (unit, send_error) result
+(** Trigger Discord's typing indicator for [channel_id]. Bot token is
+    resolved from [DISCORD_BOT_TOKEN] at call time, matching
+    {!send_message}. *)

--- a/lib/gate/discord_rest_client.ml
+++ b/lib/gate/discord_rest_client.ml
@@ -27,6 +27,11 @@ let message_content_limit = 2000
 let user_agent =
   "DiscordBot (https://github.com/jeong-sik/masc, 0.1)"
 
+let auth_headers ~token =
+  [ "Authorization", "Bot " ^ token
+  ; "User-Agent", user_agent
+  ]
+
 let build_request ~token ~channel_id ~content ?reply_to_message_id () =
   let url =
     Printf.sprintf
@@ -34,10 +39,7 @@ let build_request ~token ~channel_id ~content ?reply_to_message_id () =
       channel_id
   in
   let headers =
-    [ "Authorization", "Bot " ^ token
-    ; "Content-Type", "application/json"
-    ; "User-Agent", user_agent
-    ]
+    ("Content-Type", "application/json") :: auth_headers ~token
   in
   let fields = [ "content", `String content ] in
   let fields =
@@ -50,14 +52,38 @@ let build_request ~token ~channel_id ~content ?reply_to_message_id () =
   let body = Yojson.Safe.to_string (`Assoc fields) in
   (url, headers, body)
 
+let build_typing_request ~token ~channel_id () =
+  let url =
+    Printf.sprintf
+      "https://discord.com/api/v10/channels/%s/typing"
+      channel_id
+  in
+  (url, auth_headers ~token, "")
+
+let parse_json_safe s =
+  try Some (Yojson.Safe.from_string s) with Yojson.Json_error _ -> None
+
+let field_opt name = function
+  | `Assoc fields -> List.assoc_opt name fields
+  | _ -> None
+
+let error_of_non2xx ~status ~body =
+  match parse_json_safe body with
+  | None -> Http_status { code = status; body }
+  | Some json ->
+      let code =
+        match field_opt "code" json with
+        | Some (`Int c) -> c
+        | _ -> status
+      in
+      let message =
+        match field_opt "message" json with
+        | Some (`String s) -> s
+        | _ -> body
+      in
+      Discord_api { code; message }
+
 let parse_response ~status ~body =
-  let parse_json_safe s =
-    try Some (Yojson.Safe.from_string s) with Yojson.Json_error _ -> None
-  in
-  let field_opt name = function
-    | `Assoc fields -> List.assoc_opt name fields
-    | _ -> None
-  in
   if status >= 200 && status < 300 then
     match parse_json_safe body with
     | None ->
@@ -67,20 +93,11 @@ let parse_response ~status ~body =
          | Some (`String id) -> Ok id
          | _ -> Error (Other "2xx response missing 'id' string"))
   else
-    match parse_json_safe body with
-    | None -> Error (Http_status { code = status; body })
-    | Some json ->
-        let code =
-          match field_opt "code" json with
-          | Some (`Int c) -> c
-          | _ -> status
-        in
-        let message =
-          match field_opt "message" json with
-          | Some (`String s) -> s
-          | _ -> body
-        in
-        Error (Discord_api { code; message })
+    Error (error_of_non2xx ~status ~body)
+
+let parse_empty_response ~status ~body =
+  if status >= 200 && status < 300 then Ok ()
+  else Error (error_of_non2xx ~status ~body)
 
 let send_message ~token ~channel_id ~content ?reply_to_message_id () =
   let (url, headers, body) =
@@ -89,3 +106,9 @@ let send_message ~token ~channel_id ~content ?reply_to_message_id () =
   match Masc_http_client.post_sync ~url ~headers ~body () with
   | Error msg -> Error (Network msg)
   | Ok (status, body) -> parse_response ~status ~body
+
+let trigger_typing ~token ~channel_id () =
+  let url, headers, body = build_typing_request ~token ~channel_id () in
+  match Masc_http_client.post_sync ~url ~headers ~body () with
+  | Error msg -> Error (Network msg)
+  | Ok (status, body) -> parse_empty_response ~status ~body

--- a/lib/gate/discord_rest_client.mli
+++ b/lib/gate/discord_rest_client.mli
@@ -1,6 +1,7 @@
 (** Discord_rest_client — outbound Discord REST API client.
 
-    Single function: post a message to a channel. Threads, DMs, and
+    Primary functions: post a message to a channel and trigger the
+    channel typing indicator. Threads, DMs, and
     guild text channels are all addressed by the same snowflake
     [channel_id], so no per-surface dispatch is needed.
 
@@ -51,6 +52,18 @@ val send_message :
 
     @raise nothing — failures are surfaced as typed {!error}. *)
 
+val trigger_typing :
+  token:string ->
+  channel_id:string ->
+  unit ->
+  (unit, error) result
+(** [trigger_typing ~token ~channel_id ()] posts to
+    [POST /api/v10/channels/{channel_id}/typing]. Discord expires the
+    typing indicator after 10 seconds, so callers handling long-running
+    work should refresh it periodically until the final message is sent.
+
+    @raise nothing — failures are surfaced as typed {!error}. *)
+
 (** {1 Internal — exposed for unit testing}
 
     These functions decompose [send_message] so request shape and
@@ -71,6 +84,14 @@ val build_request :
     [reply_to_message_id] is provided, the body includes a
     [message_reference] field so Discord threads the reply. *)
 
+val build_typing_request :
+  token:string ->
+  channel_id:string ->
+  unit ->
+  string * (string * string) list * string
+(** [(url, headers, body) = build_typing_request ~token ~channel_id ()].
+    The body is empty; headers include Authorization and User-Agent. *)
+
 val parse_response :
   status:int ->
   body:string ->
@@ -80,3 +101,12 @@ val parse_response :
     - 2xx with body shape mismatch                 → [Error (Other _)]
     - non-2xx with Discord error envelope          → [Error (Discord_api _)]
     - non-2xx without that envelope                → [Error (Http_status _)] *)
+
+val parse_empty_response :
+  status:int ->
+  body:string ->
+  (unit, error) result
+(** Classifies a Discord HTTP response for empty-success endpoints:
+    - 2xx → [Ok ()]
+    - non-2xx with Discord error envelope → [Error (Discord_api _)]
+    - non-2xx without that envelope → [Error (Http_status _)] *)

--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -55,7 +55,59 @@ let resolved_trigger_policy () =
 (* Inbound delivery                                                 *)
 (* ---------------------------------------------------------------- *)
 
+(* Discord typing indicators expire after 10s. Refresh below that window while
+   the accepted inbound is waiting for keeper output. *)
+let typing_refresh_interval_s = 8.0
+
+let trigger_typing_once ~channel_id =
+  match State.trigger_typing ~channel_id () with
+  | Ok () -> ()
+  | Error State.Missing_token ->
+      Log.Server.debug
+        "discord trigger_typing skipped: DISCORD_BOT_TOKEN is unset"
+  | Error e ->
+      Log.Server.debug
+        "discord trigger_typing failed (channel=%s): %s"
+        channel_id
+        (Format.asprintf "%a" State.pp_send_error e)
+
+(* Discord exposes only a typing indicator; MASC still treats
+   "response requested", "waiting for a keeper response", and "streaming
+   response text" as separate runtime phases. This helper projects only the
+   waiting phase to Discord UX without making typing a MASC state source of
+   truth. Streaming text should be a separate edit-loop transport. *)
+let with_response_wait_typing_indicator ~clock ~channel_id f =
+  trigger_typing_once ~channel_id;
+  Eio.Switch.run (fun typing_sw ->
+    let done_p, done_r = Eio.Promise.create () in
+    let finish () = Eio.Promise.resolve done_r () in
+    Eio.Fiber.fork ~sw:typing_sw (fun () ->
+      let rec loop () =
+        match
+          Eio.Fiber.first
+            (fun () ->
+              Eio.Promise.await done_p;
+              `Done)
+            (fun () ->
+              Eio.Time.sleep clock typing_refresh_interval_s;
+              `Tick)
+        with
+        | `Done -> ()
+        | `Tick ->
+            trigger_typing_once ~channel_id;
+            loop ()
+      in
+      loop ());
+    match f () with
+    | result ->
+        finish ();
+        result
+    | exception exn ->
+        finish ();
+        raise exn)
+
 let handle_message_create ~dispatch
+      ~clock
       ~(channel_id : string) ~(message_id : string)
       ~(author_id : string) ~(author_name : string option)
       ~(content : string) =
@@ -82,7 +134,10 @@ let handle_message_create ~dispatch
       ; metadata = []
       }
     in
-    (match Channel_gate.handle_inbound ~dispatch msg with
+    (match
+       with_response_wait_typing_indicator ~clock ~channel_id (fun () ->
+         Channel_gate.handle_inbound ~dispatch msg)
+     with
      | Error gate_err ->
        Discord_observability.record_inbound_dispatch
          Discord_observability.Gate_error;
@@ -111,7 +166,7 @@ let handle_message_create ~dispatch
               channel_id
               (Format.asprintf "%a" State.pp_send_error e)))
 
-let on_event ~dispatch (ev : Gw.gateway_event) =
+let on_event ~dispatch ~clock (ev : Gw.gateway_event) =
   match ev with
   | Gw.Ready { bot_user_id; _ } ->
     State.record_ready ~bot_user_id;
@@ -121,7 +176,7 @@ let on_event ~dispatch (ev : Gw.gateway_event) =
         mentions_bot = _ } ->
     (* mentions_bot is already enforced by the trigger policy at the
        gateway-state layer; nothing extra to check here. *)
-    handle_message_create ~dispatch ~channel_id ~message_id ~author_id
+    handle_message_create ~dispatch ~clock ~channel_id ~message_id ~author_id
       ~author_name ~content
   | Gw.Reaction_add _ ->
     (* The previous Python sidecar used a configurable emoji
@@ -209,7 +264,7 @@ let start ~sw ~env ~clock ~state =
           ~sw ~env ~token
           ~intents:default_intents
           ~trigger_policy:policy
-          ~on_event:(on_event ~dispatch)
+          ~on_event:(on_event ~dispatch ~clock)
           ~on_ambient:(fun ev ->
             (* Read base_path per event: [workspace_config] is mutable
                (workspace-switch tools swap it). *)

--- a/test/test_channel_gate_discord_state_in_process.ml
+++ b/test/test_channel_gate_discord_state_in_process.ml
@@ -3,8 +3,9 @@
    - [keeper_for_channel] (binding lookup)
    - [send_error] / [pp_send_error] (typed REST error wrapper)
    - [send_message] error path with [DISCORD_BOT_TOKEN] unset
+   - [trigger_typing] error path with [DISCORD_BOT_TOKEN] unset
 
-   The happy path of [send_message] requires a live Discord API call
+   The happy path of [send_message] and [trigger_typing] requires a live Discord API call
    and is left to operational verification. *)
 
 open Alcotest
@@ -79,6 +80,16 @@ let test_send_message_with_whitespace_token_returns_missing_token () =
    | Ok _ -> fail "expected error, got Ok");
   unsetenv "DISCORD_BOT_TOKEN"
 
+let test_trigger_typing_without_token_returns_missing_token () =
+  unsetenv "DISCORD_BOT_TOKEN";
+  match State.trigger_typing ~channel_id:"123" () with
+  | Error State.Missing_token -> ()
+  | Error other ->
+    fail
+      (Format.asprintf
+         "expected Missing_token, got %a" State.pp_send_error other)
+  | Ok () -> fail "expected error, got Ok"
+
 (* ---------------------------------------------------------------- *)
 (* Entry                                                            *)
 (* ---------------------------------------------------------------- *)
@@ -104,5 +115,9 @@ let () =
             test_send_message_without_token_returns_missing_token
         ; test_case "whitespace token => Missing_token" `Quick
             test_send_message_with_whitespace_token_returns_missing_token
+        ] )
+    ; ( "trigger_typing"
+      , [ test_case "unset token => Missing_token" `Quick
+            test_trigger_typing_without_token_returns_missing_token
         ] )
     ]

--- a/test/test_discord_rest_client.ml
+++ b/test/test_discord_rest_client.ml
@@ -55,6 +55,26 @@ let test_build_request_body_is_content_object () =
         "body shape wrong: %s"
         (Yojson.Safe.to_string json)
 
+let test_build_typing_request_url_targets_channel () =
+  let url, _, body =
+    R.build_typing_request ~token:"abc" ~channel_id:"1234567890" ()
+  in
+  check string "v10 typing URL"
+    "https://discord.com/api/v10/channels/1234567890/typing"
+    url;
+  check string "empty typing body" "" body
+
+let test_build_typing_request_authorization_uses_bot_scheme () =
+  let _, headers, _ =
+    R.build_typing_request ~token:"sekret" ~channel_id:"CH" ()
+  in
+  check string "Authorization header" "Bot sekret"
+    (header_value headers "Authorization");
+  let ua = header_value headers "User-Agent" in
+  check bool "User-Agent starts with DiscordBot" true
+    (String.length ua >= 10
+     && String.sub ua 0 10 = "DiscordBot")
+
 (* ---------------------------------------------------------------- *)
 (* parse_response                                                   *)
 (* ---------------------------------------------------------------- *)
@@ -115,6 +135,23 @@ let test_parse_response_non2xx_json_without_envelope_falls_back () =
         "expected Discord_api with code=400 fallback when JSON lacks \
          'code' field"
 
+let test_parse_empty_response_204_returns_ok () =
+  match R.parse_empty_response ~status:204 ~body:"" with
+  | Ok () -> ()
+  | Error e ->
+      failf "expected Ok, got %s" (Format.asprintf "%a" R.pp_error e)
+
+let test_parse_empty_response_discord_error_envelope () =
+  let body = {|{"code":50013,"message":"Missing Permissions"}|} in
+  match R.parse_empty_response ~status:403 ~body with
+  | Error (R.Discord_api { code = 50013; message = "Missing Permissions" }) ->
+      ()
+  | Ok () -> fail "expected Discord_api error"
+  | Error e ->
+      failf
+        "expected Discord_api 50013, got %s"
+        (Format.asprintf "%a" R.pp_error e)
+
 (* ---------------------------------------------------------------- *)
 (* Entry                                                            *)
 (* ---------------------------------------------------------------- *)
@@ -130,6 +167,10 @@ let () =
             test_build_request_user_agent_present
         ; test_case "body is { content: <content> } JSON" `Quick
             test_build_request_body_is_content_object
+        ; test_case "typing URL targets channel" `Quick
+            test_build_typing_request_url_targets_channel
+        ; test_case "typing Authorization uses Bot scheme" `Quick
+            test_build_typing_request_authorization_uses_bot_scheme
         ] )
     ; ( "parse_response"
       , [ test_case "2xx with id => Ok id" `Quick
@@ -144,5 +185,9 @@ let () =
             test_parse_response_5xx_non_json_is_http_status
         ; test_case "non-2xx JSON without envelope => Discord_api fallback"
             `Quick test_parse_response_non2xx_json_without_envelope_falls_back
+        ; test_case "empty 204 => Ok" `Quick
+            test_parse_empty_response_204_returns_ok
+        ; test_case "empty non-2xx Discord envelope => Discord_api"
+            `Quick test_parse_empty_response_discord_error_envelope
         ] )
     ]


### PR DESCRIPTION
## Summary

- Add a Discord REST typing endpoint wrapper and connector-state helper.
- Trigger and refresh Discord typing while an accepted inbound waits for keeper output.
- Add channel-independent turn surface design docs, including Hermes Agent streaming/typing references and the future streaming-out edit-loop slice.

## Notes

- Typing starts after trigger policy and channel binding, before `Channel_gate.handle_inbound`; ignored or unbound messages do not show typing.
- Typing is a Discord surface projection of response wait, not a MASC state source of truth.
- Progressive streaming output remains a separate future transport slice: initial reply, coalesced edits, final edit, fallback final send.

## Validation

- `ocamlformat --check lib/server/server_discord_in_process_gateway.ml lib/gate/discord_rest_client.mli lib/gate/discord_rest_client.ml lib/gate/channel_gate_discord_state.ml lib/gate/channel_gate_discord_state.mli test/test_discord_rest_client.ml test/test_channel_gate_discord_state_in_process.ml`
- `git diff --check origin/main...HEAD`
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_discord_typing MASC_SKIP_PIN_CHECK=1 MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_discord_rest_client.exe test/test_channel_gate_discord_state_in_process.exe lib/server/.masc_server.objs/byte/server_discord_in_process_gateway.cmo`
- `./_build_discord_typing/default/test/test_discord_rest_client.exe` — 14 tests
- `./_build_discord_typing/default/test/test_channel_gate_discord_state_in_process.exe` — 8 tests