### PR TITLE
feat(discord): persist chat conversation coordinates

### DIFF
--- a/dashboard/src/api/schemas/keeper-chat-history.test.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.test.ts
@@ -65,6 +65,20 @@ describe('safeParseKeeperChatHistoryMessage', () => {
     expect(out?.speaker_authority).toBe('external')
   })
 
+  it('passes connector conversation coordinates through when present', () => {
+    const out = safeParseKeeperChatHistoryMessage(
+      validMessage({
+        source: 'discord',
+        conversation_id: 'discord:guild-1:channel:1514586257706061834',
+        external_message_id: '1498985300729172039',
+      }),
+    )
+    expect(out?.conversation_id).toBe(
+      'discord:guild-1:channel:1514586257706061834',
+    )
+    expect(out?.external_message_id).toBe('1498985300729172039')
+  })
+
   it('accepts rows without speaker fields (legacy and non-user lines)', () => {
     const out = safeParseKeeperChatHistoryMessage(validMessage())
     expect(out).not.toBeNull()

--- a/dashboard/src/api/schemas/keeper-chat-history.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.ts
@@ -33,10 +33,14 @@ export const KeeperChatHistoryMessageSchema = object({
   // carry the executed tool's id/name; `content` holds the accumulated
   // argument JSON. `source` names the originating connector
   // ('dashboard' | 'discord' | 'slack' | 'agent') on every row of a
-  // turn. All three are absent on legacy rows.
+  // turn. Connector rows may also carry opaque conversation/message
+  // coordinates so UI surfaces can group platform channels/threads.
+  // These fields are absent on legacy rows.
   tool_call_id: optional(string()),
   tool_call_name: optional(string()),
   source: optional(string()),
+  conversation_id: optional(string()),
+  external_message_id: optional(string()),
   // RFC-0223 P1 speaker identity, present on user rows written since
   // then. `speaker_authority` is 'owner' (authenticated dashboard
   // operator) or 'external' (arbitrary person on a connector channel);

--- a/lib/gate_keeper_backend.ml
+++ b/lib/gate_keeper_backend.ml
@@ -107,11 +107,19 @@ let contextualize_message ~channel ~channel_user_id ~channel_user_name
      @ metadata_block
      @ [ ""; "[User message]"; safe_content ])
 
-let persist_connector_assistant_reply ~base_dir ~keeper_name ~source ~reply =
+let metadata_value key metadata =
+  match List.assoc_opt key metadata with
+  | Some value ->
+      let value = String.trim value in
+      if value = "" then None else Some value
+  | None -> None
+
+let persist_connector_assistant_reply ~base_dir ~keeper_name ~source
+    ?conversation_id ~reply () =
   let content = String.trim reply in
   if content <> "" then begin
     Keeper_chat_store.append_assistant_message ~base_dir ~keeper_name
-      ~content ~source ();
+      ~content ~source ?conversation_id ();
     Keeper_chat_broadcast.chat_appended ~keeper_name ~source
   end
 
@@ -149,11 +157,15 @@ let dispatch ~sw ~clock ~proc_mgr ~net ~config
      history. *)
   let lane = String.trim channel in
   let opt value = match String.trim value with "" -> None | v -> Some v in
+  let conversation_id = metadata_value "conversation_id" metadata in
+  let external_message_id = metadata_value "external_message_id" metadata in
   Keeper_chat_store.append_user_message
     ~base_dir:config.Workspace.base_path
     ~keeper_name
     ~content:(String.trim content)
     ~source:lane
+    ?conversation_id
+    ?external_message_id
     ~speaker:
       { Keeper_chat_store.speaker_id = opt channel_user_id
       ; speaker_name = opt channel_user_name
@@ -209,8 +221,8 @@ let dispatch ~sw ~clock ~proc_mgr ~net ~config
         | None -> Some { Gate_protocol.model_used = "runtime"; duration_ms; tokens_used = 0 }
       in
       persist_connector_assistant_reply
-        ~base_dir:config.Workspace.base_path
-        ~keeper_name ~source:lane ~reply;
+        ~base_dir:config.Workspace.base_path ~keeper_name ~source:lane
+        ?conversation_id ~reply ();
       Gate_protocol.Reply { content = reply; structured; stats }
   | Some result ->
       Gate_protocol.Keeper_error_result (redact_text (Tool_result.message result))

--- a/lib/gate_keeper_backend.mli
+++ b/lib/gate_keeper_backend.mli
@@ -53,7 +53,9 @@ val persist_connector_assistant_reply :
   base_dir:string ->
   keeper_name:string ->
   source:string ->
+  ?conversation_id:string ->
   reply:string ->
+  unit ->
   unit
 (** Persist a completed connector direct reply on the same chat lane that
     received the inbound user line. Empty replies are ignored. *)

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -11,6 +11,11 @@
     {v {"role":"tool","content":"{\"path\":\"x\"}","ts":...,
         "tool_call_id":"toolu_1","tool_call_name":"Read","source":"dashboard"} v}
 
+    Connector rows may additionally carry opaque route coordinates:
+    [conversation_id] for channel/thread grouping and [external_message_id]
+    for the inbound platform message. The store does not interpret these
+    values.
+
     @since 2.145.0 *)
 
 let sanitize_name name =
@@ -83,6 +88,8 @@ type chat_message = {
   tool_call_id : string option;
   tool_call_name : string option;
   source : string option;
+  conversation_id : string option;
+  external_message_id : string option;
   speaker : speaker option;
 }
 
@@ -116,7 +123,7 @@ let speaker_fields = function
       @ [ ("speaker_authority", `String (authority_label sp.speaker_authority)) ]
 
 let encode_line ~role ~content ~ts ?attachments ?tool_call_id ?tool_call_name
-    ?source ?speaker () : string =
+    ?source ?conversation_id ?external_message_id ?speaker () : string =
   let base_fields = [
     ("role", `String role);
     ("content", `String content);
@@ -144,6 +151,8 @@ let encode_line ~role ~content ~ts ?attachments ?tool_call_id ?tool_call_name
     @ opt_string_field "tool_call_id" tool_call_id
     @ opt_string_field "tool_call_name" tool_call_name
     @ opt_string_field "source" source
+    @ opt_string_field "conversation_id" conversation_id
+    @ opt_string_field "external_message_id" external_message_id
     @ speaker_fields speaker
   in
   Yojson.Safe.to_string (`Assoc all_fields)
@@ -158,8 +167,9 @@ let normalize_tool_call_id ~position call_id =
   if String.trim call_id = "" then Printf.sprintf "tc-%d" position else call_id
 
 let append_turn ~base_dir ~keeper_name ~(user_content : string)
-    ~(user_attachments : attachment list) ?(tool_calls = []) ?source ?speaker
-    ~(assistant_content : string) () =
+    ~(user_attachments : attachment list) ?(tool_calls = []) ?source
+    ?conversation_id ?external_message_id ?speaker ~(assistant_content : string)
+    () =
   try
     ensure_dir_once ~base_dir;
     let redaction = redaction_for ~base_dir ~keeper_name in
@@ -179,7 +189,8 @@ let append_turn ~base_dir ~keeper_name ~(user_content : string)
        assistant lines are the keeper's own output. *)
     let user_line =
       encode_line ~role:"user" ~content:user_content ~ts
-        ~attachments:user_attachments ?source ?speaker ()
+        ~attachments:user_attachments ?source ?conversation_id
+        ?external_message_id ?speaker ()
     in
     let tool_lines =
       List.mapi
@@ -189,11 +200,12 @@ let append_turn ~base_dir ~keeper_name ~(user_content : string)
             ~ts
             ~tool_call_id:(normalize_tool_call_id ~position tc.call_id)
             ~tool_call_name:tc.call_name
-            ?source ())
+            ?source ?conversation_id ())
         tool_calls
     in
     let asst_line =
-      encode_line ~role:"assistant" ~content:assistant_content ~ts ?source ()
+      encode_line ~role:"assistant" ~content:assistant_content ~ts ?source
+        ?conversation_id ()
     in
     let payload =
       String.concat "\n" ((user_line :: tool_lines) @ [ asst_line ]) ^ "\n"
@@ -212,14 +224,16 @@ let append_turn ~base_dir ~keeper_name ~(user_content : string)
 (* RFC-0223 P4: keeper-initiated message on one lane. A single
    assistant line — there is no user turn to pair it with. *)
 let append_assistant_message ~base_dir ~keeper_name ~(content : string)
-    ?source () =
+    ?source ?conversation_id () =
   try
     ensure_dir_once ~base_dir;
     let redaction = redaction_for ~base_dir ~keeper_name in
     let content = Keeper_secret_redaction.redact_text redaction content in
     let path = chat_path ~base_dir ~keeper_name in
     let ts = Time_compat.now () in
-    let line = encode_line ~role:"assistant" ~content ~ts ?source () in
+    let line =
+      encode_line ~role:"assistant" ~content ~ts ?source ?conversation_id ()
+    in
     Fs_compat.append_file path (line ^ "\n")
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
@@ -235,14 +249,17 @@ let append_assistant_message ~base_dir ~keeper_name ~(content : string)
    independent of) any turn. A single user line — the assistant reply,
    if one ever comes, is appended separately by the reply path. *)
 let append_user_message ~base_dir ~keeper_name ~(content : string)
-    ?source ?speaker () =
+    ?source ?conversation_id ?external_message_id ?speaker () =
   try
     ensure_dir_once ~base_dir;
     let redaction = redaction_for ~base_dir ~keeper_name in
     let content = Keeper_secret_redaction.redact_text redaction content in
     let path = chat_path ~base_dir ~keeper_name in
     let ts = Time_compat.now () in
-    let line = encode_line ~role:"user" ~content ~ts ?source ?speaker () in
+    let line =
+      encode_line ~role:"user" ~content ~ts ?source ?conversation_id
+        ?external_message_id ?speaker ()
+    in
     Fs_compat.append_file path (line ^ "\n")
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
@@ -270,6 +287,8 @@ let parse_line ~file_path (line : string) : chat_message option =
     let tool_call_id = opt_string "tool_call_id" in
     let tool_call_name = opt_string "tool_call_name" in
     let source = opt_string "source" in
+    let conversation_id = opt_string "conversation_id" in
+    let external_message_id = opt_string "external_message_id" in
     let speaker =
       let speaker_id = opt_string "speaker_id" in
       let speaker_name = opt_string "speaker_name" in
@@ -336,7 +355,7 @@ let parse_line ~file_path (line : string) : chat_message option =
     else
       Some
         { role; content; ts; attachments; tool_call_id; tool_call_name;
-          source; speaker }
+          source; conversation_id; external_message_id; speaker }
   with Yojson.Json_error detail ->
     report_persistence_read_drop
       ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
@@ -514,6 +533,8 @@ let to_json_array (messages : chat_message list) : Yojson.Safe.t =
               @ opt_string_field "tool_call_id" m.tool_call_id
               @ opt_string_field "tool_call_name" m.tool_call_name
               @ opt_string_field "source" m.source
+              @ opt_string_field "conversation_id" m.conversation_id
+              @ opt_string_field "external_message_id" m.external_message_id
               @ speaker_fields m.speaker
               @ (match m.attachments with
                  | None | Some [] -> []

--- a/lib/keeper/keeper_chat_store.mli
+++ b/lib/keeper/keeper_chat_store.mli
@@ -9,7 +9,10 @@
     Tool-call lines persisted between a turn's user and assistant lines
     additionally carry [tool_call_id] / [tool_call_name]; every line of
     a turn may carry the originating connector in [source]
-    (e.g. "dashboard", "discord", "slack", "agent").
+    (e.g. "dashboard", "discord", "slack", "agent"). Connector rows may
+    also carry [conversation_id] / [external_message_id], opaque route
+    coordinates used by dashboards to group platform channels/threads
+    without giving this store platform-specific knowledge.
 
     @since 2.145.0 *)
 
@@ -61,6 +64,8 @@ type chat_message = {
   tool_call_id : string option;
   tool_call_name : string option;
   source : string option;
+  conversation_id : string option;
+  external_message_id : string option;
   speaker : speaker option;
       (** Present on user lines written since RFC-0223 P1; [None] on
           older lines, tool/assistant lines, and lines whose persisted
@@ -71,11 +76,14 @@ type chat_message = {
 (** {1 I/O} *)
 
 (** [append_turn ~base_dir ~keeper_name ~user_content ~user_attachments
-    ?tool_calls ?source ?speaker ~assistant_content ()] appends one
+    ?tool_calls ?source ?conversation_id ?external_message_id ?speaker
+    ~assistant_content ()] appends one
     completed turn as consecutive lines — user, one line per tool call,
     assistant — sharing a single timestamp, in one write. [speaker]
     identifies the user-line author and is written on the user line
-    only. Failures are logged but never raised except for
+    only. [conversation_id] identifies the external conversation/thread
+    coordinate and is written on all lines of the turn; [external_message_id]
+    belongs to the inbound user line only. Failures are logged but never raised except for
     {!Eio.Cancel.Cancelled}. *)
 val append_turn :
   base_dir:string ->
@@ -84,12 +92,15 @@ val append_turn :
   user_attachments:attachment list ->
   ?tool_calls:tool_call list ->
   ?source:string ->
+  ?conversation_id:string ->
+  ?external_message_id:string ->
   ?speaker:speaker ->
   assistant_content:string ->
   unit ->
   unit
 
-(** [append_assistant_message ~base_dir ~keeper_name ~content ?source ()]
+(** [append_assistant_message ~base_dir ~keeper_name ~content ?source
+    ?conversation_id ()]
     appends one keeper-initiated assistant line with no paired user
     turn (RFC-0223 P4 [keeper_surface_post]). Same failure policy as
     {!append_turn}. *)
@@ -98,11 +109,12 @@ val append_assistant_message :
   keeper_name:string ->
   content:string ->
   ?source:string ->
+  ?conversation_id:string ->
   unit ->
   unit
 
 (** [append_user_message ~base_dir ~keeper_name ~content ?source
-    ?speaker ()] appends one inbound user line with no paired
+    ?conversation_id ?external_message_id ?speaker ()] appends one inbound user line with no paired
     assistant turn (RFC-0226). Written at delivery time by the inbound
     recorder — the Discord gateway's ambient arm and the gate dispatch
     boundary — so the line lands whether or not a turn starts or
@@ -112,6 +124,8 @@ val append_user_message :
   keeper_name:string ->
   content:string ->
   ?source:string ->
+  ?conversation_id:string ->
+  ?external_message_id:string ->
   ?speaker:speaker ->
   unit ->
   unit
@@ -141,6 +155,7 @@ val load_page :
 
 (** JSON array of messages. Entries without a timestamp omit the
     [ts] field; [tool_call_id] / [tool_call_name] / [source] /
+    [conversation_id] / [external_message_id] /
     [speaker_id] / [speaker_name] / [speaker_authority] appear only
     when present. *)
 val to_json_array : chat_message list -> Yojson.Safe.t

--- a/lib/keeper/keeper_surface_read.ml
+++ b/lib/keeper/keeper_surface_read.ml
@@ -37,6 +37,8 @@ let message_json (m : Store.chat_message) : Yojson.Safe.t =
     ([ ("role", `String m.role); ("content", `String m.content) ]
     @ opt_float_field "ts" m.ts
     @ opt_string_field "source" m.source
+    @ opt_string_field "conversation_id" m.conversation_id
+    @ opt_string_field "external_message_id" m.external_message_id
     @ opt_string_field "tool_call_name" m.tool_call_name
     @ speaker_fields)
 

--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -130,6 +130,12 @@ let discord_attention_surface ~guild_id ~channel_id =
   Keeper_external_attention.Discord
     { guild_id; channel_id; parent_channel_id = None; thread_id = None }
 
+let discord_chat_metadata ~guild_id ~channel_id ~message_id =
+  [
+    ("conversation_id", discord_conversation_id ~guild_id ~channel_id);
+    ("external_message_id", message_id);
+  ]
+
 let record_external_attention ~base_dir ~keeper_name ~guild_id ~channel_id
       ~message_id ~author_id ~author_name ~content ~mentions_bot ~route ~urgency
   =
@@ -237,7 +243,8 @@ let handle_message_create ~dispatch
   | Some (resolution, resolution_metadata) ->
     let keeper_name = resolution.State.keeper_name in
     let metadata =
-      [ ("discord.channel_id", channel_id)
+      discord_chat_metadata ~guild_id ~channel_id ~message_id
+      @ [ ("discord.channel_id", channel_id)
       ; ("discord.message_id", message_id)
       ; ("discord.bound_channel_id", resolution.bound_channel_id)
       ; ("discord.binding_via_parent", string_of_bool resolution.via_parent)
@@ -387,6 +394,8 @@ let handle_ambient ~base_dir
       Keeper_chat_store.append_user_message
         ~base_dir ~keeper_name ~content:trimmed
         ~source:State.channel
+        ~conversation_id:(discord_conversation_id ~guild_id ~channel_id)
+        ~external_message_id:message_id
         ~speaker:
           { Keeper_chat_store.speaker_id = Some author_id
           ; speaker_name = author_name

--- a/test/test_channel_gate.ml
+++ b/test/test_channel_gate.ml
@@ -232,6 +232,35 @@ let test_handle_inbound_passes_channel_context_to_dispatch () =
       | None -> fail "dispatch should receive connector context" )
   | Error e -> fail (Channel_gate.gate_error_to_string e)
 
+let test_handle_inbound_passes_metadata_to_dispatch () =
+  reset_dedup ();
+  let seen = ref None in
+  let dispatch ~channel:_ ~channel_user_id:_ ~channel_user_name:_
+      ~channel_workspace_id:_ ~keeper_name:_ ~metadata ~content:_ =
+    seen := Some metadata;
+    Gate_protocol.Reply { content = "ok"; structured = None; stats = None }
+  in
+  let msg =
+    {
+      (make_message ~idempotency_key:(unique_key "dispatch-metadata") ()) with
+      metadata =
+        [
+          ("conversation_id", "discord:guild-1:channel:thread-7");
+          ("external_message_id", "msg-7");
+        ];
+    }
+  in
+  match Channel_gate.handle_inbound ~dispatch msg with
+  | Ok _ -> (
+      match !seen with
+      | Some metadata ->
+          check string "conversation id" "discord:guild-1:channel:thread-7"
+            (List.assoc "conversation_id" metadata);
+          check string "external message id" "msg-7"
+            (List.assoc "external_message_id" metadata)
+      | None -> fail "dispatch should receive metadata")
+  | Error e -> fail (Channel_gate.gate_error_to_string e)
+
 let () =
   Alcotest.run "Channel_gate"
     [
@@ -264,6 +293,8 @@ let () =
             test_handle_inbound_success;
           test_case "passes channel context to dispatch" `Quick
             test_handle_inbound_passes_channel_context_to_dispatch;
+          test_case "passes metadata to dispatch" `Quick
+            test_handle_inbound_passes_metadata_to_dispatch;
           test_case "returns keeper error" `Quick
             test_handle_inbound_keeper_error;
           test_case "returns unavailable" `Quick

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -86,15 +86,21 @@ let test_persist_connector_assistant_reply_records_lane_reply () =
     (fun () ->
       let keeper_name = "discord-reply-keeper" in
       K.append_user_message ~base_dir ~keeper_name
-        ~content:"<@bot> factorio?" ~source:"discord" ();
+        ~content:"<@bot> factorio?" ~source:"discord"
+        ~conversation_id:"discord:guild-1:channel:chan-9" ();
       Gate_keeper_backend.persist_connector_assistant_reply ~base_dir
-        ~keeper_name ~source:"discord" ~reply:"already answered";
+        ~keeper_name ~source:"discord"
+        ~conversation_id:"discord:guild-1:channel:chan-9"
+        ~reply:"already answered" ();
       match K.load ~base_dir ~keeper_name with
       | [ user; assistant ] ->
           check string "user line first" "user" user.K.role;
           check string "assistant reply persisted" "assistant" assistant.K.role;
           check string "assistant lane" "discord"
             (Option.value assistant.K.source ~default:"");
+          check string "assistant conversation id"
+            "discord:guild-1:channel:chan-9"
+            (Option.value assistant.K.conversation_id ~default:"");
           check string "assistant content" "already answered" assistant.K.content
       | messages ->
           failf "expected 2 chat messages, got %d" (List.length messages))
@@ -106,7 +112,7 @@ let test_persist_connector_assistant_reply_ignores_empty_reply () =
     (fun () ->
       let keeper_name = "discord-empty-reply-keeper" in
       Gate_keeper_backend.persist_connector_assistant_reply ~base_dir
-        ~keeper_name ~source:"discord" ~reply:"   ";
+        ~keeper_name ~source:"discord" ~reply:"   " ();
       check int "empty reply does not create chat file" 0
         (List.length (K.load ~base_dir ~keeper_name)))
 

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -289,13 +289,16 @@ let test_append_user_message_roundtrip () =
       K.append_user_message ~base_dir ~keeper_name
         ~content:"two humans chatting, no mention"
         ~source:"discord"
+        ~conversation_id:"discord:guild-1:channel:chan-7"
+        ~external_message_id:"msg-7"
         ~speaker:
           { K.speaker_id = Some "55501";
             speaker_name = Some "jane";
             speaker_authority = K.External }
         ();
       K.append_assistant_message ~base_dir ~keeper_name
-        ~content:"reply recorded separately" ~source:"discord" ();
+        ~content:"reply recorded separately" ~source:"discord"
+        ~conversation_id:"discord:guild-1:channel:chan-7" ();
       match K.load ~base_dir ~keeper_name with
       | [ user; assistant ] ->
           Alcotest.(check string) "lone user line first" "user" user.K.role;
@@ -303,6 +306,10 @@ let test_append_user_message_roundtrip () =
             "two humans chatting, no mention" user.K.content;
           Alcotest.(check (option string)) "source"
             (Some "discord") user.K.source;
+          Alcotest.(check (option string)) "conversation id"
+            (Some "discord:guild-1:channel:chan-7") user.K.conversation_id;
+          Alcotest.(check (option string)) "external message id"
+            (Some "msg-7") user.K.external_message_id;
           (match user.speaker with
            | Some sp ->
                Alcotest.(check (option string)) "speaker id"
@@ -314,8 +321,32 @@ let test_append_user_message_roundtrip () =
            | None -> Alcotest.fail "ambient user line lost its speaker");
           Alcotest.(check string) "assistant joins the lane"
             "assistant" assistant.K.role;
+          Alcotest.(check (option string)) "assistant conversation id"
+            (Some "discord:guild-1:channel:chan-7") assistant.K.conversation_id;
+          Alcotest.(check (option string)) "assistant has no inbound message id"
+            None assistant.K.external_message_id;
           Alcotest.(check string) "no duplicated user line"
-            "reply recorded separately" assistant.K.content
+            "reply recorded separately" assistant.K.content;
+          let json_rows = K.to_json_array [ user; assistant ] in
+          (match Yojson.Safe.Util.to_list json_rows with
+          | user_json :: assistant_json :: _ ->
+              Alcotest.(check string) "json conversation id"
+                "discord:guild-1:channel:chan-7"
+                Yojson.Safe.Util.(
+                  user_json |> member "conversation_id" |> to_string);
+              Alcotest.(check string) "json external message id" "msg-7"
+                Yojson.Safe.Util.(
+                  user_json |> member "external_message_id" |> to_string);
+              Alcotest.(check string) "json assistant conversation id"
+                "discord:guild-1:channel:chan-7"
+                Yojson.Safe.Util.(
+                  assistant_json |> member "conversation_id" |> to_string);
+              Alcotest.(check bool) "json assistant omits inbound message id" true
+                Yojson.Safe.Util.(
+                  assistant_json |> member "external_message_id" = `Null)
+          | rows ->
+              Alcotest.failf "expected 2 json rows, got %d"
+                (List.length rows))
       | messages ->
           Alcotest.failf "expected 2 messages, got %d" (List.length messages))
 

--- a/test/test_keeper_mention_scope.ml
+++ b/test/test_keeper_mention_scope.ml
@@ -42,6 +42,8 @@ let msg ~role ?(ts = Some 1.0) ?(source = None) ?(speaker = None) content
   ; tool_call_id = None
   ; tool_call_name = None
   ; source
+  ; conversation_id = None
+  ; external_message_id = None
   ; speaker
   }
 ;;

--- a/test/test_keeper_surface_read.ml
+++ b/test/test_keeper_surface_read.ml
@@ -19,6 +19,8 @@ let msg ?ts ?source ?speaker ~role content : Store.chat_message =
     tool_call_id = None;
     tool_call_name = None;
     source;
+    conversation_id = None;
+    external_message_id = None;
     speaker;
   }
 


### PR DESCRIPTION
## Summary

- add opaque `conversation_id` / `external_message_id` fields to keeper chat rows and REST history schema
- pass Channel Gate metadata through to the keeper backend so connector adapters can preserve conversation coordinates without platform-specific chat-store logic
- persist Discord conversation coordinates for triggered and ambient inbound messages

## Product impact

Discord chat history rows now carry stable conversation coordinates, so dashboard/API consumers can group channel/thread traffic instead of showing every Discord message as one flat keeper lane. Legacy chat rows remain readable.

## Notes

- OAS is untouched.
- The chat store remains append-only and legacy rows keep parsing without the new fields.
- This does not add emoji/read receipts; it only gives dashboard/API consumers enough immutable coordinates to group Discord channels/threads instead of flattening every Discord row into one keeper lane.

## Evidence

- `env DUNE_CACHE=disabled DUNE_BUILD_DIR=_build-attention-projection-check opam exec -- dune build --root . test/test_keeper_chat_store.exe test/test_channel_gate.exe test/test_gate_keeper_backend.exe test/test_keeper_surface_read.exe test/test_keeper_mention_scope.exe`
- `./_build-attention-projection-check/default/test/test_keeper_chat_store.exe`
- `./_build-attention-projection-check/default/test/test_channel_gate.exe`
- `./_build-attention-projection-check/default/test/test_gate_keeper_backend.exe`
- `./_build-attention-projection-check/default/test/test_keeper_surface_read.exe`
- `./_build-attention-projection-check/default/test/test_keeper_mention_scope.exe`
- `pnpm install --offline --frozen-lockfile`
- `pnpm exec vitest run --config vitest.config.ts src/api/schemas/keeper-chat-history.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec tsc --noEmit --pretty false`
- `ocamlformat --check ...`
- `git diff --check`

## Direct evidence

schema_version: 1
direct_ratio: 9/9
provenance: direct

- `test_keeper_chat_store`: 15 tests passed, including conversation coordinate persistence and JSON output.
- `test_channel_gate`: 16 tests passed, including metadata pass-through.
- `test_gate_keeper_backend`: 28 tests passed, including connector assistant reply conversation preservation.
- `test_keeper_surface_read`: 9 tests passed.
- `test_keeper_mention_scope`: 15 tests passed.
- dashboard schema vitest: 1 file / 9 tests passed.
- dashboard `tsc --noEmit`: passed.

## Review evidence

- Risk grep over touched OCaml runtime files found no new `failwith`, `assert false`, `Mutex.lock`, `Eio.traceln`, `Stdlib.Lazy`, or blocking command usage.
- OAS boundary grep over touched files found no OAS/provider/workflow rejection references.

## Linked issue

None.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`feat/external-attention-projection-20260612` → `main` · 1 commit(s) · synced 2026-06-11T15:36:53Z

| sha | subject | date |
|---|---|---|
| `075d32bd0` | feat(discord): persist chat conversation coordinates | 2026-06-11 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->