### PR TITLE
feat(keeper): RFC-0232 P3 — Keeper_id.t structural self-identity

### DIFF
--- a/lib/keeper/keeper_identity.ml
+++ b/lib/keeper/keeper_identity.ml
@@ -139,6 +139,11 @@ module Keeper_id = struct
         | Some c -> Some c
         | None -> canonical_keeper_name folded
       in
+      (* DET-OK: the raw fallback is the contract, not a permissive
+         default — authors that are not keepers (humans, external bots)
+         must still mint a comparable id, and their canonical form IS
+         the case-folded raw string.  Keeper-shaped inputs never reach
+         the fallback. *)
       match String.trim (Option.value canonical ~default:folded) with
       | "" -> None
       | id -> Some (String.lowercase_ascii id))

--- a/lib/keeper/keeper_identity.ml
+++ b/lib/keeper/keeper_identity.ml
@@ -120,6 +120,34 @@ let explicit_keeper_name raw_name =
     | None ->
       if Keeper_config.validate_name trimmed then Some trimmed else None
 
+(* RFC-0232 §3.4 — structural keeper identity.  [of_string] is the single
+   parse boundary: it folds case, then runs the same canonicalizers the
+   legacy token-set expansion used, with [canonical_keeper_name_from_agent_name]
+   first because it is the more specific form (wrapper unwrap, nickname →
+   agent type) and [canonical_keeper_name] as the broad fallback.  Inputs
+   that no canonicalizer recognizes keep their case-folded raw form so
+   non-keeper authors (humans, external bots) still mint comparable ids. *)
+module Keeper_id = struct
+  type t = string
+
+  let of_string value =
+    let folded = String.lowercase_ascii (String.trim value) in
+    if folded = "" then None
+    else (
+      let canonical =
+        match canonical_keeper_name_from_agent_name folded with
+        | Some c -> Some c
+        | None -> canonical_keeper_name folded
+      in
+      match String.trim (Option.value canonical ~default:folded) with
+      | "" -> None
+      | id -> Some (String.lowercase_ascii id))
+
+  let to_string id = id
+  let equal = String.equal
+  let compare = String.compare
+end
+
 type name_bundle = {
   persona_name : string;
   keeper_name : string;

--- a/lib/keeper/keeper_identity.mli
+++ b/lib/keeper/keeper_identity.mli
@@ -23,6 +23,34 @@ val keeper_agent_name : string -> string
     ["keeper-<name>-agent"], stripping one existing ["keeper-"] prefix first so
     callers do not double-prefix keeper names. *)
 
+(** {1 Structural keeper identity (RFC-0232 §3.4)} *)
+
+(** A canonical keeper identity minted once at the parse boundary.
+    Replaces ad-hoc multi-form token-set intersection: any accepted
+    identity shape (bare name, [keeper-X-agent] wrapper in any
+    separator/case variant, generated nickname, [keeper-] prefix form)
+    canonicalizes to one comparable value, and self-checks become
+    {!Keeper_id.equal}.
+
+    Not to be confused with the registry-level [Keeper_id] compilation
+    unit ([lib/keeper_registry/keeper_id.ml]), whose [Uid] / [Trace_id]
+    / [Task_id] wrap runtime instance identifiers — this module answers
+    "who is this name?", that one answers "which run/task is this?". *)
+module Keeper_id : sig
+  type t = private string
+  (** Canonical form: case-folded; wrapper/nickname forms reduced via
+      {!canonical_keeper_name_from_agent_name} then
+      {!canonical_keeper_name}; unrecognized inputs keep their
+      case-folded raw form (non-keeper authors stay comparable). *)
+
+  val of_string : string -> t option
+  (** [None] iff the input is whitespace-only. *)
+
+  val to_string : t -> string
+  val equal : t -> t -> bool
+  val compare : t -> t -> int
+end
+
 type parsed_identity = {
   keeper_name : string;
   agent_name : string;

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -116,7 +116,7 @@ type board_signal_match = Board_signal.match_result =
 module Message_scope = Keeper_world_observation_message_scope
 module Inputs = Keeper_world_observation_inputs
 
-let self_identity_tokens = Message_scope.self_identity_tokens
+let self_ids = Message_scope.self_ids
 let is_self_author = Message_scope.is_self_author
 let collect_message_scope = Message_scope.collect_message_scope
 let read_backlog_counts = Inputs.read_backlog_counts
@@ -144,7 +144,7 @@ let pending_board_event_of_board_signal
       (signal : Board_dispatch.board_signal)
   : pending_board_event
   =
-  let self_tokens = self_identity_tokens meta in
+  let self_ids = self_ids meta in
   let matched = board_signal_match ~continuity_summary ~meta ~signal in
   let post_snapshot =
     match Board_dispatch.get_post ~post_id:signal.post_id with
@@ -170,7 +170,7 @@ let pending_board_event_of_board_signal
     match signal.kind with
     | Board_dispatch.Board_post_created -> false, 0, None, None
     | Board_dispatch.Board_comment_added ->
-      (match check_self_comment_status ~self_tokens ~post_id:signal.post_id with
+      (match check_self_comment_status ~self_ids ~post_id:signal.post_id with
        | `New_external (count, author, preview) -> true, count, Some author, Some preview
        | `No_new_external ->
          true, 0, Some signal.author, Some (short_preview ~max_len:60 signal.content)
@@ -233,11 +233,11 @@ let collect_board_events_with_cursor_policy
       else Time_compat.now () -. bootstrap_window_sec, None
     in
     let posts = list_board_posts_after_cursor base_cursor in
-    let self_tokens = self_identity_tokens meta in
+    let self_ids = self_ids meta in
     let recent =
       List.filter
         (fun (p : Board.post) ->
-           not (is_self_author ~self_tokens (Board.Agent_id.to_string p.author)))
+           not (is_self_author ~self_ids (Board.Agent_id.to_string p.author)))
         posts
     in
     let new_count = List.length recent in
@@ -263,7 +263,7 @@ let collect_board_events_with_cursor_policy
       | (p : Board.post) :: rest ->
         let post_id = Board.Post_id.to_string p.id in
         let next_cursor = board_cursor_token_of_post p in
-        let comment_status = check_self_comment_status ~self_tokens ~post_id in
+        let comment_status = check_self_comment_status ~self_ids ~post_id in
         (match comment_status with
          | `No_new_external ->
            Log.Keeper.debug

--- a/lib/keeper/keeper_world_observation_board_signal.ml
+++ b/lib/keeper/keeper_world_observation_board_signal.ml
@@ -113,8 +113,8 @@ let match_signal
       ~(signal : Board_dispatch.board_signal)
   : match_result
   =
-  let self_tokens = Message_scope.self_identity_tokens meta in
-  if Message_scope.is_self_author ~self_tokens signal.author
+  let self_ids = Message_scope.self_ids meta in
+  if Message_scope.is_self_author ~self_ids signal.author
   then { explicit_mention = false; matched_targets = []; score = 0 }
   else (
     let targets =
@@ -137,7 +137,7 @@ let match_signal
     Uses actual comment stream as ground truth (no proxy like reply_count
     or updated_at). Based on BDI commitment reconsideration: a committed
     response is only re-evaluated when new external beliefs arrive. *)
-let check_self_comment_status ~self_tokens ~(post_id : string) : comment_status =
+let check_self_comment_status ~self_ids ~(post_id : string) : comment_status =
   match Board_dispatch.get_comments ~post_id with
   | Error _ -> `Never
   | Ok comments ->
@@ -145,7 +145,7 @@ let check_self_comment_status ~self_tokens ~(post_id : string) : comment_status 
       List.filter
         (fun (c : Board.comment) ->
            Message_scope.is_self_author
-             ~self_tokens
+             ~self_ids
              (Board.Agent_id.to_string c.author))
         comments
     in
@@ -163,7 +163,7 @@ let check_self_comment_status ~self_tokens ~(post_id : string) : comment_status 
           (fun (c : Board.comment) ->
              (not
                 (Message_scope.is_self_author
-                   ~self_tokens
+                   ~self_ids
                    (Board.Agent_id.to_string c.author)))
              && c.created_at > my_latest_ts)
           comments
@@ -222,10 +222,10 @@ let wake_reason
     if stigmergy.overall_score > 0
     then Some ("stigmergy: score=" ^ string_of_int stigmergy.overall_score)
     else (
-      let self_tokens = Message_scope.self_identity_tokens meta in
+      let self_ids = Message_scope.self_ids meta in
       match signal.kind with
       | Board_dispatch.Board_comment_added ->
-        (match check_self_comment_status ~self_tokens ~post_id:signal.post_id with
+        (match check_self_comment_status ~self_ids ~post_id:signal.post_id with
          | `New_external _ -> Some "thread_reply_after_self_comment"
          | `Never | `No_new_external -> None)
       | Board_dispatch.Board_post_created -> None))

--- a/lib/keeper/keeper_world_observation_board_signal.mli
+++ b/lib/keeper/keeper_world_observation_board_signal.mli
@@ -23,7 +23,7 @@ val match_signal
   -> match_result
 
 val check_self_comment_status
-  :  self_tokens:string list
+  :  self_ids:Keeper_identity.Keeper_id.t list
   -> post_id:string
   -> comment_status
 

--- a/lib/keeper/keeper_world_observation_message_scope.ml
+++ b/lib/keeper/keeper_world_observation_message_scope.ml
@@ -10,34 +10,24 @@ let message_feed_targets (meta : keeper_meta) =
   if meta.mention_targets <> [] then meta.mention_targets else [ meta.name ]
 ;;
 
-let normalized_identity_token value =
-  let trimmed = String.lowercase_ascii (String.trim value) in
-  if trimmed = "" then None else Some trimmed
-;;
-
-let identity_tokens_of_value value =
-  let trimmed = String.trim value in
-  [ normalized_identity_token trimmed
-  ; Option.bind
-      (Keeper_identity.canonical_keeper_name_from_agent_name trimmed)
-      normalized_identity_token
-  ; Option.bind (Keeper_identity.canonical_keeper_name trimmed) normalized_identity_token
-  ]
-  |> List.filter_map (fun value -> value)
-  |> List.sort_uniq String.compare
-;;
-
-let self_identity_tokens (meta : keeper_meta) =
-  [ meta.name; meta.agent_name ]
-  |> List.map identity_tokens_of_value
-  |> List.flatten
-  |> List.sort_uniq String.compare
+(* RFC-0232 §3.4: identities are minted once at the parse boundary by
+   [Keeper_id.of_string]; the multi-form token-set expansion that used to
+   live here moved inside it.  A keeper's self is the (≤2-element) id set
+   minted from its name and agent name — they usually collapse to the
+   same canonical id. *)
+let self_ids (meta : keeper_meta) : Keeper_identity.Keeper_id.t list =
+  List.filter_map
+    Keeper_identity.Keeper_id.of_string
+    [ meta.name; meta.agent_name ]
+  |> List.sort_uniq Keeper_identity.Keeper_id.compare
 ;;
 
 (* Single source of truth for "is this author one of us?". *)
-let is_self_author ~self_tokens (author : string) : bool =
-  identity_tokens_of_value author
-  |> List.exists (fun author_token -> List.mem author_token self_tokens)
+let is_self_author ~self_ids (author : string) : bool =
+  match Keeper_identity.Keeper_id.of_string author with
+  | None -> false
+  | Some author_id ->
+    List.exists (Keeper_identity.Keeper_id.equal author_id) self_ids
 ;;
 
 let is_keeper_authored_message author =

--- a/lib/keeper/keeper_world_observation_message_scope.mli
+++ b/lib/keeper/keeper_world_observation_message_scope.mli
@@ -4,8 +4,20 @@ open Keeper_meta_contract
 open Keeper_types_profile
 
 val message_feed_targets : keeper_meta -> string list
-val self_identity_tokens : keeper_meta -> string list
-val is_self_author : self_tokens:string list -> string -> bool
+
+val self_ids : keeper_meta -> Keeper_identity.Keeper_id.t list
+(** The keeper's own identities, minted from [meta.name] and
+    [meta.agent_name] at the parse boundary (RFC-0232 §3.4).  Usually a
+    single canonical id; at most two. *)
+
+val is_self_author
+  :  self_ids:Keeper_identity.Keeper_id.t list
+  -> string
+  -> bool
+(** [is_self_author ~self_ids author] mints [author]'s id and compares
+    with {!Keeper_identity.Keeper_id.equal} — the single source of truth
+    for "is this author one of us?". *)
+
 val is_keeper_authored_message : string -> bool
 
 (** [line_mentions ~targets content] is true when some whitespace token of

--- a/test/dune
+++ b/test/dune
@@ -32,6 +32,7 @@
   test_keeper_reactive_wake_backlog_gate
   test_keeper_mention_scope
   test_keeper_turn_outcome
+  test_keeper_identity_id
   test_board_activity_cache
   test_jsonl_mtime_projection
   test_jsonl_incremental_projection
@@ -307,6 +308,7 @@
   test_keeper_reactive_wake_backlog_gate
   test_keeper_mention_scope
   test_keeper_turn_outcome
+  test_keeper_identity_id
   test_board_activity_cache
   test_jsonl_mtime_projection
   test_jsonl_incremental_projection

--- a/test/test_keeper_identity_id.ml
+++ b/test/test_keeper_identity_id.ml
@@ -1,0 +1,207 @@
+(* RFC-0232 P3: Keeper_identity.Keeper_id structural self-identity.
+   (Distinct from test_keeper_id.ml, which covers the registry-level
+   Keeper_id.Uid/Trace_id runtime identifier wrappers.)
+
+   Two things are pinned here:
+
+   1. [Keeper_id.of_string] canonicalization goldens — every accepted
+      identity shape (bare name, the four [keeper-X-agent] wrapper
+      separator variants, [keeper-] prefix form) mints the same
+      canonical id, and unrecognized inputs keep their case-folded raw
+      form.
+
+   2. Equivalence with the legacy token-set intersection that
+      [is_self_author] used before this change.  The oracle below is a
+      verbatim replica of the deleted [identity_tokens_of_value] /
+      set-intersection algorithm, run against the same
+      [Keeper_identity] canonicalizers.  The matrix crosses author
+      forms with keeper identities; old and new must agree everywhere.
+      (Mixed-case wrapper inputs are the one documented widening: the
+      old code matched them only via the raw-token fallback, the new
+      code canonicalizes them — goldens cover it.) *)
+
+open Alcotest
+
+module KI = Masc.Keeper_identity
+module Kid = Masc.Keeper_identity.Keeper_id
+module MS = Masc.Keeper_world_observation_message_scope
+
+let id_str value =
+  match Kid.of_string value with
+  | Some id -> Some (Kid.to_string id)
+  | None -> None
+
+(* ── Legacy oracle (verbatim replica of the deleted algorithm) ── *)
+
+let normalized_identity_token value =
+  let trimmed = String.lowercase_ascii (String.trim value) in
+  if trimmed = "" then None else Some trimmed
+
+let legacy_tokens_of_value value =
+  let trimmed = String.trim value in
+  [ normalized_identity_token trimmed
+  ; Option.bind
+      (KI.canonical_keeper_name_from_agent_name trimmed)
+      normalized_identity_token
+  ; Option.bind (KI.canonical_keeper_name trimmed) normalized_identity_token
+  ]
+  |> List.filter_map (fun v -> v)
+  |> List.sort_uniq String.compare
+
+let legacy_is_self ~name ~agent_name author =
+  let self_tokens =
+    [ name; agent_name ]
+    |> List.map legacy_tokens_of_value
+    |> List.flatten
+    |> List.sort_uniq String.compare
+  in
+  legacy_tokens_of_value author
+  |> List.exists (fun token -> List.mem token self_tokens)
+
+let new_is_self ~name ~agent_name author =
+  let self_ids =
+    List.filter_map Kid.of_string [ name; agent_name ]
+    |> List.sort_uniq Kid.compare
+  in
+  match Kid.of_string author with
+  | None -> false
+  | Some author_id -> List.exists (Kid.equal author_id) self_ids
+
+(* ── Goldens ── *)
+
+let test_of_string_goldens () =
+  check (option string) "bare name" (Some "dreamer") (id_str "dreamer");
+  check (option string) "wrapper -/-" (Some "dreamer")
+    (id_str "keeper-dreamer-agent");
+  check (option string) "wrapper _/_" (Some "dreamer")
+    (id_str "keeper_dreamer_agent");
+  check (option string) "wrapper -/_" (Some "dreamer")
+    (id_str "keeper-dreamer_agent");
+  check (option string) "wrapper _/-" (Some "dreamer")
+    (id_str "keeper_dreamer-agent");
+  check (option string) "keeper- prefix form" (Some "dreamer")
+    (id_str "keeper-dreamer");
+  check (option string) "case folded before canonicalizing" (Some "dreamer")
+    (id_str "Keeper-Dreamer-Agent");
+  check (option string) "whitespace trimmed" (Some "dreamer")
+    (id_str "  dreamer  ");
+  check (option string) "human author keeps raw form" (Some "vincent")
+    (id_str "Vincent");
+  check (option string) "@-form is not a keeper shape, raw fallback"
+    (Some "@dreamer") (id_str "@dreamer");
+  check (option string) "empty is None" None (id_str "");
+  check (option string) "whitespace-only is None" None (id_str "   ")
+
+let test_of_string_idempotent_on_goldens () =
+  List.iter
+    (fun input ->
+      match Kid.of_string input with
+      | None -> ()
+      | Some id ->
+        check (option string)
+          (Printf.sprintf "of_string idempotent for %S" input)
+          (Some (Kid.to_string id))
+          (id_str (Kid.to_string id)))
+    [ "dreamer"
+    ; "keeper-dreamer-agent"
+    ; "keeper_dreamer_agent"
+    ; "keeper-dreamer"
+    ; "Vincent"
+    ; "@dreamer"
+    ]
+
+(* ── Legacy equivalence matrix ── *)
+
+let keeper_identities =
+  [ ("dreamer", "keeper-dreamer-agent")
+  ; ("sangsu", "keeper_sangsu_agent")
+  ; ("analyst", "keeper-analyst-agent")
+  ]
+
+let author_forms name =
+  [ name
+  ; "keeper-" ^ name
+  ; Printf.sprintf "keeper-%s-agent" name
+  ; Printf.sprintf "keeper_%s_agent" name
+  ; Printf.sprintf "keeper-%s_agent" name
+  ; Printf.sprintf "keeper_%s-agent" name
+  ]
+
+let foreign_authors =
+  [ "vincent"
+  ; "operator"
+  ; "other"
+  ; "keeper-other-agent"
+  ; "@dreamer"
+  ; "email@dreamer.com"
+  ; "dreamerx"
+  ; ""
+  ; "   "
+  ]
+
+let test_legacy_equivalence_matrix () =
+  List.iter
+    (fun (name, agent_name) ->
+      let authors =
+        author_forms name
+        @ List.concat_map
+            (fun (other, _) -> author_forms other)
+            keeper_identities
+        @ foreign_authors
+      in
+      List.iter
+        (fun author ->
+          let expected = legacy_is_self ~name ~agent_name author in
+          let actual = new_is_self ~name ~agent_name author in
+          check bool
+            (Printf.sprintf "self(%s/%s) author=%S" name agent_name author)
+            expected actual)
+        authors)
+    keeper_identities
+
+let test_self_form_always_matches () =
+  List.iter
+    (fun (name, agent_name) ->
+      List.iter
+        (fun author ->
+          check bool
+            (Printf.sprintf "%S is self of %s" author name)
+            true
+            (new_is_self ~name ~agent_name author))
+        (author_forms name))
+    keeper_identities
+
+(* The documented widening over the legacy behavior: mixed-case forms
+   canonicalize instead of depending on the raw-token fallback. *)
+let test_case_fold_widening () =
+  check bool "mixed-case wrapper is self (legacy matched via raw token)"
+    true
+    (new_is_self ~name:"dreamer" ~agent_name:"keeper-dreamer-agent"
+       "Keeper-Dreamer-Agent");
+  check bool "uppercase bare name is self" true
+    (new_is_self ~name:"dreamer" ~agent_name:"keeper-dreamer-agent" "DREAMER")
+
+let test_message_scope_surface () =
+  let ids = List.filter_map Kid.of_string [ "dreamer" ] in
+  check bool "is_self_author over MS surface" true
+    (MS.is_self_author ~self_ids:ids "keeper-dreamer-agent");
+  check bool "foreign author is not self" false
+    (MS.is_self_author ~self_ids:ids "vincent")
+
+let () =
+  run "keeper_identity_id"
+    [
+      ( "of_string",
+        [
+          test_case "goldens" `Quick test_of_string_goldens;
+          test_case "idempotent" `Quick test_of_string_idempotent_on_goldens;
+        ] );
+      ( "legacy_equivalence",
+        [
+          test_case "matrix" `Quick test_legacy_equivalence_matrix;
+          test_case "self forms match" `Quick test_self_form_always_matches;
+          test_case "case-fold widening" `Quick test_case_fold_widening;
+        ] );
+      ( "surface",
+        [ test_case "message scope" `Quick test_message_scope_surface ] );
+    ]


### PR DESCRIPTION
## RFC-0232 P3 — `Keeper_id.t` structural self-identity

RFC: `docs/rfc/RFC-0232-typed-lane-event-model.md` §3.4 (merged #20877). P1 #20896, P2 #20914.

### 문제

"이 author가 나인가?"를 양쪽 모두 multi-form token set(raw + canonicalizer 2종)으로 펼친 뒤 교집합으로 판정했다 — 소비자마다 read-time에 identity를 재유도하고, raw-token fallback 때문에 매칭이 입력 대소문자에 의존했다 (`Keeper-Dreamer-Agent`는 wrapper 파싱이 case-sensitive라 raw 토큰으로만 우연히 매칭, mixed-case nickname은 아예 미인식).

### 변경

- **`Keeper_identity.Keeper_id`** (신규 서브모듈): `type t = private string`, parse boundary에서 한 번 mint. `of_string` = case-fold → `canonical_keeper_name_from_agent_name`(구체: wrapper unwrap, nickname→agent type) → `canonical_keeper_name`(광역) → raw fallback(비keeper author도 비교 가능 유지). registry의 `Keeper_id` compilation unit(Uid/Trace_id/Task_id, 런타임 인스턴스 ID)과는 다른 개념 — mli에 구분 명시.
- **message scope**: `identity_tokens_of_value`/`self_identity_tokens`/token-set `is_self_author` 삭제 → `self_ids`(meta.name+agent_name에서 mint, 보통 1개로 수렴) + `Keeper_id.equal`.
- **board signal / world observation**: `~self_tokens` 운반자를 `~self_ids`로 끝까지 교체.

### 동치성 — 가정이 아니라 증명

`test_keeper_identity_id`가 삭제된 token-set 알고리즘을 oracle로 verbatim 복제, author form 6종 × keeper identity 3종 (+ foreign/edge 9종) 매트릭스에서 신구 전수 일치 확인. 문서화된 유일한 widening: mixed-case wrapper/nickname이 이제 canonicalize됨 — self-매칭이 넓어지는 방향이며, self-echo 억제 관점에서 안전측.

### 검증

- `dune build @check` + default target EXIT=0
- `test_keeper_identity_id` 6/6 (goldens, idempotence, 동치성 매트릭스, case-fold widening, mli surface)
- 영향권 기존 테스트: `test_board_content_dedup` 9/9, `test_keeper_event_queue` pass, `test_keeper_mention_scope` 20/20, `test_keeper_contract_classifier_pure` 13/13
- `test_board_dispatch` 1 failure는 **fork point main에서도 동일한 pre-existing** — #20931로 기록 (reclassify 경로, 본 PR diff와 무관)

후속: P4 (boundary mention parse + persisted mentions + backfill), P5 (`Surface_ref`).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
