### PR TITLE
fix(keeper-memory): token-AND matching for keeper_memory_search

### DIFF
--- a/lib/core/string_util.ml
+++ b/lib/core/string_util.ml
@@ -98,6 +98,40 @@ let starts_with_ci ~prefix s =
     in
     match_at 0
 
+(* Whitespace tokenization for free-text queries.  ASCII whitespace
+   only; multibyte text passes through opaquely so UTF-8 tokens stay
+   intact. *)
+let is_ascii_space = function
+  | ' ' | '\t' | '\n' | '\r' -> true
+  | _ -> false
+
+let query_tokens query =
+  let buf = Buffer.create 16 in
+  let out = ref [] in
+  let flush () =
+    if Buffer.length buf > 0
+    then begin
+      out := Buffer.contents buf :: !out;
+      Buffer.clear buf
+    end
+  in
+  String.iter
+    (fun c -> if is_ascii_space c then flush () else Buffer.add_char buf c)
+    query;
+  flush ();
+  List.rev !out
+
+(* Token-AND containment: every whitespace-separated token of [query]
+   must appear in [haystack] as a case-insensitive substring, in any
+   order with arbitrary gaps ("갑오징어 ... 소주" matches the query
+   "소주 갑오징어").  Agglutinative suffixes are covered by substring
+   matching ("소주를" contains "소주").  A query with no tokens yields
+   [false], matching [contains_substring_ci]'s empty-needle behavior. *)
+let contains_all_tokens_ci haystack query =
+  match query_tokens query with
+  | [] -> false
+  | tokens -> List.for_all (contains_substring_ci haystack) tokens
+
 (* ASCII case-insensitive equality.  No allocation; equivalent to
    [String.lowercase_ascii a = String.lowercase_ascii b] but
    short-circuits on length and on first mismatching byte. *)

--- a/lib/core/string_util.mli
+++ b/lib/core/string_util.mli
@@ -20,6 +20,18 @@ val string_contains_substring_ci : needle:string -> string -> bool
     [string_contains_substring_ci ~needle haystack] is equivalent to
     [contains_substring_ci haystack needle]. *)
 
+val query_tokens : string -> string list
+(** [query_tokens query] splits a free-text query on ASCII whitespace
+    (space, tab, CR, LF) into non-empty tokens. UTF-8 bytes pass
+    through opaquely. *)
+
+val contains_all_tokens_ci : string -> string -> bool
+(** [contains_all_tokens_ci haystack query] — token-AND containment:
+    every token of [query_tokens query] appears in [haystack] as a
+    case-insensitive substring, in any order. A query with no tokens
+    yields [false], matching [contains_substring_ci]'s empty-needle
+    behavior. *)
+
 val starts_with_ci : prefix:string -> string -> bool
 (** [starts_with_ci ~prefix s] is the ASCII case-insensitive variant of
     [String.starts_with]. Performs no allocation; lowercases each byte

--- a/lib/keeper/keeper_tool_memory_runtime.ml
+++ b/lib/keeper/keeper_tool_memory_runtime.ml
@@ -176,11 +176,13 @@ let search_memory_bank
     then parsed
     else List.filter (fun m -> String_util.equals_ci m.kind kind_filter) parsed
   in
-  (* Text match: query against text field (non-deterministic data) *)
+  (* Text match: query against text field (non-deterministic data).
+     Token-AND, not whole-query substring — "소주 갑오징어" must match a
+     note containing both words in any order (issue #20908). *)
   let matched =
     if query = ""
     then filtered
-    else List.filter (fun m -> String_util.contains_substring_ci m.text query) filtered
+    else List.filter (fun m -> String_util.contains_all_tokens_ci m.text query) filtered
   in
   (* Scoring: priority * recency_weight.
      recency_weight normalizes age relative to the oldest note in the result set.
@@ -309,7 +311,7 @@ let search_history
     @ fst (dedup (snd (dedup seen0 current_history)) prev_history)
   in
   all_candidates
-  |> List.filter (fun msg -> query <> "" && String_util.contains_substring_ci msg query)
+  |> List.filter (fun msg -> query <> "" && String_util.contains_all_tokens_ci msg query)
   |> List.rev
   |> take limit
 ;;

--- a/test/test_string_util.ml
+++ b/test/test_string_util.ml
@@ -217,6 +217,40 @@ let test_contains_substring_ci_empty_and_literal () =
   check bool "regex wildcard is not magic" false
     (SU.contains_substring_ci "literal abc needle" ".*")
 
+(* ---- query_tokens / contains_all_tokens_ci ---- *)
+
+(* Regression fixture (issue #20908): the memory bank note contained both
+   words in reverse order with text in between; whole-query substring
+   matching returned 0 matches for the query "소주 갑오징어". *)
+let memory_note = "갑오징어 레시피 정리, 소주 얘기가 계속 살아있는 이유"
+
+let test_query_tokens_basic () =
+  check (list string) "splits on spaces" [ "소주"; "갑오징어" ]
+    (SU.query_tokens "소주 갑오징어");
+  check (list string) "collapses runs and mixed whitespace" [ "a"; "b"; "c" ]
+    (SU.query_tokens "  a\tb\n c\r\n");
+  check (list string) "empty query has no tokens" [] (SU.query_tokens "");
+  check (list string) "whitespace-only query has no tokens" []
+    (SU.query_tokens " \t\n")
+
+let test_contains_all_tokens_ci_order_independent () =
+  check bool "tokens match in any order with gaps" true
+    (SU.contains_all_tokens_ci memory_note "소주 갑오징어");
+  check bool "single token still matches" true
+    (SU.contains_all_tokens_ci memory_note "갑오징어");
+  check bool "agglutinative suffix covered by substring" true
+    (SU.contains_all_tokens_ci "어제 소주를 마셨다" "소주");
+  check bool "one absent token fails the AND" false
+    (SU.contains_all_tokens_ci memory_note "소주 맥주")
+
+let test_contains_all_tokens_ci_ascii_ci_and_empty () =
+  check bool "ASCII tokens are case-insensitive" true
+    (SU.contains_all_tokens_ci "Keeper Board POST" "board KEEPER");
+  check bool "no tokens yields false like empty needle" false
+    (SU.contains_all_tokens_ci "abc" "");
+  check bool "whitespace-only query yields false" false
+    (SU.contains_all_tokens_ci "abc" "  \t")
+
 let test_starts_with_ci_basic () =
   check bool "exact case" true
     (SU.starts_with_ci ~prefix:"Bearer " "Bearer abc123");
@@ -313,6 +347,12 @@ let () =
         [ test_case "ASCII" `Quick test_contains_substring_ci_ascii;
           test_case "empty and literal" `Quick
             test_contains_substring_ci_empty_and_literal ] );
+      ( "contains_all_tokens_ci",
+        [ test_case "query_tokens basic" `Quick test_query_tokens_basic;
+          test_case "order-independent token AND" `Quick
+            test_contains_all_tokens_ci_order_independent;
+          test_case "ASCII ci and empty query" `Quick
+            test_contains_all_tokens_ci_ascii_ci_and_empty ] );
       ( "starts_with_ci",
         [ test_case "basic" `Quick test_starts_with_ci_basic;
           test_case "boundaries" `Quick test_starts_with_ci_boundaries ] );


### PR DESCRIPTION
## 목적
Closes #20908 — `keeper_memory_search`의 매칭 단위 교정 (whole-query substring → token-AND).

## 증상
`{query: "소주 갑오징어"}` → `total_candidates:60, match_count:0`. 데이터는 존재 (`sangsu.memory.jsonl`에 소주 4행·갑오징어 1행, 같은 행에 공존하나 어순 반대) — recall failure.

## 원인
`keeper_tool_memory_runtime.ml:183`이 쿼리 **전체**를 단일 case-insensitive 바이트 substring으로 대조. "소주 갑오징어"(공백 포함 13바이트 연속 시퀀스)가 그대로 있어야만 매치.

## 변경
- `String_util.query_tokens`: ASCII whitespace 분리, 비어있지 않은 토큰 리스트 파싱 (UTF-8 바이트는 불투명 통과)
- `String_util.contains_all_tokens_ci`: 모든 토큰이 각각 substring 매치돼야 통과 (token-AND, 순서 무관). 토큰 없음 → `false` (`contains_substring_ci` empty-needle 의미론과 일치)
- 호출 사이트 2곳 교체: 메모리뱅크 검색(183) + 컨텍스트 히스토리 검색(314)
- 한국어 교착어 특성상 조사("소주를" ⊃ "소주")는 단어경계 없는 substring으로 커버

## 검증
- `dune build --root . lib/core/ lib/keeper/ test/test_string_util.exe` green
- `test_string_util` 34/34 OK — 사용자가 겪은 정확한 케이스("갑오징어 …, 소주 …" 노트 vs "소주 갑오징어" 쿼리)를 회귀 픽스처로 포함

## 미검증
- 라이브 keeper 대상 e2e (재배포 후 동일 쿼리 재실행으로 확인 가능)

RFC-WAIVED: 매칭 단위의 버그 수정 (분류기 추가 아님, 닫힌 함수 2개 + exhaustive 테스트). 신규 설계 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
