### PR TITLE
[codex] Support local keeper secret env projection

### DIFF
--- a/lib/exec/exec_dispatch.ml
+++ b/lib/exec/exec_dispatch.ml
@@ -127,13 +127,18 @@ let env_key entry =
   | None -> entry
   | Some idx -> String.sub entry 0 idx
 
-let resolve_host_env = function
-  | [] -> None
+let resolve_host_env ?base_host_env = function
+  | [] -> base_host_env
   | env_bindings ->
       let overrides = resolve_env env_bindings |> Array.to_list in
       let override_keys = List.map env_key overrides in
+      let base =
+        match base_host_env with
+        | Some env -> env
+        | None -> Unix.environment ()
+      in
       let inherited =
-        Unix.environment ()
+        base
         |> Array.to_list
         |> List.filter (fun entry ->
           not (List.mem (env_key entry) override_keys))
@@ -162,7 +167,7 @@ let process_spec_of_simple (s : Shell_ir.simple) =
   in
   (argv, env, cwd)
 
-let dispatch_simple ?stdin_content ?on_output_chunk (s : Shell_ir.simple) =
+let dispatch_simple ?base_host_env ?stdin_content ?on_output_chunk (s : Shell_ir.simple) =
   let argv, env, cwd = process_spec_of_simple s in
   match redirect_plan_of_redirects s.redirects with
   | Error message -> unsupported_redirect_result message
@@ -170,7 +175,7 @@ let dispatch_simple ?stdin_content ?on_output_chunk (s : Shell_ir.simple) =
     match s.sandbox with
     | Host ->
       let raw_source = String.concat " " argv in
-      let host_env = resolve_host_env s.env in
+      let host_env = resolve_host_env ?base_host_env s.env in
       let run () =
         match stdin_content with
         | None ->
@@ -250,7 +255,7 @@ let dispatch_simple ?stdin_content ?on_output_chunk (s : Shell_ir.simple) =
 
 let invalid_pipeline stderr = { status = Unix.WEXITED 1; stdout = ""; stderr }
 
-let host_pipeline_specs stages =
+let host_pipeline_specs ?base_host_env stages =
   let rec loop acc = function
     | [] -> Some (List.rev acc)
     | Shell_ir.Simple simple :: rest ->
@@ -258,7 +263,7 @@ let host_pipeline_specs stages =
          | Host when simple.redirects = [] ->
              let argv, _env, cwd = process_spec_of_simple simple in
              let stage : Process_eio.pipeline_stage =
-               { argv; env = resolve_host_env simple.env; cwd }
+               { argv; env = resolve_host_env ?base_host_env simple.env; cwd }
              in
              loop (stage :: acc) rest
          | _unsupported -> None)
@@ -294,7 +299,7 @@ let docker_pipeline_specs stages =
 
 (* TEL-OK: this lower-level Shell IR dispatcher is wrapped by Execute/keeper
    telemetry at the action boundary; it only preserves captured output delivery. *)
-let rec dispatch_pipeline ?stdin_content ?on_output_chunk stages =
+let rec dispatch_pipeline ?base_host_env ?stdin_content ?on_output_chunk stages =
   let result =
     match stages with
     | [] ->
@@ -302,7 +307,7 @@ let rec dispatch_pipeline ?stdin_content ?on_output_chunk stages =
     | [ _ ] ->
         invalid_pipeline "single-stage pipeline not supported in native dispatch"
     | _ ->
-        (match host_pipeline_specs stages with
+        (match host_pipeline_specs ?base_host_env stages with
          | Some specs ->
              let raw_source =
                specs
@@ -328,6 +333,7 @@ let rec dispatch_pipeline ?stdin_content ?on_output_chunk stages =
                    | Shell_ir.Simple s :: rest ->
                        let stage_result =
                          dispatch_simple
+                           ?base_host_env
                            ~stdin_content:prev_stdout
                            s
                        in
@@ -354,7 +360,7 @@ let rec dispatch_pipeline ?stdin_content ?on_output_chunk stages =
                   | first :: rest -> (
                     match first with
                     | Shell_ir.Simple s ->
-                        let first_result = dispatch_simple s in
+                        let first_result = dispatch_simple ?base_host_env s in
                         let status =
                           pipeline_status (Unix.WEXITED 0) first_result.status
                         in
@@ -376,12 +382,12 @@ let rec dispatch_pipeline ?stdin_content ?on_output_chunk stages =
   in
   emit_captured_output on_output_chunk result
 
-and dispatch ?on_output_chunk (ir : Shell_ir.t) =
+and dispatch ?base_host_env ?on_output_chunk (ir : Shell_ir.t) =
   match ir with
-  | Shell_ir.Simple s -> dispatch_simple ?on_output_chunk s
-  | Pipeline stages -> dispatch_pipeline ?on_output_chunk stages
+  | Shell_ir.Simple s -> dispatch_simple ?base_host_env ?on_output_chunk s
+  | Pipeline stages -> dispatch_pipeline ?base_host_env ?on_output_chunk stages
 
-let dispatch_decided ?on_output_chunk (envelope : Shell_ir_risk.decided Shell_ir_risk.decided_ir) :
+let dispatch_decided ?base_host_env ?on_output_chunk (envelope : Shell_ir_risk.decided Shell_ir_risk.decided_ir) :
     dispatch_result =
   (match envelope.Shell_ir_risk.risk with
    | Shell_ir_risk.Destructive_protected ->
@@ -394,4 +400,4 @@ let dispatch_decided ?on_output_chunk (envelope : Shell_ir_risk.decided Shell_ir
    | Shell_ir_risk.R1_Reversible_mutation
    | Shell_ir_risk.R2_Irreversible ->
        ());
-  dispatch ?on_output_chunk envelope.Shell_ir_risk.ir
+  dispatch ?base_host_env ?on_output_chunk envelope.Shell_ir_risk.ir

--- a/lib/exec/exec_dispatch.mli
+++ b/lib/exec/exec_dispatch.mli
@@ -9,6 +9,7 @@ val resolve_arg : Shell_ir.arg -> string
 
 
 val dispatch_simple :
+  ?base_host_env:string array ->
   ?stdin_content:string ->
   ?on_output_chunk:([ `Stdout of string | `Stderr of string ] -> unit) ->
   Shell_ir.simple ->
@@ -22,6 +23,7 @@ val dispatch_simple :
     output after completion. *)
 
 val dispatch :
+  ?base_host_env:string array ->
   ?on_output_chunk:([ `Stdout of string | `Stderr of string ] -> unit) ->
   Shell_ir.t ->
   dispatch_result
@@ -31,6 +33,7 @@ val dispatch :
     Exposed for tests and legacy call sites. *)
 
 val dispatch_decided :
+  ?base_host_env:string array ->
   ?on_output_chunk:([ `Stdout of string | `Stderr of string ] -> unit) ->
   Shell_ir_risk.decided Shell_ir_risk.decided_ir ->
   dispatch_result
@@ -38,6 +41,7 @@ val dispatch_decided :
     ensures the IR has passed through [Shell_ir_risk.classify]. *)
 
 val dispatch_pipeline :
+  ?base_host_env:string array ->
   ?stdin_content:string ->
   ?on_output_chunk:([ `Stdout of string | `Stderr of string ] -> unit) ->
   Shell_ir.t list ->

--- a/lib/keeper/keeper_secret_projection.ml
+++ b/lib/keeper/keeper_secret_projection.ml
@@ -211,6 +211,17 @@ let local_env_entries_with_defaults entries =
   else ("GH_CONFIG_DIR", local_empty_gh_config_dir) :: entries
 ;;
 
+let local_base_host_env ?host_env () =
+  let base =
+    match host_env with
+    | Some env -> env
+    | None -> Unix.environment ()
+  in
+  base
+  |> Env_keeper_scrub.filter_environment
+  |> Env_git_noninteractive.inject_into_environment
+;;
+
 let valid_rel_component component =
   not
     (String.equal component ""
@@ -436,7 +447,9 @@ let cleanup_files paths =
 let local_env_for_keeper ?host_env ~base_path ~keeper_name () =
   let root = secret_root ~base_path ~keeper_name in
   if not (path_exists root)
-  then Ok None
+  then
+    let env_entries = local_env_entries_with_defaults [] in
+    Ok (Some (overlay_env_entries (local_base_host_env ?host_env ()) env_entries))
   else if not (is_directory root)
   then Error (Printf.sprintf "keeper secret root is not a directory: %s" root)
   else (
@@ -448,21 +461,12 @@ let local_env_for_keeper ?host_env ~base_path ~keeper_name () =
       (match load_env_entries env_root with
        | Error _ as err -> err
        | Ok env_entries ->
-         (match collect_file_entries files_root with
-          | Error _ as err -> err
-          | Ok _file_entries ->
-            let env_entries = local_env_entries_with_defaults env_entries in
-            let base =
-              match host_env with
-              | Some env -> env
-              | None -> Unix.environment ()
-            in
-            let base =
-              base
-              |> Env_keeper_scrub.filter_environment
-              |> Env_git_noninteractive.inject_into_environment
-            in
-            Ok (Some (overlay_env_entries base env_entries)))))
+	         (match collect_file_entries files_root with
+	          | Error _ as err -> err
+	          | Ok _file_entries ->
+	            let env_entries = local_env_entries_with_defaults env_entries in
+	            let base = local_base_host_env ?host_env () in
+	            Ok (Some (overlay_env_entries base env_entries)))))
 ;;
 
 let docker_args_for_keeper ~base_path ~keeper_name ~container_name =

--- a/lib/keeper/keeper_secret_projection.ml
+++ b/lib/keeper/keeper_secret_projection.ml
@@ -175,6 +175,42 @@ let load_env_entries env_root =
       loop [] names))
 ;;
 
+let env_key entry =
+  match String.index_opt entry '=' with
+  | None -> entry
+  | Some idx -> String.sub entry 0 idx
+;;
+
+let flattened_env_entries entries =
+  List.map (fun (name, value) -> name ^ "=" ^ value) entries
+;;
+
+let overlay_env_entries base entries =
+  let overrides = flattened_env_entries entries in
+  let override_keys = List.map fst entries in
+  let inherited =
+    base
+    |> Array.to_list
+    |> List.filter (fun entry -> not (List.mem (env_key entry) override_keys))
+  in
+  Array.of_list (inherited @ overrides)
+;;
+
+(* Prevent [gh] from falling back to the operator's HOME/XDG config when the
+   keeper supplies token env credentials but no explicit GH_CONFIG_DIR. *)
+let local_empty_gh_config_dir = "/var/empty"
+
+let env_entries_have key entries =
+  List.exists (fun (name, _) -> String.equal name key) entries
+;;
+
+let local_env_entries_with_defaults entries =
+  if env_entries_have "GH_CONFIG_DIR" entries
+     || not (path_exists local_empty_gh_config_dir && is_directory local_empty_gh_config_dir)
+  then entries
+  else ("GH_CONFIG_DIR", local_empty_gh_config_dir) :: entries
+;;
+
 let valid_rel_component component =
   not
     (String.equal component ""
@@ -395,6 +431,38 @@ let cleanup_files paths =
        try if Sys.file_exists path then Sys.remove path with
        | Sys_error _ | Unix.Unix_error _ -> ())
     paths
+;;
+
+let local_env_for_keeper ?host_env ~base_path ~keeper_name () =
+  let root = secret_root ~base_path ~keeper_name in
+  if not (path_exists root)
+  then Ok None
+  else if not (is_directory root)
+  then Error (Printf.sprintf "keeper secret root is not a directory: %s" root)
+  else (
+    match reject_symlink ~kind:File_source root with
+    | Error _ as err -> err
+    | Ok _ ->
+      let env_root = Filename.concat root "env" in
+      let files_root = Filename.concat root "files" in
+      (match load_env_entries env_root with
+       | Error _ as err -> err
+       | Ok env_entries ->
+         (match collect_file_entries files_root with
+          | Error _ as err -> err
+          | Ok _file_entries ->
+            let env_entries = local_env_entries_with_defaults env_entries in
+            let base =
+              match host_env with
+              | Some env -> env
+              | None -> Unix.environment ()
+            in
+            let base =
+              base
+              |> Env_keeper_scrub.filter_environment
+              |> Env_git_noninteractive.inject_into_environment
+            in
+            Ok (Some (overlay_env_entries base env_entries)))))
 ;;
 
 let docker_args_for_keeper ~base_path ~keeper_name ~container_name =

--- a/lib/keeper/keeper_secret_projection.mli
+++ b/lib/keeper/keeper_secret_projection.mli
@@ -12,6 +12,21 @@ val secret_root_info : base_path:string -> keeper_name:string -> secret_root_inf
 
 val secret_root : base_path:string -> keeper_name:string -> string
 
+val local_env_for_keeper :
+  ?host_env:string array ->
+  base_path:string ->
+  keeper_name:string ->
+  unit ->
+  (string array option, string) result
+(** Build the child-process environment for local keeper execution from
+    [secrets/<keeper>/env]. Returns [None] when the keeper secret root is
+    absent. When present, the host environment is keeper-scrubbed, git/gh
+    noninteractive defaults are injected, secret files are validated, and
+    env entries are overlaid without writing temp files. If the keeper does
+    not supply [GH_CONFIG_DIR], local execution points [gh] at an empty
+    system config directory when available to avoid ambient host config
+    fallback. *)
+
 val docker_args_for_keeper :
   base_path:string -> keeper_name:string -> container_name:string -> (t, string) result
 

--- a/lib/keeper/keeper_secret_projection.mli
+++ b/lib/keeper/keeper_secret_projection.mli
@@ -19,13 +19,13 @@ val local_env_for_keeper :
   unit ->
   (string array option, string) result
 (** Build the child-process environment for local keeper execution from
-    [secrets/<keeper>/env]. Returns [None] when the keeper secret root is
-    absent. When present, the host environment is keeper-scrubbed, git/gh
-    noninteractive defaults are injected, secret files are validated, and
-    env entries are overlaid without writing temp files. If the keeper does
-    not supply [GH_CONFIG_DIR], local execution points [gh] at an empty
-    system config directory when available to avoid ambient host config
-    fallback. *)
+    [secrets/<keeper>/env]. The host environment is keeper-scrubbed and
+    git/gh noninteractive defaults are injected even when the keeper secret
+    root is absent; a missing root only means there are no keeper-specific
+    env/file overlays. When present, secret files are validated and env
+    entries are overlaid without writing temp files. If the keeper does not
+    supply [GH_CONFIG_DIR], local execution points [gh] at an empty system
+    config directory when available to avoid ambient host config fallback. *)
 
 val docker_args_for_keeper :
   base_path:string -> keeper_name:string -> container_name:string -> (t, string) result

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -178,9 +178,24 @@ let handle_tool_execute_typed
         let sandbox_profile, _sandbox_network_mode =
           Keeper_sandbox_runner.effective_sandbox_profile ~meta
         in
+        let local_dispatch_sandbox ?(extra_fields = []) () =
+          match
+            Keeper_secret_projection.local_env_for_keeper
+              ~base_path:config.base_path
+              ~keeper_name:meta.name
+              ()
+          with
+          | Error err ->
+            Error
+              (Keeper_sandbox_shell_ir_target.target_error
+                 ~fields:extra_fields
+                 ("local_secret_projection_failed: " ^ err))
+          | Ok base_host_env ->
+            Ok (Masc_exec.Sandbox_target.host (), extra_fields, base_host_env)
+        in
         let dispatch_sandbox =
           match sandbox_profile with
-          | Local -> Ok (Masc_exec.Sandbox_target.host (), [])
+          | Local -> local_dispatch_sandbox ()
           | Docker ->
             if typed_input_has_env input
             then
@@ -189,7 +204,11 @@ let handle_tool_execute_typed
                    "typed Shell IR Docker dispatch does not support env yet")
             else (
               match docker_local_fallback_target ~meta with
-              | Some fallback when in_playground -> Ok fallback
+              | Some (target, fields) when in_playground ->
+                (match target with
+                 | Masc_exec.Sandbox_target.Host ->
+                   local_dispatch_sandbox ~extra_fields:fields ()
+                 | Docker _ -> Ok (target, fields, None))
               | Some _ | None ->
                 docker_sandbox_target ~turn_sandbox_factory ~meta ~cwd
                 |> Result.map (fun target ->
@@ -197,7 +216,8 @@ let handle_tool_execute_typed
                   , [ "requested_sandbox", `String "docker"
                     ; "via", `String "docker"
                     ; "sandbox_profile", `String "docker"
-                    ] )))
+                    ]
+                  , None )))
         in
         (match dispatch_sandbox with
          | Error ({ message; fields } : Keeper_sandbox_shell_ir_target.target_error) ->
@@ -207,7 +227,7 @@ let handle_tool_execute_typed
                 @ execution_location_fields cwd
                 @ fields)
              message
-         | Ok (dispatch_sandbox, sandbox_extra_fields) ->
+         | Ok (dispatch_sandbox, sandbox_extra_fields, base_host_env) ->
         let response_cwd_json =
           typed_execute_response_cwd_json
             ~turn_sandbox_factory
@@ -380,6 +400,7 @@ let handle_tool_execute_typed
               ~base_path:root
               ~workdir:cwd
               ~sandbox:dispatch_sandbox
+              ?base_host_env
               ~on_output_chunk
               envelope
           in

--- a/lib/keeper_tooling/keeper_tool_execute_shell_ir.ml
+++ b/lib/keeper_tooling/keeper_tool_execute_shell_ir.ml
@@ -97,6 +97,7 @@ let dispatch_classified
       ?base_path
       ~workdir
       ~sandbox
+      ?base_host_env
       ?on_output_chunk
       envelope
   =
@@ -117,7 +118,7 @@ let dispatch_classified
     ~f_allow:(fun _context ->
       match validate_paths ?keeper_id ?base_path ~workdir ir with
       | Error e -> Error (Path_reject e)
-      | Ok () -> Ok (Masc_exec.Exec_dispatch.dispatch_decided ?on_output_chunk envelope))
+      | Ok () -> Ok (Masc_exec.Exec_dispatch.dispatch_decided ?base_host_env ?on_output_chunk envelope))
 ;;
 
 (* TEL-OK: wrapper only classifies before delegating to dispatch_classified. *)
@@ -128,6 +129,7 @@ let dispatch
       ?base_path
       ~workdir
       ~sandbox
+      ?base_host_env
       ?on_output_chunk
       ir
   =
@@ -138,6 +140,7 @@ let dispatch
     ?base_path
     ~workdir
     ~sandbox
+    ?base_host_env
     ?on_output_chunk
     (classify ir)
 ;;

--- a/lib/keeper_tooling/keeper_tool_execute_shell_ir.mli
+++ b/lib/keeper_tooling/keeper_tool_execute_shell_ir.mli
@@ -62,6 +62,7 @@ val dispatch_classified :
   ?base_path:string ->
   workdir:string ->
   sandbox:Masc_exec.Sandbox_target.t ->
+  ?base_host_env:string array ->
   ?on_output_chunk:([ `Stdout of string | `Stderr of string ] -> unit) ->
   Masc_exec.Shell_ir_risk.decided Masc_exec.Shell_ir_risk.decided_ir ->
   (Masc_exec.Exec_dispatch.dispatch_result, dispatch_error) result
@@ -78,6 +79,7 @@ val dispatch :
   ?base_path:string ->
   workdir:string ->
   sandbox:Masc_exec.Sandbox_target.t ->
+  ?base_host_env:string array ->
   ?on_output_chunk:([ `Stdout of string | `Stderr of string ] -> unit) ->
   Masc_exec.Shell_ir.t ->
   (Masc_exec.Exec_dispatch.dispatch_result, dispatch_error) result

--- a/test/test_exec_dispatch.ml
+++ b/test/test_exec_dispatch.ml
@@ -64,6 +64,27 @@ let () =
   assert (stdout = "hello world");
   assert (result.status = Unix.WEXITED 0)
 
+let () =
+  with_eio @@ fun () ->
+  let open Masc_exec.Shell_ir in
+  let bin = Masc_exec.Exec_program.of_string "sh" |> Result.get_ok in
+  let ir =
+      { bin
+      ; args = [ Lit ("-c", default_meta); Lit ("printf %s \"$MASC_TEST_BASE_HOST_ENV\"", default_meta) ]
+      ; env = []
+      ; cwd = None
+      ; redirects = []
+      ; sandbox = Masc_exec.Sandbox_target.host ()
+      }
+  in
+  let result =
+    Masc_exec.Exec_dispatch.dispatch_simple
+      ~base_host_env:[| "PATH=/bin:/usr/bin"; "MASC_TEST_BASE_HOST_ENV=from-base" |]
+      ir
+  in
+  assert (result.stdout = "from-base");
+  assert (result.status = Unix.WEXITED 0)
+
 (* --- dispatch_simple captures stderr --- *)
 
 let () =
@@ -98,6 +119,44 @@ let () =
   let result = Masc_exec.Exec_dispatch.dispatch_pipeline stages in
   let stdout = String.trim result.stdout in
   assert (stdout = "HELLO WORLD");
+  assert (result.status = Unix.WEXITED 0)
+
+let () =
+  with_eio @@ fun () ->
+  let open Masc_exec.Shell_ir in
+  let sh_bin = Masc_exec.Exec_program.of_string "sh" |> Result.get_ok in
+  let cat_bin = Masc_exec.Exec_program.of_string "cat" |> Result.get_ok in
+  let host_sandbox = Masc_exec.Sandbox_target.host () in
+  let stages =
+    [
+      Simple
+        { bin = sh_bin
+        ; args =
+            [ Lit ("-c", default_meta)
+            ; Lit ("printf %s \"$MASC_TEST_PIPE_BASE_HOST_ENV\"", default_meta)
+            ]
+        ; env = []
+        ; cwd = None
+        ; redirects = []
+        ; sandbox = host_sandbox
+        };
+      Simple
+        { bin = cat_bin
+        ; args = []
+        ; env = []
+        ; cwd = None
+        ; redirects = []
+        ; sandbox = host_sandbox
+        };
+    ]
+  in
+  let result =
+    Masc_exec.Exec_dispatch.dispatch_pipeline
+      ~base_host_env:
+        [| "PATH=/bin:/usr/bin"; "MASC_TEST_PIPE_BASE_HOST_ENV=from-pipeline-base" |]
+      stages
+  in
+  assert (result.stdout = "from-pipeline-base");
   assert (result.status = Unix.WEXITED 0)
 
 (* --- host pipeline streams between stages --- *)

--- a/test/test_keeper_secret_projection.ml
+++ b/test/test_keeper_secret_projection.ml
@@ -203,20 +203,47 @@ let test_secret_dir_override_uses_keeper_subdir () =
             projection.cleanup ()))
 ;;
 
-let test_local_env_missing_secret_dir_is_none () =
+let test_local_env_missing_secret_dir_is_scrubbed () =
   let base = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
   with_env "MASC_SECRET_DIR" "" @@ fun () ->
+  let host_env =
+    [| "PATH=/usr/bin"
+     ; "GH_TOKEN=ambient-gh"
+     ; "GITHUB_TOKEN=ambient-github"
+     ; "GH_CONFIG_DIR=/Users/operator/.config/gh"
+     ; "SSH_AUTH_SOCK=/tmp/operator-agent.sock"
+     ; "GIT_TERMINAL_PROMPT=1"
+    |]
+  in
   match
     Keeper_secret_projection.local_env_for_keeper
-      ~host_env:[| "PATH=/usr/bin"; "GH_TOKEN=ambient" |]
+      ~host_env
       ~base_path:base
       ~keeper_name:"minjae"
       ()
   with
   | Error err -> Alcotest.fail err
-  | Ok None -> ()
-  | Ok (Some _) -> Alcotest.fail "expected missing local secret root to be None"
+  | Ok None -> Alcotest.fail "expected scrubbed local env for missing secret root"
+  | Ok (Some env) ->
+    Alcotest.(check (option string)) "ambient gh token stripped" None
+      (env_value "GH_TOKEN" env);
+    Alcotest.(check (option string)) "ambient github token stripped" None
+      (env_value "GITHUB_TOKEN" env);
+    Alcotest.(check bool) "ambient gh config not inherited" true
+      (env_value "GH_CONFIG_DIR" env <> Some "/Users/operator/.config/gh");
+    if Sys.file_exists "/var/empty" && Sys.is_directory "/var/empty"
+    then
+      Alcotest.(check (option string))
+        "empty gh config fallback"
+        (Some "/var/empty")
+        (env_value "GH_CONFIG_DIR" env);
+    Alcotest.(check (option string)) "ambient ssh agent stripped" None
+      (env_value "SSH_AUTH_SOCK" env);
+    Alcotest.(check (option string)) "noninteractive git prompt injected" (Some "0")
+      (env_value "GIT_TERMINAL_PROMPT" env);
+    Alcotest.(check (option string)) "safe PATH preserved" (Some "/usr/bin")
+      (env_value "PATH" env)
 ;;
 
 let test_local_env_uses_keeper_secret_env_without_ambient_credentials () =
@@ -446,8 +473,8 @@ let () =
             test_env_and_files_project_to_docker_args
         ; Alcotest.test_case "MASC_SECRET_DIR uses keeper subdir" `Quick
             test_secret_dir_override_uses_keeper_subdir
-        ; Alcotest.test_case "local env missing secret dir is noop" `Quick
-            test_local_env_missing_secret_dir_is_none
+        ; Alcotest.test_case "local env missing secret dir is scrubbed" `Quick
+            test_local_env_missing_secret_dir_is_scrubbed
         ; Alcotest.test_case "local env uses keeper env without ambient creds" `Quick
             test_local_env_uses_keeper_secret_env_without_ambient_credentials
         ; Alcotest.test_case "invalid env name rejects" `Quick

--- a/test/test_keeper_secret_projection.ml
+++ b/test/test_keeper_secret_projection.ml
@@ -99,6 +99,20 @@ let rec env_file_arg = function
   | [] -> None
 ;;
 
+let env_value key env =
+  Array.to_list env
+  |> List.find_map (fun entry ->
+    match String.index_opt entry '=' with
+    | None -> None
+    | Some idx ->
+      let entry_key = String.sub entry 0 idx in
+      if String.equal entry_key key
+      then
+        Some
+          (String.sub entry (idx + 1) (String.length entry - idx - 1))
+      else None)
+;;
+
 let secret_root_default ~base ~keeper_name =
   Filename.concat
     (Filename.concat (Filename.concat base Common.masc_dirname) "secrets")
@@ -187,6 +201,95 @@ let test_secret_dir_override_uses_keeper_subdir () =
             Alcotest.(check string) "override env content" "GH_TOKEN=override\n"
               (read_file env_file);
             projection.cleanup ()))
+;;
+
+let test_local_env_missing_secret_dir_is_none () =
+  let base = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  with_env "MASC_SECRET_DIR" "" @@ fun () ->
+  match
+    Keeper_secret_projection.local_env_for_keeper
+      ~host_env:[| "PATH=/usr/bin"; "GH_TOKEN=ambient" |]
+      ~base_path:base
+      ~keeper_name:"minjae"
+      ()
+  with
+  | Error err -> Alcotest.fail err
+  | Ok None -> ()
+  | Ok (Some _) -> Alcotest.fail "expected missing local secret root to be None"
+;;
+
+let test_local_env_uses_keeper_secret_env_without_ambient_credentials () =
+  let base = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  with_env "MASC_SECRET_DIR" "" @@ fun () ->
+  let root = secret_root_default ~base ~keeper_name:"MinJae" in
+  let env_root = Filename.concat root "env" in
+  let files_root = Filename.concat root "files" in
+  write_file (Filename.concat env_root "GH_TOKEN") "keeper-token\n";
+  write_file
+    (Filename.concat env_root "GIT_SSH_COMMAND")
+    ("ssh -i " ^ Filename.concat files_root "ssh/id_ed25519");
+  write_file (Filename.concat files_root "ssh/id_ed25519") "PRIVATE KEY";
+  let host_env =
+    [| "PATH=/usr/bin"
+     ; "HOME=/Users/operator"
+     ; "FOO=bar"
+     ; "GH_TOKEN=ambient-gh"
+     ; "GITHUB_TOKEN=ambient-github"
+     ; "GH_CONFIG_DIR=/Users/operator/.config/gh"
+     ; "SSH_AUTH_SOCK=/tmp/operator-agent.sock"
+     ; "GIT_TERMINAL_PROMPT=1"
+    |]
+  in
+  match
+    Keeper_secret_projection.local_env_for_keeper
+      ~host_env
+      ~base_path:base
+      ~keeper_name:"MinJae"
+      ()
+  with
+  | Error err -> Alcotest.fail err
+  | Ok None -> Alcotest.fail "expected local env projection"
+  | Ok (Some env) ->
+    Alcotest.(check (option string))
+      "keeper token wins"
+      (Some "keeper-token")
+      (env_value "GH_TOKEN" env);
+    Alcotest.(check (option string))
+      "ambient github token stripped"
+      None
+      (env_value "GITHUB_TOKEN" env);
+    Alcotest.(check bool)
+      "ambient gh config not inherited"
+      true
+      (env_value "GH_CONFIG_DIR" env <> Some "/Users/operator/.config/gh");
+    if Sys.file_exists "/var/empty" && Sys.is_directory "/var/empty"
+    then
+      Alcotest.(check (option string))
+        "empty gh config fallback"
+        (Some "/var/empty")
+        (env_value "GH_CONFIG_DIR" env);
+    Alcotest.(check (option string))
+      "ambient ssh agent stripped"
+      None
+      (env_value "SSH_AUTH_SOCK" env);
+    Alcotest.(check (option string))
+      "noninteractive git prompt injected"
+      (Some "0")
+      (env_value "GIT_TERMINAL_PROMPT" env);
+    Alcotest.(check (option string))
+      "keeper ssh command projected"
+      (Some ("ssh -i " ^ Filename.concat files_root "ssh/id_ed25519"))
+      (env_value "GIT_SSH_COMMAND" env);
+    Alcotest.(check (option string))
+      "unsafe ambient variable stripped"
+      None
+      (env_value "FOO" env);
+    Alcotest.(check (option string))
+      "safe PATH preserved"
+      (Some "/usr/bin")
+      (env_value "PATH" env)
 ;;
 
 let test_invalid_env_name_rejects () =
@@ -343,6 +446,10 @@ let () =
             test_env_and_files_project_to_docker_args
         ; Alcotest.test_case "MASC_SECRET_DIR uses keeper subdir" `Quick
             test_secret_dir_override_uses_keeper_subdir
+        ; Alcotest.test_case "local env missing secret dir is noop" `Quick
+            test_local_env_missing_secret_dir_is_none
+        ; Alcotest.test_case "local env uses keeper env without ambient creds" `Quick
+            test_local_env_uses_keeper_secret_env_without_ambient_credentials
         ; Alcotest.test_case "invalid env name rejects" `Quick
             test_invalid_env_name_rejects
         ; Alcotest.test_case "symlink file rejects" `Quick test_symlink_file_rejects


### PR DESCRIPTION
## Summary
- add local keeper secret env projection from secrets/<keeper>/env without writing temp files
- scrub ambient host credentials before local keeper child execution and inject git/gh noninteractive defaults
- thread an optional base host env through Shell IR host dispatch without putting secret values into IR/log fields

## Why
Local-profile keepers were inheriting the operator host environment, so gh/git credentials could mix with keeper-specific secret files. This makes configured secrets/<keeper>/env the local child-process credential source while leaving Docker projection unchanged.

## Validation
- scripts/dune-local.sh build test/test_keeper_secret_projection.exe test/test_exec_dispatch.exe
- ./_build/default/test/test_keeper_secret_projection.exe
- ./_build/default/test/test_exec_dispatch.exe