### PR TITLE
fix(keeper_msg_async): reject `..`/`.` in is_safe_request_id (path traversal)

### DIFF
--- a/lib/keeper/keeper_msg_async.ml
+++ b/lib/keeper/keeper_msg_async.ml
@@ -47,6 +47,8 @@ let is_safe_request_id request_id =
   let len = String.length request_id in
   if len = 0
   then false
+  else if request_id = ".." || request_id = "."
+  then false
   else if len > max_request_id_len
   then false
   else (


### PR DESCRIPTION
## Summary

Rejects literal `".."` and `"."` request_id values in `is_safe_request_id` to prevent path traversal through `record_path` → `Filename.concat`.

## Background

Identified by @qa-king (PR #7 on `yousleepwhen/masc-mcp` fork), verified by @verifier and @qa-king in the code-review thread. The `is_safe_request_id` function allowed `'.'` as a valid character but did not block the literal strings `".."` or `"."`, allowing `poll("..")`, `gc_stale_disk("..")`, and `record_path` to construct filesystem paths above the intended base directory.

## Impact

CVSS 5.3 (Medium) — read-side path traversal via request_id. Attack requires ability to control or guess request_id values (internal attacker / SSRF scenario).

## Change

```diff
 let is_safe_request_id request_id =
   let len = String.length request_id in
   if len = 0
   then false
+  else if request_id = ".." || request_id = "."
+  then false
   else if len > max_request_id_len
   then false
```

Closes #20906 (dead-code thread discovery).