### PR TITLE
fix(keeper-chat): re-land live text-delta streaming with a typed guard

### DIFF
--- a/lib/server/keeper_stream_text_accum.ml
+++ b/lib/server/keeper_stream_text_accum.ml
@@ -1,0 +1,14 @@
+type t =
+  { buf : Buffer.t
+  ; mutable live_emitted : bool
+  }
+
+let create () = { buf = Buffer.create 256; live_emitted = false }
+
+let on_delta t ~redact text =
+  Buffer.add_string t.buf text;
+  t.live_emitted <- true;
+  redact text
+
+let streamed_text t = Buffer.contents t.buf
+let suppress_terminal_resend t = t.live_emitted

--- a/lib/server/keeper_stream_text_accum.mli
+++ b/lib/server/keeper_stream_text_accum.mli
@@ -1,0 +1,33 @@
+(** Keeper_stream_text_accum — text-delta policy for the keeper chat stream.
+
+    Owns the invariant that model text reaches the live view exactly once:
+    every delta is redacted and emitted as it arrives, and the terminal
+    full-reply chunk re-send fires only when no delta was emitted (the
+    empty-reply fallback path).
+
+    History (issue #20907): #20825 buffered deltas for redaction and removed
+    token streaming; #20854 restored live emission; #20869 removed it again
+    inside an unrelated test PR. The decision lives here as a typed unit with
+    tests (test/test_keeper_stream_text_accum.ml) so the next removal has to
+    delete a module and its tests instead of two inline lines. *)
+
+type t
+
+val create : unit -> t
+
+(** [on_delta t ~redact text] records the raw [text] for the terminal
+    fallback, marks the stream as live-emitted, and returns the redacted
+    chunk that the caller must publish immediately. A pattern that spans a
+    delta boundary can escape the live view; the persisted turn and the
+    terminal reply still pass through full-text redaction, so the durable
+    record stays clean. *)
+val on_delta : t -> redact:(string -> string) -> string -> string
+
+(** Raw concatenation of every delta seen so far. Terminal visible-reply
+    fallback for an empty provider body; the caller applies full-text
+    redaction afterwards. *)
+val streamed_text : t -> string
+
+(** True once [on_delta] ran at least once: the terminal chunk re-send must
+    be suppressed so streamed text is not rendered twice. *)
+val suppress_terminal_resend : t -> bool

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -560,10 +560,13 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
       (if payload.attachments = [] then base_fields
        else ("attachments", `List (List.map attachment_json payload.attachments)) :: base_fields)
   in
-  (* Buffer model text deltas until the terminal payload arrives. This
-     avoids sending raw partial output before the full reply can pass
-     through keeper-scoped redaction. *)
-  let streamed_text = Buffer.create 256 in
+  (* Stream model text deltas live with per-delta redaction — the same
+     treatment ThinkingDelta and Tool_call_args already get in
+     [consume_worker_events]. The once-only invariant (live emit + terminal
+     re-send suppression + raw fallback) is owned by
+     [Keeper_stream_text_accum]; see its interface for the #20825/#20854/
+     #20869 history this guards against. *)
+  let text_accum = Keeper_stream_text_accum.create () in
   let worker_events = Eio.Stream.create 512 in
   let push_worker_event event =
     if not !closed then
@@ -750,7 +753,10 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
              Keeper_chat_events.publish events
                (Event_error { message = redact_text ("Timeout: " ^ reason) })
          | Agent_sdk.Types.ContentBlockDelta { delta = TextDelta text; _ } ->
-             Buffer.add_string streamed_text text
+             Keeper_chat_events.publish events
+               (Text_delta
+                  (Keeper_stream_text_accum.on_delta text_accum
+                     ~redact:redact_text text))
          | Agent_sdk.Types.ContentBlockDelta { delta = ThinkingDelta text; _ } ->
              Keeper_chat_events.publish events
                (Custom
@@ -778,7 +784,9 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
           let visible_reply =
             match String.trim visible_reply with
             | "" ->
-                let streamed = Buffer.contents streamed_text |> String.trim in
+                let streamed =
+                  Keeper_stream_text_accum.streamed_text text_accum |> String.trim
+                in
                 if streamed = "" then visible_reply else streamed
             | _ -> visible_reply
           in
@@ -786,7 +794,10 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
           let is_checkpoint =
             is_continuation_checkpoint_reply visible_reply
           in
-          if not is_checkpoint then
+          if
+            (not is_checkpoint)
+            && not (Keeper_stream_text_accum.suppress_terminal_resend text_accum)
+          then
             split_keeper_reply_chunks visible_reply
             |> List.iter (fun chunk ->
                    Keeper_chat_events.publish events (Text_delta chunk));

--- a/test/dune
+++ b/test/dune
@@ -256,6 +256,7 @@
   test_keeper_retrieval_quality
   test_observability_redact
   test_keeper_tool_call_sse_io_preview
+  test_keeper_stream_text_accum
   test_keeper_tool_descriptor_registry_integrity
   test_voice_command_descriptor_parity
   test_disk_hygiene_script
@@ -532,6 +533,7 @@
   test_keeper_retrieval_quality
   test_observability_redact
   test_keeper_tool_call_sse_io_preview
+  test_keeper_stream_text_accum
   test_keeper_tool_descriptor_registry_integrity
   test_voice_command_descriptor_parity
   test_disk_hygiene_script

--- a/test/test_keeper_stream_text_accum.ml
+++ b/test/test_keeper_stream_text_accum.ml
@@ -1,0 +1,48 @@
+(** test_keeper_stream_text_accum — behavioral guard for issue #20907.
+
+    Pins the keeper chat text-delta policy: deltas are emitted live with
+    per-delta redaction, the terminal full-reply re-send fires only when
+    nothing was streamed, and the raw concatenation stays available as the
+    terminal empty-reply fallback. #20825 and #20869 both removed live
+    emission without any test failing; these tests make the next removal
+    visible. *)
+
+let test_fresh_accum_allows_terminal_resend () =
+  let t = Keeper_stream_text_accum.create () in
+  Alcotest.(check bool)
+    "no deltas → terminal re-send allowed" false
+    (Keeper_stream_text_accum.suppress_terminal_resend t);
+  Alcotest.(check string)
+    "fallback starts empty" ""
+    (Keeper_stream_text_accum.streamed_text t)
+
+let test_delta_emitted_live_with_per_delta_redaction () =
+  let t = Keeper_stream_text_accum.create () in
+  let redact s = "[r]" ^ s in
+  let chunk = Keeper_stream_text_accum.on_delta t ~redact "hello" in
+  Alcotest.(check string)
+    "live chunk passes through the per-delta redactor" "[r]hello" chunk;
+  Alcotest.(check bool)
+    "delta emitted → terminal re-send suppressed" true
+    (Keeper_stream_text_accum.suppress_terminal_resend t)
+
+let test_fallback_keeps_raw_concatenation_in_order () =
+  let t = Keeper_stream_text_accum.create () in
+  let redact = String.uppercase_ascii in
+  ignore (Keeper_stream_text_accum.on_delta t ~redact "ab");
+  ignore (Keeper_stream_text_accum.on_delta t ~redact "cd");
+  Alcotest.(check string)
+    "fallback is the raw (unredacted) concatenation in arrival order" "abcd"
+    (Keeper_stream_text_accum.streamed_text t)
+
+let () =
+  Alcotest.run "keeper_stream_text_accum"
+    [ ( "delta-policy"
+      , [ Alcotest.test_case "fresh accum allows terminal re-send" `Quick
+            test_fresh_accum_allows_terminal_resend
+        ; Alcotest.test_case "delta emitted live, redacted per delta" `Quick
+            test_delta_emitted_live_with_per_delta_redaction
+        ; Alcotest.test_case "terminal fallback keeps raw concatenation" `Quick
+            test_fallback_keeps_raw_concatenation_in_order
+        ] )
+    ]


### PR DESCRIPTION
## 목적
Closes #20907 — keeper chat 토큰 스트리밍 3단 회귀의 re-land + 재발 가드.

## 배경 (`git log -S deltas_sent`)
| 커밋 | 내용 |
|---|---|
| #20825 `2d4746adc` | redaction 위해 TextDelta 버퍼링 → 토큰 스트리밍 사망 |
| #20854 `ea19a15fb` | per-delta redaction으로 라이브 발행 복원 |
| #20869 `6f5bfdeb2` | test(otel) 제목 PR이 복원분을 통째로 제거 — silent revert |

#20854와 #20869가 같은 트레이드오프(경계 걸친 패턴의 redaction)에서 반대 결정을 내리며 flip-flop. 운영자 확정 방향은 라이브 스트리밍: 경계 걸친 패턴은 영속 턴/터미널 reply의 full-text redaction이 커버한다 (#20854 원래 설계).

## 변경
- `lib/server/keeper_stream_text_accum.ml(i)` **신규**: once-only invariant(라이브 발행 + 터미널 재전송 억제 + raw empty-reply fallback)를 typed 모듈로 소유. 다음 제거 시도는 인라인 2줄이 아니라 모듈+테스트 삭제가 필요 → 리뷰에서 가시화.
- `server_routes_http_keeper_stream.ml`: TextDelta 케이스가 `on_delta`(버퍼 기록 + redact 반환)를 거쳐 즉시 publish. 터미널 chunk 재전송은 `suppress_terminal_resend`로 억제.
- `test/test_keeper_stream_text_accum.ml` **신규** (3 cases): 라이브 발행 + per-delta redaction 적용, delta 존재 시 터미널 재전송 억제, fallback은 raw 누적 유지.

## 검증
- `dune build --root . lib/server/ test/test_keeper_stream_text_accum.exe` green
- `dune exec test/test_keeper_stream_text_accum.exe` → 3/3 OK
- pre-commit full build 통과

## 미검증
- 실제 SSE 대시보드 e2e (서버 재시작 필요 — 머지 후 재배포 시 확인)

RFC-WAIVED: 회귀 re-land (원 설계 #20854 복원 + 테스트 가드 추가). 신규 설계 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
