### PR TITLE
feat(keeper): RFC-0231 P1 memory os core persistence

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -187,7 +187,8 @@
   meta_cognition_snapshot
   meta_cognition_parse
   meta_cognition_interpret
-  meta_cognition_digest)
+  meta_cognition_digest
+  keeper_memory_os_io)
  (libraries
   mcp_protocol
   mcp_protocol.eio

--- a/lib/keeper/keeper_memory_os_io.ml
+++ b/lib/keeper/keeper_memory_os_io.ml
@@ -1,0 +1,318 @@
+(** Keeper_memory_os_io — append-only atomic I/O for tiered memory files.
+
+    All writes are append-only and best-effort atomic (temp file + rename
+    for single-record files; direct append with O_APPEND semantics for
+    JSONL logs). Reads are bounded tail reads to keep startup cost low. *)
+
+open Keeper_memory_os_types
+
+let rec ensure_dir path =
+  if path = "" || path = Filename.current_dir_name
+  then ()
+  else if Sys.file_exists path
+  then (
+    if not (Sys.is_directory path)
+    then invalid_arg (Printf.sprintf "not a directory: %s" path))
+  else (
+    let parent = Filename.dirname path in
+    if parent <> path then ensure_dir parent;
+    try Unix.mkdir path 0o755 with
+    | Unix.Unix_error (Unix.EEXIST, _, _) ->
+      if not (Sys.file_exists path && Sys.is_directory path)
+      then invalid_arg (Printf.sprintf "not a directory: %s" path))
+;;
+
+let keepers_dir_override : string option ref = ref None
+
+let keepers_dir () =
+  match !keepers_dir_override with
+  | Some path -> path
+  | None -> Config_dir_resolver.keepers_dir ()
+;;
+
+module For_testing = struct
+  let with_keepers_dir path f =
+    ensure_dir path;
+    let previous = !keepers_dir_override in
+    keepers_dir_override := Some path;
+    Fun.protect
+      ~finally:(fun () -> keepers_dir_override := previous)
+      f
+  ;;
+end
+
+let facts_path ~keeper_id =
+  Filename.concat (keepers_dir ()) (keeper_id ^ ".facts.jsonl")
+;;
+
+let events_path ~keeper_id =
+  Filename.concat (keepers_dir ()) (keeper_id ^ ".events.jsonl")
+;;
+
+let episodes_dir ~keeper_id =
+  let d = Filename.concat (keepers_dir ()) (Filename.concat keeper_id "episodes") in
+  ensure_dir d;
+  d
+;;
+
+let tool_results_dir ~keeper_id =
+  let d = Filename.concat (keepers_dir ()) (Filename.concat keeper_id "tool-results") in
+  ensure_dir d;
+  d
+;;
+
+let tool_result_path ~keeper_id ~tool_call_id =
+  Filename.concat (tool_results_dir ~keeper_id) (tool_call_id ^ ".json")
+;;
+
+let episode_path ~keeper_id ~trace_id ~generation =
+  Filename.concat
+    (episodes_dir ~keeper_id)
+    (Printf.sprintf "%s-g%04d.json" trace_id generation)
+;;
+
+let unique_episode_path ~keeper_id episode =
+  let created_ms =
+    episode.created_at *. 1000.0 |> Float.max 0.0 |> Int64.of_float
+  in
+  let base =
+    Filename.concat
+      (episodes_dir ~keeper_id)
+      (Printf.sprintf
+         "%s-g%04d-t%013Ld"
+         episode.trace_id
+         episode.generation
+         created_ms)
+  in
+  let rec loop suffix =
+    let path =
+      if suffix = 0
+      then base ^ ".json"
+      else Printf.sprintf "%s-%04d.json" base suffix
+    in
+    if Sys.file_exists path then loop (suffix + 1) else path
+  in
+  loop 0
+;;
+
+(* ---------- Append helpers ---------- *)
+
+let remove_noerr path =
+  try
+    if Sys.file_exists path then Sys.remove path
+  with
+  | Sys_error _ | Unix.Unix_error _ -> ()
+;;
+
+let append_line path line =
+  ensure_dir (Filename.dirname path);
+  let oc = open_out_gen [ Open_append; Open_creat; Open_text ] 0o644 path in
+  let close_attempted = ref false in
+  try
+    output_string oc (line ^ "\n");
+    close_attempted := true;
+    close_out oc
+  with
+  | exn ->
+    if not !close_attempted then close_out_noerr oc;
+    raise exn
+;;
+
+let append_json path json =
+  append_line path (Yojson.Safe.to_string json)
+;;
+
+let append_fact ~keeper_id fact =
+  append_json (facts_path ~keeper_id) (fact_to_json fact)
+;;
+
+let append_event ~keeper_id episode =
+  append_json (events_path ~keeper_id) (episode_to_json episode)
+;;
+
+let write_file_atomically path content =
+  ensure_dir (Filename.dirname path);
+  let rec open_tmp attempt =
+    (* PID/counter affect only the collision-resistant temp path;
+       NDT-OK: persisted content and final path stay input-derived, and O_EXCL
+       prevents accidental reuse before the checked close + rename. *)
+    let tmp = Printf.sprintf "%s.tmp.%d.%d" path (Unix.getpid ()) attempt in
+    try
+      let fd =
+        Unix.openfile tmp [ Unix.O_WRONLY; Unix.O_CREAT; Unix.O_EXCL ] 0o644
+      in
+      tmp, Unix.out_channel_of_descr fd
+    with
+    | Unix.Unix_error (Unix.EEXIST, _, _) -> open_tmp (attempt + 1)
+  in
+  let tmp, oc = open_tmp 0 in
+  let close_attempted = ref false in
+  try
+    output_string oc content;
+    close_attempted := true;
+    close_out oc;
+    Sys.rename tmp path
+  with
+  | exn ->
+    if not !close_attempted then close_out_noerr oc;
+    remove_noerr tmp;
+    raise exn
+;;
+
+let append_episode ~keeper_id episode =
+  let path = unique_episode_path ~keeper_id episode in
+  write_file_atomically path (Yojson.Safe.pretty_to_string (episode_to_json episode))
+;;
+
+let append_episode_bundle ~keeper_id episode =
+  append_episode ~keeper_id episode;
+  append_event ~keeper_id episode;
+  List.iter (append_fact ~keeper_id) episode.claims
+;;
+
+let save_tool_result ~keeper_id ~tool_call_id json =
+  let path = tool_result_path ~keeper_id ~tool_call_id in
+  write_file_atomically path (Yojson.Safe.pretty_to_string json)
+;;
+
+let load_tool_result ~keeper_id ~tool_call_id =
+  let path = tool_result_path ~keeper_id ~tool_call_id in
+  if Sys.file_exists path
+  then (
+    let ic = open_in_bin path in
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr ic)
+      (fun () ->
+         let len = in_channel_length ic in
+         let buf = really_input_string ic len in
+         Some (Yojson.Safe.from_string buf)))
+  else None
+;;
+
+(* ---------- Tail reads ---------- *)
+
+let count_newlines s =
+  let count = ref 0 in
+  String.iter (fun ch -> if Char.equal ch '\n' then incr count) s;
+  !count
+;;
+
+let split_lines s =
+  let len = String.length s in
+  let rec loop start i acc =
+    if i = len
+    then (
+      let acc =
+        if start = len
+        then acc
+        else String.sub s start (len - start) :: acc
+      in
+      List.rev acc)
+    else if Char.equal s.[i] '\n'
+    then (
+      let line_len = i - start in
+      let line =
+        if line_len > 0 && Char.equal s.[i - 1] '\r'
+        then String.sub s start (line_len - 1)
+        else String.sub s start line_len
+      in
+      loop (i + 1) (i + 1) (line :: acc))
+    else
+      loop start (i + 1) acc
+  in
+  loop 0 0 []
+;;
+
+let read_lines_tail path ~n =
+  if n <= 0 || not (Sys.file_exists path)
+  then []
+  else (
+    let ic = open_in_bin path in
+    let rec loop pos chunks newline_count =
+      if pos <= 0 || newline_count > n
+      then chunks
+      else (
+        let chunk_len = min 8192 pos in
+        let next_pos = pos - chunk_len in
+        seek_in ic next_pos;
+        let chunk = really_input_string ic chunk_len in
+        loop next_pos (chunk :: chunks) (newline_count + count_newlines chunk))
+    in
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr ic)
+      (fun () ->
+         let len = in_channel_length ic in
+         loop len [] 0 |> String.concat "" |> split_lines))
+;;
+
+let take_last n xs =
+  let rec drop k = function
+    | xs when k <= 0 -> xs
+    | [] -> []
+    | _ :: tl -> drop (k - 1) tl
+  in
+  let len = List.length xs in
+  if n <= 0 then [] else if len <= n then xs else drop (len - n) xs
+;;
+
+let parse_json_line parse line =
+  try parse (Yojson.Safe.from_string line) with
+  | Yojson.Json_error _ -> None
+;;
+
+let read_facts_tail ~keeper_id ~n =
+  read_lines_tail (facts_path ~keeper_id) ~n
+  |> List.filter_map (parse_json_line fact_of_json)
+  |> take_last n
+;;
+
+let read_events_tail ~keeper_id ~n =
+  read_lines_tail (events_path ~keeper_id) ~n
+  |> List.filter_map (parse_json_line episode_of_json)
+  |> take_last n
+;;
+
+let read_episode_file path =
+  let ic = open_in_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () ->
+       let len = in_channel_length ic in
+       let buf = really_input_string ic len in
+       parse_json_line episode_of_json buf)
+;;
+
+let compare_episode_recency a b =
+  let by_created = Float.compare a.created_at b.created_at in
+  if by_created <> 0
+  then by_created
+  else (
+    let by_trace = String.compare a.trace_id b.trace_id in
+    if by_trace <> 0
+    then by_trace
+    else (
+      let by_generation = Int.compare a.generation b.generation in
+      if by_generation <> 0
+      then by_generation
+      else String.compare a.episode_summary b.episode_summary))
+;;
+
+let read_episode_files_tail ~keeper_id ~n =
+  let dir = Filename.concat (keepers_dir ()) (Filename.concat keeper_id "episodes") in
+  if n <= 0 || not (Sys.file_exists dir && Sys.is_directory dir)
+  then []
+  else (
+    Sys.readdir dir
+    |> Array.to_list
+    |> List.filter (fun name -> Filename.check_suffix name ".json")
+    |> List.map (fun name -> Filename.concat dir name)
+    |> List.filter Sys.file_exists
+    |> List.filter_map read_episode_file
+    |> List.sort compare_episode_recency
+    |> take_last n)
+;;
+
+let read_episodes_tail ~keeper_id ~n =
+  let events = read_events_tail ~keeper_id ~n in
+  if events = [] then read_episode_files_tail ~keeper_id ~n else events
+;;

--- a/lib/keeper/keeper_memory_os_io.mli
+++ b/lib/keeper/keeper_memory_os_io.mli
@@ -1,0 +1,34 @@
+(** Keeper_memory_os_io — append-only atomic I/O for tiered memory files.
+
+    Path helpers, atomic writes, and bounded tail reads for facts,
+    events/episodes, and external tool-result archives. *)
+
+open Keeper_memory_os_types
+
+(** {1 Path helpers} *)
+
+val facts_path : keeper_id:string -> string
+val events_path : keeper_id:string -> string
+val episodes_dir : keeper_id:string -> string
+val tool_results_dir : keeper_id:string -> string
+val tool_result_path : keeper_id:string -> tool_call_id:string -> string
+val episode_path : keeper_id:string -> trace_id:string -> generation:int -> string
+
+(** {1 Atomic writes} *)
+
+val append_fact : keeper_id:string -> fact -> unit
+val append_event : keeper_id:string -> episode -> unit
+val append_episode : keeper_id:string -> episode -> unit
+val append_episode_bundle : keeper_id:string -> episode -> unit
+val save_tool_result : keeper_id:string -> tool_call_id:string -> Yojson.Safe.t -> unit
+val load_tool_result : keeper_id:string -> tool_call_id:string -> Yojson.Safe.t option
+
+(** {1 Bounded tail reads} *)
+
+val read_facts_tail : keeper_id:string -> n:int -> fact list
+val read_events_tail : keeper_id:string -> n:int -> episode list
+val read_episodes_tail : keeper_id:string -> n:int -> episode list
+
+module For_testing : sig
+  val with_keepers_dir : string -> (unit -> 'a) -> 'a
+end

--- a/lib/keeper/keeper_memory_os_policy.ml
+++ b/lib/keeper/keeper_memory_os_policy.ml
@@ -1,0 +1,107 @@
+(** Keeper_memory_os_policy — deterministic importance scoring and
+    retention decisions for the Memory OS.
+
+    The LLM librarian decides *what facts exist*; this module decides
+    *how to retain them* using a deterministic composite score and
+    explicit retention verdicts. *)
+
+open Keeper_memory_os_types
+
+type retention_verdict =
+  | KeepVerbatim
+  | Summarize
+  | ReferenceOnly
+  | Discard
+
+let default_lambda = 1.0 /. (86400.0 *. 7.0) (* half-life ~7 days *)
+let default_alpha = 0.5
+let keep_verbatim_score_threshold = 0.75
+let summarize_score_threshold = 0.35
+
+(** Forgetting curve: recency decays exponentially with a half-life
+    controlled by [lambda]. *)
+let recency_factor ~lambda ~now last_accessed =
+  let delta = now -. last_accessed in
+  if delta <= 0.0 then 1.0 else exp (-.lambda *. delta)
+;;
+
+(** Access boost: each recall incrementally increases the weight of a
+    fact, governed by [alpha] (sub-linear by default). *)
+let access_factor ~alpha access_count =
+  (1.0 +. float access_count) ** alpha
+;;
+
+let score_fact ?(lambda = default_lambda) ?(alpha = default_alpha) ~now fact =
+  fact.confidence *. recency_factor ~lambda ~now fact.last_accessed *. access_factor ~alpha fact.access_count
+;;
+
+let score_tool_result
+      ?(lambda = default_lambda)
+      ?(alpha = default_alpha)
+      ~now
+      ~created_at
+      ~was_successful
+      ~access_count
+      ()
+  =
+  let base_confidence = if was_successful then 0.9 else 0.5 in
+  base_confidence *. recency_factor ~lambda ~now created_at *. access_factor ~alpha access_count
+;;
+
+let decide_retention score =
+  if score >= keep_verbatim_score_threshold
+  then KeepVerbatim
+  else if score >= summarize_score_threshold
+  then Summarize
+  else Discard
+;;
+
+let verdict_to_string = function
+  | KeepVerbatim -> "keep_verbatim"
+  | Summarize -> "summarize"
+  | ReferenceOnly -> "reference_only"
+  | Discard -> "discard"
+;;
+
+let string_contains substring str =
+  let sub_len = String.length substring in
+  let str_len = String.length str in
+  let rec aux i =
+    if i + sub_len > str_len
+    then false
+    else if String.sub str i sub_len = substring
+    then true
+    else aux (i + 1)
+  in
+  if sub_len = 0 then true else aux 0
+;;
+
+let normalize_word_char = function
+  | 'A'..'Z' as c -> Char.lowercase_ascii c
+  | ('a'..'z' | '0'..'9') as c -> c
+  | _ -> ' '
+;;
+
+(** Bumps access counters for facts whose claims semantically match the
+    current turn keywords. This is intentionally a cheap heuristic (no
+    embedding model) to keep the system deterministic and offline. *)
+let bump_access_for_turn ~now (facts : fact list) ~(turn_text : string) : fact list =
+  let tokens =
+    String.map normalize_word_char turn_text
+    |> String.split_on_char ' '
+    |> List.map String.trim
+    |> List.filter (fun s -> String.length s > 2)
+    |> List.sort_uniq String.compare
+  in
+  let score_claim claim =
+    let lower = String.lowercase_ascii claim in
+    List.fold_left (fun acc tok -> if string_contains tok lower then acc + 1 else acc) 0 tokens
+  in
+  List.map
+    (fun f ->
+       let match_score = score_claim f.claim in
+       if match_score > 0
+       then { f with access_count = f.access_count + 1; last_accessed = now }
+       else f)
+    facts
+;;

--- a/lib/keeper/keeper_memory_os_policy.mli
+++ b/lib/keeper/keeper_memory_os_policy.mli
@@ -1,0 +1,53 @@
+(** Keeper_memory_os_policy — deterministic importance scoring and
+    retention decisions for the Memory OS. *)
+
+open Keeper_memory_os_types
+
+(** Explicit retention verdict. The librarian extracts facts; this
+    policy decides how each fact should be materialised in working
+    memory. *)
+type retention_verdict =
+  | KeepVerbatim
+  | Summarize
+  | ReferenceOnly
+  | Discard
+
+val default_lambda : float
+val default_alpha : float
+val keep_verbatim_score_threshold : float
+val summarize_score_threshold : float
+
+(** Composite importance score for a fact.
+
+    Score = confidence × recency × access_boost
+    where recency follows an exponential forgetting curve and
+    access_boost is [(1 + access_count) ** alpha]. *)
+val score_fact : ?lambda:float -> ?alpha:float -> now:float -> fact -> float
+
+(** Score an archived tool result. *)
+val score_tool_result
+  :  ?lambda:float
+  -> ?alpha:float
+  -> now:float
+  -> created_at:float
+  -> was_successful:bool
+  -> access_count:int
+  -> unit
+  -> float
+
+(** Map a score to a retention verdict using fixed thresholds. *)
+val decide_retention : float -> retention_verdict
+
+val verdict_to_string : retention_verdict -> string
+
+(** Lightweight keyword access bump.
+
+    Increments [access_count] and updates [last_accessed] for facts
+    whose claims contain at least one keyword from [turn_text]. This is
+    a cheap, deterministic heuristic to approximate recall without an
+    embedding model. *)
+val bump_access_for_turn
+  :  now:float
+  -> fact list
+  -> turn_text:string
+  -> fact list

--- a/lib/keeper/keeper_memory_os_types.ml
+++ b/lib/keeper/keeper_memory_os_types.ml
@@ -1,0 +1,242 @@
+(** Keeper_memory_os_types — typed schema for the tiered Memory OS.
+
+    Facts are immutable, versioned claims extracted by the librarian.
+    Episodes group related facts with a short summary and metadata for
+    downstream retention scoring. *)
+
+let schema_version = "rfc0231-v1"
+
+type provenance_event =
+  { trace_id : string
+  ; turn : int
+  ; tool_call_id : string option
+  }
+
+type fact =
+  { claim : string
+  ; confidence : float
+  ; category : string
+  ; source : provenance_event
+  ; access_count : int
+  ; first_seen : float
+  ; last_accessed : float
+  ; valid_until : float option
+  ; schema_version : string
+  }
+
+type episode =
+  { trace_id : string
+  ; generation : int
+  ; episode_summary : string
+  ; claims : fact list
+  ; open_items : string list
+  ; constraints : string list
+  ; preserved_tool_refs : string list
+  ; source_turn_range : (int * int) option
+  ; created_at : float
+  ; schema_version : string
+  }
+
+(* ---------- JSON codecs ---------- *)
+
+let json_string_field key (fields : (string * Yojson.Safe.t) list) =
+  match List.assoc_opt key fields with
+  | Some (`String s) -> Some s
+  | Some (`Assoc _ | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null)
+  | None -> None
+;;
+
+let json_int_field key (fields : (string * Yojson.Safe.t) list) =
+  match List.assoc_opt key fields with
+  | Some (`Int i) -> Some i
+  | Some (`Assoc _ | `Bool _ | `Float _ | `Intlit _ | `List _ | `Null | `String _)
+  | None -> None
+;;
+
+let json_float_field key (fields : (string * Yojson.Safe.t) list) =
+  match List.assoc_opt key fields with
+  | Some (`Float f) -> Some f
+  | Some (`Int i) -> Some (float_of_int i)
+  | Some (`Assoc _ | `Bool _ | `Intlit _ | `List _ | `Null | `String _) | None -> None
+;;
+
+let json_bool_field key (fields : (string * Yojson.Safe.t) list) =
+  match List.assoc_opt key fields with
+  | Some (`Bool b) -> Some b
+  | Some (`Assoc _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _)
+  | None -> None
+;;
+
+let json_string_list_field key (fields : (string * Yojson.Safe.t) list) =
+  match List.assoc_opt key fields with
+  | Some (`List items) ->
+    let strings =
+      List.filter_map
+        (function
+          | `String s -> Some s
+          | `Assoc _ | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null -> None)
+        items
+    in
+    if List.length strings = List.length items then Some strings else None
+  | Some (`Assoc _ | `Bool _ | `Float _ | `Int _ | `Intlit _ | `Null | `String _)
+  | None -> None
+;;
+
+let provenance_event_to_json (e : provenance_event) =
+  let base =
+    [ "trace_id", `String e.trace_id
+    ; "turn", `Int e.turn
+    ]
+  in
+  let tool =
+    match e.tool_call_id with
+    | Some id -> [ "tool_call_id", `String id ]
+    | None -> []
+  in
+  `Assoc (base @ tool)
+;;
+
+let provenance_event_of_json (json : Yojson.Safe.t) =
+  match json with
+  | `Assoc fields ->
+    (match json_string_field "trace_id" fields, json_int_field "turn" fields with
+     | Some trace_id, Some turn ->
+       let tool_call_id = json_string_field "tool_call_id" fields in
+       Some { trace_id; turn; tool_call_id }
+     | (Some _, None) | (None, Some _) | (None, None) -> None)
+  | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ -> None
+;;
+
+let fact_to_json f =
+  `Assoc
+    ([ "claim", `String f.claim
+     ; "confidence", `Float f.confidence
+     ; "category", `String f.category
+     ; "source", provenance_event_to_json f.source
+     ; "access_count", `Int f.access_count
+     ; "first_seen", `Float f.first_seen
+     ; "last_accessed", `Float f.last_accessed
+     ; "schema_version", `String f.schema_version
+     ]
+     @
+     match f.valid_until with
+     | Some ts -> [ "valid_until", `Float ts ]
+     | None -> [])
+;;
+
+let fact_of_json (json : Yojson.Safe.t) =
+  match json with
+  | `Assoc fields ->
+    (match
+       ( json_string_field "claim" fields
+       , json_float_field "confidence" fields
+       , json_string_field "category" fields
+       , List.assoc_opt "source" fields )
+     with
+     | Some claim, Some confidence, Some category, Some source_json ->
+       (match provenance_event_of_json source_json with
+        | Some source ->
+          (* DET-OK: backward-compatible defaults for optional persisted fields. *)
+          let access_count = Option.value (json_int_field "access_count" fields) ~default:0 in
+          (* DET-OK: absent first_seen defaults to epoch for migration safety. *)
+          let first_seen = Option.value (json_float_field "first_seen" fields) ~default:0.0 in
+          (* DET-OK: absent last_accessed inherits first_seen. *)
+          let last_accessed = Option.value (json_float_field "last_accessed" fields) ~default:first_seen in
+          let valid_until = json_float_field "valid_until" fields in
+          Some
+            { claim
+            ; confidence = Float.max 0.0 (Float.min 1.0 confidence)
+            ; category
+            ; source
+            ; access_count
+            ; first_seen
+            ; last_accessed
+            ; valid_until
+            ; schema_version =
+                (* DET-OK: default to current schema for forward compatibility. *)
+                Option.value (json_string_field "schema_version" fields) ~default:schema_version
+            }
+        | None -> None)
+     | (Some _, Some _, Some _, None)
+     | (Some _, Some _, None, _)
+     | (Some _, None, _, _)
+     | (None, _, _, _) -> None)
+  | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ -> None
+;;
+
+let episode_to_json e =
+  let range_json =
+    match e.source_turn_range with
+    | Some (lo, hi) ->
+      [ "source_turn_range", `Assoc [ "lo", `Int lo; "hi", `Int hi ] ]
+    | None -> []
+  in
+  `Assoc
+    ([ "trace_id", `String e.trace_id
+     ; "generation", `Int e.generation
+     ; "episode_summary", `String e.episode_summary
+     ; "claims", `List (List.map fact_to_json e.claims)
+     ; "open_items", `List (List.map (fun s -> `String s) e.open_items)
+     ; "constraints", `List (List.map (fun s -> `String s) e.constraints)
+     ; "preserved_tool_refs", `List (List.map (fun s -> `String s) e.preserved_tool_refs)
+     ; "created_at", `Float e.created_at
+     ; "schema_version", `String e.schema_version
+     ]
+     @ range_json)
+;;
+
+let episode_of_json (json : Yojson.Safe.t) =
+  match json with
+  | `Assoc fields ->
+    (match
+       ( json_string_field "trace_id" fields
+       , json_int_field "generation" fields
+       , json_string_field "episode_summary" fields
+       , List.assoc_opt "claims" fields )
+     with
+     | Some trace_id, Some generation, Some episode_summary, Some (`List claim_items) ->
+       let claims = List.filter_map fact_of_json claim_items in
+       (* DET-OK: optional list fields default to empty. *)
+       let open_items = Option.value (json_string_list_field "open_items" fields) ~default:[] in
+       (* DET-OK: optional list fields default to empty. *)
+       let constraints = Option.value (json_string_list_field "constraints" fields) ~default:[] in
+       (* DET-OK: optional list fields default to empty. *)
+       let preserved_tool_refs =
+         Option.value (json_string_list_field "preserved_tool_refs" fields) ~default:[]
+       in
+       let source_turn_range =
+         match List.assoc_opt "source_turn_range" fields with
+         | Some (`Assoc r) ->
+           (match json_int_field "lo" r, json_int_field "hi" r with
+            | Some lo, Some hi -> Some (lo, hi)
+            | (Some _, None) | (None, Some _) | (None, None) -> None)
+         | Some (`Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _)
+         | None ->
+           None
+       in
+       (* DET-OK: absent created_at defaults to epoch for migration safety. *)
+       let created_at = Option.value (json_float_field "created_at" fields) ~default:0.0 in
+       Some
+         { trace_id
+         ; generation
+         ; episode_summary
+         ; claims
+         ; open_items
+         ; constraints
+         ; preserved_tool_refs
+         ; source_turn_range
+         ; created_at
+         ; schema_version =
+             (* DET-OK: default to current schema for forward compatibility. *)
+             Option.value (json_string_field "schema_version" fields) ~default:schema_version
+         }
+     | ( Some _
+       , Some _
+       , Some _
+       , Some (`Assoc _ | `Bool _ | `Float _ | `Int _ | `Intlit _ | `Null | `String _) )
+     | (Some _, Some _, Some _, None)
+     | (Some _, Some _, None, _)
+     | (Some _, None, _, _)
+     | (None, _, _, _) -> None)
+  | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ -> None
+;;

--- a/lib/keeper/keeper_memory_os_types.mli
+++ b/lib/keeper/keeper_memory_os_types.mli
@@ -1,0 +1,53 @@
+(** Keeper_memory_os_types — typed schema for the tiered Memory OS.
+
+    This module defines the canonical fact and episode records used by
+    the librarian, the I/O layer, and the retention policy. All records
+    carry a [schema_version] to support future migrations. *)
+
+(** Current schema version written to disk. *)
+val schema_version : string
+
+(** Source attribution for a single extracted fact. *)
+type provenance_event =
+  { trace_id : string
+  ; turn : int
+  ; tool_call_id : string option
+  }
+
+(** A single semantic claim extracted from conversation history. *)
+type fact =
+  { claim : string
+  ; confidence : float
+  ; category : string
+  ; source : provenance_event
+  ; access_count : int
+  ; first_seen : float
+  ; last_accessed : float
+  ; valid_until : float option
+  ; schema_version : string
+  }
+
+(** A librarian extraction result: a summary plus structured claims. *)
+type episode =
+  { trace_id : string
+  ; generation : int
+  ; episode_summary : string
+  ; claims : fact list
+  ; open_items : string list
+  ; constraints : string list
+  ; preserved_tool_refs : string list
+  ; source_turn_range : (int * int) option
+  ; created_at : float
+  ; schema_version : string
+  }
+
+(** {1 JSON codecs} *)
+
+val provenance_event_to_json : provenance_event -> Yojson.Safe.t
+val provenance_event_of_json : Yojson.Safe.t -> provenance_event option
+
+val fact_to_json : fact -> Yojson.Safe.t
+val fact_of_json : Yojson.Safe.t -> fact option
+
+val episode_to_json : episode -> Yojson.Safe.t
+val episode_of_json : Yojson.Safe.t -> episode option

--- a/test/dune
+++ b/test/dune
@@ -72,6 +72,7 @@
   test_pool
   test_keeper_turn_disposition
   test_keeper_turn_terminal_disposition_field
+  test_keeper_memory_os
   test_keeper_reconcile_state
   test_attempt_state
   test_runtime_attempt_fsm
@@ -343,6 +344,7 @@
   test_pool
   test_keeper_turn_disposition
   test_keeper_turn_terminal_disposition_field
+  test_keeper_memory_os
   test_keeper_reconcile_state
   test_attempt_state
   test_runtime_attempt_fsm

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -1,0 +1,244 @@
+(** Unit tests for the Keeper Memory OS core types, I/O, and policy. *)
+
+module Types = Masc.Keeper_memory_os_types
+module Policy = Masc.Keeper_memory_os_policy
+module Memory_io = Masc.Keeper_memory_os_io
+
+let fact_fixture ~now () =
+  { Types.claim = "User prefers concise responses"
+  ; Types.confidence = 0.9
+  ; Types.category = "preference"
+  ; Types.source = { Types.trace_id = "trace-123"; Types.turn = 5; Types.tool_call_id = None }
+  ; Types.access_count = 2
+  ; Types.first_seen = now -. 86400.0
+  ; Types.last_accessed = now -. 3600.0
+  ; Types.valid_until = None
+  ; Types.schema_version = Types.schema_version
+  }
+;;
+
+let with_temp_keepers_dir f =
+  let marker = Filename.temp_file "keeper-memory-os-" ".tmp" in
+  Sys.remove marker;
+  Memory_io.For_testing.with_keepers_dir marker (fun () -> f marker)
+;;
+
+let episode_fixture ~now ~trace_id ~generation ~summary =
+  let fact =
+    { (fact_fixture ~now ()) with
+      Types.claim = summary ^ " fact"
+    ; Types.source = { Types.trace_id; turn = 0; tool_call_id = None }
+    ; Types.first_seen = now
+    ; Types.last_accessed = now
+    }
+  in
+  { Types.trace_id
+  ; Types.generation
+  ; Types.episode_summary = summary
+  ; Types.claims = [ fact ]
+  ; Types.open_items = []
+  ; Types.constraints = []
+  ; Types.preserved_tool_refs = []
+  ; Types.source_turn_range = Some (0, 0)
+  ; Types.created_at = now
+  ; Types.schema_version = Types.schema_version
+  }
+;;
+
+let test_json_roundtrip () =
+  let now = 1_000_000.0 in
+  let f = fact_fixture ~now () in
+  let f2 = Option.get (Types.fact_of_json (Types.fact_to_json f)) in
+  Alcotest.(check string) "claim round-trip" f.claim f2.Types.claim;
+  Alcotest.(check (float 0.001)) "confidence round-trip" f.confidence f2.Types.confidence;
+  Alcotest.(check int) "access_count round-trip" f.access_count f2.Types.access_count;
+  Alcotest.(check (float 0.001)) "first_seen round-trip" f.first_seen f2.Types.first_seen;
+  let e =
+    { Types.trace_id = "trace-123"
+    ; Types.generation = 1
+    ; Types.episode_summary = "A short summary of the turn."
+    ; Types.claims = [ f ]
+    ; Types.open_items = [ "item1" ]
+    ; Types.constraints = [ "c1" ]
+    ; Types.preserved_tool_refs = [ "call_a" ]
+    ; Types.source_turn_range = Some (5, 5)
+    ; Types.created_at = now
+    ; Types.schema_version = Types.schema_version
+    }
+  in
+  let e2 = Option.get (Types.episode_of_json (Types.episode_to_json e)) in
+  Alcotest.(check string)
+    "episode summary round-trip"
+    e.episode_summary
+    e2.Types.episode_summary;
+  Alcotest.(check int) "claims length" 1 (List.length e2.Types.claims);
+  Alcotest.(check int) "open_items length" 1 (List.length e2.Types.open_items)
+;;
+
+let test_policy_score_and_retention () =
+  let now = 1_000_000.0 in
+  let f = fact_fixture ~now () in
+  let score = Policy.score_fact ~now f in
+  Alcotest.(check bool) "score positive" true (score > 0.0);
+  let verdict = Policy.decide_retention score in
+  Alcotest.(check bool) "high score -> KeepVerbatim" true (verdict = Policy.KeepVerbatim);
+  let low =
+    { f with
+      Types.confidence = 0.1
+    ; Types.access_count = 0
+    ; Types.last_accessed = now -. 864_000.0
+    }
+  in
+  let verdict_low = Policy.decide_retention (Policy.score_fact ~now low) in
+  Alcotest.(check bool) "low score -> Discard" true (verdict_low = Policy.Discard)
+;;
+
+let test_bump_access () =
+  let now = 1_000_000.0 in
+  let f = fact_fixture ~now () in
+  let bumped = Policy.bump_access_for_turn ~now [ f ] ~turn_text:"User prefers concise" in
+  (match bumped with
+   | [ got ] -> Alcotest.(check int) "access bumped" 3 got.Types.access_count
+   | _ -> Alcotest.fail "expected one bumped fact");
+  let not_bumped =
+    Policy.bump_access_for_turn ~now [ f ] ~turn_text:"completely unrelated"
+  in
+  match not_bumped with
+  | [ got ] -> Alcotest.(check int) "access unchanged" 2 got.Types.access_count
+  | _ -> Alcotest.fail "expected one unchanged fact"
+;;
+
+let json_episode_file_count ~keeper_id =
+  Memory_io.episodes_dir ~keeper_id
+  |> Sys.readdir
+  |> Array.to_list
+  |> List.filter (fun name -> Filename.check_suffix name ".json")
+  |> List.length
+;;
+
+let test_episode_files_do_not_overwrite_generation () =
+  with_temp_keepers_dir (fun _keepers_dir ->
+    let keeper_id = "episode-unique-keeper" in
+    let first =
+      episode_fixture
+        ~now:1_000_000.0
+        ~trace_id:"trace-same"
+        ~generation:9
+        ~summary:"first compaction"
+    in
+    let second =
+      episode_fixture
+        ~now:1_000_001.0
+        ~trace_id:"trace-same"
+        ~generation:9
+        ~summary:"second compaction"
+    in
+    Memory_io.append_episode ~keeper_id first;
+    Memory_io.append_episode ~keeper_id second;
+    Alcotest.(check int) "two episode files persisted" 2 (json_episode_file_count ~keeper_id);
+    match Memory_io.read_episodes_tail ~keeper_id ~n:2 with
+    | [ older; newer ] ->
+      Alcotest.(check string)
+        "older summary retained"
+        first.Types.episode_summary
+        older.Types.episode_summary;
+      Alcotest.(check string)
+        "newer summary retained"
+        second.Types.episode_summary
+        newer.Types.episode_summary
+    | episodes -> Alcotest.failf "expected two episodes, got %d" (List.length episodes))
+;;
+
+let test_episode_file_tail_uses_created_at_not_filename () =
+  with_temp_keepers_dir (fun _keepers_dir ->
+    let keeper_id = "episode-order-keeper" in
+    let older =
+      episode_fixture
+        ~now:1_000_000.0
+        ~trace_id:"trace-zz"
+        ~generation:1
+        ~summary:"older lexicographically last"
+    in
+    let newer =
+      episode_fixture
+        ~now:1_000_100.0
+        ~trace_id:"trace-aa"
+        ~generation:1
+        ~summary:"newer lexicographically first"
+    in
+    Memory_io.append_episode ~keeper_id older;
+    Memory_io.append_episode ~keeper_id newer;
+    match Memory_io.read_episodes_tail ~keeper_id ~n:1 with
+    | [ got ] ->
+      Alcotest.(check string)
+        "newest episode returned"
+        newer.Types.episode_summary
+        got.Types.episode_summary
+    | episodes -> Alcotest.failf "expected one episode, got %d" (List.length episodes))
+;;
+
+let test_jsonl_tail_reads_last_entries () =
+  with_temp_keepers_dir (fun _keepers_dir ->
+    let keeper_id = "jsonl-tail-keeper" in
+    let first =
+      episode_fixture
+        ~now:1_000_000.0
+        ~trace_id:"trace-first"
+        ~generation:1
+        ~summary:"first event"
+    in
+    let second =
+      episode_fixture
+        ~now:1_000_100.0
+        ~trace_id:"trace-second"
+        ~generation:2
+        ~summary:"second event"
+    in
+    Memory_io.append_episode_bundle ~keeper_id first;
+    Memory_io.append_episode_bundle ~keeper_id second;
+    Alcotest.(check int)
+      "zero facts requested"
+      0
+      (List.length (Memory_io.read_facts_tail ~keeper_id ~n:0));
+    (match Memory_io.read_facts_tail ~keeper_id ~n:1 with
+     | [ fact ] ->
+       Alcotest.(check string)
+         "last fact returned"
+         "second event fact"
+         fact.Types.claim
+     | facts -> Alcotest.failf "expected one fact, got %d" (List.length facts));
+    match Memory_io.read_episodes_tail ~keeper_id ~n:1 with
+    | [ event ] ->
+      Alcotest.(check string)
+        "last episode event returned"
+        second.Types.episode_summary
+        event.Types.episode_summary
+    | events -> Alcotest.failf "expected one event, got %d" (List.length events))
+;;
+
+let () =
+  Alcotest.run
+    "keeper_memory_os"
+    [ ( "json"
+      , [ Alcotest.test_case "fact and episode round-trip" `Quick test_json_roundtrip
+        ] )
+    ; ( "policy"
+      , [ Alcotest.test_case "score and retention" `Quick test_policy_score_and_retention
+        ; Alcotest.test_case "bump access" `Quick test_bump_access
+        ] )
+    ; ( "io"
+      , [ Alcotest.test_case
+            "episode files do not overwrite generation"
+            `Quick
+            test_episode_files_do_not_overwrite_generation
+        ; Alcotest.test_case
+            "episode file tail uses created_at"
+            `Quick
+            test_episode_file_tail_uses_created_at_not_filename
+        ; Alcotest.test_case
+            "jsonl tail reads last entries"
+            `Quick
+            test_jsonl_tail_reads_last_entries
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary
- Split RFC-0231 into P1 core only after #20829 was closed for phase separation.
- Add Memory OS typed facts/episodes schema and JSON codecs.
- Add append-only keeper memory persistence for facts/events/episodes/tool-result archives with bounded tail reads, checked atomic close, and non-overwriting episode files.
- Add deterministic retention/access scoring policy.

## Verification
- `scripts/dune-local.sh build test/test_keeper_memory_os.exe`
- `./_build/default/test/test_keeper_memory_os.exe`
- `python3 scripts/ci/check-fun-protect-finally-guard.py --base origin/main --head HEAD`
- `bash scripts/ci/check-ignore-without-comment-diff.sh --base origin/main --head HEAD`
- `bash scripts/lint/no-runtime-literal-outside-boundary-redaction.sh --fail`
- `bash scripts/lint/no-yojson-3-dead-arms.sh`

## Follow-up Phases
- P2: recall rendering + external prompt templates.
- P3: librarian extraction/runtime bridge.
- P4: keeper integration and post-turn wiring.