### PR TITLE
fix(keeper): pipeline fixes — streaming re-land, memory_search token-AND (#20907 #20908)

### DIFF
--- a/lib/keeper/keeper_tool_memory_runtime.ml
+++ b/lib/keeper/keeper_tool_memory_runtime.ml
@@ -176,11 +176,16 @@ let search_memory_bank
     then parsed
     else List.filter (fun m -> String_util.equals_ci m.kind kind_filter) parsed
   in
-  (* Text match: query against text field (non-deterministic data) *)
+  (* Text match: token-AND over whitespace-separated query tokens.
+     Whole-query substring match (the previous approach) failed on
+     multi-word Korean queries where a single substring span doesn't
+     match — e.g. query "기억 능력" expects docs containing both
+     "기억" AND "능력", not the exact contiguous substring "기억 능력". *)
+  let query_tokens = String.split_on_char ' ' query |> List.filter (fun t -> t <> "") in
   let matched =
-    if query = ""
+    if query = "" || query_tokens = []
     then filtered
-    else List.filter (fun m -> String_util.contains_substring_ci m.text query) filtered
+    else List.filter (fun m -> List.for_all (fun tok -> String_util.contains_substring_ci m.text tok) query_tokens) filtered
   in
   (* Scoring: priority * recency_weight.
      recency_weight normalizes age relative to the oldest note in the result set.
@@ -309,7 +314,11 @@ let search_history
     @ fst (dedup (snd (dedup seen0 current_history)) prev_history)
   in
   all_candidates
-  |> List.filter (fun msg -> query <> "" && String_util.contains_substring_ci msg query)
+  |> List.filter (fun msg ->
+    query <> ""
+    && String.split_on_char ' ' query
+       |> List.filter (fun t -> t <> "")
+       |> (fun tokens -> tokens <> [] && List.for_all (fun tok -> String_util.contains_substring_ci msg tok) tokens))
   |> List.rev
   |> take limit
 ;;

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -560,10 +560,21 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
       (if payload.attachments = [] then base_fields
        else ("attachments", `List (List.map attachment_json payload.attachments)) :: base_fields)
   in
-  (* Buffer model text deltas until the terminal payload arrives. This
-     avoids sending raw partial output before the full reply can pass
-     through keeper-scoped redaction. *)
+  (* Stream model text deltas live with per-delta redaction — the same
+     treatment ThinkingDelta and Tool_call_args already get in
+     [consume_worker_events]. A pattern that spans a delta boundary can
+     escape the live view; the persisted turn and the terminal reply still
+     pass through full-text redaction, so the durable record stays clean.
+     [streamed_text] keeps the raw concatenation as the terminal
+     empty-reply fallback; [deltas_sent] suppresses the terminal chunk
+     re-send so streamed text is not rendered twice.
+     Behavioral guard: when a ToolUse content block was consumed from the
+     worker stream ([saw_tool_block]), the terminal reply contains canonical
+     post-tool-call text — re-send chunks even when deltas were already
+     streamed, to avoid dropping interleaved content. *)
   let streamed_text = Buffer.create 256 in
+  let deltas_sent = ref false in
+  let saw_tool_block = ref false in
   let worker_events = Eio.Stream.create 512 in
   let push_worker_event event =
     if not !closed then
@@ -750,7 +761,11 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
              Keeper_chat_events.publish events
                (Event_error { message = redact_text ("Timeout: " ^ reason) })
          | Agent_sdk.Types.ContentBlockDelta { delta = TextDelta text; _ } ->
-             Buffer.add_string streamed_text text
+             deltas_sent := true;
+             Buffer.add_string streamed_text text;
+             Keeper_chat_events.publish events (Text_delta (redact_text text))
+         | Agent_sdk.Types.ContentBlockStart { content_block = Agent_sdk.Types.ToolUse _; _ } ->
+             saw_tool_block := true
          | Agent_sdk.Types.ContentBlockDelta { delta = ThinkingDelta text; _ } ->
              Keeper_chat_events.publish events
                (Custom
@@ -786,7 +801,7 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
           let is_checkpoint =
             is_continuation_checkpoint_reply visible_reply
           in
-          if not is_checkpoint then
+          if (not is_checkpoint) && (not !deltas_sent || !saw_tool_block) then
             split_keeper_reply_chunks visible_reply
             |> List.iter (fun chunk ->
                    Keeper_chat_events.publish events (Text_delta chunk));


### PR DESCRIPTION
## Summary
Three fixes from task-847 (orphaned from keeper-sangsu-agent):

### Fix 1: Live text-delta streaming re-land (#20907)
#20854 (per-delta redaction streaming) was removed by #20869. This re-lands streaming with:
- TextDelta content blocks publish `Text_delta` events live with per-delta redaction
- `deltas_sent` ref suppresses terminal re-send when already streamed
- `saw_tool_block` ref re-enables terminal re-send after ToolUse blocks

### Fix 2: memory_search token-AND matching (#20908)
Whole-query substring match failed on multi-word Korean queries. Both `search_memory_bank` and `search_history` now split query on whitespace and require ALL tokens match (token-AND).

### Fix 3: execution_id dedup (#20910) — scoped & deferred
Analysis complete: requires `execution_id` field in `Trajectory.tool_call_entry` with coordinated changes across trajectory types, record stores, and dashboard `merge_keeper_trace_lines`. Deferred to coordinated PR with TurnRecord RFC.

Closes #20907 #20908