### PR TITLE
fix: reject `..` and `.` in keeper_msg request_id (path traversal)

### DIFF
--- a/lib/keeper/keeper_msg_async.ml
+++ b/lib/keeper/keeper_msg_async.ml
@@ -58,7 +58,7 @@ let is_safe_request_id request_id =
         | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '-' | '.' -> loop (i + 1)
         | _ -> false)
     in
-    loop 0)
+    loop 0 && request_id <> ".." && request_id <> ".")
 ;;
 
 let record_path ~base_path ~request_id =


### PR DESCRIPTION
## Problem

`is_safe_request_id` in `keeper_msg_async.ml` allows `.` in the character set, which means `".."` and `"."` pass validation. This enables path traversal through `record_path` → `load_record` → `poll`/`gc_stale_disk`, allowing an attacker to read or delete arbitrary `.json` files outside the request directory.

## Fix

Add a guard on `loop 0` to reject literal `".."` and `"."` request IDs. The `is_safe_request_id` function already rejects empty and too-long IDs, but the per-character loop trusts `.` because it appears in valid UUID/ULID patterns (e.g. ULID separators in some conventions).

## Impact

- **+1 line change** in `lib/keeper/keeper_msg_async.ml`
- Covers `record_path` → `load_record` → `poll`/`gc_stale_disk`
- No performance impact (two cheap string comparisons only when char-loop passes)