### PR TITLE
fix(runtime): remove dead code format_exhausted_error (0 callers)

### DIFF
--- a/lib/runtime/runtime_attempt_fsm.ml
+++ b/lib/runtime/runtime_attempt_fsm.ml
@@ -62,20 +62,6 @@ let to_user_message = function
     Llm_provider.Http_client.provider_failure_to_string ~kind ~message
   | None -> "No providers available"
 
-let format_exhausted_error last_err =
-  let message = to_user_message last_err in
-  let kind =
-    match last_err with
-    | Some (Llm_provider.Http_client.NetworkError { kind; _ }) -> kind
-    | Some (Llm_provider.Http_client.TimeoutError _) -> Llm_provider.Http_client.Timeout
-    | _ -> Llm_provider.Http_client.Unknown
-  in
-  match last_err with
-  | Some (Llm_provider.Http_client.AcceptRejected _ as err) -> err
-  | _ ->
-    Llm_provider.Http_client.NetworkError
-      { message = Printf.sprintf "All providers failed: %s" message; kind }
-
 let provider_outcome_to_string = function
   | Call_ok _ -> "call-ok"
   | Call_err _ -> "call-err"

--- a/lib/runtime/runtime_attempt_fsm.mli
+++ b/lib/runtime/runtime_attempt_fsm.mli
@@ -34,9 +34,7 @@ val decide_and_record :
 
 val to_user_message : Llm_provider.Http_client.http_error option -> string
 
-val format_exhausted_error :
-  Llm_provider.Http_client.http_error option ->
-  Llm_provider.Http_client.http_error
+
 
 val provider_outcome_to_string : provider_outcome -> string
 


### PR DESCRIPTION
Closes task-844.

Confirmed zero-caller dead code via board post p-5645b94aae7b8b86ce2b637a82106ab3.

**Evidence**
- `format_exhausted_error` declared in `.mli:43`, defined in `.ml:80`
- Zero callers across `lib/`, `bin/`, `test/`
- Consumer `keeper_turn_driver_try_runtime.ml:35` uses `to_user_message()` directly, bypassing this wrapper

**Change**
- Remove `val format_exhausted_error` from `.mli`
- Remove `let format_exhausted_error` block from `.ml`
- 2 files, +1/-17 lines

Draft: dune build CI needed to confirm no breaking references.