### PR TITLE
fix(discord): persist direct reply memory

### DIFF
--- a/lib/gate/channel_gate.ml
+++ b/lib/gate/channel_gate.ml
@@ -58,7 +58,10 @@ type dispatch_fn =
 
 let max_content_length () = 4000
 
-let dedup_ttl_sec () = 300.0
+let dedup_ttl_sec () =
+  Env_config_core.get_int ~default:3600 "MASC_CHANNEL_GATE_DEDUP_TTL_SEC"
+  |> max 1
+  |> float_of_int
 
 (* ── Deduplication (TTL hashtable, Eio-guarded mutex) ───────── *)
 

--- a/lib/gate/channel_gate.mli
+++ b/lib/gate/channel_gate.mli
@@ -61,7 +61,8 @@ val validation_error_to_string : validation_error -> string
 
 val dedup_check : string -> bool
 (** [dedup_check key] returns [true] if [key] was already seen
-    within the TTL window (default 300 s).  Thread-safe. *)
+    within the TTL window ([MASC_CHANNEL_GATE_DEDUP_TTL_SEC], default
+    3600 s).  Thread-safe. *)
 
 val dedup_cleanup : now:float -> unit
 (** Evict expired entries.  Called periodically by the Pulse consumer
@@ -123,4 +124,4 @@ val max_content_length : unit -> int
 (** [MASC_CHANNEL_GATE_MAX_CONTENT_LENGTH], default 4000. *)
 
 val dedup_ttl_sec : unit -> float
-(** [MASC_CHANNEL_GATE_DEDUP_TTL_SEC], default 300.0. *)
+(** [MASC_CHANNEL_GATE_DEDUP_TTL_SEC], default 3600.0. *)

--- a/lib/gate_keeper_backend.ml
+++ b/lib/gate_keeper_backend.ml
@@ -89,6 +89,14 @@ let contextualize_message ~channel ~channel_user_id ~channel_user_name
       safe_content;
     ]
 
+let persist_connector_assistant_reply ~base_dir ~keeper_name ~source ~reply =
+  let content = String.trim reply in
+  if content <> "" then begin
+    Keeper_chat_store.append_assistant_message ~base_dir ~keeper_name
+      ~content ~source ();
+    Keeper_chat_broadcast.chat_appended ~keeper_name ~source
+  end
+
 let dispatch ~sw ~clock ~proc_mgr ~net ~config
     ~channel ~channel_user_id ~channel_user_name ~channel_workspace_id
     ~keeper_name ~content =
@@ -116,11 +124,11 @@ let dispatch ~sw ~clock ~proc_mgr ~net ~config
   (* RFC-0226: the gate inbound boundary is the sole recorder of
      connector user lines. Recording happens here — post
      validation/dedup ([Channel_gate.handle_inbound]), pre turn — so a
-     failed or silent turn cannot drop the inbound message. The reply
-     path ([Keeper_tool_surface_ops.append_direct_chat_pair_if_reply])
-     appends the assistant line only for connector traffic. The line
-     carries the raw [content]; the contextualized wrapper below is
-     turn input, not conversation history. *)
+     failed or silent turn cannot drop the inbound message. The final
+     connector reply is appended below after [dispatch_stream] returns
+     the keeper's direct reply. The user line carries the raw [content];
+     the contextualized wrapper below is turn input, not conversation
+     history. *)
   let lane = String.trim channel in
   let opt value = match String.trim value with "" -> None | v -> Some v in
   Keeper_chat_store.append_user_message
@@ -181,6 +189,9 @@ let dispatch ~sw ~clock ~proc_mgr ~net ~config
         | Some s -> Some { s with duration_ms }
         | None -> Some { Gate_protocol.model_used = "runtime"; duration_ms; tokens_used = 0 }
       in
+      persist_connector_assistant_reply
+        ~base_dir:config.Workspace.base_path
+        ~keeper_name ~source:lane ~reply;
       Gate_protocol.Reply { content = reply; structured; stats }
   | Some result ->
       Gate_protocol.Keeper_error_result (redact_text (Tool_result.message result))

--- a/lib/gate_keeper_backend.mli
+++ b/lib/gate_keeper_backend.mli
@@ -47,6 +47,15 @@ val contextualize_message :
 (** Render a stable external-channel context envelope ahead of the raw
     user message so keeper memory can retain actor/channel metadata. *)
 
+val persist_connector_assistant_reply :
+  base_dir:string ->
+  keeper_name:string ->
+  source:string ->
+  reply:string ->
+  unit
+(** Persist a completed connector direct reply on the same chat lane that
+    received the inbound user line. Empty replies are ignored. *)
+
 val filesystem_safe_or_unknown : string -> string
 (** Sanitize a value for use as a filesystem path component.
     Replaces everything outside [A-Za-z0-9_-] with '_'.

--- a/test/test_channel_gate.ml
+++ b/test/test_channel_gate.ml
@@ -66,6 +66,10 @@ let test_validate_allows_key_after_cleanup () =
   | Ok () -> ()
   | Error _ -> fail "cleanup should evict expired idempotency key"
 
+let test_dedup_ttl_covers_discord_resume_replays () =
+  check bool "default ttl spans long gateway resume/replay windows" true
+    (Channel_gate.dedup_ttl_sec () >= 3600.0)
+
 let test_failed_validation_does_not_consume_idempotency_key () =
   reset_dedup ();
   let key = unique_key "retryable" in
@@ -238,6 +242,8 @@ let () =
             test_validate_rejects_duplicate_message;
           test_case "allows key after cleanup" `Quick
             test_validate_allows_key_after_cleanup;
+          test_case "dedup ttl covers discord resume replays" `Quick
+            test_dedup_ttl_covers_discord_resume_replays;
           test_case "failed validation does not consume key" `Quick
             test_failed_validation_does_not_consume_idempotency_key;
           test_case "serializes duplicate race under eio" `Quick

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -1,6 +1,21 @@
 open Alcotest
 open Masc
 
+module K = Keeper_chat_store
+
+let rec remove_tree path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path
+      |> Array.iter (fun name -> remove_tree (Filename.concat path name));
+      Unix.rmdir path
+    end else
+      Sys.remove path
+
+let temp_base_path prefix =
+  Filename.concat (Filename.get_temp_dir_name ())
+    (Printf.sprintf "%s-%d-%d" prefix (Unix.getpid ()) (Random.bits ()))
+
 let test_agent_name_for_channel_actor () =
   let agent_name =
     Gate_keeper_backend.agent_name_for_channel_actor
@@ -61,6 +76,37 @@ user_name: Alice Ops
 [User message]
 hello keeper|}
     rendered
+
+let test_persist_connector_assistant_reply_records_lane_reply () =
+  let base_dir = temp_base_path "gate-keeper-reply" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "discord-reply-keeper" in
+      K.append_user_message ~base_dir ~keeper_name
+        ~content:"<@bot> factorio?" ~source:"discord" ();
+      Gate_keeper_backend.persist_connector_assistant_reply ~base_dir
+        ~keeper_name ~source:"discord" ~reply:"already answered";
+      match K.load ~base_dir ~keeper_name with
+      | [ user; assistant ] ->
+          check string "user line first" "user" user.K.role;
+          check string "assistant reply persisted" "assistant" assistant.K.role;
+          check string "assistant lane" "discord"
+            (Option.value assistant.K.source ~default:"");
+          check string "assistant content" "already answered" assistant.K.content
+      | messages ->
+          failf "expected 2 chat messages, got %d" (List.length messages))
+
+let test_persist_connector_assistant_reply_ignores_empty_reply () =
+  let base_dir = temp_base_path "gate-keeper-empty-reply" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "discord-empty-reply-keeper" in
+      Gate_keeper_backend.persist_connector_assistant_reply ~base_dir
+        ~keeper_name ~source:"discord" ~reply:"   ";
+      check int "empty reply does not create chat file" 0
+        (List.length (K.load ~base_dir ~keeper_name)))
 
 let test_parse_keeper_chat_stream_request_accepts_connector_context () =
   let body =
@@ -233,6 +279,10 @@ let () =
             test_contextualize_message_includes_external_metadata;
           test_case "context envelope sanitizes metadata lines" `Quick
             test_contextualize_message_sanitizes_context_lines;
+          test_case "persists connector assistant reply" `Quick
+            test_persist_connector_assistant_reply_records_lane_reply;
+          test_case "skips empty connector assistant reply" `Quick
+            test_persist_connector_assistant_reply_ignores_empty_reply;
           test_case "stream request accepts connector context" `Quick
             test_parse_keeper_chat_stream_request_accepts_connector_context;
           test_case "stream request rejects partial connector context" `Quick


### PR DESCRIPTION
## Summary
- persist Discord/channel direct assistant replies into keeper_chat after dispatch_stream returns the final reply
- keep the connector user line as the inbound boundary recorder, but append the assistant reply on the same lane so surface reads can see the self watermark
- make channel gate dedupe TTL configurable and raise the default to 3600s for Discord reconnect/replay windows

## Verification
- ocamlformat --check lib/gate/channel_gate.ml lib/gate/channel_gate.mli lib/gate_keeper_backend.ml lib/gate_keeper_backend.mli test/test_gate_keeper_backend.ml test/test_channel_gate.ml
- env DUNE_BUILD_DIR=_build-discord-direct-reply-memory scripts/dune-local.sh build test/test_gate_keeper_backend.exe test/test_channel_gate.exe
- env DUNE_BUILD_DIR=_build-discord-direct-reply-memory ./_build-discord-direct-reply-memory/default/test/test_gate_keeper_backend.exe
- env DUNE_BUILD_DIR=_build-discord-direct-reply-memory ./_build-discord-direct-reply-memory/default/test/test_channel_gate.exe
- git diff --check