### PR TITLE
[codex] Record Discord external attention

### DIFF
--- a/lib/gate/discord_gateway_client.ml
+++ b/lib/gate/discord_gateway_client.ml
@@ -21,6 +21,7 @@ type gateway_event = Discord_gateway_state.dispatched_event =
       }
   | Message_create of
       { channel_id : string
+      ; guild_id : string option
       ; message_id : string
       ; author_id : string
       ; author_name : string option

--- a/lib/gate/discord_gateway_client.mli
+++ b/lib/gate/discord_gateway_client.mli
@@ -30,6 +30,7 @@ type gateway_event = Discord_gateway_state.dispatched_event =
       }
   | Message_create of
       { channel_id : string
+      ; guild_id : string option
       ; message_id : string
       ; author_id : string
       ; author_name : string option

--- a/lib/gate/discord_gateway_state.ml
+++ b/lib/gate/discord_gateway_state.ml
@@ -76,6 +76,7 @@ type dispatched_event =
       }
   | Message_create of
       { channel_id : string
+      ; guild_id : string option
       ; message_id : string
       ; author_id : string
       ; author_name : string option
@@ -265,6 +266,7 @@ let decode_ready ~payload =
 
 let decode_message_create ~bot_user_id ~payload =
   let channel_id = field_string_opt "channel_id" payload in
+  let guild_id = field_string_opt "guild_id" payload in
   let message_id = field_string_opt "id" payload in
   let content =
     match field_string_opt "content" payload with
@@ -304,7 +306,7 @@ let decode_message_create ~bot_user_id ~payload =
   | Some channel_id, Some message_id, Some author_id ->
       Ok
         (Message_create
-           { channel_id; message_id; author_id; author_name; content;
+           { channel_id; guild_id; message_id; author_id; author_name; content;
              mentions_bot })
   | _ ->
       Error "MESSAGE_CREATE payload: missing channel_id / id / author.id"

--- a/lib/gate/discord_gateway_state.mli
+++ b/lib/gate/discord_gateway_state.mli
@@ -75,6 +75,9 @@ type dispatched_event =
       }
   | Message_create of
       { channel_id : string
+      ; guild_id : string option
+        (** Guild snowflake when Discord includes one. Direct messages and
+            some partial payloads omit it. *)
       ; message_id : string
       ; author_id : string
       ; author_name : string option

--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -106,11 +106,91 @@ let with_response_wait_typing_indicator ~clock ~channel_id f =
         finish ();
         raise exn)
 
+let discord_conversation_id ~guild_id ~channel_id =
+  let guild_label =
+    match guild_id with
+    | Some guild_id when not (String.equal (String.trim guild_id) "") ->
+        guild_id
+    | Some _ | None -> "dm"
+  in
+  Printf.sprintf "discord:%s:channel:%s" guild_label channel_id
+
+let discord_attention_surface ~guild_id ~channel_id =
+  Keeper_external_attention.Discord
+    { guild_id; channel_id; parent_channel_id = None; thread_id = None }
+
+let optional_metadata key = function
+  | Some value when not (String.equal (String.trim value) "") ->
+      [ key, value ]
+  | Some _ | None -> []
+
+let record_external_attention ~base_dir ~keeper_name ~guild_id ~channel_id
+      ~message_id ~author_id ~author_name ~content ~mentions_bot ~route ~urgency
+  =
+  let surface = discord_attention_surface ~guild_id ~channel_id in
+  let conversation_id = discord_conversation_id ~guild_id ~channel_id in
+  let dedupe_key =
+    Printf.sprintf "discord:%s:%s" conversation_id message_id
+  in
+  let event_id = Keeper_external_attention.event_id_of_dedupe_key dedupe_key in
+  let item : Keeper_external_attention.item =
+    { event_id
+    ; dedupe_key
+    ; keeper_name
+    ; conversation = { conversation_id; surface }
+    ; external_message =
+        Some { surface; message_id; reply_to_message_id = None }
+    ; source_label = State.channel
+    ; actor =
+        { actor_id = Some author_id
+        ; display_name = author_name
+        ; authority = Keeper_chat_store.External
+        }
+    ; urgency
+    ; content_preview = content
+    ; content_ref = None
+    ; received_at =
+        Unix.gettimeofday ()
+        (* NDT-OK: Discord ingress wall-clock timestamp. The value is
+           persisted as event evidence and for pending-order projection;
+           it does not branch deterministic policy. *)
+    ; metadata =
+        [ "route", route
+        ; "mentions_bot", string_of_bool mentions_bot
+        ; "discord_channel_id", channel_id
+        ]
+        @ optional_metadata "discord_guild_id" guild_id
+    }
+  in
+  match Keeper_external_attention.record ~base_path:base_dir item with
+  | `Recorded -> Some event_id
+  | `Duplicate item -> Some item.event_id
+  | `Error error ->
+      Log.Server.warn
+        "discord external attention record failed (channel=%s keeper=%s): %s"
+        channel_id keeper_name error;
+      None
+
+let mark_attention_resolved ~base_dir ~keeper_name ~event_id ~reason =
+  match
+    Keeper_external_attention.mark_resolved
+      ~base_path:base_dir
+      ~keeper_name
+      ~event_ids:[ event_id ]
+      ~reason
+      ()
+  with
+  | Ok () -> ()
+  | Error error ->
+      Log.Server.warn
+        "discord external attention resolve failed (keeper=%s event=%s): %s"
+        keeper_name event_id error
+
 let handle_message_create ~dispatch
-      ~clock
-      ~(channel_id : string) ~(message_id : string)
+      ~clock ~base_dir
+      ~(channel_id : string) ~(guild_id : string option) ~(message_id : string)
       ~(author_id : string) ~(author_name : string option)
-      ~(content : string) =
+      ~(content : string) ~(mentions_bot : bool) =
   match State.keeper_for_channel ~channel_id with
   | None ->
     (* No binding for this channel — drop quietly. The bot may be in
@@ -119,6 +199,18 @@ let handle_message_create ~dispatch
       Discord_observability.Dropped_unbound;
     ()
   | Some keeper_name ->
+    let urgency =
+      if mentions_bot then Keeper_external_attention.Mention
+      else
+        match guild_id with
+        | None -> Keeper_external_attention.Direct_message
+        | Some _ -> Keeper_external_attention.Ambient
+    in
+    let attention_event_id =
+      record_external_attention ~base_dir ~keeper_name ~guild_id ~channel_id
+        ~message_id ~author_id ~author_name ~content ~mentions_bot
+        ~route:"triggered" ~urgency
+    in
     let msg : Channel_gate.inbound_message =
       { channel = State.channel
       ; channel_user_id = author_id
@@ -146,6 +238,11 @@ let handle_message_create ~dispatch
          (Channel_gate.gate_error_to_string gate_err)
      | Ok out ->
        if String.equal out.content "" then begin
+         (match attention_event_id with
+          | Some event_id ->
+              mark_attention_resolved ~base_dir ~keeper_name ~event_id
+                ~reason:"discord_empty_reply"
+          | None -> ());
          Discord_observability.record_inbound_dispatch
            Discord_observability.Empty_reply;
          Discord_observability.record_reply Discord_observability.Reply_empty
@@ -153,6 +250,11 @@ let handle_message_create ~dispatch
        else
          (match State.send_message ~channel_id ~content:out.content ~reply_to_message_id:message_id () with
           | Ok _ ->
+            (match attention_event_id with
+             | Some event_id ->
+                 mark_attention_resolved ~base_dir ~keeper_name ~event_id
+                   ~reason:"discord_reply_sent"
+             | None -> ());
             Discord_observability.record_inbound_dispatch
               Discord_observability.Reply_sent;
             Discord_observability.record_reply
@@ -166,18 +268,18 @@ let handle_message_create ~dispatch
               channel_id
               (Format.asprintf "%a" State.pp_send_error e)))
 
-let on_event ~dispatch ~clock (ev : Gw.gateway_event) =
+let on_event ~dispatch ~clock ~base_dir (ev : Gw.gateway_event) =
   match ev with
   | Gw.Ready { bot_user_id; _ } ->
     State.record_ready ~bot_user_id;
     Log.Server.info "Discord gateway READY (bot_user_id=%s)" bot_user_id
   | Gw.Message_create
-      { channel_id; message_id; author_id; author_name; content;
-        mentions_bot = _ } ->
+      { channel_id; guild_id; message_id; author_id; author_name; content;
+        mentions_bot } ->
     (* mentions_bot is already enforced by the trigger policy at the
        gateway-state layer; nothing extra to check here. *)
-    handle_message_create ~dispatch ~clock ~channel_id ~message_id ~author_id
-      ~author_name ~content
+    handle_message_create ~dispatch ~clock ~base_dir ~channel_id ~guild_id
+      ~message_id ~author_id ~author_name ~content ~mentions_bot
   | Gw.Reaction_add _ ->
     (* The previous Python sidecar used a configurable emoji
        trigger to drain pending messages. That feature is dropped in
@@ -191,8 +293,8 @@ let on_event ~dispatch ~clock (ev : Gw.gateway_event) =
    a single user line — no dispatch, no turn. Unbound channels drop, as
    on the dispatch path. *)
 let handle_ambient ~base_dir
-      ~(channel_id : string) ~(author_id : string)
-      ~(author_name : string option) ~(content : string) =
+      ~(channel_id : string) ~(guild_id : string option) ~(message_id : string)
+      ~(author_id : string) ~(author_name : string option) ~(content : string) =
   match State.keeper_for_channel ~channel_id with
   | None ->
     Discord_observability.record_ambient
@@ -210,6 +312,12 @@ let handle_ambient ~base_dir
       Discord_observability.record_ambient
         Discord_observability.Ambient_dropped_too_long
     else begin
+      let (_ : string option) =
+        record_external_attention ~base_dir ~keeper_name ~guild_id ~channel_id
+          ~message_id ~author_id ~author_name ~content:trimmed
+          ~mentions_bot:false ~route:"ambient"
+          ~urgency:Keeper_external_attention.Ambient
+      in
       Keeper_chat_store.append_user_message
         ~base_dir ~keeper_name ~content:trimmed
         ~source:State.channel
@@ -226,8 +334,11 @@ let handle_ambient ~base_dir
 
 let on_ambient ~base_dir (ev : Gw.gateway_event) =
   match ev with
-  | Gw.Message_create { channel_id; author_id; author_name; content; _ } ->
-    handle_ambient ~base_dir ~channel_id ~author_id ~author_name ~content
+  | Gw.Message_create
+      { channel_id; guild_id; message_id; author_id; author_name; content; _ }
+    ->
+    handle_ambient ~base_dir ~channel_id ~guild_id ~message_id ~author_id
+      ~author_name ~content
   | Gw.Ready _ | Gw.Reaction_add _ | Gw.Ignored _ -> ()
 
 (* ---------------------------------------------------------------- *)
@@ -264,7 +375,14 @@ let start ~sw ~env ~clock ~state =
           ~sw ~env ~token
           ~intents:default_intents
           ~trigger_policy:policy
-          ~on_event:(on_event ~dispatch ~clock)
+          ~on_event:(fun ev ->
+            (* Read base_path per event: [workspace_config] is mutable
+               (workspace-switch tools swap it). *)
+            on_event
+              ~dispatch
+              ~clock
+              ~base_dir:state.Mcp_server.workspace_config.base_path
+              ev)
           ~on_ambient:(fun ev ->
             (* Read base_path per event: [workspace_config] is mutable
                (workspace-switch tools swap it). *)

--- a/test/test_discord_gateway_state.ml
+++ b/test/test_discord_gateway_state.ml
@@ -295,7 +295,8 @@ let test_heartbeat_tick_when_connected () =
 (* ---------------------------------------------------------------- *)
 
 let message_create_payload
-    ~id ~channel_id ~author_id ?username ?global_name ~content ~mention_ids ()
+    ~id ~channel_id ?guild_id ~author_id ?username ?global_name ~content
+    ~mention_ids ()
     : Yojson.Safe.t =
   let mentions =
     `List
@@ -312,13 +313,19 @@ let message_create_payload
        | Some g -> [ ("global_name", `String g) ]
        | None -> [])
   in
+  let guild_fields =
+    match guild_id with
+    | Some guild_id -> [ ("guild_id", `String guild_id) ]
+    | None -> []
+  in
   `Assoc
-    [ ("id", `String id)
-    ; ("channel_id", `String channel_id)
-    ; ("author", `Assoc author_fields)
-    ; ("content", `String content)
-    ; ("mentions", mentions)
-    ]
+    ([ ("id", `String id)
+     ; ("channel_id", `String channel_id)
+     ; ("author", `Assoc author_fields)
+     ; ("content", `String content)
+     ; ("mentions", mentions)
+     ]
+    @ guild_fields)
 
 let reaction_add_payload
     ~channel_id ~message_id ~user_id ~emoji_name ?emoji_id () : Yojson.Safe.t =
@@ -354,6 +361,7 @@ let test_decode_message_create_with_mention () =
   | Ok
       (S.Message_create
         { channel_id = "CH1"
+        ; guild_id = None
         ; message_id = "MSG1"
         ; author_id = "USER1"
         ; author_name = None
@@ -424,6 +432,31 @@ let test_decode_message_create_without_mention () =
   with
   | Ok (S.Message_create { mentions_bot = false; _ }) -> ()
   | Ok _ -> fail "expected mentions_bot=false"
+  | Error msg -> fail msg
+
+let test_decode_message_create_preserves_guild_id () =
+  let payload =
+    message_create_payload
+      ~id:"MSG3"
+      ~channel_id:"CH1"
+      ~guild_id:"GUILD1"
+      ~author_id:"USER1"
+      ~content:"guild message"
+      ~mention_ids:[]
+      ()
+  in
+  match
+    S.decode_dispatch
+      ~bot_user_id:(Some "BOT")
+      ~event_name:"MESSAGE_CREATE"
+      ~payload
+  with
+  | Ok (S.Message_create { guild_id = Some "GUILD1"; _ }) -> ()
+  | Ok (S.Message_create { guild_id = Some other; _ }) ->
+      failf "expected guild_id=GUILD1, got %s" other
+  | Ok (S.Message_create { guild_id = None; _ }) ->
+      fail "expected guild_id to be preserved"
+  | Ok _ -> fail "expected MESSAGE_CREATE"
   | Error msg -> fail msg
 
 let test_decode_reaction_add_unicode () =
@@ -1043,6 +1076,8 @@ let () =
             `Quick test_decode_message_create_with_mention
         ; test_case "MESSAGE_CREATE without mention sets mentions_bot=false"
             `Quick test_decode_message_create_without_mention
+        ; test_case "MESSAGE_CREATE preserves guild_id" `Quick
+            test_decode_message_create_preserves_guild_id
         ; test_case "author_name prefers global_name" `Quick
             test_decode_author_name_prefers_global_name
         ; test_case "author_name falls back to username" `Quick


### PR DESCRIPTION
## What changed

- Preserved Discord `guild_id` on typed `MESSAGE_CREATE` gateway events.
- Recorded bound Discord messages into `Keeper_external_attention` before dispatch.
- Left ambient Discord messages pending in the external attention store while keeping existing chat-store ambient recording.
- Marked triggered attention resolved after an empty keeper reply or successful Discord reply send.

## Why

This is the first implementation slice after the external attention store: Discord messages now get durable, conversation-scoped attention records without involving OAS. Conversation IDs are keyed by Discord guild/channel. Discord thread messages are separated when Discord delivers the thread as the event `channel_id`; parent-thread enrichment remains a later adapter metadata problem.

## Validation

- `ocamlformat --check lib/gate/discord_gateway_state.mli lib/gate/discord_gateway_client.mli lib/gate/discord_gateway_state.ml lib/gate/discord_gateway_client.ml lib/server/server_discord_in_process_gateway.ml test/test_discord_gateway_state.ml`
- `scripts/dune-local.sh build test/test_discord_gateway_state.exe`
- `./_build/default/test/test_discord_gateway_state.exe` (47 tests)
- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-attention-check opam exec -- dune build --root . lib/server/server_discord_in_process_gateway.ml test/test_discord_gateway_state.exe`
- `scripts/ci/check-determinism-contract.sh`
- `git diff --check`