### PR TITLE
[codex] Project live turn state onto keeper surfaces

### DIFF
--- a/dashboard/src/components/agent-roster.test.ts
+++ b/dashboard/src/components/agent-roster.test.ts
@@ -16,6 +16,7 @@ import {
 } from '../store'
 import { missionSnapshot } from '../mission-signals'
 import { namespaceTruth } from '../namespace-truth-store'
+import { fleetCompositeSnapshot } from '../composite-signals'
 
 function makeAgent(overrides: Partial<Agent> = {}): Agent {
   return {
@@ -24,6 +25,37 @@ function makeAgent(overrides: Partial<Agent> = {}): Agent {
     current_task: null,
     ...overrides,
   }
+}
+
+function makeCompositeSnapshot(
+  overrides: Partial<KeeperCompositeSnapshot> = {},
+): KeeperCompositeSnapshot {
+  return {
+    keeper: 'sangsu',
+    correlation_id: 'keeper:sangsu:1',
+    run_id: 'r-1',
+    ts: 0,
+    phase: 'running',
+    turn_phase: 'idle',
+    decision: { stage: 'undecided' },
+    runtime: { state: 'idle' },
+    compaction: { stage: 'accumulating' },
+    measurement: { captured: false },
+    invariants: {
+      phase_turn_alignment: true,
+      no_runtime_before_measurement: true,
+      compaction_atomicity: true,
+      event_priority_monotone: true,
+      phase_derivation_agreement: true,
+    },
+    fsm_guard_violations: 0,
+    fsm_guard_violation_breakdown: [],
+    is_live: false,
+    live_turn: null,
+    last_outcome: null,
+    recommended_actions: [],
+    ...overrides,
+  } as KeeperCompositeSnapshot
 }
 
 async function flushUi(): Promise<void> {
@@ -503,6 +535,7 @@ describe('AgentRoster live-only cards', () => {
     serverStatus.value = null
     namespaceTruth.value = null
     missionSnapshot.value = null
+    fleetCompositeSnapshot.value = null
   })
 
   afterEach(() => {
@@ -518,6 +551,7 @@ describe('AgentRoster live-only cards', () => {
     serverStatus.value = null
     namespaceTruth.value = null
     missionSnapshot.value = null
+    fleetCompositeSnapshot.value = null
   })
 
   it('renders keeper cards from live runtime data and ignores stale mission brief fields', async () => {
@@ -825,6 +859,99 @@ describe('AgentRoster live-only cards', () => {
     const text = container.textContent ?? ''
     expect(text).toContain('일시정지 원인: 런타임 후보 소진')
     expect(text).toContain('런타임 후보가 모두 소진되어 runtime 상태 확인이 필요합니다.')
+  })
+
+  it('projects live composite turns into keeper operation presence', async () => {
+    agents.value = [
+      makeAgent({
+        name: 'keeper-sangsu-agent',
+        status: 'active',
+      }),
+    ]
+    keepers.value = [
+      {
+        name: 'sangsu',
+        agent_name: 'keeper-sangsu-agent',
+        status: 'active',
+        phase: 'Running',
+        pipeline_stage: 'idle',
+        registered: true,
+        keepalive_running: true,
+      } as Keeper,
+    ]
+    fleetCompositeSnapshot.value = {
+      generated_at: 1,
+      count: 1,
+      snapshots: [
+        makeCompositeSnapshot({
+          keeper: 'sangsu',
+          is_live: true,
+          turn_phase: 'executing',
+          live_turn: {
+            turn_id: 686,
+            started_at: 1_781_184_817,
+            last_progress_at: 1_781_184_843,
+            last_progress_kind: 'sse_thinking_delta',
+          },
+        }),
+      ],
+    }
+
+    await act(async () => {
+      render(html`<${AgentRoster} keeperFilter="keeper-only" />`, container)
+    })
+    await flushUi()
+
+    const row = container.querySelector('[data-testid="keeper-operations-row"]') as HTMLElement
+    const presence = row.querySelector('[data-agent-presence]') as HTMLElement
+    expect(presence.dataset.presenceRawStatus).toBe('busy')
+    expect(presence.dataset.presenceState).toBe('working')
+    expect(presence.dataset.presenceLabel).toBe('작업 중')
+    expect(presence.textContent).toContain('executing live')
+  })
+
+  it('projects non-live composite keepers as waiting instead of busy', async () => {
+    agents.value = [
+      makeAgent({
+        name: 'keeper-sangsu-agent',
+        status: 'active',
+      }),
+    ]
+    keepers.value = [
+      {
+        name: 'sangsu',
+        agent_name: 'keeper-sangsu-agent',
+        status: 'active',
+        phase: 'Running',
+        pipeline_stage: 'idle',
+        registered: true,
+        keepalive_running: true,
+      } as Keeper,
+    ]
+    fleetCompositeSnapshot.value = {
+      generated_at: 1,
+      count: 1,
+      snapshots: [
+        makeCompositeSnapshot({
+          keeper: 'sangsu',
+          is_live: false,
+          turn_phase: 'idle',
+          live_turn: null,
+        }),
+      ],
+    }
+
+    await act(async () => {
+      render(html`<${AgentRoster} keeperFilter="keeper-only" />`, container)
+    })
+    await flushUi()
+
+    const row = container.querySelector('[data-testid="keeper-operations-row"]') as HTMLElement
+    const presence = row.querySelector('[data-agent-presence]') as HTMLElement
+    expect(presence.dataset.presenceRawStatus).toBe('idle')
+    expect(presence.dataset.presenceState).toBe('idle')
+    expect(presence.dataset.presenceLabel).toBe('대기')
+    expect(presence.textContent).toContain('대기 중')
   })
 
   it('uses heartbeat and full keeper model for cards when action/model fallbacks disagree', async () => {

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -243,6 +243,14 @@ function rosterPresenceDisplay(
     return { status: 'offline', detail: `중단된 작업 ${agent.current_task}` }
   }
 
+  if (state.kind === 'running' && composite?.is_live === true) {
+    return { status: 'busy', detail: `${state.turnPhase} live` }
+  }
+
+  if (state.kind === 'running' && composite?.is_live === false) {
+    return { status: 'idle', detail: '대기 중' }
+  }
+
   return { status: agent.status ?? keeper.status ?? null, detail: null }
 }
 

--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -75,7 +75,10 @@ let trigger_typing_once ~channel_id =
    "response requested", "waiting for a keeper response", and "streaming
    response text" as separate runtime phases. This helper projects only the
    waiting phase to Discord UX without making typing a MASC state source of
-   truth. Streaming text should be a separate edit-loop transport. *)
+   truth. If the keeper is already running another lane, the dispatch waits
+   behind the same turn-admission slot; this refresh loop is the Discord-side
+   projection of that derived Busy/waiting state. Streaming text should be a
+   separate edit-loop transport. *)
 let with_response_wait_typing_indicator ~clock ~channel_id f =
   trigger_typing_once ~channel_id;
   Eio.Switch.run (fun typing_sw ->


### PR DESCRIPTION
## Summary

- Project fleet composite `is_live` into Keeper Operations roster presence.
- Show live turns as `busy` / `작업 중` with the current turn phase, and non-live running keepers as `idle` / `대기 중`.
- Clarify that Discord uses the existing typing refresh loop as the surface projection while a request waits behind the keeper turn-admission slot.

## Validation

- `ocamlformat --check lib/server/server_discord_in_process_gateway.ml`
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build_surface_presence MASC_SKIP_PIN_CHECK=1 MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build lib/server/.masc_server.objs/byte/server_discord_in_process_gateway.cmo`
- `pnpm install --offline` in `dashboard/` for the worktree-local node_modules
- `pnpm vitest run src/components/agent-roster.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1`
- `pnpm typecheck`
- `pnpm eslint src/components/agent-roster.ts`
- `git diff --check`