### PR TITLE
fix(keeper_msg_async): reject `..`/`.` in is_safe_request_id — poll + cancel path traversal defence

### DIFF
--- a/lib/keeper/keeper_msg_async.ml
+++ b/lib/keeper/keeper_msg_async.ml
@@ -58,7 +58,7 @@ let is_safe_request_id request_id =
         | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '-' | '.' -> loop (i + 1)
         | _ -> false)
     in
-    loop 0)
+    loop 0 && request_id <> ".." && request_id <> ".")
 ;;
 
 let record_path ~base_path ~request_id =

--- a/lib/keeper/keeper_msg_async.ml
+++ b/lib/keeper/keeper_msg_async.ml
@@ -408,6 +408,8 @@ let submit ?clock ?timeout_sec ~sw ~base_path ~(f : unit -> tool_result)
 
 (** Poll for the result of an async keeper_msg request. *)
 let poll ?base_path request_id : entry option =
+  if not (is_safe_request_id request_id) then None
+  else
   match Eio.Mutex.use_ro mu (fun () -> Hashtbl.find_opt pending request_id) with
   | Some _ as found -> found
   | None ->
@@ -471,6 +473,8 @@ let entry_to_json (e : entry) : Yojson.Safe.t =
 ;;
 
 let cancel ?base_path request_id : bool =
+  if not (is_safe_request_id request_id) then false
+  else
   let sw_opt = with_lock (fun () -> Hashtbl.find_opt active_switches request_id) in
   match sw_opt with
   | Some sw ->

--- a/test/test_keeper_mutex_coverage.ml
+++ b/test/test_keeper_mutex_coverage.ml
@@ -358,7 +358,26 @@ let test_keeper_msg_async_rejects_oversized_request_id () =
          (option string)
          "129-char request id rejected"
          None
-         (Keeper_msg_async.For_testing.record_path ~base_path ~request_id:too_long))
+         (Keeper_msg_async.For_testing.record_path ~base_path ~request_id:too_long);
+       (* path traversal: ".." must be rejected *)
+       check
+         (option string)
+         ".. path traversal rejected"
+         None
+         (Keeper_msg_async.For_testing.record_path ~base_path ~request_id:"..");
+       (* path traversal: "." must be rejected *)
+       check
+         (option string)
+         ". path traversal rejected"
+         None
+         (Keeper_msg_async.For_testing.record_path ~base_path ~request_id:".");
+       (* regression: "good.id" still accepted *)
+       check
+         bool
+         "good.id still accepted (regression)"
+         true
+         (Option.is_some
+            (Keeper_msg_async.For_testing.record_path ~base_path ~request_id:"good.id")))
 ;;
 
 let test_yield_meter_noops_without_runnable_fiber () =


### PR DESCRIPTION
## Summary

Rejects literal `".."` and `"."` request_id values in `is_safe_request_id` AND adds the same guard to `poll()` and `cancel()` paths.

## Changes

Two commits from @qa-king:

1. `e0e51078a` — Add `".."` / `"."` rejection in `is_safe_request_id` (base guard)
2. `c768b754c` — Add `is_safe_request_id` guard to `poll()` + `cancel()` entry points (defence-in-depth)

CC: @verifier