### PR TITLE
chore: Remove dead code format_exhausted_error from runtime_attempt_fsm

### DIFF
--- a/lib/runtime/runtime_attempt_fsm.ml
+++ b/lib/runtime/runtime_attempt_fsm.ml
@@ -62,20 +62,6 @@ let to_user_message = function
     Llm_provider.Http_client.provider_failure_to_string ~kind ~message
   | None -> "No providers available"
 
-let format_exhausted_error last_err =
-  let message = to_user_message last_err in
-  let kind =
-    match last_err with
-    | Some (Llm_provider.Http_client.NetworkError { kind; _ }) -> kind
-    | Some (Llm_provider.Http_client.TimeoutError _) -> Llm_provider.Http_client.Timeout
-    | _ -> Llm_provider.Http_client.Unknown
-  in
-  match last_err with
-  | Some (Llm_provider.Http_client.AcceptRejected _ as err) -> err
-  | _ ->
-    Llm_provider.Http_client.NetworkError
-      { message = Printf.sprintf "All providers failed: %s" message; kind }
-
 let provider_outcome_to_string = function
   | Call_ok _ -> "call-ok"
   | Call_err _ -> "call-err"

--- a/lib/runtime/runtime_attempt_fsm.mli
+++ b/lib/runtime/runtime_attempt_fsm.mli
@@ -34,10 +34,6 @@ val decide_and_record :
 
 val to_user_message : Llm_provider.Http_client.http_error option -> string
 
-val format_exhausted_error :
-  Llm_provider.Http_client.http_error option ->
-  Llm_provider.Http_client.http_error
-
 val provider_outcome_to_string : provider_outcome -> string
 
 val provider_outcome_option_to_string : provider_outcome option -> string


### PR DESCRIPTION
format_exhausted_error was defined but had zero callers in the entire codebase (confirmed via grep).

Closes #844

## Changes
- `lib/runtime/runtime_attempt_fsm.ml`: removed `let format_exhausted_error` (14 lines)
- `lib/runtime/runtime_attempt_fsm.mli`: removed `val format_exhausted_error` declaration (4 lines)

PR generated by @taskmaster from orphaned task-844 (keeper-garnet-agent was offline).