### PR TITLE
[codex] Guard stale Llm_provider interface caches

### DIFF
--- a/scripts/check-oas-pin.sh
+++ b/scripts/check-oas-pin.sh
@@ -240,6 +240,8 @@ verify_agent_sdk_switch_artifacts() {
   verify_agent_sdk_artifact "agent_sdk.llm_provider" "${llm_provider_dir}" "llm_provider.cmi"
   verify_agent_sdk_artifact "agent_sdk.llm_provider" "${llm_provider_dir}" "llm_provider.cmxa"
   verify_agent_sdk_artifact "agent_sdk.llm_provider" "${llm_provider_dir}" "llm_provider.a"
+  verify_agent_sdk_artifact "agent_sdk.llm_provider" "${llm_provider_dir}" "llm_provider__Provider_config.cmi"
+  verify_agent_sdk_artifact "agent_sdk.llm_provider" "${llm_provider_dir}" "llm_provider__Provider_kind.cmi"
 }
 
 if command -v opam >/dev/null 2>&1; then

--- a/scripts/dune-local.sh
+++ b/scripts/dune-local.sh
@@ -531,18 +531,20 @@ fi
 # The pin guard can be intentionally bypassed during local surgery with
 # MASC_SKIP_PIN_CHECK=1.  Even then, the shared opam switch may have moved
 # from one agent_sdk build to another while _build still contains CMIs
-# compiled against the previous Llm_provider.Provider_config interface.
-# Track the actual installed Provider_config CMI checksum and clear _build
-# when it changes, before Dune can produce a cascade of "inconsistent
-# assumptions" diagnostics.
+# compiled against the previous Llm_provider interfaces.  Track the actual
+# installed Provider_config and Provider_kind CMI checksums and clear _build
+# when they change, before Dune can produce a cascade of stale alias or
+# "inconsistent assumptions" diagnostics.
 #
 # This guard is intentionally independent of MASC_SKIP_PIN_CHECK.  It does
 # not prove the pin is correct; it only keeps the current build directory
 # internally consistent with whatever agent_sdk is installed right now.
-_current_agent_sdk_provider_config_crc() {
+_current_agent_sdk_llm_provider_crc() {
+  local module_name="$1"
+  local unit_name="Llm_provider__${module_name}"
   command -v ocamlobjinfo >/dev/null 2>&1 || return 1
 
-  local llm_provider_dir provider_config_cmi
+  local llm_provider_dir cmi_path
   if command -v ocamlfind >/dev/null 2>&1; then
     llm_provider_dir="$(ocamlfind query agent_sdk.llm_provider 2>/dev/null || true)"
   elif command -v opam >/dev/null 2>&1; then
@@ -552,32 +554,58 @@ _current_agent_sdk_provider_config_crc() {
   fi
 
   [[ -n "${llm_provider_dir}" ]] || return 1
-  provider_config_cmi="${llm_provider_dir%/}/llm_provider__Provider_config.cmi"
-  [[ -r "${provider_config_cmi}" ]] || return 1
+  cmi_path="${llm_provider_dir%/}/llm_provider__${module_name}.cmi"
+  [[ -r "${cmi_path}" ]] || return 1
 
-  ocamlobjinfo "${provider_config_cmi}" 2>/dev/null \
-    | awk '$2 == "Llm_provider__Provider_config" { print $1; found = 1; exit }
+  ocamlobjinfo "${cmi_path}" 2>/dev/null \
+    | awk -v unit="${unit_name}" '$2 == unit { print $1; found = 1; exit }
            END { if (!found) exit 1 }'
 }
 
 if [[ "${GITHUB_ACTIONS:-}" != "true" \
       && "${MASC_DUNE_DRY_RUN:-0}" != "1" \
       && "${_subcommand}" != "clean" ]]; then
-  _provider_config_crc="$(_current_agent_sdk_provider_config_crc || true)"
-  if [[ -n "${_provider_config_crc}" ]]; then
-    _provider_config_build_dir="${DUNE_BUILD_DIR:-$repo_root/_build}"
-    _provider_config_marker="${_provider_config_build_dir}/.last-agent-sdk-provider-config-crc"
-    if [[ -f "${_provider_config_marker}" ]]; then
-      _last_provider_config_crc="$(cat "${_provider_config_marker}" 2>/dev/null || true)"
-      if [[ -n "${_last_provider_config_crc}" \
-            && "${_last_provider_config_crc}" != "${_provider_config_crc}" ]]; then
-        printf '[dune-local] agent_sdk Provider_config interface changed (%.8s -> %.8s) - cleaning stale _build artifacts\n' \
-          "${_last_provider_config_crc}" "${_provider_config_crc}" >&2
-        rm -rf "${_provider_config_build_dir}"
+  _agent_sdk_interface_build_dir="${DUNE_BUILD_DIR:-$repo_root/_build}"
+  _agent_sdk_interface_markers=()
+  _agent_sdk_interface_crcs=()
+  _agent_sdk_interface_changed=0
+  for _agent_sdk_interface in Provider_config Provider_kind; do
+    _agent_sdk_interface_crc="$(_current_agent_sdk_llm_provider_crc "${_agent_sdk_interface}" || true)"
+    [[ -n "${_agent_sdk_interface_crc}" ]] || continue
+    case "${_agent_sdk_interface}" in
+      Provider_config)
+        _agent_sdk_interface_marker="${_agent_sdk_interface_build_dir}/.last-agent-sdk-provider-config-crc"
+        ;;
+      Provider_kind)
+        _agent_sdk_interface_marker="${_agent_sdk_interface_build_dir}/.last-agent-sdk-provider-kind-crc"
+        ;;
+      *)
+        continue
+        ;;
+    esac
+    _agent_sdk_interface_markers+=("${_agent_sdk_interface_marker}")
+    _agent_sdk_interface_crcs+=("${_agent_sdk_interface_crc}")
+    if [[ -f "${_agent_sdk_interface_marker}" ]]; then
+      _last_agent_sdk_interface_crc="$(cat "${_agent_sdk_interface_marker}" 2>/dev/null || true)"
+      if [[ -n "${_last_agent_sdk_interface_crc}" \
+            && "${_last_agent_sdk_interface_crc}" != "${_agent_sdk_interface_crc}" ]]; then
+        printf '[dune-local] agent_sdk %s interface changed (%.8s -> %.8s) - cleaning stale _build artifacts\n' \
+          "${_agent_sdk_interface}" \
+          "${_last_agent_sdk_interface_crc}" \
+          "${_agent_sdk_interface_crc}" >&2
+        _agent_sdk_interface_changed=1
       fi
     fi
-    mkdir -p "${_provider_config_build_dir}" 2>/dev/null || true
-    printf '%s' "${_provider_config_crc}" > "${_provider_config_marker}"
+  done
+  if [[ "${_agent_sdk_interface_changed}" -eq 1 ]]; then
+    rm -rf "${_agent_sdk_interface_build_dir}"
+  fi
+  if [[ "${#_agent_sdk_interface_markers[@]}" -gt 0 ]]; then
+    mkdir -p "${_agent_sdk_interface_build_dir}" 2>/dev/null || true
+    for _agent_sdk_interface_i in "${!_agent_sdk_interface_markers[@]}"; do
+      printf '%s' "${_agent_sdk_interface_crcs[${_agent_sdk_interface_i}]}" \
+        > "${_agent_sdk_interface_markers[${_agent_sdk_interface_i}]}"
+    done
   fi
 fi
 # -----------------------------------------------------------------------

--- a/test/test_dune_local_script.ml
+++ b/test/test_dune_local_script.ml
@@ -162,6 +162,9 @@ exit 0
   write_file
     (Filename.concat fake_llm_provider_dir "llm_provider__Provider_config.cmi")
     "fake-cmi";
+  write_file
+    (Filename.concat fake_llm_provider_dir "llm_provider__Provider_kind.cmi")
+    "fake-cmi";
   write_executable
     (Filename.concat bin_dir "ocamlfind")
     (Printf.sprintf
@@ -176,10 +179,20 @@ exit 1
   write_executable
     (Filename.concat bin_dir "ocamlobjinfo")
     {|#!/bin/sh
+case "$1" in
+  *llm_provider__Provider_kind.cmi)
+    unit=Llm_provider__Provider_kind
+    crc="${MASC_TEST_PROVIDER_KIND_CRC:-8b2c2a1da7a2b790f36f2cdbb3512b8f}"
+    ;;
+  *)
+    unit=Llm_provider__Provider_config
+    crc="${MASC_TEST_PROVIDER_CONFIG_CRC:-feedfacefeedfacefeedfacefeedface}"
+    ;;
+esac
 printf 'File %s\n' "$1"
-printf 'Unit name: Llm_provider__Provider_config\n'
+printf 'Unit name: %s\n' "$unit"
 printf 'Interfaces imported:\n'
-printf '\t%s\tLlm_provider__Provider_config\n' "${MASC_TEST_PROVIDER_CONFIG_CRC:-feedfacefeedfacefeedfacefeedface}"
+printf '\t%s\t%s\n' "$crc" "$unit"
 exit 0
 |};
   (* Fake dune: log subcommand and exit 0 *)
@@ -300,6 +313,37 @@ let test_skip_pin_check_still_cleans_on_provider_config_crc_change () =
       check string "crc marker refreshed" "newcrc"
         (read_file
            (Filename.concat build_dir ".last-agent-sdk-provider-config-crc"));
+      check bool "dune was invoked after cleanup" true (Sys.file_exists dune_log))
+
+let test_skip_pin_check_still_cleans_on_provider_kind_crc_change () =
+  with_temp_dir "dune-local-provider-kind-crc" (fun dir ->
+      let bin_dir, dune_log =
+        setup_fake_repo dir ~pin_check_exit_code:1
+          ~pin_check_stderr_msg:"pin mismatch"
+      in
+      let build_dir = Filename.concat dir "_build" in
+      mkdir_p build_dir;
+      write_file (Filename.concat build_dir ".last-agent-sdk-provider-kind-crc")
+        "oldcrc";
+      write_file (Filename.concat build_dir "stale-object") "stale";
+      let code, _stdout, stderr =
+        run_dune_local dir bin_dir
+          ~env:
+            [
+              ("MASC_SKIP_PIN_CHECK", "1");
+              ("MASC_TEST_PROVIDER_KIND_CRC", "newcrc");
+            ]
+          ~unset_env:[ "GITHUB_ACTIONS" ]
+          "build"
+      in
+      check int "exits zero when pin guard is skipped" 0 code;
+      check bool "crc change message present" true
+        (contains_substring stderr "Provider_kind interface changed");
+      check bool "stale build artifact removed" false
+        (Sys.file_exists (Filename.concat build_dir "stale-object"));
+      check string "crc marker refreshed" "newcrc"
+        (read_file
+           (Filename.concat build_dir ".last-agent-sdk-provider-kind-crc"));
       check bool "dune was invoked after cleanup" true (Sys.file_exists dune_log))
 
 let test_github_actions_bypasses_pin_guard () =
@@ -1262,6 +1306,10 @@ let () =
             "MASC_SKIP_PIN_CHECK=1 still cleans on Provider_config CRC change"
             `Quick
             test_skip_pin_check_still_cleans_on_provider_config_crc_change;
+          test_case
+            "MASC_SKIP_PIN_CHECK=1 still cleans on Provider_kind CRC change"
+            `Quick
+            test_skip_pin_check_still_cleans_on_provider_kind_crc_change;
           test_case "GITHUB_ACTIONS=true bypasses pin guard" `Quick
             test_github_actions_bypasses_pin_guard;
           test_case "opam absent skips pin guard" `Quick


### PR DESCRIPTION
## Summary
- verify `Provider_config` and `Provider_kind` CMI artifacts in `scripts/check-oas-pin.sh`
- extend `scripts/dune-local.sh` stale agent_sdk interface cleanup from `Provider_config` to both `Provider_config` and `Provider_kind`
- add regression coverage for `Provider_kind` CRC changes in `test_dune_local_script`

## Validation
- `bash -n scripts/check-oas-pin.sh`
- `bash -n scripts/dune-local.sh`
- `ocamlformat --check test/test_dune_local_script.ml`
- `git diff --check origin/main..HEAD`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_SKIP_PIN_CHECK=1 DUNE_BUILD_DIR=/Users/dancer/me/workspace/yousleepwhen/masc/.worktrees/llm-provider-kind-crc-guard/_build_pr_llm_provider_kind scripts/dune-local.sh build ./test/test_dune_local_script.exe`
- `./_build_pr_llm_provider_kind/default/test/test_dune_local_script.exe` (33 tests)
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_SKIP_PIN_CHECK=1 DUNE_BUILD_DIR=/Users/dancer/me/workspace/yousleepwhen/masc/.worktrees/llm-provider-kind-crc-guard/_build_pr_llm_provider_kind scripts/dune-local.sh build lib/provider_tool_support/provider_tool_support.cmxa lib/runtime_provider_labels/masc_runtime_provider_labels.cmxa`

## Local note
- `scripts/check-oas-pin.sh --local-only` currently reports this machine's opam switch pinned to `agent_sdk` source `1cd315c104bac1c8eedd56d899e896b004b30534`, while repo SSOT expects `4899b52d3e6af9f428db6a6bb610c16dc643c5d3`. Non-bypassed wrapper builds are expected to stop on that local switch drift until the opam pin is repaired.