### PR TITLE
[codex] Add Gemma4 Ollama runtime seed

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -1,0 +1,44 @@
+# MASC runtime seed.
+#
+# This file is copied into <base-path>/.masc/config/runtime.toml for new
+# workspaces. Existing live config roots are preserved and must be edited
+# explicitly through the dashboard/runtime config path.
+#
+# Gemma 4 QAT on Ollama uses Gemma's chat-template/control-token thinking path.
+# Do not translate thinking-support=true into a generic provider "think": true
+# parameter; the OAS Ollama adapter owns the Gemma 4 template behavior.
+
+[runtime]
+default = "ollama.gemma4-26b-a4b-qat"
+
+[providers.ollama]
+display-name = "Local Ollama"
+protocol = "ollama-http"
+endpoint = "http://localhost:11434"
+
+[models.gemma4-26b-a4b-qat]
+api-name = "hf.co/unsloth/gemma-4-26B-A4B-it-qat-GGUF:UD-Q4_K_XL"
+max-context = 262144
+tools-support = true
+thinking-support = true
+preserve-thinking = true
+streaming = true
+
+[models.gemma4-26b-a4b-qat.capabilities]
+supports-tool-choice = true
+thinking-control-format = "chat-template-kwargs"
+supports-native-streaming = true
+supports-top-k = true
+supports-seed = true
+supports-image-input = true
+supports-multimodal-inputs = true
+
+[ollama.gemma4-26b-a4b-qat]
+max-concurrent = 1
+
+# Optional explicit keeper pins. Omit this table to let keepers use
+# [runtime].default.
+#
+# [runtime.assignments]
+# sangsu = "ollama.gemma4-26b-a4b-qat"
+# executor = "ollama.gemma4-26b-a4b-qat"

--- a/docs/BOOT-ENV-STATE-INVENTORY.md
+++ b/docs/BOOT-ENV-STATE-INVENTORY.md
@@ -89,8 +89,10 @@ The checked-in versioned seed config tree currently contains:
 | `config/prompts/*.md` | Versioned system prompt fragments and governance/keeper prompt templates. |
 | `config/excuse_patterns.json` | Auxiliary config used by selected flows. |
 
-`runtime.toml` is not checked into the repo seed tree. It is an optional
-active-root file at `<active config root>/runtime.toml`.
+`runtime.toml` is checked into the repo seed tree as a local-first example and
+bootstrap default. Live authoring still happens in the active-root file at
+`<active config root>/runtime.toml`; existing active roots are preserved and
+are not overwritten by the seed.
 
 ### 1.3 runtime.toml — per-base-path startup keeper env seeding
 

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -23,6 +23,16 @@ let test_runtime_json_not_in_repo_config () =
   let path = Filename.concat (repo_root ()) "config/runtime.json" in
   check bool "retired runtime.json absent" false (Sys.file_exists path)
 
+let test_repo_runtime_toml_loads () =
+  let path = Filename.concat (repo_root ()) "config/runtime.toml" in
+  check bool "repo runtime.toml present" true (Sys.file_exists path);
+  match Runtime.load_list ~config_path:path with
+  | Error msg -> failf "repo runtime.toml should load: %s" msg
+  | Ok (runtimes, default, assignments) ->
+    check bool "at least one runtime" true (List.length runtimes > 0);
+    check string "default runtime" "ollama.gemma4-26b-a4b-qat" default.Runtime.id;
+    check int "no explicit keeper pins in seed" 0 (List.length assignments)
+
 let test_toml_catalog_resolves_lifecycle_keys () =
   let doc =
     parse_or_fail
@@ -50,6 +60,8 @@ let () =
     [ ( "runtime TOML gate",
         [ test_case "runtime.json is not a repo config source" `Quick
             test_runtime_json_not_in_repo_config;
+          test_case "repo runtime.toml loads through runtime parser" `Quick
+            test_repo_runtime_toml_loads;
           test_case
             "lifecycle TOML keys resolve through the declarative catalog"
             `Quick test_toml_catalog_resolves_lifecycle_keys ] )


### PR DESCRIPTION
## Summary
- add checked-in `config/runtime.toml` seed for local Ollama Gemma4 26B A4B QAT
- document that live authoring remains in the active config root and existing live roots are not overwritten
- cover the seed with `Runtime.load_list` in the runtime config validity test

## Validation
- `python3 -c 'import sys,tomllib; tomllib.load(open(sys.argv[1], "rb")); print("toml-ok")' config/runtime.toml`
- `scripts/dune-local.sh exec ./test/test_runtime_config_validity.exe`