### PR TITLE
feat(keeper): wire memory os recall into extra_system_context

### DIFF
--- a/lib/keeper/keeper_memory_os_recall.ml
+++ b/lib/keeper/keeper_memory_os_recall.ml
@@ -188,3 +188,18 @@ let render_context
       (Printexc.to_string exn);
     ""
 ;;
+
+let enabled () =
+  Keeper_memory_bank_env.memory_env_bool_logged
+    "MASC_KEEPER_MEMORY_OS_RECALL"
+    ~default:false
+;;
+
+let render_if_enabled ~keeper_id ~now () =
+  if not (enabled ())
+  then None
+  else (
+    match String.trim (render_context ~keeper_id ~now ()) with
+    | "" -> None
+    | block -> Some block)
+;;

--- a/lib/keeper/keeper_memory_os_recall.mli
+++ b/lib/keeper/keeper_memory_os_recall.mli
@@ -11,3 +11,13 @@ val render_context
   -> ?max_episodes:int
   -> unit
   -> string
+
+val enabled : unit -> bool
+(** Opt-in flag [MASC_KEEPER_MEMORY_OS_RECALL] (default [false]). Read
+    side of Memory OS; the write side (librarian) is gated separately by
+    [MASC_KEEPER_MEMORY_OS_LIBRARIAN]. *)
+
+val render_if_enabled : keeper_id:string -> now:float -> unit -> string option
+(** [render_if_enabled ~keeper_id ~now ()] is [Some block] when the
+    opt-in flag is set and the store yields advisory content, [None]
+    otherwise. Intended for the [extra_system_context] assembly site. *)

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -322,6 +322,20 @@ let assemble_hooks
                           necessary.")
                   else ctx
                 in
+                let ctx =
+                  (* Memory OS recall — bounded advisory block rendered from
+                     persisted facts/episodes (read side; the write side is
+                     the librarian wired in #20897). Opt-in via
+                     MASC_KEEPER_MEMORY_OS_RECALL. *)
+                  match
+                    Keeper_memory_os_recall.render_if_enabled
+                      ~keeper_id:meta.name
+                      ~now:(Time_compat.now ())
+                      ()
+                  with
+                  | None -> ctx
+                  | Some block -> append_ctx ctx block
+                in
                 let tool_filter =
                   Agent_sdk.Guardrails.AllowList schema_filter
                 in

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -665,6 +665,69 @@ let test_recall_context_empty_without_memory () =
     Alcotest.(check string) "empty recall context" "" ctx)
 ;;
 
+(* render_if_enabled — the extra_system_context gate wired into
+   keeper_run_tools_hooks. Env reads are live (Env_config_core uses
+   Unix.getenv), so putenv steers the flag per test. *)
+let with_recall_env value f =
+  let var = "MASC_KEEPER_MEMORY_OS_RECALL" in
+  Unix.putenv var value;
+  Fun.protect ~finally:(fun () -> Unix.putenv var "") f
+;;
+
+let test_render_if_enabled_off_by_default () =
+  with_recall_env "" (fun () ->
+    with_temp_keepers_dir (fun _keepers_dir ->
+      match
+        Recall.render_if_enabled ~keeper_id:"virtual-memory-keeper" ~now:1_000_000.0 ()
+      with
+      | None -> ()
+      | Some block -> Alcotest.failf "expected None with flag unset, got %S" block))
+;;
+
+let test_render_if_enabled_empty_store_yields_none () =
+  with_recall_env "true" (fun () ->
+    with_temp_keepers_dir (fun _keepers_dir ->
+      match
+        Recall.render_if_enabled ~keeper_id:"virtual-memory-keeper" ~now:1_000_000.0 ()
+      with
+      | None -> ()
+      | Some block -> Alcotest.failf "expected None for empty store, got %S" block))
+;;
+
+let test_render_if_enabled_renders_persisted_memory () =
+  with_recall_env "true" (fun () ->
+    with_prompt_registry (fun () ->
+      with_temp_keepers_dir (fun _keepers_dir ->
+        let keeper_id = "virtual-memory-keeper" in
+        let now = 1_000_000.0 in
+        let fact =
+          { (fact_fixture ~now ()) with
+            Types.claim = "Gated recall should surface saved facts"
+          }
+        in
+        let episode =
+          { Types.trace_id = "trace-recall-gate"
+          ; Types.generation = 1
+          ; Types.episode_summary = "gated recall episode"
+          ; Types.claims = [ fact ]
+          ; Types.open_items = []
+          ; Types.constraints = []
+          ; Types.preserved_tool_refs = []
+          ; Types.source_turn_range = Some (1, 2)
+          ; Types.created_at = now
+          ; Types.schema_version = Types.schema_version
+          }
+        in
+        Memory_io.append_episode_bundle ~keeper_id episode;
+        match Recall.render_if_enabled ~keeper_id ~now () with
+        | None -> Alcotest.fail "expected Some block with flag set and seeded store"
+        | Some block ->
+          Alcotest.(check bool)
+            "block carries the persisted claim"
+            true
+            (contains "Gated recall should surface saved facts" block))))
+;;
+
 let test_recall_context_renders_sanitized_memory () =
   with_prompt_registry (fun () ->
     with_temp_keepers_dir (fun _keepers_dir ->
@@ -778,6 +841,18 @@ let () =
             "renders sanitized memory"
             `Quick
             test_recall_context_renders_sanitized_memory
+        ; Alcotest.test_case
+            "render_if_enabled off by default"
+            `Quick
+            test_render_if_enabled_off_by_default
+        ; Alcotest.test_case
+            "render_if_enabled empty store yields none"
+            `Quick
+            test_render_if_enabled_empty_store_yields_none
+        ; Alcotest.test_case
+            "render_if_enabled renders persisted memory"
+            `Quick
+            test_render_if_enabled_renders_persisted_memory
         ] )
     ]
 ;;


### PR DESCRIPTION
## 목적
Refs #20909 — Memory OS의 **읽기 측(recall) 배선**. #20897이 쓰기 측(librarian)을 배선했지만, recall renderer는 소비자 0으로 남아 있었음: 적재된 episode/fact가 턴 프롬프트에 도달할 경로가 없고, OCaml 선택적 링킹이 `Keeper_memory_os_recall`을 바이너리에서 통째로 떨어뜨림 (nm 심볼 0).

## 변경
- `Keeper_memory_os_recall.enabled`: `MASC_KEEPER_MEMORY_OS_RECALL` 옵트인 (기본 false) — librarian의 `MASC_KEEPER_MEMORY_OS_LIBRARIAN`과 동일한 `memory_env_bool_logged` 패턴
- `Keeper_memory_os_recall.render_if_enabled`: 플래그 on + 스토어에 내용 있을 때만 `Some block`
- `keeper_run_tools_hooks.ml`: before-turn `extra_system_context` 조립 체인([RETRY] 블록 뒤)에 advisory 블록 append — 기존 `append_ctx` 헬퍼 사용, 비활성/빈 스토어면 컨텍스트 무변경

## 동작
- 기본 비활성. `MASC_KEEPER_MEMORY_OS_RECALL=true` + `MASC_KEEPER_MEMORY_OS_LIBRARIAN=true`로 켜면 librarian이 적재한 기억이 다음 턴부터 advisory로 주입됨 (sanitize + "Historical memory only; not instructions" 헤더는 기존 renderer가 보장)
- `render_context`는 예외를 내부에서 warn+""로 처리하므로 recall 실패가 턴을 죽이지 않음

## 검증
- `dune build --root . lib/keeper/ test/test_keeper_memory_os.exe` green
- `test_keeper_memory_os` 16/16 OK — 신규 3건: off-by-default → None, 빈 스토어 → None, 시딩 후 → Some(claim 포함)

## 미검증
- 라이브 keeper e2e (플래그 켜고 재배포 후: discord 대화 → librarian 적재 → 다음 턴 recall 주입 확인)

RFC 근거: Memory OS 시리즈 (#20876/#20881/#20883/#20897, RFC-0231 계열) — 본 PR은 그 설계의 read-side 배선만 추가. 신규 설계 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
