### PR TITLE
[codex] Externalize tool contract lifecycle guidance

### DIFF
--- a/config/prompts/tool_contract.task_lifecycle_rule.md
+++ b/config/prompts/tool_contract.task_lifecycle_rule.md
@@ -1,0 +1,5 @@
+---
+description: MASC task lifecycle rule shared by MCP tool schema descriptions
+category: tool_contract
+---
+For normal task work, claim first, then call action='start' before action='done'.

--- a/config/prompts/tool_contract.task_lifecycle_workflow.md
+++ b/config/prompts/tool_contract.task_lifecycle_workflow.md
@@ -1,0 +1,5 @@
+---
+description: MASC task lifecycle workflow shared by MCP profile instructions
+category: tool_contract
+---
+masc_status -> masc_transition(claim) -> masc_transition(start) -> work in a repo-local worktree -> masc_transition(done)

--- a/lib/dune
+++ b/lib/dune
@@ -249,6 +249,7 @@
   ;; leaf sub-library. The parent library still references those modules
   ;; unqualified, so it must depend on the leaf explicitly.
   masc.tool_types
+  masc.tool_contract_prompts
   ;; Shared leaf helpers extracted out of include_subdirs-unqualified ownership.
   masc.lockfree_atomic
   masc.json_field

--- a/lib/mcp_sdk_adapter_masc.ml
+++ b/lib/mcp_sdk_adapter_masc.ml
@@ -16,7 +16,7 @@ let handles_method method_ =
   List.mem method_ sdk_owned_methods
 
 let instructions_for_profile = function
-  | Full -> TP.default_instructions
+  | Full -> TP.default_instructions ()
   | Managed_agent -> TP.managed_agent_instructions
   | Operator_remote -> TP.operator_remote_instructions
 

--- a/lib/mcp_server_eio_protocol.ml
+++ b/lib/mcp_server_eio_protocol.ml
@@ -163,7 +163,7 @@ let handle_initialize_eio ?(profile = Full) id params =
              ; ( "instructions"
                , `String
                    (match profile with
-                    | Full -> TP.default_instructions
+                    | Full -> TP.default_instructions ()
                     | Managed_agent -> TP.managed_agent_instructions
                     | Operator_remote -> TP.operator_remote_instructions) )
              ; ( "_meta"
@@ -181,7 +181,7 @@ let handle_initialize_eio ?(profile = Full) id params =
 ;;
 
 let profile_instructions = function
-  | Full -> TP.default_instructions
+  | Full -> TP.default_instructions ()
   | Managed_agent -> TP.managed_agent_instructions
   | Operator_remote -> TP.operator_remote_instructions
 ;;

--- a/lib/mcp_server_eio_tool_profile.ml
+++ b/lib/mcp_server_eio_tool_profile.ml
@@ -52,16 +52,18 @@ let dedupe_tool_schemas_by_name (schemas : Masc_domain.tool_schema list) =
   in
   List.rev result
 
-let default_instructions =
-  "MASC (Multi-Agent Streaming Workspace) enables AI agent collaboration. \
+let default_instructions () =
+  Printf.sprintf
+    "MASC (Multi-Agent Streaming Workspace) enables AI agent collaboration. \
 PROJECT: Agents sharing the same base path (.masc/ folder) align together. \
 CLUSTER: Set MASC_CLUSTER_NAME for multi-machine workspace (otherwise tool surfaces use the configured cluster/default label). \
 READ: use resources/list + resources/read (status/tasks/agents/events/schema) for snapshots. \
 WRITE: prefer masc_transition (claim/start/done/cancel/release) with expected_version for CAS. \
-WORKFLOW: masc_status → masc_transition(claim) → masc_transition(start) → work in a repo-local worktree → masc_transition(done). \
+WORKFLOW: %s. \
 Use masc_heartbeat periodically; use @agent mentions in masc_broadcast. \
 Prefer worktrees for parallel work. \
 Use masc_tool_help to inspect tool contracts and prefer the smallest useful surface."
+    (Tool_contract_guidance.task_lifecycle_workflow ())
 
 let tool_schemas_for_profile ?(include_hidden = false)
     ?(include_agent_internal = false) _state

--- a/lib/mcp_server_eio_tool_profile.mli
+++ b/lib/mcp_server_eio_tool_profile.mli
@@ -44,10 +44,11 @@ type tool_profile = Mcp_server_eio_types.tool_profile =
     [initialize] response.  Operator-visible — drift in these
     strings changes how clients describe / discover the server. *)
 
-val default_instructions : string
-(** [Full] profile instructions.  Describes MASC project /
+val default_instructions : unit -> string
+(** [default_instructions ()] returns [Full] profile instructions. Describes MASC project /
     cluster / read / write conventions and points clients at
-    [masc_tool_help]. *)
+    [masc_tool_help]. Tool lifecycle prose is loaded from
+    [config/prompts/tool_contract.task_lifecycle_workflow.md]. *)
 
 val managed_agent_instructions : string
 (** [Managed_agent] profile instructions.  Names the canonical

--- a/lib/task/dune
+++ b/lib/task/dune
@@ -40,6 +40,7 @@
   masc_eio_context
   masc.masc_tool_dispatch
   masc.tool_types
+  masc.tool_contract_prompts
   masc.config_dir_resolver
   masc.prompt_registry
   masc_goal

--- a/lib/task/tool_task_schemas.ml
+++ b/lib/task/tool_task_schemas.ml
@@ -206,11 +206,12 @@ Tip: Look for status='todo' tasks to claim.";
       "Move a task through its lifecycle: claim, start, done, cancel, release, \
 submit_for_verification, approve, or reject. \
 Call when you pick up, finish, or abandon a task. Supports CAS via expected_version. \
-For normal task work, claim first, then call action='start' before action='done'. \
+%s \
 After %s or %s; pair with masc_deliver before action='done'. \
 Use submit_for_verification only for explicit review of a claimed/in_progress task you own; approve/reject for verifier actions. \
 Tasks created through %s complete via action='done' after LLM completion review; \
 they do not route normal completion through the verifier agent."
+      (Tool_contract_guidance.task_lifecycle_rule ())
       masc_add_task_name
       "keeper_task_claim"
       masc_add_task_name;

--- a/lib/tool_contract_prompts/dune
+++ b/lib/tool_contract_prompts/dune
@@ -1,0 +1,11 @@
+(include_subdirs no)
+
+(library
+ (name masc_tool_contract_prompts)
+ (public_name masc.tool_contract_prompts)
+ (wrapped false)
+ (modules tool_contract_guidance tool_contract_prompt_names)
+ (libraries
+  fs_compat
+  masc.config_dir_resolver
+  masc.prompt_registry))

--- a/lib/tool_contract_prompts/tool_contract_guidance.ml
+++ b/lib/tool_contract_prompts/tool_contract_guidance.ml
@@ -1,0 +1,111 @@
+(** Tool_contract_guidance — externalized tool-contract prose.
+
+    Contract prose lives under [config/prompts/] so operators can tune it
+    without editing OCaml string literals.  Resolution order:
+
+    1. Prompt_registry effective value, once startup has loaded prompt files or
+       overrides.
+    2. Active config prompt file resolved by Config_dir_resolver.
+    3. Checked-in seed prompt file found from the current working directory.
+
+    Missing content returns an explicit config-drift marker instead of a
+    stale in-code fallback. *)
+
+let strip_frontmatter content =
+  let lines = String.split_on_char '\n' content in
+  match lines with
+  | first :: rest when String.trim first = "---" ->
+    let rec drop_until_close = function
+      | [] -> None
+      | line :: remaining when String.trim line = "---" -> Some remaining
+      | _ :: remaining -> drop_until_close remaining
+    in
+    (match drop_until_close rest with
+     | Some ("" :: body_lines) -> String.concat "\n" body_lines
+     | Some body_lines -> String.concat "\n" body_lines
+     | None -> content)
+  | _ -> content
+;;
+
+let read_prompt_file path =
+  try
+    if Sys.file_exists path && not (Sys.is_directory path)
+    then
+      let text = Fs_compat.load_file path |> strip_frontmatter |> String.trim in
+      if String.equal text "" then None else Some text
+    else None
+  with
+  | Sys_error _ -> None
+;;
+
+let prompt_filename key = key ^ ".md"
+
+let prompt_path_in_dir dir key =
+  Filename.concat dir (prompt_filename key)
+;;
+
+let rec find_seed_prompt_from dir key hops =
+  if hops > 8
+  then None
+  else
+    let candidate =
+      Filename.concat (Filename.concat dir "config/prompts") (prompt_filename key)
+    in
+    if Sys.file_exists candidate
+    then Some candidate
+    else
+      let parent = Filename.dirname dir in
+      if String.equal parent dir
+      then None
+      else find_seed_prompt_from parent key (hops + 1)
+;;
+
+let seed_prompt_path key =
+  let cwd_candidate = find_seed_prompt_from (Sys.getcwd ()) key 0 in
+  match cwd_candidate with
+  | Some _ as path -> path
+  | None ->
+    let exe_dir = Filename.dirname Sys.executable_name in
+    find_seed_prompt_from exe_dir key 0
+;;
+
+let registry_prompt key =
+  let value = Prompt_registry.get_prompt key |> String.trim in
+  if String.equal value "" then None else Some value
+;;
+
+let active_config_prompt key =
+  Config_dir_resolver.prompts_dir ()
+  |> fun dir -> prompt_path_in_dir dir key
+  |> read_prompt_file
+;;
+
+let seed_prompt key =
+  match seed_prompt_path key with
+  | None -> None
+  | Some path -> read_prompt_file path
+;;
+
+let missing_marker key =
+  Printf.sprintf "[Tool contract config drift: missing %s.md]" key
+;;
+
+let prompt_text key =
+  match registry_prompt key with
+  | Some text -> text
+  | None ->
+    (match active_config_prompt key with
+     | Some text -> text
+     | None ->
+       (match seed_prompt key with
+        | Some text -> text
+        | None -> missing_marker key))
+;;
+
+let task_lifecycle_rule () =
+  prompt_text Tool_contract_prompt_names.task_lifecycle_rule
+;;
+
+let task_lifecycle_workflow () =
+  prompt_text Tool_contract_prompt_names.task_lifecycle_workflow
+;;

--- a/lib/tool_contract_prompts/tool_contract_guidance.mli
+++ b/lib/tool_contract_prompts/tool_contract_guidance.mli
@@ -1,0 +1,7 @@
+(** Externalized tool-contract guidance fragments. *)
+
+val task_lifecycle_rule : unit -> string
+(** Rule text for [masc_transition] schema descriptions. *)
+
+val task_lifecycle_workflow : unit -> string
+(** Workflow text for MCP profile instructions. *)

--- a/lib/tool_contract_prompts/tool_contract_prompt_names.ml
+++ b/lib/tool_contract_prompts/tool_contract_prompt_names.ml
@@ -1,0 +1,8 @@
+(** Tool_contract_prompt_names — SSOT for tool-contract prompt keys.
+
+    These keys identify operator-managed prompt fragments under
+    [config/prompts/] that are shared by MCP profile instructions and
+    MCP tool schema descriptions. *)
+
+let task_lifecycle_rule = "tool_contract.task_lifecycle_rule"
+let task_lifecycle_workflow = "tool_contract.task_lifecycle_workflow"

--- a/lib/tool_contract_prompts/tool_contract_prompt_names.mli
+++ b/lib/tool_contract_prompts/tool_contract_prompt_names.mli
@@ -1,0 +1,7 @@
+(** Tool-contract prompt keys under [config/prompts/]. *)
+
+val task_lifecycle_rule : string
+(** Short rule text for task tool schema descriptions. *)
+
+val task_lifecycle_workflow : string
+(** Workflow text for MCP profile instructions. *)

--- a/test/deps/dune
+++ b/test/deps/dune
@@ -172,6 +172,7 @@
   ;; Phase 2 / LANE 6). Re-export so test code using bare Tool_spec.X /
   ;; Tool_capability.X / Tool_shard_types*.X / Board_tool.X etc. resolves.
   (re_export masc.masc_tool_surface)
+  (re_export masc.tool_contract_prompts)
   ;; Thompson Sampling extracted to lib/thompson/ (masc_thompson). Re-export so
   ;; test code using bare Thompson_sampling.X resolves after the carve.
   (re_export masc_thompson)

--- a/test/test_mcp_server_eio_tool_profile_capability.ml
+++ b/test/test_mcp_server_eio_tool_profile_capability.ml
@@ -206,7 +206,7 @@ let test_descriptor_resolution_capabilities_for_public_aliases () =
 ;;
 
 let test_default_instructions_pin_start_transition_workflow () =
-  let instructions = Masc.Mcp_server_eio_tool_profile.default_instructions in
+  let instructions = Masc.Mcp_server_eio_tool_profile.default_instructions () in
   check
     bool
     "write summary names start"
@@ -223,7 +223,7 @@ let test_default_instructions_pin_start_transition_workflow () =
     false
     (contains_substring
        instructions
-       "masc_transition(claim) \226\134\146 work in a repo-local worktree")
+       "masc_transition(claim) -> work in a repo-local worktree")
 ;;
 
 let () =

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -1408,6 +1408,38 @@ let test_orchestrator_prompt_pins_start_transition () =
   assert_contains "orchestrator prompt starts before work" prompt "action: \"start\"";
   assert_contains "orchestrator prompt marks done" prompt "action: \"done\""
 
+let test_task_lifecycle_guidance_is_externalized () =
+  let rule =
+    read_source_file "config/prompts/tool_contract.task_lifecycle_rule.md"
+  in
+  let workflow =
+    read_source_file "config/prompts/tool_contract.task_lifecycle_workflow.md"
+  in
+  assert_contains
+    "external rule pins start before done"
+    rule
+    "action='start' before action='done'";
+  assert_contains
+    "external workflow includes start transition"
+    workflow
+    "masc_transition(start)";
+  assert_contains
+    "external workflow keeps worktree guidance"
+    workflow
+    "work in a repo-local worktree";
+  let schema_source = read_source_file "lib/task/tool_task_schemas.ml" in
+  let profile_source =
+    read_source_file "lib/mcp_server_eio_tool_profile.ml"
+  in
+  assert_not_contains
+    "task schema does not own lifecycle prose literal"
+    schema_source
+    "For normal task work, claim first";
+  assert_not_contains
+    "profile does not own workflow prose literal"
+    profile_source
+    "masc_status -> masc_transition(claim) -> masc_transition(start)"
+
 let test_board_prompt_does_not_require_optional_hearth () =
   let prompt = read_source_file "config/prompts/keeper.capabilities.md" in
   assert_contains
@@ -1950,6 +1982,8 @@ let () =
         test_keeper_tool_hint_contracts_match_required_fields;
       Alcotest.test_case "orchestrator prompt includes start transition" `Quick
         test_orchestrator_prompt_pins_start_transition;
+      Alcotest.test_case "task lifecycle guidance is externalized" `Quick
+        test_task_lifecycle_guidance_is_externalized;
       Alcotest.test_case "board prompt does not require optional hearth" `Quick
         test_board_prompt_does_not_require_optional_hearth;
     ]);


### PR DESCRIPTION
## Summary
- move task lifecycle guidance out of OCaml literals into `config/prompts/tool_contract.*.md`
- add `Tool_contract_guidance` / `Tool_contract_prompt_names` leaf modules for shared MCP/tool-schema prose lookup
- wire MCP default instructions and `masc_transition` schema description through the external guidance source
- add regression coverage that the lifecycle prose remains externalized and still pins `claim -> start -> done`

## Keeper lifecycle safety
- This PR only changes prompt/guidance/schema text plumbing and tests.
- It does not touch keeper process lifecycle, pause/stop, supervisor, autoboot, or fleet-control runtime paths.

## Validation
- `env DUNE_CACHE=disabled MASC_SKIP_PIN_CHECK=1 MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_tool_input_validation.exe test/test_mcp_server_eio_tool_profile_capability.exe test/test_tools_coverage.exe`
- `_build/default/test/test_tool_input_validation.exe` (75 tests)
- `_build/default/test/test_mcp_server_eio_tool_profile_capability.exe` (6 tests)
- `git diff --check`

Note: local `agent_sdk` switch state is currently pinned above this branch's declared floor, so the local focused build skipped only the pin guard to avoid downgrading the shared switch. CI will resolve dependencies from the PR branch.