### PR TITLE
fix(workspace): add after_commit callback to write_backlog for stale-cache cleanup

### DIFF
--- a/lib/workspace/workspace_backlog.ml
+++ b/lib/workspace/workspace_backlog.ml
@@ -53,7 +53,15 @@ let read_backlog config =
       Log.Misc.error "%s" msg;
       { tasks = []; last_updated = now_iso (); version = 1 }
 
-let write_backlog config backlog =
+(** [write_backlog ?after_commit config backlog] persists the backlog to
+    both the primary and recovery paths, then invokes [after_commit] if
+    provided.  The callback runs only after both writes succeed, making it
+    the correct place for cache-invalidation side-effects that must not
+    fire unless the backlog actually landed on disk (RFC-0221 §3.3). *)
+let write_backlog ?after_commit config backlog =
   let json = backlog_to_yojson backlog in
   write_json config (backlog_path config) json;
-  write_json config (backlog_recovery_path config) json
+  write_json config (backlog_recovery_path config) json;
+  (match after_commit with
+   | Some f -> f ()
+   | None -> ())

--- a/lib/workspace/workspace_backlog.mli
+++ b/lib/workspace/workspace_backlog.mli
@@ -10,4 +10,13 @@ val decode_backlog : path:string ->
 val read_backlog_r : Workspace_utils_backend_setup.config ->
            (Masc_domain.backlog, string) result
 val read_backlog : Workspace_utils_backend_setup.config -> Masc_domain.backlog
-val write_backlog : Workspace_utils_backend_setup.config -> Masc_domain.backlog -> unit
+val write_backlog :
+  ?after_commit:(unit -> unit) ->
+  Workspace_utils_backend_setup.config ->
+  Masc_domain.backlog ->
+  unit
+(** [write_backlog ?after_commit config backlog] persists the backlog to
+    both the primary and recovery paths, then invokes [after_commit] if
+    provided.  Use [after_commit] for cache-invalidation side-effects that
+    must not fire unless the backlog commit succeeded (RFC-0221 §3.3).
+    Non-transition callers (GC, init, query) omit the callback. *)

--- a/lib/workspace/workspace_task.ml
+++ b/lib/workspace/workspace_task.ml
@@ -135,7 +135,13 @@ let cancel_task_r config ~agent_name ~task_id ~reason : string Masc_domain.masc_
                  ; version = backlog.version + 1
                  }
                in
-               write_backlog config new_backlog;
+               write_backlog
+                 ~after_commit:(fun () ->
+                   Task_cache_invariant.clear_stale_agent_task config
+                     ~agent_name ~task_id
+                     ~status:(Cancelled { cancelled_by = agent_name; cancelled_at = now_iso (); reason = Some reason })
+                     ~module_name:"cancel_task_r")
+                 config new_backlog;
                (* Update agent status if they had this task *)
                update_local_agent_state config ~agent_name (fun agent ->
                  if agent.current_task = Some task_id

--- a/lib/workspace/workspace_task_claim.ml
+++ b/lib/workspace/workspace_task_claim.ml
@@ -180,13 +180,21 @@ let claim_task_r config ~agent_name ~task_id ()
               now lives in the task FSM (single authority via [phase]), so the
               former defer-to-dispatch-loop workaround is gone — no cross-lib
               call into [Verification.assign_verifier] is needed. *)
+           let claimed_task =
+             List.find (fun (t : Masc_domain.task) -> String.equal t.id task_id) new_tasks
+           in
            let new_backlog =
              { tasks = new_tasks
              ; last_updated = now_iso ()
              ; version = backlog.version + 1
              }
            in
-           write_backlog config new_backlog;
+           write_backlog
+             ~after_commit:(fun () ->
+               Task_cache_invariant.clear_stale_agent_task config
+                 ~agent_name ~task_id ~status:claimed_task.task_status
+                 ~module_name:"claim_task_r.verification")
+             config new_backlog;
            Workspace_task_classify.update_local_agent_state config ~agent_name (fun agent ->
              { agent with status = Busy; current_task = Some task_id });
            let _ =
@@ -219,13 +227,21 @@ let claim_task_r config ~agent_name ~task_id ()
                ; auto_released_task_ids = []
                })
          | `Claimed_ok ->
+           let claimed_task =
+             List.find (fun (t : Masc_domain.task) -> String.equal t.id task_id) new_tasks
+           in
            let new_backlog =
              { tasks = new_tasks
              ; last_updated = now_iso ()
              ; version = backlog.version + 1
              }
            in
-           write_backlog config new_backlog;
+           write_backlog
+             ~after_commit:(fun () ->
+               Task_cache_invariant.clear_stale_agent_task config
+                 ~agent_name ~task_id ~status:claimed_task.task_status
+                 ~module_name:"claim_task_r.claimed_ok")
+             config new_backlog;
            Workspace_task_classify.update_local_agent_state config ~agent_name (fun agent ->
              { agent with status = Busy; current_task = Some task_id });
            let _ =

--- a/lib/workspace/workspace_task_schedule.ml
+++ b/lib/workspace/workspace_task_schedule.ml
@@ -532,7 +532,12 @@ let claim_next_r
              ; version = backlog.version + 1
              }
            in
-           write_backlog config new_backlog;
+           write_backlog
+             ~after_commit:(fun () ->
+               Task_cache_invariant.clear_stale_agent_task config
+                 ~agent_name ~task_id:task.id ~status:claimed_status
+                 ~module_name:"claim_next_r.claim")
+             config new_backlog;
            (* Update agent status — takes [with_file_lock] on the
              agent file via [Workspace_task.update_local_agent_state] to
              keep the record consistent with concurrent


### PR DESCRIPTION
## Problem

The same `clear_stale_agent_task` fix was spread across 3 separate PRs (#20844, #20845, #20846) — one per `write_backlog` call site. This is the N-of-M anti-pattern (CLAUDEmd §워크어라운드 거부 기준 시그니처 #3): same boilerplate pasted at every site, no abstraction, compiler cannot enforce completeness.

Additionally, investigation revealed that `workspace_task_schedule.ml` lines 474/487 **already** called `clear_stale_agent_task` via `clear_agent_state_after_release()` — the closed PRs would have produced **double clears**.

## Solution

Add `?after_commit:(unit -> unit)` optional callback to `Workspace_backlog.write_backlog`. The callback runs only after both primary and recovery JSON writes succeed, making it the correct place for cache-invalidation side-effects (RFC-0221 §3.3).

**5 files changed, +51/-7:**

| File | Change |
|------|--------|
| `workspace_backlog.ml/mli` | Add `?after_commit` parameter + doc |
| `workspace_task.ml` | Cancel path: `after_commit` with `clear_stale_agent_task` |
| `workspace_task_claim.ml` | Verification + OK claim paths: `after_commit` with `clear_stale_agent_task` |
| `workspace_task_schedule.ml` | Claim-next claim path: `after_commit` with `clear_stale_agent_task` |

**Unchanged (intentional):**
- `workspace_task_transitions.ml` — keeps explicit separate call due to try/with compensation logic around `write_backlog`
- `workspace_task_schedule.ml` release paths (474/487) — already have `clear_stale_agent_task` via `clear_agent_state_after_release()`
- Non-transition callers (`workspace_gc`, `workspace_init`, `workspace_query`) — omit callback

## Verification

- `@check` passes (full type verification)
- Backward compatible: `?after_commit` defaults to `None`

Supersedes: #20844, #20845, #20846

Co-Authored-By: Claude <noreply@anthropic.com>