### PR TITLE
feat(keeper): memory os on by default, env vars become kill switches

### DIFF
--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -16,9 +16,12 @@ let default_complete ~sw ~net ?clock ~config ~messages () =
 ;;
 
 let enabled () =
+  (* Default on: a keeper without conversation ingestion is the pathology
+     the Memory OS exists to fix (2026-06-12 diagnosis, issue #20909).
+     The env var stays as the kill switch. *)
   Keeper_memory_bank_env.memory_env_bool_logged
     "MASC_KEEPER_MEMORY_OS_LIBRARIAN"
-    ~default:false
+    ~default:true
 ;;
 
 let max_messages () =

--- a/lib/keeper/keeper_memory_os_recall.ml
+++ b/lib/keeper/keeper_memory_os_recall.ml
@@ -190,9 +190,11 @@ let render_context
 ;;
 
 let enabled () =
+  (* Default on, mirroring the librarian (write side): persisted memory
+     that never reaches a prompt is dead weight. Env var = kill switch. *)
   Keeper_memory_bank_env.memory_env_bool_logged
     "MASC_KEEPER_MEMORY_OS_RECALL"
-    ~default:false
+    ~default:true
 ;;
 
 let render_if_enabled ~keeper_id ~now () =

--- a/lib/keeper/keeper_memory_os_recall.mli
+++ b/lib/keeper/keeper_memory_os_recall.mli
@@ -13,11 +13,11 @@ val render_context
   -> string
 
 val enabled : unit -> bool
-(** Opt-in flag [MASC_KEEPER_MEMORY_OS_RECALL] (default [false]). Read
-    side of Memory OS; the write side (librarian) is gated separately by
-    [MASC_KEEPER_MEMORY_OS_LIBRARIAN]. *)
+(** Kill-switch flag [MASC_KEEPER_MEMORY_OS_RECALL] (default [true]).
+    Read side of Memory OS; the write side (librarian) is gated
+    separately by [MASC_KEEPER_MEMORY_OS_LIBRARIAN]. *)
 
 val render_if_enabled : keeper_id:string -> now:float -> unit -> string option
 (** [render_if_enabled ~keeper_id ~now ()] is [Some block] when the
-    opt-in flag is set and the store yields advisory content, [None]
-    otherwise. Intended for the [extra_system_context] assembly site. *)
+    flag is on and the store yields advisory content, [None] otherwise.
+    Intended for the [extra_system_context] assembly site. *)

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -674,14 +674,19 @@ let with_recall_env value f =
   Fun.protect ~finally:(fun () -> Unix.putenv var "") f
 ;;
 
-let test_render_if_enabled_off_by_default () =
+let test_render_if_enabled_default_is_on () =
   with_recall_env "" (fun () ->
+    Alcotest.(check bool) "flag unset → enabled by default" true (Recall.enabled ()))
+;;
+
+let test_render_if_enabled_explicit_off () =
+  with_recall_env "false" (fun () ->
     with_temp_keepers_dir (fun _keepers_dir ->
       match
         Recall.render_if_enabled ~keeper_id:"virtual-memory-keeper" ~now:1_000_000.0 ()
       with
       | None -> ()
-      | Some block -> Alcotest.failf "expected None with flag unset, got %S" block))
+      | Some block -> Alcotest.failf "expected None with kill switch set, got %S" block))
 ;;
 
 let test_render_if_enabled_empty_store_yields_none () =
@@ -842,9 +847,13 @@ let () =
             `Quick
             test_recall_context_renders_sanitized_memory
         ; Alcotest.test_case
-            "render_if_enabled off by default"
+            "render_if_enabled default is on"
             `Quick
-            test_render_if_enabled_off_by_default
+            test_render_if_enabled_default_is_on
+        ; Alcotest.test_case
+            "render_if_enabled explicit off"
+            `Quick
+            test_render_if_enabled_explicit_off
         ; Alcotest.test_case
             "render_if_enabled empty store yields none"
             `Quick


### PR DESCRIPTION
## 목적
Refs #20909 — 운영자 결정: 기억은 켜진 게 기본이다. opt-in default는 "머지됐지만 잠자는 Memory OS" 상태를 설정 레벨에서 재생산한다.

## 변경
- `MASC_KEEPER_MEMORY_OS_LIBRARIAN` default false → **true** (kill switch로 의미 전환)
- `MASC_KEEPER_MEMORY_OS_RECALL` default false → **true** (동일)
- 테스트 갱신: off-by-default 단언 → default-is-on + explicit-off(kill switch) 2건으로 교체

## 비용 주의
librarian은 켜진 상태에서 keeper 턴마다 post-turn LLM 호출 1회 추가 (best-effort: 실패 시 warn + `EpisodeCreateFailures` 카운터, 턴 실패 전파 없음 — #20897 설계 유지). fleet 전체 기준 비용/지연 증가는 카운터로 관측 가능.

## 후속 (RFC-0231 계열)
env knob 2개를 runtime.toml SSOT로 이전 — env는 비상용으로만.

## 검증
- `dune build --root . bin/main_eio.exe` green
- `test_keeper_memory_os` 17/17 OK

RFC-WAIVED: default 값 1줄×2 flip + 테스트 (운영자 명시 지시). 신규 설계 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
