### PR TITLE
feat(keeper): RFC-0232 P2 — producer-typed turn outcome replaces checkpoint prefix sniff

### DIFF
--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -111,8 +111,6 @@ const TERMINAL_QUEUED_KEEPER_MESSAGE_STATUSES = new Set<QueuedKeeperMessageStatu
   'cancelled',
 ])
 
-const CONTINUATION_CHECKPOINT_PREFIX = 'Continuation checkpoint saved;'
-
 function normalizeQueuedKeeperMessageStatus(value: unknown): QueuedKeeperMessageStatus {
   switch (asString(value, '').trim()) {
     case 'queued':
@@ -184,10 +182,6 @@ function parseQueuedKeeperMessageCancelResult(data: unknown): QueuedKeeperMessag
 
 export function isTerminalQueuedKeeperMessage(result: QueuedKeeperMessageResult): boolean {
   return TERMINAL_QUEUED_KEEPER_MESSAGE_STATUSES.has(result.status)
-}
-
-export function isKeeperContinuationCheckpointText(text: string): boolean {
-  return text.trim().startsWith(CONTINUATION_CHECKPOINT_PREFIX)
 }
 
 // Server no longer enforces an external timeout for keeper_msg.

--- a/dashboard/src/keeper-message.ts
+++ b/dashboard/src/keeper-message.ts
@@ -1,5 +1,5 @@
 import { asNumber, asString, isRecord } from './components/common/normalize'
-import type { KeeperConversationDetails } from './types'
+import type { KeeperConversationDetails, KeeperTurnOutcome } from './types'
 
 const STATE_START = '[STATE]'
 const STATE_END = '[/STATE]'
@@ -41,6 +41,21 @@ export function formatKeeperVisibleReply(reply: string): string {
   return withoutState.replace(/\n{3,}/g, '\n\n').trim()
 }
 
+// RFC-0232 P2: closed decode of the producer-typed `turn_outcome` label.
+// Missing field (older server) or unknown label decodes to null, which
+// consumers treat as a visible reply — the bitten failure mode (#20870)
+// was a reply silently dropped, so decode failure fails toward showing.
+function normalizeKeeperTurnOutcome(value: unknown): KeeperTurnOutcome | null {
+  switch (asString(value, '').trim()) {
+    case 'visible_reply':
+      return 'visible_reply'
+    case 'continuation_checkpoint':
+      return 'continuation_checkpoint'
+    default:
+      return null
+  }
+}
+
 export function normalizeKeeperConversationDetails(raw: unknown): KeeperConversationDetails | null {
   const payload = (() => {
     if (!isRecord(raw)) return null
@@ -70,6 +85,7 @@ export function normalizeKeeperConversationDetails(raw: unknown): KeeperConversa
     skillReason: asString(payload.skill_reason) ?? null,
     stateBlock,
     replyText: reply || null,
+    turnOutcome: normalizeKeeperTurnOutcome(payload.turn_outcome),
     rawPayload: payload,
   }
 }

--- a/dashboard/src/keeper-stream.test.ts
+++ b/dashboard/src/keeper-stream.test.ts
@@ -94,7 +94,27 @@ describe('applyKeeperStreamEvent', () => {
     expect(entry?.text).toBe('Keeper request failed: Timeout after 630.0s')
   })
 
-  it('does not render continuation checkpoint text as a chat reply', () => {
+  // RFC-0232 P2: the checkpoint distinction rides the producer-typed
+  // `turn_outcome` field, not the reply text.
+  it('does not render a declared continuation checkpoint as a chat reply', () => {
+    assistantEntry()
+    expect(applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_REPLY_DETAILS',
+      value: {
+        reply: 'Continuation checkpoint saved; keeper remains scheduled for the next cycle.',
+        turn_outcome: 'continuation_checkpoint',
+      },
+    })).toBeNull()
+
+    const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
+    expect(entry?.text).toBe('')
+    expect(entry?.rawText).toBe('Continuation checkpoint saved; keeper remains scheduled for the next cycle.')
+    expect(entry?.delivery).toBe('queued')
+    expect(entry?.streamState).toBeNull()
+  })
+
+  it('renders checkpoint-shaped text as a reply when not declared a checkpoint', () => {
     assistantEntry()
     expect(applyKeeperStreamEvent('sangsu', 'reply-1', {
       type: 'CUSTOM',
@@ -105,10 +125,24 @@ describe('applyKeeperStreamEvent', () => {
     })).toBeNull()
 
     const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
+    expect(entry?.text).toBe('Continuation checkpoint saved; keeper remains scheduled for the next cycle.')
+    expect(entry?.delivery).toBe('sending')
+  })
+
+  it('suppresses a declared checkpoint regardless of reply text', () => {
+    assistantEntry()
+    expect(applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_REPLY_DETAILS',
+      value: {
+        reply: '작업을 완료했습니다.',
+        turn_outcome: 'continuation_checkpoint',
+      },
+    })).toBeNull()
+
+    const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
     expect(entry?.text).toBe('')
-    expect(entry?.rawText).toBe('Continuation checkpoint saved; keeper remains scheduled for the next cycle.')
     expect(entry?.delivery).toBe('queued')
-    expect(entry?.streamState).toBeNull()
   })
 
   it('extracts error messages from events', () => {

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -15,8 +15,6 @@ import {
 } from './keeper-state'
 import { isRecord, asString } from './components/common/normalize'
 
-const CONTINUATION_CHECKPOINT_PREFIX = 'Continuation checkpoint saved;'
-
 // Most recent TOOL_CALL_START id per keeper — fallback target for
 // TOOL_CALL_ARGS / TOOL_CALL_END events that omit toolCallId.
 const lastToolCallIds = new Map<string, string>()
@@ -157,7 +155,7 @@ export function applyKeeperStreamEvent(
         if (details) {
           updateThreadEntry(keeperName, assistantEntryId, entry => {
             const rawText = details.replyText ?? entry.rawText ?? entry.text
-            if (rawText.trim().startsWith(CONTINUATION_CHECKPOINT_PREFIX)) {
+            if (details.turnOutcome === 'continuation_checkpoint') {
               return {
                 ...entry,
                 details,

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -707,6 +707,11 @@ interface KeeperConversationUsage {
   totalTokens?: number | null
 }
 
+// RFC-0232 P2: producer-typed turn outcome carried in the reply payload
+// (`turn_outcome`). `continuation_checkpoint` marks the synthetic
+// resume-next-cycle notice; everything else is model output.
+export type KeeperTurnOutcome = 'visible_reply' | 'continuation_checkpoint'
+
 export interface KeeperConversationDetails {
   traceId?: string | null
   generation?: number | null
@@ -718,6 +723,7 @@ export interface KeeperConversationDetails {
   skillReason?: string | null
   stateBlock?: string | null
   replyText?: string | null
+  turnOutcome?: KeeperTurnOutcome | null
   rawPayload?: unknown
 }
 

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -505,30 +505,22 @@ let resolve_keeper_name_config ~(config : Workspace.config) args =
 let resolve_keeper_name ctx args =
   resolve_keeper_name_config ~config:ctx.config args
 
-let has_string_prefix ~prefix value =
-  let prefix_len = String.length prefix in
-  String.length value >= prefix_len
-  && String.equal (String.sub value 0 prefix_len) prefix
-;;
-
-let continuation_checkpoint_prefix = "Continuation checkpoint saved;"
-
 let direct_reply_visible_text body =
   try
     let json = Yojson.Safe.from_string body in
-    match Json_util.get_string json "reply" with
-    | None -> None
-    | Some reply ->
-        let visible =
-          reply
-          |> Keeper_skill_routing.strip_skill_route_lines
-          |> Keeper_execution.strip_state_blocks_text
-          |> String.trim
-        in
-        if visible = ""
-           || has_string_prefix ~prefix:continuation_checkpoint_prefix visible
-        then None
-        else Some visible
+    match Keeper_turn_outcome.of_reply_payload (Some json) with
+    | Keeper_turn_outcome.Continuation_checkpoint -> None
+    | Keeper_turn_outcome.Visible_reply -> (
+        match Json_util.get_string json "reply" with
+        | None -> None
+        | Some reply ->
+            let visible =
+              reply
+              |> Keeper_skill_routing.strip_skill_route_lines
+              |> Keeper_execution.strip_state_blocks_text
+              |> String.trim
+            in
+            if visible = "" then None else Some visible)
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | Yojson.Json_error _ -> None

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -686,6 +686,11 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ctx args : tool_result
                 in
                 `Assoc [
                   ("reply", `String result.response_text);
+                  ( Keeper_turn_outcome.wire_key,
+                    `String
+                      (Keeper_turn_outcome.to_label
+                         (Keeper_turn_outcome.of_stop_reason
+                            result.stop_reason)) );
                   ("model", `String surface_model_used);
                   ("model_used_raw", `String surface_model_used);
                   ("turns", `Int result.turn_count);

--- a/lib/keeper/keeper_turn_outcome.ml
+++ b/lib/keeper/keeper_turn_outcome.ml
@@ -1,0 +1,50 @@
+(** RFC-0232 P2 — producer-typed turn outcome.  See the interface for
+    the contract; this module is the single mapping site from
+    {!Runtime_agent.stop_reason} to the reply-surface outcome. *)
+
+type t =
+  | Visible_reply
+  | Continuation_checkpoint
+
+let equal a b =
+  match (a, b) with
+  | Visible_reply, Visible_reply
+  | Continuation_checkpoint, Continuation_checkpoint ->
+      true
+  | (Visible_reply | Continuation_checkpoint), _ -> false
+
+let to_label = function
+  | Visible_reply -> "visible_reply"
+  | Continuation_checkpoint -> "continuation_checkpoint"
+
+let of_label = function
+  | "visible_reply" -> Some Visible_reply
+  | "continuation_checkpoint" -> Some Continuation_checkpoint
+  | _ -> None
+
+let wire_key = "turn_outcome"
+
+let of_stop_reason = function
+  | Runtime_agent.Completed -> Visible_reply
+  | Runtime_agent.TurnBudgetExhausted _ -> Continuation_checkpoint
+  | Runtime_agent.MutationBoundaryReached _ -> Continuation_checkpoint
+
+let of_reply_payload payload =
+  match payload with
+  | None -> Visible_reply
+  | Some json -> (
+      match Json_util.get_string json wire_key with
+      | None -> Visible_reply
+      | Some label -> (
+          match of_label label with
+          | Some outcome -> outcome
+          | None ->
+              (* Unknown label: report, then fail toward persisting —
+                 the bitten failure mode (#20870) was silent
+                 non-persistence (watermark stall, keeper re-answering
+                 the same message).  Never widen [of_label] itself. *)
+              Log.Keeper.warn
+                "turn_outcome: unknown label %S; treating as \
+                 visible_reply"
+                label;
+              Visible_reply))

--- a/lib/keeper/keeper_turn_outcome.mli
+++ b/lib/keeper/keeper_turn_outcome.mli
@@ -1,0 +1,41 @@
+(** RFC-0232 P2 — producer-typed turn outcome.
+
+    The keeper reply payload declares at the write boundary whether its
+    [reply] text is model output ([Visible_reply]) or the synthetic
+    continuation notice substituted when a run stops at a budget /
+    mutation boundary ([Continuation_checkpoint]).  Consumers (lane
+    persistence, stream terminal, direct-reply surface, dashboard)
+    match on the decoded variant; the legacy
+    ["Continuation checkpoint saved;"] prefix sniff is deleted. *)
+
+type t =
+  | Visible_reply
+  | Continuation_checkpoint
+
+val equal : t -> t -> bool
+
+val to_label : t -> string
+(** Closed wire labels: ["visible_reply"] / ["continuation_checkpoint"]. *)
+
+val of_label : string -> t option
+(** Inverse of {!to_label}; [None] on any other string. *)
+
+val wire_key : string
+(** JSON field name carrying the label in the keeper reply payload:
+    ["turn_outcome"]. *)
+
+val of_stop_reason : Runtime_agent.stop_reason -> t
+(** [Completed] is the only stop reason whose reply text is model
+    output.  [TurnBudgetExhausted] replaces the reply with the synthetic
+    continuation notice ({!Runtime_agent} MaxTurnsExceeded arm);
+    [MutationBoundaryReached] shares the resume-next-cycle contract
+    (currently unreachable: no production caller passes
+    [exit_condition_result]). *)
+
+val of_reply_payload : Yojson.Safe.t option -> t
+(** Decode from a parsed keeper reply payload.  Absent payload, absent
+    field, or unknown label decodes to [Visible_reply] (unknown labels
+    are logged at WARN): the bitten failure mode (#20870) was a reply
+    silently {e not} persisted — the lane watermark stalled and the
+    keeper re-answered the same message — so decode failure must fail
+    toward persisting, never toward dropping. *)

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -701,6 +701,9 @@ let run
       let partial_response =
         partial_response_of_stop
           ~session_id
+          (* Display text only.  Checkpoint classification flows through
+             [stop_reason] → [Keeper_turn_outcome] (RFC-0232 P2); no
+             consumer may sniff this string. *)
           ~text:
             "Continuation checkpoint saved; keeper remains scheduled for the \
              next cycle."

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -293,11 +293,6 @@ let strip_keeper_visible_reply (reply : string) =
   |> Keeper_execution.strip_state_blocks_text
   |> String.trim
 
-let continuation_checkpoint_prefix = "Continuation checkpoint saved;"
-
-let is_continuation_checkpoint_reply text =
-  has_prefix ~prefix:continuation_checkpoint_prefix (String.trim text)
-
 let split_keeper_reply_chunks (text : string) : string list =
   let len = String.length text in
   if len = 0 then
@@ -669,8 +664,10 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
         in
         match dispatch_result with
         | Ok (true, body) ->
-            let _payload_json_opt, visible_reply = extract_visible_reply body in
-            if not (is_continuation_checkpoint_reply visible_reply) then begin
+            let payload_json_opt, visible_reply = extract_visible_reply body in
+            (match Keeper_turn_outcome.of_reply_payload payload_json_opt with
+            | Keeper_turn_outcome.Continuation_checkpoint -> ()
+            | Keeper_turn_outcome.Visible_reply ->
               Keeper_chat_store.append_turn
                 ~base_dir:base_path
                 ~keeper_name:payload.name
@@ -682,8 +679,7 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
                 ~assistant_content:visible_reply
                 ();
               Keeper_chat_broadcast.chat_appended
-                ~keeper_name:payload.name ~source:chat_source
-            end;
+                ~keeper_name:payload.name ~source:chat_source);
             push_worker_event (Stream_terminal (true, body));
             Tool_result.ok ~tool_name:"masc_keeper_msg" ~start_time body
         | Ok (false, err) ->
@@ -784,7 +780,9 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
           in
           let visible_reply = redact_text visible_reply in
           let is_checkpoint =
-            is_continuation_checkpoint_reply visible_reply
+            match Keeper_turn_outcome.of_reply_payload payload_json_opt with
+            | Keeper_turn_outcome.Continuation_checkpoint -> true
+            | Keeper_turn_outcome.Visible_reply -> false
           in
           if not is_checkpoint then
             split_keeper_reply_chunks visible_reply

--- a/test/dune
+++ b/test/dune
@@ -31,6 +31,7 @@
  (names
   test_keeper_reactive_wake_backlog_gate
   test_keeper_mention_scope
+  test_keeper_turn_outcome
   test_board_activity_cache
   test_jsonl_mtime_projection
   test_jsonl_incremental_projection
@@ -304,6 +305,7 @@
   test_env_keeper_scrub
   test_keeper_reactive_wake_backlog_gate
   test_keeper_mention_scope
+  test_keeper_turn_outcome
   test_board_activity_cache
   test_jsonl_mtime_projection
   test_jsonl_incremental_projection

--- a/test/test_keeper_turn_outcome.ml
+++ b/test/test_keeper_turn_outcome.ml
@@ -1,0 +1,136 @@
+(* RFC-0232 P2: producer-typed turn outcome.
+
+   The reply payload's [turn_outcome] field is the only carrier of the
+   checkpoint/visible distinction; the legacy "Continuation checkpoint
+   saved;" prefix sniff is deleted.  These tests pin:
+   - the closed label codec (round-trip, unknown -> None),
+   - the stop_reason -> outcome mapping (single mapping site),
+   - payload decode policy: absent/unknown fails toward Visible_reply
+     (the bitten failure mode, #20870, was silent non-persistence),
+   - prefix deadness: checkpoint-shaped reply TEXT alone never
+     classifies as a checkpoint. *)
+
+open Alcotest
+
+module TO = Masc.Keeper_turn_outcome
+module Ops = Masc.Keeper_tool_surface_ops
+
+let outcome : TO.t testable =
+  testable
+    (fun fmt t -> Format.pp_print_string fmt (TO.to_label t))
+    TO.equal
+
+let all = [ TO.Visible_reply; TO.Continuation_checkpoint ]
+
+let test_label_round_trip () =
+  List.iter
+    (fun t ->
+      check (option outcome) "of_label (to_label t) = Some t"
+        (Some t)
+        (TO.of_label (TO.to_label t)))
+    all
+
+let test_unknown_label_is_none () =
+  List.iter
+    (fun label ->
+      check (option outcome) label None (TO.of_label label))
+    [ ""; "completed"; "checkpoint"; "Visible_reply"; "VISIBLE_REPLY" ]
+
+let test_of_stop_reason () =
+  check outcome "completed -> visible" TO.Visible_reply
+    (TO.of_stop_reason Runtime_agent.Completed);
+  check outcome "budget exhausted -> checkpoint" TO.Continuation_checkpoint
+    (TO.of_stop_reason
+       (Runtime_agent.TurnBudgetExhausted { turns_used = 3; limit = 3 }));
+  check outcome "mutation boundary -> checkpoint" TO.Continuation_checkpoint
+    (TO.of_stop_reason
+       (Runtime_agent.MutationBoundaryReached
+          { turns_used = 2; tool_name = Some "masc_add_task" }))
+
+let payload fields = Some (`Assoc fields)
+
+let test_payload_decode () =
+  check outcome "no payload -> visible" TO.Visible_reply
+    (TO.of_reply_payload None);
+  check outcome "field absent -> visible" TO.Visible_reply
+    (TO.of_reply_payload (payload [ ("reply", `String "hi") ]));
+  check outcome "checkpoint label" TO.Continuation_checkpoint
+    (TO.of_reply_payload
+       (payload [ (TO.wire_key, `String "continuation_checkpoint") ]));
+  check outcome "visible label" TO.Visible_reply
+    (TO.of_reply_payload
+       (payload [ (TO.wire_key, `String "visible_reply") ]));
+  check outcome "unknown label -> visible (report-and-persist)"
+    TO.Visible_reply
+    (TO.of_reply_payload (payload [ (TO.wire_key, `String "deferred") ]))
+
+let checkpoint_text =
+  "Continuation checkpoint saved; keeper remains scheduled for the next \
+   cycle."
+
+(* The reply text no longer participates in classification: a reply that
+   *looks* like the synthetic notice but is declared visible stays
+   visible, and the declared checkpoint suppresses regardless of text. *)
+let test_prefix_is_dead () =
+  check outcome "checkpoint-shaped text, declared visible"
+    TO.Visible_reply
+    (TO.of_reply_payload
+       (payload
+          [ ("reply", `String checkpoint_text);
+            (TO.wire_key, `String "visible_reply")
+          ]));
+  check outcome "ordinary text, declared checkpoint"
+    TO.Continuation_checkpoint
+    (TO.of_reply_payload
+       (payload
+          [ ("reply", `String "all done");
+            (TO.wire_key, `String "continuation_checkpoint")
+          ]))
+
+let body fields = Yojson.Safe.to_string (`Assoc fields)
+
+let test_direct_reply_visible_text () =
+  check (option string) "declared checkpoint -> None" None
+    (Ops.direct_reply_visible_text
+       (body
+          [ ("reply", `String checkpoint_text);
+            ("turn_outcome", `String "continuation_checkpoint")
+          ]));
+  check (option string) "checkpoint-shaped text without field -> visible"
+    (Some checkpoint_text)
+    (Ops.direct_reply_visible_text
+       (body [ ("reply", `String checkpoint_text) ]));
+  check (option string) "declared visible -> reply text" (Some "all done")
+    (Ops.direct_reply_visible_text
+       (body
+          [ ("reply", `String "all done");
+            ("turn_outcome", `String "visible_reply")
+          ]));
+  check (option string) "empty reply -> None" None
+    (Ops.direct_reply_visible_text
+       (body
+          [ ("reply", `String "   ");
+            ("turn_outcome", `String "visible_reply")
+          ]))
+
+let () =
+  run "keeper_turn_outcome"
+    [
+      ( "codec",
+        [
+          test_case "label round trip" `Quick test_label_round_trip;
+          test_case "unknown label is None" `Quick test_unknown_label_is_none;
+        ] );
+      ( "mapping",
+        [ test_case "of_stop_reason" `Quick test_of_stop_reason ] );
+      ( "payload_decode",
+        [
+          test_case "decode policy" `Quick test_payload_decode;
+          test_case "prefix is dead" `Quick test_prefix_is_dead;
+        ] );
+      ( "direct_reply",
+        [
+          test_case "direct_reply_visible_text" `Quick
+            test_direct_reply_visible_text;
+        ] );
+    ]


### PR DESCRIPTION
## RFC-0232 P2 — producer-typed turn outcome

RFC: docs/rfc/RFC-0232-typed-lane-event-model.md §3.5 (#20877, Draft). P1(closed `Role.t` + positional watermark)은 #20896로 머지됨.

### 문제

`"Continuation checkpoint saved;"` prefix 문자열이 checkpoint/visible 구분의 유일한 운반자였고, 소비자 4곳이 각자 reply 텍스트를 sniff했다:

| 사이트 | 역할 |
|---|---|
| `server_routes_http_keeper_stream.ml` ×2 | lane 영속 게이트 + 스트림 터미널 분기 |
| `keeper_tool_surface_ops.ml` | direct-reply 표면 가시 텍스트 |
| `dashboard/src/keeper-stream.ts` | KEEPER_REPLY_DETAILS 렌더 분기 |
| `dashboard/src/api/keeper.ts` | `isKeeperContinuationCheckpointText` — **호출자 0, dead export** |

typed source는 이미 존재했다: `Runtime_agent.stop_reason`이 합성 텍스트를 만드는 *같은 match arm*에서 설정되어 `keeper_turn`까지 흐르는데, reply JSON에서 문자열로 붕괴되고 있었다.

### 변경

- **신규 `Keeper_turn_outcome`**: 닫힌 합 `Visible_reply | Continuation_checkpoint`, label codec, `stop_reason → outcome` 단일 매핑 사이트.
- **producer**: `keeper_turn` reply JSON에 `turn_outcome` 필드 — 쓰기 경계에서 한 번 선언.
- **소비자 4곳**: prefix sniff → 디코드된 variant match. prefix 상수/`is_continuation_checkpoint_reply`/`has_string_prefix`/dead export 전부 삭제. **string 분류기 추가가 아니라 제거.**
- **디코드 정책**: 필드 부재/미지 라벨 → WARN 로그 + `Visible_reply`. 실증된 failure mode(#20870)는 *조용한 미영속* → watermark 정지 → 같은 메시지 재응답이었으므로, 디코드 실패는 영속 쪽으로 fail한다.
- `MutationBoundaryReached → Continuation_checkpoint`: 동일한 resume-next-cycle 계약(`keeper_unified_turn_success` 로그가 증명)이고, `exit_condition_result`를 `Some`으로 넘기는 프로덕션 caller가 없어 현재 도달 불가 — 관찰 가능한 행동 변화 없음.
- `runtime_agent`의 합성 텍스트는 표시 전용으로 강등 (주석으로 고정).

### 검증

- `dune build @check` + default target 모두 EXIT=0 (worktree, base `685aa5fbb`)
- `test_keeper_turn_outcome` 6/6: codec 왕복, unknown→None, stop_reason 매핑, 디코드 정책, **prefix-deadness** (checkpoint 모양 텍스트 + `visible_reply` 선언 → visible; 평범한 텍스트 + checkpoint 선언 → 억제), `direct_reply_visible_text` 4케이스
- dashboard: `tsc --noEmit` 0 errors (v6.0.3, `./node_modules/.bin/tsc` 직접 실행), `keeper-stream.test.ts` 11/11 (선언된 checkpoint 억제 / 필드 없는 checkpoint 모양 텍스트는 visible 유지 / 텍스트 무관 억제), `keeper-message.test.ts` 50/50, eslint 0
- 잔존 prefix 참조 전수 감사: producer 표시 텍스트 1곳 + 테스트 픽스처만

### 호환성

- OCaml producer/consumer는 동일 바이너리 — 배포 후 skew 없음.
- 구버전 dashboard ↔ 신버전 서버: 필드 무시, 기존 동작 유지 아님 — 단 구 dashboard는 prefix sniff를 여전히 수행하므로 checkpoint 억제 동작 유지됨. 신 dashboard ↔ 구버전 서버: 필드 부재 → visible 취급 (위 디코드 정책).

후속: P3 (`Keeper_id.t`), P4 (boundary mention parse + backfill), P5 (`Surface_ref`).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
