### PR TITLE
[codex] Add tool contract regression harness

### DIFF
--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -113,8 +113,7 @@ Knowledge lookup:
 Board and communication:
 - Discover board post IDs: keeper_board_list for recent posts, keeper_board_search for keyword lookup. Use these before get/comment/vote when no post_id is already visible.
 - Read or react to an existing board post: keeper_board_post_get, keeper_board_comment, and keeper_board_vote all require an exact post_id. Never call keeper_board_post_get with `{}` or without post_id.
-- Create a new board post: keeper_board_post (hearth required)
-- When posting to the board, always set hearth to your keeper name (e.g. hearth="sangsu"). Never post without hearth.
+- Create a new board post: keeper_board_post with content. Hearth is optional; set it only when targeting a specific topic channel. If omitted, the runtime fills the keeper identity.
 - Broadcast to all agents: keeper_broadcast
 - Speak aloud: keeper_voice_speak (requires voice_config.json with tts.endpoints configured)
 

--- a/config/prompts/keeper.tool_hints.toml
+++ b/config/prompts/keeper.tool_hints.toml
@@ -80,8 +80,8 @@ description = "approve or reject an awaiting_verification task after inspecting 
 
 [[hints]]
 name = "keeper_task_done"
-call = "`keeper_task_done` { notes: \"evidence\" }"
-description = "close non-PR task work with evidence"
+call = "`keeper_task_done` { task_id: \"TASK_ID\", result: \"completion evidence\" }"
+description = "close claimed task work with task_id and concrete result evidence"
 
 [[hints]]
 name = "keeper_stay_silent"

--- a/config/prompts/system.orchestrator.md
+++ b/config/prompts/system.orchestrator.md
@@ -19,15 +19,20 @@ You have access to MASC MCP tools via mcp__masc__* prefix.
    - task_id: "task-XXX"
    - action: "claim"
 
-4. **Work on the task**: Execute the task description
+4. **Start the task**: Call `mcp__masc__masc_transition` with:
+   - agent_name: "orchestrator"
+   - task_id: "task-XXX"
+   - action: "start"
 
-5. **Mark done**: Call `mcp__masc__masc_transition` with:
+5. **Work on the task**: Execute the task description
+
+6. **Mark done**: Call `mcp__masc__masc_transition` with:
    - agent_name: "orchestrator"
    - task_id: "task-XXX"
    - action: "done"
    - notes: completion summary
 
-6. **Broadcast progress**: Call `mcp__masc__masc_broadcast` to notify others
+7. **Broadcast progress**: Call `mcp__masc__masc_broadcast` to notify others
 
 ## Available MCP Tools:
 - mcp__masc__masc_status - Get project status

--- a/lib/mcp_server_eio_tool_profile.ml
+++ b/lib/mcp_server_eio_tool_profile.ml
@@ -58,7 +58,7 @@ PROJECT: Agents sharing the same base path (.masc/ folder) align together. \
 CLUSTER: Set MASC_CLUSTER_NAME for multi-machine workspace (otherwise tool surfaces use the configured cluster/default label). \
 READ: use resources/list + resources/read (status/tasks/agents/events/schema) for snapshots. \
 WRITE: prefer masc_transition (claim/start/done/cancel/release) with expected_version for CAS. \
-WORKFLOW: masc_status → masc_transition(claim) → work in a repo-local worktree → masc_transition(done). \
+WORKFLOW: masc_status → masc_transition(claim) → masc_transition(start) → work in a repo-local worktree → masc_transition(done). \
 Use masc_heartbeat periodically; use @agent mentions in masc_broadcast. \
 Prefer worktrees for parallel work. \
 Use masc_tool_help to inspect tool contracts and prefer the smallest useful surface."

--- a/lib/task/tool_task_schemas.ml
+++ b/lib/task/tool_task_schemas.ml
@@ -206,6 +206,7 @@ Tip: Look for status='todo' tasks to claim.";
       "Move a task through its lifecycle: claim, start, done, cancel, release, \
 submit_for_verification, approve, or reject. \
 Call when you pick up, finish, or abandon a task. Supports CAS via expected_version. \
+For normal task work, claim first, then call action='start' before action='done'. \
 After %s or %s; pair with masc_deliver before action='done'. \
 Use submit_for_verification only for explicit review of a claimed/in_progress task you own; approve/reject for verifier actions. \
 Tasks created through %s complete via action='done' after LLM completion review; \

--- a/test/test_mcp_server_eio_tool_profile_capability.ml
+++ b/test/test_mcp_server_eio_tool_profile_capability.ml
@@ -1,5 +1,17 @@
 open Alcotest
 
+let contains_substring haystack needle =
+  let hlen = String.length haystack in
+  let nlen = String.length needle in
+  let rec loop index =
+    if nlen = 0 then true
+    else if index + nlen > hlen then false
+    else if String.sub haystack index nlen = needle then true
+    else loop (index + 1)
+  in
+  loop 0
+;;
+
 let annotation_fields tool_name =
   match
     Masc.Mcp_server_eio_tool_profile.tool_annotations_for_profile
@@ -193,6 +205,27 @@ let test_descriptor_resolution_capabilities_for_public_aliases () =
     (capability_has Tool_capability.Destructive "Read")
 ;;
 
+let test_default_instructions_pin_start_transition_workflow () =
+  let instructions = Masc.Mcp_server_eio_tool_profile.default_instructions in
+  check
+    bool
+    "write summary names start"
+    true
+    (contains_substring instructions "claim/start/done");
+  check
+    bool
+    "workflow includes start transition"
+    true
+    (contains_substring instructions "masc_transition(start)");
+  check
+    bool
+    "workflow does not skip start"
+    false
+    (contains_substring
+       instructions
+       "masc_transition(claim) \226\134\146 work in a repo-local worktree")
+;;
+
 let () =
   run
     "mcp-server-eio-tool-profile-capability"
@@ -217,6 +250,10 @@ let () =
             "descriptor-resolution-capabilities-for-public-aliases"
             `Quick
             test_descriptor_resolution_capabilities_for_public_aliases
+        ; test_case
+            "default-instructions-pin-start-transition-workflow"
+            `Quick
+            test_default_instructions_pin_start_transition_workflow
         ] )
     ]
 ;;

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -19,6 +19,37 @@ let string_contains haystack needle =
     done;
     !found
 
+let read_file path =
+  let ic = open_in path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () -> In_channel.input_all ic)
+
+let rec find_source_root_from dir hops rel =
+  if hops > 8 then None
+  else if Sys.file_exists (Filename.concat dir rel) then Some dir
+  else
+    let parent = Filename.dirname dir in
+    if String.equal parent dir then None else find_source_root_from parent (hops + 1) rel
+
+let source_root () =
+  let anchor = "config/prompts/keeper.tool_hints.toml" in
+  match Sys.getenv_opt "DUNE_SOURCEROOT" with
+  | Some root when String.trim root <> "" && Sys.file_exists (Filename.concat root anchor) ->
+    root
+  | _ ->
+    (match find_source_root_from (Sys.getcwd ()) 0 anchor with
+     | Some root -> root
+     | None -> Alcotest.fail "could not locate repo source root")
+
+let read_source_file rel = read_file (Filename.concat (source_root ()) rel)
+
+let assert_contains label haystack needle =
+  Alcotest.(check bool) label true (string_contains haystack needle)
+
+let assert_not_contains label haystack needle =
+  Alcotest.(check bool) label false (string_contains haystack needle)
+
 (* ================================================================ *)
 (* Helper: validate via the same pipeline as the pre-hook            *)
 (* ================================================================ *)
@@ -457,6 +488,12 @@ let keeper_board_list_schema =
 
 let keeper_board_search_schema =
   find_schema_exn "keeper_board_search" Config.raw_all_tool_schemas
+
+let keeper_board_post_get_schema =
+  find_schema_exn "keeper_board_post_get" Config.raw_all_tool_schemas
+
+let keeper_task_done_schema =
+  find_schema_exn "keeper_task_done" Config.raw_all_tool_schemas
 
 let tool_execute_schema =
   find_schema_exn "tool_execute" Config.raw_all_tool_schemas
@@ -1260,6 +1297,132 @@ let test_registered_hook_required_enum_blank_is_not_stripped () =
   Alcotest.(check string) "required blank preserved for handler validation" ""
     (assoc_string "mode" forwarded)
 
+let schema_required_fields schema =
+  match Yojson.Safe.Util.member "required" schema with
+  | `List values ->
+    List.filter_map (function `String value -> Some value | _ -> None) values
+  | _ -> []
+
+let assert_schema_requires label schema field =
+  Alcotest.(check bool)
+    (label ^ " requires " ^ field)
+    true
+    (List.mem field (schema_required_fields schema))
+
+let assert_validation_rejects ~label ~schema ~tool_name ~args ~snippets =
+  match Tool_input_validation.validate_args ~schema ~name:tool_name ~args () with
+  | Error result ->
+    let msg = Yojson.Safe.to_string (Tool_result.data result) in
+    List.iter
+      (fun snippet ->
+         assert_contains (label ^ " mentions " ^ snippet) msg snippet)
+      snippets
+  | Ok forwarded ->
+    Alcotest.failf
+      "%s: expected validation rejection, got %s"
+      label
+      (Yojson.Safe.to_string forwarded)
+
+let test_high_risk_tool_contract_rejection_corpus () =
+  List.iter
+    (fun (label, tool_name, schema, args, snippets) ->
+       assert_validation_rejects ~label ~tool_name ~schema ~args ~snippets)
+    [ ( "execute empty object"
+      , "tool_execute"
+      , tool_execute_schema
+      , `Assoc []
+      , [ "exactly one of" ] )
+    ; ( "execute raw cmd string"
+      , "tool_execute"
+      , tool_execute_schema
+      , `Assoc [ "cmd", `String "git status --short" ]
+      , [ "cmd"; "executable/argv" ] )
+    ; ( "keeper_task_done notes-only drift"
+      , "keeper_task_done"
+      , keeper_task_done_schema
+      , `Assoc [ "notes", `String "evidence" ]
+      , [ "task_id"; "result" ] )
+    ; ( "keeper_board_post_get missing post_id"
+      , "keeper_board_post_get"
+      , keeper_board_post_get_schema
+      , `Assoc []
+      , [ "post_id" ] )
+    ; ( "masc_transition retired alias fields"
+      , "masc_transition"
+      , masc_transition_schema
+      , `Assoc
+          [ "agent_name", `String "agent_code-local-admin"
+          ; "task_id", `String "task-239"
+          ; "action", `String "claim"
+          ; "to", `String "claimed"
+          ; "note", `String "PR #8308 Draft"
+          ]
+      , [ "to"; "note" ] )
+    ]
+
+let test_keeper_tool_hint_contracts_match_required_fields () =
+  assert_schema_requires "keeper_task_done schema" keeper_task_done_schema "task_id";
+  assert_schema_requires "keeper_task_done schema" keeper_task_done_schema "result";
+  assert_schema_requires
+    "keeper_board_post_get schema"
+    keeper_board_post_get_schema
+    "post_id";
+  assert_schema_requires "keeper_board_post schema" keeper_board_post_schema "content";
+  Alcotest.(check bool)
+    "keeper_board_post schema does not require hearth"
+    false
+    (List.mem "hearth" (schema_required_fields keeper_board_post_schema));
+  let hints = read_source_file "config/prompts/keeper.tool_hints.toml" in
+  assert_contains
+    "keeper_task_done hint names task_id"
+    hints
+    "`keeper_task_done` { task_id:";
+  assert_contains
+    "keeper_task_done hint names result"
+    hints
+    "result:";
+  assert_contains
+    "keeper_task_done hint names evidence"
+    hints
+    "completion evidence";
+  assert_not_contains
+    "keeper_task_done hint does not regress to notes-only"
+    hints
+    "`keeper_task_done` { notes: \"evidence\" }";
+  assert_contains
+    "board get hint uses current tool name"
+    hints
+    "name = \"keeper_board_post_get\"";
+  assert_contains
+    "board get hint names post_id"
+    hints
+    "post_id:";
+  assert_not_contains
+    "board get hint avoids retired name"
+    hints
+    "name = \"keeper_board_get\""
+
+let test_orchestrator_prompt_pins_start_transition () =
+  let prompt = read_source_file "config/prompts/system.orchestrator.md" in
+  assert_contains "orchestrator prompt claims first" prompt "action: \"claim\"";
+  assert_contains "orchestrator prompt starts before work" prompt "action: \"start\"";
+  assert_contains "orchestrator prompt marks done" prompt "action: \"done\""
+
+let test_board_prompt_does_not_require_optional_hearth () =
+  let prompt = read_source_file "config/prompts/keeper.capabilities.md" in
+  assert_contains
+    "board prompt says hearth optional"
+    prompt
+    "Hearth is optional";
+  assert_not_contains
+    "board prompt does not claim hearth required"
+    prompt
+    "hearth required";
+  assert_not_contains
+    "board prompt does not forbid omitted hearth"
+    prompt
+    "Never post without hearth"
+
 (* ================================================================ *)
 (* Test: oneOf with empty/null values (regression guard)             *)
 (* ================================================================ *)
@@ -1779,6 +1942,16 @@ let () =
         test_registered_hook_goal_list_preserves_invalid_enum_for_handler;
       Alcotest.test_case "required enum blanks are not stripped" `Quick
         test_registered_hook_required_enum_blank_is_not_stripped;
+    ]);
+    ("high_risk_contract_harness", [
+      Alcotest.test_case "rejects live high-risk invalid call corpus" `Quick
+        test_high_risk_tool_contract_rejection_corpus;
+      Alcotest.test_case "keeper prompt hints match schema-required fields" `Quick
+        test_keeper_tool_hint_contracts_match_required_fields;
+      Alcotest.test_case "orchestrator prompt includes start transition" `Quick
+        test_orchestrator_prompt_pins_start_transition;
+      Alcotest.test_case "board prompt does not require optional hearth" `Quick
+        test_board_prompt_does_not_require_optional_hearth;
     ]);
     ("oneof_const_discriminator", [
       Alcotest.test_case "alpha branch matches via const" `Quick

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -202,6 +202,9 @@ let test_masc_transition_schema () =
       Alcotest.(check bool) "description omits requires tools routing"
         false
         (contains_substring ~needle:"requires tools" schema.description);
+      Alcotest.(check bool) "description pins start before done"
+        true
+        (contains_substring ~needle:"action='start' before action='done'" schema.description);
       (match get_json_assoc "properties" schema.input_schema with
       | Some props ->
           Alcotest.(check bool) "has completion_contract" true


### PR DESCRIPTION
## Summary
- add a high-risk tool contract regression harness for repeated invalid call patterns
- align keeper task completion and transition guidance with schema-required fields and claim/start/done lifecycle
- remove stale board-post guidance that incorrectly treated optional hearth as required

## Why
Recent runtime analysis showed many failures were valid tool invocations with invalid arguments or stale prompt guidance, especially around Execute shape, keeper_task_done, keeper_board_post_get, and masc_transition lifecycle usage.

## Keeper lifecycle safety
This PR does not touch keeper process lifecycle, supervisor, pause, stop, autoboot, or fleet-control runtime paths. The transition changes are task-board lifecycle guidance only: claim -> start -> work -> done.

## Validation
- scripts/dune-local.sh build test/test_tool_input_validation.exe test/test_mcp_server_eio_tool_profile_capability.exe test/test_tools_coverage.exe
- _build/default/test/test_tool_input_validation.exe: 74 tests passed
- _build/default/test/test_mcp_server_eio_tool_profile_capability.exe: 6 tests passed
- git diff --check
