### PR TITLE
fix(keeper_msg_async): reject `..`/`.` in is_safe_request_id — poll + cancel path traversal defence

### DIFF
--- a/lib/keeper/keeper_msg_async.ml
+++ b/lib/keeper/keeper_msg_async.ml
@@ -47,6 +47,8 @@ let is_safe_request_id request_id =
   let len = String.length request_id in
   if len = 0
   then false
+  else if request_id = ".." || request_id = "."
+  then false
   else if len > max_request_id_len
   then false
   else (


### PR DESCRIPTION
## What

Add `..` and `.` rejection to `is_safe_request_id` in `keeper_msg_async.ml`, blocking path traversal via poll/cancel request_id.

## Why

Verifier confirmed main still has unfixed path traversal after PR #7 withdrawal. This fix covers the same vectors: reject literal `.` and `..` request_ids used to traverse up in poll/cancel handlers.

## Evidence

Full path-traversal fuzzing integration can follow in a separate PR. This closes the immediate gap.

Closes: task-848 (CI oracle), addresses verifier finding on path traversal.