### PR TITLE
Enable Gemma4 template-token thinking in runtime seed

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -6,7 +6,8 @@
 #
 # Local Gemma 4 QAT is a canary runtime, not the fleet default. Keep the
 # default on the cloud runtime and pin only one keeper to local Ollama until
-# sustained turns prove the local box can absorb more load.
+# sustained turns prove the local box can absorb more load. OAS handles Gemma 4
+# thinking through the chat-template control token path, not Ollama think:true.
 
 [runtime]
 default = "ollama_cloud.deepseek-v4-flash"
@@ -41,16 +42,15 @@ streaming = true
 api-name = "hf.co/unsloth/gemma-4-26B-A4B-it-qat-GGUF:UD-Q4_K_XL"
 max-context = 262144
 tools-support = true
-# This exact QAT model is served by local Ollama with tools/vision, but Ollama
-# rejects generic thinking enablement for it. OAS Gemma 4 template/control-token
-# handling belongs in the adapter path; the runtime seed keeps keeper thinking
-# off for this local canary.
-thinking-support = false
+# OAS maps this to Gemma 4's <|think|> chat-template token and omits the
+# generic Ollama top-level think field for this model family.
+thinking-support = true
 preserve-thinking = false
 streaming = true
 
 [models.gemma4-26b-a4b-qat.capabilities]
 supports-tool-choice = true
+thinking-control-format = "chat_template_token"
 supports-native-streaming = true
 supports-top-k = true
 supports-seed = true

--- a/lib/runtime/runtime_schema.ml
+++ b/lib/runtime/runtime_schema.ml
@@ -85,6 +85,7 @@ type thinking_control_format =
   | No_thinking_control
   | Thinking_object
   | Chat_template_kwargs
+  | Chat_template_token
   | Reasoning_effort
 [@@deriving show, eq]
 

--- a/lib/runtime/runtime_schema.mli
+++ b/lib/runtime/runtime_schema.mli
@@ -63,6 +63,7 @@ type thinking_control_format =
   | No_thinking_control
   | Thinking_object
   | Chat_template_kwargs
+  | Chat_template_token
   | Reasoning_effort
 [@@deriving show, eq]
 

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -298,10 +298,11 @@ let parse_thinking_control_format ~(path : string) (raw : string)
     Runtime_schema.No_thinking_control
   | "thinking-object" | "thinking_object" -> Runtime_schema.Thinking_object
   | "chat-template-kwargs" | "chat_template_kwargs" -> Runtime_schema.Chat_template_kwargs
+  | "chat-template-token" | "chat_template_token" -> Runtime_schema.Chat_template_token
   | "reasoning-effort" | "reasoning_effort" -> Runtime_schema.Reasoning_effort
   | other ->
     Log.Runtime.warn "runtime_toml: %s.capabilities.thinking-control-format = %S — expected one of \
-         none|thinking-object|chat-template-kwargs|reasoning-effort, defaulting to none"
+         none|thinking-object|chat-template-kwargs|chat-template-token|reasoning-effort, defaulting to none"
         path
         other;
     Runtime_schema.No_thinking_control

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -35,7 +35,25 @@ let test_repo_runtime_toml_loads () =
     check int "one local Gemma canary pin in seed" 1 (List.length assignments);
     check (option string) "nick0cave Gemma canary pin"
       (Some "ollama.gemma4-26b-a4b-qat")
-      (List.assoc_opt "nick0cave" assignments)
+      (List.assoc_opt "nick0cave" assignments);
+    (match
+       List.find_opt
+         (fun (runtime : Runtime.t) ->
+            String.equal runtime.id "ollama.gemma4-26b-a4b-qat")
+         runtimes
+     with
+     | None -> fail "expected Gemma4 Ollama runtime in seed"
+     | Some runtime ->
+       check bool "Gemma4 thinking enabled" true runtime.model.thinking_support;
+       check bool "Gemma4 thinking not preserved" false
+         runtime.model.preserve_thinking;
+       (match runtime.model.capabilities with
+        | Some caps ->
+          check bool "Gemma4 chat-template-token thinking control" true
+            (Runtime_schema.equal_thinking_control_format
+               caps.thinking_control_format
+               Runtime_schema.Chat_template_token)
+        | None -> fail "expected Gemma4 capabilities"))
 
 let test_toml_catalog_resolves_lifecycle_keys () =
   let doc =

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -223,6 +223,51 @@ let test_runtime_toml_accepts_deepseek_reasoning_effort_capability () =
      | None -> fail "expected model capabilities")
   | models -> failf "expected one model, got %d" (List.length models)
 
+let test_runtime_toml_accepts_chat_template_token_capability () =
+  let toml =
+    {|
+[runtime]
+default = "ollama.gemma4"
+
+[providers.ollama]
+display-name = "Local Ollama"
+protocol = "ollama-http"
+endpoint = "http://localhost:11434"
+
+[models.gemma4]
+api-name = "hf.co/unsloth/gemma-4-26B-A4B-it-qat-GGUF:UD-Q4_K_XL"
+max-context = 262144
+tools-support = true
+thinking-support = true
+streaming = true
+
+[models.gemma4.capabilities]
+thinking-control-format = "chat_template_token"
+
+[ollama.gemma4]
+max-concurrent = 1
+|}
+  in
+  match Runtime_toml.parse_string toml with
+  | Error errors ->
+    failf
+      "expected Gemma4 runtime TOML to parse: %s"
+      (String.concat
+         "; "
+         (List.map
+            (fun (err : Runtime_toml.parse_error) ->
+               Printf.sprintf "%s: %s" err.path err.message)
+            errors))
+  | Ok cfg ->
+    (match cfg.models with
+     | [ model ] ->
+       (match model.capabilities with
+        | Some caps ->
+          check bool "chat template token parsed" true
+            (caps.thinking_control_format = Runtime_schema.Chat_template_token)
+        | None -> fail "expected model capabilities")
+     | models -> failf "expected one model, got %d" (List.length models))
+
 let test_runtime_adapter_materializes_deepseek_openai_compat () =
   with_deepseek_env "ds-test-key" (fun () ->
     let provider_cfg = deepseek_provider_config_or_fail () in
@@ -588,6 +633,10 @@ let () =
             "runtime TOML accepts DeepSeek reasoning effort"
             `Quick
             test_runtime_toml_accepts_deepseek_reasoning_effort_capability
+        ; test_case
+            "runtime TOML accepts chat template token thinking"
+            `Quick
+            test_runtime_toml_accepts_chat_template_token_capability
         ; test_case
             "runtime adapter materializes DeepSeek OpenAI compat"
             `Quick


### PR DESCRIPTION
## Summary
- enable the local Gemma4 QAT canary runtime for thinking now that OAS handles Gemma4 via the chat-template control token path
- add `chat_template_token` to the MASC runtime TOML capability schema so the seed can represent the OAS special path explicitly
- keep `preserve-thinking = false` for Gemma4 so prior thought blocks are not replayed in multi-turn history
- keep only `nick0cave` pinned to `ollama.gemma4-26b-a4b-qat`; the default runtime remains `ollama_cloud.deepseek-v4-flash`

## Verification
- `python3 -c 'import sys,tomllib; tomllib.load(open(sys.argv[1], "rb")); print("toml-ok")' config/runtime.toml`\n- `git diff --check`\n- `env DUNE_BUILD_DIR=_build-codex-runtime-test dune exec --root . ./test/test_runtime_config_validity.exe`\n- `env DUNE_BUILD_DIR=_build-codex-runtime-test dune exec --root . ./test/test_runtime_provider_auth_headers.exe`\n\n## Live check\n- reloaded `/Users/dancer/me/.masc/config/runtime.toml` through `POST /api/v1/runtime/config/raw` and got `reloaded=true`\n- `GET /api/v1/providers` shows `ollama.gemma4-26b-a4b-qat` as `thinking_support=true`, `is_default_runtime=false`, `available=true`\n- `GET /api/v1/gate/keeper-status?name=nick0cave` shows `runtime_id=ollama.gemma4-26b-a4b-qat` and context budget `262144`\n\nDepends on OAS PR #2016 behavior: Gemma4 Ollama thinking uses `<|think|>` template/control-token injection and must not send generic Ollama `think:true`.