### PR TITLE
test(keeper_mutex): add timeout_sec boundary tests (0.0, infinity, negative, no-clock)

### DIFF
--- a/test/test_keeper_mutex_coverage.ml
+++ b/test/test_keeper_mutex_coverage.ml
@@ -361,6 +361,132 @@ let test_keeper_msg_async_rejects_oversized_request_id () =
          (Keeper_msg_async.For_testing.record_path ~base_path ~request_id:too_long))
 ;;
 
+(* ── timeout_sec boundary tests ── *)
+
+let test_keeper_msg_async_timeout_sec_zero () =
+  with_eio_env
+  @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run
+  @@ fun sw ->
+  let base_path = temp_dir "keeper-msg-async-timeout0-" in
+  let request_id =
+    Keeper_msg_async.submit
+      ~clock
+      ~timeout_sec:0.0
+      ~sw
+      ~base_path
+      ~keeper_name:"t0"
+      ~f:(fun () ->
+        Eio.Fiber.yield ();
+        Eio.Time.sleep clock 10.0;
+        tr_ok "too-late")
+      ()
+  in
+  let entry = wait_for_done_with_clock clock request_id in
+  (match entry.Keeper_msg_async.status with
+   | Done { ok = false; body } ->
+     Alcotest.(check bool)
+       "timeout_sec=0.0 triggers immediate timeout"
+       true
+       (contains_substring ~needle:"keeper_msg_timeout" body)
+   | Done { ok = true; _ } ->
+     Alcotest.fail "timeout_sec=0.0 should not produce ok=true"
+   | Running -> Alcotest.fail "timeout_sec=0.0 should not remain running"
+   | Lost _ -> Alcotest.fail "timeout_sec=0.0 should not produce lost");
+  rm_rf base_path
+;;
+
+let test_keeper_msg_async_timeout_sec_infinity () =
+  with_eio_env
+  @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run
+  @@ fun sw ->
+  let base_path = temp_dir "keeper-msg-async-timeoutinf-" in
+  let request_id =
+    Keeper_msg_async.submit
+      ~clock
+      ~timeout_sec:Float.infinity
+      ~sw
+      ~base_path
+      ~keeper_name:"tinf"
+      ~f:(fun () ->
+        Eio.Fiber.yield ();
+        tr_ok (Yojson.Safe.to_string (`Assoc [ "kind", `String "infinity-ok" ])))
+      ()
+  in
+  let entry = wait_for_done request_id in
+  Alcotest.(check bool)
+    "timeout_sec=infinity completes normally"
+    true
+    (match entry.Keeper_msg_async.status with
+     | Done { ok = true; body } ->
+       String.length body > 0
+       && contains_substring ~needle:"infinity-ok" body
+     | _ -> false);
+  rm_rf base_path
+;;
+
+let test_keeper_msg_async_timeout_sec_negative () =
+  with_eio_env
+  @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run
+  @@ fun sw ->
+  let base_path = temp_dir "keeper-msg-async-negtimeout-" in
+  let request_id =
+    Keeper_msg_async.submit
+      ~clock
+      ~timeout_sec:(-1.0)
+      ~sw
+      ~base_path
+      ~keeper_name:"tneg"
+      ~f:(fun () ->
+        Eio.Fiber.yield ();
+        tr_ok (Yojson.Safe.to_string (`Assoc [ "kind", `String "negative-ok" ])))
+      ()
+  in
+  let entry = wait_for_done_with_clock clock request_id in
+  (match entry.Keeper_msg_async.status with
+   | Done { ok = false; body } ->
+     Alcotest.(check bool)
+       "negative timeout handled gracefully (timeout)"
+       true
+       (contains_substring ~needle:"keeper_msg_timeout" body)
+   | Done { ok = true; _ } -> ()
+   | Running -> Alcotest.fail "negative timeout should not remain running"
+   | Lost _ -> Alcotest.fail "negative timeout should not produce lost");
+  rm_rf base_path
+;;
+
+let test_keeper_msg_async_timeout_sec_zero_no_clock () =
+  with_eio_env
+  @@ fun _env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let base_path = temp_dir "keeper-msg-async-t0noclock-" in
+  let request_id =
+    Keeper_msg_async.submit
+      ~timeout_sec:0.0
+      ~sw
+      ~base_path
+      ~keeper_name:"t0nc"
+      ~f:(fun () ->
+        Eio.Fiber.yield ();
+        tr_ok "no-clock-ok")
+      ()
+  in
+  let entry = wait_for_done request_id in
+  Alcotest.(check bool)
+    "timeout_sec without clock is ignored, completes normally"
+    true
+    (match entry.Keeper_msg_async.status with
+     | Done { ok = true; _ } -> true
+     | _ -> false);
+  rm_rf base_path
+;;
+
 let test_yield_meter_noops_without_runnable_fiber () =
   let meter = Eio_guard.create_yield_meter ~interval:0 () in
   Eio_guard.enable ();
@@ -441,6 +567,22 @@ let () =
             "gc removes stale terminal disk record"
             `Quick
             test_keeper_msg_async_gc_removes_stale_terminal_disk_record
+        ; test_case
+            "timeout_sec=0.0 triggers immediate timeout"
+            `Quick
+            test_keeper_msg_async_timeout_sec_zero
+        ; test_case
+            "timeout_sec=infinity completes normally"
+            `Quick
+            test_keeper_msg_async_timeout_sec_infinity
+        ; test_case
+            "timeout_sec=negative handled gracefully"
+            `Quick
+            test_keeper_msg_async_timeout_sec_negative
+        ; test_case
+            "timeout_sec without clock is ignored"
+            `Quick
+            test_keeper_msg_async_timeout_sec_zero_no_clock
         ; test_case
             "oversized request id rejected"
             `Quick


### PR DESCRIPTION
## Summary

Adds 4 boundary test cases for `timeout_sec` in `Keeper_msg_async.submit`:

### Test cases
1. **`timeout_sec=0.0`** — immediate timeout. Ensures `Eio.Time.with_timeout_exn clock 0.0` triggers `Worker_timeout` → `Done{ok=false}` with `keeper_msg_timeout` error.
2. **`timeout_sec=Float.infinity`** — no timeout. Ensures the fiber completes normally with `Done{ok=true}`.
3. **`timeout_sec=(-1.0)`** — negative value. Verifies graceful handling (no crash/div-by-zero). Either times out immediately or completes.
4. **`timeout_sec` without `clock`** — confirms `timeout_sec` is ignored when no clock is provided (completes normally).

### Why
- P0 blocker identified during code review: `timeout_sec=0.0` could cause division-by-zero or instant timeout issues
- Existing test only covers `0.02` — missing boundary coverage is a real CI risk
- CI green is priority: these tests prove edge cases don't crash the runtime

### Verification
- All tests registered as `Quick` cases in the `keeper_msg_async` test suite
- Pattern matches existing `test_keeper_msg_async_timeout_is_terminal_error`
- All 4 tests use the same helpers (`wait_for_done`, `wait_for_done_with_clock`, `contains_substring`)

Closes task-817