### PR TITLE
feat(keeper): wire memory os librarian runtime

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -149,6 +149,7 @@
   keeper_memory_llm_summary
   keeper_memory_recall
   keeper_librarian
+  keeper_librarian_runtime
   keeper_status_bridge
   keeper_runtime_trust_timeline
   keeper_hooks_oas_response_metrics

--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -174,15 +174,22 @@ let finalize
     (* CDAL proof evaluation / verdict-ledger persistence removed: task/goal
        completion is verified by [Cdal_evidence_gate] (evidence-substantiveness),
        not by an internal proof/verdict pipeline. *)
+    let librarian_messages =
+      match saved_checkpoint with
+      | Some checkpoint -> checkpoint.Agent_sdk.Checkpoint.messages
+      | None -> [ assistant_msg ]
+    in
     Keeper_agent_run_post_turn_memory.run
       ~config
       ~meta
+      ~generation
       ~turn:manifest_keeper_turn_id
       ~oas_turn_count:result.turns
       ~response_text
       ~actual_tools:actual_keeper_tool_names
       ~state_snapshot
       ~state_snapshot_source
+      ~librarian_messages
       ~post_turn_t0
       ?provider_filter
       ~runtime_id:runtime_id_string

--- a/lib/keeper/keeper_agent_run_post_turn_memory.ml
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.ml
@@ -5,12 +5,14 @@
 let run
   ~config
   ~meta
+  ~generation
   ~turn
   ~oas_turn_count
   ~response_text
   ~actual_tools
   ~state_snapshot
   ~state_snapshot_source
+  ~librarian_messages
   ~post_turn_t0
   ?provider_filter
   ~runtime_id
@@ -68,6 +70,18 @@ let run
        Keeper_metrics.(to_string MemoryWriteFailures)
        ~labels:[ "keeper", meta.name ]
        ());
+
+  (* Memory OS librarian extraction: opt-in, provider-backed, best-effort. *)
+  let librarian_input : Keeper_librarian.input =
+    { trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id
+    ; generation
+    ; messages = librarian_messages
+    }
+  in
+  Keeper_librarian_runtime.run_best_effort
+    ~runtime_id
+    ~keeper_id:meta.name
+    librarian_input;
 
   (* Memory bank compaction: dedup + consolidate if over threshold. *)
   (try

--- a/lib/keeper/keeper_agent_run_post_turn_memory.mli
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.mli
@@ -11,12 +11,14 @@
 val run :
   config:Workspace.config ->
   meta:Keeper_meta_contract.keeper_meta ->
+  generation:int ->
   turn:int ->
   oas_turn_count:int ->
   response_text:string ->
   actual_tools:string list ->
   state_snapshot:Keeper_memory_policy.keeper_state_snapshot ->
   state_snapshot_source:string ->
+  librarian_messages:Agent_sdk.Types.message list ->
   post_turn_t0:float ->
   ?provider_filter:string list ->
   runtime_id:string ->

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -1,0 +1,246 @@
+(** Runtime adapter for Memory OS librarian extraction. *)
+
+let librarian_max_tokens = 1024
+
+type complete_fn =
+  sw:Eio.Switch.t ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  config:Llm_provider.Provider_config.t ->
+  messages:Agent_sdk.Types.message list ->
+  unit ->
+  (Agent_sdk.Types.api_response, Llm_provider.Http_client.http_error) result
+
+let default_complete ~sw ~net ?clock ~config ~messages () =
+  Llm_provider.Complete.complete ~sw ~net ?clock ~config ~messages ()
+;;
+
+let enabled () =
+  Keeper_memory_bank_env.memory_env_bool_logged
+    "MASC_KEEPER_MEMORY_OS_LIBRARIAN"
+    ~default:false
+;;
+
+let max_messages () =
+  Keeper_memory_bank_env.memory_env_int_logged
+    "MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_MESSAGES"
+    ~default:24
+  |> max 1
+;;
+
+let select_recent_messages ~max_messages messages =
+  let max_messages = max 0 max_messages in
+  let len = List.length messages in
+  let drop_count = max 0 (len - max_messages) in
+  let rec drop n xs =
+    if n <= 0
+    then xs
+    else (
+      match xs with
+      | [] -> []
+      | _ :: rest -> drop (n - 1) rest)
+  in
+  drop drop_count messages
+;;
+
+let provider_for_librarian (provider_cfg : Llm_provider.Provider_config.t) =
+  let max_tokens =
+    match provider_cfg.max_tokens with
+    | Some n when n > 0 -> Some (min n librarian_max_tokens)
+    | Some _ -> Some librarian_max_tokens
+    | None -> Some librarian_max_tokens
+  in
+  { provider_cfg with
+    max_tokens
+  ; temperature = Some 0.0
+  ; tool_choice = None
+  ; disable_parallel_tool_use = true
+  ; response_format = Agent_sdk.Types.JsonMode
+  ; output_schema = None
+  ; enable_thinking = Some false
+  ; preserve_thinking = Some false
+  ; thinking_budget = None
+  ; clear_thinking = Some true
+  }
+;;
+
+let message role text =
+  Agent_sdk.Types.make_message ~role [ Agent_sdk.Types.Text text ]
+;;
+
+let render_prompt key variables =
+  match Prompt_registry.render_prompt_template key variables with
+  | Ok text ->
+    let text = String.trim text in
+    if String.equal text ""
+    then Error (Printf.sprintf "%s rendered empty prompt" key)
+    else Ok text
+  | Error msg -> Error (Printf.sprintf "%s: %s" key msg)
+;;
+
+let messages_for_librarian (inp : Keeper_librarian.input) =
+  let input =
+    { inp with messages = select_recent_messages ~max_messages:(max_messages ()) inp.messages }
+  in
+  match render_prompt Keeper_prompt_names.librarian_system [] with
+  | Error _ as e -> e
+  | Ok system ->
+    (match
+       render_prompt
+         Keeper_prompt_names.librarian_episode_extraction
+         (Keeper_librarian.prompt_variables input)
+     with
+     | Error _ as e -> e
+     | Ok user ->
+       Ok
+         [ message Agent_sdk.Types.System system
+         ; message Agent_sdk.Types.User user
+         ])
+;;
+
+let http_error_message (err : Llm_provider.Http_client.http_error) =
+  match err with
+  | Llm_provider.Http_client.NetworkError { message; _ } -> message
+  | Llm_provider.Http_client.TimeoutError { message; phase } ->
+    Printf.sprintf
+      "provider timeout: %s: %s"
+      (Llm_provider.Http_client.timeout_phase_to_label phase)
+      message
+  | Llm_provider.Http_client.AcceptRejected { reason } -> reason
+  | Llm_provider.Http_client.ProviderTerminal { kind = _; message } ->
+    Printf.sprintf "provider terminal: %s" message
+  | Llm_provider.Http_client.ProviderFailure { kind; message } ->
+    Llm_provider.Http_client.provider_failure_to_string ~kind ~message
+  | Llm_provider.Http_client.HttpError { code; body } ->
+    Printf.sprintf
+      "HTTP %d: %s"
+      code
+      (if String.length body > 200 then String.sub body 0 200 ^ "..." else body)
+;;
+
+let with_timeout ?clock ~timeout_sec f =
+  match clock with
+  | None -> Some (f ())
+  | Some clock ->
+    (try Some (Eio.Time.with_timeout_exn clock timeout_sec f) with
+     | Eio.Time.Timeout -> None)
+;;
+
+let extract_with_provider
+    ?(complete = default_complete)
+    ?clock
+    ?(timeout_sec = Env_config_governance.Inference.timeout_seconds)
+    ~sw
+    ~net
+    ~provider_cfg
+    (inp : Keeper_librarian.input)
+  =
+  match messages_for_librarian inp with
+  | Error _ as e -> e
+  | Ok messages ->
+    let provider_cfg = provider_for_librarian provider_cfg in
+    (match
+       with_timeout ?clock ~timeout_sec (fun () ->
+         complete ~sw ~net ?clock ~config:provider_cfg ~messages ())
+     with
+     | None -> Error "librarian provider timed out"
+     | Some (Error err) -> Error (http_error_message err)
+     | Some (Ok response) ->
+       let raw = Agent_sdk_response.text_of_response response |> String.trim in
+       if String.equal raw ""
+       then Error "librarian provider returned empty response"
+       else (
+         match Keeper_librarian.episode_of_output inp raw with
+         | Some episode -> Ok episode
+         | None -> Error "librarian provider returned invalid episode JSON"))
+;;
+
+let extract_and_append_with_provider
+    ?complete
+    ?clock
+    ?timeout_sec
+    ~sw
+    ~net
+    ~keeper_id
+    ~provider_cfg
+    inp
+  =
+  match extract_with_provider ?complete ?clock ?timeout_sec ~sw ~net ~provider_cfg inp with
+  | Error _ as e -> e
+  | Ok episode ->
+    Keeper_memory_os_io.append_episode_bundle ~keeper_id episode;
+    Ok episode
+;;
+
+let provider_for_runtime ~runtime_id =
+  match Runtime.get_runtime_by_id runtime_id with
+  | Some rt -> Ok rt.Runtime.provider_config
+  | None ->
+    (match Runtime.get_default_runtime () with
+     | Some rt -> Ok rt.Runtime.provider_config
+     | None -> Error "no runtime configured for librarian extraction")
+;;
+
+let run_best_effort ?complete ?timeout_sec ~runtime_id ~keeper_id inp =
+  if enabled ()
+  then (
+    try
+      match Eio_context.get_switch_opt (), Eio_context.get_net_opt () with
+      | Some sw, Some net ->
+        (match provider_for_runtime ~runtime_id with
+         | Error err ->
+           Log.Keeper.warn ~keeper_name:keeper_id
+             "memory os librarian skipped runtime=%s: %s"
+             runtime_id
+             err
+         | Ok provider_cfg ->
+           if not (Keeper_memory_llm_summary.is_direct_completion_provider provider_cfg)
+           then
+             Log.Keeper.warn ~keeper_name:keeper_id
+               "memory os librarian skipped runtime=%s provider=%s: provider does not support direct completion"
+               runtime_id
+               provider_cfg.Llm_provider.Provider_config.model_id
+           else (
+             let clock = Eio_context.get_clock_opt () in
+             match
+               extract_and_append_with_provider
+                 ?complete
+                 ?clock
+                 ?timeout_sec
+                 ~sw
+                 ~net
+                 ~keeper_id
+                 ~provider_cfg
+                 inp
+             with
+             | Ok episode ->
+               Log.Keeper.info ~keeper_name:keeper_id
+                 "memory os librarian wrote episode trace_id=%s generation=%d claims=%d"
+                 episode.Keeper_memory_os_types.trace_id
+                 episode.generation
+                 (List.length episode.claims)
+             | Error err ->
+               Otel_metric_store.inc_counter
+                 Keeper_metrics.(to_string EpisodeCreateFailures)
+                 ~labels:[ "keeper", keeper_id; "site", "memory_os_librarian" ]
+                 ();
+               Log.Keeper.warn ~keeper_name:keeper_id
+                 "memory os librarian failed runtime=%s: %s"
+                 runtime_id
+                 err))
+      | _ ->
+        Log.Keeper.warn ~keeper_name:keeper_id
+          "memory os librarian skipped: Eio context unavailable runtime=%s"
+          runtime_id
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
+      Otel_metric_store.inc_counter
+        Keeper_metrics.(to_string EpisodeCreateFailures)
+        ~labels:[ "keeper", keeper_id; "site", "memory_os_librarian" ]
+        ();
+      Log.Keeper.warn ~keeper_name:keeper_id
+        "memory os librarian failed runtime=%s: %s"
+        runtime_id
+        (Printexc.to_string exn))
+;;

--- a/lib/keeper/keeper_librarian_runtime.mli
+++ b/lib/keeper/keeper_librarian_runtime.mli
@@ -1,0 +1,65 @@
+(** Runtime adapter for Memory OS librarian extraction.
+
+    [Keeper_librarian] owns pure prompt variables and JSON parsing. This module
+    owns the side-effect boundary: render external prompts, call a provider, and
+    append accepted episodes to [Keeper_memory_os_io]. *)
+
+type complete_fn =
+  sw:Eio.Switch.t ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  config:Llm_provider.Provider_config.t ->
+  messages:Agent_sdk.Types.message list ->
+  unit ->
+  (Agent_sdk.Types.api_response, Llm_provider.Http_client.http_error) result
+
+val enabled : unit -> bool
+(** Opt-in gate controlled by [MASC_KEEPER_MEMORY_OS_LIBRARIAN]. *)
+
+val max_messages : unit -> int
+(** Maximum recent checkpoint messages sent to the librarian prompt. *)
+
+val select_recent_messages
+  :  max_messages:int
+  -> Agent_sdk.Types.message list
+  -> Agent_sdk.Types.message list
+
+val messages_for_librarian
+  :  Keeper_librarian.input
+  -> (Agent_sdk.Types.message list, string) result
+
+val provider_for_librarian
+  :  Llm_provider.Provider_config.t
+  -> Llm_provider.Provider_config.t
+
+val extract_with_provider
+  :  ?complete:complete_fn
+  -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
+  -> ?timeout_sec:float
+  -> sw:Eio.Switch.t
+  -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
+  -> provider_cfg:Llm_provider.Provider_config.t
+  -> Keeper_librarian.input
+  -> (Keeper_memory_os_types.episode, string) result
+
+val extract_and_append_with_provider
+  :  ?complete:complete_fn
+  -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
+  -> ?timeout_sec:float
+  -> sw:Eio.Switch.t
+  -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
+  -> keeper_id:string
+  -> provider_cfg:Llm_provider.Provider_config.t
+  -> Keeper_librarian.input
+  -> (Keeper_memory_os_types.episode, string) result
+
+val run_best_effort
+  :  ?complete:complete_fn
+  -> ?timeout_sec:float
+  -> runtime_id:string
+  -> keeper_id:string
+  -> Keeper_librarian.input
+  -> unit
+(** Run the opt-in post-turn librarian path.
+
+    Non-cancel failures are logged and counted, never raised. *)

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -4,6 +4,7 @@ module Types = Masc.Keeper_memory_os_types
 module Policy = Masc.Keeper_memory_os_policy
 module Memory_io = Masc.Keeper_memory_os_io
 module Librarian = Masc.Keeper_librarian
+module Librarian_runtime = Masc.Keeper_librarian_runtime
 module Prompt_names = Keeper_prompt_names
 module Recall = Masc.Keeper_memory_os_recall
 
@@ -98,6 +99,49 @@ let text_message ?(role = Agent_sdk.Types.User) text : Agent_sdk.Types.message =
   ; tool_call_id = None
   ; metadata = []
   }
+;;
+
+let message_text (message : Agent_sdk.Types.message) =
+  message.content
+  |> List.filter_map (function
+    | Agent_sdk.Types.Text text -> Some text
+    | Agent_sdk.Types.Thinking _
+    | Agent_sdk.Types.RedactedThinking _
+    | Agent_sdk.Types.ToolUse _
+    | Agent_sdk.Types.ToolResult _
+    | Agent_sdk.Types.Image _
+    | Agent_sdk.Types.Document _
+    | Agent_sdk.Types.Audio _ -> None)
+  |> String.concat "\n"
+;;
+
+let fake_response raw : Agent_sdk.Types.api_response =
+  { id = "fake-librarian-response"
+  ; model = "fake-librarian-model"
+  ; stop_reason = Agent_sdk.Types.EndTurn
+  ; content = [ Agent_sdk.Types.Text raw ]
+  ; usage = None
+  ; telemetry = None
+  }
+;;
+
+let test_provider_cfg () =
+  Llm_provider.Provider_config.make
+    ~kind:Llm_provider.Provider_config.OpenAI_compat
+    ~model_id:"fake-librarian-model"
+    ~base_url:"http://127.0.0.1:1"
+    ~max_tokens:4096
+    ~enable_thinking:true
+    ~preserve_thinking:true
+    ~thinking_budget:512
+    ()
+;;
+
+let with_eio f =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw -> f ~sw ~net:(Eio.Stdenv.net env) ~clock:(Eio.Stdenv.clock env)
 ;;
 
 let episode_fixture ~now ~trace_id ~generation ~summary =
@@ -358,6 +402,123 @@ let test_librarian_rejects_invalid_claims () =
        ])
 ;;
 
+let json_episode_file_count ~keeper_id =
+  Memory_io.episodes_dir ~keeper_id
+  |> Sys.readdir
+  |> Array.to_list
+  |> List.filter (fun name -> Filename.check_suffix name ".json")
+  |> List.length
+;;
+
+let test_librarian_runtime_appends_episode_bundle () =
+  with_prompt_registry (fun () ->
+    with_temp_keepers_dir (fun _keepers_dir ->
+      with_eio (fun ~sw ~net ~clock ->
+        let keeper_id = "runtime-librarian-keeper" in
+        let captured = ref None in
+        let complete ~sw:_ ~net:_ ?clock:_ ~config ~messages () =
+          captured := Some (config, messages);
+          Ok (fake_response (valid_librarian_output () |> Yojson.Safe.to_string))
+        in
+        let private_msg : Agent_sdk.Types.message =
+          { role = Agent_sdk.Types.Assistant
+          ; content =
+              [ Agent_sdk.Types.Text
+                  "[STATE]\nruntime secret sentinel\n[/STATE]\nvisible durable fact"
+              ; Agent_sdk.Types.Thinking
+                  { thinking_type = "reasoning"; content = "hidden chain of thought" }
+              ; Agent_sdk.Types.ToolResult
+                  { tool_use_id = "call_runtime"
+                  ; content = "secret tool payload"
+                  ; is_error = false
+                  ; json = None
+                  ; content_blocks = None
+                  }
+              ]
+          ; name = None
+          ; tool_call_id = None
+          ; metadata = []
+          }
+        in
+        let inp : Librarian.input =
+          { Librarian.trace_id = "trace-runtime"
+          ; generation = 7
+          ; messages =
+              [ text_message "older message"
+              ; text_message "Please remember the runtime boundary."
+              ; private_msg
+              ]
+          }
+        in
+        (match
+           Librarian_runtime.extract_and_append_with_provider
+             ~complete
+             ~clock
+             ~timeout_sec:1.0
+             ~sw
+             ~net
+             ~keeper_id
+             ~provider_cfg:(test_provider_cfg ())
+             inp
+         with
+         | Error msg -> Alcotest.fail msg
+         | Ok episode ->
+           Alcotest.(check string) "trace id" "trace-runtime" episode.Types.trace_id;
+           Alcotest.(check int) "generation" 7 episode.Types.generation;
+           Alcotest.(check int) "claim persisted in result" 1 (List.length episode.Types.claims));
+        (match !captured with
+         | None -> Alcotest.fail "expected fake provider to be called"
+         | Some (provider_cfg, messages) ->
+           Alcotest.(check (option bool))
+             "thinking disabled"
+             (Some false)
+             provider_cfg.Llm_provider.Provider_config.enable_thinking;
+           Alcotest.(check (option bool))
+             "thinking preservation disabled"
+             (Some false)
+             provider_cfg.Llm_provider.Provider_config.preserve_thinking;
+           Alcotest.(check bool)
+             "json mode"
+             true
+             (provider_cfg.response_format = Agent_sdk.Types.JsonMode);
+           Alcotest.(check int) "system+user prompt" 2 (List.length messages);
+           let rendered_prompt = messages |> List.map message_text |> String.concat "\n" in
+           Alcotest.(check bool)
+             "contains visible prompt"
+             true
+             (contains "visible durable fact" rendered_prompt);
+           Alcotest.(check bool)
+             "scrubs state text"
+             false
+             (contains "runtime secret sentinel" rendered_prompt);
+           Alcotest.(check bool)
+             "scrubs thinking"
+             false
+             (contains "hidden chain of thought" rendered_prompt);
+           Alcotest.(check bool)
+             "scrubs tool payload"
+             false
+             (contains "secret tool payload" rendered_prompt));
+        Alcotest.(check int)
+          "episode file persisted"
+          1
+          (json_episode_file_count ~keeper_id);
+        (match Memory_io.read_events_tail ~keeper_id ~n:1 with
+         | [ episode ] ->
+           Alcotest.(check string)
+             "event persisted"
+             "Integer confidence should still persist"
+             episode.Types.episode_summary
+         | events -> Alcotest.failf "expected one event, got %d" (List.length events));
+        match Memory_io.read_facts_tail ~keeper_id ~n:1 with
+        | [ fact ] ->
+          Alcotest.(check string)
+            "fact persisted"
+            "Integer confidence survives parsing"
+            fact.Types.claim
+        | facts -> Alcotest.failf "expected one fact, got %d" (List.length facts))))
+;;
+
 let test_policy_score_and_retention () =
   let now = 1_000_000.0 in
   let f = fact_fixture ~now () in
@@ -389,14 +550,6 @@ let test_bump_access () =
   match not_bumped with
   | [ got ] -> Alcotest.(check int) "access unchanged" 2 got.Types.access_count
   | _ -> Alcotest.fail "expected one unchanged fact"
-;;
-
-let json_episode_file_count ~keeper_id =
-  Memory_io.episodes_dir ~keeper_id
-  |> Sys.readdir
-  |> Array.to_list
-  |> List.filter (fun name -> Filename.check_suffix name ".json")
-  |> List.length
 ;;
 
 let test_episode_files_do_not_overwrite_generation () =
@@ -593,6 +746,10 @@ let () =
             "librarian rejects invalid claims"
             `Quick
             test_librarian_rejects_invalid_claims
+        ; Alcotest.test_case
+            "librarian runtime appends episode bundle"
+            `Quick
+            test_librarian_runtime_appends_episode_bundle
         ] )
     ; ( "policy"
       , [ Alcotest.test_case "score and retention" `Quick test_policy_score_and_retention


### PR DESCRIPTION
## Summary
- Add `Keeper_librarian_runtime`, a narrow provider adapter that renders external librarian prompts, requests JSON mode, disables thinking preservation, parses strict episode JSON, and appends accepted Memory OS episode bundles.
- Wire the opt-in librarian path into post-turn memory using the saved checkpoint messages from the completed turn.
- Add a fake-provider Memory OS test that verifies prompt scrubbing and persisted episode/event/fact writes without network access.

## Runtime behavior
- Disabled by default.
- Enable with `MASC_KEEPER_MEMORY_OS_LIBRARIAN=true`.
- Bound prompt slice with `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_MESSAGES` (default 24).
- Non-cancel failures are best-effort: warn + `EpisodeCreateFailures`, no turn failure propagation.

## Validation
- `scripts/dune-local.sh build test/test_keeper_memory_os.exe`
- `./_build/default/test/test_keeper_memory_os.exe`
- `scripts/validate-prompt-paths.sh`
- `bash scripts/lint/no-runtime-literal-outside-boundary-redaction.sh --fail`
- `bash scripts/lint/no-yojson-3-dead-arms.sh`
- `bash scripts/ci/check-determinism-contract.sh`
- `python3 scripts/ci/check-fun-protect-finally-guard.py --base origin/main --head HEAD`
- `bash scripts/ci/check-ignore-without-comment-diff.sh --base origin/main --head HEAD`
- `git diff --cached --check`