### PR TITLE
feat(keeper): RFC-0232 P1 — closed Role.t + positional lane watermark

### DIFF
--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -61,6 +61,32 @@ type tool_call = {
   args : string;
 }
 
+(* RFC-0232 P1: the lane role is a closed sum parsed once at the read
+   boundary; consumers match exhaustively instead of comparing role
+   strings. On-disk labels are unchanged ("user"/"assistant"/"tool"). *)
+module Role = struct
+  type t =
+    | User
+    | Assistant
+    | Tool
+
+  let to_label = function
+    | User -> "user"
+    | Assistant -> "assistant"
+    | Tool -> "tool"
+
+  let of_label = function
+    | "user" -> Some User
+    | "assistant" -> Some Assistant
+    | "tool" -> Some Tool
+    | _ -> None
+
+  let equal a b =
+    match a, b with
+    | User, User | Assistant, Assistant | Tool, Tool -> true
+    | (User | Assistant | Tool), _ -> false
+end
+
 type speaker_authority =
   | Owner
   | External
@@ -81,7 +107,7 @@ type speaker = {
 }
 
 type chat_message = {
-  role : string;
+  role : Role.t;
   content : string;
   ts : float option;
   attachments : attachment list option;
@@ -122,10 +148,11 @@ let speaker_fields = function
       @ opt_string_field "speaker_name" sp.speaker_name
       @ [ ("speaker_authority", `String (authority_label sp.speaker_authority)) ]
 
-let encode_line ~role ~content ~ts ?attachments ?tool_call_id ?tool_call_name
-    ?source ?conversation_id ?external_message_id ?speaker () : string =
+let encode_line ~(role : Role.t) ~content ~ts ?attachments ?tool_call_id
+    ?tool_call_name ?source ?conversation_id ?external_message_id ?speaker ()
+    : string =
   let base_fields = [
-    ("role", `String role);
+    ("role", `String (Role.to_label role));
     ("content", `String content);
     ("ts", `Float ts);
   ] in
@@ -188,14 +215,14 @@ let append_turn ~base_dir ~keeper_name ~(user_content : string)
     (* Speaker identity belongs to the user line only: tool and
        assistant lines are the keeper's own output. *)
     let user_line =
-      encode_line ~role:"user" ~content:user_content ~ts
+      encode_line ~role:Role.User ~content:user_content ~ts
         ~attachments:user_attachments ?source ?conversation_id
         ?external_message_id ?speaker ()
     in
     let tool_lines =
       List.mapi
         (fun position tc ->
-          encode_line ~role:"tool"
+          encode_line ~role:Role.Tool
             ~content:(normalize_tool_args tc.args)
             ~ts
             ~tool_call_id:(normalize_tool_call_id ~position tc.call_id)
@@ -204,7 +231,7 @@ let append_turn ~base_dir ~keeper_name ~(user_content : string)
         tool_calls
     in
     let asst_line =
-      encode_line ~role:"assistant" ~content:assistant_content ~ts ?source
+      encode_line ~role:Role.Assistant ~content:assistant_content ~ts ?source
         ?conversation_id ()
     in
     let payload =
@@ -232,7 +259,7 @@ let append_assistant_message ~base_dir ~keeper_name ~(content : string)
     let path = chat_path ~base_dir ~keeper_name in
     let ts = Time_compat.now () in
     let line =
-      encode_line ~role:"assistant" ~content ~ts ?source ?conversation_id ()
+      encode_line ~role:Role.Assistant ~content ~ts ?source ?conversation_id ()
     in
     Fs_compat.append_file path (line ^ "\n")
   with
@@ -257,7 +284,7 @@ let append_user_message ~base_dir ~keeper_name ~(content : string)
     let path = chat_path ~base_dir ~keeper_name in
     let ts = Time_compat.now () in
     let line =
-      encode_line ~role:"user" ~content ~ts ?source ?conversation_id
+      encode_line ~role:Role.User ~content ~ts ?source ?conversation_id
         ?external_message_id ?speaker ()
     in
     Fs_compat.append_file path (line ^ "\n")
@@ -274,7 +301,9 @@ let append_user_message ~base_dir ~keeper_name ~(content : string)
 let parse_line ~file_path (line : string) : chat_message option =
   try
     let json = Yojson.Safe.from_string line in
-    let role = Json_util.get_string_with_default json ~key:"role" ~default:"" in
+    let role_label =
+      Json_util.get_string_with_default json ~key:"role" ~default:""
+    in
     let content = Json_util.get_string_with_default json ~key:"content" ~default:"" in
     let ts =
       (try Some ((match Json_util.assoc_member_opt "ts" json with Some (`Float f) -> f | _ -> 0.0))
@@ -340,22 +369,33 @@ let parse_line ~file_path (line : string) : chat_message option =
           if atts = [] then None else Some atts
       | _ -> None
     in
-    if role = "" || content = "" then (
+    if role_label = "" || content = "" then (
       report_persistence_read_drop
         ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
         ~path:file_path
         ~detail:"chat row missing non-empty role/content";
       None)
-    else if role = "tool" && tool_call_name = None then (
-      report_persistence_read_drop
-        ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
-        ~path:file_path
-        ~detail:"tool chat row missing non-empty tool_call_name";
-      None)
     else
-      Some
-        { role; content; ts; attachments; tool_call_id; tool_call_name;
-          source; conversation_id; external_message_id; speaker }
+      match Role.of_label role_label with
+      | None ->
+          (* RFC-0232 P1: an unknown role cannot participate in any lane
+             semantics (watermark, pending, rendering); surface it
+             instead of carrying an untyped row. *)
+          report_persistence_read_drop
+            ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
+            ~path:file_path
+            ~detail:(Printf.sprintf "unknown chat row role %S" role_label);
+          None
+      | Some Role.Tool when tool_call_name = None ->
+          report_persistence_read_drop
+            ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
+            ~path:file_path
+            ~detail:"tool chat row missing non-empty tool_call_name";
+          None
+      | Some role ->
+          Some
+            { role; content; ts; attachments; tool_call_id; tool_call_name;
+              source; conversation_id; external_message_id; speaker }
   with Yojson.Json_error detail ->
     report_persistence_read_drop
       ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
@@ -370,7 +410,7 @@ let parse_line ~file_path (line : string) : chat_message option =
 let max_history = 100
 let max_total_lines = 400
 
-let is_tool_message (msg : chat_message) = String.equal msg.role "tool"
+let is_tool_message (msg : chat_message) = Role.equal msg.role Role.Tool
 
 (* A turn is persisted as user, tool*, assistant. Evicting the front of
    the window can leave tool lines whose owning user line is gone;
@@ -525,7 +565,7 @@ let to_json_array (messages : chat_message list) : Yojson.Safe.t =
     (List.map
        (fun m ->
          `Assoc
-           ([ ("role", `String m.role);
+           ([ ("role", `String (Role.to_label m.role));
               ("content", `String m.content);
             ] @ (match m.ts with
                  | Some t -> [("ts", `Float t)]

--- a/lib/keeper/keeper_chat_store.mli
+++ b/lib/keeper/keeper_chat_store.mli
@@ -35,6 +35,22 @@ type tool_call = {
   args : string;
 }
 
+(** Lane line role as a closed sum (RFC-0232 P1). Parsed once at the
+    read boundary; a line whose persisted label is none of
+    ["user"] / ["assistant"] / ["tool"] is reported as a persistence
+    read drop and excluded — it can participate in no lane semantics
+    (watermark, pending, rendering). On-disk labels are unchanged. *)
+module Role : sig
+  type t =
+    | User
+    | Assistant
+    | Tool
+
+  val to_label : t -> string
+  val of_label : string -> t option
+  val equal : t -> t -> bool
+end
+
 (** Authority class of the human (or agent) whose message opened a
     turn. Derived structurally from the arrival route, never from
     message content: the authenticated dashboard route is [Owner];
@@ -57,7 +73,7 @@ type speaker = {
 }
 
 type chat_message = {
-  role : string;
+  role : Role.t;
   content : string;
   ts : float option;
   attachments : attachment list option;

--- a/lib/keeper/keeper_surface_read.ml
+++ b/lib/keeper/keeper_surface_read.ml
@@ -34,7 +34,8 @@ let message_json (m : Store.chat_message) : Yojson.Safe.t =
           ]
   in
   `Assoc
-    ([ ("role", `String m.role); ("content", `String m.content) ]
+    ([ ("role", `String (Store.Role.to_label m.role));
+       ("content", `String m.content) ]
     @ opt_float_field "ts" m.ts
     @ opt_string_field "source" m.source
     @ opt_string_field "conversation_id" m.conversation_id

--- a/lib/keeper/keeper_world_observation_message_scope.ml
+++ b/lib/keeper/keeper_world_observation_message_scope.ml
@@ -108,19 +108,31 @@ let speaker_display (m : Keeper_chat_store.chat_message) : string =
    mention newer than my last line". An unanswered mention stays pending across
    observations (it keeps the keeper reactive until it replies in the lane).
 
+   RFC-0232 P1: "newer" is lane order, not wall-clock. The lane is an
+   append-only file, so its line order is the true arrival order; the
+   watermark is the *position* of the keeper's last assistant line. Folding
+   forward, an assistant line clears every candidate accumulated so far —
+   no float comparisons, no equal-timestamp conventions, no skew
+   sensitivity. [append_turn]'s user→tool→assistant write order makes a
+   turn's own user line answered by its own reply, as before.
+
    Pure over the loaded lane so it is testable without I/O; [collect_message_scope]
    only adds the [Keeper_chat_store.load]. *)
 
-(* The watermark: ts of the keeper's own last lane line (assistant role). A user
-   line at or before it is already answered. *)
-let last_self_ts (messages : Keeper_chat_store.chat_message list) : float =
+(* User lines after the keeper's last assistant line, in lane order. The
+   shared positional watermark for mentions and scope. *)
+let user_lines_after_last_self (messages : Keeper_chat_store.chat_message list)
+  : Keeper_chat_store.chat_message list
+  =
   List.fold_left
     (fun acc (m : Keeper_chat_store.chat_message) ->
-      match m.ts with
-      | Some ts when m.role = "assistant" && ts > acc -> ts
-      | _ -> acc)
-    0.0
+      match m.role with
+      | Keeper_chat_store.Role.Assistant -> []
+      | Keeper_chat_store.Role.User -> m :: acc
+      | Keeper_chat_store.Role.Tool -> acc)
+    []
     messages
+  |> List.rev
 ;;
 
 let is_owner_authored (m : Keeper_chat_store.chat_message) : bool =
@@ -134,14 +146,11 @@ let pending_mentions_of_messages
       (messages : Keeper_chat_store.chat_message list)
   : (string * string) list
   =
-  let my_last_ts = last_self_ts messages in
-  List.filter_map
-    (fun (m : Keeper_chat_store.chat_message) ->
-      match m.ts with
-      | Some ts when ts > my_last_ts && m.role = "user" && line_mentions ~targets m.content
-        -> Some (speaker_display m, m.content)
-      | _ -> None)
-    messages
+  user_lines_after_last_self messages
+  |> List.filter_map (fun (m : Keeper_chat_store.chat_message) ->
+    if line_mentions ~targets m.content
+    then Some (speaker_display m, m.content)
+    else None)
 ;;
 
 (* RFC-0230 P2 — scope messages: a keeper's lane is, in practice, an operator
@@ -155,17 +164,11 @@ let pending_scope_of_messages
       (messages : Keeper_chat_store.chat_message list)
   : (string * string) list
   =
-  let my_last_ts = last_self_ts messages in
-  List.filter_map
-    (fun (m : Keeper_chat_store.chat_message) ->
-      match m.ts with
-      | Some ts
-        when ts > my_last_ts
-             && m.role = "user"
-             && is_owner_authored m
-             && not (line_mentions ~targets m.content) -> Some (speaker_display m, m.content)
-      | _ -> None)
-    messages
+  user_lines_after_last_self messages
+  |> List.filter_map (fun (m : Keeper_chat_store.chat_message) ->
+    if is_owner_authored m && not (line_mentions ~targets m.content)
+    then Some (speaker_display m, m.content)
+    else None)
 ;;
 
 let collect_message_scope ~(config : Workspace.config) ~(meta : keeper_meta)

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -94,8 +94,8 @@ let test_persist_connector_assistant_reply_records_lane_reply () =
         ~reply:"already answered" ();
       match K.load ~base_dir ~keeper_name with
       | [ user; assistant ] ->
-          check string "user line first" "user" user.K.role;
-          check string "assistant reply persisted" "assistant" assistant.K.role;
+          check string "user line first" "user" (K.Role.to_label user.K.role);
+          check string "assistant reply persisted" "assistant" (K.Role.to_label assistant.K.role);
           check string "assistant lane" "discord"
             (Option.value assistant.K.source ~default:"");
           check string "assistant conversation id"

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -111,7 +111,8 @@ let test_load_records_malformed_row_drops () =
         1.0
         (drop_value invalid_payload -. before_invalid_payload))
 
-let roles messages = List.map (fun (m : K.chat_message) -> m.role) messages
+let roles messages =
+  List.map (fun (m : K.chat_message) -> K.Role.to_label m.role) messages
 
 let test_append_turn_roundtrip () =
   let base_dir = temp_base_path "keeper-chat-store-turn" in
@@ -301,7 +302,7 @@ let test_append_user_message_roundtrip () =
         ~conversation_id:"discord:guild-1:channel:chan-7" ();
       match K.load ~base_dir ~keeper_name with
       | [ user; assistant ] ->
-          Alcotest.(check string) "lone user line first" "user" user.K.role;
+          Alcotest.(check string) "lone user line first" "user" (K.Role.to_label user.K.role);
           Alcotest.(check string) "content"
             "two humans chatting, no mention" user.K.content;
           Alcotest.(check (option string)) "source"
@@ -320,7 +321,7 @@ let test_append_user_message_roundtrip () =
                  "external" (K.authority_label sp.K.speaker_authority)
            | None -> Alcotest.fail "ambient user line lost its speaker");
           Alcotest.(check string) "assistant joins the lane"
-            "assistant" assistant.K.role;
+            "assistant" (K.Role.to_label assistant.K.role);
           Alcotest.(check (option string)) "assistant conversation id"
             (Some "discord:guild-1:channel:chan-7") assistant.K.conversation_id;
           Alcotest.(check (option string)) "assistant has no inbound message id"
@@ -401,6 +402,28 @@ let test_unknown_speaker_authority_reported_not_guessed () =
         1.0
         (drop_value invalid_payload -. before))
 
+let test_unknown_role_row_dropped () =
+  (* RFC-0232 P1: a role label outside the closed sum cannot participate
+     in lane semantics; the row is dropped and reported, never defaulted. *)
+  let base_dir = temp_base_path "keeper-chat-store-role-bad" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-role-bad" in
+      let path = chat_path ~base_dir ~keeper_name in
+      let invalid_payload = Safe_ops.persistence_read_drop_reason_invalid_payload in
+      let before = drop_value invalid_payload in
+      write_file path
+        ({|{"role":"user","content":"hi","ts":1.0}|} ^ "\n"
+        ^ {|{"role":"system","content":"injected","ts":2.0}|} ^ "\n"
+        ^ {|{"role":"assistant","content":"done","ts":3.0}|} ^ "\n");
+      let messages = K.load ~base_dir ~keeper_name in
+      Alcotest.(check (list string)) "unknown role row dropped"
+        [ "user"; "assistant" ] (roles messages);
+      Alcotest.(check (float 0.001)) "drop counted as invalid payload"
+        1.0
+        (drop_value invalid_payload -. before))
+
 let test_tool_row_missing_name_dropped () =
   let base_dir = temp_base_path "keeper-chat-store-toolname" in
   Fun.protect
@@ -442,13 +465,13 @@ let test_window_keeps_tool_lines_of_retained_turns () =
       let messages = K.load ~base_dir ~keeper_name in
       Alcotest.(check int) "50 full turns survive" 150 (List.length messages);
       let primaries =
-        List.filter (fun (m : K.chat_message) -> m.role <> "tool") messages
+        List.filter (fun (m : K.chat_message) -> not (K.Role.equal m.role K.Role.Tool)) messages
       in
       Alcotest.(check int) "primary window is 100" 100 (List.length primaries);
       match messages with
       | first :: _ ->
           Alcotest.(check string) "window starts at a user line, not an orphan tool"
-            "user" first.role;
+            "user" (K.Role.to_label first.role);
           Alcotest.(check string) "oldest retained turn is turn 2" "u2" first.content
       | [] -> Alcotest.fail "expected non-empty window")
 
@@ -503,14 +526,14 @@ let test_tail_bounded_load_matches_full_scan_window () =
        | first :: _ ->
            Alcotest.(check string) "window starts at line 5101"
              "msg-5101" (content_prefix first);
-           Alcotest.(check string) "line 5101 is a user line" "user" first.K.role
+           Alcotest.(check string) "line 5101 is a user line" "user" (K.Role.to_label first.K.role)
        | [] -> Alcotest.fail "expected non-empty window");
       (match List.rev messages with
        | last :: _ ->
            Alcotest.(check string) "window ends at line 5200"
              "msg-5200" (content_prefix last);
            Alcotest.(check string) "line 5200 is an assistant line"
-             "assistant" last.K.role
+             "assistant" (K.Role.to_label last.K.role)
        | [] -> Alcotest.fail "expected non-empty window"))
 
 (* RFC-0228 P1 — backward paging. Raw JSONL with controlled ts so the
@@ -602,6 +625,8 @@ let () =
             test_load_records_malformed_row_drops;
           Alcotest.test_case "tool row without name dropped" `Quick
             test_tool_row_missing_name_dropped;
+          Alcotest.test_case "unknown role row dropped (RFC-0232)" `Quick
+            test_unknown_role_row_dropped;
         ] );
       ( "speaker_identity",
         [

--- a/test/test_keeper_mention_scope.ml
+++ b/test/test_keeper_mention_scope.ml
@@ -51,15 +51,15 @@ let msg ~role ?(ts = Some 1.0) ?(source = None) ?(speaker = None) content
 let contents pms = List.map snd pms
 
 let test_unanswered_mention_is_pending () =
-  let messages = [ msg ~role:"user" ~ts:(Some 10.0) "@dreamer please look" ] in
+  let messages = [ msg ~role:Store.Role.User ~ts:(Some 10.0) "@dreamer please look" ] in
   check (list string) "no later own line -> pending" [ "@dreamer please look" ]
     (contents (MS.pending_mentions_of_messages ~targets messages))
 ;;
 
 let test_answered_mention_is_cleared () =
   let messages =
-    [ msg ~role:"user" ~ts:(Some 10.0) "@dreamer please look"
-    ; msg ~role:"assistant" ~ts:(Some 11.0) "on it"
+    [ msg ~role:Store.Role.User ~ts:(Some 10.0) "@dreamer please look"
+    ; msg ~role:Store.Role.Assistant ~ts:(Some 11.0) "on it"
     ]
   in
   check (list string) "own line after mention -> cleared" []
@@ -68,9 +68,9 @@ let test_answered_mention_is_cleared () =
 
 let test_rementioned_after_reply_is_pending () =
   let messages =
-    [ msg ~role:"user" ~ts:(Some 10.0) "@dreamer first"
-    ; msg ~role:"assistant" ~ts:(Some 11.0) "done"
-    ; msg ~role:"user" ~ts:(Some 12.0) "@dreamer again"
+    [ msg ~role:Store.Role.User ~ts:(Some 10.0) "@dreamer first"
+    ; msg ~role:Store.Role.Assistant ~ts:(Some 11.0) "done"
+    ; msg ~role:Store.Role.User ~ts:(Some 12.0) "@dreamer again"
     ]
   in
   check (list string) "new mention after reply -> pending" [ "@dreamer again" ]
@@ -78,7 +78,7 @@ let test_rementioned_after_reply_is_pending () =
 ;;
 
 let test_assistant_self_mention_ignored () =
-  let messages = [ msg ~role:"assistant" ~ts:(Some 10.0) "@dreamer note to self" ] in
+  let messages = [ msg ~role:Store.Role.Assistant ~ts:(Some 10.0) "@dreamer note to self" ] in
   check (list string) "own assistant line is never a pending mention" []
     (contents (MS.pending_mentions_of_messages ~targets messages))
 ;;
@@ -91,32 +91,132 @@ let owner = speaker_with Store.Owner
 let external_ = speaker_with Store.External
 
 let test_owner_unmentioned_line_is_scope () =
-  let messages = [ msg ~role:"user" ~ts:(Some 10.0) ~speaker:owner "can you check the deploy" ] in
+  let messages = [ msg ~role:Store.Role.User ~ts:(Some 10.0) ~speaker:owner "can you check the deploy" ] in
   check (list string) "operator without @ -> scope" [ "can you check the deploy" ]
     (contents (MS.pending_scope_of_messages ~targets messages))
 ;;
 
 let test_owner_mention_is_not_scope () =
   (* an owner line that mentions is a mention, not a scope message (disjoint) *)
-  let messages = [ msg ~role:"user" ~ts:(Some 10.0) ~speaker:owner "@dreamer check it" ] in
+  let messages = [ msg ~role:Store.Role.User ~ts:(Some 10.0) ~speaker:owner "@dreamer check it" ] in
   check (list string) "owner mention excluded from scope" []
     (contents (MS.pending_scope_of_messages ~targets messages))
 ;;
 
 let test_external_unmentioned_is_not_scope () =
-  let messages = [ msg ~role:"user" ~ts:(Some 10.0) ~speaker:external_ "random channel chatter" ] in
+  let messages = [ msg ~role:Store.Role.User ~ts:(Some 10.0) ~speaker:external_ "random channel chatter" ] in
   check (list string) "external without @ -> ignored" []
     (contents (MS.pending_scope_of_messages ~targets messages))
 ;;
 
 let test_answered_owner_line_is_cleared () =
   let messages =
-    [ msg ~role:"user" ~ts:(Some 10.0) ~speaker:owner "please check"
-    ; msg ~role:"assistant" ~ts:(Some 11.0) "done"
+    [ msg ~role:Store.Role.User ~ts:(Some 10.0) ~speaker:owner "please check"
+    ; msg ~role:Store.Role.Assistant ~ts:(Some 11.0) "done"
     ]
   in
   check (list string) "answered owner line -> cleared" []
     (contents (MS.pending_scope_of_messages ~targets messages))
+;;
+
+(* RFC-0232 P1 — positional watermark properties. The lane's file order is
+   the only order; timestamps cannot change pending semantics. *)
+
+let test_skewed_clock_cannot_unanswer () =
+  (* The reply's wall clock is *behind* the mention's (NTP step, skewed
+     writer). Lane order says answered; a ts-based watermark would say
+     pending. Positional semantics must clear it. *)
+  let messages =
+    [ msg ~role:Store.Role.User ~ts:(Some 100.0) "@dreamer please look"
+    ; msg ~role:Store.Role.Assistant ~ts:(Some 5.0) "on it"
+    ]
+  in
+  check (list string) "skewed reply ts still clears" []
+    (contents (MS.pending_mentions_of_messages ~targets messages))
+;;
+
+let test_ts_fuzz_does_not_change_pending () =
+  (* Same lane, three ts assignments (ordered, reversed, absent): the
+     pending set depends on lane order alone. *)
+  let lane ts_of =
+    [ msg ~role:Store.Role.User ~ts:(ts_of 0) "@dreamer first"
+    ; msg ~role:Store.Role.Assistant ~ts:(ts_of 1) "done"
+    ; msg ~role:Store.Role.User ~ts:(ts_of 2) "@dreamer again"
+    ]
+  in
+  let expected = [ "@dreamer again" ] in
+  List.iter
+    (fun (label, ts_of) ->
+      check (list string) label expected
+        (contents (MS.pending_mentions_of_messages ~targets (lane ts_of))))
+    [ ("ordered ts", fun i -> Some (float_of_int (10 + i)))
+    ; ("reversed ts", fun i -> Some (float_of_int (10 - i)))
+    ; ("absent ts", fun _ -> None)
+    ]
+;;
+
+let test_none_ts_assistant_still_clears () =
+  (* A legacy assistant line without a timestamp is still the keeper
+     speaking; it must advance the watermark. *)
+  let messages =
+    [ msg ~role:Store.Role.User ~ts:(Some 10.0) "@dreamer please look"
+    ; msg ~role:Store.Role.Assistant ~ts:None "on it"
+    ]
+  in
+  check (list string) "ts-less reply clears" []
+    (contents (MS.pending_mentions_of_messages ~targets messages))
+;;
+
+let tool_line : Store.chat_message =
+  { role = Store.Role.Tool
+  ; content = "{}"
+  ; ts = Some 10.5
+  ; attachments = None
+  ; tool_call_id = Some "tc-0"
+  ; tool_call_name = Some "Read"
+  ; source = None
+  ; conversation_id = None
+  ; external_message_id = None
+  ; speaker = None
+  }
+;;
+
+let test_tool_lines_do_not_clear () =
+  (* Tool lines are the keeper *working*, not the keeper *answering*;
+     they must not advance the watermark. *)
+  let messages =
+    [ msg ~role:Store.Role.User ~ts:(Some 10.0) "@dreamer please look"; tool_line ]
+  in
+  check (list string) "tool line is not an answer" [ "@dreamer please look" ]
+    (contents (MS.pending_mentions_of_messages ~targets messages))
+;;
+
+let test_assistant_append_empties_pending () =
+  (* Appending the keeper's own line can only shrink pending — for any
+     prefix of a lane, prefix @ [assistant] has no pending mentions or
+     scope. Exhaustive over every prefix of a mixed sample lane. *)
+  let sample =
+    [ msg ~role:Store.Role.User ~ts:(Some 1.0) "@dreamer a"
+    ; msg ~role:Store.Role.User ~ts:(Some 2.0) ~speaker:owner "status?"
+    ; msg ~role:Store.Role.Assistant ~ts:(Some 3.0) "reply"
+    ; msg ~role:Store.Role.User ~ts:(Some 4.0) ~speaker:external_ "chatter"
+    ; tool_line
+    ; msg ~role:Store.Role.User ~ts:(Some 5.0) "@dreamer b"
+    ]
+  in
+  let self_reply = msg ~role:Store.Role.Assistant ~ts:(Some 99.0) "ack" in
+  let rec prefixes acc rev_prefix = function
+    | [] -> List.rev (List.rev rev_prefix :: acc)
+    | m :: rest -> prefixes (List.rev rev_prefix :: acc) (m :: rev_prefix) rest
+  in
+  List.iter
+    (fun prefix ->
+      let lane = prefix @ [ self_reply ] in
+      check (list string) "own line empties pending mentions" []
+        (contents (MS.pending_mentions_of_messages ~targets lane));
+      check (list string) "own line empties pending scope" []
+        (contents (MS.pending_scope_of_messages ~targets lane)))
+    (prefixes [] [] sample)
 ;;
 
 let () =
@@ -141,6 +241,14 @@ let () =
         ; test_case "owner_mention_not_scope" `Quick test_owner_mention_is_not_scope
         ; test_case "external_unmentioned_ignored" `Quick test_external_unmentioned_is_not_scope
         ; test_case "answered_owner_cleared" `Quick test_answered_owner_line_is_cleared
+        ] )
+    ; ( "positional_watermark"
+      , [ test_case "skewed_clock_cannot_unanswer" `Quick test_skewed_clock_cannot_unanswer
+        ; test_case "ts_fuzz_invariant" `Quick test_ts_fuzz_does_not_change_pending
+        ; test_case "none_ts_assistant_clears" `Quick test_none_ts_assistant_still_clears
+        ; test_case "tool_lines_do_not_clear" `Quick test_tool_lines_do_not_clear
+        ; test_case "assistant_append_empties_pending" `Quick
+            test_assistant_append_empties_pending
         ] )
     ]
 ;;

--- a/test/test_keeper_surface_post.ml
+++ b/test/test_keeper_surface_post.ml
@@ -99,7 +99,7 @@ let test_assistant_message_persists_with_source () =
       let messages = Store.load ~base_dir ~keeper_name:"post-keeper" in
       check int "one line" 1 (List.length messages);
       let m = List.hd messages in
-      check string "role" "assistant" m.Store.role;
+      check string "role" "assistant" (Store.Role.to_label m.Store.role);
       check string "content" "keeper-initiated hello" m.Store.content;
       check (option string) "source" (Some "discord") m.Store.source;
       check bool "no speaker on keeper output" true (m.Store.speaker = None))

--- a/test/test_keeper_surface_read.ml
+++ b/test/test_keeper_surface_read.ml
@@ -39,18 +39,18 @@ let to_string_j json = Yojson.Safe.Util.to_string json
 
 let discord_fixture : Store.chat_message list =
   [
-    msg ~ts:1.0 ~source:"dashboard" ~role:"user" "hello from owner";
+    msg ~ts:1.0 ~source:"dashboard" ~role:Store.Role.User "hello from owner";
     msg ~ts:2.0 ~source:"discord"
       ~speaker:(external_speaker ~name:"minsu_old" "98791450001")
-      ~role:"user" "first discord message";
-    msg ~ts:2.5 ~source:"discord" ~role:"assistant" "keeper reply";
+      ~role:Store.Role.User "first discord message";
+    msg ~ts:2.5 ~source:"discord" ~role:Store.Role.Assistant "keeper reply";
     msg ~ts:3.0 ~source:"discord"
       ~speaker:(external_speaker ~name:"Minsu" "98791450001")
-      ~role:"user" "second discord message";
+      ~role:Store.Role.User "second discord message";
     msg ~ts:4.0 ~source:"discord"
       ~speaker:(external_speaker "55500001111")
-      ~role:"user" "drive-by, no display name";
-    msg ~role:"user" "legacy row without source";
+      ~role:Store.Role.User "drive-by, no display name";
+    msg ~role:Store.Role.User "legacy row without source";
   ]
 
 let test_lane_filter_excludes_other_sources_and_legacy () =
@@ -168,7 +168,7 @@ let test_oldest_ts_absent_when_page_unstamped () =
   let json =
     parse
       (SR.respond ~surface:"discord" ~limit:10 ~has_more:false ~notes:[]
-         [ msg ~source:"discord" ~role:"user" "no ts row" ])
+         [ msg ~source:"discord" ~role:Store.Role.User "no ts row" ])
   in
   check bool "oldest_ts omitted" true (member "oldest_ts" json = `Null)
 


### PR DESCRIPTION
## Summary
- RFC-0232 P1 (docs PR #20877): lane `role` becomes a closed sum `Keeper_chat_store.Role.t` (`User | Assistant | Tool`) parsed once at the read boundary; the RFC-0230 watermark becomes lane-positional (file order) instead of wall-clock float comparison.
- `keeper_world_observation_message_scope`: `last_self_ts` (float fold) is replaced by `user_lines_after_last_self` (positional fold) — an assistant line clears every candidate accumulated before it; tool lines are transparent.
- Unknown persisted role labels are reported persistence read drops (same policy as `speaker_authority`), never defaulted.
- On-disk format unchanged ("user"/"assistant"/"tool" labels).

## Deliberate semantic changes
1. Clock-skewed replies can no longer "unanswer" a mention: a reply whose `ts` is behind the user line it follows still clears it (lane order is the order). Under the old float watermark this stayed pending forever and the keeper re-answered every observation — the #20870 failure shape.
2. `ts:None` lines now participate: a legacy ts-less assistant line advances the watermark; a ts-less user mention after the last assistant line is pending (previously invisible).
3. Rows with role labels outside the closed sum are dropped+counted at read (previously carried untyped and silently excluded from every consumer).

## Verification
- `bash scripts/dune-local.sh build` (default target) EXIT=0, `@check` clean
- `_build/default/test/test_keeper_mention_scope.exe` — 20 tests (5 new: skewed-clock cannot unanswer, ts-fuzz invariance ordered/reversed/absent, ts-less assistant clears, tool lines do not clear, assistant-append-empties-pending over every lane prefix)
- `_build/default/test/test_keeper_chat_store.exe` — 16 tests (1 new: unknown role row dropped+counted)
- `test_keeper_surface_post.exe` 7, `test_keeper_surface_read.exe` 9, `test_gate_keeper_backend.exe` 29 — all green

## RFC discovery
- RFC-0232 (docs PR #20877) §3.1-§3.2, preserving RFC-0230 cursor-free semantics (carrier typed, location unchanged). Related: RFC-0223/0225/0226/0228.

MASC task: task-827

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
